### PR TITLE
Validate activity tool allowlists during asset loading

### DIFF
--- a/crates/orbit-common/src/types/activity_job/asset_loader.rs
+++ b/crates/orbit-common/src/types/activity_job/asset_loader.rs
@@ -5,6 +5,7 @@ use crate::types::ResourceKind;
 use super::activity_v2::ActivityV2;
 use super::job_v2::JobV2;
 use super::schema_header::SchemaHeader;
+use super::tool_allowlist::{ToolAllowlistError, validate_activity_tool_allowlist};
 
 /// Loaded schemaVersion 2 activity asset plus its envelope metadata.
 #[derive(Debug, Clone)]
@@ -32,6 +33,11 @@ pub enum AssetLoadError {
     Parse(serde_yaml::Error),
     #[error("kind mismatch: expected `{expected}`, got `{actual}`")]
     KindMismatch { expected: String, actual: String },
+    #[error("activity `{activity}` tool allowlist invalid: {source}")]
+    ToolAllowlist {
+        activity: String,
+        source: ToolAllowlistError,
+    },
 }
 
 /// Two-pass activity-asset loader for schemaVersion 2 assets.
@@ -43,6 +49,12 @@ pub fn load_activity_asset(yaml: &str) -> Result<ActivityAsset, AssetLoadError> 
             let res: V2EnvelopeYaml<ActivityV2> =
                 serde_yaml::from_str(yaml).map_err(AssetLoadError::Parse)?;
             require_kind(&res.kind, ResourceKind::Activity)?;
