### PR TITLE
Fix CodeQL cleartext-logging alerts for parse_user_name

### DIFF
--- a/orbit-cli/src/command/init.rs
+++ b/orbit-cli/src/command/init.rs
@@ -44,12 +44,13 @@ impl InitCommand {
 }
 
 fn print_init_result(result: &orbit_core::command::init::InitResult) {
+    use orbit_types::redaction::redact_home_dir;
     println!(
         "skills: root={}, refreshed={}, symlink_created={}; config: path={}, created={}; default_activities_refreshed={}; default_jobs_refreshed={}",
-        result.skills_root,
+        redact_home_dir(&result.skills_root),
         result.refreshed_skill_files,
         result.created_skills_symlink,
-        result.config_path,
+        redact_home_dir(&result.config_path),
         result.created_config,
         result.refreshed_default_activities,
         result.refreshed_default_jobs

--- a/orbit-cli/tests/init_commands.rs
+++ b/orbit-cli/tests/init_commands.rs
@@ -411,10 +411,7 @@ fn init_always_targets_global_root_regardless_of_cwd() {
         .args(["init"])
         .assert()
         .success()
-        .stdout(predicate::str::contains(format!(
-            "skills: root={}",
-            home.path().join(".orbit").join("skills").display()
-        )));
+        .stdout(predicate::str::contains("skills: root=~/.orbit/skills"));
 
     // Skills are at HOME/.orbit, not at the workspace
     assert!(

--- a/orbit-store/src/sqlite/connection.rs
+++ b/orbit-store/src/sqlite/connection.rs
@@ -2,6 +2,7 @@ use std::path::Path;
 use std::sync::{Arc, Mutex};
 
 use orbit_types::OrbitError;
+use orbit_types::redaction::redact_home_dir;
 use rusqlite::{Connection, Transaction};
 
 use crate::sqlite::migration;
@@ -30,7 +31,7 @@ impl Store {
         if let Err(e) = conn.pragma_update(None, "journal_mode", "WAL") {
             eprintln!(
                 "orbit: warning: could not set WAL mode on {}: {e}",
-                path.display()
+                redact_home_dir(&path.display().to_string())
             );
         }
         conn.pragma_update(None, "foreign_keys", "ON")

--- a/orbit-types/src/redaction.rs
+++ b/orbit-types/src/redaction.rs
@@ -95,6 +95,26 @@ pub fn redact_sensitive_env_error(error: OrbitError) -> OrbitError {
     }
 }
 
+/// Replace the user's home directory with `~` in the given string.
+///
+/// This prevents user-identifiable paths (e.g. `/Users/alice/.orbit/store.db`)
+/// from appearing in log or terminal output, addressing CodeQL
+/// `rust/cleartext-logging` alerts.
+pub fn redact_home_dir(text: &str) -> String {
+    if let Some(home) = home_dir_string() {
+        text.replace(&home, "~")
+    } else {
+        text.to_string()
+    }
+}
+
+fn home_dir_string() -> Option<String> {
+    std::env::var("HOME")
+        .ok()
+        .or_else(|| std::env::var("USERPROFILE").ok())
+        .filter(|h| !h.is_empty())
+}
+
 fn sensitive_env_values() -> Vec<String> {
     let mut values = std::env::vars()
         .filter(|(name, value)| is_sensitive_env_name(name) && is_redactable_value(value))
@@ -135,9 +155,23 @@ mod tests {
     use crate::OrbitError;
 
     use super::{
-        REDACTED_ENV_VALUE, redact_sensitive_env_error, redact_sensitive_env_json,
-        redact_sensitive_env_text,
+        REDACTED_ENV_VALUE, redact_home_dir, redact_sensitive_env_error,
+        redact_sensitive_env_json, redact_sensitive_env_text,
     };
+
+    #[test]
+    fn redacts_home_dir_in_path() {
+        let home = std::env::var("HOME")
+            .or_else(|_| std::env::var("USERPROFILE"))
+            .expect("HOME or USERPROFILE must be set");
+        let input = format!("{home}/.orbit/store.db");
+        assert_eq!(redact_home_dir(&input), "~/.orbit/store.db");
+    }
+
+    #[test]
+    fn redact_home_dir_leaves_non_home_paths_unchanged() {
+        assert_eq!(redact_home_dir("/tmp/data.db"), "/tmp/data.db");
+    }
 
     #[test]
     fn redacts_sensitive_env_values_in_text() {


### PR DESCRIPTION
## Changes
## Status
success

## 1. Summary of Changes
Added `redact_home_dir` utility to `orbit-types/src/redaction.rs` that replaces the user's home directory (`$HOME` / `$USERPROFILE`) with `~` in strings. Applied this redaction at the two concrete log/print sites flagged by CodeQL:
- `orbit-store/src/sqlite/connection.rs:31` — `eprintln!` WAL warning now redacts the DB path
- `orbit-cli/src/command/init.rs:47` — `println!` init result now redacts `skills_root` and `config_path`
- Updated the `init_always_targets_global_root_regardless_of_cwd` test to expect the redacted `~` path

For `orbit-core/src/config/runtime.rs:122`, investigation confirmed that `parse_user_name` returns a configured identity string (not an OS username) that is stored in `RuntimeConfig.user_name` but never flows to any log/print call. No code change needed — the CodeQL alert at that location traces the taint source, not a concrete sink.

## 2. Strategic Decisions
- Used `$HOME` / `$USERPROFILE` env vars for home dir detection rather than platform-specific APIs | Rationale: `orbit-types` has no `dirs` dependency and env vars are sufficient since agents always run in a shell context | Trade-offs: Would miss edge cases where HOME is unset (fallback returns the string unchanged, which is safe)
- Placed the utility in existing `orbit-types::redaction` module | Rationale: Natural home for redaction functions; already imported by all crates | Trade-offs: None

## 3. Assumptions Made
- The 3 pre-existing test failures in `task_commands.rs` (provenance fields) are unrelated to this change | Impact if incorrect: None — verified by running the same tests on the unmodified branch
- CodeQL alert at `runtime.rs:122` is a source-tracking alert, not a concrete cleartext-logging sink | Impact if incorrect: If the username does flow to logs via a path not found by grep, the alert would persist

## 4. Design Weaknesses / Risks
- None | The change is minimal and the fallback behavior (no redaction when HOME is unset) is safe

## 5. Deviations from Original Plan
- No code change for `orbit-core/src/config/runtime.rs:122` | Justification: Investigation confirmed `user_name` never flows to log output; changing the storage site would not address a CodeQL cleartext-logging alert since the issue is at the sink, not the source

## 6. Technical Debt Introduced
None

## 7. Recommended Follow-Ups
- Monitor CodeQL alerts after merge to confirm alerts #5, #6, #8 are resolved
- If alert #8 (runtime.rs:122) persists, investigate whether CodeQL traces through a path not covered by this grep-based analysis

## Branch Freshness
- Base ref: `agent-main`
- Head ref: `orbit/T20260328-013421`
- Behind base: 0
- Ahead of base: 1

## Files Changed
- `orbit-cli/src/command/init.rs`
- `orbit-cli/tests/init_commands.rs`
- `orbit-store/src/sqlite/connection.rs`
- `orbit-types/src/redaction.rs`

*Implemented by: claude / opus*