### PR TITLE
task_epic_pipeline cannot converge after normal PR/local shipment leaves subtasks in review

### DIFF
--- a/crates/orbit-core/assets/activities/epic_orchestrator.yaml
+++ b/crates/orbit-core/assets/activities/epic_orchestrator.yaml
@@ -38,18 +38,20 @@ spec:
 
     # Objective
 
-    Drive every subtask to a terminal state (`done`, `blocked`, or
-    `failed`). Use judgment on dependency ordering and on when to run
-    subtasks in parallel vs sequentially.
+    Drive every subtask to a state where automated shipment should stop:
+    shipped to `review`, already `done`, or unable to proceed
+    (`blocked`/`rejected`). Use judgment on dependency ordering and on
+    when to run subtasks in parallel vs sequentially.
 
     # Per-cycle procedure
 
     1. **Read state.** Use the `subtasks` input as the current
-       deterministic snapshot. It contains the non-terminal subtasks
-       after the workflow's latest `load_epic` refresh.
+       deterministic snapshot. It contains the subtasks still needing
+       automated shipment after the workflow's latest `load_epic`
+       refresh.
 
     2. **Decide READY subtasks.** A subtask is READY iff:
-       - its current task status is not terminal;
+       - its current task status still needs automated shipment;
        - its dependencies (inferred from descriptions) are all `done`;
        - it is not already represented by a child run you dispatched in
          this cycle.
@@ -73,7 +75,9 @@ spec:
 
     5. **Wait.** Call `orbit.pipeline.wait` with the dispatched
        `run_ids`. On terminal responses:
-       - `status: succeeded` → mark subtask `state: "done"`.
+       - `status: succeeded` → mark subtask `state: "done"` or
+         `state: "shipped"` in audit notes; the deterministic refresh
+         treats review as the shipped stop state.
        - `status: failed` or `cancelled` or `timeout` → increment
          note the failed run IDs and leave retry/blocking decisions for
          the next cycle's deterministic task snapshot.

--- a/crates/orbit-core/assets/activities/load_epic.yaml
+++ b/crates/orbit-core/assets/activities/load_epic.yaml
@@ -6,11 +6,13 @@ spec:
   type: deterministic
   description: >
     Materialize the working set for `epic_orchestrator`: the epic task
-    itself plus all non-terminal subtasks (reverse-parent lookup).
-    Filters out Done / Archived — the orchestrator only needs to drive
-    the open subset. The orchestrator reasons over task descriptions
-    for dependency ordering, so titles and full descriptions ship in
-    the payload.
+    itself plus all subtasks that still need automated shipment
+    (reverse-parent lookup). Filters out Done / Review / Blocked /
+    Archived / Rejected — the orchestrator only needs to drive the open
+    subset, and Review is the shipped human-handoff state for normal
+    PR/local child pipelines. The orchestrator reasons over task
+    descriptions for dependency ordering, so titles and full
+    descriptions ship in the payload.
   input_schema_json:
     type: object
     required: [epic_task_id]

--- a/crates/orbit-core/assets/activities/summarize_epic.yaml
+++ b/crates/orbit-core/assets/activities/summarize_epic.yaml
@@ -6,10 +6,11 @@ spec:
   type: deterministic
   description: >
     Fold the orchestrator's final `state` snapshot into an audit-grade
-    summary (counts + unfinished ids + one-line status message). Pure
-    aggregation — no I/O, no side effects. The workflow obtains `state`
-    from deterministic task refresh output, not from the orchestrator's
-    final response.
+    summary (counts + unfinished ids + one-line status message). The
+    `done` count is the epic-complete bucket, including review-shipped
+    subtasks from `load_epic`. Pure aggregation — no I/O, no side
+    effects. The workflow obtains `state` from deterministic task
+    refresh output, not from the orchestrator's final response.
   input_schema_json:
     type: object
     required: [state]

--- a/crates/orbit-core/assets/jobs/task_epic_pipeline.yaml
+++ b/crates/orbit-core/assets/jobs/task_epic_pipeline.yaml
@@ -17,6 +17,8 @@
 #   reference its own prior reasoning.
 # - `break_when: "{{ steps.refresh_epic.output.all_terminal }} == true"`
 #   keys off deterministic task state, not the agent's final response.
