### PR TITLE
Fix leaked & double-dotted task-bundle create-lock files

### DIFF
--- a/crates/orbit-store/src/file/task_store/v2_bundle.rs
+++ b/crates/orbit-store/src/file/task_store/v2_bundle.rs
@@ -83,9 +83,28 @@ impl TaskBundleStoreV2 {
     ) -> Result<TaskBundleCreateResult, OrbitError> {
         let task_id = bundle.envelope.id.clone();
         let bundle_dir = self.bundle_path(&task_id)?;
-        let create_lock_path = create_lock_path(&bundle_dir, &task_id)?;
-        with_exclusive_file_lock(&create_lock_path, "task bundle create", || {
-            self.create_bundle_locked(&task_id, &bundle_dir, bundle)
+        let lock_sentinel_path = task_bundle_lock_sentinel_path(&bundle_dir)?;
+        with_exclusive_file_lock(&bundle_dir, "task bundle create", || {
+            let result = self.create_bundle_locked(&task_id, &bundle_dir, bundle);
+            match (
+                result,
+                remove_task_bundle_lock_sentinel(&lock_sentinel_path),
+            ) {
+                (Ok(created), Ok(())) => Ok(created),
+                (Err(err), Ok(())) => Err(err),
+                (Ok(_), Err(cleanup_err)) => Err(cleanup_err),
+                (Err(err), Err(cleanup_err)) => {
+                    orbit_common::tracing::warn!(
+                        target: "orbit.store.task_bundle_v2",
+                        task_id,
+                        lock_path = %lock_sentinel_path.display(),
+                        original_error = %err,
+                        cleanup_error = %cleanup_err,
+                        "failed to clean up task bundle lock sentinel",
+                    );
+                    Err(err)
+                }
+            }
         })
     }
 
@@ -258,14 +277,25 @@ impl TaskBundleStoreV2 {
     }
 }
 
-fn create_lock_path(bundle_dir: &Path, task_id: &str) -> Result<PathBuf, OrbitError> {
-    let parent = bundle_dir.parent().ok_or_else(|| {
-        OrbitError::Store(format!(
-            "task bundle path {} has no parent directory",
-            bundle_dir.display()
-        ))
-    })?;
-    Ok(parent.join(format!(".{task_id}.create")))
+fn task_bundle_lock_sentinel_path(bundle_dir: &Path) -> Result<PathBuf, OrbitError> {
+    let file_name = bundle_dir
+        .file_name()
+        .and_then(|value| value.to_str())
+        .ok_or_else(|| {
+            OrbitError::Store(format!(
+                "task bundle path {} has no file name",
+                bundle_dir.display()
+            ))
+        })?;
+    Ok(bundle_dir.with_file_name(format!(".{file_name}.lock")))
+}
+
+fn remove_task_bundle_lock_sentinel(lock_path: &Path) -> Result<(), OrbitError> {
+    match fs::remove_file(lock_path) {
+        Ok(()) => Ok(()),
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(err) => Err(OrbitError::Io(err.to_string())),
+    }
 }
 
 fn ensure_projection_entry_removable(
@@ -990,6 +1020,34 @@ mod tests {
         TaskBundleStoreV2::new(registry, binding.workspace_id, orbit_dir)
     }
 
+    fn task_lock_path(bundle_dir: &Path) -> PathBuf {
+        let file_name = bundle_dir
+            .file_name()
+            .and_then(|value| value.to_str())
+            .expect("bundle path has file name");
+        bundle_dir.with_file_name(format!(".{file_name}.lock"))
+    }
+
+    fn legacy_double_dot_lock_path(bundle_dir: &Path, task_id: &str) -> PathBuf {
+        bundle_dir.with_file_name(format!("..{task_id}.create.lock"))
+    }
+
+    fn lock_entries_for_task(tasks_dir: &Path, task_id: &str) -> Vec<String> {
+        let mut entries = fs::read_dir(tasks_dir)
+            .expect("read task workspace dir")
+            .map(|entry| {
+                entry
+                    .expect("read task workspace entry")
+                    .file_name()
+                    .to_string_lossy()
+                    .into_owned()
+            })
+            .filter(|name| name.contains(task_id) && name.ends_with(".lock"))
+            .collect::<Vec<_>>();
+        entries.sort();
+        entries
+    }
+
     #[test]
     fn write_and_read_bundle_round_trips_v2_shape() {
         let temp = TempDir::new().expect("tempdir");
@@ -1052,6 +1110,92 @@ mod tests {
                 .join(TASK_REVIEW_THREADS_DIR_NAME)
                 .join("RT-0001.md")
                 .is_file()
+        );
+    }
+
+    #[test]
+    fn create_bundle_removes_lock_sentinel_after_success() {
+        let temp = TempDir::new().expect("tempdir");
+        let store = bundle_store(&temp);
+        let bundle_dir = store.bundle_path("ORB-00000").expect("bundle path");
+        let tasks_dir = bundle_dir.parent().expect("bundle parent");
+
+        let created = store
+            .create_bundle(&sample_bundle("ORB-00000"))
+            .expect("create bundle");
+
+        assert_eq!(created.binding.task_id, "ORB-00000");
+        assert!(bundle_dir.is_dir());
+        assert_eq!(
+            lock_entries_for_task(tasks_dir, "ORB-00000"),
+            Vec::<String>::new()
+        );
+        assert!(!task_lock_path(&bundle_dir).exists());
+        assert!(!legacy_double_dot_lock_path(&bundle_dir, "ORB-00000").exists());
+    }
+
+    #[derive(Debug, PartialEq, Eq)]
+    enum CreateOutcome {
+        Created,
+        AlreadyExists,
+        Unexpected(String),
+    }
+
+    #[test]
+    fn create_bundle_serializes_concurrent_duplicate_creators() {
+        let temp = TempDir::new().expect("tempdir");
+        let store = Arc::new(bundle_store(&temp));
+        let bundle = Arc::new(sample_bundle("ORB-00000"));
+        let bundle_dir = store.bundle_path("ORB-00000").expect("bundle path");
+        let tasks_dir = bundle_dir.parent().expect("bundle parent").to_path_buf();
+        let barrier = Arc::new(Barrier::new(2));
+        let handles = (0..2)
+            .map(|_| {
+                let store = Arc::clone(&store);
+                let bundle = Arc::clone(&bundle);
+                let barrier = Arc::clone(&barrier);
+                thread::spawn(move || {
+                    barrier.wait();
+                    match store.create_bundle(bundle.as_ref()) {
+                        Ok(_) => CreateOutcome::Created,
+                        Err(OrbitError::Store(message)) if message.contains("already exists") => {
+                            CreateOutcome::AlreadyExists
+                        }
+                        Err(err) => CreateOutcome::Unexpected(err.to_string()),
+                    }
+                })
+            })
+            .collect::<Vec<_>>();
+
+        let outcomes = handles
+            .into_iter()
+            .map(|handle| handle.join().expect("join creator"))
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            outcomes
+                .iter()
+                .filter(|outcome| matches!(outcome, CreateOutcome::Created))
+                .count(),
+            1
+        );
+        assert_eq!(
+            outcomes
+                .iter()
+                .filter(|outcome| matches!(outcome, CreateOutcome::AlreadyExists))
+                .count(),
+            1
+        );
+        assert!(
+            !outcomes
+                .iter()
+                .any(|outcome| matches!(outcome, CreateOutcome::Unexpected(_))),
+            "unexpected outcomes: {outcomes:?}"
+        );
+        assert!(bundle_dir.is_dir());
+        assert_eq!(
+            lock_entries_for_task(&tasks_dir, "ORB-00000"),
+            Vec::<String>::new()
         );
     }
 
@@ -1337,15 +1481,22 @@ mod tests {
     }
 
     #[test]
-    fn create_bundle_cleans_partial_directory_on_validation_error() {
+    fn create_bundle_cleans_partial_directory_and_lock_on_validation_error() {
         let temp = TempDir::new().expect("tempdir");
         let store = bundle_store(&temp);
         let mut bundle = sample_bundle("ORB-00000");
         bundle.envelope.title = " ".to_string();
         let bundle_path = store.bundle_path("ORB-00000").expect("bundle path");
+        let tasks_dir = bundle_path.parent().expect("bundle parent").to_path_buf();
 
         assert!(store.create_bundle(&bundle).is_err());
         assert!(!bundle_path.exists());
+        assert_eq!(
+            lock_entries_for_task(&tasks_dir, "ORB-00000"),
+            Vec::<String>::new()
+        );
+        assert!(!task_lock_path(&bundle_path).exists());
+        assert!(!legacy_double_dot_lock_path(&bundle_path, "ORB-00000").exists());
     }
 
     #[test]


### PR DESCRIPTION
## Task

[ORB-00033](https://orbit-cli.com/tasks/ORB-00033) — Fix leaked & double-dotted task-bundle create-lock files

### Description

## Problem

Every call to `TaskBundleStoreV2::create_bundle` leaves a zero-byte sentinel file behind in the workspace's tasks directory, and the filename has an unintended double-dot prefix.

Example, after creating 33 tasks in workspace `orbit-8fb91e`:

```
$ ls -A /Users/daniel/.orbit/tasks/workspaces/orbit-8fb91e/ | grep 'create\.lock$' | wc -l
33
$ ls -A /Users/daniel/.orbit/tasks/workspaces/orbit-8fb91e/ | grep 'create\.lock$' | head -3
..ORB-00000.create.lock
..ORB-00001.create.lock
..ORB-00002.create.lock
```

Two distinct defects compound:

1. **Naming (cosmetic).** [`create_lock_path`](crates/orbit-store/src/file/task_store/v2_bundle.rs:261-269) returns `.{task_id}.create` (already dot-prefixed). It then passes that path to [`with_exclusive_file_lock`](crates/orbit-common/src/utility/fs.rs:219), whose [`lock_path_for`](crates/orbit-common/src/utility/fs.rs:249-257) treats its argument as a *target* and synthesises a sibling lock by prepending `.` and appending `.lock`. The two prefixes stack → `..ORB-XXXXX.create.lock`.

2. **Leak.** `with_exclusive_file_lock` releases the OS `flock` when the file handle drops but never `unlink`s the sentinel file. So each `create_bundle` call leaves a permanent zero-byte file. Files accumulate linearly with task count per workspace.

## Why It Matters

- Workspace tasks directories grow unboundedly with cruft (one file per task ever created), which is confusing to humans inspecting the on-disk layout and noisy in `ls`.
- The double-dot naming makes the locks look like a bug rather than an intentional advisory-lock convention.
- Neither issue is currently a correctness problem — locks still serialize correctly — but both are signs of layered conventions that don't compose, and they make the on-disk state hard to reason about.

## Proposed Fix

Change `create_bundle` to pass `bundle_dir` itself (not a pre-dotted variant) as the target to `with_exclusive_file_lock`. The helper's own `lock_path_for` will then produce `.ORB-XXXXX.lock` — a single-dotted sibling of the bundle directory — which is exactly the convention `with_exclusive_file_lock` is designed for.

For the leak: unlink the lock file from **inside** the locked closure on success, before the file handle drops. This is safe because `create_bundle_locked` already short-circuits when `bundle_dir.exists()` — any racing creator that re-creates the lock file path after our unlink will simply hit the "task bundle already exists" branch and error correctly. The lock is belt-and-suspenders on top of the directory-existence check, so it's fine to delete the sentinel file.

Delete `create_lock_path` and its call site once `bundle_dir` is the target.

## Constraints / Notes

- The lock helper API in `orbit-common` does not need to change; this is fully fixable inside `v2_bundle.rs`.
- Must not regress concurrent-creator serialization — two simultaneous `create_bundle` calls for the same `task_id` must still produce exactly one bundle and one "already exists" error, not two bundles or two errors.
- One-time cleanup of existing `..ORB-*.create.lock` files in already-populated workspaces is out of scope; they're harmless and users can `rm` them at will. If a cleanup step is desired, file a separate follow-up.
- No migration of stored task data; this only touches sentinel files.

### Acceptance Criteria

- After calling `TaskBundleStoreV2::create_bundle` for a new task ID `ORB-XXXXX`, the workspace tasks directory contains the bundle directory `ORB-XXXXX/` and NO sentinel file with a name matching `*ORB-XXXXX*.lock` (verifiable via `ls -A <workspace_tasks_dir>`).
- The previous filename `..{task_id}.create.lock` no longer appears anywhere on disk after `create_bundle`. If any lock file appears transiently during the call, it must be named `.{task_id}.lock` (single leading dot, no `.create` infix) and must be removed before `create_bundle` returns `Ok`.
- `create_bundle` continues to serialize concurrent creators of the same task ID: a new unit or integration test in `crates/orbit-store/src/file/task_store/` spawns two threads each calling `create_bundle` with the same `TaskBundleV2`, joins them, and asserts that exactly one returns `Ok(TaskBundleCreateResult)` and the other returns `Err(OrbitError::Store(_))` with message containing `already exists`.
- `create_lock_path` in `crates/orbit-store/src/file/task_store/v2_bundle.rs` is removed (or repurposed) — `grep -n 'create_lock_path' crates/orbit-store/src/file/task_store/v2_bundle.rs` returns no matches, or only matches a renamed helper whose return value is now `bundle_dir` itself.
- `make ci` passes (workspace `cargo clippy --all-targets -- -D warnings` and full test suite).
- On an error path inside `create_bundle_locked` (e.g. `write_bundle_at` fails), the lock file is still cleaned up — verified by a test that injects a write failure via a fake filesystem or by constructing a bundle path whose parent is read-only, then asserts no `.{task_id}.lock` remains afterward. If cleanup-on-error is judged too invasive for this task, the AC may be downgraded to a `// TODO` comment naming a follow-up task ID, with reviewer sign-off.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- TaskBundleStoreV2::create_bundle now locks on the bundle directory target so the helper creates .ORB-XXXXX.lock, then removes that sentinel from inside the locked closure before returning.
- Removed the old pre-dotted create-lock helper and added focused regression coverage for success cleanup, duplicate concurrent creators, and cleanup after a write validation failure.

Assessment: The change is scoped to orbit-store task bundle creation and preserves duplicate-create serialization while preventing lock sentinel files from surviving create_bundle.

Validation:
- cargo fmt --check
- cargo test -p orbit-store file::task_store::v2_bundle
- cargo test -p orbit-store
- cargo clippy -p orbit-store --all-targets -- -D warnings
- make ci-fast
- rg -n create_lock_path crates/orbit-store/src/file/task_store/v2_bundle.rs returned no matches

Deviations from original plan:
- Full make ci was not run locally because project instructions reserve it for the PR CI gate; package tests, targeted clippy, and make ci-fast passed locally.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-00033-6a0694dc`
- Behind base: 0
- Ahead of base: 1

*authored by: claude-opus-4-7*