+            validate_activity_tool_allowlist(&res.spec).map_err(|source| {
+                AssetLoadError::ToolAllowlist {
+                    activity: res.metadata.name.clone(),
+                    source,
+                }
+            })?;
             Ok(ActivityAsset {
                 name: res.metadata.name,
                 spec: res.spec,
@@ -88,4 +100,55 @@ struct V2EnvelopeYaml<T> {
     kind: ResourceKind,
     metadata: crate::types::ResourceMetadata,
     spec: T,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn agent_loop_activity_yaml(name: &str, tools: &str) -> String {
+        format!(
+            r#"schemaVersion: 2
+kind: Activity
+metadata:
+  name: {name}
+spec:
+  type: agent_loop
+  description: Test agent loop.
+  instruction: Test.
+  tools:
+{tools}"#
+        )
+    }
+
+    #[test]
+    fn load_activity_asset_accepts_task_wildcard_tool_allowlist() {
+        let yaml = agent_loop_activity_yaml("task_tools", "    - orbit.task.*\n");
+
+        let asset = load_activity_asset(&yaml).expect("activity should load");
+
+        assert_eq!(asset.name, "task_tools");
+    }
+
+    #[test]
+    fn load_activity_asset_rejects_top_level_orbit_wildcard() {
+        let yaml = agent_loop_activity_yaml("broad_tools", "    - orbit.*\n");
+
+        let err = load_activity_asset(&yaml).expect_err("broad wildcard should fail");
+        let message = err.to_string();
+
+        assert!(message.contains("orbit.*"), "{message}");
+        assert!(message.contains("wildcard root not permitted"), "{message}");
+    }
+
+    #[test]
+    fn load_activity_asset_rejects_empty_tool_name() {
+        let yaml = agent_loop_activity_yaml("empty_tools", "    - \"\"\n");
+
+        let err = load_activity_asset(&yaml).expect_err("empty tool should fail");
+        let message = err.to_string();
+
+        assert!(message.contains("empty tool name"), "{message}");
+        assert!(message.contains("index 0"), "{message}");
+    }
 }

--- a/crates/orbit-common/src/types/activity_job/catalog.rs
+++ b/crates/orbit-common/src/types/activity_job/catalog.rs
@@ -21,6 +21,9 @@ use thiserror::Error;
 use super::activity_v2::ActivityV2;
 use super::asset_loader::{AssetLoadError, load_activity_asset};
 use super::job_v2::{JobV2, JobV2Step, JobV2StepBody, LoopBlock, TargetRef, TargetStep};
+use super::tool_allowlist::{
+    ToolAllowlistError, validate_activity_tool_allowlist_against_registered_tools,
+};
 
 /// `activity:<name>` prefix for the `target:` field on a [`TargetRef`].
 pub const ACTIVITY_REF_PREFIX: &str = "activity:";
@@ -53,6 +56,11 @@ pub enum CatalogError {
         name: String,
         first: PathBuf,
         second: PathBuf,
+    },
+    #[error("activity `{name}` tool allowlist invalid: {source}")]
+    ToolAllowlist {
+        name: String,
+        source: ToolAllowlistError,
     },
 }
 
@@ -178,6 +186,27 @@ impl V2ActivityCatalog {
 
     pub fn names(&self) -> impl Iterator<Item = &str> {
         self.entries.keys().map(String::as_str)
+    }
+
+    /// Validate every agent-facing activity tool allowlist against a caller
+    /// supplied registry snapshot. This keeps `orbit-common` registry-agnostic
+    /// while letting core/engine fail malformed assets before dispatch.
+    pub fn validate_tool_allowlists<'a, I>(&self, registered_tools: I) -> Result<(), CatalogError>
+    where
+        I: IntoIterator<Item = &'a str>,
+    {
+        let registered_tools: Vec<&str> = registered_tools.into_iter().collect();
+        for (name, activity) in &self.entries {
+            validate_activity_tool_allowlist_against_registered_tools(
+                activity,
+                registered_tools.iter().copied(),
+            )
+            .map_err(|source| CatalogError::ToolAllowlist {
+                name: name.clone(),
+                source,
+            })?;
+        }
+        Ok(())
     }
 }
 

--- a/crates/orbit-common/src/types/activity_job/mod.rs
+++ b/crates/orbit-common/src/types/activity_job/mod.rs
@@ -32,5 +32,8 @@ pub use job_v2::{
 };
 pub use schema_header::SchemaHeader;
 pub use tool_allowlist::{
-    ToolAllowlistError, V2_TOOL_WILDCARD_ROOTS, tool_allowed, validate_tool_allowlist,
+    ToolAllowlistError, V2_INTENTIONALLY_EMPTY_TOOL_WILDCARD_ROOTS, V2_TOOL_WILDCARD_ROOTS,
+    tool_allowed, validate_activity_tool_allowlist,
+    validate_activity_tool_allowlist_against_registered_tools, validate_tool_allowlist,
+    validate_tool_allowlist_against_registered_tools,
 };

--- a/crates/orbit-common/src/types/activity_job/tool_allowlist.rs
+++ b/crates/orbit-common/src/types/activity_job/tool_allowlist.rs
@@ -1,4 +1,8 @@
+use std::collections::BTreeSet;
+
 use thiserror::Error;
+
+use super::activity_v2::{ActivityV2, ActivityV2Spec};
 
 /// Explicit list of permitted wildcard roots (§6 / §12 Q7).
 ///
@@ -9,17 +13,28 @@ use thiserror::Error;
 pub const V2_TOOL_WILDCARD_ROOTS: &[&str] = &[
     "orbit.graph.",
     "orbit.task.",
+    "orbit.state.",
+    // Reserved for audit-session tools. No builtin tools currently live under
+    // this root, so registry validation treats it as intentionally empty.
     "orbit.audit.",
     "fs.",
     "proc.",
 ];
 
-#[derive(Debug, Error)]
+pub const V2_INTENTIONALLY_EMPTY_TOOL_WILDCARD_ROOTS: &[&str] = &["orbit.audit."];
+
+#[derive(Debug, Error, Clone, PartialEq, Eq)]
 pub enum ToolAllowlistError {
-    #[error("wildcard root not permitted: `{0}` (see V2_TOOL_WILDCARD_ROOTS)")]
-    WildcardRootNotPermitted(String),
-    #[error("empty tool name in allowlist")]
-    EmptyName,
+    #[error(
+        "wildcard root not permitted in allowlist entry `{entry}` (see V2_TOOL_WILDCARD_ROOTS)"
+    )]
+    WildcardRootNotPermitted { entry: String },
+    #[error("empty tool name in allowlist entry at index {index}")]
+    EmptyName { index: usize },
+    #[error("unknown tool name in allowlist entry `{entry}`")]
+    UnknownToolName { entry: String },
+    #[error("wildcard allowlist entry `{entry}` did not match any registered tools")]
+    WildcardRootMatchesNoTools { entry: String },
 }
 
 /// Validate an activity's declared tool allowlist at asset-load time.
