### PR TITLE
Make OrbitContext fields private and enforce access through OrbitRuntime

### DIFF
--- a/orbit-core/src/command/activity.rs
+++ b/orbit-core/src/command/activity.rs
@@ -153,19 +153,16 @@ impl OrbitRuntime {
         validate_activity_params(&params)?;
         let skill_refs = activity_skill_refs_from_spec_config(&params.spec_config)?;
         let _ = self.resolve_activity_skill_refs(&skill_refs)?;
-        let activity = self
-            .context
-            .activity_store
-            .add_activity(StoreWorkCreateParams {
-                id: params.id,
-                spec_type: params.spec_type,
-                description: params.description,
-                input_schema_json: params.input_schema_json,
-                output_schema_json: params.output_schema_json,
-                spec_config: params.spec_config,
-                workspace_path: params.workspace_path,
-                created_by: params.created_by,
-            })?;
+        let activity = self.add_activity_record(StoreWorkCreateParams {
+            id: params.id,
+            spec_type: params.spec_type,
+            description: params.description,
+            input_schema_json: params.input_schema_json,
+            output_schema_json: params.output_schema_json,
+            spec_config: params.spec_config,
+            workspace_path: params.workspace_path,
+            created_by: params.created_by,
+        })?;
         self.record_event(OrbitEvent::ActivityAdded {
             id: activity.id.clone(),
         })?;
@@ -173,15 +170,11 @@ impl OrbitRuntime {
     }
 
     pub fn list_activities(&self, include_inactive: bool) -> Result<Vec<Activity>, OrbitError> {
-        self.context
-            .activity_store
-            .list_activities(include_inactive)
+        self.list_activity_records(include_inactive)
     }
 
     pub fn show_activity(&self, id: &str) -> Result<Activity, OrbitError> {
-        self.context
-            .activity_store
-            .get_activity(id)?
+        self.get_activity_record(id)?
             .ok_or_else(|| OrbitError::ActivityNotFound(id.to_string()))
     }
 
@@ -196,7 +189,7 @@ impl OrbitRuntime {
             let _ = self.resolve_activity_skill_refs(&skill_refs)?;
         }
 
-        let activity = self.context.activity_store.update_activity(
+        let activity = self.update_activity_record(
             id,
             StoreActivityUpdateParams {
                 description: params.description,
@@ -215,7 +208,7 @@ impl OrbitRuntime {
     }
 
     pub fn delete_activity(&self, id: &str) -> Result<(), OrbitError> {
-        let changed = self.context.activity_store.disable_activity(id)?;
+        let changed = self.disable_activity_record(id)?;
         if !changed {
             return Err(OrbitError::ActivityNotFound(id.to_string()));
         }

--- a/orbit-core/src/command/audit_event.rs
+++ b/orbit-core/src/command/audit_event.rs
@@ -13,28 +13,22 @@ impl OrbitRuntime {
         role: Option<String>,
         limit: usize,
     ) -> Result<Vec<AuditEvent>, OrbitError> {
-        self.context
-            .audit_event_store
-            .list_audit_events(&AuditEventFilter {
-                since,
-                tool_name: tool,
-                status,
-                role,
-                limit,
-            })
+        self.list_audit_event_records(&AuditEventFilter {
+            since,
+            tool_name: tool,
+            status,
+            role,
+            limit,
+        })
     }
 
     pub fn show_audit_event(&self, id: i64) -> Result<AuditEvent, OrbitError> {
-        self.context
-            .audit_event_store
-            .get_audit_event(id)?
+        self.get_audit_event_record(id)?
             .ok_or_else(|| OrbitError::InvalidInput(format!("audit event not found: {id}")))
     }
 
     pub fn prune_audit_events(&self, older_than: &DateTime<Utc>) -> Result<usize, OrbitError> {
-        self.context
-            .audit_event_store
-            .prune_audit_events(older_than)
+        self.prune_audit_event_records(older_than)
     }
 
     pub fn audit_event_stats(
@@ -43,14 +37,9 @@ impl OrbitRuntime {
         tool: Option<String>,
     ) -> Result<AuditStats, OrbitError> {
         let (total, success_count, failure_count, denied_count, avg_duration_ms, max_duration_ms) =
-            self.context
-                .audit_event_store
-                .get_audit_event_stats(since.as_ref(), tool.as_deref())?;
+            self.audit_event_stats_record(since.as_ref(), tool.as_deref())?;
 
-        let durations = self
-            .context
-            .audit_event_store
-            .get_audit_event_durations(since.as_ref(), tool.as_deref())?;
+        let durations = self.audit_event_durations_record(since.as_ref(), tool.as_deref())?;
 
         let p95_duration_ms = compute_p95(&durations);
 
@@ -66,9 +55,7 @@ impl OrbitRuntime {
     }
 
     pub fn record_audit_event(&self, params: &AuditEventInsertParams) -> Result<(), OrbitError> {
-        self.context
-            .audit_event_store
-            .insert_audit_event_record(params)
+        self.insert_audit_event_record(params)
     }
 }
 

--- a/orbit-core/src/command/job.rs
+++ b/orbit-core/src/command/job.rs
@@ -135,7 +135,7 @@ impl OrbitRuntime {
             })
             .collect::<Result<Vec<_>, OrbitError>>()?;
 
-        let job = self.context.job_store.add_job(StoreActivityCreateParams {
+        let job = self.add_job_record(StoreActivityCreateParams {
             job_id: params.job_id,
             default_input,
             max_active_runs,
@@ -156,7 +156,7 @@ impl OrbitRuntime {
         steps: Vec<JobStep>,
         state: JobScheduleState,
     ) -> Result<Job, OrbitError> {
-        let job = self.context.job_store.update_job(
+        let job = self.update_job_record(
             job_id,
             StoreJobUpdateParams {
                 default_input: Some(normalize_job_default_input(default_input)?),
@@ -187,9 +187,7 @@ impl OrbitRuntime {
         for job in jobs {
             let _ = self.recover_stale_active_run_for_job(&job, now);
             let last_run = self
-                .context
-                .job_store
-                .list_job_runs_filtered(&JobRunQuery {
+                .list_job_runs_filtered_record(&JobRunQuery {
                     job_id: Some(job.job_id.clone()),
                     state: None,
                     created_since: None,
@@ -208,7 +206,7 @@ impl OrbitRuntime {
     }
 
     pub fn delete_job(&self, job_id: &str) -> Result<(), OrbitError> {
-        let changed = self.context.job_store.mark_job_disabled(job_id)?;
+        let changed = self.mark_job_disabled_record(job_id)?;
         if !changed {
             return Err(OrbitError::JobNotFound(job_id.to_string()));
         }
@@ -218,11 +216,11 @@ impl OrbitRuntime {
     }
 
     fn list_jobs_backend(&self, include_disabled: bool) -> Result<Vec<Job>, OrbitError> {
-        self.context.job_store.list_jobs(include_disabled)
+        self.list_job_records(include_disabled)
     }
 
     fn get_job_backend(&self, job_id: &str) -> Result<Option<Job>, OrbitError> {
-        self.context.job_store.get_job(job_id)
+        self.get_job_record(job_id)
     }
 }
 

--- a/orbit-core/src/command/job_run.rs
+++ b/orbit-core/src/command/job_run.rs
@@ -21,7 +21,7 @@ impl OrbitRuntime {
                 run_id
             )));
         }
-        let job_id = self.context.job_store.archive_job_run(run_id)?;
+        let job_id = self.archive_job_run_record(run_id)?;
         self.record_event(OrbitEvent::JobRunArchived {
             job_id,
             run_id: run_id.to_string(),
@@ -37,7 +37,7 @@ impl OrbitRuntime {
                 run_id
             )));
         }
-        let job_id = self.context.job_store.delete_job_run(run_id)?;
+        let job_id = self.delete_job_run_record(run_id)?;
         self.record_event(OrbitEvent::JobRunDeleted {
             job_id,
             run_id: run_id.to_string(),
@@ -87,17 +87,17 @@ impl OrbitRuntime {
     }
 
     fn list_job_history_backend(&self, job_id: &str) -> Result<Vec<JobRun>, OrbitError> {
-        self.context.job_store.list_job_runs(job_id)
+        self.list_job_run_records(job_id)
     }
 
     fn list_job_runs_filtered_backend(
         &self,
         query: &JobRunQuery,
     ) -> Result<Vec<JobRun>, OrbitError> {
-        self.context.job_store.list_job_runs_filtered(query)
+        self.list_job_runs_filtered_record(query)
     }
 
     fn get_job_run_backend(&self, run_id: &str) -> Result<Option<JobRun>, OrbitError> {
-        self.context.job_store.get_job_run(run_id)
+        self.get_job_run_record(run_id)
     }
 }

--- a/orbit-core/src/command/skill.rs
+++ b/orbit-core/src/command/skill.rs
@@ -76,15 +76,15 @@ fn inject_skill_template_tokens(raw: &str, orbit_root: &Path) -> String {
 
 impl OrbitRuntime {
     pub fn list_file_skills(&self) -> Result<Vec<LoadedSkill>, OrbitError> {
-        self.context.skill_catalog.list()
+        self.skill_catalog().list()
     }
 
     pub fn show_file_skill(&self, name: &str) -> Result<LoadedSkill, OrbitError> {
-        self.context.skill_catalog.load(name)
+        self.skill_catalog().load(name)
     }
 
     pub fn doctor_file_skills(&self) -> Result<Vec<SkillDoctorResult>, OrbitError> {
-        let rows = self.context.skill_catalog.doctor()?;
+        let rows = self.skill_catalog().doctor()?;
         Ok(rows
             .into_iter()
             .map(|row| SkillDoctorResult {
@@ -108,7 +108,7 @@ impl OrbitRuntime {
             if !dedup.insert(skill_id.clone()) {
                 continue;
             }
-            output.push(self.context.skill_catalog.load(skill_id)?);
+            output.push(self.skill_catalog().load(skill_id)?);
         }
         Ok(output)
     }

--- a/orbit-core/src/command/task.rs
+++ b/orbit-core/src/command/task.rs
@@ -50,9 +50,9 @@ pub struct TaskUpdateParams {
 impl OrbitRuntime {
     pub fn add_task(&self, params: TaskAddParams) -> Result<Task, OrbitError> {
         let workspace_path = normalize_path(params.workspace_path)?;
-        let actor = self.context.actor.clone();
-        let initial_status =
-            if actor.kind == ActorKind::Agent && self.context.task_approval_required_for_agent {
+        let actor = self.actor().clone();
+        let initial_status = if actor.kind == ActorKind::Agent && self.task_approval_required_for_agent()
+        {
                 TaskStatus::Proposed
             } else {
                 TaskStatus::Backlog
@@ -60,7 +60,7 @@ impl OrbitRuntime {
         let comments = build_task_comments(params.comment.clone(), actor.label.as_str())?;
 
         self.with_mutation(|| {
-            let task = self.context.task_store.create_task(StoreTaskCreateParams {
+            let task = self.create_task_record(StoreTaskCreateParams {
                 actor: actor.label.clone(),
                 title: params.title.clone(),
                 description: params.description.clone(),
@@ -88,14 +88,12 @@ impl OrbitRuntime {
     }
 
     pub fn get_task(&self, id: &str) -> Result<Task, OrbitError> {
-        self.context
-            .task_store
-            .get_task(id)?
+        self.get_task_record(id)?
             .ok_or_else(|| OrbitError::TaskNotFound(id.to_string()))
     }
 
     pub fn list_tasks(&self) -> Result<Vec<Task>, OrbitError> {
-        self.context.task_store.list_tasks()
+        self.list_task_records()
     }
 
     pub fn list_tasks_filtered(
@@ -103,9 +101,7 @@ impl OrbitRuntime {
         status: Option<TaskStatus>,
         priority: Option<TaskPriority>,
     ) -> Result<Vec<Task>, OrbitError> {
-        self.context
-            .task_store
-            .list_tasks_filtered(status, priority)
+        self.list_task_records_filtered(status, priority)
     }
 
     pub fn update_task(&self, id: &str, params: TaskUpdateParams) -> Result<Task, OrbitError> {
@@ -189,7 +185,7 @@ impl OrbitRuntime {
             }
         }
 
-        let actor = self.context.actor.clone();
+        let actor = self.actor().clone();
         let status_note = status_note
             .as_deref()
             .map(str::trim)
@@ -205,7 +201,7 @@ impl OrbitRuntime {
         });
 
         let task = self.with_mutation(|| {
-            let task = self.context.task_store.update_task(
+            let task = self.update_task_record(
                 id,
                 StoreTaskUpdateParams {
                     actor: actor.label.clone(),
@@ -235,13 +231,13 @@ impl OrbitRuntime {
         comment: Option<String>,
     ) -> Result<Task, OrbitError> {
         let task = self.get_task(id)?;
-        let actor = self.context.actor.clone();
+        let actor = self.actor().clone();
         let append_comments = build_task_comments(comment, actor.label.as_str())?;
 
         match task.status {
             TaskStatus::Proposed => {
                 let task = self.with_mutation(|| {
-                    let task = self.context.task_store.update_task(
+                    let task = self.update_task_record(
                         id,
                         StoreTaskUpdateParams {
                             actor: actor.label.clone(),
@@ -265,7 +261,7 @@ impl OrbitRuntime {
             }
             TaskStatus::Review => {
                 let task = self.with_mutation(|| {
-                    let task = self.context.task_store.update_task(
+                    let task = self.update_task_record(
                         id,
                         StoreTaskUpdateParams {
                             actor: actor.label.clone(),
@@ -299,14 +295,14 @@ impl OrbitRuntime {
         comment: Option<String>,
     ) -> Result<Task, OrbitError> {
         let task = self.get_task(id)?;
-        let actor = self.context.actor.clone();
+        let actor = self.actor().clone();
         let append_comments = build_task_comments(comment, actor.label.as_str())?;
 
         match task.status {
             TaskStatus::Proposed => {
                 let task = self.with_mutation(|| {
                     let at = Utc::now();
-                    let task = self.context.task_store.update_task(
+                    let task = self.update_task_record(
                         id,
                         StoreTaskUpdateParams {
                             actor: actor.label.clone(),
@@ -338,7 +334,7 @@ impl OrbitRuntime {
             }
             TaskStatus::Backlog | TaskStatus::Blocked => {
                 let task = self.with_mutation(|| {
-                    let task = self.context.task_store.update_task(
+                    let task = self.update_task_record(
                         id,
                         StoreTaskUpdateParams {
                             actor: actor.label.clone(),
@@ -377,7 +373,7 @@ impl OrbitRuntime {
         comment: Option<String>,
     ) -> Result<Task, OrbitError> {
         let task = self.get_task(id)?;
-        let actor = self.context.actor.clone();
+        let actor = self.actor().clone();
         let reason = note.trim();
         if reason.is_empty() {
             return Err(OrbitError::InvalidInput(
@@ -390,7 +386,7 @@ impl OrbitRuntime {
         match task.status {
             TaskStatus::Proposed => {
                 let task = self.with_mutation(|| {
-                    let task = self.context.task_store.update_task(
+                    let task = self.update_task_record(
                         id,
                         StoreTaskUpdateParams {
                             actor: actor.label.clone(),
@@ -413,7 +409,7 @@ impl OrbitRuntime {
             }
             TaskStatus::Review => {
                 let task = self.with_mutation(|| {
-                    let task = self.context.task_store.update_task(
+                    let task = self.update_task_record(
                         id,
                         StoreTaskUpdateParams {
                             actor: actor.label.clone(),
@@ -450,10 +446,10 @@ impl OrbitRuntime {
         }
 
         self.with_mutation(|| {
-            let _ = self.context.task_store.update_task(
+            let _ = self.update_task_record(
                 id,
                 StoreTaskUpdateParams {
-                    actor: self.context.actor.label.clone(),
+                    actor: self.actor_label().to_string(),
                     status: Some(TaskStatus::Archived),
                     ..Default::default()
                 },
@@ -473,10 +469,10 @@ impl OrbitRuntime {
         }
 
         self.with_mutation(|| {
-            let _ = self.context.task_store.update_task(
+            let _ = self.update_task_record(
                 id,
                 StoreTaskUpdateParams {
-                    actor: self.context.actor.label.clone(),
+                    actor: self.actor_label().to_string(),
                     status: Some(TaskStatus::Backlog),
                     ..Default::default()
                 },
@@ -487,7 +483,7 @@ impl OrbitRuntime {
 
     pub fn delete_task(&self, id: &str) -> Result<(), OrbitError> {
         self.with_mutation(|| {
-            let deleted = self.context.task_store.delete_task(id)?;
+            let deleted = self.delete_task_record(id)?;
             if !deleted {
                 return Err(OrbitError::TaskNotFound(id.to_string()));
             }
@@ -496,7 +492,47 @@ impl OrbitRuntime {
     }
 
     pub fn search_tasks(&self, query: &str) -> Result<Vec<Task>, OrbitError> {
-        self.context.task_store.search_tasks(query)
+        self.search_task_records(query)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn add_task_with_status(
+        &self,
+        title: &str,
+        status: TaskStatus,
+    ) -> Result<Task, OrbitError> {
+        let actor = if status == TaskStatus::Proposed {
+            "agent".to_string()
+        } else {
+            self.actor_label().to_string()
+        };
+        let execution_summary = if matches!(
+            status,
+            TaskStatus::Review | TaskStatus::Done | TaskStatus::Archived
+        ) {
+            "seeded by runtime test helper".to_string()
+        } else {
+            String::new()
+        };
+
+        self.create_task_record(StoreTaskCreateParams {
+            actor: actor.clone(),
+            title: title.to_string(),
+            description: String::new(),
+            plan: String::new(),
+            execution_summary,
+            context_files: Vec::new(),
+            workspace_path: None,
+            created_by: Some(actor.clone()),
+            assigned_to: Some(actor.clone()),
+            status,
+            priority: TaskPriority::Medium,
+            task_type: TaskType::Task,
+            branch: None,
+            pr_number: None,
+            proposed_by: (status == TaskStatus::Proposed).then_some(actor),
+            comments: Vec::new(),
+        })
     }
 }
 

--- a/orbit-core/src/command/tool.rs
+++ b/orbit-core/src/command/tool.rs
@@ -61,8 +61,8 @@ fn read_activity_tools_from_env() -> Vec<String> {
 
 impl OrbitRuntime {
     pub fn list_tools(&self) -> Result<Vec<ToolInfo>, OrbitError> {
-        let registry_schemas = self.context.registry.schemas();
-        let stored_tools = self.context.tool_store.list_tools()?;
+        let registry_schemas = self.tool_registry().schemas();
+        let stored_tools = self.list_tool_records()?;
 
         let mut tools: Vec<ToolInfo> = registry_schemas
             .into_iter()
@@ -98,12 +98,11 @@ impl OrbitRuntime {
 
     pub fn show_tool(&self, name: &str) -> Result<ToolInfo, OrbitError> {
         let schema = self
-            .context
-            .registry
+            .tool_registry()
             .get_schema(name)
             .ok_or_else(|| OrbitError::ToolNotFound(name.to_string()))?;
 
-        let stored = self.context.tool_store.get_tool(name)?;
+        let stored = self.get_tool_record(name)?;
         let enabled = stored.is_none_or(|s| s.enabled);
 
         Ok(ToolInfo {
@@ -123,7 +122,7 @@ impl OrbitRuntime {
             )));
         }
 
-        if let Some(schema) = self.context.registry.get_schema(name)
+        if let Some(schema) = self.tool_registry().get_schema(name)
             && schema.builtin
         {
             return Err(OrbitError::InvalidInput(format!(
@@ -140,7 +139,7 @@ impl OrbitRuntime {
         };
 
         self.with_mutation(|| {
-            self.context.tool_store.insert_tool(&tool)?;
+            self.insert_tool_record(&tool)?;
             Ok((
                 (),
                 OrbitEvent::ToolAdded {
@@ -151,7 +150,7 @@ impl OrbitRuntime {
     }
 
     pub fn remove_tool(&self, name: &str) -> Result<(), OrbitError> {
-        if let Some(schema) = self.context.registry.get_schema(name)
+        if let Some(schema) = self.tool_registry().get_schema(name)
             && schema.builtin
         {
             return Err(OrbitError::InvalidInput(format!(
@@ -160,7 +159,7 @@ impl OrbitRuntime {
         }
 
         self.with_mutation(|| {
-            let deleted = self.context.tool_store.delete_tool(name)?;
+            let deleted = self.delete_tool_record(name)?;
             if !deleted {
                 return Err(OrbitError::ToolNotFound(name.to_string()));
             }
@@ -197,7 +196,7 @@ impl OrbitRuntime {
             }
 
             if !tool.builtin
-                && let Some(stored) = self.context.tool_store.get_tool(&tool.name)?
+                && let Some(stored) = self.get_tool_record(&tool.name)?
                 && !stored.path.is_empty()
             {
                 let path = std::path::Path::new(&stored.path);
@@ -230,15 +229,14 @@ impl OrbitRuntime {
     }
 
     fn set_tool_enabled_state(&self, name: &str, enabled: bool) -> Result<(), OrbitError> {
-        if !self.context.registry.has(name) {
+        if !self.tool_registry().has(name) {
             return Err(OrbitError::ToolNotFound(name.to_string()));
         }
 
-        let existing = self.context.tool_store.get_tool(name)?;
+        let existing = self.get_tool_record(name)?;
         if existing.is_none() {
             let schema = self
-                .context
-                .registry
+                .tool_registry()
                 .get_schema(name)
                 .ok_or_else(|| OrbitError::ToolNotFound(name.to_string()))?;
             let tool = StoredTool {
@@ -249,7 +247,7 @@ impl OrbitRuntime {
                 builtin: schema.builtin,
             };
             return self.with_mutation(|| {
-                self.context.tool_store.insert_tool(&tool)?;
+                self.insert_tool_record(&tool)?;
                 let event = if enabled {
                     OrbitEvent::ToolEnabled {
                         name: name.to_string(),
@@ -264,7 +262,7 @@ impl OrbitRuntime {
         }
 
         self.with_mutation(|| {
-            self.context.tool_store.set_tool_enabled(name, enabled)?;
+            self.set_tool_enabled_record(name, enabled)?;
             let event = if enabled {
                 OrbitEvent::ToolEnabled {
                     name: name.to_string(),

--- a/orbit-core/src/context.rs
+++ b/orbit-core/src/context.rs
@@ -1,4 +1,4 @@
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use orbit_policy::PolicyEngine;
@@ -68,22 +68,135 @@ impl Default for ActorIdentity {
 
 #[derive(Clone)]
 pub struct OrbitContext {
-    pub(crate) data_root: PathBuf,
-    pub(crate) task_store: Arc<dyn TaskStoreBackend>,
-    pub(crate) activity_store: Arc<dyn ActivityStoreBackend>,
-    pub(crate) job_store: Arc<dyn JobStoreBackend>,
-    pub(crate) tool_store: Arc<dyn ToolStoreBackend>,
-    pub(crate) audit_event_store: Arc<dyn AuditEventStoreBackend>,
-    pub(crate) policy: PolicyEngine,
-    pub(crate) registry: Arc<ToolRegistry>,
-    pub(crate) skill_catalog: SkillCatalog,
-    pub(crate) execution_env_policy: ExecutionEnvPolicy,
-    pub(crate) codex_execution_policy: CodexExecutionPolicy,
-    pub(crate) persistence: PersistenceConfig,
-    pub(crate) user_name: String,
-    pub(crate) actor: ActorIdentity,
-    pub(crate) task_approval_required_for_agent: bool,
-    pub(crate) task_delegate_approval: bool,
+    data_root: PathBuf,
+    task_store: Arc<dyn TaskStoreBackend>,
+    activity_store: Arc<dyn ActivityStoreBackend>,
+    job_store: Arc<dyn JobStoreBackend>,
+    tool_store: Arc<dyn ToolStoreBackend>,
+    audit_event_store: Arc<dyn AuditEventStoreBackend>,
+    policy: PolicyEngine,
+    registry: Arc<ToolRegistry>,
+    skill_catalog: SkillCatalog,
+    execution_env_policy: ExecutionEnvPolicy,
+    codex_execution_policy: CodexExecutionPolicy,
+    persistence: PersistenceConfig,
+    user_name: String,
+    actor: ActorIdentity,
+    task_approval_required_for_agent: bool,
+    task_delegate_approval: bool,
+}
+
+impl OrbitContext {
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn new(
+        data_root: PathBuf,
+        task_store: Arc<dyn TaskStoreBackend>,
+        activity_store: Arc<dyn ActivityStoreBackend>,
+        job_store: Arc<dyn JobStoreBackend>,
+        tool_store: Arc<dyn ToolStoreBackend>,
+        audit_event_store: Arc<dyn AuditEventStoreBackend>,
+        policy: PolicyEngine,
+        registry: Arc<ToolRegistry>,
+        skill_catalog: SkillCatalog,
+        execution_env_policy: ExecutionEnvPolicy,
+        codex_execution_policy: CodexExecutionPolicy,
+        persistence: PersistenceConfig,
+        user_name: String,
+        actor: ActorIdentity,
+        task_approval_required_for_agent: bool,
+        task_delegate_approval: bool,
+    ) -> Self {
+        Self {
+            data_root,
+            task_store,
+            activity_store,
+            job_store,
+            tool_store,
+            audit_event_store,
+            policy,
+            registry,
+            skill_catalog,
+            execution_env_policy,
+            codex_execution_policy,
+            persistence,
+            user_name,
+            actor,
+            task_approval_required_for_agent,
+            task_delegate_approval,
+        }
+    }
+
+    pub(crate) fn data_root(&self) -> &Path {
+        &self.data_root
+    }
+
+    pub(crate) fn task_store(&self) -> &Arc<dyn TaskStoreBackend> {
+        &self.task_store
+    }
+
+    pub(crate) fn activity_store(&self) -> &Arc<dyn ActivityStoreBackend> {
+        &self.activity_store
+    }
+
+    pub(crate) fn job_store(&self) -> &Arc<dyn JobStoreBackend> {
+        &self.job_store
+    }
+
+    pub(crate) fn tool_store(&self) -> &Arc<dyn ToolStoreBackend> {
+        &self.tool_store
+    }
+
+    pub(crate) fn audit_event_store(&self) -> &Arc<dyn AuditEventStoreBackend> {
+        &self.audit_event_store
+    }
+
+    pub(crate) fn policy(&self) -> &PolicyEngine {
+        &self.policy
+    }
+
+    pub(crate) fn set_policy(&mut self, policy: PolicyEngine) {
+        self.policy = policy;
+    }
+
+    pub(crate) fn registry(&self) -> &ToolRegistry {
+        self.registry.as_ref()
+    }
+
+    pub(crate) fn skill_catalog(&self) -> &SkillCatalog {
+        &self.skill_catalog
+    }
+
+    pub(crate) fn execution_env_policy(&self) -> &ExecutionEnvPolicy {
+        &self.execution_env_policy
+    }
+
+    pub(crate) fn codex_execution_policy(&self) -> &CodexExecutionPolicy {
+        &self.codex_execution_policy
+    }
+
+    pub(crate) fn persistence(&self) -> &PersistenceConfig {
+        &self.persistence
+    }
+
+    pub(crate) fn user_name(&self) -> &str {
+        &self.user_name
+    }
+
+    pub(crate) fn actor(&self) -> &ActorIdentity {
+        &self.actor
+    }
+
+    pub(crate) fn set_actor(&mut self, actor: ActorIdentity) {
+        self.actor = actor;
+    }
+
+    pub(crate) fn task_approval_required_for_agent(&self) -> bool {
+        self.task_approval_required_for_agent
+    }
+
+    pub(crate) fn task_delegate_approval(&self) -> bool {
+        self.task_delegate_approval
+    }
 }
 
 fn normalize_actor_label(label: String, default_label: &str) -> String {

--- a/orbit-core/src/lib.rs
+++ b/orbit-core/src/lib.rs
@@ -28,9 +28,8 @@ mod tests {
     use std::os::unix::fs::PermissionsExt;
 
     use orbit_policy::PolicyEngine;
-    use orbit_store::TaskCreateParams as StoreTaskCreateParams;
     use orbit_types::{
-        JobRunState, JobStep, JobTargetType, OrbitEvent, TaskPriority, TaskStatus, TaskType,
+        JobRunState, JobStep, JobTargetType, OrbitEvent, TaskPriority, TaskStatus,
     };
     use serde_json::json;
     use tempfile::tempdir;
@@ -593,26 +592,7 @@ mod tests {
     fn update_task_rejects_field_mutations_for_done_tasks() {
         let runtime = OrbitRuntime::in_memory().expect("runtime");
         let task = runtime
-            .context
-            .task_store
-            .create_task(StoreTaskCreateParams {
-                actor: "human".to_string(),
-                title: "done task".to_string(),
-                description: String::new(),
-                plan: String::new(),
-                execution_summary: "already shipped".to_string(),
-                context_files: Vec::new(),
-                workspace_path: None,
-                created_by: Some("human".to_string()),
-                assigned_to: Some("human".to_string()),
-                status: TaskStatus::Done,
-                priority: TaskPriority::Medium,
-                task_type: TaskType::Task,
-                branch: None,
-                pr_number: None,
-                proposed_by: None,
-                comments: Vec::new(),
-            })
+            .add_task_with_status("done task", TaskStatus::Done)
             .expect("create done task");
 
         let result = runtime.update_task(
@@ -639,26 +619,7 @@ mod tests {
     fn update_task_rejects_field_mutations_for_archived_tasks() {
         let runtime = OrbitRuntime::in_memory().expect("runtime");
         let task = runtime
-            .context
-            .task_store
-            .create_task(StoreTaskCreateParams {
-                actor: "human".to_string(),
-                title: "archived task".to_string(),
-                description: String::new(),
-                plan: String::new(),
-                execution_summary: "archived after review".to_string(),
-                context_files: Vec::new(),
-                workspace_path: None,
-                created_by: Some("human".to_string()),
-                assigned_to: Some("human".to_string()),
-                status: TaskStatus::Archived,
-                priority: TaskPriority::Medium,
-                task_type: TaskType::Task,
-                branch: None,
-                pr_number: None,
-                proposed_by: None,
-                comments: Vec::new(),
-            })
+            .add_task_with_status("archived task", TaskStatus::Archived)
             .expect("create archived task");
 
         let result = runtime.update_task(
@@ -685,26 +646,7 @@ mod tests {
     fn update_task_allows_field_mutations_for_in_progress_tasks() {
         let runtime = OrbitRuntime::in_memory().expect("runtime");
         let task = runtime
-            .context
-            .task_store
-            .create_task(StoreTaskCreateParams {
-                actor: "human".to_string(),
-                title: "active task".to_string(),
-                description: String::new(),
-                plan: String::new(),
-                execution_summary: String::new(),
-                context_files: Vec::new(),
-                workspace_path: None,
-                created_by: Some("human".to_string()),
-                assigned_to: Some("human".to_string()),
-                status: TaskStatus::InProgress,
-                priority: TaskPriority::Medium,
-                task_type: TaskType::Task,
-                branch: None,
-                pr_number: None,
-                proposed_by: None,
-                comments: Vec::new(),
-            })
+            .add_task_with_status("active task", TaskStatus::InProgress)
             .expect("create in-progress task");
 
         let updated = runtime
@@ -849,26 +791,7 @@ mod tests {
     fn start_task_from_proposed_records_approval_before_starting() {
         let runtime = OrbitRuntime::in_memory().expect("runtime");
         let task = runtime
-            .context
-            .task_store
-            .create_task(StoreTaskCreateParams {
-                actor: "agent".to_string(),
-                title: "proposal to start".to_string(),
-                description: String::new(),
-                plan: String::new(),
-                execution_summary: String::new(),
-                context_files: Vec::new(),
-                workspace_path: None,
-                created_by: Some("agent".to_string()),
-                assigned_to: Some("agent".to_string()),
-                status: TaskStatus::Proposed,
-                priority: TaskPriority::Medium,
-                task_type: TaskType::Task,
-                branch: None,
-                pr_number: None,
-                proposed_by: Some("agent".to_string()),
-                comments: Vec::new(),
-            })
+            .add_task_with_status("proposal to start", TaskStatus::Proposed)
             .expect("create proposed task");
 
         let started = runtime

--- a/orbit-core/src/runtime/builder.rs
+++ b/orbit-core/src/runtime/builder.rs
@@ -91,15 +91,15 @@ fn build_context_common(
     let task_approval_required_for_agent = runtime_config.task_approval.required_for_agent;
     let task_delegate_approval = runtime_config.task_approval.delegate_approval;
 
-    Ok(OrbitContext {
+    Ok(OrbitContext::new(
         data_root,
         task_store,
         activity_store,
         job_store,
         tool_store,
         audit_event_store,
-        policy: PolicyEngine::new_local_default_allow(),
-        registry: Arc::new(registry),
+        PolicyEngine::new_local_default_allow(),
+        Arc::new(registry),
         skill_catalog,
         execution_env_policy,
         codex_execution_policy,
@@ -108,7 +108,7 @@ fn build_context_common(
         actor,
         task_approval_required_for_agent,
         task_delegate_approval,
-    })
+    ))
 }
 fn load_external_tools(store: &Store, registry: &mut ToolRegistry) -> Result<(), OrbitError> {
     let stored_tools = store.list_tools()?;

--- a/orbit-core/src/runtime/engine.rs
+++ b/orbit-core/src/runtime/engine.rs
@@ -142,10 +142,10 @@ fn execute_commit_request_if_present(
     let files = commit.files.clone();
     let message = commit.message.clone();
 
-    let repo_root = paths::find_git_repo_root(&runtime.context.data_root).ok_or_else(|| {
+    let repo_root = paths::find_git_repo_root(runtime.data_root_path()).ok_or_else(|| {
         OrbitError::Execution(format!(
             "cannot locate git repository root from Orbit data root '{}'",
-            runtime.context.data_root.display()
+            runtime.data_root_path().display()
         ))
     })?;
     let repo_root_str = repo_root.to_string_lossy().to_string();
@@ -198,9 +198,7 @@ impl RuntimeHost for OrbitRuntime {
 
 impl JobRunHost for OrbitRuntime {
     fn list_pending_or_running_job_runs(&self, job_id: &str) -> Result<Vec<JobRun>, OrbitError> {
-        self.context
-            .job_store
-            .list_pending_or_running_job_runs(job_id)
+        self.list_pending_or_running_job_runs_record(job_id)
     }
 
     fn insert_job_run(
@@ -209,9 +207,7 @@ impl JobRunHost for OrbitRuntime {
         attempt: u32,
         scheduled_at: DateTime<Utc>,
     ) -> Result<JobRun, OrbitError> {
-        self.context
-            .job_store
-            .insert_job_run(job_id, attempt, scheduled_at)
+        self.insert_job_run_record(job_id, attempt, scheduled_at)
     }
 
     fn mark_job_run_running(
@@ -219,9 +215,7 @@ impl JobRunHost for OrbitRuntime {
         run_id: &str,
         started_at: DateTime<Utc>,
     ) -> Result<bool, OrbitError> {
-        self.context
-            .job_store
-            .mark_job_run_running(run_id, started_at)
+        self.mark_job_run_running_record(run_id, started_at)
     }
 
     fn complete_job_run_step(
@@ -229,7 +223,7 @@ impl JobRunHost for OrbitRuntime {
         run_id: &str,
         params: &JobRunStepParams,
     ) -> Result<bool, OrbitError> {
-        self.context.job_store.complete_job_run_step(run_id, params)
+        self.complete_job_run_step_record(run_id, params)
     }
 
     fn finalize_job_run(
@@ -239,13 +233,11 @@ impl JobRunHost for OrbitRuntime {
         finished_at: DateTime<Utc>,
         duration_ms: Option<u64>,
     ) -> Result<bool, OrbitError> {
-        self.context
-            .job_store
-            .finalize_job_run(run_id, state, finished_at, duration_ms)
+        self.finalize_job_run_record(run_id, state, finished_at, duration_ms)
     }
 
     fn get_job_run(&self, run_id: &str) -> Result<Option<JobRun>, OrbitError> {
-        self.context.job_store.get_job_run(run_id)
+        self.get_job_run_record(run_id)
     }
 }
 
@@ -258,27 +250,26 @@ impl EnvironmentHost for OrbitRuntime {
         Ok(AgentConfig::cli(agent_cli.to_string())
             .with_model(model)
             .with_codex_execution(
-                self.context.codex_execution_policy.sandbox(),
-                self.context.codex_execution_policy.approval_policy(),
+                self.codex_execution_policy().sandbox(),
+                self.codex_execution_policy().approval_policy(),
             ))
     }
 
     fn execution_environment_mode(&self, env_extra: &[String]) -> EnvironmentMode {
-        if self.context.execution_env_policy.inherit() {
+        if self.execution_env_policy().inherit() {
             // Full inheritance: ORBIT_ROOT resolution relies on find_git_repo_root
             // handling git worktrees correctly (which it does after the worktree fix).
             EnvironmentMode::Inherit
         } else {
             let mut env = self
-                .context
-                .execution_env_policy
+                .execution_env_policy()
                 .hydrated_allowlist_env_with_extras(env_extra);
             // Explicitly inject ORBIT_ROOT so that any orbit CLI invocation made
             // by the agent subprocess (e.g., `orbit tool run orbit.task.*`) resolves
             // to the same data root regardless of its working directory. Without this,
             // a Codex or Claude agent running inside a git worktree would either create
             // a spurious .orbit/ in the worktree or resolve to the wrong database.
-            let orbit_root = self.context.data_root.to_string_lossy().into_owned();
+            let orbit_root = self.data_root_path().to_string_lossy().into_owned();
             if !env.iter().any(|(k, _)| k == "ORBIT_ROOT") {
                 env.push(("ORBIT_ROOT".to_string(), orbit_root));
             }
@@ -287,15 +278,12 @@ impl EnvironmentHost for OrbitRuntime {
     }
 
     fn cli_command_environment(&self, env_extra: &[String]) -> Vec<(String, String)> {
-        self.context
-            .execution_env_policy
+        self.execution_env_policy()
             .hydrated_cli_command_env_with_extras(env_extra)
     }
 
     fn missing_required_environment_vars(&self, required_env_vars: &[&str]) -> Vec<String> {
-        self.context
-            .execution_env_policy
-            .missing_required(required_env_vars)
+        self.execution_env_policy().missing_required(required_env_vars)
     }
 }
 
@@ -360,7 +348,7 @@ impl TaskHost for OrbitRuntime {
         update: TaskAutomationUpdate,
     ) -> Result<(), OrbitError> {
         let _ = self.with_mutation(|| {
-            let task = self.context.task_store.update_task(
+            let task = self.update_task_record(
                 task_id,
                 StoreTaskUpdateParams {
                     actor: "agent".to_string(),
@@ -408,10 +396,10 @@ fn activity_envelope_json(activity: &Activity) -> Value {
 }
 
 fn current_repo_root(runtime: &OrbitRuntime) -> Result<String, OrbitError> {
-    let repo_root = paths::find_git_repo_root(&runtime.context.data_root).ok_or_else(|| {
+    let repo_root = paths::find_git_repo_root(runtime.data_root_path()).ok_or_else(|| {
         OrbitError::Execution(format!(
             "cannot locate git repository root from Orbit data root '{}'",
-            runtime.context.data_root.display()
+            runtime.data_root_path().display()
         ))
     })?;
     Ok(repo_root.to_string_lossy().to_string())

--- a/orbit-core/src/runtime/mod.rs
+++ b/orbit-core/src/runtime/mod.rs
@@ -10,7 +10,15 @@ use std::path::{Path, PathBuf};
 
 use chrono::Utc;
 use orbit_policy::PolicyEngine;
-use orbit_types::{Audit, Job, OrbitError, OrbitEvent};
+use orbit_store::{
+    ActivityCreateParams, ActivityUpdateParams, AuditEventFilter, AuditEventInsertParams,
+    JobCreateParams, JobRunQuery, JobRunStepParams, JobUpdateParams, TaskCreateParams,
+    TaskUpdateParams as StoreTaskUpdateParams,
+};
+use orbit_types::{
+    Activity, Audit, AuditEvent, Job, JobRun, JobRunState, OrbitError, OrbitEvent,
+    StoredTool, Task, TaskPriority, TaskStatus,
+};
 use serde::Deserialize;
 use serde_json::Value;
 
@@ -21,7 +29,7 @@ use crate::paths;
 
 #[derive(Clone)]
 pub struct OrbitRuntime {
-    pub(crate) context: OrbitContext,
+    context: OrbitContext,
     pub event_log: event_bus::EventLog,
 }
 
@@ -52,12 +60,12 @@ impl OrbitRuntime {
     }
 
     pub fn with_policy(mut self, policy: PolicyEngine) -> Self {
-        self.context.policy = policy;
+        self.context.set_policy(policy);
         self
     }
 
     pub fn with_actor(mut self, actor: ActorIdentity) -> Self {
-        self.context.actor = actor;
+        self.context.set_actor(actor);
         self
     }
 
@@ -74,28 +82,28 @@ impl OrbitRuntime {
     }
 
     pub fn get_job(&self, job_id: &str) -> Result<Option<Job>, OrbitError> {
-        self.context.job_store.get_job(job_id)
+        self.get_job_record(job_id)
     }
 
     pub fn execution_env_config(&self) -> (bool, Vec<String>) {
         (
-            self.context.execution_env_policy.inherit(),
-            self.context.execution_env_policy.pass().to_vec(),
+            self.context.execution_env_policy().inherit(),
+            self.context.execution_env_policy().pass().to_vec(),
         )
     }
 
     pub fn codex_execution_config(&self) -> (String, Option<String>) {
         (
-            self.context.codex_execution_policy.sandbox().to_string(),
+            self.context.codex_execution_policy().sandbox().to_string(),
             self.context
-                .codex_execution_policy
+                .codex_execution_policy()
                 .approval_policy()
                 .map(ToString::to_string),
         )
     }
 
     pub fn data_root(&self) -> PathBuf {
-        self.context.data_root.clone()
+        self.context.data_root().to_path_buf()
     }
 
     /// Returns the runtime config file at `<data_root>/config.toml`
@@ -105,19 +113,292 @@ impl OrbitRuntime {
     }
 
     pub fn persistence_config_json(&self) -> Value {
-        self.context.persistence.as_json_value()
+        self.context.persistence().as_json_value()
     }
 
     pub fn task_approval_required_for_agent(&self) -> bool {
-        self.context.task_approval_required_for_agent
+        self.context.task_approval_required_for_agent()
     }
 
     pub fn task_delegate_approval(&self) -> bool {
-        self.context.task_delegate_approval
+        self.context.task_delegate_approval()
     }
 
     pub fn user_name(&self) -> &str {
-        &self.context.user_name
+        self.context.user_name()
+    }
+
+    pub(crate) fn actor(&self) -> &ActorIdentity {
+        self.context.actor()
+    }
+
+    pub(crate) fn actor_label(&self) -> &str {
+        self.context.actor().label.as_str()
+    }
+
+    pub(crate) fn policy_engine(&self) -> &PolicyEngine {
+        self.context.policy()
+    }
+
+    pub(crate) fn tool_registry(&self) -> &orbit_tools::ToolRegistry {
+        self.context.registry()
+    }
+
+    pub(crate) fn skill_catalog(&self) -> &crate::skill_catalog::SkillCatalog {
+        self.context.skill_catalog()
+    }
+
+    pub(crate) fn data_root_path(&self) -> &Path {
+        self.context.data_root()
+    }
+
+    pub(crate) fn execution_env_policy(&self) -> &crate::config::ExecutionEnvPolicy {
+        self.context.execution_env_policy()
+    }
+
+    pub(crate) fn codex_execution_policy(&self) -> &crate::config::CodexExecutionPolicy {
+        self.context.codex_execution_policy()
+    }
+
+    pub(crate) fn create_task_record(
+        &self,
+        params: TaskCreateParams,
+    ) -> Result<Task, OrbitError> {
+        self.context.task_store().create_task(params)
+    }
+
+    pub(crate) fn get_task_record(&self, id: &str) -> Result<Option<Task>, OrbitError> {
+        self.context.task_store().get_task(id)
+    }
+
+    pub(crate) fn list_task_records(&self) -> Result<Vec<Task>, OrbitError> {
+        self.context.task_store().list_tasks()
+    }
+
+    pub(crate) fn list_task_records_filtered(
+        &self,
+        status: Option<TaskStatus>,
+        priority: Option<TaskPriority>,
+    ) -> Result<Vec<Task>, OrbitError> {
+        self.context.task_store().list_tasks_filtered(status, priority)
+    }
+
+    pub(crate) fn update_task_record(
+        &self,
+        id: &str,
+        params: StoreTaskUpdateParams,
+    ) -> Result<Task, OrbitError> {
+        self.context.task_store().update_task(id, params)
+    }
+
+    pub(crate) fn delete_task_record(&self, id: &str) -> Result<bool, OrbitError> {
+        self.context.task_store().delete_task(id)
+    }
+
+    pub(crate) fn search_task_records(&self, query: &str) -> Result<Vec<Task>, OrbitError> {
+        self.context.task_store().search_tasks(query)
+    }
+
+    pub(crate) fn add_activity_record(
+        &self,
+        params: ActivityCreateParams,
+    ) -> Result<Activity, OrbitError> {
+        self.context.activity_store().add_activity(params)
+    }
+
+    pub(crate) fn list_activity_records(
+        &self,
+        include_inactive: bool,
+    ) -> Result<Vec<Activity>, OrbitError> {
+        self.context
+            .activity_store()
+            .list_activities(include_inactive)
+    }
+
+    pub(crate) fn get_activity_record(&self, id: &str) -> Result<Option<Activity>, OrbitError> {
+        self.context.activity_store().get_activity(id)
+    }
+
+    pub(crate) fn update_activity_record(
+        &self,
+        id: &str,
+        params: ActivityUpdateParams,
+    ) -> Result<Activity, OrbitError> {
+        self.context.activity_store().update_activity(id, params)
+    }
+
+    pub(crate) fn disable_activity_record(&self, id: &str) -> Result<bool, OrbitError> {
+        self.context.activity_store().disable_activity(id)
+    }
+
+    pub(crate) fn add_job_record(&self, params: JobCreateParams) -> Result<Job, OrbitError> {
+        self.context.job_store().add_job(params)
+    }
+
+    pub(crate) fn update_job_record(
+        &self,
+        job_id: &str,
+        params: JobUpdateParams,
+    ) -> Result<Job, OrbitError> {
+        self.context.job_store().update_job(job_id, params)
+    }
+
+    pub(crate) fn mark_job_disabled_record(&self, job_id: &str) -> Result<bool, OrbitError> {
+        self.context.job_store().mark_job_disabled(job_id)
+    }
+
+    pub(crate) fn list_job_records(&self, include_disabled: bool) -> Result<Vec<Job>, OrbitError> {
+        self.context.job_store().list_jobs(include_disabled)
+    }
+
+    pub(crate) fn get_job_record(&self, job_id: &str) -> Result<Option<Job>, OrbitError> {
+        self.context.job_store().get_job(job_id)
+    }
+
+    pub(crate) fn list_job_runs_filtered_record(
+        &self,
+        query: &JobRunQuery,
+    ) -> Result<Vec<JobRun>, OrbitError> {
+        self.context.job_store().list_job_runs_filtered(query)
+    }
+
+    pub(crate) fn list_pending_or_running_job_runs_record(
+        &self,
+        job_id: &str,
+    ) -> Result<Vec<JobRun>, OrbitError> {
+        self.context
+            .job_store()
+            .list_pending_or_running_job_runs(job_id)
+    }
+
+    pub(crate) fn insert_job_run_record(
+        &self,
+        job_id: &str,
+        attempt: u32,
+        scheduled_at: chrono::DateTime<chrono::Utc>,
+    ) -> Result<JobRun, OrbitError> {
+        self.context
+            .job_store()
+            .insert_job_run(job_id, attempt, scheduled_at)
+    }
+
+    pub(crate) fn mark_job_run_running_record(
+        &self,
+        run_id: &str,
+        started_at: chrono::DateTime<chrono::Utc>,
+    ) -> Result<bool, OrbitError> {
+        self.context
+            .job_store()
+            .mark_job_run_running(run_id, started_at)
+    }
+
+    pub(crate) fn complete_job_run_step_record(
+        &self,
+        run_id: &str,
+        params: &JobRunStepParams,
+    ) -> Result<bool, OrbitError> {
+        self.context.job_store().complete_job_run_step(run_id, params)
+    }
+
+    pub(crate) fn finalize_job_run_record(
+        &self,
+        run_id: &str,
+        state: JobRunState,
+        finished_at: chrono::DateTime<chrono::Utc>,
+        duration_ms: Option<u64>,
+    ) -> Result<bool, OrbitError> {
+        self.context
+            .job_store()
+            .finalize_job_run(run_id, state, finished_at, duration_ms)
+    }
+
+    pub(crate) fn get_job_run_record(&self, run_id: &str) -> Result<Option<JobRun>, OrbitError> {
+        self.context.job_store().get_job_run(run_id)
+    }
+
+    pub(crate) fn list_job_run_records(&self, job_id: &str) -> Result<Vec<JobRun>, OrbitError> {
+        self.context.job_store().list_job_runs(job_id)
+    }
+
+    pub(crate) fn archive_job_run_record(&self, run_id: &str) -> Result<String, OrbitError> {
+        self.context.job_store().archive_job_run(run_id)
+    }
+
+    pub(crate) fn delete_job_run_record(&self, run_id: &str) -> Result<String, OrbitError> {
+        self.context.job_store().delete_job_run(run_id)
+    }
+
+    pub(crate) fn list_tool_records(&self) -> Result<Vec<StoredTool>, OrbitError> {
+        self.context.tool_store().list_tools()
+    }
+
+    pub(crate) fn get_tool_record(&self, name: &str) -> Result<Option<StoredTool>, OrbitError> {
+        self.context.tool_store().get_tool(name)
+    }
+
+    pub(crate) fn insert_tool_record(&self, tool: &StoredTool) -> Result<(), OrbitError> {
+        self.context.tool_store().insert_tool(tool)
+    }
+
+    pub(crate) fn delete_tool_record(&self, name: &str) -> Result<bool, OrbitError> {
+        self.context.tool_store().delete_tool(name)
+    }
+
+    pub(crate) fn set_tool_enabled_record(
+        &self,
+        name: &str,
+        enabled: bool,
+    ) -> Result<bool, OrbitError> {
+        self.context.tool_store().set_tool_enabled(name, enabled)
+    }
+
+    pub(crate) fn list_audit_event_records(
+        &self,
+        filter: &AuditEventFilter,
+    ) -> Result<Vec<AuditEvent>, OrbitError> {
+        self.context.audit_event_store().list_audit_events(filter)
+    }
+
+    pub(crate) fn get_audit_event_record(&self, id: i64) -> Result<Option<AuditEvent>, OrbitError> {
+        self.context.audit_event_store().get_audit_event(id)
+    }
+
+    pub(crate) fn prune_audit_event_records(
+        &self,
+        older_than: &chrono::DateTime<chrono::Utc>,
+    ) -> Result<usize, OrbitError> {
+        self.context
+            .audit_event_store()
+            .prune_audit_events(older_than)
+    }
+
+    pub(crate) fn audit_event_stats_record(
+        &self,
+        since: Option<&chrono::DateTime<chrono::Utc>>,
+        tool: Option<&str>,
+    ) -> Result<(i64, i64, i64, i64, f64, i64), OrbitError> {
+        self.context
+            .audit_event_store()
+            .get_audit_event_stats(since, tool)
+    }
+
+    pub(crate) fn audit_event_durations_record(
+        &self,
+        since: Option<&chrono::DateTime<chrono::Utc>>,
+        tool: Option<&str>,
+    ) -> Result<Vec<i64>, OrbitError> {
+        self.context
+            .audit_event_store()
+            .get_audit_event_durations(since, tool)
+    }
+
+    pub(crate) fn insert_audit_event_record(
+        &self,
+        params: &AuditEventInsertParams,
+    ) -> Result<(), OrbitError> {
+        self.context
+            .audit_event_store()
+            .insert_audit_event_record(params)
     }
 }
 

--- a/orbit-core/src/runtime/pipeline.rs
+++ b/orbit-core/src/runtime/pipeline.rs
@@ -46,7 +46,7 @@ impl OrbitRuntime {
             )));
         }
 
-        let decision = self.context.policy.evaluate(&PolicyContext {
+        let decision = self.policy_engine().evaluate(&PolicyContext {
             entrypoint: "cli".to_string(),
             tool_name: Some(name.to_string()),
             role,
@@ -66,8 +66,7 @@ impl OrbitRuntime {
             }
             PolicyDecision::Allow => {
                 let output = self
-                    .context
-                    .registry
+                    .tool_registry()
                     .execute(name, &tool_context, input)
                     .map_err(redact_sensitive_env_error)?;
                 let output = redact_sensitive_env_json(output);
@@ -90,12 +89,11 @@ impl OrbitRuntime {
         self.check_tool_enabled(name)?;
 
         let schema = self
-            .context
-            .registry
+            .tool_registry()
             .get_schema(name)
             .ok_or_else(|| OrbitError::ToolNotFound(name.to_string()))?;
 
-        let decision = self.context.policy.evaluate(&PolicyContext {
+        let decision = self.policy_engine().evaluate(&PolicyContext {
             entrypoint: "cli".to_string(),
             tool_name: Some(name.to_string()),
             role: Role::Admin,
@@ -127,7 +125,7 @@ impl OrbitRuntime {
     }
 
     fn check_tool_enabled(&self, name: &str) -> Result<(), OrbitError> {
-        if let Some(stored) = self.context.tool_store.get_tool(name)?
+        if let Some(stored) = self.get_tool_record(name)?
             && !stored.enabled
         {
             return Err(OrbitError::Execution(format!(


### PR DESCRIPTION
## Changes
refactor: Make OrbitContext fields private and enforce access through OrbitRuntime [T20260320-002851]

Implemented `OrbitContext` encapsulation in `orbit-core` by making its fields private, privatizing `OrbitRuntime.context`, routing internal callers through runtime-owned access helpers, and replacing test store seeding with a test-only `OrbitRuntime::add_task_with_status` helper so task setup no longer bypasses runtime domain rules. Verified with `cargo check -p orbit-core`, `cargo test -p orbit-core`, `cargo test --workspace`, `cargo clippy --workspace -- -D warnings`, and a grep confirming no non-runtime direct store access via `context.(task_store|activity_store|job_store|tool_store|audit_event_store)` remains.

## Branch Freshness
- Base ref: `origin/agent-main`
- Head ref: `orbit/T20260320-002851`
- Behind base: 0
- Ahead of base: 1

## Files Changed
- `orbit-core/src/command/activity.rs`
- `orbit-core/src/command/audit_event.rs`
- `orbit-core/src/command/job.rs`
- `orbit-core/src/command/job_run.rs`
- `orbit-core/src/command/skill.rs`
- `orbit-core/src/command/task.rs`
- `orbit-core/src/command/tool.rs`
- `orbit-core/src/context.rs`
- `orbit-core/src/lib.rs`
- `orbit-core/src/runtime/builder.rs`
- `orbit-core/src/runtime/engine.rs`
- `orbit-core/src/runtime/mod.rs`
- `orbit-core/src/runtime/pipeline.rs`