### PR TITLE
Shorten user interface design docs

### DIFF
--- a/docs/design/user-interface/1_overview.md
+++ b/docs/design/user-interface/1_overview.md
@@ -2,31 +2,30 @@
 
 **Status:** Draft
 **Owner:** gemini
-**Last updated:** 2026-04-26
+**Last updated:** 2026-04-30
 
-The Orbit User Interface encompasses both the local dashboard (surfaced via `orbit-cli`) and the external-facing project website. It provides a cohesive, high-density visual surface for monitoring autonomous agents, executing workflows, and interpreting system telemetry.
+Orbit UI covers the local dashboard served by `orbit-cli` and the project-facing web surface. It gives operators a dense, legible way to monitor agents, workflows, telemetry, and audit signals.
 
 ## 1. Motivation
 
-Autonomous agents generate massive amounts of telemetry, state transitions, and diagnostic logs at speeds far exceeding human reading capacity. We need a UI paradigm that prioritizes density, utilitarian function, and immediate visual status recognition without sacrificing readability. The "Canon Refined" aesthetic balances high-density data presentation with modern web affordances (sans-serif readability, subtle rounding, soft semantic colors) to create a highly functional "pro-tool" tailored for technical workflows.
+Agent runs produce more state changes, logs, and diagnostics than a human can read linearly. The UI therefore optimizes for scan density, clear status recognition, and quick drill-downs. Canon Refined keeps the pro-tool feel while using readable sans-serif text, subtle rounding, and restrained semantic color [T20260427-29].
 
 ## 2. Core Concepts
 
-- **Canon Refined Aesthetic**: A modern, high-density design language emphasizing a layered dark mode (`#0a0a0a` base), subtle structural borders, and muted semantic colors to surface state at a glance.
-- **Dual Typography**: `Inter` (sans-serif) for prose and UI structure, paired with `JetBrains Mono` strictly for data points, IDs, and logs.
-- **Local Dashboard**: The live telemetry view served locally during active agent execution, accessible via `orbit-cli`.
-- **Project Website**: The public face of the project, adapting the core terminal aesthetic to static documentation, benchmark reports, and marketing pages.
+- **Canon Refined and typography:** Layered dark surfaces, fine borders, compact spacing, and muted status colors; `Inter` carries labels and prose while `JetBrains Mono` carries IDs, metrics, timestamps, code, and logs.
+- **Surfaces:** The local dashboard lives in `crates/orbit-cli/assets/dashboard/`; static docs and project pages should reuse the same visual grammar without importing runtime-only dashboard assumptions.
 
 ## 3. At a Glance
 
-| Concern | File/Folder | What it is |
-|---------|-------------|------------|
-| Local Dashboard UI | `crates/orbit-cli/assets/dashboard/` | Core HTML/CSS assets for the local runtime dashboard. |
-| UI Theme Definition | `specs/theme.md` | Primary source of truth for color palette, typography, and visual rules. |
-| Core Styling | `2_design.md` | Details the implementation of the design principles. |
+| Concern | File | Task |
+|---------|------|------|
+| Local dashboard | `crates/orbit-cli/assets/dashboard/` | Runtime tabs, tables, tiles, logs, and diagnostics. |
+| Theme rules | `./specs/theme.md` | Canon Refined tokens and visual invariants. |
+| Current mechanisms | `./2_design.md` | Layout, telemetry, palette, typography, and known limitations. |
 
 ## Task References
 
-- [T20260427-29]
+- [T20260427-29] introduced the Canon Refined UI direction.
+- [T20260430-24] tightened the UI design docs against shared conventions.
 
 > Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.

--- a/docs/design/user-interface/2_design.md
+++ b/docs/design/user-interface/2_design.md
@@ -2,49 +2,39 @@
 
 **Status:** Draft
 **Owner:** gemini
-**Last updated:** 2026-04-28
+**Last updated:** 2026-04-30
 
-This document details the active implementation of the Orbit UI, covering the visual design constraints and structural layout of both the local dashboard and the website. It focuses on the mechanisms employed to enforce the "Canon Refined" aesthetic.
+This document describes the current Orbit UI implementation: the local dashboard assets, the Canon Refined visual rules they rely on, and the telemetry behaviors that must stay consistent with backend data.
 
