### PR TITLE
Reject parent traversal in policy candidate paths

### DIFF
--- a/crates/orbit-common/src/types/policy_def.rs
+++ b/crates/orbit-common/src/types/policy_def.rs
@@ -382,11 +382,34 @@ fn normalize_path(path: &str) -> Result<String, OrbitError> {
     if normalized == "." {
         normalized.clear();
     }
-    if normalized.starts_with('/') || normalized == "~" || normalized.starts_with("~/") {
+    if normalized == "~"
+        || normalized.starts_with("~/")
+        || normalized.starts_with("../")
+        || normalized == ".."
+    {
         return Err(OrbitError::InvalidInput(format!(
             "filesystem path `{path}` must stay inside the workspace root"
         )));
     }
+
+    let path_ref = Path::new(&normalized);
+    if path_ref.is_absolute() {
+        return Err(OrbitError::InvalidInput(format!(
+            "filesystem path `{path}` must stay inside the workspace root"
+        )));
+    }
+
+    for component in path_ref.components() {
+        match component {
+            Component::CurDir | Component::Normal(_) => {}
+            Component::ParentDir | Component::RootDir | Component::Prefix(_) => {
+                return Err(OrbitError::InvalidInput(format!(
+                    "filesystem path `{path}` must stay inside the workspace root"
+                )));
+            }
+        }
+    }
+
     Ok(normalized)
 }
 

--- a/crates/orbit-policy/src/engine.rs
+++ b/crates/orbit-policy/src/engine.rs
@@ -159,6 +159,56 @@ mod tests {
     }
 
     #[test]
+    fn check_rejects_parent_traversal_for_read_and_modify_paths() {
+        let def = make_def(vec![], vec![], &[("default", &["**"], &["**"])]);
+        let engine = PolicyEngine::from_def(&def).expect("engine");
+
+        for (operation, path) in [
+            (FsOperation::Read, "../secret.txt"),
+            (FsOperation::Read, "src/../secret.txt"),
+            (FsOperation::Read, "..\\secret.txt"),
+            (FsOperation::Read, "src\\..\\secret.txt"),
+            (FsOperation::Modify, "../secret.txt"),
+            (FsOperation::Modify, "src/../secret.txt"),
+            (FsOperation::Modify, "..\\secret.txt"),
+            (FsOperation::Modify, "src\\..\\secret.txt"),
+        ] {
+            let err = engine
+                .check("default", operation, path)
+                .expect_err("parent traversal must be rejected");
+
+            assert!(
+                matches!(err, OrbitError::InvalidInput(_)),
+                "expected InvalidInput for {operation:?} `{path}`, got {err:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn check_accepts_valid_relative_paths_after_normalization() {
+        let def = make_def(
+            vec![],
+            vec![],
+            &[("default", &["src/lib.rs"], &["src/lib.rs"])],
+        );
+        let engine = PolicyEngine::from_def(&def).expect("engine");
+
+        for (operation, path) in [
+            (FsOperation::Read, "src/lib.rs"),
+            (FsOperation::Read, "./src/lib.rs"),
+            (FsOperation::Modify, "src/lib.rs"),
+            (FsOperation::Modify, "./src/lib.rs"),
+        ] {
+            let result = engine
+                .check("default", operation, path)
+                .expect("valid relative path should check");
+
+            assert!(result.allowed, "{operation:?} `{path}` should be allowed");
+            assert_eq!(result.matched_rule, "src/lib.rs");
+        }
+    }
+
+    #[test]
     fn check_unknown_profile_returns_error_not_silent_allow() {
         // Invariant: requesting an undefined profile name must surface a
         // structured error rather than silently allowing or silently denying.

--- a/docs/design/policy-sandbox/2_design.md
+++ b/docs/design/policy-sandbox/2_design.md
@@ -2,7 +2,7 @@
 
 **Status:** Draft
 **Owner:** claude
-**Last updated:** 2026-05-09 (T20260509-7)
+**Last updated:** 2026-05-09 (T20260509-27)
 
 This document describes Orbit's shipped policy and sandboxing implementation: v2 `PolicyDef`, profile resolution, last-match-wins path evaluation, HTTP-tool enforcement, activity/job `fsProfile` binding, macOS CLI sandbox wrapping, and `orbit-exec` supervision. See [1_overview.md](./1_overview.md) for purpose and [3_vision.md](./3_vision.md) for forward-looking gaps.
 
@@ -46,7 +46,7 @@ The implicit `unrestricted` profile appears only when an activity omitted `fsPro
 4. Walk rules in order and record the most recent match against the normalized workspace-relative path. Later matches override earlier ones.
 5. Use the last match's negation flag. If no rule matched but a positive rule exists, deny with `<no matching rule>`; if only negated rules exist, deny with `[]`.
 
-Path normalization (`normalize_path`) trims, flips slashes, strips `./` prefixes, and rejects absolute paths or `~`-anchored paths. Tool callers are expected to canonicalize first and then express the path workspace-relative — `crates/orbit-tools/src/builtin/fs/mod.rs::workspace_relative_path` handles that on the call site.
+Path normalization (`normalize_path`) trims, flips slashes, strips `./` prefixes, and rejects absolute paths, `~`-anchored paths, and parent-directory traversal anywhere in the component list ([T20260509-27]). Tool callers are expected to canonicalize first and then express the path workspace-relative — `crates/orbit-tools/src/builtin/fs/mod.rs::workspace_relative_path` handles that on the call site.
 
 The glob translator supports `*`, `**`, `?`, and `<prefix>/**`. It is intentionally narrower than POSIX glob syntax.
 
@@ -156,7 +156,10 @@ Risk-weighted regression tests sit beside the implementations they guard
   to `allowed=false`; global `denyRead` / `denyModify` rules override
   profile-level positive rules under last-match-wins; an unknown profile name
   errors structurally (with the documented `unrestricted` exception); and the
-  `matched_rule` field is populated for audit attribution.
+  `matched_rule` field is populated for audit attribution. Traversal inputs
+  such as `../secret.txt`, `src/../secret.txt`, and their backslash-normalized
+  equivalents are rejected as `OrbitError::InvalidInput` for both read and
+  modify checks ([T20260509-27]).
 - `crates/orbit-exec/src/macos_sandbox.rs#tests` — SBPL compilation tests
   cover `denyRead` / `denyModify` clause emission (`subpath` for simple
   rules, `regex` for non-trivial globs) and the deny-after-allow ordering
@@ -207,5 +210,6 @@ non-empty on Linux CI.
 - **[T20260428-14]** — Extend the macOS sandbox state-dir allowance to Claude (`~/.claude` / `$CLAUDE_CONFIG_DIR`) and Gemini (`~/.gemini`), and document why side-write roots remain Codex-only.
 - **[T20260430-23]** — Shorten the policy sandbox design docs while preserving the shipped contract and ADR history.
 - **[T20260509-7]** — Add `PolicyEngine::check` boundary tests and macOS sandbox `denyRead` / realistic agent-loop profile tests.
+- **[T20260509-27]** — Reject parent-directory traversal in candidate policy paths while preserving valid relative path normalization.
 
 > Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.

--- a/docs/design/policy-sandbox/specs/fs-profile-resolution.md
+++ b/docs/design/policy-sandbox/specs/fs-profile-resolution.md
@@ -21,7 +21,7 @@ The resolution algorithm has multiple layered transformations (lookup, normaliza
 
 ## Evaluation Invariants
 
-- **Path normalization.** Caller-supplied paths are normalized via `normalize_path`: trim, slash-flip, strip leading `./`. Absolute paths and `~`-anchored paths are rejected.
+- **Path normalization.** Caller-supplied paths are normalized via `normalize_path`: trim, slash-flip, strip leading `./`. Absolute paths, `~`-anchored paths, and parent-directory components are rejected after backslash normalization.
 - **Empty rule list.** If the operation's rule list is empty after deny injection, the decision is `allowed = false` with `matched_rule = "[]"`.
 - **Rule walk.** The evaluator walks the rule list in order and tracks the most recent match. The decision uses the *last* match's negation flag: positive match → allow, negated match → deny.
 - **Empty positive set.** If the rule list contains no positive rules (only negated rules), the decision is `allowed = false` with `matched_rule = "[]"`.
@@ -49,4 +49,4 @@ The resolution algorithm has multiple layered transformations (lookup, normaliza
 
 ## Agent Signature
 
-Last revised by claude / claude-opus-4-7 for [T20260426-0622].
+Last revised by codex / gpt-5.5 for [T20260509-27].


### PR DESCRIPTION
## Task

[T20260509-27](https://orbit-cli.com/tasks/T20260509-27) — Reject parent traversal in policy candidate paths

### Description

## Problem
`PolicyDef::check_path` normalizes candidate paths with `normalize_path`, which rejects absolute and `~` paths but does not reject `Component::ParentDir`. Unlike rule normalization, candidate paths such as `src/../secret.txt` or `../secret.txt` can be checked against allow rules after only string cleanup.

## Why It Matters
A caller using policy checks as the filesystem boundary can receive false allows for paths that escape the intended workspace scope.

## Constraints / Notes
Mirror the component validation already used by `normalize_rule`, including backslash-normalized variants.

### Acceptance Criteria

- `PolicyDef::check_path` rejects `../secret.txt`, `src/../secret.txt`, and equivalent backslash forms with `OrbitError::InvalidInput`.
- Existing valid relative paths such as `src/lib.rs` and `./src/lib.rs` continue to normalize and match as before.
- Policy tests cover denied traversal for both read and modify operations.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Rejected parent-directory components in `PolicyDef::check_path` candidate path normalization after trimming, backslash normalization, and leading `./` stripping.
- Added `PolicyEngine::check` regression coverage for read and modify traversal inputs, including `../secret.txt`, `src/../secret.txt`, and backslash-normalized forms.
- Confirmed valid relative paths (`src/lib.rs`, `./src/lib.rs`) still match for read and modify operations.
- Updated policy-sandbox design/spec docs to record candidate path traversal rejection for T20260509-27.

Assessment: The scoped bug is fixed and validated with targeted policy tests plus full workspace CI. A transient unrelated CI flake in a fanout ordering test was reported as friction task T20260509-52; the focused test and a subsequent full `make ci` passed.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/T20260509-27-69febff0`
- Behind base: 0
- Ahead of base: 1

*authored by: gpt-5.5*