### PR TITLE
Lock duel scoreboard append operations

### DIFF
--- a/crates/orbit-store/src/file/scoreboard/duel_scoreboard.rs
+++ b/crates/orbit-store/src/file/scoreboard/duel_scoreboard.rs
@@ -30,7 +30,9 @@ use std::process::Command;
 use orbit_common::types::{Ambiguity, Decision, DuelRun, OrbitError, TaskScope, Verdict};
 use serde::{Deserialize, Serialize};
 
-use orbit_common::utility::fs::atomic_write_text_volatile as write_atomic;
+use orbit_common::utility::fs::{
+    atomic_write_text_volatile as write_atomic, with_exclusive_file_lock,
+};
 
 const SCOREBOARD_FILENAME: &str = "duel.json";
 const CURRENT_SCHEMA_VERSION: u32 = 1;
@@ -61,12 +63,14 @@ impl Default for DuelScoreboardFile {
 /// the rewrite cannot corrupt earlier entries.
 pub fn append_run(scoreboard_dir: &Path, run: &DuelRun) -> Result<(), OrbitError> {
     let path = scoreboard_dir.join(SCOREBOARD_FILENAME);
-    let mut file = load_scoreboard_file(&path)?;
-    file.runs.push(run.clone());
+    with_exclusive_file_lock(&path, "duel scoreboard", || {
+        let mut file = load_scoreboard_file(&path)?;
+        file.runs.push(run.clone());
 
-    let json = serde_json::to_string_pretty(&file)
-        .map_err(|e| OrbitError::Io(format!("serialize duel.json: {e}")))?;
-    write_atomic(&path, &format!("{json}\n")).map_err(Into::into)
+        let json = serde_json::to_string_pretty(&file)
+            .map_err(|e| OrbitError::Io(format!("serialize duel.json: {e}")))?;
+        write_atomic(&path, &format!("{json}\n")).map_err(Into::into)
+    })
 }
 
 /// Load every run entry from `scoreboard_dir/duel.json`. Returns an empty
@@ -435,3 +439,104 @@ fn _ensure_decision_in_scope(_: Decision) {}
 // ============================================================================
 // Tests
 // ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeSet;
+    use std::sync::{Arc, Barrier};
+    use std::thread;
+
+    use chrono::Utc;
+    use orbit_common::types::{
+        Cost, ImplementerStats, Outcome, ReviewerStats, RoleAssignment, Roles, Scores, TaskClass,
+        ValidIssuesBySeverity,
+    };
+
+    use super::*;
+
+    #[test]
+    fn append_run_keeps_all_concurrent_writes() {
+        let temp = tempfile::tempdir().expect("create tempdir");
+        let scoreboard_dir = Arc::new(temp.path().to_path_buf());
+        let writers = 32;
+        let barrier = Arc::new(Barrier::new(writers));
+
+        let handles: Vec<_> = (0..writers)
+            .map(|index| {
+                let scoreboard_dir = Arc::clone(&scoreboard_dir);
+                let barrier = Arc::clone(&barrier);
+                thread::spawn(move || {
+                    let run = test_run(format!("run-{index:02}"));
+                    barrier.wait();
+                    append_run(&scoreboard_dir, &run).expect("append run");
+                })
+            })
+            .collect();
+
+        for handle in handles {
+            handle.join().expect("join writer thread");
+        }
+
+        let runs = load_runs(&scoreboard_dir).expect("load runs");
+        assert_eq!(runs.len(), writers);
+
+        let run_ids: BTreeSet<_> = runs.into_iter().map(|run| run.run_id).collect();
+        let expected: BTreeSet<_> = (0..writers)
+            .map(|index| format!("run-{index:02}"))
+            .collect();
+        assert_eq!(run_ids, expected);
+    }
+
+    fn test_run(run_id: String) -> DuelRun {
+        DuelRun {
+            run_id,
+            task_id: "T-test".to_string(),
+            completed_at: Utc::now(),
+            task_class: TaskClass {
+                scope: TaskScope::SingleFile,
+                ambiguity: Some(Ambiguity::WellSpecified),
+                source: "test".to_string(),
+            },
+            roles: Roles {
+                implementer: role("codex", "gpt-5.5"),
+                reviewer: role("claude", "opus"),
+                arbiter: role("gemini", "pro"),
+            },
+            outcome: Outcome {
+                decision: Decision::Approved,
+                fix_loop_iterations: 0,
+                fix_loop_exhausted: false,
+                pr_number: Some(1),
+                merged: true,
+            },
+            scores: Scores {
+                implementer_score: 1.0,
+                reviewer_score: 1.0,
+            },
+            reviewer_stats: ReviewerStats {
+                total_comments: 0,
+                valid: 0,
+                invalid: 0,
+                out_of_scope: 0,
+                nitpick: 0,
+                precision: 0.0,
+                arbiter_override_rate: 0.0,
+            },
+            implementer_stats: ImplementerStats {
+                valid_issues_against: ValidIssuesBySeverity::default(),
+            },
+            cost: Cost {
+                wall_clock_seconds: 1,
+                tokens_in: None,
+                tokens_out: None,
+            },
+        }
+    }
+
+    fn role(agent: &str, model: &str) -> RoleAssignment {
+        RoleAssignment {
+            agent: agent.to_string(),
+            model: model.to_string(),
+        }
+    }
+}

