### PR TITLE
Update task-sync design docs for v1/v2 boundary shift onto orbit-registry

### DIFF
--- a/docs/design/task-sync/1_overview.md
+++ b/docs/design/task-sync/1_overview.md
@@ -2,11 +2,13 @@
 
 **Status:** Draft
 **Owner:** claude
-**Last updated:** 2026-05-06
+**Last updated:** 2026-05-07
 
-Task sync is an opt-in, git-orphan-branch task registry that lets engineers on the same team see each other's tasks without running a shared Orbit instance. **Sync is a v2 feature.** v1 ships per-engineer per the [README](../../../README.md) and [POSITIONING](../../POSITIONING.md) doctrines — each operator runs Orbit on their own machine, with tasks, locks, and audit DB local to that machine. This document captures the v2 design now while context is fresh; the implementation lands as a separate sequence of tasks once the design is Accepted.
+Task sync is an opt-in v2 feature that lets engineers on the same team see each other's tasks without running a shared Orbit instance. It is now scoped as **task-sync built on the v1 [orbit-registry](../orbit-registry/) primitive**: v1 lands reusable git-backed registry infrastructure for branch-scoped publication, while task bundles remain local-only until task sync itself ships in v2. v1 still ships per-engineer per the [README](../../../README.md) and [POSITIONING](../../POSITIONING.md) doctrines: each operator runs Orbit on their own machine, with tasks, locks, and audit DB local to that machine. This document captures the v2 task-sync layer while context is fresh; the implementation lands as a separate sequence of tasks once the design is Accepted.
 
-**2026-05-06 note ([T20260506-11]).** The prior cross-machine `task_id` motivation has been retired for v1. Orbit task IDs remain local search keys for the author (`git log --grep '[T...]'`); cross-engineer task references go through `external_refs`. This task-sync design remains a future v2 registry proposal, not a statement that today's `task_id` is globally resolvable.
+**2026-05-07 note ([T20260507-10]).** CEO/EXPANSION review D8 shifted the release boundary. The unified `OrbitRegistry` primitive lands in v1 as shared code infrastructure, alongside knowledge-graph snapshot publication; task sync remains v2 and becomes a consumer of that primitive rather than the feature that introduces the registry concept.
+
+**2026-05-06 note ([T20260506-11]).** The prior cross-machine `task_id` motivation has been retired for v1. Orbit task IDs remain local search keys for the author (`git log --grep '[T...]'`); cross-engineer task references go through `external_refs`. This task-sync design remains a future v2 task-sync proposal layered on the registry primitive, not a statement that today's `task_id` is globally resolvable.
 
 This document is the entry point. [2_design.md](./2_design.md) specifies the mechanism, call sites, and migration paths in detail; [3_vision.md](./3_vision.md) names open questions and prior work; [4_decisions.md](./4_decisions.md) is the ADR log.
 
@@ -16,13 +18,13 @@ This document is the entry point. [2_design.md](./2_design.md) specifies the mec
 
 The per-engineer-deployment commitment is honest about what v1 supports, but it leaves a visible coordination gap. Engineer A creates [T20260504-1] on their laptop; engineer B has no way to know it exists short of asking, finding the resulting PR, or reading commits the agent produces. For a 10–50 engineer team, that's expensive friction — exactly the friction the per-engineer framing was supposed to be honest about, not pretend away.
 
-Three obvious options for closing the gap:
+The v1 [orbit-registry](../orbit-registry/) primitive narrows the implementation gap but does not itself publish tasks. Three obvious options remain for closing the human coordination gap:
 
 1. **A shared Orbit server.** Solves it natively but is the v2 shared-host story, not v1.
-2. **Sync the task store via some external mechanism.** Generic, vague, hand-wavy.
-3. **Use git itself as the coordination primitive.** The team already has a shared git remote. Auth, ACL, and transport are already solved by whatever git host the team uses.
+2. **Build a task-specific registry from scratch in v2.** Plausible before the v1 registry decision, but now duplicated infrastructure.
+3. **Layer task sync on the v1 OrbitRegistry primitive.** The team already has a shared git remote. Auth, ACL, and transport are already solved by whatever git host the team uses, and Orbit now has one reusable branch-backed registry abstraction.
 
