### PR TITLE
Bring user-interface design folder up to convention

### DIFF
--- a/docs/design/user-interface/1_overview.md
+++ b/docs/design/user-interface/1_overview.md
@@ -2,18 +2,23 @@
 
 **Status:** Draft
 **Owner:** gemini
-**Last updated:** 2026-04-30
+**Last updated:** 2026-05-07
 
-Orbit UI covers the local dashboard served by `orbit-cli` and the project-facing web surface. It gives operators a dense, legible way to monitor agents, workflows, telemetry, and audit signals.
+Orbit UI covers the local dashboard served by `orbit-cli` and the project-facing web surface. It gives operators a dense, legible way to monitor tasks, agents, job runs, telemetry, policy denials, scoreboards, and audit signals without turning the interface into a chat transcript or marketing site.
 
 ## 1. Motivation
 
 Agent runs produce more state changes, logs, and diagnostics than a human can read linearly. The UI therefore optimizes for scan density, clear status recognition, and quick drill-downs. Canon Refined keeps the pro-tool feel while using readable sans-serif text, subtle rounding, and restrained semantic color [T20260427-29].
 
+The feature remains intentionally narrow: the current design target is the local operator dashboard plus shared visual language for project-facing pages, not a general component library or hosted product shell [T20260506-20].
+
 ## 2. Core Concepts
 
 - **Canon Refined and typography:** Layered dark surfaces, fine borders, compact spacing, and muted status colors; `Inter` carries labels and prose while `JetBrains Mono` carries IDs, metrics, timestamps, code, and logs.
-- **Surfaces:** The local dashboard lives in `crates/orbit-cli/assets/dashboard/`; static docs and project pages should reuse the same visual grammar without importing runtime-only dashboard assumptions.
+- **Dashboard shell:** The local dashboard lives in `crates/orbit-cli/assets/dashboard/` and is intentionally static HTML/CSS/JavaScript served by the CLI web command.
+- **Operational surfaces:** Tasks, live logs, job runs, run detail, audit events, policy denials, diagnostics, and scoreboards are separate views over durable Orbit state rather than bespoke workflow engines.
+- **Shared vocabulary:** UI-specific terms are kept in `./references/glossary.md`; generic web terms stay out unless Orbit gives them a narrower dashboard meaning [T20260506-20].
+- **Project-facing surfaces:** Static docs and project pages should reuse the same visual grammar without importing runtime-only dashboard assumptions.
 
 ## 3. At a Glance
 
@@ -22,10 +27,11 @@ Agent runs produce more state changes, logs, and diagnostics than a human can re
 | Local dashboard | `crates/orbit-cli/assets/dashboard/` | Runtime tabs, tables, tiles, logs, and diagnostics. |
 | Theme rules | `./specs/theme.md` | Canon Refined tokens and visual invariants. |
 | Current mechanisms | `./2_design.md` | Layout, telemetry, palette, typography, and known limitations. |
+| UI vocabulary | `./references/glossary.md` | Orbit-specific terms used by the design docs. |
 
 ## Task References
 
 - [T20260427-29] introduced the Canon Refined UI direction.
-- [T20260430-24] tightened the UI design docs against shared conventions.
+- [T20260506-20] added the required references folder and clarified the intentionally minimal UI scope.
 
 > Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.

--- a/docs/design/user-interface/2_design.md
+++ b/docs/design/user-interface/2_design.md
@@ -2,19 +2,25 @@
 
 **Status:** Draft
 **Owner:** gemini
-**Last updated:** 2026-04-30
+**Last updated:** 2026-05-07
 
-This document describes the current Orbit UI implementation: the local dashboard assets, the Canon Refined visual rules they rely on, and the telemetry behaviors that must stay consistent with backend data.
+This document describes the current Orbit UI implementation: the local dashboard assets, the CLI web API surface behind them, the Canon Refined visual rules they rely on [T20260427-29], and the telemetry behaviors that must stay consistent with backend data. The implementation is deliberately small: runtime state is rendered by static dashboard assets rather than a compiled frontend application [T20260506-20].
 
-## 1. Dense Layout
+## 1. Runtime Shell
 
