### PR TITLE
feat: parallel batch [T20260408-0246, T20260408-0242, T20260408-0133, T20260406-0454-2]

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ orbit run review-pr --pr-number 42 --base main
 For advanced cases, the lower-level job interface remains available:
 
 ```bash
-orbit job run <job_id> --input '{"base":"main"}'
+orbit job run <job_id> --input base=main
 ```
 
 ---
@@ -268,7 +268,7 @@ orbit run review-pr --pr-number 42 --base main
 Underlying job:
 
 ```bash
-orbit job run job_batch_review_cycle --input '{"base":"main","pr_number":"42"}'
+orbit job run job_batch_review_cycle --input base=main --input pr_number=42
 ```
 
 ### `job_review_tasks`

--- a/orbit-map/README.md
+++ b/orbit-map/README.md
@@ -151,6 +151,25 @@ orbit-map knowledge pack leaf:src/a.py#a:function --depth 1 --siblings 2 --child
 orbit-map knowledge pack dir:orbit-map/orbit_map/schemas --format json
 ```
 
+### Lineage Brief
+
+Render a worker-oriented markdown brief from task intent plus assigned lineage:
+
+```bash
+orbit-map knowledge brief \
+  --task-id T20260406-0454-2 \
+  --task-title "Add lineage brief builder" \
+  --task-intent "Build a markdown lineage brief for worker bootstrap." \
+  --root dir:orbit-map/orbit_map/service \
+  --target file:orbit-map/orbit_map/service/graph_context.py \
+  --write file:orbit-map/orbit_map/service/graph_context.py \
+  --read-only file:orbit-map/orbit_map/service/lineage_pack.py
+```
+
+The brief keeps full `LeafNode.source` for target leaves by default, summarizes
+related lineage context more compactly, and emits navigation handles that point
+back to `graph context`, `graph lineage`, and `knowledge pack`.
+
 ### Worker Handoff
 
 Planner agents can package lineage scope for worker agents with

--- a/orbit-map/graph_navigation.md
+++ b/orbit-map/graph_navigation.md
@@ -191,6 +191,31 @@ handoff packets stay consistent with graph navigation semantics.
 4. worker expands additional context with `render_lineage_pack_from_handoff(...)`
    using the packet's navigation handles
 
+## Lineage Brief
+
+Worker prompts often need a higher-signal artifact than raw handoff JSON or a
+generic lineage pack. `build_lineage_brief(...)` produces a markdown brief that
+combines:
+
+- task identity and intent
+- the assigned lineage map
+- full source for target leaves by default
+- compact summaries for surrounding lineage and read-only context
+- explicit edit boundaries, risks, constraints, and navigation handles
+
+The CLI entry point is:
+
+```bash
+orbit-map knowledge brief \
+  --task-id T20260406-0454-2 \
+  --task-intent "Build a lineage brief for worker bootstrap." \
+  --root dir:orbit-map/orbit_map/service \
+  --target file:orbit-map/orbit_map/service/graph_context.py
+```
+
+This is intended for planner-to-worker prompt bootstrapping where agents need
+the relevant lineage in markdown form without expanding the full repository.
+
 ---
 
 ## Navigation Model

--- a/orbit-map/orbit_map/cli/knowledge.py
+++ b/orbit-map/orbit_map/cli/knowledge.py
@@ -5,6 +5,7 @@ import logging
 import click
 
 from orbit_map.service.bootstrap import render_knowledge_bootstrap
+from orbit_map.service.lineage_brief import build_lineage_brief
 from orbit_map.service.lineage_pack import render_lineage_pack
 
 from .common import BOOTSTRAP_FORMAT_CHOICES, PACK_FORMAT_CHOICES, resolve_paths
@@ -156,6 +157,112 @@ def knowledge_pack(
             siblings=siblings,
             children=children,
             detail=detail,
+            include_source=include_source,
+            source_budget=source_budget,
+        )
+    )
+
+
+@knowledge.command("brief")
+@click.option("--task-id", required=True, help="Stable task identifier.")
+@click.option("--task-title", default="", help="Optional task title.")
+@click.option("--task-intent", required=True, help="Task intent for the worker.")
+@click.option(
+    "--root",
+    "root_selectors",
+    multiple=True,
+    help="Root lineage selector or node id. Repeat to include multiple roots.",
+)
+@click.option(
+    "--target",
+    "target_selectors",
+    multiple=True,
+    help="Target selector or node id. Repeat to include multiple targets.",
+)
+@click.option(
+    "--write",
+    "write_selectors",
+    multiple=True,
+    help="Writable selector or node id. Defaults to the target selectors.",
+)
+@click.option(
+    "--read-only",
+    "read_only_selectors",
+    multiple=True,
+    help="Read-only selector or node id. Repeat to include multiple context handles.",
+)
+@click.option(
+    "--risk",
+    "risks",
+    multiple=True,
+    help="Planner-supplied risk note. Repeat to include multiple risks.",
+)
+@click.option(
+    "--constraint",
+    "constraints",
+    multiple=True,
+    help="Planner-supplied constraint note. Repeat to include multiple constraints.",
+)
+@click.option("--repo", default=".", help="Repository root path.")
+@click.option(
+    "--output", default=".orbit/knowledge", help="Knowledge output directory."
+)
+@click.option(
+    "--budget",
+    type=int,
+    default=12000,
+    show_default=True,
+    help="Approximate markdown character budget for the rendered brief.",
+)
+@click.option(
+    "--include-source/--no-include-source",
+    default=True,
+    show_default=True,
+    help="Include full source for target leaves when available.",
+)
+@click.option(
+    "--source-budget",
+    type=int,
+    default=0,
+    show_default=True,
+    help="Maximum characters of each target leaf source excerpt to include. Zero keeps full source.",
+)
+def knowledge_brief(
+    task_id: str,
+    task_title: str,
+    task_intent: str,
+    root_selectors: tuple[str, ...],
+    target_selectors: tuple[str, ...],
+    write_selectors: tuple[str, ...],
+    read_only_selectors: tuple[str, ...],
+    risks: tuple[str, ...],
+    constraints: tuple[str, ...],
+    repo: str,
+    output: str,
+    budget: int,
+    include_source: bool,
+    source_budget: int,
+) -> None:
+    """Render a task-oriented lineage brief for worker bootstrap."""
+    if not root_selectors:
+        raise click.UsageError("At least one --root selector is required.")
+    if not target_selectors:
+        raise click.UsageError("At least one --target selector is required.")
+    _, output_dir = resolve_paths(repo, output)
+    logger.info("Rendering lineage brief from %s", output_dir)
+    click.echo(
+        build_lineage_brief(
+            output_dir,
+            task_id=task_id,
+            task_title=task_title,
+            task_intent=task_intent,
+            root_selectors=root_selectors,
+            target_selectors=target_selectors,
+            write_selectors=write_selectors,
+            read_only_selectors=read_only_selectors,
+            risks=risks,
+            constraints=constraints,
+            budget=budget,
             include_source=include_source,
             source_budget=source_budget,
         )

--- a/orbit-map/orbit_map/service/__init__.py
+++ b/orbit-map/orbit_map/service/__init__.py
@@ -5,6 +5,7 @@ from orbit_map.service.graph_context import (
     load_graph_context_service,
 )
 from orbit_map.service.bootstrap import render_knowledge_bootstrap
+from orbit_map.service.lineage_brief import LineageBriefOptions, build_lineage_brief
 from orbit_map.service.lineage_pack import (
     render_lineage_pack,
     render_lineage_pack_from_handoff,
@@ -12,7 +13,9 @@ from orbit_map.service.lineage_pack import (
 
 __all__ = [
     "GraphContextService",
+    "LineageBriefOptions",
     "load_graph_context_service",
+    "build_lineage_brief",
     "render_knowledge_bootstrap",
     "render_lineage_pack",
     "render_lineage_pack_from_handoff",

--- a/orbit-map/orbit_map/service/lineage_brief.py
+++ b/orbit-map/orbit_map/service/lineage_brief.py
@@ -1,0 +1,546 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Sequence
+
+from orbit_map.schemas import FileSummaryV1, FileSymbolV1, HandoffConstraint, HandoffRisk
+from orbit_map.schemas.graph.contexts import NodeContextRef
+from orbit_map.schemas.graph.handoff import HandoffNodeRef, WorkerHandoffPacket
+from orbit_map.schemas.graph.nodes import DirNode, FileNode, LeafNode
+from orbit_map.service.graph_context import GraphContextService
+
+
+@dataclass(slots=True)
+class LineageBriefOptions:
+    task_id: str
+    task_intent: str
+    task_title: str = ""
+    root_selectors: Sequence[str] = ()
+    target_selectors: Sequence[str] = ()
+    write_selectors: Sequence[str] = ()
+    read_only_selectors: Sequence[str] = ()
+    risks: Sequence[HandoffRisk | dict[str, Any] | str] = ()
+    constraints: Sequence[HandoffConstraint | dict[str, Any] | str] = ()
+    budget: int = 12_000
+    include_source: bool = True
+    source_budget: int = 0
+
+
+def build_lineage_brief(
+    knowledge_dir: Path | str,
+    *,
+    task_id: str,
+    task_intent: str,
+    task_title: str = "",
+    root_selectors: Sequence[str],
+    target_selectors: Sequence[str],
+    write_selectors: Sequence[str] = (),
+    read_only_selectors: Sequence[str] = (),
+    risks: Sequence[HandoffRisk | dict[str, Any] | str] = (),
+    constraints: Sequence[HandoffConstraint | dict[str, Any] | str] = (),
+    budget: int = 12_000,
+    include_source: bool = True,
+    source_budget: int = 0,
+) -> str:
+    if not root_selectors:
+        raise ValueError("Lineage brief requires at least one root selector")
+    if not target_selectors:
+        raise ValueError("Lineage brief requires at least one target selector")
+
+    options = LineageBriefOptions(
+        task_id=task_id,
+        task_title=task_title,
+        task_intent=task_intent,
+        root_selectors=tuple(root_selectors),
+        target_selectors=tuple(target_selectors),
+        write_selectors=tuple(write_selectors) if write_selectors else tuple(target_selectors),
+        read_only_selectors=tuple(read_only_selectors),
+        risks=tuple(risks),
+        constraints=tuple(constraints),
+        budget=max(1, budget),
+        include_source=include_source,
+        source_budget=max(0, source_budget),
+    )
+
+    service = GraphContextService.from_knowledge_dir(knowledge_dir)
+    packet = service.build_handoff_packet(
+        task_id=options.task_id,
+        task_title=options.task_title,
+        task_intent=options.task_intent,
+        root_selectors=options.root_selectors,
+        target_selectors=options.target_selectors,
+        write_selectors=options.write_selectors,
+        read_only_selectors=options.read_only_selectors,
+        risks=[_normalize_risk(item) for item in options.risks],
+        constraints=[_normalize_constraint(item) for item in options.constraints],
+        knowledge_dir=str(Path(knowledge_dir)),
+    )
+
+    target_details = [
+        _build_target_detail(service, ref, options) for ref in packet.target_nodes
+    ]
+    target_leaf_ids = {
+        leaf["id"]
+        for detail in target_details
+        for leaf in detail["target_leaves"]
+        if leaf.get("id")
+    }
+    context_nodes = _build_context_nodes(service, packet, target_leaf_ids)
+    return _render_lineage_brief(packet, target_details, context_nodes, options)
+
+
+def _render_lineage_brief(
+    packet: WorkerHandoffPacket,
+    target_details: list[dict[str, Any]],
+    context_nodes: list[dict[str, Any]],
+    options: LineageBriefOptions,
+) -> str:
+    writer = _MarkdownWriter(budget=options.budget)
+
+    writer.line("# Lineage Brief")
+    writer.line()
+    writer.line("## Task")
+    writer.line(f"- task id: `{packet.task_id}`")
+    writer.line(f"- task title: {packet.task_title or '(none)'}")
+    writer.line(f"- task intent: {packet.task_intent}")
+    writer.line()
+    writer.line("## Assigned Lineage")
+    _write_node_section(writer, "Roots", packet.root_nodes)
+    _write_node_section(writer, "Targets", packet.target_nodes)
+    _write_lineage_paths(writer, target_details)
+    if not writer.truncated:
+        writer.line("## Target Nodes")
+        if target_details:
+            for detail in target_details:
+                if not _write_target_detail(writer, detail):
+                    break
+        else:
+            writer.line("- (none)")
+        writer.line()
+    if not writer.truncated:
+        writer.line("## Context Summaries")
+        if context_nodes:
+            for entry in context_nodes:
+                summary = entry["summary"]
+                roles = ", ".join(entry["roles"])
+                line = (
+                    f"- `{entry['selector']}` | roles: {roles} | type: {entry['node_type']}"
+                )
+                if summary:
+                    line += f" | {summary}"
+                if not writer.line(line):
+                    break
+        else:
+            writer.line("- (none)")
+        writer.line()
+    if not writer.truncated:
+        writer.line("## Edit Boundaries")
+        _write_node_section(writer, "Writable Scope", packet.write_nodes)
+        _write_node_section(writer, "Read-Only Scope", packet.read_only_nodes)
+    if not writer.truncated:
+        writer.line("## Risks")
+        if packet.risks:
+            for risk in packet.risks:
+                if not writer.line(risk.to_markdown_line()):
+                    break
+        else:
+            writer.line("- (none)")
+        writer.line()
+    if not writer.truncated:
+        writer.line("## Constraints")
+        if packet.constraints:
+            for constraint in packet.constraints:
+                if not writer.line(constraint.to_markdown_line()):
+                    break
+        else:
+            writer.line("- (none)")
+        writer.line()
+    if not writer.truncated:
+        writer.line("## Navigation")
+        writer.line(f"- knowledge dir: `{packet.knowledge_dir or '(none)'}`")
+        writer.line(
+            "- graph selectors: "
+            + (
+                ", ".join(f"`{selector}`" for selector in packet.navigation_selectors())
+                if packet.navigation_selectors()
+                else "(none)"
+            )
+        )
+        if packet.target_nodes:
+            writer.line(
+                "- inspect first target: "
+                f"`orbit-map graph context {packet.target_nodes[0].selector}`"
+            )
+            writer.line(
+                "- trace first target lineage: "
+                f"`orbit-map graph lineage {packet.target_nodes[0].selector} --include-self`"
+            )
+        if packet.navigation_selectors():
+            selector_args = " ".join(packet.navigation_selectors())
+            writer.line(f"- render lineage pack: `orbit-map knowledge pack {selector_args}`")
+
+    if writer.truncated:
+        writer.note("_output truncated to respect the requested budget._")
+
+    return writer.text()
+
+
+def _write_lineage_paths(
+    writer: "_MarkdownWriter", target_details: list[dict[str, Any]]
+) -> None:
+    if not writer.line("### Lineage Paths"):
+        return
+    if target_details:
+        for detail in target_details:
+            if not writer.line(
+                f"- `{detail['selector']}`: "
+                + " -> ".join(f"`{selector}`" for selector in detail["lineage"])
+            ):
+                break
+    else:
+        writer.line("- (none)")
+    writer.line()
+
+
+def _write_target_detail(writer: "_MarkdownWriter", detail: dict[str, Any]) -> bool:
+    if not writer.line(f"### `{detail['selector']}`"):
+        return False
+    writer.line(f"- type: {detail['node_type']}")
+    writer.line(f"- writable: {'yes' if detail['is_writable'] else 'no'}")
+    writer.line(
+        "- lineage: " + " -> ".join(f"`{selector}`" for selector in detail["lineage"])
+    )
+    if detail["summary"]:
+        writer.line(f"- summary: {detail['summary']}")
+    if detail["target_leaves"]:
+        writer.line("- target leaves:")
+        for leaf in detail["target_leaves"]:
+            line = f"  - `{leaf['signature']}` (`{leaf['selector']}`)"
+            if leaf.get("file_selector"):
+                line += f" | file: `{leaf['file_selector']}`"
+            if leaf.get("description"):
+                line += f" | {leaf['description']}"
+            if not writer.line(line):
+                return False
+            source = leaf.get("source")
+            if source:
+                if not writer.line("    ```"):
+                    return False
+                for source_line in source.splitlines():
+                    if not writer.line(f"    {source_line}"):
+                        return False
+                if not writer.line("    ```"):
+                    return False
+    else:
+        writer.line("- target leaves: (none)")
+    writer.line()
+    return not writer.truncated
+
+
+def _write_node_section(
+    writer: "_MarkdownWriter", heading: str, nodes: list[HandoffNodeRef]
+) -> None:
+    if not writer.line(f"### {heading}"):
+        return
+    if nodes:
+        for node in nodes:
+            if not writer.line(node.to_markdown_line()):
+                break
+    else:
+        writer.line("- (none)")
+    writer.line()
+
+
+def _build_target_detail(
+    service: GraphContextService,
+    ref: HandoffNodeRef,
+    options: LineageBriefOptions,
+) -> dict[str, Any]:
+    node = service.get_node(ref.id)
+    return {
+        "selector": ref.selector,
+        "node_type": ref.node_type,
+        "summary": _single_line(_node_summary(service, node)),
+        "lineage": [
+            service.selector_for_node(item)
+            for item in service.navigator.get_lineage(node.id, include_self=True)
+        ],
+        "is_writable": _is_node_covered(service, node, options.write_selectors),
+        "target_leaves": _expand_target_leaves(service, node, options),
+    }
+
+
+def _build_context_nodes(
+    service: GraphContextService,
+    packet: WorkerHandoffPacket,
+    target_leaf_ids: set[str],
+) -> list[dict[str, Any]]:
+    target_ids = {ref.id for ref in packet.target_nodes}
+    tagged_ids: dict[str, set[str]] = {}
+
+    for ref in packet.root_nodes:
+        _add_role(tagged_ids, ref.id, "root")
+    for ref in packet.write_nodes:
+        _add_role(tagged_ids, ref.id, "write")
+    for ref in packet.read_only_nodes:
+        _add_role(tagged_ids, ref.id, "read-only")
+
+    for ref in packet.target_nodes:
+        for ancestor in service.navigator.get_lineage(ref.id):
+            _add_role(tagged_ids, ancestor.id, "lineage")
+        for sibling in sorted(
+            service.navigator.get_siblings(ref.id), key=lambda item: item.location
+        )[:2]:
+            _add_role(tagged_ids, sibling.id, "sibling")
+
+    entries: list[dict[str, Any]] = []
+    for node_id in sorted(
+        tagged_ids,
+        key=lambda current_id: service.selector_for_node(service.get_node(current_id)),
+    ):
+        if node_id in target_ids or node_id in target_leaf_ids:
+            continue
+        node = service.get_node(node_id)
+        entries.append(
+            {
+                "selector": service.selector_for_node(node),
+                "node_type": node.node_type,
+                "roles": sorted(tagged_ids[node_id]),
+                "summary": _single_line(_node_summary(service, node)),
+            }
+        )
+    return entries
+
+
+def _expand_target_leaves(
+    service: GraphContextService,
+    node: DirNode | FileNode | LeafNode,
+    options: LineageBriefOptions,
+) -> list[dict[str, Any]]:
+    if isinstance(node, LeafNode):
+        return [_leaf_detail_from_node(service, node, options)]
+    if isinstance(node, FileNode):
+        return _leaf_details_from_file(service, node, options)
+
+    details: list[dict[str, Any]] = []
+    for file_node in _descendant_files(service, node):
+        details.extend(_leaf_details_from_file(service, file_node, options))
+    return details
+
+
+def _leaf_details_from_file(
+    service: GraphContextService,
+    file_node: FileNode,
+    options: LineageBriefOptions,
+) -> list[dict[str, Any]]:
+    context = service.get_file_context(file_node.id)
+    summary = _summary_for_file(service, file_node)
+    return [
+        _leaf_detail_from_ref(service, file_node, ref, summary, options)
+        for ref in context.top_level_leaves
+    ]
+
+
+def _leaf_detail_from_node(
+    service: GraphContextService,
+    node: LeafNode,
+    options: LineageBriefOptions,
+) -> dict[str, Any]:
+    containing_file = service.navigator.get_containing_file(node.id)
+    return {
+        "id": node.id,
+        "selector": service.selector_for_node(node),
+        "signature": _leaf_signature(node),
+        "description": _single_line(node.description),
+        "file_selector": (
+            service.selector_for_node(containing_file) if containing_file is not None else ""
+        ),
+        "source": _render_leaf_source(node.source, options),
+    }
+
+
+def _leaf_detail_from_ref(
+    service: GraphContextService,
+    file_node: FileNode,
+    ref: NodeContextRef,
+    summary: FileSummaryV1 | None,
+    options: LineageBriefOptions,
+) -> dict[str, Any]:
+    node = service.navigator.node_index.get(ref.id)
+    if isinstance(node, LeafNode):
+        return _leaf_detail_from_node(service, node, options)
+
+    symbol = _summary_symbol(summary, ref.name, ref.kind)
+    return {
+        "id": ref.id,
+        "selector": _selector_for_ref(ref),
+        "signature": symbol.signature if symbol is not None else ref.name,
+        "description": _single_line(
+            symbol.description if symbol is not None else ref.description
+        ),
+        "file_selector": service.selector_for_node(file_node),
+    }
+
+
+def _render_leaf_source(source: str, options: LineageBriefOptions) -> str:
+    if not options.include_source or not source:
+        return ""
+    if options.source_budget > 0:
+        return source[: options.source_budget]
+    return source
+
+
+def _descendant_files(
+    service: GraphContextService, dir_node: DirNode
+) -> list[FileNode]:
+    files: list[FileNode] = []
+    queue = [dir_node]
+
+    while queue:
+        current = queue.pop(0)
+        child_dirs = [
+            service.navigator.get_dir(child_id) for child_id in current.dir_children
+        ]
+        child_files = [
+            service.navigator.get_file(child_id) for child_id in current.file_children
+        ]
+        child_dirs.sort(key=lambda item: item.location)
+        child_files.sort(key=lambda item: item.location)
+        queue.extend(child_dirs)
+        files.extend(child_files)
+
+    return files
+
+
+def _normalize_risk(item: HandoffRisk | dict[str, Any] | str) -> dict[str, Any]:
+    if isinstance(item, HandoffRisk):
+        return item.model_dump(mode="json")
+    if isinstance(item, str):
+        return {"description": item}
+    return item
+
+
+def _normalize_constraint(
+    item: HandoffConstraint | dict[str, Any] | str,
+) -> dict[str, Any]:
+    if isinstance(item, HandoffConstraint):
+        return item.model_dump(mode="json")
+    if isinstance(item, str):
+        return {"description": item}
+    return item
+
+
+def _add_role(tagged_ids: dict[str, set[str]], node_id: str, role: str) -> None:
+    tagged_ids.setdefault(node_id, set()).add(role)
+
+
+def _is_node_covered(
+    service: GraphContextService, node: DirNode | FileNode | LeafNode, selectors: Sequence[str]
+) -> bool:
+    for selector in selectors:
+        scope_node = service.resolve_selector(selector)
+        current: DirNode | FileNode | LeafNode | None = node
+        while current is not None:
+            if current.id == scope_node.id:
+                return True
+            parent = service.navigator.get_parent(current.id)
+            current = parent if parent is not None else None
+    return False
+
+
+def _node_summary(service: GraphContextService, node: DirNode | FileNode | LeafNode) -> str:
+    if isinstance(node, DirNode):
+        return node.description
+    if isinstance(node, FileNode):
+        return service.get_file_context(node.id).summary
+    return node.description or _leaf_signature(node)
+
+
+def _summary_for_file(
+    service: GraphContextService, file_node: FileNode
+) -> FileSummaryV1 | None:
+    if file_node.source_blob_hash is None:
+        return None
+    return service.file_summaries_by_hash.get(file_node.source_blob_hash)
+
+
+def _summary_symbol(
+    summary: FileSummaryV1 | None, name: str, kind: str | None
+) -> FileSymbolV1 | None:
+    if summary is None:
+        return None
+    for symbol in summary.symbols:
+        if symbol.name == name and (kind is None or symbol.kind == kind):
+            return symbol
+    return None
+
+
+def _leaf_signature(node: LeafNode) -> str:
+    inputs = ", ".join(
+        _signature_field(field.name, field.annotation) for field in node.input_signature
+    )
+    signature = f"{node.name}({inputs})" if inputs else f"{node.name}()"
+    outputs = _render_outputs(node.output_signature)
+    if outputs:
+        signature += f" -> {outputs}"
+    return signature
+
+
+def _signature_field(name: str, annotation: str | None) -> str:
+    return f"{name}: {annotation}" if annotation else name
+
+
+def _render_outputs(fields: list[Any]) -> str:
+    if not fields:
+        return ""
+    if len(fields) == 1:
+        annotation = fields[0].annotation
+        if annotation:
+            return annotation
+        return fields[0].name
+    return ", ".join(_signature_field(field.name, field.annotation) for field in fields)
+
+
+def _selector_for_ref(ref: NodeContextRef) -> str:
+    if ref.node_type == "dir":
+        return f"dir:{ref.location}"
+    if ref.node_type == "file":
+        return f"file:{ref.location}"
+    return f"leaf:{ref.location}:{ref.kind}"
+
+
+def _single_line(text: str | None) -> str:
+    if not text:
+        return ""
+    return " ".join(text.split())
+
+
+class _MarkdownWriter:
+    def __init__(self, budget: int):
+        self.budget = budget
+        self._parts: list[str] = []
+        self._length = 0
+        self.truncated = False
+
+    def line(self, text: str = "") -> bool:
+        if self.truncated:
+            return False
+        piece = f"{text}\n"
+        if self._length + len(piece) > self.budget:
+            self.truncated = True
+            return False
+        self._parts.append(piece)
+        self._length += len(piece)
+        return True
+
+    def note(self, text: str) -> None:
+        piece = f"{text}\n"
+        if self._length + len(piece) <= self.budget:
+            self._parts.append(piece)
+            self._length += len(piece)
+
+    def text(self) -> str:
+        if not self._parts:
+            return ""
+        return "".join(self._parts).rstrip() + "\n"

