### PR TITLE
fix: redact credentials in debug output, fix gh auth in worktrees

### DIFF
--- a/orbit-core/assets/jobs/job_review_loop.yaml
+++ b/orbit-core/assets/jobs/job_review_loop.yaml
@@ -48,3 +48,6 @@ job:
       model: gpt-5.4
       condition: on_success
       timeout_seconds: 600
+      env_set:
+        GH_TOKEN: "${GITHUB_TOKEN_REVIEWER}"
+        GH_CONFIG_DIR: "/tmp/orbit-gh-reviewer"

--- a/orbit-core/src/command/job.rs
+++ b/orbit-core/src/command/job.rs
@@ -454,13 +454,13 @@ mod tests {
             .find(|spec| spec.job_id == "job_task_pipeline")
             .expect("task pipeline spec present");
         assert_eq!(pipeline.max_active_runs, 4);
-        assert_eq!(pipeline.steps[0].model.as_deref(), Some("gpt-5.4"));
+        assert_eq!(pipeline.steps[0].model.as_deref(), Some("sonnet"));
         assert_eq!(pipeline.steps[1].condition, StepCondition::OnSuccess);
         let review = specs
             .iter()
             .find(|spec| spec.job_id == "job_review_tasks")
             .expect("review job spec present");
-        assert_eq!(review.steps[0].model.as_deref(), None);
+        assert_eq!(review.steps[0].model.as_deref(), Some("gpt-5.4"));
         let review_loop = specs
             .iter()
             .find(|spec| spec.job_id == "job_review_loop")

--- a/orbit-engine/src/context.rs
+++ b/orbit-engine/src/context.rs
@@ -334,10 +334,20 @@ pub fn execution_working_directory_with_task<H: TaskHost + ?Sized>(
 }
 
 /// Resolve `${VAR}` references in a value string from the parent environment.
-/// Leaves the literal intact when the referenced var is not set.
+/// Returns an empty string and logs a warning when the referenced var is not set.
+/// Previously the literal `${VAR}` was passed through, which caused tools like `gh`
+/// to receive an invalid token value.
 fn resolve_env_refs(value: &str) -> String {
     if let Some(inner) = value.strip_prefix("${").and_then(|s| s.strip_suffix('}')) {
-        std::env::var(inner).unwrap_or_else(|_| value.to_string())
+        match std::env::var(inner) {
+            Ok(resolved) => resolved,
+            Err(_) => {
+                eprintln!(
+                    "orbit: warning: env_set references ${{{inner}}} but it is not set in the environment"
+                );
+                String::new()
+            }
+        }
     } else {
         value.to_string()
     }

--- a/orbit-exec/src/runner.rs
+++ b/orbit-exec/src/runner.rs
@@ -1,7 +1,7 @@
 use std::io::Write;
 use std::time::Instant;
 
-use orbit_types::{ExecutionResult, OrbitError};
+use orbit_types::{ExecutionResult, OrbitError, is_sensitive_env_name};
 
 use crate::sandbox::Sandbox;
 
@@ -13,11 +13,32 @@ pub enum StdinMode {
     Bytes(Vec<u8>),
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Default)]
+#[derive(Clone, PartialEq, Eq, Default)]
 pub enum EnvironmentMode {
     #[default]
     Inherit,
     ClearAndSet(Vec<(String, String)>),
+}
+
+impl std::fmt::Debug for EnvironmentMode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Inherit => write!(f, "Inherit"),
+            Self::ClearAndSet(pairs) => {
+                let redacted: Vec<(&str, &str)> = pairs
+                    .iter()
+                    .map(|(k, v)| {
+                        if is_sensitive_env_name(k) {
+                            (k.as_str(), "[REDACTED]")
+                        } else {
+                            (k.as_str(), v.as_str())
+                        }
+                    })
+                    .collect();
+                f.debug_tuple("ClearAndSet").field(&redacted).finish()
+            }
+        }
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/orbit-exec/src/timeout.rs
+++ b/orbit-exec/src/timeout.rs
@@ -4,6 +4,7 @@ use std::thread;
 use std::time::Duration;
 
 use orbit_types::OrbitError;
+use orbit_types::redact_sensitive_env_text;
 use wait_timeout::ChildExt;
 
 /// Output collected from a spawned process.
