### PR TITLE
git_commit action ignores task.implemented_by; commits land as local git config user

### DIFF
--- a/crates/orbit-engine/src/executor/automation/commit.rs
+++ b/crates/orbit-engine/src/executor/automation/commit.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeSet;
 use std::path::{Component, Path, PathBuf};
 
-use orbit_common::types::{OrbitError, Task};
+use orbit_common::types::{OrbitError, Task, infer_agent_family_from_model};
 use orbit_common::utility::selector::anchor_path;
 use serde_json::{Value, json};
 
@@ -88,7 +88,8 @@ pub(super) fn commit_task_artifact_changes<H: TaskHost + RuntimeHost + ?Sized>(
         }
 
         let message = task_commit_message(&task);
-        git_success(&workspace_path, &["commit", "-m", &message])?;
+        let author = git_author_for_task(&task);
+        git_commit_with_author(&workspace_path, &message, author.as_ref())?;
         committed_task_ids.push(task.id);
     }
 
@@ -140,8 +141,10 @@ pub(super) fn commit_finalize_artifact_changes<H: TaskHost + RuntimeHost + ?Size
         return Ok(json!({}));
     }
 
-    let message = finalize_commit_message(&affected_tasks);
-    git_success(&workspace_path, &["commit", "-m", &message])?;
+    let mut message = finalize_commit_message(&affected_tasks);
+    let (author, coauthors) = commit_author_for_tasks(&affected_tasks);
+    append_co_author_trailers(&mut message, &coauthors);
+    git_commit_with_author(&workspace_path, &message, author.as_ref())?;
 
     Ok(json!({
         "workspace_path": workspace_path.to_string_lossy().to_string(),
@@ -162,7 +165,6 @@ pub(super) fn commit_batch_changes<H: TaskHost + RuntimeHost + ?Sized>(
 
     let workspace_path = resolve_workspace_path(host, input, batch_id)?;
     ensure_named_branch(&workspace_path)?;
-    let completed_task_ids: Vec<String> = batch_tasks.iter().map(|t| t.id.clone()).collect();
 
     ensure_no_unmerged_changes(&workspace_path)?;
     git_success(&workspace_path, &["add", "--all", "--", "."])?;
@@ -175,20 +177,163 @@ pub(super) fn commit_batch_changes<H: TaskHost + RuntimeHost + ?Sized>(
 
     let mut task_lines = Vec::new();
     let mut id_labels = Vec::new();
-    for task_id in &completed_task_ids {
-        let task = host.get_task(task_id)?;
-        task_lines.push(format!("- {}: {}", task_id, task.title.trim()));
-        id_labels.push(task_id.clone());
+    for task in &batch_tasks {
+        task_lines.push(format!("- {}: {}", task.id, task.title.trim()));
+        id_labels.push(task.id.clone());
     }
     let ids_joined = id_labels.join(", ");
-    let message = format!(
+    let mut message = format!(
         "feat: parallel batch [{}]\n\nTasks:\n{}",
         ids_joined,
         task_lines.join("\n")
     );
+    let (author, coauthors) = commit_author_for_tasks(&batch_tasks);
+    append_co_author_trailers(&mut message, &coauthors);
 
-    git_success(&workspace_path, &["commit", "-m", &message])?;
+    git_commit_with_author(&workspace_path, &message, author.as_ref())?;
     Ok(json!({}))
+}
+
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
+struct GitAuthor {
+    name: String,
+    email: String,
+}
+
+impl GitAuthor {
+    fn new(name: impl Into<String>, email: impl Into<String>) -> Self {
+        Self {
+            name: name.into(),
+            email: email.into(),
+        }
+    }
+
+    fn spec(&self) -> String {
+        format!("{} <{}>", self.name, self.email)
+    }
+
+    fn trailer(&self) -> String {
+        format!("Co-Authored-By: {}", self.spec())
+    }
+}
+
+fn git_author_for_task(task: &Task) -> Option<GitAuthor> {
+    git_author_for_implemented_by(task.implemented_by.as_deref())
+}
+
+fn commit_author_for_tasks(tasks: &[Task]) -> (Option<GitAuthor>, Vec<GitAuthor>) {
+    let authors = tasks
+        .iter()
+        .filter_map(git_author_for_task)
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect::<Vec<_>>();
+
+    match authors.as_slice() {
+        [] => (None, Vec::new()),
+        [author] => (Some(author.clone()), Vec::new()),
+        _ => (Some(GitAuthor::new("orbit", "orbit@orbit.local")), authors),
+    }
+}
+
+fn append_co_author_trailers(message: &mut String, coauthors: &[GitAuthor]) {
+    if coauthors.is_empty() {
+        return;
+    }
+
+    message.push_str("\n\n");
+    message.push_str(
+        &coauthors
+            .iter()
+            .map(GitAuthor::trailer)
+            .collect::<Vec<_>>()
+            .join("\n"),
+    );
+}
+
+fn git_author_for_implemented_by(implemented_by: Option<&str>) -> Option<GitAuthor> {
+    let implemented_by = implemented_by?.trim();
+    if implemented_by.is_empty() {
+        return None;
+    }
+
+    match implementer_family(implemented_by).as_deref() {
+        Some("claude") => Some(GitAuthor::new("claude", "claude@orbit.local")),
+        Some("gemini") => Some(GitAuthor::new("gemini", "gemini@orbit.local")),
+        Some("codex") => Some(GitAuthor::new("codex", "codex@openai.com")),
+        _ => {
+            let slug = author_slug(implemented_by);
+            Some(GitAuthor::new(slug.clone(), format!("{slug}@orbit.local")))
+        }
+    }
+}
+
+fn implementer_family(implemented_by: &str) -> Option<String> {
+    let lower = implemented_by.trim().to_ascii_lowercase();
+    if lower.is_empty() {
+        return None;
+    }
+
+    let model_hint = lower
+        .rsplit_once(" / ")
+        .map(|(_, model)| model.trim())
+        .unwrap_or(lower.as_str());
+
+    infer_agent_family_from_model(model_hint)
+        .or_else(|| {
+            if model_hint.starts_with("o4") {
+                Some("codex".to_string())
+            } else {
+                None
+            }
+        })
+        .or_else(|| {
+            if lower.starts_with("codex") || lower.starts_with("openai") {
+                Some("codex".to_string())
+            } else if lower.starts_with("claude") || lower.contains("/claude") {
+                Some("claude".to_string())
+            } else if lower.starts_with("gemini") || lower.contains("/gemini") {
+                Some("gemini".to_string())
+            } else {
+                None
+            }
+        })
+}
+
+fn author_slug(label: &str) -> String {
+    let mut slug = String::new();
+    let mut last_was_dash = false;
+
+    for ch in label.trim().chars().flat_map(char::to_lowercase) {
+        if ch.is_ascii_alphanumeric() {
+            slug.push(ch);
+            last_was_dash = false;
+        } else if !last_was_dash {
+            slug.push('-');
+            last_was_dash = true;
+        }
+    }
+
+    let slug = slug.trim_matches('-').to_string();
+    if slug.is_empty() {
+        "agent".to_string()
+    } else {
+        slug
+    }
+}
+
+fn git_commit_with_author(
+    workspace_path: &Path,
+    message: &str,
+    author: Option<&GitAuthor>,
+) -> Result<(), OrbitError> {
+    let mut args = vec!["commit".to_string()];
+    if let Some(author) = author {
+        args.push("--author".to_string());
+        args.push(author.spec());
+    }
+    args.extend(["-m".to_string(), message.to_string()]);
+    git_success_dynamic(workspace_path, &args)
 }
 
 fn resolve_workspace_path<H: RuntimeHost + ?Sized>(
@@ -451,9 +596,224 @@ fn ensure_no_unmerged_changes(workspace_path: &Path) -> Result<(), OrbitError> {
 
 #[cfg(test)]
 mod tests {
-    use super::{normalize_task_scope, path_matches_scope};
+    use std::fs;
+    use std::path::{Path, PathBuf};
 
+    use chrono::Utc;
+    use orbit_common::types::{
+        Activity, Job, JobTargetType, OrbitEvent, Role, TaskArtifact, TaskPriority, TaskStatus,
+        TaskType,
+    };
+    use orbit_tools::ToolContext;
+    use serde_json::{Value, json};
     use tempfile::tempdir;
+
+    use crate::context::{
+        JobRunResult, RuntimeHost, TaskAutomationUpdate, TaskReadHost, TaskWriteHost,
+    };
+    use crate::executor::registry::ActivityExecutorRegistry;
+
+    use super::*;
+
+    struct CommitTestHost {
+        tasks: Vec<Task>,
+        repo_root: PathBuf,
+        data_root: PathBuf,
+        scoreboard_dir: PathBuf,
+        registry: ActivityExecutorRegistry,
+    }
+
+    impl CommitTestHost {
+        fn new(tasks: Vec<Task>, repo_root: PathBuf) -> Self {
+            let data_root = repo_root.join(".orbit-test-data");
+            let scoreboard_dir = data_root.join("scoreboard");
+            Self {
+                tasks,
+                repo_root,
+                data_root,
+                scoreboard_dir,
+                registry: ActivityExecutorRegistry::default(),
+            }
+        }
+    }
+
+    impl TaskReadHost for CommitTestHost {
+        fn get_task(&self, task_id: &str) -> Result<Task, OrbitError> {
+            self.tasks
+                .iter()
+                .find(|task| task.id == task_id)
+                .cloned()
+                .ok_or_else(|| OrbitError::TaskNotFound(task_id.to_string()))
+        }
+
+        fn get_task_artifacts(&self, _task_id: &str) -> Result<Vec<TaskArtifact>, OrbitError> {
+            Ok(Vec::new())
+        }
+
+        fn list_tasks_filtered(
+            &self,
+            status: Option<TaskStatus>,
+            priority: Option<TaskPriority>,
+            parent_id: Option<&str>,
+            batch_id: Option<&str>,
+            external_ref: Option<&orbit_common::types::ExternalRef>,
+            has_external_ref_system: Option<&str>,
+        ) -> Result<Vec<Task>, OrbitError> {
+            Ok(self
+                .tasks
+                .iter()
+                .filter(|task| status.is_none_or(|status| task.status == status))
+                .filter(|task| priority.is_none_or(|priority| task.priority == priority))
+                .filter(|task| {
+                    parent_id.is_none_or(|parent_id| task.parent_id.as_deref() == Some(parent_id))
+                })
+                .filter(|task| {
+                    batch_id.is_none_or(|batch_id| task.batch_id.as_deref() == Some(batch_id))
+                })
+                .filter(|task| {
+                    external_ref.is_none_or(|external_ref| {
+                        task.external_refs.iter().any(|candidate| {
+                            candidate.system == external_ref.system
+                                && candidate.id == external_ref.id
+                        })
+                    })
+                })
+                .filter(|task| {
+                    has_external_ref_system.is_none_or(|system| {
+                        task.external_refs
+                            .iter()
+                            .any(|candidate| candidate.system == system)
+                    })
+                })
+                .cloned()
+                .collect())
+        }
+    }
+
+    impl TaskWriteHost for CommitTestHost {
+        fn start_task(
+            &self,
+            _task_id: &str,
+            _note: Option<String>,
+            _comment: Option<String>,
+        ) -> Result<Task, OrbitError> {
+            Err(OrbitError::Execution(
+                "start_task is not needed by commit tests".to_string(),
+            ))
+        }
+
+        fn admit_task_for_workflow(
+            &self,
+            _task_id: &str,
+            _workflow: &str,
+        ) -> Result<Task, OrbitError> {
+            Err(OrbitError::Execution(
+                "admit_task_for_workflow is not needed by commit tests".to_string(),
+            ))
+        }
+
+        fn update_task_from_activity(
+            &self,
+            _task_id: &str,
+            _status: TaskStatus,
+            _execution_summary: Option<String>,
+            _comment: Option<String>,
+            _note: Option<String>,
+        ) -> Result<Task, OrbitError> {
+            Err(OrbitError::Execution(
+                "update_task_from_activity is not needed by commit tests".to_string(),
+            ))
+        }
+
+        fn apply_task_automation_update(
+            &self,
+            _task_id: &str,
+            _update: TaskAutomationUpdate,
+        ) -> Result<(), OrbitError> {
+            Err(OrbitError::Execution(
+                "apply_task_automation_update is not needed by commit tests".to_string(),
+            ))
+        }
+    }
+
+    impl RuntimeHost for CommitTestHost {
+        fn record_event(&self, _event: OrbitEvent) -> Result<(), OrbitError> {
+            Ok(())
+        }
+
+        fn repo_root(&self) -> Result<String, OrbitError> {
+            Ok(self.repo_root.to_string_lossy().to_string())
+        }
+
+        fn data_root(&self) -> &Path {
+            &self.data_root
+        }
+
+        fn activity_executor_registry(&self) -> &ActivityExecutorRegistry {
+            &self.registry
+        }
+
+        fn run_job_now_with_input_debug(
+            &self,
+            _job_id: &str,
+            _input: Value,
+            _debug: bool,
+        ) -> Result<JobRunResult, OrbitError> {
+            Err(OrbitError::Execution(
+                "run_job_now_with_input_debug is not needed by commit tests".to_string(),
+            ))
+        }
+
+        fn validate_activity_target_exists(
+            &self,
+            _target_type: JobTargetType,
+            _target_id: &str,
+        ) -> Result<Activity, OrbitError> {
+            Err(OrbitError::Execution(
+                "validate_activity_target_exists is not needed by commit tests".to_string(),
+            ))
+        }
+
+        fn get_job(&self, _job_id: &str) -> Result<Option<Job>, OrbitError> {
+            Ok(None)
+        }
+
+        fn run_tool_with_context_and_role(
+            &self,
+            _name: &str,
+            _input: Value,
+            _role: Role,
+            _tool_context: ToolContext,
+        ) -> Result<Value, OrbitError> {
+            Err(OrbitError::Execution(
+                "run_tool_with_context_and_role is not needed by commit tests".to_string(),
+            ))
+        }
+
+        fn maybe_create_failure_task(
+            &self,
+            _job_id: &str,
+            _run_id: &str,
+            _error_code: &str,
+            _error_message: &str,
+            _agent: Option<&str>,
+            _model: Option<&str>,
+        ) -> Result<(), OrbitError> {
+            Ok(())
+        }
+
+        fn scoring_enabled(&self) -> bool {
+            false
+        }
+
+        fn graph_editing(&self) -> bool {
+            false
+        }
+
+        fn scoreboard_dir(&self) -> &Path {
+            &self.scoreboard_dir
+        }
+    }
 
     #[test]
     fn normalize_task_scope_uses_selector_anchor_paths() {
@@ -482,5 +842,132 @@ mod tests {
         assert!(path_matches_scope("src/lib.rs", "src"));
         assert!(path_matches_scope("src/lib.rs", "src/lib.rs"));
         assert!(!path_matches_scope("tests/lib.rs", "src"));
+    }
+
+    #[test]
+    fn git_commit_uses_task_implemented_by_as_author() {
+        let cases = [
+            ("claude-opus-4-7", "claude <claude@orbit.local>"),
+            ("gemini-3.1-pro", "gemini <gemini@orbit.local>"),
+            ("gpt-5.5", "codex <codex@openai.com>"),
+        ];
+
+        for (implemented_by, expected_author) in cases {
+            let temp = initialized_git_repo();
+            let workspace = temp.path();
+            fs::create_dir_all(workspace.join("src")).unwrap();
+            fs::write(
+                workspace.join("src/task.txt"),
+                format!("implemented by {implemented_by}\n"),
+            )
+            .unwrap();
+
+            let task = task_with_file("T1", "Implement one task", "src/task.txt", implemented_by);
+            let host = CommitTestHost::new(vec![task], workspace.to_path_buf());
+            let input = json!({
+                "scope": "per_task",
+                "batch_id": "batch-1",
+                "workspace_path": workspace.to_string_lossy().to_string(),
+                "completed_task_ids": ["T1"],
+            });
+
+            let user_name_before = git_output(workspace, &["config", "--get", "user.name"])
+                .expect("read git user.name before");
+            let user_email_before = git_output(workspace, &["config", "--get", "user.email"])
+                .expect("read git user.email before");
+
+            git_commit(&host, &input).expect("git_commit succeeds");
+
+            let actual_author = git_output(workspace, &["log", "-1", "--format=%an <%ae>"])
+                .expect("read git author");
+            assert_eq!(actual_author, expected_author);
+            assert_eq!(
+                git_output(workspace, &["config", "--get", "user.name"])
+                    .expect("read git user.name after"),
+                user_name_before
+            );
+            assert_eq!(
+                git_output(workspace, &["config", "--get", "user.email"])
+                    .expect("read git user.email after"),
+                user_email_before
+            );
+        }
+    }
+
+    #[test]
+    fn mixed_implementer_batch_commit_uses_aggregate_author_with_trailers() {
+        let temp = initialized_git_repo();
+        let workspace = temp.path();
+        fs::create_dir_all(workspace.join("src")).unwrap();
+        fs::write(workspace.join("src/claude.txt"), "claude work\n").unwrap();
+        fs::write(workspace.join("src/gemini.txt"), "gemini work\n").unwrap();
+
+        let tasks = vec![
+            task_with_file("T1", "Claude task", "src/claude.txt", "claude-opus-4-7"),
+            task_with_file("T2", "Gemini task", "src/gemini.txt", "gemini-3.1-pro"),
+        ];
+        let host = CommitTestHost::new(tasks, workspace.to_path_buf());
+        let input = json!({
+            "scope": "all",
+            "batch_id": "batch-1",
+            "workspace_path": workspace.to_string_lossy().to_string(),
+        });
+
+        git_commit(&host, &input).expect("git_commit succeeds");
+
+        let actual_author =
+            git_output(workspace, &["log", "-1", "--format=%an <%ae>"]).expect("read git author");
+        let body = git_output(workspace, &["log", "-1", "--format=%B"]).expect("read git body");
+        assert_eq!(actual_author, "orbit <orbit@orbit.local>");
+        assert!(body.contains("Co-Authored-By: claude <claude@orbit.local>"));
+        assert!(body.contains("Co-Authored-By: gemini <gemini@orbit.local>"));
+    }
+
+    fn initialized_git_repo() -> tempfile::TempDir {
+        let temp = tempdir().unwrap();
+        let repo = temp.path();
+        git_success(repo, &["init"]).expect("git init");
+        git_success(repo, &["config", "user.name", "Local User"]).expect("config user.name");
+        git_success(repo, &["config", "user.email", "local@example.test"])
+            .expect("config user.email");
+        fs::write(repo.join("README.md"), "base\n").unwrap();
+        git_success(repo, &["add", "README.md"]).expect("git add");
+        git_success(repo, &["commit", "-m", "initial commit"]).expect("initial commit");
+        temp
+    }
+
+    fn task_with_file(id: &str, title: &str, path: &str, implemented_by: &str) -> Task {
+        let now = Utc::now();
+        Task {
+            id: id.to_string(),
+            parent_id: None,
+            title: title.to_string(),
+            description: String::new(),
+            acceptance_criteria: Vec::new(),
+            dependencies: Vec::new(),
+            plan: String::new(),
+            execution_summary: String::new(),
+            context_files: vec![format!("file:{path}")],
+            workspace_path: None,
+            repo_root: None,
+            created_by: None,
+            planned_by: None,
+            implemented_by: Some(implemented_by.to_string()),
+            agent: None,
+            model: None,
+            status: TaskStatus::InProgress,
+            priority: TaskPriority::Medium,
+            complexity: None,
+            task_type: TaskType::Task,
+            pr_status: None,
+            external_refs: Vec::new(),
+            source_task_id: None,
+            batch_id: Some("batch-1".to_string()),
+            comments: Vec::new(),
+            history: Vec::new(),
+            review_threads: Vec::new(),
+            created_at: now,
+            updated_at: now,
+        }
     }
 }

--- a/docs/design/auditability/1_overview.md
+++ b/docs/design/auditability/1_overview.md
@@ -2,7 +2,7 @@
 
 **Status:** Draft
 **Owner:** codex
-**Last updated:** 2026-05-06 (T20260506-2)
+**Last updated:** 2026-05-09 (T20260506-2, T20260508-22)
 
 Auditability is Orbit's answer to the operator question that matters after an agent touches a real repository: what happened, why, and who is accountable? The contract spans command rows, Orbit tool mutations, activity/job runs, provider turns, tool calls, filesystem denials, task attribution, metrics, and redacted payload storage. [2_design.md](./2_design.md) describes the shipped implementation; [3_vision.md](./3_vision.md) names the remaining gaps.
 
@@ -14,7 +14,7 @@ Orbit runs fleets of agents against user-owned repositories, so auditability is 
 
 1. **Replayable accountability.** README and positioning docs promise enough context for every meaningful action to answer what, why, and who. The dedicated design folder from [T20260426-0605] keeps that promise reviewable.
 2. **Layered evidence.** A command row says which command ran. A v2 envelope says which workflow step ran. Loop events and blobs preserve provider/tool detail. The layers must remain related without becoming one oversized record.
-3. **Durable identity.** Task author fields, command audit roles, v2 `agent_identity`, invocation metrics, and commit/task metadata all need to point back to a concrete actor or model.
+3. **Durable identity.** Task author fields, command audit roles, v2 `agent_identity`, invocation metrics, git commit authors, and commit/task metadata all need to point back to a concrete actor or model.
 4. **Write-side secrecy.** Orbit preserves useful payloads while redacting provider keys and sensitive environment-derived values before durable storage.
 5. **Explicit gaps.** Silent mutation paths are bugs. Missing coverage belongs in the coverage matrix, not in tribal memory.
 
@@ -61,6 +61,7 @@ The default tracing subscriber appends redacted structured events to `~/.orbit/s
 | Global tracing JSONL feed and live projections | `crates/orbit-common/src/utility/logging.rs`, selected FS/proc/task producers | [T20260426-2343], [T20260427-0023] |
 | V2 invocation metrics persistence | `crates/orbit-store/src/sqlite/invocation_store.rs`, `crates/orbit-core/src/runtime/v2_host.rs` | [T20260426-0526] |
 | Task attribution fields | `crates/orbit-common/src/types/task.rs`, task update/runtime host paths | [T20260426-0605], [T20260427-47] |
+| Git commit author attribution | `crates/orbit-engine/src/executor/automation/commit.rs` | [T20260508-22] |
 
 ---
 
@@ -78,5 +79,6 @@ The default tracing subscriber appends redacted structured events to `~/.orbit/s
 - **[T20260427-47]** — Allow explicit task attribution correction for `planned_by` and `implemented_by` through task update paths.
 - **[T20260430-20]** — Shorten the auditability docs while preserving required guarantees.
 - **[T20260506-2]** — Lazily materialize loop audit JSONL files only when loop-level events are emitted.
+- **[T20260508-22]** — Use `task.implemented_by` to set git commit authors for automated task commits.
 
 > Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.

--- a/docs/design/auditability/2_design.md
+++ b/docs/design/auditability/2_design.md
@@ -2,7 +2,7 @@
 
 **Status:** Draft
 **Owner:** codex
-**Last updated:** 2026-05-08 (T20260506-2, T20260508-8, T20260508-14)
+**Last updated:** 2026-05-09 (T20260506-2, T20260508-8, T20260508-14, T20260508-22)
 
 This document describes Orbit's shipped auditability implementation across command audit rows, activity/job envelopes, loop-level provider/tool traces, blob storage, redaction, identity attribution, metrics-adjacent invocation records, and known limitations. See [1_overview.md](./1_overview.md) for the feature purpose and [3_vision.md](./3_vision.md) for future questions.
 
@@ -90,6 +90,8 @@ Orbit currently carries identity through related fields rather than one universa
 
 Task attribution remains automatic by default: non-empty plan writes stamp `planned_by`, and transitions into `review` or `done` stamp `implemented_by`. After [T20260427-47], `orbit.task.update` and direct `orbit task update` can explicitly set or clear those fields; explicit values win within the same update.
 
+After [T20260508-22], `git_commit` automation carries that task attribution into git metadata. Per-task commits pass `--author` derived from `task.implemented_by` (`claude`, `gemini`, or `codex` family identities), leaving repository `git config user.name` and `user.email` untouched for committer identity. Multi-implementer batch commits use `orbit <orbit@orbit.local>` as the aggregate author and add `Co-Authored-By` trailers for each distinct implementer identity.
+
 The requirement is not to collapse every field into one value. It is that a reviewer can follow task state, command rows, run envelopes, provider/tool traces, and metrics back to a concrete human or model. A unified identity glossary and query join story remain open.
 
 ---
@@ -155,5 +157,6 @@ Each record contains timestamp, level, target, and structured fields. After [T20
 - **[T20260506-2]** — Lazily materialize loop audit JSONL files only when loop-level events are emitted.
 - **[T20260508-8]** — Record backend: cli subprocess cwd in v2 audit and live tracing.
 - **[T20260508-14]** — Surface bounded per-step agent log previews and derived diagnostics error rows in the dashboard.
+- **[T20260508-22]** — Use `task.implemented_by` to set git commit authors for automated task commits.
 
 > Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.

--- a/docs/design/auditability/4_decisions.md
+++ b/docs/design/auditability/4_decisions.md
@@ -2,7 +2,7 @@
 
 **Status:** Draft
 **Owner:** codex
-**Last updated:** 2026-05-06 (T20260506-2)
+**Last updated:** 2026-05-09 (T20260506-2, T20260508-22)
 
 This is the append-only ADR log for Auditability. Entries are ordered by ADR number. New entries should use the template in [../CONVENTIONS.md](../CONVENTIONS.md) and cite the task that made the decision real.
 
@@ -260,6 +260,19 @@ This is the append-only ADR log for Auditability. Entries are ordered by ADR num
 - Runs with no loop-level provider/tool events no longer leave empty loop JSONL placeholders.
 - Cost: consumers must treat a missing loop JSONL file as "no loop events were emitted", not as a missing run; the v2 envelope file remains the canonical run spine.
 
+## ADR-022 — Automated git commits carry implementer authorship
+
+**Status:** Accepted · 2026-05 · [T20260508-22]
+
+**Context.** Task records already store `implemented_by`, but automated `git_commit` actions previously delegated commit authorship to local git config, hiding the agent that actually produced the change.
+
+**Decision.** Pass a per-commit `--author` derived from `task.implemented_by` for single-implementer commits. Mixed-implementer batch commits use `orbit <orbit@orbit.local>` as the aggregate author and add one `Co-Authored-By` trailer per distinct implementer identity.
+
+**Consequences.**
+- Reviewers can see implementation provenance directly in git history without joining back through run audit events.
+- Local git config remains committer identity only and can stay stable across parallel agent runs.
+- Cost: multi-implementer batch commits require trailer-aware attribution queries; `git log --author` finds the aggregate commit author, not every co-author trailer.
+
 ---
 
 ## Task References
@@ -289,5 +302,6 @@ This is the append-only ADR log for Auditability. Entries are ordered by ADR num
 - **[T20260430-20]** — Shorten the auditability docs while preserving required guarantees.
 - **[T20260505-6]** — Replace timestamp-only command-audit execution ids with process-disambiguated generated ids for parallel tool runs.
 - **[T20260506-2]** — Lazily materialize loop audit JSONL files only when loop-level events are emitted.
+- **[T20260508-22]** — Use `task.implemented_by` to set git commit authors for automated task commits.
 
 > Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.


### PR DESCRIPTION
## Task

[T20260508-22](https://orbit-cli.com/tasks/T20260508-22) — git_commit action ignores task.implemented_by; commits land as local git config user

### Description

## Problem

The `git_commit` automation action (`crates/orbit-engine/src/executor/automation/commit.rs`) calls `git commit -m <message>` with no `--author` flag and no `GIT_AUTHOR_*` environment overrides. All three commit scopes — `commit_task_artifact_changes` (line 91), `commit_finalize_artifact_changes` (line 144), and `commit_batch_changes` (line 190) — go through the same `git_success(..., &["commit", "-m", &message])` call.

Result: every commit produced by the pipeline is authored by whatever user identity the workspace's `git config user.name/user.email` resolves to, regardless of which agent actually did the implementation work.

Concrete reproduction:

- Run: `jrun-20260508-0637` (task `T20260508-20`, branch `orbit/T20260508-20-69fd8497`).
- `cli.invocation.started` event records `provider=claude model=claude-opus-4-7` — claude was the implementer.
- The branch's tip commit `d2b00f85` is authored as `codex <codex@openai.com>` because that's the local user's git config.
- PR https://github.com/anthropics/orbit/pull/161 (now closed) shows `codex` as committer everywhere, with no surface signal that claude was the implementer.

The implementer identity IS captured elsewhere — `task.implemented_by` is populated correctly per `crates/orbit-core/src/runtime/engine/task_host.rs:118-148`. It just never makes it to the git author trailer.

## Why It Matters

- "Who actually did this work?" becomes a multi-step lookup: read the run's audit events, find `cli.invocation.started`, parse `provider`/`model`. Anyone outside the run (PR reviewer, retro author, friction triager) sees only the workspace user identity.
- The "parallel batch" workflow runs different implementers in parallel and the only way to compare their output via git history (e.g., `git log --author='claude <claude@orbit.local>'`) is broken.
- Friction reports and retros that bucket commits by implementer to compute scoreboards (`crates/orbit-store/src/file/scoreboard/...`) cannot use git as a source of truth — they have to join through `task.implemented_by`, which assumes a stable mapping that's invisible from the commit alone.

T20260508-17's commit-message convention already prescribes per-implementer identity: prior commits use `claude <claude@orbit.local>`, `gemini <gemini@orbit.local>`, etc. The `git_commit` automation just doesn't honor it.

## Constraints / Notes

- The fix must thread `implemented_by` (or an aggregate of implementers when committing a multi-task batch) into the `git commit` call as `--author='<name> <email>'`. Email mapping convention is already in use: `claude@orbit.local`, `gemini@orbit.local`, `codex@openai.com`, etc.
- `commit_batch_changes` is the trickiest scope: a parallel batch may have multiple distinct implementers across the included tasks. Reasonable options: (a) pick the dominant implementer; (b) use a synthetic `orbit <orbit@orbit.local>` author and add per-task `Co-Authored-By` trailers to the message; (c) split the batch commit into per-implementer commits. Pick whichever option preserves the per-implementer git-log filter.
- Per-task scopes (`commit_task_artifact_changes`, `commit_finalize_artifact_changes`) are simpler: each commit covers one task, so `task.implemented_by` maps cleanly to one author identity.
- Committer (vs author) can stay as the local git config — that matches existing convention where `claude` is author and `codex@openai.com` is the committer host machine.
- Don't change `git config` globally; pass `--author` per-commit so multiple implementers can coexist in the same workspace.

## Investigation pointers

- `file:crates/orbit-engine/src/executor/automation/commit.rs:91` — single-task commit path.
- `file:crates/orbit-engine/src/executor/automation/commit.rs:144` — finalize-artifact commit path.
- `file:crates/orbit-engine/src/executor/automation/commit.rs:190` — batch commit path.
- `file:crates/orbit-core/src/runtime/engine/task_host.rs:118` — `implemented_by` population at task-update time; canonical source of truth.
- `file:crates/orbit-engine/src/executor/automation/git.rs` — wraps `Command::new("git")`; `--author` injection lands here or in commit.rs.
- Existing convention examples: `git log --pretty=format:'%h %an &lt;%ae>'` shows `claude &lt;claude@orbit.local>`, `gemini &lt;gemini@orbit.local>`, `codex &lt;codex@openai.com>`.

### Acceptance Criteria

- A new commit produced by `git_commit` (any scope) when `task.implemented_by == "claude-opus-4-7"` (or any claude-* model) has author `claude <claude@orbit.local>`. Verifiable via `git log -1 --format='%an <%ae>' <commit>`.
- The same property holds for at least two other implementers used in the wild (e.g. `gemini-3.1-pro` → `gemini <gemini@orbit.local>`, `gpt-5.5` → `codex <codex@openai.com>`).
- When `commit_batch_changes` covers tasks from multiple distinct implementers, the resulting commit either (a) sets `--author` to the chosen aggregate identity AND adds `Co-Authored-By:` trailers for the others, or (b) splits into per-implementer commits — and a unit test in `crates/orbit-engine/src/executor/automation/commit.rs` asserts the chosen behavior.
- `git config user.name` / `user.email` are NOT modified by the action — verifiable via `git config --get user.name` before and after a commit run.
- A regression unit test in `commit.rs` constructs a fake task with `implemented_by` set, runs `git_commit` against a tempdir git repo, and asserts the resulting `git log -1` author matches the expected identity.
- Replay against a real `task_pr_pipeline` run with `provider=claude` produces a commit whose `git log` author is `claude <claude@orbit.local>` (not the local git-config user) — captured in the task's execution summary.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Threaded task.implemented_by into git_commit author selection for per-task, finalize, and batch scopes without changing git config.
- Added claude, gemini, and codex author identity mapping, plus mixed-batch aggregate author behavior with Co-Authored-By trailers.
- Added tempdir git regression tests for claude, gemini, gpt/codex, git-config preservation, and mixed-implementer batch commits.
- Updated auditability design docs and ADR-022 for git commit authorship provenance.

Validation:
- make fmt
- cargo test -p orbit-engine executor::automation::commit::tests -- --nocapture
- make build
- git diff --check

Design weaknesses / risks:
- Full live provider=claude task_pr_pipeline replay was not invoked from this executor because it would require an external agent/provider run; the commit action behavior was validated directly against real temporary git repositories instead.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/T20260508-22-69fe9132`
- Behind base: 0
- Ahead of base: 1

*authored by: claude-opus-4-7*