### PR TITLE
Cap orbit.log panel height to the viewport

### DIFF
--- a/crates/orbit-cli/assets/dashboard/app.js
+++ b/crates/orbit-cli/assets/dashboard/app.js
@@ -805,6 +805,7 @@ function setActiveTab(raw, opts = {}) {
   for (const pane of document.querySelectorAll(".tab-pane")) {
     pane.classList.toggle("active", pane.dataset.tab === top);
   }
+  if (top === "tasks") requestAnimationFrame(fitLogPanelToViewport);
 
   const indicator = $("tab-indicator") || el("div", {id: "tab-indicator", class: "tab-indicator"});
   if (!indicator.parentNode) document.querySelector(".tabs").appendChild(indicator);
@@ -2047,6 +2048,7 @@ async function refreshDashboard() {
   }
   if (btn) btn.disabled = false;
   isRefreshing = false;
+  if (activeTab === "tasks") fitLogPanelToViewport();
   
   $("footer").textContent = `orbit dashboard · auto-refresh 30s · GET /api/{tasks,jobs,job-runs,audit?since|tool|status|role|execution_id|profile|q|limit|offset,audit/summary?since|denial_threshold,runs/:id,runs/:id/events?kind|limit|offset,scoreboard,diagnostics/{metrics,friction,denials?since|kind|profile|agent}}`;
 }
@@ -2064,6 +2066,26 @@ let logBuffered = [];
 let logFollowTail = true;
 let logRows = []; // Keep track to enforce max 200 after 250 limit
 let activeLogFilters = new Set(["all"]);
