### PR TITLE
Fix ship-auto empty-backlog failure from unsupported bundle_count guard

### DIFF
--- a/crates/orbit-core/assets/jobs/task_auto_pipeline.yaml
+++ b/crates/orbit-core/assets/jobs/task_auto_pipeline.yaml
@@ -76,7 +76,7 @@ spec:
         collect: gate_results
 
     - id: require_gate_success
-      when: "{{ steps.validate_bundles.output.bundle_count }} > 0"
+      when: "{{ steps.validate_bundles.output.bundle_count }} != 0"
       target: activity:pipeline_success_guard
       default_input:
         context: task_auto_pipeline gate runs

--- a/crates/orbit-core/src/command/job/catalog.rs
+++ b/crates/orbit-core/src/command/job/catalog.rs
@@ -613,7 +613,7 @@ spec:
         let guard = &asset.spec.steps[guard_index];
         assert_eq!(
             guard.when.as_deref(),
-            Some("{{ steps.validate_bundles.output.bundle_count }} > 0")
+            Some("{{ steps.validate_bundles.output.bundle_count }} != 0")
         );
         match &guard.body {
             JobV2StepBody::TargetRef(target) => {

--- a/crates/orbit-engine/src/job_runner/condition.rs
+++ b/crates/orbit-engine/src/job_runner/condition.rs
@@ -113,6 +113,32 @@ mod tests {
     }
 
     #[test]
+    fn test_neq_numeric_string_zero() {
+        assert!(!evaluate_expr("0 != 0").unwrap());
+        assert!(evaluate_expr("3 != 0").unwrap());
+    }
+
+    #[test]
+    fn test_rendered_bundle_count_skip_guard() {
+        let mut ctx = TemplateContext::default();
+        ctx.steps.insert(
+            "validate_bundles".to_string(),
+            serde_json::json!({
+                "output": {
+                    "bundle_count": 0
+                }
+            }),
+        );
+
+        let result = evaluate_bool_expr(
+            "{{ steps.validate_bundles.output.bundle_count }} != 0",
+            &ctx,
+        )
+        .unwrap();
+        assert!(!result);
+    }
+
+    #[test]
     fn test_and() {
         assert!(evaluate_expr("a == a && b == b").unwrap());
         assert!(!evaluate_expr("a == a && b == c").unwrap());

--- a/docs/design/activity-job/2_design.md
+++ b/docs/design/activity-job/2_design.md
@@ -2,7 +2,7 @@
 
 **Status:** Draft
 **Owner:** codex
-**Last updated:** 2026-05-09 (T20260427-34, T20260427-36, T20260427-38, T20260427-40, T20260508-3, T20260508-8, T20260509-2, T20260509-7, T20260509-9)
+**Last updated:** 2026-05-09 (T20260427-34, T20260427-36, T20260427-38, T20260427-40, T20260508-3, T20260508-8, T20260509-2, T20260509-7, T20260509-9, T20260509-11)
 
 This document describes the shipped Activity / Job substrate across `orbit-common`, `orbit-engine`, `orbit-core`, and `orbit-cli`: asset shape, normalization, dispatch boundaries, backend semantics, DAG execution, audit, and retained legacy edges. See [1_overview.md](./1_overview.md) for purpose and [3_vision.md](./3_vision.md) for open questions.
 
@@ -251,6 +251,8 @@ For `run_command` or any shell-based step, there is no implicit structured outpu
 ### 8.2 `when` and `retry`
 
 `when` is evaluated once, before retry. A skipped step is a successful no-op and does not retry.
+
+After [T20260509-11], the shipped condition grammar remains equality-only (`==` / `!=`, combined with `&&` / `||`); skip-on-empty guards express emptiness as `!= 0` or `!= []` rather than numeric comparisons, preserving `ship-auto` empty-backlog no-op behavior.
 
 The retry wrapper re-runs the whole step body up to `max_attempts`, with exponential or linear backoff. Some errors bypass retry:
 
@@ -526,5 +528,6 @@ Read-only history does not need the same dependencies as live execution. [T20260
 - **[T20260508-8]** — Resolve backend: cli subprocess cwd from workspace context and record it in audit/tracing.
 - **[T20260509-2]** — Split the v2 job executor into responsibility-focused modules without changing runtime behavior.
 - **[T20260509-7]** — Establish focused test coverage for the activity/job DAG executor (linear, retry, parallel, fan-out, loop, pipeline durability) and the macOS sandbox / policy boundary.
+- **[T20260509-11]** — Keep condition guards on equality-only grammar and repair the `ship-auto` empty-backlog guard.
 
 > Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.

--- a/docs/design/activity-job/4_decisions.md
+++ b/docs/design/activity-job/4_decisions.md
@@ -2,7 +2,7 @@
 
 **Status:** Draft
 **Owner:** codex
-**Last updated:** 2026-05-09 (T20260427-34, T20260427-36, T20260427-38, T20260427-40, T20260508-3, T20260508-8, T20260509-2, T20260509-7, T20260509-9)
+**Last updated:** 2026-05-09 (T20260427-34, T20260427-36, T20260427-38, T20260427-40, T20260508-3, T20260508-8, T20260509-2, T20260509-7, T20260509-9, T20260509-11)
 
 This ADR log records the decisions that define the current Activity / Job substrate. Entries are append-only and stay in place when later ADRs supersede or fold them. See [1_overview.md](./1_overview.md) for the feature summary, [2_design.md](./2_design.md) for the current implementation, and [3_vision.md](./3_vision.md) for the questions that may force more decisions.
 
@@ -486,6 +486,19 @@ The plumbing adds a single optional field to `TaskAutomationUpdate` (`context_fi
 - New blocks (e.g. a future `dag` or `gate` construct) must land with a sibling test module covering at least the invariants enumerated in the seed surface.
 - Shared scaffolding in `tests/mod.rs` is the consolidation seam — broaden it (agent_loop or shell hosts, additional builders) there rather than re-deriving in each block module.
 
+## ADR-049 — Condition guards stay equality-only
+
+**Status:** Accepted · 2026-05 · [T20260509-11]
+
+**Context.** `task_auto_pipeline` needed to skip its success guard for empty backlog runs, but its seeded `bundle_count > 0` guard rendered to an unsupported comparison and failed before the step could be skipped. Orbit could either extend the shared evaluator with numeric ordering or express the guard in the existing grammar.
+
+**Decision.** Keep the shared condition grammar to `==` and `!=`, with `&&` and `||` composition, and express skip-on-empty guards with equality-compatible forms such as `!= 0` and `!= []`. The `ship-auto` guard uses `{{ steps.validate_bundles.output.bundle_count }} != 0`, so zero bundles skip the guard and populated fan-out still checks child gate success.
+
+**Consequences.**
+- The evaluator stays string-based and shared between `StepCondition::Expr`, v2 `when:`, and loop `break_when:` without adding numeric coercion rules.
+- Seeded jobs can still model empty collections and counts, but authored guards must avoid ordering operators unless a future task intentionally extends the grammar.
+- Cost: authors cannot write natural numeric comparisons in guards today; they must encode supported equality checks or add a deliberate grammar extension with tests and docs.
+
 ---
 
 ## Task References
@@ -549,5 +562,6 @@ The plumbing adds a single optional field to `TaskAutomationUpdate` (`context_fi
 - **[T20260509-2]** — Split the v2 job executor into responsibility-focused modules without changing runtime behavior.
 - **[T20260509-7]** — Establish focused test coverage for the activity/job DAG executor (linear, retry, parallel, fan-out, loop, pipeline durability) and the macOS sandbox / policy boundary.
 - **[T20260509-9]** — Auto-populate `task.context_files` from the winning planning-duel plan after resolution.
+- **[T20260509-11]** — Keep condition guards on equality-only grammar and repair the `ship-auto` empty-backlog guard.
 
 > Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.


### PR DESCRIPTION
## Task

[T20260509-11](https://orbit-cli.com/tasks/T20260509-11) — Fix ship-auto empty-backlog failure from unsupported bundle_count guard

### Description

## Problem
`orbit run ship-auto` can fail on an empty backlog instead of completing as a no-op. Observed run `jrun-20260509-0210` failed at 2026-05-09T02:10:01Z with:

`execution failed: v2 job dispatch: job executor: when expr: invalid input: condition atom must contain '==' or '!=', got: '0 > 0'`

The tracked seeded job `crates/orbit-core/assets/jobs/task_auto_pipeline.yaml` has `require_gate_success.when: {{ steps.validate_bundles.output.bundle_count }} > 0`. The workspace resource copy under `.orbit/resources/jobs/task_auto_pipeline.yaml` has the same expression. When `validate_bundles.output.bundle_count` is zero, that renders to `0 > 0`. The shared condition evaluator in `crates/orbit-engine/src/job_runner/condition.rs` only supports `==` and `!=`, so the skip guard itself becomes a runtime failure.

This contradicts the job comment and activity/job design docs: empty backlog should make fan-out a no-op, skip the success guard, and report `workflow_status=empty_backlog` without failing.

## Why It Matters
`ship-auto` is the default automatic shipping workflow. Empty backlog is a normal operator state, not an error. The current failure makes the command look broken even when there is simply no work to dispatch.

## Constraints / Notes
- Decide explicitly whether the fix is to keep the equality-only expression grammar and change the guard to a supported expression such as `!= 0`, or to extend the evaluator to support numeric comparisons. Keep docs and tests aligned with that choice.
- The existing catalog test in `crates/orbit-core/src/command/job/catalog.rs` currently asserts the invalid `> 0` guard, so update the test rather than preserving the broken expression.
- Do not change empty-backlog semantics: zero candidate bundles must not dispatch child gate runs or invoke `pipeline_success_guard`.
- If the seeded asset is changed, make sure the workspace resource seeding/override story is considered so a repaired checkout does not keep using the stale `.orbit/resources/jobs/task_auto_pipeline.yaml` expression.

### Acceptance Criteria

- A deterministic test or fixture demonstrates that `task_auto_pipeline` with `validate_bundles.output.bundle_count` equal to `0` skips `require_gate_success` and completes without the `condition atom must contain` error.
- Inspection of `crates/orbit-core/assets/jobs/task_auto_pipeline.yaml` shows `require_gate_success.when` uses only syntax supported by `crates/orbit-engine/src/job_runner/condition.rs`, unless the evaluator is intentionally extended with tests and docs for numeric comparisons.
- The catalog/unit tests no longer assert `{{ steps.validate_bundles.output.bundle_count }} > 0` as the expected seeded guard; they assert the repaired expression or the newly supported grammar instead.
- Running `make build` succeeds after the fix.
- The activity/job design docs are updated or explicitly left unchanged with a note in the execution summary; any doc change cites this task ID and preserves the documented empty-backlog no-op behavior.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Repaired the seeded `task_auto_pipeline` success-guard condition from unsupported `> 0` syntax to `!= 0`, so zero bundles skip `pipeline_success_guard` while populated fan-out still checks gate results.
- Updated the catalog assertion and added condition evaluator regressions for `0 != 0` and the rendered `steps.validate_bundles.output.bundle_count` guard path.
- Updated Activity / Job docs and ADR-049 to record the equality-only grammar decision for condition guards, citing [T20260509-11].
- Updated the current operator workspace copy at `/Users/daniel/workspace/repos/orbit/.orbit/resources/jobs/task_auto_pipeline.yaml` so this checkout does not keep using the stale seeded guard.

Validation:
- `make fmt`
- `cargo test -p orbit-engine condition::tests`
- `cargo test -p orbit-core auto_pipeline_checks_gate_results_after_fan_in`
- `make build`

Strategic decisions:
- Kept the condition evaluator grammar equality-only | Rationale: the existing string comparison grammar already models this skip-on-empty case without adding numeric coercion or ordering semantics.

Design weaknesses / risks:
- Existing workspaces can keep stale `.orbit/resources/jobs/task_auto_pipeline.yaml` files because default seeding preserves existing resources | Severity: Medium | Mitigation: updated this operator workspace copy and filed follow-up friction task [T20260509-17] for content-hash-aware re-seeding.
- An isolated `ship-auto` smoke test was not completed because `orbit init --root <temp> --non-interactive` failed during resource seeding with an opaque `Operation not permitted` error | Severity: Low | Mitigation: filed friction task [T20260509-16]; deterministic unit tests and `make build` passed.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/T20260509-11-69fea8d5`
- Behind base: 0
- Ahead of base: 1

*authored by: gpt-5.5*