### PR TITLE
Include `orbit-registry` in dependency-direction guardrails

### DIFF
--- a/crates/orbit-common/src/types/activity_job/tool_allowlist.rs
+++ b/crates/orbit-common/src/types/activity_job/tool_allowlist.rs
@@ -47,7 +47,7 @@ pub fn validate_tool_allowlist(allowlist: &[String]) -> Result<(), ToolAllowlist
             return Err(ToolAllowlistError::EmptyName { index });
         }
         if let Some(prefix) = wildcard_prefix(entry)
-            && !V2_TOOL_WILDCARD_ROOTS.iter().any(|root| *root == prefix)
+            && !V2_TOOL_WILDCARD_ROOTS.contains(&prefix)
         {
             return Err(ToolAllowlistError::WildcardRootNotPermitted {
                 entry: entry.clone(),
@@ -75,11 +75,7 @@ where
     for entry in allowlist {
         if let Some(prefix) = wildcard_prefix(entry) {
             let has_match = registered_tools.iter().any(|tool| tool.starts_with(prefix));
-            if !has_match
-                && !V2_INTENTIONALLY_EMPTY_TOOL_WILDCARD_ROOTS
-                    .iter()
-                    .any(|root| *root == prefix)
-            {
+            if !has_match && !V2_INTENTIONALLY_EMPTY_TOOL_WILDCARD_ROOTS.contains(&prefix) {
                 return Err(ToolAllowlistError::WildcardRootMatchesNoTools {
                     entry: entry.clone(),
                 });
@@ -125,7 +121,7 @@ pub fn tool_allowed(tool_name: &str, allowlist: &[String]) -> bool {
             return true;
         }
         if let Some(prefix) = wildcard_prefix(entry)
-            && tool_name.starts_with(&prefix)
+            && tool_name.starts_with(prefix)
         {
             return true;
         }
@@ -153,7 +149,7 @@ mod tests {
     fn registry_validation_accepts_documented_empty_audit_root() {
         validate_tool_allowlist_against_registered_tools(
             &["orbit.audit.*".to_string()],
-            ["orbit.task.show"].into_iter(),
+            ["orbit.task.show"],
         )
         .expect("reserved audit root is intentionally empty");
     }
@@ -162,7 +158,7 @@ mod tests {
     fn registry_validation_rejects_unmatched_non_empty_root() {
         let err = validate_tool_allowlist_against_registered_tools(
             &["fs.*".to_string()],
-            ["orbit.task.show"].into_iter(),
+            ["orbit.task.show"],
         )
         .expect_err("fs wildcard must match registered tools");
 

--- a/scripts/check-dependency-direction.sh
+++ b/scripts/check-dependency-direction.sh
@@ -10,6 +10,9 @@ allowed_internal_deps() {
     orbit-common)
       echo ""
       ;;
+    orbit-registry)
+      echo "orbit-common"
+      ;;
     orbit-policy | orbit-exec | orbit-knowledge | orbit-store)
       echo "orbit-common"
       ;;
@@ -32,7 +35,7 @@ allowed_internal_deps() {
       echo "orbit-common orbit-core orbit-mcp"
       ;;
     *)
-      echo ""
+      return 1
       ;;
   esac
 }
@@ -48,19 +51,35 @@ contains_word() {
   return 1
 }
 
-workspace_crates=(
-  orbit-agent
-  orbit-cli
-  orbit-common
-  orbit-core
-  orbit-engine
-  orbit-exec
-  orbit-knowledge
-  orbit-mcp
-  orbit-policy
-  orbit-store
-  orbit-tools
+load_workspace_crates() {
+  cargo metadata --format-version 1 --no-deps --manifest-path "$repo_root/Cargo.toml" |
+    python3 -c '
+import json
+import sys
+
+metadata = json.load(sys.stdin)
+workspace_members = set(metadata["workspace_members"])
+workspace_crates = sorted(
+    package["name"]
+    for package in metadata["packages"]
+    if package["id"] in workspace_members and package["name"].startswith("orbit-")
 )
+for crate in workspace_crates:
+    print(crate)
+'
+}
+
+workspace_crates=()
+while IFS= read -r crate; do
+  if [[ -n "$crate" ]]; then
+    workspace_crates+=("$crate")
+  fi
+done < <(load_workspace_crates)
+
+if [[ "${#workspace_crates[@]}" -eq 0 ]]; then
+  echo "no orbit workspace crates discovered from cargo metadata"
+  exit 1
+fi
 
 for crate in "${workspace_crates[@]}"; do
   manifest="$repo_root/crates/${crate}/Cargo.toml"
@@ -70,7 +89,12 @@ for crate in "${workspace_crates[@]}"; do
     continue
   fi
 
-  allowed="$(allowed_internal_deps "$crate")"
+  if ! allowed="$(allowed_internal_deps "$crate")"; then
+    echo "missing dependency direction policy for workspace crate '${crate}'"
+    fail=1
+    continue
+  fi
+
   while IFS= read -r dep; do
     if [[ -n "$dep" ]] && ! contains_word "$allowed" "$dep"; then
       echo "forbidden dependency '${dep}' found in ${manifest}"


### PR DESCRIPTION
## Task

[T20260509-46](https://orbit-cli.com/tasks/T20260509-46) — Include `orbit-registry` in dependency-direction guardrails

### Description

## Problem
The workspace includes `crates/orbit-registry`, but `scripts/check-dependency-direction.sh` hardcodes `workspace_crates` without it. The crate already depends on `orbit-common`, so future forbidden internal dependencies in `orbit-registry` would not be caught by CI.

## Why It Matters
Architecture guardrails can pass while a workspace crate drifts outside the allowed dependency graph.

## Constraints / Notes
Prefer deriving the crate list from `cargo metadata` so new workspace crates cannot be silently omitted.

## Scope Restriction
Do not modify anything under `./docs` as part of this task.

### Acceptance Criteria

- Dependency-direction CI covers `orbit-registry` with explicit allowed internal dependencies, or derives all workspace crates automatically.
- A guardrail test or fixture fails when a workspace crate is omitted from the check list.
- `make ci` runs the updated guard successfully.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- `scripts/check-dependency-direction.sh` now discovers `orbit-*` workspace members from `cargo metadata`, adds explicit `orbit-registry -> orbit-common` policy, and fails when a discovered crate lacks policy.
- `crates/orbit-common/src/types/activity_job/tool_allowlist.rs` received small clippy fixes required for `make ci` on the current toolchain.

Assessment: dependency guard now covers new workspace crates automatically while preserving explicit dependency policy.

Validation:
- `./scripts/check-dependency-direction.sh`
- temporary omission fixture confirmed missing `orbit-registry` policy fails
- `make ci`

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/T20260509-46-69fecef5`
- Behind base: 0
- Ahead of base: 1

*authored by: gpt-5.5*