### PR TITLE
Kill CLI subprocess trees on timeout

### DIFF
--- a/crates/orbit-engine/src/activity_job/cli_runner/spawn.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/spawn.rs
@@ -49,6 +49,11 @@ fn spawn_bare(
     if let Some(path) = cwd {
         command.current_dir(path);
     }
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::CommandExt;
+        command.process_group(0);
+    }
     let child = command
         .spawn()
         .map_err(|err| OrbitError::Execution(format!("failed to spawn `{program}`: {err}")))?;

--- a/crates/orbit-engine/src/activity_job/cli_runner/supervisor.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/supervisor.rs
@@ -1,6 +1,7 @@
 use std::io::{BufRead, BufReader, Read, Write};
 use std::path::Path;
-use std::sync::{Arc, Mutex};
+use std::process::Child;
+use std::sync::{Arc, Mutex, mpsc};
 use std::thread;
 use std::time::{Duration, Instant};
 
@@ -13,6 +14,8 @@ use super::spawn::{SpawnedChild, spawn_child_with_optional_sandbox};
 pub(super) const DEFAULT_WALL_CLOCK_TIMEOUT_SECONDS: u64 = 300;
 
 pub(super) type SpawnOutput = (Vec<u8>, Vec<u8>, Option<i32>, Duration, bool);
+
+const OUTPUT_READER_JOIN_TIMEOUT: Duration = Duration::from_millis(500);
 
 pub(super) struct SpawnTraceContext<'a> {
     pub(super) provider: &'a str,
