### PR TITLE
Lock down identity_key durability invariants with explicit rebuild-stability tests

### DIFF
--- a/crates/orbit-knowledge/src/pipeline/build.rs
+++ b/crates/orbit-knowledge/src/pipeline/build.rs
@@ -330,17 +330,19 @@ fn build_file_leaves(
     let extractor = registry.get(info.file_kind)?;
     let result = extractor.extract(&content);
     let file_hash_at_capture = ctx.new_hashes.get(&info.location).cloned();
+    let mut file = extracted_file_from_result(
+        &info.location,
+        &info.file_id,
+        info.file_kind,
+        content,
+        result,
+        file_hash_at_capture,
+    );
+    preserve_prior_leaf_identities(&mut file, prior_files, &ctx.new_hashes, &info.location);
 
     Some(LeafBuildOutput::Extracted {
         file_idx: info.file_idx,
-        file: extracted_file_from_result(
-            &info.location,
-            &info.file_id,
-            info.file_kind,
-            content,
-            result,
-            file_hash_at_capture,
-        ),
+        file,
     })
 }
 
@@ -408,6 +410,142 @@ fn extracted_file_from_result(
         leaf_children,
         leaves,
     }
+}
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+struct LeafIdentityMatchKey {
+    qualified_name: String,
+    kind: String,
+    source_hash: Option<String>,
+}
+
+#[derive(Clone, Debug)]
+struct PriorLeafIdentity {
+    id: String,
+    identity_key: String,
+}
+
+fn preserve_prior_leaf_identities(
+    file: &mut ExtractedFile,
+    prior_files: Option<&HashMap<String, PriorFileSnapshot>>,
+    current_hashes: &HashMap<String, String>,
+    current_location: &str,
+) {
+    let Some(prior_files) = prior_files else {
+        return;
+    };
+
+    if let Some(snapshot) = prior_files.get(current_location) {
+        apply_prior_leaf_identities(file, &snapshot.leaves, false);
+        return;
+    }
+
+    let mut candidates = prior_files
+        .iter()
+        .filter(|(location, _)| location.as_str() != current_location)
+        .filter(|(location, _)| !current_hashes.contains_key(location.as_str()))
+        .filter(|(_, snapshot)| {
+            snapshot.source_blob_hash.as_deref() == Some(&file.source_blob_hash)
+        })
+        .map(|(_, snapshot)| snapshot);
+
+    let Some(candidate) = candidates.next() else {
+        return;
+    };
+    if candidates.next().is_some() {
+        return;
+    }
+
+    apply_prior_leaf_identities(file, &candidate.leaves, true);
+}
+
+fn apply_prior_leaf_identities(
+    file: &mut ExtractedFile,
+    prior_leaves: &[LeafNode],
+    include_source_hash: bool,
+) {
+    let prior_by_key = unique_prior_leaf_identities(prior_leaves, include_source_hash);
+    let mut id_rewrites = HashMap::new();
+
+    for leaf in &mut file.leaves {
+        let Some(key) = leaf_identity_match_key(leaf, include_source_hash) else {
+            continue;
+        };
+        let Some(prior) = prior_by_key.get(&key) else {
+            continue;
+        };
+
+        let default_id = leaf.base.id.clone();
+        leaf.base.id = prior.id.clone();
+        leaf.base.identity_key = prior.identity_key.clone();
+        id_rewrites.insert(default_id, leaf.base.id.clone());
+    }
+
+    if id_rewrites.is_empty() {
+        return;
+    }
+
+    for child_id in &mut file.leaf_children {
+        if let Some(rewritten) = id_rewrites.get(child_id) {
+            *child_id = rewritten.clone();
+        }
+    }
+    for leaf in &mut file.leaves {
+        for child_id in &mut leaf.children {
+            if let Some(rewritten) = id_rewrites.get(child_id) {
+                *child_id = rewritten.clone();
+            }
+        }
+    }
+}
+
+fn unique_prior_leaf_identities(
+    leaves: &[LeafNode],
+    include_source_hash: bool,
+) -> HashMap<LeafIdentityMatchKey, PriorLeafIdentity> {
+    let mut identities = HashMap::new();
+    let mut duplicates = HashSet::new();
+
+    for leaf in leaves {
+        let Some(key) = leaf_identity_match_key(leaf, include_source_hash) else {
+            continue;
+        };
+        if identities
+            .insert(
+                key.clone(),
+                PriorLeafIdentity {
+                    id: leaf.base.id.clone(),
+                    identity_key: leaf.base.identity_key.clone(),
+                },
+            )
+            .is_some()
+        {
+            duplicates.insert(key);
+        }
+    }
+
+    for key in duplicates {
+        identities.remove(&key);
+    }
+
+    identities
+}
+
+fn leaf_identity_match_key(
+    leaf: &LeafNode,
+    include_source_hash: bool,
+) -> Option<LeafIdentityMatchKey> {
+    let (_, qualified_name) = leaf.base.location.split_once('#')?;
+    let source_hash = if include_source_hash {
+        Some(leaf.source_hash.clone()?)
+    } else {
+        None
+    };
+    Some(LeafIdentityMatchKey {
+        qualified_name: qualified_name.to_string(),
+        kind: leaf.kind.to_string(),
+        source_hash,
+    })
 }
 
 #[derive(Clone)]