@@ -27,15 +42,77 @@ pub enum ToolAllowlistError {
 /// wildcard root. Does NOT verify that concrete tool names resolve in the
 /// registry — that's a separate load-time check at the engine layer.
 pub fn validate_tool_allowlist(allowlist: &[String]) -> Result<(), ToolAllowlistError> {
-    for entry in allowlist {
-        if entry.is_empty() {
-            return Err(ToolAllowlistError::EmptyName);
+    for (index, entry) in allowlist.iter().enumerate() {
+        if entry.trim().is_empty() {
+            return Err(ToolAllowlistError::EmptyName { index });
         }
         if let Some(prefix) = wildcard_prefix(entry)
             && !V2_TOOL_WILDCARD_ROOTS.iter().any(|root| *root == prefix)
         {
-            return Err(ToolAllowlistError::WildcardRootNotPermitted(entry.clone()));
+            return Err(ToolAllowlistError::WildcardRootNotPermitted {
+                entry: entry.clone(),
+            });
         }
+    }
+    Ok(())
+}
+
+/// Validate an activity allowlist against the registered tool surface.
+///
+/// Concrete names must resolve exactly. Wildcards must use an approved root,
+/// and must expand to at least one registered tool unless the root is an
+/// explicitly documented empty reservation.
+pub fn validate_tool_allowlist_against_registered_tools<'a, I>(
+    allowlist: &[String],
+    registered_tools: I,
+) -> Result<(), ToolAllowlistError>
+where
+    I: IntoIterator<Item = &'a str>,
+{
+    validate_tool_allowlist(allowlist)?;
+
+    let registered_tools: BTreeSet<&str> = registered_tools.into_iter().collect();
+    for entry in allowlist {
+        if let Some(prefix) = wildcard_prefix(entry) {
+            let has_match = registered_tools.iter().any(|tool| tool.starts_with(prefix));
+            if !has_match
+                && !V2_INTENTIONALLY_EMPTY_TOOL_WILDCARD_ROOTS
+                    .iter()
+                    .any(|root| *root == prefix)
+            {
+                return Err(ToolAllowlistError::WildcardRootMatchesNoTools {
+                    entry: entry.clone(),
+                });
+            }
+            continue;
+        }
+
+        if !registered_tools.contains(entry.as_str()) {
+            return Err(ToolAllowlistError::UnknownToolName {
+                entry: entry.clone(),
+            });
+        }
+    }
+
+    Ok(())
+}
+
+pub fn validate_activity_tool_allowlist(activity: &ActivityV2) -> Result<(), ToolAllowlistError> {
+    if let Some(allowlist) = activity_tool_allowlist(activity) {
+        validate_tool_allowlist(allowlist)?;
+    }
+    Ok(())
+}
+
+pub fn validate_activity_tool_allowlist_against_registered_tools<'a, I>(
+    activity: &ActivityV2,
+    registered_tools: I,
+) -> Result<(), ToolAllowlistError>
+where
+    I: IntoIterator<Item = &'a str>,
+{
+    if let Some(allowlist) = activity_tool_allowlist(activity) {
+        validate_tool_allowlist_against_registered_tools(allowlist, registered_tools)?;
     }
     Ok(())
 }
@@ -56,6 +133,44 @@ pub fn tool_allowed(tool_name: &str, allowlist: &[String]) -> bool {
     false
 }
 
-fn wildcard_prefix(entry: &str) -> Option<String> {
-    entry.strip_suffix('*').map(|s| s.to_string())
+fn activity_tool_allowlist(activity: &ActivityV2) -> Option<&[String]> {
+    match &activity.spec {
+        ActivityV2Spec::AgentLoop(spec) => Some(&spec.tools),
+        ActivityV2Spec::Groundhog(spec) => Some(&spec.tools),
+        ActivityV2Spec::Deterministic(_) | ActivityV2Spec::Shell(_) => None,
+    }
+}
+
+fn wildcard_prefix(entry: &str) -> Option<&str> {
+    entry.strip_suffix('*')
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn registry_validation_accepts_documented_empty_audit_root() {
+        validate_tool_allowlist_against_registered_tools(
+            &["orbit.audit.*".to_string()],
+            ["orbit.task.show"].into_iter(),
+        )
+        .expect("reserved audit root is intentionally empty");
+    }
+
+    #[test]
+    fn registry_validation_rejects_unmatched_non_empty_root() {
+        let err = validate_tool_allowlist_against_registered_tools(
+            &["fs.*".to_string()],
+            ["orbit.task.show"].into_iter(),
+        )
+        .expect_err("fs wildcard must match registered tools");
+
+        assert_eq!(
+            err,
+            ToolAllowlistError::WildcardRootMatchesNoTools {
+                entry: "fs.*".to_string()
+            }
+        );
+    }
 }

--- a/crates/orbit-core/assets/activities/step_failure_recovery.yaml
+++ b/crates/orbit-core/assets/activities/step_failure_recovery.yaml
@@ -83,7 +83,6 @@ spec:
     - orbit.state.*
     - orbit.graph.*
     - fs.read
-    - fs.write
     - fs.delete
     - proc.spawn
   on_denial: terminate

--- a/crates/orbit-core/src/command/activity_v2.rs
+++ b/crates/orbit-core/src/command/activity_v2.rs
@@ -12,6 +12,7 @@ use std::path::{Path, PathBuf};
 
 use orbit_common::types::activity_job::{
     Backend, V2AuditEventKind, load_activity_asset, resolve_activity_backends,
+    validate_activity_tool_allowlist_against_registered_tools,
 };
 use orbit_common::types::{OrbitError, OrbitEvent};
 use orbit_engine::activity_job::{V2AuditWriter, V2DispatchInput, dispatch_v2_activity};
@@ -20,6 +21,7 @@ use serde_json::Value;
 use crate::OrbitRuntime;
 use crate::command::SYSTEM_AUDIT_IDENTITY;
 
+#[derive(Debug)]
 pub struct V2ActivityRunResult {
     pub activity_name: String,
     pub activity_type: &'static str,
@@ -51,6 +53,22 @@ impl OrbitRuntime {
         })?;
         let mut asset = load_activity_asset(&yaml).map_err(|err| {
             OrbitError::InvalidInput(format!("load {}: {err}", yaml_path.display()))
+        })?;
+        let registered_tools: Vec<String> = self
+            .tool_registry()
+            .schemas()
+            .into_iter()
+            .map(|schema| schema.name)
+            .collect();
+        validate_activity_tool_allowlist_against_registered_tools(
+            &asset.spec,
+            registered_tools.iter().map(String::as_str),
+        )
+        .map_err(|err| {
+            OrbitError::InvalidInput(format!(
+                "activity `{}` tool allowlist invalid: {err}",
+                asset.name
+            ))
         })?;
 
         // §3.1 resolution: replace `Auto` with a concrete backend per
@@ -178,6 +196,23 @@ spec:
         std::fs::write(path, yaml).expect("write activity yaml");
     }
 
+    fn write_agent_loop_activity(path: &Path, name: &str, tool: &str) {
+        let yaml = format!(
+            r#"schemaVersion: 2
+kind: Activity
+metadata:
+  name: {name}
+spec:
+  type: agent_loop
+  description: Test agent loop.
+  instruction: Test.
+  tools:
+    - {tool}
+"#
+        );
+        std::fs::write(path, yaml).expect("write activity yaml");
+    }
+
     #[test]
     fn direct_activity_run_uses_system_audit_identity() {
         let (_root, runtime, repo_root) = test_runtime();
@@ -203,5 +238,21 @@ spec:
                 .and_then(serde_json::Value::as_str),
             Some(SYSTEM_AUDIT_IDENTITY)
         );
+    }
+
+    #[test]
+    fn direct_activity_run_rejects_unknown_tool_before_dispatch() {
+        let (_root, runtime, repo_root) = test_runtime();
+        let yaml_path = repo_root.join("unknown_tool_activity.yaml");
+        write_agent_loop_activity(&yaml_path, "unknown_tool_activity", "orbit.task.nope");
+
+        let err = runtime
+            .run_activity_v2_from_yaml(&yaml_path, json!({}), None)
+            .expect_err("unknown tool should fail before dispatch");
+        let message = err.to_string();
+
+        assert!(message.contains("unknown_tool_activity"), "{message}");
+        assert!(message.contains("orbit.task.nope"), "{message}");
+        assert!(message.contains("unknown tool name"), "{message}");
     }
 }

