### PR TITLE
Shorten auditability design docs

### DIFF
--- a/docs/design/auditability/1_overview.md
+++ b/docs/design/auditability/1_overview.md
@@ -2,21 +2,21 @@
 
 **Status:** Draft
 **Owner:** codex
-**Last updated:** 2026-04-28 (T20260427-47)
+**Last updated:** 2026-04-30 (T20260430-20)
 
-Auditability is Orbit's answer to the operator question that matters after an agent touches a real repository: what happened, why did it happen, and who is accountable? It is not one log file. It is a set of structured audit channels that cover CLI commands, Orbit tool mutations, activity/job runs, provider turns, tool calls, filesystem denials, task attribution, and metrics side effects. [2_design.md](./2_design.md) describes the current implementation; [3_vision.md](./3_vision.md) captures the gaps between the current audit channels and Orbit's longer-term audit promise.
+Auditability is Orbit's answer to the operator question that matters after an agent touches a real repository: what happened, why, and who is accountable? The contract spans command rows, Orbit tool mutations, activity/job runs, provider turns, tool calls, filesystem denials, task attribution, metrics, and redacted payload storage. [2_design.md](./2_design.md) describes the shipped implementation; [3_vision.md](./3_vision.md) names the remaining gaps.
 
 ---
 
 ## 1. Motivation
 
-Orbit runs fleets of agents against user-owned repositories. That makes auditability a product feature rather than an observability afterthought:
+Orbit runs fleets of agents against user-owned repositories, so auditability is a product feature rather than an observability afterthought:
 
-1. **Users need replayable accountability.** README and positioning docs promise that every meaningful action has enough context to answer what, why, and who. The dedicated design folder added in [T20260426-0605] makes that promise easier to review as implementation grows.
-2. **Audit data has multiple levels of detail.** A CLI command audit row answers "which command ran?" A v2 activity/job envelope answers "which workflow step ran?" A loop audit event and blob reference answer "which provider payload or tool call happened?" Those layers must stay related without being collapsed into one oversized record.
-3. **Agent identity has to survive every boundary.** Task author fields, command audit roles, v2 `agent_identity`, invocation metrics, and commit/task metadata all need to point back to a concrete actor or model.
-4. **Secret handling is part of the audit contract.** Orbit aims to preserve faithful payloads, but audit storage must redact provider keys and sensitive environment-derived values before writing durable artifacts.
-5. **Coverage gaps must be explicit.** Silent paths are bugs. Where the implementation is still incomplete, those gaps belong in a coverage matrix rather than tribal memory.
+1. **Replayable accountability.** README and positioning docs promise enough context for every meaningful action to answer what, why, and who. The dedicated design folder from [T20260426-0605] keeps that promise reviewable.
+2. **Layered evidence.** A command row says which command ran. A v2 envelope says which workflow step ran. Loop events and blobs preserve provider/tool detail. The layers must remain related without becoming one oversized record.
+3. **Durable identity.** Task author fields, command audit roles, v2 `agent_identity`, invocation metrics, and commit/task metadata all need to point back to a concrete actor or model.
+4. **Write-side secrecy.** Orbit preserves useful payloads while redacting provider keys and sensitive environment-derived values before durable storage.
+5. **Explicit gaps.** Silent mutation paths are bugs. Missing coverage belongs in the coverage matrix, not in tribal memory.
 
 ---
 
@@ -24,41 +24,27 @@ Orbit runs fleets of agents against user-owned repositories. That makes auditabi
 
 ### 2.1 Command audit records are queryable SQLite rows
 
-The CLI audit middleware writes persistent `AuditEvent` records for most top-level commands. These rows live in the configured audit database and back `orbit audit list`, `orbit audit show`, `orbit audit stats`, and export commands.
-
-Command audit rows are compact and queryable. They carry command metadata, target metadata, status, timing, working directory, host, process id, and optional argument/error fields. They do not carry full provider transcripts.
+The CLI audit middleware and runtime tool-dispatch paths write persistent `AuditEvent` records for most top-level commands and tool calls. These compact rows back `orbit audit list`, `orbit audit show`, `orbit audit stats`, and export commands. They carry command/target metadata, actor role, status, timing, working directory, host, process id, and optional argument/error fields, but not full provider transcripts.
 
 ### 2.2 Activity/job run traces are file-backed JSONL trees
 
-The v2 activity/job runtime emits `V2AuditEvent` envelopes for run, step, activity, fan-out, loop, filesystem, denial, and CLI-backend lifecycle events. The current file-backed sink writes these envelopes under `.orbit/state/audit/v2_loop/`.
-
-This layer is the structural spine for workflow replay. It knows `run_id`, `event_id`, `parent_event_id`, `agent_identity`, and optional `workspace_path`.
-
-`orbit run events <run_id>` and `orbit run trace <run_id>` expose this layer as chronological and tree-shaped operator views after [T20260426-0705]. `orbit run show -s <id>` and `orbit run logs -s <id>` use the same activity DAG `step.id` source of truth after [T20260426-0709].
+The v2 activity/job runtime emits `V2AuditEvent` envelopes for run, step, activity, fan-out, loop, filesystem, denial, and CLI-backend lifecycle events under `.orbit/state/audit/v2_loop/`. This layer is the workflow replay spine: it carries `run_id`, `event_id`, `parent_event_id`, `agent_identity`, and optional `workspace_path`. `orbit run events`, `orbit run trace`, `orbit run show -s`, and `orbit run logs -s` expose the same activity DAG `step.id` source of truth after [T20260426-0705] and [T20260426-0709].
 
 ### 2.3 Agent-loop audit events preserve provider and tool detail
 
-The HTTP loop engine emits structured `LoopAuditEvent` records for sessions, HTTP requests/responses, tool requests/results, iteration boundaries, and policy denials. Large payload bodies are stored as redacted content-addressed blobs and referenced by sha256.
-
-Loop-level JSONL lives beside the v2 envelope tree under `.orbit/state/audit/loop/`, with blobs under `.orbit/state/audit/blobs/`.
+The HTTP loop engine emits `LoopAuditEvent` records for sessions, HTTP requests/responses, tool requests/results, iteration boundaries, and policy denials. Loop JSONL lives under `.orbit/state/audit/loop/`; large request, response, input, and output bodies are stored as redacted content-addressed blobs under `.orbit/state/audit/blobs/`.
 
 ### 2.4 Invocation metrics are adjacent, not a replacement
 
-The invocation store records token usage, tool-call counts, task IDs, agent, model, job run, and activity IDs for metrics and scoreboards. It is audit-adjacent because it helps answer cost and usage questions, but it is not the canonical transcript.
-
-This distinction became explicit when v2 job metrics started persisting invocation traces beside audit in [T20260426-0526].
+The invocation store records token usage, tool-call counts, task IDs, agent, model, job run, and activity IDs for metrics and scoreboards. It helps answer cost and usage questions, but it summarizes rather than preserves transcript structure. V2 job metrics began persisting beside audit in [T20260426-0526].
 
 ### 2.5 Redaction happens before durable payload storage
 
-Blob writes apply pattern-based redaction at write time. CLI error audit paths scrub sensitive live environment values before persistence. Redaction is therefore a write-side guarantee; readers should not need to re-scrub normal audit artifacts.
-
-The redaction and retention contract is specified in [specs/redaction-retention.md](./specs/redaction-retention.md).
+Blob writes apply pattern-based redaction at write time, and CLI error audit paths scrub sensitive live environment values before persistence. Readers should not need to re-scrub normal audit artifacts. The detailed contract lives in [specs/redaction-retention.md](./specs/redaction-retention.md).
 
 ### 2.6 Process tracing has a global JSONL feed
 
-The default tracing subscriber appends structured events to `~/.orbit/state/logs/orbit.jsonl` after [T20260426-2343]. After [T20260426-2349], the subscriber redacts string field values, `Debug`-formatted field values, and unstructured messages before writing stderr or JSONL output. This feed is global because subscriber initialization runs before Orbit knows the workspace root, and it is the live, tail-able counterpart to workspace-local run traces.
-
-After [T20260427-0023], high-signal non-subprocess producers also project into that feed: filesystem policy denials, proc-spawn allowlist denials, and friction task submissions emit stable `tracing::warn!` events alongside their canonical stores.
+The default tracing subscriber appends redacted structured events to `~/.orbit/state/logs/orbit.jsonl` after [T20260426-2343] and [T20260426-2349]. The feed is global because logging initializes before workspace resolution. After [T20260427-0023], filesystem policy denials, proc-spawn allowlist denials, and friction task submissions also project stable `tracing::warn!` events beside their canonical stores.
 
 ---
 
@@ -67,18 +53,12 @@ After [T20260427-0023], high-signal non-subprocess producers also project into t
 | Concern | Where it lives | Primary task ID |
 |---------|----------------|-----------------|
 | Audit design ownership | `docs/design/auditability/` | [T20260426-0605] |
-| Command audit record type | `crates/orbit-common/src/types/audit_event.rs` | [T20260426-0605] |
-| Command audit middleware | `crates/orbit-cli/src/audit_middleware.rs`, `crates/orbit-cli/src/main.rs` | [T20260426-0605] |
-| SQLite audit event store | `crates/orbit-store/src/sqlite/audit_event_store.rs`, `crates/orbit-store/migrations/0001_init.sql` | [T20260426-0605] |
-| Audit query/export CLI | `crates/orbit-cli/src/command/audit.rs`, `crates/orbit-core/src/command/audit_event.rs` | [T20260426-0605] |
-| V2 activity/job envelope | `crates/orbit-common/src/types/activity_job/audit_envelope.rs` | [T20260419-0002] |
-| V2 JSONL writer and sink | `crates/orbit-engine/src/activity_job/audit_writer.rs`, `crates/orbit-engine/src/activity_job/jsonl_sink.rs` | [T20260419-0002], [T20260426-0519] |
-| Workspace-local run trace location | `.orbit/state/audit/` | [T20260426-0519] |
+| Command audit records and queries | `crates/orbit-common/src/types/audit_event.rs`, `crates/orbit-cli/src/command/audit.rs`, `crates/orbit-store/src/sqlite/audit_event_store.rs` | [T20260426-0605] |
+| V2 activity/job envelopes and JSONL sink | `crates/orbit-common/src/types/activity_job/audit_envelope.rs`, `crates/orbit-engine/src/activity_job/audit_writer.rs` | [T20260419-0002], [T20260426-0519] |
 | Run trace inspection CLI | `crates/orbit-cli/src/command/run.rs`, `crates/orbit-core/src/runtime/run_audit.rs` | [T20260426-0705], [T20260426-0709] |
-| Loop audit events and blob storage | `crates/orbit-agent/src/loop_engine/audit/mod.rs`, `crates/orbit-common/src/utility/blob_store.rs` | [T20260426-0605] |
-| Redaction utilities | `crates/orbit-common/src/utility/redaction.rs` | [T20260426-0605] |
-| Global tracing JSONL feed | `crates/orbit-common/src/utility/logging.rs`, `~/.orbit/state/logs/orbit.jsonl` | [T20260426-2343], [T20260426-2349], [T20260427-0023] |
-| Live tracing producers | `crates/orbit-tools/src/builtin/fs/mod.rs`, `crates/orbit-tools/src/builtin/proc/spawn.rs`, `crates/orbit-core/src/command/task/add.rs` | [T20260427-0023] |
+| Loop audit events and blobs | `crates/orbit-agent/src/loop_engine/audit/mod.rs`, `crates/orbit-common/src/utility/blob_store.rs` | [T20260426-0605] |
+| Redaction utilities | `crates/orbit-common/src/utility/redaction.rs` | [T20260426-0605], [T20260426-2349] |
+| Global tracing JSONL feed and live projections | `crates/orbit-common/src/utility/logging.rs`, selected FS/proc/task producers | [T20260426-2343], [T20260427-0023] |
 | V2 invocation metrics persistence | `crates/orbit-store/src/sqlite/invocation_store.rs`, `crates/orbit-core/src/runtime/v2_host.rs` | [T20260426-0526] |
 | Task attribution fields | `crates/orbit-common/src/types/task.rs`, task update/runtime host paths | [T20260426-0605], [T20260427-47] |
 
