### PR TITLE
npm postinstall must hard-fail on missing or unverifiable checksum

### DIFF
--- a/plugin/npm/scripts/install-binary.js
+++ b/plugin/npm/scripts/install-binary.js
@@ -117,7 +117,7 @@ async function main() {
     const checksums = parseChecksums(checksumText);
     const expected = checksums[asset];
     if (!expected) {
-      log(`warning: no checksum entry for ${asset}; proceeding without verification.`);
+      fail(`checksum entry for ${asset} was not found in orbit-checksums.txt`);
     } else {
       const actual = sha256(archiveBuf);
       if (actual !== expected) {
@@ -125,7 +125,7 @@ async function main() {
       }
     }
   } catch (err) {
-    log(`warning: could not verify checksum (${err.message}); proceeding anyway.`);
+    fail(`could not verify checksum for ${asset}: ${err.message}`);
   }
 
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'orbit-cli-'));


### PR DESCRIPTION
## Tasks
- [T20260507-7] npm postinstall must hard-fail on missing or unverifiable checksum
  <details><summary>Execution Summary</summary>

## Status
failed

## Summary of Changes
- Updated `plugin/npm/scripts/install-binary.js` so a missing checksum entry and checksum retrieval/parse failures call `fail(...)`, aborting npm postinstall instead of installing an unverified archive.
- Preserved the explicit `ORBIT_SKIP_DOWNLOAD=1` and `ORBIT_BINARY=<path>` early-return escape hatches.

## Overall Assessment
The scoped checksum hard-fail behavior is implemented and focused validations pass. The manual npm install end-to-end check could not be completed because the packed dev package is version `0.0.0`, which resolves to release tag `v0.0.0`; that GitHub release asset returns 404. Retrying with the only published latest release, `v0.2.0`, also returns 404 for the installer's expected `orbit-aarch64-apple-darwin.tar.gz`; `gh release view v0.2.0` shows only `orbit_0.2.0_darwin_arm64.tar.gz` and no `orbit-checksums.txt`.

## Validation
- Mocked checksum URL error: non-zero exit; stderr mentions `checksum`.
- Mocked checksum file with no platform asset entry: non-zero exit; stderr mentions `checksum`.
- `grep -nE 'proceeding without verification|proceeding anyway' plugin/npm/scripts/install-binary.js`: no matches.
- `ORBIT_SKIP_DOWNLOAD=1 node plugin/npm/scripts/install-binary.js`: exit 0.
- `ORBIT_BINARY=/path/to/orbit node plugin/npm/scripts/install-binary.js`: exit 0.
- `node --check plugin/npm/scripts/install-binary.js`: exit 0.
- `git diff --check -- plugin/npm/scripts/install-binary.js`: exit 0.
- `npm pack` in `plugin/npm` with a temporary npm cache: exit 0.
- `npm install` of the packed tarball in a fresh temp dir: failed before binary placement because `https://github.com/danieljhkim/orbit/releases/download/v0.0.0/orbit-aarch64-apple-darwin.tar.gz` returned HTTP 404; retry with `ORBIT_BINARY_VERSION=v0.2.0` also failed with HTTP 404 for the installer's expected asset name.

## Design Weaknesses / Risks
- Current published release assets do not match the npm installer's expected asset/checksum naming. | Severity: Medium | Mitigation: publish matching release assets plus `orbit-checksums.txt`, then rerun the manual npm install end-to-end check.

## Recommended Follow-Ups
- Publish or point the npm package at a release containing `orbit-<target>.tar.gz` assets and `orbit-checksums.txt` so the package install path can be verified end to end.
- Consider signing the checksum manifest via Sigstore or a comparable mechanism, or hosting it independently, so integrity verification is not solely dependent on fetching binary and checksum from the same GitHub release.

  </details>

## Branch Freshness
- Base ref: `origin/agent-main`
- Head ref: `orbit/T20260507-7-69fc0353`
- Behind base: 0
- Ahead of base: 1

## Files Changed
- `plugin/npm/scripts/install-binary.js`

*authored by: claude-opus-4-7*