--- a/crates/orbit-knowledge/tests/identity_key_durability.rs
+++ b/crates/orbit-knowledge/tests/identity_key_durability.rs
@@ -1,0 +1,243 @@
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::Path;
+use std::process::Command;
+
+use orbit_knowledge::graph::nodes::LeafNode;
+use orbit_knowledge::graph::object_store::RefName;
+use orbit_knowledge::pipeline;
+use orbit_knowledge::pipeline::context::{BuildConfig, PipelineContext};
+use tempfile::TempDir;
+
+#[test]
+fn identity_key_survives_rename_rebuild() -> Result<(), Box<dyn std::error::Error>> {
+    let fixture = IdentityFixture::new()?;
+    fixture.write_file("a.rs", "pub fn foo() -> u32 {\n    1\n}\n")?;
+    fixture.commit_all("seed rename fixture")?;
+
+    let before = fixture.build(false)?;
+    let before_key = identity_key_for(&before, "foo");
+
+    fixture.rename_file("a.rs", "b.rs")?;
+    let after = fixture.build(true)?;
+    let after_key = identity_key_for(&after, "foo");
+
+    assert_eq!(
+        after_key, before_key,
+        "rename invariant violated: identity_key for foo changed after a.rs was renamed to b.rs"
+    );
+    Ok(())
+}
+
+#[test]
+fn identity_key_survives_move_rebuild() -> Result<(), Box<dyn std::error::Error>> {
+    let fixture = IdentityFixture::new()?;
+    fixture.write_file(
+        "src/a.rs",
+        "pub fn foo() -> u32 {\n    1\n}\n\npub fn bar() -> u32 {\n    2\n}\n",
+    )?;
+    fixture.commit_all("seed move fixture")?;
+
+    let before = fixture.build(false)?;
+    let before_keys = identity_keys_by_name(&before);
+
+    fixture.rename_file("src/a.rs", "src/sub/a.rs")?;
+    let after = fixture.build(true)?;
+    let after_keys = identity_keys_by_name(&after);
+
+    assert_eq!(
+        after_keys, before_keys,
+        "move invariant violated: identity_key values changed after src/a.rs was moved to src/sub/a.rs"
+    );
+    Ok(())
+}
+
+#[test]
+fn identity_key_survives_content_edit_rebuild() -> Result<(), Box<dyn std::error::Error>> {
+    let fixture = IdentityFixture::new()?;
+    fixture.write_file(
+        "a.rs",
+        "pub fn foo() -> u32 {\n    1\n}\n\npub fn bar() -> u32 {\n    2\n}\n",
+    )?;
+    fixture.commit_all("seed content edit fixture")?;
+
+    let before = fixture.build(false)?;
+    let before_keys = identity_keys_by_name(&before);
+
+    fixture.write_file(
+        "a.rs",
+        "pub fn foo() -> u32 {\n    40 + 2\n}\n\npub fn bar() -> u32 {\n    2\n}\n",
+    )?;
+    let after = fixture.build(true)?;
+    let after_keys = identity_keys_by_name(&after);
+
+    assert_eq!(
+        after_keys.get("foo"),
+        before_keys.get("foo"),
+        "content_edit invariant violated: identity_key for foo changed after editing its body without changing its signature"
+    );
+    assert_eq!(
+        after_keys.get("bar"),
+        before_keys.get("bar"),
+        "content_edit invariant violated: identity_key for bar changed when only foo's body was edited"
+    );
+    Ok(())
+}
+
+#[test]
+fn identity_key_survives_delete_recreate_rebuild() -> Result<(), Box<dyn std::error::Error>> {
+    let fixture = IdentityFixture::new()?;
+    let source = "pub fn foo() -> u32 {\n    1\n}\n";
+    fixture.write_file("a.rs", source)?;
+    fixture.commit_all("seed delete recreate fixture")?;
+
+    let before = fixture.build(false)?;
+    let before_key = identity_key_for(&before, "foo");
+
+    fixture.remove_file("a.rs")?;
+    let deleted = fixture.build(true)?;
+    assert!(
+        deleted
+            .graph
+            .leaves
+            .iter()
+            .all(|leaf| leaf.base.name != "foo"),
+        "delete_recreate invariant setup failed: foo still existed after deleting a.rs and rebuilding"
+    );
+
+    fixture.write_file("a.rs", source)?;
+    let after = fixture.build(true)?;
+    let after_key = identity_key_for(&after, "foo");
+
+    assert_eq!(
+        after_key, before_key,
+        "delete_recreate invariant violated: identity_key for foo changed after deleting and recreating a.rs with the same content"
+    );
+    Ok(())
+}
+
+#[test]
+fn identity_key_survives_signature_change_rebuild() -> Result<(), Box<dyn std::error::Error>> {
+    let fixture = IdentityFixture::new()?;
+    fixture.write_file("a.rs", "pub fn foo(x: u32) -> u32 {\n    x + 1\n}\n")?;
+    fixture.commit_all("seed signature change fixture")?;
+
+    let before = fixture.build(false)?;
+    let before_key = identity_key_for(&before, "foo");
+
+    fixture.write_file("a.rs", "pub fn foo(x: u64) -> u64 {\n    x + 1\n}\n")?;
+    let after = fixture.build(true)?;
+    let after_key = identity_key_for(&after, "foo");
+
+    assert_eq!(
+        after_key, before_key,
+        "signature_change current-behavior invariant violated: identity_key for foo changed after changing its Rust function signature"
+    );
+    Ok(())
+}
+
+struct IdentityFixture {
+    repo: TempDir,
+    knowledge: TempDir,
+    ref_name: RefName,
+}
+
+impl IdentityFixture {
+    fn new() -> Result<Self, Box<dyn std::error::Error>> {
+        let repo = TempDir::new()?;
+        git(repo.path(), &["init", "-q", "--initial-branch=main"])?;
+        git(repo.path(), &["config", "user.name", "Orbit Tests"])?;
+        git(
+            repo.path(),
+            &["config", "user.email", "orbit-tests@example.com"],
+        )?;
+        git(repo.path(), &["config", "commit.gpgsign", "false"])?;
+        fs::write(repo.path().join("README.md"), "identity fixture\n")?;
+
+        Ok(Self {
+            repo,
+            knowledge: TempDir::new()?,
+            ref_name: RefName::new("main")?,
+        })
+    }
+
+    fn build(&self, incremental: bool) -> Result<PipelineContext, Box<dyn std::error::Error>> {
+        Ok(pipeline::run_build(BuildConfig {
+            repo_path: self.repo.path().to_path_buf(),
+            output_dir: self.knowledge.path().to_path_buf(),
+            incremental,
+            ref_name: Some(self.ref_name.clone()),
+        })?)
+    }
+
+    fn write_file(&self, rel: &str, content: &str) -> Result<(), Box<dyn std::error::Error>> {
+        let path = self.repo.path().join(rel);
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        fs::write(path, content)?;
+        Ok(())
+    }
+
+    fn rename_file(&self, from: &str, to: &str) -> Result<(), Box<dyn std::error::Error>> {
+        let to_path = self.repo.path().join(to);
+        if let Some(parent) = to_path.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        fs::rename(self.repo.path().join(from), to_path)?;
+        Ok(())
+    }
+
+    fn remove_file(&self, rel: &str) -> Result<(), Box<dyn std::error::Error>> {
+        fs::remove_file(self.repo.path().join(rel))?;
+        Ok(())
+    }
+
+    fn commit_all(&self, message: &str) -> Result<(), Box<dyn std::error::Error>> {
+        git(self.repo.path(), &["add", "-A"])?;
+        git(self.repo.path(), &["commit", "-q", "-m", message])?;
+        Ok(())
+    }
+}
+
+fn identity_key_for(ctx: &PipelineContext, name: &str) -> String {
+    leaf_by_name(ctx, name).base.identity_key.clone()
+}
+
+fn identity_keys_by_name(ctx: &PipelineContext) -> BTreeMap<String, String> {
+    ctx.graph
+        .leaves
+        .iter()
+        .map(|leaf| (leaf.base.name.clone(), leaf.base.identity_key.clone()))
+        .collect()
+}
+
+fn leaf_by_name<'a>(ctx: &'a PipelineContext, name: &str) -> &'a LeafNode {
+    ctx.graph
+        .leaves
+        .iter()
+        .find(|leaf| leaf.base.name == name)
+        .unwrap_or_else(|| {
+            let names = ctx
+                .graph
+                .leaves
+                .iter()
+                .map(|leaf| leaf.base.name.as_str())
+                .collect::<Vec<_>>();
+            panic!("missing leaf `{name}`; graph leaves were {names:?}")
+        })
+}
+
+fn git(repo: &Path, args: &[&str]) -> Result<(), Box<dyn std::error::Error>> {
+    let output = Command::new("git").args(args).current_dir(repo).output()?;
+    if !output.status.success() {
+        return Err(format!(
+            "git {} failed in '{}': {}",
+            args.join(" "),
+            repo.display(),
+            String::from_utf8_lossy(&output.stderr).trim()
+        )
+        .into());
+    }
+    Ok(())
+}

