### PR TITLE
Keep bulk approve/reject JSON stdout machine-readable

### DIFF
--- a/crates/orbit-cli/src/command/task/lifecycle.rs
+++ b/crates/orbit-cli/src/command/task/lifecycle.rs
@@ -77,7 +77,7 @@ pub struct TaskApproveArgs {
 impl Execute for TaskApproveArgs {
     fn execute(self, runtime: &OrbitRuntime) -> Result<(), OrbitError> {
         let ids = if self.all_proposed {
-            select_proposed_task_ids(runtime, self.yes, "approved")?
+            select_proposed_task_ids(runtime, self.yes, "approved", self.json)?
         } else {
             self.ids
         };
@@ -148,7 +148,7 @@ pub struct TaskRejectArgs {
 impl Execute for TaskRejectArgs {
     fn execute(self, runtime: &OrbitRuntime) -> Result<(), OrbitError> {
         let ids = if self.all_proposed {
-            select_proposed_task_ids(runtime, self.yes, "rejected")?
+            select_proposed_task_ids(runtime, self.yes, "rejected", self.json)?
         } else {
             self.ids
         };
@@ -288,33 +288,57 @@ fn select_proposed_task_ids(
     runtime: &OrbitRuntime,
     yes: bool,
     action: &str,
+    json: bool,
 ) -> Result<Vec<String>, OrbitError> {
     let proposed =
         runtime.list_tasks_filtered(Some(TaskStatus::Proposed), None, None, None, None, None)?;
     if proposed.is_empty() {
-        println!("No proposed tasks found.");
+        if json {
+            eprintln!("No proposed tasks found.");
+        } else {
+            println!("No proposed tasks found.");
+        }
         return Ok(Vec::new());
     }
     if !yes {
-        println!(
-            "The following {} task(s) will be {}:",
-            proposed.len(),
-            action
-        );
-        for task in &proposed {
-            println!("  {} — {}", task.id, task.title);
-        }
-        print!("Proceed? [y/N] ");
         use std::io::Write;
-        std::io::stdout()
-            .flush()
-            .map_err(|e| OrbitError::Io(e.to_string()))?;
+        if json {
+            eprintln!(
+                "The following {} task(s) will be {}:",
+                proposed.len(),
+                action
+            );
+            for task in &proposed {
+                eprintln!("  {} — {}", task.id, task.title);
+            }
+            eprint!("Proceed? [y/N] ");
+            std::io::stderr()
+                .flush()
+                .map_err(|e| OrbitError::Io(e.to_string()))?;
+        } else {
+            println!(
+                "The following {} task(s) will be {}:",
+                proposed.len(),
+                action
+            );
+            for task in &proposed {
+                println!("  {} — {}", task.id, task.title);
+            }
+            print!("Proceed? [y/N] ");
+            std::io::stdout()
+                .flush()
+                .map_err(|e| OrbitError::Io(e.to_string()))?;
+        }
         let mut input = String::new();
         std::io::stdin()
             .read_line(&mut input)
             .map_err(|e| OrbitError::Io(e.to_string()))?;
         if !matches!(input.trim().to_lowercase().as_str(), "y" | "yes") {
-            println!("Aborted.");
+            if json {
+                eprintln!("Aborted.");
+            } else {
+                println!("Aborted.");
+            }
             return Ok(Vec::new());
         }
     }

--- a/crates/orbit-cli/tests/task_lifecycle_bulk_json.rs
+++ b/crates/orbit-cli/tests/task_lifecycle_bulk_json.rs
@@ -1,0 +1,146 @@
+use std::fs;
+use std::path::Path;
+use std::process::Output;
+
+use assert_cmd::cargo::cargo_bin_cmd;
+use serde_json::{Value, json};
+use tempfile::{TempDir, tempdir};
+
+#[test]
+fn approve_all_proposed_json_no_proposed_stdout_is_json() {
+    assert_no_proposed_json_stdout("approve", &[]);
+}
+
+#[test]
+fn reject_all_proposed_json_no_proposed_stdout_is_json() {
+    assert_no_proposed_json_stdout("reject", &["--note", "not needed"]);
+}
+
+#[test]
+fn approve_all_proposed_json_abort_stdout_is_json() {
+    assert_aborted_json_stdout("approve", &[]);
+}
+
+#[test]
+fn reject_all_proposed_json_abort_stdout_is_json() {
+    assert_aborted_json_stdout("reject", &["--note", "not now"]);
+}
+
+fn assert_no_proposed_json_stdout(command: &str, extra_args: &[&str]) {
+    let workspace = TestWorkspace::new();
+    let output = workspace.run(
+        &task_lifecycle_args(command, extra_args),
+        None,
+        "run bulk lifecycle command",
+    );
+
+    assert_json_array_stdout(&output);
+    assert_stderr_contains(&output, "No proposed tasks found.");
+}
+
+fn assert_aborted_json_stdout(command: &str, extra_args: &[&str]) {
+    let workspace = TestWorkspace::new();
+    workspace.add_proposed_task();
+
+    let output = workspace.run(
+        &task_lifecycle_args(command, extra_args),
+        Some("n\n"),
+        "run bulk lifecycle command",
+    );
+
+    assert_json_array_stdout(&output);
+    assert_stderr_contains(&output, "Proceed? [y/N]");
+    assert_stderr_contains(&output, "Aborted.");
+}
+
+fn task_lifecycle_args<'a>(command: &'a str, extra_args: &'a [&'a str]) -> Vec<&'a str> {
+    let mut args = vec!["task", command, "--all-proposed", "--json"];
+    args.extend(extra_args);
+    args
+}
+
+struct TestWorkspace {
+    _temp: TempDir,
+    home: std::path::PathBuf,
+    work: std::path::PathBuf,
+}
+
+impl TestWorkspace {
+    fn new() -> Self {
+        let temp = tempdir().expect("tempdir");
+        let home = temp.path().join("home");
+        let work = temp.path().join("work");
+        fs::create_dir_all(&home).expect("create home");
+        fs::create_dir_all(&work).expect("create work");
+
+        let workspace = Self {
+            _temp: temp,
+            home,
+            work,
+        };
+        workspace.run(
+            &["workspace", "init", "--name", "bulk-json-test"],
+            None,
+            "initialize workspace",
+        );
+        workspace
+    }
+
+    fn add_proposed_task(&self) {
+        let output = self.run(
+            &[
+                "task",
+                "add",
+                "--title",
+                "Needs decision",
+                "--description",
+                "Created by the bulk lifecycle JSON integration test.",
+                "--acceptance-criteria",
+                "decision recorded",
+                "--json",
+            ],
+            None,
+            "add proposed task",
+        );
+        let task: Value = serde_json::from_slice(&output.stdout).expect("task add JSON");
+        assert_eq!(task["status"], json!("proposed"));
+    }
+
+    fn run(&self, args: &[&str], stdin: Option<&str>, label: &str) -> Output {
+        let output = run_orbit(&self.work, &self.home, args, stdin);
+        assert!(
+            output.status.success(),
+            "{label} failed\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        output
+    }
+}
+
+fn run_orbit(cwd: &Path, home: &Path, args: &[&str], stdin: Option<&str>) -> Output {
+    let mut command = cargo_bin_cmd!("orbit");
+    command
+        .current_dir(cwd)
+        .env("HOME", home)
+        .env("USERPROFILE", home)
+        .env_remove("ORBIT_ROOT")
+        .args(args);
+    if let Some(input) = stdin {
+        command.write_stdin(input);
+    }
+    command.output().expect("run orbit")
+}
+
+fn assert_json_array_stdout(output: &Output) {
+    let value: Value = serde_json::from_slice(&output.stdout).expect("stdout is pure JSON");
+    assert_eq!(value, Value::Array(Vec::new()));
+}
+
+fn assert_stderr_contains(output: &Output, expected: &str) {
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains(expected),
+        "stderr missing {expected:?}\nstderr:\n{stderr}"
+    );
+}


### PR DESCRIPTION
## Task

[T20260509-47](https://orbit-cli.com/tasks/T20260509-47) — Keep bulk approve/reject JSON stdout machine-readable

### Description

## Problem
`orbit task approve --all-proposed --json` and reject equivalents call `select_proposed_task_ids`; that helper prints human messages and prompts such as `No proposed tasks found.` and `Aborted.` to stdout before the JSON path finishes.

## Why It Matters
Scripts using `--json` can receive mixed human text and JSON on stdout, making the output invalid to parse.

## Constraints / Notes
Preserve interactive UX for non-JSON mode, but make JSON mode stdout pure JSON.

## Scope Restriction
Do not modify anything under `./docs` as part of this task.

### Acceptance Criteria

- In `--json` mode, approve/reject bulk paths emit only JSON to stdout for no-proposed, aborted, and successful cases.
- Human prompts/status messages are suppressed or sent to stderr in JSON mode.
- CLI tests cover `--all-proposed --json` no-proposed and aborted paths for both approve and reject.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Routed bulk approve/reject proposed-task selection messages and confirmation prompts to stderr when --json is active, keeping stdout reserved for the final JSON payload.
- Added CLI integration coverage for approve/reject --all-proposed --json no-proposed and aborted flows.

Assessment: Focused change with targeted CLI tests; make fmt and make build pass.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/T20260509-47-69fed4c1`
- Behind base: 0
- Ahead of base: 1

*authored by: gpt-5.5*