### PR TITLE
step_failure_recovery invokes unavailable Gemini model

### DIFF
--- a/crates/orbit-core/assets/executors/gemini.yaml
+++ b/crates/orbit-core/assets/executors/gemini.yaml
@@ -16,6 +16,6 @@ spec:
   stdout_format: envelope
   sandbox: macos-sandbox-exec
   models:
-    strong: gemini-3.1-pro
-    weak: gemini-3-flash
+    strong: gemini-3.1-pro-preview
+    weak: gemini-3-flash-preview
   env: {}

--- a/crates/orbit-core/src/config/agent_detect.rs
+++ b/crates/orbit-core/src/config/agent_detect.rs
@@ -111,7 +111,7 @@ pub fn default_model_for(provider: &str) -> Option<&'static str> {
     match provider {
         "claude" => Some("claude-opus-4-7"),
         "codex" => Some("gpt-5.5"),
-        "gemini" => Some("gemini-3-pro"),
+        "gemini" => Some("gemini-3.1-pro-preview"),
         _ => None,
     }
 }
@@ -318,7 +318,7 @@ mod tests {
     fn model_registry_returns_expected_defaults() {
         assert_eq!(default_model_for("claude"), Some("claude-opus-4-7"));
         assert_eq!(default_model_for("codex"), Some("gpt-5.5"));
-        assert_eq!(default_model_for("gemini"), Some("gemini-3-pro"));
+        assert_eq!(default_model_for("gemini"), Some("gemini-3.1-pro-preview"));
         assert_eq!(default_model_for("ollama"), None);
         assert_eq!(default_model_for("unknown"), None);
     }

--- a/crates/orbit-core/src/runtime/engine/identity.rs
+++ b/crates/orbit-core/src/runtime/engine/identity.rs
@@ -21,10 +21,17 @@ impl OrbitRuntime {
             .ok()
             .flatten()
             .and_then(|def| {
-                Some(AgentModelPair::new(
-                    def.model_for_tier("strong")?.to_string(),
-                    def.model_for_tier("weak")?.to_string(),
-                ))
+                let orchestrator = normalize_configured_model_for_agent(
+                    agent_cli,
+                    def.model_for_tier("strong")?,
+                    true,
+                );
+                let helper = normalize_configured_model_for_agent(
+                    agent_cli,
+                    def.model_for_tier("weak")?,
+                    false,
+                );
+                Some(AgentModelPair::new(orchestrator, helper))
             })
             .or_else(|| resolve_agent_model_pair(agent_cli))
     }
@@ -134,9 +141,25 @@ fn matches_model_alias(family: &str, requested: &str, configured: &str, strong: 
                 || claude_cli_full_model_name(configured)
                     .is_some_and(|value| requested.eq_ignore_ascii_case(&value))
         }
-        ("gemini", true) => requested.eq_ignore_ascii_case("gemini-3.1-pro"),
+        ("gemini", true) => ["gemini-3.1-pro", "gemini-3-pro", "gemini-3-pro-preview"]
+            .iter()
+            .any(|alias| requested.eq_ignore_ascii_case(alias)),
         ("gemini", false) => requested.eq_ignore_ascii_case("gemini-3-flash"),
         _ => false,
+    }
+}
+
+fn normalize_configured_model_for_agent(agent_cli: &str, model: &str, strong: bool) -> String {
+    let family = agent_family_from_cli(agent_cli);
+    let trimmed = model.trim();
+    let lower = trimmed.to_ascii_lowercase();
+
+    match (family.as_str(), strong, lower.as_str()) {
+        ("gemini", true, "gemini-3.1-pro" | "gemini-3-pro" | "gemini-3-pro-preview") => {
+            "gemini-3.1-pro-preview".to_string()
+        }
+        ("gemini", false, "gemini-3-flash") => "gemini-3-flash-preview".to_string(),
+        _ => trimmed.to_string(),
     }
 }
 
@@ -149,4 +172,78 @@ fn claude_cli_full_model_name(model: &str) -> Option<String> {
         return Some(format!("claude-sonnet-{}", version.replace('.', "-")));
     }
     None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Utc;
