### PR TITLE
feat: parallel batch [T20260402-0330, T20260402-0324]

### DIFF
--- a/orbit-core/assets/activities/automation/pull_batch_changes.yaml
+++ b/orbit-core/assets/activities/automation/pull_batch_changes.yaml
@@ -1,0 +1,32 @@
+schema_version: 1
+
+# ---- metadata ----
+created_by: system
+
+# ---- activity ----
+activity:
+  # ---- registration ----
+  id: pull_batch_changes
+  spec_type: automation
+
+  # ---- content ----
+  description: "Pull latest remote commits with rebase in the shared batch worktree."
+
+  # ---- interface ----
+  input_schema_json:
+    type: object
+    required:
+      - run_id
+    properties:
+      run_id:
+        type: string
+        description: Batch run ID (batch_id). The shared worktree and branch are resolved from batch task metadata.
+      workspace_path:
+        type: string
+        description: Optional explicit workspace path. If omitted, resolved from batch task metadata.
+  output_schema_json:
+    type: object
+    properties: {}
+
+  # ---- execution ----
+  action: pull_batch_changes

--- a/orbit-core/assets/jobs/job_batch_review_loop.yaml
+++ b/orbit-core/assets/jobs/job_batch_review_loop.yaml
@@ -29,6 +29,11 @@ job:
     base: agent-main
   steps:
     - target_type: activity
+      target_id: pull_batch_changes
+      condition: always
+      timeout_seconds: 120
+
+    - target_type: activity
       target_id: implement_batch_fix
       agent_cli: claude
       model: opus

--- a/orbit-core/assets/skills/orbit-track-issues/SKILL.md
+++ b/orbit-core/assets/skills/orbit-track-issues/SKILL.md
@@ -56,6 +56,7 @@ orbit tool run orbit.task.add --input '{
   "description": "<what happened, where, and why it caused friction>",
   "type": "friction",
   "priority": "<low|medium|high|critical>",
+  "workspace": ".",
   "agent": "<agent>",
   "model": "<model>"
 }'

--- a/orbit-core/src/command/activity.rs
+++ b/orbit-core/src/command/activity.rs
@@ -68,6 +68,10 @@ pub(crate) const DEFAULT_ACTIVITY_FILES: &[(&str, &str)] = &[
         include_str!("../../assets/activities/automation/commit_batch_changes.yaml"),
     ),
     (
+        "pull_batch_changes",
+        include_str!("../../assets/activities/automation/pull_batch_changes.yaml"),
+    ),
+    (
         "push_batch_changes",
         include_str!("../../assets/activities/automation/push_batch_changes.yaml"),
     ),

--- a/orbit-engine/src/executor/automation/mod.rs
+++ b/orbit-engine/src/executor/automation/mod.rs
@@ -6,6 +6,7 @@ mod git;
 mod input;
 mod parallel;
 mod pr;
+mod pull;
 mod push;
 pub(crate) mod review;
 mod snapshot;
@@ -30,6 +31,7 @@ const AUTOMATION_SNAPSHOT_BATCH_STATE: &str = "snapshot_batch_state";
 const AUTOMATION_MERGE_BATCH_PR: &str = "merge_batch_pr";
 const AUTOMATION_CHECK_BATCH_REVIEW_DECISION: &str = "check_batch_review_decision";
 const AUTOMATION_SYNC_BATCH_REVIEW_TO_GITHUB: &str = "sync_batch_review_to_github";
+const AUTOMATION_PULL_BATCH_CHANGES: &str = "pull_batch_changes";
 const AUTOMATION_PUSH_BATCH_CHANGES: &str = "push_batch_changes";
 
 #[derive(Debug, Clone, Deserialize)]
@@ -99,6 +101,7 @@ pub fn execute<H: crate::context::RuntimeHost + crate::context::TaskHost + Sync 
         AUTOMATION_SYNC_BATCH_REVIEW_TO_GITHUB => {
             sync_review::sync_batch_review_to_github(host, input)
         }