-The dashboard favors wide, dense tables and panels over narrative screens. Tight spacing, small radii, and expandable sunken detail rows preserve hierarchy without hiding root lists. The scoreboard compresses companion metrics into pairs: `tokens` is `total/output`, `tool fail/all` is failed over total tool calls, and `duel w/all` is wins over participated duels. The primary friction column remains reported count only [T20260428-15].
+The dashboard lives in `crates/orbit-cli/assets/dashboard/` as `index.html` plus `app.js`, with the CLI web server exposing `/api/...` routes from `crates/orbit-cli/src/command/web/api.rs`. This keeps the operator console dependency-light and easy to ship with the binary, but it also means view structure, state transitions, and rendering helpers are hand-maintained in plain JavaScript.
 
-## 2. Layered Palette
+Dashboard state is fetched from task YAML, job-run state, audit stores, scoreboard summaries, and diagnostics endpoints. The UI should preserve that read-mostly posture: task lifecycle actions are present, but durable workflow truth remains in Orbit stores, not browser-local state.
+
+## 2. Dense Layout
+
+The dashboard favors wide, dense tables and panels over narrative screens. Tight spacing, small radii, grouped lifecycle sections, and expandable sunken detail rows preserve hierarchy without hiding root lists.
+
+The Tasks view pairs a grouped task table with a live log tail so an operator can correlate lifecycle state with recent execution noise. The Scoreboard view compresses companion metrics into pairs: `tokens` is `total/output`, `tool fail/all` is failed over total tool calls, and `duel w/all` is wins over participated duels. The primary friction column remains reported count only [T20260428-15].
+
+## 3. Layered Palette and Typography
 
 The UI uses layered dark surfaces instead of flat black: base canvas, elevated panels, sunken wells, and accent washes. Status color should stay muted and distinct; exact token values live in `./specs/theme.md` and the dashboard CSS.
-
-## 3. Typography
 
 `Inter` carries labels, headings, and prose. `JetBrains Mono` is reserved for IDs, metrics, timestamps, code, and log streams so numeric and diagnostic data stays aligned.
 
@@ -22,20 +28,30 @@ The UI uses layered dark surfaces instead of flat black: base canvas, elevated p
 
 Live processing is visible through pulsing dots, spinners, buffered-log counters, periodically refreshed tiles, and compact ticker-style values. The `orbit.log` panel is viewport-bounded; overflowing rows scroll inside the log stream so footer filters and follow-tail controls remain visible [T20260430-29]. Motion is functional: it points to active work without making the operator read raw logs first.
 
-## 5. Dashboard Telemetry Consistency
+## 5. Audit and Policy Surfaces
 
 Summary tiles and drill-down panels must agree. Audit > Policy is the detail view for the Denials 24h tile, so `/api/diagnostics/denials` combines v2 loop JSONL denial rows with SQLite `status = denied` audit events. SQLite filesystem boundary denials without an activity fsProfile use the stable `workspace-boundary` label [T20260428-13].
 
-## 6. Concerns & Honest Limitations
+Audit Events filters by status, tool, role, execution id, profile, search text, and time window. Run Detail follows job-run ids and v2 audit envelope steps rather than pretending SQLite command audit rows contain the full activity/job trace. When a control links between these views, it should preserve the underlying identifier semantics instead of overloading labels such as `run_id`.
+
+## 6. Diagnostics and Scoreboards
+
+Diagnostics surfaces expose recent run metrics and friction rows so agent failures can be triaged without scraping process stdout. The scoreboard joins metrics-derived per-agent summaries with friction counts, duel participation, token/tool-call ratios, and audit denials by role.
+
+Scoreboard cells should stay comparable at a glance. If a metric needs explanatory depth, the primary table should link or filter into a detail surface rather than adding more columns.
+
+## 7. Concerns & Honest Limitations
 
 Accessibility still needs a real WCAG pass; responsive behavior remains optimized for wide desktop viewports; raw HTML, CSS variables, and dashboard JavaScript keep the runtime simple but leave duplication across project surfaces.
+
+The UI design folder is now convention-shaped, but the feature itself is still under-developed outside the local dashboard: there is no accepted component packaging strategy, no keyboard-interaction contract, no public-site reuse mechanism, and no automated visual regression suite [T20260506-20].
 
 ## Task References
 
 - [T20260427-29] introduced the Canon Refined UI direction.
 - [T20260428-13] unified dashboard denial sources for the policy drill-down.
 - [T20260428-15] compacted scoreboard ratio columns.
