### PR TITLE
Replace string-dispatch on activity spec_type with executor registry (OCP)

### DIFF
--- a/orbit-engine/src/activity_runner.rs
+++ b/orbit-engine/src/activity_runner.rs
@@ -5,7 +5,7 @@ use crate::context::{
     ACTIVITY_EXECUTION_FAILED, AttemptOutcome, DirectActivityRunOutcome, EngineHost,
     ExecutionContext, input_workspace_path, redact_attempt_outcome,
 };
-use crate::executor::{agent, api, automation, cli_command};
+use crate::executor::builtin_activity_executor_registry;
 use crate::json_schema::validate_instance_against_schema;
 use crate::template::TemplateContext;
 
@@ -57,148 +57,27 @@ pub fn execute_single_attempt<H: EngineHost>(
     host: &H,
     execution: &ExecutionContext,
 ) -> AttemptOutcome {
-    let outcome = match execution.activity.spec_type.as_str() {
-        "agent_invoke" => agent::execute(host, execution),
-        "cli_command" => execute_cli_command_attempt(host, execution),
-        "api" => execute_api_attempt(execution),
-        "automation" => execute_automation_attempt(host, execution),
-        other => AttemptOutcome {
-            state: JobRunState::Failed,
-            exit_code: Some(1),
-            duration_ms: None,
-            response_json: None,
-            error_code: Some(ACTIVITY_EXECUTION_FAILED.to_string()),
-            error_message: Some(format!("unsupported activity spec_type '{other}'")),
-            protocol_violation: false,
-        },
-    };
+    let registry = builtin_activity_executor_registry();
+    let spec_type = execution.activity.spec_type.as_str();
+    let supported_spec_types = registry.supported_spec_types().join(", ");
+    let outcome = registry
+        .get(spec_type)
+        .map(|executor| executor.execute(host, execution))
+        .unwrap_or_else(|| unsupported_spec_type_outcome(spec_type, &supported_spec_types));
     redact_attempt_outcome(outcome)
 }
 
