### PR TITLE
Surface per-step agent logs and error diagnostics in dashboard

### DIFF
--- a/crates/orbit-cli/assets/dashboard/app.js
+++ b/crates/orbit-cli/assets/dashboard/app.js
@@ -35,7 +35,7 @@ let activeStatuses = new Set(
 );
 let lastTasks = [];
 let lastRuns = [];
-let lastDiagnostics = { metrics: [], friction: [] };
+let lastDiagnostics = { metrics: [], friction: [], errors: [] };
 let activeTab = "tasks";
 let activeDiagSubtab = "runs";
 let expandedTaskIds = new Set();
@@ -71,6 +71,7 @@ let lastSummary = null;
 let activeRunId = null;
 let activeRunDetail = null;
 let activeRunEvents = [];
+let activeRunLogs = [];
 let activeRunSubtab = "steps";
 let expandedStepIndices = new Set();
 
@@ -875,7 +876,7 @@ function wireSearch() {
 }
 
 const TABS = ["tasks", "scoreboard", "audit", "diagnostics", "run-detail"];
-const DIAG_SUBTABS = ["runs", "metrics", "friction"];
+const DIAG_SUBTABS = ["runs", "metrics", "friction", "errors"];
 const RUN_DETAIL_SUBTABS = ["steps", "events"];
 const AUDIT_SUBTABS = ["events", "policy"];
 
@@ -895,7 +896,16 @@ function setActiveTab(raw, opts = {}) {
   let top;
   if (head === "runs" && segments[1]) {
     top = "run-detail";
-    activeRunId = decodeURIComponent(segments[1]);
+    const nextRunId = decodeURIComponent(segments[1]);
+    if (activeRunId !== nextRunId) {
+      activeRunLogs = [];
+      expandedStepIndices.clear();
+    }
+    activeRunId = nextRunId;
+    const expandStep = query.get("step");
+    if (expandStep != null && /^\d+$/.test(expandStep)) {
+      expandedStepIndices.add(Number(expandStep));
+    }
     const sub = RUN_DETAIL_SUBTABS.includes(segments[2]) ? segments[2] : activeRunSubtab;
     activeRunSubtab = sub;
   } else if (TABS.includes(head)) {
@@ -950,6 +960,7 @@ function setActiveTab(raw, opts = {}) {
     setRunDetailSubtab(activeRunSubtab);
     hash = `#runs/${encodeURIComponent(activeRunId || "")}` +
       (activeRunSubtab !== "steps" ? `/${activeRunSubtab}` : "");
+    if (query.get("step") != null) hash += `?step=${encodeURIComponent(query.get("step"))}`;
   } else {
     hash = `#${top}`;
   }
@@ -1148,6 +1159,24 @@ const DIAG_FRICTION_COLUMNS = [
   },
 ];
 
+const DIAG_ERRORS_COLUMNS = [
+  { key: "ts", label: "time", num: false, render: (v) => fmtRelative(v) },
+  { key: "source", label: "source", num: false },
+  { key: "provider", label: "provider", num: false, render: (v) => v || "-" },
+  { key: "step", label: "step", num: false, render: (v) => v || "-" },
+  {
+    key: "message",
+    label: "message",
+    num: false,
+    cellClass: "stderr",
+    render: (v, row, td) => {
+      const full = v || "";
+      td.title = row.target ? `${row.target}: ${full}` : full;
+      return truncate(full, 220);
+    },
+  },
+];
+
 function renderDiagnosticsTable(rows, columns) {
   const body = $("diag-body");
   
@@ -1194,6 +1223,14 @@ function renderDiagnosticsTable(rows, columns) {
     }
     tr.dataset.key = `diag-${row.ts || ''}-${row.step || i}-${row.command || row.actor_identity || ''}`;
     tr.dataset.hash = JSON.stringify(row);
+    if (row.job_run) {
+      tr.classList.add("clickable");
+      tr.title = "Open owning run";
+      tr.addEventListener("click", () => {
+        const stepQuery = row.step_index == null ? "" : `?step=${encodeURIComponent(row.step_index)}`;
+        setActiveTab(`runs/${encodeURIComponent(row.job_run)}${stepQuery}`);
+      });
+    }
     frag.appendChild(tr);
   }
   
@@ -1204,9 +1241,15 @@ function renderDiagnostics() {
   const sub = activeDiagSubtab;
   const rows = lastDiagnostics[sub] || [];
   $("diag-count").textContent = `${rows.length}`;
+  const columns =
+    sub === "metrics"
+      ? DIAG_METRICS_COLUMNS
+      : sub === "errors"
+        ? DIAG_ERRORS_COLUMNS
+        : DIAG_FRICTION_COLUMNS;
   renderDiagnosticsTable(
     rows,
-    sub === "metrics" ? DIAG_METRICS_COLUMNS : DIAG_FRICTION_COLUMNS,
+    columns,
   );
 }
 
@@ -1248,6 +1291,7 @@ function activeRefreshJobs() {
     // they're fetched on every run-detail refresh regardless of which sub-tab
     // is active.
     jobs.push(fetchAndRenderRunEvents());
+    jobs.push(fetchAndRenderRunLogs());
     return jobs;
   }
 
@@ -1260,6 +1304,16 @@ function activeRefreshJobs() {
     jobs.push(
       fetchJson(`/api/diagnostics/metrics?limit=${DIAG_LIMIT}`).then((rows) => {
         lastDiagnostics.metrics = rows;
+        renderDiagnostics();
+      }),
+    );
+    return jobs;
+  }
+
+  if (activeDiagSubtab === "errors") {
+    jobs.push(
+      fetchJson(`/api/diagnostics/errors?limit=${DIAG_LIMIT}`).then((rows) => {
+        lastDiagnostics.errors = rows;
         renderDiagnostics();
       }),
     );
@@ -1306,6 +1360,17 @@ function fetchAndRenderRunEvents() {
     // Missing v2 events file is non-fatal — run detail still renders.
     activeRunEvents = [];
     renderRunGantt();
+  });
+}
+
+function fetchAndRenderRunLogs() {
+  if (!activeRunId) return Promise.resolve();
+  return fetchJson(`/api/runs/${encodeURIComponent(activeRunId)}/logs?limit=${RUN_EVENTS_LIMIT}`).then((logs) => {
+    activeRunLogs = logs;
+    renderRunSteps();
+  }).catch(() => {
+    activeRunLogs = [];
+    renderRunSteps();
   });
 }
 
@@ -2048,6 +2113,41 @@ function hideGanttTooltip() {
   tip.setAttribute("aria-hidden", "true");
 }
 
