### PR TITLE
Filter list_backlog_tasks by task_dependencies_ready in v2 backlog selection

### DIFF
--- a/crates/orbit-core/assets/activities/list_backlog_tasks.yaml
+++ b/crates/orbit-core/assets/activities/list_backlog_tasks.yaml
@@ -7,7 +7,7 @@ spec:
   description: >
     Materialize the current workspace backlog as an ordered task list for
     the auto-pipeline. In automatic mode it
-    filters to `status: backlog` while leaving legacy untriaged
+    filters to `status: backlog` with all task dependencies satisfied while leaving legacy untriaged
     `status: friction` reports out, and
     drops any backlog parent/subtask group whose `context_files` overlap the
     active task-lock surface from `in-progress` or `review` tasks. Automatic

--- a/crates/orbit-core/src/runtime/v2_host/backlog_exclusion.rs
+++ b/crates/orbit-core/src/runtime/v2_host/backlog_exclusion.rs
@@ -1,7 +1,10 @@
 use std::collections::BTreeMap;
 use std::path::Path;
 
-use orbit_common::types::{Task, TaskStatus, TaskType, prune_missing_context_files};
+use orbit_common::types::{
+    Task, TaskStatus, TaskType, build_task_status_index, prune_missing_context_files,
+    task_dependencies_ready,
+};
 use orbit_common::utility::path::workspace_relative_paths_overlap;
 use orbit_common::utility::selector::canonical_selector_in_workspace;
 use orbit_engine::DispatchError;
