### PR TITLE
Onboard Ruby to knowledge graph

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1658,6 +1658,7 @@ dependencies = [
  "tree-sitter-java",
  "tree-sitter-javascript",
  "tree-sitter-python",
+ "tree-sitter-ruby",
  "tree-sitter-rust",
  "tree-sitter-typescript",
 ]
@@ -2875,6 +2876,16 @@ name = "tree-sitter-python"
 version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6bf85fd39652e740bf60f46f4cda9492c3a9ad75880575bf14960f775cb74a1c"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-ruby"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be0484ea4ef6bb9c575b4fdabde7e31340a8d2dbc7d52b321ac83da703249f95"
 dependencies = [
  "cc",
  "tree-sitter-language",

--- a/crates/orbit-knowledge/Cargo.toml
+++ b/crates/orbit-knowledge/Cargo.toml
@@ -25,6 +25,7 @@ tree-sitter-javascript = "0.25.0"
 tree-sitter-typescript = "0.23.2"
 tree-sitter-rust = "0.24"
 tree-sitter-python = "0.25"
+tree-sitter-ruby = "0.23.1"
 lru = "0.17.0"
 rayon = "1.12.0"
 

--- a/crates/orbit-knowledge/src/extract/language.rs
+++ b/crates/orbit-knowledge/src/extract/language.rs
@@ -19,6 +19,7 @@ pub enum Language {
     JavaScript,
     TypeScript,
     Tsx,
+    Ruby,
 }
 
 impl Language {
@@ -31,6 +32,9 @@ impl Language {
             "js" | "jsx" | "mjs" | "cjs" => Some(Self::JavaScript),
             "ts" | "mts" | "cts" => Some(Self::TypeScript),
             "tsx" => Some(Self::Tsx),
+            // Ruby tooling commonly uses .rake tasks and .gemspec manifests;
+            // both are plain Ruby syntax for extractor purposes.
+            "rb" | "rake" | "gemspec" => Some(Self::Ruby),
             _ => None,
         }
     }
@@ -44,6 +48,7 @@ impl Language {
             Self::JavaScript => "javascript",
             Self::TypeScript => "typescript",
             Self::Tsx => "tsx",
+            Self::Ruby => "ruby",
         }
     }
 }
@@ -168,8 +173,21 @@ mod tests {
             FileKind::from_extension("tsx"),
             FileKind::Code(Language::Tsx)
         );
+        assert_eq!(
+            FileKind::from_extension("rb"),
+            FileKind::Code(Language::Ruby)
+        );
+        assert_eq!(
+            FileKind::from_extension("rake"),
+            FileKind::Code(Language::Ruby)
+        );
+        assert_eq!(
+            FileKind::from_extension("gemspec"),
+            FileKind::Code(Language::Ruby)
+        );
         assert_eq!(FileKind::from_extension("ts").as_str(), "typescript");
         assert_eq!(FileKind::from_extension("tsx").as_str(), "tsx");
+        assert_eq!(FileKind::from_extension("rb").as_str(), "ruby");
     }
 
     #[test]

--- a/crates/orbit-knowledge/src/extract/mod.rs
+++ b/crates/orbit-knowledge/src/extract/mod.rs
@@ -17,6 +17,7 @@ mod javascript;
 mod language;
 mod markdown;
 mod python;
+mod ruby;
 mod rust;
 mod table;
 mod typescript;
@@ -33,6 +34,7 @@ use java::JavaExtractor;
 use javascript::JavaScriptExtractor;
 use markdown::MarkdownExtractor;
 use python::PythonExtractor;
+use ruby::RubyExtractor;
 use rust::RustExtractor;
 use table::TableExtractor;
 use typescript::TypeScriptExtractor;
