### PR TITLE
Do not follow symlinked directories during knowledge scans

### DIFF
--- a/crates/orbit-knowledge/src/pipeline/scan.rs
+++ b/crates/orbit-knowledge/src/pipeline/scan.rs
@@ -97,8 +97,11 @@ fn walk_dir(
         let path = entry.path();
         let file_name = entry.file_name();
         let name = file_name.to_string_lossy();
+        let file_type = entry
+            .file_type()
+            .map_err(|e| KnowledgeError::io(format!("metadata {}: {e}", path.display())))?;
 
-        if path.is_dir() {
+        if file_type.is_dir() {
             // Skip hidden directories
             if name.starts_with('.') {
                 continue;
@@ -109,7 +112,7 @@ fn walk_dir(
                 continue;
             }
             walk_dir(root, &path, orbitignore, out)?;
-        } else if path.is_file() {
+        } else if file_type.is_file() {
             if name.as_ref() == ORBITIGNORE_FILE_NAME {
                 continue;
             }
@@ -148,13 +151,16 @@ fn collect_orbitignore_files(
         let path = entry.path();
         let file_name = entry.file_name();
         let name = file_name.to_string_lossy();
+        let file_type = entry
+            .file_type()
+            .map_err(|e| KnowledgeError::io(format!("metadata {}: {e}", path.display())))?;
 
-        if path.is_dir() {
+        if file_type.is_dir() {
             if name.starts_with('.') {
                 continue;
             }
             collect_orbitignore_files(root, &path, out)?;
-        } else if path.is_file() && name.as_ref() == ORBITIGNORE_FILE_NAME {
+        } else if file_type.is_file() && name.as_ref() == ORBITIGNORE_FILE_NAME {
             let relative = path
                 .strip_prefix(root)
                 .map_err(|e| KnowledgeError::io(format!("strip prefix: {e}")))?;

--- a/crates/orbit-knowledge/tests/orbitignore.rs
+++ b/crates/orbit-knowledge/tests/orbitignore.rs
@@ -1,4 +1,6 @@
 use std::fs;
+#[cfg(unix)]
+use std::os::unix::fs::symlink;
 use std::path::Path;
 use std::process::Command;
 
@@ -130,6 +132,64 @@ fn orbitignore_nested_files_compose_with_root_file() {
     assert_eq!(
         symbol_search_total(&output_dir, repo, "excluded_marker_symbol"),
         0
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn scanner_skips_outside_repo_directory_symlink() {
+    let repo_dir = tempdir().unwrap();
+    let repo = repo_dir.path();
+    init_repo(repo);
+
+    write_file(
+        repo,
+        "src/in_repo.rs",
+        "pub fn in_repo_symlink_guard_marker() {}\n",
+    );
+
+    let outside_dir = tempdir().unwrap();
+    fs::write(
+        outside_dir.path().join("outside.rs"),
+        "pub fn outside_symlink_guard_marker() {}\n",
+    )
+    .unwrap();
+    symlink(outside_dir.path(), repo.join("linked_outside")).unwrap();
+    commit_all(repo, "seed outside directory symlink");
+
+    let knowledge_dir = tempdir().unwrap();
+    let output_dir = knowledge_dir.path().join("knowledge");
+    run_build(build_config(repo, &output_dir)).unwrap();
+
+    assert_eq!(
+        symbol_search_total(&output_dir, repo, "in_repo_symlink_guard_marker"),
+        1
+    );
+    assert_eq!(
+        symbol_search_total(&output_dir, repo, "outside_symlink_guard_marker"),
+        0
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn scanner_skips_cyclic_directory_symlinks() {
+    let repo_dir = tempdir().unwrap();
+    let repo = repo_dir.path();
+    init_repo(repo);
+
+    write_file(repo, "src/lib.rs", "pub fn cycle_safe_marker() {}\n");
+    symlink(".", repo.join("src/self")).unwrap();
+    symlink("..", repo.join("src/parent")).unwrap();
+    commit_all(repo, "seed cyclic directory symlinks");
+
+    let knowledge_dir = tempdir().unwrap();
+    let output_dir = knowledge_dir.path().join("knowledge");
+    run_build(build_config(repo, &output_dir)).unwrap();
+
+    assert_eq!(
+        symbol_search_total(&output_dir, repo, "cycle_safe_marker"),
+        1
     );
 }
 

--- a/docs/design/knowledge-graph/1_overview.md
+++ b/docs/design/knowledge-graph/1_overview.md
@@ -2,7 +2,7 @@
 
 **Status:** Draft
 **Owner:** claude
-**Last updated:** 2026-05-06
+**Last updated:** 2026-05-09
 
 The knowledge graph is Orbit's durable, queryable codebase map: a content-addressed, branch-scoped tree of directories, files, and extracted symbols. It sits between raw files and the agent prompt so agents can ask *"where is `AgentRuntime` defined?"* without re-reading the repo from scratch. Task attribution was removed in [T20260506-11]; task IDs now remain local commit-search keys rather than graph fields. This compaction pass [T20260430-22] keeps the overview focused on entry-point concepts and leaves mechanism detail to [2_design.md](./2_design.md).
 
@@ -82,7 +82,7 @@ The graph no longer stores task attribution. `[T...]` commit tags remain useful 
 |---------|----------------|-----------------|
 | Crate boundary | `crates/orbit-knowledge` | [T20260411-0008], [T20260411-0424] |
 | Storage layout | `src/graph/object_store.rs` | [T20260421-0358] |
-| Build pipeline | `src/pipeline/` | [T20260411-0424], [T20260417-0639], [T20260426-0139] |
+| Build pipeline | `src/pipeline/` | [T20260411-0424], [T20260417-0639], [T20260426-0139], [T20260509-33] |
 | Historical task attribution removal | `src/pipeline/` | [T20260506-11] |
 | Query services | `src/service/` | [T20260412-0645-2], [T20260412-0645-3] |
 | Working graph | `src/working_graph/` | [T20260411-0424] |
@@ -108,5 +108,6 @@ The graph no longer stores task attribution. `[T...]` commit tags remain useful 
 - **[T20260428-1]** — Historical graph task-ID attribution/search alignment; superseded by [T20260506-11].
 - **[T20260506-11]** — Remove knowledge-graph task attribution; preserve task IDs as local commit-search keys.
 - **[T20260430-22]** — Compact the knowledge-graph design docs and remove duplicate top-level narrative.
+- **[T20260509-33]** — Skip symlinked directory entries during knowledge scanner traversal.
 
 Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.

--- a/docs/design/knowledge-graph/2_design.md
+++ b/docs/design/knowledge-graph/2_design.md
@@ -2,7 +2,7 @@
 
 **Status:** Draft
 **Owner:** claude
-**Last updated:** 2026-05-06
+**Last updated:** 2026-05-09
 
 This document specifies the current knowledge graph: storage, build pipeline, query services, Orbit integration, locking, and limitations. The [T20260430-22] cleanup removes duplicated rationale already covered by [1_overview.md](./1_overview.md), [3_vision.md](./3_vision.md), and ADRs.
 
@@ -39,7 +39,7 @@ scan → hash → detect_changes → build_dirs → build_files → build_leaves
 
 | Stage | Output | Notes |
 |-------|--------|-------|
-| `scan_repo` | `ctx.file_paths` | Walks the repo honoring `.gitignore` plus Orbit-specific `.orbitignore` rules |
+| `scan_repo` | `ctx.file_paths` | Walks the repo honoring `.gitignore` plus Orbit-specific `.orbitignore` rules; classifies entries with `DirEntry::file_type()` and skips symlinked directories/files instead of following them ([T20260509-33]) |
 | `compute_hashes` | Per-file content hashes | Drives incremental detection; reads and hashes files in parallel, then publishes `ctx.new_hashes` after the worker phase ([T20260426-0139]) |
 | `detect_changes` | Added / modified / unchanged path set | Incremental leaf extraction uses this set to decide what can reuse the prior graph |
 | `build_graph_dirs` | `DirNode` entries with parent/child wiring | Deterministic; root dir id derived from `.` |
@@ -88,6 +88,8 @@ Those layers answer a different question than runtime policy. `.orbitignore` dec
 That split is structural on purpose. The knowledge-graph crate depends only on `orbit-common`; it does not depend on `orbit-policy`, and the scanner does not consult runtime policy while building the graph. This keeps graph refresh deterministic and keeps policy semantics out of the indexing hot path.
 
 The default `.orbitignore` baseline excludes common generated or runtime-owned trees (`.orbit/`, `node_modules/`, `target/`, `dist/`, `build/`, virtualenvs, caches, `*.egg-info/`). `orbit workspace init` seeds the list so users can edit it. A path can appear in both layers with different intent: benchmark transcripts may be excluded from indexing while policy still allows reads; `.orbit/` may be excluded from indexing while policy denies modification.
+
+Both scan paths use directory-entry file type metadata rather than `Path::is_dir()` / `Path::is_file()`, so symlinks are classified as symlinks instead of followed. The scanner recurses only into non-symlink directories and records only regular files; `.orbitignore` discovery uses the same boundary. That prevents repository symlinks from pulling in files outside the workspace or creating recursive scan cycles ([T20260509-33]).
 
 ### 2.5 Build benchmark scoreboard
 
@@ -243,6 +245,10 @@ The read cache is per `KnowledgeStore`, not global ([T20260426-0141]). Long-runn
 
 `graph_bench.json` records wall time and peak RSS from the local machine that ran `make bench` ([T20260426-0236]). The default corpus is the Orbit repo itself, so counts and timings move with checked-in source and benchmark fixtures. Compare records as local trend signals and include the machine/core context when using them in reviews.
 
+### 6.12 Symlinked source trees are excluded
+
+The scanner skips symlinked directories rather than trying to canonicalize and follow only in-workspace targets ([T20260509-33]). This is the safer default for agent indexing because it avoids outside-repo leakage and cycles, but a workspace that intentionally exposes source through symlinked directories must materialize those files or wait for an explicit, cycle-safe opt-in traversal policy.
+
 ---
 
 ## Task References
@@ -273,5 +279,6 @@ The read cache is per `KnowledgeStore`, not global ([T20260426-0141]). Long-runn
 - **[T20260505-16]** — Add C and header extraction coverage, documented by gpt-5.
 - **[T20260505-5]** — Bound `orbit.graph.pack` selector gathering and skip inline refresh by default, documented by gpt-5.5.
 - **[T20260506-11]** — Remove graph task attribution after 0/961 audited reverse-lookup uses; preserve task IDs as local commit-search keys.
+- **[T20260509-33]** — Skip symlinked directories/files during knowledge scans and `.orbitignore` discovery to prevent outside-repo indexing and recursive cycles.
 
 Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.

--- a/docs/design/knowledge-graph/4_decisions.md
+++ b/docs/design/knowledge-graph/4_decisions.md
@@ -2,7 +2,7 @@
 
 **Status:** Draft
 **Owner:** claude
-**Last updated:** 2026-05-07
+**Last updated:** 2026-05-09
 
 ADR-style log of non-obvious knowledge-graph decisions. Each entry names the pressure, the choice, and the tradeoff. Entries are append-only and keyed by number; superseded entries are marked, not deleted.
 
@@ -440,6 +440,23 @@ These entries were formerly ADR headings, but they are plain instances of ADR-00
 
 ---
 
+## ADR-030 — Skip symlinked scan entries by default
+
+**Status:** Accepted · 2026-05 · [T20260509-33]
+**Author:** gpt-5.5
+
+**Context.** The scanner used `Path::is_dir()` while walking files and discovering nested `.orbitignore` files. That follows directory symlinks, so a repository symlink could index files outside the workspace or recurse through cyclic self/parent links. A more permissive option would canonicalize symlink targets, follow only those still inside the workspace, and maintain a visited-directory set.
+
+**Decision.** Treat symlink traversal as opt-out by omission: classify entries with `DirEntry::file_type()` and recurse only into non-symlink directories. Apply the same rule to `.orbitignore` discovery. Regular files and non-symlink directories continue through the existing `.gitignore` / `.orbitignore` inclusion pipeline.
+
+**Consequences.**
+- Repository symlinks cannot pull outside-workspace files into the graph by default.
+- Cyclic symlinked directories cannot make scan recursion unbounded.
+- `.orbitignore` discovery and source-file scanning now share the same symlink boundary.
+- Cost: legitimate source exposed only through symlinked directories is not indexed until Orbit grows an explicit, canonicalized, cycle-safe follow policy.
+
+---
+
 ## Task References
 
 Tasks cited by ADRs above:
@@ -484,5 +501,6 @@ Tasks cited by ADRs above:
 - **[T20260505-16]** — Add C and header classification, tree-sitter extraction, and graph search coverage.
 - **[T20260506-11]** — Remove graph task attribution after audited reverse-lookup usage was 0/961; preserve `[T...]` as a local commit-search key.
 - **[T20260506-19]** — Normalize knowledge-graph ADR Cost lines and demote folded language instances to coverage records.
+- **[T20260509-33]** — Skip symlinked directory entries during scanner traversal and `.orbitignore` discovery.
 
 Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.


### PR DESCRIPTION
## Task

[T20260509-33](https://orbit-cli.com/tasks/T20260509-33) — Do not follow symlinked directories during knowledge scans

### Description

## Problem
The knowledge scanner uses `path.is_dir()` in `walk_dir` and `collect_orbitignore_files`, which follows directory symlinks. Recursive scanning does not check `DirEntry::file_type().is_symlink()` or track canonical visited directories.

## Why It Matters
A repository symlink can make Orbit index files outside the workspace or recurse through cyclic directory links until the build fails.

## Constraints / Notes
Decide whether symlinked directories are skipped entirely or followed only when their canonical target remains inside the workspace and is cycle-safe.

### Acceptance Criteria

- Recursive scan uses `DirEntry::file_type`/`symlink_metadata` semantics and does not follow outside-repo symlinked directories by default.
- Regression tests cover an outside-repo directory symlink and a cyclic self/parent symlink.
- Regular files and non-symlink directories continue to be indexed according to `.orbitignore` rules.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Updated knowledge scan traversal to classify entries with `DirEntry::file_type()` so symlinked directories/files are skipped instead of followed.
- Applied the same symlink-safe traversal to `.orbitignore` discovery.
- Added Unix regression tests for an outside-repo directory symlink and cyclic self/parent symlinks while preserving normal in-repo indexing assertions.
- Updated knowledge-graph design docs and added ADR-030 for the default skip-symlinks traversal decision.

Assessment: Scoped scanner fix is implemented and focused validation passes.

Strategic decisions:
- Skip symlinked directories entirely | Rationale: This avoids outside-workspace indexing and symlink cycles by default without adding canonical traversal policy.

Design weaknesses / risks:
- `make ci` is blocked by unrelated `orbit-engine` fanout ordering test failure | Severity: Medium | Mitigation: Focused orbit-knowledge tests, `make fmt`, and `make build` pass; filed friction T20260509-53 with the failing test details.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/T20260509-33-69fec1ae`
- Behind base: 0
- Ahead of base: 1

*authored by: gpt-5.5*