### PR TITLE
Allow accepted friction tasks in auto-backlog listing

### DIFF
--- a/crates/orbit-core/assets/activities/list_backlog_tasks.yaml
+++ b/crates/orbit-core/assets/activities/list_backlog_tasks.yaml
@@ -7,12 +7,13 @@ spec:
   description: >
     Materialize the current workspace backlog as an ordered task list for
     the auto-pipeline. In automatic mode it
-    filters to `status: backlog`, excludes `type: friction` (per CLAUDE.md,
-    friction is reserved for agent self-reports, not shippable work), and
+    filters to `status: backlog`, including accepted friction reports whose
+    `type` remains `friction` while leaving untriaged `status: friction`
+    reports out, and
     drops any backlog parent/subtask group whose `context_files` overlap the
     active task-lock surface from `in-progress` or `review` tasks. Automatic
     mode includes an `excluded` array that attributes those pre-gate lock
-    exclusions; it does not report friction filtering or `max_tasks`
+    exclusions; it does not report status-based admission or `max_tasks`
     truncation. Explicit `task_ids` input is treated as an override, skips
     conflict filtering, and omits `excluded`.
     Sorts critical → high → medium → low, then by `created_at` ascending so

--- a/crates/orbit-core/src/runtime/v2_host.rs
+++ b/crates/orbit-core/src/runtime/v2_host.rs
@@ -184,13 +184,13 @@ impl V2RuntimeHost for OrbitRuntime {
                 }))
             }
             // Materialize the workspace backlog for auto-dispatch.
