### PR TITLE
graph.overview: expose downgrade reason and threshold in response payload

### DIFF
--- a/crates/orbit-knowledge/src/commands/overview.rs
+++ b/crates/orbit-knowledge/src/commands/overview.rs
@@ -10,6 +10,18 @@ const FILE_THRESHOLD: usize = 50;
 pub const SUMMARY_HINT: &str =
     "Use `prefix` to narrow the overview and get per-file symbol listings.";
 
+/// Machine-readable reason an overview request was downgraded from full to summary.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DowngradeReason {
+    /// The requested full overview exceeded the maximum file count for full mode.
+    FileThreshold {
+        /// Maximum file count allowed before full mode is downgraded.
+        threshold: usize,
+        /// Actual file count observed for the requested scope.
+        actual: usize,
+    },
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum OverviewFormat {
     Full,
@@ -50,6 +62,7 @@ pub enum OverviewBody {
     Summary {
         summary: GraphOverviewSummary,
         downgraded: bool,
+        downgrade_reason: Option<DowngradeReason>,
     },
 }
 
@@ -65,6 +78,7 @@ pub fn run(input: OverviewInput) -> Result<OverviewResult, KnowledgeError> {
             body: OverviewBody::Summary {
                 summary: summary.summary,
                 downgraded: summary.downgraded,
+                downgrade_reason: summary.downgrade_reason,
             },
         });
     }
@@ -72,19 +86,34 @@ pub fn run(input: OverviewInput) -> Result<OverviewResult, KnowledgeError> {
     let graph = input.context.read_graph(GraphReadOptions::default())?;
     let svc = GraphContextService::new(&graph);
     let overview = svc.overview(input.prefix.as_deref());
-    let resolved_format = input
-        .requested_format
-        .unwrap_or_else(|| default_format_for_scope(input.prefix.as_deref(), overview.files.len()));
-    let downgraded = matches!(input.requested_format, Some(OverviewFormat::Full))
-        && overview.files.len() > FILE_THRESHOLD;
+    Ok(result_from_overview(
+        overview,
+        input.prefix.as_deref(),
+        input.requested_format,
+        requested_format,
+    ))
+}
+
+fn result_from_overview(
+    overview: GraphOverview,
+    prefix: Option<&str>,
+    input_format: Option<OverviewFormat>,
+    requested_format: RequestedOverviewFormat,
+) -> OverviewResult {
+    let resolved_format =
+        input_format.unwrap_or_else(|| default_format_for_scope(prefix, overview.files.len()));
+    let downgrade_reason = downgrade_reason(input_format, overview.files.len());
+    let downgraded = downgrade_reason.is_some();
     let use_summary = matches!(resolved_format, OverviewFormat::Summary) || downgraded;
 
-    Ok(if use_summary {
+    if use_summary {
+        let hint = summary_hint(downgrade_reason.as_ref());
         OverviewResult {
             requested_format,
             body: OverviewBody::Summary {
-                summary: compact_from_overview(&overview, input.prefix.as_deref(), SUMMARY_HINT),
+                summary: compact_from_overview(&overview, prefix, &hint),
                 downgraded,
+                downgrade_reason,
             },
         }
     } else {
@@ -92,7 +121,7 @@ pub fn run(input: OverviewInput) -> Result<OverviewResult, KnowledgeError> {
             requested_format,
             body: OverviewBody::Full(overview),
         }
-    })
+    }
 }
 
 fn requested_format(format: Option<OverviewFormat>) -> RequestedOverviewFormat {
@@ -111,9 +140,33 @@ fn default_format_for_scope(prefix: Option<&str>, file_count: usize) -> Overview
     }
 }
 
