### PR TITLE
Add task-sync to CONVENTIONS §12 ownership table

### DIFF
--- a/docs/design/CONVENTIONS.md
+++ b/docs/design/CONVENTIONS.md
@@ -194,9 +194,10 @@ Until those exist: cross-review is the enforcement mechanism. When one agent rev
 |---------|--------|------|
 | Activity / Job | [docs/design/activity-job/](./activity-job/) | codex |
 | Auditability | [docs/design/auditability/](./auditability/) | codex |
-| Knowledge graph | [docs/design/knowledge-graph/](./knowledge-graph/) | claude |
 | Groundhog | [docs/design/groundhog/](./groundhog/) | codex |
+| Knowledge graph | [docs/design/knowledge-graph/](./knowledge-graph/) | claude |
 | Policy & Sandboxing | [docs/design/policy-sandbox/](./policy-sandbox/) | claude |
+| Task Sync | [docs/design/task-sync/](./task-sync/) | claude |
 | User Interface | [docs/design/user-interface/](./user-interface/) | gemini |
 
 Ownership means: the lead is accountable for keeping the folder's docs in sync with implementation, for flipping ADR status when tasks ship, and for responding to cross-review comments. Ownership does not preclude other agents from editing — it names who's on the hook when things drift.


### PR DESCRIPTION
## Tasks
- [T20260506-21] Add task-sync to CONVENTIONS §12 ownership table
  <details><summary>Execution Summary</summary>

## Status
success

## Summary of Changes
Added Task Sync to docs/design/CONVENTIONS.md §12 Ownership with lead claude, matching docs/design/task-sync/1_overview.md. Reordered the Knowledge graph and Groundhog rows so the ownership table remains alphabetized.

## Overall Assessment
Docs-only change satisfies both acceptance criteria. Validated by inspecting §12, checking the Task Sync row against the Owner field, and reviewing git diff.

  </details>

## Branch Freshness
- Base ref: `origin/agent-main`
- Head ref: `orbit/T20260506-21-69fc0e48`
- Behind base: 0
- Ahead of base: 1

## Files Changed
- `docs/design/CONVENTIONS.md`

*authored by: claude-opus-4-7*