### PR TITLE
Wire push-injection pipeline for project-learnings (Layers 1–3)

### DIFF
--- a/.claude/hooks/orbit-learning-reminder
+++ b/.claude/hooks/orbit-learning-reminder
@@ -1,0 +1,116 @@
+#!/bin/sh
+# Orbit project-learning PreToolUse hook.
+#
+# Environment:
+# - ORBIT_BIN: explicit orbit binary path; falls back to `command -v orbit`.
+# - ORBIT_SESSION_ID: shared dedup session id from orbit-engine.
+# - ORBIT_LEARNING_PER_CALL_CAP: per-hook cap; default 5.
+# - ORBIT_LEARNING_SESSION_CAP: per-session hard cap; default 20.
+
+payload=$(cat)
+
+if command -v python3 >/dev/null 2>&1; then
+  parsed=$(printf '%s' "$payload" | python3 -c '
+import json, sys
+try:
+    data = json.load(sys.stdin)
+except Exception:
+    sys.exit(0)
+tool = data.get("tool_name") or data.get("toolName") or ""
+tool_input = data.get("tool_input") or data.get("toolInput") or {}
+path = tool_input.get("file_path") or tool_input.get("filePath") or tool_input.get("path") or ""
+if tool in {"Edit", "Write", "Read"} and isinstance(path, str) and path.strip():
+    print(tool + "\t" + path.strip())
+')
+else
+  parsed=""
+fi
+
+[ -n "$parsed" ] || exit 0
+tool_name=${parsed%%	*}
+target_path=${parsed#*	}
+
+case "$tool_name" in
+  Edit|Write|Read) ;;
+  *) exit 0 ;;
+esac
+
+if [ -n "${ORBIT_BIN:-}" ]; then
+  orbit_bin=$ORBIT_BIN
+else
+  orbit_bin=$(command -v orbit 2>/dev/null || true)
+fi
+[ -n "$orbit_bin" ] || exit 0
+
+limit=${ORBIT_LEARNING_PER_CALL_CAP:-5}
+session_cap=${ORBIT_LEARNING_SESSION_CAP:-20}
+results=$("$orbit_bin" learning search --path "$target_path" --limit "$limit" --json 2>/dev/null) || exit 0
+[ -n "$results" ] || exit 0
+
+repo_root=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
+if [ -n "${ORBIT_SESSION_ID:-}" ]; then
+  state_file="$repo_root/.orbit/state/sessions/$ORBIT_SESSION_ID/learnings.json"
+else
+  state_file="${TMPDIR:-/tmp}/orbit-learning-hook-${PPID}.json"
+fi
+
+ORBIT_LEARNING_RESULTS=$results python3 - "$state_file" "$limit" "$session_cap" <<'PY'
+import fcntl
+import json
+import os
+import sys
+
+state_file, per_call_raw, session_cap_raw = sys.argv[1:4]
+try:
+    rows = json.loads(os.environ.get("ORBIT_LEARNING_RESULTS", ""))
+except Exception:
+    sys.exit(0)
+try:
+    per_call = max(1, int(per_call_raw))
+except Exception:
+    per_call = 5
+try:
+    session_cap = max(1, int(session_cap_raw))
+except Exception:
+    session_cap = 20
+
+os.makedirs(os.path.dirname(state_file), exist_ok=True)
+with open(state_file, "a+", encoding="utf-8") as handle:
+    fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
+    handle.seek(0)
+    raw = handle.read().strip()
+    try:
+        state = json.loads(raw) if raw else {"emitted_ids": [], "count": 0}
+    except Exception:
+        state = {"emitted_ids": [], "count": 0}
+    emitted = set(state.get("emitted_ids", []))
+    count = int(state.get("count", len(emitted)))
+    admitted = []
+    for row in rows:
+        learning_id = row.get("id")
+        summary = row.get("summary")
+        if not learning_id or not summary or learning_id in emitted:
+            continue
+        if count >= session_cap or len(admitted) >= per_call:
+            break
+        emitted.add(learning_id)
+        count += 1
+        admitted.append({"id": learning_id, "summary": summary})
+    handle.seek(0)
+    handle.truncate()
+    json.dump({"emitted_ids": sorted(emitted), "count": count}, handle, indent=2)
+    handle.write("\n")
+    fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+
+if not admitted:
+    sys.exit(0)
+
+print("<system-reminder>")
+print("Project learnings relevant to this task:")
+print()
+for row in admitted:
+    print(f"- [{row['id']}] {row['summary']}")
+print()
+print("Read full body via `orbit.learning.show <id>` if needed.")
+print("</system-reminder>")
+PY

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Edit|Write|Read",
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".claude/hooks/orbit-learning-reminder"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/crates/orbit-agent/src/loop_engine/session.rs
+++ b/crates/orbit-agent/src/loop_engine/session.rs
@@ -9,6 +9,7 @@
 use std::sync::atomic::{AtomicU64, Ordering};
 
 use chrono::Utc;
+use orbit_common::types::LearningInjectionState;
 
 use orbit_tools::{ToolContext, ToolRegistry};
 
@@ -24,6 +25,7 @@ pub struct Session {
     model: String,
     system_prompt: String,
     history: Vec<Message>,
+    learning_injection_state: LearningInjectionState,
     audit_tag: Option<String>,
     spawn_emitted: bool,
 }
@@ -44,6 +46,7 @@ impl Session {
             model: model.into(),
             system_prompt: system_prompt.into(),
             history: Vec::new(),
+            learning_injection_state: LearningInjectionState::default(),
             audit_tag,
             spawn_emitted: false,
         }
@@ -75,6 +78,14 @@ impl Session {
 
     pub fn history_mut(&mut self) -> &mut Vec<Message> {
         &mut self.history
+    }
+
+    pub fn learning_injection_state(&self) -> &LearningInjectionState {
+        &self.learning_injection_state
+    }
+
+    pub fn learning_injection_state_mut(&mut self) -> &mut LearningInjectionState {
+        &mut self.learning_injection_state
     }
 
     pub fn append_message(&mut self, msg: Message) {

--- a/crates/orbit-common/src/types/learning.rs
+++ b/crates/orbit-common/src/types/learning.rs
@@ -13,6 +13,7 @@
 //! without loss.
 
 use std::collections::BTreeSet;
+use std::env;
 use std::fmt::{Display, Formatter};
 use std::str::FromStr;
 
@@ -159,6 +160,144 @@ pub struct Learning {
     pub priority: Option<u8>,
 }
 
+pub const DEFAULT_LEARNING_REMINDER_PER_CALL_CAP: usize = 5;
+pub const DEFAULT_LEARNING_REMINDER_SESSION_CAP: usize = 20;
+
+/// Envelope projected into agent context by the project-learnings injection
+/// layers. It deliberately carries only the summary, never the body.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct LearningReminder {
+    pub id: OrbitId,
+    pub summary: String,
+}
+
+/// Budget controls for project-learning injection.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+pub struct LearningInjectionCaps {
+    pub per_call: usize,
+    pub per_session_hard: usize,
+}
+
+impl Default for LearningInjectionCaps {
+    fn default() -> Self {
+        Self {
+            per_call: DEFAULT_LEARNING_REMINDER_PER_CALL_CAP,
+            per_session_hard: DEFAULT_LEARNING_REMINDER_SESSION_CAP,
+        }
+    }
+}
+
+impl LearningInjectionCaps {
+    /// Read documented cap overrides from the environment.
+    ///
+    /// Invalid or zero values fall back to defaults so a bad shell export does
+    /// not disable the learning-injection path.
+    pub fn from_env() -> Self {
+        let defaults = Self::default();
+        Self {
+            per_call: read_cap_env("ORBIT_LEARNING_PER_CALL_CAP").unwrap_or(defaults.per_call),
+            per_session_hard: read_cap_env("ORBIT_LEARNING_SESSION_CAP")
+                .unwrap_or(defaults.per_session_hard),
+        }
+    }
+}
+
+fn read_cap_env(name: &str) -> Option<usize> {
+    env::var(name)
+        .ok()
+        .and_then(|value| value.trim().parse::<usize>().ok())
+        .filter(|value| *value > 0)
+}
+
+/// Per-session deduplication state for all learning-injection layers.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+pub struct LearningInjectionState {
+    #[serde(default)]
+    pub emitted_ids: BTreeSet<OrbitId>,
+    #[serde(default)]
+    pub count: usize,
+}
+
+impl LearningInjectionState {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn seeded(ids: impl IntoIterator<Item = OrbitId>) -> Self {
+        let emitted_ids: BTreeSet<_> = ids.into_iter().collect();
+        let count = emitted_ids.len();
+        Self { emitted_ids, count }
+    }
+
+    /// Admit a learning ID if it is new and the hard cap has not been reached.
+    ///
+    /// Deduplication and the hard cap are intentionally separate gates:
+    /// duplicates never consume cap, while new IDs stop once the hard cap is
+    /// reached.
+    pub fn try_admit(&mut self, id: &str, caps: LearningInjectionCaps) -> bool {
+        if self.emitted_ids.contains(id) {
+            return false;
+        }
+        if self.count >= caps.per_session_hard {
+            return false;
+        }
+        self.emitted_ids.insert(id.to_string());
+        self.count += 1;
+        true
+    }
+
+    /// Return the reminders newly admitted for this call, honoring both the
+    /// per-call cap and the per-session hard cap.
+    pub fn admit_reminders(
+        &mut self,
+        reminders: &[LearningReminder],
+        caps: LearningInjectionCaps,
+    ) -> Vec<LearningReminder> {
+        let mut admitted = Vec::with_capacity(caps.per_call.min(reminders.len()));
+        for reminder in reminders {
+            if admitted.len() >= caps.per_call {
+                break;
+            }
+            if self.try_admit(&reminder.id, caps) {
+                admitted.push(reminder.clone());
+            }
+        }
+        admitted
+    }
+}
+
+/// Render a project-learning reminder block in the prompt format documented in
+/// `docs/design/project-learnings/2_design.md` §4.1.
+pub fn render_reminder_block(reminders: &[LearningReminder]) -> String {
+    if reminders.is_empty() {
+        return String::new();
+    }
+
+    let mut out = String::from("<system-reminder>\n");
+    out.push_str("Project learnings relevant to this task:\n\n");
+    for reminder in reminders {
+        out.push_str(&format!("- [{}] {}\n", reminder.id, reminder.summary));
+    }
+    out.push('\n');
+    out.push_str("Read full body via `orbit.learning.show <id>` if needed.\n");
+    out.push_str("</system-reminder>");
+    out
+}
+
+/// Prepend rendered reminders to an existing prompt, preserving byte-for-byte
+/// identity when there are no reminders.
+pub fn prepend_reminder_block(prompt: &str, reminders: &[LearningReminder]) -> String {
+    let block = render_reminder_block(reminders);
+    if block.is_empty() {
+        return prompt.to_string();
+    }
+    if prompt.is_empty() {
+        block
+    } else {
+        format!("{block}\n\n{prompt}")
+    }
+}
+
 /// Lowercase + trim + dedupe a list of tag strings. Mirrors
 /// [`crate::types::normalize_task_tags`].
 pub fn normalize_learning_tags(raw_tags: Vec<String>) -> Vec<String> {
@@ -281,6 +420,68 @@ updated_at: 2026-05-11T00:00:00Z
             assert_eq!(parsed, status);
         }
         assert!(LearningStatus::from_str("nope").is_err());
