### PR TITLE
Security: body_file path allows arbitrary file read via gh --body-file in github.pr.create

### DIFF
--- a/orbit-tools/src/builtin/fs/mod.rs
+++ b/orbit-tools/src/builtin/fs/mod.rs
@@ -26,7 +26,7 @@ pub fn register(registry: &mut ToolRegistry) {
 /// Returns `Err(PolicyDenied)` when no workspace root is set (fail-closed) or
 /// when the canonical path is outside the root. Returns `Ok` only when the
 /// canonical path is inside the workspace root.
-pub(super) fn check_workspace_boundary(
+pub(crate) fn check_workspace_boundary(
     ctx: &ToolContext,
     path: &Path,
 ) -> Result<PathBuf, OrbitError> {

--- a/orbit-tools/src/builtin/github/mod.rs
+++ b/orbit-tools/src/builtin/github/mod.rs
@@ -367,18 +367,25 @@ mod tests {
 
     #[test]
     fn pr_create_uses_body_file_when_body_absent() {
+        let workspace = tempfile::tempdir().expect("workspace dir");
+        let file = workspace.path().join("pr.md");
+        std::fs::write(&file, "body content").expect("write file");
+
+        let ctx = ToolContext {
+            workspace_root: Some(workspace.path().canonicalize().expect("canonicalize")),
+            ..Default::default()
+        };
         let req = super::pr_create::build_exec_request(
-            &ToolContext::default(),
+            &ctx,
             &json!({
                 "title": "T",
                 "base": "main",
                 "head": "branch",
-                "body_file": "/tmp/pr.md",
+                "body_file": file.to_string_lossy(),
             }),
         )
         .expect("valid");
         assert!(req.args.contains(&"--body-file".to_string()));
-        assert!(req.args.contains(&"/tmp/pr.md".to_string()));
     }
 
     #[test]

--- a/orbit-tools/src/builtin/github/pr_create.rs
+++ b/orbit-tools/src/builtin/github/pr_create.rs
@@ -1,7 +1,10 @@
+use std::path::Path;
+
 use orbit_exec::{EnvironmentMode, ExecRequest, NoSandbox, StdinMode, run_process};
 use orbit_types::{OrbitError, ToolParam, ToolSchema};
 use serde_json::{Value, json};
 
+use crate::builtin::fs::check_workspace_boundary;
 use crate::{TIMEOUT_SLOW_MS, Tool, ToolContext, check_exec_result, require_str};
 
 pub struct GithubPrCreateTool;
@@ -38,8 +41,9 @@ pub(super) fn build_exec_request(
         args.push("--body".to_string());
         args.push(super::append_signature(b, ctx, "Implemented"));
     } else if let Some(f) = body_file {
+        let validated = check_workspace_boundary(ctx, Path::new(f))?;
         args.push("--body-file".to_string());
-        args.push(f.to_string());
+        args.push(validated.to_string_lossy().to_string());
     }
 
     let label = input
@@ -130,5 +134,78 @@ impl Tool for GithubPrCreateTool {
             "stdout": result.stdout,
             "stderr": result.stderr,
         }))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use serde_json::json;
+    use tempfile::tempdir;
+
+    use super::*;
+    use crate::ToolContext;
+
+    fn base_input(body_file: &str) -> Value {
+        json!({
+            "title": "test pr",
+            "base": "main",
+            "head": "feature",
+            "body_file": body_file,
+        })
+    }
+
+    #[test]
+    fn body_file_inside_workspace_is_accepted() {
+        let workspace = tempdir().expect("workspace dir");
+        let file = workspace.path().join("pr_body.md");
+        fs::write(&file, "PR description").expect("write file");
+
+        let ctx = ToolContext {
+            workspace_root: Some(workspace.path().canonicalize().expect("canonicalize")),
+            ..Default::default()
+        };
+
+        let req = build_exec_request(&ctx, &base_input(&file.to_string_lossy()))
+            .expect("should accept body_file inside workspace");
+        assert!(req.args.contains(&"--body-file".to_string()));
+    }
+
+    #[test]
+    fn body_file_outside_workspace_is_denied() {
+        let workspace = tempdir().expect("workspace dir");
+        let outside = tempdir().expect("outside dir");
+        let outside_file = outside.path().join("secret.txt");
+        fs::write(&outside_file, "secret data").expect("write outside file");
+
+        let ctx = ToolContext {
+            workspace_root: Some(workspace.path().canonicalize().expect("canonicalize")),
+            ..Default::default()
+        };
+
+        let err = build_exec_request(&ctx, &base_input(&outside_file.to_string_lossy()))
+            .expect_err("body_file outside workspace must be denied");
+        assert!(
+            err.to_string().contains("outside workspace"),
+            "expected policy denied message, got: {err}"
+        );
+    }
+
+    #[test]
+    fn body_file_denied_when_workspace_root_is_none() {
+        let dir = tempdir().expect("temp dir");
+        let file = dir.path().join("body.md");
+        fs::write(&file, "content").expect("write file");
+
+        let err = build_exec_request(
+            &ToolContext::default(),
+            &base_input(&file.to_string_lossy()),
+        )
+        .expect_err("body_file with no workspace_root must be denied");
+        assert!(
+            err.to_string().contains("workspace_root is not set"),
+            "expected fail-closed denial, got: {err}"
+        );
     }
 }


### PR DESCRIPTION
## Changes
## Status
success

## 1. Summary of Changes
Applied workspace boundary validation to the `body_file` parameter in `github.pr.create` tool. Previously, an agent could pass an arbitrary path (e.g. `/etc/passwd`) via `body_file` and `gh` would read that file into the PR body, exfiltrating sensitive data outside the workspace. The fix reuses the existing `check_workspace_boundary()` function from the `fs` module to validate that `body_file` resolves inside the workspace root before passing it to `gh pr create --body-file`.

### Files changed:
- `orbit-tools/src/builtin/fs/mod.rs` — Changed `check_workspace_boundary` visibility from `pub(super)` to `pub(crate)` so other builtin modules can reuse it.
- `orbit-tools/src/builtin/github/pr_create.rs` — Added workspace boundary check for `body_file` parameter; added 3 unit tests.
- `orbit-tools/src/builtin/github/mod.rs` — Updated existing `pr_create_uses_body_file_when_body_absent` test to use a workspace-scoped temp dir.

## 2. Strategic Decisions
- Reused existing `check_workspace_boundary` rather than duplicating logic | Rationale: single source of truth for path validation | Trade-offs: required widening visibility from `pub(super)` to `pub(crate)`
- Used the canonical (resolved) path from `check_workspace_boundary` as the `--body-file` argument | Rationale: ensures gh reads exactly the validated file, preventing TOCTOU via symlink swap | Trade-offs: none significant

## 3. Assumptions Made
- `check_workspace_boundary` is the correct validation primitive for all path-based security boundaries | Impact if incorrect: other tools may need a different boundary check

## 4. Design Weaknesses / Risks
- None identified. The fix follows the same pattern used by all `fs.*` tools.

## 5. Deviations from Original Plan
None (no plan was provided; implementation follows the task description directly).

## 6. Technical Debt Introduced
None

## 7. Recommended Follow-Ups
- Audit other GitHub tools for similar path parameters that bypass workspace boundary checks
- Consider whether `pub(crate)` on `check_workspace_boundary` should be promoted to a crate-level utility

## Branch Freshness
- Base ref: `agent-main`
- Head ref: `orbit/T20260323-053714`
- Behind base: 0
- Ahead of base: 1

## Files Changed
- `orbit-tools/src/builtin/fs/mod.rs`
- `orbit-tools/src/builtin/github/mod.rs`
- `orbit-tools/src/builtin/github/pr_create.rs`

*Implemented by: claude / opus*