### PR TITLE
feat: add task templates for common task shapes [T20260320-043144]

### DIFF
--- a/orbit-cli/src/audit_middleware.rs
+++ b/orbit-cli/src/audit_middleware.rs
@@ -221,6 +221,7 @@ pub fn extract_command_meta(cmd: &Commands) -> CommandMeta {
                 }
                 TaskSubcommand::Delete(args) => ("delete", Some("task"), Some(args.id.as_str())),
                 TaskSubcommand::Search(_) => ("search", None, None),
+                TaskSubcommand::Templates(_) => ("templates", None, None),
             };
             CommandMeta {
                 command: "task".to_string(),

--- a/orbit-cli/src/command/task.rs
+++ b/orbit-cli/src/command/task.rs
@@ -1,6 +1,8 @@
 use clap::{Args, Subcommand};
 use orbit_core::command::task::{TaskAddParams, TaskUpdateParams};
-use orbit_core::{OrbitError, OrbitRuntime, TaskComplexity, TaskPriority, TaskStatus, TaskType};
+use orbit_core::{
+    OrbitError, OrbitRuntime, TaskComplexity, TaskPriority, TaskStatus, TaskType,
+};
 use serde_json::{Value, json};
 
 use crate::command::Execute;
@@ -41,6 +43,8 @@ pub enum TaskSubcommand {
     Delete(TaskDeleteArgs),
     /// Search tasks by title or description
     Search(TaskSearchArgs),
+    /// Manage task templates
+    Templates(TaskTemplatesCommand),
 }
 
 impl Execute for TaskSubcommand {
@@ -57,6 +61,7 @@ impl Execute for TaskSubcommand {
             TaskSubcommand::Unarchive(args) => args.execute(runtime),
             TaskSubcommand::Delete(args) => args.execute(runtime),
             TaskSubcommand::Search(args) => args.execute(runtime),
+            TaskSubcommand::Templates(cmd) => cmd.execute(runtime),
         }
     }
 }
