### PR TITLE
Drop ci.yml workflow permissions to least-privilege (contents: read)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
 
 permissions:
-  contents: write
+  contents: read
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
## Tasks
- [T20260507-8] Drop ci.yml workflow permissions to least-privilege (contents: read)
  <details><summary>Execution Summary</summary>

## Status
success

## Summary of Changes
- Updated `.github/workflows/ci.yml` top-level `permissions:` from `contents: write` to `contents: read`.
- Left `release.yml` and `deploy-website.yml` unchanged after auditing their existing permission scopes.

## Workflow Permission Audit
- `.github/workflows/release.yml` top-level permissions: `contents: read`.
- `release.yml` job `build-release`: `contents: read`.
- `release.yml` job `publish-release`: `contents: write` (required to publish GitHub release assets).
- `release.yml` job `publish-npm`: `contents: read`, `id-token: write` (required for npm provenance).
- `release.yml` job `bump-homebrew-tap`: `contents: read`.
- `release.yml` job `smoke-install-macos`: no job-level block; inherits top-level `contents: read`.
- `release.yml` job `smoke-install-ubuntu`: no job-level block; inherits top-level `contents: read`.
- `.github/workflows/deploy-website.yml` top-level permissions: `contents: read`, `deployments: write`, `pull-requests: write`.
- `deploy-website.yml` job `deploy`: no job-level block; this single-job workflow inherits the top-level deployment permissions needed by the Cloudflare Pages action/status integration.
- No over-privilege found: both workflows already scope per-job permissions to least-privilege; no changes needed.

## Validation
- `grep -nA 3 ^permissions: .github/workflows/ci.yml` shows only `contents: read` under the top-level block and no `contents: write`.
- `GOPATH=/tmp/orbit-actionlint-gopath GOMODCACHE=/tmp/orbit-actionlint-gomodcache GOCACHE=/tmp/orbit-actionlint-gocache go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/*.yml` passed.
- `make fmt` passed.
- `make build` passed.

## PR Failure-Handler Check
- Opened same-repo PR #137 from `test/cso-permissions-fix`: https://github.com/danieljhkim/orbit/pull/137.
- The validation branch includes the CI permissions change plus an intentional failing test at `crates/orbit-common/tests/intentional_ci_failure.rs`.
- CI run `25474495199` / job `74745017269` confirmed `Check / Clippy / Test` ran and the `Run CI guardrails` step executed.
- The run failed during guardrails before reaching the added test because current Linux clippy checks report unrelated pre-existing warnings as errors, but the PR failure path was still exercised.
- The `Create orbit task on CI failure` step completed successfully and its log shows local Orbit task `T20260507-1` created for PR #137.

## Overall Assessment
The scoped permission fix is minimal and validated locally. The CI failure-handler path still works with `contents: read` on a same-repo PR. Task was not moved to `review`, per pipeline instruction.

  </details>

## Branch Freshness
- Base ref: `origin/agent-main`
- Head ref: `orbit/T20260507-8-69fc064f`
- Behind base: 0
- Ahead of base: 1

## Files Changed
- `.github/workflows/ci.yml`

*authored by: claude-opus-4-7*