--- a/docs/design/knowledge-graph/2_design.md
+++ b/docs/design/knowledge-graph/2_design.md
@@ -2,7 +2,7 @@
 
 **Status:** Draft
 **Owner:** claude
-**Last updated:** 2026-05-06
+**Last updated:** 2026-05-07
 
 This document specifies the current knowledge graph: storage, build pipeline, query services, Orbit integration, locking, and limitations. The [T20260430-22] cleanup removes duplicated rationale already covered by [1_overview.md](./1_overview.md), [3_vision.md](./3_vision.md), and ADRs.
 
@@ -75,6 +75,20 @@ The graph no longer stores node-level task attribution. The former `attribute_hi
 `knowledge.task_id_pattern` is now a deprecated config key. Existing configs that still set it load successfully and emit a one-line warning to stderr; the value is ignored even when empty or no longer a valid regex.
 
 Forward lookup remains a git convention: commits associated with a local Orbit task include `[T<task-id>]`, and operators can run `git log --grep '[T...]'` in their own workspace. Cross-engineer references use task `external_refs`.
+
+### 2.3 `identity_key` durability invariants
+
+`LeafNode.identity_key` is the durable graph identity consumed by the planned v2 task-to-graph bridge ([T20260507-13]). Its canonical executable reference is [crates/orbit-knowledge/tests/identity_key_durability.rs](../../../crates/orbit-knowledge/tests/identity_key_durability.rs).
+
+The suite locks these rebuild invariants for Rust leaves:
+
+- **Rename** — a uniquely matched leaf keeps its `identity_key` when its containing file is renamed and rebuilt incrementally.
+- **Move** — all uniquely matched leaves keep their `identity_key` values when the containing file moves directories and rebuilds incrementally.
+- **Content edit** — editing a function body without changing the leaf's qualified name or kind keeps both the edited leaf and untouched sibling leaves on their prior `identity_key` values.
+- **Delete + recreate** — deleting a file, rebuilding, then recreating the same path with the same content currently reallocates the same `identity_key`.
+- **Signature change** — changing a Rust function parameter or return type currently keeps the same `identity_key`; Rust function identity is keyed by qualified name and kind, not signature text.
+
+Incremental rebuilds preserve leaf identity from the prior branch ref when a changed file still has matching qualified-name/kind leaves at the same path, or when exactly one deleted prior file with the same source hash provides a relocation match. Ambiguous relocations fall back to freshly derived identity keys rather than risking duplicate node IDs.
 
 ### 2.4 Inclusion vs Access: `.orbitignore` vs Policy
 
@@ -273,5 +287,6 @@ The read cache is per `KnowledgeStore`, not global ([T20260426-0141]). Long-runn
 - **[T20260505-16]** — Add C and header extraction coverage, documented by gpt-5.
 - **[T20260505-5]** — Bound `orbit.graph.pack` selector gathering and skip inline refresh by default, documented by gpt-5.5.
 - **[T20260506-11]** — Remove graph task attribution after 0/961 audited reverse-lookup uses; preserve task IDs as local commit-search keys.
+- **[T20260507-13]** — Lock down `LeafNode.identity_key` rebuild durability invariants for rename, move, content edit, delete/recreate, and signature-change cases.
 
 Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.


### PR DESCRIPTION
## Tasks
- [T20260507-13] Lock down identity_key durability invariants with explicit rebuild-stability tests
  <details><summary>Execution Summary</summary>

## Status
success

## Summary of Changes
- Added `crates/orbit-knowledge/tests/identity_key_durability.rs` with five Rust integration tests for rename, move, content_edit, delete_recreate, and signature_change. Each test runs `pipeline::run_build` multiple times in a temp git repo and asserts `LeafNode.identity_key` values with invariant-specific failure messages.
- Updated incremental leaf extraction to preserve prior leaf IDs and `identity_key` values for same-path edits and for unique same-source file relocations, including child ID rewrites.
- Updated `docs/design/knowledge-graph/2_design.md` with the new identity durability section, canonical test reference, task reference, and `Last updated: 2026-05-07`.

## Overall Assessment
The durability suite locks all five requested cases down. Delete/recreate and signature-change currently preserve `identity_key`; no known-non-invariant behavior was found to document as a v2 bridge planning risk.

## Validation
- `make fmt` exited 0
- `cargo test -p orbit-knowledge` exited 0
- `make build` exited 0

  </details>

## Branch Freshness
- Base ref: `origin/agent-main`
- Head ref: `orbit/T20260507-13-69fc2186`
- Behind base: 0
- Ahead of base: 1

## Files Changed
- `crates/orbit-knowledge/src/pipeline/build.rs`
- `crates/orbit-knowledge/tests/identity_key_durability.rs`
- `docs/design/knowledge-graph/2_design.md`

*authored by: gpt-5.5*