### PR TITLE
Job failure: job_task_pipeline [AGENT_PROTOCOL_VIOLATION]

### DIFF
--- a/orbit-core/src/runtime/engine.rs
+++ b/orbit-core/src/runtime/engine.rs
@@ -90,6 +90,11 @@ fn validate_skill_output_schema(
         return Ok(());
     }
     let skills = runtime.resolve_activity_skill_refs(&skill_refs)?;
+    // If no referenced skill defines an output schema, the skill_refs are context-only;
+    // there is no structured output contract to enforce here.
+    if skills.iter().all(|s| s.output_schema.is_none()) {
+        return Ok(());
+    }
     let Some(result) = envelope.result.as_ref() else {
         return Err(OrbitError::AgentProtocolViolation(
             "success response must include result payload".to_string(),


### PR DESCRIPTION
## Changes
feat: Job failure: job_task_pipeline [AGENT_PROTOCOL_VIOLATION] [T20260320-165145]

Fixed a false-positive AGENT_PROTOCOL_VIOLATION in `validate_skill_output_schema` that was incorrectly requiring a non-null `result` payload whenever an activity referenced any skill_refs — even context-only skills with no output schema. The `implement_change` activity uses `skill_refs: ["orbit"]` for instruction context, but the `orbit` skill has no `meta.json`/output_schema. The validation should only enforce non-null result when at least one referenced skill actually defines an output schema to validate against.

## Branch Freshness
- Base ref: `origin/agent-main`
- Head ref: `orbit/T20260320-165145`
- Behind base: 0
- Ahead of base: 1

## Files Changed
- `orbit-core/src/runtime/engine.rs`