+function logsForStep(step) {
+  const stepId = step.target_id == null ? null : String(step.target_id);
+  return (activeRunLogs || []).filter((record) => {
+    if (record.step_index != null && Number(record.step_index) === Number(step.step_index)) return true;
+    return stepId != null && record.step_id === stepId;
+  });
+}
+
+function buildLogBlock(record, stream) {
+  const isErr = stream === "stderr";
+  const preview = record[`${stream}_preview`] || "";
+  if (!preview) return null;
+  const block = el("div", { class: `step-log-block ${isErr ? "stderr" : "stdout"}` });
+  const meta = [
+    record.provider || "cli",
+    record.exit_code == null ? "exit -" : `exit ${record.exit_code}`,
+    record.timed_out ? "timeout" : null,
+    record[`${stream}_truncated`] ? "truncated" : null,
+  ].filter(Boolean).join(" · ");
+  block.appendChild(el("div", { class: "step-log-head" }, [
+    el("span", { class: "label", text: stream }),
+    el("span", { class: "meta", text: meta }),
+  ]));
+  const pre = el("pre");
+  for (const line of preview.split("\n")) {
+    const row = el("span", {
+      class: isErr && /\bERROR\s+[^:]+:/.test(line) ? "log-line error-line" : "log-line",
+      text: line || " ",
+    });
+    pre.appendChild(row);
+  }
+  block.appendChild(pre);
+  return block;
+}
+
 function buildStepDetail(step) {
   const wrap = el("div", { class: "step-detail" });
   wrap.dataset.key = `step-detail-${step.step_index}`;
@@ -2065,6 +2165,18 @@ function buildStepDetail(step) {
 
   if (step.error_message) addBlock("error", `${step.error_code || ""} ${step.error_message}`);
   addBlock("agent_response", step.agent_response_json);
+  const logs = logsForStep(step);
+  if (logs.length > 0) {
+    const section = el("div", { class: "step-log-section" });
+    section.appendChild(el("div", { class: "label", text: "agent logs" }));
+    for (const record of logs) {
+      const stdout = buildLogBlock(record, "stdout");
+      const stderr = buildLogBlock(record, "stderr");
+      if (stdout) section.appendChild(stdout);
+      if (stderr) section.appendChild(stderr);
+    }
+    wrap.appendChild(section);
+  }
   const km = activeRunDetail && activeRunDetail.run && activeRunDetail.run.knowledge_metrics;
   if (km && step.step_index === 0) addBlock("knowledge_metrics (run)", km);
   return wrap;
@@ -2176,7 +2288,7 @@ async function refreshDashboard() {
   isRefreshing = false;
   if (activeTab === "tasks") fitLogPanelToViewport();
   
-  $("footer").textContent = `orbit dashboard · auto-refresh 30s · GET /api/{tasks,jobs,job-runs,audit?since|tool|status|role|execution_id|profile|q|limit|offset,audit/summary?since|denial_threshold,runs/:id,runs/:id/events?kind|limit|offset,scoreboard,diagnostics/{metrics,friction,denials?since|kind|profile|agent}}`;
+  $("footer").textContent = `orbit dashboard · auto-refresh 30s · GET /api/{tasks,jobs,job-runs,audit?since|tool|status|role|execution_id|profile|q|limit|offset,audit/summary?since|denial_threshold,runs/:id,runs/:id/events?kind|limit|offset,runs/:id/logs?limit,scoreboard,diagnostics/{metrics,errors,friction,denials?since|kind|profile|agent}}`;
 }
 
 buildChips();

--- a/crates/orbit-cli/assets/dashboard/index.html
+++ b/crates/orbit-cli/assets/dashboard/index.html
@@ -877,6 +877,8 @@
         color: var(--fg-dim);
         font-size: 12px;
       }
+      tr.clickable { cursor: pointer; }
+      tr.clickable:hover td { background: rgba(255, 255, 255, 0.03); }
 
       /* Audit + Run Detail */
       .audit-status {
@@ -1004,6 +1006,62 @@
         border-bottom: 1px solid var(--border);
         display: grid;
         gap: 10px;
+      }
+
+      .step-log-section {
+        display: grid;
+        gap: 8px;
+      }
+      .step-log-section > .label,
+      .step-log-head .label {
+        color: var(--fg-dim);
+        font-size: 11px;
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+      }
+      .step-log-block {
+        border: 1px solid var(--border);
+        border-radius: 2px;
+        background: var(--bg);
+      }
+      .step-log-block.stderr {
+        border-left: 2px solid var(--state-failed);
+      }
+      .step-log-block.stdout {
+        border-left: 2px solid var(--accent);
+      }
+      .step-log-head {
+        display: flex;
+        justify-content: space-between;
+        gap: 12px;
+        padding: 6px 10px;
+        border-bottom: 1px solid var(--border);
+        font-family: var(--font-mono);
+        font-size: 11px;
+      }
+      .step-log-head .meta {
+        color: var(--fg-dim);
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
+      .step-log-block pre {
+        margin: 0;
+        padding: 8px 10px;
+        max-height: 260px;
+        overflow: auto;
+        font-family: var(--font-mono);
+        font-size: 11px;
+        line-height: 1.45;
+        color: var(--fg);
+        white-space: pre-wrap;
+      }
+      .log-line {
+        display: block;
+      }
+      .log-line.error-line {
+        color: var(--state-failed);
+        background: rgba(255, 86, 86, 0.08);
       }
 
       .back-action {
@@ -1580,6 +1638,7 @@
             <button class="subtab" data-subtab="runs" type="button">Recent Runs</button>
             <button class="subtab" data-subtab="metrics" type="button">Metrics</button>
             <button class="subtab" data-subtab="friction" type="button">Friction</button>
+            <button class="subtab" data-subtab="errors" type="button">Errors</button>
           </nav>
           <div class="body scoreboard-table-wrap" id="diag-body" style="display: none;">
             <div class="skeleton-state">

--- a/crates/orbit-cli/src/command/web/api.rs
+++ b/crates/orbit-cli/src/command/web/api.rs
@@ -25,9 +25,10 @@ use axum::routing::{get, post};
 use chrono::{DateTime, Duration, TimeZone, Timelike, Utc};
 use futures_core::Stream;
 use orbit_common::utility::blob_store::BlobStore;
+use orbit_common::utility::redaction::redact_all;
 use orbit_core::command::job::JobRunListParams;
 use orbit_core::command::task::{TaskAddParams, TaskUpdateParams};
-use orbit_core::runtime::run_audit::RunAuditStep;
+use orbit_core::runtime::run_audit::{RunAuditStep, RunCliInvocationRecord};
 use orbit_core::{
     AuditEventStatus, ExternalRef, InvocationQuery, InvocationRecord, JobRun, JobRunState,
     OrbitRuntime, Task, TaskComplexity, TaskPriority, TaskStatus, TaskType,
@@ -66,6 +67,10 @@ const LOG_DEFAULT_LIMIT: usize = 50;
 const LOG_MAX_LIMIT: usize = 500;
 const LOG_STREAM_CHANNEL_DEPTH: usize = 64;
 const LOG_STREAM_POLL_INTERVAL: StdDuration = StdDuration::from_millis(50);
+/// Maximum bytes included in stdout/stderr previews returned by run-log APIs.
+const RUN_LOG_PREVIEW_MAX_BYTES: usize = 8192;
+/// Maximum lines included in stdout/stderr previews returned by run-log APIs.
+const RUN_LOG_PREVIEW_MAX_LINES: usize = 120;
 /// Default time window for header tile counts when `?since=` is omitted.
 const DEFAULT_SUMMARY_WINDOW: &str = "24h";
 /// Default header-tile alert threshold for the denials counter. Surfaced via
@@ -256,12 +261,14 @@ pub(super) fn router() -> Router<Arc<OrbitRuntime>> {
         .route("/runs/:id/cancel", post(cancel_run_action))
         .route("/runs/:id/replay", post(replay_run_action))
         .route("/runs/:id/events", get(list_run_events))
+        .route("/runs/:id/logs", get(list_run_logs))
         .route("/audit", get(list_audit))
         .route("/log", get(get_log))
         .route("/log/stream", get(stream_log))
         .route("/audit/summary", get(audit_summary))
         .route("/scoreboard", get(scoreboard))
         .route("/diagnostics/metrics", get(list_diagnostics_metrics))
+        .route("/diagnostics/errors", get(list_diagnostics_errors))
         .route("/diagnostics/friction", get(list_diagnostics_friction))
         .route("/diagnostics/denials", get(list_denials))
         .layer(middleware::from_fn(require_localhost_origin))
@@ -1034,6 +1041,197 @@ spec:
             .expect("response")
     }
 
+    async fn request_dashboard_run_logs(runtime: OrbitRuntime, encoded_run_id: &str) -> Response {
+        Router::new()
+            .nest("/api", router())
+            .with_state(Arc::new(runtime))
+            .oneshot(
+                Request::builder()
+                    .uri(format!("/api/runs/{encoded_run_id}/logs"))
+                    .body(Body::empty())
+                    .expect("request"),
+            )
+            .await
+            .expect("response")
+    }
+
+    async fn request_dashboard_errors(runtime: OrbitRuntime) -> Response {
+        Router::new()
+            .nest("/api", router())
+            .with_state(Arc::new(runtime))
+            .oneshot(
+                Request::builder()
+                    .uri("/api/diagnostics/errors?limit=10")
+                    .body(Body::empty())
+                    .expect("request"),
+            )
+            .await
+            .expect("response")
+    }
+
+    fn seed_cli_invocation_audit(runtime: &OrbitRuntime, run_id: &str, stderr: &[u8]) -> String {
+        let audit_root = runtime.data_root().join("state").join("audit");
+        let blob_store = BlobStore::new(audit_root.join("blobs"));
+        let stdout_ref = blob_store
+            .write(b"normal output\n")
+            .expect("write stdout blob");
+        let stderr_ref = blob_store.write(stderr).expect("write stderr blob");
+        let audit_dir = audit_root.join("v2_loop");
+        std::fs::create_dir_all(&audit_dir).expect("create audit dir");
+        write_lines(
+            &audit_dir.join(format!("{run_id}.jsonl")),
+            &[
+                json!({
+                    "schemaVersion": 1,
+                    "event_type": "run.started",
+                    "event_id": "evt-run",
+                    "ts": "2026-05-08T04:12:20Z",
+                    "run_id": run_id,
+                    "body_kind": "run_started"
+                })
+                .to_string(),
+                "malformed".to_string(),
+                json!({
+                    "schemaVersion": 1,
+                    "event_type": "step.started",
+                    "event_id": "evt-step",
+                    "ts": "2026-05-08T04:12:21Z",
+                    "run_id": run_id,
+                    "parent_event_id": "evt-run",
+                    "body_kind": "step_started",
+                    "step_id": "implement"
+                })
+                .to_string(),
+                json!({
+                    "schemaVersion": 1,
+                    "event_type": "cli.invocation.finished",
+                    "event_id": "evt-cli",
+                    "ts": "2026-05-08T04:12:22Z",
+                    "run_id": run_id,
+                    "parent_event_id": "evt-step",
+                    "body_kind": "cli_invocation_finished",
+                    "provider": "codex",
+                    "stdout_blob_ref": stdout_ref,
+                    "stderr_blob_ref": stderr_ref,
+                    "exit_code": 0,
+                    "timed_out": false,
+                    "duration_ms": 123
+                })
+                .to_string(),
+            ],
+        );
+        stderr_ref
+    }
+
+    #[tokio::test]
+    async fn list_run_logs_returns_bounded_redacted_step_records() {
+        let runtime = OrbitRuntime::in_memory().expect("build runtime");
+        let run_id = "jrun-log-api";
+        let mut stderr = String::from("first line\n");
+        stderr.push_str("Authorization: Bearer sk-test-secret\n");
+        for index in 0..200 {
+            stderr.push_str(&format!("line {index}\n"));
+        }
+        let stderr_ref = seed_cli_invocation_audit(&runtime, run_id, stderr.as_bytes());
+
+        let response = request_dashboard_run_logs(runtime, run_id).await;
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let payload = body_json(response).await;
+        let rows = payload.as_array().expect("rows");
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0]["run_id"], run_id);
+        assert_eq!(rows[0]["event_id"], "evt-cli");
+        assert_eq!(rows[0]["step_id"], "implement");
+        assert_eq!(rows[0]["step_index"], 0);
+        assert_eq!(rows[0]["provider"], "codex");
+        assert_eq!(rows[0]["stderr_blob_ref"], stderr_ref);
+        assert_eq!(rows[0]["exit_code"], 0);
+        assert_eq!(rows[0]["timed_out"], false);
+        assert_eq!(rows[0]["duration_ms"], 123);
+        let preview = rows[0]["stderr_preview"].as_str().expect("stderr preview");
+        assert!(preview.contains("[REDACTED_AUTH]"));
+        assert!(!preview.contains("sk-test-secret"));
+        assert_eq!(rows[0]["stderr_truncated"], true);
+    }
+
+    #[tokio::test]
+    async fn diagnostics_errors_include_codex_style_stderr_rows() {
+        let runtime = OrbitRuntime::in_memory().expect("build runtime");
+        let run_id = "jrun-error-api";
+        let stderr = b"2026-05-08T04:12:22.346005Z ERROR codex_core::session: failed to record rollout items\nordinary stderr\nERROR codex_core::tools::router: apply_patch verification failed\n";
+        let stderr_ref = seed_cli_invocation_audit(&runtime, run_id, stderr);
+
+        let response = request_dashboard_errors(runtime).await;
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let payload = body_json(response).await;
+        let rows = payload.as_array().expect("rows");
+        let agent_rows = rows
+            .iter()
+            .filter(|row| row["source"] == "agent-stderr" && row["job_run"] == run_id)
+            .collect::<Vec<_>>();
+        assert_eq!(agent_rows.len(), 2);
+        assert_eq!(agent_rows[0]["step"], "implement");
+        assert_eq!(agent_rows[0]["step_index"], 0);
+        assert_eq!(agent_rows[0]["provider"], "codex");
+        assert_eq!(agent_rows[0]["blob_ref"], stderr_ref);
+        assert!(rows.iter().any(|row| {
+            row["message"]
+                .as_str()
+                .is_some_and(|message| message.contains("apply_patch verification failed"))
+        }));
+    }
+
+    #[test]
+    fn global_error_rows_include_process_log_errors() {
+        let dir = tempdir().expect("tempdir");
+        let path = dir.path().join("orbit.log.jsonl");
+        write_lines(
+            &path,
+            &[
+                json!({
+                    "timestamp": "2026-05-08T04:00:00Z",
+                    "level": "INFO",
+                    "target": "orbit.test",
+                    "fields": { "message": "ignored" }
+                })
+                .to_string(),
+                json!({
+                    "timestamp": "2026-05-08T04:01:00Z",
+                    "level": "ERROR",
+                    "target": "orbit.test",
+                    "fields": { "message": "process failed" }
+                })
+                .to_string(),
+            ],
+        );
+
+        let rows = global_error_rows_from_path(&path, 10).expect("rows");
+
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0]["ts"], "2026-05-08T04:01:00Z");
+        assert_eq!(rows[0]["source"], "process");
+        assert!(
+            rows[0]["message"]
+                .as_str()
+                .is_some_and(|message| message.contains("process failed"))
+        );
+    }
+
+    #[test]
+    fn parse_structured_error_line_ignores_unstructured_error_words() {
+        assert!(parse_structured_error_line("this has ERROR but no shape", "").is_none());
+        let parsed = parse_structured_error_line(
+            "2026-05-08T04:12:22.346005Z ERROR codex_core::session: failed",
+            "",
+        )
+        .expect("parsed");
+        assert_eq!(parsed.ts, "2026-05-08T04:12:22.346005Z");
+        assert_eq!(parsed.target, "codex_core::session");
+        assert_eq!(parsed.message, "failed");
+    }
+
     #[tokio::test]
     async fn list_run_events_rejects_path_traversal_id() {
         let runtime = OrbitRuntime::in_memory().expect("build runtime");
@@ -1744,6 +1942,92 @@ async fn list_run_events(
     let end = offset.saturating_add(limit).min(events.len());
     let page: Vec<Value> = events.drain(offset..end).collect();
     Json(Value::Array(page)).into_response()
+}
+
+async fn list_run_logs(
+    State(runtime): State<Arc<OrbitRuntime>>,
+    Path(id): Path<String>,
+    Query(q): Query<LimitQuery>,
+) -> Response {
+    let run_id = match validate_id(&id) {
+        Ok(id) => id,
+        Err(message) => return bad_request(message),
+    };
+    let limit = bounded_limit(q.limit, HISTORY_DEFAULT_LIMIT);
+    match runtime.collect_run_cli_invocations(run_id) {
+        Ok(records) => Json(Value::Array(
+            records
+                .into_iter()
+                .take(limit)
+                .map(run_cli_invocation_to_json)
+                .collect(),
+        ))
+        .into_response(),
+        Err(e) => map_runtime_error(e),
+    }
+}
+
+fn run_cli_invocation_to_json(record: RunCliInvocationRecord) -> Value {
+    let stdout_preview = bounded_preview(&record.stdout);
+    let stderr_preview = bounded_preview(&record.stderr);
+    json!({
+        "run_id": record.run_id,
+        "event_id": record.event_id,
+        "ts": record.ts.map(|ts| ts.to_rfc3339()),
+        "step_id": record.step_id,
+        "step_index": record.step_index,
+        "provider": record.provider,
+        "stdout_blob_ref": record.stdout_blob_ref,
+        "stderr_blob_ref": record.stderr_blob_ref,
+        "stdout_preview": stdout_preview.text,
+        "stderr_preview": stderr_preview.text,
+        "stdout_truncated": stdout_preview.truncated,
+        "stderr_truncated": stderr_preview.truncated,
+        "exit_code": record.exit_code,
+        "timed_out": record.timed_out,
+        "duration_ms": record.duration_ms,
+    })
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct Preview {
+    text: String,
+    truncated: bool,
+}
+
+fn bounded_preview(raw: &str) -> Preview {
+    let mut out = String::new();
+    let mut truncated = false;
+    for (index, line) in raw.lines().enumerate() {
+        if index >= RUN_LOG_PREVIEW_MAX_LINES {
+            truncated = true;
+            break;
+        }
+        let needed = line.len() + usize::from(!out.is_empty());
+        if out.len().saturating_add(needed) > RUN_LOG_PREVIEW_MAX_BYTES {
+            if out.is_empty() {
+                for ch in line.chars() {
+                    if out.len().saturating_add(ch.len_utf8()) > RUN_LOG_PREVIEW_MAX_BYTES {
+                        break;
+                    }
+                    out.push(ch);
+                }
+            }
+            truncated = true;
+            break;
+        }
+        if !out.is_empty() {
+            out.push('\n');
+        }
+        out.push_str(line);
+    }
+    if raw.ends_with('\n') && !out.is_empty() && out.len() < RUN_LOG_PREVIEW_MAX_BYTES {
+        out.push('\n');
+    }
+    Preview {
+        text: redact_all(&out),
+        truncated,
+    }
 }
 
 fn v2_loop_path(runtime: &OrbitRuntime, run_id: &str) -> PathBuf {
@@ -2814,6 +3098,225 @@ fn read_blob_text_best_effort(blob_store: &BlobStore, blob_ref: &str) -> String 
         .read(blob_ref)
         .map(|bytes| String::from_utf8_lossy(&bytes).into_owned())
         .unwrap_or_default()
+}
+
+async fn list_diagnostics_errors(
+    State(runtime): State<Arc<OrbitRuntime>>,
+    Query(q): Query<DiagnosticsQuery>,
+) -> Response {
+    let limit = bounded_limit(q.limit, HISTORY_DEFAULT_LIMIT);
+    match diagnostics_errors(&runtime, limit) {
+        Ok(rows) => Json(Value::Array(rows)).into_response(),
+        Err(e) => map_runtime_error(e),
+    }
+}
+
+fn diagnostics_errors(
+    runtime: &OrbitRuntime,
+    limit: usize,
+) -> Result<Vec<Value>, orbit_core::OrbitError> {
+    if limit == 0 {
+        return Ok(Vec::new());
+    }
+    let mut rows = global_error_rows(limit)?;
+    rows.extend(agent_stderr_error_rows(runtime, limit)?);
+    rows.sort_by(|a, b| {
+        let left = a.get("ts").and_then(Value::as_str).unwrap_or("");
+        let right = b.get("ts").and_then(Value::as_str).unwrap_or("");
+        right.cmp(left)
+    });
+    rows.truncate(limit);
+    Ok(rows)
+}
+
+fn global_error_rows(limit: usize) -> Result<Vec<Value>, orbit_core::OrbitError> {
+    let path = resolve_log_path(None)?;
+    global_error_rows_from_path(&path, limit)
+}
+
+fn global_error_rows_from_path(
+    path: &std::path::Path,
+    limit: usize,
+) -> Result<Vec<Value>, orbit_core::OrbitError> {
+    let filters = LogFilters::from_query_parts(None, Some("error".to_string()), None)?;
+    let events = read_recent_rendered_events(&path, &filters, limit)
+        .map_err(|e| orbit_core::OrbitError::Io(format!("read log {}: {e}", path.display())))?;
+    Ok(events
+        .into_iter()
+        .map(|event| {
+            json!({
+                "ts": event.ts,
+                "source": "process",
+                "message": strip_htmlish(&event.message_html),
+                "event_id": null,
+                "job_run": null,
+                "step": null,
+                "step_index": null,
+                "task_id": null,
+                "provider": null,
+                "blob_ref": null,
+                "target": event.source,
+            })
+        })
+        .collect())
+}
+
+fn agent_stderr_error_rows(
+    runtime: &OrbitRuntime,
+    limit: usize,
+) -> Result<Vec<Value>, orbit_core::OrbitError> {
+    let audit_dir = v2_loop_dir(runtime);
+    if !audit_dir.exists() {
+        return Ok(Vec::new());
+    }
+    let mut files = std::fs::read_dir(&audit_dir)
+        .map_err(|e| orbit_core::OrbitError::Io(e.to_string()))?
+        .filter_map(Result::ok)
+        .map(|entry| entry.path())
+        .filter(|path| path.extension().and_then(|value| value.to_str()) == Some("jsonl"))
+        .collect::<Vec<_>>();
+    files.sort();
+    if files.len() > V2_LOOP_FILE_SCAN_CAP {
+        files = files.split_off(files.len() - V2_LOOP_FILE_SCAN_CAP);
+    }
+    files.reverse();
+
+    let blob_store = BlobStore::new(
+        runtime
+            .data_root()
+            .join("state")
+            .join("audit")
+            .join("blobs"),
+    );
+    let mut rows = Vec::new();
+    for path in files {
+        let raw = std::fs::read_to_string(&path)
+            .map_err(|e| orbit_core::OrbitError::Io(format!("read {}: {e}", path.display())))?;
+        let mut events = Vec::new();
+        let mut by_id = HashMap::new();
+        for line in raw.lines() {
+            let trimmed = line.trim();
+            if trimmed.is_empty() {
+                continue;
+            }
+            let value: Value = match serde_json::from_str(trimmed) {
+                Ok(value) => value,
+                Err(_) => continue,
+            };
+            if let Some(event_id) = value.get("event_id").and_then(Value::as_str) {
+                by_id.insert(event_id.to_string(), value.clone());
+            }
+            events.push(value);
+        }
+        let step_index_by_id = step_index_by_id(&events);
+        for event in events {
+            if event.get("body_kind").and_then(Value::as_str) != Some("cli_invocation_finished") {
+                continue;
+            }
+            let Some(blob_ref) = event.get("stderr_blob_ref").and_then(Value::as_str) else {
+                continue;
+            };
+            let stderr = read_blob_text_best_effort(&blob_store, blob_ref);
+            let fallback_ts = event
+                .get("ts")
+                .and_then(Value::as_str)
+                .unwrap_or("")
+                .to_string();
+            let step = enclosing_step_id_for_event(&event, &by_id);
+            let step_index = step
+                .as_ref()
+                .and_then(|step| step_index_by_id.get(step).copied());
+            for parsed in parse_structured_error_lines(&stderr, &fallback_ts) {
+                rows.push(json!({
+                    "ts": parsed.ts,
+                    "source": "agent-stderr",
+                    "message": redact_all(&parsed.message),
+                    "job_run": event.get("run_id").and_then(Value::as_str),
+                    "step": step,
+                    "step_index": step_index,
+                    "task_id": event.get("task_id").and_then(Value::as_str),
+                    "provider": event.get("provider").and_then(Value::as_str),
+                    "blob_ref": blob_ref,
+                    "event_id": event.get("event_id").and_then(Value::as_str),
+                    "target": parsed.target,
+                }));
+                if rows.len() >= limit.saturating_mul(2) {
+                    return Ok(rows);
+                }
+            }
+        }
+    }
+    Ok(rows)
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct ParsedErrorLine {
+    ts: String,
+    target: String,
+    message: String,
+}
+
+fn parse_structured_error_lines(stderr: &str, fallback_ts: &str) -> Vec<ParsedErrorLine> {
+    stderr
+        .lines()
+        .filter_map(|line| parse_structured_error_line(line, fallback_ts))
+        .collect()
+}
+
+fn parse_structured_error_line(line: &str, fallback_ts: &str) -> Option<ParsedErrorLine> {
+    let trimmed = line.trim();
+    let (ts, rest) = if let Some((head, tail)) = trimmed.split_once(" ERROR ") {
+        if DateTime::parse_from_rfc3339(head).is_ok() {
+            (head.to_string(), tail)
+        } else {
+            (fallback_ts.to_string(), trimmed.strip_prefix("ERROR ")?)
+        }
+    } else {
+        (fallback_ts.to_string(), trimmed.strip_prefix("ERROR ")?)
+    };
+    let (target, message) = rest.rsplit_once(": ")?;
+    let target = target.trim();
+    let message = message.trim();
+    if target.is_empty() || message.is_empty() {
+        return None;
+    }
+    Some(ParsedErrorLine {
+        ts,
+        target: target.to_string(),
+        message: message.to_string(),
+    })
+}
+
+fn step_index_by_id(events: &[Value]) -> HashMap<String, u32> {
+    let mut result = HashMap::new();
+    for event in events {
+        if event.get("body_kind").and_then(Value::as_str) != Some("step_started") {
+            continue;
+        }
+        let Some(step_id) = event.get("step_id").and_then(Value::as_str) else {
+            continue;
+        };
+        let index = result.len() as u32;
+        result.entry(step_id.to_string()).or_insert(index);
+    }
+    result
+}
+
+fn strip_htmlish(raw: &str) -> String {
+    let mut out = String::new();
+    let mut in_tag = false;
+    for ch in raw.chars() {
+        match ch {
+            '<' => in_tag = true,
+            '>' => in_tag = false,
+            _ if !in_tag => out.push(ch),
+            _ => {}
+        }
+    }
+    out.replace("&lt;", "<")
+        .replace("&gt;", ">")
+        .replace("&amp;", "&")
+        .replace("&quot;", "\"")
 }
 
 async fn list_diagnostics_friction(

--- a/crates/orbit-core/src/runtime/run_audit.rs
+++ b/crates/orbit-core/src/runtime/run_audit.rs
@@ -46,12 +46,19 @@ pub struct RunAuditStep {
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct RunCliInvocationRecord {
+    pub run_id: String,
+    pub event_id: String,
+    pub ts: Option<DateTime<Utc>>,
     pub step_id: Option<String>,
+    pub step_index: Option<u32>,
     pub provider: Option<String>,
     pub stdout_blob_ref: Option<String>,
     pub stderr_blob_ref: Option<String>,
     pub stdout: String,
     pub stderr: String,
+    pub exit_code: Option<i64>,
+    pub timed_out: bool,
+    pub duration_ms: Option<u64>,
 }
 
 impl OrbitRuntime {
@@ -67,12 +74,10 @@ impl OrbitRuntime {
         let mut events_by_id = HashMap::new();
         let mut ordered_ids = Vec::new();
         for line in raw.lines().filter(|line| !line.trim().is_empty()) {
-            let value: Value = serde_json::from_str(line).map_err(|err| {
-                OrbitError::Store(format!(
-                    "invalid audit log '{}': {err}",
-                    audit_path.display()
-                ))
-            })?;
+            let value: Value = match serde_json::from_str(line) {
+                Ok(value) => value,
+                Err(_) => continue,
+            };
             let Some(event_id) = value.get("event_id").and_then(Value::as_str) else {
                 continue;
             };
@@ -192,6 +197,11 @@ impl OrbitRuntime {
     ) -> Result<Vec<RunCliInvocationRecord>, OrbitError> {
         let events = self.collect_run_audit_events(run_id)?;
         let blob_store = BlobStore::new(self.v2_audit_blob_root());
+        let step_index_by_id = self
+            .collect_run_audit_steps(run_id)?
+            .into_iter()
+            .map(|step| (step.step_id, step.step_index))
+            .collect::<HashMap<_, _>>();
         let mut records = Vec::new();
 
         for event in events {
@@ -209,14 +219,27 @@ impl OrbitRuntime {
                 .and_then(Value::as_str)
                 .map(str::to_string);
             let stdout = match stdout_blob_ref.as_deref() {
-                Some(blob_ref) => read_blob_text(&blob_store, blob_ref)?,
+                Some(blob_ref) => read_blob_text_best_effort(&blob_store, blob_ref),
                 None => String::new(),
             };
             let stderr = match stderr_blob_ref.as_deref() {
-                Some(blob_ref) => read_blob_text(&blob_store, blob_ref)?,
+                Some(blob_ref) => read_blob_text_best_effort(&blob_store, blob_ref),
                 None => String::new(),
             };
+            let step_index = event
+                .step_id
+                .as_ref()
+                .and_then(|step_id| step_index_by_id.get(step_id).copied());
             records.push(RunCliInvocationRecord {
+                run_id: event
+                    .raw
+                    .get("run_id")
+                    .and_then(Value::as_str)
+                    .unwrap_or(run_id)
+                    .to_string(),
+                event_id: event.event_id,
+                ts: event.timestamp,
+                step_index,
                 step_id: event.step_id,
                 provider: event
                     .raw
@@ -227,6 +250,13 @@ impl OrbitRuntime {
                 stderr_blob_ref,
                 stdout,
                 stderr,
+                exit_code: event.raw.get("exit_code").and_then(Value::as_i64),
+                timed_out: event
+                    .raw
+                    .get("timed_out")
+                    .and_then(Value::as_bool)
+                    .unwrap_or(false),
+                duration_ms: event.raw.get("duration_ms").and_then(Value::as_u64),
             });
         }
 
@@ -285,6 +315,10 @@ fn read_blob_text(blob_store: &BlobStore, blob_ref: &str) -> Result<String, Orbi
         .read(blob_ref)
         .map_err(|err| OrbitError::Io(format!("read audit blob '{blob_ref}': {err}")))?;
     Ok(String::from_utf8_lossy(&bytes).into_owned())
+}
+
+fn read_blob_text_best_effort(blob_store: &BlobStore, blob_ref: &str) -> String {
+    read_blob_text(blob_store, blob_ref).unwrap_or_default()
 }
 
 #[cfg(test)]
@@ -412,11 +446,18 @@ mod tests {
             .collect_run_cli_invocations(run_id)
             .expect("collect records");
         assert_eq!(records.len(), 2);
+        assert_eq!(records[0].run_id, run_id);
+        assert_eq!(records[0].event_id, "evt-cli-one");
         assert_eq!(records[0].step_id.as_deref(), Some("implement_one"));
+        assert_eq!(records[0].step_index, Some(0));
         assert_eq!(records[0].provider.as_deref(), Some("codex"));
         assert_eq!(records[0].stdout, "one stdout\n");
         assert_eq!(records[0].stderr, "one stderr\n");
+        assert_eq!(records[0].exit_code, Some(0));
+        assert!(!records[0].timed_out);
+        assert_eq!(records[0].duration_ms, Some(10));
         assert_eq!(records[1].step_id.as_deref(), Some("review"));
+        assert_eq!(records[1].step_index, Some(1));
         assert_eq!(records[1].provider.as_deref(), Some("claude"));
         assert_eq!(records[1].stdout, "two stdout\n");
         assert_eq!(records[1].stderr, "");
@@ -429,5 +470,56 @@ mod tests {
             .collect_run_cli_invocations("jrun-missing")
             .expect("collect records");
         assert!(records.is_empty());
+    }
+
+    #[test]
+    fn malformed_jsonl_and_missing_blobs_are_tolerated() {
+        let runtime = OrbitRuntime::in_memory().expect("build runtime");
+        let audit_root = runtime.data_root().join("state").join("audit");
+        let jsonl_dir = audit_root.join("v2_loop");
+        std::fs::create_dir_all(&jsonl_dir).expect("create jsonl dir");
+        let run_id = "jrun-tolerant";
+        std::fs::write(
+            jsonl_dir.join(format!("{run_id}.jsonl")),
+            format!(
+                "{}\nnot-json\n{}\n",
+                json!({
+                    "event_id": "evt-step",
+                    "ts": "2026-04-26T07:00:01Z",
+                    "run_id": run_id,
+                    "body_kind": "step_started",
+                    "step_id": "implement"
+                }),
+                json!({
+                    "event_id": "evt-cli",
+                    "ts": "2026-04-26T07:00:02Z",
+                    "run_id": run_id,
+                    "parent_event_id": "evt-step",
+                    "body_kind": "cli_invocation_finished",
+                    "provider": "codex",
+                    "exit_code": 1,
+                    "duration_ms": 42,
+                    "stdout_blob_ref": "aa/missing",
+                    "stderr_blob_ref": "error:writer-failed",
+                    "timed_out": true
+                })
+            ),
+        )
+        .expect("write jsonl");
+
+        let events = runtime
+            .collect_run_audit_events(run_id)
+            .expect("collect events");
+        assert_eq!(events.len(), 2);
+
+        let records = runtime
+            .collect_run_cli_invocations(run_id)
+            .expect("collect records");
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].step_index, Some(0));
+        assert_eq!(records[0].stdout, "");
+        assert_eq!(records[0].stderr, "");
+        assert_eq!(records[0].exit_code, Some(1));
+        assert!(records[0].timed_out);
     }
 }

--- a/docs/design/auditability/2_design.md
+++ b/docs/design/auditability/2_design.md
@@ -2,7 +2,7 @@
 
 **Status:** Draft
 **Owner:** codex
-**Last updated:** 2026-05-08 (T20260506-2, T20260508-8)
+**Last updated:** 2026-05-08 (T20260506-2, T20260508-8, T20260508-14)
 
 This document describes Orbit's shipped auditability implementation across command audit rows, activity/job envelopes, loop-level provider/tool traces, blob storage, redaction, identity attribution, metrics-adjacent invocation records, and known limitations. See [1_overview.md](./1_overview.md) for the feature purpose and [3_vision.md](./3_vision.md) for future questions.
 
@@ -57,7 +57,7 @@ After [T20260427-0023], selected canonical stores also project live tracing even
 
 `V2AuditWriter` in `crates/orbit-engine/src/activity_job/audit_writer.rs` assigns event ids, maintains per-thread parent stacks, emits through `V2JsonlSink`, keeps a smoke-verification snapshot, and exposes the inner loop sink for provider/tool events. CLI-launched v2 runs stamp envelope `agent_identity` as `system`; concrete agent identity lives in activity configuration, CLI invocation events, and invocation metrics.
 
-`crates/orbit-engine/src/activity_job/jsonl_sink.rs` appends one JSON object per line under `v2_loop/` and flushes per write. `crates/orbit-core/src/runtime/run_audit.rs` is the read-side accessor after [T20260426-0709], deriving activity DAG `step.id` values from `parent_event_id` ancestry and resolving CLI stdout/stderr blob references for `orbit run logs`.
+`crates/orbit-engine/src/activity_job/jsonl_sink.rs` appends one JSON object per line under `v2_loop/` and flushes per write. `crates/orbit-core/src/runtime/run_audit.rs` is the read-side accessor after [T20260426-0709], deriving activity DAG `step.id` values from `parent_event_id` ancestry and resolving CLI stdout/stderr blob references for `orbit run logs`. After [T20260508-14], the same accessor tolerates malformed read-side JSONL lines and missing blobs for dashboard inspection, returning partial per-step CLI invocation records with run id, event id, timestamp, step index, exit status, timeout, duration, provider, blob refs, and bounded stdout/stderr material.
 
 ---
 
@@ -74,6 +74,8 @@ Loop events reference hashes for request bodies, response bodies, tool inputs, a
 `crates/orbit-common/src/utility/blob_store.rs` writes content-addressed blobs under `{root}/{hash_prefix}/{hash}`. The hash is computed after redaction, and existing blob paths are reused.
 
 `crates/orbit-common/src/utility/redaction.rs` centralizes sensitive live environment value scrubbing plus regex-based HTTP/argv patterns for authorization headers, API keys, bearer tokens, JSON API-key fields, and bare `sk-...` tokens when argv scrubbing is requested. CLI audit errors, blob bytes, selected pipeline outputs/errors, and the default tracing subscriber all redact before persistence or terminal/JSONL output. The smoke example `crates/orbit-agent/examples/redaction_smoke.rs` verifies stored blob bytes omit the raw secret and contain a marker.
+
+Dashboard log previews added by [T20260508-14] are derived views over `.orbit/state/audit/v2_loop` and `.orbit/state/audit/blobs`; they do not duplicate full transcripts into SQLite. Preview responses are byte- and line-capped, apply defensive read-time redaction with the shared redactor, and preserve existing write-time redaction markers. The focused diagnostics error feed is also derived, combining global ERROR tracing rows with structured `ERROR <target>:` lines found in agent stderr blobs. No `.orbit/state/diagnostics/errors/` store exists in this design; retention remains bounded by the existing v2 audit, blob, and global log retention roots.
 
 ---
 
@@ -97,6 +99,8 @@ The requirement is not to collapse every field into one value. It is that a revi
 `crates/orbit-cli/src/command/audit.rs` exposes command rows through `orbit audit list`, `show`, `stats`, `export --format json`, `export --format csv`, and `prune`, with filters for time, tool, status, role, and limit. Exports include all command-audit columns, including sparse `stdout_truncated`, `stderr_truncated`, and `session_id`.
 
 V2 traces are exposed separately: `orbit run events` prints chronological envelopes, `orbit run trace` renders the parent tree, and `orbit run logs` extracts CLI stdout/stderr blobs. `orbit run history` and `orbit run show` expose job-run state rather than the full envelope stream. Metrics and scoreboard commands read invocation records; they summarize cost and usage, not transcript structure.
+
+The local dashboard exposes two read-only API surfaces for these traces after [T20260508-14]: `GET /api/runs/:id/logs` returns bounded per-step CLI invocation previews, and `GET /api/diagnostics/errors` returns recent process ERROR rows plus structured agent-stderr error rows sorted newest first. Both endpoints use existing dashboard limit conventions and tolerate missing v2 audit files, malformed lines, and missing blobs by returning empty or partial arrays.
 
 After [T20260428-11], compact `summary.json` counts all audited tool-run attempts and failed attempts from command-audit rows where `command: tool`, `subcommand` is `"run"` or `"run-mcp"`, and `tool_name` is present. Token totals still come from invocation/token scoreboards, with legacy tool-call totals used only as a max overlay to avoid obvious double counting.
 
@@ -150,5 +154,6 @@ Each record contains timestamp, level, target, and structured fields. After [T20
 - **[T20260505-6]** — Replace timestamp-only command-audit execution ids with collision-resistant generated ids for parallel tool runs.
 - **[T20260506-2]** — Lazily materialize loop audit JSONL files only when loop-level events are emitted.
 - **[T20260508-8]** — Record backend: cli subprocess cwd in v2 audit and live tracing.
+- **[T20260508-14]** — Surface bounded per-step agent log previews and derived diagnostics error rows in the dashboard.
 
 > Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.

--- a/docs/design/user-interface/2_design.md
+++ b/docs/design/user-interface/2_design.md
@@ -2,7 +2,7 @@
 
 **Status:** Draft
 **Owner:** gemini
-**Last updated:** 2026-04-30
+**Last updated:** 2026-05-08 (T20260508-14)
 
 This document describes the current Orbit UI implementation: the local dashboard assets, the Canon Refined visual rules they rely on, and the telemetry behaviors that must stay consistent with backend data.
 
@@ -26,6 +26,10 @@ Live processing is visible through pulsing dots, spinners, buffered-log counters
 
 Summary tiles and drill-down panels must agree. Audit > Policy is the detail view for the Denials 24h tile, so `/api/diagnostics/denials` combines v2 loop JSONL denial rows with SQLite `status = denied` audit events. SQLite filesystem boundary denials without an activity fsProfile use the stable `workspace-boundary` label [T20260428-13].
 
+Run Detail > Steps now includes compact per-step agent log expanders for CLI-backed activity steps [T20260508-14]. The UI renders bounded stdout and stderr previews from `/api/runs/:id/logs`, distinguishes stderr blocks from stdout blocks, highlights structured `ERROR <target>:` lines, and keeps blob references behind the API so operators do not need to resolve content hashes manually.
+
+Diagnostics has an Errors sub-tab after [T20260508-14]. It renders recent backend error rows independently of Metrics, Friction, and Policy, combining Orbit process ERROR events with structured agent stderr rows. Rows with `job_run` provenance route back to the owning Run Detail step so error triage stays connected to workflow context.
+
 ## 6. Concerns & Honest Limitations
 
 Accessibility still needs a real WCAG pass; responsive behavior remains optimized for wide desktop viewports; raw HTML, CSS variables, and dashboard JavaScript keep the runtime simple but leave duplication across project surfaces.
@@ -37,5 +41,6 @@ Accessibility still needs a real WCAG pass; responsive behavior remains optimize
 - [T20260428-15] compacted scoreboard ratio columns.
 - [T20260430-24] shortened this design doc while preserving current behavior statements.
 - [T20260430-29] bounded the live `orbit.log` panel to the viewport.
+- [T20260508-14] added Run Detail agent-log previews and Diagnostics > Errors.
 
 > Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.


### PR DESCRIPTION
## Task

[T20260508-14](https://orbit-cli.com/tasks/T20260508-14) — Surface per-step agent logs and error diagnostics in dashboard

### Description

## Problem
Agent subprocess stderr/stdout and Orbit process errors are durable but too hard to inspect from the dashboard. A run can already preserve CLI stdin/stdout/stderr as audit blobs, and the global log feed can record Orbit-level ERROR events, but the dashboard does not give operators a step-scoped view of agent activity logs or a focused stream of error lines. Operators currently have to know how to jump from a job run to v2 envelope events, find stderr blob refs, read blobs manually, and separately inspect the global log feed.

Example user-visible failure evidence that should be easy to find:

```text
2026-05-08T04:12:22.346005Z ERROR codex_core_skills::manager: failed to install system skills: io error while remove existing system skills dir: Directory not empty (os error 66)
2026-05-08T04:17:11.332530Z ERROR codex_core::tools::router: error=apply_patch verification failed: Failed to find expected lines while editing a Rust source file
2026-05-08T04:26:59.935682Z ERROR codex_core::session: failed to record rollout items: thread ... not found
```

## Why It Matters
Auditability is an Orbit product promise, not a debug afterthought. The dashboard already has run steps, v2 events, policy denials, metrics, friction, and a live log panel; agent operators need the same dense drill-down for what happened inside each agent activity step, especially when a step succeeds overall but the agent emitted ERROR lines along the way.

## Constraints / Notes
- Treat `.orbit/state/audit/v2_loop` as the run spine and `.orbit/state/audit/blobs` as the archival source for CLI stdout/stderr payloads.
- Do not duplicate full transcript bodies into SQLite command-audit rows.
- Reuse existing runtime accessors where possible, especially `OrbitRuntime::collect_run_cli_invocations`, and keep file-layout parsing behind orbit-core/runtime APIs when adding new read surfaces.
- Error extraction must preserve write-time redaction expectations: dashboard/API readers should not rehydrate or display unredacted secrets.
- The first implementation may derive the focused error stream from existing durable sources, but it must present errors as their own operator-facing diagnostics surface rather than requiring manual blob inspection.
- Dashboard controls should stay dense and work-focused: under Run Detail / Steps, expanded agent activity steps should expose logs/errors without turning the run page into a raw transcript dump.

### Acceptance Criteria

- `GET /api/runs/:id` or a new `GET /api/runs/:id/logs` dashboard API returns step-scoped CLI invocation log records derived from v2 audit events and audit blobs. Each record includes at minimum `run_id`, `step_id` or `step_index`, `provider`, `stdout_blob_ref`, `stderr_blob_ref`, bounded `stdout_preview`, bounded `stderr_preview`, `exit_code`, and `timed_out`.
- The Run Detail dashboard Steps view shows an expandable agent-log section for steps with CLI invocation records, including a visible stderr preview and a way to distinguish normal output from error lines. It must not require opening the Events sub-tab or manually resolving blob hashes.
- A focused diagnostics error surface exists in the dashboard and backend, for example `GET /api/diagnostics/errors`, that combines Orbit ERROR-level process log events with agent stderr lines that look like structured error records (`ERROR <target>:` or equivalent). Each row includes `ts`, `source`, `message`, and, when available, `job_run`, `step`, `task_id`, `provider`, and `blob_ref` or `event_id` provenance.
- The diagnostics UI includes an Errors sub-tab or equivalent filter that renders recent error rows independently of Metrics, Friction, and Policy. Rows from agent stderr must link or otherwise route back to the owning run/step when `job_run` is available.
- Error extraction is bounded and deterministic: API responses cap previews/rows with documented defaults and support a `limit` query parameter using the existing dashboard limit conventions; tests cover large stderr blobs without returning unbounded payloads.
- Malformed JSONL lines, missing blobs, and missing v2 audit files do not crash the dashboard endpoints; they return partial results or empty arrays while preserving the existing tolerant diagnostics behavior.
- Redaction expectations are covered by a test or fixture: an audit blob containing a known redacted marker remains safe in the dashboard response, and no new read-time path displays raw provider tokens.
- Focused backend tests cover step-log API behavior, error-row extraction from a sample stderr payload containing the Codex-style `ERROR codex_core...` lines, and global log ERROR inclusion. Frontend/dashboard tests or renderable fixture inspection cover the new Run Detail and Diagnostics UI states.
- Design docs are updated in `docs/design/auditability/` and `docs/design/user-interface/` to describe the new per-step log/error dashboard surface and cite this task ID. If the implementation creates a new `.orbit/state/diagnostics/errors/` store, the redaction/retention spec documents its retention boundary.
- `make fmt` and the focused Rust test commands for the modified crates pass before the task moves to review.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Added tolerant runtime collection of step-scoped CLI invocation records with run/event provenance, step indexes, exit metadata, timeout/duration, and best-effort blob reads.
- Added dashboard APIs for /api/runs/:id/logs and /api/diagnostics/errors with bounded, redacted previews and derived process/agent error rows.
- Wired Run Detail step expanders to show compact stdout/stderr previews and added Diagnostics > Errors with navigation back to owning run steps.
- Updated auditability and UI design docs for the derived log/error surfaces and retention/redaction boundaries.

Assessment: Implemented and validated with focused core/web API tests, JS syntax check, make fmt, and make build.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/T20260508-14-69fd6d74`
- Behind base: 0
- Ahead of base: 1

*authored by: gpt-5.5*