### PR TITLE
Add identity-key benchmark: script + logged results characterizing identity_key durability

### DIFF
--- a/benchmarks/Makefile
+++ b/benchmarks/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help graph-run graph-run-claude graph-run-codex graph-sweep graph-sweep-dry-run graph-sweep-claude graph-sweep-codex graph-aggregate graph-test
+.PHONY: help graph-run graph-run-claude graph-run-codex graph-sweep graph-sweep-dry-run graph-sweep-claude graph-sweep-codex graph-aggregate graph-test identity-key-run
 
 PYTHON ?= python3
 BENCH_ROOT := $(CURDIR)
@@ -29,6 +29,8 @@ GRAPH_SWEEP_ID ?=
 GRAPH_RUN_ARGS ?=
 GRAPH_SWEEP_ARGS ?=
 
+IDENTITY_KEY_SCRIPTS ?= $(BENCH_ROOT)/identity-key/scripts
+
 # Export GRAPH_VERSION so the Python scripts resolve VERSION_ROOT correctly.
 export GRAPH_VERSION
 
@@ -56,6 +58,9 @@ help:
 	@echo ""
 	@echo "  make -C benchmarks graph-test"
 	@echo "    Run benchmark script unit tests (living scripts only)."
+	@echo ""
+	@echo "  make -C benchmarks identity-key-run"
+	@echo "    Rebuild the identity-key v1 scenario records."
 	@echo ""
 	@echo "Versioning:"
 	@echo "  GRAPH_VERSION=v3 (default)  targets benchmarks/graph/v3/ (living)."
@@ -102,3 +107,6 @@ graph-aggregate:
 
 graph-test:
 	$(PYTHON) -m unittest discover -s $(BENCH_ROOT)/graph/scripts -p 'test_*.py'
+
+identity-key-run:
+	$(IDENTITY_KEY_SCRIPTS)/run.sh

--- a/benchmarks/identity-key/README.md
+++ b/benchmarks/identity-key/README.md
@@ -1,0 +1,47 @@
+# Identity-Key Benchmark
+
+Empirical benchmark for `LeafNode.identity_key` durability across rebuilds. The
+harness creates temporary git repositories, runs `orbit_knowledge::pipeline::run_build`
+before and after each mutation, and records what the current source tree does
+without asserting that any scenario should pass.
+
+## Running
+
+```bash
+make -C benchmarks identity-key-run
+```
+
+The command overwrites the v1 run records under
+`benchmarks/identity-key/v1/runs/`.
+
+## Output Layout
+
+```text
+benchmarks/identity-key/
+├── README.md
+├── scripts/
+│   └── run.sh
+└── v1/
+    ├── README.md
+    ├── METHOD.md
+    ├── RESULTS.md
+    └── runs/
+        ├── rename.json
+        ├── move.json
+        ├── content_edit.json
+        ├── delete_recreate.json
+        └── signature_change.json
+```
+
+Each JSON record contains the scenario name, mutation, relevant leaves before
+and after the mutation, a boolean `preserved` observation, and notes.
+
+## Rounds
+
+| Version | Scope | Report |
+|---|---|---|
+| [v1](./v1/) | Rust-only five-scenario baseline | [RESULTS.md](./v1/RESULTS.md) |
+
+## Conventions
+
+Layout and versioning rules: [`../CONVENTIONS.md`](../CONVENTIONS.md).

--- a/benchmarks/identity-key/scripts/run.sh
+++ b/benchmarks/identity-key/scripts/run.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BENCH_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+REPO_ROOT="$(cd "${BENCH_DIR}/../.." && pwd)"
+OUT_DIR="${BENCH_DIR}/v1/runs"
+
+cd "${REPO_ROOT}"
+cargo run -q -p orbit-knowledge --example identity_key_benchmark -- --output "${OUT_DIR}"