+let logPanelResizeWired = false;
+
+function fitLogPanelToViewport() {
+  const panel = $("log-panel");
+  if (!panel) return;
+  const top = panel.getBoundingClientRect().top;
+  const available = Math.floor(window.innerHeight - top - 24);
+  if (available <= 0) return;
+  panel.style.setProperty("--log-panel-height", `${available}px`);
+}
+
+function wireLogPanelResize() {
+  if (logPanelResizeWired) return;
+  logPanelResizeWired = true;
+  const scheduleFit = () => requestAnimationFrame(fitLogPanelToViewport);
+  window.addEventListener("resize", scheduleFit);
+  if (window.visualViewport) {
+    window.visualViewport.addEventListener("resize", scheduleFit);
+  }
+}
 
 function getLogClass(level, code) {
   if (code === "DENY") return "deny";
@@ -2105,6 +2127,8 @@ function renderLogEvent(ev, isFresh) {
 }
 
 function initLogTail() {
+  wireLogPanelResize();
+  fitLogPanelToViewport();
   fetchJson("/api/log?limit=50").then((events) => {
     const inner = $("logInner");
     if (!inner) return;

--- a/crates/orbit-cli/assets/dashboard/index.html
+++ b/crates/orbit-cli/assets/dashboard/index.html
@@ -1276,6 +1276,14 @@
       ::-webkit-scrollbar-thumb:hover { background: var(--fg-dim); }
 
       /* LOG TAIL */
+      main.tasks-layout {
+        align-items: stretch;
+      }
+      @media (max-width: 1250px) {
+        main.tasks-layout {
+          grid-template-columns: minmax(0, 2fr) minmax(280px, 1.15fr) !important;
+        }
+      }
       .col-log {
         display: flex;
         flex-direction: column;
@@ -1288,6 +1296,10 @@
         flex-direction: column;
         min-height: 0;
         min-width: 0;
+      }
+      #log-panel {
+        height: var(--log-panel-height, calc(100dvh - 224px));
+        max-height: var(--log-panel-height, calc(100dvh - 224px));
       }
       .col-log .panel > header .title {
         display: flex; align-items: center; gap: 10px;
@@ -1304,6 +1316,7 @@
       }
       .log-stream {
         flex: 1; overflow: auto; position: relative;
+        min-height: 0;
         background:
           linear-gradient(rgba(255,255,255,0.012) 1px, transparent 1px) 0 0 / 100% 22px,
           var(--bg-elev);
@@ -1430,7 +1443,7 @@
       </div>
     </section>
     <section class="tab-pane" data-tab="tasks">
-      <main style="grid-template-columns: minmax(0, 2fr) minmax(0, 1.15fr);">
+      <main class="tasks-layout" style="grid-template-columns: minmax(0, 2fr) minmax(0, 1.15fr);">
         <div class="col-tasks" style="display: flex; flex-direction: column; min-width: 0;">
           <section class="panel" id="tasks-panel">
             <header><span>Tasks</span><span class="count" id="tasks-count">-</span></header>

--- a/docs/design/user-interface/2_design.md
+++ b/docs/design/user-interface/2_design.md
@@ -20,7 +20,7 @@ The UI uses layered dark surfaces instead of flat black: base canvas, elevated p
 
 ## 4. Live Status
 
-Live processing is visible through pulsing dots, spinners, buffered-log counters, periodically refreshed tiles, and compact ticker-style values. Motion is functional: it points to active work without making the operator read raw logs first.
+Live processing is visible through pulsing dots, spinners, buffered-log counters, periodically refreshed tiles, and compact ticker-style values. The `orbit.log` panel is viewport-bounded; overflowing rows scroll inside the log stream so footer filters and follow-tail controls remain visible [T20260430-29]. Motion is functional: it points to active work without making the operator read raw logs first.
 
 ## 5. Dashboard Telemetry Consistency
 
@@ -36,5 +36,6 @@ Accessibility still needs a real WCAG pass; responsive behavior remains optimize
 - [T20260428-13] unified dashboard denial sources for the policy drill-down.
 - [T20260428-15] compacted scoreboard ratio columns.
 - [T20260430-24] shortened this design doc while preserving current behavior statements.
+- [T20260430-29] bounded the live `orbit.log` panel to the viewport.
 
 > Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.

--- a/docs/design/user-interface/4_decisions.md
+++ b/docs/design/user-interface/4_decisions.md
@@ -42,11 +42,24 @@ This append-only ADR log records UI decisions in ascending order. Each entry kee
 - The table presents reliability and participation context in fewer columns, while `0/N` tool failures stays meaningful.
 - Cost: Friction accepted/rejected counts and raw duel losses require summary JSON or a future detail view.
 
+## ADR-004 — Bounded Live Log Tail
+
+**Status:** Accepted · 2026-04 · [T20260430-29]
+
+**Context.** The Tasks view keeps `orbit.log` visible beside the task list, but the log panel could grow taller than short viewports and push footer controls below the screen.
+
+**Decision.** Keep the Tasks view in a two-column layout and size `#log-panel` to the available viewport. The log row stream owns overflow scrolling, while filters, buffered-count, and follow-tail controls remain inside the bounded panel.
+
+**Consequences.**
+- Operators get one clear scroll target for raw log rows while live-tail controls stay visible during short-screen monitoring.
+- Cost: The Tasks view trades narrow-screen stacking for denser columns so the live log remains in the first viewport.
+
 ## Task References
 
 - [T20260427-29] introduced the Canon Refined UI direction.
 - [T20260428-13] unified policy-denial sources for the dashboard.
 - [T20260428-15] compacted scoreboard ratio columns.
 - [T20260430-24] tightened this ADR log without changing decisions.
+- [T20260430-29] bounded the live `orbit.log` tail panel.
 
 > Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.


### PR DESCRIPTION
## Tasks
- [T20260430-29] Cap orbit.log panel height to the viewport
  <details><summary>Execution Summary</summary>

## Status
success

## Summary of Changes
- Bounded the Tasks view `#log-panel` to the available viewport and kept `.log-stream` as the internal scroll container.
- Preserved live-tail controls, buffered-count, and filter behavior while keeping footer controls visible.
- Documented the UI contract in `docs/design/user-interface/2_design.md` and added ADR-004 in `4_decisions.md`.

## Overall Assessment
Validated locally at 768x600 and 459x648 with overflowing synthetic log rows; panel bottom stayed within the viewport, stream overflowed internally, and toggling filters/follow-tail did not grow the outer panel.

## Validation
- `cargo run -p orbit-cli --bin orbit -- web serve --port 7979 --no-open`
- Playwright viewport checks at 768x600 and 459x648
- `git diff --check -- crates/orbit-cli/assets/dashboard crates/orbit-cli/src/command/web docs/design/user-interface`
- `make fmt`
- `make build`

  </details>

## Branch Freshness
- Base ref: `origin/agent-main`
- Head ref: `orbit/T20260430-29-69f30637`
- Behind base: 0
- Ahead of base: 1

## Files Changed
- `crates/orbit-cli/assets/dashboard/app.js`
- `crates/orbit-cli/assets/dashboard/index.html`
- `docs/design/user-interface/2_design.md`
- `docs/design/user-interface/4_decisions.md`

*authored by: gpt-5.5*