### PR TITLE
Add Grok executor YAML and CLI runner support for backend: cli

### DIFF
--- a/crates/orbit-agent/README.md
+++ b/crates/orbit-agent/README.md
@@ -2,7 +2,7 @@
 
 Agent provider abstraction for Orbit. Two transport families coexist:
 
-- **CLI transports** drive `claude`, `codex`, `gemini`, `ollama`, and `mock`
+- **CLI transports** drive `claude`, `codex`, `gemini`, `grok`, `ollama`, and `mock`
   as subprocesses via the existing `AgentRuntime` trait. An invocation
   builds an `AgentInvocationSpec` (program, args, stdin envelope) that the
   engine runs through `orbit-exec`.

--- a/crates/orbit-agent/src/agent/agent.rs
+++ b/crates/orbit-agent/src/agent/agent.rs
@@ -14,6 +14,7 @@ pub enum ProviderOptions {
         writable_dirs: Vec<String>,
     },
     Gemini,
+    Grok,
     Ollama,
     Mock,
 }

--- a/crates/orbit-agent/src/lib.rs
+++ b/crates/orbit-agent/src/lib.rs
@@ -10,7 +10,7 @@
 )]
 //! Agent provider abstraction for Orbit. Two transport families coexist:
 //!
-//! - **CLI transports** — drive `claude`, `codex`, `gemini`, `ollama`, or
+//! - **CLI transports** — drive `claude`, `codex`, `gemini`, `grok`, `ollama`, or
 //!   `mock` as subprocesses through [`AgentRuntime`]. Each runtime builds an
 //!   [`AgentInvocationSpec`] (program, args, stdin envelope) that the engine
 //!   executes through `orbit-exec`; responses are parsed via

--- a/crates/orbit-agent/src/providers/grok/grok_cli.rs
+++ b/crates/orbit-agent/src/providers/grok/grok_cli.rs
@@ -1,0 +1,44 @@
+use crate::providers::common::render_prompt_with_embedded_envelope;
+
+pub(crate) struct GrokCliTransport {
+    model: Option<String>,
+}
+
+impl GrokCliTransport {
+    pub(crate) fn new(model: Option<String>) -> Self {
+        Self { model }
+    }
+
+    // Static Grok CLI flags live in the executor definition; this transport
+    // only adds per-request toggles.
+    pub(crate) fn args(&self) -> Vec<String> {
+        let mut args = Vec::new();
+
+        if let Some(model) = &self.model {
+            args.push("--model".to_string());
+            args.push(model.clone());
+        }
+
+        args
+    }
+
+    pub(crate) fn stdin(&self, envelope_json: &[u8]) -> Vec<u8> {
+        render_prompt_with_embedded_envelope(envelope_json)
+    }
+
+    pub(crate) fn model_name(&self) -> Option<&str> {
+        self.model.as_deref()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn grok_args_pass_model_with_long_flag() {
+        let transport = GrokCliTransport::new(Some("grok-build".to_string()));
+
+        assert_eq!(transport.args(), vec!["--model", "grok-build"]);
+    }
+}

--- a/crates/orbit-agent/src/providers/grok/grok_runtime.rs
+++ b/crates/orbit-agent/src/providers/grok/grok_runtime.rs
@@ -1,0 +1,90 @@
+use std::collections::HashMap;
+
+use orbit_common::types::{InvocationTrace, OrbitError};
+
+use crate::agent::{AgentConfig, ProviderOptions};
+use crate::providers::grok::grok_cli::GrokCliTransport;
+use crate::runtime::{AgentRuntime, AgentRuntimeFactory};
+use crate::types::{AgentInvocationSpec, AgentRequest};
+
+const RUNTIME_KEY: &str = "grok";
+const REQUIRED_ENV_VARS: &[&str] = &["HOME", "PATH"];
+
+pub(crate) struct GrokRuntime {
+    command: String,
+    cli: GrokCliTransport,
+    runtime_key: &'static str,
+    required_env_vars: &'static [&'static str],
+}
+
+pub(crate) struct GrokFactory;
+
+impl GrokRuntime {
+    pub(crate) fn new(
+        command: String,
+        model: Option<String>,
+        runtime_key: &'static str,
+        required_env_vars: &'static [&'static str],
+    ) -> Self {
+        Self {
+            command,
+            cli: GrokCliTransport::new(model),
+            runtime_key,
+            required_env_vars,
+        }
+    }
+}
+
+impl AgentRuntimeFactory for GrokFactory {
+    fn key(&self) -> &'static str {
+        RUNTIME_KEY
+    }
+
+    fn required_env_vars(&self) -> &'static [&'static str] {
+        REQUIRED_ENV_VARS
+    }
+
+    fn options_from_config(
+        &self,
+        _config: &HashMap<String, String>,
+    ) -> Result<ProviderOptions, OrbitError> {
+        Ok(ProviderOptions::Grok)
+    }
+
+    fn build(&self, cfg: &AgentConfig) -> Result<Box<dyn AgentRuntime>, OrbitError> {
+        match &cfg.provider_options {
+            ProviderOptions::Grok => Ok(Box::new(GrokRuntime::new(
+                cfg.command.clone(),
+                cfg.model.clone(),
+                self.key(),
+                self.required_env_vars(),
+            ))),
+            _ => Err(OrbitError::InvalidInput(format!(
+                "provider options '{}' cannot build grok runtime",
+                cfg.provider_key
+            ))),
+        }
+    }
+}
+
+impl AgentRuntime for GrokRuntime {
+    fn invoke(
+        &self,
+        req: AgentRequest,
+    ) -> Result<(AgentInvocationSpec, InvocationTrace), OrbitError> {
+        Ok((
+            crate::providers::build_invocation_spec(
+                self.runtime_key,
+                self.required_env_vars,
+                self.command.clone(),
+                self.cli.args(),
+                self.cli.stdin(&req.envelope_json),
+            ),
+            InvocationTrace::default(),
+        ))
+    }
+
+    fn model_name(&self) -> Option<&str> {
+        self.cli.model_name()
+    }
+}