+    }
+
+    #[test]
+    fn render_reminder_block_returns_empty_for_no_reminders() {
+        assert_eq!(render_reminder_block(&[]), "");
+        assert_eq!(prepend_reminder_block("baseline", &[]), "baseline");
+    }
+
+    #[test]
+    fn render_reminder_block_matches_design_shape() {
+        let block = render_reminder_block(&[LearningReminder {
+            id: "L20260509-0001".to_string(),
+            summary: "Verify output equivalence before freezing a result.".to_string(),
+        }]);
+
+        assert_eq!(
+            block,
+            "<system-reminder>\n\
+Project learnings relevant to this task:\n\n\
+- [L20260509-0001] Verify output equivalence before freezing a result.\n\n\
+Read full body via `orbit.learning.show <id>` if needed.\n\
+</system-reminder>"
+        );
+    }
+
+    #[test]
+    fn learning_injection_state_dedupes_without_consuming_hard_cap() {
+        let caps = LearningInjectionCaps {
+            per_call: 5,
+            per_session_hard: 2,
+        };
+        let mut state = LearningInjectionState::new();
+
+        assert!(state.try_admit("L1", caps));
+        assert!(!state.try_admit("L1", caps));
+        assert!(state.try_admit("L2", caps));
+        assert!(!state.try_admit("L3", caps));
+        assert_eq!(state.count, 2);
+        assert_eq!(state.emitted_ids.len(), 2);
+    }
+
+    #[test]
+    fn admit_reminders_enforces_per_call_cap() {
+        let caps = LearningInjectionCaps {
+            per_call: 2,
+            per_session_hard: 20,
+        };
+        let mut state = LearningInjectionState::new();
+        let reminders: Vec<_> = (0..4)
+            .map(|idx| LearningReminder {
+                id: format!("L{idx}"),
+                summary: format!("summary {idx}"),
+            })
+            .collect();
+
+        let admitted = state.admit_reminders(&reminders, caps);
+
+        assert_eq!(
+            admitted.iter().map(|r| r.id.as_str()).collect::<Vec<_>>(),
+            vec!["L0", "L1"]
+        );
+        assert_eq!(state.count, 2);
     }
 
     #[test]

--- a/crates/orbit-common/src/types/mod.rs
+++ b/crates/orbit-common/src/types/mod.rs
@@ -88,8 +88,10 @@ pub use job::{
     default_job_max_active_runs, default_max_iterations, default_retry_backoff_seconds,
 };
 pub use learning::{
-    EvidenceKind, Learning, LearningEvidence, LearningScope, LearningStatus,
-    normalize_learning_paths, normalize_learning_tags,
+    DEFAULT_LEARNING_REMINDER_PER_CALL_CAP, DEFAULT_LEARNING_REMINDER_SESSION_CAP, EvidenceKind,
+    Learning, LearningEvidence, LearningInjectionCaps, LearningInjectionState, LearningReminder,
+    LearningScope, LearningStatus, normalize_learning_paths, normalize_learning_tags,
+    prepend_reminder_block, render_reminder_block,
 };
 pub use metrics::MetricsEntry;
 pub use policy_decision::PolicyDecision;

--- a/crates/orbit-common/src/utility/learning_session.rs
+++ b/crates/orbit-common/src/utility/learning_session.rs
@@ -1,0 +1,163 @@
+//! Shared session-state file helpers for project-learning injection.
+
+use std::fs::{self, OpenOptions};
+use std::io::{Read, Seek, SeekFrom, Write};
+use std::path::{Path, PathBuf};
+
+use fs2::FileExt;
+
+use crate::types::{LearningInjectionState, OrbitError};
+
+pub const LEARNING_SESSION_STATE_RELATIVE_DIR: &str = ".orbit/state/sessions";
+pub const LEARNING_SESSION_STATE_FILE_NAME: &str = "learnings.json";
+
+pub fn learning_session_state_path(workspace_root: &Path, session_id: &str) -> PathBuf {
+    workspace_root
+        .join(LEARNING_SESSION_STATE_RELATIVE_DIR)
+        .join(session_id)
+        .join(LEARNING_SESSION_STATE_FILE_NAME)
+}
+
+pub fn read_learning_session_state(
+    path: &Path,
+) -> Result<Option<LearningInjectionState>, OrbitError> {
+    if !path.exists() {
+        return Ok(None);
+    }
+    let raw = fs::read_to_string(path).map_err(|error| {
+        OrbitError::Store(format!(
+            "read learning session state '{}': {error}",
+            path.display()
+        ))
+    })?;
+    if raw.trim().is_empty() {
+        return Ok(Some(LearningInjectionState::default()));
+    }
+    serde_json::from_str(&raw).map(Some).map_err(|error| {
+        OrbitError::Store(format!(
+            "parse learning session state '{}': {error}",
+            path.display()
+        ))
+    })
+}
+
+pub fn write_learning_session_state(
+    path: &Path,
+    state: &LearningInjectionState,
+) -> Result<(), OrbitError> {
+    update_learning_session_state(path, |existing| {
+        *existing = state.clone();
+    })
+    .map(|_| ())
+}
+
+pub fn update_learning_session_state<R>(
+    path: &Path,
+    update: impl FnOnce(&mut LearningInjectionState) -> R,
+) -> Result<(LearningInjectionState, R), OrbitError> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).map_err(|error| {
+            OrbitError::Store(format!(
+                "create learning session state dir '{}': {error}",
+                parent.display()
+            ))
+        })?;
+    }
+
+    let mut file = OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .truncate(false)
+        .open(path)
+        .map_err(|error| {
+            OrbitError::Store(format!(
+                "open learning session state '{}': {error}",
+                path.display()
+            ))
+        })?;
+    file.lock_exclusive().map_err(|error| {
+        OrbitError::Store(format!(
+            "lock learning session state '{}': {error}",
+            path.display()
+        ))
+    })?;
+
+    let result = update_locked_state(&mut file, path, update);
+    let unlock_result = file.unlock().map_err(|error| {
+        OrbitError::Store(format!(
+            "unlock learning session state '{}': {error}",
+            path.display()
+        ))
+    });
+
+    match (result, unlock_result) {
+        (Ok(value), Ok(())) => Ok(value),
+        (Err(error), _) => Err(error),
+        (Ok(_), Err(error)) => Err(error),
+    }
+}
+
+fn update_locked_state<R>(
+    file: &mut fs::File,
+    path: &Path,
+    update: impl FnOnce(&mut LearningInjectionState) -> R,
+) -> Result<(LearningInjectionState, R), OrbitError> {
+    let mut raw = String::new();
+    file.seek(SeekFrom::Start(0)).map_err(|error| {
+        OrbitError::Store(format!(
+            "seek learning session state '{}': {error}",
+            path.display()
+        ))
+    })?;
+    file.read_to_string(&mut raw).map_err(|error| {
+        OrbitError::Store(format!(
+            "read learning session state '{}': {error}",
+            path.display()
+        ))
+    })?;
+    let mut state = if raw.trim().is_empty() {
+        LearningInjectionState::default()
+    } else {
+        serde_json::from_str(&raw).map_err(|error| {
+            OrbitError::Store(format!(
+                "parse learning session state '{}': {error}",
+                path.display()
+            ))
+        })?
+    };
+
+    let callback_result = update(&mut state);
+    let encoded = serde_json::to_vec_pretty(&state).map_err(|error| {
+        OrbitError::Store(format!(
+            "serialize learning session state '{}': {error}",
+            path.display()
+        ))
+    })?;
+    file.set_len(0).map_err(|error| {
+        OrbitError::Store(format!(
+            "truncate learning session state '{}': {error}",
+            path.display()
+        ))
+    })?;
+    file.seek(SeekFrom::Start(0)).map_err(|error| {
+        OrbitError::Store(format!(
+            "seek learning session state '{}': {error}",
+            path.display()
+        ))
+    })?;
+    file.write_all(&encoded).map_err(|error| {
+        OrbitError::Store(format!(
+            "write learning session state '{}': {error}",
+            path.display()
+        ))
+    })?;
+    file.write_all(b"\n").map_err(|error| {
+        OrbitError::Store(format!(
+            "write learning session state '{}': {error}",
+            path.display()
+        ))
+    })?;
+
+    Ok((state, callback_result))
+}

--- a/crates/orbit-common/src/utility/mod.rs
+++ b/crates/orbit-common/src/utility/mod.rs
@@ -2,6 +2,7 @@ pub mod blob_store;
 pub mod fs;
 pub mod git;
 pub mod glob;
+pub mod learning_session;
 pub mod logging;
 pub mod path;
 pub mod redaction;

