### PR TITLE
feat: parallel batch [T20260408-0248, T20260406-0455-2]

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,12 +110,14 @@ These surfaces are intentionally distinct because Orbit records provenance and e
 | **ship** | `orbit run ship` | Select tasks, dispatch agents, verify results, open a PR, review, and merge; requires `gh` auth |
 | **ship-local** | `orbit run ship-local` | Select tasks, dispatch agents, and commit locally without a PR |
 | **review** | `orbit run review` | Review tasks in `proposed` or `review` state |
+| **review-pr** | `orbit run review-pr --pr-number 42` | Review, gate, fix-loop, and merge an existing batch PR by PR number |
 
-Optional flags for `ship` and `ship-local`:
+Optional flags:
 
 - `--tasks T1,T2` pin specific task IDs instead of auto-selecting from backlog
 - `--parallelism N` control the number of parallel workers
 - `--base BRANCH` override the base branch
+- `--pr-number N` identify the batch PR for `review-pr`
 
 Examples:
 
@@ -131,6 +133,9 @@ orbit run ship-local --base main
 
 # review queue
 orbit run review
+
+# review and complete an existing batch PR
+orbit run review-pr --pr-number 42 --base main
 ```
 
 For advanced cases, the lower-level job interface remains available:
@@ -255,6 +260,12 @@ Source: [`orbit/orbit-core/assets/jobs/job_local_task_pipeline.yaml`](orbit/orbi
 ### `job_batch_review_cycle`
 
 Reviews a batch PR against task acceptance criteria, syncs review threads to GitHub, and either merges on approval or enters the fix loop.
+
+```bash
+orbit run review-pr --pr-number 42 --base main
+```
+
+Underlying job:
 
 ```bash
 orbit job run job_batch_review_cycle --input '{"base":"main","pr_number":"42"}'

--- a/orbit-map/README.md
+++ b/orbit-map/README.md
@@ -151,6 +151,15 @@ orbit-map knowledge pack leaf:src/a.py#a:function --depth 1 --siblings 2 --child
 orbit-map knowledge pack dir:orbit-map/orbit_map/schemas --format json
 ```
 
+### Worker Handoff
+
+Planner agents can package lineage scope for worker agents with
+`WorkerHandoffPacket`, a pydantic schema that captures task intent, root and
+target selectors, write scope, read-only context, risks, constraints, and
+navigation handles. `GraphContextService.build_handoff_packet()` validates
+selectors against the graph, and `render_lineage_pack_from_handoff()` can render
+the packet's selector set into the existing lineage-pack format.
+
 Inspect the persisted graph:
 
 ```bash

--- a/orbit-map/graph_navigation.md
+++ b/orbit-map/graph_navigation.md
@@ -118,6 +118,81 @@ The worker then expands only when necessary.
 
 ---
 
+## Planner-to-Worker Handoff
+
+Planners now have a structured packet for handing lineage scope to worker
+agents: `WorkerHandoffPacket`.
+
+The packet is designed to keep prompts deterministic while still giving workers
+enough navigation handles to continue exploring the code graph on demand.
+
+### Node Role Taxonomy
+
+Each referenced node is represented as a lightweight `HandoffNodeRef` with a
+stable graph node ID and selector. Roles are explicit:
+
+- `root`: the lineage root assigned to the worker
+- `target`: the main nodes the task is trying to change or inspect
+- `write`: nodes the worker is allowed to modify
+- `read_only`: supporting context the worker may read but should not edit
+- `locked`: nodes currently reserved elsewhere or otherwise blocked
+- `expansion`: optional nearby selectors a worker can expand into if needed
+
+### Packet Shape
+
+`WorkerHandoffPacket` includes:
+
+- task intent (`task_id`, `task_title`, `task_intent`)
+- graph scope buckets (`root_nodes`, `target_nodes`, `write_nodes`,
+  `read_only_nodes`, `locked_nodes`, `expansion_handles`)
+- planner warnings (`risks`, `constraints`)
+- navigation handles (`knowledge_dir`, `lineage_pack_selectors`)
+
+The packet intentionally references graph nodes by selector and ID instead of
+embedding raw graph objects.
+
+### Markdown Rendering
+
+Workers can receive the packet as structured JSON or as a rendered prompt
+snippet:
+
+```python
+packet = service.build_handoff_packet(
+    task_id="T20260406-0455-2",
+    task_title="Define planner-to-worker lineage handoff schema",
+    task_intent="Add a handoff schema and connect it to lineage pack rendering.",
+    root_selectors=["dir:orbit_map/service"],
+    target_selectors=["file:orbit_map/service/graph_context.py"],
+    write_selectors=["file:orbit_map/service/graph_context.py"],
+    read_only_selectors=["file:orbit_map/service/lineage_pack.py"],
+    knowledge_dir=".orbit/knowledge",
+)
+
+prompt_fragment = packet.to_markdown(budget=8000)
+```
+
+`to_markdown()` renders task details, graph scope, risks, constraints, and
+navigation selectors in a budget-aware format suitable for agent prompts.
+
+### GraphContextService API
+
+`GraphContextService.build_handoff_packet()` resolves selectors into typed
+handoff references and computes default `lineage_pack_selectors` when the
+planner does not provide them explicitly.
+
+This keeps selector validation in one place and guarantees that worker-facing
+handoff packets stay consistent with graph navigation semantics.
+
+### Example Flow
+
+1. planner identifies the relevant lineage
+2. planner calls `build_handoff_packet(...)`
+3. worker receives the structured packet or `packet.to_markdown()`
+4. worker expands additional context with `render_lineage_pack_from_handoff(...)`
+   using the packet's navigation handles
+
+---
+
 ## Navigation Model
 
 Agents need graph operations, not giant graph dumps.

--- a/orbit-map/orbit_map/schemas/__init__.py
+++ b/orbit-map/orbit_map/schemas/__init__.py
@@ -7,6 +7,12 @@ from orbit_map.schemas.graph.contexts import (
     NodeContextRef,
     NodeLockState,
 )
