### PR TITLE
Resolve `sandbox-exec` from a trusted absolute path

### DIFF
--- a/crates/orbit-common/src/types/executor_def.rs
+++ b/crates/orbit-common/src/types/executor_def.rs
@@ -103,8 +103,8 @@ pub struct ExecutorDef {
     /// wraps the spawn.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub sandbox: Option<ExecutorSandboxKind>,
-    /// When `sandbox` is set but the platform's sandbox primitive is
-    /// unavailable (e.g. `sandbox-exec` not on PATH), should the runner
+    /// When `sandbox` is set but the platform's trusted sandbox primitive is
+    /// unavailable (e.g. `/usr/bin/sandbox-exec` is missing), should the runner
     /// degrade to bare exec? Default `false` (fail-closed).
     #[serde(default, skip_serializing_if = "is_false")]
     pub allow_fallback: bool,

--- a/crates/orbit-engine/src/activity_job/cli_runner/argv.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/argv.rs
@@ -1,12 +1,13 @@
 use std::collections::HashMap;
 
 use orbit_common::types::ExecutorSandboxKind;
-use orbit_exec::claude_state_dir_from_env;
+use orbit_exec::{claude_state_dir_from_env, sandbox_exec_program_for_audit};
 
 use super::super::dispatcher::ResolvedSandbox;
 
 /// Build the argv we audit-log. When wrapped, the parent process the kernel
-/// sees is `sandbox-exec`, so we prepend `sandbox-exec -f <profile_path>` to
+/// sees is the trusted `sandbox-exec`, so we prepend
+/// `<trusted sandbox-exec> -f <profile_path>` to
 /// the child program. The profile path is the literal `<profile.sb>` because
 /// the real path is a tempfile created at spawn time and only meaningful to
 /// the kernel — the placeholder keeps the audit record stable across runs.
@@ -18,7 +19,7 @@ pub(super) fn audit_argv_for_dispatch(
     match sandbox {
         Some(sb) if sb.kind == ExecutorSandboxKind::MacosSandboxExec => {
             let mut out = Vec::with_capacity(args.len() + 4);
-            out.push("sandbox-exec".to_string());
+            out.push(sandbox_exec_program_for_audit().to_string());
             out.push("-f".to_string());
             out.push("<profile.sb>".to_string());
             out.push(program.to_string());
@@ -121,7 +122,7 @@ mod tests {
         assert_eq!(
             argv,
             vec![
-                "sandbox-exec",
+                sandbox_exec_program_for_audit(),
                 "-f",
                 "<profile.sb>",
                 "/usr/bin/claude",

--- a/crates/orbit-engine/src/activity_job/cli_runner/orchestrator.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/orchestrator.rs
@@ -110,9 +110,9 @@ pub fn run_cli_backend(
     subprocess_args.extend(invocation.args.iter().cloned());
 
     // The audit argv reflects what actually runs. Under sandbox-exec the
-    // parent is `sandbox-exec -f <profile.sb> <program> <args...>`; under
-    // bare exec it's `<program> <args...>`. The redactor still scrubs the
-    // child's program name + args so secrets in argv stay redacted.
+    // parent is `<trusted sandbox-exec> -f <profile.sb> <program> <args...>`;
+    // under bare exec it's `<program> <args...>`. The redactor still scrubs
+    // the child's program name + args so secrets in argv stay redacted.
     let redaction = PatternRedactor::with_argv_secrets();
     let audit_argv =
         audit_argv_for_dispatch(&invocation.program, &subprocess_args, sandbox.as_ref());

--- a/crates/orbit-engine/src/activity_job/cli_runner/spawn.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/spawn.rs
@@ -4,7 +4,7 @@ use std::process::{Child, Command, Stdio};
 use orbit_common::types::{ExecutorSandboxKind, OrbitError};
 use orbit_exec::{
     MacosSandboxSpawnRequest, compile_macos_sandbox_profile, sandbox_exec_available,
-    spawn_under_macos_sandbox,
+    sandbox_exec_unavailable_message, spawn_under_macos_sandbox,
 };
 use tempfile::NamedTempFile;
 
@@ -69,8 +69,8 @@ fn spawn_macos_sandboxed(
 }
 
 /// Test-friendly variant of [`spawn_macos_sandboxed`]: callers pass an
-/// explicit availability flag instead of probing `PATH`. Production routes
-/// through the public wrapper which always reads the live `PATH`; tests
+/// explicit availability flag instead of probing the trusted wrapper. Production
+/// routes through the public wrapper which resolves the trusted absolute path; tests
 /// can assert the fail-closed and fallback branches without mutating
 /// process-global state.
 fn spawn_macos_sandboxed_with(
@@ -82,18 +82,18 @@ fn spawn_macos_sandboxed_with(
     sandbox_exec_present: bool,
 ) -> Result<SpawnedChild, OrbitError> {
     if !sandbox_exec_present {
+        let unavailable = sandbox_exec_unavailable_message();
         if sandbox.allow_fallback {
             tracing::warn!(
                 target: "orbit.engine.cli_runner",
                 program = program,
-                "sandbox-exec not available on PATH; falling back to bare exec because executor declares allow_fallback"
+                "{unavailable}; falling back to bare exec because executor declares allow_fallback"
             );
             return spawn_bare(program, args, env, cwd);
         }
-        return Err(OrbitError::Execution(
-            "sandbox-exec not available on PATH; declare allow_fallback: true to permit bare exec"
-                .to_string(),
-        ));
+        return Err(OrbitError::Execution(format!(
+            "{unavailable}; declare allow_fallback: true to permit bare exec"
+        )));
     }
 
     // SBPL compilation happens at spawn time so the orbit-exec dependency
@@ -150,8 +150,12 @@ mod tests {
         match err {
             OrbitError::Execution(msg) => {
                 assert!(
-                    msg.contains("sandbox-exec not available"),
+                    msg.contains("trusted sandbox-exec not available at /usr/bin/sandbox-exec"),
                     "unexpected error message: {msg}"
+                );
+                assert!(
+                    msg.contains("allow_fallback: true"),
+                    "error should describe fallback opt-in: {msg}"
                 );
             }
             other => panic!("expected Execution error, got {other:?}"),

--- a/crates/orbit-engine/src/activity_job/cli_runner/tests/orchestrator_macos_tests.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/tests/orchestrator_macos_tests.rs
@@ -4,6 +4,7 @@ use std::time::Duration;
 
 use orbit_agent::loop_engine::audit::AuditSink;
 use orbit_common::types::activity_job::V2AuditEventKind;
+use orbit_exec::sandbox_exec_program_for_audit;
 use tempfile::tempdir;
 
 use super::super::super::audit_writer::V2AuditWriter;
@@ -71,11 +72,11 @@ fn run_cli_backend_audit_argv_starts_with_sandbox_exec_for_each_provider() {
         assert_eq!(
             &argv[..3],
             &[
-                "sandbox-exec".to_string(),
+                sandbox_exec_program_for_audit().to_string(),
                 "-f".to_string(),
                 "<profile.sb>".to_string()
             ],
-            "provider {provider_name} should log sandbox-exec prefix; argv={argv:?}"
+            "provider {provider_name} should log trusted sandbox-exec prefix; argv={argv:?}"
         );
         assert_eq!(
             argv[3],
@@ -210,7 +211,7 @@ fn run_cli_backend_drops_gemini_sandbox_flag_under_outer_wrapper() {
             _ => None,
         })
         .expect("cli.invocation.started event");
-    // Skip `sandbox-exec -f <profile.sb> <program>` prefix so the
+    // Skip `<trusted sandbox-exec> -f <profile.sb> <program>` prefix so the
     // assertion targets the gemini-side argv.
     let suffix = &argv[4..];
     assert!(

--- a/crates/orbit-engine/src/activity_job/cli_runner/tests/test_support.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/tests/test_support.rs
@@ -13,6 +13,8 @@ use orbit_agent::loop_engine::audit::{AuditSink, LoopAuditEvent};
 use orbit_common::types::ExecutorSandboxKind;
 use orbit_common::types::activity_job::{AgentLoopSpec, Backend, OnDenial, Provider};
 use orbit_common::utility::logging::RedactingFields;
+#[cfg(target_os = "macos")]
+use orbit_exec::sandbox_exec_path;
 use orbit_tools::{FsAuditLogger, ToolContext};
 use serde_json::Value;
 use tracing::field::{Field, Visit};
@@ -356,7 +358,10 @@ fn make_executable(_path: &Path) {}
 
 #[cfg(target_os = "macos")]
 pub(in crate::activity_job::cli_runner) fn sandbox_exec_can_apply_for_test() -> bool {
-    Command::new("sandbox-exec")
+    let Some(path) = sandbox_exec_path() else {
+        return false;
+    };
+    Command::new(path)
         .args(["-p", "(version 1)\n(allow default)\n", "/usr/bin/true"])
         .stdin(Stdio::null())
         .stdout(Stdio::null())

--- a/crates/orbit-exec/src/lib.rs
+++ b/crates/orbit-exec/src/lib.rs
@@ -29,7 +29,8 @@ mod supervision;
 
 pub use macos_sandbox::{
     MacosSandboxSpawnRequest, claude_state_dir_from_env, compile_macos_sandbox_profile,
-    sandbox_exec_available, spawn_under_macos_sandbox,
+    sandbox_exec_available, sandbox_exec_path, sandbox_exec_program_for_audit,
+    sandbox_exec_unavailable_message, spawn_under_macos_sandbox,
 };
 pub use result::ExecutionResult;
 pub use runner::{EnvironmentMode, ExecRequest, StdinMode, run_process};

--- a/crates/orbit-exec/src/macos_sandbox.rs
+++ b/crates/orbit-exec/src/macos_sandbox.rs
@@ -27,6 +27,8 @@ use std::process::{Child, Command, Stdio};
 use orbit_common::types::{OrbitError, ResolvedFsProfile};
 use tempfile::NamedTempFile;
 
+const TRUSTED_SANDBOX_EXEC_PATHS: &[&str] = &["/usr/bin/sandbox-exec"];
+
 /// Compile a [`ResolvedFsProfile`] into SBPL text suitable for
 /// `sandbox-exec -f`.
 ///
@@ -320,7 +322,8 @@ pub fn spawn_under_macos_sandbox(
 
     let profile_path = profile_file.path().to_path_buf();
 
-    let mut command = Command::new("sandbox-exec");
+    let sandbox_exec_path = sandbox_exec_path_or_error()?;
+    let mut command = Command::new(&sandbox_exec_path);
     command
         .arg("-f")
         .arg(&profile_path)
@@ -342,28 +345,52 @@ pub fn spawn_under_macos_sandbox(
 
     let child = command.spawn().map_err(|err| {
         OrbitError::Execution(format!(
-            "failed to spawn sandbox-exec wrapper around `{program}`: {err}"
+            "failed to spawn trusted sandbox-exec `{}` around `{program}`: {err}",
+            sandbox_exec_path.display()
         ))
     })?;
     Ok((child, profile_file))
 }
 
-/// Returns `true` if `sandbox-exec` is on `PATH`.
-pub fn sandbox_exec_available() -> bool {
-    sandbox_exec_available_in(&std::env::var_os("PATH").unwrap_or_default())
+/// Returns the stable program path used in audit logs for sandboxed CLI
+/// invocations. The real spawn path is resolved again at execution time so
+/// missing binaries still fail closed.
+pub fn sandbox_exec_program_for_audit() -> &'static str {
+    TRUSTED_SANDBOX_EXEC_PATHS[0]
 }
 
-pub(crate) fn sandbox_exec_available_in(path_var: &std::ffi::OsStr) -> bool {
-    for dir in std::env::split_paths(path_var) {
-        if dir.as_os_str().is_empty() {
-            continue;
-        }
-        let candidate = dir.join("sandbox-exec");
-        if is_executable(&candidate) {
-            return true;
-        }
-    }
-    false
+/// Returns `true` if a trusted absolute `sandbox-exec` binary is available.
+pub fn sandbox_exec_available() -> bool {
+    sandbox_exec_path().is_some()
+}
+
+/// Human-facing reason used when fail-closed sandboxing cannot find the
+/// trusted wrapper.
+pub fn sandbox_exec_unavailable_message() -> String {
+    format!(
+        "trusted sandbox-exec not available at {}",
+        TRUSTED_SANDBOX_EXEC_PATHS.join(", ")
+    )
+}
+
+/// Resolve `sandbox-exec` from trusted absolute locations only.
+pub fn sandbox_exec_path() -> Option<PathBuf> {
+    sandbox_exec_path_from(TRUSTED_SANDBOX_EXEC_PATHS.iter().map(Path::new))
+}
+
+fn sandbox_exec_path_or_error() -> Result<PathBuf, OrbitError> {
+    sandbox_exec_path().ok_or_else(|| OrbitError::Execution(sandbox_exec_unavailable_message()))
+}
+
+fn sandbox_exec_path_from<I, P>(candidates: I) -> Option<PathBuf>
+where
+    I: IntoIterator<Item = P>,
+    P: AsRef<Path>,
+{
+    candidates
+        .into_iter()
+        .map(|candidate| candidate.as_ref().to_path_buf())
+        .find(|candidate| candidate.is_absolute() && is_executable(candidate))
 }
 
 #[cfg(unix)]
@@ -834,7 +861,7 @@ mod tests {
     }
 
     #[test]
-    fn sandbox_exec_available_in_finds_executable_on_path() {
+    fn sandbox_exec_path_from_uses_trusted_absolute_candidate() {
         let dir = tempfile::tempdir().expect("tempdir");
         let bin = dir.path().join("sandbox-exec");
         std::fs::write(&bin, "#!/bin/sh\nexit 0\n").expect("write");
@@ -843,15 +870,67 @@ mod tests {
             use std::os::unix::fs::PermissionsExt;
             std::fs::set_permissions(&bin, std::fs::Permissions::from_mode(0o755)).expect("perms");
         }
-        let path_var = std::ffi::OsString::from(dir.path().display().to_string());
-        assert!(sandbox_exec_available_in(&path_var));
+        assert_eq!(sandbox_exec_path_from([bin.as_path()]), Some(bin));
     }
 
     #[test]
-    fn sandbox_exec_available_in_returns_false_when_missing() {
-        let dir = tempfile::tempdir().expect("tempdir");
-        let path_var = std::ffi::OsString::from(dir.path().display().to_string());
-        assert!(!sandbox_exec_available_in(&path_var));
+    fn sandbox_exec_path_from_rejects_relative_candidates() {
+        let bin = Path::new("sandbox-exec");
+        assert_eq!(sandbox_exec_path_from([bin]), None);
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn spawn_under_macos_sandbox_ignores_fake_sandbox_exec_on_path() {
+        if !sandbox_exec_can_apply() {
+            return;
+        }
+
+        let temp = tempfile::tempdir().expect("tempdir");
+        let fake_dir = temp.path().join("fake-bin");
+        std::fs::create_dir_all(&fake_dir).expect("fake dir");
+        let marker = temp.path().join("fake-used");
+        let fake = fake_dir.join("sandbox-exec");
+        std::fs::write(
+            &fake,
+            format!(
+                "#!/bin/sh\necho fake > {}\nexit 77\n",
+                shell_escape(&marker)
+            ),
+        )
+        .expect("write fake sandbox-exec");
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(&fake, std::fs::Permissions::from_mode(0o755))
+                .expect("fake perms");
+        }
+
+        let poisoned_path = format!("{}:/usr/bin:/bin", fake_dir.display());
+        let args = ["-c".to_string(), "exit 0".to_string()];
+        let env = [("PATH".to_string(), poisoned_path)];
+        let (child, _profile_file) = spawn_under_macos_sandbox(MacosSandboxSpawnRequest {
+            profile_text: "(version 1)\n(allow default)\n",
+            program: "/bin/sh",
+            args: &args,
+            env: &env,
+            cwd: None,
+            stdin: Stdio::null(),
+            stdout: Stdio::piped(),
+            stderr: Stdio::piped(),
+        })
+        .expect("spawn sandboxed child");
+        let output = child.wait_with_output().expect("wait for child");
+
+        assert!(
+            output.status.success(),
+            "trusted sandbox-exec should run child despite fake PATH entry; stderr={}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        assert!(
+            !marker.exists(),
+            "fake sandbox-exec on PATH should not have been executed"
+        );
     }
 
     #[cfg(target_os = "macos")]
@@ -935,7 +1014,7 @@ mod tests {
         profile_file.flush().expect("flush");
 
         let allowed_target = allowed.join("ok");
-        let allow_status = Command::new("sandbox-exec")
+        let allow_status = Command::new(sandbox_exec_path_for_test())
             .arg("-f")
             .arg(profile_file.path())
             .arg("/bin/sh")
@@ -953,7 +1032,7 @@ mod tests {
         );
 
         let blocked_target = blocked.join("nope");
-        let deny_status = Command::new("sandbox-exec")
+        let deny_status = Command::new(sandbox_exec_path_for_test())
             .arg("-f")
             .arg(profile_file.path())
             .arg("/bin/sh")
@@ -1018,7 +1097,7 @@ mod tests {
         profile_file.flush().expect("flush");
 
         // Allowed read of public_path succeeds.
-        let allow_status = Command::new("sandbox-exec")
+        let allow_status = Command::new(sandbox_exec_path_for_test())
             .arg("-f")
             .arg(profile_file.path())
             .arg("/bin/sh")
@@ -1032,7 +1111,7 @@ mod tests {
         );
 
         // Denied read of secret_path fails.
-        let deny_status = Command::new("sandbox-exec")
+        let deny_status = Command::new(sandbox_exec_path_for_test())
             .arg("-f")
             .arg(profile_file.path())
             .arg("/bin/sh")
@@ -1092,7 +1171,7 @@ mod tests {
         let source_target = src_dir.join("foo.rs");
         let env_target = repo.path().join(".env");
 
-        let source_status = Command::new("sandbox-exec")
+        let source_status = Command::new(sandbox_exec_path_for_test())
             .arg("-f")
             .arg(profile_file.path())
             .arg("/bin/sh")
@@ -1109,7 +1188,7 @@ mod tests {
         );
         assert!(source_target.exists(), "source file not written");
 
-        let env_status = Command::new("sandbox-exec")
+        let env_status = Command::new(sandbox_exec_path_for_test())
             .arg("-f")
             .arg(profile_file.path())
             .arg("/bin/sh")
@@ -1161,7 +1240,7 @@ mod tests {
         profile_file.flush().expect("flush");
 
         let allowed_target = dir.path().join("ok.txt");
-        let allow_status = Command::new("sandbox-exec")
+        let allow_status = Command::new(sandbox_exec_path_for_test())
             .arg("-f")
             .arg(profile_file.path())
             .arg("/bin/sh")
@@ -1175,7 +1254,7 @@ mod tests {
         );
 
         let env_target = dir.path().join("blocked.env");
-        let deny_status = Command::new("sandbox-exec")
+        let deny_status = Command::new(sandbox_exec_path_for_test())
             .arg("-f")
             .arg(profile_file.path())
             .arg("/bin/sh")
@@ -1247,7 +1326,7 @@ mod tests {
             ("claude", claude_dir.join("ok")),
             ("gemini", gemini_dir.join("ok")),
         ] {
-            let status = Command::new("sandbox-exec")
+            let status = Command::new(sandbox_exec_path_for_test())
                 .arg("-f")
                 .arg(profile_file.path())
                 .arg("/bin/sh")
@@ -1325,7 +1404,7 @@ mod tests {
                     .join(".claude.json.tmp.7969.1778210964004"),
             ),
         ] {
-            let status = Command::new("sandbox-exec")
+            let status = Command::new(sandbox_exec_path_for_test())
                 .arg("-f")
                 .arg(profile_file.path())
                 .arg("/bin/sh")
@@ -1351,6 +1430,11 @@ mod tests {
     }
 
     #[cfg(target_os = "macos")]
+    fn sandbox_exec_path_for_test() -> PathBuf {
+        sandbox_exec_path().expect("trusted sandbox-exec path")
+    }
+
+    #[cfg(target_os = "macos")]
     fn sandbox_exec_can_apply() -> bool {
         if !sandbox_exec_available() {
             return false;
@@ -1367,7 +1451,7 @@ mod tests {
             .expect("write probe profile");
         profile_file.flush().expect("flush probe profile");
 
-        std::process::Command::new("sandbox-exec")
+        std::process::Command::new(sandbox_exec_path_for_test())
             .arg("-f")
             .arg(profile_file.path())
             .arg("/usr/bin/true")

--- a/docs/design/activity-job/2_design.md
+++ b/docs/design/activity-job/2_design.md
@@ -2,7 +2,7 @@
 
 **Status:** Draft
 **Owner:** codex
-**Last updated:** 2026-05-09 (T20260427-34, T20260427-36, T20260427-38, T20260427-40, T20260508-3, T20260508-8, T20260509-2, T20260509-7, T20260509-9, T20260509-11)
+**Last updated:** 2026-05-09 (T20260427-34, T20260427-36, T20260427-38, T20260427-40, T20260508-3, T20260508-8, T20260509-2, T20260509-7, T20260509-9, T20260509-11, T20260509-30)
 
 This document describes the shipped Activity / Job substrate across `orbit-common`, `orbit-engine`, `orbit-core`, and `orbit-cli`: asset shape, normalization, dispatch boundaries, backend semantics, DAG execution, audit, and retained legacy edges. See [1_overview.md](./1_overview.md) for purpose and [3_vision.md](./3_vision.md) for open questions.
 
@@ -216,7 +216,7 @@ Executor args are prepended before provider runtime args. For seeded Codex, the 
 
 After [T20260427-48], provider runtime args receive provider config through `V2RuntimeHost`. Static executor definitions keep command-shape flags (`exec --json`); dynamic Codex settings such as sandbox mode, side-write roots, and approval policy stay in the retained provider runtime. Codex approval policy is an exec-compatible config override, not the interactive-only `--ask-for-approval` flag.
 
-After [T20260427-51], macOS CLI invocations declaring `sandbox: macos-sandbox-exec` run under `sandbox-exec -f <profile.sb> <provider> ...`. Orbit treats that SBPL profile as filesystem authority and neutralizes provider-native sandbox flags. After [T20260428-10], the profile grants Codex state (`$CODEX_HOME` or `$HOME/.codex`) plus side-write roots from provider config so inherited Orbit subprocesses can persist workflow state while project writes remain governed by `fsProfile`. After [T20260505-22], dispatch also runs `apply_provider_static_arg_fixups` before spawn, separately from sandbox neutralization. Today this only rewrites Claude's `--debug-file` value to `<claude_state_dir>/<basename>` so the log lands inside the already-writable state dir instead of `.orbit/**`, which the default policy denies.
+After [T20260427-51], macOS CLI invocations declaring `sandbox: macos-sandbox-exec` run under `/usr/bin/sandbox-exec -f <profile.sb> <provider> ...`; [T20260509-30] made that wrapper resolution trusted and absolute instead of `PATH`-based. Orbit treats that SBPL profile as filesystem authority and neutralizes provider-native sandbox flags. After [T20260428-10], the profile grants Codex state (`$CODEX_HOME` or `$HOME/.codex`) plus side-write roots from provider config so inherited Orbit subprocesses can persist workflow state while project writes remain governed by `fsProfile`. After [T20260505-22], dispatch also runs `apply_provider_static_arg_fixups` before spawn, separately from sandbox neutralization. Today this only rewrites Claude's `--debug-file` value to `<claude_state_dir>/<basename>` so the log lands inside the already-writable state dir instead of `.orbit/**`, which the default policy denies.
 
 After [T20260430-15], the CLI stdin envelope carries rendered activity input and durable `run_id` beside instruction, prompt, tools, and model. When input identifies one task, orbit-core embeds a canonical task snapshot with `input.workspace_path` / `input.repo_root` taking precedence over stored paths. After [T20260508-8], `backend: cli` also uses a shared workspace resolver for subprocess cwd: `input.workspace_path`, then `task.workspace_path`, then best-effort `ToolContext.workspace_root`. Declared input/task paths must already be directories; stale worktrees fail as `CliInvocationFailed` before `CliInvocationStarted` is emitted. `groundhog` delegates to the same resolver so task execution and attempt orchestration do not drift. After [T20260505-10], Orbit-managed CLI subprocesses receive `ORBIT_RUN_ID` plus an Orbit-managed run-context marker; `orbit tool run` requires both before it populates `ToolContext` reservation ownership. Direct manual CLI tool calls, including calls with only `ORBIT_RUN_ID`, remain unowned.
 
@@ -529,5 +529,6 @@ Read-only history does not need the same dependencies as live execution. [T20260
 - **[T20260509-2]** — Split the v2 job executor into responsibility-focused modules without changing runtime behavior.
 - **[T20260509-7]** — Establish focused test coverage for the activity/job DAG executor (linear, retry, parallel, fan-out, loop, pipeline durability) and the macOS sandbox / policy boundary.
 - **[T20260509-11]** — Keep condition guards on equality-only grammar and repair the `ship-auto` empty-backlog guard.
+- **[T20260509-30]** — Resolve the macOS `sandbox-exec` wrapper from a trusted absolute path before CLI spawn.
 
 > Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.

--- a/docs/design/policy-sandbox/2_design.md
+++ b/docs/design/policy-sandbox/2_design.md
@@ -2,7 +2,7 @@
 
 **Status:** Draft
 **Owner:** claude
-**Last updated:** 2026-05-09 (T20260509-7, T20260509-28)
+**Last updated:** 2026-05-09 (T20260509-7, T20260509-28, T20260509-30)
 
 This document describes Orbit's shipped policy and sandboxing implementation: v2 `PolicyDef`, profile resolution, last-match-wins path evaluation, HTTP-tool enforcement, activity/job `fsProfile` binding, macOS CLI sandbox wrapping, and `orbit-exec` supervision. See [1_overview.md](./1_overview.md) for purpose and [3_vision.md](./3_vision.md) for forward-looking gaps.
 
@@ -115,6 +115,8 @@ Legacy pipeline contexts are different. `crates/orbit-core/src/runtime/pipeline.
 
 The `Sandbox` trait remains the seam for generic `run_process` callers, but CLI-backed `agent_loop` invocations use a separate executor wrapper when the executor declares `sandbox: macos-sandbox-exec` ([T20260427-51]). The v2 host resolves the activity `fsProfile`; the engine converts workspace-relative rules to absolute roots and compiles SBPL before spawning the provider CLI.
 
+The macOS wrapper resolves `sandbox-exec` from trusted absolute locations only, currently `/usr/bin/sandbox-exec`; it does not consult `PATH` for either availability checks or process spawn. If the trusted binary is missing, the runner fails closed unless the executor declares `allow_fallback: true`, and the error names the trusted location that was probed ([T20260509-30]).
+
 The compiled macOS profile denies by default, allows broad reads required by agent CLIs and system libraries, allows process/signal/ipc/network/sysctl/iokit operations, and allows writes to:
 
 - scratch/cache roots (`/tmp`, `/private/tmp`, `/private/var/folders`, `/dev`, `$HOME/Library/Caches`)
@@ -161,7 +163,10 @@ Risk-weighted regression tests sit beside the implementations they guard
   such as `../secret.txt`, `src/../secret.txt`, and their backslash-normalized
   equivalents are rejected as `OrbitError::InvalidInput` for both read and
   modify checks ([T20260509-27]).
-- `crates/orbit-exec/src/macos_sandbox.rs#tests` — SBPL compilation tests
+- `crates/orbit-exec/src/macos_sandbox.rs#tests` — trusted wrapper
+  resolution ignores `PATH`, including a macOS runtime test that places a fake
+  `sandbox-exec` earlier on `PATH` and verifies the fake wrapper is not
+  executed ([T20260509-30]). SBPL compilation tests
   cover `denyRead` / `denyModify` clause emission (`subpath` for simple
   rules, `regex` for non-trivial globs) and the deny-after-allow ordering
   required for last-match-wins. macOS-gated runtime tests
@@ -216,5 +221,6 @@ non-empty on Linux CI.
 - **[T20260430-23]** — Shorten the policy sandbox design docs while preserving the shipped contract and ADR history.
 - **[T20260509-7]** — Add `PolicyEngine::check` boundary tests and macOS sandbox `denyRead` / realistic agent-loop profile tests.
 - **[T20260509-28]** — Validate policy and executor resource names as safe file stems before file-store path construction.
+- **[T20260509-30]** — Resolve `sandbox-exec` from trusted absolute locations and keep availability errors fail-closed and explicit.
 
 > Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.

--- a/docs/design/policy-sandbox/4_decisions.md
+++ b/docs/design/policy-sandbox/4_decisions.md
@@ -2,7 +2,7 @@
 
 **Status:** Draft
 **Owner:** claude
-**Last updated:** 2026-05-08
+**Last updated:** 2026-05-09
 
 This is the append-only ADR log for Policy & Sandboxing. Entries are ordered by ADR number. New entries follow the template in [../CONVENTIONS.md](../CONVENTIONS.md) and cite the task that made the decision real.
 
@@ -189,6 +189,19 @@ Use `literal` for the canonical and lock files (predictable names) and `regex` f
 - Cost: three additional clauses on every macOS sandbox profile when `HOME` resolves and `CLAUDE_CONFIG_DIR` is unset. Symmetric to the ADR-013 trade-off; provider plumbing is avoided.
 - This ADR amends ADR-013 rather than replacing it: the per-provider state-dir clauses still emit unconditionally; the new clauses are scoped to the HOME-fallback branch only.
 
+## ADR-015 — macOS sandbox wrapper resolves from trusted absolute locations
+
+**Status:** Accepted · 2026-05 · [T20260509-30]
+
+**Context.** The macOS CLI wrapper previously spawned `sandbox-exec` by bare name and checked availability by walking `PATH`. A writable or config-influenced `PATH` could point Orbit at an attacker-controlled wrapper while Orbit still believed kernel sandbox enforcement was active.
+
+**Decision.** Resolve the wrapper only from trusted absolute locations, currently `/usr/bin/sandbox-exec`, and use the same trusted resolver for availability checks, audit argv, and process spawn. Missing trusted binaries fail closed unless the executor explicitly allows fallback, and the error names the trusted location that was probed.
+
+**Consequences.**
+- Fake `sandbox-exec` binaries earlier on `PATH` are ignored, so the sandbox boundary no longer depends on inherited environment ordering.
+- Availability messages describe the trusted absolute location instead of implying arbitrary `PATH` lookup.
+- Cost: the implementation is intentionally macOS-location-specific; if Apple moves or removes the binary, Orbit must update the trusted location list or add a new backend rather than silently accepting a user-supplied replacement.
+
 ---
 
 ## Task References
@@ -204,5 +217,6 @@ Use `literal` for the canonical and lock files (predictable names) and `regex` f
 - **[T20260428-14]** — Extend the macOS sandbox state-dir allowance to Claude and Gemini, and document why side-write roots remain Codex-only.
 - **[T20260430-23]** — Shorten the policy sandbox design docs while preserving the shipped contract and ADR history.
 - **[T20260508-13]** — Add `$HOME/.claude.json{,.lock,.tmp.<pid>.<ms_ts>}` sibling allows to the macOS sandbox profile so Claude can persist its main settings file.
+- **[T20260509-30]** — Resolve `sandbox-exec` from trusted absolute locations rather than inherited `PATH`.
 
 > Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.


### PR DESCRIPTION
## Task

[T20260509-30](https://orbit-cli.com/tasks/T20260509-30) — Resolve `sandbox-exec` from a trusted absolute path

### Description

## Problem
The macOS sandbox wrapper is spawned with `Command::new("sandbox-exec")`, and availability checks accept any executable named `sandbox-exec` earlier on `PATH`.

## Why It Matters
A writable or config-influenced `PATH` can replace the enforcement binary and run the child with attacker-controlled behavior.

## Constraints / Notes
Prefer `/usr/bin/sandbox-exec` on macOS. If portability requires probing, probe only trusted absolute locations and report which binary is used.

### Acceptance Criteria

- Sandboxed spawn uses a trusted absolute sandbox executable path instead of PATH lookup.
- A test with a fake `sandbox-exec` earlier on PATH proves the fake binary is not used.
- Availability errors remain clear when the trusted binary is missing and fallback is not allowed.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Resolved macOS sandbox execution through trusted absolute locations only, currently /usr/bin/sandbox-exec, and made sandboxed spawn use that path instead of PATH lookup.
- Updated CLI runner availability/fallback messages and audit argv to name the trusted sandbox-exec path.
- Added regression coverage for trusted path resolution, fake sandbox-exec earlier on PATH, and clear fail-closed fallback-disabled errors.
- Updated Activity / Job and Policy & Sandboxing design docs, including ADR-015 for trusted wrapper resolution.

Assessment: The change is scoped to the macOS sandbox wrapper and CLI runner integration. Focused tests, build, formatting, and full CI pass.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/T20260509-30-69fec14f`
- Behind base: 0
- Ahead of base: 1

*authored by: gpt-5.5*