@@ -39,6 +42,11 @@ struct OutputReaderContext {
     task_id: Option<String>,
     cwd: Option<String>,
     dispatch: tracing::Dispatch,
+}
+
+struct OutputReaderHandle {
+    finished: mpsc::Receiver<()>,
+    join: thread::JoinHandle<()>,
 }
 
 pub(super) fn spawn_with_timeout(
@@ -109,14 +117,14 @@ pub(super) fn spawn_with_timeout(
     loop {
         match child.try_wait() {
             Ok(Some(status)) => {
+                cleanup_child_process_group(child.id());
                 exit_status = Some(status);
                 break;
             }
             Ok(None) => {
                 if Instant::now() >= deadline {
-                    let _ = child.kill();
+                    kill_child_process_tree(&mut child);
                     timed_out = true;
-                    let _ = child.wait();
                     exit_status = None;
                     break;
                 }
@@ -126,19 +134,16 @@ pub(super) fn spawn_with_timeout(
         }
     }
 
+    let reader_join_deadline = timed_out.then(|| Instant::now() + OUTPUT_READER_JOIN_TIMEOUT);
     if let Some(h) = stdout_reader {
-        let _ = h.join();
+        join_output_reader(h, reader_join_deadline);
     }
     if let Some(h) = stderr_reader {
-        let _ = h.join();
+        join_output_reader(h, reader_join_deadline);
     }
 
-    let stdout = Arc::try_unwrap(stdout_buf)
-        .map(|m| m.into_inner().unwrap_or_default())
-        .unwrap_or_default();
-    let stderr = Arc::try_unwrap(stderr_buf)
-        .map(|m| m.into_inner().unwrap_or_default())
-        .unwrap_or_default();
+    let stdout = stdout_buf.lock().map(|buf| buf.clone()).unwrap_or_default();
+    let stderr = stderr_buf.lock().map(|buf| buf.clone()).unwrap_or_default();
     let exit_code = exit_status.as_ref().and_then(|s| s.code());
     let duration = started.elapsed();
     Ok((stdout, stderr, exit_code, duration, timed_out))
@@ -148,7 +153,7 @@ fn spawn_output_reader<R>(
     handle: R,
     buf: Arc<Mutex<Vec<u8>>>,
     context: OutputReaderContext,
-) -> thread::JoinHandle<()>
+) -> OutputReaderHandle
 where
     R: Read + Send + 'static,
 {
@@ -161,7 +166,8 @@ where
         dispatch,
     } = context;
 
-    thread::spawn(move || {
+    let (finished_tx, finished) = mpsc::channel();
+    let join = thread::spawn(move || {
         tracing::dispatcher::with_default(&dispatch, || {
             let mut reader = BufReader::new(handle);
             let mut raw_line = Vec::new();
@@ -186,7 +192,61 @@ where
                 }
             }
         });
-    })
+        let _ = finished_tx.send(());
+    });
+    OutputReaderHandle { finished, join }
+}
+
+fn join_output_reader(reader: OutputReaderHandle, deadline: Option<Instant>) {
+    let OutputReaderHandle { finished, join } = reader;
+    match deadline {
+        Some(deadline) => {
+            let timeout = deadline.saturating_duration_since(Instant::now());
+            match finished.recv_timeout(timeout) {
+                Ok(()) | Err(mpsc::RecvTimeoutError::Disconnected) => {
+                    let _ = join.join();
+                }
+                Err(mpsc::RecvTimeoutError::Timeout) => {}
+            }
+        }
+        None => {
+            let _ = join.join();
+        }
+    }
+}
+
+fn kill_child_process_tree(child: &mut Child) {
+    #[cfg(unix)]
+    {
+        let _ = signal_child_process_group(child.id(), libc::SIGKILL);
+    }
+    let _ = child.kill();
+    let _ = child.wait();
+}
+
+#[cfg(unix)]
+fn cleanup_child_process_group(child_id: u32) {
+    let _ = signal_child_process_group(child_id, libc::SIGKILL);
+}
+
+#[cfg(not(unix))]
+fn cleanup_child_process_group(_child_id: u32) {}
+
+#[cfg(unix)]
+fn signal_child_process_group(child_id: u32, signal: libc::c_int) -> std::io::Result<()> {
+    if child_id == 0 || child_id > i32::MAX as u32 {
+        return Ok(());
+    }
+    let rc = unsafe { libc::killpg(child_id as libc::pid_t, signal) };
+    if rc == 0 {
+        return Ok(());
+    }
+    let error = std::io::Error::last_os_error();
+    if error.raw_os_error() == Some(libc::ESRCH) {
+        Ok(())
+    } else {
+        Err(error)
+    }
 }
 
 fn emit_output_line(
@@ -377,5 +437,99 @@ mod tests {
         assert_eq!(events.len(), 1);
         assert_eq!(events[0].field("stream"), Some("stdout"));
         assert_eq!(events[0].field("line"), Some("before timeout"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn spawn_with_timeout_kills_grandchild_holding_output_pipes() {
+        let pid_dir = tempdir().expect("pid tempdir");
+        let pid_file = pid_dir.path().join("grandchild.pid");
+        let script = format!(
+            "(sleep 30) & child=$!; printf '%s\\n' \"$child\" > {}; printf '%s\\n' 'before timeout'; sleep 30",
+            shell_quote(pid_file.to_string_lossy().as_ref())
+        );
+        let args = sh_args(&script);
+
+        let started = std::time::Instant::now();
+        let (stdout, stderr, exit_code, duration, timed_out) =
+            spawn_with_timeout(spawn_test_request(
+                "/bin/sh",
+                &args,
+                None,
+                Duration::from_millis(150),
+                SpawnTraceContext {
+                    provider: "codex",
+                    job_run_id: "job-timeout-tree",
+                    task_id: Some("TTREE"),
+                    cwd: None,
+                },
+            ))
+            .expect("spawn succeeds");
+
+        assert!(timed_out);
+        assert_eq!(exit_code, None);
+        assert_eq!(stdout, b"before timeout\n");
+        assert!(stderr.is_empty());
+        assert!(
+            started.elapsed() < Duration::from_secs(2),
+            "timeout path should return promptly; reported duration={duration:?}"
+        );
+
+        let grandchild_pid = read_pid(&pid_file);
+        assert!(
+            wait_until(Duration::from_secs(2), || !process_is_live(grandchild_pid)),
+            "grandchild process {grandchild_pid} should be gone after timeout"
+        );
+    }
+
+    #[cfg(unix)]
+    fn read_pid(path: &Path) -> u32 {
+        std::fs::read_to_string(path)
+            .expect("read pid file")
+            .trim()
+            .parse()
+            .expect("parse pid")
+    }
+
+    #[cfg(unix)]
+    fn wait_until<F>(timeout: Duration, mut condition: F) -> bool
+    where
+        F: FnMut() -> bool,
+    {
+        let started = std::time::Instant::now();
+        while started.elapsed() < timeout {
+            if condition() {
+                return true;
+            }
+            std::thread::sleep(Duration::from_millis(25));
+        }
+        condition()
+    }
+
+    #[cfg(unix)]
+    fn process_is_live(pid: u32) -> bool {
+        if pid == 0 || pid > i32::MAX as u32 {
+            return false;
+        }
+        let rc = unsafe { libc::kill(pid as libc::pid_t, 0) };
+        if rc != 0 && std::io::Error::last_os_error().raw_os_error() == Some(libc::ESRCH) {
+            return false;
+        }
+        let output = std::process::Command::new("ps")
+            .args(["-o", "stat=", "-p", &pid.to_string()])
+            .output();
+        let Ok(output) = output else {
+            return true;
+        };
+        if !output.status.success() {
+            return false;
+        }
+        let status = String::from_utf8_lossy(&output.stdout);
+        !status.trim_start().starts_with('Z')
+    }
+
+    #[cfg(unix)]
+    fn shell_quote(value: &str) -> String {
+        format!("'{}'", value.replace('\'', "'\\''"))
     }
 }

--- a/docs/design/activity-job/2_design.md
+++ b/docs/design/activity-job/2_design.md
@@ -2,7 +2,7 @@
 
 **Status:** Draft
 **Owner:** codex
-**Last updated:** 2026-05-09 (T20260427-34, T20260427-36, T20260427-38, T20260427-40, T20260508-3, T20260508-8, T20260509-2, T20260509-7, T20260509-9, T20260509-11, T20260509-30)
+**Last updated:** 2026-05-09 (T20260427-34, T20260427-36, T20260427-38, T20260427-40, T20260508-3, T20260508-8, T20260509-2, T20260509-7, T20260509-9, T20260509-11, T20260509-30, T20260509-40)
 
 This document describes the shipped Activity / Job substrate across `orbit-common`, `orbit-engine`, `orbit-core`, and `orbit-cli`: asset shape, normalization, dispatch boundaries, backend semantics, DAG execution, audit, and retained legacy edges. See [1_overview.md](./1_overview.md) for purpose and [3_vision.md](./3_vision.md) for open questions.
 
@@ -217,6 +217,8 @@ Executor args are prepended before provider runtime args. For seeded Codex, the 
 After [T20260427-48], provider runtime args receive provider config through `V2RuntimeHost`. Static executor definitions keep command-shape flags (`exec --json`); dynamic Codex settings such as sandbox mode, side-write roots, and approval policy stay in the retained provider runtime. Codex approval policy is an exec-compatible config override, not the interactive-only `--ask-for-approval` flag.
 
 After [T20260427-51], macOS CLI invocations declaring `sandbox: macos-sandbox-exec` run under `/usr/bin/sandbox-exec -f <profile.sb> <provider> ...`; [T20260509-30] made that wrapper resolution trusted and absolute instead of `PATH`-based. Orbit treats that SBPL profile as filesystem authority and neutralizes provider-native sandbox flags. After [T20260428-10], the profile grants Codex state (`$CODEX_HOME` or `$HOME/.codex`) plus side-write roots from provider config so inherited Orbit subprocesses can persist workflow state while project writes remain governed by `fsProfile`. After [T20260505-22], dispatch also runs `apply_provider_static_arg_fixups` before spawn, separately from sandbox neutralization. Today this only rewrites Claude's `--debug-file` value to `<claude_state_dir>/<basename>` so the log lands inside the already-writable state dir instead of `.orbit/**`, which the default policy denies.
+
+After [T20260509-40], bare Unix CLI subprocesses enter their own process group, matching the macOS sandbox wrapper's kill boundary. The supervisor kills that process group on timeout, also kills any remaining group members after the main child exits before joining output readers, and bounds timeout-path reader joins so a leaked pipe writer cannot hang the activity supervisor. Non-Unix platforms keep the immediate-child kill fallback until Orbit has an equivalent process-tree primitive there.
 
 After [T20260430-15], the CLI stdin envelope carries rendered activity input and durable `run_id` beside instruction, prompt, tools, and model. When input identifies one task, orbit-core embeds a canonical task snapshot with `input.workspace_path` / `input.repo_root` taking precedence over stored paths. After [T20260508-8], `backend: cli` also uses a shared workspace resolver for subprocess cwd: `input.workspace_path`, then `task.workspace_path`, then best-effort `ToolContext.workspace_root`. Declared input/task paths must already be directories; stale worktrees fail as `CliInvocationFailed` before `CliInvocationStarted` is emitted. `groundhog` delegates to the same resolver so task execution and attempt orchestration do not drift. After [T20260505-10], Orbit-managed CLI subprocesses receive `ORBIT_RUN_ID` plus an Orbit-managed run-context marker; `orbit tool run` requires both before it populates `ToolContext` reservation ownership. Direct manual CLI tool calls, including calls with only `ORBIT_RUN_ID`, remain unowned.
 
@@ -530,5 +532,6 @@ Read-only history does not need the same dependencies as live execution. [T20260
 - **[T20260509-7]** — Establish focused test coverage for the activity/job DAG executor (linear, retry, parallel, fan-out, loop, pipeline durability) and the macOS sandbox / policy boundary.
 - **[T20260509-11]** — Keep condition guards on equality-only grammar and repair the `ship-auto` empty-backlog guard.
 - **[T20260509-30]** — Resolve the macOS `sandbox-exec` wrapper from a trusted absolute path before CLI spawn.
+- **[T20260509-40]** — Run CLI subprocesses in killable process groups and bound timeout-path output reader joins.
 
 > Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.

--- a/docs/design/activity-job/4_decisions.md
+++ b/docs/design/activity-job/4_decisions.md
@@ -2,7 +2,7 @@
 
 **Status:** Draft
 **Owner:** codex
-**Last updated:** 2026-05-09 (T20260427-34, T20260427-36, T20260427-38, T20260427-40, T20260508-3, T20260508-8, T20260509-2, T20260509-7, T20260509-9, T20260509-11)
+**Last updated:** 2026-05-09 (T20260427-34, T20260427-36, T20260427-38, T20260427-40, T20260508-3, T20260508-8, T20260509-2, T20260509-7, T20260509-9, T20260509-11, T20260509-40)
 
 This ADR log records the decisions that define the current Activity / Job substrate. Entries are append-only and stay in place when later ADRs supersede or fold them. See [1_overview.md](./1_overview.md) for the feature summary, [2_design.md](./2_design.md) for the current implementation, and [3_vision.md](./3_vision.md) for the questions that may force more decisions.
 
@@ -499,6 +499,19 @@ The plumbing adds a single optional field to `TaskAutomationUpdate` (`context_fi
 - Seeded jobs can still model empty collections and counts, but authored guards must avoid ordering operators unless a future task intentionally extends the grammar.
 - Cost: authors cannot write natural numeric comparisons in guards today; they must encode supported equality checks or add a deliberate grammar extension with tests and docs.
 
+## ADR-050 — CLI timeout supervision owns the subprocess group
+
+**Status:** Accepted · 2026-05 · [T20260509-40]
+
+**Context.** `backend: cli` captures stdout/stderr through reader threads while supervising a wall-clock timeout. Killing only the immediate child lets shell-spawned grandchildren survive, keep inherited pipe write ends open, and either hang reader joins or leak background work after a timed-out activity.
+
+**Decision.** Spawn bare Unix CLI subprocesses as process-group leaders, matching the existing macOS sandbox wrapper boundary. On timeout, signal the whole child process group with `SIGKILL`, wait for the main child, and bound timeout-path reader joins; after a normal child exit, clean up the same process group before joining readers so orphaned pipe holders do not block capture.
+
+**Consequences.**
+- CLI subprocess supervision has one Unix tree boundary for bare and macOS-sandboxed paths.
+- Output capture still preserves partial stdout/stderr bytes already drained before timeout, even if a reader thread does not finish within the bounded join window.
+- Cost: Unix process groups do not cover descendants that deliberately create a new session/process group, and non-Unix platforms still use the immediate-child fallback until an equivalent tree-kill primitive is added.
+
 ---
 
 ## Task References
@@ -564,5 +577,6 @@ The plumbing adds a single optional field to `TaskAutomationUpdate` (`context_fi
 - **[T20260509-7]** — Establish focused test coverage for the activity/job DAG executor (linear, retry, parallel, fan-out, loop, pipeline durability) and the macOS sandbox / policy boundary.
 - **[T20260509-9]** — Auto-populate `task.context_files` from the winning planning-duel plan after resolution.
 - **[T20260509-11]** — Keep condition guards on equality-only grammar and repair the `ship-auto` empty-backlog guard.
+- **[T20260509-40]** — Run CLI subprocesses in killable process groups and bound timeout-path output reader joins.
 
 > Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.


### PR DESCRIPTION
## Task

[T20260509-40](https://orbit-cli.com/tasks/T20260509-40) — Kill CLI subprocess trees on timeout

### Description

## Problem
`spawn_with_timeout` kills only the immediate child with `child.kill()` and then joins stdout/stderr reader threads. Bare subprocesses are not started in a process group/session, so grandchildren can survive, keep inherited pipes open, and make the timeout path hang or leak background work.

## Why It Matters
Timed-out CLI-backed activities can leave running work behind and block the supervisor while readers wait for pipe EOF.

## Constraints / Notes
macOS sandboxed spawn already sets a process group on the wrapper; ensure the bare path and timeout kill semantics are equally robust across supported Unix platforms.

### Acceptance Criteria

- Bare CLI subprocesses run in a killable process group or equivalent process tree boundary.
- On timeout, Orbit kills the full process group/tree and bounds reader-thread joins.
- A regression test with a shell-spawned grandchild that holds stdout/stderr open returns promptly and leaves no live child process.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Put bare Unix CLI subprocesses into their own process group so timeout supervision has the same tree boundary as the macOS sandbox wrapper.
- Updated timeout handling to kill the child process group, wait for the main child, and bound timeout-path stdout/stderr reader joins while preserving partial captured output.
- Added a Unix regression test where a shell-spawned grandchild holds output pipes open; the timeout returns promptly and the grandchild is gone.
- Updated Activity / Job design docs and added ADR-050 for the CLI process-group supervision contract.

Assessment: The focused cli_runner tests, full workspace build, and full CI pass completed successfully.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/T20260509-40-69fec4a9`
- Behind base: 0
- Ahead of base: 1

*authored by: gpt-5.5*