+from orbit_map.schemas.graph.handoff import (
+    HandoffConstraint,
+    HandoffNodeRef,
+    HandoffRisk,
+    WorkerHandoffPacket,
+)
 from orbit_map.schemas.graph.locking import (
     build_node_index,
     iter_nodes,
@@ -81,6 +87,9 @@ __all__ = [
     "get_parent",
     "get_siblings",
     "GraphNavigator",
+    "HandoffConstraint",
+    "HandoffNodeRef",
+    "HandoffRisk",
     "HashCacheV1",
     "iter_nodes",
     "LeafHistoryEntry",
@@ -98,4 +107,5 @@ __all__ = [
     "SummarizeFilesInputV1",
     "SummarizeFilesResponseV1",
     "unlock_lineage",
+    "WorkerHandoffPacket",
 ]

--- a/orbit-map/orbit_map/schemas/graph/handoff.py
+++ b/orbit-map/orbit_map/schemas/graph/handoff.py
@@ -1,0 +1,202 @@
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+from orbit_map.schemas.graph.contexts import NodeType
+from orbit_map.schemas.graph.nodes import LeafKind
+
+HandoffNodeRole = Literal[
+    "root",
+    "target",
+    "write",
+    "read_only",
+    "locked",
+    "expansion",
+]
+RiskSeverity = Literal["low", "medium", "high"]
+
+
+class HandoffNodeRef(BaseModel):
+    id: str
+    selector: str
+    role: HandoffNodeRole
+    name: str
+    node_type: NodeType
+    location: str
+    description: str = ""
+    kind: LeafKind | None = None
+
+    def to_markdown_line(self) -> str:
+        parts = [f"`{self.selector}`", f"(id: `{self.id}`)", f"type: {self.node_type}"]
+        if self.kind is not None:
+            parts.append(f"kind: {self.kind}")
+        line = f"- {' | '.join(parts)}"
+        if self.description:
+            line += f" | {self.description}"
+        return line
+
+
+class HandoffRisk(BaseModel):
+    severity: RiskSeverity = "medium"
+    description: str
+    affected_selectors: list[str] = Field(default_factory=list)
+
+    def to_markdown_line(self) -> str:
+        selectors = ", ".join(f"`{selector}`" for selector in self.affected_selectors)
+        scope = selectors or "(none)"
+        return f"- [{self.severity}] {self.description} | Affected: {scope}"
+
+
+class HandoffConstraint(BaseModel):
+    description: str
+    selectors: list[str] = Field(default_factory=list)
+
+    def to_markdown_line(self) -> str:
+        selectors = ", ".join(f"`{selector}`" for selector in self.selectors)
+        scope = selectors or "(none)"
+        return f"- {self.description} | Scope: {scope}"
+
+
+class WorkerHandoffPacket(BaseModel):
+    task_id: str
+    task_title: str = ""
+    task_intent: str
+    root_nodes: list[HandoffNodeRef] = Field(default_factory=list)
+    target_nodes: list[HandoffNodeRef] = Field(default_factory=list)
+    write_nodes: list[HandoffNodeRef] = Field(default_factory=list)
+    read_only_nodes: list[HandoffNodeRef] = Field(default_factory=list)
+    locked_nodes: list[HandoffNodeRef] = Field(default_factory=list)
+    expansion_handles: list[HandoffNodeRef] = Field(default_factory=list)
+    risks: list[HandoffRisk] = Field(default_factory=list)
+    constraints: list[HandoffConstraint] = Field(default_factory=list)
+    knowledge_dir: str = ""
+    lineage_pack_selectors: list[str] = Field(default_factory=list)
+
+    def navigation_selectors(self) -> list[str]:
+        if self.lineage_pack_selectors:
+            return _dedupe_strings(self.lineage_pack_selectors)
+        selectors = [
+            ref.selector
+            for ref in [
+                *self.root_nodes,
+                *self.target_nodes,
+                *self.write_nodes,
+                *self.read_only_nodes,
+                *self.locked_nodes,
+                *self.expansion_handles,
+            ]
+        ]
+        return _dedupe_strings(selectors)
+
+    def to_markdown(self, budget: int = 8_000) -> str:
+        writer = _MarkdownWriter(budget=max(1, budget))
+
+        writer.line("# Worker Handoff")
+        writer.line()
+        writer.line("## Task")
+        writer.line(f"- task id: `{self.task_id}`")
+        writer.line(f"- task title: {self.task_title or '(none)'}")
+        writer.line(f"- task intent: {self.task_intent}")
+        writer.line()
+        writer.line("## Graph Scope")
+        _write_node_section(writer, "Root Nodes", self.root_nodes)
+        _write_node_section(writer, "Target Nodes", self.target_nodes)
+        _write_node_section(writer, "Write Nodes", self.write_nodes)
+        _write_node_section(writer, "Read-Only Nodes", self.read_only_nodes)
+        _write_node_section(writer, "Locked Nodes", self.locked_nodes)
+        _write_node_section(writer, "Expansion Handles", self.expansion_handles)
+        if not writer.truncated:
+            writer.line("## Risks")
+            if self.risks:
+                for risk in self.risks:
+                    if not writer.line(risk.to_markdown_line()):
+                        break
+            else:
+                writer.line("- (none)")
+            writer.line()
+        if not writer.truncated:
+            writer.line("## Constraints")
+            if self.constraints:
+                for constraint in self.constraints:
+                    if not writer.line(constraint.to_markdown_line()):
+                        break
+            else:
+                writer.line("- (none)")
+            writer.line()
+        if not writer.truncated:
+            writer.line("## Navigation")
+            if self.knowledge_dir:
+                writer.line(f"- knowledge dir: `{self.knowledge_dir}`")
+            else:
+                writer.line("- knowledge dir: (none)")
+            selectors = self.navigation_selectors()
+            writer.line(
+                "- lineage pack selectors: "
+                + (
+                    ", ".join(f"`{selector}`" for selector in selectors)
+                    if selectors
+                    else "(none)"
+                )
+            )
+
+        if writer.truncated:
+            writer.note("_output truncated to respect the requested budget._")
+
+        return writer.text()
+
+
+def _write_node_section(
+    writer: "_MarkdownWriter", heading: str, nodes: list[HandoffNodeRef]
+) -> None:
+    if not writer.line(f"### {heading}"):
+        return
+    if nodes:
+        for node in nodes:
+            if not writer.line(node.to_markdown_line()):
+                break
+    else:
+        writer.line("- (none)")
+    writer.line()
+
+
+def _dedupe_strings(values: list[str]) -> list[str]:
+    seen: set[str] = set()
+    ordered: list[str] = []
+    for value in values:
+        if value in seen:
+            continue
+        seen.add(value)
+        ordered.append(value)
+    return ordered
+
+
+class _MarkdownWriter:
+    def __init__(self, budget: int):
+        self.budget = budget
+        self._parts: list[str] = []
+        self._length = 0
+        self.truncated = False
+
+    def line(self, text: str = "") -> bool:
+        if self.truncated:
+            return False
+        piece = f"{text}\n"
+        if self._length + len(piece) > self.budget:
+            self.truncated = True
+            return False
+        self._parts.append(piece)
+        self._length += len(piece)
+        return True
+
+    def note(self, text: str) -> None:
+        piece = f"{text}\n"
+        if self._length + len(piece) <= self.budget:
+            self._parts.append(piece)
+            self._length += len(piece)
+
+    def text(self) -> str:
+        if not self._parts:
+            return ""
+        return "".join(self._parts).rstrip() + "\n"

--- a/orbit-map/orbit_map/service/__init__.py
+++ b/orbit-map/orbit_map/service/__init__.py
@@ -5,11 +5,15 @@ from orbit_map.service.graph_context import (
     load_graph_context_service,
 )
 from orbit_map.service.bootstrap import render_knowledge_bootstrap
-from orbit_map.service.lineage_pack import render_lineage_pack
+from orbit_map.service.lineage_pack import (
+    render_lineage_pack,
+    render_lineage_pack_from_handoff,
+)
 
 __all__ = [
     "GraphContextService",
     "load_graph_context_service",
     "render_knowledge_bootstrap",
     "render_lineage_pack",
+    "render_lineage_pack_from_handoff",
 ]

--- a/orbit-map/orbit_map/service/graph_context.py
+++ b/orbit-map/orbit_map/service/graph_context.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import json
 import logging
 from pathlib import Path
-from typing import Iterable
+from typing import Any, Iterable, Sequence
 
 from orbit_map.graph.extraction.base import node_id
 from orbit_map.graph.store import GraphObjectStore
@@ -13,8 +13,12 @@ from orbit_map.schemas import (
     FileContext,
     FileSummaryV1,
     FileSymbolV1,
+    HandoffConstraint,
+    HandoffNodeRef,
+    HandoffRisk,
     LeafContext,
     NodeContextRef,
+    WorkerHandoffPacket,
 )
 from orbit_map.schemas.graph.contexts import NodeType
 from orbit_map.schemas.graph.navigation import GraphNavigator, GraphNode
@@ -150,10 +154,91 @@ class GraphContextService:
             limit=limit,
         )
 
+    def build_handoff_packet(
+        self,
+        *,
+        task_id: str,
+        task_intent: str,
+        task_title: str = "",
+        root_selectors: Sequence[str],
+        target_selectors: Sequence[str],
+        write_selectors: Sequence[str],
+        read_only_selectors: Sequence[str] = (),
+        locked_selectors: Sequence[str] = (),
+        expansion_selectors: Sequence[str] = (),
+        risks: Sequence[HandoffRisk | dict[str, Any]] = (),
+        constraints: Sequence[HandoffConstraint | dict[str, Any]] = (),
+        knowledge_dir: str | None = None,
+        lineage_pack_selectors: Sequence[str] | None = None,
+    ) -> WorkerHandoffPacket:
+        root_nodes = self._resolve_handoff_refs(root_selectors, role="root")
+        target_nodes = self._resolve_handoff_refs(target_selectors, role="target")
+        write_nodes = self._resolve_handoff_refs(write_selectors, role="write")
+        read_only_nodes = self._resolve_handoff_refs(
+            read_only_selectors,
+            role="read_only",
+        )
+        locked_nodes = self._resolve_handoff_refs(locked_selectors, role="locked")
+        expansion_handles = self._resolve_handoff_refs(
+            expansion_selectors,
+            role="expansion",
+        )
+        return WorkerHandoffPacket(
+            task_id=task_id,
+            task_title=task_title,
+            task_intent=task_intent,
+            root_nodes=root_nodes,
+            target_nodes=target_nodes,
+            write_nodes=write_nodes,
+            read_only_nodes=read_only_nodes,
+            locked_nodes=locked_nodes,
+            expansion_handles=expansion_handles,
+            risks=[HandoffRisk.model_validate(item) for item in risks],
+            constraints=[
+                HandoffConstraint.model_validate(item) for item in constraints
+            ],
+            knowledge_dir=knowledge_dir or "",
+            lineage_pack_selectors=list(
+                lineage_pack_selectors
+                if lineage_pack_selectors is not None
+                else _merge_unique_selectors(
+                    [ref.selector for ref in root_nodes],
+                    [ref.selector for ref in target_nodes],
+                    [ref.selector for ref in write_nodes],
+                    [ref.selector for ref in read_only_nodes],
+                    [ref.selector for ref in locked_nodes],
+                    [ref.selector for ref in expansion_handles],
+                )
+            ),
+        )
+
     def _summary_for_file(self, node: FileNode) -> FileSummaryV1 | None:
         if node.source_blob_hash is None:
             return None
         return self.file_summaries_by_hash.get(node.source_blob_hash)
+
+    def _resolve_handoff_refs(
+        self,
+        selectors: Sequence[str],
+        *,
+        role: str,
+    ) -> list[HandoffNodeRef]:
+        refs: list[HandoffNodeRef] = []
+        for selector in selectors:
+            node = self.resolve_selector(selector)
+            refs.append(
+                HandoffNodeRef(
+                    id=node.id,
+                    selector=self.selector_for_node(node),
+                    role=role,
+                    name=node.name,
+                    node_type=node.node_type,
+                    location=node.location,
+                    description=node.description,
+                    kind=node.kind if node.node_type == "leaf" else None,
+                )
+            )
+        return refs
 
 
 def load_graph_context_service(knowledge_dir: Path | str) -> GraphContextService:
@@ -210,3 +295,15 @@ def _parse_selector(selector: str) -> tuple[str, str, str | None]:
     raise ValueError(
         f"Unsupported selector format, expected dir:, file:, leaf:, or a node id: {selector}"
     )
+
+
+def _merge_unique_selectors(*selector_groups: Sequence[str]) -> list[str]:
+    ordered: list[str] = []
+    seen: set[str] = set()
+    for group in selector_groups:
+        for selector in group:
+            if selector in seen:
+                continue
+            seen.add(selector)
+            ordered.append(selector)
+    return ordered

--- a/orbit-map/orbit_map/service/lineage_pack.py
+++ b/orbit-map/orbit_map/service/lineage_pack.py
@@ -6,7 +6,12 @@ from pathlib import Path
 from typing import Any, Literal, Sequence
 
 from orbit_map.graph.extraction.base import leaf_location
-from orbit_map.schemas import FileSummaryV1, FileSymbolV1, LeafNode
+from orbit_map.schemas import (
+    FileSummaryV1,
+    FileSymbolV1,
+    LeafNode,
+    WorkerHandoffPacket,
+)
 from orbit_map.schemas.graph.nodes import DirNode, FileNode
 from orbit_map.service.graph_context import GraphContextService
 
@@ -57,6 +62,25 @@ def render_lineage_pack(
     if detail:
         return _render_verbose_markdown(report, budget=budget)
     return _render_compact_markdown(report, budget=budget)
+
+
+def render_lineage_pack_from_handoff(
+    packet: WorkerHandoffPacket | dict[str, Any],
+    **kwargs: Any,
+) -> str:
+    handoff = (
+        packet
+        if isinstance(packet, WorkerHandoffPacket)
+        else WorkerHandoffPacket.model_validate(packet)
+    )
+    if not handoff.knowledge_dir:
+        raise ValueError("Worker handoff packet requires knowledge_dir to render lineage pack")
+    selectors = handoff.navigation_selectors()
+    if not selectors:
+        raise ValueError(
+            "Worker handoff packet must include at least one lineage pack selector"
+        )
+    return render_lineage_pack(handoff.knowledge_dir, selectors, **kwargs)
 
 
 def _build_verbose_report(

--- a/orbit-map/tests/test_handoff.py
+++ b/orbit-map/tests/test_handoff.py
@@ -1,0 +1,209 @@
+import orbit_map.service.lineage_pack as lineage_pack_module
+import pytest
+
+from orbit_map.schemas import (
+    CodebaseGraphV1,
+    DirNode,
+    FileNode,
+    LeafNode,
+    SignatureField,
+    WorkerHandoffPacket,
+)
+from orbit_map.schemas.graph.handoff import HandoffConstraint, HandoffRisk
+from orbit_map.service.graph_context import GraphContextService
+
+
+@pytest.fixture
+def graph_service():
+    root = DirNode(
+        id="dir-root",
+        name="orbit_map",
+        location="orbit_map",
+        language="python",
+        dir_children=[],
+        file_children=["file-graph-context"],
+    )
+    file_node = FileNode(
+        id="file-graph-context",
+        name="graph_context.py",
+        location="orbit_map/service/graph_context.py",
+        language="python",
+        parent_id="dir-root",
+        extension=".py",
+        imports=["typing"],
+        exports=["GraphContextService"],
+        leaf_children=["leaf-build-handoff-packet"],
+    )
+    leaf_node = LeafNode(
+        id="leaf-build-handoff-packet",
+        name="build_handoff_packet",
+        location="orbit_map/service/graph_context.py#build_handoff_packet",
+        language="python",
+        parent_id="file-graph-context",
+        kind="function",
+        description="Builds a worker handoff packet from validated selectors.",
+        input_signature=[SignatureField(name="task_id", annotation="str")],
+    )
+    graph = CodebaseGraphV1(
+        root_dir_id=root.id,
+        dirs=[root],
+        files=[file_node],
+        leaves=[leaf_node],
+    )
+    return GraphContextService(graph)
+
+
+def test_worker_handoff_packet_to_markdown_renders_sections(graph_service):
+    packet = graph_service.build_handoff_packet(
+        task_id="T1",
+        task_title="Test handoff",
+        task_intent="Explain the worker's scope.",
+        root_selectors=["dir:orbit_map"],
+        target_selectors=["file:orbit_map/service/graph_context.py"],
+        write_selectors=[
+            "leaf:orbit_map/service/graph_context.py#build_handoff_packet:function"
+        ],
+        read_only_selectors=["file:orbit_map/service/graph_context.py"],
+        locked_selectors=[],
+        expansion_selectors=["dir:orbit_map"],
+        risks=[
+            HandoffRisk(
+                severity="high",
+                description="Editing the wrong selector could widen scope.",
+                affected_selectors=["file:orbit_map/service/graph_context.py"],
+            )
+        ],
+        constraints=[
+            HandoffConstraint(
+                description="Do not modify unrelated files.",
+                selectors=["file:orbit_map/service/graph_context.py"],
+            )
+        ],
+        knowledge_dir=".orbit/knowledge",
+    )
+
+    markdown = packet.to_markdown()
+
+    assert "## Task" in markdown
+    assert "## Graph Scope" in markdown
+    assert "### Root Nodes" in markdown
+    assert "### Write Nodes" in markdown
+    assert "## Risks" in markdown
+    assert "## Constraints" in markdown
+    assert "## Navigation" in markdown
+    assert "`dir:orbit_map`" in markdown
+    assert "`leaf:orbit_map/service/graph_context.py#build_handoff_packet:function`" in markdown
+
+
+def test_worker_handoff_packet_to_markdown_respects_budget(graph_service):
+    packet = graph_service.build_handoff_packet(
+        task_id="T1",
+        task_title="Test handoff",
+        task_intent="Explain the worker's scope.",
+        root_selectors=["dir:orbit_map"],
+        target_selectors=["file:orbit_map/service/graph_context.py"],
+        write_selectors=[
+            "leaf:orbit_map/service/graph_context.py#build_handoff_packet:function"
+        ],
+    )
+
+    full_markdown = packet.to_markdown(budget=4_000)
+    trimmed_markdown = packet.to_markdown(budget=120)
+
+    assert len(trimmed_markdown) < len(full_markdown)
+    assert trimmed_markdown.startswith("# Worker Handoff")
+
+
+def test_build_handoff_packet_resolves_selectors(graph_service):
+    packet = graph_service.build_handoff_packet(
+        task_id="T1",
+        task_title="Test handoff",
+        task_intent="Explain the worker's scope.",
+        root_selectors=["dir:orbit_map"],
+        target_selectors=["file:orbit_map/service/graph_context.py"],
+        write_selectors=[
+            "leaf:orbit_map/service/graph_context.py#build_handoff_packet:function"
+        ],
+        read_only_selectors=["file:orbit_map/service/graph_context.py"],
+        expansion_selectors=["dir:orbit_map"],
+    )
+
+    assert packet.root_nodes[0].role == "root"
+    assert packet.target_nodes[0].role == "target"
+    assert packet.write_nodes[0].role == "write"
+    assert packet.read_only_nodes[0].role == "read_only"
+    assert packet.expansion_handles[0].role == "expansion"
+    assert packet.lineage_pack_selectors == [
+        "dir:orbit_map",
+        "file:orbit_map/service/graph_context.py",
+        "leaf:orbit_map/service/graph_context.py#build_handoff_packet:function",
+    ]
+
+
+def test_build_handoff_packet_rejects_unknown_selector(graph_service):
+    with pytest.raises(ValueError, match="Unknown file selector"):
+        graph_service.build_handoff_packet(
+            task_id="T1",
+            task_intent="Explain the worker's scope.",
+            root_selectors=["dir:orbit_map"],
+            target_selectors=["file:orbit_map/service/missing.py"],
+            write_selectors=[],
+        )
+
+
+def test_worker_handoff_packet_model_dump_round_trip(graph_service):
+    packet = graph_service.build_handoff_packet(
+        task_id="T1",
+        task_title="Test handoff",
+        task_intent="Explain the worker's scope.",
+        root_selectors=["dir:orbit_map"],
+        target_selectors=["file:orbit_map/service/graph_context.py"],
+        write_selectors=[
+            "leaf:orbit_map/service/graph_context.py#build_handoff_packet:function"
+        ],
+        knowledge_dir=".orbit/knowledge",
+    )
+
+    restored = WorkerHandoffPacket.model_validate(packet.model_dump())
+
+    assert restored == packet
+
+
+def test_render_lineage_pack_from_handoff_accepts_model_dump(monkeypatch):
+    observed = {}
+
+    def fake_render_lineage_pack(knowledge_dir, selectors, **kwargs):
+        observed["knowledge_dir"] = knowledge_dir
+        observed["selectors"] = selectors
+        observed["kwargs"] = kwargs
+        return "rendered"
+
+    monkeypatch.setattr(
+        lineage_pack_module,
+        "render_lineage_pack",
+        fake_render_lineage_pack,
+    )
+    packet = WorkerHandoffPacket(
+        task_id="T1",
+        task_intent="Explain the worker's scope.",
+        knowledge_dir=".orbit/knowledge",
+        lineage_pack_selectors=[
+            "dir:orbit_map",
+            "file:orbit_map/service/graph_context.py",
+        ],
+    )
+
+    rendered = lineage_pack_module.render_lineage_pack_from_handoff(
+        packet.model_dump(),
+        budget=321,
+    )
+
+    assert rendered == "rendered"
+    assert observed == {
+        "knowledge_dir": ".orbit/knowledge",
+        "selectors": [
+            "dir:orbit_map",
+            "file:orbit_map/service/graph_context.py",
+        ],
+        "kwargs": {"budget": 321},
+    }

--- a/orbit/orbit-cli/src/command/run.rs
+++ b/orbit/orbit-cli/src/command/run.rs
@@ -10,10 +10,10 @@ use crate::command::Execute;
 #[derive(Args)]
 #[command(
     about = "Run a first-class workflow",
-    after_help = "Examples:\n  orbit run ship\n  orbit run ship --tasks T123,T456 --parallelism 2\n  orbit run ship-local --base main\n  orbit run review\n  orbit run --list"
+    after_help = "Examples:\n  orbit run ship\n  orbit run ship --tasks T123,T456 --parallelism 2\n  orbit run ship-local --base main\n  orbit run review\n  orbit run review-pr --pr-number 42 --base main\n  orbit run --list"
 )]
 pub struct RunCommand {
-    /// Workflow name (e.g. ship, ship-local, review)
+    /// Workflow name (e.g. ship, ship-local, review, review-pr)
     pub workflow: Option<String>,
 
     /// Comma-separated task IDs to process (omit to auto-select from backlog)
@@ -27,6 +27,10 @@ pub struct RunCommand {
     /// Base branch for the pipeline
     #[arg(long)]
     pub base: Option<String>,
+
+    /// Pull request number for review-pr workflows
+    #[arg(long = "pr-number")]
+    pub pr_number: Option<String>,
 
     /// Stream agent stderr to the terminal for debugging
     #[arg(long)]
@@ -61,6 +65,7 @@ impl Execute for RunCommand {
             tasks: self.tasks.clone(),
             parallelism: self.parallelism,
             base: self.base.clone(),
+            pr_number: self.pr_number.clone(),
         };
         validate_workflow_flags(workflow, &wf_input)?;
         let input = build_workflow_input(&wf_input)?;

--- a/orbit/orbit-core/assets/activities/automation/bootstrap_batch_review.yaml
+++ b/orbit/orbit-core/assets/activities/automation/bootstrap_batch_review.yaml
@@ -1,0 +1,45 @@
+schema_version: 1
+
+# ---- metadata ----
+created_by: system
+
+# ---- activity ----
+activity:
+  # ---- registration ----
+  id: bootstrap_batch_review
+  spec_type: automation
+
+  # ---- content ----
+  description: Resolve or establish the batch task set for a batch PR review cycle
+
+  # ---- interface ----
+  input_schema_json:
+    type: object
+    required:
+      - run_id
+    properties:
+      run_id:
+        type: string
+        description: Batch run ID used to tag or resolve the batch task set.
+      pr_number:
+        type: string
+        description: Pull request number used to find tasks when no batch_id is already present.
+  output_schema_json:
+    type: object
+    required:
+      - batch_id
+      - task_count
+      - tagged_count
+    properties:
+      batch_id:
+        type: string
+        description: Effective batch ID for downstream review and merge steps.
+      task_count:
+        type: integer
+        description: Number of tasks in the resolved batch.
+      tagged_count:
+        type: integer
+        description: Number of tasks newly tagged with batch_id during bootstrap.
+
+  # ---- execution ----
+  action: bootstrap_batch_review

--- a/orbit/orbit-core/assets/jobs/job_batch_review_cycle.yaml
+++ b/orbit/orbit-core/assets/jobs/job_batch_review_cycle.yaml
@@ -11,6 +11,7 @@ job:
   # Batch review cycle: review a batch PR and either merge it or enter the fix-and-review loop.
   #
   # Step flow:
+  #   bootstrap_batch_review     — resolve tasks for this review cycle by existing batch_id or supplied PR number
   #   review_batch_pr             — review the opened PR against all batch tasks' acceptance criteria
   #   sync_batch_review_to_github — publish review threads to GitHub
   #   check_batch_review_decision — gate: succeeds if all tasks APPROVED, fails if any REQUEST_CHANGES
@@ -21,6 +22,11 @@ job:
   default_input:
     base: main
   steps:
+    - target_type: activity
+      target_id: bootstrap_batch_review
+      condition: on_success
+      timeout_seconds: 30
+
     - target_type: activity
       target_id: review_batch_pr
       agent_cli: claude

--- a/orbit/orbit-core/src/command/activity.rs
+++ b/orbit/orbit-core/src/command/activity.rs
@@ -48,6 +48,10 @@ pub(crate) const DEFAULT_ACTIVITY_FILES: &[(&str, &str)] = &[
         include_str!("../../assets/activities/automation/snapshot_batch_state.yaml"),
     ),
     (
+        "bootstrap_batch_review",
+        include_str!("../../assets/activities/automation/bootstrap_batch_review.yaml"),
+    ),
+    (
         "implement_batch_fix",
         include_str!("../../assets/activities/agent_invoke/implement_batch_fix.yaml"),
     ),

--- a/orbit/orbit-core/src/command/workflow.rs
+++ b/orbit/orbit-core/src/command/workflow.rs
@@ -9,6 +9,8 @@ pub struct Workflow {
     pub supports_tasks: bool,
     pub supports_parallelism: bool,
     pub supports_base: bool,
+    pub supports_pr_number: bool,
+    pub requires_pr_number: bool,
 }
 
 pub const WORKFLOWS: &[Workflow] = &[
@@ -19,6 +21,8 @@ pub const WORKFLOWS: &[Workflow] = &[
         supports_tasks: true,
         supports_parallelism: true,
         supports_base: true,
+        supports_pr_number: false,
+        requires_pr_number: false,
     },
     Workflow {
         alias: "ship-local",
@@ -27,6 +31,8 @@ pub const WORKFLOWS: &[Workflow] = &[
         supports_tasks: true,
         supports_parallelism: true,
         supports_base: true,
+        supports_pr_number: false,
+        requires_pr_number: false,
     },
     Workflow {
         alias: "review",
@@ -35,6 +41,18 @@ pub const WORKFLOWS: &[Workflow] = &[
         supports_tasks: false,
         supports_parallelism: false,
         supports_base: false,
+        supports_pr_number: false,
+        requires_pr_number: false,
+    },
+    Workflow {
+        alias: "review-pr",
+        job_id: "job_batch_review_cycle",
+        description: "Review, gate, fix-loop, and merge a batch PR by PR number",
+        supports_tasks: false,
+        supports_parallelism: false,
+        supports_base: true,
+        supports_pr_number: true,
+        requires_pr_number: true,
     },
 ];
 
@@ -46,6 +64,7 @@ pub struct WorkflowInput {
     pub tasks: Option<String>,
     pub parallelism: Option<u32>,
     pub base: Option<String>,
+    pub pr_number: Option<String>,
 }
 
 pub fn validate_workflow_flags(
@@ -67,6 +86,18 @@ pub fn validate_workflow_flags(
     if !workflow.supports_base && input.base.is_some() {
         return Err(OrbitError::InvalidInput(format!(
             "--base is not supported by workflow '{}'",
+            workflow.alias
+        )));
+    }
+    if !workflow.supports_pr_number && input.pr_number.is_some() {
+        return Err(OrbitError::InvalidInput(format!(
+            "--pr-number is not supported by workflow '{}'",
+            workflow.alias
+        )));
+    }
+    if workflow.requires_pr_number && input.pr_number.is_none() {
+        return Err(OrbitError::InvalidInput(format!(
+            "--pr-number is required for workflow '{}'",
             workflow.alias
         )));
     }
@@ -109,6 +140,15 @@ pub fn build_workflow_input(input: &WorkflowInput) -> Result<Value, OrbitError> 
         map.insert("base".to_string(), Value::String(base.clone()));
     }
 
+    if let Some(pr_number) = &input.pr_number {
+        if pr_number.is_empty() {
+            return Err(OrbitError::InvalidInput(
+                "--pr-number must not be empty".to_string(),
+            ));
+        }
+        map.insert("pr_number".to_string(), Value::String(pr_number.clone()));
+    }
+
     Ok(Value::Object(map))
 }
 
@@ -128,6 +168,10 @@ mod tests {
             "job_local_task_pipeline"
         );
         assert_eq!(find_workflow("review").unwrap().job_id, "job_review_tasks");
+        assert_eq!(
+            find_workflow("review-pr").unwrap().job_id,
+            "job_batch_review_cycle"
+        );
     }
 
     #[test]
@@ -142,6 +186,7 @@ mod tests {
             tasks: Some("T123".to_string()),
             parallelism: None,
             base: None,
+            pr_number: None,
         };
         assert!(validate_workflow_flags(workflow, &input).is_err());
     }
@@ -153,6 +198,7 @@ mod tests {
             tasks: None,
             parallelism: Some(2),
             base: None,
+            pr_number: None,
         };
         assert!(validate_workflow_flags(workflow, &input).is_err());
     }
@@ -164,6 +210,43 @@ mod tests {
             tasks: Some("T123,T456".to_string()),
             parallelism: Some(2),
             base: Some("main".to_string()),
+            pr_number: None,
+        };
+        assert!(validate_workflow_flags(workflow, &input).is_ok());
+    }
+
+    #[test]
+    fn validate_rejects_unsupported_pr_number() {
+        let workflow = find_workflow("ship").unwrap();
+        let input = WorkflowInput {
+            tasks: None,
+            parallelism: None,
+            base: None,
+            pr_number: Some("42".to_string()),
+        };
+        assert!(validate_workflow_flags(workflow, &input).is_err());
+    }
+
+    #[test]
+    fn validate_requires_pr_number_for_review_pr() {
+        let workflow = find_workflow("review-pr").unwrap();
+        let input = WorkflowInput {
+            tasks: None,
+            parallelism: None,
+            base: Some("main".to_string()),
+            pr_number: None,
+        };
+        assert!(validate_workflow_flags(workflow, &input).is_err());
+    }
+
+    #[test]
+    fn validate_accepts_review_pr_flags() {
+        let workflow = find_workflow("review-pr").unwrap();
+        let input = WorkflowInput {
+            tasks: None,
+            parallelism: None,
+            base: Some("main".to_string()),
+            pr_number: Some("42".to_string()),
         };
         assert!(validate_workflow_flags(workflow, &input).is_ok());
     }
@@ -174,6 +257,7 @@ mod tests {
             tasks: None,
             parallelism: None,
             base: None,
+            pr_number: None,
         };
         assert_eq!(build_workflow_input(&input).unwrap(), json!({}));
     }
