### PR TITLE
Ensure PR bodies include populated execution summaries

### DIFF
--- a/crates/orbit-engine/src/executor/automation/pr.rs
+++ b/crates/orbit-engine/src/executor/automation/pr.rs
@@ -200,6 +200,20 @@ pub(super) fn open_batch_pr<H: RuntimeHost + TaskHost + ?Sized>(
         )));
     }
 
+    let mut completed_tasks = Vec::new();
+    for task_id in &completed_task_ids {
+        let task = host.get_task(task_id)?;
+        if task.batch_id.as_deref() != Some(batch_id) {
+            return Err(OrbitError::Execution(format!(
+                "open_batch_pr: task '{}' no longer belongs to batch '{}'",
+                task.id, batch_id
+            )));
+        }
+        ensure_task_can_enter_pr_review(&task)?;
+        completed_tasks.push(task);
+    }
+    ensure_completed_tasks_have_meaningful_execution_summaries(&completed_tasks)?;
+
     let head = git_output(&workspace_path, &["rev-parse", "--abbrev-ref", "HEAD"])?;
     let head = head.trim().to_string();
     let base = input_string_field(input, "base").unwrap_or_else(|| "main".to_string());
@@ -224,18 +238,6 @@ pub(super) fn open_batch_pr<H: RuntimeHost + TaskHost + ?Sized>(
         .filter(|line| !line.is_empty())
         .collect();
 
-    let mut completed_tasks = Vec::new();
-    for task_id in &completed_task_ids {
-        let task = host.get_task(task_id)?;
-        if task.batch_id.as_deref() != Some(batch_id) {
-            return Err(OrbitError::Execution(format!(
-                "open_batch_pr: task '{}' no longer belongs to batch '{}'",
-                task.id, batch_id
-            )));
-        }
-        ensure_task_can_enter_pr_review(&task)?;
-        completed_tasks.push(task);
-    }
     let title = input_string_field(input, "title")
         .filter(|value| !value.trim().is_empty())
         .unwrap_or_else(|| default_pr_title(&completed_tasks));
@@ -347,6 +349,20 @@ fn ensure_task_can_enter_pr_review(task: &Task) -> Result<(), OrbitError> {
     )))
 }
 
