### PR TITLE
Add step output_map for declarative I/O field mapping

### DIFF
--- a/orbit-core/src/command/job.rs
+++ b/orbit-core/src/command/job.rs
@@ -62,6 +62,8 @@ struct DefaultJobStep {
     retry_max_attempts: u32,
     #[serde(default = "orbit_types::default_retry_backoff_seconds")]
     retry_backoff_seconds: u64,
+    #[serde(default)]
+    output_map: std::collections::HashMap<String, String>,
 }
 
 #[derive(Debug, Clone)]
@@ -349,6 +351,7 @@ fn default_job_steps(entry: &DefaultJobEntry) -> Result<Vec<JobStep>, OrbitError
                 env_extra: s.env_extra.clone(),
                 retry_max_attempts: s.retry_max_attempts,
                 retry_backoff_seconds: s.retry_backoff_seconds,
+                output_map: s.output_map.clone(),
             })
         })
         .collect()

--- a/orbit-core/tests/job_runtime_behavior.rs
+++ b/orbit-core/tests/job_runtime_behavior.rs
@@ -2095,6 +2095,229 @@ fn agent_step_result_fields_flow_into_next_step_input() {
 }
 
 #[test]
+fn step_output_map_renames_keys_before_flowing_to_next_step() {
+    use std::collections::HashMap;
+
+    let dir = tempdir().expect("tempdir");
+    let runtime = OrbitRuntime::from_data_root(dir.path()).expect("runtime");
+
+    // Step 1: agent that returns {summary: "hello", extra: "world"}
+    let script_path = dir.path().join("mock-agent");
+    let agent_cli = write_agent_script(
+        &script_path,
+        "#!/bin/sh\ncat >/dev/null\nprintf '{\"schemaVersion\":1,\"status\":\"success\",\"result\":{\"summary\":\"hello\",\"extra\":\"world\"},\"error\":null,\"durationMs\":1}'\n",
+    );
+
+    runtime
+        .add_activity(ActivityAddParams {
+            id: "spec-agent-map-source".to_string(),
+            spec_type: "agent_invoke".to_string(),
+            description: "agent producing output for mapping".to_string(),
+            input_schema_json: json!({}),
+            output_schema_json: json!({}),
+            spec_config: json!({ "instruction": "Return summary and extra." }),
+            workspace_path: None,
+            created_by: None,
+        })
+        .expect("add agent activity");
+
+    // Step 2: cli that captures pr_body and extra from env
+    let cli_script_path = dir.path().join("capture-mapped.sh");
+    std::fs::write(
+        &cli_script_path,
+        "#!/bin/sh\nprintf '{\"seen_pr_body\":\"%s\",\"seen_extra\":\"%s\"}' \"$PR_BODY\" \"$EXTRA\" > \"$ORBIT_OUTPUT_FILE\"\n",
+    )
+    .expect("write cli script");
+    #[cfg(unix)]
+    std::fs::set_permissions(&cli_script_path, std::fs::Permissions::from_mode(0o755))
+        .expect("chmod cli script");
+
+    runtime
+        .add_activity(ActivityAddParams {
+            id: "spec-cli-map-consumer".to_string(),
+            spec_type: "cli_command".to_string(),
+            description: "consume mapped output".to_string(),
+            input_schema_json: json!({
+                "type": "object",
+                "properties": {
+                    "pr_body": { "type": "string" },
+                    "extra": { "type": "string" }
+                },
+                "required": ["pr_body", "extra"]
+            }),
+            output_schema_json: json!({
+                "type": "object",
+                "properties": {
+                    "seen_pr_body": { "type": "string" },
+                    "seen_extra": { "type": "string" }
+                },
+                "required": ["seen_pr_body", "seen_extra"]
+            }),
+            spec_config: json!({
+                "command": cli_script_path.to_string_lossy().to_string(),
+                "expected_exit_codes": [0],
+                "env": {
+                    "PR_BODY": "{{input.pr_body}}",
+                    "EXTRA": "{{input.extra}}"
+                }
+            }),
+            workspace_path: None,
+            created_by: None,
+        })
+        .expect("add cli activity");
+
+    let job_id = runtime
+        .add_job(JobAddParams {
+            job_id: None,
+            default_input: None,
+            max_active_runs: None,
+            steps: vec![
+                JobStep {
+                    target_id: "spec-agent-map-source".to_string(),
+                    agent_cli,
+                    timeout_seconds: 10,
+                    output_map: HashMap::from([
+                        ("summary".to_string(), "pr_body".to_string()),
+                    ]),
+                    ..Default::default()
+                },
+                JobStep {
+                    target_id: "spec-cli-map-consumer".to_string(),
+                    timeout_seconds: 10,
+                    ..Default::default()
+                },
+            ],
+            initial_state_override: None,
+        })
+        .expect("add job")
+        .job_id;
+
+    let result = runtime.run_job_now(&job_id).expect("run job");
+    assert_eq!(result.state, JobRunState::Success);
+
+    let history = runtime.job_history(&job_id).expect("job history");
+    let cli_output = history[0]
+        .steps
+        .get(1)
+        .and_then(|step| step.agent_response_json.as_ref())
+        .expect("cli step output");
+
+    // "summary" was renamed to "pr_body"
+    assert_eq!(cli_output["seen_pr_body"], json!("hello"));
+    // "extra" passed through unmapped
+    assert_eq!(cli_output["seen_extra"], json!("world"));
+}
+
+#[test]
+fn step_output_map_silently_skips_missing_source_keys() {
+    use std::collections::HashMap;
+
+    let dir = tempdir().expect("tempdir");
+    let runtime = OrbitRuntime::from_data_root(dir.path()).expect("runtime");
+
+    // Agent returns only {value: "present"}
+    let script_path = dir.path().join("mock-agent");
+    let agent_cli = write_agent_script(
+        &script_path,
+        "#!/bin/sh\ncat >/dev/null\nprintf '{\"schemaVersion\":1,\"status\":\"success\",\"result\":{\"value\":\"present\"},\"error\":null,\"durationMs\":1}'\n",
+    );
+
+    runtime
+        .add_activity(ActivityAddParams {
+            id: "spec-agent-skip-source".to_string(),
+            spec_type: "agent_invoke".to_string(),
+            description: "agent with partial output".to_string(),
+            input_schema_json: json!({}),
+            output_schema_json: json!({}),
+            spec_config: json!({ "instruction": "Return value only." }),
+            workspace_path: None,
+            created_by: None,
+        })
+        .expect("add agent activity");
+
+    let cli_script_path = dir.path().join("capture-skip.sh");
+    std::fs::write(
+        &cli_script_path,
+        "#!/bin/sh\nprintf '{\"seen_value\":\"%s\"}' \"$VALUE\" > \"$ORBIT_OUTPUT_FILE\"\n",
+    )
+    .expect("write cli script");
+    #[cfg(unix)]
+    std::fs::set_permissions(&cli_script_path, std::fs::Permissions::from_mode(0o755))
+        .expect("chmod cli script");
+
+    runtime
+        .add_activity(ActivityAddParams {
+            id: "spec-cli-skip-consumer".to_string(),
+            spec_type: "cli_command".to_string(),
+            description: "consume with missing mapped key".to_string(),
+            input_schema_json: json!({
+                "type": "object",
+                "properties": {
+                    "value": { "type": "string" }
+                },
+                "required": ["value"]
+            }),
+            output_schema_json: json!({
+                "type": "object",
+                "properties": {
+                    "seen_value": { "type": "string" }
+                },
+                "required": ["seen_value"]
+            }),
+            spec_config: json!({
+                "command": cli_script_path.to_string_lossy().to_string(),
+                "expected_exit_codes": [0],
+                "env": {
+                    "VALUE": "{{input.value}}"
+                }
+            }),
+            workspace_path: None,
+            created_by: None,
+        })
+        .expect("add cli activity");
+
+    let job_id = runtime
+        .add_job(JobAddParams {
+            job_id: None,
+            default_input: None,
+            max_active_runs: None,
+            steps: vec![
+                JobStep {
+                    target_id: "spec-agent-skip-source".to_string(),
+                    agent_cli,
+                    timeout_seconds: 10,
+                    output_map: HashMap::from([
+                        // "missing_key" doesn't exist in output — should be silently skipped
+                        ("missing_key".to_string(), "renamed".to_string()),
+                    ]),
+                    ..Default::default()
+                },
+                JobStep {
+                    target_id: "spec-cli-skip-consumer".to_string(),
+                    timeout_seconds: 10,
+                    ..Default::default()
+                },
+            ],
+            initial_state_override: None,
+        })
+        .expect("add job")
+        .job_id;
+
+    let result = runtime.run_job_now(&job_id).expect("run job");
+    assert_eq!(result.state, JobRunState::Success);
+
+    let history = runtime.job_history(&job_id).expect("job history");
+    let cli_output = history[0]
+        .steps
+        .get(1)
+        .and_then(|step| step.agent_response_json.as_ref())
+        .expect("cli step output");
+
+    // "value" passed through unchanged despite the mapping for a missing key
+    assert_eq!(cli_output["seen_value"], json!("present"));
+}
+
+#[test]
 fn agent_step_workspace_path_flows_into_cli_working_directory() {
     let dir = tempdir().expect("tempdir");
     let runtime = OrbitRuntime::from_data_root(dir.path()).expect("runtime");

--- a/orbit-engine/src/job_runner.rs
+++ b/orbit-engine/src/job_runner.rs
@@ -109,8 +109,17 @@ fn execute_activity_with_retries<H: EngineHost>(
                 )
                 && let Value::Object(ref mut input_map) = current_input
             {
-                for (key, value) in output_map {
-                    input_map.insert(key.clone(), value.clone());
+                let mut merged: serde_json::Map<String, Value> = output_map
+                    .iter()
+                    .map(|(k, v)| (k.clone(), v.clone()))
+                    .collect();
+                for (source, target) in &step.output_map {
+                    if let Some(value) = merged.remove(source) {
+                        merged.insert(target.clone(), value);
+                    }
+                }
+                for (key, value) in merged {
+                    input_map.insert(key, value);
                 }
             }
 

--- a/orbit-types/src/job.rs
+++ b/orbit-types/src/job.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::fmt::{Display, Formatter};
 use std::str::FromStr;
 
@@ -178,6 +179,10 @@ pub struct JobStep {
     /// Initial backoff delay in seconds before the first retry; doubles with each attempt.
     #[serde(default = "default_retry_backoff_seconds")]
     pub retry_backoff_seconds: u64,
+    /// Rename output keys before merging into the next step's input.
+    /// Each entry maps `source_key -> target_key`. Unmapped keys pass through unchanged.
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub output_map: HashMap<String, String>,
 }
 
 impl Default for JobStep {
@@ -191,6 +196,7 @@ impl Default for JobStep {
             env_extra: Vec::new(),
             retry_max_attempts: 0,
             retry_backoff_seconds: default_retry_backoff_seconds(),
+            output_map: HashMap::new(),
         }
     }
 }


### PR DESCRIPTION
## Summary

- Add `output_map: HashMap<String, String>` to `JobStep` for renaming output keys before they flow into the next step's input
- Applied after `step_output_for_following_input()` extracts the output, before merging into `current_input`
- Semantics: source key removed, target key inserted; unmapped keys pass through; missing source keys silently skipped
- Depends on #29 (remove redundant task fields)

## Test plan

- [x] `cargo build` compiles cleanly
- [x] `step_output_map_renames_keys_before_flowing_to_next_step` — verifies mapped key rename and unmapped passthrough
- [x] `step_output_map_silently_skips_missing_source_keys` — verifies missing source keys are ignored
- [x] Full test suite passes (1 pre-existing unrelated failure)

🤖 Generated with [Claude Code](https://claude.com/claude-code)