### PR TITLE
feat: parallel batch [T20260331-014109, T20260331-013856]

### DIFF
--- a/orbit-core/assets/activities/agent_invoke/implement_change.yaml
+++ b/orbit-core/assets/activities/agent_invoke/implement_change.yaml
@@ -20,6 +20,10 @@ activity:
        - Call orbit.task.show with id: input.task_id to fetch the task's title, description,
          acceptance_criteria, plan, context_files, workspace_path, and repo_root.
        - The task's workspace_path is the authoritative implementation workspace.
+       - However, if input.workspace_path is provided (as in parallel batch execution),
+         it takes precedence over the task's workspace_path. This ensures agents work
+         in the correct worktree when running inside a batch pipeline.
+       - Similarly, if input.repo_root is provided, use it over the task's repo_root.
        - The task's plan should already have been authored by the planning phase before
          execution began.
 
@@ -31,7 +35,8 @@ activity:
 
     3. Explore the workspace:
        - Read the files listed in the task's context_files. Understand the existing code before writing.
-       - All relative file and process work should happen inside the task's workspace_path.
+       - All relative file and process work should happen inside the effective workspace_path
+         (input.workspace_path if provided, otherwise the task's workspace_path).
        - If the plan is missing or still placeholder text, stop and return status: "blocked"
          with an execution_summary explaining that the planning phase must be completed first.
 
@@ -108,6 +113,12 @@ activity:
       verification_mode:
         type: string
         description: Optional verification policy. Use `deferred` when this implementation is part of a parallel batch and verification must wait for `finalize_tasks`.
+      workspace_path:
+        type: string
+        description: Override workspace path. When provided (e.g., in parallel batch execution), use this instead of the task's workspace_path.
+      repo_root:
+        type: string
+        description: Override repo root path. When provided, use this instead of the task's repo_root.
   output_schema_json: {}
 
   # ---- execution ----

--- a/orbit-core/src/config/runtime.rs
+++ b/orbit-core/src/config/runtime.rs
@@ -43,11 +43,6 @@ impl RuntimeConfig {
         }
     }
 
-    #[cfg(test)]
-    pub(crate) fn load_from_data_root(data_root: &Path) -> Result<Self, OrbitError> {
-        Self::load_layered(data_root, data_root)
-    }
-
     /// Load config with workspace-replaces-global semantics for execution/approval/user.
     ///
     /// Persistence paths are always derived from the two roots (not configurable).

