### PR TITLE
Simplify task attribution to model-only; drop derived agent field

### DIFF
--- a/crates/orbit-cli/src/bin/migrate-task-attribution.rs
+++ b/crates/orbit-cli/src/bin/migrate-task-attribution.rs
@@ -18,6 +18,18 @@ struct MigrationStats {
     scoreboard_files: usize,
 }
 
+#[derive(Default)]
+struct TaskMigrationReport {
+    changed_files: usize,
+    affected_task_ids: Vec<String>,
+}
+
+#[derive(Default)]
+struct TaskYamlNormalization {
+    changed: bool,
+    affected_task_id: Option<String>,
+}
+
 fn main() {
     if let Err(err) = run() {
         eprintln!("error: {err}");
@@ -28,9 +40,13 @@ fn main() {
 fn run() -> Result<(), OrbitError> {
     let mut args = std::env::args().skip(1);
     let mut root_override: Option<PathBuf> = None;
+    let mut dry_run = false;
 
     while let Some(arg) = args.next() {
         match arg.as_str() {
+            "--dry-run" => {
+                dry_run = true;
+            }
             "--root" => {
                 let Some(value) = args.next() else {
                     return Err(OrbitError::InvalidInput(
@@ -54,8 +70,17 @@ fn run() -> Result<(), OrbitError> {
     let runtime = OrbitRuntime::initialize_with_root_override(root_override.as_deref())?;
     let rules = build_rules()?;
     let data_root = runtime.data_root();
+    let task_report = normalize_task_artifacts(&data_root.join("tasks"), &rules, dry_run)?;
+    if dry_run {
+        println!("would normalize {} task files", task_report.changed_files);
+        for task_id in task_report.affected_task_ids {
+            println!("{task_id}");
+        }
+        return Ok(());
+    }
+
     let mut stats = MigrationStats {
-        task_files: normalize_task_artifacts(&data_root.join("tasks"), &rules)?,
+        task_files: task_report.changed_files,
         scoreboard_files: normalize_scoreboard_artifacts(
             &data_root.join("state/scoreboard"),
             &rules,
@@ -103,29 +128,51 @@ fn build_rules() -> Result<NormalizationRules, OrbitError> {
 fn normalize_task_artifacts(
     tasks_dir: &Path,
     rules: &NormalizationRules,
-) -> Result<usize, OrbitError> {
+    dry_run: bool,
+) -> Result<TaskMigrationReport, OrbitError> {
     if !tasks_dir.exists() {
-        return Ok(0);
+        return Ok(TaskMigrationReport::default());
     }
 
-    let mut changed = 0usize;
+    let mut report = TaskMigrationReport::default();
     visit_files(tasks_dir, &mut |path| {
         let file_changed = match path.file_name().and_then(|name| name.to_str()) {
-            Some("task.yaml") => normalize_task_yaml(path, rules)?,
-            _ => normalize_text_file(path, &rules.legacy_label)?,
+            Some("task.yaml") => {
+                let normalization = normalize_task_yaml(path, rules, dry_run)?;
+                if let Some(task_id) = normalization.affected_task_id {
+                    report.affected_task_ids.push(task_id);
+                }
+                normalization.changed
+            }
+            _ => normalize_text_file(path, &rules.legacy_label, dry_run)?,
         };
         if file_changed {
-            changed += 1;
+            report.changed_files += 1;
         }
         Ok(())
     })?;
-    Ok(changed)
+    report.affected_task_ids.sort();
+    report.affected_task_ids.dedup();
+    Ok(report)
 }
 
-fn normalize_task_yaml(path: &Path, rules: &NormalizationRules) -> Result<bool, OrbitError> {
+fn normalize_task_yaml(
+    path: &Path,
+    rules: &NormalizationRules,
+    dry_run: bool,
+) -> Result<TaskYamlNormalization, OrbitError> {
     let Some(raw) = read_optional_utf8(path)? else {
-        return Ok(false);
+        return Ok(TaskYamlNormalization::default());
     };
+
+    let agent_line_present = has_top_level_key(&raw, "agent");
+    let agent_value = top_level_scalar_value(&raw, "agent");
+    let task_id = infer_task_id(path, &raw);
+    if agent_value.is_some() && top_level_scalar_value(&raw, "model").is_none() {
+        return Err(OrbitError::InvalidInput(format!(
+            "task {task_id} has `agent` but no `model`; add the model before running migration"
+        )));
+    }
 
     let model_hint = infer_task_model_hint(&raw, rules);
     let mut normalized = String::with_capacity(raw.len());
@@ -135,6 +182,9 @@ fn normalize_task_yaml(path: &Path, rules: &NormalizationRules) -> Result<bool, 
         } else {
             (segment, "")
         };
+        if line.starts_with("agent:") {
+            continue;
+        }
         normalized.push_str(&normalize_task_yaml_line(
             line,
             rules,
@@ -144,11 +194,19 @@ fn normalize_task_yaml(path: &Path, rules: &NormalizationRules) -> Result<bool, 
     }
 
     if normalized == raw {
-        return Ok(false);
+        return Ok(TaskYamlNormalization {
+            changed: false,
+            affected_task_id: None,
+        });
     }
 
-    write_atomic_text(path, &normalized)?;
-    Ok(true)
+    if !dry_run {
+        write_atomic_text(path, &normalized)?;
+    }
+    Ok(TaskYamlNormalization {
+        changed: true,
+        affected_task_id: agent_line_present.then_some(task_id),
+    })
 }
 
 fn infer_task_model_hint(task_yaml: &str, rules: &NormalizationRules) -> Option<String> {
@@ -180,7 +238,7 @@ fn normalize_task_yaml_line(
     rules: &NormalizationRules,
     model_hint: Option<&str>,
 ) -> String {
-    if line.starts_with("agent:") || line.starts_with("actor_identity:") {
+    if line.starts_with("actor_identity:") {
         return line.to_string();
     }
 
@@ -209,7 +267,11 @@ fn normalize_task_yaml_line(
     normalize_legacy_text(line, &rules.legacy_label)
 }
 
-fn normalize_text_file(path: &Path, legacy_label: &Regex) -> Result<bool, OrbitError> {
+fn normalize_text_file(
+    path: &Path,
+    legacy_label: &Regex,
+    dry_run: bool,
+) -> Result<bool, OrbitError> {
     let Some(raw) = read_optional_utf8(path)? else {
         return Ok(false);
     };
@@ -217,7 +279,9 @@ fn normalize_text_file(path: &Path, legacy_label: &Regex) -> Result<bool, OrbitE
     if normalized == raw {
         return Ok(false);
     }
-    write_atomic_text(path, &normalized)?;
+    if !dry_run {
+        write_atomic_text(path, &normalized)?;
+    }
     Ok(true)
 }
 
@@ -422,6 +486,30 @@ fn parse_scalar(value: &str) -> Option<&str> {
     }
 }
 
+fn has_top_level_key(task_yaml: &str, key: &str) -> bool {
+    task_yaml
+        .lines()
+        .any(|line| line.starts_with(&format!("{key}:")))
+}
+
+fn top_level_scalar_value(task_yaml: &str, key: &str) -> Option<String> {
+    let prefix = format!("{key}:");
+    task_yaml.lines().find_map(|line| {
+        let value = line.strip_prefix(&prefix)?;
+        parse_scalar(value).map(ToOwned::to_owned)
+    })
+}
+
+fn infer_task_id(path: &Path, task_yaml: &str) -> String {
+    top_level_scalar_value(task_yaml, "id").unwrap_or_else(|| {
+        path.parent()
+            .and_then(|parent| parent.file_name())
+            .and_then(|name| name.to_str())
+            .unwrap_or("<unknown>")
+            .to_string()
+    })
+}
+
 fn is_model_like(value: &str) -> bool {
     let trimmed = value.trim();
     !trimmed.is_empty()
@@ -434,6 +522,6 @@ fn is_model_like(value: &str) -> bool {
 }
 
 fn print_help() {
-    println!("Usage: migrate-task-attribution [--root <path>]");
+    println!("Usage: migrate-task-attribution [--dry-run] [--root <path>]");
     println!("Rewrites Orbit task and scoreboard artifacts to the model-only attribution schema.");
 }

--- a/crates/orbit-cli/src/command/web/api/scoreboard.rs
+++ b/crates/orbit-cli/src/command/web/api/scoreboard.rs
@@ -114,8 +114,7 @@ fn compute_metrics_extras(
         };
         for entry in entries {
             let key = match &entry.actor_identity {
-                ActorIdentity::Agent { model, name } if !model.is_empty() => model.clone(),
-                ActorIdentity::Agent { name, .. } if !name.is_empty() => name.clone(),
+                ActorIdentity::Agent { model } if !model.is_empty() => model.clone(),
                 ActorIdentity::Human { label } if !label.is_empty() => label.clone(),
                 _ => continue,
             };

--- a/crates/orbit-cli/tests/task_attribution_migration.rs
+++ b/crates/orbit-cli/tests/task_attribution_migration.rs
@@ -1,0 +1,234 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Output;
+
+use assert_cmd::cargo::cargo_bin_cmd;
+use serde_json::Value;
+use tempfile::{TempDir, tempdir};
+
+#[test]
+fn task_tool_rejects_agent_and_model_only_storage_omits_agent() {
+    let workspace = TestWorkspace::new();
+
+    let rejected = workspace.run_raw(
+        &[
+            "tool",
+            "run",
+            "orbit.task.add",
+            "--input",
+            r#"{"title":"Legacy agent task","description":"Should fail.","workspace":".","agent":"codex"}"#,
+        ],
+        "reject legacy agent field",
+    );
+    assert!(!rejected.status.success());
+    let rejected_output = format!(
+        "{}{}",
+        String::from_utf8_lossy(&rejected.stdout),
+        String::from_utf8_lossy(&rejected.stderr)
+    );
+    assert!(
+        rejected_output.contains("use `model`"),
+        "output:\n{rejected_output}"
+    );
+
+    let created = workspace.run(
+        &[
+            "tool",
+            "run",
+            "orbit.task.add",
+            "--full",
+            "--input",
+            r#"{"title":"Model-only task","description":"Should succeed.","workspace":".","model":"gpt-5.5"}"#,
+        ],
+        "create model-only task",
+    );
+    let task: Value = serde_json::from_slice(&created.stdout).expect("created task JSON");
+    let task_id = task["id"].as_str().expect("task id");
+    let task_yaml = fs::read_to_string(workspace.task_yaml(task_id)).expect("read task yaml");
+
+    assert!(task_yaml.contains("model: gpt-5.5"));
+    assert!(!task_yaml.contains("agent:"));
+}
+
+#[test]
+fn migration_dry_run_write_and_second_run_are_idempotent() {
+    let workspace = TestWorkspace::new();
+    let task_id = workspace.add_model_task("Migration task");
+    let task_yaml_path = workspace.task_yaml(&task_id);
+    let original = fs::read_to_string(&task_yaml_path).expect("read task yaml");
+    fs::write(
+        &task_yaml_path,
+        original.replace("model: gpt-5.5", "agent: codex\nmodel: gpt-5.5"),
+    )
+    .expect("write legacy agent field");
+
+    let dry_run = workspace.run_migration(&["--dry-run"], "dry-run migration");
+    assert!(
+        String::from_utf8_lossy(&dry_run.stdout).contains(&task_id),
+        "stdout:\n{}",
+        String::from_utf8_lossy(&dry_run.stdout)
+    );
+    let after_dry_run = fs::read_to_string(&task_yaml_path).expect("read task yaml");
+    assert!(after_dry_run.contains("agent: codex"));
+
+    let migrated = workspace.run_migration(&[], "write migration");
+    assert!(
+        String::from_utf8_lossy(&migrated.stdout).contains("normalized 1 task files"),
+        "stdout:\n{}",
+        String::from_utf8_lossy(&migrated.stdout)
+    );
+    let after_write = fs::read_to_string(&task_yaml_path).expect("read task yaml");
+    assert!(!after_write.contains("agent:"));
+    assert!(after_write.contains("model: gpt-5.5"));
+
+    let second = workspace.run_migration(&[], "second migration");
+    assert!(
+        String::from_utf8_lossy(&second.stdout).contains("normalized 0 task files"),
+        "stdout:\n{}",
+        String::from_utf8_lossy(&second.stdout)
+    );
+}
+
+#[test]
+fn migration_fails_when_agent_has_no_model() {
+    let workspace = TestWorkspace::new();
+    let task_id = workspace.add_model_task("Broken migration task");
+    let task_yaml_path = workspace.task_yaml(&task_id);
+    let broken = fs::read_to_string(&task_yaml_path)
+        .expect("read task yaml")
+        .lines()
+        .filter(|line| !line.starts_with("model:"))
+        .collect::<Vec<_>>()
+        .join("\n");
+    fs::write(
+        &task_yaml_path,
+        broken.replace(
+            "# ---- implementation ----",
+            "# ---- implementation ----\nagent: codex\n",
+        ),
+    )
+    .expect("write broken legacy agent field");
+
+    let output = workspace.run_migration_raw(&[], "broken migration");
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains(&task_id), "stderr:\n{stderr}");
+    assert!(
+        stderr.contains("agent") && stderr.contains("model"),
+        "stderr:\n{stderr}"
+    );
+}
+
+struct TestWorkspace {
+    _temp: TempDir,
+    home: PathBuf,
+    work: PathBuf,
+}
+
+impl TestWorkspace {
+    fn new() -> Self {
+        let temp = tempdir().expect("tempdir");
+        let home = temp.path().join("home");
+        let work = temp.path().join("work");
+        fs::create_dir_all(&home).expect("create home");
+        fs::create_dir_all(&work).expect("create work");
+
+        let workspace = Self {
+            _temp: temp,
+            home,
+            work,
+        };
+        workspace.run(
+            &["workspace", "init", "--name", "task-attribution-test"],
+            "init",
+        );
+        workspace
+    }
+
+    fn add_model_task(&self, title: &str) -> String {
+        let output = self.run(
+            &[
+                "task",
+                "add",
+                "--title",
+                title,
+                "--description",
+                "Migration fixture.",
+                "--model",
+                "gpt-5.5",
+                "--json",
+            ],
+            "add model task",
+        );
+        let task: Value = serde_json::from_slice(&output.stdout).expect("task JSON");
+        task["id"].as_str().expect("task id").to_string()
+    }
+
+    fn task_yaml(&self, task_id: &str) -> PathBuf {
+        find_task_yaml(&self.work.join(".orbit").join("tasks"), task_id)
+            .unwrap_or_else(|| panic!("task yaml for {task_id}"))
+    }
+
+    fn run(&self, args: &[&str], label: &str) -> Output {
+        let output = self.run_raw(args, label);
+        assert!(
+            output.status.success(),
+            "{label} failed\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        output
+    }
+
+    fn run_raw(&self, args: &[&str], _label: &str) -> Output {
+        let mut command = cargo_bin_cmd!("orbit");
+        command
+            .current_dir(&self.work)
+            .env("HOME", &self.home)
+            .env("USERPROFILE", &self.home)
+            .env_remove("ORBIT_ROOT")
+            .args(args);
+        command.output().expect("run orbit")
+    }
+
+    fn run_migration(&self, args: &[&str], label: &str) -> Output {
+        let output = self.run_migration_raw(args, label);
+        assert!(
+            output.status.success(),
+            "{label} failed\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        output
+    }
+
+    fn run_migration_raw(&self, args: &[&str], _label: &str) -> Output {
+        let mut command = cargo_bin_cmd!("migrate-task-attribution");
+        command
+            .current_dir(&self.work)
+            .env("HOME", &self.home)
+            .env("USERPROFILE", &self.home)
+            .env_remove("ORBIT_ROOT")
+            .args(args);
+        command.output().expect("run migrate-task-attribution")
+    }
+}
+
+fn find_task_yaml(root: &Path, task_id: &str) -> Option<PathBuf> {
+    for entry in fs::read_dir(root).ok()? {
+        let entry = entry.ok()?;
+        let path = entry.path();
+        if path.is_dir() {
+            if path.file_name().and_then(|name| name.to_str()) == Some(task_id) {
+                let candidate = path.join("task.yaml");
+                if candidate.exists() {
+                    return Some(candidate);
+                }
+            }
+            if let Some(found) = find_task_yaml(&path, task_id) {
+                return Some(found);
+            }
+        }
+    }
+    None
+}

--- a/crates/orbit-cli/tests/worktree_resolution.rs
+++ b/crates/orbit-cli/tests/worktree_resolution.rs
@@ -41,7 +41,6 @@ fn tool_run_task_show_resolves_main_orbit_from_git_worktree() {
         "description": "Task used by worktree resolution integration test.",
         "acceptance_criteria": ["main and linked worktree resolve the same task"],
         "workspace": ".",
-        "agent": "codex",
         "model": "gpt-5"
     })
     .to_string();
@@ -64,7 +63,6 @@ fn tool_run_task_show_resolves_main_orbit_from_git_worktree() {
 
     let show_input = json!({
         "id": task_id,
-        "agent": "codex",
         "model": "gpt-5"
     })
     .to_string();

--- a/crates/orbit-common/src/types/actor.rs
+++ b/crates/orbit-common/src/types/actor.rs
@@ -6,25 +6,23 @@ use crate::types::agent_pair::{agent_family_from_cli, all_agent_families};
 
 /// Typed identity for attribution across all Orbit artifacts.
 ///
-/// Replaces ad-hoc `(Option<String>, Option<String>)` agent/model pairs.
-/// Used in tasks, friction logs, metrics entries, audit trails, and
-/// anywhere provenance matters.
+/// Orbit stores model-only agent attribution. The agent family is derived from
+/// the model string at render or routing time.
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub enum ActorIdentity {
     /// The Orbit system itself (automated processes with no specific agent).
     #[default]
     System,
-    /// An AI agent with a name and model identifier.
-    Agent { name: String, model: String },
+    /// An AI agent model identifier.
+    Agent { model: String },
     /// A human operator.
     Human { label: String },
 }
 
 impl ActorIdentity {
-    /// Construct an `Agent` variant, trimming whitespace from both fields.
-    pub fn agent(name: impl Into<String>, model: impl Into<String>) -> Self {
+    /// Construct an `Agent` variant, trimming whitespace.
+    pub fn agent(model: impl Into<String>) -> Self {
         Self::Agent {
-            name: name.into().trim().to_string(),
             model: model.into().trim().to_string(),
         }
     }
@@ -36,32 +34,26 @@ impl ActorIdentity {
         }
     }
 
-    /// Build from legacy `(Option<String>, Option<String>)` agent/model pair.
-    ///
-    /// - Both present → `Agent { name, model }`
-    /// - Only agent → `Agent { name, model: "" }` (model unknown)
-    /// - Neither → `System`
+    /// Build from a legacy `(Option<String>, Option<String>)` agent/model pair.
+    /// The model wins because the agent family is derivable from it.
     pub fn from_legacy(agent: Option<&str>, model: Option<&str>) -> Self {
-        match (
-            agent.filter(|s| !s.trim().is_empty()),
-            model.filter(|s| !s.trim().is_empty()),
-        ) {
-            (Some(name), Some(model)) => Self::Agent {
-                name: name.trim().to_string(),
-                model: model.trim().to_string(),
-            },
-            (Some(name), None) => Self::Agent {
-                name: name.trim().to_string(),
-                model: String::new(),
-            },
-            (None, _) => Self::System,
+        if let Some(model) = model.map(str::trim).filter(|s| !s.is_empty()) {
+            return Self::Agent {
+                model: model.to_string(),
+            };
         }
+        if let Some(agent) = agent.map(str::trim).filter(|s| !s.is_empty()) {
+            return Self::Agent {
+                model: agent.to_string(),
+            };
+        }
+        Self::System
     }
 
-    /// Returns the agent name if this is an `Agent` variant.
+    /// Returns the derived agent family if this is a known `Agent` model.
     pub fn agent_name(&self) -> Option<&str> {
         match self {
-            Self::Agent { name, .. } => Some(name),
+            Self::Agent { model } => agent_from_model(model),
             _ => None,
         }
     }
@@ -69,7 +61,7 @@ impl ActorIdentity {
     /// Returns the model name if this is an `Agent` variant.
     pub fn agent_model(&self) -> Option<&str> {
         match self {
-            Self::Agent { model, .. } if !model.is_empty() => Some(model),
+            Self::Agent { model } if !model.is_empty() => Some(model),
             _ => None,
         }
     }
@@ -78,8 +70,7 @@ impl ActorIdentity {
     pub fn label(&self) -> String {
         match self {
             Self::System => "system".to_string(),
-            Self::Agent { name, model } if model.is_empty() => name.clone(),
-            Self::Agent { name, model } => format!("{name} / {model}"),
+            Self::Agent { model } => model.clone(),
             Self::Human { label } => label.clone(),
         }
     }
@@ -104,13 +95,10 @@ impl ActorIdentity {
     pub fn to_legacy(&self) -> (Option<String>, Option<String>) {
         match self {
             Self::System => (None, None),
-            Self::Agent { name, model } => (
-                Some(name.clone()),
-                if model.is_empty() {
-                    None
-                } else {
-                    Some(model.clone())
-                },
+            Self::Agent { model } if model.is_empty() => (None, None),
+            Self::Agent { model } => (
+                agent_from_model(model).map(ToOwned::to_owned),
+                Some(model.clone()),
             ),
             Self::Human { .. } => (None, None),
         }
@@ -120,6 +108,40 @@ impl ActorIdentity {
 impl Display for ActorIdentity {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.label())
+    }
+}
+
+/// Infer Orbit's agent family from a model identifier.
+pub fn agent_from_model(model: &str) -> Option<&'static str> {
+    let model = model.trim().to_ascii_lowercase();
+    if model.is_empty() {
+        return None;
+    }
+
+    if model.starts_with("claude-") || model.starts_with("opus") || model.starts_with("sonnet") {
+        return Some("claude");
+    }
+    if model.starts_with("gpt-") || model.starts_with("o1") || model.starts_with("o3") {
+        return Some("codex");
+    }
+    if model.starts_with("gemini-") {
+        return Some("gemini");
+    }
+    if model.starts_with("ollama:") {
+        return Some("ollama");
+    }
+
+    None
+}
+
+/// Infer a provider family from a model identifier.
+pub fn provider_from_model(model: &str) -> Option<&'static str> {
+    match agent_from_model(model)? {
+        "claude" => Some("anthropic"),
+        "codex" => Some("openai"),
+        "gemini" => Some("google"),
+        "ollama" => Some("ollama"),
+        _ => None,
     }
 }
 
@@ -168,7 +190,7 @@ pub fn normalize_optional_attribution_label(
 /// Custom serialization: emits the flat display label string.
 ///
 /// - `System` → `"system"`
-/// - `Agent { name, model }` → `"name / model"` (or just `"name"` if model is empty)
+/// - `Agent { model }` → `"model"`
 /// - `Human { label }` → `"label"`
 impl Serialize for ActorIdentity {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -178,7 +200,9 @@ impl Serialize for ActorIdentity {
 
 #[derive(Serialize, Deserialize)]
 struct AgentFields {
+    #[serde(default)]
     name: String,
+    #[serde(default)]
     model: String,
 }
 
@@ -193,7 +217,7 @@ impl<'de> Deserialize<'de> for ActorIdentity {
 
             fn expecting(&self, formatter: &mut Formatter) -> std::fmt::Result {
                 formatter.write_str(
-                    r#""system", or {"agent": {"name": "...", "model": "..."}}, or {"human": "..."}"#,
+                    r#""system", a model string, {"agent": {"model": "..."}}, or {"human": "..."}"#,
                 )
             }
 
@@ -205,7 +229,6 @@ impl<'de> Deserialize<'de> for ActorIdentity {
                         if other.contains(" / ") {
                             let parts: Vec<&str> = other.splitn(2, " / ").collect();
                             Ok(ActorIdentity::Agent {
-                                name: parts[0].trim().to_string(),
                                 model: parts[1].trim().to_string(),
                             })
                         } else if other == "human" {
@@ -213,9 +236,8 @@ impl<'de> Deserialize<'de> for ActorIdentity {
                                 label: "human".to_string(),
                             })
                         } else {
-                            // Could be an agent name without model, or a human label
-                            Ok(ActorIdentity::Human {
-                                label: other.to_string(),
+                            Ok(ActorIdentity::Agent {
+                                model: other.to_string(),
                             })
                         }
                     }
@@ -232,9 +254,13 @@ impl<'de> Deserialize<'de> for ActorIdentity {
                 match key.as_str() {
                     "agent" => {
                         let fields: AgentFields = map.next_value()?;
+                        let model = if fields.model.trim().is_empty() {
+                            fields.name
+                        } else {
+                            fields.model
+                        };
                         Ok(ActorIdentity::Agent {
-                            name: fields.name,
-                            model: fields.model,
+                            model: model.trim().to_string(),
                         })
                     }
                     "human" => {
@@ -247,5 +273,33 @@ impl<'de> Deserialize<'de> for ActorIdentity {
         }
 
         deserializer.deserialize_any(ActorVisitor)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{agent_from_model, provider_from_model};
+
+    #[test]
+    fn agent_from_model_maps_known_prefixes() {
+        assert_eq!(agent_from_model("claude-opus-4-7"), Some("claude"));
+        assert_eq!(agent_from_model("gpt-5.5"), Some("codex"));
+        assert_eq!(agent_from_model("gemini-3.1-pro-preview"), Some("gemini"));
+        assert_eq!(agent_from_model("ollama:llama3.2"), Some("ollama"));
+    }
+
+    #[test]
+    fn agent_from_model_returns_none_for_unknown_prefix() {
+        assert_eq!(agent_from_model("unknown-model"), None);
+        assert_eq!(agent_from_model(""), None);
+    }
+
+    #[test]
+    fn provider_from_model_maps_known_prefixes() {
+        assert_eq!(provider_from_model("claude-sonnet-4-7"), Some("anthropic"));
+        assert_eq!(provider_from_model("gpt-5.5"), Some("openai"));
+        assert_eq!(provider_from_model("gemini-3-pro"), Some("google"));
+        assert_eq!(provider_from_model("ollama:mistral"), Some("ollama"));
+        assert_eq!(provider_from_model("unknown-model"), None);
     }
 }

--- a/crates/orbit-common/src/types/mod.rs
+++ b/crates/orbit-common/src/types/mod.rs
@@ -56,7 +56,10 @@ pub use activity_job::{
     V2_TOOL_WILDCARD_ROOTS, V2AuditEnvelope, V2AuditEvent, V2AuditEventKind, load_activity_asset,
     load_job_asset, tool_allowed, validate_tool_allowlist,
 };
-pub use actor::{ActorIdentity, normalize_attribution_label, normalize_optional_attribution_label};
+pub use actor::{
+    ActorIdentity, agent_from_model, normalize_attribution_label,
+    normalize_optional_attribution_label, provider_from_model,
+};
 pub use agent_pair::{
     AgentModelPair, agent_family_from_cli, all_agent_families, infer_agent_family_from_model,
     normalize_agent_family_for_model, resolve_agent_model_pair,

--- a/crates/orbit-core/src/runtime/orbit_tool_host/json.rs
+++ b/crates/orbit-core/src/runtime/orbit_tool_host/json.rs
@@ -30,7 +30,6 @@ pub(super) fn task_to_json(task: &Task, status_by_id: &BTreeMap<String, TaskStat
         "created_by": task.created_by,
         "planned_by": task.planned_by,
         "implemented_by": task.implemented_by,
-        "agent": task.agent,
         "model": task.model,
         "status": task.status.to_string(),
         "priority": task.priority.to_string(),

--- a/crates/orbit-core/src/runtime/orbit_tool_host/task_tools_tests.rs
+++ b/crates/orbit-core/src/runtime/orbit_tool_host/task_tools_tests.rs
@@ -372,7 +372,7 @@ fn task_add_tool_infers_agent_from_model_only_input() {
         )
         .expect("task add tool succeeds");
 
-    assert_eq!(output.get("agent").and_then(Value::as_str), Some("codex"));
+    assert!(output.get("agent").is_none());
     assert_eq!(output.get("model").and_then(Value::as_str), Some("gpt-5.5"));
     assert_eq!(
         output.get("created_by").and_then(Value::as_str),
@@ -405,7 +405,7 @@ fn task_update_tool_infers_agent_from_model_only_input() {
         )
         .expect("task update tool succeeds");
 
-    assert_eq!(output.get("agent").and_then(Value::as_str), Some("gemini"));
+    assert!(output.get("agent").is_none());
     assert_eq!(
         output.get("model").and_then(Value::as_str),
         Some("gemini-3.1-pro-preview")
@@ -738,7 +738,7 @@ fn task_tool_rejects_mismatched_agent_and_model() {
             None,
             None,
         )
-        .expect_err("mismatched identity should fail");
+        .expect_err("agent input should fail");
 
-    assert!(error.to_string().contains("does not match `model`"));
+    assert!(error.to_string().contains("use `model`"));
 }

--- a/crates/orbit-store/src/file/task_store/bundle.rs
+++ b/crates/orbit-store/src/file/task_store/bundle.rs
@@ -2,7 +2,7 @@ use std::fs;
 use std::path::Path;
 
 use orbit_common::types::{
-    ActorIdentity, ExternalRef, OrbitError, ReviewThread, Task, TaskStatus,
+    ActorIdentity, ExternalRef, OrbitError, ReviewThread, Task, TaskStatus, agent_from_model,
     normalize_optional_attribution_label, normalize_task_tags,
 };
 
@@ -202,6 +202,17 @@ pub(super) fn bundle_to_task(state: TaskStateDir, bundle: TaskBundle) -> Task {
             .or(legacy_implemented_by.as_deref()),
         model_hint,
     );
+    let model = bundle.doc.model.or(legacy_model);
+    let agent = bundle
+        .doc
+        .agent
+        .or_else(|| {
+            model
+                .as_deref()
+                .and_then(agent_from_model)
+                .map(ToOwned::to_owned)
+        })
+        .or(legacy_agent);
 
     Task {
         id: bundle.doc.id,
@@ -219,8 +230,8 @@ pub(super) fn bundle_to_task(state: TaskStateDir, bundle: TaskBundle) -> Task {
         created_by,
         planned_by,
         implemented_by,
-        agent: bundle.doc.agent.or(legacy_agent),
-        model: bundle.doc.model.or(legacy_model),
+        agent,
+        model,
         status: state.to_status(),
         priority: bundle.doc.priority,
         complexity: bundle.doc.complexity,

--- a/crates/orbit-store/src/file/task_store/doc.rs
+++ b/crates/orbit-store/src/file/task_store/doc.rs
@@ -39,7 +39,8 @@ pub(super) struct TaskFileDocument {
     pub(super) planned_by: Option<String>,
     #[serde(default)]
     pub(super) implemented_by: Option<String>,
-    #[serde(default)]
+    /// Legacy field — read-only. Modern task YAML stores model-only attribution.
+    #[serde(default, skip_serializing)]
     pub(super) agent: Option<String>,
     #[serde(default)]
     pub(super) model: Option<String>,
@@ -233,7 +234,6 @@ pub(super) fn serialize_task_doc_yaml(doc: &TaskFileDocument) -> Result<String, 
     yaml.push_str(&yaml_field("implemented_by", &doc.implemented_by)?);
 
     yaml.push_str(&yaml_section("implementation"));
-    yaml.push_str(&yaml_field("agent", &doc.agent)?);
     yaml.push_str(&yaml_field("model", &doc.model)?);
     yaml.push_str(&yaml_field("pr_status", &doc.pr_status)?);
     if !doc.external_refs.is_empty() {

--- a/crates/orbit-tools/src/builtin/orbit/mod.rs
+++ b/crates/orbit-tools/src/builtin/orbit/mod.rs
@@ -125,6 +125,29 @@ pub(super) fn identity_params() -> Vec<ToolParam> {
     ]
 }
 
+pub(super) fn model_identity_params() -> Vec<ToolParam> {
+    vec![ToolParam {
+        name: "model".to_string(),
+        description:
+            "Preferred provenance field. Exact LLM model identifier used to infer agent family when possible (e.g. opus, gpt-5.4, gemini-3.1-pro-preview)."
+                .to_string(),
+        param_type: "string".to_string(),
+        required: false,
+    }]
+}
+
+pub(super) fn reject_agent_field(input: &Value, tool_name: &str) -> Result<(), OrbitError> {
+    if input
+        .as_object()
+        .is_some_and(|object| object.contains_key("agent"))
+    {
+        return Err(OrbitError::InvalidInput(format!(
+            "{tool_name} no longer accepts `agent`; use `model` for attribution"
+        )));
+    }
+    Ok(())
+}
+
 pub(super) fn scored_identity_params() -> Vec<ToolParam> {
     vec![
         ToolParam {

--- a/crates/orbit-tools/src/builtin/orbit/task/add.rs
+++ b/crates/orbit-tools/src/builtin/orbit/task/add.rs
@@ -122,7 +122,7 @@ impl Tool for OrbitTaskAddTool {
                 required: false,
             },
         ];
-        parameters.extend(super::super::identity_params());
+        parameters.extend(super::super::model_identity_params());
 
         ToolSchema {
             name: "orbit.task.add".to_string(),
@@ -133,6 +133,7 @@ impl Tool for OrbitTaskAddTool {
     }
 
     fn execute(&self, ctx: &ToolContext, input: Value) -> Result<Value, OrbitError> {
+        super::super::reject_agent_field(&input, "orbit.task.add")?;
         super::super::execute_host_action(ctx, input, OrbitBuiltinAction::TaskAdd)
     }
 }

--- a/crates/orbit-tools/src/builtin/orbit/task/update.rs
+++ b/crates/orbit-tools/src/builtin/orbit/task/update.rs
@@ -110,7 +110,7 @@ impl Tool for OrbitTaskUpdateTool {
                 required: false,
             },
         ]);
-        parameters.extend(super::super::identity_params());
+        parameters.extend(super::super::model_identity_params());
 
         ToolSchema {
             name: "orbit.task.update".to_string(),
@@ -121,6 +121,7 @@ impl Tool for OrbitTaskUpdateTool {
     }
 
     fn execute(&self, ctx: &ToolContext, input: Value) -> Result<Value, OrbitError> {
+        super::super::reject_agent_field(&input, "orbit.task.update")?;
         super::super::execute_host_action(ctx, input, OrbitBuiltinAction::TaskUpdate)
     }
 }

--- a/crates/orbit-tools/tests/public_tool_surface.rs
+++ b/crates/orbit-tools/tests/public_tool_surface.rs
@@ -96,6 +96,26 @@ fn task_dependency_params_remain_in_agent_tool_schemas() {
 }
 
 #[test]
+fn task_add_update_schemas_use_model_only_identity() {
+    let mut registry = ToolRegistry::new();
+    registry.register_builtins();
+
+    for tool_name in ["orbit.task.add", "orbit.task.update"] {
+        let schema = registry
+            .get_schema(tool_name)
+            .unwrap_or_else(|| panic!("{tool_name} schema"));
+        assert!(
+            schema.parameters.iter().any(|param| param.name == "model"),
+            "{tool_name} should expose model attribution"
+        );
+        assert!(
+            schema.parameters.iter().all(|param| param.name != "agent"),
+            "{tool_name} should not expose agent attribution"
+        );
+    }
+}
+
+#[test]
 fn task_delete_schema_exposes_optional_force_boolean() {
     let mut registry = ToolRegistry::new();
     registry.register_builtins();


### PR DESCRIPTION
## Task

[T20260510-15](https://orbit-cli.com/tasks/T20260510-15) — Simplify task attribution to model-only; drop derived agent field

### Description

## Problem

Task attribution fields (`created_by`, `planned_by`, `implemented_by`) currently appear to carry both `agent` (e.g. `claude`, `codex`, `gemini`) and `model` (e.g. `claude-opus-4-7`). The agent family is derivable from the model name — storing both is denormalization that requires every writer to populate both consistently.

Friction records (T20260510-13) are also moving to model-only. Tasks should match.

## Why It Matters

- One source of truth for attribution: the model name.
- One required field on `orbit.task.add` instead of two.
- Eliminates a class of bugs where `agent` and `model` drift apart.
- Provider derivation (anthropic / openai / google) follows the same rule; no need to store provider as a third field.

## Design

### Storage / type changes

- The `Actor` type at `crates/orbit-common/src/types/actor.rs` (or wherever attribution is held) reduces to a single `model: String` field. Any explicit `agent` field on the type is removed.
- A pure utility `agent_from_model(model: &str) -> Option<&'static str>` lives next to the type and maps known model prefixes to agent families: `claude-*` → `claude`, `gpt-*` → `codex`, `gemini-*` → `gemini`, `ollama:*` → `ollama`, etc. Returns `None` for unknown models.
- The same module exposes `provider_from_model(model: &str) -> Option<&'static str>` if the implementer judges it useful; not required.

### Tool surface

- `orbit.task.add` continues to require `model`. Any `agent` parameter is removed; if passed, it's rejected with a clear error.
- `orbit.task.update` similarly accepts `model` only for attribution updates.
- CLI display of attribution shows the model name. If the implementer wants `claude (claude-opus-4-7)` style display, that uses `agent_from_model` at render time, not stored data.

### Migration

For existing tasks with both `agent` and `model` stored:

- Drop the `agent` field. Data is lossless because agent was derivable.
- If a record has only `agent` and no `model`, fail loudly with the task id — manual repair required (this should be vanishingly rare).
- Migration is idempotent. Provide a `--dry-run` mode that prints affected task ids without writing.

### Doc + skill updates

- `orbit-create-task` skill template removes any `agent` field reference; only `model` is mentioned.
- CLAUDE.md "Commits & Tasks & doc authorship" section keeps its model-name guidance unchanged.

## Constraints / Notes

- Independent of T20260510-13 (friction relocation) and the type-taxonomy reduction task — can be implemented in parallel.
- Confirm whether the current `Actor` type already only stores `model` and the agent is purely derived; if so, this task narrows to deleting any redundant `agent` parameter on the tool surface and any duplicate fields in YAML/SQLite storage.
- All file I/O paths in tests must use temp dirs.
- `make build && make fmt` must pass.

### Acceptance Criteria

- The attribution type at `crates/orbit-common/src/types/actor.rs` (or equivalent) has a single `model: String` field. No `agent: String` field remains. Verified by inspecting the struct definition.
- A pure utility `agent_from_model(&str) -> Option<&'static str>` exists in the same module and returns the correct agent family for known prefixes (`claude-*`, `gpt-*`, `gemini-*`) and `None` for unknown inputs. Verified by unit tests covering all three families plus an unknown input.
- `orbit tool run orbit.task.add` with an `agent` field in the input JSON returns an error directing the caller to use `model`. Verified by integration test.
- `orbit tool run orbit.task.add` with only `model` succeeds and produces a task whose stored attribution shows only the model name (no `agent` field in the stored YAML/JSON). Verified by inspecting `.orbit/tasks/<id>.md`.
- Migration command (e.g. `orbit migrate task-actors`) drops the `agent` field from existing task records that carry both. `--dry-run` lists affected task ids without writing. Re-running after a successful migration produces zero further changes (idempotent). Verified by command output and `git diff` on `.orbit/tasks/`.
- Migration fails loudly (with the task id) if a record has `agent` but no `model`. Verified by integration test on a synthetic broken record.
- CLI task display shows the model name in `created_by` / `planned_by` / `implemented_by` columns. Verified by `orbit task show <id>` output inspection.
- `orbit-create-task` skill template at `~/.claude/skills/orbit-create-task/` no longer references an `agent` field; only `model` is mentioned. (Flag as out-of-workspace edit if applicable.)
- `rg "agent:" .orbit/tasks/` returns no matches after migration runs.
- `make build` and `make fmt` complete with no warnings or errors.
- All existing tests pass via `cargo test`. New tests cover `agent_from_model` correctness and migration idempotence.

## Execution Summary

<details>
<summary>Click to expand</summary>

Implemented model-only task attribution: ActorIdentity now stores only model, task add/update tool schemas reject legacy agent input, task YAML serialization omits agent, and migrate-task-attribution supports --dry-run, drops legacy agent fields, fails on agent-without-model records, and is idempotent. Validation: make build; make fmt; cargo test.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/T20260510-15-6a001898`
- Behind base: 0
- Ahead of base: 1

*authored by: claude-opus-4-7*