### PR TITLE
feat: parallel batch [T20260402-0304, T20260402-0208-2, T20260402-0208]

### DIFF
--- a/orbit-cli/src/audit_middleware.rs
+++ b/orbit-cli/src/audit_middleware.rs
@@ -302,6 +302,8 @@ pub fn extract_command_meta(cmd: &Commands) -> CommandMeta {
                 SkillSubcommand::List(_) => ("list", None),
                 SkillSubcommand::Show(args) => ("show", Some(args.name.as_str())),
                 SkillSubcommand::Doctor(_) => ("doctor", None),
+                SkillSubcommand::Link(_) => ("link", None),
+                SkillSubcommand::Unlink(_) => ("unlink", None),
             };
             CommandMeta {
                 command: "skill".to_string(),
@@ -321,6 +323,7 @@ pub fn extract_command_meta(cmd: &Commands) -> CommandMeta {
                 WorkspaceSubcommand::List(_) => "list",
                 WorkspaceSubcommand::Show(_) => "show",
                 WorkspaceSubcommand::Remove(_) => "remove",
+                WorkspaceSubcommand::Teardown(_) => "teardown",
             };
             CommandMeta {
                 command: "workspace".to_string(),

--- a/orbit-cli/src/command/skill.rs
+++ b/orbit-cli/src/command/skill.rs
@@ -1,4 +1,5 @@
 use clap::{Args, Subcommand};
+use orbit_core::command::init::{LinkResult, UnlinkResult};
 use orbit_core::command::skill::{SkillDoctorResult, SkillDoctorStatus};
 use orbit_core::skill_catalog::LoadedSkill;
 use orbit_core::{OrbitError, OrbitRuntime};
@@ -23,6 +24,10 @@ pub enum SkillSubcommand {
     List(SkillListArgs),
     Show(SkillShowArgs),
     Doctor(SkillDoctorArgs),
+    /// Re-create skill symlinks in .agents/skills/ and .claude/skills/
+    Link(SkillLinkArgs),
+    /// Remove skill symlinks from .agents/skills/ and .claude/skills/
+    Unlink(SkillUnlinkArgs),
 }
 
 impl Execute for SkillSubcommand {
@@ -31,6 +36,8 @@ impl Execute for SkillSubcommand {
             SkillSubcommand::List(args) => args.execute(runtime),
             SkillSubcommand::Show(args) => args.execute(runtime),
             SkillSubcommand::Doctor(args) => args.execute(runtime),
+            SkillSubcommand::Link(args) => args.execute(runtime),
+            SkillSubcommand::Unlink(args) => args.execute(runtime),
         }
     }
 }
@@ -145,6 +152,73 @@ impl Execute for SkillDoctorArgs {
         }
         Ok(())
     }
