### PR TITLE
Add GraphReadOptions and skip leaf/file source hydration in broad reads

### DIFF
--- a/crates/orbit-knowledge/src/graph/mod.rs
+++ b/crates/orbit-knowledge/src/graph/mod.rs
@@ -9,4 +9,4 @@ pub use nodes::{
     BaseNodeFields, CodebaseGraphV1, DirNode, FileNode, GraphNode, LeafHistoryEntry, LeafKind,
     LeafNode, SignatureField,
 };
-pub use object_store::GraphObjectStore;
+pub use object_store::{GraphObjectStore, GraphReadOptions};

--- a/crates/orbit-knowledge/src/graph/object_store.rs
+++ b/crates/orbit-knowledge/src/graph/object_store.rs
@@ -83,6 +83,12 @@ pub struct GraphWriteTarget {
     pub default: Option<RefName>,
 }
 
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct GraphReadOptions {
+    pub hydrate_file_source: bool,
+    pub hydrate_leaf_source: bool,
+}
+
 pub fn resolve_graph_read_target(
     workspace_path: Option<&Path>,
     explicit_ref: Option<&str>,
@@ -433,6 +439,7 @@ impl GraphObjectStore {
         requested: &RefName,
         fallback: Option<&RefName>,
         default_ref: Option<&RefName>,
+        options: GraphReadOptions,
     ) -> Result<CodebaseGraphV1, KnowledgeError> {
         self.prepare_refs_layout(default_ref)?;
         let resolved = self.resolve_ref(requested, fallback)?;
@@ -463,6 +470,7 @@ impl GraphObjectStore {
             file.base.object_hash = Some(entry.object_hash.clone());
             if let Some(ref blob_hash) = file.source_blob_hash
                 && file.source.is_empty()
+                && options.hydrate_file_source
             {
                 // Legacy graphs recorded a file source hash before file blobs were
                 // persisted. Keep those refs readable; new refs hydrate normally.
@@ -486,6 +494,7 @@ impl GraphObjectStore {
 
             if let Some(ref blob_hash) = leaf.source_blob_hash
                 && leaf.source.is_empty()
+                && options.hydrate_leaf_source
             {
                 leaf.source = self.read_blob(blob_hash)?;
             }
@@ -958,6 +967,96 @@ fn dir_depth(location: &str) -> usize {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::graph::nodes::{
+        BaseNodeFields, CodebaseGraphV1, DirNode, FileNode, LeafKind, LeafNode,
+    };
+
+    #[test]
+    fn graph_read_options_gate_blob_source_hydration() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let store = GraphObjectStore::new(temp_dir.path());
+        let graph = CodebaseGraphV1 {
+            root_dir_id: "dir-root".to_string(),
+            dirs: vec![DirNode {
+                base: base_node("dir-root", ".", "./", None),
+                dir_children: Vec::new(),
+                file_children: vec!["file-lib".to_string()],
+            }],
+            files: vec![FileNode {
+                base: base_node("file-lib", "lib.rs", "src/lib.rs", Some("dir-root")),
+                extension: Some("rs".to_string()),
+                source_blob_hash: None,
+                source: "pub fn greet() { helper(); }\n".to_string(),
+                imports: Vec::new(),
+                exports: vec!["greet".to_string()],
+                re_exports: Vec::new(),
+                leaf_children: vec!["leaf-greet".to_string()],
+            }],
+            leaves: vec![LeafNode {
+                base: base_node("leaf-greet", "greet", "src/lib.rs#greet", Some("file-lib")),
+                kind: LeafKind::Function,
+                source: "pub fn greet() { helper(); }\n".to_string(),
+                source_blob_hash: None,
+                source_hash: Some("source-hash".to_string()),
+                file_hash_at_capture: Some("file-hash".to_string()),
+                history: Vec::new(),
+                input_signature: Vec::new(),
+                output_signature: Vec::new(),
+                start_line: Some(1),
+                end_line: Some(1),
+                children: Vec::new(),
+            }],
+        };
+        let current_ref = store.write_graph(&graph).expect("write graph");
+        let ref_name = RefName::new("main").expect("valid ref");
+        store
+            .write_ref_atomic(&ref_name, &current_ref)
+            .expect("write ref");
+
+        let default_graph = store
+            .read_graph(
+                &ref_name,
+                None,
+                Some(&ref_name),
+                GraphReadOptions::default(),
+            )
+            .expect("read graph without hydration");
+        assert_eq!(default_graph.files[0].source, "");
+        assert!(default_graph.files[0].source_blob_hash.is_some());
+        assert_eq!(default_graph.leaves[0].source, "");
+        assert!(default_graph.leaves[0].source_blob_hash.is_some());
+
+        let hydrated_graph = store
+            .read_graph(
+                &ref_name,
+                None,
+                Some(&ref_name),
+                GraphReadOptions {
+                    hydrate_file_source: true,
+                    hydrate_leaf_source: true,
+                },
+            )
+            .expect("read graph with hydration");
+        assert_eq!(hydrated_graph.files[0].source, graph.files[0].source);
+        assert_eq!(hydrated_graph.leaves[0].source, graph.leaves[0].source);
+    }
+
+    fn base_node(id: &str, name: &str, location: &str, parent_id: Option<&str>) -> BaseNodeFields {
+        BaseNodeFields {
+            id: id.to_string(),
+            identity_key: id.to_string(),
+            object_hash: None,
+            name: name.to_string(),
+            location: location.to_string(),
+            language: "rust".to_string(),
+            description: String::new(),
+            parent_id: parent_id.map(str::to_string),
+            is_locked: false,
+            lineage_locked: false,
+            lock_owner: None,
+            lock_reason: String::new(),
+        }
+    }
 
     #[test]
     fn dir_depth_root_location_is_zero() {

--- a/crates/orbit-knowledge/src/lib.rs
+++ b/crates/orbit-knowledge/src/lib.rs
@@ -45,6 +45,7 @@ mod store;
 pub mod working_graph;
 
 pub use error::KnowledgeError;
+pub use graph::GraphReadOptions;
 pub use selector::{Selector, SelectorParseError};
 pub use service::{TaskGraphScope, TaskGraphService, default_knowledge_dir};
 pub use store::{

--- a/crates/orbit-knowledge/src/pipeline/build.rs
+++ b/crates/orbit-knowledge/src/pipeline/build.rs
@@ -7,7 +7,7 @@ use rayon::prelude::*;
 use crate::error::KnowledgeError;
 use crate::extract::{self, FileKind, identity_key, leaf_location, node_id};
 use crate::graph::nodes::{BaseNodeFields, DirNode, FileNode, LeafKind, LeafNode, ReExport};
-use crate::graph::object_store::GraphObjectStore;
+use crate::graph::object_store::{GraphObjectStore, GraphReadOptions};
 use crate::pipeline::context::PipelineContext;
 use tracing::debug;
 
@@ -427,7 +427,15 @@ fn load_prior_file_snapshots(ctx: &PipelineContext) -> Option<HashMap<String, Pr
     }
 
     let store = GraphObjectStore::new(ctx.graph_dir());
-    let prior_graph = match store.read_graph(&ctx.ref_name, None, ctx.default_ref_name.as_ref()) {
+    let prior_graph = match store.read_graph(
+        &ctx.ref_name,
+        None,
+        ctx.default_ref_name.as_ref(),
+        GraphReadOptions {
+            hydrate_file_source: true,
+            hydrate_leaf_source: true,
+        },
+    ) {
         Ok(graph) => graph,
         Err(error) => {
             debug!(

--- a/crates/orbit-knowledge/src/service/lineage.rs
+++ b/crates/orbit-knowledge/src/service/lineage.rs
@@ -8,7 +8,7 @@ use serde_json::{Value, json};
 use crate::error::KnowledgeError;
 use crate::graph::navigator::GraphNodeRef;
 use crate::graph::nodes::CodebaseGraphV1;
-use crate::graph::object_store::{GraphObjectStore, resolve_graph_read_target};
+use crate::graph::object_store::{GraphObjectStore, GraphReadOptions, resolve_graph_read_target};
 use crate::selector::Selector;
 use crate::service::GraphContextService;
 
@@ -59,6 +59,10 @@ pub fn render_lineage_pack(
         &read_target.requested,
         read_target.fallback.as_ref(),
         read_target.default.as_ref(),
+        GraphReadOptions {
+            hydrate_leaf_source: true,
+            ..Default::default()
+        },
     )?;
     render_lineage_pack_from_graph(&graph, selectors, options)
 }

--- a/crates/orbit-knowledge/src/service/task_graph.rs
+++ b/crates/orbit-knowledge/src/service/task_graph.rs
@@ -4,7 +4,7 @@ use orbit_common::types::OrbitError;
 use serde_json::Value;
 
 use crate::extract::{self, Language};
-use crate::graph::object_store::{GraphObjectStore, resolve_graph_read_target};
+use crate::graph::object_store::{GraphObjectStore, GraphReadOptions, resolve_graph_read_target};
 use crate::lock::GraphLockGuard;
 use crate::pipeline::context::BuildConfig;
 use crate::{
@@ -45,6 +45,7 @@ impl TaskGraphService {
         workspace_root: Option<&Path>,
         explicit_knowledge_dir: bool,
         explicit_ref: Option<&str>,
+        read_options: GraphReadOptions,
         selector_timeout_ms: Option<u64>,
     ) -> Result<Value, OrbitError> {
         if explicit_ref.is_none() {
@@ -68,7 +69,7 @@ impl TaskGraphService {
                 read_target.fallback.as_ref(),
                 read_target.default.as_ref(),
             )?;
-            store.pack_with_timeout(selectors, selector_timeout_ms)
+            store.pack_with_timeout_options(selectors, selector_timeout_ms, read_options)
         };
 
         let pack = match pack_result() {
@@ -189,6 +190,7 @@ impl TaskGraphService {
         workspace_root: Option<&Path>,
         explicit_knowledge_dir: bool,
         explicit_ref: Option<&str>,
+        options: GraphReadOptions,
     ) -> Result<crate::graph::nodes::CodebaseGraphV1, OrbitError> {
         if explicit_ref.is_none() {
             self.maybe_refresh_knowledge_graph(workspace_root, explicit_knowledge_dir);
@@ -200,6 +202,7 @@ impl TaskGraphService {
             &read_target.requested,
             read_target.fallback.as_ref(),
             read_target.default.as_ref(),
+            options,
         ) {
             Ok(graph) => Ok(graph),
             Err(first_error) => {
@@ -230,6 +233,7 @@ impl TaskGraphService {
                         &read_target.requested,
                         read_target.fallback.as_ref(),
                         read_target.default.as_ref(),
+                        options,
                     )
                     .map_err(|retry_error| {
                         OrbitError::Execution(format!(

--- a/crates/orbit-knowledge/src/store/pack.rs
+++ b/crates/orbit-knowledge/src/store/pack.rs
@@ -3,6 +3,7 @@ use std::time::{Duration, Instant};
 use serde_json::Value;
 
 use crate::error::KnowledgeError;
+use crate::graph::object_store::GraphReadOptions;
 use crate::selector::Selector;
 
 use super::KnowledgeStore;
@@ -21,6 +22,22 @@ impl KnowledgeStore {
         &self,
         selectors: &[Selector],
         timeout_ms: Option<u64>,
+    ) -> Result<KnowledgePack, KnowledgeError> {
+        self.pack_with_timeout_options(
+            selectors,
+            timeout_ms,
+            GraphReadOptions {
+                hydrate_leaf_source: true,
+                ..Default::default()
+            },
+        )
+    }
+
+    pub fn pack_with_timeout_options(
+        &self,
+        selectors: &[Selector],
+        timeout_ms: Option<u64>,
+        read_options: GraphReadOptions,
     ) -> Result<KnowledgePack, KnowledgeError> {
         let mut entries = Vec::with_capacity(selectors.len());
         let mut unresolved_selectors = Vec::new();
@@ -60,7 +77,7 @@ impl KnowledgeStore {
                 self.graph_object_cache(),
             )?;
             let node = object.get("node");
-            let source = if index_entry.node_type == "leaf" {
+            let source = if index_entry.node_type == "leaf" && read_options.hydrate_leaf_source {
                 extract_leaf_source(&self.knowledge_dir, &object, self.graph_object_cache())?
             } else {
                 None

--- a/crates/orbit-knowledge/tests/branch_refs.rs
+++ b/crates/orbit-knowledge/tests/branch_refs.rs
@@ -74,6 +74,7 @@ fn graph_reads_fall_back_to_default_branch_when_current_branch_ref_is_missing()
         &read_target.requested,
         read_target.fallback.as_ref(),
         read_target.default.as_ref(),
+        Default::default(),
     )?;
     assert_eq!(graph.root_dir_id, "dir:.");
     assert_eq!(graph.leaves.len(), 1);
@@ -109,6 +110,7 @@ fn graph_reads_fall_back_to_non_main_default_branch_when_current_branch_ref_is_m
         &read_target.requested,
         read_target.fallback.as_ref(),
         read_target.default.as_ref(),
+        Default::default(),
     )?;
     assert_eq!(graph.root_dir_id, "dir:.");
     assert_eq!(graph.leaves.len(), 1);
@@ -195,11 +197,13 @@ fn concurrent_branch_builds_keep_distinct_refs_and_graphs_reachable()
         &alpha_read_target.requested,
         alpha_read_target.fallback.as_ref(),
         Some(&default_ref),
+        Default::default(),
     )?;
     let beta_graph = store.read_graph(
         &beta_read_target.requested,
         beta_read_target.fallback.as_ref(),
         Some(&default_ref),
+        Default::default(),
     )?;
     assert!(
         alpha_graph
@@ -285,6 +289,7 @@ fn ensure_fresh_waits_for_requested_branch_ref_before_returning()
         &read_target.requested,
         read_target.fallback.as_ref(),
         read_target.default.as_ref(),
+        Default::default(),
     )?;
     assert!(
         graph
@@ -361,6 +366,7 @@ fn branch_refs_ensure_fresh_rebuilds_clean_worktree_when_branch_ref_is_missing()
         &read_target.requested,
         read_target.fallback.as_ref(),
         read_target.default.as_ref(),
+        Default::default(),
     )?;
     assert!(
         graph
@@ -449,6 +455,7 @@ fn branch_refs_ensure_fresh_rebuilds_after_reset_to_older_timestamp_head()
         &read_target.requested,
         read_target.fallback.as_ref(),
         read_target.default.as_ref(),
+        Default::default(),
     )?;
     assert!(
         graph

--- a/crates/orbit-knowledge/tests/orbitignore.rs
+++ b/crates/orbit-knowledge/tests/orbitignore.rs
@@ -62,6 +62,7 @@ fn load_graph(
             &read_target.requested,
             read_target.fallback.as_ref(),
             read_target.default.as_ref(),
+            Default::default(),
         )
         .unwrap()
 }

--- a/crates/orbit-tools/src/builtin/orbit/knowledge/callers.rs
+++ b/crates/orbit-tools/src/builtin/orbit/knowledge/callers.rs
@@ -1,7 +1,7 @@
 use orbit_common::types::{OrbitError, ToolParam, ToolSchema};
-use orbit_knowledge::Selector;
 use orbit_knowledge::service::GraphContextService;
 use orbit_knowledge::service::callers::{MAX_CALLER_DEPTH, transitive_callers};
+use orbit_knowledge::{GraphReadOptions, Selector};
 use serde_json::{Value, json};
 
 use crate::{Tool, ToolContext};
@@ -52,7 +52,14 @@ impl Tool for OrbitKnowledgeCallersTool {
             .unwrap_or(DEFAULT_DEPTH) as usize;
         let depth = requested_depth.min(MAX_CALLER_DEPTH);
 
-        let graph = super::load_graph_for_read(ctx, &input)?;
+        let graph = super::load_graph_for_read(
+            ctx,
+            &input,
+            GraphReadOptions {
+                hydrate_leaf_source: true,
+                ..Default::default()
+            },
+        )?;
         let svc = GraphContextService::new(&graph);
 
         let hits = transitive_callers(&svc, &graph, &selector, depth)

--- a/crates/orbit-tools/src/builtin/orbit/knowledge/implementors.rs
+++ b/crates/orbit-tools/src/builtin/orbit/knowledge/implementors.rs
@@ -1,7 +1,7 @@
 use orbit_common::types::{OrbitError, ToolParam, ToolSchema};
-use orbit_knowledge::Selector;
 use orbit_knowledge::service::GraphContextService;
 use orbit_knowledge::service::implementors::trait_implementors;
+use orbit_knowledge::{GraphReadOptions, Selector};
 use serde_json::{Value, json};
 
 use crate::{Tool, ToolContext};
@@ -39,7 +39,14 @@ impl Tool for OrbitKnowledgeImplementorsTool {
             .parse()
             .map_err(|e| OrbitError::InvalidInput(format!("{e}")))?;
 
-        let graph = super::load_graph_for_read(ctx, &input)?;
+        let graph = super::load_graph_for_read(
+            ctx,
+            &input,
+            GraphReadOptions {
+                hydrate_leaf_source: true,
+                ..Default::default()
+            },
+        )?;
         let svc = GraphContextService::new(&graph);
 
         let hits = trait_implementors(&svc, &graph, &selector)

--- a/crates/orbit-tools/src/builtin/orbit/knowledge/mod.rs
+++ b/crates/orbit-tools/src/builtin/orbit/knowledge/mod.rs
@@ -16,8 +16,8 @@ pub mod show;
 mod write;
 
 use orbit_common::types::OrbitError;
-use orbit_knowledge::TaskGraphService;
 use orbit_knowledge::graph::nodes::CodebaseGraphV1;
+use orbit_knowledge::{GraphReadOptions, TaskGraphService};
 use serde_json::Value;
 
 use crate::ToolContext;
@@ -32,6 +32,7 @@ pub(super) fn has_explicit_knowledge_dir(input: &Value) -> bool {
 pub(super) fn load_graph_for_read(
     ctx: &ToolContext,
     input: &Value,
+    options: GraphReadOptions,
 ) -> Result<CodebaseGraphV1, OrbitError> {
     let knowledge_dir = write::resolve_knowledge_dir(ctx, input)?;
     let service = TaskGraphService::new(knowledge_dir, write::task_graph_scope(ctx));
@@ -40,5 +41,6 @@ pub(super) fn load_graph_for_read(
         ctx.workspace_root.as_deref(),
         has_explicit_knowledge_dir(input),
         explicit_ref.as_deref(),
+        options,
     )
 }

--- a/crates/orbit-tools/src/builtin/orbit/knowledge/overview.rs
+++ b/crates/orbit-tools/src/builtin/orbit/knowledge/overview.rs
@@ -75,7 +75,7 @@ impl Tool for OrbitKnowledgeOverviewTool {
     fn execute(&self, ctx: &ToolContext, input: Value) -> Result<Value, OrbitError> {
         let prefix = super::super::optional_string(&input, "prefix")?;
         let requested_format = OverviewFormat::parse(&input)?;
-        let graph = super::load_graph_for_read(ctx, &input)?;
+        let graph = super::load_graph_for_read(ctx, &input, Default::default())?;
         let svc = GraphContextService::new(&graph);
         let overview = svc.overview(prefix.as_deref());
         let resolved_format = requested_format.unwrap_or_else(|| {

--- a/crates/orbit-tools/src/builtin/orbit/knowledge/pack.rs
+++ b/crates/orbit-tools/src/builtin/orbit/knowledge/pack.rs
@@ -1,7 +1,7 @@
 use orbit_common::types::{
     OrbitError, ToolParam, ToolSchema, optional_string, optional_string_list_alias,
 };
-use orbit_knowledge::{Selector, TaskGraphService};
+use orbit_knowledge::{GraphReadOptions, Selector, TaskGraphService};
 use serde_json::{Value, json};
 
 use crate::{Tool, ToolContext};
@@ -70,11 +70,16 @@ impl Tool for OrbitKnowledgePackTool {
         let explicit_knowledge_dir = super::has_explicit_knowledge_dir(&input);
         let skip_auto_refresh = !refresh || explicit_knowledge_dir;
         let service = TaskGraphService::new(knowledge_dir, super::write::task_graph_scope(ctx));
+        let read_options = GraphReadOptions {
+            hydrate_leaf_source: !summary,
+            ..Default::default()
+        };
         let mut pack = service.pack_json(
             &selectors,
             ctx.workspace_root.as_deref(),
             skip_auto_refresh,
             explicit_ref.as_deref(),
+            read_options,
             Some(selector_timeout_ms),
         )?;
         add_refresh_diagnostics(

--- a/crates/orbit-tools/src/builtin/orbit/knowledge/refs.rs
+++ b/crates/orbit-tools/src/builtin/orbit/knowledge/refs.rs
@@ -2,8 +2,8 @@ use std::collections::HashMap;
 use std::path::Path;
 
 use orbit_common::types::{OrbitError, ToolParam, ToolSchema, optional_string_list_alias};
-use orbit_knowledge::Selector;
 use orbit_knowledge::service::GraphContextService;
+use orbit_knowledge::{GraphReadOptions, Selector};
 use serde_json::{Value, json};
 
 use crate::{Tool, ToolContext};
@@ -102,7 +102,14 @@ impl Tool for OrbitKnowledgeRefsTool {
 
         // Extract the defining file to exclude self-references
         let knowledge_dir = super::write::resolve_knowledge_dir(ctx, &input)?;
-        let graph = super::load_graph_for_read(ctx, &input)?;
+        let graph = super::load_graph_for_read(
+            ctx,
+            &input,
+            GraphReadOptions {
+                hydrate_leaf_source: true,
+                ..Default::default()
+            },
+        )?;
         let svc = GraphContextService::new(&graph);
         let all_hits = svc.find_references(
             Some(&knowledge_dir),

--- a/crates/orbit-tools/src/builtin/orbit/knowledge/search.rs
+++ b/crates/orbit-tools/src/builtin/orbit/knowledge/search.rs
@@ -1,4 +1,5 @@
 use orbit_common::types::{OrbitError, ToolParam, ToolSchema, optional_raw_string};
+use orbit_knowledge::GraphReadOptions;
 use orbit_knowledge::graph::navigator::GraphNodeRef;
 use orbit_knowledge::service::{GraphContextService, SearchHit};
 use regex::Regex;
@@ -104,7 +105,14 @@ impl Tool for OrbitKnowledgeSearchTool {
         let use_default_ranking =
             node_type.is_none() && kind_filter.is_none() && prefix.is_none() && !has_source_regex;
 
-        let graph = super::load_graph_for_read(ctx, &input)?;
+        let graph = super::load_graph_for_read(
+            ctx,
+            &input,
+            GraphReadOptions {
+                hydrate_file_source: has_source_regex,
+                hydrate_leaf_source: has_source_regex,
+            },
+        )?;
         let svc = GraphContextService::new(&graph);
 
         let type_strs: Vec<&str> = node_type.iter().map(String::as_str).collect();

--- a/crates/orbit-tools/src/builtin/orbit/knowledge/show.rs
+++ b/crates/orbit-tools/src/builtin/orbit/knowledge/show.rs
@@ -1,6 +1,6 @@
 use orbit_common::types::{OrbitError, ToolParam, ToolSchema};
-use orbit_knowledge::Selector;
 use orbit_knowledge::service::GraphContextService;
+use orbit_knowledge::{GraphReadOptions, Selector};
 use serde_json::Value;
 
 use crate::{Tool, ToolContext};
@@ -53,7 +53,14 @@ impl Tool for OrbitKnowledgeShowTool {
         let max_siblings = input.get("siblings").and_then(Value::as_u64).unwrap_or(3) as usize;
         let max_children = input.get("children").and_then(Value::as_u64).unwrap_or(5) as usize;
 
-        let graph = super::load_graph_for_read(ctx, &input)?;
+        let graph = super::load_graph_for_read(
+            ctx,
+            &input,
+            GraphReadOptions {
+                hydrate_file_source: true,
+                hydrate_leaf_source: true,
+            },
+        )?;
         let svc = GraphContextService::new(&graph);
 
         let node = svc

--- a/crates/orbit-tools/src/graph.rs
+++ b/crates/orbit-tools/src/graph.rs
@@ -6,7 +6,7 @@ use orbit_knowledge::graph::nodes::CodebaseGraphV1;
 use orbit_knowledge::graph::object_store::RefName;
 use orbit_knowledge::pipeline::context::BuildConfig;
 use orbit_knowledge::service::GraphContextService;
-use orbit_knowledge::{Selector, TaskGraphScope, TaskGraphService};
+use orbit_knowledge::{GraphReadOptions, Selector, TaskGraphScope, TaskGraphService};
 use serde_json::{Value, json};
 
 pub(crate) const REMOVED_GRAPH_HISTORY_MESSAGE: &str = "Knowledge-graph task attribution has been removed. Use `git log --grep '[T<task-id>]'` for local forward lookup, and use `external_refs` for cross-engineer task references.";
@@ -149,7 +149,14 @@ pub fn build_graph(options: GraphBuildOptions) -> Result<GraphBuildOutput, Orbit
 }
 
 pub fn show_graph(options: GraphShowOptions) -> Result<GraphShowOutput, OrbitError> {
-    let graph = load_graph(&options.data_root, options.ref_name.as_deref())?;
+    let graph = load_graph(
+        &options.data_root,
+        options.ref_name.as_deref(),
+        GraphReadOptions {
+            hydrate_file_source: true,
+            hydrate_leaf_source: true,
+        },
+    )?;
     let service = GraphContextService::new(&graph);
 
     let selector: Selector = options
@@ -169,7 +176,11 @@ pub fn show_graph(options: GraphShowOptions) -> Result<GraphShowOutput, OrbitErr
 }
 
 pub fn search_graph(options: GraphSearchOptions) -> Result<GraphSearchOutput, OrbitError> {
-    let graph = load_graph(&options.data_root, options.ref_name.as_deref())?;
+    let graph = load_graph(
+        &options.data_root,
+        options.ref_name.as_deref(),
+        Default::default(),
+    )?;
     let service = GraphContextService::new(&graph);
 
     let type_refs: Vec<&str> = options.node_types.iter().map(String::as_str).collect();
@@ -265,11 +276,15 @@ pub(crate) fn node_context_payload(
     value
 }
 
-fn load_graph(data_root: &Path, explicit_ref: Option<&str>) -> Result<CodebaseGraphV1, OrbitError> {
+fn load_graph(
+    data_root: &Path,
+    explicit_ref: Option<&str>,
+    options: GraphReadOptions,
+) -> Result<CodebaseGraphV1, OrbitError> {
     let knowledge_dir = data_root.join("knowledge");
     let repo_path = repo_from_data_root(data_root);
     let service = TaskGraphService::new(knowledge_dir, TaskGraphScope::default());
-    service.read_graph(Some(&repo_path), false, explicit_ref)
+    service.read_graph(Some(&repo_path), false, explicit_ref, options)
 }
 
 fn repo_from_data_root(data_root: &Path) -> PathBuf {

--- a/docs/design/knowledge-graph/2_design.md
+++ b/docs/design/knowledge-graph/2_design.md
@@ -142,6 +142,12 @@ Search no longer accepts a `task_id` filter. Task-to-commit lookup is handled by
 
 Object and blob hashes are content-addressed, so a cache hit can trust the value already verified on insertion. `read_graph_object` and `extract_leaf_source` verify SHA-256 integrity only on cache miss, then insert the verified value. The cache is scoped to a `KnowledgeStore` instance rather than a global singleton so separate workspaces and tests cannot cross-contaminate.
 
+### 3.4 Source hydration is opt-in on broad graph reads
+
+`GraphObjectStore::read_graph` accepts `GraphReadOptions` with separate `hydrate_file_source` and `hydrate_leaf_source` flags, both defaulting to `false` ([T20260509-65]). The object store still loads node objects and preserves `source_blob_hash`, but it leaves `FileNode.source` and `LeafNode.source` empty unless the caller explicitly asks for the matching source class.
+
+The tool surface maps that choice to actual query needs: `show` hydrates file and leaf source; `refs`, `callers`, and `implementors` hydrate leaf source; `search` hydrates both only for `source_regex`; `overview`, default search, `deps`, and the `history` compatibility stub do not hydrate source. `pack` keeps summary mode body-free and hydrates leaf source only when `summary: false`. Incremental rebuild reuse still hydrates both file and leaf source because it copies unchanged snapshots into the next graph.
+
 ---
 
 ## 4. Orbit Integration
@@ -280,5 +286,6 @@ The scanner skips symlinked directories rather than trying to canonicalize and f
 - **[T20260505-5]** — Bound `orbit.graph.pack` selector gathering and skip inline refresh by default, documented by gpt-5.5.
 - **[T20260506-11]** — Remove graph task attribution after 0/961 audited reverse-lookup uses; preserve task IDs as local commit-search keys.
 - **[T20260509-33]** — Skip symlinked directories/files during knowledge scans and `.orbitignore` discovery to prevent outside-repo indexing and recursive cycles.
+- **[T20260509-65]** — Add `GraphReadOptions` so broad graph reads skip file/leaf source hydration unless a tool opts in.
 
 Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.

--- a/docs/design/knowledge-graph/4_decisions.md
+++ b/docs/design/knowledge-graph/4_decisions.md
@@ -474,6 +474,23 @@ These entries were formerly ADR headings, but they are plain instances of ADR-00
 
 ---
 
+## ADR-032 — Source hydration is explicit per graph read
+
+**Status:** Accepted · 2026-05 · [T20260509-65]
+**Author:** gpt-5.5
+
+**Context.** `GraphObjectStore::read_graph` historically hydrated every file and leaf source blob when node objects carried empty `source` plus `source_blob_hash`. Broad tools such as overview, default search, deps, and the history compatibility stub do not need source bodies, so large repositories paid blob I/O on reads whose answers are metadata-only.
+
+**Decision.** Add `GraphReadOptions` with separate `hydrate_file_source` and `hydrate_leaf_source` booleans that default to `false`. Tools and services opt in only when they inspect or return source: show hydrates both; refs/callers/implementors hydrate leaves; `source_regex` search hydrates both; pack hydrates leaf bodies only for non-summary output. Incremental rebuild reuse keeps an explicit hydrate-both path because it copies prior source-bearing snapshots.
+
+**Consequences.**
+- Broad metadata reads avoid source blob I/O while preserving the on-disk graph format and all blob hashes.
+- Source-returning tools keep their payloads stable by opting in at the load boundary.
+- Pack summary mode no longer reads leaf bodies only to discard them.
+- Cost: any new reader that touches `leaf.source` or `file.source` must deliberately request hydration; missing that opt-in degrades behavior to empty-source results rather than failing at compile time.
+
+---
+
 ## Task References
 
 Tasks cited by ADRs above:
@@ -520,5 +537,6 @@ Tasks cited by ADRs above:
 - **[T20260506-19]** — Normalize knowledge-graph ADR Cost lines and demote folded language instances to coverage records.
 - **[T20260509-33]** — Skip symlinked directory entries during scanner traversal and `.orbitignore` discovery.
 - **[T20260509-34]** — Use exact git checkout identity instead of commit timestamps for clean graph freshness.
+- **[T20260509-65]** — Add `GraphReadOptions` so broad graph reads skip file/leaf source hydration unless a tool opts in.
 
 Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.


### PR DESCRIPTION
## Task

[T20260509-65](https://orbit-cli.com/tasks/T20260509-65) — Add GraphReadOptions and skip leaf/file source hydration in broad reads

### Description

## Problem

`GraphObjectStore::read_graph` ([crates/orbit-knowledge/src/graph/object_store.rs:431](crates/orbit-knowledge/src/graph/object_store.rs:431)) unconditionally hydrates leaf and file source from blob files when `source.is_empty() && source_blob_hash.is_some()`. Read tools that do not need source (`overview`, default-mode `search`, `deps`, `history`) pay the full blob-read cost on every call. Source-blob I/O is the dominant constant in graph-read latency for large monorepos.

## Why It Matters

Phase 1 of the graph-latency proposal ([raw/wiki/graph/perf_proposal_claude.md](raw/wiki/graph/perf_proposal_claude.md)). This is the highest-ROI single change: source hydration is the dominant constant cost, and turning it off for tools that do not need source is a localized refactor with no disk-format change. Expected ≥ 5× p99 reduction on broad reads; falsification gate at < 2×.

## Implementation Notes

- Introduce `GraphReadOptions { hydrate_file_source: bool, hydrate_leaf_source: bool }` (or equivalent) with both fields defaulting to `false`. Place near `GraphObjectStore` in `orbit-knowledge`.
- Thread the options through `read_graph` and through `TaskGraphService::read_graph` so callers can pass them.
- Update `load_graph_for_read` in [crates/orbit-tools/src/builtin/orbit/knowledge/mod.rs](crates/orbit-tools/src/builtin/orbit/knowledge/mod.rs) to accept and forward options.
- **Tools that must opt INTO source hydration** (pass `true`):
  - `show.rs` — needs source for the returned node body.
  - `refs.rs` — scans leaf source.
  - `callers.rs` — reparses source with tree-sitter at query time.
  - `implementors.rs` — reparses source with tree-sitter at query time.
  - `pack.rs` — needs source for `summary: false`; verify `pack` summary mode can avoid it.
  - `search.rs` — only when `source_regex` filter is present; default-mode search must NOT hydrate source.
- **Tools that should default OFF** (do not pass `true`):
  - `overview.rs` — summary mode does not need source.
  - `search.rs` (default mode without `source_regex`).
  - `deps.rs` — verify it operates on metadata only; if it reparses source, treat like `callers`.
  - `history.rs` — verify; likely metadata-only.
- Audit `pack.rs` and `deps.rs` for whether they go through `load_graph_for_read` or have their own load path. Both surfaces must be updated.
- Anywhere downstream that assumes `leaf.source` or `file.source` is populated must either (a) explicitly request hydration via the options, or (b) be made tolerant of empty source. Run a targeted grep for `leaf.source` / `file.source` reads to enumerate.
- No disk-format changes. No on-disk migration.

## Constraints / Notes

- Backward compatibility: tool output payloads must not change on tools that already return source today (e.g. `show`). Verify by snapshot test or manual diff.
- Test fixture: a small graph with a leaf that has `source_blob_hash` but empty `source` field — assert `read_graph` with default options returns leaf with empty source, and with `hydrate_leaf_source: true` returns the hydrated body.
- This task lands the code change only. Measurement of the actual latency win is tracked in a separate Phase 1 measurement task (filed alongside).
- Authoring model: claude-opus-4-7. Author: claude.

### Acceptance Criteria

- `GraphReadOptions` (or equivalent named struct) exists in `orbit-knowledge` with `hydrate_file_source: bool` and `hydrate_leaf_source: bool`, both defaulting to `false`. Verifiable by `grep -rn GraphReadOptions crates/orbit-knowledge/src`.
- `GraphObjectStore::read_graph` (and `TaskGraphService::read_graph` if applicable) accepts the options struct and gates the existing eager `read_blob` calls in [object_store.rs:464](crates/orbit-knowledge/src/graph/object_store.rs:464) and [object_store.rs:487](crates/orbit-knowledge/src/graph/object_store.rs:487) on the corresponding flag.
- `load_graph_for_read` in [crates/orbit-tools/src/builtin/orbit/knowledge/mod.rs](crates/orbit-tools/src/builtin/orbit/knowledge/mod.rs) accepts and forwards `GraphReadOptions`.
- Each of these tools passes options that match the hydration list in the description: `show`, `refs`, `callers`, `implementors`, `pack` (non-summary), `search` (only when `source_regex` is set). Each of these does NOT request hydration: `overview`, default-mode `search`, `deps`, `history`. Verifiable by reading each tool entry point.
- A new unit test in `orbit-knowledge` builds a fixture graph with a leaf carrying `source_blob_hash` and empty `source`, then asserts: (a) `read_graph` with default options returns the leaf with empty `source`, (b) `read_graph` with `hydrate_leaf_source: true` returns the leaf with the hydrated body matching the blob content. Same for file source if applicable.
- Existing tool snapshot/integration tests for `show`, `refs`, `callers`, `implementors`, `pack` (non-summary) pass without payload changes.
- Existing tool tests for `overview`, default `search`, `deps`, `history` pass.
- `make build` and `make fmt` pass with no new warnings attributable to this change.
- `cargo test --workspace` passes.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Added GraphReadOptions with default-off file and leaf source hydration, threaded through GraphObjectStore, TaskGraphService, tool graph loading, and graph CLI helpers.
- Updated source-dependent graph tools to opt in: show hydrates file and leaf source; refs/callers/implementors hydrate leaf source; source_regex search hydrates both; pack hydrates leaf bodies only for non-summary output.
- Kept metadata-only tools on default options and documented the design/ADR update for T20260509-65.
- Added object-store coverage proving default reads leave blob-backed sources empty while opt-in reads hydrate file and leaf bodies.

Assessment: The change preserves on-disk format and source-returning tool payloads while avoiding broad-read source blob I/O.

Validation:
- make fmt
- make build
- cargo test --workspace

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/T20260509-65-69ff9afd`
- Behind base: 0
- Ahead of base: 1

*authored by: claude-opus-4-7*