### PR TITLE
dispatch_task: consider rejected tasks and add pre-invoke guard

### DIFF
--- a/orbit-cli/src/command/job.rs
+++ b/orbit-cli/src/command/job.rs
@@ -70,6 +70,7 @@ impl Execute for JobAddArgs {
                 agent_cli: self.agent_cli,
                 timeout_seconds,
                 env_extra: crate::parse::csv_to_vec(&self.env_extra),
+                precondition: None,
             }],
             initial_state_override: None,
         })?;

--- a/orbit-core/assets/activities/check_dispatch_needed.yaml
+++ b/orbit-core/assets/activities/check_dispatch_needed.yaml
@@ -1,0 +1,21 @@
+schema_version: 1
+
+# ---- metadata ----
+created_by: system
+
+# ---- activity ----
+activity:
+  # ---- identity ----
+  id: check_dispatch_needed
+  spec_type: cli_command
+
+  # ---- content ----
+  description: Exits 0 if backlog or rejected tasks exist; exits 1 if both queues are empty.
+  command: bash
+  args:
+    - -c
+    - |
+      COUNT=$(orbit task list --status backlog --json 2>/dev/null | jq 'length')
+      REJECTED=$(orbit task list --status rejected --json 2>/dev/null | jq 'length')
+      if [ "$COUNT" -eq 0 ] && [ "$REJECTED" -eq 0 ]; then exit 1; fi
+  expected_exit_codes: [0]

--- a/orbit-core/assets/activities/dispatch_task.yaml
+++ b/orbit-core/assets/activities/dispatch_task.yaml
@@ -11,13 +11,14 @@ activity:
   spec_type: agent_invoke
 
   # ---- content ----
-  description: CEO reviews the backlog and dispatches the single highest-priority task for execution.
+  description: CEO reviews the backlog and rejected queues and dispatches the single highest-priority task for execution.
   instruction: |
     Only use skills listed in this activity's skill_refs. Ignore all others.
-    You are Steve (CEO). Pick the single best task from the backlog and dispatch it.
+    You are Steve (CEO). Pick the single best task and dispatch it.
 
-    1. Call orbit.task.list with status: "backlog" to retrieve all backlog tasks.
-       If the list is empty, return a comment "Backlog is empty. Nothing to dispatch." and task_id "None" and exit.
+    1. Call orbit.task.list with status: "rejected" to retrieve all rejected tasks.
+       Call orbit.task.list with status: "backlog" to retrieve all backlog tasks.
+       If both lists are empty, return a comment "No tasks available. Nothing to dispatch." and task_id "None" and exit.
 
     2. Call github.pr.list with state: "open" to retrieve all currently open pull requests.
        Note the head branch and title of each open PR.
@@ -25,13 +26,20 @@ activity:
     3. Call orbit.task.list with status: "in_progress" to retrieve tasks currently being worked on.
        For each in-progress task, call orbit.task.show to read its description and plan.
 
-    4. For the top backlog candidates, call orbit.task.show with the task id to read description, plan, and priority.
+    4. For the top candidates, call orbit.task.show with the task id to read description, plan, and priority.
 
-    5. Select the single task most valuable to execute next.
-       Prioritise: critical/high priority first; tasks that unblock others or reduce systemic risk;
-       tasks with a clear, executable plan; smaller contained changes over large sweeping ones.
-       Skip any task whose scope or target files clearly overlap with an open PR or an in-progress task —
-       prefer work that can land independently without causing merge conflicts or duplicating effort.
+    5. Select the single task most valuable to execute next using this priority order:
+
+       a. Rejected tasks take precedence over backlog tasks. A rejected task represents work
+          already reviewed and found incomplete — it is a regression or incomplete change that
+          needs remediation, not net-new work.
+
+       b. Within each group (rejected first, then backlog), apply priority rules:
+          critical > high > medium > low.
+
+       c. Skip any task whose scope or target files clearly overlap with an open PR or an
+          in-progress task — prefer work that can land independently without causing merge
+          conflicts or duplicating effort.
 
     6. Call orbit.task.update with id: "<selected_task_id>" and comment: "Dispatched by Steve (CEO): <one sentence rationale>"
        to record the dispatch rationale.