-- [T20260430-24] shortened this design doc while preserving current behavior statements.
 - [T20260430-29] bounded the live `orbit.log` panel to the viewport.
+- [T20260506-20] added required reference docs and clarified current UI scope.
 
 > Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.

--- a/docs/design/user-interface/3_vision.md
+++ b/docs/design/user-interface/3_vision.md
@@ -2,7 +2,7 @@
 
 **Status:** Draft
 **Owner:** gemini
-**Last updated:** 2026-04-30
+**Last updated:** 2026-05-07
 
 This document scopes forward-looking UI work beyond the current dashboard: richer interactivity, careful motion, and a reusable design system that can span local runtime views and public project pages.
 
@@ -11,6 +11,8 @@ This document scopes forward-looking UI work beyond the current dashboard: riche
 1. **Framework adoption:** When dashboard state outgrows vanilla HTML/JS, is Preact, Svelte, or another small runtime worth the build complexity?
 2. **Motion:** Can the mark or status surfaces respond to real telemetry without becoming decorative noise?
 3. **Component sharing:** How do dashboard and static-site UI share tokens and components without a heavy Node.js pipeline?
+4. **Interaction depth:** Which workflows deserve keyboard shortcuts, saved filters, or command-palette treatment once the dashboard becomes a daily operator surface?
+5. **Accessibility target:** What WCAG level and assistive-technology matrix should Orbit commit to before the dashboard becomes more than a local developer tool?
 
 ## 2. Prior Work
 
@@ -21,18 +23,25 @@ This document scopes forward-looking UI work beyond the current dashboard: riche
 ### Modern Pro-Tools
 - **Linear and Vercel:** Benchmarks for quiet dark surfaces, precise typography, and keyboard-friendly interaction.
 
+### Observability Consoles
+- **Grafana and Honeycomb:** References for linking summary tiles into filtered detail surfaces while preserving source identifiers.
+- **GitHub Actions:** A practical comparison point for run lists, expandable logs, retry/cancel actions, and audit-friendly timestamps.
+
 ## 3. What May Be Distinctive
 
 Orbit can be distinctive by showing agent work as inspectable operations rather than hiding it behind chat. Graphs, traces, policy denials, scoreboards, and live logs should stay visible enough for engineering judgment while Canon Refined keeps the surface controlled [T20260427-29].
 
+The vision is intentionally incremental at this stage. Near-term work should deepen the existing dashboard before inventing new surfaces: better run inspection, clearer state provenance, keyboardable dense tables, saved filters, and visual consistency between docs, dashboard, and project pages [T20260506-20].
+
 ## 4. References
 
 - Orbit-internal: [Canon Refined Theme Spec](./specs/theme.md)
-- External: k9s, htop, Bloomberg Terminal, Linear, and Vercel remain comparison points for density, polish, and operator trust.
+- Orbit-internal: [User Interface Glossary](./references/glossary.md)
+- External: k9s, htop, Bloomberg Terminal, Linear, Vercel, Grafana, Honeycomb, and GitHub Actions remain comparison points for density, polish, traceability, and operator trust.
 
 ## Task References
 
 - [T20260427-29] introduced the Canon Refined UI direction.
-- [T20260430-24] tightened this vision doc around open questions and references.
+- [T20260506-20] documented the current minimal UI scope and reference vocabulary.
 
 > Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.

--- a/docs/design/user-interface/4_decisions.md
+++ b/docs/design/user-interface/4_decisions.md
@@ -2,7 +2,7 @@
 
 **Status:** Draft
 **Owner:** gemini
-**Last updated:** 2026-04-30
+**Last updated:** 2026-05-07
 
 This append-only ADR log records UI decisions in ascending order. Each entry keeps its status line, cited task ID, decision summary, and at least one explicit cost.
 
@@ -54,12 +54,24 @@ This append-only ADR log records UI decisions in ascending order. Each entry kee
 - Operators get one clear scroll target for raw log rows while live-tail controls stay visible during short-screen monitoring.
 - Cost: The Tasks view trades narrow-screen stacking for denser columns so the live log remains in the first viewport.
 