+fn downgrade_reason(
+    requested_format: Option<OverviewFormat>,
+    file_count: usize,
+) -> Option<DowngradeReason> {
+    if matches!(requested_format, Some(OverviewFormat::Full)) && file_count > FILE_THRESHOLD {
+        Some(DowngradeReason::FileThreshold {
+            threshold: FILE_THRESHOLD,
+            actual: file_count,
+        })
+    } else {
+        None
+    }
+}
+
+fn summary_hint(downgrade_reason: Option<&DowngradeReason>) -> String {
+    match downgrade_reason {
+        Some(DowngradeReason::FileThreshold { threshold, actual }) => format!(
+            "Downgrade reason file_threshold: file count {actual} exceeds threshold {threshold}. {SUMMARY_HINT}"
+        ),
+        None => SUMMARY_HINT.to_string(),
+    }
+}
+
 struct SqlOverviewSummary {
     summary: GraphOverviewSummary,
     downgraded: bool,
+    downgrade_reason: Option<DowngradeReason>,
 }
 
 fn try_summary_via_sql_index(
@@ -133,8 +186,8 @@ fn try_summary_via_sql_index(
     })?;
     let resolved_format =
         requested_format.unwrap_or_else(|| default_format_for_scope(None, total_files));
-    let downgraded =
-        matches!(requested_format, Some(OverviewFormat::Full)) && total_files > FILE_THRESHOLD;
+    let downgrade_reason = downgrade_reason(requested_format, total_files);
+    let downgraded = downgrade_reason.is_some();
     let use_summary = matches!(resolved_format, OverviewFormat::Summary) || downgraded;
     if !use_summary {
         return Ok(None);
@@ -152,6 +205,7 @@ fn try_summary_via_sql_index(
             symbol_count,
         })
         .collect();
+    let hint = summary_hint(downgrade_reason.as_ref());
 
     Ok(Some(SqlOverviewSummary {
         summary: GraphOverviewSummary {
@@ -174,9 +228,10 @@ fn try_summary_via_sql_index(
                 ))
             })?,
             top_files,
-            hint: SUMMARY_HINT.to_string(),
+            hint,
         },
         downgraded,
+        downgrade_reason,
     }))
 }
 
@@ -212,6 +267,59 @@ mod tests {
         assert!(downgraded);
     }
 
+    #[test]
+    fn requested_full_below_threshold_has_no_downgrade_reason() {
+        let result = overview_result_for_fixture(FILE_THRESHOLD, None, Some(OverviewFormat::Full));
+
+        assert!(matches!(result.body, OverviewBody::Full(_)));
+    }
+
+    #[test]
+    fn requested_full_above_threshold_reports_file_threshold_reason() {
+        let actual = 101;
+        let result = overview_result_for_fixture(actual, None, Some(OverviewFormat::Full));
+
+        let OverviewBody::Summary {
+            summary,
+            downgraded,
+            downgrade_reason,
+        } = result.body
+        else {
+            panic!("expected summary overview");
+        };
+
+        assert!(downgraded);
+        assert_eq!(summary.total_files, actual);
+        assert_eq!(
+            downgrade_reason,
+            Some(DowngradeReason::FileThreshold {
+                threshold: FILE_THRESHOLD,
+                actual,
+            })
+        );
+        assert!(summary.hint.contains("file_threshold"));
+        assert!(summary.hint.contains(&format!(
+            "file count {actual} exceeds threshold {FILE_THRESHOLD}"
+        )));
+    }
+
+    #[test]
+    fn requested_summary_above_threshold_has_no_downgrade_reason() {
+        let result = overview_result_for_fixture(101, None, Some(OverviewFormat::Summary));
+
+        let OverviewBody::Summary {
+            downgraded,
+            downgrade_reason,
+            ..
+        } = result.body
+        else {
+            panic!("expected summary overview");
+        };
+
+        assert!(!downgraded);
+        assert_eq!(downgrade_reason, None);
+    }
+
     fn overview_body_snapshot(graph: &CodebaseGraphV1, prefix: Option<&str>) -> String {
         let svc = GraphContextService::new(graph);
         let overview = svc.overview(prefix);
@@ -229,6 +337,22 @@ mod tests {
                 overview.total_dirs, overview.total_files, overview.total_symbols, downgraded
             )
         }