--- a/crates/orbit-store/src/file/scoreboard/planning_duel_scoreboard.rs
+++ b/crates/orbit-store/src/file/scoreboard/planning_duel_scoreboard.rs
@@ -12,7 +12,9 @@ use std::path::Path;
 use orbit_common::types::{OrbitError, PlannerSlot, PlanningDuelRun};
 use serde::{Deserialize, Serialize};
 
-use orbit_common::utility::fs::atomic_write_text_volatile as write_atomic;
+use orbit_common::utility::fs::{
+    atomic_write_text_volatile as write_atomic, with_exclusive_file_lock,
+};
 
 const SCOREBOARD_FILENAME: &str = "duel_plan.json";
 const CURRENT_SCHEMA_VERSION: u32 = 1;
@@ -79,12 +81,14 @@ pub struct Aggregates {
 /// Append a single [`PlanningDuelRun`] to `scoreboard_dir/duel_plan.json`.
 pub fn append_run(scoreboard_dir: &Path, run: &PlanningDuelRun) -> Result<(), OrbitError> {
     let path = scoreboard_dir.join(SCOREBOARD_FILENAME);
-    let mut file = load_scoreboard_file(&path)?;
-    file.runs.push(run.clone());
+    with_exclusive_file_lock(&path, "planning duel scoreboard", || {
+        let mut file = load_scoreboard_file(&path)?;
+        file.runs.push(run.clone());
 
-    let json = serde_json::to_string_pretty(&file)
-        .map_err(|e| OrbitError::Io(format!("serialize duel_plan.json: {e}")))?;
-    write_atomic(&path, &format!("{json}\n")).map_err(Into::into)
+        let json = serde_json::to_string_pretty(&file)
+            .map_err(|e| OrbitError::Io(format!("serialize duel_plan.json: {e}")))?;
+        write_atomic(&path, &format!("{json}\n")).map_err(Into::into)
+    })
 }
 
 /// Load every run entry from `scoreboard_dir/duel_plan.json`.
@@ -212,3 +216,91 @@ pub fn aggregate(runs: &[PlanningDuelRun], filter: AggregateFilter) -> Aggregate
 // ============================================================================
 // Tests
 // ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeSet;
+    use std::sync::{Arc, Barrier};
+    use std::thread;
+
+    use chrono::Utc;
+    use orbit_common::types::{
+        EfficiencyMetrics, PlannerSlot, PlanningEfficiency, PlanningOutcome,
+        PlanningRoleAssignment, PlanningRoles,
+    };
+
+    use super::*;
+
+    #[test]
+    fn append_run_keeps_all_concurrent_writes() {
+        let temp = tempfile::tempdir().expect("create tempdir");
+        let scoreboard_dir = Arc::new(temp.path().to_path_buf());
+        let writers = 32;
+        let barrier = Arc::new(Barrier::new(writers));
+
+        let handles: Vec<_> = (0..writers)
+            .map(|index| {
+                let scoreboard_dir = Arc::clone(&scoreboard_dir);
+                let barrier = Arc::clone(&barrier);
+                thread::spawn(move || {
+                    let run = test_run(format!("run-{index:02}"));
+                    barrier.wait();
+                    append_run(&scoreboard_dir, &run).expect("append run");
+                })
+            })
+            .collect();
+
+        for handle in handles {
+            handle.join().expect("join writer thread");
+        }
+
+        let runs = load_runs(&scoreboard_dir).expect("load runs");
+        assert_eq!(runs.len(), writers);
+
+        let run_ids: BTreeSet<_> = runs.into_iter().map(|run| run.run_id).collect();
+        let expected: BTreeSet<_> = (0..writers)
+            .map(|index| format!("run-{index:02}"))
+            .collect();
+        assert_eq!(run_ids, expected);
+    }
+
+    fn test_run(run_id: String) -> PlanningDuelRun {
+        PlanningDuelRun {
+            run_id,
+            task_id: "T-test".to_string(),
+            completed_at: Utc::now(),
+            roles: PlanningRoles {
+                planner_a: role("codex", "gpt-5.5"),
+                planner_b: role("claude", "opus"),
+                arbiter: role("gemini", "pro"),
+            },
+            planner_a_artifact_path: "artifacts/planner-a.md".to_string(),
+            planner_b_artifact_path: "artifacts/planner-b.md".to_string(),
+            outcome: PlanningOutcome {
+                winner: PlannerSlot::PlannerA,
+                arbiter_rationale: "test winner".to_string(),
+            },
+            efficiency: PlanningEfficiency {
+                planner_a: metrics(),
+                planner_b: metrics(),
+                arbiter: metrics(),
+            },
+        }
+    }
+
+    fn role(agent: &str, model: &str) -> PlanningRoleAssignment {
+        PlanningRoleAssignment {
+            agent: agent.to_string(),
+            model: model.to_string(),
+        }
+    }
+
+    fn metrics() -> EfficiencyMetrics {
+        EfficiencyMetrics {
+            wall_clock_ms: 1_000,
+            tool_call_count: 1,
+            token_usage: None,
+            byte_proxy_total: None,
+        }
+    }
+}


