### PR TITLE
Reconcile orbit-execute-task review transition with agent_implement envelope

### DIFF
--- a/crates/orbit-core/assets/activities/agent_implement.yaml
+++ b/crates/orbit-core/assets/activities/agent_implement.yaml
@@ -48,7 +48,9 @@ spec:
        real confidence.
     7. Persist an execution summary when useful, but do not move the task to
        `review`; the pipeline does that only after commit/merge or PR steps
-       succeed.
+       succeed. This envelope rule overrides the direct-execution review
+       transition described in the `orbit-execute-task` skill's Step 5 and Exit
+       Criteria.
     8. Return a short structured summary. Include a `diff` string only when you
        can produce it cheaply and accurately.
   tools:

--- a/crates/orbit-core/assets/skills/orbit-execute-task/SKILL.md
+++ b/crates/orbit-core/assets/skills/orbit-execute-task/SKILL.md
@@ -35,9 +35,8 @@ orbit tool run orbit.task.show --input '{"id": "<task-id>", "field": "plan", "mo
 # Start a task (proposed/backlog/someday/blocked -> in-progress)
 orbit tool run orbit.task.start --input '{"id": "<task-id>", "note": "<why>", "model": "<model_name>"}'
 
-# Update plan, status, or add a comment
+# Update plan or add a comment
 orbit tool run orbit.task.update --input '{"id": "<task-id>", "plan": "<markdown plan>", "model": "<model_name>"}'
-orbit tool run orbit.task.update --input '{"id": "<task-id>", "status": "review", "model": "<model_name>"}'
 orbit tool run orbit.task.update --input '{"id": "<task-id>", "comment": "<what happened>", "model": "<model_name>"}'
 
 # Persist execution summary
@@ -83,16 +82,27 @@ orbit tool run orbit.task.start --input '{"id": "<task-id>", "note": "<why this 
 
 Follow the task's `plan` step by step. Use selector-first context from `context_files` before touching code: prefer `orbit.graph.pack`, and read files directly only for unresolved selectors or when the graph is unavailable. Run the repo-approved verification commands from the plan. If repo instructions forbid tests, honor that and use the allowed validation path instead.
 
-### Step 5: Move to review and summarize
+### Step 5: Summarize and hand off
 
-```bash
-orbit tool run orbit.task.update --input '{"id": "<task-id>", "status": "review", "model": "<model_name>"}'
-```
-
-Then persist the execution summary (see template below):
+First persist the execution summary (see template below):
 
 ```bash
 orbit tool run orbit.task.update --input '{"id": "<task-id>", "execution_summary": "<summary>", "model": "<model_name>"}'
+```
+
+Then choose the lifecycle handoff path:
+
+- **Under an activity envelope** (for example, `agent_implement`): persist the
+  `execution_summary` only. Do not move the task to `review`; the pipeline owns
+  that transition after commit/merge or PR steps succeed. If the envelope gives
+  lifecycle instructions, it takes precedence over this skill's direct-execution
+  defaults.
+- **Direct execution** (no activity envelope, ad-hoc human-requested work):
+  persist the `execution_summary` and move the task to `review` via
+  `orbit.task.update`.
+
+```bash
+orbit tool run orbit.task.update --input '{"id": "<task-id>", "status": "review", "model": "<model_name>"}'
 ```
 
 ## Execution Summary Template
@@ -136,11 +146,15 @@ Recommended follow-ups:
 - If material ambiguity remains, ask clarifying questions before implementation.
 - If approval cannot be obtained for `proposed` work, stop after recording that state.
 - Do not skip lifecycle updates.
-- Moving `in-progress -> review` requires a non-empty `execution_summary`, so persist the summary before or together with the review transition.
+- Direct execution must persist a non-empty `execution_summary` before or
+  together with the review transition. Envelope-driven execution persists the
+  summary and leaves the review transition to the owning pipeline.
 
 ## Exit Criteria
 
 - Requested change implemented and validated.
 - Task started via `orbit.task.start` before execution.
-- Task advanced to `review`.
 - Execution summary persisted via `orbit.task.update`.
+- For direct execution, task advanced to `review`.
+- For envelope-driven execution, task left for the pipeline-owned review
+  transition after commit/merge or PR steps succeed.


### PR DESCRIPTION
## Task

[T20260508-9](T20260508-9) — Reconcile orbit-execute-task review transition with agent_implement envelope

### Description

The `agent_implement` activity envelope at `crates/orbit-core/assets/activities/agent_implement.yaml` step 7 instructs implementing agents *not* to move the task to `review` because the pipeline handles that transition after commit/merge or PR steps. The `orbit-execute-task` skill at `crates/orbit-core/assets/skills/orbit-execute-task/SKILL.md` Step 5 and Exit Criteria still instruct agents to move `in-progress → review` after implementation.

This is a doc-only conflict; runtime behavior is already correct. `task_local_pipeline.yaml` has a dedicated `mark_review` step after `git_merge` that performs the transition, and direct (non-pipeline) human-requested execution has no pipeline so the agent must do it itself. The skill simply doesn't acknowledge that an envelope can override it, forcing agents to choose between seeded skill guidance and the newer envelope contract.

Supersedes the originally-archived friction report T20260507-20 (`gpt-5.5`, 2026-05-07), which captured the same conflict during execution of T20260507-12 in jrun-20260507-0513-5.

### Acceptance Criteria

- SKILL.md Step 5 explicitly distinguishes pipeline (envelope-driven) execution from direct execution: under an envelope, agents persist execution_summary and do NOT move the task to review; outside an envelope, agents persist the summary AND move the task to review via orbit.task.update.
- SKILL.md Exit Criteria reflect the same two-path rule: review transition is required only when running outside a pipeline activity.
- agent_implement.yaml step 7 cross-references the skill's precedence rule so the override is documented on both sides of the contract.
- A grep for 'status: review' and 'status.*review' across crates/orbit-core/assets/skills/ and docs/design/ surfaces no remaining doc that contradicts the envelope's pipeline-owns-the-transition rule.
- make fmt and make build pass.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Updated `orbit-execute-task` Step 5 and Exit Criteria to branch between envelope-driven pipeline execution and direct execution.
- Added an `agent_implement` step 7 cross-reference documenting that the envelope rule overrides the skill defaults.

Assessment: Doc-only lifecycle guidance is now internally consistent; pipeline runs persist summaries without moving tasks to review, while direct executions still perform the review transition.

Validation:
- make fmt
- make build
- grep sweep for status/review docs reviewed; remaining hits are command examples or non-contradictory design/status references.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/T20260508-9-69fd5952`
- Behind base: 0
- Ahead of base: 1

*authored by: claude-opus-4-7*