+    }
+
+    fn overview_result_for_fixture(
+        file_count: usize,
+        prefix: Option<&str>,
+        input_format: Option<OverviewFormat>,
+    ) -> OverviewResult {
+        let graph = fixture_graph(file_count);
+        let svc = GraphContextService::new(&graph);
+        let overview = svc.overview(prefix);
+        result_from_overview(
+            overview,
+            prefix,
+            input_format,
+            requested_format(input_format),
+        )
     }
 
     fn fixture_graph(file_count: usize) -> CodebaseGraphV1 {

--- a/crates/orbit-tools/src/builtin/orbit/knowledge/overview.rs
+++ b/crates/orbit-tools/src/builtin/orbit/knowledge/overview.rs
@@ -2,7 +2,8 @@ use std::collections::{BTreeMap, HashMap};
 
 use orbit_common::types::{OrbitError, ToolParam, ToolSchema};
 use orbit_knowledge::commands::overview::{
-    self, GraphOverview, GraphOverviewSummary, OverviewBody, OverviewFormat, OverviewInput,
+    self, DowngradeReason, GraphOverview, GraphOverviewSummary, OverviewBody, OverviewFormat,
+    OverviewInput,
 };
 use serde_json::{Value, json};
 
@@ -54,7 +55,8 @@ impl Tool for OrbitKnowledgeOverviewTool {
             OverviewBody::Summary {
                 summary,
                 downgraded,
-            } => summary_response(summary, requested_format, downgraded),
+                downgrade_reason,
+            } => summary_response(summary, requested_format, downgraded, downgrade_reason),
         })
     }
 }
@@ -114,6 +116,7 @@ fn summary_response(
     summary: GraphOverviewSummary,
     requested_format: &str,
     downgraded: bool,
+    downgrade_reason: Option<DowngradeReason>,
 ) -> Value {
     let top_files: Vec<Value> = summary
         .top_files
@@ -127,7 +130,7 @@ fn summary_response(
         })
         .collect();
 
-    json!({
+    let mut response = json!({
         "mode": "summary",
         "requested_format": requested_format,
         "downgraded": downgraded,
@@ -139,9 +142,28 @@ fn summary_response(
         "dir_file_counts": summary.dir_file_counts,
         "top_files": top_files,
         "hint": summary.hint,
-    })
+    });
+    if let Some(reason) = downgrade_reason
+        && let Some(object) = response.as_object_mut()
+    {
+        object.insert(
+            "downgrade_reason".to_string(),
+            downgrade_reason_value(reason),
+        );
+    }
+    response
 }
 
 fn sorted_counts(counts: HashMap<String, usize>) -> BTreeMap<String, usize> {
     counts.into_iter().collect()
+}
+
+fn downgrade_reason_value(reason: DowngradeReason) -> Value {
+    match reason {
+        DowngradeReason::FileThreshold { threshold, actual } => json!({
+            "kind": "file_threshold",
+            "threshold": threshold,
+            "actual": actual,
+        }),
+    }
 }

--- a/crates/orbit-tools/tests/graph_tool_surface.rs
+++ b/crates/orbit-tools/tests/graph_tool_surface.rs
@@ -482,6 +482,41 @@ fn overview_defaults_to_summary_for_broad_scope() {
 }
 
 #[test]