@@ -184,11 +268,13 @@ mod tests {
             tasks: Some("T123,T456".to_string()),
             parallelism: Some(3),
             base: Some("main".to_string()),
+            pr_number: Some("42".to_string()),
         };
         let result = build_workflow_input(&input).unwrap();
         assert_eq!(result["task_ids"], json!(["T123", "T456"]));
         assert_eq!(result["parallelism"], json!(3));
         assert_eq!(result["base"], json!("main"));
+        assert_eq!(result["pr_number"], json!("42"));
     }
 
     #[test]
@@ -197,6 +283,7 @@ mod tests {
             tasks: None,
             parallelism: Some(0),
             base: None,
+            pr_number: None,
         };
         assert!(build_workflow_input(&input).is_err());
     }
@@ -207,6 +294,7 @@ mod tests {
             tasks: Some("".to_string()),
             parallelism: None,
             base: None,
+            pr_number: None,
         };
         assert!(build_workflow_input(&input).is_err());
     }
@@ -217,6 +305,18 @@ mod tests {
             tasks: None,
             parallelism: None,
             base: Some("".to_string()),
+            pr_number: None,
+        };
+        assert!(build_workflow_input(&input).is_err());
+    }
+
+    #[test]
+    fn build_input_rejects_empty_pr_number() {
+        let input = WorkflowInput {
+            tasks: None,
+            parallelism: None,
+            base: None,
+            pr_number: Some("".to_string()),
         };
         assert!(build_workflow_input(&input).is_err());
     }

