### PR TITLE
feat: parallel batch [T20260402-0425, T20260402-0352]

### DIFF
--- a/orbit-core/src/command/init.rs
+++ b/orbit-core/src/command/init.rs
@@ -367,11 +367,12 @@ pub fn unlink_skills(orbit_root: &Path) -> Result<UnlinkResult, OrbitError> {
             fs::remove_dir(skills_links_dir).map_err(|e| OrbitError::Io(e.to_string()))?;
             cleaned_dirs.push(skills_links_dir.clone());
 
-            if let Some(parent) = skills_links_dir.parent() {
-                if parent.exists() && dir_is_empty(parent)? {
-                    fs::remove_dir(parent).map_err(|e| OrbitError::Io(e.to_string()))?;
-                    cleaned_dirs.push(parent.to_path_buf());
-                }
+            if let Some(parent) = skills_links_dir.parent()
+                && parent.exists()
+                && dir_is_empty(parent)?
+            {
+                fs::remove_dir(parent).map_err(|e| OrbitError::Io(e.to_string()))?;
+                cleaned_dirs.push(parent.to_path_buf());
             }
         }
     }

--- a/orbit-engine/src/executor/automation/pr.rs
+++ b/orbit-engine/src/executor/automation/pr.rs
@@ -1,6 +1,6 @@
 use orbit_store::pr_scoreboard;
 use orbit_tools::ToolContext;
-use orbit_types::{OrbitError, Role, Task, TaskStatus};
+use orbit_types::{OrbitError, ReviewThreadStatus, Role, Task, TaskStatus};
 use serde_json::{Value, json};
 
 use crate::context::{RuntimeHost, TaskAutomationUpdate, TaskHost};
@@ -99,6 +99,14 @@ pub(super) fn merge_batch_pr<H: RuntimeHost + TaskHost + ?Sized>(
         tool_context,
     )?;
 
+    let batch_requires_revision = batch_tasks.iter().any(task_required_revision);
+    let batch_author = batch_tasks.iter().find_map(|task| {
+        Some((
+            task.actor_identity.agent_name()?.to_string(),
+            task.actor_identity.agent_model()?.to_string(),
+        ))
+    });
+
     // Advance ALL batch tasks to Done status
     for task in &batch_tasks {
         host.apply_task_automation_update(
@@ -113,16 +121,16 @@ pub(super) fn merge_batch_pr<H: RuntimeHost + TaskHost + ?Sized>(
                 ..TaskAutomationUpdate::default()
             },
         )?;
+    }
 
-        // Record PR merge to scoreboard for each task's actor identity
-        if host.scoring_enabled()
-            && let (Some(agent), Some(model)) = (
-                task.actor_identity.agent_name(),
-                task.actor_identity.agent_model(),
-            )
-        {
-            let _ = pr_scoreboard::record_pr_merged(host.scoreboard_dir(), agent, model);
-        }
+    if host.scoring_enabled()
+        && let Some((agent, model)) = batch_author
+    {
+        let _ = if batch_requires_revision {
+            pr_scoreboard::record_pr_count_with_revision(host.scoreboard_dir(), &agent, &model)
+        } else {
+            pr_scoreboard::record_pr_count_without_revision(host.scoreboard_dir(), &agent, &model)
+        };
     }
 
     Ok(json!({ "merged": true }))
@@ -300,6 +308,20 @@ fn batch_pr_signature(tasks: &[Task]) -> Option<String> {
     })
 }
 
