### PR TITLE
[ORB-00056] Fix CI failure-recovery task type: issue -> bug

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
               context: ".github/workflows/ci.yml",
               workspace: ".",
               priority: "high",
-              type: "issue"
+              type: "bug"
             }'
           )"
           cargo run -p orbit-cli --bin orbit -- tool run orbit.task.add --input "$payload"


### PR DESCRIPTION
## Summary

`.github/workflows/ci.yml` line 62 sets `type: "issue"` in the failure-recovery `orbit.task.add` payload. Valid orbit task types are `feature/bug/refactor/chore` — `bug` is the right fit for CI-failure tasks.

## Why

Self-referential broken-ness: when CI failed, the recovery step itself failed with `invalid input: type unknown task type: issue`, producing a confusing double-failure that overshadowed the real CI cause. Visible in any failed-CI workflow log since the step was added — most recently in [run 25952193060](https://github.com/danieljhkim/orbit/actions/runs/25952193060/job/76292095539) (the PR #241 CI failure that surfaced this).

Also means no CI-failure tasks have been recorded via this path since the regression — there's an invisible backlog of unrecorded failures.

## Change

One-line edit, `.github/workflows/ci.yml:62`:

```diff
-              type: "issue"
+              type: "bug"
```

Did not add the optional `tags: ["ci-failure"]` per the task's "fix the type and move on" guidance — keeping scope minimal.

## Verification limit

This can only be fully verified when CI fails next on a PR. The change is mechanical and matches the rejection message's `valid types: feature, bug, refactor, chore`. Spot-verified locally via `make ci-fast` (passes, but that doesn't exercise the failure-recovery step — by design it only runs on failure).

🤖 Generated with [Claude Code](https://claude.com/claude-code)