### PR TITLE
[codex] Inject direct-agent runtime model flag

### DIFF
--- a/crates/orbit-common/src/types/executor_def.rs
+++ b/crates/orbit-common/src/types/executor_def.rs
@@ -101,6 +101,17 @@ pub struct ExecutorDef {
     /// should encode runtime model selection in `args`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub model_pair_override: Option<ModelPairOverride>,
+    /// CLI flag name used to pass `JobStep.model` to a direct-agent subprocess.
+    ///
+    /// Carries only the flag name, for example `"-m"` or `"--model"`. At
+    /// invocation time, when both `model_flag` and the step's runtime model are
+    /// present, `direct_agent` appends `[model_flag, step.model]` after the
+    /// operator-declared `args`. Orbit does not inspect `args` for duplicates;
+    /// the CLI's own last-wins behavior resolves repeated model flags. When
+    /// either field is absent, nothing is injected, so operators can still
+    /// hardcode fixed model arguments such as `--model X` in `args`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub model_flag: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub timeout_seconds: Option<u64>,
     #[serde(default)]
@@ -154,6 +165,7 @@ impl ExecutorDef {
             stdout_format,
             model_pair_override,
             legacy_models,
+            model_flag,
             timeout_seconds,
             env,
             sandbox,
@@ -177,6 +189,7 @@ impl ExecutorDef {
             args,
             stdout_format,
             model_pair_override: model_pair_override.or(legacy_models),
+            model_flag,
             timeout_seconds,
             env,
             sandbox,
@@ -275,6 +288,7 @@ spec:
   model_pair_override:
     strong: gemini-3.1-pro
     weak: gemini-3-flash
+  model_flag: "-m"
 "#,
             "roundtrip",
         );
@@ -286,11 +300,16 @@ spec:
                 weak: "gemini-3-flash".to_string(),
             })
         );
