### PR TITLE
Rebuild missing branch graph refs during freshness checks

### DIFF
--- a/crates/orbit-knowledge/src/pipeline/mod.rs
+++ b/crates/orbit-knowledge/src/pipeline/mod.rs
@@ -114,11 +114,12 @@ fn run_build_inner(config: BuildConfig) -> Result<PipelineContext, KnowledgeErro
 
 /// Ensure the knowledge graph is up-to-date with the current checkout.
 ///
-/// Rebuilds when the checkout advances beyond the persisted manifest or when a
-/// dirty worktree fingerprint changes outside the debounce window. Dirty
-/// refreshes are debounced and concurrent refreshes are single-flighted through
-/// `refresh.lock` so read-side callers can reuse the current graph instead of
-/// stacking rebuilds.
+/// Rebuilds when the checkout advances beyond the persisted manifest, when the
+/// current branch does not have its own graph ref, or when a dirty worktree
+/// fingerprint changes outside the debounce window. Dirty refreshes are
+/// debounced and concurrent refreshes are single-flighted through `refresh.lock`
+/// so read-side callers can reuse the current graph instead of stacking
+/// rebuilds.
 pub fn ensure_fresh(
     knowledge_dir: &Path,
     repo_path: &Path,
@@ -262,6 +263,12 @@ fn compute_refresh_plan(
             .get("generated_at")
             .and_then(|v| v.as_str())
             .and_then(|s| chrono::DateTime::parse_from_rfc3339(s).ok());
+        if !graph_available {
+            return Ok(RefreshPlan::Rebuild {
+                dirty_fingerprint: None,
+                incremental: true,
+            });
+        }
         return Ok(match (generated_at, head_ts) {
             (Some(generated), Some(head_ts)) if head_ts > generated => RefreshPlan::Rebuild {
                 dirty_fingerprint: None,

--- a/crates/orbit-knowledge/tests/branch_refs.rs
+++ b/crates/orbit-knowledge/tests/branch_refs.rs
@@ -300,6 +300,95 @@ fn ensure_fresh_waits_for_requested_branch_ref_before_returning()
 }
 
 #[test]
+fn branch_refs_ensure_fresh_rebuilds_clean_worktree_when_branch_ref_is_missing()
+-> Result<(), Box<dyn std::error::Error>> {
+    let repo = init_repo()?;
+    let knowledge_dir = repo.path().join(".orbit/knowledge");
+    run_build(BuildConfig {
+        repo_path: repo.path().to_path_buf(),
+        output_dir: knowledge_dir.clone(),
+        incremental: false,
+        ref_name: None,
+        task_id_pattern: None,
+    })?;
+
+    let default_ref = RefName::new("main")?;
+    let graph_store = GraphObjectStore::new(knowledge_dir.join("graph"));
+    assert!(graph_store.ref_path(&default_ref).is_file());
+
+    git(repo.path(), &["branch", "feature/missing-refresh"])?;
+    let feature_worktree = repo.path().join("wt-missing-refresh");
+    git(
+        repo.path(),
+        &[
+            "worktree",
+            "add",
+            feature_worktree.to_str().unwrap(),
+            "feature/missing-refresh",
+        ],
+    )?;
+    write_rust_source(&feature_worktree, "feature_only_graph")?;
+    commit_all_with_date(
+        &feature_worktree,
+        "feature-only graph",
+        "2026-04-10T00:00:00Z",
+    )?;
+    let manifest: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(knowledge_dir.join("manifest.json"))?)?;
+    let generated_at = manifest
+        .get("generated_at")
+        .and_then(|value| value.as_str())
+        .ok_or_else(|| io_error("manifest generated_at missing".to_string()))?;
+    let generated_at = chrono::DateTime::parse_from_rfc3339(generated_at)?;
+    let head_ts = chrono::DateTime::parse_from_rfc3339(&git(
+        &feature_worktree,
+        &["log", "-1", "--format=%cI"],
+    )?)?;
+    assert!(head_ts < generated_at);
+
+    let read_target = resolve_graph_read_target(Some(&feature_worktree), None)?;
+    assert_eq!(read_target.requested.as_str(), "feature/missing-refresh");
+    assert_eq!(
+        read_target.fallback.as_ref().map(RefName::as_str),
+        Some("main")
+    );
+    assert!(!graph_store.ref_path(&read_target.requested).exists());
+
+    let status = ensure_fresh(&knowledge_dir, &feature_worktree)?;
+    assert_eq!(status, RefreshStatus::Rebuilt);
+    assert!(graph_store.ref_path(&read_target.requested).is_file());
+
+    let resolved =
+        graph_store.resolve_ref(&read_target.requested, read_target.fallback.as_ref())?;
+    assert!(!resolved.used_fallback);
+
+    let graph = graph_store.read_graph(
+        &read_target.requested,
+        read_target.fallback.as_ref(),
+        read_target.default.as_ref(),
+    )?;
+    assert!(
+        graph
+            .leaves
+            .iter()
+            .any(|leaf| leaf.base.name == "feature_only_graph")
+    );
+    assert!(
+        !graph
+            .leaves
+            .iter()
+            .any(|leaf| leaf.base.name == "main_graph")
+    );
+
+    write_rust_source(&feature_worktree, "feature_dirty_graph")?;
+    let status = ensure_fresh(&knowledge_dir, &feature_worktree)?;
+    assert_eq!(status, RefreshStatus::Rebuilt);
+    let status = ensure_fresh(&knowledge_dir, &feature_worktree)?;
+    assert_eq!(status, RefreshStatus::SkippedDirtyDebounce);
+    Ok(())
+}
+
+#[test]
 fn pack_regression_selector_opens_from_branch_ref_layout() -> Result<(), Box<dyn std::error::Error>>
 {
     let repo_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"))

--- a/docs/design/knowledge-graph/4_decisions.md
+++ b/docs/design/knowledge-graph/4_decisions.md
@@ -2,7 +2,7 @@
 
 **Status:** Draft
 **Owner:** claude
-**Last updated:** 2026-04-30
+**Last updated:** 2026-05-05
 
 ADR-style log of non-obvious knowledge-graph decisions. Each entry names the pressure, the choice, and the tradeoff. Entries are append-only and keyed by number; superseded entries are marked, not deleted.
 
@@ -27,7 +27,7 @@ Format for each entry: **Status · Date · Task(s)**, then *Context → Decision
 
 ## ADR-002 — Branch-scoped refs over a single shared ref
 
-**Status:** Accepted · 2026-04 · [T20260421-0358]
+**Status:** Accepted · 2026-04 · [T20260421-0358], [T20260505-1]
 
 **Context.** The original layout used `.orbit/knowledge/graph/refs/current.json` — one mutable ref shared across every branch and worktree. The last rebuild won globally. Multi-branch and multi-worktree workflows therefore saw graph reads for the wrong branch, and concurrent rebuilds raced on the single pointer.
 
@@ -35,7 +35,7 @@ Format for each entry: **Status · Date · Task(s)**, then *Context → Decision
 
 **Consequences.**
 - Two worktrees on different branches can rebuild concurrently without corruption.
-- A new branch is immediately usable via fallback — no forced rebuild.
+- A new branch remains readable via direct fallback, while auto-refresh materializes the current branch ref before treating the graph as fresh.
 - Migration path: legacy `refs/current.json` is moved to `refs/heads/<default>.json` on open.
 - Cost: two worktrees on the *same* branch still share a ref (see [2_design.md §6.5]).
 
@@ -132,11 +132,11 @@ Format for each entry: **Status · Date · Task(s)**, then *Context → Decision
 
 ## ADR-009 — Debounced, single-flighted refresh
 
-**Status:** Accepted · 2026-04 · [T20260417-0307], [T20260416-0719], [T20260417-0639]
+**Status:** Accepted · 2026-04 · [T20260417-0307], [T20260416-0719], [T20260417-0639], [T20260505-1]
 
 **Context.** Every read can trigger `ensure_fresh`. Without coordination, a dirty worktree plus many quick reads would stack rebuilds, and concurrent callers would duplicate work.
 
-**Decision.** Guard rebuilds with a `flock` on `refresh.lock`. Debounce dirty-worktree rebuilds against a fingerprint + timestamp in `refresh_state.json` (default 5s, `ORBIT_KNOWLEDGE_REFRESH_DEBOUNCE_SECS`). Concurrent callers wait briefly for the in-flight rebuild rather than starting their own.
+**Decision.** Guard rebuilds with a `flock` on `refresh.lock`. Debounce dirty-worktree rebuilds against a fingerprint + timestamp in `refresh_state.json` (default 5s, `ORBIT_KNOWLEDGE_REFRESH_DEBOUNCE_SECS`). Freshness also requires the current branch ref to exist, so debounce cannot suppress the first build for a missing branch ref. Concurrent callers wait briefly for the in-flight rebuild rather than starting their own.
 
 **Consequences.**
 - Steady-state read cost on a dirty worktree is one rebuild per debounce window, not one per read.
@@ -404,5 +404,6 @@ Tasks cited by ADRs above:
 - **[T20260428-1]** — Align graph task-ID attribution/search with current unpadded task IDs.
 - **[T20260428-3]** — Expose the full read-only graph tool set through the MCP safe surface for Codex and Gemini.
 - **[T20260430-22]** — Compact the knowledge-graph design docs and fold the obsolete evidence log into ADR-018.
+- **[T20260505-1]** — Require auto-refresh freshness checks to materialize missing current-branch graph refs before returning fresh.
 
 Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.


### PR DESCRIPTION
## Tasks
- [T20260505-1] Rebuild missing branch graph refs during freshness checks
  <details><summary>Execution Summary</summary>

## Status
success

## Summary of Changes
- Made `compute_refresh_plan` branch-ref aware for clean worktrees: an existing manifest no longer allows `Fresh` unless the current branch graph ref exists.
- Added a branch-ref regression test that proves an old feature HEAD with only the default ref present rebuilds, writes `refs/heads/feature/missing-refresh.json`, reads without fallback, and still debounces dirty refreshes after the branch ref exists.
- Updated the knowledge-graph decisions doc for the branch-ref/refresh behavior under [T20260505-1].

## Validation
- `make fmt`
- `cargo test -p orbit-knowledge branch_refs`
- `cargo test -p orbit-knowledge --test branch_refs`
- `make build`

## Overall Assessment
The change is narrowly scoped to freshness planning and preserves direct read-time fallback semantics while ensuring auto-refresh materializes missing branch refs before treating the graph as fresh.

  </details>

## Branch Freshness
- Base ref: `origin/agent-main`
- Head ref: `orbit/T20260505-1-69f939c6`
- Behind base: 0
- Ahead of base: 1

## Files Changed
- `crates/orbit-knowledge/src/pipeline/mod.rs`
- `crates/orbit-knowledge/tests/branch_refs.rs`
- `docs/design/knowledge-graph/4_decisions.md`

*authored by: gpt-5.5*