--- a/orbit-core/assets/activities/dispatch_task.yaml
+++ b/orbit-core/assets/activities/dispatch_task.yaml
@@ -19,13 +19,21 @@ activity:
     1. Call orbit.task.list with status: "backlog" to retrieve all backlog tasks.
        If the list is empty, return a comment "Backlog is empty. Nothing to dispatch." and task_id "None" and exit.
 
-    2. For the top candidates, call orbit.task.show with the task id to read description, plan, and priority.
+    2. Call github.pr.list with state: "open" to retrieve all currently open pull requests.
+       Note the head branch and title of each open PR.
 
-    3. Select the single task most valuable to execute next.
+    3. Call orbit.task.list with status: "in_progress" to retrieve tasks currently being worked on.
+       For each in-progress task, call orbit.task.show to read its description and plan.
+
+    4. For the top backlog candidates, call orbit.task.show with the task id to read description, plan, and priority.
+
+    5. Select the single task most valuable to execute next.
        Prioritise: critical/high priority first; tasks that unblock others or reduce systemic risk;
        tasks with a clear, executable plan; smaller contained changes over large sweeping ones.
+       Skip any task whose scope or target files clearly overlap with an open PR or an in-progress task —
+       prefer work that can land independently without causing merge conflicts or duplicating effort.
 
-    4. Call orbit.task.update with id: "<selected_task_id>" and comment: "Dispatched by Steve (CEO): <one sentence rationale>"
+    6. Call orbit.task.update with id: "<selected_task_id>" and comment: "Dispatched by Steve (CEO): <one sentence rationale>"
        to record the dispatch rationale.
 
     Output the selected task_id, workspace_path, and the rationale comment.
@@ -59,3 +67,4 @@ activity:
     - orbit.task.list
     - orbit.task.show
     - orbit.task.update
+    - github.pr.list

--- a/orbit-core/assets/jobs/job_task_pipeline.yaml
+++ b/orbit-core/assets/jobs/job_task_pipeline.yaml
@@ -23,6 +23,10 @@ job:
       target_id: dispatch_task
       agent_cli: claude
       timeout_seconds: 1000
+      precondition:
+        command: orbit
+        args: [activity, run, check_dispatch_needed]
+        skip_job_on_failure: true
 
     - target_type: activity
       target_id: create_branch

--- a/orbit-core/src/command/activity.rs
+++ b/orbit-core/src/command/activity.rs
@@ -16,6 +16,10 @@ pub(crate) const DEFAULT_ACTIVITY_FILES: &[(&str, &str)] = &[
         include_str!("../../assets/activities/checkout_branch.yaml"),
     ),
     (
+        "check_dispatch_needed",
+        include_str!("../../assets/activities/check_dispatch_needed.yaml"),
+    ),
+    (
         "commit_changes",
         include_str!("../../assets/activities/commit_changes.yaml"),
     ),
@@ -559,6 +563,7 @@ activity:
             ids,
             vec![
                 "checkout_branch",
+                "check_dispatch_needed",
                 "commit_changes",
                 "create_branch",
                 "dispatch_task",

--- a/orbit-core/src/command/job.rs
+++ b/orbit-core/src/command/job.rs
@@ -2,7 +2,10 @@ use chrono::{DateTime, Utc};
 use orbit_agent::{Agent, AgentConfig};
 use orbit_store::JobCreateParams as StoreActivityCreateParams;
 use orbit_store::JobUpdateParams as StoreJobUpdateParams;
-use orbit_types::{Job, JobRun, JobScheduleState, JobStep, JobTargetType, OrbitError, OrbitEvent};
+use orbit_types::{
+    Job, JobRun, JobScheduleState, JobStep, JobStepPrecondition, JobTargetType, OrbitError,
+    OrbitEvent,
+};
 use serde::Deserialize;
 use serde_json::Value;
 
@@ -43,6 +46,14 @@ struct DefaultJobEntry {
 }
 
 #[derive(Debug, Clone, Deserialize)]
+struct DefaultJobStepPrecondition {
+    command: String,
+    #[serde(default)]
+    args: Vec<String>,
+    skip_job_on_failure: bool,
+}
+
+#[derive(Debug, Clone, Deserialize)]
 struct DefaultJobStep {
     target_type: String,
     target_id: String,
@@ -51,6 +62,8 @@ struct DefaultJobStep {
     timeout_seconds: u64,
     #[serde(default)]
     env_extra: Vec<String>,
+    #[serde(default)]
+    precondition: Option<DefaultJobStepPrecondition>,
 }
 
 #[derive(Debug, Clone)]
@@ -313,12 +326,18 @@ fn default_job_steps(entry: &DefaultJobEntry) -> Result<Vec<JobStep>, OrbitError
                     )));
                 }
             };