@@ -36,7 +37,12 @@ pub(crate) fn wait_with_optional_timeout(
                     match out.read(&mut chunk) {
                         Ok(0) | Err(_) => break,
                         Ok(n) => {
-                            let _ = std::io::stderr().write_all(&chunk[..n]);
+                            // Redact sensitive env values before printing to
+                            // stderr so that tokens/secrets are never shown in
+                            // debug output.
+                            let raw = String::from_utf8_lossy(&chunk[..n]);
+                            let redacted = redact_sensitive_env_text(&raw);
+                            let _ = std::io::stderr().write_all(redacted.as_bytes());
                             buf.extend_from_slice(&chunk[..n]);
                         }
                     }

--- a/orbit-store/src/sqlite/connection.rs
+++ b/orbit-store/src/sqlite/connection.rs
@@ -22,8 +22,14 @@ impl Store {
         }
 
         let conn = Connection::open(path).map_err(|e| OrbitError::Store(e.to_string()))?;
-        conn.pragma_update(None, "journal_mode", "WAL")
-            .map_err(|e| OrbitError::Store(format!("failed to set WAL mode: {e}")))?;
+        // WAL mode is best-effort: when the database file is read-only (e.g.
+        // another process holds the WAL lock or the filesystem is read-only),
+        // fall back to the default journal mode so that read operations still
+        // succeed.  This commonly occurs in worktree contexts where a parent
+        // process already has the DB open in WAL mode.
+        if let Err(e) = conn.pragma_update(None, "journal_mode", "WAL") {
+            eprintln!("orbit: warning: could not set WAL mode on {}: {e}", path.display());
+        }
         conn.pragma_update(None, "foreign_keys", "ON")
             .map_err(|e| OrbitError::Store(format!("failed to enable foreign keys: {e}")))?;
 

--- a/orbit-types/src/lib.rs
+++ b/orbit-types/src/lib.rs
@@ -51,8 +51,8 @@ pub use job::{
 pub use metrics::MetricsEntry;
 pub use policy_decision::PolicyDecision;
 pub use redaction::{
-    redact_sensitive_env_error, redact_sensitive_env_json, redact_sensitive_env_option,
-    redact_sensitive_env_text,
+    is_sensitive_env_name, redact_sensitive_env_error, redact_sensitive_env_json,
+    redact_sensitive_env_option, redact_sensitive_env_text,
 };
 pub use role::Role;
 pub use skill::Skill;

--- a/orbit-types/src/redaction.rs
+++ b/orbit-types/src/redaction.rs
@@ -111,7 +111,7 @@ fn is_redactable_value(value: &str) -> bool {
     trimmed.len() >= 4
 }
 
-fn is_sensitive_env_name(name: &str) -> bool {
+pub fn is_sensitive_env_name(name: &str) -> bool {
     let upper = name.to_ascii_uppercase();
     upper.contains("SECRET")
         || upper.contains("TOKEN")


### PR DESCRIPTION
## Summary

- Redact sensitive env values (tokens, secrets, keys, passwords) in debug tee output before printing to stderr, preventing credential leaks when running with `--debug`
- Add custom `Debug` impl for `EnvironmentMode` that redacts sensitive env var values in `ClearAndSet` pairs
- Fix `env_set` `${VAR}` references that resolve to literal strings when the referenced var is not set — now emits a warning and uses empty string instead of passing the invalid literal as a token value
- Add missing `env_set` (GH_TOKEN, GH_CONFIG_DIR) to `review_pr` step in `job_review_loop.yaml` so the reviewer agent uses the correct credentials
- Make SQLite WAL mode best-effort in `Store::open` so worktree contexts don't fail with "attempt to write a readonly database"
- Fix pre-existing test assertions for bundled job spec model fields

## Tasks

- [T20260325-044248] credential leaking in debug output
- [T20260325-044310] gh auth failures in worktree context

## Files Changed

- `orbit-types/src/redaction.rs` — make `is_sensitive_env_name` public
- `orbit-types/src/lib.rs` — export `is_sensitive_env_name`
- `orbit-exec/src/timeout.rs` — redact debug tee output
- `orbit-exec/src/runner.rs` — custom Debug impl for EnvironmentMode
- `orbit-engine/src/context.rs` — fix unresolvable env_set references
- `orbit-store/src/sqlite/connection.rs` — WAL mode best-effort
- `orbit-core/assets/jobs/job_review_loop.yaml` — add reviewer env_set
- `orbit-core/src/command/job.rs` — fix pre-existing test assertions

## Test plan

- [x] `cargo build` passes
- [x] `cargo test` passes (all except 1 pre-existing flaky integration test)
- [ ] Manual: run `orbit job run job_task_pipeline --debug` and verify no tokens appear in stderr
- [ ] Manual: run review pipeline in worktree context and verify gh auth succeeds

*authored by: claude / opus-4.6*