### PR TITLE
Make parallel batch worker timeouts return promptly

### DIFF
--- a/crates/orbit-core/src/runtime/engine/runtime_host.rs
+++ b/crates/orbit-core/src/runtime/engine/runtime_host.rs
@@ -42,6 +42,10 @@ impl RuntimeHost for OrbitRuntime {
         )))
     }
 
+    fn cancel_job_run(&self, run_id: &str) -> Result<(), OrbitError> {
+        OrbitRuntime::cancel_job_run(self, run_id).map(|_| ())
+    }
+
     fn validate_activity_target_exists(
         &self,
         _target_type: JobTargetType,

--- a/crates/orbit-engine/src/context.rs
+++ b/crates/orbit-engine/src/context.rs
@@ -396,6 +396,11 @@ pub trait RuntimeHost {
         input: Value,
         debug: bool,
     ) -> Result<JobRunResult, OrbitError>;
+    fn cancel_job_run(&self, run_id: &str) -> Result<(), OrbitError> {
+        Err(OrbitError::Execution(format!(
+            "cancel_job_run is not implemented for run '{run_id}'"
+        )))
+    }
     fn validate_activity_target_exists(
         &self,
         target_type: JobTargetType,
@@ -826,6 +831,10 @@ impl RuntimeHost for AutomationExecutorHost<'_> {
     ) -> Result<JobRunResult, OrbitError> {
         self.runtime
             .run_job_now_with_input_debug(job_id, input, debug)
+    }
+
+    fn cancel_job_run(&self, run_id: &str) -> Result<(), OrbitError> {
+        self.runtime.cancel_job_run(run_id)
     }
 
     fn validate_activity_target_exists(

--- a/crates/orbit-engine/src/executor/automation/batch/parallel.rs
+++ b/crates/orbit-engine/src/executor/automation/batch/parallel.rs
@@ -1,10 +1,10 @@
 use std::collections::{HashSet, VecDeque};
 use std::path::Path;
-use std::sync::mpsc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
-use orbit_common::types::{JobRunState, OrbitError, Task, TaskStatus};
+use orbit_common::types::{OrbitError, Role, Task, TaskStatus};
 use orbit_common::utility::selector::overlaps;
+use orbit_tools::ToolContext;
 use serde_json::{Value, json};
 
 use super::super::vcs::{
@@ -18,6 +18,8 @@ use crate::context::{
 
 const DEFAULT_PARALLEL_BASE: &str = "main";
 const DEFAULT_PARALLELISM: usize = 4;
+const DEFAULT_WORKER_TIMEOUT_SECS: u64 = 7200;
+const WORKER_WAIT_POLL_SECS: u64 = 1;
 const PARALLEL_WORKER_JOB_ID: &str = "job_parallel_task_worker";
 
 /// Extract the `run_id` from an activity input value, returning a trimmed
@@ -44,9 +46,99 @@ struct PendingTask {
 }
 
 #[derive(Debug)]
-struct WorkerOutcome {
-    task_id: String,
-    result: Result<crate::context::JobRunResult, OrbitError>,
+struct ActiveWorker {
+    task: PendingTask,
+    run_id: String,
+    launched_at: Instant,
+}
+
+#[derive(Debug)]
+struct WorkerObservation {
+    run_id: String,
+    state: WorkerRunState,
+}
+
+#[derive(Debug)]
+enum WorkerRunState {
+    Succeeded,
+    Failed { code: &'static str, message: String },
+    Incomplete,
+}
+
+#[derive(Debug, Default)]
+struct ParallelWorkerSummary {
+    launched: usize,
+    succeeded: usize,
+    failed: usize,
+    failures: Vec<Value>,
+    completed_task_ids: HashSet<String>,
+}
+
+trait ParallelWorkerRunner {
+    fn launch(&self, task_id: &str) -> Result<String, OrbitError>;
+    fn wait(
+        &self,
+        run_ids: &[String],
+        timeout: Duration,
+    ) -> Result<Vec<WorkerObservation>, OrbitError>;
+    fn cancel(&self, run_id: &str) -> Result<(), OrbitError>;
+}
+
+struct PipelineToolWorkerRunner<'a, H: RuntimeHost + ?Sized> {
+    host: &'a H,
+    shared_worktree: &'a str,
+    repo_root: &'a str,
+}
+
+impl<H: RuntimeHost + ?Sized> ParallelWorkerRunner for PipelineToolWorkerRunner<'_, H> {
+    fn launch(&self, task_id: &str) -> Result<String, OrbitError> {
+        let output = self.host.run_tool_with_context_and_role(
+            "orbit.pipeline.invoke",
+            json!({
+                "job_name": PARALLEL_WORKER_JOB_ID,
+                "input": {
+                    "task_id": task_id,
+                    "workspace_path": self.shared_worktree,
+                    "repo_root": self.repo_root,
+                    "verification_mode": "deferred",
+                },
+            }),
+            Role::Admin,
+            ToolContext::default(),
+        )?;
+        output
+            .get("run_id")
+            .and_then(Value::as_str)
+            .map(str::to_string)
+            .ok_or_else(|| {
+                OrbitError::Execution(
+                    "orbit.pipeline.invoke returned no run_id for parallel worker".to_string(),
+                )
+            })
+    }
+
+    fn wait(
+        &self,
+        run_ids: &[String],
+        timeout: Duration,
+    ) -> Result<Vec<WorkerObservation>, OrbitError> {
+        let timeout_seconds = timeout.as_secs().max(1);
+        let output = self.host.run_tool_with_context_and_role(
+            "orbit.pipeline.wait",
+            json!({
+                "run_ids": run_ids,
+                "timeout_seconds": timeout_seconds,
+                "poll_interval_seconds": WORKER_WAIT_POLL_SECS,
+            }),
+            Role::Admin,
+            ToolContext::default(),
+        )?;
+        parse_worker_wait_observations(&output)
+    }
+
+    fn cancel(&self, run_id: &str) -> Result<(), OrbitError> {
+        self.host.cancel_job_run(run_id)
+    }
 }
 
 fn block_failed_parallel_task<H: TaskHost + ?Sized>(
@@ -72,7 +164,7 @@ pub(in crate::executor::automation) fn run_parallel_task_pipeline<
 >(
     host: &H,
     input: &Value,
-    debug: bool,
+    _debug: bool,
 ) -> Result<Value, OrbitError> {
     let base = input
         .get("base")
@@ -83,6 +175,7 @@ pub(in crate::executor::automation) fn run_parallel_task_pipeline<
         .to_string();
     let base_sync_mode = base_sync_mode_from_input(input)?;
     let parallelism = parse_parallelism(input)?;
+    let worker_timeout = parse_worker_timeout(input)?;
     let run_id = require_run_id(input, "parallel_dispatch_tasks")?.to_string();
     let Some(selected_tasks) = load_selected_tasks(host, &run_id)? else {
         // Planning can legitimately drain a batch by returning every selected
@@ -108,173 +201,250 @@ pub(in crate::executor::automation) fn run_parallel_task_pipeline<
     let shared_worktree_str = shared_worktree.to_string_lossy().to_string();
     prepare_tasks_for_worker_launch(host, &selected_tasks, &shared_worktree_str)?;
 
-    let mut pending = VecDeque::from(selected_tasks.clone());
-
-    let mut launched = 0usize;
-    let mut succeeded = 0usize;
-    let mut failed = 0usize;
-    let mut failures = Vec::new();
-    let mut completed_task_ids = HashSet::new();
-
-    let worker_result = std::thread::scope(|scope| -> Result<(), OrbitError> {
-        let (tx, rx) = mpsc::channel::<WorkerOutcome>();
-        let mut active = Vec::<PendingTask>::new();
-
-        while !pending.is_empty() || !active.is_empty() {
-            while active.len() < parallelism {
-                let Some(index) = find_launchable_index(&pending, &active) else {
-                    break;
-                };
-                let task = pending.remove(index).ok_or_else(|| {
-                    OrbitError::Execution(
-                        "parallel dispatch: pending task index out of bounds".to_string(),
-                    )
-                })?;
-                let tx = tx.clone();
-                let task_id = task.task_id.clone();
-                let worker_workspace = shared_worktree_str.clone();
-                let worker_repo_root = repo_root_str.clone();
-                active.push(task);
-                launched += 1;
-
-                scope.spawn(move || {
-                    let result = host.run_job_now_with_input_debug(
-                        PARALLEL_WORKER_JOB_ID,
-                        json!({
-                            "task_id": task_id.clone(),
-                            "workspace_path": worker_workspace,
-                            "repo_root": worker_repo_root,
-                            "verification_mode": "deferred",
-                        }),
-                        debug,
-                    );
-                    let _ = tx.send(WorkerOutcome { task_id, result });
-                });
-            }
-
-            if active.is_empty() {
-                continue;
-            }
-
-            let outcome = match rx.recv_timeout(Duration::from_secs(7200)) {
-                Ok(outcome) => outcome,
-                Err(mpsc::RecvTimeoutError::Timeout) => {
-                    tracing::error!(
-                        target: "orbit.engine.parallel",
-                        timeout_secs = 7200,
-                        "parallel task pipeline timed out waiting for worker; breaking out of receive loop",
-                    );
-                    let timeout_error = "worker timed out after 7200s";
-                    for task in active.drain(..) {
-                        failed += 1;
-                        block_failed_parallel_task(
-                            host,
-                            &task.task_id,
-                            &run_id,
-                            "WORKER_TIMEOUT",
-                            timeout_error,
-                        );
-                        failures.push(json!({
-                            "task_id": task.task_id,
-                            "error": timeout_error,
-                        }));
-                    }
-                    break;
-                }
-                Err(mpsc::RecvTimeoutError::Disconnected) => {
-                    let disconnect_error =
-                        "parallel task pipeline lost worker coordination channel";
-                    for task in active.drain(..) {
-                        block_failed_parallel_task(
-                            host,
-                            &task.task_id,
-                            &run_id,
-                            "WORKER_CHANNEL_DISCONNECTED",
-                            disconnect_error,
-                        );
-                    }
-                    return Err(OrbitError::Execution(disconnect_error.to_string()));
-                }
-            };
-            if let Some(index) = active
-                .iter()
-                .position(|task| task.task_id == outcome.task_id)
-            {
-                active.swap_remove(index);
-            }
-
-            match outcome.result {
-                Ok(result) if result.state == JobRunState::Success => {
-                    completed_task_ids.insert(outcome.task_id);
-                    succeeded += 1;
-                }
-                Ok(result) => {
-                    failed += 1;
-                    let error = format!(
-                        "parallel worker completed in non-success state '{}'",
-                        result.state
-                    );
-                    block_failed_parallel_task(
-                        host,
-                        &outcome.task_id,
-                        &result.run_id,
-                        "WORKER_NON_SUCCESS",
-                        &error,
-                    );
-                    failures.push(json!({
-                        "task_id": outcome.task_id,
-                        "error": error,
-                    }));
-                }
-                Err(error) => {
-                    failed += 1;
-                    let error = error.to_string();
-                    block_failed_parallel_task(
-                        host,
-                        &outcome.task_id,
-                        &run_id,
-                        "WORKER_EXECUTION_ERROR",
-                        &error,
-                    );
-                    failures.push(json!({
-                        "task_id": outcome.task_id,
-                        "error": error,
-                    }));
-                }
-            }
-        }
-
-        Ok(())
-    });
+    let runner = PipelineToolWorkerRunner {
+        host,
+        shared_worktree: &shared_worktree_str,
+        repo_root: &repo_root_str,
+    };
+    let worker_summary = dispatch_parallel_workers(
+        host,
+        &runner,
+        VecDeque::from(selected_tasks.clone()),
+        parallelism,
+        worker_timeout,
+        &run_id,
+    )?;
     // NOTE: Do not restore workspace paths here. Downstream pipeline steps
     // (finalize_tasks, commit_and_open_batch_pr, implement_batch_fix) expect
     // workspace_path to still point to the shared worktree.
-    worker_result?;
 
     let completed_task_ids = selected_tasks
         .into_iter()
         .filter_map(|task| {
-            completed_task_ids
+            worker_summary
+                .completed_task_ids
                 .contains(&task.task_id)
                 .then_some(task.task_id)
         })
         .collect::<Vec<_>>();
 
-    if failed > 0 {
+    if worker_summary.failed > 0 {
         return Err(OrbitError::Execution(format!(
-            "parallel task pipeline failed for {failed} task(s)"
+            "parallel task pipeline failed for {} task(s)",
+            worker_summary.failed
         )));
     }
 
     Ok(json!({
-        "launched": launched,
-        "succeeded": succeeded,
-        "failed": failed,
+        "launched": worker_summary.launched,
+        "succeeded": worker_summary.succeeded,
+        "failed": worker_summary.failed,
         "skipped": 0,
         "workspace_path": shared_worktree_str,
         "completed_task_ids": completed_task_ids,
-        "failures": failures,
+        "failures": worker_summary.failures,
     }))
+}
+
+fn dispatch_parallel_workers<H, R>(
+    host: &H,
+    runner: &R,
+    mut pending: VecDeque<PendingTask>,
+    parallelism: usize,
+    worker_timeout: Duration,
+    batch_run_id: &str,
+) -> Result<ParallelWorkerSummary, OrbitError>
+where
+    H: TaskHost + ?Sized,
+    R: ParallelWorkerRunner + ?Sized,
+{
+    let mut active = Vec::<ActiveWorker>::new();
+    let mut summary = ParallelWorkerSummary::default();
+
+    while !pending.is_empty() || !active.is_empty() {
+        while active.len() < parallelism {
+            let Some(index) = find_launchable_index(&pending, active_tasks(&active).as_slice())
+            else {
+                break;
+            };
+            let task = pending.remove(index).ok_or_else(|| {
+                OrbitError::Execution(
+                    "parallel dispatch: pending task index out of bounds".to_string(),
+                )
+            })?;
+            let run_id = match runner.launch(&task.task_id) {
+                Ok(run_id) => run_id,
+                Err(error) => {
+                    let error = error.to_string();
+                    block_failed_parallel_task(
+                        host,
+                        &task.task_id,
+                        batch_run_id,
+                        "WORKER_LAUNCH_FAILED",
+                        &error,
+                    );
+                    summary.failed += 1;
+                    summary.failures.push(json!({
+                        "task_id": task.task_id,
+                        "error": error,
+                    }));
+                    break;
+                }
+            };
+            active.push(ActiveWorker {
+                task,
+                run_id,
+                launched_at: Instant::now(),
+            });
+            summary.launched += 1;
+        }
+
+        if active.is_empty() {
+            continue;
+        }
+
+        if timeout_active_workers(
+            host,
+            runner,
+            &mut active,
+            &mut summary,
+            worker_timeout,
+            batch_run_id,
+        ) {
+            break;
+        }
+
+        let run_ids = active
+            .iter()
+            .map(|worker| worker.run_id.clone())
+            .collect::<Vec<_>>();
+        let observations =
+            runner.wait(&run_ids, next_worker_wait_duration(&active, worker_timeout))?;
+        apply_worker_observations(host, &mut active, &mut summary, observations)?;
+
+        if timeout_active_workers(
+            host,
+            runner,
+            &mut active,
+            &mut summary,
+            worker_timeout,
+            batch_run_id,
+        ) {
+            break;
+        }
+    }
+
+    Ok(summary)
+}
+
+fn active_tasks(active: &[ActiveWorker]) -> Vec<PendingTask> {
+    active.iter().map(|worker| worker.task.clone()).collect()
+}
+
+fn next_worker_wait_duration(active: &[ActiveWorker], worker_timeout: Duration) -> Duration {
+    active
+        .iter()
+        .map(|worker| worker_timeout.saturating_sub(worker.launched_at.elapsed()))
+        .min()
+        .unwrap_or(worker_timeout)
+        .min(Duration::from_secs(WORKER_WAIT_POLL_SECS))
+        .max(Duration::from_millis(1))
+}
+
+fn apply_worker_observations<H: TaskHost + ?Sized>(
+    host: &H,
+    active: &mut Vec<ActiveWorker>,
+    summary: &mut ParallelWorkerSummary,
+    observations: Vec<WorkerObservation>,
+) -> Result<(), OrbitError> {
+    for observation in observations {
+        let Some(index) = active
+            .iter()
+            .position(|worker| worker.run_id == observation.run_id)
+        else {
+            continue;
+        };
+        match observation.state {
+            WorkerRunState::Succeeded => {
+                let worker = active.swap_remove(index);
+                summary.completed_task_ids.insert(worker.task.task_id);
+                summary.succeeded += 1;
+            }
+            WorkerRunState::Failed { code, message } => {
+                let worker = active.swap_remove(index);
+                block_failed_parallel_task(
+                    host,
+                    &worker.task.task_id,
+                    &worker.run_id,
+                    code,
+                    &message,
+                );
+                summary.failed += 1;
+                summary.failures.push(json!({
+                    "task_id": worker.task.task_id,
+                    "run_id": worker.run_id,
+                    "error": message,
+                }));
+            }
+            WorkerRunState::Incomplete => {}
+        }
+    }
+    Ok(())
+}
+
+fn timeout_active_workers<H, R>(
+    host: &H,
+    runner: &R,
+    active: &mut Vec<ActiveWorker>,
+    summary: &mut ParallelWorkerSummary,
+    worker_timeout: Duration,
+    batch_run_id: &str,
+) -> bool
+where
+    H: TaskHost + ?Sized,
+    R: ParallelWorkerRunner + ?Sized,
+{
+    if !active
+        .iter()
+        .any(|worker| worker.launched_at.elapsed() >= worker_timeout)
+    {
+        return false;
+    }
+
+    tracing::error!(
+        target: "orbit.engine.parallel",
+        timeout_secs = worker_timeout.as_secs(),
+        "parallel task pipeline timed out waiting for worker; cancelling active workers",
+    );
+    let timeout_error = format!(
+        "worker timed out after {}s",
+        worker_timeout.as_secs().max(1)
+    );
+    for worker in active.drain(..) {
+        if let Err(error) = runner.cancel(&worker.run_id) {
+            tracing::warn!(
+                target: "orbit.engine.parallel",
+                run_id = %worker.run_id,
+                error = %error,
+                "failed to cancel timed-out parallel worker run",
+            );
+        }
+        summary.failed += 1;
+        block_failed_parallel_task(
+            host,
+            &worker.task.task_id,
+            batch_run_id,
+            "WORKER_TIMEOUT",
+            &timeout_error,
+        );
+        summary.failures.push(json!({
+            "task_id": worker.task.task_id,
+            "run_id": worker.run_id,
+            "error": timeout_error,
+        }));
+    }
+
+    true
 }
 
 impl From<Task> for PendingTask {
@@ -384,6 +554,77 @@ pub(super) fn parse_parallelism(input: &Value) -> Result<usize, OrbitError> {
         .ok_or_else(|| OrbitError::InvalidInput("parallelism must be at least 1".to_string()))
 }
 
+fn parse_worker_timeout(input: &Value) -> Result<Duration, OrbitError> {
+    let Some(value) = input.get("worker_timeout_seconds") else {
+        return Ok(Duration::from_secs(DEFAULT_WORKER_TIMEOUT_SECS));
+    };
+    let seconds = value.as_u64().ok_or_else(|| {
+        OrbitError::InvalidInput("worker_timeout_seconds must be a positive integer".to_string())
+    })?;
+    if seconds == 0 {
+        return Err(OrbitError::InvalidInput(
+            "worker_timeout_seconds must be at least 1".to_string(),
+        ));
+    }
+    Ok(Duration::from_secs(seconds))
+}
+
+fn parse_worker_wait_observations(output: &Value) -> Result<Vec<WorkerObservation>, OrbitError> {
+    let results = output
+        .get("results")
+        .and_then(Value::as_array)
+        .ok_or_else(|| {
+            OrbitError::Execution("orbit.pipeline.wait returned no results array".to_string())
+        })?;
+    results
+        .iter()
+        .map(|entry| {
+            let run_id = entry
+                .get("run_id")
+                .and_then(Value::as_str)
+                .ok_or_else(|| {
+                    OrbitError::Execution(
+                        "orbit.pipeline.wait result entry has no run_id".to_string(),
+                    )
+                })?
+                .to_string();
+            let status = entry.get("status").and_then(Value::as_str).ok_or_else(|| {
+                OrbitError::Execution(format!(
+                    "orbit.pipeline.wait result for run '{run_id}' has no status"
+                ))
+            })?;
+            let state = match status {
+                "succeeded" => WorkerRunState::Succeeded,
+                "failed" => WorkerRunState::Failed {
+                    code: "WORKER_NON_SUCCESS",
+                    message: worker_failure_message(entry, status),
+                },
+                "cancelled" => WorkerRunState::Failed {
+                    code: "WORKER_CANCELLED",
+                    message: worker_failure_message(entry, status),
+                },
+                "pending" | "running" | "timeout" => WorkerRunState::Incomplete,
+                other => {
+                    return Err(OrbitError::Execution(format!(
+                        "orbit.pipeline.wait returned unknown status '{other}' for run '{run_id}'"
+                    )));
+                }
+            };
+            Ok(WorkerObservation { run_id, state })
+        })
+        .collect()
+}
+
+fn worker_failure_message(entry: &Value, status: &str) -> String {
+    entry
+        .get("error")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
+        .unwrap_or_else(|| format!("parallel worker completed with status '{status}'"))
+}
+
 fn find_launchable_index(pending: &VecDeque<PendingTask>, active: &[PendingTask]) -> Option<usize> {
     pending.iter().position(|candidate| {
         !active
@@ -423,7 +664,21 @@ fn paths_conflict(left: &str, right: &str) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::tasks_conflict;
+    use super::*;
+
+    use std::fs;
+    use std::path::{Path, PathBuf};
+    use std::process::Command;
+    use std::sync::Mutex;
+
+    use chrono::Utc;
+    use orbit_common::types::{
+        Activity, ExternalRef, Job, JobTargetType, OrbitEvent, TaskArtifact, TaskComment,
+        TaskPriority, TaskType,
+    };
+
+    use crate::context::{TaskReadHost, TaskWriteHost};
+    use crate::executor::registry::ActivityExecutorRegistry;
 
     #[test]
     fn tasks_conflict_uses_selector_anchor_overlap() {
@@ -439,5 +694,413 @@ mod tests {
             &["file:f.rs".to_string()],
             &["file:g.rs".to_string()]
         ));
+    }
+
+    #[test]
+    fn parallel_pipeline_timeout_cancels_never_returning_worker_promptly() {
+        let repo = init_git_repo();
+        let batch_id = "jrun-never-returning-worker";
+        let host = ParallelTimeoutTestHost::new(
+            repo.path().to_path_buf(),
+            vec![task_with_batch("T-timeout", batch_id)],
+        );
+
+        let started = Instant::now();
+        let result = run_parallel_task_pipeline(
+            &host,
+            &json!({
+                "run_id": batch_id,
+                "base": "main",
+                "base_sync": "local",
+                "parallelism": 1,
+                "worker_timeout_seconds": 1,
+            }),
+            false,
+        );
+        let elapsed = started.elapsed();
+
+        let error = result.expect_err("hung worker should fail the batch");
+        assert!(
+            error
+                .to_string()
+                .contains("parallel task pipeline failed for 1 task(s)")
+        );
+        assert!(
+            elapsed < Duration::from_secs(4),
+            "timeout path should return promptly; elapsed={elapsed:?}"
+        );
+        assert_eq!(host.cancelled_runs(), vec!["worker-run-1".to_string()]);
+
+        let events = host.events();
+        let cancel_position = events
+            .iter()
+            .position(|event| event == "cancel:worker-run-1")
+            .expect("worker run should be cancelled");
+        let block_position = events
+            .iter()
+            .position(|event| event.starts_with("block:T-timeout:"))
+            .expect("timed-out task should be blocked");
+        assert!(
+            cancel_position < block_position,
+            "timed-out worker should be cancelled before recording failure"
+        );
+
+        let task = host.get_task("T-timeout").expect("task after timeout");
+        assert_eq!(task.status, TaskStatus::Blocked);
+        assert!(
+            task.workspace_path
+                .as_deref()
+                .is_some_and(|path| path.contains("parallel-batch"))
+        );
+    }
+
+    struct ParallelTimeoutTestHost {
+        repo_root: PathBuf,
+        data_root: PathBuf,
+        scoreboard_dir: PathBuf,
+        registry: ActivityExecutorRegistry,
+        tasks: Mutex<Vec<Task>>,
+        next_run: Mutex<usize>,
+        cancelled_runs: Mutex<Vec<String>>,
+        events: Mutex<Vec<String>>,
+    }
+
+    impl ParallelTimeoutTestHost {
+        fn new(repo_root: PathBuf, tasks: Vec<Task>) -> Self {
+            let data_root = repo_root.join(".orbit");
+            let scoreboard_dir = data_root.join("state").join("scoreboard");
+            Self {
+                repo_root,
+                data_root,
+                scoreboard_dir,
+                registry: ActivityExecutorRegistry::default(),
+                tasks: Mutex::new(tasks),
+                next_run: Mutex::new(1),
+                cancelled_runs: Mutex::new(Vec::new()),
+                events: Mutex::new(Vec::new()),
+            }
+        }
+
+        fn cancelled_runs(&self) -> Vec<String> {
+            self.cancelled_runs
+                .lock()
+                .expect("cancelled runs lock")
+                .clone()
+        }
+
+        fn events(&self) -> Vec<String> {
+            self.events.lock().expect("events lock").clone()
+        }
+    }
+
+    impl TaskReadHost for ParallelTimeoutTestHost {
+        fn get_task(&self, task_id: &str) -> Result<Task, OrbitError> {
+            self.tasks
+                .lock()
+                .expect("tasks lock")
+                .iter()
+                .find(|task| task.id == task_id)
+                .cloned()
+                .ok_or_else(|| OrbitError::TaskNotFound(task_id.to_string()))
+        }
+
+        fn get_task_artifacts(&self, _task_id: &str) -> Result<Vec<TaskArtifact>, OrbitError> {
+            Ok(Vec::new())
+        }
+
+        fn list_tasks_filtered(
+            &self,
+            status: Option<TaskStatus>,
+            priority: Option<TaskPriority>,
+            parent_id: Option<&str>,
+            batch_id: Option<&str>,
+            external_ref: Option<&ExternalRef>,
+            has_external_ref_system: Option<&str>,
+        ) -> Result<Vec<Task>, OrbitError> {
+            Ok(self
+                .tasks
+                .lock()
+                .expect("tasks lock")
+                .iter()
+                .filter(|task| status.is_none_or(|status| task.status == status))
+                .filter(|task| priority.is_none_or(|priority| task.priority == priority))
+                .filter(|task| {
+                    parent_id.is_none_or(|parent_id| task.parent_id.as_deref() == Some(parent_id))
+                })
+                .filter(|task| {
+                    batch_id.is_none_or(|batch_id| task.batch_id.as_deref() == Some(batch_id))
+                })
+                .filter(|task| {
+                    external_ref.is_none_or(|external_ref| {
+                        task.external_refs.iter().any(|candidate| {
+                            candidate.system == external_ref.system
+                                && candidate.id == external_ref.id
+                        })
+                    })
+                })
+                .filter(|task| {
+                    has_external_ref_system.is_none_or(|system| {
+                        task.external_refs
+                            .iter()
+                            .any(|candidate| candidate.system == system)
+                    })
+                })
+                .cloned()
+                .collect())
+        }
+    }
+
+    impl TaskWriteHost for ParallelTimeoutTestHost {
+        fn start_task(
+            &self,
+            _task_id: &str,
+            _note: Option<String>,
+            _comment: Option<String>,
+        ) -> Result<Task, OrbitError> {
+            Err(OrbitError::Execution(
+                "start_task is not needed by parallel timeout tests".to_string(),
+            ))
+        }
+
+        fn admit_task_for_workflow(
+            &self,
+            _task_id: &str,
+            _workflow: &str,
+        ) -> Result<Task, OrbitError> {
+            Err(OrbitError::Execution(
+                "admit_task_for_workflow is not needed by parallel timeout tests".to_string(),
+            ))
+        }
+
+        fn update_task_from_activity(
+            &self,
+            _task_id: &str,
+            _status: TaskStatus,
+            _execution_summary: Option<String>,
+            _comment: Option<String>,
+            _note: Option<String>,
+        ) -> Result<Task, OrbitError> {
+            Err(OrbitError::Execution(
+                "update_task_from_activity is not needed by parallel timeout tests".to_string(),
+            ))
+        }
+
+        fn apply_task_automation_update(
+            &self,
+            task_id: &str,
+            update: TaskAutomationUpdate,
+        ) -> Result<(), OrbitError> {
+            let mut tasks = self.tasks.lock().expect("tasks lock");
+            let task = tasks
+                .iter_mut()
+                .find(|task| task.id == task_id)
+                .ok_or_else(|| OrbitError::TaskNotFound(task_id.to_string()))?;
+            if let Some(status) = update.status {
+                task.status = status;
+                if status == TaskStatus::Blocked {
+                    self.events.lock().expect("events lock").push(format!(
+                        "block:{task_id}:{}",
+                        update.status_note.unwrap_or_default()
+                    ));
+                }
+            }
+            if let Some(workspace_path) = update.workspace_path {
+                task.workspace_path = workspace_path;
+            }
+            if let Some(execution_summary) = update.execution_summary {
+                task.execution_summary = execution_summary;
+            }
+            task.updated_at = Utc::now();
+            Ok(())
+        }
+    }
+
+    impl RuntimeHost for ParallelTimeoutTestHost {
+        fn record_event(&self, _event: OrbitEvent) -> Result<(), OrbitError> {
+            Ok(())
+        }
+
+        fn repo_root(&self) -> Result<String, OrbitError> {
+            Ok(self.repo_root.to_string_lossy().to_string())
+        }
+
+        fn data_root(&self) -> &Path {
+            &self.data_root
+        }
+
+        fn activity_executor_registry(&self) -> &ActivityExecutorRegistry {
+            &self.registry
+        }
+
+        fn run_job_now_with_input_debug(
+            &self,
+            _job_id: &str,
+            _input: Value,
+            _debug: bool,
+        ) -> Result<crate::context::JobRunResult, OrbitError> {
+            panic!("parallel timeout path must not use the legacy scoped worker runner")
+        }
+
+        fn cancel_job_run(&self, run_id: &str) -> Result<(), OrbitError> {
+            self.cancelled_runs
+                .lock()
+                .expect("cancelled runs lock")
+                .push(run_id.to_string());
+            self.events
+                .lock()
+                .expect("events lock")
+                .push(format!("cancel:{run_id}"));
+            Ok(())
+        }
+
+        fn validate_activity_target_exists(
+            &self,
+            _target_type: JobTargetType,
+            _target_id: &str,
+        ) -> Result<Activity, OrbitError> {
+            Err(OrbitError::Execution(
+                "validate_activity_target_exists is not needed by parallel timeout tests"
+                    .to_string(),
+            ))
+        }
+
+        fn get_job(&self, _job_id: &str) -> Result<Option<Job>, OrbitError> {
+            Ok(None)
+        }
+
+        fn run_tool_with_context_and_role(
+            &self,
+            name: &str,
+            input: Value,
+            _role: Role,
+            _tool_context: ToolContext,
+        ) -> Result<Value, OrbitError> {
+            match name {
+                "orbit.pipeline.invoke" => {
+                    assert_eq!(input["job_name"], PARALLEL_WORKER_JOB_ID);
+                    let mut next_run = self.next_run.lock().expect("next run lock");
+                    let run_id = format!("worker-run-{next_run}");
+                    *next_run += 1;
+                    self.events
+                        .lock()
+                        .expect("events lock")
+                        .push(format!("invoke:{run_id}"));
+                    Ok(json!({
+                        "run_id": run_id,
+                        "job_name": PARALLEL_WORKER_JOB_ID,
+                    }))
+                }
+                "orbit.pipeline.wait" => {
+                    std::thread::sleep(Duration::from_millis(25));
+                    let run_ids = input
+                        .get("run_ids")
+                        .and_then(Value::as_array)
+                        .ok_or_else(|| OrbitError::InvalidInput("missing run_ids".to_string()))?;
+                    Ok(json!({
+                        "results": run_ids.iter().map(|run_id| {
+                            json!({
+                                "run_id": run_id.as_str().expect("run id string"),
+                                "status": "running",
+                            })
+                        }).collect::<Vec<_>>()
+                    }))
+                }
+                other => Err(OrbitError::ToolNotFound(other.to_string())),
+            }
+        }
+
+        fn maybe_create_failure_task(
+            &self,
+            _job_id: &str,
+            _run_id: &str,
+            _error_code: &str,
+            _error_message: &str,
+            _agent: Option<&str>,
+            _model: Option<&str>,
+        ) -> Result<(), OrbitError> {
+            Ok(())
+        }
+
+        fn scoring_enabled(&self) -> bool {
+            false
+        }
+
+        fn graph_editing(&self) -> bool {
+            false
+        }
+
+        fn scoreboard_dir(&self) -> &Path {
+            &self.scoreboard_dir
+        }
+    }
+
+    fn task_with_batch(id: &str, batch_id: &str) -> Task {
+        let now = Utc::now();
+        Task {
+            id: id.to_string(),
+            parent_id: None,
+            title: "Never returning parallel worker".to_string(),
+            description: "Exercise timeout handling.".to_string(),
+            acceptance_criteria: Vec::new(),
+            dependencies: Vec::new(),
+            plan: String::new(),
+            execution_summary: String::new(),
+            context_files: vec![format!("file:{id}.rs")],
+            workspace_path: None,
+            repo_root: None,
+            created_by: Some("test".to_string()),
+            planned_by: None,
+            implemented_by: None,
+            agent: None,
+            model: None,
+            status: TaskStatus::Backlog,
+            priority: TaskPriority::Medium,
+            complexity: None,
+            task_type: TaskType::Bug,
+            pr_status: None,
+            external_refs: Vec::new(),
+            source_task_id: None,
+            batch_id: Some(batch_id.to_string()),
+            comments: Vec::<TaskComment>::new(),
+            history: Vec::new(),
+            review_threads: Vec::new(),
+            created_at: now,
+            updated_at: now,
+        }
+    }
+
+    fn init_git_repo() -> tempfile::TempDir {
+        let dir = tempfile::tempdir().expect("temp repo");
+        run_git(dir.path(), &["init"]);
+        run_git(dir.path(), &["checkout", "-b", "main"]);
+        fs::write(dir.path().join("README.md"), "parallel timeout test\n").expect("write file");
+        run_git(dir.path(), &["add", "README.md"]);
+        run_git(
+            dir.path(),
+            &[
+                "-c",
+                "user.name=Orbit Test",
+                "-c",
+                "user.email=orbit-test@example.invalid",
+                "commit",
+                "-m",
+                "init",
+            ],
+        );
+        dir
+    }
+
+    fn run_git(repo: &Path, args: &[&str]) {
+        let output = Command::new("git")
+            .args(args)
+            .current_dir(repo)
+            .output()
+            .expect("git command");
+        assert!(
+            output.status.success(),
+            "git {} failed: {}",
+            args.join(" "),
+            String::from_utf8_lossy(&output.stderr)
+        );
     }
 }

--- a/docs/design/activity-job/2_design.md
+++ b/docs/design/activity-job/2_design.md
@@ -2,7 +2,7 @@
 
 **Status:** Draft
 **Owner:** codex
-**Last updated:** 2026-05-09 (T20260427-34, T20260427-36, T20260427-38, T20260427-40, T20260508-3, T20260508-8, T20260509-2, T20260509-7, T20260509-9, T20260509-11, T20260509-30, T20260509-40)
+**Last updated:** 2026-05-09 (T20260427-34, T20260427-36, T20260427-38, T20260427-40, T20260508-3, T20260508-8, T20260509-2, T20260509-7, T20260509-9, T20260509-11, T20260509-30, T20260509-38, T20260509-40)
 
 This document describes the shipped Activity / Job substrate across `orbit-common`, `orbit-engine`, `orbit-core`, and `orbit-cli`: asset shape, normalization, dispatch boundaries, backend semantics, DAG execution, audit, and retained legacy edges. See [1_overview.md](./1_overview.md) for purpose and [3_vision.md](./3_vision.md) for open questions.
 
@@ -417,6 +417,7 @@ This feature spans a migration, so the retained surfaces are explicit.
 | v2 `agent_loop` CLI path | Kept | Implemented by the retained `AgentRuntime` trait and `providers/*_cli.rs` after [T20260419-0104]. |
 | `TargetRef` authoring form | Kept at authoring/load time only | Human-friendly YAML surface; resolved away before execution since [T20260418-2019]. |
 | v1 `crate::job_runner` | Kept | Older sequential/DAG runtime still exists beside the v2 executor; Phase 3 was additive in [T20260418-2018]. |
+| Legacy `run_parallel_task_pipeline` | Kept behind automation | After [T20260509-38], its workers are launched as durable pipeline runs and waited through `orbit.pipeline.wait`; timeouts cancel active child runs before blocking timed-out tasks, so the parent no longer waits on never-returning scoped threads. |
 | Seeded reference activities and jobs | Kept | They act as runnable contracts and examples, and were moved into init seeding in [T20260419-2347]. |
 | Groundhog as a dedicated activity kind | Kept | Explicit sibling activity after [T20260420-0510-2], not an `agent_loop` toggle. |
 
@@ -532,6 +533,7 @@ Read-only history does not need the same dependencies as live execution. [T20260
 - **[T20260509-7]** — Establish focused test coverage for the activity/job DAG executor (linear, retry, parallel, fan-out, loop, pipeline durability) and the macOS sandbox / policy boundary.
 - **[T20260509-11]** — Keep condition guards on equality-only grammar and repair the `ship-auto` empty-backlog guard.
 - **[T20260509-30]** — Resolve the macOS `sandbox-exec` wrapper from a trusted absolute path before CLI spawn.
+- **[T20260509-38]** — Run legacy parallel-batch workers through cancellable pipeline runs so timeout failure paths return promptly.
 - **[T20260509-40]** — Run CLI subprocesses in killable process groups and bound timeout-path output reader joins.
 
 > Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.

--- a/docs/design/activity-job/4_decisions.md
+++ b/docs/design/activity-job/4_decisions.md
@@ -2,7 +2,7 @@
 
 **Status:** Draft
 **Owner:** codex
-**Last updated:** 2026-05-09 (T20260427-34, T20260427-36, T20260427-38, T20260427-40, T20260508-3, T20260508-8, T20260509-2, T20260509-7, T20260509-9, T20260509-11, T20260509-40)
+**Last updated:** 2026-05-09 (T20260427-34, T20260427-36, T20260427-38, T20260427-40, T20260508-3, T20260508-8, T20260509-2, T20260509-7, T20260509-9, T20260509-11, T20260509-38, T20260509-40)
 
 This ADR log records the decisions that define the current Activity / Job substrate. Entries are append-only and stay in place when later ADRs supersede or fold them. See [1_overview.md](./1_overview.md) for the feature summary, [2_design.md](./2_design.md) for the current implementation, and [3_vision.md](./3_vision.md) for the questions that may force more decisions.
 
@@ -512,6 +512,19 @@ The plumbing adds a single optional field to `TaskAutomationUpdate` (`context_fi
 - Output capture still preserves partial stdout/stderr bytes already drained before timeout, even if a reader thread does not finish within the bounded join window.
 - Cost: Unix process groups do not cover descendants that deliberately create a new session/process group, and non-Unix platforms still use the immediate-child fallback until an equivalent tree-kill primitive is added.
 
+## ADR-051 — Legacy parallel-batch workers use cancellable runs
+
+**Status:** Accepted · 2026-05 · [T20260509-38]
+
+**Context.** The retained `run_parallel_task_pipeline` automation path used scoped threads to call `run_job_now_with_input_debug`, then marked active workers failed after a long receive timeout. Rust scoped threads still join before the scope exits, so a never-returning worker could keep the parent dispatcher hung even after timeout failure recording.
+
+**Decision.** Launch each legacy parallel-batch worker through the durable pipeline surface (`orbit.pipeline.invoke`) and poll active run IDs through `orbit.pipeline.wait` instead of owning scoped worker threads. When the configured worker timeout elapses, the dispatcher cancels every active child run before writing `WORKER_TIMEOUT` task failure state and returning the batch failure.
+
+**Consequences.**
+- Timeout return no longer depends on the worker's thread or agent process eventually exiting.
+- Timed-out child work gets the same run-cancellation path operators use elsewhere, including bounded process-group signaling for running pipeline workers.
+- Cost: the retained legacy path now depends on the v2 pipeline tool surface and polls active workers, so completion can lag by the polling interval rather than waking on an in-process channel send.
+
 ---
 
 ## Task References
@@ -577,6 +590,7 @@ The plumbing adds a single optional field to `TaskAutomationUpdate` (`context_fi
 - **[T20260509-7]** — Establish focused test coverage for the activity/job DAG executor (linear, retry, parallel, fan-out, loop, pipeline durability) and the macOS sandbox / policy boundary.
 - **[T20260509-9]** — Auto-populate `task.context_files` from the winning planning-duel plan after resolution.
 - **[T20260509-11]** — Keep condition guards on equality-only grammar and repair the `ship-auto` empty-backlog guard.
+- **[T20260509-38]** — Run legacy parallel-batch workers through cancellable pipeline runs so timeout failure paths return promptly.
 - **[T20260509-40]** — Run CLI subprocesses in killable process groups and bound timeout-path output reader joins.
 
 > Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.


### PR DESCRIPTION
## Task

[T20260509-38](https://orbit-cli.com/tasks/T20260509-38) — Make parallel batch worker timeouts return promptly

### Description

## Problem
`run_parallel_task_pipeline` spawns workers inside `std::thread::scope` and uses `recv_timeout(7200s)` to mark active workers failed. Exiting the scoped-thread block still waits for all spawned workers to finish, so a hung `run_job_now_with_input_debug` worker prevents the timeout path from returning.

## Why It Matters
The dispatcher can hang beyond its own timeout and leave operators with a stuck batch even after Orbit records worker timeout failures.

## Constraints / Notes
If worker cancellation is not available, isolate workers in a cancellable process/job-run boundary rather than scoped threads.

### Acceptance Criteria

- The timeout path returns promptly after the configured worker timeout without waiting for a never-returning worker thread.
- Late worker writes are prevented or safely ignored after timeout failure is recorded.
- A regression test uses a never-returning fake worker and proves the parent function returns within a bounded test duration.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Replaced legacy scoped-thread parallel batch worker execution with durable pipeline child runs launched via orbit.pipeline.invoke and polled through orbit.pipeline.wait.
- Added RuntimeHost cancellation plumbing so timed-out worker runs are cancelled before WORKER_TIMEOUT task failure state is recorded.
- Added a regression test with a never-finishing fake worker proving the dispatcher returns within a bounded duration and requests cancellation.
- Updated Activity / Job design docs and ADR-050 for the retained legacy parallel-batch timeout contract.

Assessment: Focused implementation with full workspace validation passing.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/T20260509-38-69fec5d1`
- Behind base: 0
- Ahead of base: 1

*authored by: gpt-5.5*