### PR TITLE
Agents guess wrong orbit CLI commands despite skill instructions

### DIFF
--- a/orbit-core/assets/skills/orbit-execute-change-request/SKILL.md
+++ b/orbit-core/assets/skills/orbit-execute-change-request/SKILL.md
@@ -39,6 +39,20 @@ orbit tool run orbit.task.list --input '{"status": "backlog", "agent": "<agent>"
 
 **If running from a worktree**, pass `--root` pointing to the original repo's `.orbit` directory so commands resolve correctly.
 
+## Common Mistakes — DO NOT
+
+Agents frequently make these mistakes. **Read this before running any command.**
+
+| Mistake | Why it fails | Correct form |
+|---------|-------------|--------------|
+| `cargo run -- tool run orbit.task.show ...` | `cargo run` rebuilds from source; agents must use the installed binary | `orbit tool run orbit.task.show ...` |
+| `orbit task show ...` | Direct CLI subcommands are for humans; agent provenance is not recorded | `orbit tool run orbit.task.show ...` |
+| `orbit tool run orbit.task.transition ...` | `orbit.task.transition` does not exist — there is no such tool | `orbit tool run orbit.task.start ...` or `orbit tool run orbit.task.update ...` |
+| `orbit tool run orbit.task.move ...` | `orbit.task.move` does not exist | `orbit tool run orbit.task.update --input '{"id":"...","status":"..."}'` |
+| `orbit tool run orbit.task.comment ...` | `orbit.task.comment` does not exist | `orbit tool run orbit.task.update --input '{"id":"...","comment":"..."}'` |
+
+**Rule:** If a tool name is not listed in the Command Reference above, it does not exist. Never invent tool names. Run `orbit tool list` to see all registered tools.
+
 ## When Commands Fail
 
 If any `orbit tool run` command fails unexpectedly (unknown tool, missing field, unclear error), **do not silently work around it**. Immediately create a friction task:

--- a/orbit-core/assets/skills/orbit/SKILL.md
+++ b/orbit-core/assets/skills/orbit/SKILL.md
@@ -53,6 +53,16 @@ orbit tool run orbit.job_run.archive --input '{"id": "<job_run_id>"}'
 
 Never edit task files directly.
 
+## Common Mistakes — DO NOT
+
+| Mistake | Why it fails | Correct form |
+|---------|-------------|--------------|
+| `cargo run -- tool run ...` | Agents must use the installed `orbit` binary, not rebuild from source | `orbit tool run ...` |
+| `orbit task show <id>` | Direct CLI subcommands skip agent provenance tracking | `orbit tool run orbit.task.show --input '{"id":"<id>"}'` |
+| Inventing tool names (`orbit.task.transition`, `orbit.task.move`, `orbit.task.comment`) | These tools do not exist | Use only tools from the Command Reference above or run `orbit tool list` |
+
+**Rule:** If a tool name is not in the Command Reference, it does not exist. Never guess. Run `orbit tool list` to see all registered tools.
+
 ## Lifecycle
 
 ```text


### PR DESCRIPTION
## Changes
## Status
success

## 1. Summary of Changes
Added "Common Mistakes — DO NOT" sections to both the `orbit` root skill and `orbit-execute-change-request` skill. These sections document the most frequent agent errors: using `cargo run` instead of the `orbit` binary, using direct CLI subcommands instead of `orbit tool run`, and inventing non-existent tool names like `orbit.task.transition`. Each mistake is paired with a clear explanation of why it fails and the correct command form. Both skills now also direct agents to run `orbit tool list` when in doubt.

## 2. Strategic Decisions
- Used a table format for mistakes | Rationale: Tables are scannable and unambiguous — agents can pattern-match their intended command against the "Mistake" column | Trade-offs: Tables take more vertical space than prose, but clarity is worth it for preventing errors
- Added the section after the Command Reference but before When Commands Fail | Rationale: Agents read skills top-to-bottom; placing the DO NOT section immediately after the correct commands reinforces the contrast | Trade-offs: None significant
- Included concrete invented tool names as examples | Rationale: The original bug report specifically mentioned `orbit.task.transition` — calling out real mistakes makes the warning concrete | Trade-offs: List may not cover all possible invented names, but the general rule ("if not listed, it does not exist") covers the gap

## 3. Assumptions Made
- The 3 pre-existing test failures (agent/model provenance fields) are known issues unrelated to this task | Impact if incorrect: Failures would need investigation, but git stash verification confirmed they exist on clean main

## 4. Design Weaknesses / Risks
- Agents may still skip reading the DO NOT section | Severity: Low | Mitigation: The section is placed prominently and uses bold formatting; further improvement would require runtime validation

## 5. Deviations from Original Plan
- Plan step 2 suggested "Consider adding orbit tool list output to the skill" — instead of embedding the full tool list (which would go stale), added a directive to run `orbit tool list` at runtime | Justification: A static tool list in the skill would drift as tools are added/removed; pointing to the live command is more maintainable

## 6. Technical Debt Introduced
None

## 7. Recommended Follow-Ups
- Fix the 3 pre-existing test failures in orbit-cli/tests/task_commands.rs (agent/model provenance fields)
- Monitor whether agents still make CLI mistakes after this change; if so, consider adding runtime validation that suggests corrections for unrecognized tool names

## Branch Freshness
- Base ref: `agent-main`
- Head ref: `orbit/T20260323-030036`
- Behind base: 0
- Ahead of base: 1

## Files Changed
- `orbit-core/assets/skills/orbit-execute-change-request/SKILL.md`
- `orbit-core/assets/skills/orbit/SKILL.md`

*Implemented by: claude / opus*