### PR TITLE
Add configurable parallel job runs

### DIFF
--- a/orbit-cli/src/command/job.rs
+++ b/orbit-cli/src/command/job.rs
@@ -44,6 +44,8 @@ impl Execute for JobSubcommand {
 pub struct JobAddArgs {
     #[arg(long)]
     pub job_id: Option<String>,
+    #[arg(long, default_value_t = 1)]
+    pub max_active_runs: u32,
     #[arg(long)]
     pub target_id: String,
     #[arg(long)]
@@ -64,6 +66,7 @@ impl Execute for JobAddArgs {
         let job = runtime.add_job(JobAddParams {
             job_id: self.job_id,
             default_input: None,
+            max_active_runs: Some(self.max_active_runs),
             steps: vec![JobStep {
                 target_type: JobTargetType::Activity,
                 target_id: self.target_id,
@@ -145,6 +148,7 @@ impl Execute for JobShowArgs {
         } else {
             println!("Job ID:            {}", job.job_id);
             println!("State:             {}", job.state);
+            println!("Max Active Runs:   {}", job.max_active_runs);
             if let Some(default_input) = &job.default_input {
                 let rendered = serde_json::to_string(default_input)
                     .unwrap_or_else(|_| "<invalid-json>".to_string());
@@ -319,6 +323,7 @@ fn job_to_json(job: &Job) -> Value {
         "job_id": job.job_id,
         "state": job.state.to_string(),
         "default_input": job.default_input,
+        "max_active_runs": job.max_active_runs,
         "created_at": job.created_at.to_rfc3339(),
         "updated_at": job.updated_at.to_rfc3339(),
         "steps": job.steps.iter().map(|s| json!({

--- a/orbit-cli/tests/job_commands.rs
+++ b/orbit-cli/tests/job_commands.rs
@@ -82,6 +82,33 @@ fn add_job_with_default_timeout(dir: &Path, target_id: &str, agent_cli: &str) ->
     String::from_utf8(output).expect("utf8").trim().to_string()
 }
 
+fn add_job_with_max_active_runs(
+    dir: &Path,
+    target_id: &str,
+    agent_cli: &str,
+    max_active_runs: u32,
+) -> String {
+    let output = orbit_in(dir)
+        .args([
+            "job",
+            "add",
+            "--target-id",
+            target_id,
+            "--agent-cli",
+            agent_cli,
+            "--timeout",
+            "30s",
+            "--max-active-runs",
+            &max_active_runs.to_string(),
+        ])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    String::from_utf8(output).expect("utf8").trim().to_string()
+}
+
 fn write_mock_agent(dir: &Path) -> String {
     let path = dir.join("mock-agent");
     std::fs::write(
@@ -167,6 +194,24 @@ fn job_add_defaults_timeout_to_twenty_minutes() {
         .clone();
     let show: Value = serde_json::from_slice(&show_output).expect("show json");
     assert_eq!(show["steps"][0]["timeout_seconds"], 1200); // 20m default = 1200 seconds
+}
+
+#[test]
+fn job_add_persists_max_active_runs() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let spec_id = add_activity(dir.path(), "spec-cli-max-active-runs");
+
+    let job_id = add_job_with_max_active_runs(dir.path(), &spec_id, "mock-agent", 3);
+
+    let show_output = orbit_in(dir.path())
+        .args(["job", "show", &job_id, "--json"])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let show: Value = serde_json::from_slice(&show_output).expect("show json");
+    assert_eq!(show["max_active_runs"], 3);
 }
 
 #[test]

--- a/orbit-core/assets/jobs/job_task_pipeline.yaml
+++ b/orbit-core/assets/jobs/job_task_pipeline.yaml
@@ -17,6 +17,7 @@ job:
   #   commit_changes   — let Orbit stage and commit repository changes in the task worktree
   #   open_pr          — let Orbit open a PR using task title + execution_summary
   #   review_pr        — review the opened PR against task acceptance criteria
+  max_active_runs: 4
   default_input:
     base: agent-main
   steps:

--- a/orbit-core/src/command/job.rs
+++ b/orbit-core/src/command/job.rs
@@ -2,7 +2,10 @@ use chrono::{DateTime, Utc};
 use orbit_agent::{Agent, AgentConfig};
 use orbit_store::JobCreateParams as StoreActivityCreateParams;
 use orbit_store::JobUpdateParams as StoreJobUpdateParams;
-use orbit_types::{Job, JobRun, JobScheduleState, JobStep, JobTargetType, OrbitError, OrbitEvent};
+use orbit_types::{
+    Job, JobRun, JobScheduleState, JobStep, JobTargetType, OrbitError, OrbitEvent,
+    default_job_max_active_runs,
+};
 use serde::Deserialize;
 use serde_json::Value;
 
@@ -39,6 +42,8 @@ struct DefaultJobEntry {
     state: String,
     #[serde(default)]
     default_input: Option<Value>,
+    #[serde(default = "default_job_max_active_runs")]
+    max_active_runs: u32,
     steps: Vec<DefaultJobStep>,
 }
 
@@ -57,6 +62,7 @@ struct DefaultJobStep {
 pub struct JobAddParams {
     pub job_id: Option<String>,
     pub default_input: Option<Value>,
+    pub max_active_runs: Option<u32>,
     pub steps: Vec<JobStep>,
     pub initial_state_override: Option<JobScheduleState>,
 }
@@ -89,6 +95,7 @@ impl OrbitRuntime {
                 "job must have at least one step".to_string(),
             ));
         }
+        let max_active_runs = validate_job_max_active_runs(params.max_active_runs)?;
         let default_input = normalize_job_default_input(params.default_input)?;
 
         for step in &params.steps {
@@ -127,6 +134,7 @@ impl OrbitRuntime {
         let job = self.context.job_store.add_job(StoreActivityCreateParams {
             job_id: params.job_id,
             default_input,
+            max_active_runs,
             steps,
             initial_state,
         })?;
@@ -140,6 +148,7 @@ impl OrbitRuntime {
         &self,
         job_id: &str,
         default_input: Option<Value>,
+        max_active_runs: u32,
         steps: Vec<JobStep>,
         state: JobScheduleState,
     ) -> Result<Job, OrbitError> {
@@ -147,6 +156,7 @@ impl OrbitRuntime {
             job_id,
             StoreJobUpdateParams {
                 default_input: Some(normalize_job_default_input(default_input)?),
+                max_active_runs: Some(validate_job_max_active_runs(Some(max_active_runs))?),
                 steps: Some(steps),
                 state: Some(state),
             },
@@ -269,6 +279,7 @@ pub(crate) fn seed_default_jobs(
             runtime.update_job_definition(
                 &entry.job_id,
                 entry.default_input.clone(),
+                entry.max_active_runs,
                 steps,
                 initial_state,
             )?;
@@ -280,6 +291,7 @@ pub(crate) fn seed_default_jobs(
         runtime.add_job(JobAddParams {
             job_id: Some(entry.job_id),
             default_input: entry.default_input,
+            max_active_runs: Some(entry.max_active_runs),
             steps,
             initial_state_override: Some(initial_state),
         })?;
@@ -324,6 +336,16 @@ fn default_job_steps(entry: &DefaultJobEntry) -> Result<Vec<JobStep>, OrbitError
         .collect()
 }
 
+fn validate_job_max_active_runs(max_active_runs: Option<u32>) -> Result<u32, OrbitError> {
+    let value = max_active_runs.unwrap_or_else(default_job_max_active_runs);
+    if value == 0 {
+        return Err(OrbitError::JobValidation(
+            "job max_active_runs must be at least 1".to_string(),
+        ));
+    }
+    Ok(value)
+}
+
 #[cfg(test)]
 mod tests {
     use super::{DEFAULT_JOB_FILES, load_default_job_specs};
@@ -348,12 +370,18 @@ mod tests {
         );
         for spec in &specs {
             assert!(!spec.job_id.is_empty(), "job_id must not be empty");
+            assert!(spec.max_active_runs > 0, "max_active_runs must be positive");
             assert!(!spec.steps.is_empty(), "steps must not be empty");
             for step in &spec.steps {
                 assert!(!step.target_id.is_empty(), "target_id must not be empty");
                 assert!(step.timeout_seconds > 0, "timeout_seconds must be positive");
             }
         }
+        let pipeline = specs
+            .iter()
+            .find(|spec| spec.job_id == "job_task_pipeline")
+            .expect("task pipeline spec present");
+        assert_eq!(pipeline.max_active_runs, 4);
     }
 
     #[test]

--- a/orbit-core/src/lib.rs
+++ b/orbit-core/src/lib.rs
@@ -222,6 +222,7 @@ mod tests {
             .add_job(JobAddParams {
                 job_id: None,
                 default_input: None,
+                max_active_runs: None,
                 steps: vec![JobStep {
                     target_type: JobTargetType::Activity,
                     target_id: "spec-core-double-run".to_string(),

--- a/orbit-core/src/runtime/engine.rs
+++ b/orbit-core/src/runtime/engine.rs
@@ -183,10 +183,10 @@ impl EngineHost for OrbitRuntime {
         OrbitRuntime::validate_activity_target_exists(self, target_type, target_id)
     }
 
-    fn get_pending_or_running_job_run(&self, job_id: &str) -> Result<Option<JobRun>, OrbitError> {
+    fn list_pending_or_running_job_runs(&self, job_id: &str) -> Result<Vec<JobRun>, OrbitError> {
         self.context
             .job_store
-            .get_pending_or_running_job_run(job_id)
+            .list_pending_or_running_job_runs(job_id)
     }
 
     fn insert_job_run(

--- a/orbit-core/tests/asset_formatting.rs
+++ b/orbit-core/tests/asset_formatting.rs
@@ -189,6 +189,10 @@ fn job_assets_use_grouped_sections() {
 #[test]
 fn task_pipeline_starts_task_after_worktree_creation() {
     let raw = include_str!("../assets/jobs/job_task_pipeline.yaml");
+    assert!(
+        raw.contains("max_active_runs: 4"),
+        "task pipeline should opt into explicit parallel run capacity"
+    );
     assert_in_order(
         raw,
         &[

--- a/orbit-core/tests/job_runtime_behavior.rs
+++ b/orbit-core/tests/job_runtime_behavior.rs
@@ -97,16 +97,42 @@ fn add_scheduled_activity(runtime: &OrbitRuntime, target_id: &str, agent_cli: &s
     add_scheduled_activity_with_timeout(runtime, target_id, agent_cli, 10)
 }
 
+fn add_scheduled_activity_with_limit(
+    runtime: &OrbitRuntime,
+    target_id: &str,
+    agent_cli: &str,
+    max_active_runs: u32,
+) -> String {
+    add_scheduled_activity_with_timeout_and_limit(
+        runtime,
+        target_id,
+        agent_cli,
+        10,
+        max_active_runs,
+    )
+}
+
 fn add_scheduled_activity_with_timeout(
     runtime: &OrbitRuntime,
     target_id: &str,
     agent_cli: &str,
     timeout_seconds: u64,
 ) -> String {
+    add_scheduled_activity_with_timeout_and_limit(runtime, target_id, agent_cli, timeout_seconds, 1)
+}
+
+fn add_scheduled_activity_with_timeout_and_limit(
+    runtime: &OrbitRuntime,
+    target_id: &str,
+    agent_cli: &str,
+    timeout_seconds: u64,
+    max_active_runs: u32,
+) -> String {
     runtime
         .add_job(JobAddParams {
             job_id: None,
             default_input: None,
+            max_active_runs: Some(max_active_runs),
             steps: vec![JobStep {
                 target_type: JobTargetType::Activity,
                 target_id: target_id.to_string(),
@@ -203,6 +229,7 @@ fn cli_command_activity_executes_without_agent_cli_and_captures_output_file() {
         .add_job(JobAddParams {
             job_id: None,
             default_input: None,
+            max_active_runs: None,
             steps: vec![JobStep {
                 target_type: JobTargetType::Activity,
                 target_id: "spec-cli-command".to_string(),
@@ -263,6 +290,7 @@ fn cli_command_failures_redact_sensitive_environment_values_from_error_messages(
         .add_job(JobAddParams {
             job_id: None,
             default_input: None,
+            max_active_runs: None,
             steps: vec![JobStep {
                 target_type: JobTargetType::Activity,
                 target_id: "spec-cli-secret-redaction".to_string(),
@@ -376,6 +404,7 @@ fn cli_command_receives_only_baseline_allowlisted_and_orbit_env_vars() {
         .add_job(JobAddParams {
             job_id: None,
             default_input: None,
+            max_active_runs: None,
             steps: vec![JobStep {
                 target_type: JobTargetType::Activity,
                 target_id: "spec-cli-allowlisted-env".to_string(),
@@ -475,6 +504,7 @@ fn cli_command_step_env_extra_is_scoped_per_step() {
         .add_job(JobAddParams {
             job_id: None,
             default_input: None,
+            max_active_runs: None,
             steps: vec![
                 JobStep {
                     target_type: JobTargetType::Activity,
@@ -641,10 +671,11 @@ struct JobRunFileDocument {
     run: orbit_types::JobRun,
 }
 
-fn insert_stale_running_run(
+fn rewrite_run_as_running(
     runtime: &OrbitRuntime,
     data_root: &std::path::Path,
     job_id: &str,
+    started_at: chrono::DateTime<Utc>,
 ) -> String {
     let run = runtime.run_job_now(job_id).expect("seed run");
     // jrun.yaml lives inside the run bundle directory
@@ -656,16 +687,41 @@ fn insert_stale_running_run(
         .join("jrun.yaml");
     let raw = std::fs::read_to_string(&jrun_path).expect("read jrun.yaml");
     let mut doc: JobRunFileDocument = serde_yaml::from_str(&raw).expect("parse run doc");
-    let old_time = Utc::now() - ChronoDuration::hours(2);
     // Only manipulate run-level fields; step-level fields live in steps/*.yaml
     doc.run.state = JobRunState::Running;
-    doc.run.started_at = Some(old_time);
+    doc.run.started_at = Some(started_at);
     doc.run.finished_at = None;
     doc.run.duration_ms = None;
-    doc.run.created_at = old_time;
+    doc.run.created_at = started_at;
     let updated = serde_yaml::to_string(&doc).expect("serialize run doc");
     std::fs::write(&jrun_path, updated).expect("write jrun.yaml");
     run.run_id
+}
+
+fn insert_stale_running_run(
+    runtime: &OrbitRuntime,
+    data_root: &std::path::Path,
+    job_id: &str,
+) -> String {
+    rewrite_run_as_running(
+        runtime,
+        data_root,
+        job_id,
+        Utc::now() - ChronoDuration::hours(2),
+    )
+}
+
+fn insert_fresh_running_run(
+    runtime: &OrbitRuntime,
+    data_root: &std::path::Path,
+    job_id: &str,
+) -> String {
+    rewrite_run_as_running(
+        runtime,
+        data_root,
+        job_id,
+        Utc::now() - ChronoDuration::seconds(5),
+    )
 }
 
 #[test]
@@ -778,6 +834,7 @@ fn run_job_now_uses_job_default_input_when_manual_input_is_absent() {
         .add_job(JobAddParams {
             job_id: None,
             default_input: Some(json!({ "base": "main" })),
+            max_active_runs: None,
             steps: vec![JobStep {
                 target_type: JobTargetType::Activity,
                 target_id: "spec-default-input".to_string(),
@@ -827,6 +884,7 @@ fn run_job_now_with_input_overrides_job_default_input() {
         .add_job(JobAddParams {
             job_id: None,
             default_input: Some(json!({ "base": "main", "mode": "auto" })),
+            max_active_runs: None,
             steps: vec![JobStep {
                 target_type: JobTargetType::Activity,
                 target_id: "spec-default-override".to_string(),
@@ -895,6 +953,7 @@ fn run_job_now_finalizes_failed_when_pre_step_setup_errors_after_running() {
         .add_job(JobAddParams {
             job_id: None,
             default_input: Some(json!({ "base": "main" })),
+            max_active_runs: None,
             steps: vec![JobStep {
                 target_type: JobTargetType::Activity,
                 target_id: "spec-invalid-default-input".to_string(),
@@ -1434,7 +1493,7 @@ fn run_job_now_rejects_when_active_run_exists() {
         .run_job_now(&job_id)
         .expect_err("second run should be rejected while first is active");
     assert!(matches!(err, OrbitError::JobValidation(_)));
-    assert!(err.to_string().contains("already has an active run"));
+    assert!(err.to_string().contains("max_active_runs=1"));
 
     let first = handle.join().expect("join");
     assert!(first.is_ok(), "first run should complete successfully");
@@ -1446,6 +1505,37 @@ fn run_job_now_rejects_when_active_run_exists() {
         "second invocation must not insert a pending row"
     );
     assert_eq!(history[0].state, JobRunState::Success);
+}
+
+#[test]
+fn run_job_now_allows_parallel_runs_when_job_limit_is_higher() {
+    let dir = tempdir().expect("tempdir");
+    let runtime = Arc::new(OrbitRuntime::from_data_root(dir.path()).expect("runtime"));
+    let script_path = dir.path().join("mock-agent");
+    let agent_cli = write_agent_script(
+        &script_path,
+        "#!/bin/sh\nsleep 0.5\nprintf '{\"schemaVersion\":1,\"status\":\"success\",\"result\":{},\"error\":null,\"durationMs\":1}'\n",
+    );
+
+    add_activity(&runtime, "spec-parallel-runs");
+    let job_id = add_scheduled_activity_with_limit(&runtime, "spec-parallel-runs", &agent_cli, 2);
+
+    let r1 = Arc::clone(&runtime);
+    let job_id_thread = job_id.clone();
+    let handle = thread::spawn(move || r1.run_job_now(&job_id_thread));
+    thread::sleep(std::time::Duration::from_millis(100));
+
+    let second = runtime
+        .run_job_now(&job_id)
+        .expect("second run should be allowed");
+    assert_eq!(second.state, JobRunState::Success);
+
+    let first = handle.join().expect("join");
+    assert!(first.is_ok(), "first run should complete successfully");
+
+    let history = runtime.job_history(&job_id).expect("history");
+    assert_eq!(history.len(), 2, "parallel runs should both be persisted");
+    assert!(history.iter().all(|run| run.state == JobRunState::Success));
 }
 
 #[test]
@@ -1516,6 +1606,49 @@ fn run_job_now_recovers_stale_running_run_and_executes_new_attempt() {
     assert!(
         history.iter().any(|run| run.state == JobRunState::Success),
         "new attempt should complete successfully"
+    );
+}
+
+#[test]
+fn run_job_now_recovers_only_stale_runs_when_multiple_active_runs_exist() {
+    let dir = tempdir().expect("tempdir");
+    let runtime = OrbitRuntime::from_data_root(dir.path()).expect("runtime");
+    let script_path = dir.path().join("mock-agent");
+    let agent_cli = write_agent_script(
+        &script_path,
+        "#!/bin/sh\nprintf '{\"schemaVersion\":1,\"status\":\"success\",\"result\":{},\"error\":null,\"durationMs\":1}'\n",
+    );
+
+    add_activity(&runtime, "spec-multi-active-stale");
+    let job_id =
+        add_scheduled_activity_with_limit(&runtime, "spec-multi-active-stale", &agent_cli, 2);
+    let healthy_run_id = insert_fresh_running_run(&runtime, dir.path(), &job_id);
+    let stale_run_id = insert_stale_running_run(&runtime, dir.path(), &job_id);
+
+    let result = runtime.run_job_now(&job_id).expect("run now");
+    assert_eq!(result.state, JobRunState::Success);
+
+    let history = runtime.job_history(&job_id).expect("history");
+    let healthy = history
+        .iter()
+        .find(|run| run.run_id == healthy_run_id)
+        .expect("healthy run should exist");
+    assert_eq!(healthy.state, JobRunState::Running);
+
+    let stale = history
+        .iter()
+        .find(|run| run.run_id == stale_run_id)
+        .expect("stale run should exist");
+    assert_eq!(stale.state, JobRunState::Failed);
+    assert_eq!(
+        stale.steps.last().and_then(|s| s.error_code.as_deref()),
+        Some("AGENT_INVOCATION_FAILED")
+    );
+    assert!(
+        history
+            .iter()
+            .any(|run| run.run_id == result.run_id && run.state == JobRunState::Success),
+        "new run should complete while a healthy active run remains"
     );
 }
 
@@ -1724,6 +1857,7 @@ fn claude_job_run_succeeds_with_mock_binary() {
         .add_job(JobAddParams {
             job_id: None,
             default_input: None,
+            max_active_runs: None,
             steps: vec![JobStep {
                 target_type: JobTargetType::Activity,
                 target_id: "spec-claude-run".to_string(),
@@ -1772,6 +1906,7 @@ fn run_job_now_executes_job_successfully() {
         .add_job(JobAddParams {
             job_id: None,
             default_input: None,
+            max_active_runs: None,
             steps: vec![JobStep {
                 target_type: JobTargetType::Activity,
                 target_id: "spec-manual-run".to_string(),
@@ -1861,6 +1996,7 @@ fn agent_step_result_fields_flow_into_next_step_input() {
         .add_job(JobAddParams {
             job_id: None,
             default_input: None,
+            max_active_runs: None,
             steps: vec![
                 JobStep {
                     target_type: JobTargetType::Activity,
@@ -1976,6 +2112,7 @@ fn agent_step_workspace_path_flows_into_cli_working_directory() {
         .add_job(JobAddParams {
             job_id: None,
             default_input: None,
+            max_active_runs: None,
             steps: vec![
                 JobStep {
                     target_type: JobTargetType::Activity,
@@ -2058,6 +2195,7 @@ fn agent_step_uses_workspace_path_as_process_current_dir() {
             default_input: Some(json!({
                 "workspace_path": workspace_dir.to_string_lossy().to_string()
             })),
+            max_active_runs: None,
             steps: vec![JobStep {
                 target_type: JobTargetType::Activity,
                 target_id: "spec-agent-current-dir".to_string(),
@@ -2209,6 +2347,7 @@ fn create_branch_creates_isolated_worktree_without_mutating_main_checkout() {
                     .to_string_lossy()
                     .to_string()
             })),
+            max_active_runs: None,
             steps: vec![
                 JobStep {
                     target_type: JobTargetType::Activity,
@@ -2331,6 +2470,7 @@ fn start_task_automation_moves_task_into_progress() {
                 "task_id": task.id,
                 "note": "pipeline ready to implement"
             })),
+            max_active_runs: None,
             steps: vec![JobStep {
                 target_type: JobTargetType::Activity,
                 target_id: "spec-start-task".to_string(),
@@ -2427,6 +2567,7 @@ fn update_task_automation_moves_task_to_review_with_summary_comment_and_note() {
                 "comment": "Ready for review",
                 "note": "handing off for review"
             })),
+            max_active_runs: None,
             steps: vec![JobStep {
                 target_type: JobTargetType::Activity,
                 target_id: "spec-update-task".to_string(),
@@ -2448,7 +2589,10 @@ fn update_task_automation_moves_task_to_review_with_summary_comment_and_note() {
         updated.execution_summary,
         "Implemented the task and validated targeted tests."
     );
-    assert_eq!(updated.comments.last().expect("comment").message, "Ready for review");
+    assert_eq!(
+        updated.comments.last().expect("comment").message,
+        "Ready for review"
+    );
     let history = updated.history.last().expect("history");
     assert_eq!(history.event, "moved");
     assert_eq!(history.note.as_deref(), Some("handing off for review"));
@@ -2561,6 +2705,7 @@ fn implement_change_result_status_flows_into_update_task_as_task_status() {
         .add_job(JobAddParams {
             job_id: None,
             default_input: Some(json!({ "task_id": task.id })),
+            max_active_runs: None,
             steps: vec![
                 JobStep {
                     target_type: JobTargetType::Activity,
@@ -2592,7 +2737,10 @@ fn implement_change_result_status_flows_into_update_task_as_task_status() {
         "Implemented the change and validated tests."
     );
     assert_eq!(
-        updated.history.last().and_then(|entry| entry.note.as_deref()),
+        updated
+            .history
+            .last()
+            .and_then(|entry| entry.note.as_deref()),
         Some("ready for review")
     );
 }
@@ -2676,6 +2824,7 @@ fn commit_changes_automation_commits_dirty_task_worktree() {
                 "base": "agent-main",
                 "workspace_path": repo_root.to_string_lossy().to_string()
             })),
+            max_active_runs: None,
             steps: vec![JobStep {
                 target_type: JobTargetType::Activity,
                 target_id: "spec-create-task-worktree-for-commit".to_string(),
@@ -2753,6 +2902,7 @@ fn commit_changes_automation_commits_dirty_task_worktree() {
                 "branch": branch,
                 "summary": "Implemented the automation refactor."
             })),
+            max_active_runs: None,
             steps: vec![JobStep {
                 target_type: JobTargetType::Activity,
                 target_id: "spec-commit-task-worktree".to_string(),
@@ -2862,6 +3012,7 @@ fn commit_task_changes_uses_summary_from_input() {
         .add_job(JobAddParams {
             job_id: None,
             default_input: Some(json!({"task_id": task_id, "base": "agent-main", "workspace_path": repo_root.to_string_lossy().to_string()})),
+            max_active_runs: None,
             steps: vec![JobStep { target_type: JobTargetType::Activity, target_id: "spec-create-wt-regression".to_string(), agent_cli: String::new(), timeout_seconds: 30, env_extra: vec![] }],
             initial_state_override: None,
         })
@@ -2907,6 +3058,7 @@ fn commit_task_changes_uses_summary_from_input() {
         .add_job(JobAddParams {
             job_id: None,
             default_input: Some(json!({"task_id": task_id, "workspace_path": workspace_path, "repo_root": repo_root.to_string_lossy().to_string(), "branch": branch, "summary": "Hardened bundle writes using staged directory rename."})),
+            max_active_runs: None,
             steps: vec![JobStep { target_type: JobTargetType::Activity, target_id: "spec-commit-regression".to_string(), agent_cli: String::new(), timeout_seconds: 30, env_extra: vec![] }],
             initial_state_override: None,
         })
@@ -2943,6 +3095,7 @@ fn commit_task_changes_uses_summary_from_input() {
         .add_job(JobAddParams {
             job_id: None,
             default_input: Some(json!({"task_id": task2_id, "workspace_path": workspace_path, "repo_root": repo_root.to_string_lossy().to_string(), "branch": branch, "summary": ""})),
+            max_active_runs: None,
             steps: vec![JobStep { target_type: JobTargetType::Activity, target_id: "spec-commit-regression".to_string(), agent_cli: String::new(), timeout_seconds: 30, env_extra: vec![] }],
             initial_state_override: None,
         })
@@ -3040,6 +3193,7 @@ fn commit_task_changes_supports_task_id_only_inputs() {
                 "base": "agent-main",
                 "workspace_path": repo_root.to_string_lossy().to_string()
             })),
+            max_active_runs: None,
             steps: vec![JobStep {
                 target_type: JobTargetType::Activity,
                 target_id: "spec-create-wt-task-only".to_string(),
@@ -3119,6 +3273,7 @@ fn commit_task_changes_supports_task_id_only_inputs() {
         .add_job(JobAddParams {
             job_id: None,
             default_input: Some(json!({ "task_id": task_id })),
+            max_active_runs: None,
             steps: vec![JobStep {
                 target_type: JobTargetType::Activity,
                 target_id: "spec-commit-task-only".to_string(),
@@ -3323,6 +3478,7 @@ fn open_pr_automation_uses_task_title_and_commit_output() {
                 "commit_message": format!("feat: Wire Orbit PR automation [{task_id}]\n\nOrbit owns PR creation now."),
                 "changed_files": ["orbit-core/src/lib.rs", "orbit-engine/src/executor/automation.rs"]
             })),
+            max_active_runs: None,
             steps: vec![JobStep {
                 target_type: JobTargetType::Activity,
                 target_id: "spec-open-pr-from-task".to_string(),
@@ -3517,6 +3673,7 @@ fn open_pr_automation_supports_task_id_only_inputs() {
                 "base": "agent-main",
                 "workspace_path": repo_root.to_string_lossy().to_string()
             })),
+            max_active_runs: None,
             steps: vec![JobStep {
                 target_type: JobTargetType::Activity,
                 target_id: "spec-create-wt-open-pr-task-only".to_string(),
@@ -3589,6 +3746,7 @@ fn open_pr_automation_supports_task_id_only_inputs() {
         .add_job(JobAddParams {
             job_id: None,
             default_input: Some(json!({ "task_id": task_id })),
+            max_active_runs: None,
             steps: vec![JobStep {
                 target_type: JobTargetType::Activity,
                 target_id: "spec-commit-open-pr-task-only".to_string(),
@@ -3635,6 +3793,7 @@ fn open_pr_automation_supports_task_id_only_inputs() {
         .add_job(JobAddParams {
             job_id: None,
             default_input: Some(json!({ "task_id": task_id })),
+            max_active_runs: None,
             steps: vec![JobStep {
                 target_type: JobTargetType::Activity,
                 target_id: "spec-open-pr-task-only".to_string(),
@@ -3691,6 +3850,8 @@ fn open_pr_automation_supports_task_id_only_inputs() {
 fn multi_step_same_agent_cli_each_step_gets_its_own_env_extra() {
     // Regression: env_extra was looked up by matching agent_cli (first match), so step 2
     // sharing the same agent_cli as step 1 would receive step 1's allowlist.
+    let _lock = env_lock().lock().unwrap_or_else(|err| err.into_inner());
+    let _snapshot = EnvSnapshot::capture(&["STEP1_SECRET", "STEP2_SECRET"]);
     let dir = tempdir().expect("tempdir");
 
     // Hermetic env: only the codex-required vars pass by default; each step adds its own.
@@ -3741,6 +3902,7 @@ pass = ["HOME", "PATH"]
         .add_job(JobAddParams {
             job_id: None,
             default_input: None,
+            max_active_runs: None,
             steps: vec![
                 JobStep {
                     target_type: JobTargetType::Activity,

--- a/orbit-engine/src/context.rs
+++ b/orbit-engine/src/context.rs
@@ -73,7 +73,7 @@ pub trait EngineHost {
         target_type: JobTargetType,
         target_id: &str,
     ) -> Result<Activity, OrbitError>;
-    fn get_pending_or_running_job_run(&self, job_id: &str) -> Result<Option<JobRun>, OrbitError>;
+    fn list_pending_or_running_job_runs(&self, job_id: &str) -> Result<Vec<JobRun>, OrbitError>;
     fn insert_job_run(
         &self,
         job_id: &str,

--- a/orbit-engine/src/job_runner.rs
+++ b/orbit-engine/src/job_runner.rs
@@ -15,10 +15,16 @@ pub fn run_job_with_input<H: EngineHost>(
     input: Value,
 ) -> Result<JobRunResult, OrbitError> {
     let _ = recover_stale_active_run_for_job(host, &job, Utc::now())?;
-    if let Some(active_run) = host.get_pending_or_running_job_run(&job.job_id)? {
+    let active_runs = host.list_pending_or_running_job_runs(&job.job_id)?;
+    if active_runs.len() as u32 >= job.max_active_runs {
+        let latest_active_run = active_runs.first().expect("active run exists");
         return Err(OrbitError::JobValidation(format!(
-            "job '{}' already has an active run '{}' in state '{}'",
-            job.job_id, active_run.run_id, active_run.state
+            "job '{}' already has {} active run(s), reaching max_active_runs={} (latest active run '{}' in state '{}')",
+            job.job_id,
+            active_runs.len(),
+            job.max_active_runs,
+            latest_active_run.run_id,
+            latest_active_run.state,
         )));
     }
     host.record_event(OrbitEvent::JobTriggered {
@@ -181,59 +187,68 @@ pub fn recover_stale_active_run_for_job<H: EngineHost>(
     job: &Job,
     now: DateTime<Utc>,
 ) -> Result<bool, OrbitError> {
-    let Some(active_run) = host.get_pending_or_running_job_run(&job.job_id)? else {
-        return Ok(false);
-    };
-
-    if !is_stale_active_run(job, &active_run, now) {
+    let active_runs = host.list_pending_or_running_job_runs(&job.job_id)?;
+    if active_runs.is_empty() {
         return Ok(false);
     }
+    let mut recovered_any = false;
 
-    let reference_time = active_run.started_at.unwrap_or(active_run.created_at);
-    let age_seconds = now
-        .signed_duration_since(reference_time)
-        .num_seconds()
-        .max(0) as u64;
-    let duration_ms = active_run
-        .started_at
-        .map(|started| now.signed_duration_since(started).num_milliseconds().max(0) as u64);
-    let total_timeout: u64 = job.steps.iter().map(|s| s.timeout_seconds).sum();
-    let message = format!(
-        "stale active run recovered: run '{}' remained '{}' for {}s (timeout={}s, grace={}s)",
-        active_run.run_id, active_run.state, age_seconds, total_timeout, STALE_RUN_GRACE_SECONDS
-    );
+    for active_run in active_runs {
+        if !is_stale_active_run(job, &active_run, now) {
+            continue;
+        }
 
-    if let Some(first_step) = job.steps.first() {
-        let _ = host.complete_job_run_step(
-            &active_run.run_id,
-            &JobRunStepParams {
-                step_index: 0,
-                target_type: first_step.target_type,
-                target_id: first_step.target_id.clone(),
-                started_at: active_run.started_at.unwrap_or(active_run.created_at),
-                finished_at: now,
-                duration_ms,
-                exit_code: Some(1),
-                agent_response_json: None,
-                state: JobRunState::Failed,
-                error_code: Some(AGENT_INVOCATION_FAILED.to_string()),
-                error_message: Some(message.clone()),
-            },
+        let reference_time = active_run.started_at.unwrap_or(active_run.created_at);
+        let age_seconds = now
+            .signed_duration_since(reference_time)
+            .num_seconds()
+            .max(0) as u64;
+        let duration_ms = active_run
+            .started_at
+            .map(|started| now.signed_duration_since(started).num_milliseconds().max(0) as u64);
+        let total_timeout: u64 = job.steps.iter().map(|s| s.timeout_seconds).sum();
+        let message = format!(
+            "stale active run recovered: run '{}' remained '{}' for {}s (timeout={}s, grace={}s)",
+            active_run.run_id,
+            active_run.state,
+            age_seconds,
+            total_timeout,
+            STALE_RUN_GRACE_SECONDS
         );
+
+        if let Some(first_step) = job.steps.first() {
+            let _ = host.complete_job_run_step(
+                &active_run.run_id,
+                &JobRunStepParams {
+                    step_index: 0,
+                    target_type: first_step.target_type,
+                    target_id: first_step.target_id.clone(),
+                    started_at: active_run.started_at.unwrap_or(active_run.created_at),
+                    finished_at: now,
+                    duration_ms,
+                    exit_code: Some(1),
+                    agent_response_json: None,
+                    state: JobRunState::Failed,
+                    error_code: Some(AGENT_INVOCATION_FAILED.to_string()),
+                    error_message: Some(message.clone()),
+                },
+            );
+        }
+
+        let changed =
+            host.finalize_job_run(&active_run.run_id, JobRunState::Failed, now, duration_ms)?;
+        if !changed {
+            return Err(OrbitError::JobRunNotFound(active_run.run_id.clone()));
+        }
+        host.record_event(OrbitEvent::JobRunCompleted {
+            job_id: job.job_id.clone(),
+            run_id: active_run.run_id.clone(),
+            state: JobRunState::Failed.to_string(),
+        })?;
+        recovered_any = true;
     }
 
-    let changed =
-        host.finalize_job_run(&active_run.run_id, JobRunState::Failed, now, duration_ms)?;
-    if !changed {
-        return Err(OrbitError::JobRunNotFound(active_run.run_id.clone()));
-    }
-    host.record_event(OrbitEvent::JobRunCompleted {
-        job_id: job.job_id.clone(),
-        run_id: active_run.run_id.clone(),
-        state: JobRunState::Failed.to_string(),
-    })?;
-
-    Ok(true)
+    Ok(recovered_any)
 }
 
 fn finalize_failed_started_run<H: EngineHost>(

--- a/orbit-store/src/backend/contracts.rs
+++ b/orbit-store/src/backend/contracts.rs
@@ -80,6 +80,7 @@ pub struct ActivityUpdateParams {
 pub struct JobCreateParams {
     pub job_id: Option<String>,
     pub default_input: Option<Value>,
+    pub max_active_runs: u32,
     pub steps: Vec<JobStep>,
     pub initial_state: JobScheduleState,
 }
@@ -87,6 +88,7 @@ pub struct JobCreateParams {
 #[derive(Debug, Default, Clone)]
 pub struct JobUpdateParams {
     pub default_input: Option<Option<Value>>,
+    pub max_active_runs: Option<u32>,
     pub steps: Option<Vec<JobStep>>,
     pub state: Option<JobScheduleState>,
 }
@@ -133,7 +135,7 @@ pub trait JobStoreBackend: Send + Sync {
     fn list_job_runs(&self, job_id: &str) -> Result<Vec<JobRun>, OrbitError>;
     fn list_job_runs_filtered(&self, query: &JobRunQuery) -> Result<Vec<JobRun>, OrbitError>;
     fn get_job_run(&self, run_id: &str) -> Result<Option<JobRun>, OrbitError>;
-    fn get_pending_or_running_job_run(&self, job_id: &str) -> Result<Option<JobRun>, OrbitError>;
+    fn list_pending_or_running_job_runs(&self, job_id: &str) -> Result<Vec<JobRun>, OrbitError>;
     fn set_job_state(&self, job_id: &str, state: JobScheduleState) -> Result<bool, OrbitError>;
     fn mark_job_disabled(&self, job_id: &str) -> Result<bool, OrbitError>;
     fn insert_job_run(

--- a/orbit-store/src/backend/file_backends.rs
+++ b/orbit-store/src/backend/file_backends.rs
@@ -141,13 +141,20 @@ impl JobStoreBackend for JobFileStore {
         self.insert_activity_v2(
             params.job_id,
             params.default_input,
+            params.max_active_runs,
             params.steps,
             params.initial_state,
         )
     }
 
     fn update_job(&self, job_id: &str, params: JobUpdateParams) -> Result<Job, OrbitError> {
-        self.update_job(job_id, params.default_input, params.steps, params.state)
+        self.update_job(
+            job_id,
+            params.default_input,
+            params.max_active_runs,
+            params.steps,
+            params.state,
+        )
     }
 
     fn list_jobs(&self, include_disabled: bool) -> Result<Vec<Job>, OrbitError> {
@@ -170,8 +177,8 @@ impl JobStoreBackend for JobFileStore {
         self.get_job_run(run_id)
     }
 
-    fn get_pending_or_running_job_run(&self, job_id: &str) -> Result<Option<JobRun>, OrbitError> {
-        self.get_pending_or_running_job_run(job_id)
+    fn list_pending_or_running_job_runs(&self, job_id: &str) -> Result<Vec<JobRun>, OrbitError> {
+        self.list_pending_or_running_job_runs(job_id)
     }
 
     fn set_job_state(&self, job_id: &str, state: JobScheduleState) -> Result<bool, OrbitError> {

--- a/orbit-store/src/file/job_store.rs
+++ b/orbit-store/src/file/job_store.rs
@@ -2,7 +2,10 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 use chrono::{DateTime, Utc};
-use orbit_types::{Job, JobRun, JobRunState, JobRunStep, JobScheduleState, JobStep, OrbitError};
+use orbit_types::{
+    Job, JobRun, JobRunState, JobRunStep, JobScheduleState, JobStep, OrbitError,
+    default_job_max_active_runs,
+};
 use serde::{Deserialize, Serialize};
 
 use crate::backend::JobRunStepParams;
@@ -21,6 +24,8 @@ struct PersistedJob {
     state: JobScheduleState,
     #[serde(default)]
     default_input: Option<serde_json::Value>,
+    #[serde(default = "default_job_max_active_runs")]
+    max_active_runs: u32,
     steps: Vec<JobStep>,
     // Legacy fields: tolerated when reading old artifacts, never written to new ones.
     #[serde(default, skip_serializing)]
@@ -68,10 +73,12 @@ impl JobFileStore {
         &self,
         job_id: Option<String>,
         default_input: Option<serde_json::Value>,
+        max_active_runs: u32,
         steps: Vec<JobStep>,
         initial_state: JobScheduleState,
     ) -> Result<Job, OrbitError> {
         self.ensure_layout()?;
+        validate_max_active_runs(max_active_runs)?;
         let resolved_id = match job_id {
             Some(id) => {
                 if self.job_path(&id).exists() {
@@ -88,6 +95,7 @@ impl JobFileStore {
             job_id: resolved_id,
             state: initial_state,
             default_input,
+            max_active_runs,
             steps,
             created_at: now,
             updated_at: now,
@@ -125,6 +133,7 @@ impl JobFileStore {
         &self,
         job_id: &str,
         default_input: Option<Option<serde_json::Value>>,
+        max_active_runs: Option<u32>,
         steps: Option<Vec<JobStep>>,
         state: Option<JobScheduleState>,
     ) -> Result<Job, OrbitError> {
@@ -135,6 +144,10 @@ impl JobFileStore {
 
         if let Some(default_input) = default_input {
             job.default_input = default_input;
+        }
+        if let Some(max_active_runs) = max_active_runs {
+            validate_max_active_runs(max_active_runs)?;
+            job.max_active_runs = max_active_runs;
         }
         if let Some(steps) = steps {
             job.steps = steps;
@@ -210,17 +223,17 @@ impl JobFileStore {
         Ok(Some(self.read_run_at(&run_dir)?))
     }
 
-    pub(crate) fn get_pending_or_running_job_run(
+    pub(crate) fn list_pending_or_running_job_runs(
         &self,
         job_id: &str,
-    ) -> Result<Option<JobRun>, OrbitError> {
+    ) -> Result<Vec<JobRun>, OrbitError> {
         let mut runs = self
             .read_runs_for_activity(job_id)?
             .into_iter()
             .filter(|run| run.state == JobRunState::Pending || run.state == JobRunState::Running)
             .collect::<Vec<_>>();
         runs.sort_by(|a, b| b.created_at.cmp(&a.created_at));
-        Ok(runs.into_iter().next())
+        Ok(runs)
     }
 
     pub(crate) fn set_job_state(
@@ -263,6 +276,7 @@ impl JobFileStore {
                 job_id: job.job_id.clone(),
                 state: job.state,
                 default_input: job.default_input.clone(),
+                max_active_runs: job.max_active_runs,
                 steps: job.steps.clone(),
                 created_at: None,
                 updated_at: None,
@@ -494,6 +508,7 @@ impl JobFileStore {
             job_id: p.job_id,
             state: p.state,
             default_input: p.default_input,
+            max_active_runs: validate_max_active_runs(p.max_active_runs)?,
             steps: p.steps,
             created_at,
             updated_at,
@@ -546,6 +561,7 @@ impl JobFileStore {
                 job_id: job.job_id.clone(),
                 state: job.state,
                 default_input: job.default_input.clone(),
+                max_active_runs: job.max_active_runs,
                 steps: job.steps.clone(),
                 created_at: None,
                 updated_at: None,
@@ -694,6 +710,15 @@ impl JobFileStore {
     }
 }
 
+fn validate_max_active_runs(max_active_runs: u32) -> Result<u32, OrbitError> {
+    if max_active_runs == 0 {
+        return Err(OrbitError::JobValidation(
+            "job max_active_runs must be at least 1".to_string(),
+        ));
+    }
+    Ok(max_active_runs)
+}
+
 /// Derive a UTC timestamp from a job ID of the form `job-YYYYMMDD-HHMMSS[-N]`.
 /// Falls back to `Utc::now()` for IDs that don't embed a parseable timestamp.
 fn parse_timestamp_from_job_id(job_id: &str) -> DateTime<Utc> {
@@ -762,6 +787,7 @@ mod tests {
             .insert_activity_v2(
                 None,
                 None,
+                1,
                 vec![make_step(target_id)],
                 JobScheduleState::Enabled,
             )
@@ -921,6 +947,7 @@ mod tests {
             .insert_activity_v2(
                 Some("job-roundtrip-test".to_string()),
                 Some(json!({"base": "main"})),
+                3,
                 vec![step],
                 JobScheduleState::Disabled,
             )
@@ -957,6 +984,7 @@ mod tests {
         assert_eq!(read_back.job_id, written.job_id);
         assert_eq!(read_back.state, JobScheduleState::Disabled);
         assert_eq!(read_back.default_input, Some(json!({"base": "main"})));
+        assert_eq!(read_back.max_active_runs, 3);
         assert_eq!(read_back.steps.len(), 1);
         assert_eq!(read_back.steps[0].target_id, "target-roundtrip");
         assert_eq!(read_back.steps[0].agent_cli, "my-agent-cli");
@@ -964,6 +992,39 @@ mod tests {
         assert_eq!(read_back.steps[0].env_extra, vec!["MY_VAR", "OTHER_VAR"]);
         // Timestamps are no longer stored in YAML; they are derived at read time
         // (from the job_id for standard IDs, or Utc::now() as fallback).
+    }
+
+    #[test]
+    fn list_pending_or_running_job_runs_returns_all_active_runs() {
+        let (_dir, store) = make_store();
+        let job = insert_test_job(&store, "target-active-runs");
+        let now = Utc::now();
+
+        let first = store
+            .insert_job_run(&job.job_id, 1, now)
+            .expect("insert first run");
+        let second = store
+            .insert_job_run(&job.job_id, 2, now)
+            .expect("insert second run");
+        let completed = store
+            .insert_job_run(&job.job_id, 3, now)
+            .expect("insert completed run");
+        store
+            .finalize_job_run(&completed.run_id, JobRunState::Success, now, Some(1))
+            .expect("finalize completed run");
+
+        let active_runs = store
+            .list_pending_or_running_job_runs(&job.job_id)
+            .expect("list active runs");
+        let active_ids = active_runs
+            .iter()
+            .map(|run| run.run_id.as_str())
+            .collect::<Vec<_>>();
+
+        assert_eq!(active_runs.len(), 2);
+        assert!(active_ids.contains(&first.run_id.as_str()));
+        assert!(active_ids.contains(&second.run_id.as_str()));
+        assert!(!active_ids.contains(&completed.run_id.as_str()));
     }
 
     #[test]

--- a/orbit-types/src/job.rs
+++ b/orbit-types/src/job.rs
@@ -7,6 +7,10 @@ use serde_json::Value;
 
 use crate::OrbitId;
 
+pub const fn default_job_max_active_runs() -> u32 {
+    1
+}
+
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 #[cfg_attr(feature = "clap", derive(clap::ValueEnum))]
 #[serde(rename_all = "snake_case")]
@@ -147,6 +151,8 @@ pub struct Job {
     pub state: JobScheduleState,
     #[serde(default)]
     pub default_input: Option<Value>,
+    #[serde(default = "default_job_max_active_runs")]
+    pub max_active_runs: u32,
     pub steps: Vec<JobStep>,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,

--- a/orbit-types/src/lib.rs
+++ b/orbit-types/src/lib.rs
@@ -20,7 +20,7 @@ pub use event::OrbitEvent;
 pub use id::OrbitId;
 pub use job::{
     AgentCommitRequest, AgentResponseEnvelope, AgentRunError, Job, JobRun, JobRunState, JobRunStep,
-    JobScheduleState, JobStep, JobTargetType,
+    JobScheduleState, JobStep, JobTargetType, default_job_max_active_runs,
 };
 pub use memo::Memo;
 pub use redaction::{
@@ -105,6 +105,7 @@ mod tests {
             job_id: "job-1".to_string(),
             state: JobScheduleState::Enabled,
             default_input: Some(serde_json::json!({"base": "main"})),
+            max_active_runs: 2,
             steps: vec![JobStep {
                 target_type: JobTargetType::Activity,
                 target_id: "exec-1".to_string(),
@@ -118,6 +119,7 @@ mod tests {
         let job_value = serde_json::to_value(job).expect("serialize job");
         assert_eq!(job_value["state"], "enabled");
         assert_eq!(job_value["default_input"]["base"], "main");
+        assert_eq!(job_value["max_active_runs"], 2);
         assert_eq!(job_value["steps"][0]["target_type"], "activity");
 
         let run = JobRun {


### PR DESCRIPTION
## Changes
feat: Add configurable parallel job runs [T20260319-072253]

Implemented configurable per-job concurrency via `max_active_runs`, replaced the single-active-run guard with limit-based enforcement and multi-run stale recovery, surfaced the policy in job parsing/CLI output, opted `job_task_pipeline` into parallel execution, and added regression coverage plus a test-lock fix so the full workspace test suite passes reliably.

## Files Changed
- `orbit-cli/src/command/job.rs`
- `orbit-cli/tests/job_commands.rs`
- `orbit-core/assets/jobs/job_task_pipeline.yaml`
- `orbit-core/src/command/job.rs`
- `orbit-core/src/lib.rs`
- `orbit-core/src/runtime/engine.rs`
- `orbit-core/tests/asset_formatting.rs`
- `orbit-core/tests/job_runtime_behavior.rs`
- `orbit-engine/src/context.rs`
- `orbit-engine/src/job_runner.rs`
- `orbit-store/src/backend/contracts.rs`
- `orbit-store/src/backend/file_backends.rs`
- `orbit-store/src/file/job_store.rs`
- `orbit-types/src/job.rs`
- `orbit-types/src/lib.rs`