### PR TITLE
Allow field updates on all task statuses except done and archived

### DIFF
--- a/orbit-core/src/command/job.rs
+++ b/orbit-core/src/command/job.rs
@@ -2,10 +2,7 @@ use chrono::{DateTime, Utc};
 use orbit_agent::{Agent, AgentConfig};
 use orbit_store::JobCreateParams as StoreActivityCreateParams;
 use orbit_store::JobUpdateParams as StoreJobUpdateParams;
-use orbit_types::{
-    Job, JobRun, JobScheduleState, JobStep, JobTargetType, OrbitError,
-    OrbitEvent,
-};
+use orbit_types::{Job, JobRun, JobScheduleState, JobStep, JobTargetType, OrbitError, OrbitEvent};
 use serde::Deserialize;
 use serde_json::Value;
 

--- a/orbit-core/src/command/task.rs
+++ b/orbit-core/src/command/task.rs
@@ -145,6 +145,20 @@ impl OrbitRuntime {
 
     pub fn update_task(&self, id: &str, params: TaskUpdateParams) -> Result<Task, OrbitError> {
         let task = self.get_task(id)?;
+        let is_field_update = params.title.is_some()
+            || params.description.is_some()
+            || params.plan.is_some()
+            || params.execution_summary.is_some()
+            || params.comment.is_some()
+            || params.branch.is_some()
+            || params.pr_number.is_some();
+
+        if is_field_update && matches!(task.status, TaskStatus::Done | TaskStatus::Archived) {
+            return Err(OrbitError::InvalidInput(format!(
+                "task {id} is {} and cannot be modified; unarchive or reopen it first",
+                task.status
+            )));
+        }
 
         if let Some(target_status) = params.status {
             if target_status == TaskStatus::Archived {

--- a/orbit-core/src/lib.rs
+++ b/orbit-core/src/lib.rs
@@ -509,6 +509,144 @@ mod tests {
     }
 
     #[test]
+    fn update_task_rejects_field_mutations_for_done_tasks() {
+        let runtime = OrbitRuntime::in_memory().expect("runtime");
+        let task = runtime
+            .context
+            .task_store
+            .create_task(StoreTaskCreateParams {
+                actor: "human".to_string(),
+                title: "done task".to_string(),
+                description: String::new(),
+                plan: String::new(),
+                execution_summary: "already shipped".to_string(),
+                context_files: Vec::new(),
+                workspace_path: None,
+                created_by: Some("human".to_string()),
+                assigned_to: Some("human".to_string()),
+                status: TaskStatus::Done,
+                priority: TaskPriority::Medium,
+                task_type: TaskType::Task,
+                branch: None,
+                pr_number: None,
+                proposed_by: None,
+                comments: Vec::new(),
+            })
+            .expect("create done task");
+
+        let result = runtime.update_task(
+            &task.id,
+            TaskUpdateParams {
+                title: Some("rename attempt".to_string()),
+                description: None,
+                plan: None,
+                execution_summary: None,
+                comment: None,
+                status: None,
+                branch: None,
+                pr_number: None,
+            },
+        );
+
+        assert!(matches!(
+            result,
+            Err(crate::OrbitError::InvalidInput(message)) if message.contains("cannot be modified")
+        ));
+    }
+
+    #[test]
+    fn update_task_rejects_field_mutations_for_archived_tasks() {
+        let runtime = OrbitRuntime::in_memory().expect("runtime");
+        let task = runtime
+            .context
+            .task_store
+            .create_task(StoreTaskCreateParams {
+                actor: "human".to_string(),
+                title: "archived task".to_string(),
+                description: String::new(),
+                plan: String::new(),
+                execution_summary: "archived after review".to_string(),
+                context_files: Vec::new(),
+                workspace_path: None,
+                created_by: Some("human".to_string()),
+                assigned_to: Some("human".to_string()),
+                status: TaskStatus::Archived,
+                priority: TaskPriority::Medium,
+                task_type: TaskType::Task,
+                branch: None,
+                pr_number: None,
+                proposed_by: None,
+                comments: Vec::new(),
+            })
+            .expect("create archived task");
+
+        let result = runtime.update_task(
+            &task.id,
+            TaskUpdateParams {
+                title: Some("rename attempt".to_string()),
+                description: None,
+                plan: None,
+                execution_summary: None,
+                comment: None,
+                status: None,
+                branch: None,
+                pr_number: None,
+            },
+        );
+
+        assert!(matches!(
+            result,
+            Err(crate::OrbitError::InvalidInput(message)) if message.contains("cannot be modified")
+        ));
+    }
+
+    #[test]
+    fn update_task_allows_field_mutations_for_in_progress_tasks() {
+        let runtime = OrbitRuntime::in_memory().expect("runtime");
+        let task = runtime
+            .context
+            .task_store
+            .create_task(StoreTaskCreateParams {
+                actor: "human".to_string(),
+                title: "active task".to_string(),
+                description: String::new(),
+                plan: String::new(),
+                execution_summary: String::new(),
+                context_files: Vec::new(),
+                workspace_path: None,
+                created_by: Some("human".to_string()),
+                assigned_to: Some("human".to_string()),
+                status: TaskStatus::InProgress,
+                priority: TaskPriority::Medium,
+                task_type: TaskType::Task,
+                branch: None,
+                pr_number: None,
+                proposed_by: None,
+                comments: Vec::new(),
+            })
+            .expect("create in-progress task");
+
+        let updated = runtime
+            .update_task(
+                &task.id,
+                TaskUpdateParams {
+                    title: Some("retitled active task".to_string()),
+                    description: None,
+                    plan: None,
+                    execution_summary: None,
+                    comment: None,
+                    status: None,
+                    branch: None,
+                    pr_number: None,
+                },
+            )
+            .expect("update in-progress task");
+
+        assert_eq!(updated.title, "retitled active task");
+        assert_eq!(updated.status, TaskStatus::InProgress);
+    }
+
+    #[test]
     fn add_task_comment_uses_effective_actor() {
         let runtime = OrbitRuntime::in_memory().expect("runtime");
         let task = runtime

--- a/orbit-core/src/paths.rs
+++ b/orbit-core/src/paths.rs
@@ -164,7 +164,11 @@ mod tests {
         std::fs::create_dir_all(&cwd).expect("create cwd");
 
         let root = find_git_repo_root(&cwd);
-        assert_eq!(root, Some(main_repo), "should resolve to main repo, not worktree");
+        assert_eq!(
+            root,
+            Some(main_repo),
+            "should resolve to main repo, not worktree"
+        );
     }
 
     #[test]

--- a/orbit-core/tests/job_runtime_behavior.rs
+++ b/orbit-core/tests/job_runtime_behavior.rs
@@ -9,8 +9,7 @@ use orbit_core::command::job::JobAddParams;
 use orbit_core::command::job_run::JobRunListParams;
 use orbit_core::command::task::{TaskAddParams, TaskUpdateParams};
 use orbit_types::{
-    JobRunState, JobStep, JobTargetType, OrbitError, TaskPriority, TaskStatus,
-    TaskType,
+    JobRunState, JobStep, JobTargetType, OrbitError, TaskPriority, TaskStatus, TaskType,
 };
 use serde_json::json;
 use tempfile::tempdir;
@@ -2241,7 +2240,9 @@ fn commit_changes_automation_commits_dirty_task_worktree() {
         .expect("git log");
     assert_eq!(
         String::from_utf8_lossy(&log.stdout).trim(),
-        format!("refactor: Refactor automation flow [{task_id}]\n\nImplemented the automation refactor.")
+        format!(
+            "refactor: Refactor automation flow [{task_id}]\n\nImplemented the automation refactor."
+        )
     );
     assert_eq!(git_current_branch(&repo_root), "agent-main");
 }
@@ -2314,11 +2315,24 @@ fn commit_task_changes_uses_summary_from_input() {
     let create_run = runtime.run_job_now(&create_job_id).expect("run create");
     assert_eq!(create_run.state, JobRunState::Success);
     let create_history = runtime.job_history(&create_job_id).expect("create history");
-    let create_output = create_history[0].steps[0].agent_response_json.as_ref().expect("output");
-    let workspace_path = create_output["workspace_path"].as_str().expect("workspace_path").to_string();
-    let branch = create_output["branch"].as_str().expect("branch").to_string();
+    let create_output = create_history[0].steps[0]
+        .agent_response_json
+        .as_ref()
+        .expect("output");
+    let workspace_path = create_output["workspace_path"]
+        .as_str()
+        .expect("workspace_path")
+        .to_string();
+    let branch = create_output["branch"]
+        .as_str()
+        .expect("branch")
+        .to_string();
 
-    std::fs::write(std::path::Path::new(&workspace_path).join("fix.rs"), "fixed\n").expect("write");
+    std::fs::write(
+        std::path::Path::new(&workspace_path).join("fix.rs"),
+        "fixed\n",
+    )
+    .expect("write");
 
     runtime
         .add_activity(ActivityAddParams {
@@ -2344,12 +2358,18 @@ fn commit_task_changes_uses_summary_from_input() {
         })
         .expect("add success job")
         .job_id;
-    let success_run = runtime.run_job_now(&success_job_id).expect("run success job");
+    let success_run = runtime
+        .run_job_now(&success_job_id)
+        .expect("run success job");
     match previous_worktree_root.as_ref() {
         Some(value) => unsafe { std::env::set_var("ORBIT_WORKTREE_ROOT", value) },
         None => unsafe { std::env::remove_var("ORBIT_WORKTREE_ROOT") },
     }
-    assert_eq!(success_run.state, JobRunState::Success, "must succeed when summary is in input");
+    assert_eq!(
+        success_run.state,
+        JobRunState::Success,
+        "must succeed when summary is in input"
+    );
 
     // Case 2: summary absent from input → must fail with clear error.
     let task2_id = runtime
@@ -2375,9 +2395,16 @@ fn commit_task_changes_uses_summary_from_input() {
         .expect("add fail job")
         .job_id;
     let fail_run = runtime.run_job_now(&fail_job_id).expect("run fail job");
-    assert_eq!(fail_run.state, JobRunState::Failed, "must fail when summary is absent");
+    assert_eq!(
+        fail_run.state,
+        JobRunState::Failed,
+        "must fail when summary is absent"
+    );
     let fail_history = runtime.job_history(&fail_job_id).expect("fail history");
-    let error_msg = fail_history[0].steps[0].error_message.as_deref().unwrap_or("");
+    let error_msg = fail_history[0].steps[0]
+        .error_message
+        .as_deref()
+        .unwrap_or("");
     assert!(
         error_msg.contains("requires a non-empty summary"),
         "error should mention missing summary, got: {error_msg}"
@@ -2581,9 +2608,18 @@ fn open_pr_automation_uses_task_title_and_commit_output() {
         "Wire Orbit PR automation"
     );
     let body_content = std::fs::read_to_string(body_capture).expect("body");
-    assert!(body_content.contains("Orbit owns PR creation now."), "body: {body_content}");
-    assert!(body_content.contains("## Files Changed"), "body: {body_content}");
-    assert!(body_content.contains("automation.rs"), "body: {body_content}");
+    assert!(
+        body_content.contains("Orbit owns PR creation now."),
+        "body: {body_content}"
+    );
+    assert!(
+        body_content.contains("## Files Changed"),
+        "body: {body_content}"
+    );
+    assert!(
+        body_content.contains("automation.rs"),
+        "body: {body_content}"
+    );
     assert_eq!(
         std::fs::read_to_string(base_capture).expect("base"),
         "agent-main"
@@ -2699,4 +2735,3 @@ pass = ["HOME", "PATH"]
         "step2 must not have STEP1_SECRET"
     );
 }
-

--- a/orbit-engine/src/executor/automation.rs
+++ b/orbit-engine/src/executor/automation.rs
@@ -153,7 +153,12 @@ fn open_pr_from_task<H: EngineHost>(host: &H, input: &Value) -> Result<Value, Or
     let changed_files: Vec<String> = input
         .get("changed_files")
         .and_then(Value::as_array)
-        .map(|arr| arr.iter().filter_map(Value::as_str).map(String::from).collect())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(Value::as_str)
+                .map(String::from)
+                .collect()
+        })
         .unwrap_or_default();
     let body = format!(
         "## Changes\n{}\n\n## Files Changed\n{}",
@@ -380,11 +385,7 @@ fn fetch_remote_base(repo_root: &Path, base: &str) {
     let _ = run_process(
         &ExecRequest {
             program: "git".to_string(),
-            args: vec![
-                "fetch".to_string(),
-                "origin".to_string(),
-                base.to_string(),
-            ],
+            args: vec!["fetch".to_string(), "origin".to_string(), base.to_string()],
             current_dir: Some(repo_root.to_string_lossy().to_string()),
             timeout_ms: Some(60_000),
             stdin_mode: StdinMode::Null,

--- a/orbit-types/src/task.rs
+++ b/orbit-types/src/task.rs
@@ -230,16 +230,20 @@ mod tests {
 
     #[test]
     fn rejected_can_transition_to_in_progress() {
-        assert!(TaskStatus::Rejected
-            .validate_transition(TaskStatus::InProgress)
-            .is_ok());
+        assert!(
+            TaskStatus::Rejected
+                .validate_transition(TaskStatus::InProgress)
+                .is_ok()
+        );
     }
 
     #[test]
     fn rejected_can_still_transition_to_backlog() {
-        assert!(TaskStatus::Rejected
-            .validate_transition(TaskStatus::Backlog)
-            .is_ok());
+        assert!(
+            TaskStatus::Rejected
+                .validate_transition(TaskStatus::Backlog)
+                .is_ok()
+        );
     }
 }
 


### PR DESCRIPTION
## Changes
feat: Allow field updates on all task statuses except done and archived [T20260319-033402]

Added an `update_task` guard so non-status field mutations are rejected when a task is `done` or `archived`, while active statuses still allow those edits and status transitions continue through the existing validation path. I also added regression tests covering `done`, `archived`, and `in-progress` tasks, and `cargo test --workspace` passed. `cargo clippy --workspace --all-targets -- -D warnings` is still blocked by pre-existing unrelated warnings in other files and crates (`orbit-agent`, `orbit-types`, `orbit-core/src/command/init.rs`, `orbit-core/src/runtime/mod.rs`, and `orbit-core/src/paths.rs`), so I kept this change focused and did not broaden scope to fix them here.

## Files Changed
- `orbit-core/src/command/job.rs`
- `orbit-core/src/command/task.rs`
- `orbit-core/src/lib.rs`
- `orbit-core/src/paths.rs`
- `orbit-core/tests/job_runtime_behavior.rs`
- `orbit-engine/src/executor/automation.rs`
- `orbit-types/src/task.rs`