### PR TITLE
Validate :id path param in web /api/runs/:id/events to block .jsonl path traversal

### DIFF
--- a/crates/orbit-cli/src/bin/migrate-task-attribution.rs
+++ b/crates/orbit-cli/src/bin/migrate-task-attribution.rs
@@ -336,9 +336,13 @@ fn normalize_tokens_value(value: &mut Value, rules: &NormalizationRules) -> bool
             }
             changed
         }
-        Value::Array(items) => items.iter_mut().fold(false, |changed, item| {
-            normalize_tokens_value(item, rules) || changed
-        }),
+        Value::Array(items) => {
+            let mut changed = false;
+            for item in items {
+                changed |= normalize_tokens_value(item, rules);
+            }
+            changed
+        }
         Value::String(text) => {
             let normalized = normalize_legacy_text(text, &rules.legacy_label);
             if normalized != *text {

--- a/crates/orbit-cli/src/command/web/api.rs
+++ b/crates/orbit-cli/src/command/web/api.rs
@@ -7,7 +7,7 @@ use std::collections::{BTreeMap, HashMap, HashSet};
 use std::convert::Infallible;
 use std::fs::File;
 use std::io::{self, BufRead, BufReader, Seek, SeekFrom};
-use std::path::PathBuf;
+use std::path::{Path as FsPath, PathBuf};
 use std::pin::Pin;
 use std::str::FromStr;
 use std::sync::Arc;
@@ -375,8 +375,24 @@ fn bounded_limit(requested: Option<usize>, default: usize) -> usize {
     requested.unwrap_or(default).min(HISTORY_MAX_LIMIT)
 }
 
+fn validate_id(id: &str) -> Result<&str, String> {
+    let valid = !id.is_empty()
+        && id
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_');
+    if valid {
+        Ok(id)
+    } else {
+        Err("id must contain only ASCII letters, digits, '-' or '_'".to_string())
+    }
+}
+
 async fn get_task(State(runtime): State<Arc<OrbitRuntime>>, Path(id): Path<String>) -> Response {
-    match runtime.get_task(&id) {
+    let id = match validate_id(&id) {
+        Ok(id) => id,
+        Err(message) => return bad_request(message),
+    };
+    match runtime.get_task(id) {
         Ok(task) => match dashboard_status_index(&runtime) {
             Ok(status_by_id) => Json(task_to_json(&task, &status_by_id)).into_response(),
             Err(e) => server_error(e),
@@ -421,6 +437,10 @@ async fn update_task_action(
     Path(id): Path<String>,
     Json(body): Json<UpdateTaskBody>,
 ) -> Response {
+    let id = match validate_id(&id) {
+        Ok(id) => id,
+        Err(message) => return bad_request(message),
+    };
     let params = TaskUpdateParams {
         title: body.title,
         description: body.description,
@@ -438,7 +458,7 @@ async fn update_task_action(
         upsert_artifacts: Vec::new(),
         append_review_threads: Vec::new(),
     };
-    match runtime.update_task_with_identity(&id, params, None, None) {
+    match runtime.update_task_with_identity(id, params, None, None) {
         Ok(task) => match dashboard_status_index(&runtime) {
             Ok(status_by_id) => Json(task_to_json(&task, &status_by_id)).into_response(),
             Err(e) => server_error(e),
@@ -452,8 +472,12 @@ async fn approve_task_action(
     Path(id): Path<String>,
     body: Option<Json<ApproveBody>>,
 ) -> Response {
+    let id = match validate_id(&id) {
+        Ok(id) => id,
+        Err(message) => return bad_request(message),
+    };
     let body = body.map(|Json(b)| b).unwrap_or_default();
-    match runtime.approve_task(&id, body.note, body.comment) {
+    match runtime.approve_task(id, body.note, body.comment) {
         Ok(task) => match dashboard_status_index(&runtime) {
             Ok(status_by_id) => Json(task_to_json(&task, &status_by_id)).into_response(),
             Err(e) => server_error(e),
@@ -467,7 +491,11 @@ async fn reject_task_action(
     Path(id): Path<String>,
     Json(body): Json<RejectBody>,
 ) -> Response {
-    match runtime.reject_task(&id, body.note, body.comment) {
+    let id = match validate_id(&id) {
+        Ok(id) => id,
+        Err(message) => return bad_request(message),
+    };
+    match runtime.reject_task(id, body.note, body.comment) {
         Ok(task) => match dashboard_status_index(&runtime) {
             Ok(status_by_id) => Json(task_to_json(&task, &status_by_id)).into_response(),
             Err(e) => server_error(e),
@@ -480,7 +508,11 @@ async fn archive_task_action(
     State(runtime): State<Arc<OrbitRuntime>>,
     Path(id): Path<String>,
 ) -> Response {
-    match runtime.archive_task(&id) {
+    let id = match validate_id(&id) {
+        Ok(id) => id,
+        Err(message) => return bad_request(message),
+    };
+    match runtime.archive_task(id) {
         Ok(()) => Json(json!({ "ok": true, "id": id })).into_response(),
         Err(e) => map_runtime_error(e),
     }
@@ -982,6 +1014,75 @@ spec:
             .expect("response")
     }
 
+    async fn request_dashboard_run_events(runtime: OrbitRuntime, encoded_run_id: &str) -> Response {
+        Router::new()
+            .nest("/api", router())
+            .with_state(Arc::new(runtime))
+            .oneshot(
+                Request::builder()
+                    .uri(format!("/api/runs/{encoded_run_id}/events"))
+                    .body(Body::empty())
+                    .expect("request"),
+            )
+            .await
+            .expect("response")
+    }
+
+    #[tokio::test]
+    async fn list_run_events_rejects_path_traversal_id() {
+        let runtime = OrbitRuntime::in_memory().expect("build runtime");
+
+        let response = request_dashboard_run_events(runtime, "..%2F..%2Fetc%2Fpasswd").await;
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn list_run_events_rejects_id_with_slashes() {
+        let cases = [
+            ("jrun%2F1", "literal slash"),
+            ("jrun%5C1", "backslash"),
+            (".jrun-1", "leading dot"),
+            ("jrun%00nul", "nul byte"),
+        ];
+
+        for (encoded_run_id, label) in cases {
+            let runtime = OrbitRuntime::in_memory().expect("build runtime");
+
+            let response = request_dashboard_run_events(runtime, encoded_run_id).await;
+
+            assert_eq!(response.status(), StatusCode::BAD_REQUEST, "{label}");
+        }
+    }
+
+    #[tokio::test]
+    async fn list_run_events_accepts_valid_run_id() {
+        let runtime = OrbitRuntime::in_memory().expect("build runtime");
+        let run_id = "jrun-1";
+        let audit_dir = runtime.data_root().join("state/audit/v2_loop");
+        std::fs::create_dir_all(&audit_dir).expect("create audit dir");
+        write_lines(
+            &audit_dir.join(format!("{run_id}.jsonl")),
+            &[json!({
+                "schemaVersion": 1,
+                "event_type": "step.started",
+                "event_id": "evt-step-started",
+                "run_id": run_id,
+                "body_kind": "step_started"
+            })
+            .to_string()],
+        );
+
+        let response = request_dashboard_run_events(runtime, run_id).await;
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let payload = body_json(response).await;
+        let events = payload.as_array().expect("events array");
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0]["run_id"], run_id);
+        assert_eq!(events[0]["body_kind"], "step_started");
+    }
+
     #[tokio::test]
     async fn cancel_run_endpoint_cancels_pending_run() {
         let runtime = OrbitRuntime::in_memory().expect("build runtime");
@@ -1390,7 +1491,11 @@ spec:
 }
 
 async fn get_run(State(runtime): State<Arc<OrbitRuntime>>, Path(id): Path<String>) -> Response {
-    match runtime.show_job_run(&id) {
+    let id = match validate_id(&id) {
+        Ok(id) => id,
+        Err(message) => return bad_request(message),
+    };
+    match runtime.show_job_run(id) {
         Ok(run) => Json(job_run_detail_to_json(&runtime, &run)).into_response(),
         Err(e) => map_runtime_error(e),
     }
@@ -1400,7 +1505,11 @@ async fn cancel_run_action(
     State(runtime): State<Arc<OrbitRuntime>>,
     Path(id): Path<String>,
 ) -> Response {
-    match runtime.cancel_job_run_with_context(&id, "dashboard", "web") {
+    let id = match validate_id(&id) {
+        Ok(id) => id,
+        Err(message) => return bad_request(message),
+    };
+    match runtime.cancel_job_run_with_context(id, "dashboard", "web") {
         Ok(result) => Json(json!({
             "run_id": result.run_id,
             "previous_state": result.previous_state,
@@ -1423,7 +1532,11 @@ async fn replay_run_action(
     State(runtime): State<Arc<OrbitRuntime>>,
     Path(id): Path<String>,
 ) -> Response {
-    match runtime.replay_job_run(&id) {
+    let id = match validate_id(&id) {
+        Ok(id) => id,
+        Err(message) => return bad_request(message),
+    };
+    match runtime.replay_job_run(id) {
         Ok(result) => Json(json!({ "run_id": result.run_id })).into_response(),
         Err(e) => map_runtime_error(e),
     }
@@ -1482,6 +1595,10 @@ async fn list_run_events(
     Path(id): Path<String>,
     Query(q): Query<RunEventsQuery>,
 ) -> Response {
+    let run_id = match validate_id(&id) {
+        Ok(id) => id,
+        Err(message) => return bad_request(message),
+    };
     let limit = bounded_limit(q.limit, RUN_EVENTS_DEFAULT_LIMIT);
     let offset = q.offset.unwrap_or(0);
     let kind = q
@@ -1491,7 +1608,12 @@ async fn list_run_events(
         .filter(|s| !s.is_empty())
         .map(str::to_string);
 
-    let path = v2_loop_path(&runtime, &id);
+    let path = v2_loop_path(&runtime, run_id);
+    let path = match canonical_v2_loop_path(&runtime, &path) {
+        Ok(Some(path)) => path,
+        Ok(None) => return Json(Value::Array(Vec::new())).into_response(),
+        Err(e) => return map_runtime_error(e),
+    };
     let raw = match std::fs::read_to_string(&path) {
         Ok(raw) => raw,
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
@@ -1539,6 +1661,32 @@ fn v2_loop_path(runtime: &OrbitRuntime, run_id: &str) -> PathBuf {
         .join("audit")
         .join("v2_loop")
         .join(format!("{run_id}.jsonl"))
+}
+
+fn canonical_v2_loop_path(
+    runtime: &OrbitRuntime,
+    path: &FsPath,
+) -> Result<Option<PathBuf>, orbit_core::OrbitError> {
+    let canonical_path = match path.canonicalize() {
+        Ok(path) => path,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(e) => {
+            return Err(orbit_core::OrbitError::Io(format!(
+                "resolve {}: {e}",
+                path.display()
+            )));
+        }
+    };
+    let audit_dir = v2_loop_dir(runtime);
+    let canonical_dir = audit_dir
+        .canonicalize()
+        .map_err(|e| orbit_core::OrbitError::Io(format!("resolve {}: {e}", audit_dir.display())))?;
+    if !canonical_path.starts_with(&canonical_dir) {
+        return Err(orbit_core::OrbitError::InvalidInput(
+            "run id resolved outside audit log directory".to_string(),
+        ));
+    }
+    Ok(Some(canonical_path))
 }
 
 fn v2_loop_dir(runtime: &OrbitRuntime) -> PathBuf {
@@ -2313,7 +2461,7 @@ async fn list_diagnostics_metrics(
     let limit = bounded_limit(q.limit, HISTORY_DEFAULT_LIMIT);
     match runtime.read_metrics_entries_limited(&month, limit) {
         Ok(mut entries) => {
-            entries.sort_by(|a, b| b.ts.cmp(&a.ts));
+            entries.sort_by_key(|entry| std::cmp::Reverse(entry.ts));
             entries.truncate(limit);
             let value = if entries.is_empty() {
                 match diagnostics_metrics_from_invocations(&runtime, &month, limit) {
@@ -2587,7 +2735,7 @@ async fn list_diagnostics_friction(
     let limit = bounded_limit(q.limit, HISTORY_DEFAULT_LIMIT);
     match runtime.read_friction_entries_limited(&month, limit) {
         Ok(mut entries) => {
-            entries.sort_by(|a, b| b.ts.cmp(&a.ts));
+            entries.sort_by_key(|entry| std::cmp::Reverse(entry.ts));
             entries.truncate(limit);
             let value = if entries.is_empty() {
                 match diagnostics_friction_from_v2_audit(&runtime, &month, limit) {

--- a/crates/orbit-core/src/command/executor.rs
+++ b/crates/orbit-core/src/command/executor.rs
@@ -27,7 +27,7 @@ pub(crate) fn seed_default_executors(
                 store.upsert_executor_def(&def)?;
                 created += 1;
             }
-            Some(existing) if overwrite => {
+            Some(_) if overwrite => {
                 store.upsert_executor_def(&def)?;
                 created += 1;
             }

--- a/crates/orbit-knowledge/src/io.rs
+++ b/crates/orbit-knowledge/src/io.rs
@@ -19,11 +19,7 @@ impl LineEnding {
         while index < bytes.len() {
             match bytes[index] {
                 b'\n' => return Self::Lf,
-                b'\r' => {
-                    if bytes.get(index + 1) == Some(&b'\n') {
-                        return Self::CrLf;
-                    }
-                }
+                b'\r' if bytes.get(index + 1) == Some(&b'\n') => return Self::CrLf,
                 _ => {}
             }
             index += 1;

--- a/crates/orbit-knowledge/src/working_graph/versioning.rs
+++ b/crates/orbit-knowledge/src/working_graph/versioning.rs
@@ -246,15 +246,14 @@ impl WorkingGraph {
         chain.selector = to_selector.to_string();
 
         if let Some(mut existing_target_chain) = self.version_chains.remove(to_selector) {
-            let mut next_seq = existing_target_chain
+            let next_seq = existing_target_chain
                 .edits
                 .last()
                 .map(|edit| edit.edit_sequence + 1)
                 .unwrap_or(1);
-            for edit in chain.edits {
+            for (next_seq, edit) in (next_seq..).zip(chain.edits) {
                 let mut merged = edit;
                 merged.edit_sequence = next_seq;
-                next_seq += 1;
                 existing_target_chain.edits.push(merged);
             }
             chain = existing_target_chain;

--- a/crates/orbit-store/src/file/job_store/api.rs
+++ b/crates/orbit-store/src/file/job_store/api.rs
@@ -72,7 +72,7 @@ impl JobFileStore {
             .into_iter()
             .filter(|run| run.state == JobRunState::Pending || run.state == JobRunState::Running)
             .collect::<Vec<_>>();
-        runs.sort_by(|a, b| b.created_at.cmp(&a.created_at));
+        runs.sort_by_key(|run| std::cmp::Reverse(run.created_at));
         Ok(runs)
     }
 
@@ -82,7 +82,7 @@ impl JobFileStore {
             .into_iter()
             .filter(|run| run.state == JobRunState::Pending || run.state == JobRunState::Running)
             .collect::<Vec<_>>();
-        runs.sort_by(|a, b| b.created_at.cmp(&a.created_at));
+        runs.sort_by_key(|run| std::cmp::Reverse(run.created_at));
         Ok(runs)
     }
 }


### PR DESCRIPTION
## Tasks
- [T20260507-4] Validate :id path param in web /api/runs/:id/events to block .jsonl path traversal
  <details><summary>Execution Summary</summary>

## Status
success

## Summary of Changes
- Added shared private validate_id in crates/orbit-cli/src/command/web/api.rs and applied it to every Path(id): Path<String> dashboard handler.
- list_run_events validates before constructing the v2_loop path and canonicalizes the resolved file under state/audit/v2_loop before reading.
- Added list_run_events_rejects_path_traversal_id, list_run_events_rejects_id_with_slashes, and list_run_events_accepts_valid_run_id.
- Fixed pre-existing clippy warnings reached by cargo clippy -p orbit-cli -- -D warnings in migrate-task-attribution, orbit-core executor, orbit-knowledge, orbit-store, and api sort sites.

## Path Extractor Audit
- get_task: validate_id applied before runtime.get_task.
- update_task_action: validate_id applied before runtime.update_task_with_identity.
- approve_task_action: validate_id applied before runtime.approve_task.
- reject_task_action: validate_id applied before runtime.reject_task.
- archive_task_action: validate_id applied before runtime.archive_task.
- get_run: validate_id applied before runtime.show_job_run.
- cancel_run_action: validate_id applied before runtime.cancel_job_run_with_context.
- replay_run_action: validate_id applied before runtime.replay_job_run.
- list_run_events: validate_id applied before v2_loop_path; canonical path prefix enforced before read_to_string.

## Overall Assessment
The traversal surface is closed at the dashboard route boundary, with a second filesystem prefix check for the JSONL read path and regression coverage for decoded slash, backslash, dot-prefix, NUL, traversal, and valid IDs.

## Validation
- cargo test -p orbit-cli list_run_events
- cargo test -p orbit-cli list_run_events_rejects_path_traversal
- grep -nE fn validate_run_id|fn validate_id crates/orbit-cli/src/command/web/api.rs
- cargo clippy -p orbit-cli -- -D warnings
- make fmt
- make build

  </details>

## Branch Freshness
- Base ref: `origin/agent-main`
- Head ref: `orbit/T20260507-4-69fbfffe`
- Behind base: 0
- Ahead of base: 1

## Files Changed
- `crates/orbit-cli/src/bin/migrate-task-attribution.rs`
- `crates/orbit-cli/src/command/web/api.rs`
- `crates/orbit-core/src/command/executor.rs`
- `crates/orbit-knowledge/src/io.rs`
- `crates/orbit-knowledge/src/working_graph/versioning.rs`
- `crates/orbit-store/src/file/job_store/api.rs`

*authored by: claude-opus-4-7*