### PR TITLE
Security: git push remote/branch argument injection via missing -- separator

### DIFF
--- a/orbit-tools/src/builtin/git/push.rs
+++ b/orbit-tools/src/builtin/git/push.rs
@@ -51,6 +51,17 @@ impl Tool for GitPushTool {
             .filter(|v| !v.is_empty())
             .unwrap_or("origin");
 
+        if remote.starts_with('-') {
+            return Err(OrbitError::InvalidInput(
+                "remote name must not start with '-'".to_string(),
+            ));
+        }
+        if branch.starts_with('-') {
+            return Err(OrbitError::InvalidInput(
+                "branch name must not start with '-'".to_string(),
+            ));
+        }
+
         let result = run_process(
             &ExecRequest {
                 program: "git".to_string(),
@@ -58,6 +69,7 @@ impl Tool for GitPushTool {
                     "-C".to_string(),
                     repo_root.to_string_lossy().to_string(),
                     "push".to_string(),
+                    "--".to_string(),
                     remote.to_string(),
                     branch.to_string(),
                 ],


### PR DESCRIPTION
## Changes
## Status
success

## 1. Summary of Changes
Fixed argument injection vulnerability in `orbit-tools/src/builtin/git/push.rs` where agent-supplied `remote` and `branch` parameters were passed directly as positional args to `git push` without protection. Added two defenses:
1. **`--` separator** (line 72): Inserted between `push` subcommand and positional args, consistent with `commit.rs` and `stage_paths.rs` patterns. Prevents any value from being interpreted as a git flag.
2. **Dash-prefix validation** (lines 54-63): Reject `remote` or `branch` values starting with `-` with a clear `InvalidInput` error, providing fail-closed behavior at the input boundary.

## 2. Strategic Decisions
- Defense-in-depth (both `--` and validation) | Rationale: `--` alone is sufficient for git, but dash-prefix validation catches malicious input early with a clear error message | Trade-offs: Slightly more code, but negligible complexity cost for meaningful security layering

## 3. Assumptions Made
- Valid git remote names and branch names never start with `-` | Impact if incorrect: Legitimate names would be rejected, but git itself does not allow refs starting with `-`

## 4. Design Weaknesses / Risks
- None identified | The fix follows the exact pattern already established in `commit.rs` and `stage_paths.rs`

## 5. Deviations from Original Plan
- Added dash-prefix input validation in addition to the `--` separator suggested in the task description | Justification: Defense-in-depth with early, clear error messages is preferable to relying solely on `--`

## 6. Technical Debt Introduced
None

## 7. Recommended Follow-Ups
- Audit remaining git tools for similar argument injection patterns (currently only `push.rs` was missing `--`)
- The pre-existing test failure `bundled_default_job_specs_parse_successfully` should be fixed separately (expects `sonnet` model but finds `gpt-5.4` in bundled job spec)

## Branch Freshness
- Base ref: `agent-main`
- Head ref: `orbit/T20260323-053329`
- Behind base: 0
- Ahead of base: 1

## Files Changed
- `orbit-tools/src/builtin/git/push.rs`

*Implemented by: claude / opus*