### PR TITLE
Split EngineHost trait into focused sub-traits (ISP)

### DIFF
--- a/orbit-core/src/runtime/engine.rs
+++ b/orbit-core/src/runtime/engine.rs
@@ -1,7 +1,8 @@
 use chrono::{DateTime, Utc};
 use orbit_agent::AgentConfig;
 use orbit_engine::{
-    EngineHost, ExecutionContext, TaskAutomationUpdate, activity_skill_refs_from_spec_config,
+    AgentProtocolHost, EnvironmentHost, ExecutionContext, JobRunHost, RuntimeHost,
+    TaskAutomationUpdate, TaskHost, activity_skill_refs_from_spec_config,
 };
 use orbit_exec::EnvironmentMode;
 use orbit_store::{JobRunStepParams, TaskUpdateParams as StoreTaskUpdateParams};
@@ -167,7 +168,7 @@ fn execute_commit_request_if_present(
     Ok(())
 }
 
-impl EngineHost for OrbitRuntime {
+impl RuntimeHost for OrbitRuntime {
     fn record_event(&self, event: OrbitEvent) -> Result<(), OrbitError> {
         OrbitRuntime::record_event(self, event)
     }
@@ -184,6 +185,18 @@ impl EngineHost for OrbitRuntime {
         OrbitRuntime::validate_activity_target_exists(self, target_type, target_id)
     }
 
+    fn run_tool_with_context_and_role(
+        &self,
+        name: &str,
+        input: Value,
+        role: Role,
+        tool_context: ToolContext,
+    ) -> Result<Value, OrbitError> {
+        OrbitRuntime::run_tool_with_context_and_role(self, name, input, role, tool_context)
+    }
+}
+
+impl JobRunHost for OrbitRuntime {
     fn list_pending_or_running_job_runs(&self, job_id: &str) -> Result<Vec<JobRun>, OrbitError> {
         self.context
             .job_store
@@ -234,7 +247,9 @@ impl EngineHost for OrbitRuntime {
     fn get_job_run(&self, run_id: &str) -> Result<Option<JobRun>, OrbitError> {
         self.context.job_store.get_job_run(run_id)
     }
+}
 
+impl EnvironmentHost for OrbitRuntime {
     fn agent_config_for(
         &self,
         agent_cli: &str,
@@ -282,7 +297,9 @@ impl EngineHost for OrbitRuntime {
             .execution_env_policy
             .missing_required(required_env_vars)
     }
+}
 
+impl AgentProtocolHost for OrbitRuntime {
     fn build_agent_stdin_envelope_payload(
         &self,
         execution: &ExecutionContext,
@@ -301,7 +318,9 @@ impl EngineHost for OrbitRuntime {
     fn execute_commit_request_if_present(&self, result: &Value) -> Result<(), OrbitError> {
         execute_commit_request_if_present(self, result)
     }
+}
 
+impl TaskHost for OrbitRuntime {
     fn get_task(&self, task_id: &str) -> Result<Task, OrbitError> {
         OrbitRuntime::get_task(self, task_id)
     }
@@ -364,16 +383,6 @@ impl EngineHost for OrbitRuntime {
             ))
         })?;
         Ok(())
-    }
-
-    fn run_tool_with_context_and_role(
-        &self,
-        name: &str,
-        input: Value,
-        role: Role,
-        tool_context: ToolContext,
-    ) -> Result<Value, OrbitError> {
-        OrbitRuntime::run_tool_with_context_and_role(self, name, input, role, tool_context)
     }
 }
 

--- a/orbit-engine/src/activity_runner.rs
+++ b/orbit-engine/src/activity_runner.rs
@@ -3,7 +3,7 @@ use serde_json::{Value, json};
 
 use crate::context::{
     ACTIVITY_EXECUTION_FAILED, AttemptOutcome, DirectActivityRunOutcome, EngineHost,
-    ExecutionContext, input_workspace_path, redact_attempt_outcome,
+    ExecutionContext, RuntimeHost, input_workspace_path, redact_attempt_outcome,
 };
 use crate::executor::builtin_activity_executor_registry;
 use crate::json_schema::validate_instance_against_schema;
@@ -34,7 +34,7 @@ pub fn run_activity_direct<H: EngineHost>(
     })
 }
 
