### PR TITLE
graph.show: suggest nearest selectors on knowledge_invalid resolution failure

### DIFF
--- a/crates/orbit-cli/src/output/json.rs
+++ b/crates/orbit-cli/src/output/json.rs
@@ -23,10 +23,16 @@ pub fn render(value: &Value, pretty: bool) -> Result<String, OrbitError> {
 }
 
 pub fn error_payload(error: &OrbitError) -> Value {
-    json!({
+    let mut payload = json!({
         "error": error.to_string(),
         "code": error_code(error),
-    })
+    });
+    if let Some(did_you_mean) = error.did_you_mean()
+        && let Some(object) = payload.as_object_mut()
+    {
+        object.insert("did_you_mean".to_string(), json!(did_you_mean));
+    }
+    payload
 }
 
 fn error_code(error: &OrbitError) -> &'static str {
@@ -47,7 +53,7 @@ fn error_code(error: &OrbitError) -> &'static str {
         },
         OrbitError::TaskApprovalRequired(_) => "task_approval_required",
         OrbitError::CompanionNotInstalled(_) => "companion_not_installed",
-        OrbitError::InvalidInput(_) => "invalid_input",
+        OrbitError::InvalidInput(_) | OrbitError::InvalidInputDiagnostic { .. } => "invalid_input",
         OrbitError::SkillValidation(_) => "skill_validation_failed",
         OrbitError::JobValidation(_) => "job_validation_failed",
         OrbitError::AgentProtocolViolation(_) => "agent_protocol_violation",

--- a/crates/orbit-common/src/types/error.rs
+++ b/crates/orbit-common/src/types/error.rs
@@ -50,6 +50,11 @@ pub enum OrbitError {
     CompanionNotInstalled(String),
     #[error("invalid input: {0}")]
     InvalidInput(String),
+    #[error("invalid input: {message}")]
+    InvalidInputDiagnostic {
+        message: String,
+        did_you_mean: Vec<String>,
+    },
     #[error("skill validation failed: {0}")]
     SkillValidation(String),
     #[error("job validation failed: {0}")]
@@ -79,6 +84,29 @@ impl OrbitError {
         Self::NotFound {
             kind,
             id: id.into(),
+        }
+    }
+
+    pub fn invalid_input_with_suggestions(
+        message: impl Into<String>,
+        did_you_mean: Vec<String>,
+    ) -> Self {
+        if did_you_mean.is_empty() {
+            Self::InvalidInput(message.into())
+        } else {
+            Self::InvalidInputDiagnostic {
+                message: message.into(),
+                did_you_mean,
+            }
+        }
+    }
+
+    pub fn did_you_mean(&self) -> Option<&[String]> {
+        match self {
+            Self::InvalidInputDiagnostic { did_you_mean, .. } if !did_you_mean.is_empty() => {
+                Some(did_you_mean)
+            }
+            _ => None,
         }
     }
 }

--- a/crates/orbit-common/src/utility/redaction.rs
+++ b/crates/orbit-common/src/utility/redaction.rs
@@ -97,6 +97,16 @@ pub fn redact_sensitive_env_error(error: OrbitError) -> OrbitError {
             OrbitError::CompanionNotInstalled(redact_sensitive_env_text(&m))
         }
         OrbitError::InvalidInput(m) => OrbitError::InvalidInput(redact_sensitive_env_text(&m)),
+        OrbitError::InvalidInputDiagnostic {
+            message,
+            did_you_mean,
+        } => OrbitError::InvalidInputDiagnostic {
+            message: redact_sensitive_env_text(&message),
+            did_you_mean: did_you_mean
+                .into_iter()
+                .map(|suggestion| redact_sensitive_env_text(&suggestion))
+                .collect(),
+        },
         OrbitError::SkillValidation(m) => {
             OrbitError::SkillValidation(redact_sensitive_env_text(&m))
         }

