### PR TITLE
Cross-link RELEASING.md and docs/RELEASE.md

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -2,6 +2,8 @@
 
 Runbook for cutting an Orbit release. Codified from [T20260510-23] (v0.4.0).
 
+See also [docs/RELEASE.md](docs/RELEASE.md) for the npm package, plugin manifest, and GitHub Release publishing steps.
+
 ## Versioning policy
 
 Pre-1.0 semver: `0.<minor>.<patch>`.

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -7,6 +7,8 @@ plugin manifest, and the GitHub Release tag must all agree, or the
 [`plugin/.mcp.json`](../plugin/.mcp.json) downloads a binary that does not
 match the plugin manifest.
 
+See also [../RELEASING.md](../RELEASING.md) for the higher-level release runbook and versioning policy.
+
 ## Account setup (one-time)
 
 The `@orbit-tools` scope has **publish-time 2FA** enabled, and npm no longer


### PR DESCRIPTION
## Task

[ORB-00040](https://orbit-cli.com/tasks/ORB-00040) — Cross-link RELEASING.md and docs/RELEASE.md

### Description

## Problem

Two release docs exist with no cross-reference:

- [`RELEASING.md`](RELEASING.md) (top-level, 166 lines) — canonical runbook for cutting an Orbit release. Covers versioning policy, what counts as breaking, and the full release sequence.
- [`docs/RELEASE.md`](docs/RELEASE.md) (135 lines) — npm/plugin-side release procedure: bump `plugin/npm/package.json`, plugin manifest, GitHub tag, and the 2FA-blocked npm publish step.

An agent or human landing on either file has no way to discover the other. There's overlap in topic but no overlap in content — both are load-bearing for a successful release.

## Why It Matters

The "release/deploy" entry point is ambiguous. A first-time releaser following `docs/RELEASE.md` won't learn the versioning policy; a releaser following `RELEASING.md` won't learn the npm 2FA constraint. Cross-linking removes the surprise.

## Constraints / Notes

- Documentation-only change. No code, no Rust compile risk; safe to skip `make build`.
- Keep additions minimal — a single "See also" line near the top of each file is enough. Do not merge or duplicate content.
- Pointer direction:
  - `RELEASING.md` → `docs/RELEASE.md` for "the npm package + plugin manifest + GitHub Release tag publishing steps".
  - `docs/RELEASE.md` → `RELEASING.md` for "the higher-level runbook and versioning policy".
- Use the existing markdown link style each file already uses.

### Acceptance Criteria

- `RELEASING.md` contains a single visible pointer near the top (intro section, before the first numbered step) linking to `docs/RELEASE.md`, with a one-sentence description of what that file covers (npm/plugin manifest/GitHub Release publishing).
- `docs/RELEASE.md` contains a single visible pointer near the top (intro section, before the first numbered step) linking to `RELEASING.md`, with a one-sentence description (higher-level runbook + versioning policy).
- Both pointers use relative markdown links that resolve correctly from each file's location (`docs/RELEASE.md` from the repo root; `../RELEASING.md` from `docs/`).
- No other content is moved, merged, or duplicated between the two files.
- `make ci-fast` passes.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Added a top-intro See also link in `RELEASING.md` to `docs/RELEASE.md`, describing npm package, plugin manifest, and GitHub Release publishing steps.
- Added a reciprocal top-intro See also link in `docs/RELEASE.md` to `../RELEASING.md`, describing the higher-level runbook and versioning policy.

Assessment: Documentation-only change is minimal and scoped; relative links resolve and no release content was moved or duplicated.

Validation:
- `make ci-fast` passed.
- `git diff --check` passed.
- Verified both referenced link targets exist.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-00040-6a06b7ff`
- Behind base: 0
- Ahead of base: 1