### PR TITLE
feat: Security hardening for proc.spawn [T20260323-053719]

### DIFF
--- a/orbit-core/assets/activities/implement_change.yaml
+++ b/orbit-core/assets/activities/implement_change.yaml
@@ -119,3 +119,13 @@ activity:
     - fs.delete
     - proc.spawn
     - proc.which
+  proc_allowed_programs:
+    - cargo
+    - make
+    - npm
+    - npx
+    - node
+    - sh
+    - bash
+    - git
+    - orbit

--- a/orbit-core/assets/activities/implement_fix.yaml
+++ b/orbit-core/assets/activities/implement_fix.yaml
@@ -83,3 +83,13 @@ activity:
     - proc.which
     - github.pr.comments
     - github.pr.comment.reply
+  proc_allowed_programs:
+    - cargo
+    - make
+    - npm
+    - npx
+    - node
+    - sh
+    - bash
+    - git
+    - orbit

--- a/orbit-core/src/command/tool.rs
+++ b/orbit-core/src/command/tool.rs
@@ -35,6 +35,7 @@ impl OrbitRuntime {
     pub fn execute_tool_command(&self, name: &str, input: Value) -> Result<Value, OrbitError> {
         let allowed_tools = read_activity_tools_from_env();
         let (agent_name, model_name) = read_agent_identity_from_env();
+        let proc_allowed_programs = read_proc_allowed_programs_from_env();
         let workspace_root = Some(self.paths().repo_root.clone());
         let tool_context = ToolContext {
             cwd: None,
@@ -42,6 +43,7 @@ impl OrbitRuntime {
             agent_name,
             model_name,
             workspace_root,
+            proc_allowed_programs,
             ..Default::default()
         };
         self.run_tool_with_context_and_role(name, input, Role::Admin, tool_context)
@@ -56,6 +58,19 @@ fn read_agent_identity_from_env() -> (Option<String>, Option<String>) {
         .ok()
         .filter(|s| !s.is_empty());
     (agent, model)
+}
+
+fn read_proc_allowed_programs_from_env() -> Vec<String> {
+    std::env::var("ORBIT_PROC_ALLOWED_PROGRAMS")
+        .ok()
+        .map(|raw| {
+            raw.split(',')
+                .map(str::trim)
+                .filter(|s| !s.is_empty())
+                .map(String::from)
+                .collect()
+        })
+        .unwrap_or_default()
 }
 
 fn read_activity_tools_from_env() -> Vec<String> {

--- a/orbit-engine/src/executor/agent.rs
+++ b/orbit-engine/src/executor/agent.rs
@@ -162,13 +162,16 @@ fn execute_agent_process<H: EnvironmentHost + AgentProtocolHost + ?Sized>(
 
     let resolved_model = resolve_model_for_env(host, execution);
     let environment_mode = apply_env_set(
-        inject_agent_identity(
-            inject_activity_tools(
-                host.execution_environment_mode(&execution.env_extra),
-                &execution.activity.tools,
+        inject_proc_allowed_programs(
+            inject_agent_identity(
+                inject_activity_tools(
+                    host.execution_environment_mode(&execution.env_extra),
+                    &execution.activity.tools,
+                ),
+                execution,
+                resolved_model.as_deref(),
             ),
-            execution,
-            resolved_model.as_deref(),
+            &execution.activity.proc_allowed_programs,
         ),
         &execution.env_set,
     );
@@ -201,6 +204,27 @@ fn inject_activity_tools(mode: EnvironmentMode, tools: &[String]) -> Environment
         EnvironmentMode::Inherit => {
             let mut pairs: Vec<(String, String)> = std::env::vars().collect();
             pairs.push(("ORBIT_ACTIVITY_TOOLS".to_string(), tools_str));
+            EnvironmentMode::ClearAndSet(pairs)
+        }
+    }
+}
+
+fn inject_proc_allowed_programs(
+    mode: EnvironmentMode,
+    programs: &[String],
+) -> EnvironmentMode {
+    if programs.is_empty() {
+        return mode;
+    }
+    let programs_str = programs.join(",");
+    match mode {
+        EnvironmentMode::ClearAndSet(mut pairs) => {
+            pairs.push(("ORBIT_PROC_ALLOWED_PROGRAMS".to_string(), programs_str));
+            EnvironmentMode::ClearAndSet(pairs)
+        }
+        EnvironmentMode::Inherit => {
+            let mut pairs: Vec<(String, String)> = std::env::vars().collect();
+            pairs.push(("ORBIT_PROC_ALLOWED_PROGRAMS".to_string(), programs_str));
             EnvironmentMode::ClearAndSet(pairs)
         }
     }

--- a/orbit-store/src/file/activity_store.rs
+++ b/orbit-store/src/file/activity_store.rs
@@ -254,6 +254,18 @@ fn doc_to_work(
                 .collect()
         })
         .unwrap_or_default();
+    let proc_allowed_programs: Vec<String> = doc
+        .activity
+        .spec_config
+        .get("proc_allowed_programs")
+        .and_then(Value::as_array)
+        .map(|arr| {
+            arr.iter()
+                .filter_map(Value::as_str)
+                .map(String::from)
+                .collect()
+        })
+        .unwrap_or_default();
     Activity {
         id: doc.activity.id,
         spec_type: doc.activity.spec_type,
@@ -262,6 +274,7 @@ fn doc_to_work(
         output_schema_json: normalize_json_schema_for_runtime(doc.activity.output_schema_json),
         spec_config: Value::Object(doc.activity.spec_config),
         tools,
+        proc_allowed_programs,
         workspace_path: doc.activity.workspace_path,
         created_by: doc.created_by,
         is_active,

--- a/orbit-tools/src/builtin/proc/spawn.rs
+++ b/orbit-tools/src/builtin/proc/spawn.rs
@@ -35,12 +35,23 @@ impl Tool for ProcSpawnTool {
         }
     }
 
-    fn execute(&self, _ctx: &ToolContext, input: Value) -> Result<Value, OrbitError> {
+    fn execute(&self, ctx: &ToolContext, input: Value) -> Result<Value, OrbitError> {
         let program = input
             .get("program")
             .and_then(Value::as_str)
             .ok_or_else(|| OrbitError::InvalidInput("missing `program`".to_string()))?
             .to_string();
+
+        // Enforce program allowlist when configured.
+        if !ctx.proc_allowed_programs.is_empty()
+            && !ctx.proc_allowed_programs.iter().any(|p| p == &program)
+        {
+            return Err(OrbitError::PolicyDenied(format!(
+                "program '{}' is not in the allowed list: [{}]",
+                program,
+                ctx.proc_allowed_programs.join(", ")
+            )));
+        }
 
         let args = input
             .get("args")
@@ -55,6 +66,11 @@ impl Tool for ProcSpawnTool {
 
         let timeout_ms = input.get("timeout_ms").and_then(Value::as_u64);
 
+        // Filter sensitive env vars instead of inheriting the full environment.
+        let env_pairs: Vec<(String, String)> = std::env::vars()
+            .filter(|(k, _)| !is_sensitive_env_name(k))
+            .collect();
+
         let exec_result = run_process(
             &ExecRequest {
                 program,
@@ -62,7 +78,7 @@ impl Tool for ProcSpawnTool {
                 current_dir: None,
                 timeout_ms,
                 stdin_mode: StdinMode::Inherit,
-                environment_mode: EnvironmentMode::Inherit,
+                environment_mode: EnvironmentMode::ClearAndSet(env_pairs),
                 debug: false,
             },
             &NoSandbox,
@@ -70,5 +86,62 @@ impl Tool for ProcSpawnTool {
 
         serde_json::to_value(exec_result)
             .map_err(|e| OrbitError::Execution(format!("serialize exec result: {e}")))
+    }
+}
+
+/// Returns `true` if the environment variable name looks like it holds a secret.
+fn is_sensitive_env_name(name: &str) -> bool {
+    let upper = name.to_ascii_uppercase();
+    let patterns = ["KEY", "TOKEN", "SECRET", "PASSWORD", "CREDENTIAL"];
+    patterns.iter().any(|p| upper.contains(p))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sensitive_env_detection() {
+        assert!(is_sensitive_env_name("GITHUB_TOKEN"));
+        assert!(is_sensitive_env_name("AWS_SECRET_ACCESS_KEY"));
+        assert!(is_sensitive_env_name("DB_PASSWORD"));
+        assert!(is_sensitive_env_name("api_key"));
+        assert!(is_sensitive_env_name("GOOGLE_CREDENTIALS"));
+        assert!(!is_sensitive_env_name("HOME"));
+        assert!(!is_sensitive_env_name("PATH"));
+        assert!(!is_sensitive_env_name("ORBIT_AGENT_NAME"));
+    }
+
+    #[test]
+    fn allowlist_blocks_disallowed_program() {
+        let tool = ProcSpawnTool;
+        let ctx = ToolContext {
+            proc_allowed_programs: vec!["cargo".to_string(), "git".to_string()],
+            ..Default::default()
+        };
+        let input = serde_json::json!({ "program": "curl" });
+        let result = tool.execute(&ctx, input);
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(err.contains("policy denied"), "got: {err}");
+        assert!(err.contains("curl"));
+    }
+
+    #[test]
+    fn empty_allowlist_permits_any_program() {
+        // Just verify it doesn't error on the allowlist check — the spawn itself
+        // will fail with a nonexistent program, but that's fine.
+        let tool = ProcSpawnTool;
+        let ctx = ToolContext::default();
+        let input = serde_json::json!({ "program": "echo", "args": ["hello"] });
+        // This should either succeed or fail on spawn, not on policy.
+        let result = tool.execute(&ctx, input);
+        match result {
+            Ok(_) => {} // echo worked
+            Err(e) => assert!(
+                !e.to_string().contains("policy denied"),
+                "should not be policy denied: {e}"
+            ),
+        }
     }
 }

--- a/orbit-tools/src/lib.rs
+++ b/orbit-tools/src/lib.rs
@@ -70,6 +70,9 @@ pub struct ToolContext {
     /// Resolved model identifier (e.g. `"opus-4.6"`). Used alongside `agent_name`
     /// for the attribution footer.
     pub model_name: Option<String>,
+    /// Program allowlist for `proc.spawn`. When non-empty, `proc.spawn` rejects
+    /// any program not in this list. Empty means unrestricted.
+    pub proc_allowed_programs: Vec<String>,
 }
 
 pub trait Tool: Send + Sync {

--- a/orbit-types/src/activity.rs
+++ b/orbit-types/src/activity.rs
@@ -17,6 +17,9 @@ pub struct Activity {
     /// Tool allowlist for agent_invoke activities. Empty means unrestricted.
     #[serde(default)]
     pub tools: Vec<String>,
+    /// Program allowlist for `proc.spawn`. Empty means unrestricted.
+    #[serde(default)]
+    pub proc_allowed_programs: Vec<String>,
     #[serde(default)]
     pub workspace_path: Option<String>,
     #[serde(default)]

--- a/orbit-types/src/lib.rs
+++ b/orbit-types/src/lib.rs
@@ -235,6 +235,7 @@ mod tests {
                 "tools": ["fs.read", "fs.write"]
             }),
             tools: vec!["fs.read".to_string(), "fs.write".to_string()],
+            proc_allowed_programs: vec![],
             workspace_path: None,
             created_by: Some("human".to_string()),
             is_active: true,


### PR DESCRIPTION
## Summary

- **Program allowlist**: Activities can declare `proc_allowed_programs` in YAML. When non-empty, `proc.spawn` rejects disallowed programs with `PolicyDenied`. Plumbed via `ORBIT_PROC_ALLOWED_PROGRAMS` env var through the agent executor → ToolContext → ProcSpawnTool enforcement chain.
- **Sensitive env filtering**: `proc.spawn` no longer inherits the full parent environment. Variables matching `KEY`, `TOKEN`, `SECRET`, `PASSWORD`, or `CREDENTIAL` patterns are stripped before spawning child processes.
- **Default allowlists**: `implement_change` and `implement_fix` activities now restrict `proc.spawn` to: cargo, make, npm, npx, node, sh, bash, git, orbit.

## Files changed (9)

| File | Change |
|------|--------|
| `orbit-types/src/activity.rs` | Add `proc_allowed_programs` field to `Activity` |
| `orbit-tools/src/lib.rs` | Add `proc_allowed_programs` field to `ToolContext` |
| `orbit-engine/src/executor/agent.rs` | Inject `ORBIT_PROC_ALLOWED_PROGRAMS` env var |
| `orbit-core/src/command/tool.rs` | Read env var into `ToolContext` |
| `orbit-tools/src/builtin/proc/spawn.rs` | Enforce allowlist + filter sensitive env vars |
| `orbit-store/src/file/activity_store.rs` | Parse `proc_allowed_programs` from YAML |
| `orbit-core/assets/activities/implement_change.yaml` | Add default program allowlist |
| `orbit-core/assets/activities/implement_fix.yaml` | Add default program allowlist |
| `orbit-types/src/lib.rs` | Fix test constructor |

## Test plan

- [x] `cargo build` passes
- [x] `cargo test --workspace` — all pass (3 pre-existing failures unrelated)
- [x] `cargo test -p orbit-tools` — 85/85 pass, including new allowlist + env filter tests
- [ ] Manual: verify `proc.spawn` with disallowed program returns PolicyDenied
- [ ] Manual: verify sensitive env vars (e.g. GITHUB_TOKEN) are not inherited by spawned processes

*authored by: claude / opus-4.6*

🤖 Generated with [Claude Code](https://claude.com/claude-code)