### PR TITLE
v2 cli backend: set subprocess cwd to resolved workspace_path

### DIFF
--- a/crates/orbit-common/src/types/activity_job/audit_envelope.rs
+++ b/crates/orbit-common/src/types/activity_job/audit_envelope.rs
@@ -156,6 +156,7 @@ pub enum V2AuditEventKind {
         argv_redacted: Vec<String>,
         stdin_blob_ref: Option<String>,
         model: Option<String>,
+        cwd: Option<String>,
         wall_clock_timeout_ms: u64,
     },
     /// §7.6 — CLI backend subprocess finished (either naturally or by

--- a/crates/orbit-engine/src/activity_job/cli_runner.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner.rs
@@ -23,6 +23,7 @@
 
 use std::collections::HashMap;
 use std::io::{BufRead, BufReader, Read, Write};
+use std::path::Path;
 use std::process::{Child, Command, Stdio};
 use std::sync::{Arc, Mutex};
 use std::thread;
@@ -43,6 +44,7 @@ use super::audit_writer::V2AuditWriter;
 use super::dispatcher::{
     DispatchError, DispatchInvocationTrace, DispatchOutcome, ResolvedSandbox, V2RuntimeHost,
 };
+use super::workspace::resolve_subprocess_cwd;
 
 /// Default wall-clock timeout when `AgentLoopSpec::wall_clock_timeout_seconds`
 /// is zero. Matches §7.6 guidance: CLI subprocesses must have a mandatory
@@ -74,7 +76,15 @@ pub fn run_cli_backend(
         tools: spec.tools.clone(),
     });
 
-    let envelope_json = cli_agent_envelope_json(host, spec, run_id, input)?;
+    let task_ctx = host.task_context_for_agent_input(input)?;
+    let tool_ctx = host.tool_context_for_activity(Some(run_id), fs_profile, None);
+    let subprocess_cwd =
+        resolve_subprocess_cwd(input, task_ctx.as_ref(), tool_ctx.workspace_root.as_deref())?;
+    let subprocess_cwd_string = subprocess_cwd
+        .as_ref()
+        .map(|path| path.display().to_string());
+
+    let envelope_json = cli_agent_envelope_json(spec, run_id, input, task_ctx.as_ref())?;
 
     let mut provider_config = host.provider_cli_config(&provider);
 
@@ -140,6 +150,7 @@ pub fn run_cli_backend(
         argv_redacted: argv_redacted.clone(),
         stdin_blob_ref: Some(stdin_blob_ref.clone()),
         model: model_redacted,
+        cwd: subprocess_cwd_string.clone(),
         wall_clock_timeout_ms: wall_clock_timeout.as_millis() as u64,
     });
 
@@ -152,11 +163,13 @@ pub fn run_cli_backend(
         &subprocess_args,
         &invocation.stdin,
         &child_env,
+        subprocess_cwd.as_deref(),
         wall_clock_timeout,
         SpawnTraceContext {
             provider: &provider,
             job_run_id: run_id,
             task_id: task_id_from_input(input),
+            cwd: subprocess_cwd_string.as_deref(),
         },
         sandbox.as_ref(),
     )