+fn task_required_revision(task: &Task) -> bool {
+    task.history.iter().any(|entry| {
+        entry.event == "status_changed"
+            && entry.from_status == Some(TaskStatus::Review)
+            && matches!(
+                entry.to_status,
+                Some(TaskStatus::Backlog | TaskStatus::InProgress | TaskStatus::Rejected)
+            )
+    }) || task
+        .review_threads
+        .iter()
+        .any(|thread| thread.status == ReviewThreadStatus::Resolved)
+}
+
 #[cfg(test)]
 mod tests {
     use std::path::{Path, PathBuf};
@@ -309,12 +331,13 @@ mod tests {
     use chrono::Utc;
     use orbit_tools::ToolContext;
     use orbit_types::{
-        Activity, ActorIdentity, Job, JobTargetType, OrbitError, OrbitEvent, Role, Task,
-        TaskPriority, TaskStatus, TaskType,
+        Activity, ActorIdentity, Job, JobTargetType, OrbitError, OrbitEvent, ReviewMessage,
+        ReviewThread, ReviewThreadStatus, Role, Task, TaskHistoryEntry, TaskPriority, TaskStatus,
+        TaskType,
     };
     use serde_json::{Value, json};
 
-    use super::{build_batch_pr_body, merge_batch_pr};
+    use super::{build_batch_pr_body, merge_batch_pr, task_required_revision};
     use crate::context::{JobRunResult, RuntimeHost, TaskAutomationUpdate, TaskHost};
     use crate::executor::automation::freshness::BranchFreshness;
 
@@ -323,6 +346,7 @@ mod tests {
         merge_inputs: Mutex<Vec<Value>>,
         updated_statuses: Mutex<Vec<(String, Option<TaskStatus>)>>,
         scoreboard_dir: PathBuf,
+        scoring_enabled: bool,
     }
 
     impl TestHost {
@@ -332,6 +356,17 @@ mod tests {
                 merge_inputs: Mutex::new(Vec::new()),
                 updated_statuses: Mutex::new(Vec::new()),
                 scoreboard_dir: PathBuf::from("."),
+                scoring_enabled: false,
+            }
+        }
+
+        fn with_scoreboard(tasks: Vec<Task>, scoreboard_dir: PathBuf) -> Self {
+            Self {
+                tasks,
+                merge_inputs: Mutex::new(Vec::new()),
+                updated_statuses: Mutex::new(Vec::new()),
+                scoreboard_dir,
+                scoring_enabled: true,
             }
         }
     }
@@ -475,7 +510,7 @@ mod tests {
         }
 
         fn scoring_enabled(&self) -> bool {
-            false
+            self.scoring_enabled
         }
 
         fn scoreboard_dir(&self) -> &Path {
@@ -514,6 +549,11 @@ mod tests {
             created_at: now,
             updated_at: now,
         }
+    }
+
+    fn scoreboard_value(path: &Path) -> Value {
+        serde_json::from_str(&std::fs::read_to_string(path.join("pr.json")).expect("pr.json"))
+            .expect("valid scoreboard json")
     }
 
     fn init_batch_merge_repo() -> tempfile::TempDir {
@@ -613,5 +653,90 @@ mod tests {
         );
         assert!(body.contains("### T20260330-065846: Task T20260330-065846"));
         assert!(body.ends_with("*authored by: codex / gpt-5.4*"));
+    }
+
+    #[test]
+    fn merge_batch_pr_records_one_without_revision_metric_per_batch_author() {
+        let repo = init_batch_merge_repo();
+        let repo_root = repo.path().to_string_lossy().to_string();
+        let scoreboard_dir = tempfile::tempdir().expect("scoreboard dir");
+
+        let mut first = sample_task("T20260330-063823", "batch-1", &repo_root, "76");
+        first.actor_identity = ActorIdentity::agent("codex", "gpt-5.4");
+        let mut second = sample_task("T20260330-065846", "batch-1", &repo_root, "76");
+        second.actor_identity = ActorIdentity::agent("codex", "gpt-5.4");
+
+        let host =
+            TestHost::with_scoreboard(vec![first, second], scoreboard_dir.path().to_path_buf());
+
+        merge_batch_pr(
+            &host,
+            &json!({
+                "run_id": "batch-1",
+                "base": "agent-main",
+            }),
+        )
+        .expect("merge_batch_pr succeeds");
+
+        let scoreboard = scoreboard_value(scoreboard_dir.path());
+        assert_eq!(
+            scoreboard["pr-count-without-revision"]["codex"]["gpt-5.4"],
+            1
+        );
+        assert!(scoreboard.get("pr-count-with-revision").is_none());
+    }
+
+    #[test]
+    fn merge_batch_pr_records_revision_metric_when_review_threads_were_resolved() {
+        let repo = init_batch_merge_repo();
+        let repo_root = repo.path().to_string_lossy().to_string();
+        let scoreboard_dir = tempfile::tempdir().expect("scoreboard dir");
+
+        let mut task = sample_task("T20260330-063823", "batch-1", &repo_root, "76");
+        task.actor_identity = ActorIdentity::agent("codex", "gpt-5.4");
+        task.review_threads = vec![ReviewThread {
+            thread_id: "rt-1".to_string(),
+            path: Some("orbit-engine/src/executor/automation/pr.rs".to_string()),
+            line: Some(42),
+            status: ReviewThreadStatus::Resolved,
+            messages: vec![ReviewMessage {
+                message_id: "rm-1".to_string(),
+                at: Utc::now(),
+                by: "claude / sonnet".to_string(),
+                body: "Please fix this.".to_string(),
+                github_comment_id: Some(10),
+            }],
+            github_thread_id: Some(10),
+        }];
+
+        let host = TestHost::with_scoreboard(vec![task], scoreboard_dir.path().to_path_buf());
+
+        merge_batch_pr(
+            &host,
+            &json!({
+                "run_id": "batch-1",
+                "base": "agent-main",
+            }),
+        )
+        .expect("merge_batch_pr succeeds");
+
+        let scoreboard = scoreboard_value(scoreboard_dir.path());
+        assert_eq!(scoreboard["pr-count-with-revision"]["codex"]["gpt-5.4"], 1);
+        assert!(scoreboard.get("pr-count-without-revision").is_none());
+    }
+
+    #[test]
+    fn task_required_revision_detects_review_rejection_history() {
+        let mut task = sample_task("T20260330-063823", "batch-1", "/tmp", "76");
+        task.history.push(TaskHistoryEntry {
+            at: Utc::now(),
+            by: "human".to_string(),
+            event: "status_changed".to_string(),
+            note: Some("needs changes".to_string()),
+            from_status: Some(TaskStatus::Review),
+            to_status: Some(TaskStatus::Rejected),
+        });
+
+        assert!(task_required_revision(&task));
     }
 }

