### PR TITLE
Harden tests, scoreboards, duels, and analytics for a fourth agent family

### DIFF
--- a/crates/orbit-core/src/command/task/review.rs
+++ b/crates/orbit-core/src/command/task/review.rs
@@ -280,7 +280,7 @@ mod tests {
                 Some("src/lib.rs".to_string()),
                 Some(12),
                 Some("codex".to_string()),
-                Some("gpt-5.4".to_string()),
+                Some("gpt-5.5".to_string()),
             )
             .expect("add review thread");
         runtime
@@ -289,12 +289,12 @@ mod tests {
                 &thread.thread_id,
                 "Follow-up review note.".to_string(),
                 Some("codex".to_string()),
-                Some("gpt-5.4".to_string()),
+                Some("gpt-5.5".to_string()),
             )
             .expect("reply review thread");
 
         let scoreboard = read_task_review_scoreboard(&runtime);
-        assert_eq!(scoreboard["task-review-threads"]["gpt-5.4"], Value::from(1));
+        assert_eq!(scoreboard["task-review-threads"]["gpt-5.5"], Value::from(1));
         let updated_threads = runtime
             .get_task_review_threads(&task.id)
             .expect("reload review threads");
@@ -302,13 +302,13 @@ mod tests {
             .messages
             .first()
             .expect("first review message");
-        assert_eq!(first_message.by, "gpt-5.4");
+        assert_eq!(first_message.by, "gpt-5.5");
         assert!(first_message.github_comment_id.is_none());
 
         let summary = runtime
             .generate_scoreboard_summary()
             .expect("generate scoreboard summary");
-        let reviewer = summary.agents.get("gpt-5.4").expect("reviewer summary");
+        let reviewer = summary.agents.get("gpt-5.5").expect("reviewer summary");
         assert_eq!(reviewer.task_review.threads, 1);
         assert_eq!(reviewer.pr.review_comments, 0);
     }
@@ -357,14 +357,43 @@ mod tests {
                 None,
                 None,
                 Some("codex".to_string()),
-                Some("gpt-5.4".to_string()),
+                Some("gpt-5.5".to_string()),
             )
             .expect("add review thread with configured model");
 
         let scoreboard = read_task_review_scoreboard(&runtime);
-        assert_eq!(scoreboard["task-review-threads"]["gpt-5.4"], Value::from(1));
+        assert_eq!(scoreboard["task-review-threads"]["gpt-5.5"], Value::from(1));
         assert!(scoreboard["task-review-threads"]["gpt-typo"].is_null());
         assert!(scoreboard["task-review-threads"]["opus-handle"].is_null());
+    }
+
+    #[test]
+    fn grok_review_threads_score_local_review_threads() {
+        let (_root, runtime) = test_runtime();
+        let scoreboard_dir = runtime.data_root().join("state").join("scoreboard");
+        fs::create_dir_all(&scoreboard_dir).expect("create scoreboard dir");
+        let task = runtime
+            .add_task(TaskAddParams {
+                title: "Grok review scoring".to_string(),
+                description: "Exercise grok local review-thread scoring.".to_string(),
+                workspace_path: Some(".".to_string()),
+                ..Default::default()
+            })
+            .expect("add task");
+
+        runtime
+            .add_review_thread(
+                &task.id,
+                "Grok review note.".to_string(),
+                None,
+                None,
+                Some("grok".to_string()),
+                Some("grok-4".to_string()),
+            )
+            .expect("add grok review thread");
+
+        let scoreboard = read_task_review_scoreboard(&runtime);
+        assert_eq!(scoreboard["task-review-threads"]["grok-4"], Value::from(1));
     }
 
     #[test]

--- a/crates/orbit-engine/src/executor/automation/duel/mod.rs
+++ b/crates/orbit-engine/src/executor/automation/duel/mod.rs
@@ -3,7 +3,81 @@ mod record_scores;
 mod select_roles;
 mod select_task;
 
+use orbit_common::types::OrbitError;
+
 pub(super) use planning_duel::run_planning_duel;
 pub(super) use record_scores::record_duel_scores;
 pub(super) use select_roles::select_duel_roles;
 pub(super) use select_task::select_duel_task;
+
+fn role_permutation_at(family_count: usize, index: usize) -> Result<[usize; 3], OrbitError> {
+    if family_count < 3 {
+        return Err(OrbitError::Execution(format!(
+            "duel role selection requires at least 3 agent families, got {family_count}"
+        )));
+    }
+
+    let total = family_count * (family_count - 1) * (family_count - 2);
+    let mut remaining = index % total;
+    for first in 0..family_count {
+        for second in 0..family_count {
+            if second == first {
+                continue;
+            }
+            for third in 0..family_count {
+                if third == first || third == second {
+                    continue;
+                }
+                if remaining == 0 {
+                    return Ok([first, second, third]);
+                }
+                remaining -= 1;
+            }
+        }
+    }
+
+    Err(OrbitError::Execution(
+        "duel role permutation enumeration failed".to_string(),
+    ))
+}
+
+fn validate_role_permutation(
+    perm: [usize; 3],
+    family_count: usize,
+    action: &str,
+) -> Result<[usize; 3], OrbitError> {
+    if let Some(index) = perm.into_iter().find(|index| *index >= family_count) {
+        return Err(OrbitError::Execution(format!(
+            "{action} produced family index {index}, but only {family_count} families are configured"
+        )));
+    }
+    if perm[0] == perm[1] || perm[0] == perm[2] || perm[1] == perm[2] {
+        return Err(OrbitError::Execution(format!(
+            "{action} produced non-distinct family indices: {perm:?}"
+        )));
+    }
+    Ok(perm)
+}
+
+#[cfg(test)]
+mod tests {
+    use orbit_common::types::all_agent_families;
+
+    use super::*;
+
+    #[test]
+    fn role_permutations_cover_every_family() {
+        let family_count = all_agent_families().len();
+        let total = family_count * (family_count - 1) * (family_count - 2);
+        let mut seen = vec![false; family_count];
+
+        for index in 0..total {
+            let perm = role_permutation_at(family_count, index).expect("valid permutation");
+            for family_index in perm {
+                seen[family_index] = true;
+            }
+        }
+
+        assert_eq!(seen, vec![true; family_count]);
+    }
+}

--- a/crates/orbit-engine/src/executor/automation/duel/planning_duel/roles.rs
+++ b/crates/orbit-engine/src/executor/automation/duel/planning_duel/roles.rs
@@ -12,19 +12,12 @@ use crate::context::RuntimeHost;
 
 use crate::executor::automation::input::{input_string_field, required_input_string};
 
