### PR TITLE
Phase-1 semantic search retrieval: hybrid query + CLI search/related + MCP

### DIFF
--- a/crates/orbit-cli/src/audit_middleware.rs
+++ b/crates/orbit-cli/src/audit_middleware.rs
@@ -300,6 +300,8 @@ pub fn extract_command_meta(cmd: &Commands) -> CommandMeta {
                 SemanticSubcommand::Uninstall(_) => "uninstall",
                 SemanticSubcommand::Reindex(_) => "reindex",
                 SemanticSubcommand::Stats(_) => "stats",
+                SemanticSubcommand::Search(_) => "search",
+                SemanticSubcommand::Related(_) => "related",
             };
             CommandMeta {
                 command: "semantic".to_string(),

--- a/crates/orbit-cli/src/command/mcp/mod.rs
+++ b/crates/orbit-cli/src/command/mcp/mod.rs
@@ -65,13 +65,20 @@ pub(crate) const GRAPH_READ_TOOL_NAMES: &[&str] = &[
     "orbit.graph.show",
 ];
 
+pub(crate) const SEMANTIC_READ_TOOL_NAMES: &[&str] =
+    &["orbit.semantic.search", "orbit.semantic.related"];
+
 pub(crate) fn safe_mcp_tool_names() -> Vec<&'static str> {
     let mut names = Vec::with_capacity(
-        TASK_TOOL_NAMES.len() + FRICTION_TOOL_NAMES.len() + GRAPH_READ_TOOL_NAMES.len(),
+        TASK_TOOL_NAMES.len()
+            + FRICTION_TOOL_NAMES.len()
+            + GRAPH_READ_TOOL_NAMES.len()
+            + SEMANTIC_READ_TOOL_NAMES.len(),
     );
     names.extend_from_slice(TASK_TOOL_NAMES);
     names.extend_from_slice(FRICTION_TOOL_NAMES);
     names.extend_from_slice(GRAPH_READ_TOOL_NAMES);
+    names.extend_from_slice(SEMANTIC_READ_TOOL_NAMES);
     names
 }
 
@@ -79,6 +86,7 @@ pub(crate) fn is_mcp_tool_exposed(name: &str) -> bool {
     TASK_TOOL_NAMES.contains(&name)
         || FRICTION_TOOL_NAMES.contains(&name)
         || GRAPH_READ_TOOL_NAMES.contains(&name)
+        || SEMANTIC_READ_TOOL_NAMES.contains(&name)
 }
 
 fn ensure_mcp_tool_exposed(name: &str) -> Result<(), OrbitError> {
@@ -298,8 +306,8 @@ mod tests {
     use orbit_mcp::McpHost;
 
     use super::{
-        GRAPH_READ_TOOL_NAMES, RuntimeMcpHost, TASK_TOOL_NAMES, is_mcp_tool_exposed,
-        safe_mcp_tool_names,
+        GRAPH_READ_TOOL_NAMES, RuntimeMcpHost, SEMANTIC_READ_TOOL_NAMES, TASK_TOOL_NAMES,
+        is_mcp_tool_exposed, safe_mcp_tool_names,
     };
 
     #[test]
@@ -329,6 +337,14 @@ mod tests {
             assert!(
                 names.contains(*name),
                 "missing runtime graph read tool: {name}"
+            );
+            assert!(is_mcp_tool_exposed(name));
+        }
+
+        for name in SEMANTIC_READ_TOOL_NAMES {
+            assert!(
+                names.contains(*name),
+                "missing runtime semantic read tool: {name}"
             );
             assert!(is_mcp_tool_exposed(name));
         }
@@ -364,6 +380,13 @@ mod tests {
             assert!(
                 listed.contains(*name),
                 "client-visible MCP tool list missing graph read tool: {name}"
+            );
+        }
+
+        for name in SEMANTIC_READ_TOOL_NAMES {
+            assert!(
+                listed.contains(*name),
+                "client-visible MCP tool list missing semantic read tool: {name}"
             );
         }
 

--- a/crates/orbit-cli/src/command/mod.rs
+++ b/crates/orbit-cli/src/command/mod.rs
@@ -203,6 +203,32 @@ mod tests {
     }
 
     #[test]
+    fn cli_parses_semantic_search() {
+        let cli = Cli::parse_from(["orbit", "semantic", "search", "semantic search design"]);
+        match cli.command {
+            Commands::Semantic(command) => match command.command {
+                SemanticSubcommand::Search(args) => {
+                    assert_eq!(args.query, "semantic search design")
+                }
+                _ => panic!("expected semantic search"),
+            },
+            _ => panic!("expected top-level semantic command"),
+        }
+    }
+
+    #[test]
+    fn cli_parses_semantic_related() {
+        let cli = Cli::parse_from(["orbit", "semantic", "related", "T20260510-3"]);
+        match cli.command {
+            Commands::Semantic(command) => match command.command {
+                SemanticSubcommand::Related(args) => assert_eq!(args.task_id, "T20260510-3"),
+                _ => panic!("expected semantic related"),
+            },
+            _ => panic!("expected top-level semantic command"),
+        }
+    }
+
+    #[test]
     fn cli_rejects_top_level_serve() {
         assert!(Cli::try_parse_from(["orbit", "serve"]).is_err());
     }

--- a/crates/orbit-cli/src/command/semantic.rs
+++ b/crates/orbit-cli/src/command/semantic.rs
@@ -1,6 +1,7 @@
 use clap::{Args, Subcommand};
 use orbit_core::command::semantic::{
-    SemanticInstallParams, SemanticReindexParams, SemanticUninstallParams,
+    SemanticInstallParams, SemanticReindexParams, SemanticRelatedParams, SemanticSearchParams,
+    SemanticUninstallParams,
 };
 use orbit_core::{OrbitError, OrbitRuntime};
 use serde_json::json;
@@ -24,6 +25,10 @@ pub enum SemanticSubcommand {
     Reindex(SemanticReindexArgs),
     /// Show semantic-search index and companion status
     Stats(SemanticStatsArgs),
+    /// Hybrid semantic search over indexed task fields
+    Search(SemanticSearchArgs),
+    /// Find semantically related tasks
+    Related(SemanticRelatedArgs),
 }
 
 #[derive(Args)]
@@ -60,6 +65,32 @@ pub struct SemanticStatsArgs {
     pub json: bool,
 }
 
+#[derive(Args)]
+pub struct SemanticSearchArgs {
+    pub query: String,
+    #[arg(long, default_value_t = 10)]
+    pub limit: usize,
+    #[arg(long)]
+    pub field: Option<String>,
+    #[arg(long)]
+    pub kind: Option<String>,
+    #[arg(long)]
+    pub model: Option<String>,
+    #[arg(long)]
+    pub json: bool,
+}
+
+#[derive(Args)]
+pub struct SemanticRelatedArgs {
+    pub task_id: String,
+    #[arg(long, default_value_t = 10)]
+    pub limit: usize,
+    #[arg(long)]
+    pub model: Option<String>,
+    #[arg(long)]
+    pub json: bool,
+}
+
 impl Execute for SemanticCommand {
     fn execute(self, runtime: &OrbitRuntime) -> Result<(), OrbitError> {
         self.command.execute(runtime)
@@ -73,6 +104,8 @@ impl Execute for SemanticSubcommand {
             SemanticSubcommand::Uninstall(args) => args.execute(runtime),
             SemanticSubcommand::Reindex(args) => args.execute(runtime),
             SemanticSubcommand::Stats(args) => args.execute(runtime),
+            SemanticSubcommand::Search(args) => args.execute(runtime),
+            SemanticSubcommand::Related(args) => args.execute(runtime),
         }
     }
 }
@@ -164,5 +197,53 @@ impl Execute for SemanticStatsArgs {
             );
             Ok(())
         }
+    }
+}
+
+impl Execute for SemanticSearchArgs {
+    fn execute(self, runtime: &OrbitRuntime) -> Result<(), OrbitError> {
+        let result = runtime.semantic_search(SemanticSearchParams {
+            query: self.query,
+            limit: self.limit,
+            field: self.field,
+            kind: self.kind,
+            model: self.model,
+        })?;
+        if self.json {
+            crate::output::json::print_pretty(&json!(result))
+        } else {
+            print_hits(&result.results);
+            println!("model={}", result.model_id);
+            Ok(())
+        }
+    }
+}
+
+impl Execute for SemanticRelatedArgs {
+    fn execute(self, runtime: &OrbitRuntime) -> Result<(), OrbitError> {
+        let result = runtime.semantic_related(SemanticRelatedParams {
+            task_id: self.task_id,
+            limit: self.limit,
+            model: self.model,
+        })?;
+        if self.json {
+            crate::output::json::print_pretty(&json!(result))
+        } else {
+            print_hits(&result.results);
+            println!("model={}", result.model_id);
+            Ok(())
+        }
+    }
+}
+
+fn print_hits(results: &[orbit_core::command::semantic::SemanticHit]) {
+    for hit in results {
+        println!(
+            "{}  score={:.4}  best={}  snippet=\"{}\"",
+            hit.source_id,
+            hit.score,
+            hit.best_field,
+            hit.snippet.replace('"', "\\\"")
+        );
     }
 }

