### PR TITLE
[ORB-00001] Type error discriminators with KnowledgeErrorKind and NotFoundKind

### DIFF
--- a/crates/orbit-cli/src/command/definitions/describe.rs
+++ b/crates/orbit-cli/src/command/definitions/describe.rs
@@ -1,6 +1,6 @@
 use clap::Args;
 use orbit_common::types::ResourceKind;
-use orbit_core::{OrbitError, OrbitRuntime};
+use orbit_core::{NotFoundKind, OrbitError, OrbitRuntime};
 
 use crate::command::Execute;
 
@@ -63,7 +63,7 @@ fn describe_activity(runtime: &OrbitRuntime, id: &str) -> Result<(), OrbitError>
         .map_err(|err| OrbitError::Store(format!("v2 activity catalog: {err}")))?;
     let activity = catalog
         .get(id)
-        .ok_or_else(|| OrbitError::ActivityNotFound(id.to_string()))?;
+        .ok_or_else(|| OrbitError::not_found(NotFoundKind::Activity, id.to_string()))?;
     let type_label = match &activity.spec {
         ActivityV2Spec::AgentLoop(_) => "agent_loop",
         ActivityV2Spec::Groundhog(_) => "groundhog",

--- a/crates/orbit-cli/src/command/definitions/get.rs
+++ b/crates/orbit-cli/src/command/definitions/get.rs
@@ -1,6 +1,6 @@
 use clap::Args;
 use orbit_common::types::ResourceKind;
-use orbit_core::{OrbitError, OrbitRuntime};
+use orbit_core::{NotFoundKind, OrbitError, OrbitRuntime};
 use serde_json::{Value, json};
 
 use crate::command::Execute;
@@ -151,7 +151,7 @@ fn show_activity(runtime: &OrbitRuntime, id: &str, as_json: bool) -> Result<(), 
         .map_err(|err| OrbitError::Store(format!("v2 activity catalog: {err}")))?;
     let activity = catalog
         .get(id)
-        .ok_or_else(|| OrbitError::ActivityNotFound(id.to_string()))?;
+        .ok_or_else(|| OrbitError::not_found(NotFoundKind::Activity, id.to_string()))?;
     if as_json {
         let value = json!({
             "id": id,

--- a/crates/orbit-cli/src/command/mcp/mod.rs
+++ b/crates/orbit-cli/src/command/mcp/mod.rs
@@ -14,7 +14,9 @@ use std::time::Instant;
 use clap::{Args, Subcommand};
 use orbit_common::types::{AuditEventStatus, ToolSchema, audit_execution_id};
 use orbit_core::command::tool::{ToolEntryPoint, audit_role_label};
-use orbit_core::{AuditEventInsertParams, OrbitError, OrbitRuntime, redact_sensitive_env_text};
+use orbit_core::{
+    AuditEventInsertParams, NotFoundKind, OrbitError, OrbitRuntime, redact_sensitive_env_text,
+};
 use orbit_mcp::McpHost;
 use serde_json::Value;
 
@@ -93,7 +95,7 @@ fn ensure_mcp_tool_exposed(name: &str) -> Result<(), OrbitError> {
     if is_mcp_tool_exposed(name) {
         Ok(())
     } else {
-        Err(OrbitError::ToolNotFound(name.to_string()))
+        Err(OrbitError::not_found(NotFoundKind::Tool, name.to_string()))
     }
 }
 
@@ -294,7 +296,7 @@ impl McpHost for EmptyMcpHost {
     }
 
     fn call_tool(&self, name: &str, _input: Value) -> Result<Value, OrbitError> {
-        Err(OrbitError::ToolNotFound(name.to_string()))
+        Err(OrbitError::not_found(NotFoundKind::Tool, name.to_string()))
     }
 }
 

--- a/crates/orbit-cli/src/command/run/job.rs
+++ b/crates/orbit-cli/src/command/run/job.rs
@@ -263,6 +263,7 @@ fn build_job_run_input(pairs: &[String]) -> Result<Value, OrbitError> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use orbit_core::NotFoundKind;
 
     fn write_replay_job(runtime: &OrbitRuntime, name: &str) -> PathBuf {
         let jobs_dir = runtime.data_root().join("resources/jobs");
@@ -325,6 +326,12 @@ spec:
         .execute(&runtime)
         .expect_err("unknown source run should fail");
 
-        assert!(matches!(error, OrbitError::JobRunNotFound(_)));
+        assert!(matches!(
+            error,
+            OrbitError::NotFound {
+                kind: NotFoundKind::JobRun,
+                ..
+            }
+        ));
     }
 }

--- a/crates/orbit-cli/src/command/run/show.rs
+++ b/crates/orbit-cli/src/command/run/show.rs
@@ -1,5 +1,5 @@
 use clap::Args;
-use orbit_core::{OrbitError, OrbitRuntime};
+use orbit_core::{NotFoundKind, OrbitError, OrbitRuntime};
 use serde_json::{Value, json};
 
 use crate::command::Execute;
@@ -86,7 +86,7 @@ pub(crate) fn print_legacy_logs_summary(
 ) -> Result<(), OrbitError> {
     let run = runtime
         .show_job_run(run_id)
-        .map_err(|_| OrbitError::JobRunNotFound(run_id.to_string()))?;
+        .map_err(|_| OrbitError::not_found(NotFoundKind::JobRun, run_id.to_string()))?;
     let steps = filtered_steps(&run, step_id)?;
 
     if json_output {

--- a/crates/orbit-cli/src/command/run/steps.rs
+++ b/crates/orbit-cli/src/command/run/steps.rs
@@ -1,6 +1,6 @@
 use orbit_core::command::job::JobRunListParams;
 use orbit_core::runtime::run_audit::RunAuditStep;
-use orbit_core::{JobRun, JobRunStep, JobTargetType, OrbitError, OrbitRuntime};
+use orbit_core::{JobRun, JobRunStep, JobTargetType, NotFoundKind, OrbitError, OrbitRuntime};
 use serde_json::{Value, json};
 
 use super::format::{format_duration, format_timestamp, summarize_error_message};
@@ -12,7 +12,7 @@ pub(crate) fn resolve_run(
     if let Some(run_id) = run_id {
         return runtime
             .show_job_run(run_id)
-            .map_err(|_| OrbitError::JobRunNotFound(run_id.to_string()));
+            .map_err(|_| OrbitError::not_found(NotFoundKind::JobRun, run_id.to_string()));
     }
 
     runtime
@@ -22,7 +22,7 @@ pub(crate) fn resolve_run(
         })?
         .into_iter()
         .next()
-        .ok_or_else(|| OrbitError::JobRunNotFound("latest".to_string()))
+        .ok_or_else(|| OrbitError::not_found(NotFoundKind::JobRun, "latest".to_string()))
 }
 
 pub(crate) fn resolve_run_step(

--- a/crates/orbit-cli/src/command/web/api/mod.rs
+++ b/crates/orbit-cli/src/command/web/api/mod.rs
@@ -222,9 +222,18 @@ pub(super) fn v2_loop_dir(runtime: &OrbitRuntime) -> PathBuf {
 pub(super) fn map_runtime_error(e: orbit_core::OrbitError) -> Response {
     match e {
         orbit_core::OrbitError::InvalidInput(msg) => bad_request(msg),
-        orbit_core::OrbitError::TaskNotFound(msg) => not_found(format!("task not found: {msg}")),
-        orbit_core::OrbitError::JobNotFound(msg) => not_found(format!("job not found: {msg}")),
-        orbit_core::OrbitError::JobRunNotFound(msg) => not_found(format!("run not found: {msg}")),
+        orbit_core::OrbitError::NotFound {
+            kind: orbit_core::NotFoundKind::Task,
+            id,
+        } => not_found(format!("task not found: {id}")),
+        orbit_core::OrbitError::NotFound {
+            kind: orbit_core::NotFoundKind::Job,
+            id,
+        } => not_found(format!("job not found: {id}")),
+        orbit_core::OrbitError::NotFound {
+            kind: orbit_core::NotFoundKind::JobRun,
+            id,
+        } => not_found(format!("run not found: {id}")),
         other => server_error(other),
     }
 }

--- a/crates/orbit-cli/src/output/json.rs
+++ b/crates/orbit-cli/src/output/json.rs
@@ -1,4 +1,4 @@
-use orbit_core::OrbitError;
+use orbit_core::{NotFoundKind, OrbitError};
 use serde_json::{Value, json};
 
 pub fn print(value: &Value) -> Result<(), OrbitError> {
@@ -32,14 +32,19 @@ pub fn error_payload(error: &OrbitError) -> Value {
 fn error_code(error: &OrbitError) -> &'static str {
     match error {
         OrbitError::PolicyDenied(_) => "policy_denied",
-        OrbitError::ToolNotFound(_) => "tool_not_found",
-        OrbitError::TaskNotFound(_) => "task_not_found",
+        OrbitError::NotFound { kind, .. } => match kind {
+            NotFoundKind::Tool => "tool_not_found",
+            NotFoundKind::Task => "task_not_found",
+            NotFoundKind::Skill => "skill_not_found",
+            NotFoundKind::Job => "job_not_found",
+            NotFoundKind::JobRun => "job_run_not_found",
+            NotFoundKind::Activity => "activity_not_found",
+            NotFoundKind::Adr => "adr_not_found",
+            NotFoundKind::Learning => "learning_not_found",
+            NotFoundKind::AgentSession => "agent_session_not_found",
+            NotFoundKind::Workspace => "workspace_not_found",
+        },
         OrbitError::TaskApprovalRequired(_) => "task_approval_required",
-        OrbitError::SkillNotFound(_) => "skill_not_found",
-        OrbitError::JobNotFound(_) => "job_not_found",
-        OrbitError::JobRunNotFound(_) => "job_run_not_found",
-        OrbitError::ActivityNotFound(_) => "activity_not_found",
-        OrbitError::AgentSessionNotFound(_) => "agent_session_not_found",
         OrbitError::CompanionNotInstalled(_) => "companion_not_installed",
         OrbitError::InvalidInput(_) => "invalid_input",
         OrbitError::SkillValidation(_) => "skill_validation_failed",
@@ -50,12 +55,9 @@ fn error_code(error: &OrbitError) -> &'static str {
         OrbitError::Store(_) => "store_error",
         OrbitError::TaskStatusTransition(_) => "task_status_transition",
         OrbitError::JobRunStateTransition(_) => "job_run_state_transition",
-        OrbitError::WorkspaceNotFound(_) => "workspace_not_found",
         OrbitError::WorkspaceError(_) => "workspace_error",
         OrbitError::Io(_) => "io_error",
-        OrbitError::AdrNotFound(_) => "adr_not_found",
         OrbitError::AdrInvalidTransition(_) => "adr_invalid_transition",
-        OrbitError::LearningNotFound(_) => "learning_not_found",
         OrbitError::Migration(_) => "migration_failed",
     }
 }

--- a/crates/orbit-common/src/types/error.rs
+++ b/crates/orbit-common/src/types/error.rs
@@ -1,31 +1,49 @@
+use serde::Serialize;
 use thiserror::Error;
 
-#[derive(Debug, Error)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum NotFoundKind {
+    Tool,
+    Task,
+    Skill,
+    Job,
+    JobRun,
+    Activity,
+    Adr,
+    Learning,
+    AgentSession,
+    Workspace,
+}
+
+impl std::fmt::Display for NotFoundKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let kind = match self {
+            Self::Tool => "tool",
+            Self::Task => "task",
+            Self::Skill => "skill",
+            Self::Job => "job",
+            Self::JobRun => "job run",
+            Self::Activity => "activity",
+            Self::Adr => "ADR",
+            Self::Learning => "learning",
+            Self::AgentSession => "agent session",
+            Self::Workspace => "workspace",
+        };
+        f.write_str(kind)
+    }
+}
+
+#[derive(Debug, Error, Serialize)]
 pub enum OrbitError {
     #[error("policy denied: {0}")]
     PolicyDenied(String),
-    #[error("tool not found: {0}")]
-    ToolNotFound(String),
-    #[error("task not found: {0}")]
-    TaskNotFound(String),
+    #[error("{kind} not found: {id}")]
+    NotFound { kind: NotFoundKind, id: String },
     #[error("task requires approval: {0}")]
     TaskApprovalRequired(String),
-    #[error("skill not found: {0}")]
-    SkillNotFound(String),
-    #[error("job not found: {0}")]
-    JobNotFound(String),
-    #[error("job run not found: {0}")]
-    JobRunNotFound(String),
-    #[error("activity not found: {0}")]
-    ActivityNotFound(String),
     #[error("Invalid ADR status transition: {0}")]
     AdrInvalidTransition(String),
-    #[error("ADR not found: {0}")]
-    AdrNotFound(String),
-    #[error("learning not found: {0}")]
-    LearningNotFound(String),
-    #[error("agent session not found: {0}")]
-    AgentSessionNotFound(String),
     #[error("companion not installed: {0}")]
     CompanionNotInstalled(String),
     #[error("invalid input: {0}")]
@@ -46,8 +64,6 @@ pub enum OrbitError {
     TaskStatusTransition(String),
     #[error("invalid job run state transition: {0}")]
     JobRunStateTransition(String),
-    #[error("workspace not found: {0}")]
-    WorkspaceNotFound(String),
     #[error("workspace error: {0}")]
     WorkspaceError(String),
     #[error("io error: {0}")]
@@ -56,8 +72,42 @@ pub enum OrbitError {
     Migration(String),
 }
 
+impl OrbitError {
+    pub fn not_found(kind: NotFoundKind, id: impl Into<String>) -> Self {
+        Self::NotFound {
+            kind,
+            id: id.into(),
+        }
+    }
+}
+
 impl From<std::io::Error> for OrbitError {
     fn from(err: std::io::Error) -> Self {
         OrbitError::Io(err.to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{NotFoundKind, OrbitError};
+
+    #[test]
+    fn orbit_not_found_error_serializes_with_typed_kind() {
+        let error = OrbitError::NotFound {
+            kind: NotFoundKind::Task,
+            id: "ORB-00001".to_string(),
+        };
+
+        let value = serde_json::to_value(error).expect("serialize orbit error");
+
+        assert_eq!(
+            value,
+            serde_json::json!({
+                "NotFound": {
+                    "kind": "task",
+                    "id": "ORB-00001"
+                }
+            })
+        );
     }
 }

--- a/crates/orbit-common/src/types/mod.rs
+++ b/crates/orbit-common/src/types/mod.rs
@@ -76,7 +76,7 @@ pub use duel::{
     PlanningRoleAssignment, PlanningRoles, ReviewerStats, RoleAssignment, Roles, Scores, Severity,
     TaskClass, TaskScope, ValidIssuesBySeverity, Verdict,
 };
-pub use error::OrbitError;
+pub use error::{NotFoundKind, OrbitError};
 pub use event::OrbitEvent;
 pub use executor_def::{ExecutorDef, ExecutorSandboxKind, ExecutorType, StdoutFormat};
 pub use friction::{FrictionEntry, FrictionFrontmatter, FrictionRecord};

--- a/crates/orbit-common/src/utility/redaction.rs
+++ b/crates/orbit-common/src/utility/redaction.rs
@@ -80,26 +80,15 @@ pub fn redact_home_dir(text: &str) -> String {
 pub fn redact_sensitive_env_error(error: OrbitError) -> OrbitError {
     match error {
         OrbitError::PolicyDenied(m) => OrbitError::PolicyDenied(redact_sensitive_env_text(&m)),
-        OrbitError::ToolNotFound(m) => OrbitError::ToolNotFound(redact_sensitive_env_text(&m)),
-        OrbitError::TaskNotFound(m) => OrbitError::TaskNotFound(redact_sensitive_env_text(&m)),
+        OrbitError::NotFound { kind, id } => OrbitError::NotFound {
+            kind,
+            id: redact_sensitive_env_text(&id),
+        },
         OrbitError::TaskApprovalRequired(m) => {
             OrbitError::TaskApprovalRequired(redact_sensitive_env_text(&m))
         }
-        OrbitError::SkillNotFound(m) => OrbitError::SkillNotFound(redact_sensitive_env_text(&m)),
-        OrbitError::JobNotFound(m) => OrbitError::JobNotFound(redact_sensitive_env_text(&m)),
-        OrbitError::JobRunNotFound(m) => OrbitError::JobRunNotFound(redact_sensitive_env_text(&m)),
-        OrbitError::ActivityNotFound(m) => {
-            OrbitError::ActivityNotFound(redact_sensitive_env_text(&m))
-        }
         OrbitError::AdrInvalidTransition(m) => {
             OrbitError::AdrInvalidTransition(redact_sensitive_env_text(&m))
-        }
-        OrbitError::AdrNotFound(m) => OrbitError::AdrNotFound(redact_sensitive_env_text(&m)),
-        OrbitError::LearningNotFound(m) => {
-            OrbitError::LearningNotFound(redact_sensitive_env_text(&m))
-        }
-        OrbitError::AgentSessionNotFound(m) => {
-            OrbitError::AgentSessionNotFound(redact_sensitive_env_text(&m))
         }
         OrbitError::CompanionNotInstalled(m) => {
             OrbitError::CompanionNotInstalled(redact_sensitive_env_text(&m))
@@ -124,9 +113,6 @@ pub fn redact_sensitive_env_error(error: OrbitError) -> OrbitError {
             OrbitError::JobRunStateTransition(redact_sensitive_env_text(&m))
         }
         OrbitError::Io(m) => OrbitError::Io(redact_sensitive_env_text(&m)),
-        OrbitError::WorkspaceNotFound(m) => {
-            OrbitError::WorkspaceNotFound(redact_sensitive_env_text(&m))
-        }
         OrbitError::WorkspaceError(m) => OrbitError::WorkspaceError(redact_sensitive_env_text(&m)),
         OrbitError::Migration(m) => OrbitError::Migration(redact_sensitive_env_text(&m)),
     }

--- a/crates/orbit-core/src/command/job/catalog.rs
+++ b/crates/orbit-core/src/command/job/catalog.rs
@@ -1,7 +1,9 @@
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 
-use orbit_common::types::{JobKind, JobRun, JobScheduleState, JobV2, OrbitError, load_job_asset};
+use orbit_common::types::{
+    JobKind, JobRun, JobScheduleState, JobV2, NotFoundKind, OrbitError, load_job_asset,
+};
 use orbit_common::utility::fs::write_text_with_parent;
 use serde_json::Value;
 
@@ -132,7 +134,7 @@ impl OrbitRuntime {
                 path: asset.path.clone(),
                 spec: asset.spec.clone(),
             })
-            .ok_or_else(|| OrbitError::JobNotFound(job_id.to_string()))
+            .ok_or_else(|| OrbitError::not_found(NotFoundKind::Job, job_id.to_string()))
     }
 
     fn load_v2_job_assets(&self) -> Result<BTreeMap<String, V2JobAssetEntry>, OrbitError> {
@@ -188,7 +190,7 @@ impl OrbitRuntime {
                 selected = Some(found);
             }
         }
-        selected.ok_or_else(|| OrbitError::JobNotFound(job_id.to_string()))
+        selected.ok_or_else(|| OrbitError::not_found(NotFoundKind::Job, job_id.to_string()))
     }
 }
 

--- a/crates/orbit-core/src/command/job/exec.rs
+++ b/crates/orbit-core/src/command/job/exec.rs
@@ -12,7 +12,7 @@ use orbit_common::types::activity_job::{
     validate_job_loop_session_backends,
 };
 use orbit_common::types::{
-    JobRun, JobRunState, JobTargetType, OrbitError, OrbitEvent, PipelineState,
+    JobRun, JobRunState, JobTargetType, NotFoundKind, OrbitError, OrbitEvent, PipelineState,
 };
 use orbit_engine::activity_job::{
     DispatchError, JobOutcome, V2AuditWriter, execute_job, resolve_job_catalog_refs_for_execution,
@@ -92,7 +92,7 @@ impl OrbitRuntime {
                 .jobs()
                 .mark_run_running(&run.run_id, started_at, std::process::id())?;
         if !changed {
-            return Err(OrbitError::JobRunNotFound(run.run_id));
+            return Err(OrbitError::not_found(NotFoundKind::JobRun, run.run_id));
         }
         self.record_event(OrbitEvent::JobRunStarted {
             job_id: run.job_id.clone(),

--- a/crates/orbit-core/src/command/job/run.rs
+++ b/crates/orbit-core/src/command/job/run.rs
@@ -1,5 +1,7 @@
 use chrono::{DateTime, Utc};
-use orbit_common::types::{JobRun, JobRunState, OrbitError, OrbitEvent, PipelineState};
+use orbit_common::types::{
+    JobRun, JobRunState, NotFoundKind, OrbitError, OrbitEvent, PipelineState,
+};
 use orbit_store::{JobRunQuery, TaskReservationReleaseReason};
 use serde::Serialize;
 use serde_json::Value;
@@ -46,7 +48,7 @@ impl OrbitRuntime {
     ) -> Result<JobRunCancelResult, OrbitError> {
         let run = self
             .get_job_run_backend(run_id)?
-            .ok_or_else(|| OrbitError::JobRunNotFound(run_id.to_string()))?;
+            .ok_or_else(|| OrbitError::not_found(NotFoundKind::JobRun, run_id.to_string()))?;
         run.state
             .try_transition(orbit_common::types::RunEvent::Cancel)
             .map_err(|msg| {
@@ -71,7 +73,7 @@ impl OrbitRuntime {
         )?;
         let cancelled_run = self
             .get_job_run_backend(run_id)?
-            .ok_or_else(|| OrbitError::JobRunNotFound(run_id.to_string()))?;
+            .ok_or_else(|| OrbitError::not_found(NotFoundKind::JobRun, run_id.to_string()))?;
         if cancelled_run.state != JobRunState::Cancelled {
             let detail = cancelled_run
                 .state
@@ -233,10 +235,10 @@ impl OrbitRuntime {
     pub fn show_job_run(&self, run_id: &str) -> Result<JobRun, OrbitError> {
         let run = self
             .get_job_run_backend(run_id)?
-            .ok_or_else(|| OrbitError::JobRunNotFound(run_id.to_string()))?;
+            .ok_or_else(|| OrbitError::not_found(NotFoundKind::JobRun, run_id.to_string()))?;
         self.reconcile_stale_job_run(&run)?;
         self.get_job_run_backend(run_id)?
-            .ok_or_else(|| OrbitError::JobRunNotFound(run_id.to_string()))
+            .ok_or_else(|| OrbitError::not_found(NotFoundKind::JobRun, run_id.to_string()))
     }
 
     pub(crate) fn reconcile_stale_job_runs(

--- a/crates/orbit-core/src/command/learning.rs
+++ b/crates/orbit-core/src/command/learning.rs
@@ -7,7 +7,7 @@
 
 use std::path::Path;
 
-use orbit_common::types::{EvidenceKind, Learning, LearningStatus, OrbitError};
+use orbit_common::types::{EvidenceKind, Learning, LearningStatus, NotFoundKind, OrbitError};
 use orbit_store::{
     LearningCreateParams, LearningSearchParams, LearningSearchResult, LearningUpdateParams,
 };
@@ -23,7 +23,7 @@ impl OrbitRuntime {
         self.stores()
             .learnings()
             .get(id)?
-            .ok_or_else(|| OrbitError::LearningNotFound(id.to_string()))
+            .ok_or_else(|| OrbitError::not_found(NotFoundKind::Learning, id.to_string()))
     }
 
     pub fn list_learnings(

--- a/crates/orbit-core/src/command/pipeline_run.rs
+++ b/crates/orbit-core/src/command/pipeline_run.rs
@@ -5,8 +5,8 @@ use std::time::{Duration, Instant};
 
 use chrono::Utc;
 use orbit_common::types::{
-    AuditEventStatus, JobRun, JobRunState, JobScheduleState, JobTargetType, OrbitError, OrbitEvent,
-    PipelineState, audit_execution_id,
+    AuditEventStatus, JobRun, JobRunState, JobScheduleState, JobTargetType, NotFoundKind,
+    OrbitError, OrbitEvent, PipelineState, audit_execution_id,
 };
 use orbit_store::{AuditEventInsertParams, JobRunStepParams, TaskReservationReleaseReason};
 use serde::Serialize;
@@ -365,7 +365,10 @@ impl OrbitRuntime {
             .map(|run_id| {
                 let run = match self.show_job_run(run_id) {
                     Ok(run) => run,
-                    Err(OrbitError::JobRunNotFound(_)) => {
+                    Err(OrbitError::NotFound {
+                        kind: NotFoundKind::JobRun,
+                        ..
+                    }) => {
                         return Ok(PipelineWaitEntry {
                             run_id: run_id.clone(),
                             status: "failed".to_string(),

--- a/crates/orbit-core/src/command/task/query.rs
+++ b/crates/orbit-core/src/command/task/query.rs
@@ -1,6 +1,6 @@
 use orbit_common::types::{
-    ExternalRef, OrbitError, ReviewThread, Task, TaskArtifact, TaskComment, TaskHistoryEntry,
-    prune_missing_context_files,
+    ExternalRef, NotFoundKind, OrbitError, ReviewThread, Task, TaskArtifact, TaskComment,
+    TaskHistoryEntry, prune_missing_context_files,
 };
 
 use crate::OrbitRuntime;
@@ -12,35 +12,35 @@ impl OrbitRuntime {
         self.stores()
             .tasks()
             .get(id)?
-            .ok_or_else(|| OrbitError::TaskNotFound(id.to_string()))
+            .ok_or_else(|| OrbitError::not_found(NotFoundKind::Task, id.to_string()))
     }
 
     pub fn get_task_artifacts(&self, id: &str) -> Result<Vec<TaskArtifact>, OrbitError> {
         self.stores()
             .tasks()
             .get_artifacts(id)?
-            .ok_or_else(|| OrbitError::TaskNotFound(id.to_string()))
+            .ok_or_else(|| OrbitError::not_found(NotFoundKind::Task, id.to_string()))
     }
 
     pub fn get_task_comments(&self, id: &str) -> Result<Vec<TaskComment>, OrbitError> {
         self.stores()
             .tasks()
             .get_comments(id)?
-            .ok_or_else(|| OrbitError::TaskNotFound(id.to_string()))
+            .ok_or_else(|| OrbitError::not_found(NotFoundKind::Task, id.to_string()))
     }
 
     pub fn get_task_history(&self, id: &str) -> Result<Vec<TaskHistoryEntry>, OrbitError> {
         self.stores()
             .tasks()
             .get_history(id)?
-            .ok_or_else(|| OrbitError::TaskNotFound(id.to_string()))
+            .ok_or_else(|| OrbitError::not_found(NotFoundKind::Task, id.to_string()))
     }
 
     pub fn get_task_review_threads(&self, id: &str) -> Result<Vec<ReviewThread>, OrbitError> {
         self.stores()
             .tasks()
             .get_review_threads(id)?
-            .ok_or_else(|| OrbitError::TaskNotFound(id.to_string()))
+            .ok_or_else(|| OrbitError::not_found(NotFoundKind::Task, id.to_string()))
     }
 
     pub fn list_tasks(&self) -> Result<Vec<Task>, OrbitError> {

--- a/crates/orbit-core/src/command/task/transitions.rs
+++ b/crates/orbit-core/src/command/task/transitions.rs
@@ -1,6 +1,6 @@
 use orbit_common::types::{
-    OrbitError, OrbitEvent, Task, TaskHistoryEntry, TaskStatus, build_task_status_index,
-    unmet_task_dependencies,
+    NotFoundKind, OrbitError, OrbitEvent, Task, TaskHistoryEntry, TaskStatus,
+    build_task_status_index, unmet_task_dependencies,
 };
 
 use crate::OrbitRuntime;
@@ -504,7 +504,7 @@ impl OrbitRuntime {
         self.with_mutation(|| {
             let deleted = self.stores().tasks().delete(id)?;
             if !deleted {
-                return Err(OrbitError::TaskNotFound(id.to_string()));
+                return Err(OrbitError::not_found(NotFoundKind::Task, id.to_string()));
             }
             Ok(((), OrbitEvent::TaskDeleted { id: id.to_string() }))
         })

--- a/crates/orbit-core/src/command/tool.rs
+++ b/crates/orbit-core/src/command/tool.rs
@@ -3,8 +3,8 @@ use std::path::Path;
 use std::time::Instant;
 
 use orbit_common::types::{
-    AuditEventStatus, OrbitError, OrbitEvent, Role, StoredTool, ToolParam, audit_execution_id,
-    normalize_agent_family_for_model, normalize_optional_attribution_label,
+    AuditEventStatus, NotFoundKind, OrbitError, OrbitEvent, Role, StoredTool, ToolParam,
+    audit_execution_id, normalize_agent_family_for_model, normalize_optional_attribution_label,
 };
 use orbit_store::AuditEventInsertParams;
 use orbit_tools::{ReservationOwnerContext, ToolContext};
@@ -449,7 +449,7 @@ impl OrbitRuntime {
         let schema = self
             .tool_registry()
             .get_schema(name)
-            .ok_or_else(|| OrbitError::ToolNotFound(name.to_string()))?;
+            .ok_or_else(|| OrbitError::not_found(NotFoundKind::Tool, name.to_string()))?;
 
         let stored = self.stores().tools().get(name)?;
         let enabled = stored.is_none_or(|s| s.enabled);
@@ -517,7 +517,7 @@ impl OrbitRuntime {
         self.with_mutation(|| {
             let deleted = self.stores().tools().delete(name)?;
             if !deleted {
-                return Err(OrbitError::ToolNotFound(name.to_string()));
+                return Err(OrbitError::not_found(NotFoundKind::Tool, name.to_string()));
             }
             Ok((
                 (),
@@ -586,7 +586,7 @@ impl OrbitRuntime {
 
     fn set_tool_enabled_state(&self, name: &str, enabled: bool) -> Result<(), OrbitError> {
         if !self.tool_registry().has(name) {
-            return Err(OrbitError::ToolNotFound(name.to_string()));
+            return Err(OrbitError::not_found(NotFoundKind::Tool, name.to_string()));
         }
 
         let existing = self.stores().tools().get(name)?;
@@ -594,7 +594,7 @@ impl OrbitRuntime {
             let schema = self
                 .tool_registry()
                 .get_schema(name)
-                .ok_or_else(|| OrbitError::ToolNotFound(name.to_string()))?;
+                .ok_or_else(|| OrbitError::not_found(NotFoundKind::Tool, name.to_string()))?;
             let tool = StoredTool {
                 name: name.to_string(),
                 path: String::new(),

--- a/crates/orbit-core/src/lib.rs
+++ b/crates/orbit-core/src/lib.rs
@@ -46,7 +46,6 @@ pub use command::workflow::{
     find_workflow, validate_workflow_flags,
 };
 pub use context::{ActorIdentity, ActorKind, OrbitContext};
-pub use orbit_common::types::OrbitError;
 pub use orbit_common::types::{
     Activity, AuditEvent, AuditEventStatus, AuditStats, EvidenceKind, ExecutorDef, ExternalRef,
     GITHUB_PR_EXTERNAL_REF_SYSTEM, Job, JobRun, JobRunState, JobRunStep, JobScheduleState, JobStep,
@@ -57,6 +56,7 @@ pub use orbit_common::types::{
     resolve_task_dependencies, task_dependencies_ready, task_matches_tags, unmet_task_dependencies,
     validate_task_dependencies,
 };
+pub use orbit_common::types::{NotFoundKind, OrbitError};
 pub use orbit_common::utility::redaction::{
     redact_sensitive_env_error, redact_sensitive_env_json, redact_sensitive_env_option,
     redact_sensitive_env_text,

--- a/crates/orbit-core/src/runtime/builder.rs
+++ b/crates/orbit-core/src/runtime/builder.rs
@@ -269,7 +269,7 @@ fn load_external_tools(store: &Store, registry: &mut ToolRegistry) -> Result<(),
 
 #[cfg(test)]
 mod tests {
-    use orbit_common::types::TaskStatus;
+    use orbit_common::types::{NotFoundKind, TaskStatus};
     use tempfile::tempdir;
 
     use super::*;
@@ -343,7 +343,10 @@ mod tests {
             .expect("delete v2 task");
         assert!(matches!(
             runtime.get_task(&updated.id),
-            Err(OrbitError::TaskNotFound(_))
+            Err(OrbitError::NotFound {
+                kind: NotFoundKind::Task,
+                ..
+            })
         ));
     }
 

--- a/crates/orbit-core/src/runtime/engine/job_run_host.rs
+++ b/crates/orbit-core/src/runtime/engine/job_run_host.rs
@@ -1,5 +1,5 @@
 use chrono::{DateTime, Utc};
-use orbit_common::types::{JobRun, JobRunState, KnowledgeRunMetrics, OrbitError};
+use orbit_common::types::{JobRun, JobRunState, KnowledgeRunMetrics, NotFoundKind, OrbitError};
 use orbit_engine::JobRunHost;
 use orbit_store::{JobRunStepParams, TaskReservationReleaseReason};
 
@@ -102,7 +102,10 @@ impl JobRunHost for OrbitRuntime {
     fn get_job_run(&self, run_id: &str) -> Result<Option<JobRun>, OrbitError> {
         match self.show_job_run(run_id) {
             Ok(run) => Ok(Some(run)),
-            Err(OrbitError::JobRunNotFound(_)) => Ok(None),
+            Err(OrbitError::NotFound {
+                kind: NotFoundKind::JobRun,
+                ..
+            }) => Ok(None),
             Err(error) => Err(error),
         }
     }

--- a/crates/orbit-core/src/runtime/orbit_tool_host/adr_tools.rs
+++ b/crates/orbit-core/src/runtime/orbit_tool_host/adr_tools.rs
@@ -6,9 +6,9 @@
 use std::str::FromStr;
 
 use orbit_common::types::{
-    Adr, AdrStatus, AuditEventStatus, LegacyValidation, OrbitError, audit_execution_id,
-    normalize_optional_attribution_label, optional_string, optional_string_alias,
-    optional_string_list_alias, required_string,
+    Adr, AdrStatus, AuditEventStatus, LegacyValidation, NotFoundKind, OrbitError,
+    audit_execution_id, normalize_optional_attribution_label, optional_string,
+    optional_string_alias, optional_string_list_alias, required_string,
 };
 use orbit_store::{AdrCreateParams, AdrDocumentUpdateParams};
 use serde_json::{Value, json};
@@ -73,10 +73,10 @@ pub(super) fn show(runtime: &OrbitRuntime, input: Value) -> Result<Value, OrbitE
         matches
             .into_iter()
             .next()
-            .ok_or_else(|| OrbitError::AdrNotFound(id_value.clone()))?
+            .ok_or_else(|| OrbitError::not_found(NotFoundKind::Adr, id_value.clone()))?
     } else {
         adrs.get(&id_value)?
-            .ok_or_else(|| OrbitError::AdrNotFound(id_value.clone()))?
+            .ok_or_else(|| OrbitError::not_found(NotFoundKind::Adr, id_value.clone()))?
     };
     Ok(adr_to_json(&adr))
 }
@@ -113,7 +113,7 @@ pub(super) fn update(
     let adrs = runtime.stores().adrs();
     let existing = adrs
         .get(&id)?
-        .ok_or_else(|| OrbitError::AdrNotFound(id.clone()))?;
+        .ok_or_else(|| OrbitError::not_found(NotFoundKind::Adr, id.clone()))?;
 
     let new_status = optional_string(&input, "status")?
         .map(|raw| AdrStatus::from_str(&raw).map_err(OrbitError::InvalidInput))
@@ -192,7 +192,7 @@ pub(super) fn update(
 
     let updated = adrs
         .get(&id)?
-        .ok_or_else(|| OrbitError::AdrNotFound(id.clone()))?;
+        .ok_or_else(|| OrbitError::not_found(NotFoundKind::Adr, id.clone()))?;
     Ok(adr_to_json(&updated))
 }
 
@@ -207,7 +207,7 @@ pub(super) fn supersede(
     let adrs = runtime.stores().adrs();
     let before = adrs
         .get(&old_id)?
-        .ok_or_else(|| OrbitError::AdrNotFound(old_id.clone()))?;
+        .ok_or_else(|| OrbitError::not_found(NotFoundKind::Adr, old_id.clone()))?;
     adrs.supersede(&old_id, &new_id)?;
     record_transition_audit(
         runtime,
@@ -222,7 +222,7 @@ pub(super) fn supersede(
     )?;
     let updated = adrs
         .get(&old_id)?
-        .ok_or_else(|| OrbitError::AdrNotFound(old_id.clone()))?;
+        .ok_or_else(|| OrbitError::not_found(NotFoundKind::Adr, old_id.clone()))?;
     Ok(adr_to_json(&updated))
 }
 
@@ -329,6 +329,7 @@ fn record_transition_audit(
 mod tests {
     use super::*;
     use crate::runtime::orbit_tool_host::test_support::test_runtime;
+    use orbit_common::types::NotFoundKind;
 
     fn assert_adr_field(value: &Value, field: &str, expected: &str) {
         let actual = value
@@ -432,7 +433,13 @@ mod tests {
     fn show_missing_returns_not_found() {
         let (_guard, runtime, _repo_root) = test_runtime();
         let err = show(&runtime, json!({"id": "ADR-9999"})).expect_err("missing");
-        assert!(matches!(err, OrbitError::AdrNotFound(_)));
+        assert!(matches!(
+            err,
+            OrbitError::NotFound {
+                kind: NotFoundKind::Adr,
+                ..
+            }
+        ));
     }
 
     #[test]

--- a/crates/orbit-core/src/runtime/orbit_tool_host/input.rs
+++ b/crates/orbit-core/src/runtime/orbit_tool_host/input.rs
@@ -2,8 +2,9 @@ use std::path::PathBuf;
 use std::str::FromStr;
 
 use orbit_common::types::{
-    ExternalRef, OrbitError, TaskArtifact, TaskComplexity, TaskPriority, TaskStatus, TaskType,
-    media_type_for_artifact_path, optional_string, optional_string_alias, optional_u32_alias,
+    ExternalRef, NotFoundKind, OrbitError, TaskArtifact, TaskComplexity, TaskPriority, TaskStatus,
+    TaskType, media_type_for_artifact_path, optional_string, optional_string_alias,
+    optional_u32_alias,
 };
 use orbit_store::state_io;
 use orbit_tools::OrbitTaskScope;
@@ -49,7 +50,7 @@ pub(super) fn resolve_state_dir(
     })?;
 
     state_io::resolve_active_run_state_dir(&orbit_root, &run_id)?
-        .ok_or(OrbitError::JobRunNotFound(run_id))
+        .ok_or(OrbitError::not_found(NotFoundKind::JobRun, run_id))
 }
 
 pub(super) fn resolve_step_index(input: &Value) -> Result<u32, OrbitError> {

--- a/crates/orbit-core/src/runtime/orbit_tool_host/learning_tools.rs
+++ b/crates/orbit-core/src/runtime/orbit_tool_host/learning_tools.rs
@@ -9,8 +9,8 @@
 use std::str::FromStr;
 
 use orbit_common::types::{
-    EvidenceKind, LearningEvidence, LearningScope, LearningStatus, OrbitError, optional_string,
-    optional_string_alias, required_string,
+    EvidenceKind, LearningEvidence, LearningScope, LearningStatus, NotFoundKind, OrbitError,
+    optional_string, optional_string_alias, required_string,
 };
 use orbit_store::{LearningCreateParams, LearningSearchParams, LearningUpdateParams};
 use serde_json::{Value, json};
@@ -54,7 +54,7 @@ pub(super) fn show(runtime: &OrbitRuntime, input: Value) -> Result<Value, OrbitE
         .stores()
         .learnings()
         .get(&id)?
-        .ok_or_else(|| OrbitError::LearningNotFound(id.clone()))?;
+        .ok_or_else(|| OrbitError::not_found(NotFoundKind::Learning, id.clone()))?;
     Ok(learning_to_json(&learning))
 }
 
@@ -154,12 +154,12 @@ pub(super) fn supersede(
         .stores()
         .learnings()
         .get(&id)?
-        .ok_or_else(|| OrbitError::LearningNotFound(id.clone()))?;
+        .ok_or_else(|| OrbitError::not_found(NotFoundKind::Learning, id.clone()))?;
     let new = runtime
         .stores()
         .learnings()
         .get(&with)?
-        .ok_or_else(|| OrbitError::LearningNotFound(with.clone()))?;
+        .ok_or_else(|| OrbitError::not_found(NotFoundKind::Learning, with.clone()))?;
     Ok(json!({
         "old": learning_to_json(&old),
         "new": learning_to_json(&new),

--- a/crates/orbit-core/src/runtime/orbit_tool_host/task_locks.rs
+++ b/crates/orbit-core/src/runtime/orbit_tool_host/task_locks.rs
@@ -2,7 +2,7 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::path::PathBuf;
 
 use orbit_common::types::{
-    AuditEventStatus, OrbitError, Task, TaskStatus, audit_execution_id,
+    AuditEventStatus, NotFoundKind, OrbitError, Task, TaskStatus, audit_execution_id,
     normalize_optional_attribution_label, optional_string_list_alias, optional_u32_alias,
     prune_missing_context_files, required_string,
 };
@@ -374,7 +374,7 @@ pub(crate) fn requested_task_files(
     for task_id in task_ids {
         let task = task_map
             .get(task_id)
-            .ok_or_else(|| OrbitError::TaskNotFound(task_id.clone()))?;
+            .ok_or_else(|| OrbitError::not_found(NotFoundKind::Task, task_id.clone()))?;
         requested_files.extend(existing_context_files(runtime, task));
     }
 

--- a/crates/orbit-core/src/runtime/pipeline.rs
+++ b/crates/orbit-core/src/runtime/pipeline.rs
@@ -6,7 +6,7 @@ use orbit_common::utility::redaction::{redact_sensitive_env_error, redact_sensit
 use orbit_tools::ToolContext;
 use serde_json::Value;
 
-use crate::{OrbitError, OrbitRuntime};
+use crate::{NotFoundKind, OrbitError, OrbitRuntime};
 
 impl OrbitRuntime {
     pub fn run_tool(&self, name: &str, input: Value) -> Result<Value, OrbitError> {
@@ -117,7 +117,7 @@ impl OrbitRuntime {
         let schema = self
             .tool_registry()
             .get_schema(name)
-            .ok_or_else(|| OrbitError::ToolNotFound(name.to_string()))?;
+            .ok_or_else(|| OrbitError::not_found(NotFoundKind::Tool, name.to_string()))?;
 
         let mut tool_context = ToolContext {
             cwd: std::env::current_dir()

--- a/crates/orbit-core/src/runtime/store_delegates.rs
+++ b/crates/orbit-core/src/runtime/store_delegates.rs
@@ -1,7 +1,8 @@
 use orbit_common::types::{
     Adr, AdrStatus, AuditEvent, ExecutorDef, ExternalRef, JobRun, JobRunState, KnowledgeRunMetrics,
-    Learning, LearningStatus, OrbitError, PolicyDef, ReviewThread, StoredTool, Task, TaskArtifact,
-    TaskComment, TaskComplexity, TaskHistoryEntry, TaskPriority, TaskStatus, TaskType,
+    Learning, LearningStatus, NotFoundKind, OrbitError, PolicyDef, ReviewThread, StoredTool, Task,
+    TaskArtifact, TaskComment, TaskComplexity, TaskHistoryEntry, TaskPriority, TaskStatus,
+    TaskType,
 };
 use orbit_embed::vector::{EmbedWorker, VectorStore};
 use orbit_store::{
@@ -295,7 +296,7 @@ impl TaskRecords<'_> {
 
         let task = self
             .get(id)?
-            .ok_or_else(|| OrbitError::TaskNotFound(id.to_string()))?;
+            .ok_or_else(|| OrbitError::not_found(NotFoundKind::Task, id.to_string()))?;
         if params.has_document_changes()
             || params.has_history_changes()
             || params.has_review_changes()

--- a/crates/orbit-core/src/workspace_registry.rs
+++ b/crates/orbit-core/src/workspace_registry.rs
@@ -1,7 +1,9 @@
 use std::path::{Path, PathBuf};
 
 use chrono::Utc;
-use orbit_common::types::{OrbitError, Workspace, WorkspaceRegistry, WorkspaceStatus};
+use orbit_common::types::{
+    NotFoundKind, OrbitError, Workspace, WorkspaceRegistry, WorkspaceStatus,
+};
 
 use orbit_common::utility::fs::atomic_write_text;
 
@@ -79,7 +81,7 @@ pub fn remove_workspace(
         .workspaces
         .iter()
         .position(|w| w.id == id_or_name || w.name == id_or_name)
-        .ok_or_else(|| OrbitError::WorkspaceNotFound(id_or_name.to_string()))?;
+        .ok_or_else(|| OrbitError::not_found(NotFoundKind::Workspace, id_or_name.to_string()))?;
     let removed = registry.workspaces.remove(idx);
     // Also remove any path overrides pointing to this workspace
     registry
@@ -134,7 +136,10 @@ pub fn set_path_override(
 ) -> Result<(), OrbitError> {
     // Verify the workspace exists
     if !registry.workspaces.iter().any(|w| w.id == workspace_id) {
-        return Err(OrbitError::WorkspaceNotFound(workspace_id.to_string()));
+        return Err(OrbitError::not_found(
+            NotFoundKind::Workspace,
+            workspace_id.to_string(),
+        ));
     }
     registry
         .path_overrides

--- a/crates/orbit-embed/src/commands/related.rs
+++ b/crates/orbit-embed/src/commands/related.rs
@@ -1,4 +1,4 @@
-use orbit_common::types::{OrbitError, Task};
+use orbit_common::types::{NotFoundKind, OrbitError, Task};
 use serde::{Deserialize, Serialize};
 
 use crate::commands::resolve_query_model;
@@ -52,7 +52,7 @@ pub(crate) fn run_with_embedder(
     let target = tasks
         .iter()
         .find(|task| task.id == params.task_id)
-        .ok_or_else(|| OrbitError::TaskNotFound(params.task_id.clone()))?;
+        .ok_or_else(|| OrbitError::not_found(NotFoundKind::Task, params.task_id.clone()))?;
     let query = format!("{}\n\n{}", target.title.trim(), target.description.trim());
     let query = query.trim();
     if query.is_empty() {

--- a/crates/orbit-engine/src/executor/automation/batch/parallel.rs
+++ b/crates/orbit-engine/src/executor/automation/batch/parallel.rs
@@ -668,7 +668,8 @@ mod tests {
 
     use chrono::Utc;
     use orbit_common::types::{
-        Activity, ExternalRef, Job, JobTargetType, OrbitEvent, TaskArtifact, TaskPriority, TaskType,
+        Activity, ExternalRef, Job, JobTargetType, NotFoundKind, OrbitEvent, TaskArtifact,
+        TaskPriority, TaskType,
     };
 
     use crate::context::{TaskReadHost, TaskWriteHost};
@@ -790,7 +791,7 @@ mod tests {
                 .iter()
                 .find(|task| task.id == task_id)
                 .cloned()
-                .ok_or_else(|| OrbitError::TaskNotFound(task_id.to_string()))
+                .ok_or_else(|| OrbitError::not_found(NotFoundKind::Task, task_id.to_string()))
         }
 
         fn get_task_artifacts(&self, _task_id: &str) -> Result<Vec<TaskArtifact>, OrbitError> {
@@ -883,7 +884,7 @@ mod tests {
             let task = tasks
                 .iter_mut()
                 .find(|task| task.id == task_id)
-                .ok_or_else(|| OrbitError::TaskNotFound(task_id.to_string()))?;
+                .ok_or_else(|| OrbitError::not_found(NotFoundKind::Task, task_id.to_string()))?;
             if let Some(status) = update.status {
                 task.status = status;
                 if status == TaskStatus::Blocked {
@@ -991,7 +992,7 @@ mod tests {
                         }).collect::<Vec<_>>()
                     }))
                 }
-                other => Err(OrbitError::ToolNotFound(other.to_string())),
+                other => Err(OrbitError::not_found(NotFoundKind::Tool, other.to_string())),
             }
         }
 

--- a/crates/orbit-engine/src/executor/automation/duel/planning_duel/runner.rs
+++ b/crates/orbit-engine/src/executor/automation/duel/planning_duel/runner.rs
@@ -151,8 +151,9 @@ mod tests {
 
     use chrono::Utc;
     use orbit_common::types::{
-        Activity, InvocationTrace, Job, JobTargetType, OrbitEvent, PlanningRoleAssignment, Role,
-        Task, TaskArtifact, TaskComment, TaskPriority, TaskStatus, TaskType,
+        Activity, InvocationTrace, Job, JobTargetType, NotFoundKind, OrbitError, OrbitEvent,
+        PlanningRoleAssignment, Role, Task, TaskArtifact, TaskComment, TaskPriority, TaskStatus,
+        TaskType,
     };
     use orbit_store::{InvocationQuery, InvocationRecord};
     use orbit_tools::ToolContext;
@@ -226,7 +227,8 @@ mod tests {
             if task.id == task_id {
                 Ok(task)
             } else {
-                Err(orbit_common::types::OrbitError::TaskNotFound(
+                Err(OrbitError::not_found(
+                    NotFoundKind::Task,
                     task_id.to_string(),
                 ))
             }

--- a/crates/orbit-engine/src/executor/automation/vcs/commit/mod.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/commit/mod.rs
@@ -247,8 +247,8 @@ mod tests {
 
     use chrono::Utc;
     use orbit_common::types::{
-        Activity, Job, JobTargetType, OrbitEvent, Role, TaskArtifact, TaskPriority, TaskStatus,
-        TaskType,
+        Activity, Job, JobTargetType, NotFoundKind, OrbitEvent, Role, TaskArtifact, TaskPriority,
+        TaskStatus, TaskType,
     };
     use orbit_tools::ToolContext;
     use serde_json::{Value, json};
@@ -290,7 +290,7 @@ mod tests {
                 .iter()
                 .find(|task| task.id == task_id)
                 .cloned()
-                .ok_or_else(|| OrbitError::TaskNotFound(task_id.to_string()))
+                .ok_or_else(|| OrbitError::not_found(NotFoundKind::Task, task_id.to_string()))
         }
 
         fn get_task_artifacts(&self, _task_id: &str) -> Result<Vec<TaskArtifact>, OrbitError> {

--- a/crates/orbit-engine/src/executor/automation/vcs/pr.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/pr.rs
@@ -610,8 +610,8 @@ mod tests {
 
     use chrono::Utc;
     use orbit_common::types::{
-        Activity, Job, JobTargetType, OrbitEvent, Role, TaskArtifact, TaskPriority, TaskType,
-        push_external_ref_if_missing,
+        Activity, Job, JobTargetType, NotFoundKind, OrbitEvent, Role, TaskArtifact, TaskPriority,
+        TaskType, push_external_ref_if_missing,
     };
     use orbit_tools::ToolContext;
     use serde_json::{Value, json};
@@ -678,7 +678,7 @@ mod tests {
                 .iter()
                 .find(|task| task.id == task_id)
                 .cloned()
-                .ok_or_else(|| OrbitError::TaskNotFound(task_id.to_string()))
+                .ok_or_else(|| OrbitError::not_found(NotFoundKind::Task, task_id.to_string()))
         }
 
         fn get_task_artifacts(&self, _task_id: &str) -> Result<Vec<TaskArtifact>, OrbitError> {
@@ -771,7 +771,7 @@ mod tests {
             let task = tasks
                 .iter_mut()
                 .find(|task| task.id == task_id)
-                .ok_or_else(|| OrbitError::TaskNotFound(task_id.to_string()))?;
+                .ok_or_else(|| OrbitError::not_found(NotFoundKind::Task, task_id.to_string()))?;
             if let Some(status) = update.status {
                 task.status = status;
             }
@@ -850,7 +850,7 @@ mod tests {
                 "github.pr.view" => Ok(json!({
                     "pull_request": { "number": 42 }
                 })),
-                other => Err(OrbitError::ToolNotFound(other.to_string())),
+                other => Err(OrbitError::not_found(NotFoundKind::Tool, other.to_string())),
             }
         }
 

--- a/crates/orbit-knowledge/src/commands/mod.rs
+++ b/crates/orbit-knowledge/src/commands/mod.rs
@@ -7,10 +7,10 @@ use std::path::PathBuf;
 
 use orbit_common::types::OrbitError;
 
-use crate::KnowledgeError;
 use crate::graph::object_store::{GraphObjectStore, resolve_graph_read_target};
 use crate::graph::{GraphIndexReader, GraphReadOptions};
 use crate::service::TaskGraphService;
+use crate::{KnowledgeError, KnowledgeErrorKind};
 
 pub mod callers;
 pub mod deps;
@@ -106,9 +106,11 @@ pub(crate) fn knowledge_error_from_orbit(error: OrbitError) -> KnowledgeError {
 /// `knowledge_invalid` kind maps to `InvalidInput` because callers treat it
 /// as user-input error; every other kind maps to `Execution`.
 pub fn knowledge_error_to_orbit(error: KnowledgeError) -> OrbitError {
-    if error.kind == "knowledge_invalid" {
-        OrbitError::InvalidInput(error.reason)
-    } else {
-        OrbitError::Execution(error.to_string())
+    let KnowledgeError { kind, reason } = error;
+    match kind {
+        KnowledgeErrorKind::Invalid => OrbitError::InvalidInput(reason),
+        KnowledgeErrorKind::Unavailable | KnowledgeErrorKind::Io => {
+            OrbitError::Execution(format!("{kind}: {reason}"))
+        }
     }
 }

--- a/crates/orbit-knowledge/src/error.rs
+++ b/crates/orbit-knowledge/src/error.rs
@@ -1,32 +1,76 @@
 use serde::Serialize;
 use thiserror::Error;
 
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub enum KnowledgeErrorKind {
+    #[serde(rename = "knowledge_invalid")]
+    Invalid,
+    #[serde(rename = "knowledge_unavailable")]
+    Unavailable,
+    #[serde(rename = "io_error")]
+    Io,
+}
+
+impl std::fmt::Display for KnowledgeErrorKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let kind = match self {
+            Self::Invalid => "knowledge_invalid",
+            Self::Unavailable => "knowledge_unavailable",
+            Self::Io => "io_error",
+        };
+        f.write_str(kind)
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Error)]
 #[error("{kind}: {reason}")]
 pub struct KnowledgeError {
-    pub kind: String,
+    pub kind: KnowledgeErrorKind,
     pub reason: String,
 }
 
 impl KnowledgeError {
     pub(crate) fn knowledge_unavailable(reason: impl Into<String>) -> Self {
         Self {
-            kind: "knowledge_unavailable".to_string(),
+            kind: KnowledgeErrorKind::Unavailable,
             reason: reason.into(),
         }
     }
 
     pub(crate) fn invalid_data(reason: impl Into<String>) -> Self {
         Self {
-            kind: "knowledge_invalid".to_string(),
+            kind: KnowledgeErrorKind::Invalid,
             reason: reason.into(),
         }
     }
 
     pub(crate) fn io(reason: impl Into<String>) -> Self {
         Self {
-            kind: "io_error".to_string(),
+            kind: KnowledgeErrorKind::Io,
             reason: reason.into(),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{KnowledgeError, KnowledgeErrorKind};
+
+    #[test]
+    fn knowledge_error_serializes_kind_as_stable_code() {
+        let error = KnowledgeError {
+            kind: KnowledgeErrorKind::Invalid,
+            reason: "bad selector".to_string(),
+        };
+
+        let value = serde_json::to_value(error).expect("serialize knowledge error");
+
+        assert_eq!(
+            value,
+            serde_json::json!({
+                "kind": "knowledge_invalid",
+                "reason": "bad selector"
+            })
+        );
     }
 }

--- a/crates/orbit-knowledge/src/lib.rs
+++ b/crates/orbit-knowledge/src/lib.rs
@@ -47,7 +47,7 @@ pub mod workflows;
 pub mod working_graph;
 
 pub use commands::knowledge_error_to_orbit;
-pub use error::KnowledgeError;
+pub use error::{KnowledgeError, KnowledgeErrorKind};
 pub use graph::GraphReadOptions;
 pub use selector::{Selector, SelectorParseError};
 pub use service::{TaskGraphScope, TaskGraphService, default_knowledge_dir};

--- a/crates/orbit-knowledge/src/service/task_graph.rs
+++ b/crates/orbit-knowledge/src/service/task_graph.rs
@@ -85,20 +85,16 @@ impl TaskGraphService {
                     ) {
                         Ok(true) => match pack_result() {
                             Ok(pack) => Ok(pack),
-                            Err(retry_error) => Err(KnowledgeError {
-                                kind: "knowledge_unavailable".to_string(),
-                                reason: format!(
+                            Err(retry_error) => {
+                                Err(KnowledgeError::knowledge_unavailable(format!(
                                     "failed to load knowledge pack: {first_error}; retry after rebuild failed: {retry_error}"
-                                ),
-                            }),
+                                )))
+                            }
                         },
                         Ok(false) => Err(first_error),
-                        Err(rebuild_error) => Err(KnowledgeError {
-                            kind: "knowledge_unavailable".to_string(),
-                            reason: format!(
-                                "failed to load knowledge pack: {first_error}; rebuild attempt failed: {rebuild_error}"
-                            ),
-                        }),
+                        Err(rebuild_error) => Err(KnowledgeError::knowledge_unavailable(format!(
+                            "failed to load knowledge pack: {first_error}; rebuild attempt failed: {rebuild_error}"
+                        ))),
                     }
                 };
 

--- a/crates/orbit-mcp/src/adapter.rs
+++ b/crates/orbit-mcp/src/adapter.rs
@@ -587,7 +587,7 @@ mod tests {
         });
         let server = OrbitToolServer::new(host);
         // Legacy dotted name from an older client falls through unchanged so
-        // the host's own ToolNotFound handling still runs.
+        // the host's own tool-not-found handling still runs.
         assert_eq!(
             server.canonical_name("orbit.task.add").unwrap(),
             "orbit.task.add"

--- a/crates/orbit-mcp/src/error.rs
+++ b/crates/orbit-mcp/src/error.rs
@@ -1,4 +1,4 @@
-use orbit_common::types::OrbitError;
+use orbit_common::types::{NotFoundKind, OrbitError};
 use rmcp::model::CallToolResult;
 use serde_json::{Value, json};
 
@@ -22,16 +22,18 @@ fn error_payload(err: &OrbitError) -> Value {
 
 fn error_code(err: &OrbitError) -> &'static str {
     match err {
-        OrbitError::ToolNotFound(_) => "tool_not_found",
-        OrbitError::TaskNotFound(_)
-        | OrbitError::SkillNotFound(_)
-        | OrbitError::JobNotFound(_)
-        | OrbitError::JobRunNotFound(_)
-        | OrbitError::ActivityNotFound(_)
-        | OrbitError::AgentSessionNotFound(_)
-        | OrbitError::WorkspaceNotFound(_)
-        | OrbitError::AdrNotFound(_)
-        | OrbitError::LearningNotFound(_) => "not_found",
+        OrbitError::NotFound { kind, .. } => match kind {
+            NotFoundKind::Tool => "tool_not_found",
+            NotFoundKind::Task
+            | NotFoundKind::Skill
+            | NotFoundKind::Job
+            | NotFoundKind::JobRun
+            | NotFoundKind::Activity
+            | NotFoundKind::Adr
+            | NotFoundKind::Learning
+            | NotFoundKind::AgentSession
+            | NotFoundKind::Workspace => "not_found",
+        },
         OrbitError::CompanionNotInstalled(_) => "companion_not_installed",
         OrbitError::PolicyDenied(_) => "policy_denied",
         OrbitError::TaskApprovalRequired(_) => "approval_required",

--- a/crates/orbit-store/src/file/adr_store/api.rs
+++ b/crates/orbit-store/src/file/adr_store/api.rs
@@ -2,7 +2,7 @@ use std::fs;
 use std::path::PathBuf;
 
 use chrono::Utc;
-use orbit_common::types::{Adr, AdrStatus, LegacyValidation, OrbitError};
+use orbit_common::types::{Adr, AdrStatus, LegacyValidation, NotFoundKind, OrbitError};
 use rusqlite::params;
 
 use super::bundle::{AdrBundle, bundle_to_adr, read_bundle_at, validate_bundle, write_bundle_at};
@@ -185,7 +185,7 @@ impl AdrFileStore {
         let _lock = acquire_adr_lock(&self.root, id)?;
 
         let Some((current_state, current_dir)) = self.locate_adr(id)? else {
-            return Err(OrbitError::AdrNotFound(id.to_string()));
+            return Err(OrbitError::not_found(NotFoundKind::Adr, id.to_string()));
         };
         let current_status = current_state.to_status();
         if current_status == new_status {
@@ -224,7 +224,7 @@ impl AdrFileStore {
         let _lock = acquire_adr_lock(&self.root, id)?;
 
         let Some((_, current_dir)) = self.locate_adr(id)? else {
-            return Err(OrbitError::AdrNotFound(id.to_string()));
+            return Err(OrbitError::not_found(NotFoundKind::Adr, id.to_string()));
         };
         let mut bundle = read_bundle_at(&current_dir)?;
 
@@ -312,10 +312,10 @@ impl AdrFileStore {
 
         let old = self
             .get_adr(old_id)?
-            .ok_or_else(|| OrbitError::AdrNotFound(old_id.to_string()))?;
+            .ok_or_else(|| OrbitError::not_found(NotFoundKind::Adr, old_id.to_string()))?;
         let new = self
             .get_adr(new_id)?
-            .ok_or_else(|| OrbitError::AdrNotFound(new_id.to_string()))?;
+            .ok_or_else(|| OrbitError::not_found(NotFoundKind::Adr, new_id.to_string()))?;
 
         if new.status != AdrStatus::Accepted {
             return Err(OrbitError::AdrInvalidTransition(format!(
@@ -395,7 +395,7 @@ impl AdrFileStore {
             let dir = adr_dir(&self.root, *state, id);
             if dir.is_dir() {
                 // A stray same-named dir without adr.yaml still counts as "located"
-                // here so the caller gets a sensible AdrNotFound / corruption error
+                // here so the caller gets a sensible missing-ADR / corruption error
                 // from read_bundle_at.
                 return Ok(Some((*state, dir)));
             }

--- a/crates/orbit-store/src/file/adr_store/bundle.rs
+++ b/crates/orbit-store/src/file/adr_store/bundle.rs
@@ -1,7 +1,7 @@
 use std::fs;
 use std::path::Path;
 
-use orbit_common::types::{Adr, OrbitError};
+use orbit_common::types::{Adr, NotFoundKind, OrbitError};
 use orbit_common::utility::fs::atomic_write_text_volatile as write_atomic;
 
 use super::doc::{AdrFileDocument, serialize_adr_doc_yaml};
@@ -31,7 +31,7 @@ pub(super) fn read_bundle_at(adr_dir: &Path) -> Result<AdrBundle, OrbitError> {
             .and_then(|n| n.to_str())
             .unwrap_or("<unknown>")
             .to_string();
-        return Err(OrbitError::AdrNotFound(id));
+        return Err(OrbitError::not_found(NotFoundKind::Adr, id));
     }
 
     let doc: AdrFileDocument = read_yaml_with(&doc_path, |path, err| {
@@ -62,7 +62,7 @@ fn read_companion_text(path: &Path) -> Result<String, OrbitError> {
 mod tests {
     use chrono::TimeZone;
     use chrono::Utc;
-    use orbit_common::types::{Adr, AdrStatus, LegacyValidation};
+    use orbit_common::types::{Adr, AdrStatus, LegacyValidation, NotFoundKind};
     use tempfile::tempdir;
 
     use super::super::constants::ADR_SCHEMA_VERSION;
@@ -129,8 +129,14 @@ mod tests {
         let err = read_bundle_at(&dir).expect_err("missing dir should error");
 
         assert!(
-            matches!(err, OrbitError::AdrNotFound(ref id) if id == "ADR-9999"),
-            "expected AdrNotFound, got {err:?}"
+            matches!(
+                err,
+                OrbitError::NotFound {
+                    kind: NotFoundKind::Adr,
+                    ref id,
+                } if id == "ADR-9999"
+            ),
+            "expected missing ADR error, got {err:?}"
         );
     }
 }

--- a/crates/orbit-store/src/file/job_store/run.rs
+++ b/crates/orbit-store/src/file/job_store/run.rs
@@ -4,7 +4,7 @@ use std::path::{Path, PathBuf};
 
 use chrono::{DateTime, Utc};
 use orbit_common::types::{
-    JobRun, JobRunState, JobRunStep, KnowledgeRunMetrics, OrbitError, PipelineState,
+    JobRun, JobRunState, JobRunStep, KnowledgeRunMetrics, NotFoundKind, OrbitError, PipelineState,
 };
 
 use crate::backend::JobRunStepParams;
@@ -404,7 +404,10 @@ impl JobFileStore {
 
     pub(crate) fn archive_run(&self, run_id: &str) -> Result<String, OrbitError> {
         let Some((job_id, src)) = self.find_run_path(run_id)? else {
-            return Err(OrbitError::JobRunNotFound(run_id.to_string()));
+            return Err(OrbitError::not_found(
+                NotFoundKind::JobRun,
+                run_id.to_string(),
+            ));
         };
         let dst = self.archived_run_bundle_dir(&job_id, run_id);
         let parent = dst.parent().ok_or_else(|| {
@@ -439,7 +442,10 @@ impl JobFileStore {
         state: &PipelineState,
     ) -> Result<(), OrbitError> {
         let Some((_job_id, run_dir)) = self.find_run_path(run_id)? else {
-            return Err(OrbitError::JobRunNotFound(run_id.to_string()));
+            return Err(OrbitError::not_found(
+                NotFoundKind::JobRun,
+                run_id.to_string(),
+            ));
         };
         let content =
             serde_json::to_string_pretty(state).map_err(|e| OrbitError::Store(e.to_string()))?;
@@ -455,7 +461,10 @@ impl JobFileStore {
             fs::remove_dir_all(&dir).map_err(|e| OrbitError::Io(e.to_string()))?;
             return Ok(job_id);
         }
-        Err(OrbitError::JobRunNotFound(run_id.to_string()))
+        Err(OrbitError::not_found(
+            NotFoundKind::JobRun,
+            run_id.to_string(),
+        ))
     }
 }
 

--- a/crates/orbit-store/src/file/learning_store/api.rs
+++ b/crates/orbit-store/src/file/learning_store/api.rs
@@ -4,7 +4,8 @@ use std::sync::{Arc, RwLock};
 
 use chrono::{DateTime, Utc};
 use orbit_common::types::{
-    Learning, LearningStatus, OrbitError, normalize_learning_paths, normalize_learning_tags,
+    Learning, LearningStatus, NotFoundKind, OrbitError, normalize_learning_paths,
+    normalize_learning_tags,
 };
 use orbit_common::utility::glob::{compile_glob_regex, normalize_glob_path};
 
@@ -170,7 +171,10 @@ impl LearningFileStore {
         let _lock = acquire_learning_lock(&self.root, id)?;
 
         let Some((state, path)) = locate_learning(&self.root, id)? else {
-            return Err(OrbitError::LearningNotFound(id.to_string()));
+            return Err(OrbitError::not_found(
+                NotFoundKind::Learning,
+                id.to_string(),
+            ));
         };
         let mut learning = read_learning_file(&path)?;
 
@@ -237,9 +241,9 @@ impl LearningFileStore {
         let _new_lock = acquire_learning_lock(&self.root, new_id)?;
 
         let (old_state, old_path) = locate_learning(&self.root, old_id)?
-            .ok_or_else(|| OrbitError::LearningNotFound(old_id.to_string()))?;
+            .ok_or_else(|| OrbitError::not_found(NotFoundKind::Learning, old_id.to_string()))?;
         let (_, new_path) = locate_learning(&self.root, new_id)?
-            .ok_or_else(|| OrbitError::LearningNotFound(new_id.to_string()))?;
+            .ok_or_else(|| OrbitError::not_found(NotFoundKind::Learning, new_id.to_string()))?;
 
         let mut old = read_learning_file(&old_path)?;
         let mut new = read_learning_file(&new_path)?;

--- a/crates/orbit-store/src/file/learning_store/record.rs
+++ b/crates/orbit-store/src/file/learning_store/record.rs
@@ -1,14 +1,14 @@
 use std::fs;
 use std::path::Path;
 
-use orbit_common::types::{Learning, LearningStatus, OrbitError};
+use orbit_common::types::{Learning, LearningStatus, NotFoundKind, OrbitError};
 
 use super::constants::LEARNING_SCHEMA_VERSION;
 use super::doc::{LearningFileDocument, serialize_learning_doc_yaml};
 use super::layout::validate_learning_id;
 use crate::file::yaml_doc::{read_yaml_with, write_yaml_atomic_with};
 
-/// Read a learning YAML file at the given path. Returns `LearningNotFound`
+/// Read a learning YAML file at the given path. Returns a learning not-found error
 /// when the file is missing on disk.
 pub(super) fn read_learning_file(path: &Path) -> Result<Learning, OrbitError> {
     if !path.exists() {
@@ -17,7 +17,7 @@ pub(super) fn read_learning_file(path: &Path) -> Result<Learning, OrbitError> {
             .and_then(|n| n.to_str())
             .unwrap_or("<unknown>")
             .to_string();
-        return Err(OrbitError::LearningNotFound(id));
+        return Err(OrbitError::not_found(NotFoundKind::Learning, id));
     }
     let doc: LearningFileDocument = read_yaml_with(path, |path, err| {
         OrbitError::Store(format!("invalid learning file {}: {err}", path.display()))

--- a/crates/orbit-store/src/file/skill_store.rs
+++ b/crates/orbit-store/src/file/skill_store.rs
@@ -4,7 +4,7 @@ use std::path::{Path, PathBuf};
 
 use crate::json_schema::validate_schema_document;
 use crate::scope::{ScopeStrategy, ScopedStore, resolve};
-use orbit_common::types::OrbitError;
+use orbit_common::types::{NotFoundKind, OrbitError};
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
 use sha2::{Digest, Sha256};
@@ -152,7 +152,10 @@ impl SkillCatalog {
         // otherwise fall through to the global default.
         match resolve::<LoadedSkill, _>(self, skill_id)? {
             Some(skill) => Ok(skill),
-            None => Err(OrbitError::SkillNotFound(skill_id.to_string())),
+            None => Err(OrbitError::not_found(
+                NotFoundKind::Skill,
+                skill_id.to_string(),
+            )),
         }
     }
 

--- a/crates/orbit-store/src/file/task_store/v2_bundle.rs
+++ b/crates/orbit-store/src/file/task_store/v2_bundle.rs
@@ -4,11 +4,12 @@ use std::path::{Path, PathBuf};
 
 use orbit_common::migration::Plan;
 use orbit_common::types::{
-    ArtifactManifestV2, OrbitError, ReviewThreadMetadataV2, TASK_ACCEPTANCE_FILE_NAME,
-    TASK_ARTIFACT_FILES_DIR_NAME, TASK_ARTIFACT_MANIFEST_FILE_NAME, TASK_ARTIFACTS_DIR_NAME,
-    TASK_COMMENTS_FILE_NAME, TASK_DESCRIPTION_FILE_NAME, TASK_ENVELOPE_FILE_NAME,
-    TASK_EVENTS_FILE_NAME, TASK_EXECUTION_SUMMARY_FILE_NAME, TASK_PLAN_FILE_NAME,
-    TASK_REVIEW_THREADS_DIR_NAME, TaskCommentRowV2, TaskEnvelopeV2, TaskEventRowV2,
+    ArtifactManifestV2, NotFoundKind, OrbitError, ReviewThreadMetadataV2,
+    TASK_ACCEPTANCE_FILE_NAME, TASK_ARTIFACT_FILES_DIR_NAME, TASK_ARTIFACT_MANIFEST_FILE_NAME,
+    TASK_ARTIFACTS_DIR_NAME, TASK_COMMENTS_FILE_NAME, TASK_DESCRIPTION_FILE_NAME,
+    TASK_ENVELOPE_FILE_NAME, TASK_EVENTS_FILE_NAME, TASK_EXECUTION_SUMMARY_FILE_NAME,
+    TASK_PLAN_FILE_NAME, TASK_REVIEW_THREADS_DIR_NAME, TaskCommentRowV2, TaskEnvelopeV2,
+    TaskEventRowV2,
 };
 use orbit_common::utility::fs::{atomic_write_text, with_exclusive_file_lock};
 use serde::de::DeserializeOwned;
@@ -363,7 +364,7 @@ pub(crate) fn read_bundle_at(bundle_dir: &Path) -> Result<TaskBundleV2, OrbitErr
     let expected_task_id = task_id_from_bundle_dir(bundle_dir)?;
     let envelope_path = bundle_dir.join(TASK_ENVELOPE_FILE_NAME);
     if !envelope_path.is_file() {
-        return Err(OrbitError::TaskNotFound(expected_task_id));
+        return Err(OrbitError::not_found(NotFoundKind::Task, expected_task_id));
     }
     let envelope: TaskEnvelopeV2 =
         read_migrated_yaml_file(&envelope_path, task_migrations::envelope_plan())?;
@@ -868,7 +869,7 @@ mod tests {
 
     use chrono::{TimeZone, Utc};
     use orbit_common::types::{
-        ArtifactManifestFileV2, ReviewThreadMessageMetadataV2, ReviewThreadStatus,
+        ArtifactManifestFileV2, NotFoundKind, ReviewThreadMessageMetadataV2, ReviewThreadStatus,
         TASK_ARTIFACT_FILES_DIR_NAME, TASK_ARTIFACT_SCHEMA_VERSION, TaskPriority, TaskStatus,
         TaskType,
     };
@@ -1096,7 +1097,10 @@ mod tests {
         );
         assert!(matches!(
             store.read_bundle("ORB-00000"),
-            Err(OrbitError::TaskNotFound(_))
+            Err(OrbitError::NotFound {
+                kind: NotFoundKind::Task,
+                ..
+            })
         ));
         assert!(!store.delete_bundle("ORB-00000").expect("delete missing"));
     }
@@ -1398,7 +1402,10 @@ mod tests {
 
         assert!(matches!(
             store.read_bundle("ORB-00000"),
-            Err(OrbitError::TaskNotFound(task_id)) if task_id == "ORB-00000"
+            Err(OrbitError::NotFound {
+                kind: NotFoundKind::Task,
+                id: task_id,
+            }) if task_id == "ORB-00000"
         ));
     }
 

--- a/crates/orbit-store/src/file/task_store/v2_store.rs
+++ b/crates/orbit-store/src/file/task_store/v2_store.rs
@@ -4,8 +4,8 @@ use std::path::{Component, Path, PathBuf};
 
 use chrono::Utc;
 use orbit_common::types::{
-    ArtifactManifestFileV2, ArtifactManifestV2, ExternalRef, OrbitError, OrbitId, ReviewMessage,
-    ReviewThread, ReviewThreadMessageMetadataV2, ReviewThreadMetadataV2,
+    ArtifactManifestFileV2, ArtifactManifestV2, ExternalRef, NotFoundKind, OrbitError, OrbitId,
+    ReviewMessage, ReviewThread, ReviewThreadMessageMetadataV2, ReviewThreadMetadataV2,
     TASK_ARTIFACT_FILES_DIR_NAME, TASK_ARTIFACT_SCHEMA_VERSION, TASK_ARTIFACTS_DIR_NAME, Task,
     TaskArtifact, TaskComment, TaskCommentRowV2, TaskEnvelopeV2, TaskEventRowV2, TaskHistoryEntry,
     TaskPriority, TaskRelation, TaskRelationType, TaskStatus, normalize_task_tags,
@@ -203,7 +203,10 @@ impl TaskV2Store {
         orbit_common::types::validate_orb_task_id(id)?;
         match self.bundle_store.read_bundle(id) {
             Ok(bundle) => self.task_from_bundle(bundle).map(Some),
-            Err(OrbitError::TaskNotFound(_)) => Ok(None),
+            Err(OrbitError::NotFound {
+                kind: NotFoundKind::Task,
+                ..
+            }) => Ok(None),
             Err(err) => Err(err),
         }
     }
@@ -500,7 +503,10 @@ impl TaskV2Store {
         orbit_common::types::validate_orb_task_id(id)?;
         let bundle = match self.bundle_store.read_bundle(id) {
             Ok(bundle) => bundle,
-            Err(OrbitError::TaskNotFound(_)) => return Ok(None),
+            Err(OrbitError::NotFound {
+                kind: NotFoundKind::Task,
+                ..
+            }) => return Ok(None),
             Err(err) => return Err(err),
         };
         let Some(manifest) = bundle.artifact_manifest else {
@@ -766,7 +772,10 @@ impl TaskV2Store {
                     })
                     .collect(),
             )),
-            Err(OrbitError::TaskNotFound(_)) => Ok(None),
+            Err(OrbitError::NotFound {
+                kind: NotFoundKind::Task,
+                ..
+            }) => Ok(None),
             Err(err) => Err(err),
         }
     }
@@ -791,7 +800,10 @@ impl TaskV2Store {
                     })
                     .collect(),
             )),
-            Err(OrbitError::TaskNotFound(_)) => Ok(None),
+            Err(OrbitError::NotFound {
+                kind: NotFoundKind::Task,
+                ..
+            }) => Ok(None),
             Err(err) => Err(err),
         }
     }
@@ -809,14 +821,20 @@ impl TaskV2Store {
                     .map(review_thread_from_v2)
                     .collect(),
             )),
-            Err(OrbitError::TaskNotFound(_)) => Ok(None),
+            Err(OrbitError::NotFound {
+                kind: NotFoundKind::Task,
+                ..
+            }) => Ok(None),
             Err(err) => Err(err),
         }
     }
 
     fn read_existing_bundle(&self, id: &str) -> Result<TaskBundleV2, OrbitError> {
         self.bundle_store.read_bundle(id).map_err(|err| match err {
-            OrbitError::TaskNotFound(_) => OrbitError::TaskNotFound(id.to_string()),
+            OrbitError::NotFound {
+                kind: NotFoundKind::Task,
+                ..
+            } => OrbitError::not_found(NotFoundKind::Task, id.to_string()),
             other => other,
         })
     }

--- a/crates/orbit-store/src/sqlite/task_registry.rs
+++ b/crates/orbit-store/src/sqlite/task_registry.rs
@@ -5,8 +5,8 @@ use std::sync::{Arc, Mutex};
 
 use chrono::{DateTime, Utc};
 use orbit_common::types::{
-    ORB_TASK_ID_MAX, OrbitError, TaskEnvelopeV2, TaskPriority, TaskRelationType, TaskStatus,
-    format_orb_task_id, normalize_task_tags, validate_orb_task_id,
+    NotFoundKind, ORB_TASK_ID_MAX, OrbitError, TaskEnvelopeV2, TaskPriority, TaskRelationType,
+    TaskStatus, format_orb_task_id, normalize_task_tags, validate_orb_task_id,
 };
 use orbit_common::utility::fs::{atomic_write_text, create_dir_symlink};
 use rusqlite::{Connection, OptionalExtension, TransactionBehavior, params, params_from_iter};
@@ -193,7 +193,7 @@ impl TaskRegistryStore {
             .map_err(|e| OrbitError::Store(e.to_string()))?;
 
         if workspace_by_id(&tx, &workspace_id)?.is_none() {
-            return Err(OrbitError::WorkspaceNotFound(workspace_id));
+            return Err(OrbitError::not_found(NotFoundKind::Workspace, workspace_id));
         }
 
         let next: i64 = tx
@@ -255,7 +255,7 @@ impl TaskRegistryStore {
             .map_err(|e| OrbitError::Store(e.to_string()))?;
 
         if workspace_by_id(&tx, &workspace_id)?.is_none() {
-            return Err(OrbitError::WorkspaceNotFound(workspace_id));
+            return Err(OrbitError::not_found(NotFoundKind::Workspace, workspace_id));
         }
 
         let now = now_string();
@@ -358,7 +358,7 @@ impl TaskRegistryStore {
             .map_err(|e| OrbitError::Store(e.to_string()))?;
 
         let binding = task_bundle_by_id(&tx, &envelope.id)?
-            .ok_or_else(|| OrbitError::TaskNotFound(envelope.id.clone()))?;
+            .ok_or_else(|| OrbitError::not_found(NotFoundKind::Task, envelope.id.clone()))?;
         if binding.workspace_id != workspace_id {
             return Err(OrbitError::InvalidInput(format!(
                 "task '{}' is registered to workspace '{}', not '{}'",

--- a/crates/orbit-tools/src/registry.rs
+++ b/crates/orbit-tools/src/registry.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use orbit_common::types::{OrbitError, ToolSchema};
+use orbit_common::types::{NotFoundKind, OrbitError, ToolSchema};
 use serde_json::Value;
 
 use crate::{Tool, ToolContext};
@@ -36,7 +36,7 @@ impl ToolRegistry {
         let tool = self
             .tools
             .get(name)
-            .ok_or_else(|| OrbitError::ToolNotFound(name.to_string()))?;
+            .ok_or_else(|| OrbitError::not_found(NotFoundKind::Tool, name.to_string()))?;
         tool.execute(ctx, input)
     }
 


### PR DESCRIPTION
## Summary

Replaces two stringly-typed error discriminators with typed enums so the translators between crate boundaries are checked at compile time.

- **`KnowledgeError.kind: String` → `KnowledgeErrorKind` enum** (`Invalid` / `Unavailable` / `Io`). `knowledge_error_to_orbit` uses an exhaustive `match` instead of `if error.kind == "knowledge_invalid"`.
- **Ten `OrbitError::*NotFound(String)` variants → single `NotFound { kind: NotFoundKind, id: String }`**. `NotFoundKind` is the single source of truth for not-found classification. The error-code translators in `orbit-mcp`, `orbit-cli/output/json`, `orbit-common/utility/redaction`, and `orbit-cli/command/web/api` all match `NotFoundKind` exhaustively (no `_` arm).
- **No back-compat helper shims**: the only constructor is `OrbitError::not_found(NotFoundKind::X, id)`. `NotFoundKind::X` is visible at every construction site, so adding a new resource only touches `NotFoundKind`.
- **`web/api/mod.rs::map_runtime_error` keeps its pre-PR HTTP status mapping** — only `Task | Job | JobRun` route to 404; every other `NotFoundKind` falls through to `server_error` (500). This refactor is strictly mechanical and doesn't change the dashboard API contract.
- Serialization tests for both `KnowledgeError` and `OrbitError::NotFound` guard the JSON shape.

## Test plan

- [x] `make fmt`
- [x] `make build`
- [x] `make ci` (clippy `-D warnings`)
- [x] `cargo test -p orbit-common -p orbit-knowledge -p orbit-core -p orbit-engine -p orbit-store -p orbit-cli`
- [x] `rg 'error\.kind == "' crates/orbit-knowledge` returns no hits in non-test source

🤖 Generated with [Claude Code](https://claude.com/claude-code)