### PR TITLE
Scaffold orbit-registry crate skeleton with merge-class trait and crate-boundary enforcement

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -274,6 +274,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aebf35691d1bfb0ac386a69bac2fde4dd276fb618cf8bf4f5318fe285e821bb2"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -804,6 +806,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "git2"
+version = "0.20.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b88256088d75a56f8ecfa070513a775dd9107f6530ef14919dac831af9cfe2b"
+dependencies = [
+ "bitflags",
+ "libc",
+ "libgit2-sys",
+ "log",
+ "url",
+]
+
+[[package]]
 name = "globset"
 version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1191,6 +1206,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1243,12 +1268,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
 
 [[package]]
+name = "libgit2-sys"
+version = "0.18.3+1.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9b3acc4b91781bb0b3386669d325163746af5f6e4f73e6d2d630e09a35f3487"
+dependencies = [
+ "cc",
+ "libc",
+ "libz-sys",
+ "pkg-config",
+]
+
+[[package]]
 name = "libsqlite3-sys"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c10584274047cb335c23d3e61bcef8e323adae7c5c8c760540f73610177fc3f"
 dependencies = [
  "cc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
+name = "libz-sys"
+version = "1.1.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc3a226e576f50782b3305c5ccf458698f92798987f551c6a02efe8276721e22"
+dependencies = [
+ "cc",
+ "libc",
  "pkg-config",
  "vcpkg",
 ]
@@ -1684,6 +1733,15 @@ version = "0.1.0"
 dependencies = [
  "orbit-common",
  "serde",
+]
+
+[[package]]
+name = "orbit-registry"
+version = "0.1.0"
+dependencies = [
+ "git2",
+ "orbit-common",
+ "toml",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ members = [
   "crates/orbit-agent",
   "crates/orbit-cli",
   "crates/orbit-common",
+  "crates/orbit-registry",
   "crates/orbit-core",
   "crates/orbit-engine",
   "crates/orbit-knowledge",
@@ -24,6 +25,7 @@ axum = { version = "0.7", default-features = false, features = ["http1", "json",
 chrono = { version = "0.4", features = ["serde"] }
 clap = { version = "4.5", features = ["derive"] }
 fs2 = "0.4"
+git2 = { version = "0.20", default-features = false }
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "signal", "net", "sync"] }
 jsonschema = { version = "0.18", default-features = false }
 libc = "0.2"

--- a/crates/orbit-registry/Cargo.toml
+++ b/crates/orbit-registry/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "orbit-registry"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[features]
+default = []
+transport-git2 = ["dep:git2"]
+
+[dependencies]
+git2 = { workspace = true, optional = true }
+orbit-common = { path = "../orbit-common" }
+
+[dev-dependencies]
+toml.workspace = true

--- a/crates/orbit-registry/src/error.rs
+++ b/crates/orbit-registry/src/error.rs
@@ -1,0 +1,15 @@
+use orbit_common::types::OrbitError;
+
+/// Registry operations use the shared Orbit error surface.
+pub type RegistryError = OrbitError;
+
+/// Result alias for registry APIs.
+pub type RegistryResult<T> = std::result::Result<T, RegistryError>;
+
+#[cfg(feature = "transport-git2")]
+pub(crate) fn unsupported(message: impl Into<String>) -> RegistryError {
+    OrbitError::Execution(format!(
+        "registry operation is not implemented: {}",
+        message.into()
+    ))
+}

--- a/crates/orbit-registry/src/lib.rs
+++ b/crates/orbit-registry/src/lib.rs
@@ -1,0 +1,87 @@
+#![deny(clippy::print_stderr, clippy::print_stdout)]
+//! Generic replicated registry substrate for Orbit publication flows.
+//!
+//! The crate intentionally works with opaque bytes and string keys. Consumer
+//! crates choose their own payload schemas, then select a merge class that tells
+//! registry transports how replicas may combine those payloads.
+
+pub mod error;
+pub mod merge;
+pub mod transport;
+
+pub use error::{RegistryError, RegistryResult};
+pub use merge::MergeClass;
+pub use transport::{NoopTransport, RegistryTransport, TransportEnvelope};
+
+/// Identifies a source replica participating in registry publication.
+pub trait Replica {
+    /// Stable replica identifier used by transports and merge logs.
+    fn replica_id(&self) -> &str;
+}
+
+/// Facade over a transport-backed replicated registry.
+#[derive(Debug)]
+pub struct Registry<T = NoopTransport> {
+    transport: T,
+}
+
+impl Registry<NoopTransport> {
+    /// Creates a registry with a no-op transport for callers that only need the
+    /// type surface while wiring higher-level consumers.
+    pub fn noop() -> Self {
+        Self::new(NoopTransport)
+    }
+}
+
+impl<T> Registry<T> {
+    /// Creates a registry backed by the provided transport implementation.
+    pub fn new(transport: T) -> Self {
+        Self { transport }
+    }
+
+    /// Returns the backing transport.
+    pub fn transport(&self) -> &T {
+        &self.transport
+    }
+
+    /// Consumes the registry and returns the backing transport.
+    pub fn into_transport(self) -> T {
+        self.transport
+    }
+}
+
+impl Default for Registry<NoopTransport> {
+    fn default() -> Self {
+        Self::noop()
+    }
+}
+
+impl<T> Registry<T>
+where
+    T: RegistryTransport,
+{
+    /// Publishes opaque registry bytes for a replica under the selected merge
+    /// class.
+    pub fn publish<R>(
+        &self,
+        replica: &R,
+        key: &str,
+        merge_class: MergeClass,
+        payload: &[u8],
+    ) -> RegistryResult<()>
+    where
+        R: Replica,
+    {
+        self.transport.publish(TransportEnvelope {
+            replica_id: replica.replica_id(),
+            key,
+            merge_class,
+            payload,
+        })
+    }
+
+    /// Fetches the latest transport-visible bytes for a key.
+    pub fn fetch(&self, key: &str) -> RegistryResult<Option<Vec<u8>>> {
+        self.transport.fetch(key)
+    }
+}

--- a/crates/orbit-registry/src/merge/mod.rs
+++ b/crates/orbit-registry/src/merge/mod.rs
@@ -1,0 +1,12 @@
+/// Merge behavior requested by a registry payload.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub enum MergeClass {
+    /// Replays ordered records.
+    Replay,
+    /// Merges counter state using CRDT semantics.
+    CrdtCounter,
+    /// Appends immutable records in publication order.
+    AppendOnly,
+    /// Publishes immutable bytes addressed by content identity.
+    ContentAddressedImmutable,
+}

--- a/crates/orbit-registry/src/transport/git2.rs
+++ b/crates/orbit-registry/src/transport/git2.rs
@@ -1,0 +1,40 @@
+use std::path::Path;
+
+use crate::{
+    RegistryResult,
+    error::unsupported,
+    transport::{RegistryTransport, TransportEnvelope},
+};
+
+/// Placeholder git2-backed registry transport.
+#[derive(Debug)]
+pub struct Git2Transport {
+    repository_path: std::path::PathBuf,
+}
+
+impl Git2Transport {
+    /// Opens a git repository for future registry publication work.
+    pub fn open(repository_path: impl AsRef<Path>) -> RegistryResult<Self> {
+        let repository_path = repository_path.as_ref();
+        ::git2::Repository::open(repository_path)
+            .map_err(|error| unsupported(format!("open git repository: {error}")))?;
+        Ok(Self {
+            repository_path: repository_path.to_path_buf(),
+        })
+    }
+
+    /// Returns the repository path backing this transport.
+    pub fn repository_path(&self) -> &Path {
+        &self.repository_path
+    }
+}
+
+impl RegistryTransport for Git2Transport {
+    fn publish(&self, _envelope: TransportEnvelope<'_>) -> RegistryResult<()> {
+        Err(unsupported("git2 publish transport"))
+    }
+
+    fn fetch(&self, _key: &str) -> RegistryResult<Option<Vec<u8>>> {
+        Err(unsupported("git2 fetch transport"))
+    }
+}

--- a/crates/orbit-registry/src/transport/mod.rs
+++ b/crates/orbit-registry/src/transport/mod.rs
@@ -1,0 +1,40 @@
+use crate::{MergeClass, RegistryResult};
+
+#[cfg(feature = "transport-git2")]
+pub mod git2;
+
+/// Opaque publication unit passed to registry transports.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct TransportEnvelope<'a> {
+    /// Replica that produced the payload.
+    pub replica_id: &'a str,
+    /// Consumer-defined registry key.
+    pub key: &'a str,
+    /// Merge behavior requested for the payload.
+    pub merge_class: MergeClass,
+    /// Consumer-defined payload bytes.
+    pub payload: &'a [u8],
+}
+
+/// Transport boundary for publishing and reading registry bytes.
+pub trait RegistryTransport {
+    /// Publishes an opaque envelope.
+    fn publish(&self, envelope: TransportEnvelope<'_>) -> RegistryResult<()>;
+
+    /// Fetches transport-visible bytes for a key.
+    fn fetch(&self, key: &str) -> RegistryResult<Option<Vec<u8>>>;
+}
+
+/// Transport stub used until concrete transports land.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct NoopTransport;
+
+impl RegistryTransport for NoopTransport {
+    fn publish(&self, _envelope: TransportEnvelope<'_>) -> RegistryResult<()> {
+        Ok(())
+    }
+
+    fn fetch(&self, _key: &str) -> RegistryResult<Option<Vec<u8>>> {
+        Ok(None)
+    }
+}

--- a/crates/orbit-registry/tests/dep_boundary.rs
+++ b/crates/orbit-registry/tests/dep_boundary.rs
@@ -1,0 +1,111 @@
+use std::collections::BTreeSet;
+
+use toml::Value;
+
+const MANIFEST: &str = include_str!("../Cargo.toml");
+
+#[test]
+fn only_orbit_common_is_an_internal_dependency() {
+    let manifest = parse_manifest();
+    let mut dependency_names = BTreeSet::new();
+
+    collect_dependencies(&manifest, &mut dependency_names);
+
+    let orbit_deps = dependency_names
+        .iter()
+        .filter(|name| name.starts_with("orbit-"))
+        .cloned()
+        .collect::<Vec<_>>();
+
+    assert_eq!(
+        orbit_deps,
+        vec!["orbit-common".to_string()],
+        "orbit-registry must remain consumer-agnostic and depend only on orbit-common internally"
+    );
+
+    for forbidden in [
+        "orbit-knowledge",
+        "orbit-store",
+        "orbit-tools",
+        "orbit-policy",
+        "orbit-exec",
+    ] {
+        assert!(
+            !dependency_names.contains(forbidden),
+            "forbidden internal dependency added: {forbidden}"
+        );
+    }
+}
+
+#[test]
+fn git2_transport_is_feature_gated() {
+    let manifest = parse_manifest();
+    let dependencies = manifest
+        .get("dependencies")
+        .and_then(Value::as_table)
+        .expect("dependencies table");
+    let git2_dependency = dependencies
+        .get("git2")
+        .and_then(Value::as_table)
+        .expect("git2 dependency table");
+
+    assert_eq!(
+        git2_dependency.get("optional").and_then(Value::as_bool),
+        Some(true),
+        "git2 must stay optional"
+    );
+
+    let features = manifest
+        .get("features")
+        .and_then(Value::as_table)
+        .expect("features table");
+    assert!(
+        features
+            .get("default")
+            .and_then(Value::as_array)
+            .is_some_and(Vec::is_empty),
+        "default features must not enable git2"
+    );
+    assert!(
+        features
+            .get("transport-git2")
+            .and_then(Value::as_array)
+            .is_some_and(|values| values
+                .iter()
+                .any(|value| value.as_str() == Some("dep:git2"))),
+        "transport-git2 must gate the optional git2 dependency"
+    );
+}
+
+fn parse_manifest() -> Value {
+    toml::from_str(MANIFEST).expect("crate manifest parses")
+}
+
+fn collect_dependencies(manifest: &Value, names: &mut BTreeSet<String>) {
+    for section in ["dependencies", "dev-dependencies", "build-dependencies"] {
+        collect_dependency_table(manifest.get(section), names);
+    }
+
+    if let Some(targets) = manifest.get("target").and_then(Value::as_table) {
+        for target in targets.values() {
+            for section in ["dependencies", "dev-dependencies", "build-dependencies"] {
+                collect_dependency_table(target.get(section), names);
+            }
+        }
+    }
+}
+
+fn collect_dependency_table(section: Option<&Value>, names: &mut BTreeSet<String>) {
+    let Some(table) = section.and_then(Value::as_table) else {
+        return;
+    };
+
+    for (name, value) in table {
+        let package_name = value
+            .as_table()
+            .and_then(|table| table.get("package"))
+            .and_then(Value::as_str)
+            .unwrap_or(name);
+        names.insert(package_name.to_string());
+    }
+}


### PR DESCRIPTION
## Tasks
- [T20260507-12] Scaffold orbit-registry crate skeleton with merge-class trait and crate-boundary enforcement
  <details><summary>Execution Summary</summary>

## Status
success

## Summary of Changes
- Added `crates/orbit-registry` as a workspace member with `orbit-common` as its only internal Orbit dependency.
- Added the registry skeleton: `Registry`, `Replica`, `MergeClass`, registry error/result aliases, no-op transport, placeholder transport trait, merge module, and feature-gated git2 transport stub.
- Added `transport-git2` with `git2` as an optional dependency and `default = []`; set git2 workspace dependency with `default-features = false`.
- Added `crates/orbit-registry/tests/dep_boundary.rs` to enforce the internal dependency boundary and git2 feature gating from the crate manifest.

## Overall Assessment
The crate compiles cleanly, the workspace builds, and the boundary test covers the main architectural risk: graph/store/tools/policy/exec types cannot be introduced as registry dependencies without breaking the integration test.

## Deviations from Original Plan
- Did not move the task to `review` because this executor envelope says the pipeline performs that transition only after commit/merge or PR steps succeed.
- The acceptance metadata command is invalid in this Cargo version because `cargo metadata` does not accept `-p`; the equivalent raw-output query without `-p` returned exactly `orbit-common`.

## Validation
- `CARGO_HOME=/tmp/orbit-cargo-home-jrun-20260507-0513-5 cargo metadata --format-version=1 | jq -r '.packages[] | select(.name=="orbit-registry") | .dependencies[] | .name' | grep -E '^orbit-' | sort -u` -> `orbit-common`
- `cargo build -p orbit-registry`
- `cargo test -p orbit-registry`
- `CARGO_HOME=/tmp/orbit-cargo-home-jrun-20260507-0513-5 cargo check -p orbit-registry --features transport-git2`
- `make fmt`
- `make build`

## Recommended Follow-Ups
- T20260507-20 was filed for the executor-envelope vs. `orbit-execute-task` review-transition guidance conflict encountered during this run.

  </details>

## Branch Freshness
- Base ref: `origin/agent-main`
- Head ref: `orbit/T20260507-12-69fc1f81`
- Behind base: 0
- Ahead of base: 1

## Files Changed
- `Cargo.lock`
- `Cargo.toml`
- `crates/orbit-registry/Cargo.toml`
- `crates/orbit-registry/src/error.rs`
- `crates/orbit-registry/src/lib.rs`
- `crates/orbit-registry/src/merge/mod.rs`
- `crates/orbit-registry/src/transport/git2.rs`
- `crates/orbit-registry/src/transport/mod.rs`
- `crates/orbit-registry/tests/dep_boundary.rs`

*authored by: claude-opus-4-7*