### PR TITLE
Fix clippy errors in tool_allowlist.rs blocking CI

### DIFF
--- a/crates/orbit-agent/src/types/response/envelope.rs
+++ b/crates/orbit-agent/src/types/response/envelope.rs
@@ -232,10 +232,10 @@ fn find_agent_response_envelope(value: &Value) -> Option<AgentResponseEnvelope> 
 }
 
 fn find_agent_response_envelope_in_string(raw: &str) -> Option<AgentResponseEnvelope> {
-    if let Ok(nested) = serde_json::from_str::<Value>(raw) {
-        if let Some(envelope) = find_agent_response_envelope(&nested) {
-            return Some(envelope);
-        }
+    if let Ok(nested) = serde_json::from_str::<Value>(raw)
+        && let Some(envelope) = find_agent_response_envelope(&nested)
+    {
+        return Some(envelope);
     }
 
     raw.match_indices('{').find_map(|(start, _)| {

--- a/crates/orbit-cli/src/command/task/command.rs
+++ b/crates/orbit-cli/src/command/task/command.rs
@@ -71,6 +71,30 @@ pub enum TaskSubcommand {
     PruneContext(TaskPruneContextArgs),
 }
 
+impl Execute for TaskSubcommand {
+    fn execute(self, runtime: &OrbitRuntime) -> Result<(), OrbitError> {
+        match self {
+            TaskSubcommand::Add(args) => args.execute(runtime),
+            TaskSubcommand::Artifact(cmd) => cmd.execute(runtime),
+            TaskSubcommand::List(args) => args.execute(runtime),
+            TaskSubcommand::Locks(args) => args.execute(runtime),
+            TaskSubcommand::Show(args) => args.execute(runtime),
+            TaskSubcommand::Lint(args) => args.execute(runtime),
+            TaskSubcommand::Update(args) => args.execute(runtime),
+            TaskSubcommand::Start(args) => args.execute(runtime),
+            TaskSubcommand::Approve(args) => args.execute(runtime),
+            TaskSubcommand::Reject(args) => args.execute(runtime),
+            TaskSubcommand::Archive(args) => args.execute(runtime),
+            TaskSubcommand::Unarchive(args) => args.execute(runtime),
+            TaskSubcommand::Delete(args) => args.execute(runtime),
+            TaskSubcommand::Search(args) => args.execute(runtime),
+            TaskSubcommand::Templates(cmd) => cmd.execute(runtime),
+            TaskSubcommand::ReviewThread(cmd) => cmd.execute(runtime),
+            TaskSubcommand::PruneContext(args) => args.execute(runtime),
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use clap::{Parser, error::ErrorKind};
@@ -95,29 +119,5 @@ mod tests {
         );
         assert!(!help.contains("proposed → archived"), "{help}");
         assert!(!help.contains("review → backlog"), "{help}");
-    }
-}
-
-impl Execute for TaskSubcommand {
-    fn execute(self, runtime: &OrbitRuntime) -> Result<(), OrbitError> {
-        match self {
-            TaskSubcommand::Add(args) => args.execute(runtime),
-            TaskSubcommand::Artifact(cmd) => cmd.execute(runtime),
-            TaskSubcommand::List(args) => args.execute(runtime),
-            TaskSubcommand::Locks(args) => args.execute(runtime),
-            TaskSubcommand::Show(args) => args.execute(runtime),
-            TaskSubcommand::Lint(args) => args.execute(runtime),
-            TaskSubcommand::Update(args) => args.execute(runtime),
-            TaskSubcommand::Start(args) => args.execute(runtime),
-            TaskSubcommand::Approve(args) => args.execute(runtime),
-            TaskSubcommand::Reject(args) => args.execute(runtime),
-            TaskSubcommand::Archive(args) => args.execute(runtime),
-            TaskSubcommand::Unarchive(args) => args.execute(runtime),
-            TaskSubcommand::Delete(args) => args.execute(runtime),
-            TaskSubcommand::Search(args) => args.execute(runtime),
-            TaskSubcommand::Templates(cmd) => cmd.execute(runtime),
-            TaskSubcommand::ReviewThread(cmd) => cmd.execute(runtime),
-            TaskSubcommand::PruneContext(args) => args.execute(runtime),
-        }
     }
 }


### PR DESCRIPTION
## Task

[T20260509-61](https://orbit-cli.com/tasks/T20260509-61) — Fix clippy errors in tool_allowlist.rs blocking CI

### Description

## Problem

`./scripts/ci-guardrails.sh` (invoked by `make ci` and the CI workflow) fails at the
`cargo clippy --workspace --all-targets -- -D warnings` step. Five clippy lints fire in
`crates/orbit-common/src/types/activity_job/tool_allowlist.rs`, breaking the build:

1. **`clippy::manual_contains`** at `tool_allowlist.rs:50` — replace
   `V2_TOOL_WILDCARD_ROOTS.iter().any(|root| *root == prefix)` with
   `V2_TOOL_WILDCARD_ROOTS.contains(&prefix)`.
2. **`clippy::manual_contains`** at `tool_allowlist.rs:79` — same pattern on
   `V2_INTENTIONALLY_EMPTY_TOOL_WILDCARD_ROOTS`. Replace the `.iter().any(...)` with
   `.contains(&prefix)`.
3. **`clippy::needless_borrows_for_generic_args`** at `tool_allowlist.rs:128` —
   `tool_name.starts_with(&prefix)` should be `tool_name.starts_with(prefix)`.
4. **`clippy::useless_conversion`** at `tool_allowlist.rs:156` — drop `.into_iter()` on
   `["orbit.task.show"].into_iter()`; the parameter accepts `IntoIterator`.
5. **`clippy::useless_conversion`** at `tool_allowlist.rs:165` — same fix as #4.

## Why It Matters

`-D warnings` is enforced. Until these clear, every `make ci` / GitHub Actions run on the
branch is red, blocking merges and review.

## Constraints / Notes

- Pure mechanical fixes — clippy provides exact rewrites for each. No behavior change.
- After patching, re-run the full `./scripts/ci-guardrails.sh` to confirm nothing else
  regressed (fmt, full clippy, full test suite, dependency-direction, cli-imports).
- Do not blanket-`#[allow]` these lints — fix them in code.
- If the same lint patterns exist elsewhere in the workspace (other crates, other files),
  surface them but keep this task scoped to `tool_allowlist.rs` unless `cargo clippy`
  reports more sites in the same run; if it does, fix all sites it lists in one pass.
- Watch for any unrelated test flake (e.g. the fanout-ordering flake tracked by
  T20260509-56) — do not roll a flake fix into this task.

### Acceptance Criteria

- `cargo clippy --workspace --all-targets -- -D warnings` exits 0 from a clean checkout of the branch.
- All five clippy errors at tool_allowlist.rs:50, :79, :128, :156, :165 are resolved by editing source code (no `#[allow(...)]` suppressions, no clippy.toml carve-outs).
- `./scripts/ci-guardrails.sh` exits 0 end-to-end (fmt + clippy + workspace tests + dependency-direction + cli-imports).
- No public API change in `tool_allowlist.rs`: existing call sites compile unchanged and existing tests in this file still pass without modification (other than adapting to the local variable being a value vs reference if required by the rewrite).
- If `cargo clippy` surfaces additional sites of the same five lint kinds elsewhere in the workspace during the same run, those are fixed in this task as well; if not, scope stays in `tool_allowlist.rs`.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Confirmed `tool_allowlist.rs` already contains the requested mechanical clippy rewrites for `contains(&prefix)`, `starts_with(prefix)`, and direct array arguments in the local worktree.
- Fixed two additional clippy warnings surfaced by the required workspace clippy run: collapsed nested JSON-envelope parsing in `crates/orbit-agent/src/types/response/envelope.rs`, and moved the task command test module after item definitions in `crates/orbit-cli/src/command/task/command.rs`.

Assessment: `./scripts/ci-guardrails.sh` now passes end-to-end (fmt, clippy, workspace tests, dependency-direction, cli-imports).

Deviations from original plan:
- Validation surfaced clippy warnings outside `tool_allowlist.rs`; they were fixed mechanically because the acceptance criteria require the full guardrail script to pass.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/T20260509-61-69ff958f`
- Behind base: 0
- Ahead of base: 1

*authored by: claude-opus-4-7*