--- a/crates/orbit-core/src/runtime/mod.rs
+++ b/crates/orbit-core/src/runtime/mod.rs
@@ -273,6 +273,13 @@ impl OrbitRuntime {
                 catalog.load_dir_skipping_retired_prefer_existing(&dir)?,
             );
         }
+        let registered_tools: Vec<String> = self
+            .tool_registry()
+            .schemas()
+            .into_iter()
+            .map(|schema| schema.name)
+            .collect();
+        catalog.validate_tool_allowlists(registered_tools.iter().map(String::as_str))?;
 
         Ok(catalog)
     }
@@ -447,6 +454,8 @@ mod tests {
 
     use tempfile::tempdir;
 
+    use crate::command::activity::DEFAULT_ACTIVITY_FILES;
+
     static ENV_LOCK: Mutex<()> = Mutex::new(());
 
     fn test_runtime() -> (tempfile::TempDir, OrbitRuntime, PathBuf, PathBuf) {
@@ -530,6 +539,28 @@ spec:
         std::fs::write(path, yaml).expect("write activity yaml");
     }
 
+    fn write_agent_loop_activity(path: &Path, name: &str, tools: &[&str]) {
+        let tools_yaml = tools
+            .iter()
+            .map(|tool| format!("    - {tool}\n"))
+            .collect::<String>();
+        let yaml = format!(
+            r#"schemaVersion: 2
+kind: Activity
+metadata:
+  name: {name}
+spec:
+  type: agent_loop
+  description: Test agent loop.
+  instruction: Test.
+  tools:
+{tools_yaml}"#
+        );
+        std::fs::create_dir_all(path.parent().expect("activity path has parent"))
+            .expect("create activity dir");
+        std::fs::write(path, yaml).expect("write activity yaml");
+    }
+
     #[test]
     fn workspace_activity_overrides_global_default_in_catalog() {
         let (_root, runtime, global_root, workspace_root) = test_runtime();
@@ -568,5 +599,68 @@ spec:
             .v2_activity_catalog()
             .expect_err("duplicate activity name should fail");
         assert!(err.to_string().contains("duplicate activity name"), "{err}");
+    }
+
+    #[test]
+    fn activity_catalog_accepts_registered_task_wildcard() {
+        let (_root, runtime, _global_root, workspace_root) = test_runtime();
+        write_agent_loop_activity(
+            &workspace_root.join("resources/activities/task_tools.yaml"),
+            "task_tools",
+            &["orbit.task.*"],
+        );
+
+        let catalog = runtime.v2_activity_catalog().expect("activity catalog");
+
+        assert!(catalog.get("task_tools").is_some());
+    }
+
+    #[test]
+    fn activity_catalog_rejects_unknown_concrete_tool() {
+        let (_root, runtime, _global_root, workspace_root) = test_runtime();
+        write_agent_loop_activity(
+            &workspace_root.join("resources/activities/unknown_tool.yaml"),
+            "unknown_tool",
+            &["orbit.task.nope"],
+        );
+
+        let err = runtime
+            .v2_activity_catalog()
+            .expect_err("unknown concrete tool should fail");
+        let message = err.to_string();
+
+        assert!(message.contains("unknown_tool"), "{message}");
+        assert!(message.contains("orbit.task.nope"), "{message}");
+        assert!(message.contains("unknown tool name"), "{message}");
+    }
+
+    #[test]
+    fn activity_catalog_accepts_intentionally_empty_audit_wildcard() {
+        let (_root, runtime, _global_root, workspace_root) = test_runtime();
+        write_agent_loop_activity(
+            &workspace_root.join("resources/activities/audit_tools.yaml"),
+            "audit_tools",
+            &["orbit.audit.*"],
+        );
+
+        let catalog = runtime.v2_activity_catalog().expect("activity catalog");
+
+        assert!(catalog.get("audit_tools").is_some());
+    }
+
+    #[test]
+    fn default_activity_catalog_allowlists_resolve_registered_tools() {
+        let (_root, runtime, global_root, _workspace_root) = test_runtime();
+        let activities_dir = global_root.join("resources/activities");
+        for (name, yaml) in DEFAULT_ACTIVITY_FILES {
+            let path = activities_dir.join(format!("{name}.yaml"));
+            std::fs::create_dir_all(path.parent().expect("activity path has parent"))
+                .expect("create activity dir");
+            std::fs::write(path, yaml).expect("write activity yaml");
+        }
+
+        let catalog = runtime.v2_activity_catalog().expect("activity catalog");
+
+        assert_eq!(catalog.len(), DEFAULT_ACTIVITY_FILES.len());
     }
 }


