### PR TITLE
Attribute system-driven task automation entries to system actor

### DIFF
--- a/crates/orbit-core/src/command/task/add.rs
+++ b/crates/orbit-core/src/command/task/add.rs
@@ -48,7 +48,7 @@ impl OrbitRuntime {
             effective_label.clone()
         };
         let planned_by = authored_role_value(params.plan.as_str(), &create_label);
-        let comments = build_task_comments(params.comment.clone(), effective_label.as_str())?;
+        let comments = build_task_comments(params.comment.clone(), create_label.as_str())?;
         let workspace_path =
             normalize_workspace_path(&self.paths().repo_root, params.workspace_path.as_deref())?;
         let dependencies = normalize_task_dependencies(params.dependencies.clone())?;

--- a/crates/orbit-core/src/command/task/helpers.rs
+++ b/crates/orbit-core/src/command/task/helpers.rs
@@ -4,6 +4,8 @@ use orbit_common::types::{
     normalize_optional_attribution_label,
 };
 
+pub(crate) const SYSTEM_ACTOR_LABEL: &str = "system";
+
 pub(super) fn build_task_comments(
     message: Option<String>,
     by: &str,

--- a/crates/orbit-core/src/command/task/mod.rs
+++ b/crates/orbit-core/src/command/task/mod.rs
@@ -13,6 +13,7 @@ mod update;
 pub use lint::{TaskLintFinding, TaskLintReport, TaskLintSeverity};
 pub use params::{TaskAddParams, TaskUpdateParams};
 
+pub(crate) use helpers::SYSTEM_ACTOR_LABEL;
 pub(crate) use paths::{canonicalize_context_files_for_read, context_workspace_root};
 pub(crate) use transitions::{
     ensure_task_has_execution_plan, in_progress_transition_requires_plan,

--- a/crates/orbit-core/src/command/task/transitions.rs
+++ b/crates/orbit-core/src/command/task/transitions.rs
@@ -7,7 +7,9 @@ use orbit_store::friction_bounty;
 use crate::OrbitRuntime;
 use crate::runtime::TaskRecordUpdateParams as StoreTaskUpdateParams;
 
-use super::helpers::{build_task_comments, effective_actor_label, implementation_label};
+use super::helpers::{
+    SYSTEM_ACTOR_LABEL, build_task_comments, effective_actor_label, implementation_label,
+};
 
 const UNAUTHORED_TASK_PLAN_PLACEHOLDER: &str = "To be authored by executing agent at start time.";
 
@@ -103,7 +105,7 @@ impl OrbitRuntime {
         note: Option<String>,
         comment: Option<String>,
     ) -> Result<Task, OrbitError> {
-        self.start_task_with_identity(id, note, comment, None, None)
+        self.start_task_with_actor_label_override(id, note, comment, None, None, None)
     }
 
     pub fn start_task_with_identity(
@@ -114,6 +116,34 @@ impl OrbitRuntime {
         agent: Option<String>,
         model: Option<String>,
     ) -> Result<Task, OrbitError> {
+        self.start_task_with_actor_label_override(id, note, comment, agent, model, None)
+    }
+
+    pub(crate) fn start_task_as_system(
+        &self,
+        id: &str,
+        note: Option<String>,
+        comment: Option<String>,
+    ) -> Result<Task, OrbitError> {
+        self.start_task_with_actor_label_override(
+            id,
+            note,
+            comment,
+            None,
+            None,
+            Some(SYSTEM_ACTOR_LABEL.to_string()),
+        )
+    }
+
+    fn start_task_with_actor_label_override(
+        &self,
+        id: &str,
+        note: Option<String>,
+        comment: Option<String>,
+        agent: Option<String>,
+        model: Option<String>,
+        actor_label_override: Option<String>,
+    ) -> Result<Task, OrbitError> {
         let (canonical_agent, canonical_model) =
             self.canonical_agent_model_identity(agent.as_deref(), model.as_deref());
         let task = self.get_task(id)?;
@@ -123,11 +153,13 @@ impl OrbitRuntime {
             ensure_task_has_execution_plan(id, task.plan.as_str())?;
         }
         let actor = self.actor().clone();
-        let effective_label = effective_actor_label(
-            &actor.label,
-            canonical_agent.as_deref(),
-            canonical_model.as_deref(),
-        );
+        let effective_label = actor_label_override.unwrap_or_else(|| {
+            effective_actor_label(
+                &actor.label,
+                canonical_agent.as_deref(),
+                canonical_model.as_deref(),
+            )
+        });
         let append_comments = build_task_comments(comment, effective_label.as_str())?;
         let dependency_warning = (!unmet_dependencies.is_empty()).then(|| {
             format!(

--- a/crates/orbit-core/src/command/task/update.rs
+++ b/crates/orbit-core/src/command/task/update.rs
@@ -7,7 +7,8 @@ use crate::OrbitRuntime;
 use crate::runtime::TaskRecordUpdateParams;
 
 use super::helpers::{
-    build_task_comments, effective_actor_label, implementation_label, task_comment_history_entries,
+    SYSTEM_ACTOR_LABEL, build_task_comments, effective_actor_label, implementation_label,
+    task_comment_history_entries,
 };
 use super::params::TaskUpdateParams;
 use super::paths::{
@@ -40,7 +41,7 @@ impl OrbitRuntime {
         comment: Option<String>,
         note: Option<String>,
     ) -> Result<Task, OrbitError> {
-        self.update_task_with_status_note(
+        self.update_task_with_status_note_and_identity(
             id,
             TaskUpdateParams {
                 execution_summary,
@@ -49,16 +50,9 @@ impl OrbitRuntime {
                 ..Default::default()
             },
             note,
+            Some(SYSTEM_ACTOR_LABEL.to_string()),
+            None,
         )
-    }
-
-    fn update_task_with_status_note(
-        &self,
-        id: &str,
-        params: TaskUpdateParams,
-        status_note: Option<String>,
-    ) -> Result<Task, OrbitError> {
-        self.update_task_with_status_note_and_identity(id, params, status_note, None, None)
     }
 
     fn update_task_with_status_note_and_identity(

--- a/crates/orbit-core/src/runtime/engine/task_host.rs
+++ b/crates/orbit-core/src/runtime/engine/task_host.rs
@@ -4,6 +4,7 @@ use orbit_common::types::{
 use orbit_engine::{TaskAutomationUpdate, TaskReadHost, TaskWriteHost};
 
 use crate::OrbitRuntime;
+use crate::command::task::SYSTEM_ACTOR_LABEL;
 use crate::runtime::TaskRecordUpdateParams as StoreTaskUpdateParams;
 
 impl TaskReadHost for OrbitRuntime {
@@ -36,7 +37,7 @@ impl TaskWriteHost for OrbitRuntime {
         note: Option<String>,
         comment: Option<String>,
     ) -> Result<Task, OrbitError> {
-        OrbitRuntime::start_task(self, task_id, note, comment)
+        OrbitRuntime::start_task_as_system(self, task_id, note, comment)
     }
 
     fn update_task_from_activity(
@@ -74,21 +75,30 @@ impl TaskWriteHost for OrbitRuntime {
         let _ = self.with_mutation(|| {
             let (agent, model) = self
                 .canonical_agent_model_identity(update.agent.as_deref(), update.model.as_deref());
-            let actor_label = normalize_optional_attribution_label(
+            let actor_label = SYSTEM_ACTOR_LABEL.to_string();
+            let explicit_attribution_label = normalize_optional_attribution_label(
                 update
                     .model
                     .as_deref()
+                    .or(model.as_deref())
                     .or(update.agent.as_deref())
-                    .or(Some("agent")),
-                existing_task.model.as_deref().or(model.as_deref()),
-            )
-            .unwrap_or_else(|| "agent".to_string());
+                    .or(agent.as_deref()),
+                model.as_deref(),
+            );
+            let planned_by = update.plan.as_ref().map(|_| {
+                Some(
+                    explicit_attribution_label
+                        .clone()
+                        .unwrap_or_else(|| actor_label.clone()),
+                )
+            });
             let implemented_by = normalize_optional_attribution_label(
                 existing_task
                     .model
                     .as_deref()
                     .or(model.as_deref())
                     .or(existing_task.implemented_by.as_deref())
+                    .or(explicit_attribution_label.as_deref())
                     .or(Some(actor_label.as_str())),
                 existing_task.model.as_deref().or(model.as_deref()),
             );
@@ -98,7 +108,7 @@ impl TaskWriteHost for OrbitRuntime {
                     actor: actor_label.clone(),
                     execution_summary: update.execution_summary.clone(),
                     plan: update.plan.clone(),
-                    planned_by: update.plan.as_ref().map(|_| Some(actor_label.clone())),
+                    planned_by,
                     implemented_by: if matches!(
                         update.status,
                         Some(TaskStatus::Review | TaskStatus::Done)
@@ -136,7 +146,10 @@ impl TaskWriteHost for OrbitRuntime {
 mod tests {
     use super::*;
 
-    use crate::command::task::TaskAddParams;
+    use std::collections::HashMap;
+
+    use crate::command::task::{TaskAddParams, TaskUpdateParams};
+    use serde_json::json;
     use tempfile::tempdir;
 
     fn test_runtime() -> (tempfile::TempDir, OrbitRuntime) {
@@ -188,5 +201,206 @@ mod tests {
             updated.workspace_path.as_deref(),
             Some("/tmp/orbit-worktree")
         );
+    }
+
+    #[test]
+    fn update_task_automation_records_status_history_as_system() {
+        let (_root, runtime) = test_runtime();
+        let task = runtime
+            .add_task(TaskAddParams {
+                title: "Review automated update".to_string(),
+                description: "Exercise update_task automation attribution.".to_string(),
+                workspace_path: Some(".".to_string()),
+                ..Default::default()
+            })
+            .expect("add task");
+        runtime
+            .start_task(&task.id, Some("human starts work".to_string()), None)
+            .expect("start task");
+        runtime
+            .update_task(
+                &task.id,
+                TaskUpdateParams {
+                    execution_summary: Some("Implemented and validated.".to_string()),
+                    ..Default::default()
+                },
+            )
+            .expect("set execution summary");
+
+        orbit_engine::execute_deterministic_action(
+            &runtime,
+            "update_task",
+            &json!({
+                "task_id": task.id.clone(),
+                "status": "review"
+            }),
+            false,
+            &HashMap::new(),
+            None,
+        )
+        .expect("run update_task automation");
+
+        let updated = runtime.get_task(&task.id).expect("reload task");
+        let status_entry = updated
+            .history
+            .iter()
+            .rev()
+            .find(|entry| {
+                entry.event == "status_changed" && entry.to_status == Some(TaskStatus::Review)
+            })
+            .expect("review transition history");
+        assert_eq!(status_entry.by, SYSTEM_ACTOR_LABEL);
+        assert_eq!(
+            status_entry.note.as_deref(),
+            Some("automation: update_task \u{2192} review")
+        );
+    }
+
+    #[test]
+    fn activity_update_comment_records_comment_as_system() {
+        let (_root, runtime) = test_runtime();
+        let task = runtime
+            .add_task(TaskAddParams {
+                title: "Activity comment".to_string(),
+                description: "Exercise activity comment attribution.".to_string(),
+                workspace_path: Some(".".to_string()),
+                ..Default::default()
+            })
+            .expect("add task");
+
+        runtime
+            .update_task_from_activity(
+                &task.id,
+                TaskStatus::InProgress,
+                None,
+                Some("Automation left a note.".to_string()),
+                Some("automation start".to_string()),
+            )
+            .expect("activity update");
+
+        let updated = runtime.get_task(&task.id).expect("reload task");
+        let comment = updated.comments.last().expect("activity comment");
+        assert_eq!(comment.by, SYSTEM_ACTOR_LABEL);
+        let comment_history = updated
+            .history
+            .iter()
+            .find(|entry| entry.event == "commented")
+            .expect("comment history");
+        assert_eq!(comment_history.by, SYSTEM_ACTOR_LABEL);
+    }
+
+    #[test]
+    fn generic_automation_status_update_uses_system_history_and_preserves_implementer() {
+        let (_root, runtime) = test_runtime();
+        let task = runtime
+            .add_task(TaskAddParams {
+                title: "Generic automation".to_string(),
+                description: "Exercise TaskAutomationUpdate attribution.".to_string(),
+                workspace_path: Some(".".to_string()),
+                ..Default::default()
+            })
+            .expect("add task");
+        runtime
+            .start_task(&task.id, Some("human starts work".to_string()), None)
+            .expect("start task");
+
+        runtime
+            .apply_task_automation_update(
+                &task.id,
+                TaskAutomationUpdate {
+                    status: Some(TaskStatus::Review),
+                    execution_summary: Some("Automated handoff complete.".to_string()),
+                    agent: Some("codex".to_string()),
+                    model: Some("gpt-test".to_string()),
+                    ..TaskAutomationUpdate::default()
+                },
+            )
+            .expect("automation update");
+
+        let updated = runtime.get_task(&task.id).expect("reload task");
+        let status_entry = updated
+            .history
+            .iter()
+            .rev()
+            .find(|entry| {
+                entry.event == "status_changed" && entry.to_status == Some(TaskStatus::Review)
+            })
+            .expect("review transition history");
+        assert_eq!(status_entry.by, SYSTEM_ACTOR_LABEL);
+        assert_eq!(updated.implemented_by.as_deref(), Some("gpt-test"));
+    }
+
+    #[test]
+    fn direct_update_task_keeps_default_human_attribution() {
+        let (_root, runtime) = test_runtime();
+        let task = runtime
+            .add_task(TaskAddParams {
+                title: "Human comment".to_string(),
+                description: "Exercise direct update attribution.".to_string(),
+                workspace_path: Some(".".to_string()),
+                ..Default::default()
+            })
+            .expect("add task");
+
+        runtime
+            .update_task(
+                &task.id,
+                TaskUpdateParams {
+                    comment: Some("Human-visible note.".to_string()),
+                    ..Default::default()
+                },
+            )
+            .expect("update task");
+
+        let updated = runtime.get_task(&task.id).expect("reload task");
+        let comment = updated.comments.last().expect("human comment");
+        assert_eq!(comment.by, "human");
+        let comment_history = updated
+            .history
+            .iter()
+            .find(|entry| entry.event == "commented")
+            .expect("comment history");
+        assert_eq!(comment_history.by, "human");
+    }
+
+    #[test]
+    fn dispatch_batch_claim_records_start_and_comment_as_system() {
+        let (_root, runtime) = test_runtime();
+        let task = runtime
+            .add_task(TaskAddParams {
+                title: "Claim in batch".to_string(),
+                description: "Exercise dispatch_batch attribution.".to_string(),
+                workspace_path: Some(".".to_string()),
+                ..Default::default()
+            })
+            .expect("add task");
+
+        orbit_engine::execute_deterministic_action(
+            &runtime,
+            "dispatch_batch",
+            &json!({
+                "run_id": "jrun-test",
+                "parallelism": 1,
+                "task_ids": [task.id.clone()]
+            }),
+            false,
+            &HashMap::new(),
+            None,
+        )
+        .expect("dispatch batch");
+
+        let updated = runtime.get_task(&task.id).expect("reload task");
+        let start_entry = updated
+            .history
+            .iter()
+            .find(|entry| entry.event == "started")
+            .expect("start history");
+        assert_eq!(start_entry.by, SYSTEM_ACTOR_LABEL);
+        let batch_comment = updated
+            .comments
+            .iter()
+            .find(|comment| comment.message.starts_with("Batch dispatched:"))
+            .expect("batch dispatch comment");
+        assert_eq!(batch_comment.by, SYSTEM_ACTOR_LABEL);
     }
 }

--- a/crates/orbit-engine/src/executor/automation/dispatch_batch.rs
+++ b/crates/orbit-engine/src/executor/automation/dispatch_batch.rs
@@ -13,6 +13,8 @@ use crate::context::{TaskAutomationUpdate, TaskHost};
 use super::input::required_input_string;
 use super::parallel::{parse_parallelism, tasks_conflict};
 
+const SYSTEM_ACTOR_LABEL: &str = "system";
+
 pub(super) fn dispatch_batch<H: TaskHost + ?Sized>(
     host: &H,
     input: &Value,
@@ -240,7 +242,7 @@ fn tag_task<H: TaskHost + ?Sized>(
             batch_id: Some(run_id.to_string()),
             append_comments: vec![TaskComment {
                 at: Utc::now(),
-                by: "agent".to_string(),
+                by: SYSTEM_ACTOR_LABEL.to_string(),
                 message: format!("Batch dispatched: {rationale}"),
             }],
             ..TaskAutomationUpdate::default()


### PR DESCRIPTION
## Tasks
- [T20260427-24] Attribute system-driven task automation entries to system actor

## Branch Freshness
- Base ref: `agent-main`
- Head ref: `orbit/T20260427-24-69eeb083`
- Behind base: 0
- Ahead of base: 1

## Files Changed
- `crates/orbit-core/src/command/task/add.rs`
- `crates/orbit-core/src/command/task/helpers.rs`
- `crates/orbit-core/src/command/task/mod.rs`
- `crates/orbit-core/src/command/task/transitions.rs`
- `crates/orbit-core/src/command/task/update.rs`
- `crates/orbit-core/src/runtime/engine/task_host.rs`
- `crates/orbit-engine/src/executor/automation/dispatch_batch.rs`

*authored by: claude-opus-4-7*