### PR TITLE
Resolve Dependabot alerts: fast-uri path traversal & host confusion

### DIFF
--- a/website/src/components/ThemeSelect.astro
+++ b/website/src/components/ThemeSelect.astro
@@ -1,7 +1,3 @@
----
-import { Icon } from '@astrojs/starlight/components';
----
-
 <starlight-theme-select>
 	<button
 		type="button"
@@ -35,6 +31,18 @@ import { Icon } from '@astrojs/starlight/components';
 </style>
 
 <script>
+	type StarlightThemeProvider = {
+		updatePickers: (theme: string) => void;
+	};
+
+	const updateThemePickers = (theme: string) => {
+		(
+			window as Window & {
+				StarlightThemeProvider?: StarlightThemeProvider;
+			}
+		).StarlightThemeProvider?.updatePickers(theme);
+	};
+
 	class StarlightThemeSelect extends HTMLElement {
 		constructor() {
 			super();
@@ -44,13 +52,13 @@ import { Icon } from '@astrojs/starlight/components';
 					const theme = document.documentElement.dataset.theme === 'light' ? 'dark' : 'light';
 					localStorage.setItem('starlight-theme', theme);
 					document.documentElement.dataset.theme = theme;
-					window.StarlightThemeProvider?.updatePickers(theme);
+					updateThemePickers(theme);
 				});
 			}
 		}
 		connectedCallback() {
 			const theme = document.documentElement.dataset.theme || 'dark';
-			window.StarlightThemeProvider?.updatePickers(theme);
+			updateThemePickers(theme);
 		}
 	}
 	customElements.define('starlight-theme-select', StarlightThemeSelect);


### PR DESCRIPTION
## Task

[T20260509-57](https://github.com/danieljhkim/orbit/security/dependabot/12) — Resolve Dependabot alerts: fast-uri path traversal & host confusion

### Description

## Problem

GitHub Dependabot opened two High-severity alerts against `website/package-lock.json`:

- **#12** — fast-uri vulnerable to path traversal via percent-encoded dot segments
- **#13** — fast-uri vulnerable to host confusion via percent-encoded authority delimiters

Both target `fast-uri` (npm). Current pinned version in [website/package-lock.json:3251-3254](website/package-lock.json:3251) is `fast-uri@3.1.2`.

Dependency chain (`npm ls fast-uri` from `website/`):
```
orbit-website@0.0.0
└── @astrojs/check@0.9.8
    └── @astrojs/language-server@2.16.6
        └── volar-service-yaml@0.0.70
            └── yaml-language-server@1.20.0
                └── ajv@8.18.0
                    └── fast-uri@3.1.2
```

`fast-uri` is a transitive **dev-only** dependency (it ships only into the Astro/Volar/yaml-language-server toolchain that runs during `astro check`, not into the deployed website bundle). Dependabot's "Development" tag on both alerts confirms this.

As of 2026-05-09, `npm view fast-uri version` returns `3.1.2` — i.e., **no patched release is published yet**. A direct `npm update` will not resolve the alerts today.

## Why It Matters

- Two High-severity alerts are open on the repo and visible on the security tab.
- Even though the package is dev-only, leaving them unaddressed accumulates security debt and trains the team to ignore Dependabot.
- A patched upstream release is likely imminent; we want a clear path to landing it the moment it ships.

## Constraints / Notes

- Do **not** simply close/dismiss the alerts without a written justification recorded on the alert and in the task `execution_summary`.
- The deployed site bundle does not include `fast-uri` — verify this before choosing the dismissal path. Use `cd website && npm ls fast-uri` and confirm the chain terminates inside `@astrojs/check` (devDependency tree) and that nothing under `dependencies` (production) pulls it in.
- Two viable resolution paths, in order of preference:
  1. **Wait + bump** — if a patched `fast-uri` (>3.1.2) has been published by the time this task is picked up, run `npm update fast-uri` in `website/` (or add a top-level npm `overrides` entry pinning the patched version) and verify with `npm ls fast-uri` that all instances resolve to the patched range.
  2. **Override now** — add an `overrides` block in [website/package.json](website/package.json) pointing `fast-uri` at a forked/patched build, only if upstream PRs in the fast-uri repo are not yet merged but a vetted fix exists.
  3. **Document & dismiss as "tolerable risk"** — only if (a) no patch exists, (b) dev-only scope is verified, and (c) human approver explicitly OKs dismissal.
- After a successful `npm update` / override, commit both `website/package.json` (if changed) and `website/package-lock.json`, and re-run any website CI step (`npm run check` / `npm run build` from `website/`) to confirm nothing regressed.

## Out of Scope

- Bumping unrelated transitive deps in the same `npm install` pass (avoid drive-by lockfile churn).
- Touching the Rust workspace.

### Acceptance Criteria

- Dependabot alerts #12 and #13 on the repo are both in `Closed` state — either as `Fixed` (with a commit referenced) or as `Dismissed` with a written justification recorded on the alert.
- If resolved by upgrade: `cd website && npm ls fast-uri` shows every instance of fast-uri at a version GitHub Security Advisory deems patched for both GHSAs, and `website/package-lock.json` reflects that version.
- If resolved by upgrade: `cd website && npm run check` and `npm run build` both pass.
- If resolved by dismissal: the task `execution_summary` records (a) confirmation that fast-uri appears only under devDependencies via `npm ls fast-uri`, (b) the date checked, and (c) the human approver who OK'd dismissal.
- No production runtime dependency (anything in `website/package.json` `dependencies`, not `devDependencies`) gains a new transitive path to fast-uri as a side effect of the fix.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Verified Dependabot alerts #12 and #13 through the GitHub API on 2026-05-09T06:17:19Z: both are state=fixed, with #12 fixed_at=2026-05-09T05:38:10Z and #13 fixed_at=2026-05-09T05:38:11Z.
- Confirmed website/package-lock.json resolves fast-uri@3.1.2. GitHub advisory metadata reports #12/GHSA-q3j6-qgpj-74h6 patched at 3.1.1 and #13/GHSA-v39h-62p7-jpjc patched at 3.1.2.
- Left website/package.json and website/package-lock.json unchanged because they already resolve to the patched fast-uri version.
- Fixed the website validation blocker in website/src/components/ThemeSelect.astro by removing the unused Icon import and typing the optional StarlightThemeProvider access used by the theme picker.

Validation:
- npm_config_cache=/tmp/orbit-npm-cache-jrun-20260509-0613-2 npm ci -> pass, 0 vulnerabilities.
- npm ls fast-uri --all -> fast-uri@3.1.2 only under @astrojs/check -> @astrojs/language-server -> volar-service-yaml -> yaml-language-server -> ajv.
- npm ls fast-uri --omit=dev --all -> empty tree, confirming no production dependency path to fast-uri.
- npm audit --json -> 0 vulnerabilities.
- npm run check -> pass.
- npm run build -> pass.

Assessment: Security alerts are closed as fixed, the lockfile already contains the version patched for both advisories, no production runtime dependency path to fast-uri is present, and website validation now passes.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/T20260509-57-69fed081`
- Behind base: 0
- Ahead of base: 1

*authored by: claude-opus-4-7*