### PR TITLE
Security: fs.* tools skip workspace boundary check when workspace_root is None

### DIFF
--- a/orbit-core/src/command/tool.rs
+++ b/orbit-core/src/command/tool.rs
@@ -35,11 +35,13 @@ impl OrbitRuntime {
     pub fn execute_tool_command(&self, name: &str, input: Value) -> Result<Value, OrbitError> {
         let allowed_tools = read_activity_tools_from_env();
         let (agent_name, model_name) = read_agent_identity_from_env();
+        let workspace_root = self.data_root_path().parent().map(|p| p.to_path_buf());
         let tool_context = ToolContext {
             cwd: None,
             allowed_tools,
             agent_name,
             model_name,
+            workspace_root,
             ..Default::default()
         };
         self.run_tool_with_context_and_role(name, input, Role::Admin, tool_context)

--- a/orbit-core/src/lib.rs
+++ b/orbit-core/src/lib.rs
@@ -133,11 +133,11 @@ mod tests {
         use orbit_tools::ToolContext;
         use orbit_types::Role;
 
-        let dir = tempdir().expect("temp dir");
-        let file = dir.path().join("sample.txt");
-        std::fs::write(&file, "data").expect("write");
-
         let runtime = OrbitRuntime::in_memory().expect("runtime");
+
+        // Create file inside the workspace root so the boundary check passes
+        let file = runtime.data_root().join("sample.txt");
+        std::fs::write(&file, "data").expect("write");
 
         // Empty allowed_tools = unrestricted
         let tool_context = ToolContext::default();
@@ -153,11 +153,12 @@ mod tests {
 
     #[test]
     fn successful_tool_execution_persists_audit_and_event() {
-        let dir = tempdir().expect("temp dir");
-        let file = dir.path().join("sample.txt");
+        let runtime = OrbitRuntime::in_memory().expect("runtime");
+
+        // Create file inside the workspace root so the boundary check passes
+        let file = runtime.data_root().join("sample.txt");
         std::fs::write(&file, "ok").expect("write file");
 
-        let runtime = OrbitRuntime::in_memory().expect("runtime");
         let output = runtime
             .run_tool("fs.read", json!({"path": file.to_string_lossy()}))
             .expect("tool succeeds");
@@ -320,11 +321,12 @@ mod tests {
 
     #[test]
     fn enable_tool_restores_execution() {
-        let dir = tempdir().expect("temp dir");
-        let file = dir.path().join("test.txt");
+        let runtime = OrbitRuntime::in_memory().expect("runtime");
+
+        // Create file inside the workspace root so the boundary check passes
+        let file = runtime.data_root().join("test.txt");
         std::fs::write(&file, "restored").expect("write");
 
-        let runtime = OrbitRuntime::in_memory().expect("runtime");
         runtime.disable_tool("fs.read").expect("disable");
         runtime.enable_tool("fs.read").expect("enable");
 

--- a/orbit-core/src/runtime/pipeline.rs
+++ b/orbit-core/src/runtime/pipeline.rs
@@ -34,6 +34,14 @@ impl OrbitRuntime {
             tool_context.orbit_root = Some(self.data_root_path().to_path_buf());
         }
 
+        // Ensure fs tools always have a workspace boundary for sandboxing.
+        // The workspace root is the parent of the .orbit data directory (the repo root).
+        if tool_context.workspace_root.is_none() {
+            if let Some(parent) = self.data_root_path().parent() {
+                tool_context.workspace_root = Some(parent.to_path_buf());
+            }
+        }
+
         self.check_tool_enabled(name)?;
 
         if !tool_context.allowed_tools.is_empty()

--- a/orbit-tools/src/builtin/fs/mod.rs
+++ b/orbit-tools/src/builtin/fs/mod.rs
@@ -16,22 +16,27 @@ pub fn register(registry: &mut ToolRegistry) {
     registry.register(list::FsListTool);
 }
 
-/// Checks that `path` resolves inside the context workspace root (if one is set).
+/// Checks that `path` resolves inside the context workspace root.
 ///
 /// Symlink escapes are blocked because the path is canonicalized before the check.
 /// For paths that do not yet exist (e.g. `fs.write` creating a new file), the
 /// nearest existing ancestor is canonicalized and the remaining components are
 /// appended before the check.
 ///
-/// Returns `Ok` when no workspace root is set, or when the canonical path is
-/// inside the root. Returns `Err(PolicyDenied)` otherwise.
+/// Returns `Err(PolicyDenied)` when no workspace root is set (fail-closed) or
+/// when the canonical path is outside the root. Returns `Ok` only when the
+/// canonical path is inside the workspace root.
 pub(super) fn check_workspace_boundary(
     ctx: &ToolContext,
     path: &Path,
 ) -> Result<PathBuf, OrbitError> {
     let workspace_root = match &ctx.workspace_root {
         Some(root) => root,
-        None => return Ok(path.to_path_buf()),
+        None => {
+            return Err(OrbitError::PolicyDenied(
+                "workspace_root is not set; filesystem access denied".to_string(),
+            ))
+        }
     };
 
     let canonical = if path.exists() {
@@ -52,7 +57,13 @@ pub(super) fn check_workspace_boundary(
         canonical_parent.join(file_name)
     };
 
-    if !canonical.starts_with(workspace_root) {
+    // Canonicalize the workspace root so symlinks (e.g. /var -> /private/var on
+    // macOS) don't cause false negatives when comparing against the canonical path.
+    let canonical_root = workspace_root
+        .canonicalize()
+        .unwrap_or_else(|_| workspace_root.clone());
+
+    if !canonical.starts_with(&canonical_root) {
         return Err(OrbitError::PolicyDenied(format!(
             "path is outside workspace: {}",
             canonical.display()

--- a/orbit-tools/src/lib.rs
+++ b/orbit-tools/src/lib.rs
@@ -149,6 +149,30 @@ mod tests {
 
     #[test]
     fn fs_read_returns_file_contents() {
+        let workspace = tempdir().expect("workspace dir");
+        let path = workspace.path().join("note.txt");
+        fs::write(&path, "hello").expect("write file");
+
+        let ctx = ToolContext {
+            workspace_root: Some(workspace.path().canonicalize().expect("canonicalize")),
+            ..Default::default()
+        };
+        let mut registry = ToolRegistry::new();
+        registry.register_builtins();
+
+        let output = registry
+            .execute(
+                "fs.read",
+                &ctx,
+                json!({"path": path.to_string_lossy()}),
+            )
+            .expect("tool executes");
+
+        assert_eq!(output["content"], "hello");
+    }
+
+    #[test]
+    fn fs_read_denied_when_workspace_root_is_none() {
         let dir = tempdir().expect("temp dir");
         let path = dir.path().join("note.txt");
         fs::write(&path, "hello").expect("write file");
@@ -156,15 +180,17 @@ mod tests {
         let mut registry = ToolRegistry::new();
         registry.register_builtins();
 
-        let output = registry
+        let err = registry
             .execute(
                 "fs.read",
                 &ToolContext::default(),
                 json!({"path": path.to_string_lossy()}),
             )
-            .expect("tool executes");
-
-        assert_eq!(output["content"], "hello");
+            .expect_err("read with no workspace_root must be denied");
+        assert!(
+            err.to_string().contains("workspace_root is not set"),
+            "expected fail-closed denial, got: {err}"
+        );
     }
 
     #[test]

--- a/orbit-tools/src/lib.rs
+++ b/orbit-tools/src/lib.rs
@@ -54,7 +54,8 @@ pub struct ToolContext {
     pub allowed_tools: Vec<String>,
     /// When set, fs tools enforce that all paths resolve inside this directory.
     /// Symlink escapes are blocked because paths are canonicalized before the check.
-    /// If `None`, no boundary is enforced (used for tests and legacy callers).
+    /// If `None`, fs tools deny all access (fail-closed). The runtime pipeline
+    /// auto-populates this from the data root's parent directory.
     pub workspace_root: Option<PathBuf>,
     /// The resolved `.orbit` data directory (e.g. `<repo>/.orbit`). Distinct from
     /// `workspace_root` (the repo root used for fs sandboxing) because the data


### PR DESCRIPTION
## Changes
## Status
success

## 1. Summary of Changes

Fixed a security vulnerability where fs.* tools (fs.read, fs.write, fs.delete, fs.list) bypassed workspace boundary enforcement when `workspace_root` was `None` in the `ToolContext`, granting agents unrestricted filesystem access.

**Changes across 5 files:**

1. **orbit-tools/src/builtin/fs/mod.rs** — Changed `check_workspace_boundary` from fail-open (return Ok when workspace_root is None) to fail-closed (return PolicyDenied error). Also added canonicalization of the workspace root itself to prevent false negatives from symlinks (e.g. /var → /private/var on macOS).

2. **orbit-core/src/command/tool.rs** — `execute_tool_command` now explicitly sets `workspace_root` from the runtime data root parent (the repo root), ensuring agent CLI tool invocations are properly sandboxed.

3. **orbit-core/src/runtime/pipeline.rs** — Added auto-population of `workspace_root` in `run_tool_with_context_and_role` (same pattern as existing `orbit_root` auto-set), providing defense-in-depth for all internal callers.

4. **orbit-core/src/lib.rs** — Updated 3 tests to create temp files inside the workspace root rather than in external temp directories, since the boundary check now enforces containment.

5. **orbit-tools/src/lib.rs** — Updated doc comment for `workspace_root` field to document the new fail-closed behavior.

## 2. Strategic Decisions
- Fail-closed over fail-open | Rationale: Security-critical check should deny by default | Trade-offs: All callers must now provide workspace_root
- Defense-in-depth auto-set in pipeline | Rationale: Single point of enforcement catches all callers (run_tool, run_tool_with_role, execute_tool_command) | Trade-offs: None — callers can still override
- Canonicalize workspace_root in boundary check | Rationale: macOS /var → /private/var symlink causes path mismatch | Trade-offs: Slight extra syscall per check

## 3. Assumptions Made
- data_root parent is the correct workspace boundary | Impact if incorrect: Over-broad or over-narrow sandboxing
- Pre-existing test failure (bundled_default_job_specs_parse_successfully) is unrelated | Impact if incorrect: Masked regression

## 4. Design Weaknesses / Risks
- Workspace root derived from data root parent may be too broad if data root is redirected to a non-standard location | Severity: Low | Mitigation: The existing data root resolution chain (ORBIT_ROOT, config.toml, git root) already ensures sensible placement

## 5. Deviations from Original Plan
- Added pipeline-level auto-set (pipeline.rs) beyond the two files named in the task | Justification: Defense-in-depth; without this, internal callers like run_tool would still pass None and trigger the new fail-closed check
- Added workspace_root canonicalization | Justification: Required to handle macOS symlinks that caused the CLI test to fail

## 6. Technical Debt Introduced
None

## 7. Recommended Follow-Ups
- Investigate the pre-existing test failure in bundled_default_job_specs_parse_successfully (model name mismatch sonnet vs gpt-5.4)
- Consider adding an integration test that explicitly verifies fs tools deny access when workspace_root is None

## Branch Freshness
- Base ref: `agent-main`
- Head ref: `orbit/T20260323-053324`
- Behind base: 0
- Ahead of base: 1

## Files Changed
- `orbit-core/src/command/tool.rs`
- `orbit-core/src/lib.rs`
- `orbit-core/src/runtime/pipeline.rs`
- `orbit-tools/src/builtin/fs/mod.rs`
- `orbit-tools/src/lib.rs`

*Implemented by: claude / opus*