-Option 3 is what task sync proposes. A single orphan branch (proposed: `orbit/tasks`, ref `refs/heads/orbit/tasks`) holds the canonical task registry. `orbit task add` and mutating `orbit task update` paths fetch this ref before mutating, write locally, commit on the orphan branch, and push. Atomic git ref update is the coordinator. No new server, no new auth surface, no break to the v1 deployment doctrine.
+Option 3 is what task sync proposes for v2. A task-sync registry, implemented as an `OrbitRegistry` consumer, uses a single orphan branch (proposed: `orbit/tasks`, ref `refs/heads/orbit/tasks`) to hold the canonical task registry. `orbit task add` and mutating `orbit task update` paths fetch this ref before mutating, write locally, commit on the orphan branch, and push. Atomic git ref update is the coordinator. No new server, no new auth surface, and no break to the v1 deployment doctrine because v1 ships the primitive, not shared task state.
 
 The name "task sync" is deliberately narrow. It means task YAML bundles plus their companion files (`plan.md`, `execution-summary.md`, `artifacts/**`). It does *not* mean syncing locks, the audit DB, scoreboards, or job runs. Those have different consistency needs and are out of scope at any version — see [2_design.md §7](./2_design.md).
 
@@ -32,7 +34,7 @@ The name "task sync" is deliberately narrow. It means task YAML bundles plus the
 
 ### 2.1 Task registry
 
-The orphan branch acting as the canonical store of task bundles. The ref is `refs/heads/orbit/tasks`, the user-facing branch name is `orbit/tasks`. Its tree mirrors the workspace `.orbit/tasks/` layout exactly: status directories at the top (`proposed/`, `backlog/`, `in_progress/`, `review/`, `done/`, `blocked/`, `archived/`, `rejected/`, `friction/`, `someday/`), date-partitioned subdirectories (`<yyyy-mm>/`) under terminal states, and a per-task directory containing `task.yaml`, `plan.md`, `execution-summary.md`, and an optional `artifacts/` subtree.
+The task-sync use of the v1 `OrbitRegistry` primitive. It is backed by an orphan branch acting as the canonical store of task bundles. The ref is `refs/heads/orbit/tasks`, the user-facing branch name is `orbit/tasks`. Its tree mirrors the workspace `.orbit/tasks/` layout exactly: status directories at the top (`proposed/`, `backlog/`, `in_progress/`, `review/`, `done/`, `blocked/`, `archived/`, `rejected/`, `friction/`, `someday/`), date-partitioned subdirectories (`<yyyy-mm>/`) under terminal states, and a per-task directory containing `task.yaml`, `plan.md`, `execution-summary.md`, and an optional `artifacts/` subtree.
 
 Why an orphan branch and not a normal feature branch: the registry has no shared history with code branches, and merging it into `main` would be nonsensical. Orphan history keeps the registry inspectable via standard `git log refs/heads/orbit/tasks` while preventing accidental merge into product branches.
 
@@ -54,7 +56,7 @@ Task sync v2 ships **operation-aware replay**: on push reject, the client re-fet
 
 ### 2.4 v1/v2 boundary
 
-This design exists in v1 as a docs-only artifact. v1 ships with `[task.sync] enabled = false` as the default and no sync code. The implementation lives behind that flag and lands incrementally in v2. The decision to defer is itself an ADR ([4_decisions.md ADR-001](./4_decisions.md)) because it has costs the team should be able to read and challenge.
+v1 ships the shared `OrbitRegistry` primitive and keeps task state per-engineer. v1 also ships with `[task.sync] enabled = false` as the default and no task-sync mutation code. Task sync lands incrementally in v2 as a consumer of that primitive: it contributes the task bundle schema, online mutation policy, ID allocation against the registry view, and operation-aware replay. The release-boundary decision is captured in [4_decisions.md ADR-009](./4_decisions.md), which supersedes the older all-or-nothing v1/v2 statement in ADR-007.
 
 ---
 
