### PR TITLE
orbit.graph.pack provides no progress or timeout when gathering context selectors

### DIFF
--- a/crates/orbit-knowledge/src/lib.rs
+++ b/crates/orbit-knowledge/src/lib.rs
@@ -61,9 +61,10 @@ pub use service::history::{
 pub use service::{TaskGraphScope, TaskGraphService, default_knowledge_dir};
 pub use store::{
     DEFAULT_BLOB_CACHE_CAPACITY, DEFAULT_OBJECT_CACHE_CAPACITY, GraphObjectCache,
-    KnowledgeEntryKind, KnowledgePack, KnowledgePackEntry, KnowledgeStore, LeafData, NodeTaskInfo,
-    SymbolSummary, load_task_working_graph, overlay_pack_with_working_graph,
-    pack_from_working_graph, save_task_working_graph, task_working_graph_state_path,
+    KnowledgeEntryKind, KnowledgePack, KnowledgePackEntry, KnowledgePackTimeout, KnowledgeStore,
+    LeafData, NodeTaskInfo, SymbolSummary, load_task_working_graph,
+    overlay_pack_with_working_graph, pack_from_working_graph, save_task_working_graph,
+    task_working_graph_state_path,
 };
 pub use task_id_pattern::{DEFAULT_TASK_ID_PATTERN, ORBIT_TASK_ID_PATTERN, TaskIdPattern};
 pub use working_graph::{

--- a/crates/orbit-knowledge/src/service/task_graph.rs
+++ b/crates/orbit-knowledge/src/service/task_graph.rs
@@ -45,6 +45,7 @@ impl TaskGraphService {
         workspace_root: Option<&Path>,
         explicit_knowledge_dir: bool,
         explicit_ref: Option<&str>,
+        selector_timeout_ms: Option<u64>,
     ) -> Result<Value, OrbitError> {
         if explicit_ref.is_none() {
             self.maybe_refresh_knowledge_graph(workspace_root, explicit_knowledge_dir);
@@ -67,7 +68,7 @@ impl TaskGraphService {
                 read_target.fallback.as_ref(),
                 read_target.default.as_ref(),
             )?;
-            store.pack(selectors)
+            store.pack_with_timeout(selectors, selector_timeout_ms)
         };
 
         let pack = match pack_result() {

--- a/crates/orbit-knowledge/src/store.rs
+++ b/crates/orbit-knowledge/src/store.rs
@@ -30,7 +30,10 @@ pub use task_state::{
     load_task_working_graph, overlay_pack_with_working_graph, pack_from_working_graph,
     save_task_working_graph, task_working_graph_state_path,
 };
-pub use types::{KnowledgeEntryKind, KnowledgePack, KnowledgePackEntry, LeafData, SymbolSummary};
+pub use types::{
+    KnowledgeEntryKind, KnowledgePack, KnowledgePackEntry, KnowledgePackTimeout, LeafData,
+    SymbolSummary,
+};
 
 use graph_io::{GraphIndexFile, ManifestFile};
 

--- a/crates/orbit-knowledge/src/store/pack.rs
+++ b/crates/orbit-knowledge/src/store/pack.rs
@@ -1,3 +1,5 @@
+use std::time::{Duration, Instant};
+
 use serde_json::Value;
 
 use crate::error::KnowledgeError;
@@ -5,16 +7,40 @@ use crate::selector::Selector;
 
 use super::KnowledgeStore;
 use super::graph_io::{extract_leaf_source, read_graph_object};
-use super::types::{KnowledgeEntryKind, KnowledgePack, KnowledgePackEntry};
+use super::types::{KnowledgeEntryKind, KnowledgePack, KnowledgePackEntry, KnowledgePackTimeout};
 
 const FILE_SOURCE_HINT: &str = "File selectors return metadata only. Use `orbit.graph.show` or `symbol:` selectors when you need source.";
+const SELECTOR_TIMEOUT_HINT: &str = "Selector packing timed out before this selector was resolved; retry with a larger `timeout_ms` or read this selector directly.";
 
 impl KnowledgeStore {
     pub fn pack(&self, selectors: &[Selector]) -> Result<KnowledgePack, KnowledgeError> {
+        self.pack_with_timeout(selectors, None)
+    }
+
+    pub fn pack_with_timeout(
+        &self,
+        selectors: &[Selector],
+        timeout_ms: Option<u64>,
+    ) -> Result<KnowledgePack, KnowledgeError> {
         let mut entries = Vec::with_capacity(selectors.len());
         let mut unresolved_selectors = Vec::new();
+        let timeout = timeout_ms.map(Duration::from_millis);
+        let started_at = Instant::now();
+        let mut timed_out_after = None;
 
-        for selector in selectors {
+        for (index, selector) in selectors.iter().enumerate() {
+            if timeout.is_some_and(|timeout| started_at.elapsed() >= timeout) {
+                timed_out_after = Some(index);
+                for remaining in &selectors[index..] {
+                    let selector_string = remaining.to_string();
+                    unresolved_selectors.push(selector_string.clone());
+                    let mut entry = unresolved_entry(selector_string);
+                    entry.hint = Some(SELECTOR_TIMEOUT_HINT.to_string());
+                    entries.push(entry);
+                }
+                break;
+            }
+
             let selector_string = selector.to_string();
             let Some(node_id) = self.selector_index.get(&selector.lookup_key()).cloned() else {
                 unresolved_selectors.push(selector_string.clone());
@@ -65,10 +91,17 @@ impl KnowledgeStore {
         }
 
         let total_nodes = entries.iter().filter(|entry| entry.resolved).count();
+        let timeout = timed_out_after.map(|processed_selectors| KnowledgePackTimeout {
+            timeout_ms: timeout_ms.unwrap_or_default(),
+            processed_selectors,
+            total_selectors: selectors.len(),
+            hint: SELECTOR_TIMEOUT_HINT.to_string(),
+        });
         Ok(KnowledgePack {
             knowledge_dir: self.knowledge_dir.display().to_string(),
             manifest_generated_at: self.manifest.generated_at.clone(),
             unresolved_selectors,
+            timeout,
             total_nodes,
             entries,
         })

--- a/crates/orbit-knowledge/src/store/task_state.rs
+++ b/crates/orbit-knowledge/src/store/task_state.rs
@@ -118,6 +118,7 @@ pub fn pack_from_working_graph(
         knowledge_dir: knowledge_dir.display().to_string(),
         manifest_generated_at: String::new(),
         unresolved_selectors,
+        timeout: None,
         total_nodes,
         entries,
     }

--- a/crates/orbit-knowledge/src/store/types.rs
+++ b/crates/orbit-knowledge/src/store/types.rs
@@ -60,8 +60,18 @@ pub struct KnowledgePack {
     pub knowledge_dir: String,
     pub manifest_generated_at: String,
     pub unresolved_selectors: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub timeout: Option<KnowledgePackTimeout>,
     pub total_nodes: usize,
     pub entries: Vec<KnowledgePackEntry>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct KnowledgePackTimeout {
+    pub timeout_ms: u64,
+    pub processed_selectors: usize,
+    pub total_selectors: usize,
+    pub hint: String,
 }
 
 #[derive(Debug, Clone)]

--- a/crates/orbit-tools/src/builtin/orbit/knowledge_pack.rs
+++ b/crates/orbit-tools/src/builtin/orbit/knowledge_pack.rs
@@ -2,11 +2,14 @@ use orbit_common::types::{
     OrbitError, ToolParam, ToolSchema, optional_string, optional_string_list_alias,
 };
 use orbit_knowledge::{Selector, TaskGraphService};
-use serde_json::Value;
+use serde_json::{Value, json};
 
 use crate::{Tool, ToolContext};
 
 pub struct OrbitKnowledgePackTool;
+
+const DEFAULT_PACK_TIMEOUT_MS: u64 = 15_000;
+const MAX_PACK_TIMEOUT_MS: u64 = 300_000;
 
 impl Tool for OrbitKnowledgePackTool {
     fn schema(&self) -> ToolSchema {
@@ -25,6 +28,18 @@ impl Tool for OrbitKnowledgePackTool {
                 ToolParam {
                     name: "summary".to_string(),
                     description: "Default true; drop leaf bodies.".to_string(),
+                    param_type: "boolean".to_string(),
+                    required: false,
+                },
+                ToolParam {
+                    name: "timeout_ms".to_string(),
+                    description: "Maximum selector-packing time in milliseconds. Default 15000; returns partial unresolved selector entries on timeout.".to_string(),
+                    param_type: "number".to_string(),
+                    required: false,
+                },
+                ToolParam {
+                    name: "refresh".to_string(),
+                    description: "Default false; use the existing graph snapshot instead of doing an inline auto-refresh. Set true only when a potentially slow refresh is acceptable.".to_string(),
                     param_type: "boolean".to_string(),
                     required: false,
                 },
@@ -48,16 +63,27 @@ impl Tool for OrbitKnowledgePackTool {
             .get("summary")
             .and_then(Value::as_bool)
             .unwrap_or(true);
+        let selector_timeout_ms = parse_timeout_ms(&input)?;
+        let refresh = parse_refresh(&input)?;
         let knowledge_dir = super::knowledge_write::resolve_knowledge_dir(ctx, &input)?;
         let explicit_ref = super::optional_string(&input, "ref")?;
+        let explicit_knowledge_dir = super::has_explicit_knowledge_dir(&input);
+        let skip_auto_refresh = !refresh || explicit_knowledge_dir;
         let service =
             TaskGraphService::new(knowledge_dir, super::knowledge_write::task_graph_scope(ctx));
-        let pack = service.pack_json(
+        let mut pack = service.pack_json(
             &selectors,
             ctx.workspace_root.as_deref(),
-            super::has_explicit_knowledge_dir(&input),
+            skip_auto_refresh,
             explicit_ref.as_deref(),
+            Some(selector_timeout_ms),
         )?;
+        add_refresh_diagnostics(
+            &mut pack,
+            refresh,
+            explicit_ref.as_deref(),
+            explicit_knowledge_dir,
+        );
 
         Ok(if summary {
             summarize_pack_json(pack)
@@ -86,6 +112,63 @@ fn parse_selector_strings(input: &Value) -> Result<Vec<String>, OrbitError> {
         ));
     }
     Ok(selectors)
+}
+
+fn parse_timeout_ms(input: &Value) -> Result<u64, OrbitError> {
+    let Some(value) = input.get("timeout_ms") else {
+        return Ok(DEFAULT_PACK_TIMEOUT_MS);
+    };
+    if value.is_null() {
+        return Ok(DEFAULT_PACK_TIMEOUT_MS);
+    }
+    let Some(timeout_ms) = value.as_u64() else {
+        return Err(OrbitError::InvalidInput(
+            "`timeout_ms` must be a non-negative integer".to_string(),
+        ));
+    };
+    if timeout_ms > MAX_PACK_TIMEOUT_MS {
+        return Err(OrbitError::InvalidInput(format!(
+            "`timeout_ms` must be <= {MAX_PACK_TIMEOUT_MS}"
+        )));
+    }
+    Ok(timeout_ms)
+}
+
+fn parse_refresh(input: &Value) -> Result<bool, OrbitError> {
+    let Some(value) = input.get("refresh") else {
+        return Ok(false);
+    };
+    if value.is_null() {
+        return Ok(false);
+    }
+    value
+        .as_bool()
+        .ok_or_else(|| OrbitError::InvalidInput("`refresh` must be a boolean".to_string()))
+}
+
+fn add_refresh_diagnostics(
+    pack: &mut Value,
+    refresh: bool,
+    explicit_ref: Option<&str>,
+    explicit_knowledge_dir: bool,
+) {
+    if refresh || explicit_ref.is_some() || explicit_knowledge_dir {
+        return;
+    }
+    let Some(obj) = pack.as_object_mut() else {
+        return;
+    };
+
+    obj.insert(
+        "diagnostics".to_string(),
+        json!({
+            "auto_refresh": {
+                "status": "skipped",
+                "reason": "orbit.graph.pack reads the existing graph snapshot by default so selector gathering returns promptly.",
+                "remediation": "Run `orbit graph build` for an explicit refresh, or pass `refresh: true` when an inline refresh is acceptable."
+            }
+        }),
+    );
 }
 
 fn summarize_pack_json(mut pack: Value) -> Value {

--- a/crates/orbit-tools/tests/graph_tool_surface.rs
+++ b/crates/orbit-tools/tests/graph_tool_surface.rs
@@ -1,5 +1,6 @@
 use std::fs;
 use std::path::Path;
+use std::process::Command;
 
 use orbit_common::types::OrbitError;
 use orbit_knowledge::graph::object_store::RefName;
@@ -629,6 +630,85 @@ fn pack_defaults_to_summary_without_leaf_bodies() {
 }
 
 #[test]
+fn pack_timeout_returns_unresolved_entries_for_unprocessed_selectors() {
+    let impl_leaf = leaf_node(
+        "src/runtime.rs",
+        "AgentRuntimeImpl",
+        LeafKind::Impl,
+        "impl AgentRuntime for CodexRuntime {\n    fn run(&self) {}\n}\n",
+    );
+    let fixture = write_graph_fixture(graph_with_root(
+        vec![attach_leaf(
+            file_node("src/runtime.rs", "rust", Some("rs"), vec![]),
+            &impl_leaf,
+        )],
+        vec![impl_leaf],
+    ));
+
+    let response = execute_graph_tool(
+        fixture.path(),
+        "orbit.graph.pack",
+        json!({
+            "selectors": [
+                "symbol:src/runtime.rs#AgentRuntimeImpl:impl",
+                "file:src/runtime.rs"
+            ],
+            "timeout_ms": 0
+        }),
+    );
+
+    assert_eq!(response["timeout"]["timeout_ms"], 0);
+    assert_eq!(response["timeout"]["processed_selectors"], 0);
+    assert_eq!(response["timeout"]["total_selectors"], 2);
+    assert_eq!(response["total_nodes"], 0);
+    assert_eq!(
+        response["unresolved_selectors"].as_array().unwrap().len(),
+        2
+    );
+    assert_eq!(response["entries"].as_array().unwrap().len(), 2);
+    assert_eq!(response["entries"][0]["kind"], "unresolved");
+    assert!(
+        response["entries"][0]["hint"]
+            .as_str()
+            .unwrap()
+            .contains("timed out")
+    );
+}
+
+#[test]
+fn pack_skips_inline_refresh_by_default_with_diagnostic() {
+    let impl_leaf = leaf_node(
+        "src/runtime.rs",
+        "AgentRuntimeImpl",
+        LeafKind::Impl,
+        "impl AgentRuntime for CodexRuntime {\n    fn run(&self) {}\n}\n",
+    );
+    let fixture = write_graph_fixture(graph_with_root(
+        vec![attach_leaf(
+            file_node("src/runtime.rs", "rust", Some("rs"), vec![]),
+            &impl_leaf,
+        )],
+        vec![impl_leaf],
+    ));
+    init_git_repo(fixture.path());
+
+    let response = execute_graph_tool_unpinned(
+        fixture.path(),
+        "orbit.graph.pack",
+        json!({"selectors":["symbol:src/runtime.rs#AgentRuntimeImpl:impl"]}),
+    );
+
+    assert_eq!(response["diagnostics"]["auto_refresh"]["status"], "skipped");
+    assert!(
+        response["diagnostics"]["auto_refresh"]["remediation"]
+            .as_str()
+            .unwrap()
+            .contains("refresh: true")
+    );
+    assert_eq!(response["entries"][0]["kind"], "leaf");
+}
+
+#[test]
 fn pack_rejects_invalid_selector_shapes() {
     let impl_leaf = leaf_node(
         "src/runtime.rs",
@@ -658,6 +738,65 @@ fn pack_rejects_invalid_selector_shapes() {
     .unwrap_err()
     .to_string();
     assert!(object_shape.contains("`selectors` must be a string or array of strings"));
+
+    let timeout_shape = execute_graph_tool_result(
+        fixture.path(),
+        "orbit.graph.pack",
+        json!({"selectors":["symbol:src/runtime.rs#AgentRuntimeImpl:impl"],"timeout_ms":"15s"}),
+    )
+    .unwrap_err()
+    .to_string();
+    assert!(timeout_shape.contains("`timeout_ms` must be a non-negative integer"));
+
+    let refresh_shape = execute_graph_tool_result(
+        fixture.path(),
+        "orbit.graph.pack",
+        json!({"selectors":["symbol:src/runtime.rs#AgentRuntimeImpl:impl"],"refresh":"yes"}),
+    )
+    .unwrap_err()
+    .to_string();
+    assert!(refresh_shape.contains("`refresh` must be a boolean"));
+}
+
+#[test]
+fn pack_schema_exposes_timeout_and_refresh_controls() {
+    let mut registry = ToolRegistry::new();
+    registry.register_builtins();
+
+    let schema = registry
+        .get_schema("orbit.graph.pack")
+        .expect("pack schema registered");
+    let timeout = schema
+        .parameters
+        .iter()
+        .find(|param| param.name == "timeout_ms")
+        .expect("timeout_ms parameter present");
+    assert!(!timeout.required);
+    assert_eq!(timeout.param_type, "number");
+
+    let refresh = schema
+        .parameters
+        .iter()
+        .find(|param| param.name == "refresh")
+        .expect("refresh parameter present");
+    assert!(!refresh.required);
+    assert_eq!(refresh.param_type, "boolean");
+}
+
+fn execute_graph_tool_unpinned(repo_root: &Path, tool_name: &str, input: Value) -> Value {
+    let mut registry = ToolRegistry::new();
+    registry.register_builtins();
+
+    registry
+        .execute(
+            tool_name,
+            &ToolContext {
+                workspace_root: Some(repo_root.to_path_buf()),
+                ..ToolContext::default()
+            },
+            input,
+        )
+        .unwrap_or_else(|error| panic!("tool `{tool_name}` failed: {error}"))
 }
 
 fn execute_graph_tool(repo_root: &Path, tool_name: &str, input: Value) -> Value {
@@ -708,6 +847,19 @@ fn write_repo_file(repo_root: &Path, rel: &str, content: &str) {
         fs::create_dir_all(parent).unwrap();
     }
     fs::write(path, content).unwrap();
+}
+
+fn init_git_repo(repo_root: &Path) {
+    let output = Command::new("git")
+        .args(["init", "-b", GRAPH_REF])
+        .current_dir(repo_root)
+        .output()
+        .expect("run git init");
+    assert!(
+        output.status.success(),
+        "git init failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
 }
 
 fn write_graph_fixture(graph: CodebaseGraphV1) -> TempDir {

--- a/docs/design/knowledge-graph/2_design.md
+++ b/docs/design/knowledge-graph/2_design.md
@@ -150,7 +150,7 @@ All tool inputs that reference a node accept a selector string.
 | Implementors | `trait_implementors(trait)` | [T20260412-0645-3] |
 | Dependencies | `crate_dependencies(crate)` | [T20260412-0645-3] |
 | Lineage | `render_lineage_pack(selector)` | — |
-| Pack | `pack_json(...)` | Agent-friendly field projection ships in the same era as [T20260411-0424] |
+| Pack | `pack_json(...)` | Agent-friendly field projection ships in the same era as [T20260411-0424]; selector packing is bounded and prompt-first by default after [T20260505-5] |
 
 All services are read-only against a resolved snapshot. Graph mutation code remains internal/deferred; the current public surface does not expose graph write tools.
 
@@ -196,6 +196,8 @@ The knowledge graph is exposed through `orbit-mcp` as a stable, read-only tool s
 
 An explicit `ref` means "read the stored graph for this ref." It does not trigger a rebuild against whatever branch is currently checked out, and it does not overlay task-local working-graph edits onto that explicit historical ref. That is a subtle but load-bearing rule for historical queries.
 
+`orbit.graph.pack` optimizes for the agent context-gathering path. It reads the existing graph snapshot by default instead of starting an inline auto-refresh, and returns an `auto_refresh.skipped` diagnostic with remediation guidance. Callers that deliberately want the old inline refresh path pass `refresh: true`. The packer also accepts `timeout_ms` (default 15000) for selector projection; when the budget is exhausted between selectors, remaining selectors are returned as unresolved entries with timeout hints rather than withholding all results ([T20260505-5]).
+
 ### 4.3 Activity interaction
 
 Activities use graph tools for inspection and prompt assembly only. Code-mutating workflows coordinate before dispatch with task `context_files` and `orbit.task.locks.reserve` preflight guards, then rely on optimistic integration/review checks to catch stale or overlapping edits. Activities that only read query the service directly.
@@ -233,7 +235,7 @@ Hunk-to-symbol mapping uses line-range overlap against the symbol span *at the c
 
 ### 6.4 The graph is a snapshot, not a stream
 
-Queries answer "what does this branch look like as of the last build." Public file edits are stale relative to the graph until the next refresh; deferred/internal working-graph mutations are the only path that can model mid-edit state. `ensure_fresh` narrows the gap but does not close it — a read right after an external edit and before a debounce window elapses can return pre-edit results.
+Queries answer "what does this branch look like as of the last build." Public file edits are stale relative to the graph until the next refresh; deferred/internal working-graph mutations are the only path that can model mid-edit state. `ensure_fresh` narrows the gap but does not close it — a read right after an external edit and before a debounce window elapses can return pre-edit results. `orbit.graph.pack` is intentionally more conservative than the other read tools: it skips inline refresh by default so task context selection cannot disappear into a rebuild without prompt-visible timeout guidance ([T20260505-5]).
 
 ### 6.5 Branch-scoped refs do not solve worktree-local reads
 
@@ -289,5 +291,6 @@ The read cache is per `KnowledgeStore`, not global ([T20260426-0141]). Long-runn
 - **[T20260428-1]** — Align graph task-ID attribution/search with current unpadded task IDs.
 - **[T20260430-22]** — Compact the knowledge-graph design docs and remove duplicate top-level narrative.
 - **[T20260505-11]** — Add TypeScript and TSX extraction coverage, documented by gpt-5.5.
+- **[T20260505-5]** — Bound `orbit.graph.pack` selector gathering and skip inline refresh by default, documented by gpt-5.5.
 
 Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.

--- a/docs/design/knowledge-graph/4_decisions.md
+++ b/docs/design/knowledge-graph/4_decisions.md
@@ -385,6 +385,22 @@ Format for each entry: **Status · Date · Task(s)**, then *Context → Decision
 
 ---
 
+## ADR-025 — Pack favors prompt-time responsiveness over inline refresh
+
+**Status:** Accepted · 2026-05 · [T20260505-5]
+**Author:** gpt-5.5
+
+**Context.** Agents use `orbit.graph.pack` at the start of execution to turn task context selectors into prompt material. Letting that call trigger an unbounded inline graph refresh can make the selector-first workflow appear hung, with no partial selector results or timeout hint.
+
+**Decision.** Make `orbit.graph.pack` read the existing graph snapshot by default and return an `auto_refresh.skipped` diagnostic that names the explicit refresh path. Add a `refresh: true` opt-in for callers that accept a potentially slow inline refresh, and add `timeout_ms` so selector projection can return unresolved entries for selectors not reached before the budget expires.
+
+**Consequences.**
+- Context-gathering agents get prompt-visible guidance instead of a silent rebuild when the snapshot is stale.
+- Timed-out pack calls can still return the selectors already projected plus unresolved entries for the remainder.
+- Cost: default pack reads can be stale until a separate `orbit graph build` or an opt-in refresh updates the branch ref.
+
+---
+
 ## Task References
 
 Tasks cited by ADRs above:
@@ -421,6 +437,7 @@ Tasks cited by ADRs above:
 - **[T20260428-3]** — Expose the full read-only graph tool set through the MCP safe surface for Codex and Gemini.
 - **[T20260430-22]** — Compact the knowledge-graph design docs and fold the obsolete evidence log into ADR-018.
 - **[T20260505-1]** — Require auto-refresh freshness checks to materialize missing current-branch graph refs before returning fresh.
+- **[T20260505-5]** — Bound `orbit.graph.pack` selector gathering and skip inline refresh by default.
 - **[T20260505-11]** — Add TypeScript and TSX classification, extraction, graph search/pack coverage, and symbol-level history attribution.
 
 Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.


### PR DESCRIPTION
## Tasks
- [T20260505-5] orbit.graph.pack provides no progress or timeout when gathering context selectors
  <details><summary>Execution Summary</summary>

## Status
success

## Summary of Changes
Added bounded selector packing for orbit.graph.pack via timeout_ms, returning unresolved timeout entries instead of withholding all results. Changed pack to skip inline auto-refresh by default and emit prompt-visible diagnostics with refresh remediation, while retaining refresh:true as an explicit opt-in. Updated knowledge-graph design docs/ADR and added graph tool surface tests for timeout, diagnostics, schema, and validation.

## Overall Assessment
Implementation is scoped to graph pack context gathering and preserves existing explicit-ref behavior. Validation passed: make fmt, make build, cargo check -p orbit-knowledge -p orbit-tools, and cargo test -p orbit-tools --test graph_tool_surface pack_ -- --nocapture.

## Strategic Decisions
- Default pack reads the existing snapshot rather than refreshing inline | Rationale: selector-first task context should produce prompt-visible results or guidance quickly, not block behind an implicit rebuild.

## Design Weaknesses / Risks
- Default pack results can be stale until a separate graph build or refresh:true | Severity: Low | Mitigation: diagnostics explicitly name the opt-in refresh path and graph build remediation.

  </details>

## Branch Freshness
- Base ref: `origin/agent-main`
- Head ref: `orbit/T20260505-5-69f9694e`
- Behind base: 0
- Ahead of base: 1

## Files Changed
- `crates/orbit-knowledge/src/lib.rs`
- `crates/orbit-knowledge/src/service/task_graph.rs`
- `crates/orbit-knowledge/src/store.rs`
- `crates/orbit-knowledge/src/store/pack.rs`
- `crates/orbit-knowledge/src/store/task_state.rs`
- `crates/orbit-knowledge/src/store/types.rs`
- `crates/orbit-tools/src/builtin/orbit/knowledge_pack.rs`
- `crates/orbit-tools/tests/graph_tool_surface.rs`
- `docs/design/knowledge-graph/2_design.md`
- `docs/design/knowledge-graph/4_decisions.md`

*authored by: gpt-5.5*