### PR TITLE
Scope workflow git identity to commit processes

### DIFF
--- a/crates/orbit-engine/src/executor/automation/vcs/commit/author.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/commit/author.rs
@@ -16,6 +16,18 @@ impl GitAuthor {
         }
     }
 
+    pub(super) fn orbit() -> Self {
+        Self::new("orbit", "orbit@orbit.local")
+    }
+
+    pub(super) fn name(&self) -> &str {
+        &self.name
+    }
+
+    pub(super) fn email(&self) -> &str {
+        &self.email
+    }
+
     pub(super) fn spec(&self) -> String {
         format!("{} <{}>", self.name, self.email)
     }
@@ -40,7 +52,7 @@ pub(super) fn commit_author_for_tasks(tasks: &[Task]) -> (Option<GitAuthor>, Vec
     match authors.as_slice() {
         [] => (None, Vec::new()),
         [author] => (Some(author.clone()), Vec::new()),
-        _ => (Some(GitAuthor::new("orbit", "orbit@orbit.local")), authors),
+        _ => (Some(GitAuthor::orbit()), authors),
     }
 }
 

--- a/crates/orbit-engine/src/executor/automation/vcs/commit/git_ops.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/commit/git_ops.rs
@@ -1,22 +1,23 @@
 use std::path::Path;
 
 use orbit_common::types::OrbitError;
+use orbit_exec::{EnvironmentMode, ExecRequest, NoSandbox, StdinMode, run_process};
 
 use super::super::git::{git_output, git_output_paths, git_success};
 use super::author::GitAuthor;
 
