### PR TITLE
Make task history audit trails more informative

### DIFF
--- a/orbit-cli/tests/activity_commands.rs
+++ b/orbit-cli/tests/activity_commands.rs
@@ -78,8 +78,7 @@ fn add_job(dir: &Path, target_id: &str, agent_cli: &str) -> String {
         .get_output()
         .stdout
         .clone();
-    serde_json::from_slice::<Value>(&output)
-        .expect("job json")["job_id"]
+    serde_json::from_slice::<Value>(&output).expect("job json")["job_id"]
         .as_str()
         .expect("job id")
         .to_string()
@@ -665,8 +664,22 @@ fn update_task_activity_job_run_updates_task_and_history() {
             .any(|comment| comment["message"] == "Ready for review")
     );
     let history = updated["history"].as_array().expect("history");
-    assert_eq!(history.last().expect("history entry")["event"], "moved");
-    assert_eq!(history.last().expect("history entry")["note"], "handoff ready");
+    assert_eq!(
+        history.last().expect("history entry")["event"],
+        "status_changed"
+    );
+    assert_eq!(
+        history.last().expect("history entry")["note"],
+        "handoff ready"
+    );
+    assert_eq!(
+        history.last().expect("history entry")["from_status"],
+        "in_progress"
+    );
+    assert_eq!(
+        history.last().expect("history entry")["to_status"],
+        "review"
+    );
 }
 
 #[test]

--- a/orbit-cli/tests/task_commands.rs
+++ b/orbit-cli/tests/task_commands.rs
@@ -735,6 +735,8 @@ fn task_start_backlog_moves_to_in_progress() {
         history.last().expect("latest")["note"],
         "picked up for implementation"
     );
+    assert_eq!(history.last().expect("latest")["from_status"], "backlog");
+    assert_eq!(history.last().expect("latest")["to_status"], "in_progress");
 }
 
 #[test]
@@ -769,10 +771,53 @@ fn task_start_proposed_records_approval_and_start() {
         history.iter().any(|entry| {
             entry["event"] == "proposal_approved"
                 && entry["note"] == "approved to begin immediately"
+                && entry["from_status"] == "proposed"
+                && entry["to_status"] == "backlog"
         }),
         "proposal approval must remain visible in history"
     );
     assert_eq!(history.last().expect("latest")["event"], "started");
+    assert_eq!(history.last().expect("latest")["from_status"], "proposed");
+    assert_eq!(history.last().expect("latest")["to_status"], "in_progress");
+}
+
+#[test]
+fn task_update_to_review_records_transition_details() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let id = add_task(dir.path(), "review transition");
+
+    orbit_in(dir.path())
+        .args(["task", "update", &id, "--status", "in-progress"])
+        .assert()
+        .success();
+    orbit_in(dir.path())
+        .args([
+            "task",
+            "update",
+            &id,
+            "--status",
+            "review",
+            "--execution-summary",
+            "Implemented and validated the change",
+        ])
+        .assert()
+        .success();
+
+    let show_output = orbit_in(dir.path())
+        .args(["task", "show", &id, "--json"])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let show: serde_json::Value = serde_json::from_slice(&show_output).expect("show json");
+    let history = show["history"].as_array().expect("history");
+    assert_eq!(history.last().expect("latest")["event"], "status_changed");
+    assert_eq!(
+        history.last().expect("latest")["from_status"],
+        "in_progress"
+    );
+    assert_eq!(history.last().expect("latest")["to_status"], "review");
 }
 
 #[test]
@@ -855,6 +900,8 @@ fn task_approve_proposed_to_backlog() {
         history.last().expect("latest")["note"],
         "approved verbally in sync"
     );
+    assert_eq!(history.last().expect("latest")["from_status"], "proposed");
+    assert_eq!(history.last().expect("latest")["to_status"], "backlog");
 }
 
 #[test]
