### PR TITLE
feat: parallel batch [T20260329-211639, T20260329-211544]

### DIFF
--- a/orbit-core/src/command/task.rs
+++ b/orbit-core/src/command/task.rs
@@ -7,6 +7,7 @@ use orbit_types::{
     ActorIdentity, OrbitError, OrbitEvent, OrbitId, Task, TaskComment, TaskComplexity,
     TaskHistoryEntry, TaskPriority, TaskStatus, TaskType,
 };
+use std::path::{Path, PathBuf};
 
 use crate::OrbitRuntime;
 use crate::context::ActorKind;
@@ -99,6 +100,8 @@ impl OrbitRuntime {
                 TaskStatus::Backlog
             };
         let comments = build_task_comments(params.comment.clone(), effective_label.as_str())?;
+        let workspace_path =
+            normalize_workspace_path(&self.paths().repo_root, params.workspace_path.as_deref())?;
 
         let task = self.with_mutation(|| {
             let task = self.create_task_record(StoreTaskCreateParams {
@@ -110,7 +113,7 @@ impl OrbitRuntime {
                 plan: params.plan.clone(),
                 execution_summary: String::new(),
                 context_files: params.context_files.clone(),
-                workspace_path: params.workspace_path.clone(),
+                workspace_path: workspace_path.clone(),
                 repo_root: None,
                 created_by: Some(effective_label.clone()),
                 actor_identity: ActorIdentity::from_legacy(agent.as_deref(), model.as_deref()),
@@ -922,6 +925,49 @@ fn build_task_comments(message: Option<String>, by: &str) -> Result<Vec<TaskComm
     }])
 }
 
+fn normalize_workspace_path(
+    repo_root: &Path,
+    workspace: Option<&str>,
+) -> Result<Option<String>, OrbitError> {
+    let Some(workspace) = workspace.map(str::trim).filter(|value| !value.is_empty()) else {
+        return Ok(None);
+    };
+
+    let canonical_repo_root = repo_root.canonicalize().map_err(|error| {
+        OrbitError::InvalidInput(format!(
+            "failed to resolve repository root '{}': {error}",
+            repo_root.display()
+        ))
+    })?;
+    let candidate = if Path::new(workspace).is_absolute() {
+        PathBuf::from(workspace)
+    } else {
+        canonical_repo_root.join(workspace)
+    };
+    let canonical_workspace = candidate.canonicalize().map_err(|error| {
+        OrbitError::InvalidInput(format!(
+            "workspace_path '{}' must reference an existing directory inside the repository: {error}",
+            candidate.display()
+        ))
+    })?;
+    if !canonical_workspace.is_dir() {
+        return Err(OrbitError::InvalidInput(format!(
+            "workspace_path '{}' must reference a directory inside the repository",
+            canonical_workspace.display()
+        )));
+    }
+
+    if !canonical_workspace.starts_with(&canonical_repo_root) {
+        return Err(OrbitError::InvalidInput(format!(
+            "workspace_path '{}' must stay within repository '{}'",
+            canonical_workspace.display(),
+            canonical_repo_root.display()
+        )));
+    }
+
+    Ok(Some(canonical_workspace.to_string_lossy().into_owned()))
+}
+
 const UNAUTHORED_TASK_PLAN_PLACEHOLDER: &str = "To be authored by executing agent at start time.";
 
 pub(crate) fn ensure_task_has_execution_plan(id: &str, plan: &str) -> Result<(), OrbitError> {
@@ -956,6 +1002,15 @@ mod tests {
     };
     use crate::{OrbitError, OrbitRuntime, TaskStatus};
     use orbit_engine::{TaskAutomationUpdate, TaskHost};
+    use std::fs;
+    use std::path::Path;
+
+    fn canonical_string(path: &Path) -> String {
+        path.canonicalize()
+            .expect("canonical path")
+            .to_string_lossy()
+            .into_owned()
+    }
 
     #[test]
     fn blank_or_placeholder_plan_is_rejected() {
@@ -1047,5 +1102,62 @@ mod tests {
 
         let loaded = runtime.get_task(&task.id).expect("load");
         assert_eq!(loaded.acceptance_criteria, task.acceptance_criteria);
+    }
+
+    #[test]
+    fn add_task_rejects_absolute_ancestor_workspace_path() {
+        let runtime = OrbitRuntime::in_memory().expect("runtime");
+        let repo_root = runtime.paths().repo_root.clone();
+        let filesystem_root = repo_root
+            .ancestors()
+            .last()
+            .expect("filesystem root")
+            .to_path_buf();
+
+        let err = runtime
+            .add_task(TaskAddParams {
+                title: "bad workspace".to_string(),
+                description: "desc".to_string(),
+                workspace_path: Some(filesystem_root.to_string_lossy().into_owned()),
+                ..Default::default()
+            })
+            .expect_err("workspace should be rejected");
+
+        assert!(matches!(err, OrbitError::InvalidInput(_)));
+        assert!(err.to_string().contains("must stay within repository"));
+    }
+
+    #[test]
+    fn add_task_normalizes_workspace_path_to_canonical_repo_child() {
+        let runtime = OrbitRuntime::in_memory().expect("runtime");
+        let repo_root = runtime.paths().repo_root.clone();
+        let nested = repo_root.join("nested");
+        fs::create_dir_all(&nested).expect("nested dir");
+
+        let task = runtime
+            .add_task(TaskAddParams {
+                title: "normalized workspace".to_string(),
+                description: "desc".to_string(),
+                workspace_path: Some("nested/.".to_string()),
+                ..Default::default()
+            })
+            .expect("task");
+
+        assert_eq!(task.workspace_path, Some(canonical_string(&nested)));
+    }
+
+    #[test]
+    fn add_task_allows_missing_workspace_path() {
+        let runtime = OrbitRuntime::in_memory().expect("runtime");
+
+        let task = runtime
+            .add_task(TaskAddParams {
+                title: "no workspace".to_string(),
+                description: "desc".to_string(),
+                ..Default::default()
+            })
+            .expect("task");
+
+        assert_eq!(task.workspace_path, None);
     }
 }

--- a/orbit-core/src/runtime/pipeline.rs
+++ b/orbit-core/src/runtime/pipeline.rs
@@ -5,7 +5,7 @@ use orbit_lock::FileLockChecker;
 use orbit_policy::PolicyContext;
 use orbit_tools::ToolContext;
 use orbit_types::{
-    OrbitEvent, PolicyDecision, Role, Task, redact_sensitive_env_error, redact_sensitive_env_json,
+    OrbitEvent, PolicyDecision, Role, redact_sensitive_env_error, redact_sensitive_env_json,
 };
 use serde_json::Value;
 
@@ -177,12 +177,20 @@ fn resolve_task_id_from_context(
         Ok(path) => path,
         Err(_) => PathBuf::from(cwd),
     };
+    let canonical_repo_root = canonical_repo_root(runtime);
 
     let tasks = runtime.list_task_records()?;
     Ok(tasks
         .into_iter()
-        .find(|task| task_workspace_matches(task, &canonical_cwd))
-        .map(|task| task.id))
+        .filter_map(|task| {
+            let workspace = validated_task_workspace(
+                &canonical_repo_root,
+                task.workspace_path.as_deref()?,
+            )?;
+            task_workspace_matches(&workspace, &canonical_cwd).then_some((task.id, workspace))
+        })
+        .max_by_key(|(_, workspace)| workspace.to_string_lossy().len())
+        .map(|(task_id, _)| task_id))
 }
 
 fn resolve_workspace_root_from_context(
@@ -190,23 +198,46 @@ fn resolve_workspace_root_from_context(
     tool_context: &ToolContext,
 ) -> Result<Option<PathBuf>, OrbitError> {
     if let Some(task_id) = tool_context.task_id.as_deref()
-        && let Ok(task) = runtime.get_task(task_id)
-        && let Some(workspace_path) = task.workspace_path
+        && let Some(workspace_root) = resolve_task_workspace_root(runtime, task_id)
     {
-        return Ok(Some(PathBuf::from(workspace_path)));
+        return Ok(Some(workspace_root));
     }
-    Ok(Some(runtime.context.paths().repo_root.clone()))
+    Ok(Some(canonical_repo_root(runtime)))
 }
 
-fn task_workspace_matches(task: &Task, canonical_cwd: &Path) -> bool {
-    let Some(workspace_path) = task.workspace_path.as_deref() else {
-        return false;
-    };
-    let workspace_path = Path::new(workspace_path);
-    let canonical_workspace = workspace_path
+fn canonical_repo_root(runtime: &OrbitRuntime) -> PathBuf {
+    runtime
+        .context
+        .paths()
+        .repo_root
         .canonicalize()
-        .unwrap_or_else(|_| workspace_path.to_path_buf());
-    canonical_cwd.starts_with(&canonical_workspace)
+        .unwrap_or_else(|_| runtime.context.paths().repo_root.clone())
+}
+
+fn validated_task_workspace(repo_root: &Path, workspace_path: &str) -> Option<PathBuf> {
+    let candidate = if Path::new(workspace_path).is_absolute() {
+        PathBuf::from(workspace_path)
+    } else {
+        repo_root.join(workspace_path)
+    };
+    let canonical_workspace = candidate.canonicalize().ok()?;
+    if !canonical_workspace.is_dir() {
+        return None;
+    }
+    canonical_workspace
+        .starts_with(repo_root)
+        .then_some(canonical_workspace)
+}
+
+fn resolve_task_workspace_root(runtime: &OrbitRuntime, task_id: &str) -> Option<PathBuf> {
+    let repo_root = canonical_repo_root(runtime);
+    let task = runtime.get_task(task_id).ok()?;
+    let workspace_path = task.workspace_path.as_deref()?;
+    validated_task_workspace(&repo_root, workspace_path)
+}
+
+fn task_workspace_matches(canonical_workspace: &Path, canonical_cwd: &Path) -> bool {
+    canonical_cwd.starts_with(canonical_workspace)
 }
 
 #[derive(Debug, Clone)]
@@ -214,4 +245,100 @@ pub struct DryRunResult {
     pub tool_name: String,
     pub policy_allowed: bool,
     pub missing_params: Vec<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        canonical_repo_root, resolve_task_id_from_context, resolve_workspace_root_from_context,
+    };
+    use crate::OrbitRuntime;
+    use orbit_store::TaskCreateParams as StoreTaskCreateParams;
+    use orbit_tools::ToolContext;
+    use orbit_types::{ActorIdentity, TaskPriority, TaskStatus, TaskType};
+    use std::fs;
+
+    fn seed_task(runtime: &OrbitRuntime, title: &str, workspace_path: Option<String>) -> String {
+        runtime
+            .create_task_record(StoreTaskCreateParams {
+                actor: "tester".to_string(),
+                parent_id: None,
+                title: title.to_string(),
+                description: String::new(),
+                acceptance_criteria: Vec::new(),
+                plan: "## Plan\n- test".to_string(),
+                execution_summary: String::new(),
+                context_files: Vec::new(),
+                workspace_path,
+                repo_root: None,
+                created_by: Some("tester".to_string()),
+                actor_identity: ActorIdentity::System,
+                assigned_to: Some("tester".to_string()),
+                status: TaskStatus::InProgress,
+                priority: TaskPriority::Medium,
+                complexity: None,
+                task_type: TaskType::Task,
+                pr_number: None,
+                proposed_by: None,
+                source_task_id: None,
+                comments: Vec::new(),
+            })
+            .expect("task")
+            .id
+    }
+
+    #[test]
+    fn invalid_workspace_root_falls_back_to_repo_root() {
+        let runtime = OrbitRuntime::in_memory().expect("runtime");
+        let outside = tempfile::tempdir().expect("tempdir");
+        let task_id = seed_task(
+            &runtime,
+            "escaped workspace",
+            Some(outside.path().to_string_lossy().into_owned()),
+        );
+
+        let resolved = resolve_workspace_root_from_context(
+            &runtime,
+            &ToolContext {
+                task_id: Some(task_id),
+                ..Default::default()
+            },
+        )
+        .expect("workspace root")
+        .expect("workspace path");
+
+        assert_eq!(resolved, canonical_repo_root(&runtime));
+    }
+
+    #[test]
+    fn task_resolution_prefers_most_specific_matching_workspace() {
+        let runtime = OrbitRuntime::in_memory().expect("runtime");
+        let repo_root = canonical_repo_root(&runtime);
+        let nested = repo_root.join("nested");
+        let deeper = nested.join("deeper");
+        fs::create_dir_all(&deeper).expect("workspace dirs");
+
+        let broad_id = seed_task(
+            &runtime,
+            "broad",
+            Some(nested.to_string_lossy().into_owned()),
+        );
+        let specific_id = seed_task(
+            &runtime,
+            "specific",
+            Some(deeper.to_string_lossy().into_owned()),
+        );
+
+        let resolved = resolve_task_id_from_context(
+            &runtime,
+            &ToolContext {
+                cwd: Some(deeper.to_string_lossy().into_owned()),
+                ..Default::default()
+            },
+        )
+        .expect("task id");
+
+        assert_eq!(resolved, Some(specific_id));
+        assert_ne!(resolved, Some(broad_id));
+    }
 }

--- a/orbit-tools/src/builtin/fs/delete.rs
+++ b/orbit-tools/src/builtin/fs/delete.rs
@@ -32,8 +32,57 @@ impl Tool for FsDeleteTool {
         let canonical = super::check_workspace_boundary(ctx, Path::new(path_str))?;
         super::check_file_lock(ctx, &canonical)?;
 
-        fs::remove_file(path_str).map_err(|e| OrbitError::Io(e.to_string()))?;
+        fs::remove_file(&canonical).map_err(|e| OrbitError::Io(e.to_string()))?;
 
-        Ok(json!({"path": path_str, "deleted": true}))
+        Ok(json!({"path": canonical.display().to_string(), "deleted": true}))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+    use std::path::Path;
+
+    use serde_json::json;
+
+    use crate::{Tool, ToolContext};
+
+    use super::FsDeleteTool;
+
+    #[cfg(unix)]
+    fn create_file_symlink(src: &Path, dst: &Path) -> std::io::Result<()> {
+        std::os::unix::fs::symlink(src, dst)
+    }
+
+    #[cfg(windows)]
+    fn create_file_symlink(src: &Path, dst: &Path) -> std::io::Result<()> {
+        std::os::windows::fs::symlink_file(src, dst)
+    }
+
+    #[test]
+    fn deletes_canonical_target_for_symlink_paths() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let target = dir.path().join("target.txt");
+        let alias = dir.path().join("alias.txt");
+        fs::write(&target, "before").expect("seed target");
+        create_file_symlink(&target, &alias).expect("create symlink");
+
+        let result = FsDeleteTool
+            .execute(
+                &ToolContext {
+                    workspace_root: Some(dir.path().to_path_buf()),
+                    ..Default::default()
+                },
+                json!({
+                    "path": alias.display().to_string(),
+                }),
+            )
+            .expect("delete succeeds");
+
+        assert!(!target.exists());
+        // Canonicalize before deletion to handle macOS /var -> /private/var
+        let canonical_target = dir.path().canonicalize().expect("canonical dir").join("target.txt");
+        assert_eq!(result["path"], canonical_target.display().to_string());
+        assert_eq!(result["deleted"], true);
     }
 }