@@ -219,10 +232,10 @@ pub fn run_cli_backend(
 }
 
 fn cli_agent_envelope_json(
-    host: &dyn V2RuntimeHost,
     spec: &AgentLoopSpec,
     run_id: &str,
     input: &Value,
+    task_ctx: Option<&Value>,
 ) -> Result<Vec<u8>, DispatchError> {
     let mut envelope = serde_json::Map::new();
     envelope.insert("schemaVersion".to_string(), Value::from(1));
@@ -247,8 +260,8 @@ fn cli_agent_envelope_json(
             .map_err(|err| DispatchError::CliInvocationFailed(format!("serialize model: {err}")))?,
     );
 
-    if let Some(task) = host.task_context_for_agent_input(input)? {
-        envelope.insert("task".to_string(), task);
+    if let Some(task) = task_ctx {
+        envelope.insert("task".to_string(), task.clone());
     }
 
     serde_json::to_vec(&Value::Object(envelope))
@@ -432,13 +445,14 @@ fn spawn_child_with_optional_sandbox(
     program: &str,
     args: &[String],
     env: &[(String, String)],
+    cwd: Option<&Path>,
     sandbox: Option<&ResolvedSandbox>,
 ) -> Result<SpawnedChild, OrbitError> {
     match sandbox {
         Some(sb) if sb.kind == ExecutorSandboxKind::MacosSandboxExec => {
-            spawn_macos_sandboxed(program, args, env, sb)
+            spawn_macos_sandboxed(program, args, env, cwd, sb)
         }
-        Some(_) | None => spawn_bare(program, args, env),
+        Some(_) | None => spawn_bare(program, args, env, cwd),
     }
 }
 
@@ -446,13 +460,19 @@ fn spawn_bare(
     program: &str,
     args: &[String],
     env: &[(String, String)],
+    cwd: Option<&Path>,
 ) -> Result<SpawnedChild, OrbitError> {
-    let child = Command::new(program)
+    let mut command = Command::new(program);
+    command
         .args(args)
         .envs(env.iter().map(|(key, value)| (key, value)))
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
+        .stderr(Stdio::piped());
+    if let Some(path) = cwd {
+        command.current_dir(path);
+    }
+    let child = command
         .spawn()
         .map_err(|err| OrbitError::Execution(format!("failed to spawn `{program}`: {err}")))?;
     Ok(SpawnedChild {
@@ -465,9 +485,10 @@ fn spawn_macos_sandboxed(
     program: &str,
     args: &[String],
     env: &[(String, String)],
+    cwd: Option<&Path>,
     sandbox: &ResolvedSandbox,
 ) -> Result<SpawnedChild, OrbitError> {
-    spawn_macos_sandboxed_with(program, args, env, sandbox, sandbox_exec_available())
+    spawn_macos_sandboxed_with(program, args, env, cwd, sandbox, sandbox_exec_available())
 }
 
 /// Test-friendly variant of [`spawn_macos_sandboxed`]: callers pass an
@@ -479,6 +500,7 @@ fn spawn_macos_sandboxed_with(
     program: &str,
     args: &[String],
     env: &[(String, String)],
+    cwd: Option<&Path>,
     sandbox: &ResolvedSandbox,
     sandbox_exec_present: bool,
 ) -> Result<SpawnedChild, OrbitError> {
@@ -489,7 +511,7 @@ fn spawn_macos_sandboxed_with(
                 program = program,
                 "sandbox-exec not available on PATH; falling back to bare exec because executor declares allow_fallback"
             );
-            return spawn_bare(program, args, env);
+            return spawn_bare(program, args, env, cwd);
         }
         return Err(OrbitError::Execution(
             "sandbox-exec not available on PATH; declare allow_fallback: true to permit bare exec"
@@ -507,6 +529,7 @@ fn spawn_macos_sandboxed_with(
         program,
         args,
         env,
+        cwd,
         Stdio::piped(),
         Stdio::piped(),
         Stdio::piped(),
@@ -521,6 +544,7 @@ struct SpawnTraceContext<'a> {
     provider: &'a str,
     job_run_id: &'a str,
     task_id: Option<&'a str>,
+    cwd: Option<&'a str>,
 }
 
 fn spawn_with_timeout(
@@ -528,6 +552,7 @@ fn spawn_with_timeout(
     args: &[String],
     stdin_bytes: &[u8],
     env: &[(String, String)],
+    cwd: Option<&Path>,
     timeout: Duration,
     trace: SpawnTraceContext<'_>,
     sandbox: Option<&ResolvedSandbox>,
@@ -537,7 +562,7 @@ fn spawn_with_timeout(
         mut child,
         // The temp profile must outlive the child — drop it after wait.
         _profile_temp,
-    } = spawn_child_with_optional_sandbox(program, args, env, sandbox)
+    } = spawn_child_with_optional_sandbox(program, args, env, cwd, sandbox)
         .map_err(|err| format!("spawn {program}: {err}"))?;
 
     if let Some(mut stdin) = child.stdin.take() {
@@ -559,6 +584,7 @@ fn spawn_with_timeout(
             "stdout",
             trace.job_run_id.to_string(),
             trace.task_id.map(ToString::to_string),
+            trace.cwd.map(ToString::to_string),
             dispatch.clone(),
         )
     });
@@ -570,6 +596,7 @@ fn spawn_with_timeout(
             "stderr",
             trace.job_run_id.to_string(),
             trace.task_id.map(ToString::to_string),
+            trace.cwd.map(ToString::to_string),
             dispatch,
         )
     });
@@ -622,6 +649,7 @@ fn spawn_output_reader<R>(
     stream: &'static str,
     job_run_id: String,
     task_id: Option<String>,
+    cwd: Option<String>,
     dispatch: tracing::Dispatch,
 ) -> thread::JoinHandle<()>
 where
@@ -644,6 +672,7 @@ where
                             stream,
                             &job_run_id,
                             task_id.as_deref(),
+                            cwd.as_deref(),
                             &raw_line,
                         );
                     }
@@ -659,16 +688,28 @@ fn emit_output_line(
     stream: &str,
     job_run_id: &str,
     task_id: Option<&str>,
+    cwd: Option<&str>,
     raw_line: &[u8],
 ) {
     let line = line_text(raw_line);
-    tracing::info!(
-        provider = provider,
-        stream = stream,
-        job_run_id = job_run_id,
-        task_id = task_id,
-        line = line.as_str()
-    );
+    if let Some(cwd) = cwd {
+        tracing::info!(
+            provider = provider,
+            stream = stream,
+            job_run_id = job_run_id,
+            task_id = task_id,
+            cwd = cwd,
+            line = line.as_str()
+        );
+    } else {
+        tracing::info!(
+            provider = provider,
+            stream = stream,
+            job_run_id = job_run_id,
+            task_id = task_id,
+            line = line.as_str()
+        );
+    }
 }
 
 fn line_text(raw_line: &[u8]) -> String {
@@ -735,11 +776,13 @@ mod tests {
                 &args,
                 b"",
                 &[],
+                None,
                 Duration::from_secs(5),
                 SpawnTraceContext {
                     provider: "codex",
                     job_run_id: "job-123",
                     task_id: Some("T123"),
+                    cwd: None,
                 },
                 None,
             )
@@ -761,6 +804,38 @@ mod tests {
             assert_eq!(event.field("task_id"), Some("T123"));
             assert!(event.fields.contains_key("stream"));
             assert!(event.fields.contains_key("line"));
+            assert!(!event.fields.contains_key("cwd"));
+        }
+
+        let cwd = tempdir().expect("cwd tempdir");
+        let cwd_path = cwd.path().canonicalize().expect("canonical cwd");
+        let cwd_string = cwd_path.display().to_string();
+        let (result, events) = capture_events(|| {
+            spawn_with_timeout(
+                "/bin/sh",
+                &args,
+                b"",
+                &[],
+                Some(&cwd_path),
+                Duration::from_secs(5),
+                SpawnTraceContext {
+                    provider: "codex",
+                    job_run_id: "job-456",
+                    task_id: Some("T456"),
+                    cwd: Some(cwd_string.as_str()),
+                },
+                None,
+            )
+        });
+        let (stdout, stderr, exit_code, _duration, timed_out) = result.expect("spawn succeeds");
+
+        assert_eq!(stdout, b"out-one\nout-two\n");
+        assert_eq!(stderr, b"err-one\n");
+        assert_eq!(exit_code, Some(0));
+        assert!(!timed_out);
+        assert_eq!(events.len(), 3);
+        for event in &events {
+            assert_eq!(event.field("cwd"), Some(cwd_string.as_str()));
         }
     }
 
@@ -773,11 +848,13 @@ mod tests {
                 &args,
                 b"",
                 &[],
+                None,
                 Duration::from_secs(5),
                 SpawnTraceContext {
                     provider: "codex",
                     job_run_id: "job-redact",
                     task_id: Some("TRED"),
+                    cwd: None,
                 },
                 None,
             )
@@ -792,6 +869,23 @@ mod tests {
         assert!(
             !formatted_output.contains("abc123"),
             "formatted tracing output leaked secret: {formatted_output}"
+        );
+    }
+
+    #[test]
+    fn spawn_bare_runs_program_in_provided_cwd() {
+        let temp = tempdir().expect("tempdir");
+        let cwd = temp.path().canonicalize().expect("canonical tempdir");
+        let SpawnedChild {
+            child,
+            _profile_temp,
+        } = spawn_bare("/bin/sh", &sh_args("pwd"), &[], Some(&cwd)).expect("spawn succeeds");
+
+        let output = child.wait_with_output().expect("wait succeeds");
+        assert!(output.status.success());
+        assert_eq!(
+            String::from_utf8(output.stdout).expect("stdout utf8"),
+            format!("{}\n", cwd.display())
         );
     }
 
@@ -852,6 +946,114 @@ mod tests {
         assert!(!finished.4);
         assert_eq!(sink.blob("blob-2"), Some(b"plain stdout\n".to_vec()));
         assert_eq!(sink.blob("blob-3"), Some(b"plain stderr\n".to_vec()));
+    }
+
+    #[test]
+    fn run_cli_backend_returns_error_when_declared_workspace_path_missing() {
+        let temp = tempdir().expect("tempdir");
+        let script = temp.path().join("codex");
+        write_executable(
+            &script,
+            "#!/bin/sh\ncat > /dev/null\nprintf '%s\\n' '{\"status\":\"ok\"}'\n",
+        );
+        let missing = temp.path().join("missing-worktree");
+
+        let sink = Arc::new(RecordingSink::default());
+        let sink_for_writer: Arc<dyn AuditSink> = sink;
+        let audit = Arc::new(V2AuditWriter::new(
+            "job-missing-cwd",
+            "codex:gpt-5.5",
+            sink_for_writer,
+        ));
+        let host = TestHost {
+            command: script.display().to_string(),
+            executor_args: Vec::new(),
+            provider_config: HashMap::new(),
+            sandbox: None,
+            task_context: Some(serde_json::json!({
+                "workspace_path": missing.display().to_string()
+            })),
+        };
+        let spec = test_agent_loop_spec(Duration::from_secs(5));
+        let input = serde_json::json!({
+            "prompt": "do it",
+            "task_id": "TMISSING"
+        });
+
+        let err = run_cli_backend(&host, &spec, "job-missing-cwd", audit.clone(), &input, None)
+            .expect_err("missing declared workspace should fail");
+        match err {
+            DispatchError::CliInvocationFailed(message) => {
+                assert!(
+                    message.contains(&missing.display().to_string()),
+                    "error should name missing path: {message}"
+                );
+            }
+            other => panic!("expected CliInvocationFailed, got {other:?}"),
+        }
+
+        let events = audit.events_snapshot().expect("events snapshot");
+        assert!(
+            !events
+                .iter()
+                .any(|event| matches!(&event.kind, V2AuditEventKind::CliInvocationStarted { .. })),
+            "CliInvocationStarted should not be emitted before cwd validation succeeds"
+        );
+    }
+
+    #[test]
+    fn run_cli_backend_records_resolved_cwd_in_started_event() {
+        let temp = tempdir().expect("tempdir");
+        let script = temp.path().join("codex");
+        write_executable(
+            &script,
+            "#!/bin/sh\ncat > /dev/null\nprintf '%s\\n' '{\"status\":\"ok\"}'\n",
+        );
+        let workspace_dir = tempdir().expect("workspace tempdir");
+        let workspace = workspace_dir
+            .path()
+            .canonicalize()
+            .expect("canonical workspace");
+        let workspace_string = workspace.display().to_string();
+
+        let sink = Arc::new(RecordingSink::default());
+        let sink_for_writer: Arc<dyn AuditSink> = sink;
+        let audit = Arc::new(V2AuditWriter::new(
+            "job-cwd-audit",
+            "codex:gpt-5.5",
+            sink_for_writer,
+        ));
+        let host = TestHost {
+            command: script.display().to_string(),
+            executor_args: Vec::new(),
+            provider_config: HashMap::new(),
+            sandbox: None,
+            task_context: Some(serde_json::json!({
+                "workspace_path": workspace_string.clone()
+            })),
+        };
+        let spec = test_agent_loop_spec(Duration::from_secs(5));
+
+        let outcome = run_cli_backend(
+            &host,
+            &spec,
+            "job-cwd-audit",
+            audit.clone(),
+            &serde_json::json!({ "prompt": "do it", "task_id": "TCWD" }),
+            None,
+        )
+        .expect("run succeeds");
+        assert!(outcome.success);
+
+        let events = audit.events_snapshot().expect("events snapshot");
+        let cwd = events
+            .iter()
+            .find_map(|event| match &event.kind {
+                V2AuditEventKind::CliInvocationStarted { cwd, .. } => cwd.as_deref(),
+                _ => None,
+            })
+            .expect("cli.invocation.started cwd");
+        assert_eq!(cwd, workspace_string);
     }
 
     #[test]
@@ -942,8 +1144,9 @@ mod tests {
             "workspace_path": "/tmp/orbit-worktree"
         });
 
-        let raw = cli_agent_envelope_json(&host, &spec, "jrun-context", &input)
-            .expect("build cli agent envelope");
+        let raw =
+            cli_agent_envelope_json(&spec, "jrun-context", &input, host.task_context.as_ref())
+                .expect("build cli agent envelope");
         let envelope: Value = serde_json::from_slice(&raw).expect("parse envelope json");
 
         assert_eq!(envelope["schemaVersion"], 1);
@@ -964,11 +1167,13 @@ mod tests {
                 &args,
                 b"",
                 &[],
+                None,
                 Duration::from_millis(75),
                 SpawnTraceContext {
                     provider: "codex",
                     job_run_id: "job-timeout",
                     task_id: Some("TTIME"),
+                    cwd: None,
                 },
                 None,
             )
@@ -1161,7 +1366,7 @@ mod tests {
     #[test]
     fn spawn_macos_sandboxed_returns_error_when_sandbox_exec_missing_and_fallback_disabled() {
         let sandbox = sandbox_for_test();
-        let err = spawn_macos_sandboxed_with("/bin/sh", &[], &[], &sandbox, false)
+        let err = spawn_macos_sandboxed_with("/bin/sh", &[], &[], None, &sandbox, false)
             .expect_err("expected fallback-disabled error");
         match err {
             OrbitError::Execution(msg) => {
@@ -1184,6 +1389,7 @@ mod tests {
             "/bin/sh",
             &["-c".to_string(), "exit 0".to_string()],
             &[],
+            None,
             &sandbox,
             false,
         )

--- a/crates/orbit-engine/src/activity_job/groundhog.rs
+++ b/crates/orbit-engine/src/activity_job/groundhog.rs
@@ -17,6 +17,7 @@ use serde_json::{Value, json};
 use super::agent_loop_driver::drive_agent_loop_with_tool_context;
 use super::audit_writer::V2AuditWriter;
 use super::dispatcher::{DispatchError, DispatchOutcome, V2RuntimeHost, v2_fs_audit_logger};
+use super::workspace::resolve_subprocess_cwd;
 use crate::WorkspaceSnapshot;
 
 const CHRONICLE_ARTIFACT_PATH: &str = "artifacts.chronicle";
@@ -703,23 +704,15 @@ fn resolve_workspace_path(
     tool_ctx: &ToolContext,
     task_workspace_path: &Option<String>,
 ) -> Result<PathBuf, DispatchError> {
-    let selected = input
-        .get("workspace_path")
-        .and_then(Value::as_str)
-        .map(ToString::to_string)
-        .or_else(|| task_workspace_path.clone())
-        .or_else(|| {
-            tool_ctx
-                .workspace_root
-                .as_ref()
-                .map(|path| path.to_string_lossy().into_owned())
-        })
+    let task_ctx = task_workspace_path
+        .as_ref()
+        .map(|workspace_path| json!({ "workspace_path": workspace_path }));
+    resolve_subprocess_cwd(input, task_ctx.as_ref(), tool_ctx.workspace_root.as_deref())?
         .ok_or_else(|| {
             DispatchError::GroundhogFailed(
                 "groundhog activity requires a workspace path or workspace_root".to_string(),
             )
-        })?;
-    Ok(PathBuf::from(selected))
+        })
 }
 
 fn required_input_string(input: &Value, key: &str) -> Result<String, DispatchError> {

--- a/crates/orbit-engine/src/activity_job/mod.rs
+++ b/crates/orbit-engine/src/activity_job/mod.rs
@@ -14,6 +14,7 @@ pub mod job_executor;
 pub mod jsonl_sink;
 pub mod orbit_tool_executor;
 pub mod tool_enforcement;
+pub mod workspace;
 
 pub use agent_loop_driver::{
     drive_agent_loop, drive_agent_loop_with_session, drive_agent_loop_with_tool_context,
@@ -32,3 +33,4 @@ pub use job_executor::{
 pub use jsonl_sink::V2JsonlSink;
 pub use orbit_tool_executor::OrbitToolCallExecutor;
 pub use tool_enforcement::{EnforcedAuditSink, EnforcementDecision};
+pub use workspace::resolve_subprocess_cwd;

--- a/crates/orbit-engine/src/activity_job/workspace.rs
+++ b/crates/orbit-engine/src/activity_job/workspace.rs
@@ -1,0 +1,144 @@
+use std::path::{Path, PathBuf};
+
+use serde_json::Value;
+
+use super::dispatcher::DispatchError;
+
+pub fn resolve_subprocess_cwd(
+    input: &Value,
+    task_ctx: Option<&Value>,
+    tool_ctx_workspace_root: Option<&Path>,
+) -> Result<Option<PathBuf>, DispatchError> {
+    if let Some(path) = input.get("workspace_path").and_then(Value::as_str) {
+        return validate_declared_workspace_path(path);
+    }
+
+    if let Some(path) = task_ctx
+        .and_then(|task| task.get("workspace_path"))
+        .and_then(Value::as_str)
+    {
+        return validate_declared_workspace_path(path);
+    }
+
+    let Some(path) = tool_ctx_workspace_root else {
+        return Ok(None);
+    };
+
+    if path.is_dir() {
+        return Ok(Some(canonicalize_dir(path)));
+    }
+
+    tracing::warn!(
+        target: "orbit.engine.cli_runner",
+        path = %path.display(),
+        "tool_ctx workspace_root missing, child will inherit parent cwd"
+    );
+    Ok(None)
+}
+
+fn validate_declared_workspace_path(path: &str) -> Result<Option<PathBuf>, DispatchError> {
+    let path_buf = PathBuf::from(path);
+    if path.trim().is_empty() || !path_buf.is_dir() {
+        return Err(DispatchError::CliInvocationFailed(format!(
+            "workspace path {} is not a writable directory",
+            path_buf.display()
+        )));
+    }
+    Ok(Some(canonicalize_dir(&path_buf)))
+}
+
+fn canonicalize_dir(path: &Path) -> PathBuf {
+    path.canonicalize().unwrap_or_else(|_| path.to_path_buf())
+}
+
+#[cfg(test)]
+mod tests {
+    use tempfile::tempdir;
+
+    use super::*;
+
+    #[test]
+    fn resolve_subprocess_cwd_prefers_input_over_task_over_tool_ctx() {
+        let input_dir = tempdir().expect("input tempdir");
+        let task_dir = tempdir().expect("task tempdir");
+        let tool_dir = tempdir().expect("tool tempdir");
+
+        let input = serde_json::json!({
+            "workspace_path": input_dir.path().display().to_string()
+        });
+        let task_ctx = serde_json::json!({
+            "workspace_path": task_dir.path().display().to_string()
+        });
+        let resolved = resolve_subprocess_cwd(&input, Some(&task_ctx), Some(tool_dir.path()))
+            .expect("input cwd resolves");
+        assert_eq!(
+            resolved,
+            Some(
+                input_dir
+                    .path()
+                    .canonicalize()
+                    .expect("canonical input dir")
+            )
+        );
+
+        let input = serde_json::json!({});
+        let resolved = resolve_subprocess_cwd(&input, Some(&task_ctx), Some(tool_dir.path()))
+            .expect("task cwd resolves");
+        assert_eq!(
+            resolved,
+            Some(task_dir.path().canonicalize().expect("canonical task dir"))
+        );
+
+        let resolved =
+            resolve_subprocess_cwd(&input, None, Some(tool_dir.path())).expect("tool cwd resolves");
+        assert_eq!(
+            resolved,
+            Some(tool_dir.path().canonicalize().expect("canonical tool dir"))
+        );
+
+        let resolved = resolve_subprocess_cwd(&input, None, None).expect("no cwd resolves");
+        assert_eq!(resolved, None);
+    }
+
+    #[test]
+    fn resolve_subprocess_cwd_rejects_declared_missing_path() {
+        let temp = tempdir().expect("tempdir");
+        let missing = temp.path().join("missing-worktree");
+        let input = serde_json::json!({
+            "workspace_path": missing.display().to_string()
+        });
+
+        let err = resolve_subprocess_cwd(&input, None, None).expect_err("missing path rejected");
+        match err {
+            DispatchError::CliInvocationFailed(message) => {
+                assert!(
+                    message.contains(&missing.display().to_string()),
+                    "message should name missing path: {message}"
+                );
+            }
+            other => panic!("expected CliInvocationFailed, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn resolve_subprocess_cwd_rejects_declared_file_not_dir() {
+        let temp = tempdir().expect("tempdir");
+        let file = temp.path().join("not-a-dir");
+        std::fs::write(&file, b"not a directory").expect("write file");
+        let task_ctx = serde_json::json!({
+            "workspace_path": file.display().to_string()
+        });
+
+        let err = resolve_subprocess_cwd(&serde_json::json!({}), Some(&task_ctx), None)
+            .expect_err("file path rejected");
+        match err {
+            DispatchError::CliInvocationFailed(message) => {
+                assert!(
+                    message.contains(&file.display().to_string()),
+                    "message should name file path: {message}"
+                );
+            }
+            other => panic!("expected CliInvocationFailed, got {other:?}"),
+        }
+    }
+}

--- a/crates/orbit-exec/src/macos_sandbox.rs
+++ b/crates/orbit-exec/src/macos_sandbox.rs
@@ -229,6 +229,8 @@ fn non_empty_env_path(value: Option<&OsStr>) -> Option<PathBuf> {
 /// [`Child`] paired with a [`NamedTempFile`] holding the compiled profile;
 /// the caller must keep the `NamedTempFile` alive until the child exits, or
 /// the kernel may lose the profile mid-run.
+/// When `cwd` is set, it is applied to the outer `sandbox-exec` wrapper and
+/// inherited by the wrapped child.
 ///
 /// `process_group(0)` is set on Unix so the supervision layer can reap the
 /// whole tree (matching the `orbit-exec::process::spawn` contract).
@@ -237,6 +239,7 @@ pub fn spawn_under_macos_sandbox(
     program: &str,
     args: &[String],
     env: &[(String, String)],
+    cwd: Option<&Path>,
     stdin: Stdio,
     stdout: Stdio,
     stderr: Stdio,
@@ -270,6 +273,9 @@ pub fn spawn_under_macos_sandbox(
         .stdin(stdin)
         .stdout(stdout)
         .stderr(stderr);
+    if let Some(path) = cwd {
+        command.current_dir(path);
+    }
 
     #[cfg(unix)]
     {
@@ -708,6 +714,44 @@ mod tests {
         let dir = tempfile::tempdir().expect("tempdir");
         let path_var = std::ffi::OsString::from(dir.path().display().to_string());
         assert!(!sandbox_exec_available_in(&path_var));
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn spawn_under_macos_sandbox_runs_program_in_provided_cwd() {
+        if !sandbox_exec_can_apply() {
+            return;
+        }
+
+        let parent = sandbox_test_parent("cwd");
+        let _cleanup = ScopeGuard(parent.clone());
+        let dir = tempfile::Builder::new()
+            .prefix("sandbox-cwd-")
+            .tempdir_in(&parent)
+            .expect("cwd tempdir");
+        let cwd = dir.path().canonicalize().expect("canonical cwd");
+        let (child, _profile_file) = spawn_under_macos_sandbox(
+            "(version 1)\n(allow default)\n",
+            "/bin/sh",
+            &["-c".to_string(), "pwd".to_string()],
+            &[],
+            Some(&cwd),
+            Stdio::null(),
+            Stdio::piped(),
+            Stdio::piped(),
+        )
+        .expect("spawn sandboxed child");
+        let output = child.wait_with_output().expect("wait for child");
+
+        assert!(
+            output.status.success(),
+            "sandboxed pwd should succeed; stderr={}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        assert_eq!(
+            String::from_utf8(output.stdout).expect("stdout utf8"),
+            format!("{}\n", cwd.display())
+        );
     }
 
     #[cfg(target_os = "macos")]

--- a/docs/design/activity-job/2_design.md
+++ b/docs/design/activity-job/2_design.md
@@ -2,7 +2,7 @@
 
 **Status:** Draft
 **Owner:** codex
-**Last updated:** 2026-05-08 (T20260427-34, T20260427-36, T20260427-38, T20260427-40, T20260508-3)
+**Last updated:** 2026-05-08 (T20260427-34, T20260427-36, T20260427-38, T20260427-40, T20260508-3, T20260508-8)
 
 This document describes the shipped Activity / Job substrate across `orbit-common`, `orbit-engine`, `orbit-core`, and `orbit-cli`: asset shape, normalization, dispatch boundaries, backend semantics, DAG execution, audit, and retained legacy edges. See [1_overview.md](./1_overview.md) for purpose and [3_vision.md](./3_vision.md) for open questions.
 
@@ -204,12 +204,13 @@ The CLI path is driven by `cli_runner.rs`, added in [T20260419-0104]. The flow i
 2. Build an `Agent` from `orbit-agent`.
 3. Ask the retained CLI runtime for an `AgentInvocationSpec` containing provider-specific per-request args.
 4. Emit the advisory `ToolAllowlistHarnessDelegated` event.
-5. Emit `CliInvocationStarted` with redacted argv and stdin blob ref.
-6. Spawn the subprocess with a wall-clock timeout.
-7. Emit `CliInvocationFinished` with stdout/stderr blob refs and timeout state.
-8. Parse the captured provider output with the existing Orbit response parser and persist its `InvocationTrace` through the host.
+5. Resolve the subprocess cwd from runtime-owned workspace context.
+6. Emit `CliInvocationStarted` with redacted argv, stdin blob ref, and resolved cwd.
+7. Spawn the subprocess in that cwd with a wall-clock timeout.
+8. Emit `CliInvocationFinished` with stdout/stderr blob refs and timeout state.
+9. Parse the captured provider output with the existing Orbit response parser and persist its `InvocationTrace` through the host.
 
-After [T20260426-2313], stdout/stderr readers emit line-level `tracing::info!` events while the child runs, carrying `provider`, `stream`, `job_run_id`, `task_id`, and `line`. After [T20260426-2349], the default tracing subscriber redacts formatted output. The readers still retain original bytes for the existing audit/blob path, so run logs follow blob refs rather than the live feed.
+After [T20260426-2313], stdout/stderr readers emit line-level `tracing::info!` events while the child runs, carrying `provider`, `stream`, `job_run_id`, `task_id`, and `line`. After [T20260508-8], those events also carry `cwd` when the CLI subprocess has a resolved cwd. After [T20260426-2349], the default tracing subscriber redacts formatted output. The readers still retain original bytes for the existing audit/blob path, so run logs follow blob refs rather than the live feed.
 
 Executor args are prepended before provider runtime args. For seeded Codex, the subprocess starts as `codex exec --json ...`, not the interactive TUI. [T20260423-0114] exposed the earlier command-only boundary.
 
@@ -217,7 +218,7 @@ After [T20260427-48], provider runtime args receive provider config through `V2R
 
 After [T20260427-51], macOS CLI invocations declaring `sandbox: macos-sandbox-exec` run under `sandbox-exec -f <profile.sb> <provider> ...`. Orbit treats that SBPL profile as filesystem authority and neutralizes provider-native sandbox flags. After [T20260428-10], the profile grants Codex state (`$CODEX_HOME` or `$HOME/.codex`) plus side-write roots from provider config so inherited Orbit subprocesses can persist workflow state while project writes remain governed by `fsProfile`. After [T20260505-22], dispatch also runs `apply_provider_static_arg_fixups` before spawn, separately from sandbox neutralization. Today this only rewrites Claude's `--debug-file` value to `<claude_state_dir>/<basename>` so the log lands inside the already-writable state dir instead of `.orbit/**`, which the default policy denies.
 
-After [T20260430-15], the CLI stdin envelope carries rendered activity input and durable `run_id` beside instruction, prompt, tools, and model. When input identifies one task, orbit-core embeds a canonical task snapshot with `input.workspace_path` / `input.repo_root` taking precedence over stored paths. After [T20260505-10], Orbit-managed CLI subprocesses receive `ORBIT_RUN_ID` plus an Orbit-managed run-context marker; `orbit tool run` requires both before it populates `ToolContext` reservation ownership. Direct manual CLI tool calls, including calls with only `ORBIT_RUN_ID`, remain unowned.
+After [T20260430-15], the CLI stdin envelope carries rendered activity input and durable `run_id` beside instruction, prompt, tools, and model. When input identifies one task, orbit-core embeds a canonical task snapshot with `input.workspace_path` / `input.repo_root` taking precedence over stored paths. After [T20260508-8], `backend: cli` also uses a shared workspace resolver for subprocess cwd: `input.workspace_path`, then `task.workspace_path`, then best-effort `ToolContext.workspace_root`. Declared input/task paths must already be directories; stale worktrees fail as `CliInvocationFailed` before `CliInvocationStarted` is emitted. `groundhog` delegates to the same resolver so task execution and attempt orchestration do not drift. After [T20260505-10], Orbit-managed CLI subprocesses receive `ORBIT_RUN_ID` plus an Orbit-managed run-context marker; `orbit tool run` requires both before it populates `ToolContext` reservation ownership. Direct manual CLI tool calls, including calls with only `ORBIT_RUN_ID`, remain unowned.
 
 The older `AgentRuntime` trait and `providers/*_cli.rs` files are not deprecated leftovers; they are the shipped `backend: cli` implementation.
 
@@ -483,5 +484,6 @@ Read-only history does not need the same dependencies as live execution. [T20260
 - **[T20260505-10]** — Release run-owned task lock reservations through engine-owned terminal cleanup and reserve-pressure reconciliation.
 - **[T20260505-21]** — Add whole-run replay with `retry_source_run_id` lineage and current-definition semantics.
 - **[T20260506-2]** — Lazily materialize loop audit JSONL files only when loop-level events are emitted.
+- **[T20260508-8]** — Resolve backend: cli subprocess cwd from workspace context and record it in audit/tracing.
 
 > Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.

--- a/docs/design/activity-job/4_decisions.md
+++ b/docs/design/activity-job/4_decisions.md
@@ -2,7 +2,7 @@
 
 **Status:** Draft
 **Owner:** codex
-**Last updated:** 2026-05-08 (T20260427-34, T20260427-36, T20260427-38, T20260427-40, T20260508-3)
+**Last updated:** 2026-05-08 (T20260427-34, T20260427-36, T20260427-38, T20260427-40, T20260508-3, T20260508-8)
 
 This ADR log records the decisions that define the current Activity / Job substrate. Entries are append-only and stay in place when later ADRs supersede or fold them. See [1_overview.md](./1_overview.md) for the feature summary, [2_design.md](./2_design.md) for the current implementation, and [3_vision.md](./3_vision.md) for the questions that may force more decisions.
 
@@ -424,6 +424,19 @@ Folded into ADR-002's rollup for explicit agent dispatch boundaries.
 - Audit lineage moves from agent tool calls to deterministic `ActivityStarted` / `ActivityFinished` envelopes for the join step; the child relationship remains reconstructable from `dispatched_run_ids` and run-step state.
 - If `pipeline_wait` times out while a child is still running, the next deterministic `load_epic` snapshot still shows open work. Redundant redispatch is bounded by the gate pipeline's task-lock reservation: overlapping context files are denied while the child reservation is active, and TTL remains the abandoned-run fallback.
 
+## ADR-045 — CLI subprocess cwd is runtime-owned workspace state
+
+**Status:** Accepted · 2026-05 · [T20260508-8]
+
+**Context.** Per-run worktrees are supposed to isolate task implementation, but `backend: cli` children previously inherited the pipeline worker cwd and only learned the intended workspace through prompt/input data.
+
+**Decision.** Resolve CLI subprocess cwd before spawn from `input.workspace_path`, then task snapshot `workspace_path`, then best-effort `ToolContext.workspace_root`. Declared input/task paths fail fast if stale, and the selected cwd is recorded in the CLI started audit event plus line-level tracing.
+
+**Consequences.**
+- The runtime, not the prompt, controls where relative paths in provider CLIs resolve.
+- Groundhog and CLI dispatch share one workspace resolver, reducing future drift between orchestration and implementation attempts.
+- Cost: stale declared worktrees now fail before spawn instead of silently running from the parent process directory.
+
 ---
 
 ## Task References
@@ -483,5 +496,6 @@ Folded into ADR-002's rollup for explicit agent dispatch boundaries.
 - **[T20260506-17]** — Make `orbit init` recommend Codex for reviewer and implementer when available.
 - **[T20260506-18]** — Compact activity-job ADRs via rollups.
 - **[T20260508-3]** — Revise generated task PR bodies around the one-task-per-PR workflow.
+- **[T20260508-8]** — Resolve backend: cli subprocess cwd from workspace context and record it in audit/tracing.
 
 > Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.

--- a/docs/design/activity-job/specs/audit-envelope.md
+++ b/docs/design/activity-job/specs/audit-envelope.md
@@ -34,6 +34,8 @@ Common event families are:
 - construct-level events for `parallel`, `fan_out`, and `loop`
 - policy/tool denial and CLI invocation events
 
+`cli.invocation.started` includes redacted argv, stdin blob ref, optional model, wall-clock timeout, and optional `cwd`. When present, `cwd` is the subprocess working directory selected by Activity/Job's workspace resolver.
+
 Loop-engine HTTP and tool-call events remain in the lower-level sink and are related to the envelope tree by parentage and shared run identity.
 
 ## Persistence Layout
@@ -66,6 +68,7 @@ The v2 writer may also keep an in-memory snapshot for smoke assertions and CLI s
 - Envelope writes are append-only, one JSON object per line.
 - Disk persistence failure should not crash the run by itself; the in-memory event stream is still load-bearing.
 - `workspace_path` is attached when the caller has a meaningful repo identity.
+- CLI invocation start events include `cwd` when the runtime selected a subprocess working directory.
 - Parent stacks propagate into worker threads so nested branch/worker events remain traversable.
 
 ## Failure Modes
@@ -82,4 +85,4 @@ The v2 writer may also keep an in-memory snapshot for smoke assertions and CLI s
 
 ## Agent Signature
 
-Last revised by `codex`.
+Last revised by `codex` for [T20260508-8].

--- a/docs/design/auditability/2_design.md
+++ b/docs/design/auditability/2_design.md
@@ -2,7 +2,7 @@
 
 **Status:** Draft
 **Owner:** codex
-**Last updated:** 2026-05-06 (T20260506-2)
+**Last updated:** 2026-05-08 (T20260506-2, T20260508-8)
 
 This document describes Orbit's shipped auditability implementation across command audit rows, activity/job envelopes, loop-level provider/tool traces, blob storage, redaction, identity attribution, metrics-adjacent invocation records, and known limitations. See [1_overview.md](./1_overview.md) for the feature purpose and [3_vision.md](./3_vision.md) for future questions.
 
@@ -53,7 +53,7 @@ After [T20260427-0023], selected canonical stores also project live tracing even
 
 ## 4. Activity/Job Envelope Events
 
-`V2AuditEnvelope` lives in `crates/orbit-common/src/types/activity_job/audit_envelope.rs`. Each envelope carries `schemaVersion`, `event_type`, `event_id`, timestamp, `run_id`, `agent_identity`, optional `parent_event_id`, optional `workspace_path`, and a tagged `V2AuditEventKind`. Event families cover run, step, retry, skip, denial, join, fan-out/fan-in, loop, activity, filesystem, tool denial, CLI-backend delegation, and subprocess lifecycle.
+`V2AuditEnvelope` lives in `crates/orbit-common/src/types/activity_job/audit_envelope.rs`. Each envelope carries `schemaVersion`, `event_type`, `event_id`, timestamp, `run_id`, `agent_identity`, optional `parent_event_id`, optional `workspace_path`, and a tagged `V2AuditEventKind`. Event families cover run, step, retry, skip, denial, join, fan-out/fan-in, loop, activity, filesystem, tool denial, CLI-backend delegation, and subprocess lifecycle. After [T20260508-8], `CliInvocationStarted` also records the resolved subprocess `cwd` when one is supplied by the Activity/Job workspace resolver.
 
 `V2AuditWriter` in `crates/orbit-engine/src/activity_job/audit_writer.rs` assigns event ids, maintains per-thread parent stacks, emits through `V2JsonlSink`, keeps a smoke-verification snapshot, and exposes the inner loop sink for provider/tool events. CLI-launched v2 runs stamp envelope `agent_identity` as `system`; concrete agent identity lives in activity configuration, CLI invocation events, and invocation metrics.
 
@@ -110,7 +110,7 @@ After [T20260427-43], the friction bounty scoreboard is refreshed from task hist
 
 `crates/orbit-common/src/utility/logging.rs` installs a default subscriber with one `EnvFilter`, stderr formatting, and an optional non-blocking JSONL file layer at `~/.orbit/state/logs/orbit.jsonl` after [T20260426-2343]. The retained `WorkerGuard` lets routine event emission avoid synchronous disk writes.
 
-Each record contains timestamp, level, target, and structured fields. After [T20260426-2349], both stderr and JSONL use `RedactingFields`, which scrubs string values, `Debug`-formatted values, and unstructured messages while preserving numeric and boolean JSON types. This global feed is the live landing zone for subprocess output [T20260426-2313], policy-denial and friction projections [T20260427-0023], and other `tracing` events emitted before workspace runtime context exists. It is operational telemetry, not the canonical workflow envelope.
+Each record contains timestamp, level, target, and structured fields. After [T20260426-2349], both stderr and JSONL use `RedactingFields`, which scrubs string values, `Debug`-formatted values, and unstructured messages while preserving numeric and boolean JSON types. This global feed is the live landing zone for subprocess output [T20260426-2313], policy-denial and friction projections [T20260427-0023], and other `tracing` events emitted before workspace runtime context exists. After [T20260508-8], CLI subprocess line events include `cwd` when Activity/Job resolved one, matching the audit-started event while omitting the field when the child inherits the parent cwd. It is operational telemetry, not the canonical workflow envelope.
 
 ---
 
@@ -149,5 +149,6 @@ Each record contains timestamp, level, target, and structured fields. After [T20
 - **[T20260430-20]** — Shorten the auditability docs while preserving required guarantees.
 - **[T20260505-6]** — Replace timestamp-only command-audit execution ids with collision-resistant generated ids for parallel tool runs.
 - **[T20260506-2]** — Lazily materialize loop audit JSONL files only when loop-level events are emitted.
+- **[T20260508-8]** — Record backend: cli subprocess cwd in v2 audit and live tracing.
 
 > Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.

--- a/docs/design/auditability/specs/event-schema.md
+++ b/docs/design/auditability/specs/event-schema.md
@@ -39,6 +39,7 @@ Required invariants:
 - Child events set `parent_event_id` when emitted under a parent context.
 - `workspace_path` remains optional; CLI/library callers with a real workspace should attach it, while smoke and stub hosts may omit it.
 - Body variants use the `body_kind` discriminator.
+- `cli.invocation.started` includes optional `cwd` when Activity/Job resolved a subprocess working directory.
 - A run starts with a run-start event and finishes with a run-finished event whenever execution reaches the dispatch wrapper.
 
 Failure modes:
@@ -82,4 +83,4 @@ Required invariants:
 
 ## Agent Signature
 
-Last revised by codex / gpt-5 for [T20260426-0605].
+Last revised by codex / gpt-5.5 for [T20260508-8].


### PR DESCRIPTION
## Task

[T20260508-8](T20260508-8) — v2 cli backend: set subprocess cwd to resolved workspace_path

### Description

## Problem

`run_cli_backend` in `crates/orbit-engine/src/activity_job/cli_runner.rs` spawns
the provider CLI without ever setting the subprocess working directory.

- `spawn_bare` (`cli_runner.rs:445`) builds `Command::new(program).args(...).envs(...).stdin/stdout/stderr(...).spawn()` — no `current_dir`.
- `spawn_under_macos_sandbox` (`crates/orbit-exec/src/macos_sandbox.rs:235`) builds the outer `sandbox-exec` `Command` the same way — no `current_dir`.

Result: `backend: cli` agent loops inherit the pipeline-worker cwd (repo root)
even when the activity is supposed to run inside an isolated worktree at
`.orbit/state/worktrees/orbit-jrun-…`. A polite agent recovers by reading
`input.workspace_path`; an inattentive one writes/validates against the wrong
tree. Surfaced by friction `T20260427-35` after a `task_pr_pipeline` run
(`jrun-20260427-0040`) where the Codex subprocess saw `pwd =
/Users/daniel/workspace/repos/orbit` instead of the intended jrun worktree.

## Why It Matters

The runtime — not the agent prompt — owns which checkout the CLI agent edits.
Right now an agent that ignores `input.workspace_path` can silently corrupt the
host repo or another worktree. That defeats the whole point of per-jrun
worktrees and makes pipeline failures hard to attribute. Activity-Job §3.1 / §7.6
intend the host to be the single source of truth for spawn parameters.

## Proposed Approach

1. Resolve a single `subprocess_cwd: Option<PathBuf>` inside `run_cli_backend`
   before any spawn, using this precedence:
   1. `input.workspace_path` (string)
   2. `task.workspace_path` (already returned by `host.task_context_for_agent_input`)
   3. `tool_ctx.workspace_root` from `host.tool_context_for_activity` (best-effort fallback)

   Mirrors the existing logic in `groundhog::resolve_workspace_path`
   (`groundhog.rs:701`). Promote that helper into a shared
   `activity_job::workspace::resolve_subprocess_cwd` so groundhog and the CLI
   runner share one source of truth.

2. Validate before spawn. If a workspace path is *declared* (case 1 or 2) but
   does not exist or is not a directory, return
   `DispatchError::CliInvocationFailed("workspace path … is not a writable
   directory")`. Case 3 is best-effort and only logged when missing — no spawn
   should occur with a stale declared worktree.

3. Plumb `cwd: Option<&Path>` through the spawn helpers:
   - `spawn_with_timeout` (`cli_runner.rs:526`) gains a `cwd` parameter.
   - `spawn_child_with_optional_sandbox` (`cli_runner.rs:431`) forwards it.
   - `spawn_bare` (`cli_runner.rs:445`) calls `.current_dir(path)` when `Some`.
   - `spawn_under_macos_sandbox` (`macos_sandbox.rs:235`) gains an optional
     `cwd` and applies it to the outer `sandbox-exec` `Command` —
     `sandbox-exec` is an exec wrapper, so the child inherits.

4. Surface cwd in audit + tracing:
   - Add a `cwd: Option<String>` field to `V2AuditEventKind::CliInvocationStarted`
     in `orbit-common::types::activity_job` and populate it from the resolved
     value.
   - Include `cwd` in the per-line `tracing::info!` context emitted by
     `emit_output_line` (`cli_runner.rs:657`) so jrun transcripts make the
     cwd auditable at a glance.

## Constraints / Notes

- Out of scope: the `http` (LoopTransport) backend (no fork; `input.workspace_path`
  is already the documented contract for those activities).
- Out of scope: aligning cwd with `FsProfile` write sets — `FsProfile` is the
  authoritative writability boundary; cwd just affects relative-path
  resolution. Conflating the two is a bigger design change.
- Out of scope: `orbit-exec::process::spawn` (the non-sandbox shell exec
  runner). The friction is specific to the CLI agent dispatch path.
- Behavior delta for green runs: activities that declare a `task.workspace_path`
  pointing at a stale or cleaned-up worktree will fail-fast rather than
  silently running at repo root. Desired outcome per the friction report.
- Touched crates: `orbit-engine` (cli_runner, dispatcher trait surface if
  needed), `orbit-exec` (macos_sandbox spawn signature), `orbit-common`
  (V2AuditEventKind variant — schema bump may be required, check audit
  consumers before merging).
- See parent friction: `T20260427-35`.

### Acceptance Criteria

- A new helper `resolve_subprocess_cwd(input: &serde_json::Value, task_ctx: Option<&serde_json::Value>, tool_ctx_workspace_root: Option<&std::path::Path>) -> Result<Option<std::path::PathBuf>, DispatchError>` exists in a shared `activity_job::workspace` module and returns the path using the documented precedence (`input.workspace_path` → `task.workspace_path` → `tool_ctx.workspace_root`).
- `groundhog::resolve_workspace_path` (`crates/orbit-engine/src/activity_job/groundhog.rs:701`) is rewritten to delegate to the shared helper, demonstrating both call sites use one source of truth (verified by inspection plus an existing groundhog test still passing).
- When `resolve_subprocess_cwd` returns a declared path (cases 1 or 2) that does not exist or is not a directory, `run_cli_backend` returns `Err(DispatchError::CliInvocationFailed)` with a message containing the offending path, and emits NO `V2AuditEventKind::CliInvocationStarted` event for that invocation. Test: `run_cli_backend_returns_error_when_declared_workspace_path_missing` with a tempdir-derived nonexistent path.
- `spawn_with_timeout`, `spawn_child_with_optional_sandbox`, and `spawn_bare` in `cli_runner.rs` all accept `cwd: Option<&std::path::Path>` and `spawn_bare` calls `.current_dir(path)` on the `Command` when `Some`. Test `spawn_bare_runs_program_in_provided_cwd` spawns `/bin/sh -c 'pwd'` with `cwd = tempdir.path()` and asserts stdout equals the canonicalized tempdir path followed by `\n`.
- `spawn_under_macos_sandbox` in `crates/orbit-exec/src/macos_sandbox.rs` accepts `cwd: Option<&std::path::Path>` and applies it to the outer `sandbox-exec` `Command`. Test (gated `#[cfg(target_os = "macos")]` and skipped via the existing `sandbox_exec_can_apply_for_test` helper when sandbox-exec cannot run) spawns `/bin/sh -c 'pwd'` under sandbox-exec with `cwd = tempdir.path()` and asserts stdout equals the canonicalized tempdir path.
- Resolution-precedence test `resolve_subprocess_cwd_prefers_input_over_task_over_tool_ctx` covers all three precedence cases plus the `None` case (no source available) using `serde_json::json!` literals and `tempfile::tempdir` for the existence check.
- `V2AuditEventKind::CliInvocationStarted` in `orbit-common::types::activity_job` gains an `Option<String> cwd` field. The audit envelope test `run_cli_backend_finished_audit_event_keeps_stdout_stderr_blob_refs` (or a new sibling test) asserts the `started` event records the resolved cwd as a string when one was used.
- The per-line tracing emitted by `emit_output_line` (`cli_runner.rs:657`) includes a `cwd` field whose value is the canonicalized resolved cwd string when `Some`, and is omitted (`None`) when the activity ran with no resolved cwd. Verified by extending `spawn_with_timeout_emits_structured_stdout_and_stderr_events` to assert the field on each captured event.
- `make build` succeeds.
- `make fmt` reports no diff after the change.

## Execution Summary

<details>
<summary>Click to expand</summary>

## Status
success

## Summary of Changes
- Added shared activity_job::workspace::resolve_subprocess_cwd with declared-path validation and precedence tests.
- Plumbed cwd through backend: cli spawning, macOS sandbox wrapping, audit started events, and per-line tracing.
- Updated Groundhog to use the shared resolver and refreshed Activity/Job plus Auditability docs for the cwd audit contract.

## Overall Assessment
Validated with targeted Rust tests, make build, and make fmt. Task remains in-progress for the pipeline to handle review transition.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/T20260508-8-69fd62a0`
- Behind base: 0
- Ahead of base: 1

*authored by: claude-opus-4-7*