### PR TITLE
feat: parallel batch [T20260402-0406, T20260402-0303]

### DIFF
--- a/orbit-cli/src/command/workspace.rs
+++ b/orbit-cli/src/command/workspace.rs
@@ -35,6 +35,9 @@ pub struct WorkspaceInitArgs {
     /// Base branch for this workspace (default: main)
     #[arg(long, default_value = "main")]
     pub base_branch: String,
+    /// Refresh default skills, activities, and jobs without wiping the workspace
+    #[arg(long)]
+    pub refresh_defaults: bool,
 }
 
 #[derive(Args)]
@@ -90,7 +93,13 @@ impl WorkspaceInitArgs {
         registry_path: &std::path::Path,
     ) -> Result<WorkspaceInitResult, OrbitError> {
         let orbit_dir = cwd.join(".orbit");
-        init_workspace_at_root(&orbit_dir, InitOptions::default())?;
+        init_workspace_at_root(
+            &orbit_dir,
+            InitOptions {
+                refresh_defaults: self.refresh_defaults,
+                ..Default::default()
+            },
+        )?;
 
         let tasks_dir = orbit_dir.join("tasks");
         std::fs::create_dir_all(&tasks_dir).map_err(|e| OrbitError::Io(e.to_string()))?;
@@ -363,6 +372,7 @@ mod tests {
         let init_args = WorkspaceInitArgs {
             name: None,
             base_branch: "main".to_string(),
+            refresh_defaults: false,
         };
         let result1 = init_args
             .execute_at_path(&repo_root, &registry_path)
@@ -380,6 +390,7 @@ mod tests {
         let init_args2 = WorkspaceInitArgs {
             name: None,
             base_branch: "main".to_string(),
+            refresh_defaults: false,
         };
         let result2 = init_args2
             .execute_at_path(&repo_root, &registry_path)
@@ -408,6 +419,7 @@ mod tests {
         let init_args = WorkspaceInitArgs {
             name: None,
             base_branch: "main".to_string(),
+            refresh_defaults: false,
         };
         init_args
             .execute_at_path(&repo_root, &registry_path)
@@ -434,6 +446,7 @@ mod tests {
         let init_args = WorkspaceInitArgs {
             name: None,
             base_branch: "main".to_string(),
+            refresh_defaults: false,
         };
         init_args
             .execute_at_path(&repo_root, &registry_path)
@@ -475,6 +488,7 @@ mod tests {
         let init_args = WorkspaceInitArgs {
             name: None,
             base_branch: "main".to_string(),
+            refresh_defaults: false,
         };
 
         let init_result = init_args
@@ -546,5 +560,91 @@ mod tests {
         assert_eq!(workspace.name, "repo");
         assert_eq!(workspace.root, repo_root);
         assert_eq!(workspace.orbit_dir, orbit_dir);
+    }
+
+    #[test]
+    fn workspace_init_refresh_defaults_only_overwrites_default_artifacts_when_requested() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let repo_root = temp.path().join("repo");
+        std::fs::create_dir_all(repo_root.join(".git")).expect("create .git dir");
+
+        let registry_path = temp.path().join("home/.orbit/workspaces.json");
+        WorkspaceInitArgs {
+            name: None,
+            base_branch: "main".to_string(),
+            refresh_defaults: false,
+        }
+        .execute_at_path(&repo_root, &registry_path)
+        .expect("workspace init should succeed");
+
+        let orbit_dir = repo_root.join(".orbit");
+        let skill_path = orbit_dir.join("skills/orbit/SKILL.md");
+        let activity_path = orbit_dir.join("activities/active/implement_change.yaml");
+        let job_path = orbit_dir.join("jobs/jobs/job_parallel_task_worker.yaml");
+        let custom_skill_path = orbit_dir.join("skills/custom/SKILL.md");
+
+        let original_skill = std::fs::read_to_string(&skill_path).expect("read default skill");
+        let original_activity =
+            std::fs::read_to_string(&activity_path).expect("read default activity");
+        let original_job = std::fs::read_to_string(&job_path).expect("read default job");
+        let stale_activity = format!("# stale activity\n{original_activity}");
+        let stale_job = format!("# stale job\n{original_job}");
+
+        std::fs::write(&skill_path, "stale skill\n").expect("write stale skill");
+        std::fs::write(&activity_path, &stale_activity).expect("write stale activity");
+        std::fs::write(&job_path, &stale_job).expect("write stale job");
+        std::fs::create_dir_all(custom_skill_path.parent().expect("custom skill parent"))
+            .expect("create custom skill dir");
+        std::fs::write(&custom_skill_path, "custom skill\n").expect("write custom skill");
+
+        WorkspaceInitArgs {
+            name: None,
+            base_branch: "main".to_string(),
+            refresh_defaults: false,
+        }
+        .execute_at_path(&repo_root, &registry_path)
+        .expect("workspace init without refresh should succeed");
+
+        assert_eq!(
+            std::fs::read_to_string(&skill_path).expect("read stale skill"),
+            "stale skill\n"
+        );
+        assert_eq!(
+            std::fs::read_to_string(&activity_path).expect("read stale activity"),
+            stale_activity
+        );
+        assert_eq!(
+            std::fs::read_to_string(&job_path).expect("read stale job"),
+            stale_job
+        );
+        assert_eq!(
+            std::fs::read_to_string(&custom_skill_path).expect("read custom skill"),
+            "custom skill\n"
+        );
+
+        WorkspaceInitArgs {
+            name: None,
+            base_branch: "main".to_string(),
+            refresh_defaults: true,
+        }
+        .execute_at_path(&repo_root, &registry_path)
+        .expect("workspace init with refresh should succeed");
+
+        assert_eq!(
+            std::fs::read_to_string(&skill_path).expect("read refreshed skill"),
+            original_skill
+        );
+        assert_eq!(
+            std::fs::read_to_string(&activity_path).expect("read refreshed activity"),
+            original_activity
+        );
+        assert_eq!(
+            std::fs::read_to_string(&job_path).expect("read refreshed job"),
+            original_job
+        );
+        assert_eq!(
+            std::fs::read_to_string(&custom_skill_path).expect("read preserved custom skill"),
+            "custom skill\n"
+        );
     }
 }

--- a/orbit-core/src/command/task.rs
+++ b/orbit-core/src/command/task.rs
@@ -105,7 +105,7 @@ impl OrbitRuntime {
         let (create_actor, create_identity, create_label) = if is_friction {
             (
                 "system".to_string(),
-                ActorIdentity::System,
+                ActorIdentity::from_legacy(agent.as_deref(), model.as_deref()),
                 "system".to_string(),
             )
         } else {
@@ -1054,8 +1054,10 @@ mod tests {
         TaskAddParams, TaskUpdateParams, UNAUTHORED_TASK_PLAN_PLACEHOLDER,
         ensure_task_has_execution_plan,
     };
+    use crate::context::ActorIdentity;
     use crate::{OrbitError, OrbitRuntime, TaskStatus, TaskType};
     use orbit_engine::{TaskAutomationUpdate, TaskHost};
+    use serde_json::Value;
     use std::fs;
     use std::path::Path;
 
@@ -1064,6 +1066,37 @@ mod tests {
             .expect("canonical path")
             .to_string_lossy()
             .into_owned()
+    }
+
+    fn scoring_runtime(
+        actor: ActorIdentity,
+        approval_required_for_agent: bool,
+    ) -> (tempfile::TempDir, OrbitRuntime) {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let global_root = temp.path().join("global/.orbit");
+        let workspace_root = temp.path().join("workspace/.orbit");
+        fs::create_dir_all(&global_root).expect("global root");
+        fs::create_dir_all(&workspace_root).expect("workspace root");
+        fs::write(
+            workspace_root.join("config.toml"),
+            format!(
+                "[task.approval]\nrequired_for_agent = {approval_required_for_agent}\ndelegate_approval = false\n\n[scoring]\nenabled = true\n"
+            ),
+        )
+        .expect("config");
+
+        let runtime = OrbitRuntime::from_roots(&global_root, &workspace_root)
+            .expect("runtime")
+            .with_actor(actor);
+        (temp, runtime)
+    }
+
+    fn read_friction_bounty(runtime: &OrbitRuntime) -> Value {
+        serde_json::from_str(
+            &fs::read_to_string(runtime.paths().scoreboard_dir.join("friction_bounty.json"))
+                .expect("scoreboard"),
+        )
+        .expect("valid scoreboard json")
     }
 
     #[test]
@@ -1359,6 +1392,45 @@ mod tests {
         assert_eq!(task.created_by, Some("system".to_string()));
         assert_eq!(task.proposed_by, Some("system".to_string()));
         assert_eq!(task.assigned_to, Some("system".to_string()));
+    }
+
+    #[test]
+    fn issue_task_lifecycle_updates_friction_bounty_scoreboard() {
+        let (_temp, runtime) = scoring_runtime(ActorIdentity::agent("executor"), true);
+        let task = runtime
+            .add_task_with_identity(
+                TaskAddParams {
+                    title: "issue report".to_string(),
+                    description: "friction in orbit".to_string(),
+                    task_type: TaskType::Issue,
+                    ..Default::default()
+                },
+                Some("codex".to_string()),
+                Some("gpt-5.4".to_string()),
+            )
+            .expect("issue task");
+
+        assert_eq!(task.status, TaskStatus::Proposed);
+
+        let scoreboard = read_friction_bounty(&runtime);
+        assert_eq!(scoreboard["issues-reported"]["codex"]["gpt-5.4"], 1);
+
+        runtime
+            .approve_task(&task.id, None, None)
+            .expect("approve proposed issue");
+
+        let scoreboard = read_friction_bounty(&runtime);
+        assert_eq!(scoreboard["issues-reported"]["codex"]["gpt-5.4"], 1);
+        assert_eq!(scoreboard["issues-accepted"]["codex"]["gpt-5.4"], 1);
+
+        runtime
+            .reject_task(&task.id, "not actionable".to_string(), None)
+            .expect("reject backlog issue");
+
+        let scoreboard = read_friction_bounty(&runtime);
+        assert_eq!(scoreboard["issues-reported"]["codex"]["gpt-5.4"], 1);
+        assert_eq!(scoreboard["issues-accepted"]["codex"]["gpt-5.4"], 1);
+        assert_eq!(scoreboard["issues-rejected"]["codex"]["gpt-5.4"], 1);
     }
 
     #[test]

--- a/orbit-store/src/file/friction_bounty.rs
+++ b/orbit-store/src/file/friction_bounty.rs
@@ -80,3 +80,33 @@ fn increment(
 
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        record_friction_accepted, record_friction_rejected, record_friction_reported,
+    };
+    use std::fs;
+
+    use serde_json::Value;
+    use tempfile::tempdir;
+
+    #[test]
+    fn records_metrics_by_agent_and_model() {
+        let dir = tempdir().expect("tempdir");
+
+        record_friction_reported(dir.path(), "codex", "gpt-5.4").expect("reported");
+        record_friction_reported(dir.path(), "codex", "gpt-5.4").expect("reported again");
+        record_friction_accepted(dir.path(), "claude", "opus").expect("accepted");
+        record_friction_rejected(dir.path(), "codex", "gpt-5.4").expect("rejected");
+
+        let scoreboard: Value = serde_json::from_str(
+            &fs::read_to_string(dir.path().join("friction_bounty.json")).expect("scoreboard"),
+        )
+        .expect("valid json");
+
+        assert_eq!(scoreboard["issues-reported"]["codex"]["gpt-5.4"], 2);
+        assert_eq!(scoreboard["issues-accepted"]["claude"]["opus"], 1);
+        assert_eq!(scoreboard["issues-rejected"]["codex"]["gpt-5.4"], 1);
+    }
+}


### PR DESCRIPTION
## Tasks
### T20260402-0406: orbit workspace init does not update stale default artifacts
<details><summary>Execution Summary</summary>

## Status
success

## 1. Summary of Changes
Added `--refresh-defaults` to `orbit workspace init` and threaded it into `InitOptions` so workspace init can overwrite stale default skills, activities, and jobs without forcing a full reset. Added a regression test that proves default artifacts stay stale without the flag, refresh with the flag, and a custom skill is preserved.

## 2. Strategic Decisions
- Reused existing `InitOptions.refresh_defaults` plumbing instead of adding new seeding logic | Rationale: core init already knows how to refresh default artifacts safely | Trade-offs: plain `orbit workspace init` remains conservative unless the flag is passed
- Exercised refresh behavior through the CLI command test in `orbit-cli/src/command/workspace.rs` | Rationale: keeps the test at the user-facing entrypoint that regressed | Trade-offs: relies on end-to-end file mutations instead of smaller unit seams

## 3. Assumptions Made
- Acceptance is satisfied by exposing explicit refresh behavior on `orbit workspace init` rather than changing plain init to auto-refresh stale defaults | Impact if incorrect: a follow-up may still be needed to add automatic stale-default detection
- Preserving a custom skill file is a sufficient regression signal for non-default artifacts are not overwritten in this task scope | Impact if incorrect: add dedicated activity/job preservation tests later

## 4. Design Weaknesses / Risks
- The new regression test covers one representative default activity and job, not every seeded artifact | Severity: Low | Mitigation: expand fixtures if future regressions appear in other defaults
- Workspace init still does not refresh `config.toml` because core init only refreshes defaults with overwrite support for skills, activities, and jobs | Severity: Medium | Mitigation: handle config refresh in a separate scoped task if needed

## 5. Deviations from Original Plan
- Test paths corrected during finalization pass: activity path needed `activities/active/implement_change.yaml` (not flat `activities/implement_change.yaml`) and job path needed `jobs/jobs/job_parallel_task_worker.yaml` to match the actual store layout on disk.

## 6. Technical Debt Introduced
None

## 7. Recommended Follow-Ups
- Consider a separate task for stale `config.toml` refresh behavior if workspace defaults should include config updates

## 8. Overall Assessment
Implementation is complete, correct, and tested. Finalization pass fixed a test path bug that would have caused CI failure.

</details>

### T20260402-0303: Friction bounty scoreboard not auto-updated on friction task lifecycle
<details><summary>Execution Summary</summary>

## Status
success

## 1. Summary of Changes
Added regression coverage for friction bounty scoring in both the storage layer and task lifecycle logic. The new tests verify metric persistence by agent/model key and confirm issue tasks automatically increment reported, accepted, and rejected counters during lifecycle transitions.

## 2. Strategic Decisions
- Added one focused unit test in orbit-store and one lifecycle test in orbit-core | Rationale: covers both JSON persistence and automatic task-hook wiring | Trade-offs: verification spans two crates
- Fixed a root cause bug during finalization: friction tasks stored `actor_identity = System` instead of the real agent identity, so `try_record_friction_transition` could not find the agent name for `issues-accepted`/`issues-rejected` | Rationale: the fix (use `ActorIdentity::from_legacy(agent, model)`) is minimal and does not change `created_by`, `proposed_by`, `assigned_to`, or history entries — only `actor_identity` | Trade-offs: task YAML now serializes `actor_identity` as `codex / gpt-5.4` instead of `system` for friction tasks created with agent identity

## 3. Assumptions Made
- `created_by`, `proposed_by`, `assigned_to`, and history `by` remaining as `system` satisfies the existing test contracts for friction task attribution | Impact if incorrect: existing tests would break, but they all pass
- Storing the real agent identity in `actor_identity` is the correct place for scoring provenance, not in a separate field | Impact if incorrect: a dedicated scoring field could be added in a follow-up

## 4. Design Weaknesses / Risks
- `actor_identity` on friction tasks now encodes the reporting agent, which slightly mixes the notions of creation attribution (always system) and scoring provenance (the reporting agent) | Severity: Low | Mitigation: a dedicated `scoring_agent` field could be added if this causes confusion

## 5. Deviations from Original Plan
- The plan said the implementation was already complete (just needs tests), but the finalization pass found a real bug: `issues-accepted` and `issues-rejected` were never written because `try_record_friction_transition` uses `task.actor_identity` which was `System` for friction tasks

## 6. Technical Debt Introduced
None

## 7. Recommended Follow-Ups
- Consider adding a dedicated `scoring_agent`/`scoring_model` field to `Task` if separating scoring attribution from display attribution becomes important

## 8. Overall Assessment
Scoreboard auto-update now works correctly for all three lifecycle events. The finalization pass identified and fixed the real bug that the parallel batch missed.

</details>

## Branch Freshness
- Base ref: `agent-main`
- Head ref: `orbit/parallel-batch`
- Behind base: 0
- Ahead of base: 1

## Files Changed
- `orbit-cli/src/command/workspace.rs`
- `orbit-core/src/command/task.rs`
- `orbit-store/src/file/friction_bounty.rs`

*authored by: claude / sonnet*