+        assert_eq!(def.model_flag.as_deref(), Some("-m"));
 
         let serialized = serde_yaml::to_string(&def).expect("serialize executor def");
         assert!(
             serialized.contains("model_pair_override:"),
             "serialized executor def should use new key: {serialized}"
+        );
+        assert!(
+            serialized.contains("model_flag: -m"),
+            "serialized executor def should include model flag: {serialized}"
         );
         assert!(
             !serialized.contains("models:"),

--- a/crates/orbit-common/src/types/resource.rs
+++ b/crates/orbit-common/src/types/resource.rs
@@ -178,6 +178,8 @@ pub struct ExecutorResourceSpec {
     pub stdout_format: Option<StdoutFormat>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub model_pair_override: Option<ModelPairOverride>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub model_flag: Option<String>,
     /// Deprecated alias for `model_pair_override`; remove after one release.
     #[serde(default, skip_serializing_if = "Option::is_none", rename = "models")]
     pub legacy_models: Option<ModelPairOverride>,

--- a/crates/orbit-core/assets/executors/claude.yaml
+++ b/crates/orbit-core/assets/executors/claude.yaml
@@ -18,4 +18,5 @@ spec:
   model_pair_override:
     strong: claude-opus-4-7
     weak: claude-sonnet-4-6
+  model_flag: "--model"
   env: {}

--- a/crates/orbit-core/assets/executors/codex.yaml
+++ b/crates/orbit-core/assets/executors/codex.yaml
@@ -13,4 +13,5 @@ spec:
   model_pair_override:
     strong: gpt-5.5
     weak: gpt-5.4-mini
+  model_flag: "--model"
   env: {}

--- a/crates/orbit-core/assets/executors/gemini.yaml
+++ b/crates/orbit-core/assets/executors/gemini.yaml
@@ -17,4 +17,5 @@ spec:
   model_pair_override:
     strong: gemini-3.1-pro
     weak: gemini-3-flash
+  model_flag: "-m"
   env: {}

--- a/crates/orbit-core/src/command/job/exec.rs
+++ b/crates/orbit-core/src/command/job/exec.rs
@@ -645,6 +645,7 @@ printf '%s\n' '{"type":"turn.completed","usage":{"input_tokens":100,"cached_inpu
                 args: Vec::new(),
                 stdout_format: None,
                 model_pair_override: None,
+                model_flag: None,
                 timeout_seconds: None,
                 env: HashMap::new(),
                 sandbox: None,

--- a/crates/orbit-core/src/runtime/engine/runtime_host.rs
+++ b/crates/orbit-core/src/runtime/engine/runtime_host.rs
@@ -259,6 +259,7 @@ mod tests {
                 args: Vec::new(),
                 stdout_format: None,
                 model_pair_override: None,
+                model_flag: None,
                 timeout_seconds: None,
                 env: HashMap::new(),
                 sandbox: None,

--- a/crates/orbit-core/src/runtime/v2_host/test_support.rs
+++ b/crates/orbit-core/src/runtime/v2_host/test_support.rs
@@ -25,6 +25,7 @@ pub(crate) fn seed_executor(
             args: vec!["exec".to_string(), "--json".to_string()],
             stdout_format: None,
             model_pair_override: None,
+            model_flag: None,
             timeout_seconds: None,
             env: HashMap::new(),
             sandbox,

--- a/crates/orbit-engine/src/executor/direct_agent.rs
+++ b/crates/orbit-engine/src/executor/direct_agent.rs
@@ -75,6 +75,23 @@ fn normalize_agent_label(agent_cli: &str) -> String {
         .to_ascii_lowercase()
 }
 
+fn append_runtime_model_args(
+    args: &mut Vec<String>,
+    model_flag: Option<&str>,
+    model: Option<&str>,
+) {
+    let (Some(model_flag), Some(model)) = (model_flag, model) else {
+        return;
+    };
+
+    if model_flag.trim().is_empty() || model.trim().is_empty() {
+        return;
+    }
+
+    args.push(model_flag.to_string());
+    args.push(model.to_string());
+}
+
 pub struct DirectAgentExecutor {
     bound_executor: ExecutorDef,
 }
@@ -112,7 +129,12 @@ impl ActivityExecutor for DirectAgentExecutor {
                 ));
             }
         };
-        let args = self.bound_executor.args.clone();
+        let mut args = self.bound_executor.args.clone();
+        append_runtime_model_args(
+            &mut args,
+            self.bound_executor.model_flag.as_deref(),
+            execution.model.as_deref(),
+        );
 
         // --- Assemble environment ---
         let label = self.bound_executor.name.clone();
@@ -233,6 +255,48 @@ mod tests {
             exit_code: Some(if success { 0 } else { 1 }),
             duration_ms: 12,
             output: None,
+        }
+    }
+
+    fn args(values: &[&str]) -> Vec<String> {
+        values.iter().map(|value| (*value).to_string()).collect()
+    }
+
+    #[test]
+    fn appends_runtime_model_after_operator_args_when_flag_and_model_present() {
+        let mut argv = args(&["--existing", "old"]);
+
+        append_runtime_model_args(&mut argv, Some("--model"), Some("gpt-5.5"));
+
+        assert_eq!(argv, args(&["--existing", "old", "--model", "gpt-5.5"]));
+    }
+
+    #[test]
+    fn leaves_args_unchanged_when_model_flag_missing() {
+        let mut argv = args(&["--existing", "old"]);
+
+        append_runtime_model_args(&mut argv, None, Some("gpt-5.5"));
+
+        assert_eq!(argv, args(&["--existing", "old"]));
+    }
+
+    #[test]
+    fn leaves_args_unchanged_when_runtime_model_missing() {
+        let mut argv = args(&["--existing", "old"]);
+
+        append_runtime_model_args(&mut argv, Some("--model"), None);
+
+        assert_eq!(argv, args(&["--existing", "old"]));
+    }
+
+    #[test]
+    fn leaves_args_unchanged_when_runtime_model_is_blank() {
+        for model in ["", "   "] {
+            let mut argv = args(&["--existing", "old"]);
+
+            append_runtime_model_args(&mut argv, Some("--model"), Some(model));
+
+            assert_eq!(argv, args(&["--existing", "old"]));
         }
     }
 