+}
+
+#[derive(Args)]
+pub struct SkillLinkArgs {
+    #[arg(long)]
+    pub json: bool,
+}
+
+impl Execute for SkillLinkArgs {
+    fn execute(self, runtime: &OrbitRuntime) -> Result<(), OrbitError> {
+        let result = orbit_core::command::init::link_skills(&runtime.data_root())?;
+        if self.json {
+            crate::output::json::print_pretty(&link_result_json(&result))
+        } else {
+            if result.linked_count == 0 {
+                println!("Skill symlinks are already up to date.");
+            } else {
+                println!("Linked {} skill(s) in:", result.linked_count);
+                for root in &result.roots {
+                    println!("  {}", root.display());
+                }
+            }
+            Ok(())
+        }
+    }
+}
+
+#[derive(Args)]
+pub struct SkillUnlinkArgs {
+    #[arg(long)]
+    pub json: bool,
+}
+
+impl Execute for SkillUnlinkArgs {
+    fn execute(self, runtime: &OrbitRuntime) -> Result<(), OrbitError> {
+        let result = orbit_core::command::init::unlink_skills(&runtime.data_root())?;
+        if self.json {
+            crate::output::json::print_pretty(&unlink_result_json(&result))
+        } else {
+            if result.removed_count == 0 {
+                println!("No skill symlinks found to remove.");
+            } else {
+                println!("Removed {} skill symlink(s).", result.removed_count);
+            }
+            if !result.cleaned_dirs.is_empty() {
+                println!("Cleaned up empty directories:");
+                for dir in &result.cleaned_dirs {
+                    println!("  {}", dir.display());
+                }
+            }
+            Ok(())
+        }
+    }
+}
+
+fn link_result_json(result: &LinkResult) -> Value {
+    json!({
+        "linked_count": result.linked_count,
+        "roots": result.roots.iter().map(|p| p.display().to_string()).collect::<Vec<_>>(),
+    })
+}
+
+fn unlink_result_json(result: &UnlinkResult) -> Value {
+    json!({
+        "removed_count": result.removed_count,
+        "cleaned_dirs": result.cleaned_dirs.iter().map(|p| p.display().to_string()).collect::<Vec<_>>(),
+    })
 }
 
 fn skill_summary_json(skill: &LoadedSkill) -> Value {

--- a/orbit-cli/src/command/workspace.rs
+++ b/orbit-cli/src/command/workspace.rs
@@ -23,6 +23,8 @@ pub enum WorkspaceSubcommand {
     Show(WorkspaceShowArgs),
     /// Remove a workspace from the registry (does not delete .orbit)
     Remove(WorkspaceRemoveArgs),
+    /// Remove all Orbit artifacts from this workspace
+    Teardown(WorkspaceTeardownArgs),
 }
 
 #[derive(Args)]
@@ -47,6 +49,13 @@ pub struct WorkspaceRemoveArgs {
     pub workspace: String,
 }
 
+#[derive(Args)]
+pub struct WorkspaceTeardownArgs {
+    /// Required flag to confirm destructive operation
+    #[arg(long)]
+    pub confirm: bool,
+}
+
 impl Execute for WorkspaceCommand {
     fn execute(self, runtime: &OrbitRuntime) -> Result<(), OrbitError> {
         match self.command {
@@ -57,6 +66,7 @@ impl Execute for WorkspaceCommand {
             WorkspaceSubcommand::List(args) => args.execute(runtime),
             WorkspaceSubcommand::Show(args) => args.execute(runtime),
             WorkspaceSubcommand::Remove(args) => args.execute(runtime),
+            WorkspaceSubcommand::Teardown(args) => args.execute(runtime),
         }
     }
 }
@@ -200,6 +210,121 @@ impl Execute for WorkspaceRemoveArgs {
         println!("workspace '{}' removed from registry", removed.name);
         Ok(())
     }
+}
+
+impl Execute for WorkspaceTeardownArgs {
+    fn execute(self, runtime: &OrbitRuntime) -> Result<(), OrbitError> {
+        if !self.confirm {
+            return Err(OrbitError::InvalidInput(
+                "teardown is destructive. Pass --confirm to proceed.".to_string(),
+            ));
+        }
+
+        let orbit_dir = runtime.data_root();
+        let global_dir =
+            workspace_registry::global_orbit_dir()?;
+
+        // Safety: never delete the global ~/.orbit/ directory
+        let orbit_canonical =
+            std::fs::canonicalize(&orbit_dir).unwrap_or_else(|_| orbit_dir.clone());
+        let global_canonical =
+            std::fs::canonicalize(&global_dir).unwrap_or_else(|_| global_dir.clone());
+        if orbit_canonical == global_canonical {
+            return Err(OrbitError::InvalidInput(
+                "refusing to teardown the global ~/.orbit/ directory".to_string(),
+            ));
+        }
+
+        // Safety: orbit_dir must end with ".orbit"
+        if orbit_dir.file_name().and_then(|n| n.to_str()) != Some(".orbit") {
+            return Err(OrbitError::InvalidInput(format!(
+                "data root '{}' does not end with .orbit — aborting teardown",
+                orbit_dir.display()
+            )));
+        }
+
+        let repo_root = orbit_dir
+            .parent()
+            .ok_or_else(|| OrbitError::InvalidInput("cannot determine repo root".to_string()))?;
+
+        let mut removed: Vec<String> = Vec::new();
+
+        // 1. Deregister from workspace registry (before deleting .orbit/)
+        let registry_path = workspace_registry::registry_path()?;
+        if registry_path.exists() {
+            let mut registry = workspace_registry::load_registry_from(&registry_path)?;
+            let ws = registry.workspaces.iter().find(|w| {
+                let ws_canonical =
+                    std::fs::canonicalize(&w.orbit_dir).unwrap_or_else(|_| w.orbit_dir.clone());
+                ws_canonical == orbit_canonical
+            });
+            if let Some(ws_id) = ws.map(|w| w.id.clone()) {
+                let ws = workspace_registry::remove_workspace(&mut registry, &ws_id)?;
+                workspace_registry::save_registry_to(&registry, &registry_path)?;
+                removed.push(format!("deregistered workspace '{}' from registry", ws.name));
+            }
+        }
+
+        // 2. Remove skill symlinks from .agents/skills/ and .claude/skills/
+        for dir_name in &[".agents", ".claude"] {
+            let skills_dir = repo_root.join(dir_name).join("skills");
+            if skills_dir.is_dir() {
+                remove_symlinks_in(&skills_dir)?;
+                removed.push(format!("removed symlinks from {}/skills/", dir_name));
+
+                // Remove skills dir if empty
+                if is_dir_empty(&skills_dir) {
+                    std::fs::remove_dir(&skills_dir)
+                        .map_err(|e| OrbitError::Io(e.to_string()))?;
+                }
+                // Remove parent dir if empty
+                let parent = repo_root.join(dir_name);
+                if parent.is_dir() && is_dir_empty(&parent) {
+                    std::fs::remove_dir(&parent)
+                        .map_err(|e| OrbitError::Io(e.to_string()))?;
+                    removed.push(format!("removed empty {}/", dir_name));
+                }
+            }
+        }
+
+        // 3. Delete .orbit/ directory
+        if orbit_dir.is_dir() {
+            std::fs::remove_dir_all(&orbit_dir).map_err(|e| OrbitError::Io(e.to_string()))?;
+            removed.push(format!("deleted {}", orbit_dir.display()));
+        }
+
+        // 4. Print summary
+        println!("teardown complete:");
+        for item in &removed {
+            println!("  - {item}");
+        }
+        if removed.is_empty() {
+            println!("  (nothing to remove)");
+        }
+
+        Ok(())
+    }
+}
+
+/// Remove all symlinks in a directory (non-recursive).
+fn remove_symlinks_in(dir: &std::path::Path) -> Result<(), OrbitError> {
+    let entries = std::fs::read_dir(dir).map_err(|e| OrbitError::Io(e.to_string()))?;
+    for entry in entries {
+        let entry = entry.map_err(|e| OrbitError::Io(e.to_string()))?;
+        let meta =
+            std::fs::symlink_metadata(entry.path()).map_err(|e| OrbitError::Io(e.to_string()))?;
+        if meta.file_type().is_symlink() {
+            std::fs::remove_file(entry.path()).map_err(|e| OrbitError::Io(e.to_string()))?;
+        }
+    }
+    Ok(())
+}
+
+/// Check if a directory is empty.
+fn is_dir_empty(dir: &std::path::Path) -> bool {
+    std::fs::read_dir(dir)
+        .map(|mut entries| entries.next().is_none())
+        .unwrap_or(false)
 }
 
 fn dir_name_or_fallback(path: &std::path::Path) -> String {

--- a/orbit-cli/src/command/workspace.rs
+++ b/orbit-cli/src/command/workspace.rs
@@ -221,8 +221,7 @@ impl Execute for WorkspaceTeardownArgs {
         }
 
         let orbit_dir = runtime.data_root();
-        let global_dir =
-            workspace_registry::global_orbit_dir()?;
+        let global_dir = workspace_registry::global_orbit_dir()?;
 
         // Safety: never delete the global ~/.orbit/ directory
         let orbit_canonical =
@@ -261,7 +260,10 @@ impl Execute for WorkspaceTeardownArgs {
             if let Some(ws_id) = ws.map(|w| w.id.clone()) {
                 let ws = workspace_registry::remove_workspace(&mut registry, &ws_id)?;
                 workspace_registry::save_registry_to(&registry, &registry_path)?;
-                removed.push(format!("deregistered workspace '{}' from registry", ws.name));
+                removed.push(format!(
+                    "deregistered workspace '{}' from registry",
+                    ws.name
+                ));
             }
         }
 
@@ -274,14 +276,12 @@ impl Execute for WorkspaceTeardownArgs {
 
                 // Remove skills dir if empty
                 if is_dir_empty(&skills_dir) {
-                    std::fs::remove_dir(&skills_dir)
-                        .map_err(|e| OrbitError::Io(e.to_string()))?;
+                    std::fs::remove_dir(&skills_dir).map_err(|e| OrbitError::Io(e.to_string()))?;
                 }
                 // Remove parent dir if empty
                 let parent = repo_root.join(dir_name);
                 if parent.is_dir() && is_dir_empty(&parent) {
-                    std::fs::remove_dir(&parent)
-                        .map_err(|e| OrbitError::Io(e.to_string()))?;
+                    std::fs::remove_dir(&parent).map_err(|e| OrbitError::Io(e.to_string()))?;
                     removed.push(format!("removed empty {}/", dir_name));
                 }
             }

--- a/orbit-cli/src/command/workspace.rs
+++ b/orbit-cli/src/command/workspace.rs
@@ -399,6 +399,73 @@ mod tests {
     }
 
     #[test]
+    fn teardown_requires_confirm_flag() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let repo_root = temp.path().join("repo");
+        std::fs::create_dir_all(repo_root.join(".git")).expect("create .git dir");
+        let registry_path = temp.path().join("home/.orbit/workspaces.json");
+
+        let init_args = WorkspaceInitArgs {
+            name: None,
+            base_branch: "main".to_string(),
+        };
+        init_args
+            .execute_at_path(&repo_root, &registry_path)
+            .expect("init");
+
+        let orbit_dir = repo_root.join(".orbit");
+        assert!(orbit_dir.is_dir());
+
+        // Without --confirm, teardown should fail
+        let runtime = OrbitRuntime::from_data_root(&orbit_dir).expect("runtime");
+        let args = WorkspaceTeardownArgs { confirm: false };
+        let err = args.execute(&runtime);
+        assert!(err.is_err(), "teardown without --confirm should fail");
+        assert!(orbit_dir.is_dir(), ".orbit should still exist");
+    }
+
+    #[test]
+    fn teardown_removes_orbit_dir_and_symlinks() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let repo_root = temp.path().join("repo");
+        std::fs::create_dir_all(repo_root.join(".git")).expect("create .git dir");
+        let registry_path = temp.path().join("home/.orbit/workspaces.json");
+
+        let init_args = WorkspaceInitArgs {
+            name: None,
+            base_branch: "main".to_string(),
+        };
+        init_args
+            .execute_at_path(&repo_root, &registry_path)
+            .expect("init");
+
+        let orbit_dir = repo_root.join(".orbit");
+        assert!(orbit_dir.is_dir());
+
+        // Verify symlinks were created
+        assert!(repo_root.join(".agents/skills").is_dir());
+        assert!(repo_root.join(".claude/skills").is_dir());
+
+        // Execute teardown with --confirm
+        let runtime = OrbitRuntime::from_data_root(&orbit_dir).expect("runtime");
+        let args = WorkspaceTeardownArgs { confirm: true };
+        args.execute(&runtime).expect("teardown should succeed");
+
+        // .orbit/ should be gone
+        assert!(!orbit_dir.exists(), ".orbit should be deleted");
+
+        // Symlink dirs should be cleaned up
+        assert!(
+            !repo_root.join(".agents/skills").exists(),
+            ".agents/skills should be gone"
+        );
+        assert!(
+            !repo_root.join(".claude/skills").exists(),
+            ".claude/skills should be gone"
+        );
+    }
+
+    #[test]
     fn workspace_init_seeds_default_artifacts_and_registers_workspace() {
         let temp = tempfile::tempdir().expect("tempdir");
         let repo_root = temp.path().join("repo");

--- a/orbit-core/src/command/init.rs
+++ b/orbit-core/src/command/init.rs
@@ -171,7 +171,7 @@ fn resolve_init_target_from_root(orbit_root: &Path) -> InitTarget {
     }
 }
 
