### PR TITLE
Bound and redact CLI `stdout_text` in dispatch output

### DIFF
--- a/crates/orbit-engine/src/activity_job/cli_runner/orchestrator.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/orchestrator.rs
@@ -5,7 +5,7 @@ use std::time::Duration;
 
 use orbit_agent::{Agent, AgentConfig, AgentOperation, AgentRequest, peek_response_status};
 use orbit_common::types::activity_job::{AgentLoopSpec, V2AuditEventKind};
-use orbit_common::utility::redaction::PatternRedactor;
+use orbit_common::utility::redaction::{PatternRedactor, redact_sensitive_env_text};
 use serde_json::Value;
 
 use super::super::audit_writer::V2AuditWriter;
@@ -21,6 +21,8 @@ use super::supervisor::{
     DEFAULT_WALL_CLOCK_TIMEOUT_SECONDS, SpawnTraceContext, SpawnWithTimeoutRequest,
     spawn_with_timeout,
 };
+
+const STDOUT_TEXT_PREVIEW_LIMIT_BYTES: usize = 64 * 1024;
 
 pub fn run_cli_backend(
     host: &dyn V2RuntimeHost,
@@ -174,6 +176,7 @@ pub fn run_cli_backend(
     let exit_success = !timed_out && matches!(exit_code, Some(0));
     let stdout_text = String::from_utf8_lossy(&stdout).into_owned();
     let envelope_status = peek_response_status(&stdout_text);
+    let stdout_preview = stdout_text_preview(&stdout_text, &redaction);
     let envelope_indicates_failure =
         matches!(envelope_status.as_deref(), Some("failed") | Some("timeout"));
     let success = exit_success && !envelope_indicates_failure;
@@ -211,7 +214,11 @@ pub fn run_cli_backend(
             "exit_code": exit_code,
             "duration_ms": duration.as_millis() as u64,
             "timed_out": timed_out,
-            "stdout_text": stdout_text,
+            "stdout_text": stdout_preview.text,
+            "stdout_text_truncated": stdout_preview.truncated,
+            "stdout_text_original_bytes": stdout.len(),
+            "stdout_text_preview_bytes": stdout_preview.preview_bytes,
+            "stdout_text_preview_limit_bytes": STDOUT_TEXT_PREVIEW_LIMIT_BYTES,
         }),
         message,
         invocation: trace.map(|trace| DispatchInvocationTrace {
@@ -220,4 +227,33 @@ pub fn run_cli_backend(
             trace,
         }),
     })
+}
+
+struct StdoutTextPreview {
+    text: String,
+    truncated: bool,
+    preview_bytes: usize,
+}
+
+fn stdout_text_preview(raw: &str, redactor: &PatternRedactor) -> StdoutTextPreview {
+    let redacted = redactor.apply_str(&redact_sensitive_env_text(raw));
+    let truncated = redacted.len() > STDOUT_TEXT_PREVIEW_LIMIT_BYTES;
+    let text = if truncated {
+        let boundary = redacted
+            .char_indices()
+            .map(|(idx, _)| idx)
+            .take_while(|idx| *idx <= STDOUT_TEXT_PREVIEW_LIMIT_BYTES)
+            .last()
+            .unwrap_or(0);
+        redacted[..boundary].to_string()
+    } else {
+        redacted
+    };
+    let preview_bytes = text.len();
+
+    StdoutTextPreview {
+        text,
+        truncated,
+        preview_bytes,
+    }
 }

