### PR TITLE
Implement `on_denial: continue` for agent loops

### DIFF
--- a/crates/orbit-agent/src/loop_engine/agent_loop.rs
+++ b/crates/orbit-agent/src/loop_engine/agent_loop.rs
@@ -11,7 +11,7 @@
 use std::time::{Duration, Instant};
 
 use chrono::Utc;
-use orbit_common::types::activity_job::tool_allowed;
+use orbit_common::types::activity_job::{OnDenial, tool_allowed};
 use orbit_tools::{ToolContext, ToolRegistry};
 
 use super::audit::{AuditSink, LoopAuditEvent, UsageSnapshot};
@@ -36,6 +36,7 @@ pub struct AgentLoopConfig {
     pub max_total_tokens: u64,
     pub wall_clock_timeout: Duration,
     pub max_response_tokens: u32,
+    pub on_denial: OnDenial,
     pub run_id: String,
     pub task_id: Option<String>,
     pub cache_hint: CacheHint,
@@ -50,6 +51,7 @@ impl AgentLoopConfig {
             max_total_tokens: 500_000,
             wall_clock_timeout: Duration::from_secs(600),
             max_response_tokens: 4096,
+            on_denial: OnDenial::Terminate,
             run_id: run_id.into(),
             task_id: None,
             cache_hint: CacheHint::SystemAndEarliestHistory,
@@ -88,6 +90,11 @@ impl AgentLoopConfig {
 
     pub fn with_max_response_tokens(mut self, n: u32) -> Self {
         self.max_response_tokens = n;
+        self
+    }
+
+    pub fn with_on_denial(mut self, on_denial: OnDenial) -> Self {
+        self.on_denial = on_denial;
         self
     }
 }
@@ -263,6 +270,10 @@ impl AgentLoop {
                 if !tool_allowed(&tool_name, &cfg.tool_allowlist) {
                     let reason = "tool not in allowlist".to_string();
                     let denial_payload = serde_json::json!({
+                        "error": {
+                            "code": "tool_denied",
+                            "message": &reason,
+                        },
                         "tool_name": &tool_name,
                         "tool_use_id": &tool_use_id,
                         "reason": &reason,
@@ -279,24 +290,40 @@ impl AgentLoop {
                         reason,
                     });
                     iter_denials.push(tool_name.clone());
-                    sink.emit(&LoopAuditEvent::IterationBoundary {
-                        ts: Utc::now(),
-                        run_id: cfg.run_id.clone(),
-                        session_id: session.id().to_string(),
-                        iteration,
-                        continues: false,
-                    });
-                    trace.push(IterationTrace {
-                        iteration,
-                        stop_reason,
-                        tool_calls: iter_tool_names,
-                        policy_denials: iter_denials,
-                        usage: usage.clone(),
-                    });
-                    return Err(AgentLoopError::PolicyDenied {
-                        tool_name,
-                        iteration,
-                    });
+                    match cfg.on_denial {
+                        OnDenial::Terminate => {
+                            sink.emit(&LoopAuditEvent::IterationBoundary {
+                                ts: Utc::now(),
+                                run_id: cfg.run_id.clone(),
+                                session_id: session.id().to_string(),
+                                iteration,
+                                continues: false,
+                            });
+                            trace.push(IterationTrace {
+                                iteration,
+                                stop_reason,
+                                tool_calls: iter_tool_names,
+                                policy_denials: iter_denials,
+                                usage: usage.clone(),
+                            });
+                            return Err(AgentLoopError::PolicyDenied {
+                                tool_name,
+                                iteration,
+                            });
+                        }
+                        OnDenial::Continue => {
+                            let tool_text = match serde_json::to_string(&denial_payload) {
+                                Ok(s) => s,
+                                Err(err) => format!("{{\"error\":\"serialize: {err}\"}}"),
+                            };
+                            user_tool_results.push(ContentBlock::ToolResult {
+                                tool_use_id,
+                                content: tool_text,
+                                is_error: true,
+                            });
+                            continue;
+                        }
+                    }
                 }
 
                 let input_bytes = serde_json::to_vec(&input).unwrap_or_default();
@@ -498,6 +525,7 @@ mod tests {
     use std::sync::{Arc, Mutex};
 
     use orbit_common::types::OrbitError;
+    use orbit_common::types::activity_job::OnDenial;
     use orbit_tools::{OrbitBuiltinAction, OrbitTaskScope, OrbitToolHost, ReservationOwnerContext};
     use serde_json::{Value, json};
 
@@ -546,6 +574,75 @@ mod tests {
                     StopReason::ToolUse,
                 )
             } else {
+                (
+                    vec![ContentBlock::Text {
+                        text: "done".to_string(),
+                    }],
+                    StopReason::EndTurn,
+                )
+            };
+
+            Ok(TurnResponse {
+                content,
+                stop_reason,
+                usage: TurnUsage::default(),
+                raw_request_body: Vec::new(),
+                raw_response_body: Vec::new(),
+                endpoint: String::new(),
+                http_status: 200,
+            })
+        }
+    }
+
+    #[derive(Default)]
+    struct DenialContinueTransport {
+        calls: Mutex<usize>,
+    }
+
+    impl LoopTransport for DenialContinueTransport {
+        fn provider(&self) -> &str {
+            "test"
+        }
+
+        fn model(&self) -> &str {
+            "test-model"
+        }
+
+        fn send_turn(&self, req: &TurnRequest<'_>) -> Result<TurnResponse, TransportError> {
+            let mut calls = self.calls.lock().expect("calls mutex");
+            let call_index = *calls;
+            *calls += 1;
+
+            let (content, stop_reason) = if call_index == 0 {
+                (
+                    vec![ContentBlock::ToolUse {
+                        id: "denied-1".to_string(),
+                        name: "fs.delete".to_string(),
+                        input: json!({ "path": "/tmp/blocked.txt" }),
+                    }],
+                    StopReason::ToolUse,
+                )
+            } else {
+                let last_message = req.messages.last().expect("tool result user message");
+                assert_eq!(last_message.role, MessageRole::User);
+                let [
+                    ContentBlock::ToolResult {
+                        tool_use_id,
+                        content,
+                        is_error,
+                    },
+                ] = last_message.content.as_slice()
+                else {
+                    panic!("expected one tool_result block");
+                };
+                assert_eq!(tool_use_id, "denied-1");
+                assert!(*is_error);
+                let payload: Value =
+                    serde_json::from_str(content).expect("denial tool result is json");
+                assert_eq!(payload["error"]["code"], "tool_denied");
+                assert_eq!(payload["tool_name"], "fs.delete");
+                assert_eq!(payload["tool_use_id"], "denied-1");
+
                 (
                     vec![ContentBlock::Text {
                         text: "done".to_string(),
@@ -631,6 +728,38 @@ mod tests {
                 .expect("first request")
                 .iter()
                 .any(|name| name == "orbit.task.show")
+        );
+    }
+
+    #[test]
+    fn continue_on_denial_returns_structured_tool_result_error() {
+        let mut session = Session::new("test", "test-model", "", None);
+        let cfg = AgentLoopConfig::new_for_run("run-test")
+            .with_advertised_tools(vec!["fs.delete".to_string()])
+            .with_on_denial(OnDenial::Continue)
+            .with_max_iterations(3);
+        let mut registry = ToolRegistry::new();
+        registry.register_builtins();
+        let tool_ctx = ToolContext::default();
+        let transport = DenialContinueTransport::default();
+        let sink = NullSink;
+
+        let outcome = AgentLoop::run(
+            &mut session,
+            &cfg,
+            &transport,
+            &registry,
+            &tool_ctx,
+            &sink,
+            "try deleting",
+        )
+        .expect("continue should feed denial back to model");
+
+        assert_eq!(outcome.final_message, "done");
+        assert_eq!(outcome.trace.len(), 2);
+        assert_eq!(
+            outcome.trace[0].policy_denials,
+            vec!["fs.delete".to_string()]
         );
     }
 }

--- a/crates/orbit-engine/src/activity_job/agent_loop_driver.rs
+++ b/crates/orbit-engine/src/activity_job/agent_loop_driver.rs
@@ -193,6 +193,9 @@ fn replay_active() -> bool {
 /// fixtures). Cleared by `reset_replay_transport` in tests.
 static REPLAY_TRANSPORT: OnceLock<Mutex<Option<Arc<ReplayTransport>>>> = OnceLock::new();
 
+#[cfg(test)]
+pub(crate) static REPLAY_TEST_ENV_LOCK: Mutex<()> = Mutex::new(());
+
 fn acquire_replay_transport(model: &str) -> Result<Arc<ReplayTransport>, DispatchError> {
     let cell = REPLAY_TRANSPORT.get_or_init(|| Mutex::new(None));
     let mut guard = cell.lock().expect("replay mutex poisoned");
@@ -320,7 +323,8 @@ fn run_loop<T: LoopTransport>(
         .with_advertised_tools(spec.tools.clone())
         .with_max_iterations(spec.max_iterations.max(1))
         .with_max_total_tokens(u64::MAX)
-        .with_wall_clock_timeout(Duration::from_secs(spec.wall_clock_timeout_seconds.max(1)));
+        .with_wall_clock_timeout(Duration::from_secs(spec.wall_clock_timeout_seconds.max(1)))
+        .with_on_denial(spec.on_denial);
 
     let session_id = session.id().to_string();
 
@@ -350,5 +354,195 @@ fn run_loop<T: LoopTransport>(
             iteration,
         }),
         Err(err) => Err(DispatchError::AgentLoopFailed(format!("{err:?}"))),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use orbit_agent::loop_engine::audit::{AuditSink, NullSink};
+    use orbit_common::types::activity_job::{Backend, OnDenial, Provider};
+    use tempfile::NamedTempFile;
+
+    use super::*;
+
+    struct ReplayEnvGuard {
+        fixture_prior: Option<String>,
+    }
+
+    impl ReplayEnvGuard {
+        fn set_fixture(path: &std::path::Path) -> Self {
+            let fixture_prior = std::env::var("ORBIT_V2_REPLAY_FIXTURE").ok();
+            // SAFETY: these tests serialize all replay-env mutation with
+            // REPLAY_TEST_ENV_LOCK and restore the previous value on drop.
+            unsafe {
+                std::env::set_var("ORBIT_V2_REPLAY_FIXTURE", path);
+            }
+            reset_replay_transport();
+            Self { fixture_prior }
+        }
+    }
+
+    impl Drop for ReplayEnvGuard {
+        fn drop(&mut self) {
+            reset_replay_transport();
+            // SAFETY: see ReplayEnvGuard::set_fixture.
+            unsafe {
+                match &self.fixture_prior {
+                    Some(value) => std::env::set_var("ORBIT_V2_REPLAY_FIXTURE", value),
+                    None => std::env::remove_var("ORBIT_V2_REPLAY_FIXTURE"),
+                }
+            }
+        }
+    }
+
+    struct ReplayHost;
+
+    impl V2RuntimeHost for ReplayHost {
+        fn run_deterministic(
+            &self,
+            _action: &str,
+            _config: &Value,
+            _input: &Value,
+            _tool_context: ToolContext,
+        ) -> Result<Value, DispatchError> {
+            Err(DispatchError::DeterministicActionNotRegistered(
+                "replay host: not used".to_string(),
+            ))
+        }
+
+        fn api_key_for(&self, _provider: &str) -> Result<String, DispatchError> {
+            Err(DispatchError::AgentLoopFailed(
+                "replay host: no credentials".to_string(),
+            ))
+        }
+
+        fn resolve_cli_executor(
+            &self,
+            _provider: &str,
+        ) -> Result<super::super::dispatcher::ResolvedCliExecutor, DispatchError> {
+            Err(DispatchError::CliInvocationFailed(
+                "replay host: no CLI mapping".to_string(),
+            ))
+        }
+
+        fn tool_context_for_activity(
+            &self,
+            _run_id: Option<&str>,
+            _fs_profile: Option<&str>,
+            _fs_audit: Option<Arc<dyn orbit_tools::FsAuditLogger>>,
+        ) -> ToolContext {
+            ToolContext::default()
+        }
+    }
+
+    fn replay_spec(on_denial: OnDenial) -> AgentLoopSpec {
+        AgentLoopSpec {
+            instruction: "test".to_string(),
+            tools: Vec::new(),
+            on_denial,
+            model: Some("test-model".to_string()),
+            max_iterations: 4,
+            backend: Backend::Http,
+            provider: Provider::Claude,
+            wall_clock_timeout_seconds: 30,
+            role: None,
+        }
+    }
+
+    fn audit_writer(run_id: &str) -> Arc<V2AuditWriter> {
+        let inner: Arc<dyn AuditSink> = Arc::new(NullSink);
+        Arc::new(V2AuditWriter::new(run_id, "test-agent", inner))
+    }
+
+    fn write_fixture(value: Value) -> NamedTempFile {
+        let file = NamedTempFile::new().expect("fixture temp file");
+        std::fs::write(
+            file.path(),
+            serde_json::to_vec(&value).expect("serialize fixture"),
+        )
+        .expect("write fixture");
+        file
+    }
+
+    #[test]
+    fn replay_denial_terminate_surfaces_structural_tool_denied() {
+        let _lock = REPLAY_TEST_ENV_LOCK.lock().expect("replay env lock");
+        let fixture = write_fixture(serde_json::json!({
+            "turns": [{
+                "content": [{
+                    "kind": "tool_use",
+                    "id": "denied-1",
+                    "name": "fs.delete",
+                    "input": { "path": "/tmp/blocked.txt" }
+                }],
+                "stop_reason": "tool_use"
+            }]
+        }));
+        let _guard = ReplayEnvGuard::set_fixture(fixture.path());
+        let host = ReplayHost;
+
+        let err = drive_agent_loop(
+            &replay_spec(OnDenial::Terminate),
+            None,
+            "run-denial-terminate",
+            audit_writer("run-denial-terminate"),
+            &serde_json::json!({ "prompt": "try a denied tool" }),
+            &host,
+            None,
+        )
+        .expect_err("terminate should surface structural denial");
+
+        assert!(matches!(
+            err,
+            DispatchError::ToolDenied {
+                ref tool_name,
+                iteration: 1,
+            } if tool_name == "fs.delete"
+        ));
+    }
+
+    #[test]
+    fn replay_denial_continue_runs_until_normal_stop() {
+        let _lock = REPLAY_TEST_ENV_LOCK.lock().expect("replay env lock");
+        let fixture = write_fixture(serde_json::json!({
+            "turns": [
+                {
+                    "content": [{
+                        "kind": "tool_use",
+                        "id": "denied-1",
+                        "name": "fs.delete",
+                        "input": { "path": "/tmp/blocked.txt" }
+                    }],
+                    "stop_reason": "tool_use"
+                },
+                {
+                    "content": [{ "kind": "text", "text": "done" }],
+                    "stop_reason": "end_turn"
+                }
+            ]
+        }));
+        let _guard = ReplayEnvGuard::set_fixture(fixture.path());
+        let host = ReplayHost;
+
+        let outcome = drive_agent_loop(
+            &replay_spec(OnDenial::Continue),
+            None,
+            "run-denial-continue",
+            audit_writer("run-denial-continue"),
+            &serde_json::json!({ "prompt": "try a denied tool" }),
+            &host,
+            None,
+        )
+        .expect("continue should let replay reach final turn");
+
+        assert_eq!(outcome.final_message, "done");
+        assert_eq!(outcome.trace.len(), 2);
+        assert_eq!(
+            outcome.trace[0].policy_denials,
+            vec!["fs.delete".to_string()]
+        );
+        assert!(outcome.trace[1].policy_denials.is_empty());
     }
 }

--- a/crates/orbit-engine/src/activity_job/groundhog/attempt.rs
+++ b/crates/orbit-engine/src/activity_job/groundhog/attempt.rs
@@ -291,3 +291,194 @@ impl GroundhogToolHost for AttemptGroundhogHost {
         self.scope.clone()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use orbit_agent::loop_engine::audit::{AuditSink, NullSink};
+    use orbit_common::types::activity_job::{OnDenial, Provider};
+    use orbit_common::types::{TaskPlanCheckpoint, TaskPlanSuccessCriterion};
+    use orbit_tools::ToolContext;
+    use serde_json::{Value, json};
+    use tempfile::NamedTempFile;
+
+    use super::super::super::agent_loop_driver::{REPLAY_TEST_ENV_LOCK, reset_replay_transport};
+    use super::*;
+
+    struct ReplayEnvGuard {
+        fixture_prior: Option<String>,
+    }
+
+    impl ReplayEnvGuard {
+        fn set_fixture(path: &std::path::Path) -> Self {
+            let fixture_prior = std::env::var("ORBIT_V2_REPLAY_FIXTURE").ok();
+            // SAFETY: this test serializes replay-env mutation with
+            // REPLAY_TEST_ENV_LOCK and restores the previous value on drop.
+            unsafe {
+                std::env::set_var("ORBIT_V2_REPLAY_FIXTURE", path);
+            }
+            reset_replay_transport();
+            Self { fixture_prior }
+        }
+    }
+
+    impl Drop for ReplayEnvGuard {
+        fn drop(&mut self) {
+            reset_replay_transport();
+            // SAFETY: see ReplayEnvGuard::set_fixture.
+            unsafe {
+                match &self.fixture_prior {
+                    Some(value) => std::env::set_var("ORBIT_V2_REPLAY_FIXTURE", value),
+                    None => std::env::remove_var("ORBIT_V2_REPLAY_FIXTURE"),
+                }
+            }
+        }
+    }
+
+    struct AttemptHost;
+
+    impl V2RuntimeHost for AttemptHost {
+        fn run_deterministic(
+            &self,
+            _action: &str,
+            _config: &Value,
+            _input: &Value,
+            _tool_context: ToolContext,
+        ) -> Result<Value, DispatchError> {
+            Err(DispatchError::DeterministicActionNotRegistered(
+                "attempt host: not used".to_string(),
+            ))
+        }
+
+        fn api_key_for(&self, _provider: &str) -> Result<String, DispatchError> {
+            Err(DispatchError::AgentLoopFailed(
+                "attempt host: no credentials".to_string(),
+            ))
+        }
+
+        fn resolve_cli_executor(
+            &self,
+            _provider: &str,
+        ) -> Result<super::super::super::dispatcher::ResolvedCliExecutor, DispatchError> {
+            Err(DispatchError::CliInvocationFailed(
+                "attempt host: no CLI mapping".to_string(),
+            ))
+        }
+
+        fn tool_context_for_activity(
+            &self,
+            _run_id: Option<&str>,
+            _fs_profile: Option<&str>,
+            _fs_audit: Option<Arc<dyn orbit_tools::FsAuditLogger>>,
+        ) -> ToolContext {
+            ToolContext::default()
+        }
+    }
+
+    fn audit_writer(run_id: &str) -> Arc<V2AuditWriter> {
+        let inner: Arc<dyn AuditSink> = Arc::new(NullSink);
+        Arc::new(V2AuditWriter::new(run_id, "test-agent", inner))
+    }
+
+    fn write_fixture(value: Value) -> NamedTempFile {
+        let file = NamedTempFile::new().expect("fixture temp file");
+        std::fs::write(
+            file.path(),
+            serde_json::to_vec(&value).expect("serialize fixture"),
+        )
+        .expect("write fixture");
+        file
+    }
+
+    fn groundhog_spec(on_denial: OnDenial) -> GroundhogSpec {
+        GroundhogSpec {
+            instruction: String::new(),
+            tools: Vec::new(),
+            on_denial,
+            model: Some("test-model".to_string()),
+            max_iterations: 5,
+            provider: Provider::Claude,
+            wall_clock_timeout_seconds: 30,
+            attempt_budget_default: 1,
+            role: None,
+        }
+    }
+
+    fn checkpoint() -> TaskPlanCheckpoint {
+        TaskPlanCheckpoint {
+            id: "ckpt_1".to_string(),
+            spec: "finish the checkpoint".to_string(),
+            success_criteria: vec![TaskPlanSuccessCriterion::Semantic {
+                statement: "checkpoint is complete".to_string(),
+            }],
+            attempt_budget: 1,
+        }
+    }
+
+    #[test]
+    fn groundhog_attempt_continue_on_denial_reaches_terminal_tool() {
+        let _lock = REPLAY_TEST_ENV_LOCK.lock().expect("replay env lock");
+        let fixture = write_fixture(serde_json::json!({
+            "turns": [
+                {
+                    "content": [{
+                        "kind": "tool_use",
+                        "id": "denied-1",
+                        "name": "fs.delete",
+                        "input": { "path": "/tmp/blocked.txt" }
+                    }],
+                    "stop_reason": "tool_use"
+                },
+                {
+                    "content": [{
+                        "kind": "tool_use",
+                        "id": "success-1",
+                        "name": "orbit.groundhog.checkpoint_success",
+                        "input": {
+                            "summary": "checkpoint complete",
+                            "side_effects": []
+                        }
+                    }],
+                    "stop_reason": "tool_use"
+                },
+                {
+                    "content": [{ "kind": "text", "text": "done" }],
+                    "stop_reason": "end_turn"
+                }
+            ]
+        }));
+        let _guard = ReplayEnvGuard::set_fixture(fixture.path());
+        let host = AttemptHost;
+        let checkpoint = checkpoint();
+        let groundhog_host = Arc::new(AttemptGroundhogHost::new("T-test", &checkpoint.id));
+
+        let result = run_attempt(
+            &host,
+            &groundhog_spec(OnDenial::Continue),
+            "run-groundhog-denial-continue",
+            audit_writer("run-groundhog-denial-continue"),
+            &json!({}),
+            None,
+            "checkpoint plan",
+            &Chronicle::new("T-test".to_string(), "plan-test".to_string()),
+            &checkpoint,
+            None,
+            groundhog_host,
+        )
+        .expect("denial continue should let Groundhog attempt finish");
+
+        match result {
+            AttemptResult::Success {
+                summary,
+                side_effects,
+            } => {
+                assert_eq!(summary, "checkpoint complete");
+                assert!(side_effects.is_empty());
+            }
+            AttemptResult::Failure(report) => {
+                panic!("expected success, got failure: {}", report.what_happened);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Task

[T20260509-23](https://orbit-cli.com/tasks/T20260509-23) — Implement `on_denial: continue` for agent loops

### Description

## Problem
`AgentLoopSpec` and `GroundhogSpec` deserialize `on_denial: terminate | continue`, but no runtime path reads the field. `AgentLoop` always returns `AgentLoopError::PolicyDenied` on a denied tool call, and the v2 driver always maps that to non-retryable `DispatchError::ToolDenied`.

## Why It Matters
Activity authors can request `continue`, but a denied tool still terminates the loop. That is schema/behavior drift and makes denial policy impossible to reason about from YAML.

## Constraints / Notes
Keep `terminate` as the default. If `continue` is intentionally no longer supported, remove it from the schema and docs instead of silently accepting it.

## Scope Restriction
Do not modify anything under `./docs` as part of this task.

### Acceptance Criteria

- A denied tool call with `on_denial: terminate` still ends the activity with structural `ToolDenied`.
- A denied tool call with `on_denial: continue` returns a structured tool-result error to the model and continues until a normal stop or another guardrail fires.
- Tests cover both HTTP replay and Groundhog attempt paths, or the schema is narrowed and tests prove unsupported `continue` is rejected at load time.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Threaded AgentLoopSpec/GroundhogSpec on_denial into the HTTP AgentLoop runtime configuration.
- Preserved terminate as the default structural ToolDenied path.
- Implemented continue by returning an is_error tool_result with structured tool_denied JSON, recording denial trace/audit, and allowing the loop to continue to normal stop.
- Added coverage for structured tool-result feedback, HTTP replay terminate/continue behavior, and Groundhog attempts continuing past a denied tool to a terminal Groundhog verb.

Assessment: Implementation is scoped to runtime behavior and tests; docs were intentionally untouched per task scope restriction. Validation passed: make fmt, make build, cargo test -p orbit-agent, cargo test -p orbit-engine.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/T20260509-23-69feca13`
- Behind base: 0
- Ahead of base: 1

*authored by: gpt-5.5*