--- a/crates/orbit-store/src/file/executor_def_store.rs
+++ b/crates/orbit-store/src/file/executor_def_store.rs
@@ -71,6 +71,7 @@ impl ExecutorDefFileStore {
                 args: def.args.clone(),
                 stdout_format: def.stdout_format,
                 model_pair_override: def.model_pair_override.clone(),
+                model_flag: def.model_flag.clone(),
                 legacy_models: None,
                 timeout_seconds: def.timeout_seconds,
                 env: def.env.clone(),
@@ -128,6 +129,7 @@ mod tests {
             args: vec!["--flag".to_string()],
             stdout_format: None,
             model_pair_override: None,
+            model_flag: None,
             timeout_seconds: None,
             env: HashMap::new(),
             sandbox: None,
@@ -154,6 +156,28 @@ mod tests {
         assert_eq!(loaded.name, "claude");
         assert_eq!(loaded.sandbox, Some(ExecutorSandboxKind::MacosSandboxExec));
         assert!(loaded.allow_fallback);
+    }
+
+    #[test]
+    fn roundtrips_model_flag_field() {
+        let dir = tempdir().expect("tempdir");
+        let store = ExecutorDefFileStore::new(dir.path().to_path_buf());
+
+        let mut def = baseline_def("gemini");
+        def.model_flag = Some("-m".to_string());
+        store.upsert_executor_def(&def).expect("upsert");
+
+        let loaded = store
+            .get_executor_def("gemini")
+            .expect("get")
+            .expect("present");
+        assert_eq!(loaded.model_flag.as_deref(), Some("-m"));
+
+        let on_disk = std::fs::read_to_string(dir.path().join("gemini.yaml")).expect("read");
+        assert!(
+            on_disk.contains("model_flag: -m"),
+            "model_flag should be persisted: {on_disk}"
+        );
     }
 
     #[test]

--- a/docs/design/policy-sandbox/1_overview.md
+++ b/docs/design/policy-sandbox/1_overview.md
@@ -2,7 +2,7 @@
 
 **Status:** Draft
 **Owner:** claude
-**Last updated:** 2026-05-14
+**Last updated:** 2026-05-16
 
 > **Sandbox backend status.** The only OS-level sandbox backend implemented today is `macos-sandbox-exec`. `ExecutorSandboxKind` (`crates/orbit-common/src/types/executor_def.rs`) defines no Linux or Windows variant, and `EnvironmentHost::resolve_executor_sandbox` (`crates/orbit-core/src/runtime/v2_host/sandbox.rs`) rejects `macos-sandbox-exec` on non-macOS platforms. On Linux and Windows the spawned agent subprocess runs without OS-level isolation; HTTP-tool `fs.*` enforcement and process supervision still apply. A Linux backend is named in [3_vision.md](./3_vision.md) as future work but is not in `2_design.md`'s shipped contract. [T20260505-23]
 

--- a/docs/design/policy-sandbox/2_design.md
+++ b/docs/design/policy-sandbox/2_design.md
@@ -2,7 +2,7 @@
 
 **Status:** Draft
 **Owner:** claude
-**Last updated:** 2026-05-14
+**Last updated:** 2026-05-16
 
 This document describes Orbit's shipped policy and sandboxing implementation: v2 `PolicyDef`, profile resolution, last-match-wins path evaluation, HTTP-tool enforcement, activity/job `fsProfile` binding, macOS CLI sandbox wrapping, and `orbit-exec` supervision. See [1_overview.md](./1_overview.md) for purpose and [3_vision.md](./3_vision.md) for forward-looking gaps.
 

--- a/docs/design/policy-sandbox/3_vision.md
+++ b/docs/design/policy-sandbox/3_vision.md
@@ -2,7 +2,7 @@
 
 **Status:** Draft
 **Owner:** claude
-**Last updated:** 2026-05-12
+**Last updated:** 2026-05-16
 
 This document captures the questions Orbit must answer before policy and sandboxing become a fuller safety contract. [2_design.md](./2_design.md) describes today's implementation; this file keeps future work distinct from shipped guarantees.
 


### PR DESCRIPTION
## Task

ORB-00053: make direct_agent inject the per-step runtime model through a data-driven executor `model_flag` field.

## Execution Summary

- Added `ExecutorDef.model_flag: Option<String>` and mirrored it on `ExecutorResourceSpec` with serde defaults.
- Propagated `model_flag` through `ExecutorDef::from_resource_spec` and the executor definition save path.
- Appended `[model_flag, step.model]` in direct_agent argv assembly only when both values are present and non-empty, after operator-declared args.
- Added bundled executor flags: Gemini uses `-m`; Claude and Codex use `--model`.
- Updated hand-written `ExecutorDef` literals and added focused unit/store round-trip coverage.
- Restamped policy-sandbox design docs after reading the affected docs because the decay check tracks the touched schema files.

## Validation

- `make ci-fast`
- `cargo test --workspace`
- `orbit design check --include-missing`
- `git diff --check`

Manual smoke:

- `jrun-20260516-0343`: Gemini direct-agent run with `step.model: gemini-2.5-flash`; audit argv includes `-m gemini-2.5-flash`; `cli.invocation.finished.exit_code = 0`.
- `jrun-20260516-0344`: Gemini direct-agent run with `step.model: gemini-3-flash-preview`; audit argv includes `-m gemini-3-flash-preview`; `cli.invocation.finished.exit_code = 0`.

Note: `gemini-3-flash` currently returns `ModelNotFoundError` from the installed Gemini CLI/API, so the successful second smoke used `gemini-3-flash-preview` to verify the model argument flips. Gemini CLI 0.42.0 also hung in this environment when the prompt was supplied only through stdin, so the smoke used a temporary executor with `-p <prompt>` in operator args and no `-m` in args.

## Branch Freshness

Rebased cleanly onto `origin/agent-main` before push.
