### PR TITLE
Fix Gemini planning-duel artifact persistence under sandbox

### DIFF
--- a/crates/orbit-core/src/runtime/orbit_tool_host/task_tools_tests.rs
+++ b/crates/orbit-core/src/runtime/orbit_tool_host/task_tools_tests.rs
@@ -98,6 +98,41 @@ fn task_add_tool_creates_proposed_tasks_for_agents() {
 }
 
 #[test]
+fn duel_plan_add_persists_gemini_planner_artifact() {
+    let (_root, runtime, repo_root) = test_runtime();
+    let task = create_task(
+        &runtime,
+        &repo_root,
+        "Gemini planning duel artifact",
+        "Exercise the planner artifact write path used by direct-agent duels.",
+        TaskStatus::InProgress,
+        &[],
+    );
+    let content = "*authored by: gemini / gemini-3.1-pro*\n## Plan\nPersist through Orbit tools.";
+
+    runtime
+        .execute_tool_command(
+            "orbit.duel.plan.add",
+            json!({
+                "id": task.id.clone(),
+                "content": content,
+            }),
+            Some("gemini".to_string()),
+            Some("gemini-3.1-pro".to_string()),
+        )
+        .expect("gemini duel plan add succeeds");
+
+    let artifacts = runtime
+        .get_task_artifacts(&task.id)
+        .expect("read task artifacts");
+    let artifact = artifacts
+        .iter()
+        .find(|artifact| artifact.path == "planning-duel/gemini-gemini-3.1-pro.md")
+        .expect("gemini planner artifact");
+    assert_eq!(artifact.text_content(), Some(content));
+}
+
+#[test]
 fn task_add_tool_rejects_dropped_task_types_and_friction_status() {
     let (_root, runtime, _repo_root) = test_runtime();
 

--- a/crates/orbit-core/src/runtime/v2_host/sandbox.rs
+++ b/crates/orbit-core/src/runtime/v2_host/sandbox.rs
@@ -48,6 +48,7 @@ pub(super) fn resolve_executor_sandbox(
                         ))
                     })?;
                 append_codex_side_write_roots(runtime, provider, &mut resolved)?;
