### PR TITLE
feat: track orbit tool identities [T20260322-194749]

### DIFF
--- a/orbit-cli/src/command/task.rs
+++ b/orbit-cli/src/command/task.rs
@@ -98,6 +98,12 @@ pub struct TaskAddArgs {
     /// For bug tasks: the originating task whose implementation introduced the defect
     #[arg(long = "source-task")]
     pub source_task: Option<String>,
+    /// Explicit agent name to persist on the task artifact
+    #[arg(long)]
+    pub agent: Option<String>,
+    /// Explicit agent model to persist on the task artifact
+    #[arg(long)]
+    pub model: Option<String>,
     /// Output as JSON
     #[arg(long)]
     pub json: bool,
@@ -141,18 +147,22 @@ impl Execute for TaskAddArgs {
             (self.description, self.plan, self.priority, self.task_type)
         };
 
-        let task = runtime.add_task(TaskAddParams {
-            title: self.title,
-            description,
-            plan,
-            comment: self.comment,
-            context_files: parse_context_csv(&self.context),
-            workspace_path: None,
-            priority,
-            complexity: self.complexity,
-            task_type,
-            source_task_id: self.source_task.clone(),
-        })?;
+        let task = runtime.add_task_with_identity(
+            TaskAddParams {
+                title: self.title,
+                description,
+                plan,
+                comment: self.comment,
+                context_files: parse_context_csv(&self.context),
+                workspace_path: None,
+                priority,
+                complexity: self.complexity,
+                task_type,
+                source_task_id: self.source_task.clone(),
+            },
+            self.agent,
+            self.model,
+        )?;
 
         if self.json {
             crate::output::json::print_pretty(&task_to_json(&task))
@@ -445,6 +455,12 @@ pub struct TaskUpdateArgs {
     /// Pull request number (empty string clears)
     #[arg(long)]
     pub pr_number: Option<String>,
+    /// Explicit agent name to persist on the task artifact
+    #[arg(long)]
+    pub agent: Option<String>,
+    /// Explicit agent model to persist on the task artifact
+    #[arg(long)]
+    pub model: Option<String>,
     /// Output as JSON
     #[arg(long)]
     pub json: bool,
@@ -460,7 +476,7 @@ impl Execute for TaskUpdateArgs {
             }
         });
 
-        let task = runtime.update_task(
+        let task = runtime.update_task_with_identity(
             &self.id,
             TaskUpdateParams {
                 title: self.title,
@@ -471,6 +487,8 @@ impl Execute for TaskUpdateArgs {
                 status: self.status.map(Into::into),
                 pr_number,
             },
+            self.agent,
+            self.model,
         )?;
 
         if self.json {
@@ -522,6 +540,12 @@ pub struct TaskStartArgs {
     /// Append a task comment
     #[arg(long)]
     pub comment: Option<String>,
+    /// Explicit agent name to persist on the task artifact
+    #[arg(long)]
+    pub agent: Option<String>,
+    /// Explicit agent model to persist on the task artifact
+    #[arg(long)]
+    pub model: Option<String>,
     /// Output as JSON
     #[arg(long)]
     pub json: bool,
@@ -529,7 +553,13 @@ pub struct TaskStartArgs {
 
 impl Execute for TaskStartArgs {
     fn execute(self, runtime: &OrbitRuntime) -> Result<(), OrbitError> {
-        let task = runtime.start_task(&self.id, self.note, self.comment)?;
+        let task = runtime.start_task_with_identity(
+            &self.id,
+            self.note,
+            self.comment,
+            self.agent,
+            self.model,
+        )?;
         if self.json {
             crate::output::json::print_pretty(&task_to_json(&task))
         } else {
@@ -558,6 +588,12 @@ pub struct TaskApproveArgs {
     /// Append a task comment
     #[arg(long)]
     pub comment: Option<String>,
+    /// Explicit agent name to persist on the task artifact
+    #[arg(long)]
+    pub agent: Option<String>,
+    /// Explicit agent model to persist on the task artifact
+    #[arg(long)]
+    pub model: Option<String>,
     /// Output as JSON
     #[arg(long)]
     pub json: bool,
@@ -599,7 +635,13 @@ impl Execute for TaskApproveArgs {
         if self.json {
             let mut results = Vec::new();
             for id in &ids {
-                let task = runtime.approve_task(id, self.note.clone(), self.comment.clone())?;
+                let task = runtime.approve_task_with_identity(
+                    id,
+                    self.note.clone(),
+                    self.comment.clone(),
+                    self.agent.clone(),
+                    self.model.clone(),
+                )?;
                 results.push(task_to_json(&task));
             }
             if bulk {
@@ -609,7 +651,13 @@ impl Execute for TaskApproveArgs {
             }
         } else {
             for id in &ids {
-                let task = runtime.approve_task(id, self.note.clone(), self.comment.clone())?;
+                let task = runtime.approve_task_with_identity(
+                    id,
+                    self.note.clone(),
+                    self.comment.clone(),
+                    self.agent.clone(),
+                    self.model.clone(),
+                )?;
                 println!("Approved task '{}'", task.id);
             }
             Ok(())
@@ -636,6 +684,12 @@ pub struct TaskRejectArgs {
     /// Append a task comment
     #[arg(long)]
     pub comment: Option<String>,
+    /// Explicit agent name to persist on the task artifact
+    #[arg(long)]
+    pub agent: Option<String>,
+    /// Explicit agent model to persist on the task artifact
+    #[arg(long)]
+    pub model: Option<String>,
     /// Output as JSON
     #[arg(long)]
     pub json: bool,
@@ -677,7 +731,13 @@ impl Execute for TaskRejectArgs {
         if self.json {
             let mut results = Vec::new();
             for id in &ids {
-                let task = runtime.reject_task(id, self.note.clone(), self.comment.clone())?;
+                let task = runtime.reject_task_with_identity(
+                    id,
+                    self.note.clone(),
+                    self.comment.clone(),
+                    self.agent.clone(),
+                    self.model.clone(),
+                )?;
                 results.push(task_to_json(&task));
             }
             if bulk {
@@ -687,7 +747,13 @@ impl Execute for TaskRejectArgs {
             }
         } else {
             for id in &ids {
-                let task = runtime.reject_task(id, self.note.clone(), self.comment.clone())?;
+                let task = runtime.reject_task_with_identity(
+                    id,
+                    self.note.clone(),
+                    self.comment.clone(),
+                    self.agent.clone(),
+                    self.model.clone(),
+                )?;
                 println!("Rejected task '{}'", task.id);
             }
             Ok(())

--- a/orbit-cli/tests/task_commands.rs
+++ b/orbit-cli/tests/task_commands.rs
@@ -774,6 +774,49 @@ fn task_start_with_explicit_identity_updates_provenance_fields() {
 }
 
 #[test]
+fn direct_task_start_with_explicit_identity_updates_provenance_fields() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let id = add_task(dir.path(), "direct precise provenance");
+
+    let output = orbit_in(dir.path())
+        .args([
+            "task",
+            "start",
+            &id,
+            "--note",
+            "picked up with explicit identity",
+            "--comment",
+            "starting with provenance",
+            "--agent",
+            "codex",
+            "--model",
+            "gpt-5.4",
+            "--json",
+        ])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let task: serde_json::Value = serde_json::from_slice(&output).expect("task json");
+
+    assert_eq!(task["status"], "in-progress");
+    assert_eq!(task["assigned_to"], "codex / gpt-5.4");
+    assert_eq!(task["agent"], "codex");
+    assert_eq!(task["model"], "gpt-5.4");
+    assert_eq!(task["comments"][0]["by"], "codex / gpt-5.4");
+    assert_eq!(task["comments"][0]["message"], "starting with provenance");
+    assert_eq!(
+        task["history"]
+            .as_array()
+            .expect("history")
+            .last()
+            .expect("latest")["by"],
+        "codex / gpt-5.4"
+    );
+}
+
+#[test]
 fn task_start_proposed_records_approval_and_start() {
     let dir = tempfile::tempdir().expect("tempdir");
     std::fs::create_dir_all(dir.path().join(".orbit")).expect("create .orbit");

--- a/orbit-cli/tests/task_commands.rs
+++ b/orbit-cli/tests/task_commands.rs
@@ -5,12 +5,19 @@ use std::path::Path;
 fn orbit_in(dir: &Path) -> Command {
     #[allow(deprecated)]
     let mut cmd = Command::cargo_bin("orbit").expect("binary exists");
+    let orbit_bin = assert_cmd::cargo::cargo_bin!("orbit");
+    let mut paths = vec![orbit_bin.parent().expect("binary parent").to_path_buf()];
+    if let Some(existing_path) = std::env::var_os("PATH") {
+        paths.extend(std::env::split_paths(&existing_path));
+    }
+    let path = std::env::join_paths(paths).expect("joined PATH");
     cmd.current_dir(dir);
     cmd.env("HOME", dir);
     cmd.env("USERPROFILE", dir);
     // Prevent find_git_repo_root() from walking up to the real repo's .git
     // and writing task artifacts into the project's .orbit/ directory.
     cmd.env("ORBIT_ROOT", dir.join(".orbit"));
+    cmd.env("PATH", path);
     cmd
 }
 
@@ -731,6 +738,39 @@ fn task_start_backlog_moves_to_in_progress() {
     );
     assert_eq!(history.last().expect("latest")["from_status"], "backlog");
     assert_eq!(history.last().expect("latest")["to_status"], "in_progress");
+}
+
+#[test]
+fn task_start_with_explicit_identity_updates_provenance_fields() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let id = add_task(dir.path(), "precise provenance");
+    let input = format!(
+        "{{\"id\":\"{id}\",\"note\":\"picked up with explicit identity\",\"comment\":\"starting with provenance\",\"agent\":\"codex\",\"model\":\"gpt-5.4\"}}"
+    );
+
+    let output = orbit_in(dir.path())
+        .args(["tool", "run", "orbit.task.start", "--input", &input])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let task: serde_json::Value = serde_json::from_slice(&output).expect("task json");
+
+    assert_eq!(task["status"], "in-progress");
+    assert_eq!(task["assigned_to"], "codex / gpt-5.4");
+    assert_eq!(task["agent"], "codex");
+    assert_eq!(task["model"], "gpt-5.4");
+    assert_eq!(task["comments"][0]["by"], "codex / gpt-5.4");
+    assert_eq!(task["comments"][0]["message"], "starting with provenance");
+    assert_eq!(
+        task["history"]
+            .as_array()
+            .expect("history")
+            .last()
+            .expect("latest")["by"],
+        "codex / gpt-5.4"
+    );
 }
 
 #[test]

--- a/orbit-core/assets/skills/orbit-execute-change-request/SKILL.md
+++ b/orbit-core/assets/skills/orbit-execute-change-request/SKILL.md
@@ -13,24 +13,26 @@ Handle a human-requested engineering change or existing Orbit task from intent t
 
 All agent Orbit interactions go through `orbit tool run`. **Never guess command names — use exactly these:**
 
+Include your identity on every `orbit tool run orbit.*` call by passing `agent` and `model` in the input JSON. Orbit uses these fields to write precise task provenance (`history`, `assigned_to`, comments, and task metadata) instead of the generic `agent` label.
+
 ```bash
 # Load a task
-orbit tool run orbit.task.show --input '{"id": "<task-id>"}'
+orbit tool run orbit.task.show --input '{"id": "<task-id>", "agent": "<agent>", "model": "<model>"}'
 
 # Start a task (backlog/proposed -> in-progress)
-orbit tool run orbit.task.start --input '{"id": "<task-id>", "note": "<why>"}'
+orbit tool run orbit.task.start --input '{"id": "<task-id>", "note": "<why>", "agent": "<agent>", "model": "<model>"}'
 
 # Update task status
-orbit tool run orbit.task.update --input '{"id": "<task-id>", "status": "review"}'
+orbit tool run orbit.task.update --input '{"id": "<task-id>", "status": "review", "agent": "<agent>", "model": "<model>"}'
 
 # Update execution summary
-orbit tool run orbit.task.update --input '{"id": "<task-id>", "execution_summary": "<summary>"}'
+orbit tool run orbit.task.update --input '{"id": "<task-id>", "execution_summary": "<summary>", "agent": "<agent>", "model": "<model>"}'
 
 # Add a comment
-orbit tool run orbit.task.update --input '{"id": "<task-id>", "comment": "<what happened>"}'
+orbit tool run orbit.task.update --input '{"id": "<task-id>", "comment": "<what happened>", "agent": "<agent>", "model": "<model>"}'
 
 # List tasks
-orbit tool run orbit.task.list --input '{"status": "backlog"}'
+orbit tool run orbit.task.list --input '{"status": "backlog", "agent": "<agent>", "model": "<model>"}'
 ```
 
 **Important:** Always use `orbit tool run` — never use `orbit task ...` directly. The tool interface tracks agent provenance. Direct CLI usage is reserved for humans.
@@ -42,7 +44,7 @@ orbit tool run orbit.task.list --input '{"status": "backlog"}'
 If any `orbit tool run` command fails unexpectedly (unknown tool, missing field, unclear error), **do not silently work around it**. Immediately create a friction task:
 
 ```bash
-orbit tool run orbit.task.add --input '{"title": "<short problem statement>", "description": "<what command failed, the error message, and why it caused friction>", "type": "issue", "priority": "medium"}'
+orbit tool run orbit.task.add --input '{"title": "<short problem statement>", "description": "<what command failed, the error message, and why it caused friction>", "type": "issue", "priority": "medium", "agent": "<agent>", "model": "<model>"}'
 ```
 
 Then continue with your work. The friction must be recorded so it gets fixed for the next agent.
@@ -54,7 +56,7 @@ Then continue with your work. The friction must be recorded so it gets fixed for
 **If given an existing task ID**, load it:
 
 ```bash
-orbit tool run orbit.task.show --input '{"id": "<task-id>"}'
+orbit tool run orbit.task.show --input '{"id": "<task-id>", "agent": "<agent>", "model": "<model>"}'
 ```
 
 Read the returned JSON carefully. Extract:
@@ -68,7 +70,7 @@ Read the returned JSON carefully. Extract:
 ### Step 2: Start the task
 
 ```bash
-orbit tool run orbit.task.start --input '{"id": "<task-id>", "note": "<why this is ready now>"}'
+orbit tool run orbit.task.start --input '{"id": "<task-id>", "note": "<why this is ready now>", "agent": "<agent>", "model": "<model>"}'
 ```
 
 - `task start` moves `backlog -> in-progress`
@@ -82,7 +84,7 @@ Follow the task's `plan` field step by step. Read the `context_files` before tou
 ### Step 4: Move to review
 
 ```bash
-orbit tool run orbit.task.update --input '{"id": "<task-id>", "status": "review"}'
+orbit tool run orbit.task.update --input '{"id": "<task-id>", "status": "review", "agent": "<agent>", "model": "<model>"}'
 ```
 
 ### Step 5: Persist the execution summary
@@ -103,7 +105,9 @@ Persist the execution summary via the Orbit task update tool — do NOT write to
 ```bash
 orbit tool run orbit.task.update --input '{
   "id": "<task-id>",
-  "execution_summary": "<summary content>"
+  "execution_summary": "<summary content>",
+  "agent": "<agent>",
+  "model": "<model>"
 }'
 ```
 
@@ -151,6 +155,6 @@ See `orbit-pr` skill for the full PR tool reference. Key rules for implementers:
 
 - Requested change implemented
 - Validation completed
-- Task started via `orbit tool run orbit.task.start` before execution
+- Task started via `orbit tool run orbit.task.start` with explicit `agent` and `model` before execution
 - Task advanced through `review`
-- Execution summary persisted via `orbit tool run orbit.task.update --input '{"id": "...", "execution_summary": "..."}'`
+- Execution summary persisted via `orbit tool run orbit.task.update --input '{"id": "...", "execution_summary": "...", "agent": "...", "model": "..."}'`

--- a/orbit-core/assets/skills/orbit-pr/SKILL.md
+++ b/orbit-core/assets/skills/orbit-pr/SKILL.md
@@ -9,6 +9,8 @@ description: Use this skill when creating pull requests and replying to comments
 
 Standardize how agents interact with pull requests — creating, commenting, and replying. 
 
+When this workflow needs Orbit task metadata, include `agent` and `model` on every `orbit tool run orbit.*` call so Orbit records precise provenance instead of the generic `agent` label.
+
 ## Signature
 
 The **agent-identity-signature** (defined in CLAUDE.md / AGENTS.md) must be appended to the end of your PR bodies and PR comment replies: `*authored by: <agent> / <model>*`

--- a/orbit-core/assets/skills/orbit-review-pr/SKILL.md
+++ b/orbit-core/assets/skills/orbit-review-pr/SKILL.md
@@ -9,6 +9,8 @@ description: Use this skill when reviewing a pull request. Ensures proper attrib
 
 Review a pull request with proper attribution, structured feedback, and scoreable comments.
 
+When this workflow uses Orbit task tools, include your identity on every `orbit tool run orbit.*` call by passing `agent` and `model` in the input JSON. Orbit uses those fields for precise task provenance instead of the generic `agent` label.
+
 ## Signature
 
 Every PR comment you leave must end with your **agent-identity-signature**:
@@ -60,7 +62,7 @@ Every comment thread is an independent score event. More precise comments = more
 ### Step 1: Load context
 
 ```bash
-orbit tool run orbit.task.show --input '{"id": "<task-id>"}'
+orbit tool run orbit.task.show --input '{"id": "<task-id>", "agent": "<agent>", "model": "<model>"}'
 ```
 
 Read the task plan, description, and acceptance criteria. You are reviewing against **these requirements** — not your personal preferences.

--- a/orbit-core/src/command/task.rs
+++ b/orbit-core/src/command/task.rs
@@ -66,6 +66,15 @@ impl From<TaskUpdateParams> for StoreTaskUpdateParams {
 
 impl OrbitRuntime {
     pub fn add_task(&self, params: TaskAddParams) -> Result<Task, OrbitError> {
+        self.add_task_with_identity(params, None, None)
+    }
+
+    pub fn add_task_with_identity(
+        &self,
+        params: TaskAddParams,
+        agent: Option<String>,
+        model: Option<String>,
+    ) -> Result<Task, OrbitError> {
         let actor = self.actor().clone();
         let initial_status =
             if actor.kind == ActorKind::Agent && self.task_approval_required_for_agent() {
@@ -86,8 +95,8 @@ impl OrbitRuntime {
                 workspace_path: params.workspace_path.clone(),
                 repo_root: None,
                 created_by: Some(actor.label.clone()),
-                agent: None,
-                model: None,
+                agent: agent.clone(),
+                model: model.clone(),
                 assigned_to: Some(actor.label.clone()),
                 status: initial_status,
                 priority: params.priority,
@@ -125,7 +134,17 @@ impl OrbitRuntime {
     }
 
     pub fn update_task(&self, id: &str, params: TaskUpdateParams) -> Result<Task, OrbitError> {
-        self.update_task_with_status_note(id, params, None)
+        self.update_task_with_identity(id, params, None, None)
+    }
+
+    pub fn update_task_with_identity(
+        &self,
+        id: &str,
+        params: TaskUpdateParams,
+        agent: Option<String>,
+        model: Option<String>,
+    ) -> Result<Task, OrbitError> {
+        self.update_task_with_status_note_and_identity(id, params, None, agent, model)
     }
 
     pub fn update_task_from_activity(
@@ -156,6 +175,17 @@ impl OrbitRuntime {
         id: &str,
         params: TaskUpdateParams,
         status_note: Option<String>,
+    ) -> Result<Task, OrbitError> {
+        self.update_task_with_status_note_and_identity(id, params, status_note, None, None)
+    }
+
+    fn update_task_with_status_note_and_identity(
+        &self,
+        id: &str,
+        params: TaskUpdateParams,
+        status_note: Option<String>,
+        agent: Option<String>,
+        model: Option<String>,
     ) -> Result<Task, OrbitError> {
         let task = self.get_task(id)?;
         let is_field_update = params.title.is_some()
@@ -218,6 +248,8 @@ impl OrbitRuntime {
                     actor: actor.label.clone(),
                     assigned_to,
                     status_note,
+                    agent: agent.clone().map(Some),
+                    model: model.clone().map(Some),
                     append_comments: append_comments.clone(),
                     ..StoreTaskUpdateParams::from(params)
                 },
@@ -234,6 +266,17 @@ impl OrbitRuntime {
         note: Option<String>,
         comment: Option<String>,
     ) -> Result<Task, OrbitError> {
+        self.approve_task_with_identity(id, note, comment, None, None)
+    }
+
+    pub fn approve_task_with_identity(
+        &self,
+        id: &str,
+        note: Option<String>,
+        comment: Option<String>,
+        agent: Option<String>,
+        model: Option<String>,
+    ) -> Result<Task, OrbitError> {
         let task = self.get_task(id)?;
         let actor = self.actor().clone();
         let append_comments = build_task_comments(comment, actor.label.as_str())?;
@@ -249,6 +292,8 @@ impl OrbitRuntime {
                             status_event: Some("proposal_approved".to_string()),
                             status_note: note.clone(),
                             assigned_to: Some(Some(actor.label.clone())),
+                            agent: agent.clone().map(Some),
+                            model: model.clone().map(Some),
                             append_comments: append_comments.clone(),
                             ..Default::default()
                         },
@@ -272,6 +317,8 @@ impl OrbitRuntime {
                             status: Some(TaskStatus::Done),
                             status_event: Some("review_approved".to_string()),
                             status_note: note.clone(),
+                            agent: agent.clone().map(Some),
+                            model: model.clone().map(Some),
                             append_comments: append_comments.clone(),
                             ..Default::default()
                         },
@@ -298,6 +345,17 @@ impl OrbitRuntime {
         note: Option<String>,
         comment: Option<String>,
     ) -> Result<Task, OrbitError> {
+        self.start_task_with_identity(id, note, comment, None, None)
+    }
+
+    pub fn start_task_with_identity(
+        &self,
+        id: &str,
+        note: Option<String>,
+        comment: Option<String>,
+        agent: Option<String>,
+        model: Option<String>,
+    ) -> Result<Task, OrbitError> {
         let task = self.get_task(id)?;
         let actor = self.actor().clone();
         let append_comments = build_task_comments(comment, actor.label.as_str())?;
@@ -313,6 +371,8 @@ impl OrbitRuntime {
                             status: Some(TaskStatus::InProgress),
                             status_event: Some("started".to_string()),
                             assigned_to: Some(Some(actor.label.clone())),
+                            agent: agent.clone().map(Some),
+                            model: model.clone().map(Some),
                             append_history: vec![TaskHistoryEntry {
                                 at,
                                 by: actor.label.clone(),
@@ -346,6 +406,8 @@ impl OrbitRuntime {
                             status_event: Some("started".to_string()),
                             status_note: note.clone(),
                             assigned_to: Some(Some(actor.label.clone())),
+                            agent: agent.clone().map(Some),
+                            model: model.clone().map(Some),
                             append_comments: append_comments.clone(),
                             ..Default::default()
                         },
@@ -376,6 +438,17 @@ impl OrbitRuntime {
         note: String,
         comment: Option<String>,
     ) -> Result<Task, OrbitError> {
+        self.reject_task_with_identity(id, note, comment, None, None)
+    }
+
+    pub fn reject_task_with_identity(
+        &self,
+        id: &str,
+        note: String,
+        comment: Option<String>,
+        agent: Option<String>,
+        model: Option<String>,
+    ) -> Result<Task, OrbitError> {
         let task = self.get_task(id)?;
         let actor = self.actor().clone();
         let reason = note.trim();
@@ -397,6 +470,8 @@ impl OrbitRuntime {
                             status: Some(TaskStatus::Rejected),
                             status_event: Some("proposal_rejected".to_string()),
                             status_note: Some(reason.clone()),
+                            agent: agent.clone().map(Some),
+                            model: model.clone().map(Some),
                             append_comments: append_comments.clone(),
                             ..Default::default()
                         },
@@ -420,6 +495,8 @@ impl OrbitRuntime {
                             status: Some(TaskStatus::Rejected),
                             status_event: Some("review_rejected".to_string()),
                             status_note: Some(reason.clone()),
+                            agent: agent.clone().map(Some),
+                            model: model.clone().map(Some),
                             append_comments: append_comments.clone(),
                             ..Default::default()
                         },

--- a/orbit-core/src/command/task.rs
+++ b/orbit-core/src/command/task.rs
@@ -76,17 +76,18 @@ impl OrbitRuntime {
         model: Option<String>,
     ) -> Result<Task, OrbitError> {
         let actor = self.actor().clone();
+        let effective_label = effective_actor_label(&actor.label, agent.as_deref(), model.as_deref());
         let initial_status =
             if actor.kind == ActorKind::Agent && self.task_approval_required_for_agent() {
                 TaskStatus::Proposed
             } else {
                 TaskStatus::Backlog
             };
-        let comments = build_task_comments(params.comment.clone(), actor.label.as_str())?;
+        let comments = build_task_comments(params.comment.clone(), effective_label.as_str())?;
 
         self.with_mutation(|| {
             let task = self.create_task_record(StoreTaskCreateParams {
-                actor: actor.label.clone(),
+                actor: effective_label.clone(),
                 title: params.title.clone(),
                 description: params.description.clone(),
                 plan: params.plan.clone(),
@@ -94,16 +95,16 @@ impl OrbitRuntime {
                 context_files: params.context_files.clone(),
                 workspace_path: params.workspace_path.clone(),
                 repo_root: None,
-                created_by: Some(actor.label.clone()),
+                created_by: Some(effective_label.clone()),
                 agent: agent.clone(),
                 model: model.clone(),
-                assigned_to: Some(actor.label.clone()),
+                assigned_to: Some(effective_label.clone()),
                 status: initial_status,
                 priority: params.priority,
                 complexity: params.complexity,
                 task_type: params.task_type,
                 pr_number: None,
-                proposed_by: Some(actor.label.clone()),
+                proposed_by: Some(effective_label.clone()),
                 source_task_id: params.source_task_id.clone(),
                 comments: comments.clone(),
             })?;
@@ -227,15 +228,16 @@ impl OrbitRuntime {
         }
 
         let actor = self.actor().clone();
+        let effective_label = effective_actor_label(&actor.label, agent.as_deref(), model.as_deref());
         let status_note = status_note
             .as_deref()
             .map(str::trim)
             .filter(|value| !value.is_empty())
             .map(ToOwned::to_owned);
-        let append_comments = build_task_comments(params.comment.clone(), actor.label.as_str())?;
+        let append_comments = build_task_comments(params.comment.clone(), effective_label.as_str())?;
         let assigned_to = params.status.and_then(|status| {
             if status == TaskStatus::InProgress {
-                Some(Some(actor.label.clone()))
+                Some(Some(effective_label.clone()))
             } else {
                 None
             }
@@ -245,7 +247,7 @@ impl OrbitRuntime {
             let task = self.update_task_record(
                 id,
                 StoreTaskUpdateParams {
-                    actor: actor.label.clone(),
+                    actor: effective_label.clone(),
                     assigned_to,
                     status_note,
                     agent: agent.clone().map(Some),
@@ -279,7 +281,8 @@ impl OrbitRuntime {
     ) -> Result<Task, OrbitError> {
         let task = self.get_task(id)?;
         let actor = self.actor().clone();
-        let append_comments = build_task_comments(comment, actor.label.as_str())?;
+        let effective_label = effective_actor_label(&actor.label, agent.as_deref(), model.as_deref());
+        let append_comments = build_task_comments(comment, effective_label.as_str())?;
 
         match task.status {
             TaskStatus::Proposed => {
@@ -287,11 +290,11 @@ impl OrbitRuntime {
                     let task = self.update_task_record(
                         id,
                         StoreTaskUpdateParams {
-                            actor: actor.label.clone(),
+                            actor: effective_label.clone(),
                             status: Some(TaskStatus::Backlog),
                             status_event: Some("proposal_approved".to_string()),
                             status_note: note.clone(),
-                            assigned_to: Some(Some(actor.label.clone())),
+                            assigned_to: Some(Some(effective_label.clone())),
                             agent: agent.clone().map(Some),
                             model: model.clone().map(Some),
                             append_comments: append_comments.clone(),
@@ -302,7 +305,7 @@ impl OrbitRuntime {
                         task.clone(),
                         OrbitEvent::TaskProposalApproved {
                             id: id.to_string(),
-                            approved_by: actor.label.clone(),
+                            approved_by: effective_label.clone(),
                         },
                     ))
                 })?;
@@ -313,7 +316,7 @@ impl OrbitRuntime {
                     let task = self.update_task_record(
                         id,
                         StoreTaskUpdateParams {
-                            actor: actor.label.clone(),
+                            actor: effective_label.clone(),
                             status: Some(TaskStatus::Done),
                             status_event: Some("review_approved".to_string()),
                             status_note: note.clone(),
@@ -327,7 +330,7 @@ impl OrbitRuntime {
                         task.clone(),
                         OrbitEvent::TaskReviewApproved {
                             id: id.to_string(),
-                            approved_by: actor.label.clone(),
+                            approved_by: effective_label.clone(),
                         },
                     ))
                 })?;
@@ -358,7 +361,8 @@ impl OrbitRuntime {
     ) -> Result<Task, OrbitError> {
         let task = self.get_task(id)?;
         let actor = self.actor().clone();
-        let append_comments = build_task_comments(comment, actor.label.as_str())?;
+        let effective_label = effective_actor_label(&actor.label, agent.as_deref(), model.as_deref());
+        let append_comments = build_task_comments(comment, effective_label.as_str())?;
 
         match task.status {
             TaskStatus::Proposed => {
@@ -367,15 +371,15 @@ impl OrbitRuntime {
                     let task = self.update_task_record(
                         id,
                         StoreTaskUpdateParams {
-                            actor: actor.label.clone(),
+                            actor: effective_label.clone(),
                             status: Some(TaskStatus::InProgress),
                             status_event: Some("started".to_string()),
-                            assigned_to: Some(Some(actor.label.clone())),
+                            assigned_to: Some(Some(effective_label.clone())),
                             agent: agent.clone().map(Some),
                             model: model.clone().map(Some),
                             append_history: vec![TaskHistoryEntry {
                                 at,
-                                by: actor.label.clone(),
+                                by: effective_label.clone(),
                                 event: "proposal_approved".to_string(),
                                 note: note.clone(),
                                 from_status: Some(TaskStatus::Proposed),
@@ -389,7 +393,7 @@ impl OrbitRuntime {
                         task.clone(),
                         OrbitEvent::TaskStarted {
                             id: id.to_string(),
-                            started_by: actor.label.clone(),
+                            started_by: effective_label.clone(),
                             approved_from_proposed: true,
                         },
                     ))
@@ -401,11 +405,11 @@ impl OrbitRuntime {
                     let task = self.update_task_record(
                         id,
                         StoreTaskUpdateParams {
-                            actor: actor.label.clone(),
+                            actor: effective_label.clone(),
                             status: Some(TaskStatus::InProgress),
                             status_event: Some("started".to_string()),
                             status_note: note.clone(),
-                            assigned_to: Some(Some(actor.label.clone())),
+                            assigned_to: Some(Some(effective_label.clone())),
                             agent: agent.clone().map(Some),
                             model: model.clone().map(Some),
                             append_comments: append_comments.clone(),
@@ -416,7 +420,7 @@ impl OrbitRuntime {
                         task.clone(),
                         OrbitEvent::TaskStarted {
                             id: id.to_string(),
-                            started_by: actor.label.clone(),
+                            started_by: effective_label.clone(),
                             approved_from_proposed: false,
                         },
                     ))
@@ -451,6 +455,7 @@ impl OrbitRuntime {
     ) -> Result<Task, OrbitError> {
         let task = self.get_task(id)?;
         let actor = self.actor().clone();
+        let effective_label = effective_actor_label(&actor.label, agent.as_deref(), model.as_deref());
         let reason = note.trim();
         if reason.is_empty() {
             return Err(OrbitError::InvalidInput(
@@ -458,7 +463,7 @@ impl OrbitRuntime {
             ));
         }
         let reason = reason.to_string();
-        let append_comments = build_task_comments(comment, actor.label.as_str())?;
+        let append_comments = build_task_comments(comment, effective_label.as_str())?;
 
         match task.status {
             TaskStatus::Proposed => {
@@ -466,7 +471,7 @@ impl OrbitRuntime {
                     let task = self.update_task_record(
                         id,
                         StoreTaskUpdateParams {
-                            actor: actor.label.clone(),
+                            actor: effective_label.clone(),
                             status: Some(TaskStatus::Rejected),
                             status_event: Some("proposal_rejected".to_string()),
                             status_note: Some(reason.clone()),
@@ -480,7 +485,7 @@ impl OrbitRuntime {
                         task.clone(),
                         OrbitEvent::TaskProposalRejected {
                             id: id.to_string(),
-                            rejected_by: actor.label.clone(),
+                            rejected_by: effective_label.clone(),
                         },
                     ))
                 })?;
@@ -491,7 +496,7 @@ impl OrbitRuntime {
                     let task = self.update_task_record(
                         id,
                         StoreTaskUpdateParams {
-                            actor: actor.label.clone(),
+                            actor: effective_label.clone(),
                             status: Some(TaskStatus::Rejected),
                             status_event: Some("review_rejected".to_string()),
                             status_note: Some(reason.clone()),
@@ -505,7 +510,7 @@ impl OrbitRuntime {
                         task.clone(),
                         OrbitEvent::TaskReviewRejected {
                             id: id.to_string(),
-                            rejected_by: actor.label.clone(),
+                            rejected_by: effective_label.clone(),
                         },
                     ))
                 })?;
@@ -643,4 +648,13 @@ fn build_task_comments(message: Option<String>, by: &str) -> Result<Vec<TaskComm
         by: by.to_string(),
         message: message.to_string(),
     }])
+}
+
+fn effective_actor_label(default_label: &str, agent: Option<&str>, model: Option<&str>) -> String {
+    match (agent, model) {
+        (Some(agent), Some(model)) => format!("{agent} / {model}"),
+        (Some(agent), None) => agent.to_string(),
+        (None, Some(model)) => model.to_string(),
+        (None, None) => default_label.to_string(),
+    }
 }

--- a/orbit-core/src/lib.rs
+++ b/orbit-core/src/lib.rs
@@ -767,6 +767,43 @@ mod tests {
     }
 
     #[test]
+    fn explicit_identity_overrides_default_actor_label_for_task_provenance() {
+        let runtime = OrbitRuntime::in_memory().expect("runtime");
+
+        let task = runtime
+            .add_task_with_identity(
+                TaskAddParams {
+                    title: "identity aware task".to_string(),
+                    comment: Some("seeded with explicit identity".to_string()),
+                    ..Default::default()
+                },
+                Some("codex".to_string()),
+                Some("gpt-5.4".to_string()),
+            )
+            .expect("add");
+
+        assert_eq!(task.created_by.as_deref(), Some("codex / gpt-5.4"));
+        assert_eq!(task.assigned_to.as_deref(), Some("codex / gpt-5.4"));
+        assert_eq!(task.proposed_by.as_deref(), Some("codex / gpt-5.4"));
+        assert_eq!(task.comments[0].by, "codex / gpt-5.4");
+        assert_eq!(task.agent.as_deref(), Some("codex"));
+        assert_eq!(task.model.as_deref(), Some("gpt-5.4"));
+
+        let started = runtime
+            .start_task_with_identity(
+                &task.id,
+                Some("picked up with explicit identity".to_string()),
+                Some("implementation started".to_string()),
+                Some("codex".to_string()),
+                Some("gpt-5.4".to_string()),
+            )
+            .expect("start");
+        assert_eq!(started.assigned_to.as_deref(), Some("codex / gpt-5.4"));
+        assert_eq!(started.comments.last().expect("comment").by, "codex / gpt-5.4");
+        assert_eq!(started.history.last().expect("history").by, "codex / gpt-5.4");
+    }
+
+    #[test]
     fn start_task_moves_backlog_work_into_progress() {
         let runtime = OrbitRuntime::in_memory().expect("runtime");
         let task = runtime

--- a/orbit-tools/src/builtin/orbit/activity_show.rs
+++ b/orbit-tools/src/builtin/orbit/activity_show.rs
@@ -10,8 +10,9 @@ pub(super) fn build_exec_request(
     ctx: &ToolContext,
     input: &Value,
 ) -> Result<ExecRequest, OrbitError> {
+    let identity = super::resolve_identity(ctx, input)?;
     let id = super::required_string(input, &["id"], "id")?;
-    Ok(super::orbit_exec_request(
+    Ok(super::orbit_exec_request_with_identity(
         ctx,
         vec![
             "activity".to_string(),
@@ -19,15 +20,18 @@ pub(super) fn build_exec_request(
             id,
             "--json".to_string(),
         ],
+        &identity,
     ))
 }
 
 impl Tool for OrbitActivityShowTool {
     fn schema(&self) -> ToolSchema {
+        let mut parameters = super::orbit_id_params("activity");
+        parameters.extend(super::identity_params());
         ToolSchema {
             name: "orbit.activity.show".to_string(),
             description: "Fetch a single Orbit activity as JSON".to_string(),
-            parameters: super::orbit_id_params("activity"),
+            parameters,
             builtin: true,
         }
     }

--- a/orbit-tools/src/builtin/orbit/job_run_archive.rs
+++ b/orbit-tools/src/builtin/orbit/job_run_archive.rs
@@ -10,19 +10,23 @@ pub(super) fn build_exec_request(
     ctx: &ToolContext,
     input: &Value,
 ) -> Result<ExecRequest, OrbitError> {
+    let identity = super::resolve_identity(ctx, input)?;
     let id = super::required_string(input, &["id", "run_id", "runId"], "id")?;
-    Ok(super::orbit_exec_request(
+    Ok(super::orbit_exec_request_with_identity(
         ctx,
         vec!["job-run".to_string(), "archive".to_string(), id],
+        &identity,
     ))
 }
 
 impl Tool for OrbitJobRunArchiveTool {
     fn schema(&self) -> ToolSchema {
+        let mut parameters = super::orbit_id_params("job run");
+        parameters.extend(super::identity_params());
         ToolSchema {
             name: "orbit.job_run.archive".to_string(),
             description: "Archive an Orbit job run".to_string(),
-            parameters: super::orbit_id_params("job run"),
+            parameters,
             builtin: true,
         }
     }

--- a/orbit-tools/src/builtin/orbit/job_run_list.rs
+++ b/orbit-tools/src/builtin/orbit/job_run_list.rs
@@ -10,6 +10,7 @@ pub(super) fn build_exec_request(
     ctx: &ToolContext,
     input: &Value,
 ) -> Result<ExecRequest, OrbitError> {
+    let identity = super::resolve_identity(ctx, input)?;
     let mut args = vec![
         "job-run".to_string(),
         "list".to_string(),
@@ -33,40 +34,44 @@ pub(super) fn build_exec_request(
         args.push(limit);
     }
 
-    Ok(super::orbit_exec_request(ctx, args))
+    Ok(super::orbit_exec_request_with_identity(
+        ctx, args, &identity,
+    ))
 }
 
 impl Tool for OrbitJobRunListTool {
     fn schema(&self) -> ToolSchema {
+        let mut parameters = vec![
+            ToolParam {
+                name: "job".to_string(),
+                description: "Optional job ID filter".to_string(),
+                param_type: "string".to_string(),
+                required: false,
+            },
+            ToolParam {
+                name: "status".to_string(),
+                description: "Optional job run status filter".to_string(),
+                param_type: "string".to_string(),
+                required: false,
+            },
+            ToolParam {
+                name: "since".to_string(),
+                description: "Optional lower timestamp bound".to_string(),
+                param_type: "string".to_string(),
+                required: false,
+            },
+            ToolParam {
+                name: "limit".to_string(),
+                description: "Optional result limit".to_string(),
+                param_type: "string".to_string(),
+                required: false,
+            },
+        ];
+        parameters.extend(super::identity_params());
         ToolSchema {
             name: "orbit.job_run.list".to_string(),
             description: "List Orbit job runs as JSON".to_string(),
-            parameters: vec![
-                ToolParam {
-                    name: "job".to_string(),
-                    description: "Optional job ID filter".to_string(),
-                    param_type: "string".to_string(),
-                    required: false,
-                },
-                ToolParam {
-                    name: "status".to_string(),
-                    description: "Optional job run status filter".to_string(),
-                    param_type: "string".to_string(),
-                    required: false,
-                },
-                ToolParam {
-                    name: "since".to_string(),
-                    description: "Optional lower timestamp bound".to_string(),
-                    param_type: "string".to_string(),
-                    required: false,
-                },
-                ToolParam {
-                    name: "limit".to_string(),
-                    description: "Optional result limit".to_string(),
-                    param_type: "string".to_string(),
-                    required: false,
-                },
-            ],
+            parameters,
             builtin: true,
         }
     }

--- a/orbit-tools/src/builtin/orbit/job_run_show.rs
+++ b/orbit-tools/src/builtin/orbit/job_run_show.rs
@@ -10,8 +10,9 @@ pub(super) fn build_exec_request(
     ctx: &ToolContext,
     input: &Value,
 ) -> Result<ExecRequest, OrbitError> {
+    let identity = super::resolve_identity(ctx, input)?;
     let id = super::required_string(input, &["id", "run_id", "runId"], "id")?;
-    Ok(super::orbit_exec_request(
+    Ok(super::orbit_exec_request_with_identity(
         ctx,
         vec![
             "job-run".to_string(),
@@ -19,15 +20,18 @@ pub(super) fn build_exec_request(
             id,
             "--json".to_string(),
         ],
+        &identity,
     ))
 }
 
 impl Tool for OrbitJobRunShowTool {
     fn schema(&self) -> ToolSchema {
+        let mut parameters = super::orbit_id_params("job run");
+        parameters.extend(super::identity_params());
         ToolSchema {
             name: "orbit.job_run.show".to_string(),
             description: "Fetch a single Orbit job run as JSON".to_string(),
-            parameters: super::orbit_id_params("job run"),
+            parameters,
             builtin: true,
         }
     }

--- a/orbit-tools/src/builtin/orbit/mod.rs
+++ b/orbit-tools/src/builtin/orbit/mod.rs
@@ -19,6 +19,14 @@ use serde_json::Value;
 use crate::{TIMEOUT_DEFAULT_MS, ToolContext, ToolRegistry};
 
 const ORBIT_TASK_ACTOR_KIND: &str = "ORBIT_TASK_ACTOR_KIND";
+const ORBIT_TASK_ACTOR_LABEL: &str = "ORBIT_TASK_ACTOR_LABEL";
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub(super) struct OrbitIdentity {
+    pub agent: Option<String>,
+    pub model: Option<String>,
+    pub actor_label: Option<String>,
+}
 
 pub fn register(registry: &mut ToolRegistry) {
     registry.register(task_add::OrbitTaskAddTool);
@@ -34,6 +42,65 @@ pub fn register(registry: &mut ToolRegistry) {
     registry.register(activity_show::OrbitActivityShowTool);
 }
 
+fn build_actor_label(agent: Option<&str>, model: Option<&str>) -> Option<String> {
+    match (agent, model) {
+        (Some(agent), Some(model)) => Some(format!("{agent} / {model}")),
+        (Some(agent), None) => Some(agent.to_string()),
+        (None, Some(model)) => Some(model.to_string()),
+        (None, None) => None,
+    }
+}
+
+pub(super) fn resolve_identity(
+    ctx: &ToolContext,
+    input: &Value,
+) -> Result<OrbitIdentity, OrbitError> {
+    let agent = optional_string_alias(input, &["agent"])?.or_else(|| {
+        ctx.agent_name
+            .clone()
+            .filter(|value| !value.trim().is_empty())
+    });
+    let model = optional_string_alias(input, &["model"])?.or_else(|| {
+        ctx.model_name
+            .clone()
+            .filter(|value| !value.trim().is_empty())
+    });
+    let actor_label = build_actor_label(agent.as_deref(), model.as_deref());
+    Ok(OrbitIdentity {
+        agent,
+        model,
+        actor_label,
+    })
+}
+
+pub(super) fn identity_params() -> Vec<ToolParam> {
+    vec![
+        ToolParam {
+            name: "agent".to_string(),
+            description: "Optional agent name for precise Orbit provenance".to_string(),
+            param_type: "string".to_string(),
+            required: false,
+        },
+        ToolParam {
+            name: "model".to_string(),
+            description: "Optional agent model for precise Orbit provenance".to_string(),
+            param_type: "string".to_string(),
+            required: false,
+        },
+    ]
+}
+
+pub(super) fn append_identity_flags(args: &mut Vec<String>, identity: &OrbitIdentity) {
+    if let Some(agent) = &identity.agent {
+        args.push("--agent".to_string());
+        args.push(agent.clone());
+    }
+    if let Some(model) = &identity.model {
+        args.push("--model".to_string());
+        args.push(model.clone());
+    }
+}
+
 /// Build an [`ExecRequest`] that runs the `orbit` CLI with `args`.
 ///
 /// The environment is deliberately rebuilt from the current process's env vars
@@ -41,9 +108,21 @@ pub fn register(registry: &mut ToolRegistry) {
 /// injected. This lets the orbit CLI distinguish agent-initiated mutations from
 /// human-initiated ones (e.g. for audit attribution and policy checks) without
 /// requiring callers to set the variable themselves.
+#[cfg(test)]
 pub(super) fn orbit_exec_request(ctx: &ToolContext, args: Vec<String>) -> ExecRequest {
+    orbit_exec_request_with_identity(ctx, args, &OrbitIdentity::default())
+}
+
+pub(super) fn orbit_exec_request_with_identity(
+    ctx: &ToolContext,
+    args: Vec<String>,
+    identity: &OrbitIdentity,
+) -> ExecRequest {
     let mut env = std::env::vars().collect::<HashMap<_, _>>();
     env.insert(ORBIT_TASK_ACTOR_KIND.to_string(), "agent".to_string());
+    if let Some(actor_label) = &identity.actor_label {
+        env.insert(ORBIT_TASK_ACTOR_LABEL.to_string(), actor_label.clone());
+    }
 
     // Inject --root so the spawned orbit CLI resolves to the correct data root
     // regardless of the agent's working directory (e.g. inside a git worktree).
@@ -66,10 +145,7 @@ pub(super) fn orbit_exec_request(ctx: &ToolContext, args: Vec<String>) -> ExecRe
     }
 }
 
-pub(super) fn run_orbit_json_command(
-    req: ExecRequest,
-    label: &str,
-) -> Result<Value, OrbitError> {
+pub(super) fn run_orbit_json_command(req: ExecRequest, label: &str) -> Result<Value, OrbitError> {
     let result = run_process(&req, &NoSandbox)?;
     if !result.success {
         let stderr = result.stderr.trim();
@@ -247,6 +323,28 @@ mod tests {
     }
 
     #[test]
+    fn orbit_exec_request_with_identity_sets_actor_label_env() {
+        let req = super::orbit_exec_request_with_identity(
+            &ToolContext::default(),
+            vec!["task".to_string(), "list".to_string()],
+            &super::OrbitIdentity {
+                agent: Some("codex".to_string()),
+                model: Some("gpt-5.4".to_string()),
+                actor_label: Some("codex / gpt-5.4".to_string()),
+            },
+        );
+
+        let orbit_exec::EnvironmentMode::ClearAndSet(env) = req.environment_mode else {
+            panic!("expected clear-and-set env");
+        };
+        let env_map = env.into_iter().collect::<std::collections::HashMap<_, _>>();
+        assert_eq!(
+            env_map.get("ORBIT_TASK_ACTOR_LABEL").map(String::as_str),
+            Some("codex / gpt-5.4")
+        );
+    }
+
+    #[test]
     fn task_show_builds_request_from_id() {
         let req = super::task_show::build_exec_request(
             &ToolContext::default(),
@@ -280,6 +378,8 @@ mod tests {
                 "id": "T20260316-010101",
                 "note": "approved and ready",
                 "comment": "starting implementation",
+                "agent": "codex",
+                "model": "gpt-5.4",
             }),
         )
         .expect("valid start input");
@@ -294,6 +394,10 @@ mod tests {
                 "approved and ready".to_string(),
                 "--comment".to_string(),
                 "starting implementation".to_string(),
+                "--agent".to_string(),
+                "codex".to_string(),
+                "--model".to_string(),
+                "gpt-5.4".to_string(),
                 "--json".to_string(),
             ]
         );
@@ -313,6 +417,8 @@ mod tests {
                 "priority": "high",
                 "complexity": "hard",
                 "type": "feature",
+                "agent": "codex",
+                "model": "gpt-5.4",
             }),
         )
         .expect("valid add input");
@@ -340,6 +446,10 @@ mod tests {
                 "hard".to_string(),
                 "--type".to_string(),
                 "feature".to_string(),
+                "--agent".to_string(),
+                "codex".to_string(),
+                "--model".to_string(),
+                "gpt-5.4".to_string(),
                 "--json".to_string(),
             ]
         );
@@ -353,6 +463,8 @@ mod tests {
                 "id": "T20260315-205817",
                 "note": "lgtm",
                 "comment": "ship it",
+                "agent": "codex",
+                "model": "gpt-5.4",
             }),
         )
         .expect("valid approve input");
@@ -367,6 +479,10 @@ mod tests {
                 "lgtm".to_string(),
                 "--comment".to_string(),
                 "ship it".to_string(),
+                "--agent".to_string(),
+                "codex".to_string(),
+                "--model".to_string(),
+                "gpt-5.4".to_string(),
                 "--json".to_string(),
             ]
         );
@@ -380,6 +496,8 @@ mod tests {
                 "id": "T20260315-205817",
                 "note": "needs work",
                 "comment": "please revise",
+                "agent": "codex",
+                "model": "gpt-5.4",
             }),
         )
         .expect("valid reject input");
@@ -394,6 +512,10 @@ mod tests {
                 "needs work".to_string(),
                 "--comment".to_string(),
                 "please revise".to_string(),
+                "--agent".to_string(),
+                "codex".to_string(),
+                "--model".to_string(),
+                "gpt-5.4".to_string(),
                 "--json".to_string(),
             ]
         );
@@ -427,6 +549,8 @@ mod tests {
                 "id": "T20260315-025432",
                 "status": "review",
                 "comment": "ready for review",
+                "agent": "codex",
+                "model": "gpt-5.4",
             }),
         )
         .expect("valid update input");
@@ -441,6 +565,10 @@ mod tests {
                 "review".to_string(),
                 "--comment".to_string(),
                 "ready for review".to_string(),
+                "--agent".to_string(),
+                "codex".to_string(),
+                "--model".to_string(),
+                "gpt-5.4".to_string(),
             ]
         );
         assert_eq!(

--- a/orbit-tools/src/builtin/orbit/task_add.rs
+++ b/orbit-tools/src/builtin/orbit/task_add.rs
@@ -10,6 +10,7 @@ pub(super) fn build_exec_request(
     ctx: &ToolContext,
     input: &Value,
 ) -> Result<ExecRequest, OrbitError> {
+    let identity = super::resolve_identity(ctx, input)?;
     let title = super::required_string(input, &["title"], "title")?;
     let description = super::required_string(input, &["description"], "description")?;
     let plan = super::required_string(input, &["plan"], "plan")?;
@@ -56,79 +57,85 @@ pub(super) fn build_exec_request(
         args.push("--source-task".to_string());
         args.push(source_task);
     }
+    super::append_identity_flags(&mut args, &identity);
 
     args.push("--json".to_string());
-    Ok(super::orbit_exec_request(ctx, args))
+    Ok(super::orbit_exec_request_with_identity(
+        ctx, args, &identity,
+    ))
 }
 
 impl Tool for OrbitTaskAddTool {
     fn schema(&self) -> ToolSchema {
+        let mut parameters = vec![
+            ToolParam {
+                name: "title".to_string(),
+                description: "Task title".to_string(),
+                param_type: "string".to_string(),
+                required: true,
+            },
+            ToolParam {
+                name: "description".to_string(),
+                description: "Task description markdown".to_string(),
+                param_type: "string".to_string(),
+                required: true,
+            },
+            ToolParam {
+                name: "plan".to_string(),
+                description: "Task plan markdown".to_string(),
+                param_type: "string".to_string(),
+                required: true,
+            },
+            ToolParam {
+                name: "workspace".to_string(),
+                description: "Workspace path for the task".to_string(),
+                param_type: "string".to_string(),
+                required: true,
+            },
+            ToolParam {
+                name: "comment".to_string(),
+                description: "Optional initial task comment".to_string(),
+                param_type: "string".to_string(),
+                required: false,
+            },
+            ToolParam {
+                name: "context".to_string(),
+                description: "Optional comma-separated context file paths".to_string(),
+                param_type: "string".to_string(),
+                required: false,
+            },
+            ToolParam {
+                name: "priority".to_string(),
+                description: "Optional priority level".to_string(),
+                param_type: "string".to_string(),
+                required: false,
+            },
+            ToolParam {
+                name: "complexity".to_string(),
+                description: "Optional task complexity level".to_string(),
+                param_type: "string".to_string(),
+                required: false,
+            },
+            ToolParam {
+                name: "type".to_string(),
+                description: "Optional task type".to_string(),
+                param_type: "string".to_string(),
+                required: false,
+            },
+            ToolParam {
+                name: "source_task_id".to_string(),
+                description: "For bug tasks: originating task ID that introduced the defect"
+                    .to_string(),
+                param_type: "string".to_string(),
+                required: false,
+            },
+        ];
+        parameters.extend(super::identity_params());
+
         ToolSchema {
             name: "orbit.task.add".to_string(),
             description: "Create an Orbit task and return the created task JSON".to_string(),
-            parameters: vec![
-                ToolParam {
-                    name: "title".to_string(),
-                    description: "Task title".to_string(),
-                    param_type: "string".to_string(),
-                    required: true,
-                },
-                ToolParam {
-                    name: "description".to_string(),
-                    description: "Task description markdown".to_string(),
-                    param_type: "string".to_string(),
-                    required: true,
-                },
-                ToolParam {
-                    name: "plan".to_string(),
-                    description: "Task plan markdown".to_string(),
-                    param_type: "string".to_string(),
-                    required: true,
-                },
-                ToolParam {
-                    name: "workspace".to_string(),
-                    description: "Workspace path for the task".to_string(),
-                    param_type: "string".to_string(),
-                    required: true,
-                },
-                ToolParam {
-                    name: "comment".to_string(),
-                    description: "Optional initial task comment".to_string(),
-                    param_type: "string".to_string(),
-                    required: false,
-                },
-                ToolParam {
-                    name: "context".to_string(),
-                    description: "Optional comma-separated context file paths".to_string(),
-                    param_type: "string".to_string(),
-                    required: false,
-                },
-                ToolParam {
-                    name: "priority".to_string(),
-                    description: "Optional priority level".to_string(),
-                    param_type: "string".to_string(),
-                    required: false,
-                },
-                ToolParam {
-                    name: "complexity".to_string(),
-                    description: "Optional task complexity level".to_string(),
-                    param_type: "string".to_string(),
-                    required: false,
-                },
-                ToolParam {
-                    name: "type".to_string(),
-                    description: "Optional task type".to_string(),
-                    param_type: "string".to_string(),
-                    required: false,
-                },
-                ToolParam {
-                    name: "source_task_id".to_string(),
-                    description: "For bug tasks: originating task ID that introduced the defect"
-                        .to_string(),
-                    param_type: "string".to_string(),
-                    required: false,
-                },
-            ],
+            parameters,
             builtin: true,
         }
     }

--- a/orbit-tools/src/builtin/orbit/task_approve.rs
+++ b/orbit-tools/src/builtin/orbit/task_approve.rs
@@ -10,6 +10,7 @@ pub(super) fn build_exec_request(
     ctx: &ToolContext,
     input: &Value,
 ) -> Result<ExecRequest, OrbitError> {
+    let identity = super::resolve_identity(ctx, input)?;
     let id = super::required_string(input, &["id"], "id")?;
     let note = super::required_string(input, &["note"], "note")?;
 
@@ -25,9 +26,12 @@ pub(super) fn build_exec_request(
         args.push("--comment".to_string());
         args.push(comment);
     }
+    super::append_identity_flags(&mut args, &identity);
 
     args.push("--json".to_string());
-    Ok(super::orbit_exec_request(ctx, args))
+    Ok(super::orbit_exec_request_with_identity(
+        ctx, args, &identity,
+    ))
 }
 
 impl Tool for OrbitTaskApproveTool {
@@ -47,6 +51,7 @@ impl Tool for OrbitTaskApproveTool {
                 required: false,
             },
         ]);
+        parameters.extend(super::identity_params());
 
         ToolSchema {
             name: "orbit.task.approve".to_string(),

--- a/orbit-tools/src/builtin/orbit/task_list.rs
+++ b/orbit-tools/src/builtin/orbit/task_list.rs
@@ -10,6 +10,7 @@ pub(super) fn build_exec_request(
     ctx: &ToolContext,
     input: &Value,
 ) -> Result<ExecRequest, OrbitError> {
+    let identity = super::resolve_identity(ctx, input)?;
     let mut args = vec!["task".to_string(), "list".to_string(), "--json".to_string()];
 
     if let Some(status) = super::optional_string(input, "status")? {
@@ -17,20 +18,24 @@ pub(super) fn build_exec_request(
         args.push(status);
     }
 
-    Ok(super::orbit_exec_request(ctx, args))
+    Ok(super::orbit_exec_request_with_identity(
+        ctx, args, &identity,
+    ))
 }
 
 impl Tool for OrbitTaskListTool {
     fn schema(&self) -> ToolSchema {
+        let mut parameters = vec![ToolParam {
+            name: "status".to_string(),
+            description: "Optional task status filter".to_string(),
+            param_type: "string".to_string(),
+            required: false,
+        }];
+        parameters.extend(super::identity_params());
         ToolSchema {
             name: "orbit.task.list".to_string(),
             description: "List Orbit tasks, optionally filtered by status".to_string(),
-            parameters: vec![ToolParam {
-                name: "status".to_string(),
-                description: "Optional task status filter".to_string(),
-                param_type: "string".to_string(),
-                required: false,
-            }],
+            parameters,
             builtin: true,
         }
     }

--- a/orbit-tools/src/builtin/orbit/task_reject.rs
+++ b/orbit-tools/src/builtin/orbit/task_reject.rs
@@ -10,6 +10,7 @@ pub(super) fn build_exec_request(
     ctx: &ToolContext,
     input: &Value,
 ) -> Result<ExecRequest, OrbitError> {
+    let identity = super::resolve_identity(ctx, input)?;
     let id = super::required_string(input, &["id"], "id")?;
     let note = super::required_string(input, &["note"], "note")?;
 
@@ -25,9 +26,12 @@ pub(super) fn build_exec_request(
         args.push("--comment".to_string());
         args.push(comment);
     }
+    super::append_identity_flags(&mut args, &identity);
 
     args.push("--json".to_string());
-    Ok(super::orbit_exec_request(ctx, args))
+    Ok(super::orbit_exec_request_with_identity(
+        ctx, args, &identity,
+    ))
 }
 
 impl Tool for OrbitTaskRejectTool {
@@ -47,6 +51,7 @@ impl Tool for OrbitTaskRejectTool {
                 required: false,
             },
         ]);
+        parameters.extend(super::identity_params());
 
         ToolSchema {
             name: "orbit.task.reject".to_string(),

--- a/orbit-tools/src/builtin/orbit/task_show.rs
+++ b/orbit-tools/src/builtin/orbit/task_show.rs
@@ -10,8 +10,9 @@ pub(super) fn build_exec_request(
     ctx: &ToolContext,
     input: &Value,
 ) -> Result<ExecRequest, OrbitError> {
+    let identity = super::resolve_identity(ctx, input)?;
     let id = super::required_string(input, &["id"], "id")?;
-    Ok(super::orbit_exec_request(
+    Ok(super::orbit_exec_request_with_identity(
         ctx,
         vec![
             "task".to_string(),
@@ -19,15 +20,18 @@ pub(super) fn build_exec_request(
             id,
             "--json".to_string(),
         ],
+        &identity,
     ))
 }
 
 impl Tool for OrbitTaskShowTool {
     fn schema(&self) -> ToolSchema {
+        let mut parameters = super::orbit_id_params("task");
+        parameters.extend(super::identity_params());
         ToolSchema {
             name: "orbit.task.show".to_string(),
             description: "Fetch a single Orbit task as JSON".to_string(),
-            parameters: super::orbit_id_params("task"),
+            parameters,
             builtin: true,
         }
     }

--- a/orbit-tools/src/builtin/orbit/task_start.rs
+++ b/orbit-tools/src/builtin/orbit/task_start.rs
@@ -10,6 +10,7 @@ pub(super) fn build_exec_request(
     ctx: &ToolContext,
     input: &Value,
 ) -> Result<ExecRequest, OrbitError> {
+    let identity = super::resolve_identity(ctx, input)?;
     let id = super::required_string(input, &["id"], "id")?;
 
     let mut args = vec!["task".to_string(), "start".to_string(), id];
@@ -22,9 +23,12 @@ pub(super) fn build_exec_request(
         args.push("--comment".to_string());
         args.push(comment);
     }
+    super::append_identity_flags(&mut args, &identity);
 
     args.push("--json".to_string());
-    Ok(super::orbit_exec_request(ctx, args))
+    Ok(super::orbit_exec_request_with_identity(
+        ctx, args, &identity,
+    ))
 }
 
 impl Tool for OrbitTaskStartTool {
@@ -44,6 +48,7 @@ impl Tool for OrbitTaskStartTool {
                 required: false,
             },
         ]);
+        parameters.extend(super::identity_params());
 
         ToolSchema {
             name: "orbit.task.start".to_string(),

--- a/orbit-tools/src/builtin/orbit/task_update.rs
+++ b/orbit-tools/src/builtin/orbit/task_update.rs
@@ -10,6 +10,7 @@ pub(super) fn build_exec_requests(
     ctx: &ToolContext,
     input: &Value,
 ) -> Result<(ExecRequest, ExecRequest), OrbitError> {
+    let identity = super::resolve_identity(ctx, input)?;
     let id = super::required_string(input, &["id"], "id")?;
     let mut args = vec!["task".to_string(), "update".to_string(), id.clone()];
     let mut changed = false;
@@ -37,8 +38,10 @@ pub(super) fn build_exec_requests(
         ));
     }
 
-    let update = super::orbit_exec_request(ctx, args);
-    let show = super::orbit_exec_request(
+    super::append_identity_flags(&mut args, &identity);
+
+    let update = super::orbit_exec_request_with_identity(ctx, args, &identity);
+    let show = super::orbit_exec_request_with_identity(
         ctx,
         vec![
             "task".to_string(),
@@ -46,6 +49,7 @@ pub(super) fn build_exec_requests(
             id,
             "--json".to_string(),
         ],
+        &identity,
     );
     Ok((update, show))
 }
@@ -73,6 +77,7 @@ impl Tool for OrbitTaskUpdateTool {
                 required: false,
             },
         ]);
+        parameters.extend(super::identity_params());
 
         ToolSchema {
             name: "orbit.task.update".to_string(),


### PR DESCRIPTION
## Summary
- accept optional `agent` and `model` across the builtin `orbit.*` tool surface
- propagate explicit identity through task add/update/start/approve/reject so task provenance is precise
- update Orbit skills and add CLI coverage for the explicit identity path

## Task
- T20260322-194749

## Validation
- `cargo test -p orbit-tools builtin::orbit:: -- --nocapture`
- `cargo test -p orbit-cli --test task_commands -- --nocapture`
- `cargo test -p orbit-core --lib task_ -- --nocapture`

*authored by: codex / gpt-5.4*