### PR TITLE
Surface friction tag enum in orbit.friction.add description and orbit-track-issues skill

### DIFF
--- a/crates/orbit-common/src/friction.rs
+++ b/crates/orbit-common/src/friction.rs
@@ -1,0 +1,28 @@
+//! Shared friction taxonomy defaults.
+
+/// Default friction tags and their human-readable glosses.
+///
+/// This list seeds `.orbit/frictions/tags.yaml` for new workspaces and keeps
+/// tool-schema affordances aligned with the default validator vocabulary.
+pub const DEFAULT_FRICTION_TAGS: &[(&str, &str)] = &[
+    ("build", "make/fmt/lint friction"),
+    ("docs", "Stale or missing CLAUDE.md or design docs"),
+    ("lifecycle", "Task lifecycle confusion or transition issues"),
+    ("naming", "Naming drift or duplicated sources of truth"),
+    ("other", "Fallback"),
+    ("policy", "fsProfile or sandboxing surprises"),
+    (
+        "skill-guidance",
+        "Misleading or incorrect skill instructions",
+    ),
+    ("tooling", "Orbit tool/CLI/MCP failures"),
+];
+
+/// Return the default friction tag enum in schema-friendly literal form.
+pub fn friction_tags_literal() -> String {
+    DEFAULT_FRICTION_TAGS
+        .iter()
+        .map(|(tag, _description)| *tag)
+        .collect::<Vec<_>>()
+        .join(" | ")
+}

--- a/crates/orbit-common/src/lib.rs
+++ b/crates/orbit-common/src/lib.rs
@@ -11,6 +11,7 @@
 //! Shared leaf crate for the Orbit workspace.
 //!
 //! The public surface is intentionally split into four namespaces:
+//! - [`friction`] for shared friction taxonomy defaults
 //! - [`groundhog`] for Groundhog checkpoint lineage and append-only chronicle
 //!   serialization
 //! - [`migration`] for forward-only schema migrations of YAML artifacts
@@ -19,6 +20,7 @@
 //!   and blob storage
 //! - [`tracing`] as the shared structured-event facade used by Orbit crates
 
+pub mod friction;
 pub mod groundhog;
 pub mod migration;
 pub mod types;

--- a/crates/orbit-core/assets/skills/orbit-track-issues/SKILL.md
+++ b/crates/orbit-core/assets/skills/orbit-track-issues/SKILL.md
@@ -31,6 +31,19 @@ There is no task lifecycle, triage state, rejection penalty, or precomputed scor
 
 Do **not ignore friction**. Always create a report.
 
+## Valid Tags
+
+| Tag | Use for |
+| --- | --- |
+| `build` | make/fmt/lint friction |
+| `docs` | Stale or missing CLAUDE.md or design docs |
+| `lifecycle` | Task lifecycle confusion or transition issues |
+| `naming` | Naming drift or duplicated sources of truth |
+| `other` | Fallback when no specific tag fits |
+| `policy` | fsProfile or sandboxing surprises |
+| `skill-guidance` | Misleading or incorrect skill instructions |
+| `tooling` | Orbit tool/CLI/MCP failures |
+
 ## How to Create the Report
 
 Two surfaces, identical JSON args. See the `orbit` skill for the full mapping.