+    use orbit_common::types::{ExecutorDef, ExecutorType};
+    use std::collections::HashMap;
+    use tempfile::{TempDir, tempdir};
+
+    fn test_runtime() -> (TempDir, OrbitRuntime) {
+        let root = tempdir().expect("tempdir");
+        let global = root.path().join("home/.orbit");
+        let workspace = root.path().join("repo/.orbit");
+        std::fs::create_dir_all(&global).expect("create global root");
+        std::fs::create_dir_all(&workspace).expect("create workspace root");
+        let runtime = OrbitRuntime::from_roots(&global, &workspace).expect("build runtime");
+        (root, runtime)
+    }
+
+    #[test]
+    fn gemini_defaults_use_current_preview_model_ids() {
+        let (_root, runtime) = test_runtime();
+
+        let pair = runtime
+            .configured_agent_model_pair("gemini")
+            .expect("gemini pair");
+
+        assert_eq!(pair.orchestrator, "gemini-3.1-pro-preview");
+        assert_eq!(pair.helper, "gemini-3-flash-preview");
+    }
+
+    #[test]
+    fn stale_gemini_executor_models_are_canonicalized() {
+        let (_root, runtime) = test_runtime();
+        let now = Utc::now();
+        runtime
+            .upsert_executor_def(&ExecutorDef {
+                name: "gemini".to_string(),
+                executor_type: ExecutorType::DirectAgent,
+                command: Some("gemini".to_string()),
+                args: Vec::new(),
+                stdout_format: None,
+                models: HashMap::from([
+                    ("strong".to_string(), "gemini-3.1-pro".to_string()),
+                    ("weak".to_string(), "gemini-3-flash".to_string()),
+                ]),
+                timeout_seconds: None,
+                env: HashMap::new(),
+                sandbox: None,
+                allow_fallback: false,
+                created_at: now,
+                updated_at: now,
+            })
+            .expect("seed stale executor");
+
+        let pair = runtime
+            .configured_agent_model_pair("gemini")
+            .expect("gemini pair");
+        assert_eq!(pair.orchestrator, "gemini-3.1-pro-preview");
+        assert_eq!(pair.helper, "gemini-3-flash-preview");
+        assert_eq!(
+            runtime.canonical_model_for_agent("gemini", Some("gemini-3.1-pro")),
+            Some("gemini-3.1-pro-preview".to_string())
+        );
+        assert_eq!(
+            runtime.canonical_model_for_agent("gemini", Some("gemini-3-pro")),
+            Some("gemini-3.1-pro-preview".to_string())
+        );
+        assert_eq!(
+            runtime.canonical_model_for_agent("gemini", Some("weak")),
+            Some("gemini-3-flash-preview".to_string())
+        );
+    }
 }

--- a/crates/orbit-core/src/runtime/v2_host/mod.rs
+++ b/crates/orbit-core/src/runtime/v2_host/mod.rs
@@ -49,6 +49,10 @@ impl V2RuntimeHost for OrbitRuntime {
         cli_executor::resolve_cli_executor(self, provider)
     }
 
+    fn canonical_model_name(&self, provider: &str, model: Option<&str>) -> Option<String> {
+        self.canonical_model_for_agent(provider, model)
+    }
+
     fn provider_cli_config(&self, _provider: &str) -> HashMap<String, String> {
         EnvironmentHost::agent_provider_config(self)
     }