--- a/orbit-store/src/file/task_store.rs
+++ b/orbit-store/src/file/task_store.rs
@@ -591,10 +591,8 @@ impl TaskFileStore {
     }
 
     fn task_dir(&self, state: TaskStateDir, id: &str) -> PathBuf {
-        if state.is_partitioned() {
-            if let Some(partition) = partition_key(id) {
-                return self.state_dir_path(state).join(partition).join(id);
-            }
+        if state.is_partitioned() && let Some(partition) = partition_key(id) {
+            return self.state_dir_path(state).join(partition).join(id);
         }
         self.state_dir_path(state).join(id)
     }

--- a/orbit-tools/src/builtin/github/pr_checkout.rs
+++ b/orbit-tools/src/builtin/github/pr_checkout.rs
@@ -27,7 +27,7 @@ super::gh_tool! {
         build_exec_request(input)
     }
     response: |_ctx, _input, result| {
-        check_exec_result(&result, "gh pr checkout")?;
+        check_exec_result(result, "gh pr checkout")?;
         Ok(json!({
             "stdout": result.stdout.as_str(),
             "stderr": result.stderr.as_str(),

--- a/orbit-tools/src/builtin/github/pr_close.rs
+++ b/orbit-tools/src/builtin/github/pr_close.rs
@@ -29,7 +29,7 @@ super::gh_tool! {
         build_exec_request(input)
     }
     response: |_ctx, _input, result| {
-        check_exec_result(&result, "gh pr close")?;
+        check_exec_result(result, "gh pr close")?;
         Ok(json!({
             "stdout": result.stdout.as_str(),
             "stderr": result.stderr.as_str(),

--- a/orbit-tools/src/builtin/github/pr_comment.rs
+++ b/orbit-tools/src/builtin/github/pr_comment.rs
@@ -40,7 +40,7 @@ super::gh_tool! {
         build_exec_request(ctx, input)
     }
     response: |_ctx, _input, result| {
-        check_exec_result(&result, "gh pr comment")?;
+        check_exec_result(result, "gh pr comment")?;
         Ok(json!({
             "stdout": result.stdout.as_str(),
             "stderr": result.stderr.as_str(),

--- a/orbit-tools/src/builtin/github/pr_create.rs
+++ b/orbit-tools/src/builtin/github/pr_create.rs
@@ -93,7 +93,7 @@ super::gh_tool! {
         build_exec_request(ctx, input)
     }
     response: |_ctx, _input, result| {
-        check_exec_result(&result, "gh pr create")?;
+        check_exec_result(result, "gh pr create")?;
         Ok(json!({
             "url": result.stdout.trim(),
             "stdout": result.stdout.as_str(),

--- a/orbit-tools/src/builtin/github/pr_merge.rs
+++ b/orbit-tools/src/builtin/github/pr_merge.rs
@@ -71,7 +71,7 @@ super::gh_tool! {
         build_exec_request(input)
     }
     response: |_ctx, _input, result| {
-        check_exec_result(&result, "gh pr merge")?;
+        check_exec_result(result, "gh pr merge")?;
         Ok(json!({
             "stdout": result.stdout.as_str(),
             "stderr": result.stderr.as_str(),


### PR DESCRIPTION
## Tasks
### T20260331-014109: Fix all clippy warnings across workspace
<details><summary>Execution Summary</summary>

## Status
success

## 1. Summary of Changes
Fixed all clippy warnings across the workspace:
- Removed needless `&` borrows from 5 `check_exec_result` calls in orbit-tools github modules (pr_checkout.rs:30, pr_close.rs:32, pr_comment.rs:43, pr_create.rs:96, pr_merge.rs:74)
- Removed dead `load_from_data_root` function (marked `#[cfg(test)]` but never called) from orbit-core/src/config/runtime.rs
- Collapsed nested `if` into `if state.is_partitioned() && let Some(partition) = partition_key(id)` in orbit-store/src/file/task_store.rs:594

## 2. Strategic Decisions
- Remove `load_from_data_root` entirely | Rationale: No test or non-test caller found; keeping it as `#[allow(dead_code)]` would just suppress the signal | Trade-offs: If a future test needs it, it can be re-added trivially from git history
- Use let-chain syntax for collapsible_if fix | Rationale: Direct translation of what clippy suggests; cleaner than restructuring the logic | Trade-offs: Requires Rust edition/version that supports let chains (stabilized 1.88)

## 3. Assumptions Made
- `load_from_data_root` has no hidden callers outside the workspace (e.g., in integration tests or examples) | Impact if incorrect: compile error that will surface in the deferred verification phase
- The Rust toolchain in use supports let-chain syntax (`if cond && let Some(x) = expr`) | Impact if incorrect: compile error caught in deferred verification

## 4. Design Weaknesses / Risks
- Let-chain syntax dependency | Severity: Low | Mitigation: If the toolchain is too old, revert to the two-level `if` nesting (the original form)

## 5. Deviations from Original Plan
None — all six fixes implemented exactly as planned.

## 6. Technical Debt Introduced
None

## 7. Recommended Follow-Ups
- Add `-D warnings` to the CI clippy step to prevent regression
- Verify that the Rust edition in Cargo.toml supports let chains (requires edition 2021+ and rustc ≥ 1.88)

</details>

### T20260331-013856: Task execution workspace_path can conflict with batch worktree path
<details><summary>Execution Summary</summary>

## Status
success

## 1. Summary of Changes
Added `workspace_path` and `repo_root` override fields to `implement_change.yaml` input schema and updated the activity instructions to clarify precedence: when these fields are provided in the job input (as parallel batch workers do), they take precedence over the values stored on the task. This resolves the ambiguity where agents saw the task workspace_path (repo root) but needed to operate in the worktree path injected by the batch executor.

## 2. Strategic Decisions
- Added fields to input_schema_json rather than changing parallel.rs | Rationale: The schema is the contract agents read; parallel.rs already passes the fields correctly. Declaring them makes the override explicit and discoverable. | Trade-offs: No behavioral change to the pipeline; only documentation and schema clarity.
- Instruction update uses "if provided" wording | Rationale: Keeps backwards compatibility — when fields are absent (non-batch runs), the task workspace_path remains authoritative. | Trade-offs: Agents must check for presence; slightly more conditional logic in the prompt.

## 3. Assumptions Made
- parallel.rs already passes workspace_path and repo_root in the job input | Impact if incorrect: agents in batch mode would still lack the override, but the schema addition is still a no-op improvement.

## 4. Design Weaknesses / Risks
- Agents could misread the instruction and always prefer input.workspace_path even when it is empty/null | Severity: Low | Mitigation: Instruction says "if provided", which is unambiguous for most LLMs.

## 5. Deviations from Original Plan
None — all three plan steps were followed exactly. Step 3 (verify parallel.rs) was checked; it already passes the fields.

## 6. Technical Debt Introduced
None

## 7. Recommended Follow-Ups
- Consider adding a similar override pattern to other activities that reference task.workspace_path (e.g., plan_task.yaml) so the pattern is consistent across all pipeline activities.

</details>

## Branch Freshness
- Base ref: `agent-main`
- Head ref: `orbit/parallel-batch`
- Behind base: 0
- Ahead of base: 1

## Files Changed
- `orbit-core/assets/activities/agent_invoke/implement_change.yaml`
- `orbit-core/src/config/runtime.rs`
- `orbit-store/src/file/task_store.rs`
- `orbit-tools/src/builtin/github/pr_checkout.rs`
- `orbit-tools/src/builtin/github/pr_close.rs`
- `orbit-tools/src/builtin/github/pr_comment.rs`
- `orbit-tools/src/builtin/github/pr_create.rs`
- `orbit-tools/src/builtin/github/pr_merge.rs`

*authored by: claude / sonnet*