### PR TITLE
Fix scoping: scoreboard and task dirs writing to global .orbit instead of workspace

### DIFF
--- a/orbit-cli/src/command/init.rs
+++ b/orbit-cli/src/command/init.rs
@@ -20,6 +20,7 @@ impl Execute for InitCommand {
             InitOptions {
                 force: self.force,
                 refresh_defaults: true,
+                ..Default::default()
             },
         )?;
         print_init_result(&result);
@@ -34,6 +35,7 @@ impl InitCommand {
             InitOptions {
                 force: self.force,
                 refresh_defaults: true,
+                ..Default::default()
             },
         )?;
         print_init_result(&result);

--- a/orbit-core/src/command/init.rs
+++ b/orbit-core/src/command/init.rs
@@ -19,6 +19,7 @@ pub struct InitResult {
     pub config_path: String,
     pub refreshed_default_activities: usize,
     pub refreshed_default_jobs: usize,
+    pub scoring_enabled: bool,
 }
 
 #[derive(Debug, Clone, Default)]
@@ -28,6 +29,10 @@ pub struct InitOptions {
     /// they already exist.  Explicit `orbit init` sets this; implicit
     /// bootstrap from other commands does not.
     pub refresh_defaults: bool,
+    /// When true, skip workspace-only artifacts (scoreboards) during init.
+    /// Set for global-root bootstrapping to avoid writing workspace-scoped
+    /// files into `~/.orbit/`.
+    pub global_only: bool,
 }
 
 impl OrbitRuntime {
@@ -44,17 +49,27 @@ impl OrbitRuntime {
 }
 
 /// Ensures both global and workspace roots are bootstrapped.
-/// Global root gets full init (config, skills, activities, jobs, db).
-/// Workspace root just needs tasks/ directory.
+/// Global root gets config, skills, activities, jobs, and db (global-scoped artifacts).
+/// Workspace root gets tasks/ directory and scoreboard templates (workspace-scoped artifacts).
 pub(crate) fn ensure_orbit_root_initialized(
     global_root: &Path,
     workspace_root: &Path,
 ) -> Result<(), OrbitError> {
-    // Bootstrap global root with all defaults
-    let _ = init_workspace_at_root(global_root, InitOptions::default())?;
-    // Ensure workspace tasks directory exists
+    // Bootstrap global root — skip workspace-only artifacts (scoreboards, task dirs, job runs)
+    let global_init = init_workspace_at_root(
+        global_root,
+        InitOptions {
+            global_only: true,
+            ..Default::default()
+        },
+    )?;
+    // Ensure workspace tasks directory exists (tasks are WorkspaceOnly)
     let tasks_dir = workspace_root.join("tasks");
     fs::create_dir_all(&tasks_dir).map_err(|e| OrbitError::Io(e.to_string()))?;
+    // Seed scoreboard templates at workspace root (scoreboards are workspace-scoped)
+    if global_init.scoring_enabled {
+        seed_scoreboard_templates(workspace_root)?;
+    }
     Ok(())
 }
 
@@ -68,7 +83,13 @@ pub fn init_global(
         Some(root) => root.to_path_buf(),
         None => crate::workspace_registry::global_orbit_dir()?,
     };
-    init_workspace_at_root(&global_root, options)
+    init_workspace_at_root(
+        &global_root,
+        InitOptions {
+            global_only: true,
+            ..options
+        },
+    )
 }
 
 pub fn init_workspace_from_root_override(
@@ -111,7 +132,8 @@ fn init_workspace_at_root(
         seed_default_activities(&init_runtime, &orbit_root, overwrite)?;
     let refreshed_default_jobs = seed_default_jobs(&init_runtime, overwrite)?;
 
-    if init_runtime.scoring_enabled() {
+    let scoring_enabled = init_runtime.scoring_enabled();
+    if scoring_enabled && !options.global_only {
         seed_scoreboard_templates(&orbit_root)?;
     }
 
@@ -123,6 +145,7 @@ fn init_workspace_at_root(
         config_path: config_path.to_string_lossy().to_string(),
         refreshed_default_activities,
         refreshed_default_jobs,
+        scoring_enabled,
     })
 }
 

--- a/orbit-core/src/command/task.rs
+++ b/orbit-core/src/command/task.rs
@@ -10,7 +10,6 @@ use orbit_types::{
 
 use crate::OrbitRuntime;
 use crate::context::ActorKind;
-use crate::paths::find_git_repo_root;
 
 pub struct TaskAddParams {
     pub parent_id: Option<OrbitId>,
@@ -122,13 +121,16 @@ impl OrbitRuntime {
             ))
         })?;
 
