### PR TITLE
feat: parallel batch [T20260329-211735, T20260329-204905]

### DIFF
--- a/orbit-core/src/config/raw.rs
+++ b/orbit-core/src/config/raw.rs
@@ -3,7 +3,6 @@ use serde::Deserialize;
 #[derive(Debug, Clone, Deserialize)]
 pub(super) struct RawRuntimeConfig {
     pub(super) execution: Option<RawExecutionConfig>,
-    pub(super) user: Option<RawUserSection>,
     #[allow(dead_code)]
     pub(super) identity: Option<toml::Value>,
     pub(super) task: Option<RawTaskSection>,
@@ -20,11 +19,6 @@ pub(super) struct RawScoringConfig {
 pub(super) struct RawExecutionConfig {
     pub(super) env: Option<RawExecutionEnvConfig>,
     pub(super) codex: Option<RawCodexExecutionConfig>,
-}
-
-#[derive(Debug, Clone, Deserialize, Default)]
-pub(super) struct RawUserSection {
-    pub(super) name: Option<String>,
 }
 
 #[derive(Debug, Clone, Deserialize)]

--- a/orbit-core/src/config/runtime.rs
+++ b/orbit-core/src/config/runtime.rs
@@ -10,13 +10,11 @@ use crate::paths;
 use super::persistence::PersistenceConfig;
 use super::raw::{
     RawCodexExecutionConfig, RawExecutionEnvConfig, RawRuntimeConfig, RawTaskSection,
-    RawUserSection,
 };
 
 const DEFAULT_ENV_INHERIT: bool = false;
 const DEFAULT_TASK_APPROVAL_REQUIRED_FOR_AGENT: bool = false;
 const DEFAULT_TASK_APPROVAL_DELEGATE_APPROVAL: bool = false;
-const DEFAULT_USER_NAME: &str = "human";
 const DEFAULT_SCORING_ENABLED: bool = false;
 
 #[derive(Debug, Clone)]
@@ -25,7 +23,6 @@ pub(crate) struct RuntimeConfig {
     pub(crate) codex_execution: CodexExecutionPolicy,
     pub(crate) persistence: PersistenceConfig,
     pub(crate) task_approval: TaskApprovalConfig,
-    pub(crate) user_name: String,
     pub(crate) scoring_enabled: bool,
 }
 
@@ -42,7 +39,6 @@ impl RuntimeConfig {
             codex_execution: CodexExecutionPolicy::default(),
             persistence: PersistenceConfig::default_for_data_root(data_root),
             task_approval: TaskApprovalConfig::default(),
-            user_name: DEFAULT_USER_NAME.to_string(),
             scoring_enabled: DEFAULT_SCORING_ENABLED,
         }
     }
@@ -120,26 +116,9 @@ impl RuntimeConfig {
             )?,
             persistence,
             task_approval: TaskApprovalConfig::from_raw(parsed.task.as_ref())?,
-            user_name: parse_user_name(parsed.user.as_ref())?,
             scoring_enabled,
         })
     }
