### PR TITLE
Fix broken task_id link in PR body; add opt-in URL template config

### DIFF
--- a/crates/orbit-core/src/config/raw.rs
+++ b/crates/orbit-core/src/config/raw.rs
@@ -7,6 +7,7 @@ pub(super) struct RawRuntimeConfig {
     #[allow(dead_code)]
     pub(super) identity: Option<toml::Value>,
     pub(super) task: Option<RawTaskSection>,
+    pub(super) pr: Option<RawPrSection>,
     pub(super) scoring: Option<RawScoringConfig>,
     pub(super) graph: Option<RawGraphConfig>,
     pub(super) knowledge: Option<RawKnowledgeConfig>,
@@ -92,6 +93,11 @@ pub(super) struct RawCodexExecutionConfig {
 #[derive(Debug, Clone, Deserialize)]
 pub(super) struct RawTaskSection {
     pub(super) approval: Option<RawTaskApprovalConfig>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub(super) struct RawPrSection {
+    pub(super) task_url_template: Option<String>,
 }
 
 #[derive(Debug, Clone, Deserialize)]

--- a/crates/orbit-core/src/config/runtime.rs
+++ b/crates/orbit-core/src/config/runtime.rs
@@ -5,13 +5,14 @@ use std::path::Path;
 
 use orbit_common::types::OrbitError;
 use orbit_common::utility::redaction::redact_home_dir;
+use orbit_engine::PrConfig;
 
 use crate::paths;
 
 use super::persistence::PersistenceConfig;
 use super::raw::{
-    RawAgentRoleConfig, RawCodexExecutionConfig, RawExecutionEnvConfig, RawRuntimeConfig,
-    RawTaskSection, RawWorkflowConfig,
+    RawAgentRoleConfig, RawCodexExecutionConfig, RawExecutionEnvConfig, RawPrSection,
+    RawRuntimeConfig, RawTaskSection, RawWorkflowConfig,
 };
 
 const DEFAULT_ENV_INHERIT: bool = false;
@@ -29,6 +30,7 @@ pub(crate) struct RuntimeConfig {
     pub(crate) codex_execution: CodexExecutionPolicy,
     pub(crate) persistence: PersistenceConfig,
     pub(crate) task_approval: TaskApprovalConfig,
+    pub(crate) pr: PrConfig,
     pub(crate) scoring_enabled: bool,
     pub(crate) graph_editing: bool,
     /// Persisted default for the v2 `agent_loop` execution backend (§3.1).
@@ -58,6 +60,7 @@ impl RuntimeConfig {
             codex_execution: CodexExecutionPolicy::default(),
             persistence: PersistenceConfig::default_for_data_root(data_root),
             task_approval: TaskApprovalConfig::default(),
+            pr: PrConfig::default(),
             scoring_enabled: DEFAULT_SCORING_ENABLED,
             graph_editing: DEFAULT_GRAPH_EDITING,
             v2_backend: None,
@@ -137,6 +140,7 @@ impl RuntimeConfig {
             .and_then(|section| section.backend.clone());
 
         let workflow_base_branch = workflow_base_branch_from_raw(parsed.workflow.as_ref())?;
+        let pr = pr_config_from_raw(parsed.pr.as_ref());
 
         if parsed
             .knowledge
@@ -158,6 +162,7 @@ impl RuntimeConfig {
             )?,
             persistence,
             task_approval: TaskApprovalConfig::from_raw(parsed.task.as_ref())?,
+            pr,
             scoring_enabled,
             graph_editing,
             v2_backend,
@@ -173,6 +178,16 @@ impl RuntimeConfig {
 
     pub(crate) fn workflow_base_branch(&self) -> &str {
         &self.workflow_base_branch
+    }
+
+    pub(crate) fn pr_config(&self) -> &PrConfig {
+        &self.pr
+    }
+}
+
+fn pr_config_from_raw(raw: Option<&RawPrSection>) -> PrConfig {
+    PrConfig {
+        task_url_template: raw.and_then(|section| section.task_url_template.clone()),
     }
 }
 
@@ -533,5 +548,35 @@ mod tests {
         let config =
             RuntimeConfig::load_layered(global.path(), workspace.path()).expect("config loads");
         assert!(config.v2_backend().is_none());
+        assert_eq!(config.pr_config().task_url_template.as_deref(), None);
+    }
+
+    #[test]
+    fn pr_config_defaults_to_no_task_url_template_without_config() {
+        let global = tempdir().expect("global tempdir");
+        let workspace = tempdir().expect("workspace tempdir");
+
+        let config =
+            RuntimeConfig::load_layered(global.path(), workspace.path()).expect("config loads");
+
+        assert_eq!(config.pr_config().task_url_template.as_deref(), None);
+    }
+
+    #[test]
+    fn pr_task_url_template_loads_from_workspace_config() {
+        let global = tempdir().expect("global tempdir");
+        let workspace = tempdir().expect("workspace tempdir");
+        write_config(
+            workspace.path(),
+            "[pr]\ntask_url_template = \"https://orbit-cli.com/tasks/{task_id}\"\n",
+        );
+
+        let config =
+            RuntimeConfig::load_layered(global.path(), workspace.path()).expect("config loads");
+
+        assert_eq!(
+            config.pr_config().task_url_template.as_deref(),
+            Some("https://orbit-cli.com/tasks/{task_id}")
+        );
     }
 }

--- a/crates/orbit-core/src/context.rs
+++ b/crates/orbit-core/src/context.rs
@@ -2,6 +2,7 @@ use std::path::Path;
 use std::sync::Arc;
 
 use orbit_common::types::WorkspacePaths;
+use orbit_engine::PrConfig;
 use orbit_policy::PolicyEngine;
 use orbit_store::{
     AuditEventStoreBackend, ExecutorDefStoreBackend, JobRunStoreBackend, PolicyDefStoreBackend,
@@ -159,6 +160,7 @@ pub(crate) struct OrbitRuntimeSettings {
     task_delegate_approval: bool,
     scoring_enabled: bool,
     graph_editing: bool,
+    pr_config: PrConfig,
     /// Persisted default for the v2 `agent_loop` execution backend (§3.1).
     v2_backend: Option<String>,
     /// Default base branch for ship/ship-auto/duel-plan workflows
@@ -178,6 +180,7 @@ impl OrbitRuntimeSettings {
         task_delegate_approval: bool,
         scoring_enabled: bool,
         graph_editing: bool,
+        pr_config: PrConfig,
         v2_backend: Option<String>,
         workflow_base_branch: String,
         agent_roles: std::collections::BTreeMap<String, crate::config::RawAgentRoleConfig>,
@@ -189,10 +192,15 @@ impl OrbitRuntimeSettings {
             task_delegate_approval,
             scoring_enabled,
             graph_editing,
+            pr_config,
             v2_backend,
             workflow_base_branch,
             agent_roles,
         }
+    }
+
+    pub(crate) fn pr_config(&self) -> &PrConfig {
+        &self.pr_config
     }
 
     pub(crate) fn v2_backend(&self) -> Option<&str> {
@@ -292,6 +300,10 @@ impl OrbitContext {
 
     pub(crate) fn graph_editing(&self) -> bool {
         self.runtime.graph_editing
+    }
+
+    pub(crate) fn pr_config(&self) -> &PrConfig {
+        self.runtime.pr_config()
     }
 
     /// Persisted default for the v2 `agent_loop` execution backend (§3.1

--- a/crates/orbit-core/src/runtime/builder.rs
+++ b/crates/orbit-core/src/runtime/builder.rs
@@ -93,6 +93,7 @@ pub(crate) fn build_context_from_roots(
     let task_delegate_approval = runtime_config.task_approval.delegate_approval;
     let scoring_enabled = runtime_config.scoring_enabled;
     let graph_editing = runtime_config.graph_editing;
+    let pr_config = runtime_config.pr_config().clone();
     let v2_backend = runtime_config.v2_backend().map(ToString::to_string);
     let workflow_base_branch = runtime_config.workflow_base_branch().to_string();
     let agent_roles = runtime_config.agent_roles.clone();
@@ -125,6 +126,7 @@ pub(crate) fn build_context_from_roots(
             task_delegate_approval,
             scoring_enabled,
             graph_editing,
+            pr_config,
             v2_backend,
             workflow_base_branch,
             agent_roles,

--- a/crates/orbit-core/src/runtime/engine/runtime_host.rs
+++ b/crates/orbit-core/src/runtime/engine/runtime_host.rs
@@ -160,6 +160,10 @@ impl RuntimeHost for OrbitRuntime {
         self.context.graph_editing()
     }
 
+    fn pr_config(&self) -> orbit_engine::PrConfig {
+        OrbitRuntime::pr_config(self).clone()
+    }
+
     fn scoreboard_dir(&self) -> &std::path::Path {
         &self.context.paths().scoreboard_dir
     }

--- a/crates/orbit-core/src/runtime/mod.rs
+++ b/crates/orbit-core/src/runtime/mod.rs
@@ -225,6 +225,10 @@ impl OrbitRuntime {
         self.context.graph_editing()
     }
 
+    pub fn pr_config(&self) -> &orbit_engine::PrConfig {
+        self.context.pr_config()
+    }
+
     /// Configured default for the v2 `agent_loop` execution backend (§3.1
     /// precedence step 3). Returns `None` when not set.
     pub fn v2_backend_config(&self) -> Option<&str> {

--- a/crates/orbit-engine/src/context.rs
+++ b/crates/orbit-engine/src/context.rs
@@ -315,6 +315,11 @@ pub struct AgentRoleConfig {
     pub backend: Option<Backend>,
 }
 
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct PrConfig {
+    pub task_url_template: Option<String>,
+}
+
 pub trait EnvironmentHost {
     // ── Config accessors (implementors provide these) ──────────────────
 
@@ -454,6 +459,9 @@ pub trait RuntimeHost {
     }
     fn scoring_enabled(&self) -> bool;
     fn graph_editing(&self) -> bool;
+    fn pr_config(&self) -> PrConfig {
+        PrConfig::default()
+    }
     fn scoreboard_dir(&self) -> &Path;
     fn persist_invocation_trace(
         &self,

--- a/crates/orbit-engine/src/executor/automation/pr.rs
+++ b/crates/orbit-engine/src/executor/automation/pr.rs
@@ -8,7 +8,7 @@ use orbit_store::pr_scoreboard;
 use orbit_tools::ToolContext;
 use serde_json::{Value, json};
 
-use crate::context::{RuntimeHost, TaskAutomationUpdate, TaskHost};
+use crate::context::{PrConfig, RuntimeHost, TaskAutomationUpdate, TaskHost};
 
 use super::freshness::{ensure_branch_fresh_against_base, ensure_branch_rebased_onto_base};
 use super::git::{base_sync_mode_from_input, git_output};
@@ -244,9 +244,12 @@ pub(super) fn open_batch_pr<H: RuntimeHost + TaskHost + ?Sized>(
     let title = input_string_field(input, "title")
         .filter(|value| !value.trim().is_empty())
         .unwrap_or_else(|| default_pr_title(&completed_tasks));
+    let pr_config = host.pr_config();
     let body = input_string_field(input, "body")
         .filter(|value| !value.trim().is_empty())
-        .unwrap_or_else(|| build_batch_pr_body(&completed_tasks, &freshness, &changed_files));
+        .unwrap_or_else(|| {
+            build_batch_pr_body(&completed_tasks, &freshness, &changed_files, &pr_config)
+        });
 
     let tool_context = ToolContext {
         cwd: Some(workspace_path.to_string_lossy().to_string()),
@@ -373,11 +376,12 @@ fn build_batch_pr_body(
     tasks: &[Task],
     freshness: &super::freshness::BranchFreshness,
     changed_files: &[&str],
+    pr_config: &PrConfig,
 ) -> String {
     let mut body = if let [task] = tasks {
-        build_single_task_pr_body(task, freshness)
+        build_single_task_pr_body(task, freshness, pr_config)
     } else {
-        build_legacy_batch_pr_body(tasks, freshness, changed_files)
+        build_legacy_batch_pr_body(tasks, freshness, changed_files, pr_config)
     };
 
     if let Some(signature) = batch_pr_signature(tasks) {
@@ -388,8 +392,12 @@ fn build_batch_pr_body(
     body
 }
 
-fn build_single_task_pr_body(task: &Task, freshness: &super::freshness::BranchFreshness) -> String {
-    let mut sections = vec![render_single_task_section(task)];
+fn build_single_task_pr_body(
+    task: &Task,
+    freshness: &super::freshness::BranchFreshness,
+    pr_config: &PrConfig,
+) -> String {
+    let mut sections = vec![render_single_task_section(task, pr_config)];
 
     if let Some(execution_summary) = meaningful_execution_summary(&task.execution_summary) {
         sections.push(render_execution_summary_section(execution_summary));
@@ -404,10 +412,11 @@ fn build_legacy_batch_pr_body(
     tasks: &[Task],
     freshness: &super::freshness::BranchFreshness,
     changed_files: &[&str],
+    pr_config: &PrConfig,
 ) -> String {
     let task_sections = tasks
         .iter()
-        .map(render_legacy_task_section)
+        .map(|task| render_legacy_task_section(task, pr_config))
         .collect::<Vec<_>>()
         .join("\n");
     let changed_files_section = changed_files
@@ -426,12 +435,12 @@ fn build_legacy_batch_pr_body(
     )
 }
 
-fn render_single_task_section(task: &Task) -> String {
+fn render_single_task_section(task: &Task, pr_config: &PrConfig) -> String {
     let acceptance_criteria = render_acceptance_criteria(&task.acceptance_criteria);
 
     format!(
         "## Task\n\n{}\n\n### Description\n\n{}\n\n### Acceptance Criteria\n\n{}",
-        render_single_task_line(task),
+        render_single_task_line(task, pr_config),
         task.description,
         acceptance_criteria
     )
@@ -462,8 +471,8 @@ fn render_acceptance_criteria(criteria: &[String]) -> String {
         .join("\n")
 }
 
-fn render_legacy_task_section(task: &Task) -> String {
-    let line = render_task_line(task);
+fn render_legacy_task_section(task: &Task, pr_config: &PrConfig) -> String {
+    let line = render_task_line(task, pr_config);
     match meaningful_execution_summary(&task.execution_summary) {
         Some(execution_summary) => {
             format!(
@@ -510,31 +519,44 @@ fn is_placeholder_execution_summary(summary: &str) -> bool {
         )
 }
 
-fn render_task_line(task: &Task) -> String {
+fn render_task_line(task: &Task, pr_config: &PrConfig) -> String {
     let title = task.title.trim();
+    let task_ref = render_task_ref(task, pr_config);
     if title.is_empty() {
-        format!("- [{}]", task.id)
+        format!("- {task_ref}")
     } else {
-        format!("- [{}] {}", task.id, title)
+        format!("- {task_ref} {title}")
     }
 }
 
-fn render_single_task_line(task: &Task) -> String {
+fn render_single_task_line(task: &Task, pr_config: &PrConfig) -> String {
     let title = task.title.trim();
-    let url = task_url(task);
+    let task_ref = render_task_ref(task, pr_config);
     if title.is_empty() {
-        format!("[{}]({url})", task.id)
+        task_ref
     } else {
-        format!("[{}]({url}) — {title}", task.id)
+        format!("{task_ref} — {title}")
     }
 }
 
-fn task_url(task: &Task) -> String {
+fn render_task_ref(task: &Task, pr_config: &PrConfig) -> String {
+    match task_url(task, pr_config) {
+        Some(url) => format!("[{}]({url})", task.id),
+        None => task.id.clone(),
+    }
+}
+
+fn task_url(task: &Task, pr_config: &PrConfig) -> Option<String> {
     task.external_refs
         .iter()
         .find_map(|external_ref| external_ref.url.as_deref())
-        .unwrap_or(task.id.as_str())
-        .to_string()
+        .map(ToOwned::to_owned)
+        .or_else(|| {
+            pr_config
+                .task_url_template
+                .as_ref()
+                .map(|template| template.replace("{task_id}", &task.id))
+        })
 }
 
 fn default_pr_title(tasks: &[Task]) -> String {
@@ -927,6 +949,12 @@ mod tests {
         }
     }
 
+    fn test_pr_config(task_url_template: Option<&str>) -> PrConfig {
+        PrConfig {
+            task_url_template: task_url_template.map(ToOwned::to_owned),
+        }
+    }
+
     struct PrWorkspace {
         _temp: TempDir,
         repo: PathBuf,
@@ -980,6 +1008,99 @@ mod tests {
     }
 
     #[test]
+    fn task_url_rendering_covers_template_and_external_ref_priority() {
+        let plain = task_with_contract("T123", "Plain task", "done", "", &[], None);
+        assert_eq!(task_url(&plain, &test_pr_config(None)), None);
+        assert_eq!(
+            render_single_task_line(&plain, &test_pr_config(None)),
+            "T123 — Plain task"
+        );
+
+        let external = task_with_contract(
+            "T124",
+            "External task",
+            "done",
+            "",
+            &[],
+            Some("https://tracker.example/T124"),
+        );
+        assert_eq!(
+            task_url(&external, &test_pr_config(None)).as_deref(),
+            Some("https://tracker.example/T124")
+        );
+        assert_eq!(
+            render_single_task_line(&external, &test_pr_config(None)),
+            "[T124](https://tracker.example/T124) — External task"
+        );
+
+        let templated = task_with_contract("T125", "Templated task", "done", "", &[], None);
+        assert_eq!(
+            task_url(
+                &templated,
+                &test_pr_config(Some("https://orbit-cli.com/tasks/{task_id}"))
+            )
+            .as_deref(),
+            Some("https://orbit-cli.com/tasks/T125")
+        );
+        assert_eq!(
+            render_single_task_line(
+                &templated,
+                &test_pr_config(Some("https://orbit-cli.com/tasks/{task_id}"))
+            ),
+            "[T125](https://orbit-cli.com/tasks/T125) — Templated task"
+        );
+
+        let external_wins = task_with_contract(
+            "T126",
+            "External wins",
+            "done",
+            "",
+            &[],
+            Some("https://tracker.example/T126"),
+        );
+        assert_eq!(
+            task_url(
+                &external_wins,
+                &test_pr_config(Some("https://orbit-cli.com/tasks/{task_id}"))
+            )
+            .as_deref(),
+            Some("https://tracker.example/T126")
+        );
+        assert_eq!(
+            render_single_task_line(
+                &external_wins,
+                &test_pr_config(Some("https://orbit-cli.com/tasks/{task_id}"))
+            ),
+            "[T126](https://tracker.example/T126) — External wins"
+        );
+    }
+
+    #[test]
+    fn default_pr_config_renders_plain_task_id_without_markdown_link_punctuation() {
+        let body = build_batch_pr_body(
+            &[task_with_contract(
+                "T20260508-11",
+                "Fix task links",
+                "done",
+                "Default config must not create broken links.",
+                &["Task id renders as plain text.".to_string()],
+                None,
+            )],
+            &freshness(),
+            &[],
+            &test_pr_config(None),
+        );
+        let task_line = body
+            .lines()
+            .find(|line| line.starts_with("T20260508-11"))
+            .expect("plain task line");
+
+        assert_eq!(task_line, "T20260508-11 — Fix task links");
+        assert!(!task_line.contains(']'));
+        assert!(!task_line.contains('('));
+    }
+
+    #[test]
     fn multi_task_pr_body_preserves_legacy_execution_summary_layout() {
         let first_summary = "## Status\nsuccess\n\n## Summary of Changes\n- Routed automation updates through system.";
         let second_summary =
@@ -991,10 +1112,11 @@ mod tests {
             ],
             &freshness(),
             &["crates/orbit-core/src/runtime/engine/task_host.rs"],
+            &test_pr_config(None),
         );
 
-        assert!(body.contains("- [T20260427-24] System attribution fix"));
-        assert!(body.contains("- [T20260427-25] Review handoff"));
+        assert!(body.contains("- T20260427-24 System attribution fix"));
+        assert!(body.contains("- T20260427-25 Review handoff"));
         assert_eq!(
             body.matches("<details><summary>Execution Summary</summary>")
                 .count(),
@@ -1015,12 +1137,13 @@ mod tests {
             ],
             &freshness(),
             &[],
+            &test_pr_config(None),
         );
 
-        assert!(body.contains("- [T20260427-32] Include execution summaries"));
-        assert!(body.contains("- [T20260427-33] Whitespace summary"));
-        assert!(body.contains("- [T20260427-34] Placeholder summary"));
-        assert!(body.contains("- [T20260427-35] Ellipsis summary"));
+        assert!(body.contains("- T20260427-32 Include execution summaries"));
+        assert!(body.contains("- T20260427-33 Whitespace summary"));
+        assert!(body.contains("- T20260427-34 Placeholder summary"));
+        assert!(body.contains("- T20260427-35 Ellipsis summary"));
         assert!(!body.contains("<details><summary>Execution Summary</summary>"));
     }
 
@@ -1040,6 +1163,7 @@ mod tests {
             )],
             &freshness(),
             &["crates/orbit-engine/src/executor/automation/pr.rs"],
+            &test_pr_config(None),
         );
 
         assert_eq!(
@@ -1061,6 +1185,7 @@ mod tests {
             )],
             &freshness(),
             &["crates/orbit-engine/src/executor/automation/pr.rs"],
+            &test_pr_config(None),
         );
 
         let headings = body
@@ -1107,6 +1232,7 @@ mod tests {
             )],
             &freshness(),
             &[],
+            &test_pr_config(None),
         );
 
         assert!(body.contains("## Task"));
@@ -1170,9 +1296,9 @@ mod tests {
         .expect("pr_open should create PR");
         let body = host.pr_create_body();
 
-        assert!(body.contains("- [T20260430-31A] First completed task"));
+        assert!(body.contains("- T20260430-31A First completed task"));
         assert!(body.contains(first_summary));
-        assert!(body.contains("- [T20260430-31B] Second completed task"));
+        assert!(body.contains("- T20260430-31B Second completed task"));
         assert!(body.contains(second_summary));
         assert_eq!(
             body.matches("<details><summary>Execution Summary</summary>")

--- a/crates/orbit-engine/src/lib.rs
+++ b/crates/orbit-engine/src/lib.rs
@@ -37,10 +37,10 @@ pub use context::{
     ACTIVITY_EXECUTION_FAILED, AGENT_COMMIT_FAILED, AGENT_INVOCATION_FAILED,
     AGENT_PROTOCOL_VIOLATION, AGENT_TIMEOUT, ActivityInvocationResult, AgentProtocolHost,
     AgentRoleConfig, AttemptOutcome, DirectActivityRunOutcome, EngineHost, EnvironmentHost,
-    ExecutionContext, ExecutorHost, ExecutorLookupHost, JobRunHost, JobRunResult, RuntimeHost,
-    STALE_RUN_GRACE_SECONDS, TaskAutomationUpdate, TaskHost, TaskReadHost, TaskWriteHost,
-    execution_working_directory, execution_working_directory_with_task, input_workspace_path,
-    redact_attempt_outcome,
+    ExecutionContext, ExecutorHost, ExecutorLookupHost, JobRunHost, JobRunResult, PrConfig,
+    RuntimeHost, STALE_RUN_GRACE_SECONDS, TaskAutomationUpdate, TaskHost, TaskReadHost,
+    TaskWriteHost, execution_working_directory, execution_working_directory_with_task,
+    input_workspace_path, redact_attempt_outcome,
 };
 pub use executor::automation::{
     StateExecutionContext, execute_action as execute_deterministic_action,


### PR DESCRIPTION
## Task

[T20260508-11](T20260508-11) — Fix broken task_id link in PR body; add opt-in URL template config

### Description

## Problem

`task_url()` in `crates/orbit-engine/src/executor/automation/pr.rs:532` falls back to using the bare task ID as a URL when a task has no `external_refs[].url`:

```rust
fn task_url(task: &Task) -> String {
    task.external_refs
        .iter()
        .find_map(|external_ref| external_ref.url.as_deref())
        .unwrap_or(task.id.as_str())  // ← bare ID, not a URL
        .to_string()
}
```

The caller (`render_single_task_line`) wraps that in `[T20260427-36](T20260427-36)`, which GitHub renders as a relative link to `…/pull/<n>/T20260427-36` → **404**. Every PR body whose task lacks an `external_refs[].url` ships a broken hyperlink.

## Why It Matters

- **Bug visible in production**: PR description headers point at dead URLs. Reviewers click and land on a 404.
- **We want orbit-cli.com integration**: now that done tasks publish at `orbit-cli.com/tasks/<task_id>` (T20260508-4), our PR bodies should hyperlink the task ID to that page. Downstream Orbit users (forks, internal installs) don't publish to orbit-cli.com, so the link should *not* appear for them — they should see plain text.

## Constraints / Notes

- Add a workspace-level config setting `pr.task_url_template` (string, optional). Format: a template containing the literal placeholder `{task_id}`, e.g. `"https://orbit-cli.com/tasks/{task_id}"`.
- Resolution priority for the rendered task ID:
  1. If `task.external_refs[].url` exists for any ref, use the first such URL (per-task override beats template).
  2. Else if `pr.task_url_template` is set, substitute `{task_id}` and use the result.
  3. Else render plain text task ID with no Markdown link.
- Default config has the template unset → plain text for everyone except workspaces that opt in. This fixes the 404 bug as a side effect, since the bare-ID-as-URL fallback is gone.
- Set the template in this workspace's config to `"https://orbit-cli.com/tasks/{task_id}"` so our future PRs hyperlink correctly. Other Orbit users get plain text by default.
- `task_url()` should return `Option<String>` (not `String`); `render_single_task_line` and any other caller switches on it to render `[T123](url)` vs plain `T123`.
- Files in scope:
  - `crates/orbit-core/src/config/raw.rs` — new `RawPrSection` struct, threaded into `RawRuntimeConfig`.
  - `crates/orbit-core/src/config/runtime.rs` — resolved `PrConfig` type.
  - `crates/orbit-engine/src/executor/automation/pr.rs` — new `task_url()` signature + use it in `render_single_task_line` and any other consumer.
  - This workspace's orbit config file (wherever existing workspace config lives) — add `[pr] task_url_template = "..."`.
- T20260508-3 (done) revised the PR body template; that's the most recent change to the same file and is good context for naming/style.

## Out of Scope (v1)

- Generalizing this template to CLI output (`orbit task show`), terminal renderers, or any other surface. Do that when a second consumer actually needs it.
- Backfilling `external_refs[].url` on existing tasks.
- Validating that `{task_id}` actually appears in the template string at config load time (nice-to-have, not required).

### Acceptance Criteria

- `crates/orbit-core/src/config/raw.rs` declares a `RawPrSection` struct (or equivalent) with an optional `task_url_template: Option<String>` field, and `RawRuntimeConfig` includes it under a `[pr]` TOML section.
- `crates/orbit-core/src/config/runtime.rs` exposes a resolved `PrConfig` (or equivalent) carrying the optional template, plumbed through the runtime so `crates/orbit-engine/src/executor/automation/pr.rs` can read it.
- `task_url(task: &Task, cfg: &PrConfig) -> Option<String>` (or equivalent signature change) is implemented in `pr.rs` and applies the priority: (1) first `external_refs[].url` if present, else (2) `cfg.task_url_template.as_ref().map(|t| t.replace("{task_id}", &task.id))`, else (3) `None`.
- `render_single_task_line` (and any other caller of `task_url`) renders `[T123](url)` when `task_url` returns `Some(_)` and plain `T123` text with no Markdown link when it returns `None`.
- Unit tests in `pr.rs` (new or extended) cover all four cells of the matrix: (a) no template + no external_ref → plain text, (b) no template + external_ref with url → external_ref URL used, (c) template set + no external_ref → template used with `{task_id}` substituted, (d) template set + external_ref with url → external_ref URL wins.
- Default config (no `[pr]` section in TOML) loads cleanly and produces plain-text task IDs in PR bodies; verified by a unit or integration test asserting no `(` or `]` markdown link punctuation around the rendered task ID.
- This workspace's orbit config (the path in this repo where existing orbit settings live) sets `task_url_template = "https://orbit-cli.com/tasks/{task_id}"` under `[pr]`; verified by `grep -n 'task_url_template' <config-path>` returning that line.
- `make fmt` exits 0.
- `make build` exits 0.
- `cargo test -p orbit-engine` and `cargo test -p orbit-core` both exit 0 with the new tests passing.

## Execution Summary

<details>
<summary>Click to expand</summary>

## Status
success

## Summary of Changes
- Added optional [pr].task_url_template config parsing and resolved PrConfig plumbing from orbit-core runtime into orbit-engine RuntimeHost.
- Changed PR task ID rendering to use external_ref URL first, then configured template, then plain text with no Markdown link.
- Added unit coverage for the no-template/external-ref/template/priority matrix and default plain-text rendering, plus core config loading tests.
- Created this workspace config at /Users/daniel/workspace/repos/orbit/.orbit/config.toml with task_url_template = "https://orbit-cli.com/tasks/{task_id}".

## Overall Assessment
The change is scoped to PR body rendering and runtime config plumbing. Validation passed: make fmt, make build, cargo test -p orbit-engine, cargo test -p orbit-core, and grep -n task_url_template /Users/daniel/workspace/repos/orbit/.orbit/config.toml.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/T20260508-11-69fd62a0`
- Behind base: 0
- Ahead of base: 1

*authored by: claude-opus-4-7*