@@ -958,6 +1005,56 @@ fn task_approve_comment_appends_with_approver_identity() {
     let show: serde_json::Value = serde_json::from_slice(&show_output).expect("show json");
     assert_eq!(show["comments"][0]["by"], "human");
     assert_eq!(show["comments"][0]["message"], "ready to schedule");
+}
+
+#[test]
+fn task_approve_review_to_done_records_transition_details() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    std::fs::create_dir_all(dir.path().join(".orbit")).expect("create .orbit");
+    std::fs::write(
+        dir.path().join(".orbit").join("config.toml"),
+        "[task.approval]\nrequired_for_agent = false\n",
+    )
+    .expect("write config");
+    let id = add_task(dir.path(), "review approval");
+
+    orbit_in(dir.path())
+        .args(["task", "update", &id, "--status", "in-progress"])
+        .assert()
+        .success();
+    orbit_in(dir.path())
+        .args([
+            "task",
+            "update",
+            &id,
+            "--status",
+            "review",
+            "--execution-summary",
+            "Ready for approval",
+        ])
+        .assert()
+        .success();
+
+    orbit_in(dir.path())
+        .args(["task", "approve", &id, "--note", "looks good"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Approved task"));
+
+    let show_output = orbit_in(dir.path())
+        .args(["task", "show", &id, "--json"])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let show: serde_json::Value = serde_json::from_slice(&show_output).expect("show json");
+    assert_eq!(show["status"], "done");
+    let history = show["history"].as_array().expect("history");
+    assert_eq!(history.last().expect("latest")["event"], "review_approved");
+    assert_eq!(history.last().expect("latest")["note"], "looks good");
+    assert_eq!(history.last().expect("latest")["from_status"], "review");
+    assert_eq!(history.last().expect("latest")["to_status"], "done");
 }
 
 #[test]
@@ -1091,6 +1188,8 @@ fn task_reject_review_to_rejected() {
         history.last().expect("latest")["note"],
         "Needs stronger coverage before merge"
     );
+    assert_eq!(history.last().expect("latest")["from_status"], "review");
+    assert_eq!(history.last().expect("latest")["to_status"], "rejected");
 }
 
 #[test]

--- a/orbit-core/src/command/task.rs
+++ b/orbit-core/src/command/task.rs
@@ -355,6 +355,8 @@ impl OrbitRuntime {
                                 by: actor.label.clone(),
                                 event: "proposal_approved".to_string(),
                                 note: note.clone(),
+                                from_status: Some(TaskStatus::Proposed),
+                                to_status: Some(TaskStatus::Backlog),
                             }],
                             append_comments: append_comments.clone(),
                             ..Default::default()

--- a/orbit-core/tests/job_runtime_behavior.rs
+++ b/orbit-core/tests/job_runtime_behavior.rs
@@ -2594,8 +2594,10 @@ fn update_task_automation_moves_task_to_review_with_summary_comment_and_note() {
         "Ready for review"
     );
     let history = updated.history.last().expect("history");
-    assert_eq!(history.event, "moved");
+    assert_eq!(history.event, "status_changed");
     assert_eq!(history.note.as_deref(), Some("handing off for review"));
+    assert_eq!(history.from_status, Some(TaskStatus::InProgress));
+    assert_eq!(history.to_status, Some(TaskStatus::Review));
 
     let history = runtime.job_history(&job_id).expect("job history");
     let output = history[0].steps[0]

--- a/orbit-store/src/file/task_store.rs
+++ b/orbit-store/src/file/task_store.rs
@@ -248,6 +248,8 @@ impl TaskFileStore {
                     by: params.actor,
                     event: "created".to_string(),
                     note: None,
+                    from_status: None,
+                    to_status: Some(params.status),
                 }],
                 comments: params.comments,
                 activity_id: None,
