### PR TITLE
Make GitHub PR label optional in github.pr.create tool

### DIFF
--- a/orbit-tools/src/builtin/github/mod.rs
+++ b/orbit-tools/src/builtin/github/mod.rs
@@ -517,8 +517,10 @@ mod tests {
         assert!(req.args.contains(&"main".to_string()));
         assert!(req.args.contains(&"--head".to_string()));
         assert!(req.args.contains(&"feature/foo".to_string()));
-        assert!(req.args.contains(&"--label".to_string()));
-        assert!(req.args.contains(&"orbit".to_string()));
+        assert!(
+            !req.args.contains(&"--label".to_string()),
+            "no --label flag expected when label is not provided"
+        );
     }
 
     #[test]

--- a/orbit-tools/src/builtin/github/pr_create.rs
+++ b/orbit-tools/src/builtin/github/pr_create.rs
@@ -46,12 +46,10 @@ pub(super) fn build_exec_request(
         args.push(validated.to_string_lossy().to_string());
     }
 
-    let label = input
-        .get("label")
-        .and_then(Value::as_str)
-        .unwrap_or("orbit");
-    args.push("--label".to_string());
-    args.push(label.to_string());
+    if let Some(label) = input.get("label").and_then(Value::as_str) {
+        args.push("--label".to_string());
+        args.push(label.to_string());
+    }
 
     if let Some(repo) = input.get("repo").and_then(Value::as_str) {
         args.push("--repo".to_string());
@@ -110,7 +108,7 @@ impl Tool for GithubPrCreateTool {
                 },
                 ToolParam {
                     name: "label".to_string(),
-                    description: "Label to apply (defaults to \"orbit\")".to_string(),
+                    description: "Label to apply (optional, omitted if not provided)".to_string(),
                     param_type: "string".to_string(),
                     required: false,
                 },
@@ -154,6 +152,44 @@ mod tests {
             "head": "feature",
             "body_file": body_file,
         })
+    }
+
+    #[test]
+    fn no_label_flag_when_label_omitted() {
+        let workspace = tempdir().expect("workspace dir");
+        let file = workspace.path().join("pr_body.md");
+        fs::write(&file, "PR description").expect("write file");
+
+        let ctx = ToolContext {
+            workspace_root: Some(workspace.path().canonicalize().expect("canonicalize")),
+            ..Default::default()
+        };
+
+        let req = build_exec_request(&ctx, &base_input(&file.to_string_lossy()))
+            .expect("should succeed without label");
+        assert!(
+            !req.args.contains(&"--label".to_string()),
+            "expected no --label flag when label is omitted, got args: {:?}",
+            req.args
+        );
+    }
+
+    #[test]
+    fn label_flag_passed_when_provided() {
+        let workspace = tempdir().expect("workspace dir");
+        let file = workspace.path().join("pr_body.md");
+        fs::write(&file, "PR description").expect("write file");
+
+        let ctx = ToolContext {
+            workspace_root: Some(workspace.path().canonicalize().expect("canonicalize")),
+            ..Default::default()
+        };
+
+        let mut input = base_input(&file.to_string_lossy());
+        input["label"] = json!("orbit");
+        let req = build_exec_request(&ctx, &input).expect("should succeed with label");
+        let label_idx = req.args.iter().position(|a| a == "--label").expect("--label flag present");
+        assert_eq!(req.args[label_idx + 1], "orbit");
     }
 
     #[test]


### PR DESCRIPTION
## Changes
## Status
success

## 1. Summary of Changes
Made the `label` parameter in `github.pr.create` truly optional. Previously, the tool unconditionally passed `--label orbit` to `gh pr create`, causing failures on repos without the "orbit" label. Now `--label` is only included when the caller explicitly provides a label value.

**Files changed:**
- `orbit-tools/src/builtin/github/pr_create.rs` — conditional label logic, updated schema description, added 2 new tests
- `orbit-tools/src/builtin/github/mod.rs` — updated `pr_create_builds_correct_args` test to verify no `--label` when omitted

## 2. Strategic Decisions
- Only pass `--label` when explicitly provided | Rationale: The engine automation already passes `"label": "orbit"` explicitly, so removing the default at the tool level is safe and unblocks new users | Trade-offs: Callers who relied on the implicit default must now pass it explicitly (but the only caller already does)

## 3. Assumptions Made
- The engine automation at `orbit-engine/src/executor/automation/pr.rs:195` is the only internal caller that needs the orbit label | Impact if incorrect: PRs created by other code paths would lose the orbit label — but verified via grep that this is the only call site

## 4. Design Weaknesses / Risks
- None identified | Severity: N/A | Mitigation: N/A

## 5. Deviations from Original Plan
- Plan mentioned updating test `pr_create_uses_default_label` but that test did not exist. Instead updated the existing `pr_create_builds_correct_args` test in `mod.rs` which asserted `--label` was always present. Also added two new focused tests in `pr_create.rs`.

## 6. Technical Debt Introduced
None

## 7. Recommended Follow-Ups
- None

## Branch Freshness
- Base ref: `agent-main`
- Head ref: `orbit/T20260328-031437`
- Behind base: 0
- Ahead of base: 1

## Files Changed
- `orbit-tools/src/builtin/github/mod.rs`
- `orbit-tools/src/builtin/github/pr_create.rs`

*Implemented by: claude / opus*