### PR TITLE
fix: use REST API for PR reviews to support fine-grained PATs

### DIFF
--- a/orbit-tools/src/builtin/github/mod.rs
+++ b/orbit-tools/src/builtin/github/mod.rs
@@ -282,9 +282,17 @@ mod tests {
     }
 
     #[test]
+    fn pr_review_rejects_missing_repo() {
+        let err =
+            super::pr_review::build_exec_request(&ToolContext::default(), &json!({ "pr": "42", "action": "approve" }))
+                .expect_err("must fail");
+        assert!(err.to_string().contains("repo"), "{err}");
+    }
+
+    #[test]
     fn pr_review_rejects_missing_action() {
         let err =
-            super::pr_review::build_exec_request(&ToolContext::default(), &json!({ "pr": "42" }))
+            super::pr_review::build_exec_request(&ToolContext::default(), &json!({ "repo": "owner/repo", "pr": "42" }))
                 .expect_err("must fail");
         assert!(err.to_string().contains("action"), "{err}");
     }
@@ -293,7 +301,7 @@ mod tests {
     fn pr_review_rejects_invalid_action() {
         let err = super::pr_review::build_exec_request(
             &ToolContext::default(),
-            &json!({ "pr": "42", "action": "lgtm" }),
+            &json!({ "repo": "owner/repo", "pr": "42", "action": "lgtm" }),
         )
         .expect_err("must fail");
         assert!(err.to_string().contains("action"), "{err}");
@@ -304,6 +312,7 @@ mod tests {
         let err = super::pr_review::build_exec_request(
             &ToolContext::default(),
             &json!({
+                "repo": "owner/repo",
                 "pr": "42",
                 "action": "request-changes",
             }),
@@ -410,14 +419,17 @@ mod tests {
         let req = super::pr_review::build_exec_request(
             &ToolContext::default(),
             &json!({
+                "repo": "owner/repo",
                 "pr": "42",
                 "action": "approve",
             }),
         )
         .expect("valid");
-        assert!(req.args.contains(&"review".to_string()));
-        assert!(req.args.contains(&"42".to_string()));
-        assert!(req.args.contains(&"--approve".to_string()));
+        assert_eq!(req.program, "gh");
+        assert_eq!(req.args[0], "api");
+        assert_eq!(req.args[1], "repos/owner/repo/pulls/42/reviews");
+        assert_eq!(req.args[2], "-f");
+        assert_eq!(req.args[3], "event=APPROVE");
     }
 
     #[test]
@@ -425,15 +437,18 @@ mod tests {
         let req = super::pr_review::build_exec_request(
             &ToolContext::default(),
             &json!({
+                "repo": "owner/repo",
                 "pr": "42",
                 "action": "request-changes",
                 "body": "fix it",
             }),
         )
         .expect("valid");
-        assert!(req.args.contains(&"--request-changes".to_string()));
-        assert!(req.args.contains(&"--body".to_string()));
-        assert!(req.args.contains(&"fix it".to_string()));
+        assert_eq!(req.args[0], "api");
+        assert_eq!(req.args[1], "repos/owner/repo/pulls/42/reviews");
+        assert_eq!(req.args[3], "event=REQUEST_CHANGES");
+        assert_eq!(req.args[4], "-f");
+        assert_eq!(req.args[5], "body=fix it");
     }
 
     #[test]
@@ -478,14 +493,16 @@ mod tests {
         let req = super::pr_review::build_exec_request(
             &ctx,
             &json!({
+                "repo": "owner/repo",
                 "pr": "42",
                 "action": "request-changes",
                 "body": "needs work",
             }),
         )
         .expect("valid");
-        let body_pos = req.args.iter().position(|a| a == "--body").unwrap();
-        let body = &req.args[body_pos + 1];
+        // body is passed as "-f" "body=..." in the gh api args
+        let body_pos = req.args.iter().position(|a| a.starts_with("body=")).unwrap();
+        let body = &req.args[body_pos];
         assert!(
             body.ends_with("\n\n*Reviewed by: codex / o3*"),
             "body missing signature: {body}"
@@ -502,14 +519,15 @@ mod tests {
         let req = super::pr_review::build_exec_request(
             &ctx,
             &json!({
+                "repo": "owner/repo",
                 "pr": "42",
                 "action": "approve",
             }),
         )
         .expect("valid");
-        let body_pos = req.args.iter().position(|a| a == "--body").unwrap();
-        let body = &req.args[body_pos + 1];
-        assert_eq!(body, "*Reviewed by: claude / sonnet-4*");
+        let body_pos = req.args.iter().position(|a| a.starts_with("body=")).unwrap();
+        let body = &req.args[body_pos];
+        assert_eq!(body, "body=*Reviewed by: claude / sonnet-4*");
     }
 
     #[test]

--- a/orbit-tools/src/builtin/github/pr_review.rs
+++ b/orbit-tools/src/builtin/github/pr_review.rs
@@ -10,15 +10,16 @@ pub(super) fn build_exec_request(
     ctx: &ToolContext,
     input: &Value,
 ) -> Result<ExecRequest, OrbitError> {
+    let repo = require_str(input, "repo")?;
     let pr = super::require_pr(input)?;
     let action = require_str(input, "action")?;
 
     let body = input.get("body").and_then(Value::as_str);
 
-    let action_flag = match action.as_str() {
-        "approve" => "--approve",
-        "request-changes" => "--request-changes",
-        "comment" => "--comment",
+    let event = match action.as_str() {
+        "approve" => "APPROVE",
+        "request-changes" => "REQUEST_CHANGES",
+        "comment" => "COMMENT",
         other => {
             return Err(OrbitError::InvalidInput(format!(
                 "invalid `action`: \"{other}\"; must be approve, request-changes, or comment"
@@ -32,24 +33,25 @@ pub(super) fn build_exec_request(
         )));
     }
 
+    let review_body = if let Some(b) = body {
+        super::append_signature(b, ctx, "Reviewed")
+    } else {
+        super::agent_signature(ctx, "Reviewed").unwrap_or_default()
+    };
+
+    // POST /repos/{owner}/{repo}/pulls/{pull_number}/reviews
+    let endpoint = format!("repos/{repo}/pulls/{pr}/reviews");
+
     let mut args = vec![
-        "pr".to_string(),
-        "review".to_string(),
-        pr,
-        action_flag.to_string(),
+        "api".to_string(),
+        endpoint,
+        "-f".to_string(),
+        format!("event={event}"),
     ];
 
-    if let Some(b) = body {
-        args.push("--body".to_string());
-        args.push(super::append_signature(b, ctx, "Reviewed"));
-    } else if let Some(sig) = super::agent_signature(ctx, "Reviewed") {
-        args.push("--body".to_string());
-        args.push(sig);
-    }
-
-    if let Some(repo) = input.get("repo").and_then(Value::as_str) {
-        args.push("--repo".to_string());
-        args.push(repo.to_string());
+    if !review_body.is_empty() {
+        args.push("-f".to_string());
+        args.push(format!("body={review_body}"));
     }
 
     Ok(ExecRequest {
@@ -71,8 +73,14 @@ impl Tool for GithubPrReviewTool {
                 .to_string(),
             parameters: vec![
                 ToolParam {
+                    name: "repo".to_string(),
+                    description: "Repository in owner/name format".to_string(),
+                    param_type: "string".to_string(),
+                    required: true,
+                },
+                ToolParam {
                     name: "pr".to_string(),
-                    description: "PR number, URL, or branch name".to_string(),
+                    description: "PR number".to_string(),
                     param_type: "string".to_string(),
                     required: true,
                 },
@@ -89,12 +97,6 @@ impl Tool for GithubPrReviewTool {
                     param_type: "string".to_string(),
                     required: false,
                 },
-                ToolParam {
-                    name: "repo".to_string(),
-                    description: "Repository in owner/name format".to_string(),
-                    param_type: "string".to_string(),
-                    required: false,
-                },
             ],
             builtin: true,
         }
@@ -103,10 +105,12 @@ impl Tool for GithubPrReviewTool {
     fn execute(&self, ctx: &ToolContext, input: Value) -> Result<Value, OrbitError> {
         let req = build_exec_request(ctx, &input)?;
         let result = run_process(&req, &NoSandbox)?;
-        check_exec_result(&result, "gh pr review")?;
+        check_exec_result(&result, "gh api (pr review)")?;
+        let response: Value = serde_json::from_str(result.stdout.trim()).unwrap_or(json!({}));
+        let id = response.get("id").and_then(Value::as_u64).unwrap_or(0);
         Ok(json!({
-            "stdout": result.stdout,
-            "stderr": result.stderr,
+            "id": id,
+            "reviewed": true,
         }))
     }
 }


### PR DESCRIPTION
## Summary
- Replaced `gh pr review` (GraphQL `addPullRequestReview`) with `gh api` REST endpoint (`POST /repos/{owner}/{repo}/pulls/{pr}/reviews`)
- Fine-grained PATs with "Pull requests: Read and Write" can now submit reviews
- Added required `repo` input parameter (owner/repo format)
- Added `pr_review_rejects_missing_repo` test

## Context
Fine-grained PATs fail with `Resource not accessible by personal access token (addPullRequestReview)` when using the GraphQL mutation. The REST API works correctly with the same token permissions.

## Test plan
- [x] `cargo build --workspace` passes
- [x] `cargo test -p orbit-tools` — 74 tests pass
- [ ] Manual verification: run job pipeline with reviewer token

*authored by: claude / opus-4.6*