### PR TITLE
feat: add token metrics and knowledge freshness

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,6 +43,11 @@ orbit-types → orbit-policy, orbit-exec → orbit-tools → orbit-store, orbit-
 | Skills | WorkspaceReplaces | Workspace has full control over available skills |
 | Audit | GlobalOnly | Single authoritative event trail |
 
+## Task Authoring Quality
+
+Task creation must follow the `## Task Quality Standards` section in `orbit/orbit-core/assets/skills/orbit-create-task/SKILL.md`.
+Use those standards to require deterministic, mock-based testing, explicit definitions for summary fields such as `purpose`, and implementation patterns that preserve testability.
+
 ---
 
 ## Performance Tracking

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,6 +37,11 @@ orbit-types → orbit-policy, orbit-exec → orbit-tools → orbit-store, orbit-
 | Skills | WorkspaceReplaces | Workspace has full control over available skills |
 | Audit | GlobalOnly | Single authoritative event trail |
 
+## Task Authoring Quality
+
+Task creation must follow the `## Task Quality Standards` section in `orbit/orbit-core/assets/skills/orbit-create-task/SKILL.md`.
+Use those standards to require deterministic, mock-based testing, explicit definitions for summary fields such as `purpose`, and implementation patterns that preserve testability.
+
 ---
 
 ## Performance Tracking

--- a/orbit-map/AGENTS.md
+++ b/orbit-map/AGENTS.md
@@ -81,7 +81,7 @@ Primary artifact pointer is `graph/refs/current.json` (not `architecture.json`).
 
 **architecture.json**: optional, not produced by the default pipeline. Only present when the `generate_architecture` component is explicitly included.
 
-Optional: `.orbit/cache/hashes.json` for incremental rebuild support.
+Optional: `.orbit/knowledge/hashes.json` for incremental rebuild support.
 
 ---
 