--- a/orbit-engine/src/executor/automation/sync_review.rs
+++ b/orbit-engine/src/executor/automation/sync_review.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 
 use orbit_exec::{EnvironmentMode, ExecRequest, NoSandbox, StdinMode, run_process};
+use orbit_store::pr_scoreboard;
 use orbit_types::{OrbitError, ReviewThread};
 use serde_json::{Value, json};
 
@@ -82,6 +83,7 @@ fn sync_task_review_to_github<H: RuntimeHost + TaskHost + ?Sized>(
     let mut synced_count: u64 = 0;
 
     for thread in threads.iter_mut() {
+        let pending_labels = pending_sync_message_labels(thread);
         let thread_synced = sync_thread(
             repo_root,
             &owner_repo,
@@ -91,6 +93,18 @@ fn sync_task_review_to_github<H: RuntimeHost + TaskHost + ?Sized>(
             thread,
         )?;
         synced_count += thread_synced;
+
+        if host.scoring_enabled() {
+            for label in pending_labels {
+                if let Some((agent, model)) = parse_agent_model_label(&label) {
+                    let _ = pr_scoreboard::record_pr_review_comment(
+                        host.scoreboard_dir(),
+                        agent,
+                        model,
+                    );
+                }
+            }
+        }
     }
 
     if synced_count > 0 {
@@ -197,6 +211,37 @@ fn sync_mode_for_thread(
         }
         _ => ThreadSyncMode::General,
     }
+}
+
+fn pending_sync_message_labels(thread: &ReviewThread) -> Vec<String> {
+    let mut labels = Vec::new();
+
+    if thread.github_thread_id.is_none()
+        && let Some(first) = thread.messages.first()
+    {
+        labels.push(first.by.clone());
+    }
+
+    labels.extend(
+        thread
+            .messages
+            .iter()
+            .skip(1)
+            .filter(|message| message.github_comment_id.is_none())
+            .map(|message| message.by.clone()),
+    );
+
+    labels
+}
+
+fn parse_agent_model_label(label: &str) -> Option<(&str, &str)> {
+    let (agent, model) = label.split_once(" / ")?;
+    let agent = agent.trim();
+    let model = model.trim();
+    if agent.is_empty() || model.is_empty() {
+        return None;
+    }
+    Some((agent, model))
 }
 
 fn render_general_comment_body(path: Option<&str>, line: Option<u64>, body: &str) -> String {
@@ -559,11 +604,14 @@ fn json_type_name(value: &Value) -> &'static str {
 mod tests {
     use std::collections::HashMap;
 
+    use chrono::Utc;
+    use orbit_types::{ReviewMessage, ReviewThread, ReviewThreadStatus};
     use serde_json::json;
 
     use super::{
-        ThreadSyncMode, parse_pr_file_patches, patch_supports_right_side_line,
-        render_general_comment_body, sync_mode_for_thread,
+        ThreadSyncMode, parse_agent_model_label, parse_pr_file_patches,
+        patch_supports_right_side_line, pending_sync_message_labels, render_general_comment_body,
+        sync_mode_for_thread,
     };
 
     #[test]
@@ -660,5 +708,54 @@ mod tests {
             Some("@@ -1 +1 @@\n-old\n+new")
         );
         assert!(parsed.get("README.md").is_some_and(|value| value.is_none()));
+    }
+
+    #[test]
+    fn pending_sync_message_labels_collects_only_unsynced_messages() {
+        let thread = ReviewThread {
+            thread_id: "rt-1".to_string(),
+            path: Some("src/lib.rs".to_string()),
+            line: Some(42),
+            status: ReviewThreadStatus::Open,
+            messages: vec![
+                ReviewMessage {
+                    message_id: "rm-1".to_string(),
+                    at: Utc::now(),
+                    by: "claude / sonnet".to_string(),
+                    body: "Needs a test.".to_string(),
+                    github_comment_id: None,
+                },
+                ReviewMessage {
+                    message_id: "rm-2".to_string(),
+                    at: Utc::now(),
+                    by: "codex / gpt-5.4".to_string(),
+                    body: "Added coverage.".to_string(),
+                    github_comment_id: None,
+                },
+                ReviewMessage {
+                    message_id: "rm-3".to_string(),
+                    at: Utc::now(),
+                    by: "claude / sonnet".to_string(),
+                    body: "Looks good.".to_string(),
+                    github_comment_id: Some(33),
+                },
+            ],
+            github_thread_id: None,
+        };
+
+        assert_eq!(
+            pending_sync_message_labels(&thread),
+            vec!["claude / sonnet".to_string(), "codex / gpt-5.4".to_string()]
+        );
+    }
+
+    #[test]
+    fn parse_agent_model_label_requires_agent_and_model() {
+        assert_eq!(
+            parse_agent_model_label("claude / sonnet"),
+            Some(("claude", "sonnet"))
+        );
+        assert_eq!(parse_agent_model_label("human reviewer"), None);
+        assert_eq!(parse_agent_model_label("claude / "), None);
     }
 }

--- a/orbit-engine/src/executor/automation/sync_review.rs
+++ b/orbit-engine/src/executor/automation/sync_review.rs
@@ -603,16 +603,299 @@ fn json_type_name(value: &Value) -> &'static str {
 #[cfg(test)]
 mod tests {
     use std::collections::HashMap;
+    use std::env;
+    use std::fs;
+    use std::os::unix::fs::PermissionsExt;
+    use std::path::{Path, PathBuf};
+    use std::sync::{Mutex, OnceLock};
 
     use chrono::Utc;
-    use orbit_types::{ReviewMessage, ReviewThread, ReviewThreadStatus};
-    use serde_json::json;
+    use orbit_tools::ToolContext;
+    use orbit_types::{
+        Activity, ActorIdentity, Job, JobTargetType, OrbitError, OrbitEvent, ReviewMessage,
+        ReviewThread, ReviewThreadStatus, Role, Task, TaskPriority, TaskStatus, TaskType,
+    };
+    use serde_json::{Value, json};
+    use tempfile::tempdir;
 
     use super::{
         ThreadSyncMode, parse_agent_model_label, parse_pr_file_patches,
         patch_supports_right_side_line, pending_sync_message_labels, render_general_comment_body,
-        sync_mode_for_thread,
+        sync_mode_for_thread, sync_task_review_to_github,
     };
+    use crate::context::{JobRunResult, RuntimeHost, TaskAutomationUpdate, TaskHost};
+
+    static SYNC_REVIEW_ENV_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+
+    struct TestHost {
+        task: Task,
+        scoreboard_dir: PathBuf,
+        scoring_enabled: bool,
+        applied_updates: Mutex<Vec<TaskAutomationUpdate>>,
+    }
+
+    impl TestHost {
+        fn with_scoreboard(task: Task, scoreboard_dir: PathBuf) -> Self {
+            Self {
+                task,
+                scoreboard_dir,
+                scoring_enabled: true,
+                applied_updates: Mutex::new(Vec::new()),
+            }
+        }
+    }
+
+    impl TaskHost for TestHost {
+        fn get_task(&self, task_id: &str) -> Result<Task, OrbitError> {
+            if self.task.id == task_id {
+                Ok(self.task.clone())
+            } else {
+                Err(OrbitError::TaskNotFound(task_id.to_string()))
+            }
+        }
+
+        fn list_tasks_filtered(
+            &self,
+            _status: Option<TaskStatus>,
+            _priority: Option<TaskPriority>,
+            _parent_id: Option<&str>,
+            _batch_id: Option<&str>,
+        ) -> Result<Vec<Task>, OrbitError> {
+            unimplemented!("not used in sync_review tests")
+        }
+
+        fn start_task(
+            &self,
+            _task_id: &str,
+            _note: Option<String>,
+            _comment: Option<String>,
+        ) -> Result<Task, OrbitError> {
+            unimplemented!("not used in sync_review tests")
+        }
+
+        fn update_task_from_activity(
+            &self,
+            _task_id: &str,
+            _status: TaskStatus,
+            _execution_summary: Option<String>,
+            _comment: Option<String>,
+            _note: Option<String>,
+        ) -> Result<Task, OrbitError> {
+            unimplemented!("not used in sync_review tests")
+        }
+
+        fn apply_task_automation_update(
+            &self,
+            _task_id: &str,
+            update: TaskAutomationUpdate,
+        ) -> Result<(), OrbitError> {
+            self.applied_updates
+                .lock()
+                .expect("applied updates lock")
+                .push(update);
+            Ok(())
+        }
+    }
+
+    impl RuntimeHost for TestHost {
+        fn record_event(&self, _event: OrbitEvent) -> Result<(), OrbitError> {
+            Ok(())
+        }
+
+        fn repo_root(&self) -> Result<String, OrbitError> {
+            Ok(self.task.repo_root.clone().unwrap_or_default())
+        }
+
+        fn data_root(&self) -> &Path {
+            Path::new(".")
+        }
+
+        fn acquire_file_locks(
+            &self,
+            _task_id: &str,
+            _repo_root: &str,
+            _paths: &[&str],
+        ) -> Result<(), OrbitError> {
+            Ok(())
+        }
+
+        fn release_file_locks(&self, _task_id: &str) -> Result<usize, OrbitError> {
+            Ok(0)
+        }
+
+        fn cleanup_stale_file_locks(&self) -> Result<usize, OrbitError> {
+            Ok(0)
+        }
+
+        fn run_job_now_with_input_debug(
+            &self,
+            _job_id: &str,
+            _input: Value,
+            _debug: bool,
+        ) -> Result<JobRunResult, OrbitError> {
+            unimplemented!("not used in sync_review tests")
+        }
+
+        fn validate_activity_target_exists(
+            &self,
+            _target_type: JobTargetType,
+            _target_id: &str,
+        ) -> Result<Activity, OrbitError> {
+            unimplemented!("not used in sync_review tests")
+        }
+
+        fn get_job(&self, _job_id: &str) -> Result<Option<Job>, OrbitError> {
+            Ok(None)
+        }
+
+        fn run_tool_with_context_and_role(
+            &self,
+            _name: &str,
+            _input: Value,
+            _role: Role,
+            _tool_context: ToolContext,
+        ) -> Result<Value, OrbitError> {
+            unimplemented!("not used in sync_review tests")
+        }
+
+        fn maybe_create_failure_task(
+            &self,
+            _job_id: &str,
+            _run_id: &str,
+            _error_code: &str,
+            _error_message: &str,
+            _agent: Option<&str>,
+            _model: Option<&str>,
+        ) -> Result<(), OrbitError> {
+            Ok(())
+        }
+
+        fn scoring_enabled(&self) -> bool {
+            self.scoring_enabled
+        }
+
+        fn scoreboard_dir(&self) -> &Path {
+            &self.scoreboard_dir
+        }
+    }
+
+    struct PathGuard {
+        original_path: Option<String>,
+    }
+
+    impl PathGuard {
+        fn prepend(dir: &Path) -> Self {
+            let original_path = env::var("PATH").ok();
+            let mut new_path = dir.display().to_string();
+            if let Some(existing) = &original_path
+                && !existing.is_empty()
+            {
+                new_path.push(':');
+                new_path.push_str(existing);
+            }
+
+            // SAFETY: tests serialize PATH mutation via SYNC_REVIEW_ENV_LOCK.
+            unsafe {
+                env::set_var("PATH", new_path);
+            }
+
+            Self { original_path }
+        }
+    }
+
+    impl Drop for PathGuard {
+        fn drop(&mut self) {
+            match &self.original_path {
+                Some(path) => {
+                    // SAFETY: tests serialize PATH mutation via SYNC_REVIEW_ENV_LOCK.
+                    unsafe {
+                        env::set_var("PATH", path);
+                    }
+                }
+                None => {
+                    // SAFETY: tests serialize PATH mutation via SYNC_REVIEW_ENV_LOCK.
+                    unsafe {
+                        env::remove_var("PATH");
+                    }
+                }
+            }
+        }
+    }
+
+    fn sample_task(task_id: &str, repo_root: &Path) -> Task {
+        let now = Utc::now();
+        Task {
+            id: task_id.to_string(),
+            parent_id: None,
+            title: format!("Task {task_id}"),
+            description: "test".to_string(),
+            acceptance_criteria: vec![],
+            plan: "plan".to_string(),
+            execution_summary: String::new(),
+            context_files: vec![],
+            workspace_path: Some(repo_root.display().to_string()),
+            repo_root: Some(repo_root.display().to_string()),
+            assigned_to: None,
+            created_by: None,
+            actor_identity: ActorIdentity::default(),
+            status: TaskStatus::Review,
+            priority: TaskPriority::Medium,
+            complexity: None,
+            task_type: TaskType::Feature,
+            pr_number: Some("91".to_string()),
+            pr_status: Some("REQUEST_CHANGES".to_string()),
+            proposed_by: None,
+            source_task_id: None,
+            batch_id: Some("batch-1".to_string()),
+            comments: vec![],
+            history: vec![],
+            review_threads: vec![],
+            created_at: now,
+            updated_at: now,
+        }
+    }
+
+    fn scoreboard_value(scoreboard_dir: &Path) -> Value {
+        serde_json::from_str(
+            &fs::read_to_string(scoreboard_dir.join("pr.json")).expect("read scoreboard"),
+        )
+        .expect("valid scoreboard json")
+    }
+
+    fn install_fake_gh(bin_dir: &Path) {
+        let script = r#"#!/bin/sh
+set -eu
+
+if [ "$#" -ge 2 ] && [ "$1" = "repo" ] && [ "$2" = "view" ]; then
+  printf 'orbit/orbit\n'
+  exit 0
+fi
+
+if [ "$#" -ge 3 ] && [ "$1" = "pr" ] && [ "$2" = "view" ]; then
+  printf 'deadbeef\n'
+  exit 0
+fi
+
+if [ "$#" -ge 2 ] && [ "$1" = "api" ] && [ "$2" = "repos/orbit/orbit/pulls/91/files" ]; then
+  printf '[[]]\n'
+  exit 0
+fi
+
+if [ "$#" -ge 2 ] && [ "$1" = "pr" ] && [ "$2" = "comment" ]; then
+  printf 'https://github.com/orbit/orbit/pull/91#issuecomment-123\n'
+  exit 0
+fi
+
+printf 'unexpected gh invocation: %s\n' "$*" >&2
+exit 1
+"#;
+
+        let gh_path = bin_dir.join("gh");
+        fs::write(&gh_path, script).expect("write fake gh");
+        let mut perms = fs::metadata(&gh_path).expect("gh metadata").permissions();
+        perms.set_mode(0o755);
+        fs::set_permissions(&gh_path, perms).expect("chmod fake gh");
+    }
 
     #[test]
     fn patch_supports_right_side_line_matches_context_and_added_lines() {
@@ -757,5 +1040,51 @@ mod tests {
         );
         assert_eq!(parse_agent_model_label("human reviewer"), None);
         assert_eq!(parse_agent_model_label("claude / "), None);
+    }
+
+    #[test]
+    fn sync_task_review_to_github_records_pr_review_comments_in_scoreboard() {
+        let _env_lock = SYNC_REVIEW_ENV_LOCK
+            .get_or_init(|| Mutex::new(()))
+            .lock()
+            .expect("env lock");
+        let repo_dir = tempdir().expect("repo dir");
+        let bin_dir = tempdir().expect("bin dir");
+        let scoreboard_dir = tempdir().expect("scoreboard dir");
+        install_fake_gh(bin_dir.path());
+        let _path_guard = PathGuard::prepend(bin_dir.path());
+
+        let mut task = sample_task("T20260402-0425", repo_dir.path());
+        task.review_threads = vec![ReviewThread {
+            thread_id: "rt-1".to_string(),
+            path: None,
+            line: None,
+            status: ReviewThreadStatus::Open,
+            messages: vec![ReviewMessage {
+                message_id: "rm-1".to_string(),
+                at: Utc::now(),
+                by: "claude / sonnet".to_string(),
+                body: "Please add a behavior-level sync test.".to_string(),
+                github_comment_id: None,
+            }],
+            github_thread_id: None,
+        }];
+
+        let host = TestHost::with_scoreboard(task, scoreboard_dir.path().to_path_buf());
+
+        let synced = sync_task_review_to_github(&host, "T20260402-0425").expect("sync succeeds");
+
+        assert_eq!(synced, 1);
+        let scoreboard = scoreboard_value(scoreboard_dir.path());
+        assert_eq!(scoreboard["pr-review-comments"]["claude"]["sonnet"], 1);
+
+        let updates = host.applied_updates.lock().expect("applied updates");
+        assert_eq!(updates.len(), 1);
+        let threads = updates[0]
+            .review_threads
+            .as_ref()
+            .expect("review threads updated");
+        assert_eq!(threads[0].github_thread_id, Some(123));
+        assert_eq!(threads[0].messages[0].github_comment_id, Some(123));
     }
 }

--- a/orbit-store/src/file/pr_scoreboard.rs
+++ b/orbit-store/src/file/pr_scoreboard.rs
@@ -1,9 +1,9 @@
 //! PR scoreboard auto-increment.
 //!
 //! Updates `.orbit/scoreboard/pr.json` when PR lifecycle events occur:
-//! - **merge**: increment `prs-merged`
-//! - **revision**: increment `revisions` (each review loop iteration)
-//! - **comment resolved**: increment `comments-resolved` (implementer fixed a flagged issue)
+//! - **review comment sync**: increment `pr-review-comments`
+//! - **merge without revision**: increment `pr-count-without-revision`
+//! - **merge with revision**: increment `pr-count-with-revision`
 
 use std::collections::HashMap;
 use std::fs;
@@ -14,27 +14,31 @@ use orbit_types::OrbitError;
 type AgentScores = HashMap<String, HashMap<String, u64>>;
 type Scoreboard = HashMap<String, AgentScores>;
 
-/// Increment the `prs-merged` counter for the given agent/model.
-pub fn record_pr_merged(scoreboard_dir: &Path, agent: &str, model: &str) -> Result<(), OrbitError> {
-    increment(scoreboard_dir, "prs-merged", agent, model)
-}
-
-/// Increment the `revisions` counter for the given agent/model.
-pub fn record_pr_revision(
+/// Increment the `pr-review-comments` counter for the given agent/model.
+pub fn record_pr_review_comment(
     scoreboard_dir: &Path,
     agent: &str,
     model: &str,
 ) -> Result<(), OrbitError> {
-    increment(scoreboard_dir, "revisions", agent, model)
+    increment(scoreboard_dir, "pr-review-comments", agent, model)
 }
 
-/// Increment the `comments-resolved` counter for the given agent/model.
-pub fn record_comment_resolved(
+/// Increment the `pr-count-without-revision` counter for the given agent/model.
+pub fn record_pr_count_without_revision(
     scoreboard_dir: &Path,
     agent: &str,
     model: &str,
 ) -> Result<(), OrbitError> {
-    increment(scoreboard_dir, "comments-resolved", agent, model)
+    increment(scoreboard_dir, "pr-count-without-revision", agent, model)
+}
+
+/// Increment the `pr-count-with-revision` counter for the given agent/model.
+pub fn record_pr_count_with_revision(
+    scoreboard_dir: &Path,
+    agent: &str,
+    model: &str,
+) -> Result<(), OrbitError> {
+    increment(scoreboard_dir, "pr-count-with-revision", agent, model)
 }
 
 fn increment(
@@ -72,4 +76,42 @@ fn increment(
     fs::rename(&tmp, &path).map_err(|e| OrbitError::Io(format!("rename pr.json tmp: {e}")))?;
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use serde_json::Value;
+    use tempfile::tempdir;
+
+    use super::{
+        record_pr_count_with_revision, record_pr_count_without_revision, record_pr_review_comment,
+    };
+
+    #[test]
+    fn records_simplified_pr_metrics_by_agent_and_model() {
+        let dir = tempdir().expect("tempdir");
+
+        record_pr_review_comment(dir.path(), "claude", "sonnet").expect("review comment");
+        record_pr_review_comment(dir.path(), "claude", "sonnet").expect("review comment again");
+        record_pr_count_without_revision(dir.path(), "codex", "gpt-5.4")
+            .expect("merged without revision");
+        record_pr_count_with_revision(dir.path(), "codex", "gpt-5.4")
+            .expect("merged with revision");
+
+        let scoreboard: Value =
+            serde_json::from_str(&fs::read_to_string(dir.path().join("pr.json")).expect("pr.json"))
+                .expect("valid json");
+
+        assert_eq!(scoreboard["pr-review-comments"]["claude"]["sonnet"], 2);
+        assert_eq!(
+            scoreboard["pr-count-without-revision"]["codex"]["gpt-5.4"],
+            1
+        );
+        assert_eq!(scoreboard["pr-count-with-revision"]["codex"]["gpt-5.4"], 1);
+        assert!(scoreboard.get("prs-merged").is_none());
+        assert!(scoreboard.get("revisions").is_none());
+        assert!(scoreboard.get("comments-resolved").is_none());
+    }
 }

--- a/orbit-store/src/lib.rs
+++ b/orbit-store/src/lib.rs
@@ -39,7 +39,7 @@ pub mod friction_bounty {
 
 pub mod pr_scoreboard {
     pub use crate::file::pr_scoreboard::{
-        record_comment_resolved, record_pr_merged, record_pr_revision,
+        record_pr_count_with_revision, record_pr_count_without_revision, record_pr_review_comment,
     };
 }
 


### PR DESCRIPTION
## Tasks
### T20260402-0425: Automate simplified PR scoreboard metrics
<details><summary>Execution Summary</summary>

## Status
success

## 1. Summary of Changes
Aligned PR scoreboard automation with the simplified schema by renaming the store helpers to `pr-review-comments`, `pr-count-without-revision`, and `pr-count-with-revision`; updated batch merge automation to record exactly one merge outcome for the batch author; and recorded synced review comments from the existing GitHub review sync path using message-level agent/model attribution. Added focused tests for the new scoreboard helpers, merge outcome tracking, revision detection, and review-comment attribution parsing.

## 2. Verification (finalize_tasks)
- `cargo clippy`: zero warnings, zero errors across the full workspace.
- `cargo test -p orbit-store -p orbit-engine`: all 42 tests passed (7 orbit-store, 35 orbit-engine).

## 3. Strategic Decisions
- Record merge outcome once per batch PR using the batch author identity from the first task with agent/model attribution | Rationale: the scoreboard metric is PR-level, so counting once avoids overcounting multi-task batches | Trade-offs: mixed-author batches remain ambiguous until Orbit persists explicit batch-level PR ownership.
- Detect revision loops from resolved review threads plus review-to-backlog/in-progress/rejected history transitions | Rationale: parallel batch review loops persist thread resolution today, while task status history covers non-batch review rejection paths | Trade-offs: the system still infers revision state indirectly because PR review-decision history is not stored explicitly.

## 4. Assumptions Made
- Batch PRs are normally authored by a single agent/model, so attributing the merge metric to the first task actor matches the real PR author in practice | Impact if incorrect: mixed-author batches may credit the wrong agent for a merged PR.
- Review thread author labels continue to use the standard `agent / model` format produced by Orbit task review commands | Impact if incorrect: malformed or human-authored labels will be skipped instead of contributing to `pr-review-comments`.

## 5. Design Weaknesses / Risks
- Batch-level PR attribution is still inferred instead of persisted explicitly | Severity: Medium | Mitigation: track and implement explicit batch PR author metadata in Orbit task/job records.
- Revision detection still depends on review-thread resolution or task status transitions rather than a first-class review-cycle counter | Severity: Medium | Mitigation: persist review loop outcomes directly when PR decisions change.

## 6. Deviations from Original Plan
- Used resolved review threads and existing status transitions as the revision heuristic instead of scanning prior `pr_status` states | Justification: Orbit does not currently persist historical `pr_status` transitions on tasks, so the planned heuristic was not implementable from task artifacts alone.

## 7. Technical Debt Introduced
- Friction task `T20260402-0553` tracks the missing batch-level PR attribution/revision metadata that forced heuristic inference here | Recommended resolution: add explicit persisted PR author and review-cycle fields, then simplify scoreboard updates to use them directly.

## 8. Overall Assessment
All acceptance criteria met and verified. The implementation correctly records exactly one merge outcome per PR, attributes review comments to the writing agent/model, and eliminates all legacy metric names.

</details>

### T20260402-0352: Fix all clippy warnings and errors across workspace
<details><summary>Execution Summary</summary>

## Status
success

## 1. Summary of Changes
Collapsed the nested parent-directory cleanup condition in orbit-core/src/command/init.rs into a single let-chain. This applies Clippy's collapsible_if suggestion without changing unlink_skills behavior.

## 2. Strategic Decisions
- Used a let-chain for the parent cleanup guard | Rationale: This is Clippy's direct recommendation and keeps the existing control flow intact | Trade-offs: Requires reading a slightly denser condition, but removes unnecessary nesting.

## 3. Verification (finalize_tasks)
- `cargo clippy`: zero warnings, zero errors across the full workspace.
- `cargo test -p orbit-core`: 43 tests passed.

## 4. Technical Debt Introduced
None

## 5. Overall Assessment
Simple, targeted one-line fix. Verification confirmed clean in finalize_tasks pass.

</details>

## Branch Freshness
- Base ref: `agent-main`
- Head ref: `orbit/parallel-batch`
- Behind base: 0
- Ahead of base: 1

## Files Changed
- `orbit-core/src/command/init.rs`
- `orbit-engine/src/executor/automation/pr.rs`
- `orbit-engine/src/executor/automation/sync_review.rs`
- `orbit-store/src/file/pr_scoreboard.rs`
- `orbit-store/src/lib.rs`

*authored by: claude / sonnet*