### PR TITLE
refactor: replace codex-specific EnvironmentHost methods with generic provider config

### DIFF
--- a/orbit-agent/src/agent/agent.rs
+++ b/orbit-agent/src/agent/agent.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use orbit_types::OrbitError;
 
 use crate::providers::AgentProvider;
@@ -16,18 +18,29 @@ pub enum ProviderOptions {
 
 impl ProviderOptions {
     /// Build `ProviderOptions` for a given agent CLI binary, using the supplied
-    /// Codex-specific settings when the CLI resolves to Codex.  Callers that
-    /// do not need non-default Codex settings can use `AgentConfig::cli()`.
+    /// provider-agnostic config map.  Provider-specific keys are extracted
+    /// inside each provider's match arm:
+    ///
+    /// - Codex reads `"sandbox"` (defaults to `"workspace-write"`) and
+    ///   `"approval_policy"` (optional).
+    ///
+    /// Callers that do not need non-default settings can use `AgentConfig::cli()`.
     pub fn for_agent_cli(
         agent_cli: &str,
-        sandbox: String,
-        approval_policy: Option<String>,
+        config: &HashMap<String, String>,
     ) -> Result<Self, OrbitError> {
         match AgentProvider::detect_from_cli(agent_cli)? {
-            AgentProvider::Codex => Ok(Self::Codex {
-                sandbox,
-                approval_policy,
-            }),
+            AgentProvider::Codex => {
+                let sandbox = config
+                    .get("sandbox")
+                    .cloned()
+                    .unwrap_or_else(|| "workspace-write".to_string());
+                let approval_policy = config.get("approval_policy").cloned();
+                Ok(Self::Codex {
+                    sandbox,
+                    approval_policy,
+                })
+            }
             AgentProvider::Claude => Ok(Self::Claude),
             AgentProvider::MockAgent => Ok(Self::Mock),
         }
@@ -48,8 +61,7 @@ impl AgentConfig {
     /// directly when non-default Codex settings are required.
     pub fn cli(command: impl Into<String>) -> Result<Self, OrbitError> {
         let command = command.into();
-        let provider_options =
-            ProviderOptions::for_agent_cli(&command, "workspace-write".to_string(), None)?;
+        let provider_options = ProviderOptions::for_agent_cli(&command, &HashMap::new())?;
         Ok(Self {
             command,
             model: None,

--- a/orbit-core/src/runtime/engine.rs
+++ b/orbit-core/src/runtime/engine.rs
@@ -318,14 +318,14 @@ impl JobRunHost for OrbitRuntime {
 }
 
 impl EnvironmentHost for OrbitRuntime {
-    fn codex_sandbox_policy(&self) -> String {
-        self.codex_execution_policy().sandbox().to_string()
-    }
-
-    fn codex_approval_policy(&self) -> Option<String> {
-        self.codex_execution_policy()
-            .approval_policy()
-            .map(|s| s.to_string())
+    fn agent_provider_config(&self) -> std::collections::HashMap<String, String> {
+        let mut config = std::collections::HashMap::new();
+        let policy = self.codex_execution_policy();
+        config.insert("sandbox".to_string(), policy.sandbox().to_string());
+        if let Some(approval) = policy.approval_policy() {
+            config.insert("approval_policy".to_string(), approval.to_string());
+        }
+        config
     }
 
     fn execution_env_inherit(&self) -> bool {

--- a/orbit-engine/src/context.rs
+++ b/orbit-engine/src/context.rs
@@ -7,6 +7,7 @@ use orbit_types::{
     TaskStatus, redact_sensitive_env_json, redact_sensitive_env_option,
 };
 use serde_json::Value;
+use std::collections::HashMap;
 use std::path::Path;
 
 pub const AGENT_PROTOCOL_VIOLATION: &str = "AGENT_PROTOCOL_VIOLATION";
@@ -223,8 +224,11 @@ pub trait AgentProtocolHost {
 
 pub trait EnvironmentHost {
     // ── Config accessors (implementors provide these) ──────────────────
-    fn codex_sandbox_policy(&self) -> String;
-    fn codex_approval_policy(&self) -> Option<String>;
+
+    /// Returns provider-agnostic key-value configuration that is forwarded
+    /// to `ProviderOptions::for_agent_cli`.  Each provider extracts the keys
+    /// it cares about (e.g. Codex reads `"sandbox"` and `"approval_policy"`).
+    fn agent_provider_config(&self) -> HashMap<String, String>;
     fn execution_env_inherit(&self) -> bool;
     fn hydrated_env_allowlist(&self, env_extra: &[String]) -> Vec<(String, String)>;
     fn orbit_root(&self) -> Option<String>;
@@ -239,11 +243,8 @@ pub trait EnvironmentHost {
         model: Option<&str>,
     ) -> Result<AgentConfig, OrbitError> {
         use orbit_agent::ProviderOptions;
-        let provider_options = ProviderOptions::for_agent_cli(
-            agent_cli,
-            self.codex_sandbox_policy(),
-            self.codex_approval_policy(),
-        )?;
+        let config = self.agent_provider_config();
+        let provider_options = ProviderOptions::for_agent_cli(agent_cli, &config)?;
         Ok(AgentConfig {
             command: agent_cli.to_string(),
             model: model.map(|m| m.to_string()),


### PR DESCRIPTION
## Summary

- Removes `codex_sandbox_policy()` and `codex_approval_policy()` from the `EnvironmentHost` trait (orbit-engine), replacing them with a single `agent_provider_config() -> HashMap<String, String>` method
- Updates `ProviderOptions::for_agent_cli()` (orbit-agent) to accept a generic config map instead of explicit codex parameters; Codex-specific key extraction (`sandbox`, `approval_policy`) now lives inside the Codex match arm
- Updates `OrbitRuntime` impl (orbit-core) to pack codex execution policy values into the generic config map

No behavioral changes -- same sandbox/approval_policy values reach codex at runtime. All existing tests pass unchanged.

**Task:** T20260327-025905

## Test plan

- [x] `cargo build --workspace` passes
- [x] `cargo test -p orbit-agent -p orbit-engine -p orbit-core --lib` -- 27 tests pass
- [x] `cargo test -p orbit-agent` -- 15 tests pass (including protocol_behavior integration tests)
- [x] `cargo clippy --workspace` passes (no new warnings)

*authored by: claude / opus-4.6*