### PR TITLE
Bug: cleartext-logging alert #6 still open after init.rs mitigation

### DIFF
--- a/orbit-cli/src/command/init.rs
+++ b/orbit-cli/src/command/init.rs
@@ -1,5 +1,5 @@
 use clap::Args;
-use orbit_core::command::init::{InitOptions, InitResult, init_global};
+use orbit_core::command::init::{InitOptions, init_global};
 use orbit_core::{OrbitError, OrbitRuntime};
 use std::path::{Path, PathBuf};
 
@@ -23,7 +23,16 @@ impl Execute for InitCommand {
                 ..Default::default()
             },
         )?;
-        print_init_result(&result, reported_init_paths(None));
+        let paths = reported_init_paths(None);
+        print_init_result(InitOutput {
+            skills_root: paths.skills_root,
+            refreshed_skill_files: result.refreshed_skill_files,
+            created_skills_symlink: result.created_skills_symlink,
+            config_path: paths.config_path,
+            created_config: result.created_config,
+            refreshed_default_activities: result.refreshed_default_activities,
+            refreshed_default_jobs: result.refreshed_default_jobs,
+        });
         Ok(())
     }
 }
@@ -38,22 +47,42 @@ impl InitCommand {
                 ..Default::default()
             },
         )?;
-        print_init_result(&result, reported_init_paths(root_override));
+        let paths = reported_init_paths(root_override);
+        print_init_result(InitOutput {
+            skills_root: paths.skills_root,
+            refreshed_skill_files: result.refreshed_skill_files,
+            created_skills_symlink: result.created_skills_symlink,
+            config_path: paths.config_path,
+            created_config: result.created_config,
+            refreshed_default_activities: result.refreshed_default_activities,
+            refreshed_default_jobs: result.refreshed_default_jobs,
+        });
         Ok(())
     }
 }
 
