### PR TITLE
Remove `friction` status filter chip from web dashboard

### DIFF
--- a/crates/orbit-cli/assets/dashboard/app.js
+++ b/crates/orbit-cli/assets/dashboard/app.js
@@ -6,7 +6,6 @@ const STATUS_ORDER = [
   "review",
   "blocked",
   "proposed",
-  "friction",
   "backlog",
   "someday",
   "rejected",
@@ -398,8 +397,8 @@ function buildTaskDetail(task) {
   return detail;
 }
 
-const APPROVE_STATUSES = new Set(["proposed", "friction", "review"]);
-const REJECT_STATUSES = new Set(["proposed", "friction", "review", "backlog"]);
+const APPROVE_STATUSES = new Set(["proposed", "review"]);
+const REJECT_STATUSES = new Set(["proposed", "review", "backlog"]);
 
 function buildActionsRow(task, detail) {
   const actions = el("div", { class: "actions" });


### PR DESCRIPTION
## Task

[ORB-00024](https://orbit-cli.com/tasks/ORB-00024) — Remove `friction` status filter chip from web dashboard

### Description

## Problem

`crates/orbit-cli/assets/dashboard/app.js` includes `"friction"` in the `STATUS_ORDER` array at line 9 and in the `APPROVE_STATUSES`/`REJECT_STATUSES` sets at lines 401–402. These drive the task-filter chip row (`buildChips()` at line 853) and the per-task action eligibility logic.

`friction` is no longer part of the task lifecycle — it has been promoted to a first-class diagnostic concept tracked outside task status (see `orbit.friction.*` MCP tools and `/api/diagnostics/friction`). The chip is dead UI for the task panel, and the approve/reject action sets reference a status that the task lifecycle no longer emits.

## Why It Matters

The dashboard exposes an interactive control whose only effect is to filter a status that never appears in the data — confusing for any human or agent inspecting state. Worse, the action-eligibility sets imply `friction` is a state from which approve/reject transitions are meaningful, which is no longer true. Pruning these references keeps the dashboard's mental model aligned with the post-promotion lifecycle.

## Constraints / Notes

- **Scope this task to the task panel only.** The diagnostics tab's `friction` subtab (`DIAG_SUBTABS` at `app.js:890`), the `/api/diagnostics/friction` fetch at `app.js:1335`, the `lastDiagnostics.friction` field at `app.js:38`, and the `friction.reported` metric label at `app.js:738` are all about the friction *diagnostic* surface and must remain untouched.
- **Out of scope:** the MCP status enum in `orbit_task_update`/`orbit_task_add` still includes `friction`. Reducing the backend enum is a separate decision and not part of this task.
- **Out of scope:** `rejected` stays. Only `friction` is removed.
- No tasks currently have `status: friction` (verified via `orbit.task.list` at task-creation time), so removing the chip does not orphan any visible work. If a legacy `friction` task surfaces later, it will render in the catch-all branch at `app.js:523–524` since that block already handles statuses absent from `STATUS_ORDER`.
- A separate follow-up task is expected to add a dedicated friction panel to the web dashboard — do **not** absorb that scope here.

## Acceptance Criteria

(captured in the acceptance_criteria field)

### Acceptance Criteria

- `STATUS_ORDER` in `crates/orbit-cli/assets/dashboard/app.js` no longer contains `"friction"`; the array length drops by one and the remaining order is unchanged.
- `APPROVE_STATUSES` (`app.js:401`) and `REJECT_STATUSES` (`app.js:402`) no longer reference `"friction"`.
- `DIAG_SUBTABS` (`app.js:890`), `lastDiagnostics.friction` (`app.js:38`), the `friction.reported` metric label (`app.js:738`), and the `/api/diagnostics/friction` fetch (`app.js:1335`) are unchanged — the diagnostics-side `friction` surface is preserved.
- Loading the dashboard renders no `friction` chip in the `#task-filter` row, and the `all` chip still toggles correctly (`refreshChips()` math at `app.js:847` keeps working after the `STATUS_ORDER.length` change).
- Tasks in other statuses (`proposed`, `in-progress`, `review`, `blocked`, `backlog`, `someday`, `done`, `rejected`) still render under their existing status groups in the task list with no ordering regression.
- `make ci` passes (no Rust changes expected; this is JS-only, but workspace lints/fmt must still pass).

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Removed `friction` from the dashboard task `STATUS_ORDER`, so the task filter chip row no longer renders a friction status chip while preserving the remaining status order.
- Removed `friction` from the approve/reject eligibility sets; diagnostics-side friction references were left unchanged.

Assessment: Scoped JS-only cleanup completed. Verified status/friction invariants with a Node check and ran `make ci` successfully.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-00024-6a067a6a`
- Behind base: 0
- Ahead of base: 1

*authored by: claude-opus-4-7*