--- a/crates/orbit-engine/src/activity_job/cli_runner/orchestrator.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/orchestrator.rs
@@ -33,11 +33,14 @@ pub fn run_cli_backend(
     fs_profile: Option<&str>,
 ) -> Result<DispatchOutcome, DispatchError> {
     let provider = spec.provider.as_str().to_string();
+    let canonical_model = host.canonical_model_name(&provider, spec.model.as_deref());
+    let mut dispatch_spec = spec.clone();
+    dispatch_spec.model = canonical_model;
     let mut cli_executor = host.resolve_cli_executor(&provider)?;
-    let timeout_seconds = if spec.wall_clock_timeout_seconds == 0 {
+    let timeout_seconds = if dispatch_spec.wall_clock_timeout_seconds == 0 {
         DEFAULT_WALL_CLOCK_TIMEOUT_SECONDS
     } else {
-        spec.wall_clock_timeout_seconds
+        dispatch_spec.wall_clock_timeout_seconds
     };
     let wall_clock_timeout = Duration::from_secs(timeout_seconds);
 
@@ -45,7 +48,7 @@ pub fn run_cli_backend(
     // subprocess starts so a reviewer can see the enforcement gap at a glance.
     let _ = audit.emit(V2AuditEventKind::ToolAllowlistHarnessDelegated {
         provider: provider.clone(),
-        tools: spec.tools.clone(),
+        tools: dispatch_spec.tools.clone(),
     });
 
     let task_ctx = host.task_context_for_agent_input(input)?;
@@ -62,7 +65,7 @@ pub fn run_cli_backend(
     let sandbox =
         host.resolve_executor_sandbox(&provider, fs_profile, subprocess_cwd.as_deref())?;
 
-    let envelope_json = cli_agent_envelope_json(spec, run_id, input, task_ctx.as_ref())?;
+    let envelope_json = cli_agent_envelope_json(&dispatch_spec, run_id, input, task_ctx.as_ref())?;
 
     let mut provider_config = host.provider_cli_config(&provider);
 
@@ -87,7 +90,7 @@ pub fn run_cli_backend(
 
     let config = AgentConfig::from_cli_config(
         cli_executor.command.clone(),
-        spec.model.as_deref(),
+        dispatch_spec.model.as_deref(),
         &provider_config,
     )
     .map_err(|err| DispatchError::CliInvocationFailed(format!("agent config: {err}")))?;

--- a/crates/orbit-engine/src/activity_job/cli_runner/tests/orchestrator_macos_tests.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/tests/orchestrator_macos_tests.rs
@@ -172,7 +172,7 @@ fn run_cli_backend_drops_gemini_sandbox_flag_under_outer_wrapper() {
     let sink_for_writer: Arc<dyn AuditSink> = sink;
     let audit = Arc::new(V2AuditWriter::new(
         "job-gemini-drop",
-        "gemini:gemini-3.1-pro",
+        "gemini:gemini-3.1-pro-preview",
         sink_for_writer,
     ));
     let host = TestHost {

--- a/crates/orbit-engine/src/activity_job/cli_runner/tests/orchestrator_tests.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/tests/orchestrator_tests.rs
@@ -73,6 +73,55 @@ fn run_cli_backend_finished_audit_event_keeps_stdout_stderr_blob_refs() {
 }
 
 #[test]
+fn run_cli_backend_canonicalizes_model_before_invocation() {
+    let temp = tempdir().expect("tempdir");
+    let script = temp.path().join("codex");
+    write_executable(
+        &script,
+        "#!/bin/sh\ncat > /dev/null\nprintf '%s\\n' '{\"status\":\"ok\"}'\n",
+    );
+
+    let sink = Arc::new(RecordingSink::default());
+    let sink_for_writer: Arc<dyn AuditSink> = sink;
+    let audit = Arc::new(V2AuditWriter::new(
+        "job-canonical-model",
+        "codex:canonical-model",
+        sink_for_writer,
+    ));
+    let host = TestHost::with_command(script.display().to_string());
+    let mut spec = test_agent_loop_spec(Duration::from_secs(5));
+    spec.model = Some("legacy-model".to_string());
+
+    let outcome = run_cli_backend(
+        &host,
+        &spec,
+        "job-canonical-model",
+        audit.clone(),
+        &serde_json::json!({"prompt": "hi"}),
+        None,
+    )
+    .expect("run succeeds");
+
+    assert!(outcome.success);
+    let events = audit.events_snapshot().expect("events snapshot");
+    let (argv, model) = events
+        .iter()
+        .find_map(|event| match &event.kind {
+            V2AuditEventKind::CliInvocationStarted {
+                argv_redacted,
+                model,
+                ..
+            } => Some((argv_redacted, model.as_deref())),
+            _ => None,
+        })
+        .expect("started event");
+
+    assert_eq!(model, Some("canonical-model"));
+    assert!(argv.iter().any(|arg| arg == "canonical-model"));
+    assert!(!argv.iter().any(|arg| arg == "legacy-model"));
+}
+
+#[test]
 fn run_cli_backend_bounds_stdout_text_preview_and_keeps_envelope_status_from_full_stdout() {
     let temp = tempdir().expect("tempdir");
     let script = temp.path().join("codex");

--- a/crates/orbit-engine/src/activity_job/cli_runner/tests/test_support.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/tests/test_support.rs
@@ -272,6 +272,14 @@ impl V2RuntimeHost for TestHost {
         })
     }
 
+    fn canonical_model_name(&self, _provider: &str, model: Option<&str>) -> Option<String> {
+        match model {
+            Some("legacy-model") => Some("canonical-model".to_string()),
+            Some(model) => Some(model.to_string()),
+            None => None,
+        }
+    }
+
     fn provider_cli_config(&self, _provider: &str) -> HashMap<String, String> {
         self.provider_config.clone()
     }

--- a/crates/orbit-engine/src/activity_job/dispatcher.rs
+++ b/crates/orbit-engine/src/activity_job/dispatcher.rs
@@ -77,6 +77,15 @@ pub trait V2RuntimeHost: Send + Sync {
     /// CLI mapping (e.g. `openai_compat` which is HTTP-only).
     fn resolve_cli_executor(&self, provider: &str) -> Result<ResolvedCliExecutor, DispatchError>;
 
+    /// Canonicalize a provider-specific model name before dispatch.
+    ///
+    /// The core host resolves tier aliases and compatibility renames against
+    /// the active executor registry. Test hosts and embedders that do not
+    /// model runtime executor state can rely on the passthrough default.
+    fn canonical_model_name(&self, _provider: &str, model: Option<&str>) -> Option<String> {
+        model.map(ToOwned::to_owned)
+    }
+
     /// Return provider-specific CLI runtime config for `backend: cli`.
     ///
     /// Most providers ignore this today. Codex uses it for sandbox,

--- a/crates/orbit-engine/src/activity_job/job_executor/tests/recovery_tests.rs
+++ b/crates/orbit-engine/src/activity_job/job_executor/tests/recovery_tests.rs
@@ -178,7 +178,7 @@ fn recovery_agent_loop_uses_reviewer_role_config() {
         AgentRole::Reviewer,
         AgentRoleConfig {
             provider: Some(Provider::Gemini),
-            model: Some("gemini-3.1-pro".to_string()),
+            model: Some("gemini-3.1-pro-preview".to_string()),
             backend: Some(Backend::Cli),
         },
     );
@@ -198,7 +198,7 @@ fn recovery_agent_loop_uses_reviewer_role_config() {
         panic!("expected agent_loop recovery spec");
     };
     assert_eq!(spec.provider, Provider::Gemini);
-    assert_eq!(spec.model.as_deref(), Some("gemini-3.1-pro"));
+    assert_eq!(spec.model.as_deref(), Some("gemini-3.1-pro-preview"));
     assert_eq!(spec.backend, Backend::Cli);
     assert_eq!(host.observed_role_lookups(), vec![AgentRole::Reviewer]);
 }

--- a/crates/orbit-engine/src/executor/automation/duel/planning_duel/artifacts.rs
+++ b/crates/orbit-engine/src/executor/automation/duel/planning_duel/artifacts.rs
@@ -517,7 +517,7 @@ mod tests {
             },
             arbiter: PlanningRoleAssignment {
                 agent: "gemini".to_string(),
-                model: "gemini-3.1-pro".to_string(),
+                model: "gemini-3.1-pro-preview".to_string(),
             },
         }
     }
@@ -561,7 +561,7 @@ mod tests {
             "planning-duel/claude-claude-opus-4-7.md"
         );
         assert_eq!(winner.arbiter_agent_cli, "gemini");
-        assert_eq!(winner.arbiter_model, "gemini-3.1-pro");
+        assert_eq!(winner.arbiter_model, "gemini-3.1-pro-preview");
         assert_eq!(
             winner.arbiter_rationale,
             "Claude provided a more comprehensive diagnosis."
@@ -586,7 +586,7 @@ mod tests {
 
         assert!(
             message.contains(
-                "winner artifact arbiter codex/gpt-5.5 does not match recorded arbiter gemini/gemini-3.1-pro"
+                "winner artifact arbiter codex/gpt-5.5 does not match recorded arbiter gemini/gemini-3.1-pro-preview"
             ),
             "{message}"
         );
@@ -620,7 +620,7 @@ mod tests {
             "winner_model": "claude-opus-4-7",
             "artifact_path": "planning-duel/claude-claude-opus-4-7.md",
             "arbiter_agent_cli": "gemini",
-            "arbiter_model": "gemini-3.1-pro",
+            "arbiter_model": "gemini-3.1-pro-preview",
             "arbiter_rationale": "Claude provided a more comprehensive diagnosis."
         }));
 
@@ -634,6 +634,6 @@ mod tests {
             "planning-duel/claude-claude-opus-4-7.md"
         );
         assert_eq!(winner.arbiter_agent_cli, "gemini");
-        assert_eq!(winner.arbiter_model, "gemini-3.1-pro");
+        assert_eq!(winner.arbiter_model, "gemini-3.1-pro-preview");
     }
 }

--- a/crates/orbit-engine/src/executor/automation/duel/planning_duel/runner.rs
+++ b/crates/orbit-engine/src/executor/automation/duel/planning_duel/runner.rs
@@ -600,7 +600,7 @@ mod tests {
                 "planning_duel_roles": {
                     "planner_a": { "agent": "codex", "model": "gpt-5.5" },
                     "planner_b": { "agent": "claude", "model": "claude-opus-4-7" },
-                    "arbiter":   { "agent": "gemini", "model": "gemini-3.1-pro" }
+                    "arbiter":   { "agent": "gemini", "model": "gemini-3.1-pro-preview" }
                 }
             }),
         )