+fn overview_requested_full_downgrade_response_includes_reason() {
+    let fixture = write_graph_fixture(large_overview_graph(101, 1));
+
+    let response = execute_graph_tool(
+        fixture.path(),
+        "orbit.graph.overview",
+        json!({"prefix":"src/","format":"full"}),
+    );
+
+    assert_eq!(response["mode"], "summary");
+    assert_eq!(response["requested_format"], "full");
+    assert_eq!(response["downgraded"], true);
+    assert_eq!(
+        response["downgrade_reason"],
+        json!({
+            "kind": "file_threshold",
+            "threshold": 50,
+            "actual": 101,
+        })
+    );
+    assert!(
+        response["hint"]
+            .as_str()
+            .unwrap()
+            .contains("file count 101 exceeds threshold 50")
+    );
+    assert!(
+        response["hint"]
+            .as_str()
+            .unwrap()
+            .contains("file_threshold")
+    );
+}
+
+#[test]
 fn overview_summary_uses_sql_index_without_by_id_graph_read() {
     let fixture = write_graph_fixture(large_overview_graph(120, 12));
     let knowledge_dir = fixture.path().join(".orbit/knowledge");


### PR DESCRIPTION
## Task

[ORB-00032](https://orbit-cli.com/tasks/ORB-00032) — graph.overview: expose downgrade reason and threshold in response payload

### Description

## Problem

`orbit.graph.overview` returns `downgraded:true` with no machine-readable reason or threshold value. Callers cannot tell whether the downgrade was triggered by file count, token cap, depth, or another rule, and so cannot decide between narrowing the `prefix`, accepting summary mode, or raising a threshold.

Concrete repro from F2026-05-010:

```bash
orbit tool run orbit.graph.overview --input '{"prefix":"crates/orbit-engine/src","format":"full","model":"gpt-5.5"}'
```

Returns:

```json
{"downgraded":true,"hint":"Use `prefix` to narrow the overview and get per-file symbol listings.","total_files":101,"requested_format":"full","mode":"summary","...":"..."}
```

Implementation evidence from the friction report points to `crates/orbit-knowledge/src/commands/overview.rs`:

```rust
const FILE_THRESHOLD: usize = 50;
let downgraded = matches!(input.requested_format, Some(OverviewFormat::Full))
    && overview.files.len() > FILE_THRESHOLD;
```

So `total_files=101 > 50` triggered the downgrade — but the response does not say that.

## Why It Matters

Without a typed downgrade reason, agents cannot make informed retry decisions. A `downgrade_reason` field lets callers programmatically narrow the prefix until under threshold, or accept summary mode with full context. Source friction: F2026-05-010 (rollout-2026-05-14T18-06-18, lines 30-41).

## Constraints / Notes

- Add a structured `downgrade_reason` field; do not remove or change the existing `downgraded` boolean.
- Initial reason kinds: `file_threshold` (current trigger). Leave room for future kinds (`auto_summary_file_threshold`, `token_cap`).
- Update the `hint` text to reference the actual threshold value and reason kind so the user-facing message matches the structured field.

### Acceptance Criteria

- For the F2026-05-010 repro, the response contains a `downgrade_reason` field shaped as `{"kind":"file_threshold","threshold":50,"actual":101}` (field naming may differ slightly; the values must match the source constant `FILE_THRESHOLD` and the observed `total_files`).
- When `downgraded:false`, the response either omits `downgrade_reason` or sets it to null.
- When downgrade is present, the `hint` field includes the threshold value and a reference to the reason kind (e.g. `"file count 101 exceeds threshold 50"`).
- New unit tests in `crates/orbit-knowledge/src/commands/overview.rs` cover: (a) below-threshold full overview returns no downgrade reason, (b) above-threshold full overview returns the `file_threshold` reason with correct `threshold` and `actual` values, (c) explicitly requested summary mode does not set a downgrade reason.
- `make ci` passes.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Added a typed `DowngradeReason::FileThreshold` to `orbit-knowledge` overview command results and threaded it through SQL and graph fallback summary paths.
- Updated `orbit.graph.overview` JSON responses to include `downgrade_reason: {kind, threshold, actual}` only when a full request is downgraded by the file threshold.
- Updated downgrade hints to include `file_threshold` plus the actual file count and threshold.
- Added command-level overview tests for below-threshold full, above-threshold full downgrade, and explicit summary behavior; added a tool-surface regression test for the JSON payload.

Validation:
- `cargo test -p orbit-knowledge commands::overview::tests` passed.
- `cargo test -p orbit-tools overview --test graph_tool_surface` passed.
- Exact repro via `cargo run -q -p orbit-cli -- tool run orbit.graph.overview --input ...` returned `downgrade_reason: {actual:101, kind:"file_threshold", threshold:50}` and the updated hint.
- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps -p orbit-knowledge -p orbit-tools` passed.
- `make ci-fast` passed.
- Full `make ci` reached workspace tests but failed in pre-existing `orbit-cli --test design_check` golden because multiple docs/design files are stale relative to 2026-05-14 code changes outside this task.

Assessment: Scoped implementation is validated; remaining full-CI failure is unrelated repo-state/doc decay and was not broadened into ORB-00032.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-00032-6a069a6a`
- Behind base: 0
- Ahead of base: 1