### PR DESCRIPTION
## Task

[T20260509-32](https://orbit-cli.com/tasks/T20260509-32) — Lock duel scoreboard append operations

### Description

## Problem
`duel_scoreboard::append_run` and `planning_duel_scoreboard::append_run` load the JSON file, push a run, then atomically rewrite the file without an exclusive lock.

## Why It Matters
Concurrent duel completions can race and lose one of the appended run records even though each individual write is atomic.

## Constraints / Notes
Use the existing file-locking helpers used by other stores; keep crash-safe atomic replacement after mutation.

## Scope Restriction
Do not modify anything under `./docs` as part of this task.

### Acceptance Criteria

- Both duel append paths wrap load/mutate/write in an exclusive file lock scoped to the scoreboard file or directory.
- A concurrent append regression test records all expected run IDs with no lost updates.
- Existing aggregate/read tests continue to pass.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Wrapped duel.json append load/mutate/write in with_exclusive_file_lock while preserving the existing atomic rewrite.
- Wrapped duel_plan.json append load/mutate/write in with_exclusive_file_lock while preserving the existing atomic rewrite.
- Added concurrent append regression coverage for both duel scoreboards, asserting every expected run ID is retained with the expected run count.

Assessment: Focused change using the existing store locking helper; formatting, orbit-store tests, diff whitespace check, and workspace build pass.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/T20260509-32-69fecad2`
- Behind base: 0
- Ahead of base: 1

*authored by: gpt-5.5*