### PR TITLE
feat: auto-append agent/model identity to PR bodies and review comments

### DIFF
--- a/orbit-core/src/command/tool.rs
+++ b/orbit-core/src/command/tool.rs
@@ -34,13 +34,26 @@ pub struct DoctorResult {
 impl OrbitRuntime {
     pub fn execute_tool_command(&self, name: &str, input: Value) -> Result<Value, OrbitError> {
         let allowed_tools = read_activity_tools_from_env();
+        let (agent_name, model_name) = read_agent_identity_from_env();
         let tool_context = ToolContext {
             cwd: None,
             allowed_tools,
+            agent_name,
+            model_name,
             ..Default::default()
         };
         self.run_tool_with_context_and_role(name, input, Role::Admin, tool_context)
     }
+}
+
+fn read_agent_identity_from_env() -> (Option<String>, Option<String>) {
+    let agent = std::env::var("ORBIT_AGENT_NAME")
+        .ok()
+        .filter(|s| !s.is_empty());
+    let model = std::env::var("ORBIT_AGENT_MODEL")
+        .ok()
+        .filter(|s| !s.is_empty());
+    (agent, model)
 }
 
 fn read_activity_tools_from_env() -> Vec<String> {

--- a/orbit-engine/src/executor/agent.rs
+++ b/orbit-engine/src/executor/agent.rs
@@ -143,9 +143,12 @@ fn execute_agent_process<H: EnvironmentHost + AgentProtocolHost + ?Sized>(
     let (args, _stdout_schema_file) =
         prepare_exec_args(&invocation).map_err(invocation_failed_outcome)?;
 
-    let environment_mode = inject_activity_tools(
-        host.execution_environment_mode(&execution.env_extra),
-        &execution.activity.tools,
+    let environment_mode = inject_agent_identity(
+        inject_activity_tools(
+            host.execution_environment_mode(&execution.env_extra),
+            &execution.activity.tools,
+        ),
+        execution,
     );
 
     run_process(
@@ -179,6 +182,42 @@ fn inject_activity_tools(mode: EnvironmentMode, tools: &[String]) -> Environment
             EnvironmentMode::ClearAndSet(pairs)
         }
     }
+}
+
+fn inject_agent_identity(
+    mode: EnvironmentMode,
+    execution: &ExecutionContext,
+) -> EnvironmentMode {
+    let agent = normalize_agent_label(&execution.agent_cli);
+    if agent.is_empty() {
+        return mode;
+    }
+    let model = execution.model.clone().unwrap_or_default();
+    let inject = |pairs: &mut Vec<(String, String)>| {
+        pairs.push(("ORBIT_AGENT_NAME".to_string(), agent.clone()));
+        if !model.is_empty() {
+            pairs.push(("ORBIT_AGENT_MODEL".to_string(), model.clone()));
+        }
+    };
+    match mode {
+        EnvironmentMode::ClearAndSet(mut pairs) => {
+            inject(&mut pairs);
+            EnvironmentMode::ClearAndSet(pairs)
+        }
+        EnvironmentMode::Inherit => {
+            let mut pairs: Vec<(String, String)> = std::env::vars().collect();
+            inject(&mut pairs);
+            EnvironmentMode::ClearAndSet(pairs)
+        }
+    }
+}
+
+fn normalize_agent_label(agent_cli: &str) -> String {
+    std::path::Path::new(agent_cli)
+        .file_name()
+        .and_then(|value| value.to_str())
+        .unwrap_or(agent_cli)
+        .to_ascii_lowercase()
 }
 
 fn process_agent_response<H: EnvironmentHost + AgentProtocolHost + ?Sized>(

--- a/orbit-engine/src/executor/agent.rs
+++ b/orbit-engine/src/executor/agent.rs
@@ -143,12 +143,14 @@ fn execute_agent_process<H: EnvironmentHost + AgentProtocolHost + ?Sized>(
     let (args, _stdout_schema_file) =
         prepare_exec_args(&invocation).map_err(invocation_failed_outcome)?;
 
+    let resolved_model = resolve_model_for_env(host, execution);
     let environment_mode = inject_agent_identity(
         inject_activity_tools(
             host.execution_environment_mode(&execution.env_extra),
             &execution.activity.tools,
         ),
         execution,
+        resolved_model.as_deref(),
     );
 
     run_process(
@@ -187,16 +189,17 @@ fn inject_activity_tools(mode: EnvironmentMode, tools: &[String]) -> Environment
 fn inject_agent_identity(
     mode: EnvironmentMode,
     execution: &ExecutionContext,
+    resolved_model: Option<&str>,
 ) -> EnvironmentMode {
     let agent = normalize_agent_label(&execution.agent_cli);
     if agent.is_empty() {
         return mode;
     }
-    let model = execution.model.clone().unwrap_or_default();
+    let model = resolved_model.unwrap_or_default();
     let inject = |pairs: &mut Vec<(String, String)>| {
         pairs.push(("ORBIT_AGENT_NAME".to_string(), agent.clone()));
         if !model.is_empty() {
-            pairs.push(("ORBIT_AGENT_MODEL".to_string(), model.clone()));
+            pairs.push(("ORBIT_AGENT_MODEL".to_string(), model.to_string()));
         }
     };
     match mode {
@@ -210,6 +213,25 @@ fn inject_agent_identity(
             EnvironmentMode::ClearAndSet(pairs)
         }
     }
+}
+
+/// Resolve the effective model name for environment injection.
+///
+/// Mirrors the logic in `job_runner::resolved_model_name` — queries the agent
+/// config and asks the provider for its canonical model name. Falls back to
+/// the config-level model when the provider cannot be instantiated.
+fn resolve_model_for_env<H: EnvironmentHost + ?Sized>(
+    host: &H,
+    execution: &ExecutionContext,
+) -> Option<String> {
+    let config = host
+        .agent_config_for(&execution.agent_cli, execution.model.as_deref())
+        .ok()?;
+    let model_from_config = config.model.clone();
+    let agent = Agent::new(&config).ok();
+    agent
+        .and_then(|a| a.model_name().map(ToOwned::to_owned))
+        .or(model_from_config)
 }
 
 fn normalize_agent_label(agent_cli: &str) -> String {

--- a/orbit-engine/src/executor/automation/pr.rs
+++ b/orbit-engine/src/executor/automation/pr.rs
@@ -155,6 +155,8 @@ pub(super) fn open_pr_from_task<H: RuntimeHost + TaskHost + ?Sized>(
     let tool_context = ToolContext {
         cwd: Some(repo_root.to_string_lossy().to_string()),
         allowed_tools: vec![],
+        agent_name: task.agent.clone(),
+        model_name: task.model.clone(),
         ..Default::default()
     };
 

--- a/orbit-tools/src/builtin/github/mod.rs
+++ b/orbit-tools/src/builtin/github/mod.rs
@@ -13,7 +13,7 @@ pub mod repo;
 use orbit_types::OrbitError;
 use serde_json::Value;
 
-use crate::{ToolRegistry, require_str};
+use crate::{ToolContext, ToolRegistry, require_str};
 
 pub fn register(registry: &mut ToolRegistry) {
     registry.register(auth::GithubAuthStatusTool);
@@ -32,6 +32,24 @@ pub fn register(registry: &mut ToolRegistry) {
 /// Extract a non-empty `pr` field from the tool input.
 pub(super) fn require_pr(input: &Value) -> Result<String, OrbitError> {
     require_str(input, "pr")
+}
+
+/// Build an agent attribution footer line.
+///
+/// Returns `None` when `agent_name` is not set on the context (i.e. the tool
+/// was not called from an agent execution path).
+pub(super) fn agent_signature(ctx: &ToolContext, verb: &str) -> Option<String> {
+    let agent = ctx.agent_name.as_deref()?;
+    let model = ctx.model_name.as_deref().unwrap_or("unknown");
+    Some(format!("*{verb} by: {agent} / {model}*"))
+}
+
+/// Append an agent attribution footer to a body string, if identity is available.
+pub(super) fn append_signature(body: &str, ctx: &ToolContext, verb: &str) -> String {
+    match agent_signature(ctx, verb) {
+        Some(sig) => format!("{body}\n\n{sig}"),
+        None => body.to_string(),
+    }
 }
 
 #[cfg(test)]
@@ -132,38 +150,47 @@ mod tests {
 
     #[test]
     fn pr_comment_rejects_missing_pr() {
-        let err = super::pr_comment::build_exec_request(&json!({ "body": "msg" }))
-            .expect_err("must fail");
+        let err =
+            super::pr_comment::build_exec_request(&ToolContext::default(), &json!({ "body": "msg" }))
+                .expect_err("must fail");
         assert!(err.to_string().contains("pr"), "{err}");
     }
 
     #[test]
     fn pr_comment_rejects_missing_body() {
         let err =
-            super::pr_comment::build_exec_request(&json!({ "pr": "42" })).expect_err("must fail");
+            super::pr_comment::build_exec_request(&ToolContext::default(), &json!({ "pr": "42" }))
+                .expect_err("must fail");
         assert!(err.to_string().contains("body"), "{err}");
     }
 
     #[test]
     fn pr_review_rejects_missing_action() {
         let err =
-            super::pr_review::build_exec_request(&json!({ "pr": "42" })).expect_err("must fail");
+            super::pr_review::build_exec_request(&ToolContext::default(), &json!({ "pr": "42" }))
+                .expect_err("must fail");
         assert!(err.to_string().contains("action"), "{err}");
     }
 
     #[test]
     fn pr_review_rejects_invalid_action() {
-        let err = super::pr_review::build_exec_request(&json!({ "pr": "42", "action": "lgtm" }))
-            .expect_err("must fail");
+        let err = super::pr_review::build_exec_request(
+            &ToolContext::default(),
+            &json!({ "pr": "42", "action": "lgtm" }),
+        )
+        .expect_err("must fail");
         assert!(err.to_string().contains("action"), "{err}");
     }
 
     #[test]
     fn pr_review_request_changes_requires_body() {
-        let err = super::pr_review::build_exec_request(&json!({
-            "pr": "42",
-            "action": "request-changes",
-        }))
+        let err = super::pr_review::build_exec_request(
+            &ToolContext::default(),
+            &json!({
+                "pr": "42",
+                "action": "request-changes",
+            }),
+        )
         .expect_err("must fail");
         assert!(err.to_string().contains("body"), "{err}");
     }
@@ -256,10 +283,13 @@ mod tests {
 
     #[test]
     fn pr_review_approve_builds_correct_args() {
-        let req = super::pr_review::build_exec_request(&json!({
-            "pr": "42",
-            "action": "approve",
-        }))
+        let req = super::pr_review::build_exec_request(
+            &ToolContext::default(),
+            &json!({
+                "pr": "42",
+                "action": "approve",
+            }),
+        )
         .expect("valid");
         assert!(req.args.contains(&"review".to_string()));
         assert!(req.args.contains(&"42".to_string()));
@@ -268,11 +298,14 @@ mod tests {
 
     #[test]
     fn pr_review_request_changes_includes_body() {
-        let req = super::pr_review::build_exec_request(&json!({
-            "pr": "42",
-            "action": "request-changes",
-            "body": "fix it",
-        }))
+        let req = super::pr_review::build_exec_request(
+            &ToolContext::default(),
+            &json!({
+                "pr": "42",
+                "action": "request-changes",
+                "body": "fix it",
+            }),
+        )
         .expect("valid");
         assert!(req.args.contains(&"--request-changes".to_string()));
         assert!(req.args.contains(&"--body".to_string()));
@@ -284,6 +317,115 @@ mod tests {
         let req = super::pr_list::build_exec_request(&json!({ "label": "orbit" })).expect("valid");
         assert!(req.args.contains(&"--label".to_string()));
         assert!(req.args.contains(&"orbit".to_string()));
+    }
+
+    #[test]
+    fn pr_create_appends_agent_signature_when_identity_set() {
+        let ctx = ToolContext {
+            agent_name: Some("claude".to_string()),
+            model_name: Some("opus-4.6".to_string()),
+            ..Default::default()
+        };
+        let req = super::pr_create::build_exec_request(
+            &ctx,
+            &json!({
+                "title": "T",
+                "base": "main",
+                "head": "branch",
+                "body": "description",
+            }),
+        )
+        .expect("valid");
+        let body_pos = req.args.iter().position(|a| a == "--body").unwrap();
+        let body = &req.args[body_pos + 1];
+        assert!(
+            body.ends_with("\n\n*Implemented by: claude / opus-4.6*"),
+            "body missing signature: {body}"
+        );
+    }
+
+    #[test]
+    fn pr_review_appends_agent_signature_when_identity_set() {
+        let ctx = ToolContext {
+            agent_name: Some("codex".to_string()),
+            model_name: Some("o3".to_string()),
+            ..Default::default()
+        };
+        let req = super::pr_review::build_exec_request(
+            &ctx,
+            &json!({
+                "pr": "42",
+                "action": "request-changes",
+                "body": "needs work",
+            }),
+        )
+        .expect("valid");
+        let body_pos = req.args.iter().position(|a| a == "--body").unwrap();
+        let body = &req.args[body_pos + 1];
+        assert!(
+            body.ends_with("\n\n*Reviewed by: codex / o3*"),
+            "body missing signature: {body}"
+        );
+    }
+
+    #[test]
+    fn pr_review_approve_appends_signature_as_body_when_identity_set() {
+        let ctx = ToolContext {
+            agent_name: Some("claude".to_string()),
+            model_name: Some("sonnet-4".to_string()),
+            ..Default::default()
+        };
+        let req = super::pr_review::build_exec_request(
+            &ctx,
+            &json!({
+                "pr": "42",
+                "action": "approve",
+            }),
+        )
+        .expect("valid");
+        let body_pos = req.args.iter().position(|a| a == "--body").unwrap();
+        let body = &req.args[body_pos + 1];
+        assert_eq!(body, "*Reviewed by: claude / sonnet-4*");
+    }
+
+    #[test]
+    fn pr_comment_appends_agent_signature_when_identity_set() {
+        let ctx = ToolContext {
+            agent_name: Some("codex".to_string()),
+            model_name: Some("o3".to_string()),
+            ..Default::default()
+        };
+        let req = super::pr_comment::build_exec_request(
+            &ctx,
+            &json!({
+                "pr": "42",
+                "body": "looks good",
+            }),
+        )
+        .expect("valid");
+        let body_pos = req.args.iter().position(|a| a == "--body").unwrap();
+        let body = &req.args[body_pos + 1];
+        assert!(
+            body.ends_with("\n\n*Reviewed by: codex / o3*"),
+            "body missing signature: {body}"
+        );
+    }
+
+    #[test]
+    fn pr_create_omits_signature_when_no_identity() {
+        let req = super::pr_create::build_exec_request(
+            &ToolContext::default(),
+            &json!({
+                "title": "T",
+                "base": "main",
+                "head": "branch",
+                "body": "description",
+            }),
+        )
+        .expect("valid");
+        let body_pos = req.args.iter().position(|a| a == "--body").unwrap();
+        let body = &req.args[body_pos + 1];
+        assert_eq!(body, "description");
     }
 
     #[test]

--- a/orbit-tools/src/builtin/github/mod.rs
+++ b/orbit-tools/src/builtin/github/mod.rs
@@ -3,6 +3,7 @@ pub mod pr_checkout;
 pub mod pr_checks;
 pub mod pr_close;
 pub mod pr_comment;
+pub mod pr_comment_reply;
 pub mod pr_create;
 pub mod pr_list;
 pub mod pr_merge;
@@ -23,6 +24,7 @@ pub fn register(registry: &mut ToolRegistry) {
     registry.register(pr_view::GithubPrViewTool);
     registry.register(pr_checkout::GithubPrCheckoutTool);
     registry.register(pr_comment::GithubPrCommentTool);
+    registry.register(pr_comment_reply::GithubPrCommentReplyTool);
     registry.register(pr_review::GithubPrReviewTool);
     registry.register(pr_merge::GithubPrMergeTool);
     registry.register(pr_close::GithubPrCloseTool);
@@ -78,6 +80,7 @@ mod tests {
             "github.pr.view",
             "github.pr.checkout",
             "github.pr.comment",
+            "github.pr.comment.reply",
             "github.pr.review",
             "github.pr.merge",
             "github.pr.close",
@@ -162,6 +165,69 @@ mod tests {
             super::pr_comment::build_exec_request(&ToolContext::default(), &json!({ "pr": "42" }))
                 .expect_err("must fail");
         assert!(err.to_string().contains("body"), "{err}");
+    }
+
+    #[test]
+    fn pr_comment_reply_rejects_missing_repo() {
+        let err = super::pr_comment_reply::build_exec_request(
+            &ToolContext::default(),
+            &json!({ "pr": "42", "comment_id": "123", "body": "reply" }),
+        )
+        .expect_err("must fail");
+        assert!(err.to_string().contains("repo"), "{err}");
+    }
+
+    #[test]
+    fn pr_comment_reply_rejects_missing_comment_id() {
+        let err = super::pr_comment_reply::build_exec_request(
+            &ToolContext::default(),
+            &json!({ "repo": "owner/repo", "pr": "42", "body": "reply" }),
+        )
+        .expect_err("must fail");
+        assert!(err.to_string().contains("comment_id"), "{err}");
+    }
+
+    #[test]
+    fn pr_comment_reply_builds_correct_api_endpoint() {
+        let (req, _body) = super::pr_comment_reply::build_exec_request(
+            &ToolContext::default(),
+            &json!({
+                "repo": "owner/repo",
+                "pr": "34",
+                "comment_id": "12345",
+                "body": "looks good",
+            }),
+        )
+        .expect("valid");
+        assert_eq!(req.program, "gh");
+        assert_eq!(req.args[0], "api");
+        assert_eq!(req.args[1], "repos/owner/repo/pulls/34/comments/12345/replies");
+        assert_eq!(req.args[2], "-f");
+        assert_eq!(req.args[3], "body=looks good");
+    }
+
+    #[test]
+    fn pr_comment_reply_appends_agent_signature() {
+        let ctx = ToolContext {
+            agent_name: Some("claude".to_string()),
+            model_name: Some("opus-4.6".to_string()),
+            ..Default::default()
+        };
+        let (req, _body) = super::pr_comment_reply::build_exec_request(
+            &ctx,
+            &json!({
+                "repo": "owner/repo",
+                "pr": "34",
+                "comment_id": "12345",
+                "body": "fixed",
+            }),
+        )
+        .expect("valid");
+        let body_arg = &req.args[3];
+        assert!(
+            body_arg.ends_with("\n\n*Reviewed by: claude / opus-4.6*"),
+            "body missing signature: {body_arg}"
+        );
     }
 
     #[test]

--- a/orbit-tools/src/builtin/github/pr_comment.rs
+++ b/orbit-tools/src/builtin/github/pr_comment.rs
@@ -6,7 +6,10 @@ use crate::{TIMEOUT_DEFAULT_MS, Tool, ToolContext, check_exec_result, require_st
 
 pub struct GithubPrCommentTool;
 
-pub(super) fn build_exec_request(input: &Value) -> Result<ExecRequest, OrbitError> {
+pub(super) fn build_exec_request(
+    ctx: &ToolContext,
+    input: &Value,
+) -> Result<ExecRequest, OrbitError> {
     let pr = super::require_pr(input)?;
     let body = require_str(input, "body")?;
 
@@ -15,7 +18,7 @@ pub(super) fn build_exec_request(input: &Value) -> Result<ExecRequest, OrbitErro
         "comment".to_string(),
         pr,
         "--body".to_string(),
-        body.to_string(),
+        super::append_signature(&body, ctx, "Reviewed"),
     ];
 
     if let Some(repo) = input.get("repo").and_then(Value::as_str) {
@@ -63,8 +66,8 @@ impl Tool for GithubPrCommentTool {
         }
     }
 
-    fn execute(&self, _ctx: &ToolContext, input: Value) -> Result<Value, OrbitError> {
-        let req = build_exec_request(&input)?;
+    fn execute(&self, ctx: &ToolContext, input: Value) -> Result<Value, OrbitError> {
+        let req = build_exec_request(ctx, &input)?;
         let result = run_process(&req, &NoSandbox)?;
         check_exec_result(&result, "gh pr comment")?;
         Ok(json!({

--- a/orbit-tools/src/builtin/github/pr_comment_reply.rs
+++ b/orbit-tools/src/builtin/github/pr_comment_reply.rs
@@ -1,0 +1,89 @@
+use orbit_exec::{EnvironmentMode, ExecRequest, NoSandbox, StdinMode, run_process};
+use orbit_types::{OrbitError, ToolParam, ToolSchema};
+use serde_json::{Value, json};
+
+use crate::{TIMEOUT_DEFAULT_MS, Tool, ToolContext, check_exec_result, require_str};
+
+pub struct GithubPrCommentReplyTool;
+
+pub(super) fn build_exec_request(
+    ctx: &ToolContext,
+    input: &Value,
+) -> Result<(ExecRequest, String), OrbitError> {
+    let repo = require_str(input, "repo")?;
+    let pr = super::require_pr(input)?;
+    let comment_id = require_str(input, "comment_id")?;
+    let body = require_str(input, "body")?;
+    let body = super::append_signature(&body, ctx, "Reviewed");
+
+    // gh api repos/{owner}/{repo}/pulls/{pr}/comments/{comment_id}/replies -f body=...
+    let endpoint = format!("repos/{repo}/pulls/{pr}/comments/{comment_id}/replies");
+
+    let args = vec![
+        "api".to_string(),
+        endpoint,
+        "-f".to_string(),
+        format!("body={body}"),
+    ];
+
+    Ok((
+        ExecRequest {
+            program: "gh".to_string(),
+            args,
+            current_dir: None,
+            timeout_ms: Some(TIMEOUT_DEFAULT_MS),
+            stdin_mode: StdinMode::Null,
+            environment_mode: EnvironmentMode::Inherit,
+            debug: false,
+        },
+        body,
+    ))
+}
+
+impl Tool for GithubPrCommentReplyTool {
+    fn schema(&self) -> ToolSchema {
+        ToolSchema {
+            name: "github.pr.comment.reply".to_string(),
+            description: "Reply to a pull request review comment thread".to_string(),
+            parameters: vec![
+                ToolParam {
+                    name: "repo".to_string(),
+                    description: "Repository in owner/name format".to_string(),
+                    param_type: "string".to_string(),
+                    required: true,
+                },
+                ToolParam {
+                    name: "pr".to_string(),
+                    description: "PR number".to_string(),
+                    param_type: "string".to_string(),
+                    required: true,
+                },
+                ToolParam {
+                    name: "comment_id".to_string(),
+                    description: "ID of the review comment to reply to".to_string(),
+                    param_type: "string".to_string(),
+                    required: true,
+                },
+                ToolParam {
+                    name: "body".to_string(),
+                    description: "Reply text".to_string(),
+                    param_type: "string".to_string(),
+                    required: true,
+                },
+            ],
+            builtin: true,
+        }
+    }
+
+    fn execute(&self, ctx: &ToolContext, input: Value) -> Result<Value, OrbitError> {
+        let (req, _body) = build_exec_request(ctx, &input)?;
+        let result = run_process(&req, &NoSandbox)?;
+        check_exec_result(&result, "gh api (pr comment reply)")?;
+        let response: Value = serde_json::from_str(result.stdout.trim()).unwrap_or(json!({}));
+        let id = response.get("id").and_then(Value::as_u64).unwrap_or(0);
+        Ok(json!({
+            "id": id,
+            "replied": true,
+        }))
+    }
+}

--- a/orbit-tools/src/builtin/github/pr_create.rs
+++ b/orbit-tools/src/builtin/github/pr_create.rs
@@ -36,7 +36,7 @@ pub(super) fn build_exec_request(
 
     if let Some(b) = body {
         args.push("--body".to_string());
-        args.push(b.to_string());
+        args.push(super::append_signature(b, ctx, "Implemented"));
     } else if let Some(f) = body_file {
         args.push("--body-file".to_string());
         args.push(f.to_string());

--- a/orbit-tools/src/builtin/github/pr_review.rs
+++ b/orbit-tools/src/builtin/github/pr_review.rs
@@ -6,7 +6,10 @@ use crate::{TIMEOUT_DEFAULT_MS, Tool, ToolContext, check_exec_result, require_st
 
 pub struct GithubPrReviewTool;
 
-pub(super) fn build_exec_request(input: &Value) -> Result<ExecRequest, OrbitError> {
+pub(super) fn build_exec_request(
+    ctx: &ToolContext,
+    input: &Value,
+) -> Result<ExecRequest, OrbitError> {
     let pr = super::require_pr(input)?;
     let action = require_str(input, "action")?;
 
@@ -38,7 +41,10 @@ pub(super) fn build_exec_request(input: &Value) -> Result<ExecRequest, OrbitErro
 
     if let Some(b) = body {
         args.push("--body".to_string());
-        args.push(b.to_string());
+        args.push(super::append_signature(b, ctx, "Reviewed"));
+    } else if let Some(sig) = super::agent_signature(ctx, "Reviewed") {
+        args.push("--body".to_string());
+        args.push(sig);
     }
 
     if let Some(repo) = input.get("repo").and_then(Value::as_str) {
@@ -94,8 +100,8 @@ impl Tool for GithubPrReviewTool {
         }
     }
 
-    fn execute(&self, _ctx: &ToolContext, input: Value) -> Result<Value, OrbitError> {
-        let req = build_exec_request(&input)?;
+    fn execute(&self, ctx: &ToolContext, input: Value) -> Result<Value, OrbitError> {
+        let req = build_exec_request(ctx, &input)?;
         let result = run_process(&req, &NoSandbox)?;
         check_exec_result(&result, "gh pr review")?;
         Ok(json!({

--- a/orbit-tools/src/lib.rs
+++ b/orbit-tools/src/lib.rs
@@ -63,6 +63,12 @@ pub struct ToolContext {
     /// `--root <path>` so the spawned orbit CLI resolves to the correct data root
     /// regardless of the agent's working directory (e.g. inside a git worktree).
     pub orbit_root: Option<PathBuf>,
+    /// Normalized agent name (e.g. `"claude"`). When set, GitHub tools auto-append
+    /// an attribution footer to PR bodies and review comments.
+    pub agent_name: Option<String>,
+    /// Resolved model identifier (e.g. `"opus-4.6"`). Used alongside `agent_name`
+    /// for the attribution footer.
+    pub model_name: Option<String>,
 }
 
 pub trait Tool: Send + Sync {


### PR DESCRIPTION
## Summary
- Adds `agent_name` and `model_name` fields to `ToolContext` so GitHub tools can auto-append attribution footers
- `github.pr.create` appends `*Implemented by: agent / model*` to PR body
- `github.pr.review` and `github.pr.comment` append `*Reviewed by: agent / model*` to comment body
- Agent executor injects `ORBIT_AGENT_NAME`/`ORBIT_AGENT_MODEL` env vars into subprocess environment
- `orbit tool run` reads those env vars into ToolContext, making identity available to all agent-invoked tools
- PR automation (`open_pr_from_task`) populates identity from task record fields

Closes T20260322-032447

## Test plan
- [x] All existing tests pass (243 tests across orbit-tools, orbit-engine, orbit-core)
- [x] New tests verify signature is appended when identity is set on ToolContext
- [x] New tests verify signature is omitted when no identity is set
- [x] New test for review approve action (no body) — signature is injected as body
- [x] Pre-existing init test failure confirmed unrelated

*Implemented by: claude / opus-4.6*