### PR TITLE
Extract Gemini CLI stats token metrics

### DIFF
--- a/crates/orbit-agent/src/types/response/usage.rs
+++ b/crates/orbit-agent/src/types/response/usage.rs
@@ -3,18 +3,38 @@ use serde_json::Value;
 
 use super::JsonMap;
 
+const USAGE_CHILD_KEYS: &[&str] = &[
+    "usage",
+    "token_usage",
+    "tokenUsage",
+    "tokens",
+    "usageMetadata",
+    "usage_metadata",
+];
+
+#[derive(Clone, Copy)]
+enum UsageKeyMode {
+    Standard,
+    TokenBlock,
+}
+
 pub(super) fn sum_usage(documents: &[Value]) -> TokenUsage {
     let mut usage = TokenUsage::default();
     for document in documents {
-        collect_usage(document, &mut usage, true);
+        collect_usage(document, &mut usage, true, UsageKeyMode::Standard);
     }
     usage
 }
 
-fn collect_usage(value: &Value, usage: &mut TokenUsage, allow_direct_usage: bool) {
+fn collect_usage(
+    value: &Value,
+    usage: &mut TokenUsage,
+    allow_direct_usage: bool,
+    key_mode: UsageKeyMode,
+) {
     match value {
         Value::Object(map) => {
-            if allow_direct_usage && let Some(found) = usage_from_map(map) {
+            if allow_direct_usage && let Some(found) = usage_from_map(map, key_mode) {
                 add_usage(usage, found);
                 return;
             }
@@ -23,40 +43,37 @@ fn collect_usage(value: &Value, usage: &mut TokenUsage, allow_direct_usage: bool
                 return;
             }
 
-            for key in [
-                "usage",
-                "token_usage",
-                "tokenUsage",
-                "tokens",
-                "usageMetadata",
-                "usage_metadata",
-            ] {
-                if let Some(child) = map.get(key) {
-                    collect_usage(child, usage, true);
+            let has_model_token_usage = map
+                .get("tokens")
+                .and_then(Value::as_object)
+                .and_then(|tokens| usage_from_map(tokens, UsageKeyMode::TokenBlock))
+                .is_some();
+
+            for &key in USAGE_CHILD_KEYS {
+                if let Some(mode) = usage_key_mode(key)
+                    && let Some(child) = map.get(key)
+                {
+                    collect_usage(child, usage, true, mode);
                 }
             }
 
             for (key, child) in map {
                 if key != "tool_calls"
-                    && key != "usage"
-                    && key != "token_usage"
-                    && key != "tokenUsage"
-                    && key != "tokens"
-                    && key != "usageMetadata"
-                    && key != "usage_metadata"
+                    && usage_key_mode(key).is_none()
+                    && !(has_model_token_usage && key == "roles")
                 {
-                    collect_usage(child, usage, false);
+                    collect_usage(child, usage, false, UsageKeyMode::Standard);
                 }
             }
         }
         Value::Array(items) => {
             for item in items {
-                collect_usage(item, usage, allow_direct_usage);
+                collect_usage(item, usage, allow_direct_usage, key_mode);
             }
         }
         Value::String(raw) => {
             if allow_direct_usage && let Ok(nested) = serde_json::from_str::<Value>(raw) {
-                collect_usage(&nested, usage, true);
+                collect_usage(&nested, usage, true, key_mode);
             }
         }
         _ => {}
@@ -70,51 +87,33 @@ fn add_usage(usage: &mut TokenUsage, found: TokenUsage) {
     usage.output = usage.output.saturating_add(found.output);
 }
 
-fn usage_from_map(map: &JsonMap) -> Option<TokenUsage> {
-    let input = first_u64(
-        map,
-        &[
-            "input_tokens",
-            "inputTokens",
-            "prompt_tokens",
-            "promptTokens",
-            "promptTokenCount",
-            "prompt_token_count",
-        ],
-    );
-    let cache_read = first_u64(
-        map,
-        &[
-            "cache_read_input_tokens",
-            "cacheReadInputTokens",
-            "cache_read_tokens",
-            "cacheReadTokens",
-            "cached_input_tokens",
-            "cachedInputTokens",
-            "cachedContentTokenCount",
-            "cached_content_token_count",
-        ],
-    );
-    let cache_create = first_u64(
-        map,
-        &[
-            "cache_creation_input_tokens",
-            "cacheCreationInputTokens",
-            "cache_create_tokens",
-            "cacheCreateTokens",
-        ],
-    );
-    let output = first_u64(
-        map,
-        &[
-            "output_tokens",
-            "outputTokens",
-            "completion_tokens",
-            "completionTokens",
-            "candidatesTokenCount",
-            "candidates_token_count",
-        ],
-    );
+fn usage_key_mode(key: &str) -> Option<UsageKeyMode> {
+    match key {
+        "tokens" => Some(UsageKeyMode::TokenBlock),
+        "usage" | "token_usage" | "tokenUsage" | "usageMetadata" | "usage_metadata" => {
+            Some(UsageKeyMode::Standard)
+        }
+        _ => None,
+    }
+}
+
+fn usage_from_map(map: &JsonMap, key_mode: UsageKeyMode) -> Option<TokenUsage> {
+    let input = match key_mode {
+        UsageKeyMode::Standard => first_u64(map, STANDARD_INPUT_KEYS),
+        UsageKeyMode::TokenBlock => first_u64(map, TOKEN_BLOCK_INPUT_KEYS),
+    };
+    let cache_read = match key_mode {
+        UsageKeyMode::Standard => first_u64(map, STANDARD_CACHE_READ_KEYS),
+        UsageKeyMode::TokenBlock => first_u64(map, TOKEN_BLOCK_CACHE_READ_KEYS),
+    };
+    let cache_create = match key_mode {
+        UsageKeyMode::Standard => first_u64(map, STANDARD_CACHE_CREATE_KEYS),
+        UsageKeyMode::TokenBlock => first_u64(map, STANDARD_CACHE_CREATE_KEYS),
+    };
+    let output = match key_mode {
+        UsageKeyMode::Standard => first_u64(map, STANDARD_OUTPUT_KEYS),
+        UsageKeyMode::TokenBlock => first_u64(map, TOKEN_BLOCK_OUTPUT_KEYS),
+    };
 
     input.or(cache_read).or(cache_create).or(output)?;
 
@@ -126,6 +125,76 @@ fn usage_from_map(map: &JsonMap) -> Option<TokenUsage> {
     })
 }
 
+const STANDARD_INPUT_KEYS: &[&str] = &[
+    "input_tokens",
+    "inputTokens",
+    "prompt_tokens",
+    "promptTokens",
+    "promptTokenCount",
+    "prompt_token_count",
+];
+
+const TOKEN_BLOCK_INPUT_KEYS: &[&str] = &[
+    "input_tokens",
+    "inputTokens",
+    "prompt_tokens",
+    "promptTokens",
+    "promptTokenCount",
+    "prompt_token_count",
+    "input",
+    "prompt",
+];
+
+const STANDARD_CACHE_READ_KEYS: &[&str] = &[
+    "cache_read_input_tokens",
+    "cacheReadInputTokens",
+    "cache_read_tokens",
+    "cacheReadTokens",
+    "cached_input_tokens",
+    "cachedInputTokens",
+    "cachedContentTokenCount",
+    "cached_content_token_count",
+];
+
+const TOKEN_BLOCK_CACHE_READ_KEYS: &[&str] = &[
+    "cache_read_input_tokens",
+    "cacheReadInputTokens",
+    "cache_read_tokens",
+    "cacheReadTokens",
+    "cached_input_tokens",
+    "cachedInputTokens",
+    "cachedContentTokenCount",
+    "cached_content_token_count",
+    "cached",
+];
+
+const STANDARD_CACHE_CREATE_KEYS: &[&str] = &[
+    "cache_creation_input_tokens",
+    "cacheCreationInputTokens",
+    "cache_create_tokens",
+    "cacheCreateTokens",
+];
+
+const STANDARD_OUTPUT_KEYS: &[&str] = &[
+    "output_tokens",
+    "outputTokens",
+    "completion_tokens",
+    "completionTokens",
+    "candidatesTokenCount",
+    "candidates_token_count",
+];
+
+const TOKEN_BLOCK_OUTPUT_KEYS: &[&str] = &[
+    "output_tokens",
+    "outputTokens",
+    "completion_tokens",
+    "completionTokens",
+    "candidatesTokenCount",
+    "candidates_token_count",
+    "candidates",
+    "output",
+];
+
 fn first_u64(map: &JsonMap, keys: &[&str]) -> Option<u64> {
     keys.iter().find_map(|key| value_as_u64(map.get(*key)?))
 }
@@ -135,5 +204,131 @@ pub(super) fn value_as_u64(value: &Value) -> Option<u64> {
         Value::Number(number) => number.as_u64(),
         Value::String(raw) => raw.parse::<u64>().ok(),
         _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+
+    #[test]
+    fn gemini_cli_model_token_blocks_are_summed_once_per_model() {
+        let documents = vec![json!({
+            "stats": {
+                "models": {
+                    "gemini-3.1-pro": {
+                        "tokens": {
+                            "input": 10,
+                            "cached": 2,
+                            "candidates": 4,
+                            "total": 999,
+                            "thoughts": 70,
+                            "tool": 30
+                        },
+                        "roles": {
+                            "user": {
+                                "tokens": {
+                                    "input": 10,
+                                    "cached": 2
+                                }
+                            },
+                            "model": {
+                                "tokens": {
+                                    "candidates": 4
+                                }
+                            }
+                        }
+                    },
+                    "gemini-2.5-flash": {
+                        "tokens": {
+                            "prompt": 20,
+                            "cached": "3",
+                            "output": "5",
+                            "total": 28
+                        },
+                        "roles": {
+                            "user": {
+                                "tokens": {
+                                    "prompt": 20
+                                }
+                            },
+                            "model": {
+                                "tokens": {
+                                    "output": 5
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        })];
+
+        assert_eq!(
+            sum_usage(&documents),
+            TokenUsage {
+                input: 30,
+                cache_read: 5,
+                cache_create: 0,
+                output: 9,
+            }
+        );
+    }
+
+    #[test]
+    fn gemini_cli_role_tokens_are_counted_when_model_tokens_are_absent() {
+        let documents = vec![json!({
+            "stats": {
+                "models": {
+                    "gemini-3.1-pro": {
+                        "roles": {
+                            "user": {
+                                "tokens": {
+                                    "input": 7,
+                                    "cached": 1
+                                }
+                            },
+                            "model": {
+                                "tokens": {
+                                    "candidates": 3
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        })];
+
+        assert_eq!(
+            sum_usage(&documents),
+            TokenUsage {
+                input: 7,
+                cache_read: 1,
+                cache_create: 0,
+                output: 3,
+            }
+        );
+    }
+
+    #[test]
+    fn gemini_cli_total_thoughts_and_tool_are_not_folded_into_usage() {
+        let documents = vec![json!({
+            "stats": {
+                "models": {
+                    "gemini-3.1-pro": {
+                        "tokens": {
+                            "total": 999,
+                            "thoughts": 70,
+                            "tool": 30
+                        }
+                    }
+                }
+            }
+        })];
+
+        // TokenUsage has no thoughts/tool fields yet, so these Gemini-only
+        // counts are intentionally ignored rather than mixed into I/O totals.
+        assert_eq!(sum_usage(&documents), TokenUsage::default());
     }
 }

--- a/crates/orbit-engine/src/activity_job/cli_runner/envelope.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/envelope.rs
@@ -113,6 +113,7 @@ mod tests {
 
     use super::super::tests::test_support::{TestHost, test_agent_loop_spec};
     use super::*;
+    use orbit_common::types::TokenUsage;
 
     #[test]
     fn user_prompt_from_object_input_without_prompt_serializes_full_input() {
@@ -190,5 +191,53 @@ mod tests {
             Some("T3")
         );
         assert_eq!(task_id_from_input(&serde_json::json!({})), None);
+    }
+
+    #[test]
+    fn parse_cli_invocation_trace_extracts_gemini_cli_stats_tokens() {
+        let stdout = serde_json::json!({
+            "result": {
+                "schemaVersion": 1,
+                "status": "success",
+                "result": {}
+            },
+            "stats": {
+                "models": {
+                    "gemini-3.1-pro": {
+                        "tokens": {
+                            "input": 12,
+                            "cached": 3,
+                            "candidates": 4,
+                            "total": 19
+                        },
+                        "roles": {
+                            "user": {
+                                "tokens": {
+                                    "input": 12,
+                                    "cached": 3
+                                }
+                            },
+                            "model": {
+                                "tokens": {
+                                    "candidates": 4
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        })
+        .to_string();
+
+        assert_eq!(
+            parse_cli_invocation_trace(stdout.as_bytes(), b"", Some(0), 99, true)
+                .map(|trace| trace.usage),
+            Some(TokenUsage {
+                input: 12,
+                cache_read: 3,
+                cache_create: 0,
+                output: 4,
+            })
+        );
     }
 }

--- a/crates/orbit-store/src/file/scoreboard/token_scoreboard.rs
+++ b/crates/orbit-store/src/file/scoreboard/token_scoreboard.rs
@@ -25,7 +25,7 @@ pub fn write_token_scoreboard(scoreboard_dir: &Path, store: &Store) -> Result<()
                 "cache_read_tokens are reported separately from input_tokens.",
                 "Multi-task invocations are fully attributed to every tagged task.",
                 "Legacy agent invocations without a resolved model are omitted from the activities and agents sections.",
-                "Non-Claude providers currently emit zero traces."
+                "Providers without structured usage metadata may emit zero traces."
             ]
         });
 


### PR DESCRIPTION
## Task

[ORB-00028](https://orbit-cli.com/tasks/ORB-00028) — Extract Gemini CLI stats token metrics

### Description

## Problem
Gemini CLI can return a structured response with token accounting under `stats.models.<model>.tokens`, for example `input`, `prompt`, `candidates`, `total`, `cached`, `thoughts`, and `tool`. Orbit currently parses provider stdout through the shared invocation trace extractor, but the usage parser only recognizes normalized names like `input_tokens`, `output_tokens`, `cached_input_tokens`, `promptTokenCount`, and `candidatesTokenCount`. It does not recognize Gemini CLI short keys such as `tokens.input`, `tokens.cached`, or `tokens.candidates`.

The sample Gemini response also repeats token totals below `stats.models.<model>.roles.<role>.tokens`. A naive recursive extraction would double count model-level and role-level aggregates.

## Why It Matters
Gemini direct-agent invocations currently persist as zero-token traces in the invocation DB and token scoreboard even when the CLI reports usable metrics. This makes provider cost/efficiency comparisons and planning-duel scoreboards misleading.

## Constraints / Notes
- Preserve existing Codex, Claude, OpenAI-compatible, Anthropic, and Gemini HTTP token extraction behavior.
- Do not count Gemini `total` directly when component fields are present; Orbit stores normalized token components.
- Decide explicitly how `thoughts` and `tool` should be represented. If the existing `TokenUsage` schema remains unchanged, document and test that those fields are ignored rather than folded into input/output totals.
- The parser must avoid double-counting nested `roles.*.tokens` when model-level `stats.models.*.tokens` is present.

### Acceptance Criteria

- A deterministic parser test feeds a Gemini CLI response shaped like `stats.models.<model>.tokens` with two models and nested `roles.*.tokens`, and asserts the extracted usage sums each model-level token block exactly once.
- Gemini CLI short token fields are mapped as follows: `input` or `prompt` to Orbit input tokens, `cached` to cache_read tokens, and `candidates` or `output` to Orbit output tokens; `total` is not used as a substitute when component fields are available.
- The test suite covers the no-double-counting case where `stats.models.<model>.roles.<role>.tokens` duplicates the model aggregate, with expected totals matching only the model-level aggregates.
- Existing parser tests for Claude/Codex-style `usage` blocks and Gemini HTTP `usageMetadata` continue to pass without changed expected values.
- An integration-style CLI dispatch or invocation-trace test demonstrates that a Gemini-shaped stdout payload persists non-zero `input_tokens`, `cache_read_tokens`, and `output_tokens` into an invocation trace/record.
- If `thoughts` and `tool` token counts are not added to the persisted schema, the implementation adds an explicit test or comment documenting that they are intentionally ignored for now; if they are added, SQLite migration, record types, metrics output, and `tokens.json` scoreboard include them.
- Run `cargo test -p orbit-agent response::` or the nearest focused parser test target, plus any focused orbit-store/orbit-engine tests touched by persistence changes; run `make fmt` before moving the task to review.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Updated the shared response usage parser so Gemini CLI tokens.input/prompt, tokens.cached, and tokens.candidates/output map into normalized TokenUsage fields only when reading token blocks.
- Avoided double-counting Gemini stats.models.*.roles.*.tokens when a model-level tokens aggregate is present, while still counting role tokens if no model aggregate exists.
- Added focused parser tests for two-model Gemini stats, duplicated role aggregates, total/thoughts/tool omission, and an engine invocation-trace test for Gemini-shaped stdout.
- Refreshed the token scoreboard limitation text now that providers with structured usage metadata can emit non-zero traces.

Assessment: Focused parser and CLI trace validation passed. No persisted schema change was made; Gemini thoughts/tool counts remain intentionally ignored by test/comment until TokenUsage grows fields for them.

Validation:
- make fmt
- cargo test -p orbit-agent response::
- cargo test -p orbit-engine parse_cli_invocation_trace_extracts_gemini_cli_stats_tokens

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-00028-6a067a6a`
- Behind base: 0
- Ahead of base: 1

*authored by: gpt-5.5*