### PR TITLE
feat: parallel batch [T20260402-0259, T20260402-0255, T20260402-0250, T20260402-0246]

### DIFF
--- a/orbit-cli/src/command/workspace.rs
+++ b/orbit-cli/src/command/workspace.rs
@@ -262,7 +262,11 @@ mod tests {
         assert_eq!(result2.id, "ws_repo");
 
         let registry = workspace_registry::load_registry_from(&registry_path).expect("registry");
-        assert_eq!(registry.workspaces.len(), 1, "should still have exactly 1 workspace");
+        assert_eq!(
+            registry.workspaces.len(),
+            1,
+            "should still have exactly 1 workspace"
+        );
         assert!(
             registry.workspaces[0].updated_at > first_updated_at,
             "updated_at should be refreshed on re-init"

--- a/orbit-cli/src/command/workspace.rs
+++ b/orbit-cli/src/command/workspace.rs
@@ -103,7 +103,11 @@ impl WorkspaceInitArgs {
         };
 
         let mut registry = workspace_registry::load_registry_from(registry_path)?;
-        workspace_registry::register_workspace(&mut registry, ws)?;
+        if let Some(existing) = registry.workspaces.iter_mut().find(|w| w.id == id) {
+            existing.updated_at = Utc::now();
+        } else {
+            workspace_registry::register_workspace(&mut registry, ws)?;
+        }
         workspace_registry::save_registry_to(&registry, registry_path)?;
 
         Ok(WorkspaceInitResult {
@@ -223,6 +227,49 @@ mod tests {
     use super::*;
 
     #[test]
+    fn workspace_init_is_idempotent() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let repo_root = temp.path().join("repo");
+        std::fs::create_dir_all(repo_root.join(".git")).expect("create .git dir");
+
+        let registry_path = temp.path().join("home/.orbit/workspaces.json");
+
+        // First init
+        let init_args = WorkspaceInitArgs {
+            name: None,
+            base_branch: "main".to_string(),
+        };
+        let result1 = init_args
+            .execute_at_path(&repo_root, &registry_path)
+            .expect("first init should succeed");
+        assert_eq!(result1.id, "ws_repo");
+
+        let registry = workspace_registry::load_registry_from(&registry_path).expect("registry");
+        assert_eq!(registry.workspaces.len(), 1);
+        let first_updated_at = registry.workspaces[0].updated_at;
+
+        // Small delay so updated_at differs
+        std::thread::sleep(std::time::Duration::from_millis(10));
+
+        // Second init — should not error
+        let init_args2 = WorkspaceInitArgs {
+            name: None,
+            base_branch: "main".to_string(),
+        };
+        let result2 = init_args2
+            .execute_at_path(&repo_root, &registry_path)
+            .expect("second init should succeed (idempotent)");
+        assert_eq!(result2.id, "ws_repo");
+
+        let registry = workspace_registry::load_registry_from(&registry_path).expect("registry");
+        assert_eq!(registry.workspaces.len(), 1, "should still have exactly 1 workspace");
+        assert!(
+            registry.workspaces[0].updated_at > first_updated_at,
+            "updated_at should be refreshed on re-init"
+        );
+    }
+
+    #[test]
     fn workspace_init_seeds_default_artifacts_and_registers_workspace() {
         let temp = tempfile::tempdir().expect("tempdir");
         let repo_root = temp.path().join("repo");
@@ -252,8 +299,8 @@ mod tests {
         );
         assert!(orbit_dir.join("jobs").is_dir(), "jobs dir should exist");
         assert!(
-            orbit_dir.join("config.toml").is_file(),
-            "config should be seeded"
+            !orbit_dir.join("config.toml").is_file(),
+            "workspace init should not seed config.toml"
         );
         // Scoreboards are only seeded when scoring.enabled = true in config.
         // The default config template sets scoring.enabled = false, so

--- a/orbit-core/src/command/init.rs
+++ b/orbit-core/src/command/init.rs
@@ -114,8 +114,12 @@ pub fn init_workspace_at_root(
 
     let overwrite = options.force || options.refresh_defaults;
     let refreshed_skill_files = seed_default_skills(&skills_root, &orbit_root, overwrite)?;
-    let config_path = orbit_root.join("config.toml");
-    let created_config = seed_default_config(&config_path)?;
+    let created_config = if options.global_only {
+        let config_path = orbit_root.join("config.toml");
+        seed_default_config(&config_path)?
+    } else {
+        false
+    };
 
     let skill_ids = default_skill_ids();
     let mut created_skills_symlink = false;

--- a/orbit-engine/src/executor/automation/git.rs
+++ b/orbit-engine/src/executor/automation/git.rs
@@ -102,6 +102,29 @@ pub(super) fn fetch_remote_base(repo_root: &Path, base: &str) {
     );
 }
 
+pub(super) fn refresh_local_base_branch(repo_root: &Path, base: &str) {
+    // Best-effort: if pull fails (e.g. no remote, offline, fresh branch),
+    // we continue with whatever the local branch has. The push step will
+    // catch actual divergence later.
+    let _ = run_process(
+        &ExecRequest {
+            program: "git".to_string(),
+            args: vec![
+                "pull".to_string(),
+                "--rebase".to_string(),
+                "origin".to_string(),
+                base.to_string(),
+            ],
+            current_dir: Some(repo_root.to_string_lossy().to_string()),
+            timeout_ms: Some(60_000),
+            stdin_mode: StdinMode::Null,
+            environment_mode: EnvironmentMode::Inherit,
+            debug: false,
+        },
+        &NoSandbox,
+    );
+}
+
 pub(super) fn resolve_worktree_start_point(
     repo_root: &Path,
     base: &str,

--- a/orbit-engine/src/executor/automation/parallel.rs
+++ b/orbit-engine/src/executor/automation/parallel.rs
@@ -6,7 +6,9 @@ use std::time::Duration;
 use orbit_types::{JobRunState, OrbitError, Task, TaskStatus};
 use serde_json::{Value, json};
 
-use super::git::{git_output, git_success, refresh_local_base_branch, resolve_worktree_start_point};
+use super::git::{
+    git_output, git_success, refresh_local_base_branch, resolve_worktree_start_point,
+};
 use crate::context::{RuntimeHost, TaskAutomationUpdate, TaskHost};
 
 const DEFAULT_PARALLEL_BASE: &str = "agent-main";

--- a/orbit-engine/src/executor/automation/parallel.rs
+++ b/orbit-engine/src/executor/automation/parallel.rs
@@ -6,7 +6,7 @@ use std::time::Duration;
 use orbit_types::{JobRunState, OrbitError, Task, TaskStatus};
 use serde_json::{Value, json};
 
-use super::git::{git_output, git_success, resolve_worktree_start_point};
+use super::git::{git_output, git_success, refresh_local_base_branch, resolve_worktree_start_point};
 use crate::context::{RuntimeHost, TaskAutomationUpdate, TaskHost};
 
 const DEFAULT_PARALLEL_BASE: &str = "agent-main";
@@ -58,6 +58,7 @@ pub(super) fn run_parallel_task_pipeline<H: RuntimeHost + TaskHost + Sync + ?Siz
     // Set up the shared worktree before spawning workers.
     let repo_root_str = host.repo_root()?;
     let repo_root = Path::new(&repo_root_str);
+    refresh_local_base_branch(repo_root, &base);
     let shared_worktree = resolve_shared_worktree_path(repo_root)?;
     ensure_shared_worktree(repo_root, &shared_worktree, &base)?;
     let shared_worktree_str = shared_worktree.to_string_lossy().to_string();

--- a/orbit-tools/src/lib.rs
+++ b/orbit-tools/src/lib.rs
@@ -121,13 +121,20 @@ pub trait Tool: Send + Sync {
 /// Returns `Err(OrbitError::InvalidInput)` if the key is absent, not a string,
 /// or contains only whitespace. The returned string is trimmed.
 pub fn require_str(input: &Value, key: &str) -> Result<String, OrbitError> {
-    input
+    let value = input
         .get(key)
-        .and_then(Value::as_str)
-        .map(str::trim)
-        .filter(|s| !s.is_empty())
-        .map(ToString::to_string)
-        .ok_or_else(|| OrbitError::InvalidInput(format!("missing `{key}`")))
+        .ok_or_else(|| OrbitError::InvalidInput(format!("missing `{key}`")))?;
+    // Accept both strings and numbers (agents often pass numeric IDs without quotes).
+    let raw = match value {
+        Value::String(s) => s.clone(),
+        Value::Number(n) => n.to_string(),
+        _ => return Err(OrbitError::InvalidInput(format!("missing `{key}`"))),
+    };
+    let trimmed = raw.trim().to_string();
+    if trimmed.is_empty() {
+        return Err(OrbitError::InvalidInput(format!("missing `{key}`")));
+    }
+    Ok(trimmed)
 }
 
 /// Assert that a process result succeeded, returning a descriptive error if not.
@@ -155,4 +162,40 @@ pub fn map_input_from_pairs(pairs: impl IntoIterator<Item = (String, String)>) -
         map.insert(key, Value::String(value));
     }
     Value::Object(map)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn require_str_accepts_numeric_value() {
+        let input = json!({"pr": 86});
+        assert_eq!(require_str(&input, "pr").unwrap(), "86");
+    }
+
+    #[test]
+    fn require_str_accepts_string_value() {
+        let input = json!({"pr": "86"});
+        assert_eq!(require_str(&input, "pr").unwrap(), "86");
+    }
+
+    #[test]
+    fn require_str_rejects_missing_key() {
+        let input = json!({});
+        assert!(require_str(&input, "pr").is_err());
+    }
+
+    #[test]
+    fn require_str_rejects_empty_string() {
+        let input = json!({"pr": ""});
+        assert!(require_str(&input, "pr").is_err());
+    }
+
+    #[test]
+    fn require_str_rejects_whitespace_only() {
+        let input = json!({"pr": "   "});
+        assert!(require_str(&input, "pr").is_err());
+    }
 }


### PR DESCRIPTION
## Tasks
### T20260402-0259: orbit workspace init should be idempotent
<details><summary>Execution Summary</summary>

## Status
success

## 1. Summary of Changes
Made `orbit workspace init` idempotent by checking if the workspace already exists in the registry before calling `register_workspace`. If it exists, only `updated_at` is refreshed. The `init_workspace_at_root` call still runs unconditionally so default artifacts are always re-seeded.

Also fixed an existing broken test assertion (`config.toml` is not seeded during workspace init since `global_only` defaults to false) and added a new `workspace_init_is_idempotent` test.

## 2. Strategic Decisions
- Put idempotency logic in the caller (`execute_at_path`) rather than modifying `register_workspace` | Rationale: keeps `register_workspace` strict as a safety net for other callers | Trade-offs: each caller that wants idempotency must implement the check, but currently only one caller exists

## 3. Assumptions Made
- The `config.toml` assertion fix (line 254-257) is correct — workspace init with `InitOptions::default()` has `global_only: false` so config is not seeded | Impact if incorrect: test would fail

## 4. Design Weaknesses / Risks
- None significant | Severity: Low | Mitigation: N/A

## 5. Deviations from Original Plan
None

## 6. Technical Debt Introduced
None

## 7. Recommended Follow-Ups
- None

</details>

### T20260402-0255: Pull --rebase base branch before creating shared worktree
<details><summary>Execution Summary</summary>

## Status
success

## 1. Summary of Changes
Added `refresh_local_base_branch` function to `git.rs` that runs `git pull --rebase origin <base>` before worktree creation. Called it from `run_parallel_task_pipeline` in `parallel.rs` immediately before `ensure_shared_worktree`. This ensures the local base branch is synced with the remote so the final push is always a fast-forward.

## 2. Strategic Decisions
- Best-effort pull (ignore failure) | Rationale: Matches `fetch_remote_base` pattern already in the codebase; allows pipeline to work offline or on fresh branches with no remote | Trade-offs: Silent failure means a stale local branch could still cause push rejection, but this is the same behavior as before the fix
- Placed in `git.rs` alongside `fetch_remote_base` | Rationale: Keeps git operations in one module | Trade-offs: None

## 3. Assumptions Made
- The base branch is checked out locally (not detached HEAD) so `git pull --rebase` works | Impact if incorrect: Pull would fail silently (best-effort), falling back to existing behavior

## 4. Design Weaknesses / Risks
- None significant. The best-effort pattern is consistent with existing code.

## 5. Deviations from Original Plan
None

## 6. Technical Debt Introduced
None

## 7. Recommended Follow-Ups
- Consider logging a warning when the pull fails so operators can diagnose connectivity issues

</details>

### T20260402-0250: Fix scope violations: tasks/scoreboard leak to global, config.toml leaks to workspace
<details><summary>Execution Summary</summary>

## Status
success

## 1. Summary of Changes
Gated `seed_default_config` in `init_workspace_at_root` behind `options.global_only` (orbit-core/src/command/init.rs:117-122). Previously, `config.toml` was unconditionally seeded for both global and workspace init. Now it is only seeded when `global_only: true`, preventing workspace init from creating a `config.toml` that could silently override global config.

## 2. Strategic Decisions
- Gate on existing `global_only` flag rather than introducing a new `workspace_only` flag | Rationale: the flag already exists and is set correctly by all callers | Trade-offs: none — simpler than adding new flags

## 3. Assumptions Made
- All workspace init paths pass `global_only: false` (the default) | Impact if incorrect: workspace init would stop getting config.toml (desired outcome, but could break if some workspace path relied on it)
- No workspace-scoped code depends on `.orbit/config.toml` existing | Impact if incorrect: workspace operations could fail if they expect local config

## 4. Design Weaknesses / Risks
- None identified. The change is minimal and follows the existing gating pattern used for scoreboard seeding on line 133.

## 5. Deviations from Original Plan
None

## 6. Technical Debt Introduced
None

## 7. Recommended Follow-Ups
- T20260402-0259 must update the workspace init test that asserts config.toml is seeded during workspace init

</details>

### T20260402-0246: github.pr.view rejects numeric PR input
<details><summary>Execution Summary</summary>

## Status
success

## 1. Summary of Changes
Extended `require_str` in `orbit-tools/src/lib.rs` to accept `Value::Number` in addition to `Value::String`. When a numeric JSON value is provided (e.g. `{"pr": 86}`), it is converted to its string representation. This fixes `github.pr.view` and all other tools that use `require_str` or `require_pr` from rejecting numeric input with a misleading "missing `pr`" error.

Added a `#[cfg(test)]` module with 5 unit tests covering: numeric input, string input, missing key, empty string, and whitespace-only string.

## 2. Strategic Decisions
- Fixed at `require_str` level rather than per-tool | Rationale: single fix covers all tools (`github.pr.*`, `orbit.task.*`, etc.) | Trade-offs: broader blast radius, but the change is backward-compatible since strings still work identically

## 3. Assumptions Made
- `Value::Number::to_string()` produces a clean integer string (e.g. "86") for whole numbers | Impact if incorrect: PR numbers could contain decimals like "86.0", but serde_json preserves integer formatting

## 4. Design Weaknesses / Risks
- None significant | Severity: Low | Mitigation: unit tests cover both input types

## 5. Deviations from Original Plan
None

## 6. Technical Debt Introduced
None

## 7. Recommended Follow-Ups
- Consider updating the orbit-review-pr skill documentation to note that both string and numeric PR values are accepted

</details>

## Branch Freshness
- Base ref: `agent-main`
- Head ref: `orbit/parallel-batch`
- Behind base: 0
- Ahead of base: 1

## Files Changed
- `orbit-cli/src/command/workspace.rs`
- `orbit-core/src/command/init.rs`
- `orbit-engine/src/executor/automation/git.rs`
- `orbit-engine/src/executor/automation/parallel.rs`
- `orbit-tools/src/lib.rs`

*authored by: claude / sonnet*