-fn execute_cli_command_attempt<H: EngineHost>(
-    host: &H,
-    execution: &ExecutionContext,
-) -> AttemptOutcome {
-    let template_context = execution_template_context_with_env(
-        execution,
-        host.cli_command_environment(&execution.env_extra),
-    );
-    match cli_command::execute(
-        &execution.activity.spec_config,
-        &template_context,
-        execution.timeout_seconds,
-    ) {
-        Ok((result, duration_ms, exit_code)) => {
-            if let Err(err) = validate_activity_output_schema(&execution.activity, &result) {
-                return AttemptOutcome {
-                    state: JobRunState::Failed,
-                    exit_code,
-                    duration_ms: Some(duration_ms),
-                    response_json: Some(result),
-                    error_code: Some(ACTIVITY_EXECUTION_FAILED.to_string()),
-                    error_message: Some(err.to_string()),
-                    protocol_violation: false,
-                };
-            }
-            AttemptOutcome {
-                state: JobRunState::Success,
-                exit_code,
-                duration_ms: Some(duration_ms),
-                response_json: Some(result),
-                error_code: None,
-                error_message: None,
-                protocol_violation: false,
-            }
-        }
-        Err(err) => AttemptOutcome {
-            state: JobRunState::Failed,
-            exit_code: Some(1),
-            duration_ms: None,
-            response_json: None,
-            error_code: Some(ACTIVITY_EXECUTION_FAILED.to_string()),
-            error_message: Some(err.to_string()),
-            protocol_violation: false,
-        },
-    }
-}
-
-fn execute_api_attempt(execution: &ExecutionContext) -> AttemptOutcome {
-    let template_context = execution_template_context(execution);
-    match api::execute(
-        &execution.activity.spec_config,
-        &template_context,
-        execution.timeout_seconds,
-    ) {
-        Ok(result) => {
-            if let Err(err) = validate_activity_output_schema(&execution.activity, &result) {
-                return AttemptOutcome {
-                    state: JobRunState::Failed,
-                    exit_code: Some(0),
-                    duration_ms: None,
-                    response_json: Some(result),
-                    error_code: Some(ACTIVITY_EXECUTION_FAILED.to_string()),
-                    error_message: Some(err.to_string()),
-                    protocol_violation: false,
-                };
-            }
-            AttemptOutcome {
-                state: JobRunState::Success,
-                exit_code: Some(0),
-                duration_ms: None,
-                response_json: Some(result),
-                error_code: None,
-                error_message: None,
-                protocol_violation: false,
-            }
-        }
-        Err(err) => AttemptOutcome {
-            state: JobRunState::Failed,
-            exit_code: Some(1),
-            duration_ms: None,
-            response_json: None,
-            error_code: Some(ACTIVITY_EXECUTION_FAILED.to_string()),
-            error_message: Some(err.to_string()),
-            protocol_violation: false,
-        },
-    }
-}
-
-fn execute_automation_attempt<H: EngineHost>(
-    host: &H,
-    execution: &ExecutionContext,
-) -> AttemptOutcome {
-    match automation::execute(host, &execution.activity, &execution.input) {
-        Ok(result) => {
-            if let Err(err) = validate_activity_output_schema(&execution.activity, &result) {
-                return AttemptOutcome {
-                    state: JobRunState::Failed,
-                    exit_code: Some(0),
-                    duration_ms: None,
-                    response_json: Some(result),
-                    error_code: Some(ACTIVITY_EXECUTION_FAILED.to_string()),
-                    error_message: Some(err.to_string()),
-                    protocol_violation: false,
-                };
-            }
-            AttemptOutcome {
-                state: JobRunState::Success,
-                exit_code: Some(0),
-                duration_ms: None,
-                response_json: Some(result),
-                error_code: None,
-                error_message: None,
-                protocol_violation: false,
-            }
-        }
-        Err(err) => AttemptOutcome {
-            state: JobRunState::Failed,
-            exit_code: Some(1),
-            duration_ms: None,
-            response_json: None,
-            error_code: Some(ACTIVITY_EXECUTION_FAILED.to_string()),
-            error_message: Some(err.to_string()),
-            protocol_violation: false,
-        },
+fn unsupported_spec_type_outcome(spec_type: &str, supported_spec_types: &str) -> AttemptOutcome {
+    AttemptOutcome {
+        state: JobRunState::Failed,
+        exit_code: Some(1),
+        duration_ms: None,
+        response_json: None,
+        error_code: Some(ACTIVITY_EXECUTION_FAILED.to_string()),
+        error_message: Some(format!(
+            "unsupported activity spec_type '{spec_type}' (supported: {supported_spec_types})"
+        )),
+        protocol_violation: false,
     }
 }
 
@@ -206,7 +85,7 @@ pub fn execution_template_context(execution: &ExecutionContext) -> TemplateConte
     execution_template_context_with_env(execution, std::env::vars().collect())
 }
 
-fn execution_template_context_with_env(
+pub(crate) fn execution_template_context_with_env(
     execution: &ExecutionContext,
     env_pairs: Vec<(String, String)>,
 ) -> TemplateContext {

--- a/orbit-engine/src/executor/agent.rs
+++ b/orbit-engine/src/executor/agent.rs
@@ -5,12 +5,25 @@ use orbit_exec::{EnvironmentMode, ExecRequest, NoSandbox, StdinMode, run_process
 use orbit_types::{AgentResponseEnvelope, JobRunState, OrbitError};
 use tempfile::NamedTempFile;
 
+use super::ActivityExecutor;
 use crate::context::{
     AGENT_COMMIT_FAILED, AGENT_INVOCATION_FAILED, AGENT_PROTOCOL_VIOLATION, AGENT_TIMEOUT,
     AttemptOutcome, EngineHost, ExecutionContext, execution_working_directory,
 };
 
-pub fn execute<H: EngineHost>(host: &H, execution: &ExecutionContext) -> AttemptOutcome {
+pub struct AgentExecutor;
+
+impl ActivityExecutor for AgentExecutor {
+    fn spec_type(&self) -> &str {
+        "agent_invoke"
+    }
+
+    fn execute(&self, host: &dyn EngineHost, execution: &ExecutionContext) -> AttemptOutcome {
+        execute(host, execution)
+    }
+}
+
+pub fn execute<H: EngineHost + ?Sized>(host: &H, execution: &ExecutionContext) -> AttemptOutcome {
     let invocation = match build_agent_invocation(host, execution) {
         Ok(invocation) => invocation,
         Err(outcome) => return outcome,
@@ -57,7 +70,7 @@ pub fn execute<H: EngineHost>(host: &H, execution: &ExecutionContext) -> Attempt
     }
 }
 
-fn build_agent_invocation<H: EngineHost>(
+fn build_agent_invocation<H: EngineHost + ?Sized>(
     host: &H,
     execution: &ExecutionContext,
 ) -> Result<orbit_agent::AgentResponse, AttemptOutcome> {
@@ -101,7 +114,7 @@ configure .orbit/config.toml [execution.env].pass and set these variables in the
     Ok(invocation)
 }
 
-fn execute_agent_process<H: EngineHost>(
+fn execute_agent_process<H: EngineHost + ?Sized>(
     host: &H,
     execution: &ExecutionContext,
     invocation: orbit_agent::AgentResponse,
@@ -146,7 +159,7 @@ fn inject_activity_tools(mode: EnvironmentMode, tools: &[String]) -> Environment
     }
 }
 
-fn process_agent_response<H: EngineHost>(
+fn process_agent_response<H: EngineHost + ?Sized>(
     host: &H,
     execution: &ExecutionContext,
     exec_result: &orbit_types::ExecutionResult,
@@ -178,7 +191,7 @@ fn process_agent_response<H: EngineHost>(
     }
 }
 
-fn validate_agent_success<H: EngineHost>(
+fn validate_agent_success<H: EngineHost + ?Sized>(
     host: &H,
     execution: &ExecutionContext,
     exec_result: &orbit_types::ExecutionResult,

--- a/orbit-engine/src/executor/api.rs
+++ b/orbit-engine/src/executor/api.rs
@@ -1,12 +1,16 @@
 use std::collections::HashMap;
 use std::time::Duration;
 
+use orbit_types::JobRunState;
 use orbit_types::OrbitError;
 use reqwest::Method;
 use reqwest::blocking::Client;
 use serde::Deserialize;
 use serde_json::{Value, json};
 
+use super::ActivityExecutor;
+use crate::activity_runner::{execution_template_context, validate_activity_output_schema};
+use crate::context::{ACTIVITY_EXECUTION_FAILED, AttemptOutcome, EngineHost, ExecutionContext};
 use crate::template::{TemplateContext, render};
 
 #[derive(Debug, Clone, Deserialize)]
@@ -23,6 +27,55 @@ pub struct ApiSpec {
 
 fn default_status_codes() -> Vec<u16> {
     vec![200]
+}
+
+pub struct ApiExecutor;
+
+impl ActivityExecutor for ApiExecutor {
+    fn spec_type(&self) -> &str {
+        "api"
+    }
+
+    fn execute(&self, _host: &dyn EngineHost, execution: &ExecutionContext) -> AttemptOutcome {
+        let template_context = execution_template_context(execution);
+        match execute(
+            &execution.activity.spec_config,
+            &template_context,
+            execution.timeout_seconds,
+        ) {
+            Ok(result) => {
+                if let Err(err) = validate_activity_output_schema(&execution.activity, &result) {
+                    return AttemptOutcome {
+                        state: JobRunState::Failed,
+                        exit_code: Some(0),
+                        duration_ms: None,
+                        response_json: Some(result),
+                        error_code: Some(ACTIVITY_EXECUTION_FAILED.to_string()),
+                        error_message: Some(err.to_string()),
+                        protocol_violation: false,
+                    };
+                }
+                AttemptOutcome {
+                    state: JobRunState::Success,
+                    exit_code: Some(0),
+                    duration_ms: None,
+                    response_json: Some(result),
+                    error_code: None,
+                    error_message: None,
+                    protocol_violation: false,
+                }
+            }
+            Err(err) => AttemptOutcome {
+                state: JobRunState::Failed,
+                exit_code: Some(1),
+                duration_ms: None,
+                response_json: None,
+                error_code: Some(ACTIVITY_EXECUTION_FAILED.to_string()),
+                error_message: Some(err.to_string()),
+                protocol_violation: false,
+            },
+        }
+    }
 }
 
 pub fn execute(

--- a/orbit-engine/src/executor/automation.rs
+++ b/orbit-engine/src/executor/automation.rs
@@ -2,11 +2,15 @@ use std::path::{Path, PathBuf};
 
 use orbit_exec::{EnvironmentMode, ExecRequest, NoSandbox, StdinMode, run_process};
 use orbit_tools::ToolContext;
-use orbit_types::{Activity, OrbitError, Role, TaskStatus, TaskType};
+use orbit_types::{Activity, JobRunState, OrbitError, Role, TaskStatus, TaskType};
 use serde::Deserialize;
 use serde_json::{Value, json};
 
-use crate::context::{EngineHost, TaskAutomationUpdate};
+use super::ActivityExecutor;
+use crate::activity_runner::validate_activity_output_schema;
+use crate::context::{
+    ACTIVITY_EXECUTION_FAILED, AttemptOutcome, EngineHost, ExecutionContext, TaskAutomationUpdate,
+};
 
 const AUTOMATION_CREATE_TASK_WORKTREE: &str = "create_task_worktree";
 const AUTOMATION_START_TASK: &str = "start_task";
@@ -29,7 +33,51 @@ struct BranchFreshness {
     commits_ahead: u64,
 }
 
-pub fn execute<H: EngineHost>(
+pub struct AutomationExecutor;
+
+impl ActivityExecutor for AutomationExecutor {
+    fn spec_type(&self) -> &str {
+        "automation"
+    }
+
+    fn execute(&self, host: &dyn EngineHost, execution: &ExecutionContext) -> AttemptOutcome {
+        match execute(host, &execution.activity, &execution.input) {
+            Ok(result) => {
+                if let Err(err) = validate_activity_output_schema(&execution.activity, &result) {
+                    return AttemptOutcome {
+                        state: JobRunState::Failed,
+                        exit_code: Some(0),
+                        duration_ms: None,
+                        response_json: Some(result),
+                        error_code: Some(ACTIVITY_EXECUTION_FAILED.to_string()),
+                        error_message: Some(err.to_string()),
+                        protocol_violation: false,
+                    };
+                }
+                AttemptOutcome {
+                    state: JobRunState::Success,
+                    exit_code: Some(0),
+                    duration_ms: None,
+                    response_json: Some(result),
+                    error_code: None,
+                    error_message: None,
+                    protocol_violation: false,
+                }
+            }
+            Err(err) => AttemptOutcome {
+                state: JobRunState::Failed,
+                exit_code: Some(1),
+                duration_ms: None,
+                response_json: None,
+                error_code: Some(ACTIVITY_EXECUTION_FAILED.to_string()),
+                error_message: Some(err.to_string()),
+                protocol_violation: false,
+            },
+        }
+    }
+}
+
+pub fn execute<H: EngineHost + ?Sized>(
     host: &H,
     activity: &Activity,
     input: &Value,
@@ -53,7 +101,10 @@ pub fn execute<H: EngineHost>(
     }
 }
 
-fn create_task_worktree<H: EngineHost>(host: &H, input: &Value) -> Result<Value, OrbitError> {
+fn create_task_worktree<H: EngineHost + ?Sized>(
+    host: &H,
+    input: &Value,
+) -> Result<Value, OrbitError> {
     let task_id = required_input_string(input, "task_id")?;
     let repo_root = host.repo_root().or_else(|_| {
         let task = host.get_task(task_id)?;
@@ -106,7 +157,7 @@ fn create_task_worktree<H: EngineHost>(host: &H, input: &Value) -> Result<Value,
     }))
 }
 
-fn start_task<H: EngineHost>(host: &H, input: &Value) -> Result<Value, OrbitError> {
+fn start_task<H: EngineHost + ?Sized>(host: &H, input: &Value) -> Result<Value, OrbitError> {
     let task_id = required_input_string(input, "task_id")?;
     let task = host.start_task(
         task_id,
@@ -123,7 +174,7 @@ fn start_task<H: EngineHost>(host: &H, input: &Value) -> Result<Value, OrbitErro
     }))
 }
 
-fn update_task<H: EngineHost>(host: &H, input: &Value) -> Result<Value, OrbitError> {
+fn update_task<H: EngineHost + ?Sized>(host: &H, input: &Value) -> Result<Value, OrbitError> {
     let task_id = required_input_string(input, "task_id")?;
     let status = required_input_string(input, "status")?
         .parse::<TaskStatus>()
@@ -141,7 +192,10 @@ fn update_task<H: EngineHost>(host: &H, input: &Value) -> Result<Value, OrbitErr
     })
 }
 
-fn commit_task_changes<H: EngineHost>(host: &H, input: &Value) -> Result<Value, OrbitError> {
+fn commit_task_changes<H: EngineHost + ?Sized>(
+    host: &H,
+    input: &Value,
+) -> Result<Value, OrbitError> {
     let task_id = required_input_string(input, "task_id")?;
     let task = host.get_task(task_id)?;
     let workspace_path = canonicalize_existing_dir(
@@ -223,7 +277,10 @@ fn commit_task_changes<H: EngineHost>(host: &H, input: &Value) -> Result<Value, 
     }))
 }
 
-fn merge_pr_from_task<H: EngineHost>(host: &H, input: &Value) -> Result<Value, OrbitError> {
+fn merge_pr_from_task<H: EngineHost + ?Sized>(
+    host: &H,
+    input: &Value,
+) -> Result<Value, OrbitError> {
     let task_id = required_input_string(input, "task_id")?;
     let task = host.get_task(task_id)?;
     let repo_root = canonicalize_existing_dir(
@@ -306,7 +363,7 @@ fn merge_pr_from_task<H: EngineHost>(host: &H, input: &Value) -> Result<Value, O
     }))
 }
 
-fn open_pr_from_task<H: EngineHost>(host: &H, input: &Value) -> Result<Value, OrbitError> {
+fn open_pr_from_task<H: EngineHost + ?Sized>(host: &H, input: &Value) -> Result<Value, OrbitError> {
     let task_id = required_input_string(input, "task_id")?;
     let task = host.get_task(task_id)?;
     let repo_root = canonicalize_existing_dir(

--- a/orbit-engine/src/executor/cli_command.rs
+++ b/orbit-engine/src/executor/cli_command.rs
@@ -1,11 +1,17 @@
 use std::collections::HashMap;
 
 use orbit_exec::{EnvironmentMode, ExecRequest, NoSandbox, StdinMode, run_process};
+use orbit_types::JobRunState;
 use orbit_types::OrbitError;
 use serde::Deserialize;
 use serde_json::{Value, json};
 use tempfile::tempdir;
 
+use super::ActivityExecutor;
+use crate::activity_runner::{
+    execution_template_context_with_env, validate_activity_output_schema,
+};
+use crate::context::{ACTIVITY_EXECUTION_FAILED, AttemptOutcome, EngineHost, ExecutionContext};
 use crate::template::{TemplateContext, render};
 
 #[derive(Debug, Clone, Deserialize)]
@@ -23,6 +29,58 @@ pub struct CliCommandSpec {
 
 fn default_exit_codes() -> Vec<i32> {
     vec![0]
+}
+
+pub struct CliCommandExecutor;
+
+impl ActivityExecutor for CliCommandExecutor {
+    fn spec_type(&self) -> &str {
+        "cli_command"
+    }
+
+    fn execute(&self, host: &dyn EngineHost, execution: &ExecutionContext) -> AttemptOutcome {
+        let template_context = execution_template_context_with_env(
+            execution,
+            host.cli_command_environment(&execution.env_extra),
+        );
+        match execute(
+            &execution.activity.spec_config,
+            &template_context,
+            execution.timeout_seconds,
+        ) {
+            Ok((result, duration_ms, exit_code)) => {
+                if let Err(err) = validate_activity_output_schema(&execution.activity, &result) {
+                    return AttemptOutcome {
+                        state: JobRunState::Failed,
+                        exit_code,
+                        duration_ms: Some(duration_ms),
+                        response_json: Some(result),
+                        error_code: Some(ACTIVITY_EXECUTION_FAILED.to_string()),
+                        error_message: Some(err.to_string()),
+                        protocol_violation: false,
+                    };
+                }
+                AttemptOutcome {
+                    state: JobRunState::Success,
+                    exit_code,
+                    duration_ms: Some(duration_ms),
+                    response_json: Some(result),
+                    error_code: None,
+                    error_message: None,
+                    protocol_violation: false,
+                }
+            }
+            Err(err) => AttemptOutcome {
+                state: JobRunState::Failed,
+                exit_code: Some(1),
+                duration_ms: None,
+                response_json: None,
+                error_code: Some(ACTIVITY_EXECUTION_FAILED.to_string()),
+                error_message: Some(err.to_string()),
+                protocol_violation: false,
+            },
+        }
+    }
 }
 
 pub fn execute(

--- a/orbit-engine/src/executor/mod.rs
+++ b/orbit-engine/src/executor/mod.rs
@@ -2,3 +2,8 @@ pub mod agent;
 pub mod api;
 pub mod automation;
 pub mod cli_command;
+pub mod registry;
+pub mod traits;
+
+pub(crate) use registry::builtin_activity_executor_registry;
+pub(crate) use traits::ActivityExecutor;

--- a/orbit-engine/src/executor/registry.rs
+++ b/orbit-engine/src/executor/registry.rs
@@ -1,0 +1,112 @@
+use std::collections::HashMap;
+use std::sync::OnceLock;
+
+use super::agent::AgentExecutor;
+use super::api::ApiExecutor;
+use super::automation::AutomationExecutor;
+use super::cli_command::CliCommandExecutor;
+use super::traits::ActivityExecutor;
+
+pub struct ActivityExecutorRegistry {
+    executors: HashMap<String, Box<dyn ActivityExecutor>>,
+}
+
+impl ActivityExecutorRegistry {
+    pub fn new() -> Self {
+        Self {
+            executors: HashMap::new(),
+        }
+    }
+
+    pub fn with_builtins() -> Self {
+        let mut registry = Self::new();
+        registry.register_builtins();
+        registry
+    }
+
+    pub fn register<E>(&mut self, executor: E) -> Option<Box<dyn ActivityExecutor>>
+    where
+        E: ActivityExecutor + 'static,
+    {
+        self.executors
+            .insert(executor.spec_type().to_string(), Box::new(executor))
+    }
+
+    pub fn register_builtins(&mut self) {
+        let _ = self.register(AgentExecutor);
+        let _ = self.register(CliCommandExecutor);
+        let _ = self.register(ApiExecutor);
+        let _ = self.register(AutomationExecutor);
+    }
+
+    pub fn get(&self, spec_type: &str) -> Option<&dyn ActivityExecutor> {
+        self.executors.get(spec_type).map(Box::as_ref)
+    }
+
+    pub fn supported_spec_types(&self) -> Vec<&str> {
+        let mut spec_types = self
+            .executors
+            .keys()
+            .map(String::as_str)
+            .collect::<Vec<_>>();
+        spec_types.sort_unstable();
+        spec_types
+    }
+}
+
+impl Default for ActivityExecutorRegistry {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+pub fn builtin_activity_executor_registry() -> &'static ActivityExecutorRegistry {
+    static BUILTIN_EXECUTORS: OnceLock<ActivityExecutorRegistry> = OnceLock::new();
+    BUILTIN_EXECUTORS.get_or_init(ActivityExecutorRegistry::with_builtins)
+}
+
+#[cfg(test)]
+mod tests {
+    use orbit_types::JobRunState;
+    use serde_json::json;
+
+    use super::*;
+    use crate::context::{AttemptOutcome, EngineHost, ExecutionContext};
+
+    struct FakeExecutor;
+
+    impl ActivityExecutor for FakeExecutor {
+        fn spec_type(&self) -> &str {
+            "fake"
+        }
+
+        fn execute(&self, _host: &dyn EngineHost, _execution: &ExecutionContext) -> AttemptOutcome {
+            AttemptOutcome {
+                state: JobRunState::Success,
+                exit_code: Some(0),
+                duration_ms: Some(0),
+                response_json: Some(json!({})),
+                error_code: None,
+                error_message: None,
+                protocol_violation: false,
+            }
+        }
+    }
+
+    #[test]
+    fn registers_and_lists_custom_executors() {
+        let mut registry = ActivityExecutorRegistry::new();
+        let _ = registry.register(FakeExecutor);
+
+        assert!(registry.get("fake").is_some());
+        assert_eq!(registry.supported_spec_types(), vec!["fake"]);
+    }
+
+    #[test]
+    fn builtins_are_discoverable() {
+        assert_eq!(
+            builtin_activity_executor_registry().supported_spec_types(),
+            vec!["agent_invoke", "api", "automation", "cli_command"]
+        );
+    }
+}

--- a/orbit-engine/src/executor/traits.rs
+++ b/orbit-engine/src/executor/traits.rs
@@ -1,0 +1,6 @@
+use crate::context::{AttemptOutcome, EngineHost, ExecutionContext};
+
+pub trait ActivityExecutor: Send + Sync {
+    fn spec_type(&self) -> &str;
+    fn execute(&self, host: &dyn EngineHost, execution: &ExecutionContext) -> AttemptOutcome;
+}


### PR DESCRIPTION
## Changes
refactor: Replace string-dispatch on activity spec_type with executor registry (OCP) [T20260320-002640]

Introduced an `ActivityExecutor` trait plus a built-in executor registry in `orbit-engine`, converted the four existing executor types to registry-backed executor structs, and updated `activity_runner` to dispatch through the registry with discoverable unsupported-type errors. The refactor compiles cleanly and `cargo test -p orbit-engine` plus `cargo clippy -p orbit-engine --no-deps -- -D warnings` pass, but full workspace verification is still blocked by pre-existing failures outside this change (`orbit-core` has a bundled job model expectation mismatch and `orbit-agent` fails workspace clippy).

## Branch Freshness
- Base ref: `origin/agent-main`
- Head ref: `orbit/T20260320-002640`
- Behind base: 0
- Ahead of base: 1

## Files Changed
- `orbit-engine/src/activity_runner.rs`
- `orbit-engine/src/executor/agent.rs`
- `orbit-engine/src/executor/api.rs`
- `orbit-engine/src/executor/automation.rs`
- `orbit-engine/src/executor/cli_command.rs`
- `orbit-engine/src/executor/mod.rs`
- `orbit-engine/src/executor/registry.rs`
- `orbit-engine/src/executor/traits.rs`