### PR TITLE
Add dashboard controls to cancel active job runs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1553,6 +1553,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "toml",
+ "tower",
 ]
 
 [[package]]

--- a/crates/orbit-cli/Cargo.toml
+++ b/crates/orbit-cli/Cargo.toml
@@ -33,3 +33,4 @@ serde_json.workspace = true
 serde_yaml.workspace = true
 tempfile = "3"
 toml.workspace = true
+tower = { version = "0.5", features = ["util"] }

--- a/crates/orbit-cli/assets/dashboard/app.js
+++ b/crates/orbit-cli/assets/dashboard/app.js
@@ -25,6 +25,7 @@ const AUDIT_LIMIT = positiveIntParam("audit", 50);
 const RUN_EVENTS_LIMIT = positiveIntParam("events", 100);
 
 const AUDIT_STATUSES = ["success", "failure", "denied"];
+const CANCELLABLE_RUN_STATES = new Set(["pending", "running"]);
 
 const $ = (id) => document.getElementById(id);
 
@@ -112,6 +113,64 @@ function fetchJson(path) {
       if (!res.ok) throw new Error(`${path}: HTTP ${res.status}`);
       return res.json();
     });
+}
+
+function postJson(path) {
+  return fetch(path, {
+    method: "POST",
+    headers: { accept: "application/json" },
+  }).then(async (res) => {
+    const text = await res.text();
+    const body = text ? JSON.parse(text) : {};
+    if (!res.ok) {
+      throw new Error(body.error || `${path}: HTTP ${res.status}`);
+    }
+    return body;
+  });
+}
+
+function runIsCancellable(run) {
+  return CANCELLABLE_RUN_STATES.has(run && run.state);
+}
+
+function buildCancelRunButton(run, host) {
+  const btn = el("button", {
+    class: "action reject run-cancel",
+    text: "cancel",
+    title: `Cancel ${run.run_id}`,
+  });
+  btn.disabled = !runIsCancellable(run);
+  btn.addEventListener("click", (e) => {
+    e.stopPropagation();
+    cancelRun(run.run_id, btn, host);
+  });
+  return btn;
+}
+
+async function cancelRun(runId, btn, host) {
+  if (!runId) return;
+  const old = btn.textContent;
+  btn.disabled = true;
+  btn.innerHTML = `<span class="spinner"></span>cancel`;
+  if (host) {
+    for (const node of host.querySelectorAll(".action-error")) node.remove();
+  }
+  try {
+    await postJson(`/api/runs/${encodeURIComponent(runId)}/cancel`);
+    await Promise.all([
+      fetchAndRenderRuns(),
+      activeRunId === runId ? fetchAndRenderRunDetail() : Promise.resolve(),
+      activeRunId === runId ? fetchAndRenderRunEvents() : Promise.resolve(),
+    ]);
+  } catch (e) {
+    if (host) {
+      host.appendChild(el("div", { class: "action-error", text: e.message || "cancel failed" }));
+    }
+    console.error(e);
+  } finally {
+    btn.disabled = false;
+    btn.textContent = old;
+  }
 }
 
 function syncNodes(container, newNodesArr) {
@@ -556,6 +615,7 @@ function renderRuns(runs) {
     el("span", { text: "run id" }),
     el("span", { text: "duration", style: { textAlign: "right" } }),
     el("span", { text: "state", style: { textAlign: "right" } }),
+    el("span", { text: "" }),
   ]);
   header.dataset.key = "runs-header";
   header.dataset.hash = "header";
@@ -580,6 +640,7 @@ function renderRuns(runs) {
       runIdSpan,
       el("span", { class: "duration", text: fmtDuration(r.duration_ms) }),
       el("span", { class: "state" }, [stateCell(r.state)]),
+      el("span", { class: "run-actions" }, runIsCancellable(r) ? [buildCancelRunButton(r, body)] : []),
     ]);
     row.dataset.key = `run-${r.run_id}`;
     row.dataset.hash = `${r.run_id}-${ts}-${r.duration_ms}-${r.state}`;
@@ -1138,42 +1199,16 @@ function activeRefreshJobs() {
       renderRunDetailEmpty("No run selected.");
       return jobs;
     }
-    jobs.push(
-      fetchJson(`/api/runs/${encodeURIComponent(activeRunId)}`).then((data) => {
-        activeRunDetail = data;
-        renderRunDetailMeta();
-        renderRunKnowledge();
-        renderRunGantt();
-        renderRunSteps();
-      }).catch((e) => {
-        renderRunDetailEmpty(`Run not found: ${activeRunId}`);
-        throw e;
-      }),
-    );
+    jobs.push(fetchAndRenderRunDetail());
     // Events power both the Events sub-tab and the Gantt's retry markers, so
     // they're fetched on every run-detail refresh regardless of which sub-tab
     // is active.
-    jobs.push(
-      fetchJson(`/api/runs/${encodeURIComponent(activeRunId)}/events?limit=${RUN_EVENTS_LIMIT}`).then((events) => {
-        activeRunEvents = events;
-        renderRunEvents();
-        renderRunGantt();
-      }).catch(() => {
-        // Missing v2 events file is non-fatal — run detail still renders.
-        activeRunEvents = [];
-        renderRunGantt();
-      }),
-    );
+    jobs.push(fetchAndRenderRunEvents());
     return jobs;
   }
 
   if (activeDiagSubtab === "runs") {
-    jobs.push(
-      fetchJson(`/api/job-runs?limit=${JOB_RUN_LIMIT}`).then((runs) => {
-        lastRuns = runs;
-        renderRuns(runs);
-      }),
-    );
+    jobs.push(fetchAndRenderRuns());
     return jobs;
   }
 
@@ -1194,6 +1229,40 @@ function activeRefreshJobs() {
     }),
   );
   return jobs;