+## ADR-005 — Minimal UI Scope With Required References
+
+**Status:** Accepted · 2026-05 · [T20260506-20]
+
+**Context.** The user-interface design folder had the four numbered docs and a theme spec, but it lacked the required `references/` folder. The numbered docs also read thinner than other feature folders, making it unclear whether the UI had rotted or was intentionally limited.
+
+**Decision.** Keep the UI feature scoped to the local dashboard and shared Canon Refined visual grammar for now, add `references/glossary.md`, and document missing future commitments as explicit limitations rather than filling the folder with speculative mechanisms.
+
+**Consequences.**
+- The folder now satisfies the shared design-doc layout while staying honest about the dashboard-first implementation.
+- Cost: Future UI work still needs separate decisions for component packaging, keyboard contracts, accessibility targets, and visual regression testing.
+
 ## Task References
 
 - [T20260427-29] introduced the Canon Refined UI direction.
 - [T20260428-13] unified policy-denial sources for the dashboard.
 - [T20260428-15] compacted scoreboard ratio columns.
-- [T20260430-24] tightened this ADR log without changing decisions.
 - [T20260430-29] bounded the live `orbit.log` tail panel.
+- [T20260506-20] added required UI references and accepted the current minimal scope.
 
 > Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.

--- a/docs/design/user-interface/references/glossary.md
+++ b/docs/design/user-interface/references/glossary.md
@@ -1,0 +1,12 @@
+# Glossary: User Interface
+
+This glossary covers Orbit-specific UI vocabulary used by the User Interface docs. It deliberately excludes generic web, accessibility, and observability terms unless the Orbit dashboard gives them a narrower meaning.
+
+| Term | Meaning |
+|------|---------|
+| **Audit > Policy** | The dashboard drill-down surface for policy denials, backed by `/api/diagnostics/denials` rather than the generic audit-events table alone. See [../2_design.md §5](../2_design.md#5-audit-and-policy-surfaces). |
+| **Canon Refined** | Orbit's dense, layered dark UI language: compact spacing, subtle radii, muted semantic color, `Inter` for prose, and `JetBrains Mono` for diagnostic data. See [../2_design.md §3](../2_design.md#3-layered-palette-and-typography) and [../specs/theme.md](../specs/theme.md). |
+| **Denials 24h** | The dashboard summary tile that counts recent policy denials from both SQLite command audit rows and v2 loop denial envelopes. See [../2_design.md §5](../2_design.md#5-audit-and-policy-surfaces). |
+| **Live log tail** | The bounded `orbit.log` stream shown beside the Tasks view, with follow-tail and buffered-row controls kept visible while rows scroll internally. See [../2_design.md §4](../2_design.md#4-live-status). |
+| **Scoreboard ratio** | A compact paired metric in the agent scoreboard, such as `tokens` as `total/output`, `tool fail/all`, or `duel w/all`. See [../2_design.md §6](../2_design.md#6-diagnostics-and-scoreboards). |
+| **Workspace boundary** | The stable UI label for SQLite filesystem boundary denials that do not have an activity fsProfile. See [../2_design.md §5](../2_design.md#5-audit-and-policy-surfaces). |


### PR DESCRIPTION
## Tasks
- [T20260506-20] Bring user-interface design folder up to convention
  <details><summary>Execution Summary</summary>

## Status
success

## Summary of Changes
Added docs/design/user-interface/references/glossary.md in the shared glossary format. Expanded the UI numbered docs to describe the dashboard runtime shell, operational surfaces, audit/policy drill-downs, diagnostics/scoreboards, and intentional dashboard-first limitations. Added ADR-005 to record the minimal UI scope and required references decision for T20260506-20.

## Overall Assessment
The user-interface design folder now satisfies the required references folder/glossary acceptance criteria, and each numbered doc keeps the required section shape while honestly documenting the feature as under-developed outside the local dashboard.

## Validation
- git diff --check
- make fmt
- make build
- references/glossary.md existence and heading check

  </details>

## Branch Freshness
- Base ref: `origin/agent-main`
- Head ref: `orbit/T20260506-20-69fc10cc`
- Behind base: 0
- Ahead of base: 1

## Files Changed
- `docs/design/user-interface/1_overview.md`
- `docs/design/user-interface/2_design.md`
- `docs/design/user-interface/3_vision.md`
- `docs/design/user-interface/4_decisions.md`
- `docs/design/user-interface/references/glossary.md`

*authored by: claude-opus-4-7*