### PR TITLE
Bound search default-ranking scan with named cap

### DIFF
--- a/crates/orbit-tools/src/builtin/orbit/knowledge/search.rs
+++ b/crates/orbit-tools/src/builtin/orbit/knowledge/search.rs
@@ -10,13 +10,17 @@ use crate::{Tool, ToolContext};
 pub struct OrbitKnowledgeSearchTool;
 
 const DEFAULT_LIMIT: usize = 20;
+const DEFAULT_RANKING_HEADROOM: usize = 10;
+const DEFAULT_RANKING_HARD_CAP: usize = 5_000;
 const SOURCE_REGEX_UNBOUNDED_LIMIT_MAX: usize = 200;
 
 impl Tool for OrbitKnowledgeSearchTool {
     fn schema(&self) -> ToolSchema {
         ToolSchema {
             name: "orbit.graph.search".to_string(),
-            description: "Use when you need to locate selectors by name/path/source regex. Prefer over grep when text hits lose node type or source-context filters.".to_string(),
+            description: format!(
+                "Use when you need to locate selectors by name/path/source regex. Prefer over grep when text hits lose node type or source-context filters. Default ranking keeps at most {DEFAULT_RANKING_HARD_CAP} candidates before ranking."
+            ),
             parameters: vec![
                 ToolParam {
                     name: "query".to_string(),
@@ -122,7 +126,8 @@ impl Tool for OrbitKnowledgeSearchTool {
             Some(type_strs.as_slice())
         };
         let search_limit = if use_default_ranking {
-            usize::MAX
+            // Bound retained service hits while still ranking a wider candidate pool down to `limit`.
+            default_ranking_search_limit(limit)
         } else {
             limit
         };
@@ -253,6 +258,12 @@ fn compile_source_regex(source_regex: Option<&str>) -> Result<Option<Regex>, Orb
         .transpose()
 }
 
+fn default_ranking_search_limit(limit: usize) -> usize {
+    limit
+        .saturating_mul(DEFAULT_RANKING_HEADROOM)
+        .min(DEFAULT_RANKING_HARD_CAP)
+}
+
 fn rank_default_search_results<'a>(
     nodes: Vec<GraphNodeRef<'a>>,
     include_non_code: bool,
@@ -313,4 +324,123 @@ fn is_non_code_path(path: &str) -> bool {
         extension.as_str(),
         "md" | "txt" | "rst" | "adoc" | "yaml" | "yml" | "toml" | "json" | "jsonc" | "csv" | "tsv"
     ) || lower.starts_with("docs/")
+}
+
+#[cfg(test)]
+mod tests {
+    use orbit_knowledge::graph::nodes::{
+        BaseNodeFields, CodebaseGraphV1, DirNode, FileNode, LeafKind, LeafNode,
+    };
+
+    use super::*;
+
+    #[test]
+    fn default_ranking_search_uses_finite_capped_bound_for_large_graph() {
+        const REQUESTED_LIMIT: usize = 10;
+        const FIXTURE_LEAF_COUNT: usize = 1_000;
+
+        let graph = graph_with_matching_leaves(FIXTURE_LEAF_COUNT);
+        let service = GraphContextService::new(&graph);
+        let search_limit = default_ranking_search_limit(REQUESTED_LIMIT);
+
+        assert!(search_limit <= DEFAULT_RANKING_HARD_CAP);
+        assert_eq!(search_limit, REQUESTED_LIMIT * DEFAULT_RANKING_HEADROOM);
+
+        let (_total, hits) =
+            service.search_hits_with_total("fixture", None, None, None, None, search_limit);
+
+        assert_eq!(hits.len(), search_limit);
+    }
+
+    #[test]
+    fn default_ranking_search_limit_saturates_at_hard_cap() {
+        let over_cap_limit = DEFAULT_RANKING_HARD_CAP / DEFAULT_RANKING_HEADROOM + 1;
+
+        assert_eq!(
+            default_ranking_search_limit(over_cap_limit),
+            DEFAULT_RANKING_HARD_CAP
+        );
+    }
+
+    fn graph_with_matching_leaves(leaf_count: usize) -> CodebaseGraphV1 {
+        let root_id = "dir:.".to_string();
+        let file_id = "file:src/fixture.rs".to_string();
+        let mut leaf_ids = Vec::with_capacity(leaf_count);
+        let mut leaves = Vec::with_capacity(leaf_count);
+
+        for index in 0..leaf_count {
+            let name = format!("fixture_{index}");
+            let leaf_id = format!("symbol:src/fixture.rs#{name}:function");
+            leaf_ids.push(leaf_id.clone());
+            leaves.push(LeafNode {
+                base: base_node(
+                    &leaf_id,
+                    &name,
+                    &format!("src/fixture.rs#{name}"),
+                    "rust",
+                    Some(&file_id),
+                ),
+                kind: LeafKind::Function,
+                source: String::new(),
+                source_blob_hash: None,
+                source_hash: None,
+                file_hash_at_capture: None,
+                history: Vec::new(),
+                input_signature: Vec::new(),
+                output_signature: Vec::new(),
+                start_line: Some((index + 1) as u32),
+                end_line: Some((index + 1) as u32),
+                children: Vec::new(),
+            });
+        }
+
+        CodebaseGraphV1 {
+            root_dir_id: root_id.clone(),
+            dirs: vec![DirNode {
+                base: base_node(&root_id, ".", ".", "", None),
+                dir_children: Vec::new(),
+                file_children: vec![file_id.clone()],
+            }],
+            files: vec![FileNode {
+                base: base_node(
+                    &file_id,
+                    "fixture.rs",
+                    "src/fixture.rs",
+                    "rust",
+                    Some(&root_id),
+                ),
+                extension: Some("rs".to_string()),
+                source_blob_hash: None,
+                source: String::new(),
+                imports: Vec::new(),
+                exports: Vec::new(),
+                re_exports: Vec::new(),
+                leaf_children: leaf_ids,
+            }],
+            leaves,
+        }
+    }
+
+    fn base_node(
+        id: &str,
+        name: &str,
+        location: &str,
+        language: &str,
+        parent_id: Option<&str>,
+    ) -> BaseNodeFields {
+        BaseNodeFields {
+            id: id.to_string(),
+            identity_key: id.to_string(),
+            object_hash: None,
+            name: name.to_string(),
+            location: location.to_string(),
+            language: language.to_string(),
+            description: String::new(),
+            parent_id: parent_id.map(str::to_string),
+            is_locked: false,
+            lineage_locked: false,
+            lock_owner: None,
+            lock_reason: String::new(),
+        }
+    }
 }

--- a/docs/design/knowledge-graph/2_design.md
+++ b/docs/design/knowledge-graph/2_design.md
@@ -136,6 +136,8 @@ All services are read-only against a resolved snapshot. Graph mutation code rema
 
 Search no longer accepts a `task_id` filter. Task-to-commit lookup is handled by `git log --grep '[T...]'`; the graph remains focused on code structure and source queries.
 
+Default `orbit.graph.search` ranking keeps a bounded candidate pool before ranking rather than retaining every matching node. The cap gives ranking enough headroom over the requested `limit` while preventing broad searches from allocating unbounded hit sets on large graphs ([T20260509-67]).
+
 ### 3.3 Object/blob read cache
 
 `KnowledgeStore` owns a bounded `GraphObjectCache` for selector-oriented reads ([T20260426-0141]). The cache keeps two LRU sets: graph node objects keyed by object hash and source blobs keyed by blob hash. Default capacities are 10,000 objects and 2,000 blobs, enforced by the `lru` crate.

--- a/docs/design/knowledge-graph/4_decisions.md
+++ b/docs/design/knowledge-graph/4_decisions.md
@@ -491,6 +491,23 @@ These entries were formerly ADR headings, but they are plain instances of ADR-00
 
 ---
 
+## ADR-033 — Default search ranking uses a bounded candidate pool
+
+**Status:** Accepted · 2026-05 · [T20260509-67]
+**Author:** gpt-5.5
+
+**Context.** `orbit.graph.search` default ranking previously asked the service for `usize::MAX` hits so ranking could choose the best `limit` results from the full match set. On large graphs this let a small user-facing limit retain an effectively unbounded candidate list before ranking.
+
+**Decision.** Replace the unbounded request with a named headroom multiplier and hard cap. Default ranking collects more candidates than the requested `limit`, ranks that bounded pool, and returns the top `limit`; filtered and source-regex searches keep their explicit limit behavior.
+
+**Consequences.**
+- Broad default searches retain a bounded candidate set before ranking.
+- Queries whose strongest matches fit inside the capped candidate pool keep the same ranking and output order.
+- The tool description now states the cap so callers know very broad default searches can rank only the retained candidate pool.
+- Cost: if the best-ranked match appears after the cap in service traversal order, it is no longer considered until a narrower query, type/kind filter, or prefix is supplied.
+
+---
+
 ## Task References
 
 Tasks cited by ADRs above:
@@ -538,5 +555,6 @@ Tasks cited by ADRs above:
 - **[T20260509-33]** — Skip symlinked directory entries during scanner traversal and `.orbitignore` discovery.
 - **[T20260509-34]** — Use exact git checkout identity instead of commit timestamps for clean graph freshness.
 - **[T20260509-65]** — Add `GraphReadOptions` so broad graph reads skip file/leaf source hydration unless a tool opts in.
+- **[T20260509-67]** — Bound default-ranking graph search candidate retention with named headroom and hard cap constants.
 
 Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.


### PR DESCRIPTION
## Task

[T20260509-67](https://orbit-cli.com/tasks/T20260509-67) — Bound search default-ranking scan with named cap

### Description

## Problem

[crates/orbit-tools/src/builtin/orbit/knowledge/search.rs:116-120](crates/orbit-tools/src/builtin/orbit/knowledge/search.rs:116) passes `usize::MAX` as the search bound to the service whenever default ranking is enabled:

```rust
let search_limit = if use_default_ranking { usize::MAX } else { limit };
```

The service scan in [crates/orbit-knowledge/src/service/search.rs:65-122](crates/orbit-knowledge/src/service/search.rs:65) then walks every dir/file/leaf in the graph before any ranking happens. The user-facing `limit` only trims the post-ranked result, so a request for 10 hits still pays full-graph scan cost on large corpora. The user-facing limit is not a work bound today.

## Why It Matters

Phase 2 of the graph-latency proposal ([raw/wiki/graph/perf_proposal_claude.md](raw/wiki/graph/perf_proposal_claude.md)). The smallest possible change that turns a runaway scan into a bounded one. Independent of Phase 1 (lazy hydration); they compose multiplicatively on tail latency.

## Implementation Notes

- Replace the `usize::MAX` branch with a bounded cap. Suggested shape:

  ```rust
  const DEFAULT_RANKING_HEADROOM: usize = 10;
  const DEFAULT_RANKING_HARD_CAP: usize = 5000;
  let search_limit = if use_default_ranking {
      limit.saturating_mul(DEFAULT_RANKING_HEADROOM).min(DEFAULT_RANKING_HARD_CAP)
  } else {
      limit
  };
  ```

  Names and constants are illustrative; pick what reads cleanest. The intent: enough headroom that default ranking still has a strong candidate pool, capped at a hard ceiling that bounds worst-case work.
- A one-line `// ` comment explaining *why* (cap exists to bound work; ranking still picks top `limit` of the kept set) is justified here.
- Verify: for queries that fit within the cap, output ordering and ranking must be unchanged. For queries that exceed the cap, document the truncation behavior in the tool description if not already stated.

## Constraints / Notes

- Independent of T20260509-65 (Phase 1) and T20260509-66 (Phase 1 measurement) for code-level concerns. Sequenced after T20260509-66 so the v3 measurement isolates Phase 2 effects from Phase 1 effects.
- No schema change. No tool API change. Pure internal bound.
- Authoring model: claude-opus-4-7. Author: claude.

### Acceptance Criteria

- `usize::MAX` no longer appears as the default-ranking branch in [crates/orbit-tools/src/builtin/orbit/knowledge/search.rs](crates/orbit-tools/src/builtin/orbit/knowledge/search.rs); replaced by a bounded expression using named constants.
- The cap constants are named (not magic numbers in the expression) and live near the search tool entry point or in a clearly-named module constant.
- A new unit test invokes search with `limit = 10` against a fixture graph of ≥ 1000 nodes and asserts the bound passed into the service is finite and ≤ the documented hard cap. Verifiable by exposing the computed `search_limit` to the test or asserting via a logging hook.
- Existing search integration tests pass without changes to expected output for queries that fit within the cap. Verifiable by `cargo test -p orbit-tools` and `cargo test -p orbit-knowledge`.
- `make build` and `make fmt` pass with no new warnings.
- `cargo test --workspace` passes.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Replaced the default-ranking `usize::MAX` branch with named headroom and hard-cap constants, plus a helper that computes the bounded candidate-retention limit.
- Added unit coverage with a 1,000-leaf fixture graph and `limit = 10` to verify the service receives a finite capped bound.
- Documented default-ranking candidate truncation in the graph search tool description and knowledge-graph design docs/ADR log.

Assessment: Focused internal change; filtered/source-regex search paths keep their existing limit behavior. Validation passed: `make fmt`, `cargo test -p orbit-tools`, `cargo test -p orbit-knowledge`, `make build`, and a rerun of `cargo test --workspace` (the first workspace run hit an unrelated flaky review-scoreboard assertion that passed standalone and on rerun).

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/T20260509-67-69ff9e14`
- Behind base: 0
- Ahead of base: 1

*authored by: claude-opus-4-7*