-fn print_init_result(result: &InitResult, paths: ReportedInitPaths) {
+fn print_init_result(output: InitOutput) {
     println!(
         "skills: root={}, refreshed={}, symlink_created={}; config: path={}, created={}; default_activities_refreshed={}; default_jobs_refreshed={}",
-        paths.skills_root,
-        result.refreshed_skill_files,
-        result.created_skills_symlink,
-        paths.config_path,
-        result.created_config,
-        result.refreshed_default_activities,
-        result.refreshed_default_jobs
+        output.skills_root,
+        output.refreshed_skill_files,
+        output.created_skills_symlink,
+        output.config_path,
+        output.created_config,
+        output.refreshed_default_activities,
+        output.refreshed_default_jobs
     );
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+struct InitOutput {
+    skills_root: &'static str,
+    refreshed_skill_files: usize,
+    created_skills_symlink: bool,
+    config_path: &'static str,
+    created_config: bool,
+    refreshed_default_activities: usize,
+    refreshed_default_jobs: usize,
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]

--- a/orbit-core/src/command/init.rs
+++ b/orbit-core/src/command/init.rs
@@ -17,7 +17,6 @@ pub struct InitResult {
     pub created_config: bool,
     pub refreshed_default_activities: usize,
     pub refreshed_default_jobs: usize,
-    pub scoring_enabled: bool,
 }
 
 #[derive(Debug, Clone, Default)]
@@ -54,7 +53,7 @@ pub(crate) fn ensure_orbit_root_initialized(
     workspace_root: &Path,
 ) -> Result<(), OrbitError> {
     // Bootstrap global root — skip workspace-only artifacts (scoreboards, task dirs, job runs)
-    let global_init = init_workspace_at_root(
+    init_workspace_at_root(
         global_root,
         InitOptions {
             global_only: true,
@@ -65,7 +64,7 @@ pub(crate) fn ensure_orbit_root_initialized(
     let tasks_dir = workspace_root.join("tasks");
     fs::create_dir_all(&tasks_dir).map_err(|e| OrbitError::Io(e.to_string()))?;
     // Seed scoreboard templates at workspace root (scoreboards are workspace-scoped)
-    if global_init.scoring_enabled {
+    if OrbitRuntime::from_data_root(global_root)?.scoring_enabled() {
         seed_scoreboard_templates(workspace_root)?;
     }
     Ok(())
@@ -141,7 +140,6 @@ fn init_workspace_at_root(
         created_config,
         refreshed_default_activities,
         refreshed_default_jobs,
-        scoring_enabled,
     })
 }
 

--- a/orbit-engine/src/executor/automation/task.rs
+++ b/orbit-engine/src/executor/automation/task.rs
@@ -137,13 +137,13 @@ mod tests {
     #[test]
     fn missing_status_is_noop() {
         let host = FakeHost::new(test_task());
-        let result = update_task(
-            &host,
-            &json!({ "task_id": "T20260328-001" }),
-        )
-        .expect("should succeed as no-op");
+        let result = update_task(&host, &json!({ "task_id": "T20260328-001" }))
+            .expect("should succeed as no-op");
         assert_eq!(result, json!({}));
-        assert!(host.updated_status.borrow().is_none(), "host should not be called");
+        assert!(
+            host.updated_status.borrow().is_none(),
+            "host should not be called"
+        );
     }
 
     #[test]

--- a/orbit-engine/src/job_runner.rs
+++ b/orbit-engine/src/job_runner.rs
@@ -1177,28 +1177,19 @@ mod tests {
     #[test]
     fn loop_exit_true_in_input_exits() {
         let host = FakeTaskHost::empty();
-        assert!(check_loop_exit(
-            &host,
-            &json!({ "loop_exit": true })
-        ));
+        assert!(check_loop_exit(&host, &json!({ "loop_exit": true })));
     }
 
     #[test]
     fn loop_exit_false_in_input_does_not_exit() {
         let host = FakeTaskHost::empty();
-        assert!(!check_loop_exit(
-            &host,
-            &json!({ "loop_exit": false })
-        ));
+        assert!(!check_loop_exit(&host, &json!({ "loop_exit": false })));
     }
 
     #[test]
     fn no_loop_exit_no_task_does_not_exit() {
         let host = FakeTaskHost::empty();
-        assert!(!check_loop_exit(
-            &host,
-            &json!({ "task_id": "T-missing" })
-        ));
+        assert!(!check_loop_exit(&host, &json!({ "task_id": "T-missing" })));
     }
 
     #[test]


### PR DESCRIPTION
## Changes
## Status
success

## 1. Summary of Changes
Updated the init command logging path to build a CLI-only `InitOutput` payload from explicit safe primitives before printing, rather than passing `InitResult` directly into the logging helper. Removed `scoring_enabled` from `orbit_core::command::init::InitResult` so the returned struct no longer carries runtime-config data derived from `parse_user_name(...)`; workspace scoreboard seeding now re-reads the global runtime when needed.

## 2. Strategic Decisions
- Removed the taint-carrying `scoring_enabled` field from `InitResult` instead of suppressing the alert at the sink | Rationale: this breaks the data lineage in the value crossing the CLI boundary while preserving the existing human-facing output counts | Trade-offs: `ensure_orbit_root_initialized` performs one extra runtime load when deciding whether to seed scoreboard templates.
- Introduced a dedicated `InitOutput` display struct for the CLI printer | Rationale: the logging helper now only accepts redacted labels and explicit booleans/counts, matching the task plan and reducing future taint regressions | Trade-offs: small amount of duplicated field mapping at the two init call sites.

## 3. Assumptions Made
- CodeQL was keeping alert #6 open because `InitResult` still preserved taint lineage from runtime config parsing through `scoring_enabled` and the CLI printer accepted that struct directly | Impact if incorrect: the next code scanning run could still report the alert and we would need a narrower follow-up using the fresh trace.

## 4. Design Weaknesses / Risks
- GitHub code scanning could model taint more broadly than the local reasoning here | Severity: Medium | Mitigation: watch the next code scanning run for alert #6 and inspect the updated trace if it remains open.
- `ensure_orbit_root_initialized` now reloads the global runtime to check scoring state | Severity: Low | Mitigation: keep the call isolated and revisit only if init hot-path performance becomes measurable.

## 5. Deviations from Original Plan
- Persisting `execution_summary` via `orbit.task.update` failed because `ORBIT_ROOT=/Users/daniel/workspace/repos/orbit/.orbit` is outside this sandbox's writable roots | Justification: preserved the full summary in this activity output so downstream automation or a human can persist it from an environment with write access.
- Remote verification of GitHub alert #6 closure was not performed from this environment | Justification: local workspace access allowed build/test verification, but GitHub code scanning reruns are external to this sandboxed execution step.

## 6. Technical Debt Introduced
None

## 7. Recommended Follow-Ups
- Confirm the next GitHub code scanning run closes alert #6 for `orbit-cli/src/command/init.rs`.
- If the alert persists, capture the fresh CodeQL trace and compare it against the new `InitOutput` / `InitResult` boundary.

## Branch Freshness
- Base ref: `agent-main`
- Head ref: `orbit/T20260329-010956`
- Behind base: 0
- Ahead of base: 1

## Files Changed
- `orbit-cli/src/command/init.rs`
- `orbit-core/src/command/init.rs`
- `orbit-engine/src/executor/automation/task.rs`
- `orbit-engine/src/job_runner.rs`

*Implemented by: codex / gpt-5.4*