### PR TITLE
Build SQLite secondary index during graph write

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1695,6 +1695,7 @@ dependencies = [
  "orbit-common",
  "rayon",
  "regex",
+ "rusqlite",
  "serde",
  "serde_json",
  "serde_yaml",

--- a/crates/orbit-knowledge/Cargo.toml
+++ b/crates/orbit-knowledge/Cargo.toml
@@ -11,6 +11,7 @@ ignore = "0.4.25"
 libc.workspace = true
 orbit-common = { path = "../orbit-common" }
 regex.workspace = true
+rusqlite.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 serde_yaml.workspace = true

--- a/crates/orbit-knowledge/src/graph/mod.rs
+++ b/crates/orbit-knowledge/src/graph/mod.rs
@@ -3,6 +3,7 @@
 pub mod navigator;
 pub mod nodes;
 pub mod object_store;
+mod sqlite_index;
 
 pub use navigator::{GraphNavigator, GraphNodeRef};
 pub use nodes::{

--- a/crates/orbit-knowledge/src/graph/object_store.rs
+++ b/crates/orbit-knowledge/src/graph/object_store.rs
@@ -17,6 +17,7 @@ use sha2::{Digest, Sha256};
 use tracing::{info, warn};
 
 use super::nodes::{CodebaseGraphV1, DirNode, FileNode, LeafNode};
+use super::sqlite_index::{GRAPH_SQLITE_INDEX_FILENAME, write_graph_index};
 use crate::error::KnowledgeError;
 use crate::io::{write_text_atomic, write_text_atomic_durable};
 
@@ -258,6 +259,10 @@ impl GraphObjectStore {
 
     fn blobs_dir(&self) -> PathBuf {
         self.graph_dir.join("blobs")
+    }
+
+    pub fn graph_sqlite_index_path(&self) -> PathBuf {
+        self.graph_dir.join(GRAPH_SQLITE_INDEX_FILENAME)
     }
 
     fn object_path(&self, hash: &str) -> Result<PathBuf, KnowledgeError> {
@@ -715,6 +720,7 @@ impl GraphObjectStore {
             "nodes": index_nodes,
         });
         write_json_file(&self.index_path_for_hash(&root_graph_hash)?, &by_id_index)?;
+        write_graph_index(&self.graph_sqlite_index_path(), &root_graph_hash, graph)?;
 
         // The stored `index` path is knowledge-root-relative. Readers rooted at
         // `knowledge_dir` can join it directly; readers rooted at `graph_dir`
@@ -970,43 +976,14 @@ mod tests {
     use crate::graph::nodes::{
         BaseNodeFields, CodebaseGraphV1, DirNode, FileNode, LeafKind, LeafNode,
     };
+    use rusqlite::Connection;
+    use std::collections::BTreeMap;
 
     #[test]
     fn graph_read_options_gate_blob_source_hydration() {
         let temp_dir = tempfile::tempdir().expect("temp dir");
         let store = GraphObjectStore::new(temp_dir.path());
-        let graph = CodebaseGraphV1 {
-            root_dir_id: "dir-root".to_string(),
-            dirs: vec![DirNode {
-                base: base_node("dir-root", ".", "./", None),
-                dir_children: Vec::new(),
-                file_children: vec!["file-lib".to_string()],
-            }],
-            files: vec![FileNode {
-                base: base_node("file-lib", "lib.rs", "src/lib.rs", Some("dir-root")),
-                extension: Some("rs".to_string()),
-                source_blob_hash: None,
-                source: "pub fn greet() { helper(); }\n".to_string(),
-                imports: Vec::new(),
-                exports: vec!["greet".to_string()],
-                re_exports: Vec::new(),
-                leaf_children: vec!["leaf-greet".to_string()],
-            }],
-            leaves: vec![LeafNode {
-                base: base_node("leaf-greet", "greet", "src/lib.rs#greet", Some("file-lib")),
-                kind: LeafKind::Function,
-                source: "pub fn greet() { helper(); }\n".to_string(),
-                source_blob_hash: None,
-                source_hash: Some("source-hash".to_string()),
-                file_hash_at_capture: Some("file-hash".to_string()),
-                history: Vec::new(),
-                input_signature: Vec::new(),
-                output_signature: Vec::new(),
-                start_line: Some(1),
-                end_line: Some(1),
-                children: Vec::new(),
-            }],
-        };
+        let graph = fixture_graph();
         let current_ref = store.write_graph(&graph).expect("write graph");
         let ref_name = RefName::new("main").expect("valid ref");
         store
@@ -1039,6 +1016,214 @@ mod tests {
             .expect("read graph with hydration");
         assert_eq!(hydrated_graph.files[0].source, graph.files[0].source);
         assert_eq!(hydrated_graph.leaves[0].source, graph.leaves[0].source);
+    }
+
+    #[test]
+    fn write_graph_creates_sqlite_index_schema_and_rows() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let store = GraphObjectStore::new(temp_dir.path());
+        let graph = fixture_graph();
+
+        let current_ref = store.write_graph(&graph).expect("write graph");
+        let index_path = store.graph_sqlite_index_path();
+        assert!(index_path.is_file());
+
+        let conn = Connection::open(&index_path).expect("open sqlite index");
+        let tables = sqlite_master_names(&conn, "table");
+        assert_eq!(tables, vec!["file_summary", "meta", "node"]);
+        let indexes = sqlite_master_names(&conn, "index");
+        assert!(indexes.contains(&"idx_file_symbol_count".to_string()));
+        assert!(indexes.contains(&"idx_node_location_lower".to_string()));
+        assert!(indexes.contains(&"idx_node_name_lower".to_string()));
+        assert!(indexes.contains(&"idx_node_parent".to_string()));
+        assert!(indexes.contains(&"idx_node_selector".to_string()));
+
+        let meta = sqlite_meta(&conn);
+        assert_eq!(meta.get("schema_version").map(String::as_str), Some("1"));
+        assert_eq!(
+            meta.get("graph_ref").map(String::as_str),
+            Some(current_ref.root_graph_hash.as_str())
+        );
+
+        let expected_node_count = graph.dirs.len() + graph.files.len() + graph.leaves.len();
+        let node_count: i64 = conn
+            .query_row("SELECT COUNT(*) FROM node", [], |row| row.get(0))
+            .expect("count nodes");
+        assert_eq!(node_count, expected_node_count as i64);
+
+        let selector_count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM node WHERE selector IS NOT NULL",
+                [],
+                |row| row.get(0),
+            )
+            .expect("count selectors");
+        assert_eq!(selector_count, expected_node_count as i64);
+
+        let (name_lower, location_lower, selector): (String, String, String) = conn
+            .query_row(
+                "SELECT name_lower, location_lower, selector FROM node WHERE id = 'leaf-greet'",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+            )
+            .expect("leaf row");
+        assert_eq!(name_lower, "greet");
+        assert_eq!(location_lower, "src/lib.rs#greet");
+        assert_eq!(selector, "symbol:src/Lib.rs#Greet:function");
+
+        let (symbol_count, path): (i64, String) = conn
+            .query_row(
+                "SELECT symbol_count, path FROM file_summary WHERE file_id = 'file-lib'",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .expect("file summary");
+        assert_eq!(symbol_count, 1);
+        assert_eq!(path, "src/Lib.rs");
+    }
+
+    #[test]
+    fn write_graph_rebuilds_sqlite_index_idempotently_for_same_ref() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let store = GraphObjectStore::new(temp_dir.path());
+        let graph = fixture_graph();
+
+        let first_ref = store.write_graph(&graph).expect("write graph first");
+        let first_conn = Connection::open(store.graph_sqlite_index_path()).expect("open first");
+        let first_meta = sqlite_meta(&first_conn);
+        let first_node_count: i64 = first_conn
+            .query_row("SELECT COUNT(*) FROM node", [], |row| row.get(0))
+            .expect("first node count");
+        drop(first_conn);
+
+        let second_ref = store.write_graph(&graph).expect("write graph second");
+        let second_conn = Connection::open(store.graph_sqlite_index_path()).expect("open second");
+        let second_meta = sqlite_meta(&second_conn);
+        let second_node_count: i64 = second_conn
+            .query_row("SELECT COUNT(*) FROM node", [], |row| row.get(0))
+            .expect("second node count");
+
+        assert_eq!(first_ref.root_graph_hash, second_ref.root_graph_hash);
+        assert_eq!(first_meta, second_meta);
+        assert_eq!(first_node_count, second_node_count);
+    }
+
+    #[test]
+    fn write_graph_replaces_sqlite_index_for_different_ref() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let store = GraphObjectStore::new(temp_dir.path());
+
+        let first_ref = store
+            .write_graph(&fixture_graph())
+            .expect("write first graph");
+        let second_graph = replacement_graph();
+        let second_ref = store
+            .write_graph(&second_graph)
+            .expect("write second graph");
+        assert_ne!(first_ref.root_graph_hash, second_ref.root_graph_hash);
+
+        let conn = Connection::open(store.graph_sqlite_index_path()).expect("open sqlite index");
+        let meta = sqlite_meta(&conn);
+        assert_eq!(
+            meta.get("graph_ref").map(String::as_str),
+            Some(second_ref.root_graph_hash.as_str())
+        );
+
+        let node_count: i64 = conn
+            .query_row("SELECT COUNT(*) FROM node", [], |row| row.get(0))
+            .expect("node count");
+        assert_eq!(
+            node_count,
+            (second_graph.dirs.len() + second_graph.files.len() + second_graph.leaves.len()) as i64
+        );
+        let old_leaf_count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM node WHERE id = 'leaf-greet'",
+                [],
+                |row| row.get(0),
+            )
+            .expect("old leaf count");
+        assert_eq!(old_leaf_count, 0);
+    }
+
+    fn fixture_graph() -> CodebaseGraphV1 {
+        CodebaseGraphV1 {
+            root_dir_id: "dir-root".to_string(),
+            dirs: vec![DirNode {
+                base: base_node("dir-root", ".", "./", None),
+                dir_children: Vec::new(),
+                file_children: vec!["file-lib".to_string()],
+            }],
+            files: vec![FileNode {
+                base: base_node("file-lib", "Lib.rs", "src/Lib.rs", Some("dir-root")),
+                extension: Some("rs".to_string()),
+                source_blob_hash: None,
+                source: "pub fn greet() { helper(); }\n".to_string(),
+                imports: Vec::new(),
+                exports: vec!["greet".to_string()],
+                re_exports: Vec::new(),
+                leaf_children: vec!["leaf-greet".to_string()],
+            }],
+            leaves: vec![LeafNode {
+                base: base_node("leaf-greet", "Greet", "src/Lib.rs#Greet", Some("file-lib")),
+                kind: LeafKind::Function,
+                source: "pub fn greet() { helper(); }\n".to_string(),
+                source_blob_hash: None,
+                source_hash: Some("source-hash".to_string()),
+                file_hash_at_capture: Some("file-hash".to_string()),
+                history: Vec::new(),
+                input_signature: Vec::new(),
+                output_signature: Vec::new(),
+                start_line: Some(1),
+                end_line: Some(1),
+                children: Vec::new(),
+            }],
+        }
+    }
+
+    fn replacement_graph() -> CodebaseGraphV1 {
+        let mut graph = fixture_graph();
+        graph.files[0].leaf_children = vec!["leaf-helper".to_string()];
+        graph.leaves = vec![LeafNode {
+            base: base_node(
+                "leaf-helper",
+                "Helper",
+                "src/Lib.rs#Helper",
+                Some("file-lib"),
+            ),
+            kind: LeafKind::Struct,
+            source: "pub struct Helper;\n".to_string(),
+            source_blob_hash: None,
+            source_hash: Some("replacement-source-hash".to_string()),
+            file_hash_at_capture: Some("replacement-file-hash".to_string()),
+            history: Vec::new(),
+            input_signature: Vec::new(),
+            output_signature: Vec::new(),
+            start_line: Some(3),
+            end_line: Some(3),
+            children: Vec::new(),
+        }];
+        graph
+    }
+
+    fn sqlite_meta(conn: &Connection) -> BTreeMap<String, String> {
+        let mut stmt = conn
+            .prepare("SELECT key, value FROM meta ORDER BY key")
+            .expect("prepare meta query");
+        stmt.query_map([], |row| Ok((row.get(0)?, row.get(1)?)))
+            .expect("query meta")
+            .map(|row| row.expect("meta row"))
+            .collect()
+    }
+
+    fn sqlite_master_names(conn: &Connection, kind: &str) -> Vec<String> {
+        let mut stmt = conn
+            .prepare("SELECT name FROM sqlite_master WHERE type = ?1 ORDER BY name")
+            .expect("prepare sqlite_master query");
+        stmt.query_map([kind], |row| row.get(0))
+            .expect("query sqlite_master")
+            .map(|row| row.expect("sqlite_master row"))
+            .collect()
     }
 
     fn base_node(id: &str, name: &str, location: &str, parent_id: Option<&str>) -> BaseNodeFields {

--- a/crates/orbit-knowledge/src/graph/sqlite_index.rs
+++ b/crates/orbit-knowledge/src/graph/sqlite_index.rs
@@ -1,0 +1,313 @@
+use std::collections::HashMap;
+use std::fs;
+use std::path::Path;
+
+use chrono::{SecondsFormat, Utc};
+use rusqlite::{Connection, TransactionBehavior, params};
+
+use super::nodes::{BaseNodeFields, CodebaseGraphV1, FileNode, LeafKind};
+use crate::error::KnowledgeError;
+
+pub(crate) const GRAPH_SQLITE_INDEX_SCHEMA_VERSION: u32 = 1;
+pub(crate) const GRAPH_SQLITE_INDEX_FILENAME: &str = "graph_index.sqlite";
+
+pub(crate) fn write_graph_index(
+    path: &Path,
+    graph_ref: &str,
+    graph: &CodebaseGraphV1,
+) -> Result<(), KnowledgeError> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).map_err(|error| {
+            KnowledgeError::knowledge_unavailable(format!(
+                "create graph sqlite index dir {}: {error}",
+                parent.display()
+            ))
+        })?;
+    }
+
+    let mut conn = open_connection(path)?;
+    enable_wal_mode(&conn)?;
+    conn.pragma_update(None, "busy_timeout", "5000")
+        .map_err(|error| sqlite_error(path, "set busy_timeout", error))?;
+
+    let created_at = previous_created_at_for_same_ref(&conn, graph_ref)?
+        .unwrap_or_else(|| Utc::now().to_rfc3339_opts(SecondsFormat::Secs, true));
+    let selector_counts = selector_counts(graph);
+
+    let tx = conn
+        .transaction_with_behavior(TransactionBehavior::Immediate)
+        .map_err(|error| sqlite_error(path, "begin graph sqlite index transaction", error))?;
+    tx.execute_batch(
+        r#"
+        DROP TABLE IF EXISTS meta;
+        DROP TABLE IF EXISTS node;
+        DROP TABLE IF EXISTS file_summary;
+
+        CREATE TABLE meta (
+          key TEXT PRIMARY KEY,
+          value TEXT NOT NULL
+        );
+
+        CREATE TABLE node (
+          id TEXT PRIMARY KEY,
+          node_type TEXT NOT NULL,
+          kind TEXT,
+          name TEXT NOT NULL,
+          name_lower TEXT NOT NULL,
+          location TEXT NOT NULL,
+          location_lower TEXT NOT NULL,
+          parent_id TEXT,
+          selector TEXT
+        );
+        CREATE INDEX idx_node_name_lower ON node(name_lower);
+        CREATE INDEX idx_node_location_lower ON node(location_lower);
+        CREATE INDEX idx_node_parent ON node(parent_id);
+        CREATE UNIQUE INDEX idx_node_selector ON node(selector) WHERE selector IS NOT NULL;
+
+        CREATE TABLE file_summary (
+          file_id TEXT PRIMARY KEY,
+          symbol_count INTEGER NOT NULL,
+          path TEXT NOT NULL
+        );
+        CREATE INDEX idx_file_symbol_count ON file_summary(symbol_count DESC);
+        "#,
+    )
+    .map_err(|error| sqlite_error(path, "initialize graph sqlite index schema", error))?;
+
+    tx.execute(
+        "INSERT INTO meta (key, value) VALUES (?1, ?2)",
+        params![
+            "schema_version",
+            GRAPH_SQLITE_INDEX_SCHEMA_VERSION.to_string()
+        ],
+    )
+    .map_err(|error| sqlite_error(path, "insert sqlite index schema_version", error))?;
+    tx.execute(
+        "INSERT INTO meta (key, value) VALUES (?1, ?2)",
+        params!["created_at", created_at],
+    )
+    .map_err(|error| sqlite_error(path, "insert sqlite index created_at", error))?;
+
+    {
+        let mut node_insert = tx
+            .prepare(
+                r#"
+                INSERT OR REPLACE INTO node (
+                  id, node_type, kind, name, name_lower, location, location_lower, parent_id, selector
+                ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)
+                "#,
+            )
+            .map_err(|error| sqlite_error(path, "prepare graph sqlite node insert", error))?;
+
+        for dir in &graph.dirs {
+            let selector = stable_selector(dir_selector(&dir.base), &selector_counts);
+            insert_node(
+                path,
+                &mut node_insert,
+                &dir.base,
+                "dir",
+                None,
+                selector.as_deref(),
+            )?;
+        }
+
+        for file in &graph.files {
+            let selector = stable_selector(file_selector(&file.base), &selector_counts);
+            insert_node(
+                path,
+                &mut node_insert,
+                &file.base,
+                "file",
+                None,
+                selector.as_deref(),
+            )?;
+        }
+
+        for leaf in &graph.leaves {
+            let kind = leaf.kind.to_string();
+            let selector = stable_selector(leaf_selector(&leaf.base, &leaf.kind), &selector_counts);
+            insert_node(
+                path,
+                &mut node_insert,
+                &leaf.base,
+                "leaf",
+                Some(kind.as_str()),
+                selector.as_deref(),
+            )?;
+        }
+    }
+
+    {
+        let mut file_summary_insert = tx
+            .prepare(
+                "INSERT OR REPLACE INTO file_summary (file_id, symbol_count, path) VALUES (?1, ?2, ?3)",
+            )
+            .map_err(|error| {
+                sqlite_error(path, "prepare graph sqlite file_summary insert", error)
+            })?;
+
+        for file in &graph.files {
+            insert_file_summary(path, &mut file_summary_insert, file)?;
+        }
+    }
+
+    tx.execute(
+        "INSERT INTO meta (key, value) VALUES (?1, ?2)",
+        params!["graph_ref", graph_ref],
+    )
+    .map_err(|error| sqlite_error(path, "insert sqlite index graph_ref", error))?;
+    tx.commit()
+        .map_err(|error| sqlite_error(path, "commit graph sqlite index", error))?;
+    Ok(())
+}
+
+fn open_connection(path: &Path) -> Result<Connection, KnowledgeError> {
+    match Connection::open(path) {
+        Ok(conn) => Ok(conn),
+        Err(first_error) => {
+            if path.exists() {
+                fs::remove_file(path).map_err(|remove_error| {
+                    KnowledgeError::knowledge_unavailable(format!(
+                        "open graph sqlite index {} failed ({first_error}); remove corrupt file failed: {remove_error}",
+                        path.display()
+                    ))
+                })?;
+                Connection::open(path)
+                    .map_err(|error| sqlite_error(path, "recreate graph sqlite index", error))
+            } else {
+                Err(sqlite_error(path, "open graph sqlite index", first_error))
+            }
+        }
+    }
+}
+
+fn enable_wal_mode(conn: &Connection) -> Result<(), KnowledgeError> {
+    let mode = conn
+        .pragma_update_and_check(None, "journal_mode", "WAL", |row| row.get::<_, String>(0))
+        .map_err(|error| {
+            KnowledgeError::knowledge_unavailable(format!(
+                "set graph sqlite index journal_mode=WAL: {error}"
+            ))
+        })?;
+    if !mode.eq_ignore_ascii_case("wal") {
+        return Err(KnowledgeError::knowledge_unavailable(format!(
+            "set graph sqlite index journal_mode=WAL returned `{mode}`"
+        )));
+    }
+    Ok(())
+}
+
+fn previous_created_at_for_same_ref(
+    conn: &Connection,
+    graph_ref: &str,
+) -> Result<Option<String>, KnowledgeError> {
+    let expected_schema = GRAPH_SQLITE_INDEX_SCHEMA_VERSION.to_string();
+    let schema_version = query_meta(conn, "schema_version")?;
+    let previous_graph_ref = query_meta(conn, "graph_ref")?;
+    if schema_version.as_deref() == Some(expected_schema.as_str())
+        && previous_graph_ref.as_deref() == Some(graph_ref)
+    {
+        return query_meta(conn, "created_at");
+    }
+    Ok(None)
+}
+
+fn query_meta(conn: &Connection, key: &str) -> Result<Option<String>, KnowledgeError> {
+    match conn.query_row(
+        "SELECT value FROM meta WHERE key = ?1",
+        params![key],
+        |row| row.get::<_, String>(0),
+    ) {
+        Ok(value) => Ok(Some(value)),
+        Err(rusqlite::Error::SqliteFailure(_, _)) => Ok(None),
+        Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
+        Err(error) => Err(KnowledgeError::knowledge_unavailable(format!(
+            "read graph sqlite index meta `{key}`: {error}"
+        ))),
+    }
+}
+
+fn insert_node(
+    path: &Path,
+    statement: &mut rusqlite::Statement<'_>,
+    base: &BaseNodeFields,
+    node_type: &str,
+    kind: Option<&str>,
+    selector: Option<&str>,
+) -> Result<(), KnowledgeError> {
+    statement
+        .execute(params![
+            base.id.as_str(),
+            node_type,
+            kind,
+            base.name.as_str(),
+            base.name.to_lowercase(),
+            base.location.as_str(),
+            base.location.to_lowercase(),
+            base.parent_id.as_deref(),
+            selector,
+        ])
+        .map_err(|error| sqlite_error(path, "insert graph sqlite node", error))?;
+    Ok(())
+}
+
+fn insert_file_summary(
+    path: &Path,
+    statement: &mut rusqlite::Statement<'_>,
+    file: &FileNode,
+) -> Result<(), KnowledgeError> {
+    let symbol_count = i64::try_from(file.leaf_children.len()).map_err(|_| {
+        KnowledgeError::invalid_data(format!(
+            "file `{}` has too many leaf children for sqlite index",
+            file.base.id
+        ))
+    })?;
+    statement
+        .execute(params![
+            file.base.id.as_str(),
+            symbol_count,
+            file.base.location.as_str()
+        ])
+        .map_err(|error| sqlite_error(path, "insert graph sqlite file_summary", error))?;
+    Ok(())
+}
+
+fn selector_counts(graph: &CodebaseGraphV1) -> HashMap<String, usize> {
+    let mut counts = HashMap::new();
+    for dir in &graph.dirs {
+        count_selector(&mut counts, dir_selector(&dir.base));
+    }
+    for file in &graph.files {
+        count_selector(&mut counts, file_selector(&file.base));
+    }
+    for leaf in &graph.leaves {
+        count_selector(&mut counts, leaf_selector(&leaf.base, &leaf.kind));
+    }
+    counts
+}
+
+fn count_selector(counts: &mut HashMap<String, usize>, selector: String) {
+    *counts.entry(selector).or_default() += 1;
+}
+
+fn stable_selector(selector: String, counts: &HashMap<String, usize>) -> Option<String> {
+    (counts.get(&selector) == Some(&1)).then_some(selector)
+}
+
+fn dir_selector(base: &BaseNodeFields) -> String {
+    let location = base.location.trim_end_matches('/');
+    let location = if location.is_empty() { "." } else { location };
+    format!("dir:{location}")
+}
+
+fn file_selector(base: &BaseNodeFields) -> String {
+    format!("file:{}", base.location)
+}
+
+fn leaf_selector(base: &BaseNodeFields, kind: &LeafKind) -> String {
+    format!("symbol:{}:{}", base.location, kind)
+}
+
+fn sqlite_error(path: &Path, action: &str, error: rusqlite::Error) -> KnowledgeError {
+    KnowledgeError::knowledge_unavailable(format!("{action} {}: {error}", path.display()))
+}