### PR DESCRIPTION
## Task

[T20260509-24](https://orbit-cli.com/tasks/T20260509-24) — Validate activity tool allowlists during asset loading

### Description

## Problem
`validate_tool_allowlist` says activity allowlists are validated at asset-load time, but `load_activity_asset` and catalog loading never call it. Invalid wildcard roots and empty entries can be parsed and survive until execution.

## Why It Matters
Malformed tool policy should fail before dispatch; otherwise operators get late, confusing runtime behavior and assets can claim broader or misspelled tool access than Orbit recognizes.

## Constraints / Notes
Concrete tool existence requires registry context, so validate syntax in `orbit-common` and resolve concrete names or wildcards in the engine/core catalog layer where the registry is available.

## Scope Restriction
Do not modify anything under `./docs` as part of this task.

### Acceptance Criteria

- Loading an activity with an empty tool name or an unapproved wildcard root returns a parse/catalog error that names the offending entry.
- Concrete unknown tool names fail before provider dispatch, while permitted wildcard roots are accepted only when they expand to registered tools or intentionally empty roots are documented and tested.
- Catalog or asset-loader tests cover both accepted `orbit.task.*` and rejected `orbit.*` entries.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Added schema-time allowlist validation for activity assets so empty tool entries and unapproved wildcard roots fail with the offending entry named.
- Added registry-backed catalog/direct activity validation so unknown concrete tools fail before dispatch and wildcard roots must expand to registered tools unless explicitly reserved as intentionally empty.
- Updated default step failure recovery activity to remove unregistered fs.write from its allowlist and added tests for accepted orbit.task.*, rejected orbit.*, unknown concrete tools, and intentionally empty orbit.audit.*.

Assessment: The change is scoped to v2 activity allowlist loading/validation and is covered by common/core tests plus workspace build validation.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/T20260509-24-69fec9f9`
- Behind base: 0
- Ahead of base: 1

*authored by: gpt-5.5*