### PR TITLE
make ci can flake in fanout collected-output ordering test

### DIFF
--- a/crates/orbit-engine/src/activity_job/job_executor/tests/fanout_tests.rs
+++ b/crates/orbit-engine/src/activity_job/job_executor/tests/fanout_tests.rs
@@ -51,32 +51,43 @@ fn fanout_empty_items_emits_dispatched_zero_and_joined_zero() {
 
 #[test]
 fn fanout_collected_outputs_are_index_ordered_even_when_workers_finish_out_of_order() {
-    // Two-item fan_out where the host scripts ordered outputs whose first
-    // worker (spawn idx 0) sleeps long enough for spawn idx 1 to finish
-    // first. fan_out.rs:131 sorts by spawn idx so the collected output must
-    // be in declaration order regardless.
+    // Each worker renders its own spawn index and sleep duration into the
+    // deterministic action input. The first worker sleeps long enough for the
+    // second worker to finish first, without coupling the expected output to
+    // whichever thread reaches ScriptedHost first.
     let host = ScriptedHost::new([(
         "w",
         vec![
-            Action::SleepOk {
-                ms: 80,
-                value: json!({"spawn_index": 0}),
+            Action::SleepInputMsThenEcho {
+                ms_field: "sleep_ms",
             },
-            Action::Ok(json!({"spawn_index": 1})),
+            Action::SleepInputMsThenEcho {
+                ms_field: "sleep_ms",
+            },
         ],
     )]);
+    let mut worker = target_step("worker", "w");
+    match &mut worker.body {
+        JobV2StepBody::Target(target) => {
+            target.default_input = Some(json!({
+                "sleep_ms": "{{ input.item.sleep_ms }}",
+                "spawn_index": "{{ input.iteration }}",
+            }));
+        }
+        _ => unreachable!("target_step must build a target body"),
+    }
     let job = job_with_steps(vec![fanout_step(
         "scatter",
         "{{ input.items }}",
         4, // both run concurrently
-        target_step("worker", "w"),
+        worker,
         JoinMode::All,
         None,
     )]);
     let outcome = run_job(
         &host,
         &job,
-        json!({"items": ["a", "b"]}),
+        json!({"items": [{"sleep_ms": 80}, {"sleep_ms": 0}]}),
         "run-fanout-order",
     );
 

--- a/crates/orbit-engine/src/activity_job/job_executor/tests/mod.rs
+++ b/crates/orbit-engine/src/activity_job/job_executor/tests/mod.rs
@@ -159,6 +159,7 @@ pub(super) enum Action {
     Ok(Value),
     Err(DispatchError),
     SleepOk { ms: u64, value: Value },
+    SleepInputMsThenEcho { ms_field: &'static str },
 }
 
 pub(super) struct ScriptedHost {
@@ -202,7 +203,7 @@ impl V2RuntimeHost for ScriptedHost {
         &self,
         action: &str,
         _config: &Value,
-        _input: &Value,
+        input: &Value,
         _tool_context: orbit_tools::ToolContext,
     ) -> Result<Value, DispatchError> {
         let now = self.in_flight.fetch_add(1, Ordering::SeqCst) + 1;
@@ -234,6 +235,15 @@ impl V2RuntimeHost for ScriptedHost {
             Some(Action::SleepOk { ms, value }) => {
                 std::thread::sleep(Duration::from_millis(ms));
                 Ok(value)
+            }
+            Some(Action::SleepInputMsThenEcho { ms_field }) => {
+                let ms = input.get(ms_field).and_then(Value::as_u64).ok_or_else(|| {
+                    DispatchError::JobExecution(format!(
+                        "scripted host missing numeric sleep field `{ms_field}`"
+                    ))
+                })?;
+                std::thread::sleep(Duration::from_millis(ms));
+                Ok(input.clone())
             }
             // Default: succeed with `{ "action": <name> }` so untyped tests
             // don't have to script every call.


### PR DESCRIPTION
## Task

[T20260509-52](https://orbit-cli.com/tasks/T20260509-52) — make ci can flake in fanout collected-output ordering test

### Description

While validating T20260509-27, a repeated `make ci` run failed in `activity_job::job_executor::tests::fanout_tests::fanout_collected_outputs_are_index_ordered_even_when_workers_finish_out_of_order` with `left: Some(Number(1))` and `right: Some(Number(0))`. The previous full `make ci` run in the same worktree had passed, and the failure is unrelated to the policy path-normalization change. This creates validation friction because agents must distinguish a likely nondeterministic test from task regressions.

### Acceptance Criteria



## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Made the fanout collected-output ordering test deterministic by deriving worker output and sleep duration from each worker input instead of ScriptedHost call order.
- Added a ScriptedHost test action that sleeps based on a rendered input field and echoes that input, so scheduler timing can no longer swap expected values.

Validation:
- cargo test -p orbit-engine fanout_collected_outputs_are_index_ordered_even_when_workers_finish_out_of_order -- --nocapture
- repeated focused test 20x with cargo test -p orbit-engine fanout_collected_outputs_are_index_ordered_even_when_workers_finish_out_of_order --quiet
- cargo test -p orbit-engine activity_job::job_executor::tests::fanout_tests -- --nocapture
- make fmt
- make build

Assessment: Focused test-only change removes the nondeterministic assertion source while preserving the intended index-ordering coverage.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/T20260509-52-69fed053`
- Behind base: 0
- Ahead of base: 1

*authored by: gpt-5.5*