### PR TITLE
feat: add conditional job step routing [T20260321-230020]

### DIFF
--- a/orbit-core/assets/jobs/job_task_pipeline.yaml
+++ b/orbit-core/assets/jobs/job_task_pipeline.yaml
@@ -30,34 +30,42 @@ job:
 
     - target_type: activity
       target_id: create_branch
+      condition: on_success
       timeout_seconds: 60
 
     - target_type: activity
       target_id: implement_change
       agent_cli: claude
+      condition: on_success
       timeout_seconds: 2000
 
     - target_type: activity
       target_id: update_task
+      condition: on_success
       timeout_seconds: 15
 
     - target_type: activity
       target_id: run_tests
+      condition: on_success
       timeout_seconds: 600
 
     - target_type: activity
       target_id: commit_changes
+      condition: on_success
       timeout_seconds: 60
 
     - target_type: activity
       target_id: open_pr
+      condition: on_success
       timeout_seconds: 300
 
     - target_type: activity
       target_id: review_pr
       agent_cli: claude
+      condition: on_success
       timeout_seconds: 600
 
     - target_type: activity
       target_id: merge_pr
+      condition: on_success
       timeout_seconds: 60

--- a/orbit-core/src/command/job.rs
+++ b/orbit-core/src/command/job.rs
@@ -3,7 +3,7 @@ use orbit_agent::{Agent, AgentConfig};
 use orbit_store::JobCreateParams as StoreActivityCreateParams;
 use orbit_store::JobUpdateParams as StoreJobUpdateParams;
 use orbit_types::{
-    Job, JobRun, JobScheduleState, JobStep, JobTargetType, OrbitError, OrbitEvent,
+    Job, JobRun, JobScheduleState, JobStep, JobTargetType, OrbitError, OrbitEvent, StepCondition,
     default_job_max_active_runs,
 };
 use serde::Deserialize;
@@ -62,6 +62,8 @@ struct DefaultJobStep {
     retry_max_attempts: u32,
     #[serde(default = "orbit_types::default_retry_backoff_seconds")]
     retry_backoff_seconds: u64,
+    #[serde(default)]
+    condition: StepCondition,
     #[serde(default)]
     output_map: std::collections::HashMap<String, String>,
 }
@@ -351,6 +353,7 @@ fn default_job_steps(entry: &DefaultJobEntry) -> Result<Vec<JobStep>, OrbitError
                 env_extra: s.env_extra.clone(),
                 retry_max_attempts: s.retry_max_attempts,
                 retry_backoff_seconds: s.retry_backoff_seconds,
+                condition: s.condition,
                 output_map: s.output_map.clone(),
             })
         })
