### PR TITLE
Shorten policy sandbox design docs

### DIFF
--- a/docs/design/policy-sandbox/1_overview.md
+++ b/docs/design/policy-sandbox/1_overview.md
@@ -2,9 +2,9 @@
 
 **Status:** Draft
 **Owner:** claude
-**Last updated:** 2026-04-26
+**Last updated:** 2026-04-30
 
-Policy & Sandboxing is the safety surface that decides what an agent is allowed to read, modify, and execute inside a workspace. It is two layers stitched together: a filesystem-scoping policy engine that resolves a named `FsProfile` plus global `denyRead` / `denyModify` rules into an allow/deny answer for every fs operation, and a process supervision layer that spawns shell commands with timeouts, signal handling, and process-group cleanup. [2_design.md](./2_design.md) describes the shipped implementation; [3_vision.md](./3_vision.md) names the gaps between today's policy/sandbox semantics and a defensible long-term contract.
+Policy & Sandboxing is Orbit's safety surface for filesystem access and process execution. It combines v2 `PolicyDef` profiles, global `denyRead` / `denyModify` rules, HTTP-tool fs enforcement, optional macOS `sandbox-exec` wrapping for CLI agents, and `orbit-exec` process supervision. [2_design.md](./2_design.md) documents what ships today; [3_vision.md](./3_vision.md) names the gaps to a fuller isolation contract.
 
 ---
 
@@ -12,37 +12,35 @@ Policy & Sandboxing is the safety surface that decides what an agent is allowed 
 
 Orbit runs agents against user repositories, so the safety boundary is a product feature rather than an internal hygiene concern.
 
-1. **Default-safe with explicit expansion.** When an activity does not declare an `fsProfile:`, runtime materializes an implicit `unrestricted` profile so the activity still runs against `./**`, but every read and modify still passes through the same evaluator and audits the same way. There is no silent bypass path.
-2. **Profiles are activity-scoped.** Each activity binds to one named profile. Two activities in the same job can run under different profiles, and the resolver re-evaluates per call. Profile switching happens at activity boundaries, not inside a tool call.
-3. **Deny rules are global, not profile-local.** `denyRead` and `denyModify` live on the policy itself and are injected into every resolved profile as negated rules. A workspace-level policy can only narrow the surface; it cannot widen past a global deny.
-4. **Sandboxing is shell supervision, not OS isolation.** `orbit-exec` ensures that every spawned process is reaped, time-bounded, and signal-aware. It is not a kernel-level sandbox today. The real isolation surface is the policy/tool layer, which means tool authors — not the exec runner — are responsible for routing fs work through the policy engine.
-5. **Denials must be auditable.** Filesystem denials emit through `FsAuditLogger` and surface as `V2AuditEvent` filesystem entries. Cross-link to [docs/design/auditability/](../auditability/) for how those records are stored.
+1. **Default paths stay explicit.** Omitting `fsProfile:` maps to `unrestricted`, then still runs through profile resolution and global denies.
+2. **Profiles are activity-scoped.** A job can mix profiles by activity; evaluation happens per call, not by mutating a process-global mode.
+3. **Deny rules are global.** `denyRead` and `denyModify` are injected into every resolved profile as negated rules, so workspace policy can narrow but not erase global denies.
+4. **Execution has two layers.** `orbit-exec` always supervises child processes; CLI-agent filesystem narrowing is OS-enforced only where the configured executor uses macOS `sandbox-exec`.
+5. **Denials are evidence.** HTTP fs denials emit through `FsAuditLogger` into `V2AuditEvent` filesystem entries; [auditability](../auditability/) owns durable storage.
 
 ---
 
 ## 2. Core Concepts
 
-### 2.1 Policy is a v2 schema with named profiles and global denies
+### 2.1 Policy is v2-only
 
-`PolicyDef` declares `denyRead`, `denyModify`, and a map of named `FsProfile` entries. Each profile lists `read` and `modify` glob rules. Schema version 1 is rejected at load time; only v2 with the three sections is accepted. Workspace policies override globals by name and concatenate global denies.
+`PolicyDef` accepts only schema v2: `denyRead`, `denyModify`, and named `FsProfile` entries with `read` / `modify` glob rules. Workspace profiles override globals by name; global denies accumulate.
 
 ### 2.2 Profile resolution materializes an implicit `unrestricted`
 
-When an activity omits `fsProfile:`, the v2 host substitutes the constant `UNRESTRICTED_FS_PROFILE`. If no policy defines `unrestricted`, the policy engine fills in `read: ["./**"]` and `modify: ["./**"]` so the lookup never fails. Global denies are then injected as negated rules, so even an unrestricted activity cannot read or modify a globally denied path.
+When an activity omits `fsProfile:`, the v2 host uses `UNRESTRICTED_FS_PROFILE`. If the policy does not define that profile, the resolver synthesizes `read: ["./**"]` and `modify: ["./**"]`, then injects global denies.
 
 ### 2.3 Path evaluation is last-match-wins over a normalized rule list
 
-`PolicyDef::check_path` walks the resolved rule list in order. Each rule is either positive (`./src/**`) or negated (`!./.git/**`). The last rule that matches the normalized workspace-relative path wins. If no positive rule exists, every path is denied with a sentinel `[]` matched-rule string. If positive rules exist but none match, the denial returns `<no matching rule>`.
+`PolicyDef::check_path` evaluates normalized workspace-relative paths against positive and negated rules. The last matching rule wins. Empty positive sets deny with `[]`; unmatched positive sets deny with `<no matching rule>`.
 
-### 2.4 Tool-layer enforcement applies to HTTP-backed activities only
+### 2.4 Enforcement depends on backend
 
-The `orbit-tools` `fs.*` builtins call `enforce_fs_policy` before every read or modify. The policy decision is rendered into an `FsCallEvent` (request, result, or denied) and emitted through the activity's `FsAuditLogger`. A denied call returns `OrbitError::PolicyDenied` and never reaches the filesystem. The exec layer does not consult policy directly — it trusts the calling tool to have already applied it.
+HTTP activities enforce policy in the `orbit-tools` `fs.*` builtins before any read or modify. Denials return `OrbitError::PolicyDenied` and emit audit events. CLI activities do not call those builtins; they rely on harness delegation plus the configured executor sandbox, currently macOS `sandbox-exec` for supported CLI agents.
 