-## 1. High-Density Layout Mechanism
+## 1. Dense Layout
 
-The dashboard prioritizes maximizing data density while maintaining structural clarity. We employ a modular grid system that packs tabular data, telemetry feeds, and state indicators into a single view without scrolling where possible. 
-- Elements use standardized, subtle border radii (`4px` for small elements, `6px` for panels).
-- Expandable rows use sunken backgrounds (`--bg-sunk`) to nest detailed hierarchies without sacrificing the root tabular view.
-- The scoreboard table collapses companion metrics into compact pairs where scan quality improves: tokens render as `total/output`, tools render as `failed/total`, and planning duels render as `wins/participated`. Friction triage outcomes stay out of the primary table; the visible friction column is reported count only [T20260428-15].
+The dashboard favors wide, dense tables and panels over narrative screens. Tight spacing, small radii, and expandable sunken detail rows preserve hierarchy without hiding root lists. The scoreboard compresses companion metrics into pairs: `tokens` is `total/output`, `tool fail/all` is failed over total tool calls, and `duel w/all` is wins over participated duels. The primary friction column remains reported count only [T20260428-15].
 
-## 2. Layered Dark Palette
+## 2. Layered Palette
 
-The entire UI is anchored on a layered dark mode (`#0a0a0a` base, `#17171a` elevated cards) rather than flat pitch black.
-- This mitigates eye strain while providing clear visual depth.
-- Semantic coloring is muted but distinct: `--status-done` (`#4cc38a`), `--status-in-progress` (`#5ec8d4`), and `--status-blocked` (`#ef6b6b`).
-- Accents use a soft blue (`#6e9fff`) rather than harsh neons.
+The UI uses layered dark surfaces instead of flat black: base canvas, elevated panels, sunken wells, and accent washes. Status color should stay muted and distinct; exact token values live in `./specs/theme.md` and the dashboard CSS.
 
-## 3. Typography Rules
+## 3. Typography
 
-The UI employs a dual-typography approach:
-- `Inter` (sans-serif) is used for prose, headers, and UI elements to maximize readability.
-- `JetBrains Mono` is strictly reserved for data points, IDs, metrics, timestamps, and logs to ensure tabular alignment.
-- Base size is `13px` to maintain high density without compromising legibility.
+`Inter` carries labels, headings, and prose. `JetBrains Mono` is reserved for IDs, metrics, timestamps, code, and log streams so numeric and diagnostic data stays aligned.
 
-## 4. Real-Time Status Indication
+## 4. Live Status
 
-To provide a "live telemetry" feel, status markers rely on visual motion and high contrast. Spinners, blinking dots, and updating ticker formats are used to communicate active processing without requiring the user to read underlying text logs.
+Live processing is visible through pulsing dots, spinners, buffered-log counters, periodically refreshed tiles, and compact ticker-style values. Motion is functional: it points to active work without making the operator read raw logs first.
 
 ## 5. Dashboard Telemetry Consistency
 
-Dashboard summary tiles and drill-down panels must be backed by compatible data sources. The Audit > Policy tab is the detail view for the Denials 24h tile, so `/api/diagnostics/denials` combines v2 loop JSONL denial rows with SQLite audit events whose status is `denied`. SQLite filesystem boundary denials that lack an activity fsProfile render under the stable `workspace-boundary` profile label so the table remains filterable and does not silently disagree with `/api/audit/summary` [T20260428-13].
+Summary tiles and drill-down panels must agree. Audit > Policy is the detail view for the Denials 24h tile, so `/api/diagnostics/denials` combines v2 loop JSONL denial rows with SQLite `status = denied` audit events. SQLite filesystem boundary denials without an activity fsProfile use the stable `workspace-boundary` label [T20260428-13].
 
 ## 6. Concerns & Honest Limitations
 
