### PR TITLE
Onboard C to knowledge graph

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1654,6 +1654,7 @@ dependencies = [
  "toml",
  "tracing",
  "tree-sitter",
+ "tree-sitter-c",
  "tree-sitter-go",
  "tree-sitter-java",
  "tree-sitter-javascript",
@@ -2832,6 +2833,16 @@ dependencies = [
  "regex-syntax",
  "serde_json",
  "streaming-iterator",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-c"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9b2eb57a55fed6b00812912e730b7a275cf4fe98bfd6a5d76263d4438371728"
+dependencies = [
+ "cc",
  "tree-sitter-language",
 ]
 

--- a/crates/orbit-knowledge/Cargo.toml
+++ b/crates/orbit-knowledge/Cargo.toml
@@ -19,6 +19,7 @@ thiserror.workspace = true
 toml.workspace = true
 tracing.workspace = true
 tree-sitter = "0.26"
+tree-sitter-c = "0.24.2"
 tree-sitter-go = "0.25.0"
 tree-sitter-java = "0.23.5"
 tree-sitter-javascript = "0.25.0"

--- a/crates/orbit-knowledge/src/extract/c.rs
+++ b/crates/orbit-knowledge/src/extract/c.rs
@@ -1,0 +1,391 @@
+use tree_sitter::{Node, Parser};
+
+use super::FileExtractor;
+use super::common::{ExtractedLeaf, ExtractionResult, compute_source_hash};
+use super::language::{FileKind, Language};
+
+pub struct CExtractor;
+
+impl FileExtractor for CExtractor {
+    fn file_kind(&self) -> FileKind {
+        FileKind::Code(Language::C)
+    }
+
+    fn extract(&self, source: &str) -> ExtractionResult {
+        let mut parser = Parser::new();
+        parser
+            .set_language(&tree_sitter_c::LANGUAGE.into())
+            .expect("tree-sitter-c");
+
+        let tree = match parser.parse(source, None) {
+            Some(t) => t,
+            None => return ExtractionResult::default(),
+        };
+
+        let mut leaves = Vec::new();
+        extract_top_level(tree.root_node(), source, &mut leaves);
+        ExtractionResult {
+            leaves,
+            ..Default::default()
+        }
+    }
+}
+
+fn get_name(node: Node, source: &str) -> Option<String> {
+    node.child_by_field_name("name")
+        .map(|n| node_text(n, source))
+        .filter(|name| !name.is_empty())
+}
+
+fn node_text(node: Node, source: &str) -> String {
+    node.utf8_text(source.as_bytes())
+        .unwrap_or("")
+        .trim()
+        .to_string()
+}
+
+fn node_source(node: Node, source: &str) -> String {
+    source[node.start_byte()..node.end_byte()]
+        .trim_end()
+        .to_string()
+}
+
+fn extract_top_level(node: Node, source: &str, leaves: &mut Vec<ExtractedLeaf>) {
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        if !child.is_named() {
+            continue;
+        }
+
+        match child.kind() {
+            "function_definition" => extract_function_definition(child, source, leaves),
+            "declaration" => extract_declaration(child, source, leaves),
+            "type_definition" => extract_type_definition(child, source, leaves),
+            "struct_specifier" | "union_specifier" | "enum_specifier" => {
+                extract_tag_specifier(child, source, leaves)
+            }
+            "preproc_def" | "preproc_function_def" => extract_macro(child, source, leaves),
+            "preproc_if" | "preproc_ifdef" | "preproc_elif" | "preproc_elifdef"
+            | "preproc_else" => extract_top_level(child, source, leaves),
+            _ => {}
+        }
+    }
+}
+
+fn extract_function_definition(node: Node, source: &str, leaves: &mut Vec<ExtractedLeaf>) {
+    let Some(declarator) = node.child_by_field_name("declarator") else {
+        return;
+    };
+    let Some(name) = declarator_name(declarator, source) else {
+        return;
+    };
+
+    push_leaf(node, source, leaves, &name, &name, "function");
+}
+
+fn extract_declaration(node: Node, source: &str, leaves: &mut Vec<ExtractedLeaf>) {
+    if let Some(type_node) = node.child_by_field_name("type") {
+        extract_tag_specifier(type_node, source, leaves);
+    }
+
+    for declarator in declarators(node) {
+        let Some(name) = declarator_name(declarator, source) else {
+            continue;
+        };
+
+        if is_function_prototype_declarator(declarator, source) {
+            // Prototypes and definitions both represent callable C symbols.
+            // The kind tag distinguishes header/source declarations from
+            // definitions because ExtractedLeaf has no separate signature field.
+            push_leaf(node, source, leaves, &name, &name, "function_declaration");
+        } else {
+            push_leaf(node, source, leaves, &name, &name, "global");
+        }
+    }
+}
+
+fn extract_type_definition(node: Node, source: &str, leaves: &mut Vec<ExtractedLeaf>) {
+    if let Some(type_node) = node.child_by_field_name("type") {
+        extract_tag_specifier(type_node, source, leaves);
+    }
+
+    for declarator in declarators(node) {
+        let Some(name) = declarator_name(declarator, source) else {
+            continue;
+        };
+        push_leaf(node, source, leaves, &name, &name, "type_alias");
+    }
+}
+
+fn extract_tag_specifier(node: Node, source: &str, leaves: &mut Vec<ExtractedLeaf>) {
+    let kind = match node.kind() {
+        "struct_specifier" => "struct",
+        "union_specifier" => "union",
+        "enum_specifier" => "enum",
+        _ => return,
+    };
+
+    if node.child_by_field_name("body").is_none() {
+        return;
+    }
+
+    let Some(name) = get_name(node, source) else {
+        return;
+    };
+    push_leaf(node, source, leaves, &name, &name, kind);
+}
+
+fn extract_macro(node: Node, source: &str, leaves: &mut Vec<ExtractedLeaf>) {
+    let Some(name) = get_name(node, source) else {
+        return;
+    };
+    push_leaf(node, source, leaves, &name, &name, "macro");
+}
+
+fn declarators(node: Node) -> Vec<Node> {
+    let mut nodes = Vec::new();
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        if is_declarator_kind(child.kind()) {
+            nodes.push(child);
+        }
+    }
+    nodes
+}
+
+fn declarator_name(node: Node, source: &str) -> Option<String> {
+    match node.kind() {
+        "identifier" | "type_identifier" | "field_identifier" => Some(node_text(node, source)),
+        "init_declarator" | "function_declarator" | "array_declarator" | "pointer_declarator" => {
+            child_declarator(node).and_then(|child| declarator_name(child, source))
+        }
+        "attributed_declarator" | "parenthesized_declarator" => {
+            first_declarator_child(node).and_then(|child| declarator_name(child, source))
+        }
+        _ => None,
+    }
+    .filter(|name| !name.is_empty())
+}
+
+fn is_function_prototype_declarator(node: Node, source: &str) -> bool {
+    if node.kind() != "function_declarator" {
+        return false;
+    }
+
+    let Some(inner) = child_declarator(node) else {
+        return false;
+    };
+    declarator_name(inner, source).is_some() && !contains_parenthesized_pointer(inner)
+}
+
+fn contains_parenthesized_pointer(node: Node) -> bool {
+    if node.kind() == "parenthesized_declarator"
+        && first_declarator_child(node)
+            .map(|child| child.kind() == "pointer_declarator")
+            .unwrap_or(false)
+    {
+        return true;
+    }
+
+    child_declarator(node)
+        .map(contains_parenthesized_pointer)
+        .unwrap_or(false)
+}
+
+fn child_declarator(node: Node) -> Option<Node> {
+    node.child_by_field_name("declarator")
+        .or_else(|| first_declarator_child(node))
+}
+
+fn first_declarator_child(node: Node) -> Option<Node> {
+    let mut cursor = node.walk();
+    node.children(&mut cursor)
+        .find(|child| is_declarator_kind(child.kind()))
+}
+
+fn is_declarator_kind(kind: &str) -> bool {
+    matches!(
+        kind,
+        "array_declarator"
+            | "attributed_declarator"
+            | "function_declarator"
+            | "identifier"
+            | "init_declarator"
+            | "parenthesized_declarator"
+            | "pointer_declarator"
+            | "type_identifier"
+    )
+}
+
+fn push_leaf(
+    node: Node,
+    source: &str,
+    leaves: &mut Vec<ExtractedLeaf>,
+    name: &str,
+    qualified_name: &str,
+    kind: &str,
+) {
+    let src = node_source(node, source);
+    let start_line = node.start_position().row + 1;
+    let line_count = src.lines().count().max(1);
+    leaves.push(ExtractedLeaf {
+        qualified_name: qualified_name.to_string(),
+        name: name.to_string(),
+        kind: kind.to_string(),
+        start_line,
+        end_line: start_line + line_count - 1,
+        source: src.clone(),
+        source_hash: compute_source_hash(&src),
+        parent_qualified_name: None,
+        children_qualified_names: vec![],
+        depth: None,
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn source_fixture() -> &'static str {
+        r#"#define ORBIT_C_LIMIT 16
+
+struct OrbitPacket {
+    int id;
+    const char *payload;
+};
+
+union OrbitValue {
+    int as_int;
+    float as_float;
+};
+
+enum OrbitState {
+    ORBIT_IDLE,
+    ORBIT_ACTIVE,
+};
+
+typedef struct OrbitPacket OrbitPacketAlias;
+
+int orbit_global_counter = 0;
+
+static void orbit_reset(void) {
+    orbit_global_counter = 0;
+}
+
+int orbit_sum(int left, int right) {
+    return left + right;
+}"#
+    }
+
+    fn header_fixture() -> &'static str {
+        r#"#ifndef ORBIT_PACKET_H
+#define ORBIT_PACKET_H
+
+#define ORBIT_PACKET_MAGIC 0x51
+
+struct OrbitHeader {
+    unsigned version;
+};
+
+typedef enum OrbitHeaderKind {
+    ORBIT_HEADER_SHORT,
+    ORBIT_HEADER_LONG,
+} OrbitHeaderKind;
+
+extern int orbit_header_global;
+
+int orbit_parse_header(const char *bytes, unsigned len);
+void orbit_emit_header(struct OrbitHeader *header);
+
+#endif"#
+    }
+
+    fn leaf<'a>(leaves: &'a [ExtractedLeaf], name: &str, kind: &str) -> &'a ExtractedLeaf {
+        leaves
+            .iter()
+            .find(|leaf| leaf.name == name && leaf.kind == kind)
+            .unwrap_or_else(|| panic!("missing {kind} leaf {name}"))
+    }
+
+    #[test]
+    fn file_kind_is_c() {
+        assert_eq!(CExtractor.file_kind(), FileKind::Code(Language::C));
+    }
+
+    #[test]
+    fn extracts_c_source_symbols() {
+        let result = CExtractor.extract(source_fixture());
+        let leaves = result.leaves;
+
+        let macro_leaf = leaf(&leaves, "ORBIT_C_LIMIT", "macro");
+        assert_eq!(macro_leaf.start_line, 1);
+        assert_eq!(macro_leaf.end_line, 1);
+
+        let struct_leaf = leaf(&leaves, "OrbitPacket", "struct");
+        assert_eq!(struct_leaf.start_line, 3);
+        assert_eq!(struct_leaf.end_line, 6);
+
+        let union_leaf = leaf(&leaves, "OrbitValue", "union");
+        assert_eq!(union_leaf.start_line, 8);
+        assert_eq!(union_leaf.end_line, 11);
+
+        let enum_leaf = leaf(&leaves, "OrbitState", "enum");
+        assert_eq!(enum_leaf.start_line, 13);
+        assert_eq!(enum_leaf.end_line, 16);
+
+        let typedef_leaf = leaf(&leaves, "OrbitPacketAlias", "type_alias");
+        assert_eq!(typedef_leaf.start_line, 18);
+        assert_eq!(typedef_leaf.end_line, 18);
+
+        let global_leaf = leaf(&leaves, "orbit_global_counter", "global");
+        assert_eq!(global_leaf.start_line, 20);
+        assert_eq!(global_leaf.end_line, 20);
+
+        let reset_leaf = leaf(&leaves, "orbit_reset", "function");
+        assert_eq!(reset_leaf.start_line, 22);
+        assert_eq!(reset_leaf.end_line, 24);
+        assert!(reset_leaf.source.starts_with("static void orbit_reset"));
+
+        let sum_leaf = leaf(&leaves, "orbit_sum", "function");
+        assert_eq!(sum_leaf.start_line, 26);
+        assert_eq!(sum_leaf.end_line, 28);
+    }
+
+    #[test]
+    fn extracts_c_header_symbols_and_prototypes() {
+        let result = CExtractor.extract(header_fixture());
+        let leaves = result.leaves;
+
+        let macro_leaf = leaf(&leaves, "ORBIT_PACKET_MAGIC", "macro");
+        assert_eq!(macro_leaf.start_line, 4);
+        assert_eq!(macro_leaf.end_line, 4);
+
+        let struct_leaf = leaf(&leaves, "OrbitHeader", "struct");
+        assert_eq!(struct_leaf.start_line, 6);
+        assert_eq!(struct_leaf.end_line, 8);
+
+        let enum_leaf = leaf(&leaves, "OrbitHeaderKind", "enum");
+        assert_eq!(enum_leaf.start_line, 10);
+        assert_eq!(enum_leaf.end_line, 13);
+
+        let typedef_leaf = leaf(&leaves, "OrbitHeaderKind", "type_alias");
+        assert_eq!(typedef_leaf.start_line, 10);
+        assert_eq!(typedef_leaf.end_line, 13);
+
+        let global_leaf = leaf(&leaves, "orbit_header_global", "global");
+        assert_eq!(global_leaf.start_line, 15);
+        assert_eq!(global_leaf.end_line, 15);
+
+        let parse_leaf = leaf(&leaves, "orbit_parse_header", "function_declaration");
+        assert_eq!(parse_leaf.start_line, 17);
+        assert_eq!(parse_leaf.end_line, 17);
+        assert_eq!(
+            parse_leaf.source,
+            "int orbit_parse_header(const char *bytes, unsigned len);"
+        );
+
+        let emit_leaf = leaf(&leaves, "orbit_emit_header", "function_declaration");
+        assert_eq!(emit_leaf.start_line, 18);
+        assert_eq!(emit_leaf.end_line, 18);
+    }
+}