@@ -68,12 +73,15 @@ pub struct TaskAddArgs {
     /// Task title
     #[arg(long)]
     pub title: String,
-    /// Task description
-    #[arg(long)]
+    /// Task description (overrides template if --template is also given)
+    #[arg(long, default_value = "")]
     pub description: String,
-    /// Task plan payload (agent planning input)
-    #[arg(long, alias = "instructions")]
+    /// Task plan payload (agent planning input; overrides template if --template is also given)
+    #[arg(long, alias = "instructions", default_value = "")]
     pub plan: String,
+    /// Pre-populate description, plan, and instructions from a named template
+    #[arg(long)]
+    pub template: Option<String>,
     /// Append an initial task comment
     #[arg(long)]
     pub comment: Option<String>,
@@ -99,22 +107,134 @@ pub struct TaskAddArgs {
 
 impl Execute for TaskAddArgs {
     fn execute(self, runtime: &OrbitRuntime) -> Result<(), OrbitError> {
+        // If a template is requested, resolve it and use its fields as defaults.
+        let (description, plan, priority, task_type) = if let Some(ref tpl_name) = self.template {
+            let tpl = runtime.get_task_template(tpl_name)?;
+            let description = if self.description.is_empty() {
+                tpl.description_template
+            } else {
+                self.description
+            };
+            let plan = if self.plan.is_empty() {
+                // Combine plan_template and instructions_template.
+                let combined = format!(
+                    "{}\n\n---\n\n{}",
+                    tpl.plan_template.trim_end(),
+                    tpl.instructions_template.trim_end()
+                );
+                combined
+            } else {
+                self.plan
+            };
+            // Template priority/type only apply when the caller didn't override them
+            // (detect override by comparing against defaults).
+            let priority = if self.priority == TaskPriority::Medium {
+                tpl.priority
+            } else {
+                self.priority
+            };
+            let task_type = if self.task_type == TaskType::Task {
+                tpl.task_type
+            } else {
+                self.task_type
+            };
+            (description, plan, priority, task_type)
+        } else {
+            (self.description, self.plan, self.priority, self.task_type)
+        };
+
         let task = runtime.add_task(TaskAddParams {
             title: self.title,
-            description: self.description,
-            plan: self.plan,
+            description,
+            plan,
             comment: self.comment,
             context_files: parse_context_csv(&self.context),
             workspace_path: Some(self.workspace),
-            priority: self.priority,
+            priority,
             complexity: self.complexity,
-            task_type: self.task_type,
+            task_type,
         })?;
 
         if self.json {
             crate::output::json::print_pretty(&task_to_json(&task))
         } else {
             println!("{}", task.id);
+            Ok(())
+        }
+    }
+}
+
+// --- Templates ---
+
+#[derive(Args)]
+pub struct TaskTemplatesCommand {
+    #[command(subcommand)]
+    pub command: TaskTemplatesSubcommand,
+}
+
+impl Execute for TaskTemplatesCommand {
+    fn execute(self, runtime: &OrbitRuntime) -> Result<(), OrbitError> {
+        self.command.execute(runtime)
+    }
+}
+
+#[derive(Subcommand)]
+pub enum TaskTemplatesSubcommand {
+    /// List available task templates (built-in and user-defined)
+    List(TaskTemplatesListArgs),
+}
+
+impl Execute for TaskTemplatesSubcommand {
+    fn execute(self, runtime: &OrbitRuntime) -> Result<(), OrbitError> {
+        match self {
+            TaskTemplatesSubcommand::List(args) => args.execute(runtime),
+        }
+    }
+}
+
+#[derive(Args)]
+pub struct TaskTemplatesListArgs {
+    /// Output as JSON
+    #[arg(long)]
+    pub json: bool,
+}
+
+impl Execute for TaskTemplatesListArgs {
+    fn execute(self, runtime: &OrbitRuntime) -> Result<(), OrbitError> {
+        let templates = runtime.list_task_templates()?;
+
+        if self.json {
+            let json_templates: Vec<Value> = templates
+                .iter()
+                .map(|t| {
+                    json!({
+                        "name": t.name,
+                        "description": t.description,
+                        "task_type": t.task_type.to_string(),
+                        "priority": t.priority.to_string(),
+                        "description_template": t.description_template,
+                        "plan_template": t.plan_template,
+                        "instructions_template": t.instructions_template,
+                        "builtin": t.builtin,
+                    })
+                })
+                .collect();
+            crate::output::json::print_pretty(&Value::Array(json_templates))
+        } else {
+            use comfy_table::Cell;
+            let mut table =
+                crate::output::table::build_table(&["NAME", "TYPE", "PRIORITY", "SOURCE", "DESCRIPTION"]);
+            for t in &templates {
+                let source = if t.builtin { "built-in" } else { "user" };
+                table.add_row(vec![
+                    Cell::new(&t.name),
+                    Cell::new(t.task_type.to_string()),
+                    Cell::new(t.priority.to_string()),
+                    Cell::new(source),
+                    Cell::new(&t.description),
+                ]);
+            }
+            println!("{table}");
             Ok(())
         }
     }

--- a/orbit-core/assets/task_templates/bug-fix.yaml
+++ b/orbit-core/assets/task_templates/bug-fix.yaml
@@ -1,0 +1,27 @@
+name: bug-fix
+description: Template for reproducing and fixing a defect
+task_type: issue
+priority: high
+description_template: |
+  <SUMMARY_OF_THE_BUG>
+
+  Steps to reproduce:
+  1. <STEP_1>
+  2. <STEP_2>
+
+  Expected behavior: <EXPECTED>
+  Actual behavior: <ACTUAL>
+plan_template: |
+  1. Reproduce the bug locally and confirm the failure.
+  2. Identify the root cause in the code.
+  3. Write a failing test that captures the regression.
+  4. Implement the fix.
+  5. Confirm the test passes and no existing tests regress.
+  6. Update relevant documentation if behavior changes.
+instructions_template: |
+  Fix the bug described in the task description.
+
+  - Confirm the issue is reproducible before changing any code.
+  - Add a regression test so this cannot silently reappear.
+  - Keep the fix minimal; do not refactor unrelated code.
+  - Note the root cause in the execution summary.

--- a/orbit-core/assets/task_templates/chore.yaml
+++ b/orbit-core/assets/task_templates/chore.yaml
@@ -1,0 +1,19 @@
+name: chore
+description: Template for maintenance, housekeeping, or non-functional work
+task_type: chore
+priority: low
+description_template: |
+  <DESCRIPTION_OF_THE_MAINTENANCE_WORK>
+
+  Motivation: <WHY_THIS_NEEDS_TO_BE_DONE>
+plan_template: |
+  1. Identify the scope of the chore.
+  2. Make the required changes.
+  3. Verify no existing behavior is broken.
+  4. Clean up any related lint, dead code, or outdated references.
+instructions_template: |
+  Complete the maintenance task described in the task description.
+
+  - Keep changes focused on the stated scope.
+  - Do not introduce new features or refactor unrelated code.
+  - Ensure all tests still pass after the change.

--- a/orbit-core/assets/task_templates/feature.yaml
+++ b/orbit-core/assets/task_templates/feature.yaml
@@ -1,0 +1,26 @@
+name: feature
+description: Template for building a new user-facing feature
+task_type: feature
+priority: medium
+description_template: |
+  <FEATURE_DESCRIPTION>
+
+  Motivation: <WHY_THIS_FEATURE_IS_NEEDED>
+
+  Acceptance criteria:
+  - <CRITERION_1>
+  - <CRITERION_2>
+plan_template: |
+  1. Clarify requirements and acceptance criteria.
+  2. Design the public API or interface.
+  3. Implement the feature behind the interface.
+  4. Write unit and integration tests covering the acceptance criteria.
+  5. Update documentation and usage examples.
+  6. Submit for review.
+instructions_template: |
+  Implement the feature described in the task description.
+
+  - Follow the existing code style and patterns in this codebase.
+  - Cover all acceptance criteria with tests.
+  - Do not add features beyond the stated scope (YAGNI).
+  - Summarize what was built and any design decisions in the execution summary.

--- a/orbit-core/assets/task_templates/spike.yaml
+++ b/orbit-core/assets/task_templates/spike.yaml
@@ -1,0 +1,20 @@
+name: spike
+description: Template for a time-boxed research or investigation task
+task_type: task
+priority: medium
+description_template: |
+  <QUESTION_OR_TOPIC_TO_INVESTIGATE>
+
+  Goal: Produce a concrete finding or recommendation by <TIMEBOX>.
+plan_template: |
+  1. Define the specific question(s) to answer.
+  2. Gather relevant information (docs, code, experiments).
+  3. Prototype or test candidate approaches if needed.
+  4. Document findings and a recommendation.
+  5. Present conclusions in the execution summary.
+instructions_template: |
+  Investigate the topic described in the task description.
+
+  - This is a time-boxed spike; do not implement production code unless explicitly requested.
+  - Record your findings and a clear recommendation in the execution summary.
+  - If you discover the scope is larger than expected, flag it as a follow-up task rather than expanding the spike.

--- a/orbit-core/src/command/mod.rs
+++ b/orbit-core/src/command/mod.rs
@@ -5,4 +5,5 @@ pub mod job;
 pub mod job_run;
 pub mod skill;
 pub mod task;
+pub mod task_template;
 pub mod tool;

--- a/orbit-core/src/command/task_template.rs
+++ b/orbit-core/src/command/task_template.rs
@@ -1,0 +1,309 @@
+use orbit_types::{OrbitError, TaskPriority, TaskType};
+use serde::Deserialize;
+
+use crate::OrbitRuntime;
+
+// ---------------------------------------------------------------------------
+// Built-in templates (embedded at compile time)
+// ---------------------------------------------------------------------------
+
+const BUILTIN_TEMPLATES: [(&str, &str); 4] = [
+    ("bug-fix", include_str!("../../assets/task_templates/bug-fix.yaml")),
+    ("chore", include_str!("../../assets/task_templates/chore.yaml")),
+    ("feature", include_str!("../../assets/task_templates/feature.yaml")),
+    ("spike", include_str!("../../assets/task_templates/spike.yaml")),
+];
+
+// ---------------------------------------------------------------------------
+// Template type
+// ---------------------------------------------------------------------------
+
+/// A resolved task template ready for use.
+#[derive(Debug, Clone)]
+pub struct TaskTemplate {
+    pub name: String,
+    pub description: String,
+    pub task_type: TaskType,
+    pub priority: TaskPriority,
+    pub description_template: String,
+    pub plan_template: String,
+    pub instructions_template: String,
+    /// True if this template came from the built-in set; false if user-defined.
+    pub builtin: bool,
+}
+
+/// Raw YAML deserialization shape.
+#[derive(Debug, Deserialize)]
+struct RawTemplate {
+    name: String,
+    #[serde(default)]
+    description: String,
+    #[serde(default)]
+    task_type: Option<RawTaskType>,
+    #[serde(default)]
+    priority: Option<RawPriority>,
+    #[serde(default)]
+    description_template: String,
+    #[serde(default)]
+    plan_template: String,
+    #[serde(default)]
+    instructions_template: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum RawTaskType {
+    Task,
+    Feature,
+    Issue,
+    Bug,
+    Chore,
+    Refactor,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum RawPriority {
+    Low,
+    Medium,
+    High,
+    Critical,
+}
+
+impl From<RawTaskType> for TaskType {
+    fn from(v: RawTaskType) -> Self {
+        match v {
+            RawTaskType::Task => TaskType::Task,
+            RawTaskType::Feature => TaskType::Feature,
+            RawTaskType::Issue | RawTaskType::Bug => TaskType::Issue,
+            RawTaskType::Chore => TaskType::Chore,
+            RawTaskType::Refactor => TaskType::Refactor,
+        }
+    }
+}
+
+impl From<RawPriority> for TaskPriority {
+    fn from(v: RawPriority) -> Self {
+        match v {
+            RawPriority::Low => TaskPriority::Low,
+            RawPriority::Medium => TaskPriority::Medium,
+            RawPriority::High => TaskPriority::High,
+            RawPriority::Critical => TaskPriority::Critical,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Parsing helpers
+// ---------------------------------------------------------------------------
+
+fn parse_template(yaml: &str, builtin: bool) -> Result<TaskTemplate, OrbitError> {
+    let raw: RawTemplate = serde_yaml::from_str(yaml).map_err(|e| {
+        OrbitError::InvalidInput(format!("failed to parse task template: {e}"))
+    })?;
+
+    Ok(TaskTemplate {
+        name: raw.name,
+        description: raw.description,
+        task_type: raw.task_type.map(Into::into).unwrap_or(TaskType::Task),
+        priority: raw.priority.map(Into::into).unwrap_or(TaskPriority::Medium),
+        description_template: raw.description_template,
+        plan_template: raw.plan_template,
+        instructions_template: raw.instructions_template,
+        builtin,
+    })
+}
+
+// ---------------------------------------------------------------------------
+// OrbitRuntime methods
+// ---------------------------------------------------------------------------
+
+impl OrbitRuntime {
+    /// Returns the path where user-defined templates are stored:
+    /// `<data_root>/task_templates/`
+    pub fn task_templates_dir(&self) -> std::path::PathBuf {
+        self.data_root_path().join("task_templates")
+    }
+
+    /// List all available templates: built-ins first, then user-defined ones.
+    ///
+    /// User-defined templates with the same name as a built-in override the built-in.
+    pub fn list_task_templates(&self) -> Result<Vec<TaskTemplate>, OrbitError> {
+        let mut templates: Vec<TaskTemplate> = Vec::new();
+
+        // Load built-ins first.
+        for (_, yaml) in BUILTIN_TEMPLATES {
+            templates.push(parse_template(yaml, true)?);
+        }
+
+        // Load user-defined templates and override/extend.
+        let user_dir = self.task_templates_dir();
+        if user_dir.is_dir() {
+            let mut entries = std::fs::read_dir(&user_dir)
+                .map_err(|e| OrbitError::Io(format!("failed to read task_templates dir: {e}")))?
+                .filter_map(|entry| entry.ok())
+                .filter(|entry| {
+                    let p = entry.path();
+                    p.extension().map_or(false, |ext| ext == "yaml" || ext == "yml")
+                })
+                .collect::<Vec<_>>();
+            entries.sort_by_key(|e| e.file_name());
+
+            for entry in entries {
+                let path = entry.path();
+                let yaml = std::fs::read_to_string(&path).map_err(|e| {
+                    OrbitError::Io(format!(
+                        "failed to read template '{}': {e}",
+                        path.display()
+                    ))
+                })?;
+                let tmpl = parse_template(&yaml, false).map_err(|e| {
+                    OrbitError::InvalidInput(format!(
+                        "invalid template '{}': {e}",
+                        path.display()
+                    ))
+                })?;
+                // User-defined templates override built-ins of the same name.
+                if let Some(existing) = templates.iter_mut().find(|t| t.name == tmpl.name) {
+                    *existing = tmpl;
+                } else {
+                    templates.push(tmpl);
+                }
+            }
+        }
+
+        Ok(templates)
+    }
+
+    /// Look up a single template by name.
+    pub fn get_task_template(&self, name: &str) -> Result<TaskTemplate, OrbitError> {
+        // Check user-defined first (they take priority).
+        let user_dir = self.task_templates_dir();
+        if user_dir.is_dir() {
+            for ext in ["yaml", "yml"] {
+                let path = user_dir.join(format!("{name}.{ext}"));
+                if path.is_file() {
+                    let yaml = std::fs::read_to_string(&path).map_err(|e| {
+                        OrbitError::Io(format!(
+                            "failed to read template '{}': {e}",
+                            path.display()
+                        ))
+                    })?;
+                    return parse_template(&yaml, false);
+                }
+            }
+        }
+
+        // Fall back to built-ins.
+        for (id, yaml) in BUILTIN_TEMPLATES {
+            if id == name {
+                return parse_template(yaml, true);
+            }
+        }
+
+        Err(OrbitError::InvalidInput(format!(
+            "task template '{name}' not found; run `orbit task templates list` to see available templates"
+        )))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::OrbitRuntime;
+
+    #[test]
+    fn builtin_templates_parse_without_error() {
+        for (name, yaml) in BUILTIN_TEMPLATES {
+            let tmpl = parse_template(yaml, true)
+                .unwrap_or_else(|e| panic!("built-in template '{name}' failed to parse: {e}"));
+            assert_eq!(tmpl.name, name, "template name should match file key");
+            assert!(!tmpl.description_template.is_empty(), "description_template should not be empty for '{name}'");
+            assert!(!tmpl.plan_template.is_empty(), "plan_template should not be empty for '{name}'");
+            assert!(!tmpl.instructions_template.is_empty(), "instructions_template should not be empty for '{name}'");
+            assert!(tmpl.builtin);
+        }
+    }
+
+    #[test]
+    fn list_task_templates_returns_all_builtins() {
+        let runtime = OrbitRuntime::in_memory().expect("runtime");
+        let templates = runtime.list_task_templates().expect("list");
+        assert_eq!(templates.len(), 4);
+        let names: Vec<&str> = templates.iter().map(|t| t.name.as_str()).collect();
+        assert!(names.contains(&"bug-fix"));
+        assert!(names.contains(&"feature"));
+        assert!(names.contains(&"spike"));
+        assert!(names.contains(&"chore"));
+    }
+
+    #[test]
+    fn get_task_template_returns_builtin() {
+        let runtime = OrbitRuntime::in_memory().expect("runtime");
+        let tmpl = runtime.get_task_template("feature").expect("get");
+        assert_eq!(tmpl.name, "feature");
+        assert!(tmpl.builtin);
+        assert_eq!(tmpl.task_type, TaskType::Feature);
+        assert_eq!(tmpl.priority, TaskPriority::Medium);
+    }
+
+    #[test]
+    fn get_task_template_not_found() {
+        let runtime = OrbitRuntime::in_memory().expect("runtime");
+        let result = runtime.get_task_template("nonexistent");
+        assert!(matches!(result, Err(OrbitError::InvalidInput(_))));
+    }
+
+    #[test]
+    fn user_defined_template_overrides_builtin() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let data_root = dir.path();
+        let tpl_dir = data_root.join("task_templates");
+        std::fs::create_dir_all(&tpl_dir).expect("create dir");
+        std::fs::write(
+            tpl_dir.join("feature.yaml"),
+            "name: feature\ndescription: custom\ntask_type: chore\npriority: high\ndescription_template: custom desc\nplan_template: custom plan\ninstructions_template: custom instructions\n",
+        )
+        .expect("write");
+
+        let runtime = OrbitRuntime::from_data_root(data_root).expect("runtime");
+        let tmpl = runtime.get_task_template("feature").expect("get");
+        assert!(!tmpl.builtin);
+        assert_eq!(tmpl.task_type, TaskType::Chore);
+        assert_eq!(tmpl.priority, TaskPriority::High);
+    }
+
+    #[test]
+    fn user_defined_template_appears_in_list() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let data_root = dir.path();
+        let tpl_dir = data_root.join("task_templates");
+        std::fs::create_dir_all(&tpl_dir).expect("create dir");
+        std::fs::write(
+            tpl_dir.join("my-custom.yaml"),
+            "name: my-custom\ndescription: my custom template\ndescription_template: desc\nplan_template: plan\ninstructions_template: instr\n",
+        )
+        .expect("write");
+
+        let runtime = OrbitRuntime::from_data_root(data_root).expect("runtime");
+        let templates = runtime.list_task_templates().expect("list");
+        // 4 builtins + 1 user-defined
+        assert_eq!(templates.len(), 5);
+        let custom = templates.iter().find(|t| t.name == "my-custom").expect("custom");
+        assert!(!custom.builtin);
+    }
+
+    #[test]
+    fn list_templates_without_user_dir_returns_only_builtins() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        // data_root exists, but task_templates/ subdirectory does NOT
+        let runtime = OrbitRuntime::from_data_root(dir.path()).expect("runtime");
+        let templates = runtime.list_task_templates().expect("list");
+        assert_eq!(templates.len(), 4);
+        assert!(templates.iter().all(|t| t.builtin));
+    }
+}

--- a/orbit-core/src/lib.rs
+++ b/orbit-core/src/lib.rs
@@ -12,6 +12,7 @@ pub use orbit_store::skill_store as skill_catalog;
 pub use context::{ActorIdentity, ActorKind, OrbitContext};
 pub use orbit_store::AuditEventInsertParams;
 pub use orbit_types::OrbitError;
+pub use command::task_template::TaskTemplate;
 pub use orbit_types::{
     Activity, AuditEvent, AuditEventStatus, AuditStats, Job, JobRun, JobRunState, JobScheduleState,
     JobStep, JobTargetType, Role, Skill, Task, TaskComment, TaskComplexity, TaskPriority,


### PR DESCRIPTION
## Summary
- Adds 4 built-in task templates (bug-fix, feature, spike, chore) as YAML files in `orbit-core/assets/task_templates/`, embedded at compile time via `include_str!`
- Adds `--template <name>` flag to `orbit task add`; when specified, pre-populates description, plan, and instructions fields from the template (caller-supplied values take precedence over template defaults)
- Adds `orbit task templates list` subcommand that shows all available templates (built-in + user-defined) in a table or `--json`
- User-defined templates can be placed in `.orbit/task_templates/*.yaml` and will override built-ins of the same name or extend the list

## Test plan
- [ ] `cargo test --workspace` passes
- [ ] `orbit task add --template feature --title "my feature" --workspace .` pre-populates description and plan from the feature template
- [ ] `orbit task templates list` shows all 4 built-in templates
- [ ] `orbit task templates list --json` returns JSON array
- [ ] User-defined template in `.orbit/task_templates/my.yaml` appears in the list and overrides a built-in of the same name

🤖 Generated with [Claude Code](https://claude.com/claude-code)