+#   `review` counts as terminal for this pipeline because the normal
+#   PR/local child workflows stop at that human handoff state.
 # - `max_iterations: 20` is the structural ceiling on cycles — a
 #   literal because `LoopBlock.max_iterations` is `u32` (not templated).
 #   Callers who need a different ceiling must fork this YAML.

--- a/crates/orbit-core/src/runtime/v2_host/backlog_exclusion.rs
+++ b/crates/orbit-core/src/runtime/v2_host/backlog_exclusion.rs
@@ -53,15 +53,21 @@ fn active_task_lock_holders<'a>(
 fn is_epic_terminal_status(status: TaskStatus) -> bool {
     matches!(
         status,
-        TaskStatus::Done | TaskStatus::Blocked | TaskStatus::Archived | TaskStatus::Rejected
+        TaskStatus::Done
+            | TaskStatus::Blocked
+            | TaskStatus::Archived
+            | TaskStatus::Rejected
+            | TaskStatus::Review
     )
 }
 
 fn epic_state_for_task_status(status: TaskStatus) -> &'static str {
     match status {
-        TaskStatus::Done | TaskStatus::Archived => "done",
+        // For epic orchestration, `review` means a child shipment workflow
+        // reached the human handoff point and should not be dispatched again.
+        TaskStatus::Done | TaskStatus::Archived | TaskStatus::Review => "done",
         TaskStatus::Blocked | TaskStatus::Rejected => "blocked",
-        TaskStatus::InProgress | TaskStatus::Review => "in_flight",
+        TaskStatus::InProgress => "in_flight",
         TaskStatus::Proposed | TaskStatus::Friction | TaskStatus::Backlog | TaskStatus::Someday => {
             "pending"
         }
@@ -305,7 +311,6 @@ pub(super) fn load_epic(
         .collect::<Vec<_>>();
     let subtask_payload: Vec<Value> = open_subtasks
         .iter()
-        .filter(|t| !matches!(t.status, TaskStatus::Done | TaskStatus::Archived))
         .map(|t| {
             serde_json::json!({
                 "id": t.id,
@@ -374,7 +379,7 @@ pub(super) fn summarize_epic(input: &Value) -> Result<Value, DispatchError> {
     let message = if total == 0 {
         "epic had no subtasks".to_string()
     } else if unfinished_ids.is_empty() {
-        format!("all {total} subtasks done")
+        format!("all {total} subtasks complete")
     } else {
         format!(
             "{done}/{total} done; {failed} failed, {blocked} blocked, \

--- a/crates/orbit-core/src/runtime/v2_host/backlog_exclusion_tests.rs
+++ b/crates/orbit-core/src/runtime/v2_host/backlog_exclusion_tests.rs
@@ -20,6 +20,17 @@ fn list_backlog_tasks(runtime: &OrbitRuntime, input: Value) -> Value {
         .expect("list backlog tasks")
 }
 
+fn load_epic(runtime: &OrbitRuntime, epic_task_id: &str) -> Value {
+    runtime
+        .run_deterministic(
+            "load_epic",
+            &json!({}),
+            &json!({ "epic_task_id": epic_task_id }),
+            ToolContext::default(),
+        )
+        .expect("load epic")
+}
+
 fn excluded_entry<'a>(output: &'a Value, task_id: &str) -> &'a Value {
     output["excluded"]
         .as_array()
@@ -27,6 +38,104 @@ fn excluded_entry<'a>(output: &'a Value, task_id: &str) -> &'a Value {
         .iter()
         .find(|entry| entry["id"] == task_id)
         .expect("excluded entry")
+}
+
+#[test]
+fn load_epic_treats_review_subtasks_as_shipped_terminal_state() {
+    let (_root, runtime, _repo_root) = runtime_with_workspace_layout();
+    let epic = seed_list_backlog_task(
+        &runtime,
+        "Epic",
+        TaskStatus::InProgress,
+        TaskPriority::High,
+        TaskType::Epic,
+        None,
+        vec![],
+    );
+    let review = seed_list_backlog_task(
+        &runtime,
+        "Review child",
+        TaskStatus::Review,
+        TaskPriority::High,
+        TaskType::Task,
+        Some(epic.id.clone()),
+        vec![],
+    );
+    let done = seed_list_backlog_task(
+        &runtime,
+        "Done child",
+        TaskStatus::Done,
+        TaskPriority::Medium,
+        TaskType::Task,
+        Some(epic.id.clone()),
+        vec![],
+    );
+
+    let output = load_epic(&runtime, &epic.id);
+
+    assert_eq!(output["all_terminal"], json!(true));
+    assert_eq!(output["subtasks"], json!([]));
+    assert_eq!(
+        output["final_state"]["subtasks"][review.id.as_str()],
+        json!({
+            "state": "done",
+            "status": "review",
+            "title": "Review child"
+        })
+    );
+    assert_eq!(
+        output["final_state"]["subtasks"][done.id.as_str()],
+        json!({
+            "state": "done",
+            "status": "done",
+            "title": "Done child"
+        })
+    );
+}
+
+#[test]
+fn load_epic_keeps_in_progress_subtasks_open_when_review_is_shipped() {
+    let (_root, runtime, _repo_root) = runtime_with_workspace_layout();
+    let epic = seed_list_backlog_task(
+        &runtime,
+        "Epic",
+        TaskStatus::InProgress,
+        TaskPriority::High,
+        TaskType::Epic,
+        None,
+        vec![],
+    );
+    let review = seed_list_backlog_task(
+        &runtime,
+        "Review child",
+        TaskStatus::Review,
+        TaskPriority::High,
+        TaskType::Task,
+        Some(epic.id.clone()),
+        vec![],
+    );
+    let in_progress = seed_list_backlog_task(
+        &runtime,
+        "In progress child",
+        TaskStatus::InProgress,
+        TaskPriority::High,
+        TaskType::Task,
+        Some(epic.id.clone()),
+        vec![],
+    );
+
+    let output = load_epic(&runtime, &epic.id);
+    let subtasks = output["subtasks"].as_array().expect("subtasks array");
+
+    assert_eq!(output["all_terminal"], json!(false));
+    assert_eq!(subtasks.len(), 1);
+    assert_eq!(subtasks[0]["id"], json!(in_progress.id));
+    assert_eq!(subtasks[0]["status"], json!("in-progress"));
+    assert!(
+        subtasks
+            .iter()
+            .all(|entry| entry["id"].as_str() != Some(review.id.as_str()))
+    );
 }
 
 #[test]

--- a/crates/orbit-core/src/runtime/v2_host/dispatch.rs
+++ b/crates/orbit-core/src/runtime/v2_host/dispatch.rs
@@ -174,7 +174,8 @@ pub(super) fn run_deterministic(
         "list_backlog_tasks" => backlog_exclusion::list_backlog_tasks(runtime, action, input),
         // Materialize an epic's working set for the orchestrator:
         // the epic task itself plus non-terminal subtasks
-        // (`parent_id == epic_task_id` and status ∉ {done, archived}).
+        // (`parent_id == epic_task_id` and status not done, review,
+        // blocked, archived, or rejected).
         // Full descriptions ride along because the orchestrator
         // reasons about dependency ordering from prose.
         "load_epic" => backlog_exclusion::load_epic(runtime, action, input),

--- a/docs/design/activity-job/2_design.md
+++ b/docs/design/activity-job/2_design.md
@@ -2,7 +2,7 @@
 
 **Status:** Draft
 **Owner:** codex
-**Last updated:** 2026-05-08 (T20260427-36, T20260508-3)
+**Last updated:** 2026-05-08 (T20260427-36, T20260427-38, T20260508-3)
 
 This document describes the shipped Activity / Job substrate across `orbit-common`, `orbit-engine`, `orbit-core`, and `orbit-cli`: asset shape, normalization, dispatch boundaries, backend semantics, DAG execution, audit, and retained legacy edges. See [1_overview.md](./1_overview.md) for purpose and [3_vision.md](./3_vision.md) for open questions.
 
@@ -128,6 +128,8 @@ Seeded direct shipment workflows (`task_local_pipeline` and `task_pr_pipeline`) 
 The seeded `list_backlog_tasks` deterministic activity starts `task_auto_pipeline`. Automatic mode admits tasks by `status: backlog`, including accepted friction reports whose `type` remains `friction`, while untriaged `status: friction` reports stay out. It emits `task_count`, `task_ids`, `tasks`, singleton `bundles`, and an `excluded` array for admitted backlog tasks filtered because their context files overlap `in-progress` or `review` locks. `excluded` covers only lock overlap; status-based admission and `max_tasks` truncation stay silent, and explicit `task_ids` mode omits it. This attribution contract was added in [T20260421-0542-2] and the friction admission rule was updated in [T20260505-2].
 
 `task_gate_pipeline` reserves a bundle's context files before it dispatches `task_pr_pipeline` or `task_local_pipeline` through `invoke_and_wait`. The reservation owner is the gate run that executed `reserve_locks`, not the child shipment run. Seeded defaults keep `ttl_seconds` aligned with `dispatch_timeout_seconds` at 7200 seconds, so the admission reservation covers the full child wait budget; workspace overrides must preserve `ttl_seconds >= dispatch_timeout_seconds` [T20260427-36]. Owned reservations are engine-cleaned when that owner run reaches a terminal state (`success`, `failed`, `cancelled`, or `timeout`), so correctness does not depend on every workspace override preserving a YAML release step. The seeded deterministic `release_locks` activity still calls `orbit.task.locks.release` after a terminal child wait as an early-release optimization; idempotent terminal cleanup then finds nothing left to release. Unowned/manual reservations remain explicit-release-or-TTL only. TTL is the fallback for abandoned/manual reservations or cases where no terminal cleanup or reserve-pressure reconciliation trigger runs. This lifecycle was tightened in [T20260430-26] and made engine-owned in [T20260505-10].
+
+`task_epic_pipeline` loops over deterministic `load_epic` snapshots rather than trusting the orchestrator's prose response. After [T20260427-38], `load_epic` treats `review` as a shipped stop state for epic automation: normal PR/local child workflows stop at that human handoff, so review subtasks are omitted from the next orchestrator input and can satisfy `all_terminal`. The final snapshot still preserves raw `status: "review"` while mapping the epic state to `done` for summary counters; this is pipeline completion, not human approval of the task lifecycle.
 
 Reserve conflict checking also performs bounded, opportunistic stale-owned-reservation reconciliation before reporting reservation conflicts. It inspects only overlapping owned reservations under current reserve pressure; it is not a background sweeper. Existing job-run list/show reconciliation remains in place, and both paths release run-owned reservations with `release_reason: stale_run_reconciled` when they prove the owner is already terminal or stale. Release audit rows use the task-lock audit surface and include `reservation_id`, `owner_run_id` when present, and `release_reason` (`explicit`, `run_terminal`, `stale_run_reconciled`, or TTL expiration).
 
@@ -463,6 +465,7 @@ Read-only history does not need the same dependencies as live execution. [T20260
 - **[T20260426-2313]** — Stream CLI subprocess stdout/stderr through structured tracing events while retaining the existing audit/blob path.
 - **[T20260426-2349]** — Move CLI tracing output redaction from `cli_runner` call sites into the default tracing formatter layer.
 - **[T20260427-36]** — Align task-gate reservation TTL with the child dispatch wait budget.
+- **[T20260427-38]** — Treat review as a shipped stop state for epic automation.
 - **[T20260427-45]** — Use freshly fetched remote base refs for default task-shipping worktrees.
 - **[T20260427-48]** — Thread provider config into the v2 CLI backend and keep Codex dynamic flags exec-compatible.
 - **[T20260427-51]** — Wrap cli-backend agent invocations in `sandbox-exec` on macOS.

--- a/docs/design/activity-job/4_decisions.md
+++ b/docs/design/activity-job/4_decisions.md
@@ -2,7 +2,7 @@
 
 **Status:** Draft
 **Owner:** codex
-**Last updated:** 2026-05-08 (T20260427-36, T20260508-3)
+**Last updated:** 2026-05-08 (T20260427-36, T20260427-38, T20260508-3)
 
 This ADR log records the decisions that define the current Activity / Job substrate. Entries are append-only and stay in place when later ADRs supersede or fold them. See [1_overview.md](./1_overview.md) for the feature summary, [2_design.md](./2_design.md) for the current implementation, and [3_vision.md](./3_vision.md) for the questions that may force more decisions.
 
@@ -397,6 +397,19 @@ Folded into ADR-002's rollup for explicit agent dispatch boundaries.
 
 **Decision.** Render one-task PR bodies as `## Task`, optional collapsed `## Execution Summary`, `## Validation`, and `## Branch Freshness`. The task section includes the task link, verbatim description, and plain-bullet acceptance criteria. Multi-task callers keep the legacy body while those paths remain supported.
 
+## ADR-043 — Epic review status is a shipped stop state
+
+**Status:** Accepted · 2026-05 · [T20260427-38]
+
+**Context.** `task_epic_pipeline` exits from deterministic `load_epic` snapshots, while normal child shipment workflows stop successful subtasks in `review` for human handoff. Treating `review` as open work made a clean epic cycle redispatch already-shipped subtasks or run until its iteration ceiling.
+
+**Decision.** For epic orchestration only, treat `review` as a shipped stop state: `load_epic` omits review subtasks from the open workset, allows them to satisfy `all_terminal`, and maps their epic summary state to `done` while preserving the raw task status.
+
+**Consequences.**
+- Epic loops can converge after normal PR/local child shipment without embedding human approval into the pipeline.
+- Operators can still inspect raw `status: "review"` in the final snapshot and task records before approving lifecycle completion.
+- Cost: `summarize_epic`'s `done` counter now includes review-shipped subtasks for epic completion, so readers must distinguish pipeline completion from task approval.
+
 ---
 
 ## Task References
@@ -431,6 +444,7 @@ Folded into ADR-002's rollup for explicit agent dispatch boundaries.
 - **[T20260426-2349]** — Move CLI tracing output redaction from `cli_runner` call sites into the default tracing formatter layer.
 - **[T20260427-33]** — Remove the audit-only `dispatch_agent` step from `task_auto_pipeline`.
 - **[T20260427-36]** — Align task-gate reservation TTL with the child dispatch wait budget.
+- **[T20260427-38]** — Treat review as a shipped stop state for epic automation.
 - **[T20260427-45]** — Use freshly fetched remote base refs for default task-shipping worktrees.
 - **[T20260427-48]** — Thread provider config into the v2 CLI backend and keep Codex dynamic flags exec-compatible.
 - **[T20260428-8]** — Add workflow-specific task admission for task-starting workflows.


### PR DESCRIPTION
## Task

[T20260427-38](T20260427-38) — task_epic_pipeline cannot converge after normal PR/local shipment leaves subtasks in review

### Description

While tracing `task_epic_pipeline`, I found the loop exits only when `load_epic.output.all_terminal == true`. `load_epic` treats only done/blocked/archived/rejected as terminal and maps `review` to `in_flight`, but the normal child ship workflows move successful subtasks to `review`: `task_pr_pipeline` opens a PR and stamps tasks to review, and `task_local_pipeline` explicitly runs `mark_review`. That means a successful epic cycle still refreshes subtasks as non-terminal, so the epic loop can continue dispatching already-shipped review tasks or run until the max-iteration ceiling. The workflow objective says drive subtasks to done/blocked/failed, but the available child pipelines only drive them to review without human approval. Consider treating review as a terminal shipped state for this pipeline, adding an explicit review/merge stage, or changing the epic objective/exit condition.

### Acceptance Criteria



## Execution Summary

<details>
<summary>Click to expand</summary>

## Status
success

## Summary of Changes
- Treated `review` as an epic-pipeline shipped stop state in `load_epic`, excluding review subtasks from future orchestrator cycles while preserving raw `status: "review"` in the final snapshot.
- Updated seeded epic activity/job guidance, summarize wording, and Activity / Job design docs with ADR-043 for the review handoff decision.
- Added focused regression tests for review subtasks being terminal for epic automation while in-progress subtasks keep the loop open.

## Overall Assessment
The epic loop can now converge after normal PR/local child shipment without requiring human approval inside the pipeline. Validated with `make fmt`, `cargo test -p orbit-core runtime::v2_host::backlog_exclusion::tests`, and `make build`.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/T20260427-38-69fd5370`
- Behind base: 0
- Ahead of base: 1

*authored by: gpt-5.5*