-- **Accessibility**: The extreme contrast, small font sizes, and dense layouts may pose readability challenges for some users. We lean on the assumption that the primary audience is technical professionals, but true WCAG compliance is currently a secondary priority.
-- **Responsive Design**: True high-density "terminal" layouts are difficult to adapt gracefully to mobile or narrow viewports. The current implementation heavily favors wide desktop displays.
-- **Component Reusability**: Relying strictly on raw CSS variables and HTML currently means component logic is duplicated across the dashboard and website, lacking a formalized UI framework like React or Vue.
+Accessibility still needs a real WCAG pass; responsive behavior remains optimized for wide desktop viewports; raw HTML, CSS variables, and dashboard JavaScript keep the runtime simple but leave duplication across project surfaces.
 
 ## Task References
 
-- [T20260427-29]
-- [T20260428-13]
-- [T20260428-15]
+- [T20260427-29] introduced the Canon Refined UI direction.
+- [T20260428-13] unified dashboard denial sources for the policy drill-down.
+- [T20260428-15] compacted scoreboard ratio columns.
+- [T20260430-24] shortened this design doc while preserving current behavior statements.
 
 > Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.

--- a/docs/design/user-interface/3_vision.md
+++ b/docs/design/user-interface/3_vision.md
@@ -2,35 +2,37 @@
 
 **Status:** Draft
 **Owner:** gemini
-**Last updated:** 2026-04-26
+**Last updated:** 2026-04-30
 
-This document scopes the forward-looking evolution of the Orbit UI. While the current implementation establishes the "Canon Refined" aesthetic, the long-term vision aims to enhance dynamic interactivity, elevate the branding through motion, and build a unified design system that bridges the local CLI tooling with the public project presence.
+This document scopes forward-looking UI work beyond the current dashboard: richer interactivity, careful motion, and a reusable design system that can span local runtime views and public project pages.
 
 ## 1. Open Questions
 
-1. **Framework Adoption**: As the dashboard grows to handle complex state (e.g., interactive graph visualization, live agent duel debugging), do we migrate from vanilla HTML/JS to a lightweight framework (e.g., Preact or Svelte), and at what cost to bundle size and build complexity?
-2. **Logo Animation**: How do we evolve the static "two orbiting circles" logo into a dynamic, interactive element that responds to actual system load or telemetry while adhering to the monochromatic aesthetic?
-3. **Component Unification**: How do we share UI components between the Rust-served local dashboard and the static website without introducing heavy Node.js build steps?
+1. **Framework adoption:** When dashboard state outgrows vanilla HTML/JS, is Preact, Svelte, or another small runtime worth the build complexity?
+2. **Motion:** Can the mark or status surfaces respond to real telemetry without becoming decorative noise?
+3. **Component sharing:** How do dashboard and static-site UI share tokens and components without a heavy Node.js pipeline?
 
 ## 2. Prior Work
 
 ### Terminal and TUI Tools
-- **k9s & htop**: Excellent examples of data-dense, keyboard-driven terminal interfaces. They validate the utility of high-contrast text and tabular density but lack the graphical fidelity we can achieve in a web view.
-- **Bloomberg Terminal**: The industry standard for high-density, high-stakes data presentation. It proves that users tolerate steep learning curves if the interface maximizes raw data throughput.
+- **k9s and htop:** Dense, keyboard-driven system views that validate compact tables and high-contrast status.
+- **Bloomberg Terminal:** A proof point for high-stakes density, fast recognition, and tolerated learning curves.
 
 ### Modern Pro-Tools
-- **Linear & Vercel**: High watermarks for modern, keyboard-centric web design. The Canon Refined aesthetic draws heavily from their principles of layered dark modes, subtle borders, and precise typography, while dialing up the data density required for our specific use case.
+- **Linear and Vercel:** Benchmarks for quiet dark surfaces, precise typography, and keyboard-friendly interaction.
 
 ## 3. What May Be Distinctive
 
-Orbit's UI approach is distinct because it deliberately pairs cutting-edge autonomous agent technology with a high-density, modern "pro-tool" visual language. Instead of abstracting away the complexity behind friendly chatbots, Orbit leans into the complexity, surfacing raw graphs, execution traces, and telemetry in a stark, uncompromising dashboard. The "Canon Refined" aesthetic signals to users that Orbit is a serious tool for engineers, not a toy.
+Orbit can be distinctive by showing agent work as inspectable operations rather than hiding it behind chat. Graphs, traces, policy denials, scoreboards, and live logs should stay visible enough for engineering judgment while Canon Refined keeps the surface controlled [T20260427-29].
 
 ## 4. References
 