--- a/crates/orbit-core/src/runtime/v2_host/learning_reminders.rs
+++ b/crates/orbit-core/src/runtime/v2_host/learning_reminders.rs
@@ -1,0 +1,242 @@
+use std::collections::BTreeMap;
+
+use orbit_common::types::{
+    LearningInjectionCaps, LearningReminder, OrbitError, Task, normalize_learning_tags,
+};
+use orbit_common::utility::selector::anchor_path;
+use orbit_engine::DispatchError;
+use orbit_store::{LearningSearchParams, LearningSearchResult};
+use serde_json::Value;
+
+use crate::OrbitRuntime;
+use crate::command::task::{canonicalize_context_files_for_read, context_workspace_root};
+
+pub(super) fn learning_reminders_for_task(
+    runtime: &OrbitRuntime,
+    input: &Value,
+    caps: LearningInjectionCaps,
+) -> Result<Vec<LearningReminder>, DispatchError> {
+    let Some(task_id) = super::task_context::singular_task_id_from_input(input) else {
+        return Ok(Vec::new());
+    };
+    let task = runtime.get_task(task_id).map_err(|err| {
+        DispatchError::CliInvocationFailed(format!(
+            "load task `{task_id}` for learning reminders: {err}"
+        ))
+    })?;
+    learning_reminders_for_task_snapshot(runtime, &task, input, caps).map_err(|err| {
+        DispatchError::CliInvocationFailed(format!("search learnings for task `{task_id}`: {err}"))
+    })
+}
+
+fn learning_reminders_for_task_snapshot(
+    runtime: &OrbitRuntime,
+    task: &Task,
+    input: &Value,
+    caps: LearningInjectionCaps,
+) -> Result<Vec<LearningReminder>, OrbitError> {
+    let mut batches = Vec::new();
+    for path in task_context_paths(runtime, task, input) {
+        batches.push(runtime.search_learnings(LearningSearchParams {
+            path: Some(path),
+            tag: None,
+            query: None,
+            limit: None,
+        })?);
+    }
+    for tag in normalize_learning_tags(task.tags.clone()) {
+        batches.push(runtime.search_learnings(LearningSearchParams {
+            path: None,
+            tag: Some(tag),
+            query: None,
+            limit: None,
+        })?);
+    }
+
+    Ok(merge_ranked_results(batches, caps.per_call)
+        .into_iter()
+        .map(|result| LearningReminder {
+            id: result.learning.id,
+            summary: result.learning.summary,
+        })
+        .collect())
+}
+
+fn task_context_paths(runtime: &OrbitRuntime, task: &Task, input: &Value) -> Vec<String> {
+    let workspace_path = input.get("workspace_path").and_then(Value::as_str);
+    let prune_root = context_workspace_root(&runtime.paths().repo_root, workspace_path);
+    let canonical_context_files =
+        canonicalize_context_files_for_read(&task.context_files, &prune_root);
+    let mut paths = Vec::new();
+    for selector in canonical_context_files {
+        let Ok(path) = anchor_path(&selector) else {
+            continue;
+        };
+        let path = path.to_string_lossy().replace('\\', "/");
+        if !path.is_empty() && !paths.iter().any(|existing| existing == &path) {
+            paths.push(path);
+        }
+    }
+    paths
+}
+
+fn merge_ranked_results(
+    batches: Vec<Vec<LearningSearchResult>>,
+    limit: usize,
+) -> Vec<LearningSearchResult> {
+    let mut by_id: BTreeMap<String, LearningSearchResult> = BTreeMap::new();
+    for result in batches.into_iter().flatten() {
+        by_id
+            .entry(result.learning.id.clone())
+            .and_modify(|existing| merge_matched_by(existing, &result))
+            .or_insert(result);
+    }
+    let mut merged: Vec<_> = by_id.into_values().collect();
+    merged.sort_by(|a, b| {
+        priority_rank(b.learning.priority)
+            .cmp(&priority_rank(a.learning.priority))
+            .then_with(|| b.learning.updated_at.cmp(&a.learning.updated_at))
+            .then_with(|| a.learning.id.cmp(&b.learning.id))
+    });
+    merged.truncate(limit);
+    merged
+}
+
+fn merge_matched_by(existing: &mut LearningSearchResult, incoming: &LearningSearchResult) {
+    for axis in &incoming.matched_by {
+        if !existing.matched_by.iter().any(|seen| seen == axis) {
+            existing.matched_by.push(axis.clone());
+        }
+    }
+}
+
+fn priority_rank(priority: Option<u8>) -> i16 {
+    priority.map(i16::from).unwrap_or(-1)
+}
+
+#[cfg(test)]
+mod tests {
+    use orbit_common::types::{LearningScope, Task};
+    use orbit_engine::V2RuntimeHost;
+    use orbit_store::LearningCreateParams;
+    use serde_json::json;
+
+    use super::*;
+    use crate::OrbitRuntime;
+    use crate::command::task::TaskAddParams;
+
+    fn create_learning(
+        runtime: &OrbitRuntime,
+        summary: &str,
+        paths: &[&str],
+        tags: &[&str],
+        priority: Option<u8>,
+    ) {
+        runtime
+            .create_learning(LearningCreateParams {
+                summary: summary.to_string(),
+                scope: LearningScope {
+                    paths: paths.iter().map(|value| (*value).to_string()).collect(),
+                    tags: tags.iter().map(|value| (*value).to_string()).collect(),
+                    ..Default::default()
+                },
+                body: "body must not be injected".to_string(),
+                evidence: Vec::new(),
+                created_by: Some("gpt-5.5".to_string()),
+                priority,
+            })
+            .expect("create learning");
+    }
+
+    fn task_with_context(
+        runtime: &OrbitRuntime,
+        context_files: Vec<String>,
+        tags: Vec<String>,
+    ) -> Task {
+        std::fs::create_dir_all(runtime.paths().repo_root.join("crates/orbit-engine/src"))
+            .expect("create context dir");
+        runtime
+            .add_task(TaskAddParams {
+                title: "Learning reminder task".to_string(),
+                description: "Task description.".to_string(),
+                acceptance_criteria: vec!["works".to_string()],
+                plan: "plan".to_string(),
+                context_files,
+                tags,
+                workspace_path: Some(".".to_string()),
+                ..Default::default()
+            })
+            .expect("add task")
+    }
+
+    #[test]
+    fn reminders_match_task_context_paths_and_tags_without_body() {
+        let runtime = OrbitRuntime::in_memory().expect("build runtime");
+        create_learning(
+            &runtime,
+            "Remember the engine path.",
+            &["crates/orbit-engine/**"],
+            &[],
+            None,
+        );
+        create_learning(&runtime, "Remember the tag.", &[], &["workflow"], None);
+        let task = task_with_context(
+            &runtime,
+            vec!["dir:crates/orbit-engine/src".to_string()],
+            vec!["workflow".to_string()],
+        );
+
+        let reminders = runtime
+            .learning_reminders_for_task(
+                &json!({"task_id": task.id}),
+                LearningInjectionCaps::default(),
+            )
+            .expect("learning reminders");
+
+        assert_eq!(reminders.len(), 2);
+        assert!(
+            reminders
+                .iter()
+                .any(|reminder| reminder.summary == "Remember the engine path.")
+        );
+        assert!(
+            reminders
+                .iter()
+                .any(|reminder| reminder.summary == "Remember the tag.")
+        );
+        assert!(
+            !serde_json::to_string(&reminders)
+                .expect("json")
+                .contains("body")
+        );
+    }
+
+    #[test]
+    fn reminders_apply_default_per_call_cap_after_merge() {
+        let runtime = OrbitRuntime::in_memory().expect("build runtime");
+        for idx in 0..7 {
+            create_learning(
+                &runtime,
+                &format!("Learning {idx}"),
+                &["crates/orbit-engine/**"],
+                &[],
+                Some(idx),
+            );
+        }
+        let task = task_with_context(
+            &runtime,
+            vec!["dir:crates/orbit-engine/src".to_string()],
+            Vec::new(),
+        );
+
+        let reminders = runtime
+            .learning_reminders_for_task(
+                &json!({"task_id": task.id}),
+                LearningInjectionCaps::default(),
+            )
+            .expect("learning reminders");
+
+        assert_eq!(reminders.len(), 5);
+        assert_eq!(reminders[0].summary, "Learning 6");
+    }
+}

--- a/crates/orbit-core/src/runtime/v2_host/mod.rs
+++ b/crates/orbit-core/src/runtime/v2_host/mod.rs
@@ -11,6 +11,7 @@
 mod backlog_exclusion;
 mod cli_executor;
 mod dispatch;
+mod learning_reminders;
 mod pipeline_actions;
 mod sandbox;
 mod task_context;
@@ -22,7 +23,9 @@ use std::path::Path;
 use std::sync::Arc;
 
 use orbit_common::types::activity_job::AgentRole;
-use orbit_common::types::{InvocationTrace, UNRESTRICTED_FS_PROFILE};
+use orbit_common::types::{
+    InvocationTrace, LearningInjectionCaps, LearningReminder, UNRESTRICTED_FS_PROFILE,
+};
 use orbit_engine::{AgentRoleConfig, EnvironmentHost};
 use orbit_engine::{DispatchError, ResolvedCliExecutor, ResolvedSandbox, V2RuntimeHost};
 use orbit_store::{InvocationInsertParams, Store, token_scoreboard};
@@ -75,6 +78,14 @@ impl V2RuntimeHost for OrbitRuntime {
 
     fn task_context_for_agent_input(&self, input: &Value) -> Result<Option<Value>, DispatchError> {
         task_context::task_context_for_agent_input(self, input)
+    }
+
+    fn learning_reminders_for_task(
+        &self,
+        input: &Value,
+        caps: LearningInjectionCaps,
+    ) -> Result<Vec<LearningReminder>, DispatchError> {
+        learning_reminders::learning_reminders_for_task(self, input, caps)
     }
 
     fn tool_context_for_activity(

--- a/crates/orbit-core/src/runtime/v2_host/task_context.rs
+++ b/crates/orbit-core/src/runtime/v2_host/task_context.rs
@@ -56,7 +56,7 @@ pub(super) fn task_context_for_agent_input(
     )))
 }
 