--- a/orbit-map/README.md
+++ b/orbit-map/README.md
@@ -13,6 +13,7 @@ It scans a repository, builds structural knowledge artifacts, and writes determi
 ```text
 .orbit/knowledge/
   manifest.json
+  hashes.json
   graph/
     refs/current.json
     index/by-id.json
@@ -28,6 +29,9 @@ These artifacts are intended to conform to Orbit's knowledge schema and support:
 - reproducible context
 - faster task execution
 - auditable, diff-friendly outputs
+
+`hashes.json` sits in the knowledge root and stores the file-hash cache used for
+incremental graph and knowledge updates.
 
 `orbit-map` implements the schema, but does not own it.
 

--- a/orbit-map/orbit_map/cli/knowledge.py
+++ b/orbit-map/orbit_map/cli/knowledge.py
@@ -145,7 +145,7 @@ def knowledge_pack(
     """Render a deterministic lineage-specific knowledge pack."""
     if not selectors:
         raise click.UsageError("At least one context selector is required.")
-    _, output_dir = resolve_paths(repo, output)
+    repo_path, output_dir = resolve_paths(repo, output)
     logger.info("Rendering lineage pack from %s", output_dir)
     click.echo(
         render_lineage_pack(
@@ -159,6 +159,7 @@ def knowledge_pack(
             detail=detail,
             include_source=include_source,
             source_budget=source_budget,
+            repo_path=repo_path,
         )
     )
 

--- a/orbit-map/orbit_map/pipeline/hash.py
+++ b/orbit-map/orbit_map/pipeline/hash.py
@@ -26,7 +26,7 @@ def compute_hashes(file_paths: list[Path], repo_path: Path) -> dict[str, str]:
 
 def detect_changes(new_hashes: dict[str, str], output_dir: Path) -> list[str]:
     """Return list of relative paths that are new or changed vs. the cached hashes."""
-    cache_path = output_dir.parent / "cache" / "hashes.json"
+    cache_path = output_dir / "hashes.json"
     logger.debug("Detecting changes with cache file %s", cache_path)
 
     if not cache_path.exists():
@@ -47,8 +47,8 @@ def detect_changes(new_hashes: dict[str, str], output_dir: Path) -> list[str]:
 
 
 def save_hash_cache(hashes: dict[str, str], output_dir: Path) -> None:
-    """Persist hashes to .orbit/cache/hashes.json."""
-    cache_path = output_dir.parent / "cache" / "hashes.json"
+    """Persist hashes to .orbit/knowledge/hashes.json."""
+    cache_path = output_dir / "hashes.json"
     cache_path.parent.mkdir(parents=True, exist_ok=True)
     logger.debug("Writing hash cache to %s", cache_path)
     cache_path.write_text(json.dumps(hashes, indent=2, sort_keys=True) + "\n")

--- a/orbit-map/orbit_map/service/freshness.py
+++ b/orbit-map/orbit_map/service/freshness.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+from typing import Iterable, Literal
+
+from orbit_map.schemas.graph.nodes import FileNode
+
+FreshnessStatus = Literal["fresh", "stale", "unknown"]
+
+
+def file_freshness_status(
+    file_node: FileNode, repo_path: Path | str | None
+) -> FreshnessStatus:
+    current_hash = _current_source_blob_hash(file_node, repo_path)
+    if current_hash is None:
+        return "unknown"
+    if current_hash == file_node.source_blob_hash:
+        return "fresh"
+    return "stale"
+
+
+def compute_freshness_report(
+    file_nodes: Iterable[FileNode],
+    repo_path: Path | str | None,
+) -> dict[str, object]:
+    fresh_count = 0
+    stale_files: list[str] = []
+    unknown_files: list[str] = []
+
+    for file_node in sorted(file_nodes, key=lambda item: item.location):
+        status = file_freshness_status(file_node, repo_path)
+        if status == "fresh":
+            fresh_count += 1
+            continue
+        if status == "stale":
+            stale_files.append(file_node.location)
+            continue
+        unknown_files.append(file_node.location)
+
+    stale_count = len(stale_files)
+    unknown_count = len(unknown_files)
+    compared_count = fresh_count + stale_count + unknown_count
+    if stale_count:
+        status: FreshnessStatus = "stale"
+    elif unknown_count or compared_count == 0:
+        status = "unknown"
+    else:
+        status = "fresh"
+
+    return {
+        "status": status,
+        "fresh_count": fresh_count,
+        "stale_count": stale_count,
+        "unknown_count": unknown_count,
+        "stale_files": stale_files,
+        "unknown_files": unknown_files,
+    }
+
+
+def _current_source_blob_hash(
+    file_node: FileNode, repo_path: Path | str | None
+) -> str | None:
+    if repo_path is None or file_node.source_blob_hash is None:
+        return None
+
+    source_path = Path(repo_path) / file_node.location
+    if not source_path.is_file():
+        return None
+
+    try:
+        source = source_path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return None
+    return hashlib.sha256(source.encode("utf-8")).hexdigest()

--- a/orbit-map/orbit_map/service/lineage_pack.py
+++ b/orbit-map/orbit_map/service/lineage_pack.py
@@ -13,6 +13,7 @@ from orbit_map.schemas import (
     WorkerHandoffPacket,
 )
 from orbit_map.schemas.graph.nodes import DirNode, FileNode
+from orbit_map.service.freshness import compute_freshness_report
 from orbit_map.service.graph_context import GraphContextService
 
 LineagePackFormat = Literal["markdown", "json"]
@@ -28,6 +29,7 @@ class LineagePackRenderOptions:
     detail: bool = False
     include_source: bool = False
     source_budget: int = 0
+    repo_path: Path | None = None
 
 
 def render_lineage_pack(
@@ -42,6 +44,7 @@ def render_lineage_pack(
     detail: bool = False,
     include_source: bool = False,
     source_budget: int = 0,
+    repo_path: Path | str | None = None,
 ) -> str:
     service = GraphContextService.from_knowledge_dir(knowledge_dir)
     options = LineagePackRenderOptions(
@@ -53,6 +56,7 @@ def render_lineage_pack(
         detail=detail,
         include_source=include_source,
         source_budget=max(0, source_budget),
+        repo_path=Path(repo_path) if repo_path is not None else None,
     )
     report = _build_verbose_report(service, selectors, options)
     if not detail:
@@ -123,6 +127,7 @@ def _build_verbose_report(
         )
     ]
     graph = service.graph
+    freshness = compute_freshness_report(graph.files, options.repo_path)
 
     return {
         "repo": {
@@ -140,6 +145,7 @@ def _build_verbose_report(
                 and node.source_blob_hash in service.file_summaries_by_hash
             ),
         },
+        "freshness": freshness,
         "overview": _generate_overview(service, requested_nodes),
         "options": {
             "depth": options.depth,
@@ -515,6 +521,7 @@ def _compact_report(verbose_report: dict[str, Any]) -> dict[str, Any]:
             "leaf_count": verbose_report["repo"]["leaf_count"],
             "file_summary_count": verbose_report["repo"]["file_summary_count"],
         },
+        "freshness": verbose_report["freshness"],
         "overview": verbose_report.get("overview", ""),
         "options": {
             "depth": verbose_report["options"]["depth"],
@@ -598,6 +605,7 @@ def _compact_leaf_preview(preview: dict[str, Any]) -> dict[str, Any]:
 def _render_compact_markdown(report: dict[str, Any], budget: int) -> str:
     writer = _MarkdownWriter(budget=budget)
     repo = report["repo"]
+    freshness = report["freshness"]
     selections = report["selections"]
     nodes = report["nodes"]
 
@@ -610,6 +618,7 @@ def _render_compact_markdown(report: dict[str, Any], budget: int) -> str:
     writer.line(f"- files: {repo['file_count']}")
     writer.line(f"- leaves: {repo['leaf_count']}")
     writer.line()
+    _write_freshness_section(writer, freshness)
 
     if report.get("overview"):
         writer.line("## Overview")
@@ -694,6 +703,7 @@ def _render_compact_markdown(report: dict[str, Any], budget: int) -> str:
 def _render_verbose_markdown(report: dict[str, Any], budget: int) -> str:
     writer = _MarkdownWriter(budget=budget)
     repo = report["repo"]
+    freshness = report["freshness"]
     options = report["options"]
     selections = report["selections"]
     nodes = report["nodes"]
@@ -713,6 +723,7 @@ def _render_verbose_markdown(report: dict[str, Any], budget: int) -> str:
         f"- traversal bounds: depth={options['depth']}, siblings={options['siblings']}, children={options['children']}"
     )
     writer.line()
+    _write_freshness_section(writer, freshness)
 
     if report.get("overview"):
         writer.line("## Overview")
@@ -802,6 +813,26 @@ def _render_verbose_markdown(report: dict[str, Any], budget: int) -> str:
         writer.line("_output truncated to respect the requested budget._")
 
     return writer.text()
+
+
+def _write_freshness_section(
+    writer: "_MarkdownWriter", freshness: dict[str, Any]
+) -> None:
+    writer.line("## Freshness")
+    writer.line(f"- status: `{freshness['status']}`")
+    writer.line(
+        "- fresh: "
+        f"{freshness['fresh_count']}, "
+        f"stale: {freshness['stale_count']}, "
+        f"unknown: {freshness['unknown_count']}"
+    )
+    for path in freshness.get("stale_files", []):
+        if not writer.line(f"  - stale: `{path}`"):
+            return
+    for path in freshness.get("unknown_files", []):
+        if not writer.line(f"  - unknown: `{path}`"):
+            return
+    writer.line()
 
 
 def _single_line(text: str | None) -> str:

--- a/orbit-map/tests/test_hash_cache.py
+++ b/orbit-map/tests/test_hash_cache.py
@@ -1,0 +1,20 @@
+from pathlib import Path
+
+from orbit_map.pipeline.hash import detect_changes, save_hash_cache
+
+
+def test_save_hash_cache_writes_into_knowledge_root(tmp_path: Path):
+    output_dir = tmp_path / "knowledge"
+
+    save_hash_cache({"a.py": "abc"}, output_dir)
+
+    assert (output_dir / "hashes.json").exists()
+
+
+def test_detect_changes_reads_hash_cache_from_knowledge_root(tmp_path: Path):
+    output_dir = tmp_path / "knowledge"
+
+    save_hash_cache({"a.py": "abc"}, output_dir)
+
+    assert detect_changes({"a.py": "abc"}, output_dir) == []
+    assert detect_changes({"a.py": "xyz"}, output_dir) == ["a.py"]

--- a/orbit-map/tests/test_lineage_pack.py
+++ b/orbit-map/tests/test_lineage_pack.py
@@ -1,14 +1,21 @@
-import pytest
+import json
+from pathlib import Path
 from unittest.mock import MagicMock
-from orbit_map.service.lineage_pack import render_lineage_pack, _generate_overview
-from orbit_map.schemas.graph.nodes import DirNode, FileNode, LeafNode
+
+import pytest
+
+from orbit_map.graph.store import GraphObjectStore
+from orbit_map.schemas.graph.nodes import CodebaseGraphV1, DirNode, FileNode
+from orbit_map.service.freshness import compute_freshness_report, file_freshness_status
+from orbit_map.service.lineage_pack import _generate_overview, render_lineage_pack
+
 
 @pytest.fixture
 def mock_service():
     service = MagicMock()
     # Mock navigator
     service.navigator = MagicMock()
-    
+
     # Helper to create mock nodes
     def create_node(node_type, location, node_id=None):
         node = MagicMock()
@@ -19,84 +26,194 @@ def mock_service():
 
     service.create_node = create_node
     service.selector_for_node.side_effect = lambda n: f"{n.node_type}:{n.location}"
-    
+
     return service
+
+
+def _build_file_graph(
+    location: str, *, source_blob_hash: str | None = None
+) -> CodebaseGraphV1:
+    root = DirNode(
+        id="dir-src",
+        name="src",
+        location="src",
+        language="python",
+        dir_children=[],
+        file_children=["file-example"],
+    )
+    file_node = FileNode(
+        id="file-example",
+        name="example.py",
+        location=location,
+        language="python",
+        parent_id=root.id,
+        extension=".py",
+        source_blob_hash=source_blob_hash,
+    )
+    return CodebaseGraphV1(
+        root_dir_id=root.id,
+        dirs=[root],
+        files=[file_node],
+        leaves=[],
+    )
+
+
+def _persist_knowledge_graph(tmp_path: Path, source: str) -> tuple[Path, Path, FileNode]:
+    repo_path = tmp_path / "repo"
+    knowledge_dir = tmp_path / "knowledge"
+    source_path = repo_path / "src" / "example.py"
+    source_path.parent.mkdir(parents=True, exist_ok=True)
+    source_path.write_text(source, encoding="utf-8")
+
+    graph = _build_file_graph("src/example.py")
+    GraphObjectStore(knowledge_dir / "graph").write_graph(graph, repo_path=repo_path)
+    return repo_path, knowledge_dir, graph.files[0]
+
 
 def test_generate_overview_single_file(mock_service):
     file_node = mock_service.create_node("file", "orbit_map/service/graph_context.py")
     mock_service.get_file_context.return_value = MagicMock(
         summary="This file defines GraphContextService.",
-        exports=["GraphContextService"]
+        exports=["GraphContextService"],
     )
-    
+
     selector = "file:orbit_map/service/graph_context.py"
     overview = _generate_overview(mock_service, [(selector, file_node)])
-    
+
     assert "File: `file:orbit_map/service/graph_context.py`" in overview
     assert "This file defines GraphContextService." in overview
     assert "Key exports: GraphContextService." in overview
+
 
 def test_generate_overview_directory(mock_service):
     dir_node = mock_service.create_node("dir", "orbit_map/service")
     dir_node.description = "Service layer for graph operations."
     dir_node.file_children = ["file1", "file2"]
     dir_node.dir_children = []
-    
+
     selector = "dir:orbit_map/service"
     overview = _generate_overview(mock_service, [(selector, dir_node)])
-    
+
     assert "Directory: `dir:orbit_map/service`" in overview
     assert "Service layer for graph operations." in overview
     assert "Contains 2 files and 0 subdirectories." in overview
+
 
 def test_generate_overview_multiple_with_shared_ancestor(mock_service):
     ancestor = mock_service.create_node("dir", "orbit_map")
     file1 = mock_service.create_node("file", "orbit_map/a.py")
     file2 = mock_service.create_node("file", "orbit_map/b.py")
-    
+
     mock_service.navigator.get_lineage.side_effect = [
         [ancestor, file1],
-        [ancestor, file2]
+        [ancestor, file2],
     ]
-    
+
     mock_service.get_file_context.side_effect = [
         MagicMock(summary="Module A", exports=[]),
-        MagicMock(summary="Module B", exports=[])
+        MagicMock(summary="Module B", exports=[]),
     ]
-    
+
     requested_nodes = [
         ("file:orbit_map/a.py", file1),
-        ("file:orbit_map/b.py", file2)
+        ("file:orbit_map/b.py", file2),
     ]
-    
+
     overview = _generate_overview(mock_service, requested_nodes)
-    
+
     assert "Selection includes 2 nodes under `dir:orbit_map`:" in overview
     assert "- `file:orbit_map/a.py` (file): Module A" in overview
     assert "- `file:orbit_map/b.py` (file): Module B" in overview
+
 
 def test_generate_overview_multiple_no_shared_ancestor(mock_service):
     # One file in orbit_map, one in orbit_core
     file1 = mock_service.create_node("file", "orbit_map/a.py")
     file2 = mock_service.create_node("file", "orbit_core/b.py")
-    
-    mock_service.navigator.get_lineage.side_effect = [
-        [file1],
-        [file2]
-    ]
-    
+
+    mock_service.navigator.get_lineage.side_effect = [[file1], [file2]]
+
     mock_service.get_file_context.side_effect = [
         MagicMock(summary="Module A", exports=[]),
-        MagicMock(summary="Module B", exports=[])
+        MagicMock(summary="Module B", exports=[]),
     ]
-    
+
     requested_nodes = [
         ("file:orbit_map/a.py", file1),
-        ("file:orbit_core/b.py", file2)
+        ("file:orbit_core/b.py", file2),
     ]
-    
+
     overview = _generate_overview(mock_service, requested_nodes)
-    
+
     assert "Selection includes 2 nodes under root:" in overview
     assert "- `file:orbit_map/a.py` (file): Module A" in overview
     assert "- `file:orbit_core/b.py` (file): Module B" in overview
+
+
+def test_file_freshness_status_reports_fresh_for_matching_repo_file(tmp_path):
+    repo_path, _, file_node = _persist_knowledge_graph(tmp_path, "print('fresh')\n")
+
+    report = compute_freshness_report([file_node], repo_path)
+
+    assert file_freshness_status(file_node, repo_path) == "fresh"
+    assert report == {
+        "status": "fresh",
+        "fresh_count": 1,
+        "stale_count": 0,
+        "unknown_count": 0,
+        "stale_files": [],
+        "unknown_files": [],
+    }
+
+
+def test_compute_freshness_report_reports_stale_when_repo_file_changes(tmp_path):
+    repo_path, _, file_node = _persist_knowledge_graph(tmp_path, "print('before')\n")
+
+    (repo_path / file_node.location).write_text("print('after')\n", encoding="utf-8")
+    report = compute_freshness_report([file_node], repo_path)
+
+    assert file_freshness_status(file_node, repo_path) == "stale"
+    assert report["status"] == "stale"
+    assert report["stale_files"] == [file_node.location]
+    assert report["unknown_files"] == []
+
+
+def test_compute_freshness_report_reports_unknown_without_repo_path(tmp_path):
+    _, _, file_node = _persist_knowledge_graph(tmp_path, "print('unknown')\n")
+
+    report = compute_freshness_report([file_node], None)
+
+    assert file_freshness_status(file_node, None) == "unknown"
+    assert report["status"] == "unknown"
+    assert report["unknown_files"] == [file_node.location]
+
+
+def test_compute_freshness_report_reports_unknown_without_source_blob_hash(tmp_path):
+    repo_path = tmp_path / "repo"
+    source_path = repo_path / "src" / "example.py"
+    source_path.parent.mkdir(parents=True, exist_ok=True)
+    source_path.write_text("print('no hash')\n", encoding="utf-8")
+
+    file_node = _build_file_graph("src/example.py", source_blob_hash=None).files[0]
+    report = compute_freshness_report([file_node], repo_path)
+
+    assert file_freshness_status(file_node, repo_path) == "unknown"
+    assert report["status"] == "unknown"
+    assert report["unknown_files"] == [file_node.location]
+
+
+def test_render_lineage_pack_json_includes_freshness(tmp_path):
+    repo_path, knowledge_dir, _ = _persist_knowledge_graph(tmp_path, "print('pack')\n")
+
+    report = json.loads(
+        render_lineage_pack(
+            knowledge_dir,
+            ["file:src/example.py"],
+            format="json",
+            repo_path=repo_path,
+        )
+    )
+
+    assert "freshness" in report
+    assert report["freshness"]["status"] == "fresh"
+    assert report["freshness"]["fresh_count"] == 1

--- a/orbit/orbit-agent/src/agent/agent.rs
+++ b/orbit/orbit-agent/src/agent/agent.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use orbit_types::OrbitError;
+use orbit_types::{InvocationTrace, OrbitError};
 
 use crate::providers::AgentProvider;
 use crate::runtime::{AgentRuntime, RuntimeBackend, resolve_runtime};
@@ -101,7 +101,10 @@ impl Agent {
         })
     }
 
-    pub fn invoke(&self, req: AgentRequest) -> Result<AgentResponse, OrbitError> {
+    pub fn invoke(
+        &self,
+        req: AgentRequest,
+    ) -> Result<(AgentResponse, InvocationTrace), OrbitError> {
         self.runtime.invoke(req)
     }
 

--- a/orbit/orbit-agent/src/lib.rs
+++ b/orbit/orbit-agent/src/lib.rs
@@ -15,7 +15,7 @@
 //! - [`Agent`] / [`AgentConfig`] — high-level agent configuration
 //! - [`AgentRequest`] / [`AgentResponse`] — request and CLI-command response types
 //! - [`AgentOperation`] / [`AgentResponseStatus`] — operation kinds and status variants
-//! - [`parse_and_validate_response`] — parses the agent's JSON envelope and validates schema
+//! - [`parse_and_validate_response`] — parses the agent's JSON envelope, usage, and tool traces
 //!
 //! # Dependency direction
 //! `orbit-types` → `orbit-agent` → orbit-engine
@@ -26,6 +26,7 @@ mod runtime;
 mod types;
 
 pub use agent::{Agent, AgentConfig, ProviderOptions};
+pub use orbit_types::{InvocationTrace, TokenUsage, ToolCallTrace};
 pub use runtime::AgentRuntime;
 pub use types::{AgentOperation, AgentRequest, AgentResponse, AgentResponseStatus};
 pub use types::{is_timeout, parse_and_validate_response};

--- a/orbit/orbit-agent/src/providers/claude/claude_cli.rs
+++ b/orbit/orbit-agent/src/providers/claude/claude_cli.rs
@@ -17,9 +17,7 @@ impl ClaudeCliTransport {
             "--permission-mode".to_string(),
             "bypassPermissions".to_string(),
             "--output-format".to_string(),
-            // Always use "text" — "json" wraps the response in a CLI envelope
-            // that breaks Orbit's own envelope parsing.
-            "text".to_string(),
+            "json".to_string(),
             "--no-session-persistence".to_string(),
         ];
 

--- a/orbit/orbit-agent/src/providers/claude/claude_runtime.rs
+++ b/orbit/orbit-agent/src/providers/claude/claude_runtime.rs
@@ -1,4 +1,4 @@
-use orbit_types::OrbitError;
+use orbit_types::{InvocationTrace, OrbitError};
 
 use crate::providers::claude::claude_cli::ClaudeCliTransport;
 use crate::providers::{AgentProvider, build_agent_response};
@@ -20,12 +20,15 @@ impl ClaudeRuntime {
 }
 
 impl AgentRuntime for ClaudeRuntime {
-    fn invoke(&self, req: AgentRequest) -> Result<AgentResponse, OrbitError> {
-        Ok(build_agent_response(
-            AgentProvider::Claude,
-            self.command.clone(),
-            self.cli.args(req.verbose),
-            self.cli.stdin(&req.envelope_json),
+    fn invoke(&self, req: AgentRequest) -> Result<(AgentResponse, InvocationTrace), OrbitError> {
+        Ok((
+            build_agent_response(
+                AgentProvider::Claude,
+                self.command.clone(),
+                self.cli.args(req.verbose),
+                self.cli.stdin(&req.envelope_json),
+            ),
+            InvocationTrace::default(),
         ))
     }
 

--- a/orbit/orbit-agent/src/providers/codex/codex_runtime.rs
+++ b/orbit/orbit-agent/src/providers/codex/codex_runtime.rs
@@ -2,7 +2,7 @@ use crate::providers::codex::codex_cli::CodexCliTransport;
 use crate::providers::{AgentProvider, build_agent_response};
 use crate::runtime::AgentRuntime;
 use crate::types::{AgentRequest, AgentResponse};
-use orbit_types::OrbitError;
+use orbit_types::{InvocationTrace, OrbitError};
 
 pub(crate) struct CodexRuntime {
     command: String,
@@ -25,16 +25,19 @@ impl CodexRuntime {
 }
 
 impl AgentRuntime for CodexRuntime {
-    fn invoke(&self, req: AgentRequest) -> Result<AgentResponse, OrbitError> {
+    fn invoke(&self, req: AgentRequest) -> Result<(AgentResponse, InvocationTrace), OrbitError> {
         // Note: stdout_schema_json is intentionally None — Codex rejects Orbit's
         // generic envelope schema because open-ended object branches must be closed
         // with additionalProperties=false. Orbit validates the returned envelope
         // after execution instead.
-        Ok(build_agent_response(
-            AgentProvider::Codex,
-            self.command.clone(),
-            self.cli.args(),
-            self.cli.stdin(&req.envelope_json),
+        Ok((
+            build_agent_response(
+                AgentProvider::Codex,
+                self.command.clone(),
+                self.cli.args(),
+                self.cli.stdin(&req.envelope_json),
+            ),
+            InvocationTrace::default(),
         ))
     }
 

--- a/orbit/orbit-agent/src/providers/gemini/gemini_runtime.rs
+++ b/orbit/orbit-agent/src/providers/gemini/gemini_runtime.rs
@@ -1,4 +1,4 @@
-use orbit_types::OrbitError;
+use orbit_types::{InvocationTrace, OrbitError};
 
 use crate::providers::gemini::gemini_cli::GeminiCliTransport;
 use crate::providers::{AgentProvider, build_agent_response};
@@ -20,12 +20,15 @@ impl GeminiRuntime {
 }
 
 impl AgentRuntime for GeminiRuntime {
-    fn invoke(&self, req: AgentRequest) -> Result<AgentResponse, OrbitError> {
-        Ok(build_agent_response(
-            AgentProvider::Gemini,
-            self.command.clone(),
-            self.cli.args(req.verbose),
-            self.cli.stdin(&req.envelope_json),
+    fn invoke(&self, req: AgentRequest) -> Result<(AgentResponse, InvocationTrace), OrbitError> {
+        Ok((
+            build_agent_response(
+                AgentProvider::Gemini,
+                self.command.clone(),
+                self.cli.args(req.verbose),
+                self.cli.stdin(&req.envelope_json),
+            ),
+            InvocationTrace::default(),
         ))
     }
 

--- a/orbit/orbit-agent/src/providers/mock_agent/mock_agent_runtime.rs
+++ b/orbit/orbit-agent/src/providers/mock_agent/mock_agent_runtime.rs
@@ -1,4 +1,4 @@
-use orbit_types::OrbitError;
+use orbit_types::{InvocationTrace, OrbitError};
 
 use crate::providers::mock_agent::mock_agent_cli::MockAgentCliTransport;
 use crate::providers::{AgentProvider, build_agent_response};
@@ -20,12 +20,15 @@ impl MockAgentRuntime {
 }
 
 impl AgentRuntime for MockAgentRuntime {
-    fn invoke(&self, req: AgentRequest) -> Result<AgentResponse, OrbitError> {
-        Ok(build_agent_response(
-            AgentProvider::MockAgent,
-            self.command.clone(),
-            self.cli.args(&req.operation),
-            self.cli.stdin(&req.envelope_json),
+    fn invoke(&self, req: AgentRequest) -> Result<(AgentResponse, InvocationTrace), OrbitError> {
+        Ok((
+            build_agent_response(
+                AgentProvider::MockAgent,
+                self.command.clone(),
+                self.cli.args(&req.operation),
+                self.cli.stdin(&req.envelope_json),
+            ),
+            InvocationTrace::default(),
         ))
     }
 

--- a/orbit/orbit-agent/src/runtime/backend.rs
+++ b/orbit/orbit-agent/src/runtime/backend.rs
@@ -1,4 +1,4 @@
-use orbit_types::OrbitError;
+use orbit_types::{InvocationTrace, OrbitError};
 
 use crate::providers::{ClaudeRuntime, CodexRuntime, GeminiRuntime, MockAgentRuntime};
 use crate::runtime::AgentRuntime;
@@ -13,7 +13,7 @@ pub(crate) enum RuntimeBackend {
 }
 
 impl AgentRuntime for RuntimeBackend {
-    fn invoke(&self, req: AgentRequest) -> Result<AgentResponse, OrbitError> {
+    fn invoke(&self, req: AgentRequest) -> Result<(AgentResponse, InvocationTrace), OrbitError> {
         match self {
             RuntimeBackend::CodexCli(runtime) => runtime.invoke(req),
             RuntimeBackend::ClaudeCli(runtime) => runtime.invoke(req),

--- a/orbit/orbit-agent/src/runtime/runtime_trait.rs
+++ b/orbit/orbit-agent/src/runtime/runtime_trait.rs
@@ -1,9 +1,9 @@
-use orbit_types::OrbitError;
+use orbit_types::{InvocationTrace, OrbitError};
 
 use crate::types::{AgentRequest, AgentResponse};
 
 pub trait AgentRuntime {
-    fn invoke(&self, req: AgentRequest) -> Result<AgentResponse, OrbitError>;
+    fn invoke(&self, req: AgentRequest) -> Result<(AgentResponse, InvocationTrace), OrbitError>;
 
     fn model_name(&self) -> Option<&str> {
         None

--- a/orbit/orbit-agent/src/types/response.rs
+++ b/orbit/orbit-agent/src/types/response.rs
@@ -1,5 +1,9 @@
-use orbit_types::{AgentResponseEnvelope, AgentRunError, ExecutionResult, OrbitError};
+use orbit_types::{
+    AgentResponseEnvelope, AgentRunError, ExecutionResult, InvocationTrace, OrbitError, TokenUsage,
+    ToolCallTrace,
+};
 use serde_json::{Deserializer, Value};
+use std::collections::HashMap;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AgentResponse {
@@ -20,7 +24,7 @@ pub enum AgentResponseStatus {
 
 pub fn parse_and_validate_response(
     exec_result: &ExecutionResult,
-) -> Result<(AgentResponseEnvelope, AgentResponseStatus), OrbitError> {
+) -> Result<(AgentResponseEnvelope, AgentResponseStatus, InvocationTrace), OrbitError> {
     match parse_json_envelope(exec_result) {
         Ok(parsed) => Ok(parsed),
         Err(_) => Ok(synthesize_response(exec_result)),
@@ -31,26 +35,21 @@ pub fn is_timeout(exec_result: &ExecutionResult) -> bool {
     !exec_result.success && exec_result.stderr.contains("process timed out")
 }
 
-fn parse_single_json_document(stdout: &str) -> Result<Value, OrbitError> {
+fn parse_json_documents(stdout: &str) -> Result<Vec<Value>, OrbitError> {
     let mut stream = Deserializer::from_str(stdout).into_iter::<Value>();
-
-    let Some(first) = stream.next() else {
+    let mut documents = Vec::new();
+    while let Some(item) = stream.next() {
+        let value = item.map_err(|error| {
+            OrbitError::AgentProtocolViolation(format!("stdout is not valid JSON: {error}"))
+        })?;
+        documents.push(value);
+    }
+    if documents.is_empty() {
         return Err(OrbitError::AgentProtocolViolation(
             "stdout does not contain a JSON document".to_string(),
         ));
-    };
-
-    let first = first.map_err(|error| {
-        OrbitError::AgentProtocolViolation(format!("stdout is not valid JSON: {error}"))
-    })?;
-
-    if stream.next().is_some() {
-        return Err(OrbitError::AgentProtocolViolation(
-            "stdout contains multiple JSON documents".to_string(),
-        ));
     }
-
-    Ok(first)
+    Ok(documents)
 }
 
 fn validate_exit_alignment(
@@ -86,11 +85,18 @@ fn validate_exit_alignment(
 
 fn parse_json_envelope(
     exec_result: &ExecutionResult,
-) -> Result<(AgentResponseEnvelope, AgentResponseStatus), OrbitError> {
-    let value = parse_single_json_document(&exec_result.stdout)?;
-    let envelope: AgentResponseEnvelope = serde_json::from_value(value).map_err(|error| {
-        OrbitError::AgentProtocolViolation(format!("invalid agent response envelope: {error}"))
-    })?;
+) -> Result<(AgentResponseEnvelope, AgentResponseStatus, InvocationTrace), OrbitError> {
+    let documents = parse_json_documents(&exec_result.stdout)?;
+    let envelope = documents
+        .iter()
+        .rev()
+        .find_map(find_agent_response_envelope)
+        .ok_or_else(|| {
+            OrbitError::AgentProtocolViolation(
+                "stdout does not contain an Orbit response envelope".to_string(),
+            )
+        })?;
+    let trace = extract_invocation_trace(&documents, exec_result.duration_ms);
 
     if envelope.schema_version != 1 {
         return Err(OrbitError::AgentProtocolViolation(format!(
@@ -123,12 +129,12 @@ fn parse_json_envelope(
     };
 
     validate_exit_alignment(exec_result, &envelope)?;
-    Ok((envelope, state))
+    Ok((envelope, state, trace))
 }
 
 fn synthesize_response(
     exec_result: &ExecutionResult,
-) -> (AgentResponseEnvelope, AgentResponseStatus) {
+) -> (AgentResponseEnvelope, AgentResponseStatus, InvocationTrace) {
     if is_timeout(exec_result) {
         return (
             AgentResponseEnvelope {
@@ -143,6 +149,10 @@ fn synthesize_response(
                 duration_ms: Some(exec_result.duration_ms),
             },
             AgentResponseStatus::Timeout,
+            InvocationTrace {
+                duration_ms: exec_result.duration_ms,
+                ..InvocationTrace::default()
+            },
         );
     }
 
@@ -156,6 +166,10 @@ fn synthesize_response(
                 duration_ms: Some(exec_result.duration_ms),
             },
             AgentResponseStatus::Success,
+            InvocationTrace {
+                duration_ms: exec_result.duration_ms,
+                ..InvocationTrace::default()
+            },
         );
     }
 
@@ -172,6 +186,10 @@ fn synthesize_response(
             duration_ms: Some(exec_result.duration_ms),
         },
         AgentResponseStatus::Failed,
+        InvocationTrace {
+            duration_ms: exec_result.duration_ms,
+            ..InvocationTrace::default()
+        },
     )
 }
 
@@ -185,6 +203,294 @@ fn synthetic_error_message(exec_result: &ExecutionResult) -> String {
         return stdout.to_string();
     }
     "agent execution failed".to_string()
+}
+
+fn find_agent_response_envelope(value: &Value) -> Option<AgentResponseEnvelope> {
+    if let Some(envelope) = deserialize_envelope(value) {
+        return Some(envelope);
+    }
+
+    match value {
+        Value::String(raw) => {
+            let nested = serde_json::from_str::<Value>(raw).ok()?;
+            find_agent_response_envelope(&nested)
+        }
+        Value::Array(items) => items.iter().rev().find_map(find_agent_response_envelope),
+        Value::Object(map) => {
+            for key in [
+                "result",
+                "response",
+                "message",
+                "messages",
+                "content",
+                "final",
+                "final_message",
+                "output",
+            ] {
+                if let Some(found) = map.get(key).and_then(find_agent_response_envelope) {
+                    return Some(found);
+                }
+            }
+
+            map.values().find_map(find_agent_response_envelope)
+        }
+        _ => None,
+    }
+}
+
+fn deserialize_envelope(value: &Value) -> Option<AgentResponseEnvelope> {
+    let object = value.as_object()?;
+    if !object.contains_key("schemaVersion") || !object.contains_key("status") {
+        return None;
+    }
+    serde_json::from_value(value.clone()).ok()
+}
+
+fn extract_invocation_trace(documents: &[Value], duration_ms: u64) -> InvocationTrace {
+    let usage = documents
+        .iter()
+        .rev()
+        .find_map(find_usage)
+        .unwrap_or_default();
+    let tool_calls = extract_tool_calls(documents);
+    InvocationTrace {
+        usage,
+        tool_calls,
+        duration_ms,
+    }
+}
+
+fn find_usage(value: &Value) -> Option<TokenUsage> {
+    match value {
+        Value::Object(map) => {
+            if let Some(usage) = usage_from_map(map) {
+                return Some(usage);
+            }
+            for key in ["usage", "token_usage", "tokens", "result", "message"] {
+                if let Some(found) = map.get(key).and_then(find_usage) {
+                    return Some(found);
+                }
+            }
+            map.values().find_map(find_usage)
+        }
+        Value::Array(items) => items.iter().rev().find_map(find_usage),
+        Value::String(raw) => serde_json::from_str::<Value>(raw)
+            .ok()
+            .and_then(|nested| find_usage(&nested)),
+        _ => None,
+    }
+}
+
+fn usage_from_map(map: &serde_json::Map<String, Value>) -> Option<TokenUsage> {
+    let input = first_u64(
+        map,
+        &[
+            "input_tokens",
+            "inputTokens",
+            "prompt_tokens",
+            "promptTokens",
+        ],
+    );
+    let cache_read = first_u64(
+        map,
+        &[
+            "cache_read_input_tokens",
+            "cacheReadInputTokens",
+            "cache_read_tokens",
+            "cacheReadTokens",
+        ],
+    );
+    let cache_create = first_u64(
+        map,
+        &[
+            "cache_creation_input_tokens",
+            "cacheCreationInputTokens",
+            "cache_create_tokens",
+            "cacheCreateTokens",
+        ],
+    );
+    let output = first_u64(
+        map,
+        &[
+            "output_tokens",
+            "outputTokens",
+            "completion_tokens",
+            "completionTokens",
+        ],
+    );
+
+    if input.or(cache_read).or(cache_create).or(output).is_none() {
+        return None;
+    }
+
+    Some(TokenUsage {
+        input: input.unwrap_or(0),
+        cache_read: cache_read.unwrap_or(0),
+        cache_create: cache_create.unwrap_or(0),
+        output: output.unwrap_or(0),
+    })
+}
+
+fn first_u64(map: &serde_json::Map<String, Value>, keys: &[&str]) -> Option<u64> {
+    keys.iter().find_map(|key| value_as_u64(map.get(*key)?))
+}
+
+fn value_as_u64(value: &Value) -> Option<u64> {
+    match value {
+        Value::Number(number) => number.as_u64(),
+        Value::String(raw) => raw.parse::<u64>().ok(),
+        _ => None,
+    }
+}
+
+fn extract_tool_calls(documents: &[Value]) -> Vec<ToolCallTrace> {
+    let mut collector = ToolCallCollector::default();
+    for document in documents {
+        collector.walk(document);
+    }
+    collector.finish()
+}
+
+#[derive(Default)]
+struct ToolCallCollector {
+    calls: Vec<ToolCallTrace>,
+    by_id: HashMap<String, usize>,
+}
+
+impl ToolCallCollector {
+    fn walk(&mut self, value: &Value) {
+        match value {
+            Value::Object(map) => {
+                if let Some(tool_calls) = map.get("tool_calls").and_then(Value::as_array) {
+                    for item in tool_calls {
+                        self.record_inline_tool_call(item);
+                    }
+                }
+
+                if let Some(kind) = map.get("type").and_then(Value::as_str) {
+                    match kind {
+                        "tool_use" | "tool_call" => {
+                            self.record_tool_use(map);
+                        }
+                        "tool_result" => {
+                            self.record_tool_result(map);
+                        }
+                        _ => {}
+                    }
+                }
+
+                for (key, nested) in map {
+                    if key != "tool_calls" {
+                        self.walk(nested);
+                    }
+                }
+            }
+            Value::Array(items) => {
+                for item in items {
+                    self.walk(item);
+                }
+            }
+            Value::String(raw) => {
+                if let Ok(nested) = serde_json::from_str::<Value>(raw) {
+                    self.walk(&nested);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    fn record_inline_tool_call(&mut self, value: &Value) {
+        let Some(map) = value.as_object() else {
+            return;
+        };
+        let tool_name = tool_name_from_map(map);
+        if tool_name.is_empty() {
+            return;
+        }
+        self.calls.push(ToolCallTrace {
+            seq: (self.calls.len() + 1) as u32,
+            tool_name,
+            result_bytes: inline_result_bytes(map),
+        });
+    }
+
+    fn record_tool_use(&mut self, map: &serde_json::Map<String, Value>) {
+        let tool_name = tool_name_from_map(map);
+        if tool_name.is_empty() {
+            return;
+        }
+        let index = self.calls.len();
+        self.calls.push(ToolCallTrace {
+            seq: (index + 1) as u32,
+            tool_name,
+            result_bytes: 0,
+        });
+        if let Some(id) = map
+            .get("id")
+            .and_then(Value::as_str)
+            .or_else(|| map.get("tool_use_id").and_then(Value::as_str))
+        {
+            self.by_id.insert(id.to_string(), index);
+        }
+    }
+
+    fn record_tool_result(&mut self, map: &serde_json::Map<String, Value>) {
+        let result_bytes = map
+            .get("result_bytes")
+            .and_then(value_as_u64)
+            .unwrap_or_else(|| {
+                map.get("content")
+                    .or_else(|| map.get("result"))
+                    .map(serialized_size)
+                    .unwrap_or(0)
+            });
+
+        if let Some(tool_use_id) = map.get("tool_use_id").and_then(Value::as_str)
+            && let Some(index) = self.by_id.get(tool_use_id).copied()
+        {
+            self.calls[index].result_bytes = result_bytes;
+            return;
+        }
+
+        if let Some(last) = self
+            .calls
+            .iter_mut()
+            .rev()
+            .find(|call| call.result_bytes == 0)
+        {
+            last.result_bytes = result_bytes;
+        }
+    }
+
+    fn finish(self) -> Vec<ToolCallTrace> {
+        self.calls
+    }
+}
+
+fn tool_name_from_map(map: &serde_json::Map<String, Value>) -> String {
+    map.get("name")
+        .and_then(Value::as_str)
+        .or_else(|| map.get("tool_name").and_then(Value::as_str))
+        .or_else(|| map.get("tool").and_then(Value::as_str))
+        .unwrap_or_default()
+        .to_string()
+}
+
+fn inline_result_bytes(map: &serde_json::Map<String, Value>) -> u64 {
+    map.get("result_bytes")
+        .and_then(value_as_u64)
+        .unwrap_or_else(|| {
+            map.get("result")
+                .or_else(|| map.get("content"))
+                .map(serialized_size)
+                .unwrap_or(0)
+        })
+}
+
+fn serialized_size(value: &Value) -> u64 {
+    serde_json::to_vec(value)
+        .map(|bytes| bytes.len() as u64)
+        .unwrap_or(0)
 }
 
 #[cfg(test)]
@@ -206,7 +512,7 @@ mod tests {
 
     #[test]
     fn parses_envelope_without_duration_ms() {
-        let (envelope, status) = parse_and_validate_response(&exec_result(json!({
+        let (envelope, status, trace) = parse_and_validate_response(&exec_result(json!({
             "schemaVersion": 1,
             "status": "success",
             "result": {}
@@ -215,11 +521,12 @@ mod tests {
 
         assert_eq!(status, AgentResponseStatus::Success);
         assert_eq!(envelope.duration_ms, None);
+        assert_eq!(trace.duration_ms, 42);
     }
 
     #[test]
     fn parses_envelope_with_duration_ms_for_backwards_compatibility() {
-        let (envelope, status) = parse_and_validate_response(&exec_result(json!({
+        let (envelope, status, trace) = parse_and_validate_response(&exec_result(json!({
             "schemaVersion": 1,
             "status": "success",
             "result": {},
@@ -229,5 +536,55 @@ mod tests {
 
         assert_eq!(status, AgentResponseStatus::Success);
         assert_eq!(envelope.duration_ms, Some(123));
+        assert_eq!(trace.duration_ms, 42);
+    }
+
+    #[test]
+    fn parses_claude_json_wrapper_with_usage_and_tool_calls() {
+        let stdout = [
+            json!({
+                "type": "assistant",
+                "message": {
+                    "content": [
+                        { "type": "tool_use", "id": "toolu_1", "name": "fs.read" },
+                        { "type": "tool_result", "tool_use_id": "toolu_1", "content": { "ok": true, "bytes": 12 } },
+                        { "type": "text", "text": "{\"schemaVersion\":1,\"status\":\"success\",\"result\":{}}" }
+                    ]
+                }
+            })
+            .to_string(),
+            json!({
+                "type": "result",
+                "usage": {
+                    "input_tokens": 100,
+                    "cache_read_input_tokens": 40,
+                    "cache_creation_input_tokens": 5,
+                    "output_tokens": 20
+                }
+            })
+            .to_string(),
+        ]
+        .join("\n");
+        let exec_result = ExecutionResult {
+            success: true,
+            stdout,
+            stderr: String::new(),
+            exit_code: Some(0),
+            duration_ms: 84,
+            output: None,
+        };
+
+        let (envelope, status, trace) =
+            parse_and_validate_response(&exec_result).expect("claude wrapper should parse");
+
+        assert_eq!(status, AgentResponseStatus::Success);
+        assert_eq!(envelope.status, "success");
+        assert_eq!(trace.usage.input, 100);
+        assert_eq!(trace.usage.cache_read, 40);
+        assert_eq!(trace.usage.cache_create, 5);
+        assert_eq!(trace.usage.output, 20);
+        assert_eq!(trace.tool_calls.len(), 1);
+        assert_eq!(trace.tool_calls[0].tool_name, "fs.read");
+        assert!(trace.tool_calls[0].result_bytes > 0);
     }
 }

--- a/orbit/orbit-cli/src/audit_middleware.rs
+++ b/orbit/orbit-cli/src/audit_middleware.rs
@@ -327,6 +327,23 @@ pub fn extract_command_meta(cmd: &Commands) -> CommandMeta {
                 arguments_json: None,
             }
         }
+        Commands::Metrics(cmd) => {
+            use crate::command::metrics::MetricsSubcommand;
+            let (sub, target_id) = match &cmd.command {
+                MetricsSubcommand::Activity(_) => ("activity", None),
+                MetricsSubcommand::Task(args) => ("task", Some(args.id.as_str())),
+                MetricsSubcommand::Tools(_) => ("tools", None),
+            };
+            CommandMeta {
+                command: "metrics".to_string(),
+                subcommand: Some(sub.to_string()),
+                tool_name: None,
+                target_type: Some("metrics".to_string()),
+                target_id: target_id.map(String::from),
+                role: "admin".to_string(),
+                arguments_json: None,
+            }
+        }
         Commands::Audit(_) => unreachable!("audit commands should not be audited"),
         Commands::Workspace(cmd) => {
             use crate::command::workspace::WorkspaceSubcommand;

--- a/orbit/orbit-cli/src/command/metrics.rs
+++ b/orbit/orbit-cli/src/command/metrics.rs
@@ -1,0 +1,186 @@
+use clap::{Args, Subcommand};
+use orbit_core::{OrbitError, OrbitRuntime, TaskInvocationMetrics};
+
+use crate::command::Execute;
+
+const LIMITATIONS_HELP: &str = "Known limitations:\n  - Subagent attribution folds into the parent invocation totals.\n  - cache_read_tokens are reported separately from input_tokens.\n  - Multi-task invocations are fully attributed to every tagged task.\n  - Non-Claude providers currently emit zero traces.";
+
+#[derive(Args)]
+#[command(about = "Inspect invocation token and tool-call metrics", after_help = LIMITATIONS_HELP)]
+pub struct MetricsCommand {
+    #[command(subcommand)]
+    pub command: MetricsSubcommand,
+}
+
+impl Execute for MetricsCommand {
+    fn execute(self, runtime: &OrbitRuntime) -> Result<(), OrbitError> {
+        self.command.execute(runtime)
+    }
+}
+
+#[derive(Subcommand)]
+pub enum MetricsSubcommand {
+    /// Show token rollups grouped by activity
+    Activity(MetricsActivityArgs),
+    /// Show token rollups for a task
+    Task(MetricsTaskArgs),
+    /// Show tool call frequency and result sizes grouped by activity
+    Tools(MetricsToolsArgs),
+}
+
+impl Execute for MetricsSubcommand {
+    fn execute(self, runtime: &OrbitRuntime) -> Result<(), OrbitError> {
+        match self {
+            MetricsSubcommand::Activity(args) => args.execute(runtime),
+            MetricsSubcommand::Task(args) => args.execute(runtime),
+            MetricsSubcommand::Tools(args) => args.execute(runtime),
+        }
+    }
+}
+
+#[derive(Args)]
+pub struct MetricsActivityArgs {
+    /// Output as JSON
+    #[arg(long)]
+    pub json: bool,
+}
+
+impl Execute for MetricsActivityArgs {
+    fn execute(self, runtime: &OrbitRuntime) -> Result<(), OrbitError> {
+        let rows = runtime.activity_invocation_metrics()?;
+        if self.json {
+            return crate::output::json::print_pretty(
+                &serde_json::to_value(&rows).map_err(|e| OrbitError::Store(e.to_string()))?,
+            );
+        }
+        if rows.is_empty() {
+            println!("No invocation metrics found.");
+            return Ok(());
+        }
+
+        use comfy_table::Cell;
+        let mut table = crate::output::table::build_table(&[
+            "ACTIVITY",
+            "INVOCATIONS",
+            "AVG",
+            "P50",
+            "P95",
+            "TOTAL",
+            "INPUT",
+            "CACHE READ",
+            "CACHE CREATE",
+            "OUTPUT",
+            "TOOLS",
+        ]);
+        for row in rows {
+            table.add_row(vec![
+                Cell::new(row.activity_id),
+                Cell::new(row.invocation_count),
+                Cell::new(format_decimal(row.avg_tokens)),
+                Cell::new(row.p50_tokens),
+                Cell::new(row.p95_tokens),
+                Cell::new(row.total_tokens),
+                Cell::new(row.total_input_tokens),
+                Cell::new(row.total_cache_read_tokens),
+                Cell::new(row.total_cache_create_tokens),
+                Cell::new(row.total_output_tokens),
+                Cell::new(row.total_tool_calls),
+            ]);
+        }
+        println!("{table}");
+        Ok(())
+    }
+}
+
+#[derive(Args)]
+pub struct MetricsTaskArgs {
+    /// Task ID
+    pub id: String,
+    /// Output as JSON
+    #[arg(long)]
+    pub json: bool,
+}
+
+impl Execute for MetricsTaskArgs {
+    fn execute(self, runtime: &OrbitRuntime) -> Result<(), OrbitError> {
+        let row = runtime.task_invocation_metrics(&self.id)?;
+        if self.json {
+            return crate::output::json::print_pretty(
+                &serde_json::to_value(&row).map_err(|e| OrbitError::Store(e.to_string()))?,
+            );
+        }
+        print_task_metrics(&row);
+        Ok(())
+    }
+}
+
+#[derive(Args)]
+pub struct MetricsToolsArgs {
+    /// Output as JSON
+    #[arg(long)]
+    pub json: bool,
+}
+
+impl Execute for MetricsToolsArgs {
+    fn execute(self, runtime: &OrbitRuntime) -> Result<(), OrbitError> {
+        let rows = runtime.tool_invocation_metrics()?;
+        if self.json {
+            return crate::output::json::print_pretty(
+                &serde_json::to_value(&rows).map_err(|e| OrbitError::Store(e.to_string()))?,
+            );
+        }
+        if rows.is_empty() {
+            println!("No tool call metrics found.");
+            return Ok(());
+        }
+
+        use comfy_table::Cell;
+        let mut table = crate::output::table::build_table(&[
+            "ACTIVITY",
+            "TOOL",
+            "CALLS",
+            "AVG RESULT BYTES",
+            "TOTAL RESULT BYTES",
+        ]);
+        for row in rows {
+            table.add_row(vec![
+                Cell::new(row.activity_id),
+                Cell::new(row.tool_name),
+                Cell::new(row.call_count),
+                Cell::new(format_decimal(row.avg_result_bytes)),
+                Cell::new(row.total_result_bytes),
+            ]);
+        }
+        println!("{table}");
+        Ok(())
+    }
+}
+
+fn print_task_metrics(row: &TaskInvocationMetrics) {
+    use comfy_table::Cell;
+    let mut table = crate::output::table::build_table(&[
+        "TASK",
+        "INVOCATIONS",
+        "TOTAL",
+        "INPUT",
+        "CACHE READ",
+        "CACHE CREATE",
+        "OUTPUT",
+        "TOOLS",
+    ]);
+    table.add_row(vec![
+        Cell::new(&row.task_id),
+        Cell::new(row.invocation_count),
+        Cell::new(row.total_tokens),
+        Cell::new(row.total_input_tokens),
+        Cell::new(row.total_cache_read_tokens),
+        Cell::new(row.total_cache_create_tokens),
+        Cell::new(row.total_output_tokens),
+        Cell::new(row.total_tool_calls),
+    ]);
+    println!("{table}");
+}
+
+fn format_decimal(value: f64) -> String {
+    format!("{value:.1}")
+}

--- a/orbit/orbit-cli/src/command/mod.rs
+++ b/orbit/orbit-cli/src/command/mod.rs
@@ -4,6 +4,7 @@ pub mod config;
 pub mod init;
 pub mod job;
 pub mod job_run;
+pub mod metrics;
 pub mod run;
 pub mod skill;
 pub mod task;
@@ -45,6 +46,7 @@ Configure and inspect:
   init       Initialize the global Orbit root (~/.orbit)
   workspace  Initialize and manage workspaces
   audit      Query the audit event log
+  metrics    Inspect invocation token and tool-call metrics
 
 Options:
 {options}"
@@ -76,6 +78,7 @@ pub enum Commands {
     Init(init::InitCommand),
     Workspace(workspace::WorkspaceCommand),
     Audit(audit::AuditCommand),
+    Metrics(metrics::MetricsCommand),
 }
 
 impl Execute for Commands {
@@ -92,6 +95,7 @@ impl Execute for Commands {
             Commands::JobRun(cmd) => cmd.execute(runtime),
             Commands::Run(cmd) => cmd.execute(runtime),
             Commands::Workspace(cmd) => cmd.execute(runtime),
+            Commands::Metrics(cmd) => cmd.execute(runtime),
         }
     }
 }

--- a/orbit/orbit-cli/src/command/task.rs
+++ b/orbit/orbit-cli/src/command/task.rs
@@ -406,27 +406,27 @@ impl Execute for TaskShowArgs {
                 }
                 "plan" => {
                     if self.json {
-                        return crate::output::json::print_pretty(
-                            &serde_json::Value::String(task.plan.clone()),
-                        );
+                        return crate::output::json::print_pretty(&serde_json::Value::String(
+                            task.plan.clone(),
+                        ));
                     }
                     print!("{}", task.plan);
                     return Ok(());
                 }
                 "execution_summary" => {
                     if self.json {
-                        return crate::output::json::print_pretty(
-                            &serde_json::Value::String(task.execution_summary.clone()),
-                        );
+                        return crate::output::json::print_pretty(&serde_json::Value::String(
+                            task.execution_summary.clone(),
+                        ));
                     }
                     print!("{}", task.execution_summary);
                     return Ok(());
                 }
                 "description" => {
                     if self.json {
-                        return crate::output::json::print_pretty(
-                            &serde_json::Value::String(task.description.clone()),
-                        );
+                        return crate::output::json::print_pretty(&serde_json::Value::String(
+                            task.description.clone(),
+                        ));
                     }
                     print!("{}", task.description);
                     return Ok(());

--- a/orbit/orbit-core/assets/skills/orbit-create-task/SKILL.md
+++ b/orbit/orbit-core/assets/skills/orbit-create-task/SKILL.md
@@ -28,6 +28,35 @@ Create an Orbit task another engineer or agent can execute without guessing. Foc
 - Blank or missing task companion files (`plan.md`, `execution-summary.md`) are treated as blank task fields. Repair them through `orbit.task.update` (`plan` or `execution_summary`), not manual file edits.
 - Orbit fills `created_by`, `assigned_to`, and `proposed_by` automatically from execution context.
 
+## Task Quality Standards
+
+### Environment Independence checklist
+
+- Tests must not assume the presence of `.orbit/knowledge/`, local config files, or filesystem artifacts that are neither committed nor created by the test itself.
+- File I/O tests must use temp directories or in-memory fakes.
+- Acceptance criteria must state filesystem independence explicitly when behavior touches persisted state.
+
+### Explicit Definitions checklist
+
+- Terms such as `purpose`, `summary`, and `description` in acceptance criteria must include an observable format or output requirement.
+- If acceptance criteria mention a `signature`, specify the exact form it must take.
+- Prohibit vague pass/fail language such as `works correctly` or `handles edge cases`; replace it with concrete observable behavior.
+
+### Mock-Based, Deterministic Testing
+
+- Tasks that modify behavior involving external services, filesystem I/O, or time-dependent state must require mock or fake coverage in acceptance criteria.
+- Prefer `node_type` attribute dispatch over `isinstance` checks when task code must remain compatible with mocks or fakes.
+- Acceptance criteria must specify expected return types or output shapes when functions change.
+
+### Per-Node Purpose checklist
+
+- For graph or knowledge tasks, define each node `purpose` as: role in one sentence, crate or module, and whether the node is leaf or internal.
+
+### AC Format Rule
+
+- Each acceptance criterion must be independently verifiable and name a command, test, or observable output.
+- Include at least one acceptance criterion that specifies the validation command.
+
 ## Command
 
 ```bash

