### PR TITLE
Fix CI clippy failure: unused imports in sandbox.rs tests on non-macOS targets

### DIFF
--- a/crates/orbit-core/src/runtime/v2_host/sandbox.rs
+++ b/crates/orbit-core/src/runtime/v2_host/sandbox.rs
@@ -185,9 +185,9 @@ fn absolutize_rule(workspace_root: &str, rule: &str) -> String {
 mod tests {
     use orbit_engine::activity_job::V2RuntimeHost;
 
-    use crate::runtime::v2_host::test_support::{
-        runtime_with_workspace_layout, seed_executor, seeded_runtime_with_executor,
-    };
+    use crate::runtime::v2_host::test_support::seeded_runtime_with_executor;
+    #[cfg(target_os = "macos")]
+    use crate::runtime::v2_host::test_support::{runtime_with_workspace_layout, seed_executor};
 
     #[test]
     fn resolve_executor_sandbox_returns_none_when_executor_has_no_sandbox() {


### PR DESCRIPTION
## Task

[T20260508-10](T20260508-10) — Fix CI clippy failure: unused imports in sandbox.rs tests on non-macOS targets

### Description

## Problem

`./scripts/ci-guardrails.sh` fails on Linux with:

```
error: unused imports: `runtime_with_workspace_layout` and `seed_executor`
   --> crates/orbit-core/src/runtime/v2_host/sandbox.rs:189:9
    |
189 |         runtime_with_workspace_layout, seed_executor, seeded_runtime_with_executor,
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^  ^^^^^^^^^^^^^
    |
    = note: `-D unused-imports` implied by `-D warnings`
error: could not compile `orbit-core` (lib test) due to 1 previous error
```

CI runs `cargo clippy --workspace --all-targets -- -D warnings` (see `scripts/ci-guardrails.sh:8`). On macOS the same command passes clean, so the regression is invisible to local-mac development.

## Why It Matters

CI is currently red on the standard guardrails workflow. Every PR opened from a non-macOS runner blocks on this one error. Beyond unblocking CI, this is also a structural reminder that local clippy on macOS does not exercise the `#[cfg(not(target_os = "macos"))]` paths in `sandbox.rs`, so the same class of cfg-skew can recur.

## Root Cause

In [crates/orbit-core/src/runtime/v2_host/sandbox.rs](crates/orbit-core/src/runtime/v2_host/sandbox.rs):

- The `tests` module imports three symbols at sandbox.rs:188-190: `runtime_with_workspace_layout`, `seed_executor`, `seeded_runtime_with_executor`.
- `seeded_runtime_with_executor` is used by tests under both `#[cfg(target_os = "macos")]` and `#[cfg(not(target_os = "macos"))]` (sandbox.rs:194, sandbox.rs:286).
- `runtime_with_workspace_layout` and `seed_executor` are referenced only inside `#[cfg(target_os = "macos")]` tests (sandbox.rs:233-238).

On non-macOS builds the macOS-only tests are compiled out, so those two imports become unused and `-D warnings` upgrades the lint to an error.

## Constraints / Notes

- Do NOT silence with `#[allow(unused_imports)]` — fix the cfg-gating so each import is only present when consumed.
- Reasonable approaches: split the `use` statement into a shared import plus a `#[cfg(target_os = "macos")]`-gated import; or move the macOS-only imports into the macOS-only test functions; or refer to `crate::runtime::v2_host::test_support::*` symbols by full path inside the macOS-only tests.
- Do NOT change `crates/orbit-core/src/runtime/v2_host/test_support.rs` — the symbols there are correctly exported.
- After fixing, also confirm no other Linux-only clippy warnings surface in the same run (the `-D warnings` build aborts on the first error, so additional warnings may have been masked).
- Validate on Linux: easiest path is `cargo clippy --workspace --all-targets --target x86_64-unknown-linux-gnu -- -D warnings` if that target's std is installed locally; otherwise rely on CI re-run.

### Acceptance Criteria

- On macOS: `./scripts/ci-guardrails.sh` exits 0 (covers fmt --check, clippy -D warnings, full workspace test, and the dependency-direction / cli-imports scripts).
- On a non-macOS target: `cargo clippy --workspace --all-targets -- -D warnings` exits 0. Verifiable either by running on a Linux host/container, by `--target x86_64-unknown-linux-gnu` if the cross-target stdlib is installed, or by a re-run of the GitHub Actions ci-guardrails workflow showing a green check.
- `crates/orbit-core/src/runtime/v2_host/sandbox.rs` contains no `#[allow(unused_imports)]` attribute (greppable: `grep -n 'allow(unused_imports)' crates/orbit-core/src/runtime/v2_host/sandbox.rs` returns nothing).
- On macOS, `cargo test --workspace -p orbit-core` continues to compile and run the `resolve_executor_sandbox_*` tests in `sandbox.rs`, including the `#[cfg(target_os = "macos")]` ones; no test is removed or skipped as part of the fix.
- The diff is limited to `crates/orbit-core/src/runtime/v2_host/sandbox.rs`. Changes to `test_support.rs`, `Cargo.toml` lints, or other modules are out of scope unless required to satisfy the clippy gate.
- If additional Linux-only clippy warnings surface after fixing the unused-import error (because `-D warnings` previously aborted on the first), they are also resolved within this task; the final ci-guardrails run is fully green.

## Execution Summary

<details>
<summary>Click to expand</summary>

## Status
success

## Summary of Changes
Split the sandbox.rs test-support import so seeded_runtime_with_executor remains available on every target while runtime_with_workspace_layout and seed_executor are imported only for macOS tests. No #[allow(unused_imports)] was added.

## Overall Assessment
The scoped Linux cfg-skew clippy failure is fixed with a one-file diff limited to crates/orbit-core/src/runtime/v2_host/sandbox.rs.

## Validation
- ./scripts/ci-guardrails.sh passed on macOS.
- cargo clippy --workspace --all-targets --target x86_64-unknown-linux-gnu -- -D warnings passed using a temporary Linux Rust std sysroot plus Zig cross compiler, with OPENSSL_DIR pointed at the local OpenSSL install for build-script discovery.
- cargo test -p orbit-core runtime::v2_host::sandbox::tests passed and ran the macOS resolve_executor_sandbox_* tests.
- cargo test --workspace -p orbit-core -- --test-threads=1 passed. The default parallel form hit an unrelated pre-existing race in command::task::review::tests::non_model_labels_do_not_score_local_review_threads during two follow-up runs; the earlier full ci-guardrails run was green.
- grep -n 'allow(unused_imports)' crates/orbit-core/src/runtime/v2_host/sandbox.rs returned no matches.

## Design Weaknesses / Risks
- Default parallel orbit-core test execution can expose an unrelated review-thread test race. Severity: Low for this task; Mitigation: left out of scope to preserve the one-file diff constraint.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/T20260508-10-69fd62a0`
- Behind base: 0
- Ahead of base: 1

*authored by: claude-opus-4-7*