### PR TITLE
orbit-track-issues skill omits required fields from example command

### DIFF
--- a/orbit-core/assets/skills/orbit-create-task/SKILL.md
+++ b/orbit-core/assets/skills/orbit-create-task/SKILL.md
@@ -23,7 +23,7 @@ Create an Orbit task another engineer or agent can execute without guessing. Pla
 - Never edit task files directly.
 - Never invent task IDs.
 - `description` and `plan` must be multi-line markdown.
-- Required fields: `title`, `description`, `plan`, and `workspace`.
+- Required fields: `title`, `description`, and `workspace`. The `plan` field is optional but strongly recommended for actionable tasks.
 - Orbit fills `created_by`, `assigned_to`, and `proposed_by` automatically from execution context.
 
 ## Command

--- a/orbit-core/assets/skills/orbit-track-issues/SKILL.md
+++ b/orbit-core/assets/skills/orbit-track-issues/SKILL.md
@@ -54,12 +54,15 @@ Do **not ignore friction**. Always create a task.
 orbit tool run orbit.task.add --input '{
   "title": "<short, specific problem statement>",
   "description": "<what happened, where, and why it caused friction>",
+  "workspace": ".",
   "type": "friction",
   "priority": "<low|medium|high|critical>",
   "agent": "<agent>",
   "model": "<model>"
 }'
 ```
+
+Required fields: `title`, `description`, and `workspace`. The `plan` field is optional for friction tasks — omit it when the issue is an observation rather than a planned change.
 
 Always include your `agent` and `model` in the input. Keep the description concrete — name the command, file, or workflow that broke.
 

--- a/orbit-tools/src/builtin/orbit/mod.rs
+++ b/orbit-tools/src/builtin/orbit/mod.rs
@@ -433,10 +433,10 @@ mod tests {
                 "Add a tool".to_string(),
                 "--description".to_string(),
                 "Details".to_string(),
-                "--plan".to_string(),
-                "Plan".to_string(),
                 "--workspace".to_string(),
                 "/tmp/orbit".to_string(),
+                "--plan".to_string(),
+                "Plan".to_string(),
                 "--comment".to_string(),
                 "seed comment".to_string(),
                 "--context".to_string(),
@@ -480,10 +480,38 @@ mod tests {
                 "Fix bug".to_string(),
                 "--description".to_string(),
                 "Details here".to_string(),
-                "--plan".to_string(),
-                "Step 1".to_string(),
                 "--workspace".to_string(),
                 "/repo".to_string(),
+                "--plan".to_string(),
+                "Step 1".to_string(),
+                "--json".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn task_add_builds_request_without_plan() {
+        let req = super::task_add::build_exec_request(
+            &ToolContext::default(),
+            &json!({
+                "title": "Friction report",
+                "description": "Something broke",
+                "workspace": ".",
+            }),
+        )
+        .expect("valid add input without plan");
+
+        assert_eq!(
+            req.args,
+            vec![
+                "task".to_string(),
+                "add".to_string(),
+                "--title".to_string(),
+                "Friction report".to_string(),
+                "--description".to_string(),
+                "Something broke".to_string(),
+                "--workspace".to_string(),
+                ".".to_string(),
                 "--json".to_string(),
             ]
         );

--- a/orbit-tools/src/builtin/orbit/task_add.rs
+++ b/orbit-tools/src/builtin/orbit/task_add.rs
@@ -13,7 +13,6 @@ pub(super) fn build_exec_request(
     let identity = super::resolve_identity(ctx, input)?;
     let title = super::required_string(input, &["title"], "title")?;
     let description = super::required_string(input, &["description"], "description")?;
-    let plan = super::required_string(input, &["plan"], "plan")?;
     let workspace = super::required_string(input, &["workspace"], "workspace")?;
 
     let mut args = vec![
@@ -23,11 +22,14 @@ pub(super) fn build_exec_request(
         title,
         "--description".to_string(),
         description,
-        "--plan".to_string(),
-        plan,
         "--workspace".to_string(),
         workspace,
     ];
+
+    if let Some(plan) = super::optional_string(input, "plan")? {
+        args.push("--plan".to_string());
+        args.push(plan);
+    }
 
     if let Some(comment) = super::optional_string(input, "comment")? {
         args.push("--comment".to_string());
@@ -88,9 +90,9 @@ impl Tool for OrbitTaskAddTool {
             },
             ToolParam {
                 name: "plan".to_string(),
-                description: "Task plan markdown".to_string(),
+                description: "Optional task plan markdown (defaults to empty)".to_string(),
                 param_type: "string".to_string(),
-                required: true,
+                required: false,
             },
             ToolParam {
                 name: "workspace".to_string(),


### PR DESCRIPTION
## Changes
## Status
success

## 1. Summary of Changes

Fixed the orbit-track-issues skill to include all required fields in its example command, and made `plan` optional in `orbit.task.add` for friction-type tasks.

### Files changed:
- **orbit-tools/src/builtin/orbit/task_add.rs** — Changed `plan` from required to optional in both the `build_exec_request` function and the tool schema. When omitted, the `--plan` flag is simply not passed to the CLI (which already defaults plan to empty string).
- **orbit-tools/src/builtin/orbit/mod.rs** — Updated existing tests for new arg order and added `task_add_builds_request_without_plan` test.
- **orbit-core/assets/skills/orbit-track-issues/SKILL.md** — Added `workspace` field to example command. Added note that `plan` is optional for friction tasks.
- **orbit-core/assets/skills/orbit-create-task/SKILL.md** — Updated required fields list to reflect `plan` being optional (but strongly recommended for actionable tasks).

## 2. Strategic Decisions
- Made `plan` optional at the tool layer rather than adding a default value | Rationale: The CLI already defaults plan to empty string, so the tool should not be stricter than the CLI | Trade-offs: Agents may create tasks without plans, but the skill docs guide proper usage
- Kept `workspace` required | Rationale: Workspace is always needed for task resolution and has no sensible default | Trade-offs: None

## 3. Assumptions Made
- The 3 failing tests in orbit-cli/tests/task_commands.rs are pre-existing and unrelated | Impact if incorrect: Would need investigation, but verified by running tests on clean main branch

## 4. Design Weaknesses / Risks
- None | Severity: N/A | Mitigation: N/A

## 5. Deviations from Original Plan
- Plan step 3 mentioned --root; investigation showed --root is auto-injected by the tool infrastructure, so no skill documentation change was needed for it | Justification: --root is internal plumbing, not an agent-facing parameter

## 6. Technical Debt Introduced
None

## 7. Recommended Follow-Ups
- Fix the 3 pre-existing test failures in orbit-cli/tests/task_commands.rs related to agent/model identity fields

## Branch Freshness
- Base ref: `agent-main`
- Head ref: `orbit/T20260323-030141`
- Behind base: 0
- Ahead of base: 1

## Files Changed
- `orbit-core/assets/skills/orbit-create-task/SKILL.md`
- `orbit-core/assets/skills/orbit-track-issues/SKILL.md`
- `orbit-tools/src/builtin/orbit/mod.rs`
- `orbit-tools/src/builtin/orbit/task_add.rs`

*Implemented by: claude / opus*