### PR TITLE
Collapse YAML/JSON/TOML/CSV/TSV extraction to file-as-leaf

### DIFF
--- a/crates/orbit-knowledge/src/extract/config.rs
+++ b/crates/orbit-knowledge/src/extract/config.rs
@@ -1,12 +1,11 @@
-//! Shallow structured-config extractor for YAML / JSON / TOML (T20260422-1540).
+//! Structured-config extractor for YAML / JSON / TOML.
 //!
-//! Emits one `LeafKind::ConfigKey` per **top-level** map entry. Nested keys
-//! are deliberately out of scope (see the MVP scope in task T20260422-1540);
-//! a non-map root (e.g. a JSON top-level array or a YAML scalar) produces zero
-//! leaves without erroring.
+//! Config files are indexed at file granularity. The extractor stays registered
+//! so the pipeline captures file-level source, but it deliberately emits no
+//! per-key leaves.
 
 use super::FileExtractor;
-use super::common::{ExtractedLeaf, ExtractionResult, compute_source_hash};
+use super::common::ExtractionResult;
 use super::language::{ConfigFormat, FileKind};
 
 pub struct ConfigExtractor {
@@ -24,74 +23,8 @@ impl FileExtractor for ConfigExtractor {
         FileKind::Config(self.format)
     }
 
-    fn extract(&self, source: &str) -> ExtractionResult {
-        let keys = match self.format {
-            ConfigFormat::Yaml => extract_yaml_top_level(source),
-            ConfigFormat::Json => extract_json_top_level(source),
-            ConfigFormat::Toml => extract_toml_top_level(source),
-        };
-        let mut leaves = Vec::with_capacity(keys.len());
-        for (idx, key) in keys.into_iter().enumerate() {
-            let hash = compute_source_hash(&key);
-            leaves.push(ExtractedLeaf {
-                qualified_name: key.clone(),
-                name: key,
-                kind: "config_key".to_string(),
-                start_line: idx + 1,
-                end_line: idx + 1,
-                source: String::new(),
-                source_hash: hash,
-                parent_qualified_name: None,
-                children_qualified_names: Vec::new(),
-                depth: None,
-            });
-        }
-        ExtractionResult {
-            leaves,
-            ..Default::default()
-        }
-    }
-}
-
-fn extract_yaml_top_level(source: &str) -> Vec<String> {
-    let Ok(value) = serde_yaml::from_str::<serde_yaml::Value>(source) else {
-        return Vec::new();
-    };
-    match value {
-        serde_yaml::Value::Mapping(map) => map
-            .into_iter()
-            .filter_map(|(k, _)| yaml_key_as_string(k))
-            .collect(),
-        _ => Vec::new(),
-    }
-}
-
-fn yaml_key_as_string(key: serde_yaml::Value) -> Option<String> {
-    match key {
-        serde_yaml::Value::String(s) => Some(s),
-        serde_yaml::Value::Number(n) => Some(n.to_string()),
-        serde_yaml::Value::Bool(b) => Some(b.to_string()),
-        _ => None,
-    }
-}
-
-fn extract_json_top_level(source: &str) -> Vec<String> {
-    let Ok(value) = serde_json::from_str::<serde_json::Value>(source) else {
-        return Vec::new();
-    };
-    match value {
-        serde_json::Value::Object(map) => map.into_iter().map(|(k, _)| k).collect(),
-        _ => Vec::new(),
-    }
-}
-
-fn extract_toml_top_level(source: &str) -> Vec<String> {
-    let Ok(value) = source.parse::<toml::Value>() else {
-        return Vec::new();
-    };
-    match value {
-        toml::Value::Table(map) => map.into_iter().map(|(k, _)| k).collect(),
-        _ => Vec::new(),
+    fn extract(&self, _source: &str) -> ExtractionResult {
+        ExtractionResult::default()
     }
 }
 
@@ -99,62 +32,35 @@ fn extract_toml_top_level(source: &str) -> Vec<String> {
 mod tests {
     use super::*;
 
-    /// Set-based comparison: per-format map order is an implementation
-    /// detail of each parser and not part of the extractor's contract.
-    fn sorted_names(result: &ExtractionResult) -> Vec<String> {
-        let mut names: Vec<String> = result.leaves.iter().map(|l| l.name.clone()).collect();
-        names.sort();
-        names
-    }
-
     #[test]
-    fn extracts_top_level_yaml_keys_only() {
+    fn yaml_files_emit_no_config_key_leaves() {
         let src = "name: orbit\n\
                    version: 0.1.0\n\
                    nested:\n  child: ignored\n\
                    owners:\n  - claude\n  - codex\n";
         let out = ConfigExtractor::new(ConfigFormat::Yaml).extract(src);
-        assert_eq!(
-            sorted_names(&out),
-            vec!["name", "nested", "owners", "version"]
-        );
-        assert!(out.leaves.iter().all(|l| l.kind == "config_key"));
-        assert!(out.leaves.iter().all(|l| l.depth.is_none()));
+        assert!(out.leaves.is_empty());
     }
 
     #[test]
-    fn extracts_top_level_json_keys_only() {
+    fn json_files_emit_no_config_key_leaves() {
         let src = r#"{"a": 1, "b": {"c": 2}, "d": [1,2]}"#;
         let out = ConfigExtractor::new(ConfigFormat::Json).extract(src);
-        assert_eq!(sorted_names(&out), vec!["a", "b", "d"]);
+        assert!(out.leaves.is_empty());
     }
 
     #[test]
-    fn extracts_top_level_toml_keys_only() {
+    fn toml_files_emit_no_config_key_leaves() {
         let src = "name = \"orbit\"\n\
                    version = \"0.1.0\"\n\
                    [package]\n\
                    edition = \"2021\"\n";
         let out = ConfigExtractor::new(ConfigFormat::Toml).extract(src);
-        assert_eq!(sorted_names(&out), vec!["name", "package", "version"]);
-    }
-
-    #[test]
-    fn yaml_non_map_root_produces_no_leaves() {
-        let src = "- one\n- two\n- three\n";
-        let out = ConfigExtractor::new(ConfigFormat::Yaml).extract(src);
         assert!(out.leaves.is_empty());
     }
 
     #[test]
-    fn json_non_object_root_produces_no_leaves() {
-        let src = "[1, 2, 3]";
-        let out = ConfigExtractor::new(ConfigFormat::Json).extract(src);
-        assert!(out.leaves.is_empty());
-    }
-
-    #[test]
-    fn malformed_input_produces_no_leaves() {
+    fn malformed_input_still_produces_no_leaves() {
         let out = ConfigExtractor::new(ConfigFormat::Json).extract("{not valid");
         assert!(out.leaves.is_empty());
         let out = ConfigExtractor::new(ConfigFormat::Yaml).extract("a: b:\n  - [");

--- a/crates/orbit-knowledge/src/extract/mod.rs
+++ b/crates/orbit-knowledge/src/extract/mod.rs
@@ -1,9 +1,8 @@
 //! File content extractors for the knowledge graph.
 //!
 //! Extracts structural symbols from source code via tree-sitter (`Language`
-//! extractors in `rust.rs`, `python.rs`, …) and shallow anchors from non-code
-//! files (markdown headings, config keys, tabular headers) added by
-//! T20260422-1540 in `markdown.rs`, `config.rs`, `table.rs`.
+//! extractors in `rust.rs`, `python.rs`, …), markdown heading anchors, and
+//! file-level source capture for structured config and tabular files.
 //!
 //! Dispatch key is `FileKind`, which subsumes the prior `Language`-based
 //! dispatch under `FileKind::Code(Language)` without changing extractor
@@ -49,8 +48,8 @@ use typescript::TypeScriptExtractor;
 ///
 /// Implementors declare the `FileKind` they handle and emit a flat list of
 /// `ExtractedLeaf` anchors for that file's content. For code, anchors are
-/// symbols; for docs/configs/tables, anchors are sections/keys/columns
-/// (T20260422-1540).
+/// symbols; for markdown, anchors are sections. Config and table extractors
+/// stay registered to preserve file-level source capture but emit no leaves.
 pub trait FileExtractor: Send + Sync {
     fn file_kind(&self) -> FileKind;
     fn extract(&self, source: &str) -> ExtractionResult;

--- a/crates/orbit-knowledge/src/extract/table.rs
+++ b/crates/orbit-knowledge/src/extract/table.rs
@@ -1,20 +1,12 @@
-//! Shallow tabular extractor for CSV / TSV (T20260422-1540).
+//! Tabular extractor for CSV / TSV.
 //!
-//! Emits one `LeafKind::Column` per header cell (splitting the first
-//! non-empty line on `,` for CSV and `\t` for TSV). Files larger than
-//! `SIZE_CAP_BYTES` produce zero leaves — the cap short-circuits before
-//! parsing to avoid ingesting very large data dumps.
-//!
-//! Deliberately out of scope: quoted/escaped cells, multi-line headers,
-//! type inference, row-level nodes.
+//! Table files are indexed at file granularity. The extractor stays registered
+//! so the pipeline captures file-level source, but it deliberately emits no
+//! per-column leaves.
 
 use super::FileExtractor;
-use super::common::{ExtractedLeaf, ExtractionResult, compute_source_hash};
+use super::common::ExtractionResult;
 use super::language::{FileKind, TableFormat};
-
-/// Files above this size are not parsed. Deliberate MVP default; not
-/// user-configurable per task T20260422-1540 scope.
-pub(crate) const SIZE_CAP_BYTES: usize = 1024 * 1024;
 
 pub struct TableExtractor {
     format: TableFormat,
@@ -24,13 +16,6 @@ impl TableExtractor {
     pub fn new(format: TableFormat) -> Self {
         Self { format }
     }
-
-    fn delimiter(&self) -> char {
-        match self.format {
-            TableFormat::Csv => ',',
-            TableFormat::Tsv => '\t',
-        }
-    }
 }
 
 impl FileExtractor for TableExtractor {
@@ -38,42 +23,8 @@ impl FileExtractor for TableExtractor {
         FileKind::Table(self.format)
     }
 
-    fn extract(&self, source: &str) -> ExtractionResult {
-        extract_with_cap(self, source, SIZE_CAP_BYTES)
-    }
-}
-
-fn extract_with_cap(ext: &TableExtractor, source: &str, cap: usize) -> ExtractionResult {
-    if source.len() > cap {
-        return ExtractionResult::default();
-    }
-    let Some(header) = source.lines().find(|line| !line.trim().is_empty()) else {
-        return ExtractionResult::default();
-    };
-    let cells: Vec<&str> = header.split(ext.delimiter()).collect();
-    let mut leaves = Vec::with_capacity(cells.len());
-    for raw in cells.into_iter() {
-        let trimmed = raw.trim().to_string();
-        if trimmed.is_empty() {
-            continue;
-        }
-        let hash = compute_source_hash(&trimmed);
-        leaves.push(ExtractedLeaf {
-            qualified_name: trimmed.clone(),
-            name: trimmed,
-            kind: "column".to_string(),
-            start_line: 1,
-            end_line: 1,
-            source: String::new(),
-            source_hash: hash,
-            parent_qualified_name: None,
-            children_qualified_names: Vec::new(),
-            depth: None,
-        });
-    }
-    ExtractionResult {
-        leaves,
-        ..Default::default()
+    fn extract(&self, _source: &str) -> ExtractionResult {
+        ExtractionResult::default()
     }
 }
 
@@ -82,28 +33,16 @@ mod tests {
     use super::*;
 
     #[test]
-    fn extracts_csv_header_columns() {
+    fn csv_files_emit_no_column_leaves() {
         let src = "id,name,email\n1,alice,a@x\n2,bob,b@x\n";
         let out = TableExtractor::new(TableFormat::Csv).extract(src);
-        let names: Vec<&String> = out.leaves.iter().map(|l| &l.name).collect();
-        assert_eq!(names, vec!["id", "name", "email"]);
-        assert!(out.leaves.iter().all(|l| l.kind == "column"));
+        assert!(out.leaves.is_empty());
     }
 
     #[test]
-    fn extracts_tsv_header_columns() {
+    fn tsv_files_emit_no_column_leaves() {
         let src = "id\tname\temail\n1\talice\ta@x\n";
         let out = TableExtractor::new(TableFormat::Tsv).extract(src);
-        let names: Vec<&String> = out.leaves.iter().map(|l| &l.name).collect();
-        assert_eq!(names, vec!["id", "name", "email"]);
-    }
-
-    #[test]
-    fn oversized_input_yields_zero_leaves() {
-        // Use a stub cap so the test doesn't actually allocate 1 MiB.
-        let ext = TableExtractor::new(TableFormat::Csv);
-        let src = "a,b,c\n";
-        let out = extract_with_cap(&ext, src, 2);
         assert!(out.leaves.is_empty());
     }
 
@@ -114,10 +53,9 @@ mod tests {
     }
 
     #[test]
-    fn trims_whitespace_and_skips_empty_cells() {
+    fn whitespace_header_still_produces_no_leaves() {
         let src = "id, name ,,email\n";
         let out = TableExtractor::new(TableFormat::Csv).extract(src);
-        let names: Vec<&String> = out.leaves.iter().map(|l| &l.name).collect();
-        assert_eq!(names, vec!["id", "name", "email"]);
+        assert!(out.leaves.is_empty());
     }
 }

--- a/crates/orbit-knowledge/tests/config_table_file_nodes.rs
+++ b/crates/orbit-knowledge/tests/config_table_file_nodes.rs
@@ -1,0 +1,86 @@
+use std::path::Path;
+
+use orbit_knowledge::Selector;
+use orbit_knowledge::graph::GraphNodeRef;
+use orbit_knowledge::graph::object_store::RefName;
+use orbit_knowledge::pipeline::context::BuildConfig;
+use orbit_knowledge::service::GraphContextService;
+use tempfile::tempdir;
+
+#[test]
+fn config_and_table_files_are_file_level_graph_nodes() {
+    let repo_dir = tempdir().expect("repo tempdir");
+    let repo = repo_dir.path();
+    write_file(repo, "settings.yaml", "name: orbit\nversion: 1\n");
+    write_file(
+        repo,
+        "package.json",
+        "{\"name\":\"orbit\",\"version\":\"1.0.0\"}\n",
+    );
+    write_file(repo, "Cargo.toml", "[package]\nname = \"orbit\"\n");
+    write_file(repo, "people.csv", "id,name\n1,Alice\n");
+    write_file(repo, "people.tsv", "id\tname\n1\tAlice\n");
+
+    let knowledge_root = tempdir().expect("knowledge tempdir");
+    let ctx = run_build(repo, knowledge_root.path());
+    let service = GraphContextService::new(&ctx.graph);
+
+    assert!(ctx.graph.leaves.is_empty());
+    for location in [
+        "settings.yaml",
+        "package.json",
+        "Cargo.toml",
+        "people.csv",
+        "people.tsv",
+    ] {
+        let file = ctx
+            .graph
+            .files
+            .iter()
+            .find(|file| file.base.location == location)
+            .unwrap_or_else(|| panic!("missing file node {location}"));
+        assert!(
+            file.leaf_children.is_empty(),
+            "expected no leaves for {location}"
+        );
+        assert!(
+            !file.source.is_empty() || file.source_blob_hash.is_some(),
+            "expected file-level source for {location}"
+        );
+    }
+
+    let search_results = service.search_structured("package.json", Some(&["file"]), None, None, 10);
+    assert_eq!(search_results.len(), 1);
+    assert_eq!(search_results[0].selector, "file:package.json");
+    assert_eq!(search_results[0].kind, "file");
+
+    let selector: Selector = "file:package.json".parse().expect("selector parses");
+    let node = service
+        .resolve_selector(&selector)
+        .expect("file selector resolves");
+    let GraphNodeRef::File(file) = node else {
+        panic!("package.json selector did not resolve to a file node");
+    };
+    assert!(file.source.contains("\"name\":\"orbit\""));
+}
+
+fn run_build(
+    repo: &Path,
+    output_dir: &Path,
+) -> orbit_knowledge::pipeline::context::PipelineContext {
+    let config = BuildConfig {
+        repo_path: repo.to_path_buf(),
+        output_dir: output_dir.to_path_buf(),
+        incremental: false,
+        ref_name: Some(RefName::new("main").expect("valid ref")),
+    };
+    orbit_knowledge::pipeline::run_build(config).expect("pipeline runs")
+}
+
+fn write_file(repo: &Path, rel: &str, content: &str) {
+    let path = repo.join(rel);
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).expect("create parent dir");
+    }
+    std::fs::write(path, content).expect("write fixture file");
+}

--- a/crates/orbit-tools/src/graph.rs
+++ b/crates/orbit-tools/src/graph.rs
@@ -243,6 +243,12 @@ pub(crate) fn node_context_payload(
         }
         GraphNodeRef::File(file) => {
             let obj = value.as_object_mut().expect("node context payload object");
+            if !file.source.is_empty() {
+                obj.insert("source".to_string(), json!(file.source));
+            }
+            if let Some(source_blob_hash) = file.source_blob_hash.as_ref() {
+                obj.insert("source_blob_hash".to_string(), json!(source_blob_hash));
+            }
             if !file.imports.is_empty() {
                 obj.insert("imports".to_string(), json!(file.imports));
             }

--- a/crates/orbit-tools/tests/graph_tool_surface.rs
+++ b/crates/orbit-tools/tests/graph_tool_surface.rs
@@ -17,10 +17,10 @@ const GRAPH_REF: &str = "main";
 #[test]
 fn search_prefers_code_symbols_and_hides_non_code_by_default() {
     let runtime_file = file_node("src/runtime.rs", "rust", Some("rs"), vec![]);
-    let config_file = file_node(
-        "benchmarks/locate-agentruntime.yaml",
-        "yaml",
-        Some("yaml"),
+    let doc_file = file_node(
+        "docs/locate-agentruntime.md",
+        "markdown",
+        Some("md"),
         vec![],
     );
     let runtime_trait = leaf_node(
@@ -29,18 +29,18 @@ fn search_prefers_code_symbols_and_hides_non_code_by_default() {
         LeafKind::Trait,
         "pub trait AgentRuntime {}",
     );
-    let config_key = leaf_node(
-        "benchmarks/locate-agentruntime.yaml",
+    let doc_section = leaf_node(
+        "docs/locate-agentruntime.md",
         "AgentRuntime",
-        LeafKind::ConfigKey,
-        "",
+        LeafKind::Section { depth: 1 },
+        "# AgentRuntime\n\nDocs mention the runtime contract.\n",
     );
     let fixture = write_graph_fixture(graph_with_root(
         vec![
             attach_leaf(runtime_file, &runtime_trait),
-            attach_leaf(config_file, &config_key),
+            attach_leaf(doc_file, &doc_section),
         ],
-        vec![runtime_trait, config_key],
+        vec![runtime_trait, doc_section],
     ));
 
     let response = execute_graph_tool(
@@ -69,9 +69,7 @@ fn search_prefers_code_symbols_and_hides_non_code_by_default() {
         .map(|entry| entry["selector"].as_str().unwrap())
         .collect();
     assert_eq!(selectors[0], "symbol:src/runtime.rs#AgentRuntime:trait");
-    assert!(
-        selectors.contains(&"symbol:benchmarks/locate-agentruntime.yaml#AgentRuntime:config_key")
-    );
+    assert!(selectors.contains(&"symbol:docs/locate-agentruntime.md#AgentRuntime:section"));
 }
 
 #[test]
@@ -139,6 +137,40 @@ fn search_source_regex_selector_format_stays_plain_selectors() {
     );
 
     assert_eq!(response, json!(["file:src/lib.rs"]));
+}
+
+#[test]
+fn search_file_selector_finds_package_json_by_filename() {
+    let mut file = file_node("package.json", "json", Some("json"), vec![]);
+    file.source = "{\"name\":\"orbit\"}\n".to_string();
+    let fixture = write_graph_fixture(graph_with_root(vec![file], Vec::new()));
+
+    let response = execute_graph_tool(
+        fixture.path(),
+        "orbit.graph.search",
+        json!({"query":"package.json","type":"file","limit":5}),
+    );
+
+    assert_eq!(response["total"], 1);
+    assert_eq!(response["results"][0]["selector"], "file:package.json");
+    assert_eq!(response["results"][0]["kind"], "file");
+}
+
+#[test]
+fn show_file_selector_includes_file_level_source() {
+    let mut file = file_node("package.json", "json", Some("json"), vec![]);
+    file.source = "{\"name\":\"orbit\"}\n".to_string();
+    let fixture = write_graph_fixture(graph_with_root(vec![file], Vec::new()));
+
+    let response = execute_graph_tool(
+        fixture.path(),
+        "orbit.graph.show",
+        json!({"selector":"file:package.json"}),
+    );
+
+    assert_eq!(response["selector"], "file:package.json");
+    assert_eq!(response["source"], "{\"name\":\"orbit\"}\n");
+    assert!(response["children"].as_array().unwrap().is_empty());
 }
 
 #[test]


### PR DESCRIPTION
## Task

[T20260509-64](https://orbit-cli.com/tasks/T20260509-64) — Collapse YAML/JSON/TOML/CSV/TSV extraction to file-as-leaf

### Description

## Problem

`extract/config.rs` (YAML/JSON/TOML) and `extract/table.rs` (CSV/TSV) emit per-key and per-header-column leaves with `source: ""` — name-only entries that have no body to `show`, cannot be `refs`-targeted, and clutter the search namespace with every `name`/`version`/`dependencies` from every config file. The semantic unit agents actually navigate to is the *file* (`package.json`, `Cargo.toml`, `tsconfig.json`), not the key.

Markdown is **explicitly out of scope**: per-section leaves carry real bodies and a clear forward path (per-section vector embeddings for semantic search). `extract/markdown.rs` stays as-is.

## Why It Matters

- Removes a `source: ""` corner case from the codebase and from downstream tools that special-case empty-source leaves.
- Cuts leaf count for any config-heavy directory (tsconfig matrices, helm charts, monorepo CI manifests) without losing capability — file nodes still carry source so file-level search and `show` continue to work.
- Lands **before** the `benchmarks/graph-latency/` Phase 0 baseline freeze in [perf_proposal_claude.md](raw/wiki/graph/perf_proposal_claude.md) so v1 numbers measure the leaf model we are keeping rather than one we are about to change.

## Implementation Notes

- Make `ConfigExtractor` (YAML/JSON/TOML) and `TableExtractor` (CSV/TSV) either return `ExtractionResult::default()` or be removed from the dispatch in `extract/mod.rs`. Either is acceptable; the executing agent should pick the path that leaves the fewest dead enum variants behind.
- Keep `FileKind::Config(...)` and `FileKind::Table(...)` enum entries — file-level `kind` metadata is still useful for downstream filtering.
- Confirm file nodes for these formats continue to hold `source` (or `source_blob_hash`) so `search` (substring/path) and `show` against config files keep working.
- Update or remove tests that assert `LeafKind::ConfigKey` or `LeafKind::Column` leaves are produced.
- The `SIZE_CAP_BYTES` short-circuit in `table.rs` becomes redundant once the extractor is gutted; remove it if the extractor is removed.

## Constraints / Notes
- Markdown stays segmented; do NOT modify `extract/markdown.rs`.
- Keep `FileKind::Config` / `FileKind::Table` enum variants for forward compatibility; only the extraction wiring changes.
- Sequencing: must land before Phase 0 baseline freeze in graph-latency benchmark work.
- Authoring model: claude-opus-4-7. Author: claude.

### Acceptance Criteria

- `make build` and `make fmt` pass with no new warnings attributable to this change.
- `cargo test -p orbit-knowledge` passes; any test asserting `LeafKind::ConfigKey` or `LeafKind::Column` leaves is updated to assert zero leaves for those formats (or removed if the assertion is the entire test).
- A new or updated test builds a knowledge graph over a fixture directory containing at least one .yaml, .json, .toml, and .csv file, and asserts: (a) the file node for each config/table file has `leaves: []`, (b) the file node has non-empty `source` or a populated `source_blob_hash`.
- Searching for a config filename via `orbit.graph.search` (e.g. query `package.json` against a fixture) returns the file as a hit — demonstrated by a test or by manual invocation against a fixture repo, with the command and output recorded in the execution summary.
- `orbit.graph.show` against a config file selector returns file-level source — demonstrated by a test or recorded manual invocation.
- `git diff crates/orbit-knowledge/src/extract/markdown.rs` shows no changes.
- `FileKind::Config(_)` and `FileKind::Table(_)` enum variants still exist and are still produced by `FileKind::from_extension` for yaml/yml/json/toml/csv/tsv extensions (verified by the existing language-detection tests, which should continue to pass unmodified).

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Collapsed YAML/JSON/TOML and CSV/TSV extractors to no-op leaf extraction while keeping their FileKind dispatch registered so file nodes still capture source.
- Added a config/table fixture graph test covering .yaml, .json, .toml, .csv, and .tsv file nodes with empty leaf children, file-level source, package.json file search, and file selector resolution.
- Updated orbit.graph.show payloads to include file-level source/source_blob_hash for file selectors, with graph tool coverage for package.json.
- Added orbit.graph.search tool coverage proving query package.json returns file:package.json, and updated non-code search coverage away from ConfigKey fixtures to markdown sections.
- Markdown extractor and FileKind language detection stayed unchanged.

Validation:
- cargo test -p orbit-knowledge: passed (includes config_and_table_files_are_file_level_graph_nodes and existing FileKind config/table classification tests).
- cargo test -p orbit-tools --test graph_tool_surface: passed (includes orbit.graph.search package.json and orbit.graph.show package.json source assertions).
- make build: passed.
- make fmt and make fmt-check: passed.
- git diff crates/orbit-knowledge/src/extract/markdown.rs: no output / no changes.

Assessment: Scoped refactor removes empty-source config/table leaves without dropping file-level graph navigation for these formats.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/T20260509-64-69ff958f`
- Behind base: 0
- Ahead of base: 1

*authored by: claude-opus-4-7*