--- a/crates/orbit-core/src/command/semantic.rs
+++ b/crates/orbit-core/src/command/semantic.rs
@@ -2,8 +2,10 @@ use orbit_common::types::OrbitError;
 use orbit_embed::commands::{self as semantic_commands};
 
 pub use orbit_embed::commands::{
-    CompanionStatus, SemanticInstallParams, SemanticInstallResult, SemanticReindexParams,
-    SemanticReindexResult, SemanticStatsResult, SemanticUninstallParams, SemanticUninstallResult,
+    CompanionStatus, ScoreBreakdown, SemanticHit, SemanticInstallParams, SemanticInstallResult,
+    SemanticReindexParams, SemanticReindexResult, SemanticRelatedParams, SemanticRelatedResult,
+    SemanticSearchParams, SemanticSearchResult, SemanticStatsResult, SemanticUninstallParams,
+    SemanticUninstallResult,
 };
 
 use crate::OrbitRuntime;
@@ -40,5 +42,20 @@ impl OrbitRuntime {
             .map(|task| task.id)
             .collect();
         semantic_commands::stats::run(&self.stores().semantic_vector, &task_ids)
+    }
+
+    pub fn semantic_search(
+        &self,
+        params: SemanticSearchParams,
+    ) -> Result<SemanticSearchResult, OrbitError> {
+        semantic_commands::search::run(&self.stores().semantic_vector, params)
+    }
+
+    pub fn semantic_related(
+        &self,
+        params: SemanticRelatedParams,
+    ) -> Result<SemanticRelatedResult, OrbitError> {
+        let tasks = self.stores().tasks().list()?;
+        semantic_commands::related::run(&self.stores().semantic_vector, &tasks, params)
     }
 }

--- a/crates/orbit-core/src/runtime/orbit_tool_host/dispatch.rs
+++ b/crates/orbit-core/src/runtime/orbit_tool_host/dispatch.rs
@@ -34,6 +34,8 @@ pub(super) fn execute(
         OrbitBuiltinAction::ReviewThreadResolve => {
             super::review_threads::resolve(runtime, input, agent, model)
         }
+        OrbitBuiltinAction::SemanticRelated => super::semantic_tools::related(runtime, input),
+        OrbitBuiltinAction::SemanticSearch => super::semantic_tools::search(runtime, input),
         OrbitBuiltinAction::StateGet => super::state_tools::get(task_scope, input),
         OrbitBuiltinAction::StateSet => super::state_tools::set(task_scope, input),
         OrbitBuiltinAction::TaskAdd => super::task_tools::add(runtime, input, agent, model),

--- a/crates/orbit-core/src/runtime/orbit_tool_host/mod.rs
+++ b/crates/orbit-core/src/runtime/orbit_tool_host/mod.rs
@@ -5,6 +5,7 @@ mod input;
 mod json;
 mod pipeline_tools;
 mod review_threads;
+mod semantic_tools;
 mod state_tools;
 mod task_locks;
 mod task_tools;

--- a/crates/orbit-core/src/runtime/orbit_tool_host/semantic_tools.rs
+++ b/crates/orbit-core/src/runtime/orbit_tool_host/semantic_tools.rs
@@ -1,0 +1,39 @@
+use orbit_common::types::{OrbitError, optional_string_alias, optional_u32_alias, required_string};
+use orbit_embed::commands::{SemanticRelatedParams, SemanticSearchParams};
+use serde_json::Value;
+
+use crate::OrbitRuntime;
+
+pub(super) fn search(runtime: &OrbitRuntime, input: Value) -> Result<Value, OrbitError> {
+    let result = runtime.semantic_search(SemanticSearchParams {
+        query: required_string(&input, &["query"], "query")?,
+        limit: optional_limit(&input)?.unwrap_or(10),
+        field: optional_string_alias(&input, &["field"])?,
+        kind: optional_string_alias(&input, &["kind"])?,
+        model: optional_string_alias(
+            &input,
+            &["embedding_model", "embeddingModel", "embedding-model"],
+        )?,
+    })?;
+    serde_json::to_value(result).map_err(|error| {
+        OrbitError::Execution(format!("serialize semantic search result: {error}"))
+    })
+}
+
+pub(super) fn related(runtime: &OrbitRuntime, input: Value) -> Result<Value, OrbitError> {
+    let result = runtime.semantic_related(SemanticRelatedParams {
+        task_id: required_string(&input, &["id", "task_id", "taskId", "task-id"], "id")?,
+        limit: optional_limit(&input)?.unwrap_or(10),
+        model: optional_string_alias(
+            &input,
+            &["embedding_model", "embeddingModel", "embedding-model"],
+        )?,
+    })?;
+    serde_json::to_value(result).map_err(|error| {
+        OrbitError::Execution(format!("serialize semantic related result: {error}"))
+    })
+}
+
+fn optional_limit(input: &Value) -> Result<Option<usize>, OrbitError> {
+    optional_u32_alias(input, &["limit"]).map(|value| value.map(|limit| limit as usize))
+}

--- a/crates/orbit-embed/src/commands/mod.rs
+++ b/crates/orbit-embed/src/commands/mod.rs
@@ -7,11 +7,15 @@
 
 pub mod install;
 pub mod reindex;
+pub mod related;
+pub mod search;
 pub mod stats;
 pub mod uninstall;
 
 pub use install::{SemanticInstallParams, SemanticInstallResult};
 pub use reindex::{SemanticReindexParams, SemanticReindexResult};
+pub use related::{SemanticRelatedParams, SemanticRelatedResult};
+pub use search::{ScoreBreakdown, SemanticHit, SemanticSearchParams, SemanticSearchResult};
 pub use stats::{CompanionStatus, SemanticStatsResult};
 pub use uninstall::{SemanticUninstallParams, SemanticUninstallResult};
 
@@ -29,6 +33,16 @@ pub(crate) fn parse_model(model: Option<&str>) -> Result<ModelSpec, OrbitError> 
         Some(value) => ModelSpec::parse(value),
         None => Ok(default_model()),
     }
