### PR TITLE
Expose orbit.learning.* tools through orbit mcp serve

### DIFF
--- a/crates/orbit-cli/src/command/mcp/mod.rs
+++ b/crates/orbit-cli/src/command/mcp/mod.rs
@@ -70,17 +70,30 @@ pub(crate) const GRAPH_READ_TOOL_NAMES: &[&str] = &[
 pub(crate) const SEMANTIC_READ_TOOL_NAMES: &[&str] =
     &["orbit.semantic.search", "orbit.semantic.related"];
 
+pub(crate) const LEARNING_TOOL_NAMES: &[&str] = &[
+    "orbit.learning.add",
+    "orbit.learning.list",
+    "orbit.learning.search",
+    "orbit.learning.show",
+    "orbit.learning.update",
+    "orbit.learning.supersede",
+    "orbit.learning.prune",
+    "orbit.learning.reindex",
+];
+
 pub(crate) fn safe_mcp_tool_names() -> Vec<&'static str> {
     let mut names = Vec::with_capacity(
         TASK_TOOL_NAMES.len()
             + FRICTION_TOOL_NAMES.len()
             + GRAPH_READ_TOOL_NAMES.len()
-            + SEMANTIC_READ_TOOL_NAMES.len(),
+            + SEMANTIC_READ_TOOL_NAMES.len()
+            + LEARNING_TOOL_NAMES.len(),
     );
     names.extend_from_slice(TASK_TOOL_NAMES);
     names.extend_from_slice(FRICTION_TOOL_NAMES);
     names.extend_from_slice(GRAPH_READ_TOOL_NAMES);
     names.extend_from_slice(SEMANTIC_READ_TOOL_NAMES);
+    names.extend_from_slice(LEARNING_TOOL_NAMES);
     names
 }
 