@@ -96,5 +76,6 @@ After [T20260427-0023], high-signal non-subprocess producers also project into t
 - **[T20260426-2349]** — Apply tracing-layer redaction before stderr and global JSONL output.
 - **[T20260427-0023]** — Project policy denials and friction task submissions into the global tracing feed.
 - **[T20260427-47]** — Allow explicit task attribution correction for `planned_by` and `implemented_by` through task update paths.
+- **[T20260430-20]** — Shorten the auditability docs while preserving required guarantees.
 
 > Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.

--- a/docs/design/auditability/2_design.md
+++ b/docs/design/auditability/2_design.md
@@ -2,207 +2,126 @@
 
 **Status:** Draft
 **Owner:** codex
-**Last updated:** 2026-04-30 (T20260430-4)
+**Last updated:** 2026-04-30 (T20260430-20)
 
-This document describes Orbit's shipped auditability implementation across command audit rows, activity/job envelopes, loop-level provider/tool traces, blob storage, redaction, identity attribution, metrics-adjacent invocation records, and the current limitations that still need design attention. See [1_overview.md](./1_overview.md) for the feature's purpose and [3_vision.md](./3_vision.md) for forward-looking questions.
+This document describes Orbit's shipped auditability implementation across command audit rows, activity/job envelopes, loop-level provider/tool traces, blob storage, redaction, identity attribution, metrics-adjacent invocation records, and known limitations. See [1_overview.md](./1_overview.md) for the feature purpose and [3_vision.md](./3_vision.md) for future questions.
 
 ---
 
 ## 1. Storage Roots and Audit Channels
 
-Auditability is currently split across five channels:
+Auditability is split across five channels:
 
-1. **Command audit records.** SQLite rows in the configured audit database. These back the public `orbit audit` query/export surface.
-2. **V2 activity/job envelope events.** JSONL files under `.orbit/state/audit/v2_loop/{run_id}.jsonl`.
-3. **Loop-level provider/tool events.** JSONL files under `.orbit/state/audit/loop/{run_id}.jsonl`.
-4. **Global tracing events.** JSONL lines under `~/.orbit/state/logs/orbit.jsonl`.
+1. **Command audit records.** SQLite rows in the configured audit database; queried through `orbit audit`.
+2. **V2 activity/job envelope events.** JSONL under `.orbit/state/audit/v2_loop/{run_id}.jsonl`.
+3. **Loop-level provider/tool events.** JSONL under `.orbit/state/audit/loop/{run_id}.jsonl`.
+4. **Global tracing events.** Redacted JSONL under `~/.orbit/state/logs/orbit.jsonl`.
 5. **Invocation metrics.** SQLite records keyed by job run, activity, task, agent, model, usage, and tool-call summaries.
 
-The split is intentional. Command audit rows are compact and queryable across invocations. Activity/job envelopes preserve workflow structure. Loop audit preserves provider and tool-call detail. The global tracing feed gives operators a live, tail-able stream before workspace runtime context exists. Invocation metrics support cost and scoreboard questions without scraping audit JSONL.
-
-The run-trace storage-placement decision is [T20260426-0519]: file-backed run traces moved under `.orbit/state/audit/`, while command audit rows remain in the configured SQLite database. README now describes that split as "command audit events remain globally scoped in SQLite; file-backed activity/job run traces are workspace-local under `.orbit/state/audit`."
+The split is deliberate: command rows stay compact and queryable; envelopes preserve workflow structure; loop audit preserves provider/tool detail; tracing gives operators a live feed before workspace context exists; metrics answer cost and scoreboard questions without scraping transcripts. [T20260426-0519] moved file-backed run traces under `.orbit/state/audit/` while command audit rows remained in SQLite.
 
 ---
 
 ## 2. Command Audit Rows
 
-The command audit schema is `AuditEvent` in `crates/orbit-common/src/types/audit_event.rs`. A row includes:
+`AuditEvent` lives in `crates/orbit-common/src/types/audit_event.rs`. Rows include execution id, timestamp, command/subcommand, optional tool and target metadata, role, status, exit code, duration, working directory, optional argument/error/stdout/stderr fields, host, pid, and session id. The table and indexes live in `crates/orbit-store/migrations/0001_init.sql`; `crates/orbit-store/src/sqlite/audit_event_store.rs` lists, shows, prunes, exports, computes stats, and returns durations for p95 calculation.
 
-- `execution_id`
-- timestamp
-- command and subcommand
-- optional tool, target type, and target id
-- role
-- status: `success`, `failure`, or `denied`
-- exit code and duration
-- working directory
-- optional argument JSON, truncated stdout/stderr, error message, host, pid, and session id
+The CLI RAII guard in `crates/orbit-cli/src/audit_middleware.rs` defaults to failure, marks success or denial explicitly, and writes one row in `Drop`, so early returns still audit when stack unwinding reaches the guard. Direct `orbit audit ...` commands are outside the guard today to avoid recursive audit noise.
 
-The table and indexes live in `crates/orbit-store/migrations/0001_init.sql`, and the store implementation is `crates/orbit-store/src/sqlite/audit_event_store.rs`. The store can list, show, prune, compute stats, and return durations for p95 calculation.
+For `orbit tool run`, [T20260427-52] made provenance model-first. Orbit resolves identity from input JSON or input file, then explicit `--agent` / `--model`, then `ORBIT_AGENT_NAME` / `ORBIT_AGENT_MODEL`. An exact model becomes the row role and can infer an agent family for task provenance; legacy `agent` inputs remain accepted only when consistent. Missing identity falls back to `agent` for tool dispatch, while direct non-tool CLI commands use `admin`.
 