+}
+
+function fetchAndRenderRuns() {
+  return fetchJson(`/api/job-runs?limit=${JOB_RUN_LIMIT}`).then((runs) => {
+    lastRuns = runs;
+    renderRuns(runs);
+  });
+}
+
+function fetchAndRenderRunDetail() {
+  if (!activeRunId) return Promise.resolve();
+  return fetchJson(`/api/runs/${encodeURIComponent(activeRunId)}`).then((data) => {
+    activeRunDetail = data;
+    renderRunDetailMeta();
+    renderRunKnowledge();
+    renderRunGantt();
+    renderRunSteps();
+  }).catch((e) => {
+    renderRunDetailEmpty(`Run not found: ${activeRunId}`);
+    throw e;
+  });
+}
+
+function fetchAndRenderRunEvents() {
+  if (!activeRunId) return Promise.resolve();
+  return fetchJson(`/api/runs/${encodeURIComponent(activeRunId)}/events?limit=${RUN_EVENTS_LIMIT}`).then((events) => {
+    activeRunEvents = events;
+    renderRunEvents();
+    renderRunGantt();
+  }).catch(() => {
+    // Missing v2 events file is non-fatal — run detail still renders.
+    activeRunEvents = [];
+    renderRunGantt();
+  });
 }
 
 function fetchAndRenderAudit() {
@@ -1657,7 +1726,9 @@ function renderRunDetailMeta() {
   const wrap = el("div");
   const back = el("button", { class: "back-action", text: "← back to runs" });
   back.addEventListener("click", () => setActiveTab("diagnostics/runs"));
-  wrap.appendChild(el("div", { style: { padding: "8px 16px 0 16px" } }, [back]));
+  const actions = el("div", { class: "run-detail-actions" }, [back]);
+  if (runIsCancellable(run)) actions.appendChild(buildCancelRunButton(run, wrap));
+  wrap.appendChild(actions);
   wrap.appendChild(grid);
   syncNodes(meta, [wrap]);
 }

--- a/crates/orbit-cli/assets/dashboard/index.html
+++ b/crates/orbit-cli/assets/dashboard/index.html
@@ -44,6 +44,7 @@
         --state-pending: #f59e0b;
         --state-failed: #ef4444;
         --state-error: #ef4444;
+        --state-cancelled: #f87171;
         --state-disabled: #52525b;
       }
       
