### PR TITLE
feat: auto-increment friction bounty scoreboard on task lifecycle events

### DIFF
--- a/orbit-cli/tests/init_commands.rs
+++ b/orbit-cli/tests/init_commands.rs
@@ -226,7 +226,7 @@ fn init_is_idempotent_for_existing_defaults() {
         .assert()
         .success()
         .stdout(predicate::str::contains("skills: root="))
-        .stdout(predicate::str::contains("refreshed=6"));
+        .stdout(predicate::str::contains("refreshed=8"));
 
     // Second init also refreshes all defaults (overwrite in place).
     orbit_in(home.path())
@@ -234,7 +234,7 @@ fn init_is_idempotent_for_existing_defaults() {
         .assert()
         .success()
         .stdout(predicate::str::contains("skills: root="))
-        .stdout(predicate::str::contains("refreshed=6"));
+        .stdout(predicate::str::contains("refreshed=8"));
 }
 
 #[test]

--- a/orbit-core/assets/skills/orbit-track-issues/SKILL.md
+++ b/orbit-core/assets/skills/orbit-track-issues/SKILL.md
@@ -54,7 +54,7 @@ Do **not ignore friction**. Always create a task.
 orbit tool run orbit.task.add --input '{
   "title": "<short, specific problem statement>",
   "description": "<what happened, where, and why it caused friction>",
-  "type": "issue",
+  "type": "friction",
   "priority": "<low|medium|high|critical>",
   "agent": "<agent>",
   "model": "<model>"

--- a/orbit-core/src/command/task.rs
+++ b/orbit-core/src/command/task.rs
@@ -256,7 +256,9 @@ impl OrbitRuntime {
             }
         });
 