-The CLI path is an RAII guard in `crates/orbit-cli/src/audit_middleware.rs`. `AuditGuard` defaults to failure, marks success or denial explicitly, and writes one row in `Drop`. This means early returns still write an audit record as long as stack unwinding reaches the guard.
-
-For `orbit tool run`, command-audit role attribution is model-first after [T20260427-52]. Orbit resolves one identity source at a time: `--input` or `--input-file` fields first, then explicit `--agent` / `--model` flags, then `ORBIT_AGENT_NAME` / `ORBIT_AGENT_MODEL`. When a source provides `model`, Orbit uses that exact model as the role label and infers the agent family from known model names for downstream task provenance. The legacy `agent` field and `--agent` flag remain accepted for compatibility, but if an explicit agent contradicts an inferable model family, the tool execution rejects the input instead of recording inconsistent provenance. If no identity source is present, the row uses `agent` as the fallback role because the tool-dispatch command surface is agent-facing by default. Direct non-tool CLI commands continue to use `admin`.
-
-`crates/orbit-cli/src/main.rs` wraps non-audit commands in that guard after runtime initialization. Direct `orbit audit ...` commands are deliberately outside the guard today, so querying the audit log does not itself emit another command audit row.
-
-After [T20260428-4], **tool-invocation audit ownership moved into the runtime layer** ([ADR-016](./4_decisions.md#adr-016--tool-invocation-audit-is-owned-by-the-runtime-with-mcp-preflight-bracketing)). `OrbitRuntime::execute_tool_command_dispatch` now writes the audit row for every tool dispatch — CLI tool-run, MCP `tools/call`, and any future entry point — with identical identity-resolution rules and policy chain. The dispatch carries a `ToolEntryPoint` discriminator (`Cli` | `Mcp`) that surfaces in the audit `subcommand` field as `"run"` (CLI) or `"run-mcp"` (MCP), so the same SQLite table can attribute calls back to their origin without a schema migration. Setup failures inside dispatch (e.g. an inconsistent `agent`/`model` rejected by `normalize_agent_family_for_model`) are wrapped into the same audit-write block so they too produce a failure-status row. `duration_ms` is clamped to `>= 1` at the audit-write site.
-
-To prevent the legacy CLI `AuditGuard` from double-emitting on the `orbit tool run` path, the runtime sets a per-thread `mark_tool_audit_recorded` signal after writing, and the guard's `Drop` calls `take_tool_audit_recorded()` and skips its own emission when the flag is set. Paths that bail before the runtime is reached — invalid JSON, missing input, `--dry-run` short-circuit — leave the flag clear and continue to produce their existing guard-side audit row, so the per-invocation row count remains exactly one in every case.
+After [T20260428-4], tool-invocation audit is written in `OrbitRuntime::execute_tool_command_dispatch` for CLI, MCP, and future entry points. A `ToolEntryPoint` discriminator surfaces as `subcommand: "run"` or `"run-mcp"`, setup failures inside dispatch are audited, and `duration_ms` is clamped to at least `1`. The legacy CLI guard skips its own emission when the runtime sets a per-thread `mark_tool_audit_recorded` signal; pre-runtime CLI failures such as invalid JSON still produce the existing guard-side row.
 
 ---
 
 ## 3. Tool-Driven and Runtime Audit Records
 
-Command audit records do not only come from the top-level CLI guard. Some runtime paths write targeted rows directly:
+Some runtime paths write targeted command-audit rows directly:
 
-- `crates/orbit-core/src/command/tool.rs` (`execute_tool_command_dispatch`) records every tool invocation — CLI and MCP — as `command: tool` with `subcommand` set to `"run"` for CLI dispatch and `"run-mcp"` for MCP dispatch ([ADR-016](./4_decisions.md#adr-016--tool-invocation-audit-is-owned-by-the-runtime-with-mcp-preflight-bracketing)).
-- `crates/orbit-cli/src/command/mcp/mod.rs` (`audited_mcp_call`) brackets the MCP `tools/call` preflight and dispatch so a rejected unknown / unexposed tool name (`ensure_mcp_tool_exposed` returning `Err`) produces a failure-status row tagged with `subcommand: "run-mcp"` even though the runtime is never reached.
-- `crates/orbit-core/src/runtime/orbit_tool_host/mod.rs` records task lock reservation checks, reservations, releases, and denials with `target_type: task_reservation`.
-- `crates/orbit-core/src/runtime/v2_host.rs` records gate-starvation failures for task bundles with `command: gate.starvation`.
+- `crates/orbit-core/src/command/tool.rs` records CLI and MCP tool invocations as `command: tool` with `subcommand: "run"` or `"run-mcp"`.
+- `crates/orbit-cli/src/command/mcp/mod.rs` records MCP preflight failures for unknown or unexposed tools before runtime dispatch.
+- `crates/orbit-core/src/runtime/orbit_tool_host/mod.rs` records task lock reservation checks, reservations, releases, and denials.
+- `crates/orbit-core/src/runtime/v2_host.rs` records gate-starvation failures for task bundles.
 
-These records use the same SQLite schema so `orbit audit list` and export commands can see them. The current design implication is important: audit producers are allowed below the CLI layer, but they must still use `AuditEventInsertParams` and preserve the same status, target, actor, and redaction expectations.
+These producers share the SQLite schema and must preserve the same status, target, actor, and redaction expectations as CLI rows. Prescriptive coverage expectations live in [specs/coverage-matrix.md](./specs/coverage-matrix.md).
 
-The prescriptive coverage expectations live in [specs/coverage-matrix.md](./specs/coverage-matrix.md).
-
-After [T20260427-0023], selected high-signal runtime paths also emit live tracing projections without changing their canonical stores. Filesystem policy denials still write `FsCallEventKind::Denied` audit events, proc-spawn allowlist denials still return `OrbitError::PolicyDenied`, and friction task creation still increments the friction bounty scoreboard. The added tracing targets are `orbit.policy.deny` for FS/proc denials and `orbit.friction.reported` for friction submissions.
+After [T20260427-0023], selected canonical stores also project live tracing events: filesystem policy denials still write FS audit events, proc-spawn allowlist denials still return `OrbitError::PolicyDenied`, friction task creation still updates the scoreboard, and each path also emits a redacted `orbit.policy.deny` or `orbit.friction.reported` event.
 
 ---
 
 ## 4. Activity/Job Envelope Events
 
-The v2 activity/job audit envelope type lives in `crates/orbit-common/src/types/activity_job/audit_envelope.rs`. The envelope fields are:
+`V2AuditEnvelope` lives in `crates/orbit-common/src/types/activity_job/audit_envelope.rs`. Each envelope carries `schemaVersion`, `event_type`, `event_id`, timestamp, `run_id`, `agent_identity`, optional `parent_event_id`, optional `workspace_path`, and a tagged `V2AuditEventKind`. Event families cover run, step, retry, skip, denial, join, fan-out/fan-in, loop, activity, filesystem, tool denial, CLI-backend delegation, and subprocess lifecycle.
 
-- `schemaVersion`
-- `event_type`
-- `event_id`
-- timestamp
-- `run_id`
-- `agent_identity`
-- optional `parent_event_id`
-- optional `workspace_path`
+`V2AuditWriter` in `crates/orbit-engine/src/activity_job/audit_writer.rs` assigns event ids, maintains per-thread parent stacks, emits through `V2JsonlSink`, keeps a smoke-verification snapshot, and exposes the inner loop sink for provider/tool events. CLI-launched v2 runs stamp envelope `agent_identity` as `system`; concrete agent identity lives in activity configuration, CLI invocation events, and invocation metrics.
 
-The body is a tagged `V2AuditEventKind`. Current event families include:
-
-- run lifecycle
-- step lifecycle, retry, skip, denial, and join outcomes
-- fan-out/fan-in worker state
-- loop iteration lifecycle and non-convergence
-- activity lifecycle
-- filesystem request/result/denial
-- tool denial
-- CLI-backend allowlist delegation and subprocess lifecycle
-
-`crates/orbit-engine/src/activity_job/audit_writer.rs` owns `V2AuditWriter`. It assigns event ids, stores parent stacks per thread, emits JSONL through `V2JsonlSink`, keeps an in-memory snapshot for smoke verification, and exposes the inner loop sink so provider/tool events can live beneath the envelope tree. CLI-launched v2 activity/job runs stamp envelope `agent_identity` as `system` because these records describe Orbit's workflow orchestration; concrete agent/provider identity is carried by activity configuration, CLI invocation events, and invocation metrics.
-
-`crates/orbit-engine/src/activity_job/jsonl_sink.rs` writes one JSON object per line under `v2_loop/`, append-only for the life of a run and flushed per write.
-
-`crates/orbit-core/src/runtime/run_audit.rs` owns the read-side accessor for this file-backed layer after [T20260426-0709]. It collects v2 envelope events, derives activity DAG `step.id` values from `parent_event_id` ancestry, and resolves CLI stdout/stderr blob references for `orbit run logs` without exposing audit storage paths to the CLI renderer.
+`crates/orbit-engine/src/activity_job/jsonl_sink.rs` appends one JSON object per line under `v2_loop/` and flushes per write. `crates/orbit-core/src/runtime/run_audit.rs` is the read-side accessor after [T20260426-0709], deriving activity DAG `step.id` values from `parent_event_id` ancestry and resolving CLI stdout/stderr blob references for `orbit run logs`.
 
 ---
 
 ## 5. Loop-Level Provider and Tool Events
 
-The lower-level loop audit type is `LoopAuditEvent` in `crates/orbit-agent/src/loop_engine/audit/mod.rs`. Its events cover:
+`LoopAuditEvent` in `crates/orbit-agent/src/loop_engine/audit/mod.rs` covers session spawn/close, HTTP request/response, tool-call request/result, iteration boundary, and policy denial. `JsonlFileSink` writes loop events to `{audit_root}/loop/{run_id}.jsonl` and payload blobs to `{audit_root}/blobs/`; runtime callers pass `.orbit/state/audit` as `audit_root`.
 
-- session spawn and close
-- HTTP request and response
-- tool-call request and result
-- iteration boundary
-- policy denial
-
-`JsonlFileSink` writes loop events to `{audit_root}/loop/{run_id}.jsonl`. The same sink writes payload blobs to `{audit_root}/blobs/` and references them by sha256. Orbit runtime callers pass `.orbit/state/audit` as `audit_root`, so loop traces share the same workspace-local audit root as v2 envelopes.
-
-The loop engine emits hashes for request bodies, response bodies, tool inputs, and tool outputs rather than embedding those bodies in the event row. This keeps event lines queryable while still preserving replay material in blob storage.
+Loop events reference hashes for request bodies, response bodies, tool inputs, and tool outputs instead of embedding the bodies inline. This keeps event lines queryable while preserving replay material in redacted blob storage.
 
 ---
 
 ## 6. Blob Storage and Redaction
 
-`crates/orbit-common/src/utility/blob_store.rs` writes content-addressed blobs under `{root}/{hash_prefix}/{hash}`. The hash is computed after redaction, and an existing blob path is reused without rewriting.
+`crates/orbit-common/src/utility/blob_store.rs` writes content-addressed blobs under `{root}/{hash_prefix}/{hash}`. The hash is computed after redaction, and existing blob paths are reused.
 
-`crates/orbit-common/src/utility/redaction.rs` centralizes two redaction mechanisms:
-
-- sensitive live environment values, selected by environment variable name patterns such as `SECRET`, `TOKEN`, `PASSWORD`, `API_KEY`, `AUTH`, and related names
-- regex-based HTTP and argv patterns for authorization headers, x-api-key fields, bearer tokens, JSON API keys, and bare `sk-...` tokens when argv scrubbing is requested
-
-The CLI audit guard redacts error messages before writing them. The blob store redacts bytes before writing them. The pipeline runtime also redacts JSON outputs and errors before persisting selected pipeline data. After [T20260426-2349], the default tracing subscriber also redacts string field values, `Debug`-formatted field values, and unstructured `message` fields before writing stderr or global JSONL tracing output.
-
-The smoke example `crates/orbit-agent/examples/redaction_smoke.rs` verifies that stored blob bytes omit the raw secret and contain a redaction marker.
+`crates/orbit-common/src/utility/redaction.rs` centralizes sensitive live environment value scrubbing plus regex-based HTTP/argv patterns for authorization headers, API keys, bearer tokens, JSON API-key fields, and bare `sk-...` tokens when argv scrubbing is requested. CLI audit errors, blob bytes, selected pipeline outputs/errors, and the default tracing subscriber all redact before persistence or terminal/JSONL output. The smoke example `crates/orbit-agent/examples/redaction_smoke.rs` verifies stored blob bytes omit the raw secret and contain a marker.
 
 ---
 
 ## 7. Identity and Attribution
 
-Orbit currently carries identity through several related fields:
+Orbit currently carries identity through related fields rather than one universal key:
 
-- CLI runtime actor identity defaults direct CLI commands to `human`.
-- `orbit tool run` paths prefer exact `model` inputs for provenance; known model names infer the task `agent` family, while legacy explicit `agent` inputs are compatibility hints that must agree with the model.
-- `V2AuditEnvelope.agent_identity` records the workflow-envelope actor. CLI-launched v2 runs use `system`; concrete agent activity is recorded in provider-specific event bodies and invocation metrics.
-- Task records carry `created_by`, `planned_by`, `implemented_by`, `agent`, and `model` fields.
+- Direct CLI commands default to a human/admin-facing role; agent-facing tool rows prefer exact `model` labels and infer compatible agent families.
+- `V2AuditEnvelope.agent_identity` records the workflow-envelope actor. CLI-launched v2 runs use `system`; concrete provider activity appears in event bodies and metrics.
+- Task records carry `created_by`, `planned_by`, `implemented_by`, `agent`, and `model`.
 - Invocation metrics record agent and model beside job run and activity ids.
 
-Task attribution remains automatic by default. Non-empty plan writes stamp `planned_by` from the effective actor label, and transitions into `review` or `done` stamp `implemented_by` from the task/model identity path. After [T20260427-47], `orbit.task.update` and the direct `orbit task update` CLI also accept explicit `planned_by` and `implemented_by` values for corrective provenance edits; explicit values win over automatic stamping for the same update, and empty strings clear the fields.
+Task attribution remains automatic by default: non-empty plan writes stamp `planned_by`, and transitions into `review` or `done` stamp `implemented_by`. After [T20260427-47], `orbit.task.update` and direct `orbit task update` can explicitly set or clear those fields; explicit values win within the same update.
 
-The core design requirement is not that all of these fields collapse into one value. It is that a reviewer can follow the chain from task state, command rows, v2 run envelope, provider/tool trace, and metrics record back to a concrete human or model identity.
-
-This area is still uneven. Direct command rows still store role strings such as `admin`; agent-facing tool rows store resolved actor labels; some task paths normalize model names into attribution labels. The design intent is clear, but a unified identity glossary and query join story remain open.
+The requirement is not to collapse every field into one value. It is that a reviewer can follow task state, command rows, run envelopes, provider/tool traces, and metrics back to a concrete human or model. A unified identity glossary and query join story remain open.
 
 ---
 
 ## 8. Query, Export, and Metrics Surfaces
 
-`crates/orbit-cli/src/command/audit.rs` exposes command audit rows through:
+`crates/orbit-cli/src/command/audit.rs` exposes command rows through `orbit audit list`, `show`, `stats`, `export --format json`, `export --format csv`, and `prune`, with filters for time, tool, status, role, and limit. Exports include all command-audit columns, including sparse `stdout_truncated`, `stderr_truncated`, and `session_id`.
 
-- `orbit audit list`
-- `orbit audit show <id>`
-- `orbit audit stats`
-- `orbit audit export --format json`
-- `orbit audit export --format csv`
-- `orbit audit prune`
+V2 traces are exposed separately: `orbit run events` prints chronological envelopes, `orbit run trace` renders the parent tree, and `orbit run logs` extracts CLI stdout/stderr blobs. `orbit run history` and `orbit run show` expose job-run state rather than the full envelope stream. Metrics and scoreboard commands read invocation records; they summarize cost and usage, not transcript structure.
 
-The command audit query surface supports filters for time, tool, status, role, and limit. Exports include all command-audit columns, including currently sparse fields such as `stdout_truncated`, `stderr_truncated`, and `session_id`.
+After [T20260428-11], compact `summary.json` counts all audited tool-run attempts and failed attempts from command-audit rows where `command: tool`, `subcommand` is `"run"` or `"run-mcp"`, and `tool_name` is present. Token totals still come from invocation/token scoreboards, with legacy tool-call totals used only as a max overlay to avoid obvious double counting.
 
-V2 JSONL traces are exposed through run-scoped inspection commands after [T20260426-0705]:
+After [T20260428-17] and [T20260430-4], local task review and GitHub PR review are separate scoreboard inputs. Local review-thread creations record `task-review-threads` in `task_review.json`; successful GitHub sync records `pr-review-comments` in `pr.json`. `summary.json` schema version 2 exposes these as `task_review.threads` and `pr.review_comments`, and scoring accepts only exact configured model identities or built-in defaults, skipping `human`, `system`, and arbitrary bare labels.
 
-- `orbit run events [run_id]` prints chronological envelope events and supports step and event-type filters.
-- `orbit run trace [run_id]` renders the `event_id` / `parent_event_id` tree.
-- `orbit run logs [run_id]` extracts CLI stdout/stderr blobs from CLI invocation envelope events.
-
-These are intentionally separate from `orbit audit`, which remains the compact SQLite command-audit query surface. `orbit run history` and `orbit run show` expose durable job-run state rather than the full envelope stream.
-
-Invocation metrics are surfaced through metrics and scoreboard commands. They are useful for cost and usage analysis, but they do not replace the audit trail because they summarize rather than preserve transcript structure.
-
-After [T20260428-11], `summary.json` uses command-audit rows as the source for all audited Orbit tool-run attempts and failed tool-run attempts. The query counts `command: tool` rows with `subcommand: "run"` or `"run-mcp"` and a concrete `tool_name`, grouped by normalized role/model. `tool_calls` remains the public all-call field; `failed_tool_calls` counts non-success tool-run rows (`failure` and `denied`). Token totals still come from the invocation/token scoreboard, and legacy token-scoreboard tool-call totals remain a fallback through a max overlay rather than an additive merge to avoid obvious double counting between model traces and command-audit rows.
-
-After [T20260428-17] and [T20260430-4], local Orbit task review feedback and GitHub PR review feedback are separate scoreboard inputs. Creating a local task review thread records one `task-review-threads` review-thread creation in `.orbit/state/scoreboard/task_review.json`; replies keep the discussion attached to the thread but do not add local review credit. Successful GitHub sync of pending review-thread entries records `pr-review-comments` in `.orbit/state/scoreboard/pr.json`. GitHub sync accepts legacy `agent / model` labels plus model-only labels that exactly match the configured orchestrator/helper model for an inferred agent family; it skips `human`, `system`, and arbitrary bare labels. `summary.json` schema version 2 exposes those counters as `task_review.threads` and `pr.review_comments` respectively so dashboards can show both without mixing local review activity with PR review activity.
-
-After [T20260427-43], the friction bounty scoreboard is refreshed from task history rather than trusted only as an increment log. `type: friction` tasks are counted as reported, `status: friction` exits to `backlog`, `in-progress`, or `done` count as accepted, and `status: friction` exits to `rejected` count as rejected. The task store migration that moves legacy untriaged friction reports from `proposed/` into `friction/` keeps the scoreboard derivation tied to lifecycle history instead of current status alone.
+After [T20260427-43], the friction bounty scoreboard is refreshed from task history: `type: friction` counts reports, exits from `status: friction` to `backlog`, `in-progress`, or `done` count acceptances, and exits to `rejected` count rejections.
 
 ---
 
 ## 9. Global Process Tracing JSONL
 
-`crates/orbit-common/src/utility/logging.rs` installs the default tracing subscriber. After [T20260426-2343], that subscriber is a `tracing_subscriber::Registry` with one shared `EnvFilter`, the existing stderr fmt layer, and an optional JSON Lines file layer.
+`crates/orbit-common/src/utility/logging.rs` installs a default subscriber with one `EnvFilter`, stderr formatting, and an optional non-blocking JSONL file layer at `~/.orbit/state/logs/orbit.jsonl` after [T20260426-2343]. The retained `WorkerGuard` lets routine event emission avoid synchronous disk writes.
 
-The file layer opens `~/.orbit/state/logs/orbit.jsonl` in append mode and writes through `tracing_appender::non_blocking`. The associated `WorkerGuard` is retained for the process lifetime inside `logging.rs`, so routine event emission does not synchronously block on disk writes.
-
-Each JSONL record contains timestamp, level, target, and a `fields` object containing the structured event fields. After [T20260426-2349], `logging.rs` routes JSONL events through the same `RedactingFields` formatter used by stderr, so string field values, `Debug`-formatted field values, and unstructured messages are scrubbed before serialization while typed numeric and boolean values keep their JSON types. The timestamp is assigned when the formatter writes the record, so a non-blocking writer under load may introduce a small lag from event emission. This is the durable landing zone for live `tracing` events such as the CLI subprocess stdout/stderr events added in [T20260426-2313], the `orbit.policy.deny` events added for FS/proc policy denials in [T20260427-0023], and the `orbit.friction.reported` events added for friction submissions in [T20260427-0023].
-
-This channel is global rather than workspace-local because `orbit-cli` initializes logging before clap parsing and before `OrbitRuntime` can resolve workspace roots. It is not a replacement for command audit rows or run traces: readers should treat it as an operational log stream, not the canonical workflow envelope.
+Each record contains timestamp, level, target, and structured fields. After [T20260426-2349], both stderr and JSONL use `RedactingFields`, which scrubs string values, `Debug`-formatted values, and unstructured messages while preserving numeric and boolean JSON types. This global feed is the live landing zone for subprocess output [T20260426-2313], policy-denial and friction projections [T20260427-0023], and other `tracing` events emitted before workspace runtime context exists. It is operational telemetry, not the canonical workflow envelope.
 
 ---
 
 ## 10. Concerns & Honest Limitations
 
-1. **Tamper evidence is promised more strongly than it is implemented.** README describes append-only and tamper-evident retention, but the current SQLite rows and JSONL files do not yet have a hash chain, signature, or external transparency log.
-2. **Audit is split across storage systems.** Command audit rows, v2 JSONL, loop JSONL, blobs, job-run state, and invocation metrics are related by ids but not yet joined by one operator command.
-3. **`orbit audit` does not audit itself.** That avoids recursive noise, but it also means audit-log reads, exports, and prunes are not themselves recorded through the normal command guard.
-4. **Some command-audit fields are placeholders.** `stdout_truncated`, `stderr_truncated`, and `session_id` exist in the schema but are often `None`.
-5. **CLI backend tool enforcement remains weaker than HTTP.** Activity/job audit records the CLI backend allowlist as harness-delegated. That preserves accountability but does not enforce Orbit-level tool denial semantics in the CLI provider path.
-6. **Redaction favors known secret shapes.** Environment-value and regex redaction cover common provider-key paths, but no redactor can prove arbitrary user secrets are absent from every payload.
-7. **The global tracing feed is intentionally v1-simple.** It has no rotation and no cross-process line lock; readers should tolerate rare malformed lines if concurrent processes interleave large writes. Redaction covers known string secret shapes, but span attributes and binary blobs are separate concerns.
-8. **Coverage is still expanding.** Some deterministic actions and direct runtime mutations write explicit audit rows; others rely on enclosing command/job context. The coverage matrix must become the review checklist for new mutation paths.
+1. **Tamper evidence is promised more strongly than implemented.** SQLite rows and JSONL files do not yet have hash chains, signatures, or external transparency logs.
+2. **Audit is split across stores.** Command rows, v2 JSONL, loop JSONL, blobs, job-run state, and invocation metrics share ids but lack one joined operator command.
+3. **`orbit audit` does not audit itself.** That avoids recursion but leaves audit reads, exports, and prunes outside the normal guard.
+4. **Some command-audit fields are sparse.** `stdout_truncated`, `stderr_truncated`, and `session_id` often remain `None`.
+5. **CLI backend tool enforcement is weaker than HTTP.** Activity/job audit records the CLI backend allowlist as harness-delegated rather than enforcing Orbit-level tool denial semantics inside the provider path.
+6. **Redaction covers known secret shapes.** Environment-value and regex redaction reduce risk but cannot prove arbitrary user secrets are absent from every payload.
+7. **The global tracing feed is v1-simple.** It has no rotation and no cross-process line lock; readers should tolerate rare malformed lines if concurrent processes interleave large writes.
+8. **Coverage is still expanding.** Some deterministic mutations write explicit audit rows; others rely on enclosing command/job context. The coverage matrix should become the review checklist for new mutation paths.
 
 ---
 
@@ -221,9 +140,10 @@ This channel is global rather than workspace-local because `orbit-cli` initializ
 - **[T20260427-0023]** — Project policy denials and friction task submissions into the global tracing feed.
 - **[T20260427-43]** — Add `status: friction`, creation-time type/status inference, migration, and history-derived friction bounty refresh.
 - **[T20260427-47]** — Allow explicit task attribution correction for `planned_by` and `implemented_by` through task update paths.
-- **[T20260428-4]** — Move tool-invocation audit ownership into the runtime, add the `ToolEntryPoint` discriminator (`run` / `run-mcp`), bracket MCP preflight + dispatch in `audited_mcp_call`, and add the per-thread CLI dedup signal so every tool invocation produces exactly one audit row from the right origin.
+- **[T20260428-4]** — Move tool-invocation audit ownership into the runtime, add the `ToolEntryPoint` discriminator, bracket MCP preflight + dispatch, and deduplicate CLI guard rows.
 - **[T20260428-11]** — Derive `summary.json` all/failed tool-call counts from command-audit tool-run rows while keeping invocation/token scoreboard data as the token source.
 - **[T20260428-17]** — Split local Orbit task-review scoring from PR review-comment scoring and surface both in compact scoreboards.
 - **[T20260430-4]** — Change local task-review scoring to count review-thread creations rather than replies, rename the compact field to `task_review.threads`, and keep legacy metric reads mapped forward.
+- **[T20260430-20]** — Shorten the auditability docs while preserving required guarantees.
 
 > Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.

--- a/docs/design/auditability/3_vision.md
+++ b/docs/design/auditability/3_vision.md
@@ -2,24 +2,24 @@
 
 **Status:** Draft
 **Owner:** codex
-**Last updated:** 2026-04-27
+**Last updated:** 2026-04-30 (T20260430-20)
 
-This document captures the questions that need to be answered before Orbit's auditability story matches its product promise end to end. It is intentionally forward-looking: [2_design.md](./2_design.md) is the current implementation, while this file names the pressure points that should drive future tasks and ADRs.
+This document captures the questions that remain before Orbit's auditability story matches its product promise end to end. [2_design.md](./2_design.md) is the current implementation; this file names the pressure points that should drive future tasks and ADRs.
 
 ---
 
 ## 1. Open Questions
 
-1. **What is the canonical audit query surface?** Should `orbit audit` remain command-row-only, or should it grow a run-centric view that joins command audit rows, job-run state, v2 envelope JSONL, loop JSONL, blobs, and invocation metrics?
-2. **How should tamper evidence work locally?** Options include per-file hash chains, SQLite append proofs, signed manifests, git-backed checkpoints, or export-time attestations. The answer must preserve Orbit's self-hosted/no-cloud constraint.
-3. **Should audit-log reads and prunes be audited?** `orbit audit` is currently outside the normal command guard. That avoids recursion but weakens accountability for audit export and prune operations.
-4. **What is the stable identity key?** Orbit needs a joinable identity story across human CLI usage, model-first tool inputs that infer an agent family, task attribution fields, v2 `agent_identity`, invocation metrics, commits, and PR metadata.
-5. **How complete should stdout/stderr capture be?** The command-audit schema has truncated stdout/stderr fields, but most paths do not populate them. Orbit needs a retention policy before filling them broadly.
-6. **How should file-backed JSONL migrate?** [T20260426-0519] moved run traces to `.orbit/state/audit/`; any future reader should decide whether old `.orbit/audit/` files are migrated, ignored, or read through a legacy fallback.
-7. **How much payload should be replayable?** Faithful reproducibility argues for storing prompts and responses. Secret minimization argues for smaller, redacted payloads. The long-term contract needs to say when summaries are enough and when verbatim redacted payloads are required.
-8. **Can policy denials become a uniform audit shape?** Filesystem denials, tool allowlist denials, task-lock conflicts, and gate starvation all exist, but they do not yet share one event schema.
-9. **What is the operator story for coverage gaps?** New mutation paths should fail review if they lack audit coverage, but the repo needs mechanical lint or tests before that expectation scales.
-10. **Should invocation metrics be derived or primary?** Today they are separate primary records for metrics. A future system could derive them from loop traces, but doing so would increase coupling and reduce resilience to provider-specific output gaps.
+1. **Canonical query surface.** Should `orbit audit` stay command-row-only, or grow a run-centric view that joins command rows, job-run state, v2 envelopes, loop JSONL, blobs, and invocation metrics?
+2. **Local tamper evidence.** Should Orbit use per-file hash chains, SQLite append proofs, signed manifests, git-backed checkpoints, or export-time attestations while staying self-hosted by default?
+3. **Auditing audit reads.** Should `orbit audit` reads, exports, and prunes remain outside the guard to avoid recursion, or be recorded through a separate path?
+4. **Stable identity key.** What joins human CLI usage, model-first tool inputs, task attribution fields, v2 `agent_identity`, invocation metrics, commits, and PR metadata?
+5. **Stdout/stderr retention.** The command schema has truncated stdout/stderr fields, but most paths leave them empty. What retention policy should exist before broad capture?
+6. **JSONL migration.** [T20260426-0519] moved run traces to `.orbit/state/audit/`; should old `.orbit/audit/` files be migrated, ignored, or read through a legacy fallback?
+7. **Replay payload depth.** When are redacted verbatim prompts/responses required, and when are summaries enough?
+8. **Uniform denials.** Can filesystem denials, tool allowlist denials, task-lock conflicts, and gate starvation share one audit shape?
+9. **Coverage enforcement.** What lint or tests should fail review when a new mutation path lacks audit coverage?
+10. **Metrics derivation.** Should invocation metrics stay primary records, or eventually derive from loop traces at the cost of tighter coupling?
 
 ---
 
@@ -27,35 +27,33 @@ This document captures the questions that need to be answered before Orbit's aud
 
 ### 2.1 Orbit-Internal
 
-The closest internal design work is Activity / Job's audit-envelope section and ADRs in [../activity-job/2_design.md](../activity-job/2_design.md) and [../activity-job/4_decisions.md](../activity-job/4_decisions.md). That feature documents the v2 envelope, backend differences, CLI allowlist delegation, file-backed audit placement, and invocation trace persistence.
+Activity / Job's audit-envelope section and ADRs in [../activity-job/2_design.md](../activity-job/2_design.md) and [../activity-job/4_decisions.md](../activity-job/4_decisions.md) document the v2 envelope, backend differences, CLI allowlist delegation, file-backed audit placement, and invocation trace persistence.
 
-The product contract lives in [../../../README.md](../../../README.md) and [../../POSITIONING.md](../../POSITIONING.md): auditability should answer what, why, and who; audit rows should be structured and queryable; provider interactions should be faithfully reproducible after redaction; retention should become tamper-evident; and identity should attach to every write.
+The product contract lives in [../../../README.md](../../../README.md) and [../../POSITIONING.md](../../POSITIONING.md): auditability should answer what, why, and who; audit rows should be structured and queryable; provider interactions should be reproducible after redaction; retention should become tamper-evident; and identity should attach to every write.
 
-The redaction and blob-store implementation gives Orbit an existing write-side safety boundary. That boundary should be preserved even if future query tools read blobs more directly.
+The redaction and blob-store implementation is the existing write-side safety boundary. Future query tools should preserve it even if they read blobs more directly.
 
 ### 2.2 Workflow and Observability Systems
 
-Durable workflow engines such as Temporal and Airflow show the value of explicit run, step, retry, and state-transition history. Orbit's distinction is that provider turns, code tools, filesystem policy, and git/worktree state are first-class audit subjects rather than opaque task logs.
-
-OpenTelemetry and structured logging systems show the value of trace/span identifiers and exportable schemas. Orbit can borrow the join model without turning audit into generic telemetry; audit events carry accountability and replay obligations that metrics do not.
+Temporal and Airflow show the value of explicit run, step, retry, and state-transition history. OpenTelemetry shows the value of trace/span identifiers and exportable schemas. Orbit should borrow the join model while keeping accountability and replay obligations distinct from generic telemetry.
 
 ### 2.3 Supply-Chain Attestation
 
-SLSA, in-toto, Sigstore, and Rekor point toward signed or transparency-backed provenance. Orbit should learn from those systems, especially for tamper evidence, but it must keep local/self-hosted operation as the default.
+SLSA, in-toto, Sigstore, and Rekor point toward signed or transparency-backed provenance. Orbit can learn from those systems, but local/self-hosted operation must remain the default.
 
 ### 2.4 Security Event Logging
 
-Security audit systems treat reads, writes, privilege decisions, and retention as part of one accountability surface. Orbit has a narrower domain, but the principle applies: a policy denial, a task update, a provider request, and a PR operation should all be explainable from the audit trail.
+Security audit systems treat reads, writes, privilege decisions, and retention as one accountability surface. Orbit's domain is narrower, but a policy denial, task update, provider request, and PR operation should all be explainable from the audit trail.
 
 ---
 
 ## 3. What May Be Distinctive
 
-1. **Code-aware audit joins.** Orbit can join audit records not only by run id, but by task id, context selector, lock reservation, worktree, graph node, and commit attribution.
-2. **Agent identity as a first-class actor.** The audit trail can name humans, model families, provider backends, and task roles without pretending an agent is just a service account.
-3. **Transcript plus structure.** V2 envelopes describe the workflow tree, while loop blobs preserve redacted provider/tool payloads. Most systems pick either high-level structure or low-level logs; Orbit needs both.
-4. **Local tamper evidence.** A self-hosted team-scale runtime can produce verifiable local audit bundles without requiring a hosted control plane.
-5. **Coverage as a design gate.** New Orbit mutation paths should have to name their audit event family before they ship, just as new activity/job semantics now need ADR coverage.
+1. **Code-aware audit joins.** Orbit can join records by run id, task id, context selector, lock reservation, worktree, graph node, and commit attribution.
+2. **Agent identity as a first-class actor.** The trail can name humans, model families, provider backends, and task roles without treating agents as generic service accounts.
+3. **Transcript plus structure.** V2 envelopes describe the workflow tree while loop blobs preserve redacted provider/tool payloads.
+4. **Local tamper evidence.** A self-hosted team-scale runtime can produce verifiable local audit bundles without a hosted control plane.
+5. **Coverage as a design gate.** New mutation paths should name their audit event family before they ship.
 
 ---
 
@@ -68,9 +66,9 @@ Orbit-internal:
 - [specs/event-schema.md](./specs/event-schema.md) — prescriptive event-channel contract.
 - [specs/coverage-matrix.md](./specs/coverage-matrix.md) — expected audit coverage by operation class.
 - [specs/redaction-retention.md](./specs/redaction-retention.md) — write-side redaction and retention boundaries.
-- [../activity-job/specs/audit-envelope.md](../activity-job/specs/audit-envelope.md) — existing v2 activity/job audit envelope spec.
+- [../activity-job/specs/audit-envelope.md](../activity-job/specs/audit-envelope.md) — v2 activity/job audit envelope spec.
 - [../../../README.md](../../../README.md) — product-level auditability commitments and public status.
-- [../../POSITIONING.md](../../POSITIONING.md) — decision lens for auditability as a non-negotiable.
+- [../../POSITIONING.md](../../POSITIONING.md) — auditability as a non-negotiable.
 
 External reference categories:
 
@@ -87,5 +85,6 @@ External reference categories:
 - **[T20260426-0519]** — Move file-backed activity/job audit traces under workspace state.
 - **[T20260426-0526]** — Persist v2 invocation traces for metrics beside audit.
 - **[T20260426-0605]** — Add this auditability design folder and name future auditability questions.
+- **[T20260430-20]** — Shorten the auditability docs while preserving required guarantees.
 
 > Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.

--- a/docs/design/auditability/4_decisions.md
+++ b/docs/design/auditability/4_decisions.md
@@ -2,7 +2,7 @@
 
 **Status:** Draft
 **Owner:** codex
-**Last updated:** 2026-04-30 (T20260430-4)
+**Last updated:** 2026-04-30 (T20260430-20)
 
 This is the append-only ADR log for Auditability. Entries are ordered by ADR number. New entries should use the template in [../CONVENTIONS.md](../CONVENTIONS.md) and cite the task that made the decision real.
 
@@ -12,262 +12,229 @@ This is the append-only ADR log for Auditability. Entries are ordered by ADR num
 
 **Status:** Accepted · 2026-04 · [T20260426-0605]
 
-**Context.** Auditability is named as a primary Orbit feature, but the implementation and rationale were spread across README prose, Activity / Job docs, SQLite audit code, loop audit code, and redaction utilities.
+**Context.** Auditability is a primary Orbit feature, but its implementation and rationale were spread across README prose, Activity / Job docs, SQLite audit code, loop audit code, and redaction utilities.
 
-**Decision.** Create `docs/design/auditability/` as the canonical design folder for auditability, with codex as owner.
+**Decision.** Create `docs/design/auditability/` as the canonical auditability design folder, owned by codex.
 
 **Consequences.**
 - Audit decisions now have one ADR log and one glossary.
-- Future audit coverage work can cite a feature-owned spec rather than copying README promises.
-- Cost: auditability now overlaps with Activity / Job docs, so cross-links must stay current rather than duplicating the full v2 runtime design.
+- Cost: auditability overlaps with Activity / Job docs, so cross-links must stay current instead of duplicating the full runtime design.
 
 ## ADR-002 — Command audit rows stay compact and queryable
 
 **Status:** Accepted · 2026-04 · [T20260426-0605]
 
-**Context.** CLI commands need a durable, filterable history across process invocations, but stuffing full provider payloads into command rows would make routine audit queries noisy and expensive.
+**Context.** CLI commands need durable, filterable history across processes, but full provider payloads would make routine queries noisy and expensive.
 
-**Decision.** Keep command audit records as compact SQLite rows with command, target, role, status, timing, working directory, and optional argument/error fields. Store transcript-level detail in run-trace JSONL and blobs instead.
+**Decision.** Keep command audit records as compact SQLite rows with command, target, role, status, timing, working directory, and optional argument/error fields; store transcript detail in JSONL and blobs.
 
 **Consequences.**
 - `orbit audit list/show/stats/export` can stay fast and table-shaped.
-- Full replay data has a separate home better suited to append-only files and content-addressed blobs.
-- Cost: reconstructing a complete incident can require joining command rows with job state and file-backed traces.
+- Cost: complete incident reconstruction may require joining command rows with job state and file-backed traces.
 
 ## ADR-003 — V2 run structure and loop transcript detail are separate audit layers
 
 **Status:** Accepted · 2026-04 · [T20260419-0002]
 
-**Context.** Activity/job execution needs run, step, retry, fan-out, loop, and activity structure. Provider loops need HTTP, tool-call, payload, and session detail. One event type cannot serve both needs cleanly.
+**Context.** Activity/job execution needs run, step, retry, fan-out, loop, and activity structure. Provider loops need HTTP, tool-call, payload, and session detail.
 
-**Decision.** Use `V2AuditEnvelope` for activity/job structure and keep `LoopAuditEvent` for provider/tool detail. Connect the layers through run ids and parent event ids rather than merging them into one schema.
+**Decision.** Use `V2AuditEnvelope` for activity/job structure and `LoopAuditEvent` for provider/tool detail, connected through run ids and parent event ids.
 
 **Consequences.**
 - Workflow replay can traverse a run tree without loading every provider payload.
-- Loop-level audit can evolve with provider/tool semantics without changing the job DAG envelope.
 - Cost: reviewers need tooling or documentation to move between related files.
 
 ## ADR-004 — File-backed run traces are workspace-local state
 
 **Status:** Accepted · 2026-04 · [T20260426-0519]
 
-**Context.** V2 JSONL and blob traces were runtime artifacts, but they previously lived under a first-level `.orbit/audit/` path that blurred command audit, workspace state, and durable authoring surfaces.
+**Context.** V2 JSONL and blob traces are runtime artifacts, but their old first-level `.orbit/audit/` path blurred command audit, workspace state, and authored docs.
 
-**Decision.** Store activity/job envelopes, loop events, and blobs under `.orbit/state/audit/`, while command audit rows remain in the configured SQLite audit database.
+**Decision.** Store activity/job envelopes, loop events, and blobs under `.orbit/state/audit/`; keep command audit rows in the configured SQLite database.
 
 **Consequences.**
 - Runtime traces live with other workspace-local run state.
-- The file layout distinguishes command audit queries from run reconstruction artifacts.
-- Cost: old local `.orbit/audit/` artifacts may require manual fallback or migration if a user wants historical run reconstruction.
+- Cost: old `.orbit/audit/` artifacts may need manual fallback or migration for historical reconstruction.
 
 ## ADR-005 — Redaction is a write-side durability boundary
 
 **Status:** Accepted · 2026-04 · [T20260426-0605]
 
-**Context.** Audit needs faithful payloads for reproducibility, but storing raw provider keys or sensitive environment-derived values would make the audit trail unsafe by default.
+**Context.** Audit needs useful payloads for reproducibility, but raw provider keys or sensitive environment-derived values would make the trail unsafe by default.
 
-**Decision.** Redact sensitive env values, HTTP authorization patterns, API-key fields, bearer tokens, and selected argv token shapes before durable blob or error-message persistence.
+**Decision.** Redact sensitive environment values, HTTP authorization patterns, API-key fields, bearer tokens, and selected argv token shapes before durable blob or error-message persistence.
 
 **Consequences.**
 - Audit readers can treat normal stored blobs as already redacted.
-- Smoke tests can verify stored bytes, not just display output.
-- Cost: redaction changes payload hashes and may remove exact bytes that would otherwise help reproduce a provider interaction.
+- Cost: redaction changes payload hashes and may remove exact bytes useful for reproducing a provider interaction.
 
 ## ADR-006 — Invocation metrics are audit-adjacent primary records
 
 **Status:** Accepted · 2026-04 · [T20260426-0526]
 
-**Context.** V2 job execution emitted audit JSONL, but metrics and scoreboards read the invocation store. Deriving metrics by scraping audit logs would couple operator reporting to provider transcript format and JSONL retention.
+**Context.** V2 job execution emits audit JSONL, but metrics and scoreboards read the invocation store. Scraping audit logs would couple reporting to transcript format and retention.
 
 **Decision.** Persist `InvocationTrace` records beside audit as first-class metric records keyed by job run, activity, task ids, agent, model, usage, and tool-call summaries.
 
 **Consequences.**
-- `orbit metrics` and scoreboards do not need to parse audit JSONL.
-- CLI and HTTP agent-loop paths can converge on one usage record shape.
-- Cost: job execution has another persistence side effect, and metrics can diverge from transcript detail if a provider path reports incomplete usage.
+- `orbit metrics` and scoreboards can avoid parsing audit JSONL.
+- Cost: metrics can diverge from transcript detail if a provider path reports incomplete usage.
 
 ## ADR-007 — Run trace inspection stays separate from command audit
 
 **Status:** Accepted · 2026-04 · [T20260426-0705], [T20260426-0709]
 
-**Context.** Operators need first-class commands for activity/job envelope JSONL, but `orbit audit` is intentionally the compact SQLite command-audit surface. Mixing run-local envelope traversal into command-audit queries would blur two storage scopes and make command audit rows carry workflow-specific semantics.
+**Context.** Operators need first-class commands for activity/job envelope JSONL, but `orbit audit` is the compact SQLite command-audit surface.
 
-**Decision.** Expose v2 envelope inspection under `orbit run events` and `orbit run trace`, and keep `orbit audit` focused on command-audit rows. Keep envelope JSONL/blob parsing behind orbit-core runtime accessors so CLI rendering does not own file-backed run-trace layout.
+**Decision.** Expose v2 envelope inspection under `orbit run events` and `orbit run trace`, and keep envelope/blob parsing behind orbit-core runtime accessors.
 
 **Consequences.**
-- Operators can inspect both command history and run-local workflow traces through dedicated commands.
-- Activity `step.id` becomes the shared selector for `run show`, `run logs`, and run trace/event inspection.
-- Cost: users must understand that `orbit audit` and `orbit run events/trace` answer related but different audit questions.
+- Command history and run-local workflow traces have dedicated commands.
+- Cost: users must learn that `orbit audit` and `orbit run events/trace` answer related but different questions.
 
 ## ADR-008 — Process tracing feed is global JSONL
 
 **Status:** Accepted · 2026-04 · [T20260426-2343]
 
-**Context.** CLI subprocess output now emits structured tracing events after [T20260426-2313], but subscriber initialization happens before Orbit resolves a workspace root.
+**Context.** CLI subprocess output emits structured tracing events after [T20260426-2313], but subscriber initialization happens before Orbit resolves a workspace root.
 
-**Decision.** Append process-level tracing events to `~/.orbit/state/logs/orbit.jsonl` through the default subscriber, using the same `EnvFilter` as stderr and a non-blocking file writer retained for the process lifetime.
+**Decision.** Append process-level tracing events to `~/.orbit/state/logs/orbit.jsonl` through the default subscriber using the same `EnvFilter` as stderr and a retained non-blocking writer.
 
 **Consequences.**
-- Operators and future dashboards can tail one machine-readable feed across workspaces.
-- Early bootstrap events have a durable destination without needing runtime path resolution.
+- Operators and dashboards can tail one machine-readable feed across workspaces.
 - Cost: the v1 file is unrotated and concurrent processes can rarely interleave oversized JSONL records.
 
 ## ADR-009 — Tracing redaction is enforced by field formatting
 
 **Status:** Accepted · 2026-04 · [T20260426-2349]
 
-**Context.** The global JSONL feed made `tracing` output durable, but pre-emission helpers such as `redact_event_text` only protected call sites that remembered to use them.
+**Context.** A durable JSONL feed made tracing output persistent, but call-site helpers only protected emitters that remembered to use them.
 
-**Decision.** Install a redacting `FormatFields` implementation on both stderr and JSONL tracing formatters. The formatter redacts string field values, `Debug`-formatted field values, and unstructured `message` output while preserving field names and typed numeric/boolean JSON values.
+**Decision.** Install redacting `FormatFields` implementations on stderr and JSONL tracing formatters so string fields, `Debug` values, and messages are scrubbed before output.
 
 **Consequences.**
-- New structured tracing emitters inherit the default redaction path before data reaches terminal or disk output.
-- CLI subprocess tracing can emit raw line fields while the retained stdout/stderr audit blobs preserve original bytes.
-- Cost: span attribute redaction, binary payload redaction, and user-configurable redaction policies remain separate follow-up concerns.
+- New structured tracing emitters inherit default redaction before terminal or disk output.
+- Cost: span attribute redaction, binary payload redaction, and user-configurable policies remain follow-up concerns.
 
 ## ADR-010 — Canonical audit stores project high-signal events to tracing
 
 **Status:** Accepted · 2026-04 · [T20260427-0023]
 
-**Context.** The global JSONL tracing feed existed, but policy denials and friction submissions still only reached their canonical stores or return paths. Operators tailing the live feed could miss the highest-signal safety and agent-friction events.
+**Context.** Policy denials and friction submissions reached canonical stores or return paths, but operators tailing the live feed could miss them.
 
-**Decision.** Emit structured `tracing::warn!` projections beside the existing canonical side effects for filesystem policy denials, proc-spawn allowlist denials, and friction task submissions. Keep the SQLite audit rows, FS audit events, `OrbitError::PolicyDenied` returns, and scoreboard updates authoritative.
+**Decision.** Emit structured `tracing::warn!` projections beside canonical side effects for filesystem denials, proc-spawn denials, and friction task submissions.
 
 **Consequences.**
-- Dashboards and operators can watch `orbit.policy.deny` and `orbit.friction.reported` without querying the canonical stores.
-- New producers can follow the same dual-write pattern: persist to the source of truth first, then project a redacted live event.
-- Cost: the tracing feed is lossy and filterable, so readers must not treat missing live events as proof that the canonical store has no matching record.
+- Dashboards can watch `orbit.policy.deny` and `orbit.friction.reported` without querying canonical stores.
+- Cost: the tracing feed is lossy and filterable, so missing live events cannot prove the canonical store has no matching record.
 
 ## ADR-011 — Unified log feed: producer completion + reader CLI
 
 **Status:** Accepted · 2026-04 · [T20260427-27]
 
-**Context.** Producer-side coverage of the unified JSONL tracing feed (ADR-008/009/010) reached policy and friction events, but three gaps blocked the v2-terminal-console mockup from being demonstrable end-to-end:
-1. Job-DAG lifecycle events (`step.*`, `fanout.*`, `worker.state`, `loop.*`) flowed only into the `V2AuditWriter` audit store.
-2. ~16 stray `eprintln!` / `println!` calls in library crates (orbit-core, orbit-engine, orbit-store, orbit-knowledge) bypassed `tracing` entirely.
-3. Operators had to `tail -F | jq` the JSONL file by hand — no first-class reader existed.
+**Context.** The unified JSONL feed still lacked job-DAG lifecycle projections, library print hygiene, and a first-class reader for the v2-terminal-console mockup.
 
-**Decision.** Close all three slices in one task:
-- **Slice 1.** Add a single `emit_job_event` dual-write helper in `crates/orbit-engine/src/activity_job/job_executor.rs` that pairs every `V2AuditEventKind` lifecycle emission with a structured `tracing::*!` event under stable targets (`orbit.job.step_started`, `orbit.job.step_finished`, `orbit.job.step_skipped`, `orbit.job.step_retry`, `orbit.job.step_denied`, `orbit.job.step_join`, `orbit.job.fanout`, `orbit.job.worker_state`, `orbit.job.loop_iteration`, `orbit.job.loop_did_not_converge`). Tracing emit precedes the audit emit so the live feed reflects activity before the audit lock; the audit store remains authoritative. The helper is the only call site that pairs both writes — adding a new variant only requires touching `emit_job_tracing`.
-- **Slice 2.** Migrate every stray `eprintln!` / `println!` in library crates to `tracing::warn!` / `error!` / `info!` with namespaced targets (`orbit.store.sqlite`, `orbit.task.dependencies`, `orbit.knowledge.*`, etc.) and stable structured fields. Add `#![deny(clippy::print_stderr, clippy::print_stdout)]` to every library crate root (`orbit-common`, `orbit-policy`, `orbit-exec`, `orbit-knowledge`, `orbit-store`, `orbit-tools`, `orbit-agent`, `orbit-engine`, `orbit-core`, `orbit-mcp`); `orbit-cli` and `examples/` stay exempt because they own user-facing stdout/stderr. `cargo clippy --workspace --all-targets -- -D warnings` is the regression-prevention gate.
-- **Slice 3.** Add `orbit log tail` at `crates/orbit-cli/src/command/log/`. The reader resolves the JSONL path from `--path` → `$ORBIT_LOG_PATH` → `orbit_common::utility::logging::global_jsonl_log_path()` (newly made `pub`). It filters by `--target` prefix, `--level` minimum, and `--since` duration; emits raw lines under `--json` and a four-column rendering otherwise (timestamp · source · code · message) with target-aware formatters for the high-signal targets above plus the cli_runner subprocess target. ANSI escapes are suppressed when stdout is not a TTY. Follow mode (`-f`) seeks to EOF after the initial window and polls every 50 ms.
+**Decision.** Add one `emit_job_event` dual-write helper for job lifecycle tracing, migrate library `println!`/`eprintln!` calls to structured tracing with clippy denies in library crates, and add `orbit log tail` with path, target, level, since, follow, and JSON options.
 
 **Consequences.**
-- The v2-terminal-console mockup is fully demonstrable from real Orbit binaries; no fictional events.
-- Library code can no longer regress on `eprintln!`/`println!` — clippy fails the workspace under `-D warnings`.
-- The audit store and JSONL feed stay independent: schema and bytes-level shape of `V2AuditEnvelope` records are unchanged, the tracing feed is purely additive.
-- Cost: scheduler-event semantics from the mockup remain aspirational (Orbit has no scheduler), follow mode does not handle file rotation or truncation, and the CLI reader currently keeps the entire file in memory before applying `-n` (acceptable for the v1 unrotated file).
+- The terminal-console mockup can use real Orbit events, and library crates fail clippy if raw prints return.
+- Cost: scheduler-event semantics remain aspirational, follow mode is v1, and the reader keeps the file in memory before applying `-n`.
 
 ## ADR-012 — Friction scorekeeping derives from lifecycle history
 
 **Status:** Accepted · 2026-04 · [T20260427-43]
 
-**Context.** Friction reports already used `type: friction`, but untriaged reports shared `status: proposed` with human-authored proposals. That made the friction bounty scoreboard depend on ambiguous proposed-state transitions and made MCP filing harder to express.
+**Context.** Friction reports used `type: friction`, but untriaged reports shared `status: proposed` with human-authored proposals, making scoreboard derivation ambiguous.
 
-**Decision.** Add `status: friction` as the creation status for agent self-reported friction, infer the paired type/status at creation, and rebuild `friction_bounty.json` from task history. Reported counts come from `type: friction`; accepted and rejected counts come only from exits out of `status: friction`.
+**Decision.** Add `status: friction` as the creation status for self-reports, infer paired type/status at creation, and rebuild `friction_bounty.json` from task history.
 
 **Consequences.**
-- Friction inbox items are separated from human proposals without losing the lifetime `type: friction` category.
-- Scoreboard refreshes can repair stale increment files because task history is the source of truth for triage outcomes.
-- Cost: legacy untriaged friction tasks need a file-store migration from `proposed/` to `friction/`, and already-triaged legacy histories remain dependent on their existing transition records.
+- Friction inbox items are separated from human proposals while the lifetime `type: friction` category remains intact.
+- Cost: legacy untriaged reports need migration, and already-triaged legacy histories depend on existing transition records.
 
 ## ADR-013 — Unified log feed exposes shared backend surfaces for dashboard UI
 
 **Status:** Accepted · 2026-04 · [T20260427-44], [T20260427-46]
 
-**Context.** ADR-011 made `orbit log tail` the first-class terminal reader for the global JSONL tracing feed. The dashboard needs the same source/code/message semantics without copying formatter logic into browser JavaScript, and the UI feature is owned separately from the backend/API slice.
+**Context.** `orbit log tail` established terminal semantics, but the dashboard needed the same source/code/message vocabulary without copying formatter logic into browser JavaScript.
 
-**Decision.** Extract the CLI tail formatter/filter/path-resolution logic into a shared `orbit-cli` log module and expose two read-only dashboard backend endpoints: `/api/log` for a bounded initial snapshot and `/api/log/stream` for Server-Sent Events from newly appended JSONL lines. Both endpoints resolve the same log path as `orbit log tail`, accept the same target/level/since filters, and render `message_html` server-side with dynamic field values HTML-escaped before adding emphasis markup. The Tasks-tab DOM/CSS/JS panel remains a Gemini-owned follow-up task that consumes this API contract rather than duplicating log semantics.
+**Decision.** Extract log formatter/filter/path logic into a shared `orbit-cli` module and expose dashboard `/api/log` snapshot plus `/api/log/stream` SSE endpoints that render escaped `message_html` server-side.
 
 **Consequences.**
-- CLI, dashboard backend, and dashboard UI share one log vocabulary for source labels, short codes, level filtering, and high-value target messages.
-- Browser clients receive pre-rendered, escaped message HTML while keeping dynamic labels and classes outside formatter templates.
-- Cost: the backend stream still follows the v1 append-only file model; rotation/truncation handling is best-effort and the visual panel ships separately under the UI-owned task.
+- CLI, dashboard backend, and dashboard UI share one log vocabulary and escaping boundary.
+- Cost: stream rotation/truncation handling is best-effort, and the visual panel ships separately under UI ownership.
 
 ## ADR-014 — Tool-call provenance is model-first
 
 **Status:** Accepted · 2026-04 · [T20260427-52]
 
-**Context.** Orbit task and workflow instructions told agents to provide both `agent` and `model` in every `orbit tool run` JSON payload. That duplicated information for the built-in providers and created a mismatch class where an exact model could be paired with the wrong agent family.
+**Context.** Asking agents to pass both `agent` and `model` duplicated information and allowed exact models to be paired with the wrong family.
 
-**Decision.** Deprecate `agent` as a normal tool-call input and make exact `model` the preferred provenance field. Tool dispatch infers the agent family from known model names, persists both fields internally for compatibility and scoreboards, and rejects explicit legacy `agent` values when they contradict an inferable model family.
+**Decision.** Deprecate `agent` as a normal tool-call input, prefer exact `model`, infer the agent family from known model names, and reject inconsistent legacy pairs.
 
 **Consequences.**
-- Seeded skills and instructions can show shorter model-only tool calls while task records still retain `agent` and `model`.
-- Legacy callers that still pass `agent` continue to work when the pair is consistent.
-- Cost: unknown or ambiguous model names cannot infer an agent family; callers that need family-specific dispatch for those names must still provide a compatible legacy `agent` value.
+- Seeded skills and instructions can use shorter model-only tool calls while task records still retain both fields internally.
+- Cost: unknown or ambiguous models still need a compatible legacy `agent` value when family-specific dispatch matters.
 
 ## ADR-015 — Task attribution can be corrected explicitly
 
 **Status:** Accepted · 2026-04 · [T20260427-47]
 
-**Context.** Automatic task attribution keeps routine lifecycle updates low-friction, but it can leave stale `planned_by` or `implemented_by` values when a task is started by one actor and finished by another.
+**Context.** Automatic task attribution is low-friction but can leave stale `planned_by` or `implemented_by` values when different actors start and finish work.
 
-**Decision.** Keep automatic stamping for plan writes and review/done transitions, but let task update callers provide explicit `planned_by` and `implemented_by` values. Explicit attribution values override automatic stamps within the same update, and empty strings clear the corresponding field.
+**Decision.** Keep automatic stamping for plan writes and review/done transitions, but let task update callers explicitly set or clear `planned_by` and `implemented_by`.
 
 **Consequences.**
-- Agents can correct split or stale task provenance without editing task files directly.
-- Existing lifecycle automation keeps working when explicit attribution fields are omitted.
-- Cost: attribution fields become intentionally editable metadata, so reviewers must read task history and audit rows when they need stronger authorship evidence than the latest field value.
+- Agents can correct split or stale provenance without editing task files directly.
+- Cost: attribution fields are editable metadata, so stronger authorship evidence still requires task history and audit rows.
 
 ## ADR-016 — Tool-invocation audit is owned by the runtime, with MCP preflight bracketing
 
 **Status:** Accepted · 2026-04 · [T20260428-4]
 
-**Context.** Tool-invocation audit was historically written by `AuditGuard` in `orbit-cli`, an RAII wrapper around CLI command dispatch. MCP `tools/call` requests entered through `orbit mcp serve`, which executes outside any `AuditGuard`, and called `OrbitRuntime::execute_tool_command` directly. The runtime emitted only an in-memory `OrbitEvent::ToolExecuted`, so MCP-originated tool calls were missing from the SQLite command-audit trail entirely. A second gap sat at the MCP preflight check (`ensure_mcp_tool_exposed` in `orbit-cli/src/command/mcp/mod.rs`): unknown or unexposed tool names were rejected before runtime dispatch, so even a runtime-level audit-write would not cover the failure path that the acceptance criteria for the fix called out as the sharpest case.
+**Context.** CLI `AuditGuard` historically wrote tool-invocation audit rows, leaving MCP `tools/call` dispatch and MCP preflight failures outside the SQLite command-audit trail.
 
-**Decision.** Move tool-invocation audit recording into the runtime layer (`OrbitRuntime::execute_tool_command_dispatch`), so every entry point — CLI tool-run, MCP, future HTTP — produces an audit row from a single seam. Tag each dispatch with a `ToolEntryPoint` discriminator (`Cli`, `Mcp`) encoded in the audit `subcommand` field (`"run"` vs `"run-mcp"`) to avoid an audit-table schema migration. Bracket the MCP path with `audited_mcp_call`, which records a failure-status audit row when preflight rejects an unknown or unexposed tool name and otherwise delegates to the runtime for the dispatch audit. To prevent the legacy CLI `AuditGuard` from double-emitting on the `orbit tool run` path, expose a per-thread `mark_tool_audit_recorded` / `take_tool_audit_recorded` signal that the runtime sets after writing and the guard checks during `Drop`. CLI paths that bail before the runtime is reached (invalid JSON, missing input, `--dry-run`) leave the signal clear and continue to produce their existing guard-side audit row.
+**Decision.** Move tool-invocation audit to `OrbitRuntime::execute_tool_command_dispatch`, tag dispatches as CLI `"run"` or MCP `"run-mcp"`, bracket MCP preflight failures in `audited_mcp_call`, and use a per-thread signal so CLI guard rows are not duplicated.
 
 **Consequences.**
-- MCP-originated tool calls now show up in `orbit audit list` with full agent/model identity resolved from the same input-JSON → CLI-flags → env-vars precedence the CLI uses.
-- Preflight failures for unknown / unexposed tool names are auditable in their own right; the failure layer is no longer silent.
-- Adding another entry point (HTTP, IPC) can reuse `execute_tool_command_dispatch` without re-implementing audit-write.
-- `duration_ms` is clamped to `>= 1` at the audit-write site so sub-millisecond invocations cannot record `0` and false-trigger downstream alerts that key on `duration_ms > 0`.
-- Cost: the dedup signal is a per-thread one-shot. Async or multi-threaded entry points that span thread boundaries between dispatch and the higher-level audit writer will need to re-evaluate this seam if they emerge; today, the CLI is sync and `orbit mcp serve` runs without a CLI guard at all, so the constraint is a non-issue.
+- CLI and MCP tool calls, including unknown/unexposed MCP failures, now produce one audit row with shared identity resolution.
+- Cost: the dedup signal is thread-local; future async or cross-thread guarded entry points must re-evaluate the boundary.
 
 ## ADR-017 — Command-audit rows carry task / run / activity correlation IDs
 
 **Status:** Accepted · 2026-04 · [T20260428-7]
 
-**Context.** The SQLite `audit_events` table records every CLI- and MCP-originated tool invocation but stored no link back to the Orbit task, job run, or activity that triggered it. The dashboard's command-audit view rendered rows like `claude-opus-4-7 → orbit.task.approve → success` with no way to drill back to the surrounding execution context. The v2 audit envelope (`V2AuditEnvelope`, ADR-003) already carries `run_id`, `parent_event_id`, and activity context as workspace-local JSONL, but the two streams were unjoined: command-audit rows had no foreign-key into v2 events, and v2 events had no `execution_id` back-reference to the SQLite row. Operator drilldown stopped at the row.
+**Context.** SQLite command-audit rows recorded tool invocations but had no direct link to the task, job run, activity, or step that caused them.
 
-**Decision.** Add four nullable correlation columns to `audit_events` — `task_id`, `job_run_id`, `activity_id`, `step_index` — and populate them at the runtime tool-dispatch seam established in ADR-016. The runtime resolves each field with the same precedence used for agent/model identity: caller-asserted value from the tool input JSON wins, falling back to the runtime-asserted env vars (`ORBIT_TASK_ID`, `ORBIT_RUN_ID`, `ORBIT_ACTIVITY_ID`, `ORBIT_STEP_INDEX`) exported by the engine when it spawned the agent subprocess. The engine's `state_env_vars` is extended to emit `ORBIT_TASK_ID` (sourced from activity input by the same convention as `execution_working_directory_with_task`) and `ORBIT_ACTIVITY_ID` (sourced from `execution.activity.id`) alongside the existing `ORBIT_RUN_ID`. Indexes on `(task_id)` and `(job_run_id)` keep correlation queries cheap. The dashboard surfaces the four fields in the audit detail row and renders `job_run_id` as a deep link to the existing `#runs/<id>` view.
+**Decision.** Add nullable `task_id`, `job_run_id`, `activity_id`, and `step_index` columns, populate them at runtime tool dispatch from caller JSON first and engine env vars second, index task/run ids, and render the fields in dashboard detail rows.
 
 **Consequences.**
-- An operator clicking through a command-audit row can immediately see "this `orbit.task.approve` ran under task `T...` inside run `jrun-...` step `2`," and the run id is one click away from the run-detail page.
-- Failure triage for MCP tool calls — denials, validation failures, sandbox rejections — gains the surrounding context without out-of-band correlation.
-- The two audit streams (SQLite command rows + workspace-local v2 envelope) remain separate, consistent with ADR-003. ADR-002's "compact rows" principle is preserved: the new columns are short identifiers, not transcript payloads.
-- Trust boundary: input-JSON values can be asserted by an MCP client and should be treated as caller-claimed; env-supplied values are the engine's ground truth. Code comments on `resolve_audit_context` document the precedence so future call sites do not invert it.
-- Cost: a one-time SQLite migration (`ALTER TABLE audit_events ADD COLUMN ...`). Historical rows render with NULL correlation cells; backfill is intentionally out of scope.
+- Operators can drill from a tool row to the originating task and run context without out-of-band correlation.
+- Cost: historical rows remain NULL, and caller-asserted JSON values are weaker evidence than engine-supplied env context.
 
 ## ADR-018 — Scoreboard tool-call totals project from command audit
 
 **Status:** Accepted · 2026-04 · [T20260428-11]
 
-**Context.** `summary.json` previously sourced `tool_calls` from the token/invocation scoreboard, which can be empty or zero for providers that do not emit invocation traces. At the same time, the SQLite command-audit trail now records every CLI and MCP tool-run attempt, including runtime failures, pre-runtime CLI failures, and denials.
+**Context.** `summary.json` used token/invocation scoreboard tool-call totals, which can be empty for providers that do not emit invocation traces, while command audit records every tool-run attempt.
 
-**Decision.** Treat command-audit rows as the source for scoreboard all/failed tool-run attempt counts. `summary.json` counts `command: tool` rows whose `subcommand` is `"run"` or `"run-mcp"` and whose `tool_name` is present, groups them by normalized role/model, writes the all-attempt count to the existing `tool_calls` field, and adds `failed_tool_calls` for non-success rows (`failure` and `denied`). Token totals continue to come from the token/invocation scoreboard. Legacy token-scoreboard `total_tool_calls` remains a fallback through a max overlay instead of being added to audit counts.
+**Decision.** Count `command: tool` rows with `subcommand: "run"` or `"run-mcp"` and `tool_name` present as scoreboard all/failed tool-run attempts; keep token totals sourced from invocation/token scoreboards.
 
 **Consequences.**
-- Failed and denied tool runs become visible in the compact scoreboard summary rather than only in `orbit audit list`.
-- Non-Claude or trace-sparse providers can still show tool activity because command audit does not depend on provider usage traces.
-- The existing `tool_calls` JSON field keeps its name and now represents all known tool-run attempts rather than only invocation-trace tool-call summaries.
-- Cost: the max overlay is conservative, not a perfect dedupe. If invocation traces contain tool calls that are genuinely absent from command audit while audit rows also exist for the same model, the summary may undercount the mathematical union until both streams share a common invocation id.
+- Failed and denied tool runs become visible in compact summaries even for trace-sparse providers.
+- Cost: the legacy max overlay is conservative and may undercount the true union until both streams share an invocation id.
 
 ## ADR-019 — Task-review feedback scores separately from PR review comments
 
-**Status:** Accepted · 2026-04 · [T20260428-17], [T20260430-4]
+**Status:** Accepted · 2026-04 · [T20260428-17], [T20260430-4], [T20260430-5]
 
-**Context.** Orbit task review threads are the local review surface, while GitHub PR review comments are an external PR workflow artifact. Counting local-only review-thread creations directly in `pr.review_comments` would make the PR scoreboard ambiguous for tasks that never opened or synced a pull request, and counting replies as additional local observations would reward discussion volume rather than distinct review findings.
+**Context.** Local Orbit task review threads and GitHub PR review comments are different workflow artifacts, and reply volume should not be scored as distinct review findings.
 
-**Decision.** Keep `pr.review_comments` limited to comments that enter the PR/GitHub review flow, including Orbit review-thread entries after successful GitHub sync. Score local Orbit review-thread creations in a separate `task-review-threads` metric stored in `task_review.json` and surfaced in compact summaries as `task_review.threads`; replies do not increment local task-review score. Both local task-review scoring and GitHub sync scoring require the message model label to resolve to an exact configured orchestrator/helper model from the active executor catalog, falling back to Orbit's built-in `resolve_agent_model_pair` defaults when no host-specific model pair exists. Prefix-only family inference such as `gpt-typo` or `opus-handle` is not a scoring identity.
+**Decision.** Keep `pr.review_comments` for synced PR/GitHub comments, score local review-thread creations separately as `task-review-threads` surfaced as `task_review.threads`, do not score replies, and accept only exact configured or built-in model identities.
 
 **Consequences.**
-- Local code-review feedback earns scoreboard credit immediately when a scored agent creates an Orbit task review thread.
-- The dashboard can show local review feedback beside PR review feedback without renaming or overloading the existing PR fields.
-- A local review-thread creation that is later synced to GitHub can appear once in `task_review.threads` and once in `pr.review_comments`; those are intentionally distinct workflow metrics, not one mixed counter.
-- `summary.json` schema version 2 adds `task_review.threads`; consumers that only understand schema version 1 can ignore the additional field.
-- Cost: review productivity now has two counters. Readers need to compare both fields for a full picture of review activity, and future aggregate views must avoid adding them together without a clear label.
+- Local review feedback earns immediate task-review credit while synced PR feedback remains a separate PR metric.
+- Cost: review productivity now has two counters, and aggregate views must label them clearly rather than adding them blindly.
 
 ---
 
@@ -289,11 +256,12 @@ This is the append-only ADR log for Auditability. Entries are ordered by ADR num
 - **[T20260427-46]** — Implement the Gemini-owned Tasks-tab `orbit.log` panel using the shared dashboard backend API.
 - **[T20260427-47]** — Allow explicit task attribution correction for `planned_by` and `implemented_by` through task update paths.
 - **[T20260427-52]** — Deprecate `agent` in normal tool-call JSON, infer agent family from `model`, and reject inconsistent legacy pairs.
-- **[T20260428-4]** — Record audit events for MCP tool invocations: move tool-invocation audit into the runtime, add the `ToolEntryPoint` discriminator, and bracket MCP preflight + dispatch in `audited_mcp_call`.
-- **[T20260428-7]** — Correlate command-audit rows with originating run/task/activity: add nullable `task_id` / `job_run_id` / `activity_id` / `step_index` columns, thread context through engine env vars, populate at the runtime dispatch seam, surface on the dashboard.
+- **[T20260428-4]** — Record audit events for MCP tool invocations by moving ownership into the runtime, adding the entry-point discriminator, and bracketing MCP preflight.
+- **[T20260428-7]** — Correlate command-audit rows with originating run/task/activity by adding nullable correlation columns and surfacing them on the dashboard.
 - **[T20260428-11]** — Derive compact scoreboard all/failed tool-call counts from command-audit tool-run rows.
 - **[T20260428-17]** — Split local Orbit task-review scoring from PR review-comment scoring and surface both in compact scoreboards.
 - **[T20260430-4]** — Count local task-review score by review-thread creations, not replies, and rename the task-review summary field to `threads`.
 - **[T20260430-5]** — Tighten task and PR review-message scoring so only exact configured orchestrator/helper model identities score; typo-prefixed labels are ignored.
+- **[T20260430-20]** — Shorten the auditability docs while preserving required guarantees.
 
 > Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.


### PR DESCRIPTION
## Tasks
- [T20260430-20] Shorten auditability design docs
  <details><summary>Execution Summary</summary>

## Status
success

## Summary of Changes
Shortened the four top-level auditability design docs and removed repeated rationale while preserving the command-audit, run-trace, blob, redaction, identity, metrics, and ADR contracts. Updated Last updated and Task References in each touched numbered doc to cite T20260430-20. Total line count dropped from 719 to 587.

## Validation
- wc before: 100 + 229 + 91 + 299 = 719 total lines.
- wc after: 81 + 149 + 90 + 267 = 587 total lines.
- Inspected 1_overview.md, 2_design.md, 3_vision.md, and 4_decisions.md against docs/design/CONVENTIONS.md; required sections remain present in order.
- Inspected edited ADRs with counts: 19 ADR headings, 19 accepted status lines with task IDs, 19 decision summaries, and 19 explicit Cost consequences.
- git diff --check -- docs/design/auditability: passed.
- make fmt: passed.
- make build: passed.

## Overall Assessment
Documentation-only cleanup is complete; auditability docs are shorter and still preserve required guarantees and history.

  </details>

## Branch Freshness
- Base ref: `origin/agent-main`
- Head ref: `orbit/T20260430-20-69f2ff02`
- Behind base: 0
- Ahead of base: 1

## Files Changed
- `docs/design/auditability/1_overview.md`
- `docs/design/auditability/2_design.md`
- `docs/design/auditability/3_vision.md`
- `docs/design/auditability/4_decisions.md`

*authored by: gpt-5.5*