### PR TITLE
Resolve dashboard dependency statuses from all tasks

### DIFF
--- a/crates/orbit-cli/src/command/web/api/mod.rs
+++ b/crates/orbit-cli/src/command/web/api/mod.rs
@@ -313,10 +313,11 @@ mod tests {
 
     use axum::body::Body;
     use axum::http::{Method, Request, StatusCode, header};
-    use orbit_core::{JobRunState, OrbitRuntime};
+    use orbit_core::command::task::TaskAddParams;
+    use orbit_core::{JobRunState, OrbitRuntime, TaskStatus};
     use tower::ServiceExt;
 
-    use super::test_support::seed_run;
+    use super::test_support::{body_json, seed_run};
     use super::*;
 
     async fn request_cancel(runtime: OrbitRuntime, run_id: &str, origin: Option<&str>) -> Response {
@@ -331,6 +332,38 @@ mod tests {
             .oneshot(builder.body(Body::empty()).expect("request"))
             .await
             .expect("response")
+    }
+
+    async fn request_tasks(runtime: OrbitRuntime) -> Response {
+        router()
+            .with_state(Arc::new(runtime))
+            .oneshot(
+                Request::builder()
+                    .method(Method::GET)
+                    .uri("/tasks")
+                    .body(Body::empty())
+                    .expect("request"),
+            )
+            .await
+            .expect("response")
+    }
+
+    fn seed_task(
+        runtime: &OrbitRuntime,
+        title: &str,
+        status: TaskStatus,
+        dependencies: Vec<String>,
+    ) -> orbit_core::Task {
+        runtime
+            .add_task(TaskAddParams {
+                title: title.to_string(),
+                description: format!("Fixture for {title}."),
+                status: Some(status),
+                dependencies,
+                workspace_path: Some(".".to_string()),
+                ..Default::default()
+            })
+            .expect("create task")
     }
 
     #[tokio::test]
@@ -355,6 +388,78 @@ mod tests {
             let stored = runtime.show_job_run(&run.run_id).expect("show run");
             assert_eq!(stored.state, JobRunState::Pending, "{label}");
         }
+    }
+
+    #[tokio::test]
+    async fn tasks_resolve_dependency_statuses_from_all_tasks() {
+        let runtime = OrbitRuntime::in_memory().expect("build runtime");
+        let done = seed_task(
+            &runtime,
+            "Completed dependency",
+            TaskStatus::Done,
+            Vec::new(),
+        );
+        let archived = seed_task(
+            &runtime,
+            "Archived dependency",
+            TaskStatus::Backlog,
+            Vec::new(),
+        );
+        runtime.archive_task(&archived.id).expect("archive task");
+        let rejected = seed_task(
+            &runtime,
+            "Rejected dependency",
+            TaskStatus::Rejected,
+            Vec::new(),
+        );
+        let visible = seed_task(
+            &runtime,
+            "Visible dependent",
+            TaskStatus::Backlog,
+            vec![done.id.clone(), archived.id.clone(), rejected.id.clone()],
+        );
+
+        let response = request_tasks(runtime).await;
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = body_json(response).await;
+        let rows = body.as_array().expect("tasks response array");
+        assert!(
+            rows.iter()
+                .any(|task| task["id"].as_str() == Some(&visible.id))
+        );
+        assert!(
+            rows.iter()
+                .any(|task| task["id"].as_str() == Some(&rejected.id))
+        );
+        assert!(
+            !rows
+                .iter()
+                .any(|task| task["id"].as_str() == Some(&done.id))
+        );
+        assert!(
+            !rows
+                .iter()
+                .any(|task| task["id"].as_str() == Some(&archived.id))
+        );
+
+        let visible_json = rows
+            .iter()
+            .find(|task| task["id"].as_str() == Some(&visible.id))
+            .expect("visible task row");
+        let dependencies = visible_json["resolved_dependencies"]
+            .as_array()
+            .expect("resolved dependencies array");
+        let dependency_labels = dependencies
+            .iter()
+            .map(|value| value.as_str().expect("dependency label"))
+            .collect::<Vec<_>>();
+        let done_label = format!("{} [done]", done.id);
+        let archived_label = format!("{} [archived]", archived.id);
+        let rejected_label = format!("{} [rejected]", rejected.id);
+        assert!(dependency_labels.contains(&done_label.as_str()));
+        assert!(dependency_labels.contains(&archived_label.as_str()));
+        assert!(dependency_labels.contains(&rejected_label.as_str()));
     }
 
     #[tokio::test]

--- a/crates/orbit-cli/src/command/web/api/tasks.rs
+++ b/crates/orbit-cli/src/command/web/api/tasks.rs
@@ -107,14 +107,16 @@ pub(super) struct UpdateTaskBody {
 
 pub(super) async fn list_tasks(State(runtime): State<Arc<OrbitRuntime>>) -> Response {
     match list_dashboard_tasks(&runtime) {
-        Ok(tasks) => {
-            let status_by_id = orbit_core::build_task_status_index(&tasks);
-            let values: Vec<Value> = tasks
-                .iter()
-                .map(|task| task_to_json(task, &status_by_id))
-                .collect();
-            Json(Value::Array(values)).into_response()
-        }
+        Ok(tasks) => match dashboard_status_index(&runtime) {
+            Ok(status_by_id) => {
+                let values: Vec<Value> = tasks
+                    .iter()
+                    .map(|task| task_to_json(task, &status_by_id))
+                    .collect();
+                Json(Value::Array(values)).into_response()
+            }
+            Err(e) => server_error(e),
+        },
         Err(e) => server_error(e),
     }
 }
@@ -130,9 +132,7 @@ fn list_dashboard_tasks(runtime: &OrbitRuntime) -> Result<Vec<Task>, orbit_core:
 fn dashboard_status_index(
     runtime: &OrbitRuntime,
 ) -> Result<std::collections::BTreeMap<String, TaskStatus>, orbit_core::OrbitError> {
-    Ok(orbit_core::build_task_status_index(&list_dashboard_tasks(
-        runtime,
-    )?))
+    Ok(orbit_core::build_task_status_index(&runtime.list_tasks()?))
 }
 
 pub(super) async fn get_task(


### PR DESCRIPTION
## Task

[T20260509-48](https://orbit-cli.com/tasks/T20260509-48) — Resolve dashboard dependency statuses from all tasks

### Description

## Problem
The dashboard task API builds `status_by_id` only from dashboard-visible statuses, excluding `done` and `archived`. Dependency resolution treats absent IDs as `missing`, so a visible task depending on a completed task can be reported as depending on a missing task.

## Why It Matters
Operators can misread task readiness and dependency health in the UI/API.

## Constraints / Notes
Continue filtering displayed rows; only the dependency-status index needs full task visibility.

## Scope Restriction
Do not modify anything under `./docs` as part of this task.

### Acceptance Criteria

- Dashboard task JSON builds dependency status indexes from all `runtime.list_tasks()` results while still returning only display-filtered rows.
- A web API test shows a backlog or in-progress task depending on a `done` task reports dependency status `done`, not `missing`.
- Archived and rejected dependencies are represented accurately according to existing `dependency_statuses` semantics.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Updated the dashboard task API to keep display rows filtered through DASHBOARD_TASK_STATUSES while resolving dependency labels from a status index built from runtime.list_tasks().
- Added a web API regression test covering a backlog task that depends on done, archived, and rejected tasks; /tasks excludes done/archived rows while reporting dependency labels as done, archived, and rejected.

Assessment: Focused fix with regression coverage for the prior missing-status behavior.

Validation:
- cargo test -p orbit-cli tasks_resolve_dependency_statuses_from_all_tasks
- make fmt
- make fmt-check
- make build
- git diff --check

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/T20260509-48-69fecefe`
- Behind base: 0
- Ahead of base: 1

*authored by: gpt-5.5*