--- a/benchmarks/identity-key/v1/METHOD.md
+++ b/benchmarks/identity-key/v1/METHOD.md
@@ -1,0 +1,61 @@
+# Identity-Key Benchmark v1 Method
+
+## Harness Git SHA at Freeze Time
+
+Production baseline: `daa8f9c693eb2413258d9daaa3f9a3787b559bf6`
+(`agent-main` HEAD before T20260508-2 benchmark additions). The harness and v1
+records are authored by T20260508-2 and should be cited by the commit that lands
+this benchmark directory.
+
+## Delta vs v0
+
+v1 is the first round; no prior version exists.
+
+## Fixture List
+
+| Scenario | Purpose |
+|---|---|
+| `rename` | Rename `a.rs` containing `foo` to `b.rs`. |
+| `move` | Move `src/a.rs` containing `foo` and `bar` to `src/sub/a.rs`. |
+| `content_edit` | Edit `foo`'s body while keeping the function name and signature stable. |
+| `delete_recreate` | Delete `a.rs`, rebuild, then recreate the same file contents and rebuild again. |
+| `signature_change` | Change `foo`'s argument and return type from `u32` to `u64`. |
+
+## Scope
+
+The benchmark is Rust-only. Each scenario runs in a fresh temporary git
+repository with an initial commit, then calls
+`orbit_knowledge::pipeline::run_build` directly. The first build uses
+`BuildConfig { incremental: false, ref_name: Some("identity-key-v1") }`; the
+post-mutation build uses the same `repo_path`, `output_dir`, and ref name with
+`incremental: true`.
+
+`delete_recreate` has one additional incremental build between deletion and
+recreation so the graph observes the missing leaf before the file returns.
+
+## Known Caveats
+
+- The records observe `identity_key` and `id` for selected Rust leaves only.
+- The harness commits each mutation in the temporary git repo before the
+  incremental build so git state stays clean and the ref name is stable.
+- Rust function signature details are not part of the current `identity_key`
+  derivation; v1 records the observed result rather than asserting a desired
+  bridge policy.
+- No production source under `crates/orbit-knowledge/src/` is changed by this
+  benchmark.
+
+## Reproduction Command
+
+```bash
+make -C benchmarks identity-key-run
+```
+
+The command overwrites exactly these records:
+
+```text
+benchmarks/identity-key/v1/runs/rename.json
+benchmarks/identity-key/v1/runs/move.json
+benchmarks/identity-key/v1/runs/content_edit.json
+benchmarks/identity-key/v1/runs/delete_recreate.json
+benchmarks/identity-key/v1/runs/signature_change.json
+```

--- a/benchmarks/identity-key/v1/README.md
+++ b/benchmarks/identity-key/v1/README.md
@@ -1,0 +1,8 @@
+# Identity-Key Benchmark v1
+
+Status: baseline round for T20260508-2. This round records the observed
+`identity_key` behavior of `agent-main` before any identity-preservation fixes.
+
+- Method: [`METHOD.md`](./METHOD.md)
+- Results: [`RESULTS.md`](./RESULTS.md)
+- Run records: [`runs/`](./runs/)

--- a/benchmarks/identity-key/v1/RESULTS.md
+++ b/benchmarks/identity-key/v1/RESULTS.md
@@ -1,0 +1,35 @@
+# Identity-Key Benchmark v1 Results
+
+Task T20260508-2, run on May 8, 2026. Scope: Rust-only five-scenario baseline
+against `orbit_knowledge::pipeline::run_build`; records are stored in
+[`runs/`](./runs/).
+
+## Headline
+
+- `identity_key` is preserved when the path, qualified name, and kind stay fixed.
+- Path changes are not preserved: both `rename` and `move` produce new keys and
+  new IDs for the same Rust function names.
+- Source and signature text changes do not change `identity_key` in v1.
+
+## Primary Table
+
+| Scenario | Mutation | identity_key preserved? | Notes |
+|---|---|---|---|
+| rename | `a.rs -> b.rs` | no | Path changed; `identity_key` includes the file location. |
+| move | `src/a.rs -> src/sub/a.rs` | no | Directory changed; `identity_key` includes the file location for both `foo` and `bar`. |
+| content_edit | edit `foo`'s body | yes | Body changed, but path, qualified name, and kind stayed fixed. |
+| delete_recreate | rm + recreate same content | yes | After an intermediate deletion rebuild, recreating the same path/name/kind produced the same key. |
+| signature_change | `u32 -> u64` | yes | Signature text changed, but current key derivation ignores signature/source hash. |
+
+## Synthesis
+
+The v1 "no" rows are `rename` and `move`; those are the direct inputs for
+v2-bridge planning because a task-to-KG bridge cannot assume leaf identity
+survives path changes on current `agent-main`. The `content_edit`,
+`delete_recreate`, and `signature_change` rows preserve identity under today's
+path/name/kind-based derivation.
+
+## Methodology Notes
+
+Reproduce with `make -C benchmarks identity-key-run`. See
+[`METHOD.md`](./METHOD.md) for the exact build config and caveats.