--- a/docs/design/knowledge-graph/2_design.md
+++ b/docs/design/knowledge-graph/2_design.md
@@ -19,11 +19,14 @@ This document specifies the current knowledge graph: storage, build pipeline, qu
 │   ├── objects/<hh>/<hash>.json   immutable node bodies (dir / file / leaf)
 │   ├── blobs/<hh>/<hash>.txt      immutable source blobs
 │   ├── index/by-id/<root-graph-hash>.json   immutable per-build index
+│   ├── graph_index.sqlite         mutable SQLite secondary index for future fast reads
 │   └── refs/heads/<branch>.json   mutable branch ref → active index
 └── working/<activity_id>/       (in memory today; see 3_vision.md §2.3)
 ```
 
 The split between immutable objects/blobs/index and mutable refs is deliberate. Rebuilds always write new immutable artifacts and then atomically rename a ref file; no object file is ever overwritten. This survives concurrent worktree rebuilds and interrupted writes ([T20260421-0358]).
+
+`graph/graph_index.sqlite` is a mutable secondary index written alongside the content-addressed graph ([T20260509-70]). Its `meta` table records `schema_version`, `created_at`, and the active `graph_ref` root hash; `node` contains one row per dir/file/leaf with lowercased name/location fields and stable selectors where unambiguous; `file_summary` stores one row per file with direct leaf-child count. Writes rebuild the SQLite schema/data in one WAL-backed transaction and insert `meta.graph_ref` last, so future readers can treat a missing or mismatched `graph_ref` as invalid. No read tool consumes this sidecar yet.
 
 The legacy `refs/current.json` layout is migrated to `refs/heads/<default-branch>.json` on open; see [specs/refs.md](./specs/refs.md).
 
@@ -45,7 +48,7 @@ scan → hash → detect_changes → build_dirs → build_files → build_leaves
 | `build_graph_dirs` | `DirNode` entries with parent/child wiring | Deterministic; root dir id derived from `.` |
 | `build_graph_files` | `FileNode` entries linked to parent dir | Language detected from extension |
 | `build_graph_leaves` | `LeafNode` entries via file-kind-dispatched extractor | Code via tree-sitter (C, C#, Rust, Python, Go, Java, JavaScript, Kotlin, TypeScript, TSX, Ruby); markdown sections, YAML/JSON/TOML top-level keys, and CSV/TSV header columns via shallow extractors added in [T20260422-1540]. TypeScript/TSX coverage was added in [T20260505-11]; C# coverage was added in [T20260505-13]; C `.c`/`.h` coverage was added in [T20260505-16]. Per-file read/extract work runs in parallel, then graph mutation is merged on the main thread in file order ([T20260426-0139]). Incremental builds reuse unchanged file/leaf snapshots from the same branch ref when hashes match ([T20260426-0140]) |
-| `persist_graph` | Content-addressed objects, blobs, index | Atomic via tempfile + rename |
+| `persist_graph` | Content-addressed objects, blobs, JSON index, SQLite secondary index | Atomic file writes for immutable JSON artifacts; SQLite sidecar rebuilt in one WAL transaction with `meta.graph_ref` written last ([T20260509-70]) |
 | `write_manifest` | `manifest.json` | Timestamp + clean checkout identity + graph summary |
 | `save_hash_cache` | `hashes.json` | Baseline for the next incremental `detect_changes` pass |
 
@@ -257,6 +260,10 @@ The read cache is per `KnowledgeStore`, not global ([T20260426-0141]). Long-runn
 
 The scanner skips symlinked directories rather than trying to canonicalize and follow only in-workspace targets ([T20260509-33]). This is the safer default for agent indexing because it avoids outside-repo leakage and cycles, but a workspace that intentionally exposes source through symlinked directories must materialize those files or wait for an explicit, cycle-safe opt-in traversal policy.
 
+### 6.13 SQLite secondary index is write-only
+
+The `graph/graph_index.sqlite` sidecar exists to make future selector, name, and file-symbol-count reads sublinear, but current graph services still hydrate through the JSON by-id index and object store ([T20260509-70]). Until a read facade verifies `meta.graph_ref` against the resolved branch ref, this sidecar is an independently testable write-path artifact rather than a query source.
+
 ---
 
 ## Task References
@@ -289,5 +296,6 @@ The scanner skips symlinked directories rather than trying to canonicalize and f
 - **[T20260506-11]** — Remove graph task attribution after 0/961 audited reverse-lookup uses; preserve task IDs as local commit-search keys.
 - **[T20260509-33]** — Skip symlinked directories/files during knowledge scans and `.orbitignore` discovery to prevent outside-repo indexing and recursive cycles.
 - **[T20260509-65]** — Add `GraphReadOptions` so broad graph reads skip file/leaf source hydration unless a tool opts in.
+- **[T20260509-70]** — Build the write-only SQLite secondary index sidecar during graph persistence.
 
 Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.

--- a/docs/design/knowledge-graph/4_decisions.md
+++ b/docs/design/knowledge-graph/4_decisions.md
@@ -508,6 +508,23 @@ These entries were formerly ADR headings, but they are plain instances of ADR-00
 
 ---
 
+## ADR-034 — SQLite sidecar for secondary graph indexes
+
+**Status:** Accepted · 2026-05 · [T20260509-70]
+**Author:** gpt-5.5
+
+**Context.** Selector resolution, name search, and file-symbol counts still walk the hydrated graph or JSON by-id index. A JSON sidecar would keep persistence simple but would not provide efficient prefix/range lookup, partial indexes, or concurrent read/write behavior.
+
+**Decision.** Write a mutable SQLite sidecar at `graph/graph_index.sqlite` during `GraphObjectStore::write_graph`. The sidecar is rebuilt in a WAL-backed transaction with `meta`, `node`, and `file_summary` tables; `meta.graph_ref` stores the root graph hash and is inserted last so readers can reject missing or mismatched indexes. Existing graph reads do not consume the sidecar until a separate read facade lands.
+
+**Consequences.**
+- Future read tasks can add SQL fast paths without changing the content-addressed object format.
+- Write-path validation can measure the index independently before read behavior depends on it.
+- Re-running the same graph preserves semantic meta/node contents, while a new root graph hash cleanly replaces prior rows.
+- Cost: graph persistence now pays an extra SQLite write per rebuild and `orbit-knowledge` directly depends on the workspace `rusqlite` dependency.
+
+---
+
 ## Task References
 
 Tasks cited by ADRs above:
@@ -556,5 +573,6 @@ Tasks cited by ADRs above:
 - **[T20260509-34]** — Use exact git checkout identity instead of commit timestamps for clean graph freshness.
 - **[T20260509-65]** — Add `GraphReadOptions` so broad graph reads skip file/leaf source hydration unless a tool opts in.
 - **[T20260509-67]** — Bound default-ranking graph search candidate retention with named headroom and hard cap constants.
+- **[T20260509-70]** — Build the write-only SQLite secondary index sidecar during graph persistence.
 
 Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.


### PR DESCRIPTION
## Task

[T20260509-70](https://orbit-cli.com/tasks/T20260509-70) — Build SQLite secondary index during graph write

### Description

## Problem

Graph reads scale with total node count today because all metadata lookups (selector resolve, name search, file-symbol counts) walk the full hydrated graph. There is no compact index optimized for read queries.

## Why It Matters

Phase 3 of the graph-latency proposal ([raw/wiki/graph/perf_proposal_claude.md](raw/wiki/graph/perf_proposal_claude.md)). Establishes the index sidecar that subsequent fast-path tasks read from. Phases 1 and 2 reduce per-node hydration cost and bound work; Phase 3 changes the asymptotic shape from O(total nodes) to O(index lookup + result size) for common reads.

This task lands the **write path only**. No reader consumes the index yet — that is intentional, so the change is safe to ship and measure independently.

## Implementation Notes

Format decision: SQLite, not JSON sidecars. Rationale lives in the proposal — Orbit already uses SQLite for the command audit store, range/prefix queries are first-class, and a single file beats small-file overhead.

Location: `.orbit/state/knowledge/<workspace>/graph_index.sqlite` (or wherever the existing graph object store roots). Versioned by graph ref hash; the easiest pattern is a `meta` table with `graph_ref` as a single row that readers verify.

Schema sketch (names illustrative, refine as needed):

```sql
CREATE TABLE meta (
  key TEXT PRIMARY KEY,
  value TEXT NOT NULL
);
-- meta rows: schema_version, graph_ref, created_at