--- a/crates/orbit-knowledge/src/extract/language.rs
+++ b/crates/orbit-knowledge/src/extract/language.rs
@@ -12,6 +12,7 @@
 /// Supported source-code languages with tree-sitter extractors.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Language {
+    C,
     Rust,
     Python,
     Go,
@@ -25,6 +26,7 @@ pub enum Language {
 impl Language {
     pub fn from_extension(ext: &str) -> Option<Self> {
         match ext {
+            "c" | "h" => Some(Self::C),
             "rs" => Some(Self::Rust),
             "py" => Some(Self::Python),
             "go" => Some(Self::Go),
@@ -41,6 +43,7 @@ impl Language {
 
     pub fn as_str(&self) -> &'static str {
         match self {
+            Self::C => "c",
             Self::Rust => "rust",
             Self::Python => "python",
             Self::Go => "go",
@@ -128,6 +131,8 @@ mod tests {
 
     #[test]
     fn from_extension_classifies_code() {
+        assert_eq!(FileKind::from_extension("c"), FileKind::Code(Language::C));
+        assert_eq!(FileKind::from_extension("h"), FileKind::Code(Language::C));
         assert_eq!(
             FileKind::from_extension("rs"),
             FileKind::Code(Language::Rust)
@@ -187,6 +192,7 @@ mod tests {
         );
         assert_eq!(FileKind::from_extension("ts").as_str(), "typescript");
         assert_eq!(FileKind::from_extension("tsx").as_str(), "tsx");
+        assert_eq!(FileKind::from_extension("h").as_str(), "c");
         assert_eq!(FileKind::from_extension("rb").as_str(), "ruby");
     }
 

--- a/crates/orbit-knowledge/src/extract/mod.rs
+++ b/crates/orbit-knowledge/src/extract/mod.rs
@@ -9,6 +9,7 @@
 //! dispatch under `FileKind::Code(Language)` without changing extractor
 //! internals.
 
+mod c;
 mod common;
 mod config;
 mod go;
@@ -28,6 +29,7 @@ pub use common::{
 };
 pub use language::{ConfigFormat, DocFormat, FileKind, Language, TableFormat};
 
+use c::CExtractor;
 use config::ConfigExtractor;
 use go::GoExtractor;
 use java::JavaExtractor;
@@ -59,6 +61,7 @@ impl ExtractorRegistry {
     pub fn new() -> Self {
         Self {
             extractors: vec![
+                Box::new(CExtractor),
                 Box::new(RustExtractor),
                 Box::new(PythonExtractor),
                 Box::new(RubyExtractor),

--- a/crates/orbit-knowledge/src/graph/nodes.rs
+++ b/crates/orbit-knowledge/src/graph/nodes.rs
@@ -11,6 +11,7 @@ use serde::{Deserialize, Serialize};
 #[serde(rename_all = "snake_case")]
 pub enum LeafKind {
     Function,
+    FunctionDeclaration,
     Method,
     SingletonMethod,
     Class,
@@ -22,6 +23,8 @@ pub enum LeafKind {
     Trait,
     Impl,
     Field,
+    Global,
+    Macro,
     Constant,
     Module,
     /// Markdown ATX heading (`#`–`######`). `depth` is 1–6. Added T20260422-1540.
@@ -39,6 +42,7 @@ impl fmt::Display for LeafKind {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let s = match self {
             Self::Function => "function",
+            Self::FunctionDeclaration => "function_declaration",
             Self::Method => "method",
             Self::SingletonMethod => "singleton_method",
             Self::Class => "class",
@@ -50,6 +54,8 @@ impl fmt::Display for LeafKind {
             Self::Trait => "trait",
             Self::Impl => "impl",
             Self::Field => "field",
+            Self::Global => "global",
+            Self::Macro => "macro",
             Self::Constant => "constant",
             Self::Module => "module",
             Self::Section { .. } => "section",

--- a/crates/orbit-knowledge/src/pipeline/attribute.rs
+++ b/crates/orbit-knowledge/src/pipeline/attribute.rs
@@ -888,6 +888,10 @@ mod tests {
     fn leaf_kind_to_str_matches_extractor_lowercase() {
         assert_eq!(leaf_kind_to_str(&LeafKind::Function), "function");
         assert_eq!(
+            leaf_kind_to_str(&LeafKind::FunctionDeclaration),
+            "function_declaration"
+        );
+        assert_eq!(
             leaf_kind_to_str(&LeafKind::SingletonMethod),
             "singleton_method"
         );
@@ -897,6 +901,8 @@ mod tests {
             "singleton_class"
         );
         assert_eq!(leaf_kind_to_str(&LeafKind::Constant), "constant");
+        assert_eq!(leaf_kind_to_str(&LeafKind::Global), "global");
+        assert_eq!(leaf_kind_to_str(&LeafKind::Macro), "macro");
         assert_eq!(leaf_kind_to_str(&LeafKind::Trait), "trait");
     }
 

--- a/crates/orbit-knowledge/src/pipeline/build.rs
+++ b/crates/orbit-knowledge/src/pipeline/build.rs
@@ -564,6 +564,7 @@ fn apply_extracted_file(ctx: &mut PipelineContext, file_idx: usize, extracted: E
 fn parse_leaf_kind(s: &str, depth: Option<u8>) -> LeafKind {
     match s {
         "function" => LeafKind::Function,
+        "function_declaration" => LeafKind::FunctionDeclaration,
         "method" => LeafKind::Method,
         "singleton_method" => LeafKind::SingletonMethod,
         "class" => LeafKind::Class,
@@ -575,6 +576,8 @@ fn parse_leaf_kind(s: &str, depth: Option<u8>) -> LeafKind {
         "trait" => LeafKind::Trait,
         "impl" => LeafKind::Impl,
         "field" => LeafKind::Field,
+        "global" => LeafKind::Global,
+        "macro" => LeafKind::Macro,
         "constant" => LeafKind::Constant,
         "module" => LeafKind::Module,
         "section" => LeafKind::Section {

--- a/docs/design/knowledge-graph/2_design.md
+++ b/docs/design/knowledge-graph/2_design.md
@@ -44,7 +44,7 @@ scan → hash → detect_changes → build_dirs → build_files → build_leaves
 | `detect_changes` | Added / modified / unchanged path set | Incremental leaf extraction uses this set to decide what can reuse the prior graph |
 | `build_graph_dirs` | `DirNode` entries with parent/child wiring | Deterministic; root dir id derived from `.` |
 | `build_graph_files` | `FileNode` entries linked to parent dir | Language detected from extension |
-| `build_graph_leaves` | `LeafNode` entries via file-kind-dispatched extractor | Code via tree-sitter (Rust, Python, Go, Java, JavaScript, TypeScript, TSX); markdown sections, YAML/JSON/TOML top-level keys, and CSV/TSV header columns via shallow extractors added in [T20260422-1540]. TypeScript/TSX coverage was added in [T20260505-11]. Per-file read/extract work runs in parallel, then graph mutation is merged on the main thread in file order ([T20260426-0139]). Incremental builds reuse unchanged file/leaf snapshots from the same branch ref when hashes match ([T20260426-0140]) |
+| `build_graph_leaves` | `LeafNode` entries via file-kind-dispatched extractor | Code via tree-sitter (C, Rust, Python, Go, Java, JavaScript, TypeScript, TSX); markdown sections, YAML/JSON/TOML top-level keys, and CSV/TSV header columns via shallow extractors added in [T20260422-1540]. TypeScript/TSX coverage was added in [T20260505-11]; C `.c`/`.h` coverage was added in [T20260505-16]. Per-file read/extract work runs in parallel, then graph mutation is merged on the main thread in file order ([T20260426-0139]). Incremental builds reuse unchanged file/leaf snapshots from the same branch ref when hashes match ([T20260426-0140]) |
 | `attribute_history` | `task_ids` on touched nodes | Introduced in [T20260421-0528] |
 | `persist_graph` | Content-addressed objects, blobs, index | Atomic via tempfile + rename |
 | `write_manifest` | `manifest.json` | Timestamp + commit + ref pointer |
@@ -223,7 +223,7 @@ The shared file-based lock store was introduced in [T20260411-0424] (replacing a
 
 ### 6.1 Extractor coverage drives graph precision
 
-The leaf graph is only as good as each extractor. Code coverage (tree-sitter): Rust, Python, Go, Java, JavaScript, TypeScript, and TSX. Doc coverage: markdown (ATX headings only — no frontmatter, no fenced-block leaves, no RST). Config coverage: YAML / JSON / TOML top-level keys only — nested paths like `a.b.c` are not indexed. Tabular coverage: CSV / TSV header row only; files over 1 MiB produce zero leaves by design. Anything outside those families (shell scripts, C/C++, `.env`, SQL, etc.) lands in the graph as a leafless `FileNode`, and the agent has to fall back to file-level reads for the uncovered slice. Depth-of-extraction tradeoffs are captured in ADR-011 and ADR-024.
+The leaf graph is only as good as each extractor. Code coverage (tree-sitter): C, Rust, Python, Go, Java, JavaScript, TypeScript, and TSX. Doc coverage: markdown (ATX headings only — no frontmatter, no fenced-block leaves, no RST). Config coverage: YAML / JSON / TOML top-level keys only — nested paths like `a.b.c` are not indexed. Tabular coverage: CSV / TSV header row only; files over 1 MiB produce zero leaves by design. Anything outside those families (shell scripts, C++, `.env`, SQL, etc.) lands in the graph as a leafless `FileNode`, and the agent has to fall back to file-level reads for the uncovered slice. Depth-of-extraction tradeoffs are captured in ADR-011, ADR-024, and ADR-026.
 
 ### 6.2 No cross-file reference resolution
 
@@ -291,6 +291,7 @@ The read cache is per `KnowledgeStore`, not global ([T20260426-0141]). Long-runn
 - **[T20260428-1]** — Align graph task-ID attribution/search with current unpadded task IDs.
 - **[T20260430-22]** — Compact the knowledge-graph design docs and remove duplicate top-level narrative.
 - **[T20260505-11]** — Add TypeScript and TSX extraction coverage, documented by gpt-5.5.
+- **[T20260505-16]** — Add C and header extraction coverage, documented by gpt-5.
 - **[T20260505-5]** — Bound `orbit.graph.pack` selector gathering and skip inline refresh by default, documented by gpt-5.5.
 
 Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.

--- a/docs/design/knowledge-graph/4_decisions.md
+++ b/docs/design/knowledge-graph/4_decisions.md
@@ -43,11 +43,11 @@ Format for each entry: **Status · Date · Task(s)**, then *Context → Decision
 
 ## ADR-003 — Tree-sitter extractors over an LSP backend
 
-**Status:** Accepted · 2026-04 · [T20260406-0455-3], [T20260416-0352], [T20260505-11], [T20260505-15]
+**Status:** Accepted · 2026-04 · [T20260406-0455-3], [T20260416-0352], [T20260505-11], [T20260505-15], [T20260505-16]
 
-**Context.** Reference resolution is strongest via a language server, but LSPs are stateful long-running processes tuned for interactive UX. Agent tools want bulk, structured, token-budgeted output and low lifecycle overhead. The Rust extractor landed first ([T20260406-0455-3], hardened in [T20260409-0550]); Go, Java, and JavaScript followed in [T20260416-0352], TypeScript/TSX followed in [T20260505-11], and Ruby followed in [T20260505-15].
+**Context.** Reference resolution is strongest via a language server, but LSPs are stateful long-running processes tuned for interactive UX. Agent tools want bulk, structured, token-budgeted output and low lifecycle overhead. The Rust extractor landed first ([T20260406-0455-3], hardened in [T20260409-0550]); Go, Java, and JavaScript followed in [T20260416-0352], TypeScript/TSX followed in [T20260505-11], Ruby followed in [T20260505-15], and C followed in [T20260505-16].
 
-**Decision.** Use tree-sitter grammars with per-language extractors (`rust`, `python`, `go`, `java`, `javascript`, `typescript`, `tsx`, `ruby`) producing structural symbols only. Defer cross-file reference resolution indefinitely. See [3_vision.md §1.1] for the open question of re-introducing LSP as a pluggable backend.
+**Decision.** Use tree-sitter grammars with per-language extractors (`c`, `rust`, `python`, `go`, `java`, `javascript`, `typescript`, `tsx`, `ruby`) producing structural symbols only. Defer cross-file reference resolution indefinitely. See [3_vision.md §1.1] for the open question of re-introducing LSP as a pluggable backend.
 
 **Consequences.**
 - Fast, deterministic extraction with no per-query process lifecycle.
@@ -399,6 +399,20 @@ Format for each entry: **Status · Date · Task(s)**, then *Context → Decision
 - Timed-out pack calls can still return the selectors already projected plus unresolved entries for the remainder.
 - Cost: default pack reads can be stale until a separate `orbit graph build` or an opt-in refresh updates the branch ref.
 
+## ADR-026 — C source and headers share one extractor
+
+**Status:** Accepted · 2026-05 · [T20260505-16]
+**Author:** gpt-5
+
+**Context.** C source and header files use the same grammar, and the graph layer classifies files by language rather than by downstream role. Function prototypes are common in `.h` files but can also appear in `.c` files.
+
+**Decision.** Classify both `.c` and `.h` as `Language::C` and route both through the `tree-sitter-c` extractor. Emit function definitions as `function` leaves and prototypes as `function_declaration` leaves so callers can distinguish declarations without header/source inference; add explicit leaf kinds for C macros and globals instead of collapsing them into functions.
+
+**Consequences.**
+- Agents can search C systems code and headers through the same graph surface.
+- The extractor stays syntax-only and avoids guessing whether a header is public, private, generated, or included.
+- Cost: `.h` files that are C++-shaped are treated as C until a separate C++ classifier/extractor lands.
+
 ---
 
 ## Task References
@@ -440,5 +454,6 @@ Tasks cited by ADRs above:
 - **[T20260505-5]** — Bound `orbit.graph.pack` selector gathering and skip inline refresh by default.
 - **[T20260505-11]** — Add TypeScript and TSX classification, extraction, graph search/pack coverage, and symbol-level history attribution.
 - **[T20260505-15]** — Add Ruby classification, tree-sitter extraction, graph search coverage, and Ruby symbol kinds.
+- **[T20260505-16]** — Add C and header classification, tree-sitter extraction, and graph search coverage.
 
 Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.


### PR DESCRIPTION
## Tasks
- [T20260505-16] Onboard C to knowledge graph
  <details><summary>Execution Summary</summary>

## Status
success

## Summary of Changes
Added C knowledge-graph extraction via `tree-sitter-c` for `.c` and `.h` files. Registered `Language::C`, wired `CExtractor` into the extractor registry, added C-specific leaf kinds for function declarations, macros, and globals, and mapped typedefs to the existing type-alias graph kind. The new extractor covers function definitions, prototypes, structs, unions, enums, typedefs, macros, and globals with fixture-string tests for both source and header files. Updated knowledge-graph design docs/ADR references for T20260505-16.

## Overall Assessment
Implementation is validated and ready for downstream review. Plain `make build` was blocked by the executor's unwritable default Cargo registry cache when Cargo tried to fetch `tree-sitter-c`; validation passed with `CARGO_HOME=/tmp/orbit-cargo-home`, and friction task T20260505-18 records the environment issue.

## Validation
- `grep tree-sitter-c crates/orbit-knowledge/Cargo.toml` passed.
- `CARGO_HOME=/tmp/orbit-cargo-home cargo test -p orbit-knowledge --tests` passed.
- `CARGO_HOME=/tmp/orbit-cargo-home cargo build -p orbit-knowledge` passed.
- `make fmt` passed.
- `CARGO_HOME=/tmp/orbit-cargo-home make build` passed.
- Graph smoke: built a temporary git workspace with `smoke.c` and `smoke.h`; `orbit graph build` reported 2 files and 8 leaves, and `orbit graph search smoke_add --json` returned both `symbol:smoke.c#smoke_add:function` and `symbol:smoke.h#smoke_add:function_declaration`.

  </details>

## Branch Freshness
- Base ref: `origin/agent-main`
- Head ref: `orbit/T20260505-16-69f97640`
- Behind base: 0
- Ahead of base: 1

## Files Changed
- `Cargo.lock`
- `crates/orbit-knowledge/Cargo.toml`
- `crates/orbit-knowledge/src/extract/c.rs`
- `crates/orbit-knowledge/src/extract/language.rs`
- `crates/orbit-knowledge/src/extract/mod.rs`
- `crates/orbit-knowledge/src/graph/nodes.rs`
- `crates/orbit-knowledge/src/pipeline/attribute.rs`
- `crates/orbit-knowledge/src/pipeline/build.rs`
- `docs/design/knowledge-graph/2_design.md`
- `docs/design/knowledge-graph/4_decisions.md`

*authored by: claude-opus-4-7*