### PR TITLE
PR body "authored by" falls back to created_by; embed implementer instead

### DIFF
--- a/crates/orbit-core/src/runtime/engine/runtime_host.rs
+++ b/crates/orbit-core/src/runtime/engine/runtime_host.rs
@@ -164,6 +164,13 @@ impl RuntimeHost for OrbitRuntime {
         self.context.graph_editing()
     }
 
+    fn actor_model_identity(&self) -> Option<String> {
+        matches!(self.actor().kind, crate::context::ActorKind::Agent)
+            .then(|| self.actor_label().trim())
+            .filter(|label| !label.is_empty())
+            .map(ToOwned::to_owned)
+    }
+
     fn pr_config(&self) -> orbit_engine::PrConfig {
         OrbitRuntime::pr_config(self).clone()
     }

--- a/crates/orbit-engine/src/context.rs
+++ b/crates/orbit-engine/src/context.rs
@@ -477,6 +477,11 @@ pub trait RuntimeHost {
     }
     fn scoring_enabled(&self) -> bool;
     fn graph_editing(&self) -> bool;
+    /// Return the current agent model identity when this runtime is operating
+    /// as an agent, or `None` when there is no model-bearing actor.
+    fn actor_model_identity(&self) -> Option<String> {
+        None
+    }
     fn pr_config(&self) -> PrConfig {
         PrConfig::default()
     }
