### PR TITLE
[codex] Refresh semantic companion installs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2139,6 +2139,7 @@ dependencies = [
  "rusqlite",
  "serde",
  "serde_json",
+ "tempfile",
 ]
 
 [[package]]

--- a/crates/orbit-cli/src/command/mod.rs
+++ b/crates/orbit-cli/src/command/mod.rs
@@ -191,6 +191,18 @@ mod tests {
     }
 
     #[test]
+    fn cli_parses_semantic_install_force() {
+        let cli = Cli::parse_from(["orbit", "semantic", "install", "--force"]);
+        match cli.command {
+            Commands::Semantic(command) => match command.command {
+                SemanticSubcommand::Install(args) => assert!(args.force),
+                _ => panic!("expected semantic install"),
+            },
+            _ => panic!("expected top-level semantic command"),
+        }
+    }
+
+    #[test]
     fn cli_parses_semantic_stats() {
         let cli = Cli::parse_from(["orbit", "semantic", "stats"]);
         match cli.command {

--- a/crates/orbit-cli/src/command/semantic.rs
+++ b/crates/orbit-cli/src/command/semantic.rs
@@ -35,6 +35,9 @@ pub enum SemanticSubcommand {
 pub struct SemanticInstallArgs {
     #[arg(long)]
     pub model: Option<String>,
+    /// Replace the companion even when the installed version is current
+    #[arg(long)]
+    pub force: bool,
     #[arg(long)]
     pub json: bool,
 }
@@ -112,7 +115,10 @@ impl Execute for SemanticSubcommand {
 
 impl Execute for SemanticInstallArgs {
     fn execute(self, runtime: &OrbitRuntime) -> Result<(), OrbitError> {
-        let result = runtime.semantic_install(SemanticInstallParams { model: self.model })?;
+        let result = runtime.semantic_install(SemanticInstallParams {
+            model: self.model,
+            force: self.force,
+        })?;
         if self.json {
             crate::output::json::print_pretty(&json!(result))
         } else {
@@ -120,7 +126,7 @@ impl Execute for SemanticInstallArgs {
                 "Installed semantic search: companion={} model={} companion_changed={} model_changed={}",
                 result.companion_path,
                 result.model_id,
-                result.companion_installed,
+                result.companion_changed,
                 result.model_installed
             );
             Ok(())

--- a/crates/orbit-cli/tests/semantic_companion.rs
+++ b/crates/orbit-cli/tests/semantic_companion.rs
@@ -1,0 +1,231 @@
+use std::fs;
+use std::path::Path;
+use std::process::Output;
+
+use assert_cmd::cargo::cargo_bin_cmd;
+use serde_json::{Value, json};
+use tempfile::{TempDir, tempdir};
+
+#[test]
+#[cfg(unix)]
+fn tool_run_task_update_with_noisy_background_companion_has_clean_stderr() {
+    let workspace = TestWorkspace::new();
+    workspace.write_noisy_companion();
+    let task = workspace.add_task_without_companion();
+    let task_id = task["id"].as_str().expect("task id");
+
+    let mut saw_companion_invocation = false;
+    for attempt in 0..8 {
+        let input = json!({
+            "id": task_id,
+            "comment": format!("background semantic indexing attempt {attempt}"),
+            "model": "gpt-5"
+        })
+        .to_string();
+        let output = workspace.run_with_companion(
+            &[
+                "tool",
+                "run",
+                "orbit.task.update",
+                "--input",
+                &input,
+                "--full",
+            ],
+            "tool run task update",
+        );
+        assert_stderr_lacks_broken_pipe(&output);
+
+        if workspace.companion_invoked() {
+            saw_companion_invocation = true;
+            break;
+        }
+    }
+
+    assert!(
+        saw_companion_invocation,
+        "mock companion was not invoked by background task indexing"
+    );
+}
+
+#[test]
+#[cfg(unix)]
+fn direct_semantic_command_surfaces_companion_stderr() {
+    let workspace = TestWorkspace::new();
+    workspace.write_failing_companion();
+
+    let output = run_orbit(
+        &workspace.work,
+        &workspace.home,
+        &["semantic", "search", "anything"],
+        Some(&workspace.companion),
+    );
+
+    assert!(
+        !output.status.success(),
+        "semantic search unexpectedly succeeded\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("direct semantic failure detail"),
+        "direct semantic command should inherit companion stderr\nstderr:\n{stderr}"
+    );
+}
+
+struct TestWorkspace {
+    _temp: TempDir,
+    home: std::path::PathBuf,
+    work: std::path::PathBuf,
+    companion: std::path::PathBuf,
+    invocations: std::path::PathBuf,
+}
+
+impl TestWorkspace {
+    fn new() -> Self {
+        let temp = tempdir().expect("tempdir");
+        let home = temp.path().join("home");
+        let work = temp.path().join("work");
+        let companion = temp.path().join("mock-companion");
+        let invocations = temp.path().join("companion-invocations");
+        fs::create_dir_all(&home).expect("create home");
+        fs::create_dir_all(&work).expect("create work");
+
+        let workspace = Self {
+            _temp: temp,
+            home,
+            work,
+            companion,
+            invocations,
+        };
+        workspace.run_without_companion(
+            &["workspace", "init", "--name", "semantic-companion-test"],
+            "initialize workspace",
+        );
+        workspace
+    }
+
+    fn add_task_without_companion(&self) -> Value {
+        let output = self.run_without_companion(
+            &[
+                "task",
+                "add",
+                "--title",
+                "Noisy companion regression",
+                "--description",
+                "Task used by the semantic indexing stderr regression test.",
+                "--acceptance-criteria",
+                "task mutation succeeds",
+                "--json",
+            ],
+            "add task",
+        );
+        serde_json::from_slice(&output.stdout).expect("task add JSON")
+    }
+
+    fn run_without_companion(&self, args: &[&str], label: &str) -> Output {
+        let output = run_orbit(&self.work, &self.home, args, None);
+        assert_success(label, &output);
+        output
+    }
+
+    fn run_with_companion(&self, args: &[&str], label: &str) -> Output {
+        let _ = fs::remove_file(&self.invocations);
+        let output = run_orbit(&self.work, &self.home, args, Some(&self.companion));
+        assert_success(label, &output);
+        output
+    }
+
+    #[cfg(unix)]
+    fn write_noisy_companion(&self) {
+        let script = format!(
+            r#"#!/bin/sh
+printf '%s\n' 'execution failed: Broken pipe (os error 32)' >&2
+printf '%s\n' invoked >> "{}"
+while IFS= read -r line; do
+  id=$(printf '%s\n' "$line" | sed -n 's/.*"id":\([0-9][0-9]*\).*/\1/p')
+  if [ -z "$id" ]; then
+    id=0
+  fi
+  case "$line" in
+    *'"method":"info"'*)
+      printf '{{"id":%s,"result":{{"model_id":"bge-small-en-v1.5","dim":2,"max_input_tokens":512,"version":"0.3.1"}}}}\n' "$id"
+      ;;
+    *'"method":"token_count"'*)
+      printf '{{"id":%s,"result":{{"tokens":1}}}}\n' "$id"
+      ;;
+    *'"method":"embed"'*)
+      printf '{{"id":%s,"result":{{"vectors":[[1.0,0.0]]}}}}\n' "$id"
+      ;;
+    *'"method":"exit"'*)
+      printf '{{"id":%s,"result":{{"ok":true}}}}\n' "$id"
+      exit 0
+      ;;
+    *)
+      printf '{{"id":%s,"error":{{"code":"unknown","message":"unknown request"}}}}\n' "$id"
+      ;;
+  esac
+done
+"#,
+            self.invocations.display()
+        );
+        write_executable(&self.companion, &script);
+    }
+
+    #[cfg(unix)]
+    fn write_failing_companion(&self) {
+        let script = r#"#!/bin/sh
+printf '%s\n' 'direct semantic failure detail' >&2
+exit 7
+"#;
+        write_executable(&self.companion, script);
+    }
+
+    fn companion_invoked(&self) -> bool {
+        fs::read_to_string(&self.invocations)
+            .map(|content| !content.trim().is_empty())
+            .unwrap_or(false)
+    }
+}
+
+fn run_orbit(cwd: &Path, home: &Path, args: &[&str], companion: Option<&Path>) -> Output {
+    let mut command = cargo_bin_cmd!("orbit");
+    command
+        .current_dir(cwd)
+        .env("HOME", home)
+        .env("USERPROFILE", home)
+        .env_remove("ORBIT_ROOT")
+        .env_remove("ORBIT_EMBED_COMPANION")
+        .args(args);
+    if let Some(path) = companion {
+        command.env("ORBIT_EMBED_COMPANION", path);
+    }
+    command.output().expect("run orbit")
+}
+
+fn assert_success(label: &str, output: &Output) {
+    assert!(
+        output.status.success(),
+        "{label} failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+fn assert_stderr_lacks_broken_pipe(output: &Output) {
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !stderr.contains("execution failed: Broken pipe (os error 32)"),
+        "background companion stderr leaked into command output\nstderr:\n{stderr}"
+    );
+}
+
+#[cfg(unix)]
+fn write_executable(path: &Path, content: &str) {
+    use std::os::unix::fs::PermissionsExt;
+
+    fs::write(path, content).expect("write executable");
+    let mut permissions = fs::metadata(path).expect("metadata").permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(path, permissions).expect("chmod executable");
+}

--- a/crates/orbit-embed/Cargo.toml
+++ b/crates/orbit-embed/Cargo.toml
@@ -12,3 +12,6 @@ reqwest.workspace = true
 rusqlite.workspace = true
 serde.workspace = true
 serde_json.workspace = true
+
+[dev-dependencies]
+tempfile = "3"

--- a/crates/orbit-embed/src/commands/install.rs
+++ b/crates/orbit-embed/src/commands/install.rs
@@ -1,22 +1,23 @@
 use std::fs;
 use std::path::Path;
-use std::process::Command;
+use std::process::{Command, Stdio};
 
 use orbit_common::types::OrbitError;
 use serde::Serialize;
 
 use crate::commands::{DEFAULT_RELEASE_BASE_URL, parse_model};
-use crate::{CompanionPaths, platform_companion_filename};
+use crate::{CompanionPaths, RpcResponse, RpcResult, platform_companion_filename};
 
 #[derive(Debug, Clone)]
 pub struct SemanticInstallParams {
     pub model: Option<String>,
+    pub force: bool,
 }
 
 #[derive(Debug, Clone, Serialize)]
 pub struct SemanticInstallResult {
     pub companion_path: String,
-    pub companion_installed: bool,
+    pub companion_changed: bool,
     pub model_id: String,
     pub model_installed: bool,
 }
@@ -28,11 +29,11 @@ pub fn run(params: SemanticInstallParams) -> Result<SemanticInstallResult, Orbit
     fs::create_dir_all(&paths.models_dir).map_err(|error| OrbitError::Io(error.to_string()))?;
 
     let companion_path = paths.companion_path();
-    let companion_installed = if companion_path.exists() {
-        false
-    } else {
+    let companion_changed = if params.force || companion_needs_install(&companion_path) {
         install_companion(&companion_path)?;
         true
+    } else {
+        false
     };
 
     let model_dir = paths.model_dir(spec.alias);
@@ -49,18 +50,32 @@ pub fn run(params: SemanticInstallParams) -> Result<SemanticInstallResult, Orbit
 
     Ok(SemanticInstallResult {
         companion_path: companion_path.to_string_lossy().to_string(),
-        companion_installed,
+        companion_changed,
         model_id: spec.alias.to_string(),
         model_installed,
     })
 }
 
 fn install_companion(destination: &Path) -> Result<(), OrbitError> {
+    let temp_path = temporary_companion_path(destination)?;
+    if temp_path.exists() {
+        fs::remove_file(&temp_path).map_err(|error| OrbitError::Io(error.to_string()))?;
+    }
+
+    let install_result = install_companion_to_temp(&temp_path)
+        .and_then(|()| replace_companion(&temp_path, destination));
+    if install_result.is_err() {
+        let _ = fs::remove_file(&temp_path);
+    }
+    install_result
+}
+
+fn install_companion_to_temp(temp_path: &Path) -> Result<(), OrbitError> {
     if let Ok(local_path) = std::env::var("ORBIT_EMBED_COMPANION")
         && Path::new(&local_path).is_file()
     {
-        fs::copy(&local_path, destination).map_err(|error| OrbitError::Io(error.to_string()))?;
-        make_executable(destination)?;
+        fs::copy(&local_path, temp_path).map_err(|error| OrbitError::Io(error.to_string()))?;
+        make_executable(temp_path)?;
         return Ok(());
     }
 
@@ -78,8 +93,79 @@ fn install_companion(destination: &Path) -> Result<(), OrbitError> {
         .map_err(|error| {
             OrbitError::Execution(format!("failed to read companion download: {error}"))
         })?;
-    fs::write(destination, bytes).map_err(|error| OrbitError::Io(error.to_string()))?;
-    make_executable(destination)
+    fs::write(temp_path, bytes).map_err(|error| OrbitError::Io(error.to_string()))?;
+    make_executable(temp_path)
+}
+
+fn companion_needs_install(path: &Path) -> bool {
+    if !path.exists() {
+        return true;
+    }
+    match companion_version(path) {
+        Some(version) => version != env!("CARGO_PKG_VERSION"),
+        None => true,
+    }
+}
+
+fn companion_version(path: &Path) -> Option<String> {
+    let output = Command::new(path)
+        .arg("--version-info")
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    parse_version_info(&output.stdout)
+}
+
+fn parse_version_info(stdout: &[u8]) -> Option<String> {
+    let output = std::str::from_utf8(stdout).ok()?;
+    output.lines().find_map(|line| {
+        let line = line.trim();
+        if line.is_empty() {
+            return None;
+        }
+        match serde_json::from_str::<RpcResponse>(line).ok()? {
+            RpcResponse::Result {
+                result:
+                    RpcResult::Info {
+                        version: Some(version),
+                        ..
+                    },
+                ..
+            } => Some(version),
+            _ => None,
+        }
+    })
+}
+
+fn temporary_companion_path(destination: &Path) -> Result<std::path::PathBuf, OrbitError> {
+    let file_name = destination
+        .file_name()
+        .and_then(|name| name.to_str())
+        .ok_or_else(|| {
+            OrbitError::InvalidInput(format!(
+                "companion destination has no file name: {}",
+                destination.display()
+            ))
+        })?;
+    Ok(destination.with_file_name(format!(".{file_name}.tmp-{}", std::process::id())))
+}
+
+#[cfg(unix)]
+fn replace_companion(temp_path: &Path, destination: &Path) -> Result<(), OrbitError> {
+    fs::rename(temp_path, destination).map_err(|error| OrbitError::Io(error.to_string()))
+}
+
+#[cfg(not(unix))]
+fn replace_companion(temp_path: &Path, destination: &Path) -> Result<(), OrbitError> {
+    if destination.exists() {
+        fs::remove_file(destination).map_err(|error| OrbitError::Io(error.to_string()))?;
+    }
+    fs::rename(temp_path, destination).map_err(|error| OrbitError::Io(error.to_string()))
 }
 
 fn download_model_with_companion(
@@ -121,4 +207,192 @@ fn make_executable(path: &Path) -> Result<(), OrbitError> {
 #[cfg(not(unix))]
 fn make_executable(_path: &Path) -> Result<(), OrbitError> {
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::path::PathBuf;
+    use std::sync::{Mutex, MutexGuard, OnceLock};
+
+    use tempfile::{TempDir, tempdir};
+
+    #[test]
+    #[cfg(unix)]
+    fn stale_installed_companion_is_replaced_and_reported_as_changed() {
+        let _guard = EnvGuard::new();
+        let fixture = InstallFixture::new();
+        fixture.write_installed_companion("0.3.1", "old");
+        fixture.write_source_companion(env!("CARGO_PKG_VERSION"), "fresh");
+
+        let result = run(SemanticInstallParams {
+            model: None,
+            force: false,
+        })
+        .expect("install should replace stale companion");
+
+        assert!(result.companion_changed);
+        assert!(!result.model_installed);
+        assert!(
+            std::fs::read_to_string(fixture.paths.companion_path())
+                .expect("read replaced companion")
+                .contains("replacement-marker: fresh")
+        );
+        let json = serde_json::to_value(&result).expect("serialize result");
+        assert_eq!(json["companion_changed"], true);
+        assert_eq!(json.get("companion_installed"), None);
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn force_replaces_current_companion() {
+        let _guard = EnvGuard::new();
+        let fixture = InstallFixture::new();
+        fixture.write_installed_companion(env!("CARGO_PKG_VERSION"), "old-current");
+        fixture.write_source_companion(env!("CARGO_PKG_VERSION"), "forced-fresh");
+
+        let result = run(SemanticInstallParams {
+            model: None,
+            force: true,
+        })
+        .expect("forced install should replace current companion");
+
+        assert!(result.companion_changed);
+        assert!(
+            std::fs::read_to_string(fixture.paths.companion_path())
+                .expect("read replaced companion")
+                .contains("replacement-marker: forced-fresh")
+        );
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn current_companion_is_left_in_place_without_force() {
+        let _guard = EnvGuard::new();
+        let fixture = InstallFixture::new();
+        fixture.write_installed_companion(env!("CARGO_PKG_VERSION"), "kept-current");
+        fixture.write_source_companion(env!("CARGO_PKG_VERSION"), "unused-source");
+
+        let result = run(SemanticInstallParams {
+            model: None,
+            force: false,
+        })
+        .expect("current install should be accepted");
+
+        assert!(!result.companion_changed);
+        assert!(
+            std::fs::read_to_string(fixture.paths.companion_path())
+                .expect("read kept companion")
+                .contains("replacement-marker: kept-current")
+        );
+    }
+
+    struct InstallFixture {
+        _temp: TempDir,
+        paths: CompanionPaths,
+        source_path: PathBuf,
+    }
+
+    impl InstallFixture {
+        fn new() -> Self {
+            let temp = tempdir().expect("tempdir");
+            let home = temp.path().join("home");
+            let source_path = temp.path().join("source-companion");
+            std::fs::create_dir_all(&home).expect("create home");
+            set_env("HOME", &home.to_string_lossy());
+            set_env("USERPROFILE", &home.to_string_lossy());
+            set_env("ORBIT_EMBED_COMPANION", &source_path.to_string_lossy());
+            remove_env("ORBIT_EMBED_COMPANION_URL");
+
+            let paths = CompanionPaths::default_under_home().expect("paths");
+            std::fs::create_dir_all(&paths.bin_dir).expect("create bin");
+            let model_dir = paths.model_dir(crate::default_model().alias);
+            std::fs::create_dir_all(&model_dir).expect("create model dir");
+            std::fs::write(model_dir.join("orbit-model.json"), "{}").expect("write marker");
+
+            Self {
+                _temp: temp,
+                paths,
+                source_path,
+            }
+        }
+
+        #[cfg(unix)]
+        fn write_installed_companion(&self, version: &str, marker: &str) {
+            write_mock_companion(&self.paths.companion_path(), version, marker);
+        }
+
+        #[cfg(unix)]
+        fn write_source_companion(&self, version: &str, marker: &str) {
+            write_mock_companion(&self.source_path, version, marker);
+        }
+    }
+
+    struct EnvGuard {
+        _lock: MutexGuard<'static, ()>,
+        vars: Vec<(&'static str, Option<String>)>,
+    }
+
+    impl EnvGuard {
+        fn new() -> Self {
+            static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+            let lock = LOCK
+                .get_or_init(|| Mutex::new(()))
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            let names = [
+                "HOME",
+                "USERPROFILE",
+                "ORBIT_EMBED_COMPANION",
+                "ORBIT_EMBED_COMPANION_URL",
+            ];
+            let vars = names
+                .into_iter()
+                .map(|name| (name, std::env::var(name).ok()))
+                .collect::<Vec<_>>();
+            Self { _lock: lock, vars }
+        }
+    }
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            for (name, value) in &self.vars {
+                match value {
+                    Some(value) => set_env(name, value),
+                    None => remove_env(name),
+                }
+            }
+        }
+    }
+
+    #[cfg(unix)]
+    fn write_mock_companion(path: &std::path::Path, version: &str, marker: &str) {
+        use std::os::unix::fs::PermissionsExt;
+
+        let script = format!(
+            r#"#!/bin/sh
+# replacement-marker: {marker}
+if [ "$1" = "--version-info" ]; then
+  printf '%s\n' '{{"id":0,"result":{{"model_id":"bge-small-en-v1.5","dim":0,"max_input_tokens":0,"version":"{version}"}}}}'
+  exit 0
+fi
+exit 0
+"#
+        );
+        std::fs::write(path, script).expect("write companion");
+        let mut permissions = std::fs::metadata(path).expect("metadata").permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(path, permissions).expect("chmod companion");
+    }
+
+    fn set_env(name: &str, value: &str) {
+        // SAFETY: tests that mutate process environment hold EnvGuard's global lock.
+        unsafe { std::env::set_var(name, value) }
+    }
+
+    fn remove_env(name: &str) {
+        // SAFETY: tests that mutate process environment hold EnvGuard's global lock.
+        unsafe { std::env::remove_var(name) }
+    }
 }

--- a/crates/orbit-embed/src/subprocess.rs
+++ b/crates/orbit-embed/src/subprocess.rs
@@ -14,6 +14,12 @@ use crate::companion::locate_companion;
 use crate::embedder::{DEFAULT_MODEL, Embedder};
 use crate::rpc::{RpcRequest, RpcResponse, RpcResult};
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum CompanionStderr {
+    Inherit,
+    Suppress,
+}
+
 pub struct SubprocessEmbedder {
     model_id: String,
     dim: usize,
@@ -38,12 +44,24 @@ impl SubprocessEmbedder {
     }
 
     pub fn with_path_and_model(path: PathBuf, model: &str) -> Result<Self, OrbitError> {
+        Self::with_path_model_and_stderr(path, model, CompanionStderr::Inherit)
+    }
+
+    pub(crate) fn quiet_with_model(model: &str) -> Result<Self, OrbitError> {
+        Self::with_path_model_and_stderr(locate_companion()?, model, CompanionStderr::Suppress)
+    }
+
+    fn with_path_model_and_stderr(
+        path: PathBuf,
+        model: &str,
+        stderr: CompanionStderr,
+    ) -> Result<Self, OrbitError> {
         let mut child = Command::new(&path)
             .arg("--model")
             .arg(model)
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
-            .stderr(Stdio::inherit())
+            .stderr(stderr.stdio())
             .spawn()
             .map_err(|error| {
                 OrbitError::Execution(format!(
@@ -152,6 +170,15 @@ impl SubprocessEmbedder {
 
     fn next_request_id(&self) -> u64 {
         self.next_id.fetch_add(1, Ordering::Relaxed)
+    }
+}
+
+impl CompanionStderr {
+    fn stdio(self) -> Stdio {
+        match self {
+            Self::Inherit => Stdio::inherit(),
+            Self::Suppress => Stdio::null(),
+        }
     }
 }
 

--- a/crates/orbit-embed/src/vector/worker.rs
+++ b/crates/orbit-embed/src/vector/worker.rs
@@ -40,7 +40,7 @@ impl EmbedWorker {
                     }
                 }
                 if embedder.is_none() {
-                    match SubprocessEmbedder::new() {
+                    match SubprocessEmbedder::quiet_with_model(crate::DEFAULT_MODEL) {
                         Ok(value) => embedder = Some(value),
                         Err(error) => {
                             orbit_common::tracing::debug!(

--- a/docs/design/semantic-search/2_design.md
+++ b/docs/design/semantic-search/2_design.md
@@ -90,7 +90,7 @@ The protocol is intentionally minimal — four methods, no streaming, no auth. T
 
 ### 2.4 Default model and install-time model selection
 
-`orbit semantic install` accepts `--model {bge-small | minilm-l6 | nomic-v1.5}`; default is `bge-small`. Model files are downloaded into `~/.orbit/embed/models/<model_id>/`. Switching model means running `orbit semantic install --model OTHER`, which downloads the new model alongside the existing one (so the embeddings under the old `model_id` keep working until reindexed; see [§7.2](#72-backfill-and-migration)).
+`orbit semantic install` accepts `--model {bge-small | minilm-l6 | nomic-v1.5}`; default is `bge-small`. The install command probes an existing companion with `--version-info` and replaces it when the reported companion version differs from the current Orbit package version; `--force` replaces it even when the probe says it is current. Model files are downloaded into `~/.orbit/embed/models/<model_id>/`. Switching model means running `orbit semantic install --model OTHER`, which downloads the new model alongside the existing one (so the embeddings under the old `model_id` keep working until reindexed; see [§7.2](#72-backfill-and-migration)).
 
 The three supported models per [3_vision.md §1](./3_vision.md):
 
@@ -241,7 +241,7 @@ Either retriever alone has a failure mode the other doesn't. RRF resolves both a
 ### 6.1 CLI
 
 ```
-orbit semantic install   [--model bge-small | minilm-l6 | nomic-v1.5]
+orbit semantic install   [--model bge-small | minilm-l6 | nomic-v1.5] [--force]
 orbit semantic uninstall [--model MODEL] [--all]
 orbit semantic search    <query> [--limit N] [--field FIELD] [--kind task]
 orbit semantic related   <task-id> [--limit N]
@@ -249,7 +249,7 @@ orbit semantic reindex   [--force] [--model MODEL]
 orbit semantic stats
 ```
 
-`install` is the gate that enables every other subcommand. It downloads the platform-appropriate `orbit-embed-companion` binary from the published release URL and the chosen model from HuggingFace, both into `~/.orbit/embed/`. Default model is `bge-small`; users can override per [§2.4](#24-default-model-and-install-time-model-selection). Re-running `install` with a different `--model` adds that model alongside existing ones.
+`install` is the gate that enables every other subcommand. It downloads the platform-appropriate `orbit-embed-companion` binary from the published release URL and the chosen model from HuggingFace, both into `~/.orbit/embed/`. Default model is `bge-small`; users can override per [§2.4](#24-default-model-and-install-time-model-selection). Re-running `install` with a different `--model` adds that model alongside existing ones. Re-running `install` after an Orbit upgrade also refreshes a stale companion automatically because the existing binary's `--version-info` output is compared to the current package version; `--force` is the explicit override for reinstalling the current version.
 
 `uninstall` removes the companion binary and (by default) the currently active model. `--model M` removes only model M. `--all` removes the companion plus every installed model.
 
@@ -290,7 +290,7 @@ The score breakdown is deliberately exposed: agents can use it to decide whether
 
 ### 7.1 On-mutation indexing
 
-`task.add` and mutating `task.update` paths emit an `EmbedJob` to a bounded in-process channel after the durable write commits. A worker drains the channel, batches up to 16 jobs at a time, and runs `upsert_embeddings`. Failures log and continue — embedding is not in the critical path of task mutation. Users without the companion installed (`orbit semantic install` not yet run) see `OrbitError::CompanionNotInstalled` from the worker, which it logs at debug level and skips; core task operations are entirely unaffected.
+`task.add` and mutating `task.update` paths emit an `EmbedJob` to a bounded in-process channel after the durable write commits. A worker drains the channel, batches up to 16 jobs at a time, and runs `upsert_embeddings`. Failures log and continue — embedding is not in the critical path of task mutation. Background indexing spawns the companion with stderr suppressed so a best-effort indexing failure cannot make a successful task mutation look failed; direct semantic commands still inherit companion stderr so users see actionable failures. Users without the companion installed (`orbit semantic install` not yet run) see `OrbitError::CompanionNotInstalled` from the worker, which it logs at debug level and skips; core task operations are entirely unaffected.
 
 ### 7.2 Backfill and migration
 
@@ -334,5 +334,6 @@ All embeddings stay local. Task content never leaves the workspace. This is stru
 
 - [T20260510-3] — Design semantic search over task artifacts and graph (v2). The task that produced this folder.
 - [T20260510-9] — Phase-1 semantic search foundation: orbit-embed + orbit-embed-companion + indexing pipeline. Accepted the foundation implementation and workspace-local semantic DB placement.
+- [T20260510-26] — Make semantic companion install/update quiet and version-aware. Accepted version-aware companion replacement and quiet background indexing.
 
 Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.

--- a/docs/design/semantic-search/4_decisions.md
+++ b/docs/design/semantic-search/4_decisions.md
@@ -176,10 +176,27 @@ Compare to the analogous knowledge-graph crate: `orbit-knowledge` owns its data 
 
 ---
 
+## ADR-008 — Version-aware companion refresh and quiet background indexing
+
+**Status:** Accepted · 2026-05 · [T20260510-26]
+
+**Context.** The companion binary is installed outside the main `orbit` executable, so upgrading Orbit does not automatically replace an already-present `~/.orbit/embed/bin/orbit-embed-companion-<platform>`. A stale companion can therefore keep old subprocess behavior after the main binary has moved on. The concrete failure was a stale companion writing `execution failed: Broken pipe (os error 32)` to stderr during best-effort background task indexing, after the durable task update had already succeeded. Direct semantic commands should still surface companion stderr because users explicitly invoked the semantic subsystem and need useful failure detail.
+
+**Decision.** `orbit semantic install` probes an existing installed companion with `--version-info` and compares the returned version to the current Orbit package version. Missing, stale, unprobeable, or explicitly forced companions are replaced through a temporary sibling file before being moved into place; successful install output reports `companion_changed`. The CLI exposes `--force` for intentional replacement even when the probe says the companion is current. `SubprocessEmbedder` keeps inherited stderr as the default for direct semantic commands, while the background task-mutation worker uses a quiet spawn mode.
+
+**Consequences.**
+- Re-running `orbit semantic install` after upgrading Orbit naturally refreshes stale companions without requiring users to uninstall first.
+- Task mutation output stays trustworthy: background indexing remains best-effort and cannot leak companion stderr into successful `task.add` / `task.update` command output.
+- Direct commands such as `orbit semantic search`, `related`, and `reindex` still show actionable companion stderr because they use the inherited-stderr path.
+- Cost: install now trusts the companion's `--version-info` protocol. If a broken companion cannot answer the probe, Orbit conservatively replaces it, which can redownload or recopy the binary even when the file might have been usable for embeddings.
+
+---
+
 ## Task References
 
 - [T20260510-3] — Design semantic search over task artifacts and graph (v2). The task that produced this folder.
 - [T20260510-9] — Phase-1 semantic search foundation: orbit-embed + orbit-embed-companion + indexing pipeline. The task that accepted and implemented ADR-001 through ADR-006.
 - [T20260510-20] — Refactor: relocate semantic-search ownership to orbit-embed (vector store + commands). The task that accepted and implemented ADR-007.
+- [T20260510-26] — Make semantic companion install/update quiet and version-aware. The task that accepted and implemented ADR-008.
 
 Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.


### PR DESCRIPTION
## Summary

Implements Orbit task `T20260510-26`.

- Makes `orbit semantic install` probe the installed companion with `--version-info` and replace missing, stale, unprobeable, or `--force`-requested binaries.
- Adds the `orbit semantic install --force` CLI flag and updates install output to report `companion_changed`.
- Suppresses companion stderr for best-effort background task mutation indexing while preserving inherited stderr for direct semantic commands.
- Adds deterministic regression coverage for noisy background companions and direct semantic stderr surfacing.
- Updates the semantic-search design docs and ADR log for the new install/update behavior.

## Why

The companion binary lives outside the main `orbit` executable, so upgrading Orbit can leave an old companion installed. A stale companion could emit noisy stderr during successful task mutations, making best-effort background indexing look like a failed command.

## Impact

Users can rerun `orbit semantic install` after upgrades and get the current companion automatically. Task mutation output stays clean when background indexing encounters companion stderr, while explicit semantic commands still show useful companion failure details.

## Validation

- `make fmt`
- `cargo test -p orbit-embed commands::install -- --nocapture`
- `cargo test -p orbit-cli cli_parses_semantic_install_force -- --nocapture`
- `cargo test -p orbit-cli --test semantic_companion -- --nocapture`
- `make ci`
- `make build`
- `git diff --check`
- `git diff --cached --check`
