### PR TITLE
Tighten orbit-create-task context_files guidance

### DIFF
--- a/crates/orbit-core/assets/skills/orbit-create-task/SKILL.md
+++ b/crates/orbit-core/assets/skills/orbit-create-task/SKILL.md
@@ -31,6 +31,9 @@ See the `orbit` skill for the full mapping rule and surface coverage. Examples b
 
 - Prefer canonical task context selectors in `context_files`: `file:path`, `dir:path`, and `symbol:path#name:kind`.
 - Raw legacy paths are still accepted, but Orbit silently upgrades them to canonical selector form on write.
+- Add `context_files` entries only for existing files, directories, or symbols expected to be modified or deleted by the task.
+- Do not add entries solely for files that will be created later, or for files that are only relevant background context.
+- Prefer `file:` selectors over `dir:` selectors whenever the expected changes can be named at file level; use `dir:` only when the directory itself is the smallest honest scope.
 - When a task needs precise code context, prefer `symbol:` selectors over whole-file scopes.
 
 ## Operating Rules


### PR DESCRIPTION
## Task

[T20260509-75](https://orbit-cli.com/tasks/T20260509-75) — Tighten orbit-create-task context_files guidance

### Description

## Problem
The seeded `orbit-create-task` skill instructions in `crates/orbit-core/assets/skills/orbit-create-task/SKILL.md` describe canonical selectors for `context_files`, but they do not clearly constrain when entries should be added. Agents can over-populate task context with broad directories, new files, or merely relevant files, which makes task context less accurate over time.

## Why It Matters
`context_files` should be an accurate, precise handoff for later planning and execution. For this skill, context should represent existing files or directories expected to be modified or deleted, not newly created files or loosely related references. File-level selectors should be preferred over directory-level selectors whenever feasible.

## Constraints / Notes
- Update the seeded skill under `crates/orbit-core/assets/skills`, specifically `orbit-create-task`.
- The instruction should say not to add `context_files` entries solely for new files that do not exist yet or for files that are only relevant background.
- Preserve canonical selector guidance (`file:`, `dir:`, `symbol:`) while adding the modified/deleted-only rule.
- Keep the wording concise and agent-actionable.

### Acceptance Criteria

- Inspection of `crates/orbit-core/assets/skills/orbit-create-task/SKILL.md` shows `context_files` guidance that limits entries to existing files or directories expected to be modified or deleted by the task.
- Inspection of the same file shows guidance that newly created files and merely relevant/background files should not be listed in `context_files` solely for context.
- Inspection of the same file shows precision guidance that prefers file-level selectors over directory-level selectors when possible, while retaining canonical selector forms such as `file:`, `dir:`, and `symbol:`.
- Running `make fmt` succeeds after the instruction update.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Tightened the seeded orbit-create-task context_files guidance so entries are limited to existing files, directories, or symbols expected to be modified or deleted.
- Added explicit exclusions for future-created files and background-only references, while preserving canonical selector forms and preferring file-level selectors over directory-level scopes.

Assessment: The change is concise, scoped to the requested skill text, and make fmt succeeds.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/T20260509-75-69ffaac9`
- Behind base: 0
- Ahead of base: 1

*authored by: gpt-5*