### PR TITLE
feat: parallel batch [T20260331-010337]

### DIFF
--- a/orbit-store/src/file/job_store.rs
+++ b/orbit-store/src/file/job_store.rs
@@ -814,11 +814,7 @@ fn validate_max_active_runs(max_active_runs: u32) -> Result<u32, OrbitError> {
 }
 
 fn format_timestamped_id(prefix: &str, now: DateTime<Utc>) -> String {
-    format!(
-        "{prefix}-{}-{:03}",
-        now.format("%Y%m%d-%H%M%S"),
-        now.timestamp_subsec_millis()
-    )
+    format!("{prefix}-{}", now.format("%Y%m%d-%H%M"))
 }
 
 fn id_generation_state() -> &'static Mutex<IdGenerationState> {
@@ -826,15 +822,23 @@ fn id_generation_state() -> &'static Mutex<IdGenerationState> {
     ID_GENERATION_STATE.get_or_init(|| Mutex::new(IdGenerationState::default()))
 }
 
-/// Derive a UTC timestamp from a job ID of the form `job-YYYYMMDD-HHMMSS[-mmm][-N]`.
-/// Falls back to `Utc::now()` for IDs that don't embed a parseable timestamp.
+/// Derive a UTC timestamp from a job ID of the form `job-YYYYMMDD-HHMM[-N]` (new)
+/// or `job-YYYYMMDD-HHMMSS[-mmm][-N]` (legacy). Falls back to `Utc::now()` for IDs
+/// that don't embed a parseable timestamp.
 fn parse_timestamp_from_job_id(job_id: &str) -> DateTime<Utc> {
     let rest = job_id.strip_prefix("job-").unwrap_or(job_id);
     let mut parts = rest.splitn(3, '-');
     let date = parts.next().unwrap_or("");
     let time = parts.next().unwrap_or("");
-    if date.len() == 8 && time.len() == 6 {
-        let s = format!("{date}{time}");
+    if date.len() == 8 {
+        let padded_time = if time.len() == 4 {
+            format!("{time}00")
+        } else if time.len() == 6 {
+            time.to_string()
+        } else {
+            return Utc::now();
+        };
+        let s = format!("{date}{padded_time}");
         if let Ok(ndt) = chrono::NaiveDateTime::parse_from_str(&s, "%Y%m%d%H%M%S") {
             return ndt.and_utc();
         }
@@ -891,18 +895,18 @@ mod tests {
         assert_eq!(job_ids.len(), 2);
         assert_ne!(job_ids[0], job_ids[1]);
         assert!(job_ids.iter().all(|id| id.starts_with("job-")));
-        assert!(
-            job_ids
-                .iter()
-                .all(|id| id.split('-').nth(3).is_some_and(|millis| millis.len() == 3))
-        );
+        // New format: job-YYYYMMDD-HHMM (optionally with -N dedup suffix)
+        assert!(job_ids.iter().all(|id| {
+            let parts: Vec<&str> = id.splitn(4, '-').collect();
+            parts.len() >= 3 && parts[1].len() == 8 && parts[2].len() == 4
+        }));
     }
 
     #[test]
     fn insert_job_run_generates_distinct_ids_for_parallel_threads() {
         let temp_dir = tempdir().expect("create tempdir");
         let store = Arc::new(JobFileStore::new(temp_dir.path().to_path_buf()));
-        let job_id = "job-20260330-060536-000".to_string();
+        let job_id = "job-20260330-0605".to_string();
 
         store
             .add_job(JobCreateParams {
@@ -948,12 +952,9 @@ mod tests {
                     .exists()
             );
             assert!(run_id.starts_with("jrun-"));
-            assert!(
-                run_id
-                    .split('-')
-                    .nth(3)
-                    .is_some_and(|millis| millis.len() == 3)
-            );
+            // New format: jrun-YYYYMMDD-HHMM (optionally with -N dedup suffix)
+            let parts: Vec<&str> = run_id.splitn(4, '-').collect();
+            assert!(parts.len() >= 3 && parts[1].len() == 8 && parts[2].len() == 4);
         }
     }
 }

--- a/orbit-store/src/file/task_store.rs
+++ b/orbit-store/src/file/task_store.rs
@@ -445,7 +445,7 @@ impl TaskFileStore {
     }
 
     fn next_task_id(&self, now: DateTime<Utc>) -> Result<String, OrbitError> {
-        let base = format!("T{}", now.format("%Y%m%d-%H%M%S"));
+        let base = format!("T{}", now.format("%Y%m%d-%H%M"));
         if self.locate_task(&base)?.is_none() {
             return Ok(base);
         }


### PR DESCRIPTION
## Tasks
### T20260331-010337: Shorten job-run and task ID formats to minute granularity
<details><summary>Execution Summary</summary>

## Status
success

## 1. Summary of Changes
Shortened ID formats for job-runs and tasks from second/millisecond granularity to minute granularity:
- `format_timestamped_id()` in `job_store.rs`: changed format from `{prefix}-YYYYMMDD-HHMMSS-mmm` to `{prefix}-YYYYMMDD-HHMM`
- `parse_timestamp_from_job_id()` in `job_store.rs`: updated to handle both new `HHMM` (4-char) and legacy `HHMMSS` (6-char) time formats
- `next_task_id()` in `task_store.rs`: changed format from `TYYYYMMDD-HHMMSS` to `TYYYYMMDD-HHMM`
- Updated 2 tests: replaced millis-length assertions with new HHMM format assertions; updated hardcoded job ID `job-20260330-060536-000` to `job-20260330-0605`

## 2. Strategic Decisions
- Updated `parse_timestamp_from_job_id` to handle both formats | Rationale: backward compatibility for any existing job IDs with old format | Trade-offs: minor extra branching but no migration burden
- Used `splitn(4, -)` in test assertions | Rationale: cleanly separates prefix, date, time, and optional dedup suffix | Trade-offs: none

## 3. Assumptions Made
- The `partition_key()` function in task_store.rs does not need changes | Impact if incorrect: month-based partitioning would break — but verified it extracts bytes 1..4 (year) and 5..6 (month) which are unchanged
- No other files outside context_files reference the ID format patterns | Impact if incorrect: other tests may fail — deferred to batch verification phase

## 4. Design Weaknesses / Risks
- Same-minute ID collisions are handled by the dedup suffix loop, but under extreme parallelism (1024+ jobs in one minute) allocation would fail | Severity: Low | Mitigation: existing error message is clear

## 5. Deviations from Original Plan
None — all five plan steps were followed exactly.

## 6. Technical Debt Introduced
None

## 7. Recommended Follow-Ups
- Run `cargo test -p orbit-store` in batch finalization to confirm all tests pass
- Verify `partition_key("T20260330-0707")` returns `Some("2026-03")` as planned

</details>

## Branch Freshness
- Base ref: `agent-main`
- Head ref: `orbit/parallel-batch`
- Behind base: 0
- Ahead of base: 1

## Files Changed
- `orbit-store/src/file/job_store.rs`
- `orbit-store/src/file/task_store.rs`

*authored by: claude / sonnet*