### PR TITLE
Collapse Diagnostics > Friction subtab into Recent Runs

### DIFF
--- a/crates/orbit-cli/assets/dashboard/app.js
+++ b/crates/orbit-cli/assets/dashboard/app.js
@@ -37,9 +37,10 @@ let activeStatuses = new Set(
 );
 let lastTasks = [];
 let lastRuns = [];
-let lastDiagnostics = { metrics: [], friction: [], errors: [] };
+let lastDiagnostics = { metrics: [], errors: [] };
 let activeTab = "tasks";
 let activeDiagSubtab = "runs";
+let runSort = { key: "when", dir: "desc" };
 let expandedTaskIds = new Set();
 let isRefreshing = false;
 let taskActionNotice = null;
@@ -704,13 +705,255 @@ function formatScoreboardPair(agent, col) {
   };
 }
 
+const RUN_SORT_DEFAULT_DIR = {
+  when: "desc",
+  job: "asc",
+  run_id: "asc",
+  denials: "desc",
+  tool_fails: "desc",
+  duration: "desc",
+  state: "asc",
+};
+
+function coerceNumber(value) {
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  if (typeof value !== "string" || value.trim() === "") return null;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function firstNumericField(row, keys) {
+  for (const key of keys) {
+    const value = coerceNumber(row && row[key]);
+    if (value != null) return value;
+  }
+  return null;
+}
+
+function firstBooleanField(row, keys) {
+  for (const key of keys) {
+    const value = row && row[key];
+    if (typeof value === "boolean") return value;
+    if (typeof value === "string") {
+      const normalized = value.trim().toLowerCase();
+      if (normalized === "true") return true;
+      if (normalized === "false") return false;
+    }
+  }
+  return false;
+}
+
+function frictionRunId(row) {
+  return (
+    (row && (row.run_id || row.job_run || row.runId || row.jobRun)) ||
+    ""
+  );
+}
+
+function frictionRowText(row) {
+  return [
+    row && (row.kind || row.body_kind || row.event_kind || row.type || row.category),
+    row && (row.command || row.tool || row.tool_name || row.status || row.outcome),
+    row && (row.stderr || row.message || row.reason || row.error),
+  ]
+    .filter(Boolean)
+    .join(" ")
+    .toLowerCase();
+}
+
+function frictionRowLooksDenied(row) {
+  const text = frictionRowText(row).replace(/[_-]/g, " ");
+  return /\bden(?:y|ied|ial|ials)\b/.test(text) || text.includes("policy deny");
+}
+
+function frictionRowLooksToolFail(row) {
+  const exitCode = coerceNumber(row && row.exit_code);
+  if (exitCode != null && exitCode !== 0) return true;
+  if (firstBooleanField(row, ["timed_out", "timeout"])) return true;
+  const text = frictionRowText(row).replace(/[_-]/g, " ");
+  return text.includes("tool") && /\b(fail|failed|failure|timeout|timed out)\b/.test(text);
+}
+
+function frictionRowLooksLongRun(row) {
+  if (firstBooleanField(row, ["long_run", "is_long_run", "long_running"])) return true;
+  const text = frictionRowText(row).replace(/[_-]/g, " ");
+  return text.includes("long run") || text.includes("long running");
+}
+
+function emptyRunFrictionSummary(run) {
+  return {
+    denials: 0,
+    toolFails: 0,
+    durationMs: coerceNumber(run && run.duration_ms),
+    longRun: false,
+  };
+}
+
+function addFrictionRowToSummary(summary, row) {
+  const denials = firstNumericField(row, [
+    "denials",
+    "denial_count",
+    "policy_denials",
+  ]);
+  if (denials != null) {
+    summary.denials += denials;
+  } else if (frictionRowLooksDenied(row)) {
+    summary.denials += 1;
+  }
+
+  const toolFails = firstNumericField(row, [
+    "tool_fails",
+    "tool_failures",
+    "tool_fail_count",
+    "failed_tool_calls",
+  ]);
+  if (toolFails != null) {
+    summary.toolFails += toolFails;
+  } else if (frictionRowLooksToolFail(row)) {
+    summary.toolFails += 1;
+  }
+
+  const durationMs = firstNumericField(row, [
+    "duration_ms",
+    "run_duration_ms",
+    "wall_clock_ms",
+    "elapsed_ms",
+  ]);
+  if (durationMs != null) {
+    summary.durationMs = Math.max(summary.durationMs || 0, durationMs);
+  }
+  summary.longRun = summary.longRun || frictionRowLooksLongRun(row);
+}
+
+function mergeRunsWithFriction(runs, frictionRows) {
+  const byRun = new Map();
+  for (const row of frictionRows || []) {
+    const runId = frictionRunId(row);
+    if (!runId) continue;
+    if (!byRun.has(runId)) byRun.set(runId, emptyRunFrictionSummary());
+    addFrictionRowToSummary(byRun.get(runId), row);
+  }
+  return (runs || []).map((run) => ({
+    ...run,
+    diagnostics_friction: mergeRunFrictionSummary(run, byRun.get(run.run_id)),
+  }));
+}
+
+function mergeRunFrictionSummary(run, friction) {
+  const base = emptyRunFrictionSummary(run);
+  if (!friction) return base;
+  return {
+    ...base,
+    ...friction,
+    durationMs: friction.durationMs == null ? base.durationMs : friction.durationMs,
+  };
+}
+
+function runTimestampValue(run) {
+  const ts = run.finished_at || run.started_at || run.scheduled_at || run.created_at;
+  const time = ts ? new Date(ts).getTime() : 0;
+  return Number.isFinite(time) ? time : 0;
+}
+
+function runFriction(run) {
+  return run.diagnostics_friction || emptyRunFrictionSummary(run);
+}
+
+function runSortValue(run, key) {
+  const friction = runFriction(run);
+  switch (key) {
+    case "when":
+      return runTimestampValue(run);
+    case "job":
+      return run.job_id || "";
+    case "run_id":
+      return run.run_id || "";
+    case "denials":
+      return friction.denials || 0;
+    case "tool_fails":
+      return friction.toolFails || 0;
+    case "duration":
+      return friction.durationMs || 0;
+    case "state":
+      return run.state || "";
+    default:
+      return "";
+  }
+}
+
+function compareRunValues(left, right) {
+  if (typeof left === "number" && typeof right === "number") return left - right;
+  return String(left).localeCompare(String(right));
+}
+
+function sortedRunsForDisplay(runs) {
+  const rows = (runs || []).slice();
+  rows.sort((a, b) => {
+    const primary = compareRunValues(runSortValue(a, runSort.key), runSortValue(b, runSort.key));
+    const directed = runSort.dir === "asc" ? primary : -primary;
+    if (directed !== 0) return directed;
+    return runTimestampValue(b) - runTimestampValue(a);
+  });
+  return rows;
+}
+
+function setRunSort(key) {
+  if (runSort.key === key) {
+    runSort = { key, dir: runSort.dir === "asc" ? "desc" : "asc" };
+  } else {
+    runSort = { key, dir: RUN_SORT_DEFAULT_DIR[key] || "asc" };
+  }
+  renderRuns(lastRuns);
+}
+
+function runHeaderCell(label, key, opts = {}) {
+  const classes = [opts.class, opts.num ? "num" : ""].filter(Boolean).join(" ");
+  const cell = el("span", { class: classes, style: opts.style });
+  const button = el("button", {
+    class: `runs-sort${runSort.key === key ? " active" : ""}`,
+    text: label,
+    title: `Sort Recent Runs by ${label}`,
+  });
+  button.type = "button";
+  if (runSort.key === key) {
+    button.appendChild(el("span", {
+      class: "sort-arrow",
+      text: runSort.dir === "asc" ? " ▲" : " ▼",
+    }));
+  }
+  button.addEventListener("click", (event) => {
+    event.stopPropagation();
+    setRunSort(key);
+  });
+  cell.appendChild(button);
+  return cell;
+}
+
+function runCountCell(value) {
+  return el("span", {
+    class: `num${value > 0 ? " hot" : ""}`,
+    text: String(value || 0),
+  });
+}
+
+function runDurationCell(run) {
+  const friction = runFriction(run);
+  return el("span", { class: "duration" }, [
+    fmtDuration(friction.durationMs),
+    friction.longRun
+      ? el("span", { class: "long-run-flag", text: "!", title: "Long run" })
+      : null,
+  ]);
+}
+
 function renderRuns(runs) {
   const body = $("runs-body");
   const frag = document.createDocumentFragment();
   
-  const top = runs.slice(0, 20);
+  const sorted = sortedRunsForDisplay(runs);
+  const top = sorted.slice(0, 20);
   if ($("diag-count") && activeDiagSubtab === "runs") {
-    $("diag-count").textContent = `${top.length}/${runs.length}`;
+    $("diag-count").textContent = `${top.length}/${sorted.length}`;
   }
   if (top.length === 0) {
     syncNodes(body, [el("div", { class: "empty-state" }, [
@@ -720,18 +963,21 @@ function renderRuns(runs) {
     return;
   }
   const header = el("div", { class: "runs-row runs-header" }, [
-    el("span", { text: "when" }),
-    el("span", { text: "job" }),
-    el("span", { text: "run id" }),
-    el("span", { text: "duration", style: { textAlign: "right" } }),
-    el("span", { text: "state", style: { textAlign: "right" } }),
+    runHeaderCell("when", "when"),
+    runHeaderCell("job", "job"),
+    runHeaderCell("run id", "run_id"),
+    runHeaderCell("denials", "denials", { num: true }),
+    runHeaderCell("tool fails", "tool_fails", { num: true }),
+    runHeaderCell("duration", "duration", { style: { textAlign: "right" } }),
+    runHeaderCell("state", "state", { style: { textAlign: "right" } }),
     el("span", { text: "" }),
   ]);
   header.dataset.key = "runs-header";
-  header.dataset.hash = "header";
+  header.dataset.hash = `header-${runSort.key}-${runSort.dir}`;
   frag.appendChild(header);
   for (const r of top) {
     const ts = r.finished_at || r.started_at || r.scheduled_at || r.created_at;
+    const friction = runFriction(r);
     const runIdSpan = el("span", { class: "run-id", text: r.run_id, title: "Click to copy run ID" });
     runIdSpan.addEventListener("click", (e) => {
       e.stopPropagation();
@@ -748,12 +994,14 @@ function renderRuns(runs) {
       el("span", { class: "when", text: fmtTimestamp(ts) }),
       el("span", { class: "id", text: r.job_id }),
       runIdSpan,
-      el("span", { class: "duration", text: fmtDuration(r.duration_ms) }),
+      runCountCell(friction.denials),
+      runCountCell(friction.toolFails),
+      runDurationCell(r),
       el("span", { class: "state" }, [stateCell(r.state)]),
       el("span", { class: "run-actions" }, runIsCancellable(r) ? [buildCancelRunButton(r, body)] : []),
     ]);
     row.dataset.key = `run-${r.run_id}`;
-    row.dataset.hash = `${r.run_id}-${ts}-${r.duration_ms}-${r.state}`;
+    row.dataset.hash = `${r.run_id}-${ts}-${r.duration_ms}-${r.state}-${friction.denials}-${friction.toolFails}-${friction.durationMs}-${friction.longRun}`;
     row.style.cursor = "pointer";
     row.addEventListener("click", () => navigateToRun(r.run_id));
     frag.appendChild(row);
@@ -953,7 +1201,7 @@ function wireSearch() {
 }
 
 const TABS = ["tasks", "scoreboard", "audit", "diagnostics", "run-detail"];
-const DIAG_SUBTABS = ["runs", "metrics", "friction", "errors"];
+const DIAG_SUBTABS = ["runs", "metrics", "errors"];
 const RUN_DETAIL_SUBTABS = ["steps", "events"];
 const AUDIT_SUBTABS = ["events", "policy"];
 
@@ -1209,33 +1457,6 @@ const DIAG_METRICS_COLUMNS = [
   { key: "retry_count", label: "retries", num: true },
 ];
 
-const DIAG_FRICTION_COLUMNS = [
-  { key: "ts", label: "time", num: false, render: (v) => fmtRelative(v) },
-  { key: "step", label: "step", num: false },
-  { key: "command", label: "command", num: false },
-  {
-    key: "exit_code",
-    label: "exit",
-    num: true,
-    render: (v, _row, td) => {
-      if (v == null) return "-";
-      if (v !== 0) td.classList.add("exit-fail");
-      return String(v);
-    },
-  },
-  {
-    key: "stderr",
-    label: "stderr",
-    num: false,
-    cellClass: "stderr",
-    render: (v, _row, td) => {
-      const full = v || "";
-      td.title = full;
-      return truncate(full, 160);
-    },
-  },
-];
-
 const DIAG_ERRORS_COLUMNS = [
   { key: "ts", label: "time", num: false, render: (v) => fmtRelative(v) },
   { key: "source", label: "source", num: false },
@@ -1321,9 +1542,7 @@ function renderDiagnostics() {
   const columns =
     sub === "metrics"
       ? DIAG_METRICS_COLUMNS
-      : sub === "errors"
-        ? DIAG_ERRORS_COLUMNS
-        : DIAG_FRICTION_COLUMNS;
+      : DIAG_ERRORS_COLUMNS;
   renderDiagnosticsTable(
     rows,
     columns,
@@ -1396,20 +1615,16 @@ function activeRefreshJobs() {
     );
     return jobs;
   }
-
-  jobs.push(
-    fetchJson(`/api/diagnostics/friction?limit=${DIAG_LIMIT}`).then((rows) => {
-      lastDiagnostics.friction = rows;
-      renderDiagnostics();
-    }),
-  );
   return jobs;
 }
 
 function fetchAndRenderRuns() {
-  return fetchJson(`/api/job-runs?limit=${JOB_RUN_LIMIT}`).then((runs) => {
-    lastRuns = runs;
-    renderRuns(runs);
+  return Promise.all([
+    fetchJson(`/api/job-runs?limit=${JOB_RUN_LIMIT}`),
+    fetchJson(`/api/diagnostics/friction?limit=${DIAG_LIMIT}`),
+  ]).then(([runs, frictionRows]) => {
+    lastRuns = mergeRunsWithFriction(runs, frictionRows);
+    renderRuns(lastRuns);
   });
 }
 

--- a/crates/orbit-cli/assets/dashboard/index.html
+++ b/crates/orbit-cli/assets/dashboard/index.html
@@ -712,7 +712,9 @@
       
       .runs-row {
         display: grid;
-        grid-template-columns: 80px 1fr minmax(100px, 0.6fr) 70px 80px 72px;
+        grid-template-columns:
+          80px minmax(100px, 1fr) minmax(100px, 0.7fr)
+          58px 74px 86px 80px 72px;
         gap: 12px;
         padding: 8px 16px;
         font-family: var(--font-mono);
@@ -737,7 +739,17 @@
       }
       .runs-row .run-id:hover { color: var(--accent); }
       .runs-row .duration { color: var(--fg-dim); text-align: right; }
+      .runs-row .num { text-align: right; color: var(--fg-dim); }
+      .runs-row .num.hot { color: var(--state-failed); }
       .runs-row .state { text-align: right; }
+      .runs-row .long-run-flag {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        margin-left: 6px;
+        color: var(--priority-medium);
+        font-weight: 700;
+      }
       .runs-row .run-actions {
         display: flex;
         justify-content: flex-end;
@@ -762,6 +774,18 @@
         background: var(--bg-elev);
         z-index: 1;
       }
+      .runs-sort {
+        appearance: none;
+        border: 0;
+        background: transparent;
+        color: inherit;
+        font: inherit;
+        letter-spacing: inherit;
+        text-transform: inherit;
+        padding: 0;
+        cursor: pointer;
+      }
+      .runs-sort.active { color: var(--fg); }
       
       .scoreboard-row {
         display: grid;
@@ -1665,7 +1689,6 @@
           <nav class="subtabs" id="diag-subtabs">
             <button class="subtab" data-subtab="runs" type="button">Recent Runs</button>
             <button class="subtab" data-subtab="metrics" type="button">Metrics</button>
-            <button class="subtab" data-subtab="friction" type="button">Friction</button>
             <button class="subtab" data-subtab="errors" type="button">Errors</button>
           </nav>
           <div class="body scoreboard-table-wrap" id="diag-body" style="display: none;">

--- a/docs/design/user-interface/2_design.md
+++ b/docs/design/user-interface/2_design.md
@@ -2,7 +2,7 @@
 
 **Status:** Draft
 **Owner:** gemini
-**Last updated:** 2026-05-08 (T20260508-14)
+**Last updated:** 2026-05-16 (ORB-00060)
 
 This document describes the current Orbit UI implementation: the local dashboard assets, the Canon Refined visual rules they rely on, and the telemetry behaviors that must stay consistent with backend data.
 
@@ -28,7 +28,9 @@ Summary tiles and drill-down panels must agree. Audit > Policy is the detail vie
 
 Run Detail > Steps now includes compact per-step agent log expanders for CLI-backed activity steps [T20260508-14]. The UI renders bounded stdout and stderr previews from `/api/runs/:id/logs`, distinguishes stderr blocks from stdout blocks, highlights structured `ERROR <target>:` lines, and keeps blob references behind the API so operators do not need to resolve content hashes manually.
 
-Diagnostics has an Errors sub-tab after [T20260508-14]. It renders recent backend error rows independently of Metrics, Friction, and Policy, combining Orbit process ERROR events with structured agent stderr rows. Rows with `job_run` provenance route back to the owning Run Detail step so error triage stays connected to workflow context.
+Diagnostics has an Errors sub-tab after [T20260508-14]. It renders recent backend error rows independently of Metrics and Policy, combining Orbit process ERROR events with structured agent stderr rows. Rows with `job_run` provenance route back to the owning Run Detail step so error triage stays connected to workflow context.
+
+Diagnostics no longer has a Friction sub-tab after [ORB-00060]. The Friction name is reserved for append-only `.orbit/frictions/` artifacts, while audit-derived negative run signals stay visible in Recent Runs. Recent Runs joins `/api/job-runs` with `/api/diagnostics/friction` client-side by run id (`run_id`/`job_run`) and keeps the table sortable across `denials`, `tool fails`, and `duration`; the duration cell can carry the long-run flag when the diagnostics source supplies one. This preserves column continuity with the existing compact dashboard telemetry direction from [T20260428-15].
 
 ## 6. Concerns & Honest Limitations
 
@@ -42,5 +44,6 @@ Accessibility still needs a real WCAG pass; responsive behavior remains optimize
 - [T20260430-24] shortened this design doc while preserving current behavior statements.
 - [T20260430-29] bounded the live `orbit.log` panel to the viewport.
 - [T20260508-14] added Run Detail agent-log previews and Diagnostics > Errors.
+- [ORB-00060] collapsed Diagnostics > Friction into Recent Runs diagnostics columns.
 
 > Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.


### PR DESCRIPTION
## Task

[ORB-00060](https://orbit-cli.com/tasks/ORB-00060) — Collapse Diagnostics > Friction subtab into Recent Runs

### Description

## Problem
The Dashboard has a `Diagnostics > Friction` subtab that shows per-run aggregates of audit-derived negative events (failed tool calls, denials, error spans, long-runs). With the new first-class `Friction` artifact (`.orbit/frictions/*`), the word collides: the subtab is *not* the artifact view. Rather than rename (every candidate stayed ambiguous), we collapse the subtab and fold its data into `Recent Runs` as sortable columns.

## Why It Matters
Clears the naming conflict cheaply before the Knowledge tab lands (follow-up tasks add Learnings/Frictions/ADRs subtabs), so 'friction' in the dashboard can mean exactly one thing: the artifact. Also reduces subtab maintenance.

## Constraints / Notes
- Keep `/api/diagnostics/friction` endpoint as-is — it becomes the data source for the new columns, not a tab of its own. Server-side merge into `/api/job-runs` is explicitly out of scope (follow-up).
- Client-side join by `run_id`: Recent Runs fetcher additionally calls `/api/diagnostics/friction` and merges rows.
- Scoreboard column `friction.reported` (`app.js:804`) is per-agent count semantics, not the artifact — leave it for now; renaming is a separate decision.
- Update `docs/design/user-interface/2_design.md` Dashboard Telemetry Consistency section; cite [T20260428-15] for column continuity.

### Acceptance Criteria

- `Diagnostics > Friction` subtab is absent from the rendered dashboard: the `<button data-subtab="friction">` is removed from `index.html` and the `'friction'` entry is removed from `DIAG_SUBTABS` in `app.js`.
- `Recent Runs` table in Diagnostics shows three additional sortable columns: `denials`, `tool fails`, `duration`/long-run flag — values populated by merging `/api/diagnostics/friction` rows by `run_id`.
- `docs/design/user-interface/2_design.md` `Last updated:` is bumped and the Dashboard Telemetry Consistency section documents (a) the subtab removal and (b) the new Recent Runs columns and their data source.
- `make ci-fast` passes locally and via the PR `ci` workflow.
- Dashboard smoke check: `cargo run -p orbit-cli -- web` serves `/static/index.html`, the Diagnostics tab renders without console errors, the new columns sort, and clicking a Recent Runs row still opens Run Detail as before.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Removed the Diagnostics > Friction subtab from the dashboard HTML and removed friction from the diagnostics subtab registry/render path.
- Updated Recent Runs to fetch /api/diagnostics/friction with /api/job-runs, join rows by run_id/job_run, and render sortable denials, tool fails, and duration/long-run flag columns while preserving row navigation to Run Detail.
- Updated docs/design/user-interface/2_design.md Last updated and Dashboard Telemetry Consistency notes for the subtab removal and Recent Runs friction-data source, citing [T20260428-15].

Assessment: Scoped dashboard/doc change validated with node --check, make ci-fast, and a headless Chrome dashboard smoke. make check-design-docs was also attempted; it failed on unrelated stale docs outside this task (activity-job and auditability).

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-00060-6a08c54a`
- Behind base: 0
- Ahead of base: 1