### PR TITLE
refactor: replace agent response chaining with batch_id in parallel pipeline

### DIFF
--- a/orbit-cli/src/command/task.rs
+++ b/orbit-cli/src/command/task.rs
@@ -294,6 +294,9 @@ pub struct TaskListArgs {
     /// Filter to subtasks belonging to a parent task
     #[arg(long = "parent")]
     pub parent_id: Option<String>,
+    /// Filter by batch ID
+    #[arg(long)]
+    pub batch_id: Option<String>,
     /// Output full task objects as JSON
     #[arg(long)]
     pub json: bool,
@@ -308,6 +311,7 @@ impl Execute for TaskListArgs {
         let status = self.status;
         let priority = self.priority;
         let parent_id = self.parent_id;
+        let batch_id = self.batch_id;
 
         let all_tasks = runtime.list_tasks()?;
         let active_statuses = [TaskStatus::Backlog, TaskStatus::InProgress];
@@ -327,6 +331,11 @@ impl Execute for TaskListArgs {
                 parent_id
                     .as_deref()
                     .is_none_or(|p| t.parent_id.as_deref() == Some(p))
+            })
+            .filter(|t| {
+                batch_id
+                    .as_deref()
+                    .is_none_or(|b| t.batch_id.as_deref() == Some(b))
             })
             .collect();
 
@@ -500,6 +509,9 @@ pub struct TaskUpdateArgs {
     /// PR review status (approve, request-changes)
     #[arg(long)]
     pub pr_status: Option<String>,
+    /// Batch ID to associate with the task (empty string clears)
+    #[arg(long)]
+    pub batch_id: Option<String>,
     /// Explicit agent name to persist on the task artifact
     #[arg(long)]
     pub agent: Option<String>,
@@ -527,6 +539,13 @@ impl Execute for TaskUpdateArgs {
                 Some(value)
             }
         });
