### PR TITLE
Fix clippy: move Display impl before test module in task.rs

### DIFF
--- a/orbit-types/src/task.rs
+++ b/orbit-types/src/task.rs
@@ -230,6 +230,16 @@ pub struct Task {
     pub updated_at: DateTime<Utc>,
 }
 
+impl Display for Task {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}\t{}\t{}\t{}",
+            self.id, self.status, self.priority, self.title
+        )
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -250,15 +260,5 @@ mod tests {
                 .validate_transition(TaskStatus::Backlog)
                 .is_ok()
         );
-    }
-}
-
-impl Display for Task {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "{}\t{}\t{}\t{}",
-            self.id, self.status, self.priority, self.title
-        )
     }
 }


### PR DESCRIPTION
## Changes
chore: Fix clippy: move Display impl before test module in task.rs [T20260318-053955]

Moved the `impl Display for Task` block above the `#[cfg(test)] mod tests` section in `orbit-types/src/task.rs` to satisfy Clippy's `items-after-test-module` lint without changing behavior. Verified the crate with `cargo clippy -p orbit-types --all-targets --all-features -- -D warnings` and `cargo test -p orbit-types`.

## Files Changed
- `orbit-types/src/task.rs`