+            let precondition = s.precondition.as_ref().map(|p| JobStepPrecondition {
+                command: p.command.clone(),
+                args: p.args.clone(),
+                skip_job_on_failure: p.skip_job_on_failure,
+            });
             Ok(JobStep {
                 target_type,
                 target_id: s.target_id.clone(),
                 agent_cli: s.agent_cli.clone(),
                 timeout_seconds: s.timeout_seconds,
                 env_extra: s.env_extra.clone(),
+                precondition,
             })
         })
         .collect()

--- a/orbit-core/src/lib.rs
+++ b/orbit-core/src/lib.rs
@@ -157,6 +157,7 @@ mod tests {
                     agent_cli: agent_path.to_string_lossy().to_string(),
                     timeout_seconds: 30,
                     env_extra: vec![],
+                    precondition: None,
                 }],
                 initial_state_override: None,
             })

--- a/orbit-core/tests/job_runtime_behavior.rs
+++ b/orbit-core/tests/job_runtime_behavior.rs
@@ -9,7 +9,8 @@ use orbit_core::command::job::JobAddParams;
 use orbit_core::command::job_run::JobRunListParams;
 use orbit_core::command::task::{TaskAddParams, TaskUpdateParams};
 use orbit_types::{
-    JobRunState, JobStep, JobTargetType, OrbitError, TaskPriority, TaskStatus, TaskType,
+    JobRunState, JobStep, JobStepPrecondition, JobTargetType, OrbitError, TaskPriority, TaskStatus,
+    TaskType,
 };
 use serde_json::json;
 use tempfile::tempdir;
@@ -89,6 +90,7 @@ fn add_scheduled_activity_with_timeout(
                 agent_cli: agent_cli.to_string(),
                 timeout_seconds,
                 env_extra: vec![],
+                precondition: None,
             }],
             initial_state_override: None,
         })
@@ -186,6 +188,7 @@ fn cli_command_activity_executes_without_agent_cli_and_captures_output_file() {
                 agent_cli: String::new(),
                 timeout_seconds: 30,
                 env_extra: vec![],
+                precondition: None,
             }],
             initial_state_override: None,
         })
@@ -241,6 +244,7 @@ fn cli_command_failures_redact_sensitive_environment_values_from_error_messages(
                 agent_cli: String::new(),
                 timeout_seconds: 30,
                 env_extra: vec![],
+                precondition: None,
             }],
             initial_state_override: None,
         })
@@ -537,6 +541,7 @@ fn run_job_now_uses_job_default_input_when_manual_input_is_absent() {
                 agent_cli,
                 timeout_seconds: 10,
                 env_extra: vec![],
+                precondition: None,
             }],
             initial_state_override: None,
         })
@@ -586,6 +591,7 @@ fn run_job_now_with_input_overrides_job_default_input() {
                 agent_cli,
                 timeout_seconds: 10,
                 env_extra: vec![],
+                precondition: None,
             }],
             initial_state_override: None,
         })
@@ -654,6 +660,7 @@ fn run_job_now_finalizes_failed_when_pre_step_setup_errors_after_running() {
                 agent_cli: "mock-agent".to_string(),
                 timeout_seconds: 10,
                 env_extra: vec![],
+                precondition: None,
             }],
             initial_state_override: None,
         })
@@ -1488,6 +1495,7 @@ fn claude_job_run_succeeds_with_mock_binary() {
                 agent_cli,
                 timeout_seconds: 10,
                 env_extra: vec![],
+                precondition: None,
             }],
             initial_state_override: None,
         })
@@ -1536,6 +1544,7 @@ fn run_job_now_executes_job_successfully() {
                 agent_cli,
                 timeout_seconds: 10,
                 env_extra: vec![],
+                precondition: None,
             }],
             initial_state_override: None,
         })
@@ -1628,6 +1637,7 @@ fn agent_step_result_fields_flow_into_next_step_input() {
                     agent_cli,
                     timeout_seconds: 10,
                     env_extra: vec![],
+                    precondition: None,
                 },
                 JobStep {
                     target_type: JobTargetType::Activity,
@@ -1635,6 +1645,7 @@ fn agent_step_result_fields_flow_into_next_step_input() {
                     agent_cli: String::new(),
                     timeout_seconds: 10,
                     env_extra: vec![],
+                    precondition: None,
                 },
             ],
             initial_state_override: None,
