### PR TITLE
Require valid GitHub IDs in review tool responses

### DIFF
--- a/crates/orbit-tools/src/builtin/github/mod.rs
+++ b/crates/orbit-tools/src/builtin/github/mod.rs
@@ -202,6 +202,20 @@ pub(super) fn require_numeric_str(input: &Value, key: &str) -> Result<String, Or
     Ok(value)
 }
 
+pub(super) fn parse_gh_api_id(stdout: &str, label: &str) -> Result<u64, OrbitError> {
+    let response: Value = serde_json::from_str(stdout.trim())
+        .map_err(|err| OrbitError::Execution(format!("{label} returned invalid JSON: {err}")))?;
+    response
+        .as_object()
+        .and_then(|object| object.get("id"))
+        .and_then(Value::as_u64)
+        .ok_or_else(|| {
+            OrbitError::Execution(format!(
+                "{label} returned unexpected JSON: expected object with numeric `id`"
+            ))
+        })
+}
+
 /// Build an agent attribution footer line.
 ///
 /// Returns `None` when `agent_name` is not set on the context (i.e. the tool

--- a/crates/orbit-tools/src/builtin/github/pr_comment_reply.rs
+++ b/crates/orbit-tools/src/builtin/github/pr_comment_reply.rs
@@ -27,6 +27,14 @@ pub(super) fn build_exec_request(
     Ok(super::gh_exec_request(args, None, TIMEOUT_DEFAULT_MS))
 }
 