@@ -59,6 +61,7 @@ impl ExtractorRegistry {
             extractors: vec![
                 Box::new(RustExtractor),
                 Box::new(PythonExtractor),
+                Box::new(RubyExtractor),
                 Box::new(GoExtractor),
                 Box::new(JavaExtractor),
                 Box::new(JavaScriptExtractor),

--- a/crates/orbit-knowledge/src/extract/ruby.rs
+++ b/crates/orbit-knowledge/src/extract/ruby.rs
@@ -1,0 +1,495 @@
+use tree_sitter::{Node, Parser};
+
+use super::FileExtractor;
+use super::common::{ExtractedLeaf, ExtractionResult, compute_source_hash};
+use super::language::{FileKind, Language};
+
+pub struct RubyExtractor;
+
+impl FileExtractor for RubyExtractor {
+    fn file_kind(&self) -> FileKind {
+        FileKind::Code(Language::Ruby)
+    }
+
+    fn extract(&self, source: &str) -> ExtractionResult {
+        let mut parser = Parser::new();
+        parser
+            .set_language(&tree_sitter_ruby::LANGUAGE.into())
+            .expect("tree-sitter-ruby");
+
+        let tree = match parser.parse(source, None) {
+            Some(t) => t,
+            None => return ExtractionResult::default(),
+        };
+
+        let mut leaves = Vec::new();
+        extract_children(tree.root_node(), source, &mut leaves, None);
+        ExtractionResult {
+            leaves,
+            ..Default::default()
+        }
+    }
+}
+
+fn get_name(node: Node, source: &str) -> Option<String> {
+    node.child_by_field_name("name")
+        .map(|n| node_text(n, source))
+        .filter(|name| !name.is_empty())
+}
+
+fn node_text(node: Node, source: &str) -> String {
+    node.utf8_text(source.as_bytes())
+        .unwrap_or("")
+        .trim()
+        .to_string()
+}
+
+fn node_source(node: Node, source: &str) -> String {
+    source[node.start_byte()..node.end_byte()]
+        .trim_end()
+        .to_string()
+}
+
+fn qualify_name(parent: Option<&str>, name: &str) -> String {
+    match parent {
+        Some(parent) if !name.contains("::") => format!("{parent}::{name}"),
+        _ => name.to_string(),
+    }
+}
+
+fn extract_children(
+    node: Node,
+    source: &str,
+    leaves: &mut Vec<ExtractedLeaf>,
+    parent: Option<&str>,
+) -> Vec<String> {
+    let mut children = Vec::new();
+    let mut cursor = node.walk();
+
+    for child in node.children(&mut cursor) {
+        if !child.is_named() {
+            continue;
+        }
+
+        match child.kind() {
+            "module" => {
+                if let Some(qualified_name) = extract_scope(child, source, leaves, parent, "module")
+                {
+                    children.push(qualified_name);
+                }
+            }
+            "class" => {
+                if let Some(qualified_name) = extract_scope(child, source, leaves, parent, "class")
+                {
+                    children.push(qualified_name);
+                }
+            }
+            "singleton_class" => {
+                if let Some(qualified_name) = extract_singleton_class(child, source, leaves, parent)
+                {
+                    children.push(qualified_name);
+                }
+            }
+            "method" => {
+                if let Some(qualified_name) = extract_method(child, source, leaves, parent) {
+                    children.push(qualified_name);
+                }
+            }
+            "singleton_method" => {
+                if let Some(qualified_name) =
+                    extract_singleton_method(child, source, leaves, parent)
+                {
+                    children.push(qualified_name);
+                }
+            }
+            "assignment" if parent.is_none() => {
+                if let Some(qualified_name) = extract_top_level_constant(child, source, leaves) {
+                    children.push(qualified_name);
+                }
+            }
+            "call" => {
+                children.extend(extract_attr_call(child, source, leaves, parent));
+            }
+            "body_statement" | "program" => {
+                children.extend(extract_children(child, source, leaves, parent));
+            }
+            _ => {}
+        }
+    }
+
+    children
+}
+
+fn extract_scope(
+    node: Node,
+    source: &str,
+    leaves: &mut Vec<ExtractedLeaf>,
+    parent: Option<&str>,
+    kind: &str,
+) -> Option<String> {
+    let name = get_name(node, source)?;
+    let qualified_name = qualify_name(parent, &name);
+    let children = node
+        .child_by_field_name("body")
+        .map(|body| extract_children(body, source, leaves, Some(&qualified_name)))
+        .unwrap_or_default();
+    let src = node_source(node, source);
+
+    leaves.push(ExtractedLeaf {
+        qualified_name: qualified_name.clone(),
+        name,
+        kind: kind.to_string(),
+        start_line: node.start_position().row + 1,
+        end_line: node.end_position().row + 1,
+        source: src.clone(),
+        source_hash: compute_source_hash(&src),
+        parent_qualified_name: parent.map(str::to_string),
+        children_qualified_names: children,
+        depth: None,
+    });
+
+    Some(qualified_name)
+}
+
+fn extract_singleton_class(
+    node: Node,
+    source: &str,
+    leaves: &mut Vec<ExtractedLeaf>,
+    parent: Option<&str>,
+) -> Option<String> {
+    let value = node.child_by_field_name("value")?;
+    let name = node_text(value, source);
+    if name.is_empty() {
+        return None;
+    }
+
+    let qualified_name = match parent {
+        Some(parent) => format!("{parent}::{name}"),
+        None => name.clone(),
+    };
+    let children = node
+        .child_by_field_name("body")
+        .map(|body| extract_children(body, source, leaves, Some(&qualified_name)))
+        .unwrap_or_default();
+    let src = node_source(node, source);
+
+    leaves.push(ExtractedLeaf {
+        qualified_name: qualified_name.clone(),
+        name,
+        kind: "singleton_class".to_string(),
+        start_line: node.start_position().row + 1,
+        end_line: node.end_position().row + 1,
+        source: src.clone(),
+        source_hash: compute_source_hash(&src),
+        parent_qualified_name: parent.map(str::to_string),
+        children_qualified_names: children,
+        depth: None,
+    });
+
+    Some(qualified_name)
+}
+
+fn extract_method(
+    node: Node,
+    source: &str,
+    leaves: &mut Vec<ExtractedLeaf>,
+    parent: Option<&str>,
+) -> Option<String> {
+    let name = get_name(node, source)?;
+    let qualified_name = qualify_name(parent, &name);
+    push_leaf(
+        node,
+        source,
+        leaves,
+        &qualified_name,
+        &name,
+        "method",
+        parent,
+    );
+    Some(qualified_name)
+}
+
+fn extract_singleton_method(
+    node: Node,
+    source: &str,
+    leaves: &mut Vec<ExtractedLeaf>,
+    parent: Option<&str>,
+) -> Option<String> {
+    let object = node.child_by_field_name("object")?;
+    let method_name = get_name(node, source)?;
+    let object_name = node_text(object, source);
+    if object_name.is_empty() {
+        return None;
+    }
+
+    let name = format!("{object_name}.{method_name}");
+    let qualified_name = match parent {
+        Some(parent) if object_name == "self" => format!("{parent}.{method_name}"),
+        _ => name.clone(),
+    };
+
+    push_leaf(
+        node,
+        source,
+        leaves,
+        &qualified_name,
+        &name,
+        "singleton_method",
+        parent,
+    );
+    Some(qualified_name)
+}
+
+fn extract_top_level_constant(
+    node: Node,
+    source: &str,
+    leaves: &mut Vec<ExtractedLeaf>,
+) -> Option<String> {
+    let left = node.child_by_field_name("left")?;
+    if left.kind() != "constant" {
+        return None;
+    }
+
+    let name = node_text(left, source);
+    if name.is_empty() {
+        return None;
+    }
+
+    push_leaf(node, source, leaves, &name, &name, "constant", None);
+    Some(name)
+}
+
+// Ruby attr_* declarations define methods at runtime, so the graph records
+// each generated accessor as a method leaf while keeping the declaration's span.
+fn extract_attr_call(
+    node: Node,
+    source: &str,
+    leaves: &mut Vec<ExtractedLeaf>,
+    parent: Option<&str>,
+) -> Vec<String> {
+    if node.child_by_field_name("receiver").is_some() {
+        return Vec::new();
+    }
+
+    let Some(method) = node.child_by_field_name("method") else {
+        return Vec::new();
+    };
+    let method_name = node_text(method, source);
+    if !matches!(
+        method_name.as_str(),
+        "attr_accessor" | "attr_reader" | "attr_writer"
+    ) {
+        return Vec::new();
+    }
+
+    let Some(arguments) = node.child_by_field_name("arguments") else {
+        return Vec::new();
+    };
+
+    let accessors = attr_accessor_names(&method_name, arguments, source);
+    let mut children = Vec::new();
+    for name in accessors {
+        let qualified_name = qualify_name(parent, &name);
+        push_leaf(
+            node,
+            source,
+            leaves,
+            &qualified_name,
+            &name,
+            "method",
+            parent,
+        );
+        children.push(qualified_name);
+    }
+
+    children
+}
+
+fn attr_accessor_names(method_name: &str, arguments: Node, source: &str) -> Vec<String> {
+    let mut names = Vec::new();
+    let mut cursor = arguments.walk();
+
+    for child in arguments.children(&mut cursor) {
+        if !matches!(child.kind(), "simple_symbol" | "string") {
+            continue;
+        }
+        let Some(name) = literal_attribute_name(child, source) else {
+            continue;
+        };
+
+        match method_name {
+            "attr_accessor" => {
+                names.push(name.clone());
+                names.push(format!("{name}="));
+            }
+            "attr_reader" => names.push(name),
+            "attr_writer" => names.push(format!("{name}=")),
+            _ => {}
+        }
+    }
+
+    names
+}
+
+fn literal_attribute_name(node: Node, source: &str) -> Option<String> {
+    let raw = node_text(node, source);
+    let name = raw
+        .trim_start_matches(':')
+        .trim_matches('"')
+        .trim_matches('\'')
+        .to_string();
+    (!name.is_empty()).then_some(name)
+}
+
+fn push_leaf(
+    node: Node,
+    source: &str,
+    leaves: &mut Vec<ExtractedLeaf>,
+    qualified_name: &str,
+    name: &str,
+    kind: &str,
+    parent: Option<&str>,
+) {
+    let src = node_source(node, source);
+    leaves.push(ExtractedLeaf {
+        qualified_name: qualified_name.to_string(),
+        name: name.to_string(),
+        kind: kind.to_string(),
+        start_line: node.start_position().row + 1,
+        end_line: node.end_position().row + 1,
+        source: src.clone(),
+        source_hash: compute_source_hash(&src),
+        parent_qualified_name: parent.map(str::to_string),
+        children_qualified_names: vec![],
+        depth: None,
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn fixture() -> &'static str {
+        r#"APP_ROOT = "/srv"
+
+module Billing
+  class Invoice
+    attr_accessor :total
+    attr_reader :status
+    attr_writer :token
+
+    def initialize(total)
+      @total = total
+    end
+
+    def self.from_hash(hash)
+      new(hash[:total])
+    end
+
+    class << self
+      def reset_cache
+      end
+    end
+  end
+end"#
+    }
+
+    fn leaf<'a>(leaves: &'a [ExtractedLeaf], name: &str, kind: &str) -> &'a ExtractedLeaf {
+        leaves
+            .iter()
+            .find(|leaf| leaf.name == name && leaf.kind == kind)
+            .unwrap_or_else(|| panic!("missing {kind} leaf {name}"))
+    }
+
+    #[test]
+    fn file_kind_is_ruby() {
+        assert_eq!(RubyExtractor.file_kind(), FileKind::Code(Language::Ruby));
+    }
+
+    #[test]
+    fn extracts_ruby_declarations_and_runtime_accessors() {
+        let result = RubyExtractor.extract(fixture());
+        let leaves = result.leaves;
+
+        let constant = leaf(&leaves, "APP_ROOT", "constant");
+        assert_eq!(constant.start_line, 1);
+        assert_eq!(constant.end_line, 1);
+
+        let module = leaf(&leaves, "Billing", "module");
+        assert_eq!(module.qualified_name, "Billing");
+        assert_eq!(module.start_line, 3);
+        assert_eq!(module.end_line, 22);
+        assert!(
+            module
+                .children_qualified_names
+                .contains(&"Billing::Invoice".to_string())
+        );
+
+        let class = leaf(&leaves, "Invoice", "class");
+        assert_eq!(class.qualified_name, "Billing::Invoice");
+        assert_eq!(class.parent_qualified_name.as_deref(), Some("Billing"));
+        assert_eq!(class.start_line, 4);
+        assert_eq!(class.end_line, 21);
+
+        let initialize = leaf(&leaves, "initialize", "method");
+        assert_eq!(initialize.qualified_name, "Billing::Invoice::initialize");
+        assert_eq!(
+            initialize.parent_qualified_name.as_deref(),
+            Some("Billing::Invoice")
+        );
+        assert_eq!(initialize.start_line, 9);
+        assert_eq!(initialize.end_line, 11);
+
+        let singleton_method = leaf(&leaves, "self.from_hash", "singleton_method");
+        assert_eq!(
+            singleton_method.qualified_name,
+            "Billing::Invoice.from_hash"
+        );
+        assert_eq!(
+            singleton_method.parent_qualified_name.as_deref(),
+            Some("Billing::Invoice")
+        );
+        assert_eq!(singleton_method.start_line, 13);
+        assert_eq!(singleton_method.end_line, 15);
+
+        let singleton_class = leaf(&leaves, "self", "singleton_class");
+        assert_eq!(singleton_class.qualified_name, "Billing::Invoice::self");
+        assert_eq!(singleton_class.start_line, 17);
+        assert_eq!(singleton_class.end_line, 20);
+
+        let reader = leaf(&leaves, "total", "method");
+        assert_eq!(reader.qualified_name, "Billing::Invoice::total");
+        assert_eq!(reader.start_line, 5);
+        assert_eq!(reader.end_line, 5);
+        assert_eq!(reader.source, "attr_accessor :total");
+
+        let accessor_writer = leaf(&leaves, "total=", "method");
+        assert_eq!(accessor_writer.qualified_name, "Billing::Invoice::total=");
+        assert_eq!(accessor_writer.start_line, 5);
+        assert_eq!(accessor_writer.end_line, 5);
+
+        let attr_reader = leaf(&leaves, "status", "method");
+        assert_eq!(attr_reader.start_line, 6);
+        assert_eq!(attr_reader.end_line, 6);
+
+        let attr_writer = leaf(&leaves, "token=", "method");
+        assert_eq!(attr_writer.start_line, 7);
+        assert_eq!(attr_writer.end_line, 7);
+    }
+
+    #[test]
+    fn ignores_explicit_receiver_attr_calls() {
+        let result = RubyExtractor.extract(
+            r#"class Account
+  Other.attr_accessor :token
+end"#,
+        );
+
+        assert!(
+            result
+                .leaves
+                .iter()
+                .all(|leaf| leaf.name != "token" && leaf.name != "token=")
+        );
+    }
+}

--- a/crates/orbit-knowledge/src/graph/nodes.rs
+++ b/crates/orbit-knowledge/src/graph/nodes.rs
@@ -12,7 +12,9 @@ use serde::{Deserialize, Serialize};
 pub enum LeafKind {
     Function,
     Method,
+    SingletonMethod,
     Class,
+    SingletonClass,
     Enum,
     Struct,
     Interface,
@@ -20,6 +22,7 @@ pub enum LeafKind {
     Trait,
     Impl,
     Field,
+    Constant,
     Module,
     /// Markdown ATX heading (`#`–`######`). `depth` is 1–6. Added T20260422-1540.
     Section {
@@ -37,7 +40,9 @@ impl fmt::Display for LeafKind {
         let s = match self {
             Self::Function => "function",
             Self::Method => "method",
+            Self::SingletonMethod => "singleton_method",
             Self::Class => "class",
+            Self::SingletonClass => "singleton_class",
             Self::Enum => "enum",
             Self::Struct => "struct",
             Self::Interface => "interface",
@@ -45,6 +50,7 @@ impl fmt::Display for LeafKind {
             Self::Trait => "trait",
             Self::Impl => "impl",
             Self::Field => "field",
+            Self::Constant => "constant",
             Self::Module => "module",
             Self::Section { .. } => "section",
             Self::ConfigKey => "config_key",

--- a/crates/orbit-knowledge/src/pipeline/attribute.rs
+++ b/crates/orbit-knowledge/src/pipeline/attribute.rs
@@ -887,7 +887,16 @@ mod tests {
     #[test]
     fn leaf_kind_to_str_matches_extractor_lowercase() {
         assert_eq!(leaf_kind_to_str(&LeafKind::Function), "function");
+        assert_eq!(
+            leaf_kind_to_str(&LeafKind::SingletonMethod),
+            "singleton_method"
+        );
         assert_eq!(leaf_kind_to_str(&LeafKind::Struct), "struct");
+        assert_eq!(
+            leaf_kind_to_str(&LeafKind::SingletonClass),
+            "singleton_class"
+        );
+        assert_eq!(leaf_kind_to_str(&LeafKind::Constant), "constant");
         assert_eq!(leaf_kind_to_str(&LeafKind::Trait), "trait");
     }
 

--- a/crates/orbit-knowledge/src/pipeline/build.rs
+++ b/crates/orbit-knowledge/src/pipeline/build.rs
@@ -565,7 +565,9 @@ fn parse_leaf_kind(s: &str, depth: Option<u8>) -> LeafKind {
     match s {
         "function" => LeafKind::Function,
         "method" => LeafKind::Method,
+        "singleton_method" => LeafKind::SingletonMethod,
         "class" => LeafKind::Class,
+        "singleton_class" => LeafKind::SingletonClass,
         "enum" => LeafKind::Enum,
         "struct" => LeafKind::Struct,
         "interface" => LeafKind::Interface,
@@ -573,6 +575,7 @@ fn parse_leaf_kind(s: &str, depth: Option<u8>) -> LeafKind {
         "trait" => LeafKind::Trait,
         "impl" => LeafKind::Impl,
         "field" => LeafKind::Field,
+        "constant" => LeafKind::Constant,
         "module" => LeafKind::Module,
         "section" => LeafKind::Section {
             depth: depth.unwrap_or(1),

--- a/docs/design/knowledge-graph/4_decisions.md
+++ b/docs/design/knowledge-graph/4_decisions.md
@@ -43,11 +43,11 @@ Format for each entry: **Status · Date · Task(s)**, then *Context → Decision
 
 ## ADR-003 — Tree-sitter extractors over an LSP backend
 
-**Status:** Accepted · 2026-04 · [T20260406-0455-3], [T20260416-0352]
+**Status:** Accepted · 2026-04 · [T20260406-0455-3], [T20260416-0352], [T20260505-11], [T20260505-15]
 
-**Context.** Reference resolution is strongest via a language server, but LSPs are stateful long-running processes tuned for interactive UX. Agent tools want bulk, structured, token-budgeted output and low lifecycle overhead. The Rust extractor landed first ([T20260406-0455-3], hardened in [T20260409-0550]); Go, Java, and JavaScript followed in [T20260416-0352], and TypeScript/TSX followed in [T20260505-11].
+**Context.** Reference resolution is strongest via a language server, but LSPs are stateful long-running processes tuned for interactive UX. Agent tools want bulk, structured, token-budgeted output and low lifecycle overhead. The Rust extractor landed first ([T20260406-0455-3], hardened in [T20260409-0550]); Go, Java, and JavaScript followed in [T20260416-0352], TypeScript/TSX followed in [T20260505-11], and Ruby followed in [T20260505-15].
 
-**Decision.** Use tree-sitter grammars with per-language extractors (`rust`, `python`, `go`, `java`, `javascript`, `typescript`, `tsx`) producing structural symbols only. Defer cross-file reference resolution indefinitely. See [3_vision.md §1.1] for the open question of re-introducing LSP as a pluggable backend.
+**Decision.** Use tree-sitter grammars with per-language extractors (`rust`, `python`, `go`, `java`, `javascript`, `typescript`, `tsx`, `ruby`) producing structural symbols only. Defer cross-file reference resolution indefinitely. See [3_vision.md §1.1] for the open question of re-introducing LSP as a pluggable backend.
 
 **Consequences.**
 - Fast, deterministic extraction with no per-query process lifecycle.
@@ -439,5 +439,6 @@ Tasks cited by ADRs above:
 - **[T20260505-1]** — Require auto-refresh freshness checks to materialize missing current-branch graph refs before returning fresh.
 - **[T20260505-5]** — Bound `orbit.graph.pack` selector gathering and skip inline refresh by default.
 - **[T20260505-11]** — Add TypeScript and TSX classification, extraction, graph search/pack coverage, and symbol-level history attribution.
+- **[T20260505-15]** — Add Ruby classification, tree-sitter extraction, graph search coverage, and Ruby symbol kinds.
 
 Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.


### PR DESCRIPTION
## Tasks
- [T20260505-15] Onboard Ruby to knowledge graph
  <details><summary>Execution Summary</summary>

## Status
success

## Summary of Changes
Added Ruby knowledge-graph extraction with `tree-sitter-ruby`, language/extension classification for `.rb`, `.rake`, and `.gemspec`, extractor registry wiring, explicit graph leaf kinds for Ruby constants/singleton constructs, and deterministic Ruby unit coverage for modules, classes, singleton classes, methods, constants, and attr_* runtime accessors.

## Overall Assessment
The Ruby extractor is integrated and validated. `tree-sitter-ruby = "0.23.1"` builds against the workspace `tree-sitter = "0.26"`, and graph build/search finds Ruby class and method leaves from a smoke fixture.

## Strategic Decisions
- attr_accessor emits getter and setter method leaves; attr_reader emits a getter; attr_writer emits a setter. Rationale: these declarations define runtime methods and should be searchable like methods.
- Added `.rake` and `.gemspec` alongside `.rb`. Rationale: both are standard Ruby-syntax project files.
- Added `constant`, `singleton_class`, and `singleton_method` LeafKind variants. Rationale: preserve Ruby-specific extractor output instead of letting the graph parser fall back to `function`.

## Validation
- `cargo test -p orbit-knowledge --tests` passed with `CARGO_HOME=/tmp/orbit-cargo-home-jrun-20260505-0418-5`.
- `cargo build -p orbit-knowledge` passed with the same local Cargo cache.
- `make fmt` passed.
- `make build` passed with the same local Cargo cache.
- `PATH="$PWD/target/debug:$PATH" orbit graph build --repo "$PWD" --ref ruby-smoke` and `orbit graph search --ref ruby-smoke --json InvoiceRunner` returned Ruby method, singleton_method, and class selectors.
- Bare default `cargo test -p orbit-knowledge --tests` failed before compile because the agent cannot write to `/Users/daniel/.cargo/registry/cache/...`; filed friction task T20260505-17 and used a local Cargo cache for validation.

  </details>

## Branch Freshness
- Base ref: `origin/agent-main`
- Head ref: `orbit/T20260505-15-69f96fa8`
- Behind base: 0
- Ahead of base: 1

## Files Changed
- `Cargo.lock`
- `crates/orbit-knowledge/Cargo.toml`
- `crates/orbit-knowledge/src/extract/language.rs`
- `crates/orbit-knowledge/src/extract/mod.rs`
- `crates/orbit-knowledge/src/extract/ruby.rs`
- `crates/orbit-knowledge/src/graph/nodes.rs`
- `crates/orbit-knowledge/src/pipeline/attribute.rs`
- `crates/orbit-knowledge/src/pipeline/build.rs`
- `docs/design/knowledge-graph/4_decisions.md`

*authored by: claude-opus-4-7*