@@ -402,19 +404,15 @@ impl TaskFileStore {
             .status
             .map(TaskStateDir::from_status)
             .unwrap_or(current_state);
+        let status_transition = (target_state != current_state)
+            .then_some((current_state.to_status(), target_state.to_status()));
 
         let event = if let Some(event) = fields.status_event.clone() {
             Some(event)
         } else if target_state == current_state {
             None
-        } else if target_state == TaskStateDir::Done {
-            Some("completed".to_string())
-        } else if target_state == TaskStateDir::Archived {
-            Some("archived".to_string())
-        } else if target_state == TaskStateDir::Rejected {
-            Some("rejected".to_string())
         } else {
-            Some("moved".to_string())
+            Some("status_changed".to_string())
         };
 
         bundle.doc.updated_at = Utc::now();
@@ -424,6 +422,8 @@ impl TaskFileStore {
                 by: fields.actor.clone(),
                 event,
                 note: fields.status_note.clone(),
+                from_status: status_transition.map(|(from, _)| from),
+                to_status: status_transition.map(|(_, to)| to),
             });
         }
         if title_changed {
@@ -432,6 +432,8 @@ impl TaskFileStore {
                 by: fields.actor.clone(),
                 event: "renamed".to_string(),
                 note: None,
+                from_status: None,
+                to_status: None,
             });
         }
 
@@ -928,6 +930,9 @@ mod tests {
         assert!(in_progress_dir.exists());
         let yaml = fs::read_to_string(in_progress_dir.join(TASK_DOC_FILE_NAME)).expect("read yaml");
         assert!(yaml.contains("by: daniel"));
+        assert!(yaml.contains("event: status_changed"));
+        assert!(yaml.contains("from_status: backlog"));
+        assert!(yaml.contains("to_status: in_progress"));
         assert_eq!(
             fs::read_to_string(in_progress_dir.join(ARTIFACTS_DIR_NAME).join("report.md"))
                 .expect("artifact"),
@@ -1053,6 +1058,36 @@ mod tests {
             err.to_string()
                 .contains("unsupported task schema version: 9")
         );
+    }
+
+    #[test]
+    fn get_task_loads_legacy_history_entries_without_transition_fields() {
+        let dir = tempdir().expect("tempdir");
+        let store = TaskFileStore::new(dir.path().to_path_buf());
+
+        let task = store
+            .create_task(sample_insert(TaskStatus::Backlog))
+            .expect("create task");
+        let yaml_path = dir
+            .path()
+            .join("backlog")
+            .join(&task.id)
+            .join(TASK_DOC_FILE_NAME);
+        let yaml = fs::read_to_string(&yaml_path).expect("read yaml");
+        fs::write(
+            &yaml_path,
+            yaml.replace(
+                "event: created\n  note: null\n  to_status: backlog\n",
+                "event: moved\n  note: null\n",
+            ),
+        )
+        .expect("write yaml");
+
+        let loaded = store.get_task(&task.id).expect("load task").expect("task");
+        assert_eq!(loaded.history.len(), 1);
+        assert_eq!(loaded.history[0].event, "moved");
+        assert_eq!(loaded.history[0].from_status, None);
+        assert_eq!(loaded.history[0].to_status, None);
     }
 
     #[test]

--- a/orbit-types/src/task.rs
+++ b/orbit-types/src/task.rs
@@ -189,6 +189,10 @@ pub struct TaskHistoryEntry {
     pub event: String,
     #[serde(default)]
     pub note: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub from_status: Option<TaskStatus>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub to_status: Option<TaskStatus>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]


### PR DESCRIPTION
## Changes
refactor: Make task history audit trails more informative [T20260315-204447]

Task history entries now record explicit lifecycle transition details by adding optional `from_status` and `to_status` fields, replacing generic default `moved` events with `status_changed`, and extending lifecycle tests so proposed, review, rejection, and job-driven task updates all verify the richer audit trail while preserving compatibility with older history entries that lack the new fields.

## Files Changed
- `orbit-cli/tests/activity_commands.rs`
- `orbit-cli/tests/task_commands.rs`
- `orbit-core/src/command/task.rs`
- `orbit-core/tests/job_runtime_behavior.rs`
- `orbit-store/src/file/task_store.rs`
- `orbit-types/src/task.rs`