### PR TITLE
Update reject help text to match current lifecycle

### DIFF
--- a/crates/orbit-cli/src/command/task/command.rs
+++ b/crates/orbit-cli/src/command/task/command.rs
@@ -50,7 +50,7 @@ pub enum TaskSubcommand {
     Start(TaskStartArgs),
     /// Approve a task (proposed → backlog, or review → done)
     Approve(TaskApproveArgs),
-    /// Reject a task (proposed → archived, or review → backlog)
+    /// Reject a task (proposed/friction/review/backlog/in-progress -> rejected)
     Reject(TaskRejectArgs),
     /// Archive a task
     Archive(TaskArchiveArgs),
@@ -69,6 +69,33 @@ pub enum TaskSubcommand {
     /// Defaults to a dry-run report; pass `--write` to apply.
     #[command(name = "prune-context")]
     PruneContext(TaskPruneContextArgs),
+}
+
+#[cfg(test)]
+mod tests {
+    use clap::{Parser, error::ErrorKind};
+
+    use crate::command::Cli;
+
+    #[test]
+    fn task_help_describes_reject_transition_to_rejected() {
+        let err = match Cli::try_parse_from(["orbit", "task", "--help"]) {
+            Ok(_) => panic!("task help should exit before parsing a subcommand"),
+            Err(err) => err,
+        };
+
+        assert_eq!(err.kind(), ErrorKind::DisplayHelp);
+
+        let help = err.to_string();
+        assert!(
+            help.contains(
+                "Reject a task (proposed/friction/review/backlog/in-progress -> rejected)"
+            ),
+            "{help}"
+        );
+        assert!(!help.contains("proposed → archived"), "{help}");
+        assert!(!help.contains("review → backlog"), "{help}");
+    }
 }
 
 impl Execute for TaskSubcommand {


### PR DESCRIPTION
## Task

[T20260509-50](https://orbit-cli.com/tasks/T20260509-50) — Update reject help text to match current lifecycle

### Description

## Problem
Top-level task help says reject performs `proposed -> archived` and `review -> backlog`, but the implementation moves `proposed`, `friction`, `review`, `backlog`, and `in-progress` to `rejected`.

## Why It Matters
This is lifecycle UX, not cosmetic wording: users can misunderstand a destructive state transition.

## Constraints / Notes
Keep help concise while matching the actual transition code and `TaskRejectArgs` behavior.

## Scope Restriction
Do not modify anything under `./docs` as part of this task.

### Acceptance Criteria

- The top-level reject help describes the current `rejected` transition behavior and eligible source statuses accurately.
- A help snapshot or parser test asserts the lifecycle summary does not regress to obsolete archived/backlog wording.
- Existing reject transition tests continue to pass.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Updated the top-level `orbit task --help` reject summary to describe proposed/friction/review/backlog/in-progress -> rejected.
- Added a CLI help regression test that asserts the current reject lifecycle summary and guards against obsolete archived/backlog wording.

Assessment: Targeted help-only change; no docs touched. Validated with `make fmt`, `make build`, `cargo test -p orbit-cli reject`, and `cargo test -p orbit-core reject`.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/T20260509-50-69fed375`
- Behind base: 0
- Ahead of base: 1

*authored by: gpt-5.5*