+fn ensure_completed_tasks_have_meaningful_execution_summaries(
+    tasks: &[Task],
+) -> Result<(), OrbitError> {
+    for task in tasks {
+        if meaningful_execution_summary(&task.execution_summary).is_none() {
+            return Err(OrbitError::Execution(format!(
+                "open_batch_pr: task '{}' requires a meaningful persisted execution_summary before opening the PR",
+                task.id
+            )));
+        }
+    }
+    Ok(())
+}
+
 fn build_batch_pr_body(
     tasks: &[Task],
     freshness: &super::freshness::BranchFreshness,
@@ -382,14 +398,50 @@ fn build_batch_pr_body(
 
 fn render_task_section(task: &Task) -> String {
     let line = render_task_line(task);
-    let execution_summary = task.execution_summary.trim();
-    if execution_summary.is_empty() {
-        return line;
+    match meaningful_execution_summary(&task.execution_summary) {
+        Some(execution_summary) => {
+            format!(
+                "{line}\n  <details><summary>Execution Summary</summary>\n\n{execution_summary}\n\n  </details>"
+            )
+        }
+        None => line,
     }
+}
 
-    format!(
-        "{line}\n  <details><summary>Execution Summary</summary>\n\n{execution_summary}\n\n  </details>"
-    )
+fn meaningful_execution_summary(summary: &str) -> Option<&str> {
+    let trimmed = summary.trim();
+    if trimmed.is_empty() || is_placeholder_execution_summary(trimmed) {
+        None
+    } else {
+        Some(trimmed)
+    }
+}
+
+fn is_placeholder_execution_summary(summary: &str) -> bool {
+    let normalized = summary
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+        .collect::<Vec<_>>()
+        .join(" ");
+    let lower = normalized.to_ascii_lowercase();
+    let stripped = lower.trim_matches(|c: char| c.is_ascii_punctuation() || c.is_whitespace());
+    stripped.is_empty()
+        || matches!(
+            stripped,
+            "todo"
+                | "tbd"
+                | "n/a"
+                | "na"
+                | "none"
+                | "placeholder"
+                | "execution summary"
+                | "summary"
+                | "no execution summary"
+                | "no summary provided"
+                | "no execution summary provided"
+                | "to be authored by executing agent at start time"
+        )
 }
 
 fn render_task_line(task: &Task) -> String {
@@ -440,11 +492,263 @@ fn task_required_revision(task: &Task) -> bool {
 
 #[cfg(test)]
 mod tests {
+    use std::fs;
+    use std::path::{Path, PathBuf};
+    use std::process::Command;
+    use std::sync::Mutex;
+
     use chrono::Utc;
-    use orbit_common::types::{TaskPriority, TaskType};
+    use orbit_common::types::{
+        Activity, Job, JobTargetType, OrbitEvent, Role, TaskArtifact, TaskPriority, TaskType,
+    };
+    use orbit_tools::ToolContext;
+    use serde_json::{Value, json};
+    use tempfile::{TempDir, tempdir};
+
+    use crate::context::{JobRunResult, RuntimeHost, TaskReadHost, TaskWriteHost};
+    use crate::executor::registry::ActivityExecutorRegistry;
 
     use super::super::freshness::BranchFreshness;
     use super::*;
+
+    #[derive(Clone, Debug)]
+    struct ToolCall {
+        name: String,
+        input: Value,
+    }
+
+    struct PrOpenTestHost {
+        tasks: Mutex<Vec<Task>>,
+        tool_calls: Mutex<Vec<ToolCall>>,
+        repo_root: PathBuf,
+        data_root: PathBuf,
+        scoreboard_dir: PathBuf,
+        registry: ActivityExecutorRegistry,
+    }
+
+    impl PrOpenTestHost {
+        fn new(tasks: Vec<Task>, repo_root: PathBuf) -> Self {
+            let data_root = repo_root.join(".orbit-test-data");
+            let scoreboard_dir = data_root.join("scoreboard");
+            Self {
+                tasks: Mutex::new(tasks),
+                tool_calls: Mutex::new(Vec::new()),
+                repo_root,
+                data_root,
+                scoreboard_dir,
+                registry: ActivityExecutorRegistry::default(),
+            }
+        }
+
+        fn tool_calls(&self) -> Vec<ToolCall> {
+            self.tool_calls.lock().expect("tool calls lock").clone()
+        }
+
+        fn pr_create_body(&self) -> String {
+            self.tool_calls()
+                .into_iter()
+                .find(|call| call.name == "github.pr.create")
+                .and_then(|call| {
+                    call.input
+                        .get("body")
+                        .and_then(Value::as_str)
+                        .map(ToOwned::to_owned)
+                })
+                .expect("github.pr.create body")
+        }
+    }
+
+    impl TaskReadHost for PrOpenTestHost {
+        fn get_task(&self, task_id: &str) -> Result<Task, OrbitError> {
+            self.tasks
+                .lock()
+                .expect("tasks lock")
+                .iter()
+                .find(|task| task.id == task_id)
+                .cloned()
+                .ok_or_else(|| OrbitError::TaskNotFound(task_id.to_string()))
+        }
+
+        fn get_task_artifacts(&self, _task_id: &str) -> Result<Vec<TaskArtifact>, OrbitError> {
+            Ok(Vec::new())
+        }
+
+        fn list_tasks_filtered(
+            &self,
+            status: Option<TaskStatus>,
+            priority: Option<TaskPriority>,
+            parent_id: Option<&str>,
+            batch_id: Option<&str>,
+        ) -> Result<Vec<Task>, OrbitError> {
+            Ok(self
+                .tasks
+                .lock()
+                .expect("tasks lock")
+                .iter()
+                .filter(|task| status.is_none_or(|status| task.status == status))
+                .filter(|task| priority.is_none_or(|priority| task.priority == priority))
+                .filter(|task| {
+                    parent_id.is_none_or(|parent_id| task.parent_id.as_deref() == Some(parent_id))
+                })
+                .filter(|task| {
+                    batch_id.is_none_or(|batch_id| task.batch_id.as_deref() == Some(batch_id))
+                })
+                .cloned()
+                .collect())
+        }
+    }
+
+    impl TaskWriteHost for PrOpenTestHost {
+        fn start_task(
+            &self,
+            _task_id: &str,
+            _note: Option<String>,
+            _comment: Option<String>,
+        ) -> Result<Task, OrbitError> {
+            Err(OrbitError::Execution(
+                "start_task is not needed by pr_open tests".to_string(),
+            ))
+        }
+
+        fn admit_task_for_workflow(
+            &self,
+            _task_id: &str,
+            _workflow: &str,
+        ) -> Result<Task, OrbitError> {
+            Err(OrbitError::Execution(
+                "admit_task_for_workflow is not needed by pr_open tests".to_string(),
+            ))
+        }
+
+        fn update_task_from_activity(
+            &self,
+            _task_id: &str,
+            _status: TaskStatus,
+            _execution_summary: Option<String>,
+            _comment: Option<String>,
+            _note: Option<String>,
+        ) -> Result<Task, OrbitError> {
+            Err(OrbitError::Execution(
+                "update_task_from_activity is not needed by pr_open tests".to_string(),
+            ))
+        }
+
+        fn apply_task_automation_update(
+            &self,
+            task_id: &str,
+            update: TaskAutomationUpdate,
+        ) -> Result<(), OrbitError> {
+            let mut tasks = self.tasks.lock().expect("tasks lock");
+            let task = tasks
+                .iter_mut()
+                .find(|task| task.id == task_id)
+                .ok_or_else(|| OrbitError::TaskNotFound(task_id.to_string()))?;
+            if let Some(status) = update.status {
+                task.status = status;
+            }
+            if let Some(pr_number) = update.pr_number {
+                task.pr_number = Some(pr_number);
+            }
+            if let Some(execution_summary) = update.execution_summary {
+                task.execution_summary = execution_summary;
+            }
+            Ok(())
+        }
+    }
+
+    impl RuntimeHost for PrOpenTestHost {
+        fn record_event(&self, _event: OrbitEvent) -> Result<(), OrbitError> {
+            Ok(())
+        }
+
+        fn repo_root(&self) -> Result<String, OrbitError> {
+            Ok(self.repo_root.to_string_lossy().to_string())
+        }
+
+        fn data_root(&self) -> &Path {
+            &self.data_root
+        }
+
+        fn activity_executor_registry(&self) -> &ActivityExecutorRegistry {
+            &self.registry
+        }
+
+        fn run_job_now_with_input_debug(
+            &self,
+            _job_id: &str,
+            _input: Value,
+            _debug: bool,
+        ) -> Result<JobRunResult, OrbitError> {
+            Err(OrbitError::Execution(
+                "run_job_now_with_input_debug is not needed by pr_open tests".to_string(),
+            ))
+        }
+
+        fn validate_activity_target_exists(
+            &self,
+            _target_type: JobTargetType,
+            _target_id: &str,
+        ) -> Result<Activity, OrbitError> {
+            Err(OrbitError::Execution(
+                "validate_activity_target_exists is not needed by pr_open tests".to_string(),
+            ))
+        }
+
+        fn get_job(&self, _job_id: &str) -> Result<Option<Job>, OrbitError> {
+            Ok(None)
+        }
+
+        fn run_tool_with_context_and_role(
+            &self,
+            name: &str,
+            input: Value,
+            _role: Role,
+            _tool_context: ToolContext,
+        ) -> Result<Value, OrbitError> {
+            self.tool_calls
+                .lock()
+                .expect("tool calls lock")
+                .push(ToolCall {
+                    name: name.to_string(),
+                    input: input.clone(),
+                });
+
+            match name {
+                "git.push" => Ok(json!({})),
+                "github.pr.create" => Ok(json!({
+                    "url": "https://github.example/orbit/orbit/pull/42"
+                })),
+                "github.pr.view" => Ok(json!({
+                    "pull_request": { "number": 42 }
+                })),
+                other => Err(OrbitError::ToolNotFound(other.to_string())),
+            }
+        }
+
+        fn maybe_create_failure_task(
+            &self,
+            _job_id: &str,
+            _run_id: &str,
+            _error_code: &str,
+            _error_message: &str,
+            _agent: Option<&str>,
+            _model: Option<&str>,
+        ) -> Result<(), OrbitError> {
+            Ok(())
+        }
+
+        fn scoring_enabled(&self) -> bool {
+            false
+        }
+
+        fn graph_editing(&self) -> bool {
+            false
+        }
+
+        fn scoreboard_dir(&self) -> &Path {
+            &self.scoreboard_dir
+        }
+    }
 
     fn task(id: &str, title: &str, execution_summary: &str) -> Task {
         let now = Utc::now();
@@ -481,6 +785,13 @@ mod tests {
         }
     }
 
+    fn batch_task(id: &str, title: &str, execution_summary: &str) -> Task {
+        let mut task = task(id, title, execution_summary);
+        task.status = TaskStatus::InProgress;
+        task.batch_id = Some("batch-1".to_string());
+        task
+    }
+
     fn freshness() -> BranchFreshness {
         BranchFreshness {
             base_ref: "main".to_string(),
@@ -490,33 +801,100 @@ mod tests {
         }
     }
 
+    struct PrWorkspace {
+        _temp: TempDir,
+        repo: PathBuf,
+    }
+
+    fn pr_workspace() -> PrWorkspace {
+        let temp = tempdir().expect("tempdir");
+        let repo = temp.path().join("repo");
+        fs::create_dir_all(&repo).expect("create repo dir");
+        git(&repo, &["init"]);
+        git(&repo, &["checkout", "-b", "agent-main"]);
+        git(&repo, &["config", "user.name", "Orbit Test"]);
+        git(&repo, &["config", "user.email", "orbit-test@example.com"]);
+        fs::write(repo.join("README.md"), "base\n").expect("write readme");
+        git(&repo, &["add", "README.md"]);
+        git(&repo, &["commit", "-m", "base"]);
+        git(&repo, &["checkout", "-b", "orbit/test-batch"]);
+        fs::create_dir_all(repo.join("src")).expect("create src dir");
+        fs::write(repo.join("src/lib.rs"), "pub fn changed() {}\n").expect("write lib");
+        git(&repo, &["add", "src/lib.rs"]);
+        git(&repo, &["commit", "-m", "change"]);
+
+        PrWorkspace { _temp: temp, repo }
+    }
+
+    fn pr_open_input(repo: &Path, completed_task_ids: Vec<&str>) -> Value {
+        json!({
+            "workspace_path": repo.to_string_lossy(),
+            "batch_id": "batch-1",
+            "completed_task_ids": completed_task_ids,
+            "base": "agent-main",
+            "base_sync": "local",
+        })
+    }
+
+    fn git(current_dir: &Path, args: &[&str]) -> String {
+        let output = Command::new("git")
+            .args(args)
+            .current_dir(current_dir)
+            .output()
+            .expect("run git");
+        assert!(
+            output.status.success(),
+            "git {} failed in {}:\nstdout: {}\nstderr: {}",
+            args.join(" "),
+            current_dir.display(),
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        String::from_utf8_lossy(&output.stdout).trim().to_string()
+    }
+
     #[test]
     fn default_pr_body_includes_non_empty_execution_summary() {
+        let first_summary = "## Status\nsuccess\n\n## Summary of Changes\n- Routed automation updates through system.";
+        let second_summary =
+            "## Status\nsuccess\n\n## Summary of Changes\n- Added PR body summary coverage.";
         let body = build_batch_pr_body(
-            &[task(
-                "T20260427-24",
-                "System attribution fix",
-                "## Status\nsuccess\n\n## Summary of Changes\n- Routed automation updates through system.",
-            )],
+            &[
+                task("T20260427-24", "System attribution fix", first_summary),
+                task("T20260427-25", "Review handoff", second_summary),
+            ],
             &freshness(),
             &["crates/orbit-core/src/runtime/engine/task_host.rs"],
         );
 
         assert!(body.contains("- [T20260427-24] System attribution fix"));
-        assert!(body.contains("<details><summary>Execution Summary</summary>"));
-        assert!(body.contains("## Status\nsuccess"));
-        assert!(body.contains("- Routed automation updates through system."));
+        assert!(body.contains("- [T20260427-25] Review handoff"));
+        assert_eq!(
+            body.matches("<details><summary>Execution Summary</summary>")
+                .count(),
+            2
+        );
+        assert!(body.contains(first_summary));
+        assert!(body.contains(second_summary));
     }
 
     #[test]
-    fn default_pr_body_omits_empty_execution_summary_block() {
+    fn default_pr_body_omits_empty_or_placeholder_execution_summary_block() {
         let body = build_batch_pr_body(
-            &[task("T20260427-32", "Include execution summaries", "   \n")],
+            &[
+                task("T20260427-32", "Include execution summaries", ""),
+                task("T20260427-33", "Whitespace summary", "   \n"),
+                task("T20260427-34", "Placeholder summary", "TODO"),
+                task("T20260427-35", "Ellipsis summary", "..."),
+            ],
             &freshness(),
             &[],
         );
 
         assert!(body.contains("- [T20260427-32] Include execution summaries"));
+        assert!(body.contains("- [T20260427-33] Whitespace summary"));
+        assert!(body.contains("- [T20260427-34] Placeholder summary"));
+        assert!(body.contains("- [T20260427-35] Ellipsis summary"));
         assert!(!body.contains("<details><summary>Execution Summary</summary>"));
     }
 
@@ -534,5 +912,89 @@ mod tests {
         assert!(body.contains("## Files Changed"));
         assert!(body.contains("- `crates/orbit-engine/src/executor/automation/pr.rs`"));
         assert!(body.contains("*authored by: gpt-5.5*"));
+    }
+
+    #[test]
+    fn pr_open_rejects_missing_execution_summary_before_create() {
+        let workspace = pr_workspace();
+        let host = PrOpenTestHost::new(
+            vec![
+                batch_task(
+                    "T20260430-31A",
+                    "First completed task",
+                    "## Status\nsuccess\n\n## Summary of Changes\n- First task is complete.",
+                ),
+                batch_task("T20260430-31B", "Second completed task", "   \n"),
+            ],
+            workspace.repo.clone(),
+        );
+
+        let error = pr_open(
+            &host,
+            &pr_open_input(&workspace.repo, vec!["T20260430-31A", "T20260430-31B"]),
+        )
+        .expect_err("missing execution summary should reject PR creation");
+        let message = error.to_string();
+
+        assert!(message.contains("T20260430-31B"));
+        assert!(message.contains("requires a meaningful persisted execution_summary"));
+        assert!(message.contains("before opening the PR"));
+        assert!(
+            host.tool_calls()
+                .iter()
+                .all(|call| call.name != "github.pr.create")
+        );
+    }
+
+    #[test]
+    fn pr_open_generates_body_with_all_completed_task_summaries() {
+        let workspace = pr_workspace();
+        let first_summary =
+            "## Status\nsuccess\n\n## Summary of Changes\n- Implemented the first bundle task.";
+        let second_summary =
+            "## Status\nsuccess\n\n## Summary of Changes\n- Implemented the second bundle task.";
+        let host = PrOpenTestHost::new(
+            vec![
+                batch_task("T20260430-31A", "First completed task", first_summary),
+                batch_task("T20260430-31B", "Second completed task", second_summary),
+            ],
+            workspace.repo.clone(),
+        );
+
+        pr_open(
+            &host,
+            &pr_open_input(&workspace.repo, vec!["T20260430-31A", "T20260430-31B"]),
+        )
+        .expect("pr_open should create PR");
+        let body = host.pr_create_body();
+
+        assert!(body.contains("- [T20260430-31A] First completed task"));
+        assert!(body.contains(first_summary));
+        assert!(body.contains("- [T20260430-31B] Second completed task"));
+        assert!(body.contains(second_summary));
+        assert_eq!(
+            body.matches("<details><summary>Execution Summary</summary>")
+                .count(),
+            2
+        );
+    }
+
+    #[test]
+    fn pr_open_preserves_non_empty_explicit_body() {
+        let workspace = pr_workspace();
+        let host = PrOpenTestHost::new(
+            vec![batch_task(
+                "T20260430-31A",
+                "First completed task",
+                "## Status\nsuccess\n\n## Summary of Changes\n- Implemented the task.",
+            )],
+            workspace.repo.clone(),
+        );
+        let mut input = pr_open_input(&workspace.repo, vec!["T20260430-31A"]);
+        input["body"] = json!("Custom reviewer handoff.");
+
+        pr_open(&host, &input).expect("pr_open should create PR with explicit body");
+
+        assert_eq!(host.pr_create_body(), "Custom reviewer handoff.");
     }
 }

--- a/docs/design/activity-job/2_design.md
+++ b/docs/design/activity-job/2_design.md
@@ -2,7 +2,7 @@
 
 **Status:** Draft
 **Owner:** codex
-**Last updated:** 2026-04-30
+**Last updated:** 2026-05-05
 
 This document describes the shipped Activity / Job substrate across `orbit-common`, `orbit-engine`, `orbit-core`, and `orbit-cli`: asset shape, normalization, dispatch boundaries, backend semantics, DAG execution, audit, and retained legacy edges. See [1_overview.md](./1_overview.md) for purpose and [3_vision.md](./3_vision.md) for open questions.
 
@@ -317,6 +317,10 @@ This path stays separate from `orbit.task.update` and generic deterministic meta
 
 Planning-duel writeback now reports `task_status: "in-progress"` instead of `status_unchanged`; the plan artifact still lands through `planning_duel_resolved`.
 
+### 8.11 Task PR handoff summaries
+
+`task_pr_pipeline` sends the selected task IDs to `pr_open` as `completed_task_ids`. Before `pr_open` pushes or creates the pull request, the deterministic action reloads each task record, checks that the task still belongs to the batch, confirms it can enter review, and requires a meaningful persisted `execution_summary` for every completed task. Empty, whitespace-only, and explicit placeholder summaries fail the PR step with an error naming the task id; generated default PR bodies also omit placeholder summary details blocks. When callers pass a non-empty `body`, `pr_open` preserves that body verbatim after the same durable-summary guard passes. This handoff contract was tightened in [T20260430-31].
+
 ---
 
 ## 9. Filesystem Policy and `fsProfile`
@@ -448,5 +452,6 @@ Read-only history does not need the same dependencies as live execution. [T20260
 - **[T20260430-26]** — Release task-gate reservations after terminal child shipment runs and expose active reservations through the lock view.
 - **[T20260430-27]** — Make `ship-auto` output distinguish empty backlog, gated no-op, and waiting gate children.
 - **[T20260430-30]** — Make `ship-auto` default text output human-readable while preserving JSON fields.
+- **[T20260430-31]** — Require populated execution summaries before opening task PRs.
 
 > Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.

--- a/docs/design/activity-job/4_decisions.md
+++ b/docs/design/activity-job/4_decisions.md
@@ -2,7 +2,7 @@
 
 **Status:** Draft
 **Owner:** codex
-**Last updated:** 2026-04-30 (ADR-034 text output clarified)
+**Last updated:** 2026-05-05 (ADR-036 task PR summaries)
 
 This ADR log records the decisions that define the current Activity / Job substrate. Entries are append-only and stay in place when later ADRs supersede them. See [1_overview.md](./1_overview.md) for the feature summary, [2_design.md](./2_design.md) for the current implementation, and [3_vision.md](./3_vision.md) for the questions that may force more decisions.
 
@@ -472,6 +472,19 @@ This ADR log records the decisions that define the current Activity / Job substr
 - Operators can distinguish task-held locks from reservation-held locks without reading raw SQLite state.
 - Cost: `task_gate_pipeline` now relies on the dynamic `task_{{ input.mode }}_pipeline` job-name convention, so future gate modes must either follow that naming convention or refactor the dispatch selector.
 
+## ADR-036 — Task PRs require durable execution summaries
+
+**Status:** Accepted · 2026-05 · [T20260430-31]
+
+**Context.** `task_pr_pipeline` generated pull request bodies from persisted task records, but `pr_open` could still create a PR with an empty or placeholder `Execution Summary` disclosure. That made reviewer handoff look complete while forcing reviewers to reconstruct implementation results from logs or history.
+
+**Decision.** Treat each completed task's persisted `execution_summary` as required PR handoff data. `pr_open` reloads every `completed_task_ids` task, rejects empty, whitespace-only, and explicit placeholder summaries before creating the PR, and preserves non-empty caller-provided `body` text only after that durable-summary guard passes. Generated default PR bodies render summary details blocks only for meaningful summaries.
+
+**Consequences.**
+- A task-shipment PR cannot be opened until every participating task has a durable implementation handoff on the task record.
+- Multi-task bundles include one populated summary per completed task in generated PR bodies.
+- Cost: manual or custom-body shipment paths must still persist task summaries before opening the PR, even when the caller already prepared a complete body.
+
 ---
 
 ## Task References
@@ -518,5 +531,6 @@ This ADR log records the decisions that define the current Activity / Job substr
 - **[T20260430-26]** — Release task-gate reservations after terminal child shipment runs and expose active reservations through the lock view.
 - **[T20260430-27]** — Make `ship-auto` output distinguish empty backlog, gated no-op, and waiting gate children.
 - **[T20260430-30]** — Make `ship-auto` default text output human-readable while preserving JSON fields.
+- **[T20260430-31]** — Require populated execution summaries before opening task PRs.
 
 > Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.


### PR DESCRIPTION
## Tasks
- [T20260430-31] Ensure PR bodies include populated execution summaries
  <details><summary>Execution Summary</summary>

## Status
success

## Summary of Changes
- Added a meaningful execution-summary guard to pr_open so completed task bundles fail before PR creation when any task has an empty, whitespace-only, or placeholder execution_summary.
- Updated default PR body rendering to include Execution Summary details only for meaningful summaries while preserving explicit non-empty body input.
- Added focused default PR body and pr_open fake-host tests, plus Activity / Job design docs and ADR-036 for the durable PR handoff contract.

## Overall Assessment
The implementation is scoped to the PR automation path and validates the durable task-record handoff before GitHub PR creation.

## Validation
- cargo test -p orbit-engine default_pr_body
- cargo test -p orbit-engine pr_open
- make build
- make fmt

  </details>

## Branch Freshness
- Base ref: `origin/agent-main`
- Head ref: `orbit/T20260430-31-69f93670`
- Behind base: 0
- Ahead of base: 1

## Files Changed
- `crates/orbit-engine/src/executor/automation/pr.rs`
- `docs/design/activity-job/2_design.md`
- `docs/design/activity-job/4_decisions.md`

*authored by: gpt-5.5*