-pub(super) fn git_commit_with_author(
+pub(super) fn git_commit_with_identity(
     workspace_path: &Path,
     message: &str,
     author: Option<&GitAuthor>,
 ) -> Result<(), OrbitError> {
+    let committer = author.cloned().unwrap_or_else(GitAuthor::orbit);
+    let author = author.cloned().unwrap_or_else(|| committer.clone());
     let mut args = vec!["commit".to_string()];
-    if let Some(author) = author {
-        args.push("--author".to_string());
-        args.push(author.spec());
-    }
+    args.push("--author".to_string());
+    args.push(author.spec());
     args.extend(["-m".to_string(), message.to_string()]);
-    git_success_dynamic(workspace_path, &args)
+    git_success_dynamic_with_identity(workspace_path, &args, &author, &committer)
 }
 
 pub(super) fn stage_paths(workspace_path: &Path, files: &[String]) -> Result<(), OrbitError> {
@@ -39,6 +40,56 @@ pub(super) fn staged_changed_files(workspace_path: &Path) -> Result<Vec<String>,
 fn git_success_dynamic(current_dir: &Path, args: &[String]) -> Result<(), OrbitError> {
     let args = args.iter().map(String::as_str).collect::<Vec<_>>();
     git_success(current_dir, &args)
+}
+
+fn git_success_dynamic_with_identity(
+    current_dir: &Path,
+    args: &[String],
+    author: &GitAuthor,
+    committer: &GitAuthor,
+) -> Result<(), OrbitError> {
+    let env_overrides = [
+        ("GIT_AUTHOR_NAME", author.name()),
+        ("GIT_AUTHOR_EMAIL", author.email()),
+        ("GIT_COMMITTER_NAME", committer.name()),
+        ("GIT_COMMITTER_EMAIL", committer.email()),
+    ];
+    let mut environment = std::env::vars()
+        .filter(|(key, _)| {
+            !env_overrides
+                .iter()
+                .any(|(override_key, _)| key == override_key)
+        })
+        .collect::<Vec<_>>();
+    environment.extend(
+        env_overrides
+            .iter()
+            .map(|(key, value)| ((*key).to_string(), (*value).to_string())),
+    );
+
+    let result = run_process(
+        &ExecRequest {
+            program: "git".to_string(),
+            args: args.to_vec(),
+            current_dir: Some(current_dir.to_string_lossy().to_string()),
+            timeout_ms: Some(30_000),
+            stdin_mode: StdinMode::Null,
+            environment_mode: EnvironmentMode::ClearAndSet(environment),
+            debug: false,
+        },
+        &NoSandbox,
+    )?;
+
+    if !result.success {
+        return Err(OrbitError::Execution(format!(
+            "git {} failed in '{}': {}",
+            args.join(" "),
+            current_dir.display(),
+            result.stderr.trim()
+        )));
+    }
+
+    Ok(())
 }
 
 pub(super) fn ensure_named_branch(workspace_path: &Path) -> Result<(), OrbitError> {

--- a/crates/orbit-engine/src/executor/automation/vcs/commit/mod.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/commit/mod.rs
@@ -18,7 +18,7 @@ use super::super::input::{canonicalize_existing_dir, input_string_field, require
 use super::git::git_success;
 use author::{append_co_author_trailers, commit_author_for_tasks, git_author_for_task};
 use git_ops::{
-    ensure_named_branch, ensure_no_unmerged_changes, git_commit_with_author, stage_paths,
+    ensure_named_branch, ensure_no_unmerged_changes, git_commit_with_identity, stage_paths,
     staged_changed_files,
 };
 use message::{finalize_commit_message, task_commit_message};
@@ -106,7 +106,7 @@ pub(super) fn commit_task_artifact_changes<H: TaskHost + RuntimeHost + ?Sized>(
 
         let message = task_commit_message(&task);
         let author = git_author_for_task(&task);
-        git_commit_with_author(&workspace_path, &message, author.as_ref())?;
+        git_commit_with_identity(&workspace_path, &message, author.as_ref())?;
         committed_task_ids.push(task.id);
     }
 
@@ -161,7 +161,7 @@ pub(super) fn commit_finalize_artifact_changes<H: TaskHost + RuntimeHost + ?Size
     let mut message = finalize_commit_message(&affected_tasks);
     let (author, coauthors) = commit_author_for_tasks(&affected_tasks);
     append_co_author_trailers(&mut message, &coauthors);
-    git_commit_with_author(&workspace_path, &message, author.as_ref())?;
+    git_commit_with_identity(&workspace_path, &message, author.as_ref())?;
 
     Ok(json!({
         "workspace_path": workspace_path.to_string_lossy().to_string(),
@@ -207,7 +207,7 @@ pub(super) fn commit_batch_changes<H: TaskHost + RuntimeHost + ?Sized>(
     let (author, coauthors) = commit_author_for_tasks(&batch_tasks);
     append_co_author_trailers(&mut message, &coauthors);
 
-    git_commit_with_author(&workspace_path, &message, author.as_ref())?;
+    git_commit_with_identity(&workspace_path, &message, author.as_ref())?;
     Ok(json!({}))
 }
 
@@ -243,6 +243,7 @@ fn completed_task_ids_field(input: &Value) -> Option<Vec<String>> {
 mod tests {
     use std::fs;
     use std::path::{Path, PathBuf};
+    use std::process::Command;
 
     use chrono::Utc;
     use orbit_common::types::{
@@ -491,7 +492,7 @@ mod tests {
     }
 
     #[test]
-    fn git_commit_uses_task_implemented_by_as_author() {
+    fn git_commit_uses_scoped_identity_without_mutating_local_human_config() {
         let cases = [
             ("claude-opus-4-7", "claude <claude@orbit.local>"),
             ("gemini-3.1-pro", "gemini <gemini@orbit.local>"),
@@ -521,12 +522,25 @@ mod tests {
                 .expect("read git user.name before");
             let user_email_before = git_output(workspace, &["config", "--get", "user.email"])
                 .expect("read git user.email before");
+            let local_user_name_before = git_stdout_bytes(
+                workspace,
+                &["config", "--local", "--get", "user.name"],
+                "read local git user.name before",
+            );
+            let local_user_email_before = git_stdout_bytes(
+                workspace,
+                &["config", "--local", "--get", "user.email"],
+                "read local git user.email before",
+            );
 
             git_commit(&host, &input).expect("git_commit succeeds");
 
             let actual_author = git_output(workspace, &["log", "-1", "--format=%an <%ae>"])
                 .expect("read git author");
+            let actual_committer = git_output(workspace, &["log", "-1", "--format=%cn <%ce>"])
+                .expect("read git committer");
             assert_eq!(actual_author, expected_author);
+            assert_eq!(actual_committer, expected_author);
             assert_eq!(
                 git_output(workspace, &["config", "--get", "user.name"])
                     .expect("read git user.name after"),
@@ -537,11 +551,59 @@ mod tests {
                     .expect("read git user.email after"),
                 user_email_before
             );
+            assert_eq!(
+                git_stdout_bytes(
+                    workspace,
+                    &["config", "--local", "--get", "user.name"],
+                    "read local git user.name after",
+                ),
+                local_user_name_before
+            );
+            assert_eq!(
+                git_stdout_bytes(
+                    workspace,
+                    &["config", "--local", "--get", "user.email"],
+                    "read local git user.email after",
+                ),
+                local_user_email_before
+            );
         }
     }
 
     #[test]
-    fn mixed_implementer_batch_commit_uses_aggregate_author_with_trailers() {
+    fn git_commit_succeeds_without_creating_local_user_config() {
+        let temp = initialized_git_repo_without_local_user_config();
+        let workspace = temp.path();
+        fs::create_dir_all(workspace.join("src")).unwrap();
+        fs::write(workspace.join("src/task.txt"), "codex work\n").unwrap();
+
+        let task = task_with_file("T1", "Implement one task", "src/task.txt", "gpt-5.5");
+        let host = CommitTestHost::new(vec![task], workspace.to_path_buf());
+        let input = json!({
+            "scope": "per_task",
+            "batch_id": "batch-1",
+            "workspace_path": workspace.to_string_lossy().to_string(),
+            "completed_task_ids": ["T1"],
+        });
+
+        let local_user_config_before = local_user_config_snapshot(workspace);
+
+        git_commit(&host, &input).expect("git_commit succeeds without local user config");
+
+        let actual_author =
+            git_output(workspace, &["log", "-1", "--format=%an <%ae>"]).expect("read author");
+        let actual_committer =
+            git_output(workspace, &["log", "-1", "--format=%cn <%ce>"]).expect("read committer");
+        assert_eq!(actual_author, "codex <codex@openai.com>");
+        assert_eq!(actual_committer, "codex <codex@openai.com>");
+        assert_eq!(
+            local_user_config_snapshot(workspace),
+            local_user_config_before
+        );
+    }
+
+    #[test]
+    fn git_commit_mixed_implementer_batch_uses_aggregate_identity_with_trailers() {
         let temp = initialized_git_repo();
         let workspace = temp.path();
         fs::create_dir_all(workspace.join("src")).unwrap();
@@ -559,14 +621,23 @@ mod tests {
             "workspace_path": workspace.to_string_lossy().to_string(),
         });
 
+        let local_user_config_before = local_user_config_snapshot(workspace);
+
         git_commit(&host, &input).expect("git_commit succeeds");
 
         let actual_author =
             git_output(workspace, &["log", "-1", "--format=%an <%ae>"]).expect("read git author");
+        let actual_committer = git_output(workspace, &["log", "-1", "--format=%cn <%ce>"])
+            .expect("read git committer");
         let body = git_output(workspace, &["log", "-1", "--format=%B"]).expect("read git body");
         assert_eq!(actual_author, "orbit <orbit@orbit.local>");
+        assert_eq!(actual_committer, "orbit <orbit@orbit.local>");
         assert!(body.contains("Co-Authored-By: claude <claude@orbit.local>"));
         assert!(body.contains("Co-Authored-By: gemini <gemini@orbit.local>"));
+        assert_eq!(
+            local_user_config_snapshot(workspace),
+            local_user_config_before
+        );
     }
 
     fn initialized_git_repo() -> tempfile::TempDir {
@@ -580,6 +651,71 @@ mod tests {
         git_success(repo, &["add", "README.md"]).expect("git add");
         git_success(repo, &["commit", "-m", "initial commit"]).expect("initial commit");
         temp
+    }
+
+    fn initialized_git_repo_without_local_user_config() -> tempfile::TempDir {
+        let temp = tempdir().unwrap();
+        let repo = temp.path();
+        git_success(repo, &["init"]).expect("git init");
+        fs::write(repo.join("README.md"), "base\n").unwrap();
+        git_success(repo, &["add", "README.md"]).expect("git add");
+        git_success(
+            repo,
+            &[
+                "-c",
+                "user.name=Initial User",
+                "-c",
+                "user.email=initial@example.test",
+                "commit",
+                "-m",
+                "initial commit",
+            ],
+        )
+        .expect("initial commit");
+        assert_eq!(
+            local_user_config_snapshot(repo),
+            CommandSnapshot {
+                code: Some(1),
+                stdout: Vec::new(),
+                stderr: Vec::new(),
+            }
+        );
+        temp
+    }
+
+    #[derive(Debug, Eq, PartialEq)]
+    struct CommandSnapshot {
+        code: Option<i32>,
+        stdout: Vec<u8>,
+        stderr: Vec<u8>,
+    }
+
+    fn local_user_config_snapshot(repo: &Path) -> CommandSnapshot {
+        git_command_snapshot(repo, &["config", "--local", "--get-regexp", "^user\\."])
+    }
+
+    fn git_stdout_bytes(repo: &Path, args: &[&str], context: &str) -> Vec<u8> {
+        let snapshot = git_command_snapshot(repo, args);
+        assert_eq!(
+            snapshot.code,
+            Some(0),
+            "{context}: stderr={}",
+            String::from_utf8_lossy(&snapshot.stderr)
+        );
+        snapshot.stdout
+    }
+
+    fn git_command_snapshot(repo: &Path, args: &[&str]) -> CommandSnapshot {
+        let output = Command::new("git")
+            .current_dir(repo)
+            .args(args)
+            .output()
+            .expect("run git command");
+        CommandSnapshot {
+            code: output.status.code(),
+            stdout: output.stdout,
+            stderr: output.stderr,
+        }
     }
 
     fn task_with_file(id: &str, title: &str, path: &str, implemented_by: &str) -> Task {

--- a/crates/orbit-tools/src/builtin/git/commit.rs
+++ b/crates/orbit-tools/src/builtin/git/commit.rs
@@ -11,7 +11,7 @@ impl Tool for GitCommitTool {
     fn schema(&self) -> ToolSchema {
         ToolSchema {
             name: "git.commit".to_string(),
-            description: "Create a git commit for an explicit file list".to_string(),
+            description: "Create a user-directed git commit for an explicit file list using the repository's ambient Git identity; workflow-owned commits use separate scoped automation.".to_string(),
             parameters: vec![
                 ToolParam {
                     name: "repo_root".to_string(),

--- a/docs/design/auditability/1_overview.md
+++ b/docs/design/auditability/1_overview.md
@@ -2,7 +2,7 @@
 
 **Status:** Draft
 **Owner:** codex
-**Last updated:** 2026-05-09 (T20260506-2, T20260508-22)
+**Last updated:** 2026-05-09 (T20260506-2, T20260508-22, T20260509-12)
 
 Auditability is Orbit's answer to the operator question that matters after an agent touches a real repository: what happened, why, and who is accountable? The contract spans command rows, Orbit tool mutations, activity/job runs, provider turns, tool calls, filesystem denials, task attribution, metrics, and redacted payload storage. [2_design.md](./2_design.md) describes the shipped implementation; [3_vision.md](./3_vision.md) names the remaining gaps.
 
@@ -14,7 +14,7 @@ Orbit runs fleets of agents against user-owned repositories, so auditability is 
 
 1. **Replayable accountability.** README and positioning docs promise enough context for every meaningful action to answer what, why, and who. The dedicated design folder from [T20260426-0605] keeps that promise reviewable.
 2. **Layered evidence.** A command row says which command ran. A v2 envelope says which workflow step ran. Loop events and blobs preserve provider/tool detail. The layers must remain related without becoming one oversized record.
-3. **Durable identity.** Task author fields, command audit roles, v2 `agent_identity`, invocation metrics, git commit authors, and commit/task metadata all need to point back to a concrete actor or model.
+3. **Durable identity.** Task author fields, command audit roles, v2 `agent_identity`, invocation metrics, git commit identities, and commit/task metadata all need to point back to a concrete actor or model.
 4. **Write-side secrecy.** Orbit preserves useful payloads while redacting provider keys and sensitive environment-derived values before durable storage.
 5. **Explicit gaps.** Silent mutation paths are bugs. Missing coverage belongs in the coverage matrix, not in tribal memory.
 
@@ -61,7 +61,7 @@ The default tracing subscriber appends redacted structured events to `~/.orbit/s
 | Global tracing JSONL feed and live projections | `crates/orbit-common/src/utility/logging.rs`, selected FS/proc/task producers | [T20260426-2343], [T20260427-0023] |
 | V2 invocation metrics persistence | `crates/orbit-store/src/sqlite/invocation_store.rs`, `crates/orbit-core/src/runtime/v2_host.rs` | [T20260426-0526] |
 | Task attribution fields | `crates/orbit-common/src/types/task.rs`, task update/runtime host paths | [T20260426-0605], [T20260427-47] |
-| Git commit author attribution | `crates/orbit-engine/src/executor/automation/commit.rs` | [T20260508-22] |
+| Workflow git commit identity attribution | `crates/orbit-engine/src/executor/automation/vcs/commit/` | [T20260508-22], [T20260509-12] |
 
 ---
 
@@ -80,5 +80,6 @@ The default tracing subscriber appends redacted structured events to `~/.orbit/s
 - **[T20260430-20]** — Shorten the auditability docs while preserving required guarantees.
 - **[T20260506-2]** — Lazily materialize loop audit JSONL files only when loop-level events are emitted.
 - **[T20260508-22]** — Use `task.implemented_by` to set git commit authors for automated task commits.
+- **[T20260509-12]** — Scope workflow git author and committer identity to the spawned commit process without writing repo-local Git config.
 
 > Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.

--- a/docs/design/auditability/2_design.md
+++ b/docs/design/auditability/2_design.md
@@ -2,7 +2,7 @@
 
 **Status:** Draft
 **Owner:** codex
-**Last updated:** 2026-05-09 (T20260506-2, T20260508-8, T20260508-14, T20260508-22)
+**Last updated:** 2026-05-09 (T20260506-2, T20260508-8, T20260508-14, T20260508-22, T20260509-12)
 
 This document describes Orbit's shipped auditability implementation across command audit rows, activity/job envelopes, loop-level provider/tool traces, blob storage, redaction, identity attribution, metrics-adjacent invocation records, and known limitations. See [1_overview.md](./1_overview.md) for the feature purpose and [3_vision.md](./3_vision.md) for future questions.
 
@@ -90,7 +90,7 @@ Orbit currently carries identity through related fields rather than one universa
 
 Task attribution remains automatic by default: non-empty plan writes stamp `planned_by`, and transitions into `review` or `done` stamp `implemented_by`. After [T20260427-47], `orbit.task.update` and direct `orbit task update` can explicitly set or clear those fields; explicit values win within the same update.
 
-After [T20260508-22], `git_commit` automation carries that task attribution into git metadata. Per-task commits pass `--author` derived from `task.implemented_by` (`claude`, `gemini`, or `codex` family identities), leaving repository `git config user.name` and `user.email` untouched for committer identity. Multi-implementer batch commits use `orbit <orbit@orbit.local>` as the aggregate author and add `Co-Authored-By` trailers for each distinct implementer identity.
+After [T20260508-22] and [T20260509-12], `git_commit` automation carries that task attribution into git metadata. Per-task commits use process-scoped author and committer identity derived from `task.implemented_by` (`claude`, `gemini`, or `codex` family identities), leaving repository `git config user.name` and `user.email` untouched. Multi-implementer batch commits use `orbit <orbit@orbit.local>` as the aggregate author and committer and add `Co-Authored-By` trailers for each distinct implementer identity.
 
 The requirement is not to collapse every field into one value. It is that a reviewer can follow task state, command rows, run envelopes, provider/tool traces, and metrics back to a concrete human or model. A unified identity glossary and query join story remain open.
 
@@ -158,5 +158,6 @@ Each record contains timestamp, level, target, and structured fields. After [T20
 - **[T20260508-8]** — Record backend: cli subprocess cwd in v2 audit and live tracing.
 - **[T20260508-14]** — Surface bounded per-step agent log previews and derived diagnostics error rows in the dashboard.
 - **[T20260508-22]** — Use `task.implemented_by` to set git commit authors for automated task commits.
+- **[T20260509-12]** — Scope workflow git author and committer identity to the spawned commit process without writing repo-local Git config.
 
 > Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.

--- a/docs/design/auditability/4_decisions.md
+++ b/docs/design/auditability/4_decisions.md
@@ -2,7 +2,7 @@
 
 **Status:** Draft
 **Owner:** codex
-**Last updated:** 2026-05-09 (T20260506-2, T20260508-22)
+**Last updated:** 2026-05-09 (T20260506-2, T20260508-22, T20260509-12)
 
 This is the append-only ADR log for Auditability. Entries are ordered by ADR number. New entries should use the template in [../CONVENTIONS.md](../CONVENTIONS.md) and cite the task that made the decision real.
 
@@ -266,12 +266,27 @@ This is the append-only ADR log for Auditability. Entries are ordered by ADR num
 
 **Context.** Task records already store `implemented_by`, but automated `git_commit` actions previously delegated commit authorship to local git config, hiding the agent that actually produced the change.
 
-**Decision.** Pass a per-commit `--author` derived from `task.implemented_by` for single-implementer commits. Mixed-implementer batch commits use `orbit <orbit@orbit.local>` as the aggregate author and add one `Co-Authored-By` trailer per distinct implementer identity.
+**Decision.** Pass a per-commit `--author` derived from `task.implemented_by` for single-implementer commits. Mixed-implementer batch commits use `orbit <orbit@orbit.local>` as the aggregate author and add one `Co-Authored-By` trailer per distinct implementer identity. ADR-023 extends this provenance to committer identity without reusing repo-local user config.
 
 **Consequences.**
 - Reviewers can see implementation provenance directly in git history without joining back through run audit events.
-- Local git config remains committer identity only and can stay stable across parallel agent runs.
+- Local git config is not written by workflow commit automation and is no longer the source of committer identity for those commits.
 - Cost: multi-implementer batch commits require trailer-aware attribution queries; `git log --author` finds the aggregate commit author, not every co-author trailer.
+
+---
+
+## ADR-023 — Workflow git commit identity is process-scoped
+
+**Status:** Accepted · 2026-05 · [T20260509-12]
+
+**Context.** Reusing local Git config for workflow committers made agent identities sticky in developer repositories. If `user.name` or `user.email` was set to an agent identity in repo-local config, later human commits inherited that attribution.
+
+**Decision.** Automated `git_commit` actions set author and committer identity only for the spawned `git commit` process. Single-implementer commits use that implementer's scoped identity for both author and committer. Mixed-implementer commits use `orbit <orbit@orbit.local>` as the aggregate author and committer while preserving distinct implementers as `Co-Authored-By` trailers. Workflows must not write agent or aggregate identities into repo-local Git config.
+
+**Consequences.**
+- Human `user.name` and `user.email` settings remain byte-for-byte stable across workflow commits.
+- Worktrees with no local `user.*` config can still create workflow-owned commits with explicit provenance.
+- The public `git.commit` tool remains user-directed and ambient-config based; workflow-owned commit automation uses this scoped path instead.
 
 ---
 
@@ -303,5 +318,6 @@ This is the append-only ADR log for Auditability. Entries are ordered by ADR num
 - **[T20260505-6]** — Replace timestamp-only command-audit execution ids with process-disambiguated generated ids for parallel tool runs.
 - **[T20260506-2]** — Lazily materialize loop audit JSONL files only when loop-level events are emitted.
 - **[T20260508-22]** — Use `task.implemented_by` to set git commit authors for automated task commits.
+- **[T20260509-12]** — Scope workflow git author and committer identity to the spawned commit process without writing repo-local Git config.
 
 > Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.


### PR DESCRIPTION
## Task

[T20260509-12](https://orbit-cli.com/tasks/T20260509-12) — Scope workflow git identity to commit processes

### Description

## Problem
Personal commits in this repo can be accidentally authored and committed as `codex` when `user.name` / `user.email` are left in repo-local Git config. The desired behavior is that Orbit workflow-owned commits use agent identity dynamically for that commit process, without persisting `codex`, `claude`, or other agent identities into the user's repository or worktree config.

## Why It Matters
Agent-authored commits still need durable provenance, but sticky repo-local identity makes ordinary human commits look like agent work. That breaks attribution, surprises users, and conflicts with the auditability goal that provenance should be explicit and scoped to the action that produced it.

## Constraints / Notes
- Preserve the existing task-implemented author mapping from `git_commit` automation: single implementer commits use the agent family identity; mixed-implementer batch commits use `orbit <orbit@orbit.local>` plus `Co-Authored-By` trailers.
- Add dynamic committer handling for workflow-owned commits, preferably through process-scoped Git environment variables or `git -c` arguments, not persistent `git config user.*` writes.
- Do not mutate existing human Git config in the main repo or generated worktrees. If a temporary worktree lacks a usable committer identity, fail with a clear workflow error or supply an explicit workflow-scoped committer identity; do not write config as a side effect.
- Update auditability/activity-job docs if the implementation changes the current statement that local Git config remains the committer identity.
- The motivating local observation was `/Users/daniel/workspace/repos/orbit/.git/config` containing `user.name = codex` and `user.email = codex@openai.com`, causing `git var GIT_AUTHOR_IDENT` and `git var GIT_COMMITTER_IDENT` to resolve to Codex for personal commits.

### Acceptance Criteria

- A deterministic test exercises workflow `git_commit` in a temp repository whose local `user.name` and `user.email` start as a human identity, then verifies both author and committer metadata for the new workflow commit are the expected scoped agent/aggregate identity while `git config --local --get user.name` and `git config --local --get user.email` are byte-for-byte unchanged after the commit.
- A deterministic test covers the no-local-agent-config case: running workflow commit code must not create or overwrite repo/worktree `user.name` or `user.email`; the observable assertion is that `git config --local --get-regexp ^user\.` returns the same result before and after the workflow commit attempt.
- The implementation removes or avoids any production path that persists `codex`, `claude`, `gemini`, or `orbit` into repo-local Git config for workflow commits; inspection of `crates/orbit-engine/src/executor/automation/**` shows identity is applied only to the spawned commit command or its environment.
- If the public `git.commit` tool remains dependent on ambient Git config, its behavior is either updated to accept scoped author/committer identity or explicitly documented/tested as a user-directed tool outside workflow-owned commit automation.
- Run `cargo test -p orbit-engine git_commit` and `make fmt`; both commands complete successfully.
- Auditability and/or activity-job design docs are updated in the same change if committer semantics change, including a task reference to this task ID.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Workflow `git_commit` now runs `git commit` with process-scoped `GIT_AUTHOR_*` and `GIT_COMMITTER_*`, defaulting to aggregate `orbit` when no task implementer identity is present; no repo-local `user.*` writes are used.
- Added deterministic tests for human local config preservation, no-local-config workflow commits, and mixed implementer aggregate author/committer metadata.
- Documented scoped workflow git identity in the auditability overview/design/ADR, and clarified that public `git.commit` remains user-directed and ambient-config based.

Assessment: Validated with `cargo test -p orbit-engine git_commit`, `make fmt`, and `git diff --check`.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/T20260509-12-69febe31`
- Behind base: 0
- Ahead of base: 1

*authored by: gpt-5.5*