### PR TITLE
Fix command injection in proc.which tool

### DIFF
--- a/orbit-tools/src/builtin/proc/which.rs
+++ b/orbit-tools/src/builtin/proc/which.rs
@@ -10,7 +10,7 @@ impl Tool for ProcWhichTool {
     fn schema(&self) -> ToolSchema {
         ToolSchema {
             name: "proc.which".to_string(),
-            description: "Resolve a command path using shell lookup".to_string(),
+            description: "Resolve a command path".to_string(),
             parameters: vec![ToolParam {
                 name: "command".to_string(),
                 description: "Command name to look up".to_string(),
@@ -27,10 +27,16 @@ impl Tool for ProcWhichTool {
             .and_then(Value::as_str)
             .ok_or_else(|| OrbitError::InvalidInput("missing `command`".to_string()))?;
 
+        let which_program = if cfg!(target_os = "windows") {
+            "where"
+        } else {
+            "which"
+        };
+
         let result = run_process(
             &ExecRequest {
-                program: "sh".to_string(),
-                args: vec!["-c".to_string(), format!("command -v {command}")],
+                program: which_program.to_string(),
+                args: vec![command.to_string()],
                 current_dir: None,
                 timeout_ms: Some(1_000),
                 stdin_mode: StdinMode::Inherit,


### PR DESCRIPTION
## Changes
fix: Fix command injection in proc.which tool [T20260318-054255]

Fixed the command injection vulnerability in `orbit-tools/src/builtin/proc/which.rs` by replacing the `sh -c "command -v {command}"` shell invocation with a direct call to `which` (Unix) or `where` (Windows), passing the command name as a separate argument. This eliminates shell interpolation entirely, so user-supplied values like `foo; rm -rf /` can no longer execute arbitrary code. All 46 orbit-tools tests pass and clippy reports no warnings. Two pre-existing `config_commands` integration test failures were confirmed to exist on the main branch before this change and are unrelated.

## Files Changed
- `orbit-tools/src/builtin/proc/which.rs`