@@ -1745,6 +1756,7 @@ fn agent_step_workspace_path_flows_into_cli_working_directory() {
                     agent_cli,
                     timeout_seconds: 10,
                     env_extra: vec![],
+                    precondition: None,
                 },
                 JobStep {
                     target_type: JobTargetType::Activity,
@@ -1752,6 +1764,7 @@ fn agent_step_workspace_path_flows_into_cli_working_directory() {
                     agent_cli: String::new(),
                     timeout_seconds: 10,
                     env_extra: vec![],
+                    precondition: None,
                 },
             ],
             initial_state_override: None,
@@ -1827,6 +1840,7 @@ fn agent_step_uses_workspace_path_as_process_current_dir() {
                 agent_cli,
                 timeout_seconds: 10,
                 env_extra: vec![],
+                precondition: None,
             }],
             initial_state_override: None,
         })
@@ -1979,6 +1993,7 @@ fn create_branch_creates_isolated_worktree_without_mutating_main_checkout() {
                     agent_cli: String::new(),
                     timeout_seconds: 30,
                     env_extra: vec![],
+                    precondition: None,
                 },
                 JobStep {
                     target_type: JobTargetType::Activity,
@@ -1986,6 +2001,7 @@ fn create_branch_creates_isolated_worktree_without_mutating_main_checkout() {
                     agent_cli: String::new(),
                     timeout_seconds: 30,
                     env_extra: vec![],
+                    precondition: None,
                 },
             ],
             initial_state_override: None,
@@ -2125,6 +2141,7 @@ fn commit_changes_automation_commits_dirty_task_worktree() {
                 agent_cli: String::new(),
                 timeout_seconds: 30,
                 env_extra: vec![],
+                precondition: None,
             }],
             initial_state_override: None,
         })
@@ -2203,6 +2220,7 @@ fn commit_changes_automation_commits_dirty_task_worktree() {
                 agent_cli: String::new(),
                 timeout_seconds: 30,
                 env_extra: vec![],
+                precondition: None,
             }],
             initial_state_override: None,
         })
@@ -2305,7 +2323,7 @@ fn commit_task_changes_uses_summary_from_input() {
         .add_job(JobAddParams {
             job_id: None,
             default_input: Some(json!({"task_id": task_id, "base": "agent-main", "workspace_path": repo_root.to_string_lossy().to_string()})),
-            steps: vec![JobStep { target_type: JobTargetType::Activity, target_id: "spec-create-wt-regression".to_string(), agent_cli: String::new(), timeout_seconds: 30, env_extra: vec![] }],
+            steps: vec![JobStep { target_type: JobTargetType::Activity, target_id: "spec-create-wt-regression".to_string(), agent_cli: String::new(), timeout_seconds: 30, env_extra: vec![], precondition: None }],
             initial_state_override: None,
         })
         .expect("add create job")
@@ -2338,7 +2356,7 @@ fn commit_task_changes_uses_summary_from_input() {
         .add_job(JobAddParams {
             job_id: None,
             default_input: Some(json!({"task_id": task_id, "workspace_path": workspace_path, "repo_root": repo_root.to_string_lossy().to_string(), "branch": branch, "summary": "Hardened bundle writes using staged directory rename."})),
-            steps: vec![JobStep { target_type: JobTargetType::Activity, target_id: "spec-commit-regression".to_string(), agent_cli: String::new(), timeout_seconds: 30, env_extra: vec![] }],
+            steps: vec![JobStep { target_type: JobTargetType::Activity, target_id: "spec-commit-regression".to_string(), agent_cli: String::new(), timeout_seconds: 30, env_extra: vec![], precondition: None }],
             initial_state_override: None,
         })
         .expect("add success job")
@@ -2368,7 +2386,7 @@ fn commit_task_changes_uses_summary_from_input() {
         .add_job(JobAddParams {
             job_id: None,
             default_input: Some(json!({"task_id": task2_id, "workspace_path": workspace_path, "repo_root": repo_root.to_string_lossy().to_string(), "branch": branch, "summary": ""})),
-            steps: vec![JobStep { target_type: JobTargetType::Activity, target_id: "spec-commit-regression".to_string(), agent_cli: String::new(), timeout_seconds: 30, env_extra: vec![] }],
+            steps: vec![JobStep { target_type: JobTargetType::Activity, target_id: "spec-commit-regression".to_string(), agent_cli: String::new(), timeout_seconds: 30, env_extra: vec![], precondition: None }],
             initial_state_override: None,
         })
         .expect("add fail job")
@@ -2551,6 +2569,7 @@ fn open_pr_automation_uses_task_title_and_commit_output() {
                 agent_cli: String::new(),
                 timeout_seconds: 30,
                 env_extra: vec![],
+                precondition: None,
             }],
             initial_state_override: None,
         })
