### PR TITLE
Use commit or tree identity for graph freshness

### DIFF
--- a/crates/orbit-knowledge/src/graph/object_store.rs
+++ b/crates/orbit-knowledge/src/graph/object_store.rs
@@ -53,6 +53,10 @@ pub struct CurrentRef {
     pub root_object_hash: String,
     #[serde(default)]
     pub root_dir_id: String,
+    #[serde(default)]
+    pub git_head_oid: Option<String>,
+    #[serde(default)]
+    pub git_tree_oid: Option<String>,
     pub index: String,
 }
 
@@ -711,6 +715,8 @@ impl GraphObjectStore {
             root_graph_hash: root_graph_hash.clone(),
             root_object_hash,
             root_dir_id: graph.root_dir_id.clone(),
+            git_head_oid: None,
+            git_tree_oid: None,
             index: format!("graph/index/by-id/{root_graph_hash}.json"),
         })
     }

--- a/crates/orbit-knowledge/src/pipeline/context.rs
+++ b/crates/orbit-knowledge/src/pipeline/context.rs
@@ -3,6 +3,7 @@ use std::path::{Path, PathBuf};
 
 use crate::graph::nodes::CodebaseGraphV1;
 use crate::graph::object_store::RefName;
+use crate::pipeline::GitCheckoutIdentity;
 
 /// Configuration for a build run.
 pub struct BuildConfig {
@@ -19,6 +20,7 @@ pub struct PipelineContext {
     pub incremental: bool,
     pub ref_name: RefName,
     pub default_ref_name: Option<RefName>,
+    pub(crate) checkout_identity: Option<GitCheckoutIdentity>,
     /// Relative file paths discovered by scan.
     pub file_paths: Vec<PathBuf>,
     /// SHA-256 hashes keyed by relative path string.
@@ -37,6 +39,7 @@ impl PipelineContext {
             incremental: config.incremental,
             ref_name,
             default_ref_name,
+            checkout_identity: None,
             file_paths: Vec::new(),
             new_hashes: HashMap::new(),
             changed_paths: Vec::new(),

--- a/crates/orbit-knowledge/src/pipeline/mod.rs
+++ b/crates/orbit-knowledge/src/pipeline/mod.rs
@@ -15,7 +15,7 @@ use std::{fs, fs::OpenOptions, io::ErrorKind};
 
 use crate::error::KnowledgeError;
 use crate::graph::object_store::{
-    GraphObjectStore, resolve_graph_read_target, resolve_graph_write_target,
+    CurrentRef, GraphObjectStore, resolve_graph_read_target, resolve_graph_write_target,
 };
 use crate::io::write_text_atomic_durable;
 use context::{BuildConfig, PipelineContext};
@@ -50,6 +50,12 @@ struct DirtyFingerprint {
     status_hash: String,
     path_count: usize,
     newest_mtime_ns: Option<u128>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct GitCheckoutIdentity {
+    pub head_oid: String,
+    pub tree_oid: String,
 }
 
 enum RefreshPlan {
@@ -92,6 +98,7 @@ fn run_build_inner(config: BuildConfig) -> Result<PipelineContext, KnowledgeErro
         KnowledgeError::knowledge_unavailable(format!("resolve graph ref: {error}"))
     })?;
     let mut ctx = PipelineContext::new(config, build_target.requested, build_target.default);
+    ctx.checkout_identity = git_checkout_identity(&ctx.repo_path);
 
     scan::scan_repo(&mut ctx)?;
     hash::compute_hashes(&mut ctx)?;
@@ -158,18 +165,23 @@ pub fn ensure_fresh(
     Ok(RefreshStatus::Rebuilt)
 }
 
-/// Get the committer timestamp of HEAD as a fixed-offset DateTime.
-fn git_head_timestamp(repo_path: &Path) -> Option<chrono::DateTime<chrono::FixedOffset>> {
+fn git_checkout_identity(repo_path: &Path) -> Option<GitCheckoutIdentity> {
     let output = Command::new("git")
-        .args(["log", "-1", "--format=%cI"])
+        .args(["rev-parse", "HEAD^{commit}", "HEAD^{tree}"])
         .current_dir(repo_path)
         .output()
         .ok()?;
     if !output.status.success() {
         return None;
     }
-    let ts_str = String::from_utf8_lossy(&output.stdout);
-    chrono::DateTime::parse_from_rfc3339(ts_str.trim()).ok()
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let mut lines = stdout
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty());
+    let head_oid = lines.next()?.to_string();
+    let tree_oid = lines.next()?.to_string();
+    Some(GitCheckoutIdentity { head_oid, tree_oid })
 }
 
 fn git_dirty_fingerprint(repo_path: &Path) -> Option<DirtyFingerprint> {
@@ -232,9 +244,10 @@ fn compute_refresh_plan(
     repo_path: &Path,
 ) -> Result<RefreshPlan, KnowledgeError> {
     let manifest_path = knowledge_dir.join("manifest.json");
-    let graph_available = current_branch_graph_available(knowledge_dir, repo_path);
+    let current_ref = current_branch_ref(knowledge_dir, repo_path);
+    let graph_available = current_ref.is_some();
     let dirty_fingerprint = git_dirty_fingerprint(repo_path);
-    let head_ts = git_head_timestamp(repo_path);
+    let checkout_identity = git_checkout_identity(repo_path);
 
     if let Some(dirty_fingerprint) = dirty_fingerprint {
         if manifest_path.is_file()
@@ -252,28 +265,26 @@ fn compute_refresh_plan(
     if manifest_path.is_file() {
         let raw = fs::read_to_string(&manifest_path)
             .map_err(|e| KnowledgeError::knowledge_unavailable(format!("read manifest: {e}")))?;
-        let manifest: serde_json::Value = serde_json::from_str(&raw)
+        let _: serde_json::Value = serde_json::from_str(&raw)
             .map_err(|e| KnowledgeError::knowledge_unavailable(format!("parse manifest: {e}")))?;
-        let generated_at = manifest
-            .get("generated_at")
-            .and_then(|v| v.as_str())
-            .and_then(|s| chrono::DateTime::parse_from_rfc3339(s).ok());
         if !graph_available {
             return Ok(RefreshPlan::Rebuild {
                 dirty_fingerprint: None,
                 incremental: true,
             });
         }
-        return Ok(match (generated_at, head_ts) {
-            (Some(generated), Some(head_ts)) if head_ts > generated => RefreshPlan::Rebuild {
+        let Some(checkout_identity) = checkout_identity else {
+            return Ok(RefreshPlan::Rebuild {
                 dirty_fingerprint: None,
                 incremental: true,
-            },
-            (None, _) => RefreshPlan::Rebuild {
-                dirty_fingerprint: None,
-                incremental: true,
-            },
-            _ => RefreshPlan::Fresh,
+            });
+        };
+        if stored_checkout_identity_matches(current_ref.as_ref(), &checkout_identity) {
+            return Ok(RefreshPlan::Fresh);
+        }
+        return Ok(RefreshPlan::Rebuild {
+            dirty_fingerprint: None,
+            incremental: true,
         });
     }
 
@@ -281,6 +292,22 @@ fn compute_refresh_plan(
         dirty_fingerprint: None,
         incremental: false,
     })
+}
+
+fn stored_checkout_identity_matches(
+    current_ref: Option<&CurrentRef>,
+    checkout_identity: &GitCheckoutIdentity,
+) -> bool {
+    if let Some(current_ref) = current_ref {
+        if let Some(stored_head_oid) = current_ref.git_head_oid.as_deref() {
+            return stored_head_oid == checkout_identity.head_oid;
+        }
+        if let Some(stored_tree_oid) = current_ref.git_tree_oid.as_deref() {
+            return stored_tree_oid == checkout_identity.tree_oid;
+        }
+    }
+
+    false
 }
 
 fn refresh_state_within_cooldown(
@@ -366,12 +393,16 @@ fn acquire_refresh_lock(
 }
 
 fn current_branch_graph_available(knowledge_dir: &Path, repo_path: &Path) -> bool {
+    current_branch_ref(knowledge_dir, repo_path).is_some()
+}
+
+fn current_branch_ref(knowledge_dir: &Path, repo_path: &Path) -> Option<CurrentRef> {
     if !knowledge_dir.join("manifest.json").is_file() {
-        return false;
+        return None;
     }
 
     let Ok(read_target) = resolve_graph_read_target(Some(repo_path), None) else {
-        return false;
+        return None;
     };
 
     let store = GraphObjectStore::new(knowledge_dir.join("graph"));
@@ -379,10 +410,14 @@ fn current_branch_graph_available(knowledge_dir: &Path, repo_path: &Path) -> boo
         .prepare_refs_layout(read_target.default.as_ref())
         .is_err()
     {
-        return false;
+        return None;
     }
 
-    store.ref_path(&read_target.requested).is_file()
+    if !store.ref_path(&read_target.requested).is_file() {
+        return None;
+    }
+
+    store.read_ref(&read_target.requested).ok()
 }
 
 fn wait_for_current_graph(knowledge_dir: &Path, repo_path: &Path) {

--- a/crates/orbit-knowledge/src/pipeline/persist.rs
+++ b/crates/orbit-knowledge/src/pipeline/persist.rs
@@ -13,7 +13,11 @@ pub fn persist_graph(ctx: &PipelineContext) -> Result<String, KnowledgeError> {
     let store = GraphObjectStore::new(ctx.graph_dir());
     store.prepare_refs_layout(ctx.default_ref_name.as_ref())?;
 
-    let current_ref = store.write_graph(&ctx.graph)?;
+    let mut current_ref = store.write_graph(&ctx.graph)?;
+    if let Some(identity) = ctx.checkout_identity.as_ref() {
+        current_ref.git_head_oid = Some(identity.head_oid.clone());
+        current_ref.git_tree_oid = Some(identity.tree_oid.clone());
+    }
     store.write_ref_atomic(&ctx.ref_name, &current_ref)?;
 
     Ok(current_ref.root_graph_hash)
@@ -24,12 +28,18 @@ pub fn write_manifest(ctx: &PipelineContext) -> Result<(), KnowledgeError> {
     fs::create_dir_all(&ctx.output_dir)
         .map_err(|e| KnowledgeError::io(format!("mkdir {}: {e}", ctx.output_dir.display())))?;
 
-    let manifest = json!({
+    let mut manifest = json!({
         "generated_at": Utc::now().to_rfc3339(),
         "graph": "graph/",
         "file_count": ctx.graph.files.len(),
         "leaf_count": ctx.graph.leaves.len(),
     });
+    if let Some(identity) = ctx.checkout_identity.as_ref()
+        && let Some(manifest) = manifest.as_object_mut()
+    {
+        manifest.insert("git_head_oid".to_string(), json!(identity.head_oid.clone()));
+        manifest.insert("git_tree_oid".to_string(), json!(identity.tree_oid.clone()));
+    }
 
     let json = serde_json::to_string_pretty(&manifest)
         .map_err(|e| KnowledgeError::invalid_data(format!("manifest serialize: {e}")))?;

--- a/crates/orbit-knowledge/tests/branch_refs.rs
+++ b/crates/orbit-knowledge/tests/branch_refs.rs
@@ -384,6 +384,88 @@ fn branch_refs_ensure_fresh_rebuilds_clean_worktree_when_branch_ref_is_missing()
 }
 
 #[test]
+fn branch_refs_ensure_fresh_rebuilds_after_reset_to_older_timestamp_head()
+-> Result<(), Box<dyn std::error::Error>> {
+    let repo = init_repo()?;
+    let knowledge_temp = TempDir::new()?;
+    let knowledge_dir = knowledge_temp.path().join("knowledge");
+
+    write_rust_source(repo.path(), "old_graph")?;
+    commit_all_with_date(repo.path(), "old graph", "2026-04-01T00:00:00Z")?;
+    let old_head = git(repo.path(), &["rev-parse", "HEAD"])?;
+
+    write_rust_source(repo.path(), "new_graph")?;
+    commit_all_with_date(repo.path(), "new graph", "2030-01-01T00:00:00Z")?;
+    let new_head = git(repo.path(), &["rev-parse", "HEAD"])?;
+
+    run_build(BuildConfig {
+        repo_path: repo.path().to_path_buf(),
+        output_dir: knowledge_dir.clone(),
+        incremental: false,
+        ref_name: None,
+    })?;
+
+    let read_target = resolve_graph_read_target(Some(repo.path()), None)?;
+    let graph_store = GraphObjectStore::new(knowledge_dir.join("graph"));
+    let current_ref = graph_store.read_ref(&read_target.requested)?;
+    assert_eq!(current_ref.git_head_oid.as_deref(), Some(new_head.as_str()));
+    assert!(current_ref.git_tree_oid.as_deref().is_some());
+
+    let manifest: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(knowledge_dir.join("manifest.json"))?)?;
+    assert_eq!(
+        manifest
+            .get("git_head_oid")
+            .and_then(|value| value.as_str()),
+        Some(new_head.as_str())
+    );
+    assert!(
+        manifest
+            .get("git_tree_oid")
+            .and_then(|value| value.as_str())
+            .is_some()
+    );
+
+    git(repo.path(), &["reset", "--hard", &old_head])?;
+    let generated_at = manifest
+        .get("generated_at")
+        .and_then(|value| value.as_str())
+        .ok_or_else(|| io_error("manifest generated_at missing".to_string()))?;
+    let generated_at = chrono::DateTime::parse_from_rfc3339(generated_at)?;
+    let head_ts =
+        chrono::DateTime::parse_from_rfc3339(&git(repo.path(), &["log", "-1", "--format=%cI"])?)?;
+    assert!(head_ts < generated_at);
+
+    let status = ensure_fresh(&knowledge_dir, repo.path())?;
+    assert_eq!(status, RefreshStatus::Rebuilt);
+
+    let refreshed_ref = graph_store.read_ref(&read_target.requested)?;
+    assert_eq!(
+        refreshed_ref.git_head_oid.as_deref(),
+        Some(old_head.as_str())
+    );
+
+    let graph = graph_store.read_graph(
+        &read_target.requested,
+        read_target.fallback.as_ref(),
+        read_target.default.as_ref(),
+    )?;
+    assert!(
+        graph
+            .leaves
+            .iter()
+            .any(|leaf| leaf.base.name == "old_graph")
+    );
+    assert!(
+        !graph
+            .leaves
+            .iter()
+            .any(|leaf| leaf.base.name == "new_graph")
+    );
+    Ok(())
+}
+
+#[test]
 fn pack_regression_selector_opens_from_branch_ref_layout() -> Result<(), Box<dyn std::error::Error>>
 {
     let repo_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"))

--- a/docs/design/knowledge-graph/2_design.md
+++ b/docs/design/knowledge-graph/2_design.md
@@ -12,7 +12,7 @@ This document specifies the current knowledge graph: storage, build pipeline, qu
 
 ```
 .orbit/knowledge/
-├── manifest.json                commit pointer + generated_at timestamp
+├── manifest.json                checkout identity + generated_at timestamp
 ├── refresh.lock                 flock for single-flighted rebuilds
 ├── refresh_state.json           debounce bookkeeping for dirty refreshes
 ├── graph/
@@ -46,7 +46,7 @@ scan → hash → detect_changes → build_dirs → build_files → build_leaves
 | `build_graph_files` | `FileNode` entries linked to parent dir | Language detected from extension |
 | `build_graph_leaves` | `LeafNode` entries via file-kind-dispatched extractor | Code via tree-sitter (C, C#, Rust, Python, Go, Java, JavaScript, Kotlin, TypeScript, TSX, Ruby); markdown sections, YAML/JSON/TOML top-level keys, and CSV/TSV header columns via shallow extractors added in [T20260422-1540]. TypeScript/TSX coverage was added in [T20260505-11]; C# coverage was added in [T20260505-13]; C `.c`/`.h` coverage was added in [T20260505-16]. Per-file read/extract work runs in parallel, then graph mutation is merged on the main thread in file order ([T20260426-0139]). Incremental builds reuse unchanged file/leaf snapshots from the same branch ref when hashes match ([T20260426-0140]) |
 | `persist_graph` | Content-addressed objects, blobs, index | Atomic via tempfile + rename |
-| `write_manifest` | `manifest.json` | Timestamp + commit + ref pointer |
+| `write_manifest` | `manifest.json` | Timestamp + clean checkout identity + graph summary |
 | `save_hash_cache` | `hashes.json` | Baseline for the next incremental `detect_changes` pass |
 
 Extraction dispatches on `FileKind`. Each `FileExtractor` emits `ExtractedLeaf` records with name, kind, span, hash, and child names. Code uses tree-sitter; shallow doc/config/table extractors handle markdown ATX headings, top-level YAML/JSON/TOML keys, and CSV/TSV header cells with a 1 MiB cap ([T20260422-1540]).
@@ -55,7 +55,7 @@ Hashing and leaf extraction are parallelized only across independent file work. 
 
 ### 2.1 Incremental refresh
 
-`ensure_fresh(knowledge_dir, repo_path)` is the read-side entry point. It compares the persisted manifest against the current HEAD timestamp and the dirty-worktree fingerprint, and picks one of:
+`ensure_fresh(knowledge_dir, repo_path)` is the read-side entry point. For clean worktrees, it compares the current git checkout identity (`HEAD` commit OID, with tree OID persisted for diagnostics/fallback) against the current branch ref. Commit timestamps remain diagnostic metadata and are not freshness authority. Dirty worktrees still use the dirty-worktree fingerprint, and the planner picks one of:
 
 - **Fresh** — nothing to do.
 - **SkippedDirtyDebounce** — worktree is dirty with the same fingerprint as a recent refresh; reuse.
@@ -66,7 +66,7 @@ The refresh lock is a `flock` on `.orbit/knowledge/refresh.lock`. Concurrent cal
 
 Incremental rebuilds still rebuild the directory and file node skeleton from the current scan so deletes and `.orbitignore` changes take effect. The expensive leaf phase loads the previously persisted graph for the same branch ref and copies unchanged files' `source_blob_hash`, hydrated source, exports, re-exports, `leaf_children`, and leaf nodes when both the file source hash and every reused leaf's `file_hash_at_capture` match the new hash. Paths in `ctx.changed_paths`, new files, hash mismatches, absent refs, or unreadable prior graphs take the full extractor path instead ([T20260426-0140]).
 
-Refresh hardening: [T20260417-0307] gated and guarded the refresh/search hot paths; [T20260416-0719] added recovery from a corrupted default store; [T20260417-0639] sped up the workspace-init persistence path.
+Refresh hardening: [T20260417-0307] gated and guarded the refresh/search hot paths; [T20260416-0719] added recovery from a corrupted default store; [T20260417-0639] sped up the workspace-init persistence path; [T20260509-34] moved clean-checkout freshness from commit timestamps to exact git identity.
 
 ### 2.2 Removed task attribution ([T20260506-11])
 

--- a/docs/design/knowledge-graph/4_decisions.md
+++ b/docs/design/knowledge-graph/4_decisions.md
@@ -457,6 +457,23 @@ These entries were formerly ADR headings, but they are plain instances of ADR-00
 
 ---
 
+## ADR-031 — Refresh freshness by checkout identity
+
+**Status:** Accepted · 2026-05 · [T20260509-34]
+**Author:** gpt-5.5
+
+**Context.** Auto-refresh used `manifest.generated_at` versus `git log -1 --format=%cI` to decide if a clean branch graph was fresh. A branch reset, rebase, or old-date commit can move `HEAD` to a different checkout with a committer timestamp older than the manifest, causing reads to reuse a graph built for the previous checkout.
+
+**Decision.** Persist the build checkout's exact git identity on branch refs (`git_head_oid`, `git_tree_oid`) and mirror it in `manifest.json`. Clean-worktree refresh compares the current `HEAD` OID against the current branch ref before returning `Fresh`; tree OID remains a content fallback for partial records. Missing ref identity forces an incremental rebuild so newly written refs become self-describing. Commit timestamps remain diagnostic only.
+
+**Consequences.**
+- History rewrites, resets, and rebases refresh based on the actual checkout instead of wall-clock or commit dates.
+- Branch refs become the per-branch freshness authority, which avoids treating a manifest from another branch as proof that the current branch is fresh.
+- Legacy refs without identity rebuild once and then carry the new metadata.
+- Cost: every build and clean refresh shells out to git for exact OIDs, adding a small fixed process cost to the refresh path.
+
+---
+
 ## Task References
 
 Tasks cited by ADRs above:
@@ -502,5 +519,6 @@ Tasks cited by ADRs above:
 - **[T20260506-11]** — Remove graph task attribution after audited reverse-lookup usage was 0/961; preserve `[T...]` as a local commit-search key.
 - **[T20260506-19]** — Normalize knowledge-graph ADR Cost lines and demote folded language instances to coverage records.
 - **[T20260509-33]** — Skip symlinked directory entries during scanner traversal and `.orbitignore` discovery.
+- **[T20260509-34]** — Use exact git checkout identity instead of commit timestamps for clean graph freshness.
 
 Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.

--- a/docs/design/knowledge-graph/specs/refs.md
+++ b/docs/design/knowledge-graph/specs/refs.md
@@ -36,11 +36,15 @@ A branch ref is JSON with the same high-level metadata as the old current ref pl
   "root_graph_hash": "<sha256>",
   "root_object_hash": "<sha256>",
   "root_dir_id": "dir:.",
+  "git_head_oid": "<commit-oid>",
+  "git_tree_oid": "<tree-oid>",
   "index": "graph/index/by-id/<root-graph-hash>.json"
 }
 ```
 
 The `index` field is knowledge-root-relative. That means it is interpreted relative to `.orbit/knowledge/`, not relative to `.orbit/knowledge/graph/`. This is now the single documented frame of reference for stored ref paths.
+
+The git identity fields record the clean checkout identity used for the build. Read-side auto-refresh compares the current `HEAD` OID to `git_head_oid` before treating a branch ref as fresh; `git_tree_oid` remains available as a content identity fallback and diagnostic. Commit timestamps are not a freshness authority, because history rewrites and resets can move a branch to an older-dated commit.
 
 ## Read Resolution
 


### PR DESCRIPTION
## Task

[T20260509-34](https://orbit-cli.com/tasks/T20260509-34) — Use commit or tree identity for graph freshness

### Description

## Problem
Graph auto-refresh compares manifest `generated_at` to `git log -1 --format=%cI`. If the current branch is reset or rebased to a commit with an older committer timestamp, a clean checkout can be treated as fresh even though `HEAD` changed.

## Why It Matters
Graph reads can silently describe a previous checkout after history rewrites or old-date commits.

## Constraints / Notes
Persist exact Git identity in the manifest/ref metadata; timestamps may remain diagnostic but should not be the freshness authority.

### Acceptance Criteria

- Manifest or branch-ref state records the exact `HEAD` OID or tree OID used to build the graph.
- `compute_refresh_plan` rebuilds when the current clean checkout identity differs, even if the new commit timestamp is older than `generated_at`.
- Tests cover resetting/rebasing to an older-timestamp commit on the same branch.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Persisted exact git checkout identity (`git_head_oid`, `git_tree_oid`) on branch refs and mirrored it in `manifest.json`.
- Changed clean-worktree refresh planning to compare the current checkout identity against the current branch ref instead of using commit timestamps as freshness authority.
- Added a reset-to-older-timestamp regression test and updated knowledge-graph design docs/ADR-030 for the new freshness contract.

Assessment: Focused branch-ref regression, workspace build, and full CI pass after rerunning one unrelated flaky test.

Design weaknesses / risks:
- Initial `make ci` hit an unrelated flaky `orbit-engine` fanout ordering test; the targeted rerun passed and the second full CI passed. Filed friction task T20260509-54.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/T20260509-34-69fec29a`
- Behind base: 0
- Ahead of base: 1

*authored by: gpt-5.5*