### PR TITLE
[ORB-00055] Allow expect/unwrap in orbit-store::legacy_models_warns test

### DIFF
--- a/crates/orbit-store/tests/legacy_models_warns.rs
+++ b/crates/orbit-store/tests/legacy_models_warns.rs
@@ -1,5 +1,7 @@
 //! Regression coverage for legacy `models:` executor definitions.
 
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
 use std::io::{self, Write};
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex};


### PR DESCRIPTION
## Summary

Adds `#![allow(clippy::expect_used, clippy::unwrap_used)]` to `crates/orbit-store/tests/legacy_models_warns.rs` — matching the existing convention across `orbit-common/tests/*`, `orbit-knowledge/tests/*`, `orbit-registry/tests/*` (12+ test files with this exact pattern).

## Why

The 5 `expect()` sites are all legitimate test invariants:

| Line | Site | Invariant |
|---|---|---|
| 26-28 | `Mutex::lock().expect("capture writer lock")` | poisoned-lock panic propagation (standard test pattern) |
| 51:34 | `buffer.lock().expect("capture buffer lock")` | same |
| 51:16 | `String::from_utf8(...).expect("captured logs are utf8")` | tests write UTF-8 strings by construction |
| 61 | `store.list_executor_defs().expect("load fixtures")` | fixture load is a test precondition |
| 64-66 | `def.model_pair_override().expect("legacy models become model_pair_override")` | the exact behavior under test — if it fails, the test should fail |

Per `CLAUDE.md` Rust Practices, scoped allowlists with comments are the accepted pattern for tests.

## Unblocks

Branch protection on `main` (established in [ORB-00054](.orbit/tasks/ORB-00054.md)) requires `Check / Clippy / Test` green. Until this lands, every PR to `main` needs `--admin` override.

## Verification

- `cargo clippy -p orbit-store --tests -- -D warnings` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean across all crates
- `cargo test -p orbit-store --test legacy_models_warns` — 1 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)