+use super::super::{role_permutation_at, validate_role_permutation};
+
 pub(super) const PLANNER_ACTIVITY_ID: &str = "propose_duel_plan";
 pub(super) const ARBITER_ACTIVITY_ID: &str = "arbitrate_duel_plan";
 pub(super) const PLANNER_TIMEOUT_SECONDS: u64 = 1800;
 pub(super) const ARBITER_TIMEOUT_SECONDS: u64 = 900;
-
-const PERMUTATIONS: [[usize; 3]; 6] = [
-    [0, 1, 2],
-    [0, 2, 1],
-    [1, 0, 2],
-    [1, 2, 0],
-    [2, 0, 1],
-    [2, 1, 0],
-];
 
 const PLANNING_DUEL_INSTRUCTION: &str = r#"Only use skills listed in this activity's skill_refs. Ignore all others.
 You are a PLANNER in an Orbit planning duel. Inspect the task and surrounding
@@ -117,17 +110,18 @@ thread_local! {
         const { RefCell::new(VecDeque::new()) };
 }
 
-fn next_permutation() -> [usize; 3] {
+fn next_permutation() -> Result<[usize; 3], OrbitError> {
+    let family_count = all_agent_families().len();
     let from_test = TEST_PERMUTATION_QUEUE.with(|cell| cell.borrow_mut().pop_front());
     if let Some(perm) = from_test {
-        return perm;
+        return validate_role_permutation(perm, family_count, "select_planning_duel_roles");
     }
 
     let nanos = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .map(|d| d.as_nanos() as u64)
         .unwrap_or(0);
-    PERMUTATIONS[(nanos as usize) % PERMUTATIONS.len()]
+    role_permutation_at(family_count, nanos as usize)
 }
 
 fn orchestrator_model_for<H: RuntimeHost + ?Sized>(
@@ -158,16 +152,10 @@ fn build_roles_output<H: RuntimeHost + ?Sized>(
     perm: [usize; 3],
 ) -> Result<Value, OrbitError> {
     let families = all_agent_families();
+    let perm = validate_role_permutation(perm, families.len(), "select_planning_duel_roles")?;
     let planner_a = families[perm[0]];
     let planner_b = families[perm[1]];
     let arbiter = families[perm[2]];
-
-    if planner_a == planner_b || planner_b == arbiter || planner_a == arbiter {
-        return Err(OrbitError::Execution(format!(
-            "select_planning_duel_roles produced non-distinct families: \
-             planner_a={planner_a}, planner_b={planner_b}, arbiter={arbiter}"
-        )));
-    }
 
     let started_at = Utc::now().to_rfc3339();
 
@@ -307,7 +295,7 @@ pub(super) fn select_planning_duel_roles<H: RuntimeHost + ?Sized>(
     input: &Value,
 ) -> Result<Value, OrbitError> {
     let task_id = required_input_string(input, "task_id")?;
-    let perm = next_permutation();
+    let perm = next_permutation()?;
     let output = build_roles_output(host, perm)?;
 
     Ok(json!({
@@ -321,4 +309,141 @@ pub(super) fn select_planning_duel_roles<H: RuntimeHost + ?Sized>(
         "arbiter_model": output["arbiter_model"].clone(),
         "planning_duel_roles": output["planning_duel_roles"].clone(),
     }))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::{Path, PathBuf};
+
+    use orbit_common::types::{Activity, AgentModelPair, Job, JobTargetType, OrbitEvent, Role};
+    use orbit_store::InvocationRecord;
+    use orbit_tools::ToolContext;
+
+    use crate::context::{JobRunResult, RuntimeHost};
+    use crate::executor::registry::ActivityExecutorRegistry;
+
+    use super::*;
+
+    struct TestHost {
+        data_root: PathBuf,
+        scoreboard_dir: PathBuf,
+        registry: ActivityExecutorRegistry,
+    }
+
+    impl TestHost {
+        fn new() -> Self {
+            let temp_root = std::env::temp_dir().join("orbit-planning-duel-role-test");
+            Self {
+                scoreboard_dir: temp_root.join("scoreboard"),
+                data_root: temp_root,
+                registry: ActivityExecutorRegistry::default(),
+            }
+        }
+    }
+
+    impl RuntimeHost for TestHost {
+        fn record_event(&self, _event: OrbitEvent) -> Result<(), OrbitError> {
+            Ok(())
+        }
+
+        fn repo_root(&self) -> Result<String, OrbitError> {
+            Ok(self.data_root.to_string_lossy().to_string())
+        }
+
+        fn data_root(&self) -> &Path {
+            &self.data_root
+        }
+
+        fn activity_executor_registry(&self) -> &ActivityExecutorRegistry {
+            &self.registry
+        }
+
+        fn run_job_now_with_input_debug(
+            &self,
+            _job_id: &str,
+            _input: Value,
+            _debug: bool,
+        ) -> Result<JobRunResult, OrbitError> {
+            unimplemented!("not needed by planning-duel role tests")
+        }
+
+        fn validate_activity_target_exists(
+            &self,
+            _target_type: JobTargetType,
+            _target_id: &str,
+        ) -> Result<Activity, OrbitError> {
+            unimplemented!("not needed by planning-duel role tests")
+        }
+
+        fn get_job(&self, _job_id: &str) -> Result<Option<Job>, OrbitError> {
+            Ok(None)
+        }
+
+        fn invocation_records(
+            &self,
+            _query: orbit_store::InvocationQuery,
+        ) -> Result<Vec<InvocationRecord>, OrbitError> {
+            Ok(Vec::new())
+        }
+
+        fn run_tool_with_context_and_role(
+            &self,
+            _name: &str,
+            _input: Value,
+            _role: Role,
+            _tool_context: ToolContext,
+        ) -> Result<Value, OrbitError> {
+            unimplemented!("not needed by planning-duel role tests")
+        }
+
+        fn maybe_create_failure_task(
+            &self,
+            _job_id: &str,
+            _run_id: &str,
+            _error_code: &str,
+            _error_message: &str,
+            _agent: Option<&str>,
+            _model: Option<&str>,
+        ) -> Result<(), OrbitError> {
+            Ok(())
+        }
+
+        fn resolved_agent_model_pair(&self, agent_cli: &str) -> Option<AgentModelPair> {
+            match agent_cli {
+                "codex" => Some(AgentModelPair::new("gpt-5.5", "gpt-5.4-mini")),
+                "claude" => Some(AgentModelPair::new("opus-4.7", "sonnet-4.6")),
+                "gemini" => Some(AgentModelPair::new("pro", "flash")),
+                "grok" => Some(AgentModelPair::new("grok-4", "grok-3")),
+                _ => None,
+            }
+        }
+
+        fn scoring_enabled(&self) -> bool {
+            false
+        }
+
+        fn graph_editing(&self) -> bool {
+            false
+        }
+
+        fn scoreboard_dir(&self) -> &Path {
+            &self.scoreboard_dir
+        }
+    }
+
+    #[test]
+    fn planning_duel_role_output_can_assign_grok() {
+        let host = TestHost::new();
+        let output = build_roles_output(&host, [3, 0, 1]).expect("roles output");
+
+        assert_eq!(output["planner_a_agent_cli"], "grok");
+        assert_eq!(output["planner_a_model"], "grok-4");
+        assert_eq!(output["planning_duel_roles"]["planner_a"]["agent"], "grok");
+        assert_eq!(
+            output["planning_duel_roles"]["planner_a"]["model"],
+            "grok-4"
+        );
+        assert_eq!(output["planner_b_agent_cli"], "codex");
+        assert_eq!(output["arbiter_agent_cli"], "claude");
+    }
 }

--- a/crates/orbit-engine/src/executor/automation/duel/select_roles.rs
+++ b/crates/orbit-engine/src/executor/automation/duel/select_roles.rs
@@ -1,7 +1,7 @@
 //! `select_duel_roles` automation.
 //!
-//! Generates a random permutation of the three agent families
-//! (`codex`, `claude`, `gemini`) across the three duel roles
+//! Generates a random ordered selection of three distinct agent families
+//! from Orbit's current family set across the three duel roles
 //! (implementer, reviewer, arbiter) and writes them into the current
 //! job input so downstream steps can resolve per-role agent CLIs via
 //! `agent_cli_from_input` / `model_from_input`.
@@ -27,40 +27,29 @@ use serde_json::{Value, json};
 use crate::context::{RuntimeHost, TaskAutomationUpdate, TaskHost};
 
 use super::super::input::required_input_string;
-
-/// The six permutations of `[0, 1, 2]`, used to assign families to
-/// `(implementer, reviewer, arbiter)` slots.
-const PERMUTATIONS: [[usize; 3]; 6] = [
-    [0, 1, 2],
-    [0, 2, 1],
-    [1, 0, 2],
-    [1, 2, 0],
-    [2, 0, 1],
-    [2, 1, 0],
-];
+use super::{role_permutation_at, validate_role_permutation};
 
 thread_local! {
     /// Test seam. When non-empty, each call to the executor pops the
     /// front entry and uses it as the permutation instead of consulting
-    /// the clock.  Populated via [`push_test_permutations`].
+    /// the clock.
     static TEST_PERMUTATION_QUEUE: RefCell<VecDeque<[usize; 3]>> =
         const { RefCell::new(VecDeque::new()) };
 }
 
-/// Seed the thread-local test permutation queue. Each subsequent call
-/// to `select_duel_roles` on this thread consumes one entry.
 /// Pick the next permutation of family indices — test override first,
 /// otherwise derive from `SystemTime` nanoseconds.
-fn next_permutation() -> [usize; 3] {
+fn next_permutation() -> Result<[usize; 3], OrbitError> {
+    let family_count = all_agent_families().len();
     let from_test = TEST_PERMUTATION_QUEUE.with(|cell| cell.borrow_mut().pop_front());
     if let Some(perm) = from_test {
-        return perm;
+        return validate_role_permutation(perm, family_count, "select_duel_roles");
     }
     let nanos = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .map(|d| d.as_nanos() as u64)
         .unwrap_or(0);
-    PERMUTATIONS[(nanos as usize) % PERMUTATIONS.len()]
+    role_permutation_at(family_count, nanos as usize)
 }
 
 /// Shape of the JSON object this executor writes into current_input.
@@ -73,18 +62,10 @@ fn build_roles_output<H: RuntimeHost + ?Sized>(
     perm: [usize; 3],
 ) -> Result<Value, OrbitError> {
     let families = all_agent_families();
+    let perm = validate_role_permutation(perm, families.len(), "select_duel_roles")?;
     let implementer = families[perm[0]];
     let reviewer = families[perm[1]];
     let arbiter = families[perm[2]];
-
-    // Sanity check — the permutation generator must produce distinct
-    // indices. A failure here means PERMUTATIONS was corrupted.
-    if implementer == reviewer || reviewer == arbiter || implementer == arbiter {
-        return Err(OrbitError::Execution(format!(
-            "select_duel_roles produced non-distinct families: \
-             implementer={implementer}, reviewer={reviewer}, arbiter={arbiter}"
-        )));
-    }
 
     let implementer_model = orchestrator_model_for(host, implementer)?;
     let reviewer_model = orchestrator_model_for(host, reviewer)?;
@@ -132,7 +113,7 @@ pub(in crate::executor::automation) fn select_duel_roles<H: RuntimeHost + TaskHo
 ) -> Result<Value, OrbitError> {
     let task_id = required_input_string(input, "task_id")?;
 
-    let perm = next_permutation();
+    let perm = next_permutation()?;
     let output = build_roles_output(host, perm)?;
 
     // Stamp the implementer onto the task's actor identity so that the

--- a/crates/orbit-engine/src/executor/automation/review/sync_review/thread_sync.rs
+++ b/crates/orbit-engine/src/executor/automation/review/sync_review/thread_sync.rs
@@ -475,6 +475,7 @@ mod tests {
                     "gemini-3.1-pro-preview",
                     "gemini-3-flash-preview",
                 )),
+                "grok" => Some(AgentModelPair::new("grok-4", "grok-3")),
                 _ => None,
             }
         }
@@ -677,5 +678,28 @@ mod tests {
         assert_eq!(scoreable_review_model(&host, "human"), None);
         assert_eq!(scoreable_review_model(&host, "system"), None);
         assert_eq!(scoreable_review_model(&host, "daniel"), None);
+    }
+
+    #[test]
+    fn scoreable_review_model_scores_grok_threads() {
+        let temp = tempdir().expect("create tempdir");
+        let host = TestHost::new(
+            fixture_task(temp.path()),
+            temp.path().to_path_buf(),
+            temp.path().join("scoreboard"),
+        );
+
+        assert_eq!(
+            scoreable_review_model(&host, "grok-4").as_deref(),
+            Some("grok-4")
+        );
+        assert_eq!(
+            scoreable_review_model(&host, "grok / grok-4").as_deref(),
+            Some("grok-4")
+        );
+        assert_eq!(
+            scoreable_review_model(&host, "grok / grok-3").as_deref(),
+            Some("grok-3")
+        );
     }
 }

--- a/crates/orbit-exec/src/macos_sandbox.rs
+++ b/crates/orbit-exec/src/macos_sandbox.rs
@@ -173,7 +173,7 @@ fn provider_state_dirs(
     codex_home: Option<&OsStr>,
     claude_config_dir: Option<&OsStr>,
 ) -> Vec<PathBuf> {
-    let mut dirs = Vec::with_capacity(3);
+    let mut dirs = Vec::with_capacity(4);
     if let Some(dir) = codex_state_dir(home, codex_home) {
         dirs.push(dir);
     }
@@ -181,6 +181,9 @@ fn provider_state_dirs(
         dirs.push(dir);
     }
     if let Some(dir) = gemini_state_dir(home) {
+        dirs.push(dir);
+    }
+    if let Some(dir) = grok_state_dir(home) {
         dirs.push(dir);
     }
     dirs
@@ -217,6 +220,12 @@ pub fn claude_state_dir_from_env() -> Option<PathBuf> {
 /// it through `SandboxCompileEnv` here.
 fn gemini_state_dir(home: Option<&OsStr>) -> Option<PathBuf> {
     non_empty_env_path(home).map(|path| path.join(".gemini"))
+}
+
+/// Grok Build follows the common CLI convention and stores state under
+/// `$HOME/.grok`.
+fn grok_state_dir(home: Option<&OsStr>) -> Option<PathBuf> {
+    non_empty_env_path(home).map(|path| path.join(".grok"))
 }
 
 fn non_empty_env_path(value: Option<&OsStr>) -> Option<PathBuf> {
@@ -737,7 +746,7 @@ mod tests {
     #[test]
     fn compile_emits_all_provider_state_dirs() {
         // Active provider is not threaded through SBPL compilation; emitting
-        // all three keeps the profile symmetric and avoids per-provider
+        // every supported provider keeps the profile symmetric and avoids per-provider
         // branching at compile time.
         let resolved = profile("default", &["/Users/test/repo"], &["/Users/test/repo/src"]);
         let text = compile_with_env(
@@ -747,7 +756,7 @@ mod tests {
                 ..Default::default()
             },
         );
-        for dir in [".codex", ".claude", ".gemini"] {
+        for dir in [".codex", ".claude", ".gemini", ".grok"] {
             let needle = format!("(allow file-write* (subpath \"/Users/test/{dir}\"))");
             assert!(
                 text.contains(&needle),
@@ -1402,11 +1411,11 @@ mod tests {
 
     #[cfg(target_os = "macos")]
     #[test]
-    fn compiled_profile_allows_writes_to_claude_and_gemini_state_dirs() {
+    fn compiled_profile_allows_writes_to_provider_state_dirs() {
         // Documented equivalent for AC #2 / #3 of T20260428-14: rather than
         // executing real provider binaries, exercise the same SBPL allow
-        // clause Claude/Gemini rely on at startup. If the kernel permits a
-        // write under the synthetic `.claude` / `.gemini` subpaths, the same
+        // clause provider CLIs rely on at startup. If the kernel permits a
+        // write under the synthetic provider state subpaths, the same
         // mechanism unblocks the real CLIs writing settings/sessions there.
         use std::process::Command;
 
@@ -1422,8 +1431,10 @@ mod tests {
             .expect("synthetic home tempdir");
         let claude_dir = synthetic_home.path().join(".claude");
         let gemini_dir = synthetic_home.path().join(".gemini");
+        let grok_dir = synthetic_home.path().join(".grok");
         std::fs::create_dir_all(&claude_dir).expect("claude dir");
         std::fs::create_dir_all(&gemini_dir).expect("gemini dir");
+        std::fs::create_dir_all(&grok_dir).expect("grok dir");
 
         let resolved = ResolvedFsProfile {
             name: "default".to_string(),
@@ -1453,6 +1464,7 @@ mod tests {
         for (label, target) in [
             ("claude", claude_dir.join("ok")),
             ("gemini", gemini_dir.join("ok")),
+            ("grok", grok_dir.join("ok")),
         ] {
             let status = Command::new(sandbox_exec_path_for_test())
                 .arg("-f")

--- a/crates/orbit-store/src/file/friction_store.rs
+++ b/crates/orbit-store/src/file/friction_store.rs
@@ -4,8 +4,8 @@ use std::path::{Path, PathBuf};
 
 use chrono::{DateTime, Utc};
 use orbit_common::types::{
-    FrictionFrontmatter, FrictionRecord, OrbitError, Task, TaskStatus,
-    normalize_optional_attribution_label,
+    FrictionFrontmatter, FrictionRecord, OrbitError, Task, TaskStatus, all_agent_families,
+    normalize_optional_attribution_label, resolve_agent_model_pair,
 };
 use orbit_common::utility::fs::{atomic_write_text, with_exclusive_file_lock};
 use serde_json::{Value, json};
@@ -162,6 +162,7 @@ pub fn friction_stats(frictions_root: &Path, tasks: &[Task]) -> Result<Value, Or
         }
     }
     models.extend(tasks_done.keys().cloned());
+    models.extend(known_family_model_keys());
 
     let mut by_model = serde_json::Map::new();
     for model in &models {
@@ -420,6 +421,14 @@ fn completed_tasks_by_model(tasks: &[Task]) -> BTreeMap<String, u64> {
     counts
 }
 
+fn known_family_model_keys() -> impl Iterator<Item = String> {
+    all_agent_families().into_iter().map(|family| {
+        resolve_agent_model_pair(family)
+            .map(|pair| pair.orchestrator)
+            .unwrap_or_else(|| family.to_string())
+    })
+}
+
 fn rate_row(frictions: u64, tasks_done: u64) -> Value {
     let rate = if tasks_done == 0 {
         json!("n/a")
@@ -487,6 +496,21 @@ mod tests {
         assert_eq!(
             stats["by_model"]["gpt-done"]["frictions_per_10_tasks"],
             json!(0.0)
+        );
+    }
+
+    #[test]
+    fn stats_render_zero_rows_for_known_grok_family() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let root = temp.path();
+
+        let stats = friction_stats(root, &[]).expect("stats");
+
+        assert_eq!(stats["by_model"]["grok-4"]["frictions"], json!(0));
+        assert_eq!(stats["by_model"]["grok-4"]["tasks_done"], json!(0));
+        assert_eq!(
+            stats["by_model"]["grok-4"]["frictions_per_10_tasks"],
+            json!("n/a")
         );
     }
 

--- a/crates/orbit-store/src/file/scoreboard/duel_scoreboard.rs
+++ b/crates/orbit-store/src/file/scoreboard/duel_scoreboard.rs
@@ -30,7 +30,10 @@ use std::fs;
 use std::path::Path;
 use std::process::Command;
 
-use orbit_common::types::{Ambiguity, Decision, DuelRun, OrbitError, TaskScope, Verdict};
+use orbit_common::types::{
+    Ambiguity, Decision, DuelRun, OrbitError, TaskScope, Verdict, all_agent_families,
+    resolve_agent_model_pair,
+};
 use serde::{Deserialize, Serialize};
 
 use orbit_common::utility::fs::{
@@ -297,6 +300,39 @@ pub fn aggregate(runs: &[DuelRun], filter: AggregateFilter) -> Aggregates {
         None => &[RoleAxis::Implementer, RoleAxis::Reviewer, RoleAxis::Arbiter],
     };
 
+    let seed_segments: Vec<String> = if filter.segment_by == SegmentBy::None {
+        vec![String::new()]
+    } else {
+        let mut segments: BTreeSet<String> = runs
+            .iter()
+            .map(|run| segment_key_for(run, filter.segment_by))
+            .collect();
+        if segments.is_empty() {
+            segments.insert(String::new());
+        }
+        segments.into_iter().collect()
+    };
+
+    for segment_key in seed_segments {
+        for role in roles_to_emit {
+            let role_name = match role {
+                RoleAxis::Implementer => "implementer",
+                RoleAxis::Reviewer => "reviewer",
+                RoleAxis::Arbiter => "arbiter",
+            };
+            for family in all_agent_families() {
+                buckets
+                    .entry((
+                        segment_key.clone(),
+                        role_name,
+                        family.to_string(),
+                        default_orchestrator_model(family),
+                    ))
+                    .or_default();
+            }
+        }
+    }
+
     for run in runs {
         let segment_key = segment_key_for(run, filter.segment_by);
         for role in roles_to_emit {
@@ -354,6 +390,12 @@ pub fn aggregate(runs: &[DuelRun], filter: AggregateFilter) -> Aggregates {
         .collect();
 
     Aggregates { rows }
+}
+
+fn default_orchestrator_model(family: &str) -> String {
+    resolve_agent_model_pair(family)
+        .map(|pair| pair.orchestrator)
+        .unwrap_or_else(|| family.to_string())
 }
 
 fn segment_key_for(run: &DuelRun, axis: SegmentBy) -> String {
@@ -488,6 +530,24 @@ mod tests {
             .map(|index| format!("run-{index:02}"))
             .collect();
         assert_eq!(run_ids, expected);
+    }
+
+    #[test]
+    fn aggregate_emits_zero_rows_for_known_families() {
+        let aggregates = aggregate(&[], AggregateFilter::default());
+
+        assert!(aggregates.rows.iter().any(|row| row.role == "implementer"
+            && row.agent == "grok"
+            && row.model == "grok-4"
+            && row.runs == 0));
+        assert!(aggregates.rows.iter().any(|row| row.role == "reviewer"
+            && row.agent == "grok"
+            && row.model == "grok-4"
+            && row.runs == 0));
+        assert!(aggregates.rows.iter().any(|row| row.role == "arbiter"
+            && row.agent == "grok"
+            && row.model == "grok-4"
+            && row.runs == 0));
     }
 
     fn test_run(run_id: String) -> DuelRun {

--- a/crates/orbit-store/src/file/scoreboard/planning_duel_scoreboard.rs
+++ b/crates/orbit-store/src/file/scoreboard/planning_duel_scoreboard.rs
@@ -9,7 +9,9 @@ use std::collections::BTreeMap;
 use std::fs;
 use std::path::Path;
 
-use orbit_common::types::{OrbitError, PlannerSlot, PlanningDuelRun};
+use orbit_common::types::{
+    OrbitError, PlannerSlot, PlanningDuelRun, all_agent_families, resolve_agent_model_pair,
+};
 use serde::{Deserialize, Serialize};
 
 use orbit_common::utility::fs::{
@@ -74,6 +76,18 @@ pub struct Aggregates {
     pub rows: Vec<AggregateRow>,
 }
 
+#[derive(Default)]
+struct Bucket {
+    runs: u32,
+    points: u32,
+    wall_ms_sum: u128,
+    tool_calls_sum: u128,
+    token_sum: u128,
+    token_count: u32,
+    byte_proxy_sum: u128,
+    byte_proxy_count: u32,
+}
+
 // ============================================================================
 // Append + load
 // ============================================================================
@@ -115,18 +129,6 @@ fn load_scoreboard_file(path: &Path) -> Result<PlanningDuelScoreboardFile, Orbit
 
 /// Reduce `runs` into an [`Aggregates`] report.
 pub fn aggregate(runs: &[PlanningDuelRun], filter: AggregateFilter) -> Aggregates {
-    #[derive(Default)]
-    struct Bucket {
-        runs: u32,
-        points: u32,
-        wall_ms_sum: u128,
-        tool_calls_sum: u128,
-        token_sum: u128,
-        token_count: u32,
-        byte_proxy_sum: u128,
-        byte_proxy_count: u32,
-    }
-
     let mut buckets: BTreeMap<(String, &'static str, String, String), Bucket> = BTreeMap::new();
 
     let roles_to_emit: &[RoleAxis] = match filter.role {
@@ -135,6 +137,8 @@ pub fn aggregate(runs: &[PlanningDuelRun], filter: AggregateFilter) -> Aggregate
         Some(RoleAxis::Arbiter) => &[RoleAxis::Arbiter],
         None => &[RoleAxis::PlannerA, RoleAxis::PlannerB, RoleAxis::Arbiter],
     };
+
+    seed_zero_family_rows(&mut buckets, roles_to_emit);
 
     for run in runs {
         for role in roles_to_emit {
@@ -213,6 +217,39 @@ pub fn aggregate(runs: &[PlanningDuelRun], filter: AggregateFilter) -> Aggregate
     Aggregates { rows }
 }
 
+fn seed_zero_family_rows(
+    buckets: &mut BTreeMap<(String, &'static str, String, String), Bucket>,
+    roles_to_emit: &[RoleAxis],
+) {
+    for role in roles_to_emit {
+        let role_name = role_name(*role);
+        for family in all_agent_families() {
+            buckets
+                .entry((
+                    role_name.to_string(),
+                    role_name,
+                    family.to_string(),
+                    default_orchestrator_model(family),
+                ))
+                .or_default();
+        }
+    }
+}
+
+fn role_name(role: RoleAxis) -> &'static str {
+    match role {
+        RoleAxis::PlannerA => "planner_a",
+        RoleAxis::PlannerB => "planner_b",
+        RoleAxis::Arbiter => "arbiter",
+    }
+}
+
+fn default_orchestrator_model(family: &str) -> String {
+    resolve_agent_model_pair(family)
+        .map(|pair| pair.orchestrator)
+        .unwrap_or_else(|| family.to_string())
+}
+
 // ============================================================================
 // Tests
 // ============================================================================
@@ -262,6 +299,24 @@ mod tests {
             .map(|index| format!("run-{index:02}"))
             .collect();
         assert_eq!(run_ids, expected);
+    }
+
+    #[test]
+    fn aggregate_emits_zero_rows_for_known_families() {
+        let aggregates = aggregate(&[], AggregateFilter::default());
+
+        assert!(aggregates.rows.iter().any(|row| row.role == "planner_a"
+            && row.agent == "grok"
+            && row.model == "grok-4"
+            && row.runs == 0));
+        assert!(aggregates.rows.iter().any(|row| row.role == "planner_b"
+            && row.agent == "grok"
+            && row.model == "grok-4"
+            && row.runs == 0));
+        assert!(aggregates.rows.iter().any(|row| row.role == "arbiter"
+            && row.agent == "grok"
+            && row.model == "grok-4"
+            && row.runs == 0));
     }
 
     fn test_run(run_id: String) -> PlanningDuelRun {

--- a/crates/orbit-store/src/file/scoreboard/scoreboard_summary.rs
+++ b/crates/orbit-store/src/file/scoreboard/scoreboard_summary.rs
@@ -4,8 +4,8 @@ use std::path::Path;
 
 use chrono::{DateTime, Duration, Utc};
 use orbit_common::types::{
-    JobRun, JobRunState, OrbitError, PlannerSlot, Task, TaskStatus, normalize_attribution_label,
-    normalize_optional_attribution_label,
+    JobRun, JobRunState, OrbitError, PlannerSlot, Task, TaskStatus, all_agent_families,
+    normalize_attribution_label, normalize_optional_attribution_label, resolve_agent_model_pair,
 };
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -200,6 +200,7 @@ pub fn generate_summary_with_inputs(
 ) -> Result<ScoreboardSummary, OrbitError> {
     let audit_tool_calls = inputs.audit_tool_calls;
     let mut agents: BTreeMap<String, AgentSummary> = BTreeMap::new();
+    seed_known_family_agents(&mut agents);
 
     let pr = read_model_scoreboard(scoreboard_dir, "pr.json")?;
     overlay_nested_metric(&mut agents, &pr, "pr-review-comments", |summary, value| {
@@ -532,6 +533,18 @@ fn model_key(model: &str) -> String {
     normalize_attribution_label(model, None)
 }
 
+fn seed_known_family_agents(agents: &mut BTreeMap<String, AgentSummary>) {
+    for family in all_agent_families() {
+        let model = resolve_agent_model_pair(family)
+            .map(|pair| pair.orchestrator)
+            .unwrap_or_else(|| family.to_string());
+        let key = model_key(&model);
+        if !key.is_empty() {
+            agents.entry(key).or_default();
+        }
+    }
+}
+
 fn normalize_model_scoreboard(parsed: Value) -> Result<ModelScoreboard, OrbitError> {
     let mut normalized = ModelScoreboard::new();
     let Value::Object(metrics) = parsed else {
@@ -610,6 +623,18 @@ mod tests {
         let gpt5 = summary.agents.get("gpt-5").expect("gpt-5 summary");
         assert_eq!(gpt5.tool_calls, 3);
         assert_eq!(gpt5.failed_tool_calls, 2);
+    }
+
+    #[test]
+    fn summary_includes_zero_rows_for_known_families() {
+        let temp = tempfile::tempdir().expect("create tempdir");
+
+        let summary = generate_summary(temp.path(), &[]).expect("generate summary");
+
+        let grok = summary.agents.get("grok-4").expect("grok summary");
+        assert_eq!(grok.tasks_completed, 0);
+        assert_eq!(grok.duels.participated, 0);
+        assert_eq!(grok.task_review.threads, 0);
     }
 
     #[test]

--- a/docs/design/agent-families/1_overview.md
+++ b/docs/design/agent-families/1_overview.md
@@ -40,6 +40,7 @@ The authoritative list lives in `all_agent_families()` in `crates/orbit-common/s
 
 - ORB-00042: Onboard Grok (xAI) as a first-class supported agent family (epic)
 - ORB-00043: Add Grok to agent_from_model, all_agent_families, and provider_from_model
+- ORB-00048: Harden duels, scoreboards, review sync, friction stats, and analytics for the fourth family
 - ADR-0151: Add Grok (xAI) as a fourth peer agent family
 
 Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.

--- a/docs/design/policy-sandbox/2_design.md
+++ b/docs/design/policy-sandbox/2_design.md
@@ -121,7 +121,7 @@ The compiled macOS profile denies by default, allows broad reads required by age
 
 - scratch/cache roots (`/tmp`, `/private/tmp`, `/private/var/folders`, `/dev`, `$HOME/Library/Caches`)
 - `$HOME/.orbit` for inherited Orbit subprocess audit/state
-- provider state dirs: Codex (`$CODEX_HOME` or `$HOME/.codex`), Claude (`$CLAUDE_CONFIG_DIR` or `$HOME/.claude`), and Gemini (`$HOME/.gemini`)
+- provider state dirs: Codex (`$CODEX_HOME` or `$HOME/.codex`), Claude (`$CLAUDE_CONFIG_DIR` or `$HOME/.claude`), Gemini (`$HOME/.gemini`), and Grok (`$HOME/.grok`)
 - Claude `$HOME/.claude.json` sibling files (`.claude.json`, `.claude.json.lock`, atomic-write `.claude.json.tmp.<pid>.<ms_ts>`) when `CLAUDE_CONFIG_DIR` is unset, since these live at the home root rather than under `$HOME/.claude/` ([T20260508-13])
 - positive `modify` roots from the resolved profile
 - Codex side-write roots from runtime provider config, appended after policy denies so workflow state remains writable under the outer sandbox

--- a/docs/design/policy-sandbox/4_decisions.md
+++ b/docs/design/policy-sandbox/4_decisions.md
@@ -2,7 +2,7 @@
 
 **Status:** Draft
 **Owner:** claude
-**Last updated:** 2026-05-09
+**Last updated:** 2026-05-16
 
 This is the append-only ADR log for Policy & Sandboxing. Entries are ordered by ADR number. New entries follow the template in [../CONVENTIONS.md](../CONVENTIONS.md) and cite the task that made the decision real.
 
@@ -158,14 +158,14 @@ This is the append-only ADR log for Policy & Sandboxing. Entries are ordered by 
 
 **Status:** Accepted · 2026-04 · [T20260428-14]
 
-**Context.** ADR-012 unblocked Codex state writes, but Claude writes startup state under `$HOME/.claude` or `$CLAUDE_CONFIG_DIR`, and Gemini writes under `$HOME/.gemini`. SBPL compilation receives `ResolvedFsProfile` plus host env, not the active provider, so provider-conditional allow clauses would require new plumbing.
+**Context.** ADR-012 unblocked Codex state writes, but Claude writes startup state under `$HOME/.claude` or `$CLAUDE_CONFIG_DIR`, Gemini writes under `$HOME/.gemini`, and Grok writes under `$HOME/.grok`. SBPL compilation receives `ResolvedFsProfile` plus host env, not the active provider, so provider-conditional allow clauses would require new plumbing.
 
-**Decision.** Emit state-dir allows for all supported CLI providers on every macOS sandbox profile: `$CODEX_HOME` / `$HOME/.codex`, `$CLAUDE_CONFIG_DIR` / `$HOME/.claude`, and `$HOME/.gemini`. Keep `append_provider_side_write_roots` Codex-only because Claude and Gemini have no `--add-dir` equivalent; document that a future provider with such a surface should generalize the branch.
+**Decision.** Emit state-dir allows for all supported CLI providers on every macOS sandbox profile: `$CODEX_HOME` / `$HOME/.codex`, `$CLAUDE_CONFIG_DIR` / `$HOME/.claude`, `$HOME/.gemini`, and `$HOME/.grok`. Keep `append_provider_side_write_roots` Codex-only because Claude, Gemini, and Grok have no `--add-dir` equivalent; document that a future provider with such a surface should generalize the branch.
 
 **Consequences.**
-- Claude and Gemini reach past CLI startup under `macos-sandbox-exec` with the same state-dir defense story as Codex.
-- Emitting all three narrow state-dir allowances avoids provider plumbing; Codex side roots remain a separate branch until another provider ships an equivalent surface.
-- Cost: every macOS sandbox profile carries three state-dir allow clauses regardless of which provider runs. If a future provider's state dir overlaps with another sensitive root, this design needs revisiting.
+- Claude, Gemini, and Grok reach past CLI startup under `macos-sandbox-exec` with the same state-dir defense story as Codex.
+- Emitting all four narrow state-dir allowances avoids provider plumbing; Codex side roots remain a separate branch until another provider ships an equivalent surface.
+- Cost: every macOS sandbox profile carries four state-dir allow clauses regardless of which provider runs. If a future provider's state dir overlaps with another sensitive root, this design needs revisiting.
 
 ## ADR-014 — Claude state surface includes `$HOME/.claude.json` siblings, not just `$HOME/.claude/`
 
@@ -218,5 +218,6 @@ Use `literal` for the canonical and lock files (predictable names) and `regex` f
 - **[T20260430-23]** — Shorten the policy sandbox design docs while preserving the shipped contract and ADR history.
 - **[T20260508-13]** — Add `$HOME/.claude.json{,.lock,.tmp.<pid>.<ms_ts>}` sibling allows to the macOS sandbox profile so Claude can persist its main settings file.
 - **[T20260509-30]** — Resolve `sandbox-exec` from trusted absolute locations rather than inherited `PATH`.
+- **[ORB-00048]** — Extend the unconditional provider state-dir allowance set to include Grok's `$HOME/.grok` state directory while hardening fourth-family scoreboards and analytics.
 
 > Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.

--- a/scripts/orbit_scoreboard.py
+++ b/scripts/orbit_scoreboard.py
@@ -32,11 +32,20 @@ AGENT_COLORS = {
     "claude":  "#4C9BE8",
     "codex":   "#F5A623",
     "gemini":  "#7ED321",
+    "grok":    "#E84C9B",
     "system":  "#888888",
 }
+KNOWN_AGENTS = ("claude", "codex", "gemini", "grok")
 
 def agent_color(name: str) -> str:
     return AGENT_COLORS.get(name.lower(), "#BD10E0")
+
+
+def known_agents(*counters) -> list[str]:
+    agents = set(KNOWN_AGENTS)
+    for counter in counters:
+        agents.update(counter.keys())
+    return sorted(agents)
 
 
 # ── Loaders ───────────────────────────────────────────────────────────────────
@@ -65,7 +74,7 @@ def chart_win_rate(runs: list, fig, row, col):
         for role in ("planner_a", "planner_b"):
             total[r["roles"][role]["agent"]] += 1
 
-    agents = sorted(total)
+    agents = known_agents(total)
 
     # One trace per agent so each bar is its own color in the stack
     for a in agents:
@@ -91,7 +100,7 @@ def chart_win_rate_pct(runs: list, fig, row, col):
         for role in ("planner_a", "planner_b"):
             total[r["roles"][role]["agent"]] += 1
 
-    agents = sorted(total)
+    agents = known_agents(total)
     pcts   = [100 * wins[a] / total[a] if total[a] else 0 for a in agents]
     colors = [agent_color(a) for a in agents]
 
@@ -117,8 +126,8 @@ def chart_tool_calls(runs: list, fig, row, col):
                 agent = r["roles"][role]["agent"]
                 calls[agent].append(tc)
 
-    agents = sorted(calls)
-    avgs   = [sum(calls[a]) / len(calls[a]) for a in agents]
+    agents = known_agents(calls)
+    avgs   = [sum(calls[a]) / len(calls[a]) if calls[a] else 0 for a in agents]
     colors = [agent_color(a) for a in agents]
 
     fig.add_trace(go.Bar(
@@ -186,7 +195,7 @@ def chart_token_breakdown(runs: list, fig, row, col):
             for f in token_fields:
                 totals[agent][f] += tu.get(f, 0)
 
-    agents = sorted(totals)
+    agents = known_agents(totals)
     if not agents:
         return
 
@@ -208,7 +217,7 @@ def chart_arbiter_breakdown(runs: list, fig, row, col):
     for r in runs:
         counts[r["roles"]["arbiter"]["agent"]] += 1
 
-    agents = sorted(counts)
+    agents = known_agents(counts)
     fig.add_trace(go.Pie(
         labels=agents,
         values=[counts[a] for a in agents],

--- a/website/scripts/sync-scoreboard.mjs
+++ b/website/scripts/sync-scoreboard.mjs
@@ -15,6 +15,7 @@ const scoreboardPath = path.join(metricsDir, 'scoreboard.md');
 const legacyPath = path.join(docsRoot, 'scoreboard.md');
 
 const HIDDEN_AGENTS = new Set(['human', 'agent', 'system', 'admin']);
+const KNOWN_AGENT_FAMILIES = ['claude', 'codex', 'gemini', 'grok'];
 const TOP_TOOLS_RENDER_LIMIT = 20;
 
 const summary = await loadSummary(sourcePath);
@@ -116,19 +117,24 @@ async function loadDuelStats(filePath) {
     if (err.code !== 'ENOENT') throw err;
   }
 
-  const stats = new Map();
-  const bump = (model, key) => {
-    if (!model || HIDDEN_AGENTS.has(model)) return;
-    if (!stats.has(model)) {
-      stats.set(model, { wins: 0, losses: 0, plannerRuns: 0, arbiterRuns: 0 });
+  const stats = new Map(
+    KNOWN_AGENT_FAMILIES.map((family) => [
+      family,
+      { wins: 0, losses: 0, plannerRuns: 0, arbiterRuns: 0 },
+    ]),
+  );
+  const bump = (agent, key) => {
+    if (!agent || HIDDEN_AGENTS.has(agent)) return;
+    if (!stats.has(agent)) {
+      stats.set(agent, { wins: 0, losses: 0, plannerRuns: 0, arbiterRuns: 0 });
     }
-    stats.get(model)[key] += 1;
+    stats.get(agent)[key] += 1;
   };
 
   for (const run of runs) {
-    const a = run.roles?.planner_a?.model;
-    const b = run.roles?.planner_b?.model;
-    const arb = run.roles?.arbiter?.model;
+    const a = run.roles?.planner_a?.agent ?? run.roles?.planner_a?.model;
+    const b = run.roles?.planner_b?.agent ?? run.roles?.planner_b?.model;
+    const arb = run.roles?.arbiter?.agent ?? run.roles?.arbiter?.model;
     const winner = run.outcome?.winner;
 
     if (a) bump(a, 'plannerRuns');
@@ -285,7 +291,6 @@ function renderPrsTable(agents) {
 
 function renderDuelsTable(duelsByModel) {
   const rows = duelsByModel
-    .filter(([, d]) => d.wins + d.losses + d.plannerRuns + d.arbiterRuns > 0)
     .map(([name, d]) => {
       const decided = d.wins + d.losses;
       const rate = decided > 0 ? d.wins / decided : null;


### PR DESCRIPTION
## Task

[ORB-00048](https://orbit-cli.com/tasks/ORB-00048) — Harden tests, scoreboards, duels, and analytics for a fourth agent family

### Description

## Problem
Even after ORB-00043 makes the workspace compile against a 4-element `all_agent_families()`, several behavioral surfaces may silently ignore or mis-tally the new family:

- Planning-duel role selection (does it now consider grok as orchestrator/helper?)
- Review-thread sync attribution
- Scoreboard tallies and JSON layouts (zero-grok rows must render correctly)
- Friction-stats pages and benchmark fixtures
- Analytics that bucket events by family

The fixed-size array was intentionally designed to force this audit; this task is the behavioral half. Pure compile-fix updates are owned by ORB-00043.

## Scope
- Audit every consumer of `all_agent_families()` (and equivalents) for *behavioral* correctness with grok present, not just compilation.
- Update planning-duel role selection so grok can participate.
- Update scoreboard renderers (`.orbit/state/scoreboard/*.json` schema + readers) to handle zero-grok rows.
- Update or remove tests/fixtures that asserted exactly the legacy trio with semantic intent (vs. mechanical `== 3`, which is -43's territory).

## Why It Matters
Without this, grok will compile but be silently absent from analytics and duels — worse than failing loudly.

### Acceptance Criteria

- Planning-duel role selection includes grok and produces valid orchestrator/helper assignments when grok is in the pool
- Scoreboard renderers (duel_plan and any siblings) render zero-grok rows without panicking or omitting the family
- Review-thread sync correctly attributes grok-authored threads to the grok family
- Friction-stats and benchmark fixtures include grok where the legacy trio was enumerated with semantic (not mechanical) intent
- `make ci` passes with the 4-family array

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Replaced hard-coded three-family duel role permutations with dynamic three-role selections over all_agent_families(), so Grok can appear in implementer/reviewer/arbiter and planning-duel planner/arbiter assignments.
- Seeded duel, planning-duel, scoreboard-summary, and friction-stats outputs with zero rows for known families, and updated website/Python scoreboard renderers to retain Grok rows.
- Added Grok review-thread scoring coverage for local task reviews and GitHub review sync attribution.
- Added Grok macOS provider state-dir allowance and updated the agent-family/policy-sandbox design docs.

Validation:
- make ci-fast
- make check-design-docs
- cargo test -p orbit-engine
- cargo test -p orbit-store
- cargo test -p orbit-core grok_review_threads_score_local_review_threads
- cargo test -p orbit-core add_and_reply_review_threads_score_local_review_threads_once
- cargo test -p orbit-core typo_prefixed_models_do_not_score_local_review_threads
- cargo test -p orbit-exec compile_emits_all_provider_state_dirs
- node --check website/scripts/sync-scoreboard.mjs
- python3 -m py_compile scripts/orbit_scoreboard.py

Assessment: Fourth-family behavioral surfaces are covered with focused regression tests. Full make ci was not run per repository guidance; a full cargo test -p orbit-core run still shows unrelated command::job::run TZ/process-owner failures, while the task-review tests touched here pass.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-00048-6a08af2d`
- Behind base: 0
- Ahead of base: 1