### PR TITLE
task_gate_pipeline lock TTL can expire before child implementation timeout

### DIFF
--- a/crates/orbit-core/assets/jobs/task_gate_pipeline.yaml
+++ b/crates/orbit-core/assets/jobs/task_gate_pipeline.yaml
@@ -18,12 +18,16 @@
 #   budget is enforced by `input.max_wait_seconds`, which the
 #   `starvation_check` step surfaces via the `gate.starvation` audit
 #   event when the loop exits without a reservation.
+# - The default reservation TTL intentionally covers the child dispatch wait
+#   budget. Keep `ttl_seconds >= dispatch_timeout_seconds` when overriding
+#   these inputs; otherwise a second gate can reserve the same context before
+#   the first child pipeline finishes.
 # - The dispatched child pipeline runs while the reservation is still valid;
 #   a fresh `orbit.task.locks.reserve` call from another bundle will either
 #   wait or surface `task.locks.reserve.denied`. After `invoke_and_wait`
 #   returns a terminal child-run status, `release_reservation` frees the
 #   reservation immediately. TTL remains the fallback for abandoned/crashed
-#   runs or wait-side timeouts where the child may still be running.
+#   runs.
 
 schemaVersion: 2
 kind: Job
@@ -40,7 +44,7 @@ spec:
     base_sync: remote
     max_wait_seconds: 3600
     poll_interval_seconds: 30
-    ttl_seconds: 1800
+    ttl_seconds: 7200
     dispatch_timeout_seconds: 7200
 
   steps:

--- a/crates/orbit-core/src/command/job/catalog.rs
+++ b/crates/orbit-core/src/command/job/catalog.rs
@@ -547,6 +547,31 @@ spec:
     }
 
     #[test]
