### PR TITLE
Add merge_pr automation activity with dual approval check

### DIFF
--- a/orbit-cli/tests/init_commands.rs
+++ b/orbit-cli/tests/init_commands.rs
@@ -88,6 +88,7 @@ fn assert_default_named_activities_visible(base_root: &std::path::Path) {
         "update_task",
         "dispatch_task",
         "implement_change",
+        "merge_pr",
         "open_pr",
         "oversee_orbit_operations",
         "perform_maintenance",
@@ -179,7 +180,7 @@ fn init_refreshes_full_bundled_activity_and_job_set() {
         .args(["init"])
         .assert()
         .success()
-        .stdout(predicate::str::contains("default_activities_refreshed=13"))
+        .stdout(predicate::str::contains("default_activities_refreshed=14"))
         .stdout(predicate::str::contains("default_jobs_refreshed=4"));
 
     let activities_dir = workspace
@@ -193,6 +194,7 @@ fn init_refreshes_full_bundled_activity_and_job_set() {
         "create_branch",
         "dispatch_task",
         "implement_change",
+        "merge_pr",
         "open_pr",
         "oversee_orbit_operations",
         "perform_maintenance",
@@ -292,7 +294,7 @@ fn explicit_init_refreshes_builtin_activities_and_jobs_but_implicit_bootstrap_do
         .args(["init"])
         .assert()
         .success()
-        .stdout(predicate::str::contains("default_activities_refreshed=13"))
+        .stdout(predicate::str::contains("default_activities_refreshed=14"))
         .stdout(predicate::str::contains("default_jobs_refreshed=4"));
 
     let refreshed_activity_raw = std::fs::read_to_string(&activity_path).expect("read activity");

--- a/orbit-core/assets/activities/merge_pr.yaml
+++ b/orbit-core/assets/activities/merge_pr.yaml
@@ -1,0 +1,54 @@
+schema_version: 1
+
+# ---- metadata ----
+created_by: system
+
+# ---- activity ----
+activity:
+  # ---- registration ----
+  id: merge_pr
+  spec_type: automation
+
+  # ---- content ----
+  description: Merge an approved Orbit pull request and advance the task to done
+
+  # ---- interface ----
+  input_schema_json:
+    type: object
+    required:
+      - task_id
+    properties:
+      task_id:
+        type: string
+        description: The Orbit task ID whose pull request should be merged
+      pr_number:
+        type: string
+        description: Pull request number, URL, or branch name. Optional when task_id is provided; falls back to the task pr_number.
+      review_decision:
+        type: string
+        description: Optional upstream review decision. When provided, APPROVED skips the extra gh pr view approval lookup.
+      repo_root:
+        type: string
+        description: Canonical repository root or task worktree used to resolve the current repository context. Optional when task_id is provided; falls back to input.workspace_path, task.repo_root, and then task.workspace_path.
+      strategy:
+        type: string
+        description: Merge strategy passed to github.pr.merge. Defaults to squash.
+  output_schema_json:
+    type: object
+    required:
+      - pr_number
+      - merged
+      - review_decision
+    properties:
+      pr_number:
+        type: string
+        description: Pull request number, URL, or branch name that was merged.
+      merged:
+        type: boolean
+        description: Whether the pull request merge completed successfully.
+      review_decision:
+        type: string
+        description: Review decision used to authorize the merge.
+
+  # ---- execution ----
+  action: merge_pr_from_task

--- a/orbit-core/assets/jobs/job_task_pipeline.yaml
+++ b/orbit-core/assets/jobs/job_task_pipeline.yaml
@@ -17,6 +17,7 @@ job:
   #   commit_changes   — let Orbit stage and commit repository changes in the task worktree
   #   open_pr          — let Orbit open a PR using task title + execution_summary
   #   review_pr        — review the opened PR against task acceptance criteria
+  #   merge_pr         — merge approved PRs and advance tasks to done
   max_active_runs: 4
   default_input:
     base: agent-main
@@ -59,3 +60,7 @@ job:
       target_id: review_pr
       agent_cli: claude
       timeout_seconds: 600
+
+    - target_type: activity
+      target_id: merge_pr
+      timeout_seconds: 60

--- a/orbit-core/src/command/activity.rs
+++ b/orbit-core/src/command/activity.rs
@@ -40,6 +40,10 @@ pub(crate) const DEFAULT_ACTIVITY_FILES: &[(&str, &str)] = &[
         include_str!("../../assets/activities/implement_change.yaml"),
     ),
     (
+        "merge_pr",
+        include_str!("../../assets/activities/merge_pr.yaml"),
+    ),
+    (
         "open_pr",
         include_str!("../../assets/activities/open_pr.yaml"),
     ),
@@ -559,6 +563,7 @@ activity:
                 "update_task",
                 "dispatch_task",
                 "implement_change",
+                "merge_pr",
                 "open_pr",
                 "review_tasks",
                 "oversee_orbit_operations",

--- a/orbit-core/tests/asset_formatting.rs
+++ b/orbit-core/tests/asset_formatting.rs
@@ -39,6 +39,10 @@ fn activity_assets_use_grouped_sections_and_literal_instruction_blocks() {
             "implement_change",
             include_str!("../assets/activities/implement_change.yaml"),
         ),
+        (
+            "merge_pr",
+            include_str!("../assets/activities/merge_pr.yaml"),
+        ),
         ("open_pr", include_str!("../assets/activities/open_pr.yaml")),
         (
             "oversee_orbit_operations",

--- a/orbit-core/tests/job_runtime_behavior.rs
+++ b/orbit-core/tests/job_runtime_behavior.rs
@@ -3847,6 +3847,287 @@ fn open_pr_automation_supports_task_id_only_inputs() {
 }
 
 #[test]
+fn merge_pr_automation_uses_input_review_decision_without_extra_gh_lookup() {
+    let _guard = env_lock().lock().unwrap_or_else(|err| err.into_inner());
+    let _snapshot = EnvSnapshot::capture(&["PATH"]);
+    let dir = tempdir().expect("tempdir");
+    let data_root = dir.path().join("orbit");
+    std::fs::create_dir_all(&data_root).expect("create data root");
+    let repo_root = dir.path().join("repo");
+    std::fs::create_dir_all(&repo_root).expect("create repo root");
+    init_git_repo(&repo_root);
+    std::fs::write(repo_root.join("README.md"), "seed\n").expect("write seed file");
+    git_commit_all(&repo_root, "chore: seed repo");
+
+    let gh_dir = dir.path().join("bin");
+    std::fs::create_dir_all(&gh_dir).expect("create gh dir");
+    let merge_capture = dir.path().join("gh-merge.txt");
+    let gh_script = gh_dir.join("gh");
+    let gh_body = format!(
+        concat!(
+            "#!/bin/sh\n",
+            "if [ \"$1\" = \"pr\" ] && [ \"$2\" = \"view\" ]; then\n",
+            "  echo 'unexpected gh pr view call' >&2\n",
+            "  exit 1\n",
+            "fi\n",
+            "if [ \"$1\" = \"pr\" ] && [ \"$2\" = \"merge\" ]; then\n",
+            "  printf '%s' \"$3\" > \"{merge_capture}\"\n",
+            "  exit 0\n",
+            "fi\n",
+            "exit 1\n",
+        ),
+        merge_capture = merge_capture.display(),
+    );
+    std::fs::write(&gh_script, gh_body).expect("write gh script");
+    #[cfg(unix)]
+    std::fs::set_permissions(&gh_script, std::fs::Permissions::from_mode(0o755)).expect("chmod gh");
+
+    unsafe {
+        std::env::set_var("PATH", prepend_path(&gh_dir));
+    }
+
+    let runtime = OrbitRuntime::from_data_root(&data_root).expect("runtime");
+    let task_id = runtime
+        .add_task(TaskAddParams {
+            title: "Merge task PR".to_string(),
+            description: "desc".to_string(),
+            plan: "plan".to_string(),
+            comment: None,
+            context_files: vec![],
+            workspace_path: Some(repo_root.to_string_lossy().to_string()),
+            priority: TaskPriority::High,
+            task_type: TaskType::Task,
+        })
+        .expect("add task")
+        .id;
+    runtime
+        .start_task(&task_id, None, None)
+        .expect("start task");
+    runtime
+        .update_task(
+            &task_id,
+            TaskUpdateParams {
+                title: None,
+                description: None,
+                plan: None,
+                execution_summary: Some("Ready to merge".to_string()),
+                comment: None,
+                status: Some(TaskStatus::Review),
+                branch: Some(Some(format!("orbit/{task_id}"))),
+                pr_number: Some(Some("42".to_string())),
+            },
+        )
+        .expect("prepare task");
+
+    runtime
+        .add_activity(ActivityAddParams {
+            id: "spec-merge-pr-from-input".to_string(),
+            spec_type: "automation".to_string(),
+            description: "merge pr using provided approval".to_string(),
+            input_schema_json: json!({
+                "type": "object",
+                "properties": {
+                    "task_id": { "type": "string" },
+                    "review_decision": { "type": "string" }
+                },
+                "required": ["task_id", "review_decision"]
+            }),
+            output_schema_json: json!({
+                "type": "object",
+                "properties": {
+                    "pr_number": { "type": "string" },
+                    "merged": { "type": "boolean" },
+                    "review_decision": { "type": "string" }
+                },
+                "required": ["pr_number", "merged", "review_decision"]
+            }),
+            spec_config: json!({"action":"merge_pr_from_task"}),
+            workspace_path: None,
+            created_by: None,
+        })
+        .expect("add merge activity");
+
+    let job_id = runtime
+        .add_job(JobAddParams {
+            job_id: None,
+            default_input: Some(json!({
+                "task_id": task_id,
+                "review_decision": "APPROVED",
+            })),
+            max_active_runs: None,
+            steps: vec![JobStep {
+                target_type: JobTargetType::Activity,
+                target_id: "spec-merge-pr-from-input".to_string(),
+                agent_cli: String::new(),
+                timeout_seconds: 30,
+                env_extra: vec![],
+            }],
+            initial_state_override: None,
+        })
+        .expect("add merge job")
+        .job_id;
+
+    let run = runtime.run_job_now(&job_id).expect("run merge job");
+    assert_eq!(run.state, JobRunState::Success);
+
+    let history = runtime.job_history(&job_id).expect("history");
+    let output = history[0].steps[0]
+        .agent_response_json
+        .as_ref()
+        .expect("merge output");
+    assert_eq!(output["pr_number"], json!("42"));
+    assert_eq!(output["merged"], json!(true));
+    assert_eq!(output["review_decision"], json!("APPROVED"));
+    assert_eq!(std::fs::read_to_string(merge_capture).expect("merge"), "42");
+
+    let updated_task = runtime.get_task(&task_id).expect("updated task");
+    assert_eq!(updated_task.status, TaskStatus::Done);
+}
+
+#[test]
+fn merge_pr_automation_fetches_review_decision_from_gh_when_not_provided() {
+    let _guard = env_lock().lock().unwrap_or_else(|err| err.into_inner());
+    let _snapshot = EnvSnapshot::capture(&["PATH"]);
+    let dir = tempdir().expect("tempdir");
+    let data_root = dir.path().join("orbit");
+    std::fs::create_dir_all(&data_root).expect("create data root");
+    let repo_root = dir.path().join("repo");
+    std::fs::create_dir_all(&repo_root).expect("create repo root");
+    init_git_repo(&repo_root);
+    std::fs::write(repo_root.join("README.md"), "seed\n").expect("write seed file");
+    git_commit_all(&repo_root, "chore: seed repo");
+
+    let gh_dir = dir.path().join("bin");
+    std::fs::create_dir_all(&gh_dir).expect("create gh dir");
+    let view_capture = dir.path().join("gh-view-count.txt");
+    let merge_capture = dir.path().join("gh-merge-count.txt");
+    std::fs::write(&view_capture, "0").expect("seed view count");
+    std::fs::write(&merge_capture, "0").expect("seed merge count");
+    let gh_script = gh_dir.join("gh");
+    let gh_body = format!(
+        concat!(
+            "#!/bin/sh\n",
+            "if [ \"$1\" = \"pr\" ] && [ \"$2\" = \"view\" ]; then\n",
+            "  count=$(cat \"{view_capture}\")\n",
+            "  count=$((count + 1))\n",
+            "  printf '%s' \"$count\" > \"{view_capture}\"\n",
+            "  printf '{{\"reviewDecision\":\"APPROVED\"}}'\n",
+            "  exit 0\n",
+            "fi\n",
+            "if [ \"$1\" = \"pr\" ] && [ \"$2\" = \"merge\" ]; then\n",
+            "  count=$(cat \"{merge_capture}\")\n",
+            "  count=$((count + 1))\n",
+            "  printf '%s' \"$count\" > \"{merge_capture}\"\n",
+            "  exit 0\n",
+            "fi\n",
+            "exit 1\n",
+        ),
+        view_capture = view_capture.display(),
+        merge_capture = merge_capture.display(),
+    );
+    std::fs::write(&gh_script, gh_body).expect("write gh script");
+    #[cfg(unix)]
+    std::fs::set_permissions(&gh_script, std::fs::Permissions::from_mode(0o755)).expect("chmod gh");
+
+    unsafe {
+        std::env::set_var("PATH", prepend_path(&gh_dir));
+    }
+
+    let runtime = OrbitRuntime::from_data_root(&data_root).expect("runtime");
+    let task_id = runtime
+        .add_task(TaskAddParams {
+            title: "Merge task PR after gh lookup".to_string(),
+            description: "desc".to_string(),
+            plan: "plan".to_string(),
+            comment: None,
+            context_files: vec![],
+            workspace_path: Some(repo_root.to_string_lossy().to_string()),
+            priority: TaskPriority::High,
+            task_type: TaskType::Task,
+        })
+        .expect("add task")
+        .id;
+    runtime
+        .start_task(&task_id, None, None)
+        .expect("start task");
+    runtime
+        .update_task(
+            &task_id,
+            TaskUpdateParams {
+                title: None,
+                description: None,
+                plan: None,
+                execution_summary: Some("Ready to merge".to_string()),
+                comment: None,
+                status: Some(TaskStatus::Review),
+                branch: Some(Some(format!("orbit/{task_id}"))),
+                pr_number: Some(Some("24".to_string())),
+            },
+        )
+        .expect("prepare task");
+
+    runtime
+        .add_activity(ActivityAddParams {
+            id: "spec-merge-pr-from-gh".to_string(),
+            spec_type: "automation".to_string(),
+            description: "merge pr using gh lookup".to_string(),
+            input_schema_json: json!({
+                "type": "object",
+                "properties": {
+                    "task_id": { "type": "string" }
+                },
+                "required": ["task_id"]
+            }),
+            output_schema_json: json!({
+                "type": "object",
+                "properties": {
+                    "pr_number": { "type": "string" },
+                    "merged": { "type": "boolean" },
+                    "review_decision": { "type": "string" }
+                },
+                "required": ["pr_number", "merged", "review_decision"]
+            }),
+            spec_config: json!({"action":"merge_pr_from_task"}),
+            workspace_path: None,
+            created_by: None,
+        })
+        .expect("add merge activity");
+
+    let job_id = runtime
+        .add_job(JobAddParams {
+            job_id: None,
+            default_input: Some(json!({
+                "task_id": task_id,
+            })),
+            max_active_runs: None,
+            steps: vec![JobStep {
+                target_type: JobTargetType::Activity,
+                target_id: "spec-merge-pr-from-gh".to_string(),
+                agent_cli: String::new(),
+                timeout_seconds: 30,
+                env_extra: vec![],
+            }],
+            initial_state_override: None,
+        })
+        .expect("add merge job")
+        .job_id;
+
+    let run = runtime.run_job_now(&job_id).expect("run merge job");
+    assert_eq!(run.state, JobRunState::Success);
+    assert_eq!(
+        std::fs::read_to_string(view_capture).expect("view count"),
+        "1"
+    );
+    assert_eq!(
+        std::fs::read_to_string(merge_capture).expect("merge count"),
+        "1"
+    );
+
+    let updated_task = runtime.get_task(&task_id).expect("updated task");
+    assert_eq!(updated_task.status, TaskStatus::Done);
+}
+
+#[test]
 fn multi_step_same_agent_cli_each_step_gets_its_own_env_extra() {
     // Regression: env_extra was looked up by matching agent_cli (first match), so step 2
     // sharing the same agent_cli as step 1 would receive step 1's allowlist.

--- a/orbit-engine/src/executor/automation.rs
+++ b/orbit-engine/src/executor/automation.rs
@@ -12,6 +12,7 @@ const AUTOMATION_CREATE_TASK_WORKTREE: &str = "create_task_worktree";
 const AUTOMATION_START_TASK: &str = "start_task";
 const AUTOMATION_UPDATE_TASK: &str = "update_task";
 const AUTOMATION_COMMIT_TASK_CHANGES: &str = "commit_task_changes";
+const AUTOMATION_MERGE_PR_FROM_TASK: &str = "merge_pr_from_task";
 const AUTOMATION_OPEN_PR_FROM_TASK: &str = "open_pr_from_task";
 const AUTOMATION_FINALIZE_TASK_WORKTREE: &str = "finalize_task_worktree";
 
@@ -35,6 +36,7 @@ pub fn execute<H: EngineHost>(
         AUTOMATION_START_TASK => start_task(host, input),
         AUTOMATION_UPDATE_TASK => update_task(host, input),
         AUTOMATION_COMMIT_TASK_CHANGES => commit_task_changes(host, input),
+        AUTOMATION_MERGE_PR_FROM_TASK => merge_pr_from_task(host, input),
         AUTOMATION_OPEN_PR_FROM_TASK => open_pr_from_task(host, input),
         AUTOMATION_FINALIZE_TASK_WORKTREE => finalize_task_worktree(input),
         other => Err(OrbitError::InvalidInput(format!(
@@ -210,6 +212,79 @@ fn commit_task_changes<H: EngineHost>(host: &H, input: &Value) -> Result<Value, 
         "commit_message": message,
         "commit_sha": commit_sha,
         "changed_files": changed_files,
+    }))
+}
+
+fn merge_pr_from_task<H: EngineHost>(host: &H, input: &Value) -> Result<Value, OrbitError> {
+    let task_id = required_input_string(input, "task_id")?;
+    let task = host.get_task(task_id)?;
+    let repo_root = canonicalize_existing_dir(
+        &input_string_field(input, "repo_root")
+            .or_else(|| input_workspace_path(input))
+            .or_else(|| task.repo_root.clone())
+            .or_else(|| task.workspace_path.clone())
+            .ok_or_else(|| {
+                OrbitError::InvalidInput(
+                    "merge_pr_from_task requires input.repo_root, input.workspace_path, task.repo_root, or task.workspace_path"
+                        .to_string(),
+                )
+            })?,
+        "repo_root",
+    )?;
+    let pr_number = input_string_field(input, "pr_number")
+        .or_else(|| task.pr_number.clone())
+        .ok_or_else(|| {
+            OrbitError::InvalidInput(
+                "merge_pr_from_task requires input.pr_number or task.pr_number".to_string(),
+            )
+        })?;
+    let review_decision = resolve_review_decision(input, &repo_root, &pr_number)?;
+    if review_decision != "APPROVED" {
+        return Err(OrbitError::Execution(format!(
+            "pull request '{pr_number}' is not approved (review_decision={review_decision})"
+        )));
+    }
+
+    if !matches!(task.status, TaskStatus::Review | TaskStatus::Done) {
+        return Err(OrbitError::Execution(format!(
+            "task '{}' must be in review before merge_pr_from_task; current status is {}",
+            task.id, task.status
+        )));
+    }
+
+    let tool_context = ToolContext {
+        cwd: Some(repo_root.to_string_lossy().to_string()),
+        allowed_tools: vec![],
+        ..Default::default()
+    };
+    let strategy = input_string_field(input, "strategy").unwrap_or_else(|| "squash".to_string());
+    host.run_tool_with_context_and_role(
+        "github.pr.merge",
+        json!({
+            "pr": pr_number.clone(),
+            "strategy": strategy,
+        }),
+        Role::Admin,
+        tool_context,
+    )?;
+
+    host.apply_task_automation_update(
+        task_id,
+        TaskAutomationUpdate {
+            status: if task.status == TaskStatus::Review {
+                Some(TaskStatus::Done)
+            } else {
+                None
+            },
+            pr_number: Some(pr_number.clone()),
+            ..TaskAutomationUpdate::default()
+        },
+    )?;
+
+    Ok(json!({
+        "pr_number": pr_number,
+        "merged": true,
+        "review_decision": review_decision,
     }))
 }
 
@@ -411,6 +486,74 @@ fn input_repo_root(input: &Value) -> Result<String, OrbitError> {
     input_string_field(input, "repo_root")
         .or_else(|| input_workspace_path(input))
         .ok_or_else(|| OrbitError::InvalidInput("missing required input.repo_root".to_string()))
+}
+
+fn resolve_review_decision(
+    input: &Value,
+    repo_root: &Path,
+    pr_number: &str,
+) -> Result<String, OrbitError> {
+    if let Some(decision) =
+        input_string_field(input, "review_decision").or_else(|| input_string_field(input, "action"))
+    {
+        return Ok(normalize_review_decision(&decision));
+    }
+
+    fetch_review_decision_from_gh(repo_root, pr_number)
+}
+
+fn normalize_review_decision(value: &str) -> String {
+    match value.trim().to_ascii_uppercase().as_str() {
+        "APPROVED" | "APPROVE" => "APPROVED".to_string(),
+        "REQUEST-CHANGES" | "REQUEST_CHANGES" | "CHANGES_REQUESTED" => {
+            "CHANGES_REQUESTED".to_string()
+        }
+        "COMMENT" | "COMMENTED" => "COMMENTED".to_string(),
+        other => other.to_string(),
+    }
+}
+
+fn fetch_review_decision_from_gh(repo_root: &Path, pr_number: &str) -> Result<String, OrbitError> {
+    let result = run_process(
+        &ExecRequest {
+            program: "gh".to_string(),
+            args: vec![
+                "pr".to_string(),
+                "view".to_string(),
+                pr_number.to_string(),
+                "--json".to_string(),
+                "reviewDecision".to_string(),
+            ],
+            current_dir: Some(repo_root.to_string_lossy().to_string()),
+            timeout_ms: Some(15_000),
+            stdin_mode: StdinMode::Null,
+            environment_mode: EnvironmentMode::Inherit,
+        },
+        &NoSandbox,
+    )?;
+
+    if !result.success {
+        return Err(OrbitError::Execution(format!(
+            "gh pr view failed while fetching reviewDecision for '{pr_number}': {}",
+            result.stderr.trim()
+        )));
+    }
+
+    let payload: Value = serde_json::from_str(&result.stdout).map_err(|error| {
+        OrbitError::Execution(format!(
+            "failed to parse gh pr view reviewDecision output for '{pr_number}': {error}"
+        ))
+    })?;
+    payload
+        .get("reviewDecision")
+        .and_then(Value::as_str)
+        .map(normalize_review_decision)
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| {
+            OrbitError::Execution(format!(
+                "gh pr view did not return reviewDecision for '{pr_number}'"
+            ))
+        })
 }
 
 fn canonicalize_existing_dir(raw: &str, field_name: &str) -> Result<PathBuf, OrbitError> {


### PR DESCRIPTION
## Changes
feat: Add merge_pr automation activity with dual approval check [T20260319-072546]

Implemented a new `merge_pr` automation activity that merges approved Orbit pull requests, prefers an upstream approval signal when available, falls back to `gh pr view --json reviewDecision` when needed, and advances the task to `done` after a successful merge. The activity is now bundled by default, added to `job_task_pipeline` after `review_pr`, and covered by runtime, asset, init, and full-workspace verification.

## Files Changed
- `orbit-cli/tests/init_commands.rs`
- `orbit-core/assets/activities/merge_pr.yaml`
- `orbit-core/assets/jobs/job_task_pipeline.yaml`
- `orbit-core/src/command/activity.rs`
- `orbit-core/tests/asset_formatting.rs`
- `orbit-core/tests/job_runtime_behavior.rs`
- `orbit-engine/src/executor/automation.rs`