+        AUTOMATION_PULL_BATCH_CHANGES => pull::pull_batch_changes(host, input),
         AUTOMATION_PUSH_BATCH_CHANGES => push::push_batch_changes(host, input),
         other => Err(OrbitError::InvalidInput(format!(
             "unsupported automation action '{other}'"

--- a/orbit-engine/src/executor/automation/pull.rs
+++ b/orbit-engine/src/executor/automation/pull.rs
@@ -24,3 +24,194 @@ pub(super) fn pull_batch_changes<H: RuntimeHost + ?Sized>(
     git_success(&workspace_path, &["pull", "--rebase"])?;
     Ok(json!({}))
 }
+
+#[cfg(test)]
+mod tests {
+    use std::path::Path;
+    use std::process::Command;
+
+    use serde_json::json;
+
+    use orbit_types::{OrbitError, OrbitEvent};
+
+    use super::pull_batch_changes;
+    use crate::context::RuntimeHost;
+
+    struct StubHost {
+        repo_root: String,
+    }
+
+    impl RuntimeHost for StubHost {
+        fn record_event(&self, _event: OrbitEvent) -> Result<(), OrbitError> {
+            Ok(())
+        }
+        fn repo_root(&self) -> Result<String, OrbitError> {
+            Ok(self.repo_root.clone())
+        }
+        fn data_root(&self) -> &Path {
+            Path::new(".")
+        }
+        fn acquire_file_locks(
+            &self,
+            _task_id: &str,
+            _repo_root: &str,
+            _paths: &[&str],
+        ) -> Result<(), OrbitError> {
+            Ok(())
+        }
+        fn release_file_locks(&self, _task_id: &str) -> Result<usize, OrbitError> {
+            Ok(0)
+        }
+        fn cleanup_stale_file_locks(&self) -> Result<usize, OrbitError> {
+            Ok(0)
+        }
+        fn run_job_now_with_input_debug(
+            &self,
+            _job_id: &str,
+            _input: serde_json::Value,
+            _debug: bool,
+        ) -> Result<crate::context::JobRunResult, OrbitError> {
+            unimplemented!()
+        }
+        fn validate_activity_target_exists(
+            &self,
+            _target_type: orbit_types::JobTargetType,
+            _target_id: &str,
+        ) -> Result<orbit_types::Activity, OrbitError> {
+            unimplemented!()
+        }
+        fn get_job(&self, _job_id: &str) -> Result<Option<orbit_types::Job>, OrbitError> {
+            Ok(None)
+        }
+        fn run_tool_with_context_and_role(
+            &self,
+            _name: &str,
+            _input: serde_json::Value,
+            _role: orbit_types::Role,
+            _tool_context: orbit_tools::ToolContext,
+        ) -> Result<serde_json::Value, OrbitError> {
+            unimplemented!()
+        }
+        fn maybe_create_failure_task(
+            &self,
+            _job_id: &str,
+            _run_id: &str,
+            _error_code: &str,
+            _error_message: &str,
+            _agent: Option<&str>,
+            _model: Option<&str>,
+        ) -> Result<(), OrbitError> {
+            Ok(())
+        }
+        fn scoring_enabled(&self) -> bool {
+            false
+        }
+        fn scoreboard_dir(&self) -> &Path {
+            Path::new(".")
+        }
+    }
+
+    fn run_git(dir: &Path, args: &[&str]) {
+        let status = Command::new("git")
+            .args(args)
+            .current_dir(dir)
+            .status()
+            .expect("run git");
+        assert!(status.success(), "git {:?} failed", args);
+    }
+
+    #[test]
+    fn pull_rebase_syncs_remote_commits() {
+        // Set up a bare "remote" and a "worktree" clone.
+        let remote_dir = tempfile::tempdir().expect("tempdir");
+        let work_dir = tempfile::tempdir().expect("tempdir");
+
+        // Init bare remote
+        run_git(remote_dir.path(), &["init", "--bare"]);
+
+        // Clone remote into work_dir
+        let work_path = work_dir.path().join("repo");
+        let status = Command::new("git")
+            .args([
+                "clone",
+                &remote_dir.path().to_string_lossy(),
+                &work_path.to_string_lossy(),
+            ])
+            .status()
+            .expect("clone");
+        assert!(status.success());
+
+        run_git(&work_path, &["config", "user.name", "Test"]);
+        run_git(&work_path, &["config", "user.email", "test@test.com"]);
+
+        // Create initial commit and push
+        std::fs::write(work_path.join("file.txt"), "v1\n").expect("write");
+        run_git(&work_path, &["add", "file.txt"]);
+        run_git(&work_path, &["commit", "-m", "initial"]);
+        run_git(&work_path, &["push", "-u", "origin", "HEAD"]);
+
+        // Simulate a CI commit pushed to the remote by cloning again and pushing
+        let ci_dir = tempfile::tempdir().expect("tempdir");
+        let ci_path = ci_dir.path().join("ci");
+        let status = Command::new("git")
+            .args([
+                "clone",
+                &remote_dir.path().to_string_lossy(),
+                &ci_path.to_string_lossy(),
+            ])
+            .status()
+            .expect("clone ci");
+        assert!(status.success());
+
+        run_git(&ci_path, &["config", "user.name", "CI"]);
+        run_git(&ci_path, &["config", "user.email", "ci@test.com"]);
+        std::fs::write(ci_path.join("formatted.txt"), "auto-format\n").expect("write");
+        run_git(&ci_path, &["add", "formatted.txt"]);
+        run_git(&ci_path, &["commit", "-m", "style: auto-format"]);
+        run_git(&ci_path, &["push"]);
+
+        // Now the work_dir is 1 commit behind. Pull should sync it.
+        let host = StubHost { repo_root: work_path.to_string_lossy().to_string() };
+        let input = json!({ "workspace_path": work_path.to_string_lossy() });
+        let result = pull_batch_changes(&host, &input).expect("pull should succeed");
+        assert_eq!(result, json!({}));
+
+        // Verify the CI commit is now in the work_dir
+        assert!(
+            work_path.join("formatted.txt").exists(),
+            "CI commit should be synced into worktree"
+        );
+    }
+
+    #[test]
+    fn pull_rebase_noop_when_up_to_date() {
+        let remote_dir = tempfile::tempdir().expect("tempdir");
+        let work_dir = tempfile::tempdir().expect("tempdir");
+
+        run_git(remote_dir.path(), &["init", "--bare"]);
+
+        let work_path = work_dir.path().join("repo");
+        let status = Command::new("git")
+            .args([
+                "clone",
+                &remote_dir.path().to_string_lossy(),
+                &work_path.to_string_lossy(),
+            ])
+            .status()
+            .expect("clone");
+        assert!(status.success());
+
+        run_git(&work_path, &["config", "user.name", "Test"]);
+        run_git(&work_path, &["config", "user.email", "test@test.com"]);
+        std::fs::write(work_path.join("file.txt"), "v1\n").expect("write");
+        run_git(&work_path, &["add", "file.txt"]);
+        run_git(&work_path, &["commit", "-m", "initial"]);
+        run_git(&work_path, &["push", "-u", "origin", "HEAD"]);
+
+        // Already up-to-date — should succeed as a no-op
+        let host = StubHost { repo_root: work_path.to_string_lossy().to_string() };
+        let input = json!({ "workspace_path": work_path.to_string_lossy() });
+        let result = pull_batch_changes(&host, &input).expect("pull noop should succeed");
+        assert_eq!(result, json!({}));
+    }
+}

--- a/orbit-engine/src/executor/automation/pull.rs
+++ b/orbit-engine/src/executor/automation/pull.rs
@@ -1,0 +1,26 @@
+use std::path::Path;
+
+use orbit_types::OrbitError;
+use serde_json::{Value, json};
+
+use crate::context::RuntimeHost;
+
+use super::git::git_success;
+use super::input::{canonicalize_existing_dir, input_string_field};
+
+pub(super) fn pull_batch_changes<H: RuntimeHost + ?Sized>(
+    host: &H,
+    input: &Value,
+) -> Result<Value, OrbitError> {
+    let workspace_path = match input_string_field(input, "workspace_path") {
+        Some(ws) => canonicalize_existing_dir(&ws, "workspace_path")?,
+        None => {
+            let repo_root_str = host.repo_root()?;
+            let repo_root = Path::new(&repo_root_str);
+            super::parallel::resolve_shared_worktree_path(repo_root)?
+        }
+    };
+
+    git_success(&workspace_path, &["pull", "--rebase"])?;
+    Ok(json!({}))
+}


### PR DESCRIPTION
## Tasks
### T20260402-0330: orbit.task.add requires workspace but orbit-track-issues instructions omit it
<details><summary>Execution Summary</summary>

## Status
success

## 1. Summary of Changes
Added the missing `"workspace": "."` field to the example JSON payload in the `orbit-track-issues` SKILL.md (line 59). This aligns the documented example with the `orbit.task.add` tool's required input schema, preventing `invalid input: missing workspace` errors when agents follow the skill documentation.

## 2. Strategic Decisions
- Added `"."` as the workspace value | Rationale: current working directory is the standard default used elsewhere in Orbit docs | Trade-offs: none

## 3. Assumptions Made
- The `workspace` field accepts `"."` as a valid value for current directory | Impact if incorrect: agents would still get errors, but this is consistent with `orbit-create-task` and the `orbit` skill docs

## 4. Design Weaknesses / Risks
None

## 5. Deviations from Original Plan
None

## 6. Technical Debt Introduced
None

## 7. Recommended Follow-Ups
- Audit other skill SKILL.md files for similar missing required fields in example payloads

</details>

### T20260402-0324: Pull --rebase at start of review loop iteration to sync CI commits
<details><summary>Execution Summary</summary>

## Status
success

## 1. Summary of Changes
Added a `pull_batch_changes` automation activity that runs `git pull --rebase` in the shared batch worktree. This activity is now the first step of `job_batch_review_loop`, ensuring the agent syncs CI auto-format commits before `implement_batch_fix` runs.

Files created:
- `orbit-engine/src/executor/automation/pull.rs` — implements `pull_batch_changes()` following the same pattern as `push.rs`
- `orbit-core/assets/activities/automation/pull_batch_changes.yaml` — activity definition

Files modified:
- `orbit-engine/src/executor/automation/mod.rs` — added `mod pull`, constant, and match arm
- `orbit-core/src/command/activity.rs` — registered `pull_batch_changes` in `DEFAULT_ACTIVITY_FILES`
- `orbit-core/assets/jobs/job_batch_review_loop.yaml` — inserted `pull_batch_changes` as the first step

## 2. Strategic Decisions
- Used `git pull --rebase` without explicit branch arg | Rationale: the worktree is already on the correct branch; `--rebase` keeps history linear | Trade-offs: simpler than specifying origin/branch explicitly, but relies on upstream tracking being set (which `push -u` already ensures)
- Modeled after `push.rs` for consistency | Rationale: same workspace resolution logic, same error patterns | Trade-offs: none

## 3. Assumptions Made
- The worktree branch has an upstream tracking ref set | Impact if incorrect: `git pull --rebase` would fail; mitigated because `push -u` is always used

## 4. Design Weaknesses / Risks
- None identified | The pull is a no-op when already up-to-date, satisfying the acceptance criteria

## 5. Deviations from Original Plan
None

## 6. Technical Debt Introduced
None

## 7. Recommended Follow-Ups
- None

</details>

## Branch Freshness
- Base ref: `agent-main`
- Head ref: `orbit/parallel-batch`
- Behind base: 0
- Ahead of base: 1

## Files Changed
- `orbit-core/assets/activities/automation/pull_batch_changes.yaml`
- `orbit-core/assets/jobs/job_batch_review_loop.yaml`
- `orbit-core/assets/skills/orbit-track-issues/SKILL.md`
- `orbit-core/src/command/activity.rs`
- `orbit-engine/src/executor/automation/mod.rs`
- `orbit-engine/src/executor/automation/pull.rs`

*authored by: claude / sonnet*