### PR TITLE
feat: support parent task relationships [T20260321-230249]

### DIFF
--- a/orbit-agent/tests/protocol_behavior.rs
+++ b/orbit-agent/tests/protocol_behavior.rs
@@ -200,9 +200,7 @@ fn provider_mapper_supports_claude_model_override() {
 
 #[test]
 fn provider_mapper_rejects_unsupported_provider() {
-    let err = AgentConfig::cli("custom-agent")
-        .err()
-        .expect("unsupported provider must fail");
+    let err = AgentConfig::cli("custom-agent").expect_err("unsupported provider must fail");
     assert!(matches!(
         err,
         OrbitError::UnsupportedAgentProvider(provider) if provider == "custom-agent"

--- a/orbit-cli/src/command/task.rs
+++ b/orbit-cli/src/command/task.rs
@@ -268,7 +268,7 @@ impl Execute for TaskTemplatesListArgs {
 
 #[derive(Args)]
 #[command(
-    after_help = "Examples:\n  orbit task list\n  orbit task list --all\n  orbit task list --status backlog\n  orbit task list --status in-progress,review\n  orbit task list --priority high\n  orbit task list --parent T20260321-230249\n  orbit task list --json"
+    after_help = "Examples:\n  orbit task list\n  orbit task list --all\n  orbit task list --status backlog\n  orbit task list --status in-progress,review\n  orbit task list --priority high\n  orbit task list --parent T12345678-123456\n  orbit task list --json"
 )]
 pub struct TaskListArgs {
     /// Filter by one or more statuses (comma-separated). Defaults to backlog,in-progress.

--- a/orbit-cli/src/command/task.rs
+++ b/orbit-cli/src/command/task.rs
@@ -68,6 +68,9 @@ impl Execute for TaskSubcommand {
 
 #[derive(Args)]
 pub struct TaskAddArgs {
+    /// Parent task ID for hierarchical decomposition
+    #[arg(long = "parent")]
+    pub parent_id: Option<String>,
     /// Task title
     #[arg(long)]
     pub title: String,
@@ -111,6 +114,12 @@ pub struct TaskAddArgs {
 
 impl Execute for TaskAddArgs {
     fn execute(self, runtime: &OrbitRuntime) -> Result<(), OrbitError> {
+        if let Some(parent_id) = self.parent_id.as_deref()
+            && runtime.get_task(parent_id).is_err()
+        {
+            eprintln!("warning: parent task '{parent_id}' was not found; creating subtask anyway");
+        }
+
         // If a template is requested, resolve it and use its fields as defaults.
         let (description, plan, priority, task_type) = if let Some(ref tpl_name) = self.template {
             let tpl = runtime.get_task_template(tpl_name)?;
@@ -149,6 +158,7 @@ impl Execute for TaskAddArgs {
 
         let task = runtime.add_task_with_identity(
             TaskAddParams {
+                parent_id: self.parent_id,
                 title: self.title,
                 description,
                 plan,
@@ -258,7 +268,7 @@ impl Execute for TaskTemplatesListArgs {
 
 #[derive(Args)]
 #[command(
-    after_help = "Examples:\n  orbit task list\n  orbit task list --all\n  orbit task list --status backlog\n  orbit task list --status in-progress,review\n  orbit task list --priority high\n  orbit task list --json"
+    after_help = "Examples:\n  orbit task list\n  orbit task list --all\n  orbit task list --status backlog\n  orbit task list --status in-progress,review\n  orbit task list --priority high\n  orbit task list --parent T20260321-230249\n  orbit task list --json"
 )]
 pub struct TaskListArgs {
     /// Filter by one or more statuses (comma-separated). Defaults to backlog,in-progress.
@@ -270,6 +280,9 @@ pub struct TaskListArgs {
     /// Filter by priority level (low, medium, high)
     #[arg(long, value_enum)]
     pub priority: Option<TaskPriority>,
+    /// Filter to subtasks belonging to a parent task
+    #[arg(long = "parent")]
+    pub parent_id: Option<String>,
     /// Output full task objects as JSON
     #[arg(long)]
     pub json: bool,
@@ -283,6 +296,7 @@ impl Execute for TaskListArgs {
         let all = self.all;
         let status = self.status;
         let priority = self.priority;
+        let parent_id = self.parent_id;
 
         let all_tasks = runtime.list_tasks()?;
         let active_statuses = [TaskStatus::Backlog, TaskStatus::InProgress];
@@ -298,6 +312,11 @@ impl Execute for TaskListArgs {
             .into_iter()
             .filter(|t| status_filter.is_empty() || status_filter.contains(&t.status))
             .filter(|t| priority.is_none_or(|p| t.priority == p))
+            .filter(|t| {
+                parent_id
+                    .as_deref()
+                    .is_none_or(|p| t.parent_id.as_deref() == Some(p))
+            })
             .collect();
 
         if self.ops {
@@ -333,6 +352,9 @@ impl Execute for TaskShowArgs {
         } else {
             use crate::output::color::{bold, dimmed, priority_color, status_color};
             println!("{} {}", bold("ID:"), task.id);
+            if let Some(ref parent_id) = task.parent_id {
+                println!("{} {}", bold("Parent Task:"), parent_id);
+            }
             println!("{} {}", bold("Title:"), task.title);
             println!(
                 "{} {}",
@@ -602,7 +624,7 @@ pub struct TaskApproveArgs {
 impl Execute for TaskApproveArgs {
     fn execute(self, runtime: &OrbitRuntime) -> Result<(), OrbitError> {
         let ids = if self.all_proposed {
-            let proposed = runtime.list_tasks_filtered(Some(TaskStatus::Proposed), None)?;
+            let proposed = runtime.list_tasks_filtered(Some(TaskStatus::Proposed), None, None)?;
             if proposed.is_empty() {
                 println!("No proposed tasks found.");
                 return Ok(());
@@ -698,7 +720,7 @@ pub struct TaskRejectArgs {
 impl Execute for TaskRejectArgs {
     fn execute(self, runtime: &OrbitRuntime) -> Result<(), OrbitError> {
         let ids = if self.all_proposed {
-            let proposed = runtime.list_tasks_filtered(Some(TaskStatus::Proposed), None)?;
+            let proposed = runtime.list_tasks_filtered(Some(TaskStatus::Proposed), None, None)?;
             if proposed.is_empty() {
                 println!("No proposed tasks found.");
                 return Ok(());
@@ -880,6 +902,7 @@ fn print_task_table(tasks: &[orbit_core::Task]) {
 fn task_to_signal_json(task: &orbit_core::Task) -> Value {
     json!({
         "id": task.id,
+        "parent_id": task.parent_id,
         "title": task.title,
         "type": task.task_type.to_string(),
         "status": task.status.to_string(),
@@ -891,6 +914,7 @@ fn task_to_signal_json(task: &orbit_core::Task) -> Value {
 fn task_to_json(task: &orbit_core::Task) -> Value {
     json!({
         "id": task.id,
+        "parent_id": task.parent_id,
         "title": task.title,
         "description": task.description,
         "plan": task.plan,

--- a/orbit-cli/src/command/workspace.rs
+++ b/orbit-cli/src/command/workspace.rs
@@ -112,7 +112,7 @@ impl Execute for WorkspaceListArgs {
         // Save back if staleness changed any status
         workspace_registry::save_registry_to(&registry, &registry_path)?;
 
-        println!("{:<20} {:<12} {:<8} {}", "NAME", "ID", "STATUS", "ROOT");
+        println!("{:<20} {:<12} {:<8} ROOT", "NAME", "ID", "STATUS");
         for ws in &registry.workspaces {
             println!(
                 "{:<20} {:<12} {:<8} {}",

--- a/orbit-cli/tests/task_commands.rs
+++ b/orbit-cli/tests/task_commands.rs
@@ -139,6 +139,34 @@ fn task_add_json_returns_task_object() {
 }
 
 #[test]
+fn task_add_json_includes_parent_id_when_provided() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let parent_id = add_task(dir.path(), "parent task");
+
+    let output = orbit_in(dir.path())
+        .args([
+            "task",
+            "add",
+            "--title",
+            "child task",
+            "--description",
+            "json description",
+            "--plan",
+            "json plan",
+            "--parent",
+            &parent_id,
+            "--json",
+        ])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let task: serde_json::Value = serde_json::from_slice(&output).expect("task json");
+    assert_eq!(task["parent_id"], parent_id);
+}
+
+#[test]
 fn task_add_json_includes_complexity_when_provided() {
     let dir = tempfile::tempdir().expect("tempdir");
 
@@ -247,6 +275,49 @@ fn task_list_json() {
 }
 
 #[test]
+fn task_list_parent_filters_subtasks() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let parent_id = add_task(dir.path(), "parent task");
+    let child_output = orbit_in(dir.path())
+        .args([
+            "task",
+            "add",
+            "--title",
+            "child task",
+            "--description",
+            "desc",
+            "--plan",
+            "plan",
+            "--parent",
+            &parent_id,
+        ])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let child_id = String::from_utf8(child_output)
+        .expect("utf8")
+        .trim()
+        .to_string();
+    let _unrelated_id = add_task(dir.path(), "unrelated task");
+
+    let output = orbit_in(dir.path())
+        .args(["task", "list", "--all", "--parent", &parent_id, "--json"])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+
+    let parsed: serde_json::Value = serde_json::from_slice(&output).expect("valid JSON");
+    let arr = parsed.as_array().expect("array");
+    assert_eq!(arr.len(), 1);
+    assert_eq!(arr[0]["id"], child_id);
+    assert_eq!(arr[0]["parent_id"], parent_id);
+}
+
+#[test]
 fn task_show_displays_fields() {
     let dir = tempfile::tempdir().expect("tempdir");
     let id = add_task(dir.path(), "showable task");
@@ -261,12 +332,71 @@ fn task_show_displays_fields() {
 }
 
 #[test]
+fn task_show_displays_parent_task_when_present() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let parent_id = add_task(dir.path(), "parent task");
+    let child_output = orbit_in(dir.path())
+        .args([
+            "task",
+            "add",
+            "--title",
+            "child task",
+            "--description",
+            "desc",
+            "--plan",
+            "plan",
+            "--parent",
+            &parent_id,
+        ])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let child_id = String::from_utf8(child_output)
+        .expect("utf8")
+        .trim()
+        .to_string();
+
+    orbit_in(dir.path())
+        .args(["task", "show", &child_id])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Parent Task:"))
+        .stdout(predicate::str::contains(&parent_id));
+}
+
+#[test]
 fn task_show_nonexistent() {
     let dir = tempfile::tempdir().expect("tempdir");
     orbit_in(dir.path())
         .args(["task", "show", "task-nonexistent"])
         .assert()
         .failure();
+}
+
+#[test]
+fn task_add_warns_when_parent_is_missing() {
+    let dir = tempfile::tempdir().expect("tempdir");
+
+    orbit_in(dir.path())
+        .args([
+            "task",
+            "add",
+            "--title",
+            "child task",
+            "--description",
+            "desc",
+            "--plan",
+            "plan",
+            "--parent",
+            "T20260320-999999",
+        ])
+        .assert()
+        .success()
+        .stderr(predicate::str::contains(
+            "warning: parent task 'T20260320-999999' was not found",
+        ));
 }
 
 #[test]

--- a/orbit-core/src/command/job.rs
+++ b/orbit-core/src/command/job.rs
@@ -132,13 +132,13 @@ impl OrbitRuntime {
             }
             if step.target_type == JobTargetType::Job {
                 // Reject self-references.
-                if let Some(ref job_id) = params.job_id {
-                    if step.target_id == *job_id {
-                        return Err(OrbitError::JobValidation(format!(
-                            "job '{}' cannot reference itself as a step",
-                            job_id
-                        )));
-                    }
+                if let Some(ref job_id) = params.job_id
+                    && step.target_id == *job_id
+                {
+                    return Err(OrbitError::JobValidation(format!(
+                        "job '{}' cannot reference itself as a step",
+                        job_id
+                    )));
                 }
                 // Validate that the referenced job exists.
                 let referenced_job = self.get_job_backend(&step.target_id)?.ok_or_else(|| {
@@ -168,8 +168,7 @@ impl OrbitRuntime {
             // When agent_cli is specified, validate it eagerly. When empty,
             // the runner resolves it from the task's agent field at runtime
             // (e.g. review loop steps that route back to the original implementer).
-            if activity_requires_agent_cli(&activity.spec_type)
-                && !step.agent_cli.trim().is_empty()
+            if activity_requires_agent_cli(&activity.spec_type) && !step.agent_cli.trim().is_empty()
             {
                 let _ = Agent::new(
                     &AgentConfig::cli(step.agent_cli.clone())?.with_model(step.model.as_deref()),

--- a/orbit-core/src/command/task.rs
+++ b/orbit-core/src/command/task.rs
@@ -4,8 +4,8 @@ use orbit_store::{
     friction_bounty,
 };
 use orbit_types::{
-    OrbitError, OrbitEvent, Task, TaskComment, TaskComplexity, TaskHistoryEntry, TaskPriority,
-    TaskStatus, TaskType,
+    OrbitError, OrbitEvent, OrbitId, Task, TaskComment, TaskComplexity, TaskHistoryEntry,
+    TaskPriority, TaskStatus, TaskType,
 };
 
 use crate::OrbitRuntime;
@@ -13,6 +13,7 @@ use crate::context::ActorKind;
 use crate::paths::find_git_repo_root;
 
 pub struct TaskAddParams {
+    pub parent_id: Option<OrbitId>,
     pub title: String,
     pub description: String,
     pub plan: String,
@@ -28,6 +29,7 @@ pub struct TaskAddParams {
 impl Default for TaskAddParams {
     fn default() -> Self {
         Self {
+            parent_id: None,
             title: String::new(),
             description: String::new(),
             plan: String::new(),
@@ -91,6 +93,7 @@ impl OrbitRuntime {
         let task = self.with_mutation(|| {
             let task = self.create_task_record(StoreTaskCreateParams {
                 actor: effective_label.clone(),
+                parent_id: params.parent_id.clone(),
                 title: params.title.clone(),
                 description: params.description.clone(),
                 plan: params.plan.clone(),
@@ -120,12 +123,11 @@ impl OrbitRuntime {
         })?;
 
         // Friction bounty: record issues-reported on creation when agent+model present
-        if params.task_type.is_friction() {
-            if let (Some(a), Some(m)) = (&agent, &model) {
-                if let Some(repo_root) = find_git_repo_root(self.data_root_path()) {
-                    let _ = friction_bounty::record_friction_reported(&repo_root, a, m);
-                }
-            }
+        if params.task_type.is_friction()
+            && let (Some(a), Some(m)) = (&agent, &model)
+            && let Some(repo_root) = find_git_repo_root(self.data_root_path())
+        {
+            let _ = friction_bounty::record_friction_reported(&repo_root, a, m);
         }
 
         Ok(task)
@@ -144,8 +146,9 @@ impl OrbitRuntime {
         &self,
         status: Option<TaskStatus>,
         priority: Option<TaskPriority>,
+        parent_id: Option<&str>,
     ) -> Result<Vec<Task>, OrbitError> {
-        self.list_task_records_filtered(status, priority)
+        self.list_task_records_filtered(status, priority, parent_id)
     }
 
     pub fn update_task(&self, id: &str, params: TaskUpdateParams) -> Result<Task, OrbitError> {
@@ -277,10 +280,10 @@ impl OrbitRuntime {
             Ok((task.clone(), OrbitEvent::TaskUpdated { id: id.to_string() }))
         })?;
 
-        if let Some(new_status) = target_status {
-            if new_status != old_status {
-                self.try_record_friction_transition(&task, old_status, new_status);
-            }
+        if let Some(new_status) = target_status
+            && new_status != old_status
+        {
+            self.try_record_friction_transition(&task, old_status, new_status);
         }
 
         Ok(updated)
@@ -665,6 +668,7 @@ impl OrbitRuntime {
 
         self.create_task_record(StoreTaskCreateParams {
             actor: actor.clone(),
+            parent_id: None,
             title: title.to_string(),
             description: String::new(),
             plan: String::new(),

--- a/orbit-core/src/command/task_template.rs
+++ b/orbit-core/src/command/task_template.rs
@@ -157,7 +157,7 @@ impl OrbitRuntime {
                 .filter(|entry| {
                     let p = entry.path();
                     p.extension()
-                        .map_or(false, |ext| ext == "yaml" || ext == "yml")
+                        .is_some_and(|ext| ext == "yaml" || ext == "yml")
                 })
                 .collect::<Vec<_>>();
             entries.sort_by_key(|e| e.file_name());

--- a/orbit-core/src/lib.rs
+++ b/orbit-core/src/lib.rs
@@ -534,7 +534,7 @@ mod tests {
         runtime.archive_task(&t2.id).expect("archive");
 
         let backlog = runtime
-            .list_tasks_filtered(Some(TaskStatus::Backlog), None)
+            .list_tasks_filtered(Some(TaskStatus::Backlog), None, None)
             .expect("filter");
         assert_eq!(backlog.len(), 1);
         assert_eq!(backlog[0].title, "open");
@@ -559,10 +559,41 @@ mod tests {
             .expect("add");
 
         let high = runtime
-            .list_tasks_filtered(None, Some(TaskPriority::High))
+            .list_tasks_filtered(None, Some(TaskPriority::High), None)
             .expect("filter");
         assert_eq!(high.len(), 1);
         assert_eq!(high[0].title, "high");
+    }
+
+    #[test]
+    fn list_tasks_filters_by_parent_id() {
+        let runtime = OrbitRuntime::in_memory().expect("runtime");
+        let parent = runtime
+            .add_task(TaskAddParams {
+                title: "parent".to_string(),
+                ..Default::default()
+            })
+            .expect("add parent");
+        let child = runtime
+            .add_task(TaskAddParams {
+                parent_id: Some(parent.id.clone()),
+                title: "child".to_string(),
+                ..Default::default()
+            })
+            .expect("add child");
+        runtime
+            .add_task(TaskAddParams {
+                title: "other".to_string(),
+                ..Default::default()
+            })
+            .expect("add other");
+
+        let subtasks = runtime
+            .list_tasks_filtered(None, None, Some(&parent.id))
+            .expect("filter by parent");
+        assert_eq!(subtasks.len(), 1);
+        assert_eq!(subtasks[0].id, child.id);
+        assert_eq!(subtasks[0].parent_id.as_deref(), Some(parent.id.as_str()));
     }
 
     #[test]

--- a/orbit-core/src/paths.rs
+++ b/orbit-core/src/paths.rs
@@ -97,6 +97,7 @@ fn resolve_main_repo_from_worktree_gitfile(git_file: &Path) -> Option<PathBuf> {
 }
 
 #[cfg(test)]
+#[allow(clippy::items_after_test_module)]
 mod tests {
     use super::*;
 

--- a/orbit-core/src/runtime/engine.rs
+++ b/orbit-core/src/runtime/engine.rs
@@ -241,6 +241,7 @@ impl RuntimeHost for OrbitRuntime {
              3. Re-run the job to verify it completes successfully"
         );
         let _ = self.add_task(crate::command::task::TaskAddParams {
+            parent_id: None,
             title,
             description,
             plan,

--- a/orbit-core/src/runtime/mod.rs
+++ b/orbit-core/src/runtime/mod.rs
@@ -215,10 +215,11 @@ impl OrbitRuntime {
         &self,
         status: Option<TaskStatus>,
         priority: Option<TaskPriority>,
+        parent_id: Option<&str>,
     ) -> Result<Vec<Task>, OrbitError> {
         self.context
             .task_store()
-            .list_tasks_filtered(status, priority)
+            .list_tasks_filtered(status, priority, parent_id)
     }
 
     pub(crate) fn update_task_record(

--- a/orbit-core/src/runtime/resolve.rs
+++ b/orbit-core/src/runtime/resolve.rs
@@ -46,10 +46,10 @@ pub(crate) fn resolve_initialize_data_root(
     if let Some(orbit_dir) = find_orbit_dir_walk_up(cwd) {
         // Check if this .orbit has a config.toml with a root redirect
         let config_path = orbit_dir.join("config.toml");
-        if config_path.exists() {
-            if let Some(configured_root) = configured_root_from_config(&config_path)? {
-                return Ok(configured_root);
-            }
+        if config_path.exists()
+            && let Some(configured_root) = configured_root_from_config(&config_path)?
+        {
+            return Ok(configured_root);
         }
         return Ok(orbit_dir);
     }
@@ -182,9 +182,8 @@ mod tests {
         .expect("write repo config");
 
         let previous = std::env::var("ORBIT_ROOT").ok();
-        match previous {
-            Some(_) => unsafe { std::env::remove_var("ORBIT_ROOT") },
-            None => {}
+        if previous.is_some() {
+            unsafe { std::env::remove_var("ORBIT_ROOT") };
         }
         let chosen = resolve_initialize_data_root(&cwd, None).expect("resolve");
         if let Some(value) = previous {
@@ -203,9 +202,8 @@ mod tests {
         std::fs::create_dir_all(&cwd).expect("create cwd");
 
         let previous = std::env::var("ORBIT_ROOT").ok();
-        match previous {
-            Some(_) => unsafe { std::env::remove_var("ORBIT_ROOT") },
-            None => {}
+        if previous.is_some() {
+            unsafe { std::env::remove_var("ORBIT_ROOT") };
         }
         let chosen = resolve_initialize_data_root(&cwd, None).expect("resolve");
         if let Some(value) = previous {
@@ -222,9 +220,8 @@ mod tests {
         std::fs::create_dir_all(&cwd).expect("create cwd");
 
         let previous = std::env::var("ORBIT_ROOT").ok();
-        match previous {
-            Some(_) => unsafe { std::env::remove_var("ORBIT_ROOT") },
-            None => {}
+        if previous.is_some() {
+            unsafe { std::env::remove_var("ORBIT_ROOT") };
         }
         let chosen = resolve_initialize_data_root(&cwd, None).expect("resolve");
         if let Some(value) = previous {
@@ -242,9 +239,8 @@ mod tests {
         std::fs::create_dir_all(repo.join(".git")).expect("create git dir");
         std::fs::create_dir_all(&cwd).expect("create cwd");
         let previous = std::env::var("ORBIT_ROOT").ok();
-        match previous {
-            Some(_) => unsafe { std::env::remove_var("ORBIT_ROOT") },
-            None => {}
+        if previous.is_some() {
+            unsafe { std::env::remove_var("ORBIT_ROOT") };
         }
         let chosen = resolve_initialize_data_root(&cwd, None).expect("resolve");
         if let Some(value) = previous {

--- a/orbit-core/src/workspace_registry.rs
+++ b/orbit-core/src/workspace_registry.rs
@@ -159,10 +159,10 @@ fn home_dir() -> Result<PathBuf, OrbitError> {
 
 fn dirs_or_fallback() -> Result<PathBuf, OrbitError> {
     // Try HOME env first (works in tests), then platform default
-    if let Ok(home) = std::env::var("HOME") {
-        if !home.is_empty() {
-            return Ok(PathBuf::from(home));
-        }
+    if let Ok(home) = std::env::var("HOME")
+        && !home.is_empty()
+    {
+        return Ok(PathBuf::from(home));
     }
     #[cfg(windows)]
     if let Ok(profile) = std::env::var("USERPROFILE") {

--- a/orbit-core/tests/job_runtime_behavior.rs
+++ b/orbit-core/tests/job_runtime_behavior.rs
@@ -777,6 +777,7 @@ fn agent_step_records_task_agent_and_model_when_execution_starts() {
 
     let task = runtime
         .add_task(TaskAddParams {
+            parent_id: None,
             title: "Track agent metadata".to_string(),
             description: "desc".to_string(),
             plan: "plan".to_string(),
@@ -837,6 +838,7 @@ fn failed_steps_append_friction_entries_to_daily_log() {
 
     let task = runtime
         .add_task(TaskAddParams {
+            parent_id: None,
             title: "Record friction".to_string(),
             description: "desc".to_string(),
             plan: "plan".to_string(),
@@ -910,6 +912,7 @@ fn run_job_now_with_input_passes_manual_input_to_agent() {
     let agent_cli = write_agent_script(&script_path, &script);
     let task = runtime
         .add_task(TaskAddParams {
+            parent_id: None,
             title: "Manual input task".to_string(),
             description: "desc".to_string(),
             plan: "plan".to_string(),
@@ -2787,6 +2790,7 @@ fn create_branch_creates_isolated_worktree_without_mutating_main_checkout() {
     let runtime = OrbitRuntime::from_data_root(&data_root).expect("runtime");
     let task_id = runtime
         .add_task(TaskAddParams {
+            parent_id: None,
             title: "Create worktree".to_string(),
             description: "desc".to_string(),
             plan: "plan".to_string(),
@@ -2945,6 +2949,7 @@ fn update_task_automation_moves_task_to_review_with_summary_comment_and_note() {
 
     let task = runtime
         .add_task(TaskAddParams {
+            parent_id: None,
             title: "Review me".to_string(),
             description: "desc".to_string(),
             plan: "plan".to_string(),
@@ -3048,6 +3053,7 @@ fn implement_change_result_status_flows_into_update_task_as_task_status() {
 
     let task = runtime
         .add_task(TaskAddParams {
+            parent_id: None,
             title: "Implement then persist".to_string(),
             description: "desc".to_string(),
             plan: "plan".to_string(),
@@ -3216,6 +3222,7 @@ fn commit_changes_automation_commits_dirty_task_worktree() {
     let runtime = OrbitRuntime::from_data_root(&data_root).expect("runtime");
     let task_id = runtime
         .add_task(TaskAddParams {
+            parent_id: None,
             title: "Refactor automation flow".to_string(),
             description: "desc".to_string(),
             plan: "plan".to_string(),
@@ -3396,6 +3403,7 @@ fn commit_task_changes_uses_summary_from_task() {
     let runtime = OrbitRuntime::from_data_root(&data_root).expect("runtime");
     let task_id = runtime
         .add_task(TaskAddParams {
+            parent_id: None,
             title: "Fix bundle atomicity".to_string(),
             description: "desc".to_string(),
             plan: "plan".to_string(),
@@ -3570,6 +3578,7 @@ fn commit_task_changes_supports_task_id_only_inputs() {
     let runtime = OrbitRuntime::from_data_root(&data_root).expect("runtime");
     let task_id = runtime
         .add_task(TaskAddParams {
+            parent_id: None,
             title: "Persist pipeline artifacts".to_string(),
             description: "desc".to_string(),
             plan: "plan".to_string(),
@@ -3811,6 +3820,7 @@ fn open_pr_automation_uses_task_title_and_commit_output() {
     let runtime = OrbitRuntime::from_data_root(&data_root).expect("runtime");
     let task_id = runtime
         .add_task(TaskAddParams {
+            parent_id: None,
             title: "Wire Orbit PR automation".to_string(),
             description: "desc".to_string(),
             plan: "plan".to_string(),
@@ -4016,6 +4026,7 @@ fn open_pr_automation_supports_task_id_only_inputs() {
     let runtime = OrbitRuntime::from_data_root(&data_root).expect("runtime");
     let task_id = runtime
         .add_task(TaskAddParams {
+            parent_id: None,
             title: "Open PR from stored artifacts".to_string(),
             description: "desc".to_string(),
             plan: "plan".to_string(),
@@ -4249,6 +4260,7 @@ fn open_pr_automation_rejects_stale_task_branches_before_pr_creation() {
     let runtime = OrbitRuntime::from_data_root(&data_root).expect("runtime");
     let task_id = runtime
         .add_task(TaskAddParams {
+            parent_id: None,
             title: "Reject stale PR branches".to_string(),
             description: "desc".to_string(),
             plan: "plan".to_string(),
@@ -4423,6 +4435,7 @@ fn merge_pr_automation_rejects_stale_task_branches_before_merging() {
     let runtime = OrbitRuntime::from_data_root(&data_root).expect("runtime");
     let task_id = runtime
         .add_task(TaskAddParams {
+            parent_id: None,
             title: "Reject stale merge branches".to_string(),
             description: "desc".to_string(),
             plan: "plan".to_string(),
@@ -4598,6 +4611,7 @@ fn merge_pr_automation_fetches_review_decision_from_gh_when_not_provided() {
     let runtime = OrbitRuntime::from_data_root(&data_root).expect("runtime");
     let task_id = runtime
         .add_task(TaskAddParams {
+            parent_id: None,
             title: "Merge task PR after gh lookup".to_string(),
             description: "desc".to_string(),
             plan: "plan".to_string(),
@@ -4930,6 +4944,7 @@ fn create_branch_includes_local_base_commits_not_yet_pushed_to_remote() {
     let runtime = OrbitRuntime::from_data_root(&data_root).expect("runtime");
     let task_id = runtime
         .add_task(TaskAddParams {
+            parent_id: None,
             title: "Create worktree from fresh local base".to_string(),
             description: "desc".to_string(),
             plan: "plan".to_string(),

--- a/orbit-engine/src/activity_runner.rs
+++ b/orbit-engine/src/activity_runner.rs
@@ -169,6 +169,7 @@ pub(crate) fn execution_template_context_with_env(
 }
 
 #[cfg(test)]
+#[allow(clippy::items_after_test_module)]
 mod retry_tests {
     use orbit_types::JobRunState;
 

--- a/orbit-engine/src/context.rs
+++ b/orbit-engine/src/context.rs
@@ -6,8 +6,8 @@ use orbit_types::{
     Activity, Job, JobRun, JobRunState, JobTargetType, OrbitError, OrbitEvent, Role, Task,
     TaskStatus, redact_sensitive_env_json, redact_sensitive_env_option,
 };
-use std::path::Path;
 use serde_json::Value;
+use std::path::Path;
 
 pub const AGENT_PROTOCOL_VIOLATION: &str = "AGENT_PROTOCOL_VIOLATION";
 pub const AGENT_INVOCATION_FAILED: &str = "AGENT_INVOCATION_FAILED";

--- a/orbit-engine/src/executor/agent.rs
+++ b/orbit-engine/src/executor/agent.rs
@@ -386,6 +386,7 @@ fn classify_invocation_error(message: &str) -> String {
 }
 
 #[cfg(test)]
+#[allow(clippy::items_after_test_module)]
 mod tests {
     use super::classify_invocation_error;
     use crate::context::{

--- a/orbit-engine/src/executor/automation/check_review.rs
+++ b/orbit-engine/src/executor/automation/check_review.rs
@@ -12,8 +12,7 @@ pub(super) fn check_review_decision<H: TaskHost + ?Sized>(
     let task_id = required_input_string(input, "task_id")?;
     let task = host.get_task(task_id)?;
     let repo_root = canonicalize_existing_dir(
-        &task
-            .repo_root
+        task.repo_root
             .as_deref()
             .or(task.workspace_path.as_deref())
             .ok_or_else(|| {

--- a/orbit-engine/src/executor/automation/comments.rs
+++ b/orbit-engine/src/executor/automation/comments.rs
@@ -122,7 +122,11 @@ fn filter_unresolved_comments(
         .map(|threads| {
             threads
                 .iter()
-                .filter(|t| t.get("isResolved").and_then(Value::as_bool).unwrap_or(false))
+                .filter(|t| {
+                    t.get("isResolved")
+                        .and_then(Value::as_bool)
+                        .unwrap_or(false)
+                })
                 .flat_map(|t| {
                     t.get("comments")
                         .and_then(Value::as_array)

--- a/orbit-engine/src/executor/automation/commit.rs
+++ b/orbit-engine/src/executor/automation/commit.rs
@@ -15,7 +15,7 @@ pub(super) fn commit_task_changes<H: TaskHost + ?Sized>(
     let task_id = required_input_string(input, "task_id")?;
     let task = host.get_task(task_id)?;
     let workspace_path = canonicalize_existing_dir(
-        &task.workspace_path.as_deref().ok_or_else(|| {
+        task.workspace_path.as_deref().ok_or_else(|| {
             OrbitError::InvalidInput("commit_task_changes requires task.workspace_path".to_string())
         })?,
         "workspace_path",

--- a/orbit-engine/src/executor/automation/pr.rs
+++ b/orbit-engine/src/executor/automation/pr.rs
@@ -18,8 +18,7 @@ pub(super) fn merge_pr_from_task<H: RuntimeHost + TaskHost + ?Sized>(
     let task_id = required_input_string(input, "task_id")?;
     let task = host.get_task(task_id)?;
     let repo_root = canonicalize_existing_dir(
-        &task
-            .repo_root
+        task.repo_root
             .as_deref()
             .or(task.workspace_path.as_deref())
             .ok_or_else(|| {
@@ -89,8 +88,7 @@ pub(super) fn open_pr_from_task<H: RuntimeHost + TaskHost + ?Sized>(
     let task_id = required_input_string(input, "task_id")?;
     let task = host.get_task(task_id)?;
     let repo_root = canonicalize_existing_dir(
-        &task
-            .repo_root
+        task.repo_root
             .as_deref()
             .or(task.workspace_path.as_deref())
             .ok_or_else(|| {
@@ -481,6 +479,7 @@ mod tests {
     fn test_task(repo_root: &Path) -> Task {
         Task {
             id: "T20260320-021158".to_string(),
+            parent_id: None,
             title: "merge_pr_from_task uses GitHub review decision".to_string(),
             description: "desc".to_string(),
             plan: "plan".to_string(),

--- a/orbit-engine/src/executor/cli_command.rs
+++ b/orbit-engine/src/executor/cli_command.rs
@@ -48,12 +48,11 @@ impl ActivityExecutor for CliCommandExecutor {
         // When a cli_command step has task_id in its input, load the task and
         // inject its fields into the template context so {{workspace_path}}
         // resolves from the task without explicit pipeline input.
-        if template_context.workspace_path.is_none() {
-            if let Some(task_id) = execution.input.get("task_id").and_then(JsonValue::as_str) {
-                if let Ok(task) = host.get_task(task_id) {
-                    template_context.workspace_path = task.workspace_path;
-                }
-            }
+        if template_context.workspace_path.is_none()
+            && let Some(task_id) = execution.input.get("task_id").and_then(JsonValue::as_str)
+            && let Ok(task) = host.get_task(task_id)
+        {
+            template_context.workspace_path = task.workspace_path;
         }
         match execute(
             &execution.activity.spec_config,

--- a/orbit-engine/src/job_runner.rs
+++ b/orbit-engine/src/job_runner.rs
@@ -99,10 +99,10 @@ fn execute_activity_with_retries<H: EngineHost>(
 
             // Clear loop_exit flag at the start of each iteration so a
             // previous iteration's flag doesn't short-circuit immediately.
-            if iteration > 0 {
-                if let Value::Object(ref mut map) = current_input {
-                    map.remove("loop_exit");
-                }
+            if iteration > 0
+                && let Value::Object(ref mut map) = current_input
+            {
+                map.remove("loop_exit");
             }
 
             for (step_index, step) in job.steps.iter().enumerate() {
@@ -140,9 +140,8 @@ fn execute_activity_with_retries<H: EngineHost>(
                 // ---- Job-as-step: delegate to a nested job run ----
                 if step.target_type == JobTargetType::Job {
                     let step_started = Utc::now();
-                    let sub_result = execute_job_step(
-                        host, data_root, &step.target_id, &current_input, debug,
-                    );
+                    let sub_result =
+                        execute_job_step(host, data_root, &step.target_id, &current_input, debug);
                     let step_finished = Utc::now();
                     let (step_state, duration_ms, error_code, error_message) = match &sub_result {
                         Ok(result) => (result.state, None, None, None),
@@ -190,8 +189,13 @@ fn execute_activity_with_retries<H: EngineHost>(
                 // task's agent/model fields so the original implementer is used.
                 let resolved_step = resolve_step_agent_from_task(host, step, &current_input);
                 let effective_step = resolved_step.as_ref().unwrap_or(step);
-                let execution =
-                    build_execution_context_for_step(host, &job, effective_step, current_input.clone(), debug)?;
+                let execution = build_execution_context_for_step(
+                    host,
+                    &job,
+                    effective_step,
+                    current_input.clone(),
+                    debug,
+                )?;
                 // Only record agent context when the step explicitly specifies
                 // agent_cli — skip when resolved from the task to avoid overwriting.
                 if !step.agent_cli.trim().is_empty() {
@@ -517,6 +521,7 @@ fn pid_is_alive(_pid: u32) -> bool {
     true
 }
 
+#[allow(clippy::too_many_arguments)]
 fn finalize_failed_started_run<H: JobRunHost + RuntimeHost>(
     host: &H,
     data_root: &Path,
@@ -723,6 +728,7 @@ struct FrictionContext {
     model: Option<String>,
 }
 
+#[allow(clippy::too_many_arguments)]
 fn append_failed_step_friction<H: EngineHost>(
     data_root: &Path,
     host: &H,
@@ -821,6 +827,7 @@ fn normalize_agent_label(agent_cli: &str) -> String {
         .to_ascii_lowercase()
 }
 
+#[allow(clippy::too_many_arguments)]
 fn append_step_metrics<H: EngineHost>(
     data_root: &Path,
     host: &H,

--- a/orbit-store/src/backend/contracts.rs
+++ b/orbit-store/src/backend/contracts.rs
@@ -1,6 +1,6 @@
 use chrono::{DateTime, Utc};
 use orbit_types::{
-    Activity, AuditEvent, Job, JobRun, JobRunState, JobScheduleState, JobStep, OrbitError,
+    Activity, AuditEvent, Job, JobRun, JobRunState, JobScheduleState, JobStep, OrbitError, OrbitId,
     StoredTool, Task, TaskComment, TaskComplexity, TaskHistoryEntry, TaskPriority, TaskStatus,
     TaskType,
 };
@@ -11,6 +11,7 @@ use crate::sqlite::audit_event_store::{AuditEventFilter, AuditEventInsertParams}
 #[derive(Debug, Clone)]
 pub struct TaskCreateParams {
     pub actor: String,
+    pub parent_id: Option<OrbitId>,
     pub title: String,
     pub description: String,
     pub plan: String,
@@ -129,6 +130,7 @@ pub trait TaskStoreBackend: Send + Sync {
         &self,
         status: Option<TaskStatus>,
         priority: Option<TaskPriority>,
+        parent_id: Option<&str>,
     ) -> Result<Vec<Task>, OrbitError>;
     fn get_task(&self, id: &str) -> Result<Option<Task>, OrbitError>;
     fn search_tasks(&self, query: &str) -> Result<Vec<Task>, OrbitError>;

--- a/orbit-store/src/backend/file_backends.rs
+++ b/orbit-store/src/backend/file_backends.rs
@@ -25,8 +25,9 @@ impl TaskStoreBackend for TaskFileStore {
         &self,
         status: Option<TaskStatus>,
         priority: Option<TaskPriority>,
+        parent_id: Option<&str>,
     ) -> Result<Vec<Task>, OrbitError> {
-        self.list_tasks_filtered(status, priority)
+        self.list_tasks_filtered(status, priority, parent_id)
     }
 
     fn get_task(&self, id: &str) -> Result<Option<Task>, OrbitError> {

--- a/orbit-store/src/file/task_store.rs
+++ b/orbit-store/src/file/task_store.rs
@@ -3,8 +3,8 @@ use std::path::{Path, PathBuf};
 
 use chrono::{DateTime, Utc};
 use orbit_types::{
-    OrbitError, Task, TaskComment, TaskComplexity, TaskHistoryEntry, TaskPriority, TaskStatus,
-    TaskType,
+    OrbitError, OrbitId, Task, TaskComment, TaskComplexity, TaskHistoryEntry, TaskPriority,
+    TaskStatus, TaskType,
 };
 use serde::{Deserialize, Serialize};
 use serde_yaml::{Mapping, Value as YamlValue};
@@ -100,6 +100,8 @@ struct TaskFileDocument {
     #[serde(rename = "schema_version")]
     schema_version: u8,
     id: String,
+    #[serde(default)]
+    parent_id: Option<OrbitId>,
     #[serde(rename = "type", default = "default_task_type")]
     task_type: TaskType,
     priority: TaskPriority,
@@ -182,6 +184,7 @@ impl TaskFileStore {
             doc: TaskFileDocument {
                 schema_version: TASK_SCHEMA_VERSION,
                 id,
+                parent_id: params.parent_id,
                 title: params.title,
                 description: params.description,
                 context_files: params.context_files,
@@ -251,12 +254,14 @@ impl TaskFileStore {
         &self,
         status: Option<TaskStatus>,
         priority: Option<TaskPriority>,
+        parent_id: Option<&str>,
     ) -> Result<Vec<Task>, OrbitError> {
         let tasks = self.list_tasks()?;
         Ok(tasks
             .into_iter()
             .filter(|task| status.is_none_or(|value| task.status == value))
             .filter(|task| priority.is_none_or(|value| task.priority == value))
+            .filter(|task| parent_id.is_none_or(|value| task.parent_id.as_deref() == Some(value)))
             .collect())
     }
 
@@ -563,6 +568,7 @@ fn serialize_task_doc_yaml(doc: &TaskFileDocument) -> Result<String, OrbitError>
 
     yaml.push_str(&yaml_section("identity"));
     yaml.push_str(&yaml_field("id", &doc.id)?);
+    yaml.push_str(&yaml_field("parent_id", &doc.parent_id)?);
     yaml.push_str(&yaml_field("type", &doc.task_type)?);
     yaml.push_str(&yaml_field("priority", &doc.priority)?);
     if let Some(complexity) = doc.complexity {
@@ -638,6 +644,7 @@ fn bundle_read_error(path: &Path, label: &str, err: std::io::Error) -> OrbitErro
 fn bundle_to_task(state: TaskStateDir, bundle: TaskBundle) -> Task {
     Task {
         id: bundle.doc.id,
+        parent_id: bundle.doc.parent_id,
         title: bundle.doc.title,
         description: bundle.doc.description,
         plan: bundle.plan,
@@ -677,6 +684,7 @@ mod tests {
     fn sample_insert(status: TaskStatus) -> TaskCreateParams {
         TaskCreateParams {
             actor: "Codex".to_string(),
+            parent_id: None,
             title: "Bundle task".to_string(),
             description: "Task description".to_string(),
             plan: "Task plan".to_string(),
@@ -716,6 +724,7 @@ mod tests {
 
         let yaml = fs::read_to_string(task_dir.join(TASK_DOC_FILE_NAME)).expect("read yaml");
         assert!(yaml.contains("schema_version: 4"));
+        assert!(yaml.contains("parent_id: null"));
         assert!(yaml.contains("description: Task description"));
         assert!(yaml.contains("context_files:"));
         assert!(yaml.contains("created_by: Codex"));
@@ -917,6 +926,7 @@ mod tests {
         let two = store
             .create_task(TaskCreateParams {
                 actor: "Codex".to_string(),
+                parent_id: None,
                 title: "Another task".to_string(),
                 description: "Searchable phrase".to_string(),
                 plan: "Other plan".to_string(),
@@ -948,6 +958,84 @@ mod tests {
         assert_eq!(matches.len(), 1);
         assert_eq!(matches[0].id, two.id);
         assert_eq!(matches[0].description, "Searchable phrase");
+    }
+
+    #[test]
+    fn create_task_persists_parent_id_when_present() {
+        let dir = tempdir().expect("tempdir");
+        let store = TaskFileStore::new(dir.path().to_path_buf());
+
+        let created = store
+            .create_task(TaskCreateParams {
+                actor: "Codex".to_string(),
+                parent_id: Some("T20260320-000001".to_string()),
+                title: "Nested task".to_string(),
+                description: "desc".to_string(),
+                plan: "plan".to_string(),
+                execution_summary: String::new(),
+                context_files: vec![],
+                workspace_path: None,
+                repo_root: None,
+                assigned_to: None,
+                created_by: None,
+                agent: None,
+                model: None,
+                status: TaskStatus::Backlog,
+                priority: TaskPriority::Medium,
+                complexity: None,
+                task_type: TaskType::Task,
+                pr_number: None,
+                proposed_by: None,
+                source_task_id: None,
+                comments: Vec::new(),
+            })
+            .expect("create nested task");
+
+        assert_eq!(created.parent_id.as_deref(), Some("T20260320-000001"));
+        let yaml = fs::read_to_string(
+            dir.path()
+                .join("backlog")
+                .join(&created.id)
+                .join(TASK_DOC_FILE_NAME),
+        )
+        .expect("read yaml");
+        assert!(yaml.contains("parent_id: T20260320-000001"));
+    }
+
+    #[test]
+    fn list_tasks_filtered_by_parent_id_returns_only_matching_subtasks() {
+        let dir = tempdir().expect("tempdir");
+        let store = TaskFileStore::new(dir.path().to_path_buf());
+
+        let parent = store
+            .create_task(TaskCreateParams {
+                title: "Parent".to_string(),
+                ..sample_insert(TaskStatus::Backlog)
+            })
+            .expect("create parent");
+
+        let child = store
+            .create_task(TaskCreateParams {
+                parent_id: Some(parent.id.clone()),
+                title: "Child".to_string(),
+                ..sample_insert(TaskStatus::Backlog)
+            })
+            .expect("create child");
+
+        store
+            .create_task(TaskCreateParams {
+                title: "Unrelated".to_string(),
+                ..sample_insert(TaskStatus::Backlog)
+            })
+            .expect("create unrelated");
+
+        let subtasks = store
+            .list_tasks_filtered(None, None, Some(&parent.id))
+            .expect("filter by parent");
+
+        assert_eq!(subtasks.len(), 1);
+        assert_eq!(subtasks[0].id, child.id);
+        assert_eq!(subtasks[0].parent_id.as_deref(), Some(parent.id.as_str()));
     }
 
     #[test]

--- a/orbit-store/src/file/task_store.rs
+++ b/orbit-store/src/file/task_store.rs
@@ -568,7 +568,9 @@ fn serialize_task_doc_yaml(doc: &TaskFileDocument) -> Result<String, OrbitError>
 
     yaml.push_str(&yaml_section("identity"));
     yaml.push_str(&yaml_field("id", &doc.id)?);
-    yaml.push_str(&yaml_field("parent_id", &doc.parent_id)?);
+    if let Some(ref parent_id) = doc.parent_id {
+        yaml.push_str(&yaml_field("parent_id", parent_id)?);
+    }
     yaml.push_str(&yaml_field("type", &doc.task_type)?);
     yaml.push_str(&yaml_field("priority", &doc.priority)?);
     if let Some(complexity) = doc.complexity {
@@ -724,7 +726,7 @@ mod tests {
 
         let yaml = fs::read_to_string(task_dir.join(TASK_DOC_FILE_NAME)).expect("read yaml");
         assert!(yaml.contains("schema_version: 4"));
-        assert!(yaml.contains("parent_id: null"));
+        assert!(!yaml.contains("parent_id:"));
         assert!(yaml.contains("description: Task description"));
         assert!(yaml.contains("context_files:"));
         assert!(yaml.contains("created_by: Codex"));

--- a/orbit-tools/src/builtin/orbit/mod.rs
+++ b/orbit-tools/src/builtin/orbit/mod.rs
@@ -412,6 +412,7 @@ mod tests {
                 "description": "Details",
                 "plan": "Plan",
                 "workspace": "/tmp/orbit",
+                "parent_id": "T20260316-000001",
                 "comment": "seed comment",
                 "context": "a.rs,b.rs",
                 "priority": "high",
@@ -446,6 +447,8 @@ mod tests {
                 "hard".to_string(),
                 "--type".to_string(),
                 "feature".to_string(),
+                "--parent".to_string(),
+                "T20260316-000001".to_string(),
                 "--agent".to_string(),
                 "codex".to_string(),
                 "--model".to_string(),
@@ -537,6 +540,26 @@ mod tests {
                 "--json".to_string(),
                 "--status".to_string(),
                 "backlog".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn task_list_builds_parent_filter_when_present() {
+        let req = super::task_list::build_exec_request(
+            &ToolContext::default(),
+            &json!({"parent_id": "T20260316-000001"}),
+        )
+        .expect("valid list input");
+
+        assert_eq!(
+            req.args,
+            vec![
+                "task".to_string(),
+                "list".to_string(),
+                "--json".to_string(),
+                "--parent".to_string(),
+                "T20260316-000001".to_string(),
             ]
         );
     }

--- a/orbit-tools/src/builtin/orbit/task_add.rs
+++ b/orbit-tools/src/builtin/orbit/task_add.rs
@@ -57,6 +57,12 @@ pub(super) fn build_exec_request(
         args.push("--source-task".to_string());
         args.push(source_task);
     }
+    if let Some(parent_id) =
+        super::optional_string_alias(input, &["parent_id", "parent", "parentId"])?
+    {
+        args.push("--parent".to_string());
+        args.push(parent_id);
+    }
     super::append_identity_flags(&mut args, &identity);
 
     args.push("--json".to_string());
@@ -126,6 +132,12 @@ impl Tool for OrbitTaskAddTool {
                 name: "source_task_id".to_string(),
                 description: "For bug tasks: originating task ID that introduced the defect"
                     .to_string(),
+                param_type: "string".to_string(),
+                required: false,
+            },
+            ToolParam {
+                name: "parent_id".to_string(),
+                description: "Optional parent task ID for a subtask relationship".to_string(),
                 param_type: "string".to_string(),
                 required: false,
             },

--- a/orbit-tools/src/builtin/orbit/task_list.rs
+++ b/orbit-tools/src/builtin/orbit/task_list.rs
@@ -17,6 +17,12 @@ pub(super) fn build_exec_request(
         args.push("--status".to_string());
         args.push(status);
     }
+    if let Some(parent_id) =
+        super::optional_string_alias(input, &["parent_id", "parent", "parentId"])?
+    {
+        args.push("--parent".to_string());
+        args.push(parent_id);
+    }
 
     Ok(super::orbit_exec_request_with_identity(
         ctx, args, &identity,
@@ -25,16 +31,24 @@ pub(super) fn build_exec_request(
 
 impl Tool for OrbitTaskListTool {
     fn schema(&self) -> ToolSchema {
-        let mut parameters = vec![ToolParam {
-            name: "status".to_string(),
-            description: "Optional task status filter".to_string(),
-            param_type: "string".to_string(),
-            required: false,
-        }];
+        let mut parameters = vec![
+            ToolParam {
+                name: "status".to_string(),
+                description: "Optional task status filter".to_string(),
+                param_type: "string".to_string(),
+                required: false,
+            },
+            ToolParam {
+                name: "parent_id".to_string(),
+                description: "Optional parent task ID to list subtasks for".to_string(),
+                param_type: "string".to_string(),
+                required: false,
+            },
+        ];
         parameters.extend(super::identity_params());
         ToolSchema {
             name: "orbit.task.list".to_string(),
-            description: "List Orbit tasks, optionally filtered by status".to_string(),
+            description: "List Orbit tasks, optionally filtered by status or parent".to_string(),
             parameters,
             builtin: true,
         }

--- a/orbit-types/src/task.rs
+++ b/orbit-types/src/task.rs
@@ -293,6 +293,8 @@ pub struct TaskHistoryEntry {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct Task {
     pub id: OrbitId,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub parent_id: Option<OrbitId>,
     pub title: String,
     pub description: String,
     #[serde(default, alias = "instructions")]
@@ -408,6 +410,28 @@ mod tests {
         assert_eq!(task.complexity, None);
         assert_eq!(task.agent.as_deref(), Some("codex"));
         assert_eq!(task.model.as_deref(), Some("gpt-5.4"));
+    }
+
+    #[test]
+    fn task_missing_parent_id_deserializes_to_none() {
+        let task: Task = serde_json::from_value(serde_json::json!({
+            "id": "T20260320-000001",
+            "title": "Missing parent",
+            "description": "desc",
+            "plan": "plan",
+            "execution_summary": "",
+            "context_files": [],
+            "status": "backlog",
+            "priority": "medium",
+            "task_type": "task",
+            "comments": [],
+            "history": [],
+            "created_at": "2026-03-20T00:00:00Z",
+            "updated_at": "2026-03-20T00:00:00Z"
+        }))
+        .expect("deserialize task");
+
+        assert_eq!(task.parent_id, None);
     }
 
     #[test]


### PR DESCRIPTION
Summary:
- add optional task parent_id metadata and persist it through types, store, runtime, and task serialization
- support parent-aware task creation, listing, display, and Orbit tool inputs for subtasks
- add runtime/store/CLI/tool coverage and keep workspace verification green

Verification:
- cargo test --workspace
- cargo clippy --workspace --all-targets -- -D warnings

Task: T20260321-230249

*authored by: codex / gpt-5.4*