@@ -139,11 +142,14 @@ pub(super) fn list_backlog_tasks(
             .cloned()
             .map(|task| (task.id.clone(), task))
             .collect();
+        let status_by_id = build_task_status_index(&all_tasks);
         let workspace_root = runtime.paths().repo_root.as_path();
         let lock_holders = active_task_lock_holders(task_lookup.values(), workspace_root);
         let mut backlog: Vec<Task> = all_tasks
             .into_iter()
-            .filter(|task| task.status == TaskStatus::Backlog)
+            .filter(|task| {
+                task.status == TaskStatus::Backlog && task_dependencies_ready(task, &status_by_id)
+            })
             .collect();
         backlog.sort_by(|a, b| {
             let rank = |p: orbit_common::types::TaskPriority| match p {

--- a/crates/orbit-core/src/runtime/v2_host/backlog_exclusion_tests.rs
+++ b/crates/orbit-core/src/runtime/v2_host/backlog_exclusion_tests.rs
@@ -1,9 +1,10 @@
-use orbit_common::types::{TaskPriority, TaskStatus, TaskType};
+use orbit_common::types::{Task, TaskPriority, TaskStatus, TaskType};
 use orbit_engine::V2RuntimeHost;
 use orbit_tools::ToolContext;
 use serde_json::{Value, json};
 
 use crate::OrbitRuntime;
+use crate::command::task::{TaskAddParams, TaskUpdateParams};
 use crate::runtime::v2_host::test_support::{
     runtime_with_workspace_layout, seed_accepted_friction_task, seed_list_backlog_task,
     write_workspace_file,
@@ -38,6 +39,50 @@ fn excluded_entry<'a>(output: &'a Value, task_id: &str) -> &'a Value {
         .iter()
         .find(|entry| entry["id"] == task_id)
         .expect("excluded entry")
+}
+
+fn output_task_ids(output: &Value) -> Vec<String> {
+    output["task_ids"]
+        .as_array()
+        .expect("task_ids array")
+        .iter()
+        .map(|task_id| {
+            task_id
+                .as_str()
+                .expect("task_id should be a string")
+                .to_string()
+        })
+        .collect()
+}
+
+fn seed_task_with_dependencies(
+    runtime: &OrbitRuntime,
+    title: &str,
+    status: TaskStatus,
+    dependencies: Vec<String>,
+) -> Task {
+    runtime
+        .add_task(TaskAddParams {
+            title: title.to_string(),
+            description: format!("Fixture task: {title}"),
+            acceptance_criteria: vec!["Fixture task is observable.".to_string()],
+            dependencies,
+            plan: "Fixture plan.".to_string(),
+            workspace_path: Some(".".to_string()),
+            priority: TaskPriority::Medium,
+            task_type: Some(TaskType::Chore),
+            status: Some(status),
+            ..Default::default()
+        })
+        .expect("seed task with dependencies")
+}
+
+fn seed_backlog_task_with_dependencies(
+    runtime: &OrbitRuntime,
+    title: &str,
+    dependencies: Vec<String>,
+) -> Task {
+    seed_task_with_dependencies(runtime, title, TaskStatus::Backlog, dependencies)
 }
 
 #[test]
@@ -188,6 +233,115 @@ fn list_backlog_tasks_preserves_existing_fields_without_conflicts() {
         ])
     );
     assert_eq!(output["excluded"], json!([]));
+}
+
+#[test]
+fn list_backlog_tasks_filters_dependency_readiness() {
+    let (_root, runtime, _repo_root) = runtime_with_workspace_layout();
+    let proposed_dependency = seed_task_with_dependencies(
+        &runtime,
+        "Proposed dependency",
+        TaskStatus::Proposed,
+        vec![],
+    );
+    let backlog_dependency =
+        seed_task_with_dependencies(&runtime, "Backlog dependency", TaskStatus::Backlog, vec![]);
+    let in_progress_dependency = seed_task_with_dependencies(
+        &runtime,
+        "In-progress dependency",
+        TaskStatus::InProgress,
+        vec![],
+    );
+    let review_dependency =
+        seed_task_with_dependencies(&runtime, "Review dependency", TaskStatus::Review, vec![]);
+    let done_dependency =
+        seed_task_with_dependencies(&runtime, "Done dependency", TaskStatus::Done, vec![]);
+    let ready = seed_backlog_task_with_dependencies(
+        &runtime,
+        "Ready dependent",
+        vec![done_dependency.id.clone()],
+    );
+    let no_dependencies = seed_backlog_task_with_dependencies(&runtime, "No dependencies", vec![]);
+    let blocked_by_proposed = seed_backlog_task_with_dependencies(
+        &runtime,
+        "Blocked by proposed",
+        vec![proposed_dependency.id.clone()],
+    );
+    let blocked_by_backlog = seed_backlog_task_with_dependencies(
+        &runtime,
+        "Blocked by backlog",
+        vec![backlog_dependency.id.clone()],
+    );
+    let blocked_by_in_progress = seed_backlog_task_with_dependencies(
+        &runtime,
+        "Blocked by in-progress",
+        vec![in_progress_dependency.id.clone()],
+    );
+    let blocked_by_review = seed_backlog_task_with_dependencies(
+        &runtime,
+        "Blocked by review",
+        vec![review_dependency.id.clone()],
+    );
+
+    let output = list_backlog_tasks(&runtime, json!({}));
+    let task_ids = output_task_ids(&output);
+
+    assert!(task_ids.contains(&ready.id));
+    assert!(task_ids.contains(&no_dependencies.id));
+    assert!(task_ids.contains(&backlog_dependency.id));
+    assert!(!task_ids.contains(&blocked_by_proposed.id));
+    assert!(!task_ids.contains(&blocked_by_backlog.id));
+    assert!(!task_ids.contains(&blocked_by_in_progress.id));
+    assert!(!task_ids.contains(&blocked_by_review.id));
+    assert_eq!(output["excluded"], json!([]));
+}
+
+#[test]
+fn list_backlog_tasks_serializes_orb_00042_grok_epic_chain() {
+    let (_root, runtime, _repo_root) = runtime_with_workspace_layout();
+    let orb43 = seed_backlog_task_with_dependencies(&runtime, "ORB-00043 grok foundation", vec![]);
+    let orb44 = seed_backlog_task_with_dependencies(
+        &runtime,
+        "ORB-00044 grok follow-up",
+        vec![orb43.id.clone()],
+    );
+    let orb45 = seed_backlog_task_with_dependencies(
+        &runtime,
+        "ORB-00045 grok follow-up",
+        vec![orb43.id.clone()],
+    );
+    let orb46 = seed_backlog_task_with_dependencies(
+        &runtime,
+        "ORB-00046 grok follow-up",
+        vec![orb43.id.clone()],
+    );
+    let orb48 = seed_backlog_task_with_dependencies(
+        &runtime,
+        "ORB-00048 grok follow-up",
+        vec![orb43.id.clone()],
+    );
+
+    let output = list_backlog_tasks(&runtime, json!({}));
+
+    assert_eq!(output_task_ids(&output), vec![orb43.id.clone()]);
+
+    runtime
+        .update_task(
+            &orb43.id,
+            TaskUpdateParams {
+                status: Some(TaskStatus::Done),
+                ..Default::default()
+            },
+        )
+        .expect("mark ORB-00043 done");
+    let output = list_backlog_tasks(&runtime, json!({}));
+    let task_ids = output_task_ids(&output);
+
+    assert_eq!(task_ids.len(), 4);
+    assert!(task_ids.contains(&orb44.id));
+    assert!(task_ids.contains(&orb45.id));
+    assert!(task_ids.contains(&orb46.id));
+    assert!(task_ids.contains(&orb48.id));
 }
 
 #[test]


