### PR TITLE
fix: Always fetch review decision from GitHub in merge_pr_from_task [T20260320-021158]

### DIFF
--- a/orbit-engine/src/executor/automation.rs
+++ b/orbit-engine/src/executor/automation.rs
@@ -310,7 +310,7 @@ fn merge_pr_from_task<H: RuntimeHost + TaskHost + ?Sized>(
             ))
         })?;
     let base = input_string_field(input, "base").unwrap_or_else(|| "agent-main".to_string());
-    let review_decision = resolve_review_decision(input, &repo_root, &pr_number)?;
+    let review_decision = resolve_review_decision(&repo_root, &pr_number)?;
     if review_decision != "APPROVED" {
         return Err(OrbitError::Execution(format!(
             "pull request '{pr_number}' is not approved (review_decision={review_decision})"
@@ -568,17 +568,7 @@ fn input_repo_root(input: &Value) -> Result<String, OrbitError> {
         .ok_or_else(|| OrbitError::InvalidInput("missing required input.repo_root".to_string()))
 }
 
-fn resolve_review_decision(
-    input: &Value,
-    repo_root: &Path,
-    pr_number: &str,
-) -> Result<String, OrbitError> {
-    if let Some(decision) =
-        input_string_field(input, "review_decision").or_else(|| input_string_field(input, "action"))
-    {
-        return Ok(normalize_review_decision(&decision));
-    }
-
+fn resolve_review_decision(repo_root: &Path, pr_number: &str) -> Result<String, OrbitError> {
     fetch_review_decision_from_gh(repo_root, pr_number)
 }
 
@@ -961,4 +951,326 @@ fn json_number_to_string(value: &Value) -> Option<String> {
         .map(|number| number.to_string())
         .or_else(|| value.as_u64().map(|number| number.to_string()))
         .or_else(|| value.as_str().map(ToOwned::to_owned))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::cell::RefCell;
+    use std::collections::HashMap;
+    use std::fs;
+    use std::path::Path;
+    use std::process::Command;
+    use std::sync::{Mutex, OnceLock};
+
+    use chrono::Utc;
+    use orbit_tools::ToolContext;
+    use orbit_types::{Activity, JobTargetType, OrbitEvent, Role, Task, TaskPriority};
+    use serde_json::json;
+    use tempfile::TempDir;
+
+    use super::*;
+    use crate::context::{RuntimeHost, TaskAutomationUpdate, TaskHost};
+
+    #[cfg(unix)]
+    use std::os::unix::fs::PermissionsExt;
+
+    #[derive(Debug, Clone)]
+    struct ToolInvocation {
+        name: String,
+        input: Value,
+        role: Role,
+        tool_context: ToolContext,
+    }
+
+    #[derive(Default)]
+    struct FakeHost {
+        task: RefCell<Option<Task>>,
+        tool_invocations: RefCell<Vec<ToolInvocation>>,
+        automation_updates: RefCell<Vec<TaskAutomationUpdate>>,
+    }
+
+    impl FakeHost {
+        fn new(task: Task) -> Self {
+            Self {
+                task: RefCell::new(Some(task)),
+                tool_invocations: RefCell::new(Vec::new()),
+                automation_updates: RefCell::new(Vec::new()),
+            }
+        }
+    }
+
+    impl TaskHost for FakeHost {
+        fn get_task(&self, task_id: &str) -> Result<Task, OrbitError> {
+            let task = self
+                .task
+                .borrow()
+                .clone()
+                .ok_or_else(|| OrbitError::TaskNotFound(task_id.to_string()))?;
+            if task.id != task_id {
+                return Err(OrbitError::TaskNotFound(task_id.to_string()));
+            }
+            Ok(task)
+        }
+
+        fn start_task(
+            &self,
+            _task_id: &str,
+            _note: Option<String>,
+            _comment: Option<String>,
+        ) -> Result<Task, OrbitError> {
+            unimplemented!("start_task is not used in automation merge tests")
+        }
+
+        fn update_task_from_activity(
+            &self,
+            _task_id: &str,
+            _status: TaskStatus,
+            _execution_summary: Option<String>,
+            _files_changed: Vec<String>,
+            _comment: Option<String>,
+            _note: Option<String>,
+        ) -> Result<Task, OrbitError> {
+            unimplemented!("update_task_from_activity is not used in automation merge tests")
+        }
+
+        fn apply_task_automation_update(
+            &self,
+            _task_id: &str,
+            update: TaskAutomationUpdate,
+        ) -> Result<(), OrbitError> {
+            self.automation_updates.borrow_mut().push(update);
+            Ok(())
+        }
+    }
+
+    impl RuntimeHost for FakeHost {
+        fn record_event(&self, _event: OrbitEvent) -> Result<(), OrbitError> {
+            Ok(())
+        }
+
+        fn repo_root(&self) -> Result<String, OrbitError> {
+            Err(OrbitError::Execution(
+                "repo_root is not used in automation merge tests".to_string(),
+            ))
+        }
+
+        fn validate_activity_target_exists(
+            &self,
+            _target_type: JobTargetType,
+            _target_id: &str,
+        ) -> Result<Activity, OrbitError> {
+            unimplemented!(
+                "validate_activity_target_exists is not used in automation merge tests"
+            )
+        }
+
+        fn run_tool_with_context_and_role(
+            &self,
+            name: &str,
+            input: Value,
+            role: Role,
+            tool_context: ToolContext,
+        ) -> Result<Value, OrbitError> {
+            self.tool_invocations.borrow_mut().push(ToolInvocation {
+                name: name.to_string(),
+                input,
+                role,
+                tool_context,
+            });
+            Ok(json!({}))
+        }
+    }
+
+    struct PathGuard {
+        _lock: std::sync::MutexGuard<'static, ()>,
+        original_path: Option<String>,
+    }
+
+    impl Drop for PathGuard {
+        fn drop(&mut self) {
+            match self.original_path.take() {
+                Some(path) => unsafe { std::env::set_var("PATH", path) },
+                None => unsafe { std::env::remove_var("PATH") },
+            }
+        }
+    }
+
+    fn path_lock() -> &'static Mutex<()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
+    }
+
+    fn prepend_path(dir: &Path) -> String {
+        let mut entries = vec![dir.to_string_lossy().to_string()];
+        if let Some(existing) = std::env::var_os("PATH") {
+            entries.push(existing.to_string_lossy().to_string());
+        }
+        entries.join(":")
+    }
+
+    fn install_fake_gh(bin_dir: &Path, decisions: &[(&str, &str)]) {
+        let decision_map = decisions
+            .iter()
+            .map(|(pr_number, decision)| {
+                (
+                    pr_number.to_string(),
+                    format!("{{\"reviewDecision\":\"{decision}\"}}"),
+                )
+            })
+            .collect::<HashMap<_, _>>();
+        let cases = decision_map
+            .iter()
+            .map(|(pr_number, payload)| {
+                format!("  {pr_number}) printf '%s' '{payload}'; exit 0 ;;\n")
+            })
+            .collect::<String>();
+        let script = format!(
+            concat!(
+                "#!/bin/sh\n",
+                "if [ \"$1\" = \"pr\" ] && [ \"$2\" = \"view\" ] && [ \"$4\" = \"--json\" ] && [ \"$5\" = \"reviewDecision\" ]; then\n",
+                "  case \"$3\" in\n",
+                "{cases}",
+                "  esac\n",
+                "fi\n",
+                "printf '%s\\n' \"unexpected gh args: $*\" >&2\n",
+                "exit 1\n"
+            ),
+            cases = cases
+        );
+        let gh_path = bin_dir.join("gh");
+        fs::write(&gh_path, script).expect("write fake gh");
+        #[cfg(unix)]
+        fs::set_permissions(&gh_path, fs::Permissions::from_mode(0o755)).expect("chmod gh");
+    }
+
+    fn use_fake_gh(decisions: &[(&str, &str)]) -> (TempDir, PathGuard) {
+        let bin_dir = tempfile::tempdir().expect("temp gh dir");
+        install_fake_gh(bin_dir.path(), decisions);
+        let lock = path_lock()
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let original_path = std::env::var("PATH").ok();
+        unsafe { std::env::set_var("PATH", prepend_path(bin_dir.path())) };
+        (
+            bin_dir,
+            PathGuard {
+                _lock: lock,
+                original_path,
+            },
+        )
+    }
+
+    fn git(repo_root: &Path, args: &[&str]) {
+        let status = Command::new("git")
+            .args(args)
+            .current_dir(repo_root)
+            .status()
+            .expect("run git");
+        assert!(status.success(), "git {:?} failed", args);
+    }
+
+    fn init_repo() -> TempDir {
+        let repo_dir = tempfile::tempdir().expect("temp repo dir");
+        git(repo_dir.path(), &["init", "--initial-branch=agent-main"]);
+        git(repo_dir.path(), &["config", "user.name", "Orbit Tests"]);
+        git(repo_dir.path(), &["config", "user.email", "orbit-tests@example.com"]);
+        fs::write(repo_dir.path().join("README.md"), "orbit\n").expect("write readme");
+        git(repo_dir.path(), &["add", "README.md"]);
+        git(repo_dir.path(), &["commit", "-m", "init"]);
+        git(repo_dir.path(), &["checkout", "-b", "orbit/T20260320-021158"]);
+        git(repo_dir.path(), &["checkout", "agent-main"]);
+        repo_dir
+    }
+
+    fn test_task(repo_root: &Path) -> Task {
+        Task {
+            id: "T20260320-021158".to_string(),
+            title: "merge_pr_from_task uses GitHub review decision".to_string(),
+            description: "desc".to_string(),
+            plan: "plan".to_string(),
+            execution_summary: String::new(),
+            context_files: vec!["orbit-engine/src/executor/automation.rs".to_string()],
+            workspace_path: Some(repo_root.to_string_lossy().to_string()),
+            repo_root: Some(repo_root.to_string_lossy().to_string()),
+            assigned_to: None,
+            created_by: Some("test".to_string()),
+            status: TaskStatus::Review,
+            priority: TaskPriority::High,
+            task_type: TaskType::Issue,
+            branch: Some("orbit/T20260320-021158".to_string()),
+            commit_message: None,
+            changed_files: None,
+            pr_number: Some("18".to_string()),
+            proposed_by: None,
+            comments: vec![],
+            history: vec![],
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+        }
+    }
+
+    #[test]
+    fn merge_pr_from_task_prefers_github_approval_over_agent_reported_commented() {
+        let repo_dir = init_repo();
+        let (_gh_dir, _path_guard) = use_fake_gh(&[("18", "APPROVED")]);
+        let host = FakeHost::new(test_task(repo_dir.path()));
+        let canonical_repo_root = repo_dir.path().canonicalize().expect("canonical repo root");
+
+        let result = merge_pr_from_task(
+            &host,
+            &json!({
+                "task_id": "T20260320-021158",
+                "repo_root": repo_dir.path().to_string_lossy().to_string(),
+                "review_decision": "COMMENTED",
+                "action": "COMMENTED",
+                "pr_number": "18",
+            }),
+        )
+        .expect("merge should succeed");
+
+        assert_eq!(result["merged"], json!(true));
+        assert_eq!(result["review_decision"], json!("APPROVED"));
+
+        let tool_invocations = host.tool_invocations.borrow();
+        assert_eq!(tool_invocations.len(), 1);
+        assert_eq!(tool_invocations[0].name, "github.pr.merge");
+        assert_eq!(tool_invocations[0].input["pr"], json!("18"));
+        assert_eq!(tool_invocations[0].input["strategy"], json!("squash"));
+        assert_eq!(tool_invocations[0].role, Role::Admin);
+        assert_eq!(
+            tool_invocations[0].tool_context.cwd.as_deref(),
+            Some(canonical_repo_root.to_string_lossy().as_ref())
+        );
+
+        let automation_updates = host.automation_updates.borrow();
+        assert_eq!(automation_updates.len(), 1);
+        assert_eq!(automation_updates[0].status, Some(TaskStatus::Done));
+        assert_eq!(automation_updates[0].pr_number.as_deref(), Some("18"));
+    }
+
+    #[test]
+    fn merge_pr_from_task_blocks_when_github_reports_commented_even_if_agent_reported_approved() {
+        let repo_dir = init_repo();
+        let (_gh_dir, _path_guard) = use_fake_gh(&[("18", "COMMENTED")]);
+        let host = FakeHost::new(test_task(repo_dir.path()));
+
+        let error = merge_pr_from_task(
+            &host,
+            &json!({
+                "task_id": "T20260320-021158",
+                "repo_root": repo_dir.path().to_string_lossy().to_string(),
+                "review_decision": "APPROVED",
+                "action": "APPROVE",
+                "pr_number": "18",
+            }),
+        )
+        .expect_err("merge should fail");
+
+        assert_eq!(
+            error.to_string(),
+            "execution failed: pull request '18' is not approved (review_decision=COMMENTED)"
+        );
+        assert!(host.tool_invocations.borrow().is_empty());
+        assert!(host.automation_updates.borrow().is_empty());
+    }
 }


### PR DESCRIPTION
## Summary

- Removes the agent-output shortcut in `resolve_review_decision` that allowed a `review_pr` step result of `COMMENTED` to block the merge gate even when GitHub's actual `reviewDecision` was `APPROVED`
- `merge_pr_from_task` now always calls `fetch_review_decision_from_gh` — GitHub is the sole authoritative source for the merge decision
- Adds two regression tests covering both directions

## Root cause

`resolve_review_decision` checked `input.review_decision` / `input.action` (from the previous step's agent output) first, short-circuiting before GitHub. If the `review_pr` agent emitted `COMMENTED`, the merge gate failed immediately regardless of actual GitHub state.

## Test plan
- [ ] `cargo test -p orbit-engine` passes (new regression tests in `automation.rs`)
- [ ] `cargo clippy --workspace -- -D warnings` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)