### PR TITLE
[T20260507-8] Validate CI permissions failure handler

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
 
 permissions:
-  contents: write
+  contents: read
 
 env:
   CARGO_TERM_COLOR: always

--- a/crates/orbit-common/tests/intentional_ci_failure.rs
+++ b/crates/orbit-common/tests/intentional_ci_failure.rs
@@ -1,0 +1,9 @@
+#[test]
+fn intentional_ci_failure_for_permissions_validation() {
+    assert_eq!(
+        std::env::var("ORBIT_CSO_PERMISSION_VALIDATION")
+            .ok()
+            .as_deref(),
+        Some("pass")
+    );
+}


### PR DESCRIPTION
Validation PR for T20260507-8. This branch intentionally adds one failing Rust test so CI reaches the pull_request failure handler while ci.yml uses contents: read.