--- a/orbit/orbit-engine/src/executor/automation/mod.rs
+++ b/orbit/orbit-engine/src/executor/automation/mod.rs
@@ -27,6 +27,7 @@ const AUTOMATION_COMMIT_BATCH_CHANGES: &str = "commit_batch_changes";
 const AUTOMATION_OPEN_BATCH_PR: &str = "open_batch_pr";
 const AUTOMATION_COMMIT_AND_OPEN_BATCH_PR: &str = "commit_and_open_batch_pr";
 const AUTOMATION_SNAPSHOT_BATCH_STATE: &str = "snapshot_batch_state";
+const AUTOMATION_BOOTSTRAP_BATCH_REVIEW: &str = "bootstrap_batch_review";
 
 const AUTOMATION_MERGE_BATCH_PR: &str = "merge_batch_pr";
 const AUTOMATION_CHECK_BATCH_REVIEW_DECISION: &str = "check_batch_review_decision";
@@ -93,6 +94,7 @@ pub fn execute<H: crate::context::RuntimeHost + crate::context::TaskHost + Sync 
         AUTOMATION_OPEN_BATCH_PR => pr::open_batch_pr(host, input),
         AUTOMATION_COMMIT_AND_OPEN_BATCH_PR => commit_and_pr::commit_and_open_batch_pr(host, input),
         AUTOMATION_SNAPSHOT_BATCH_STATE => snapshot::snapshot_batch_state(host, input),
