### PR TITLE
Validate policy and executor resource names as safe file stems

### DIFF
--- a/crates/orbit-common/src/types/mod.rs
+++ b/crates/orbit-common/src/types/mod.rs
@@ -89,7 +89,7 @@ pub use policy_def::{
 pub use resource::{
     EXECUTOR_RESOURCE_SCHEMA_VERSION, ExecutorResource, ExecutorResourceSpec,
     POLICY_RESOURCE_SCHEMA_VERSION, PolicyResource, PolicyResourceSpec, ResourceEnvelope,
-    ResourceHeader, ResourceKind, ResourceMetadata, parse_policy_resource,
+    ResourceHeader, ResourceKind, ResourceMetadata, parse_policy_resource, validate_resource_name,
 };
 pub use role::Role;
 pub use run_state::PipelineState;

--- a/crates/orbit-common/src/types/policy_def.rs
+++ b/crates/orbit-common/src/types/policy_def.rs
@@ -5,7 +5,7 @@ use chrono::{DateTime, Utc};
 use regex::Regex;
 use serde::{Deserialize, Serialize};
 
-use crate::types::OrbitError;
+use crate::types::{OrbitError, validate_resource_name};
 
 pub const DEFAULT_POLICY_NAME: &str = "default";
 pub const UNRESTRICTED_FS_PROFILE: &str = "unrestricted";
@@ -74,6 +74,8 @@ pub struct FsCheckResult {
 
 impl PolicyDef {
     pub fn validate(&self) -> Result<(), OrbitError> {
+        validate_resource_name(&self.name)?;
+
         let deny_read = normalize_rule_set(&self.deny_read, "spec.denyRead")?;
         let deny_modify = normalize_rule_set(&self.deny_modify, "spec.denyModify")?;
 

--- a/crates/orbit-common/src/types/resource.rs
+++ b/crates/orbit-common/src/types/resource.rs
@@ -57,6 +57,54 @@ impl ResourceMetadata {
             annotations: HashMap::new(),
         }
     }
+
+    pub fn validate_name(&self) -> Result<(), OrbitError> {
+        validate_resource_name(&self.name)
+    }
+}
+
+pub fn validate_resource_name(name: &str) -> Result<(), OrbitError> {
+    if name.is_empty() {
+        return invalid_resource_name(name, "must not be empty");
+    }
+
+    if name.trim() != name {
+        return invalid_resource_name(name, "must not have leading or trailing whitespace");
+    }
+
+    if name.starts_with('.') {
+        return invalid_resource_name(name, "must not start with `.`");
+    }
+
+    if name.contains("..") {
+        return invalid_resource_name(name, "must not contain `..`");
+    }
+
+    if name
+        .chars()
+        .any(|ch| matches!(ch, '/' | '\\' | ':' | '\0') || ch.is_control())
+    {
+        return invalid_resource_name(
+            name,
+            "must not contain separators, drive prefixes, or control characters",
+        );
+    }
+
+    if std::path::Path::new(name)
+        .file_stem()
+        .and_then(|stem| stem.to_str())
+        != Some(name)
+    {
+        return invalid_resource_name(name, "must be a single file stem");
+    }
+
+    Ok(())
+}
+
+fn invalid_resource_name(name: &str, reason: &str) -> Result<(), OrbitError> {
+    Err(OrbitError::InvalidInput(format!(
+        "invalid resource name {name:?}: {reason}"
+    )))
 }
 
 /// Header-only parse for routing `orbit apply` to the right store.
@@ -173,6 +221,38 @@ pub fn parse_policy_resource(yaml: &str, label: &str) -> Result<PolicyResource, 
         )));
     }
 
+    header.metadata.validate_name()?;
+
     serde_yaml::from_str(yaml)
         .map_err(|error| OrbitError::InvalidInput(format!("failed to parse {label}: {error}")))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::validate_resource_name;
+
+    #[test]
+    fn resource_name_accepts_existing_seeded_name_shapes() {
+        for name in [
+            "default",
+            "local-shell",
+            "task_auto_pipeline",
+            "agent_loop_cli_reference",
+        ] {
+            validate_resource_name(name).expect(name);
+        }
+    }
+
+    #[test]
+    fn resource_name_rejects_path_like_names() {
+        for name in [
+            "", " ", ".hidden", ".", "..", "../x", "x/../y", "x/y", "x\\y", "C:foo", "foo:bar",
+            "foo.yaml", "foo\nbar",
+        ] {
+            assert!(
+                validate_resource_name(name).is_err(),
+                "expected invalid resource name: {name:?}"
+            );
+        }
+    }
 }