-}
-
-fn parse_user_name(raw: Option<&RawUserSection>) -> Result<String, OrbitError> {
-    let Some(raw) = raw else {
-        return Ok(DEFAULT_USER_NAME.to_string());
-    };
-    let Some(name) = raw.name.as_deref() else {
-        return Ok(DEFAULT_USER_NAME.to_string());
-    };
-    let name = name.trim();
-    if name.is_empty() {
-        return Err(OrbitError::InvalidInput(
-            "user.name must not be empty when configured".to_string(),
-        ));
-    }
-    Ok(name.to_string())
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/orbit-core/src/context.rs
+++ b/orbit-core/src/context.rs
@@ -83,7 +83,6 @@ pub struct OrbitContext {
     execution_env_policy: ExecutionEnvPolicy,
     codex_execution_policy: CodexExecutionPolicy,
     persistence: PersistenceConfig,
-    user_name: String,
     actor: ActorIdentity,
     task_approval_required_for_agent: bool,
     task_delegate_approval: bool,
@@ -106,7 +105,6 @@ impl OrbitContext {
         execution_env_policy: ExecutionEnvPolicy,
         codex_execution_policy: CodexExecutionPolicy,
         persistence: PersistenceConfig,
-        user_name: String,
         actor: ActorIdentity,
         task_approval_required_for_agent: bool,
         task_delegate_approval: bool,
@@ -126,7 +124,6 @@ impl OrbitContext {
             execution_env_policy,
             codex_execution_policy,
             persistence,
-            user_name,
             actor,
             task_approval_required_for_agent,
             task_delegate_approval,
@@ -197,10 +194,6 @@ impl OrbitContext {
 
     pub(crate) fn persistence(&self) -> &PersistenceConfig {
         &self.persistence
-    }
-
-    pub(crate) fn user_name(&self) -> &str {
-        &self.user_name
     }
 
     pub(crate) fn actor(&self) -> &ActorIdentity {

--- a/orbit-core/src/runtime/builder.rs
+++ b/orbit-core/src/runtime/builder.rs
@@ -90,7 +90,6 @@ pub(crate) fn build_context_from_roots(
     let execution_env_policy = runtime_config.execution_env.clone();
     let codex_execution_policy = runtime_config.codex_execution.clone();
     let persistence = runtime_config.persistence.clone();
-    let user_name = runtime_config.user_name.clone();
     let actor = ActorIdentity::from_env();
     let task_approval_required_for_agent = runtime_config.task_approval.required_for_agent;
     let task_delegate_approval = runtime_config.task_approval.delegate_approval;
@@ -110,7 +109,6 @@ pub(crate) fn build_context_from_roots(
         execution_env_policy,
         codex_execution_policy,
         persistence,
-        user_name,
         actor,
         task_approval_required_for_agent,
         task_delegate_approval,

--- a/orbit-core/src/runtime/mod.rs
+++ b/orbit-core/src/runtime/mod.rs
@@ -168,10 +168,6 @@ impl OrbitRuntime {
         self.context.scoring_enabled()
     }
 
-    pub fn user_name(&self) -> &str {
-        self.context.user_name()
-    }
-
     pub(crate) fn actor(&self) -> &ActorIdentity {
         self.context.actor()
     }

--- a/orbit-policy/src/evaluator.rs
+++ b/orbit-policy/src/evaluator.rs
@@ -2,6 +2,7 @@ use std::collections::HashSet;
 
 use crate::PolicyDecision;
 use crate::engine::PolicyContext;
+use orbit_types::Role;
 
 pub(crate) fn evaluate(
     ctx: &PolicyContext,
@@ -9,6 +10,7 @@ pub(crate) fn evaluate(
     default_allow: bool,
 ) -> PolicyDecision {
     if let Some(tool_name) = &ctx.tool_name
+        && ctx.role != Role::Admin
         && denied_tools.contains(tool_name)
     {
         return PolicyDecision::Deny {
@@ -21,6 +23,93 @@ pub(crate) fn evaluate(
     } else {
         PolicyDecision::Deny {
             reason: "default deny policy".to_string(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashSet;
+
+    use orbit_types::Role;
+
+    use super::evaluate;
+    use crate::{PolicyDecision, engine::PolicyContext};
+
+    #[test]
+    fn agent_denied_tool_is_rejected() {
+        let denied_tools = HashSet::from([String::from("dangerous.tool")]);
+        let decision = evaluate(
+            &PolicyContext {
+                entrypoint: "cli".to_string(),
+                tool_name: Some("dangerous.tool".to_string()),
+                role: Role::Agent,
+            },
+            &denied_tools,
+            true,
+        );
+
+        assert_eq!(
+            decision,
+            PolicyDecision::Deny {
+                reason: "tool `dangerous.tool` denied by policy".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn admin_bypasses_denied_tool() {
+        let denied_tools = HashSet::from([String::from("dangerous.tool")]);
+        let decision = evaluate(
+            &PolicyContext {
+                entrypoint: "cli".to_string(),
+                tool_name: Some("dangerous.tool".to_string()),
+                role: Role::Admin,
+            },
+            &denied_tools,
+            true,
+        );
+
+        assert_eq!(decision, PolicyDecision::Allow);
+    }
+
+    #[test]
+    fn agent_allowed_tool_passes() {
+        let denied_tools = HashSet::from([String::from("dangerous.tool")]);
+        let decision = evaluate(
+            &PolicyContext {
+                entrypoint: "cli".to_string(),
+                tool_name: Some("safe.tool".to_string()),
+                role: Role::Agent,
+            },
+            &denied_tools,
+            true,
+        );
+
+        assert_eq!(decision, PolicyDecision::Allow);
+    }
+
+    #[test]
+    fn default_deny_rejects_all_roles() {
+        let denied_tools = HashSet::new();
+
+        for role in [Role::Admin, Role::Agent] {
+            let decision = evaluate(
+                &PolicyContext {
+                    entrypoint: "cli".to_string(),
+                    tool_name: Some("safe.tool".to_string()),
+                    role,
+                },
+                &denied_tools,
+                false,
+            );
+
+            assert_eq!(
+                decision,
+                PolicyDecision::Deny {
+                    reason: "default deny policy".to_string(),
+                }
+            );
         }
     }
 }

--- a/orbit-policy/src/lib.rs
+++ b/orbit-policy/src/lib.rs
@@ -1,8 +1,9 @@
 //! RBAC policy evaluation engine for Orbit tool and command authorization.
 //!
 //! Evaluates whether a given actor (identified by [`orbit_types::Role`]) is
-//! permitted to invoke a specific tool or CLI entrypoint, based on a set of
-//! configured allow/deny rules.
+//! permitted to invoke a specific tool or CLI entrypoint. Admin callers bypass
+//! explicit tool deny rules, while agent callers are subject to them; both
+//! roles still respect the engine's default allow or default deny mode.
 //!
 //! # Role
 //! Sits directly above `orbit-types` in the dependency graph. Consumed by


### PR DESCRIPTION
## Tasks
- T20260329-211735: Make Orbit policy evaluation meaningfully role-aware
- T20260329-204905: Remove dead user_name field from RuntimeConfig and its plumbing

## Branch Freshness
- Base ref: `agent-main`
- Head ref: `orbit/parallel-batch`
- Behind base: 0
- Ahead of base: 1

## Files Changed
- `orbit-core/src/config/raw.rs`
- `orbit-core/src/config/runtime.rs`
- `orbit-core/src/context.rs`
- `orbit-core/src/runtime/builder.rs`
- `orbit-core/src/runtime/mod.rs`
- `orbit-policy/src/evaluator.rs`
- `orbit-policy/src/lib.rs`