+        AUTOMATION_BOOTSTRAP_BATCH_REVIEW => pr::bootstrap_batch_review(host, input),
 
         AUTOMATION_MERGE_BATCH_PR => pr::merge_batch_pr(host, input),
         AUTOMATION_CHECK_BATCH_REVIEW_DECISION => {

--- a/orbit/orbit-engine/src/executor/automation/pr.rs
+++ b/orbit/orbit-engine/src/executor/automation/pr.rs
@@ -11,6 +11,50 @@ use super::input::{
     canonicalize_existing_dir, input_string_field, json_number_to_string, required_input_string,
 };
 
+pub(super) fn bootstrap_batch_review<H: TaskHost + ?Sized>(
+    host: &H,
+    input: &Value,
+) -> Result<Value, OrbitError> {
+    let run_id = super::parallel::require_run_id(input, "bootstrap_batch_review")?;
+    let existing_batch_tasks = host.list_tasks_filtered(None, None, None, Some(run_id))?;
+    if !existing_batch_tasks.is_empty() {
+        return Ok(json!({
+            "batch_id": run_id,
+            "task_count": existing_batch_tasks.len(),
+            "tagged_count": 0,
+        }));
+    }
+
+    let pr_number = required_input_string(input, "pr_number")?;
+    let pr_tasks: Vec<Task> = host
+        .list_tasks_filtered(None, None, None, None)?
+        .into_iter()
+        .filter(|task| task.pr_number.as_deref() == Some(pr_number))
+        .collect();
+
+    if pr_tasks.is_empty() {
+        return Err(OrbitError::InvalidInput(format!(
+            "bootstrap_batch_review: no tasks found for pr_number '{pr_number}'"
+        )));
+    }
+
+    for task in &pr_tasks {
+        host.apply_task_automation_update(
+            &task.id,
+            TaskAutomationUpdate {
+                batch_id: Some(run_id.to_string()),
+                ..TaskAutomationUpdate::default()
+            },
+        )?;
+    }
+
+    Ok(json!({
+        "batch_id": run_id,
+        "task_count": pr_tasks.len(),
+        "tagged_count": pr_tasks.len(),
+    }))
+}
+
 pub(super) fn merge_batch_pr<H: RuntimeHost + TaskHost + ?Sized>(
     host: &H,
     input: &Value,
@@ -343,14 +387,16 @@ mod tests {
     };
     use serde_json::{Value, json};
 
-    use super::{build_batch_pr_body, merge_batch_pr, task_required_revision};
+    use super::{
+        bootstrap_batch_review, build_batch_pr_body, merge_batch_pr, task_required_revision,
+    };
     use crate::context::{JobRunResult, RuntimeHost, TaskAutomationUpdate, TaskHost};
     use crate::executor::automation::freshness::BranchFreshness;
 
     struct TestHost {
         tasks: Vec<Task>,
         merge_inputs: Mutex<Vec<Value>>,
-        updated_statuses: Mutex<Vec<(String, Option<TaskStatus>)>>,
+        task_updates: Mutex<Vec<(String, TaskAutomationUpdate)>>,
         scoreboard_dir: PathBuf,
         scoring_enabled: bool,
     }
@@ -360,7 +406,7 @@ mod tests {
             Self {
                 tasks,
                 merge_inputs: Mutex::new(Vec::new()),
-                updated_statuses: Mutex::new(Vec::new()),
+                task_updates: Mutex::new(Vec::new()),
                 scoreboard_dir: PathBuf::from("."),
                 scoring_enabled: false,
             }
@@ -370,7 +416,7 @@ mod tests {
             Self {
                 tasks,
                 merge_inputs: Mutex::new(Vec::new()),
-                updated_statuses: Mutex::new(Vec::new()),
+                task_updates: Mutex::new(Vec::new()),
                 scoreboard_dir,
                 scoring_enabled: true,
             }
@@ -428,10 +474,10 @@ mod tests {
             task_id: &str,
             update: TaskAutomationUpdate,
         ) -> Result<(), OrbitError> {
-            self.updated_statuses
+            self.task_updates
                 .lock()
-                .expect("updated statuses lock")
-                .push((task_id.to_string(), update.status));
+                .expect("task updates lock")
+                .push((task_id.to_string(), update));
             Ok(())
         }
     }
@@ -557,6 +603,12 @@ mod tests {
         }
     }
 
+    fn sample_task_for_pr(id: &str, workspace_path: &str, pr_number: &str) -> Task {
+        let mut task = sample_task(id, "batch-1", workspace_path, pr_number);
+        task.batch_id = None;
+        task
+    }
+
     fn scoreboard_value(path: &Path) -> Value {
         serde_json::from_str(&std::fs::read_to_string(path.join("pr.json")).expect("pr.json"))
             .expect("valid scoreboard json")
@@ -624,10 +676,96 @@ mod tests {
             })
         );
 
-        let updated = host.updated_statuses.lock().expect("updated statuses");
+        let updated = host.task_updates.lock().expect("task updates");
         assert_eq!(
-            updated.as_slice(),
+            updated
+                .iter()
+                .map(|(task_id, update)| (task_id.clone(), update.status))
+                .collect::<Vec<_>>()
+                .as_slice(),
             &[("T20260330-063823".to_string(), Some(TaskStatus::Done))]
+        );
+    }
+
+    #[test]
+    fn bootstrap_batch_review_is_noop_when_batch_already_exists() {
+        let host = TestHost::new(vec![sample_task("T20260330-063823", "batch-9", "/tmp", "76")]);
+
+        let result = bootstrap_batch_review(
+            &host,
+            &json!({
+                "run_id": "batch-9",
+            }),
+        )
+        .expect("bootstrap succeeds");
+
+        assert_eq!(
+            result,
+            json!({
+                "batch_id": "batch-9",
+                "task_count": 1,
+                "tagged_count": 0,
+            })
+        );
+        assert!(host.task_updates.lock().expect("task updates").is_empty());
+    }
+
+    #[test]
+    fn bootstrap_batch_review_tags_tasks_by_pr_number() {
+        let host = TestHost::new(vec![
+            sample_task_for_pr("T20260330-063823", "/tmp", "76"),
+            sample_task_for_pr("T20260330-065846", "/tmp", "76"),
+            sample_task_for_pr("T20260330-071500", "/tmp", "77"),
+        ]);
+
+        let result = bootstrap_batch_review(
+            &host,
+            &json!({
+                "run_id": "batch-9",
+                "pr_number": "76",
+            }),
+        )
+        .expect("bootstrap succeeds");
+
+        assert_eq!(
+            result,
+            json!({
+                "batch_id": "batch-9",
+                "task_count": 2,
+                "tagged_count": 2,
+            })
+        );
+
+        let updated = host.task_updates.lock().expect("task updates");
+        assert_eq!(
+            updated
+                .iter()
+                .map(|(task_id, update)| (task_id.clone(), update.batch_id.clone()))
+                .collect::<Vec<_>>(),
+            vec![
+                ("T20260330-063823".to_string(), Some("batch-9".to_string())),
+                ("T20260330-065846".to_string(), Some("batch-9".to_string())),
+            ]
+        );
+    }
+
+    #[test]
+    fn bootstrap_batch_review_errors_when_no_tasks_match_pr() {
+        let host = TestHost::new(vec![sample_task_for_pr("T20260330-071500", "/tmp", "77")]);
+
+        let error = bootstrap_batch_review(
+            &host,
+            &json!({
+                "run_id": "batch-9",
+                "pr_number": "76",
+            }),
+        )
+        .expect_err("bootstrap should fail");
+
+        assert!(
+            error
+                .to_string()
+                .contains("bootstrap_batch_review: no tasks found for pr_number '76'")
         );
     }
 


