### PR TITLE
Security: GitHub API endpoint path traversal via unsanitized repo/pr/comment_id

### DIFF
--- a/orbit-tools/src/builtin/github/mod.rs
+++ b/orbit-tools/src/builtin/github/mod.rs
@@ -35,9 +35,63 @@ pub fn register(registry: &mut ToolRegistry) {
     registry.register(pr_checks::GithubPrChecksTool);
 }
 
-/// Extract a non-empty `pr` field from the tool input.
+/// Validate that `repo` matches the `owner/name` format expected by the GitHub API.
+///
+/// Rejects values containing path traversal sequences, extra slashes, or characters
+/// outside the set GitHub allows for owner and repository names.
+pub(super) fn validate_repo(repo: &str) -> Result<(), OrbitError> {
+    // GitHub owner: alphanumeric or hyphen (no leading hyphen, no consecutive hyphens in org names,
+    // but we keep the regex simple — GitHub itself will reject truly invalid names).
+    // Repo name: alphanumeric, hyphen, underscore, or dot.
+    // Exactly one slash separating owner and name.
+    let valid = repo.split('/').count() == 2 && {
+        let mut parts = repo.split('/');
+        let owner = parts.next().unwrap_or("");
+        let name = parts.next().unwrap_or("");
+        !owner.is_empty()
+            && !name.is_empty()
+            && owner
+                .chars()
+                .all(|c| c.is_ascii_alphanumeric() || c == '-')
+            && name
+                .chars()
+                .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_' || c == '.')
+    };
+    if !valid {
+        return Err(OrbitError::InvalidInput(format!(
+            "invalid `repo` format: \"{repo}\"; expected owner/name (e.g. octocat/hello-world)"
+        )));
+    }
+    Ok(())
+}
+
+/// Extract and validate a `repo` field in `owner/name` format.
+pub(super) fn require_repo(input: &Value) -> Result<String, OrbitError> {
+    let repo = require_str(input, "repo")?;
+    validate_repo(&repo)?;
+    Ok(repo)
+}
+
+/// Extract a non-empty `pr` field from the tool input, validated as numeric.
 pub(super) fn require_pr(input: &Value) -> Result<String, OrbitError> {
-    require_str(input, "pr")
+    let pr = require_str(input, "pr")?;
+    if !pr.chars().all(|c| c.is_ascii_digit()) || pr.is_empty() {
+        return Err(OrbitError::InvalidInput(format!(
+            "invalid `pr`: \"{pr}\"; must be a numeric PR number"
+        )));
+    }
+    Ok(pr)
+}
+
+/// Extract a non-empty numeric string field from tool input.
+pub(super) fn require_numeric_str(input: &Value, key: &str) -> Result<String, OrbitError> {
+    let value = require_str(input, key)?;
+    if !value.chars().all(|c| c.is_ascii_digit()) || value.is_empty() {
+        return Err(OrbitError::InvalidInput(format!(
+            "invalid `{key}`: \"{value}\"; must be numeric"
+        )));
+    }
+    Ok(value)
 }
 
 /// Build an agent attribution footer line.
@@ -323,6 +377,95 @@ mod tests {
         )
         .expect_err("must fail");
         assert!(err.to_string().contains("body"), "{err}");
+    }
+
+    // --- Path traversal / format validation ---
+
+    #[test]
+    fn validate_repo_accepts_valid_formats() {
+        assert!(super::validate_repo("owner/repo").is_ok());
+        assert!(super::validate_repo("my-org/my-repo").is_ok());
+        assert!(super::validate_repo("octocat/hello-world").is_ok());
+        assert!(super::validate_repo("org/repo_name").is_ok());
+        assert!(super::validate_repo("org/repo.name").is_ok());
+    }
+
+    #[test]
+    fn validate_repo_rejects_path_traversal() {
+        assert!(super::validate_repo("../evil/repo").is_err());
+        assert!(super::validate_repo("owner/../other").is_err());
+        assert!(super::validate_repo("owner/repo/../../etc").is_err());
+    }
+
+    #[test]
+    fn validate_repo_rejects_malformed_values() {
+        assert!(super::validate_repo("noslash").is_err());
+        assert!(super::validate_repo("too/many/slashes").is_err());
+        assert!(super::validate_repo("/leading").is_err());
+        assert!(super::validate_repo("trailing/").is_err());
+        assert!(super::validate_repo("").is_err());
+        assert!(super::validate_repo("has spaces/repo").is_err());
+    }
+
+    #[test]
+    fn require_pr_rejects_non_numeric() {
+        assert!(super::require_pr(&json!({ "pr": "42" })).is_ok());
+        assert!(super::require_pr(&json!({ "pr": "abc" })).is_err());
+        assert!(super::require_pr(&json!({ "pr": "42/../../etc" })).is_err());
+        assert!(super::require_pr(&json!({ "pr": "12 34" })).is_err());
+    }
+
+    #[test]
+    fn require_numeric_str_rejects_non_numeric() {
+        assert!(super::require_numeric_str(&json!({ "id": "12345" }), "id").is_ok());
+        assert!(super::require_numeric_str(&json!({ "id": "abc" }), "id").is_err());
+        assert!(super::require_numeric_str(&json!({ "id": "../123" }), "id").is_err());
+    }
+
+    #[test]
+    fn pr_review_comment_rejects_traversal_repo() {
+        let err = super::pr_review_comment::build_exec_request(
+            &ToolContext::default(),
+            &json!({
+                "repo": "evil/../other",
+                "pr": "42",
+                "path": "src/main.rs",
+                "line": 10,
+                "body": "issue"
+            }),
+        )
+        .expect_err("must reject path traversal");
+        assert!(err.to_string().contains("repo"), "{err}");
+    }
+
+    #[test]
+    fn pr_comment_reply_rejects_traversal_repo() {
+        let err = super::pr_comment_reply::build_exec_request(
+            &ToolContext::default(),
+            &json!({
+                "repo": "evil/../other",
+                "pr": "42",
+                "comment_id": "123",
+                "body": "reply"
+            }),
+        )
+        .expect_err("must reject path traversal");
+        assert!(err.to_string().contains("repo"), "{err}");
+    }
+
+    #[test]
+    fn pr_comment_reply_rejects_non_numeric_comment_id() {
+        let err = super::pr_comment_reply::build_exec_request(
+            &ToolContext::default(),
+            &json!({
+                "repo": "owner/repo",
+                "pr": "42",
+                "comment_id": "abc/../123",
+                "body": "reply"
+            }),
+        )
+        .expect_err("must reject non-numeric comment_id");
+        assert!(err.to_string().contains("comment_id"), "{err}");
     }
 
     #[test]