-fn singular_task_id_from_input(input: &Value) -> Option<&str> {
+pub(super) fn singular_task_id_from_input(input: &Value) -> Option<&str> {
     fn non_empty(value: &str) -> Option<&str> {
         let trimmed = value.trim();
         (!trimmed.is_empty()).then_some(trimmed)
@@ -105,6 +105,7 @@ fn agent_task_context_json(task: &Task, input: &Value, fallback_repo_root: &Path
         "acceptance_criteria": task.acceptance_criteria.clone(),
         "plan": task.plan.clone(),
         "context_files": kept_context_files,
+        "tags": task.tags.clone(),
         "external_refs": task.external_refs.clone(),
         "workspace_path": workspace_path,
         "repo_root": repo_root,

--- a/crates/orbit-engine/src/activity_job/agent_loop_driver.rs
+++ b/crates/orbit-engine/src/activity_job/agent_loop_driver.rs
@@ -26,6 +26,10 @@ use orbit_agent::loop_engine::{
 };
 use orbit_agent::providers::anthropic::AnthropicMessagesTransport;
 use orbit_common::types::activity_job::AgentLoopSpec;
+use orbit_common::types::{LearningInjectionCaps, LearningReminder, prepend_reminder_block};
+use orbit_common::utility::learning_session::{
+    learning_session_state_path, write_learning_session_state,
+};
 use orbit_tools::ToolContext;
 use serde_json::Value;
 
@@ -56,7 +60,16 @@ pub fn drive_agent_loop(
         fs_profile,
         Some(v2_fs_audit_logger(audit.clone())),
     );
-    drive_inner(spec, api_key, run_id, audit, &mut session, input, tool_ctx)
+    drive_inner(
+        spec,
+        api_key,
+        run_id,
+        audit,
+        &mut session,
+        input,
+        tool_ctx,
+        Some(host),
+    )
 }
 
 /// Drive a v2 agent_loop activity reusing an existing `Session`.
@@ -80,7 +93,16 @@ pub fn drive_agent_loop_with_session(
         fs_profile,
         Some(v2_fs_audit_logger(audit.clone())),
     );
-    drive_inner(spec, api_key, run_id, audit, session, input, tool_ctx)
+    drive_inner(
+        spec,
+        api_key,
+        run_id,
+        audit,
+        session,
+        input,
+        tool_ctx,
+        Some(host),
+    )
 }
 
 /// Drive a v2 agent_loop activity with a caller-supplied ToolContext.
@@ -98,9 +120,19 @@ pub fn drive_agent_loop_with_tool_context(
     let model = resolve_model(spec);
     let provider = expected_provider();
     let mut session = Session::new(provider, model.clone(), &spec.instruction, None);
-    drive_inner(spec, api_key, run_id, audit, &mut session, input, tool_ctx)
+    drive_inner(
+        spec,
+        api_key,
+        run_id,
+        audit,
+        &mut session,
+        input,
+        tool_ctx,
+        None,
+    )
 }
 
+#[allow(clippy::too_many_arguments)]
 fn drive_inner(
     spec: &AgentLoopSpec,
     api_key: Option<&str>,
@@ -109,9 +141,12 @@ fn drive_inner(
     session: &mut Session,
     input: &Value,
     tool_ctx: ToolContext,
+    host: Option<&dyn V2RuntimeHost>,
 ) -> Result<LoopOutcome, DispatchError> {
     let model = resolve_model(spec);
     let user_prompt = user_prompt_from_input(input)?;
+    let user_prompt =
+        maybe_prepend_learning_reminders(user_prompt, host, input, session, &tool_ctx)?;
 
     if replay_active() {
         // Reuse the same ReplayTransport across calls so the cursor advances
@@ -151,6 +186,44 @@ fn drive_inner(
             tool_ctx,
         )
     }
+}
+
+fn maybe_prepend_learning_reminders(
+    user_prompt: String,
+    host: Option<&dyn V2RuntimeHost>,
+    input: &Value,
+    session: &mut Session,
+    tool_ctx: &ToolContext,
+) -> Result<String, DispatchError> {
+    let Some(host) = host else {
+        return Ok(user_prompt);
+    };
+    let caps = LearningInjectionCaps::from_env();
+    let reminders = host.learning_reminders_for_task(input, caps)?;
+    if reminders.is_empty() {
+        return Ok(user_prompt);
+    }
+    let admitted = session
+        .learning_injection_state_mut()
+        .admit_reminders(&reminders, caps);
+    if admitted.is_empty() {
+        return Ok(user_prompt);
+    }
+    persist_session_learning_state(tool_ctx, session, &admitted)?;
+    Ok(prepend_reminder_block(&user_prompt, &admitted))
+}
+
+fn persist_session_learning_state(
+    tool_ctx: &ToolContext,
+    session: &Session,
+    _admitted: &[LearningReminder],
+) -> Result<(), DispatchError> {
+    let Some(workspace_root) = tool_ctx.workspace_root.as_deref() else {
+        return Ok(());
+    };
+    let path = learning_session_state_path(workspace_root, session.id());
+    write_learning_session_state(&path, session.learning_injection_state())
+        .map_err(|err| DispatchError::AgentLoopFailed(format!("persist learning state: {err}")))
 }
 
 fn user_prompt_from_input(input: &Value) -> Result<String, DispatchError> {
@@ -365,7 +438,9 @@ mod tests {
     use std::sync::Arc;
 
     use orbit_agent::loop_engine::audit::{AuditSink, NullSink};
+    use orbit_agent::loop_engine::transport::MessageRole;
     use orbit_common::types::activity_job::{Backend, OnDenial, Provider};
+    use orbit_common::types::{LearningInjectionCaps, LearningReminder};
     use tempfile::NamedTempFile;
 
     use super::*;
@@ -440,6 +515,56 @@ mod tests {
         }
     }
 
+    struct LearningReplayHost {
+        reminders: Vec<LearningReminder>,
+    }
+
+    impl V2RuntimeHost for LearningReplayHost {
+        fn run_deterministic(
+            &self,
+            _action: &str,
+            _config: &Value,
+            _input: &Value,
+            _tool_context: ToolContext,
+        ) -> Result<Value, DispatchError> {
+            Err(DispatchError::DeterministicActionNotRegistered(
+                "learning replay host: not used".to_string(),
+            ))
+        }
+
+        fn api_key_for(&self, _provider: &str) -> Result<String, DispatchError> {
+            Err(DispatchError::AgentLoopFailed(
+                "learning replay host: no credentials".to_string(),
+            ))
+        }
+
+        fn resolve_cli_executor(
+            &self,
+            _provider: &str,
+        ) -> Result<super::super::dispatcher::ResolvedCliExecutor, DispatchError> {
+            Err(DispatchError::CliInvocationFailed(
+                "learning replay host: no CLI mapping".to_string(),
+            ))
+        }
+
+        fn learning_reminders_for_task(
+            &self,
+            _input: &Value,
+            caps: LearningInjectionCaps,
+        ) -> Result<Vec<LearningReminder>, DispatchError> {
+            Ok(self.reminders.iter().take(caps.per_call).cloned().collect())
+        }
+
+        fn tool_context_for_activity(
+            &self,
+            _run_id: Option<&str>,
+            _fs_profile: Option<&str>,
+            _fs_audit: Option<Arc<dyn orbit_tools::FsAuditLogger>>,
+        ) -> ToolContext {
+            ToolContext::default()
+        }
+    }
+
     fn replay_spec(on_denial: OnDenial) -> AgentLoopSpec {
         AgentLoopSpec {
             instruction: "test".to_string(),
@@ -467,6 +592,24 @@ mod tests {
         )
         .expect("write fixture");
         file
+    }
+
+    fn replay_done_fixture() -> NamedTempFile {
+        write_fixture(serde_json::json!({
+            "turns": [{
+                "content": [{ "kind": "text", "text": "done" }],
+                "stop_reason": "end_turn"
+            }]
+        }))
+    }
+
+    fn first_user_text(session: &Session) -> &str {
+        let message = session.history().first().expect("first message");
+        assert_eq!(message.role, MessageRole::User);
+        match message.content.first().expect("first content") {
+            ContentBlock::Text { text } => text,
+            _ => panic!("expected text content"),
+        }
     }
 
     #[test]
@@ -547,5 +690,99 @@ mod tests {
             vec!["fs.delete".to_string()]
         );
         assert!(outcome.trace[1].policy_denials.is_empty());
+    }
+
+    #[test]
+    fn l1_learning_reminder_prepends_prompt_for_matching_task() {
+        let _lock = REPLAY_TEST_ENV_LOCK.lock().expect("replay env lock");
+        let fixture = replay_done_fixture();
+        let _guard = ReplayEnvGuard::set_fixture(fixture.path());
+        let host = LearningReplayHost {
+            reminders: vec![LearningReminder {
+                id: "L20260515-0001".to_string(),
+                summary: "Remember to validate the output.".to_string(),
+            }],
+        };
+        let mut session = Session::new("replay", "test-model", "test", None);
+
+        drive_agent_loop_with_session(
+            &replay_spec(OnDenial::Terminate),
+            None,
+            "run-learning-positive",
+            audit_writer("run-learning-positive"),
+            &mut session,
+            &serde_json::json!({"prompt": "baseline prompt"}),
+            &host,
+            None,
+        )
+        .expect("replay should finish");
+
+        assert_eq!(
+            first_user_text(&session),
+            "<system-reminder>\n\
+Project learnings relevant to this task:\n\n\
+- [L20260515-0001] Remember to validate the output.\n\n\
+Read full body via `orbit.learning.show <id>` if needed.\n\
+</system-reminder>\n\n\
+baseline prompt"
+        );
+    }
+
+    #[test]
+    fn l1_learning_reminder_leaves_prompt_unchanged_without_matches() {
+        let _lock = REPLAY_TEST_ENV_LOCK.lock().expect("replay env lock");
+        let fixture = replay_done_fixture();
+        let _guard = ReplayEnvGuard::set_fixture(fixture.path());
+        let host = LearningReplayHost {
+            reminders: Vec::new(),
+        };
+        let mut session = Session::new("replay", "test-model", "test", None);
+
+        drive_agent_loop_with_session(
+            &replay_spec(OnDenial::Terminate),
+            None,
+            "run-learning-negative",
+            audit_writer("run-learning-negative"),
+            &mut session,
+            &serde_json::json!({"prompt": "baseline prompt"}),
+            &host,
+            None,
+        )
+        .expect("replay should finish");
+
+        assert_eq!(first_user_text(&session), "baseline prompt");
+    }
+
+    #[test]
+    fn l1_learning_reminder_applies_default_per_call_cap() {
+        let _lock = REPLAY_TEST_ENV_LOCK.lock().expect("replay env lock");
+        let fixture = replay_done_fixture();
+        let _guard = ReplayEnvGuard::set_fixture(fixture.path());
+        let host = LearningReplayHost {
+            reminders: (0..7)
+                .map(|idx| LearningReminder {
+                    id: format!("L20260515-{idx:04}"),
+                    summary: format!("Learning {idx}"),
+                })
+                .collect(),
+        };
+        let mut session = Session::new("replay", "test-model", "test", None);
+
+        drive_agent_loop_with_session(
+            &replay_spec(OnDenial::Terminate),
+            None,
+            "run-learning-cap",
+            audit_writer("run-learning-cap"),
+            &mut session,
+            &serde_json::json!({"prompt": "baseline prompt"}),
+            &host,
+            None,
+        )
+        .expect("replay should finish");
+
+        let text = first_user_text(&session);
+        assert!(text.contains("[L20260515-0004] Learning 4"));
+        assert!(!text.contains("L20260515-0005"));
+        assert_eq!(session.learning_injection_state().count, 5);
     }
 }

--- a/crates/orbit-engine/src/activity_job/cli_runner/envelope.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/envelope.rs
@@ -10,6 +10,7 @@ pub(super) fn cli_agent_envelope_json(
     run_id: &str,
     input: &Value,
     task_ctx: Option<&Value>,
+    prompt_override: Option<&str>,
 ) -> Result<Vec<u8>, DispatchError> {
     let mut envelope = serde_json::Map::new();
     envelope.insert("schemaVersion".to_string(), Value::from(1));
@@ -19,7 +20,10 @@ pub(super) fn cli_agent_envelope_json(
     );
     envelope.insert(
         "prompt".to_string(),
-        Value::String(user_prompt_from_input(input)?),
+        Value::String(match prompt_override {
+            Some(prompt) => prompt.to_string(),
+            None => user_prompt_from_input(input)?,
+        }),
     );
     envelope.insert("input".to_string(), input.clone());
     envelope.insert("run_id".to_string(), Value::String(run_id.to_string()));
@@ -63,7 +67,7 @@ pub(super) fn parse_cli_invocation_trace(
         .ok()
 }
 
-fn user_prompt_from_input(input: &Value) -> Result<String, DispatchError> {
+pub(super) fn user_prompt_from_input(input: &Value) -> Result<String, DispatchError> {
     match input {
         Value::Object(map) => match map.get("prompt") {
             Some(Value::String(text)) => Ok(text.clone()),
@@ -162,9 +166,14 @@ mod tests {
             "workspace_path": "/tmp/orbit-worktree"
         });
 
-        let raw =
-            cli_agent_envelope_json(&spec, "jrun-context", &input, host.task_context.as_ref())
-                .expect("build cli agent envelope");
+        let raw = cli_agent_envelope_json(
+            &spec,
+            "jrun-context",
+            &input,
+            host.task_context.as_ref(),
+            None,
+        )
+        .expect("build cli agent envelope");
         let envelope: Value = serde_json::from_slice(&raw).expect("parse envelope json");
 
         assert_eq!(envelope["schemaVersion"], 1);

--- a/crates/orbit-engine/src/activity_job/cli_runner/orchestrator.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/orchestrator.rs
@@ -3,8 +3,13 @@
 use std::sync::Arc;
 use std::time::Duration;
 
+use chrono::Utc;
 use orbit_agent::{Agent, AgentConfig, AgentOperation, AgentRequest, peek_response_status};
 use orbit_common::types::activity_job::{AgentLoopSpec, V2AuditEventKind};
+use orbit_common::types::{LearningInjectionCaps, LearningInjectionState, prepend_reminder_block};
+use orbit_common::utility::learning_session::{
+    learning_session_state_path, write_learning_session_state,
+};
 use orbit_common::utility::redaction::{PatternRedactor, redact_sensitive_env_text};
 use serde_json::Value;
 
@@ -62,7 +67,14 @@ pub fn run_cli_backend(
     let sandbox =
         host.resolve_executor_sandbox(&provider, fs_profile, subprocess_cwd.as_deref())?;
 
-    let envelope_json = cli_agent_envelope_json(spec, run_id, input, task_ctx.as_ref())?;
+    let learning_context = cli_learning_context(host, input, tool_ctx.workspace_root.as_deref())?;
+    let envelope_json = cli_agent_envelope_json(
+        spec,
+        run_id,
+        input,
+        task_ctx.as_ref(),
+        learning_context.prompt.as_deref(),
+    )?;
 
     let mut provider_config = host.provider_cli_config(&provider);
 
@@ -132,10 +144,13 @@ pub fn run_cli_backend(
         wall_clock_timeout_ms: wall_clock_timeout.as_millis() as u64,
     });
 
-    let child_env = vec![
+    let mut child_env = vec![
         ("ORBIT_RUN_ID".to_string(), run_id.to_string()),
         ("ORBIT_MANAGED_RUN_CONTEXT".to_string(), "1".to_string()),
     ];
+    if let Some(session_id) = learning_context.session_id {
+        child_env.push(("ORBIT_SESSION_ID".to_string(), session_id));
+    }
     let (stdout, stderr, exit_code, duration, timed_out) =
         spawn_with_timeout(SpawnWithTimeoutRequest {
             program: &invocation.program,
@@ -226,6 +241,48 @@ pub fn run_cli_backend(
             model,
             trace,
         }),
+    })
+}
+
+struct CliLearningContext {
+    prompt: Option<String>,
+    session_id: Option<String>,
+}
+
+fn cli_learning_context(
+    host: &dyn V2RuntimeHost,
+    input: &Value,
+    workspace_root: Option<&std::path::Path>,
+) -> Result<CliLearningContext, DispatchError> {
+    let caps = LearningInjectionCaps::from_env();
+    let reminders = host.learning_reminders_for_task(input, caps)?;
+    if reminders.is_empty() {
+        return Ok(CliLearningContext {
+            prompt: None,
+            session_id: None,
+        });
+    }
+
+    let mut state = LearningInjectionState::new();
+    let admitted = state.admit_reminders(&reminders, caps);
+    if admitted.is_empty() {
+        return Ok(CliLearningContext {
+            prompt: None,
+            session_id: None,
+        });
+    }
+    let base_prompt = super::envelope::user_prompt_from_input(input)?;
+    let prompt = prepend_reminder_block(&base_prompt, &admitted);
+    let session_id = format!("S{:x}-cli", Utc::now().timestamp_micros());
+    if let Some(root) = workspace_root {
+        let path = learning_session_state_path(root, &session_id);
+        write_learning_session_state(&path, &state).map_err(|err| {
+            DispatchError::CliInvocationFailed(format!("persist learning state: {err}"))
+        })?;
+    }
+    Ok(CliLearningContext {
+        prompt: Some(prompt),
+        session_id: Some(session_id),
     })
 }
 

--- a/crates/orbit-engine/src/activity_job/dispatcher.rs
+++ b/crates/orbit-engine/src/activity_job/dispatcher.rs
@@ -11,7 +11,8 @@ use orbit_common::types::activity_job::{
 
 use crate::context::AgentRoleConfig;
 use orbit_common::types::{
-    ExecutorSandboxKind, InvocationTrace, OrbitError, ResolvedFsProfile, TokenUsage, ToolCallTrace,
+    ExecutorSandboxKind, InvocationTrace, LearningInjectionCaps, LearningReminder, OrbitError,
+    ResolvedFsProfile, TokenUsage, ToolCallTrace,
 };
 use orbit_tools::{FsAuditLogger, FsCallEvent, FsCallEventKind, ToolContext};
 use serde_json::Value;
@@ -115,6 +116,17 @@ pub trait V2RuntimeHost: Send + Sync {
     /// without leaking store or task-query details into orbit-engine.
     fn task_context_for_agent_input(&self, _input: &Value) -> Result<Option<Value>, DispatchError> {
         Ok(None)
+    }
+
+    /// Return project-learning reminders relevant to the task represented by
+    /// `input`. Implementors that do not own task storage can ignore this; the
+    /// engine preserves the original prompt when the returned set is empty.
+    fn learning_reminders_for_task(
+        &self,
+        _input: &Value,
+        _caps: LearningInjectionCaps,
+    ) -> Result<Vec<LearningReminder>, DispatchError> {
+        Ok(Vec::new())
     }
 
     fn tool_context_for_activity(

--- a/crates/orbit-mcp/src/adapter.rs
+++ b/crates/orbit-mcp/src/adapter.rs
@@ -2,7 +2,14 @@ use std::collections::{BTreeMap, HashMap};
 use std::fmt;
 use std::sync::{Arc, RwLock};
 
-use orbit_common::types::{OrbitError, ToolParam, ToolSchema};
+use orbit_common::types::{
+    LearningInjectionCaps, LearningInjectionState, LearningReminder, OrbitError, ToolParam,
+    ToolSchema,
+};
+use orbit_common::utility::learning_session::{
+    learning_session_state_path, read_learning_session_state, update_learning_session_state,
+};
+use orbit_common::utility::selector::anchor_path;
 use rmcp::ErrorData as McpError;
 use rmcp::ServerHandler;
 use rmcp::model::{
@@ -35,13 +42,54 @@ use crate::error::tool_error_result;
 pub struct OrbitToolServer {
     host: Arc<dyn McpHost>,
     name_map: RwLock<HashMap<String, String>>,
+    learning_session_id: Option<String>,
+    learning_caps: LearningInjectionCaps,
+    learning_states: tokio::sync::Mutex<HashMap<String, LearningInjectionState>>,
 }
 
 impl OrbitToolServer {
     pub fn new(host: Arc<dyn McpHost>) -> Self {
+        let learning_session_id = std::env::var("ORBIT_SESSION_ID")
+            .ok()
+            .map(|value| value.trim().to_string())
+            .filter(|value| !value.is_empty());
+        let learning_caps = LearningInjectionCaps::from_env();
+        let mut learning_states = HashMap::new();
+        let key = learning_session_id
+            .clone()
+            .unwrap_or_else(|| PROCESS_LEARNING_SESSION_KEY.to_string());
+        let state = learning_session_id
+            .as_deref()
+            .and_then(load_learning_state_for_session)
+            .unwrap_or_default();
+        learning_states.insert(key, state);
         Self {
             host,
             name_map: RwLock::new(HashMap::new()),
+            learning_session_id,
+            learning_caps,
+            learning_states: tokio::sync::Mutex::new(learning_states),
+        }
+    }
+
+    #[cfg(test)]
+    fn new_for_test(
+        host: Arc<dyn McpHost>,
+        learning_session_id: Option<String>,
+        learning_caps: LearningInjectionCaps,
+        initial_state: LearningInjectionState,
+    ) -> Self {
+        let key = learning_session_id
+            .clone()
+            .unwrap_or_else(|| PROCESS_LEARNING_SESSION_KEY.to_string());
+        let mut learning_states = HashMap::new();
+        learning_states.insert(key, initial_state);
+        Self {
+            host,
+            name_map: RwLock::new(HashMap::new()),
+            learning_session_id,
+            learning_caps,
+            learning_states: tokio::sync::Mutex::new(learning_states),
         }
     }
 
@@ -98,10 +146,16 @@ impl OrbitToolServer {
 
         let host = Arc::clone(&self.host);
         let exec_name = canonical.clone();
+        let input_for_learning = input.clone();
         let join = tokio::task::spawn_blocking(move || host.call_tool(&exec_name, input)).await;
 
         match join {
-            Ok(Ok(value)) => Ok(CallToolResult::structured(mcp_structured_content(value))),
+            Ok(Ok(value)) => {
+                let value = self
+                    .maybe_attach_learning_sidecar(&canonical, input_for_learning, value)
+                    .await?;
+                Ok(CallToolResult::structured(mcp_structured_content(value)))
+            }
             Ok(Err(orbit_err)) => Ok(tool_error_result(&orbit_err)),
             Err(join_err) => {
                 let err = OrbitError::Execution(format!(
@@ -110,6 +164,288 @@ impl OrbitToolServer {
                 Ok(tool_error_result(&err))
             }
         }
+    }
+
+    async fn maybe_attach_learning_sidecar(
+        &self,
+        canonical: &str,
+        input: Value,
+        value: Value,
+    ) -> Result<Value, McpError> {
+        if !learning_sidecar_tool(canonical) {
+            return Ok(value);
+        }
+        let paths = collect_learning_candidate_paths(&input, &value);
+        if paths.is_empty() {
+            return Ok(value);
+        }
+
+        let host = Arc::clone(&self.host);
+        let caps = self.learning_caps;
+        let join =
+            tokio::task::spawn_blocking(move || search_learning_reminders(&*host, &paths, caps))
+                .await;
+        let reminders = match join {
+            Ok(Ok(reminders)) => reminders,
+            Ok(Err(error)) => {
+                tracing::warn!(
+                    target: "orbit.mcp.learnings",
+                    error = %error,
+                    "failed to search learning sidecar",
+                );
+                Vec::new()
+            }
+            Err(error) => {
+                tracing::warn!(
+                    target: "orbit.mcp.learnings",
+                    error = %error,
+                    "learning sidecar worker failed",
+                );
+                Vec::new()
+            }
+        };
+        if reminders.is_empty() {
+            return Ok(value);
+        }
+
+        let admitted = self.admit_learning_reminders(reminders).await?;
+        Ok(attach_learning_sidecar(value, admitted))
+    }
+
+    async fn admit_learning_reminders(
+        &self,
+        reminders: Vec<LearningReminder>,
+    ) -> Result<Vec<LearningReminder>, McpError> {
+        let key = self.learning_session_key();
+        let caps = self.learning_caps;
+        if let Some(session_id) = self.learning_session_id.clone() {
+            let root = std::env::current_dir().map_err(|error| {
+                McpError::internal_error(
+                    format!("resolve current dir for learning session: {error}"),
+                    None,
+                )
+            })?;
+            let path = learning_session_state_path(&root, &session_id);
+            let reminders_for_file = reminders.clone();
+            let join = tokio::task::spawn_blocking(move || {
+                update_learning_session_state(&path, |state| {
+                    state.admit_reminders(&reminders_for_file, caps)
+                })
+            })
+            .await
+            .map_err(|error| {
+                McpError::internal_error(
+                    format!("learning session state worker failed: {error}"),
+                    None,
+                )
+            })?;
+            let (state, admitted) = join.map_err(|error| {
+                McpError::internal_error(format!("update learning session state: {error}"), None)
+            })?;
+            let mut states = self.learning_states.lock().await;
+            states.insert(key, state);
+            return Ok(admitted);
+        }
+
+        let mut states = self.learning_states.lock().await;
+        let state = states.entry(key).or_default();
+        Ok(state.admit_reminders(&reminders, caps))
+    }
+
+    fn learning_session_key(&self) -> String {
+        self.learning_session_id
+            .clone()
+            .unwrap_or_else(|| PROCESS_LEARNING_SESSION_KEY.to_string())
+    }
+}
+
+const PROCESS_LEARNING_SESSION_KEY: &str = "__process__";
+
+fn load_learning_state_for_session(session_id: &str) -> Option<LearningInjectionState> {
+    let root = std::env::current_dir().ok()?;
+    let path = learning_session_state_path(&root, session_id);
+    read_learning_session_state(&path).ok().flatten()
+}
+
+fn learning_sidecar_tool(canonical: &str) -> bool {
+    matches!(
+        canonical,
+        "orbit.graph.show" | "orbit.graph.refs" | "orbit.task.show"
+    )
+}
+
+fn collect_learning_candidate_paths(input: &Value, response: &Value) -> Vec<String> {
+    let mut paths = Vec::new();
+    collect_paths_from_input(input, &mut paths);
+    collect_paths_from_response(response, &mut paths);
+    paths
+}
+
+fn collect_paths_from_input(value: &Value, out: &mut Vec<String>) {
+    let Some(object) = value.as_object() else {
+        return;
+    };
+    for key in ["selector", "selectors", "path", "paths"] {
+        if let Some(value) = object.get(key) {
+            collect_path_values(value, out);
+        }
+    }
+}
+
+fn collect_paths_from_response(value: &Value, out: &mut Vec<String>) {
+    match value {
+        Value::Object(object) => {
+            for (key, value) in object {
+                if matches!(key.as_str(), "file" | "path" | "context_files") {
+                    collect_path_values(value, out);
+                    continue;
+                }
+                if key == "code_refs" {
+                    collect_code_ref_paths(value, out);
+                    continue;
+                }
+                collect_paths_from_response(value, out);
+            }
+        }
+        Value::Array(items) => {
+            for item in items {
+                collect_paths_from_response(item, out);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn collect_code_ref_paths(value: &Value, out: &mut Vec<String>) {
+    let Some(items) = value.as_array() else {
+        return;
+    };
+    for item in items {
+        if let Some(file) = item.get("file") {
+            collect_path_values(file, out);
+        }
+    }
+}
+
+fn collect_path_values(value: &Value, out: &mut Vec<String>) {
+    match value {
+        Value::String(raw) => push_candidate_path(raw, out),
+        Value::Array(items) => {
+            for item in items {
+                collect_path_values(item, out);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn push_candidate_path(raw: &str, out: &mut Vec<String>) {
+    let Ok(path) = anchor_path(raw) else {
+        return;
+    };
+    let path = path.to_string_lossy().replace('\\', "/");
+    if !path.is_empty() && !out.iter().any(|existing| existing == &path) {
+        out.push(path);
+    }
+}
+
+#[derive(Debug, Clone)]
+struct ReminderCandidate {
+    reminder: LearningReminder,
+    priority: Option<u8>,
+    updated_at: String,
+}
+
+fn search_learning_reminders(
+    host: &dyn McpHost,
+    paths: &[String],
+    caps: LearningInjectionCaps,
+) -> Result<Vec<LearningReminder>, OrbitError> {
+    let mut by_id: BTreeMap<String, ReminderCandidate> = BTreeMap::new();
+    for path in paths {
+        let value = host.call_tool(
+            "orbit.learning.search",
+            json!({
+                "path": path,
+                "limit": caps.per_call,
+            }),
+        )?;
+        for candidate in parse_learning_search_candidates(&value) {
+            by_id
+                .entry(candidate.reminder.id.clone())
+                .or_insert(candidate);
+        }
+    }
+    let mut candidates: Vec<_> = by_id.into_values().collect();
+    candidates.sort_by(|a, b| {
+        priority_rank(b.priority)
+            .cmp(&priority_rank(a.priority))
+            .then_with(|| b.updated_at.cmp(&a.updated_at))
+            .then_with(|| a.reminder.id.cmp(&b.reminder.id))
+    });
+    candidates.truncate(caps.per_call);
+    Ok(candidates
+        .into_iter()
+        .map(|candidate| candidate.reminder)
+        .collect())
+}
+
+fn parse_learning_search_candidates(value: &Value) -> Vec<ReminderCandidate> {
+    let items = value
+        .as_array()
+        .or_else(|| value.get("items").and_then(Value::as_array))
+        .into_iter()
+        .flatten();
+    items
+        .filter_map(|item| {
+            let id = item.get("id").and_then(Value::as_str)?.to_string();
+            let summary = item.get("summary").and_then(Value::as_str)?.to_string();
+            let priority = item
+                .get("priority")
+                .and_then(Value::as_u64)
+                .and_then(|value| u8::try_from(value).ok());
+            let updated_at = item
+                .get("updated_at")
+                .and_then(Value::as_str)
+                .unwrap_or_default()
+                .to_string();
+            Some(ReminderCandidate {
+                reminder: LearningReminder { id, summary },
+                priority,
+                updated_at,
+            })
+        })
+        .collect()
+}
+
+fn priority_rank(priority: Option<u8>) -> i16 {
+    priority.map(i16::from).unwrap_or(-1)
+}
+
+fn attach_learning_sidecar(mut value: Value, reminders: Vec<LearningReminder>) -> Value {
+    if reminders.is_empty() {
+        return value;
+    }
+    let sidecar = Value::Array(
+        reminders
+            .into_iter()
+            .map(|reminder| {
+                json!({
+                    "id": reminder.id,
+                    "summary": reminder.summary,
+                })
+            })
+            .collect(),
+    );
+    match &mut value {
+        Value::Object(object) => {
+            object.insert("learnings".to_string(), sidecar);
+            value
+        }
+        _ => json!({
+            "result": value,
+            "learnings": sidecar,
+        }),
     }
 }
 
@@ -361,6 +697,8 @@ fn property_for(param_type: &str) -> Map<String, Value> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Mutex as StdMutex;
+
     use serde_json::json;
 
     fn param_with_type(name: &str, param_type: &str) -> ToolParam {
@@ -383,6 +721,16 @@ mod tests {
             parameters: Vec::new(),
             builtin: true,
         }
+    }
+
+    fn request_with_args(name: &str, args: Value) -> CallToolRequestParams {
+        CallToolRequestParams::new(sanitize_tool_name(name)).with_arguments(
+            args.as_object()
+                .expect("object args")
+                .iter()
+                .map(|(key, value)| (key.clone(), value.clone()))
+                .collect(),
+        )
     }
 
     #[test]
@@ -649,6 +997,235 @@ mod tests {
                     .any(|schema| schema.get("type").and_then(Value::as_str) == Some("string")),
                 "{tool_name} dependencies must accept a string"
             );
+        }
+    }
+
+    #[tokio::test]
+    async fn learning_sidecar_present_with_summary_only_on_path_match() {
+        let mut search_by_path = HashMap::new();
+        search_by_path.insert(
+            "crates/orbit-engine/src/lib.rs".to_string(),
+            vec![json!({
+                "id": "L20260515-0001",
+                "summary": "Remember the engine rule.",
+                "body": "full body must stay out",
+                "updated_at": "2026-05-15T00:00:00Z",
+                "priority": 7
+            })],
+        );
+        let host = Arc::new(LearningSidecarHost::new(
+            json!({
+                "code_refs": [{"file": "crates/orbit-engine/src/lib.rs"}]
+            }),
+            search_by_path,
+        ));
+        let server = OrbitToolServer::new_for_test(
+            host,
+            None,
+            LearningInjectionCaps::default(),
+            LearningInjectionState::default(),
+        );
+
+        let result = server
+            .call_tool_request(request_with_args(
+                "orbit.graph.show",
+                json!({"selector": "file:crates/orbit-engine/src/lib.rs"}),
+            ))
+            .await
+            .expect("call succeeds");
+        let structured = result
+            .structured_content
+            .as_ref()
+            .expect("structured content");
+
+        assert_eq!(
+            structured.get("learnings"),
+            Some(&json!([{
+                "id": "L20260515-0001",
+                "summary": "Remember the engine rule."
+            }]))
+        );
+        assert!(
+            !serde_json::to_string(structured)
+                .expect("json")
+                .contains("full body")
+        );
+    }
+
+    #[tokio::test]
+    async fn learning_sidecar_absent_when_no_learning_matches() {
+        let mut search_by_path = HashMap::new();
+        search_by_path.insert("crates/orbit-engine/src/lib.rs".to_string(), Vec::new());
+        let host = Arc::new(LearningSidecarHost::new(
+            json!({
+                "code_refs": [{"file": "crates/orbit-engine/src/lib.rs"}]
+            }),
+            search_by_path,
+        ));
+        let server = OrbitToolServer::new_for_test(
+            host,
+            None,
+            LearningInjectionCaps::default(),
+            LearningInjectionState::default(),
+        );
+
+        let result = server
+            .call_tool_request(request_with_args(
+                "orbit.graph.refs",
+                json!({"selector": "file:crates/orbit-engine/src/lib.rs"}),
+            ))
+            .await
+            .expect("call succeeds");
+        let structured = result
+            .structured_content
+            .as_ref()
+            .expect("structured content");
+
+        assert!(structured.get("learnings").is_none());
+    }
+
+    #[tokio::test]
+    async fn l1_seeded_learning_is_suppressed_by_l2_dedup_state() {
+        let mut search_by_path = HashMap::new();
+        search_by_path.insert(
+            "crates/orbit-engine/src/lib.rs".to_string(),
+            vec![json!({
+                "id": "L20260515-0001",
+                "summary": "Already injected at L1.",
+                "updated_at": "2026-05-15T00:00:00Z",
+                "priority": null
+            })],
+        );
+        let host = Arc::new(LearningSidecarHost::new(
+            json!({
+                "context_files": ["file:crates/orbit-engine/src/lib.rs"]
+            }),
+            search_by_path,
+        ));
+        let initial_state = LearningInjectionState::seeded(["L20260515-0001".to_string()]);
+        let server = OrbitToolServer::new_for_test(
+            host,
+            None,
+            LearningInjectionCaps::default(),
+            initial_state,
+        );
+
+        let result = server
+            .call_tool_request(request_with_args(
+                "orbit.task.show",
+                json!({"id": "ORB-00009"}),
+            ))
+            .await
+            .expect("call succeeds");
+        let structured = result
+            .structured_content
+            .as_ref()
+            .expect("structured content");
+
+        assert!(structured.get("learnings").is_none());
+        let states = server.learning_states.lock().await;
+        let state = states.get(PROCESS_LEARNING_SESSION_KEY).expect("state");
+        assert_eq!(state.count, 1);
+        assert!(state.emitted_ids.contains("L20260515-0001"));
+    }
+
+    #[tokio::test]
+    async fn learning_sidecar_enforces_per_session_hard_cap() {
+        let mut search_by_path = HashMap::new();
+        for call_idx in 0..5 {
+            let path = format!("p{call_idx}.rs");
+            let rows: Vec<_> = (0..5)
+                .map(|row_idx| {
+                    let id_idx = call_idx * 5 + row_idx;
+                    json!({
+                        "id": format!("L20260515-{id_idx:04}"),
+                        "summary": format!("Learning {id_idx}"),
+                        "updated_at": "2026-05-15T00:00:00Z",
+                        "priority": null
+                    })
+                })
+                .collect();
+            search_by_path.insert(path, rows);
+        }
+        let host = Arc::new(LearningSidecarHost::new(json!({}), search_by_path));
+        let server = OrbitToolServer::new_for_test(
+            host,
+            None,
+            LearningInjectionCaps {
+                per_call: 5,
+                per_session_hard: 20,
+            },
+            LearningInjectionState::default(),
+        );
+        let mut emitted = 0usize;
+
+        for call_idx in 0..5 {
+            let result = server
+                .call_tool_request(request_with_args(
+                    "orbit.graph.show",
+                    json!({"selector": format!("file:p{call_idx}.rs")}),
+                ))
+                .await
+                .expect("call succeeds");
+            let structured = result
+                .structured_content
+                .as_ref()
+                .expect("structured content");
+            emitted += structured
+                .get("learnings")
+                .and_then(Value::as_array)
+                .map(Vec::len)
+                .unwrap_or_default();
+        }
+
+        assert_eq!(emitted, 20);
+        let states = server.learning_states.lock().await;
+        let state = states.get(PROCESS_LEARNING_SESSION_KEY).expect("state");
+        assert_eq!(state.count, 20);
+        assert_eq!(state.emitted_ids.len(), 20);
+    }
+
+    struct LearningSidecarHost {
+        response: Value,
+        search_by_path: HashMap<String, Vec<Value>>,
+        calls: StdMutex<Vec<String>>,
+    }
+
+    impl LearningSidecarHost {
+        fn new(response: Value, search_by_path: HashMap<String, Vec<Value>>) -> Self {
+            Self {
+                response,
+                search_by_path,
+                calls: StdMutex::new(Vec::new()),
+            }
+        }
+    }
+
+    impl crate::McpHost for LearningSidecarHost {
+        fn list_tool_schemas(&self) -> Vec<ToolSchema> {
+            vec![
+                tool_schema("orbit.graph.show"),
+                tool_schema("orbit.graph.refs"),
+                tool_schema("orbit.task.show"),
+                tool_schema("orbit.learning.search"),
+            ]
+        }
+
+        fn call_tool(&self, name: &str, input: Value) -> Result<Value, OrbitError> {
+            self.calls
+                .lock()
+                .expect("calls lock")
+                .push(name.to_string());
+            if name == "orbit.learning.search" {
+                let path = input
+                    .get("path")
+                    .and_then(Value::as_str)
+                    .unwrap_or_default();
+                return Ok(Value::Array(
+                    self.search_by_path.get(path).cloned().unwrap_or_default(),
+                ));
+            }
+            Ok(self.response.clone())
         }
     }
 }

--- a/docs/design/project-learnings/1_overview.md
+++ b/docs/design/project-learnings/1_overview.md
@@ -2,7 +2,7 @@
 
 **Status:** Draft
 **Owner:** claude
-**Last updated:** 2026-05-09
+**Last updated:** 2026-05-15
 
 Project learnings is a system for preserving and surfacing non-obvious project knowledge — gotchas, root causes from incidents, validated approaches, hard-won workflow insights — at the moment of action so agents stop repeating the same mistakes. The system is **push-first**: relevant learnings inject into agent context automatically when an agent is about to touch code, files, or workflows the learning applies to. A pull surface exists for active exploration, but pull is the secondary mode.
 

--- a/docs/design/project-learnings/2_design.md
+++ b/docs/design/project-learnings/2_design.md
@@ -2,7 +2,7 @@
 
 **Status:** Draft
 **Owner:** claude
-**Last updated:** 2026-05-12
+**Last updated:** 2026-05-15
 
 This document specifies phase-1 project-learnings: the placement of learning storage in `orbit-store`, the schema of a learning record, the phase-1 scope-matching algorithm (path globs + tags), the three-layer push-injection pipeline (engine pre-prompt + MCP sidecar + optional Claude Code hook), the pull surface (skill + tools), the curation lifecycle, and the concerns the design deliberately leaves to follow-ups.
 
@@ -31,7 +31,7 @@ orbit-store/
 
 The third push layer — a Claude Code `PreToolUse` hook on `Edit | Write | Read` — is not part of any Orbit crate; it ships as a hook configuration in [.claude/settings.json](../../../.claude/settings.json) (or whichever scope is appropriate; see [§4.3](#43-layer-3-claude-code-pretooluse-hook-optional)).
 
-No cross-crate dependencies that violate the architecture diagram in [CLAUDE.md](../../../CLAUDE.md) are introduced. The dependency edges added are `orbit-store` (extended internally), `orbit-tools → orbit-store` (already present), `orbit-engine → orbit-store` (already present via task storage), and `orbit-mcp → orbit-store` (already present).
+No cross-crate dependencies that violate the architecture diagram in [CLAUDE.md](../../../CLAUDE.md) are introduced. The dependency edges added are `orbit-store` (extended internally), `orbit-tools → orbit-store` (already present), and `orbit-engine → orbit-store` (already present). `orbit-mcp` remains a transport adapter that depends only on `orbit-common`; Layer 2 asks the injected host to run `orbit.learning.search` instead of reading the learning store directly.
 
 ---
 
@@ -214,9 +214,11 @@ A naive implementation injects the same learning multiple times across layers (e
 
 - The agent process tracks injected learning IDs in a per-session set.
 - Each layer consults the set before emitting a `<system-reminder>`; already-injected IDs are skipped.
-- Per-call cap of **5** learnings (configurable). Hard cap of **20** per session to bound total context cost.
+- Per-call cap of **5** learnings (configurable via `ORBIT_LEARNING_PER_CALL_CAP`). Hard cap of **20** per session (configurable via `ORBIT_LEARNING_SESSION_CAP`) to bound total context cost.
 
 Implementation note: the per-session set lives in the agent's working memory. The Orbit-side store does not need to track session state; it just provides idempotent search. Layers consult the set; the store is stateless.
+
+Cross-process deduplication is best-effort via `ORBIT_SESSION_ID` plus `.orbit/state/sessions/<id>/learnings.json`. In-process Layer 1 + Layer 2 dedup is exact; when Layer 2 or Layer 3 runs without `ORBIT_SESSION_ID` (for example, an `orbit-mcp` server started outside an engine-spawned session, or a Claude session not initiated through Orbit), they fall back to per-process state and may double-emit. The dedup layer is belt-and-braces; the agent's own context window remains the practical backstop.
 
 ### 4.5 What gets injected
 

--- a/docs/design/project-learnings/4_decisions.md
+++ b/docs/design/project-learnings/4_decisions.md
@@ -2,7 +2,7 @@
 
 **Status:** Draft
 **Owner:** claude
-**Last updated:** 2026-05-11
+**Last updated:** 2026-05-15
 
 ADR-style log of non-obvious project-learnings decisions. Each entry names the pressure, the choice, and the tradeoff. Entries are append-only and keyed by number; superseded entries are marked, not deleted.
 
@@ -12,7 +12,7 @@ Format for each entry: **Status · Date · Task(s)**, then *Context → Decision
 
 ## ADR-001 — Push-based discovery via context injection, not pull-only via search
 
-**Status:** Proposed · 2026-05 · [T20260510-11]
+**Status:** Accepted · 2026-05 · [T20260510-11] · [ORB-00009]
 
 **Context.** Three classes of discovery were on the table:
 
@@ -117,7 +117,7 @@ Phase 2 ([3_vision.md §1.1](./3_vision.md), [§1.2](./3_vision.md)) layers symb
 
 ## ADR-005 — Three-layer push pipeline (engine pre-prompt + MCP sidecar + Claude Code hook), not single-layer
 
-**Status:** Proposed · 2026-05 · [T20260510-11]
+**Status:** Accepted · 2026-05 · [T20260510-11] · [ORB-00009]
 
 **Context.** The push-injection layer ([2_design.md §4](./2_design.md)) has multiple natural placements, each with different coverage:
 


### PR DESCRIPTION
## Task

[ORB-00009](https://orbit-cli.com/tasks/ORB-00009) — Wire push-injection pipeline for project-learnings (Layers 1–3)

### Description

## Problem

Phase 1's primary discovery surface — push-injection of relevant learnings into agent context — is unbuilt. The tool surface (`orbit.learning.*`) and host-side dispatch (`crates/orbit-core/src/runtime/orbit_tool_host/learning_tools.rs`) exist, but the three injection layers specified in [docs/design/project-learnings/2_design.md §4](docs/design/project-learnings/2_design.md) do not.

## Why It Matters

[docs/design/project-learnings/1_overview.md:23](docs/design/project-learnings/1_overview.md:23) names pull-only systems as the failure mode the project-learnings system is explicitly built to prevent: *"if discovery depends on agent discipline, the agent that needed the learning most — the one that forgot it existed — won't find it."* The sibling task creates the pull-side skill; this task delivers the headline value.

## Constraints / Notes

- **Three layers, per design §4.1–§4.3:**
  - **L1 — Engine pre-prompt (universal).** Before `orbit-engine` spawns an agent runtime for a task, query `orbit.learning.search` with the union of (paths from `task.context_files`) and (`task.tags`). Take top-K (default 5). Prepend a `<system-reminder>` block of `id + summary` lines to the agent prompt, formatted per §4.1.
  - **L2 — MCP sidecar (cross-agent).** `orbit-mcp` attaches a `learnings: [...]` sidecar field to responses of path-bearing tools (`orbit_graph_show`, `orbit_graph_refs`, `orbit_task_show`, etc.) per §4.2.
  - **L3 — Claude Code PreToolUse hook (Claude-only).** A `PreToolUse` hook in `.claude/settings.json` on `Edit | Write | Read` extracts the target path, calls `orbit learning search --path <path>`, and emits a `<system-reminder>` to the agent per §4.3.

- **Budget & dedup (§4.4):** Per-call cap 5; per-session hard cap 20; per-session ID dedup set lives in agent working memory (Orbit-side store is stateless re: session dedup).

- **What gets injected (§4.5):** `summary` only. Never `body`. Bodies load on demand via `orbit.learning.show`.

- **Prerequisite check:** `Task.tags` already exists (`crates/orbit-common/src/types/task.rs:609`). No schema prerequisite blocker.

- **Reuse, don't reimplement:** Use the same glob matcher `orbit-policy` uses (§3.1) for path scope matching. The shared implementation lives at `crates/orbit-common/src/utility/glob.rs` (`normalize_glob_path`, `match_glob`) — `orbit-policy` and `orbit-store::learning_store` both consume it.

- **Architecture:** No new cross-crate dependency edges. `orbit-engine → orbit-store` already exists. **`orbit-mcp → orbit-store` does NOT exist** and is forbidden by [ARCHITECTURE.md](ARCHITECTURE.md) ("orbit-mcp: Model Context Protocol adapter using rmcp. Depends only on orbit-common"). L2 must therefore go through `McpHost::call_tool("orbit.learning.search", ...)` rather than a direct store call.

- **Out of scope:** Phase-2 symbol-aware scope, semantic ranking, knowledge-graph-triggered staleness, auto-extraction from review threads or postmortems.

### Acceptance Criteria

- L1 (positive): when `orbit-engine` spawns an agent for a task whose `context_files` paths or `tags` match an active learning, the agent prompt is prepended with a `<system-reminder>` block listing `id + summary` for each match (up to 5), exactly matching the format shown in §4.1. Verified via unit test in `crates/orbit-engine/`.
- L1 (negative): when no active learning matches the task's `context_files` paths or `tags`, the agent prompt is byte-for-byte identical to the no-learnings baseline (no empty `<system-reminder>` block). Verified via unit test.
- L2: responses from `orbit_graph_show`, `orbit_graph_refs`, and `orbit_task_show` carry a top-level `learnings: [{id, summary}, ...]` field when at least one active learning's `scope.paths` glob matches a path in the request or response. Field is absent (not an empty array) when there is no match. Verified via integration test in `crates/orbit-mcp/`.
- L3: `.claude/settings.json` contains a `PreToolUse` hook registered for `Edit`, `Write`, and `Read` that invokes a script which calls `orbit learning search --path <target>` and prints a `<system-reminder>` block to stdout. The hook is exercised end-to-end in a Claude Code session and the transcript is included in the execution summary.
- Per-session dedup: an integration test demonstrates that when the same learning would be injected by both L1 and L2 in a single agent session, the second injection is suppressed (the `<system-reminder>` is emitted exactly once). Test asserts the dedup set's behavior, not just byte counts.
- Per-call cap: an integration test with 7 matching active learnings asserts that exactly 5 are injected at L1 (default cap). Cap is configurable via a documented setting.
- Per-session hard cap: an integration test simulates 25 distinct matching learnings across multiple tool calls in one session and asserts that no more than 20 distinct learning IDs ever appear in injected `<system-reminder>` output.
- Body suppression: across all three layers' integration tests, assert that no injected `<system-reminder>` block, MCP sidecar entry, or hook output contains the learning's `body` field. Only `id` and `summary` are emitted.
- Glob matcher reuse: L1 and L2 import the path-glob implementation from `orbit-policy` (or the shared utility it depends on). No new glob implementation is introduced. Verified by grep for new glob crates in `Cargo.toml` diffs and by reviewer inspection.
- Design doc ADRs flipped: in `docs/design/project-learnings/4_decisions.md`, ADR-001 (push injection) and ADR-005 (3-layer pipeline) statuses move from Proposed → Accepted, each annotated with this task's ORB ID. `**Last updated:**` on `1_overview.md`, `2_design.md`, and `4_decisions.md` is bumped to the implementation date.
- `make ci` passes (fmt, clippy `-D warnings`, full workspace tests, dependency-direction check, CLI-imports check, stability check).

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Added shared learning reminder rendering, caps, per-session dedup state, and locked session-state file helpers in `orbit-common`.
- Wired Layer 1 through `V2RuntimeHost`: task context now carries tags, engine HTTP prompts and CLI envelopes get summary-only `<system-reminder>` blocks, and CLI children receive `ORBIT_SESSION_ID` for cross-process dedup.
- Wired Layer 2 in `orbit-mcp` for `orbit.graph.show`, `orbit.graph.refs`, and `orbit.task.show`; sidecars are summary-only, absent on no match, and respect per-call/per-session caps with L1-seeded dedup.
- Added the Claude Code `PreToolUse` hook and `.claude/settings.json` registration for `Edit|Write|Read`; the hook calls `orbit learning search --path`, emits summary-only reminders, and uses the shared session file when `ORBIT_SESSION_ID` is present.
- Updated project-learnings docs and accepted ADR-001/ADR-005 for ORB-00009.

Validation:
- `cargo test -p orbit-common -p orbit-engine -p orbit-core -p orbit-mcp --lib` passed.
- `cargo clippy -p orbit-common -p orbit-engine -p orbit-core -p orbit-mcp --all-targets -- -D warnings` passed.
- `make ci-fast` passed.
- Hook transcript from an end-to-end PreToolUse-style invocation with a prepared fake `ORBIT_BIN`:
  `<system-reminder>` / `Project learnings relevant to this task:` / `- [L20260515-0001] Hook surfaced this summary.` / `Read full body via `orbit.learning.show <id>` if needed.` / `</system-reminder>`; the fake search result included `body: "secret body"`, and the emitted text did not include it.
- `make check-design-docs` failed on pre-existing stale docs outside this task: `docs/design/activity-job/1_overview.md`, `docs/design/activity-job/2_design.md`, `docs/design/auditability/1_overview.md`, and `docs/design/knowledge-graph/specs/leaf-id-uniqueness.md`.
- `make ci` failed for the same unrelated design-check golden mismatch in `crates/orbit-cli/tests/design_check.rs`; all earlier clippy/test work reached that gate cleanly.

Assessment: Scoped implementation is complete and locally validated except for the repository's unrelated stale-design-doc blocker. I did not broaden the diff to fake-refresh unrelated design docs.

Deviations from original plan:
- Layer 2 uses `orbit.learning.search` through the MCP host as planned, with the shared `orbit-common` session file helper instead of local `fs2` code in `orbit-mcp` so the crate keeps its internal dependency boundary.
- The hook was exercised with a PreToolUse payload and fake `ORBIT_BIN` rather than a live Claude Code UI session, because this execution environment does not expose an interactive Claude Code session.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-00009-6a06910a`
- Behind base: 0
- Ahead of base: 1

*authored by: claude-opus-4-7*