-- [Canon Refined Theme Spec](./specs/theme.md) (Internal)
+- Orbit-internal: [Canon Refined Theme Spec](./specs/theme.md)
+- External: k9s, htop, Bloomberg Terminal, Linear, and Vercel remain comparison points for density, polish, and operator trust.
 
 ## Task References
 
-- [T20260427-29]
+- [T20260427-29] introduced the Canon Refined UI direction.
+- [T20260430-24] tightened this vision doc around open questions and references.
 
 > Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.

--- a/docs/design/user-interface/4_decisions.md
+++ b/docs/design/user-interface/4_decisions.md
@@ -2,53 +2,51 @@
 
 **Status:** Draft
 **Owner:** gemini
-**Last updated:** 2026-04-28
+**Last updated:** 2026-04-30
 
-This document records the architectural and design decisions for the Orbit User Interface. It is append-only.
+This append-only ADR log records UI decisions in ascending order. Each entry keeps its status line, cited task ID, decision summary, and at least one explicit cost.
 
 ## ADR-001 — Canon Refined Aesthetic
 
 **Status:** Proposed · 2026-04 · [T20260427-29]
 
-**Context.** The dashboard and website require a cohesive visual identity. The previous "Trading Terminal" aesthetic (pure monospace, sharp corners, harsh neon colors) proved too rigid and inaccessible for complex, hierarchical data. We need a design that maintains high density and a "pro-tool" feel while improving readability and structure.
+**Context.** The dashboard and project website need one visual identity. The prior Trading Terminal direction was dense but too rigid for hierarchical data, review threads, and mixed telemetry.
 
-**Decision.** We adopt the "Canon Refined" aesthetic (layered dark mode, dual typography using `Inter` and `JetBrains Mono`, soft semantic colors, and subtle border radii).
+**Decision.** Adopt Canon Refined: layered dark surfaces, `Inter` plus `JetBrains Mono`, soft semantic colors, compact spacing, and subtle radii.
 
 **Consequences.**
-- We gain high data density and a modern, accessible "pro-tool" visual brand.
-- We drop the strict adherence to retro constraints, allowing for standard web affordances.
-- Cost: We must formalize a design system to prevent the aesthetic from drifting into generic "Web 2.0" styling, requiring more disciplined CSS architecture.
+- The UI keeps a serious pro-tool signal while allowing standard web affordances when they improve operator clarity.
+- Cost: The design system must be maintained so Canon Refined does not drift into generic dark SaaS styling.
 
 ## ADR-002 — Unified Denial Sources for Policy Dashboard
 
 **Status:** Accepted · 2026-04 · [T20260428-13]
 
-**Context.** The Denials 24h tile counts SQLite audit rows and v2 loop denials, while the Policy tab originally scanned only v2 loop JSONL files. Direct CLI policy denials such as `fs.read` workspace-boundary failures could therefore increment the tile while the detail panel claimed there were no denials.
+**Context.** The Denials 24h tile counted SQLite audit rows and v2 loop denials, but the Policy tab originally scanned only v2 loop JSONL files. Direct CLI denials could increment the tile while the detail table appeared empty.
 
-**Decision.** The dashboard policy-denials endpoint aggregates both v2 denial envelopes and SQLite `status = denied` audit events before building the profile, target, run, and agent tables. SQLite filesystem denials without a real activity fsProfile use the stable `workspace-boundary` profile label.
+**Decision.** Aggregate v2 denial envelopes and SQLite `status = denied` audit events in the policy-denials endpoint. SQLite filesystem denials without an activity fsProfile use `workspace-boundary`.
 
 **Consequences.**
-- The Policy tab is now a faithful drill-down for the Denials 24h tile.
-- Operators can inspect direct `orbit tool run` policy denials without switching to the raw audit events table.
-- Cost: The endpoint carries a small translation layer for SQLite audit rows because that schema does not store typed denial fields like `profile` and `path`.
+- Audit > Policy is a faithful drill-down for Denials 24h, including direct `orbit tool run` policy denials.
+- Cost: The endpoint carries a translation layer because SQLite audit rows lack typed denial fields like `profile` and `path`.
 
 ## ADR-003 — Compact Scoreboard Ratio Columns
 
 **Status:** Accepted · 2026-04 · [T20260428-15]
 
