### PR TITLE
Wrap array MCP tool results in objects for strict MCP clients (Cursor, VS Code)

### DIFF
--- a/crates/orbit-mcp/src/adapter.rs
+++ b/crates/orbit-mcp/src/adapter.rs
@@ -82,6 +82,35 @@ impl OrbitToolServer {
         self.replace_name_map(map);
         Ok(resolved.unwrap_or_else(|| advertised.to_string()))
     }
+
+    async fn call_tool_request(
+        &self,
+        req: CallToolRequestParams,
+    ) -> Result<CallToolResult, McpError> {
+        let inbound = req.name.to_string();
+        let canonical = self
+            .canonical_name(&inbound)
+            .map_err(ToolNameCollision::into_mcp_error)?;
+        let input = req
+            .arguments
+            .map(Value::Object)
+            .unwrap_or_else(|| Value::Object(Map::new()));
+
+        let host = Arc::clone(&self.host);
+        let exec_name = canonical.clone();
+        let join = tokio::task::spawn_blocking(move || host.call_tool(&exec_name, input)).await;
+
+        match join {
+            Ok(Ok(value)) => Ok(CallToolResult::structured(mcp_structured_content(value))),
+            Ok(Err(orbit_err)) => Ok(tool_error_result(&orbit_err)),
+            Err(join_err) => {
+                let err = OrbitError::Execution(format!(
+                    "tool '{canonical}' worker panicked or was cancelled: {join_err}"
+                ));
+                Ok(tool_error_result(&err))
+            }
+        }
+    }
 }
 
 /// Sanitize an Orbit tool name into the character set MCP clients accept.
@@ -150,6 +179,16 @@ fn build_name_map(schemas: &[ToolSchema]) -> Result<HashMap<String, String>, Too
     Ok(map)
 }
 
