### PR TITLE
Implement orbit mcp init/remove support for Grok Build (.grok/ config)

### DIFF
--- a/crates/orbit-cli/src/command/environment/workspace.rs
+++ b/crates/orbit-cli/src/command/environment/workspace.rs
@@ -237,6 +237,7 @@ mod tests {
 
         std::fs::create_dir_all(workspace.path().join(".claude")).expect("create .claude");
         std::fs::create_dir_all(workspace.path().join(".gemini")).expect("create .gemini");
+        std::fs::create_dir_all(workspace.path().join(".grok")).expect("create .grok");
         std::fs::create_dir_all(home.path().join(".codex")).expect("create global .codex");
         std::fs::write(
             home.path().join(".codex").join("config.toml"),
@@ -288,6 +289,7 @@ mod tests {
                 .join("settings.json")
                 .exists()
         );
+        assert!(workspace.path().join(".grok").join("config.toml").exists());
     }
 
     #[test]
@@ -298,6 +300,7 @@ mod tests {
 
         std::fs::create_dir_all(workspace.path().join(".claude")).expect("create .claude");
         std::fs::create_dir_all(workspace.path().join(".gemini")).expect("create .gemini");
+        std::fs::create_dir_all(workspace.path().join(".grok")).expect("create .grok");
         std::fs::create_dir_all(home.path().join(".codex")).expect("create global .codex");
         std::fs::write(
             home.path().join(".codex").join("config.toml"),
@@ -349,6 +352,7 @@ mod tests {
                 .join("settings.json")
                 .exists()
         );
+        assert!(!workspace.path().join(".grok").join("config.toml").exists());
     }
 
     #[test]

--- a/crates/orbit-cli/src/command/mcp/mod.rs
+++ b/crates/orbit-cli/src/command/mcp/mod.rs
@@ -1,9 +1,9 @@
 //! `orbit mcp` — MCP client integration and server.
 //!
 //! `orbit mcp init/remove` manages local client integration for Claude Code,
-//! Codex, and Gemini. `orbit mcp serve` serves the Orbit tool surface over MCP so
-//! external clients can discover and invoke Orbit operations with typed JSON
-//! schemas.
+//! Codex, Gemini, and Grok. `orbit mcp serve` serves the Orbit tool surface over
+//! MCP so external clients can discover and invoke Orbit operations with typed
+//! JSON schemas.
 
 mod setup;
 

--- a/crates/orbit-cli/src/command/mcp/setup/args.rs
+++ b/crates/orbit-cli/src/command/mcp/setup/args.rs
@@ -8,18 +8,19 @@ use super::workspace::{env_home_dir, resolve_workspace_layout};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum, Default)]
 pub enum ScopeArg {
-    /// Write to user-level config (~/.claude, ~/.codex, ~/.gemini).
+    /// Write to user-level config (~/.claude, ~/.codex, ~/.gemini, ~/.grok).
     Home,
-    /// Write to repo-local config (.mcp.json, .codex/, .gemini/). Default.
+    /// Write to repo-local config (.mcp.json, .codex/, .gemini/, .grok/). Default.
     #[default]
     Workspace,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, ValueEnum)]
 pub(super) enum McpProvider {
     Claude,
     Codex,
     Gemini,
+    Grok,
     Cursor,
     Vscode,
     Windsurf,
@@ -31,6 +32,7 @@ impl McpProvider {
             Self::Claude => "claude",
             Self::Codex => "codex",
             Self::Gemini => "gemini",
+            Self::Grok => "grok",
             Self::Cursor => "cursor",
             Self::Vscode => "vscode",
             Self::Windsurf => "windsurf",
@@ -58,6 +60,9 @@ pub struct ProviderSelectionArgs {
     /// Use auto-detected provider targets for the current workspace.
     #[arg(long)]
     pub auto: bool,
+    /// Target a supported MCP client integration. Can be repeated.
+    #[arg(long = "client", value_enum, value_name = "CLIENT")]
+    clients: Vec<McpProvider>,
     /// Target Claude Code integration only.
     #[arg(long)]
     pub claude: bool,
@@ -67,6 +72,9 @@ pub struct ProviderSelectionArgs {
     /// Target Gemini CLI integration only.
     #[arg(long)]
     pub gemini: bool,
+    /// Target Grok Build integration only.
+    #[arg(long)]
+    pub grok: bool,
     /// Target Cursor integration only.
     #[arg(long)]
     pub cursor: bool,
@@ -83,18 +91,25 @@ pub struct ProviderSelectionArgs {
 
 impl ProviderSelectionArgs {
     fn any_explicit_provider(&self) -> bool {
-        self.claude || self.codex || self.gemini || self.cursor || self.vscode || self.windsurf
+        !self.clients.is_empty()
+            || self.claude
+            || self.codex
+            || self.gemini
+            || self.grok
+            || self.cursor
+            || self.vscode
+            || self.windsurf
     }
 
     fn resolve_mode(&self) -> Result<ProviderSelectionMode, OrbitError> {
         if self.auto && (self.any_explicit_provider() || self.all) {
             return Err(OrbitError::InvalidInput(
-                "--auto cannot be combined with --claude, --codex, --gemini, --cursor, --vscode, --windsurf, or --all".to_string(),
+                "--auto cannot be combined with --client, --claude, --codex, --gemini, --grok, --cursor, --vscode, --windsurf, or --all".to_string(),
             ));
         }
         if self.all && self.any_explicit_provider() {
             return Err(OrbitError::InvalidInput(
-                "--all cannot be combined with --claude, --codex, --gemini, --cursor, --vscode, or --windsurf".to_string(),
+                "--all cannot be combined with --client, --claude, --codex, --gemini, --grok, --cursor, --vscode, or --windsurf".to_string(),
             ));
         }
         if self.auto || (!self.any_explicit_provider() && !self.all) {
@@ -105,6 +120,7 @@ impl ProviderSelectionArgs {
                 McpProvider::Claude,
                 McpProvider::Codex,
                 McpProvider::Gemini,
+                McpProvider::Grok,
                 McpProvider::Cursor,
                 McpProvider::Vscode,
                 McpProvider::Windsurf,
@@ -112,25 +128,33 @@ impl ProviderSelectionArgs {
         }
 
         let mut providers = Vec::new();
-        if self.claude {
-            providers.push(McpProvider::Claude);
-        }
-        if self.codex {
-            providers.push(McpProvider::Codex);
-        }
-        if self.gemini {
-            providers.push(McpProvider::Gemini);
-        }
-        if self.cursor {
-            providers.push(McpProvider::Cursor);
-        }
-        if self.vscode {
-            providers.push(McpProvider::Vscode);
-        }
-        if self.windsurf {
-            providers.push(McpProvider::Windsurf);
+        for provider in [
+            McpProvider::Claude,
+            McpProvider::Codex,
+            McpProvider::Gemini,
+            McpProvider::Grok,
+            McpProvider::Cursor,
+            McpProvider::Vscode,
+            McpProvider::Windsurf,
+        ] {
+            if self.explicit_provider_requested(provider) {
+                providers.push(provider);
+            }
         }
         Ok(ProviderSelectionMode::Explicit(providers))
+    }
+
+    fn explicit_provider_requested(&self, provider: McpProvider) -> bool {
+        self.clients.contains(&provider)
+            || match provider {
+                McpProvider::Claude => self.claude,
+                McpProvider::Codex => self.codex,
+                McpProvider::Gemini => self.gemini,
+                McpProvider::Grok => self.grok,
+                McpProvider::Cursor => self.cursor,
+                McpProvider::Vscode => self.vscode,
+                McpProvider::Windsurf => self.windsurf,
+            }
     }
 }
 
@@ -250,6 +274,7 @@ mod tests {
                     McpProvider::Claude,
                     McpProvider::Codex,
                     McpProvider::Gemini,
+                    McpProvider::Grok,
                     McpProvider::Cursor,
                     McpProvider::Vscode,
                     McpProvider::Windsurf,
@@ -261,12 +286,14 @@ mod tests {
 
     #[test]
     fn provider_selection_rejects_auto_combined_with_new_flags() {
-        for flag in ["cursor", "vscode", "windsurf"] {
+        for flag in ["client", "grok", "cursor", "vscode", "windsurf"] {
             let mut args = ProviderSelectionArgs {
                 auto: true,
                 ..ProviderSelectionArgs::default()
             };
             match flag {
+                "client" => args.clients.push(McpProvider::Grok),
+                "grok" => args.grok = true,
                 "cursor" => args.cursor = true,
                 "vscode" => args.vscode = true,
                 "windsurf" => args.windsurf = true,
@@ -276,6 +303,21 @@ mod tests {
                 args.resolve_mode().is_err(),
                 "--auto + --{flag} should error"
             );
+        }
+    }
+
+    #[test]
+    fn provider_selection_accepts_client_aliases() {
+        let args = ProviderSelectionArgs {
+            clients: vec![McpProvider::Grok, McpProvider::Codex, McpProvider::Grok],
+            grok: true,
+            ..ProviderSelectionArgs::default()
+        };
+        match args.resolve_mode().expect("resolve mode") {
+            ProviderSelectionMode::Explicit(providers) => {
+                assert_eq!(providers, vec![McpProvider::Codex, McpProvider::Grok]);
+            }
+            ProviderSelectionMode::Auto => panic!("expected explicit provider set"),
         }
     }
 }

--- a/crates/orbit-cli/src/command/mcp/setup/dispatch.rs
+++ b/crates/orbit-cli/src/command/mcp/setup/dispatch.rs
@@ -23,6 +23,8 @@ pub(super) fn run_action(
             (McpAction::Remove, McpProvider::Codex) => apply_codex_remove(&target)?,
             (McpAction::Init, McpProvider::Gemini) => apply_gemini_init(&target)?,
             (McpAction::Remove, McpProvider::Gemini) => apply_gemini_remove(&target)?,
+            (McpAction::Init, McpProvider::Grok) => apply_grok_init(&target)?,
+            (McpAction::Remove, McpProvider::Grok) => apply_grok_remove(&target)?,
             (McpAction::Init, McpProvider::Cursor) => {
                 apply_simple_json_init(&target, "mcpServers")?
             }
@@ -95,6 +97,17 @@ impl ConfigTarget {
             }
             (ScopeArg::Workspace, McpProvider::Gemini) => Ok(Self {
                 mcp_path: repo_root.join(".gemini").join("settings.json"),
+                settings_path: None,
+            }),
+            (ScopeArg::Home, McpProvider::Grok) => {
+                let home = require_home_dir(home_dir)?;
+                Ok(Self {
+                    mcp_path: home.join(".grok").join("config.toml"),
+                    settings_path: None,
+                })
+            }
+            (ScopeArg::Workspace, McpProvider::Grok) => Ok(Self {
+                mcp_path: repo_root.join(".grok").join("config.toml"),
                 settings_path: None,
             }),
             (ScopeArg::Home, McpProvider::Cursor) => {
@@ -207,6 +220,13 @@ pub(super) fn auto_detected_providers(
     if gemini_repo || gemini_home {
         providers.push(McpProvider::Gemini);
     }
+    let grok_repo = repo_root.join(".grok").is_dir();
+    let grok_home = home_dir
+        .map(|home| home.join(".grok").join("config.toml").is_file())
+        .unwrap_or(false);
+    if grok_repo || grok_home {
+        providers.push(McpProvider::Grok);
+    }
     let cursor_repo = repo_root.join(".cursor").is_dir();
     let cursor_home = home_dir
         .map(|home| home.join(".cursor").join("mcp.json").is_file())
@@ -263,6 +283,7 @@ mod tests {
         let home = tempdir().expect("home tempdir");
         std::fs::create_dir_all(repo.path().join(".claude")).expect("create .claude");
         std::fs::create_dir_all(repo.path().join(".gemini")).expect("create .gemini");
+        std::fs::create_dir_all(repo.path().join(".grok")).expect("create .grok");
         std::fs::create_dir_all(home.path().join(".codex")).expect("create codex dir");
         std::fs::write(
             home.path().join(".codex").join("config.toml"),
@@ -273,7 +294,12 @@ mod tests {
         let providers = auto_detected_providers(repo.path(), Some(home.path()));
         assert_eq!(
             providers,
-            vec![McpProvider::Claude, McpProvider::Codex, McpProvider::Gemini]
+            vec![
+                McpProvider::Claude,
+                McpProvider::Codex,
+                McpProvider::Gemini,
+                McpProvider::Grok,
+            ]
         );
     }
 
@@ -287,6 +313,18 @@ mod tests {
 
         let providers = auto_detected_providers(repo.path(), Some(home.path()));
         assert_eq!(providers, vec![McpProvider::Gemini]);
+    }
+
+    #[test]
+    fn auto_detects_grok_from_home_when_repo_lacks_dotgrok() {
+        let repo = tempdir().expect("repo tempdir");
+        let home = tempdir().expect("home tempdir");
+        std::fs::create_dir_all(home.path().join(".grok")).expect("create grok home dir");
+        std::fs::write(home.path().join(".grok").join("config.toml"), "\n")
+            .expect("write global grok config");
+
+        let providers = auto_detected_providers(repo.path(), Some(home.path()));
+        assert_eq!(providers, vec![McpProvider::Grok]);
     }
 
     #[test]
@@ -304,6 +342,7 @@ mod tests {
                 McpProvider::Claude,
                 McpProvider::Codex,
                 McpProvider::Gemini,
+                McpProvider::Grok,
             ]),
             Some(home.path().to_path_buf()),
             ScopeArg::Home,
@@ -359,10 +398,26 @@ mod tests {
         assert_eq!(gemini_args.len(), 2);
         assert!(gemini_settings["mcpServers"]["orbit"]["cwd"].is_null());
 
+        let grok_config = std::fs::read_to_string(home.path().join(".grok").join("config.toml"))
+            .expect("read grok home config");
+        let grok_parsed: toml::Value = toml::from_str(&grok_config).expect("parse grok");
+        let grok_args = grok_parsed["mcp_servers"]["orbit"]["args"]
+            .as_array()
+            .expect("grok args");
+        assert_eq!(grok_args.len(), 2);
+        assert_eq!(grok_args[0].as_str(), Some("mcp"));
+        assert_eq!(grok_args[1].as_str(), Some("serve"));
+        assert_eq!(
+            grok_parsed["mcp_servers"]["orbit"]["enabled"].as_bool(),
+            Some(true)
+        );
+        assert!(grok_parsed["mcp_servers"]["orbit"].get("cwd").is_none());
+
         // Repo-local files should not have been touched.
         assert!(!repo.path().join(".mcp.json").exists());
         assert!(!repo.path().join(".codex").join("config.toml").exists());
         assert!(!repo.path().join(".gemini").join("settings.json").exists());
+        assert!(!repo.path().join(".grok").join("config.toml").exists());
         assert!(!repo.path().join(".claude").join("settings.json").exists());
     }
 
@@ -382,6 +437,12 @@ mod tests {
             "{\n  \"theme\": \"dark\",\n  \"mcpServers\": {\n    \"other\": {\"command\": \"demo\"}\n  }\n}\n",
         )
         .expect("write gemini settings");
+        std::fs::create_dir_all(home.path().join(".grok")).expect("create grok home");
+        std::fs::write(
+            home.path().join(".grok").join("config.toml"),
+            "model = \"grok-4\"\n[mcp_servers.other]\ncommand = \"demo\"\n",
+        )
+        .expect("write grok config");
 
         let orbit_root = repo.path().join(".orbit");
         std::fs::create_dir_all(&orbit_root).expect("create orbit root");
@@ -390,7 +451,11 @@ mod tests {
             McpAction::Init,
             repo.path(),
             &orbit_root,
-            ProviderSelectionMode::Explicit(vec![McpProvider::Codex, McpProvider::Gemini]),
+            ProviderSelectionMode::Explicit(vec![
+                McpProvider::Codex,
+                McpProvider::Gemini,
+                McpProvider::Grok,
+            ]),
             Some(home.path().to_path_buf()),
             ScopeArg::Home,
         )
@@ -400,7 +465,11 @@ mod tests {
             McpAction::Remove,
             repo.path(),
             &orbit_root,
-            ProviderSelectionMode::Explicit(vec![McpProvider::Codex, McpProvider::Gemini]),
+            ProviderSelectionMode::Explicit(vec![
+                McpProvider::Codex,
+                McpProvider::Gemini,
+                McpProvider::Grok,
+            ]),
             Some(home.path().to_path_buf()),
             ScopeArg::Home,
         )
@@ -429,6 +498,21 @@ mod tests {
         assert_eq!(gemini_settings["theme"], "dark");
         assert!(gemini_settings["mcpServers"]["orbit"].is_null());
         assert!(gemini_settings["mcpServers"]["other"].is_object());
+
+        let grok_config = std::fs::read_to_string(home.path().join(".grok").join("config.toml"))
+            .expect("read grok");
+        let grok_parsed: toml::Value = toml::from_str(&grok_config).expect("parse grok");
+        assert_eq!(grok_parsed["model"].as_str(), Some("grok-4"));
+        assert_eq!(
+            grok_parsed["mcp_servers"]["other"]["command"].as_str(),
+            Some("demo")
+        );
+        assert!(
+            grok_parsed["mcp_servers"]
+                .as_table()
+                .and_then(|t| t.get("orbit"))
+                .is_none()
+        );
     }
 
     #[test]

--- a/crates/orbit-cli/src/command/mcp/setup/providers/grok.rs
+++ b/crates/orbit-cli/src/command/mcp/setup/providers/grok.rs
@@ -1,0 +1,165 @@
+use orbit_core::OrbitError;
+use toml::{Table as TomlTable, Value as TomlValue};
+
+use crate::command::mcp::ORBIT_MCP_SERVER_ID;
+
+use super::super::dispatch::ConfigTarget;
+use super::super::format::*;
+use super::common::server_args;
+
+pub(in crate::command::mcp::setup) fn apply_grok_init(
+    target: &ConfigTarget,
+) -> Result<(), OrbitError> {
+    let mut root = load_toml_table(&target.mcp_path)?;
+    let mcp_servers = ensure_toml_table(&mut root, "mcp_servers")?;
+    mcp_servers.insert(
+        ORBIT_MCP_SERVER_ID.to_string(),
+        TomlValue::Table(grok_mcp_server_table()),
+    );
+    write_toml_table(&target.mcp_path, &root)
+}
+
+pub(in crate::command::mcp::setup) fn apply_grok_remove(
+    target: &ConfigTarget,
+) -> Result<(), OrbitError> {
+    let mut root = load_toml_table(&target.mcp_path)?;
+    if let Some(mcp_servers) = root
+        .get_mut("mcp_servers")
+        .and_then(TomlValue::as_table_mut)
+    {
+        mcp_servers.remove(ORBIT_MCP_SERVER_ID);
+        if mcp_servers.is_empty() {
+            root.remove("mcp_servers");
+        }
+    }
+    write_or_remove_toml_table(&target.mcp_path, &root)
+}
+
+pub(super) fn grok_mcp_server_table() -> TomlTable {
+    TomlTable::from_iter([
+        (
+            "command".to_string(),
+            TomlValue::String("orbit".to_string()),
+        ),
+        (
+            "args".to_string(),
+            TomlValue::Array(server_args().into_iter().map(TomlValue::String).collect()),
+        ),
+        ("enabled".to_string(), TomlValue::Boolean(true)),
+    ])
+}
+
+#[cfg(test)]
+mod tests {
+    use tempfile::tempdir;
+
+    use super::super::super::args::{McpAction, McpProvider, ProviderSelectionMode, ScopeArg};
+    use super::super::super::dispatch::run_action;
+
+    #[test]
+    fn grok_workspace_scope_init_and_remove_preserve_unrelated_entries() {
+        let repo = tempdir().expect("repo tempdir");
+        let home = tempdir().expect("home tempdir");
+        std::fs::create_dir_all(repo.path().join(".grok")).expect("create .grok");
+        std::fs::write(
+            repo.path().join(".grok").join("config.toml"),
+            "model = \"grok-4\"\n[mcp_servers.other]\ncommand = \"demo\"\n",
+        )
+        .expect("write config");
+        let orbit_root = repo.path().join(".orbit");
+        std::fs::create_dir_all(&orbit_root).expect("create orbit root");
+
+        run_action(
+            McpAction::Init,
+            repo.path(),
+            &orbit_root,
+            ProviderSelectionMode::Explicit(vec![McpProvider::Grok]),
+            Some(home.path().to_path_buf()),
+            ScopeArg::Workspace,
+        )
+        .expect("init grok");
+
+        let config = std::fs::read_to_string(repo.path().join(".grok").join("config.toml"))
+            .expect("read config");
+        let parsed: toml::Value = toml::from_str(&config).expect("parse config");
+        assert_eq!(parsed["model"].as_str(), Some("grok-4"));
+        assert_eq!(
+            parsed["mcp_servers"]["orbit"]["command"].as_str(),
+            Some("orbit")
+        );
+        let args = parsed["mcp_servers"]["orbit"]["args"]
+            .as_array()
+            .expect("args array");
+        assert_eq!(args.len(), 2);
+        assert_eq!(args[0].as_str(), Some("mcp"));
+        assert_eq!(args[1].as_str(), Some("serve"));
+        assert_eq!(
+            parsed["mcp_servers"]["orbit"]["enabled"].as_bool(),
+            Some(true)
+        );
+        assert!(parsed["mcp_servers"]["orbit"].get("cwd").is_none());
+        assert_eq!(
+            parsed["mcp_servers"]["other"]["command"].as_str(),
+            Some("demo")
+        );
+
+        run_action(
+            McpAction::Remove,
+            repo.path(),
+            &orbit_root,
+            ProviderSelectionMode::Explicit(vec![McpProvider::Grok]),
+            Some(home.path().to_path_buf()),
+            ScopeArg::Workspace,
+        )
+        .expect("remove grok");
+
+        let config = std::fs::read_to_string(repo.path().join(".grok").join("config.toml"))
+            .expect("read config");
+        let parsed: toml::Value = toml::from_str(&config).expect("parse config");
+        assert!(
+            parsed
+                .get("mcp_servers")
+                .and_then(toml::Value::as_table)
+                .and_then(|table| table.get("orbit"))
+                .is_none()
+        );
+        assert_eq!(
+            parsed["mcp_servers"]["other"]["command"].as_str(),
+            Some("demo")
+        );
+    }
+
+    #[test]
+    fn workspace_scope_grok_init_is_idempotent() {
+        let repo = tempdir().expect("repo tempdir");
+        let home = tempdir().expect("home tempdir");
+        let orbit_root = repo.path().join(".orbit");
+        std::fs::create_dir_all(&orbit_root).expect("create orbit root");
+
+        run_action(
+            McpAction::Init,
+            repo.path(),
+            &orbit_root,
+            ProviderSelectionMode::Explicit(vec![McpProvider::Grok]),
+            Some(home.path().to_path_buf()),
+            ScopeArg::Workspace,
+        )
+        .expect("init grok");
+        let first = std::fs::read_to_string(repo.path().join(".grok").join("config.toml"))
+            .expect("read first config");
+
+        run_action(
+            McpAction::Init,
+            repo.path(),
+            &orbit_root,
+            ProviderSelectionMode::Explicit(vec![McpProvider::Grok]),
+            Some(home.path().to_path_buf()),
+            ScopeArg::Workspace,
+        )
+        .expect("init grok again");
+        let second = std::fs::read_to_string(repo.path().join(".grok").join("config.toml"))
+            .expect("read second config");
+
+        assert_eq!(first, second);
+    }
+}

--- a/crates/orbit-cli/src/command/mcp/setup/providers/mod.rs
+++ b/crates/orbit-cli/src/command/mcp/setup/providers/mod.rs
@@ -2,9 +2,11 @@ mod claude;
 mod codex;
 mod common;
 mod gemini;
+mod grok;
 mod simple_json;
 
 pub(super) use self::claude::{apply_claude_init, apply_claude_remove};
 pub(super) use self::codex::{apply_codex_init, apply_codex_remove};
 pub(super) use self::gemini::{apply_gemini_init, apply_gemini_remove};
+pub(super) use self::grok::{apply_grok_init, apply_grok_remove};
 pub(super) use self::simple_json::{apply_simple_json_init, apply_simple_json_remove};

--- a/crates/orbit-common/src/types/agent_pair.rs
+++ b/crates/orbit-common/src/types/agent_pair.rs
@@ -147,10 +147,7 @@ pub fn resolve_agent_model_pair_or(
     match family.as_str() {
         "codex" => Some(AgentModelPair::new("gpt-5.5", "gpt-5.4-mini")),
         "claude" => Some(AgentModelPair::new("opus-4.7", "sonnet-4.6")),
-        "gemini" => Some(AgentModelPair::new(
-            "pro",
-            "flash",
-        )),
+        "gemini" => Some(AgentModelPair::new("pro", "flash")),
         "grok" => Some(AgentModelPair::new("grok-4", "grok-3")),
         _ => None,
     }


### PR DESCRIPTION
## Task

[ORB-00046](https://orbit-cli.com/tasks/ORB-00046) — Implement orbit mcp init/remove support for Grok Build (.grok/ config)

### Description

## Problem
`crates/orbit-cli/src/command/mcp/setup/providers/` only has `claude.rs`, `codex.rs`, and `gemini.rs`. `orbit mcp init` cannot generate a correct `.grok/config.toml` (or `.mcp.json`) for the current workspace or user home.

Grok Build users must manually create the config (as we did in this session), breaking the "one-command onboarding" story that exists for the other three agents.

## Why It Matters
MCP is the primary way most agents (including Grok) discover Orbit tools. First-class `mcp init` support is table stakes for any new agent family.

### Acceptance Criteria

- New `grok.rs` provider in `mcp/setup/providers/` implementing `apply_grok_init` and `apply_grok_remove`
- `orbit mcp init --client grok` (or auto-detection) writes a correct `[mcp_servers.orbit]` entry to `.grok/config.toml` (and/or `~/.grok/config.toml`)
- `orbit mcp remove` cleanly removes the Grok entry
- Help text, dispatch, and tests in the mcp setup module cover the grok client

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Added Grok as a first-class MCP setup provider, writing/removing `.grok/config.toml` and `~/.grok/config.toml` with `[mcp_servers.orbit]`, `command = "orbit"`, `args = ["mcp", "serve"]`, and `enabled = true`.
- Wired Grok through `orbit mcp init/remove` provider selection, `--client grok`, `--grok`, `--all`, auto-detection, dispatch, help text, and workspace-init MCP auto setup.
- Added focused mcp setup tests for Grok workspace/home behavior, idempotence, removal, auto-detection, and provider selection.
- Applied a rustfmt-only cleanup in `orbit-common/src/types/agent_pair.rs` so the repo-required `make ci-fast` guard passes.

Assessment: Targeted MCP setup tests, workspace-init tests, CLI smoke checks, `git diff --check`, and `make ci-fast` all pass.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-00046-6a08af23`
- Behind base: 0
- Ahead of base: 1