### PR DESCRIPTION
## Tasks
### T20260408-0248: Make batch review cycle a first-class Orbit workflow
<details><summary>Execution Summary</summary>

## Status
success

## 1. Summary of Changes
Added a first-class `orbit run review-pr` workflow with explicit `--pr-number` support, then bootstrapped `job_batch_review_cycle` so standalone runs can resolve and tag the relevant batch tasks before review/sync/merge steps execute. Updated README/help examples to promote the new workflow while keeping the underlying job relationship visible.

## 2. Strategic Decisions
- Added a dedicated `review-pr` workflow alias and flag validation in the shared workflow layer | Rationale: keeps the public CLI ergonomic without duplicating job-launch logic in the CLI | Trade-offs: introduces another workflow-specific flag path to maintain.
- Inserted `bootstrap_batch_review` as step 0 of `job_batch_review_cycle` | Rationale: fixes the hidden `batch_id = run_id` coupling at the workflow boundary so downstream review-loop steps continue using the existing batch-id contract | Trade-offs: reruns now retag matching PR tasks onto the current run id.
- Implemented bootstrap inside the existing PR automation module and registered it as a default activity | Rationale: keeps batch review orchestration close to the existing PR review/merge automation | Trade-offs: PR automation module now owns one more responsibility.

## 3. Assumptions Made
- Tasks associated with a standalone batch review already have `pr_number` populated | Impact if incorrect: `review-pr` cannot discover the batch and will fail during bootstrap.
- Re-tagging all tasks that share the supplied PR number onto the current run id is acceptable for standalone reruns | Impact if incorrect: concurrent review runs for the same PR could interfere with each other.

