### PR TITLE
Apply task-delete status guards to the Orbit tool surface

### DIFF
--- a/crates/orbit-cli/src/command/mcp/mod.rs
+++ b/crates/orbit-cli/src/command/mcp/mod.rs
@@ -371,10 +371,25 @@ mod tests {
     mod audited_mcp_call_tests {
         use orbit_common::types::AuditEventStatus;
         use orbit_core::OrbitRuntime;
+        use orbit_core::TaskStatus;
+        use orbit_core::command::task::TaskAddParams;
         use orbit_mcp::McpHost;
         use serde_json::json;
 
         use super::super::{RuntimeMcpHost, audited_mcp_call};
+
+        fn create_task(runtime: &OrbitRuntime, status: TaskStatus) -> String {
+            runtime
+                .add_task(TaskAddParams {
+                    title: format!("Delete {status}"),
+                    description: "Exercise MCP task deletion guard.".to_string(),
+                    workspace_path: Some(".".to_string()),
+                    status: Some(status),
+                    ..Default::default()
+                })
+                .expect("create task")
+                .id
+        }
 
         #[test]
         fn preflight_failure_for_unknown_tool_records_failure_audit_row() {
@@ -422,6 +437,101 @@ mod tests {
             assert_eq!(events.len(), 1, "exactly one audit row for happy path");
             assert_eq!(events[0].subcommand.as_deref(), Some("run-mcp"));
             assert_eq!(events[0].status, AuditEventStatus::Success);
+        }
+
+        #[test]
+        fn task_delete_rejects_unforced_protected_status_and_audits_failure() {
+            let runtime = OrbitRuntime::in_memory().expect("build test runtime");
+            let task_id = create_task(&runtime, TaskStatus::Backlog);
+            let host = RuntimeMcpHost {
+                runtime: runtime.clone(),
+            };
+
+            let result = host.call_tool(
+                "orbit.task.delete",
+                json!({ "id": task_id, "model": "gpt-5.5" }),
+            );
+
+            let error = result.expect_err("unforced protected delete fails");
+            assert!(error.to_string().contains(
+                "use --force to delete tasks not in proposed, friction, or rejected status"
+            ));
+            runtime
+                .get_task(&task_id)
+                .expect("unforced protected task remains");
+
+            let events = runtime
+                .list_audit_events(None, Some("orbit.task.delete".to_string()), None, None, 16)
+                .expect("list audit events");
+            assert_eq!(events.len(), 1);
+            assert_eq!(events[0].subcommand.as_deref(), Some("run-mcp"));
+            assert_eq!(events[0].status, AuditEventStatus::Failure);
+            assert_eq!(events[0].exit_code, 1);
+            assert!(
+                events[0]
+                    .error_message
+                    .as_deref()
+                    .is_some_and(|message| message.contains("use --force"))
+            );
+        }
+
+        #[test]
+        fn task_delete_allows_unforced_proposed_friction_and_rejected_tasks_over_mcp() {
+            let runtime = OrbitRuntime::in_memory().expect("build test runtime");
+            let host = RuntimeMcpHost {
+                runtime: runtime.clone(),
+            };
+
+            for status in [
+                TaskStatus::Proposed,
+                TaskStatus::Friction,
+                TaskStatus::Rejected,
+            ] {
+                let task_id = create_task(&runtime, status);
+                let value = host
+                    .call_tool(
+                        "orbit.task.delete",
+                        json!({ "id": task_id, "model": "gpt-5.5" }),
+                    )
+                    .expect("unprotected delete succeeds");
+                assert_eq!(value, json!({ "id": task_id, "deleted": true }));
+            }
+
+            let events = runtime
+                .list_audit_events(None, Some("orbit.task.delete".to_string()), None, None, 16)
+                .expect("list audit events");
+            assert_eq!(events.len(), 3);
+            assert!(events.iter().all(|event| {
+                event.subcommand.as_deref() == Some("run-mcp")
+                    && event.status == AuditEventStatus::Success
+            }));
+        }
+
+        #[test]
+        fn task_delete_allows_forced_protected_status_over_mcp_and_audits_success() {
+            let runtime = OrbitRuntime::in_memory().expect("build test runtime");
+            let task_id = create_task(&runtime, TaskStatus::InProgress);
+            let host = RuntimeMcpHost {
+                runtime: runtime.clone(),
+            };
+
+            let value = host
+                .call_tool(
+                    "orbit.task.delete",
+                    json!({ "id": task_id, "force": true, "model": "gpt-5.5" }),
+                )
+                .expect("forced protected delete succeeds");
+
+            assert_eq!(value, json!({ "id": task_id, "deleted": true }));
+            assert!(runtime.get_task(&task_id).is_err(), "task was deleted");
+
+            let events = runtime
+                .list_audit_events(None, Some("orbit.task.delete".to_string()), None, None, 16)
+                .expect("list audit events");
+            assert_eq!(events.len(), 1);
+            assert_eq!(events[0].subcommand.as_deref(), Some("run-mcp"));
+            assert_eq!(events[0].status, AuditEventStatus::Success);
+            assert_eq!(events[0].exit_code, 0);
         }
     }
 }

--- a/crates/orbit-cli/src/command/task/lifecycle.rs
+++ b/crates/orbit-cli/src/command/task/lifecycle.rs
@@ -245,19 +245,7 @@ pub struct TaskDeleteArgs {
 
 impl Execute for TaskDeleteArgs {
     fn execute(self, runtime: &OrbitRuntime) -> Result<(), OrbitError> {
-        let task = runtime.get_task(&self.id)?;
-        if !self.force
-            && !matches!(
-                task.status,
-                TaskStatus::Proposed | TaskStatus::Friction | TaskStatus::Rejected
-            )
-        {
-            return Err(OrbitError::InvalidInput(format!(
-                "task '{}' is in status '{}'; use --force to delete tasks not in proposed, friction, or rejected status",
-                self.id, task.status
-            )));
-        }
-        runtime.delete_task(&self.id)?;
+        runtime.delete_task_guarded(&self.id, self.force)?;
         if self.json {
             crate::output::json::print_pretty(&json!({
                 "id": self.id,

--- a/crates/orbit-core/src/command/task/transitions.rs
+++ b/crates/orbit-core/src/command/task/transitions.rs
@@ -526,6 +526,27 @@ impl OrbitRuntime {
             Ok(((), OrbitEvent::TaskDeleted { id: id.to_string() }))
         })
     }
+
+    pub fn delete_task_guarded(&self, id: &str, force: bool) -> Result<(), OrbitError> {
+        let task = self.get_task(id)?;
+        ensure_task_delete_allowed(&task.id, task.status, force)?;
+        self.delete_task(id)
+    }
+}
+
+fn ensure_task_delete_allowed(id: &str, status: TaskStatus, force: bool) -> Result<(), OrbitError> {
+    if force
+        || matches!(
+            status,
+            TaskStatus::Proposed | TaskStatus::Friction | TaskStatus::Rejected
+        )
+    {
+        return Ok(());
+    }
+
+    Err(OrbitError::InvalidInput(format!(
+        "task '{id}' is in status '{status}'; use --force to delete tasks not in proposed, friction, or rejected status"
+    )))
 }
 
 pub(crate) fn ensure_task_has_execution_plan(id: &str, plan: &str) -> Result<(), OrbitError> {

--- a/crates/orbit-core/src/runtime/orbit_tool_host/task_tools.rs
+++ b/crates/orbit-core/src/runtime/orbit_tool_host/task_tools.rs
@@ -103,7 +103,8 @@ pub(super) fn approve(
 
 pub(super) fn delete(runtime: &OrbitRuntime, input: Value) -> Result<Value, OrbitError> {
     let id = required_string(&input, &["id"], "id")?;
-    runtime.delete_task(&id)?;
+    let force = optional_bool_alias(&input, &["force"])?.unwrap_or(false);
+    runtime.delete_task_guarded(&id, force)?;
     Ok(json!({ "id": id, "deleted": true }))
 }
 

--- a/crates/orbit-core/src/runtime/orbit_tool_host/task_tools_tests.rs
+++ b/crates/orbit-core/src/runtime/orbit_tool_host/task_tools_tests.rs
@@ -1,7 +1,7 @@
 use orbit_common::types::TaskStatus;
 use serde_json::{Value, json};
 
-use super::test_support::{create_task, test_runtime};
+use super::test_support::{create_task, invalid_input_message, test_runtime};
 
 #[test]
 fn execute_tool_command_searches_tasks_for_agents() {
@@ -72,6 +72,93 @@ fn task_add_tool_creates_proposed_tasks_for_agents() {
         output.get("status").and_then(Value::as_str),
         Some("proposed")
     );
+}
+
+#[test]
+fn task_delete_tool_rejects_unforced_protected_statuses() {
+    let (_root, runtime, repo_root) = test_runtime();
+    let task = create_task(
+        &runtime,
+        &repo_root,
+        "Protected delete",
+        "Backlog tasks require force before permanent deletion.",
+        TaskStatus::Backlog,
+        &[],
+    );
+
+    let message = invalid_input_message(runtime.execute_tool_command(
+        "orbit.task.delete",
+        json!({ "id": task.id.clone() }),
+        Some("codex".to_string()),
+        Some("gpt-5.5".to_string()),
+    ));
+
+    assert_eq!(
+        message,
+        format!(
+            "task '{}' is in status 'backlog'; use --force to delete tasks not in proposed, friction, or rejected status",
+            task.id
+        )
+    );
+    runtime
+        .get_task(&task.id)
+        .expect("unforced protected task remains");
+}
+
+#[test]
+fn task_delete_tool_allows_unforced_proposed_friction_and_rejected_tasks() {
+    let (_root, runtime, repo_root) = test_runtime();
+
+    for status in [
+        TaskStatus::Proposed,
+        TaskStatus::Friction,
+        TaskStatus::Rejected,
+    ] {
+        let task = create_task(
+            &runtime,
+            &repo_root,
+            &format!("Delete {status}"),
+            "Unprotected statuses can be permanently deleted without force.",
+            status,
+            &[],
+        );
+
+        let output = runtime
+            .execute_tool_command(
+                "orbit.task.delete",
+                json!({ "id": task.id.clone() }),
+                Some("codex".to_string()),
+                Some("gpt-5.5".to_string()),
+            )
+            .expect("unprotected delete succeeds");
+
+        assert_eq!(output, json!({ "id": task.id, "deleted": true }));
+    }
+}
+
+#[test]
+fn task_delete_tool_allows_forced_protected_statuses() {
+    let (_root, runtime, repo_root) = test_runtime();
+    let task = create_task(
+        &runtime,
+        &repo_root,
+        "Forced delete",
+        "Protected statuses can be permanently deleted with explicit force.",
+        TaskStatus::InProgress,
+        &[],
+    );
+
+    let output = runtime
+        .execute_tool_command(
+            "orbit.task.delete",
+            json!({ "id": task.id.clone(), "force": true }),
+            Some("codex".to_string()),
+            Some("gpt-5.5".to_string()),
+        )
+        .expect("forced protected delete succeeds");
+
+    assert_eq!(output, json!({ "id": task.id.clone(), "deleted": true }));
+    assert!(runtime.get_task(&task.id).is_err(), "task was deleted");
 }
 
 #[test]

--- a/crates/orbit-tools/src/builtin/orbit/task/delete.rs
+++ b/crates/orbit-tools/src/builtin/orbit/task/delete.rs
@@ -1,4 +1,4 @@
-use orbit_common::types::{OrbitError, ToolSchema};
+use orbit_common::types::{OrbitError, ToolParam, ToolSchema};
 use serde_json::Value;
 
 use crate::{OrbitBuiltinAction, Tool, ToolContext};
@@ -7,7 +7,15 @@ pub struct OrbitTaskDeleteTool;
 
 impl Tool for OrbitTaskDeleteTool {
     fn schema(&self) -> ToolSchema {
-        let parameters = super::super::orbit_id_params("task");
+        let mut parameters = super::super::orbit_id_params("task");
+        parameters.push(ToolParam {
+            name: "force".to_string(),
+            description:
+                "When true, allow permanent deletion outside proposed, friction, or rejected status"
+                    .to_string(),
+            param_type: "boolean".to_string(),
+            required: false,
+        });
 
         ToolSchema {
             name: "orbit.task.delete".to_string(),

--- a/crates/orbit-tools/tests/public_tool_surface.rs
+++ b/crates/orbit-tools/tests/public_tool_surface.rs
@@ -95,6 +95,24 @@ fn task_dependency_params_remain_in_agent_tool_schemas() {
     }
 }
 
+#[test]
+fn task_delete_schema_exposes_optional_force_boolean() {
+    let mut registry = ToolRegistry::new();
+    registry.register_builtins();
+
+    let schema = registry
+        .get_schema("orbit.task.delete")
+        .expect("task delete schema");
+    let force_param = schema
+        .parameters
+        .iter()
+        .find(|param| param.name == "force")
+        .expect("force param");
+
+    assert_eq!(force_param.param_type, "boolean");
+    assert!(!force_param.required);
+}
+
 fn registered_tool_names() -> BTreeSet<String> {
     let mut registry = ToolRegistry::new();
     registry.register_builtins();


### PR DESCRIPTION
## Task

[T20260509-44](https://orbit-cli.com/tasks/T20260509-44) — Apply task-delete status guards to the Orbit tool surface

### Description

## Problem
The CLI delete command requires `--force` for tasks outside `proposed`, `friction`, or `rejected`, but the `orbit.task.delete` tool calls `runtime.delete_task(&id)` directly and is exposed over MCP.

## Why It Matters
Agents or MCP clients can permanently delete active, review, done, or backlog tasks through the tool surface despite the human CLI safety guard.

## Constraints / Notes
Keep a force escape hatch if needed, but make protected deletion explicit and audited on every public surface.

### Acceptance Criteria

- `orbit.task.delete` rejects protected statuses by default with the same status set and message semantics as the CLI guard.
- A boolean `force` input, if present, is required to delete protected statuses through the tool path and is reflected in tests/audit output as appropriate.
- Tool-host and MCP tests cover unforced protected deletion, allowed unforced proposed/friction/rejected deletion, and forced protected deletion.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Centralized task delete status guarding in OrbitRuntime::delete_task_guarded and routed both CLI delete and orbit.task.delete through it.
- Added optional boolean force to the orbit.task.delete schema and tool-host parsing so protected statuses require explicit force.
- Added tool-host, MCP, audit-status, and public schema coverage for unforced protected deletion, unforced proposed/friction/rejected deletion, and forced protected deletion.

Assessment: Full CI guardrails passed; the tool surface now matches the CLI delete safety semantics while preserving an explicit forced escape hatch.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/T20260509-44-69fec46d`
- Behind base: 0
- Ahead of base: 1

*authored by: gpt-5.5*