--- a/benchmarks/identity-key/v1/runs/content_edit.json
+++ b/benchmarks/identity-key/v1/runs/content_edit.json
@@ -1,0 +1,34 @@
+{
+  "scenario": "content_edit",
+  "mutation": "edit foo's body",
+  "before": [
+    {
+      "name": "foo",
+      "kind": "function",
+      "identity_key": "symbol:a.rs#foo:function",
+      "id": "symbol:a8b0a03441c7a9f0dbcf50f3662e57bef1bf94d666096dd22e390d1f07f54bae"
+    },
+    {
+      "name": "bar",
+      "kind": "function",
+      "identity_key": "symbol:a.rs#bar:function",
+      "id": "symbol:c3a0da9719465bab75b0b59431f80ab92b73b12080aadd6df7b49641e584700a"
+    }
+  ],
+  "after": [
+    {
+      "name": "foo",
+      "kind": "function",
+      "identity_key": "symbol:a.rs#foo:function",
+      "id": "symbol:a8b0a03441c7a9f0dbcf50f3662e57bef1bf94d666096dd22e390d1f07f54bae"
+    },
+    {
+      "name": "bar",
+      "kind": "function",
+      "identity_key": "symbol:a.rs#bar:function",
+      "id": "symbol:c3a0da9719465bab75b0b59431f80ab92b73b12080aadd6df7b49641e584700a"
+    }
+  ],
+  "preserved": true,
+  "notes": "Function body changed, but path, qualified name, and kind stayed fixed. Observed identity_key/id preservation."
+}

--- a/benchmarks/identity-key/v1/runs/delete_recreate.json
+++ b/benchmarks/identity-key/v1/runs/delete_recreate.json
@@ -1,0 +1,22 @@
+{
+  "scenario": "delete_recreate",
+  "mutation": "rm + recreate same content",
+  "before": [
+    {
+      "name": "foo",
+      "kind": "function",
+      "identity_key": "symbol:a.rs#foo:function",
+      "id": "symbol:a8b0a03441c7a9f0dbcf50f3662e57bef1bf94d666096dd22e390d1f07f54bae"
+    }
+  ],
+  "after": [
+    {
+      "name": "foo",
+      "kind": "function",
+      "identity_key": "symbol:a.rs#foo:function",
+      "id": "symbol:a8b0a03441c7a9f0dbcf50f3662e57bef1bf94d666096dd22e390d1f07f54bae"
+    }
+  ],
+  "preserved": true,
+  "notes": "The intermediate rebuild removed the leaf; recreating the same path/name/kind produced the same key. Observed identity_key/id preservation."
+}

