### PR TITLE
fix: Fix 3 broken task_commands CLI tests after ActorIdentity refacto…

### DIFF
--- a/orbit-cli/tests/task_commands.rs
+++ b/orbit-cli/tests/task_commands.rs
@@ -653,25 +653,23 @@ fn task_show_json_includes_agent_and_model_when_present() {
     let id = add_task(dir.path(), "agent metadata");
     let task_yaml_path = task_dir(dir.path(), &id).join("task.yaml");
     let task_yaml = std::fs::read_to_string(&task_yaml_path).expect("read yaml");
-    let mut saw_agent = false;
-    let mut saw_model = false;
+    let mut saw_actor_identity = false;
     let rewritten = task_yaml
         .lines()
         .map(|line| {
-            if line.starts_with("agent:") {
-                saw_agent = true;
-                "agent: codex".to_string()
-            } else if line.starts_with("model:") {
-                saw_model = true;
-                "model: gpt-5.4".to_string()
+            if line.starts_with("actor_identity:") {
+                saw_actor_identity = true;
+                "actor_identity: codex / gpt-5.4".to_string()
             } else {
                 line.to_string()
             }
         })
         .collect::<Vec<_>>()
         .join("\n");
-    assert!(saw_agent, "task yaml should contain agent field");
-    assert!(saw_model, "task yaml should contain model field");
+    assert!(
+        saw_actor_identity,
+        "task yaml should contain actor_identity field"
+    );
     std::fs::write(&task_yaml_path, format!("{rewritten}\n")).expect("write yaml");
 
     let show_output = orbit_in(dir.path())

--- a/orbit-core/src/command/task.rs
+++ b/orbit-core/src/command/task.rs
@@ -416,6 +416,9 @@ impl OrbitRuntime {
                             status: Some(TaskStatus::InProgress),
                             status_event: Some("started".to_string()),
                             assigned_to: Some(Some(effective_label.clone())),
+                            actor_identity: agent.as_ref().map(|_| {
+                                ActorIdentity::from_legacy(agent.as_deref(), model.as_deref())
+                            }),
                             append_history: vec![TaskHistoryEntry {
                                 at,
                                 by: effective_label.clone(),
@@ -454,6 +457,9 @@ impl OrbitRuntime {
                             status_event: Some("started".to_string()),
                             status_note: note.clone(),
                             assigned_to: Some(Some(effective_label.clone())),
+                            actor_identity: agent.as_ref().map(|_| {
+                                ActorIdentity::from_legacy(agent.as_deref(), model.as_deref())
+                            }),
                             append_comments: append_comments.clone(),
                             ..Default::default()
                         },


### PR DESCRIPTION
…r [T20260328-182014]

## Fixes applied
- Updated `task_show_json_includes_agent_and_model_when_present` to rewrite the serialized `actor_identity` field instead of legacy `agent`/`model` YAML keys, matching the flat-string ActorIdentity format.
- Updated `start_task_with_identity` to persist `actor_identity` during both `proposed -> in-progress` and `backlog|someday|blocked -> in-progress` transitions so JSON output continues exposing derived `agent` and `model` fields after explicit identity starts.

## Verification
- `cargo test -p orbit-cli --test task_commands` passes.
- `cargo test --workspace` still fails in unrelated existing `orbit-core` assertions that expect older bundled activity/job counts (`bundled_default_activity_specs_parse_successfully` and `bundled_default_job_specs_parse_successfully`).

## PR review context
- Task metadata does not include a `pr_number`, so no GitHub PR review comments were available to fetch or reply to from this workspace.`authored by: codex / gpt-5.4`