-pub fn build_execution_context_for_step<H: EngineHost>(
+pub fn build_execution_context_for_step<H: RuntimeHost>(
     host: &H,
     job: &Job,
     step: &JobStep,

--- a/orbit-engine/src/context.rs
+++ b/orbit-engine/src/context.rs
@@ -66,14 +66,7 @@ pub struct TaskAutomationUpdate {
     pub execution_summary: Option<String>,
 }
 
-pub trait EngineHost {
-    fn record_event(&self, event: OrbitEvent) -> Result<(), OrbitError>;
-    fn repo_root(&self) -> Result<String, OrbitError>;
-    fn validate_activity_target_exists(
-        &self,
-        target_type: JobTargetType,
-        target_id: &str,
-    ) -> Result<Activity, OrbitError>;
+pub trait JobRunHost {
     fn list_pending_or_running_job_runs(&self, job_id: &str) -> Result<Vec<JobRun>, OrbitError>;
     fn insert_job_run(
         &self,
@@ -99,26 +92,9 @@ pub trait EngineHost {
         duration_ms: Option<u64>,
     ) -> Result<bool, OrbitError>;
     fn get_job_run(&self, run_id: &str) -> Result<Option<JobRun>, OrbitError>;
+}
 
-    fn agent_config_for(
-        &self,
-        agent_cli: &str,
-        model: Option<&str>,
-    ) -> Result<AgentConfig, OrbitError>;
-    fn execution_environment_mode(&self, env_extra: &[String]) -> EnvironmentMode;
-    fn cli_command_environment(&self, env_extra: &[String]) -> Vec<(String, String)>;
-    fn missing_required_environment_vars(&self, required_env_vars: &[&str]) -> Vec<String>;
-    fn build_agent_stdin_envelope_payload(
-        &self,
-        execution: &ExecutionContext,
-    ) -> Result<Vec<u8>, OrbitError>;
-    fn validate_skill_output_schema(
-        &self,
-        activity: &Activity,
-        envelope: &orbit_types::AgentResponseEnvelope,
-    ) -> Result<(), OrbitError>;
-    fn execute_commit_request_if_present(&self, result: &Value) -> Result<(), OrbitError>;
-
+pub trait TaskHost {
     fn get_task(&self, task_id: &str) -> Result<Task, OrbitError>;
     fn start_task(
         &self,
@@ -140,6 +116,40 @@ pub trait EngineHost {
         task_id: &str,
         update: TaskAutomationUpdate,
     ) -> Result<(), OrbitError>;
+}
+
+pub trait AgentProtocolHost {
+    fn build_agent_stdin_envelope_payload(
+        &self,
+        execution: &ExecutionContext,
+    ) -> Result<Vec<u8>, OrbitError>;
+    fn validate_skill_output_schema(
+        &self,
+        activity: &Activity,
+        envelope: &orbit_types::AgentResponseEnvelope,
+    ) -> Result<(), OrbitError>;
+    fn execute_commit_request_if_present(&self, result: &Value) -> Result<(), OrbitError>;
+}
+
+pub trait EnvironmentHost {
+    fn agent_config_for(
+        &self,
+        agent_cli: &str,
+        model: Option<&str>,
+    ) -> Result<AgentConfig, OrbitError>;
+    fn execution_environment_mode(&self, env_extra: &[String]) -> EnvironmentMode;
+    fn cli_command_environment(&self, env_extra: &[String]) -> Vec<(String, String)>;
+    fn missing_required_environment_vars(&self, required_env_vars: &[&str]) -> Vec<String>;
+}
+
+pub trait RuntimeHost {
+    fn record_event(&self, event: OrbitEvent) -> Result<(), OrbitError>;
+    fn repo_root(&self) -> Result<String, OrbitError>;
+    fn validate_activity_target_exists(
+        &self,
+        target_type: JobTargetType,
+        target_id: &str,
+    ) -> Result<Activity, OrbitError>;
     fn run_tool_with_context_and_role(
         &self,
         name: &str,
@@ -147,6 +157,16 @@ pub trait EngineHost {
         role: Role,
         tool_context: ToolContext,
     ) -> Result<Value, OrbitError>;
+}
+
+pub trait EngineHost:
+    JobRunHost + TaskHost + AgentProtocolHost + EnvironmentHost + RuntimeHost
+{
+}
+
+impl<T> EngineHost for T where
+    T: JobRunHost + TaskHost + AgentProtocolHost + EnvironmentHost + RuntimeHost
+{
 }
 
 pub fn step_output_for_following_input<'a>(

--- a/orbit-engine/src/executor/agent.rs
+++ b/orbit-engine/src/executor/agent.rs
@@ -8,7 +8,8 @@ use tempfile::NamedTempFile;
 use super::ActivityExecutor;
 use crate::context::{
     AGENT_COMMIT_FAILED, AGENT_INVOCATION_FAILED, AGENT_PROTOCOL_VIOLATION, AGENT_TIMEOUT,
-    AttemptOutcome, EngineHost, ExecutionContext, execution_working_directory,
+    AgentProtocolHost, AttemptOutcome, EngineHost, EnvironmentHost, ExecutionContext,
+    execution_working_directory,
 };
 
 pub struct AgentExecutor;
@@ -23,7 +24,10 @@ impl ActivityExecutor for AgentExecutor {
     }
 }
 
-pub fn execute<H: EngineHost + ?Sized>(host: &H, execution: &ExecutionContext) -> AttemptOutcome {
+pub fn execute<H: EnvironmentHost + AgentProtocolHost + ?Sized>(
+    host: &H,
+    execution: &ExecutionContext,
+) -> AttemptOutcome {
     let invocation = match build_agent_invocation(host, execution) {
         Ok(invocation) => invocation,
         Err(outcome) => return outcome,
@@ -70,7 +74,7 @@ pub fn execute<H: EngineHost + ?Sized>(host: &H, execution: &ExecutionContext) -
     }
 }
 
-fn build_agent_invocation<H: EngineHost + ?Sized>(
+fn build_agent_invocation<H: EnvironmentHost + AgentProtocolHost + ?Sized>(
     host: &H,
     execution: &ExecutionContext,
 ) -> Result<orbit_agent::AgentResponse, AttemptOutcome> {
@@ -114,7 +118,7 @@ configure .orbit/config.toml [execution.env].pass and set these variables in the
     Ok(invocation)
 }
 
-fn execute_agent_process<H: EngineHost + ?Sized>(
+fn execute_agent_process<H: EnvironmentHost + AgentProtocolHost + ?Sized>(
     host: &H,
     execution: &ExecutionContext,
     invocation: orbit_agent::AgentResponse,
@@ -159,7 +163,7 @@ fn inject_activity_tools(mode: EnvironmentMode, tools: &[String]) -> Environment
     }
 }
 
-fn process_agent_response<H: EngineHost + ?Sized>(
+fn process_agent_response<H: EnvironmentHost + AgentProtocolHost + ?Sized>(
     host: &H,
     execution: &ExecutionContext,
     exec_result: &orbit_types::ExecutionResult,
@@ -191,7 +195,7 @@ fn process_agent_response<H: EngineHost + ?Sized>(
     }
 }
 
-fn validate_agent_success<H: EngineHost + ?Sized>(
+fn validate_agent_success<H: EnvironmentHost + AgentProtocolHost + ?Sized>(
     host: &H,
     execution: &ExecutionContext,
     exec_result: &orbit_types::ExecutionResult,

--- a/orbit-engine/src/executor/automation.rs
+++ b/orbit-engine/src/executor/automation.rs
@@ -9,7 +9,8 @@ use serde_json::{Value, json};
 use super::ActivityExecutor;
 use crate::activity_runner::validate_activity_output_schema;
 use crate::context::{
-    ACTIVITY_EXECUTION_FAILED, AttemptOutcome, EngineHost, ExecutionContext, TaskAutomationUpdate,
+    ACTIVITY_EXECUTION_FAILED, AttemptOutcome, EngineHost, ExecutionContext, RuntimeHost,
+    TaskAutomationUpdate, TaskHost,
 };
 
 const AUTOMATION_CREATE_TASK_WORKTREE: &str = "create_task_worktree";
@@ -77,7 +78,7 @@ impl ActivityExecutor for AutomationExecutor {
     }
 }
 
-pub fn execute<H: EngineHost + ?Sized>(
+pub fn execute<H: RuntimeHost + TaskHost + ?Sized>(
     host: &H,
     activity: &Activity,
     input: &Value,
@@ -101,7 +102,7 @@ pub fn execute<H: EngineHost + ?Sized>(
     }
 }
 
-fn create_task_worktree<H: EngineHost + ?Sized>(
+fn create_task_worktree<H: RuntimeHost + TaskHost + ?Sized>(
     host: &H,
     input: &Value,
 ) -> Result<Value, OrbitError> {
@@ -157,7 +158,7 @@ fn create_task_worktree<H: EngineHost + ?Sized>(
     }))
 }
 
-fn start_task<H: EngineHost + ?Sized>(host: &H, input: &Value) -> Result<Value, OrbitError> {
+fn start_task<H: TaskHost + ?Sized>(host: &H, input: &Value) -> Result<Value, OrbitError> {
     let task_id = required_input_string(input, "task_id")?;
     let task = host.start_task(
         task_id,
@@ -174,7 +175,7 @@ fn start_task<H: EngineHost + ?Sized>(host: &H, input: &Value) -> Result<Value, 
     }))
 }
 
-fn update_task<H: EngineHost + ?Sized>(host: &H, input: &Value) -> Result<Value, OrbitError> {
+fn update_task<H: TaskHost + ?Sized>(host: &H, input: &Value) -> Result<Value, OrbitError> {
     let task_id = required_input_string(input, "task_id")?;
     let status = required_input_string(input, "status")?
         .parse::<TaskStatus>()
@@ -192,10 +193,7 @@ fn update_task<H: EngineHost + ?Sized>(host: &H, input: &Value) -> Result<Value,
     })
 }
 
-fn commit_task_changes<H: EngineHost + ?Sized>(
-    host: &H,
-    input: &Value,
-) -> Result<Value, OrbitError> {
+fn commit_task_changes<H: TaskHost + ?Sized>(host: &H, input: &Value) -> Result<Value, OrbitError> {
     let task_id = required_input_string(input, "task_id")?;
     let task = host.get_task(task_id)?;
     let workspace_path = canonicalize_existing_dir(
@@ -277,7 +275,7 @@ fn commit_task_changes<H: EngineHost + ?Sized>(
     }))
 }
 
-fn merge_pr_from_task<H: EngineHost + ?Sized>(
+fn merge_pr_from_task<H: RuntimeHost + TaskHost + ?Sized>(
     host: &H,
     input: &Value,
 ) -> Result<Value, OrbitError> {
@@ -363,7 +361,10 @@ fn merge_pr_from_task<H: EngineHost + ?Sized>(
     }))
 }
 
-fn open_pr_from_task<H: EngineHost + ?Sized>(host: &H, input: &Value) -> Result<Value, OrbitError> {
+fn open_pr_from_task<H: RuntimeHost + TaskHost + ?Sized>(
+    host: &H,
+    input: &Value,
+) -> Result<Value, OrbitError> {
     let task_id = required_input_string(input, "task_id")?;
     let task = host.get_task(task_id)?;
     let repo_root = canonicalize_existing_dir(

--- a/orbit-engine/src/job_runner.rs
+++ b/orbit-engine/src/job_runner.rs
@@ -5,8 +5,8 @@ use serde_json::Value;
 
 use crate::activity_runner::{build_execution_context_for_step, execute_single_attempt};
 use crate::context::{
-    ACTIVITY_EXECUTION_FAILED, AGENT_INVOCATION_FAILED, EngineHost, JobRunResult,
-    STALE_RUN_GRACE_SECONDS, step_output_for_following_input,
+    ACTIVITY_EXECUTION_FAILED, AGENT_INVOCATION_FAILED, EngineHost, JobRunHost, JobRunResult,
+    RuntimeHost, STALE_RUN_GRACE_SECONDS, step_output_for_following_input,
 };
 
 pub fn run_job_with_input<H: EngineHost>(
@@ -182,7 +182,7 @@ fn execute_activity_with_retries<H: EngineHost>(
     }
 }
 
-pub fn recover_stale_active_run_for_job<H: EngineHost>(
+pub fn recover_stale_active_run_for_job<H: JobRunHost + RuntimeHost>(
     host: &H,
     job: &Job,
     now: DateTime<Utc>,
@@ -251,7 +251,7 @@ pub fn recover_stale_active_run_for_job<H: EngineHost>(
     Ok(recovered_any)
 }
 
-fn finalize_failed_started_run<H: EngineHost>(
+fn finalize_failed_started_run<H: JobRunHost + RuntimeHost>(
     host: &H,
     job: &Job,
     run: &JobRun,

--- a/orbit-engine/src/lib.rs
+++ b/orbit-engine/src/lib.rs
@@ -11,8 +11,9 @@ pub use activity_runner::{
 };
 pub use context::{
     ACTIVITY_EXECUTION_FAILED, AGENT_COMMIT_FAILED, AGENT_INVOCATION_FAILED,
-    AGENT_PROTOCOL_VIOLATION, AGENT_TIMEOUT, AttemptOutcome, DirectActivityRunOutcome, EngineHost,
-    ExecutionContext, JobRunResult, STALE_RUN_GRACE_SECONDS, TaskAutomationUpdate,
+    AGENT_PROTOCOL_VIOLATION, AGENT_TIMEOUT, AgentProtocolHost, AttemptOutcome,
+    DirectActivityRunOutcome, EngineHost, EnvironmentHost, ExecutionContext, JobRunHost,
+    JobRunResult, RuntimeHost, STALE_RUN_GRACE_SECONDS, TaskAutomationUpdate, TaskHost,
     execution_working_directory, input_workspace_path, redact_attempt_outcome,
     step_output_for_following_input,
 };


### PR DESCRIPTION
## Changes
refactor: Split EngineHost trait into focused sub-traits (ISP) [T20260320-002620]

Split the monolithic `EngineHost` interface into focused `JobRunHost`, `TaskHost`, `AgentProtocolHost`, `EnvironmentHost`, and `RuntimeHost` traits in `orbit-engine`, kept `EngineHost` as a composite blanket trait for executor dispatch, narrowed helper function bounds where possible, and updated `OrbitRuntime` to implement the new traits with no behavior changes. Workspace check, full test suite, and clippy all pass.

## Branch Freshness
- Base ref: `origin/agent-main`
- Head ref: `orbit/T20260320-002620`
- Behind base: 0
- Ahead of base: 1

## Files Changed
- `orbit-core/src/runtime/engine.rs`
- `orbit-engine/src/activity_runner.rs`
- `orbit-engine/src/context.rs`
- `orbit-engine/src/executor/agent.rs`
- `orbit-engine/src/executor/automation.rs`
- `orbit-engine/src/job_runner.rs`
- `orbit-engine/src/lib.rs`