@@ -63,6 +65,7 @@ This design exists in v1 as a docs-only artifact. v1 ships with `[task.sync] ena
 | Concern | File | Task |
 |---------|------|------|
 | Folder layout, frontmatter, ADR template | [docs/design/CONVENTIONS.md](../CONVENTIONS.md) | — |
+| Shared registry primitive | [docs/design/orbit-registry/](../orbit-registry/) | — |
 | Per-engineer deployment doctrine | [README.md](../../../README.md), [POSITIONING.md](../../POSITIONING.md) | — |
 | Task ID allocation (`T<YYYYMMDD>-<N>`) | [crates/orbit-store/src/file/task_store/layout.rs:102-132](../../../crates/orbit-store/src/file/task_store/layout.rs) | [T20260505-12] |
 | Task bundle write path | [crates/orbit-store/src/file/task_store/bundle.rs](../../../crates/orbit-store/src/file/task_store/bundle.rs) | [T20260505-12] |
@@ -79,5 +82,6 @@ This design exists in v1 as a docs-only artifact. v1 ships with `[task.sync] ena
 
 - [T20260505-12] — Design git-orphan-branch task sync (v2 feature). The task that produced this folder.
 - [T20260421-0528] — Historical knowledge-graph task attribution work. Superseded as evidence that `T<YYYYMMDD>-<N>` must be load-bearing across machines by [T20260506-11].
+- [T20260507-10] — Updates task-sync docs after CEO review D8 split the v1 orbit-registry primitive from the v2 task-sync consumer.
 
 Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.

--- a/docs/design/task-sync/2_design.md
+++ b/docs/design/task-sync/2_design.md
@@ -2,9 +2,9 @@
 
 **Status:** Draft
 **Owner:** claude
-**Last updated:** 2026-05-06
+**Last updated:** 2026-05-07
 
-This document specifies the v2 design for task sync: the registry mechanism, the conflict-resolution model and why it's the central design question, the call sites that need to become sync-aware, the CLI surface, the config schema, and the migration paths. v1 ships with sync disabled by default and the code path absent. The architectural boundary is explicit: the task store ([orbit-store/src/file/task_store/](../../../crates/orbit-store/src/file/task_store/)) keeps owning YAML layout and validation; a new task-sync coordinator above the store owns git transport.
+This document specifies the v2 design for task sync: the task registry shape, the conflict-resolution model and why it's the central design question, the call sites that need to become sync-aware, the CLI surface, the config schema, and the migration paths. v1 ships with sync disabled by default and the task-sync code path absent, while the shared [orbit-registry](../orbit-registry/) primitive lands first. The architectural boundary is explicit: the task store ([orbit-store/src/file/task_store/](../../../crates/orbit-store/src/file/task_store/)) keeps owning YAML layout and validation; the v2 task-sync coordinator consumes `OrbitRegistry` for branch-backed publication and owns task-specific mutation semantics.
 
 ---
 
@@ -15,7 +15,7 @@ In scope for task sync:
 - Task YAML bundles (`task.yaml`).
 - Companion files: `plan.md`, `execution-summary.md`.
 - Task artifacts under `<task-id>/artifacts/**`.
