### PR TITLE
Wire show by selector through SQLite index

### DIFF
--- a/crates/orbit-knowledge/src/graph/mod.rs
+++ b/crates/orbit-knowledge/src/graph/mod.rs
@@ -11,3 +11,4 @@ pub use nodes::{
     LeafNode, SignatureField,
 };
 pub use object_store::{GraphObjectStore, GraphReadOptions};
+pub use sqlite_index::{GraphIndexNodeRow, GraphIndexReader};

--- a/crates/orbit-knowledge/src/graph/object_store.rs
+++ b/crates/orbit-knowledge/src/graph/object_store.rs
@@ -16,7 +16,7 @@ use serde_json::Value;
 use sha2::{Digest, Sha256};
 use tracing::{info, warn};
 
-use super::nodes::{CodebaseGraphV1, DirNode, FileNode, LeafNode};
+use super::nodes::{CodebaseGraphV1, DirNode, FileNode, GraphNode, LeafNode};
 use super::sqlite_index::{GRAPH_SQLITE_INDEX_FILENAME, write_graph_index};
 use crate::error::KnowledgeError;
 use crate::io::{write_text_atomic, write_text_atomic_durable};
@@ -515,6 +515,68 @@ impl GraphObjectStore {
         })
     }
 
+    pub fn read_node_by_object_hash(
+        &self,
+        node_id: &str,
+        node_type: &str,
+        object_hash: &str,
+        options: GraphReadOptions,
+    ) -> Result<GraphNode, KnowledgeError> {
+        let envelope = self.read_object_envelope(object_hash)?;
+        let node = match node_type {
+            "dir" => {
+                let mut dir: DirNode = serde_json::from_value(envelope.node).map_err(|error| {
+                    KnowledgeError::invalid_data(format!("dir node parse: {error}"))
+                })?;
+                dir.base.object_hash = Some(object_hash.to_string());
+                GraphNode::Dir(dir)
+            }
+            "file" => {
+                let mut file: FileNode =
+                    serde_json::from_value(envelope.node).map_err(|error| {
+                        KnowledgeError::invalid_data(format!("file node parse: {error}"))
+                    })?;
+                file.base.object_hash = Some(object_hash.to_string());
+                if let Some(ref blob_hash) = file.source_blob_hash
+                    && file.source.is_empty()
+                    && options.hydrate_file_source
+                    && let Ok(source) = self.read_blob(blob_hash)
+                {
+                    file.source = source;
+                }
+                GraphNode::File(file)
+            }
+            "leaf" => {
+                let mut leaf: LeafNode =
+                    serde_json::from_value(envelope.node).map_err(|error| {
+                        KnowledgeError::invalid_data(format!("leaf node parse: {error}"))
+                    })?;
+                leaf.base.object_hash = Some(object_hash.to_string());
+                if let Some(ref blob_hash) = leaf.source_blob_hash
+                    && leaf.source.is_empty()
+                    && options.hydrate_leaf_source
+                {
+                    leaf.source = self.read_blob(blob_hash)?;
+                }
+                GraphNode::Leaf(leaf)
+            }
+            other => {
+                return Err(KnowledgeError::invalid_data(format!(
+                    "unsupported graph node type `{other}` for `{node_id}`"
+                )));
+            }
+        };
+
+        if node.id() != node_id {
+            return Err(KnowledgeError::invalid_data(format!(
+                "graph object `{object_hash}` contained node `{}` instead of `{node_id}`",
+                node.id()
+            )));
+        }
+
+        Ok(node)
+    }
+
     // -----------------------------------------------------------------------
     // Write path
     // -----------------------------------------------------------------------
@@ -720,7 +782,12 @@ impl GraphObjectStore {
             "nodes": index_nodes,
         });
         write_json_file(&self.index_path_for_hash(&root_graph_hash)?, &by_id_index)?;
-        write_graph_index(&self.graph_sqlite_index_path(), &root_graph_hash, graph)?;
+        write_graph_index(
+            &self.graph_sqlite_index_path(),
+            &root_graph_hash,
+            graph,
+            &object_hashes,
+        )?;
 
         // The stored `index` path is knowledge-root-relative. Readers rooted at
         // `knowledge_dir` can join it directly; readers rooted at `graph_dir`