--- a/crates/orbit-knowledge/src/commands/mod.rs
+++ b/crates/orbit-knowledge/src/commands/mod.rs
@@ -96,6 +96,10 @@ impl GraphCommandContext {
 pub(crate) fn knowledge_error_from_orbit(error: OrbitError) -> KnowledgeError {
     match error {
         OrbitError::InvalidInput(message) => KnowledgeError::invalid_data(message),
+        OrbitError::InvalidInputDiagnostic {
+            message,
+            did_you_mean,
+        } => KnowledgeError::invalid_data_with_suggestions(message, did_you_mean),
         OrbitError::Execution(message) => KnowledgeError::knowledge_unavailable(message),
         other => KnowledgeError::knowledge_unavailable(other.to_string()),
     }
@@ -106,9 +110,15 @@ pub(crate) fn knowledge_error_from_orbit(error: OrbitError) -> KnowledgeError {
 /// `knowledge_invalid` kind maps to `InvalidInput` because callers treat it
 /// as user-input error; every other kind maps to `Execution`.
 pub fn knowledge_error_to_orbit(error: KnowledgeError) -> OrbitError {
-    let KnowledgeError { kind, reason } = error;
+    let KnowledgeError {
+        kind,
+        reason,
+        did_you_mean,
+    } = error;
     match kind {
-        KnowledgeErrorKind::Invalid => OrbitError::InvalidInput(reason),
+        KnowledgeErrorKind::Invalid => {
+            OrbitError::invalid_input_with_suggestions(reason, did_you_mean)
+        }
         KnowledgeErrorKind::Unavailable | KnowledgeErrorKind::Io => {
             OrbitError::Execution(format!("{kind}: {reason}"))
         }

--- a/crates/orbit-knowledge/src/commands/show.rs
+++ b/crates/orbit-knowledge/src/commands/show.rs
@@ -2,9 +2,13 @@ use serde_json::Value;
 
 use crate::commands::GraphCommandContext;
 use crate::graph::object_store::{GraphObjectStore, resolve_graph_read_target};
-use crate::graph::{GraphIndexNodeRow, GraphNode, GraphReadOptions};
+use crate::graph::{CodebaseGraphV1, GraphIndexNodeRow, GraphNode, GraphReadOptions, LeafKind};
 use crate::service::{GraphContextService, NodeContext};
 use crate::{KnowledgeError, Selector};
+
+/// Diagnostic suggestions are intentionally capped so failed lookups stay cheap
+/// and payloads remain small for agent callers.
+const DID_YOU_MEAN_LIMIT: usize = 5;
 
 #[derive(Debug, Clone)]
 pub struct ShowInput {
@@ -62,9 +66,12 @@ pub fn run(input: ShowInput) -> Result<ShowResult, KnowledgeError> {
         hydrate_leaf_source: true,
     })?;
     let svc = GraphContextService::new(&graph);
-    let node = svc
-        .resolve_selector(&selector)
-        .map_err(|error| KnowledgeError::invalid_data(error.to_string()))?;
+    let node = match svc.resolve_selector(&selector) {
+        Ok(node) => node,
+        Err(error) => {
+            return Err(invalid_selector_resolution_error(&graph, &selector, error));
+        }
+    };
     let context = svc
         .bounded_context(
             node.id(),
@@ -75,6 +82,162 @@ pub fn run(input: ShowInput) -> Result<ShowResult, KnowledgeError> {
         .map_err(|error| KnowledgeError::knowledge_unavailable(error.to_string()))?;
 
     Ok(result_from_context(&svc, &context))
+}
+
+fn invalid_selector_resolution_error(
+    graph: &CodebaseGraphV1,
+    selector: &Selector,
+    error: KnowledgeError,
+) -> KnowledgeError {
+    let reason = error.to_string();
+    KnowledgeError::invalid_data_with_suggestions(
+        reason,
+        did_you_mean_for_unresolved_selector(graph, selector),
+    )
+}
+
+fn did_you_mean_for_unresolved_selector(
+    graph: &CodebaseGraphV1,
+    selector: &Selector,
+) -> Vec<String> {
+    let Selector::Symbol { path, symbol, kind } = selector else {
+        return Vec::new();
+    };
+    if kind != "method" {
+        return Vec::new();
+    }
+    let Some((container, requested_method)) = symbol.rsplit_once("::") else {
+        return Vec::new();
+    };
+    if requested_method.is_empty()
+        || !file_resolves(graph, path)
+        || !containing_context_resolves(graph, path, container)
+    {
+        return Vec::new();
+    }
+
+    let requested_method_lower = requested_method.to_ascii_lowercase();
+    let mut candidates = graph
+        .leaves
+        .iter()
+        .filter(|leaf| leaf.kind.to_string() == *kind)
+        .filter_map(|leaf| {
+            let (leaf_path, leaf_symbol) = leaf.base.location.split_once('#')?;
+            if leaf_path != path {
+                return None;
+            }
+            let (leaf_container, leaf_method) = leaf_symbol.rsplit_once("::")?;
+            if leaf_container != container {
+                return None;
+            }
+            let leaf_method_lower = leaf_method.to_ascii_lowercase();
+            Some((
+                string_affinity_rank(&requested_method_lower, &leaf_method_lower),
+                levenshtein_distance(&requested_method_lower, &leaf_method_lower),
+                leaf_method_lower
+                    .len()
+                    .abs_diff(requested_method_lower.len()),
+                format!("symbol:{}:{}", leaf.base.location, leaf.kind),
+            ))
+        })
+        .collect::<Vec<_>>();
+
+    candidates.sort_by(|left, right| {
+        left.0
+            .cmp(&right.0)
+            .then_with(|| left.1.cmp(&right.1))
+            .then_with(|| left.2.cmp(&right.2))
+            .then_with(|| left.3.cmp(&right.3))
+    });
+    candidates
+        .into_iter()
+        .map(|(_, _, _, selector)| selector)
+        .take(DID_YOU_MEAN_LIMIT)
+        .collect()
+}
+
+fn file_resolves(graph: &CodebaseGraphV1, path: &str) -> bool {
+    graph.files.iter().any(|file| file.base.location == path)
+}
+
+fn containing_context_resolves(graph: &CodebaseGraphV1, path: &str, container: &str) -> bool {
+    let normalized_type_name = normalized_container_type_name(container);
+    graph.leaves.iter().any(|leaf| {
+        let Some((leaf_path, leaf_symbol)) = leaf.base.location.split_once('#') else {
+            return false;
+        };
+        if leaf_path != path {
+            return false;
+        }
+
+        (matches!(leaf.kind, LeafKind::Impl) && leaf_symbol == container)
+            || (is_type_like_kind(&leaf.kind) && leaf_symbol == normalized_type_name)
+    })
+}
+
+fn normalized_container_type_name(container: &str) -> &str {
+    let without_angles = container
+        .strip_prefix('<')
+        .and_then(|value| value.strip_suffix('>'))
+        .unwrap_or(container);
+    without_angles
+        .split_once(" as ")
+        .map(|(type_name, _)| type_name)
+        .unwrap_or(without_angles)
+}
+
+fn is_type_like_kind(kind: &LeafKind) -> bool {
+    matches!(
+        kind,
+        LeafKind::Class
+            | LeafKind::SingletonClass
+            | LeafKind::Enum
+            | LeafKind::Struct
+            | LeafKind::Record
+            | LeafKind::Interface
+            | LeafKind::Trait
+            | LeafKind::Object
+            | LeafKind::CompanionObject
+    )
+}
+
+fn string_affinity_rank(needle: &str, candidate: &str) -> u8 {
+    if candidate.starts_with(needle) {
+        0
+    } else if candidate.contains(needle) {
+        1
+    } else {
+        2
+    }
+}
+
+fn levenshtein_distance(left: &str, right: &str) -> usize {
+    if left == right {
+        return 0;
+    }
+    if left.is_empty() {
+        return right.chars().count();
+    }
+    if right.is_empty() {
+        return left.chars().count();
+    }
+
+    let right_chars = right.chars().collect::<Vec<_>>();
+    let mut previous = (0..=right_chars.len()).collect::<Vec<_>>();
+    let mut current = vec![0; right_chars.len() + 1];
+
+    for (left_index, left_char) in left.chars().enumerate() {
+        current[0] = left_index + 1;
+        for (right_index, right_char) in right_chars.iter().enumerate() {
+            let substitution = usize::from(left_char != *right_char);
+            current[right_index + 1] = (previous[right_index + 1] + 1)
+                .min(current[right_index] + 1)
+                .min(previous[right_index] + substitution);
+        }
+        std::mem::swap(&mut previous, &mut current);
+    }
+
+    previous[right_chars.len()]
 }
 
 fn try_show_via_sql_index(
@@ -269,4 +432,160 @@ fn selector_for_index_row(row: &GraphIndexNodeRow) -> String {
             }
             _ => row.id.clone(),
         })
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::graph::{BaseNodeFields, DirNode, FileNode, LeafNode};
+    use crate::service::GraphContextService;
+
+    use super::*;
+
+    #[test]
+    fn failed_method_on_resolvable_type_returns_did_you_mean() {
+        let graph = graph_with_methods(vec![
+            "load_layered",
+            "default_for_data_root",
+            "workflow_base_branch",
+        ]);
+        let selector: Selector = "symbol:src/runtime.rs#<RuntimeConfig>::load:method"
+            .parse()
+            .expect("valid selector");
+
+        let error = resolution_error_for(&graph, &selector);
+
+        assert_eq!(
+            error.did_you_mean.first().map(String::as_str),
+            Some("symbol:src/runtime.rs#<RuntimeConfig>::load_layered:method")
+        );
+    }
+
+    #[test]
+    fn failed_type_or_file_returns_no_suggestions() {
+        let graph = graph_with_methods(vec!["load_layered"]);
+        let missing_type: Selector = "symbol:src/runtime.rs#<MissingConfig>::load:method"
+            .parse()
+            .expect("valid selector");
+        let missing_file: Selector = "symbol:src/missing.rs#<RuntimeConfig>::load:method"
+            .parse()
+            .expect("valid selector");
+
+        assert!(
+            resolution_error_for(&graph, &missing_type)
+                .did_you_mean
+                .is_empty()
+        );
+        assert!(
+            resolution_error_for(&graph, &missing_file)
+                .did_you_mean
+                .is_empty()
+        );
+    }
+
+    #[test]
+    fn method_suggestions_are_bounded_by_cap() {
+        let graph = graph_with_methods(vec![
+            "alpha", "bravo", "charlie", "delta", "echo", "foxtrot", "golf",
+        ]);
+        let selector: Selector = "symbol:src/runtime.rs#<RuntimeConfig>::missing:method"
+            .parse()
+            .expect("valid selector");
+
+        let error = resolution_error_for(&graph, &selector);
+
+        assert_eq!(error.did_you_mean.len(), DID_YOU_MEAN_LIMIT);
+    }
+
+    fn resolution_error_for(graph: &CodebaseGraphV1, selector: &Selector) -> KnowledgeError {
+        let service = GraphContextService::new(graph);
+        let error = service
+            .resolve_selector(selector)
+            .expect_err("selector should be unresolved");
+        invalid_selector_resolution_error(graph, selector, error)
+    }
+
+    fn graph_with_methods(method_names: Vec<&str>) -> CodebaseGraphV1 {
+        let file_id = "file:src/runtime.rs";
+        let mut leaf_children = vec!["symbol:src/runtime.rs#RuntimeConfig:struct".to_string()];
+        let mut leaves = vec![leaf_node(
+            "symbol:src/runtime.rs#RuntimeConfig:struct",
+            "RuntimeConfig",
+            "src/runtime.rs#RuntimeConfig",
+            file_id,
+            LeafKind::Struct,
+        )];
+
+        for method_name in method_names {
+            let location = format!("src/runtime.rs#<RuntimeConfig>::{method_name}");
+            let id = format!("symbol:{location}:method");
+            leaf_children.push(id.clone());
+            leaves.push(leaf_node(
+                &id,
+                method_name,
+                &location,
+                file_id,
+                LeafKind::Method,
+            ));
+        }
+
+        CodebaseGraphV1 {
+            root_dir_id: "dir:.".to_string(),
+            dirs: vec![DirNode {
+                base: base_node("dir:.", ".", ".", None),
+                dir_children: Vec::new(),
+                file_children: vec![file_id.to_string()],
+            }],
+            files: vec![FileNode {
+                base: base_node(file_id, "runtime.rs", "src/runtime.rs", Some("dir:.")),
+                extension: Some("rs".to_string()),
+                source_blob_hash: None,
+                source: String::new(),
+                imports: Vec::new(),
+                exports: Vec::new(),
+                re_exports: Vec::new(),
+                leaf_children,
+            }],
+            leaves,
+        }
+    }
+
+    fn leaf_node(
+        id: &str,
+        name: &str,
+        location: &str,
+        parent_id: &str,
+        kind: LeafKind,
+    ) -> LeafNode {
+        LeafNode {
+            base: base_node(id, name, location, Some(parent_id)),
+            kind,
+            source: String::new(),
+            source_blob_hash: None,
+            source_hash: None,
+            file_hash_at_capture: None,
+            history: Vec::new(),
+            input_signature: Vec::new(),
+            output_signature: Vec::new(),
+            start_line: None,
+            end_line: None,
+            children: Vec::new(),
+        }
+    }
+
+    fn base_node(id: &str, name: &str, location: &str, parent_id: Option<&str>) -> BaseNodeFields {
+        BaseNodeFields {
+            id: id.to_string(),
+            identity_key: id.to_string(),
+            object_hash: None,
+            name: name.to_string(),
+            location: location.to_string(),
+            language: "rust".to_string(),
+            description: String::new(),
+            parent_id: parent_id.map(str::to_string),
+            is_locked: false,
+            lineage_locked: false,
+            lock_owner: None,
+            lock_reason: String::new(),
+        }
+    }
 }

--- a/crates/orbit-knowledge/src/error.rs
+++ b/crates/orbit-knowledge/src/error.rs
@@ -27,6 +27,8 @@ impl std::fmt::Display for KnowledgeErrorKind {
 pub struct KnowledgeError {
     pub kind: KnowledgeErrorKind,
     pub reason: String,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub did_you_mean: Vec<String>,
 }
 
 impl KnowledgeError {
@@ -34,6 +36,7 @@ impl KnowledgeError {
         Self {
             kind: KnowledgeErrorKind::Unavailable,
             reason: reason.into(),
+            did_you_mean: Vec::new(),
         }
     }
 
@@ -41,6 +44,18 @@ impl KnowledgeError {
         Self {
             kind: KnowledgeErrorKind::Invalid,
             reason: reason.into(),
+            did_you_mean: Vec::new(),
+        }
+    }
+
+    pub(crate) fn invalid_data_with_suggestions(
+        reason: impl Into<String>,
+        did_you_mean: Vec<String>,
+    ) -> Self {
+        Self {
+            kind: KnowledgeErrorKind::Invalid,
+            reason: reason.into(),
+            did_you_mean,
         }
     }
 
@@ -48,6 +63,7 @@ impl KnowledgeError {
         Self {
             kind: KnowledgeErrorKind::Io,
             reason: reason.into(),
+            did_you_mean: Vec::new(),
         }
     }
 }
@@ -61,6 +77,7 @@ mod tests {
         let error = KnowledgeError {
             kind: KnowledgeErrorKind::Invalid,
             reason: "bad selector".to_string(),
+            did_you_mean: Vec::new(),
         };
 
         let value = serde_json::to_value(error).expect("serialize knowledge error");
@@ -70,6 +87,26 @@ mod tests {
             serde_json::json!({
                 "kind": "knowledge_invalid",
                 "reason": "bad selector"
+            })
+        );
+    }
+
+    #[test]
+    fn knowledge_error_serializes_suggestions_when_present() {
+        let error = KnowledgeError {
+            kind: KnowledgeErrorKind::Invalid,
+            reason: "bad selector".to_string(),
+            did_you_mean: vec!["symbol:src/lib.rs#good:method".to_string()],
+        };
+
+        let value = serde_json::to_value(error).expect("serialize knowledge error");
+
+        assert_eq!(
+            value,
+            serde_json::json!({
+                "kind": "knowledge_invalid",
+                "reason": "bad selector",
+                "did_you_mean": ["symbol:src/lib.rs#good:method"]
             })
         );
     }

--- a/crates/orbit-mcp/src/error.rs
+++ b/crates/orbit-mcp/src/error.rs
@@ -14,10 +14,16 @@ pub(crate) fn tool_error_result(err: &OrbitError) -> CallToolResult {
 }
 
 fn error_payload(err: &OrbitError) -> Value {
-    json!({
+    let mut payload = json!({
         "code": error_code(err),
         "message": err.to_string(),
-    })
+    });
+    if let Some(did_you_mean) = err.did_you_mean()
+        && let Some(object) = payload.as_object_mut()
+    {
+        object.insert("did_you_mean".to_string(), json!(did_you_mean));
+    }
+    payload
 }
 
 fn error_code(err: &OrbitError) -> &'static str {
@@ -38,7 +44,7 @@ fn error_code(err: &OrbitError) -> &'static str {
         OrbitError::CompanionNotInstalled(_) => "companion_not_installed",
         OrbitError::PolicyDenied(_) => "policy_denied",
         OrbitError::TaskApprovalRequired(_) => "approval_required",
-        OrbitError::InvalidInput(_) => "invalid_input",
+        OrbitError::InvalidInput(_) | OrbitError::InvalidInputDiagnostic { .. } => "invalid_input",
         OrbitError::SkillValidation(_) | OrbitError::JobValidation(_) => "validation_failed",
         OrbitError::TaskStatusTransition(_)
         | OrbitError::JobRunStateTransition(_)


### PR DESCRIPTION
## Task

[ORB-00029](https://orbit-cli.com/tasks/ORB-00029) — graph.show: suggest nearest selectors on knowledge_invalid resolution failure

### Description

## Problem

`orbit.graph.show` returns a hard `knowledge_invalid` error when a selector does not resolve to a node, with no hints about adjacent valid selectors. This forces callers into a fallback loop of `graph.overview` + manual scanning.

Concrete repro from F2026-05-007:

```bash
orbit tool run orbit.graph.show --input '{"selector":"symbol:crates/orbit-core/src/config/runtime.rs#<RuntimeConfig>::load:method","model":"gpt-5.5"}'
```

Returns:

```json
{"code":"invalid_input","error":"invalid input: knowledge_invalid: selector `symbol:crates/orbit-core/src/config/runtime.rs#<RuntimeConfig>::load:method` does not resolve to a node"}
```

The containing struct `RuntimeConfig` resolves, and `load_layered` is a valid sibling method on the same struct, but the response surfaces neither.

## Why It Matters

Planning agents (Codex, Claude) routinely guess plausible method names from context. Hard failures with no hints inflate token usage and round-trips. Source friction: F2026-05-007 (rollout-2026-05-14T18-06-18, lines 316-326).

## Constraints / Notes

- Suggestions should be cheap: limit to symbols inside the same file/containing-type.
- Keep the error code; add a `did_you_mean` field on the structured error payload.
- The resolution failure itself remains correct — this is a diagnostic improvement, not a behavior change.
- No fabricated suggestions when the containing context is itself unresolvable.

### Acceptance Criteria

- Re-running the F2026-05-007 repro selector returns a structured error payload that contains `did_you_mean` listing at least `symbol:crates/orbit-core/src/config/runtime.rs#<RuntimeConfig>::load_layered:method` among the top suggestions.
- When the requested selector is `symbol:<file>#<TypeName>::<method>:method` and `TypeName` resolves but `<method>` does not, the response surfaces up to a documented cap (e.g. 5) of nearest sibling symbols on the same type, ranked by string similarity.
- When neither the containing type nor the file resolves, the response omits `did_you_mean` (no fabricated suggestions).
- New unit tests in `crates/orbit-knowledge/src/commands/show.rs` cover: (a) failed method on a resolvable type returns `did_you_mean`, (b) failed type/file returns no suggestions, (c) suggestions are bounded by a documented cap.
- `make ci` passes.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Added `did_you_mean` diagnostics for `orbit.graph.show` method-selector resolution failures when the containing file/type resolves, capped at 5 same-type sibling method selectors and ranked by affinity/Levenshtein similarity.
- Preserved the `invalid_input` error code while carrying suggestions through `KnowledgeError`, `OrbitError`, CLI JSON output, and MCP structured error payloads.
- Added focused unit coverage in `crates/orbit-knowledge/src/commands/show.rs` for resolvable-type suggestions, unresolved context with no suggestions, and cap enforcement.

Validation:
- `cargo test -p orbit-knowledge commands::show -- --nocapture`
- `cargo check --workspace`
- `cargo clippy -p orbit-common -p orbit-knowledge -p orbit-cli -p orbit-mcp --all-targets -- -D warnings`
- `make ci-fast`
- Local repro with `./target/debug/orbit tool run orbit.graph.show ...` returned `did_you_mean` with `symbol:crates/orbit-core/src/config/runtime.rs#<RuntimeConfig>::load_layered:method` first.

Assessment: Scoped diagnostic improvement with existing resolution failure semantics preserved. Full `make ci` was not run locally per repository guidance that it is the PR merge gate.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-00029-6a06910a`
- Behind base: 0
- Ahead of base: 1

*authored by: claude-opus-4-7*