### PR TITLE
[codex] Rename executor model pair override

### DIFF
--- a/.grok/config.toml
+++ b/.grok/config.toml
@@ -1,0 +1,4 @@
+[mcp_servers.orbit]
+command = "orbit"
+args = ["mcp", "serve"]
+enabled = true

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2267,6 +2267,8 @@ dependencies = [
  "serde_yaml",
  "sha2",
  "tempfile",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/crates/orbit-cli/src/command/definitions/apply.rs
+++ b/crates/orbit-cli/src/command/definitions/apply.rs
@@ -119,26 +119,18 @@ fn apply_executor(
 ) -> Result<(), OrbitError> {
     let doc: ExecutorResource = parse_resource(content, path, "Executor resource")?;
     let existing = runtime.get_executor_def(name)?;
-    let mut def = ExecutorDef {
-        name: name.to_string(),
-        executor_type: doc.spec.executor_type,
-        command: doc.spec.command,
-        args: doc.spec.args,
-        stdout_format: doc.spec.stdout_format,
-        models: doc.spec.models,
-        timeout_seconds: doc.spec.timeout_seconds,
-        env: doc.spec.env,
-        sandbox: doc.spec.sandbox,
-        allow_fallback: doc.spec.allow_fallback,
-        created_at: existing
-            .as_ref()
-            .map(|executor| executor.created_at)
-            .unwrap_or(doc.spec.created_at),
-        updated_at: Utc::now(),
-    };
-    if existing.is_none() {
-        def.created_at = doc.spec.created_at;
-    }
+    let created_at = existing
+        .as_ref()
+        .map(|executor| executor.created_at)
+        .unwrap_or(doc.spec.created_at);
+    let source_label = format!("{}: Executor resource", path.display());
+    let def = ExecutorDef::from_resource_spec(
+        name.to_string(),
+        doc.spec,
+        &source_label,
+        created_at,
+        Utc::now(),
+    );
     runtime.upsert_executor_def(&def)?;
     println!("executor/{name} applied");
     Ok(())

--- a/crates/orbit-common/src/types/executor_def.rs
+++ b/crates/orbit-common/src/types/executor_def.rs
@@ -4,6 +4,9 @@ use std::fmt;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
+// ExecutorResourceSpec is the persisted wire shape; ExecutorDef is the runtime shape.
+use super::resource::ExecutorResourceSpec;
+
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Hash)]
 #[serde(rename_all = "snake_case")]
 pub enum ExecutorType {
@@ -91,8 +94,13 @@ pub struct ExecutorDef {
     /// Expected stdout format, serialized as "envelope", "json", or "text".
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub stdout_format: Option<StdoutFormat>,
-    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
-    pub models: HashMap<String, String>,
+    /// Overrides the agent family's default `AgentModelPair` resolution for audit
+    /// canonicalization, envelope rendering, and review attribution.
+    ///
+    /// Does NOT control which model the subprocess actually runs; operators
+    /// should encode runtime model selection in `args`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub model_pair_override: Option<ModelPairOverride>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub timeout_seconds: Option<u64>,
     #[serde(default)]
@@ -112,16 +120,249 @@ pub struct ExecutorDef {
     pub updated_at: DateTime<Utc>,
 }
 
+/// Override for an agent family's strong/weak `AgentModelPair`.
+///
+/// Controls how Orbit canonicalizes the agent's model for audit trail,
+/// envelope rendering, and review automation attribution.
+///
+/// Does NOT control which model the subprocess actually runs. Operators must
+/// encode the runtime model in `args`, and may set `ORBIT_AGENT_MODEL` via
+/// `env:` for explicit audit attribution.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[serde(deny_unknown_fields)]
+pub struct ModelPairOverride {
+    pub strong: String,
+    pub weak: String,
+}
+
 fn is_false(value: &bool) -> bool {
     !*value
 }
 
 impl ExecutorDef {
-    pub fn model_for_tier(&self, tier: &str) -> Option<&str> {
-        self.models
-            .get(tier)
-            .map(String::as_str)
-            .map(str::trim)
-            .filter(|value| !value.is_empty())
+    pub fn from_resource_spec(
+        name: String,
+        spec: ExecutorResourceSpec,
+        source_label: &str,
+        created_at: DateTime<Utc>,
+        updated_at: DateTime<Utc>,
+    ) -> Self {
+        let ExecutorResourceSpec {
+            executor_type,
+            command,
+            args,
+            stdout_format,
+            model_pair_override,
+            legacy_models,
+            timeout_seconds,
+            env,
+            sandbox,
+            allow_fallback,
+            created_at: _,
+            updated_at: _,
+        } = spec;
+
+        if legacy_models.is_some() {
+            tracing::warn!(
+                target: "orbit.executor.def",
+                source = %source_label,
+                "deprecated `models` key on executor def; rename to `model_pair_override` for AgentModelPair audit/envelope/review overrides. Runtime model selection is not controlled by this field; encode it in `args`, and set `ORBIT_AGENT_MODEL` via `env:` for explicit audit attribution."
+            );
+        }
+
+        Self {
+            name,
+            executor_type,
+            command,
+            args,
+            stdout_format,
+            model_pair_override: model_pair_override.or(legacy_models),
+            timeout_seconds,
+            env,
+            sandbox,
+            allow_fallback,
+            created_at,
+            updated_at,
+        }
+    }
+
+    pub fn model_pair_override(&self) -> Option<&ModelPairOverride> {
+        self.model_pair_override.as_ref()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::{self, Write};
+    use std::sync::{Arc, Mutex};
+
+    use tracing_subscriber::filter::LevelFilter;
+    use tracing_subscriber::fmt::MakeWriter;
+
+    use super::*;
+    use crate::types::ExecutorResource;
+
+    #[derive(Clone)]
+    struct CaptureMakeWriter(Arc<Mutex<Vec<u8>>>);
+
+    struct CaptureWriter(Arc<Mutex<Vec<u8>>>);
+
+    impl<'a> MakeWriter<'a> for CaptureMakeWriter {
+        type Writer = CaptureWriter;
+
+        fn make_writer(&'a self) -> Self::Writer {
+            CaptureWriter(Arc::clone(&self.0))
+        }
+    }
+
+    impl Write for CaptureWriter {
+        fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+            self.0
+                .lock()
+                .expect("capture writer lock")
+                .extend_from_slice(buf);
+            Ok(buf.len())
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
+
+    fn capture_warnings<F, T>(f: F) -> (T, String)
+    where
+        F: FnOnce() -> T,
+    {
+        let buffer = Arc::new(Mutex::new(Vec::new()));
+        let subscriber = tracing_subscriber::fmt()
+            .with_writer(CaptureMakeWriter(Arc::clone(&buffer)))
+            .with_max_level(LevelFilter::WARN)
+            .with_target(true)
+            .with_ansi(false)
+            .without_time()
+            .finish();
+        let result = tracing::subscriber::with_default(subscriber, f);
+        let logs = String::from_utf8(buffer.lock().expect("capture buffer lock").clone())
+            .expect("captured logs are utf8");
+        (result, logs)
+    }
+
+    fn def_from_yaml(yaml: &str, source_label: &str) -> ExecutorDef {
+        let resource: ExecutorResource = serde_yaml::from_str(yaml).expect("parse executor yaml");
+        ExecutorDef::from_resource_spec(
+            resource.metadata.name,
+            resource.spec.clone(),
+            source_label,
+            resource.spec.created_at,
+            resource.spec.updated_at,
+        )
+    }
+
+    #[test]
+    fn roundtrips_model_pair_override_without_legacy_models_key() {
+        let def = def_from_yaml(
+            r#"
+schemaVersion: 2
+kind: Executor
+metadata:
+  name: gemini
+spec:
+  executor_type: direct_agent
+  command: gemini
+  args:
+    - -m
+    - gemini-3.1-pro
+  model_pair_override:
+    strong: gemini-3.1-pro
+    weak: gemini-3-flash
+"#,
+            "roundtrip",
+        );
+
+        assert_eq!(
+            def.model_pair_override(),
+            Some(&ModelPairOverride {
+                strong: "gemini-3.1-pro".to_string(),
+                weak: "gemini-3-flash".to_string(),
+            })
+        );
+
+        let serialized = serde_yaml::to_string(&def).expect("serialize executor def");
+        assert!(
+            serialized.contains("model_pair_override:"),
+            "serialized executor def should use new key: {serialized}"
+        );
+        assert!(
+            !serialized.contains("models:"),
+            "serialized executor def should not use legacy key: {serialized}"
+        );
+    }
+
+    #[test]
+    fn legacy_models_deserializes_with_deprecation_warning() {
+        let (def, logs) = capture_warnings(|| {
+            def_from_yaml(
+                r#"
+schemaVersion: 2
+kind: Executor
+metadata:
+  name: gemini
+spec:
+  executor_type: direct_agent
+  command: gemini
+  models:
+    strong: gemini-3.1-pro
+    weak: gemini-3-flash
+"#,
+                "legacy",
+            )
+        });
+
+        assert_eq!(
+            def.model_pair_override(),
+            Some(&ModelPairOverride {
+                strong: "gemini-3.1-pro".to_string(),
+                weak: "gemini-3-flash".to_string(),
+            })
+        );
+        assert_eq!(
+            logs.matches("deprecated `models` key").count(),
+            1,
+            "expected one deprecation warning, got: {logs}"
+        );
+        assert!(
+            logs.contains("orbit.executor.def"),
+            "warning should use executor def target: {logs}"
+        );
+        assert!(logs.contains("model_pair_override"), "{logs}");
+        assert!(logs.contains("AgentModelPair"), "{logs}");
+        assert!(logs.contains("args"), "{logs}");
+        assert!(logs.contains("env:"), "{logs}");
+        assert!(logs.contains("ORBIT_AGENT_MODEL"), "{logs}");
+    }
+
+    #[test]
+    fn legacy_models_rejects_unknown_keys() {
+        let err = serde_yaml::from_str::<ExecutorResource>(
+            r#"
+schemaVersion: 2
+kind: Executor
+metadata:
+  name: gemini
+spec:
+  executor_type: direct_agent
+  command: gemini
+  models:
+    strong: gemini-3.1-pro
+    weak: gemini-3-flash
+    extra: unsupported
+"#,
+        )
+        .expect_err("unknown model-pair keys should be rejected");
+
+        assert!(
+            err.to_string().contains("extra"),
+            "error should name the unsupported key: {err}"
+        );
     }
 }

--- a/crates/orbit-common/src/types/job.rs
+++ b/crates/orbit-common/src/types/job.rs
@@ -303,8 +303,6 @@ pub struct JobStep {
     pub executor: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub model: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub model_tier: Option<String>,
     pub timeout_seconds: u64,
     /// Additional env var names to pass through in hermetic mode, on top of the global allowlist.
     #[serde(default)]
@@ -340,7 +338,6 @@ impl Default for JobStep {
             agent_cli: String::new(),
             executor: None,
             model: None,
-            model_tier: None,
             timeout_seconds: 0,
             env_extra: Vec::new(),
             env_set: HashMap::new(),

--- a/crates/orbit-common/src/types/mod.rs
+++ b/crates/orbit-common/src/types/mod.rs
@@ -78,7 +78,9 @@ pub use duel::{
 };
 pub use error::{NotFoundKind, OrbitError};
 pub use event::OrbitEvent;
-pub use executor_def::{ExecutorDef, ExecutorSandboxKind, ExecutorType, StdoutFormat};
+pub use executor_def::{
+    ExecutorDef, ExecutorSandboxKind, ExecutorType, ModelPairOverride, StdoutFormat,
+};
 pub use friction::{FrictionEntry, FrictionFrontmatter, FrictionRecord};
 pub use id::OrbitId;
 pub use invocation::{InvocationTrace, TokenUsage, ToolCallTrace};

--- a/crates/orbit-common/src/types/resource.rs
+++ b/crates/orbit-common/src/types/resource.rs
@@ -3,7 +3,9 @@ use std::collections::HashMap;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
-use crate::types::{ExecutorSandboxKind, ExecutorType, FsProfile, OrbitError, StdoutFormat};
+use crate::types::{
+    ExecutorSandboxKind, ExecutorType, FsProfile, ModelPairOverride, OrbitError, StdoutFormat,
+};
 
 pub const EXECUTOR_RESOURCE_SCHEMA_VERSION: u32 = 2;
 pub const POLICY_RESOURCE_SCHEMA_VERSION: u32 = 2;
@@ -174,8 +176,11 @@ pub struct ExecutorResourceSpec {
     pub args: Vec<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub stdout_format: Option<StdoutFormat>,
-    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
-    pub models: HashMap<String, String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub model_pair_override: Option<ModelPairOverride>,
+    /// Deprecated alias for `model_pair_override`; remove after one release.
+    #[serde(default, skip_serializing_if = "Option::is_none", rename = "models")]
+    pub legacy_models: Option<ModelPairOverride>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub timeout_seconds: Option<u64>,
     #[serde(default)]

--- a/crates/orbit-core/assets/executors/claude.yaml
+++ b/crates/orbit-core/assets/executors/claude.yaml
@@ -15,7 +15,7 @@ spec:
     - default
   stdout_format: envelope
   sandbox: macos-sandbox-exec
-  models:
+  model_pair_override:
     strong: claude-opus-4-7
     weak: claude-sonnet-4-6
   env: {}

--- a/crates/orbit-core/assets/executors/codex.yaml
+++ b/crates/orbit-core/assets/executors/codex.yaml
@@ -10,7 +10,7 @@ spec:
     - --json
   stdout_format: envelope
   sandbox: macos-sandbox-exec
-  models:
+  model_pair_override:
     strong: gpt-5.5
     weak: gpt-5.4-mini
   env: {}

--- a/crates/orbit-core/src/command/executor.rs
+++ b/crates/orbit-core/src/command/executor.rs
@@ -81,18 +81,11 @@ fn parse_default_executor(name: &str, yaml: &str) -> Result<ExecutorDef, OrbitEr
         )));
     }
 
-    Ok(ExecutorDef {
-        name: resource.metadata.name,
-        executor_type: resource.spec.executor_type,
-        command: resource.spec.command,
-        args: resource.spec.args,
-        stdout_format: resource.spec.stdout_format,
-        models: resource.spec.models,
-        timeout_seconds: resource.spec.timeout_seconds,
-        env: resource.spec.env,
-        sandbox: resource.spec.sandbox,
-        allow_fallback: resource.spec.allow_fallback,
-        created_at: resource.spec.created_at,
-        updated_at: resource.spec.updated_at,
-    })
+    Ok(ExecutorDef::from_resource_spec(
+        resource.metadata.name,
+        resource.spec.clone(),
+        &format!("embedded:{name}"),
+        resource.spec.created_at,
+        resource.spec.updated_at,
+    ))
 }

--- a/crates/orbit-core/src/command/job/exec.rs
+++ b/crates/orbit-core/src/command/job/exec.rs
@@ -644,7 +644,7 @@ printf '%s\n' '{"type":"turn.completed","usage":{"input_tokens":100,"cached_inpu
                 command: Some(fake_bin.display().to_string()),
                 args: Vec::new(),
                 stdout_format: None,
-                models: HashMap::new(),
+                model_pair_override: None,
                 timeout_seconds: None,
                 env: HashMap::new(),
                 sandbox: None,

--- a/crates/orbit-core/src/runtime/engine/envelope.rs
+++ b/crates/orbit-core/src/runtime/engine/envelope.rs
@@ -297,7 +297,6 @@ mod tests {
             job: None,
             agent_cli: "codex".to_string(),
             model: Some("test-model".to_string()),
-            model_tier: None,
             timeout_seconds: 5,
             env_extra: Vec::new(),
             env_set: HashMap::new(),

--- a/crates/orbit-core/src/runtime/engine/identity.rs
+++ b/crates/orbit-core/src/runtime/engine/identity.rs
@@ -21,10 +21,8 @@ impl OrbitRuntime {
             .ok()
             .flatten()
             .and_then(|def| {
-                Some(AgentModelPair::new(
-                    def.model_for_tier("strong")?.to_string(),
-                    def.model_for_tier("weak")?.to_string(),
-                ))
+                def.model_pair_override()
+                    .map(|pair| AgentModelPair::new(pair.strong.clone(), pair.weak.clone()))
             })
             .or_else(|| resolve_agent_model_pair(agent_cli))
     }

--- a/crates/orbit-core/src/runtime/engine/runtime_host.rs
+++ b/crates/orbit-core/src/runtime/engine/runtime_host.rs
@@ -112,7 +112,6 @@ impl RuntimeHost for OrbitRuntime {
             job: None,
             agent_cli: agent_cli.to_string(),
             model: model.map(ToOwned::to_owned),
-            model_tier: None,
             timeout_seconds,
             env_extra: Vec::new(),
             env_set: HashMap::new(),
@@ -185,10 +184,7 @@ impl RuntimeHost for OrbitRuntime {
         execution: &ExecutionContext,
         trace: &InvocationTrace,
     ) -> Result<(), OrbitError> {
-        let requested_model = execution
-            .model
-            .as_deref()
-            .or(execution.model_tier.as_deref());
+        let requested_model = execution.model.as_deref();
         let (agent, model) =
             self.canonical_agent_model_identity(Some(&execution.agent_cli), requested_model);
         let store = open_invocation_store(self)?;
@@ -262,7 +258,7 @@ mod tests {
                 command: Some(fake_agent.display().to_string()),
                 args: Vec::new(),
                 stdout_format: None,
-                models: HashMap::new(),
+                model_pair_override: None,
                 timeout_seconds: None,
                 env: HashMap::new(),
                 sandbox: None,

--- a/crates/orbit-core/src/runtime/v2_host/test_support.rs
+++ b/crates/orbit-core/src/runtime/v2_host/test_support.rs
@@ -24,7 +24,7 @@ pub(crate) fn seed_executor(
             command: Some(name.to_string()),
             args: vec!["exec".to_string(), "--json".to_string()],
             stdout_format: None,
-            models: HashMap::new(),
+            model_pair_override: None,
             timeout_seconds: None,
             env: HashMap::new(),
             sandbox,

--- a/crates/orbit-engine/src/context.rs
+++ b/crates/orbit-engine/src/context.rs
@@ -93,7 +93,6 @@ pub struct ExecutionContext {
     pub job: Option<Job>,
     pub agent_cli: String,
     pub model: Option<String>,
-    pub model_tier: Option<String>,
     pub timeout_seconds: u64,
     pub env_extra: Vec<String>,
     /// Explicit env var key-value pairs that override same-named vars from
@@ -1179,7 +1178,6 @@ mod state_env_var_tests {
             job: None,
             agent_cli: "claude".to_string(),
             model: None,
-            model_tier: None,
             timeout_seconds: 60,
             env_extra: Vec::new(),
             env_set: HashMap::new(),

--- a/crates/orbit-engine/src/executor/direct_agent.rs
+++ b/crates/orbit-engine/src/executor/direct_agent.rs
@@ -21,7 +21,7 @@ fn inject_proc_allowed_programs(mode: EnvironmentMode, programs: &[String]) -> E
 fn inject_agent_identity(
     mode: EnvironmentMode,
     agent_label: &str,
-    resolved_model: Option<&str>,
+    execution: &ExecutionContext,
 ) -> EnvironmentMode {
     let agent = normalize_agent_label(agent_label);
     if agent.is_empty() {
@@ -30,7 +30,12 @@ fn inject_agent_identity(
 
     inject_environment(mode, |pairs| {
         pairs.push(("ORBIT_AGENT_NAME".to_string(), agent.clone()));
-        if let Some(model) = resolved_model.filter(|value| !value.is_empty()) {
+        if let Some(model) = execution
+            .model
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+        {
             pairs.push(("ORBIT_AGENT_MODEL".to_string(), model.to_string()));
         }
     })
@@ -109,9 +114,6 @@ impl ActivityExecutor for DirectAgentExecutor {
         };
         let args = self.bound_executor.args.clone();
 
-        // --- Resolve model (step.model → step.model_tier → executor def models) ---
-        let model = resolve_executor_model(&self.bound_executor, execution);
-
         // --- Assemble environment ---
         let label = self.bound_executor.name.clone();
         let mut env_set = self.bound_executor.env.clone();
@@ -125,7 +127,7 @@ impl ActivityExecutor for DirectAgentExecutor {
                             &execution.activity.tools,
                         ),
                         &label,
-                        model.as_deref(),
+                        execution,
                     ),
                     &execution.activity.proc_allowed_programs,
                 ),
@@ -153,34 +155,6 @@ impl ActivityExecutor for DirectAgentExecutor {
 
         map_exec_result_to_outcome(&exec_result)
     }
-}
-
-// ---------------------------------------------------------------------------
-// Model resolution
-// ---------------------------------------------------------------------------
-
-fn resolve_executor_model(
-    executor_def: &ExecutorDef,
-    execution: &ExecutionContext,
-) -> Option<String> {
-    // 1. Explicit model on the step
-    if let Some(model) = execution
-        .model
-        .as_deref()
-        .map(str::trim)
-        .filter(|v| !v.is_empty())
-    {
-        return Some(model.to_string());
-    }
-
-    // 2. Model tier mapped through executor def
-    let tier = execution
-        .model_tier
-        .as_deref()
-        .map(str::trim)
-        .filter(|v| !v.is_empty())?;
-
-    executor_def.model_for_tier(tier).map(|m| m.to_string())
 }
 
 fn is_timeout(exec_result: &orbit_common::types::ExecutionResult) -> bool {

--- a/crates/orbit-store/Cargo.toml
+++ b/crates/orbit-store/Cargo.toml
@@ -25,3 +25,5 @@ sha2.workspace = true
 
 [dev-dependencies]
 tempfile = "3"
+tracing.workspace = true
+tracing-subscriber.workspace = true

--- a/crates/orbit-store/src/file/executor_def_store.rs
+++ b/crates/orbit-store/src/file/executor_def_store.rs
@@ -70,7 +70,8 @@ impl ExecutorDefFileStore {
                 command: def.command.clone(),
                 args: def.args.clone(),
                 stdout_format: def.stdout_format,
-                models: def.models.clone(),
+                model_pair_override: def.model_pair_override.clone(),
+                legacy_models: None,
                 timeout_seconds: def.timeout_seconds,
                 env: def.env.clone(),
                 sandbox: def.sandbox,
@@ -100,20 +101,13 @@ fn parse_executor_def(content: &str, label: String) -> Result<ExecutorDef, Orbit
         )));
     }
     doc.metadata.validate_name()?;
-    Ok(ExecutorDef {
-        name: doc.metadata.name,
-        executor_type: doc.spec.executor_type,
-        command: doc.spec.command,
-        args: doc.spec.args,
-        stdout_format: doc.spec.stdout_format,
-        models: doc.spec.models,
-        timeout_seconds: doc.spec.timeout_seconds,
-        env: doc.spec.env,
-        sandbox: doc.spec.sandbox,
-        allow_fallback: doc.spec.allow_fallback,
-        created_at: doc.spec.created_at,
-        updated_at: doc.spec.updated_at,
-    })
+    Ok(ExecutorDef::from_resource_spec(
+        doc.metadata.name,
+        doc.spec.clone(),
+        &label,
+        doc.spec.created_at,
+        doc.spec.updated_at,
+    ))
 }
 
 #[cfg(test)]
@@ -133,7 +127,7 @@ mod tests {
             command: Some(name.to_string()),
             args: vec!["--flag".to_string()],
             stdout_format: None,
-            models: HashMap::new(),
+            model_pair_override: None,
             timeout_seconds: None,
             env: HashMap::new(),
             sandbox: None,

--- a/crates/orbit-store/tests/fixtures/legacy_models_executor.yaml
+++ b/crates/orbit-store/tests/fixtures/legacy_models_executor.yaml
@@ -1,20 +1,18 @@
 schemaVersion: 2
 kind: Executor
 metadata:
-  name: gemini
+  name: legacy-gemini
 spec:
   executor_type: direct_agent
   command: gemini
   args:
     - --approval-mode
     - yolo
-    - --allowed-mcp-server-names
-    - orbit
     - -o
     - json
   stdout_format: envelope
   sandbox: macos-sandbox-exec
-  model_pair_override:
+  models:
     strong: gemini-3.1-pro
     weak: gemini-3-flash
   env: {}

--- a/crates/orbit-store/tests/legacy_models_warns.rs
+++ b/crates/orbit-store/tests/legacy_models_warns.rs
@@ -1,0 +1,78 @@
+//! Regression coverage for legacy `models:` executor definitions.
+
+use std::io::{self, Write};
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
+
+use orbit_store::global_executor_def_store;
+use tracing_subscriber::filter::LevelFilter;
+use tracing_subscriber::fmt::MakeWriter;
+
+#[derive(Clone)]
+struct CaptureMakeWriter(Arc<Mutex<Vec<u8>>>);
+
+struct CaptureWriter(Arc<Mutex<Vec<u8>>>);
+
+impl<'a> MakeWriter<'a> for CaptureMakeWriter {
+    type Writer = CaptureWriter;
+
+    fn make_writer(&'a self) -> Self::Writer {
+        CaptureWriter(Arc::clone(&self.0))
+    }
+}
+
+impl Write for CaptureWriter {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.0
+            .lock()
+            .expect("capture writer lock")
+            .extend_from_slice(buf);
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+fn capture_warnings<F, T>(f: F) -> (T, String)
+where
+    F: FnOnce() -> T,
+{
+    let buffer = Arc::new(Mutex::new(Vec::new()));
+    let subscriber = tracing_subscriber::fmt()
+        .with_writer(CaptureMakeWriter(Arc::clone(&buffer)))
+        .with_max_level(LevelFilter::WARN)
+        .with_target(true)
+        .with_ansi(false)
+        .without_time()
+        .finish();
+    let result = tracing::subscriber::with_default(subscriber, f);
+    let logs = String::from_utf8(buffer.lock().expect("capture buffer lock").clone())
+        .expect("captured logs are utf8");
+    (result, logs)
+}
+
+#[test]
+fn loading_legacy_models_fixture_warns_once_per_def() {
+    let fixtures = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures");
+    let store = global_executor_def_store(fixtures);
+
+    let (defs, logs) = capture_warnings(|| store.list_executor_defs().expect("load fixtures"));
+
+    assert_eq!(defs.len(), 1);
+    let pair = defs[0]
+        .model_pair_override()
+        .expect("legacy models become model_pair_override");
+    assert_eq!(pair.strong, "gemini-3.1-pro");
+    assert_eq!(pair.weak, "gemini-3-flash");
+    assert_eq!(
+        logs.matches("deprecated `models` key").count(),
+        1,
+        "expected one deprecation warning, got: {logs}"
+    );
+    assert!(
+        logs.contains("orbit.executor.def"),
+        "warning should use executor def target: {logs}"
+    );
+}


### PR DESCRIPTION
## Task

ORB-00038 — Rename `ExecutorDef.models` → `model_pair_override`; delete dead `model_tier`.

## Execution Summary

- Added `ModelPairOverride { strong, weak }` in `orbit-common`, re-exported it, and replaced `ExecutorDef.models` with `model_pair_override` plus documentation that the field affects `AgentModelPair` audit/envelope/review attribution, not subprocess runtime model selection.
- Added `ExecutorDef::from_resource_spec(...)` and routed embedded executor loading, file-store loading, and `orbit apply` through it so legacy `models:` handling is centralized.
- Added a one-release `ExecutorResourceSpec.legacy_models` alias for old YAML, with a `tracing::warn!` on `orbit.executor.def` whenever the deprecated key is present.
- Removed dead `model_tier` from `ExecutionContext` and `JobStep`, simplified audit requested-model selection, and deleted `resolve_executor_model` from `direct_agent`.
- Migrated bundled executor YAMLs to `model_pair_override:` while preserving existing strong/weak values.
- Added unit coverage and an orbit-store integration fixture/test for legacy `models:` warnings.

## Notes

- Save-then-reload migrates persisted executor YAML: `ExecutorDefFileStore::upsert_executor_def` writes only `model_pair_override:` and omits the legacy `models:` alias.
- `from_resource_spec` is public because its production callers are in separate crates (`orbit-cli`, `orbit-core`, `orbit-store`) and it belongs to the common type conversion surface.
- The legacy warning fires whenever `models:` is present, even if `model_pair_override:` is also present, so operators are told to remove the deprecated key. The new key wins for the actual override value.
- Follow-up filed: ORB-00051 removes the legacy alias and warning shim after the compatibility window.

## Smoke Evidence

The current Gemini CLI/API returned `ModelNotFoundError` for `gemini-3.1-pro`, so the live smoke used `gemini-2.5-flash` for runtime execution. The executor override values are still preserved in YAML as required.

New-shape run: `jrun-20260516-0233`

```json
{"schemaVersion":1,"event_type":"cli.invocation.started","event_id":"v2evt-jrun-20260516-0233-00000005","ts":"2026-05-16T02:33:23.357795Z","run_id":"jrun-20260516-0233","agent_identity":"system","parent_event_id":"v2evt-jrun-20260516-0233-00000003","workspace_path":"/private/tmp/orbit-orb-00038-smoke-new-live.MLExDc/workspace","body_kind":"cli_invocation_started","provider":"gemini","argv_redacted":["gemini","--approval-mode","yolo","--skip-trust","--allowed-mcp-server-names","orbit","-o","json","-m","gemini-2.5-flash"],"stdin_blob_ref":"5b4d003c423633e466e77ab1d68a26a6be178a5b4554873a151a3998f9e98604","model":"gemini-2.5-flash","cwd":"/private/tmp/orbit-orb-00038-smoke-new-live.MLExDc/workspace","wall_clock_timeout_ms":120000}
{"schemaVersion":1,"event_type":"run.finished","event_id":"v2evt-jrun-20260516-0233-00000009","ts":"2026-05-16T02:33:29.563360Z","run_id":"jrun-20260516-0233","agent_identity":"system","workspace_path":"/private/tmp/orbit-orb-00038-smoke-new-live.MLExDc/workspace","body_kind":"run_finished","outcome":"success"}
```

Legacy-shape run: `jrun-20260516-0234`

```json
{"schemaVersion":1,"event_type":"cli.invocation.started","event_id":"v2evt-jrun-20260516-0234-00000005","ts":"2026-05-16T02:34:09.150191Z","run_id":"jrun-20260516-0234","agent_identity":"system","parent_event_id":"v2evt-jrun-20260516-0234-00000003","workspace_path":"/private/tmp/orbit-orb-00038-smoke-legacy-live2.J9LfKf/workspace","body_kind":"cli_invocation_started","provider":"gemini","argv_redacted":["gemini","--approval-mode","yolo","--skip-trust","-o","json","-m","gemini-2.5-flash"],"stdin_blob_ref":"b3510968ac254775cb79efead239e516991d81bc8e3b07465eb33b27c756a314","model":"gemini-2.5-flash","cwd":"/private/tmp/orbit-orb-00038-smoke-legacy-live2.J9LfKf/workspace","wall_clock_timeout_ms":120000}
{"schemaVersion":1,"event_type":"run.finished","event_id":"v2evt-jrun-20260516-0234-00000009","ts":"2026-05-16T02:34:15.934316Z","run_id":"jrun-20260516-0234","agent_identity":"system","workspace_path":"/private/tmp/orbit-orb-00038-smoke-legacy-live2.J9LfKf/workspace","body_kind":"run_finished","outcome":"success"}
```

Legacy warning line:

```text
2026-05-16T02:34:09.052684Z  WARN orbit.executor.def: deprecated `models` key on executor def; rename to `model_pair_override` for AgentModelPair audit/envelope/review overrides. Runtime model selection is not controlled by this field; encode it in `args`, and set `ORBIT_AGENT_MODEL` via `env:` for explicit audit attribution. source=/tmp/orbit-orb-00038-smoke-legacy-live2.J9LfKf/home/.orbit/resources/executors/gemini.yaml
```

## Validation

- `cargo check -p orbit-common -p orbit-core -p orbit-engine -p orbit-cli -p orbit-store`
- `cargo test --workspace`
- `make ci-fast`

## Branch Freshness

Built from `5f5b1c51` and pushed as `codex/orb-00038-model-pair-override`.