--- a/crates/orbit-agent/src/providers/grok/mod.rs
+++ b/crates/orbit-agent/src/providers/grok/mod.rs
@@ -1,0 +1,4 @@
+mod grok_cli;
+mod grok_runtime;
+
+pub(crate) use grok_runtime::GrokFactory;

--- a/crates/orbit-agent/src/providers/mod.rs
+++ b/crates/orbit-agent/src/providers/mod.rs
@@ -2,7 +2,7 @@
 //!
 //! Two families live here:
 //!
-//! - **CLI transports** (`claude`, `codex`, `gemini`, `ollama`, `mock_agent`):
+//! - **CLI transports** (`claude`, `codex`, `gemini`, `grok`, `ollama`, `mock_agent`):
 //!   translate an [`AgentRequest`] into a CLI command invocation and stdin
 //!   envelope that the engine runs via `orbit-exec`.
 //! - **HTTP transports** (`anthropic`, `openai_compat`, `gemini_http`): implement the sibling
@@ -19,6 +19,7 @@ pub(crate) mod codex;
 mod common;
 pub(crate) mod gemini;
 pub mod gemini_http;
+pub(crate) mod grok;
 pub(crate) mod mock_agent;
 pub(crate) mod ollama;
 pub mod openai_compat;

--- a/crates/orbit-agent/src/runtime/backend.rs
+++ b/crates/orbit-agent/src/runtime/backend.rs
@@ -54,6 +54,7 @@ impl Default for ProviderRegistry {
         let _ = registry.register(Arc::new(crate::providers::codex::CodexFactory));
         let _ = registry.register(Arc::new(crate::providers::claude::ClaudeFactory));
         let _ = registry.register(Arc::new(crate::providers::gemini::GeminiFactory));
+        let _ = registry.register(Arc::new(crate::providers::grok::GrokFactory));
         let _ = registry.register(Arc::new(crate::providers::ollama::OllamaFactory));
         registry
     }