--- a/orbit-tools/src/builtin/fs/write.rs
+++ b/orbit-tools/src/builtin/fs/write.rs
@@ -44,11 +44,86 @@ impl Tool for FsWriteTool {
         let canonical = super::check_workspace_boundary(ctx, Path::new(path_str))?;
         super::check_file_lock(ctx, &canonical)?;
 
-        fs::write(path_str, content).map_err(|e| OrbitError::Io(e.to_string()))?;
+        fs::write(&canonical, content).map_err(|e| OrbitError::Io(e.to_string()))?;
 
         Ok(json!({
-            "path": path_str,
+            "path": canonical.display().to_string(),
             "bytes_written": content.len(),
         }))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+    use std::path::Path;
+
+    use orbit_types::OrbitError;
+    use serde_json::json;
+
+    use crate::{Tool, ToolContext};
+
+    use super::FsWriteTool;
+
+    #[cfg(unix)]
+    fn create_file_symlink(src: &Path, dst: &Path) -> std::io::Result<()> {
+        std::os::unix::fs::symlink(src, dst)
+    }
+
+    #[cfg(windows)]
+    fn create_file_symlink(src: &Path, dst: &Path) -> std::io::Result<()> {
+        std::os::windows::fs::symlink_file(src, dst)
+    }
+
+    #[test]
+    fn writes_to_canonical_target_for_symlink_paths() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let target = dir.path().join("target.txt");
+        let alias = dir.path().join("alias.txt");
+        fs::write(&target, "before").expect("seed target");
+        create_file_symlink(&target, &alias).expect("create symlink");
+
+        let result = FsWriteTool
+            .execute(
+                &ToolContext {
+                    workspace_root: Some(dir.path().to_path_buf()),
+                    ..Default::default()
+                },
+                json!({
+                    "path": alias.display().to_string(),
+                    "content": "after",
+                }),
+            )
+            .expect("write succeeds");
+
+        assert_eq!(fs::read_to_string(&target).expect("read target"), "after");
+        let canonical_target = target.canonicalize().expect("canonical target");
+        assert_eq!(result["path"], canonical_target.display().to_string());
+        assert_eq!(result["bytes_written"], 5);
+    }
+
+    #[test]
+    fn rejects_symlink_paths_that_escape_workspace() {
+        let workspace = tempfile::tempdir().expect("workspace");
+        let outside = tempfile::tempdir().expect("outside");
+        let target = outside.path().join("target.txt");
+        let alias = workspace.path().join("alias.txt");
+        fs::write(&target, "outside").expect("seed target");
+        create_file_symlink(&target, &alias).expect("create symlink");
+
+        let err = FsWriteTool
+            .execute(
+                &ToolContext {
+                    workspace_root: Some(workspace.path().to_path_buf()),
+                    ..Default::default()
+                },
+                json!({
+                    "path": alias.display().to_string(),
+                    "content": "after",
+                }),
+            )
+            .expect_err("workspace escape should be denied");
+
+        assert!(matches!(err, OrbitError::PolicyDenied(_)));
     }
 }