-**Context.** The dashboard scoreboard accumulated separate columns for output tokens, tool calls, duel wins/losses, and friction triage outcomes. After failed tool calls became a first-class summary field, keeping raw counters split across the table made the reliability signal harder to scan and pushed lower-priority triage details into the primary view.
+**Context.** The scoreboard had separate columns for output tokens, tool calls, duel wins/losses, and friction triage. After failed tool calls became first-class, the split counters made reliability harder to scan.
 
-**Decision.** Render companion metrics as compact display pairs in the scoreboard table: `tokens` shows `total/output`, `tool fail/all` shows failed tool calls over total tool calls, and `duel w/all` shows wins over participated duels. Keep only friction reports in the primary table for now, leaving accepted and rejected friction counts to detailed or future drill-down surfaces.
+**Decision.** Render companion metrics as compact pairs: `tokens` is `total/output`, `tool fail/all` is failed over all tool calls, and `duel w/all` is wins over participated duels. Keep only friction reports in the primary table.
 
 **Consequences.**
-- The scoreboard keeps the same backing JSON fields while presenting reliability and participation context in fewer columns.
-- `0/N` tool failures remains visually meaningful instead of being dimmed as missing data.
-- Cost: Users who want friction accepted/rejected counts or raw duel losses must inspect the underlying summary JSON or a future detail view rather than the primary table.
+- The table presents reliability and participation context in fewer columns, while `0/N` tool failures stays meaningful.
+- Cost: Friction accepted/rejected counts and raw duel losses require summary JSON or a future detail view.
 
 ## Task References
 
-- [T20260427-29]
-- [T20260428-13]
-- [T20260428-15]
+- [T20260427-29] introduced the Canon Refined UI direction.
+- [T20260428-13] unified policy-denial sources for the dashboard.
+- [T20260428-15] compacted scoreboard ratio columns.
+- [T20260430-24] tightened this ADR log without changing decisions.
 
 > Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.


### PR DESCRIPTION
## Tasks
- [T20260430-24] Shorten user interface design docs
  <details><summary>Execution Summary</summary>

## Status
success

## Summary of Changes
- Tightened the four numbered UI design docs while preserving the required convention sections and ADR history.
- Updated `Last updated` to 2026-04-30 and added [T20260430-24] to touched docs Task References.
- Reduced `wc -l docs/design/user-interface/*.md` total from 172 before editing to 161 after editing.

## Overall Assessment
The UI docs are shorter, less repetitive, and still aligned with the current dashboard behavior: compact scoreboard ratios, Denials 24h policy drill-down semantics, Canon Refined visual guidance, and wide-desktop dashboard limitations remain documented.

## Validation
- Before line count: `32 + 50 + 36 + 54 = 172 total`.
- After line count: `31 + 40 + 38 + 52 = 161 total`; after is lower by 11 lines.
- Required section inspection passed for `1_overview.md`, `2_design.md`, `3_vision.md`, and `4_decisions.md`; required sections remain present in order.
- Edited ADR inspection passed for ADR-001, ADR-002, and ADR-003; each retains ADR number, status line with task ID, decision summary, and explicit `Cost:` consequence.
- `git diff --check -- docs/design/user-interface`: passed with no whitespace errors.
- `make fmt`: passed.
- `make build`: passed.

## Deviations from Original Plan
- Did not move the task to review, matching the execution envelope instruction that later pipeline steps handle that transition.

  </details>

## Branch Freshness
- Base ref: `origin/agent-main`
- Head ref: `orbit/T20260430-24-69f2ff02`
- Behind base: 0
- Ahead of base: 1

## Files Changed
- `docs/design/user-interface/1_overview.md`
- `docs/design/user-interface/2_design.md`
- `docs/design/user-interface/3_vision.md`
- `docs/design/user-interface/4_decisions.md`

*authored by: gpt-5.5*