### PR TITLE
feat: parallel batch [T20260331-0236, T20260331-0233]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -489,12 +489,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
-name = "foldhash"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
-
-[[package]]
 name = "foreign-types"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -613,19 +607,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "getrandom"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "139ef39800118c7683f2fd3c98c1b23c09ae076556b435f8e9064ae108aaeeec"
-dependencies = [
- "cfg-if",
- "libc",
- "r-efi",
- "wasip2",
- "wasip3",
-]
-
-[[package]]
 name = "h2"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -651,15 +632,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 dependencies = [
  "ahash",
-]
-
-[[package]]
-name = "hashbrown"
-version = "0.15.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
-dependencies = [
- "foldhash",
 ]
 
 [[package]]
@@ -907,12 +879,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "id-arena"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
-
-[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -941,8 +907,6 @@ checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
 dependencies = [
  "equivalent",
  "hashbrown 0.16.1",
- "serde",
- "serde_core",
 ]
 
 [[package]]
@@ -984,10 +948,12 @@ checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
 name = "js-sys"
-version = "0.3.88"
+version = "0.3.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7e709f3e3d22866f9c25b3aff01af289b18422cc8b4262fb19103ee80fe513d"
+checksum = "2e04e2ef80ce82e13552136fabeef8a5ed1f985a96805761cbb9a2c34e7664d9"
 dependencies = [
+ "cfg-if",
+ "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
@@ -1025,12 +991,6 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
-
-[[package]]
-name = "leb128fmt"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
@@ -1524,16 +1484,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "prettyplease"
-version = "0.2.37"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
-dependencies = [
- "proc-macro2",
- "syn",
-]
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1703,9 +1653,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.9"
+version = "0.103.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -1761,12 +1711,6 @@ dependencies = [
  "core-foundation-sys",
  "libc",
 ]
-
-[[package]]
-name = "semver"
-version = "1.0.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
 
 [[package]]
 name = "serde"
@@ -1970,7 +1914,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0136791f7c95b1f6dd99f9cc786b91bb81c3800b639b3478e561ddb7be95e5f1"
 dependencies = [
  "fastrand",
- "getrandom 0.4.1",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -2276,12 +2220,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
-name = "unicode-xid"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
-
-[[package]]
 name = "unsafe-libyaml"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2379,19 +2317,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasip3"
-version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
-dependencies = [
- "wit-bindgen",
-]
-
-[[package]]
 name = "wasm-bindgen"
-version = "0.2.111"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec1adf1535672f5b7824f817792b1afd731d7e843d2d04ec8f27e8cb51edd8ac"
+checksum = "0551fc1bb415591e3372d0bc4780db7e587d84e2a7e79da121051c5c4b89d0b0"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -2402,23 +2331,19 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.61"
+version = "0.4.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe88540d1c934c4ec8e6db0afa536876c5441289d7f9f9123d4f065ac1250a6b"
+checksum = "03623de6905b7206edd0a75f69f747f134b7f0a2323392d664448bf2d3c5d87e"
 dependencies = [
- "cfg-if",
- "futures-util",
  "js-sys",
- "once_cell",
  "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.111"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19e638317c08b21663aed4d2b9a2091450548954695ff4efa75bff5fa546b3b1"
+checksum = "7fbdf9a35adf44786aecd5ff89b4563a90325f9da0923236f6104e603c7e86be"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2426,9 +2351,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.111"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c64760850114d03d5f65457e96fc988f11f01d38fbaa51b254e4ab5809102af"
+checksum = "dca9693ef2bab6d4e6707234500350d8dad079eb508dca05530c85dc3a529ff2"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -2439,52 +2364,18 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.111"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60eecd4fe26177cfa3339eb00b4a36445889ba3ad37080c2429879718e20ca41"
+checksum = "39129a682a6d2d841b6c429d0c51e5cb0ed1a03829d8b3d1e69a011e62cb3d3b"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
-name = "wasm-encoder"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
-dependencies = [
- "leb128fmt",
- "wasmparser",
-]
-
-[[package]]
-name = "wasm-metadata"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
-dependencies = [
- "anyhow",
- "indexmap",
- "wasm-encoder",
- "wasmparser",
-]
-
-[[package]]
-name = "wasmparser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
-dependencies = [
- "bitflags",
- "hashbrown 0.15.5",
- "indexmap",
- "semver",
-]
-
-[[package]]
 name = "web-sys"
-version = "0.3.88"
+version = "0.3.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d6bb20ed2d9572df8584f6dc81d68a41a625cadc6f15999d649a70ce7e3597a"
+checksum = "cd70027e39b12f0849461e08ffc50b9cd7688d942c1c8e3c7b22273236b4dd0a"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2678,88 +2569,6 @@ name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
-dependencies = [
- "wit-bindgen-rust-macro",
-]
-
-[[package]]
-name = "wit-bindgen-core"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
-dependencies = [
- "anyhow",
- "heck",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-bindgen-rust"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
-dependencies = [
- "anyhow",
- "heck",
- "indexmap",
- "prettyplease",
- "syn",
- "wasm-metadata",
- "wit-bindgen-core",
- "wit-component",
-]
-
-[[package]]
-name = "wit-bindgen-rust-macro"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
-dependencies = [
- "anyhow",
- "prettyplease",
- "proc-macro2",
- "quote",
- "syn",
- "wit-bindgen-core",
- "wit-bindgen-rust",
-]
-
-[[package]]
-name = "wit-component"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
-dependencies = [
- "anyhow",
- "bitflags",
- "indexmap",
- "log",
- "serde",
- "serde_derive",
- "serde_json",
- "wasm-encoder",
- "wasm-metadata",
- "wasmparser",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-parser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
-dependencies = [
- "anyhow",
- "id-arena",
- "indexmap",
- "log",
- "semver",
- "serde",
- "serde_derive",
- "serde_json",
- "unicode-xid",
- "wasmparser",
-]
 
 [[package]]
 name = "writeable"

--- a/orbit-cli/src/command/task.rs
+++ b/orbit-cli/src/command/task.rs
@@ -921,10 +921,22 @@ pub struct TaskDeleteArgs {
     /// Output as JSON
     #[arg(long)]
     pub json: bool,
+    /// Force deletion without status guard (required for non-proposed/rejected tasks)
+    #[arg(long)]
+    pub force: bool,
 }
 
 impl Execute for TaskDeleteArgs {
     fn execute(self, runtime: &OrbitRuntime) -> Result<(), OrbitError> {
+        let task = runtime.get_task(&self.id)?;
+        if !self.force
+            && !matches!(task.status, TaskStatus::Proposed | TaskStatus::Rejected)
+        {
+            return Err(OrbitError::InvalidInput(format!(
+                "task '{}' is in status '{}'; use --force to delete tasks not in proposed or rejected status",
+                self.id, task.status
+            )));
+        }
         runtime.delete_task(&self.id)?;
         if self.json {
             crate::output::json::print_pretty(&json!({

--- a/orbit-core/src/command/task.rs
+++ b/orbit-core/src/command/task.rs
@@ -1257,4 +1257,59 @@ mod tests {
 
         assert_eq!(task.workspace_path, None);
     }
+
+    #[test]
+    fn reject_from_backlog_succeeds() {
+        let runtime = OrbitRuntime::in_memory().expect("runtime");
+        let task = runtime
+            .add_task_with_status("backlog task", TaskStatus::Backlog)
+            .expect("task");
+
+        let rejected = runtime
+            .reject_task(&task.id, "duplicate".to_string(), None)
+            .expect("reject from backlog should succeed");
+
+        assert_eq!(rejected.status, TaskStatus::Rejected);
+    }
+
+    #[test]
+    fn reject_from_in_progress_succeeds() {
+        let runtime = OrbitRuntime::in_memory().expect("runtime");
+        let task = runtime
+            .add_task_with_status("wip task", TaskStatus::InProgress)
+            .expect("task");
+
+        let rejected = runtime
+            .reject_task(&task.id, "no longer needed".to_string(), None)
+            .expect("reject from in_progress should succeed");
+
+        assert_eq!(rejected.status, TaskStatus::Rejected);
+    }
+
+    #[test]
+    fn reject_from_done_is_disallowed() {
+        let runtime = OrbitRuntime::in_memory().expect("runtime");
+        let task = runtime
+            .add_task_with_status("done task", TaskStatus::Done)
+            .expect("task");
+
+        let err = runtime
+            .reject_task(&task.id, "oops".to_string(), None)
+            .expect_err("reject from done should fail");
+
+        assert!(matches!(err, OrbitError::InvalidInput(_)));
+    }
+
+    #[test]
+    fn delete_task_removes_it() {
+        let runtime = OrbitRuntime::in_memory().expect("runtime");
+        let task = runtime
+            .add_task_with_status("to delete", TaskStatus::Proposed)
+            .expect("task");
+
+        runtime.delete_task(&task.id).expect("delete should succeed");
+
+        let err = runtime.get_task(&task.id).expect_err("task should be gone");
+        assert!(matches!(err, OrbitError::TaskNotFound(_)));
+    }
 }

--- a/orbit-core/src/command/task.rs
+++ b/orbit-core/src/command/task.rs
@@ -577,8 +577,48 @@ impl OrbitRuntime {
                     },
                 ))
             }),
+            TaskStatus::Backlog => self.with_mutation(|| {
+                let task = self.update_task_record(
+                    id,
+                    StoreTaskUpdateParams {
+                        actor: effective_label.clone(),
+                        status: Some(TaskStatus::Rejected),
+                        status_event: Some("backlog_rejected".to_string()),
+                        status_note: Some(reason.clone()),
+                        append_comments: append_comments.clone(),
+                        ..Default::default()
+                    },
+                )?;
+                Ok((
+                    task.clone(),
+                    OrbitEvent::TaskProposalRejected {
+                        id: id.to_string(),
+                        rejected_by: effective_label.clone(),
+                    },
+                ))
+            }),
+            TaskStatus::InProgress => self.with_mutation(|| {
+                let task = self.update_task_record(
+                    id,
+                    StoreTaskUpdateParams {
+                        actor: effective_label.clone(),
+                        status: Some(TaskStatus::Rejected),
+                        status_event: Some("in_progress_rejected".to_string()),
+                        status_note: Some(reason.clone()),
+                        append_comments: append_comments.clone(),
+                        ..Default::default()
+                    },
+                )?;
+                Ok((
+                    task.clone(),
+                    OrbitEvent::TaskProposalRejected {
+                        id: id.to_string(),
+                        rejected_by: effective_label.clone(),
+                    },
+                ))
+            }),
             other => Err(OrbitError::InvalidInput(format!(
-                "task '{id}' is in status '{other}'; reject requires 'proposed' or 'review'"
+                "task '{id}' is in status '{other}'; reject requires 'proposed', 'review', 'backlog', or 'in-progress'"
             ))),
         }?;
 

--- a/orbit-tools/src/builtin/orbit/mod.rs
+++ b/orbit-tools/src/builtin/orbit/mod.rs
@@ -8,6 +8,7 @@ pub mod review_thread_reply;
 pub mod review_thread_resolve;
 pub mod task_add;
 pub mod task_approve;
+pub mod task_delete;
 pub mod task_list;
 pub mod task_reject;
 pub mod task_show;
@@ -35,6 +36,7 @@ pub(super) struct OrbitIdentity {
 pub fn register(registry: &mut ToolRegistry) {
     registry.register(task_add::OrbitTaskAddTool);
     registry.register(task_approve::OrbitTaskApproveTool);
+    registry.register(task_delete::OrbitTaskDeleteTool);
     registry.register(task_start::OrbitTaskStartTool);
     registry.register(task_reject::OrbitTaskRejectTool);
     registry.register(task_show::OrbitTaskShowTool);

--- a/orbit-tools/src/builtin/orbit/task_delete.rs
+++ b/orbit-tools/src/builtin/orbit/task_delete.rs
@@ -1,5 +1,5 @@
 use orbit_exec::ExecRequest;
-use orbit_types::{OrbitError, ToolParam, ToolSchema};
+use orbit_types::{OrbitError, ToolSchema};
 use serde_json::Value;
 
 use crate::{Tool, ToolContext};

--- a/orbit-tools/src/builtin/orbit/task_delete.rs
+++ b/orbit-tools/src/builtin/orbit/task_delete.rs
@@ -1,0 +1,46 @@
+use orbit_exec::ExecRequest;
+use orbit_types::{OrbitError, ToolParam, ToolSchema};
+use serde_json::Value;
+
+use crate::{Tool, ToolContext};
+
+pub struct OrbitTaskDeleteTool;
+
+pub(super) fn build_exec_request(
+    ctx: &ToolContext,
+    input: &Value,
+) -> Result<ExecRequest, OrbitError> {
+    let identity = super::resolve_identity(ctx, input)?;
+    let id = super::required_string(input, &["id"], "id")?;
+
+    let mut args = vec![
+        "task".to_string(),
+        "delete".to_string(),
+        id,
+        "--force".to_string(),
+    ];
+
+    args.push("--json".to_string());
+    Ok(super::orbit_exec_request_with_identity(
+        ctx, args, &identity,
+    ))
+}
+
+impl Tool for OrbitTaskDeleteTool {
+    fn schema(&self) -> ToolSchema {
+        let parameters = super::orbit_id_params("task");
+
+        ToolSchema {
+            name: "orbit.task.delete".to_string(),
+            description: "Permanently delete an Orbit task and return confirmation JSON"
+                .to_string(),
+            parameters,
+            builtin: true,
+        }
+    }
+
+    fn execute(&self, ctx: &ToolContext, input: Value) -> Result<Value, OrbitError> {
+        let req = build_exec_request(ctx, &input)?;
+        super::run_orbit_json_command(req, "orbit task delete")
+    }
+}


### PR DESCRIPTION
## Tasks
### T20260331-0236: Allow task rejection and deletion from any status
<details><summary>Execution Summary</summary>

## Status
success

## 1. Summary of Changes
- Extended `reject_task_with_identity` in `orbit-core/src/command/task.rs` to handle `Backlog` and `InProgress` statuses, adding new match arms with events `backlog_rejected` and `in_progress_rejected` (both emit `TaskProposalRejected` for event compatibility).
- Added `--force` flag to `TaskDeleteArgs` in `orbit-cli/src/command/task.rs` with status guard: non-proposed/rejected tasks require `--force`.
- Created `orbit-tools/src/builtin/orbit/task_delete.rs` — new `orbit.task.delete` tool that passes `--force` automatically (tool invocations are intentional).
- Registered `OrbitTaskDeleteTool` in `orbit-tools/src/builtin/orbit/mod.rs`.

## 2. Strategic Decisions
- Reuse `TaskProposalRejected` event variant for backlog/in-progress rejections | Rationale: the `status_event` field in history already distinguishes source status; no new event variant needed | Trade-offs: slight semantic mismatch in event name, but avoids schema churn.
- `--force` guard in CLI layer, not in `delete_task` core | Rationale: `delete_task` is already unrestricted; the guard is a UX/safety concern for CLI users, not a domain invariant | Trade-offs: tool invocations bypass the guard by passing `--force`, which is the intended behavior.

## 3. Assumptions Made
- `TaskStatus` is already imported in `orbit-cli/src/command/task.rs` at the crate level | Impact if incorrect: compile error, easy fix.
- `orbit.task.delete` tool should not require identity params (no actor attribution needed for hard deletes) | Impact if incorrect: minor DX gap.

## 4. Design Weaknesses / Risks
- Rejecting `Done` or `Archived` tasks is still disallowed (catch-all error) | Severity: Low | Mitigation: Description notes this is acceptable behavior per spec.

## 5. Deviations from Original Plan
- None

## 6. Technical Debt Introduced
- None

## 7. Recommended Follow-Ups
- Add integration tests for backlog/in-progress rejection and force-delete flows.
- Consider adding audit event for hard deletes (currently only `TaskDeleted` in-memory event).

</details>

### T20260331-0233: Upgrade rustls-webpki to fix RUSTSEC-2026-0049 vulnerability
<details><summary>Execution Summary</summary>

## Status
success

## 1. Summary of Changes
Updated `Cargo.lock` only (no `Cargo.toml` changes needed):
- `rustls-webpki` bumped from 0.103.9 → 0.103.10, resolving RUSTSEC-2026-0049 (faulty CRL distribution-point matching).
- Full `wasm-bindgen` ecosystem bumped from 0.2.111 → 0.2.117 and `js-sys` from 0.3.88 → 0.3.94, resolving the two yanked-crate warnings. `wasm-bindgen-futures`, `wasm-bindgen-macro`, `wasm-bindgen-macro-support`, `wasm-bindgen-shared`, and `web-sys` updated in the same pass.

The yanked packages (`js-sys 0.3.88`, `wasm-bindgen 0.2.111`) used strict `=X.Y.Z` semver pins internally, requiring all packages in the ecosystem to be updated together with a single `cargo update` invocation.

## 2. Strategic Decisions
- Updated the full `wasm-bindgen` family atomically | Rationale: `js-sys` and `wasm-bindgen` use exact-version pins (`=X.Y.Z`) between each other, so partial updates fail with a resolver error — all must move together | Trade-offs: Slightly wider change scope, but unavoidable given the pin structure.
- Did not touch `Cargo.toml` | Rationale: `cargo update` is sufficient since all affected crates are transitive dependencies with compatible semver ranges | Trade-offs: None.

## 3. Assumptions Made
- wasm-bindgen 0.2.117 and js-sys 0.3.94 are ABI-compatible with 0.2.111 / 0.3.88 for the features used by reqwest/chrono | Impact if incorrect: compile errors or test failures caught in deferred verification.

## 4. Design Weaknesses / Risks
- Yanked transitive deps recur when upstream crates (reqwest, chrono) pin exact wasm-bindgen versions | Severity: Low | Mitigation: Monitor `cargo audit` in CI; upstream crates will release newer versions as the ecosystem moves.

## 5. Deviations from Original Plan
None. Followed the plan exactly.

## 6. Technical Debt Introduced
None.

## 7. Recommended Follow-Ups
- Run `cargo audit` in the finalization phase to confirm zero vulnerabilities and zero yanked warnings.
- Run `cargo test --workspace` to verify no regressions from the wasm-bindgen bump.

</details>

## Branch Freshness
- Base ref: `agent-main`
- Head ref: `orbit/parallel-batch`
- Behind base: 0
- Ahead of base: 1

## Files Changed
- `Cargo.lock`
- `orbit-cli/src/command/task.rs`
- `orbit-core/src/command/task.rs`
- `orbit-tools/src/builtin/orbit/mod.rs`
- `orbit-tools/src/builtin/orbit/task_delete.rs`

*authored by: claude / sonnet*