### PR TITLE
Wire overview summary fast path through SQLite index

### DIFF
--- a/crates/orbit-knowledge/src/graph/object_store.rs
+++ b/crates/orbit-knowledge/src/graph/object_store.rs
@@ -1107,7 +1107,7 @@ mod tests {
         assert!(indexes.contains(&"idx_node_selector".to_string()));
 
         let meta = sqlite_meta(&conn);
-        assert_eq!(meta.get("schema_version").map(String::as_str), Some("2"));
+        assert_eq!(meta.get("schema_version").map(String::as_str), Some("3"));
         assert_eq!(
             meta.get("graph_ref").map(String::as_str),
             Some(current_ref.root_graph_hash.as_str())
@@ -1128,14 +1128,15 @@ mod tests {
             .expect("count selectors");
         assert_eq!(selector_count, expected_node_count as i64);
 
-        let (name_lower, location_lower, selector): (String, String, String) = conn
+        let (name_lower, language, location_lower, selector): (String, String, String, String) = conn
             .query_row(
-                "SELECT name_lower, location_lower, selector FROM node WHERE id = 'leaf-greet'",
+                "SELECT name_lower, language, location_lower, selector FROM node WHERE id = 'leaf-greet'",
                 [],
-                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
             )
             .expect("leaf row");
         assert_eq!(name_lower, "greet");
+        assert_eq!(language, "rust");
         assert_eq!(location_lower, "src/lib.rs#greet");
         assert_eq!(selector, "symbol:src/Lib.rs#Greet:function");
 

--- a/crates/orbit-knowledge/src/graph/sqlite_index.rs
+++ b/crates/orbit-knowledge/src/graph/sqlite_index.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::fs;
 use std::path::{Path, PathBuf};
 
@@ -8,7 +8,7 @@ use rusqlite::{Connection, OpenFlags, OptionalExtension, Row, TransactionBehavio
 use super::nodes::{BaseNodeFields, CodebaseGraphV1, FileNode, LeafKind};
 use crate::error::KnowledgeError;
 
-pub(crate) const GRAPH_SQLITE_INDEX_SCHEMA_VERSION: u32 = 2;
+pub(crate) const GRAPH_SQLITE_INDEX_SCHEMA_VERSION: u32 = 3;
 pub(crate) const GRAPH_SQLITE_INDEX_FILENAME: &str = "graph_index.sqlite";
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -154,6 +154,191 @@ impl GraphIndexReader {
             Ok(lineage)
         }
     }
+
+    pub fn overview_counts(&self) -> Result<(usize, usize, usize), KnowledgeError> {
+        Ok((
+            self.node_count("dir")?,
+            self.node_count("file")?,
+            self.node_count("leaf")?,
+        ))
+    }
+
+    pub fn overview_language_counts(&self) -> Result<HashMap<String, usize>, KnowledgeError> {
+        self.string_count_map(
+            r#"
+            SELECT language, COUNT(*)
+            FROM node
+            WHERE node_type = 'file' AND language <> ''
+            GROUP BY language
+            ORDER BY language ASC
+            "#,
+            "query graph sqlite overview language counts",
+        )
+    }
+
+    pub fn overview_symbol_kind_counts(&self) -> Result<HashMap<String, usize>, KnowledgeError> {
+        self.string_count_map(
+            r#"
+            SELECT kind, COUNT(*)
+            FROM node
+            WHERE node_type = 'leaf' AND kind IS NOT NULL
+            GROUP BY kind
+            ORDER BY kind ASC
+            "#,
+            "query graph sqlite overview symbol kind counts",
+        )
+    }
+
+    pub fn overview_dir_file_counts(&self) -> Result<BTreeMap<String, usize>, KnowledgeError> {
+        let mut stmt = self
+            .conn
+            .prepare(
+                r#"
+                SELECT dir_key, COUNT(*)
+                FROM (
+                  SELECT CASE
+                    WHEN trimmed_path = '' THEN '.'
+                    WHEN instr(trimmed_path, '/') = 0 THEN '.'
+                    ELSE substr(trimmed_path, 1, instr(trimmed_path, '/') - 1)
+                  END AS dir_key
+                  FROM (
+                    SELECT ltrim(path, '/') AS trimmed_path
+                    FROM file_summary
+                  )
+                )
+                GROUP BY dir_key
+                ORDER BY dir_key ASC
+                "#,
+            )
+            .map_err(|error| {
+                sqlite_error(
+                    &self.path,
+                    "prepare graph sqlite overview dir file counts",
+                    error,
+                )
+            })?;
+        let rows = stmt
+            .query_map([], |row| {
+                Ok((row.get::<_, String>(0)?, row.get::<_, i64>(1)?))
+            })
+            .map_err(|error| {
+                sqlite_error(
+                    &self.path,
+                    "query graph sqlite overview dir file counts",
+                    error,
+                )
+            })?;
+
+        let mut counts = BTreeMap::new();
+        for row in rows {
+            let (key, count) = row.map_err(|error| {
+                sqlite_error(
+                    &self.path,
+                    "read graph sqlite overview dir file count row",
+                    error,
+                )
+            })?;
+            counts.insert(
+                key,
+                usize_from_i64(&self.path, "overview dir file count", count)?,
+            );
+        }
+        Ok(counts)
+    }
+
+    pub fn overview_top_files(
+        &self,
+        limit: usize,
+    ) -> Result<Vec<(String, String, usize)>, KnowledgeError> {
+        if limit == 0 {
+            return Ok(Vec::new());
+        }
+
+        let limit = i64::try_from(limit).map_err(|_| {
+            KnowledgeError::invalid_data("graph sqlite overview top-file limit exceeds i64")
+        })?;
+        let mut stmt = self
+            .conn
+            .prepare(
+                r#"
+                SELECT COALESCE(node.selector, 'file:' || file_summary.path) AS selector,
+                       node.name,
+                       file_summary.symbol_count
+                FROM file_summary
+                JOIN node ON node.id = file_summary.file_id
+                ORDER BY file_summary.symbol_count DESC,
+                         file_summary.path ASC,
+                         selector ASC,
+                         node.name ASC
+                LIMIT ?1
+                "#,
+            )
+            .map_err(|error| {
+                sqlite_error(&self.path, "prepare graph sqlite overview top files", error)
+            })?;
+        let rows = stmt
+            .query_map(params![limit], |row| {
+                Ok((
+                    row.get::<_, String>(0)?,
+                    row.get::<_, String>(1)?,
+                    row.get::<_, i64>(2)?,
+                ))
+            })
+            .map_err(|error| {
+                sqlite_error(&self.path, "query graph sqlite overview top files", error)
+            })?;
+
+        let mut files = Vec::new();
+        for row in rows {
+            let (selector, name, symbol_count) = row.map_err(|error| {
+                sqlite_error(&self.path, "read graph sqlite overview top-file row", error)
+            })?;
+            files.push((
+                selector,
+                name,
+                usize_from_i64(&self.path, "overview top-file symbol count", symbol_count)?,
+            ));
+        }
+        Ok(files)
+    }
+
+    fn node_count(&self, node_type: &str) -> Result<usize, KnowledgeError> {
+        let count: i64 = self
+            .conn
+            .query_row(
+                "SELECT COUNT(*) FROM node WHERE node_type = ?1",
+                params![node_type],
+                |row| row.get(0),
+            )
+            .map_err(|error| {
+                sqlite_error(&self.path, "query graph sqlite overview count", error)
+            })?;
+        usize_from_i64(&self.path, "overview node count", count)
+    }
+
+    fn string_count_map(
+        &self,
+        sql: &str,
+        action: &str,
+    ) -> Result<HashMap<String, usize>, KnowledgeError> {
+        let mut stmt = self
+            .conn
+            .prepare(sql)
+            .map_err(|error| sqlite_error(&self.path, action, error))?;
+        let rows = stmt
+            .query_map([], |row| {
+                Ok((row.get::<_, String>(0)?, row.get::<_, i64>(1)?))
+            })
+            .map_err(|error| sqlite_error(&self.path, action, error))?;
+
+        let mut counts = HashMap::new();
+        for row in rows {
+            let (key, count) = row
+                .map_err(|error| sqlite_error(&self.path, "read graph sqlite count row", error))?;
+            counts.insert(key, usize_from_i64(&self.path, "overview count", count)?);
+        }
+        Ok(counts)
+    }
 }
 
 pub(crate) fn write_graph_index(
@@ -200,6 +385,7 @@ pub(crate) fn write_graph_index(
           kind TEXT,
           name TEXT NOT NULL,
           name_lower TEXT NOT NULL,
+          language TEXT NOT NULL,
           location TEXT NOT NULL,
           location_lower TEXT NOT NULL,
           parent_id TEXT,
@@ -243,9 +429,9 @@ pub(crate) fn write_graph_index(
             .prepare(
                 r#"
                 INSERT OR REPLACE INTO node (
-                  id, node_type, kind, name, name_lower, location, location_lower, parent_id,
-                  selector, object_hash, ordinal
-                ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)
+                  id, node_type, kind, name, name_lower, language, location, location_lower,
+                  parent_id, selector, object_hash, ordinal
+                ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)
                 "#,
             )
             .map_err(|error| sqlite_error(path, "prepare graph sqlite node insert", error))?;
@@ -404,6 +590,7 @@ fn insert_node(
             kind,
             base.name.as_str(),
             base.name.to_lowercase(),
+            base.language.as_str(),
             base.location.as_str(),
             base.location.to_lowercase(),
             base.parent_id.as_deref(),
@@ -413,6 +600,15 @@ fn insert_node(
         ])
         .map_err(|error| sqlite_error(path, "insert graph sqlite node", error))?;
     Ok(())
+}
+
+fn usize_from_i64(path: &Path, label: &str, value: i64) -> Result<usize, KnowledgeError> {
+    usize::try_from(value).map_err(|_| {
+        KnowledgeError::invalid_data(format!(
+            "graph sqlite index {} returned invalid {label} `{value}`",
+            path.display()
+        ))
+    })
 }
 
 fn graph_index_node_from_row(row: &Row<'_>) -> rusqlite::Result<GraphIndexNodeRow> {

--- a/crates/orbit-tools/src/builtin/orbit/knowledge/overview.rs
+++ b/crates/orbit-tools/src/builtin/orbit/knowledge/overview.rs
@@ -1,6 +1,11 @@
+use std::collections::{BTreeMap, HashMap};
+
+use orbit_common::tracing::debug;
 use orbit_common::types::{OrbitError, ToolParam, ToolSchema};
+use orbit_knowledge::graph::GraphIndexReader;
+use orbit_knowledge::graph::object_store::{GraphObjectStore, resolve_graph_read_target};
 use orbit_knowledge::service::{
-    GraphContextService, GraphOverview, GraphOverviewSummary, compact_from_overview,
+    GraphContextService, GraphOverview, GraphOverviewSummary, TopFileEntry, compact_from_overview,
 };
 use serde_json::{Value, json};
 
@@ -75,6 +80,18 @@ impl Tool for OrbitKnowledgeOverviewTool {
     fn execute(&self, ctx: &ToolContext, input: Value) -> Result<Value, OrbitError> {
         let prefix = super::super::optional_string(&input, "prefix")?;
         let requested_format = OverviewFormat::parse(&input)?;
+        let requested_format_label = requested_format_label(requested_format);
+
+        if let Some(sql_summary) =
+            try_summary_via_sql_index(ctx, &input, prefix.as_deref(), requested_format)?
+        {
+            return Ok(summary_response(
+                sql_summary.summary,
+                requested_format_label,
+                sql_summary.downgraded,
+            ));
+        }
+
         let graph = super::load_graph_for_read(ctx, &input, Default::default())?;
         let svc = GraphContextService::new(&graph);
         let overview = svc.overview(prefix.as_deref());
@@ -84,21 +101,140 @@ impl Tool for OrbitKnowledgeOverviewTool {
         let downgraded = matches!(requested_format, Some(OverviewFormat::Full))
             && overview.files.len() > FILE_THRESHOLD;
         let use_summary = matches!(resolved_format, OverviewFormat::Summary) || downgraded;
-        let requested_format = match requested_format {
-            Some(OverviewFormat::Full) => "full",
-            Some(OverviewFormat::Summary) => "summary",
-            None => "auto",
-        };
-
         Ok(if use_summary {
             summary_response(
                 compact_from_overview(&overview, prefix.as_deref(), SUMMARY_HINT),
-                requested_format,
+                requested_format_label,
                 downgraded,
             )
         } else {
-            full_response(overview, requested_format)
+            full_response(overview, requested_format_label)
         })
+    }
+}
+
+struct SqlOverviewSummary {
+    summary: GraphOverviewSummary,
+    downgraded: bool,
+}
+
+fn requested_format_label(requested_format: Option<OverviewFormat>) -> &'static str {
+    match requested_format {
+        Some(OverviewFormat::Full) => "full",
+        Some(OverviewFormat::Summary) => "summary",
+        None => "auto",
+    }
+}
+
+fn try_summary_via_sql_index(
+    ctx: &ToolContext,
+    input: &Value,
+    prefix: Option<&str>,
+    requested_format: Option<OverviewFormat>,
+) -> Result<Option<SqlOverviewSummary>, OrbitError> {
+    if prefix.is_some() {
+        debug!("falling back to graph overview scan because scoped SQL summaries are unsupported");
+        return Ok(None);
+    }
+
+    let Some(reader) = open_current_sql_index(ctx, input)? else {
+        return Ok(None);
+    };
+
+    let (total_dirs, total_files, total_symbols) = reader
+        .overview_counts()
+        .map_err(|error| OrbitError::Execution(format!("query graph sqlite overview: {error}")))?;
+    let resolved_format =
+        requested_format.unwrap_or_else(|| OverviewFormat::default_for_scope(None, total_files));
+    let downgraded =
+        matches!(requested_format, Some(OverviewFormat::Full)) && total_files > FILE_THRESHOLD;
+    let use_summary = matches!(resolved_format, OverviewFormat::Summary) || downgraded;
+    if !use_summary {
+        debug!("falling back to graph overview scan because full output is required");
+        return Ok(None);
+    }
+
+    let top_files = reader
+        .overview_top_files(10)
+        .map_err(|error| OrbitError::Execution(format!("query graph sqlite overview: {error}")))?
+        .into_iter()
+        .map(|(selector, name, symbol_count)| TopFileEntry {
+            selector,
+            name,
+            symbol_count,
+        })
+        .collect();
+
+    Ok(Some(SqlOverviewSummary {
+        summary: GraphOverviewSummary {
+            total_dirs,
+            total_files,
+            total_symbols,
+            languages: reader.overview_language_counts().map_err(|error| {
+                OrbitError::Execution(format!("query graph sqlite overview: {error}"))
+            })?,
+            symbol_kinds: reader.overview_symbol_kind_counts().map_err(|error| {
+                OrbitError::Execution(format!("query graph sqlite overview: {error}"))
+            })?,
+            dir_file_counts: reader.overview_dir_file_counts().map_err(|error| {
+                OrbitError::Execution(format!("query graph sqlite overview: {error}"))
+            })?,
+            top_files,
+            hint: SUMMARY_HINT.to_string(),
+        },
+        downgraded,
+    }))
+}
+
+fn open_current_sql_index(
+    ctx: &ToolContext,
+    input: &Value,
+) -> Result<Option<GraphIndexReader>, OrbitError> {
+    let knowledge_dir = super::write::resolve_knowledge_dir(ctx, input)?;
+    let explicit_ref = super::super::optional_string(input, "ref")?;
+
+    if explicit_ref.is_none()
+        && !super::has_explicit_knowledge_dir(input)
+        && let Some(workspace_root) = ctx.workspace_root.as_deref()
+    {
+        let _ = orbit_knowledge::pipeline::ensure_fresh(&knowledge_dir, workspace_root);
+    }
+
+    let read_target =
+        match resolve_graph_read_target(ctx.workspace_root.as_deref(), explicit_ref.as_deref()) {
+            Ok(target) => target,
+            Err(error) => {
+                debug!(%error, "falling back to graph overview scan; graph ref target unavailable");
+                return Ok(None);
+            }
+        };
+    let graph_store = GraphObjectStore::new(knowledge_dir.join("graph"));
+    if let Err(error) = graph_store.prepare_refs_layout(read_target.default.as_ref()) {
+        debug!(%error, "falling back to graph overview scan; graph refs unavailable");
+        return Ok(None);
+    }
+    let resolved =
+        match graph_store.resolve_ref(&read_target.requested, read_target.fallback.as_ref()) {
+            Ok(resolved) => resolved,
+            Err(error) => {
+                debug!(%error, "falling back to graph overview scan; graph ref unavailable");
+                return Ok(None);
+            }
+        };
+
+    match GraphIndexReader::open_current(
+        graph_store.graph_sqlite_index_path(),
+        &resolved.current_ref.root_graph_hash,
+    ) {
+        Ok(Some(reader)) => Ok(Some(reader)),
+        Ok(None) => {
+            debug!("falling back to graph overview scan; sqlite graph index is missing or stale");
+            Ok(None)
+        }
+        Err(error) => {
+            debug!(%error, "falling back to graph overview scan; sqlite graph index could not be opened");
+            Ok(None)
+        }
     }
 }
 
@@ -163,10 +299,14 @@ fn summary_response(
         "total_dirs": summary.total_dirs,
         "total_files": summary.total_files,
         "total_symbols": summary.total_symbols,
-        "languages": summary.languages,
-        "symbol_kinds": summary.symbol_kinds,
+        "languages": sorted_counts(summary.languages),
+        "symbol_kinds": sorted_counts(summary.symbol_kinds),
         "dir_file_counts": summary.dir_file_counts,
         "top_files": top_files,
         "hint": summary.hint,
     })
+}
+
+fn sorted_counts(counts: HashMap<String, usize>) -> BTreeMap<String, usize> {
+    counts.into_iter().collect()
 }

--- a/crates/orbit-tools/tests/graph_tool_surface.rs
+++ b/crates/orbit-tools/tests/graph_tool_surface.rs
@@ -481,6 +481,148 @@ fn overview_defaults_to_summary_for_broad_scope() {
 }
 
 #[test]
+fn overview_summary_uses_sql_index_without_by_id_graph_read() {
+    let fixture = write_graph_fixture(large_overview_graph(120, 12));
+    let knowledge_dir = fixture.path().join(".orbit/knowledge");
+
+    delete_by_id_index(&knowledge_dir);
+
+    let response = execute_graph_tool(
+        fixture.path(),
+        "orbit.graph.overview",
+        json!({"format":"summary"}),
+    );
+
+    assert_eq!(response["mode"], "summary");
+    assert_eq!(response["total_files"], 120);
+    assert_eq!(response["total_symbols"], 1440);
+    assert_eq!(response["dir_file_counts"], json!({"src": 120}));
+}
+
+#[test]
+fn overview_summary_falls_back_when_sqlite_index_is_missing_or_stale() {
+    let missing_fixture = write_graph_fixture(large_overview_graph(120, 12));
+    let missing_knowledge_dir = missing_fixture.path().join(".orbit/knowledge");
+    fs::remove_file(missing_knowledge_dir.join("graph/graph_index.sqlite")).unwrap();
+    let fallback_response = execute_graph_tool(
+        missing_fixture.path(),
+        "orbit.graph.overview",
+        json!({"format":"summary"}),
+    );
+
+    let stale_fixture = write_graph_fixture(large_overview_graph(120, 12));
+    let index_path = stale_fixture
+        .path()
+        .join(".orbit/knowledge/graph/graph_index.sqlite");
+    let conn = Connection::open(index_path).unwrap();
+    conn.execute(
+        "UPDATE meta SET value = 'stale-root' WHERE key = 'graph_ref'",
+        [],
+    )
+    .unwrap();
+    let stale_response = execute_graph_tool(
+        stale_fixture.path(),
+        "orbit.graph.overview",
+        json!({"format":"summary"}),
+    );
+
+    assert_eq!(stale_response, fallback_response);
+}
+
+#[test]
+fn overview_summary_sql_path_and_fallback_are_byte_equal_for_large_fixture() {
+    let fixture = write_graph_fixture(large_overview_graph(120, 12));
+    let knowledge_dir = fixture.path().join(".orbit/knowledge");
+
+    let sql_response = execute_graph_tool(
+        fixture.path(),
+        "orbit.graph.overview",
+        json!({"format":"summary"}),
+    );
+    fs::remove_file(knowledge_dir.join("graph/graph_index.sqlite")).unwrap();
+    let fallback_response = execute_graph_tool(
+        fixture.path(),
+        "orbit.graph.overview",
+        json!({"format":"summary"}),
+    );
+
+    assert_eq!(
+        serde_json::to_vec(&sql_response).unwrap(),
+        serde_json::to_vec(&fallback_response).unwrap()
+    );
+}
+
+#[test]
+fn overview_summary_with_prefix_falls_back_and_matches_fallback() {
+    let fixture = write_graph_fixture(large_overview_graph(120, 12));
+    let knowledge_dir = fixture.path().join(".orbit/knowledge");
+
+    let scoped_response = execute_graph_tool(
+        fixture.path(),
+        "orbit.graph.overview",
+        json!({"prefix":"src/group_00/","format":"summary"}),
+    );
+    fs::remove_file(knowledge_dir.join("graph/graph_index.sqlite")).unwrap();
+    let fallback_response = execute_graph_tool(
+        fixture.path(),
+        "orbit.graph.overview",
+        json!({"prefix":"src/group_00/","format":"summary"}),
+    );
+
+    assert_eq!(scoped_response, fallback_response);
+    assert_eq!(scoped_response["total_files"], 10);
+    assert_eq!(scoped_response["dir_file_counts"], json!({".": 10}));
+}
+
+#[test]
+#[ignore = "manual latency observation for T20260509-72"]
+fn overview_summary_sql_path_microbenchmark_10k_leaf_fixture() {
+    let fixture = write_graph_fixture(large_overview_graph(200, 50));
+    let knowledge_dir = fixture.path().join(".orbit/knowledge");
+
+    let sql_response = execute_graph_tool(
+        fixture.path(),
+        "orbit.graph.overview",
+        json!({"format":"summary"}),
+    );
+    let sql_start = Instant::now();
+    let timed_sql_response = execute_graph_tool(
+        fixture.path(),
+        "orbit.graph.overview",
+        json!({"format":"summary"}),
+    );
+    let sql_elapsed = sql_start.elapsed();
+    assert_eq!(timed_sql_response, sql_response);
+
+    fs::remove_file(knowledge_dir.join("graph/graph_index.sqlite")).unwrap();
+    let fallback_response = execute_graph_tool(
+        fixture.path(),
+        "orbit.graph.overview",
+        json!({"format":"summary"}),
+    );
+    let fallback_start = Instant::now();
+    let timed_fallback_response = execute_graph_tool(
+        fixture.path(),
+        "orbit.graph.overview",
+        json!({"format":"summary"}),
+    );
+    let fallback_elapsed = fallback_start.elapsed();
+    assert_eq!(fallback_response, sql_response);
+    assert_eq!(timed_fallback_response, sql_response);
+
+    let sql_ms = sql_elapsed.as_secs_f64() * 1000.0;
+    let fallback_ms = fallback_elapsed.as_secs_f64() * 1000.0;
+    let speedup = fallback_ms / sql_ms.max(f64::EPSILON);
+    println!(
+        "overview summary 10k leaves: sql={sql_ms:.3}ms fallback={fallback_ms:.3}ms speedup={speedup:.1}x"
+    );
+    assert!(
+        speedup >= 5.0,
+        "expected SQL overview path to be at least 5x faster, got {speedup:.1}x"
+    );
+}
+
+#[test]
 fn refs_partition_code_doc_and_config_hits() {
     let definition = leaf_node(
         "src/runtime.rs",
@@ -986,6 +1128,32 @@ fn write_graph_fixture(graph: CodebaseGraphV1) -> TempDir {
         .unwrap();
 
     repo_root
+}
+
+fn large_overview_graph(file_count: usize, symbols_per_file: usize) -> CodebaseGraphV1 {
+    let mut files = Vec::with_capacity(file_count);
+    let mut leaves = Vec::with_capacity(file_count * symbols_per_file);
+
+    for file_index in 0..file_count {
+        let path = format!("src/group_{:02}/file_{file_index:04}.rs", file_index / 10);
+        let mut file = file_node(&path, "rust", Some("rs"), vec![]);
+
+        for symbol_index in 0..symbols_per_file {
+            let name = format!("symbol_{file_index:04}_{symbol_index:04}");
+            let leaf = leaf_node(
+                &path,
+                &name,
+                LeafKind::Function,
+                &format!("fn {name}() {{}}"),
+            );
+            file = attach_leaf(file, &leaf);
+            leaves.push(leaf);
+        }
+
+        files.push(file);
+    }
+
+    graph_with_root(files, leaves)
 }
 
 fn delete_by_id_index(knowledge_dir: &Path) {

--- a/docs/design/knowledge-graph/1_overview.md
+++ b/docs/design/knowledge-graph/1_overview.md
@@ -59,10 +59,11 @@ Storage follows a git-style split:
 ├── objects/<hh>/<hash>.json     immutable, content-addressed node bodies
 ├── blobs/<hh>/<hash>.txt        immutable, content-addressed file/symbol source
 ├── index/by-id/<root-graph-hash>.json   immutable per-build index
+├── graph_index.sqlite           mutable secondary index for current fast reads
 └── refs/heads/<branch>.json     mutable branch ref → active index
 ```
 
-A rebuild writes new immutable objects/blobs and index, then atomically swings the branch ref. Refs are the only mutable surface, so concurrent builds on different worktrees cannot corrupt each other ([T20260421-0358]). See [specs/refs.md](./specs/refs.md).
+A rebuild writes new immutable objects/blobs and index, refreshes the SQLite sidecar for current fast reads, then atomically swings the branch ref. Refs are the only authoritative mutable pointer, so concurrent builds on different worktrees cannot corrupt each other ([T20260421-0358], [T20260509-70], [T20260509-72]). See [specs/refs.md](./specs/refs.md).
 
 ### 2.4 Working graph and write guards
 
@@ -81,10 +82,10 @@ The graph no longer stores task attribution. `[T...]` commit tags remain useful 
 | Concern | Where it lives | Primary task ID |
 |---------|----------------|-----------------|
 | Crate boundary | `crates/orbit-knowledge` | [T20260411-0008], [T20260411-0424] |
-| Storage layout | `src/graph/object_store.rs` | [T20260421-0358] |
+| Storage layout | `src/graph/object_store.rs`, `src/graph/sqlite_index.rs` | [T20260421-0358], [T20260509-70] |
 | Build pipeline | `src/pipeline/` | [T20260411-0424], [T20260417-0639], [T20260426-0139], [T20260509-33] |
 | Historical task attribution removal | `src/pipeline/` | [T20260506-11] |
-| Query services | `src/service/` | [T20260412-0645-2], [T20260412-0645-3] |
+| Query services | `src/service/`, `crates/orbit-tools/src/builtin/orbit/knowledge/` | [T20260412-0645-2], [T20260412-0645-3], [T20260509-72] |
 | Working graph | `src/working_graph/` | [T20260411-0424] |
 | Locking | `src/lock.rs` | [T20260411-0424], [T20260417-0301-2] |
 | Refresh safety | `src/pipeline/mod.rs` | [T20260417-0307], [T20260416-0719] |
@@ -109,5 +110,7 @@ The graph no longer stores task attribution. `[T...]` commit tags remain useful 
 - **[T20260506-11]** — Remove knowledge-graph task attribution; preserve task IDs as local commit-search keys.
 - **[T20260430-22]** — Compact the knowledge-graph design docs and remove duplicate top-level narrative.
 - **[T20260509-33]** — Skip symlinked directory entries during knowledge scanner traversal.
+- **[T20260509-70]** — Build the SQLite secondary index sidecar during graph persistence.
+- **[T20260509-72]** — Use the SQLite secondary index for current, unscoped `orbit.graph.overview` summary aggregation.
 
 Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.

--- a/docs/design/knowledge-graph/2_design.md
+++ b/docs/design/knowledge-graph/2_design.md
@@ -19,14 +19,14 @@ This document specifies the current knowledge graph: storage, build pipeline, qu
 │   ├── objects/<hh>/<hash>.json   immutable node bodies (dir / file / leaf)
 │   ├── blobs/<hh>/<hash>.txt      immutable source blobs
 │   ├── index/by-id/<root-graph-hash>.json   immutable per-build index
-│   ├── graph_index.sqlite         mutable SQLite secondary index for future fast reads
+│   ├── graph_index.sqlite         mutable SQLite secondary index for fast reads
 │   └── refs/heads/<branch>.json   mutable branch ref → active index
 └── working/<activity_id>/       (in memory today; see 3_vision.md §2.3)
 ```
 
 The split between immutable objects/blobs/index and mutable refs is deliberate. Rebuilds always write new immutable artifacts and then atomically rename a ref file; no object file is ever overwritten. This survives concurrent worktree rebuilds and interrupted writes ([T20260421-0358]).
 
-`graph/graph_index.sqlite` is a mutable secondary index written alongside the content-addressed graph ([T20260509-70]). Its `meta` table records `schema_version`, `created_at`, and the active `graph_ref` root hash; `node` contains one row per dir/file/leaf with lowercased name/location fields and stable selectors where unambiguous; `file_summary` stores one row per file with direct leaf-child count. Writes rebuild the SQLite schema/data in one WAL-backed transaction and insert `meta.graph_ref` last, so future readers can treat a missing or mismatched `graph_ref` as invalid. No read tool consumes this sidecar yet.
+`graph/graph_index.sqlite` is a mutable secondary index written alongside the content-addressed graph ([T20260509-70]). Its `meta` table records `schema_version`, `created_at`, and the active `graph_ref` root hash; `node` contains one row per dir/file/leaf with lowercased name/location fields, language, and stable selectors where unambiguous; `file_summary` stores one row per file with direct leaf-child count. Writes rebuild the SQLite schema/data in one WAL-backed transaction and insert `meta.graph_ref` last, so readers can treat a missing or mismatched `graph_ref` as invalid. Current read use is intentionally narrow: selector context and broad `overview` summaries can use the sidecar when it matches the resolved graph ref, while scoped overview summaries still fall back to the JSON/object path ([T20260509-72]).
 
 The legacy `refs/current.json` layout is migrated to `refs/heads/<default-branch>.json` on open; see [specs/refs.md](./specs/refs.md).
 
@@ -125,7 +125,7 @@ All tool inputs that reference a node accept a selector string.
 
 | Service | Entry point | Notable task |
 |---------|-------------|--------------|
-| Overview | `overview(prefix?)` | Compact mode above 50 files added in [T20260412-0645-2] |
+| Overview | `overview(prefix?)` | Compact mode above 50 files added in [T20260412-0645-2]; broad summaries use the SQLite sidecar when current ([T20260509-72]) |
 | Search | `search(query)` / `search_structured` | Source-regex and structured selector search |
 | Context | `bounded_context(selector, budget)` | — |
 | References | `find_references(selector)` | — |
@@ -260,9 +260,9 @@ The read cache is per `KnowledgeStore`, not global ([T20260426-0141]). Long-runn
 
 The scanner skips symlinked directories rather than trying to canonicalize and follow only in-workspace targets ([T20260509-33]). This is the safer default for agent indexing because it avoids outside-repo leakage and cycles, but a workspace that intentionally exposes source through symlinked directories must materialize those files or wait for an explicit, cycle-safe opt-in traversal policy.
 
-### 6.13 SQLite secondary index is write-only
+### 6.13 SQLite secondary index coverage is intentionally partial
 
-The `graph/graph_index.sqlite` sidecar exists to make future selector, name, and file-symbol-count reads sublinear, but current graph services still hydrate through the JSON by-id index and object store ([T20260509-70]). Until a read facade verifies `meta.graph_ref` against the resolved branch ref, this sidecar is an independently testable write-path artifact rather than a query source.
+The `graph/graph_index.sqlite` sidecar exists to make selector, name, and file-symbol-count reads sublinear ([T20260509-70]). Readers must verify `meta.graph_ref` against the resolved branch ref before trusting it; missing, stale, corrupt, or unsupported shapes fall back to the JSON by-id index and object store. As of [T20260509-72], broad `overview` summaries query aggregate counts and top files from SQLite, but scoped summaries still fall back so their output stays byte-for-byte aligned with the established prefix semantics.
 
 ---
 
@@ -297,5 +297,6 @@ The `graph/graph_index.sqlite` sidecar exists to make future selector, name, and
 - **[T20260509-33]** — Skip symlinked directories/files during knowledge scans and `.orbitignore` discovery to prevent outside-repo indexing and recursive cycles.
 - **[T20260509-65]** — Add `GraphReadOptions` so broad graph reads skip file/leaf source hydration unless a tool opts in.
 - **[T20260509-70]** — Build the write-only SQLite secondary index sidecar during graph persistence.
+- **[T20260509-72]** — Use the SQLite secondary index for current, unscoped `orbit.graph.overview` summary aggregation.
 
 Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.

--- a/docs/design/knowledge-graph/4_decisions.md
+++ b/docs/design/knowledge-graph/4_decisions.md
@@ -510,17 +510,18 @@ These entries were formerly ADR headings, but they are plain instances of ADR-00
 
 ## ADR-034 — SQLite sidecar for secondary graph indexes
 
-**Status:** Accepted · 2026-05 · [T20260509-70]
+**Status:** Accepted · 2026-05 · [T20260509-70], [T20260509-72]
 **Author:** gpt-5.5
 
 **Context.** Selector resolution, name search, and file-symbol counts still walk the hydrated graph or JSON by-id index. A JSON sidecar would keep persistence simple but would not provide efficient prefix/range lookup, partial indexes, or concurrent read/write behavior.
 
-**Decision.** Write a mutable SQLite sidecar at `graph/graph_index.sqlite` during `GraphObjectStore::write_graph`. The sidecar is rebuilt in a WAL-backed transaction with `meta`, `node`, and `file_summary` tables; `meta.graph_ref` stores the root graph hash and is inserted last so readers can reject missing or mismatched indexes. Existing graph reads do not consume the sidecar until a separate read facade lands.
+**Decision.** Write a mutable SQLite sidecar at `graph/graph_index.sqlite` during `GraphObjectStore::write_graph`. The sidecar is rebuilt in a WAL-backed transaction with `meta`, `node`, and `file_summary` tables; `meta.graph_ref` stores the root graph hash and is inserted last so readers can reject missing or mismatched indexes. Read paths may use the sidecar only after validating that graph ref; `overview` summary uses SQL aggregation for current, unscoped reads and falls back for scoped summaries so prefix semantics stay identical.
 
 **Consequences.**
 - Future read tasks can add SQL fast paths without changing the content-addressed object format.
 - Write-path validation can measure the index independently before read behavior depends on it.
 - Re-running the same graph preserves semantic meta/node contents, while a new root graph hash cleanly replaces prior rows.
+- Schema v3 stores node language because broad overview summaries must return the same language counts as the hydrated fallback.
 - Cost: graph persistence now pays an extra SQLite write per rebuild and `orbit-knowledge` directly depends on the workspace `rusqlite` dependency.
 
 ---
@@ -574,5 +575,6 @@ Tasks cited by ADRs above:
 - **[T20260509-65]** — Add `GraphReadOptions` so broad graph reads skip file/leaf source hydration unless a tool opts in.
 - **[T20260509-67]** — Bound default-ranking graph search candidate retention with named headroom and hard cap constants.
 - **[T20260509-70]** — Build the write-only SQLite secondary index sidecar during graph persistence.
+- **[T20260509-72]** — Use the SQLite secondary index for current, unscoped `orbit.graph.overview` summary aggregation.
 
 Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.


### PR DESCRIPTION
## Task

[T20260509-72](https://orbit-cli.com/tasks/T20260509-72) — Wire overview summary fast path through SQLite index

### Description

## Problem

`overview` summary today builds a full `GraphOverview` and walks every scoped file/leaf to compute counts and `top_files`, even though summary mode only returns aggregated numbers. After Phase 1 (lazy hydration) and Phase 2 (top-K heap) land, the remaining cost is the linear scan over node metadata. The SQLite index (T20260509-70) plus read facade (T20260509-71) make this an aggregation query.

## Why It Matters

Phase 3 of the graph-latency proposal ([raw/wiki/graph/perf_proposal_claude.md](raw/wiki/graph/perf_proposal_claude.md)). `overview` summary is the canonical broad-read tool — it should be the cheapest call in the toolbox. The latency budget commits to p99 50ms warm on a 100k-symbol corpus; this task is the path to meeting it.

## Implementation Notes

- In the overview tool entry point ([crates/orbit-tools/src/builtin/orbit/knowledge/overview.rs](crates/orbit-tools/src/builtin/orbit/knowledge/overview.rs)) and/or the service ([crates/orbit-knowledge/src/service/overview.rs](crates/orbit-knowledge/src/service/overview.rs)):

  1. Compute the expected graph ref (from manifest or service context).
  2. Call `GraphIndexReader::open(index_path, expected_ref)`.
  3. If `Some(reader)`: run aggregation queries against the SQLite index. Return the summary directly without hydrating any nodes.
  4. If `None`: fall back to the current implementation. Log at debug level so observability shows when fallback fires.

- Aggregation queries (illustrative):

  ```sql
  SELECT COUNT(*) FROM node WHERE node_type = 'leaf';
  SELECT COUNT(*) FROM node WHERE node_type = 'file';
  SELECT COUNT(*) FROM node WHERE node_type = 'dir';
  SELECT path, symbol_count
    FROM file_summary
    ORDER BY symbol_count DESC, path ASC
    LIMIT ?;
  ```

- Top-K via SQL avoids the in-memory heap entirely on this path (note: T20260509-68 already replaced the in-memory sort with a heap; that path remains as the fallback).
- Output payload must be byte-for-byte identical between the SQL fast path and the fallback path on the same fixture corpus. This is the single most important correctness invariant — verify with a snapshot test.
- If `overview` is invoked with a scope (e.g. a subdirectory), the SQL queries must filter by `location` prefix or by parent traversal. If implementing scope filtering blows up the query complexity, document and ship without scope support on the SQL path (fall back when a scope is set).

## Constraints / Notes

- Output equality with the fallback path is non-negotiable. A faster-but-different overview is a regression.
- Depends on T20260509-71 (read facade). Soft prerequisite: T20260509-66 (Phase 1 measurement) and Phase 2 measurement to confirm Phase 3 is still motivated; document the v3 numbers when running v4 measurement.
- Authoring model: claude-opus-4-7. Author: claude.

### Acceptance Criteria

- When the SQLite index is present and current, `overview` summary executes via SQL queries through `GraphIndexReader`. Verified by an instrumented test that asserts the SQL path was taken (e.g. via a counter or a feature flag the test can read).
- When the SQLite index is missing or stale, `overview` summary falls back to the existing implementation. Verified by deleting the index and re-running the same query.
- Output payloads from the SQL fast path and the fallback path are identical on a fixture corpus with at least 100 files and 1000 leaves. Verified by a snapshot or equality assertion test that runs both paths and asserts equality.
- If scope filtering is implemented on the SQL path, scoped overview output matches the fallback. If scope filtering falls back, the test corpus exercises that fallback.
- Latency observation: a microbenchmark or test timing the SQL path versus the fallback on a 10k-leaf fixture shows the SQL path is at least 5× faster on warm-cache reads. Record numbers in the execution summary.
- Existing overview integration tests pass without expected-output changes.
- `make build` and `make fmt` pass.
- `cargo test --workspace` passes.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Added SQLite overview aggregation methods to GraphIndexReader and bumped the graph_index.sqlite schema to v3 so file language counts are available without hydrating graph nodes.
- Wired orbit.graph.overview summary mode to use the current SQLite index for unscoped summary responses, with debug-logged fallback for missing/stale indexes, scoped prefixes, and full-output requests.
- Added integration coverage for SQL path usage, missing/stale fallback, SQL/fallback byte equality on a 120-file/1440-leaf fixture, scoped fallback equality, and the 10k-leaf latency observation.
- Updated knowledge-graph design docs and ADR-034 to describe the partial SQLite read coverage and overview summary fast path.

Strategic decisions:
- Scoped overview requests intentionally fall back instead of duplicating prefix semantics in SQL. | Rationale: output equality is the invariant, and scoped query complexity is not needed for the broad-summary latency target.

Validation:
- make fmt
- make build
- cargo test --workspace
- cargo test -p orbit-tools --test graph_tool_surface overview_summary -- --nocapture
- cargo test -p orbit-knowledge graph::object_store::tests::write_graph_creates_sqlite_index_schema_and_rows -- --nocapture
- Manual ignored microbenchmark: overview summary 10k leaves sql=18.469ms, fallback=1329.974ms, speedup=72.0x.

Assessment: The broad overview summary path now avoids graph hydration when the SQLite sidecar is current, while fallback behavior preserves existing payloads for unsupported or stale cases.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/T20260509-72-69ffaf51`
- Behind base: 0
- Ahead of base: 1

*authored by: claude-opus-4-7*