+                append_orbit_child_runtime_write_roots(runtime, &mut resolved);
                 append_active_worktree_root(runtime, subprocess_cwd, &mut resolved);
                 Ok(Some(ResolvedSandbox {
                     kind,
@@ -142,6 +143,51 @@ fn append_codex_side_write_roots(
         resolved.modify.push(root);
     }
     Ok(())
+}
+
+/// Allow the nested Orbit processes launched by provider CLIs to initialize
+/// only the runtime stores they need while staying inside the outer sandbox.
+///
+/// Gemini and Claude do not have a codex-style `--add-dir` side channel, but
+/// their MCP/tool calls still execute `orbit ...` as a sandbox-inherited child.
+/// Those child processes initialize the global audit/tool database, the global
+/// task registry + canonical task bundles, and the workspace-local semantic
+/// index before a planner can persist `planning-duel/<agent>-<model>.md`.
+/// Keep the grants path-shaped instead of re-allowing the whole home directory.
+#[cfg(target_os = "macos")]
+fn append_orbit_child_runtime_write_roots(
+    runtime: &OrbitRuntime,
+    resolved: &mut ResolvedFsProfile,
+) {
+    let global_root = runtime
+        .paths()
+        .global_dir
+        .canonicalize()
+        .unwrap_or_else(|_| runtime.paths().global_dir.clone());
+    let global = global_root.display().to_string();
+
+    let workspace_orbit = runtime
+        .paths()
+        .orbit_dir
+        .canonicalize()
+        .unwrap_or_else(|_| runtime.paths().orbit_dir.clone());
+    let workspace = workspace_orbit.display().to_string();
+
+    for root in [
+        format!("{global}/state/logs/**"),
+        format!("{global}/orbit.db*"),
+        format!("{global}/tasks/**"),
+        format!("{workspace}/state/semantic.db*"),
+    ] {
+        append_unique_modify_root(resolved, root);
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn append_unique_modify_root(resolved: &mut ResolvedFsProfile, root: String) {
+    if !resolved.modify.iter().any(|entry| entry == &root) {
+        resolved.modify.push(root);
+    }
 }
 
 /// Re-allow the active job-run worktree under `<workspace>/.orbit/state/worktrees/`
@@ -332,6 +378,101 @@ mod tests {
         assert!(
             modify.iter().any(|entry| entry == &global_orbit),
             "codex side write roots should include global .orbit: {modify:?}"
+        );
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn resolve_executor_sandbox_appends_gemini_orbit_runtime_roots_without_home_reallow() {
+        let (_root, runtime, _repo_root) = runtime_with_workspace_layout();
+        seed_executor(
+            &runtime,
+            "gemini",
+            Some(orbit_common::types::ExecutorSandboxKind::MacosSandboxExec),
+        );
+
+        let resolved = runtime
+            .resolve_executor_sandbox("gemini", None, None)
+            .expect("resolve")
+            .expect("descriptor");
+        let modify = &resolved.fs_profile.modify;
+        let global = runtime
+            .paths()
+            .global_dir
+            .canonicalize()
+            .unwrap_or_else(|_| runtime.paths().global_dir.clone())
+            .display()
+            .to_string();
+        let workspace_orbit = runtime
+            .paths()
+            .orbit_dir
+            .canonicalize()
+            .unwrap_or_else(|_| runtime.paths().orbit_dir.clone())
+            .display()
+            .to_string();
+        let expected = [
+            format!("{global}/state/logs/**"),
+            format!("{global}/orbit.db*"),
+            format!("{global}/tasks/**"),
+            format!("{workspace_orbit}/state/semantic.db*"),
+        ];
+        for root in expected {
+            assert!(
+                modify.iter().any(|entry| entry == &root),
+                "gemini sandbox should allow Orbit runtime root {root}; modify={modify:?}"
+            );
+        }
+        assert!(
+            !modify.iter().any(|entry| entry == &global),
+            "gemini sandbox must not re-allow the whole global Orbit root: {modify:?}"
+        );
+        assert!(
+            !modify.iter().any(|entry| entry == &workspace_orbit),
+            "gemini sandbox must not re-allow the whole workspace .orbit root: {modify:?}"
+        );
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn resolve_executor_sandbox_appends_workspace_semantic_store_after_policy_deny() {
+        let (_root, runtime, _repo_root) = runtime_with_workspace_layout();
+        seed_executor(
+            &runtime,
+            "gemini",
+            Some(orbit_common::types::ExecutorSandboxKind::MacosSandboxExec),
+        );
+
+        let resolved = runtime
+            .resolve_executor_sandbox("gemini", None, None)
+            .expect("resolve")
+            .expect("descriptor");
+        let modify = &resolved.fs_profile.modify;
+        let workspace_orbit = runtime
+            .paths()
+            .orbit_dir
+            .canonicalize()
+            .unwrap_or_else(|_| runtime.paths().orbit_dir.clone())
+            .display()
+            .to_string();
+        let workspace_orbit_deny = format!("!{workspace_orbit}/**");
+        let deny_pos = modify
+            .iter()
+            .position(|entry| entry == &workspace_orbit_deny)
+            .unwrap_or_else(|| {
+                panic!(
+                    "default policy should deny workspace .orbit writes via {workspace_orbit_deny}; modify={modify:?}"
+                )
+            });
+        let semantic_store = format!("{workspace_orbit}/state/semantic.db*");
+        let allow_pos = modify
+            .iter()
+            .position(|entry| entry == &semantic_store)
+            .unwrap_or_else(|| {
+                panic!("semantic store should be re-allowed under sandbox: {modify:?}")
+            });
+        assert!(
+            deny_pos < allow_pos,
+            "semantic store re-allow must come after policy deny: {modify:?}"
         );
     }
 

--- a/crates/orbit-engine/src/executor/automation/duel/planning_duel/runner.rs
+++ b/crates/orbit-engine/src/executor/automation/duel/planning_duel/runner.rs
@@ -1,8 +1,9 @@
 use std::collections::BTreeMap;
 
-use orbit_common::types::OrbitError;
+use orbit_common::types::{OrbitError, PlanningRoleAssignment};
 use serde_json::{Value, json};
 
+use super::types::PlanningDuelPlanArtifact;
 use super::{artifacts, metrics, roles};
 use crate::context::{ActivityInvocationResult, RuntimeHost, TaskHost};
 use crate::executor::automation::input::{input_string_field, required_input_string};
@@ -16,6 +17,78 @@ fn join_activity_result(
         Err(_) => Err(OrbitError::Execution(format!(
             "{label} activity thread panicked"
         ))),
+    }
+}
+
+fn require_plan_artifact_for_assignment<'a>(
+    plan_artifacts: &'a [PlanningDuelPlanArtifact],
+    assignment: &PlanningRoleAssignment,
+    invocation: &ActivityInvocationResult,
+) -> Result<&'a PlanningDuelPlanArtifact, OrbitError> {
+    artifacts::plan_artifact_for_assignment(plan_artifacts, assignment).map_err(|error| {
+        OrbitError::Execution(format!(
+            "{error}; {}",
+            planner_invocation_diagnostics(invocation)
+        ))
+    })
+}
+
+fn planner_invocation_diagnostics(invocation: &ActivityInvocationResult) -> String {
+    let mut parts = vec![
+        format!("exit_code={:?}", invocation.exit_code),
+        format!("duration_ms={}", invocation.duration_ms),
+    ];
+
+    if let Some(response) = invocation.response_json.as_ref().and_then(Value::as_object) {
+        for key in [
+            "provider",
+            "exit_code",
+            "timed_out",
+            "stdout_blob_ref",
+            "stderr_blob_ref",
+            "error",
+            "error_message",
+        ] {
+            if let Some(value) = response.get(key) {
+                parts.push(format!("{key}={}", diagnostic_value(value)));
+            }
+        }
+        if let Some(stdout_text) = response.get("stdout_text").and_then(Value::as_str) {
+            parts.push(format!(
+                "stdout_text={}",
+                compact_diagnostic_text(stdout_text)
+            ));
+        }
+    }
+
+    let tool_calls = invocation
+        .invocation_trace
+        .tool_calls
+        .iter()
+        .map(|call| call.tool_name.trim())
+        .filter(|name| !name.is_empty())
+        .collect::<Vec<_>>();
+    if !tool_calls.is_empty() {
+        parts.push(format!("tool_calls={}", tool_calls.join(",")));
+    }
+
+    format!("child invocation diagnostics: {}", parts.join(", "))
+}
+
+fn diagnostic_value(value: &Value) -> String {
+    value
+        .as_str()
+        .map(compact_diagnostic_text)
+        .unwrap_or_else(|| value.to_string())
+}
+
+fn compact_diagnostic_text(value: &str) -> String {
+    const LIMIT: usize = 240;
+    let compact = value.split_whitespace().collect::<Vec<_>>().join(" ");
+    if compact.chars().count() <= LIMIT {
+        compact
+    } else {
+        format!("{}...", compact.chars().take(LIMIT).collect::<String>())
     }
 }
 
@@ -74,8 +147,16 @@ pub(crate) fn run_planning_duel<H: RuntimeHost + TaskHost + Sync + ?Sized>(
 
     let planner_artifacts = host.get_task_artifacts(task_id)?;
     let plan_artifacts = artifacts::planning_duel_plan_artifacts(&planner_artifacts)?;
-    let _ = artifacts::plan_artifact_for_assignment(&plan_artifacts, &planning_roles.planner_a)?;
-    let _ = artifacts::plan_artifact_for_assignment(&plan_artifacts, &planning_roles.planner_b)?;
+    let _ = require_plan_artifact_for_assignment(
+        &plan_artifacts,
+        &planning_roles.planner_a,
+        &planner_a_result,
+    )?;
+    let _ = require_plan_artifact_for_assignment(
+        &plan_artifacts,
+        &planning_roles.planner_b,
+        &planner_b_result,
+    )?;
 
     let arbiter_result = host.invoke_activity(
         roles::arbiter_activity(),
@@ -178,6 +259,7 @@ mod tests {
         workflow_admissions: AtomicUsize,
         task_starts: AtomicUsize,
         last_automation_update: Mutex<Option<TaskAutomationUpdate>>,
+        omit_planner_artifacts: AtomicUsize,
     }
 
     impl PlanningDuelHost {
@@ -197,6 +279,7 @@ mod tests {
                 workflow_admissions: AtomicUsize::new(0),
                 task_starts: AtomicUsize::new(0),
                 last_automation_update: Mutex::new(None),
+                omit_planner_artifacts: AtomicUsize::new(0),
             }
         }
 
@@ -218,6 +301,10 @@ mod tests {
 
         fn start_count(&self) -> usize {
             self.task_starts.load(Ordering::SeqCst)
+        }
+
+        fn omit_planner_artifacts(&self) {
+            self.omit_planner_artifacts.store(1, Ordering::SeqCst);
         }
     }
 
@@ -399,15 +486,23 @@ mod tests {
             let model = model.unwrap_or("unknown-model");
             match activity.id.as_str() {
                 "propose_duel_plan" => {
-                    self.artifacts
-                        .lock()
-                        .expect("artifacts lock")
-                        .push(TaskArtifact::from_text(
-                            format!("planning-duel/{agent_cli}-{model}.md"),
-                            format!(
-                                "*authored by: {agent_cli} / {model}*\n## Plan\nPreserve task status.\n"
-                            ),
-                        ));
+                    let should_omit = self
+                        .omit_planner_artifacts
+                        .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |remaining| {
+                            remaining.checked_sub(1)
+                        })
+                        .is_ok();
+                    if !should_omit {
+                        self.artifacts
+                            .lock()
+                            .expect("artifacts lock")
+                            .push(TaskArtifact::from_text(
+                                format!("planning-duel/{agent_cli}-{model}.md"),
+                                format!(
+                                    "*authored by: {agent_cli} / {model}*\n## Plan\nPreserve task status.\n"
+                                ),
+                            ));
+                    }
                 }
                 "arbitrate_duel_plan" => {
                     let winner =
@@ -433,8 +528,21 @@ mod tests {
             }
 
             Ok(ActivityInvocationResult {
-                response_json: Some(json!({})),
-                invocation_trace: InvocationTrace::default(),
+                response_json: Some(json!({
+                    "provider": agent_cli,
+                    "stdout_blob_ref": "stdout-digest",
+                    "stderr_blob_ref": "stderr-digest",
+                    "stdout_text": "orbit.duel.plan.add failed: store_error: attempt to write a readonly database",
+                })),
+                invocation_trace: InvocationTrace {
+                    tool_calls: vec![orbit_common::types::ToolCallTrace {
+                        seq: 1,
+                        tool_name: "orbit.duel.plan.add".to_string(),
+                        result_bytes: 91,
+                        result_payload: None,
+                    }],
+                    ..InvocationTrace::default()
+                },
                 exit_code: Some(0),
                 duration_ms: 1,
             })
@@ -572,6 +680,40 @@ mod tests {
             assert_eq!(host.admission_count(), 0, "{status}");
             assert_eq!(host.start_count(), 0, "{status}");
         }
+    }
+
+    #[test]
+    fn missing_planner_artifact_error_includes_child_invocation_diagnostics() {
+        let host = PlanningDuelHost::new(TaskStatus::InProgress);
+        host.omit_planner_artifacts();
+
+        let err = run_planning_duel(
+            &host,
+            &json!({
+                "task_id": "T20260430-STATUS",
+                "run_id": "jrun-missing-planner-artifact"
+            }),
+            false,
+        )
+        .expect_err("missing planner artifact should fail");
+        let message = err.to_string();
+
+        assert!(
+            message.contains("missing planning duel artifact for"),
+            "{message}"
+        );
+        assert!(
+            message.contains("stderr_blob_ref=stderr-digest"),
+            "{message}"
+        );
+        assert!(
+            message.contains("store_error: attempt to write a readonly database"),
+            "{message}"
+        );
+        assert!(
+            message.contains("tool_calls=orbit.duel.plan.add"),
+            "{message}"
+        );
     }
 
     fn install_planning_duel_artifacts(host: &PlanningDuelHost, plan_body: &str) {

--- a/crates/orbit-exec/src/macos_sandbox.rs
+++ b/crates/orbit-exec/src/macos_sandbox.rs
@@ -42,8 +42,8 @@ const TRUSTED_SANDBOX_EXEC_PATHS: &[&str] = &["/usr/bin/sandbox-exec"];
 ///   provider APIs;
 /// - allows writes inside the resolved `modify` scope plus a small set of
 ///   well-known scratch areas (`/tmp`, `/private/tmp`,
-///   `/private/var/folders`, `~/Library/Caches`) that tools and the
-///   filesystem layer expect to write to;
+///   `/private/var/folders`, `~/Library/Caches`, and the HOME-derived Orbit
+///   JSONL log directory) that tools and the filesystem layer expect to write to;
 /// - appends explicit `(deny ...)` clauses for any negated entry in
 ///   `read` / `modify` so global `denyRead` / `denyModify` rules win
 ///   under SBPL's last-match-wins evaluation.
@@ -118,13 +118,13 @@ fn compile_macos_sandbox_profile_with_env(
             sbpl_escape(&home)
         ));
         // The agent CLI inherits the sandbox into its `orbit mcp serve` child
-        // (and any other `orbit ...` calls it makes). Those processes need
-        // write access to the global Orbit data root so audit events, the
-        // SQLite store, and run-state files can be persisted. Without this
-        // the inherited child fails with `readonly database` and MCP tool
-        // calls round-trip empty.
+        // (and any other `orbit ...` calls it makes). Logging initializes
+        // before the child can resolve Orbit's runtime roots, so the profile
+        // carries the one HOME-derived path that must be writable up front.
+        // Runtime-specific store/artifact paths are appended by orbit-core's
+        // sandbox resolver instead of granting the whole HOME/.orbit tree.
         out.push_str(&format!(
-            "(allow file-write* (subpath \"{}/.orbit\"))\n",
+            "(allow file-write* (subpath \"{}/.orbit/state/logs\"))\n",
             sbpl_escape(&home)
         ));
     }
@@ -150,10 +150,9 @@ fn compile_macos_sandbox_profile_with_env(
             ));
             continue;
         }
-        let path = subpath_root(rule);
         out.push_str(&format!(
-            "(allow file-write* (subpath \"{}\"))\n",
-            sbpl_escape(&path)
+            "(allow file-write* {})\n",
+            sbpl_filter_for_allow_rule(rule)
         ));
     }
 
@@ -412,7 +411,7 @@ fn sbpl_escape(value: &str) -> String {
 }
 
 fn sbpl_filter_for_deny_rule(rule: &str) -> String {
-    if deny_rule_can_use_subpath(rule) {
+    if rule_can_use_subpath(rule) {
         let path = subpath_root(rule);
         format!("(subpath \"{}\")", sbpl_escape(&path))
     } else {
@@ -421,7 +420,17 @@ fn sbpl_filter_for_deny_rule(rule: &str) -> String {
     }
 }
 
-fn deny_rule_can_use_subpath(rule: &str) -> bool {
+fn sbpl_filter_for_allow_rule(rule: &str) -> String {
+    if rule_can_use_subpath(rule) {
+        let path = subpath_root(rule);
+        format!("(subpath \"{}\")", sbpl_escape(&path))
+    } else {
+        let regex = glob_rule_to_regex(rule);
+        format!("(regex \"{}\")", sbpl_escape(&regex))
+    }
+}
+
+fn rule_can_use_subpath(rule: &str) -> bool {
     let trimmed = rule.trim_end_matches('/');
     if !contains_glob(trimmed) {
         return true;
@@ -546,11 +555,12 @@ mod tests {
     }
 
     #[test]
-    fn compile_grants_write_access_to_global_orbit_data_root() {
+    fn compile_grants_write_access_to_global_orbit_log_dir() {
         // The agent CLI inherits the sandbox into `orbit mcp serve` and any
-        // other `orbit ...` calls; those need to write to ~/.orbit (audit
-        // events, SQLite stores, run state). Without this clause the
-        // inherited child fails with `readonly database`.
+        // other `orbit ...` calls. The JSONL tracing layer resolves its
+        // HOME-based path before runtime root resolution, so only the log
+        // directory is granted here; store and artifact roots are appended by
+        // the runtime sandbox resolver.
         let resolved = profile("default", &["/Users/test/repo"], &["/Users/test/repo/src"]);
         let text = compile_with_env(
             &resolved,
@@ -560,8 +570,12 @@ mod tests {
             },
         );
         assert!(
-            text.contains("(allow file-write* (subpath \"/Users/test/.orbit\"))"),
-            "missing ~/.orbit write allow: {text}"
+            text.contains("(allow file-write* (subpath \"/Users/test/.orbit/state/logs\"))"),
+            "missing ~/.orbit/state/logs write allow: {text}"
+        );
+        assert!(
+            !text.contains("(allow file-write* (subpath \"/Users/test/.orbit\"))"),
+            "profile must not broadly allow HOME/.orbit writes: {text}"
         );
     }
 
@@ -577,8 +591,8 @@ mod tests {
             },
         );
         assert!(
-            text.contains("(allow file-write* (subpath \"/Users/test/.orbit\"))"),
-            "missing injected HOME/.orbit write allow: {text}"
+            text.contains("(allow file-write* (subpath \"/Users/test/.orbit/state/logs\"))"),
+            "missing injected HOME/.orbit/state/logs write allow: {text}"
         );
         assert_eq!(
             std::env::var_os("HOME"),
@@ -779,6 +793,120 @@ mod tests {
         assert!(
             !text.contains("/src/**"),
             "subpath should not contain glob marker: {text}"
+        );
+    }
+
+    #[test]
+    fn compile_uses_regex_for_non_subpath_positive_modify_glob() {
+        let resolved = profile(
+            "default",
+            &["/Users/test/repo"],
+            &["/Users/test/.orbit/orbit.db*"],
+        );
+        let text = compile_with_env(&resolved, EnvOverrides::default());
+        assert!(
+            text.contains(
+                "(allow file-write* (regex \"^/Users/test/\\\\.orbit/orbit\\\\.db[^/]*$\"))"
+            ),
+            "missing regex allow for SQLite sidecar glob: {text}"
+        );
+        assert!(
+            !text.contains("(allow file-write* (subpath \"/Users/test/.orbit\"))"),
+            "positive file glob must not collapse to the whole Orbit root: {text}"
+        );
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn compiled_profile_allows_nested_orbit_runtime_writes_without_home_orbit_reallow() {
+        use std::process::Command;
+
+        if !sandbox_exec_can_apply() {
+            return;
+        }
+
+        let parent = sandbox_test_parent("orbit-runtime-roots");
+        let _cleanup = ScopeGuard(parent.clone());
+        let home = parent.join("home");
+        let global = home.join(".orbit");
+        let workspace = parent.join("repo/.orbit");
+        std::fs::create_dir_all(global.join("state/logs")).expect("global log dir");
+        std::fs::create_dir_all(global.join("tasks")).expect("global tasks dir");
+        std::fs::create_dir_all(workspace.join("state")).expect("workspace state dir");
+
+        let log_path = global.join("state/logs/orbit.jsonl");
+        let db_wal_path = global.join("orbit.db-wal");
+        let artifact_path = global
+            .join("tasks/workspaces/orbit-test/ORB-00009/artifacts/files/planning-duel")
+            .join("gemini-gemini-3.1-pro.md");
+        let semantic_wal_path = workspace.join("state/semantic.db-wal");
+        let denied_path = global.join("not-allowed.txt");
+
+        let resolved = ResolvedFsProfile {
+            name: "gemini-direct-agent".to_string(),
+            read: vec![parent.display().to_string()],
+            modify: vec![
+                format!("{}/state/logs/**", global.display()),
+                format!("{}/orbit.db*", global.display()),
+                format!("{}/tasks/**", global.display()),
+                format!("{}/state/semantic.db*", workspace.display()),
+            ],
+        };
+        let home_str = home.to_string_lossy().into_owned();
+        let profile_text = compile_with_env(
+            &resolved,
+            EnvOverrides {
+                home: Some(&home_str),
+                ..Default::default()
+            },
+        );
+        let mut profile_file = tempfile::Builder::new()
+            .prefix("orbit-sandbox-test-")
+            .suffix(".sb")
+            .tempfile()
+            .expect("tempfile");
+        use std::io::Write;
+        profile_file
+            .write_all(profile_text.as_bytes())
+            .expect("write profile");
+        profile_file.flush().expect("flush");
+
+        let script = format!(
+            "set -e\n: > {}\n: > {}\nmkdir -p {}\nprintf '%s\\n' '*authored by: gemini / gemini-3.1-pro*' > {}\n: > {}\nif : > {} 2>/dev/null; then exit 99; else exit 0; fi\n",
+            shell_escape(&log_path),
+            shell_escape(&db_wal_path),
+            shell_escape(artifact_path.parent().expect("artifact parent")),
+            shell_escape(&artifact_path),
+            shell_escape(&semantic_wal_path),
+            shell_escape(&denied_path),
+        );
+        let status = Command::new(sandbox_exec_path_for_test())
+            .arg("-f")
+            .arg(profile_file.path())
+            .arg("/bin/sh")
+            .arg("-c")
+            .arg(script)
+            .env("HOME", &home)
+            .status()
+            .expect("run sandbox-exec");
+
+        assert!(
+            status.success(),
+            "expected Orbit runtime writes to succeed while arbitrary HOME/.orbit write is denied; status={status:?}"
+        );
+        assert!(log_path.exists(), "log file should be writable");
+        assert!(db_wal_path.exists(), "SQLite sidecar should be writable");
+        assert!(
+            artifact_path.exists(),
+            "planner artifact should be writable"
+        );
+        assert!(
+            semantic_wal_path.exists(),
+            "semantic sidecar should be writable"
+        );
+        assert!(
+            !denied_path.exists(),
+            "arbitrary HOME/.orbit write should remain denied"
         );
     }
 
@@ -1514,7 +1642,7 @@ mod tests {
             let claude_config_dir = std::env::var_os("CLAUDE_CONFIG_DIR");
             if let Some(home) = non_empty_env_path(home.as_deref()) {
                 roots.push(home.join("Library/Caches"));
-                roots.push(home.join(".orbit"));
+                roots.push(home.join(".orbit/state/logs"));
             }
             roots.extend(provider_state_dirs(
                 home.as_deref(),


### PR DESCRIPTION
## Task

[ORB-00027](https://orbit-cli.com/tasks/ORB-00027) — Fix Gemini planning-duel artifact persistence under sandbox

### Description

## Problem

The planning-duel run `jrun-20260515-0106` for `ORB-00009` failed because the Gemini planner could not persist its required artifact `planning-duel/gemini-gemini-3.1-pro.md`. Gemini produced a valid plan in its session log, but every durable write path failed under the Gemini/direct-agent sandbox:

- `orbit tool run orbit.duel.plan.add` failed with `cannot open JSONL tracing log /Users/daniel/.orbit/state/logs/orbit.jsonl: Operation not permitted` followed by `store_error: attempt to write a readonly database`.
- `orbit tool list` and graph reads failed the same way, so this is not specific to `orbit.duel.plan.add`.
- Direct writes through `.orbit/tasks/ORB-00009` failed because that path is a symlink to `/Users/daniel/.orbit/tasks/workspaces/orbit-8fb91e/ORB-00009`, outside Gemini CLI's allowed workspace.
- `ORBIT_ROOT` did not redirect the problematic `/Users/daniel/.orbit/...` access; `HOME=$(pwd)` broke rustup; manual shell writes hit `Operation not permitted`.

Related evidence:
- Failed run: `jrun-20260515-0106`
- Task: `ORB-00009`
- Gemini session log: `/Users/daniel/.gemini/tmp/orbit/chats/session-2026-05-15T01-06-74e31851.json`
- Friction report: `F2026-05-004`

## Why It Matters

Planning duels require each planner to persist an artifact through `orbit.duel.plan.add`. If Gemini direct-agent invocations cannot write Orbit task artifacts or initialize Orbit's global logging/store state under sandbox, any duel where Gemini is a planner can fail after producing useful work. The failure is especially costly because the top-level run reports only a missing artifact, while the actionable sandbox/store error is buried in the provider session log.

## Constraints / Notes

- Do not solve this by parsing Gemini's final prose as a workflow handoff. The durable contract remains task artifacts written through Orbit tools.
- Preserve sandbox protections; add the narrowest required write/read allowances or root redirection needed for Orbit tool calls and task artifact persistence.
- Keep Codex and Claude behavior intact. Codex and Claude executor configs also use `macos-sandbox-exec`, so regression coverage should show the fix is targeted or generally safe.
- Prefer deterministic tests with temporary roots/fake executor invocation over tests that depend on the operator's real `~/.orbit` or Gemini credentials.
- If the right fix requires changing where Orbit JSONL logs or task artifact symlinks resolve under sandbox, document the invariant in the relevant design doc or code comments.

### Acceptance Criteria

- A deterministic test or integration-style fixture demonstrates that a sandboxed direct-agent invocation for Gemini can run `orbit.duel.plan.add` for a planning-duel task and persist `planning-duel/gemini-gemini-3.1-pro.md` without `store_error: attempt to write a readonly database`.
- The macOS sandbox profile or executor setup grants only the minimal required access for Orbit global logging/store initialization and task artifact writes; reviewer inspection confirms it does not broadly allow arbitrary home-directory writes.
- Task artifact paths that pass through `.orbit/tasks/<id>` symlinks to the global Orbit task workspace are handled intentionally: either the sandbox allows the resolved artifact root or Orbit tools avoid exposing a path Gemini cannot access directly.
- Regression coverage verifies `orbit tool list` or an equivalent read-only Orbit tool command no longer fails inside the Gemini direct-agent sandbox due to `/Users/daniel/.orbit/state/logs/orbit.jsonl` access.
- Planning-duel diagnostics are improved so a future missing planner artifact report includes the nested provider/tool failure source or a captured child invocation log, rather than only `missing planning duel artifact for <agent>/<model>`.
- `make fmt` and a focused test command covering the sandbox/executor change pass; if `make ci` is not run, the execution summary states why.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Added narrow Orbit child-runtime write allowances for macOS-sandboxed direct agents: global logs, Orbit DB sidecars, global task workspace bundles, and workspace semantic DB sidecars, so Gemini provider tool calls can initialize Orbit and persist planning-duel artifacts while .orbit/tasks/<id> symlink targets remain intentional.
- Tightened macOS sandbox profile generation so HOME-derived defaults allow only $HOME/.orbit/state/logs, and non-subpath modify globs compile to regex filters instead of broad parent-root write grants.
- Added deterministic coverage for Gemini orbit.duel.plan.add persistence to planning-duel/gemini-gemini-3.1-pro.md and for the resolved executor sandbox roots.
- Improved planning-duel missing-artifact diagnostics to surface nested child invocation/provider evidence, including exit code, stdout or error text, blob refs, and tool call names.

Assessment: The implementation is scoped to the sandbox/executor and planning-duel diagnostic paths, preserves the durable Orbit artifact contract, and avoids broad arbitrary home-directory write access.

Design weaknesses / risks:
- Risk: make ci was not run. | Severity: Low | Mitigation: focused validation passed for sandbox profile generation, Gemini duel-plan artifact persistence, executor sandbox resolution, planning-duel diagnostics, formatting, and diff cleanliness.

Validation:
- make fmt passed.
- cargo test -p orbit-exec macos_sandbox passed.
- cargo test -p orbit-core duel_plan_add_persists_gemini_planner_artifact passed.
- cargo test -p orbit-core resolve_executor_sandbox passed.
- cargo test -p orbit-engine missing_planner_artifact_error_includes_child_invocation_diagnostics passed.
- git diff --check passed.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-00027-6a067a6a`
- Behind base: 0
- Ahead of base: 1

*authored by: gpt-5.5*