@@ -2658,6 +2677,7 @@ pass = ["HOME", "PATH"]
                     agent_cli: agent_cli.clone(),
                     timeout_seconds: 10,
                     env_extra: vec!["STEP1_SECRET".to_string()],
+                    precondition: None,
                 },
                 JobStep {
                     target_type: JobTargetType::Activity,
@@ -2665,6 +2685,7 @@ pass = ["HOME", "PATH"]
                     agent_cli: agent_cli.clone(),
                     timeout_seconds: 10,
                     env_extra: vec!["STEP2_SECRET".to_string()],
+                    precondition: None,
                 },
             ],
             initial_state_override: None,
@@ -2697,4 +2718,197 @@ pass = ["HOME", "PATH"]
         !step2_env.contains("STEP1_SECRET"),
         "step2 must not have STEP1_SECRET"
     );
+}
+
+#[test]
+fn precondition_failing_with_skip_job_on_failure_completes_as_success() {
+    let dir = tempdir().expect("tempdir");
+    let runtime = OrbitRuntime::from_data_root(dir.path()).expect("runtime");
+
+    // A cli_command activity that would fail if executed (never should be).
+    runtime
+        .add_activity(ActivityAddParams {
+            id: "spec-precond-guarded".to_string(),
+            spec_type: "cli_command".to_string(),
+            description: "must not be reached".to_string(),
+            input_schema_json: json!({}),
+            output_schema_json: json!({}),
+            spec_config: json!({
+                "command": "sh",
+                "args": ["-c", "echo 'should not run' && exit 1"]
+            }),
+            workspace_path: None,
+            identity_id: None,
+            created_by: None,
+        })
+        .expect("add activity");
+
+    let job = runtime
+        .add_job(JobAddParams {
+            job_id: None,
+            default_input: None,
+            steps: vec![JobStep {
+                target_type: JobTargetType::Activity,
+                target_id: "spec-precond-guarded".to_string(),
+                agent_cli: String::new(),
+                timeout_seconds: 30,
+                env_extra: vec![],
+                precondition: Some(JobStepPrecondition {
+                    command: "sh".to_string(),
+                    args: vec!["-c".to_string(), "exit 1".to_string()],
+                    skip_job_on_failure: true,
+                }),
+            }],
+            initial_state_override: None,
+        })
+        .expect("add job");
+
+    let result = runtime.run_job_now(&job.job_id).expect("run job");
+    assert_eq!(
+        result.state,
+        JobRunState::Success,
+        "job should succeed when precondition fails with skip_job_on_failure=true"
+    );
+
+    // The activity itself must not have run — no step records.
+    let history = runtime.job_history(&job.job_id).expect("history");
+    assert_eq!(history.len(), 1, "one run recorded");
+    let run = &history[0];
+    assert_eq!(
+        run.steps.len(),
+        0,
+        "no steps executed when precondition blocks the pipeline"
+    );
+
+    // A JobSkipped event must be recorded with the step id in the reason.
+    let audits = runtime.list_audits(50).expect("audits");
+    let skipped = audits.iter().any(|a| {
+        a.event_type == "JobSkipped"
+            && a.payload.to_string().contains("spec-precond-guarded")
+    });
+    assert!(
+        skipped,
+        "JobSkipped event must be recorded with the step target_id"
+    );
+}
+
+#[test]
+fn precondition_failing_without_skip_job_on_failure_fails_job() {
+    let dir = tempdir().expect("tempdir");
+    let runtime = OrbitRuntime::from_data_root(dir.path()).expect("runtime");
+
+    runtime
+        .add_activity(ActivityAddParams {
+            id: "spec-precond-fail".to_string(),
+            spec_type: "cli_command".to_string(),
+            description: "must not be reached".to_string(),
+            input_schema_json: json!({}),
+            output_schema_json: json!({}),
+            spec_config: json!({
+                "command": "sh",
+                "args": ["-c", "echo guarded"]
+            }),
+            workspace_path: None,
+            identity_id: None,
+            created_by: None,
+        })
+        .expect("add activity");
+
+    let job = runtime
+        .add_job(JobAddParams {
+            job_id: None,
+            default_input: None,
+            steps: vec![JobStep {
+                target_type: JobTargetType::Activity,
+                target_id: "spec-precond-fail".to_string(),
+                agent_cli: String::new(),
+                timeout_seconds: 30,
+                env_extra: vec![],
+                precondition: Some(JobStepPrecondition {
+                    command: "sh".to_string(),
+                    args: vec!["-c".to_string(), "exit 1".to_string()],
+                    skip_job_on_failure: false,
+                }),
+            }],
+            initial_state_override: None,
+        })
+        .expect("add job");
+
+    // When skip_job_on_failure is false, a failing precondition returns an Err.
+    let err = runtime
+        .run_job_now(&job.job_id)
+        .expect_err("run_job_now must return Err when precondition fails with skip_job_on_failure=false");
+    assert!(
+        err.to_string().contains("Precondition failed"),
+        "error message should describe the precondition failure"
+    );
+
+    // The job run should be recorded as failed.
+    let history = runtime.job_history(&job.job_id).expect("history");
+    assert_eq!(history.len(), 1, "one run recorded");
+    assert_eq!(
+        history[0].state,
+        JobRunState::Failed,
+        "job run state should be failed"
+    );
+}
+
+#[test]
+fn precondition_passing_allows_step_to_execute() {
+    let dir = tempdir().expect("tempdir");
+    let runtime = OrbitRuntime::from_data_root(dir.path()).expect("runtime");
+
+    let marker = dir.path().join("step-ran.txt");
+    let script_path = dir.path().join("run-step.sh");
+    let script = format!(
+        "#!/bin/sh\ntouch \"{}\"\n",
+        marker.to_string_lossy()
+    );
+    std::fs::write(&script_path, &script).expect("write script");
+    #[cfg(unix)]
+    std::fs::set_permissions(
+        &script_path,
+        std::fs::Permissions::from_mode(0o755),
+    )
+    .expect("chmod script");
+
+    runtime
+        .add_activity(ActivityAddParams {
+            id: "spec-precond-pass".to_string(),
+            spec_type: "cli_command".to_string(),
+            description: "should run when precondition passes".to_string(),
+            input_schema_json: json!({}),
+            output_schema_json: json!({}),
+            spec_config: json!({
+                "command": script_path.to_string_lossy().to_string()
+            }),
+            workspace_path: None,
+            identity_id: None,
+            created_by: None,
+        })
+        .expect("add activity");
+
+    let job = runtime
+        .add_job(JobAddParams {
+            job_id: None,
+            default_input: None,
+            steps: vec![JobStep {
+                target_type: JobTargetType::Activity,
+                target_id: "spec-precond-pass".to_string(),
+                agent_cli: String::new(),
+                timeout_seconds: 30,
+                env_extra: vec![],
+                precondition: Some(JobStepPrecondition {
+                    command: "sh".to_string(),
+                    args: vec!["-c".to_string(), "exit 0".to_string()],
+                    skip_job_on_failure: true,
+                }),
+            }],
+            initial_state_override: None,
+        })
+        .expect("add job");
+
+    let result = runtime.run_job_now(&job.job_id).expect("run job");
+    assert_eq!(result.state, JobRunState::Success, "job should succeed");
+    assert!(marker.exists(), "step must have executed when precondition passed");
 }

