### PR TITLE
Job failure: job_task_pipeline [AGENT_OUTPUT_MISSING]

### DIFF
--- a/orbit-agent/src/types/response.rs
+++ b/orbit-agent/src/types/response.rs
@@ -35,22 +35,55 @@ fn parse_single_json_document(stdout: &str) -> Result<Value, OrbitError> {
     let mut stream = Deserializer::from_str(stdout).into_iter::<Value>();
 
     let Some(first) = stream.next() else {
-        return Err(OrbitError::AgentProtocolViolation(
-            "stdout does not contain a JSON document".to_string(),
-        ));
+        return extract_embedded_json(stdout);
     };
 
-    let first = first.map_err(|error| {
-        OrbitError::AgentProtocolViolation(format!("stdout is not valid JSON: {error}"))
-    })?;
+    let first = match first {
+        Ok(value) => value,
+        Err(_) => return extract_embedded_json(stdout),
+    };
 
-    if stream.next().is_some() {
+    // Accept a valid first document even if followed by non-JSON trailing text.
+    // Only reject when there are genuinely multiple valid JSON documents.
+    if let Some(Ok(_)) = stream.next() {
         return Err(OrbitError::AgentProtocolViolation(
             "stdout contains multiple JSON documents".to_string(),
         ));
     }
 
     Ok(first)
+}
+
+/// Scan stdout for an embedded JSON object when strict parsing fails.
+///
+/// Agents using `--output-format text` may emit non-JSON text before or after
+/// the JSON envelope. This function searches for the first `{` that begins a
+/// valid JSON object, which handles the common case of explanatory text
+/// surrounding the envelope.
+fn extract_embedded_json(stdout: &str) -> Result<Value, OrbitError> {
+    let bytes = stdout.as_bytes();
+    let mut pos = 0;
+    while pos < bytes.len() {
+        if bytes[pos] == b'{' {
+            let slice = &stdout[pos..];
+            if let Ok(value) = serde_json::from_str::<Value>(slice) {
+                if value.is_object() {
+                    return Ok(value);
+                }
+            }
+            // Try streaming deserializer to handle trailing text after the JSON
+            let mut stream = Deserializer::from_str(slice).into_iter::<Value>();
+            if let Some(Ok(value)) = stream.next() {
+                if value.is_object() {
+                    return Ok(value);
+                }
+            }
+        }
+        pos += 1;
+    }
+    Err(OrbitError::AgentProtocolViolation(
+        "stdout does not contain a JSON document".to_string(),
+    ))
 }
 
 fn validate_exit_alignment(

--- a/orbit-agent/tests/protocol_behavior.rs
+++ b/orbit-agent/tests/protocol_behavior.rs
@@ -300,3 +300,82 @@ fn protocol_parser_falls_back_to_success_for_invalid_json_stdout_on_zero_exit() 
     assert_eq!(envelope.status, "success");
     assert!(envelope.result.is_none());
 }
+
+#[test]
+fn protocol_parser_extracts_json_envelope_from_mixed_text_stdout() {
+    let json_str = serde_json::to_string(&json!({
+        "schemaVersion": 1,
+        "status": "success",
+        "result": {"status": "review", "execution_summary": "done"},
+        "error": null,
+        "durationMs": 200
+    }))
+    .expect("serialize");
+
+    let exec = ExecutionResult {
+        success: true,
+        stdout: format!("Some explanatory text before the JSON:\n{json_str}\n"),
+        stderr: String::new(),
+        exit_code: Some(0),
+        duration_ms: 200,
+        output: None,
+    };
+
+    let (envelope, state) = parse_and_validate_response(&exec).expect("should extract envelope");
+    assert_eq!(state, AgentResponseStatus::Success);
+    assert_eq!(envelope.status, "success");
+    assert!(envelope.result.is_some());
+}
+
+#[test]
+fn protocol_parser_extracts_json_envelope_with_trailing_text() {
+    let json_str = serde_json::to_string(&json!({
+        "schemaVersion": 1,
+        "status": "success",
+        "result": {"ok": true},
+        "error": null,
+        "durationMs": 50
+    }))
+    .expect("serialize");
+
+    let exec = ExecutionResult {
+        success: true,
+        stdout: format!("{json_str}\nSome trailing text here"),
+        stderr: String::new(),
+        exit_code: Some(0),
+        duration_ms: 50,
+        output: None,
+    };
+
+    let (envelope, state) = parse_and_validate_response(&exec).expect("should extract envelope");
+    assert_eq!(state, AgentResponseStatus::Success);
+    assert!(envelope.result.is_some());
+}
+
+#[test]
+fn protocol_parser_extracts_json_after_markdown_fences() {
+    let json_str = serde_json::to_string(&json!({
+        "schemaVersion": 1,
+        "status": "failed",
+        "result": {},
+        "error": {"code": "TASK_BLOCKED", "message": "cannot proceed", "details": null},
+        "durationMs": 10
+    }))
+    .expect("serialize");
+
+    let exec = ExecutionResult {
+        success: false,
+        stdout: format!("```json\n{json_str}\n```"),
+        stderr: String::new(),
+        exit_code: Some(1),
+        duration_ms: 10,
+        output: None,
+    };
+
+    let (envelope, state) = parse_and_validate_response(&exec).expect("should extract envelope");
+    assert_eq!(state, AgentResponseStatus::Failed);
+    assert_eq!(
+        envelope.error.as_ref().expect("error").code,
+        "TASK_BLOCKED"
+    );
+}

--- a/orbit-core/assets/jobs/job_task_pipeline.yaml
+++ b/orbit-core/assets/jobs/job_task_pipeline.yaml
@@ -29,6 +29,8 @@ job:
       agent_cli: claude
       model: sonnet
       timeout_seconds: 1000
+      retry_max_attempts: 2
+      retry_backoff_seconds: 15
 
     - target_type: activity
       target_id: create_branch
@@ -41,6 +43,8 @@ job:
       model: opus
       condition: on_success
       timeout_seconds: 2000
+      retry_max_attempts: 2
+      retry_backoff_seconds: 15
 
     - target_type: activity
       target_id: update_task
@@ -68,6 +72,8 @@ job:
       model: gpt-5.4
       condition: on_success
       timeout_seconds: 600
+      retry_max_attempts: 2
+      retry_backoff_seconds: 15
       env_set:
         GH_TOKEN: "${GITHUB_TOKEN_REVIEWER}"
         GH_CONFIG_DIR: "/tmp/orbit-gh-reviewer"

--- a/orbit-core/src/command/job.rs
+++ b/orbit-core/src/command/job.rs
@@ -454,13 +454,13 @@ mod tests {
             .find(|spec| spec.job_id == "job_task_pipeline")
             .expect("task pipeline spec present");
         assert_eq!(pipeline.max_active_runs, 4);
-        assert_eq!(pipeline.steps[0].model.as_deref(), Some("gpt-5.4"));
+        assert_eq!(pipeline.steps[0].model.as_deref(), Some("sonnet"));
         assert_eq!(pipeline.steps[1].condition, StepCondition::OnSuccess);
         let review = specs
             .iter()
             .find(|spec| spec.job_id == "job_review_tasks")
             .expect("review job spec present");
-        assert_eq!(review.steps[0].model.as_deref(), None);
+        assert_eq!(review.steps[0].model.as_deref(), Some("gpt-5.4"));
         let review_loop = specs
             .iter()
             .find(|spec| spec.job_id == "job_review_loop")


### PR DESCRIPTION
## Changes
## Status
success

## 1. Summary of Changes

**Root cause**: When agents (especially Claude with `--output-format text`) output non-JSON text before/after the JSON result envelope in stdout, `parse_single_json_document` fails to find the JSON. The fallback `synthesize_response` creates a synthetic success with `result: None`, triggering the `AGENT_OUTPUT_MISSING` error. No retries were configured on agent steps, so the transient error was terminal.

**Fix 1 — Robust JSON extraction** (`orbit-agent/src/types/response.rs`):
- Added `extract_embedded_json()` that scans stdout for a valid JSON object when strict parsing fails, handling agents that wrap JSON in explanatory text or markdown fences
- Changed `parse_single_json_document` to fall back to `extract_embedded_json` instead of erroring immediately
- Relaxed the "multiple documents" check to only reject genuinely multiple valid JSON documents (trailing non-JSON text is now tolerated)

**Fix 2 — Retry configuration** (`orbit-core/assets/jobs/job_task_pipeline.yaml`):
- Added `retry_max_attempts: 2` and `retry_backoff_seconds: 15` to `dispatch_task`, `implement_change`, and `review_pr` steps as defense-in-depth

**Fix 3 — Stale test assertions** (`orbit-core/src/command/job.rs`):
- Fixed pre-existing test `bundled_default_job_specs_parse_successfully` which had stale model assertions (`gpt-5.4` instead of `sonnet` for pipeline step 0, `None` instead of `gpt-5.4` for review_tasks step 0)

## 2. Strategic Decisions
- Extract JSON from mixed text output rather than requiring clean JSON-only stdout | Rationale: Claude `--output-format text` legitimately produces non-JSON text around the envelope | Trade-offs: slightly looser parsing, but the envelope schema validation catches malformed envelopes downstream
- Add retries to agent steps | Rationale: AGENT_OUTPUT_MISSING was already classified as transient/retryable but no retries were configured | Trade-offs: longer total execution time on genuine failures (30s extra)

## 3. Assumptions Made
- The first `{` that begins a valid JSON object in stdout is the intended envelope | Impact if incorrect: could parse an unrelated JSON object, but schema validation catches this

## 4. Design Weaknesses / Risks
- The embedded JSON scanner is O(n*m) worst-case for many `{` characters in stdout | Severity: Low | Mitigation: agent stdout is typically small; and the scan short-circuits on first valid object

## 5. Deviations from Original Plan
None

## 6. Technical Debt Introduced
None

## 7. Recommended Follow-Ups
- Consider adding `--output-format json` support to Claude provider if/when available to eliminate text wrapping at the source

## Branch Freshness
- Base ref: `agent-main`
- Head ref: `orbit/T20260323-063545`
- Behind base: 0
- Ahead of base: 1

## Files Changed
- `orbit-agent/src/types/response.rs`
- `orbit-agent/tests/protocol_behavior.rs`
- `orbit-core/assets/jobs/job_task_pipeline.yaml`
- `orbit-core/src/command/job.rs`

*Implemented by: claude / opus*