### PR TITLE
Replace overview.top_files Vec-then-sort with bounded heap

### DIFF
--- a/crates/orbit-knowledge/src/service/overview.rs
+++ b/crates/orbit-knowledge/src/service/overview.rs
@@ -1,5 +1,5 @@
-use std::cmp::Ordering;
-use std::collections::{BTreeMap, HashMap};
+use std::cmp::{Ordering, Reverse};
+use std::collections::{BTreeMap, BinaryHeap, HashMap};
 
 use crate::graph::navigator::GraphNodeRef;
 
@@ -87,13 +87,52 @@ impl<'a> GraphContextService<'a> {
 impl GraphOverview {
     /// Select the most symbol-dense files with deterministic tie-breaking.
     pub fn top_files(&self, limit: usize) -> Vec<TopFileEntry> {
-        let mut files: Vec<&FileOverview> = self.files.iter().collect();
+        if limit == 0 {
+            return Vec::new();
+        }
+
+        let heap_capacity = limit.min(self.files.len()).saturating_add(1);
+        let mut heap: BinaryHeap<Reverse<FileOverviewRank<'_>>> =
+            BinaryHeap::with_capacity(heap_capacity);
+        for file in &self.files {
+            heap.push(Reverse(FileOverviewRank(file)));
+            if heap.len() > limit {
+                heap.pop();
+            }
+        }
+
+        let mut files: Vec<&FileOverview> = heap
+            .into_iter()
+            .map(|Reverse(FileOverviewRank(file))| file)
+            .collect();
         files.sort_by(|left, right| compare_file_overview_rank(left, right));
         files
             .into_iter()
-            .take(limit)
             .map(FileOverview::top_file_entry)
             .collect()
+    }
+}
+
+#[derive(Clone, Copy)]
+struct FileOverviewRank<'a>(&'a FileOverview);
+
+impl PartialEq for FileOverviewRank<'_> {
+    fn eq(&self, other: &Self) -> bool {
+        compare_file_overview_rank(self.0, other.0) == Ordering::Equal
+    }
+}
+
+impl Eq for FileOverviewRank<'_> {}
+
+impl PartialOrd for FileOverviewRank<'_> {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for FileOverviewRank<'_> {
+    fn cmp(&self, other: &Self) -> Ordering {
+        compare_file_overview_rank(self.0, other.0).reverse()
     }
 }
 
@@ -152,4 +191,147 @@ fn top_level_dir_key(path: &str, location_prefix: Option<&str>) -> String {
         .filter(|segment| !segment.is_empty())
         .unwrap_or(".")
         .to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::graph::nodes::{
+        BaseNodeFields, CodebaseGraphV1, DirNode, FileNode, LeafKind, LeafNode,
+    };
+
+    use super::*;
+
+    #[test]
+    fn top_files_matches_full_sort_for_large_fixture() {
+        let graph = large_overview_graph();
+        assert!(graph.files.len() >= 1000);
+
+        let service = GraphContextService::new(&graph);
+        let overview = service.overview(None);
+        let expected = full_sort_top_files(&overview, 10);
+
+        assert_eq!(overview.top_files(10), expected);
+        assert_eq!(expected[0].selector, "file:src/top_tie_a.rs");
+        assert_eq!(expected[1].selector, "file:src/top_tie_b.rs");
+        assert_eq!(expected[0].symbol_count, expected[1].symbol_count);
+    }
+
+    fn full_sort_top_files(overview: &GraphOverview, limit: usize) -> Vec<TopFileEntry> {
+        let mut files: Vec<&FileOverview> = overview.files.iter().collect();
+        files.sort_by(|left, right| {
+            right
+                .symbol_count
+                .cmp(&left.symbol_count)
+                .then_with(|| left.path.cmp(&right.path))
+                .then_with(|| left.selector.cmp(&right.selector))
+                .then_with(|| left.name.cmp(&right.name))
+        });
+        files
+            .into_iter()
+            .take(limit)
+            .map(FileOverview::top_file_entry)
+            .collect()
+    }
+
+    fn large_overview_graph() -> CodebaseGraphV1 {
+        let root_id = "dir:.".to_string();
+        let mut fixture = vec![
+            ("src/top_tie_a.rs".to_string(), 200),
+            ("src/top_tie_b.rs".to_string(), 200),
+            ("src/top_001.rs".to_string(), 199),
+            ("src/top_002.rs".to_string(), 198),
+            ("src/top_003.rs".to_string(), 197),
+            ("src/top_004.rs".to_string(), 196),
+            ("src/top_005.rs".to_string(), 195),
+            ("src/top_006.rs".to_string(), 194),
+            ("src/top_007.rs".to_string(), 193),
+            ("src/top_008.rs".to_string(), 192),
+        ];
+        for index in 0..1000 {
+            fixture.push((format!("src/bulk_{index:04}.rs"), index % 50));
+        }
+
+        let mut file_children = Vec::with_capacity(fixture.len());
+        let mut files = Vec::with_capacity(fixture.len());
+        let mut leaves = Vec::new();
+
+        for (file_index, (path, symbol_count)) in fixture.into_iter().enumerate() {
+            let file_id = format!("file:{path}");
+            let file_name = path.rsplit('/').next().unwrap_or(path.as_str()).to_string();
+            let mut leaf_children = Vec::with_capacity(symbol_count);
+
+            for symbol_index in 0..symbol_count {
+                let symbol_name = format!("symbol_{file_index}_{symbol_index}");
+                let leaf_location = format!("{path}#{symbol_name}");
+                let leaf_id = format!("symbol:{leaf_location}:function");
+                leaf_children.push(leaf_id.clone());
+                leaves.push(LeafNode {
+                    base: base_node(
+                        &leaf_id,
+                        &symbol_name,
+                        &leaf_location,
+                        "rust",
+                        Some(&file_id),
+                    ),
+                    kind: LeafKind::Function,
+                    source: String::new(),
+                    source_blob_hash: None,
+                    source_hash: None,
+                    file_hash_at_capture: None,
+                    history: Vec::new(),
+                    input_signature: Vec::new(),
+                    output_signature: Vec::new(),
+                    start_line: None,
+                    end_line: None,
+                    children: Vec::new(),
+                });
+            }
+
+            file_children.push(file_id.clone());
+            files.push(FileNode {
+                base: base_node(&file_id, &file_name, &path, "rust", Some(&root_id)),
+                extension: Some("rs".to_string()),
+                source_blob_hash: None,
+                source: String::new(),
+                imports: Vec::new(),
+                exports: Vec::new(),
+                re_exports: Vec::new(),
+                leaf_children,
+            });
+        }
+
+        CodebaseGraphV1 {
+            root_dir_id: root_id.clone(),
+            dirs: vec![DirNode {
+                base: base_node(&root_id, ".", ".", "", None),
+                dir_children: Vec::new(),
+                file_children,
+            }],
+            files,
+            leaves,
+        }
+    }
+
+    fn base_node(
+        id: &str,
+        name: &str,
+        location: &str,
+        language: &str,
+        parent_id: Option<&str>,
+    ) -> BaseNodeFields {
+        BaseNodeFields {
+            id: id.to_string(),
+            identity_key: id.to_string(),
+            object_hash: None,
+            name: name.to_string(),
+            location: location.to_string(),
+            language: language.to_string(),
+            description: String::new(),
+            parent_id: parent_id.map(str::to_string),
+            is_locked: false,
+            lineage_locked: false,
+            lock_owner: None,
+            lock_reason: String::new(),
+        }
+    }
 }