## 4. Design Weaknesses / Risks
- `bootstrap_batch_review` matches tasks solely by `pr_number` when no batch is pre-tagged | Severity: Medium | Mitigation: add an active-run/concurrency guard if simultaneous review cycles for one PR become common.

## 5. Deviations from Original Plan
- None

## 6. Technical Debt Introduced
- None

## 7. Recommended Follow-Ups
- Consider guarding against concurrent standalone review cycles targeting the same PR if that workflow becomes common.

## 8. Overall Assessment
All orbit-core and orbit-engine tests pass (43 and 39 respectively). The `review-pr` workflow, `bootstrap_batch_review` activity, and supporting flag validation are fully tested including new unit tests covering the no-op, tag-by-pr-number, and error cases.

</details>

### T20260406-0455-2: Define planner-to-worker lineage handoff schema
<details><summary>Execution Summary</summary>

## Status
success

## 1. Summary of Changes
Added a planner-to-worker handoff schema in `orbit-map`, including pydantic models (`WorkerHandoffPacket`, `HandoffNodeRef`, `HandoffRisk`, `HandoffConstraint`), markdown rendering with budget support, `GraphContextService.build_handoff_packet()`, a lineage-pack helper `render_lineage_pack_from_handoff()` that accepts the packet shape, documentation updates in README and graph_navigation.md, and 6 focused tests.

