### PR TITLE
Resolve unused OrbitContext lock_store warning

### DIFF
--- a/orbit-core/src/context.rs
+++ b/orbit-core/src/context.rs
@@ -3,8 +3,8 @@ use std::sync::Arc;
 
 use orbit_policy::PolicyEngine;
 use orbit_store::{
-    ActivityStoreBackend, AuditEventStoreBackend, JobStoreBackend, LockStoreBackend,
-    TaskStoreBackend, ToolStoreBackend,
+    ActivityStoreBackend, AuditEventStoreBackend, JobStoreBackend, TaskStoreBackend,
+    ToolStoreBackend,
 };
 use orbit_tools::ToolRegistry;
 
@@ -20,7 +20,6 @@ pub struct OrbitContext {
     pub(crate) job_store: Arc<dyn JobStoreBackend>,
     pub(crate) tool_store: Arc<dyn ToolStoreBackend>,
     pub(crate) audit_event_store: Arc<dyn AuditEventStoreBackend>,
-    pub(crate) lock_store: Arc<dyn LockStoreBackend>,
     pub(crate) policy: PolicyEngine,
     pub(crate) registry: Arc<ToolRegistry>,
     pub(crate) skill_catalog: SkillCatalog,

--- a/orbit-core/src/runtime/builder.rs
+++ b/orbit-core/src/runtime/builder.rs
@@ -4,8 +4,8 @@ use std::sync::Arc;
 use chrono::Utc;
 use orbit_policy::PolicyEngine;
 use orbit_store::{
-    Store, activity_store_file, audit_event_store_sqlite, job_store_file, lock_store_memory,
-    task_store_file, tool_store_sqlite,
+    Store, activity_store_file, audit_event_store_sqlite, job_store_file, task_store_file,
+    tool_store_sqlite,
 };
 
 use orbit_tools::ToolRegistry;
@@ -74,7 +74,6 @@ fn build_context_common(
 ) -> Result<OrbitContext, OrbitError> {
     let tool_store = tool_store_sqlite(store.clone());
     let audit_event_store = audit_event_store_sqlite(store.clone());
-    let lock_store = lock_store_memory();
 
     let skill_root = runtime_config.persistence.skill.clone();
     let skill_catalog = SkillCatalog::new(skill_root);
@@ -103,7 +102,6 @@ fn build_context_common(
         job_store,
         tool_store,
         audit_event_store,
-        lock_store,
         policy: PolicyEngine::new_local_default_allow(),
         registry: Arc::new(registry),
         skill_catalog,


### PR DESCRIPTION
## Changes
chore: Resolve unused OrbitContext lock_store warning [T20260315-195600]

Removed the unused `lock_store: Arc<dyn LockStoreBackend>` field from `OrbitContext` and all associated construction code in `build_context_common`. A full codebase search confirmed no runtime path ever reads the field — it was dead plumbing introduced alongside the `LockStoreBackend` trait but never wired into actual locking behavior. The `LockStoreBackend` trait, `MemoryLockStoreBackend` implementation, and `lock_store_memory()` factory in `orbit-store` are retained as they have their own tests and are public API. All 130 `orbit-core` tests pass; the release build is clean with no warnings. Two pre-existing failures in `orbit-cli/tests/config_commands.rs` were confirmed to exist before these changes and are unrelated (environment/path-specific CLI test issues).

## Files Changed
- `orbit-core/src/context.rs`
- `orbit-core/src/runtime/builder.rs`