### PR TITLE
Reject job steps with multiple body shapes

### DIFF
--- a/crates/orbit-common/src/types/activity_job/job_v2.rs
+++ b/crates/orbit-common/src/types/activity_job/job_v2.rs
@@ -57,9 +57,8 @@ pub struct JobV2Step {
     pub body: JobV2StepBody,
 }
 
-/// One-of body for a v2 step. Picked by presence of the `parallel` / `fan_out`
-/// / `loop` / `target` keys; otherwise falls back to the flat target shape
-/// (inline `spec:`).
+/// One-of body for a v2 step. Picked by exactly one of the `target`, `spec`,
+/// `parallel`, `fan_out`, or `loop` body keys.
 ///
 /// `TargetRef` and `Target` are distinct variants so the executor only ever
 /// sees `Target` after [`super::catalog::resolve_job_target_refs`] runs at
@@ -113,16 +112,27 @@ impl<'de> Deserialize<'de> for JobV2Step {
         let has_fan_out = obj.contains_key("fan_out");
         let has_loop = obj.contains_key("loop");
         let has_target = obj.contains_key("target");
+        let has_spec = obj.contains_key("spec");
 
-        let body = match (has_parallel, has_fan_out, has_loop) {
-            (true, false, false) => {
+        let body_shape_count = [has_parallel, has_fan_out, has_loop, has_target, has_spec]
+            .iter()
+            .filter(|present| **present)
+            .count();
+        if body_shape_count != 1 {
+            return Err(D::Error::custom(
+                "step must set exactly one body shape: `target`, `spec`, `parallel`, `fan_out`, or `loop`",
+            ));
+        }
+
+        let body = match (has_parallel, has_fan_out, has_loop, has_target, has_spec) {
+            (true, false, false, false, false) => {
                 let block = obj.remove("parallel").unwrap();
                 JobV2StepBody::Parallel {
                     parallel: serde_json::from_value(block)
                         .map_err(|e| D::Error::custom(format!("parallel: {e}")))?,
                 }
             }
-            (false, true, false) => {
+            (false, true, false, false, false) => {
                 let fan_out_block = obj.remove("fan_out").unwrap();
                 let fan_in_block = obj
                     .remove("fan_in")
@@ -134,26 +144,22 @@ impl<'de> Deserialize<'de> for JobV2Step {
                         .map_err(|e| D::Error::custom(format!("fan_in: {e}")))?,
                 }
             }
-            (false, false, true) => {
+            (false, false, true, false, false) => {
                 let block = obj.remove("loop").unwrap();
                 JobV2StepBody::Loop {
                     loop_: serde_json::from_value(block)
                         .map_err(|e| D::Error::custom(format!("loop: {e}")))?,
                 }
             }
-            (false, false, false) if has_target => JobV2StepBody::TargetRef(
+            (false, false, false, true, false) => JobV2StepBody::TargetRef(
                 serde_json::from_value(Value::Object(std::mem::take(obj)))
                     .map_err(|e| D::Error::custom(format!("target ref: {e}")))?,
             ),
-            (false, false, false) => JobV2StepBody::Target(
+            (false, false, false, false, true) => JobV2StepBody::Target(
                 serde_json::from_value(Value::Object(std::mem::take(obj)))
                     .map_err(|e| D::Error::custom(format!("target step: {e}")))?,
             ),
-            _ => {
-                return Err(D::Error::custom(
-                    "step may set exactly one of `parallel`, `fan_out`, or `loop`",
-                ));
-            }
+            _ => unreachable!("body shape count already validated"),
         };
 
         Ok(JobV2Step {
@@ -344,6 +350,60 @@ const fn default_max_workers() -> u32 {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn assert_step_body_shape_error(yaml: &str) {
+        let err = serde_yaml::from_str::<JobV2Step>(yaml).expect_err("step should fail to parse");
+        assert!(
+            err.to_string().contains("exactly one body shape"),
+            "unexpected parse error: {err}",
+        );
+    }
+
+    #[test]
+    fn rejects_step_with_parallel_and_target() {
+        assert_step_body_shape_error(
+            r#"
+id: invalid
+parallel:
+  join: { mode: all }
+  branches:
+    - id: branch
+      target: activity:something
+target: activity:other
+"#,
+        );
+    }
+
+    #[test]
+    fn rejects_step_with_fan_out_and_loop() {
+        assert_step_body_shape_error(
+            r#"
+id: invalid
+fan_out:
+  items: "{{ input.items }}"
+  worker:
+    id: worker
+    target: activity:something
+fan_in:
+  join: { mode: all }
+loop:
+  max_iterations: 1
+  steps:
+    - id: loop_child
+      target: activity:something
+"#,
+        );
+    }
+
+    #[test]
+    fn rejects_step_without_body_shape() {
+        assert_step_body_shape_error(
+            r#"
+id: invalid
+when: "{{ input.ready }}"
+"#,
+        );
+    }
 
     #[test]
     fn target_step_yaml_carries_step_level_role() {


### PR DESCRIPTION
## Task

[T20260509-31](https://orbit-cli.com/tasks/T20260509-31) — Reject job steps with multiple body shapes

### Description

## Problem
`JobV2Step` deserialization records `has_target`, but the body-shape match only considers `parallel`, `fan_out`, and `loop`. A YAML step containing both `parallel` and `target` parses as `Parallel` and silently drops the target.

## Why It Matters
Malformed workflow YAML can execute a different step shape than the author intended, making reviews and audit trails misleading.

## Constraints / Notes
The schema comment says each step has exactly one body; enforce that invariant in deserialization.

## Scope Restriction
Do not modify anything under `./docs` as part of this task.

### Acceptance Criteria

- Deserialization counts `parallel`, `fan_out`, `loop`, `target`, and inline `spec` indicators and rejects anything other than exactly one body shape.
- Parse-failure tests cover `parallel + target`, `fan_out + loop`, and missing body shapes.
- Valid existing default job assets still load and resolve.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Updated `JobV2Step` deserialization to count `target`, inline `spec`, `parallel`, `fan_out`, and `loop` as mutually exclusive body shapes and reject zero or multiple indicators before selecting a body variant.
- Added parse-failure tests for `parallel` + `target`, `fan_out` + `loop`, and missing body shape YAML.

Assessment: Focused change in `orbit-common`; existing default job asset resolution remains covered by the catalog test. Validation passed: `make fmt`, `cargo test -p orbit-common activity_job::job_v2::tests`, `cargo test -p orbit-core default_job_target_refs_resolve_against_default_activities`, and `make build`.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/T20260509-31-69fecdcc`
- Behind base: 0
- Ahead of base: 1

*authored by: gpt-5.5*