CREATE TABLE node (
  id TEXT PRIMARY KEY,
  node_type TEXT NOT NULL,    -- dir | file | leaf
  kind TEXT,                  -- e.g. function, struct, section
  name TEXT NOT NULL,
  name_lower TEXT NOT NULL,
  location TEXT NOT NULL,
  location_lower TEXT NOT NULL,
  parent_id TEXT,
  selector TEXT
);
CREATE INDEX idx_node_name_lower ON node(name_lower);
CREATE INDEX idx_node_location_lower ON node(location_lower);
CREATE INDEX idx_node_parent ON node(parent_id);
CREATE UNIQUE INDEX idx_node_selector ON node(selector) WHERE selector IS NOT NULL;

CREATE TABLE file_summary (
  file_id TEXT PRIMARY KEY,
  symbol_count INTEGER NOT NULL,
  path TEXT NOT NULL
);
CREATE INDEX idx_file_symbol_count ON file_summary(symbol_count DESC);
```

Write path:

- Hook into `GraphObjectStore::write_graph` (or the equivalent graph-build persist step in [crates/orbit-knowledge/src/pipeline/persist.rs](crates/orbit-knowledge/src/pipeline/persist.rs)).
- Open the SQLite file in WAL mode. Truncate or migrate cleanly when `meta.schema_version` mismatches.
- Insert in a single transaction. Lowercase `name` and `location` once per node during the insert.
- Use prepared statements; batch inserts in chunks of e.g. 1000.
- After commit, write the `graph_ref` meta row last so a partial index never appears valid.

Idempotency: re-running `write_graph` for the same ref must produce the same index file. Re-running for a different ref must rewrite cleanly.

## Constraints / Notes

- Pure additive change. No reader uses the index yet — guarantees no behavior regression.
- Build-time cost target: less than 10% increase to graph build wall time on a fixture monorepo. If the increase exceeds 10%, document the cause in the execution summary and either accept it explicitly or block on optimization.
- WAL mode is important for the future read facade (Task: Add SQLite read facade) which will hold a read-only connection while writes may occur in another process.
- Existing dependencies: if `rusqlite` is not already a workspace dependency, evaluate whether it should be added at workspace level (it is already used by the audit store; check `Cargo.toml`).
- Authoring model: claude-opus-4-7. Author: claude.

### Acceptance Criteria

- After `write_graph` completes on a fixture corpus, a SQLite file exists at the documented index path with the schema described above (verifiable via a unit test that opens the file and queries `sqlite_master`).
- The `meta` table contains a `graph_ref` row matching the ref of the graph just written, and a `schema_version` row.
- The `node` table contains one row per dir, file, and leaf node in the graph; `name_lower` and `location_lower` are populated with lowercased values; `selector` is non-NULL where the node has a stable selector.
- The `file_summary` table contains one row per file node with the count of leaf children.
- Re-running `write_graph` for the same graph ref produces a byte-identical OR semantically equivalent index (test by calling write twice and asserting node-row count and meta values match).
- Re-running `write_graph` for a different graph ref overwrites the prior index cleanly; the `meta.graph_ref` reflects the new ref.
- Build-time benchmark: time `write_graph` against a fixture corpus before and after this change; the increase is less than 10% (record numbers in the execution summary).
- No graph read tool reads from the index yet — verifiable by `git grep` showing no read-side opens of the new file path outside this task scope.
- `make build` and `make fmt` pass with no new warnings.
- `cargo test --workspace` passes.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Added a write-only SQLite secondary index at graph/graph_index.sqlite, rebuilt from GraphObjectStore::write_graph in one WAL-backed transaction.
- Added meta, node, and file_summary schema population with lowercased lookup columns, stable selectors when unique, idempotent same-ref meta preservation, and clean replacement for new root graph hashes.
- Added focused SQLite index tests for schema, meta rows, node/file_summary contents, same-ref idempotency, and different-ref replacement.
- Updated knowledge-graph design docs and ADR-034 for the new sidecar and write-only status.

Assessment: The change is additive; existing graph readers still use the JSON by-id index/object store. Duplicate node IDs are handled with INSERT OR REPLACE to match the current by-id index semantics.

Validation:
- cargo test -p orbit-knowledge: pass
- make fmt: pass
- make build: pass
- cargo test --workspace: pass
- rg -n graph_index.sqlite|graph_sqlite_index_path|write_graph_index crates docs: only writer/tests/docs mention the sidecar; no read tool opens it.

Benchmark:
- Existing graph_build fixture before change: cold_build 4082ms, warm_incremental_noop 5958ms, files 831, leaves 7902.
- After change: cold_build 4142ms (+1.5%), warm_incremental_noop 6015ms (+1.0%), files 832, leaves 7922 due this new source file. Both are under the 10% target.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/T20260509-70-69ffa8ae`
- Behind base: 0
- Ahead of base: 1

*authored by: claude-opus-4-7*