### PR TITLE
Support boolean literals in v2 `when` and `break_when` expressions

### DIFF
--- a/crates/orbit-engine/src/activity_job/job_executor/tests/step_tests.rs
+++ b/crates/orbit-engine/src/activity_job/job_executor/tests/step_tests.rs
@@ -19,6 +19,36 @@ fn linear_step_success_propagates_output_to_pipeline() {
 }
 
 #[test]
+fn when_false_literal_skips_step_without_failing_job() {
+    let host = ScriptedHost::new([("disabled", vec![Action::Ok(json!({"ran": true}))])]);
+    let mut skipped = target_step("safety", "disabled");
+    skipped.when = Some("false".to_string());
+    let job = job_with_steps(vec![skipped]);
+    let writer = std::sync::Arc::new(test_writer("run-when-false-literal"));
+
+    let outcome = execute_job(
+        &job,
+        Value::Null,
+        "run-when-false-literal",
+        writer.clone(),
+        &host,
+    )
+    .expect("when:false should skip cleanly");
+
+    assert!(outcome.success);
+    assert_eq!(host.call_count("disabled"), 0, "skipped step must not run");
+    let events = writer.events_snapshot().expect("audit");
+    assert!(
+        events.iter().any(|event| matches!(
+            &event.kind,
+            V2AuditEventKind::StepSkipped { step_id, reason }
+                if step_id == "safety" && reason == "when:false => false"
+        )),
+        "expected StepSkipped audit event for when:false"
+    );
+}
+
+#[test]
 fn step_failure_short_circuits_remaining_steps() {
     // Invariant: a failed step terminates the linear loop in `execute_job`
     // (mod.rs:131-148). Without retry/recovery, a retryable

--- a/crates/orbit-engine/src/job_runner/condition.rs
+++ b/crates/orbit-engine/src/job_runner/condition.rs
@@ -3,7 +3,7 @@
 //! Evaluates `StepCondition::Expr` strings against a `TemplateContext`.
 //!
 //! Expression syntax (post template resolution):
-//!   `<lhs> == <rhs>` | `<lhs> != <rhs>`
+//!   `true` | `false` | `<lhs> == <rhs>` | `<lhs> != <rhs>`
 //!   Combined with `&&` (AND, higher precedence) and `||` (OR).
 //!
 //! Examples:
@@ -51,7 +51,8 @@ pub fn evaluate_bool_expr(expr: &str, ctx: &TemplateContext) -> Result<bool, Orb
 ///   expr     = or_expr
 ///   or_expr  = and_expr ('||' and_expr)*
 ///   and_expr = atom ('&&' atom)*
-///   atom     = value ('==' | '!=') value
+///   atom     = boolean-literal | value ('==' | '!=') value
+///   boolean-literal = 'true' | 'false'
 ///   value    = non-whitespace token (unquoted)
 fn evaluate_expr(resolved: &str) -> Result<bool, OrbitError> {
     let or_groups: Vec<&str> = split_keep_delim(resolved, "||");
@@ -82,7 +83,11 @@ fn split_keep_delim<'a>(input: &'a str, delim: &str) -> Vec<&'a str> {
 
 /// Evaluate a single comparison atom: `<lhs> == <rhs>` or `<lhs> != <rhs>`.
 fn evaluate_atom(atom: &str) -> Result<bool, OrbitError> {
-    if let Some((lhs, rhs)) = atom.split_once("!=") {
+    if atom == "true" {
+        Ok(true)
+    } else if atom == "false" {
+        Ok(false)
+    } else if let Some((lhs, rhs)) = atom.split_once("!=") {
         // Check != before == to avoid matching the = inside !=
         // But we need to be careful: "a != b" should match here, not "a !" + "= b"
         // split_once on "!=" is correct since != is a 2-char sequence.
@@ -91,7 +96,7 @@ fn evaluate_atom(atom: &str) -> Result<bool, OrbitError> {
         Ok(lhs.trim() == rhs.trim())
     } else {
         Err(OrbitError::InvalidInput(format!(
-            "condition atom must contain '==' or '!=', got: '{atom}'"
+            "condition atom must be 'true', 'false', or contain '==' or '!=', got: '{atom}'"
         )))
     }
 }
@@ -136,6 +141,16 @@ mod tests {
         )
         .unwrap();
         assert!(!result);
+    }
+
+    #[test]
+    fn test_boolean_literals() {
+        let ctx = TemplateContext::default();
+
+        assert!(evaluate_bool_expr("true", &ctx).unwrap());
+        assert!(!evaluate_bool_expr("false", &ctx).unwrap());
+        assert!(evaluate_expr("false || true && true").unwrap());
+        assert!(!evaluate_expr("true && false || false").unwrap());
     }
 
     #[test]


### PR DESCRIPTION
## Task

[T20260509-25](https://orbit-cli.com/tasks/T20260509-25) — Support boolean literals in v2 `when` and `break_when` expressions

### Description

## Problem
The condition evaluator only accepts comparison atoms containing `==` or `!=`, but `crates/orbit-core/assets/jobs/examples/task_pipeline.yaml` uses `when: "false"` to guard a disabled failure-safety step. That expression currently evaluates as an error rather than a clean skipped step.

## Why It Matters
Job YAML that uses a straightforward boolean guard can fail the workflow instead of skipping the step. The default examples should be executable as authored.

## Constraints / Notes
Keep existing comparison behavior and precedence; add literal booleans without turning the evaluator into an unsafe general expression language.

## Scope Restriction
Do not modify anything under `./docs` as part of this task.

### Acceptance Criteria

- `evaluate_bool_expr("false", ctx)` returns `Ok(false)` and `evaluate_bool_expr("true", ctx)` returns `Ok(true)`.
- A job step with `when: "false"` emits `StepSkipped` and does not fail the job.
- Existing comparison, `&&`, and `||` tests continue to pass under `make test -p orbit-engine`.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Added exact `true` and `false` atom support to the condition evaluator while leaving comparison, `&&`, and `||` parsing intact.
- Added focused tests for `evaluate_bool_expr("true"/"false")` and for a v2 job step with `when: "false"` emitting `StepSkipped` without invoking the target action.

Assessment: Boolean literal guards now skip cleanly in v2 `when` and `break_when` expressions without broadening the expression language.

Validation:
- `make fmt` passed.
- `make build` passed.
- `cargo test -p orbit-engine` passed: 154 unit tests, 4 checkpoint verifier tests, 6 workspace snapshot tests, and doc tests.
- Attempted task-specified `make test -p orbit-engine`; it ran workspace tests but failed because make parsed `-p` as its own print-database flag and `orbit-engine` as a target. Filed friction task T20260509-60.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/T20260509-25-69fec981`
- Behind base: 0
- Ahead of base: 1

*authored by: gpt-5.5*