--- a/crates/orbit-store/src/file/executor_def_store.rs
+++ b/crates/orbit-store/src/file/executor_def_store.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 
 use orbit_common::types::{
     EXECUTOR_RESOURCE_SCHEMA_VERSION, ExecutorDef, ExecutorResource, ExecutorResourceSpec,
-    OrbitError, ResourceKind, ResourceMetadata,
+    OrbitError, ResourceKind, ResourceMetadata, validate_resource_name,
 };
 
 use orbit_common::utility::fs::atomic_write_text_volatile as write_atomic;
@@ -19,6 +19,11 @@ impl ExecutorDefFileStore {
 
     fn executors_dir(&self) -> PathBuf {
         self.root.clone()
+    }
+
+    fn executor_path(&self, name: &str) -> Result<PathBuf, OrbitError> {
+        validate_resource_name(name)?;
+        Ok(self.executors_dir().join(format!("{name}.yaml")))
     }
 
     pub fn list_executor_defs(&self) -> Result<Vec<ExecutorDef>, OrbitError> {
@@ -43,7 +48,7 @@ impl ExecutorDefFileStore {
     }
 
     pub fn get_executor_def(&self, name: &str) -> Result<Option<ExecutorDef>, OrbitError> {
-        let path = self.executors_dir().join(format!("{name}.yaml"));
+        let path = self.executor_path(name)?;
         if !path.exists() {
             return Ok(None);
         }
@@ -53,9 +58,9 @@ impl ExecutorDefFileStore {
     }
 
     pub fn upsert_executor_def(&self, def: &ExecutorDef) -> Result<(), OrbitError> {
+        let path = self.executor_path(&def.name)?;
         let dir = self.executors_dir();
         fs::create_dir_all(&dir).map_err(|e| OrbitError::Io(e.to_string()))?;
-        let path = dir.join(format!("{}.yaml", def.name));
         let content = serde_yaml::to_string(&ExecutorResource {
             schema_version: EXECUTOR_RESOURCE_SCHEMA_VERSION,
             kind: ResourceKind::Executor,
@@ -94,6 +99,7 @@ fn parse_executor_def(content: &str, label: String) -> Result<ExecutorDef, Orbit
             label, doc.schema_version
         )));
     }
+    doc.metadata.validate_name()?;
     Ok(ExecutorDef {
         name: doc.metadata.name,
         executor_type: doc.spec.executor_type,
@@ -151,6 +157,7 @@ mod tests {
             .get_executor_def("claude")
             .expect("get")
             .expect("present");
+        assert_eq!(loaded.name, "claude");
         assert_eq!(loaded.sandbox, Some(ExecutorSandboxKind::MacosSandboxExec));
         assert!(loaded.allow_fallback);
     }
@@ -187,5 +194,41 @@ mod tests {
             .expect("present");
         assert_eq!(loaded.sandbox, Some(ExecutorSandboxKind::MacosSandboxExec));
         assert!(loaded.allow_fallback);
+    }
+
+    #[test]
+    fn rejects_traversal_executor_name_without_external_write() {
+        let dir = tempdir().expect("tempdir");
+        let store = ExecutorDefFileStore::new(dir.path().join("executors"));
+
+        let err = store
+            .upsert_executor_def(&baseline_def("../x"))
+            .expect_err("traversal name must fail");
+        assert!(matches!(err, OrbitError::InvalidInput(_)));
+        assert!(!dir.path().join("x.yaml").exists());
+
+        let err = store
+            .get_executor_def("../x")
+            .expect_err("traversal lookup must fail");
+        assert!(matches!(err, OrbitError::InvalidInput(_)));
+    }
+
+    #[test]
+    fn rejects_traversal_executor_metadata_name_when_loading() {
+        let dir = tempdir().expect("tempdir");
+        let executors_dir = dir.path().join("executors");
+        std::fs::create_dir_all(&executors_dir).expect("mkdir");
+        std::fs::write(
+            executors_dir.join("bad.yaml"),
+            "schemaVersion: 2\nkind: Executor\nmetadata:\n  name: ../x\nspec:\n  executor_type: direct_agent\n",
+        )
+        .expect("seed");
+
+        let store = ExecutorDefFileStore::new(executors_dir);
+        let err = store
+            .list_executor_defs()
+            .expect_err("traversal metadata name must fail");
+        assert!(matches!(err, OrbitError::InvalidInput(_)));
+        assert!(!dir.path().join("x.yaml").exists());
     }
 }

--- a/crates/orbit-store/src/file/policy_def_store.rs
+++ b/crates/orbit-store/src/file/policy_def_store.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 
 use orbit_common::types::{
     OrbitError, POLICY_RESOURCE_SCHEMA_VERSION, PolicyDef, PolicyResource, PolicyResourceSpec,
-    ResourceKind, ResourceMetadata, parse_policy_resource,
+    ResourceKind, ResourceMetadata, parse_policy_resource, validate_resource_name,
 };
 
 use orbit_common::utility::fs::atomic_write_text_volatile as write_atomic;
@@ -19,6 +19,11 @@ impl PolicyDefFileStore {
 
     fn policies_dir(&self) -> PathBuf {
         self.root.clone()
+    }
+
+    fn policy_path(&self, name: &str) -> Result<PathBuf, OrbitError> {
+        validate_resource_name(name)?;
+        Ok(self.policies_dir().join(format!("{name}.yaml")))
     }
 
     pub(crate) fn ensure_layout(&self) -> Result<(), OrbitError> {
@@ -51,7 +56,7 @@ impl PolicyDefFileStore {
     }
 
     pub(crate) fn get_policy_def(&self, name: &str) -> Result<Option<PolicyDef>, OrbitError> {
-        let path = self.policies_dir().join(format!("{name}.yaml"));
+        let path = self.policy_path(name)?;
         if !path.exists() {
             return Ok(None);
         }
@@ -61,9 +66,9 @@ impl PolicyDefFileStore {
     }
 
     pub(crate) fn upsert_policy_def(&self, def: &PolicyDef) -> Result<(), OrbitError> {
-        self.ensure_layout()?;
         def.validate()?;
-        let path = self.policies_dir().join(format!("{}.yaml", def.name));
+        let path = self.policy_path(&def.name)?;
+        self.ensure_layout()?;
         let content = serde_yaml::to_string(&PolicyResource {
             schema_version: POLICY_RESOURCE_SCHEMA_VERSION,
             kind: ResourceKind::Policy,
@@ -97,4 +102,77 @@ fn parse_policy_def(content: &str, label: String) -> Result<PolicyDef, OrbitErro
     };
     def.validate()?;
     Ok(def)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Utc;
+    use std::collections::HashMap;
+    use tempfile::tempdir;
+
+    fn baseline_def(name: &str) -> PolicyDef {
+        let now = Utc::now();
+        PolicyDef {
+            name: name.to_string(),
+            description: Some("test policy".to_string()),
+            deny_read: Vec::new(),
+            deny_modify: Vec::new(),
+            fs_profiles: HashMap::new(),
+            created_at: now,
+            updated_at: now,
+        }
+    }
+
+    #[test]
+    fn roundtrips_valid_policy_name_unchanged() {
+        let dir = tempdir().expect("tempdir");
+        let store = PolicyDefFileStore::new(dir.path().join("policies"));
+
+        let def = baseline_def("local-policy_1");
+        store.upsert_policy_def(&def).expect("upsert");
+
+        let loaded = store
+            .get_policy_def("local-policy_1")
+            .expect("get")
+            .expect("present");
+        assert_eq!(loaded.name, "local-policy_1");
+        assert!(dir.path().join("policies/local-policy_1.yaml").exists());
+    }
+
+    #[test]
+    fn rejects_traversal_policy_name_without_external_write() {
+        let dir = tempdir().expect("tempdir");
+        let store = PolicyDefFileStore::new(dir.path().join("policies"));
+
+        let err = store
+            .upsert_policy_def(&baseline_def("../x"))
+            .expect_err("traversal name must fail");
+        assert!(matches!(err, OrbitError::InvalidInput(_)));
+        assert!(!dir.path().join("x.yaml").exists());
+
+        let err = store
+            .get_policy_def("../x")
+            .expect_err("traversal lookup must fail");
+        assert!(matches!(err, OrbitError::InvalidInput(_)));
+    }
+
+    #[test]
+    fn rejects_traversal_policy_metadata_name_when_loading() {
+        let dir = tempdir().expect("tempdir");
+        let policies_dir = dir.path().join("policies");
+        std::fs::create_dir_all(&policies_dir).expect("mkdir");
+        std::fs::write(
+            policies_dir.join("bad.yaml"),
+            "schemaVersion: 2\nkind: Policy\nmetadata:\n  name: ../x\nspec: {}\n",
+        )
+        .expect("seed");
+
+        let store = PolicyDefFileStore::new(policies_dir);
+        let err = store
+            .list_policy_defs()
+            .expect_err("traversal metadata name must fail");
+        assert!(matches!(err, OrbitError::InvalidInput(_)));
+        assert!(!dir.path().join("x.yaml").exists());
+    }
 }

--- a/docs/design/policy-sandbox/2_design.md
+++ b/docs/design/policy-sandbox/2_design.md
@@ -2,7 +2,7 @@
 
 **Status:** Draft
 **Owner:** claude
-**Last updated:** 2026-05-09 (T20260509-7)
+**Last updated:** 2026-05-09 (T20260509-7, T20260509-28)
 
 This document describes Orbit's shipped policy and sandboxing implementation: v2 `PolicyDef`, profile resolution, last-match-wins path evaluation, HTTP-tool enforcement, activity/job `fsProfile` binding, macOS CLI sandbox wrapping, and `orbit-exec` supervision. See [1_overview.md](./1_overview.md) for purpose and [3_vision.md](./3_vision.md) for forward-looking gaps.
 
@@ -12,13 +12,14 @@ This document describes Orbit's shipped policy and sandboxing implementation: v2
 
 `PolicyDef` in `crates/orbit-common/src/types/policy_def.rs` is v2-only. `crates/orbit-common/src/types/resource.rs` rejects schema v1 with a migration message that names `spec.denyRead`, `spec.denyModify`, and `spec.fsProfiles`.
 
-A valid policy declares `name`, optional `description`, global `denyRead` / `denyModify`, and `fsProfiles` mapping names to `FsProfile { read, modify }`.
+A valid policy declares `name`, optional `description`, global `denyRead` / `denyModify`, and `fsProfiles` mapping names to `FsProfile { read, modify }`. The policy name must also pass the centralized resource-name validator in `crates/orbit-common/src/types/resource.rs`: it is a non-empty single file stem, not a hidden dot name, and contains no separators, traversal markers, drive-prefix characters, extension dots, or control characters ([T20260509-28]). File-backed stores validate before constructing `<name>.yaml` paths.
 
 `PolicyDef::validate` enforces:
 
-1. Every profile name is non-empty.
-2. Every positive `modify` rule is covered by a positive `read` rule in the same profile.
-3. Profile rules do not exactly duplicate global deny entries.
+1. The policy name is a safe resource file stem.
+2. Every profile name is non-empty.
+3. Every positive `modify` rule is covered by a positive `read` rule in the same profile.
+4. Profile rules do not exactly duplicate global deny entries.
 
 `PolicyDef::merged(global, workspace)` lets workspace `fsProfiles` overwrite globals by name while global denies accumulate. The merged policy is revalidated.
 
@@ -165,6 +166,10 @@ Risk-weighted regression tests sit beside the implementations they guard
   `compiled_profile_for_realistic_agent_loop_profile_allows_repo_writes_denies_dotenv`)
   exercise an `agent_loop`-shaped profile end-to-end against the kernel
   sandbox.
+- `crates/orbit-store/src/file/policy_def_store.rs#tests` — policy resource
+  name tests reject traversal-shaped names such as `../x` before path
+  construction and assert no file is written outside the policy store
+  ([T20260509-28]).
 
 Tests skip on non-macOS (and on macOS hosts where `sandbox-exec` cannot
 apply) via the existing `cfg(target_os = "macos")` + `sandbox_exec_can_apply()`
@@ -207,5 +212,6 @@ non-empty on Linux CI.
 - **[T20260428-14]** — Extend the macOS sandbox state-dir allowance to Claude (`~/.claude` / `$CLAUDE_CONFIG_DIR`) and Gemini (`~/.gemini`), and document why side-write roots remain Codex-only.
 - **[T20260430-23]** — Shorten the policy sandbox design docs while preserving the shipped contract and ADR history.
 - **[T20260509-7]** — Add `PolicyEngine::check` boundary tests and macOS sandbox `denyRead` / realistic agent-loop profile tests.
+- **[T20260509-28]** — Validate policy and executor resource names as safe file stems before file-store path construction.
 
 > Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.


### PR DESCRIPTION
## Task

[T20260509-28](https://orbit-cli.com/tasks/T20260509-28) — Validate policy and executor resource names as safe file stems

### Description

## Problem
Policy and executor stores use `metadata.name` directly in filenames: `format!("{}.yaml", def.name)`. `ResourceMetadata.name` is currently an unconstrained string, so names like `../x` can influence paths in `get` and `upsert` operations.

## Why It Matters
Applying a resource with a traversal name can read or write outside the policy/executor store directories.

## Constraints / Notes
Centralize a resource-name validator so future file-backed resource stores inherit the same boundary.

### Acceptance Criteria

- Policy and executor resource names must be non-empty single path stems with no separators, traversal, drive prefixes, or hidden path tricks.
- `orbit apply` or store tests using `metadata.name: ../x` fail without creating files outside the resource store.
- Existing valid resource names round-trip unchanged.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Added centralized orbit-common resource-name validation for non-empty single file-stem names, rejecting traversal, separators, drive-prefix characters, hidden dot names, extensions, and control characters.
- Wired policy and executor file stores to validate names before get/upsert path construction, and reject invalid metadata names during policy/executor resource parsing/loading.
- Added focused tests for seeded valid-name shapes, `metadata.name: ../x` load failures without external writes, traversal upsert/get rejection, and valid policy/executor round trips.
- Updated the policy-sandbox design doc to record the policy resource-name boundary and new store test surface.

Assessment: Scoped security boundary fix; focused tests, make fmt, make build, and make ci passed.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/T20260509-28-69fec027`
- Behind base: 0
- Ahead of base: 1

*authored by: gpt-5.5*