--- a/crates/orbit-engine/src/activity_job/cli_runner/tests/orchestrator_tests.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/tests/orchestrator_tests.rs
@@ -39,6 +39,8 @@ fn run_cli_backend_finished_audit_event_keeps_stdout_stderr_blob_refs() {
 
     assert!(outcome.success);
     assert_eq!(outcome.output["stdout_text"], "plain stdout\n");
+    assert_eq!(outcome.output["stdout_text_truncated"], false);
+    assert_eq!(outcome.output["stdout_text_original_bytes"], 13);
     let events = audit.events_snapshot().expect("events snapshot");
     let finished = events
         .iter()
@@ -68,6 +70,124 @@ fn run_cli_backend_finished_audit_event_keeps_stdout_stderr_blob_refs() {
     assert!(!finished.4);
     assert_eq!(sink.blob("blob-2"), Some(b"plain stdout\n".to_vec()));
     assert_eq!(sink.blob("blob-3"), Some(b"plain stderr\n".to_vec()));
+}
+
+#[test]
+fn run_cli_backend_bounds_stdout_text_preview_and_keeps_envelope_status_from_full_stdout() {
+    let temp = tempdir().expect("tempdir");
+    let script = temp.path().join("codex");
+    let embedded_envelope = r#"{"schemaVersion":1,"status":"failed","error":{"code":"workspace_unavailable","message":"worktree missing","details":null}}"#;
+    let stdout = serde_json::json!({
+        "type": "result",
+        "subtype": "success",
+        "result": format!("{}{}", "x".repeat(70 * 1024), embedded_envelope),
+        "usage": {
+            "input_tokens": 1,
+            "output_tokens": 1
+        }
+    })
+    .to_string();
+    write_executable(
+        &script,
+        &format!("#!/bin/sh\ncat > /dev/null\nprintf '%s\\n' '{stdout}'\n"),
+    );
+
+    let sink = Arc::new(RecordingSink::default());
+    let sink_for_writer: Arc<dyn AuditSink> = sink;
+    let audit = Arc::new(V2AuditWriter::new(
+        "job-stdout-preview",
+        "codex:gpt-5.5",
+        sink_for_writer,
+    ));
+    let host = TestHost::with_command(script.display().to_string());
+    let spec = test_agent_loop_spec(Duration::from_secs(5));
+
+    let outcome = run_cli_backend(
+        &host,
+        &spec,
+        "job-stdout-preview",
+        audit,
+        &serde_json::json!({"prompt": "hi"}),
+        None,
+    )
+    .expect("run succeeds");
+
+    assert!(
+        !outcome.success,
+        "status=failed after the preview limit must still demote success"
+    );
+    let preview = outcome.output["stdout_text"]
+        .as_str()
+        .expect("stdout_text preview");
+    assert!(preview.len() <= 64 * 1024);
+    assert!(!preview.contains("workspace_unavailable"));
+    assert_eq!(outcome.output["stdout_text_truncated"], true);
+    assert_eq!(
+        outcome.output["stdout_text_preview_bytes"].as_u64(),
+        Some(preview.len() as u64)
+    );
+    assert_eq!(
+        outcome.output["stdout_text_preview_limit_bytes"].as_u64(),
+        Some((64 * 1024) as u64)
+    );
+    let message = outcome.message.expect("expected demote message");
+    assert!(
+        message.contains("envelope status") && message.contains("failed"),
+        "demote message should explain envelope status; got {message:?}"
+    );
+}
+
+#[test]
+fn run_cli_backend_redacts_secret_like_stdout_text_preview() {
+    let temp = tempdir().expect("tempdir");
+    let script = temp.path().join("codex");
+    write_executable(
+        &script,
+        r#"#!/bin/sh
+cat > /dev/null
+printf '%s\n' 'Authorization: Bearer stdout-secret-token'
+printf '%s\n' 'x-api-key: stdout-header-key'
+printf '%s\n' 'sk-stdoutsecret123'
+printf '%s\n' '{"api_key":"stdout-json-key"}'
+"#,
+    );
+
+    let sink = Arc::new(RecordingSink::default());
+    let sink_for_writer: Arc<dyn AuditSink> = sink;
+    let audit = Arc::new(V2AuditWriter::new(
+        "job-stdout-redaction",
+        "codex:gpt-5.5",
+        sink_for_writer,
+    ));
+    let host = TestHost::with_command(script.display().to_string());
+    let spec = test_agent_loop_spec(Duration::from_secs(5));
+
+    let outcome = run_cli_backend(
+        &host,
+        &spec,
+        "job-stdout-redaction",
+        audit,
+        &serde_json::json!({"prompt": "hi"}),
+        None,
+    )
+    .expect("run succeeds");
+
+    assert!(outcome.success);
+    let preview = outcome.output["stdout_text"]
+        .as_str()
+        .expect("stdout_text preview");
+    assert!(!preview.contains("stdout-secret-token"));
+    assert!(!preview.contains("stdout-header-key"));
+    assert!(!preview.contains("stdout-json-key"));
+    assert!(!preview.contains("sk-stdoutsecret123"));
+    assert!(preview.contains("[REDACTED_AUTH]"));
+    assert!(preview.contains("[REDACTED_API_KEY]"));
+    assert_eq!(outcome.output["stdout_text_truncated"], false);
+    assert_eq!(
+        outcome.output["stdout_blob_ref"].as_str(),
+        Some("blob-2"),
+        "full stdout should remain available via blob ref"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Task

[T20260509-43](https://orbit-cli.com/tasks/T20260509-43) — Bound and redact CLI `stdout_text` in dispatch output

### Description

## Problem
CLI-backed agent dispatch writes stdout/stderr to audit blobs, then also places full raw `stdout_text` into the structured `DispatchOutcome.output`. The string is built from the full stdout bytes without truncation or redaction.

## Why It Matters
Provider stdout can be huge or secret-bearing, and duplicating it into pipeline/state surfaces bypasses the more controlled blob-reference path.

## Constraints / Notes
Keep enough preview text for envelope parsing and operator diagnostics, but make blob refs the source of full output.

## Scope Restriction
Do not modify anything under `./docs` as part of this task.

### Acceptance Criteria

- Structured dispatch output keeps blob refs and includes only a bounded redacted stdout preview, not unbounded raw stdout.
- Envelope status parsing still works for normal provider output after truncation/redaction changes.
- Tests assert truncation and redaction behavior for large stdout and secret-like content.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Bounded CLI dispatch stdout_text to a 64 KiB redacted preview while preserving stdout/stderr blob refs and byte/truncation metadata.
- Kept envelope status classification on full stdout before previewing.
- Added orchestrator tests for truncation, redaction, and full-stdout envelope demotion.

Assessment: Targeted orchestrator tests, make fmt, and make build pass.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/T20260509-43-69fecf31`
- Behind base: 0
- Ahead of base: 1

*authored by: gpt-5.5*