--- a/orbit-engine/src/job_runner.rs
+++ b/orbit-engine/src/job_runner.rs
@@ -1,6 +1,8 @@
+use std::process::Command;
+
 use chrono::{DateTime, Utc};
 use orbit_store::JobRunStepParams;
-use orbit_types::{Job, JobRun, JobRunState, JobStep, OrbitError, OrbitEvent};
+use orbit_types::{Job, JobRun, JobRunState, JobStep, JobStepPrecondition, OrbitError, OrbitEvent};
 use serde_json::Value;
 
 use crate::activity_runner::{build_execution_context_for_step, execute_single_attempt};
@@ -76,6 +78,54 @@ fn execute_activity_with_retries<H: EngineHost>(
 
         for (step_index, step) in job.steps.iter().enumerate() {
             failure_step = (step_index, step.clone());
+
+            // Evaluate precondition before paying the step execution cost.
+            if let Some(precondition) = &step.precondition {
+                match evaluate_precondition(precondition) {
+                    Ok(true) => {} // precondition passed, continue normally
+                    Ok(false) if precondition.skip_job_on_failure => {
+                        // Clean stop — not a failure.
+                        let reason = format!(
+                            "Precondition not met for step '{}': skipped cleanly.",
+                            step.target_id
+                        );
+                        let finished_at = Utc::now();
+                        let changed = host.finalize_job_run(
+                            &run.run_id,
+                            JobRunState::Success,
+                            finished_at,
+                            None,
+                        )?;
+                        if !changed {
+                            return Err(OrbitError::JobRunNotFound(run.run_id.clone()));
+                        }
+                        host.record_event(OrbitEvent::JobSkipped {
+                            job_id: job.job_id.clone(),
+                            reason: reason.clone(),
+                        })?;
+                        host.record_event(OrbitEvent::JobRunCompleted {
+                            job_id: job.job_id.clone(),
+                            run_id: run.run_id.clone(),
+                            state: JobRunState::Success.to_string(),
+                        })?;
+                        return Ok(JobRunResult {
+                            job_id: job.job_id.clone(),
+                            run_id: run.run_id.clone(),
+                            state: JobRunState::Success,
+                            attempt: run.attempt,
+                        });
+                    }
+                    Ok(false) => {
+                        // skip_job_on_failure is false — treat as step failure.
+                        return Err(OrbitError::Execution(format!(
+                            "Precondition failed for step '{}'",
+                            step.target_id
+                        )));
+                    }
+                    Err(err) => return Err(err),
+                }
+            }
+
             let execution =
                 build_execution_context_for_step(host, &job, step, current_input.clone())?;
             let step_started = Utc::now();
@@ -292,6 +342,20 @@ fn is_stale_active_run(job: &Job, run: &JobRun, now: DateTime<Utc>) -> bool {
     let elapsed_seconds = now.signed_duration_since(reference_time).num_seconds();
     let stale_after_seconds = total_timeout.saturating_add(STALE_RUN_GRACE_SECONDS) as i64;
     elapsed_seconds >= stale_after_seconds
+}
+
+/// Runs the precondition command and returns `Ok(true)` if it exits 0, `Ok(false)` if non-zero.
+fn evaluate_precondition(precondition: &JobStepPrecondition) -> Result<bool, OrbitError> {
+    let status = Command::new(&precondition.command)
+        .args(&precondition.args)
+        .status()
+        .map_err(|err| {
+            OrbitError::Execution(format!(
+                "failed to spawn precondition command '{}': {err}",
+                precondition.command
+            ))
+        })?;
+    Ok(status.success())
 }
 
 fn merge_job_input(default_input: Option<&Value>, input: Value) -> Result<Value, OrbitError> {

--- a/orbit-store/src/file/job_store.rs
+++ b/orbit-store/src/file/job_store.rs
@@ -754,6 +754,7 @@ mod tests {
             agent_cli: "mock-agent".to_string(),
             timeout_seconds: 300,
             env_extra: vec![],
+            precondition: None,
         }
     }
 
@@ -916,6 +917,7 @@ mod tests {
             agent_cli: "my-agent-cli".to_string(),
             timeout_seconds: 600,
             env_extra: vec!["MY_VAR".to_string(), "OTHER_VAR".to_string()],
+            precondition: None,
         };
         let written = store
             .insert_activity_v2(

--- a/orbit-types/src/job.rs
+++ b/orbit-types/src/job.rs
@@ -128,6 +128,17 @@ pub struct AgentCommitRequest {
     pub files: Vec<String>,
 }
 
+/// Precondition check for a job step.
+/// If the command exits non-zero and `skip_job_on_failure` is true, the pipeline
+/// stops cleanly with success state. If false, the step is treated as a failure.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct JobStepPrecondition {
+    pub command: String,
+    #[serde(default)]
+    pub args: Vec<String>,
+    pub skip_job_on_failure: bool,
+}
+
 /// A single step within a job definition.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct JobStep {
@@ -139,6 +150,8 @@ pub struct JobStep {
     /// Additional env var names to pass through in hermetic mode, on top of the global allowlist.
     #[serde(default)]
     pub env_extra: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub precondition: Option<JobStepPrecondition>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -150,6 +163,55 @@ pub struct Job {
     pub steps: Vec<JobStep>,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn job_step_precondition_round_trips_json() {
+        let step = JobStep {
+            target_type: JobTargetType::Activity,
+            target_id: "dispatch_task".to_string(),
+            agent_cli: "claude".to_string(),
+            timeout_seconds: 1000,
+            env_extra: vec![],
+            precondition: Some(JobStepPrecondition {
+                command: "orbit".to_string(),
+                args: vec![
+                    "activity".to_string(),
+                    "run".to_string(),
+                    "check_dispatch_needed".to_string(),
+                ],
+                skip_job_on_failure: true,
+            }),
+        };
+        let json = serde_json::to_string(&step).expect("serialize");
+        let back: JobStep = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(step, back);
+        let precondition = back.precondition.expect("has precondition");
+        assert_eq!(precondition.command, "orbit");
+        assert_eq!(
+            precondition.args,
+            vec!["activity", "run", "check_dispatch_needed"]
+        );
+        assert!(precondition.skip_job_on_failure);
+    }
+
+    #[test]
+    fn job_step_without_precondition_omits_field_in_json() {
+        let step = JobStep {
+            target_type: JobTargetType::Activity,
+            target_id: "some_step".to_string(),
+            agent_cli: String::new(),
+            timeout_seconds: 60,
+            env_extra: vec![],
+            precondition: None,
+        };
+        let json = serde_json::to_string(&step).expect("serialize");
+        assert!(!json.contains("precondition"), "precondition must be omitted when None");
+    }
 }
 
 /// Per-step execution record stored in a step file inside the run bundle directory.

--- a/orbit-types/src/lib.rs
+++ b/orbit-types/src/lib.rs
@@ -22,7 +22,7 @@ pub use id::OrbitId;
 pub use identity::{IdentityRole, ResolvedIdentity};
 pub use job::{
     AgentCommitRequest, AgentResponseEnvelope, AgentRunError, Job, JobRun, JobRunState, JobRunStep,
-    JobScheduleState, JobStep, JobTargetType,
+    JobScheduleState, JobStep, JobStepPrecondition, JobTargetType,
 };
 pub use memo::Memo;
 pub use redaction::{
@@ -113,6 +113,7 @@ mod tests {
                 agent_cli: "claude".to_string(),
                 timeout_seconds: 300,
                 env_extra: vec![],
+                precondition: None,
             }],
             created_at: Utc::now(),
             updated_at: Utc::now(),


### PR DESCRIPTION
## Changes
feat: dispatch_task: consider rejected tasks and add pre-invoke guard [T20260315-200609]

Implemented the dispatch_task guard and rejected-task priority feature. Added a `JobStepPrecondition` struct to `orbit-types` with `command`, `args`, and `skip_job_on_failure` fields. Wired precondition evaluation into the job runner in `orbit-engine` so a failing precondition with `skip_job_on_failure: true` stops the pipeline cleanly as `Success` (emitting a `JobSkipped` event), while `skip_job_on_failure: false` follows the existing failure path. Created a `check_dispatch_needed` cli_command activity (bash + jq) and registered it as a bundled default. Updated `dispatch_task` to query both `rejected` and `backlog` queues with rejected tasks taking priority. Wired the precondition into `job_task_pipeline.yaml`'s dispatch_task step. All workspace tests pass (only 2 pre-existing orbit-cli failures unrelated to this work).

## Files Changed
- `orbit-cli/src/command/job.rs`
- `orbit-core/assets/activities/check_dispatch_needed.yaml`
- `orbit-core/assets/activities/dispatch_task.yaml`
- `orbit-core/assets/jobs/job_task_pipeline.yaml`
- `orbit-core/src/command/activity.rs`
- `orbit-core/src/command/job.rs`
- `orbit-core/src/lib.rs`
- `orbit-core/tests/job_runtime_behavior.rs`
- `orbit-engine/src/job_runner.rs`
- `orbit-store/src/file/job_store.rs`
- `orbit-types/src/job.rs`
- `orbit-types/src/lib.rs`