--- a/orbit-tools/src/builtin/orbit/task_update.rs
+++ b/orbit-tools/src/builtin/orbit/task_update.rs
@@ -169,7 +169,6 @@ impl Tool for OrbitTaskUpdateTool {
 #[cfg(test)]
 mod tests {
     use std::path::PathBuf;
-
     use serde_json::json;
 
     use crate::ToolContext;
@@ -178,10 +177,11 @@ mod tests {
 
     fn test_context() -> ToolContext {
         ToolContext {
-            cwd: PathBuf::from("/tmp/orbit"),
+            cwd: Some("/tmp/orbit".to_string()),
             orbit_root: Some(PathBuf::from("/tmp/orbit-root")),
             agent_name: Some("codex".to_string()),
             model_name: Some("gpt-5.4".to_string()),
+            ..Default::default()
         }
     }
 


### PR DESCRIPTION
## Tasks
- T20260329-211639: Eliminate TOCTOU races in fs.write and fs.delete boundary checks
- T20260329-211544: Validate task workspace paths before deriving fs sandbox roots

## Branch Freshness
- Base ref: `agent-main`
- Head ref: `orbit/parallel-batch`
- Behind base: 0
- Ahead of base: 1

## Files Changed
- `orbit-core/src/command/task.rs`
- `orbit-core/src/runtime/pipeline.rs`
- `orbit-tools/src/builtin/fs/delete.rs`
- `orbit-tools/src/builtin/fs/write.rs`
- `orbit-tools/src/builtin/orbit/task_update.rs`