-        // Friction bounty: record issues-reported on creation when agent+model present
+        // Friction bounty: record issues-reported on creation when agent+model present.
+        // data_root_path() is the workspace .orbit/ dir; its parent is the repo root
+        // for scoreboard writes. Using parent() instead of find_git_repo_root avoids
+        // worktree mis-resolution where find_git_repo_root follows to the main repo.
         if self.scoring_enabled()
             && params.task_type.is_friction()
             && let (Some(a), Some(m)) = (&agent, &model)
-            && let Some(repo_root) = find_git_repo_root(self.data_root_path())
+            && let Some(repo_root) = self.data_root_path().parent()
         {
-            let _ = friction_bounty::record_friction_reported(&repo_root, a, m);
+            let _ = friction_bounty::record_friction_reported(repo_root, a, m);
         }
 
         Ok(task)
@@ -629,7 +631,7 @@ impl OrbitRuntime {
         let (Some(agent), Some(model)) = (&task.agent, &task.model) else {
             return;
         };
-        let Some(repo_root) = find_git_repo_root(self.data_root_path()) else {
+        let Some(repo_root) = self.data_root_path().parent() else {
             return;
         };
 

--- a/orbit-store/src/backend/factory.rs
+++ b/orbit-store/src/backend/factory.rs
@@ -51,20 +51,21 @@ impl ResolvedScope {
 }
 
 pub fn task_store_file(root: PathBuf) -> Result<Arc<dyn TaskStoreBackend>, OrbitError> {
+    // ensure_layout is called lazily before each write operation (create_task, update_task).
+    // Eager layout here would create workspace-only task state directories at global scope.
     let store = TaskFileStore::new(root);
-    store.ensure_layout()?;
     Ok(Arc::new(store))
 }
 
 pub fn activity_store_file(root: PathBuf) -> Result<Arc<dyn ActivityStoreBackend>, OrbitError> {
+    // ensure_layout is called lazily before each write operation (insert, update, disable).
     let store = ActivityFileStore::new(root);
-    store.ensure_layout()?;
     Ok(Arc::new(store))
 }
 
 pub fn job_store_file(root: PathBuf) -> Result<Arc<dyn JobStoreBackend>, OrbitError> {
+    // ensure_layout is called lazily before each write operation (add_job, write_activity, etc).
     let store = JobFileStore::new(root);
-    store.ensure_layout()?;
     Ok(Arc::new(store))
 }
 

--- a/orbit-store/src/file/job_store.rs
+++ b/orbit-store/src/file/job_store.rs
@@ -68,7 +68,9 @@ impl JobFileStore {
     pub(crate) fn ensure_layout(&self) -> Result<(), OrbitError> {
         fs::create_dir_all(self.activities_dir()).map_err(|e| OrbitError::Io(e.to_string()))?;
         fs::create_dir_all(self.disabled_jobs_dir()).map_err(|e| OrbitError::Io(e.to_string()))?;
-        fs::create_dir_all(self.runs_dir()).map_err(|e| OrbitError::Io(e.to_string()))?;
+        // runs_dir is NOT created here: job runs are WorkspaceOnly per scoping rules
+        // and must not be initialized at global scope. write_run creates run dirs
+        // on demand via fs::create_dir_all.
         Ok(())
     }
 


### PR DESCRIPTION
## Changes
## Status
success

## 1. Summary of Changes

Four scoping violations fixed where workspace-only artifacts were being created at global `~/.orbit/` scope:

1. **Store factory eager layout removed** (`orbit-store/src/backend/factory.rs`): Removed `ensure_layout()` calls from `task_store_file`, `activity_store_file`, and `job_store_file` factory functions. All stores already call `ensure_layout` lazily before write operations, so the eager calls during construction were creating workspace-only directories (task state dirs, job run dirs) at global scope as a side effect of runtime initialization.

2. **Job store runs dir removed from ensure_layout** (`orbit-store/src/file/job_store.rs`): Removed `runs_dir` creation from `JobFileStore::ensure_layout()`. Job runs are WorkspaceOnly per scoping rules and must not be initialized at global scope. `write_run` already creates run directories on demand via `fs::create_dir_all`.

3. **Scoreboard seeding scoped to workspace** (`orbit-core/src/command/init.rs`): Added `global_only` flag to `InitOptions`. When set (during `ensure_orbit_root_initialized` global bootstrap and `init_global`), scoreboard template seeding is skipped. Scoreboards are now seeded at workspace root in `ensure_orbit_root_initialized` instead.

4. **Friction bounty path resolution fixed** (`orbit-core/src/command/task.rs`): Replaced `find_git_repo_root(self.data_root_path())` with `self.data_root_path().parent()` for scoreboard writes. `data_root_path()` returns the workspace `.orbit/` directory; its parent is the correct repo root. The previous approach using `find_git_repo_root` would incorrectly resolve to the main repo root in worktree contexts, writing scoreboards to the wrong workspace.

## 2. Strategic Decisions
- Lazy ensure_layout over eager | Rationale: All stores already call ensure_layout before writes; eager factory calls were redundant and caused the scoping violation | Trade-offs: First write to a fresh store pays the mkdir cost, but this is negligible
- global_only flag on InitOptions | Rationale: Minimal change that distinguishes global vs workspace init without restructuring the init flow | Trade-offs: Slightly broader API surface, but the flag has clear semantics
- parent() over find_git_repo_root() | Rationale: data_root_path() is already the canonical workspace .orbit/ dir; walking up to .git is unnecessary and broken in worktrees | Trade-offs: Assumes workspace root is always the parent of .orbit/, which is true by construction

## 3. Assumptions Made
- data_root_path() always returns a path with a valid parent | Impact if incorrect: friction bounty recording silently skipped (same as existing find_git_repo_root returning None)
- All store write operations already call ensure_layout before writing | Impact if incorrect: write operations could fail with missing directory errors. Verified by code inspection: create_task, insert_work, add_job, write_activity, write_run all call ensure_layout.

## 4. Design Weaknesses / Risks
- Pre-existing global directories not cleaned up | Severity: Low | Mitigation: Empty directories at ~/.orbit/tasks/ and ~/.orbit/jobs/runs/ from prior runs are harmless and can be manually removed
- Scoreboard seeding in ensure_orbit_root_initialized requires scoring_enabled from global init result | Severity: Low | Mitigation: Added scoring_enabled field to InitResult to propagate this cleanly

## 5. Deviations from Original Plan
None — no plan was provided with the task; implementation followed the bug description.

## 6. Technical Debt Introduced
None

## 7. Recommended Follow-Ups
- Add integration test verifying that `ensure_orbit_root_initialized` does not create task/job-run/scoreboard dirs at global root
- Consider adding a `cleanup_stale_global_dirs` utility to remove workspace-only directories from existing global roots
- The pre-existing test failure `bundled_default_job_specs_parse_successfully` (model mismatch sonnet vs gpt-5.4) should be fixed separately

## Branch Freshness
- Base ref: `agent-main`
- Head ref: `orbit/T20260323-030541`
- Behind base: 0
- Ahead of base: 1

## Files Changed
- `orbit-cli/src/command/init.rs`
- `orbit-core/src/command/init.rs`
- `orbit-core/src/command/task.rs`
- `orbit-store/src/backend/factory.rs`
- `orbit-store/src/file/job_store.rs`

*Implemented by: claude / opus*