### PR TITLE
feat: parallel batch [T20260330-054139, T20260330-025954, T20260330-011535]

### DIFF
--- a/orbit-core/src/runtime/pipeline.rs
+++ b/orbit-core/src/runtime/pipeline.rs
@@ -222,9 +222,25 @@ fn validated_task_workspace(repo_root: &Path, workspace_path: &str) -> Option<Pa
     if !canonical_workspace.is_dir() {
         return None;
     }
+    if canonical_workspace.starts_with(repo_root) {
+        return Some(canonical_workspace);
+    }
+
+    let worktree_root = configured_worktree_root()?;
     canonical_workspace
-        .starts_with(repo_root)
+        .starts_with(worktree_root)
         .then_some(canonical_workspace)
+}
+
+fn configured_worktree_root() -> Option<PathBuf> {
+    let value = std::env::var("ORBIT_WORKTREE_ROOT").ok()?;
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+
+    let path = PathBuf::from(trimmed);
+    Some(path.canonicalize().unwrap_or(path))
 }
 
 fn resolve_task_workspace_root(runtime: &OrbitRuntime, task_id: &str) -> Option<PathBuf> {
@@ -254,7 +270,41 @@ mod tests {
     use orbit_store::TaskCreateParams as StoreTaskCreateParams;
     use orbit_tools::ToolContext;
     use orbit_types::{ActorIdentity, TaskPriority, TaskStatus, TaskType};
+    use std::ffi::OsString;
     use std::fs;
+    use std::sync::{Mutex, MutexGuard};
+
+    static WORKTREE_ROOT_ENV_LOCK: Mutex<()> = Mutex::new(());
+    const WORKTREE_ROOT_ENV: &str = "ORBIT_WORKTREE_ROOT";
+
+    struct WorktreeRootEnvGuard {
+        _lock: MutexGuard<'static, ()>,
+        original: Option<OsString>,
+    }
+
+    impl Drop for WorktreeRootEnvGuard {
+        fn drop(&mut self) {
+            match self.original.take() {
+                Some(value) => unsafe { std::env::set_var(WORKTREE_ROOT_ENV, value) },
+                None => unsafe { std::env::remove_var(WORKTREE_ROOT_ENV) },
+            }
+        }
+    }
+
+    fn set_worktree_root_env(path: Option<&std::path::Path>) -> WorktreeRootEnvGuard {
+        let lock = WORKTREE_ROOT_ENV_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let original = std::env::var_os(WORKTREE_ROOT_ENV);
+        match path {
+            Some(path) => unsafe { std::env::set_var(WORKTREE_ROOT_ENV, path) },
+            None => unsafe { std::env::remove_var(WORKTREE_ROOT_ENV) },
+        }
+        WorktreeRootEnvGuard {
+            _lock: lock,
+            original,
+        }
+    }
 
     fn seed_task(runtime: &OrbitRuntime, title: &str, workspace_path: Option<String>) -> String {
         runtime
@@ -338,5 +388,80 @@ mod tests {
 
         assert_eq!(resolved, Some(specific_id));
         assert_ne!(resolved, Some(broad_id));
+    }
+
+    #[test]
+    fn external_worktree_root_is_used_for_task_resolution_and_workspace_root() {
+        let runtime = OrbitRuntime::in_memory().expect("runtime");
+        let repo_root = canonical_repo_root(&runtime);
+        let external_root = tempfile::tempdir().expect("tempdir");
+        let external_workspace = external_root
+            .path()
+            .join(
+                repo_root
+                    .file_name()
+                    .expect("repo name")
+                    .to_string_lossy()
+                    .as_ref(),
+            )
+            .join("parallel-batch");
+        let nested_cwd = external_workspace.join("orbit-core");
+        fs::create_dir_all(&nested_cwd).expect("external workspace");
+
+        let _env = set_worktree_root_env(Some(external_root.path()));
+        let task_id = seed_task(
+            &runtime,
+            "external worktree",
+            Some(external_workspace.to_string_lossy().into_owned()),
+        );
+
+        let resolved_task = resolve_task_id_from_context(
+            &runtime,
+            &ToolContext {
+                cwd: Some(nested_cwd.to_string_lossy().into_owned()),
+                ..Default::default()
+            },
+        )
+        .expect("task id");
+        let resolved_workspace = resolve_workspace_root_from_context(
+            &runtime,
+            &ToolContext {
+                task_id: Some(task_id.clone()),
+                ..Default::default()
+            },
+        )
+        .expect("workspace root")
+        .expect("workspace path");
+
+        let canonical_external_workspace = external_workspace.canonicalize().expect("canonicalize");
+        assert_eq!(resolved_task, Some(task_id));
+        assert_eq!(resolved_workspace, canonical_external_workspace);
+    }
+
+    #[test]
+    fn repo_worktree_paths_still_resolve_without_external_root_env() {
+        let runtime = OrbitRuntime::in_memory().expect("runtime");
+        let repo_root = canonical_repo_root(&runtime);
+        let in_repo_workspace = repo_root.join(".orbit").join("worktrees").join("task-123");
+        let nested_cwd = in_repo_workspace.join("orbit-core");
+        fs::create_dir_all(&nested_cwd).expect("workspace dirs");
+
+        let _env = set_worktree_root_env(None);
+        let task_id = seed_task(
+            &runtime,
+            "repo worktree",
+            Some(in_repo_workspace.to_string_lossy().into_owned()),
+        );
+
+        let resolved_task = resolve_task_id_from_context(
+            &runtime,
+            &ToolContext {
+                cwd: Some(nested_cwd.to_string_lossy().into_owned()),
+                ..Default::default()
+            },
+        )
+        .expect("task id");
+
+        assert_eq!(resolved_task, Some(task_id));
     }
 }

--- a/orbit-store/src/file/job_store.rs
+++ b/orbit-store/src/file/job_store.rs
@@ -2,6 +2,7 @@ use std::fs;
 use std::path::{Path, PathBuf};
 #[cfg(unix)]
 use std::process::Command;
+use std::sync::{Mutex, OnceLock};
 
 use chrono::{DateTime, Utc};
 use orbit_types::{
@@ -59,6 +60,12 @@ struct JobRunFileDocument {
 struct JobRunStepFileDocument {
     schema_version: u8,
     step: JobRunStep,
+}
+
+#[derive(Default)]
+struct IdGenerationState {
+    last_base: String,
+    next_suffix: u32,
 }
 
 impl JobFileStore {
@@ -662,33 +669,15 @@ impl JobFileStore {
     }
 
     fn next_job_id(&self) -> String {
-        let now = Utc::now();
-        let base = format!("job-{}", now.format("%Y%m%d-%H%M%S"));
-        if !self.job_path(&base).exists() && !self.disabled_job_path(&base).exists() {
-            return base;
-        }
-        for suffix in 2..1024_u32 {
-            let candidate = format!("{base}-{suffix}");
-            if !self.job_path(&candidate).exists() && !self.disabled_job_path(&candidate).exists() {
-                return candidate;
-            }
-        }
-        base
+        self.next_timestamped_id("job", |candidate| {
+            self.job_path(candidate).exists() || self.disabled_job_path(candidate).exists()
+        })
     }
 
     fn next_run_id(&self, job_id: &str) -> String {
-        let now = Utc::now();
-        let base = format!("jrun-{}", now.format("%Y%m%d-%H%M%S"));
-        if !self.run_id_exists_globally(job_id, &base) {
-            return base;
-        }
-        for suffix in 2..1024_u32 {
-            let candidate = format!("{base}-{suffix}");
-            if !self.run_id_exists_globally(job_id, &candidate) {
-                return candidate;
-            }
-        }
-        base
+        self.next_timestamped_id("jrun", |candidate| {
+            self.run_id_exists_globally(job_id, candidate)
+        })
     }
 
     fn run_id_exists_globally(&self, job_id: &str, run_id: &str) -> bool {
@@ -696,6 +685,37 @@ impl JobFileStore {
             || self.archived_run_bundle_dir(job_id, run_id).exists()
             || self.find_run_path(run_id).ok().flatten().is_some()
             || self.find_archived_run_path(run_id).ok().flatten().is_some()
+    }
+
+    fn next_timestamped_id<F>(&self, prefix: &str, exists: F) -> String
+    where
+        F: Fn(&str) -> bool,
+    {
+        let base = format_timestamped_id(prefix, Utc::now());
+        let state = id_generation_state();
+        let mut state = state
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let start_suffix = if state.last_base == base {
+            state.next_suffix
+        } else {
+            1
+        };
+
+        for suffix in start_suffix..1024_u32 {
+            let candidate = if suffix == 1 {
+                base.clone()
+            } else {
+                format!("{base}-{suffix}")
+            };
+            if !exists(&candidate) {
+                state.last_base = base.clone();
+                state.next_suffix = suffix + 1;
+                return candidate;
+            }
+        }
+
+        base
     }
 
     fn activities_dir(&self) -> PathBuf {
@@ -793,7 +813,20 @@ fn validate_max_active_runs(max_active_runs: u32) -> Result<u32, OrbitError> {
     Ok(max_active_runs)
 }
 
-/// Derive a UTC timestamp from a job ID of the form `job-YYYYMMDD-HHMMSS[-N]`.
+fn format_timestamped_id(prefix: &str, now: DateTime<Utc>) -> String {
+    format!(
+        "{prefix}-{}-{:03}",
+        now.format("%Y%m%d-%H%M%S"),
+        now.timestamp_subsec_millis()
+    )
+}
+
+fn id_generation_state() -> &'static Mutex<IdGenerationState> {
+    static ID_GENERATION_STATE: OnceLock<Mutex<IdGenerationState>> = OnceLock::new();
+    ID_GENERATION_STATE.get_or_init(|| Mutex::new(IdGenerationState::default()))
+}
+
+/// Derive a UTC timestamp from a job ID of the form `job-YYYYMMDD-HHMMSS[-mmm][-N]`.
 /// Falls back to `Utc::now()` for IDs that don't embed a parseable timestamp.
 fn parse_timestamp_from_job_id(job_id: &str) -> DateTime<Utc> {
     let rest = job_id.strip_prefix("job-").unwrap_or(job_id);
@@ -813,4 +846,114 @@ fn is_yaml(path: &Path) -> bool {
     path.extension()
         .and_then(|value| value.to_str())
         .is_some_and(|ext| ext.eq_ignore_ascii_case("yaml") || ext.eq_ignore_ascii_case("yml"))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{Arc, Barrier};
+    use std::thread;
+
+    use tempfile::tempdir;
+
+    use super::*;
+
+    #[test]
+    fn add_job_generates_distinct_ids_for_parallel_threads() {
+        let temp_dir = tempdir().expect("create tempdir");
+        let store = Arc::new(JobFileStore::new(temp_dir.path().to_path_buf()));
+        let barrier = Arc::new(Barrier::new(3));
+
+        let mut handles = Vec::new();
+        for _ in 0..2 {
+            let store = Arc::clone(&store);
+            let barrier = Arc::clone(&barrier);
+            handles.push(thread::spawn(move || {
+                barrier.wait();
+                store
+                    .add_job(JobCreateParams {
+                        job_id: None,
+                        default_input: None,
+                        max_active_runs: 1,
+                        max_iterations: default_max_iterations(),
+                        steps: vec![],
+                        initial_state: JobScheduleState::Enabled,
+                    })
+                    .expect("create job")
+                    .job_id
+            }));
+        }
+
+        barrier.wait();
+        let job_ids: Vec<String> = handles
+            .into_iter()
+            .map(|handle| handle.join().expect("join thread"))
+            .collect();
+        assert_eq!(job_ids.len(), 2);
+        assert_ne!(job_ids[0], job_ids[1]);
+        assert!(job_ids.iter().all(|id| id.starts_with("job-")));
+        assert!(
+            job_ids
+                .iter()
+                .all(|id| id.split('-').nth(3).is_some_and(|millis| millis.len() == 3))
+        );
+    }
+
+    #[test]
+    fn insert_job_run_generates_distinct_ids_for_parallel_threads() {
+        let temp_dir = tempdir().expect("create tempdir");
+        let store = Arc::new(JobFileStore::new(temp_dir.path().to_path_buf()));
+        let job_id = "job-20260330-060536-000".to_string();
+
+        store
+            .add_job(JobCreateParams {
+                job_id: Some(job_id.clone()),
+                default_input: None,
+                max_active_runs: 1,
+                max_iterations: default_max_iterations(),
+                steps: vec![],
+                initial_state: JobScheduleState::Enabled,
+            })
+            .expect("create job");
+
+        let barrier = Arc::new(Barrier::new(3));
+        let mut handles = Vec::new();
+        for _ in 0..2 {
+            let store = Arc::clone(&store);
+            let barrier = Arc::clone(&barrier);
+            let job_id = job_id.clone();
+            handles.push(thread::spawn(move || {
+                barrier.wait();
+                store
+                    .insert_job_run(&job_id, 1, Utc::now(), None, None)
+                    .expect("create run")
+                    .run_id
+            }));
+        }
+
+        barrier.wait();
+        let run_ids: Vec<String> = handles
+            .into_iter()
+            .map(|handle| handle.join().expect("join thread"))
+            .collect();
+        assert_eq!(run_ids.len(), 2);
+        assert_ne!(run_ids[0], run_ids[1]);
+
+        let runs = store.list_job_runs(&job_id).expect("list runs");
+        assert_eq!(runs.len(), 2);
+        for run_id in &run_ids {
+            assert!(
+                store
+                    .run_bundle_dir(&job_id, run_id)
+                    .join("jrun.yaml")
+                    .exists()
+            );
+            assert!(run_id.starts_with("jrun-"));
+            assert!(
+                run_id
+                    .split('-')
+                    .nth(3)
+                    .is_some_and(|millis| millis.len() == 3)
+            );
+        }
+    }
 }

--- a/orbit-tools/src/builtin/orbit/task_update.rs
+++ b/orbit-tools/src/builtin/orbit/task_update.rs
@@ -53,9 +53,9 @@ pub(super) fn build_exec_requests(
         args.push(batch_id);
         changed = true;
     }
-    if let Some(context_files) = super::optional_string(input, "context_files")? {
+    if let Some(context_files) = super::optional_string_list_alias(input, &["context_files"])? {
         args.push("--context".to_string());
-        args.push(context_files);
+        args.push(context_files.join(","));
         changed = true;
     }
 
@@ -131,8 +131,10 @@ impl Tool for OrbitTaskUpdateTool {
             },
             ToolParam {
                 name: "context_files".to_string(),
-                description: "Comma-separated context file paths (empty string clears)".to_string(),
-                param_type: "string".to_string(),
+                description:
+                    "Context file paths as a comma-separated string or array of strings"
+                        .to_string(),
+                param_type: "array".to_string(),
                 required: false,
             },
         ]);
@@ -224,11 +226,50 @@ mod tests {
     }
 
     #[test]
+    fn build_exec_requests_accepts_context_files_array() {
+        let (update, _) = build_exec_requests(
+            &test_context(),
+            &json!({
+                "id": "T20260330-002312",
+                "context_files": [
+                    "orbit-cli/src/command/task.rs",
+                    "orbit-tools/src/builtin/orbit/task_update.rs"
+                ]
+            }),
+        )
+        .expect("request should build");
+
+        let context_index = update
+            .args
+            .iter()
+            .position(|arg| arg == "--context")
+            .expect("expected `--context` in request");
+        assert_eq!(
+            update.args.get(context_index + 1).map(String::as_str),
+            Some("orbit-cli/src/command/task.rs,orbit-tools/src/builtin/orbit/task_update.rs")
+        );
+    }
+
+    #[test]
     fn build_exec_requests_error_mentions_context_files() {
         let err = build_exec_requests(&test_context(), &json!({ "id": "T20260330-002312" }))
             .expect_err("missing fields should fail");
         let message = err.to_string();
 
         assert!(message.contains("context_files"));
+    }
+
+    #[test]
+    fn build_exec_requests_rejects_non_string_context_files_entries() {
+        let err = build_exec_requests(
+            &test_context(),
+            &json!({
+                "id": "T20260330-002312",
+                "context_files": ["orbit-cli/src/command/task.rs", 7]
+            }),
+        )
+        .expect_err("non-string entries should fail");
+
+        assert!(err.to_string().contains("entries must be strings"));
     }
 }


### PR DESCRIPTION
## Tasks
- T20260330-054139: Fix parallel worker job_run ID collision causing lost run records
- T20260330-025954: Fix external worktree validation regression in runtime pipeline
- T20260330-011535: orbit.task.update rejects JSON array for context_files, expects comma-separated string

## Branch Freshness
- Base ref: `agent-main`
- Head ref: `orbit/parallel-batch`
- Behind base: 0
- Ahead of base: 1

## Files Changed
- `orbit-core/src/runtime/pipeline.rs`
- `orbit-store/src/file/job_store.rs`
- `orbit-tools/src/builtin/orbit/task_update.rs`