@@ -684,7 +685,7 @@
       
       .runs-row {
         display: grid;
-        grid-template-columns: 80px 1fr minmax(100px, 0.6fr) 70px 80px;
+        grid-template-columns: 80px 1fr minmax(100px, 0.6fr) 70px 80px 72px;
         gap: 12px;
         padding: 8px 16px;
         font-family: var(--font-mono);
@@ -710,6 +711,17 @@
       .runs-row .run-id:hover { color: var(--accent); }
       .runs-row .duration { color: var(--fg-dim); text-align: right; }
       .runs-row .state { text-align: right; }
+      .runs-row .run-actions {
+        display: flex;
+        justify-content: flex-end;
+        min-height: 26px;
+      }
+      .runs-row .run-actions .action {
+        font-family: var(--font-mono);
+        font-size: 10px;
+        padding: 4px 8px;
+        border-radius: 2px;
+      }
       .runs-row.runs-header {
         color: var(--fg-dim);
         font-size: 10px;
@@ -1009,6 +1021,14 @@
       .back-action:hover {
         color: var(--fg);
         border-color: var(--fg-dim);
+      }
+
+      .run-detail-actions {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        padding: 8px 16px 0 16px;
+        flex-wrap: wrap;
       }
       
       @keyframes highlight-changed {

--- a/crates/orbit-cli/src/command/web/api.rs
+++ b/crates/orbit-cli/src/command/web/api.rs
@@ -218,6 +218,7 @@ pub(super) fn router() -> Router<Arc<OrbitRuntime>> {
         .route("/jobs", get(list_jobs))
         .route("/job-runs", get(list_job_runs))
         .route("/runs/:id", get(get_run))
+        .route("/runs/:id/cancel", post(cancel_run_action))
         .route("/runs/:id/events", get(list_run_events))
         .route("/audit", get(list_audit))
         .route("/log", get(get_log))
@@ -744,9 +745,13 @@ impl Stream for ReceiverSseStream {
 #[cfg(test)]
 mod tests {
     use std::io::Write;
+    use std::sync::Arc;
 
+    use axum::body::to_bytes;
+    use axum::http::Method;
     use serde_json::json;
     use tempfile::tempdir;
+    use tower::ServiceExt;
 
     use super::*;
 
@@ -757,6 +762,144 @@ mod tests {
             content.push('\n');
         }
         std::fs::write(path, content).expect("write fixture");
+    }
+
+    fn seed_run(runtime: &OrbitRuntime, run_id: &str, job_id: &str, state: JobRunState) -> JobRun {
+        #[derive(serde::Serialize)]
+        #[serde(rename_all = "camelCase")]
+        struct JobRunDoc<'a> {
+            schema_version: u8,
+            run: &'a JobRun,
+        }
+
+        let now = Utc::now();
+        let run = JobRun {
+            run_id: run_id.to_string(),
+            job_id: job_id.to_string(),
+            attempt: 1,
+            state,
+            scheduled_at: now,
+            started_at: matches!(
+                state,
+                JobRunState::Running
+                    | JobRunState::Success
+                    | JobRunState::Failed
+                    | JobRunState::Timeout
+                    | JobRunState::Cancelled
+            )
+            .then_some(now),
+            finished_at: state.is_terminal().then_some(now),
+            duration_ms: state.is_terminal().then_some(0),
+            created_at: now,
+            pid: None,
+            pid_start_time: None,
+            input: None,
+            retry_source_run_id: None,
+            knowledge_metrics: None,
+            steps: Vec::new(),
+        };
+        let run_dir = runtime
+            .data_root()
+            .join("state")
+            .join("job-runs")
+            .join(job_id)
+            .join(run_id);
+        std::fs::create_dir_all(&run_dir).expect("create run dir");
+        let content = serde_yaml::to_string(&JobRunDoc {
+            schema_version: 1,
+            run: &run,
+        })
+        .expect("serialize run yaml");
+        std::fs::write(run_dir.join("jrun.yaml"), content).expect("write run yaml");
+        run
+    }
+
+    async fn body_json(response: Response) -> Value {
+        let bytes = to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("read response body");
+        serde_json::from_slice(&bytes).expect("json response")
+    }
+
+    async fn request_cancel(runtime: OrbitRuntime, run_id: &str, origin: Option<&str>) -> Response {
+        let mut builder = Request::builder()
+            .method(Method::POST)
+            .uri(format!("/runs/{run_id}/cancel"));
+        if let Some(origin) = origin {
+            builder = builder.header(header::ORIGIN, origin);
+        }
+        router()
+            .with_state(Arc::new(runtime))
+            .oneshot(builder.body(Body::empty()).expect("request"))
+            .await
+            .expect("response")
+    }
+
+    #[tokio::test]
+    async fn cancel_run_endpoint_cancels_pending_run() {
+        let runtime = OrbitRuntime::in_memory().expect("build runtime");
+        let run = seed_run(
+            &runtime,
+            "jrun-web-cancel-pending",
+            "web_cancel_pending",
+            JobRunState::Pending,
+        );
+
+        let response =
+            request_cancel(runtime.clone(), &run.run_id, Some("http://localhost:3000")).await;
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let payload = body_json(response).await;
+        assert_eq!(payload["run_id"], run.run_id);
+        assert_eq!(payload["previous_state"], "pending");
+        assert_eq!(payload["final_state"], "cancelled");
+        assert_eq!(payload["signal_attempted"], false);
+        assert_eq!(payload["signal_outcome"], Value::Null);
+        let stored = runtime.show_job_run(&run.run_id).expect("show cancelled");
+        assert_eq!(stored.state, JobRunState::Cancelled);
+    }
+
+    #[tokio::test]
+    async fn cancel_run_endpoint_rejects_terminal_run_without_mutating_bundle() {
+        let runtime = OrbitRuntime::in_memory().expect("build runtime");
+        let run = seed_run(
+            &runtime,
+            "jrun-web-cancel-terminal",
+            "web_cancel_terminal",
+            JobRunState::Success,
+        );
+        let before = runtime.show_job_run(&run.run_id).expect("show before");
+
+        let response =
+            request_cancel(runtime.clone(), &run.run_id, Some("http://localhost:3000")).await;
+
+        assert_eq!(response.status(), StatusCode::CONFLICT);
+        let payload = body_json(response).await;
+        assert!(
+            payload["error"]
+                .as_str()
+                .is_some_and(|message| message.contains("cannot cancel job run"))
+        );
+        let after = runtime.show_job_run(&run.run_id).expect("show after");
+        assert_eq!(after, before);
+    }
+
+    #[tokio::test]
+    async fn cancel_run_endpoint_applies_localhost_origin_guard() {
+        let runtime = OrbitRuntime::in_memory().expect("build runtime");
+        let run = seed_run(
+            &runtime,
+            "jrun-web-cancel-origin",
+            "web_cancel_origin",
+            JobRunState::Pending,
+        );
+
+        let response =
+            request_cancel(runtime.clone(), &run.run_id, Some("https://example.test")).await;
+
+        assert_eq!(response.status(), StatusCode::FORBIDDEN);
+        let stored = runtime.show_job_run(&run.run_id).expect("show run");
+        assert_eq!(stored.state, JobRunState::Pending);
     }
 
     #[test]
@@ -1025,6 +1168,29 @@ mod tests {
 async fn get_run(State(runtime): State<Arc<OrbitRuntime>>, Path(id): Path<String>) -> Response {
     match runtime.show_job_run(&id) {
         Ok(run) => Json(job_run_detail_to_json(&runtime, &run)).into_response(),
+        Err(e) => map_runtime_error(e),
+    }
+}
+
+async fn cancel_run_action(
+    State(runtime): State<Arc<OrbitRuntime>>,
+    Path(id): Path<String>,
+) -> Response {
+    match runtime.cancel_job_run_with_context(&id, "dashboard", "web") {
+        Ok(result) => Json(json!({
+            "run_id": result.run_id,
+            "previous_state": result.previous_state,
+            "final_state": result.final_state,
+            "actor": result.actor,
+            "source": result.source,
+            "signal_attempted": result.signal_attempted,
+            "signal_outcome": result.signal_outcome,
+        }))
+        .into_response(),
+        Err(orbit_core::OrbitError::JobValidation(msg))
+        | Err(orbit_core::OrbitError::JobRunStateTransition(msg)) => {
+            (StatusCode::CONFLICT, Json(json!({ "error": msg }))).into_response()
+        }
         Err(e) => map_runtime_error(e),
     }
 }

--- a/crates/orbit-common/src/types/event.rs
+++ b/crates/orbit-common/src/types/event.rs
@@ -62,6 +62,18 @@ pub enum OrbitEvent {
     JobRunCancelled {
         job_id: String,
         run_id: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        previous_state: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        final_state: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        actor: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        source: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        signal_attempted: Option<bool>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        signal_outcome: Option<String>,
     },
     JobRunDeleted {
         job_id: String,

--- a/crates/orbit-core/src/command/job_run.rs
+++ b/crates/orbit-core/src/command/job_run.rs
@@ -1,11 +1,16 @@
 use chrono::{DateTime, Utc};
-use orbit_common::types::{JobRun, JobRunState, OrbitError, OrbitEvent};
+use orbit_common::types::{JobRun, JobRunState, OrbitError, OrbitEvent, PipelineState};
 use orbit_store::JobRunQuery;
+use serde::Serialize;
 use serde_json::Value;
 use std::fs;
 use std::path::Path;
 #[cfg(unix)]
 use std::process::Command;
+#[cfg(unix)]
+use std::thread;
+#[cfg(unix)]
+use std::time::{Duration, Instant};
 
 use crate::OrbitRuntime;
 
@@ -17,9 +22,31 @@ pub struct JobRunListParams {
     pub limit: Option<usize>,
 }
 
+#[derive(Debug, Clone, Serialize)]
+pub struct JobRunCancelResult {
+    pub run_id: String,
+    pub previous_state: String,
+    pub final_state: String,
+    pub actor: String,
+    pub source: String,
+    pub signal_attempted: bool,
+    pub signal_outcome: Option<String>,
+}
+
 impl OrbitRuntime {
-    pub fn cancel_job_run(&self, run_id: &str) -> Result<(), OrbitError> {
-        let run = self.show_job_run(run_id)?;
+    pub fn cancel_job_run(&self, run_id: &str) -> Result<JobRunCancelResult, OrbitError> {
+        self.cancel_job_run_with_context(run_id, "system", "runtime")
+    }
+
+    pub fn cancel_job_run_with_context(
+        &self,
+        run_id: &str,
+        actor: &str,
+        source: &str,
+    ) -> Result<JobRunCancelResult, OrbitError> {
+        let run = self
+            .get_job_run_backend(run_id)?
+            .ok_or_else(|| OrbitError::JobRunNotFound(run_id.to_string()))?;
         run.state
             .try_transition(orbit_common::types::RunEvent::Cancel)
             .map_err(|msg| {
@@ -29,21 +56,54 @@ impl OrbitRuntime {
         let duration_ms = run
             .started_at
             .map(|s| now.signed_duration_since(s).num_milliseconds().max(0) as u64);
-        let should_signal_owner = run_owner_identity_matches(&run);
-        let owner_pid = run.pid;
+        let signal_attempted = run.state == JobRunState::Running && run.pid.is_some();
         self.stores()
             .jobs()
             .finalize_run(run_id, JobRunState::Cancelled, now, duration_ms)?;
-        self.record_event(OrbitEvent::JobRunCancelled {
-            job_id: run.job_id,
-            run_id: run_id.to_string(),
-        })?;
-        if let Some(pid) = owner_pid
-            && should_signal_owner
-        {
-            signal_run_owner_process(pid)?;
+        let cancelled_run = self
+            .get_job_run_backend(run_id)?
+            .ok_or_else(|| OrbitError::JobRunNotFound(run_id.to_string()))?;
+        if cancelled_run.state != JobRunState::Cancelled {
+            let detail = cancelled_run
+                .state
+                .try_transition(orbit_common::types::RunEvent::Cancel)
+                .err()
+                .unwrap_or_else(|| {
+                    format!(
+                        "stored state remained {} after cancellation",
+                        cancelled_run.state
+                    )
+                });
+            return Err(OrbitError::JobValidation(format!(
+                "cannot cancel job run '{}': {}",
+                run_id, detail
+            )));
         }
-        Ok(())
+        self.mark_cancelled_pipeline_state(&cancelled_run)?;
+        let signal_outcome = if signal_attempted {
+            Some(signal_run_owner_process(&run)?)
+        } else {
+            None
+        };
+        self.record_event(OrbitEvent::JobRunCancelled {
+            job_id: run.job_id.clone(),
+            run_id: run_id.to_string(),
+            previous_state: Some(run.state.to_string()),
+            final_state: Some(JobRunState::Cancelled.to_string()),
+            actor: Some(actor.to_string()),
+            source: Some(source.to_string()),
+            signal_attempted: Some(signal_attempted),
+            signal_outcome: signal_outcome.clone(),
+        })?;
+        Ok(JobRunCancelResult {
+            run_id: run_id.to_string(),
+            previous_state: run.state.to_string(),
+            final_state: JobRunState::Cancelled.to_string(),
+            actor: actor.to_string(),
+            source: source.to_string(),
+            signal_attempted,
+            signal_outcome,
+        })
     }
 
     pub fn archive_job_run(&self, run_id: &str) -> Result<(), OrbitError> {
@@ -85,6 +145,45 @@ impl OrbitRuntime {
         run_id: &str,
     ) -> Result<Option<orbit_common::types::PipelineState>, OrbitError> {
         self.stores().jobs().read_run_state(run_id)
+    }
+
+    fn mark_cancelled_pipeline_state(&self, run: &JobRun) -> Result<(), OrbitError> {
+        if let Some(mut state) = self.read_run_state(&run.run_id)? {
+            if let Some(object) = state.pipeline.as_object_mut() {
+                object.insert(
+                    "status".to_string(),
+                    Value::String(JobRunState::Cancelled.to_string()),
+                );
+                object.insert(
+                    "state".to_string(),
+                    Value::String(JobRunState::Cancelled.to_string()),
+                );
+                object.insert("cancelled".to_string(), Value::Bool(true));
+            }
+            state.updated_at = Utc::now();
+            self.stores().jobs().write_run_state(&run.run_id, &state)?;
+        } else if run.input.is_some() {
+            let mut state = PipelineState::new(
+                run.run_id.clone(),
+                run.job_id.clone(),
+                run.input
+                    .clone()
+                    .unwrap_or_else(|| Value::Object(Default::default())),
+            );
+            if let Some(object) = state.pipeline.as_object_mut() {
+                object.insert(
+                    "status".to_string(),
+                    Value::String(JobRunState::Cancelled.to_string()),
+                );
+                object.insert(
+                    "state".to_string(),
+                    Value::String(JobRunState::Cancelled.to_string()),
+                );
+                object.insert("cancelled".to_string(), Value::Bool(true));
+            }
+            self.stores().jobs().write_run_state(&run.run_id, &state)?;
+        }
+        Ok(())
     }
 
     pub fn job_history(&self, job_id: &str) -> Result<Vec<JobRun>, OrbitError> {
@@ -298,31 +397,146 @@ impl OrbitRuntime {
 }
 
 #[cfg(unix)]
-fn signal_run_owner_process(pid: u32) -> Result<(), OrbitError> {
+const RUN_OWNER_TERMINATION_GRACE: Duration = Duration::from_secs(2);
+#[cfg(unix)]
+const RUN_OWNER_TERMINATION_POLL: Duration = Duration::from_millis(50);
+
+#[cfg(unix)]
+fn signal_run_owner_process(run: &JobRun) -> Result<String, OrbitError> {
+    let Some(pid) = run.pid else {
+        return Ok("no_pid".to_string());
+    };
     if pid == std::process::id() {
-        return Ok(());
+        return Ok("self_not_signalled".to_string());
+    }
+    if !run_owner_identity_matches(run) {
+        return Ok("owner_identity_mismatch".to_string());
     }
 
-    // Safety: `kill` only sends a signal to the run owner process so it can
-    // tear down its active child process tree.
-    let rc = unsafe { libc::kill(pid as libc::pid_t, libc::SIGTERM) };
+    let pgid = owner_process_group_id(pid);
+    if let Some(pgid) = pgid
+        && pgid > 1
+    {
+        if pgid == unsafe { libc::getpgrp() } {
+            return Ok("owner_process_group_matches_current_process".to_string());
+        }
+        match send_signal_to_process_group(pgid, libc::SIGTERM) {
+            Ok(()) => {}
+            Err(error) if error.raw_os_error() == Some(libc::ESRCH) => {
+                return Ok("already_exited".to_string());
+            }
+            Err(error) => {
+                return Err(OrbitError::Execution(format!(
+                    "failed to signal job run owner process group {pgid} for pid {pid}: {error}"
+                )));
+            }
+        }
+
+        if wait_for_process_group_exit(pgid, RUN_OWNER_TERMINATION_GRACE) {
+            return Ok("terminated_process_group".to_string());
+        }
+
+        match send_signal_to_process_group(pgid, libc::SIGKILL) {
+            Ok(()) => {}
+            Err(error) if error.raw_os_error() == Some(libc::ESRCH) => {
+                return Ok("terminated_process_group".to_string());
+            }
+            Err(error) => {
+                return Err(OrbitError::Execution(format!(
+                    "failed to kill job run owner process group {pgid} for pid {pid}: {error}"
+                )));
+            }
+        }
+        let _ = wait_for_process_group_exit(pgid, RUN_OWNER_TERMINATION_GRACE);
+        return Ok("killed_process_group".to_string());
+    }
+
+    // Fallback for platforms/configurations where the owner process group
+    // cannot be resolved. The PID identity guard above still protects against
+    // killing a reused PID.
+    send_signal_to_pid(pid, libc::SIGTERM)?;
+    if wait_for_owner_exit(pid, RUN_OWNER_TERMINATION_GRACE) {
+        Ok("terminated_owner".to_string())
+    } else {
+        send_signal_to_pid(pid, libc::SIGKILL)?;
+        let _ = wait_for_owner_exit(pid, RUN_OWNER_TERMINATION_GRACE);
+        Ok("killed_owner".to_string())
+    }
+}
+
+#[cfg(unix)]
+fn send_signal_to_pid(pid: u32, signal: libc::c_int) -> Result<(), OrbitError> {
+    let rc = unsafe { libc::kill(pid as libc::pid_t, signal) };
     if rc == 0 {
         return Ok(());
     }
-
     let err = std::io::Error::last_os_error();
     if err.raw_os_error() == Some(libc::ESRCH) {
         return Ok(());
     }
-
     Err(OrbitError::Execution(format!(
-        "failed to signal job run owner pid {pid}: {err}"
+        "failed to signal job run owner pid {pid}: {err}",
     )))
 }
 
 #[cfg(not(unix))]
-fn signal_run_owner_process(_pid: u32) -> Result<(), OrbitError> {
-    Ok(())
+fn signal_run_owner_process(_run: &JobRun) -> Result<String, OrbitError> {
+    Ok("unsupported_platform".to_string())
+}
+
+#[cfg(unix)]
+fn owner_process_group_id(pid: u32) -> Option<libc::pid_t> {
+    if pid == 0 || pid > i32::MAX as u32 {
+        return None;
+    }
+    let pgid = unsafe { libc::getpgid(pid as libc::pid_t) };
+    if pgid > 0 { Some(pgid) } else { None }
+}
+
+#[cfg(unix)]
+fn send_signal_to_process_group(pgid: libc::pid_t, signal: libc::c_int) -> std::io::Result<()> {
+    let rc = unsafe { libc::kill(-pgid, signal) };
+    if rc == 0 {
+        Ok(())
+    } else {
+        Err(std::io::Error::last_os_error())
+    }
+}
+
+#[cfg(unix)]
+fn wait_for_owner_exit(pid: u32, timeout: Duration) -> bool {
+    let started = Instant::now();
+    while started.elapsed() < timeout {
+        if !process_is_alive(pid) {
+            return true;
+        }
+        thread::sleep(RUN_OWNER_TERMINATION_POLL);
+    }
+    !process_is_alive(pid)
+}
+
+#[cfg(unix)]
+fn wait_for_process_group_exit(pgid: libc::pid_t, timeout: Duration) -> bool {
+    let started = Instant::now();
+    while started.elapsed() < timeout {
+        if !process_group_is_alive(pgid) {
+            return true;
+        }
+        thread::sleep(RUN_OWNER_TERMINATION_POLL);
+    }
+    !process_group_is_alive(pgid)
+}
+
+#[cfg(unix)]
+fn process_group_is_alive(pgid: libc::pid_t) -> bool {
+    if pgid <= 1 {
+        return false;
+    }
+    let rc = unsafe { libc::kill(-pgid, 0) };
+    if rc == 0 {
+        return true;
+    }
+    std::io::Error::last_os_error().raw_os_error() == Some(libc::EPERM)
 }
 
 #[cfg(unix)]
@@ -348,7 +562,7 @@ fn run_owner_identity_matches(run: &JobRun) -> bool {
     };
     match process_start_time_token(pid) {
         Some(actual) => actual == expected,
-        None => process_is_alive(pid),
+        None => false,
     }
 }
 
@@ -417,6 +631,10 @@ fn parse_audit_timestamp(event: &Value, path: &Path) -> Result<Option<DateTime<U
 mod tests {
     use super::*;
     use chrono::Duration;
+    #[cfg(unix)]
+    use std::process::Stdio;
+    #[cfg(unix)]
+    use std::time::{Duration as StdDuration, Instant as StdInstant};
     use tempfile::tempdir;
 
     fn test_runtime() -> (tempfile::TempDir, OrbitRuntime) {
@@ -477,6 +695,266 @@ mod tests {
         });
         std::fs::write(dir.join(format!("{run_id}.jsonl")), format!("{line}\n"))
             .expect("write audit event");
+    }
+
+    #[test]
+    fn cancel_job_run_marks_pending_cancelled_without_signal() {
+        let (_root, runtime) = test_runtime();
+        let run = insert_pending_run(&runtime, "qa_cancel_pending");
+
+        let result = runtime
+            .cancel_job_run_with_context(&run.run_id, "tester", "unit")
+            .expect("cancel pending");
+
+        assert_eq!(result.previous_state, "pending");
+        assert_eq!(result.final_state, "cancelled");
+        assert!(!result.signal_attempted);
+        assert_eq!(result.signal_outcome, None);
+        let stored = runtime.show_job_run(&run.run_id).expect("show run");
+        assert_eq!(stored.state, JobRunState::Cancelled);
+        assert!(stored.finished_at.is_some());
+        assert_eq!(stored.duration_ms, None);
+
+        let audits = runtime.list_session_events(10).expect("events");
+        let payload = audits
+            .iter()
+            .find(|event| event.event_type == "JobRunCancelled")
+            .map(|event| &event.payload["data"])
+            .expect("cancel event");
+        assert_eq!(payload["run_id"], run.run_id);
+        assert_eq!(payload["previous_state"], "pending");
+        assert_eq!(payload["final_state"], "cancelled");
+        assert_eq!(payload["actor"], "tester");
+        assert_eq!(payload["source"], "unit");
+        assert_eq!(payload["signal_attempted"], false);
+    }
+
+    #[test]
+    fn cancelled_pending_run_is_not_claimed_by_pipeline_worker() {
+        let (_root, runtime) = test_runtime();
+        let run = insert_pending_run(&runtime, "qa_cancel_worker_skip");
+        runtime
+            .cancel_job_run(&run.run_id)
+            .expect("cancel pending run");
+
+        runtime
+            .execute_pipeline_run_worker(&run.run_id)
+            .expect("worker exits without executing cancelled run");
+
+        let stored = runtime.show_job_run(&run.run_id).expect("show run");
+        assert_eq!(stored.state, JobRunState::Cancelled);
+        assert!(stored.started_at.is_none());
+        assert!(stored.steps.is_empty());
+    }
+
+    #[test]
+    fn cancelled_run_wait_status_reports_cancelled() {
+        let (_root, runtime) = test_runtime();
+        let run = insert_pending_run(&runtime, "qa_cancel_wait");
+        runtime.cancel_job_run(&run.run_id).expect("cancel run");
+
+        let result = runtime
+            .wait_pipeline_runs(std::slice::from_ref(&run.run_id), 1, 1, Some("test"))
+            .expect("wait cancelled");
+
+        assert_eq!(result.results.len(), 1);
+        assert_eq!(result.results[0].run_id, run.run_id);
+        assert_eq!(result.results[0].status, "cancelled");
+    }
+
+    #[test]
+    fn cancel_job_run_rejects_terminal_run_without_mutating_bundle() {
+        let (_root, runtime) = test_runtime();
+        let run = insert_pending_run(&runtime, "qa_cancel_terminal");
+        let started_at = Utc::now() - Duration::seconds(2);
+        let finished_at = Utc::now();
+        runtime
+            .stores()
+            .jobs()
+            .mark_run_running(&run.run_id, started_at, std::process::id())
+            .expect("mark running");
+        runtime
+            .stores()
+            .jobs()
+            .finalize_run(&run.run_id, JobRunState::Success, finished_at, Some(2_000))
+            .expect("finalize success");
+        let before = runtime.show_job_run(&run.run_id).expect("show before");
+
+        let error = runtime
+            .cancel_job_run(&run.run_id)
+            .expect_err("terminal cancellation must fail");
+
+        assert!(
+            error.to_string().contains("cannot cancel job run"),
+            "{error}"
+        );
+        let after = runtime.show_job_run(&run.run_id).expect("show after");
+        assert_eq!(after, before);
+        let events = runtime.list_session_events(20).expect("events");
+        assert!(
+            events
+                .iter()
+                .all(|event| event.event_type != "JobRunCancelled")
+        );
+    }
+
+    #[cfg(unix)]
+    fn wait_until<F>(timeout: StdDuration, mut condition: F) -> bool
+    where
+        F: FnMut() -> bool,
+    {
+        let started = StdInstant::now();
+        while started.elapsed() < timeout {
+            if condition() {
+                return true;
+            }
+            std::thread::sleep(StdDuration::from_millis(50));
+        }
+        condition()
+    }
+
+    #[cfg(unix)]
+    fn read_pid_pair(path: &Path) -> (u32, u32) {
+        let raw = std::fs::read_to_string(path).expect("read pid file");
+        let mut parts = raw.split_whitespace();
+        let owner = parts
+            .next()
+            .expect("owner pid")
+            .parse()
+            .expect("parse owner pid");
+        let child = parts
+            .next()
+            .expect("child pid")
+            .parse()
+            .expect("parse child pid");
+        (owner, child)
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn cancel_job_run_does_not_signal_reused_pid_identity_mismatch() {
+        let (_root, runtime) = test_runtime();
+        let run = insert_pending_run(&runtime, "qa_cancel_reused_pid");
+        let mut sentinel = Command::new("sleep")
+            .arg("30")
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("spawn sentinel");
+        let sentinel_pid = sentinel.id();
+        let started_at = Utc::now() - Duration::seconds(1);
+        runtime
+            .stores()
+            .jobs()
+            .mark_run_running(&run.run_id, started_at, sentinel_pid)
+            .expect("mark running");
+        let path = runtime
+            .data_root()
+            .join("state")
+            .join("job-runs")
+            .join(&run.job_id)
+            .join(&run.run_id)
+            .join("jrun.yaml");
+        let raw = std::fs::read_to_string(&path).expect("read run yaml");
+        let edited = if raw.contains("pid_start_time:") {
+            raw.lines()
+                .map(|line| {
+                    if line.trim_start().starts_with("pid_start_time:") {
+                        "  pid_start_time: definitely-not-the-sentinel-start-token".to_string()
+                    } else {
+                        line.to_string()
+                    }
+                })
+                .collect::<Vec<_>>()
+                .join("\n")
+        } else {
+            raw.lines()
+                .map(|line| {
+                    if line.trim_start().starts_with("pid:") {
+                        format!("{line}\n  pid_start_time: definitely-not-the-sentinel-start-token")
+                    } else {
+                        line.to_string()
+                    }
+                })
+                .collect::<Vec<_>>()
+                .join("\n")
+        };
+        std::fs::write(&path, format!("{edited}\n")).expect("write mismatched pid token");
+
+        let result = runtime.cancel_job_run(&run.run_id).expect("cancel run");
+
+        assert!(result.signal_attempted);
+        assert_eq!(
+            result.signal_outcome.as_deref(),
+            Some("owner_identity_mismatch")
+        );
+        assert!(
+            process_is_alive(sentinel_pid),
+            "sentinel process must not be killed by mismatched owner identity"
+        );
+        let _ = sentinel.kill();
+        let _ = sentinel.wait();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn cancel_job_run_terminates_owner_process_group_and_child() {
+        use std::os::unix::process::CommandExt;
+
+        let (_root, runtime) = test_runtime();
+        let run = insert_pending_run(&runtime, "qa_cancel_process_group");
+        let pid_dir = tempdir().expect("pid tempdir");
+        let pid_file = pid_dir.path().join("pids");
+        let script = format!(
+            "trap 'exit 0' TERM; (trap '' TERM; sleep 30) & child=$!; printf '%s %s\\n' $$ \"$child\" > {}; wait",
+            shell_quote(pid_file.to_string_lossy().as_ref())
+        );
+        let mut owner = Command::new("/bin/sh");
+        owner
+            .arg("-c")
+            .arg(script)
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null());
+        unsafe {
+            owner.pre_exec(|| {
+                if libc::setsid() == -1 {
+                    return Err(std::io::Error::last_os_error());
+                }
+                Ok(())
+            });
+        }
+        let mut owner = owner.spawn().expect("spawn owner");
+        assert!(
+            wait_until(StdDuration::from_secs(2), || pid_file.exists()),
+            "owner did not write pid file"
+        );
+        let (owner_pid, child_pid) = read_pid_pair(&pid_file);
+        assert_eq!(owner.id(), owner_pid);
+        runtime
+            .stores()
+            .jobs()
+            .mark_run_running(&run.run_id, Utc::now(), owner_pid)
+            .expect("mark running");
+
+        let result = runtime.cancel_job_run(&run.run_id).expect("cancel run");
+        let _ = owner.wait();
+
+        assert!(result.signal_attempted);
+        assert_eq!(
+            result.signal_outcome.as_deref(),
+            Some("killed_process_group")
+        );
+        assert!(
+            wait_until(StdDuration::from_secs(3), || !process_is_alive(child_pid)),
+            "child process {child_pid} should be gone after process-group cancellation"
+        );
+    }
+
+    #[cfg(unix)]
+    fn shell_quote(value: &str) -> String {
+        format!("'{}'", value.replace('\'', "'\\''"))
     }
 
     #[cfg(unix)]

--- a/docs/design/activity-job/2_design.md
+++ b/docs/design/activity-job/2_design.md
@@ -283,6 +283,8 @@ This operator-surface repair keeps `orbit run ship --json`, direct `orbit job ru
 
 After [T20260430-27], `orbit run ship-auto` also interprets the parent `task_auto_pipeline` snapshot for operator output. Text and JSON modes keep the persisted run state and exit-code semantics, but add `workflow_status` labels: `empty_backlog`, `gated_noop`, `gate_waiting`, `gate_failed`, and `completed`. `empty_backlog` means no candidates and no exclusions. `gated_noop` means zero dispatched bundles with one or more `list_backlog.excluded` entries. `gate_waiting` means a child `task_gate_pipeline` run is still pending/running or the parent wait timed out while the child remains active. `gate_failed` means a child gate run reached a failed or cancelled state. The output also carries dispatched bundle count, excluded task count, exclusion reasons, blocker summaries, and child gate run status so operators do not have to run `orbit run show` merely to tell no backlog from lock-gated work. After [T20260430-30], default text renders that data as labeled multi-line operator output, while `--json` remains the stable machine-readable surface with raw status fields.
 
+After [T20260505-8], active job runs can be cancelled through the same durable run surface. `pending` and `running` runs transition to `cancelled`; terminal runs remain immutable. Pending cancellation only rewrites the run bundle and pipeline snapshot, so a later pipeline worker observes `cancelled` and exits without claiming the run. Running cancellation first validates the stored owner PID start-time token, then signals the owner process group on Unix with a bounded graceful period and `SIGKILL` escalation. `JobRunCancelled` audit payloads include run id, previous/final state, actor/source, whether signaling was attempted, and the signal outcome.
+
 The loop shares one pipeline map and session map across iterations, which makes cross-iteration `session:` meaningful.
 
 ### 8.7 Invocation metrics
@@ -454,5 +456,6 @@ Read-only history does not need the same dependencies as live execution. [T20260
 - **[T20260430-30]** — Make `ship-auto` default text output human-readable while preserving JSON fields.
 - **[T20260430-31]** — Require populated execution summaries before opening task PRs.
 - **[T20260505-2]** — Admit accepted backlog friction reports in automatic backlog listing.
+- **[T20260505-8]** — Add dashboard/runtime controls to cancel active job runs.
 
 > Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.

--- a/docs/design/activity-job/4_decisions.md
+++ b/docs/design/activity-job/4_decisions.md
@@ -498,6 +498,19 @@ This ADR log records the decisions that define the current Activity / Job substr
 - The `excluded` array remains scoped to context-lock conflicts; it reports accepted friction tasks only when they are otherwise admitted backlog candidates and overlap active locks.
 - Cost: reviewers must read friction eligibility as a status rule, not a task-type rule.
 
+## ADR-038 — Dashboard cancellation is a durable job-run transition
+
+**Status:** Accepted · 2026-05 · [T20260505-8]
+
+**Context.** Dashboard Recent Runs exposed job-run status but no operator stop control. The runtime already had a cancellation entry point, but it signalled only the owner PID and returned no structured cancellation outcome, which was too weak for stuck CLI-backed workflows with provider subprocess trees.
+
+**Decision.** Treat cancellation as a first-class durable job-run transition. `pending` and `running` may become `cancelled`; terminal states reject cancellation. Pending cancellation does not signal. Running cancellation validates the stored PID start-time identity and, on Unix, terminates the run owner process group with graceful signal plus bounded `SIGKILL` escalation. The dashboard calls `POST /api/runs/:id/cancel`, and client cancellability is derived from `state` rather than a redundant server field.
+
+**Consequences.**
+- Operators can stop active work from Diagnostics while preserving coherent `orbit run show` and `orbit.pipeline.wait` state.
+- `JobRunCancelled` audit payloads carry previous/final state, actor/source, signal-attempted flag, and signal outcome.
+- Cost: direct in-process job runs still cannot safely self-signal; dashboard cancellation is primarily the durable pipeline-worker/operator path.
+
 ---
 
 ## Task References
@@ -546,5 +559,6 @@ This ADR log records the decisions that define the current Activity / Job substr
 - **[T20260430-30]** — Make `ship-auto` default text output human-readable while preserving JSON fields.
 - **[T20260430-31]** — Require populated execution summaries before opening task PRs.
 - **[T20260505-2]** — Admit accepted backlog friction reports in automatic backlog listing.
+- **[T20260505-8]** — Add dashboard/runtime controls to cancel active job runs.
 
 > Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.


### PR DESCRIPTION
## Tasks
- [T20260505-8] Add dashboard controls to cancel active job runs
  <details><summary>Execution Summary</summary>

## Status
success

## Summary of Changes
Implemented dashboard/runtime cancellation for active job runs. Added `POST /api/runs/:id/cancel`, Recent Runs and Run Detail cancel controls derived from `pending`/`running` state, structured cancellation results, additive `JobRunCancelled` audit payload fields, pending-run cancellation semantics, pipeline wait/state coherence, and Unix owner process-group termination with bounded SIGKILL escalation after PID start-token validation.

Updated Activity / Job design docs with the cancellation contract and ADR-038 for [T20260505-8].

## Overall Assessment
The implementation is scoped to existing job-run lifecycle surfaces and preserves existing run JSON fields. Pending and terminal behavior is covered at API/runtime level, and Unix signal-path tests cover reused PID identity safety plus process-group child cleanup.

## Dashboard Verification Path
The repo does not currently have a headless dashboard DOM harness for `crates/orbit-cli/assets/dashboard/app.js`. The documented manual smoke path is: start `orbit web`, open Diagnostics > Recent Runs, verify active `pending` or `running` rows render the cancel control, open an active run detail and verify the same cancel action appears there, cancel the run, then verify `/api/runs/:id`, `/api/runs/:id/events`, and Recent Runs refresh with `cancelled`; terminal rows (`success`, `failed`, `timeout`, `cancelled`) should show no active cancel control.

## Validation
- `cargo test -p orbit-core cancel_job_run -- --test-threads=1`
- `cargo test -p orbit-core cancel_job_run_terminates_owner_process_group_and_child -- --test-threads=1`
- `cargo test -p orbit-cli cancel_run`
- `cargo test -p orbit-core cancel -- --test-threads=1`
- `make fmt`
- `make build`
- `git diff --check`

## Deviations from Original Plan
- Did not add a redundant server-side `cancellable` field; the dashboard derives cancellability from run state as requested.
- The deterministic subprocess-leak coverage uses a Unix owner-process-group fixture that models a CLI-backed worker/provider process tree, because direct in-process job runs cannot safely self-signal.

  </details>

## Branch Freshness
- Base ref: `origin/agent-main`
- Head ref: `orbit/T20260505-8-69f94d80`
- Behind base: 0
- Ahead of base: 1

## Files Changed
- `Cargo.lock`
- `crates/orbit-cli/Cargo.toml`
- `crates/orbit-cli/assets/dashboard/app.js`
- `crates/orbit-cli/assets/dashboard/index.html`
- `crates/orbit-cli/src/command/web/api.rs`
- `crates/orbit-common/src/types/event.rs`
- `crates/orbit-core/src/command/job_run.rs`
- `docs/design/activity-job/2_design.md`
- `docs/design/activity-job/4_decisions.md`

*authored by: gpt-5.5*