@@ -958,6 +963,10 @@ impl RuntimeHost for AutomationExecutorHost<'_> {
 
     fn graph_editing(&self) -> bool {
         self.runtime.graph_editing()
+    }
+
+    fn actor_model_identity(&self) -> Option<String> {
+        self.runtime.actor_model_identity()
     }
 
     fn scoreboard_dir(&self) -> &Path {

--- a/crates/orbit-engine/src/executor/automation/vcs/pr.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/pr.rs
@@ -276,10 +276,17 @@ pub(super) fn open_batch_pr<H: RuntimeHost + TaskHost + ?Sized>(
         .filter(|value| !value.trim().is_empty())
         .unwrap_or_else(|| default_pr_title(&completed_tasks));
     let pr_config = host.pr_config();
+    let pr_opener_model = host.actor_model_identity();
     let body = input_string_field(input, "body")
         .filter(|value| !value.trim().is_empty())
         .unwrap_or_else(|| {
-            build_batch_pr_body(&completed_tasks, &freshness, &changed_files, &pr_config)
+            build_batch_pr_body(
+                &completed_tasks,
+                &freshness,
+                &changed_files,
+                &pr_config,
+                pr_opener_model.as_deref(),
+            )
         });
 
     let tool_context = ToolContext {
@@ -418,6 +425,7 @@ fn build_batch_pr_body(
     freshness: &super::freshness::BranchFreshness,
     changed_files: &[&str],
     pr_config: &PrConfig,
+    pr_opener_model: Option<&str>,
 ) -> String {
     let mut body = if let [task] = tasks {
         build_single_task_pr_body(task, freshness, pr_config)
@@ -425,7 +433,7 @@ fn build_batch_pr_body(
         build_legacy_batch_pr_body(tasks, freshness, changed_files, pr_config)
     };
 
-    if let Some(signature) = batch_pr_signature(tasks) {
+    if let Some(signature) = batch_pr_signature(tasks, pr_opener_model) {
         body.push_str("\n\n");
         body.push_str(&signature);
     }
@@ -613,14 +621,19 @@ fn default_pr_title(tasks: &[Task]) -> String {
     }
 }
 
-fn batch_pr_signature(tasks: &[Task]) -> Option<String> {
-    tasks.iter().find_map(|task| {
-        let model = task
-            .implemented_by
-            .as_deref()
-            .or(task.created_by.as_deref())?;
-        Some(format!("*authored by: {model}*"))
-    })
+fn batch_pr_signature(tasks: &[Task], pr_opener_model: Option<&str>) -> Option<String> {
+    let model = tasks
+        .iter()
+        .find_map(|task| {
+            let model = task.implemented_by.as_deref()?.trim();
+            (!model.is_empty()).then_some(model)
+        })
+        .or_else(|| {
+            pr_opener_model
+                .map(str::trim)
+                .filter(|model| !model.is_empty())
+        })?;
+    Some(format!("*authored by: {model}*"))
 }
 
 fn task_required_revision<H: TaskHost + ?Sized>(host: &H, task: &Task) -> Result<bool, OrbitError> {
@@ -1139,6 +1152,7 @@ mod tests {
             &freshness(),
             &[],
             &test_pr_config(None),
+            None,
         );
         let task_line = body
             .lines()
@@ -1163,6 +1177,7 @@ mod tests {
             &freshness(),
             &["crates/orbit-core/src/runtime/engine/task_host.rs"],
             &test_pr_config(None),
+            None,
         );
 
         assert!(body.contains("- T20260427-24 System attribution fix"));
@@ -1188,6 +1203,7 @@ mod tests {
             &freshness(),
             &[],
             &test_pr_config(None),
+            None,
         );
 
         assert!(body.contains("- T20260427-32 Include execution summaries"));
@@ -1214,6 +1230,7 @@ mod tests {
             &freshness(),
             &["crates/orbit-engine/src/executor/automation/vcs/pr.rs"],
             &test_pr_config(None),
+            Some("gpt-5.5"),
         );
 
         assert_eq!(
@@ -1236,6 +1253,7 @@ mod tests {
             &freshness(),
             &["crates/orbit-engine/src/executor/automation/vcs/pr.rs"],
             &test_pr_config(None),
+            Some("gpt-5.5"),
         );
 
         let headings = body
@@ -1283,6 +1301,7 @@ mod tests {
             &freshness(),
             &[],
             &test_pr_config(None),
+            None,
         );
 
         assert!(body.contains("## Task"));
@@ -1290,6 +1309,104 @@ mod tests {
         assert!(!body.contains("<details>"));
         assert!(body.contains("## Validation"));
         assert!(body.contains("## Branch Freshness"));
+    }
+
+    #[test]
+    fn single_task_pr_signature_uses_implemented_by_when_present() {
+        let mut task = task_with_contract(
+            "T20260515-1",
+            "Keep implementation attribution",
+            "done",
+            "Preserve implemented_by attribution.",
+            &["implemented_by remains authoritative.".to_string()],
+            None,
+        );
+        task.created_by = Some("Y".to_string());
+        task.implemented_by = Some("X".to_string());
+
+        let body =
+            build_batch_pr_body(&[task], &freshness(), &[], &test_pr_config(None), Some("Z"));
+
+        assert!(body.contains("*authored by: X*"));
+    }
+
+    #[test]
+    fn single_task_pr_signature_does_not_fallback_to_created_by() {
+        let mut task = task_with_contract(
+            "T20260515-2",
+            "Do not attribute task creator",
+            "done",
+            "created_by is not implementation attribution.",
+            &["created_by is not rendered as author.".to_string()],
+            None,
+        );
+        task.created_by = Some("Y".to_string());
+        task.implemented_by = None;
+
+        let body = build_batch_pr_body(&[task], &freshness(), &[], &test_pr_config(None), None);
+        let created_by_signature =
+            regex::Regex::new(r"(?m)^\*authored by: Y\*$").expect("valid authored-by regex");
+
+        assert!(!created_by_signature.is_match(&body));
+    }
+
+    #[test]
+    fn single_task_pr_signature_uses_pr_opener_model_when_implemented_by_absent() {
+        let mut task = task_with_contract(
+            "T20260515-3",
+            "Use opener attribution",
+            "done",
+            "The PR opener is the fallback implementation source.",
+            &["opener model is rendered as author.".to_string()],
+            None,
+        );
+        task.created_by = Some("Y".to_string());
+        task.implemented_by = None;
+
+        let body =
+            build_batch_pr_body(&[task], &freshness(), &[], &test_pr_config(None), Some("Z"));
+
+        assert!(body.contains("*authored by: Z*"));
+    }
+
+    #[test]
+    fn single_task_pr_signature_omits_author_without_implemented_by_or_opener() {
+        let mut task = task_with_contract(
+            "T20260515-4",
+            "Omit unknown attribution",
+            "done",
+            "No implementation attribution is available.",
+            &["no authored-by line is rendered.".to_string()],
+            None,
+        );
+        task.created_by = Some("Y".to_string());
+        task.implemented_by = None;
+
+        let body = build_batch_pr_body(&[task], &freshness(), &[], &test_pr_config(None), None);
+
+        assert!(!body.contains("authored by:"));
+    }
+
+    #[test]
+    fn multi_task_pr_signature_uses_first_implemented_by() {
+        let mut first = task("T20260515-5A", "First task", "done");
+        first.implemented_by = Some("A".to_string());
+        let mut second = task("T20260515-5B", "Second task", "done");
+        second.implemented_by = Some("B".to_string());
+
+        let body = build_batch_pr_body(
+            &[first, second],
+            &freshness(),
+            &[],
+            &test_pr_config(None),
+            Some("Z"),
+        );
+        let signature_lines = body
+            .lines()
+            .filter(|line| line.starts_with("*authored by:"))
+            .collect::<Vec<_>>();
+
+        assert_eq!(signature_lines, vec!["*authored by: A*"]);
     }
 
     #[test]


### PR DESCRIPTION
## Task

[ORB-00034](https://orbit-cli.com/tasks/ORB-00034) — PR body "authored by" falls back to created_by; embed implementer instead

### Description

## Problem

`batch_pr_signature` in [crates/orbit-engine/src/executor/automation/vcs/pr.rs:616-624](crates/orbit-engine/src/executor/automation/vcs/pr.rs:616) emits the trailing `*authored by: <model>*` line on every generated PR body. Its source-of-truth logic is:

```rust
fn batch_pr_signature(tasks: &[Task]) -> Option<String> {
    tasks.iter().find_map(|task| {
        let model = task
            .implemented_by
            .as_deref()
            .or(task.created_by.as_deref())?;
        Some(format!("*authored by: {model}*"))
    })
}
```

`implemented_by` is only written on the `Review → Done` transition in [crates/orbit-core/src/command/task/transitions.rs:80](crates/orbit-core/src/command/task/transitions.rs:80) — i.e. *after* PR approval. The PR is generated *before* approval, so `implemented_by` is unset at render time and the fallback fires in the common case. The PR body then declares the task **creator** (often a human filing the bug, or a different planning agent) as the code author. That is wrong.

`Task` carries three semantically distinct attribution slots:

- `created_by` — who called `orbit.task.add`.
- `planned_by` — who authored the plan.
- `implemented_by` — who wrote the code.

Only `implemented_by` belongs in `*authored by:*`. `created_by` and `planned_by` describe other roles.

## Why It Matters

- The signature line is misleading in essentially every PR Orbit opens today, because `implemented_by` is set *after* PR creation. Reviewers reading the PR body get a wrong claim about authorship.
- Reviewers and downstream automation (changelog generators, attribution audits, anything that scrapes `authored by:` lines) silently treat the task creator as the code author.
- The misattribution is not just cosmetic when the creator is a human and the implementer is an agent (or vice versa): it confuses code-provenance answers.

## Proposed Fix

Drop the `created_by` fallback. Use the actor invoking `open_batch_pr` (i.e. the agent that is in fact opening the PR) as the implementer-of-record source when `implemented_by` is None on every task in the batch. The PR-opening actor is by construction the author of the commits the PR contains.

Concrete shape:

1. Plumb the agent identity that is opening the PR through `build_batch_pr_body` (likely via `PrConfig` or a new parameter) so `batch_pr_signature` has access to it.
2. Rewrite `batch_pr_signature` as: prefer the first task's `implemented_by`; if all tasks have None, use the PR-opener's model identity; if even that is unknown, omit the signature.
3. Never read `created_by` or `planned_by` in the signature path.

Alternative discussed and rejected: simply remove the signature line entirely when `implemented_by` is None. Rejected because the signature is a useful diagnostic and the opener identity is reliably available at PR-open time — preserving correctness is cheap.

Out-of-scope follow-up (mention in plan, don't fold in): populating `implemented_by` earlier in the lifecycle (e.g. when a task transitions to `in-progress`) would also fix this at the source. That's a larger semantic change and should be a separate task with its own migration story for any tasks whose `implemented_by` was retroactively set on `Review → Done`.

## Constraints / Notes

- Must not change behavior of `Co-Authored-By:` trailers on commits — those live in [crates/orbit-engine/src/executor/automation/vcs/commit/author.rs](crates/orbit-engine/src/executor/automation/vcs/commit/author.rs) and have their own attribution path.
- Multi-task batched PRs may legitimately have several distinct implementers across tasks. Continue emitting a single signature line for the PR as a whole; pick the first task's `implemented_by` (current behavior) and only fall back to the opener when **all** tasks lack it. Do not synthesize a comma-joined multi-author signature.
- The existing test at [crates/orbit-engine/src/executor/automation/vcs/pr.rs:1221-1269](crates/orbit-engine/src/executor/automation/vcs/pr.rs:1221) covers the `implemented_by`-present path and must remain green.

### Acceptance Criteria

- For a single-task PR where the task has `implemented_by = Some("X")`, the generated PR body still contains the line `*authored by: X*` (no regression from current behavior). A unit test asserts this exact substring.
- For a single-task PR where the task has `implemented_by = None` and `created_by = Some("Y")`, the generated PR body MUST NOT contain `*authored by: Y*`. A unit test constructs such a task and asserts that no line matching the regex `^\*authored by: Y\*$` appears in the rendered body.
- For a single-task PR where the task has `implemented_by = None` and the PR-opening actor's model identity is `Z`, the generated PR body contains `*authored by: Z*`. A unit test plumbs the actor identity through `build_batch_pr_body` (or its equivalent after refactor) and asserts the exact substring.
- For a single-task PR where the task has `implemented_by = None` and no PR-opener identity is available, the generated PR body does NOT contain any line starting with `*authored by:`. A unit test asserts the substring `authored by:` is absent.
- A `grep -n 'created_by\|planned_by' crates/orbit-engine/src/executor/automation/vcs/pr.rs` returns no matches inside the body of `batch_pr_signature` (or its renamed successor). Equivalently: the signature function does not reference either field on `Task`.
- For a multi-task (batch) PR where the first task has `implemented_by = Some("A")` and later tasks have different `implemented_by` values, the signature line is `*authored by: A*` (single signature, first-task-wins behavior preserved). A unit test asserts this.
- `make ci` passes (`cargo clippy --workspace --all-targets -- -D warnings` and full test suite).

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Plumbed the PR-opening agent model identity into generated PR body rendering.
- Reworked the PR signature to prefer task implemented_by, fall back to the PR opener model only when no task has implemented_by, and never read created_by or planned_by in the signature path.
- Added focused PR body unit tests for implemented_by, created_by-only, opener fallback, absent opener, and multi-task first-implemented-by attribution.

Assessment: Task-scoped implementation is complete. Focused PR body tests and clippy passed through make ci. Full make ci is blocked by an unrelated existing design_check golden failure reporting stale docs/design files tied to 2026-05-14 changes outside this task scope.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-00034-6a0696b7`
- Behind base: 0
- Ahead of base: 1

*authored by: claude-opus-4-7*