--- a/crates/orbit-common/src/types/activity_job/activity_v2.rs
+++ b/crates/orbit-common/src/types/activity_job/activity_v2.rs
@@ -166,6 +166,7 @@ pub enum Provider {
     Claude,
     Codex,
     Gemini,
+    Grok,
     Ollama,
     #[serde(rename = "openai_compat", alias = "openai-compat")]
     OpenaiCompat,
@@ -177,6 +178,7 @@ impl Provider {
             Provider::Claude => "claude",
             Provider::Codex => "codex",
             Provider::Gemini => "gemini",
+            Provider::Grok => "grok",
             Provider::Ollama => "ollama",
             Provider::OpenaiCompat => "openai_compat",
         }

--- a/crates/orbit-core/assets/executors/grok.yaml
+++ b/crates/orbit-core/assets/executors/grok.yaml
@@ -1,0 +1,22 @@
+schemaVersion: 2
+kind: Executor
+metadata:
+  name: grok
+spec:
+  executor_type: direct_agent
+  command: grok
+  args:
+    - --permission-mode
+    - bypassPermissions
+    - --output-format
+    - json
+    - --no-plan
+    - --prompt-file
+    - /dev/stdin
+  stdout_format: envelope
+  sandbox: macos-sandbox-exec
+  model_pair_override:
+    strong: grok-build
+    weak: grok-build
+  model_flag: "-m"
+  env: {}

--- a/crates/orbit-core/src/command/executor.rs
+++ b/crates/orbit-core/src/command/executor.rs
@@ -8,6 +8,7 @@ pub(crate) const DEFAULT_EXECUTOR_FILES: &[(&str, &str)] = &[
     ("claude", include_str!("../../assets/executors/claude.yaml")),
     ("codex", include_str!("../../assets/executors/codex.yaml")),
     ("gemini", include_str!("../../assets/executors/gemini.yaml")),
+    ("grok", include_str!("../../assets/executors/grok.yaml")),
     (
         "local-shell",
         include_str!("../../assets/executors/local-shell.yaml"),

--- a/crates/orbit-core/src/config/agent_detect.rs
+++ b/crates/orbit-core/src/config/agent_detect.rs
@@ -84,6 +84,7 @@ pub struct DetectedAgents {
     pub claude_cli: bool,
     pub codex_cli: bool,
     pub gemini_cli: bool,
+    pub grok_cli: bool,
     pub ollama_cli: bool,
     pub anthropic_api_key: bool,
     pub openai_api_key: bool,
@@ -97,6 +98,7 @@ pub fn detect(probe: &dyn AgentEnvProbe) -> DetectedAgents {
         claude_cli: probe.binary_on_path("claude"),
         codex_cli: probe.binary_on_path("codex"),
         gemini_cli: probe.binary_on_path("gemini"),
+        grok_cli: probe.binary_on_path("grok"),
         ollama_cli: probe.binary_on_path("ollama"),
         anthropic_api_key: probe.env_var("ANTHROPIC_API_KEY").is_some(),
         openai_api_key: probe.env_var("OPENAI_API_KEY").is_some(),
@@ -112,13 +114,14 @@ pub fn default_model_for(provider: &str) -> Option<&'static str> {
         "claude" => Some("claude-opus-4-7"),
         "codex" => Some("gpt-5.5"),
         "gemini" => Some("gemini-3-pro"),
+        "grok" => Some("grok-build"),
         _ => None,
     }
 }
 
 /// Pick a default provider for the role given a detection snapshot.
 ///
-/// Preference order: first detected CLI in [claude, codex, gemini, ollama],
+/// Preference order: first detected CLI in [claude, codex, gemini, grok, ollama],
 /// else first detected API key in [anthropic→claude, openai→codex,
 /// gemini→gemini], else `claude` as a last resort.
 pub fn default_provider(detected: &DetectedAgents) -> &'static str {
@@ -130,6 +133,9 @@ pub fn default_provider(detected: &DetectedAgents) -> &'static str {
     }
     if detected.gemini_cli {
         return "gemini";
+    }
+    if detected.grok_cli {
+        return "grok";
     }
     if detected.ollama_cli {
         return "ollama";
@@ -153,6 +159,7 @@ pub fn default_backend(provider: &str, detected: &DetectedAgents) -> &'static st
         "claude" => detected.claude_cli,
         "codex" => detected.codex_cli,
         "gemini" => detected.gemini_cli,
+        "grok" => detected.grok_cli,
         "ollama" => detected.ollama_cli,
         _ => false,
     };
@@ -217,6 +224,7 @@ mod tests {
             detected,
             DetectedAgents {
                 claude_cli: true,
+                grok_cli: true,
                 ollama_cli: true,
                 anthropic_api_key: true,
                 ..DetectedAgents::default()
@@ -237,6 +245,7 @@ mod tests {
             claude_cli: true,
             codex_cli: true,
             gemini_cli: true,
+            grok_cli: true,
             ollama_cli: true,
             ..DetectedAgents::default()
         };
@@ -246,6 +255,7 @@ mod tests {
         let detected = DetectedAgents {
             codex_cli: true,
             gemini_cli: true,
+            grok_cli: true,
             ollama_cli: true,
             ..DetectedAgents::default()
         };
@@ -254,10 +264,19 @@ mod tests {
         // gemini wins when claude/codex absent
         let detected = DetectedAgents {
             gemini_cli: true,
+            grok_cli: true,
             ollama_cli: true,
             ..DetectedAgents::default()
         };
         assert_eq!(default_provider(&detected), "gemini");
+
+        // grok wins when claude/codex/gemini absent
+        let detected = DetectedAgents {
+            grok_cli: true,
+            ollama_cli: true,
+            ..DetectedAgents::default()
+        };
+        assert_eq!(default_provider(&detected), "grok");
 
         // ollama wins when nothing else
         let detected = DetectedAgents {
@@ -319,6 +338,7 @@ mod tests {
         assert_eq!(default_model_for("claude"), Some("claude-opus-4-7"));
         assert_eq!(default_model_for("codex"), Some("gpt-5.5"));
         assert_eq!(default_model_for("gemini"), Some("gemini-3-pro"));
+        assert_eq!(default_model_for("grok"), Some("grok-build"));
         assert_eq!(default_model_for("ollama"), None);
         assert_eq!(default_model_for("unknown"), None);
     }

--- a/crates/orbit-core/src/config/agent_prompt.rs
+++ b/crates/orbit-core/src/config/agent_prompt.rs
@@ -269,6 +269,9 @@ fn agent_options(role: &str, detected: &DetectedAgents) -> Vec<AgentOption> {
     if detected.gemini_cli {
         options.push(agent_option("Gemini CLI", "gemini", "cli"));
     }
+    if detected.grok_cli {
+        options.push(agent_option("Grok CLI", "grok", "cli"));
+    }
     if detected.ollama_cli {
         options.push(agent_option("Ollama CLI", "ollama", "cli"));
     }
@@ -316,6 +319,8 @@ fn agent_label(provider: &str, backend: &str) -> &'static str {
         ("codex", "http") => "Codex API",
         ("gemini", "cli") => "Gemini CLI",
         ("gemini", "http") => "Gemini API",
+        ("grok", "cli") => "Grok CLI",
+        ("grok", "http") => "Grok API",
         ("ollama", "cli") => "Ollama CLI",
         ("ollama", "http") => "Ollama API",
         _ => "Custom agent",
@@ -347,6 +352,7 @@ fn detection_lines(detected: &DetectedAgents) -> String {
         ("Claude CLI", detected.claude_cli),
         ("Codex CLI", detected.codex_cli),
         ("Gemini CLI", detected.gemini_cli),
+        ("Grok CLI", detected.grok_cli),
         ("Ollama CLI", detected.ollama_cli),
         ("ANTHROPIC_API_KEY", detected.anthropic_api_key),
         ("OPENAI_API_KEY", detected.openai_api_key),

--- a/crates/orbit-core/src/runtime/engine/environment_host.rs
+++ b/crates/orbit-core/src/runtime/engine/environment_host.rs
@@ -110,6 +110,7 @@ fn parse_provider(raw: &str) -> Option<Provider> {
         "claude" => Some(Provider::Claude),
         "codex" => Some(Provider::Codex),
         "gemini" => Some(Provider::Gemini),
+        "grok" => Some(Provider::Grok),
         "ollama" => Some(Provider::Ollama),
         "openai_compat" | "openai-compat" => Some(Provider::OpenaiCompat),
         _ => None,

--- a/crates/orbit-core/src/runtime/v2_host/cli_executor.rs
+++ b/crates/orbit-core/src/runtime/v2_host/cli_executor.rs
@@ -7,7 +7,7 @@ use crate::OrbitRuntime;
 /// overrides (`ORBIT_V2_CLI_<PROVIDER>`) let smokes substitute a fixture
 /// binary for the real provider CLI; production normally comes from the
 /// registered executor def, falling back to the provider name itself
-/// (`claude`, `codex`, `gemini`, `ollama`) when no executor is registered.
+/// (`claude`, `codex`, `gemini`, `grok`, `ollama`) when no executor is registered.
 pub(super) fn resolve_cli_executor(
     runtime: &OrbitRuntime,
     provider: &str,
@@ -58,7 +58,7 @@ pub(super) fn resolve_cli_executor(
     }
 
     match provider {
-        "claude" | "codex" | "gemini" | "ollama" => Ok(ResolvedCliExecutor {
+        "claude" | "codex" | "gemini" | "grok" | "ollama" => Ok(ResolvedCliExecutor {
             command: provider.to_string(),
             args: Vec::new(),
         }),

--- a/crates/orbit-core/tests/grok_cli_backend_smoke.rs
+++ b/crates/orbit-core/tests/grok_cli_backend_smoke.rs
@@ -1,0 +1,119 @@
+#![allow(missing_docs)]
+// ORB-00045: this smoke deliberately invokes the installed Grok CLI and uses
+// expect/assert for fixture setup and end-to-end validation.
+#![allow(clippy::expect_used)]
+
+use orbit_common::types::activity_job::{
+    ActivityV2Spec, AgentLoopSpec, Backend, OnDenial, Provider,
+};
+use orbit_common::types::{EXECUTOR_RESOURCE_SCHEMA_VERSION, ExecutorDef, ExecutorResource};
+use orbit_core::OrbitRuntime;
+use orbit_engine::{V2AuditWriter, V2DispatchInput, dispatch_v2_activity};
+
+fn seed_grok_executor(runtime: &OrbitRuntime) {
+    let resource: ExecutorResource =
+        serde_yaml::from_str(include_str!("../assets/executors/grok.yaml"))
+            .expect("parse embedded grok executor");
+    assert_eq!(resource.schema_version, EXECUTOR_RESOURCE_SCHEMA_VERSION);
+    let mut def = ExecutorDef::from_resource_spec(
+        resource.metadata.name,
+        resource.spec.clone(),
+        "test:assets/executors/grok.yaml",
+        resource.spec.created_at,
+        resource.spec.updated_at,
+    );
+    if !sandbox_exec_can_apply() {
+        def.sandbox = None;
+    }
+    runtime
+        .upsert_executor_def(&def)
+        .expect("seed grok executor");
+}
+
+fn sandbox_exec_can_apply() -> bool {
+    std::process::Command::new("/usr/bin/sandbox-exec")
+        .args(["-p", "(version 1)\n(allow default)\n", "/usr/bin/true"])
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .is_ok_and(|status| status.success())
+}
+
+#[test]
+#[ignore = "requires installed, authenticated Grok CLI and network access"]
+fn installed_grok_cli_backend_smoke_captures_stdout_artifact() {
+    let version = std::process::Command::new("grok")
+        .arg("--version")
+        .output()
+        .expect("grok CLI must be installed on PATH for this smoke");
+    assert!(
+        version.status.success(),
+        "grok --version failed: {}",
+        String::from_utf8_lossy(&version.stderr)
+    );
+
+    let runtime = OrbitRuntime::in_memory().expect("build runtime");
+    seed_grok_executor(&runtime);
+
+    let audit_dir = tempfile::tempdir().expect("audit tempdir");
+    let audit = V2AuditWriter::with_disk_sinks(
+        audit_dir.path(),
+        "grok-installed-smoke",
+        "grok:grok-build".to_string(),
+        None,
+    )
+    .expect("build audit writer");
+    let spec = AgentLoopSpec {
+        instruction: "Return the requested Orbit response envelope.".to_string(),
+        tools: Vec::new(),
+        on_denial: OnDenial::Terminate,
+        model: Some("grok-build".to_string()),
+        max_iterations: 1,
+        backend: Backend::Cli,
+        provider: Provider::Grok,
+        wall_clock_timeout_seconds: 120,
+        role: None,
+    };
+
+    let outcome = dispatch_v2_activity(V2DispatchInput {
+        activity_name: "grok_installed_smoke",
+        spec: &ActivityV2Spec::AgentLoop(spec),
+        fs_profile: None,
+        input: serde_json::json!({
+            "prompt": "Return exactly this JSON object and no other text: {\"schemaVersion\":1,\"status\":\"success\",\"result\":{\"provider\":\"grok\",\"smoke\":\"ok\"},\"error\":null}"
+        }),
+        audit: audit.clone(),
+        run_id: "grok-installed-smoke",
+        host: Some(&runtime),
+    })
+    .expect("dispatch grok cli backend");
+
+    assert!(
+        outcome.success,
+        "grok cli backend failed: {:?}; output={}",
+        outcome.message, outcome.output
+    );
+    assert_eq!(outcome.output["provider"], "grok");
+    assert!(
+        outcome
+            .output
+            .get("stdout_text")
+            .and_then(serde_json::Value::as_str)
+            .is_some_and(|text| !text.trim().is_empty()),
+        "stdout preview should be non-empty"
+    );
+    assert!(
+        outcome
+            .output
+            .get("stdout_blob_ref")
+            .and_then(serde_json::Value::as_str)
+            .is_some_and(|value| !value.trim().is_empty()),
+        "stdout blob ref should be captured"
+    );
+    let invocation = outcome
+        .invocation
+        .as_ref()
+        .expect("well-formed grok stdout should parse invocation trace");
+    assert_eq!(invocation.provider, "grok");
+    assert_eq!(invocation.model.as_deref(), Some("grok-build"));
+}

--- a/crates/orbit-engine/src/activity_job/cli_runner/argv.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/argv.rs
@@ -35,10 +35,10 @@ pub(super) fn audit_argv_for_dispatch(
     }
 }
 
-/// Pin codex's `--sandbox` to `danger-full-access` and drop gemini's `-s` /
-/// `--sandbox` flag so the inner CLI sandbox does not double-encode the
-/// outer orbit-exec sandbox. Claude has no native sandbox flag — nothing to
-/// neutralize.
+/// Pin codex's `--sandbox` to `danger-full-access`, drop gemini's `-s` /
+/// `--sandbox` toggle, and drop grok's `--sandbox <profile>` value so the
+/// inner CLI sandbox does not double-encode the outer orbit-exec sandbox.
+/// Claude has no native sandbox flag — nothing to neutralize.
 pub(super) fn neutralize_inner_sandbox(
     provider: &str,
     provider_config: &mut HashMap<String, String>,
@@ -50,6 +50,9 @@ pub(super) fn neutralize_inner_sandbox(
         }
         "gemini" => {
             *static_args = filter_gemini_inner_sandbox_args(static_args);
+        }
+        "grok" => {
+            *static_args = filter_grok_inner_sandbox_args(static_args);
         }
         _ => {}
     }
@@ -103,6 +106,27 @@ fn filter_gemini_inner_sandbox_args(args: &[String]) -> Vec<String> {
         .filter(|a| a.as_str() != "-s" && a.as_str() != "--sandbox")
         .cloned()
         .collect()
+}
+
+/// Strip grok's sandbox flag from a static-args vector. `--sandbox` takes a
+/// value and may also be spelled `--sandbox=<profile>`.
+fn filter_grok_inner_sandbox_args(args: &[String]) -> Vec<String> {
+    let mut filtered = Vec::with_capacity(args.len());
+    let mut idx = 0;
+    while idx < args.len() {
+        let arg = &args[idx];
+        if arg == "--sandbox" {
+            idx += 2;
+            continue;
+        }
+        if arg.starts_with("--sandbox=") {
+            idx += 1;
+            continue;
+        }
+        filtered.push(arg.clone());
+        idx += 1;
+    }
+    filtered
 }
 
 #[cfg(test)]
@@ -176,6 +200,35 @@ mod tests {
         );
         assert!(args.iter().any(|a| a == "--approval-mode"));
         assert!(args.iter().any(|a| a == "json"));
+    }
+
+    #[test]
+    fn neutralize_inner_sandbox_drops_grok_sandbox_flag_and_value() {
+        let mut config = HashMap::new();
+        let mut args = vec![
+            "--permission-mode".to_string(),
+            "bypassPermissions".to_string(),
+            "--sandbox".to_string(),
+            "workspace-write".to_string(),
+            "--output-format".to_string(),
+            "json".to_string(),
+            "--sandbox=another-profile".to_string(),
+        ];
+        neutralize_inner_sandbox("grok", &mut config, &mut args);
+        assert_eq!(
+            args,
+            vec![
+                "--permission-mode".to_string(),
+                "bypassPermissions".to_string(),
+                "--output-format".to_string(),
+                "json".to_string(),
+            ],
+            "grok sandbox flags should be removed with their values"
+        );
+        assert!(
+            config.is_empty(),
+            "grok provider_config must remain untouched"
+        );
     }
 
     #[test]

--- a/crates/orbit-engine/src/activity_job/cli_runner/envelope.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/envelope.rs
@@ -249,4 +249,20 @@ mod tests {
             })
         );
     }
+
+    #[test]
+    fn parse_cli_invocation_trace_accepts_grok_json_text_envelope() {
+        let stdout = serde_json::json!({
+            "text": "{\"schemaVersion\":1,\"status\":\"success\",\"result\":{\"pong\":\"grok\"},\"error\":null}",
+            "stopReason": "EndTurn",
+            "sessionId": "grok-session",
+            "requestId": "grok-request"
+        })
+        .to_string();
+
+        assert!(
+            parse_cli_invocation_trace(stdout.as_bytes(), b"", Some(0), 99, true).is_some(),
+            "grok --output-format json stdout should expose the embedded Orbit envelope"
+        );
+    }
 }

--- a/crates/orbit-engine/src/activity_job/cli_runner/tests/orchestrator_macos_tests.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/tests/orchestrator_macos_tests.rs
@@ -23,7 +23,7 @@ fn run_cli_backend_audit_argv_starts_with_sandbox_exec_for_each_provider() {
         return;
     }
 
-    for provider_name in ["claude", "codex", "gemini"] {
+    for provider_name in ["claude", "codex", "gemini", "grok"] {
         let temp = tempdir().expect("tempdir");
         let script = temp.path().join(provider_name);
         write_executable(
@@ -219,6 +219,69 @@ fn run_cli_backend_drops_gemini_sandbox_flag_under_outer_wrapper() {
     assert!(
         !suffix.iter().any(|a| a == "--sandbox" || a == "-s"),
         "gemini argv suffix must not contain --sandbox / -s: {suffix:?}"
+    );
+}
+
+#[cfg(target_os = "macos")]
+#[test]
+fn run_cli_backend_drops_grok_sandbox_flag_under_outer_wrapper() {
+    if !sandbox_exec_can_apply_for_test() {
+        return;
+    }
+
+    let temp = tempdir().expect("tempdir");
+    let script = temp.path().join("grok");
+    write_executable(
+        &script,
+        "#!/bin/sh\ncat > /dev/null\nprintf '%s\\n' '{\"status\":\"ok\"}'\n",
+    );
+
+    let sink = Arc::new(RecordingSink::default());
+    let sink_for_writer: Arc<dyn AuditSink> = sink;
+    let audit = Arc::new(V2AuditWriter::new(
+        "job-grok-drop",
+        "grok:grok-build",
+        sink_for_writer,
+    ));
+    let host = TestHost {
+        command: script.display().to_string(),
+        executor_args: vec![
+            "--sandbox".to_string(),
+            "workspace-write".to_string(),
+            "--output-format".to_string(),
+            "json".to_string(),
+        ],
+        provider_config: HashMap::new(),
+        sandbox: Some(sandbox_for_test()),
+        task_context: None,
+    };
+    let spec = test_agent_loop_spec_for("grok", Duration::from_secs(5));
+
+    let outcome = run_cli_backend(
+        &host,
+        &spec,
+        "job-grok-drop",
+        audit.clone(),
+        &serde_json::json!({"prompt": "hi"}),
+        None,
+    )
+    .expect("run cli backend");
+    assert!(outcome.success);
+
+    let events = audit.events_snapshot().expect("events snapshot");
+    let argv = events
+        .iter()
+        .find_map(|event| match &event.kind {
+            V2AuditEventKind::CliInvocationStarted { argv_redacted, .. } => {
+                Some(argv_redacted.clone())
+            }
+            _ => None,
+        })
+        .expect("cli.invocation.started event");
+    let suffix = &argv[4..];
+    assert!(
+        !suffix.iter().any(|a| a == "--sandbox") && !suffix.iter().any(|a| a == "workspace-write"),
+        "grok argv suffix must not contain --sandbox profile: {suffix:?}"
     );
 }
 

--- a/crates/orbit-engine/src/activity_job/cli_runner/tests/orchestrator_tests.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/tests/orchestrator_tests.rs
@@ -11,7 +11,9 @@ use tempfile::tempdir;
 use super::super::super::audit_writer::V2AuditWriter;
 use super::super::super::dispatcher::DispatchError;
 use super::super::run_cli_backend;
-use super::test_support::{RecordingSink, TestHost, test_agent_loop_spec, write_executable};
+use super::test_support::{
+    RecordingSink, TestHost, test_agent_loop_spec, test_agent_loop_spec_for, write_executable,
+};
 
 #[test]
 fn run_cli_backend_finished_audit_event_keeps_stdout_stderr_blob_refs() {
@@ -365,6 +367,83 @@ fn run_cli_backend_passes_provider_config_to_codex_runtime_args() {
             "--add-dir".to_string(),
             "/tmp/orbit-b".to_string(),
         ]
+    );
+}
+
+#[test]
+fn run_cli_backend_passes_model_to_grok_and_captures_well_formed_stdout() {
+    let temp = tempdir().expect("tempdir");
+    let script = temp.path().join("grok");
+    let grok_stdout = serde_json::json!({
+        "text": "{\"schemaVersion\":1,\"status\":\"success\",\"result\":{\"pong\":\"grok-smoke\"},\"error\":null}",
+        "stopReason": "EndTurn"
+    })
+    .to_string();
+    write_executable(
+        &script,
+        &format!("#!/bin/sh\ncat > /dev/null\nprintf '%s\\n' '{grok_stdout}'\n"),
+    );
+
+    let sink = Arc::new(RecordingSink::default());
+    let sink_for_writer: Arc<dyn AuditSink> = sink;
+    let audit = Arc::new(V2AuditWriter::new(
+        "job-grok-model",
+        "grok:grok-build",
+        sink_for_writer,
+    ));
+    let host = TestHost {
+        command: script.display().to_string(),
+        executor_args: vec![
+            "--output-format".to_string(),
+            "json".to_string(),
+            "--prompt-file".to_string(),
+            "/dev/stdin".to_string(),
+        ],
+        provider_config: HashMap::new(),
+        sandbox: None,
+        task_context: None,
+    };
+    let mut spec = test_agent_loop_spec_for("grok", Duration::from_secs(5));
+    spec.model = Some("grok-build".to_string());
+
+    let outcome = run_cli_backend(
+        &host,
+        &spec,
+        "job-grok-model",
+        audit.clone(),
+        &serde_json::json!({"prompt": "hi"}),
+        None,
+    )
+    .expect("run succeeds");
+
+    assert!(outcome.success);
+    assert!(outcome.invocation.is_some());
+    assert_eq!(outcome.output["provider"], "grok");
+    assert_eq!(outcome.output["stdout_blob_ref"].as_str(), Some("blob-2"));
+    assert!(
+        outcome
+            .output
+            .get("stdout_text")
+            .and_then(serde_json::Value::as_str)
+            .is_some_and(|text| text.contains("grok-smoke")),
+        "stdout preview should include the grok response"
+    );
+
+    let events = audit.events_snapshot().expect("events snapshot");
+    let argv = events
+        .iter()
+        .find_map(|event| match &event.kind {
+            V2AuditEventKind::CliInvocationStarted { argv_redacted, .. } => Some(argv_redacted),
+            _ => None,
+        })
+        .expect("cli.invocation.started event");
+    let model_idx = argv
+        .iter()
+        .position(|arg| arg == "--model")
+        .expect("grok argv should include --model");
+    assert_eq!(
+        argv.get(model_idx + 1).map(String::as_str),
+        Some("grok-build")
     );
 }
 

--- a/crates/orbit-engine/src/activity_job/cli_runner/tests/test_support.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/tests/test_support.rs
@@ -317,7 +317,6 @@ pub(in crate::activity_job::cli_runner) fn test_agent_loop_spec(
     }
 }
 
-#[cfg(target_os = "macos")]
 pub(in crate::activity_job::cli_runner) fn test_agent_loop_spec_for(
     provider: &str,
     timeout: Duration,
@@ -326,6 +325,7 @@ pub(in crate::activity_job::cli_runner) fn test_agent_loop_spec_for(
         "claude" => Provider::Claude,
         "codex" => Provider::Codex,
         "gemini" => Provider::Gemini,
+        "grok" => Provider::Grok,
         other => panic!("unsupported provider for test: {other}"),
     };
     AgentLoopSpec {


### PR DESCRIPTION
## Task

[ORB-00045](https://orbit-cli.com/tasks/ORB-00045) — Add Grok executor YAML and CLI runner support for backend: cli

### Description

## Problem
There is no `grok.yaml` in `crates/orbit-core/assets/executors/`. The CLI runner (orchestrator, supervisor, envelope) has special-case logic only for claude/codex/gemini (arg fixups, output parsing, debug file handling).

The Grok CLI is already installed in this environment, so `backend: cli` + `provider: grok` should be a real, exercisable path — not scaffolding.

## Scope
- Add `crates/orbit-core/assets/executors/grok.yaml` modeled on the existing claude/codex/gemini executor YAMLs.
- Extend the CLI runner's arg-fixup / stdout-handling / model-selection logic to recognize the grok executor. Audit the same call sites that special-case the other three families and add a grok branch (or refactor toward a data-driven dispatch where the change is mechanical).
- Add an integration-level smoke test that actually invokes the installed Grok CLI through the executor and asserts a non-empty, well-formed response.

## Why It Matters
Parity for users driving Grok under Orbit's supervised execution and sandbox model. With the Grok CLI installed, this is now a real, testable surface — not future-proofing.

### Acceptance Criteria

- `crates/orbit-core/assets/executors/grok.yaml` exists and follows the schema of claude/codex/gemini.yaml
- CLI runner code paths (argument fixups, stdout handling, model selection) recognize the grok executor
- An integration smoke test invokes the installed Grok CLI end-to-end through the executor and asserts a non-empty, well-formed response
- Activity jobs using `backend: cli` with a Grok model can be started, executed, and produce a captured stdout artifact

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Added the embedded Grok executor asset and default executor seeding, using Grok CLI JSON headless mode with `--prompt-file /dev/stdin` and `grok-build` as the runtime model.
- Added Grok as a first-class backend: cli provider across provider parsing, CLI resolution, config detection/prompting, and the orbit-agent runtime registry.
- Extended CLI runner handling for Grok model args, stdout envelope parsing, sandbox flag neutralization, and provider coverage tests.
- Added an ignored installed-Grok smoke test that dispatches a real backend: cli activity and asserts parsed stdout plus captured stdout blob ref.

Assessment: Focused implementation with fake-provider unit coverage, installed Grok end-to-end smoke validation, and repo guardrails passing. The installed smoke disables the OS sandbox only when `/usr/bin/sandbox-exec` cannot apply in the current host, while keeping executor-driven args and stdout artifact assertions.

Validation:
- `cargo test -p orbit-agent grok`
- `cargo test -p orbit-engine grok`
- `cargo test -p orbit-core model_registry_returns_expected_defaults`
- `cargo test -p orbit-core default_provider_prefers_cli_in_documented_order`
- `cargo test -p orbit-core config::agent_prompt`
- `cargo test -p orbit-core cli_executor_resolution_preserves_registered_static_args`
- `cargo test -p orbit-core --test grok_cli_backend_smoke -- --ignored`
- `make ci-fast`

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-00045-6a08b44c`
- Behind base: 0
- Ahead of base: 1