### PR TITLE
feat: conflict-aware dispatch using context_files [T20260320-041631]

### DIFF
--- a/orbit-core/assets/activities/dispatch_task.yaml
+++ b/orbit-core/assets/activities/dispatch_task.yaml
@@ -19,7 +19,9 @@ activity:
        {"task_id": "None", "comment": "No tasks available. Nothing to dispatch."}
 
     2. Call orbit.task.list with status: "in_progress" to retrieve tasks currently being worked on.
-       For each in-progress task, call orbit.task.show to read its description and plan.
+       Collect the union of all context_files from every in-progress task — this is the
+       "blocked file set". For each in-progress task, call orbit.task.show if you need
+       its full context_files list.
 
     3. For the top candidates, call orbit.task.show with the task id to read description, plan, and priority.
 
@@ -27,12 +29,15 @@ activity:
 
        a. Apply priority rules: critical > high > medium > low.
 
-       b. Skip any task whose scope or target files clearly overlap with an
-          in-progress task — prefer work that can land independently without causing merge
-          conflicts or duplicating effort.
+       b. Conflict check: for each candidate task, compare its context_files against the
+          blocked file set. A conflict exists when any path in the candidate's context_files
+          exactly matches, or is a path prefix of, any path in the blocked file set (and
+          vice versa). Skip any candidate with a conflict and note the reason.
+          Tasks with an empty context_files list are never skipped by this check.
 
     5. Call orbit.task.update with id: "<selected_task_id>" and comment: "Dispatched by Orbit: <one sentence rationale>"
-       to record the dispatch rationale.
+       to record the dispatch rationale. If one or more candidates were skipped due to a
+       conflict, include "Skipped <id> (conflicts with in-progress <id>: <file>)" in the comment.
 
     6. Return a JSON result with EXACTLY these fields (no prose, no explanation):
        Output the selected task_id and the rationale comment.

--- a/orbit-core/tests/asset_formatting.rs
+++ b/orbit-core/tests/asset_formatting.rs
@@ -103,6 +103,23 @@ fn dispatch_task_asset_accepts_shared_pipeline_base_input() {
 }
 
 #[test]
+fn dispatch_task_asset_checks_context_files_for_conflict() {
+    let raw = include_str!("../assets/activities/dispatch_task.yaml");
+    assert!(
+        raw.contains("context_files"),
+        "dispatch_task should explicitly reference context_files for conflict detection"
+    );
+    assert!(
+        raw.contains("blocked file set") || raw.contains("conflict"),
+        "dispatch_task should describe the conflict check logic"
+    );
+    assert!(
+        raw.contains("empty context_files") || raw.contains("empty"),
+        "dispatch_task should document that tasks with empty context_files are not skipped"
+    );
+}
+
+#[test]
 fn pipeline_cli_activity_assets_document_workspace_path_input() {
     let assets = [
         include_str!("../assets/activities/run_tests.yaml"),


### PR DESCRIPTION
## Summary

- Updates `dispatch_task` instruction to replace the vague "clearly overlap" heuristic with an explicit `context_files` path-prefix conflict check
- Step 2 now explicitly builds a "blocked file set" from all in-progress tasks' `context_files`
- Step 4b performs exact/prefix matching; tasks with empty `context_files` are never skipped
- Skip reasons are included in the dispatch `comment` output for observability
- Adds `dispatch_task_asset_checks_context_files_for_conflict` test in `asset_formatting.rs`

**Note:** `.orbit/activities/active/dispatch_task.yaml` is not git-tracked. After merge, run `orbit activity register dispatch_task` (or equivalent) to apply the updated instruction to the active runtime config.

## Test plan

- [x] All workspace tests pass (`cargo test --workspace`)
- [x] `dispatch_task_asset_checks_context_files_for_conflict` verifies instruction references `context_files`, conflict logic, and the empty-context_files exemption
- [x] Existing `dispatch_task_asset_accepts_shared_pipeline_base_input` test still passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)