-fn skill_link_roots(base_root: &Path) -> Vec<PathBuf> {
+pub(crate) fn skill_link_roots(base_root: &Path) -> Vec<PathBuf> {
     [".agents", ".claude"]
         .into_iter()
         .map(|dir| base_root.join(dir).join("skills"))
@@ -292,4 +292,98 @@ fn ensure_skill_links(
     }
 
     Ok(changed)
+}
+
+// --- Public link/unlink API ---
+
+#[derive(Debug, Clone)]
+pub struct LinkResult {
+    pub linked_count: usize,
+    pub roots: Vec<PathBuf>,
+}
+
+#[derive(Debug, Clone)]
+pub struct UnlinkResult {
+    pub removed_count: usize,
+    pub cleaned_dirs: Vec<PathBuf>,
+}
+
+/// Re-create skill symlinks in `.agents/skills/` and `.claude/skills/`.
+pub fn link_skills(orbit_root: &Path) -> Result<LinkResult, OrbitError> {
+    let init_target = resolve_init_target_from_root(orbit_root);
+    let skills_root = init_target.orbit_root.join("skills");
+
+    if !skills_root.exists() {
+        return Err(OrbitError::InvalidInput(format!(
+            "skills root does not exist: {}",
+            skills_root.display()
+        )));
+    }
+
+    let skill_ids = default_skill_ids();
+    let mut linked_count = 0usize;
+    let mut roots = Vec::new();
+
+    for skills_links_root in &init_target.skills_links_roots {
+        let changed = ensure_skill_links(&skills_root, &skill_ids, skills_links_root, false)?;
+        if changed {
+            linked_count += skill_ids.len();
+        }
+        roots.push(skills_links_root.clone());
+    }
+
+    Ok(LinkResult {
+        linked_count,
+        roots,
+    })
+}
+
+/// Remove skill symlinks from `.agents/skills/` and `.claude/skills/`.
+/// Only removes symlinks — regular files and directories are left intact.
+pub fn unlink_skills(orbit_root: &Path) -> Result<UnlinkResult, OrbitError> {
+    let init_target = resolve_init_target_from_root(orbit_root);
+    let mut removed_count = 0usize;
+    let mut cleaned_dirs = Vec::new();
+
+    for skills_links_dir in &init_target.skills_links_roots {
+        if !skills_links_dir.exists() {
+            continue;
+        }
+
+        let entries =
+            fs::read_dir(skills_links_dir).map_err(|e| OrbitError::Io(e.to_string()))?;
+
+        for entry in entries {
+            let entry = entry.map_err(|e| OrbitError::Io(e.to_string()))?;
+            let meta =
+                fs::symlink_metadata(entry.path()).map_err(|e| OrbitError::Io(e.to_string()))?;
+            if meta.file_type().is_symlink() {
+                fs::remove_file(entry.path()).map_err(|e| OrbitError::Io(e.to_string()))?;
+                removed_count += 1;
+            }
+        }
+
+        // Clean up empty skills dir, then empty parent (.agents/ or .claude/)
+        if skills_links_dir.exists() && dir_is_empty(skills_links_dir)? {
+            fs::remove_dir(skills_links_dir).map_err(|e| OrbitError::Io(e.to_string()))?;
+            cleaned_dirs.push(skills_links_dir.clone());
+
+            if let Some(parent) = skills_links_dir.parent() {
+                if parent.exists() && dir_is_empty(parent)? {
+                    fs::remove_dir(parent).map_err(|e| OrbitError::Io(e.to_string()))?;
+                    cleaned_dirs.push(parent.to_path_buf());
+                }
+            }
+        }
+    }
+
+    Ok(UnlinkResult {
+        removed_count,
+        cleaned_dirs,
+    })
+}
+
+fn dir_is_empty(path: &Path) -> Result<bool, OrbitError> {
+    let mut entries = fs::read_dir(path).map_err(|e| OrbitError::Io(e.to_string()))?;
+    Ok(entries.next().is_none())
 }

--- a/orbit-core/src/command/init.rs
+++ b/orbit-core/src/command/init.rs
@@ -403,8 +403,14 @@ mod tests {
         // Verify symlinks exist
         let agents_skills = repo_root.join(".agents/skills");
         let claude_skills = repo_root.join(".claude/skills");
-        assert!(agents_skills.is_dir(), ".agents/skills should exist after init");
-        assert!(claude_skills.is_dir(), ".claude/skills should exist after init");
+        assert!(
+            agents_skills.is_dir(),
+            ".agents/skills should exist after init"
+        );
+        assert!(
+            claude_skills.is_dir(),
+            ".claude/skills should exist after init"
+        );
 
         // Place a regular file in .agents/skills/ (should NOT be removed)
         fs::write(agents_skills.join("user_file.txt"), "keep me").expect("write user file");
@@ -458,7 +464,10 @@ mod tests {
 
         // Re-link
         let link_result = link_skills(&orbit_root).expect("link");
-        assert!(link_result.linked_count > 0, "should have re-created symlinks");
+        assert!(
+            link_result.linked_count > 0,
+            "should have re-created symlinks"
+        );
 
         // Verify symlinks are back
         let restored_count = fs::read_dir(repo_root.join(".claude/skills"))

--- a/orbit-core/src/command/init.rs
+++ b/orbit-core/src/command/init.rs
@@ -350,8 +350,7 @@ pub fn unlink_skills(orbit_root: &Path) -> Result<UnlinkResult, OrbitError> {
             continue;
         }
 
-        let entries =
-            fs::read_dir(skills_links_dir).map_err(|e| OrbitError::Io(e.to_string()))?;
+        let entries = fs::read_dir(skills_links_dir).map_err(|e| OrbitError::Io(e.to_string()))?;
 
         for entry in entries {
             let entry = entry.map_err(|e| OrbitError::Io(e.to_string()))?;

--- a/orbit-core/src/command/init.rs
+++ b/orbit-core/src/command/init.rs
@@ -386,3 +386,94 @@ fn dir_is_empty(path: &Path) -> Result<bool, OrbitError> {
     let mut entries = fs::read_dir(path).map_err(|e| OrbitError::Io(e.to_string()))?;
     Ok(entries.next().is_none())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn unlink_removes_only_symlinks() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let repo_root = temp.path().join("repo");
+        fs::create_dir_all(repo_root.join(".git")).expect("create .git");
+
+        let orbit_root = repo_root.join(".orbit");
+        init_workspace_at_root(&orbit_root, InitOptions::default()).expect("init");
+
+        // Verify symlinks exist
+        let agents_skills = repo_root.join(".agents/skills");
+        let claude_skills = repo_root.join(".claude/skills");
+        assert!(agents_skills.is_dir(), ".agents/skills should exist after init");
+        assert!(claude_skills.is_dir(), ".claude/skills should exist after init");
+
+        // Place a regular file in .agents/skills/ (should NOT be removed)
+        fs::write(agents_skills.join("user_file.txt"), "keep me").expect("write user file");
+
+        let result = unlink_skills(&orbit_root).expect("unlink");
+        assert!(result.removed_count > 0, "should have removed symlinks");
+
+        // Regular file should still exist
+        assert!(
+            agents_skills.join("user_file.txt").exists(),
+            "non-symlink file should be preserved"
+        );
+        // .agents/skills/ should still exist (has a regular file)
+        assert!(
+            agents_skills.is_dir(),
+            ".agents/skills should remain (has non-symlink content)"
+        );
+        // .claude/skills/ was only symlinks so it should be cleaned up
+        assert!(
+            !claude_skills.exists(),
+            ".claude/skills should be removed (was empty after unlink)"
+        );
+    }
+
+    #[test]
+    fn link_restores_symlinks_after_unlink() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let repo_root = temp.path().join("repo");
+        fs::create_dir_all(repo_root.join(".git")).expect("create .git");
+
+        let orbit_root = repo_root.join(".orbit");
+        init_workspace_at_root(&orbit_root, InitOptions::default()).expect("init");
+
+        // Count initial symlinks
+        let claude_skills = repo_root.join(".claude/skills");
+        let initial_count = fs::read_dir(&claude_skills)
+            .expect("read")
+            .filter(|e| {
+                e.as_ref()
+                    .ok()
+                    .and_then(|e| fs::symlink_metadata(e.path()).ok())
+                    .map(|m| m.file_type().is_symlink())
+                    .unwrap_or(false)
+            })
+            .count();
+        assert!(initial_count > 0, "should have symlinks after init");
+
+        // Unlink
+        let unlink_result = unlink_skills(&orbit_root).expect("unlink");
+        assert!(unlink_result.removed_count > 0);
+
+        // Re-link
+        let link_result = link_skills(&orbit_root).expect("link");
+        assert!(link_result.linked_count > 0, "should have re-created symlinks");
+
+        // Verify symlinks are back
+        let restored_count = fs::read_dir(repo_root.join(".claude/skills"))
+            .expect("read")
+            .filter(|e| {
+                e.as_ref()
+                    .ok()
+                    .and_then(|e| fs::symlink_metadata(e.path()).ok())
+                    .map(|m| m.file_type().is_symlink())
+                    .unwrap_or(false)
+            })
+            .count();
+        assert_eq!(
+            restored_count, initial_count,
+            "link should restore the same number of symlinks"
+        );
+    }
+}

--- a/orbit-core/src/command/task.rs
+++ b/orbit-core/src/command/task.rs
@@ -101,13 +101,27 @@ impl OrbitRuntime {
             } else {
                 TaskStatus::Backlog
             };
+        let is_friction = params.task_type.is_friction();
+        let (create_actor, create_identity, create_label) = if is_friction {
+            (
+                "system".to_string(),
+                ActorIdentity::System,
+                "system".to_string(),
+            )
+        } else {
+            (
+                effective_label.clone(),
+                ActorIdentity::from_legacy(agent.as_deref(), model.as_deref()),
+                effective_label.clone(),
+            )
+        };
         let comments = build_task_comments(params.comment.clone(), effective_label.as_str())?;
         let workspace_path =
             normalize_workspace_path(&self.paths().repo_root, params.workspace_path.as_deref())?;
 
         let task = self.with_mutation(|| {
             let task = self.create_task_record(StoreTaskCreateParams {
-                actor: effective_label.clone(),
+                actor: create_actor.clone(),
                 parent_id: params.parent_id.clone(),
                 title: params.title.clone(),
                 description: params.description.clone(),
@@ -117,15 +131,15 @@ impl OrbitRuntime {
                 context_files: params.context_files.clone(),
                 workspace_path: workspace_path.clone(),
                 repo_root: None,
-                created_by: Some(effective_label.clone()),
-                actor_identity: ActorIdentity::from_legacy(agent.as_deref(), model.as_deref()),
-                assigned_to: Some(effective_label.clone()),
+                created_by: Some(create_label.clone()),
+                actor_identity: create_identity.clone(),
+                assigned_to: Some(create_label.clone()),
                 status: initial_status,
                 priority: params.priority,
                 complexity: params.complexity,
                 task_type: params.task_type,
                 pr_number: None,
-                proposed_by: Some(effective_label.clone()),
+                proposed_by: Some(create_label.clone()),
                 source_task_id: params.source_task_id.clone(),
                 comments: comments.clone(),
             })?;

--- a/orbit-core/src/command/task.rs
+++ b/orbit-core/src/command/task.rs
@@ -1054,7 +1054,7 @@ mod tests {
         TaskAddParams, TaskUpdateParams, UNAUTHORED_TASK_PLAN_PLACEHOLDER,
         ensure_task_has_execution_plan,
     };
-    use crate::{OrbitError, OrbitRuntime, TaskStatus};
+    use crate::{OrbitError, OrbitRuntime, TaskStatus, TaskType};
     use orbit_engine::{TaskAutomationUpdate, TaskHost};
     use std::fs;
     use std::path::Path;
@@ -1312,6 +1312,80 @@ mod tests {
             .expect_err("reject from done should fail");
 
         assert!(matches!(err, OrbitError::InvalidInput(_)));
+    }
+
+    #[test]
+    fn friction_task_attributes_to_system() {
+        let runtime = OrbitRuntime::in_memory().expect("runtime");
+        let task = runtime
+            .add_task_with_identity(
+                TaskAddParams {
+                    title: "friction report".to_string(),
+                    description: "something is broken".to_string(),
+                    task_type: TaskType::Friction,
+                    ..Default::default()
+                },
+                Some("codex".to_string()),
+                Some("gpt-5.4".to_string()),
+            )
+            .expect("friction task");
+
+        assert_eq!(task.created_by, Some("system".to_string()));
+        assert_eq!(task.proposed_by, Some("system".to_string()));
+        assert_eq!(task.assigned_to, Some("system".to_string()));
+        assert_eq!(
+            task.history.first().map(|h| h.by.as_str()),
+            Some("system"),
+            "history actor should be system for friction tasks"
+        );
+    }
+
+    #[test]
+    fn issue_task_attributes_to_system() {
+        let runtime = OrbitRuntime::in_memory().expect("runtime");
+        let task = runtime
+            .add_task_with_identity(
+                TaskAddParams {
+                    title: "issue report".to_string(),
+                    description: "also friction".to_string(),
+                    task_type: TaskType::Issue,
+                    ..Default::default()
+                },
+                Some("claude".to_string()),
+                Some("opus".to_string()),
+            )
+            .expect("issue task");
+
+        assert_eq!(task.created_by, Some("system".to_string()));
+        assert_eq!(task.proposed_by, Some("system".to_string()));
+        assert_eq!(task.assigned_to, Some("system".to_string()));
+    }
+
+    #[test]
+    fn non_friction_task_attributes_to_agent() {
+        let runtime = OrbitRuntime::in_memory().expect("runtime");
+        let task = runtime
+            .add_task_with_identity(
+                TaskAddParams {
+                    title: "normal task".to_string(),
+                    description: "not friction".to_string(),
+                    task_type: TaskType::Feature,
+                    ..Default::default()
+                },
+                Some("codex".to_string()),
+                Some("gpt-5.4".to_string()),
+            )
+            .expect("non-friction task");
+
+        // Non-friction tasks should use the agent identity
+        assert_ne!(task.created_by, Some("system".to_string()));
+        assert_ne!(task.proposed_by, Some("system".to_string()));
+        assert_ne!(task.assigned_to, Some("system".to_string()));
+        assert_eq!(
+            task.created_by,
+            Some("codex / gpt-5.4".to_string()),
+            "non-friction tasks should use agent label"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Tasks
### T20260402-0304: Friction tasks created by orbit should attribute created_by to system, not the invoking agent
<details><summary>Execution Summary</summary>

## Status
success

## 1. Summary of Changes
Modified `add_task_with_identity` in `orbit-core/src/command/task.rs` to override `created_by`, `proposed_by`, `assigned_to`, `actor` (history event attribution), and `actor_identity` to `"system"` / `ActorIdentity::System` when the task type is friction. Non-friction tasks are unaffected. The friction bounty scoreboard call already uses the raw `agent`/`model` parameters (not the overridden fields), so reporter attribution for scoring continues to work correctly.

## 2. Strategic Decisions
- Override at the core layer (`add_task_with_identity`) rather than the tool layer | Rationale: single point of change regardless of how tasks are created | Trade-offs: tool layer callers cannot opt out, but that is the desired behavior
- Use a tuple destructure for the three related fields | Rationale: keeps the conditional compact and ensures all fields are consistently set | Trade-offs: slightly more verbose than individual if-else per field, but safer

## 3. Assumptions Made
- `is_friction()` is the correct predicate for identifying friction-type tasks | Impact if incorrect: wrong task types would get system attribution
- Comments should still use `effective_label` (the agent identity) rather than system | Impact if incorrect: comment attribution would be wrong, but comments are informational and this preserves the reporter trail

## 4. Design Weaknesses / Risks
- No dedicated `reported_by` field on the task struct | Severity: Low | Mitigation: the friction bounty scoreboard already captures reporter identity separately; a dedicated field could be added later if needed

## 5. Deviations from Original Plan
None

## 6. Technical Debt Introduced
None

## 7. Recommended Follow-Ups
- Consider adding a `reported_by` field to the Task struct for explicit reporter attribution visible in task YAML

</details>

### T20260402-0208-2: Add orbit teardown command to remove all .orbit artifacts
<details><summary>Execution Summary</summary>

## Status
success

## 1. Summary of Changes
Added `orbit workspace teardown` subcommand to `orbit-cli/src/command/workspace.rs`. The command:
- Requires `--confirm` flag (returns error without it)
- Validates the orbit dir is not the global `~/.orbit/` and ends with `.orbit`
- Deregisters the workspace from the global registry before deletion
- Removes symlinks from `.agents/skills/` and `.claude/skills/`
- Cleans up empty `.agents/` and `.claude/` directories
- Deletes the `.orbit/` directory
- Prints a summary of all removed artifacts

Also added two helper functions: `remove_symlinks_in()` and `is_dir_empty()`.
Also added `Teardown` arm to `audit_middleware.rs` workspace match (integration fix during finalization).

## 2. Strategic Decisions
- Deregister before deleting .orbit/ | Rationale: registry needs orbit_dir path to match | Trade-offs: none
- Only remove symlinks (not regular files) from skills dirs | Rationale: user may have non-Orbit files in those dirs | Trade-offs: leaves non-symlink files behind
- Use canonicalize for path comparison | Rationale: handles symlinks and relative paths | Trade-offs: fails gracefully to uncanonicalized path

## 3. Assumptions Made
- `runtime.data_root()` returns the workspace `.orbit/` dir, not global | Impact if incorrect: could delete wrong directory (mitigated by safety checks)
- Skill symlinks are only in `.agents/skills/` and `.claude/skills/` | Impact if incorrect: orphaned symlinks elsewhere

## 4. Design Weaknesses / Risks
- No dry-run mode | Severity: Low | Mitigation: --confirm flag prevents accidental execution

## 5. Deviations from Original Plan
None

## 6. Technical Debt Introduced
None

## 7. Recommended Follow-Ups
- Add tests for teardown (init then teardown, verify cleanup)
- Consider adding --dry-run flag for previewing what would be removed

</details>

### T20260402-0208: Add orbit skills unlink/link commands
<details><summary>Execution Summary</summary>

## Status
success

## 1. Summary of Changes
Added `orbit skill link` and `orbit skill unlink` subcommands. `unlink` removes skill symlinks from `.agents/skills/` and `.claude/skills/` (only symlinks, not regular files) and cleans up empty directories. `link` re-creates the symlinks using the existing `ensure_skill_links` logic.

Changes in two files:
- `orbit-core/src/command/init.rs`: Added public `link_skills()` and `unlink_skills()` functions, plus `LinkResult`/`UnlinkResult` structs. Made `skill_link_roots` `pub(crate)`.
- `orbit-cli/src/command/skill.rs`: Added `Link` and `Unlink` variants to `SkillSubcommand` with `--json` output support.
- `orbit-cli/src/audit_middleware.rs`: Added `Link` and `Unlink` arms to the skill subcommand match (integration fix during finalization).

## 2. Strategic Decisions
- Reuse existing `ensure_skill_links` and `resolve_init_target_from_root` | Rationale: avoids duplicating symlink creation logic | Trade-offs: couples link command to init internals
- Clean up empty parent dirs after unlink | Rationale: avoids leaving orphaned `.agents/` and `.claude/` dirs | Trade-offs: minimal risk since only empty dirs are removed

## 3. Assumptions Made
- `runtime.data_root()` is the correct orbit root for resolving symlink targets | Impact if incorrect: symlinks would point to wrong skills directory

## 4. Design Weaknesses / Risks
- None significant | Severity: Low | Mitigation: n/a

## 5. Deviations from Original Plan
- Did not make `resolve_init_target_from_root` pub(crate) — it is only called internally by the new public functions | Justification: minimizes API surface
- Added audit_middleware.rs arms (integration fix) — parallel batch agent missed exhaustive match | Justification: required for compilation

## 6. Technical Debt Introduced
None

## 7. Recommended Follow-Ups
- Add unit tests for `link_skills` and `unlink_skills`

</details>

## Branch Freshness
- Base ref: `agent-main`
- Head ref: `orbit/parallel-batch`
- Behind base: 0
- Ahead of base: 1

## Files Changed
- `orbit-cli/src/audit_middleware.rs`
- `orbit-cli/src/command/skill.rs`
- `orbit-cli/src/command/workspace.rs`
- `orbit-core/src/command/init.rs`
- `orbit-core/src/command/task.rs`

*authored by: claude / sonnet*