## 2. Strategic Decisions
- Keep the handoff packet selector-driven and store canonical selectors in `lineage_pack_selectors` | Rationale: workers can navigate or render lineage context without embedding full graph objects | Trade-offs: the packet carries a small amount of duplicated node metadata for prompt readability.
- Add `render_lineage_pack_from_handoff()` that accepts either a validated model or a compatible dict payload | Rationale: planner output can be consumed directly by downstream tooling without extra reshaping | Trade-offs: validation happens at runtime instead of through a stricter type-only API.

## 3. Assumptions Made
- Worker prompts benefit from lightweight node metadata alongside selectors and IDs | Impact if incorrect: the packet may use slightly more tokens than a selector-only payload.

## 4. Design Weaknesses / Risks
- `WorkerHandoffPacket.to_markdown()` uses a local budget-aware writer instead of a shared rendering utility | Severity: Medium | Mitigation: extract a shared markdown helper if additional packet renderers adopt the same pattern.

## 5. Deviations from Original Plan
- Inlined the handoff markdown writer inside the new schema module instead of refactoring existing bootstrap and lineage renderers to a shared utility | Justification: kept the batch change isolated while still delivering deterministic, budget-aware prompt rendering.

## 6. Technical Debt Introduced
- Markdown budget handling now exists in another local helper | Recommended resolution: consolidate renderer helpers once the handoff format and other markdown outputs stabilize.

## 7. Recommended Follow-Ups
- Consider exposing the handoff packet through planner automation or CLI flows once worker spawning starts consuming it.

## 8. Overall Assessment
All 10 orbit-map pytest tests pass (6 new handoff tests + 4 existing lineage_pack tests). The schema is well-structured and integrates cleanly with the existing graph context service.

</details>

## Branch Freshness
- Base ref: `main`
- Head ref: `orbit/parallel-batch-jrun-20260408-0318`
- Behind base: 0
- Ahead of base: 1

## Files Changed
- `README.md`
- `orbit-map/README.md`
- `orbit-map/graph_navigation.md`
- `orbit-map/orbit_map/schemas/__init__.py`
- `orbit-map/orbit_map/schemas/graph/handoff.py`
- `orbit-map/orbit_map/service/__init__.py`
- `orbit-map/orbit_map/service/graph_context.py`
- `orbit-map/orbit_map/service/lineage_pack.py`
- `orbit-map/tests/test_handoff.py`
- `orbit/orbit-cli/src/command/run.rs`
- `orbit/orbit-core/assets/activities/automation/bootstrap_batch_review.yaml`
- `orbit/orbit-core/assets/jobs/job_batch_review_cycle.yaml`
- `orbit/orbit-core/src/command/activity.rs`
- `orbit/orbit-core/src/command/workflow.rs`
- `orbit/orbit-engine/src/executor/automation/mod.rs`
- `orbit/orbit-engine/src/executor/automation/pr.rs`

*authored by: claude / sonnet*