@@ -1036,10 +1103,11 @@ mod tests {
         assert!(indexes.contains(&"idx_node_location_lower".to_string()));
         assert!(indexes.contains(&"idx_node_name_lower".to_string()));
         assert!(indexes.contains(&"idx_node_parent".to_string()));
+        assert!(indexes.contains(&"idx_node_parent_ordinal".to_string()));
         assert!(indexes.contains(&"idx_node_selector".to_string()));
 
         let meta = sqlite_meta(&conn);
-        assert_eq!(meta.get("schema_version").map(String::as_str), Some("1"));
+        assert_eq!(meta.get("schema_version").map(String::as_str), Some("2"));
         assert_eq!(
             meta.get("graph_ref").map(String::as_str),
             Some(current_ref.root_graph_hash.as_str())

--- a/crates/orbit-knowledge/src/graph/sqlite_index.rs
+++ b/crates/orbit-knowledge/src/graph/sqlite_index.rs
@@ -1,20 +1,166 @@
 use std::collections::HashMap;
 use std::fs;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use chrono::{SecondsFormat, Utc};
-use rusqlite::{Connection, TransactionBehavior, params};
+use rusqlite::{Connection, OpenFlags, OptionalExtension, Row, TransactionBehavior, params};
 
 use super::nodes::{BaseNodeFields, CodebaseGraphV1, FileNode, LeafKind};
 use crate::error::KnowledgeError;
 
-pub(crate) const GRAPH_SQLITE_INDEX_SCHEMA_VERSION: u32 = 1;
+pub(crate) const GRAPH_SQLITE_INDEX_SCHEMA_VERSION: u32 = 2;
 pub(crate) const GRAPH_SQLITE_INDEX_FILENAME: &str = "graph_index.sqlite";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GraphIndexNodeRow {
+    pub id: String,
+    pub node_type: String,
+    pub kind: Option<String>,
+    pub location: String,
+    pub parent_id: Option<String>,
+    pub selector: Option<String>,
+    pub object_hash: String,
+}
+
+pub struct GraphIndexReader {
+    conn: Connection,
+    path: PathBuf,
+}
+
+impl GraphIndexReader {
+    pub fn open_current(
+        path: impl AsRef<Path>,
+        graph_ref: &str,
+    ) -> Result<Option<Self>, KnowledgeError> {
+        let path = path.as_ref();
+        if !path.is_file() {
+            return Ok(None);
+        }
+
+        let conn = match Connection::open_with_flags(path, OpenFlags::SQLITE_OPEN_READ_ONLY) {
+            Ok(conn) => conn,
+            Err(_) => return Ok(None),
+        };
+        conn.pragma_update(None, "busy_timeout", "5000")
+            .map_err(|error| sqlite_error(path, "set busy_timeout", error))?;
+
+        let expected_schema = GRAPH_SQLITE_INDEX_SCHEMA_VERSION.to_string();
+        if query_meta(&conn, "schema_version")?.as_deref() != Some(expected_schema.as_str()) {
+            return Ok(None);
+        }
+        if query_meta(&conn, "graph_ref")?.as_deref() != Some(graph_ref) {
+            return Ok(None);
+        }
+
+        Ok(Some(Self {
+            conn,
+            path: path.to_path_buf(),
+        }))
+    }
+
+    pub fn find_node_by_selector(
+        &self,
+        selector: &str,
+    ) -> Result<Option<GraphIndexNodeRow>, KnowledgeError> {
+        self.conn
+            .query_row(
+                r#"
+                SELECT id, node_type, kind, location, parent_id, selector, object_hash
+                FROM node
+                WHERE selector = ?1
+                LIMIT 1
+                "#,
+                params![selector],
+                graph_index_node_from_row,
+            )
+            .optional()
+            .map_err(|error| sqlite_error(&self.path, "query graph sqlite selector", error))
+    }
+
+    pub fn node_by_id(&self, id: &str) -> Result<Option<GraphIndexNodeRow>, KnowledgeError> {
+        self.conn
+            .query_row(
+                r#"
+                SELECT id, node_type, kind, location, parent_id, selector, object_hash
+                FROM node
+                WHERE id = ?1
+                LIMIT 1
+                "#,
+                params![id],
+                graph_index_node_from_row,
+            )
+            .optional()
+            .map_err(|error| sqlite_error(&self.path, "query graph sqlite node by id", error))
+    }
+
+    pub fn children_of(
+        &self,
+        parent_id: &str,
+        limit: usize,
+    ) -> Result<Vec<GraphIndexNodeRow>, KnowledgeError> {
+        if limit == 0 {
+            return Ok(Vec::new());
+        }
+
+        let limit = i64::try_from(limit).map_err(|_| {
+            KnowledgeError::invalid_data("graph sqlite child limit exceeds i64".to_string())
+        })?;
+        let mut stmt = self
+            .conn
+            .prepare(
+                r#"
+                SELECT id, node_type, kind, location, parent_id, selector, object_hash
+                FROM node
+                WHERE parent_id = ?1
+                ORDER BY ordinal ASC, id ASC
+                LIMIT ?2
+                "#,
+            )
+            .map_err(|error| {
+                sqlite_error(&self.path, "prepare graph sqlite children query", error)
+            })?;
+        let rows = stmt
+            .query_map(params![parent_id, limit], graph_index_node_from_row)
+            .map_err(|error| sqlite_error(&self.path, "query graph sqlite children", error))?;
+        rows.collect::<Result<Vec<_>, _>>()
+            .map_err(|error| sqlite_error(&self.path, "read graph sqlite child row", error))
+    }
+
+    pub fn lineage_for(
+        &self,
+        parent_id: Option<&str>,
+        depth: usize,
+    ) -> Result<Vec<GraphIndexNodeRow>, KnowledgeError> {
+        if depth == 0 {
+            return Ok(Vec::new());
+        }
+
+        let mut lineage = Vec::new();
+        let mut next_id = parent_id.map(ToOwned::to_owned);
+        while let Some(id) = next_id {
+            let row = self.node_by_id(&id)?.ok_or_else(|| {
+                KnowledgeError::invalid_data(format!(
+                    "graph sqlite index references missing parent node `{id}`"
+                ))
+            })?;
+            next_id = row.parent_id.clone();
+            lineage.push(row);
+        }
+        lineage.reverse();
+
+        if lineage.len() > depth {
+            Ok(lineage.split_off(lineage.len() - depth))
+        } else {
+            Ok(lineage)
+        }
+    }
+}
 
 pub(crate) fn write_graph_index(
     path: &Path,
     graph_ref: &str,
     graph: &CodebaseGraphV1,
+    node_object_hashes: &HashMap<String, String>,
 ) -> Result<(), KnowledgeError> {
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent).map_err(|error| {
@@ -57,11 +203,14 @@ pub(crate) fn write_graph_index(
           location TEXT NOT NULL,
           location_lower TEXT NOT NULL,
           parent_id TEXT,
-          selector TEXT
+          selector TEXT,
+          object_hash TEXT NOT NULL,
+          ordinal INTEGER NOT NULL
         );
         CREATE INDEX idx_node_name_lower ON node(name_lower);
         CREATE INDEX idx_node_location_lower ON node(location_lower);
         CREATE INDEX idx_node_parent ON node(parent_id);
+        CREATE INDEX idx_node_parent_ordinal ON node(parent_id, ordinal);
         CREATE UNIQUE INDEX idx_node_selector ON node(selector) WHERE selector IS NOT NULL;
 
         CREATE TABLE file_summary (
@@ -89,18 +238,21 @@ pub(crate) fn write_graph_index(
     .map_err(|error| sqlite_error(path, "insert sqlite index created_at", error))?;
 
     {
+        let child_ordinals = child_ordinals(graph);
         let mut node_insert = tx
             .prepare(
                 r#"
                 INSERT OR REPLACE INTO node (
-                  id, node_type, kind, name, name_lower, location, location_lower, parent_id, selector
-                ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)
+                  id, node_type, kind, name, name_lower, location, location_lower, parent_id,
+                  selector, object_hash, ordinal
+                ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)
                 "#,
             )
             .map_err(|error| sqlite_error(path, "prepare graph sqlite node insert", error))?;
 
         for dir in &graph.dirs {
             let selector = stable_selector(dir_selector(&dir.base), &selector_counts);
+            let object_hash = object_hash_for(path, node_object_hashes, &dir.base.id)?;
             insert_node(
                 path,
                 &mut node_insert,
@@ -108,11 +260,14 @@ pub(crate) fn write_graph_index(
                 "dir",
                 None,
                 selector.as_deref(),
+                object_hash,
+                child_ordinals.get(&dir.base.id).copied().unwrap_or(0),
             )?;
         }
 
         for file in &graph.files {
             let selector = stable_selector(file_selector(&file.base), &selector_counts);
+            let object_hash = object_hash_for(path, node_object_hashes, &file.base.id)?;
             insert_node(
                 path,
                 &mut node_insert,
@@ -120,12 +275,15 @@ pub(crate) fn write_graph_index(
                 "file",
                 None,
                 selector.as_deref(),
+                object_hash,
+                child_ordinals.get(&file.base.id).copied().unwrap_or(0),
             )?;
         }
 
         for leaf in &graph.leaves {
             let kind = leaf.kind.to_string();
             let selector = stable_selector(leaf_selector(&leaf.base, &leaf.kind), &selector_counts);
+            let object_hash = object_hash_for(path, node_object_hashes, &leaf.base.id)?;
             insert_node(
                 path,
                 &mut node_insert,
@@ -133,6 +291,8 @@ pub(crate) fn write_graph_index(
                 "leaf",
                 Some(kind.as_str()),
                 selector.as_deref(),
+                object_hash,
+                child_ordinals.get(&leaf.base.id).copied().unwrap_or(0),
             )?;
         }
     }
@@ -234,6 +394,8 @@ fn insert_node(
     node_type: &str,
     kind: Option<&str>,
     selector: Option<&str>,
+    object_hash: &str,
+    ordinal: i64,
 ) -> Result<(), KnowledgeError> {
     statement
         .execute(params![
@@ -246,9 +408,64 @@ fn insert_node(
             base.location.to_lowercase(),
             base.parent_id.as_deref(),
             selector,
+            object_hash,
+            ordinal,
         ])
         .map_err(|error| sqlite_error(path, "insert graph sqlite node", error))?;
     Ok(())
+}
+
+fn graph_index_node_from_row(row: &Row<'_>) -> rusqlite::Result<GraphIndexNodeRow> {
+    Ok(GraphIndexNodeRow {
+        id: row.get(0)?,
+        node_type: row.get(1)?,
+        kind: row.get(2)?,
+        location: row.get(3)?,
+        parent_id: row.get(4)?,
+        selector: row.get(5)?,
+        object_hash: row.get(6)?,
+    })
+}
+
+fn object_hash_for<'a>(
+    path: &Path,
+    node_object_hashes: &'a HashMap<String, String>,
+    node_id: &str,
+) -> Result<&'a str, KnowledgeError> {
+    node_object_hashes
+        .get(node_id)
+        .map(String::as_str)
+        .ok_or_else(|| {
+            KnowledgeError::invalid_data(format!(
+                "graph sqlite index {} missing object hash for node `{node_id}`",
+                path.display()
+            ))
+        })
+}
+
+fn child_ordinals(graph: &CodebaseGraphV1) -> HashMap<String, i64> {
+    let mut ordinals = HashMap::new();
+    for dir in &graph.dirs {
+        for (ordinal, child_id) in dir
+            .dir_children
+            .iter()
+            .chain(dir.file_children.iter())
+            .enumerate()
+        {
+            ordinals.insert(child_id.clone(), ordinal as i64);
+        }
+    }
+    for file in &graph.files {
+        for (ordinal, child_id) in file.leaf_children.iter().enumerate() {
+            ordinals.insert(child_id.clone(), ordinal as i64);
+        }
+    }
+    for leaf in &graph.leaves {
+        for (ordinal, child_id) in leaf.children.iter().enumerate() {
+            ordinals.insert(child_id.clone(), ordinal as i64);
+        }
+    }
+    ordinals
 }
 
 fn insert_file_summary(

--- a/crates/orbit-tools/src/builtin/orbit/knowledge/show.rs
+++ b/crates/orbit-tools/src/builtin/orbit/knowledge/show.rs
@@ -1,7 +1,9 @@
 use orbit_common::types::{OrbitError, ToolParam, ToolSchema};
+use orbit_knowledge::graph::object_store::{GraphObjectStore, resolve_graph_read_target};
+use orbit_knowledge::graph::{GraphIndexNodeRow, GraphIndexReader, GraphNode};
 use orbit_knowledge::service::GraphContextService;
 use orbit_knowledge::{GraphReadOptions, Selector};
-use serde_json::Value;
+use serde_json::{Value, json};
 
 use crate::{Tool, ToolContext};
 
@@ -53,6 +55,12 @@ impl Tool for OrbitKnowledgeShowTool {
         let max_siblings = input.get("siblings").and_then(Value::as_u64).unwrap_or(3) as usize;
         let max_children = input.get("children").and_then(Value::as_u64).unwrap_or(5) as usize;
 
+        if let Some(payload) =
+            try_show_via_sql_index(ctx, &input, &selector, depth, max_siblings, max_children)?
+        {
+            return Ok(payload);
+        }
+
         let graph = super::load_graph_for_read(
             ctx,
             &input,
@@ -73,4 +81,165 @@ impl Tool for OrbitKnowledgeShowTool {
 
         Ok(crate::graph::node_context_payload(&svc, &node_ctx))
     }
+}
+
+fn try_show_via_sql_index(
+    ctx: &ToolContext,
+    input: &Value,
+    selector: &Selector,
+    depth: usize,
+    max_siblings: usize,
+    max_children: usize,
+) -> Result<Option<Value>, OrbitError> {
+    let knowledge_dir = super::write::resolve_knowledge_dir(ctx, input)?;
+    let explicit_ref = super::super::optional_string(input, "ref")?;
+
+    if explicit_ref.is_none()
+        && !super::has_explicit_knowledge_dir(input)
+        && let Some(workspace_root) = ctx.workspace_root.as_deref()
+    {
+        let _ = orbit_knowledge::pipeline::ensure_fresh(&knowledge_dir, workspace_root);
+    }
+
+    let read_target =
+        match resolve_graph_read_target(ctx.workspace_root.as_deref(), explicit_ref.as_deref()) {
+            Ok(target) => target,
+            Err(_) => return Ok(None),
+        };
+    let graph_store = GraphObjectStore::new(knowledge_dir.join("graph"));
+    if graph_store
+        .prepare_refs_layout(read_target.default.as_ref())
+        .is_err()
+    {
+        return Ok(None);
+    }
+    let resolved =
+        match graph_store.resolve_ref(&read_target.requested, read_target.fallback.as_ref()) {
+            Ok(resolved) => resolved,
+            Err(_) => return Ok(None),
+        };
+    let reader = match GraphIndexReader::open_current(
+        graph_store.graph_sqlite_index_path(),
+        &resolved.current_ref.root_graph_hash,
+    ) {
+        Ok(Some(reader)) => reader,
+        Ok(None) | Err(_) => return Ok(None),
+    };
+
+    let Some(row) = reader
+        .find_node_by_selector(&selector.to_string())
+        .map_err(|error| OrbitError::Execution(format!("query graph sqlite index: {error}")))?
+    else {
+        return Ok(None);
+    };
+
+    let node = graph_store
+        .read_node_by_object_hash(
+            &row.id,
+            &row.node_type,
+            &row.object_hash,
+            GraphReadOptions {
+                hydrate_file_source: true,
+                hydrate_leaf_source: true,
+            },
+        )
+        .map_err(|error| OrbitError::Execution(format!("read graph node: {error}")))?;
+    let lineage = reader
+        .lineage_for(row.parent_id.as_deref(), depth)
+        .map_err(|error| OrbitError::Execution(format!("query graph sqlite lineage: {error}")))?;
+    let siblings = if let Some(parent_id) = row.parent_id.as_deref() {
+        reader
+            .children_of(parent_id, max_siblings.saturating_add(1))
+            .map_err(|error| {
+                OrbitError::Execution(format!("query graph sqlite siblings: {error}"))
+            })?
+            .into_iter()
+            .filter(|sibling| sibling.id != row.id)
+            .take(max_siblings)
+            .collect()
+    } else {
+        Vec::new()
+    };
+    let children = reader
+        .children_of(&row.id, max_children)
+        .map_err(|error| OrbitError::Execution(format!("query graph sqlite children: {error}")))?;
+
+    Ok(Some(sql_node_context_payload(
+        &node, &lineage, &siblings, &children,
+    )))
+}
+
+fn sql_node_context_payload(
+    node: &GraphNode,
+    lineage: &[GraphIndexNodeRow],
+    siblings: &[GraphIndexNodeRow],
+    children: &[GraphIndexNodeRow],
+) -> Value {
+    let lineage: Vec<String> = lineage.iter().map(selector_for_index_row).collect();
+    let siblings: Vec<String> = siblings.iter().map(selector_for_index_row).collect();
+    let children: Vec<String> = children.iter().map(selector_for_index_row).collect();
+
+    let mut value = json!({
+        "selector": selector_for_graph_node(node),
+        "lineage": lineage,
+        "siblings": siblings,
+        "children": children,
+    });
+
+    match node {
+        GraphNode::Leaf(leaf) => {
+            let obj = value.as_object_mut().expect("node context payload object");
+            obj.insert("source".to_string(), json!(leaf.source));
+            obj.insert("lines".to_string(), json!([leaf.start_line, leaf.end_line]));
+        }
+        GraphNode::File(file) => {
+            let obj = value.as_object_mut().expect("node context payload object");
+            if !file.source.is_empty() {
+                obj.insert("source".to_string(), json!(file.source));
+            }
+            if let Some(source_blob_hash) = file.source_blob_hash.as_ref() {
+                obj.insert("source_blob_hash".to_string(), json!(source_blob_hash));
+            }
+            if !file.imports.is_empty() {
+                obj.insert("imports".to_string(), json!(file.imports));
+            }
+            if !file.exports.is_empty() {
+                obj.insert("exports".to_string(), json!(file.exports));
+            }
+            if !file.re_exports.is_empty() {
+                obj.insert("re_exports".to_string(), json!(file.re_exports));
+            }
+        }
+        GraphNode::Dir(_) => {}
+    }
+
+    value
+}
+
+fn selector_for_graph_node(node: &GraphNode) -> String {
+    match node {
+        GraphNode::Dir(dir) => {
+            let path = dir.base.location.trim_end_matches('/');
+            format!("dir:{path}")
+        }
+        GraphNode::File(file) => format!("file:{}", file.base.location),
+        GraphNode::Leaf(leaf) => format!("symbol:{}:{}", leaf.base.location, leaf.kind),
+    }
+}
+
+fn selector_for_index_row(row: &GraphIndexNodeRow) -> String {
+    row.selector
+        .clone()
+        .unwrap_or_else(|| match row.node_type.as_str() {
+            "dir" => {
+                let path = row.location.trim_end_matches('/');
+                format!("dir:{path}")
+            }
+            "file" => format!("file:{}", row.location),
+            "leaf" => {
+                let kind = row.kind.as_deref().unwrap_or_default();
+                format!("symbol:{}:{kind}", row.location)
+            }
+            _ => row.id.clone(),
+        })
 }

--- a/crates/orbit-tools/tests/graph_tool_surface.rs
+++ b/crates/orbit-tools/tests/graph_tool_surface.rs
@@ -1,6 +1,7 @@
 use std::fs;
 use std::path::Path;
 use std::process::Command;
+use std::time::Instant;
 
 use orbit_common::types::OrbitError;
 use orbit_knowledge::graph::object_store::RefName;
@@ -9,6 +10,7 @@ use orbit_knowledge::graph::{
 };
 use orbit_knowledge::pipeline::context::BuildConfig;
 use orbit_tools::{ToolContext, ToolRegistry};
+use rusqlite::Connection;
 use serde_json::{Value, json};
 use tempfile::TempDir;
 
@@ -171,6 +173,179 @@ fn show_file_selector_includes_file_level_source() {
     assert_eq!(response["selector"], "file:package.json");
     assert_eq!(response["source"], "{\"name\":\"orbit\"}\n");
     assert!(response["children"].as_array().unwrap().is_empty());
+}
+
+#[test]
+fn show_selector_uses_sql_index_without_by_id_graph_read() {
+    let mut file = file_node("src/lib.rs", "rust", Some("rs"), vec!["use std::fmt;"]);
+    file.source = "pub fn alpha() {}\npub fn beta() {}\n".to_string();
+    let alpha = leaf_node(
+        "src/lib.rs",
+        "alpha",
+        LeafKind::Function,
+        "pub fn alpha() {}",
+    );
+    let beta = leaf_node("src/lib.rs", "beta", LeafKind::Function, "pub fn beta() {}");
+    file = attach_leaf(file, &alpha);
+    file = attach_leaf(file, &beta);
+    let fixture = write_graph_fixture(graph_with_root(vec![file], vec![alpha, beta]));
+    let knowledge_dir = fixture.path().join(".orbit/knowledge");
+
+    delete_by_id_index(&knowledge_dir);
+    delete_objects_except(&knowledge_dir, "file:src/lib.rs");
+
+    let response = execute_graph_tool(
+        fixture.path(),
+        "orbit.graph.show",
+        json!({"selector":"file:src/lib.rs","children":5}),
+    );
+
+    assert_eq!(response["selector"], "file:src/lib.rs");
+    assert_eq!(response["source"], "pub fn alpha() {}\npub fn beta() {}\n");
+    assert_eq!(response["lineage"], json!(["dir:."]));
+    assert_eq!(
+        response["children"],
+        json!([
+            "symbol:src/lib.rs#alpha:function",
+            "symbol:src/lib.rs#beta:function"
+        ])
+    );
+}
+
+#[test]
+fn show_selector_sql_path_and_fallback_are_byte_equal() {
+    let mut file = file_node("src/lib.rs", "rust", Some("rs"), vec!["use std::fmt;"]);
+    file.source = "pub fn alpha() {}\npub fn beta() {}\n".to_string();
+    let alpha = leaf_node(
+        "src/lib.rs",
+        "alpha",
+        LeafKind::Function,
+        "pub fn alpha() {}",
+    );
+    let beta = leaf_node("src/lib.rs", "beta", LeafKind::Function, "pub fn beta() {}");
+    file = attach_leaf(file, &alpha);
+    file = attach_leaf(file, &beta);
+    let fixture = write_graph_fixture(graph_with_root(vec![file], vec![alpha, beta]));
+    let knowledge_dir = fixture.path().join(".orbit/knowledge");
+
+    let sql_response = execute_graph_tool(
+        fixture.path(),
+        "orbit.graph.show",
+        json!({"selector":"file:src/lib.rs","children":5}),
+    );
+    fs::remove_file(knowledge_dir.join("graph/graph_index.sqlite")).unwrap();
+    let fallback_response = execute_graph_tool(
+        fixture.path(),
+        "orbit.graph.show",
+        json!({"selector":"file:src/lib.rs","children":5}),
+    );
+
+    assert_eq!(
+        serde_json::to_vec(&sql_response).unwrap(),
+        serde_json::to_vec(&fallback_response).unwrap()
+    );
+}
+
+#[test]
+fn show_selector_falls_back_when_sqlite_index_is_stale() {
+    let mut file = file_node("package.json", "json", Some("json"), vec![]);
+    file.source = "{\"name\":\"orbit\"}\n".to_string();
+    let fixture = write_graph_fixture(graph_with_root(vec![file], Vec::new()));
+    let index_path = fixture
+        .path()
+        .join(".orbit/knowledge/graph/graph_index.sqlite");
+    let conn = Connection::open(index_path).unwrap();
+    conn.execute(
+        "UPDATE meta SET value = 'stale-root' WHERE key = 'graph_ref'",
+        [],
+    )
+    .unwrap();
+
+    let response = execute_graph_tool(
+        fixture.path(),
+        "orbit.graph.show",
+        json!({"selector":"file:package.json"}),
+    );
+
+    assert_eq!(response["selector"], "file:package.json");
+    assert_eq!(response["source"], "{\"name\":\"orbit\"}\n");
+}
+
+#[test]
+fn show_selector_not_found_matches_fallback_error() {
+    let file = file_node("src/lib.rs", "rust", Some("rs"), vec![]);
+    let fixture = write_graph_fixture(graph_with_root(vec![file], Vec::new()));
+    let knowledge_dir = fixture.path().join(".orbit/knowledge");
+
+    let sql_error = execute_graph_tool_result(
+        fixture.path(),
+        "orbit.graph.show",
+        json!({"selector":"file:missing.rs"}),
+    )
+    .unwrap_err();
+    fs::remove_file(knowledge_dir.join("graph/graph_index.sqlite")).unwrap();
+    let fallback_error = execute_graph_tool_result(
+        fixture.path(),
+        "orbit.graph.show",
+        json!({"selector":"file:missing.rs"}),
+    )
+    .unwrap_err();
+
+    assert!(matches!(sql_error, OrbitError::InvalidInput(_)));
+    assert!(matches!(fallback_error, OrbitError::InvalidInput(_)));
+    assert_eq!(sql_error.to_string(), fallback_error.to_string());
+}
+
+#[test]
+#[ignore = "manual latency observation for T20260509-74"]
+fn show_selector_sql_path_microbenchmark_10k_leaf_fixture() {
+    let mut file = file_node("src/generated.rs", "rust", Some("rs"), vec![]);
+    let leaves: Vec<LeafNode> = (0..10_000)
+        .map(|idx| {
+            leaf_node(
+                "src/generated.rs",
+                &format!("generated_{idx}"),
+                LeafKind::Function,
+                &format!("pub fn generated_{idx}() {{}}\n"),
+            )
+        })
+        .collect();
+    for leaf in &leaves {
+        file = attach_leaf(file, leaf);
+    }
+    let target_selector = "symbol:src/generated.rs#generated_9999:function";
+    let fixture = write_graph_fixture(graph_with_root(vec![file], leaves));
+    let knowledge_dir = fixture.path().join(".orbit/knowledge");
+
+    let sql_start = Instant::now();
+    let sql_response = execute_graph_tool(
+        fixture.path(),
+        "orbit.graph.show",
+        json!({"selector":target_selector,"depth":2,"siblings":3,"children":5}),
+    );
+    let sql_elapsed = sql_start.elapsed();
+    assert_eq!(sql_response["selector"], target_selector);
+
+    fs::remove_file(knowledge_dir.join("graph/graph_index.sqlite")).unwrap();
+    let fallback_start = Instant::now();
+    let fallback_response = execute_graph_tool(
+        fixture.path(),
+        "orbit.graph.show",
+        json!({"selector":target_selector,"depth":2,"siblings":3,"children":5}),
+    );
+    let fallback_elapsed = fallback_start.elapsed();
+    assert_eq!(fallback_response, sql_response);
+
+    let sql_ms = sql_elapsed.as_secs_f64() * 1000.0;
+    let fallback_ms = fallback_elapsed.as_secs_f64() * 1000.0;
+    let speedup = fallback_ms / sql_ms.max(f64::EPSILON);
+    println!(
+        "show selector 10k leaves: sql={sql_ms:.3}ms fallback={fallback_ms:.3}ms speedup={speedup:.1}x"
+    );
+    assert!(
+        speedup >= 10.0,
+        "expected SQL selector path to be at least 10x faster, got {speedup:.1}x"
+    );
 }
 
 #[test]
@@ -811,6 +986,43 @@ fn write_graph_fixture(graph: CodebaseGraphV1) -> TempDir {
         .unwrap();
 
     repo_root
+}
+
+fn delete_by_id_index(knowledge_dir: &Path) {
+    let by_id_dir = knowledge_dir.join("graph/index/by-id");
+    for entry in fs::read_dir(by_id_dir).unwrap() {
+        let entry = entry.unwrap();
+        if entry.path().extension().is_some_and(|ext| ext == "json") {
+            fs::remove_file(entry.path()).unwrap();
+        }
+    }
+}
+
+fn delete_objects_except(knowledge_dir: &Path, retained_node_id: &str) {
+    for (node_id, object_hash) in sqlite_node_object_hashes(knowledge_dir) {
+        if node_id == retained_node_id {
+            continue;
+        }
+        fs::remove_file(graph_object_path(knowledge_dir, &object_hash)).unwrap();
+    }
+}
+
+fn sqlite_node_object_hashes(knowledge_dir: &Path) -> Vec<(String, String)> {
+    let conn = Connection::open(knowledge_dir.join("graph/graph_index.sqlite")).unwrap();
+    let mut stmt = conn
+        .prepare("SELECT id, object_hash FROM node ORDER BY id")
+        .unwrap();
+    stmt.query_map([], |row| Ok((row.get(0)?, row.get(1)?)))
+        .unwrap()
+        .collect::<Result<Vec<_>, _>>()
+        .unwrap()
+}
+
+fn graph_object_path(knowledge_dir: &Path, object_hash: &str) -> std::path::PathBuf {
+    knowledge_dir
+        .join("graph/objects")
+        .join(&object_hash[..2])
+        .join(format!("{object_hash}.json"))
 }
 
 fn graph_with_root(files: Vec<FileNode>, leaves: Vec<LeafNode>) -> CodebaseGraphV1 {


### PR DESCRIPTION
## Task

[T20260509-74](https://orbit-cli.com/tasks/T20260509-74) — Wire show by selector through SQLite index

### Description

## Problem

`show` resolves a selector to a node by walking the in-memory graph after a full `read_graph` call. Even with Phase 1 lazy hydration in place, the selector lookup still constructs the full read facade. The SQLite index has a unique selector index that turns this into a single-row B-tree lookup, with the node body hydrated only after the ID is resolved.

Note: `KnowledgeStore::open` ([crates/orbit-knowledge/src/store/open.rs:16](crates/orbit-knowledge/src/store/open.rs:16)) already builds an in-memory selector index for `pack`. This task introduces a SQL-backed alternative; the executing agent should evaluate whether the in-memory variant remains the right choice for `pack`, but the immediate goal is making `show` cheap.

## Why It Matters

Phase 3 of the graph-latency proposal ([raw/wiki/graph/perf_proposal_claude.md](raw/wiki/graph/perf_proposal_claude.md)). Latency budget commits to p99 10ms warm on `show by selector`. The current implementation pays full `read_graph` cost (which Phase 1 reduces but does not eliminate). With the SQLite index, `show` becomes one indexed SELECT plus one node hydration.

## Implementation Notes

- In the show tool entry point ([crates/orbit-tools/src/builtin/orbit/knowledge/show.rs](crates/orbit-tools/src/builtin/orbit/knowledge/show.rs)):

  1. Open the index via `GraphIndexReader`. If `None`, fall back to the existing path.
  2. `SELECT id, node_type FROM node WHERE selector = ? LIMIT 1`. If no row, treat as not-found and return the same error the fallback would.
  3. Hydrate only that single node (and its source if `show` returns source) via the existing graph object store. Do NOT call `read_graph` to load the full graph.
  4. Return the same response shape as the fallback path.

- The single-node hydration step needs a focused API on `GraphObjectStore` (`read_node_by_id` or similar) that loads one object file and optionally its source blob, without walking the by-id index. If such an API does not exist, add a minimal one as part of this task. Keep it private to the read facade if it is awkward to expose publicly.

- Selectors not in the index (legacy or unstable forms): fall back to the existing path. The SQL path is an optimization for the common case, not a replacement.

## Constraints / Notes

- Output equality with the fallback is required.
- Depends on T20260509-71 (read facade).
- Do not refactor `pack` in this task. Touching `KnowledgeStore::open` is out of scope; if the executing agent decides to share the SQL path between `show` and `pack`, that should be a separate task.
- Authoring model: claude-opus-4-7. Author: claude.

### Acceptance Criteria

- When the SQLite index is present and current, `show` resolves the selector via `SELECT id FROM node WHERE selector = ?`. Verified by an instrumented test asserting the SQL path was taken.
- When the SQLite index is missing or stale, `show` falls back to the existing implementation. Verified by deleting the index and re-running the same selector.
- Output equality: for a fixture corpus and a selector pointing to a known node, the SQL path and the fallback produce byte-equal responses. Verified by a test that runs both and asserts equality.
- Selector not-found behavior: a selector that does not exist returns the same error type and message on both paths.
- The SQL path hydrates only the resolved node (and its source if applicable), not the full graph. Verified by an instrumented test or by confirming `read_graph` is not called on the SQL path.
- Latency observation: a microbenchmark on a 10k-leaf fixture shows the SQL path is at least 10× faster than the fallback for `show by selector`. Record numbers in the execution summary.
- `pack` and `KnowledgeStore::open` are unchanged in this task — verifiable by `git diff --stat`.
- Existing show integration tests pass without expected-output changes.
- `make build` and `make fmt` pass.
- `cargo test --workspace` passes.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Added a current SQLite graph index reader for selector lookup, parent/child context rows, and schema validation.
- Extended the SQLite node index to schema version 2 with object_hash and ordinal so show can resolve one selector, hydrate only the selected node/source, and render bounded context without loading the by-id graph.
- Wired orbit.graph.show through the SQL fast path with fallback to the existing read_graph path for missing/stale indexes and selector misses.
- Added show integration coverage for SQL-path execution without by-id graph reads, stale-index fallback, byte-equal SQL/fallback output, not-found parity, and an ignored 10k-leaf microbenchmark.

Assessment: The scoped show-by-selector path is implemented and validated. pack and KnowledgeStore::open were not modified.

Validation:
- make fmt: passed.
- make build: passed.
- cargo test -p orbit-tools --test graph_tool_surface: passed.
- cargo test -p orbit-tools --test graph_tool_surface show_selector_sql_path_microbenchmark_10k_leaf_fixture -- --ignored --nocapture: sql=19.398ms, fallback=1676.115ms, speedup=86.4x.
- cargo test --workspace: the literal command failed on pre-existing diagnostics test pollution from the global process log; filed friction T20260509-76.
- ORBIT_LOG_PATH=<empty temp file> cargo test --workspace: passed.

Design weaknesses / risks:
- Existing schema-version-1 SQLite indexes are treated as stale and fall back until the graph is rebuilt. Severity: Low. Mitigation: existing fallback remains intact and rebuilds write schema version 2.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/T20260509-74-69ffabdd`
- Behind base: 0
- Ahead of base: 1

*authored by: claude-opus-4-7*