+/// Keep MCP `structuredContent` object-shaped for clients that enforce record
+/// results (notably Cursor and VS Code), while preserving non-object payloads.
+fn mcp_structured_content(value: Value) -> Value {
+    match value {
+        Value::Object(_) => value,
+        Value::Array(items) => json!({ "items": items }),
+        value => json!({ "value": value }),
+    }
+}
+
 impl ServerHandler for OrbitToolServer {
     fn get_info(&self) -> ServerInfo {
         let implementation = Implementation::new("orbit-mcp", env!("CARGO_PKG_VERSION"));
@@ -181,29 +220,7 @@ impl ServerHandler for OrbitToolServer {
         req: CallToolRequestParams,
         _ctx: RequestContext<RoleServer>,
     ) -> Result<CallToolResult, McpError> {
-        let inbound = req.name.to_string();
-        let canonical = self
-            .canonical_name(&inbound)
-            .map_err(ToolNameCollision::into_mcp_error)?;
-        let input = req
-            .arguments
-            .map(Value::Object)
-            .unwrap_or_else(|| Value::Object(Map::new()));
-
-        let host = Arc::clone(&self.host);
-        let exec_name = canonical.clone();
-        let join = tokio::task::spawn_blocking(move || host.call_tool(&exec_name, input)).await;
-
-        match join {
-            Ok(Ok(value)) => Ok(CallToolResult::structured(value)),
-            Ok(Err(orbit_err)) => Ok(tool_error_result(&orbit_err)),
-            Err(join_err) => {
-                let err = OrbitError::Execution(format!(
-                    "tool '{canonical}' worker panicked or was cancelled: {join_err}"
-                ));
-                Ok(tool_error_result(&err))
-            }
-        }
+        self.call_tool_request(req).await
     }
 }
 
@@ -333,6 +350,7 @@ fn property_for(param_type: &str) -> Map<String, Value> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serde_json::json;
 
     fn param_with_type(name: &str, param_type: &str) -> ToolParam {
         ToolParam {
@@ -455,6 +473,56 @@ mod tests {
         assert_eq!(tool.name.as_ref(), "orbit_task_add");
     }
 
+    #[tokio::test]
+    async fn call_tool_wraps_affected_array_results_for_strict_mcp_clients() {
+        let affected_tools = [
+            "orbit.task.list",
+            "orbit.task.search",
+            "orbit.task.review_thread.list",
+        ];
+        let host = Arc::new(EchoArrayHost {
+            schemas: affected_tools
+                .iter()
+                .map(|name| tool_schema(name))
+                .collect(),
+        });
+        let server = OrbitToolServer::new(host);
+
+        for canonical_name in affected_tools {
+            let result = server
+                .call_tool_request(CallToolRequestParams::new(sanitize_tool_name(
+                    canonical_name,
+                )))
+                .await
+                .expect("MCP bridge call succeeds");
+            let structured = result
+                .structured_content
+                .as_ref()
+                .expect("structured content");
+
+            assert!(
+                structured.is_object(),
+                "{canonical_name} structuredContent must be object-shaped"
+            );
+            assert_eq!(
+                structured.get("items"),
+                Some(&json!([{ "tool": canonical_name }]))
+            );
+
+            let wire = serde_json::to_value(&result).expect("serialize CallToolResult");
+            assert!(
+                wire.get("structuredContent").is_some_and(Value::is_object),
+                "{canonical_name} serialized structuredContent must satisfy record validators"
+            );
+        }
+    }
+
+    #[test]
+    fn mcp_structured_content_preserves_existing_objects() {
+        let value = json!({ "ok": true });
+        assert_eq!(mcp_structured_content(value.clone()), value);
+    }
+
     struct StubHost {
         schemas: Vec<ToolSchema>,
     }
@@ -466,6 +534,20 @@ mod tests {
 
         fn call_tool(&self, _name: &str, _input: Value) -> Result<Value, OrbitError> {
             Ok(Value::Null)
+        }
+    }
+
+    struct EchoArrayHost {
+        schemas: Vec<ToolSchema>,
+    }
+
+    impl crate::McpHost for EchoArrayHost {
+        fn list_tool_schemas(&self) -> Vec<ToolSchema> {
+            self.schemas.clone()
+        }
+
+        fn call_tool(&self, name: &str, _input: Value) -> Result<Value, OrbitError> {
+            Ok(json!([{ "tool": name }]))
         }
     }
 


### PR DESCRIPTION
## Task

[T20260509-77](https://orbit-cli.com/tasks/T20260509-77) — Wrap array MCP tool results in objects for strict MCP clients (Cursor, VS Code)

### Description

## Problem

Some MCP clients validate tool `structuredContent` as a **JSON object (record)**. Three Orbit MCP task tools return a **top-level JSON array** from the server. Invocations fail with:

`Invalid input: expected record, received array`

Observed in **Cursor** and the same class of validation applies to **VS Code** MCP tooling (and any other host that requires object-shaped structured results).

Affected tools (verified 2026-05-09 in Cursor):

- `orbit_task_list`
- `orbit_task_search`
- `orbit_task_review_thread_list`

The underlying Orbit operations succeed; only the MCP response shape is incompatible with strict clients.

## Goal

Return a stable object wrapper (or equivalent) so these tools succeed across **Cursor, VS Code, and other MCP hosts** that require object-shaped structured content. Preserve the same data for CLI/other consumers if needed via a `items` (or `tasks` / `threads`) field, or align with existing patterns in other Orbit MCP tools.

## Scope notes

- Implementation likely lives in the Orbit MCP adapter / tool response mapping (e.g. `orbit-mcp` or wherever task MCP handlers serialize results).
- Add or extend tests so list/search/review thread list MCP responses are objects and deserialize cleanly.
- Verification: document or automate checks for at least one Cursor-style and one VS Code–style MCP client expectation where practical (e.g. unit/integration test on serialized shape; manual note in execution summary if host-specific E2E is out of scope).

### Acceptance Criteria

- Calling `orbit_task_list`, `orbit_task_search`, and `orbit_task_review_thread_list` through the MCP bridge returns JSON whose top-level value is an object (not a raw array), eliminating `expected record, received array` for strict MCP clients (including Cursor and VS Code MCP integrations).
- Automated test(s) cover the MCP response shape for at least these three tools (e.g. integration test against handler output or golden JSON).
- `make build` and `make fmt` pass.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Added MCP adapter normalization so successful structuredContent is always object-shaped: arrays become {"items": [...]}, scalars/null become {"value": ...}, and existing objects remain unchanged.
- Routed tools/call through a testable helper and covered orbit_task_list, orbit_task_search, and orbit_task_review_thread_list with serialized structuredContent object assertions.

Assessment: Focused MCP-only adapter change; CLI/runtime tool outputs remain unchanged while strict MCP clients receive record-shaped structured results.

Validation:
- cargo test -p orbit-mcp
- make fmt
- make build

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/T20260509-77-69ffb4fc`
- Behind base: 0
- Ahead of base: 1

*authored by: gpt-5.5*