--- a/orbit/orbit-core/src/command/tool.rs
+++ b/orbit/orbit-core/src/command/tool.rs
@@ -443,10 +443,7 @@ mod tests {
                         Some("cli-agent".to_string()),
                         Some("cli-model".to_string())
                     ),
-                    (
-                        Some("cli-agent".to_string()),
-                        Some("cli-model".to_string())
-                    )
+                    (Some("cli-agent".to_string()), Some("cli-model".to_string()))
                 );
             },
         );
@@ -462,10 +459,7 @@ mod tests {
             || {
                 assert_eq!(
                     resolve_agent_identity(None, None),
-                    (
-                        Some("env-agent".to_string()),
-                        Some("env-model".to_string())
-                    )
+                    (Some("env-agent".to_string()), Some("env-model".to_string()))
                 );
             },
         );

--- a/orbit/orbit-core/src/lib.rs
+++ b/orbit/orbit-core/src/lib.rs
@@ -32,6 +32,7 @@ pub mod workspace_registry;
 
 pub use orbit_engine::JobRunResult;
 pub use orbit_store::skill_store as skill_catalog;
+pub use orbit_store::{ActivityInvocationMetrics, TaskInvocationMetrics, ToolInvocationMetrics};
 
 pub use command::task_template::TaskTemplate;
 pub use command::workflow::{

--- a/orbit/orbit-core/src/runtime/engine.rs
+++ b/orbit/orbit-core/src/runtime/engine.rs
@@ -3,11 +3,16 @@ use orbit_engine::{
     AgentProtocolHost, EnvironmentHost, ExecutionContext, JobRunHost, RuntimeHost,
     TaskAutomationUpdate, TaskHost, activity_skill_refs_from_spec_config,
 };
-use orbit_store::{JobRunStepParams, TaskUpdateParams as StoreTaskUpdateParams};
+use orbit_store::{
+    ActivityInvocationMetrics, InvocationInsertParams, JobRunStepParams, Store,
+    TaskInvocationMetrics, TaskUpdateParams as StoreTaskUpdateParams, ToolInvocationMetrics,
+    token_scoreboard,
+};
 use orbit_tools::ToolContext;
 use orbit_types::{
-    Activity, ActorIdentity, AgentCommitRequest, JobRun, JobRunState, JobTargetType, OrbitError,
-    OrbitEvent, Role, Task, TaskPriority, TaskStatus, TaskType, WorkspacePaths,
+    Activity, ActorIdentity, AgentCommitRequest, InvocationTrace, JobRun, JobRunState,
+    JobTargetType, OrbitError, OrbitEvent, Role, Task, TaskPriority, TaskStatus, TaskType,
+    WorkspacePaths,
 };
 use serde::Serialize;
 use serde_json::{Value, json};
@@ -164,6 +169,74 @@ fn execute_commit_request_if_present(
     Ok(())
 }
 
+fn open_invocation_store(runtime: &OrbitRuntime) -> Result<Store, OrbitError> {
+    Store::open(&runtime.context.persistence().audit_db)
+}
+
+fn normalize_agent_name(agent_cli: &str) -> String {
+    std::path::Path::new(agent_cli)
+        .file_name()
+        .and_then(|value| value.to_str())
+        .unwrap_or(agent_cli)
+        .to_ascii_lowercase()
+}
+
+fn associated_task_ids(input: &Value) -> Vec<String> {
+    let mut task_ids = Vec::new();
+    if let Some(task_id) = input.get("task_id").and_then(Value::as_str) {
+        push_unique_task_id(&mut task_ids, task_id);
+    }
+    if let Some(items) = input.get("task_ids").and_then(Value::as_array) {
+        for item in items {
+            if let Some(task_id) = item.as_str() {
+                push_unique_task_id(&mut task_ids, task_id);
+            }
+        }
+    }
+    if let Some(items) = input.get("tasks").and_then(Value::as_array) {
+        for item in items {
+            if let Some(task_id) = item.as_str() {
+                push_unique_task_id(&mut task_ids, task_id);
+                continue;
+            }
+            if let Some(task_id) = item
+                .get("id")
+                .and_then(Value::as_str)
+                .or_else(|| item.get("task_id").and_then(Value::as_str))
+            {
+                push_unique_task_id(&mut task_ids, task_id);
+            }
+        }
+    }
+    task_ids
+}
+
+fn push_unique_task_id(task_ids: &mut Vec<String>, task_id: &str) {
+    let task_id = task_id.trim();
+    if !task_id.is_empty() && !task_ids.iter().any(|existing| existing == task_id) {
+        task_ids.push(task_id.to_string());
+    }
+}
+
+impl OrbitRuntime {
+    pub fn activity_invocation_metrics(
+        &self,
+    ) -> Result<Vec<ActivityInvocationMetrics>, OrbitError> {
+        open_invocation_store(self)?.list_activity_invocation_metrics()
+    }
+
+    pub fn task_invocation_metrics(
+        &self,
+        task_id: &str,
+    ) -> Result<TaskInvocationMetrics, OrbitError> {
+        open_invocation_store(self)?.get_task_invocation_metrics(task_id)
+    }
+
+    pub fn tool_invocation_metrics(&self) -> Result<Vec<ToolInvocationMetrics>, OrbitError> {
+        open_invocation_store(self)?.list_tool_invocation_metrics()
+    }
+}
+
 impl RuntimeHost for OrbitRuntime {
     fn record_event(&self, event: OrbitEvent) -> Result<(), OrbitError> {
         OrbitRuntime::record_event(self, event)
@@ -301,6 +374,31 @@ impl RuntimeHost for OrbitRuntime {
 
     fn scoreboard_dir(&self) -> &std::path::Path {
         &self.context.paths().scoreboard_dir
+    }
+
+    fn persist_invocation_trace(
+        &self,
+        job_run_id: &str,
+        execution: &ExecutionContext,
+        trace: &InvocationTrace,
+    ) -> Result<(), OrbitError> {
+        let store = open_invocation_store(self)?;
+        store.insert_invocation_trace_record(&InvocationInsertParams {
+            job_run_id: job_run_id.to_string(),
+            activity_id: execution.activity.id.clone(),
+            agent: normalize_agent_name(&execution.agent_cli),
+            model: execution.model.clone(),
+            task_ids: associated_task_ids(&execution.input),
+            trace: trace.clone(),
+        })?;
+
+        if let Err(error) =
+            token_scoreboard::write_token_scoreboard(&self.paths().scoreboard_dir, &store)
+        {
+            eprintln!("orbit: failed to refresh tokens scoreboard: {error}");
+        }
+
+        Ok(())
     }
 }
 
@@ -624,8 +722,7 @@ mod tests {
             execution_summary: String::new(),
             context_files: vec![
                 "orbit/orbit-core/src/runtime/engine.rs".to_string(),
-                "orbit/orbit-core/assets/activities/agent_invoke/implement_change.yaml"
-                    .to_string(),
+                "orbit/orbit-core/assets/activities/agent_invoke/implement_change.yaml".to_string(),
             ],
             workspace_path: Some("/task/worktree".to_string()),
             repo_root: Some("/task/repo".to_string()),
@@ -706,7 +803,10 @@ mod tests {
             }),
         );
 
-        assert_eq!(detail.get("workspace_path"), Some(&json!("/override/worktree")));
+        assert_eq!(
+            detail.get("workspace_path"),
+            Some(&json!("/override/worktree"))
+        );
         assert_eq!(detail.get("repo_root"), Some(&json!("/override/repo")));
     }
 

--- a/orbit/orbit-engine/src/activity_runner.rs
+++ b/orbit/orbit-engine/src/activity_runner.rs
@@ -244,6 +244,10 @@ mod retry_tests {
             state: JobRunState::Success,
             exit_code: Some(0),
             duration_ms: Some(100),
+            invocation_trace: orbit_types::InvocationTrace {
+                duration_ms: 100,
+                ..orbit_types::InvocationTrace::default()
+            },
             response_json: None,
             error_code: None,
             error_message: None,

--- a/orbit/orbit-engine/src/context.rs
+++ b/orbit/orbit-engine/src/context.rs
@@ -3,8 +3,9 @@ use orbit_exec::EnvironmentMode;
 use orbit_store::JobRunStepParams;
 use orbit_tools::ToolContext;
 use orbit_types::{
-    Activity, Job, JobRun, JobRunState, JobTargetType, OrbitError, OrbitEvent, ReviewThread, Role,
-    Task, TaskPriority, TaskStatus, redact_sensitive_env_json, redact_sensitive_env_option,
+    Activity, InvocationTrace, Job, JobRun, JobRunState, JobTargetType, OrbitError, OrbitEvent,
+    ReviewThread, Role, Task, TaskPriority, TaskStatus, redact_sensitive_env_json,
+    redact_sensitive_env_option,
 };
 use serde_json::Value;
 use std::collections::HashMap;
@@ -54,6 +55,7 @@ pub struct AttemptOutcome {
     pub state: JobRunState,
     pub exit_code: Option<i32>,
     pub duration_ms: Option<u64>,
+    pub invocation_trace: InvocationTrace,
     pub response_json: Option<Value>,
     pub error_code: Option<String>,
     pub error_message: Option<String>,
@@ -68,6 +70,7 @@ impl AttemptOutcome {
             state: JobRunState::Failed,
             exit_code: Some(1),
             duration_ms: None,
+            invocation_trace: InvocationTrace::default(),
             response_json: None,
             error_code: Some(error_code.to_string()),
             error_message: Some(message),
@@ -81,6 +84,10 @@ impl AttemptOutcome {
             state: JobRunState::Success,
             exit_code: Some(exit_code),
             duration_ms: Some(duration_ms),
+            invocation_trace: InvocationTrace {
+                duration_ms,
+                ..InvocationTrace::default()
+            },
             response_json: Some(response_json),
             error_code: None,
             error_message: None,
@@ -292,6 +299,14 @@ pub trait RuntimeHost {
     ) -> Result<(), OrbitError>;
     fn scoring_enabled(&self) -> bool;
     fn scoreboard_dir(&self) -> &Path;
+    fn persist_invocation_trace(
+        &self,
+        _job_run_id: &str,
+        _execution: &ExecutionContext,
+        _trace: &InvocationTrace,
+    ) -> Result<(), OrbitError> {
+        Ok(())
+    }
 }
 
 /// Aggregates all five sub-traits required at the top-level engine boundary.

--- a/orbit/orbit-engine/src/executor/agent.rs
+++ b/orbit/orbit-engine/src/executor/agent.rs
@@ -2,7 +2,7 @@ use std::io::Write;
 
 use orbit_agent::{Agent, AgentRequest, AgentResponseStatus, parse_and_validate_response};
 use orbit_exec::{EnvironmentMode, ExecRequest, NoSandbox, StdinMode, run_process};
-use orbit_types::{AgentResponseEnvelope, JobRunState, OrbitError};
+use orbit_types::{AgentResponseEnvelope, InvocationTrace, JobRunState, OrbitError};
 use serde_json::Value;
 use tempfile::NamedTempFile;
 
@@ -48,6 +48,10 @@ fn execute_with_cwd<H: EnvironmentHost + AgentProtocolHost + ?Sized>(
             state: JobRunState::Cancelled,
             exit_code: exec_result.exit_code,
             duration_ms: Some(exec_result.duration_ms),
+            invocation_trace: InvocationTrace {
+                duration_ms: exec_result.duration_ms,
+                ..InvocationTrace::default()
+            },
             response_json: None,
             error_code: None,
             error_message: Some(exec_result.stderr.trim().to_string()),
@@ -61,6 +65,10 @@ fn execute_with_cwd<H: EnvironmentHost + AgentProtocolHost + ?Sized>(
             state: JobRunState::Timeout,
             exit_code: exec_result.exit_code,
             duration_ms: Some(exec_result.duration_ms),
+            invocation_trace: InvocationTrace {
+                duration_ms: exec_result.duration_ms,
+                ..InvocationTrace::default()
+            },
             response_json: None,
             error_code: Some(AGENT_TIMEOUT.to_string()),
             error_message: Some(format_timeout_error_message(&exec_result)),
@@ -70,7 +78,7 @@ fn execute_with_cwd<H: EnvironmentHost + AgentProtocolHost + ?Sized>(
     }
 
     match parse_and_validate_response(&exec_result) {
-        Ok((envelope, state)) => {
+        Ok((envelope, state, trace)) => {
             // Agent exited 0 but produced no parseable JSON envelope. Since agents
             // persist state via task artifacts (side-effect model), this is a success.
             if state == AgentResponseStatus::Success
@@ -78,14 +86,20 @@ fn execute_with_cwd<H: EnvironmentHost + AgentProtocolHost + ?Sized>(
                 && exec_result.exit_code == Some(0)
                 && !orbit_agent::is_timeout(&exec_result)
             {
-                return AttemptOutcome::success(0, exec_result.duration_ms, Value::Null);
+                let mut outcome = AttemptOutcome::success(0, exec_result.duration_ms, Value::Null);
+                outcome.invocation_trace = trace;
+                return outcome;
             }
-            process_agent_response(host, execution, &exec_result, envelope, state)
+            process_agent_response(host, execution, &exec_result, envelope, state, trace)
         }
         Err(OrbitError::AgentProtocolViolation(message)) => AttemptOutcome {
             state: JobRunState::Failed,
             exit_code: exec_result.exit_code,
             duration_ms: Some(exec_result.duration_ms),
+            invocation_trace: InvocationTrace {
+                duration_ms: exec_result.duration_ms,
+                ..InvocationTrace::default()
+            },
             response_json: None,
             error_code: Some(AGENT_PROTOCOL_VIOLATION.to_string()),
             error_message: Some(message),
@@ -96,6 +110,10 @@ fn execute_with_cwd<H: EnvironmentHost + AgentProtocolHost + ?Sized>(
             state: JobRunState::Failed,
             exit_code: exec_result.exit_code,
             duration_ms: Some(exec_result.duration_ms),
+            invocation_trace: InvocationTrace {
+                duration_ms: exec_result.duration_ms,
+                ..InvocationTrace::default()
+            },
             response_json: None,
             error_code: Some(AGENT_INVOCATION_FAILED.to_string()),
             error_message: Some(err.to_string()),
@@ -121,7 +139,7 @@ fn build_agent_invocation<H: EnvironmentHost + AgentProtocolHost + ?Sized>(
         .build_agent_stdin_envelope_payload(execution)
         .map_err(invocation_failed_outcome)?;
 
-    let invocation = agent
+    let (invocation, _) = agent
         .invoke(
             match &execution.job {
                 Some(job) => AgentRequest::job(
@@ -318,6 +336,7 @@ fn process_agent_response<H: EnvironmentHost + AgentProtocolHost + ?Sized>(
     exec_result: &orbit_types::ExecutionResult,
     envelope: AgentResponseEnvelope,
     state: AgentResponseStatus,
+    invocation_trace: InvocationTrace,
 ) -> AttemptOutcome {
     let run_state = match state {
         AgentResponseStatus::Success => JobRunState::Success,
@@ -327,9 +346,14 @@ fn process_agent_response<H: EnvironmentHost + AgentProtocolHost + ?Sized>(
     let error_code = envelope.error.as_ref().map(|error| error.code.clone());
     let error_message = envelope.error.as_ref().map(|error| error.message.clone());
 
-    if let Some(outcome) =
-        validate_agent_success(host, execution, exec_result, &envelope, run_state)
-    {
+    if let Some(outcome) = validate_agent_success(
+        host,
+        execution,
+        exec_result,
+        &envelope,
+        run_state,
+        invocation_trace.clone(),
+    ) {
         return outcome;
     }
 
@@ -337,6 +361,7 @@ fn process_agent_response<H: EnvironmentHost + AgentProtocolHost + ?Sized>(
         state: run_state,
         exit_code: exec_result.exit_code,
         duration_ms: Some(exec_result.duration_ms),
+        invocation_trace,
         response_json: serde_json::to_value(envelope).ok(),
         error_code,
         error_message,
@@ -351,6 +376,7 @@ fn validate_agent_success<H: EnvironmentHost + AgentProtocolHost + ?Sized>(
     exec_result: &orbit_types::ExecutionResult,
     envelope: &AgentResponseEnvelope,
     run_state: JobRunState,
+    invocation_trace: InvocationTrace,
 ) -> Option<AttemptOutcome> {
     if run_state == JobRunState::Success
         && let Some(result) = envelope.result.as_ref()
@@ -364,6 +390,7 @@ fn validate_agent_success<H: EnvironmentHost + AgentProtocolHost + ?Sized>(
             state: JobRunState::Failed,
             exit_code: exec_result.exit_code,
             duration_ms: Some(exec_result.duration_ms),
+            invocation_trace,
             response_json: serde_json::to_value(envelope).ok(),
             error_code: Some(error_code),
             error_message: Some(err.to_string()),

--- a/orbit/orbit-engine/src/executor/automation/mod.rs
+++ b/orbit/orbit-engine/src/executor/automation/mod.rs
@@ -13,7 +13,7 @@ mod snapshot;
 mod sync_review;
 mod task;
 
-use orbit_types::{Activity, JobRunState, OrbitError};
+use orbit_types::{Activity, InvocationTrace, JobRunState, OrbitError};
 use serde::Deserialize;
 use serde_json::Value;
 
@@ -61,6 +61,7 @@ impl ActivityExecutor for AutomationExecutor {
                     state: JobRunState::Success,
                     exit_code: Some(0),
                     duration_ms: None,
+                    invocation_trace: InvocationTrace::default(),
                     response_json: Some(result),
                     error_code: None,
                     error_message: None,

--- a/orbit/orbit-engine/src/executor/automation/parallel.rs
+++ b/orbit/orbit-engine/src/executor/automation/parallel.rs
@@ -32,7 +32,9 @@ fn sanitize_run_id_token(run_id: &str) -> Result<String, OrbitError> {
             }
         })
         .collect();
-    let trimmed = sanitized.trim_matches(|c: char| c == '-' || c == '.').to_string();
+    let trimmed = sanitized
+        .trim_matches(|c: char| c == '-' || c == '.')
+        .to_string();
     if trimmed.is_empty() {
         return Err(OrbitError::InvalidInput(format!(
             "cannot derive shared worktree token from run_id '{run_id}'"
@@ -62,18 +64,13 @@ fn shared_worktree_branch_name(run_id: &str) -> Result<String, OrbitError> {
 /// Extract the `run_id` from an activity input value, returning a trimmed
 /// non-empty string. Used by downstream batch activities that need to resolve
 /// the same shared worktree as the dispatch step.
-pub(super) fn require_run_id<'a>(
-    input: &'a Value,
-    activity: &str,
-) -> Result<&'a str, OrbitError> {
+pub(super) fn require_run_id<'a>(input: &'a Value, activity: &str) -> Result<&'a str, OrbitError> {
     input
         .get("run_id")
         .and_then(Value::as_str)
         .map(str::trim)
         .filter(|value| !value.is_empty())
-        .ok_or_else(|| {
-            OrbitError::InvalidInput(format!("{activity} requires input.run_id"))
-        })
+        .ok_or_else(|| OrbitError::InvalidInput(format!("{activity} requires input.run_id")))
 }
 
 #[derive(Debug, Clone)]
@@ -694,8 +691,7 @@ mod tests {
         run_git(repo_root, &["branch", "orbit/parallel-batch-jrun-old"]);
 
         let run_id = "jrun-20260408-0219-2";
-        let worktree_path =
-            resolve_shared_worktree_path(repo_root, run_id).expect("resolve path");
+        let worktree_path = resolve_shared_worktree_path(repo_root, run_id).expect("resolve path");
         ensure_shared_worktree(repo_root, &worktree_path, "main", run_id)
             .expect("create dynamic shared worktree despite stale static branch");
 

--- a/orbit/orbit-engine/src/executor/automation/pr.rs
+++ b/orbit/orbit-engine/src/executor/automation/pr.rs
@@ -689,7 +689,12 @@ mod tests {
 
     #[test]
     fn bootstrap_batch_review_is_noop_when_batch_already_exists() {
-        let host = TestHost::new(vec![sample_task("T20260330-063823", "batch-9", "/tmp", "76")]);
+        let host = TestHost::new(vec![sample_task(
+            "T20260330-063823",
+            "batch-9",
+            "/tmp",
+            "76",
+        )]);
 
         let result = bootstrap_batch_review(
             &host,

--- a/orbit/orbit-engine/src/executor/cli_command.rs
+++ b/orbit/orbit-engine/src/executor/cli_command.rs
@@ -15,6 +15,7 @@ use crate::activity_runner::{
 };
 use crate::context::{ACTIVITY_EXECUTION_FAILED, AttemptOutcome, EngineHost, ExecutionContext};
 use crate::template::{TemplateContext, render};
+use orbit_types::InvocationTrace;
 
 #[derive(Debug, Clone, Deserialize)]
 pub struct CliCommandSpec {
@@ -78,6 +79,10 @@ impl ActivityExecutor for CliCommandExecutor {
                     state: JobRunState::Success,
                     exit_code,
                     duration_ms: Some(duration_ms),
+                    invocation_trace: InvocationTrace {
+                        duration_ms,
+                        ..InvocationTrace::default()
+                    },
                     response_json: Some(result),
                     error_code: None,
                     error_message: None,

--- a/orbit/orbit-engine/src/job_runner/execution.rs
+++ b/orbit/orbit-engine/src/job_runner/execution.rs
@@ -523,6 +523,14 @@ fn execute_activity_with_retries<H: EngineHost>(
                     return Err(OrbitError::JobRunNotFound(run.run_id.clone()));
                 }
 
+                if execution.activity.spec_type == "agent_invoke" {
+                    host.persist_invocation_trace(
+                        &run.run_id,
+                        &execution,
+                        &outcome.invocation_trace,
+                    )?;
+                }
+
                 log_step_completion(
                     global_step_index,
                     iteration,
@@ -553,6 +561,8 @@ fn execute_activity_with_retries<H: EngineHost>(
                     &step.target_id,
                     &execution,
                     outcome.duration_ms,
+                    outcome.invocation_trace.tool_calls.len() as u32,
+                    Some(outcome.invocation_trace.usage.prompt_response_total()),
                     outcome.retry_count,
                     step_finished,
                 );

--- a/orbit/orbit-engine/src/job_runner/friction.rs
+++ b/orbit/orbit-engine/src/job_runner/friction.rs
@@ -101,6 +101,8 @@ pub(super) fn append_step_metrics<H: EngineHost>(
     step_id: &str,
     execution: &crate::context::ExecutionContext,
     duration_ms: Option<u64>,
+    tool_invocations: u32,
+    token_usage: Option<u64>,
     retry_count: u32,
     ts: DateTime<Utc>,
 ) {
@@ -116,8 +118,8 @@ pub(super) fn append_step_metrics<H: EngineHost>(
         step: step_id.to_string(),
         task_id,
         actor_identity,
-        tool_invocations: 0, // Not yet tracked at the engine level
-        token_usage: None,   // Not yet tracked at the engine level
+        tool_invocations,
+        token_usage,
         step_duration_ms: duration_ms,
         retry_count,
     };

--- a/orbit/orbit-store/src/file/token_scoreboard.rs
+++ b/orbit/orbit-store/src/file/token_scoreboard.rs
@@ -1,0 +1,31 @@
+use std::fs;
+use std::path::Path;
+
+use serde_json::json;
+
+use orbit_types::OrbitError;
+
+use crate::Store;
+
+pub fn write_token_scoreboard(scoreboard_dir: &Path, store: &Store) -> Result<(), OrbitError> {
+    let path = scoreboard_dir.join("tokens.json");
+    let payload = json!({
+        "generated_at": chrono::Utc::now().to_rfc3339(),
+        "activities": store.list_activity_invocation_metrics()?,
+        "top_tasks": store.list_top_task_invocation_metrics(20)?,
+        "tools": store.list_tool_invocation_metrics()?,
+        "known_limitations": [
+            "Subagent attribution folds into the parent invocation totals.",
+            "cache_read_tokens are reported separately from input_tokens.",
+            "Multi-task invocations are fully attributed to every tagged task.",
+            "Non-Claude providers currently emit zero traces."
+        ]
+    });
+
+    fs::create_dir_all(scoreboard_dir).map_err(|e| OrbitError::Io(e.to_string()))?;
+    let tmp = scoreboard_dir.join(".tokens.json.tmp");
+    let raw = serde_json::to_string_pretty(&payload)
+        .map_err(|e| OrbitError::Store(format!("serialize tokens.json: {e}")))?;
+    fs::write(&tmp, format!("{raw}\n")).map_err(|e| OrbitError::Io(e.to_string()))?;
+    fs::rename(&tmp, &path).map_err(|e| OrbitError::Io(e.to_string()))
+}

--- a/orbit/orbit-store/src/lib.rs
+++ b/orbit/orbit-store/src/lib.rs
@@ -24,8 +24,12 @@
 
 pub mod backend;
 mod file;
+#[path = "sqlite/invocation_store.rs"]
+mod invocation_store_impl;
 pub mod json_schema;
 pub mod sqlite;
+#[path = "file/token_scoreboard.rs"]
+mod token_scoreboard_impl;
 
 pub mod skill_store {
     pub use crate::file::skill_store::*;
@@ -51,6 +55,10 @@ pub mod metrics_log {
     pub use crate::file::metrics_log::{append_metrics_entry, read_metrics_entries_for_month};
 }
 
+pub mod token_scoreboard {
+    pub use crate::token_scoreboard_impl::write_token_scoreboard;
+}
+
 use chrono::{DateTime, Utc};
 
 pub use backend::{
@@ -60,6 +68,9 @@ pub use backend::{
     TaskUpdateParams, ToolStoreBackend, activity_store_file, activity_store_resolved,
     audit_event_store_sqlite, job_store_file, job_store_resolved, task_store_file,
     task_store_resolved, tool_store_sqlite,
+};
+pub use invocation_store_impl::{
+    ActivityInvocationMetrics, InvocationInsertParams, TaskInvocationMetrics, ToolInvocationMetrics,
 };
 pub use json_schema::{validate_instance_against_schema, validate_schema_document};
 pub use sqlite::audit_event_store::{AuditEventFilter, AuditEventInsertParams};

--- a/orbit/orbit-store/src/sqlite/invocation_store.rs
+++ b/orbit/orbit-store/src/sqlite/invocation_store.rs
@@ -1,0 +1,387 @@
+use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
+
+use orbit_types::{InvocationTrace, OrbitError};
+use rusqlite::params;
+
+use crate::{Store, now_string};
+
+#[derive(Debug, Clone)]
+pub struct InvocationInsertParams {
+    pub job_run_id: String,
+    pub activity_id: String,
+    pub agent: String,
+    pub model: Option<String>,
+    pub task_ids: Vec<String>,
+    pub trace: InvocationTrace,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ActivityInvocationMetrics {
+    pub activity_id: String,
+    pub invocation_count: u64,
+    pub total_input_tokens: u64,
+    pub total_cache_read_tokens: u64,
+    pub total_cache_create_tokens: u64,
+    pub total_output_tokens: u64,
+    pub total_tokens: u64,
+    pub avg_tokens: f64,
+    pub p50_tokens: u64,
+    pub p95_tokens: u64,
+    pub total_tool_calls: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct TaskInvocationMetrics {
+    pub task_id: String,
+    pub invocation_count: u64,
+    pub total_input_tokens: u64,
+    pub total_cache_read_tokens: u64,
+    pub total_cache_create_tokens: u64,
+    pub total_output_tokens: u64,
+    pub total_tokens: u64,
+    pub total_tool_calls: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ToolInvocationMetrics {
+    pub activity_id: String,
+    pub tool_name: String,
+    pub call_count: u64,
+    pub avg_result_bytes: f64,
+    pub total_result_bytes: u64,
+}
+
+#[derive(Debug, Clone)]
+struct ActivitySample {
+    activity_id: String,
+    input_tokens: u64,
+    cache_read_tokens: u64,
+    cache_create_tokens: u64,
+    output_tokens: u64,
+    tool_call_count: u64,
+}
+
+#[derive(Debug, Clone)]
+struct TaskSample {
+    task_id: String,
+    input_tokens: u64,
+    cache_read_tokens: u64,
+    cache_create_tokens: u64,
+    output_tokens: u64,
+    tool_call_count: u64,
+}
+
+impl Store {
+    pub fn insert_invocation_trace_record(
+        &self,
+        params: &InvocationInsertParams,
+    ) -> Result<(), OrbitError> {
+        let mut conn = self
+            .conn
+            .lock()
+            .map_err(|e| OrbitError::Store(format!("mutex poisoned: {e}")))?;
+        let tx = conn
+            .transaction()
+            .map_err(|e| OrbitError::Store(e.to_string()))?;
+
+        tx.execute(
+            r#"INSERT INTO invocations(
+                ts, job_run_id, activity_id, agent, model, duration_ms,
+                input_tokens, cache_read_tokens, cache_create_tokens,
+                output_tokens, tool_call_count
+            ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)"#,
+            params![
+                now_string(),
+                params.job_run_id,
+                params.activity_id,
+                params.agent,
+                params.model,
+                params.trace.duration_ms as i64,
+                params.trace.usage.input as i64,
+                params.trace.usage.cache_read as i64,
+                params.trace.usage.cache_create as i64,
+                params.trace.usage.output as i64,
+                params.trace.tool_calls.len() as i64,
+            ],
+        )
+        .map_err(|e| OrbitError::Store(e.to_string()))?;
+
+        let invocation_id = tx.last_insert_rowid();
+
+        for task_id in &params.task_ids {
+            tx.execute(
+                "INSERT OR IGNORE INTO invocation_tasks(invocation_id, task_id) VALUES (?1, ?2)",
+                params![invocation_id, task_id],
+            )
+            .map_err(|e| OrbitError::Store(e.to_string()))?;
+        }
+
+        for tool_call in &params.trace.tool_calls {
+            tx.execute(
+                r#"INSERT INTO tool_calls(invocation_id, seq, tool_name, result_bytes)
+                   VALUES (?1, ?2, ?3, ?4)"#,
+                params![
+                    invocation_id,
+                    tool_call.seq as i64,
+                    tool_call.tool_name,
+                    tool_call.result_bytes as i64,
+                ],
+            )
+            .map_err(|e| OrbitError::Store(e.to_string()))?;
+        }
+
+        tx.commit().map_err(|e| OrbitError::Store(e.to_string()))
+    }
+
+    pub fn list_activity_invocation_metrics(
+        &self,
+    ) -> Result<Vec<ActivityInvocationMetrics>, OrbitError> {
+        let samples = self.load_activity_samples()?;
+        let mut grouped: HashMap<String, Vec<ActivitySample>> = HashMap::new();
+        for sample in samples {
+            grouped
+                .entry(sample.activity_id.clone())
+                .or_default()
+                .push(sample);
+        }
+
+        let mut rows = grouped
+            .into_iter()
+            .map(|(activity_id, samples)| {
+                let total_input_tokens = samples.iter().map(|s| s.input_tokens).sum::<u64>();
+                let total_cache_read_tokens =
+                    samples.iter().map(|s| s.cache_read_tokens).sum::<u64>();
+                let total_cache_create_tokens =
+                    samples.iter().map(|s| s.cache_create_tokens).sum::<u64>();
+                let total_output_tokens = samples.iter().map(|s| s.output_tokens).sum::<u64>();
+                let total_tool_calls = samples.iter().map(|s| s.tool_call_count).sum::<u64>();
+                let mut totals = samples
+                    .iter()
+                    .map(|sample| sample.input_tokens.saturating_add(sample.output_tokens))
+                    .collect::<Vec<_>>();
+                totals.sort_unstable();
+
+                ActivityInvocationMetrics {
+                    activity_id,
+                    invocation_count: totals.len() as u64,
+                    total_input_tokens,
+                    total_cache_read_tokens,
+                    total_cache_create_tokens,
+                    total_output_tokens,
+                    total_tokens: total_input_tokens.saturating_add(total_output_tokens),
+                    avg_tokens: average(&totals),
+                    p50_tokens: percentile(&totals, 50),
+                    p95_tokens: percentile(&totals, 95),
+                    total_tool_calls,
+                }
+            })
+            .collect::<Vec<_>>();
+
+        rows.sort_by(|left, right| {
+            right
+                .total_tokens
+                .cmp(&left.total_tokens)
+                .then_with(|| left.activity_id.cmp(&right.activity_id))
+        });
+        Ok(rows)
+    }
+
+    pub fn get_task_invocation_metrics(
+        &self,
+        task_id: &str,
+    ) -> Result<TaskInvocationMetrics, OrbitError> {
+        let mut rows = self.list_task_invocation_metrics(Some(task_id))?;
+        Ok(rows.pop().unwrap_or(TaskInvocationMetrics {
+            task_id: task_id.to_string(),
+            invocation_count: 0,
+            total_input_tokens: 0,
+            total_cache_read_tokens: 0,
+            total_cache_create_tokens: 0,
+            total_output_tokens: 0,
+            total_tokens: 0,
+            total_tool_calls: 0,
+        }))
+    }
+
+    pub fn list_top_task_invocation_metrics(
+        &self,
+        limit: usize,
+    ) -> Result<Vec<TaskInvocationMetrics>, OrbitError> {
+        let mut rows = self.list_task_invocation_metrics(None)?;
+        if limit > 0 && rows.len() > limit {
+            rows.truncate(limit);
+        }
+        Ok(rows)
+    }
+
+    pub fn list_tool_invocation_metrics(&self) -> Result<Vec<ToolInvocationMetrics>, OrbitError> {
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| OrbitError::Store(format!("mutex poisoned: {e}")))?;
+        let mut stmt = conn
+            .prepare(
+                r#"
+                SELECT i.activity_id, tc.tool_name, COUNT(*) AS call_count,
+                       COALESCE(AVG(tc.result_bytes), 0), COALESCE(SUM(tc.result_bytes), 0)
+                FROM tool_calls tc
+                INNER JOIN invocations i ON i.id = tc.invocation_id
+                GROUP BY i.activity_id, tc.tool_name
+                ORDER BY call_count DESC, i.activity_id ASC, tc.tool_name ASC
+                "#,
+            )
+            .map_err(|e| OrbitError::Store(e.to_string()))?;
+
+        let rows = stmt
+            .query_map([], |row| {
+                Ok(ToolInvocationMetrics {
+                    activity_id: row.get(0)?,
+                    tool_name: row.get(1)?,
+                    call_count: row.get::<_, i64>(2)? as u64,
+                    avg_result_bytes: row.get(3)?,
+                    total_result_bytes: row.get::<_, i64>(4)? as u64,
+                })
+            })
+            .map_err(|e| OrbitError::Store(e.to_string()))?;
+
+        rows.collect::<Result<Vec<_>, _>>()
+            .map_err(|e| OrbitError::Store(e.to_string()))
+    }
+
+    fn load_activity_samples(&self) -> Result<Vec<ActivitySample>, OrbitError> {
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| OrbitError::Store(format!("mutex poisoned: {e}")))?;
+        let mut stmt = conn
+            .prepare(
+                r#"
+                SELECT activity_id, input_tokens, cache_read_tokens, cache_create_tokens,
+                       output_tokens, tool_call_count
+                FROM invocations
+                ORDER BY activity_id ASC, id ASC
+                "#,
+            )
+            .map_err(|e| OrbitError::Store(e.to_string()))?;
+
+        let rows = stmt
+            .query_map([], |row| {
+                Ok(ActivitySample {
+                    activity_id: row.get(0)?,
+                    input_tokens: row.get::<_, i64>(1)? as u64,
+                    cache_read_tokens: row.get::<_, i64>(2)? as u64,
+                    cache_create_tokens: row.get::<_, i64>(3)? as u64,
+                    output_tokens: row.get::<_, i64>(4)? as u64,
+                    tool_call_count: row.get::<_, i64>(5)? as u64,
+                })
+            })
+            .map_err(|e| OrbitError::Store(e.to_string()))?;
+
+        rows.collect::<Result<Vec<_>, _>>()
+            .map_err(|e| OrbitError::Store(e.to_string()))
+    }
+
+    fn list_task_invocation_metrics(
+        &self,
+        task_id: Option<&str>,
+    ) -> Result<Vec<TaskInvocationMetrics>, OrbitError> {
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| OrbitError::Store(format!("mutex poisoned: {e}")))?;
+
+        let sql = if task_id.is_some() {
+            r#"
+            SELECT it.task_id, i.input_tokens, i.cache_read_tokens, i.cache_create_tokens,
+                   i.output_tokens, i.tool_call_count
+            FROM invocation_tasks it
+            INNER JOIN invocations i ON i.id = it.invocation_id
+            WHERE it.task_id = ?1
+            ORDER BY it.task_id ASC, i.id ASC
+            "#
+        } else {
+            r#"
+            SELECT it.task_id, i.input_tokens, i.cache_read_tokens, i.cache_create_tokens,
+                   i.output_tokens, i.tool_call_count
+            FROM invocation_tasks it
+            INNER JOIN invocations i ON i.id = it.invocation_id
+            ORDER BY it.task_id ASC, i.id ASC
+            "#
+        };
+
+        let mut stmt = conn
+            .prepare(sql)
+            .map_err(|e| OrbitError::Store(e.to_string()))?;
+        let mapper = |row: &rusqlite::Row<'_>| -> rusqlite::Result<TaskSample> {
+            Ok(TaskSample {
+                task_id: row.get(0)?,
+                input_tokens: row.get::<_, i64>(1)? as u64,
+                cache_read_tokens: row.get::<_, i64>(2)? as u64,
+                cache_create_tokens: row.get::<_, i64>(3)? as u64,
+                output_tokens: row.get::<_, i64>(4)? as u64,
+                tool_call_count: row.get::<_, i64>(5)? as u64,
+            })
+        };
+
+        let rows = if let Some(task_id) = task_id {
+            stmt.query_map(params![task_id], mapper)
+        } else {
+            stmt.query_map([], mapper)
+        }
+        .map_err(|e| OrbitError::Store(e.to_string()))?;
+
+        let mut grouped: HashMap<String, TaskInvocationMetrics> = HashMap::new();
+        for row in rows {
+            let row = row.map_err(|e| OrbitError::Store(e.to_string()))?;
+            let entry =
+                grouped
+                    .entry(row.task_id.clone())
+                    .or_insert_with(|| TaskInvocationMetrics {
+                        task_id: row.task_id.clone(),
+                        invocation_count: 0,
+                        total_input_tokens: 0,
+                        total_cache_read_tokens: 0,
+                        total_cache_create_tokens: 0,
+                        total_output_tokens: 0,
+                        total_tokens: 0,
+                        total_tool_calls: 0,
+                    });
+            entry.invocation_count += 1;
+            entry.total_input_tokens += row.input_tokens;
+            entry.total_cache_read_tokens += row.cache_read_tokens;
+            entry.total_cache_create_tokens += row.cache_create_tokens;
+            entry.total_output_tokens += row.output_tokens;
+            entry.total_tokens += row.input_tokens.saturating_add(row.output_tokens);
+            entry.total_tool_calls += row.tool_call_count;
+        }
+
+        let mut values = grouped.into_values().collect::<Vec<_>>();
+        values.sort_by(|left, right| {
+            right
+                .total_tokens
+                .cmp(&left.total_tokens)
+                .then_with(|| left.task_id.cmp(&right.task_id))
+        });
+        Ok(values)
+    }
+}
+
+fn average(values: &[u64]) -> f64 {
+    if values.is_empty() {
+        0.0
+    } else {
+        values.iter().sum::<u64>() as f64 / values.len() as f64
+    }
+}
+
+fn percentile(sorted_values: &[u64], percentile: u64) -> u64 {
+    if sorted_values.is_empty() {
+        return 0;
+    }
+    let n = sorted_values.len();
+    let rank = (percentile as usize * n).div_ceil(100);
+    let index = rank.saturating_sub(1).min(n - 1);
+    sorted_values[index]
+}

--- a/orbit/orbit-store/src/sqlite/migration.rs
+++ b/orbit/orbit-store/src/sqlite/migration.rs
@@ -53,6 +53,37 @@ pub(crate) fn apply_schema(conn: &Connection) -> Result<(), OrbitError> {
                 pid INTEGER NOT NULL,
                 session_id TEXT
             );
+
+            CREATE TABLE IF NOT EXISTS invocations (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                ts TEXT NOT NULL,
+                job_run_id TEXT NOT NULL,
+                activity_id TEXT NOT NULL,
+                agent TEXT NOT NULL,
+                model TEXT,
+                duration_ms INTEGER NOT NULL DEFAULT 0,
+                input_tokens INTEGER NOT NULL DEFAULT 0,
+                cache_read_tokens INTEGER NOT NULL DEFAULT 0,
+                cache_create_tokens INTEGER NOT NULL DEFAULT 0,
+                output_tokens INTEGER NOT NULL DEFAULT 0,
+                tool_call_count INTEGER NOT NULL DEFAULT 0
+            );
+
+            CREATE TABLE IF NOT EXISTS invocation_tasks (
+                invocation_id INTEGER NOT NULL,
+                task_id TEXT NOT NULL,
+                PRIMARY KEY(invocation_id, task_id),
+                FOREIGN KEY(invocation_id) REFERENCES invocations(id) ON DELETE CASCADE
+            );
+
+            CREATE TABLE IF NOT EXISTS tool_calls (
+                invocation_id INTEGER NOT NULL,
+                seq INTEGER NOT NULL,
+                tool_name TEXT NOT NULL,
+                result_bytes INTEGER NOT NULL DEFAULT 0,
+                PRIMARY KEY(invocation_id, seq),
+                FOREIGN KEY(invocation_id) REFERENCES invocations(id) ON DELETE CASCADE
+            );
         "#,
     )
     .map_err(|e| OrbitError::Store(e.to_string()))?;
@@ -60,6 +91,7 @@ pub(crate) fn apply_schema(conn: &Connection) -> Result<(), OrbitError> {
     ensure_agent_sessions_schema(conn)?;
     ensure_tools_schema(conn)?;
     ensure_audit_events_schema(conn)?;
+    ensure_invocation_schema(conn)?;
 
     Ok(())
 }
@@ -235,6 +267,25 @@ fn ensure_audit_events_schema(conn: &Connection) -> Result<(), OrbitError> {
 
             CREATE UNIQUE INDEX IF NOT EXISTS idx_audit_events_execution_id
             ON audit_events(execution_id);
+        "#,
+    )
+    .map_err(|e| OrbitError::Store(e.to_string()))
+}
+
+fn ensure_invocation_schema(conn: &Connection) -> Result<(), OrbitError> {
+    conn.execute_batch(
+        r#"
+            CREATE INDEX IF NOT EXISTS idx_invocations_job_run_id
+            ON invocations(job_run_id);
+
+            CREATE INDEX IF NOT EXISTS idx_invocations_activity_id
+            ON invocations(activity_id);
+
+            CREATE INDEX IF NOT EXISTS idx_invocation_tasks_task_id
+            ON invocation_tasks(task_id);
+
+            CREATE INDEX IF NOT EXISTS idx_tool_calls_tool_name
+            ON tool_calls(tool_name);
         "#,
     )
     .map_err(|e| OrbitError::Store(e.to_string()))

--- a/orbit/orbit-tools/src/builtin/orbit/task_show.rs
+++ b/orbit/orbit-tools/src/builtin/orbit/task_show.rs
@@ -22,7 +22,9 @@ pub(super) fn build_exec_request(
         args.push("--field".to_string());
         args.push(field.to_string());
     }
-    Ok(super::orbit_exec_request_with_identity(ctx, args, &identity))
+    Ok(super::orbit_exec_request_with_identity(
+        ctx, args, &identity,
+    ))
 }
 
 impl Tool for OrbitTaskShowTool {
@@ -31,9 +33,11 @@ impl Tool for OrbitTaskShowTool {
         parameters.extend(super::identity_params());
         parameters.push(ToolParam {
             name: "field".to_string(),
-            description: "Optional field selector. When set, returns only the specified field as JSON. \
+            description:
+                "Optional field selector. When set, returns only the specified field as JSON. \
                 Valid values: comments, plan, execution_summary, description, acceptance_criteria, \
-                history, context_files.".to_string(),
+                history, context_files."
+                    .to_string(),
             param_type: "string".to_string(),
             required: false,
         });

--- a/orbit/orbit-types/src/invocation.rs
+++ b/orbit/orbit-types/src/invocation.rs
@@ -1,0 +1,39 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct TokenUsage {
+    #[serde(default)]
+    pub input: u64,
+    #[serde(default)]
+    pub cache_read: u64,
+    #[serde(default)]
+    pub cache_create: u64,
+    #[serde(default)]
+    pub output: u64,
+}
+
+impl TokenUsage {
+    pub fn prompt_response_total(&self) -> u64 {
+        self.input.saturating_add(self.output)
+    }
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ToolCallTrace {
+    #[serde(default)]
+    pub seq: u32,
+    #[serde(default)]
+    pub tool_name: String,
+    #[serde(default)]
+    pub result_bytes: u64,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct InvocationTrace {
+    #[serde(default)]
+    pub usage: TokenUsage,
+    #[serde(default)]
+    pub tool_calls: Vec<ToolCallTrace>,
+    #[serde(default)]
+    pub duration_ms: u64,
+}

--- a/orbit/orbit-types/src/lib.rs
+++ b/orbit/orbit-types/src/lib.rs
@@ -27,6 +27,7 @@ pub mod error;
 pub mod event;
 pub mod friction;
 pub mod id;
+pub mod invocation;
 pub mod job;
 pub mod metrics;
 pub mod policy_decision;
@@ -45,6 +46,7 @@ pub use error::OrbitError;
 pub use event::OrbitEvent;
 pub use friction::FrictionEntry;
 pub use id::OrbitId;
+pub use invocation::{InvocationTrace, TokenUsage, ToolCallTrace};
 pub use job::{
     AgentCommitRequest, AgentResponseEnvelope, AgentRunError, Job, JobRun, JobRunState, JobRunStep,
     JobScheduleState, JobStep, JobTargetType, RunEvent, StepCondition, default_job_max_active_runs,


### PR DESCRIPTION
## Summary
- add invocation/token observability plumbing and a first `orbit metrics` surface for Orbit runs
- move the orbit-map hash cache into the knowledge tree and add deterministic freshness warnings to lineage packs
- tighten task-authoring guidance so new tasks are more explicit about testing and implementation constraints

## Task Descriptions
- `T20260408-0330` — Add token and invocation observability so Orbit can answer which activities, tasks, and tools are actually consuming tokens and where prompts are bloating.
- `T20260408-0338` — Move the orbit-map hash cache into the knowledge root so incremental rebuild state lives with the knowledge snapshot it belongs to.
- `T20260407-0503-3` — Surface deterministic freshness warnings in lineage packs so agents can tell when graph or summary artifacts may be stale.
- `T20260408-0211` — Strengthen Orbit task-authoring guidance around environment-independent tests, explicit definitions, and implementation guardrails.

## Verification
- `cargo test -p orbit-cli metrics --quiet`
- `cd orbit-map && python -m pytest tests/test_hash_cache.py tests/test_lineage_pack.py -q`