--- a/orbit-tools/src/builtin/github/pr_comment_reply.rs
+++ b/orbit-tools/src/builtin/github/pr_comment_reply.rs
@@ -10,9 +10,9 @@ pub(super) fn build_exec_request(
     ctx: &ToolContext,
     input: &Value,
 ) -> Result<(ExecRequest, String), OrbitError> {
-    let repo = require_str(input, "repo")?;
+    let repo = super::require_repo(input)?;
     let pr = super::require_pr(input)?;
-    let comment_id = require_str(input, "comment_id")?;
+    let comment_id = super::require_numeric_str(input, "comment_id")?;
     let body = require_str(input, "body")?;
     let body = super::append_signature(&body, ctx, "Reviewed");
 

--- a/orbit-tools/src/builtin/github/pr_review_comment.rs
+++ b/orbit-tools/src/builtin/github/pr_review_comment.rs
@@ -10,7 +10,7 @@ pub(super) fn build_exec_request(
     ctx: &ToolContext,
     input: &Value,
 ) -> Result<ExecRequest, OrbitError> {
-    let repo = require_str(input, "repo")?;
+    let repo = super::require_repo(input)?;
     let pr = super::require_pr(input)?;
     let body = require_str(input, "body")?;
     let path = require_str(input, "path")?;


### PR DESCRIPTION
## Changes
## Status
success

## 1. Summary of Changes
Added input validation to prevent GitHub API endpoint path traversal in `pr_review_comment.rs` and `pr_comment_reply.rs`. Introduced shared validation helpers in the github `mod.rs`: `validate_repo()` enforces owner/name format, `require_repo()` combines extraction + validation, `require_pr()` now validates numeric-only input, and `require_numeric_str()` validates numeric string fields like `comment_id`.

## 2. Strategic Decisions
- Centralized validation in `mod.rs` rather than inline in each file | Rationale: DRY, single source of truth for repo/PR format rules | Trade-offs: Other files using `require_str(input, "repo")` directly are not yet migrated
- Used character-level validation instead of regex | Rationale: No regex dependency needed, clear and auditable | Trade-offs: Slightly more verbose but zero additional dependencies

## 3. Assumptions Made
- GitHub owner names allow only alphanumeric + hyphen | Impact if incorrect: Legitimate owners with other characters would be rejected (unlikely, GitHub enforces this)
- GitHub repo names allow alphanumeric + hyphen + underscore + dot | Impact if incorrect: Repos with unusual characters would be rejected

## 4. Design Weaknesses / Risks
- `pr_review.rs` and `pr_comments.rs` also interpolate `repo` into API paths without the new validation | Severity: Medium | Mitigation: Documented as follow-up; same `require_repo()` helper is available for adoption

## 5. Deviations from Original Plan
None (no plan was specified; implemented per task description)

## 6. Technical Debt Introduced
None

## 7. Recommended Follow-Ups
- Apply `require_repo()` validation to `pr_review.rs:13` and `pr_comments.rs:16-17` which have the same unsanitized interpolation pattern
- Apply `require_pr()` numeric validation in `pr_comments.rs:13` (already uses `require_pr` so will pick up the fix automatically)

## Branch Freshness
- Base ref: `agent-main`
- Head ref: `orbit/T20260323-053723`
- Behind base: 0
- Ahead of base: 1

## Files Changed
- `orbit-tools/src/builtin/github/mod.rs`
- `orbit-tools/src/builtin/github/pr_comment_reply.rs`
- `orbit-tools/src/builtin/github/pr_review_comment.rs`

*Implemented by: claude / opus*