### PR TITLE
Auto-populate task.context_files from the winning plan after duel resolution

### DIFF
--- a/crates/orbit-common/src/types/event.rs
+++ b/crates/orbit-common/src/types/event.rs
@@ -155,4 +155,14 @@ pub enum OrbitEvent {
         id: String,
         message: String,
     },
+    /// Recorded when [planning-duel writeback] drops an entry from the winning
+    /// plan's "Context Files" section because it could not be canonicalized
+    /// into a `file:` / `dir:` / `symbol:` selector. The writeback continues
+    /// without the entry; consumers can use this event to debug stale or
+    /// malformed plan markdown.
+    PlanningDuelContextFileSkipped {
+        task_id: String,
+        raw_entry: String,
+        reason: String,
+    },
 }

--- a/crates/orbit-core/src/runtime/engine/task_host.rs
+++ b/crates/orbit-core/src/runtime/engine/task_host.rs
@@ -140,6 +140,7 @@ impl TaskWriteHost for OrbitRuntime {
                     actor: actor_label.clone(),
                     execution_summary: update.execution_summary.clone(),
                     plan: update.plan.clone(),
+                    context_files: update.context_files.clone(),
                     planned_by,
                     implemented_by: if matches!(
                         update.status,
@@ -252,6 +253,86 @@ mod tests {
             None,
         )
         .expect("run worktree setup")
+    }
+
+    #[test]
+    fn apply_task_automation_update_does_not_touch_context_files_when_unset() {
+        let (root, runtime) = test_runtime();
+        // Pre-create files in the workspace so add_task does not prune the
+        // selectors as missing.
+        let repo = root.path().join("repo");
+        fs::write(repo.join("README.md"), "test\n").expect("write README.md");
+        fs::write(repo.join("CLAUDE.md"), "test\n").expect("write CLAUDE.md");
+        let task = runtime
+            .add_task(TaskAddParams {
+                title: "Preserve context_files".to_string(),
+                description: "Exercise context_files preservation across automation updates."
+                    .to_string(),
+                workspace_path: Some(".".to_string()),
+                context_files: vec!["README.md".to_string(), "CLAUDE.md".to_string()],
+                ..Default::default()
+            })
+            .expect("add task");
+
+        let initial_context_files = runtime
+            .get_task(&task.id)
+            .expect("reload task")
+            .context_files;
+        assert!(
+            !initial_context_files.is_empty(),
+            "test precondition: add_task should keep existing context_files"
+        );
+
+        runtime
+            .apply_task_automation_update(
+                &task.id,
+                TaskAutomationUpdate {
+                    plan: Some("## Plan\nSome plan body.\n".to_string()),
+                    context_files: None,
+                    ..TaskAutomationUpdate::default()
+                },
+            )
+            .expect("automation update without context_files set");
+
+        let updated = runtime.get_task(&task.id).expect("reload task");
+        assert_eq!(
+            updated.context_files, initial_context_files,
+            "context_files: None should leave the field untouched"
+        );
+    }
+
+    #[test]
+    fn apply_task_automation_update_replaces_context_files_when_set() {
+        let (_root, runtime) = test_runtime();
+        let task = runtime
+            .add_task(TaskAddParams {
+                title: "Replace context_files".to_string(),
+                description: "Exercise context_files replacement via automation update."
+                    .to_string(),
+                workspace_path: Some(".".to_string()),
+                context_files: vec!["Cargo.toml".to_string()],
+                ..Default::default()
+            })
+            .expect("add task");
+
+        runtime
+            .apply_task_automation_update(
+                &task.id,
+                TaskAutomationUpdate {
+                    context_files: Some(vec![
+                        "file:src/new.rs".to_string(),
+                        "dir:src/new_dir".to_string(),
+                    ]),
+                    ..TaskAutomationUpdate::default()
+                },
+            )
+            .expect("automation update with new context_files");
+
+        let updated = runtime.get_task(&task.id).expect("reload task");
+        assert_eq!(
+            updated.context_files,
+            vec!["file:src/new.rs".to_string(), "dir:src/new_dir".to_string()]
+        );
     }
 
     #[test]

--- a/crates/orbit-engine/src/context.rs
+++ b/crates/orbit-engine/src/context.rs
@@ -186,6 +186,11 @@ pub struct ActivityInvocationResult {
 pub struct TaskAutomationUpdate {
     pub status: Option<TaskStatus>,
     pub plan: Option<String>,
+    /// Default `None` = leave the task's `context_files` untouched. `Some(v)`
+    /// replaces the field wholesale (mirrors `TaskDocumentUpdateParams.context_files`
+    /// semantics in `orbit-store`). Only set deliberately — most automation
+    /// call sites should leave this at `None`.
+    pub context_files: Option<Vec<String>>,
     pub workspace_path: Option<Option<String>>,
     pub repo_root: Option<String>,
     pub external_refs: Vec<ExternalRef>,

--- a/crates/orbit-engine/src/executor/automation/planning_duel/artifacts.rs
+++ b/crates/orbit-engine/src/executor/automation/planning_duel/artifacts.rs
@@ -3,7 +3,8 @@ use std::path::{Path, PathBuf};
 
 use chrono::Utc;
 use orbit_common::types::{
-    OrbitError, PlannerSlot, PlanningRoleAssignment, PlanningRoles, Role, TaskArtifact, TaskComment,
+    OrbitError, OrbitEvent, PlannerSlot, PlanningRoleAssignment, PlanningRoles, Role, TaskArtifact,
+    TaskComment,
 };
 use orbit_tools::ToolContext;
 use serde_json::{Value, json};
@@ -11,6 +12,7 @@ use serde_json::{Value, json};
 use crate::context::{RuntimeHost, TaskAutomationUpdate, TaskHost};
 use crate::executor::automation::input::required_input_string;
 
+use super::context_files::extract_context_files_from_plan;
 use super::roles::parse_planning_duel_roles;
 use super::types::{
     PlanningDuelPlanArtifact, PlanningDuelWinnerArtifact, PlanningDuelWinnerMarker,
@@ -390,7 +392,7 @@ pub(super) fn cleanup_stale_planning_duel_artifacts<H: RuntimeHost + TaskHost + 
     Ok(())
 }
 
-pub(super) fn writeback_planning_duel_task<H: TaskHost + ?Sized>(
+pub(super) fn writeback_planning_duel_task<H: TaskHost + RuntimeHost + ?Sized>(
     host: &H,
     input: &Value,
 ) -> Result<Value, OrbitError> {
@@ -421,6 +423,19 @@ pub(super) fn writeback_planning_duel_task<H: TaskHost + ?Sized>(
         None
     };
     let winning_plan = normalize_winning_plan_for_task(&winning_artifact.content);
+    let extraction = extract_context_files_from_plan(&winning_plan);
+    let context_files = extraction.as_ref().map(|e| e.canonical_entries.clone());
+    if let Some(extraction) = extraction.as_ref() {
+        for skipped in &extraction.skipped {
+            // Best-effort observability — never fail writeback on event-record error.
+            let _ = host.record_event(OrbitEvent::PlanningDuelContextFileSkipped {
+                task_id: task_id.to_string(),
+                raw_entry: skipped.raw_entry.clone(),
+                reason: skipped.reason.clone(),
+            });
+        }
+    }
+
     let winner_label = winner_slot
         .map(|slot| match slot {
             PlannerSlot::PlannerA => "planner_a",
@@ -441,6 +456,7 @@ pub(super) fn writeback_planning_duel_task<H: TaskHost + ?Sized>(
         task_id,
         TaskAutomationUpdate {
             plan: Some(winning_plan),
+            context_files,
             status_event: Some("planning_duel_resolved".to_string()),
             status_note: Some(format!(
                 "{status_note}; rationale={}",

--- a/crates/orbit-engine/src/executor/automation/planning_duel/context_files.rs
+++ b/crates/orbit-engine/src/executor/automation/planning_duel/context_files.rs
@@ -1,0 +1,333 @@
+use orbit_common::utility::selector::canonical_selector;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct SkippedEntry {
+    pub raw_entry: String,
+    pub reason: String,
+}
+
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub(super) struct PlanContextFilesExtraction {
+    /// Canonical, deduped selectors in first-seen order. Empty when the section
+    /// was recognized but yielded zero usable entries.
+    pub canonical_entries: Vec<String>,
+    pub skipped: Vec<SkippedEntry>,
+}
+
+/// Extract a canonical `context_files` list from a winning planning-duel plan.
+///
+/// Section recognition is deliberately strict: the plan must contain a heading
+/// line at level `##` or `###` whose trimmed, case-insensitive text equals
+/// `context files` or `context_files` (a single trailing `:` is permitted).
+/// The section body extends to the next heading of equal-or-higher level, or
+/// end of input. Anything outside this strict shape returns `None`, which the
+/// writeback treats as "preserve the existing field".
+///
+/// Bullets within the section body (`- ` or `* ` prefix on an unindented line)
+/// contribute one entry each: the first inline-code span if present, otherwise
+/// the first whitespace-bounded token after the bullet marker. Each entry is
+/// canonicalized via [`canonical_selector`]; entries that fail canonicalization
+/// are dropped and reported in `skipped`. Duplicates are collapsed in
+/// first-seen order.
+///
+/// Returns `None` for: section absent, section recognized but with zero
+/// canonicalized entries (e.g. placeholder section or every bullet
+/// unparseable). Returns `Some(extraction)` only when at least one canonical
+/// entry was produced; `extraction.skipped` carries dropped entries even in
+/// the success case so callers can record observability events.
+pub(super) fn extract_context_files_from_plan(plan: &str) -> Option<PlanContextFilesExtraction> {
+    let lines: Vec<&str> = plan.lines().collect();
+    let section_range = find_context_files_section(&lines)?;
+    let section = &lines[section_range];
+
+    let mut canonical_entries: Vec<String> = Vec::new();
+    let mut skipped: Vec<SkippedEntry> = Vec::new();
+
+    for line in section {
+        let Some(raw_entry) = bullet_entry(line) else {
+            continue;
+        };
+        match canonical_selector(&raw_entry) {
+            Ok(canonical) => {
+                if !canonical_entries.contains(&canonical) {
+                    canonical_entries.push(canonical);
+                }
+            }
+            Err(err) => {
+                skipped.push(SkippedEntry {
+                    raw_entry,
+                    reason: err.reason,
+                });
+            }
+        }
+    }
+
+    if canonical_entries.is_empty() {
+        return None;
+    }
+
+    Some(PlanContextFilesExtraction {
+        canonical_entries,
+        skipped,
+    })
+}
+
+fn find_context_files_section(lines: &[&str]) -> Option<std::ops::Range<usize>> {
+    let mut start: Option<usize> = None;
+    let mut start_level: usize = 0;
+    let mut end = lines.len();
+
+    for (idx, line) in lines.iter().enumerate() {
+        let Some((level, heading_text)) = parse_heading(line) else {
+            continue;
+        };
+
+        if start.is_none() {
+            if (level == 2 || level == 3) && heading_matches_context_files(heading_text) {
+                start = Some(idx + 1);
+                start_level = level;
+            }
+            continue;
+        }
+
+        if level <= start_level {
+            end = idx;
+            break;
+        }
+    }
+
+    let body_start = start?;
+    if body_start > end {
+        return None;
+    }
+    Some(body_start..end)
+}
+
+fn parse_heading(line: &str) -> Option<(usize, &str)> {
+    let trimmed = line.trim_start();
+    let hash_count = trimmed.bytes().take_while(|byte| *byte == b'#').count();
+    if hash_count == 0 || hash_count > 6 {
+        return None;
+    }
+    let after_hashes = &trimmed[hash_count..];
+    if !after_hashes.starts_with(' ') && !after_hashes.is_empty() {
+        return None;
+    }
+    Some((hash_count, after_hashes.trim()))
+}
+
+fn heading_matches_context_files(heading_text: &str) -> bool {
+    let normalized = heading_text.trim_end_matches(':').trim().to_lowercase();
+    normalized == "context files" || normalized == "context_files"
+}
+
+fn bullet_entry(line: &str) -> Option<String> {
+    let leading_spaces = line.bytes().take_while(|byte| *byte == b' ').count();
+    if leading_spaces >= 2 {
+        return None;
+    }
+    let trimmed = line.trim_start();
+    let after_marker = trimmed
+        .strip_prefix("- ")
+        .or_else(|| trimmed.strip_prefix("* "))?;
+    let after_marker = after_marker.trim_start();
+    if after_marker.is_empty() {
+        return None;
+    }
+
+    if let Some(after_open) = after_marker.strip_prefix('`')
+        && let Some(close) = after_open.find('`')
+    {
+        let entry = after_open[..close].trim();
+        if !entry.is_empty() {
+            return Some(entry.to_string());
+        }
+    }
+
+    let token_end = after_marker
+        .find(|c: char| c.is_whitespace())
+        .unwrap_or(after_marker.len());
+    let raw_token = &after_marker[..token_end];
+    let token = raw_token.trim_matches(|c: char| matches!(c, ',' | '.' | ';' | ')' | '('));
+    if token.is_empty() {
+        None
+    } else {
+        Some(token.to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn extract(plan: &str) -> Option<PlanContextFilesExtraction> {
+        extract_context_files_from_plan(plan)
+    }
+
+    #[test]
+    fn extract_returns_none_when_no_context_files_section() {
+        let plan = "## Plan\n\n- Step 1\n\n## Risks\n\n- Some risk.\n";
+        assert!(extract(plan).is_none());
+    }
+
+    #[test]
+    fn extract_returns_canonical_entries_for_canonical_bullets() {
+        let plan = "## Context Files\n\n- `file:src/a.rs`\n- `dir:crates/foo`\n- `symbol:src/lib.rs#bar:function`\n";
+        let result = extract(plan).expect("section present");
+        assert_eq!(
+            result.canonical_entries,
+            vec![
+                "file:src/a.rs".to_string(),
+                "dir:crates/foo".to_string(),
+                "symbol:src/lib.rs#bar:function".to_string(),
+            ]
+        );
+        assert!(result.skipped.is_empty());
+    }
+
+    #[test]
+    fn extract_upgrades_raw_paths_to_file_or_dir() {
+        let plan = "## Context Files\n\n- crates/foo/bar.rs\n- crates/foo/\n";
+        let result = extract(plan).expect("section present");
+        assert_eq!(
+            result.canonical_entries,
+            vec![
+                "file:crates/foo/bar.rs".to_string(),
+                "dir:crates/foo".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn extract_handles_mixed_canonical_and_raw_entries_in_one_list() {
+        let plan =
+            "## Context Files\n- `file:src/a.rs`\n- src/b.rs\n- `dir:crates/x`\n- crates/y/\n";
+        let result = extract(plan).expect("section present");
+        assert_eq!(
+            result.canonical_entries,
+            vec![
+                "file:src/a.rs".to_string(),
+                "file:src/b.rs".to_string(),
+                "dir:crates/x".to_string(),
+                "dir:crates/y".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn extract_strips_em_dash_annotations_after_entry() {
+        let plan = "## Context Files\n\n- `file:src/a.rs` — handles the read path.\n- `file:src/b.rs` (helper).\n";
+        let result = extract(plan).expect("section present");
+        assert_eq!(
+            result.canonical_entries,
+            vec!["file:src/a.rs".to_string(), "file:src/b.rs".to_string()]
+        );
+    }
+
+    #[test]
+    fn extract_terminates_section_at_next_same_level_heading() {
+        let plan =
+            "## Context Files\n\n- `file:src/a.rs`\n\n## Risks\n\n- `file:should/not/appear.rs`\n";
+        let result = extract(plan).expect("section present");
+        assert_eq!(result.canonical_entries, vec!["file:src/a.rs".to_string()]);
+    }
+
+    #[test]
+    fn extract_terminates_section_at_higher_level_heading() {
+        let plan = "## Context Files\n\n- `file:src/a.rs`\n\n# Top Level\n\n- `file:should/not/appear.rs`\n";
+        let result = extract(plan).expect("section present");
+        assert_eq!(result.canonical_entries, vec!["file:src/a.rs".to_string()]);
+    }
+
+    #[test]
+    fn extract_dedupes_preserving_first_seen_order() {
+        let plan = "## Context Files\n- `file:src/a.rs`\n- `file:src/b.rs`\n- `file:src/a.rs`\n- src/b.rs\n";
+        let result = extract(plan).expect("section present");
+        assert_eq!(
+            result.canonical_entries,
+            vec!["file:src/a.rs".to_string(), "file:src/b.rs".to_string()]
+        );
+    }
+
+    #[test]
+    fn extract_returns_none_when_section_recognized_but_empty() {
+        let plan = "## Context Files\n\n## Risks\n\n- `file:should/not/appear.rs`\n";
+        assert!(extract(plan).is_none());
+    }
+
+    #[test]
+    fn extract_skips_unparseable_entries_and_records_skip() {
+        // `symbol:foo` is missing the `#name:kind` suffix → canonicalization fails.
+        let plan = "## Context Files\n\n- `file:src/a.rs`\n- `symbol:foo`\n";
+        let result = extract(plan).expect("section present");
+        assert_eq!(result.canonical_entries, vec!["file:src/a.rs".to_string()]);
+        assert_eq!(result.skipped.len(), 1, "one entry should be skipped");
+        assert_eq!(result.skipped[0].raw_entry, "symbol:foo");
+        assert!(
+            !result.skipped[0].reason.is_empty(),
+            "skip reason should be populated"
+        );
+    }
+
+    #[test]
+    fn extract_skips_subbullets_and_non_bullet_lines() {
+        let plan = "## Context Files\n\n- `file:src/a.rs`\n  - `file:nested/should-not-appear.rs`\nDescription line.\n* `file:src/b.rs`\n";
+        let result = extract(plan).expect("section present");
+        assert_eq!(
+            result.canonical_entries,
+            vec!["file:src/a.rs".to_string(), "file:src/b.rs".to_string()]
+        );
+    }
+
+    #[test]
+    fn extract_accepts_h3_section() {
+        let plan = "### Context Files\n\n- `file:src/a.rs`\n";
+        let result = extract(plan).expect("section present");
+        assert_eq!(result.canonical_entries, vec!["file:src/a.rs".to_string()]);
+    }
+
+    #[test]
+    fn extract_rejects_non_exact_heading() {
+        let plan = "## Context files referenced by step 3\n\n- `file:src/a.rs`\n";
+        assert!(extract(plan).is_none());
+    }
+
+    #[test]
+    fn extract_accepts_trailing_colon_on_heading() {
+        let plan = "## Context Files:\n\n- `file:src/a.rs`\n";
+        let result = extract(plan).expect("section present");
+        assert_eq!(result.canonical_entries, vec!["file:src/a.rs".to_string()]);
+    }
+
+    #[test]
+    fn extract_handles_t20260509_7_shape() {
+        // Snapshot of a representative T20260509-7 winning plan ## Context Files
+        // section as of 2026-05-08. Pinned inline rather than referencing the
+        // live task record so the test is stable.
+        let plan = r#"## Plan
+
+Do the work.
+
+## Context Files
+
+- `symbol:crates/orbit-engine/src/executor/automation/planning_duel/artifacts.rs#writeback_planning_duel_task:function` — primary insertion point.
+- `file:crates/orbit-engine/src/context.rs` — add the `context_files` field.
+- `dir:crates/orbit-engine/src/executor/automation/planning_duel` — module folder.
+- `file:CLAUDE.md` — doc-update rule.
+
+## Risks
+
+- Heuristics drift.
+"#;
+        let result = extract(plan).expect("section present");
+        assert_eq!(
+            result.canonical_entries,
+            vec![
+                "symbol:crates/orbit-engine/src/executor/automation/planning_duel/artifacts.rs#writeback_planning_duel_task:function".to_string(),
+                "file:crates/orbit-engine/src/context.rs".to_string(),
+                "dir:crates/orbit-engine/src/executor/automation/planning_duel".to_string(),
+                "file:CLAUDE.md".to_string(),
+            ]
+        );
+    }
+}

--- a/crates/orbit-engine/src/executor/automation/planning_duel/mod.rs
+++ b/crates/orbit-engine/src/executor/automation/planning_duel/mod.rs
@@ -1,4 +1,5 @@
 mod artifacts;
+mod context_files;
 mod metrics;
 mod roles;
 mod runner;

--- a/crates/orbit-engine/src/executor/automation/planning_duel/runner.rs
+++ b/crates/orbit-engine/src/executor/automation/planning_duel/runner.rs
@@ -175,6 +175,7 @@ mod tests {
         _tempdir: TempDir,
         workflow_admissions: AtomicUsize,
         task_starts: AtomicUsize,
+        last_automation_update: Mutex<Option<TaskAutomationUpdate>>,
     }
 
     impl PlanningDuelHost {
@@ -192,11 +193,20 @@ mod tests {
                 _tempdir: tempdir,
                 workflow_admissions: AtomicUsize::new(0),
                 task_starts: AtomicUsize::new(0),
+                last_automation_update: Mutex::new(None),
             }
         }
 
         fn task_status(&self) -> TaskStatus {
             self.task.lock().expect("task lock").status
+        }
+
+        fn last_context_files_update(&self) -> Option<Option<Vec<String>>> {
+            self.last_automation_update
+                .lock()
+                .expect("update lock")
+                .as_ref()
+                .map(|update| update.context_files.clone())
         }
 
         fn admission_count(&self) -> usize {
@@ -287,9 +297,13 @@ mod tests {
                     "planning duel writeback must not include a status update".to_string(),
                 ));
             }
+            *self.last_automation_update.lock().expect("update lock") = Some(update.clone());
             let mut task = self.task.lock().expect("task lock");
             if let Some(plan) = update.plan {
                 task.plan = plan;
+            }
+            if let Some(context_files) = update.context_files {
+                task.context_files = context_files;
             }
             task.comments.extend(update.append_comments);
             task.agent = update.agent;
@@ -554,5 +568,132 @@ mod tests {
             assert_eq!(host.admission_count(), 0, "{status}");
             assert_eq!(host.start_count(), 0, "{status}");
         }
+    }
+
+    fn install_planning_duel_artifacts(host: &PlanningDuelHost, plan_body: &str) {
+        let mut artifacts = host.artifacts.lock().expect("artifacts lock");
+        artifacts.clear();
+        artifacts.push(TaskArtifact {
+            path: "planning-duel/codex-gpt-5.5.md".to_string(),
+            content: "*authored by: codex / gpt-5.5*\n## Plan\nLoser plan.\n".to_string(),
+        });
+        artifacts.push(TaskArtifact {
+            path: "planning-duel/claude-claude-opus-4-7.md".to_string(),
+            content: format!("*authored by: claude / claude-opus-4-7*\n{plan_body}"),
+        });
+        artifacts.push(TaskArtifact {
+            path: "planning-duel/winner.json".to_string(),
+            content: json!({
+                "winner_agent_cli": "claude",
+                "winner_model": "claude-opus-4-7",
+                "arbiter_rationale": "Claude provided more detail."
+            })
+            .to_string(),
+        });
+    }
+
+    fn run_writeback(host: &PlanningDuelHost) -> serde_json::Value {
+        super::artifacts::writeback_planning_duel_task(
+            host,
+            &json!({
+                "task_id": "T20260430-STATUS",
+                "planning_duel_roles": {
+                    "planner_a": { "agent": "codex", "model": "gpt-5.5" },
+                    "planner_b": { "agent": "claude", "model": "claude-opus-4-7" },
+                    "arbiter":   { "agent": "gemini", "model": "gemini-3.1-pro" }
+                }
+            }),
+        )
+        .expect("writeback succeeds")
+    }
+
+    #[test]
+    fn writeback_populates_context_files_when_section_present() {
+        let host = PlanningDuelHost::new(TaskStatus::InProgress);
+        install_planning_duel_artifacts(
+            &host,
+            "## Plan\nDo it.\n\n## Context Files\n\n- `file:src/a.rs`\n- crates/foo/\n",
+        );
+
+        let _ = run_writeback(&host);
+
+        assert_eq!(
+            host.last_context_files_update(),
+            Some(Some(vec![
+                "file:src/a.rs".to_string(),
+                "dir:crates/foo".to_string(),
+            ])),
+            "writeback should set context_files to canonical entries"
+        );
+
+        let task = host.get_task("T20260430-STATUS").expect("task readable");
+        assert_eq!(
+            task.context_files,
+            vec!["file:src/a.rs".to_string(), "dir:crates/foo".to_string()]
+        );
+    }
+
+    #[test]
+    fn writeback_preserves_context_files_when_section_absent() {
+        let host = PlanningDuelHost::new(TaskStatus::InProgress);
+        // Pre-populate the task's context_files with curated state.
+        host.task.lock().expect("task lock").context_files =
+            vec!["file:pre-existing.rs".to_string()];
+        install_planning_duel_artifacts(&host, "## Plan\nNo Context Files section here.\n");
+
+        let _ = run_writeback(&host);
+
+        assert_eq!(
+            host.last_context_files_update(),
+            Some(None),
+            "writeback must leave context_files untouched when no section is present"
+        );
+
+        let task = host.get_task("T20260430-STATUS").expect("task readable");
+        assert_eq!(
+            task.context_files,
+            vec!["file:pre-existing.rs".to_string()],
+            "pre-existing context_files should be preserved"
+        );
+    }
+
+    #[test]
+    fn writeback_preserves_context_files_when_section_recognized_but_empty() {
+        let host = PlanningDuelHost::new(TaskStatus::InProgress);
+        host.task.lock().expect("task lock").context_files =
+            vec!["file:pre-existing.rs".to_string()];
+        install_planning_duel_artifacts(
+            &host,
+            "## Plan\nDo it.\n\n## Context Files\n\n## Risks\n- something.\n",
+        );
+
+        let _ = run_writeback(&host);
+
+        assert_eq!(
+            host.last_context_files_update(),
+            Some(None),
+            "an empty Context Files section should not clear the field"
+        );
+    }
+
+    #[test]
+    fn writeback_is_idempotent_across_two_resolves() {
+        let host = PlanningDuelHost::new(TaskStatus::InProgress);
+        install_planning_duel_artifacts(
+            &host,
+            "## Plan\nDo it.\n\n## Context Files\n- `file:src/a.rs`\n- `dir:src`\n",
+        );
+
+        let _ = run_writeback(&host);
+        let first = host.last_context_files_update();
+
+        let _ = run_writeback(&host);
+        let second = host.last_context_files_update();
+
+        assert!(first.is_some());
+        assert_eq!(
+            first, second,
+            "two consecutive resolves must produce identical context_files"
+        );
     }
 }

--- a/docs/design/activity-job/2_design.md
+++ b/docs/design/activity-job/2_design.md
@@ -2,7 +2,7 @@
 
 **Status:** Draft
 **Owner:** codex
-**Last updated:** 2026-05-09 (T20260427-34, T20260427-36, T20260427-38, T20260427-40, T20260508-3, T20260508-8, T20260509-2, T20260509-7)
+**Last updated:** 2026-05-09 (T20260427-34, T20260427-36, T20260427-38, T20260427-40, T20260508-3, T20260508-8, T20260509-2, T20260509-7, T20260509-9)
 
 This document describes the shipped Activity / Job substrate across `orbit-common`, `orbit-engine`, `orbit-core`, and `orbit-cli`: asset shape, normalization, dispatch boundaries, backend semantics, DAG execution, audit, and retained legacy edges. See [1_overview.md](./1_overview.md) for purpose and [3_vision.md](./3_vision.md) for open questions.
 
@@ -339,6 +339,8 @@ After [T20260428-8], task-starting workflows own explicit admission instead of r
 This path stays separate from `orbit.task.update` and generic deterministic metadata stamping. Direct task updates keep the non-empty-plan guard, and workflow admission records system-actor lifecycle history while preserving friction-bounty accounting for `friction -> in-progress`.
 
 Planning-duel writeback now reports `task_status: "in-progress"` instead of `status_unchanged`; the plan artifact still lands through `planning_duel_resolved`.
+
+After [T20260509-9], `writeback_planning_duel_task` also extracts a "Context Files" section from the normalized winning plan and replaces `task.context_files` with the canonicalized selectors when extraction succeeds. Section recognition is strict (`##` or `###` heading whose trimmed text is exactly `context files` or `context_files`, optional trailing `:`); unindented `- ` / `* ` bullets contribute one entry each, and each entry is canonicalized via `orbit_common::utility::selector::canonical_selector`. Sections that are absent or recognized but yield zero canonical entries leave `task.context_files` untouched; entries that fail canonicalization are dropped with an `OrbitEvent::PlanningDuelContextFileSkipped` event for observability. Plumbing is a single optional field on `TaskAutomationUpdate` (`context_files: Option<Vec<String>>`); `None` leaves the field untouched, matching the `TaskDocumentUpdateParams.context_files` semantics already documented in `orbit-store`. See [ADR-048](./4_decisions.md#adr-048--auto-populate-taskcontext_files-from-the-winning-duel-plan).
 
 ### 8.11 Task PR handoff summaries
 

--- a/docs/design/activity-job/4_decisions.md
+++ b/docs/design/activity-job/4_decisions.md
@@ -2,7 +2,7 @@
 
 **Status:** Draft
 **Owner:** codex
-**Last updated:** 2026-05-09 (T20260427-34, T20260427-36, T20260427-38, T20260427-40, T20260508-3, T20260508-8, T20260509-2, T20260509-7)
+**Last updated:** 2026-05-09 (T20260427-34, T20260427-36, T20260427-38, T20260427-40, T20260508-3, T20260508-8, T20260509-2, T20260509-7, T20260509-9)
 
 This ADR log records the decisions that define the current Activity / Job substrate. Entries are append-only and stay in place when later ADRs supersede or fold them. See [1_overview.md](./1_overview.md) for the feature summary, [2_design.md](./2_design.md) for the current implementation, and [3_vision.md](./3_vision.md) for the questions that may force more decisions.
 
@@ -450,6 +450,29 @@ Folded into ADR-002's rollup for explicit agent dispatch boundaries.
 - The split preserves the existing engine/core and CLI-runner boundaries; no new crate edge or provider type crosses the activity/job layer.
 - Cost: private helper movement now requires maintaining intra-module visibility and imports across several files instead of one lexical scope.
 
+## ADR-048 — Auto-populate `task.context_files` from the winning duel plan
+
+**Status:** Accepted · 2026-05 · [T20260509-9]
+
+**Context.** Planning duels already write the winning plan markdown to `task.plan`, but operators were forced to extract the plan's "Context Files" section and push it to `task.context_files` by hand (see T20260509-7's post-hoc fix). `context_files` is the canonical machine-readable handoff to file-lock, focused-read, and scoped-agent consumers; leaving it empty silently degrades every downstream tool that depends on it.
+
+**Decision.** During duel resolution, `writeback_planning_duel_task` parses the normalized winning plan for a "Context Files" section and replaces `task.context_files` with the canonicalized entries when extraction succeeds. Section recognition is deliberately strict to keep the failure mode safe (preserve existing field) rather than best-effort:
+
+- A heading line at level `##` or `###` whose trimmed, case-insensitive text equals `context files` or `context_files` (a single trailing `:` is permitted, additional words are not). The section body extends to the next heading of equal-or-higher level, or to end-of-string.
+- Within the section body, unindented `- ` or `* ` bullets contribute one entry each: the first inline-code span on the line, otherwise the first whitespace-bounded token after the marker. Sub-bullets and prose lines are ignored.
+- Each entry is canonicalized via `orbit_common::utility::selector::canonical_selector`. Raw paths upgrade to `file:` (or `dir:` if trailing `/`); already-canonical `file:` / `dir:` / `symbol:` selectors round-trip unchanged. Entries that fail canonicalization are dropped and reported as `OrbitEvent::PlanningDuelContextFileSkipped` for observability.
+- Duplicates collapse in first-seen order. The replace-not-merge semantics mirror `task.plan`: the winning plan is the new source of truth.
+
+When the section is absent OR recognized but yields zero canonical entries (placeholder / all-unparseable), the writeback leaves `task.context_files` untouched. Both branches are asymmetric-with the right safety bias: clearing a curated field on resolution would silently destroy operator state.
+
+The plumbing adds a single optional field to `TaskAutomationUpdate` (`context_files: Option<Vec<String>>`, default `None` = leave untouched, `Some(v)` = replace). The store layer's `TaskRecordUpdateParams.context_files` already supports this shape, so no store changes are required. Plan-writing flows that aren't duel-mediated are explicitly out of scope for this ADR.
+
+**Consequences.**
+- The duel-resolution writeback is no longer a half-conversion: structured task fields stay in sync with the persisted plan markdown.
+- Section-recognition heuristics drift between writers is bounded by the strict rule above; future planner agents that emit non-conforming shapes simply fall back to the preserve-existing branch instead of triggering best-effort guesses.
+- A new `TaskAutomationUpdate.context_files` field touches every existing automation call site, but the `..Default::default()` pattern keeps each site at the "leave untouched" default. A regression test in `task_host` guards that contract.
+- Operators get a `PlanningDuelContextFileSkipped` event channel for debugging stale or malformed plan markdown, instead of silently-dropped entries.
+
 ## ADR-047 — Each new executor block ships with a sibling test module
 
 **Status:** Accepted · 2026-05 · [T20260509-7]
@@ -525,5 +548,6 @@ Folded into ADR-002's rollup for explicit agent dispatch boundaries.
 - **[T20260508-8]** — Resolve backend: cli subprocess cwd from workspace context and record it in audit/tracing.
 - **[T20260509-2]** — Split the v2 job executor into responsibility-focused modules without changing runtime behavior.
 - **[T20260509-7]** — Establish focused test coverage for the activity/job DAG executor (linear, retry, parallel, fan-out, loop, pipeline durability) and the macOS sandbox / policy boundary.
+- **[T20260509-9]** — Auto-populate `task.context_files` from the winning planning-duel plan after resolution.
 
 > Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.


### PR DESCRIPTION
## Task

[T20260509-9](https://orbit-cli.com/tasks/T20260509-9) — Auto-populate task.context_files from the winning plan after duel resolution

### Description

## Problem

When a planning duel resolves, the winner's plan is persisted to `task.plan`, but `task.context_files` stays empty even though plans typically include a "Context Files" section listing the selectors needed for execution. Operators end up extracting that list manually and pushing it via `orbit.task.update` (see T20260509-7, where the list was added post-hoc by hand after the duel resolved).

## Why It Matters

- `context_files` is the canonical machine-readable handoff to downstream tooling: file locks, focused reads, scoped agents, and the executor skill's reading list. Leaving it empty silently degrades every consumer that depends on it.
- Plan markdown is human-oriented; `context_files` is the structured surface. Duel resolution already does one half of the conversion (writing `plan`); it should finish the job.
- Without automation, the friction is paid on every dueled task — not just T20260509-7. As duel-mediated planning becomes the default, this compounds.

## Constraints / Notes

- Plans are unstructured markdown; the "Context Files" section is convention, not schema. Extraction must tolerate variation in heading wording, list style, and inline annotations after the path.
- Output entries must be canonical selectors per the orbit-create-task convention: `file:path`, `dir:path`, `symbol:path#name:kind`. Raw paths from the plan are upgraded.
- Behavior must be idempotent: re-resolving a duel with the same winning plan produces identical `context_files` (same entries, same order, no duplicates).
- If the plan has no recognizable Context Files section, the task's existing `context_files` is preserved unchanged — never cleared by the resolver.
- Scope is the duel-resolution code path (where the winner's plan is currently persisted to `task.plan`). Plan-writing flows that aren't duel-mediated are out of scope; if the planner thinks a shared extractor belongs elsewhere, call that out as a follow-up rather than expanding scope here.
- The planner should use T20260509-7's plan as a representative input — its "Context Files" section is the shape this feature must handle.

### Acceptance Criteria

- After a planning duel resolves with a winner whose plan contains a Context Files section, calling `orbit.task.show` with `field: context_files` returns a non-empty array reflecting that section's entries.
- Each entry in the resulting `context_files` is in canonical selector form (`file:`, `dir:`, or `symbol:path#name:kind`); raw paths appearing in the plan markdown are upgraded to `file:` or `dir:` selectors.
- When the winning plan has no recognizable Context Files section, the task's pre-duel `context_files` value is preserved unchanged after resolution — verifiable by reading the field before and after duel resolution.
- Re-running duel resolution with the same winning plan produces an identical `context_files` array (same entries, same order, no duplication or churn) — verifiable by inspecting the field across two consecutive resolves.
- Tests cover at minimum: section-present → field populated; section-absent → field preserved; plan-with-raw-paths → entries upgraded to canonical selectors; mixed canonical-and-raw entries → all canonical in the output.
- The duel-resolution design doc records the section-recognition rule (what heading/list shapes count as a Context Files section) and the chosen behavior when extraction is ambiguous or partial; the doc is updated in the same PR per the CLAUDE.md doc-update rule.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Added planning-duel context file extraction so a winning plan with a recognized Context Files section populates task.context_files with canonical selectors while preserving existing values when extraction is absent, empty, or ambiguous.
- Plumbed context_files through TaskAutomationUpdate into the task store update path and added a PlanningDuelContextFileSkipped event for dropped malformed entries.
- Added focused extractor, writeback, and task-host tests covering canonicalization, raw path upgrades, mixed selectors, preservation semantics, deduplication, idempotency, and the representative T20260509-7 plan shape.
- Updated the activity-job design docs with ADR-048 and the duel-resolution side effect.

Assessment: Implementation is complete and validated by the recorded implementer run: make build and make fmt passed; cargo clippy was clean for the new files; full workspace cargo test passed.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/T20260509-9-69fe9ec2`
- Behind base: 0
- Ahead of base: 1

*authored by: claude-opus-4-7*