+    fn gate_pipeline_default_reservation_ttl_covers_child_wait_budget() {
+        let yaml = DEFAULT_JOB_FILES
+            .iter()
+            .find_map(|(name, yaml)| (*name == "task_gate_pipeline").then_some(*yaml))
+            .expect("task gate pipeline default exists");
+        let asset = load_job_asset(yaml).expect("parse task gate pipeline");
+        let default_input = asset
+            .spec
+            .default_input
+            .as_ref()
+            .expect("task gate pipeline default input");
+        let ttl_seconds = default_input["ttl_seconds"]
+            .as_u64()
+            .expect("numeric ttl_seconds");
+        let dispatch_timeout_seconds = default_input["dispatch_timeout_seconds"]
+            .as_u64()
+            .expect("numeric dispatch_timeout_seconds");
+
+        assert!(
+            ttl_seconds >= dispatch_timeout_seconds,
+            "reservation TTL must cover the child dispatch wait budget"
+        );
+    }
+
+    #[test]
     fn default_jobs_do_not_template_agent_loop_outputs() {
         let agent_activity_names = DEFAULT_ACTIVITY_FILES
             .iter()

--- a/docs/design/activity-job/2_design.md
+++ b/docs/design/activity-job/2_design.md
@@ -2,7 +2,7 @@
 
 **Status:** Draft
 **Owner:** codex
-**Last updated:** 2026-05-08 (T20260508-3)
+**Last updated:** 2026-05-08 (T20260427-36, T20260508-3)
 
 This document describes the shipped Activity / Job substrate across `orbit-common`, `orbit-engine`, `orbit-core`, and `orbit-cli`: asset shape, normalization, dispatch boundaries, backend semantics, DAG execution, audit, and retained legacy edges. See [1_overview.md](./1_overview.md) for purpose and [3_vision.md](./3_vision.md) for open questions.
 
@@ -127,7 +127,7 @@ Seeded direct shipment workflows (`task_local_pipeline` and `task_pr_pipeline`) 
 
 The seeded `list_backlog_tasks` deterministic activity starts `task_auto_pipeline`. Automatic mode admits tasks by `status: backlog`, including accepted friction reports whose `type` remains `friction`, while untriaged `status: friction` reports stay out. It emits `task_count`, `task_ids`, `tasks`, singleton `bundles`, and an `excluded` array for admitted backlog tasks filtered because their context files overlap `in-progress` or `review` locks. `excluded` covers only lock overlap; status-based admission and `max_tasks` truncation stay silent, and explicit `task_ids` mode omits it. This attribution contract was added in [T20260421-0542-2] and the friction admission rule was updated in [T20260505-2].
 
-`task_gate_pipeline` reserves a bundle's context files before it dispatches `task_pr_pipeline` or `task_local_pipeline` through `invoke_and_wait`. The reservation owner is the gate run that executed `reserve_locks`, not the child shipment run. Owned reservations are engine-cleaned when that owner run reaches a terminal state (`success`, `failed`, `cancelled`, or `timeout`), so correctness does not depend on every workspace override preserving a YAML release step. The seeded deterministic `release_locks` activity still calls `orbit.task.locks.release` after a terminal child wait as an early-release optimization; idempotent terminal cleanup then finds nothing left to release. Unowned/manual reservations remain explicit-release-or-TTL only. TTL is the fallback for abandoned/manual reservations or cases where no terminal cleanup or reserve-pressure reconciliation trigger runs. This lifecycle was tightened in [T20260430-26] and made engine-owned in [T20260505-10].
+`task_gate_pipeline` reserves a bundle's context files before it dispatches `task_pr_pipeline` or `task_local_pipeline` through `invoke_and_wait`. The reservation owner is the gate run that executed `reserve_locks`, not the child shipment run. Seeded defaults keep `ttl_seconds` aligned with `dispatch_timeout_seconds` at 7200 seconds, so the admission reservation covers the full child wait budget; workspace overrides must preserve `ttl_seconds >= dispatch_timeout_seconds` [T20260427-36]. Owned reservations are engine-cleaned when that owner run reaches a terminal state (`success`, `failed`, `cancelled`, or `timeout`), so correctness does not depend on every workspace override preserving a YAML release step. The seeded deterministic `release_locks` activity still calls `orbit.task.locks.release` after a terminal child wait as an early-release optimization; idempotent terminal cleanup then finds nothing left to release. Unowned/manual reservations remain explicit-release-or-TTL only. TTL is the fallback for abandoned/manual reservations or cases where no terminal cleanup or reserve-pressure reconciliation trigger runs. This lifecycle was tightened in [T20260430-26] and made engine-owned in [T20260505-10].
 
 Reserve conflict checking also performs bounded, opportunistic stale-owned-reservation reconciliation before reporting reservation conflicts. It inspects only overlapping owned reservations under current reserve pressure; it is not a background sweeper. Existing job-run list/show reconciliation remains in place, and both paths release run-owned reservations with `release_reason: stale_run_reconciled` when they prove the owner is already terminal or stale. Release audit rows use the task-lock audit surface and include `reservation_id`, `owner_run_id` when present, and `release_reason` (`explicit`, `run_terminal`, `stale_run_reconciled`, or TTL expiration).
 
@@ -462,6 +462,7 @@ Read-only history does not need the same dependencies as live execution. [T20260
 - **[T20260426-0742]** — Remove duplicate job-level run inspection aliases and keep run inspection under `orbit run`.
 - **[T20260426-2313]** — Stream CLI subprocess stdout/stderr through structured tracing events while retaining the existing audit/blob path.
 - **[T20260426-2349]** — Move CLI tracing output redaction from `cli_runner` call sites into the default tracing formatter layer.
+- **[T20260427-36]** — Align task-gate reservation TTL with the child dispatch wait budget.
 - **[T20260427-45]** — Use freshly fetched remote base refs for default task-shipping worktrees.
 - **[T20260427-48]** — Thread provider config into the v2 CLI backend and keep Codex dynamic flags exec-compatible.
 - **[T20260427-51]** — Wrap cli-backend agent invocations in `sandbox-exec` on macOS.

--- a/docs/design/activity-job/4_decisions.md
+++ b/docs/design/activity-job/4_decisions.md
@@ -2,7 +2,7 @@
 
 **Status:** Draft
 **Owner:** codex
-**Last updated:** 2026-05-08 (T20260508-3)
+**Last updated:** 2026-05-08 (T20260427-36, T20260508-3)
 
 This ADR log records the decisions that define the current Activity / Job substrate. Entries are append-only and stay in place when later ADRs supersede or fold them. See [1_overview.md](./1_overview.md) for the feature summary, [2_design.md](./2_design.md) for the current implementation, and [3_vision.md](./3_vision.md) for the questions that may force more decisions.
 
@@ -241,11 +241,11 @@ Folded into ADR-007's rollup for durable run state and operator inspection.
 
 ## ADR-023 — Seeded task-shipment workflows are deterministic, recoverable, and lock-aware
 
-**Status:** Accepted · 2026-05 · [T20260427-33], [T20260425-2010], [T20260427-45], [T20260430-9], [T20260430-12], [T20260430-14], [T20260421-0542-2], [T20260430-27], [T20260430-30], [T20260430-26], [T20260505-2], [T20260505-10], [T20260506-18]
+**Status:** Accepted · 2026-05 · [T20260427-33], [T20260425-2010], [T20260427-45], [T20260430-9], [T20260430-12], [T20260430-14], [T20260421-0542-2], [T20260430-27], [T20260430-30], [T20260430-26], [T20260427-36], [T20260505-2], [T20260505-10], [T20260506-18]
 
 **Context.** The seeded task workflows added many small ADRs as shipment behavior grew: run aliases, deterministic auto-dispatch, remote base selection, recovery hooks, backlog exclusions, operator status, friction admission, and lock cleanup. They are one decision family: task shipment is an explicit durable workflow, not an advisory agent step or hidden side effect.
 
-**Decision.** Keep `orbit run` workflow aliases focused on execution, make automatic task shipment deterministic from backlog listing through gate fan-out, default shipping worktrees to fetched remote base refs, admit tasks through status-aware workflow gates, and protect overlapping work with durable task-lock reservations. Recovery is bounded and step-scoped on direct shipment workflows, operator status is derived from persisted pipeline state, accepted friction reports enter auto-backlog by `status: backlog`, and run-owned reservations clean up when their owner run reaches a terminal state.
+**Decision.** Keep `orbit run` workflow aliases focused on execution, make automatic task shipment deterministic from backlog listing through gate fan-out, default shipping worktrees to fetched remote base refs, admit tasks through status-aware workflow gates, and protect overlapping work with durable task-lock reservations whose seeded TTL covers the child wait budget. Recovery is bounded and step-scoped on direct shipment workflows, operator status is derived from persisted pipeline state, accepted friction reports enter auto-backlog by `status: backlog`, and run-owned reservations clean up when their owner run reaches a terminal state.
 
 Folded instances:
 
@@ -266,6 +266,7 @@ Folded instances:
 - Task shipment workflows expose durable admission, recovery, status, and lock state without asking downstream steps to parse model output.
 - Auto-dispatch no longer depends on provider credentials before it has deterministic backlog bundles.
 - Gate-owned reservations serialize overlapping bundles while their owner run is alive and are released by both seeded early-release steps and engine-owned terminal cleanup.
+- Seeded gate defaults require `ttl_seconds >= dispatch_timeout_seconds` so a legal child shipment wait cannot outlive its admission reservation.
 - Costs retained from folded entries:
 - Cost: the auto-dispatch audit trail no longer contains a model-authored advisory grouping note.
 - Cost: users of `orbit run ship local`, `orbit run ship list/show`, and `orbit run duel list/show` must update their command muscle memory and scripts.
@@ -276,6 +277,7 @@ Folded instances:
 - Cost: the Rust serializer and seeded activity YAML schema now duplicate the exclusion shape and must be kept in sync.
 - Cost: the CLI formatter now knows selected fields from `task_auto_pipeline` state, so future pipeline key renames must either preserve compatibility or update the operator summary parser.
 - Cost: `task_gate_pipeline` now relies on the dynamic `task_{{ input.mode }}_pipeline` job-name convention, so future gate modes must either follow that naming convention or refactor the dispatch selector.
+- Cost: longer default gate reservations can block overlapping work for up to two hours if both explicit release and run-owned cleanup fail.
 - Cost: reviewers must read friction eligibility as a status rule, not a task-type rule.
 - Cost: job-run finalization and reservation reserve paths are more coupled, so new terminal run paths must route through the cleanup helper rather than writing directly to the job-run store.
 
@@ -428,6 +430,7 @@ Folded into ADR-002's rollup for explicit agent dispatch boundaries.
 - **[T20260426-2313]** — Stream CLI subprocess stdout/stderr through structured tracing events while retaining the existing audit/blob path.
 - **[T20260426-2349]** — Move CLI tracing output redaction from `cli_runner` call sites into the default tracing formatter layer.
 - **[T20260427-33]** — Remove the audit-only `dispatch_agent` step from `task_auto_pipeline`.
+- **[T20260427-36]** — Align task-gate reservation TTL with the child dispatch wait budget.
 - **[T20260427-45]** — Use freshly fetched remote base refs for default task-shipping worktrees.
 - **[T20260427-48]** — Thread provider config into the v2 CLI backend and keep Codex dynamic flags exec-compatible.
 - **[T20260428-8]** — Add workflow-specific task admission for task-starting workflows.


### PR DESCRIPTION
## Task

[T20260427-36](T20260427-36) — task_gate_pipeline lock TTL can expire before child implementation timeout

### Description

While tracing `orbit run ship-auto`, I found `task_gate_pipeline` reserves task locks with default `ttl_seconds: 1800` but then dispatches child PR/local pipelines with `dispatch_timeout_seconds: 7200`; the `agent_implement` activity itself has `wall_clock_timeout_seconds: 5400`. The job comments say the child pipeline runs while the reservation is still valid, but the defaults allow the reservation to expire 30 minutes into a child run that may legally continue for 90-120 minutes. After expiry, another gate reservation can admit overlapping work while the original task is still being implemented. Consider aligning TTL with dispatch timeout, refreshing/releasing reservations around the child run, or relying on in-progress task locks with explicit conflict semantics instead of an expiring reservation only.

### Acceptance Criteria



## Execution Summary

<details>
<summary>Click to expand</summary>

## Status
success

## Summary of Changes
- Updated seeded `task_gate_pipeline` so default `ttl_seconds` is 7200, matching the 7200-second child dispatch wait budget instead of expiring at 1800 seconds.
- Added a focused catalog test asserting the gate reservation TTL covers the child dispatch timeout.
- Updated Activity / Job design docs and ADR-023 with the `T20260427-36` contract and tradeoff.

## Overall Assessment
The seeded gate no longer allows its default reservation TTL to expire before a legal child shipment wait completes. Workspace overrides are now documented to preserve `ttl_seconds >= dispatch_timeout_seconds`.

## Validation
- `make fmt`
- `cargo test -p orbit-core gate_pipeline_default_reservation_ttl_covers_child_wait_budget`
- `make build`

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/T20260427-36-69fd5370`
- Behind base: 0
- Ahead of base: 1

*authored by: gpt-5.5*