### PR DESCRIPTION
## Task

[T20260509-68](https://orbit-cli.com/tasks/T20260509-68) — Replace overview.top_files Vec-then-sort with bounded heap

### Description

## Problem

[crates/orbit-knowledge/src/service/overview.rs:89-97](crates/orbit-knowledge/src/service/overview.rs:89) implements `top_files` as collect-into-Vec → sort-all → take(limit):

```rust
let mut files: Vec<_> = ...;
files.sort_by(...);
files.into_iter().take(limit).collect()
```

This is `O(N log N)` work for a top-K problem solvable in `O(N log K)`. On a 100k-file scope with `limit = 10`, the wasted work is the dominant `overview` cost in summary mode after Phase 1 lands.

## Why It Matters

Phase 2 of the graph-latency proposal ([raw/wiki/graph/perf_proposal_claude.md](raw/wiki/graph/perf_proposal_claude.md)). Textbook top-K refactor — small, surgical, semantically identical output, measurable win on tail latency. Combines with T20260509-65 (Phase 1 lazy hydration) to make `overview` summary fast end-to-end.

## Implementation Notes

- Use `std::collections::BinaryHeap` of bounded size `limit`. Standard pattern: push, then `if heap.len() > limit { heap.pop(); }`.
- Direction: `BinaryHeap` is a max-heap by default. For top-N largest by symbol_count, you want a min-heap of size `limit` so the smallest-of-top-K can be popped when a new entry beats it. Use `std::cmp::Reverse` or implement `Ord` accordingly.
- Output must be sorted descending by symbol_count after the heap pass. Tie-break order must match the current implementation — verify by reading the existing `sort_by` closure and replicating tie-breakers in the heap''s `Ord` impl.
- Iterator chain version is acceptable: `iter.fold(BinaryHeap::new(), ...)` then `into_sorted_vec()`.

## Constraints / Notes

- Output must be observably identical to current implementation (same order, same tie-breaking).
- Sequenced after T20260509-66 (Phase 1 measurement) so v3 measurement isolates Phase 2 effects.
- No API change. No schema change.
- Authoring model: claude-opus-4-7. Author: claude.

### Acceptance Criteria

- `top_files` in [crates/orbit-knowledge/src/service/overview.rs](crates/orbit-knowledge/src/service/overview.rs) no longer materializes all files into a `Vec` before sorting; uses `BinaryHeap` (or equivalent priority queue) of bounded size matching `limit`.
- A new unit test builds an `OverviewService` with at least 1000 fixture files and asserts that `top_files(10)` returns the same 10 files in the same order as the prior implementation. Implement by snapshotting current output before the change OR by deriving expected output independently from the fixture.
- Tie-breaking is preserved: a fixture with two files at the same symbol_count and known names produces identical ordering before and after.
- Existing overview integration tests pass without expected-output changes.
- `make build` and `make fmt` pass with no new warnings.
- `cargo test --workspace` passes.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Replaced GraphOverview::top_files collect/sort-all path with a bounded BinaryHeap that keeps only limit candidates while preserving the existing rank comparator.
- Added a large GraphContextService overview fixture test with 1,010 files, including equal-symbol-count tie files, comparing top_files(10) to a full-sort expected result.

Assessment: Implementation is scoped to crates/orbit-knowledge/src/service/overview.rs with no API or schema changes. Validated with make fmt, make build, and cargo test --workspace.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/T20260509-68-69ff9e50`
- Behind base: 0
- Ahead of base: 1

*authored by: claude-opus-4-7*