@@ -89,6 +102,7 @@ pub(crate) fn is_mcp_tool_exposed(name: &str) -> bool {
         || FRICTION_TOOL_NAMES.contains(&name)
         || GRAPH_READ_TOOL_NAMES.contains(&name)
         || SEMANTIC_READ_TOOL_NAMES.contains(&name)
+        || LEARNING_TOOL_NAMES.contains(&name)
 }
 
 fn ensure_mcp_tool_exposed(name: &str) -> Result<(), OrbitError> {
@@ -308,8 +322,8 @@ mod tests {
     use orbit_mcp::McpHost;
 
     use super::{
-        GRAPH_READ_TOOL_NAMES, RuntimeMcpHost, SEMANTIC_READ_TOOL_NAMES, TASK_TOOL_NAMES,
-        is_mcp_tool_exposed, safe_mcp_tool_names,
+        GRAPH_READ_TOOL_NAMES, LEARNING_TOOL_NAMES, RuntimeMcpHost, SEMANTIC_READ_TOOL_NAMES,
+        TASK_TOOL_NAMES, is_mcp_tool_exposed, safe_mcp_tool_names,
     };
 
     #[test]
@@ -351,6 +365,24 @@ mod tests {
             assert!(is_mcp_tool_exposed(name));
         }
 
+        for name in LEARNING_TOOL_NAMES {
+            assert!(
+                names.contains(*name),
+                "missing runtime learning tool: {name}"
+            );
+            assert!(is_mcp_tool_exposed(name));
+        }
+
+        for name in names
+            .iter()
+            .filter(|name| name.starts_with("orbit.learning."))
+        {
+            assert!(
+                safe_names.contains(name.as_str()),
+                "runtime learning tool missing from safe MCP surface: {name}"
+            );
+        }
+
         for name in [
             "orbit.graph.add",
             "orbit.graph.delete",
@@ -389,6 +421,13 @@ mod tests {
             assert!(
                 listed.contains(*name),
                 "client-visible MCP tool list missing semantic read tool: {name}"
+            );
+        }
+
+        for name in LEARNING_TOOL_NAMES {
+            assert!(
+                listed.contains(*name),
+                "client-visible MCP tool list missing learning tool: {name}"
             );
         }
 
@@ -474,6 +513,14 @@ mod tests {
             assert_eq!(events.len(), 1, "exactly one audit row for happy path");
             assert_eq!(events[0].subcommand.as_deref(), Some("run-mcp"));
             assert_eq!(events[0].status, AuditEventStatus::Success);
+        }
+
+        #[test]
+        fn learning_search_is_exposed_to_mcp_dispatch() {
+            let runtime = OrbitRuntime::in_memory().expect("build test runtime");
+            let value = audited_mcp_call(&runtime, "orbit.learning.search", json!({}))
+                .expect("learning search dispatch ok");
+            assert!(value.is_array(), "learning search returns an array");
         }
 
         #[test]


### PR DESCRIPTION
## Task

[ORB-00039](https://orbit-cli.com/tasks/ORB-00039) — Expose orbit.learning.* tools through orbit mcp serve

### Description

## Problem

`orbit mcp serve` does not expose any `orbit.learning.*` tool. The runtime registers all eight (`add`, `list`, `search`, `show`, `update`, `supersede`, `prune`, `reindex`) and they are reachable via `orbit tool run`, but the MCP-side allowlist in [`crates/orbit-cli/src/command/mcp/mod.rs`](crates/orbit-cli/src/command/mcp/mod.rs) only covers `orbit.task.*`, `orbit.friction.*`, `orbit.graph.*`, and `orbit.semantic.{search,related}`:

```rust
pub(crate) fn is_mcp_tool_exposed(name: &str) -> bool {
    TASK_TOOL_NAMES.contains(&name)
        || FRICTION_TOOL_NAMES.contains(&name)
        || GRAPH_READ_TOOL_NAMES.contains(&name)
        || SEMANTIC_READ_TOOL_NAMES.contains(&name)
}
```

Two consequences:

1. `RuntimeMcpHost::list_tool_schemas` filters with `is_mcp_tool_exposed`, so the learning tools never appear in `tools/list` for any MCP client (Gemini, Claude Code via `orbit mcp serve`, Cursor, VS Code, etc.).
2. Direct calls hit `audited_mcp_call` → `ensure_mcp_tool_exposed`, which returns `OrbitError::NotFound { kind: Tool, .. }`. The MCP error mapper in [`crates/orbit-mcp/src/error.rs`](crates/orbit-mcp/src/error.rs) renders this as `tool not found: orbit.learning.search` — observed in the wild from a Gemini session that followed the `orbit-learning` skill instructions verbatim.

## Why It Matters

The `orbit-learning` and `orbit-learnings` skill descriptions instruct agents to operate on project learnings via `orbit.learning.*`, but every MCP-fronted client silently has zero access to that surface. The skill is effectively dead weight under MCP, and the failure mode is a misleading `tool_not_found` rather than an honest "not exposed" signal. Adding the surface restores parity between the CLI and MCP and unblocks the documented learnings workflow for non-Claude-Code agents.

## Constraints / Notes

- Smallest-change shape: add a `LEARNING_TOOL_NAMES` constant alongside the existing four, then include it in `safe_mcp_tool_names()` and `is_mcp_tool_exposed()`. Mirrors how `SEMANTIC_READ_TOOL_NAMES` was added — no new architecture or dependency edges.
- **Open question for the planner:** expose the full eight-tool surface (matches `TASK_TOOL_NAMES`, which includes mutations like `add`/`update`/`delete`) or read-only subset `{search, show, list}`? Default recommendation is full surface to match the skill descriptions; deviate only with a documented reason.
- The existing tooltest harness in [`crates/orbit-cli/src/command/mcp/mod.rs`](crates/orbit-cli/src/command/mcp/mod.rs) (`#[cfg(test)] mod tests { ... safe_surface_matches_runtime_graph_and_task_tools }`) is the right place to extend; do not introduce a new harness.
- No changes needed in `crates/orbit-tools` or `crates/orbit-mcp` — the tools are already registered and the adapter has no hard-coded surface restrictions of its own.
- Out of scope: rewriting the skill descriptions to use `orbit tool run`; broader audit of which other tool families are MCP-blind.

### Acceptance Criteria

- A new `LEARNING_TOOL_NAMES: &[&str]` constant exists in `crates/orbit-cli/src/command/mcp/mod.rs` and lists every `orbit.learning.*` tool the planner decides to expose. The constant is included in both `safe_mcp_tool_names()` and `is_mcp_tool_exposed()` using the same shape as `SEMANTIC_READ_TOOL_NAMES`.
- After `cargo build --release -p orbit-cli`, running `orbit mcp serve` and issuing an MCP `tools/list` request returns each exposed `orbit_learning_*` tool (advertised name uses underscores via `sanitize_tool_name`). Verified by extending the existing test `safe_surface_matches_runtime_graph_and_task_tools` (or adding a sibling test in the same `mod tests`) so it asserts every name in the new `LEARNING_TOOL_NAMES` constant is present in `RuntimeMcpHost::list_tool_schemas()` output and satisfies `is_mcp_tool_exposed`.
- A new unit test in the same `mod tests` block calls `audited_mcp_call(&runtime, "orbit.learning.search", json!({}))` (or the equivalent through `RuntimeMcpHost::call_tool`) and asserts the result is `Ok(_)` rather than `Err(OrbitError::NotFound { kind: NotFoundKind::Tool, .. })`. The test must use `OrbitRuntime::in_memory()` so it does not depend on a real `.orbit/` workspace on disk.
- `make ci-fast` passes locally with no new warnings. No changes are made under `crates/orbit-tools/`, `crates/orbit-mcp/`, or `crates/orbit-core/` — the diff is contained to `crates/orbit-cli/src/command/mcp/mod.rs` and (if applicable) any sibling test file in that module.
- The task's execution summary documents which surface variant was chosen (full eight-tool vs read-subset) and quotes the rationale. If read-subset is chosen, the summary names which mutations were deliberately excluded and why.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Added `LEARNING_TOOL_NAMES` to `crates/orbit-cli/src/command/mcp/mod.rs` and wired it into `safe_mcp_tool_names()` plus `is_mcp_tool_exposed()`.
- Exposed the full eight-tool learning surface: `orbit.learning.add`, `orbit.learning.list`, `orbit.learning.search`, `orbit.learning.show`, `orbit.learning.update`, `orbit.learning.supersede`, `orbit.learning.prune`, and `orbit.learning.reindex`.
- Extended the existing MCP tests so the runtime registry, safe allowlist, client-visible `RuntimeMcpHost::list_tool_schemas()` surface, and audited in-memory dispatch all cover learning tools.

Strategic decisions:
- Chose the full eight-tool surface | Rationale: "Default recommendation is full surface to match the skill descriptions" and it restores parity with the runtime/CLI registration that already supports all eight learning tools.

Validation:
- `cargo fmt --check`
- `cargo test -p orbit-cli mcp::tests -- --nocapture`
- `cargo build --release -p orbit-cli`
- Stdio MCP handshake against `target/release/orbit mcp serve` confirmed all `orbit_learning_*` tools are advertised.
- `make ci-fast`

Assessment: Scoped to `crates/orbit-cli/src/command/mcp/mod.rs`; no changes were made under `crates/orbit-tools/`, `crates/orbit-mcp/`, or `crates/orbit-core/`.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-00039-6a06ab02`
- Behind base: 0
- Ahead of base: 1

*authored by: gpt-5.5*