### PR TITLE
feat: parallel batch [T20260331-011517, T20260331-005204, T20260330-053417]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
     branches: [agent-main]
   pull_request:
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
 

--- a/orbit-core/src/runtime/engine.rs
+++ b/orbit-core/src/runtime/engine.rs
@@ -439,7 +439,7 @@ impl TaskHost for OrbitRuntime {
                     actor: "agent".to_string(),
                     execution_summary: update.execution_summary.clone(),
                     status: update.status,
-                    workspace_path: update.workspace_path.clone().map(Some),
+                    workspace_path: update.workspace_path.clone(),
                     repo_root: update.repo_root.clone().map(Some),
                     pr_number: update.pr_number.clone().map(Some),
                     batch_id: update.batch_id.clone().map(Some),

--- a/orbit-engine/src/context.rs
+++ b/orbit-engine/src/context.rs
@@ -110,7 +110,7 @@ pub struct JobRunResult {
 #[derive(Debug, Clone, Default)]
 pub struct TaskAutomationUpdate {
     pub status: Option<TaskStatus>,
-    pub workspace_path: Option<String>,
+    pub workspace_path: Option<Option<String>>,
     pub repo_root: Option<String>,
     pub pr_number: Option<String>,
     pub execution_summary: Option<String>,

--- a/orbit-engine/src/executor/automation/parallel.rs
+++ b/orbit-engine/src/executor/automation/parallel.rs
@@ -19,6 +19,7 @@ const SHARED_WORKTREE_BRANCH: &str = "orbit/parallel-batch";
 struct PendingTask {
     task_id: String,
     context_files: Vec<String>,
+    original_workspace_path: Option<String>,
 }
 
 #[derive(Debug)]
@@ -60,6 +61,7 @@ pub(super) fn run_parallel_task_pipeline<H: RuntimeHost + TaskHost + Sync + ?Siz
     let shared_worktree = resolve_shared_worktree_path(repo_root)?;
     ensure_shared_worktree(repo_root, &shared_worktree, &base)?;
     let shared_worktree_str = shared_worktree.to_string_lossy().to_string();
+    set_worker_workspace_path(host, &selected_tasks, &shared_worktree_str)?;
 
     let mut pending = VecDeque::from(selected_tasks.clone());
 
@@ -69,7 +71,7 @@ pub(super) fn run_parallel_task_pipeline<H: RuntimeHost + TaskHost + Sync + ?Siz
     let mut failures = Vec::new();
     let mut completed_task_ids = HashSet::new();
 
-    std::thread::scope(|scope| -> Result<(), OrbitError> {
+    let worker_result = std::thread::scope(|scope| -> Result<(), OrbitError> {
         let (tx, rx) = mpsc::channel::<WorkerOutcome>();
         let mut active = Vec::<PendingTask>::new();
 
@@ -191,7 +193,10 @@ pub(super) fn run_parallel_task_pipeline<H: RuntimeHost + TaskHost + Sync + ?Siz
         }
 
         Ok(())
-    })?;
+    });
+    let restore_result = restore_task_workspace_paths(host, &selected_tasks);
+    worker_result?;
+    restore_result?;
 
     let completed_task_ids = selected_tasks
         .into_iter()
@@ -289,8 +294,42 @@ impl From<Task> for PendingTask {
         Self {
             task_id: task.id,
             context_files: task.context_files,
+            original_workspace_path: task.workspace_path,
         }
     }
+}
+
+fn set_worker_workspace_path<H: TaskHost + ?Sized>(
+    host: &H,
+    tasks: &[PendingTask],
+    workspace_path: &str,
+) -> Result<(), OrbitError> {
+    for task in tasks {
+        host.apply_task_automation_update(
+            &task.task_id,
+            TaskAutomationUpdate {
+                workspace_path: Some(Some(workspace_path.to_string())),
+                ..TaskAutomationUpdate::default()
+            },
+        )?;
+    }
+    Ok(())
+}
+
+fn restore_task_workspace_paths<H: TaskHost + ?Sized>(
+    host: &H,
+    tasks: &[PendingTask],
+) -> Result<(), OrbitError> {
+    for task in tasks {
+        host.apply_task_automation_update(
+            &task.task_id,
+            TaskAutomationUpdate {
+                workspace_path: Some(task.original_workspace_path.clone()),
+                ..TaskAutomationUpdate::default()
+            },
+        )?;
+    }
+    Ok(())
 }
 
 fn load_selected_tasks<H: TaskHost + ?Sized>(
@@ -389,8 +428,76 @@ fn normalize_path(path: &str) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::{PendingTask, find_launchable_index, paths_conflict, validate_selected_group};
+    use super::{
+        PendingTask, find_launchable_index, paths_conflict, restore_task_workspace_paths,
+        set_worker_workspace_path, validate_selected_group,
+    };
+    use crate::context::{TaskAutomationUpdate, TaskHost};
+    use orbit_types::{OrbitError, Task, TaskPriority, TaskStatus};
     use std::collections::VecDeque;
+    use std::sync::Mutex;
+
+    #[derive(Default)]
+    struct WorkspaceUpdateHost {
+        updates: Mutex<Vec<(String, Option<Option<String>>)>>,
+    }
+
+    impl WorkspaceUpdateHost {
+        fn recorded_updates(&self) -> Vec<(String, Option<Option<String>>)> {
+            self.updates
+                .lock()
+                .expect("workspace updates lock")
+                .clone()
+        }
+    }
+
+    impl TaskHost for WorkspaceUpdateHost {
+        fn get_task(&self, _task_id: &str) -> Result<Task, OrbitError> {
+            unimplemented!("not needed for workspace update tests")
+        }
+
+        fn list_tasks_filtered(
+            &self,
+            _status: Option<TaskStatus>,
+            _priority: Option<TaskPriority>,
+            _parent_id: Option<&str>,
+            _batch_id: Option<&str>,
+        ) -> Result<Vec<Task>, OrbitError> {
+            unimplemented!("not needed for workspace update tests")
+        }
+
+        fn start_task(
+            &self,
+            _task_id: &str,
+            _note: Option<String>,
+            _comment: Option<String>,
+        ) -> Result<Task, OrbitError> {
+            unimplemented!("not needed for workspace update tests")
+        }
+
+        fn update_task_from_activity(
+            &self,
+            _task_id: &str,
+            _status: TaskStatus,
+            _execution_summary: Option<String>,
+            _comment: Option<String>,
+            _note: Option<String>,
+        ) -> Result<Task, OrbitError> {
+            unimplemented!("not needed for workspace update tests")
+        }
+
+        fn apply_task_automation_update(
+            &self,
+            task_id: &str,
+            update: TaskAutomationUpdate,
+        ) -> Result<(), OrbitError> {
+            self.updates
+                .lock()
+                .expect("workspace updates lock")
+                .push((task_id.to_string(), update.workspace_path));
+            Ok(())
+        }
+    }
 
     #[test]
     fn detects_prefix_path_conflicts() {
@@ -405,15 +512,18 @@ mod tests {
         let active = vec![PendingTask {
             task_id: "T-active".to_string(),
             context_files: vec!["src".to_string()],
+            original_workspace_path: None,
         }];
         let pending = VecDeque::from(vec![
             PendingTask {
                 task_id: "T-conflict".to_string(),
                 context_files: vec!["src/lib.rs".to_string()],
+                original_workspace_path: None,
             },
             PendingTask {
                 task_id: "T-safe".to_string(),
                 context_files: vec!["docs/readme.md".to_string()],
+                original_workspace_path: None,
             },
         ]);
 
@@ -426,13 +536,63 @@ mod tests {
             PendingTask {
                 task_id: "T-a".to_string(),
                 context_files: vec!["src".to_string()],
+                original_workspace_path: None,
             },
             PendingTask {
                 task_id: "T-b".to_string(),
                 context_files: vec!["src/lib.rs".to_string()],
+                original_workspace_path: None,
             },
         ];
 
         assert!(validate_selected_group(&selected).is_err());
+    }
+
+    #[test]
+    fn sets_task_workspace_to_shared_worktree_for_workers() {
+        let host = WorkspaceUpdateHost::default();
+        let tasks = vec![PendingTask {
+            task_id: "T-a".to_string(),
+            context_files: vec!["src/lib.rs".to_string()],
+            original_workspace_path: Some("/repo".to_string()),
+        }];
+
+        set_worker_workspace_path(&host, &tasks, "/repo/.orbit/worktrees/parallel-batch")
+            .expect("workspace path update succeeds");
+
+        assert_eq!(
+            host.recorded_updates(),
+            vec![(
+                "T-a".to_string(),
+                Some(Some("/repo/.orbit/worktrees/parallel-batch".to_string())),
+            )]
+        );
+    }
+
+    #[test]
+    fn restores_original_task_workspace_after_parallel_run() {
+        let host = WorkspaceUpdateHost::default();
+        let tasks = vec![
+            PendingTask {
+                task_id: "T-a".to_string(),
+                context_files: vec!["src/lib.rs".to_string()],
+                original_workspace_path: Some("/repo".to_string()),
+            },
+            PendingTask {
+                task_id: "T-b".to_string(),
+                context_files: vec!["docs/readme.md".to_string()],
+                original_workspace_path: None,
+            },
+        ];
+
+        restore_task_workspace_paths(&host, &tasks).expect("workspace restore succeeds");
+
+        assert_eq!(
+            host.recorded_updates(),
+            vec![
+                ("T-a".to_string(), Some(Some("/repo".to_string()))),
+                ("T-b".to_string(), Some(None)),
+            ]
+        );
     }
 }

--- a/orbit-store/src/file/task_store.rs
+++ b/orbit-store/src/file/task_store.rs
@@ -91,6 +91,13 @@ impl TaskStateDir {
             TaskStateDir::Rejected,
         ]
     }
+
+    fn is_partitioned(self) -> bool {
+        matches!(
+            self,
+            TaskStateDir::Done | TaskStateDir::Archived | TaskStateDir::Rejected
+        )
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -239,19 +246,7 @@ impl TaskFileStore {
     pub(crate) fn list_tasks(&self) -> Result<Vec<Task>, OrbitError> {
         let mut tasks = Vec::new();
         for state in TaskStateDir::all() {
-            let dir = self.state_dir_path(state);
-            if !dir.exists() {
-                continue;
-            }
-            let mut task_dirs = fs::read_dir(&dir)
-                .map_err(|e| OrbitError::Io(e.to_string()))?
-                .filter_map(Result::ok)
-                .map(|entry| entry.path())
-                .filter(|path| path.is_dir())
-                .collect::<Vec<_>>();
-            task_dirs.sort();
-
-            for task_dir in task_dirs {
+            for task_dir in self.task_dirs_for_state(state)? {
                 let bundle = self.read_bundle_at(&task_dir)?;
                 tasks.push(bundle_to_task(state, bundle));
             }
@@ -467,6 +462,29 @@ impl TaskFileStore {
 
     fn locate_task(&self, id: &str) -> Result<Option<(TaskStateDir, PathBuf)>, OrbitError> {
         for state in TaskStateDir::all() {
+            if state.is_partitioned() {
+                if let Some(partition) = partition_key(id) {
+                    let partitioned_dir = self.state_dir_path(state).join(partition).join(id);
+                    if partitioned_dir.is_dir() {
+                        return Ok(Some((state, partitioned_dir)));
+                    }
+                }
+
+                let legacy_dir = self.state_dir_path(state).join(id);
+                if legacy_dir.is_dir() {
+                    let migrated_dir = self.migrate_legacy_task_dir(state, legacy_dir)?;
+                    return Ok(Some((state, migrated_dir)));
+                }
+
+                for partition_dir in self.partition_dirs(state)? {
+                    let partitioned_dir = partition_dir.join(id);
+                    if partitioned_dir.is_dir() {
+                        return Ok(Some((state, partitioned_dir)));
+                    }
+                }
+                continue;
+            }
+
             let task_dir = self.task_dir(state, id);
             if task_dir.is_dir() {
                 return Ok(Some((state, task_dir)));
@@ -573,6 +591,11 @@ impl TaskFileStore {
     }
 
     fn task_dir(&self, state: TaskStateDir, id: &str) -> PathBuf {
+        if state.is_partitioned() {
+            if let Some(partition) = partition_key(id) {
+                return self.state_dir_path(state).join(partition).join(id);
+            }
+        }
         self.state_dir_path(state).join(id)
     }
 
@@ -591,6 +614,110 @@ impl TaskFileStore {
     fn artifacts_dir(&self, task_dir: &Path) -> PathBuf {
         task_dir.join(ARTIFACTS_DIR_NAME)
     }
+
+    fn task_dirs_for_state(&self, state: TaskStateDir) -> Result<Vec<PathBuf>, OrbitError> {
+        let state_dir = self.state_dir_path(state);
+        if !state_dir.exists() {
+            return Ok(Vec::new());
+        }
+
+        if !state.is_partitioned() {
+            return read_child_dirs(&state_dir);
+        }
+
+        let mut task_dirs = Vec::new();
+        for entry in read_child_dirs(&state_dir)? {
+            let Some(name) = entry.file_name().and_then(|value| value.to_str()) else {
+                continue;
+            };
+
+            if is_partition_dir_name(name) {
+                task_dirs.extend(read_child_dirs(&entry)?);
+                continue;
+            }
+
+            if self.task_doc_path(&entry).is_file() {
+                task_dirs.push(self.migrate_legacy_task_dir(state, entry)?);
+            }
+        }
+
+        Ok(task_dirs)
+    }
+
+    fn partition_dirs(&self, state: TaskStateDir) -> Result<Vec<PathBuf>, OrbitError> {
+        let state_dir = self.state_dir_path(state);
+        if !state_dir.exists() {
+            return Ok(Vec::new());
+        }
+
+        Ok(read_child_dirs(&state_dir)?
+            .into_iter()
+            .filter(|path| {
+                path.file_name()
+                    .and_then(|value| value.to_str())
+                    .is_some_and(is_partition_dir_name)
+            })
+            .collect())
+    }
+
+    fn migrate_legacy_task_dir(
+        &self,
+        state: TaskStateDir,
+        legacy_dir: PathBuf,
+    ) -> Result<PathBuf, OrbitError> {
+        let Some(task_id) = legacy_dir.file_name().and_then(|value| value.to_str()) else {
+            return Err(OrbitError::Store(format!(
+                "invalid task directory path {}",
+                legacy_dir.display()
+            )));
+        };
+        let target_dir = self.task_dir(state, task_id);
+        if target_dir == legacy_dir {
+            return Ok(legacy_dir);
+        }
+        if target_dir.exists() {
+            return Err(OrbitError::Store(format!(
+                "cannot migrate task directory {} because {} already exists",
+                legacy_dir.display(),
+                target_dir.display()
+            )));
+        }
+        self.move_task_dir(&legacy_dir, &target_dir)?;
+        Ok(target_dir)
+    }
+}
+
+fn partition_key(id: &str) -> Option<String> {
+    let raw = id.strip_prefix('T')?;
+    let year = raw.get(0..4)?;
+    let month = raw.get(4..6)?;
+    is_valid_year_month(year, month).then(|| format!("{year}-{month}"))
+}
+
+fn is_partition_dir_name(name: &str) -> bool {
+    let Some((year, month)) = name.split_once('-') else {
+        return false;
+    };
+    year.len() == 4 && month.len() == 2 && is_valid_year_month(year, month)
+}
+
+fn is_valid_year_month(year: &str, month: &str) -> bool {
+    year.as_bytes().iter().all(u8::is_ascii_digit)
+        && matches!(
+            month,
+            "01" | "02" | "03" | "04" | "05" | "06" | "07" | "08" | "09" | "10" | "11" | "12"
+        )
+}
+
+fn read_child_dirs(dir: &Path) -> Result<Vec<PathBuf>, OrbitError> {
+    let mut child_dirs = fs::read_dir(dir)
+        .map_err(|e| OrbitError::Io(e.to_string()))?
+        .filter_map(Result::ok)
+        .map(|entry| entry.path())
+        .filter(|path| path.is_dir())
+        .collect::<Vec<_>>();
+    child_dirs.sort();
+    Ok(child_dirs)
 }
 
 fn serialize_task_doc_yaml(doc: &TaskFileDocument) -> Result<String, OrbitError> {
@@ -740,5 +867,132 @@ fn bundle_to_task(state: TaskStateDir, bundle: TaskBundle) -> Task {
         review_threads: bundle.doc.review_threads,
         created_at: bundle.doc.created_at,
         updated_at: bundle.doc.updated_at,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use chrono::TimeZone;
+    use tempfile::tempdir;
+
+    use super::*;
+
+    #[test]
+    fn list_tasks_migrates_legacy_done_directories_into_month_partitions() {
+        let temp_dir = tempdir().expect("create tempdir");
+        let store = TaskFileStore::new(temp_dir.path().to_path_buf());
+        store.ensure_layout().expect("create task layout");
+
+        let task_id = "T20260315-123456";
+        let legacy_dir = store.state_dir_path(TaskStateDir::Done).join(task_id);
+        store
+            .write_bundle_at(&legacy_dir, &sample_bundle(task_id, 15))
+            .expect("write legacy task bundle");
+
+        let tasks = store.list_tasks().expect("list tasks");
+
+        assert_eq!(tasks.len(), 1);
+        assert_eq!(tasks[0].id, task_id);
+        assert_eq!(tasks[0].status, TaskStatus::Done);
+        assert!(!legacy_dir.exists());
+        assert!(
+            store.task_dir(TaskStateDir::Done, task_id).exists(),
+            "migrated task directory should exist under a yyyy-mm partition"
+        );
+    }
+
+    #[test]
+    fn get_task_migrates_legacy_archived_directories() {
+        let temp_dir = tempdir().expect("create tempdir");
+        let store = TaskFileStore::new(temp_dir.path().to_path_buf());
+        store.ensure_layout().expect("create task layout");
+
+        let task_id = "T20260401-091500";
+        let legacy_dir = store.state_dir_path(TaskStateDir::Archived).join(task_id);
+        store
+            .write_bundle_at(&legacy_dir, &sample_bundle(task_id, 1))
+            .expect("write legacy archived task bundle");
+
+        let task = store
+            .get_task(task_id)
+            .expect("load task")
+            .expect("task should exist");
+
+        assert_eq!(task.id, task_id);
+        assert_eq!(task.status, TaskStatus::Archived);
+        assert!(!legacy_dir.exists());
+        assert!(store.task_dir(TaskStateDir::Archived, task_id).exists());
+    }
+
+    #[test]
+    fn task_dir_only_partitions_terminal_states() {
+        let temp_dir = tempdir().expect("create tempdir");
+        let store = TaskFileStore::new(temp_dir.path().to_path_buf());
+        let task_id = "T20260331-005204";
+
+        assert_eq!(
+            store.task_dir(TaskStateDir::Done, task_id),
+            temp_dir.path().join("done").join("2026-03").join(task_id)
+        );
+        assert_eq!(
+            store.task_dir(TaskStateDir::Archived, task_id),
+            temp_dir
+                .path()
+                .join("archived")
+                .join("2026-03")
+                .join(task_id)
+        );
+        assert_eq!(
+            store.task_dir(TaskStateDir::Rejected, task_id),
+            temp_dir
+                .path()
+                .join("rejected")
+                .join("2026-03")
+                .join(task_id)
+        );
+        assert_eq!(
+            store.task_dir(TaskStateDir::Review, task_id),
+            temp_dir.path().join("review").join(task_id)
+        );
+    }
+
+    fn sample_bundle(task_id: &str, day: u32) -> TaskBundle {
+        let timestamp = Utc
+            .with_ymd_and_hms(2026, 3, day, 12, 34, 56)
+            .single()
+            .expect("valid timestamp");
+        TaskBundle {
+            doc: TaskFileDocument {
+                schema_version: TASK_SCHEMA_VERSION,
+                id: task_id.to_string(),
+                parent_id: None,
+                task_type: TaskType::Task,
+                priority: TaskPriority::Medium,
+                complexity: None,
+                title: format!("Task {task_id}"),
+                description: "Sample task".to_string(),
+                acceptance_criteria: Vec::new(),
+                context_files: Vec::new(),
+                workspace_path: None,
+                repo_root: None,
+                created_by: None,
+                actor_identity: ActorIdentity::default(),
+                agent: None,
+                model: None,
+                assigned_to: None,
+                proposed_by: None,
+                pr_number: None,
+                pr_status: None,
+                source_task_id: None,
+                batch_id: None,
+                created_at: timestamp,
+                updated_at: timestamp,
+                history: Vec::new(),
+                comments: Vec::new(),
+                review_threads: Vec::new(),
+            },
+            plan: "plan".to_string(),
+            execution_summary: String::new(),
+        }
     }
 }


### PR DESCRIPTION
## Tasks
### T20260331-011517: Add explicit permissions block to GitHub Actions workflows
<details><summary>Execution Summary</summary>

## Status
success

## 1. Summary of Changes
Added an explicit top-level `permissions` block to `.github/workflows/ci.yml` so the CI workflow now requests only `contents: read`. This brings the workflow in line with least-privilege expectations and addresses the CodeQL missing-workflow-permissions finding.

## 2. Strategic Decisions
- Restricted permissions at the workflow top level to `contents: read` | Rationale: the CI jobs only need to read repository contents for checkout, build, lint, and test steps | Trade-offs: future jobs that need broader access must opt in explicitly rather than inheriting broader defaults.
- Applied the change only to `.github/workflows/ci.yml` | Rationale: repository inspection confirmed it is the only workflow file in scope today | Trade-offs: if new workflows are added later, they must set permissions explicitly as well.

## 3. Assumptions Made
- The parallel-batch worktree at `/Users/daniel/workspace/repos/orbit/.orbit/worktrees/parallel-batch` is the correct place to apply the change despite `orbit.task.show` reporting the main repo path as `workspace_path` | Impact if incorrect: the intended checkout would remain unmodified.
- Deferred verification will be completed by the batch finalization phase | Impact if incorrect: this workflow change could reach review without a full validation pass.

## 4. Design Weaknesses / Risks
- Workflow behavior was not executed in this activity because `verification_mode` was `deferred` | Severity: Low | Mitigation: run the normal finalization verification before merge.
- A future CI step may require additional token scopes and fail until it declares them explicitly | Severity: Low | Mitigation: add granular per-job permissions only when a concrete need appears.

## 5. Deviations from Original Plan
- Skipped runtime validation commands from the plan | Justification: the execution envelope set `verification_mode` to `deferred`, so build/test/lint verification must wait for finalization.

## 6. Technical Debt Introduced
None

## 7. Recommended Follow-Ups
- Run the batch finalization verification so the restricted CI permissions are exercised in the full pipeline.
- Align parallel-batch task metadata so `orbit.task.show` returns the assigned worktree path for implementation jobs.

</details>

### T20260331-005204: Partition done/archived/rejected task directories by yyyy-mm
<details><summary>Execution Summary</summary>

## Status
success

## 1. Summary of Changes
Updated task file storage so `done`, `archived`, and `rejected` now resolve task directories through a `yyyy-mm` partition derived from the task ID. `list_tasks` now walks those partition directories and lazily migrates legacy flat terminal-state task folders into the new layout. `locate_task` now finds partitioned tasks by ID alone and migrates legacy flat directories on access. Added focused unit tests covering partitioned path generation and legacy migration behavior.

## 2. Strategic Decisions
- Used lazy automatic migration during listing and lookup instead of introducing a separate CLI migration command | Rationale: kept the change scoped to `task_store.rs` and upgraded existing data transparently | Trade-offs: untouched legacy directories are not migrated until they are accessed.
- Derived partition paths from task IDs instead of task metadata files | Rationale: task IDs already encode the timestamp needed for month bucketing and keep lookup cheap | Trade-offs: malformed IDs fall back to flat paths instead of being partitioned.

## 3. Assumptions Made
- The parallel batch worktree at /Users/daniel/workspace/repos/orbit/.orbit/worktrees/parallel-batch is the correct implementation checkout even though `orbit.task.show` reported /Users/daniel/workspace/repos/orbit as `workspace_path` | Impact if incorrect: downstream automation may inspect a different checkout than the one that received this change.
- Terminal-state directories only need a single `yyyy-mm` partition layer | Impact if incorrect: a future storage migration would be needed for finer-grained sharding.

## 4. Design Weaknesses / Risks
- Lazy migration only runs when terminal-state tasks are listed or looked up | Severity: Medium | Mitigation: add an explicit maintenance command later if eager full-disk migration becomes necessary.
- Duplicate legacy and partitioned directories for the same task ID now surface as a store error during migration | Severity: Low | Mitigation: repair conflicting on-disk data before rerunning the operation.

## 5. Deviations from Original Plan
- Added unit tests in `task_store.rs` in addition to the planned production changes | Justification: there were no existing task_store tests in scope, and this storage change benefits from local regression coverage.
- Did not run `cargo test` or clippy because `verification_mode` was `deferred` | Justification: the execution envelope explicitly deferred verification to the batch finalization phase.

## 6. Technical Debt Introduced
None

## 7. Recommended Follow-Ups
- Run deferred workspace verification during batch finalization, especially `cargo test --workspace` and the project's normal lint/check gates.
- Resolve friction task `T20260331-013856` so task metadata and batch execution agree on the authoritative workspace path.

</details>

### T20260330-053417: Parallel worker task workspace_path points at non-writable repo root
<details><summary>Execution Summary</summary>

## Status
success

## 1. Summary of Changes
Updated the parallel task pipeline so each selected task's `workspace_path` is set to the shared worker worktree before worker jobs launch, which keeps `orbit.task.show` aligned with the writable sandbox seen by the agent executor. The pipeline now records each task's original `workspace_path` and restores it after the worker phase completes. To support restoring tasks that originally had no workspace, `TaskAutomationUpdate.workspace_path` now uses the store's tri-state update shape and the runtime passes that through unchanged.

## 2. Strategic Decisions
- Set `task.workspace_path` to the shared worktree before dispatching workers | Rationale: `orbit.task.show` should report the same writable path the worker actually uses | Trade-offs: task metadata changes twice during a parallel run.
- Preserve and restore each task's original workspace path instead of hard-coding the repo root on cleanup | Rationale: some tasks may target a subdirectory or have no saved workspace path at all | Trade-offs: the dispatcher now carries a little more per-task state.
- Promote `TaskAutomationUpdate.workspace_path` to a tri-state field | Rationale: restoration needs to distinguish between "clear the workspace path" and "leave it unchanged" | Trade-offs: the automation update API is slightly broader and callers must wrap set operations in `Some(Some(...))`.

## 3. Assumptions Made
- The task description and authored plan are the authoritative requirements because this task has no acceptance criteria yet | Impact if incorrect: a hidden success condition could still be missing.
- Restoring each task's previous `workspace_path` is preferable to normalizing every task back to the repo root | Impact if incorrect: callers expecting repo-root normalization may continue to see their prior task-specific workspace instead.

## 4. Design Weaknesses / Risks
- Verification was deferred for this batch worker, so compile/test regressions are not checked in this activity | Severity: Medium | Mitigation: run the batch finalization verification steps (`cargo test --workspace`, clippy) before moving the batch forward.

## 5. Deviations from Original Plan
- Restored each task to its recorded pre-run `workspace_path` instead of always resetting to `repo_root` | Justification: this avoids corrupting tasks that intentionally point at a subdirectory or that originally had no stored workspace.

## 6. Technical Debt Introduced
None.

## 7. Recommended Follow-Ups
- Let the batch finalization step run the deferred Rust test and lint suite to validate the new workspace metadata flow end to end.
- If future automation needs to clear `repo_root` or other optional task fields, consider extending the same tri-state pattern there as well.

</details>

## Branch Freshness
- Base ref: `agent-main`
- Head ref: `orbit/parallel-batch`
- Behind base: 0
- Ahead of base: 1

## Files Changed
- `.github/workflows/ci.yml`
- `orbit-core/src/runtime/engine.rs`
- `orbit-engine/src/context.rs`
- `orbit-engine/src/executor/automation/parallel.rs`
- `orbit-store/src/file/task_store.rs`

*authored by: codex / gpt-5.4*