--- a/crates/orbit-store/src/file/friction_store.rs
+++ b/crates/orbit-store/src/file/friction_store.rs
@@ -3,6 +3,7 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 use chrono::{DateTime, Utc};
+use orbit_common::friction::DEFAULT_FRICTION_TAGS;
 use orbit_common::types::{
     FrictionFrontmatter, FrictionRecord, OrbitError, Task, TaskStatus, all_agent_families,
     normalize_optional_attribution_label, resolve_agent_model_pair,
@@ -11,19 +12,6 @@ use orbit_common::utility::fs::{atomic_write_text, with_exclusive_file_lock};
 use serde_json::{Value, json};
 
 const TAGS_FILENAME: &str = "tags.yaml";
-const DEFAULT_TAGS: &[(&str, &str)] = &[
-    ("tooling", "Orbit tool/CLI/MCP failures"),
-    (
-        "skill-guidance",
-        "Misleading or incorrect skill instructions",
-    ),
-    ("docs", "Stale or missing CLAUDE.md or design docs"),
-    ("lifecycle", "Task lifecycle confusion or transition issues"),
-    ("build", "make/fmt/lint friction"),
-    ("naming", "Naming drift or duplicated sources of truth"),
-    ("policy", "fsProfile or sandboxing surprises"),
-    ("other", "Fallback"),
-];
 
 #[derive(Debug, Clone)]
 pub struct FrictionAddParams {
@@ -192,7 +180,7 @@ pub fn ensure_default_tag_taxonomy(frictions_root: &Path) -> Result<PathBuf, Orb
     let path = frictions_root.join(TAGS_FILENAME);
     if !path.exists() {
         let mut body = String::new();
-        for (tag, description) in DEFAULT_TAGS {
+        for (tag, description) in DEFAULT_FRICTION_TAGS {
             body.push_str(&format!("{tag}: \"{description}\"\n"));
         }
         atomic_write_text(&path, &body).map_err(|error| OrbitError::Io(error.to_string()))?;

--- a/crates/orbit-tools/src/builtin/orbit/friction/add.rs
+++ b/crates/orbit-tools/src/builtin/orbit/friction/add.rs
@@ -1,3 +1,4 @@
+use orbit_common::friction::friction_tags_literal;
 use orbit_common::types::{OrbitError, ToolParam, ToolSchema};
 use serde_json::Value;
 
@@ -21,8 +22,10 @@ impl Tool for OrbitFrictionAddTool {
                 },
                 ToolParam {
                     name: "tags".to_string(),
-                    description: "Friction taxonomy tags as a string or array; defaults to other"
-                        .to_string(),
+                    description: format!(
+                        "Friction taxonomy tags as a string or array; valid tags: {}; defaults to other",
+                        friction_tags_literal()
+                    ),
                     param_type: "string_list".to_string(),
                     required: false,
                 },
@@ -47,5 +50,35 @@ impl Tool for OrbitFrictionAddTool {
     fn execute(&self, ctx: &ToolContext, input: Value) -> Result<Value, OrbitError> {
         super::super::reject_agent_field(&input, "orbit.friction.add")?;
         super::super::execute_host_action(ctx, input, OrbitBuiltinAction::FrictionAdd)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use orbit_common::friction::{DEFAULT_FRICTION_TAGS, friction_tags_literal};
+
+    use super::*;
+
+    #[test]
+    fn tags_parameter_description_lists_default_taxonomy() {
+        let schema = OrbitFrictionAddTool.schema();
+        let tags_param = schema
+            .parameters
+            .iter()
+            .find(|param| param.name == "tags")
+            .expect("tags parameter");
+
+        assert!(
+            tags_param.description.contains(&friction_tags_literal()),
+            "{}",
+            tags_param.description
+        );
+        for (tag, _description) in DEFAULT_FRICTION_TAGS {
+            assert!(
+                tags_param.description.contains(tag),
+                "tags description should include {tag}: {}",
+                tags_param.description
+            );
+        }
     }
 }


### PR DESCRIPTION
## Task

[ORB-00064](https://orbit-cli.com/tasks/ORB-00064) — Surface friction tag enum in orbit.friction.add description and orbit-track-issues skill

### Description

## Problem
`orbit.friction.add`'s `tags` parameter description today reads: _"Friction taxonomy tags as a string or array; defaults to other"_ ([crates/orbit-tools/src/builtin/orbit/friction/add.rs:23-25](crates/orbit-tools/src/builtin/orbit/friction/add.rs:23)). The closed set of valid tags (`build | docs | lifecycle | naming | other | policy | skill-guidance | tooling`, source: `.orbit/frictions/tags.yaml`) is not enumerated in the description. The `orbit-track-issues` skill is similarly silent.

An agent's first reasonable guess for a tool-failure friction is `tool-failure` — which is rejected with a generic `invalid input: unknown friction tag(s): tool-failure. valid tags: …`. The agent has to fail-then-read to discover the vocabulary. See [F2026-05-016](.orbit/frictions/2026-05/F016.md) for the source incident.

## Why It Matters
- Forces every agent to learn the enum the hard way, on a tool whose entire purpose is friction reduction.
- The rejected write is wasted round-trip cost.
- The closed vocabulary is short and stable; embedding it in the description is cheap.

## Constraints / Notes
- Source of truth: `.orbit/frictions/tags.yaml`. Description copy should not hard-code the list a second time without a regen path; either reference the file or generate the description string at tool-registration time from the YAML.
- Mirror the change in `orbit-track-issues/SKILL.md` so agents reading the skill (the documented entry point) also see the enum.
- No schema change to the tool — keep `tags` as free-form string/array; the validator already enforces the set. This task is documentation/affordance only.

### Acceptance Criteria

- `crates/orbit-tools/src/builtin/orbit/friction/add.rs` `tags` parameter `description` field includes the full enum literal `build | docs | lifecycle | naming | other | policy | skill-guidance | tooling` (or is generated from `.orbit/frictions/tags.yaml` at registration time so the literal stays in sync).
- `crates/orbit-core/assets/skills/orbit-track-issues/SKILL.md` contains a section or table listing the same valid tags with a one-line gloss per tag.
- A unit test under `crates/orbit-tools/` asserts the friction-add tool's `tags` parameter description either contains every tag from `.orbit/frictions/tags.yaml` or is structurally derived from it (whichever shape this task chooses).
- Calling `orbit.friction.add` over MCP with `tags=['tool-failure']` still returns the same `invalid input` error — the validator is unchanged; only the affordance is improved.
- `make ci-fast` passes locally and via the PR `ci` workflow.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Added a shared default friction taxonomy in orbit-common, used by orbit-store to seed tags.yaml and by orbit-tools to render the orbit.friction.add tags parameter enum literal.
- Documented the valid friction tags with one-line glosses in the orbit-track-issues skill.
- Added orbit-tools unit coverage asserting the tags parameter description includes the structurally derived default taxonomy.

Assessment: The validator path is unchanged; invalid tag probe for tool-failure still returns invalid_input with the same valid-tag list.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-00064-6a08c6e1`
- Behind base: 0
- Ahead of base: 1