### PR TITLE
Reject raw task IDs before task-store path construction

### DIFF
--- a/crates/orbit-store/src/file/task_store/api.rs
+++ b/crates/orbit-store/src/file/task_store/api.rs
@@ -10,7 +10,7 @@ use orbit_common::types::{
 use super::bundle::{TaskBundle, bundle_to_task, merge_review_threads};
 use super::constants::TASK_SCHEMA_VERSION;
 use super::doc::TaskFileDocument;
-use super::layout::TaskStateDir;
+use super::layout::{TaskStateDir, validate_task_id};
 use crate::backend::{
     TaskArtifactUpdateParams, TaskCreateParams, TaskDocumentUpdateParams, TaskHistoryUpdateParams,
     TaskReviewUpdateParams,
@@ -155,6 +155,7 @@ impl TaskFileStore {
     }
 
     pub(crate) fn get_task(&self, id: &str) -> Result<Option<Task>, OrbitError> {
+        validate_task_id(id)?;
         let Some((state, task_dir)) = self.locate_task(id)? else {
             return Ok(None);
         };
@@ -166,6 +167,7 @@ impl TaskFileStore {
         &self,
         id: &str,
     ) -> Result<Option<Vec<TaskArtifact>>, OrbitError> {
+        validate_task_id(id)?;
         let Some((_, task_dir)) = self.locate_task(id)? else {
             return Ok(None);
         };
@@ -193,6 +195,7 @@ impl TaskFileStore {
         id: &str,
         fields: &TaskDocumentUpdateParams,
     ) -> Result<(), OrbitError> {
+        validate_task_id(id)?;
         if fields.actor.trim().is_empty() {
             return Err(OrbitError::InvalidInput(
                 "task actor must not be empty".to_string(),
@@ -300,6 +303,7 @@ impl TaskFileStore {
         id: &str,
         fields: &TaskHistoryUpdateParams,
     ) -> Result<(), OrbitError> {
+        validate_task_id(id)?;
         if fields.actor.trim().is_empty() {
             return Err(OrbitError::InvalidInput(
                 "task actor must not be empty".to_string(),
@@ -361,6 +365,7 @@ impl TaskFileStore {
         id: &str,
         fields: &TaskReviewUpdateParams,
     ) -> Result<(), OrbitError> {
+        validate_task_id(id)?;
         let _task_lock = self.acquire_task_lock(id)?;
         let Some((current_state, current_dir)) = self.locate_task(id)? else {
             return Err(OrbitError::TaskNotFound(id.to_string()));
@@ -393,6 +398,7 @@ impl TaskFileStore {
         id: &str,
         fields: &TaskArtifactUpdateParams,
     ) -> Result<(), OrbitError> {
+        validate_task_id(id)?;
         let _task_lock = self.acquire_task_lock(id)?;
         let Some((_, task_dir)) = self.locate_task(id)? else {
             return Err(OrbitError::TaskNotFound(id.to_string()));
@@ -426,6 +432,7 @@ impl TaskFileStore {
     }
 
     pub(crate) fn delete_task(&self, id: &str) -> Result<bool, OrbitError> {
+        validate_task_id(id)?;
         let _task_lock = self.acquire_task_lock(id)?;
         let Some((_, task_dir)) = self.locate_task(id)? else {
             return Ok(false);
@@ -490,6 +497,82 @@ mod tests {
             source_task_id: None,
             comments: Vec::new(),
         }
+    }
+
+    fn assert_invalid_task_id<T: std::fmt::Debug>(result: Result<T, OrbitError>) {
+        let err = result.expect_err("invalid task id should be rejected");
+        assert!(
+            matches!(err, OrbitError::InvalidInput(_)),
+            "expected invalid input error, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn public_task_id_entrypoints_reject_invalid_ids_before_locking() {
+        let root = tempdir().expect("tempdir");
+        let store = TaskFileStore::new(root.path().to_path_buf());
+        let invalid_ids = [
+            "",
+            "   ",
+            "../T20260426-1",
+            "../../outside",
+            "/tmp/T20260426-1",
+            r"C:\tmp\T20260426-1",
+            r"T20260426-1\outside",
+            "T20260426-1/outside",
+            "T20260426-1..2",
+        ];
+
+        for id in invalid_ids {
+            assert_invalid_task_id(store.get_task(id));
+            assert_invalid_task_id(store.get_task_artifacts(id));
+            assert_invalid_task_id(store.update_task_document(
+                id,
+                &TaskDocumentUpdateParams {
+                    actor: "test".to_string(),
+                    ..Default::default()
+                },
+            ));
+            assert_invalid_task_id(store.update_task_history(
+                id,
+                &TaskHistoryUpdateParams {
+                    actor: "test".to_string(),
+                    ..Default::default()
+                },
+            ));
+            assert_invalid_task_id(
+                store.update_task_reviews(id, &TaskReviewUpdateParams::default()),
+            );
+            assert_invalid_task_id(
+                store.upsert_task_artifacts(id, &TaskArtifactUpdateParams::default()),
+            );
+            assert_invalid_task_id(store.delete_task(id));
+        }
+
+        assert!(
+            !store.root.join(".locks").exists(),
+            "invalid ids must not create task lock files"
+        );
+    }
+
+    #[test]
+    fn delete_task_rejects_traversal_without_removing_outside_dir_or_creating_lock() {
+        let outer = tempdir().expect("tempdir");
+        let store_root = outer.path().join("tasks");
+        let store = TaskFileStore::new(store_root.clone());
+        let outside_dir = outer.path().join("outside");
+        let sentinel = outside_dir.join("sentinel.txt");
+        fs::create_dir_all(&outside_dir).expect("create outside dir");
+        fs::write(&sentinel, "keep").expect("write sentinel");
+
+        assert_invalid_task_id(store.delete_task("../../outside"));
+
+        assert!(outside_dir.is_dir(), "outside dir must not be removed");
+        assert!(sentinel.is_file(), "outside sentinel must not be removed");
+        assert!(
+            !store_root.join(".locks").exists(),
+            "invalid delete must not create an outside lock file"
+        );
     }
 
     #[test]

--- a/crates/orbit-store/src/file/task_store/bundle.rs
+++ b/crates/orbit-store/src/file/task_store/bundle.rs
@@ -13,7 +13,7 @@ use super::{
     TaskFileStore,
     constants::TASK_SCHEMA_VERSION,
     doc::{TaskFileDocument, serialize_task_doc_yaml},
-    layout::TaskStateDir,
+    layout::{TaskStateDir, validate_task_id},
 };
 
 #[derive(Debug, Clone)]
@@ -29,6 +29,7 @@ impl TaskFileStore {
         state: TaskStateDir,
         bundle: &TaskBundle,
     ) -> Result<(), OrbitError> {
+        validate_task_id(&bundle.doc.id)?;
         self.write_bundle_at(&self.task_dir(state, &bundle.doc.id), bundle)
     }
 
@@ -91,6 +92,7 @@ impl TaskFileStore {
                 "task id must not be empty".to_string(),
             ));
         }
+        validate_task_id(&bundle.doc.id)?;
         if bundle.doc.title.trim().is_empty() {
             return Err(OrbitError::InvalidInput(
                 "task title must not be empty".to_string(),

--- a/crates/orbit-store/src/file/task_store/layout.rs
+++ b/crates/orbit-store/src/file/task_store/layout.rs
@@ -135,6 +135,8 @@ impl TaskFileStore {
         &self,
         id: &str,
     ) -> Result<Option<(TaskStateDir, PathBuf)>, OrbitError> {
+        validate_task_id(id)?;
+
         for state in TaskStateDir::all() {
             if state.is_partitioned() {
                 if let Some(partition) = partition_key(id) {
@@ -308,6 +310,7 @@ impl TaskFileStore {
                 legacy_dir.display()
             )));
         };
+        validate_task_id(task_id)?;
         let target_dir = self.task_dir(state, task_id);
         if target_dir == legacy_dir {
             return Ok(legacy_dir);
@@ -331,6 +334,16 @@ impl TaskFileStore {
     }
 }
 
+pub(super) fn validate_task_id(id: &str) -> Result<(), OrbitError> {
+    if is_valid_task_id(id) {
+        return Ok(());
+    }
+
+    Err(OrbitError::InvalidInput(
+        "task id must match TYYYYMMDD-<digits> with optional legacy -<digits> suffix".to_string(),
+    ))
+}
+
 fn rewrite_legacy_proposed_friction_history(history: &mut [orbit_common::types::TaskHistoryEntry]) {
     for entry in history {
         if entry.event == "created"
@@ -341,6 +354,40 @@ fn rewrite_legacy_proposed_friction_history(history: &mut [orbit_common::types::
             return;
         }
     }
+}
+
+fn is_valid_task_id(id: &str) -> bool {
+    let Some(raw) = id.strip_prefix('T') else {
+        return false;
+    };
+    if raw.len() < 10 {
+        return false;
+    }
+
+    let Some(date) = raw.get(0..8) else {
+        return false;
+    };
+    if !date.as_bytes().iter().all(u8::is_ascii_digit) {
+        return false;
+    }
+
+    let Some(year) = date.get(0..4) else {
+        return false;
+    };
+    let Some(month) = date.get(4..6) else {
+        return false;
+    };
+    if !is_valid_year_month(year, month) {
+        return false;
+    }
+
+    let Some(tail) = raw.get(8..).and_then(|value| value.strip_prefix('-')) else {
+        return false;
+    };
+    !tail.is_empty()
+        && tail.split('-').all(|component| {
+            !component.is_empty() && component.as_bytes().iter().all(u8::is_ascii_digit)
+        })
 }
 
 fn partition_key(id: &str) -> Option<String> {
@@ -519,6 +566,48 @@ mod tests {
             let located = store.locate_task(id).expect("locate task");
 
             assert_eq!(located, Some((TaskStateDir::Done, expected_dir)));
+        }
+    }
+
+    #[test]
+    fn locate_task_migrates_legacy_partitioned_id_forms() {
+        let (_tempdir, store, _now) = fixture();
+        let task_ids = ["T20260426-1", "T20260426-0455", "T20260426-2313-2"];
+
+        for id in task_ids {
+            let legacy_dir = store.state_dir_path(TaskStateDir::Done).join(id);
+            fs::create_dir_all(&legacy_dir).expect("create legacy task dir");
+            let expected_dir = store.task_dir(TaskStateDir::Done, id);
+
+            let located = store.locate_task(id).expect("locate task");
+
+            assert_eq!(located, Some((TaskStateDir::Done, expected_dir.clone())));
+            assert!(expected_dir.is_dir(), "{id} should be migrated");
+            assert!(!legacy_dir.exists(), "{id} legacy dir should be moved");
+        }
+    }
+
+    #[test]
+    fn locate_task_rejects_invalid_path_like_ids_before_path_lookup() {
+        let (_tempdir, store, _now) = fixture();
+        let invalid_ids = [
+            "",
+            "   ",
+            "../T20260426-1",
+            "../../outside",
+            "/tmp/T20260426-1",
+            r"C:\tmp\T20260426-1",
+            r"T20260426-1\outside",
+            "T20260426-1/outside",
+            "T20260426-1..2",
+        ];
+
+        for id in invalid_ids {
+            let err = store.locate_task(id).expect_err("invalid id rejected");
+            assert!(
+                matches!(err, OrbitError::InvalidInput(_)),
+                "{id:?} should fail as invalid input, got {err:?}"
+            );
         }
     }
 

--- a/crates/orbit-store/src/file/task_store/lock.rs
+++ b/crates/orbit-store/src/file/task_store/lock.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 use fs2::FileExt;
 use orbit_common::types::OrbitError;
 
-use super::TaskFileStore;
+use super::{TaskFileStore, layout::validate_task_id};
 
 const LOCKS_DIR_NAME: &str = ".locks";
 const TASK_LOCKS_DIR_NAME: &str = "tasks";
@@ -19,6 +19,7 @@ impl TaskFileStore {
     }
 
     pub(super) fn acquire_task_lock(&self, task_id: &str) -> Result<File, OrbitError> {
+        validate_task_id(task_id)?;
         self.acquire_lock(self.task_lock_path(task_id), &format!("task '{task_id}'"))
     }
 


### PR DESCRIPTION
## Task

[T20260509-26](https://orbit-cli.com/tasks/T20260509-26) — Reject raw task IDs before task-store path construction

### Description

## Problem
Task-store entrypoints accept user-provided IDs and eventually join them into task and lock paths. `delete_task` can call `locate_task` and then `remove_dir_all` without reading the bundle, while `task_dir` and `task_lock_path` join the raw ID string.

## Why It Matters
IDs containing separators or `..` can resolve outside `.orbit/tasks` or `.orbit/tasks/.locks`; the `orbit.task.delete` tool reaches this path directly.

## Constraints / Notes
Use the canonical task ID format as a path-stem validation boundary. Apply it before acquiring per-task locks or constructing paths.

### Acceptance Criteria

- All public task-store operations reject IDs containing `/`, `\`, `..`, absolute prefixes, or empty/whitespace values before any path or lock file is created.
- Traversal regression tests prove `delete_task("../../outside")` cannot remove an outside directory and cannot create an outside lock file.
- Valid legacy-supported ID forms still locate and migrate as before.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Added task ID validation for canonical and legacy task ID stems before task lookup, per-task locking, bundle writes, and public task-store ID operations.
- Added traversal regression coverage proving invalid delete IDs do not remove outside directories or create task lock files.
- Added legacy ID migration coverage for generated, HHMM-style, and compound legacy task IDs.

Assessment: The task-store path construction boundary now rejects path-like IDs early while preserving supported legacy lookup and migration behavior. Validation passed with focused orbit-store tests plus repository build and CI.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/T20260509-26-69febe31`
- Behind base: 0
- Ahead of base: 1

*authored by: gpt-5.5*