### PR TITLE
Fix clippy needless_return in MCP setup config path

### DIFF
--- a/crates/orbit-cli/src/command/mcp/setup.rs
+++ b/crates/orbit-cli/src/command/mcp/setup.rs
@@ -408,11 +408,10 @@ impl ConfigTarget {
 fn vscode_home_user_dir(home: &Path) -> PathBuf {
     #[cfg(target_os = "macos")]
     {
-        return home
-            .join("Library")
+        home.join("Library")
             .join("Application Support")
             .join("Code")
-            .join("User");
+            .join("User")
     }
     #[cfg(target_os = "windows")]
     {


### PR DESCRIPTION
## Tasks
- [T20260430-28] Fix clippy needless_return in MCP setup config path
  <details><summary>Execution Summary</summary>

## Status
success

## Summary of Changes
Removed the explicit `return` from the macOS `vscode_home_user_dir` branch in `crates/orbit-cli/src/command/mcp/setup.rs`, preserving the same `Library/Application Support/Code/User` path under the supplied home directory.

## Overall Assessment
Minimal lint-only fix validated with `make fmt`, `make build`, and `make clippy` after formatting; clippy no longer reports `clippy::needless-return` for the changed function.

  </details>

## Branch Freshness
- Base ref: `origin/agent-main`
- Head ref: `orbit/T20260430-28-69f30576`
- Behind base: 0
- Ahead of base: 1

## Files Changed
- `crates/orbit-cli/src/command/mcp/setup.rs`

*authored by: gpt-5.5*