--- a/orbit/orbit-cli/src/command/job.rs
+++ b/orbit/orbit-cli/src/command/job.rs
@@ -210,6 +210,9 @@ impl Execute for JobShowArgs {
 }
 
 #[derive(Args)]
+#[command(
+    after_help = "Examples:\n  orbit job run my_job\n  orbit job run my_job --input base=main --input pr_number=42"
+)]
 pub struct JobRunArgs {
     pub job_id: String,
     /// Input key=value pairs passed to all job steps (repeatable).

--- a/orbit/orbit-cli/src/command/tool.rs
+++ b/orbit/orbit-cli/src/command/tool.rs
@@ -169,6 +169,12 @@ pub struct ToolRunArgs {
     /// Path to a JSON file to use as input (bypasses shell escaping; preferred for markdown or multi-line content)
     #[arg(long, conflicts_with = "input")]
     pub input_file: Option<String>,
+    /// Explicit agent name for provenance attribution (overrides ORBIT_AGENT_NAME)
+    #[arg(long)]
+    pub agent: Option<String>,
+    /// Explicit agent model for provenance attribution (overrides ORBIT_AGENT_MODEL)
+    #[arg(long)]
+    pub model: Option<String>,
     /// Execution timeout (e.g. "30s", "5000ms")
     #[arg(long)]
     pub timeout: Option<String>,
@@ -215,7 +221,7 @@ impl Execute for ToolRunArgs {
             return Ok(());
         }
 
-        let output = runtime.execute_tool_command(&self.name, input)?;
+        let output = runtime.execute_tool_command(&self.name, input, self.agent, self.model)?;
 
         match self.output {
             OutputFormat::Json => crate::output::json::print_pretty(&output),

--- a/orbit/orbit-core/assets/activities/agent_invoke/implement_change.yaml
+++ b/orbit/orbit-core/assets/activities/agent_invoke/implement_change.yaml
@@ -17,9 +17,11 @@ activity:
 
     Steps:
     1. Load task context:
-       - Call orbit.task.show with id: input.task_id to fetch the task's title, description,
-         acceptance_criteria, plan, context_files, workspace_path, and repo_root.
-       - The task's workspace_path is the authoritative implementation workspace.
+       - Read the injected `task` object from this execution envelope. When `input.task_id`
+         is present, Orbit preloads `task.id`, `task.title`, `task.description`,
+         `task.acceptance_criteria`, `task.plan`, `task.context_files`,
+         `task.workspace_path`, and `task.repo_root` for you.
+       - The injected task snapshot is the authoritative task context for implementation.
        - However, if input.workspace_path is provided (as in parallel batch execution),
          it takes precedence over the task's workspace_path. This ensures agents work
          in the correct worktree when running inside a batch pipeline.
@@ -109,7 +111,7 @@ activity:
     properties:
       task_id:
         type: string
-        description: Orbit task ID. The agent loads task metadata (workspace_path, repo_root, branch) via orbit.task.show.
+        description: Orbit task ID. When present, Orbit injects task metadata into the execution envelope's `task` field before invoking the agent.
       verification_mode:
         type: string
         description: Optional verification policy. Use `deferred` when this implementation is part of a parallel batch and verification must wait for `finalize_tasks`.
@@ -126,7 +128,6 @@ activity:
     - orbit
     - orbit-track-issues
   tools:
-    - orbit.task.show
     - orbit.task.update
     - orbit.task.add
     - fs.write

--- a/orbit/orbit-core/assets/skills/orbit-raise-pr/SKILL.md
+++ b/orbit/orbit-core/assets/skills/orbit-raise-pr/SKILL.md
@@ -7,13 +7,35 @@ description: Use this skill when creating pull requests and replying to comments
 
 ## Purpose
 
-Standardize how agents interact with pull requests — creating, commenting, and replying. 
+Standardize how agents interact with pull requests - creating, commenting, and replying.
 
-When this workflow needs Orbit task metadata, include `agent` and `model` on every `orbit tool run orbit.*` call so Orbit records precise provenance instead of the generic `agent` label.
+When this workflow needs Orbit task metadata, include `agent` and `model` so Orbit records precise provenance instead of the generic `agent` label.
 
 ## Signature
 
 The **agent-identity-signature** (defined in CLAUDE.md / AGENTS.md) must be appended to the end of your PR bodies and PR comment replies: `*authored by: <agent> / <model>*`
+
+## Provenance
+
+Use the provenance path that matches the tool family:
+
+- `orbit.*` tools: pass `agent` and `model` inside the `--input` JSON body
+- `github.*` tools: pass `--agent` and `--model` to `orbit tool run`, or set `ORBIT_AGENT_NAME` / `ORBIT_AGENT_MODEL`
+
+Examples:
+
+```bash
+orbit tool run orbit.task.show --input '{
+  "id": "<task-id>",
+  "agent": "<agent>",
+  "model": "<model>"
+}'
+
+orbit tool run github.pr.view \
+  --input '{"pr": <pr-number>}' \
+  --agent <agent> \
+  --model <model>
+```
 
 ## PR Tool Reference
 

--- a/orbit/orbit-core/src/command/tool.rs
+++ b/orbit/orbit-core/src/command/tool.rs
@@ -32,9 +32,15 @@ pub struct DoctorResult {
 }
 
 impl OrbitRuntime {
-    pub fn execute_tool_command(&self, name: &str, input: Value) -> Result<Value, OrbitError> {
+    pub fn execute_tool_command(
+        &self,
+        name: &str,
+        input: Value,
+        agent_override: Option<String>,
+        model_override: Option<String>,
+    ) -> Result<Value, OrbitError> {
         let allowed_tools = read_activity_tools_from_env();
-        let (agent_name, model_name) = read_agent_identity_from_env();
+        let (agent_name, model_name) = resolve_agent_identity(agent_override, model_override);
         let proc_allowed_programs = read_proc_allowed_programs_from_env();
         let cwd = std::env::current_dir()
             .ok()
@@ -60,6 +66,17 @@ fn read_agent_identity_from_env() -> (Option<String>, Option<String>) {
         .ok()
         .filter(|s| !s.is_empty());
     (agent, model)
+}
+
+fn resolve_agent_identity(
+    agent_override: Option<String>,
+    model_override: Option<String>,
+) -> (Option<String>, Option<String>) {
+    let (env_agent_name, env_model_name) = read_agent_identity_from_env();
+    (
+        agent_override.or(env_agent_name),
+        model_override.or(env_model_name),
+    )
 }
 
 fn read_proc_allowed_programs_from_env() -> Vec<String> {
@@ -317,7 +334,7 @@ mod tests {
     use orbit_types::OrbitError;
     use serde_json::{Value, json};
 
-    use super::read_activity_tools_from_env;
+    use super::{read_activity_tools_from_env, resolve_agent_identity};
     use crate::OrbitRuntime;
 
     static ENV_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
@@ -414,6 +431,47 @@ mod tests {
     }
 
     #[test]
+    fn resolve_agent_identity_prefers_cli_overrides() {
+        with_test_env(
+            &[
+                ("ORBIT_AGENT_NAME", Some("env-agent")),
+                ("ORBIT_AGENT_MODEL", Some("env-model")),
+            ],
+            || {
+                assert_eq!(
+                    resolve_agent_identity(
+                        Some("cli-agent".to_string()),
+                        Some("cli-model".to_string())
+                    ),
+                    (
+                        Some("cli-agent".to_string()),
+                        Some("cli-model".to_string())
+                    )
+                );
+            },
+        );
+    }
+
+    #[test]
+    fn resolve_agent_identity_falls_back_to_env_when_overrides_missing() {
+        with_test_env(
+            &[
+                ("ORBIT_AGENT_NAME", Some("env-agent")),
+                ("ORBIT_AGENT_MODEL", Some("env-model")),
+            ],
+            || {
+                assert_eq!(
+                    resolve_agent_identity(None, None),
+                    (
+                        Some("env-agent".to_string()),
+                        Some("env-model".to_string())
+                    )
+                );
+            },
+        );
+    }
+
+    #[test]
     fn execute_tool_command_allows_allowlisted_tool_for_agent_actor() {
         with_test_env(
             &[
@@ -426,7 +484,7 @@ mod tests {
             || {
                 let runtime = OrbitRuntime::in_memory().expect("runtime");
                 let output = runtime
-                    .execute_tool_command("time.now", json!({}))
+                    .execute_tool_command("time.now", json!({}), None, None)
                     .expect("allowlisted tool should run");
 
                 assert!(output.get("now").and_then(Value::as_str).is_some());
@@ -447,7 +505,7 @@ mod tests {
             || {
                 let runtime = OrbitRuntime::in_memory().expect("runtime");
                 let error = runtime
-                    .execute_tool_command("time.sleep", json!({"ms": 0}))
+                    .execute_tool_command("time.sleep", json!({"ms": 0}), None, None)
                     .expect_err("disallowed tool should be rejected");
 
                 assert!(matches!(

--- a/orbit/orbit-core/src/runtime/engine.rs
+++ b/orbit/orbit-core/src/runtime/engine.rs
@@ -24,6 +24,8 @@ struct ExecutionEnvelope {
     skills: Vec<ExecutionSkillEnvelope>,
     input: Value,
     memory: Value,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    task: Option<Value>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -41,6 +43,7 @@ fn build_agent_stdin_envelope_payload(
 ) -> Result<Vec<u8>, OrbitError> {
     let skill_refs = activity_skill_refs_from_spec_config(&execution.activity.spec_config)?;
     let skills = runtime.resolve_activity_skill_refs(&skill_refs)?;
+    let task = task_detail_for_input(runtime, &execution.input)?;
     let envelope = ExecutionEnvelope {
         schema_version: 1,
         activity: activity_envelope_json(&execution.activity),
@@ -69,10 +72,47 @@ fn build_agent_stdin_envelope_payload(
             .collect(),
         input: execution.input.clone(),
         memory: json!({}),
+        task,
     };
 
     serde_json::to_vec(&envelope)
         .map_err(|e| OrbitError::Execution(format!("failed to serialize stdin envelope: {e}")))
+}
+
+fn task_detail_for_input<H: TaskHost + ?Sized>(
+    host: &H,
+    input: &Value,
+) -> Result<Option<Value>, OrbitError> {
+    let Some(task_id) = input.get("task_id").and_then(Value::as_str) else {
+        return Ok(None);
+    };
+
+    let task = host.get_task(task_id)?;
+    Ok(Some(task_detail_envelope_json(&task, input)))
+}
+
+fn task_detail_envelope_json(task: &Task, input: &Value) -> Value {
+    let workspace_path = input
+        .get("workspace_path")
+        .and_then(Value::as_str)
+        .map(ToOwned::to_owned)
+        .or_else(|| task.workspace_path.clone());
+    let repo_root = input
+        .get("repo_root")
+        .and_then(Value::as_str)
+        .map(ToOwned::to_owned)
+        .or_else(|| task.repo_root.clone());
+
+    json!({
+        "id": task.id.clone(),
+        "title": task.title.clone(),
+        "description": task.description.clone(),
+        "acceptance_criteria": task.acceptance_criteria.clone(),
+        "plan": task.plan.clone(),
+        "context_files": task.context_files.clone(),
+        "workspace_path": workspace_path,
+        "repo_root": repo_root,
+    })
 }
 
 fn execute_commit_request_if_present(
@@ -507,9 +547,126 @@ fn codex_workspace_write_writable_dirs(paths: &WorkspacePaths) -> Vec<String> {
 mod tests {
     use std::path::PathBuf;
 
-    use orbit_types::WorkspacePaths;
+    use chrono::Utc;
+    use orbit_engine::TaskAutomationUpdate;
+    use orbit_types::{
+        Activity, ActorIdentity, OrbitError, ReviewThread, Task, TaskPriority, TaskStatus,
+        TaskType, WorkspacePaths,
+    };
+    use serde_json::json;
 
-    use super::codex_workspace_write_writable_dirs;
+    use super::{
+        ExecutionEnvelope, ExecutionSkillEnvelope, activity_envelope_json,
+        codex_workspace_write_writable_dirs, task_detail_envelope_json, task_detail_for_input,
+    };
+
+    struct MockTaskHost {
+        task: Task,
+    }
+
+    impl orbit_engine::TaskHost for MockTaskHost {
+        fn get_task(&self, task_id: &str) -> Result<Task, OrbitError> {
+            if self.task.id == task_id {
+                Ok(self.task.clone())
+            } else {
+                Err(OrbitError::TaskNotFound(task_id.to_string()))
+            }
+        }
+
+        fn list_tasks_filtered(
+            &self,
+            _status: Option<TaskStatus>,
+            _priority: Option<TaskPriority>,
+            _parent_id: Option<&str>,
+            _batch_id: Option<&str>,
+        ) -> Result<Vec<Task>, OrbitError> {
+            unreachable!("not used in this test")
+        }
+
+        fn start_task(
+            &self,
+            _task_id: &str,
+            _note: Option<String>,
+            _comment: Option<String>,
+        ) -> Result<Task, OrbitError> {
+            unreachable!("not used in this test")
+        }
+
+        fn update_task_from_activity(
+            &self,
+            _task_id: &str,
+            _status: TaskStatus,
+            _execution_summary: Option<String>,
+            _comment: Option<String>,
+            _note: Option<String>,
+        ) -> Result<Task, OrbitError> {
+            unreachable!("not used in this test")
+        }
+
+        fn apply_task_automation_update(
+            &self,
+            _task_id: &str,
+            _update: TaskAutomationUpdate,
+        ) -> Result<(), OrbitError> {
+            unreachable!("not used in this test")
+        }
+    }
+
+    fn sample_task() -> Task {
+        let now = Utc::now();
+        Task {
+            id: "T20260408-0133".to_string(),
+            parent_id: None,
+            title: "Inject task details".to_string(),
+            description: "Populate task details in the agent envelope.".to_string(),
+            acceptance_criteria: vec!["task field is present".to_string()],
+            plan: "1. Inject task detail\n2. Update tests".to_string(),
+            execution_summary: String::new(),
+            context_files: vec![
+                "orbit/orbit-core/src/runtime/engine.rs".to_string(),
+                "orbit/orbit-core/assets/activities/agent_invoke/implement_change.yaml"
+                    .to_string(),
+            ],
+            workspace_path: Some("/task/worktree".to_string()),
+            repo_root: Some("/task/repo".to_string()),
+            assigned_to: None,
+            created_by: None,
+            actor_identity: ActorIdentity::default(),
+            status: TaskStatus::InProgress,
+            priority: TaskPriority::High,
+            complexity: None,
+            task_type: TaskType::Feature,
+            pr_number: None,
+            pr_status: None,
+            proposed_by: None,
+            source_task_id: None,
+            batch_id: None,
+            comments: vec![],
+            history: vec![],
+            review_threads: Vec::<ReviewThread>::new(),
+            created_at: now,
+            updated_at: now,
+        }
+    }
+
+    fn sample_activity() -> Activity {
+        let now = Utc::now();
+        Activity {
+            id: "implement_change".to_string(),
+            spec_type: "agent_invoke".to_string(),
+            description: "test activity".to_string(),
+            input_schema_json: json!({}),
+            output_schema_json: json!({}),
+            spec_config: json!({}),
+            tools: vec!["orbit.task.update".to_string()],
+            proc_allowed_programs: vec!["cargo".to_string()],
+            workspace_path: None,
+            created_by: None,
+            is_active: true,
+            created_at: now,
+            updated_at: now,
+        }
+    }
 
     #[test]
     fn workspace_write_includes_workspace_and_global_orbit_dirs() {
@@ -537,5 +694,96 @@ mod tests {
             codex_workspace_write_writable_dirs(&paths),
             vec!["/repo/.orbit".to_string()]
         );
+    }
+
+    #[test]
+    fn task_detail_envelope_prefers_input_overrides() {
+        let detail = task_detail_envelope_json(
+            &sample_task(),
+            &json!({
+                "workspace_path": "/override/worktree",
+                "repo_root": "/override/repo",
+            }),
+        );
+
+        assert_eq!(detail.get("workspace_path"), Some(&json!("/override/worktree")));
+        assert_eq!(detail.get("repo_root"), Some(&json!("/override/repo")));
+    }
+
+    #[test]
+    fn task_detail_envelope_falls_back_to_task_paths() {
+        let detail = task_detail_envelope_json(&sample_task(), &json!({}));
+
+        assert_eq!(detail.get("id"), Some(&json!("T20260408-0133")));
+        assert_eq!(detail.get("workspace_path"), Some(&json!("/task/worktree")));
+        assert_eq!(detail.get("repo_root"), Some(&json!("/task/repo")));
+    }
+
+    #[test]
+    fn task_detail_for_input_returns_none_without_task_id() {
+        let host = MockTaskHost {
+            task: sample_task(),
+        };
+
+        let detail = task_detail_for_input(&host, &json!({})).expect("task detail");
+
+        assert!(detail.is_none());
+    }
+
+    #[test]
+    fn serialized_execution_envelope_includes_task_details_when_present() {
+        let host = MockTaskHost {
+            task: sample_task(),
+        };
+        let input = json!({
+            "task_id": "T20260408-0133",
+            "workspace_path": "/override/worktree",
+        });
+        let task = task_detail_for_input(&host, &input).expect("task detail");
+
+        let envelope = ExecutionEnvelope {
+            schema_version: 1,
+            activity: activity_envelope_json(&sample_activity()),
+            job: None,
+            skills: vec![ExecutionSkillEnvelope {
+                id: "orbit".to_string(),
+                content_hash: "hash".to_string(),
+                content: "content".to_string(),
+                meta: None,
+            }],
+            input,
+            memory: json!({}),
+            task,
+        };
+
+        let serialized = serde_json::to_value(&envelope).expect("serialized envelope");
+
+        assert_eq!(
+            serialized.get("task").and_then(|task| task.get("title")),
+            Some(&json!("Inject task details"))
+        );
+        assert_eq!(
+            serialized
+                .get("task")
+                .and_then(|task| task.get("workspace_path")),
+            Some(&json!("/override/worktree"))
+        );
+    }
+
+    #[test]
+    fn serialized_execution_envelope_omits_task_field_when_absent() {
+        let envelope = ExecutionEnvelope {
+            schema_version: 1,
+            activity: activity_envelope_json(&sample_activity()),
+            job: None,
+            skills: vec![],
+            input: json!({}),
+            memory: json!({}),
+            task: None,
+        };
+
+        let serialized = serde_json::to_value(&envelope).expect("serialized envelope");
+
+        assert!(serialized.get("task").is_none());
     }
 }


### PR DESCRIPTION
## Tasks
### T20260408-0246: Align orbit job run docs with actual input syntax
<details><summary>Execution Summary</summary>

## Status
success

## 1. Summary of Changes
Updated the README examples for `orbit job run` so both the generic invocation and the batch review cycle use repeatable `--input key=value` flags instead of JSON. Added an `after_help` example to `JobRunArgs` so `orbit job run --help` now documents the supported syntax directly in the CLI surface.

## 2. Strategic Decisions
- Kept the task scoped to docs and help text only | Rationale: The task explicitly asked to align guidance with current behavior, not redesign the interface | Trade-offs: The CLI still differs from `orbit tool run --input`, so users must rely on clearer docs rather than a unified input format.
- Added a clap `after_help` example instead of changing parser behavior | Rationale: This makes the correct usage obvious where users ask for it most often | Trade-offs: Help text must stay in sync manually if `job run` input rules ever change.

## 3. Assumptions Made
- The current `orbit job run` parser continues to accept repeatable `key=value` pairs exactly as documented in the task plan | Impact if incorrect: The updated examples would still be misleading and final verification would fail.
- Deferred verification will be completed by the batch finalization phase | Impact if incorrect: A compile or help-rendering issue could remain undiscovered until later.

## 4. Design Weaknesses / Risks
- Verification was deferred for this worker run, so the updated clap attribute was not compiled or exercised here | Severity: Medium | Mitigation: Run the planned finalization checks, including `cargo build -p orbit-cli` and a help output check, before review completes.
- `orbit job run` still uses a different input style than `orbit tool run`, which may continue to surprise users | Severity: Low | Mitigation: Keep help text and docs aligned, and consider a separate UX task if confusion persists.

## 5. Deviations from Original Plan
None

## 6. Technical Debt Introduced
None

## 7. Recommended Follow-Ups
- During finalization, verify `orbit job run --help` renders the new example block and that no remaining `orbit job run --input '{...}'` examples exist in touched docs.

</details>

### T20260408-0242: Align orbit tool run provenance interface with Orbit PR/task skills
<details><summary>Execution Summary</summary>

## Status
success

## 1. Summary of Changes
Added `--agent` and `--model` flags to `orbit tool run`, threaded those overrides into `OrbitRuntime::execute_tool_command`, and documented the split provenance patterns in the seeded `orbit-raise-pr` skill. This makes GitHub tool invocations accept explicit CLI provenance while preserving existing env var and `orbit.*` JSON-input behavior.

## 2. Strategic Decisions
- Added CLI provenance flags only at `orbit tool run` and merged them in runtime context resolution | Rationale: GitHub tools read identity from `ToolContext`, so the CLI boundary is the smallest compatible fix | Trade-offs: `execute_tool_command` gained two extra parameters that call sites must pass
- Kept `orbit.*` provenance documented as JSON input instead of rewriting tool semantics | Rationale: `orbit-tools` already prefers input `agent` and `model`, so no behavior change was needed there | Trade-offs: Orbit now supports two provenance entry points depending on tool family

## 3. Assumptions Made
- The seeded skill source of truth for this repo is `orbit/orbit-core/assets/skills/orbit-raise-pr/SKILL.md` | Impact if incorrect: the doc update would miss the file that workspace initialization copies into agent-visible skill directories
- Deferred verification will be completed by the batch finalization phase | Impact if incorrect: compile or integration regressions could remain undiscovered until later

## 4. Design Weaknesses / Risks
- Verification was intentionally deferred for this parallel worker run | Severity: Medium | Mitigation: run the planned cargo build and test commands during `finalize_tasks` before review proceeds
- CLI flags and JSON input can now both carry provenance depending on tool family | Severity: Low | Mitigation: the updated skill docs now spell out which path applies to `orbit.*` versus `github.*` tools

## 5. Deviations from Original Plan
- Updated `orbit/orbit-core/assets/skills/orbit-raise-pr/SKILL.md` instead of `.orbit/skills/orbit-raise-pr/SKILL.md` | Justification: the task context path did not exist in the worktree, so I updated the actual seeded skill asset and tracked the path mismatch as friction in `T20260408-0400-2`

## 6. Technical Debt Introduced
None

## 7. Recommended Follow-Ups
- Run the deferred verification commands in batch finalization, especially `cargo test -p orbit-core` and `cargo test -p orbit-cli`
- Fix task context refinement so seeded skill files point at real repository paths, tracked in `T20260408-0400-2`

</details>

### T20260408-0133: Inject task details into implement_change activity instruction
<details><summary>Execution Summary</summary>

## Status
success

## 1. Summary of Changes
Added task-detail injection to the agent stdin envelope for `implement_change` so workers receive task title, description, acceptance criteria, plan, context files, workspace path, and repo root without first calling `orbit.task.show`. Updated the `implement_change` activity instructions and tool allowlist to point agents at the injected `task` object, and added unit coverage for override handling plus envelope serialization with and without task details.

## 2. Strategic Decisions
- Injected a focused `task` object into `ExecutionEnvelope` instead of serializing the full `Task` record | Rationale: keeps the agent payload aligned with the instruction contract and avoids unrelated task metadata | Trade-offs: a dedicated projection must be maintained as task fields evolve
- Resolved `workspace_path` and `repo_root` through a helper that honors `input` overrides before task defaults | Rationale: preserves the existing parallel-batch override semantics in one place | Trade-offs: this logic now exists alongside other task-aware path resolution helpers and must stay consistent

## 3. Assumptions Made
- `implement_change` invocations with `input.task_id` should fail fast if the referenced task cannot be loaded | Impact if incorrect: callers depending on silent omission would now see an execution error instead of a partial envelope
- Deferred verification for this batch means code and test changes should be authored but not executed in this activity | Impact if incorrect: additional validation may still be needed before review

## 4. Design Weaknesses / Risks
- The injected `task` payload duplicates a subset of task fields instead of reusing a typed shared envelope model | Severity: Low | Mitigation: extract a shared task-envelope struct if more activities begin consuming the same projection
- The override logic for workspace and repo root is now expressed both here and in task-aware working-directory resolution helpers | Severity: Medium | Mitigation: consolidate onto a shared helper if either path changes again

## 5. Deviations from Original Plan
None

## 6. Technical Debt Introduced
None

## 7. Recommended Follow-Ups
- Run the deferred verification phase (`cargo test -p orbit-core` / batch finalization) to confirm the new envelope serialization and YAML asset changes compile and pass in the full pipeline

</details>

### T20260406-0454-2: Add lineage brief builder for agent bootstrapping
<details><summary>Execution Summary</summary>

## Status
success

## 1. Summary of Changes
Added a new `build_lineage_brief` service in `orbit_map/service/lineage_brief.py` that resolves assigned lineage selectors through `GraphContextService`, renders a task-oriented markdown brief, expands target leaves to include source by default, and keeps surrounding lineage context compact. Wired the renderer into `orbit_map/service/__init__.py`, added a new `orbit-map knowledge brief` CLI command, and documented the workflow in `orbit-map/README.md` and `orbit-map/graph_navigation.md`.

## 2. Strategic Decisions
- Built the brief on top of `GraphContextService.build_handoff_packet()` instead of inventing a parallel selector-resolution path | Rationale: this keeps selector validation, node-role rendering, and navigation handles aligned with existing planner-to-worker handoff semantics | Trade-offs: the brief renderer now depends on the handoff schema layer.
- Defaulted omitted write scope to the target selectors | Rationale: brief consumers still get explicit edit boundaries even when the caller only supplies roots and targets | Trade-offs: purely read-only tasks should pass `--write` intentionally if they need stricter boundaries.
- Expanded file and directory targets into top-level descendant leaves for the target-source section | Rationale: this satisfies the requirement to include full target leaf source while keeping non-target nodes summarized | Trade-offs: broad directory targets can produce larger briefs and reach the markdown budget sooner.

## 3. Assumptions Made
- Existing callers may provide either stable graph node IDs or selector strings for root, target, write, and read-only inputs | Impact if incorrect: callers using unsupported identifiers will get selector-resolution errors when building the brief.
- Deferred verification for this batch task means build/test/lint execution must wait for the later finalization step | Impact if incorrect: syntax or integration issues would remain undetected until batch finalization runs.

## 4. Design Weaknesses / Risks
- The new renderer duplicates a small markdown writer and several leaf-summary helpers that already exist in other service modules | Severity: Medium | Mitigation: extract shared render utilities once the lineage/bootstrap/brief APIs stabilize.
- Directory-scoped targets can expand to many descendant files and truncate the rendered brief under the configured budget | Severity: Medium | Mitigation: prefer tighter target selectors or a lower-scope lineage pack when bootstrapping large tasks.
- Summary-only leaves without persisted `LeafNode.source` cannot show full source even when targeted | Severity: Low | Mitigation: rebuild knowledge artifacts so the graph includes the relevant leaf bodies before generating the brief.

## 5. Deviations from Original Plan
- Added `--risk` and `--constraint` CLI flags in addition to the planned core options | Justification: the service brief already renders planner risks and constraints, so exposing them at the CLI keeps the markdown artifact complete without widening the file scope.

## 6. Technical Debt Introduced
- Brief rendering now adds another local set of formatting/signature helper functions alongside bootstrap and lineage pack | Recommended resolution: consolidate the repeated markdown and leaf-formatting helpers into a shared service utility module in a follow-up task.

## 7. Recommended Follow-Ups
- Run the deferred validation pass during batch finalization, including import and CLI smoke coverage for `orbit-map knowledge brief`.
- Consider extracting shared markdown/leaf-render helpers once the brief format settles.
- If planners will rely on brief generation heavily, add focused tests for file-target, dir-target, and summary-only leaf behavior in a follow-up task.

</details>

## Branch Freshness
- Base ref: `main`
- Head ref: `orbit/parallel-batch-jrun-20260408-0352`
- Behind base: 0
- Ahead of base: 1

## Files Changed
- `README.md`
- `orbit-map/README.md`
- `orbit-map/graph_navigation.md`
- `orbit-map/orbit_map/cli/knowledge.py`
- `orbit-map/orbit_map/service/__init__.py`
- `orbit-map/orbit_map/service/lineage_brief.py`
- `orbit/orbit-cli/src/command/job.rs`
- `orbit/orbit-cli/src/command/tool.rs`
- `orbit/orbit-core/assets/activities/agent_invoke/implement_change.yaml`
- `orbit/orbit-core/assets/skills/orbit-raise-pr/SKILL.md`
- `orbit/orbit-core/src/command/tool.rs`
- `orbit/orbit-core/src/runtime/engine.rs`

*authored by: codex / gpt-5.4*