### PR TITLE
Honor wildcard tool allowlists at runtime

### DIFF
--- a/crates/orbit-agent/src/loop_engine/agent_loop.rs
+++ b/crates/orbit-agent/src/loop_engine/agent_loop.rs
@@ -11,6 +11,7 @@
 use std::time::{Duration, Instant};
 
 use chrono::Utc;
+use orbit_common::types::activity_job::tool_allowed;
 use orbit_tools::{ToolContext, ToolRegistry};
 
 use super::audit::{AuditSink, LoopAuditEvent, UsageSnapshot};
@@ -188,7 +189,6 @@ impl AgentLoop {
             None => cfg.tool_allowlist.clone(),
         };
         let tool_specs = build_tool_specs(registry, &advertised);
-        let allowlist: Vec<&str> = cfg.tool_allowlist.iter().map(String::as_str).collect();
 
         let started = Instant::now();
         let mut total_tokens_observed: u64 = 0;
@@ -260,7 +260,7 @@ impl AgentLoop {
             for (tool_use_id, tool_name, input) in tool_calls {
                 iter_tool_names.push(tool_name.clone());
 
-                if !is_tool_allowed(&tool_name, &allowlist) {
+                if !tool_allowed(&tool_name, &cfg.tool_allowlist) {
                     let reason = "tool not in allowlist".to_string();
                     let denial_payload = serde_json::json!({
                         "tool_name": &tool_name,
@@ -409,13 +409,6 @@ fn classify_content(
     (text, assistant_blocks, tool_calls)
 }
 
-fn is_tool_allowed(name: &str, allowlist: &[&str]) -> bool {
-    if allowlist.is_empty() {
-        return false;
-    }
-    allowlist.contains(&name)
-}
-
 fn accumulate(total: &mut TurnUsage, delta: &TurnUsage) {
     total.input_tokens = total.input_tokens.saturating_add(delta.input_tokens);
     total.output_tokens = total.output_tokens.saturating_add(delta.output_tokens);
@@ -498,4 +491,146 @@ fn preview_request(req: &TurnRequest<'_>, transport: &dyn LoopTransport) -> Vec<
         }),
     });
     serde_json::to_vec(&value).unwrap_or_default()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{Arc, Mutex};
+
+    use orbit_common::types::OrbitError;
+    use orbit_tools::{OrbitBuiltinAction, OrbitTaskScope, OrbitToolHost, ReservationOwnerContext};
+    use serde_json::{Value, json};
+
+    use super::super::audit::NullSink;
+    use super::super::session::Session;
+    use super::*;
+
+    #[derive(Default)]
+    struct RecordingTransport {
+        advertised: Mutex<Vec<Vec<String>>>,
+        calls: Mutex<usize>,
+    }
+
+    impl RecordingTransport {
+        fn advertised(&self) -> Vec<Vec<String>> {
+            self.advertised.lock().expect("advertised mutex").clone()
+        }
+    }
+
+    impl LoopTransport for RecordingTransport {
+        fn provider(&self) -> &str {
+            "test"
+        }
+
+        fn model(&self) -> &str {
+            "test-model"
+        }
+
+        fn send_turn(&self, req: &TurnRequest<'_>) -> Result<TurnResponse, TransportError> {
+            self.advertised
+                .lock()
+                .expect("advertised mutex")
+                .push(req.tools.iter().map(|tool| tool.name.clone()).collect());
+
+            let mut calls = self.calls.lock().expect("calls mutex");
+            let call_index = *calls;
+            *calls += 1;
+
+            let (content, stop_reason) = if call_index == 0 {
+                (
+                    vec![ContentBlock::ToolUse {
+                        id: "call-1".to_string(),
+                        name: "orbit.task.show".to_string(),
+                        input: json!({ "id": "T-test" }),
+                    }],
+                    StopReason::ToolUse,
+                )
+            } else {
+                (
+                    vec![ContentBlock::Text {
+                        text: "done".to_string(),
+                    }],
+                    StopReason::EndTurn,
+                )
+            };
+
+            Ok(TurnResponse {
+                content,
+                stop_reason,
+                usage: TurnUsage::default(),
+                raw_request_body: Vec::new(),
+                raw_response_body: Vec::new(),
+                endpoint: String::new(),
+                http_status: 200,
+            })
+        }
+    }
+
+    struct FakeOrbitHost;
+
+    impl OrbitToolHost for FakeOrbitHost {
+        fn execute(
+            &self,
+            action: OrbitBuiltinAction,
+            input: Value,
+            _agent: Option<String>,
+            _model: Option<String>,
+            _reservation_owner: Option<ReservationOwnerContext>,
+        ) -> Result<Value, OrbitError> {
+            assert_eq!(action, OrbitBuiltinAction::TaskShow);
+            assert_eq!(input["id"], "T-test");
+            Ok(json!({ "id": "T-test" }))
+        }
+
+        fn task_scope(&self) -> OrbitTaskScope {
+            OrbitTaskScope {
+                orbit_root: None,
+                task_id: Some("T-test".to_string()),
+            }
+        }
+    }
+
+    #[test]
+    fn wildcard_allowlist_advertises_and_executes_task_show() {
+        let mut session = Session::new("test", "test-model", "", None);
+        let cfg = AgentLoopConfig::new_for_run("run-test")
+            .with_allowlist(vec!["orbit.task.*".to_string()])
+            .with_max_iterations(3);
+        let mut registry = ToolRegistry::new();
+        registry.register_builtins();
+        let tool_ctx = ToolContext {
+            allowed_tools: vec!["orbit.task.*".to_string()],
+            orbit_host: Some(Arc::new(FakeOrbitHost)),
+            ..Default::default()
+        };
+        let transport = RecordingTransport::default();
+        let sink = NullSink;
+
+        let outcome = AgentLoop::run(
+            &mut session,
+            &cfg,
+            &transport,
+            &registry,
+            &tool_ctx,
+            &sink,
+            "show the task",
+        )
+        .expect("wildcard should allow orbit.task.show");
+
+        assert_eq!(outcome.final_message, "done");
+        assert!(
+            outcome
+                .trace
+                .iter()
+                .all(|iteration| iteration.policy_denials.is_empty())
+        );
+        assert!(
+            transport
+                .advertised()
+                .first()
+                .expect("first request")
+                .iter()
+                .any(|name| name == "orbit.task.show")
+        );
+    }
 }

--- a/crates/orbit-agent/src/loop_engine/tool_dispatch.rs
+++ b/crates/orbit-agent/src/loop_engine/tool_dispatch.rs
@@ -6,23 +6,43 @@
 //! `ToolRegistry::execute` entry point that the rest of Orbit uses, so tool
 //! behavior, policy, and attribution stay in a single source of truth.
 
+use std::collections::HashSet;
 use std::time::Instant;
 
-use orbit_common::types::{OrbitError, ToolSchema};
+use orbit_common::types::{
+    OrbitError, ToolSchema,
+    activity_job::{tool_allowed, validate_tool_allowlist},
+};
 use orbit_tools::{ToolContext, ToolRegistry};
 use serde_json::{Value, json};
 
 use super::transport::ToolSpec;
 
 pub fn build_tool_specs(registry: &ToolRegistry, allowlist: &[String]) -> Vec<ToolSpec> {
-    allowlist
-        .iter()
-        .filter_map(|name| {
-            registry
-                .get_schema(name)
-                .map(|schema| schema_to_tool_spec(&schema))
-        })
-        .collect()
+    let mut schemas = registry.schemas();
+    schemas.sort_unstable_by(|left, right| left.name.cmp(&right.name));
+
+    let mut seen = HashSet::new();
+    let mut specs = Vec::new();
+    for entry in allowlist {
+        if let Some(schema) = registry.get_schema(entry) {
+            push_tool_spec(&mut specs, &mut seen, &schema);
+        }
+        if entry.ends_with('*') && validate_tool_allowlist(std::slice::from_ref(entry)).is_ok() {
+            for schema in &schemas {
+                if tool_allowed(&schema.name, std::slice::from_ref(entry)) {
+                    push_tool_spec(&mut specs, &mut seen, schema);
+                }
+            }
+        }
+    }
+    specs
+}
+
+fn push_tool_spec(specs: &mut Vec<ToolSpec>, seen: &mut HashSet<String>, schema: &ToolSchema) {
+    if seen.insert(schema.name.clone()) {
+        specs.push(schema_to_tool_spec(schema));
+    }
 }
 
 pub fn schema_to_tool_spec(schema: &ToolSchema) -> ToolSpec {
@@ -231,5 +251,29 @@ mod tests {
                 "{tool_name} dependencies must accept a string"
             );
         }
+    }
+
+    #[test]
+    fn build_tool_specs_expands_wildcards_to_registered_tools_only() {
+        let mut registry = ToolRegistry::new();
+        registry.register_builtins();
+        assert!(registry.unregister("orbit.task.search"));
+
+        let specs = build_tool_specs(&registry, &["orbit.task.*".to_string()]);
+        let names = specs.into_iter().map(|spec| spec.name).collect::<Vec<_>>();
+
+        assert!(names.iter().any(|name| name == "orbit.task.show"));
+        assert!(!names.iter().any(|name| name == "orbit.task.search"));
+        assert!(!names.iter().any(|name| name == "orbit.task.*"));
+    }
+
+    #[test]
+    fn build_tool_specs_does_not_expand_unvalidated_wildcard_roots() {
+        let mut registry = ToolRegistry::new();
+        registry.register_builtins();
+
+        let specs = build_tool_specs(&registry, &["orbit.*".to_string()]);
+
+        assert!(specs.is_empty());
     }
 }

--- a/crates/orbit-core/src/runtime/pipeline.rs
+++ b/crates/orbit-core/src/runtime/pipeline.rs
@@ -1,7 +1,7 @@
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
-use orbit_common::types::{OrbitEvent, Role};
+use orbit_common::types::{OrbitEvent, Role, activity_job::tool_allowed};
 use orbit_common::utility::redaction::{redact_sensitive_env_error, redact_sensitive_env_json};
 use orbit_tools::ToolContext;
 use serde_json::Value;
@@ -63,7 +63,7 @@ impl OrbitRuntime {
         self.check_tool_enabled(name)?;
 
         if !tool_context.allowed_tools.is_empty()
-            && !tool_context.allowed_tools.iter().any(|t| t == name)
+            && !tool_allowed(name, &tool_context.allowed_tools)
         {
             self.with_mutation(|| {
                 Ok((
@@ -264,4 +264,66 @@ pub struct DryRunResult {
     pub tool_name: String,
     pub policy_allowed: bool,
     pub missing_params: Vec<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use orbit_common::types::{TaskPriority, TaskStatus, TaskType};
+    use orbit_store::TaskCreateParams;
+    use orbit_tools::ToolContext;
+    use serde_json::json;
+
+    use super::*;
+
+    #[test]
+    fn run_tool_context_allowlist_honors_task_wildcard() {
+        let runtime = OrbitRuntime::in_memory().expect("build runtime");
+        let task = runtime
+            .stores()
+            .tasks()
+            .create(TaskCreateParams {
+                actor: "test".to_string(),
+                parent_id: None,
+                title: "Wildcard task".to_string(),
+                description: "Exercise wildcard runtime allowlist".to_string(),
+                acceptance_criteria: Vec::new(),
+                dependencies: Vec::new(),
+                plan: String::new(),
+                execution_summary: String::new(),
+                context_files: Vec::new(),
+                workspace_path: Some(runtime.paths().repo_root.to_string_lossy().into_owned()),
+                repo_root: None,
+                created_by: Some("test".to_string()),
+                planned_by: None,
+                implemented_by: None,
+                agent: None,
+                model: None,
+                status: TaskStatus::Backlog,
+                priority: TaskPriority::Medium,
+                complexity: None,
+                task_type: TaskType::Task,
+                external_refs: Vec::new(),
+                source_task_id: None,
+                comments: Vec::new(),
+            })
+            .expect("create task");
+
+        let output = runtime
+            .run_tool_with_context_and_role(
+                "orbit.task.show",
+                json!({ "id": task.id.clone() }),
+                Role::Admin,
+                ToolContext {
+                    allowed_tools: vec!["orbit.task.*".to_string()],
+                    orbit_host: Some(crate::runtime::build_orbit_tool_host(
+                        &runtime,
+                        Some(task.id.clone()),
+                    )),
+                    ..Default::default()
+                },
+            )
+            .expect("wildcard activity context should permit orbit.task.show");
+
+        assert_eq!(output["id"], task.id);
+    }
 }


### PR DESCRIPTION
## Task

[T20260509-22](https://orbit-cli.com/tasks/T20260509-22) — Honor wildcard tool allowlists at runtime

### Description

## Problem
Activity assets declare wildcard tool allowlists such as `orbit.task.*`, `orbit.graph.*`, and `fs.*`, and `orbit-common` exposes wildcard-aware `tool_allowed`. Several execution paths still use exact string checks: `AgentLoop::is_tool_allowed`, `build_tool_specs`, and `OrbitRuntime::run_tool_with_context_and_role` only compare concrete names. HTTP loops also advertise no tools for wildcard entries because `ToolRegistry::get_schema` is called with the literal wildcard.

## Why It Matters
Default activities can validate conceptually while models see zero advertised tools or get denied when calling an intended concrete tool. CLI-backed activity tool calls can also reject valid wildcard-permitted tools.

## Constraints / Notes
Keep the wildcard roots constrained by `V2_TOOL_WILDCARD_ROOTS`; do not broaden the public tool surface beyond registered tools.

### Acceptance Criteria

- A regression test shows an activity/tool context with `orbit.task.*` permits `orbit.task.show` through both the HTTP loop allowlist path and `OrbitRuntime::run_tool_with_context_and_role`.
- `build_tool_specs` expands wildcard entries to registered concrete schemas and does not advertise unregistered removed tools.
- `make ci` passes after the shared wildcard matching path is used consistently.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Routed HTTP agent-loop allowlist checks through the shared wildcard-aware `tool_allowed` helper.
- Updated agent tool advertisement to expand validated wildcard entries against registered schemas only, preserving concrete allowlist ordering and suppressing removed/unregistered tools.
- Routed `OrbitRuntime::run_tool_with_context_and_role` activity allowlist checks through the same wildcard-aware helper.
- Added regression coverage for HTTP loop wildcard advertisement/execution, wildcard schema expansion, invalid wildcard roots, and runtime `orbit.task.show` with `orbit.task.*`.

Assessment: Wildcard allowlists now behave consistently across model-visible tool specs, HTTP loop dispatch, and runtime tool execution without broadening beyond `V2_TOOL_WILDCARD_ROOTS` or the registered tool surface.

Validation:
- `cargo test -p orbit-agent` passed.
- `cargo test -p orbit-core run_tool_context_allowlist_honors_task_wildcard` passed.
- Plain `make ci` exposed existing test-environment friction; filed `T20260509-51`.
- `env RUST_TEST_THREADS=1 ORBIT_LOG_PATH=/tmp/orbit-empty-ci-log-jrun-20260509-0455-9.jsonl make ci` passed.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/T20260509-22-69febe3c`
- Behind base: 0
- Ahead of base: 1

*authored by: gpt-5.5*