-This enforcement reaches only the HTTP agent loop. `backend: cli` activities spawn an external CLI agent (Claude Code, Codex CLI, etc.) that owns its own filesystem behavior and does not route through `enforce_fs_policy`. For those activities, Orbit records a `tool_allowlist.harness_delegated` envelope event and trusts the harness; `fsProfile:` is informational, not enforced. See [2_design.md §9](./2_design.md#9-concerns--honest-limitations).
+### 2.5 Exec supervision is not default OS isolation
 
-### 2.5 Sandboxed exec is process supervision, not isolation
-
-`orbit-exec::run_process` spawns a child as a process-group leader, drains stdout/stderr in background threads to prevent pipe-fill deadlocks, installs SIGINT/SIGTERM handlers in the parent, and on timeout or signal sends SIGTERM to the entire process group with a 5 second grace period before SIGKILL. The default `Sandbox` impl is `NoSandbox`; the trait is in place for future kernel-level isolation but is not implemented today.
+`orbit-exec::run_process` spawns a process-group leader, drains stdout/stderr, installs SIGINT/SIGTERM handlers, and on timeout or signal sends SIGTERM to the group with a 5 second grace before SIGKILL. The default `Sandbox` impl remains `NoSandbox`; OS isolation is added by specific executor wrappers, not the default runner.
 
 ---
 
@@ -71,5 +69,6 @@ This enforcement reaches only the HTTP agent loop. `backend: cli` activities spa
 - **[T20260419-0503]** — Enforce `fsProfiles` across runtime and CLI.
 - **[T20260426-0605]** — Add the auditability design folder cross-linked from §3.
 - **[T20260426-0622]** — Add this policy & sandboxing design folder under claude ownership.
+- **[T20260430-23]** — Shorten the policy sandbox design docs while preserving the shipped contract and ADR history.
 
 > Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.

--- a/docs/design/policy-sandbox/2_design.md
+++ b/docs/design/policy-sandbox/2_design.md
@@ -2,31 +2,25 @@
 
 **Status:** Draft
 **Owner:** claude
-**Last updated:** 2026-04-28
+**Last updated:** 2026-04-30
 
-This document describes Orbit's shipped policy and sandboxing implementation: the v2 `PolicyDef` schema, profile resolution and the implicit `unrestricted` fallback, deny-rule injection, last-match-wins path evaluation, the `orbit-policy` engine facade, tool-layer enforcement in `orbit-tools`, the activity/job binding that threads an `fsProfile` through every dispatcher path, the `orbit-exec` spawn primitive, and the process supervision layer that handles timeouts, signals, and orphan reaping. See [1_overview.md](./1_overview.md) for purpose and [3_vision.md](./3_vision.md) for forward-looking gaps.
+This document describes Orbit's shipped policy and sandboxing implementation: v2 `PolicyDef`, profile resolution, last-match-wins path evaluation, HTTP-tool enforcement, activity/job `fsProfile` binding, macOS CLI sandbox wrapping, and `orbit-exec` supervision. See [1_overview.md](./1_overview.md) for purpose and [3_vision.md](./3_vision.md) for forward-looking gaps.
 
 ---
 
 ## 1. Policy Schema
 
-The policy schema lives on `PolicyDef` in `crates/orbit-common/src/types/policy_def.rs`. A v2 policy declares:
+`PolicyDef` in `crates/orbit-common/src/types/policy_def.rs` is v2-only. `crates/orbit-common/src/types/resource.rs` rejects schema v1 with a migration message that names `spec.denyRead`, `spec.denyModify`, and `spec.fsProfiles`.
 
-- `name`
-- optional `description`
-- `denyRead` — global read-denial rules applied to every profile
-- `denyModify` — global modify-denial rules applied to every profile
-- `fsProfiles` — a map of profile name to `FsProfile { read, modify }`
+A valid policy declares `name`, optional `description`, global `denyRead` / `denyModify`, and `fsProfiles` mapping names to `FsProfile { read, modify }`.
 
-`crates/orbit-common/src/types/resource.rs` rejects `schemaVersion: 1` at load time with an explicit migration message ("policy schemaVersion 1 is no longer supported; migrate to schemaVersion 2 with `spec.denyRead`, `spec.denyModify`, and `spec.fsProfiles`"). v2 is the only accepted shape.
-
-`PolicyDef::validate` enforces three structural invariants beyond rule normalization:
+`PolicyDef::validate` enforces:
 
 1. Every profile name is non-empty.
-2. A profile's `modify` rule must be covered by at least one `read` rule in the same profile. The validator rejects modify-only writeable paths because a tool needs to read a path to make a meaningful modification, and granting modify without read produces a confusing audit story.
-3. A profile rule that exactly duplicates a global `denyRead` or `denyModify` entry is rejected. Profiles can use negations to refine globals, but cannot copy a denied rule and effectively re-allow it by ordering.
+2. Every positive `modify` rule is covered by a positive `read` rule in the same profile.
+3. Profile rules do not exactly duplicate global deny entries.
 
-`PolicyDef::merged(global, workspace)` is the merge contract: workspace `fsProfiles` overwrite global entries by name, while global `denyRead` / `denyModify` accumulate (workspace cannot remove a global deny). Merging always re-runs `validate`.
+`PolicyDef::merged(global, workspace)` lets workspace `fsProfiles` overwrite globals by name while global denies accumulate. The merged policy is revalidated.
 
 ---
 
@@ -34,11 +28,11 @@ The policy schema lives on `PolicyDef` in `crates/orbit-common/src/types/policy_
 
 `PolicyDef::effective_profile(profile_name)` returns a `ResolvedFsProfile { name, read, modify }` after applying three transformations:
 
-1. **Lookup.** If `fs_profiles` contains `profile_name`, that profile's rule lists are the base. If not and `profile_name == "unrestricted"`, the resolver synthesizes `FsProfile { read: ["./**"], modify: ["./**"] }`. Any other missing profile name returns `OrbitError::InvalidInput`.
-2. **Normalization.** Each rule is trimmed, backslashes are flipped to forward slashes, leading `./` segments are stripped, and the rule is rejected if it escapes the workspace (`~`, `~/`, absolute paths, parent traversals). Rules also compile to a glob-equivalent regex for evaluation.
-3. **Deny injection.** Every entry in `denyRead` is appended to the profile's `read` list as a negated rule (`!<rule>`); every entry in `denyModify` is appended to the profile's `modify` list as a negated rule. This is the mechanism that makes deny rules global without a separate evaluation pass.
+1. **Lookup.** Use the named profile. If the missing name is `unrestricted`, synthesize `read: ["./**"]` and `modify: ["./**"]`; other missing profiles return `OrbitError::InvalidInput`.
+2. **Normalization.** Trim, convert backslashes, strip leading `./`, reject absolute, `~`, and parent-traversal rules, then compile the narrow glob syntax to regex.
+3. **Deny injection.** Append `denyRead` to `read` and `denyModify` to `modify` as negated rules (`!<rule>`), so global denies participate in the same ordered list.
 
-The implicit `unrestricted` profile only materializes if both conditions hold: the activity omitted `fsProfile:` *and* the policy did not define a profile named `unrestricted`. A policy author who defines `unrestricted` shadows the implicit fallback, which is the intended escape hatch for narrowing a workspace's "unrestricted" mode.
+The implicit `unrestricted` profile appears only when an activity omitted `fsProfile:` and the policy did not define `unrestricted`. A real profile with that name shadows the fallback.
 
 ---
 
@@ -49,49 +43,38 @@ The implicit `unrestricted` profile only materializes if both conditions hold: t
 1. Resolve the profile (via §2).
 2. Pick the rule list by operation (`read` or `modify`).
 3. If the list is empty, deny with `matched_rule = "[]"`.
-4. Walk every rule in order, recording the most recent match. The rule is split into negated/positive form, compiled to a regex, and matched against the normalized workspace-relative path. Later matches override earlier ones — this is **last-match-wins**, not first-match.
-5. After the walk, if any rule matched, the decision uses the last match's negation flag. If no rule matched but the list contained at least one positive rule, deny with `matched_rule = "<no matching rule>"`. If the list contained only negated rules, treat that as an empty positive set and deny with `matched_rule = "[]"`.
+4. Walk rules in order and record the most recent match against the normalized workspace-relative path. Later matches override earlier ones.
+5. Use the last match's negation flag. If no rule matched but a positive rule exists, deny with `<no matching rule>`; if only negated rules exist, deny with `[]`.
 
 Path normalization (`normalize_path`) trims, flips slashes, strips `./` prefixes, and rejects absolute paths or `~`-anchored paths. Tool callers are expected to canonicalize first and then express the path workspace-relative — `crates/orbit-tools/src/builtin/fs/mod.rs::workspace_relative_path` handles that on the call site.
 
-The glob-to-regex translator supports `*` (single-segment wildcard), `**` (cross-segment wildcard), `?` (single character within a segment), and `<prefix>/**` (directory subtree match). The translator is intentionally narrow; it is not a full POSIX glob.
+The glob translator supports `*`, `**`, `?`, and `<prefix>/**`. It is intentionally narrower than POSIX glob syntax.
 
 ---
 
 ## 4. PolicyEngine Facade
 
-`crates/orbit-policy/src/lib.rs` re-exports `PolicyEngine`, `FsPolicyEvaluation`, and `PolicyDecision`. The engine wraps a validated `PolicyDef` and exposes one operational method:
+`crates/orbit-policy/src/lib.rs` re-exports `PolicyEngine`, `FsPolicyEvaluation`, and `PolicyDecision`. `PolicyEngine` wraps a validated `PolicyDef` and exposes:
 
 ```
 PolicyEngine::check(profile, operation, path) -> FsPolicyEvaluation
 ```
 
-`FsPolicyEvaluation` is the struct callers receive: `{ profile, operation, path, allowed, matched_rule }`. The evaluator module (`evaluator.rs`) is a thin pass-through to `PolicyDef::check_path`; the indirection exists so future evaluators (e.g. caching, layered profiles) can replace the implementation without changing the engine surface.
+`FsPolicyEvaluation` carries `{ profile, operation, path, allowed, matched_rule }`. `evaluator.rs` currently passes through to `PolicyDef::check_path`; the indirection leaves room for caching or layered evaluators later.
 
-`PolicyDecision` (`crates/orbit-common/src/types/policy_decision.rs`) is a separate `Allow | Deny { reason }` enum used by the broader policy/RBAC framing. It is currently a re-export from `orbit-policy::decision` and is not generated by `PolicyEngine::check` — that path returns the richer `FsPolicyEvaluation` instead. The decision enum exists for non-fs callers and for future allow/deny answers that do not carry `matched_rule` semantics.
+`PolicyDecision` (`crates/orbit-common/src/types/policy_decision.rs`) is a separate `Allow | Deny { reason }` enum for broader policy/RBAC callers. `PolicyEngine::check` does not produce it; fs callers use `FsPolicyEvaluation`.
 
 ---
 
 ## 5. Tool-Layer Enforcement
 
-`crates/orbit-tools/src/builtin/fs/mod.rs::enforce_fs_policy` is the only place fs operations consult the policy engine today. The flow:
-
-1. Read `ctx.fs_profile` (the profile name string set by the runtime when constructing the `ToolContext`).
-2. Read `ctx.policy_engine` (the `Arc<PolicyEngine>` set by the runtime).
-3. If either is missing, return `Ok(None)` — fs work proceeds unguarded. This is the "no policy installed" path used in unit tests and is not reachable from a real v2 host.
-4. Convert the canonical filesystem path to a workspace-relative form (`workspace_relative_path`).
-5. Call `policy_engine.check(profile, op, path)`.
-6. Build an `FsPolicyAllowance` carrying `{ profile, op, path, matched_rule }`.
-7. If allowed, emit `FsCallEvent { kind: Request, allowed: true, ... }` through `ctx.fs_audit` and return the allowance so the caller can later emit `FsCallEvent::Result`.
-8. If denied, emit `FsCallEvent { kind: Denied, allowed: false, ... }` and return `OrbitError::PolicyDenied("fs.<op> denied for <path> under fsProfile <profile> (matched rule <rule>)")`.
+`crates/orbit-tools/src/builtin/fs/mod.rs::enforce_fs_policy` is the only place fs operations consult the policy engine today. It reads `ctx.fs_profile` and `ctx.policy_engine`; if either is missing, it returns `Ok(None)` so fs work proceeds unguarded. That path is for unit tests / no-policy contexts, not the real v2 host path. Otherwise the helper converts the canonical path to workspace-relative form, calls `policy_engine.check`, emits a request or denied `FsCallEvent`, and returns either an `FsPolicyAllowance { profile, op, path, matched_rule }` or `OrbitError::PolicyDenied`.
 
 The audit emission goes through `ctx.fs_audit: Option<Arc<dyn FsAuditLogger>>` (`crates/orbit-tools/src/lib.rs`). The v2 dispatcher wires this to `v2_fs_audit_logger(audit.clone())`, which converts each `FsCallEvent` into a `V2AuditEvent` filesystem entry. The full audit-channel description belongs to [auditability](../auditability/2_design.md#3-tool-driven-and-runtime-audit-records); this folder owns the *enforcement* contract, not the storage contract.
 
-`FsCallEvent` itself carries `{ kind, profile, op, path, allowed, matched_rule }`. There is no separately persisted negation flag — `allowed = false` is the only structural signal that a match was a deny. Consumers that need to distinguish "denied by an explicit deny rule" from "denied because no rule matched" must compare `matched_rule` against the policy's deny lists themselves.
+`FsCallEvent` carries `{ kind, profile, op, path, allowed, matched_rule }`. There is no persisted negation flag; consumers that need to distinguish explicit deny matches from "no rule matched" must compare `matched_rule` with the policy denies. The exec layer does not consult the policy engine, so there is no `proc.spawn` policy gate today.
 
-The exec layer does not consult the policy engine at all. There is no `proc.spawn` policy gate today — exec is sandboxed only by what the calling tool has already validated and by the supervision contract in §8.
-
-**Backend scope.** Tool-layer enforcement only fires when an activity runs under `backend: http` and reaches an Orbit fs builtin. `backend: cli` activities spawn an external CLI agent (Claude Code, Codex CLI, etc.) via `cli_runner.rs`; that path emits a `tool_allowlist.harness_delegated` envelope event and trusts the harness for tool allowlist behavior. On macOS, executors that declare `sandbox: macos-sandbox-exec` are additionally wrapped by the OS-level profile described in §7, so `fsProfile:` narrows CLI filesystem writes even though no Orbit fs builtin runs inside that subprocess.
+**Backend scope.** This enforcement fires only under `backend: http` when a builtin fs tool runs. `backend: cli` spawns Claude Code, Codex CLI, Gemini, or another harness via `cli_runner.rs`, emits `tool_allowlist.harness_delegated`, and trusts that harness for tool allowlists. On macOS, executors declaring `sandbox: macos-sandbox-exec` also get the OS-level wrapper in §7, so `fsProfile:` can still narrow CLI filesystem writes.
 
 ---
 
@@ -109,9 +92,9 @@ The `fsProfile:` field on an activity flows through `crates/orbit-engine/src/act
 fs_profile: Some(fs_profile.unwrap_or(UNRESTRICTED_FS_PROFILE).to_string())
 ```
 
-This is the implicit-`unrestricted` rule from §2.2 in code form. Every dispatcher path that constructs a `ToolContext` for an activity reaches this line, so omitting `fsProfile:` always means "unrestricted within whatever the policy says about unrestricted" — never "no policy at all."
+This is the implicit-`unrestricted` rule from §2.2 in code form. Every v2 dispatcher path that constructs a `ToolContext` reaches this line, so omitting `fsProfile:` means "unrestricted within policy," not "no policy."
 
-`crates/orbit-core/src/runtime/pipeline.rs` runs a different fallback for legacy pipeline contexts. If a `ToolContext` arrives without `fs_profile`, the pipeline calls `read_activity_fs_profile_from_env()`, which returns the value of `ORBIT_ACTIVITY_FS_PROFILE` or `None` if the variable is unset or empty. This is **not** equivalent to the v2 host's behavior: when the env var is unset, `ctx.fs_profile` stays `None`, and `enforce_fs_policy` returns `Ok(None)` so fs work proceeds unguarded. The pipeline path is documented here as a real gap rather than as a fallback that mirrors `unrestricted`. See [§9](#9-concerns--honest-limitations).
+Legacy pipeline contexts are different. `crates/orbit-core/src/runtime/pipeline.rs` fills a missing profile from `ORBIT_ACTIVITY_FS_PROFILE`; if the variable is unset, `ctx.fs_profile` stays `None` and `enforce_fs_policy` returns `Ok(None)`. That unguarded path is a real gap, not another spelling of `unrestricted` (see §9).
 
 ---
 
@@ -119,41 +102,33 @@ This is the implicit-`unrestricted` rule from §2.2 in code form. Every dispatch
 
 `orbit-exec` is the process-spawn layer. The public surface is in `crates/orbit-exec/src/lib.rs`:
 
-- `ExecRequest { program, args, current_dir, timeout_ms, stdin_mode, environment_mode, debug }` — the request shape.
-- `EnvironmentMode::Inherit` (default) or `ClearAndSet(Vec<(String, String)>)`. The `Debug` impl redacts values whose keys match `is_sensitive_env_name`, so debug-printed `ExecRequest` does not leak provider keys.
+- `ExecRequest { program, args, current_dir, timeout_ms, stdin_mode, environment_mode, debug }`.
+- `EnvironmentMode::Inherit` or `ClearAndSet(Vec<(String, String)>)`; debug output redacts sensitive env values.
 - `StdinMode::Inherit` / `Null` / `Bytes(Vec<u8>)`.
-- `Sandbox` trait (`crates/orbit-exec/src/sandbox.rs`) with one method `validate(req) -> Result<()>`. The default `NoSandbox` always returns `Ok`.
+- `Sandbox::validate(req) -> Result<()>`; the default `NoSandbox` always returns `Ok`.
 - `run_process(req, sandbox) -> ExecutionResult`.
 
-`run_process` orders the work as: `sandbox.validate` first, then `process::spawn` (`crates/orbit-exec/src/process.rs`), then `supervision::wait_with_optional_timeout`. Spawn applies `EnvironmentMode` (clear + set when requested), wires stdout/stderr to piped descriptors, and on Unix calls `command.process_group(0)` so the child becomes its own process-group leader. That single setting is what allows the cleanup layer to kill orphan subprocesses later.
+`run_process` calls `sandbox.validate`, then `process::spawn`, then `supervision::wait_with_optional_timeout`. Spawn applies the requested environment, pipes stdout/stderr, and on Unix calls `command.process_group(0)` so cleanup can kill orphan subprocesses.
 
-`ExecutionResult { success, stdout, stderr, exit_code, duration_ms, output }` is the result shape (defined in `orbit-common`). The runner converts captured bytes via `String::from_utf8_lossy`, so non-UTF-8 output is preserved as replacement characters rather than failing the call.
+`ExecutionResult { success, stdout, stderr, exit_code, duration_ms, output }` is defined in `orbit-common`. Captured bytes use `String::from_utf8_lossy`, so non-UTF-8 output becomes replacement characters instead of failing the call.
 
-The `Sandbox` trait is still the seam for `run_process` callers and its default impl remains `NoSandbox`. CLI-backed `agent_loop` invocations use a separate executor-level wrapper when the executor declares `sandbox: macos-sandbox-exec` (shipped in [T20260427-51]). The v2 host resolves the activity `fsProfile`, converts workspace-relative rules to absolute roots under the workspace, and the engine compiles those roots to SBPL just before spawning the provider CLI.
+The `Sandbox` trait remains the seam for generic `run_process` callers, but CLI-backed `agent_loop` invocations use a separate executor wrapper when the executor declares `sandbox: macos-sandbox-exec` ([T20260427-51]). The v2 host resolves the activity `fsProfile`; the engine converts workspace-relative rules to absolute roots and compiles SBPL before spawning the provider CLI.
 
 The compiled macOS profile denies by default, allows broad reads required by agent CLIs and system libraries, allows process/signal/ipc/network/sysctl/iokit operations, and allows writes to:
 
-- scratch/cache roots (`/tmp`, `/private/tmp`, `/private/var/folders`, `/dev`, and `$HOME/Library/Caches`)
-- `$HOME/.orbit`, so inherited `orbit mcp serve` and other Orbit subprocesses can persist audit/state
-- per-provider state directories: Codex (`$CODEX_HOME` when set, otherwise `$HOME/.codex` — [T20260428-10]), Claude (`$CLAUDE_CONFIG_DIR` when set, otherwise `$HOME/.claude` — [T20260428-14]), and Gemini (`$HOME/.gemini` — [T20260428-14]). All three are emitted unconditionally because the active provider is not threaded through SBPL compilation; per-provider allowances are narrow and do not widen attack surface
-- every positive `modify` root from the resolved profile
-- Codex side-write roots from runtime provider config (the same roots passed as `--add-dir`, today workspace `.orbit` and global `.orbit`), appended after policy denies so workflow state remains writable under the outer sandbox ([T20260428-10]). This branch stays Codex-specific because Claude and Gemini have no analogous CLI surface — neither accepts `--add-dir`-style flags, and their startup-time writes are confined to the per-provider state directories listed above ([T20260428-14])
+- scratch/cache roots (`/tmp`, `/private/tmp`, `/private/var/folders`, `/dev`, `$HOME/Library/Caches`)
+- `$HOME/.orbit` for inherited Orbit subprocess audit/state
+- provider state dirs: Codex (`$CODEX_HOME` or `$HOME/.codex`), Claude (`$CLAUDE_CONFIG_DIR` or `$HOME/.claude`), and Gemini (`$HOME/.gemini`)
+- positive `modify` roots from the resolved profile
+- Codex side-write roots from runtime provider config, appended after policy denies so workflow state remains writable under the outer sandbox
 
-Negated `read` / `modify` rules become explicit SBPL deny clauses after ordinary profile allows so they retain last-match-wins semantics. Simple path denials and `/**` subtree denials compile to `subpath`; non-subpath globs such as `**/*.env` compile to `regex` so they do not collapse into a repo-wide deny. Host-owned provider side roots are the explicit exception: Orbit appends those write roots after the policy-derived denials because the provider CLI and inherited Orbit subprocesses need the same workflow-state roots to be writable.
+Negated `read` / `modify` rules become explicit SBPL denies after ordinary profile allows to preserve last-match-wins. Simple path and `/**` subtree denials compile to `subpath`; non-subpath globs such as `**/*.env` compile to `regex`. Host-owned provider side roots are the exception because the provider CLI and inherited Orbit subprocesses must write workflow state.
 
 ---
 
 ## 8. Process Supervision
 
-`crates/orbit-exec/src/supervision/wait.rs::wait_with_optional_timeout` orchestrates child lifetime. The contract:
-
-1. Spawn background threads to drain stdout and stderr (`spawn_stdout_drain`, `spawn_stderr_drain` from `tee.rs`). These prevent the child from blocking on a full pipe buffer, which is the canonical "stuck child" failure mode for naive subprocess code.
-2. If `StdinMode::Bytes` is set, spawn an additional stdin-writer thread (`spawn_stdin_write`).
-3. On Unix, install a `SignalHandlerGuard` that captures SIGINT and SIGTERM via `libc::sigaction`. The handler writes a single byte to a non-blocking pipe; the wait loop reads from that pipe to learn that a parent-side signal arrived.
-4. Loop with `WAIT_POLL_INTERVAL = 100ms`, calling `child.wait_timeout(slice)`. The slice is the smaller of the poll interval and the remaining deadline.
-5. When the child exits cleanly, call `kill_process_group(child.id())` to reap any orphan subprocesses still holding the pipe write ends, then join the reader threads.
-6. When a parent-side signal arrives, call `terminate_process_group(child, signal, poll_interval)` and report `exit_code = Some(128 + signal)` with a `process interrupted by signal SIG…` line appended to stderr.
-7. When the deadline expires, call `terminate_process_group(child, SIGTERM, poll_interval)` and append `process timed out` to stderr.
+`crates/orbit-exec/src/supervision/wait.rs::wait_with_optional_timeout` drains stdout/stderr in background threads, writes stdin bytes when requested, installs Unix SIGINT/SIGTERM handling, and polls `child.wait_timeout` every `WAIT_POLL_INTERVAL = 100ms`. Clean exits still call `kill_process_group(child.id())` to reap orphans. Parent signals terminate the group and report `exit_code = Some(128 + signal)` with annotated stderr; deadlines terminate with SIGTERM and append `process timed out`.
 
 `crates/orbit-exec/src/supervision/cleanup.rs` is the termination layer. The escalation policy:
 
@@ -162,9 +137,9 @@ Negated `read` / `modify` rules become explicit SBPL deny clauses after ordinary
 3. If the group is gone, return success.
 4. Otherwise send `SIGKILL` to the group, then call `child.kill()` and `child.wait()` to reap.
 
-`process_group_is_alive` uses `killpg(pid, 0)` and treats `ESRCH` as "all gone." Any other errno is treated as "still alive" so we err on the side of escalating to SIGKILL.
+`process_group_is_alive` uses `killpg(pid, 0)`, treats `ESRCH` as "all gone," and treats other errno values as "still alive" so cleanup errs toward SIGKILL.
 
-`crates/orbit-exec/src/supervision/signal.rs::SignalHandlerGuard` is an RAII guard. Install acquires a global `Mutex` (so only one wait loop installs handlers at a time), creates a non-blocking pipe, swaps in the orbit-exec handler for SIGINT and SIGTERM, and remembers the previous `sigaction` structs. Drop reverses every step in order — restore previous handlers, close the pipe, release the mutex. The handler itself is `unsafe extern "C"` and only does an atomic load and a single-byte `write`, both of which are async-signal-safe.
+`SignalHandlerGuard` is RAII: install acquires a global `Mutex`, creates a pipe, swaps in handlers, and stores prior `sigaction` structs; Drop restores handlers, closes the pipe, and releases the mutex. The handler performs only an atomic load plus one-byte `write`, both async-signal-safe.
 
 Non-Unix builds use a fallback `terminate_process_group` that just calls `child.kill().ok(); child.wait().ok();` — process-group semantics do not apply on Windows, so orphan reaping is best-effort.
 
@@ -172,20 +147,20 @@ Non-Unix builds use a fallback `terminate_process_group` that just calls `child.
 
 ## 9. Concerns & Honest Limitations
 
-1. **OS-level CLI sandboxing is macOS-only.** `backend: cli` executors can be wrapped by `sandbox-exec` on macOS. Linux (`bwrap`), Docker, and other sandbox implementations remain future work, and non-agent `run_process` callers still use the `Sandbox` trait's `NoSandbox` default unless they add their own guard.
-2. **Tool allowlists are still delegated for CLI backends.** The macOS wrapper narrows filesystem writes, but Orbit still does not enforce declared `tools:` inside Claude/Codex/Gemini CLI harnesses. The `tool_allowlist.harness_delegated` event remains the audit signal for that gap.
-3. **Provider state directories are trusted write roots.** `$HOME/.orbit`, the Codex state directory, the Claude state directory, and the Gemini state directory are allowed so each provider CLI and inherited Orbit subprocesses can initialize and persist state. Those allowances are intentionally narrow, but they are outside the activity workspace, and they are emitted unconditionally rather than gated on the active provider.
-4. **Codex side-root appends are config-coupled.** The extra workspace/global `.orbit` side roots come from Codex `writable_dirs_json`, which Orbit currently populates for the default `execution.codex.sandbox = "workspace-write"` mode. If an operator configures Codex itself to `danger-full-access` while keeping the outer `macos-sandbox-exec` wrapper, those side roots are absent and inherited Orbit subprocesses may again hit workspace `.orbit` write denials.
-5. **macOS provenance syscall allowances are private.** The `vnguard` and `Sandbox`/67 MAC-syscall allowances mirror Codex's own seatbelt profile and unblock current macOS startup behavior. They are Apple-internal details; if Codex startup returns a bare `Operation not permitted` after an OS update, inspect those clauses first.
-6. **Pipeline env-fallback can leave `fs_profile = None`.** `crates/orbit-core/src/runtime/pipeline.rs` reads `ORBIT_ACTIVITY_FS_PROFILE` to fill a missing `fs_profile`. If the env var is unset, the `ToolContext` keeps `fs_profile: None`, `enforce_fs_policy` returns `Ok(None)`, and fs work proceeds unguarded. This diverges from the v2 host's `tool_context_for_activity`, which always materializes `unrestricted`. Callers that construct contexts outside the v2 dispatcher must set `fs_profile` explicitly or accept the unguarded path.
-7. **Policy enforcement is not centralized within HTTP-backed runs either.** `enforce_fs_policy` is called from `orbit-tools::builtin::fs`, but a future tool (or a non-builtin tool) that performs fs work without going through that helper would not be guarded. There is no fs-trait-level policy interception.
-8. **Exec has no policy hook.** `proc.spawn` and similar shell-invoking tools do not consult the `PolicyEngine`. Program allowlists are recorded at the activity layer (`activity.rs` notes that `spec.allowed_programs` is consulted by the proc.spawn tool), but those allowlists are not part of the `PolicyDef` and do not flow through `effective_profile`.
-9. **Symlink semantics are not specified.** `workspace_relative_path` canonicalizes via `Path::canonicalize`, which follows symlinks and rejects out-of-workspace targets. The deny semantics for a symlink that points outside the workspace are "denied because the resolved path is not workspace-relative," but this is not currently spelled out as an invariant.
-10. **Glob translator is narrow.** It supports `*`, `**`, `?`, and `<prefix>/**`. It does not support character classes (`[abc]`), brace expansion (`{a,b}`), or POSIX bracket expressions. New profile shapes that need richer matching will hit translator gaps before they hit the evaluator.
-11. **`PolicyDecision` and `FsPolicyEvaluation` are parallel surfaces.** The fs path uses the evaluation struct; the broader RBAC plumbing uses the simple Allow/Deny enum. There is no current bridge that converts one to the other, which means future non-fs policy evaluators have to pick a return shape rather than reuse one.
-12. **Empty-rule-set semantics are conservative but non-obvious.** A profile with no `read` rules denies every read with `matched_rule = "[]"`. This is the safe default, but a user who declares a profile with only `denyRead` rules and no positive rules will see "[]" denials, not the "matched the deny rule" denial they may expect.
-13. **Signal handler installation is process-global.** `SignalHandlerGuard` uses a global `Mutex` to serialize installs, so two concurrent `run_process` calls in the same process must take turns installing handlers. This is currently fine because v2 dispatch is single-threaded per process, but it is a real constraint if exec ever moves into a worker pool.
-14. **Workspace canonicalization can deny legitimate paths.** If `workspace_root.canonicalize()` fails (e.g., the directory was just deleted), the helper falls back to the non-canonical root, which can cause `strip_prefix` to fail and surface as a `PolicyDenied("path is outside workspace")` error rather than a clearer "workspace missing" error.
+1. **OS-level CLI sandboxing is macOS-only.** Linux (`bwrap`), Docker, and other wrappers remain future work; generic `run_process` still defaults to `NoSandbox`.
+2. **CLI tool allowlists are delegated.** The macOS wrapper narrows writes, but Orbit still trusts Claude/Codex/Gemini harnesses for declared `tools:`.
+3. **Provider state directories are trusted write roots.** `$HOME/.orbit` plus Codex, Claude, and Gemini state dirs are outside the activity workspace and emitted unconditionally.
+4. **Codex side-root appends are config-coupled.** If Codex is configured without the workspace-write side roots, inherited Orbit subprocesses can hit `.orbit` write denials.
+5. **macOS provenance syscall allowances are private.** `vnguard` and `Sandbox`/67 mirror current Codex startup needs and may require review after OS changes.
+6. **Pipeline env fallback can leave `fs_profile = None`.** Legacy contexts without `ORBIT_ACTIVITY_FS_PROFILE` still bypass `enforce_fs_policy`.
+7. **HTTP enforcement is helper-based.** A future builtin or non-builtin tool that skips `enforce_fs_policy` is unguarded.
+8. **Exec has no policy hook.** `proc.spawn` program allowlists are activity-layer data, not part of `PolicyDef` or `effective_profile`.
+9. **Symlink semantics are implicit.** `workspace_relative_path` follows symlinks and rejects out-of-workspace targets, but no spec states that invariant.
+10. **Glob syntax is narrow.** Character classes, brace expansion, and POSIX bracket expressions are unsupported.
+11. **Policy result shapes are parallel.** `PolicyDecision` and `FsPolicyEvaluation` have no bridge for future non-fs evaluators.
+12. **Empty rule sets are safe but opaque.** A profile with only deny rules reports `matched_rule = "[]"`, not the matching deny rule.
+13. **Signal handling is process-global.** `SignalHandlerGuard` serializes installs with a global `Mutex`, which constrains future worker-pool exec.
+14. **Workspace canonicalization errors collapse to denial.** A missing workspace root can surface as `PolicyDenied("path is outside workspace")` rather than a clearer root-missing error.
 
 ---
 
@@ -202,5 +177,6 @@ Non-Unix builds use a fallback `terminate_process_group` that just calls `child.
 - **[T20260427-51]** — Wrap cli-backend agent invocations in `sandbox-exec` on macOS.
 - **[T20260428-10]** — Allow Codex CLI state writes under the macOS sandbox.
 - **[T20260428-14]** — Extend the macOS sandbox state-dir allowance to Claude (`~/.claude` / `$CLAUDE_CONFIG_DIR`) and Gemini (`~/.gemini`), and document why side-write roots remain Codex-only.
+- **[T20260430-23]** — Shorten the policy sandbox design docs while preserving the shipped contract and ADR history.
 
 > Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.

--- a/docs/design/policy-sandbox/3_vision.md
+++ b/docs/design/policy-sandbox/3_vision.md
@@ -2,26 +2,26 @@
 
 **Status:** Draft
 **Owner:** claude
-**Last updated:** 2026-04-26
+**Last updated:** 2026-04-30
 
-This document captures the questions that have to be answered before Orbit's policy and sandboxing story matches a defensible long-term safety contract. [2_design.md](./2_design.md) describes today's implementation; this file names the pressure points that should drive future tasks and ADRs.
+This document captures the questions Orbit must answer before policy and sandboxing become a fuller safety contract. [2_design.md](./2_design.md) describes today's implementation; this file keeps future work distinct from shipped guarantees.
 
 ---
 
 ## 1. Open Questions
 
-1. **Should `orbit-exec` get a real `Sandbox` impl?** The trait has shipped, but only `NoSandbox` is registered. Plausible candidates are `bubblewrap` on Linux, `sandbox-exec` on macOS, container-based isolation, or syscall filtering via seccomp. The cost is platform-specific code and a packaging story; the benefit is genuine OS-level isolation that does not depend on tool authors routing through `enforce_fs_policy`.
-2. **Should policy enforcement move below the tool layer?** Today `enforce_fs_policy` is called from `orbit-tools::builtin::fs`. A future tool that does fs work without that helper is unguarded. Options: a `PolicyAwareFs` trait that every tool must use; a runtime that intercepts at the syscall layer; or a static lint that rejects unguarded fs calls. Each has a different trust model.
-3. **Should `proc.spawn` consult the policy engine?** Today exec is gated only by activity-level program allowlists, not by `PolicyDef`. Adding `denyExec` / `allowExec` to the schema is one shape; binding `fsProfile` to also constrain `proc.spawn` env access is another.
-4. **What is the symlink contract?** Today `workspace_relative_path` canonicalizes and falls back to `OrbitError::PolicyDenied("path is outside workspace")` when a symlink resolves out of the workspace. This is conservative but un-documented. The contract should explicitly state whether symlinks are followed, when a symlink-out denial is distinguishable from a normal deny, and whether profile rules can match against the unresolved path.
-5. **Should the glob translator grow to match user expectations?** Profile authors often expect character classes, brace expansion, and `**` at the start of a pattern. Today the translator supports `*`, `**`, `?`, and `<prefix>/**`. Expanding it has compatibility cost (existing profiles get re-evaluated) but reduces "why didn't my pattern match" friction.
-6. **Should `PolicyDecision` and `FsPolicyEvaluation` converge?** Two parallel allow/deny shapes is not sustainable as the policy surface grows beyond fs. A unified `PolicyOutcome { allowed, decision_kind, matched_rule, reason }` would let future evaluators (network, exec, env) plug in without picking sides.
-7. **Should profiles be composable?** Today a profile is a flat `{ read, modify }` declaration, and merging is policy-level (workspace overrides global). Composition (`extends:`, `includes:`, mixin profiles) would make policy authoring less repetitive but introduces resolution-order questions.
-8. **Should empty rule lists deny silently or emit a configuration warning?** Today an `FsProfile { read: [], modify: [] }` denies everything with sentinel `"[]"`. That is technically correct but is almost always a configuration mistake, not an intentional safety stance. A load-time warning would surface the misconfiguration earlier than the first deny.
-9. **What is the dry-run / explain story?** Profile authors today have to write a profile, run an activity, and read the audit log to discover whether a path is allowed. A `orbit policy explain --profile <name> --op modify --path <path>` command would shorten the loop without changing runtime semantics.
-10. **Should policy denials always produce structured audit?** Today denials emit through `FsAuditLogger` for fs and through targeted command-audit rows for task locks, but other denial classes (program allowlist, gate starvation, future exec denials) do not share one schema. Cross-link to [auditability §3.1 open questions](../auditability/3_vision.md#1-open-questions) — uniform denial shape is named there too.
-11. **How should signal handler installation behave under concurrent exec?** `SignalHandlerGuard` serializes via a global `Mutex`. If exec ever moves into a worker pool, this becomes a contention point. Options: per-thread sigmask manipulation, cooperative cancellation tokens that bypass signal handling for non-foreground exec, or a single supervisor thread that owns all child supervision.
-12. **How should the CLI backend gain policy coverage?** Today `backend: cli` activities spawn an external CLI agent that owns its own filesystem behavior, so `enforce_fs_policy` never runs and `fsProfile:` is informational. Closing this is structurally hard: options include (a) wrapping CLI runtimes in an OS-level sandbox so the harness cannot escape the profile even when Orbit doesn't intercept its calls, (b) routing CLI fs through a trapping shim that re-enters the policy engine, or (c) deprecating `backend: cli` in favor of HTTP-only activities. Each has a different cost and migration story.
+1. **Should `orbit-exec` get real `Sandbox` impls?** `NoSandbox` is still the default; candidates include `bubblewrap`, containers, seccomp, and platform wrappers.
+2. **Should enforcement move below the tool layer?** A future tool that skips `enforce_fs_policy` is unguarded unless Orbit adds a `PolicyAwareFs` trait, syscall interception, or linting.
+3. **Should `proc.spawn` consult policy?** Activity program allowlists are not `PolicyDef`; future shapes include `allowExec` / `denyExec` or env access tied to `fsProfile`.
+4. **What is the symlink contract?** `workspace_relative_path` follows symlinks and denies out-of-workspace targets, but the invariant is not yet specified.
+5. **Should glob syntax grow?** Character classes, braces, and broader `**` forms would reduce user surprise but may re-evaluate existing profiles differently.
+6. **Should `PolicyDecision` and `FsPolicyEvaluation` converge?** A unified outcome could serve future network, exec, and env policy checks.
+7. **Should profiles be composable?** `extends:`, `includes:`, or mixins would reduce repetition but add resolution-order questions.
+8. **Should empty rule lists warn?** `read: []` / `modify: []` safely denies everything, but a load-time warning would catch likely mistakes earlier.
+9. **What is the dry-run / explain story?** A command like `orbit policy explain --profile <name> --op modify --path <path>` would shorten policy authoring loops.
+10. **Should all denials share one audit shape?** Fs denials, task-lock denials, program allowlists, and future exec denials still report through different channels; auditability asks the same question.
+11. **How should concurrent exec handle signals?** `SignalHandlerGuard` serializes installs; worker-pool exec may need sigmasks, cancellation tokens, or a supervisor thread.
+12. **How far should CLI policy coverage go?** macOS `sandbox-exec` narrows writes, but alternatives include trapping CLI fs calls or moving more work to HTTP-backed activities.
 
 ---
 
@@ -29,35 +29,35 @@ This document captures the questions that have to be answered before Orbit's pol
 
 ### 2.1 Orbit-Internal
 
-The closest internal work is the [activity-job audit-envelope spec](../activity-job/specs/audit-envelope.md), which defines how filesystem and tool denials surface as `V2AuditEvent` entries. The auditability folder ([../auditability/2_design.md §3](../auditability/2_design.md)) documents how those events reach durable storage.
+The [activity-job audit-envelope spec](../activity-job/specs/audit-envelope.md) defines how filesystem and tool denials surface as `V2AuditEvent` entries. The auditability folder ([../auditability/2_design.md §3](../auditability/2_design.md)) documents durable storage.
 
-The current policy schema and merge contract are anchored in `crates/orbit-common/src/types/policy_def.rs` and `crates/orbit-common/src/types/resource.rs`. They give the implementation a single seam at which a future evaluator can plug in.
+The current policy schema and merge contract live in `crates/orbit-common/src/types/policy_def.rs` and `crates/orbit-common/src/types/resource.rs`.
 
 ### 2.2 OS-Level Sandboxes
 
-`bubblewrap` (Linux user-namespace sandbox), `sandbox-exec` (macOS Seatbelt), `firejail` (SUID-based Linux sandbox), and seccomp-bpf filters are the credible options for adding genuine isolation under the existing `Sandbox` trait. Each has different platform coverage, packaging cost, and side-effect surface (e.g., file mounts vs. syscall filters). gVisor and Firecracker are heavier but offer stronger isolation when the workload tolerates a microVM boundary.
+`bubblewrap`, `sandbox-exec`, `firejail`, and seccomp-bpf are the near-term isolation options under the `Sandbox` trait. gVisor and Firecracker are heavier options when a workload tolerates a microVM boundary.
 
 ### 2.3 Capability Systems
 
-POSIX capabilities, Capsicum (FreeBSD), and Linux Landlock all express "what may this process do" as orthogonal capability bits rather than path globs. Landlock in particular is a credible long-term destination: it is per-thread, hierarchical, and works without root. The cost is Linux-only coverage; the benefit is that capabilities apply to every fs syscall rather than only the calls a tool routes through Orbit.
+POSIX capabilities, Capsicum, and Linux Landlock express process rights as capabilities rather than path globs. Landlock is attractive because it is hierarchical and works without root, but it is Linux-only.
 
 ### 2.4 Build Sandboxes
 
-Bazel `exec.sandbox`, Buck2's hermetic execution, and the Nix build sandbox model treat the workspace as a closed input set and reject any path not listed. They are stricter than Orbit's "allow within profile, deny within global denies" model but show that path-level enumeration scales to large repositories when paired with a fast index.
+Bazel `exec.sandbox`, Buck2 hermetic execution, and Nix sandboxing treat the workspace as a closed input set. They are stricter than Orbit's allowlist-plus-global-deny model.
 
 ### 2.5 Process Supervision Patterns
 
-`tini`, `dumb-init`, and Kubernetes' termination-grace-period contract all model the same SIGTERM-then-SIGKILL escalation that `crates/orbit-exec/src/supervision/cleanup.rs` implements. The current 5-second grace is consistent with those references; tuning that constant per activity (similar to a Kubernetes preStop hook) is a credible future request.
+`tini`, `dumb-init`, and Kubernetes termination grace model the same SIGTERM-then-SIGKILL escalation that `orbit-exec` implements. Per-activity grace periods are a plausible future extension.
 
 ---
 
 ## 3. What May Be Distinctive
 
-1. **Profile-scoped, activity-bound.** Most sandboxes are process-bound or workload-bound. Orbit policy is activity-bound: every activity declares the profile it runs under, and the resolver re-evaluates per call. That makes it natural to express "this single tool call runs under a tighter profile" without spawning a new process.
-2. **Globs, not capability bits.** Profile authors write `./src/**` instead of opening file descriptors with bounded capabilities. The cost is that enforcement is path-string-shaped; the benefit is that profiles read like project-level intent.
-3. **Globally negative denies.** `denyRead` / `denyModify` always inject as negated rules into every resolved profile. There is no profile that can opt out of a global deny without policy ownership. This is unusual; most allowlist systems treat denies as a separate evaluation pass.
-4. **Auditable by construction.** Every fs decision generates an event regardless of allow/deny outcome (as long as `fs_audit` is wired). The audit story is not bolted on after the fact; it is part of `enforce_fs_policy`.
-5. **Workspace-relative resolution.** Paths are evaluated workspace-relative, not absolutely. Two different workspaces can have the same profile and produce different absolute paths in their audits, which keeps profile authoring portable.
+1. **Activity-bound profiles.** Every activity declares its profile, and the resolver re-evaluates per call.
+2. **Project-shaped globs.** Profiles use paths such as `./src/**`, trading capability precision for readable project intent.
+3. **Global negative denies.** `denyRead` / `denyModify` inject into every resolved profile; no profile opts out of them locally.
+4. **Auditable by construction.** HTTP fs decisions emit events as part of `enforce_fs_policy`.
+5. **Workspace-relative resolution.** Profiles stay portable because paths are evaluated relative to the active workspace.
 
 ---
 
@@ -88,5 +88,6 @@ External reference categories:
 - **[T20260417-0558-4]** / **[T20260417-0558-5]** — Hardened the supervision contract that §1.11 wants to evolve.
 - **[T20260426-0605]** — Auditability folder linked from §1.10.
 - **[T20260426-0622]** — Add this folder and name the open questions.
+- **[T20260430-23]** — Shorten the policy sandbox design docs while preserving the shipped contract and ADR history.
 
 > Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.

--- a/docs/design/policy-sandbox/4_decisions.md
+++ b/docs/design/policy-sandbox/4_decisions.md
@@ -2,7 +2,7 @@
 
 **Status:** Draft
 **Owner:** claude
-**Last updated:** 2026-04-28
+**Last updated:** 2026-04-30
 
 This is the append-only ADR log for Policy & Sandboxing. Entries are ordered by ADR number. New entries follow the template in [../CONVENTIONS.md](../CONVENTIONS.md) and cite the task that made the decision real.
 
@@ -17,8 +17,7 @@ This is the append-only ADR log for Policy & Sandboxing. Entries are ordered by 
 **Decision.** Create `docs/design/policy-sandbox/` as the canonical design folder, with claude as owner. Auditability owns the recording of denials; this folder owns the *semantics* of allow/deny and the *contract* for how spawned processes are supervised.
 
 **Consequences.**
-- Policy and sandboxing decisions now have one ADR log and one glossary.
-- Future enforcement work can cite a feature-owned spec rather than re-deriving rules from code.
+- Policy and sandboxing decisions now have one ADR log, one glossary, and a feature-owned spec to cite.
 - Cost: this folder cross-links into auditability and activity-job, so when those folders change their cross-references must be kept in sync rather than this folder absorbing them.
 
 ## ADR-002 — Policy schema is v2-only with named profiles plus global denies
@@ -30,8 +29,7 @@ This is the append-only ADR log for Policy & Sandboxing. Entries are ordered by 
 **Decision.** Reject `schemaVersion: 1` at load time with an explicit migration message. v2 declares `denyRead`, `denyModify`, and `fsProfiles` and is the only accepted shape. Workspace policies override globals by profile name; global denies accumulate.
 
 **Consequences.**
-- Schema parsing has one supported branch.
-- Profile authoring becomes uniform: a profile is always a `{ read, modify }` declaration; denies are always global.
+- Schema parsing has one supported branch, and profile authoring is uniformly `{ read, modify }` with global denies.
 - Cost: existing v1 policy files require a manual migration; there is no automatic upgrader.
 
 ## ADR-003 — Implicit `unrestricted` profile materializes when an activity omits `fsProfile:`
@@ -43,9 +41,7 @@ This is the append-only ADR log for Policy & Sandboxing. Entries are ordered by 
 **Decision.** When an activity omits `fsProfile:`, the v2 host substitutes the constant `UNRESTRICTED_FS_PROFILE` ("unrestricted") at `tool_context_for_activity`. If the policy does not define a profile of that name, the resolver synthesizes `read: ["./**"]` and `modify: ["./**"]`. Global `denyRead` / `denyModify` rules still apply because they are injected after profile resolution.
 
 **Consequences.**
-- "Unrestricted" is the default, but it is still narrowed by global denies.
-- Policy authors can shadow the implicit fallback by declaring a profile named `unrestricted`, which is the supported way to narrow the default.
-- Audit emission still happens for unrestricted activities, so there is no silent unguarded path.
+- "Unrestricted" remains auditable and narrowed by global denies, while policy authors can shadow it with a real profile.
 - Cost: the word "unrestricted" carries different meaning depending on whether the policy defines a profile of that name, which is a learnable but real source of confusion.
 
 ## ADR-004 — Deny rules inject as negated profile rules with last-match-wins evaluation
@@ -57,8 +53,7 @@ This is the append-only ADR log for Policy & Sandboxing. Entries are ordered by 
 **Decision.** `effective_profile` appends every entry of `denyRead` to the profile's `read` list as `!<rule>` and every entry of `denyModify` to the profile's `modify` list as `!<rule>`. `check_path` walks the resolved list in order and the **last match wins**. There is no separate deny pass.
 
 **Consequences.**
-- Profile rules and deny rules are evaluated in one pass against one list.
-- Deny ordering is deterministic: denies are appended after profile rules, so they always win against an earlier positive match for the same path.
+- Profile rules and deny rules are evaluated in one deterministic pass; appended denies win over earlier positive matches.
 - Cost: a profile author cannot re-allow a globally denied path by ordering, which is the intended safety property but surprises authors who expect a simple allowlist with overrides.
 
 ## ADR-005 — Modify rules must be covered by a read rule in the same profile
@@ -70,8 +65,7 @@ This is the append-only ADR log for Policy & Sandboxing. Entries are ordered by 
 **Decision.** `PolicyDef::validate` rejects any profile whose positive `modify` rule is not covered by a positive `read` rule in the same profile. "Covered" is checked structurally (`rule_covers_path_rule`): exact match, `**`, or a `<prefix>/**` rule that prefixes the modify rule.
 
 **Consequences.**
-- Modify rules cannot exist without a corresponding read rule.
-- The audit story is consistent: every modify implies a prior allowed read for the same path.
+- Modify rules require corresponding read coverage, so read-modify-write audit stories stay consistent.
 - Cost: profile authors who *only* want to allow append-style writes cannot express that without granting a read rule. There is no "write-only" profile shape today.
 
 ## ADR-006 — Tool layer is the policy enforcement point for HTTP-backed activities
@@ -83,10 +77,8 @@ This is the append-only ADR log for Policy & Sandboxing. Entries are ordered by 
 **Decision.** Enforcement lives in `orbit-tools::builtin::fs::enforce_fs_policy`. Every fs builtin calls it before the underlying read or modify, and emits `FsCallEvent` through `FsAuditLogger`. The `Sandbox` trait in `orbit-exec` does not consult the policy engine; exec is supervised but not policy-gated. This applies only to `backend: http` activities — `backend: cli` runs spawn an external CLI agent and emit a `tool_allowlist.harness_delegated` event in lieu of enforcement.
 
 **Consequences.**
-- HTTP-backed activities have a single, auditable enforcement seam.
-- Tool authors are responsible for routing fs work through the helper. The contract is small, but it is a discipline rather than a structural invariant.
-- The audit story has one shape — every HTTP-backed fs decision flows through one helper that emits one event family.
-- Cost: CLI-backed activities are entirely unenforced by Orbit; a future tool (or a non-builtin tool inside HTTP) that performs fs work without using the helper is also unguarded. Both gaps are named in [2_design.md §9](./2_design.md#9-concerns--honest-limitations); closing them likely requires a `PolicyAwareFs` trait, an OS-level sandbox under CLI runtimes, or both.
+- HTTP-backed fs decisions have one auditable helper, but tool authors must route work through it.
+- Cost: CLI-backed activities still bypass this helper, and HTTP tools that skip it are also unguarded. Current macOS executors can narrow CLI filesystem writes with `sandbox-exec`, but closing the general gap likely requires a `PolicyAwareFs` trait, broader OS sandboxes, or both.
 
 ## ADR-007 — Children spawn as process-group leaders so orphan subprocesses are reapable
 
@@ -97,8 +89,7 @@ This is the append-only ADR log for Policy & Sandboxing. Entries are ordered by 
 **Decision.** On Unix, every spawned child calls `command.process_group(0)` so the child becomes a process-group leader (PGID = PID). The supervision layer kills the entire group via `killpg` when the child exits, when the parent receives SIGINT/SIGTERM, or when the deadline expires.
 
 **Consequences.**
-- Orphan subprocesses are reaped, so `wait_with_output` no longer hangs.
-- Signal handling can target the whole tree with one syscall.
+- Orphan subprocesses are reaped, and signal handling can target the whole tree with one syscall.
 - Cost: tools that intentionally fork detached helpers (e.g., long-running daemons) cannot do so under orbit-exec without explicitly creating their own process group inside the child.
 
 ## ADR-008 — SIGTERM with 5-second grace, then SIGKILL for the whole group
@@ -110,8 +101,7 @@ This is the append-only ADR log for Policy & Sandboxing. Entries are ordered by 
 **Decision.** `terminate_process_group` sends `SIGTERM` (or the supplied signal) to the group, polls `process_group_is_alive` for `TERMINATION_GRACE_PERIOD = 5 seconds`, and on expiry sends `SIGKILL` to the group plus a direct `child.kill()`/`child.wait()`. stderr is annotated with `process timed out` (deadline path) or `process interrupted by signal SIG…` (parent-signal path).
 
 **Consequences.**
-- Termination is deterministic: at most 5 seconds between intent and SIGKILL.
-- The annotated stderr lets audit consumers distinguish timeout vs. signal vs. clean exit without reading the exit code alone.
+- Termination is deterministic, and annotated stderr distinguishes timeout, signal, and clean-exit paths.
 - Cost: the 5-second constant is global. Activities that need a longer drain (database flush, large I/O cleanup) cannot extend it without code changes.
 
 ## ADR-009 — Signal handler installation is process-global and serialized
@@ -123,8 +113,7 @@ This is the append-only ADR log for Policy & Sandboxing. Entries are ordered by 
 **Decision.** `SignalHandlerGuard::install` acquires a `Mutex` from a `OnceLock`, creates a non-blocking pipe, calls `libc::sigaction` for SIGINT and SIGTERM, and stores the previous `sigaction` structs. Drop reverses the steps: restore previous handlers, close the pipe, release the mutex. The handler itself is async-signal-safe (atomic load + 1-byte `write`).
 
 **Consequences.**
-- Concurrent `run_process` calls in the same process serialize on the mutex during install/drop, but the wait loops themselves run concurrently.
-- A panic inside a wait loop still restores prior handlers via Drop.
+- Concurrent `run_process` calls serialize handler install/drop, and panics still restore prior handlers via Drop.
 - Cost: contention on the global mutex limits exec parallelism in a single process. Named as an open question in [3_vision.md §1.11](./3_vision.md#1-open-questions).
 
 ## ADR-010 — `NoSandbox` is the default `Sandbox` impl; real isolation is deferred
@@ -136,54 +125,46 @@ This is the append-only ADR log for Policy & Sandboxing. Entries are ordered by 
 **Decision.** Ship `NoSandbox` as the default and only implementation. Defer kernel-level isolation (bubblewrap, sandbox-exec, container, seccomp) until policy enforcement at the tool layer is judged insufficient and the platform-coverage cost is understood. The trait surface is stable so a future impl can attach without changing the runner.
 
 **Consequences.**
-- The trait surface is stable for a future impl to attach to.
-- Today's safety story is "policy at the tool layer" — explicit and documented, but not OS-enforced.
+- The trait surface is stable for future isolation, while today's generic runner stays explicit about relying on tool-layer policy.
 - Cost: a tool that performs fs work without `enforce_fs_policy` (or a future non-builtin tool) has no exec-level isolation backstop. This is the structural reason §1.1 of [3_vision.md](./3_vision.md) lists real sandboxing as the top open question.
 
 ## ADR-011 — `sandbox-exec` wraps cli-backend agent invocations on macOS
 
 **Status:** Accepted · 2026-04 · [T20260427-51]
 
-**Context.** ADR-006 carved CLI backends out of the policy enforcement seam: `tool_allowlist.harness_delegated` is emitted, but the agent's built-in tools (`claude` `Edit` / `Write` / `Bash`, `codex`'s tools, `gemini`'s tools) execute under the orbit process's filesystem rights. Each agent CLI ships its own native isolation primitive — codex `--sandbox`, gemini `-s`, claude nothing — so the architecture's stated "`orbit-exec` owns sandboxing under an `FsProfile`" guarantee was honored asymmetrically and not honored at all for claude. A prompt-injected claude in a worktree could `Bash(rm -rf ...)` outside its declared `fsProfile` and orbit had no answer.
+**Context.** ADR-006 left CLI backends outside Orbit's tool-layer enforcement: the harness emits `tool_allowlist.harness_delegated`, but Claude/Codex/Gemini built-in tools run with the orbit process's filesystem rights. Provider-native sandboxes were inconsistent (`codex --sandbox`, `gemini -s`, no Claude equivalent), leaving `fsProfile` unenforced for some CLI runs.
 
-**Decision.** Build `orbit-exec::macos_sandbox` as the single declarative seam: compile a `ResolvedFsProfile` to SBPL and wrap the cli invocation in `sandbox-exec -f <profile>`. Apply uniformly to claude, codex, and gemini via a new `spec.sandbox: macos-sandbox-exec` knob on the executor YAML. When orbit-exec is authoritative, neutralize each cli's native sandbox flag (codex pinned to `--sandbox danger-full-access`, gemini's `-s` / `--sandbox` dropped) so the same constraint isn't double-encoded. Default `allow_fallback: false` (fail-closed when `sandbox-exec` is missing). Layering inner CLI flags alongside the outer sandbox (defense-in-depth) is deferred — v1 picks "one source of truth" first.
-
-The sandbox descriptor is resolved by orbit-core's `V2RuntimeHost::resolve_executor_sandbox` and compiled to SBPL by orbit-engine just before spawn. orbit-core has no direct edge to orbit-exec; orbit-engine already imports orbit-exec, so SBPL compilation lives close to the spawn site.
+**Decision.** Add `orbit-exec::macos_sandbox` as the declarative seam: compile a `ResolvedFsProfile` to SBPL and wrap Claude, Codex, and Gemini invocations with `sandbox-exec -f <profile>` when executor YAML declares `spec.sandbox: macos-sandbox-exec`. When Orbit owns the outer sandbox, neutralize provider-native sandbox flags so there is one filesystem authority. Resolve descriptors in `V2RuntimeHost::resolve_executor_sandbox` and compile SBPL in orbit-engine near the spawn site.
 
 **Consequences.**
-- claude now has OS-enforced filesystem narrowing under macOS — not just in-process gates.
-- All three providers share one declarative source of truth (`FsProfile` → SBPL via orbit-exec); operators read one rule set, not three CLI-specific syntaxes.
-- The `allow_fallback` knob lets operators degrade gracefully when `sandbox-exec` is unavailable, but the safe default is fail-closed.
-- Linux (`bwrap`), Docker, network restriction, and activity-level sandbox overrides are explicitly out of scope for v1; the `ExecutorSandboxKind` enum and orbit-exec module layout leave room for `linux-bwrap` to land alongside.
-- SBPL is Apple-deprecated-but-still-shipping (codex itself uses it). v1 accepts that risk.
+- All three providers share `FsProfile` compiled to SBPL as the macOS filesystem authority, giving Claude OS-enforced narrowing too.
+- `allow_fallback` can degrade gracefully, but the safe default is fail-closed; Linux, Docker, network restriction, and activity-level overrides stay out of scope for v1.
 - Cost: SBPL writes are static text; complex `denyRead` / `denyModify` rule combinations don't always translate cleanly. Simple subtree denials use `subpath`; non-subpath deny globs use SBPL `regex` to avoid over-denying the containing directory. Activities that need precise allow-side glob semantics under sandbox should declare profiles with explicit subpath roots.
 
 ## ADR-012 — Codex state and side roots are narrow sandbox write allowances
 
 **Status:** Accepted · 2026-04 · [T20260428-10]
 
-**Context.** After workflow admission was fixed in [T20260428-8], `orbit run ship T20260428-5` reached the Codex-backed `agent_implement` step, but Codex exited during startup under `sandbox-exec` with `Operation not permitted`. The outer profile allowed task worktree writes, temp/cache writes, and `$HOME/.orbit`, but not Codex's own state directory. Codex initializes state before it reads Orbit's envelope, so the provider could not start. Once Codex state was allowed, the same run still failed because the default policy's workspace `.orbit/**` write deny overrode the Codex `--add-dir` side root that Orbit passed for workflow state, and because the `**/*.env` deny glob collapsed to a repo-wide `subpath` deny.
+**Context.** Codex-backed `agent_implement` reached startup under `sandbox-exec` but failed with `Operation not permitted`: the profile allowed worktree, temp/cache, and `$HOME/.orbit` writes but not Codex state. After that, workflow state still failed because policy denied workspace `.orbit/**` after Orbit passed the same root via Codex `--add-dir`, and `**/*.env` over-denied when compiled as a containing-directory `subpath`.
 
-**Decision.** Keep `sandbox-exec` as the filesystem authority and add two narrow Codex allowances. First, allow provider state writes to `$CODEX_HOME` when set, otherwise `$HOME/.codex`. Second, append Codex side-write roots from runtime provider config (the same roots passed as `--add-dir`, today workspace `.orbit` and global `.orbit`) after policy-derived denials. Compile non-subpath deny globs such as `**/*.env` as SBPL `regex` clauses instead of reducing them to their containing directory. Do not grant broad `$HOME` writes and do not disable the outer sandbox.
+**Decision.** Keep `sandbox-exec` authoritative and add narrow Codex allowances: `$CODEX_HOME` or `$HOME/.codex`, plus Codex side-write roots from runtime provider config appended after policy-derived denials. Compile non-subpath deny globs such as `**/*.env` as SBPL `regex` clauses. Do not grant broad `$HOME` writes or disable the outer sandbox.
 
 **Consequences.**
-- Codex-backed `backend: cli` runs can initialize under the macOS sandbox while project writes remain constrained by the resolved `fsProfile`.
-- Operators can relocate Codex state with `CODEX_HOME`, and the compiled profile follows that location.
-- Inherited Orbit subprocesses can persist workflow lifecycle state under the same side roots Codex receives as CLI arguments.
+- Codex-backed `backend: cli` runs can initialize under the macOS sandbox while project writes stay constrained by the resolved `fsProfile`.
+- `CODEX_HOME` relocates state, and inherited Orbit subprocesses can persist workflow state through the same side roots Codex receives.
 - Cost: the Codex state directory and provider side roots are trusted writable state outside ordinary project-content policy, similar to the existing `$HOME/.orbit` allowance for inherited Orbit subprocesses.
 
 ## ADR-013 — Per-provider state-dir allowances are emitted unconditionally for every supported CLI
 
 **Status:** Accepted · 2026-04 · [T20260428-14]
 
-**Context.** ADR-012 fixed Codex CLI startup under `sandbox-exec` by adding `$CODEX_HOME` / `$HOME/.codex` to the SBPL allow set. The same fix was not applied to the other `backend: cli` providers: Claude writes settings/sessions/projects/file-history/todos under `$HOME/.claude` (or `$CLAUDE_CONFIG_DIR`) and Gemini writes state under `$HOME/.gemini` during startup. Both fail with `Operation not permitted` under the same outer profile that ADR-012 unblocked for Codex. The active provider is not threaded through SBPL compilation — the profile is built from `ResolvedFsProfile` plus host env, with no provider parameter — so adding per-provider conditionals would require either threading provider through the compile API or branching at the engine layer.
+**Context.** ADR-012 unblocked Codex state writes, but Claude writes startup state under `$HOME/.claude` or `$CLAUDE_CONFIG_DIR`, and Gemini writes under `$HOME/.gemini`. SBPL compilation receives `ResolvedFsProfile` plus host env, not the active provider, so provider-conditional allow clauses would require new plumbing.
 
-**Decision.** Extend the macOS sandbox state-dir allowance to all three supported CLI providers and emit allows for `$CODEX_HOME` / `$HOME/.codex`, `$CLAUDE_CONFIG_DIR` / `$HOME/.claude`, and `$HOME/.gemini` unconditionally regardless of which provider is actually running. Honor `CLAUDE_CONFIG_DIR` (documented by Claude Code) as the env override for the Claude state dir; Gemini does not document a stable env override, so only the hardcoded fallback is honored. Keep `append_provider_side_write_roots` Codex-only because Claude and Gemini have no `--add-dir`-equivalent CLI surface, and document that constraint in the function so a future provider that does ship one is generalized rather than branched.
+**Decision.** Emit state-dir allows for all supported CLI providers on every macOS sandbox profile: `$CODEX_HOME` / `$HOME/.codex`, `$CLAUDE_CONFIG_DIR` / `$HOME/.claude`, and `$HOME/.gemini`. Keep `append_provider_side_write_roots` Codex-only because Claude and Gemini have no `--add-dir` equivalent; document that a future provider with such a surface should generalize the branch.
 
 **Consequences.**
-- Claude- and Gemini-backed `agent_loop` activities reach past CLI startup under `macos-sandbox-exec` with the same defense story Codex has.
-- The compiled profile has three narrow per-provider state-dir allowances instead of one. None of those allowances widen the attack surface meaningfully — they target documented per-CLI state roots, not broad `$HOME` writes — and emitting all three avoids per-provider conditional compilation that would otherwise need to thread provider through `compile_macos_sandbox_profile`.
-- The runtime continues to thread Codex's `writable_dirs_json` into the profile via `append_provider_side_write_roots`. Adding a new provider that ships a side-root surface should generalize that branch rather than duplicate it.
+- Claude and Gemini reach past CLI startup under `macos-sandbox-exec` with the same state-dir defense story as Codex.
+- Emitting all three narrow state-dir allowances avoids provider plumbing; Codex side roots remain a separate branch until another provider ships an equivalent surface.
 - Cost: every macOS sandbox profile carries three state-dir allow clauses regardless of which provider runs. If a future provider's state dir overlaps with another sensitive root, this design needs revisiting.
 
 ---
@@ -199,5 +180,6 @@ The sandbox descriptor is resolved by orbit-core's `V2RuntimeHost::resolve_execu
 - **[T20260427-51]** — Wrap cli-backend agent invocations in `sandbox-exec` on macOS with inner-flag neutralization for codex/gemini.
 - **[T20260428-10]** — Allow Codex CLI state writes under the macOS sandbox.
 - **[T20260428-14]** — Extend the macOS sandbox state-dir allowance to Claude and Gemini, and document why side-write roots remain Codex-only.
+- **[T20260430-23]** — Shorten the policy sandbox design docs while preserving the shipped contract and ADR history.
 
 > Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.


### PR DESCRIPTION
## Tasks
- [T20260430-23] Shorten policy sandbox design docs
  <details><summary>Execution Summary</summary>

## Status
success

## Summary of Changes
- Shortened `docs/design/policy-sandbox/1_overview.md`, `2_design.md`, `3_vision.md`, and `4_decisions.md`.
- Updated touched numbered docs to `Last updated: 2026-04-30` and added `[T20260430-23]` to Task References.
- Preserved current `FsProfile`, `denyRead` / `denyModify`, HTTP fs enforcement, macOS CLI sandbox, and process supervision facts.

## Overall Assessment
The policy sandbox docs are shorter and easier to scan. `wc -l docs/design/policy-sandbox/*.md` changed from 576 total before editing to 534 total after editing (-42 lines).

## Validation
- `wc -l docs/design/policy-sandbox/*.md`: before 576 total; after 534 total.
- Required section order verified for `1_overview.md`, `2_design.md`, `3_vision.md`, and `4_decisions.md` against `docs/design/CONVENTIONS.md`.
- ADRs 001-013 verified for number, status line, task-ID citation, `Decision`, `Consequences`, and explicit `Cost:` consequence.
- `git diff --check -- docs/design/policy-sandbox`: passed.
- `make fmt`: passed.
- `make build`: passed.

  </details>

## Branch Freshness
- Base ref: `origin/agent-main`
- Head ref: `orbit/T20260430-23-69f2ff02`
- Behind base: 0
- Ahead of base: 1

## Files Changed
- `docs/design/policy-sandbox/1_overview.md`
- `docs/design/policy-sandbox/2_design.md`
- `docs/design/policy-sandbox/3_vision.md`
- `docs/design/policy-sandbox/4_decisions.md`

*authored by: gpt-5.5*