+}
+
+pub(crate) fn resolve_query_model(model: Option<&str>) -> Result<ModelSpec, OrbitError> {
+    if model.is_some() {
+        return parse_model(model);
+    }
+    let active = CompanionPaths::default_under_home()
+        .ok()
+        .and_then(|paths| active_model(&paths));
+    parse_model(active.as_deref())
 }
 
 pub(crate) fn active_model(paths: &CompanionPaths) -> Option<String> {

--- a/crates/orbit-embed/src/commands/related.rs
+++ b/crates/orbit-embed/src/commands/related.rs
@@ -1,0 +1,232 @@
+use orbit_common::types::{OrbitError, Task};
+use serde::{Deserialize, Serialize};
+
+use crate::commands::resolve_query_model;
+use crate::commands::search::{ScoreBreakdown, SemanticHit, truncate_snippet};
+use crate::vector::VectorStore;
+use crate::vector::query::{FusedCandidate, cosine_top_k, rollup_to_tasks, snippet_for_hit};
+use crate::{Embedder, SubprocessEmbedder};
+
+const DEFAULT_LIMIT: usize = 10;
+const RETRIEVER_OVERFETCH: usize = 4;
+
+#[derive(Debug, Clone)]
+pub struct SemanticRelatedParams {
+    pub task_id: String,
+    pub limit: usize,
+    pub model: Option<String>,
+}
+
+impl SemanticRelatedParams {
+    pub fn normalized_limit(&self) -> usize {
+        if self.limit == 0 {
+            DEFAULT_LIMIT
+        } else {
+            self.limit
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct SemanticRelatedResult {
+    pub results: Vec<SemanticHit>,
+    pub model_id: String,
+}
+
+pub fn run(
+    vector_store: &VectorStore,
+    tasks: &[Task],
+    params: SemanticRelatedParams,
+) -> Result<SemanticRelatedResult, OrbitError> {
+    let model = resolve_query_model(params.model.as_deref())?;
+    let embedder = SubprocessEmbedder::with_model(model.alias)?;
+    run_with_embedder(vector_store, tasks, &embedder, params)
+}
+
+pub(crate) fn run_with_embedder(
+    vector_store: &VectorStore,
+    tasks: &[Task],
+    embedder: &dyn Embedder,
+    params: SemanticRelatedParams,
+) -> Result<SemanticRelatedResult, OrbitError> {
+    let target = tasks
+        .iter()
+        .find(|task| task.id == params.task_id)
+        .ok_or_else(|| OrbitError::TaskNotFound(params.task_id.clone()))?;
+    let query = format!("{}\n\n{}", target.title.trim(), target.description.trim());
+    let query = query.trim();
+    if query.is_empty() {
+        return Err(OrbitError::InvalidInput(format!(
+            "task {} has no embeddable purpose/summary",
+            target.id
+        )));
+    }
+
+    let vectors = embedder.embed(&[query])?;
+    let query_vector = vectors.into_iter().next().ok_or_else(|| {
+        OrbitError::Execution("embedder returned no vector for semantic related query".to_string())
+    })?;
+    let limit = params.normalized_limit();
+    let retriever_limit = limit.saturating_mul(RETRIEVER_OVERFETCH).max(limit + 1);
+    let cosine = cosine_top_k(
+        vector_store,
+        &query_vector,
+        embedder.model_id(),
+        retriever_limit,
+        Some("task"),
+    )?;
+    let candidates = cosine
+        .into_iter()
+        .filter(|hit| hit.source_id != target.id)
+        .map(|hit| FusedCandidate {
+            source_kind: hit.source_kind,
+            source_id: hit.source_id,
+            field: hit.field,
+            chunk_idx_for_snippet: Some(hit.chunk_idx),
+            rowid_for_snippet: None,
+            score: hit.score,
+            bm25_rank: None,
+            cosine_rank: Some(hit.rank),
+        })
+        .collect::<Vec<_>>();
+    let task_hits = rollup_to_tasks(candidates, limit);
+    let results = task_hits
+        .into_iter()
+        .map(|hit| {
+            let snippet = snippet_for_hit(
+                vector_store,
+                &hit.source_id,
+                &hit.best_field,
+                hit.best_chunk_idx,
+                hit.best_rowid,
+            )?
+            .unwrap_or_default();
+            Ok(SemanticHit {
+                source_kind: hit.source_kind,
+                source_id: hit.source_id,
+                best_field: hit.best_field,
+                snippet: truncate_snippet(&snippet),
+                score: hit.score,
+                score_breakdown: ScoreBreakdown {
+                    rrf: None,
+                    bm25_rank: None,
+                    cosine_rank: hit.cosine_rank,
+                },
+            })
+        })
+        .collect::<Result<Vec<_>, OrbitError>>()?;
+
+    Ok(SemanticRelatedResult {
+        results,
+        model_id: embedder.model_id().to_string(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use chrono::Utc;
+    use orbit_common::types::{Task, TaskPriority, TaskStatus, TaskType};
+
+    use super::*;
+
+    #[derive(Default)]
+    struct KeywordEmbedder;
+
+    impl Embedder for KeywordEmbedder {
+        fn model_id(&self) -> &str {
+            "keyword"
+        }
+
+        fn dim(&self) -> usize {
+            3
+        }
+
+        fn max_input_tokens(&self) -> usize {
+            512
+        }
+
+        fn embed(&self, texts: &[&str]) -> Result<Vec<Vec<f32>>, OrbitError> {
+            Ok(texts.iter().map(|text| vector_for(text)).collect())
+        }
+
+        fn token_count(&self, text: &str) -> Result<usize, OrbitError> {
+            Ok(text.split_whitespace().count().max(1))
+        }
+    }
+
+    fn vector_for(text: &str) -> Vec<f32> {
+        let lower = text.to_ascii_lowercase();
+        if lower.contains("semantic") {
+            vec![1.0, 0.0, 0.0]
+        } else {
+            vec![0.0, 1.0, 0.0]
+        }
+    }
+
+    fn task(id: &str, title: &str, description: &str) -> Task {
+        Task {
+            id: id.to_string(),
+            parent_id: None,
+            title: title.to_string(),
+            description: description.to_string(),
+            acceptance_criteria: Vec::new(),
+            dependencies: Vec::new(),
+            tags: Vec::new(),
+            plan: String::new(),
+            execution_summary: String::new(),
+            context_files: Vec::new(),
+            workspace_path: None,
+            repo_root: None,
+            created_by: None,
+            planned_by: None,
+            implemented_by: None,
+            agent: None,
+            model: None,
+            status: TaskStatus::Backlog,
+            priority: TaskPriority::Medium,
+            complexity: None,
+            task_type: TaskType::Chore,
+            pr_status: None,
+            external_refs: Vec::new(),
+            source_task_id: None,
+            batch_id: None,
+            comments: Vec::new(),
+            history: Vec::new(),
+            review_threads: Vec::new(),
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+        }
+    }
+
+    #[test]
+    fn related_excludes_self_and_uses_cosine_only() {
+        let store = VectorStore::open_in_memory().unwrap();
+        let embedder = KeywordEmbedder;
+        let tasks = vec![
+            task("T1", "semantic search", "design"),
+            task("T2", "semantic related", "retrieval"),
+            task("T3", "billing", "invoices"),
+        ];
+        for task in &tasks {
+            store.index_task(task, &embedder, false).unwrap();
+        }
+
+        let result = run_with_embedder(
+            &store,
+            &tasks,
+            &embedder,
+            SemanticRelatedParams {
+                task_id: "T1".to_string(),
+                limit: 3,
+                model: None,
+            },
+        )
+        .unwrap();
+
+        assert!(!result.results.iter().any(|hit| hit.source_id == "T1"));
+        assert_eq!(result.results[0].source_id, "T2");
+        assert!(result.results[0].score_breakdown.cosine_rank.is_some());
+        assert!(result.results[0].score_breakdown.bm25_rank.is_none());
+        assert!(result.results[0].score_breakdown.rrf.is_none());
+    }
+}

--- a/crates/orbit-embed/src/commands/search.rs
+++ b/crates/orbit-embed/src/commands/search.rs
@@ -1,0 +1,303 @@
+use std::thread;
+
+use orbit_common::types::OrbitError;
+use serde::{Deserialize, Serialize};
+
+use crate::commands::resolve_query_model;
+use crate::vector::VectorStore;
+use crate::vector::query::{
+    FusedCandidate, bm25_top_k, reciprocal_rank_fusion, rollup_to_tasks, snippet_for_hit,
+};
+use crate::{Embedder, SubprocessEmbedder};
+
+const DEFAULT_LIMIT: usize = 10;
+const RETRIEVER_OVERFETCH: usize = 4;
+const SNIPPET_MAX_CHARS: usize = 280;
+
+#[derive(Debug, Clone)]
+pub struct SemanticSearchParams {
+    pub query: String,
+    pub limit: usize,
+    pub field: Option<String>,
+    pub kind: Option<String>,
+    pub model: Option<String>,
+}
+
+impl SemanticSearchParams {
+    pub fn normalized_limit(&self) -> usize {
+        if self.limit == 0 {
+            DEFAULT_LIMIT
+        } else {
+            self.limit
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct SemanticSearchResult {
+    pub results: Vec<SemanticHit>,
+    pub model_id: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct SemanticHit {
+    pub source_kind: String,
+    pub source_id: String,
+    pub best_field: String,
+    pub snippet: String,
+    pub score: f32,
+    pub score_breakdown: ScoreBreakdown,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ScoreBreakdown {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub rrf: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub bm25_rank: Option<usize>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cosine_rank: Option<usize>,
+}
+
+pub fn run(
+    vector_store: &VectorStore,
+    params: SemanticSearchParams,
+) -> Result<SemanticSearchResult, OrbitError> {
+    let model = resolve_query_model(params.model.as_deref())?;
+    let embedder = SubprocessEmbedder::with_model(model.alias)?;
+    run_with_embedder(vector_store, &embedder, params)
+}
+
+pub(crate) fn run_with_embedder(
+    vector_store: &VectorStore,
+    embedder: &dyn Embedder,
+    params: SemanticSearchParams,
+) -> Result<SemanticSearchResult, OrbitError> {
+    let query = params.query.trim();
+    if query.is_empty() {
+        return Err(OrbitError::InvalidInput(
+            "semantic search query must not be empty".to_string(),
+        ));
+    }
+
+    let vectors = embedder.embed(&[query])?;
+    let query_vector = vectors.into_iter().next().ok_or_else(|| {
+        OrbitError::Execution("embedder returned no vector for semantic search query".to_string())
+    })?;
+    let limit = params.normalized_limit();
+    let retriever_limit = limit.saturating_mul(RETRIEVER_OVERFETCH).max(limit);
+    let kind = params.kind.as_deref();
+    let model_id = embedder.model_id().to_string();
+    let query_for_bm25 = query.to_string();
+    let cosine_store = vector_store.clone();
+    let bm25_store = vector_store.clone();
+    let cosine_model_id = model_id.clone();
+    let cosine_kind = kind.map(ToOwned::to_owned);
+
+    let (cosine, bm25) = thread::scope(|scope| {
+        let cosine_handle = scope.spawn(|| {
+            crate::vector::query::cosine_top_k(
+                &cosine_store,
+                &query_vector,
+                &cosine_model_id,
+                retriever_limit,
+                cosine_kind.as_deref(),
+            )
+        });
+        let bm25_handle = scope.spawn(|| bm25_top_k(&bm25_store, &query_for_bm25, retriever_limit));
+        let cosine = cosine_handle
+            .join()
+            .map_err(|_| OrbitError::Execution("cosine retriever panicked".to_string()))?;
+        let bm25 = bm25_handle
+            .join()
+            .map_err(|_| OrbitError::Execution("bm25 retriever panicked".to_string()))?;
+        Ok::<_, OrbitError>((cosine?, bm25?))
+    })?;
+
+    let mut candidates = reciprocal_rank_fusion(&cosine, &bm25);
+    apply_candidate_filters(&mut candidates, params.field.as_deref(), kind);
+    let task_hits = rollup_to_tasks(candidates, limit);
+    let results = task_hits
+        .into_iter()
+        .map(|hit| {
+            let snippet = snippet_for_hit(
+                vector_store,
+                &hit.source_id,
+                &hit.best_field,
+                hit.best_chunk_idx,
+                hit.best_rowid,
+            )?
+            .unwrap_or_default();
+            Ok(SemanticHit {
+                source_kind: hit.source_kind,
+                source_id: hit.source_id,
+                best_field: hit.best_field,
+                snippet: truncate_snippet(&snippet),
+                score: hit.score,
+                score_breakdown: ScoreBreakdown {
+                    rrf: Some(hit.score),
+                    bm25_rank: hit.bm25_rank,
+                    cosine_rank: hit.cosine_rank,
+                },
+            })
+        })
+        .collect::<Result<Vec<_>, OrbitError>>()?;
+
+    Ok(SemanticSearchResult { results, model_id })
+}
+
+pub(crate) fn apply_candidate_filters(
+    candidates: &mut Vec<FusedCandidate>,
+    field: Option<&str>,
+    kind: Option<&str>,
+) {
+    candidates.retain(|candidate| {
+        field.is_none_or(|field| candidate.field == field)
+            && kind.is_none_or(|kind| candidate.source_kind == kind)
+    });
+}
+
+pub(crate) fn truncate_snippet(snippet: &str) -> String {
+    let trimmed = snippet.trim();
+    let mut end = 0;
+    for (idx, ch) in trimmed.char_indices() {
+        if idx > SNIPPET_MAX_CHARS {
+            break;
+        }
+        end = idx + ch.len_utf8();
+    }
+    if end >= trimmed.len() {
+        trimmed.to_string()
+    } else {
+        format!("{}...", trimmed[..end].trim_end())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use chrono::Utc;
+    use orbit_common::types::{Task, TaskPriority, TaskStatus, TaskType};
+
+    use super::*;
+    use crate::vector::VectorStore;
+
+    #[derive(Default)]
+    struct KeywordEmbedder;
+
+    impl Embedder for KeywordEmbedder {
+        fn model_id(&self) -> &str {
+            "keyword"
+        }
+
+        fn dim(&self) -> usize {
+            3
+        }
+
+        fn max_input_tokens(&self) -> usize {
+            512
+        }
+
+        fn embed(&self, texts: &[&str]) -> Result<Vec<Vec<f32>>, OrbitError> {
+            Ok(texts.iter().map(|text| vector_for(text)).collect())
+        }
+
+        fn token_count(&self, text: &str) -> Result<usize, OrbitError> {
+            Ok(text.split_whitespace().count().max(1))
+        }
+    }
+
+    fn vector_for(text: &str) -> Vec<f32> {
+        let lower = text.to_ascii_lowercase();
+        if lower.contains("semantic design") {
+            vec![1.0, 0.0, 0.0]
+        } else if lower.contains("semantic") {
+            vec![0.8, 0.2, 0.0]
+        } else {
+            vec![0.0, 1.0, 0.0]
+        }
+    }
+
+    fn task(id: &str, title: &str, description: &str, plan: &str) -> Task {
+        Task {
+            id: id.to_string(),
+            parent_id: None,
+            title: title.to_string(),
+            description: description.to_string(),
+            acceptance_criteria: Vec::new(),
+            dependencies: Vec::new(),
+            tags: Vec::new(),
+            plan: plan.to_string(),
+            execution_summary: String::new(),
+            context_files: Vec::new(),
+            workspace_path: None,
+            repo_root: None,
+            created_by: None,
+            planned_by: None,
+            implemented_by: None,
+            agent: None,
+            model: None,
+            status: TaskStatus::Backlog,
+            priority: TaskPriority::Medium,
+            complexity: None,
+            task_type: TaskType::Chore,
+            pr_status: None,
+            external_refs: Vec::new(),
+            source_task_id: None,
+            batch_id: None,
+            comments: Vec::new(),
+            history: Vec::new(),
+            review_threads: Vec::new(),
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+        }
+    }
+
+    #[test]
+    fn search_runs_both_retrievers_and_rolls_up_fields() {
+        let store = VectorStore::open_in_memory().unwrap();
+        let embedder = KeywordEmbedder;
+        store
+            .index_task(
+                &task(
+                    "T1",
+                    "semantic design",
+                    "semantic notes",
+                    "semantic design appears again in plan",
+                ),
+                &embedder,
+                false,
+            )
+            .unwrap();
+        store
+            .index_task(
+                &task("T2", "unrelated", "other text", "other plan"),
+                &embedder,
+                false,
+            )
+            .unwrap();
+
+        let result = run_with_embedder(
+            &store,
+            &embedder,
+            SemanticSearchParams {
+                query: "semantic design".to_string(),
+                limit: 10,
+                field: None,
+                kind: Some("task".to_string()),
+                model: None,
+            },
+        )
+        .unwrap();
+
+        let t1_hits = result
+            .results
+            .iter()
+            .filter(|hit| hit.source_id == "T1")
+            .collect::<Vec<_>>();
+        assert_eq!(t1_hits.len(), 1);
+        let breakdown = &t1_hits[0].score_breakdown;
+        assert!(breakdown.rrf.is_some());
+        assert!(breakdown.bm25_rank.is_some());
+        assert!(breakdown.cosine_rank.is_some());
+    }
+}

--- a/crates/orbit-embed/src/vector/mod.rs
+++ b/crates/orbit-embed/src/vector/mod.rs
@@ -7,6 +7,7 @@
 //!   model's context window.
 //! - [`worker`] — background indexer that drains task-mutation events into
 //!   the store via a `SubprocessEmbedder`.
+//! - [`query`] — brute-force cosine, FTS5 BM25, RRF, and task-result rollup.
 //! - [`task_fields`] — extracts the per-field rows that get embedded for a
 //!   `Task`.
 //!
@@ -16,6 +17,7 @@
 //! those submodules.
 
 pub mod chunker;
+pub mod query;
 pub mod store;
 pub mod task_fields;
 pub mod worker;

--- a/crates/orbit-embed/src/vector/query/bm25.rs
+++ b/crates/orbit-embed/src/vector/query/bm25.rs
@@ -1,0 +1,192 @@
+use orbit_common::types::OrbitError;
+use rusqlite::params;
+
+use crate::vector::store::VectorStore;
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct Bm25Hit {
+    pub source_kind: String,
+    pub source_id: String,
+    pub field: String,
+    pub rowid: i64,
+    pub rank: usize,
+}
+
+pub fn bm25_top_k(
+    store: &VectorStore,
+    query: &str,
+    limit: usize,
+) -> Result<Vec<Bm25Hit>, OrbitError> {
+    if query.trim().is_empty() || limit == 0 {
+        return Ok(Vec::new());
+    }
+
+    let match_query = fts_phrase_quote(query);
+    let conn = store.connection();
+    let conn = conn
+        .lock()
+        .map_err(|error| OrbitError::Store(format!("mutex poisoned: {error}")))?;
+    let mut stmt = conn
+        .prepare(
+            r#"
+                SELECT source_id, field, rowid, bm25(tasks_fts) AS rank
+                FROM tasks_fts
+                WHERE tasks_fts MATCH ?1
+                ORDER BY rank
+                LIMIT ?2
+            "#,
+        )
+        .map_err(|error| OrbitError::Store(error.to_string()))?;
+    let mut rows = stmt
+        .query(params![match_query, limit as i64])
+        .map_err(|error| OrbitError::Store(error.to_string()))?;
+    let mut hits = Vec::new();
+    while let Some(row) = rows
+        .next()
+        .map_err(|error| OrbitError::Store(error.to_string()))?
+    {
+        hits.push(Bm25Hit {
+            source_kind: "task".to_string(),
+            source_id: row
+                .get(0)
+                .map_err(|error| OrbitError::Store(error.to_string()))?,
+            field: row
+                .get(1)
+                .map_err(|error| OrbitError::Store(error.to_string()))?,
+            rowid: row
+                .get(2)
+                .map_err(|error| OrbitError::Store(error.to_string()))?,
+            rank: hits.len() + 1,
+        });
+    }
+    Ok(hits)
+}
+
+pub fn snippet_for_hit(
+    store: &VectorStore,
+    source_id: &str,
+    field: &str,
+    chunk_idx: Option<usize>,
+    rowid: Option<i64>,
+) -> Result<Option<String>, OrbitError> {
+    if let Some(rowid) = rowid {
+        return snippet_by_rowid(store, rowid);
+    }
+    let Some(chunk_idx) = chunk_idx else {
+        return Ok(None);
+    };
+    snippet_by_chunk_idx(store, source_id, field, chunk_idx)
+}
+
+fn snippet_by_rowid(store: &VectorStore, rowid: i64) -> Result<Option<String>, OrbitError> {
+    let conn = store.connection();
+    let conn = conn
+        .lock()
+        .map_err(|error| OrbitError::Store(format!("mutex poisoned: {error}")))?;
+    conn.query_row(
+        "SELECT content FROM tasks_fts WHERE rowid = ?1",
+        params![rowid],
+        |row| row.get::<_, String>(0),
+    )
+    .map(Some)
+    .or_else(|error| match error {
+        rusqlite::Error::QueryReturnedNoRows => Ok(None),
+        other => Err(OrbitError::Store(other.to_string())),
+    })
+}
+
+fn snippet_by_chunk_idx(
+    store: &VectorStore,
+    source_id: &str,
+    field: &str,
+    chunk_idx: usize,
+) -> Result<Option<String>, OrbitError> {
+    let conn = store.connection();
+    let conn = conn
+        .lock()
+        .map_err(|error| OrbitError::Store(format!("mutex poisoned: {error}")))?;
+    conn.query_row(
+        r#"
+            SELECT content
+            FROM tasks_fts
+            WHERE source_id = ?1 AND field = ?2
+            ORDER BY rowid
+            LIMIT 1 OFFSET ?3
+        "#,
+        params![source_id, field, chunk_idx as i64],
+        |row| row.get::<_, String>(0),
+    )
+    .map(Some)
+    .or_else(|error| match error {
+        rusqlite::Error::QueryReturnedNoRows => Ok(None),
+        other => Err(OrbitError::Store(other.to_string())),
+    })
+}
+
+fn fts_phrase_quote(query: &str) -> String {
+    format!("\"{}\"", query.trim().replace('"', "\"\""))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::NoopEmbedder;
+    use crate::vector::EmbeddingField;
+
+    #[test]
+    fn bm25_top_k_ranks_lexical_matches() {
+        let store = VectorStore::open_in_memory().unwrap();
+        let embedder = NoopEmbedder::small();
+        for (id, text) in [
+            ("T1", "alpha beta"),
+            ("T2", "neutrino unique token"),
+            ("T3", "gamma delta"),
+        ] {
+            store
+                .upsert_embeddings(
+                    "task",
+                    id,
+                    &[EmbeddingField::new("purpose", text)],
+                    &embedder,
+                    false,
+                )
+                .unwrap();
+        }
+
+        let hits = bm25_top_k(&store, "neutrino", 3).unwrap();
+
+        assert_eq!(hits[0].source_id, "T2");
+        assert_eq!(hits[0].field, "purpose");
+        assert_eq!(hits[0].rank, 1);
+    }
+
+    #[test]
+    fn bm25_phrase_quotes_embedded_double_quotes() {
+        assert_eq!(
+            fts_phrase_quote("foo \"bar\" baz"),
+            "\"foo \"\"bar\"\" baz\""
+        );
+    }
+
+    #[test]
+    fn snippet_lookup_preserves_chunk_order() {
+        let store = VectorStore::open_in_memory().unwrap();
+        let conn = store.connection();
+        let conn = conn.lock().unwrap();
+        conn.execute(
+            "INSERT INTO tasks_fts(source_id, field, content) VALUES (?1, ?2, ?3)",
+            ("T1", "purpose", "first chunk"),
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO tasks_fts(source_id, field, content) VALUES (?1, ?2, ?3)",
+            ("T1", "purpose", "second chunk"),
+        )
+        .unwrap();
+        drop(conn);
+
+        let snippet = snippet_for_hit(&store, "T1", "purpose", Some(1), None).unwrap();
+
+        assert_eq!(snippet.as_deref(), Some("second chunk"));
+    }
+}

--- a/crates/orbit-embed/src/vector/query/cosine.rs
+++ b/crates/orbit-embed/src/vector/query/cosine.rs
@@ -1,0 +1,162 @@
+use orbit_common::types::OrbitError;
+use rusqlite::params;
+
+use crate::vector::store::VectorStore;
+use crate::vector::{cosine_similarity, decode_f32_blob};
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct CosineHit {
+    pub source_kind: String,
+    pub source_id: String,
+    pub field: String,
+    pub chunk_idx: usize,
+    pub score: f32,
+    pub rank: usize,
+}
+
+pub fn cosine_top_k(
+    store: &VectorStore,
+    query: &[f32],
+    model_id: &str,
+    limit: usize,
+    kind: Option<&str>,
+) -> Result<Vec<CosineHit>, OrbitError> {
+    if query.is_empty() || limit == 0 {
+        return Ok(Vec::new());
+    }
+
+    let conn = store.connection();
+    let conn = conn
+        .lock()
+        .map_err(|error| OrbitError::Store(format!("mutex poisoned: {error}")))?;
+
+    let mut candidates = Vec::new();
+    if let Some(kind) = kind {
+        let mut stmt = conn
+            .prepare(
+                r#"
+                    SELECT source_kind, source_id, field, chunk_idx, embedding
+                    FROM embeddings
+                    WHERE model_id = ?1 AND source_kind = ?2
+                "#,
+            )
+            .map_err(|error| OrbitError::Store(error.to_string()))?;
+        let mut rows = stmt
+            .query(params![model_id, kind])
+            .map_err(|error| OrbitError::Store(error.to_string()))?;
+        while let Some(row) = rows
+            .next()
+            .map_err(|error| OrbitError::Store(error.to_string()))?
+        {
+            candidates.push(row_to_hit(row, query)?);
+        }
+    } else {
+        let mut stmt = conn
+            .prepare(
+                r#"
+                    SELECT source_kind, source_id, field, chunk_idx, embedding
+                    FROM embeddings
+                    WHERE model_id = ?1
+                "#,
+            )
+            .map_err(|error| OrbitError::Store(error.to_string()))?;
+        let mut rows = stmt
+            .query(params![model_id])
+            .map_err(|error| OrbitError::Store(error.to_string()))?;
+        while let Some(row) = rows
+            .next()
+            .map_err(|error| OrbitError::Store(error.to_string()))?
+        {
+            candidates.push(row_to_hit(row, query)?);
+        }
+    }
+
+    candidates.sort_by(compare_cosine_hits);
+    candidates.truncate(limit);
+    for (idx, hit) in candidates.iter_mut().enumerate() {
+        hit.rank = idx + 1;
+    }
+    Ok(candidates)
+}
+
+fn row_to_hit(row: &rusqlite::Row<'_>, query: &[f32]) -> Result<CosineHit, OrbitError> {
+    let embedding_blob: Vec<u8> = row
+        .get(4)
+        .map_err(|error| OrbitError::Store(error.to_string()))?;
+    let embedding = decode_f32_blob(&embedding_blob)?;
+    let score = cosine_similarity(query, &embedding)?;
+    Ok(CosineHit {
+        source_kind: row
+            .get(0)
+            .map_err(|error| OrbitError::Store(error.to_string()))?,
+        source_id: row
+            .get(1)
+            .map_err(|error| OrbitError::Store(error.to_string()))?,
+        field: row
+            .get(2)
+            .map_err(|error| OrbitError::Store(error.to_string()))?,
+        chunk_idx: row
+            .get::<_, i64>(3)
+            .map_err(|error| OrbitError::Store(error.to_string()))? as usize,
+        score,
+        rank: 0,
+    })
+}
+
+pub(crate) fn compare_cosine_hits(left: &CosineHit, right: &CosineHit) -> std::cmp::Ordering {
+    right
+        .score
+        .total_cmp(&left.score)
+        .then_with(|| left.source_kind.cmp(&right.source_kind))
+        .then_with(|| left.source_id.cmp(&right.source_id))
+        .then_with(|| left.field.cmp(&right.field))
+        .then_with(|| left.chunk_idx.cmp(&right.chunk_idx))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::vector::EmbeddingField;
+    use crate::{Embedder, NoopEmbedder};
+
+    #[test]
+    fn cosine_top_k_returns_expected_ordering_with_noop_vectors() {
+        let store = VectorStore::open_in_memory().unwrap();
+        let embedder = NoopEmbedder::small();
+        store
+            .upsert_embeddings(
+                "task",
+                "T1",
+                &[EmbeddingField::new("purpose", "alpha")],
+                &embedder,
+                false,
+            )
+            .unwrap();
+        store
+            .upsert_embeddings(
+                "task",
+                "T2",
+                &[EmbeddingField::new("purpose", "beta")],
+                &embedder,
+                false,
+            )
+            .unwrap();
+        store
+            .upsert_embeddings(
+                "task",
+                "T3",
+                &[EmbeddingField::new("purpose", "gamma")],
+                &embedder,
+                false,
+            )
+            .unwrap();
+
+        let query = embedder.embed(&["beta"]).unwrap().remove(0);
+        let hits = cosine_top_k(&store, &query, embedder.model_id(), 3, Some("task")).unwrap();
+
+        assert_eq!(hits.len(), 3);
+        assert_eq!(hits[0].source_id, "T2");
+        assert_eq!(hits[0].rank, 1);
+        assert!((hits[0].score - 1.0).abs() < 0.0001);
+    }
+}

--- a/crates/orbit-embed/src/vector/query/fuse.rs
+++ b/crates/orbit-embed/src/vector/query/fuse.rs
@@ -1,0 +1,167 @@
+use std::collections::BTreeMap;
+
+use super::{Bm25Hit, CosineHit};
+
+pub const RRF_K: f32 = 60.0;
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct FusedCandidate {
+    pub source_kind: String,
+    pub source_id: String,
+    pub field: String,
+    pub chunk_idx_for_snippet: Option<usize>,
+    pub rowid_for_snippet: Option<i64>,
+    pub score: f32,
+    pub bm25_rank: Option<usize>,
+    pub cosine_rank: Option<usize>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+struct CandidateKey {
+    source_kind: String,
+    source_id: String,
+    field: String,
+}
+
+pub fn reciprocal_rank_fusion(cosine: &[CosineHit], bm25: &[Bm25Hit]) -> Vec<FusedCandidate> {
+    let mut by_key = BTreeMap::<CandidateKey, FusedCandidate>::new();
+    for hit in cosine {
+        let entry = by_key
+            .entry(CandidateKey {
+                source_kind: hit.source_kind.clone(),
+                source_id: hit.source_id.clone(),
+                field: hit.field.clone(),
+            })
+            .or_insert_with(|| FusedCandidate {
+                source_kind: hit.source_kind.clone(),
+                source_id: hit.source_id.clone(),
+                field: hit.field.clone(),
+                chunk_idx_for_snippet: Some(hit.chunk_idx),
+                rowid_for_snippet: None,
+                score: 0.0,
+                bm25_rank: None,
+                cosine_rank: None,
+            });
+        if should_replace_rank(entry.cosine_rank, hit.rank) {
+            if let Some(rank) = entry.cosine_rank {
+                entry.score -= rrf_contribution(rank);
+            }
+            entry.score += rrf_contribution(hit.rank);
+            entry.cosine_rank = Some(hit.rank);
+            entry.chunk_idx_for_snippet = Some(hit.chunk_idx);
+        }
+    }
+    for hit in bm25 {
+        let entry = by_key
+            .entry(CandidateKey {
+                source_kind: hit.source_kind.clone(),
+                source_id: hit.source_id.clone(),
+                field: hit.field.clone(),
+            })
+            .or_insert_with(|| FusedCandidate {
+                source_kind: hit.source_kind.clone(),
+                source_id: hit.source_id.clone(),
+                field: hit.field.clone(),
+                chunk_idx_for_snippet: None,
+                rowid_for_snippet: Some(hit.rowid),
+                score: 0.0,
+                bm25_rank: None,
+                cosine_rank: None,
+            });
+        if should_replace_rank(entry.bm25_rank, hit.rank) {
+            if let Some(rank) = entry.bm25_rank {
+                entry.score -= rrf_contribution(rank);
+            }
+            entry.score += rrf_contribution(hit.rank);
+            entry.bm25_rank = Some(hit.rank);
+            entry.rowid_for_snippet = Some(hit.rowid);
+        }
+    }
+    let mut candidates = by_key.into_values().collect::<Vec<_>>();
+    candidates.sort_by(compare_fused_candidates);
+    candidates
+}
+
+pub(crate) fn compare_fused_candidates(
+    left: &FusedCandidate,
+    right: &FusedCandidate,
+) -> std::cmp::Ordering {
+    right
+        .score
+        .total_cmp(&left.score)
+        .then_with(|| left.source_kind.cmp(&right.source_kind))
+        .then_with(|| left.source_id.cmp(&right.source_id))
+        .then_with(|| left.field.cmp(&right.field))
+}
+
+pub(crate) fn rrf_contribution(rank: usize) -> f32 {
+    1.0 / (RRF_K + rank as f32)
+}
+
+fn should_replace_rank(current: Option<usize>, candidate: usize) -> bool {
+    current.is_none_or(|rank| candidate < rank)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn cosine(id: &str, rank: usize) -> CosineHit {
+        CosineHit {
+            source_kind: "task".to_string(),
+            source_id: id.to_string(),
+            field: "purpose".to_string(),
+            chunk_idx: 0,
+            score: 1.0 / rank as f32,
+            rank,
+        }
+    }
+
+    fn bm25(id: &str, rank: usize) -> Bm25Hit {
+        Bm25Hit {
+            source_kind: "task".to_string(),
+            source_id: id.to_string(),
+            field: "purpose".to_string(),
+            rowid: rank as i64,
+            rank,
+        }
+    }
+
+    #[test]
+    fn rrf_reproduces_hand_computed_rank_example() {
+        let fused = reciprocal_rank_fusion(
+            &[cosine("A", 1), cosine("B", 2), cosine("C", 3)],
+            &[bm25("B", 1), bm25("A", 2), bm25("D", 3)],
+        );
+
+        let by_id = fused
+            .iter()
+            .map(|hit| (hit.source_id.as_str(), hit.score))
+            .collect::<BTreeMap<_, _>>();
+        let ab_expected = (1.0 / 61.0) + (1.0 / 62.0);
+        let cd_expected = 1.0 / 63.0;
+        assert!((by_id["A"] - ab_expected).abs() < 0.000001);
+        assert!((by_id["B"] - ab_expected).abs() < 0.000001);
+        assert!((by_id["C"] - cd_expected).abs() < 0.000001);
+        assert!((by_id["D"] - cd_expected).abs() < 0.000001);
+        assert_eq!(
+            fused
+                .iter()
+                .map(|hit| hit.source_id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["A", "B", "C", "D"]
+        );
+    }
+
+    #[test]
+    fn rrf_counts_one_rank_per_retriever_per_field() {
+        let mut lower_chunk = cosine("A", 2);
+        lower_chunk.chunk_idx = 1;
+        let fused = reciprocal_rank_fusion(&[cosine("A", 1), lower_chunk], &[]);
+
+        assert_eq!(fused.len(), 1);
+        assert!((fused[0].score - (1.0 / 61.0)).abs() < 0.000001);
+        assert_eq!(fused[0].cosine_rank, Some(1));
+        assert_eq!(fused[0].chunk_idx_for_snippet, Some(0));
+    }
+}

--- a/crates/orbit-embed/src/vector/query/mod.rs
+++ b/crates/orbit-embed/src/vector/query/mod.rs
@@ -1,0 +1,11 @@
+//! Query-side retrieval primitives for the workspace-local semantic index.
+
+pub mod bm25;
+pub mod cosine;
+pub mod fuse;
+pub mod rollup;
+
+pub use bm25::{Bm25Hit, bm25_top_k, snippet_for_hit};
+pub use cosine::{CosineHit, cosine_top_k};
+pub use fuse::{FusedCandidate, reciprocal_rank_fusion};
+pub use rollup::{TaskHit, rollup_to_tasks};

--- a/crates/orbit-embed/src/vector/query/rollup.rs
+++ b/crates/orbit-embed/src/vector/query/rollup.rs
@@ -1,0 +1,101 @@
+use std::collections::BTreeMap;
+
+use super::FusedCandidate;
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct TaskHit {
+    pub source_kind: String,
+    pub source_id: String,
+    pub best_field: String,
+    pub best_chunk_idx: Option<usize>,
+    pub best_rowid: Option<i64>,
+    pub score: f32,
+    pub bm25_rank: Option<usize>,
+    pub cosine_rank: Option<usize>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+struct TaskKey {
+    source_kind: String,
+    source_id: String,
+}
+
+pub fn rollup_to_tasks(candidates: Vec<FusedCandidate>, limit: usize) -> Vec<TaskHit> {
+    if limit == 0 {
+        return Vec::new();
+    }
+
+    let mut by_task = BTreeMap::<TaskKey, TaskHit>::new();
+    for candidate in candidates {
+        let key = TaskKey {
+            source_kind: candidate.source_kind.clone(),
+            source_id: candidate.source_id.clone(),
+        };
+        let hit = TaskHit {
+            source_kind: candidate.source_kind,
+            source_id: candidate.source_id,
+            best_field: candidate.field,
+            best_chunk_idx: candidate.chunk_idx_for_snippet,
+            best_rowid: candidate.rowid_for_snippet,
+            score: candidate.score,
+            bm25_rank: candidate.bm25_rank,
+            cosine_rank: candidate.cosine_rank,
+        };
+        by_task
+            .entry(key)
+            .and_modify(|current| {
+                if compare_task_hits(&hit, current).is_lt() {
+                    *current = hit.clone();
+                }
+            })
+            .or_insert(hit);
+    }
+
+    let mut hits = by_task.into_values().collect::<Vec<_>>();
+    hits.sort_by(compare_task_hits);
+    hits.truncate(limit);
+    hits
+}
+
+fn compare_task_hits(left: &TaskHit, right: &TaskHit) -> std::cmp::Ordering {
+    right
+        .score
+        .total_cmp(&left.score)
+        .then_with(|| left.source_kind.cmp(&right.source_kind))
+        .then_with(|| left.source_id.cmp(&right.source_id))
+        .then_with(|| left.best_field.cmp(&right.best_field))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn candidate(id: &str, field: &str, score: f32) -> FusedCandidate {
+        FusedCandidate {
+            source_kind: "task".to_string(),
+            source_id: id.to_string(),
+            field: field.to_string(),
+            chunk_idx_for_snippet: Some(0),
+            rowid_for_snippet: None,
+            score,
+            bm25_rank: None,
+            cosine_rank: Some(1),
+        }
+    }
+
+    #[test]
+    fn rollup_keeps_highest_scoring_field_per_task() {
+        let hits = rollup_to_tasks(
+            vec![
+                candidate("T1", "summary", 0.2),
+                candidate("T1", "plan", 0.7),
+                candidate("T2", "purpose", 0.3),
+            ],
+            10,
+        );
+
+        assert_eq!(hits.len(), 2);
+        assert_eq!(hits[0].source_id, "T1");
+        assert_eq!(hits[0].best_field, "plan");
+    }
+}

--- a/crates/orbit-tools/src/builtin/orbit/mod.rs
+++ b/crates/orbit-tools/src/builtin/orbit/mod.rs
@@ -5,6 +5,7 @@ pub mod groundhog;
 pub mod knowledge;
 pub mod pipeline;
 pub mod review_thread;
+pub mod semantic;
 pub mod state;
 pub mod task;
 
@@ -66,6 +67,8 @@ pub fn register(registry: &mut ToolRegistry) {
     registry.register(review_thread::list::OrbitReviewThreadListTool);
     registry.register(review_thread::reply::OrbitReviewThreadReplyTool);
     registry.register(review_thread::resolve::OrbitReviewThreadResolveTool);
+    registry.register(semantic::search::OrbitSemanticSearchTool);
+    registry.register(semantic::related::OrbitSemanticRelatedTool);
     registry.register(state::get::OrbitStateGetTool);
     registry.register(state::set::OrbitStateSetTool);
 }

--- a/crates/orbit-tools/src/builtin/orbit/semantic/mod.rs
+++ b/crates/orbit-tools/src/builtin/orbit/semantic/mod.rs
@@ -1,0 +1,2 @@
+pub mod related;
+pub mod search;

--- a/crates/orbit-tools/src/builtin/orbit/semantic/related.rs
+++ b/crates/orbit-tools/src/builtin/orbit/semantic/related.rs
@@ -1,0 +1,43 @@
+use orbit_common::types::{OrbitError, ToolParam, ToolSchema};
+use serde_json::Value;
+
+use crate::{OrbitBuiltinAction, Tool, ToolContext};
+
+pub struct OrbitSemanticRelatedTool;
+
+impl Tool for OrbitSemanticRelatedTool {
+    fn schema(&self) -> ToolSchema {
+        let mut parameters = vec![
+            ToolParam {
+                name: "id".to_string(),
+                description: "Task ID.".to_string(),
+                param_type: "string".to_string(),
+                required: true,
+            },
+            ToolParam {
+                name: "limit".to_string(),
+                description: "Maximum number of related tasks to return.".to_string(),
+                param_type: "number".to_string(),
+                required: false,
+            },
+            ToolParam {
+                name: "embedding_model".to_string(),
+                description: "Optional semantic embedding model alias, such as bge-small."
+                    .to_string(),
+                param_type: "string".to_string(),
+                required: false,
+            },
+        ];
+        parameters.extend(super::super::model_identity_params());
+        ToolSchema {
+            name: "orbit.semantic.related".to_string(),
+            description: "Cosine-similarity neighbors for an indexed task. Read-only.".to_string(),
+            parameters,
+            builtin: true,
+        }
+    }
+
+    fn execute(&self, ctx: &ToolContext, input: Value) -> Result<Value, OrbitError> {
+        super::super::execute_host_action(ctx, input, OrbitBuiltinAction::SemanticRelated)
+    }
+}

--- a/crates/orbit-tools/src/builtin/orbit/semantic/search.rs
+++ b/crates/orbit-tools/src/builtin/orbit/semantic/search.rs
@@ -1,0 +1,59 @@
+use orbit_common::types::{OrbitError, ToolParam, ToolSchema};
+use serde_json::Value;
+
+use crate::{OrbitBuiltinAction, Tool, ToolContext};
+
+pub struct OrbitSemanticSearchTool;
+
+impl Tool for OrbitSemanticSearchTool {
+    fn schema(&self) -> ToolSchema {
+        let mut parameters = vec![
+            ToolParam {
+                name: "query".to_string(),
+                description: "Semantic query text.".to_string(),
+                param_type: "string".to_string(),
+                required: true,
+            },
+            ToolParam {
+                name: "limit".to_string(),
+                description: "Maximum number of results to return.".to_string(),
+                param_type: "number".to_string(),
+                required: false,
+            },
+            ToolParam {
+                name: "field".to_string(),
+                description:
+                    "Optional indexed task field filter, such as purpose, summary, or plan."
+                        .to_string(),
+                param_type: "string".to_string(),
+                required: false,
+            },
+            ToolParam {
+                name: "kind".to_string(),
+                description: "Optional source kind filter. Phase 1 supports task.".to_string(),
+                param_type: "string".to_string(),
+                required: false,
+            },
+            ToolParam {
+                name: "embedding_model".to_string(),
+                description: "Optional semantic embedding model alias, such as bge-small."
+                    .to_string(),
+                param_type: "string".to_string(),
+                required: false,
+            },
+        ];
+        parameters.extend(super::super::model_identity_params());
+        ToolSchema {
+            name: "orbit.semantic.search".to_string(),
+            description:
+                "Hybrid BM25 and cosine semantic search over indexed task fields. Read-only."
+                    .to_string(),
+            parameters,
+            builtin: true,
+        }
+    }
+
+    fn execute(&self, ctx: &ToolContext, input: Value) -> Result<Value, OrbitError> {
+        super::super::execute_host_action(ctx, input, OrbitBuiltinAction::SemanticSearch)
+    }
+}

--- a/crates/orbit-tools/src/lib.rs
+++ b/crates/orbit-tools/src/lib.rs
@@ -70,6 +70,8 @@ pub enum OrbitBuiltinAction {
     ReviewThreadList,
     ReviewThreadReply,
     ReviewThreadResolve,
+    SemanticRelated,
+    SemanticSearch,
     StateGet,
     StateSet,
     TaskAdd,

--- a/crates/orbit-tools/tests/public_tool_surface.rs
+++ b/crates/orbit-tools/tests/public_tool_surface.rs
@@ -65,6 +65,8 @@ fn workflow_critical_tools_remain_registered() {
         "orbit.groundhog.side_effect",
         "orbit.pipeline.invoke",
         "orbit.pipeline.wait",
+        "orbit.semantic.related",
+        "orbit.semantic.search",
         "orbit.task.artifact.put",
         "proc.spawn",
     ] {


### PR DESCRIPTION
## Task

[T20260510-10](https://orbit-cli.com/tasks/T20260510-10) — Phase-1 semantic search retrieval: hybrid query + CLI search/related + MCP

### Description

Land the retrieval half of the phase-1 skeleton specified in [docs/design/semantic-search/2_design.md](docs/design/semantic-search/2_design.md). Goal: hybrid search over task artifacts works end-to-end. The `orbit-embed` client, the `orbit-embed-companion` binary, the `embeddings` and `tasks_fts` tables, and `orbit semantic install/reindex/stats` already exist from [T20260510-9]; this task adds the query side, the CLI surface, and the MCP tools.

**Scope:**

1. **Brute-force cosine query path** ([2_design.md §3.2](docs/design/semantic-search/2_design.md))
   - Embed query via the injected `Embedder` (which routes to the companion subprocess) → linear scan over `embeddings` table filtered by `model_id` → fixed-size top-k heap on cosine similarity → return `(source_kind, source_id, field, chunk_idx, score)`.
   - SIMD-friendly contiguous buffers; not blocked on HNSW at phase-1 corpus scale.

2. **FTS5 BM25 query path** ([2_design.md §5.1](docs/design/semantic-search/2_design.md))
   - `SELECT source_id, field, bm25(tasks_fts) AS rank FROM tasks_fts WHERE tasks_fts MATCH ? ORDER BY rank LIMIT ?`.

3. **Reciprocal Rank Fusion** ([2_design.md §5.2](docs/design/semantic-search/2_design.md), [4_decisions.md ADR-004](docs/design/semantic-search/4_decisions.md))
   - `score(c) = Σ over retrievers r of: 1 / (k + rank_r(c))` with `k = 60`.
   - Both retrievers run in parallel for `search`.
   - `related` (similar-task discovery) is cosine-only; lexical fusion adds noise.
   - Result-formatter rolls multiple field hits on the same task to one result with the highest-scoring field as the snippet, preserving `bm25_rank` and `cosine_rank` per result.

4. **CLI surface** ([2_design.md §6.1](docs/design/semantic-search/2_design.md))
   - `orbit semantic search <query> [--limit N] [--field FIELD] [--kind task]`
   - `orbit semantic related <task-id> [--limit N]`
   - Both surface `OrbitError::CompanionNotInstalled` cleanly when the companion isn't installed (the query embedding step routes through the subprocess and will fail there).

5. **MCP surface** ([2_design.md §6.2, §6.3](docs/design/semantic-search/2_design.md))
   - `orbit.semantic.search` and `orbit.semantic.related`. Read-only.
   - Result shape per §6.3 including `score_breakdown` (`bm25_rank`, `cosine_rank`).

**Out of scope (explicit follow-ups):**
- Phase 2 (graph-symbol embeddings under `source_kind=symbol`).
- `sqlite-vec` HNSW upgrade — phase-1 ships brute force per [4_decisions.md ADR-002](docs/design/semantic-search/4_decisions.md).
- Evaluation harness — phase-1 deliberately defers per [3_vision.md §1.1](docs/design/semantic-search/3_vision.md).
- Snippet extraction polish (smart context-window selection from chunked fields beyond just returning the matched chunk).
- Cross-task semantic affordances (auto-duplicate-detect on insert, dependency suggestion, backlog clustering).

**Dependency:** [T20260510-9] must land first — this task builds on the `embeddings` and `tasks_fts` tables, the `Embedder` trait + `SubprocessEmbedder`, and the `orbit semantic install` flow it produces.

### Acceptance Criteria

- Brute-force cosine query is implemented in `orbit-store::vector` over the `embeddings` table; the query path embeds the query via the injected `Embedder` (which under phase-1 deployment is `SubprocessEmbedder` from [T20260510-9]). Correctness pinned by a `NoopEmbedder`-driven unit test on a 3-vector toy corpus.
- FTS5 BM25 query is implemented; correctness pinned by a unit test on a toy corpus.
- RRF fusion (k=60) combines both retrievers' rankings; unit-tested with hand-computed expected ranks on a synthetic case.
- Both retrievers run in parallel for `search`; `related` is cosine-only.
- Result formatter collapses multiple field hits on the same task into a single result with the highest-scoring field's snippet, preserving `bm25_rank` and `cosine_rank` in the score breakdown.
- CLI subcommands `orbit semantic search` and `orbit semantic related` exist and behave per 2_design.md §6.1; both surface `CompanionNotInstalled` with the remediation message when the companion is absent.
- MCP tools `orbit.semantic.search` and `orbit.semantic.related` are registered and return the result shape from 2_design.md §6.3 including `score_breakdown`.
- End-to-end demo on this repo (companion installed via `orbit semantic install`): after `orbit semantic reindex`, the query `orbit semantic search 'semantic search design'` returns T20260510-3 within the top 3 results.
- End-to-end demo on this repo (companion installed): `orbit semantic related T20260510-3` returns T20260510-9 (same topic, near-identical vocabulary) in the top 3.
- `make build` and `make fmt` pass clean.

## Execution Summary

<details>
<summary>Click to expand</summary>

## Status
success

## Summary of Changes
Implemented phase-1 semantic retrieval for indexed task artifacts. Added orbit-embed query modules for brute-force cosine search, FTS5 BM25 search, reciprocal rank fusion with k=60, task-level rollup, snippet lookup, and score_breakdown result shaping.

Wired the retrieval surface through orbit-core runtime delegates, orbit semantic search and orbit semantic related CLI subcommands, MCP tool registration for orbit.semantic.search and orbit.semantic.related, safe MCP exposure, and host dispatch. Added focused public-surface and parser coverage around the new commands and tools.

## Validation
- make fmt passed.
- make build passed.
- cargo test -p orbit-embed passed, including cosine, BM25, RRF, search rollup, and related coverage.
- cargo test -p orbit-cli semantic passed.
- cargo test -p orbit-cli mcp passed.
- cargo test -p orbit-tools --test public_tool_surface passed.
- cargo test -p orbit-core orbit_tool_host passed.

## Deviations from Original Plan
- End-to-end semantic stats/search demo was attempted but blocked before the semantic command could run by an existing invalid task file in the parent workspace: /Users/daniel/workspace/repos/orbit/.orbit/tasks/proposed/T20260509-66/task.yaml uses type task, while valid task types are feature, bug, refactor, chore.

## Overall Assessment
The code, CLI, MCP, and unit-test coverage for phase-1 retrieval are in place and build cleanly. The remaining risk is environmental validation of the live semantic index once the unrelated invalid task metadata is repaired.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/T20260510-10-6a002b69`
- Behind base: 0
- Ahead of base: 1

*authored by: claude-opus-4-7*