@@ -369,6 +372,8 @@ fn validate_job_max_active_runs(max_active_runs: Option<u32>) -> Result<u32, Orb
 
 #[cfg(test)]
 mod tests {
+    use orbit_types::StepCondition;
+
     use super::{DEFAULT_JOB_FILES, load_default_job_specs};
 
     #[test]
@@ -404,6 +409,7 @@ mod tests {
             .expect("task pipeline spec present");
         assert_eq!(pipeline.max_active_runs, 4);
         assert_eq!(pipeline.steps[0].model.as_deref(), Some("gpt-5.4"));
+        assert_eq!(pipeline.steps[1].condition, StepCondition::OnSuccess);
         let review = specs
             .iter()
             .find(|spec| spec.job_id == "job_review_tasks")

--- a/orbit-core/src/command/task.rs
+++ b/orbit-core/src/command/task.rs
@@ -78,7 +78,8 @@ impl OrbitRuntime {
         model: Option<String>,
     ) -> Result<Task, OrbitError> {
         let actor = self.actor().clone();
-        let effective_label = effective_actor_label(&actor.label, agent.as_deref(), model.as_deref());
+        let effective_label =
+            effective_actor_label(&actor.label, agent.as_deref(), model.as_deref());
         let initial_status =
             if actor.kind == ActorKind::Agent && self.task_approval_required_for_agent() {
                 TaskStatus::Proposed
@@ -241,13 +242,15 @@ impl OrbitRuntime {
         }
 
         let actor = self.actor().clone();
-        let effective_label = effective_actor_label(&actor.label, agent.as_deref(), model.as_deref());
+        let effective_label =
+            effective_actor_label(&actor.label, agent.as_deref(), model.as_deref());
         let status_note = status_note
             .as_deref()
             .map(str::trim)
             .filter(|value| !value.is_empty())
             .map(ToOwned::to_owned);
-        let append_comments = build_task_comments(params.comment.clone(), effective_label.as_str())?;
+        let append_comments =
+            build_task_comments(params.comment.clone(), effective_label.as_str())?;
         let assigned_to = params.status.and_then(|status| {
             if status == TaskStatus::InProgress {
                 Some(Some(effective_label.clone()))
@@ -302,59 +305,56 @@ impl OrbitRuntime {
     ) -> Result<Task, OrbitError> {
         let task = self.get_task(id)?;
         let actor = self.actor().clone();
-        let effective_label = effective_actor_label(&actor.label, agent.as_deref(), model.as_deref());
+        let effective_label =
+            effective_actor_label(&actor.label, agent.as_deref(), model.as_deref());
         let append_comments = build_task_comments(comment, effective_label.as_str())?;
 
         let result = match task.status {
-            TaskStatus::Proposed => {
-                self.with_mutation(|| {
-                    let task = self.update_task_record(
-                        id,
-                        StoreTaskUpdateParams {
-                            actor: effective_label.clone(),
-                            status: Some(TaskStatus::Backlog),
-                            status_event: Some("proposal_approved".to_string()),
-                            status_note: note.clone(),
-                            assigned_to: Some(Some(effective_label.clone())),
-                            agent: agent.clone().map(Some),
-                            model: model.clone().map(Some),
-                            append_comments: append_comments.clone(),
-                            ..Default::default()
-                        },
-                    )?;
-                    Ok((
-                        task.clone(),
-                        OrbitEvent::TaskProposalApproved {
-                            id: id.to_string(),
-                            approved_by: effective_label.clone(),
-                        },
-                    ))
-                })
-            }
-            TaskStatus::Review => {
-                self.with_mutation(|| {
-                    let task = self.update_task_record(
-                        id,
-                        StoreTaskUpdateParams {
-                            actor: effective_label.clone(),
-                            status: Some(TaskStatus::Done),
-                            status_event: Some("review_approved".to_string()),
-                            status_note: note.clone(),
-                            agent: agent.clone().map(Some),
-                            model: model.clone().map(Some),
-                            append_comments: append_comments.clone(),
-                            ..Default::default()
-                        },
-                    )?;
-                    Ok((
-                        task.clone(),
-                        OrbitEvent::TaskReviewApproved {
-                            id: id.to_string(),
-                            approved_by: effective_label.clone(),
-                        },
-                    ))
-                })
-            }
+            TaskStatus::Proposed => self.with_mutation(|| {
+                let task = self.update_task_record(
+                    id,
+                    StoreTaskUpdateParams {
+                        actor: effective_label.clone(),
+                        status: Some(TaskStatus::Backlog),
+                        status_event: Some("proposal_approved".to_string()),
+                        status_note: note.clone(),
+                        assigned_to: Some(Some(effective_label.clone())),
+                        agent: agent.clone().map(Some),
+                        model: model.clone().map(Some),
+                        append_comments: append_comments.clone(),
+                        ..Default::default()
+                    },
+                )?;
+                Ok((
+                    task.clone(),
+                    OrbitEvent::TaskProposalApproved {
+                        id: id.to_string(),
+                        approved_by: effective_label.clone(),
+                    },
+                ))
+            }),
+            TaskStatus::Review => self.with_mutation(|| {
+                let task = self.update_task_record(
+                    id,
+                    StoreTaskUpdateParams {
+                        actor: effective_label.clone(),
+                        status: Some(TaskStatus::Done),
+                        status_event: Some("review_approved".to_string()),
+                        status_note: note.clone(),
+                        agent: agent.clone().map(Some),
+                        model: model.clone().map(Some),
+                        append_comments: append_comments.clone(),
+                        ..Default::default()
+                    },
+                )?;
+                Ok((
+                    task.clone(),
+                    OrbitEvent::TaskReviewApproved {
+                        id: id.to_string(),
+                        approved_by: effective_label.clone(),
+                    },
+                ))
+            }),
             other => Err(OrbitError::InvalidInput(format!(
                 "task '{id}' is in status '{other}'; approve requires 'proposed' or 'review'"
             ))),
@@ -363,7 +363,11 @@ impl OrbitRuntime {
         self.try_record_friction_transition(
             &task,
             task.status,
-            if task.status == TaskStatus::Proposed { TaskStatus::Backlog } else { TaskStatus::Done },
+            if task.status == TaskStatus::Proposed {
+                TaskStatus::Backlog
+            } else {
+                TaskStatus::Done
+            },
         );
 
         Ok(result)
@@ -388,7 +392,8 @@ impl OrbitRuntime {
     ) -> Result<Task, OrbitError> {
         let task = self.get_task(id)?;
         let actor = self.actor().clone();
-        let effective_label = effective_actor_label(&actor.label, agent.as_deref(), model.as_deref());
+        let effective_label =
+            effective_actor_label(&actor.label, agent.as_deref(), model.as_deref());
         let append_comments = build_task_comments(comment, effective_label.as_str())?;
 
         match task.status {
@@ -487,7 +492,8 @@ impl OrbitRuntime {
     ) -> Result<Task, OrbitError> {
         let task = self.get_task(id)?;
         let actor = self.actor().clone();
-        let effective_label = effective_actor_label(&actor.label, agent.as_deref(), model.as_deref());
+        let effective_label =
+            effective_actor_label(&actor.label, agent.as_deref(), model.as_deref());
         let reason = note.trim();
         if reason.is_empty() {
             return Err(OrbitError::InvalidInput(
@@ -498,54 +504,50 @@ impl OrbitRuntime {
         let append_comments = build_task_comments(comment, effective_label.as_str())?;
 
         let result = match task.status {
-            TaskStatus::Proposed => {
-                self.with_mutation(|| {
-                    let task = self.update_task_record(
-                        id,
-                        StoreTaskUpdateParams {
-                            actor: effective_label.clone(),
-                            status: Some(TaskStatus::Rejected),
-                            status_event: Some("proposal_rejected".to_string()),
-                            status_note: Some(reason.clone()),
-                            agent: agent.clone().map(Some),
-                            model: model.clone().map(Some),
-                            append_comments: append_comments.clone(),
-                            ..Default::default()
-                        },
-                    )?;
-                    Ok((
-                        task.clone(),
-                        OrbitEvent::TaskProposalRejected {
-                            id: id.to_string(),
-                            rejected_by: effective_label.clone(),
-                        },
-                    ))
-                })
-            }
-            TaskStatus::Review => {
-                self.with_mutation(|| {
-                    let task = self.update_task_record(
-                        id,
-                        StoreTaskUpdateParams {
-                            actor: effective_label.clone(),
-                            status: Some(TaskStatus::Rejected),
-                            status_event: Some("review_rejected".to_string()),
-                            status_note: Some(reason.clone()),
-                            agent: agent.clone().map(Some),
-                            model: model.clone().map(Some),
-                            append_comments: append_comments.clone(),
-                            ..Default::default()
-                        },
-                    )?;
-                    Ok((
-                        task.clone(),
-                        OrbitEvent::TaskReviewRejected {
-                            id: id.to_string(),
-                            rejected_by: effective_label.clone(),
-                        },
-                    ))
-                })
-            }
+            TaskStatus::Proposed => self.with_mutation(|| {
+                let task = self.update_task_record(
+                    id,
+                    StoreTaskUpdateParams {
+                        actor: effective_label.clone(),
+                        status: Some(TaskStatus::Rejected),
+                        status_event: Some("proposal_rejected".to_string()),
+                        status_note: Some(reason.clone()),
+                        agent: agent.clone().map(Some),
+                        model: model.clone().map(Some),
+                        append_comments: append_comments.clone(),
+                        ..Default::default()
+                    },
+                )?;
+                Ok((
+                    task.clone(),
+                    OrbitEvent::TaskProposalRejected {
+                        id: id.to_string(),
+                        rejected_by: effective_label.clone(),
+                    },
+                ))
+            }),
+            TaskStatus::Review => self.with_mutation(|| {
+                let task = self.update_task_record(
+                    id,
+                    StoreTaskUpdateParams {
+                        actor: effective_label.clone(),
+                        status: Some(TaskStatus::Rejected),
+                        status_event: Some("review_rejected".to_string()),
+                        status_note: Some(reason.clone()),
+                        agent: agent.clone().map(Some),
+                        model: model.clone().map(Some),
+                        append_comments: append_comments.clone(),
+                        ..Default::default()
+                    },
+                )?;
+                Ok((
+                    task.clone(),
+                    OrbitEvent::TaskReviewRejected {
+                        id: id.to_string(),
+                        rejected_by: effective_label.clone(),
+                    },
+                ))
+            }),
             other => Err(OrbitError::InvalidInput(format!(
                 "task '{id}' is in status '{other}'; reject requires 'proposed' or 'review'"
             ))),
@@ -616,12 +618,7 @@ impl OrbitRuntime {
     }
 
     /// Best-effort friction bounty scoreboard update after a status transition.
-    fn try_record_friction_transition(
-        &self,
-        task: &Task,
-        from: TaskStatus,
-        to: TaskStatus,
-    ) {
+    fn try_record_friction_transition(&self, task: &Task, from: TaskStatus, to: TaskStatus) {
         if !task.task_type.is_friction() {
             return;
         }

--- a/orbit-core/src/lib.rs
+++ b/orbit-core/src/lib.rs
@@ -799,8 +799,14 @@ mod tests {
             )
             .expect("start");
         assert_eq!(started.assigned_to.as_deref(), Some("codex / gpt-5.4"));
-        assert_eq!(started.comments.last().expect("comment").by, "codex / gpt-5.4");
-        assert_eq!(started.history.last().expect("history").by, "codex / gpt-5.4");
+        assert_eq!(
+            started.comments.last().expect("comment").by,
+            "codex / gpt-5.4"
+        );
+        assert_eq!(
+            started.history.last().expect("history").by,
+            "codex / gpt-5.4"
+        );
     }
 
     #[test]

--- a/orbit-core/tests/job_runtime_behavior.rs
+++ b/orbit-core/tests/job_runtime_behavior.rs
@@ -9,7 +9,9 @@ use orbit_core::command::job::JobAddParams;
 use orbit_core::command::job_run::JobRunListParams;
 use orbit_core::command::task::{TaskAddParams, TaskUpdateParams};
 use orbit_store::friction_log::read_friction_entries_for_month;
-use orbit_types::{JobRunState, JobStep, OrbitError, TaskPriority, TaskStatus, TaskType};
+use orbit_types::{
+    JobRunState, JobStep, OrbitError, StepCondition, TaskPriority, TaskStatus, TaskType,
+};
 use serde_json::json;
 use tempfile::tempdir;
 
@@ -1556,6 +1558,94 @@ fn empty_stdout_timeout_marks_run_as_timeout() {
             .unwrap_or_default()
             .contains("timed out")
     );
+}
+
+#[test]
+fn job_conditions_record_skips_and_continue_after_failures() {
+    let dir = tempdir().expect("tempdir");
+    let runtime = OrbitRuntime::from_data_root(dir.path()).expect("runtime");
+    let success_dir = dir.path().join("success-agent");
+    let failed_dir = dir.path().join("failed-agent");
+    std::fs::create_dir_all(&success_dir).expect("create success agent dir");
+    std::fs::create_dir_all(&failed_dir).expect("create failed agent dir");
+
+    let success_agent = write_agent_script(
+        &success_dir.join("mock-agent"),
+        "#!/bin/sh\ncat >/dev/null\nprintf '{\"schemaVersion\":1,\"status\":\"success\",\"result\":{},\"error\":null,\"durationMs\":1}'\n",
+    );
+    let failed_agent = write_agent_script(
+        &failed_dir.join("mock-agent"),
+        "#!/bin/sh\ncat >/dev/null\nprintf '{\"schemaVersion\":1,\"status\":\"failed\",\"result\":null,\"error\":{\"code\":\"STEP_FAILED\",\"message\":\"boom\",\"details\":{}},\"durationMs\":1}'\n",
+    );
+
+    for activity_id in [
+        "spec-condition-success",
+        "spec-condition-failure",
+        "spec-condition-recovery",
+        "spec-condition-timeout-only",
+        "spec-condition-always",
+    ] {
+        add_activity(&runtime, activity_id);
+    }
+
+    let job_id = runtime
+        .add_job(JobAddParams {
+            job_id: None,
+            default_input: None,
+            max_active_runs: None,
+            steps: vec![
+                JobStep {
+                    target_id: "spec-condition-success".to_string(),
+                    agent_cli: success_agent.clone(),
+                    timeout_seconds: 10,
+                    ..Default::default()
+                },
+                JobStep {
+                    target_id: "spec-condition-failure".to_string(),
+                    agent_cli: failed_agent,
+                    timeout_seconds: 10,
+                    ..Default::default()
+                },
+                JobStep {
+                    target_id: "spec-condition-recovery".to_string(),
+                    agent_cli: success_agent.clone(),
+                    timeout_seconds: 10,
+                    condition: StepCondition::OnFailure,
+                    ..Default::default()
+                },
+                JobStep {
+                    target_id: "spec-condition-timeout-only".to_string(),
+                    agent_cli: success_agent.clone(),
+                    timeout_seconds: 10,
+                    condition: StepCondition::OnTimeout,
+                    ..Default::default()
+                },
+                JobStep {
+                    target_id: "spec-condition-always".to_string(),
+                    agent_cli: success_agent,
+                    timeout_seconds: 10,
+                    condition: StepCondition::Always,
+                    ..Default::default()
+                },
+            ],
+            initial_state_override: None,
+        })
+        .expect("add job")
+        .job_id;
+
+    let run = runtime.run_job_now(&job_id).expect("run job");
+    assert_eq!(run.state, JobRunState::Failed);
+
+    let history = runtime.job_history(&job_id).expect("history");
+    let steps = &history[0].steps;
+    assert_eq!(steps.len(), 5);
+    assert_eq!(steps[0].state, JobRunState::Success);
+    assert_eq!(steps[1].state, JobRunState::Failed);
+    assert_eq!(steps[2].state, JobRunState::Success);
+    assert_eq!(steps[3].state, JobRunState::Skipped);
+    assert_eq!(steps[4].state, JobRunState::Success);
+    assert_eq!(steps[3].error_code, None);
+    assert_eq!(steps[3].agent_response_json, None);
 }
 
 #[test]

--- a/orbit-engine/src/job_runner.rs
+++ b/orbit-engine/src/job_runner.rs
@@ -546,9 +546,7 @@ fn should_run_step(condition: StepCondition, previous_step_state: Option<JobRunS
         StepCondition::OnSuccess => {
             previous_step_state.is_none_or(|state| matches!(state, JobRunState::Success))
         }
-        StepCondition::OnFailure => {
-            previous_step_state.is_some_and(|state| matches!(state, JobRunState::Failed))
-        }
+        StepCondition::OnFailure => previous_step_state.is_some_and(step_state_records_failure),
         StepCondition::OnTimeout => {
             previous_step_state.is_some_and(|state| matches!(state, JobRunState::Timeout))
         }
@@ -765,6 +763,14 @@ mod tests {
         assert!(should_run_step(
             StepCondition::OnFailure,
             Some(JobRunState::Failed)
+        ));
+    }
+
+    #[test]
+    fn on_failure_condition_runs_after_timeout() {
+        assert!(should_run_step(
+            StepCondition::OnFailure,
+            Some(JobRunState::Timeout)
         ));
     }
 

--- a/orbit-engine/src/job_runner.rs
+++ b/orbit-engine/src/job_runner.rs
@@ -5,6 +5,7 @@ use orbit_store::friction_log::append_friction_entry;
 use orbit_store::metrics_log::append_metrics_entry;
 use orbit_types::{
     FrictionEntry, Job, JobRun, JobRunState, JobStep, MetricsEntry, OrbitError, OrbitEvent,
+    StepCondition,
 };
 use serde_json::Value;
 use std::path::Path;
@@ -90,9 +91,35 @@ fn execute_activity_with_retries<H: EngineHost>(
         let mut last_protocol_violation = false;
         let mut current_input = merge_job_input(job.default_input.as_ref(), input)?;
         let mut last_failure: Option<(String, String)> = None;
+        let mut previous_step_state: Option<JobRunState> = None;
 
         for (step_index, step) in job.steps.iter().enumerate() {
             failure_step = (step_index, step.clone());
+
+            if !should_run_step(step.condition, previous_step_state) {
+                let skipped_at = Utc::now();
+                let changed = host.complete_job_run_step(
+                    &run.run_id,
+                    &JobRunStepParams {
+                        step_index,
+                        target_type: step.target_type,
+                        target_id: step.target_id.clone(),
+                        started_at: skipped_at,
+                        finished_at: skipped_at,
+                        duration_ms: Some(0),
+                        exit_code: None,
+                        agent_response_json: None,
+                        state: JobRunState::Skipped,
+                        error_code: None,
+                        error_message: None,
+                    },
+                )?;
+                if !changed {
+                    return Err(OrbitError::JobRunNotFound(run.run_id.clone()));
+                }
+                previous_step_state = Some(JobRunState::Skipped);
+                continue;
+            }
 
             let execution =
                 build_execution_context_for_step(host, &job, step, current_input.clone(), debug)?;
@@ -110,6 +137,7 @@ fn execute_activity_with_retries<H: EngineHost>(
                 total_duration_ms += d;
             }
             let step_state = outcome.state;
+            previous_step_state = Some(step_state);
 
             // Pipe this step's output fields into the next step's input.
             //
@@ -162,7 +190,7 @@ fn execute_activity_with_retries<H: EngineHost>(
                 return Err(OrbitError::JobRunNotFound(run.run_id.clone()));
             }
 
-            if step_state != JobRunState::Success {
+            if step_state_records_failure(step_state) {
                 append_failed_step_friction(
                     data_root,
                     host,
@@ -190,13 +218,12 @@ fn execute_activity_with_retries<H: EngineHost>(
                 last_protocol_violation = true;
             }
 
-            if step_state != JobRunState::Success {
+            if step_state_records_failure(step_state) {
                 last_failure = Some((
                     outcome.error_code.clone().unwrap_or_default(),
                     outcome.error_message.clone().unwrap_or_default(),
                 ));
                 final_state = step_state;
-                break;
             }
         }
 
@@ -513,6 +540,28 @@ fn merge_job_input(default_input: Option<&Value>, input: Value) -> Result<Value,
     Ok(Value::Object(merged))
 }
 
+fn should_run_step(condition: StepCondition, previous_step_state: Option<JobRunState>) -> bool {
+    match condition {
+        StepCondition::Always => true,
+        StepCondition::OnSuccess => {
+            previous_step_state.is_none_or(|state| matches!(state, JobRunState::Success))
+        }
+        StepCondition::OnFailure => {
+            previous_step_state.is_some_and(|state| matches!(state, JobRunState::Failed))
+        }
+        StepCondition::OnTimeout => {
+            previous_step_state.is_some_and(|state| matches!(state, JobRunState::Timeout))
+        }
+    }
+}
+
+fn step_state_records_failure(state: JobRunState) -> bool {
+    matches!(
+        state,
+        JobRunState::Failed | JobRunState::Timeout | JobRunState::Cancelled
+    )
+}
+
 fn record_task_agent_context<H: EngineHost>(
     host: &H,
     execution: &crate::context::ExecutionContext,
@@ -694,5 +743,43 @@ fn json_value_type_name(value: &Value) -> &'static str {
         Value::String(_) => "string",
         Value::Array(_) => "array",
         Value::Object(_) => "object",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use orbit_types::{JobRunState, StepCondition};
+
+    use super::should_run_step;
+
+    #[test]
+    fn on_failure_condition_skips_after_success() {
+        assert!(!should_run_step(
+            StepCondition::OnFailure,
+            Some(JobRunState::Success)
+        ));
+    }
+
+    #[test]
+    fn on_failure_condition_runs_after_failure() {
+        assert!(should_run_step(
+            StepCondition::OnFailure,
+            Some(JobRunState::Failed)
+        ));
+    }
+
+    #[test]
+    fn always_condition_runs_regardless_of_previous_state() {
+        let states = [
+            None,
+            Some(JobRunState::Success),
+            Some(JobRunState::Failed),
+            Some(JobRunState::Timeout),
+            Some(JobRunState::Skipped),
+        ];
+
+        for state in states {
+            assert!(should_run_step(StepCondition::Always, state));
+        }
     }
 }

--- a/orbit-store/src/file/friction_bounty.rs
+++ b/orbit-store/src/file/friction_bounty.rs
@@ -42,12 +42,7 @@ pub fn record_friction_rejected(
     increment(repo_root, "issues-rejected", agent, model)
 }
 
-fn increment(
-    repo_root: &Path,
-    metric: &str,
-    agent: &str,
-    model: &str,
-) -> Result<(), OrbitError> {
+fn increment(repo_root: &Path, metric: &str, agent: &str, model: &str) -> Result<(), OrbitError> {
     let path = repo_root.join("scoreboard").join("friction_bounty.json");
     let mut scoreboard: Scoreboard = if path.exists() {
         let content = fs::read_to_string(&path)
@@ -70,8 +65,7 @@ fn increment(
     let dir = path
         .parent()
         .ok_or_else(|| OrbitError::Io("no parent dir for friction_bounty.json".to_string()))?;
-    fs::create_dir_all(dir)
-        .map_err(|e| OrbitError::Io(format!("create scoreboard dir: {e}")))?;
+    fs::create_dir_all(dir).map_err(|e| OrbitError::Io(format!("create scoreboard dir: {e}")))?;
 
     let tmp = dir.join(".friction_bounty.json.tmp");
     fs::write(&tmp, format!("{json}\n"))
@@ -96,20 +90,17 @@ mod tests {
 
         let path = root.join("scoreboard/friction_bounty.json");
         assert!(path.exists());
-        let sb: Scoreboard =
-            serde_json::from_str(&fs::read_to_string(&path).unwrap()).unwrap();
+        let sb: Scoreboard = serde_json::from_str(&fs::read_to_string(&path).unwrap()).unwrap();
         assert_eq!(sb["issues-reported"]["claude"]["opus-4.6"], 1);
 
         // Second increment bumps the counter
         record_friction_reported(root, "claude", "opus-4.6").unwrap();
-        let sb: Scoreboard =
-            serde_json::from_str(&fs::read_to_string(&path).unwrap()).unwrap();
+        let sb: Scoreboard = serde_json::from_str(&fs::read_to_string(&path).unwrap()).unwrap();
         assert_eq!(sb["issues-reported"]["claude"]["opus-4.6"], 2);
 
         // Different metric
         record_friction_accepted(root, "claude", "opus-4.6").unwrap();
-        let sb: Scoreboard =
-            serde_json::from_str(&fs::read_to_string(&path).unwrap()).unwrap();
+        let sb: Scoreboard = serde_json::from_str(&fs::read_to_string(&path).unwrap()).unwrap();
         assert_eq!(sb["issues-accepted"]["claude"]["opus-4.6"], 1);
         // Original metric unchanged
         assert_eq!(sb["issues-reported"]["claude"]["opus-4.6"], 2);
@@ -124,8 +115,7 @@ mod tests {
         record_friction_reported(root, "codex", "gpt-5.4").unwrap();
 
         let path = root.join("scoreboard/friction_bounty.json");
-        let sb: Scoreboard =
-            serde_json::from_str(&fs::read_to_string(&path).unwrap()).unwrap();
+        let sb: Scoreboard = serde_json::from_str(&fs::read_to_string(&path).unwrap()).unwrap();
         assert_eq!(sb["issues-reported"]["claude"]["opus-4.6"], 1);
         assert_eq!(sb["issues-reported"]["codex"]["gpt-5.4"], 1);
     }

--- a/orbit-tools/src/builtin/github/pr_review_comment.rs
+++ b/orbit-tools/src/builtin/github/pr_review_comment.rs
@@ -16,7 +16,11 @@ pub(super) fn build_exec_request(
     let path = require_str(input, "path")?;
     let line = input
         .get("line")
-        .and_then(|v| v.as_u64().map(|n| n.to_string()).or_else(|| v.as_str().map(String::from)))
+        .and_then(|v| {
+            v.as_u64()
+                .map(|n| n.to_string())
+                .or_else(|| v.as_str().map(String::from))
+        })
         .filter(|s| !s.is_empty())
         .ok_or_else(|| OrbitError::InvalidInput("missing `line`".to_string()))?;
 
@@ -91,7 +95,9 @@ impl Tool for GithubPrReviewCommentTool {
     fn schema(&self) -> ToolSchema {
         ToolSchema {
             name: "github.pr.review.comment".to_string(),
-            description: "Post an inline review comment on a specific file and line of a pull request".to_string(),
+            description:
+                "Post an inline review comment on a specific file and line of a pull request"
+                    .to_string(),
             parameters: vec![
                 ToolParam {
                     name: "repo".to_string(),
@@ -125,7 +131,8 @@ impl Tool for GithubPrReviewCommentTool {
                 },
                 ToolParam {
                     name: "commit_id".to_string(),
-                    description: "Optional commit SHA to anchor the comment (defaults to PR head)".to_string(),
+                    description: "Optional commit SHA to anchor the comment (defaults to PR head)"
+                        .to_string(),
                     param_type: "string".to_string(),
                     required: false,
                 },

--- a/orbit-types/src/job.rs
+++ b/orbit-types/src/job.rs
@@ -82,6 +82,7 @@ pub enum JobRunState {
     Success,
     Failed,
     Timeout,
+    Skipped,
     /// Transient state emitted while the engine is sleeping between retry attempts.
     Retrying,
     /// Run was explicitly cancelled by the user before it completed.
@@ -106,6 +107,7 @@ impl Display for JobRunState {
             JobRunState::Success => write!(f, "success"),
             JobRunState::Failed => write!(f, "failed"),
             JobRunState::Timeout => write!(f, "timeout"),
+            JobRunState::Skipped => write!(f, "skipped"),
             JobRunState::Retrying => write!(f, "retrying"),
             JobRunState::Cancelled => write!(f, "cancelled"),
         }
@@ -122,11 +124,23 @@ impl FromStr for JobRunState {
             "success" => Ok(JobRunState::Success),
             "failed" => Ok(JobRunState::Failed),
             "timeout" => Ok(JobRunState::Timeout),
+            "skipped" => Ok(JobRunState::Skipped),
             "retrying" => Ok(JobRunState::Retrying),
             "cancelled" => Ok(JobRunState::Cancelled),
             other => Err(format!("unknown job run state: {other}")),
         }
     }
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[cfg_attr(feature = "clap", derive(clap::ValueEnum))]
+#[serde(rename_all = "snake_case")]
+pub enum StepCondition {
+    #[default]
+    Always,
+    OnSuccess,
+    OnFailure,
+    OnTimeout,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -179,6 +193,8 @@ pub struct JobStep {
     /// Initial backoff delay in seconds before the first retry; doubles with each attempt.
     #[serde(default = "default_retry_backoff_seconds")]
     pub retry_backoff_seconds: u64,
+    #[serde(default)]
+    pub condition: StepCondition,
     /// Rename output keys before merging into the next step's input.
     /// Each entry maps `source_key -> target_key`. Unmapped keys pass through unchanged.
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
@@ -196,6 +212,7 @@ impl Default for JobStep {
             env_extra: Vec::new(),
             retry_max_attempts: 0,
             retry_backoff_seconds: default_retry_backoff_seconds(),
+            condition: StepCondition::Always,
             output_map: HashMap::new(),
         }
     }

--- a/orbit-types/src/lib.rs
+++ b/orbit-types/src/lib.rs
@@ -45,7 +45,7 @@ pub use friction::FrictionEntry;
 pub use id::OrbitId;
 pub use job::{
     AgentCommitRequest, AgentResponseEnvelope, AgentRunError, Job, JobRun, JobRunState, JobRunStep,
-    JobScheduleState, JobStep, JobTargetType, default_job_max_active_runs,
+    JobScheduleState, JobStep, JobTargetType, StepCondition, default_job_max_active_runs,
     default_retry_backoff_seconds,
 };
 pub use metrics::MetricsEntry;
@@ -70,7 +70,7 @@ mod tests {
     use crate::{
         Activity, AgentCommitRequest, AgentResponseEnvelope, ExecutionResult, FrictionEntry, Job,
         JobRun, JobRunState, JobScheduleState, JobStep, MetricsEntry, OrbitEvent, Role, Skill,
-        TaskStatus,
+        StepCondition, TaskStatus,
     };
 
     #[test]
@@ -154,6 +154,7 @@ mod tests {
         assert_eq!(job_value["steps"][0]["target_type"], "activity");
         assert_eq!(job_value["steps"][0]["retry_max_attempts"], 3);
         assert_eq!(job_value["steps"][0]["retry_backoff_seconds"], 10);
+        assert_eq!(job_value["steps"][0]["condition"], "always");
 
         let run = JobRun {
             run_id: "run-1".to_string(),
@@ -185,9 +186,30 @@ mod tests {
             "retrying"
         );
         assert_eq!(
+            serde_json::to_value(JobRunState::Skipped).expect("serialize skipped"),
+            "skipped"
+        );
+        assert_eq!(
             "retrying".parse::<JobRunState>().expect("parse retrying"),
             JobRunState::Retrying
         );
+        assert_eq!(
+            "skipped".parse::<JobRunState>().expect("parse skipped"),
+            JobRunState::Skipped
+        );
+    }
+
+    #[test]
+    fn job_step_condition_defaults_to_always_when_missing() {
+        let step: JobStep = serde_json::from_value(serde_json::json!({
+            "target_type": "activity",
+            "target_id": "exec-1",
+            "agent_cli": "codex",
+            "timeout_seconds": 30
+        }))
+        .expect("deserialize step");
+
+        assert_eq!(step.condition, StepCondition::Always);
     }
 
     #[test]

--- a/scoreboard/friction_bounty.json
+++ b/scoreboard/friction_bounty.json
@@ -1,26 +1,26 @@
 {
-    "issues-reported": {
-        "codex": {
-            "gpt-5.4": 0
-        },
-        "claude": {
-            "opus-4.6": 0
-        }
+  "issues-reported": {
+    "claude": {
+      "opus-4.6": 0
     },
-    "issues-accepted": {
-        "codex": {
-            "gpt-5.4": 0
-        },
-        "claude": {
-            "opus-4.6": 0
-        }
-    },
-    "issues-rejected": {
-        "codex": {
-            "gpt-5.4": 0
-        },
-        "claude": {
-            "opus-4.6": 0
-        }
+    "codex": {
+      "gpt-5.4": 1
     }
+  },
+  "issues-rejected": {
+    "codex": {
+      "gpt-5.4": 0
+    },
+    "claude": {
+      "opus-4.6": 0
+    }
+  },
+  "issues-accepted": {
+    "codex": {
+      "gpt-5.4": 0
+    },
+    "claude": {
+      "opus-4.6": 0
+    }
+  }
 }

--- a/scoreboard/pr.json
+++ b/scoreboard/pr.json
@@ -4,7 +4,7 @@
             "gpt-5.4": 3
         },
         "claude": {
-            "opus-4.6": 3
+            "opus-4.6": 4
         }
     },
     "pr-count-without-revision": {
@@ -17,7 +17,7 @@
     },
     "valid-pr-review-comments": {
         "codex": {
-            "gpt-5.4": 7
+            "gpt-5.4": 9
         },
         "claude": {
             "opus-4.6": 6


### PR DESCRIPTION
## Summary
- add `StepCondition` and `JobRunState::Skipped` to the shared job model
- evaluate step conditions in the job runner so failed and timeout steps can be followed by conditional recovery or cleanup
- gate the bundled task pipeline explicitly with `on_success` and add coverage for skipped-step history

## Task
- T20260321-230020

## Verification
- `cargo test -p orbit-types`
- `cargo test -p orbit-engine`
- `cargo test -p orbit-core --test job_runtime_behavior job_conditions_record_skips_and_continue_after_failures`
- `cargo clippy --workspace`
- `cargo test --workspace` (still fails in unrelated pre-existing `orbit-tools` GitHub signature tests)

*authored by: codex / gpt-5.4*