-            // Filters `status: backlog`, excludes `type: friction`
-            // (per CLAUDE.md: friction is reserved for agent self-reports,
-            // not shippable work), and in automatic mode drops any backlog
-            // task group whose context overlaps files already held by
-            // `in-progress`/`review` tasks. Sorts critical → high → medium →
-            // low then by `created_at` ascending so older high-priority work
-            // ships first. Caps at `max_tasks` (default 50).
+            // Filters by `status: backlog`; accepted friction reports keep
+            // `type: friction` and ship like other backlog tasks, while
+            // untriaged `status: friction` reports remain absent. In automatic
+            // mode, drops any backlog task group whose context overlaps files
+            // already held by `in-progress`/`review` tasks. Sorts critical →
+            // high → medium → low then by `created_at` ascending so older
+            // high-priority work ships first. Caps at `max_tasks` (default 50).
             "list_backlog_tasks" => {
                 let max_tasks = input
                     .get("max_tasks")
@@ -221,9 +221,7 @@ impl V2RuntimeHost for OrbitRuntime {
                     let lock_holders = active_task_lock_holders(task_lookup.values());
                     let mut backlog: Vec<Task> = all_tasks
                         .into_iter()
-                        .filter(|task| {
-                            task.status == TaskStatus::Backlog && !task.task_type.is_friction()
-                        })
+                        .filter(|task| task.status == TaskStatus::Backlog)
                         .collect();
                     backlog.sort_by(|a, b| {
                         let rank = |p: orbit_common::types::TaskPriority| match p {
@@ -1489,6 +1487,30 @@ mod tests {
             .expect("seed task")
     }
 
+    fn seed_accepted_friction_task(
+        runtime: &OrbitRuntime,
+        title: &str,
+        priority: TaskPriority,
+        context_files: Vec<&str>,
+    ) -> Task {
+        let report = seed_list_backlog_task(
+            runtime,
+            title,
+            TaskStatus::Friction,
+            priority,
+            TaskType::Friction,
+            None,
+            context_files,
+        );
+        runtime
+            .approve_task(
+                &report.id,
+                Some("Accepted friction report.".to_string()),
+                None,
+            )
+            .expect("accept friction task")
+    }
+
     fn list_backlog_tasks(runtime: &OrbitRuntime, input: Value) -> Value {
         runtime
             .run_deterministic(
@@ -1559,6 +1581,67 @@ mod tests {
             ])
         );
         assert_eq!(output["excluded"], json!([]));
+    }
+
+    #[test]
+    fn list_backlog_tasks_includes_accepted_friction_reports() {
+        let (_root, runtime, repo_root) = runtime_with_workspace_layout();
+        write_workspace_file(&repo_root, "crates/friction/src/lib.rs");
+        let friction = seed_accepted_friction_task(
+            &runtime,
+            "Accepted friction",
+            TaskPriority::Medium,
+            vec!["crates/friction/src/lib.rs"],
+        );
+
+        let output = list_backlog_tasks(&runtime, json!({}));
+
+        assert_eq!(output["task_count"], json!(1));
+        assert_eq!(output["task_ids"], json!([friction.id]));
+        assert_eq!(output["bundles"], json!([[friction.id]]));
+        assert_eq!(
+            output["tasks"],
+            json!([{
+                "id": friction.id,
+                "title": "Accepted friction",
+                "type": "friction",
+                "priority": "medium",
+                "context_files": friction.context_files,
+                "parent_id": null
+            }])
+        );
+        assert_eq!(output["excluded"], json!([]));
+    }
+
+    #[test]
+    fn list_backlog_tasks_omits_untriaged_friction_reports() {
+        let (_root, runtime, repo_root) = runtime_with_workspace_layout();
+        write_workspace_file(&repo_root, "crates/friction/src/lib.rs");
+        let friction = seed_list_backlog_task(
+            &runtime,
+            "Untriaged friction",
+            TaskStatus::Friction,
+            TaskPriority::Medium,
+            TaskType::Friction,
+            None,
+            vec!["crates/friction/src/lib.rs"],
+        );
+        let friction_id = friction.id.clone();
+
+        let output = list_backlog_tasks(&runtime, json!({}));
+
+        assert_eq!(output["task_count"], json!(0));
+        assert_eq!(output["task_ids"], json!([]));
+        assert_eq!(output["tasks"], json!([]));
+        assert_eq!(output["bundles"], json!([]));
+        assert_eq!(output["excluded"], json!([]));
+        assert!(
+            output["task_ids"]
+                .as_array()
+                .expect("task_ids")
+                .iter()
+                .all(|task_id| task_id != &json!(friction_id))
+        );
     }
 
     #[test]
@@ -1695,7 +1778,46 @@ mod tests {
     }
 
     #[test]
-    fn list_backlog_tasks_does_not_report_friction_tasks_as_excluded() {
+    fn list_backlog_tasks_reports_accepted_friction_context_lock_conflicts() {
+        let (_root, runtime, repo_root) = runtime_with_workspace_layout();
+        write_workspace_file(&repo_root, "crates/friction/src/lib.rs");
+        let locking = seed_list_backlog_task(
+            &runtime,
+            "Locking task",
+            TaskStatus::InProgress,
+            TaskPriority::Medium,
+            TaskType::Task,
+            None,
+            vec!["crates/friction/src/lib.rs"],
+        );
+        let friction = seed_accepted_friction_task(
+            &runtime,
+            "Accepted friction",
+            TaskPriority::Medium,
+            vec!["crates/friction/src/lib.rs"],
+        );
+
+        let output = list_backlog_tasks(&runtime, json!({}));
+
+        assert_eq!(output["task_count"], json!(0));
+        assert_eq!(output["task_ids"], json!([]));
+        assert_eq!(output["tasks"], json!([]));
+        assert_eq!(output["bundles"], json!([]));
+        assert_eq!(
+            output["excluded"],
+            json!([{
+                "id": friction.id,
+                "reason": "context_lock_conflict",
+                "conflicts": [{
+                    "requested_file": friction.context_files[0],
+                    "locking_task_id": locking.id
+                }]
+            }])
+        );
+    }
+
+    #[test]
+    fn list_backlog_tasks_does_not_report_untriaged_friction_tasks_as_excluded() {
         let (_root, runtime, repo_root) = runtime_with_workspace_layout();
         write_workspace_file(&repo_root, "crates/foo/src/lib.rs");
         let locking = seed_list_backlog_task(

--- a/docs/design/activity-job/2_design.md
+++ b/docs/design/activity-job/2_design.md
@@ -125,7 +125,7 @@ Some module comments still describe older phase ordering; the authoritative beha
 
 Seeded direct shipment workflows (`task_local_pipeline` and `task_pr_pipeline`) opt into `recovery_activity: step_failure_recovery` on specific steps after [T20260430-14]. The CLI-backed recovery agent receives only the executor-provided recovery keys, inspects the failed step, makes bounded repairs when safe, and returns before the executor's single post-recovery attempt. Higher-level orchestration workflows do not enable the hook because replaying child-run dispatch or planning orchestration is not a safe default recovery action.
 
-The seeded `list_backlog_tasks` deterministic activity starts `task_auto_pipeline`. Automatic mode emits `task_count`, `task_ids`, `tasks`, singleton `bundles`, and an `excluded` array for backlog tasks filtered because their context files overlap `in-progress` or `review` locks. `excluded` covers only lock overlap; friction filtering and `max_tasks` truncation stay silent, and explicit `task_ids` mode omits it. This attribution contract was added in [T20260421-0542-2].
+The seeded `list_backlog_tasks` deterministic activity starts `task_auto_pipeline`. Automatic mode admits tasks by `status: backlog`, including accepted friction reports whose `type` remains `friction`, while untriaged `status: friction` reports stay out. It emits `task_count`, `task_ids`, `tasks`, singleton `bundles`, and an `excluded` array for admitted backlog tasks filtered because their context files overlap `in-progress` or `review` locks. `excluded` covers only lock overlap; status-based admission and `max_tasks` truncation stay silent, and explicit `task_ids` mode omits it. This attribution contract was added in [T20260421-0542-2] and the friction admission rule was updated in [T20260505-2].
 
 `task_gate_pipeline` reserves a bundle's context files before it dispatches `task_pr_pipeline` or `task_local_pipeline` through `invoke_and_wait`. The reservation remains active for the whole child run, so another gate run with overlapping selectors continues to receive a `reservation` conflict while the child is running. After `invoke_and_wait` returns a terminal child-run status (`succeeded`, `failed`, or `cancelled`), the seeded deterministic `release_locks` activity calls `orbit.task.locks.release` with the recorded reservation id. A wait-side `timeout` does not release the reservation because the child run may still be active; the original TTL remains the abandoned/crashed-run cleanup path. This lifecycle was tightened in [T20260430-26].
 
@@ -453,5 +453,6 @@ Read-only history does not need the same dependencies as live execution. [T20260
 - **[T20260430-27]** — Make `ship-auto` output distinguish empty backlog, gated no-op, and waiting gate children.
 - **[T20260430-30]** — Make `ship-auto` default text output human-readable while preserving JSON fields.
 - **[T20260430-31]** — Require populated execution summaries before opening task PRs.
+- **[T20260505-2]** — Admit accepted backlog friction reports in automatic backlog listing.
 
 > Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.

--- a/docs/design/activity-job/4_decisions.md
+++ b/docs/design/activity-job/4_decisions.md
@@ -2,7 +2,7 @@
 
 **Status:** Draft
 **Owner:** codex
-**Last updated:** 2026-05-05 (ADR-036 task PR summaries)
+**Last updated:** 2026-05-05 (ADR-037 accepted friction backlog admission)
 
 This ADR log records the decisions that define the current Activity / Job substrate. Entries are append-only and stay in place when later ADRs supersede them. See [1_overview.md](./1_overview.md) for the feature summary, [2_design.md](./2_design.md) for the current implementation, and [3_vision.md](./3_vision.md) for the questions that may force more decisions.
 
@@ -442,7 +442,7 @@ This ADR log records the decisions that define the current Activity / Job substr
 
 **Consequences.**
 - Auto-dispatch traces now contain a durable pre-gate reason for lock-overlap exclusions without changing the existing `task_count`, `task_ids`, `tasks`, or `bundles` fields.
-- The output deliberately does not attribute friction filtering or `max_tasks` truncation, keeping `excluded` scoped to context-lock behavior.
+- The output deliberately does not attribute status-based admission or `max_tasks` truncation, keeping `excluded` scoped to context-lock behavior.
 - Cost: the Rust serializer and seeded activity YAML schema now duplicate the exclusion shape and must be kept in sync.
 
 ## ADR-034 — `ship-auto` reports operator workflow status from durable pipeline state
@@ -484,6 +484,19 @@ This ADR log records the decisions that define the current Activity / Job substr
 - A task-shipment PR cannot be opened until every participating task has a durable implementation handoff on the task record.
 - Multi-task bundles include one populated summary per completed task in generated PR bodies.
 - Cost: manual or custom-body shipment paths must still persist task summaries before opening the PR, even when the caller already prepared a complete body.
+
+## ADR-037 — Accepted friction reports enter auto-backlog by status
+
+**Status:** Accepted · 2026-05 · [T20260505-2]
+
+**Context.** Friction reports keep `type: friction` for lifecycle history and friction-bounty accounting even after triage accepts them into `status: backlog`. `list_backlog_tasks` previously filtered automatic mode by both `status: backlog` and `type != friction`, so accepted friction work could only ship through explicit task IDs or manual paths.
+
+**Decision.** Make automatic `list_backlog_tasks` admission status-only: `status: backlog` tasks are candidates regardless of type, while untriaged `status: friction` reports remain absent because they are not backlog. Accepted friction reports participate in the same context-lock exclusion pass as any other backlog task, and explicit `task_ids` override mode remains unchanged.
+
+**Consequences.**
+- Accepted friction work can move through `task_auto_pipeline` without losing its `type: friction` audit and scoreboard identity.
+- The `excluded` array remains scoped to context-lock conflicts; it reports accepted friction tasks only when they are otherwise admitted backlog candidates and overlap active locks.
+- Cost: reviewers must read friction eligibility as a status rule, not a task-type rule.
 
 ---
 
@@ -532,5 +545,6 @@ This ADR log records the decisions that define the current Activity / Job substr
 - **[T20260430-27]** — Make `ship-auto` output distinguish empty backlog, gated no-op, and waiting gate children.
 - **[T20260430-30]** — Make `ship-auto` default text output human-readable while preserving JSON fields.
 - **[T20260430-31]** — Require populated execution summaries before opening task PRs.
+- **[T20260505-2]** — Admit accepted backlog friction reports in automatic backlog listing.
 
 > Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.


### PR DESCRIPTION
## Tasks
- [T20260505-2] Allow accepted friction tasks in auto-backlog listing
  <details><summary>Execution Summary</summary>

## Status
success

## Summary of Changes
- Changed automatic `list_backlog_tasks` admission to filter only by `status: backlog`, allowing accepted `type: friction` tasks to be listed while leaving `status: friction` reports out.
- Added focused orbit-core coverage for accepted friction inclusion in `tasks`, `task_ids`, and `bundles`; untriaged friction omission; and accepted friction lock exclusions.
- Updated the seeded activity YAML plus Activity / Job design docs and ADR log with [T20260505-2].

## Overall Assessment
The change is narrow and preserves the existing lock-exclusion contract while aligning automatic backlog selection with friction lifecycle semantics.

## Validation
- `cargo test -p orbit-core list_backlog_tasks`
- `make fmt`
- `make build`

  </details>

## Branch Freshness
- Base ref: `origin/agent-main`
- Head ref: `orbit/T20260505-2-69f93d8a`
- Behind base: 0
- Ahead of base: 1

## Files Changed
- `crates/orbit-core/assets/activities/list_backlog_tasks.yaml`
- `crates/orbit-core/src/runtime/v2_host.rs`
- `docs/design/activity-job/2_design.md`
- `docs/design/activity-job/4_decisions.md`

*authored by: gpt-5.5*