+fn parse_reply_response(stdout: &str) -> Result<Value, OrbitError> {
+    let id = super::parse_gh_api_id(stdout, "gh api (pr comment reply)")?;
+    Ok(json!({
+        "id": id,
+        "replied": true,
+    }))
+}
+
 super::gh_tool! {
     pub struct GithubPrCommentReplyTool;
     name: "github.pr.comment.reply";
@@ -42,11 +50,40 @@ super::gh_tool! {
     }
     response: |_ctx, _input, result| {
         check_exec_result(result, "gh api (pr comment reply)")?;
-        let response: Value = serde_json::from_str(result.stdout.trim()).unwrap_or(json!({}));
-        let id = response.get("id").and_then(Value::as_u64).unwrap_or(0);
-        Ok(json!({
-            "id": id,
-            "replied": true,
-        }))
+        parse_reply_response(&result.stdout)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_reply_response_returns_id_from_valid_stdout() {
+        let response = parse_reply_response(r#"{"id":24680,"body":"Done"}"#).unwrap();
+
+        assert_eq!(response["id"], json!(24680));
+        assert_eq!(response["replied"], json!(true));
+    }
+
+    #[test]
+    fn parse_reply_response_rejects_malformed_stdout() {
+        let error = parse_reply_response("not json").unwrap_err();
+
+        assert!(matches!(error, OrbitError::Execution(_)));
+    }
+
+    #[test]
+    fn parse_reply_response_rejects_empty_stdout() {
+        let error = parse_reply_response("").unwrap_err();
+
+        assert!(matches!(error, OrbitError::Execution(_)));
+    }
+
+    #[test]
+    fn parse_reply_response_rejects_object_without_id() {
+        let error = parse_reply_response(r#"{"body":"Done"}"#).unwrap_err();
+
+        assert!(matches!(error, OrbitError::Execution(_)));
     }
 }

--- a/crates/orbit-tools/src/builtin/github/pr_review.rs
+++ b/crates/orbit-tools/src/builtin/github/pr_review.rs
@@ -54,6 +54,14 @@ pub(super) fn build_exec_request(
     Ok(super::gh_exec_request(args, None, TIMEOUT_DEFAULT_MS))
 }
 
+fn parse_review_response(stdout: &str) -> Result<Value, OrbitError> {
+    let id = super::parse_gh_api_id(stdout, "gh api (pr review)")?;
+    Ok(json!({
+        "id": id,
+        "reviewed": true,
+    }))
+}
+
 super::gh_tool! {
     pub struct GithubPrReviewTool;
     name: "github.pr.review";
@@ -79,11 +87,40 @@ super::gh_tool! {
     }
     response: |_ctx, _input, result| {
         check_exec_result(result, "gh api (pr review)")?;
-        let response: Value = serde_json::from_str(result.stdout.trim()).unwrap_or(json!({}));
-        let id = response.get("id").and_then(Value::as_u64).unwrap_or(0);
-        Ok(json!({
-            "id": id,
-            "reviewed": true,
-        }))
+        parse_review_response(&result.stdout)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_review_response_returns_id_from_valid_stdout() {
+        let response = parse_review_response(r#"{"id":12345,"state":"APPROVED"}"#).unwrap();
+
+        assert_eq!(response["id"], json!(12345));
+        assert_eq!(response["reviewed"], json!(true));
+    }
+
+    #[test]
+    fn parse_review_response_rejects_malformed_stdout() {
+        let error = parse_review_response("not json").unwrap_err();
+
+        assert!(matches!(error, OrbitError::Execution(_)));
+    }
+
+    #[test]
+    fn parse_review_response_rejects_empty_stdout() {
+        let error = parse_review_response("").unwrap_err();
+
+        assert!(matches!(error, OrbitError::Execution(_)));
+    }
+
+    #[test]
+    fn parse_review_response_rejects_object_without_id() {
+        let error = parse_review_response(r#"{"state":"APPROVED"}"#).unwrap_err();
+
+        assert!(matches!(error, OrbitError::Execution(_)));
     }
 }

--- a/crates/orbit-tools/src/builtin/github/pr_review_comment.rs
+++ b/crates/orbit-tools/src/builtin/github/pr_review_comment.rs
@@ -77,6 +77,14 @@ fn resolve_pr_head_sha(repo: &str, pr: &str) -> Result<String, OrbitError> {
     Ok(sha)
 }
 
+fn parse_review_comment_response(stdout: &str) -> Result<Value, OrbitError> {
+    let id = super::parse_gh_api_id(stdout, "gh api (pr review comment)")?;
+    Ok(json!({
+        "id": id,
+        "commented": true,
+    }))
+}
+
 super::gh_tool! {
     pub struct GithubPrReviewCommentTool;
     name: "github.pr.review.comment";
@@ -109,11 +117,41 @@ super::gh_tool! {
     }
     response: |_ctx, _input, result| {
         check_exec_result(result, "gh api (pr review comment)")?;
-        let response: Value = serde_json::from_str(result.stdout.trim()).unwrap_or(json!({}));
-        let id = response.get("id").and_then(Value::as_u64).unwrap_or(0);
-        Ok(json!({
-            "id": id,
-            "commented": true,
-        }))
+        parse_review_comment_response(&result.stdout)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_review_comment_response_returns_id_from_valid_stdout() {
+        let response =
+            parse_review_comment_response(r#"{"id":67890,"body":"Looks good"}"#).unwrap();
+
+        assert_eq!(response["id"], json!(67890));
+        assert_eq!(response["commented"], json!(true));
+    }
+
+    #[test]
+    fn parse_review_comment_response_rejects_malformed_stdout() {
+        let error = parse_review_comment_response("not json").unwrap_err();
+
+        assert!(matches!(error, OrbitError::Execution(_)));
+    }
+
+    #[test]
+    fn parse_review_comment_response_rejects_empty_stdout() {
+        let error = parse_review_comment_response("").unwrap_err();
+
+        assert!(matches!(error, OrbitError::Execution(_)));
+    }
+
+    #[test]
+    fn parse_review_comment_response_rejects_object_without_id() {
+        let error = parse_review_comment_response(r#"{"body":"Looks good"}"#).unwrap_err();
+
+        assert!(matches!(error, OrbitError::Execution(_)));
     }
 }


### PR DESCRIPTION
## Task

[T20260509-36](https://orbit-cli.com/tasks/T20260509-36) — Require valid GitHub IDs in review tool responses

### Description

## Problem
`github.pr.review`, `github.pr.review.comment`, and `github.pr.comment.reply` parse successful `gh api` stdout with `serde_json::from_str(...).unwrap_or(json!({}))` and then default missing `id` values to `0` while reporting success.

## Why It Matters
Callers can record a successful review/comment/reply with id `0` when GitHub returned malformed or unexpected output.

## Constraints / Notes
Successful process exit is not enough; the response contract should validate the expected JSON shape.

## Scope Restriction
Do not modify anything under `./docs` as part of this task.

### Acceptance Criteria

- Malformed, empty, or object-without-id stdout from a successful `gh api` call returns an `OrbitError` for all three tools.
- Valid GitHub responses return the actual numeric id and success flag as before.
- Unit tests or macro-level tests cover malformed success stdout for review, inline review comment, and reply tools.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Added shared GitHub API response validation that requires successful stdout to be valid JSON containing a numeric `id`.
- Updated review, inline review comment, and reply tools to use the validated ID while preserving their success flags.
- Added focused unit coverage for valid IDs plus malformed, empty, and object-without-id stdout for all three tools.

Assessment: The response contract now fails closed on unexpected successful `gh api` output and preserves existing valid response shapes.

Validation:
- make fmt
- cargo test -p orbit-tools parse_
- make build

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/T20260509-36-69fecdcc`
- Behind base: 0
- Ahead of base: 1

*authored by: gpt-5.5*