--- a/benchmarks/identity-key/v1/runs/move.json
+++ b/benchmarks/identity-key/v1/runs/move.json
@@ -1,0 +1,34 @@
+{
+  "scenario": "move",
+  "mutation": "src/a.rs -> src/sub/a.rs",
+  "before": [
+    {
+      "name": "foo",
+      "kind": "function",
+      "identity_key": "symbol:src/a.rs#foo:function",
+      "id": "symbol:14e8182e24bdbc0ed0485e6fa5d0eee2020669e1d1ac52f6dd508305c0b824c5"
+    },
+    {
+      "name": "bar",
+      "kind": "function",
+      "identity_key": "symbol:src/a.rs#bar:function",
+      "id": "symbol:74bed775838786e280b8ec7c3651aba5d196f240790664b688bfedfbb18e679e"
+    }
+  ],
+  "after": [
+    {
+      "name": "foo",
+      "kind": "function",
+      "identity_key": "symbol:src/sub/a.rs#foo:function",
+      "id": "symbol:ed22540d22ab7fe3816503f03a4f88f7f1a8af7f56a26e1ad97a2a6b93bd5614"
+    },
+    {
+      "name": "bar",
+      "kind": "function",
+      "identity_key": "symbol:src/sub/a.rs#bar:function",
+      "id": "symbol:2b05b8114c328dd41c4152782c992f12b87742d3580fbc9b46de5a784520529f"
+    }
+  ],
+  "preserved": false,
+  "notes": "Directory changed from src/ to src/sub/; identity_key includes the leaf location. Observed identity_key/id change."
+}

--- a/benchmarks/identity-key/v1/runs/rename.json
+++ b/benchmarks/identity-key/v1/runs/rename.json
@@ -1,0 +1,22 @@
+{
+  "scenario": "rename",
+  "mutation": "a.rs -> b.rs",
+  "before": [
+    {
+      "name": "foo",
+      "kind": "function",
+      "identity_key": "symbol:a.rs#foo:function",
+      "id": "symbol:a8b0a03441c7a9f0dbcf50f3662e57bef1bf94d666096dd22e390d1f07f54bae"
+    }
+  ],
+  "after": [
+    {
+      "name": "foo",
+      "kind": "function",
+      "identity_key": "symbol:b.rs#foo:function",
+      "id": "symbol:331d0f042030de534050cd6c39f3febd1427246371720d73da6a3ce898ac9cf8"
+    }
+  ],
+  "preserved": false,
+  "notes": "Path changed from a.rs to b.rs; identity_key includes the leaf location. Observed identity_key/id change."
+}

--- a/benchmarks/identity-key/v1/runs/signature_change.json
+++ b/benchmarks/identity-key/v1/runs/signature_change.json
@@ -1,0 +1,22 @@
+{
+  "scenario": "signature_change",
+  "mutation": "u32 -> u64",
+  "before": [
+    {
+      "name": "foo",
+      "kind": "function",
+      "identity_key": "symbol:a.rs#foo:function",
+      "id": "symbol:a8b0a03441c7a9f0dbcf50f3662e57bef1bf94d666096dd22e390d1f07f54bae"
+    }
+  ],
+  "after": [
+    {
+      "name": "foo",
+      "kind": "function",
+      "identity_key": "symbol:a.rs#foo:function",
+      "id": "symbol:a8b0a03441c7a9f0dbcf50f3662e57bef1bf94d666096dd22e390d1f07f54bae"
+    }
+  ],
+  "preserved": true,
+  "notes": "Signature text changed, but identity_key is derived from path, qualified name, and kind. Observed identity_key/id preservation."
+}