--- a/crates/orbit-engine/src/executor/automation/vcs/commit/mod.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/commit/mod.rs
@@ -495,7 +495,7 @@ mod tests {
     fn git_commit_uses_scoped_identity_without_mutating_local_human_config() {
         let cases = [
             ("claude-opus-4-7", "claude <claude@orbit.local>"),
-            ("gemini-3.1-pro", "gemini <gemini@orbit.local>"),
+            ("gemini-3.1-pro-preview", "gemini <gemini@orbit.local>"),
             ("gpt-5.5", "codex <codex@openai.com>"),
         ];
 
@@ -612,7 +612,12 @@ mod tests {
 
         let tasks = vec![
             task_with_file("T1", "Claude task", "src/claude.txt", "claude-opus-4-7"),
-            task_with_file("T2", "Gemini task", "src/gemini.txt", "gemini-3.1-pro"),
+            task_with_file(
+                "T2",
+                "Gemini task",
+                "src/gemini.txt",
+                "gemini-3.1-pro-preview",
+            ),
         ];
         let host = CommitTestHost::new(tasks, workspace.to_path_buf());
         let input = json!({

--- a/docs/design/activity-job/2_design.md
+++ b/docs/design/activity-job/2_design.md
@@ -2,7 +2,7 @@
 
 **Status:** Draft
 **Owner:** codex
-**Last updated:** 2026-05-09 (T20260427-34, T20260427-36, T20260427-38, T20260427-40, T20260508-3, T20260508-8, T20260509-2, T20260509-7, T20260509-9, T20260509-11, T20260509-30, T20260509-38, T20260509-40)
+**Last updated:** 2026-05-09 (T20260427-34, T20260427-36, T20260427-38, T20260427-40, T20260508-3, T20260508-8, T20260509-2, T20260509-7, T20260509-9, T20260509-11, T20260509-30, T20260509-38, T20260509-40, T20260509-80)
 
 This document describes the shipped Activity / Job substrate across `orbit-common`, `orbit-engine`, `orbit-core`, and `orbit-cli`: asset shape, normalization, dispatch boundaries, backend semantics, DAG execution, audit, and retained legacy edges. See [1_overview.md](./1_overview.md) for purpose and [3_vision.md](./3_vision.md) for open questions.
 
@@ -163,6 +163,7 @@ Activity / Job is where orbit-core hands work to orbit-engine without depending 
 - run a deterministic action by name
 - source an API key for a provider
 - resolve a provider's CLI executor command plus static args
+- canonicalize a provider/model pair before CLI dispatch
 - build `ToolContext` for an activity, including policy, filesystem audit hooks, and trusted reservation-owner context from the active run id
 - persist invocation traces for completed agent-loop work
 
@@ -201,20 +202,23 @@ After [T20260426-0526], completed HTTP loop outcomes become `InvocationTrace` re
 The CLI path is driven by `cli_runner.rs`, added in [T20260419-0104]. The flow is:
 
 1. Ask the host for the concrete CLI executor: command plus static executor args.
-2. Build an `Agent` from `orbit-agent`.
-3. Ask the retained CLI runtime for an `AgentInvocationSpec` containing provider-specific per-request args.
-4. Emit the advisory `ToolAllowlistHarnessDelegated` event.
-5. Resolve the subprocess cwd from runtime-owned workspace context.
-6. Emit `CliInvocationStarted` with redacted argv, stdin blob ref, and resolved cwd.
-7. Spawn the subprocess in that cwd with a wall-clock timeout.
-8. Emit `CliInvocationFinished` with stdout/stderr blob refs and timeout state.
-9. Parse the captured provider output with the existing Orbit response parser and persist its `InvocationTrace` through the host.
+2. Ask the host to canonicalize the authored provider/model pair.
+3. Build an `Agent` from `orbit-agent`.
+4. Ask the retained CLI runtime for an `AgentInvocationSpec` containing provider-specific per-request args.
+5. Emit the advisory `ToolAllowlistHarnessDelegated` event.
+6. Resolve the subprocess cwd from runtime-owned workspace context.
+7. Emit `CliInvocationStarted` with redacted argv, stdin blob ref, and resolved cwd.
+8. Spawn the subprocess in that cwd with a wall-clock timeout.
+9. Emit `CliInvocationFinished` with stdout/stderr blob refs and timeout state.
+10. Parse the captured provider output with the existing Orbit response parser and persist its `InvocationTrace` through the host.
 
 After [T20260426-2313], stdout/stderr readers emit line-level `tracing::info!` events while the child runs, carrying `provider`, `stream`, `job_run_id`, `task_id`, and `line`. After [T20260508-8], those events also carry `cwd` when the CLI subprocess has a resolved cwd. After [T20260426-2349], the default tracing subscriber redacts formatted output. The readers still retain original bytes for the existing audit/blob path, so run logs follow blob refs rather than the live feed.
 
 Executor args are prepended before provider runtime args. For seeded Codex, the subprocess starts as `codex exec --json ...`, not the interactive TUI. [T20260423-0114] exposed the earlier command-only boundary.
 
 After [T20260427-48], provider runtime args receive provider config through `V2RuntimeHost`. Static executor definitions keep command-shape flags (`exec --json`); dynamic Codex settings such as sandbox mode, side-write roots, and approval policy stay in the retained provider runtime. Codex approval policy is an exec-compatible config override, not the interactive-only `--ask-for-approval` flag.
+
+After [T20260509-80], `backend: cli` canonicalizes the activity's provider/model through the runtime before building the provider invocation or CLI stdin envelope. The host resolves tier aliases and compatibility renames against the active executor registry; notably, stale Gemini `gemini-3.1-pro` / `gemini-3-flash` settings normalize to the seeded `gemini-3.1-pro-preview` / `gemini-3-flash-preview` IDs so recovery hooks do not fail before attempting recovery.
 
 After [T20260427-51], macOS CLI invocations declaring `sandbox: macos-sandbox-exec` run under `/usr/bin/sandbox-exec -f <profile.sb> <provider> ...`; [T20260509-30] made that wrapper resolution trusted and absolute instead of `PATH`-based. Orbit treats that SBPL profile as filesystem authority and neutralizes provider-native sandbox flags. After [T20260428-10], the profile grants Codex state (`$CODEX_HOME` or `$HOME/.codex`) plus side-write roots from provider config so inherited Orbit subprocesses can persist workflow state while project writes remain governed by `fsProfile`. After [T20260505-22], dispatch also runs `apply_provider_static_arg_fixups` before spawn, separately from sandbox neutralization. Today this only rewrites Claude's `--debug-file` value to `<claude_state_dir>/<basename>` so the log lands inside the already-writable state dir instead of `.orbit/**`, which the default policy denies.
 
@@ -535,5 +539,6 @@ Read-only history does not need the same dependencies as live execution. [T20260
 - **[T20260509-30]** — Resolve the macOS `sandbox-exec` wrapper from a trusted absolute path before CLI spawn.
 - **[T20260509-38]** — Run legacy parallel-batch workers through cancellable pipeline runs so timeout failure paths return promptly.
 - **[T20260509-40]** — Run CLI subprocesses in killable process groups and bound timeout-path output reader joins.
+- **[T20260509-80]** — Canonicalize stale Gemini model IDs before CLI recovery dispatch.
 
 > Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.

--- a/docs/design/activity-job/4_decisions.md
+++ b/docs/design/activity-job/4_decisions.md
@@ -2,7 +2,7 @@
 
 **Status:** Draft
 **Owner:** codex
-**Last updated:** 2026-05-09 (T20260427-34, T20260427-36, T20260427-38, T20260427-40, T20260508-3, T20260508-8, T20260509-2, T20260509-7, T20260509-9, T20260509-11, T20260509-38, T20260509-40)
+**Last updated:** 2026-05-09 (T20260427-34, T20260427-36, T20260427-38, T20260427-40, T20260508-3, T20260508-8, T20260509-2, T20260509-7, T20260509-9, T20260509-11, T20260509-38, T20260509-40, T20260509-80)
 
 This ADR log records the decisions that define the current Activity / Job substrate. Entries are append-only and stay in place when later ADRs supersede or fold them. See [1_overview.md](./1_overview.md) for the feature summary, [2_design.md](./2_design.md) for the current implementation, and [3_vision.md](./3_vision.md) for the questions that may force more decisions.
 
@@ -525,6 +525,19 @@ The plumbing adds a single optional field to `TaskAutomationUpdate` (`context_fi
 - Timed-out child work gets the same run-cancellation path operators use elsewhere, including bounded process-group signaling for running pipeline workers.
 - Cost: the retained legacy path now depends on the v2 pipeline tool surface and polls active workers, so completion can lag by the polling interval rather than waking on an in-process channel send.
 
+## ADR-052 — CLI dispatch canonicalizes provider model IDs
+
+**Status:** Accepted · 2026-05 · [T20260509-80]
+
+**Context.** Step-failure recovery reuses the configured reviewer role. When a workspace or seeded executor carried the non-preview Gemini `gemini-3.1-pro` model ID, the recovery activity reached `backend: cli`, launched Gemini with `-m gemini-3.1-pro`, and failed with `ModelNotFoundError` before it could attempt the bounded repair.
+
+**Decision.** Add a `V2RuntimeHost::canonical_model_name` hook and run it before backend: cli builds the provider invocation or stdin envelope. orbit-core resolves tier aliases and compatibility renames through the same executor-aware model registry used by other runtime identity surfaces. Gemini's seeded pair is `gemini-3.1-pro-preview` / `gemini-3-flash-preview`; stale `gemini-3.1-pro`, `gemini-3-pro`, `gemini-3-pro-preview`, and `gemini-3-flash` values are accepted as aliases that canonicalize to the seeded pair.
+
+**Consequences.**
+- Recovery hooks inherit role configuration without being hostage to stale Gemini model spellings.
+- CLI audit events and invocation traces record the canonical model that actually ran.
+- Cost: `V2RuntimeHost` now owns one more model-resolution hook, so custom test hosts that need non-passthrough behavior must opt into it explicitly.
+
 ---
 
 ## Task References
@@ -592,5 +605,6 @@ The plumbing adds a single optional field to `TaskAutomationUpdate` (`context_fi
 - **[T20260509-11]** — Keep condition guards on equality-only grammar and repair the `ship-auto` empty-backlog guard.
 - **[T20260509-38]** — Run legacy parallel-batch workers through cancellable pipeline runs so timeout failure paths return promptly.
 - **[T20260509-40]** — Run CLI subprocesses in killable process groups and bound timeout-path output reader joins.
+- **[T20260509-80]** — Canonicalize stale Gemini model IDs before CLI recovery dispatch.
 
 > Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.


### PR DESCRIPTION
## Task

[T20260509-80](https://orbit-cli.com/tasks/T20260509-80) — step_failure_recovery invokes unavailable Gemini model

### Description

While investigating jrun-20260509-2204-7, the pr_open recovery activity launched Gemini with model gemini-3.1-pro and failed immediately with ModelNotFoundError / Requested entity was not found. The original recoverable-looking PR freshness failure therefore could not get an automated recovery attempt. Relevant audit file: .orbit/state/audit/v2_loop/jrun-20260509-2204-7.jsonl events 25-30; stderr blob 0ec855ad2c5f273d2d99429caab8faa27d5ff9937f32366c35ae44c7414a2987.

### Acceptance Criteria



## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Canonicalized backend: cli model dispatch through V2RuntimeHost before building provider args and CLI envelopes.
- Updated Gemini seeded/default model pairs to gemini-3.1-pro-preview / gemini-3-flash-preview and added aliases for stale gemini-3.1-pro, gemini-3-pro, gemini-3-pro-preview, and gemini-3-flash values.
- Added regression tests for stale Gemini executor normalization and canonical CLI audit argv, and updated Activity / Job design docs with ADR-052.

Assessment: Focused fix validated with targeted unit tests, make fmt, and make build.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/T20260509-80-69ffb629`
- Behind base: 0
- Ahead of base: 1

*authored by: gpt-5.5*