-- ID allocation against the registry's view of state, with the format `T<YYYYMMDD>-<N>` preserved for the future sync registry. Current v1 Orbit `task_id` values remain local-only search keys after [T20260506-11]; cross-engineer references use `external_refs`.
+- ID allocation against the `OrbitRegistry` view of task state, with the format `T<YYYYMMDD>-<N>` preserved for the future sync registry. Current v1 Orbit `task_id` values remain local-only search keys after [T20260506-11]; cross-engineer references use `external_refs`.
 
 Out of scope (with rationale in [§7](#7-concerns--honest-limitations)):
 
@@ -27,7 +27,7 @@ Out of scope (with rationale in [§7](#7-concerns--honest-limitations)):
 
 ### 2.1 Registry ref and branch name
 
-The registry lives at `refs/heads/orbit/tasks`. User-facing branch name: `orbit/tasks`. This is a normal-form git branch ref so:
+Task sync configures the v1 `OrbitRegistry` primitive with `refs/heads/orbit/tasks`. User-facing branch name: `orbit/tasks`. This is a normal-form git branch ref so:
 
 - Branch protection on hosts (GitHub, GitLab, Gitea) can be applied without custom configuration.
 - Code review tooling that lists branches will include it.
@@ -187,24 +187,25 @@ All four mutation entry points (runtime, CLI, web) route through the same sync-a
 
 ### 5.1 The sync coordinator
 
-A new component, tentatively `orbit-store::sync::TaskSyncCoordinator`, sits *above* the existing file store and *below* the runtime/CLI/web entry points. It owns:
+A new component, tentatively `orbit-store::sync::TaskSyncCoordinator`, sits *above* the existing file store and *below* the runtime/CLI/web entry points. It consumes `OrbitRegistry` for reusable branch-backed publication and owns:
 
-- Git transport (fetch, commit, push, retry).
+- Task-registry configuration for the shared registry primitive.
 - Operation classification (which task operation is being attempted).
 - Replay logic (the rules in [§3.2](#32-operation-aware-replay-the-recommended-mechanism)).
-- Auth handoff to the system git credential helper.
+- Structured task-sync conflicts and resolution state.
 
 It does *not* own:
 
+- Generic git transport, ref publication, or credential-helper integration (owned by [docs/design/orbit-registry/](../orbit-registry/) after CEO review D8).
 - YAML serialization (still in [bundle.rs](../../../crates/orbit-store/src/file/task_store/bundle.rs)).
 - Layout (`<state>/<task-id>/...` paths still in [layout.rs](../../../crates/orbit-store/src/file/task_store/layout.rs)).
 - Reservation locks (still per-machine in [task_reservation_store.rs](../../../crates/orbit-store/src/sqlite/task_reservation_store.rs); locks are out of scope at any version).
 
-Putting git transport above the file store keeps `orbit-store` mockable for tests and ensures sync policy can change without rewriting layout code.
+Putting the task-sync layer above the file store keeps `orbit-store` mockable for tests and ensures sync policy can change without rewriting layout code.
 
 ### 5.2 git2 vs shelling to git
 
-The recommendation is the `git2` crate (libgit2 bindings). Reasons:
+The task-sync recommendation remains the `git2` crate (libgit2 bindings). Because the reusable transport may now land in v1 as part of orbit-registry, ADR-009 requires revalidating this cost against the knowledge-graph snapshot read path before accepting the shared primitive. Reasons:
 
 - In-process control over fetch/push/commit lets the coordinator implement retry without spawning subprocesses.
 - Authentication callbacks integrate with the system credential helper without parsing `git` output.
@@ -296,5 +297,6 @@ Task sync inherits whatever auth posture the team uses for `git push`. If a team
 - [T20260421-0528] — Historical knowledge-graph task attribution. Superseded as a canonical load-bearing ID example by [T20260506-11].
 - [T20260506-9] — Adds first-class task `external_refs` metadata and documents the task-sync merge rule.
 - [T20260506-13] — Rejected follow-up; no standalone task-sync replay implementation is currently required for `external_refs`.
+- [T20260507-10] — Updates task-sync docs after CEO review D8 split the v1 orbit-registry primitive from the v2 task-sync consumer.
 
 Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.

--- a/docs/design/task-sync/3_vision.md
+++ b/docs/design/task-sync/3_vision.md
@@ -2,9 +2,9 @@
 
 **Status:** Draft
 **Owner:** claude
-**Last updated:** 2026-05-05
+**Last updated:** 2026-05-07
 
-This document captures the open questions task sync deliberately leaves unanswered, the prior work the design builds on or rejects, what the design contributes that's specific to Orbit, and external references for readers who want to dig deeper. The questions in §1 are the most likely sources of post-v2 design pressure; the prior work in §2 explains why the v2 design landed where it did.
+This document captures the open questions task sync deliberately leaves unanswered, the prior work the design builds on or rejects, what the design contributes that's specific to Orbit, and external references for readers who want to dig deeper. The questions in §1 are the most likely sources of post-v2 design pressure after the v1 [orbit-registry](../orbit-registry/) decision; the prior work in §2 explains why the v2 task-sync layer landed where it did.
 
 ---
 
@@ -22,14 +22,14 @@ The v2 design ships without compaction. Three candidate strategies for a follow-
 
 Decision deferred until operational pain manifests on a real team's branch.
 
-### 1.2 Should sync fold into v2 shared-host?
+### 1.2 Shared-host coexistence after the registry primitive
 
-Task sync is opt-in and orthogonal to the v2 shared-host coordinator. If shared-host ships, there are two coherent end states:
+The v1 orbit-registry decision answers the infrastructure question: Orbit will have a reusable git-backed registry primitive before task sync ships. The remaining product question is how task sync should coexist with the v2 shared-host coordinator. If shared-host ships, there are two coherent end states:
 
-- **Sync remains.** Teams can choose: orphan-branch sync (no server, slower, partially manual) or shared-host (server, fast, central). Both ship.
-- **Sync is deprecated.** Shared-host becomes the team-coordination story; orphan-branch sync is removed because it duplicates functionality with worse properties.
+- **Task sync remains.** Teams can choose: a git-remote-backed `OrbitRegistry` consumer (no server, slower, partially manual) or shared-host (server, fast, central). Both ship.
+- **Task sync is deprecated.** Shared-host becomes the team-coordination story; task sync is removed because it duplicates functionality with worse properties. The underlying `OrbitRegistry` primitive can still serve other v1 consumers such as knowledge-graph snapshot publication.
 
-The honest answer depends on demand. Some teams won't run a shared service. Some teams will. The design does not pre-commit; it builds task sync as a standalone feature that can survive or be retired without restructuring the rest of Orbit.
+The honest answer depends on demand. Some teams won't run a shared service. Some teams will. The design does not pre-commit; it builds task sync as a feature-specific registry consumer that can survive or be retired without restructuring the shared primitive.
 
 ### 1.3 Soft-claim semantics
 
@@ -134,6 +134,7 @@ Task sync inherits the team's existing git auth posture. Whatever the team uses 
 - [docs/POSITIONING.md](../../POSITIONING.md) — the per-engineer-deployment doctrine that motivates this design.
 - [README.md](../../../README.md) — `Direction of travel` section names shared-host as v2; task sync slots underneath that as a v2 mechanism.
 - [docs/design/CONVENTIONS.md](../CONVENTIONS.md) — folder layout, frontmatter, ADR template.
+- [docs/design/orbit-registry/](../orbit-registry/) — the v1 shared registry primitive that task sync consumes in v2.
 - [docs/design/knowledge-graph/](../knowledge-graph/) — content-addressed branch-scoped storage; relevant precedent for "Orbit data lives in branch-aware structures."
 - [docs/design/auditability/](../auditability/) — relevant for understanding why audit DB is explicitly out-of-scope for task sync.
 
@@ -150,5 +151,6 @@ Task sync inherits the team's existing git auth posture. Whatever the team uses 
 ## Task References
 
 - [T20260505-12] — Design git-orphan-branch task sync (v2 feature). The task that produced this folder.
+- [T20260507-10] — Updates task-sync docs after CEO review D8 split the v1 orbit-registry primitive from the v2 task-sync consumer.
 
 Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.

--- a/docs/design/task-sync/4_decisions.md
+++ b/docs/design/task-sync/4_decisions.md
@@ -2,7 +2,7 @@
 
 **Status:** Draft
 **Owner:** claude
-**Last updated:** 2026-05-06
+**Last updated:** 2026-05-07
 
 ADR-style log of non-obvious task-sync decisions. Each entry names the pressure, the choice, and the tradeoff. Entries are append-only and keyed by number; superseded entries are marked, not deleted.
 
@@ -108,7 +108,7 @@ Format for each entry: **Status · Date · Task(s)**, then *Context → Decision
 
 ## ADR-007 — Sync ships in v2; v1 is per-engineer
 
-**Status:** Proposed · 2026-05 · [T20260505-12]
+**Status:** Superseded by ADR-009 · 2026-05 · [T20260505-12]
 
 **Context.** Initial discussion of task sync framed it as a v1 feature — small, opt-in, fits the existing per-engineer doctrine. Subsequent analysis (specifically the conflict-resolution scenarios in [2_design.md §3.1](./2_design.md)) revealed that doing sync correctly requires the operation-aware-replay subsystem in ADR-002, which is meaningful engineering. A half-built sync — for example, ADD-only with no update propagation — produces the wrong mental model: "I can see Bob's task exists but never see him work on it." That's worse for adoption than no sync.
 
@@ -137,8 +137,25 @@ Format for each entry: **Status · Date · Task(s)**, then *Context → Decision
 
 ---
 
+## ADR-009 — v1 registry primitive; task sync v2 consumer
+
+**Status:** Proposed · 2026-05 · [T20260507-10]
+
+**Context.** CEO/EXPANSION review on 2026-05-06, decision D8, shifted the release boundary: the unified `OrbitRegistry` primitive and knowledge-graph snapshot publication land in v1, while task sync remains v2. ADR-007 correctly deferred task sync, but it now reads as if v2 must introduce the registry concept itself.
+
+**Decision.** Split the reusable primitive from the task-sync feature. v1 lands the [orbit-registry](../orbit-registry/) primitive as shared branch-backed infrastructure; task-sync is a v2 consumer of that v1 primitive, adding task-bundle schema, online mutation policy, ID allocation against the registry view, and operation-aware replay. v1 still publishes no shared task state.
+
+**Consequences.**
+- Future v2 task-sync scope is smaller and more honest: it owns task semantics, not the generic registry substrate.
+- Knowledge-graph snapshot publication and task sync share one primitive, so transport, ref layout, auth, and audit constraints need one owner.
+- ADR-006's `git2` choice becomes load-bearing earlier than originally scoped; per CEO review D8, the KG-share read path must re-evaluate whether that transport cost is still justified before the registry primitive is accepted.
+- Cost: v1 absorbs reusable registry complexity before task-sync users exist, and any `OrbitRegistry` contract mistake becomes inherited by v2 task sync.
+
+---
+
 ## Task References
 
 - [T20260505-12] — Design git-orphan-branch task sync (v2 feature). The task that produced this folder.
+- [T20260507-10] — Updates task-sync docs after CEO review D8 split the v1 orbit-registry primitive from the v2 task-sync consumer.
 
 Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.


### PR DESCRIPTION
## Tasks
- [T20260507-10] Update task-sync design docs for v1/v2 boundary shift onto orbit-registry
  <details><summary>Execution Summary</summary>

## Status
success

## Summary of Changes
- Updated task-sync overview to describe task-sync as a v2 consumer of the v1 orbit-registry primitive and to reference docs/design/orbit-registry/.
- Updated task-sync design to make the v2 coordinator consume OrbitRegistry for branch-backed publication while retaining task-specific replay, conflict, and mutation semantics.
- Updated task-sync vision so the registry primitive decision is no longer an open infrastructure question; only shared-host coexistence remains open.
- Added ADR-009 for CEO/EXPANSION review D8 and marked ADR-007 as Superseded by ADR-009 with the original body preserved.

## Overall Assessment
Manual CONVENTIONS.md §3 readback passed for all modified numbered docs, and make fmt exits 0.

## Design Weaknesses / Risks
- docs/design/orbit-registry/ is not present in this worktree, so merge must wait for the registry folder draft to land before the new cross-reference resolves. | Severity: Medium | Mitigation: coordinate this task after the orbit-registry folder task lands.

  </details>

## Branch Freshness
- Base ref: `origin/agent-main`
- Head ref: `orbit/T20260507-10-69fc1f81`
- Behind base: 0
- Ahead of base: 1

## Files Changed
- `docs/design/task-sync/1_overview.md`
- `docs/design/task-sync/2_design.md`
- `docs/design/task-sync/3_vision.md`
- `docs/design/task-sync/4_decisions.md`

*authored by: claude-opus-4-7*