### PR TITLE
Validate backend config and align the default backend contract

### DIFF
--- a/crates/orbit-cli/src/command/run/job.rs
+++ b/crates/orbit-cli/src/command/run/job.rs
@@ -20,7 +20,7 @@ pub struct JobRunArgs {
     #[arg(long)]
     pub input: Vec<String>,
     /// Explicit execution backend override for `agent_loop` steps (§3.1).
-    /// Precedence: this flag > `ORBIT_BACKEND` > `[runtime] backend` > `http`.
+    /// Precedence: this flag > `ORBIT_BACKEND` > `[runtime] backend` > `cli`.
     /// Accepted values: `http`, `cli`, `auto`.
     #[arg(long)]
     pub backend: Option<String>,

--- a/crates/orbit-common/src/types/activity_job/activity_v2.rs
+++ b/crates/orbit-common/src/types/activity_job/activity_v2.rs
@@ -57,13 +57,13 @@ pub struct AgentLoopSpec {
     /// Upper bound on loop iterations.
     #[serde(default = "default_max_iterations")]
     pub max_iterations: u32,
-    /// Execution backend (§3.1). `Auto` is resolved to `Http` or `Cli` once per
-    /// Run at load time per the precedence rules in §3.1 and then never observed
-    /// by the dispatcher — everything downstream sees the concrete backend.
+    /// Execution backend (§3.1). Missing values default to the v1 `Cli`
+    /// release path. `Auto` is resolved to `Http` or `Cli` once per Run at
+    /// load time per the precedence rules in §3.1 and then never observed by
+    /// the dispatcher — everything downstream sees the concrete backend.
     #[serde(default)]
     pub backend: Backend,
-    /// Provider whose runtime executes this activity (§3.1). Default `Claude`
-    /// matches the Phase 2c HTTP wiring that currently supports only Anthropic.
+    /// Provider whose runtime executes this activity (§3.1).
     #[serde(default)]
     pub provider: Provider,
     /// Wall-clock timeout for a CLI invocation (§7.6). Ignored in HTTP mode
@@ -131,8 +131,8 @@ impl GroundhogSpec {
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
 #[serde(rename_all = "snake_case")]
 pub enum Backend {
-    #[default]
     Http,
+    #[default]
     Cli,
     Auto,
 }
@@ -304,5 +304,12 @@ mod tests {
         let yaml = "instruction: hi\n";
         let parsed: AgentLoopSpec = serde_yaml::from_str(yaml).expect("parse spec");
         assert_eq!(parsed.role, None);
+    }
+
+    #[test]
+    fn agent_loop_spec_defaults_to_cli_backend() {
+        let yaml = "instruction: hi\n";
+        let parsed: AgentLoopSpec = serde_yaml::from_str(yaml).expect("parse spec");
+        assert_eq!(parsed.backend, Backend::Cli);
     }
 }

--- a/crates/orbit-core/examples/v2_backend_precedence_smoke.rs
+++ b/crates/orbit-core/examples/v2_backend_precedence_smoke.rs
@@ -41,9 +41,9 @@ fn main() {
         r.source
     );
 
-    // Default falls through to `http` when nothing is set.
+    // Default falls through to `cli` when nothing is set.
     let r = resolve_backend_precedence(None, None, None);
-    assert_eq!(r.backend, Backend::Http);
+    assert_eq!(r.backend, Backend::Cli);
     assert_eq!(r.source, BackendSource::Default);
     println!(
         "  4) default tier — resolved={} source={:?}",
@@ -51,16 +51,16 @@ fn main() {
         r.source
     );
 
-    // `auto` at any lower tier folds to the hard-coded `http` fallback so the
+    // `auto` at any lower tier folds to the hard-coded `cli` fallback so the
     // dispatcher never sees `Auto` (§3.1 — resolution is one-shot at load).
     let r = resolve_backend_precedence(None, Some("auto"), Some("cli"));
     assert_eq!(
         r.backend,
-        Backend::Http,
-        "env=auto must fold to http, not cascade to config"
+        Backend::Cli,
+        "env=auto must fold to cli, not cascade to config"
     );
     assert_eq!(r.source, BackendSource::Env);
-    println!("  5) env=auto folds to http (no cascade)");
+    println!("  5) env=auto folds to cli (no cascade)");
 
     // Invalid env value is ignored (caller didn't know about it) and we fall
     // through to config.

--- a/crates/orbit-core/src/command/activity_v2.rs
+++ b/crates/orbit-core/src/command/activity_v2.rs
@@ -54,7 +54,7 @@ impl OrbitRuntime {
         })?;
 
         // §3.1 resolution: replace `Auto` with a concrete backend per
-        // precedence (flag → env → config → http).
+        // precedence (flag → env → config → cli).
         let resolution = self.resolve_v2_backend(backend_flag);
         resolve_activity_backends(&mut asset.spec, resolution.backend);
         let resolved_backend = match &asset.spec.spec {

--- a/crates/orbit-core/src/command/backend_resolver.rs
+++ b/crates/orbit-core/src/command/backend_resolver.rs
@@ -5,7 +5,7 @@
 //!   1. `--backend=<value>` CLI flag (explicit invocation-level override).
 //!   2. `ORBIT_BACKEND` env var.
 //!   3. `[runtime] backend = "<value>"` in `config.toml`.
-//!   4. Hard-coded fallback: `Http`.
+//!   4. Hard-coded fallback: `Cli`.
 //!
 //! Called once per run at load time by direct activity helpers and
 //! `orbit job run` entry points. The resolved value is then applied to the
@@ -52,7 +52,7 @@ pub fn resolve_backend_precedence(
 ) -> ResolvedBackend {
     if let Some(backend) = flag_override {
         return ResolvedBackend {
-            backend: concretize(backend, Backend::Http),
+            backend: concretize(backend, Backend::Cli),
             source: BackendSource::Flag,
         };
     }
@@ -60,7 +60,7 @@ pub fn resolve_backend_precedence(
         && let Some(backend) = Backend::parse(raw)
     {
         return ResolvedBackend {
-            backend: concretize(backend, Backend::Http),
+            backend: concretize(backend, Backend::Cli),
             source: BackendSource::Env,
         };
     }
@@ -68,12 +68,12 @@ pub fn resolve_backend_precedence(
         && let Some(backend) = Backend::parse(raw)
     {
         return ResolvedBackend {
-            backend: concretize(backend, Backend::Http),
+            backend: concretize(backend, Backend::Cli),
             source: BackendSource::Config,
         };
     }
     ResolvedBackend {
-        backend: Backend::Http,
+        backend: Backend::Cli,
         source: BackendSource::Default,
     }
 }
@@ -98,5 +98,50 @@ fn concretize(backend: Backend, fallback: Backend) -> Backend {
         Backend::Auto => fallback,
         Backend::Http => Backend::Http,
         Backend::Cli => Backend::Cli,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn missing_config_uses_cli_fallback() {
+        let resolved = resolve_backend_precedence(None, None, None);
+
+        assert_eq!(resolved.backend, Backend::Cli);
+        assert_eq!(resolved.source, BackendSource::Default);
+    }
+
+    #[test]
+    fn auto_config_folds_to_cli_fallback() {
+        let resolved = resolve_backend_precedence(None, None, Some("auto"));
+
+        assert_eq!(resolved.backend, Backend::Cli);
+        assert_eq!(resolved.source, BackendSource::Config);
+    }
+
+    #[test]
+    fn explicit_flag_overrides_env_and_config() {
+        let resolved = resolve_backend_precedence(Some(Backend::Http), Some("cli"), Some("cli"));
+
+        assert_eq!(resolved.backend, Backend::Http);
+        assert_eq!(resolved.source, BackendSource::Flag);
+    }
+
+    #[test]
+    fn explicit_env_overrides_config() {
+        let resolved = resolve_backend_precedence(None, Some("http"), Some("cli"));
+
+        assert_eq!(resolved.backend, Backend::Http);
+        assert_eq!(resolved.source, BackendSource::Env);
+    }
+
+    #[test]
+    fn auto_flag_folds_to_cli_fallback() {
+        let resolved = resolve_backend_precedence(Some(Backend::Auto), Some("http"), Some("http"));
+
+        assert_eq!(resolved.backend, Backend::Cli);
+        assert_eq!(resolved.source, BackendSource::Flag);
     }
 }

--- a/crates/orbit-core/src/config/raw.rs
+++ b/crates/orbit-core/src/config/raw.rs
@@ -58,7 +58,8 @@ pub(super) struct RawKnowledgeConfig {
 #[derive(Debug, Clone, Deserialize)]
 pub(super) struct RawRuntimeSection {
     /// `runtime.backend` — persisted default for the v2 `agent_loop` execution
-    /// backend (§3.1). One of `http`, `cli`, `auto`.
+    /// backend (§3.1). One of `http`, `cli`, `auto`; validated by
+    /// `RuntimeConfig::load_layered`.
     pub(super) backend: Option<String>,
 }
 

--- a/crates/orbit-core/src/config/runtime.rs
+++ b/crates/orbit-core/src/config/runtime.rs
@@ -3,7 +3,7 @@ use std::fs;
 use std::io::Write;
 use std::path::Path;
 
-use orbit_common::types::OrbitError;
+use orbit_common::types::{OrbitError, activity_job::Backend};
 use orbit_common::utility::redaction::redact_home_dir;
 use orbit_engine::PrConfig;
 
@@ -12,7 +12,7 @@ use crate::paths;
 use super::persistence::PersistenceConfig;
 use super::raw::{
     RawAgentRoleConfig, RawCodexExecutionConfig, RawExecutionEnvConfig, RawPrSection,
-    RawRuntimeConfig, RawTaskSection, RawWorkflowConfig,
+    RawRuntimeConfig, RawRuntimeSection, RawTaskSection, RawWorkflowConfig,
 };
 
 const DEFAULT_ENV_INHERIT: bool = false;
@@ -35,7 +35,7 @@ pub(crate) struct RuntimeConfig {
     pub(crate) graph_editing: bool,
     /// Persisted default for the v2 `agent_loop` execution backend (§3.1).
     /// `None` means "not configured"; the resolver falls through to the hard-
-    /// coded `http` default.
+    /// coded `cli` default.
     pub(crate) v2_backend: Option<String>,
     /// Default base branch for ship/ship-auto/duel-plan workflows. Sourced
     /// from `[workflow] base_branch` in `config.toml`; defaults to `"main"`
@@ -134,10 +134,7 @@ impl RuntimeConfig {
             .and_then(|g| g.editing)
             .unwrap_or(DEFAULT_GRAPH_EDITING);
 
-        let v2_backend = parsed
-            .runtime
-            .as_ref()
-            .and_then(|section| section.backend.clone());
+        let v2_backend = runtime_backend_from_raw(parsed.runtime.as_ref())?;
 
         let workflow_base_branch = workflow_base_branch_from_raw(parsed.workflow.as_ref())?;
         let pr = pr_config_from_raw(parsed.pr.as_ref());
@@ -189,6 +186,19 @@ fn pr_config_from_raw(raw: Option<&RawPrSection>) -> PrConfig {
     PrConfig {
         task_url_template: raw.and_then(|section| section.task_url_template.clone()),
     }
+}
+
+fn runtime_backend_from_raw(raw: Option<&RawRuntimeSection>) -> Result<Option<String>, OrbitError> {
+    let Some(value) = raw.and_then(|section| section.backend.as_deref()) else {
+        return Ok(None);
+    };
+    let trimmed = value.trim();
+    let Some(backend) = Backend::parse(trimmed) else {
+        return Err(OrbitError::InvalidInput(format!(
+            "[runtime] backend has invalid value '{trimmed}'; expected one of: http, cli, auto"
+        )));
+    };
+    Ok(Some(backend.as_str().to_string()))
 }
 
 fn workflow_base_branch_from_raw(raw: Option<&RawWorkflowConfig>) -> Result<String, OrbitError> {
@@ -578,5 +588,32 @@ mod tests {
             config.pr_config().task_url_template.as_deref(),
             Some("https://orbit-cli.com/tasks/{task_id}")
         );
+    }
+
+    #[test]
+    fn runtime_backend_loads_auto_from_workspace_config() {
+        let global = tempdir().expect("global tempdir");
+        let workspace = tempdir().expect("workspace tempdir");
+        write_config(workspace.path(), "[runtime]\nbackend = \"auto\"\n");
+
+        let config =
+            RuntimeConfig::load_layered(global.path(), workspace.path()).expect("config loads");
+
+        assert_eq!(config.v2_backend(), Some("auto"));
+    }
+
+    #[test]
+    fn runtime_backend_rejects_invalid_value() {
+        let global = tempdir().expect("global tempdir");
+        let workspace = tempdir().expect("workspace tempdir");
+        write_config(workspace.path(), "[runtime]\nbackend = \"clii\"\n");
+
+        let error = RuntimeConfig::load_layered(global.path(), workspace.path())
+            .expect_err("invalid backend must fail config load");
+        let message = error.to_string();
+
+        assert!(message.contains("[runtime] backend"));
+        assert!(message.contains("clii"));
+        assert!(message.contains("http, cli, auto"));
     }
 }


### PR DESCRIPTION
## Task

[T20260509-45](https://orbit-cli.com/tasks/T20260509-45) — Validate backend config and align the default backend contract

### Description

## Problem
The backend-resolution spec says v1 ships `backend: cli` as the only supported release path and invalid config values reject before dispatch. The code defaults `Backend` and resolver fallback to `Http`, and `RuntimeConfig` stores raw `[runtime] backend` strings without validation; invalid values are silently skipped by `Backend::parse` and fall through.

## Why It Matters
A typo like `backend = "clii"` or a missing non-interactive role config can route production activities toward preview HTTP behavior instead of failing clearly or using the intended v1 CLI path.

## Constraints / Notes
Align the code to the existing accepted spec (v1 CLI fallback). Spec changes are out of scope for this task.

## Scope Restriction
Do not modify anything under `./docs` as part of this task.

### Acceptance Criteria

- Invalid `[runtime] backend` values fail during config load or before dispatch with a clear error naming the bad value.
- The hard fallback in `resolve_backend_precedence` matches the accepted design doc.
- Regression tests cover invalid config, `auto`, missing config, and explicit flag/env overrides.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Defaulted v2 agent_loop backend selection to the v1 CLI release path by making Backend::default and resolve_backend_precedence fallback/auto concretization use cli.
- Validated [runtime] backend during RuntimeConfig load, normalized accepted values, and rejected invalid values with an error naming the bad value.
- Added regression coverage for invalid config, auto, missing config, and explicit flag/env overrides; updated code comments, CLI help text, and the backend precedence smoke to match the CLI fallback.

Assessment: Targeted tests, build, formatting, and full CI pass with test isolation env. Default make ci surfaced unrelated Orbit validation friction; filed T20260509-58 and T20260509-59 for those test-isolation issues.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/T20260509-45-69fec6b3`
- Behind base: 0
- Ahead of base: 1

*authored by: gpt-5.5*