### PR TITLE
Parallel tool runs can collide on audit execution_id

### DIFF
--- a/crates/orbit-cli/src/audit_middleware.rs
+++ b/crates/orbit-cli/src/audit_middleware.rs
@@ -1,6 +1,8 @@
 use std::time::Instant;
 
-use orbit_common::types::{normalize_agent_family_for_model, normalize_optional_attribution_label};
+use orbit_common::types::{
+    audit_execution_id, normalize_agent_family_for_model, normalize_optional_attribution_label,
+};
 use orbit_core::command::tool::take_tool_audit_recorded;
 use orbit_core::{
     AuditEventInsertParams, AuditEventStatus, OrbitError, OrbitRuntime, redact_sensitive_env_text,
@@ -46,14 +48,9 @@ pub struct AuditGuard<'a> {
 
 impl<'a> AuditGuard<'a> {
     pub fn new(runtime: &'a OrbitRuntime, meta: CommandMeta) -> Self {
-        let nanos = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .map(|d| d.as_nanos())
-            .unwrap_or(0);
-
         Self {
             runtime,
-            execution_id: format!("exec-{nanos}"),
+            execution_id: audit_execution_id("exec"),
             meta,
             start: Instant::now(),
             status: AuditEventStatus::Failure,

--- a/crates/orbit-cli/src/command/mcp/mod.rs
+++ b/crates/orbit-cli/src/command/mcp/mod.rs
@@ -12,7 +12,7 @@ use std::sync::Arc;
 use std::time::Instant;
 
 use clap::{Args, Subcommand};
-use orbit_common::types::{AuditEventStatus, ToolSchema};
+use orbit_common::types::{AuditEventStatus, ToolSchema, audit_execution_id};
 use orbit_core::command::tool::{ToolEntryPoint, audit_role_label};
 use orbit_core::{AuditEventInsertParams, OrbitError, OrbitRuntime, redact_sensitive_env_text};
 use orbit_mcp::McpHost;
@@ -215,13 +215,7 @@ fn record_mcp_preflight_failure(
         .unwrap_or_else(|_| ".".to_string());
 
     let params = AuditEventInsertParams {
-        execution_id: format!(
-            "exec-{}",
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .map(|d| d.as_nanos())
-                .unwrap_or(0)
-        ),
+        execution_id: audit_execution_id("exec"),
         command: "tool".to_string(),
         subcommand: Some(ToolEntryPoint::Mcp.audit_subcommand().to_string()),
         tool_name: Some(name.to_string()),

--- a/crates/orbit-common/src/types/audit_event.rs
+++ b/crates/orbit-common/src/types/audit_event.rs
@@ -1,8 +1,29 @@
 use std::fmt::{Display, Formatter};
 use std::str::FromStr;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
+
+static AUDIT_EXECUTION_SEQUENCE: AtomicU64 = AtomicU64::new(0);
+
+/// Generate a command-audit execution id that stays unique for concurrent
+/// processes on clocks with coarser-than-nanosecond resolution.
+pub fn audit_execution_id(prefix: &str) -> String {
+    let prefix = if prefix.trim().is_empty() {
+        "exec"
+    } else {
+        prefix.trim()
+    };
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    let pid = std::process::id();
+    let sequence = AUDIT_EXECUTION_SEQUENCE.fetch_add(1, Ordering::Relaxed);
+    format!("{prefix}-{nanos}-{pid}-{sequence}")
+}
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "clap", derive(clap::ValueEnum))]
@@ -92,4 +113,41 @@ pub struct AuditStats {
     pub avg_duration_ms: f64,
     pub p95_duration_ms: i64,
     pub max_duration_ms: i64,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::BTreeSet;
+    use std::sync::{Arc, Barrier};
+    use std::thread;
+
+    #[test]
+    fn audit_execution_id_is_unique_under_concurrent_generation() {
+        let workers = 16;
+        let per_worker = 64;
+        let barrier = Arc::new(Barrier::new(workers));
+
+        let handles: Vec<_> = (0..workers)
+            .map(|_| {
+                let barrier = Arc::clone(&barrier);
+                thread::spawn(move || {
+                    barrier.wait();
+                    (0..per_worker)
+                        .map(|_| audit_execution_id("exec"))
+                        .collect::<Vec<_>>()
+                })
+            })
+            .collect();
+
+        let ids: Vec<String> = handles
+            .into_iter()
+            .flat_map(|handle| handle.join().expect("worker thread joined"))
+            .collect();
+        let unique: BTreeSet<_> = ids.iter().cloned().collect();
+
+        assert_eq!(ids.len(), workers * per_worker);
+        assert_eq!(unique.len(), ids.len());
+        assert!(ids.iter().all(|id| id.starts_with("exec-")));
+    }
 }

--- a/crates/orbit-common/src/types/mod.rs
+++ b/crates/orbit-common/src/types/mod.rs
@@ -62,7 +62,7 @@ pub use agent_pair::{
     normalize_agent_family_for_model, resolve_agent_model_pair,
 };
 pub use audit::Audit;
-pub use audit_event::{AuditEvent, AuditEventStatus, AuditStats};
+pub use audit_event::{AuditEvent, AuditEventStatus, AuditStats, audit_execution_id};
 pub use duel::{
     Ambiguity, ArbiterVerdict, Cost, Decision, DuelRun, EfficiencyMetrics, ImplementerStats,
     Outcome, PerCommentVerdict, PlannerSlot, PlanningDuelRun, PlanningEfficiency, PlanningOutcome,

--- a/crates/orbit-core/src/command/pipeline_run.rs
+++ b/crates/orbit-core/src/command/pipeline_run.rs
@@ -6,7 +6,7 @@ use std::time::{Duration, Instant};
 use chrono::Utc;
 use orbit_common::types::{
     AuditEventStatus, JobRun, JobRunState, JobScheduleState, JobTargetType, OrbitError, OrbitEvent,
-    PipelineState,
+    PipelineState, audit_execution_id,
 };
 use orbit_store::{AuditEventInsertParams, JobRunStepParams, TaskReservationReleaseReason};
 use serde::Serialize;
@@ -483,10 +483,7 @@ impl OrbitRuntime {
         let arguments_json = serde_json::to_string(&arguments).map_err(|error| {
             OrbitError::Store(format!("serialize pipeline audit args: {error}"))
         })?;
-        let execution_id = format!(
-            "exec-{}",
-            Utc::now().timestamp_nanos_opt().unwrap_or_default()
-        );
+        let execution_id = audit_execution_id("exec");
         self.record_audit_event(&AuditEventInsertParams {
             execution_id,
             command: "tool".to_string(),

--- a/crates/orbit-core/src/command/tool.rs
+++ b/crates/orbit-core/src/command/tool.rs
@@ -3,7 +3,7 @@ use std::path::Path;
 use std::time::Instant;
 
 use orbit_common::types::{
-    AuditEventStatus, OrbitError, OrbitEvent, Role, StoredTool, ToolParam,
+    AuditEventStatus, OrbitError, OrbitEvent, Role, StoredTool, ToolParam, audit_execution_id,
     normalize_agent_family_for_model, normalize_optional_attribution_label,
 };
 use orbit_store::AuditEventInsertParams;
@@ -171,13 +171,7 @@ impl OrbitRuntime {
         };
 
         let params = AuditEventInsertParams {
-            execution_id: format!(
-                "exec-{}",
-                std::time::SystemTime::now()
-                    .duration_since(std::time::UNIX_EPOCH)
-                    .map(|d| d.as_nanos())
-                    .unwrap_or(0)
-            ),
+            execution_id: audit_execution_id("exec"),
             command: "tool".to_string(),
             subcommand: Some(entry_point.audit_subcommand().to_string()),
             tool_name: Some(name.to_string()),
@@ -643,8 +637,11 @@ impl OrbitRuntime {
 #[cfg(test)]
 mod audit_tests {
     use super::*;
+    use std::collections::BTreeSet;
+    use std::sync::{Arc, Barrier, Mutex, MutexGuard, OnceLock};
+    use std::thread;
+
     use serde_json::json;
-    use std::sync::{Mutex, MutexGuard, OnceLock};
 
     /// Serializes any test that mutates `ORBIT_AGENT_*` env vars or asserts on
     /// audit rows whose `role` depends on env-var precedence. Without this
@@ -798,6 +795,51 @@ mod audit_tests {
             .expect("list audit events");
         assert_eq!(events.len(), 1);
         assert_eq!(events[0].subcommand.as_deref(), Some("run"));
+    }
+
+    #[test]
+    fn concurrent_tool_dispatch_writes_distinct_execution_ids() {
+        let _g = env_guard();
+        let runtime = Arc::new(fresh_runtime());
+        let workers = 8;
+        let barrier = Arc::new(Barrier::new(workers));
+
+        let handles: Vec<_> = (0..workers)
+            .map(|_| {
+                let runtime = Arc::clone(&runtime);
+                let barrier = Arc::clone(&barrier);
+                thread::spawn(move || {
+                    barrier.wait();
+                    runtime
+                        .execute_tool_command_dispatch(
+                            "orbit.task.search",
+                            json!({ "query": "anything", "model": "gpt-5.5" }),
+                            None,
+                            None,
+                            ToolEntryPoint::Cli,
+                        )
+                        .expect("dispatch ok");
+                })
+            })
+            .collect();
+
+        for handle in handles {
+            handle.join().expect("worker joined");
+        }
+
+        let events = runtime
+            .list_audit_events(
+                None,
+                Some("orbit.task.search".to_string()),
+                None,
+                None,
+                workers,
+            )
+            .expect("list audit events");
+        let execution_ids: BTreeSet<_> = events.iter().map(|event| &event.execution_id).collect();
+
+        assert_eq!(events.len(), workers);
+        assert_eq!(execution_ids.len(), workers);
     }
 
     #[test]

--- a/crates/orbit-core/src/runtime/orbit_tool_host/mod.rs
+++ b/crates/orbit-core/src/runtime/orbit_tool_host/mod.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 
 use orbit_common::types::{
     AuditEventStatus, OrbitError, ReviewThreadStatus, Task, TaskPriority, TaskStatus,
-    build_task_status_index, normalize_optional_attribution_label,
+    audit_execution_id, build_task_status_index, normalize_optional_attribution_label,
     optional_csv_or_string_list_alias, optional_raw_string, optional_string, optional_string_alias,
     optional_string_list_alias, optional_u32_alias, prune_missing_context_files, required_string,
     task_dependencies_ready,
@@ -858,15 +858,9 @@ pub(crate) fn record_task_lock_audit_event(
     status: AuditEventStatus,
     payload: Value,
 ) -> Result<(), OrbitError> {
+    let execution_id_prefix = format!("audit-{}", command.replace('.', "-"));
     runtime.record_audit_event(&crate::AuditEventInsertParams {
-        execution_id: format!(
-            "audit-{}-{}",
-            command.replace('.', "-"),
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .map(|duration| duration.as_nanos())
-                .unwrap_or(0)
-        ),
+        execution_id: audit_execution_id(&execution_id_prefix),
         command: command.to_string(),
         subcommand: None,
         tool_name: Some(tool_name.to_string()),

--- a/crates/orbit-core/src/runtime/v2_host.rs
+++ b/crates/orbit-core/src/runtime/v2_host.rs
@@ -16,7 +16,7 @@ use std::time::{Duration, Instant};
 use orbit_common::types::activity_job::AgentRole;
 use orbit_common::types::{
     AuditEventStatus, ExecutorSandboxKind, ExecutorType, ResolvedFsProfile, Role, TaskStatus,
-    TaskType, UNRESTRICTED_FS_PROFILE, prune_missing_context_files,
+    TaskType, UNRESTRICTED_FS_PROFILE, audit_execution_id, prune_missing_context_files,
 };
 use orbit_common::types::{InvocationTrace, Task};
 use orbit_common::utility::path::workspace_relative_paths_overlap;
@@ -708,13 +708,7 @@ impl V2RuntimeHost for OrbitRuntime {
                     "max_wait_seconds": max_wait_seconds,
                 });
 
-                let execution_id = format!(
-                    "audit-gate-starvation-{}",
-                    std::time::SystemTime::now()
-                        .duration_since(std::time::UNIX_EPOCH)
-                        .map(|duration| duration.as_nanos())
-                        .unwrap_or(0)
-                );
+                let execution_id = audit_execution_id("audit-gate-starvation");
                 let working_directory = self.paths().repo_root.to_string_lossy().into_owned();
                 self.record_audit_event(&AuditEventInsertParams {
                     execution_id,

--- a/docs/design/auditability/2_design.md
+++ b/docs/design/auditability/2_design.md
@@ -2,7 +2,7 @@
 
 **Status:** Draft
 **Owner:** codex
-**Last updated:** 2026-04-30 (T20260430-20)
+**Last updated:** 2026-05-05 (T20260505-6)
 
 This document describes Orbit's shipped auditability implementation across command audit rows, activity/job envelopes, loop-level provider/tool traces, blob storage, redaction, identity attribution, metrics-adjacent invocation records, and known limitations. See [1_overview.md](./1_overview.md) for the feature purpose and [3_vision.md](./3_vision.md) for future questions.
 
@@ -25,6 +25,8 @@ The split is deliberate: command rows stay compact and queryable; envelopes pres
 ## 2. Command Audit Rows
 
 `AuditEvent` lives in `crates/orbit-common/src/types/audit_event.rs`. Rows include execution id, timestamp, command/subcommand, optional tool and target metadata, role, status, exit code, duration, working directory, optional argument/error/stdout/stderr fields, host, pid, and session id. The table and indexes live in `crates/orbit-store/migrations/0001_init.sql`; `crates/orbit-store/src/sqlite/audit_event_store.rs` lists, shows, prunes, exports, computes stats, and returns durations for p95 calculation.
+
+After [T20260505-6], command-audit producers use the shared `audit_execution_id` helper instead of timestamp-only ids. The id keeps a stable producer prefix and appends wall-clock nanoseconds, process id, and a per-process atomic sequence so same-workspace parallel `orbit tool run ...` calls do not collide on clocks with coarse effective resolution. The SQLite unique index on `execution_id` remains the enforcement boundary.
 
 The CLI RAII guard in `crates/orbit-cli/src/audit_middleware.rs` defaults to failure, marks success or denial explicitly, and writes one row in `Drop`, so early returns still audit when stack unwinding reaches the guard. Direct `orbit audit ...` commands are outside the guard today to avoid recursive audit noise.
 
@@ -145,5 +147,6 @@ Each record contains timestamp, level, target, and structured fields. After [T20
 - **[T20260428-17]** — Split local Orbit task-review scoring from PR review-comment scoring and surface both in compact scoreboards.
 - **[T20260430-4]** — Change local task-review scoring to count review-thread creations rather than replies, rename the compact field to `task_review.threads`, and keep legacy metric reads mapped forward.
 - **[T20260430-20]** — Shorten the auditability docs while preserving required guarantees.
+- **[T20260505-6]** — Replace timestamp-only command-audit execution ids with collision-resistant generated ids for parallel tool runs.
 
 > Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.

--- a/docs/design/auditability/4_decisions.md
+++ b/docs/design/auditability/4_decisions.md
@@ -2,7 +2,7 @@
 
 **Status:** Draft
 **Owner:** codex
-**Last updated:** 2026-04-30 (T20260430-20)
+**Last updated:** 2026-05-05 (T20260505-6)
 
 This is the append-only ADR log for Auditability. Entries are ordered by ADR number. New entries should use the template in [../CONVENTIONS.md](../CONVENTIONS.md) and cite the task that made the decision real.
 
@@ -236,6 +236,18 @@ This is the append-only ADR log for Auditability. Entries are ordered by ADR num
 - Local review feedback earns immediate task-review credit while synced PR feedback remains a separate PR metric.
 - Cost: review productivity now has two counters, and aggregate views must label them clearly rather than adding them blindly.
 
+## ADR-020 — Command-audit execution ids are process-disambiguated
+
+**Status:** Accepted · 2026-05 · [T20260505-6]
+
+**Context.** Timestamp-only command-audit execution ids collided when concurrent `orbit tool run orbit.task.show` processes in one workspace generated ids at the same effective clock tick.
+
+**Decision.** Generate command-audit execution ids through one shared helper that combines a stable prefix, wall-clock nanoseconds, process id, and a per-process atomic sequence while keeping the SQLite unique index authoritative.
+
+**Consequences.**
+- Parallel CLI and runtime audit producers get deterministic collision resistance without weakening uniqueness constraints.
+- Cost: execution ids are longer and less visually compact than the old `exec-<nanos>` shape.
+
 ---
 
 ## Task References
@@ -263,5 +275,6 @@ This is the append-only ADR log for Auditability. Entries are ordered by ADR num
 - **[T20260430-4]** — Count local task-review score by review-thread creations, not replies, and rename the task-review summary field to `threads`.
 - **[T20260430-5]** — Tighten task and PR review-message scoring so only exact configured orchestrator/helper model identities score; typo-prefixed labels are ignored.
 - **[T20260430-20]** — Shorten the auditability docs while preserving required guarantees.
+- **[T20260505-6]** — Replace timestamp-only command-audit execution ids with process-disambiguated generated ids for parallel tool runs.
 
 > Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.

--- a/docs/design/auditability/specs/event-schema.md
+++ b/docs/design/auditability/specs/event-schema.md
@@ -15,6 +15,7 @@ Command audit events are SQLite rows represented by `AuditEvent`.
 Required invariants:
 
 - `execution_id` is non-empty and unique within the command audit table.
+- Producer-generated `execution_id` values use the shared prefix + timestamp + process id + per-process sequence helper; new producers must not roll timestamp-only ids.
 - `timestamp`, `command`, `role`, `status`, `exit_code`, `duration_ms`, `working_directory`, and `pid` are always present.
 - `status` is one of `success`, `failure`, or `denied`.
 - A denied command uses `status: denied` and a non-zero exit code.


### PR DESCRIPTION
## Tasks
- [T20260505-6] Parallel tool runs can collide on audit execution_id
  <details><summary>Execution Summary</summary>

## Status
success

## Summary of Changes
Added shared command-audit execution id generation in orbit-common that combines prefix, wall-clock nanoseconds, process id, and a per-process sequence. Updated CLI guard, runtime tool dispatch, MCP preflight, pipeline, gate-starvation, and task-lock audit producers to use it. Added concurrent generation and concurrent tool-dispatch regression tests. Updated auditability design docs and schema spec for T20260505-6.

## Overall Assessment
The original parallel `orbit tool run orbit.task.show --full` repro now records distinct audit rows without stderr audit persistence warnings.

## Strategic Decisions
- Kept the existing SQLite unique index as the authoritative enforcement boundary while making producer ids collision-resistant. | Rationale: preserves the audit contract and avoids weakening query semantics.

## Validation
- make fmt
- cargo test -p orbit-common audit_execution_id_is_unique_under_concurrent_generation
- cargo test -p orbit-core concurrent_tool_dispatch_writes_distinct_execution_ids
- cargo test -p orbit-cli cli_dedup_invariant
- make build
- manual two-process ./target/debug/orbit tool run orbit.task.show --full repro: both exited 0, no command stderr, two distinct execution_id values recorded.

  </details>

## Branch Freshness
- Base ref: `origin/agent-main`
- Head ref: `orbit/T20260505-6-69f9694e`
- Behind base: 0
- Ahead of base: 1

## Files Changed
- `crates/orbit-cli/src/audit_middleware.rs`
- `crates/orbit-cli/src/command/mcp/mod.rs`
- `crates/orbit-common/src/types/audit_event.rs`
- `crates/orbit-common/src/types/mod.rs`
- `crates/orbit-core/src/command/pipeline_run.rs`
- `crates/orbit-core/src/command/tool.rs`
- `crates/orbit-core/src/runtime/orbit_tool_host/mod.rs`
- `crates/orbit-core/src/runtime/v2_host.rs`
- `docs/design/auditability/2_design.md`
- `docs/design/auditability/4_decisions.md`
- `docs/design/auditability/specs/event-schema.md`

*authored by: gpt-5.5*