### PR TITLE
Add SQLite read facade with version check and fallback

### DIFF
--- a/crates/orbit-knowledge/src/graph/sqlite_index.rs
+++ b/crates/orbit-knowledge/src/graph/sqlite_index.rs
@@ -1,3 +1,10 @@
+//! Read-only access to the SQLite graph secondary index.
+//!
+//! `GraphIndexReader::open` returns `Ok(None)` when the index is absent or
+//! stale for the requested graph ref/schema version. That is the
+//! graceful-fallback signal: callers must use the existing object-store graph
+//! read path when they receive `None`.
+
 use std::collections::{BTreeMap, HashMap};
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -39,9 +46,9 @@ pub struct GraphIndexReader {
 }
 
 impl GraphIndexReader {
-    pub fn open_current(
+    pub fn open(
         path: impl AsRef<Path>,
-        graph_ref: &str,
+        expected_ref: &str,
     ) -> Result<Option<Self>, KnowledgeError> {
         let path = path.as_ref();
         if !path.is_file() {
@@ -59,7 +66,7 @@ impl GraphIndexReader {
         if query_meta(&conn, "schema_version")?.as_deref() != Some(expected_schema.as_str()) {
             return Ok(None);
         }
-        if query_meta(&conn, "graph_ref")?.as_deref() != Some(graph_ref) {
+        if query_meta(&conn, "graph_ref")?.as_deref() != Some(expected_ref) {
             return Ok(None);
         }
 
@@ -67,6 +74,21 @@ impl GraphIndexReader {
             conn,
             path: path.to_path_buf(),
         }))
+    }
+
+    pub fn open_current(
+        path: impl AsRef<Path>,
+        graph_ref: &str,
+    ) -> Result<Option<Self>, KnowledgeError> {
+        Self::open(path, graph_ref)
+    }
+
+    pub fn count_nodes(&self) -> Result<u64, KnowledgeError> {
+        let count: i64 = self
+            .conn
+            .query_row("SELECT COUNT(*) FROM node", [], |row| row.get(0))
+            .map_err(|error| sqlite_error(&self.path, "query graph sqlite node count", error))?;
+        u64_from_i64(&self.path, "node count", count)
     }
 
     pub fn find_node_by_selector(
@@ -703,6 +725,15 @@ fn usize_from_i64(path: &Path, label: &str, value: i64) -> Result<usize, Knowled
     })
 }
 
+fn u64_from_i64(path: &Path, label: &str, value: i64) -> Result<u64, KnowledgeError> {
+    u64::try_from(value).map_err(|_| {
+        KnowledgeError::invalid_data(format!(
+            "graph sqlite index {} returned invalid {label} `{value}`",
+            path.display()
+        ))
+    })
+}
+
 fn graph_index_node_from_row(row: &Row<'_>) -> rusqlite::Result<GraphIndexNodeRow> {
     Ok(GraphIndexNodeRow {
         id: row.get(0)?,
@@ -842,4 +873,157 @@ fn leaf_selector(base: &BaseNodeFields, kind: &LeafKind) -> String {
 
 fn sqlite_error(path: &Path, action: &str, error: rusqlite::Error) -> KnowledgeError {
     KnowledgeError::knowledge_unavailable(format!("{action} {}: {error}", path.display()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::nodes::{
+        BaseNodeFields, CodebaseGraphV1, DirNode, FileNode, LeafKind, LeafNode,
+    };
+    use super::super::object_store::GraphObjectStore;
+    use super::*;
+
+    #[test]
+    fn open_missing_index_returns_none() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let path = temp_dir.path().join("missing.sqlite");
+
+        let reader = GraphIndexReader::open(&path, "graph-a").expect("open missing");
+
+        assert!(reader.is_none());
+    }
+
+    #[test]
+    fn open_stale_ref_returns_none() {
+        let (_temp_dir, store, current_ref) = write_fixture_index();
+
+        let reader = GraphIndexReader::open(store.graph_sqlite_index_path(), "different-ref")
+            .expect("open stale ref");
+
+        assert!(reader.is_none());
+        assert_ne!(current_ref.root_graph_hash, "different-ref");
+    }
+
+    #[test]
+    fn open_stale_schema_returns_none() {
+        let (_temp_dir, store, current_ref) = write_fixture_index();
+        let index_path = store.graph_sqlite_index_path();
+        let conn = Connection::open(&index_path).expect("open sqlite index for schema update");
+        conn.execute(
+            "UPDATE meta SET value = ?1 WHERE key = 'schema_version'",
+            [GRAPH_SQLITE_INDEX_SCHEMA_VERSION
+                .saturating_sub(1)
+                .to_string()],
+        )
+        .expect("update schema version");
+        drop(conn);
+
+        let reader =
+            GraphIndexReader::open(&index_path, &current_ref.root_graph_hash).expect("open index");
+
+        assert!(reader.is_none());
+    }
+
+    #[test]
+    fn open_valid_index_counts_nodes_like_node_table() {
+        let (_temp_dir, store, current_ref) = write_fixture_index();
+        let index_path = store.graph_sqlite_index_path();
+        let conn = Connection::open(&index_path).expect("open sqlite index");
+        let expected_count: u64 = conn
+            .query_row("SELECT COUNT(*) FROM node", [], |row| row.get::<_, i64>(0))
+            .expect("count nodes")
+            .try_into()
+            .expect("node count is non-negative");
+        drop(conn);
+
+        let reader = GraphIndexReader::open(&index_path, &current_ref.root_graph_hash)
+            .expect("open index")
+            .expect("valid current index");
+
+        assert_eq!(
+            reader.count_nodes().expect("count reader nodes"),
+            expected_count
+        );
+    }
+
+    #[test]
+    fn open_valid_index_uses_read_only_connection() {
+        let (_temp_dir, store, current_ref) = write_fixture_index();
+        let reader = GraphIndexReader::open(
+            store.graph_sqlite_index_path(),
+            &current_ref.root_graph_hash,
+        )
+        .expect("open index")
+        .expect("valid current index");
+
+        let write_result = reader.conn.execute(
+            "INSERT INTO meta (key, value) VALUES ('read_only_test', 'should_fail')",
+            [],
+        );
+
+        assert!(write_result.is_err());
+    }
+
+    fn write_fixture_index() -> (
+        tempfile::TempDir,
+        GraphObjectStore,
+        super::super::object_store::CurrentRef,
+    ) {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let store = GraphObjectStore::new(temp_dir.path());
+        let current_ref = store.write_graph(&fixture_graph()).expect("write graph");
+        (temp_dir, store, current_ref)
+    }
+
+    fn fixture_graph() -> CodebaseGraphV1 {
+        CodebaseGraphV1 {
+            root_dir_id: "dir-root".to_string(),
+            dirs: vec![DirNode {
+                base: base_node("dir-root", ".", "./", None),
+                dir_children: Vec::new(),
+                file_children: vec!["file-lib".to_string()],
+            }],
+            files: vec![FileNode {
+                base: base_node("file-lib", "Lib.rs", "src/Lib.rs", Some("dir-root")),
+                extension: Some("rs".to_string()),
+                source_blob_hash: None,
+                source: "pub fn greet() { helper(); }\n".to_string(),
+                imports: Vec::new(),
+                exports: vec!["greet".to_string()],
+                re_exports: Vec::new(),
+                leaf_children: vec!["leaf-greet".to_string()],
+            }],
+            leaves: vec![LeafNode {
+                base: base_node("leaf-greet", "Greet", "src/Lib.rs#Greet", Some("file-lib")),
+                kind: LeafKind::Function,
+                source: "pub fn greet() { helper(); }\n".to_string(),
+                source_blob_hash: None,
+                source_hash: Some("source-hash".to_string()),
+                file_hash_at_capture: Some("file-hash".to_string()),
+                history: Vec::new(),
+                input_signature: Vec::new(),
+                output_signature: Vec::new(),
+                start_line: Some(1),
+                end_line: Some(1),
+                children: Vec::new(),
+            }],
+        }
+    }
+
+    fn base_node(id: &str, name: &str, location: &str, parent_id: Option<&str>) -> BaseNodeFields {
+        BaseNodeFields {
+            id: id.to_string(),
+            identity_key: id.to_string(),
+            object_hash: None,
+            name: name.to_string(),
+            location: location.to_string(),
+            language: "rust".to_string(),
+            description: String::new(),
+            parent_id: parent_id.map(str::to_string),
+            is_locked: false,
+            lineage_locked: false,
+            lock_owner: None,
+            lock_reason: String::new(),
+        }
+    }
 }


### PR DESCRIPTION
## Task

[T20260509-71](https://orbit-cli.com/tasks/T20260509-71) — Add SQLite read facade with version check and fallback

### Description

## Problem

T20260509-70 lands the SQLite secondary index on the write side, but no reader can use it yet. We need a read-side facade that opens the index, verifies it is current relative to the graph ref, and exposes typed query methods that future fast-path tasks consume. The facade must tolerate a missing or stale index by signaling `None` so callers fall back to existing behavior.

## Why It Matters

Phase 3 of the graph-latency proposal ([raw/wiki/graph/perf_proposal_claude.md](raw/wiki/graph/perf_proposal_claude.md)). All Phase 3 fast paths (overview, search, show) read through this facade. Centralizing the open, version check, fallback, and connection sharing here keeps the per-tool wirings small and makes the fallback policy auditable in one place.

This task lands the facade and a minimal smoke-test query. No tool consumes it yet — that comes in the sibling fast-path tasks.

## Implementation Notes

Surface (names illustrative):

```rust
pub struct GraphIndexReader { /* shared SQLite connection */ }

impl GraphIndexReader {
    /// Open the index at the documented path. Returns Ok(None) if the file is absent
    /// or its `meta.graph_ref` does not match `expected_ref`. Returns Ok(Some) on a
    /// valid current index. Errors only on corrupt files or schema-version mismatches
    /// that callers cannot fall back from gracefully.
    pub fn open(path: &Path, expected_ref: &str) -> Result<Option<Self>, KnowledgeError>;

    // Query methods are added here by fast-path tasks. Only one smoke-test query
    // lands in this task.
    pub fn count_nodes(&self) -> Result<u64, KnowledgeError>;
}
```

Key points:

- Open SQLite read-only (`rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY`) so the read path cannot accidentally mutate the index.
- Single shared connection per `GraphIndexReader` instance. Wrap in `Mutex<Connection>` if multiple threads can call query methods, or document single-threaded use. Match the patterns used by the existing audit-store SQLite code.
- Version check: if `meta.schema_version` does not match the writer's current version, return `Ok(None)` (treat as missing). Do NOT return an error — the goal is graceful fallback.
- Ref check: if `meta.graph_ref` does not match `expected_ref`, return `Ok(None)`.
- Stat the index file once at open time; do not poll on every query.
- The open path is hot — broad reads will call this every invocation. Keep the open cheap (single SELECT against `meta`); avoid prepared-statement preallocation here.
- Document fallback semantics in a module doc comment so future tool authors know `None` means `use the existing path`.

## Constraints / Notes

- This task does not change tool behavior. The facade exists, has tests, and is unconsumed.
- Sibling tasks (overview / search / show fast paths) depend on this and may begin once it merges.
- Sequencing: depends on T20260509-70 (write path).
- Authoring model: claude-opus-4-7. Author: claude.

### Acceptance Criteria

- A `GraphIndexReader` (or equivalent named struct) exists in `orbit-knowledge` with an `open(path, expected_ref) -> Result<Option<Self>, _>` constructor.
- Opening a non-existent path returns `Ok(None)`. Verified by unit test.
- Opening an index whose `meta.graph_ref` does not match the requested ref returns `Ok(None)`. Verified by unit test that builds an index for ref A and tries to open it with expected_ref B.
- Opening an index whose `meta.schema_version` does not match the writer's current version returns `Ok(None)`. Verified by unit test that writes an index with a fake older schema_version.
- Opening a valid current index returns `Ok(Some(_))`; calling `count_nodes()` returns the same count as the corresponding `node` table row count. Verified by unit test using a fixture graph from T20260509-70's write path.
- The connection is opened read-only — verified by attempting a write and asserting it fails (or by inspecting the open flags in the implementation).
- Module doc comment documents that `Ok(None)` is the graceful-fallback signal and that callers must implement a fallback to the existing read path.
- No graph tool consumes the facade yet — verifiable by `git grep GraphIndexReader` showing only the new module and its tests.
- `make build` and `make fmt` pass with no new warnings.
- `cargo test --workspace` passes.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Added module-level fallback docs for the SQLite graph index reader.
- Added GraphIndexReader::open(path, expected_ref) as the primary graceful-open constructor, retaining open_current as a compatibility alias for existing callers.
- Added count_nodes() and focused tests for missing path, stale ref, stale schema, valid count parity, and read-only behavior.

Assessment: make fmt, make build, cargo test -p orbit-knowledge graph::sqlite_index -- --nocapture, cargo test --workspace, and git diff --check pass.

Design weaknesses / risks:
- Current agent-main already has GraphIndexReader consumers from merged sibling tasks T20260509-72, T20260509-73, and T20260509-74, so the task-local git grep invariant cannot be observed without reverting pre-existing fast paths. This change did not add tool consumption; filed friction task T20260509-85 for the sequencing issue.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/T20260509-71-69ffbd84`
- Behind base: 0
- Ahead of base: 1

*authored by: claude-opus-4-7*