+        let batch_id = self.batch_id.map(|value| {
+            if value.trim().is_empty() {
+                None
+            } else {
+                Some(value)
+            }
+        });
 
         let task = runtime.update_task_with_identity(
             &self.id,
@@ -539,6 +558,7 @@ impl Execute for TaskUpdateArgs {
                 status: self.status.map(Into::into),
                 pr_number,
                 pr_status,
+                batch_id,
                 ..Default::default()
             },
             self.agent,
@@ -656,7 +676,7 @@ pub struct TaskApproveArgs {
 impl Execute for TaskApproveArgs {
     fn execute(self, runtime: &OrbitRuntime) -> Result<(), OrbitError> {
         let ids = if self.all_proposed {
-            let proposed = runtime.list_tasks_filtered(Some(TaskStatus::Proposed), None, None)?;
+            let proposed = runtime.list_tasks_filtered(Some(TaskStatus::Proposed), None, None, None)?;
             if proposed.is_empty() {
                 println!("No proposed tasks found.");
                 return Ok(());
@@ -752,7 +772,7 @@ pub struct TaskRejectArgs {
 impl Execute for TaskRejectArgs {
     fn execute(self, runtime: &OrbitRuntime) -> Result<(), OrbitError> {
         let ids = if self.all_proposed {
-            let proposed = runtime.list_tasks_filtered(Some(TaskStatus::Proposed), None, None)?;
+            let proposed = runtime.list_tasks_filtered(Some(TaskStatus::Proposed), None, None, None)?;
             if proposed.is_empty() {
                 println!("No proposed tasks found.");
                 return Ok(());

--- a/orbit-core/assets/activities/commit_batch_changes.yaml
+++ b/orbit-core/assets/activities/commit_batch_changes.yaml
@@ -7,13 +7,12 @@ activity:
   input_schema_json:
     type: object
     required:
-      - completed_task_ids
+      - run_id
       - workspace_path
     properties:
-      completed_task_ids:
-        type: array
-        items:
-          type: string
+      run_id:
+        type: string
+        description: "Job run ID, used as batch_id to query tasks belonging to this batch."
       workspace_path:
         type: string
       base:

--- a/orbit-core/assets/activities/dispatch_parallel_task.yaml
+++ b/orbit-core/assets/activities/dispatch_parallel_task.yaml
@@ -17,7 +17,7 @@ activity:
 
     1. Call orbit.task.list with status: "backlog" to retrieve all backlog tasks.
        If the list is empty, return this JSON and exit:
-       {"task_ids": [], "comment": "No backlog tasks available for parallel dispatch."}
+       {"comment": "No backlog tasks available for parallel dispatch."}
 
     2. For the strongest candidates, call orbit.task.show with the task id and read:
        description, acceptance_criteria, context_files, priority, parent_id, and task type.
@@ -32,11 +32,11 @@ activity:
 
     4. For every selected task, call orbit.task.update with:
        - id: "<selected task id>"
+       - batch_id: "<the value of input.run_id>"
        - comment: "Parallel batch dispatched: <one sentence rationale>"
 
     5. Return a JSON result with EXACTLY these fields:
        {
-         "task_ids": ["<selected task ids in batch order>"],
          "comment": "<the rationale string you used in orbit.task.update>"
        }
 
@@ -44,6 +44,9 @@ activity:
   input_schema_json:
     type: object
     properties:
+      run_id:
+        type: string
+        description: Job run ID, used as batch_id when tagging selected tasks.
       base:
         type: string
         description: Shared pipeline base branch input, accepted but unused by dispatch_parallel_task.
@@ -54,13 +57,7 @@ activity:
     additional_properties: false
   output_schema_json:
     type: object
-    required:
-      - task_ids
     properties:
-      task_ids:
-        type: array
-        items:
-          type: string
       comment:
         type: string
     additional_properties: false

--- a/orbit-core/assets/activities/finalize_tasks.yaml
+++ b/orbit-core/assets/activities/finalize_tasks.yaml
@@ -17,11 +17,11 @@ activity:
 
     Steps:
     1. Handle the empty-batch case:
-       - If input.completed_task_ids is missing or empty, return:
-         {"completed_task_ids": [], "summary": "No completed tasks were available for batch finalization."}
+       - Call orbit.task.list with batch_id set to input.run_id. If the list is empty, return:
+         {"summary": "No completed tasks were available for batch finalization."}
 
     2. Load task context:
-       - For each id in input.completed_task_ids, call orbit.task.show and read:
+       - For each task returned from the batch query, call orbit.task.show and read:
          title, description, acceptance_criteria, execution_summary, context_files, workspace_path, and repo_root.
        - All tasks share the same workspace_path (the shared worktree on agent-dev).
 
@@ -40,34 +40,25 @@ activity:
 
     6. Return a JSON result with EXACTLY these fields:
        {
-         "completed_task_ids": ["<task ids that should continue to serial finalization>"],
          "summary": "<brief markdown or plain-text note about the batch finalization pass>"
        }
 
   # ---- interface ----
   input_schema_json:
     type: object
-    required:
-      - completed_task_ids
     properties:
-      completed_task_ids:
-        type: array
-        items:
-          type: string
+      run_id:
+        type: string
+        description: Job run ID, used as batch_id to query tasks belonging to this batch.
       base:
         type: string
       parallelism:
         type: integer
         minimum: 1
+    additional_properties: false
   output_schema_json:
     type: object
-    required:
-      - completed_task_ids
     properties:
-      completed_task_ids:
-        type: array
-        items:
-          type: string
       summary:
         type: string
     additional_properties: false
@@ -76,6 +67,7 @@ activity:
   skill_refs:
     - orbit
   tools:
+    - orbit.task.list
     - orbit.task.show
     - orbit.task.update
     - fs.write

--- a/orbit-core/assets/activities/open_batch_pr.yaml
+++ b/orbit-core/assets/activities/open_batch_pr.yaml
@@ -7,13 +7,12 @@ activity:
   input_schema_json:
     type: object
     required:
-      - completed_task_ids
+      - run_id
       - workspace_path
     properties:
-      completed_task_ids:
-        type: array
-        items:
-          type: string
+      run_id:
+        type: string
+        description: "Job run ID, used as batch_id to query tasks belonging to this batch."
       workspace_path:
         type: string
       base:

--- a/orbit-core/assets/activities/parallel_dispatch_tasks.yaml
+++ b/orbit-core/assets/activities/parallel_dispatch_tasks.yaml
@@ -16,13 +16,11 @@ activity:
   input_schema_json:
     type: object
     required:
-      - task_ids
+      - run_id
     properties:
-      task_ids:
-        type: array
-        items:
-          type: string
-        description: Ordered task ids selected for this parallel wave.
+      run_id:
+        type: string
+        description: Job run ID, used as batch_id to query tasks belonging to this batch.
       base:
         type: string
         description: Base branch for the shared parallel worktree. Defaults to agent-dev.

--- a/orbit-core/assets/activities/plan_parallel_batch.yaml
+++ b/orbit-core/assets/activities/plan_parallel_batch.yaml
@@ -18,11 +18,13 @@ activity:
 
     Steps:
     1. Handle the empty-batch case:
-       - If input.task_ids is missing or empty, return:
-         {"task_ids": [], "comment": "No tasks to plan."}
+       - If input.run_id is missing or empty, return:
+         {"comment": "No run_id provided."}
 
     2. Load all tasks:
-       - For each id in input.task_ids, call orbit.task.show and read:
+       - Call orbit.task.list with batch_id set to input.run_id and status: backlog.
+         If the list is empty, return: {"comment": "No tasks to plan."}
+       - For each task returned, call orbit.task.show and read:
          title, description, acceptance_criteria, current plan, context_files, and priority.
 
     3. Explore the codebase:
@@ -54,7 +56,6 @@ activity:
 
     7. Return a JSON result with EXACTLY these fields:
        {
-         "task_ids": ["<the same task ids, in batch order>"],
          "comment": "<brief summary of planning decisions>"
        }
 
@@ -62,31 +63,21 @@ activity:
   input_schema_json:
     type: object
     required:
-      - task_ids
+      - run_id
     properties:
+      run_id:
+        type: string
+        description: Job run ID, used as batch_id to query tasks belonging to this batch.
       base:
         type: string
         description: Shared pipeline base branch input, passed through from prior steps.
       parallelism:
         type: integer
         description: Batch size from pipeline input, passed through from prior steps.
-      comment:
-        type: string
-        description: Dispatch comment from prior step, passed through.
-      task_ids:
-        type: array
-        items:
-          type: string
     additional_properties: false
   output_schema_json:
     type: object
-    required:
-      - task_ids
     properties:
-      task_ids:
-        type: array
-        items:
-          type: string
       comment:
         type: string
     additional_properties: false
@@ -95,6 +86,7 @@ activity:
   skill_refs:
     - orbit
   tools:
+    - orbit.task.list
     - orbit.task.show
     - orbit.task.update
     - fs.read

--- a/orbit-core/src/command/task.rs
+++ b/orbit-core/src/command/task.rs
@@ -55,6 +55,7 @@ pub struct TaskUpdateParams {
     pub status: Option<TaskStatus>,
     pub pr_number: Option<Option<String>>,
     pub pr_status: Option<Option<String>>,
+    pub batch_id: Option<Option<String>>,
     pub append_review_threads: Vec<orbit_types::ReviewThread>,
 }
 
@@ -68,6 +69,7 @@ impl From<TaskUpdateParams> for StoreTaskUpdateParams {
             status: p.status,
             pr_number: p.pr_number,
             pr_status: p.pr_status,
+            batch_id: p.batch_id,
             append_review_threads: p.append_review_threads,
             ..Default::default()
         }
@@ -153,8 +155,9 @@ impl OrbitRuntime {
         status: Option<TaskStatus>,
         priority: Option<TaskPriority>,
         parent_id: Option<&str>,
+        batch_id: Option<&str>,
     ) -> Result<Vec<Task>, OrbitError> {
-        self.list_task_records_filtered(status, priority, parent_id)
+        self.list_task_records_filtered(status, priority, parent_id, batch_id)
     }
 
     pub fn update_task(&self, id: &str, params: TaskUpdateParams) -> Result<Task, OrbitError> {
@@ -215,7 +218,8 @@ impl OrbitRuntime {
             || params.execution_summary.is_some()
             || params.comment.is_some()
             || params.pr_number.is_some()
-            || params.pr_status.is_some();
+            || params.pr_status.is_some()
+            || params.batch_id.is_some();
 
         if is_field_update && matches!(task.status, TaskStatus::Done | TaskStatus::Archived) {
             return Err(OrbitError::InvalidInput(format!(

--- a/orbit-core/src/runtime/engine.rs
+++ b/orbit-core/src/runtime/engine.rs
@@ -441,8 +441,9 @@ impl TaskHost for OrbitRuntime {
         status: Option<TaskStatus>,
         priority: Option<TaskPriority>,
         parent_id: Option<&str>,
+        batch_id: Option<&str>,
     ) -> Result<Vec<Task>, OrbitError> {
-        OrbitRuntime::list_tasks_filtered(self, status, priority, parent_id)
+        OrbitRuntime::list_tasks_filtered(self, status, priority, parent_id, batch_id)
     }
 
     fn start_task(
@@ -491,6 +492,7 @@ impl TaskHost for OrbitRuntime {
                     workspace_path: update.workspace_path.clone().map(Some),
                     repo_root: update.repo_root.clone().map(Some),
                     pr_number: update.pr_number.clone().map(Some),
+                    batch_id: update.batch_id.clone().map(Some),
                     actor_identity: Some(ActorIdentity::from_legacy(
                         update.agent.as_deref(),
                         update.model.as_deref(),

--- a/orbit-core/src/runtime/mod.rs
+++ b/orbit-core/src/runtime/mod.rs
@@ -229,10 +229,11 @@ impl OrbitRuntime {
         status: Option<TaskStatus>,
         priority: Option<TaskPriority>,
         parent_id: Option<&str>,
+        batch_id: Option<&str>,
     ) -> Result<Vec<Task>, OrbitError> {
         self.context
             .task_store()
-            .list_tasks_filtered(status, priority, parent_id)
+            .list_tasks_filtered(status, priority, parent_id, batch_id)
     }
 
     pub(crate) fn update_task_record(

--- a/orbit-engine/src/context.rs
+++ b/orbit-engine/src/context.rs
@@ -123,6 +123,7 @@ pub struct TaskAutomationUpdate {
     pub agent: Option<String>,
     pub model: Option<String>,
     pub review_threads: Option<Vec<ReviewThread>>,
+    pub batch_id: Option<String>,
 }
 
 pub trait JobRunHost {
@@ -168,6 +169,7 @@ pub trait TaskHost {
         status: Option<TaskStatus>,
         priority: Option<TaskPriority>,
         parent_id: Option<&str>,
+        batch_id: Option<&str>,
     ) -> Result<Vec<Task>, OrbitError>;
     fn start_task(
         &self,

--- a/orbit-engine/src/executor/agent.rs
+++ b/orbit-engine/src/executor/agent.rs
@@ -718,6 +718,7 @@ mod tests {
             status: Option<TaskStatus>,
             priority: Option<TaskPriority>,
             parent_id: Option<&str>,
+            _batch_id: Option<&str>,
         ) -> Result<Vec<Task>, OrbitError> {
             let tasks = self
                 .task
@@ -936,6 +937,7 @@ mod tests {
             pr_status: pr_status.map(|s| s.to_string()),
             proposed_by: None,
             source_task_id: None,
+            batch_id: None,
             complexity: None,
             comments: vec![],
             history: vec![],

--- a/orbit-engine/src/executor/automation/commit.rs
+++ b/orbit-engine/src/executor/automation/commit.rs
@@ -77,33 +77,27 @@ pub(super) fn commit_batch_changes<H: TaskHost + ?Sized>(
         )));
     }
 
-    let completed_task_ids = input
-        .get("completed_task_ids")
-        .and_then(Value::as_array)
+    let batch_id = input
+        .get("run_id")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
         .ok_or_else(|| {
             OrbitError::InvalidInput(
-                "commit_batch_changes requires input.completed_task_ids".to_string(),
+                "commit_batch_changes requires input.run_id".to_string(),
             )
-        })?
+        })?;
+
+    let batch_tasks = host.list_tasks_filtered(None, None, None, Some(batch_id))?;
+    let completed_task_ids: Vec<String> = batch_tasks
         .iter()
-        .map(|v| {
-            v.as_str()
-                .map(str::trim)
-                .filter(|s| !s.is_empty())
-                .map(ToOwned::to_owned)
-                .ok_or_else(|| {
-                    OrbitError::InvalidInput(
-                        "commit_batch_changes.completed_task_ids must contain non-empty strings"
-                            .to_string(),
-                    )
-                })
-        })
-        .collect::<Result<Vec<String>, OrbitError>>()?;
+        .map(|t| t.id.clone())
+        .collect();
 
     if completed_task_ids.is_empty() {
-        return Err(OrbitError::InvalidInput(
-            "commit_batch_changes requires at least one completed_task_id".to_string(),
-        ));
+        return Err(OrbitError::InvalidInput(format!(
+            "commit_batch_changes: no tasks found for batch_id '{batch_id}'"
+        )));
     }
 
     ensure_no_unmerged_changes(&workspace_path)?;

--- a/orbit-engine/src/executor/automation/parallel.rs
+++ b/orbit-engine/src/executor/automation/parallel.rs
@@ -288,54 +288,40 @@ fn load_selected_tasks<H: TaskHost + ?Sized>(
     host: &H,
     input: &Value,
 ) -> Result<Vec<PendingTask>, OrbitError> {
-    let task_ids = load_task_id_array(input, "task_ids", "parallel_dispatch_tasks")?;
+    let batch_id = input
+        .get("run_id")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .ok_or_else(|| {
+            OrbitError::InvalidInput(
+                "parallel_dispatch_tasks requires input.run_id".to_string(),
+            )
+        })?;
+
+    let tasks = host.list_tasks_filtered(
+        Some(TaskStatus::Backlog),
+        None,
+        None,
+        Some(batch_id),
+    )?;
+
+    if tasks.is_empty() {
+        return Err(OrbitError::InvalidInput(format!(
+            "no backlog tasks found for batch_id '{batch_id}'"
+        )));
+    }
 
     let mut seen = HashSet::new();
-    let mut selected = Vec::with_capacity(task_ids.len());
-    for task_id in task_ids {
-        if !seen.insert(task_id.to_string()) {
-            return Err(OrbitError::InvalidInput(format!(
-                "parallel task batch contains duplicate task id '{task_id}'"
-            )));
-        }
-        let task = host.get_task(&task_id)?;
-        if task.status != TaskStatus::Backlog {
-            return Err(OrbitError::InvalidInput(format!(
-                "parallel task batch requires backlog tasks; '{task_id}' is '{}'",
-                task.status
-            )));
+    let mut selected = Vec::with_capacity(tasks.len());
+    for task in tasks {
+        if !seen.insert(task.id.clone()) {
+            continue;
         }
         selected.push(PendingTask::from(task));
     }
 
     Ok(selected)
-}
-
-fn load_task_id_array(
-    input: &Value,
-    field_name: &str,
-    activity_id: &str,
-) -> Result<Vec<String>, OrbitError> {
-    let Some(task_ids) = input.get(field_name).and_then(Value::as_array) else {
-        return Err(OrbitError::InvalidInput(format!(
-            "{activity_id} requires input.{field_name}"
-        )));
-    };
-    task_ids
-        .iter()
-        .map(|task_id| {
-            task_id
-                .as_str()
-                .map(str::trim)
-                .filter(|value| !value.is_empty())
-                .map(ToOwned::to_owned)
-                .ok_or_else(|| {
-                    OrbitError::InvalidInput(format!(
-                        "{activity_id}.{field_name} must contain non-empty strings"
-                    ))
-                })
-        })
-        .collect()
 }
 
 fn parse_parallelism(input: &Value) -> Result<usize, OrbitError> {

--- a/orbit-engine/src/executor/automation/pr.rs
+++ b/orbit-engine/src/executor/automation/pr.rs
@@ -243,33 +243,27 @@ pub(super) fn open_batch_pr<H: RuntimeHost + TaskHost + ?Sized>(
     let workspace_path_str = required_input_string(input, "workspace_path")?;
     let workspace_path = canonicalize_existing_dir(workspace_path_str, "workspace_path")?;
 
-    let completed_task_ids = input
-        .get("completed_task_ids")
-        .and_then(Value::as_array)
+    let batch_id = input
+        .get("run_id")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
         .ok_or_else(|| {
             OrbitError::InvalidInput(
-                "open_batch_pr requires input.completed_task_ids".to_string(),
+                "open_batch_pr requires input.run_id".to_string(),
             )
-        })?
+        })?;
+
+    let batch_tasks = host.list_tasks_filtered(None, None, None, Some(batch_id))?;
+    let completed_task_ids: Vec<String> = batch_tasks
         .iter()
-        .map(|v| {
-            v.as_str()
-                .map(str::trim)
-                .filter(|s| !s.is_empty())
-                .map(ToOwned::to_owned)
-                .ok_or_else(|| {
-                    OrbitError::InvalidInput(
-                        "open_batch_pr.completed_task_ids must contain non-empty strings"
-                            .to_string(),
-                    )
-                })
-        })
-        .collect::<Result<Vec<String>, OrbitError>>()?;
+        .map(|t| t.id.clone())
+        .collect();
 
     if completed_task_ids.is_empty() {
-        return Err(OrbitError::InvalidInput(
-            "open_batch_pr requires at least one completed_task_id".to_string(),
-        ));
+        return Err(OrbitError::InvalidInput(format!(
+            "open_batch_pr: no tasks found for batch_id '{batch_id}'"
+        )));
     }
 
     let head = input_string_field(input, "base").unwrap_or_else(|| "agent-dev".to_string());

--- a/orbit-engine/src/job_runner.rs
+++ b/orbit-engine/src/job_runner.rs
@@ -187,6 +187,11 @@ fn execute_activity_with_retries<H: EngineHost>(
         let mut total_duration_ms: u64 = 0;
         let mut last_protocol_violation = false;
         let mut current_input = merge_job_input(job.default_input.as_ref(), input.clone())?;
+        // Inject run_id so all steps can reference it (e.g. as batch_id for
+        // parallel task pipelines).
+        if let Value::Object(ref mut map) = current_input {
+            map.entry("run_id").or_insert_with(|| Value::String(run.run_id.clone()));
+        }
         let mut last_failure: Option<FailureInfo> = None;
         let num_steps = job.steps.len();
         let max_iterations = job.max_iterations.max(1);

--- a/orbit-store/src/backend/contracts.rs
+++ b/orbit-store/src/backend/contracts.rs
@@ -70,6 +70,7 @@ pub struct TaskUpdateParams {
     pub pr_status: Option<Option<String>>,
     pub proposed_by: Option<Option<String>>,
     pub source_task_id: Option<Option<String>>,
+    pub batch_id: Option<Option<String>>,
     pub status_event: Option<String>,
     pub status_note: Option<String>,
     pub append_history: Vec<TaskHistoryEntry>,
@@ -138,6 +139,7 @@ pub trait TaskStoreBackend: Send + Sync {
         status: Option<TaskStatus>,
         priority: Option<TaskPriority>,
         parent_id: Option<&str>,
+        batch_id: Option<&str>,
     ) -> Result<Vec<Task>, OrbitError>;
     fn get_task(&self, id: &str) -> Result<Option<Task>, OrbitError>;
     fn search_tasks(&self, query: &str) -> Result<Vec<Task>, OrbitError>;

--- a/orbit-store/src/backend/file_backends.rs
+++ b/orbit-store/src/backend/file_backends.rs
@@ -26,8 +26,9 @@ impl TaskStoreBackend for TaskFileStore {
         status: Option<TaskStatus>,
         priority: Option<TaskPriority>,
         parent_id: Option<&str>,
+        batch_id: Option<&str>,
     ) -> Result<Vec<Task>, OrbitError> {
-        self.list_tasks_filtered(status, priority, parent_id)
+        self.list_tasks_filtered(status, priority, parent_id, batch_id)
     }
 
     fn get_task(&self, id: &str) -> Result<Option<Task>, OrbitError> {

--- a/orbit-store/src/file/task_store.rs
+++ b/orbit-store/src/file/task_store.rs
@@ -139,6 +139,8 @@ struct TaskFileDocument {
     pr_status: Option<String>,
     #[serde(default)]
     source_task_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    batch_id: Option<String>,
     created_at: DateTime<Utc>,
     updated_at: DateTime<Utc>,
     #[serde(default)]
@@ -212,6 +214,7 @@ impl TaskFileStore {
                 pr_status: None,
                 proposed_by: params.proposed_by,
                 source_task_id: params.source_task_id,
+                batch_id: None,
                 created_at: now,
                 updated_at: now,
                 history: vec![TaskHistoryEntry {
@@ -267,6 +270,7 @@ impl TaskFileStore {
         status: Option<TaskStatus>,
         priority: Option<TaskPriority>,
         parent_id: Option<&str>,
+        batch_id: Option<&str>,
     ) -> Result<Vec<Task>, OrbitError> {
         let tasks = self.list_tasks()?;
         Ok(tasks
@@ -274,6 +278,7 @@ impl TaskFileStore {
             .filter(|task| status.is_none_or(|value| task.status == value))
             .filter(|task| priority.is_none_or(|value| task.priority == value))
             .filter(|task| parent_id.is_none_or(|value| task.parent_id.as_deref() == Some(value)))
+            .filter(|task| batch_id.is_none_or(|value| task.batch_id.as_deref() == Some(value)))
             .collect())
     }
 
@@ -366,6 +371,9 @@ impl TaskFileStore {
         }
         if let Some(value) = &fields.source_task_id {
             bundle.doc.source_task_id = value.clone();
+        }
+        if let Some(value) = &fields.batch_id {
+            bundle.doc.batch_id = value.clone();
         }
         if !fields.append_history.is_empty() {
             bundle.doc.history.extend(fields.append_history.clone());
@@ -622,9 +630,12 @@ fn serialize_task_doc_yaml(doc: &TaskFileDocument) -> Result<String, OrbitError>
     yaml.push_str(&yaml_field("pr_number", &doc.pr_number)?);
     yaml.push_str(&yaml_field("pr_status", &doc.pr_status)?);
 
-    if doc.source_task_id.is_some() {
+    if doc.source_task_id.is_some() || doc.batch_id.is_some() {
         yaml.push_str(&yaml_section("attribution"));
         yaml.push_str(&yaml_field("source_task_id", &doc.source_task_id)?);
+        if doc.batch_id.is_some() {
+            yaml.push_str(&yaml_field("batch_id", &doc.batch_id)?);
+        }
     }
 
     yaml.push_str(&yaml_section("timestamps"));
@@ -720,6 +731,7 @@ fn bundle_to_task(state: TaskStateDir, bundle: TaskBundle) -> Task {
         pr_status: bundle.doc.pr_status,
         proposed_by: bundle.doc.proposed_by,
         source_task_id: bundle.doc.source_task_id,
+        batch_id: bundle.doc.batch_id,
         comments: bundle.doc.comments,
         history: bundle.doc.history,
         review_threads: bundle.doc.review_threads,

--- a/orbit-tools/src/builtin/orbit/task_list.rs
+++ b/orbit-tools/src/builtin/orbit/task_list.rs
@@ -23,6 +23,10 @@ pub(super) fn build_exec_request(
         args.push("--parent".to_string());
         args.push(parent_id);
     }
+    if let Some(batch_id) = super::optional_string(input, "batch_id")? {
+        args.push("--batch-id".to_string());
+        args.push(batch_id);
+    }
 
     Ok(super::orbit_exec_request_with_identity(
         ctx, args, &identity,
@@ -41,6 +45,12 @@ impl Tool for OrbitTaskListTool {
             ToolParam {
                 name: "parent_id".to_string(),
                 description: "Optional parent task ID to list subtasks for".to_string(),
+                param_type: "string".to_string(),
+                required: false,
+            },
+            ToolParam {
+                name: "batch_id".to_string(),
+                description: "Filter by batch ID".to_string(),
                 param_type: "string".to_string(),
                 required: false,
             },

--- a/orbit-tools/src/builtin/orbit/task_update.rs
+++ b/orbit-tools/src/builtin/orbit/task_update.rs
@@ -48,10 +48,15 @@ pub(super) fn build_exec_requests(
         args.push(pr_number);
         changed = true;
     }
+    if let Some(batch_id) = super::optional_string(input, "batch_id")? {
+        args.push("--batch-id".to_string());
+        args.push(batch_id);
+        changed = true;
+    }
 
     if !changed {
         return Err(OrbitError::InvalidInput(
-            "orbit.task.update requires at least one of `status`, `plan`, `execution_summary`, `comment`, `pr_status`, or `pr_number`"
+            "orbit.task.update requires at least one of `status`, `plan`, `execution_summary`, `comment`, `pr_status`, `pr_number`, or `batch_id`"
                 .to_string(),
         ));
     }
@@ -109,6 +114,12 @@ impl Tool for OrbitTaskUpdateTool {
             ToolParam {
                 name: "pr_number".to_string(),
                 description: "Pull request number (empty string clears)".to_string(),
+                param_type: "string".to_string(),
+                required: false,
+            },
+            ToolParam {
+                name: "batch_id".to_string(),
+                description: "Batch ID to associate with the task (empty string clears)".to_string(),
                 param_type: "string".to_string(),
                 required: false,
             },

--- a/orbit-types/src/task.rs
+++ b/orbit-types/src/task.rs
@@ -390,6 +390,9 @@ pub struct Task {
     /// For `Bug` tasks: the originating task whose implementation introduced the defect.
     #[serde(default)]
     pub source_task_id: Option<String>,
+    /// Groups tasks that were created together as part of a parallel batch.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub batch_id: Option<String>,
     #[serde(default)]
     pub comments: Vec<TaskComment>,
     #[serde(default)]


### PR DESCRIPTION
## Summary

- Replace brittle agent JSON response chaining (`task_ids`, `completed_task_ids`) between parallel pipeline steps with a `batch_id` field on tasks
- Job runner now injects `run_id` into every step's input automatically; agents set `batch_id` on tasks via `orbit.task.update`, and downstream steps query by `batch_id`
- 22 files changed across all layers: types, store, engine, CLI, tools, activity YAMLs, and automation code

## Motivation

The parallel pipeline was fragile because each step depended on the previous agent's structured JSON output to pass task IDs forward. If an agent returned malformed JSON or omitted a field, the entire pipeline broke. The regular task pipeline already avoids this by using task artifacts as the source of truth — this brings the parallel pipeline in line.

## Key changes

- **`orbit-types`**: Added `batch_id: Option<String>` to `Task`
- **`orbit-store`**: `batch_id` in `TaskUpdateParams`, `TaskStoreBackend::list_tasks_filtered`, file store persistence
- **`orbit-engine`**: `batch_id` in `TaskHost` trait, `TaskAutomationUpdate`; `run_id` injected into step input by job runner
- **Automation code**: `parallel.rs`, `commit.rs`, `pr.rs` query tasks by `batch_id` instead of parsing input arrays
- **Activity YAMLs**: All 6 parallel pipeline activities updated — removed `task_ids`/`completed_task_ids` from schemas, added `run_id`, rewrote agent instructions to use `orbit.task.list` with `batch_id`
- **CLI + tools**: `--batch-id` flag on `task update` and `task list`; tool schemas updated

## Test plan

- [x] `cargo check` passes
- [x] `cargo test` passes
- [ ] Run parallel pipeline end-to-end with backlog tasks to verify batch_id flow

*authored by: claude / opus*