### PR TITLE
Seed default execution.env.pass list in config.toml on orbit init

### DIFF
--- a/orbit-core/assets/config/default-config.toml
+++ b/orbit-core/assets/config/default-config.toml
@@ -1,5 +1,15 @@
 [execution.env]
 inherit = false
+# Baseline env vars passed to agent subprocesses.
+# User-specific vars (GITHUB_TOKEN, ANTHROPIC_API_KEY, etc.) are opt-in — add them as needed.
+pass = [
+    "HOME",
+    "PATH",
+    "CODEX_HOME",
+    "TMPDIR",
+    "USER",
+    "__CF_USER_TEXT_ENCODING",  # macOS: required by CoreFoundation
+]
 
 [execution.codex]
 sandbox = "workspace-write"


### PR DESCRIPTION
## Changes
## Status
success

## 1. Summary of Changes
Updated `orbit-core/assets/config/default-config.toml` to seed the `[execution.env]` section with the baseline `pass` list: `HOME`, `PATH`, `CODEX_HOME`, `TMPDIR`, `USER`, and `__CF_USER_TEXT_ENCODING` (macOS). This makes the default passthrough variables visible in the generated config.toml so users know what is being passed without having to discover `default_pass_list()` in the source code.

## 2. Strategic Decisions
- Include `__CF_USER_TEXT_ENCODING` unconditionally in the template | Rationale: The template is a static TOML file — `#[cfg(target_os)]` is not available. Having an unused var on Linux is harmless, and the inline comment explains it is macOS-specific. | Trade-offs: Non-macOS users see a var they do not need, but the comment makes this clear.
- Keep the runtime `default_pass_list()` fallback unchanged | Rationale: The fallback still applies when `pass` is absent (e.g. older config files). No behavior change for existing installations. | Trade-offs: None.

## 3. Assumptions Made
- The TOML inline comment syntax (`# comment` after a value) is supported by the TOML parser in use | Impact if incorrect: Config parsing would fail on init-generated configs.

## 4. Design Weaknesses / Risks
None. The change is a single template file edit with no logic changes.

## 5. Deviations from Original Plan
None (no plan was provided; implementation followed the task description directly).

## 6. Technical Debt Introduced
None

## 7. Recommended Follow-Ups
- None required. The existing `default_pass_list()` and `normalize_pass_list()` code remains unchanged and continues to serve as the runtime fallback.

## Branch Freshness
- Base ref: `agent-main`
- Head ref: `orbit/T20260323-051742`
- Behind base: 0
- Ahead of base: 1

## Files Changed
- `orbit-core/assets/config/default-config.toml`

*Implemented by: claude / opus*