### PR DESCRIPTION
## Task

[ORB-00057](https://orbit-cli.com/tasks/ORB-00057) — Filter list_backlog_tasks by task_dependencies_ready in v2 backlog selection

### Description

## Problem

`list_backlog_tasks` in [crates/orbit-core/src/runtime/v2_host/backlog_exclusion.rs:111](crates/orbit-core/src/runtime/v2_host/backlog_exclusion.rs:111) — the entry point the v2 auto-pipeline uses to pick the next task to execute — filters by `status == Backlog`, priority, creation time, and context-file lock conflicts. It does **not** consult the task's `dependencies` field.

The dependency-readiness helper already exists: `task_dependencies_ready` / `satisfies_dependency` at [crates/orbit-common/src/types/task.rs:128](crates/orbit-common/src/types/task.rs:128). It is wired into the CLI `--ready` filter and the `orbit.task.list` MCP tool when `ready=true` is passed, with strict semantics: every dependency must be in `Done` status.

Result: agents composing dependent task chains (e.g. the ORB-00042 grok onboarding epic, where ORB-00044/-45/-46/-48 all depend on ORB-00043 landing first) cannot rely on the auto-pipeline to serialize execution. The pipeline will happily grab a dependent task while its blocker is still `in-progress`, silently violating the documented contract of the `dependencies` field.

Today this is masked because tasks sit in `proposed` until manually promoted to `backlog`, but the moment someone batch-promotes a chain it will execute out of order.

## Why It Matters

- Correctness foot-gun for anyone using `dependencies` to express ordering constraints. The field exists, has strict semantics, and is silently ignored on the hottest selection path.
- Divergence between the agent-facing view (`orbit.task.list ready=true` respects deps) and the auto-pipeline (does not). Same task DB, two different answers to "what's runnable now."
- Blocks the natural execution flow for the ORB-00042 grok epic; current workaround is manual gating (promote -43 alone, wait for done, then promote the next layer).

## Constraints / Notes

- Use the existing `task_dependencies_ready` helper; do not reimplement. Strict-`Done`-only semantics should be preserved for now — relaxing to `Review` is a separate discussion.
- Inspect other callers of `list_backlog_tasks` (and any sibling backlog-selection functions in `v2_host/`) — the filter should be applied at the same layer for all of them, not just one entry point.
- The context-file lock-conflict filter must continue to work after this change.
- If a task has unsatisfied dependencies, the v2 pipeline should skip it silently (same shape as today's context-lock skip), not log an error.

### Acceptance Criteria

- `list_backlog_tasks` excludes any task whose `dependencies` are not all in `TaskStatus::Done`, using the existing `task_dependencies_ready` helper from `crates/orbit-common/src/types/task.rs`
- All sibling selection functions in `crates/orbit-core/src/runtime/v2_host/` that return runnable backlog tasks apply the same dependency filter (identify them as part of the task plan)
- Unit test in `backlog_exclusion.rs` (or sibling test module) covers three cases: (a) dependent task with all deps `Done` is selected; (b) dependent task with at least one dep in `Proposed`/`Backlog`/`InProgress`/`Review` is excluded; (c) task with empty `dependencies` array is selected
- Existing context-file lock-conflict exclusion behavior is preserved (regression test or existing test still passes)
- `make ci-fast` passes; `cargo test -p orbit-core` passes
- ORB-00042 grok epic chain (ORB-00043 → -44/-45/-46/-48 → ...) executes in correct order when all tasks are simultaneously promoted to `backlog`, verified by a focused integration or unit test that constructs the chain in-memory and asserts only ORB-00043 is returned from `list_backlog_tasks` until its status flips to `Done`

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Wired automatic `list_backlog_tasks` selection through `build_task_status_index` and `task_dependencies_ready`, so backlog tasks with unmet dependencies are skipped before context-lock conflict filtering.
- Updated the activity description to document dependency-ready backlog selection.
- Added `backlog_exclusion` unit coverage for Done-only dependency readiness, empty dependency selection, context-lock regression preservation, and the ORB-00042 grok chain ordering case.

Assessment: The scoped scheduler behavior is covered by focused tests and `make ci-fast` passes. Full `cargo test -p orbit-core` was run but is blocked by unrelated existing/environment failures in job-run process identity tests (`ps` is unavailable in this execution environment) and `config::agent_detect::tests::detect_reflects_probe_results`; the new `runtime::v2_host::backlog_exclusion` test module passes independently.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-00057-6a08c540`
- Behind base: 0
- Ahead of base: 1