--- a/crates/orbit-knowledge/examples/identity_key_benchmark.rs
+++ b/crates/orbit-knowledge/examples/identity_key_benchmark.rs
@@ -1,0 +1,342 @@
+use std::env;
+use std::error::Error;
+use std::ffi::OsStr;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use orbit_knowledge::graph::LeafNode;
+use orbit_knowledge::graph::object_store::RefName;
+use orbit_knowledge::pipeline::context::BuildConfig;
+use orbit_knowledge::pipeline::run_build;
+use serde::Serialize;
+use tempfile::TempDir;
+
+type BenchResult<T> = Result<T, Box<dyn Error>>;
+
+const REF_NAME: &str = "identity-key-v1";
+const SIMPLE_SOURCE: &str = "pub fn foo() -> u32 {\n    1\n}\n";
+const TWO_FUNCTION_SOURCE: &str =
+    "pub fn foo() -> u32 {\n    1\n}\n\npub fn bar() -> u32 {\n    2\n}\n";
+
+#[derive(Debug, Serialize)]
+struct RunRecord {
+    scenario: &'static str,
+    mutation: &'static str,
+    before: Vec<LeafRecord>,
+    after: Vec<LeafRecord>,
+    preserved: bool,
+    notes: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct LeafRecord {
+    name: String,
+    kind: String,
+    identity_key: String,
+    id: String,
+}
+
+struct ScenarioRepo {
+    _tempdir: TempDir,
+    repo_path: PathBuf,
+    knowledge_dir: PathBuf,
+    ref_name: RefName,
+}
+
+impl ScenarioRepo {
+    fn new(initial_files: &[(&str, &str)]) -> BenchResult<Self> {
+        let tempdir = TempDir::new()?;
+        let repo_path = tempdir.path().join("repo");
+        let knowledge_dir = tempdir.path().join("knowledge");
+        fs::create_dir_all(&repo_path)?;
+
+        run_git(&repo_path, ["init", "-b", "main"])?;
+        run_git(&repo_path, ["config", "user.name", "Orbit Benchmark"])?;
+        run_git(
+            &repo_path,
+            ["config", "user.email", "orbit-benchmark@example.invalid"],
+        )?;
+
+        let repo = Self {
+            _tempdir: tempdir,
+            repo_path,
+            knowledge_dir,
+            ref_name: RefName::new(REF_NAME)?,
+        };
+
+        for (rel_path, content) in initial_files {
+            repo.write_file(rel_path, content)?;
+        }
+        repo.commit_all("initial fixture")?;
+
+        Ok(repo)
+    }
+
+    fn build(&self, incremental: bool, relevant_names: &[&str]) -> BenchResult<Vec<LeafRecord>> {
+        let ctx = run_build(BuildConfig {
+            repo_path: self.repo_path.clone(),
+            output_dir: self.knowledge_dir.clone(),
+            incremental,
+            ref_name: Some(self.ref_name.clone()),
+        })?;
+
+        select_leaf_records(&ctx.graph.leaves, relevant_names)
+    }
+
+    fn write_file(&self, rel_path: &str, content: &str) -> BenchResult<()> {
+        let path = self.repo_path.join(rel_path);
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        fs::write(path, content)?;
+        Ok(())
+    }
+
+    fn rename_file(&self, from: &str, to: &str) -> BenchResult<()> {
+        let to_path = self.repo_path.join(to);
+        if let Some(parent) = to_path.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        fs::rename(self.repo_path.join(from), to_path)?;
+        Ok(())
+    }
+
+    fn remove_file(&self, rel_path: &str) -> BenchResult<()> {
+        fs::remove_file(self.repo_path.join(rel_path))?;
+        Ok(())
+    }
+
+    fn commit_all(&self, message: &str) -> BenchResult<()> {
+        run_git(&self.repo_path, ["add", "-A"])?;
+        run_git(&self.repo_path, ["commit", "-m", message])?;
+        Ok(())
+    }
+}
+
+fn main() {
+    if let Err(error) = run() {
+        eprintln!("identity-key benchmark failed: {error}");
+        std::process::exit(1);
+    }
+}
+
+fn run() -> BenchResult<()> {
+    let output_dir = parse_output_dir()?;
+    fs::create_dir_all(&output_dir)?;
+    remove_stale_records(&output_dir)?;
+
+    let records = vec![
+        run_rename()?,
+        run_move()?,
+        run_content_edit()?,
+        run_delete_recreate()?,
+        run_signature_change()?,
+    ];
+
+    for record in records {
+        let path = output_dir.join(format!("{}.json", record.scenario));
+        let json = serde_json::to_string_pretty(&record)?;
+        fs::write(path, format!("{json}\n"))?;
+    }
+
+    Ok(())
+}
+
+fn parse_output_dir() -> BenchResult<PathBuf> {
+    let mut args = env::args_os().skip(1);
+    let mut output_dir = None;
+    while let Some(arg) = args.next() {
+        if arg == "--output" {
+            let value = args.next().ok_or("--output requires a path")?;
+            output_dir = Some(PathBuf::from(value));
+        } else {
+            return Err(format!("unknown argument: {}", arg.to_string_lossy()).into());
+        }
+    }
+
+    output_dir.ok_or_else(|| "--output is required".into())
+}
+
+fn remove_stale_records(output_dir: &Path) -> BenchResult<()> {
+    for entry in fs::read_dir(output_dir)? {
+        let entry = entry?;
+        let path = entry.path();
+        if path.extension() == Some(OsStr::new("json")) {
+            fs::remove_file(path)?;
+        }
+    }
+    Ok(())
+}
+
+fn run_rename() -> BenchResult<RunRecord> {
+    let repo = ScenarioRepo::new(&[("a.rs", SIMPLE_SOURCE)])?;
+    let before = repo.build(false, &["foo"])?;
+
+    repo.rename_file("a.rs", "b.rs")?;
+    repo.commit_all("rename a.rs to b.rs")?;
+    let after = repo.build(true, &["foo"])?;
+
+    Ok(record(
+        "rename",
+        "a.rs -> b.rs",
+        before,
+        after,
+        "Path changed from a.rs to b.rs; identity_key includes the leaf location.",
+    ))
+}
+
+fn run_move() -> BenchResult<RunRecord> {
+    let repo = ScenarioRepo::new(&[("src/a.rs", TWO_FUNCTION_SOURCE)])?;
+    let before = repo.build(false, &["foo", "bar"])?;
+
+    repo.rename_file("src/a.rs", "src/sub/a.rs")?;
+    repo.commit_all("move src/a.rs to src/sub/a.rs")?;
+    let after = repo.build(true, &["foo", "bar"])?;
+
+    Ok(record(
+        "move",
+        "src/a.rs -> src/sub/a.rs",
+        before,
+        after,
+        "Directory changed from src/ to src/sub/; identity_key includes the leaf location.",
+    ))
+}
+
+fn run_content_edit() -> BenchResult<RunRecord> {
+    let repo = ScenarioRepo::new(&[("a.rs", TWO_FUNCTION_SOURCE)])?;
+    let before = repo.build(false, &["foo", "bar"])?;
+
+    repo.write_file(
+        "a.rs",
+        "pub fn foo() -> u32 {\n    42\n}\n\npub fn bar() -> u32 {\n    2\n}\n",
+    )?;
+    repo.commit_all("edit foo body")?;
+    let after = repo.build(true, &["foo", "bar"])?;
+
+    Ok(record(
+        "content_edit",
+        "edit foo's body",
+        before,
+        after,
+        "Function body changed, but path, qualified name, and kind stayed fixed.",
+    ))
+}
+
+fn run_delete_recreate() -> BenchResult<RunRecord> {
+    let repo = ScenarioRepo::new(&[("a.rs", SIMPLE_SOURCE)])?;
+    let before = repo.build(false, &["foo"])?;
+
+    repo.remove_file("a.rs")?;
+    repo.commit_all("delete a.rs")?;
+    let _deleted = repo.build(true, &[])?;
+
+    repo.write_file("a.rs", SIMPLE_SOURCE)?;
+    repo.commit_all("recreate a.rs")?;
+    let after = repo.build(true, &["foo"])?;
+
+    Ok(record(
+        "delete_recreate",
+        "rm + recreate same content",
+        before,
+        after,
+        "The intermediate rebuild removed the leaf; recreating the same path/name/kind produced the same key.",
+    ))
+}
+
+fn run_signature_change() -> BenchResult<RunRecord> {
+    let repo = ScenarioRepo::new(&[("a.rs", "pub fn foo(x: u32) -> u32 {\n    x\n}\n")])?;
+    let before = repo.build(false, &["foo"])?;
+
+    repo.write_file("a.rs", "pub fn foo(x: u64) -> u64 {\n    x\n}\n")?;
+    repo.commit_all("change foo signature")?;
+    let after = repo.build(true, &["foo"])?;
+
+    Ok(record(
+        "signature_change",
+        "u32 -> u64",
+        before,
+        after,
+        "Signature text changed, but identity_key is derived from path, qualified name, and kind.",
+    ))
+}
+
+fn record(
+    scenario: &'static str,
+    mutation: &'static str,
+    before: Vec<LeafRecord>,
+    after: Vec<LeafRecord>,
+    note: &str,
+) -> RunRecord {
+    let preserved = identity_keys_preserved(&before, &after);
+    let outcome = if preserved {
+        "Observed identity_key/id preservation."
+    } else {
+        "Observed identity_key/id change."
+    };
+    RunRecord {
+        scenario,
+        mutation,
+        before,
+        after,
+        preserved,
+        notes: format!("{note} {outcome}"),
+    }
+}
+
+fn select_leaf_records(
+    leaves: &[LeafNode],
+    relevant_names: &[&str],
+) -> BenchResult<Vec<LeafRecord>> {
+    relevant_names
+        .iter()
+        .map(|name| {
+            let leaf = leaves
+                .iter()
+                .find(|leaf| leaf.base.name == *name)
+                .ok_or_else(|| format!("missing leaf `{name}`"))?;
+            Ok(LeafRecord {
+                name: leaf.base.name.clone(),
+                kind: leaf.kind.to_string(),
+                identity_key: leaf.base.identity_key.clone(),
+                id: leaf.base.id.clone(),
+            })
+        })
+        .collect()
+}
+
+fn identity_keys_preserved(before: &[LeafRecord], after: &[LeafRecord]) -> bool {
+    before.len() == after.len()
+        && before.iter().zip(after).all(|(left, right)| {
+            left.name == right.name
+                && left.kind == right.kind
+                && left.identity_key == right.identity_key
+                && left.id == right.id
+        })
+}
+
+fn run_git<I, S>(repo_path: &Path, args: I) -> BenchResult<()>
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<OsStr>,
+{
+    let output = Command::new("git")
+        .args(args)
+        .current_dir(repo_path)
+        .output()?;
+
+    if output.status.success() {
+        return Ok(());
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    Err(format!(
+        "git command failed in {}: status={} stdout={} stderr={}",
+        repo_path.display(),
+        output.status,
+        stdout.trim(),
+        stderr.trim()
+    )
+    .into())
+}


### PR DESCRIPTION
## Tasks
- [T20260508-2] Add identity-key benchmark: script + logged results characterizing identity_key durability
  <details><summary>Execution Summary</summary>

## Status
success

## Summary of Changes
Added benchmarks/identity-key with shared README/scripts, v1 docs, and exactly five JSON run records. Added an orbit-knowledge example harness outside src/ that creates temp git repos, runs pipeline::run_build before/after each scenario, and records observed identity_key/id preservation. Wired make -C benchmarks identity-key-run.

## Overall Assessment
The benchmark records current agent-main behavior without production identity_key changes. Observed no rows are rename and move; content edit, delete+recreate same path, and signature change preserve identity_key under current derivation.

## Validation
- make -C benchmarks identity-key-run
- make fmt
- make build
- cargo test -p orbit-knowledge
- git diff -- crates/orbit-knowledge/src/
- git diff agent-main..HEAD -- crates/orbit-knowledge/src/

  </details>

## Branch Freshness
- Base ref: `origin/agent-main`
- Head ref: `orbit/T20260508-2-69fd3df0`
- Behind base: 0
- Ahead of base: 1

## Files Changed
- `benchmarks/Makefile`
- `benchmarks/identity-key/README.md`
- `benchmarks/identity-key/scripts/run.sh`
- `benchmarks/identity-key/v1/METHOD.md`
- `benchmarks/identity-key/v1/README.md`
- `benchmarks/identity-key/v1/RESULTS.md`
- `benchmarks/identity-key/v1/runs/content_edit.json`
- `benchmarks/identity-key/v1/runs/delete_recreate.json`
- `benchmarks/identity-key/v1/runs/move.json`
- `benchmarks/identity-key/v1/runs/rename.json`
- `benchmarks/identity-key/v1/runs/signature_change.json`
- `crates/orbit-knowledge/examples/identity_key_benchmark.rs`

*authored by: claude-opus-4-7*