-        let task = self.with_mutation(|| {
+        let old_status = task.status;
+        let target_status = params.status;
+        let updated = self.with_mutation(|| {
             let task = self.update_task_record(
                 id,
                 StoreTaskUpdateParams {
@@ -272,7 +274,13 @@ impl OrbitRuntime {
             Ok((task.clone(), OrbitEvent::TaskUpdated { id: id.to_string() }))
         })?;
 
-        Ok(task)
+        if let Some(new_status) = target_status {
+            if new_status != old_status {
+                self.try_record_friction_transition(&task, old_status, new_status);
+            }
+        }
+
+        Ok(updated)
     }
 
     pub fn approve_task(
@@ -352,14 +360,11 @@ impl OrbitRuntime {
             ))),
         }?;
 
-        // Friction bounty: record issues-accepted on approval
-        if task.task_type.is_friction() {
-            if let (Some(a), Some(m)) = (&task.agent, &task.model) {
-                if let Some(repo_root) = find_git_repo_root(self.data_root_path()) {
-                    let _ = friction_bounty::record_friction_accepted(&repo_root, a, m);
-                }
-            }
-        }
+        self.try_record_friction_transition(
+            &task,
+            task.status,
+            if task.status == TaskStatus::Proposed { TaskStatus::Backlog } else { TaskStatus::Done },
+        );
 
         Ok(result)
     }
@@ -388,7 +393,7 @@ impl OrbitRuntime {
 
         match task.status {
             TaskStatus::Proposed => {
-                let task = self.with_mutation(|| {
+                let result = self.with_mutation(|| {
                     let at = Utc::now();
                     let task = self.update_task_record(
                         id,
@@ -420,7 +425,12 @@ impl OrbitRuntime {
                         },
                     ))
                 })?;
-                Ok(task)
+                self.try_record_friction_transition(
+                    &task,
+                    TaskStatus::Proposed,
+                    TaskStatus::InProgress,
+                );
+                Ok(result)
             }
             TaskStatus::Backlog | TaskStatus::Someday | TaskStatus::Blocked => {
                 let task = self.with_mutation(|| {
@@ -541,14 +551,7 @@ impl OrbitRuntime {
             ))),
         }?;
 
-        // Friction bounty: record issues-rejected on rejection
-        if task.task_type.is_friction() {
-            if let (Some(a), Some(m)) = (&task.agent, &task.model) {
-                if let Some(repo_root) = find_git_repo_root(self.data_root_path()) {
-                    let _ = friction_bounty::record_friction_rejected(&repo_root, a, m);
-                }
-            }
-        }
+        self.try_record_friction_transition(&task, task.status, TaskStatus::Rejected);
 
         Ok(result)
     }
@@ -610,6 +613,37 @@ impl OrbitRuntime {
 
     pub fn search_tasks(&self, query: &str) -> Result<Vec<Task>, OrbitError> {
         self.search_task_records(query)
+    }
+
+    /// Best-effort friction bounty scoreboard update after a status transition.
+    fn try_record_friction_transition(
+        &self,
+        task: &Task,
+        from: TaskStatus,
+        to: TaskStatus,
+    ) {
+        if !task.task_type.is_friction() {
+            return;
+        }
+        let (Some(agent), Some(model)) = (&task.agent, &task.model) else {
+            return;
+        };
+        let Some(repo_root) = find_git_repo_root(self.data_root_path()) else {
+            return;
+        };
+
+        let is_approval = matches!(
+            (from, to),
+            (TaskStatus::Proposed, TaskStatus::Backlog)
+                | (TaskStatus::Proposed, TaskStatus::InProgress)
+                | (TaskStatus::Review, TaskStatus::Done)
+        );
+
+        if is_approval {
+            let _ = friction_bounty::record_friction_accepted(&repo_root, agent, model);
+        } else if to == TaskStatus::Rejected {
+            let _ = friction_bounty::record_friction_rejected(&repo_root, agent, model);
+        }
     }
 
     #[cfg(test)]

--- a/orbit-core/src/command/task.rs
+++ b/orbit-core/src/command/task.rs
@@ -1,6 +1,7 @@
 use chrono::Utc;
 use orbit_store::{
     TaskCreateParams as StoreTaskCreateParams, TaskUpdateParams as StoreTaskUpdateParams,
+    friction_bounty,
 };
 use orbit_types::{
     OrbitError, OrbitEvent, Task, TaskComment, TaskComplexity, TaskHistoryEntry, TaskPriority,
@@ -9,6 +10,7 @@ use orbit_types::{
 
 use crate::OrbitRuntime;
 use crate::context::ActorKind;
+use crate::paths::find_git_repo_root;
 
 pub struct TaskAddParams {
     pub title: String,
@@ -85,7 +87,7 @@ impl OrbitRuntime {
             };
         let comments = build_task_comments(params.comment.clone(), effective_label.as_str())?;
 
-        self.with_mutation(|| {
+        let task = self.with_mutation(|| {
             let task = self.create_task_record(StoreTaskCreateParams {
                 actor: effective_label.clone(),
                 title: params.title.clone(),
@@ -114,7 +116,18 @@ impl OrbitRuntime {
                     id: task.id.clone(),
                 },
             ))
-        })
+        })?;
+
+        // Friction bounty: record issues-reported on creation when agent+model present
+        if params.task_type.is_friction() {
+            if let (Some(a), Some(m)) = (&agent, &model) {
+                if let Some(repo_root) = find_git_repo_root(self.data_root_path()) {
+                    let _ = friction_bounty::record_friction_reported(&repo_root, a, m);
+                }
+            }
+        }
+
+        Ok(task)
     }
 
     pub fn get_task(&self, id: &str) -> Result<Task, OrbitError> {
@@ -284,9 +297,9 @@ impl OrbitRuntime {
         let effective_label = effective_actor_label(&actor.label, agent.as_deref(), model.as_deref());
         let append_comments = build_task_comments(comment, effective_label.as_str())?;
 
-        match task.status {
+        let result = match task.status {
             TaskStatus::Proposed => {
-                let task = self.with_mutation(|| {
+                self.with_mutation(|| {
                     let task = self.update_task_record(
                         id,
                         StoreTaskUpdateParams {
@@ -308,11 +321,10 @@ impl OrbitRuntime {
                             approved_by: effective_label.clone(),
                         },
                     ))
-                })?;
-                Ok(task)
+                })
             }
             TaskStatus::Review => {
-                let task = self.with_mutation(|| {
+                self.with_mutation(|| {
                     let task = self.update_task_record(
                         id,
                         StoreTaskUpdateParams {
@@ -333,13 +345,23 @@ impl OrbitRuntime {
                             approved_by: effective_label.clone(),
                         },
                     ))
-                })?;
-                Ok(task)
+                })
             }
             other => Err(OrbitError::InvalidInput(format!(
                 "task '{id}' is in status '{other}'; approve requires 'proposed' or 'review'"
             ))),
+        }?;
+
+        // Friction bounty: record issues-accepted on approval
+        if task.task_type.is_friction() {
+            if let (Some(a), Some(m)) = (&task.agent, &task.model) {
+                if let Some(repo_root) = find_git_repo_root(self.data_root_path()) {
+                    let _ = friction_bounty::record_friction_accepted(&repo_root, a, m);
+                }
+            }
         }
+
+        Ok(result)
     }
 
     pub fn start_task(
@@ -465,9 +487,9 @@ impl OrbitRuntime {
         let reason = reason.to_string();
         let append_comments = build_task_comments(comment, effective_label.as_str())?;
 
-        match task.status {
+        let result = match task.status {
             TaskStatus::Proposed => {
-                let task = self.with_mutation(|| {
+                self.with_mutation(|| {
                     let task = self.update_task_record(
                         id,
                         StoreTaskUpdateParams {
@@ -488,11 +510,10 @@ impl OrbitRuntime {
                             rejected_by: effective_label.clone(),
                         },
                     ))
-                })?;
-                Ok(task)
+                })
             }
             TaskStatus::Review => {
-                let task = self.with_mutation(|| {
+                self.with_mutation(|| {
                     let task = self.update_task_record(
                         id,
                         StoreTaskUpdateParams {
@@ -513,13 +534,23 @@ impl OrbitRuntime {
                             rejected_by: effective_label.clone(),
                         },
                     ))
-                })?;
-                Ok(task)
+                })
             }
             other => Err(OrbitError::InvalidInput(format!(
                 "task '{id}' is in status '{other}'; reject requires 'proposed' or 'review'"
             ))),
+        }?;
+
+        // Friction bounty: record issues-rejected on rejection
+        if task.task_type.is_friction() {
+            if let (Some(a), Some(m)) = (&task.agent, &task.model) {
+                if let Some(repo_root) = find_git_repo_root(self.data_root_path()) {
+                    let _ = friction_bounty::record_friction_rejected(&repo_root, a, m);
+                }
+            }
         }
+
+        Ok(result)
     }
 
     pub fn archive_task(&self, id: &str) -> Result<(), OrbitError> {

--- a/orbit-engine/src/executor/automation/input.rs
+++ b/orbit-engine/src/executor/automation/input.rs
@@ -69,7 +69,7 @@ pub(super) fn task_commit_message(
 ) -> String {
     let prefix = match task_type {
         TaskType::Task | TaskType::Feature => "feat",
-        TaskType::Issue | TaskType::Bug => "fix",
+        TaskType::Friction | TaskType::Issue | TaskType::Bug => "fix",
         TaskType::Chore => "chore",
         TaskType::Refactor => "refactor",
     };

--- a/orbit-store/src/file/friction_bounty.rs
+++ b/orbit-store/src/file/friction_bounty.rs
@@ -1,0 +1,132 @@
+//! Friction bounty scoreboard auto-increment.
+//!
+//! Updates `scoreboard/friction_bounty.json` when friction/issue tasks
+//! transition through lifecycle states:
+//! - **creation** (agent + model present): increment `issues-reported`
+//! - **approval** (proposed→backlog, review→done): increment `issues-accepted`
+//! - **rejection**: increment `issues-rejected`
+
+use std::collections::HashMap;
+use std::fs;
+use std::path::Path;
+
+use orbit_types::OrbitError;
+
+type AgentScores = HashMap<String, HashMap<String, u64>>;
+type Scoreboard = HashMap<String, AgentScores>;
+
+/// Increment the `issues-reported` counter for the given agent/model.
+pub fn record_friction_reported(
+    repo_root: &Path,
+    agent: &str,
+    model: &str,
+) -> Result<(), OrbitError> {
+    increment(repo_root, "issues-reported", agent, model)
+}
+
+/// Increment the `issues-accepted` counter for the given agent/model.
+pub fn record_friction_accepted(
+    repo_root: &Path,
+    agent: &str,
+    model: &str,
+) -> Result<(), OrbitError> {
+    increment(repo_root, "issues-accepted", agent, model)
+}
+
+/// Increment the `issues-rejected` counter for the given agent/model.
+pub fn record_friction_rejected(
+    repo_root: &Path,
+    agent: &str,
+    model: &str,
+) -> Result<(), OrbitError> {
+    increment(repo_root, "issues-rejected", agent, model)
+}
+
+fn increment(
+    repo_root: &Path,
+    metric: &str,
+    agent: &str,
+    model: &str,
+) -> Result<(), OrbitError> {
+    let path = repo_root.join("scoreboard").join("friction_bounty.json");
+    let mut scoreboard: Scoreboard = if path.exists() {
+        let content = fs::read_to_string(&path)
+            .map_err(|e| OrbitError::Io(format!("read friction_bounty.json: {e}")))?;
+        serde_json::from_str(&content)
+            .map_err(|e| OrbitError::Io(format!("parse friction_bounty.json: {e}")))?
+    } else {
+        HashMap::new()
+    };
+
+    let agent_map = scoreboard.entry(metric.to_string()).or_default();
+    let model_map = agent_map.entry(agent.to_string()).or_default();
+    let counter = model_map.entry(model.to_string()).or_insert(0);
+    *counter += 1;
+
+    let json = serde_json::to_string_pretty(&scoreboard)
+        .map_err(|e| OrbitError::Io(format!("serialize friction_bounty.json: {e}")))?;
+
+    // Write atomically via temp file + rename
+    let dir = path
+        .parent()
+        .ok_or_else(|| OrbitError::Io("no parent dir for friction_bounty.json".to_string()))?;
+    fs::create_dir_all(dir)
+        .map_err(|e| OrbitError::Io(format!("create scoreboard dir: {e}")))?;
+
+    let tmp = dir.join(".friction_bounty.json.tmp");
+    fs::write(&tmp, format!("{json}\n"))
+        .map_err(|e| OrbitError::Io(format!("write friction_bounty tmp: {e}")))?;
+    fs::rename(&tmp, &path)
+        .map_err(|e| OrbitError::Io(format!("rename friction_bounty tmp: {e}")))?;
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn increment_creates_and_updates_scoreboard() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+
+        // First increment creates the file
+        record_friction_reported(root, "claude", "opus-4.6").unwrap();
+
+        let path = root.join("scoreboard/friction_bounty.json");
+        assert!(path.exists());
+        let sb: Scoreboard =
+            serde_json::from_str(&fs::read_to_string(&path).unwrap()).unwrap();
+        assert_eq!(sb["issues-reported"]["claude"]["opus-4.6"], 1);
+
+        // Second increment bumps the counter
+        record_friction_reported(root, "claude", "opus-4.6").unwrap();
+        let sb: Scoreboard =
+            serde_json::from_str(&fs::read_to_string(&path).unwrap()).unwrap();
+        assert_eq!(sb["issues-reported"]["claude"]["opus-4.6"], 2);
+
+        // Different metric
+        record_friction_accepted(root, "claude", "opus-4.6").unwrap();
+        let sb: Scoreboard =
+            serde_json::from_str(&fs::read_to_string(&path).unwrap()).unwrap();
+        assert_eq!(sb["issues-accepted"]["claude"]["opus-4.6"], 1);
+        // Original metric unchanged
+        assert_eq!(sb["issues-reported"]["claude"]["opus-4.6"], 2);
+    }
+
+    #[test]
+    fn increment_different_agents() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+
+        record_friction_reported(root, "claude", "opus-4.6").unwrap();
+        record_friction_reported(root, "codex", "gpt-5.4").unwrap();
+
+        let path = root.join("scoreboard/friction_bounty.json");
+        let sb: Scoreboard =
+            serde_json::from_str(&fs::read_to_string(&path).unwrap()).unwrap();
+        assert_eq!(sb["issues-reported"]["claude"]["opus-4.6"], 1);
+        assert_eq!(sb["issues-reported"]["codex"]["gpt-5.4"], 1);
+    }
+}

--- a/orbit-store/src/file/mod.rs
+++ b/orbit-store/src/file/mod.rs
@@ -10,6 +10,7 @@
 //! file-based stores.
 
 pub(crate) mod activity_store;
+pub(crate) mod friction_bounty;
 pub(crate) mod friction_log;
 pub(crate) mod fs_utils;
 pub(crate) mod job_store;

--- a/orbit-store/src/lib.rs
+++ b/orbit-store/src/lib.rs
@@ -31,6 +31,12 @@ pub mod skill_store {
     pub use crate::file::skill_store::*;
 }
 
+pub mod friction_bounty {
+    pub use crate::file::friction_bounty::{
+        record_friction_accepted, record_friction_rejected, record_friction_reported,
+    };
+}
+
 pub mod friction_log {
     pub use crate::file::friction_log::{append_friction_entry, read_friction_entries_for_month};
 }

--- a/orbit-types/src/task.rs
+++ b/orbit-types/src/task.rs
@@ -214,6 +214,11 @@ impl FromStr for TaskComplexity {
 pub enum TaskType {
     Task,
     Feature,
+    /// Agent-reported friction, DX issues, or system problems.
+    /// Preferred type for agent issue reports — triggers scoreboard hooks.
+    Friction,
+    /// Legacy alias for Friction. Both types trigger scoreboard hooks.
+    #[serde(alias = "issue")]
     Issue,
     /// An attributable defect — tracks which agent/model introduced the bug
     /// via the `agent`, `model`, and `source_task_id` fields on [`Task`].
@@ -229,6 +234,7 @@ impl Display for TaskType {
         let s = match self {
             TaskType::Task => "task",
             TaskType::Feature => "feature",
+            TaskType::Friction => "friction",
             TaskType::Issue => "issue",
             TaskType::Bug => "bug",
             TaskType::Chore => "chore",
@@ -245,6 +251,7 @@ impl FromStr for TaskType {
         match s {
             "task" => Ok(TaskType::Task),
             "feature" => Ok(TaskType::Feature),
+            "friction" => Ok(TaskType::Friction),
             "issue" => Ok(TaskType::Issue),
             "bug" => Ok(TaskType::Bug),
             "chore" => Ok(TaskType::Chore),
@@ -253,6 +260,13 @@ impl FromStr for TaskType {
             "refactor" => Ok(TaskType::Refactor),
             other => Err(format!("unknown task type: {other}")),
         }
+    }
+}
+
+impl TaskType {
+    /// Returns true for task types that trigger friction bounty scoreboard hooks.
+    pub fn is_friction(&self) -> bool {
+        matches!(self, TaskType::Friction | TaskType::Issue)
     }
 }
 


### PR DESCRIPTION
## Summary
- Adds `TaskType::Friction` to orbit-types with `is_friction()` helper (matches both `Friction` and `Issue` for backward compat)
- Adds `friction_bounty` module in orbit-store for atomic scoreboard read/increment/write
- Hooks `scoreboard/friction_bounty.json` auto-increment into three task lifecycle points: creation (`issues-reported`), approval (`issues-accepted`), rejection (`issues-rejected`)
- Updates `orbit-track-issues` skill to default to `type: friction`
- Fixes pre-existing init test (skill count 6→8)

## Test plan
- [x] `cargo build` passes
- [x] `cargo test -p orbit-types -p orbit-store -p orbit-core -p orbit-engine` all pass
- [x] `cargo test -p orbit-cli --test init_commands` passes (fixed pre-existing failure)
- [x] Unit tests for friction_bounty module cover creation, increment, and multi-agent scenarios
- [ ] Manual: create a friction task via `orbit tool run orbit.task.add` with agent/model and verify `friction_bounty.json` increments

Orbit Task: T20260322-211601

*authored by: claude / opus-4.6*