### PR TITLE
Demote CLI agent success when failed envelope is embedded after prose

### DIFF
--- a/crates/orbit-agent/src/types/response/envelope.rs
+++ b/crates/orbit-agent/src/types/response/envelope.rs
@@ -1,6 +1,7 @@
 use orbit_common::types::{
     AgentResponseEnvelope, AgentRunError, ExecutionResult, InvocationTrace, OrbitError,
 };
+use serde::Deserialize;
 use serde_json::{Deserializer, Value};
 
 use super::{AgentResponseStatus, ResponseParseResult, trace::extract_invocation_trace};
@@ -206,10 +207,7 @@ fn find_agent_response_envelope(value: &Value) -> Option<AgentResponseEnvelope> 
     }
 
     match value {
-        Value::String(raw) => {
-            let nested = serde_json::from_str::<Value>(raw).ok()?;
-            find_agent_response_envelope(&nested)
-        }
+        Value::String(raw) => find_agent_response_envelope_in_string(raw),
         Value::Array(items) => items.iter().rev().find_map(find_agent_response_envelope),
         Value::Object(map) => {
             for key in [
@@ -231,6 +229,20 @@ fn find_agent_response_envelope(value: &Value) -> Option<AgentResponseEnvelope> 
         }
         _ => None,
     }
+}
+
+fn find_agent_response_envelope_in_string(raw: &str) -> Option<AgentResponseEnvelope> {
+    if let Ok(nested) = serde_json::from_str::<Value>(raw) {
+        if let Some(envelope) = find_agent_response_envelope(&nested) {
+            return Some(envelope);
+        }
+    }
+
+    raw.match_indices('{').find_map(|(start, _)| {
+        let mut deserializer = Deserializer::from_str(&raw[start..]);
+        let nested = Value::deserialize(&mut deserializer).ok()?;
+        find_agent_response_envelope(&nested)
+    })
 }
 
 fn deserialize_envelope(value: &Value) -> Option<AgentResponseEnvelope> {
@@ -327,8 +339,34 @@ mod tests {
     }
 
     #[test]
+    fn peek_response_status_extracts_failed_from_prose_prefixed_claude_result() {
+        let result = concat!(
+            "I could not continue after the workspace disappeared.\n",
+            r#"{"schemaVersion":1,"status":"failed","error":{"code":"workspace_unavailable","message":"worktree missing","details":null}}"#
+        );
+        let stdout = serde_json::json!({
+            "type": "result",
+            "subtype": "success",
+            "result": result,
+            "usage": {
+                "input_tokens": 10,
+                "output_tokens": 3
+            }
+        })
+        .to_string();
+
+        assert_eq!(peek_response_status(&stdout).as_deref(), Some("failed"));
+    }
+
+    #[test]
     fn peek_response_status_returns_none_when_no_envelope_present() {
         assert_eq!(peek_response_status("{\"hello\":\"world\"}"), None);
+        assert_eq!(peek_response_status("{\"status\":\"failed\"}"), None);
+        let prose_with_braces = serde_json::json!({
+            "result": "prose with {arbitrary braces} and {\"status\":\"failed\"}, but no Orbit envelope"
+        })
+        .to_string();
+        assert_eq!(peek_response_status(&prose_with_braces), None);
         assert_eq!(peek_response_status(""), None);
         assert_eq!(peek_response_status("not json"), None);
     }

--- a/crates/orbit-engine/src/activity_job/cli_runner/tests/orchestrator_tests.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/tests/orchestrator_tests.rs
@@ -258,11 +258,25 @@ fn run_cli_backend_demotes_success_when_envelope_reports_failed_despite_exit_zer
     // the script name must match a known provider. The demotion logic is
     // provider-agnostic — codex exercises the same code path as claude.
     let script = temp.path().join("codex");
-    // Stdout shape mirrors the Claude CLI: a wrapping JSON whose `result`
-    // is a stringified Orbit envelope with status="failed". Exit 0.
+    // Stdout shape mirrors the observed Claude CLI failure: a wrapping JSON
+    // whose `result` string starts with prose before embedding an Orbit
+    // envelope with status="failed". Exit 0.
+    let stdout = serde_json::json!({
+        "type": "result",
+        "subtype": "success",
+        "result": concat!(
+            "I could not continue after the workspace disappeared.\n",
+            r#"{"schemaVersion":1,"status":"failed","error":{"code":"workspace_unavailable","message":"worktree missing","details":null}}"#
+        ),
+        "usage": {
+            "input_tokens": 1,
+            "output_tokens": 1
+        }
+    })
+    .to_string();
     write_executable(
         &script,
-        "#!/bin/sh\ncat > /dev/null\nprintf '%s\\n' '{\"type\":\"result\",\"subtype\":\"success\",\"result\":\"{\\\"schemaVersion\\\":1,\\\"status\\\":\\\"failed\\\",\\\"error\\\":{\\\"code\\\":\\\"E\\\",\\\"message\\\":\\\"m\\\",\\\"details\\\":null}}\",\"usage\":{\"input_tokens\":1,\"output_tokens\":1}}'\n",
+        &format!("#!/bin/sh\ncat > /dev/null\nprintf '%s\\n' '{stdout}'\n"),
     );
 
     let sink = Arc::new(RecordingSink::default());


### PR DESCRIPTION
## Task

[T20260509-15](https://orbit-cli.com/tasks/T20260509-15) — Demote CLI agent success when failed envelope is embedded after prose

### Description

## Problem
Run `jrun-20260509-0303-3` failed after the active worktree `/Users/daniel/workspace/repos/orbit/.orbit/state/worktrees/orbit-jrun-20260509-0303-3` disappeared while `agent_implement` was running. The external deletion explains why the implementer could not continue.

The Orbit bug is that the pipeline did not stop at `implement_one` after the implementer reported a structured failure. The Claude CLI exited `0` with an outer JSON wrapper whose `result` field began with prose and then embedded an Orbit envelope:

`{"schemaVersion":1,"status":"failed","error":{"code":"workspace_unavailable",...}}`

`crates/orbit-engine/src/activity_job/cli_runner/orchestrator.rs` relies on `peek_response_status` to demote exit-0 CLI invocations when an embedded envelope reports `failed` or `timeout`. But `crates/orbit-agent/src/types/response/envelope.rs` only recurses into string values when the entire string parses as JSON. Because this result string had explanatory prose before the JSON object, `peek_response_status` returned `None`, `run_cli_backend` kept `success=true`, and the job recorded `implement_one` / `implement_bundle` as successful. The pipeline then advanced to `git_push`, which failed on the already-missing workspace path and obscured the real implementer failure.

Related self-reported friction: `T20260509-13`.

## Why It Matters
A failed implementation step must stop the PR pipeline before push/PR actions. If provider output contains a valid Orbit failure envelope after prose, Orbit should still preserve the failure signal; otherwise workflows can push empty branches, invoke recovery for the wrong step, and make root-cause diagnosis much harder.

## Constraints / Notes
- The user confirmed the missing worktree/branch was likely deleted manually during the run; this task should not try to prevent external deletion.
- Scope the fix to response-envelope detection and CLI outcome classification.
- Keep legacy provider shapes safe: arbitrary prose with no envelope should still return `None` from `peek_response_status` rather than becoming a protocol error.
- Do not make tests depend on local `.orbit/state/audit` files; construct deterministic stdout fixtures from the observed shape instead.

## Scope Restriction
Do not modify anything under `./docs` as part of this task.

### Acceptance Criteria

- A deterministic `orbit-agent` unit test constructs Claude-shaped stdout whose outer `result` string contains leading prose followed by a valid Orbit envelope with `status: "failed"`; `peek_response_status` returns `Some("failed")`.
- A deterministic `orbit-engine` CLI runner regression test constructs an exit-0 provider subprocess with the same prose-prefixed failed envelope shape and verifies `run_cli_backend(...).success == false` with a message that names the failed envelope status.
- Existing `peek_response_status` behavior remains covered: a fully JSON-stringified inner envelope is detected, a direct success envelope is detected as success, and non-envelope prose / non-envelope JSON returns `None` without failing the dispatch path.
- The implementation avoids treating arbitrary braces in prose as an envelope unless the extracted JSON object validates as an `AgentResponseEnvelope` with `schemaVersion` and `status`.
- Running `cargo test -p orbit-agent peek_response_status` and `cargo test -p orbit-engine run_cli_backend_demotes_success -- --nocapture` succeeds after the fix.
- No validation step requires the local `jrun-20260509-0303-3` audit blobs or `.orbit/state/worktrees` directory to exist; those artifacts are evidence in the task description only.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Updated peek_response_status envelope discovery so JSON string fields can contain leading prose before a valid embedded Orbit response envelope; candidates are only accepted after deserializing as AgentResponseEnvelope with schemaVersion and status.
- Added orbit-agent regression coverage for prose-prefixed Claude-shaped output, preserved direct/stringified success and failure detection, and covered non-envelope prose/JSON with arbitrary braces.
- Updated the orbit-engine CLI runner demotion regression to use an exit-0 provider subprocess with the prose-prefixed failed envelope shape.

Assessment: The dispatcher now preserves structured failed/timeout envelope signals even when provider prose precedes the embedded payload, while legacy non-envelope provider output still falls through as None.

Validation:
- make fmt
- cargo test -p orbit-agent peek_response_status
- cargo test -p orbit-engine run_cli_backend_demotes_success -- --nocapture
- make build

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/T20260509-15-69fecdcc`
- Behind base: 0
- Ahead of base: 1

*authored by: gpt-5.5*