### PR TITLE
Introduce per-task crew override for agent model selection

### DIFF
--- a/.orbit/config.toml
+++ b/.orbit/config.toml
@@ -22,23 +22,19 @@ enabled = true
 [graph]
 editing = false
 
-[agent.implementer]
-backend = "cli"
-model = "gpt-5.5"
-provider = "codex"
+[crews.opus-codex]
+planner = { model = "claude-opus-4-7", provider = "claude", backend = "cli" }
+implementer = { model = "gpt-5.5", provider = "codex", backend = "cli" }
+reviewer = { model = "gpt-5.5", provider = "codex", backend = "cli" }
 
-[agent.planner]
-backend = "cli"
-model = "claude-opus-4-7"
-provider = "claude"
-
-[agent.reviewer]
-backend = "cli"
-model = "gpt-5.5"
-provider = "codex"
+[crews.all-claude]
+planner = { model = "claude-opus-4-7", provider = "claude", backend = "cli" }
+implementer = { model = "claude-sonnet-4-6", provider = "claude", backend = "cli" }
+reviewer = { model = "claude-opus-4-7", provider = "claude", backend = "cli" }
 
 [workflow]
 base_branch = "agent-main"
+default_crew = "opus-codex"
 
 [pr]
 task_url_template = "https://orbit-cli.com/tasks/{task_id}"

--- a/crates/orbit-cli/src/command/run/job.rs
+++ b/crates/orbit-cli/src/command/run/job.rs
@@ -204,6 +204,10 @@ pub(crate) fn job_run_to_json(run: &JobRun) -> Value {
         "error_code": last.and_then(|s| s.error_code.as_deref()),
         "error_message": last.and_then(|s| s.error_message.as_deref()),
         "knowledge_metrics": run.knowledge_metrics,
+        "resolved_crew": run.resolved_crew,
+        "planner_model": run.planner_model,
+        "implementer_model": run.implementer_model,
+        "reviewer_model": run.reviewer_model,
         "steps": run.steps.iter().map(|s| json!({
             "step_index": s.step_index,
             "target_type": s.target_type.to_string(),

--- a/crates/orbit-cli/src/command/task/add.rs
+++ b/crates/orbit-cli/src/command/task/add.rs
@@ -62,6 +62,9 @@ pub struct TaskAddArgs {
     /// For bug tasks: the originating task whose implementation introduced the defect
     #[arg(long = "source-task")]
     pub source_task: Option<String>,
+    /// Named crew to use when running this task
+    #[arg(long)]
+    pub crew: Option<String>,
     /// Explicit agent name to persist on the task artifact
     #[arg(long)]
     pub agent: Option<String>,
@@ -131,6 +134,7 @@ impl Execute for TaskAddArgs {
                     .map(|raw| ExternalRef::parse_key(raw))
                     .collect::<Result<Vec<_>, _>>()?,
                 source_task_id: self.source_task.clone(),
+                crew: self.crew,
             },
             self.agent,
             self.model,

--- a/crates/orbit-cli/src/command/task/lifecycle.rs
+++ b/crates/orbit-cli/src/command/task/lifecycle.rs
@@ -16,6 +16,9 @@ pub struct TaskStartArgs {
     /// Append a task comment
     #[arg(long)]
     pub comment: Option<String>,
+    /// Crew override for this start
+    #[arg(long)]
+    pub crew: Option<String>,
     /// Explicit agent name to persist on the task artifact
     #[arg(long)]
     pub agent: Option<String>,
@@ -29,12 +32,13 @@ pub struct TaskStartArgs {
 
 impl Execute for TaskStartArgs {
     fn execute(self, runtime: &OrbitRuntime) -> Result<(), OrbitError> {
-        let task = runtime.start_task_with_identity(
+        let task = runtime.start_task_with_identity_and_crew(
             &self.id,
             self.note,
             self.comment,
             self.agent,
             self.model,
+            self.crew,
         )?;
         if self.json {
             crate::output::json::print_pretty(&task_to_json_for_runtime(runtime, &task)?)

--- a/crates/orbit-cli/src/command/task/output.rs
+++ b/crates/orbit-cli/src/command/task/output.rs
@@ -85,44 +85,21 @@ pub(crate) fn task_to_json_with_sidecars(
         serde_json::to_value(runtime.get_task_review_threads(&task.id)?)
             .map_err(|e| OrbitError::Io(e.to_string()))?,
     );
-    if let Some(run_id) = task.job_run_id.as_deref()
-        && let Ok(run) = runtime.show_job_run(run_id)
-        && let (
-            Some(resolved_crew),
-            Some(planner_model),
-            Some(implementer_model),
-            Some(reviewer_model),
-        ) = (
-            run.resolved_crew,
-            run.planner_model,
-            run.implementer_model,
-            run.reviewer_model,
-        )
-    {
-        object.insert("resolved_crew".to_string(), Value::String(resolved_crew));
-        object.insert("planner_model".to_string(), Value::String(planner_model));
+    if let Some(projection) = runtime.resolved_crew_projection(task)? {
+        object.insert("resolved_crew".to_string(), Value::String(projection.name));
+        object.insert(
+            "planner_model".to_string(),
+            Value::String(projection.planner_model),
+        );
         object.insert(
             "implementer_model".to_string(),
-            Value::String(implementer_model),
+            Value::String(projection.implementer_model),
         );
-        object.insert("reviewer_model".to_string(), Value::String(reviewer_model));
-        return Ok(value);
+        object.insert(
+            "reviewer_model".to_string(),
+            Value::String(projection.reviewer_model),
+        );
     }
-
-    let crew = runtime.resolved_crew_for_task_projection(task)?;
-    object.insert("resolved_crew".to_string(), Value::String(crew.name));
-    object.insert(
-        "planner_model".to_string(),
-        Value::String(crew.planner.model),
-    );
-    object.insert(
-        "implementer_model".to_string(),
-        Value::String(crew.implementer.model),
-    );
-    object.insert(
-        "reviewer_model".to_string(),
-        Value::String(crew.reviewer.model),
-    );
     Ok(value)
 }
 

--- a/crates/orbit-cli/src/command/task/output.rs
+++ b/crates/orbit-cli/src/command/task/output.rs
@@ -47,6 +47,7 @@ pub(crate) fn task_to_json(
         "relations": task.relations,
         "source_task_id": task.source_task_id(),
         "job_run_id": task.job_run_id,
+        "crew": task.crew,
         "created_at": task.created_at.to_rfc3339(),
         "updated_at": task.updated_at.to_rfc3339(),
     })
@@ -84,6 +85,44 @@ pub(crate) fn task_to_json_with_sidecars(
         serde_json::to_value(runtime.get_task_review_threads(&task.id)?)
             .map_err(|e| OrbitError::Io(e.to_string()))?,
     );
+    if let Some(run_id) = task.job_run_id.as_deref()
+        && let Ok(run) = runtime.show_job_run(run_id)
+        && let (
+            Some(resolved_crew),
+            Some(planner_model),
+            Some(implementer_model),
+            Some(reviewer_model),
+        ) = (
+            run.resolved_crew,
+            run.planner_model,
+            run.implementer_model,
+            run.reviewer_model,
+        )
+    {
+        object.insert("resolved_crew".to_string(), Value::String(resolved_crew));
+        object.insert("planner_model".to_string(), Value::String(planner_model));
+        object.insert(
+            "implementer_model".to_string(),
+            Value::String(implementer_model),
+        );
+        object.insert("reviewer_model".to_string(), Value::String(reviewer_model));
+        return Ok(value);
+    }
+
+    let crew = runtime.resolved_crew_for_task_projection(task)?;
+    object.insert("resolved_crew".to_string(), Value::String(crew.name));
+    object.insert(
+        "planner_model".to_string(),
+        Value::String(crew.planner.model),
+    );
+    object.insert(
+        "implementer_model".to_string(),
+        Value::String(crew.implementer.model),
+    );
+    object.insert(
+        "reviewer_model".to_string(),
+        Value::String(crew.reviewer.model),
+    );
     Ok(value)
 }
 
@@ -93,6 +132,7 @@ pub(super) fn task_lock_to_json(task: &orbit_core::Task) -> Value {
         "title": task.title,
         "status": task.status.to_string(),
         "job_run_id": task.job_run_id,
+        "crew": task.crew,
         "context_files": task.context_files,
     })
 }

--- a/crates/orbit-cli/src/command/task/update.rs
+++ b/crates/orbit-cli/src/command/task/update.rs
@@ -53,6 +53,9 @@ pub struct TaskUpdateArgs {
     /// Job run ID to associate with the task (empty string clears)
     #[arg(long)]
     pub job_run_id: Option<String>,
+    /// Named crew to use when running this task (empty string clears)
+    #[arg(long)]
+    pub crew: Option<String>,
     /// Comma-separated task context selectors (empty string clears). Prefer
     /// `file:`, `dir:`, or `symbol:` forms; legacy raw paths are accepted and upgraded.
     #[arg(long = "context", alias = "context-files")]
@@ -89,6 +92,7 @@ impl Execute for TaskUpdateArgs {
             implemented_by,
             pr_status,
             job_run_id,
+            crew,
             context_files,
             artifacts,
             agent,
@@ -104,6 +108,13 @@ impl Execute for TaskUpdateArgs {
             }
         });
         let job_run_id = job_run_id.map(|value| {
+            if value.trim().is_empty() {
+                None
+            } else {
+                Some(value)
+            }
+        });
+        let crew = crew.map(|value| {
             if value.trim().is_empty() {
                 None
             } else {
@@ -146,6 +157,7 @@ impl Execute for TaskUpdateArgs {
                 implemented_by,
                 pr_status,
                 job_run_id,
+                crew,
                 context_files: context_files.map(|c| crate::parse::csv_to_vec(&c)),
                 upsert_artifacts,
                 ..Default::default()

--- a/crates/orbit-cli/src/command/web/api/runs_tests.rs
+++ b/crates/orbit-cli/src/command/web/api/runs_tests.rs
@@ -405,6 +405,10 @@ fn run_detail_uses_v2_audit_steps_when_step_bundle_is_empty() {
         input: None,
         retry_source_run_id: None,
         knowledge_metrics: None,
+        resolved_crew: None,
+        planner_model: None,
+        implementer_model: None,
+        reviewer_model: None,
         steps: Vec::new(),
     };
 

--- a/crates/orbit-cli/src/command/web/api/tasks.rs
+++ b/crates/orbit-cli/src/command/web/api/tasks.rs
@@ -72,6 +72,8 @@ pub(super) struct CreateTaskBody {
     parent_id: Option<String>,
     #[serde(default)]
     source_task_id: Option<String>,
+    #[serde(default)]
+    crew: Option<String>,
 }
 
 fn default_priority() -> TaskPriority {
@@ -109,6 +111,8 @@ pub(super) struct UpdateTaskBody {
     task_type: Option<TaskType>,
     #[serde(default)]
     context_files: Option<Vec<String>>,
+    #[serde(default)]
+    crew: Option<Option<String>>,
 }
 
 pub(super) async fn list_tasks(State(runtime): State<Arc<OrbitRuntime>>) -> Response {
@@ -187,6 +191,7 @@ pub(super) async fn create_task_action(
         system_created: false,
         external_refs: body.external_refs,
         source_task_id: body.source_task_id,
+        crew: body.crew,
     };
     match runtime.add_task_with_identity(params, None, None) {
         Ok(task) => match dashboard_status_index(&runtime) {
@@ -224,6 +229,7 @@ pub(super) async fn update_task_action(
         implemented_by: None,
         pr_status: None,
         job_run_id: None,
+        crew: body.crew,
         context_files: body.context_files,
         upsert_artifacts: Vec::new(),
         append_review_threads: Vec::new(),

--- a/crates/orbit-cli/src/command/web/api/test_support.rs
+++ b/crates/orbit-cli/src/command/web/api/test_support.rs
@@ -79,6 +79,10 @@ pub(super) fn seed_run(
         input: None,
         retry_source_run_id: None,
         knowledge_metrics: None,
+        resolved_crew: None,
+        planner_model: None,
+        implementer_model: None,
+        reviewer_model: None,
         steps: Vec::new(),
     };
     let run_dir = runtime

--- a/crates/orbit-common/src/types/agent_pair.rs
+++ b/crates/orbit-common/src/types/agent_pair.rs
@@ -1,5 +1,4 @@
-//! Authoritative mapping from an agent CLI family to the orchestrator/helper
-//! model pair that should drive bounded implementation work.
+//! Authoritative agent-family helpers and named crew resolution.
 //!
 //! This is the single source of truth Orbit consults whenever an activity needs
 //! to embed a model duo into its instructions. Splitting the heavy "judgment"
@@ -10,6 +9,7 @@
 //! `{{helper_model}}`, and `{{agent_family}}` placeholders, which the runtime
 //! substitutes into the instruction text before invoking the agent.
 
+use std::collections::BTreeMap;
 use std::path::Path;
 
 use serde::{Deserialize, Serialize};
@@ -33,6 +33,51 @@ impl AgentModelPair {
             helper: helper.into(),
         }
     }
+}
+
+/// One role assignment inside a named crew.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CrewRoleAssignment {
+    pub model: String,
+    pub provider: String,
+    pub backend: String,
+}
+
+/// A named planner/implementer/reviewer lineup.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Crew {
+    pub name: String,
+    pub planner: CrewRoleAssignment,
+    pub implementer: CrewRoleAssignment,
+    pub reviewer: CrewRoleAssignment,
+}
+
+impl Crew {
+    pub fn role(&self, role: &str) -> Option<&CrewRoleAssignment> {
+        match role {
+            "planner" => Some(&self.planner),
+            "implementer" => Some(&self.implementer),
+            "reviewer" => Some(&self.reviewer),
+            _ => None,
+        }
+    }
+}
+
+/// Resolve a named crew from the active registry.
+pub fn resolve_crew(name: &str, registry: &BTreeMap<String, Crew>) -> Result<Crew, OrbitError> {
+    let trimmed = name.trim();
+    if trimmed.is_empty() {
+        return Err(OrbitError::invalid_input_with_suggestions(
+            "crew name must not be empty",
+            registry.keys().cloned().collect(),
+        ));
+    }
+    registry.get(trimmed).cloned().ok_or_else(|| {
+        OrbitError::invalid_input_with_suggestions(
+            format!("crew '{trimmed}' is not defined in [crews.*]"),
+            registry.keys().cloned().collect(),
+        )
+    })
 }
 
 /// The full set of agent CLI families Orbit knows how to orchestrate.
@@ -150,5 +195,91 @@ pub fn resolve_agent_model_pair_or(
         "gemini" => Some(AgentModelPair::new("pro", "flash")),
         "grok" => Some(AgentModelPair::new("grok-4", "grok-3")),
         _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn assignment(model: &str, provider: &str) -> CrewRoleAssignment {
+        CrewRoleAssignment {
+            model: model.to_string(),
+            provider: provider.to_string(),
+            backend: "cli".to_string(),
+        }
+    }
+
+    fn registry() -> BTreeMap<String, Crew> {
+        let mut registry = BTreeMap::new();
+        registry.insert(
+            "opus-codex".to_string(),
+            Crew {
+                name: "opus-codex".to_string(),
+                planner: assignment("claude-opus-4-7", "claude"),
+                implementer: assignment("gpt-5.5", "codex"),
+                reviewer: assignment("claude-opus-4-7", "claude"),
+            },
+        );
+        registry.insert(
+            "all-claude".to_string(),
+            Crew {
+                name: "all-claude".to_string(),
+                planner: assignment("claude-opus-4-7", "claude"),
+                implementer: assignment("claude-sonnet-4-6", "claude"),
+                reviewer: assignment("claude-opus-4-7", "claude"),
+            },
+        );
+        registry
+    }
+
+    #[test]
+    fn resolve_crew_returns_assignments_for_known_name() {
+        let crew = resolve_crew("opus-codex", &registry()).expect("crew resolves");
+
+        assert_eq!(crew.name, "opus-codex");
+        assert_eq!(crew.planner.model, "claude-opus-4-7");
+        assert_eq!(crew.implementer.provider, "codex");
+        assert_eq!(crew.reviewer.backend, "cli");
+    }
+
+    #[test]
+    fn resolve_crew_lists_defined_names_on_unknown() {
+        let error = resolve_crew("missing", &registry()).expect_err("unknown crew fails");
+
+        match error {
+            OrbitError::InvalidInputDiagnostic { did_you_mean, .. } => {
+                assert_eq!(did_you_mean, vec!["all-claude", "opus-codex"]);
+            }
+            other => panic!("expected InvalidInputDiagnostic, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn infer_agent_family_from_model_handles_claude_gpt_gemini_grok_prefixes() {
+        assert_eq!(
+            infer_agent_family_from_model("claude-opus-4-7").as_deref(),
+            Some("claude")
+        );
+        assert_eq!(
+            infer_agent_family_from_model("gpt-5.5").as_deref(),
+            Some("codex")
+        );
+        assert_eq!(
+            infer_agent_family_from_model("o3-mini").as_deref(),
+            Some("codex")
+        );
+        assert_eq!(
+            infer_agent_family_from_model("gemini-3.1-pro").as_deref(),
+            Some("gemini")
+        );
+        assert_eq!(
+            infer_agent_family_from_model("grok-4").as_deref(),
+            Some("grok")
+        );
+        assert_eq!(
+            infer_agent_family_from_model("grok3").as_deref(),
+            Some("grok")
+        );
     }
 }

--- a/crates/orbit-common/src/types/job.rs
+++ b/crates/orbit-common/src/types/job.rs
@@ -427,6 +427,14 @@ pub struct JobRun {
     pub retry_source_run_id: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub knowledge_metrics: Option<KnowledgeRunMetrics>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub resolved_crew: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub planner_model: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub implementer_model: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reviewer_model: Option<String>,
     /// Step execution results; populated in-memory from step files, not stored in jrun.yaml.
     #[serde(skip)]
     pub steps: Vec<JobRunStep>,

--- a/crates/orbit-common/src/types/mod.rs
+++ b/crates/orbit-common/src/types/mod.rs
@@ -65,8 +65,9 @@ pub use actor::{
 };
 pub use adr::{Adr, AdrStatus, LegacyValidation, legacy_id_for, validate_adr_id};
 pub use agent_pair::{
-    AgentModelPair, agent_family_from_cli, all_agent_families, infer_agent_family_from_model,
-    normalize_agent_family_for_model, resolve_agent_model_pair,
+    AgentModelPair, Crew, CrewRoleAssignment, agent_family_from_cli, all_agent_families,
+    infer_agent_family_from_model, normalize_agent_family_for_model, resolve_agent_model_pair,
+    resolve_crew,
 };
 pub use audit::Audit;
 pub use audit_event::{AuditEvent, AuditEventStatus, AuditStats, audit_execution_id};

--- a/crates/orbit-common/src/types/task.rs
+++ b/crates/orbit-common/src/types/task.rs
@@ -634,6 +634,8 @@ pub struct Task {
     pub relations: Vec<TaskRelation>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub job_run_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub crew: Option<String>,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
 }
@@ -924,6 +926,35 @@ updated_at: 2026-01-01T00:00:00Z
         .expect("task without tags deserializes");
 
         assert_eq!(task.tags, Vec::<String>::new());
+        assert_eq!(task.crew, None);
+    }
+
+    #[test]
+    fn task_round_trips_with_crew_set() {
+        let task = serde_yaml::from_str::<Task>(
+            r#"id: T20260101-1
+title: Crew task
+description: Existing task record.
+acceptance_criteria: []
+dependencies: []
+plan: ""
+execution_summary: ""
+context_files: []
+status: backlog
+priority: medium
+task_type: chore
+crew: opus-codex
+created_at: 2026-01-01T00:00:00Z
+updated_at: 2026-01-01T00:00:00Z
+"#,
+        )
+        .expect("task with crew deserializes");
+
+        let serialized = serde_yaml::to_string(&task).expect("serialize task");
+        let reparsed = serde_yaml::from_str::<Task>(&serialized).expect("reparse task");
+
+        assert_eq!(reparsed, task);
+        assert_eq!(reparsed.crew.as_deref(), Some("opus-codex"));
     }
 
     #[test]

--- a/crates/orbit-common/src/types/task_artifacts.rs
+++ b/crates/orbit-common/src/types/task_artifacts.rs
@@ -65,6 +65,8 @@ pub struct TaskEnvelopeV2 {
     pub complexity: Option<TaskComplexity>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub job_run_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub crew: Option<String>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub relations: Vec<TaskRelation>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
@@ -674,6 +676,7 @@ updated_at: 2026-05-10T12:00:00Z
             priority: TaskPriority::Medium,
             complexity: None,
             job_run_id: None,
+            crew: None,
             relations: Vec::new(),
             tags: Vec::new(),
             context_files: Vec::new(),

--- a/crates/orbit-core/assets/config/default-config.toml
+++ b/crates/orbit-core/assets/config/default-config.toml
@@ -33,28 +33,14 @@ editing = false
 # `agent-main` is the dev integration branch where task PRs land — set
 # `base_branch = "agent-main"` for the same layout in your own repo.
 base_branch = "main"
+default_crew = "opus-codex"
 
-# [agent.<role>] — per-role agent settings written by `orbit init`.
-#
-# Roles: reviewer, implementer, planner. Each table accepts:
-#   provider — claude | codex | gemini | ollama | openai_compat
-#   backend  — cli | http
-#   model    — provider-specific model name (e.g. claude-opus-4-7, gpt-5.5)
-#
-# `orbit init` collects these interactively and rewrites this file. Edit the
-# values below, or re-run `orbit init --force` to start fresh.
-#
-# [agent.reviewer]
-# provider = "claude"
-# backend = "cli"
-# model = "claude-opus-4-7"
-#
-# [agent.implementer]
-# provider = "codex"
-# backend = "cli"
-# model = "gpt-5.5"
-#
-# [agent.planner]
-# provider = "claude"
-# backend = "cli"
-# model = "claude-opus-4-7"
+[crews.opus-codex]
+planner = { model = "claude-opus-4-7", provider = "claude", backend = "cli" }
+implementer = { model = "gpt-5.5", provider = "codex", backend = "cli" }
+reviewer = { model = "gpt-5.5", provider = "codex", backend = "cli" }
+
+[crews.all-claude]
+planner = { model = "claude-opus-4-7", provider = "claude", backend = "cli" }
+implementer = { model = "claude-sonnet-4-6", provider = "claude", backend = "cli" }
+reviewer = { model = "claude-opus-4-7", provider = "claude", backend = "cli" }

--- a/crates/orbit-core/src/command/init.rs
+++ b/crates/orbit-core/src/command/init.rs
@@ -46,10 +46,10 @@ pub struct InitOptions {
     /// When true, create/update user-level skill symlinks for global skills.
     pub link_global_skills: bool,
     /// Per-role agent settings to embed in the freshly seeded `config.toml`
-    /// as `[agent.<role>]` blocks. Keyed by role name (`reviewer`,
-    /// `implementer`, `planner`). `None` and an empty map both mean "leave
-    /// `[agent.*]` unset". Ignored when config.toml already exists — init
-    /// remains idempotent.
+    /// as a `[crews.custom]` table. Keyed by role name (`reviewer`,
+    /// `implementer`, `planner`). `None` and an empty map both mean "use
+    /// the default crew template". Ignored when config.toml already exists
+    /// — init remains idempotent.
     pub role_settings: Option<BTreeMap<String, RawAgentRoleConfig>>,
 }
 
@@ -718,7 +718,7 @@ mod tests {
     }
 
     #[test]
-    fn global_init_writes_role_settings_to_config_toml() {
+    fn global_init_writes_role_settings_as_custom_crew_to_config_toml() {
         let _guard = ENV_LOCK.lock().expect("lock env");
         let home = tempdir().expect("home tempdir");
         let previous_home = std::env::var_os("HOME");
@@ -748,7 +748,7 @@ mod tests {
             RawAgentRoleConfig {
                 provider: Some("gemini".into()),
                 backend: Some("http".into()),
-                model: None,
+                model: Some("gemini-3.1-pro".into()),
             },
         );
 
@@ -768,20 +768,21 @@ mod tests {
 
         let config_path = home.path().join(".orbit").join("config.toml");
         let contents = fs::read_to_string(&config_path).expect("read config");
-        assert!(contents.contains("[agent.reviewer]"));
-        assert!(contents.contains("[agent.implementer]"));
-        assert!(contents.contains("[agent.planner]"));
+        assert!(!contents.contains("[agent.reviewer]"));
+        assert!(contents.contains("default_crew = \"custom\""));
         assert!(contents.contains("provider = \"codex\""));
         assert!(contents.contains("model = \"claude-opus-4-7\""));
 
-        // Round-trips through toml: agent table contains all three roles.
+        // Round-trips through toml: custom crew contains all three roles.
         let parsed: toml::Value = toml::from_str(&contents).expect("parse");
-        let agent = parsed
-            .get("agent")
+        let custom = parsed
+            .get("crews")
             .and_then(|v| v.as_table())
-            .expect("agent table");
-        assert_eq!(agent.len(), 3);
-        let reviewer = agent
+            .and_then(|v| v.get("custom"))
+            .and_then(|v| v.as_table())
+            .expect("custom crew table");
+        assert_eq!(custom.len(), 3);
+        let reviewer = custom
             .get("reviewer")
             .and_then(|v| v.as_table())
             .expect("reviewer table");
@@ -789,12 +790,14 @@ mod tests {
             reviewer.get("provider").and_then(|v| v.as_str()),
             Some("claude")
         );
-        let planner = agent
+        let planner = custom
             .get("planner")
             .and_then(|v| v.as_table())
             .expect("planner table");
-        // None model field → absent from TOML.
-        assert!(planner.get("model").is_none());
+        assert_eq!(
+            planner.get("model").and_then(|v| v.as_str()),
+            Some("gemini-3.1-pro")
+        );
     }
 
     #[test]
@@ -864,14 +867,15 @@ mod tests {
         assert!(result.created_config);
         let config_path = home.path().join(".orbit").join("config.toml");
         let contents = fs::read_to_string(&config_path).expect("read config");
-        // Commented documentation block is allowed; an actual `[agent.<role>]`
-        // section header (uncommented) must NOT appear.
         for line in contents.lines() {
             assert!(
                 !line.trim_start().starts_with("[agent."),
                 "unexpected uncommented agent section: {line}",
             );
         }
+        assert!(contents.contains("[crews.opus-codex]"));
+        assert!(contents.contains("[crews.all-claude]"));
+        assert!(contents.contains("default_crew = \"opus-codex\""));
     }
 
     fn assert_skill_link_exists(path: PathBuf) {

--- a/crates/orbit-core/src/command/job/exec.rs
+++ b/crates/orbit-core/src/command/job/exec.rs
@@ -94,6 +94,7 @@ impl OrbitRuntime {
         if !changed {
             return Err(OrbitError::not_found(NotFoundKind::JobRun, run.run_id));
         }
+        self.record_run_crew_from_input(&run.run_id, &input)?;
         self.record_event(OrbitEvent::JobRunStarted {
             job_id: run.job_id.clone(),
             run_id: run.run_id.clone(),

--- a/crates/orbit-core/src/command/job/run.rs
+++ b/crates/orbit-core/src/command/job/run.rs
@@ -1527,6 +1527,10 @@ mod tests {
             created_at: Utc::now(),
             steps: Vec::new(),
             knowledge_metrics: None,
+            resolved_crew: None,
+            planner_model: None,
+            implementer_model: None,
+            reviewer_model: None,
         };
         // We can't override the probe at this seam (production wrapper), but
         // we can assert the lower-level helper agrees: ProbeUnavailable is
@@ -1562,6 +1566,10 @@ mod tests {
             created_at: Utc::now(),
             steps: Vec::new(),
             knowledge_metrics: None,
+            resolved_crew: None,
+            planner_model: None,
+            implementer_model: None,
+            reviewer_model: None,
         };
         let mismatch_message = stale_job_run_message(&run, Some(OwnerIdentity::Mismatch));
         let missing_message = stale_job_run_message(&run, Some(OwnerIdentity::Missing));

--- a/crates/orbit-core/src/command/pipeline_run.rs
+++ b/crates/orbit-core/src/command/pipeline_run.rs
@@ -226,6 +226,11 @@ impl OrbitRuntime {
         if !changed {
             return Ok(());
         }
+        let input = run
+            .input
+            .clone()
+            .unwrap_or_else(|| Value::Object(Default::default()));
+        self.record_run_crew_from_input(&run.run_id, &input)?;
 
         self.record_event(OrbitEvent::JobRunStarted {
             job_id: run.job_id.clone(),
@@ -233,10 +238,6 @@ impl OrbitRuntime {
             attempt: run.attempt,
         })?;
 
-        let input = run
-            .input
-            .clone()
-            .unwrap_or_else(|| Value::Object(Default::default()));
         let outcome = self.run_job_v2_from_yaml_with_run_id(
             yaml_path,
             input.clone(),

--- a/crates/orbit-core/src/command/task/add.rs
+++ b/crates/orbit-core/src/command/task/add.rs
@@ -51,6 +51,7 @@ impl OrbitRuntime {
             normalize_workspace_path(&self.paths().repo_root, params.workspace_path.as_deref())?;
         let dependencies = normalize_task_dependencies(params.dependencies.clone())?;
         validate_task_dependencies(&self.list_tasks()?, None, &dependencies)?;
+        self.validate_crew_name(params.crew.as_deref())?;
 
         let prune_root = context_workspace_root(&self.paths().repo_root, workspace_path.as_deref());
         let normalized_context_files =
@@ -82,6 +83,7 @@ impl OrbitRuntime {
                 task_type,
                 external_refs: params.external_refs.clone(),
                 source_task_id: params.source_task_id.clone(),
+                crew: params.crew.clone(),
                 comments: comments.clone(),
             })?;
             Ok((

--- a/crates/orbit-core/src/command/task/params.rs
+++ b/crates/orbit-core/src/command/task/params.rs
@@ -26,6 +26,7 @@ pub struct TaskAddParams {
     pub system_created: bool,
     pub external_refs: Vec<ExternalRef>,
     pub source_task_id: Option<String>,
+    pub crew: Option<String>,
 }
 
 impl Default for TaskAddParams {
@@ -48,6 +49,7 @@ impl Default for TaskAddParams {
             system_created: false,
             external_refs: Vec::new(),
             source_task_id: None,
+            crew: None,
         }
     }
 }
@@ -68,6 +70,7 @@ pub struct TaskUpdateParams {
     pub implemented_by: Option<Option<String>>,
     pub pr_status: Option<Option<String>>,
     pub job_run_id: Option<Option<String>>,
+    pub crew: Option<Option<String>>,
     pub context_files: Option<Vec<String>>,
     pub upsert_artifacts: Vec<TaskArtifact>,
     pub append_review_threads: Vec<ReviewThread>,
@@ -92,6 +95,7 @@ impl TaskUpdateParams {
             || self.implemented_by.is_some()
             || self.pr_status.is_some()
             || self.job_run_id.is_some()
+            || self.crew.is_some()
             || self.context_files.is_some()
             || !self.upsert_artifacts.is_empty()
             || !self.append_review_threads.is_empty()
@@ -118,6 +122,7 @@ impl From<TaskUpdateParams> for TaskRecordUpdateParams {
             implemented_by: p.implemented_by,
             pr_status: p.pr_status,
             job_run_id: p.job_run_id,
+            crew: p.crew,
             context_files: p.context_files,
             upsert_artifacts: p.upsert_artifacts,
             append_review_threads: p.append_review_threads,

--- a/crates/orbit-core/src/command/task/transitions.rs
+++ b/crates/orbit-core/src/command/task/transitions.rs
@@ -168,16 +168,31 @@ impl OrbitRuntime {
         let (canonical_agent, canonical_model) =
             self.try_canonical_agent_model_identity(agent.as_deref(), model.as_deref())?;
         let task = self.get_task(id)?;
-        let resolved_crew =
-            self.resolve_crew_for_task(crew_override.as_deref(), task.crew.as_deref())?;
-        tracing::info!(
-            task_id = id,
-            resolved_crew = %resolved_crew.name,
-            planner_model = %resolved_crew.planner.model,
-            implementer_model = %resolved_crew.implementer.model,
-            reviewer_model = %resolved_crew.reviewer.model,
-            "crew resolved for task start",
-        );
+        // Validate status before crew resolution so a misleading
+        // "no crew selected" error can't mask the real problem
+        // (e.g. trying to restart a task that's already in-progress).
+        match task.status {
+            TaskStatus::Proposed
+            | TaskStatus::Friction
+            | TaskStatus::Backlog
+            | TaskStatus::Someday
+            | TaskStatus::Blocked => {}
+            TaskStatus::InProgress => {
+                return Err(OrbitError::InvalidInput(format!(
+                    "task '{id}' is already in-progress"
+                )));
+            }
+            other => {
+                return Err(OrbitError::InvalidInput(format!(
+                    "task '{id}' is in status '{other}'; start requires 'proposed', 'friction', 'backlog', 'someday', or 'blocked'"
+                )));
+            }
+        }
+        self.resolve_and_log_crew_for_task_start(
+            id,
+            crew_override.as_deref(),
+            task.crew.as_deref(),
+        )?;
         let dependency_status_index = build_task_status_index(&self.list_tasks()?);
         let unmet_dependencies = unmet_task_dependencies(&task, &dependency_status_index);
         if in_progress_transition_requires_plan(task.status) {

--- a/crates/orbit-core/src/command/task/transitions.rs
+++ b/crates/orbit-core/src/command/task/transitions.rs
@@ -104,7 +104,7 @@ impl OrbitRuntime {
         note: Option<String>,
         comment: Option<String>,
     ) -> Result<Task, OrbitError> {
-        self.start_task_with_actor_label_override(id, note, comment, None, None, None)
+        self.start_task_with_actor_label_override(id, note, comment, None, None, None, None)
     }
 
     pub fn start_task_with_identity(
@@ -115,7 +115,27 @@ impl OrbitRuntime {
         agent: Option<String>,
         model: Option<String>,
     ) -> Result<Task, OrbitError> {
-        self.start_task_with_actor_label_override(id, note, comment, agent, model, None)
+        self.start_task_with_identity_and_crew(id, note, comment, agent, model, None)
+    }
+
+    pub fn start_task_with_identity_and_crew(
+        &self,
+        id: &str,
+        note: Option<String>,
+        comment: Option<String>,
+        agent: Option<String>,
+        model: Option<String>,
+        crew_override: Option<String>,
+    ) -> Result<Task, OrbitError> {
+        self.start_task_with_actor_label_override(
+            id,
+            note,
+            comment,
+            agent,
+            model,
+            None,
+            crew_override,
+        )
     }
 
     pub(crate) fn start_task_as_system(
@@ -131,6 +151,7 @@ impl OrbitRuntime {
             None,
             None,
             Some(SYSTEM_ACTOR_LABEL.to_string()),
+            None,
         )
     }
 
@@ -142,10 +163,21 @@ impl OrbitRuntime {
         agent: Option<String>,
         model: Option<String>,
         actor_label_override: Option<String>,
+        crew_override: Option<String>,
     ) -> Result<Task, OrbitError> {
         let (canonical_agent, canonical_model) =
             self.try_canonical_agent_model_identity(agent.as_deref(), model.as_deref())?;
         let task = self.get_task(id)?;
+        let resolved_crew =
+            self.resolve_crew_for_task(crew_override.as_deref(), task.crew.as_deref())?;
+        tracing::info!(
+            task_id = id,
+            resolved_crew = %resolved_crew.name,
+            planner_model = %resolved_crew.planner.model,
+            implementer_model = %resolved_crew.implementer.model,
+            reviewer_model = %resolved_crew.reviewer.model,
+            "crew resolved for task start",
+        );
         let dependency_status_index = build_task_status_index(&self.list_tasks()?);
         let unmet_dependencies = unmet_task_dependencies(&task, &dependency_status_index);
         if in_progress_transition_requires_plan(task.status) {

--- a/crates/orbit-core/src/command/task/update.rs
+++ b/crates/orbit-core/src/command/task/update.rs
@@ -95,6 +95,9 @@ impl OrbitRuntime {
         if let Some(tags) = params.tags.take() {
             params.tags = Some(normalize_task_tags(tags));
         }
+        if let Some(crew) = &params.crew {
+            self.validate_crew_name(crew.as_deref())?;
+        }
         if params.has_any_mutation() && task.status == TaskStatus::Archived {
             return Err(OrbitError::InvalidInput(format!(
                 "task {id} is {} and cannot be modified; unarchive or reopen it first",

--- a/crates/orbit-core/src/config/agent_prompt.rs
+++ b/crates/orbit-core/src/config/agent_prompt.rs
@@ -58,8 +58,8 @@ impl Prompter for StdinPrompter {
 /// Read provider/backend/model for each of the `ROLE_PROMPT_ORDER` roles and
 /// return a map keyed by role name suitable for serializing as
 /// `[agent.<role>]` blocks. Returned configs always carry `Some` values for
-/// provider/backend, while model is omitted when the selected provider has no
-/// known default and the user leaves it blank.
+/// provider/backend/model values. Crew-based config requires a concrete model
+/// for every role, so custom providers re-prompt until a model is supplied.
 ///
 /// Detection results seed the per-role defaults so most users can just press
 /// Enter once to accept the recommended setup.
@@ -170,15 +170,16 @@ fn collect_model_override(
     prompter: &mut dyn Prompter,
 ) -> io::Result<Option<String>> {
     let prompt = if model_default.is_empty() {
-        "Model (optional): ".to_string()
+        "Model: ".to_string()
     } else {
         format!("Model [{model_default}]: ")
     };
-    let model_value = take_or_default(prompter.prompt(&prompt)?, model_default);
-    if model_value.is_empty() {
-        Ok(None)
-    } else {
-        Ok(Some(model_value))
+    loop {
+        let model_value = take_or_default(prompter.prompt(&prompt)?, model_default);
+        if !model_value.is_empty() {
+            return Ok(Some(model_value));
+        }
+        prompter.message("Model is required for crew role assignments.")?;
     }
 }
 
@@ -595,14 +596,27 @@ mod tests {
     }
 
     #[test]
-    fn custom_provider_omits_blank_unknown_model() {
+    fn custom_provider_reprompts_for_blank_unknown_model() {
         let detected = DetectedAgents::default();
-        let mut prompter =
-            CannedPrompter::new(["n", "reviewer", "custom", "openai_compat", "http", "", ""]);
+        let mut prompter = CannedPrompter::new([
+            "n",
+            "reviewer",
+            "custom",
+            "openai_compat",
+            "http",
+            "",
+            "my-model",
+            "",
+        ]);
         let result = collect_role_settings(&detected, &mut prompter).unwrap();
         let reviewer = result.get("reviewer").expect("reviewer entry");
         assert_eq!(reviewer.provider.as_deref(), Some("openai_compat"));
         assert_eq!(reviewer.backend.as_deref(), Some("http"));
-        assert_eq!(reviewer.model, None);
+        assert_eq!(reviewer.model.as_deref(), Some("my-model"));
+        assert!(
+            prompter
+                .transcript()
+                .contains("Model is required for crew role assignments.")
+        );
     }
 }

--- a/crates/orbit-core/src/config/bootstrap.rs
+++ b/crates/orbit-core/src/config/bootstrap.rs
@@ -6,7 +6,7 @@ use serde::Serialize;
 
 use orbit_common::utility::fs::write_text_with_parent;
 
-use super::raw::RawAgentRoleConfig;
+use super::raw::{RawAgentRoleConfig, RawCrewEntry};
 
 const DEFAULT_CONFIG_TEMPLATE: &str = include_str!("../../assets/config/default-config.toml");
 
@@ -29,21 +29,55 @@ fn render_with_role_settings(
     template: &str,
     roles: &BTreeMap<String, RawAgentRoleConfig>,
 ) -> Result<String, OrbitError> {
-    #[derive(Serialize)]
-    struct AgentSection<'a> {
-        agent: &'a BTreeMap<String, RawAgentRoleConfig>,
-    }
-    let serialized = toml::to_string(&AgentSection { agent: roles })
-        .map_err(|err| OrbitError::Io(format!("serialize [agent.<role>] sections: {err}")))?;
+    validate_complete_role_settings(roles)?;
 
-    let mut out = String::with_capacity(template.len() + serialized.len() + 2);
-    out.push_str(template);
-    if !template.ends_with('\n') {
-        out.push('\n');
+    #[derive(Serialize)]
+    struct CrewConfig<'a> {
+        crews: BTreeMap<&'a str, RawCrewEntry>,
     }
-    out.push('\n');
-    out.push_str(&serialized);
-    Ok(out)
+
+    let mut crews = BTreeMap::new();
+    crews.insert(
+        "custom",
+        RawCrewEntry {
+            planner: roles.get("planner").cloned(),
+            implementer: roles.get("implementer").cloned(),
+            reviewer: roles.get("reviewer").cloned(),
+        },
+    );
+    let custom_crew = toml::to_string(&CrewConfig { crews })
+        .map_err(|err| OrbitError::Io(format!("serialize [crews.<name>] sections: {err}")))?;
+    let mut body = template.replace("default_crew = \"opus-codex\"", "default_crew = \"custom\"");
+    if !body.ends_with('\n') {
+        body.push('\n');
+    }
+    body.push('\n');
+    body.push_str(&custom_crew);
+    Ok(body)
+}
+
+fn validate_complete_role_settings(
+    roles: &BTreeMap<String, RawAgentRoleConfig>,
+) -> Result<(), OrbitError> {
+    for role in ["planner", "implementer", "reviewer"] {
+        let Some(config) = roles.get(role) else {
+            return Err(OrbitError::InvalidInput(format!(
+                "custom crew is missing required `{role}` role settings"
+            )));
+        };
+        for (field, value) in [
+            ("provider", config.provider.as_deref()),
+            ("backend", config.backend.as_deref()),
+            ("model", config.model.as_deref()),
+        ] {
+            if value.map(str::trim).is_none_or(str::is_empty) {
+                return Err(OrbitError::InvalidInput(format!(
+                    "custom crew role `{role}` is missing required `{field}`"
+                )));
+            }
+        }
+    }
+    Ok(())
 }
 
 #[cfg(test)]
@@ -75,7 +109,7 @@ mod tests {
             RawAgentRoleConfig {
                 provider: Some("claude".into()),
                 backend: Some("http".into()),
-                model: None,
+                model: Some("claude-opus-4-7".into()),
             },
         );
         roles
@@ -89,21 +123,20 @@ mod tests {
         assert!(created);
         let contents = std::fs::read_to_string(&path).expect("read");
         assert_eq!(contents, DEFAULT_CONFIG_TEMPLATE);
-        assert!(no_active_agent_section(&contents));
+        assert!(no_active_role_section(&contents));
+        assert!(contents.contains("[crews.opus-codex]"));
+        assert!(contents.contains("[crews.all-claude]"));
+        assert!(contents.contains("default_crew = \"opus-codex\""));
     }
 
-    /// Returns true when the file has no uncommented `[agent.<role>]`
-    /// section header. The default template ships with a commented-out
-    /// documentation block that includes `# [agent.reviewer]` etc; we want
-    /// to ignore those.
-    fn no_active_agent_section(contents: &str) -> bool {
+    fn no_active_role_section(contents: &str) -> bool {
         contents
             .lines()
             .all(|line| !line.trim_start().starts_with("[agent."))
     }
 
     #[test]
-    fn seed_with_role_settings_appends_agent_blocks() {
+    fn seed_with_role_settings_writes_custom_crew() {
         let dir = tempdir().expect("tempdir");
         let path = dir.path().join("config.toml");
         let roles = sample_roles();
@@ -111,13 +144,8 @@ mod tests {
         assert!(created);
         let contents = std::fs::read_to_string(&path).expect("read");
 
-        // Default template is preserved verbatim at the head of the file.
-        assert!(contents.starts_with(DEFAULT_CONFIG_TEMPLATE));
-
-        // All three role tables are present.
-        assert!(contents.contains("[agent.reviewer]"));
-        assert!(contents.contains("[agent.implementer]"));
-        assert!(contents.contains("[agent.planner]"));
+        assert!(no_active_role_section(&contents));
+        assert!(contents.contains("default_crew = \"custom\""));
         assert!(contents.contains("provider = \"claude\""));
         assert!(contents.contains("provider = \"codex\""));
         assert!(contents.contains("model = \"claude-opus-4-7\""));
@@ -125,14 +153,18 @@ mod tests {
 
         // Round-trips through toml::from_str (consumer side will need this).
         let parsed: toml::Value = toml::from_str(&contents).expect("parse");
-        let agent = parsed
-            .get("agent")
-            .expect("agent table")
+        let crews = parsed
+            .get("crews")
+            .expect("crews table")
             .as_table()
             .unwrap();
-        assert!(agent.contains_key("reviewer"));
-        assert!(agent.contains_key("implementer"));
-        assert!(agent.contains_key("planner"));
+        let custom = crews
+            .get("custom")
+            .and_then(|v| v.as_table())
+            .expect("custom crew");
+        assert!(custom.contains_key("reviewer"));
+        assert!(custom.contains_key("implementer"));
+        assert!(custom.contains_key("planner"));
     }
 
     #[test]
@@ -161,35 +193,17 @@ mod tests {
     }
 
     #[test]
-    fn seed_serialization_omits_none_fields() {
-        // The planner sample omits `model`. Verify it doesn't show up as
-        // `model = ""` or similar in the parsed output.
+    fn seed_with_incomplete_role_settings_fails() {
         let dir = tempdir().expect("tempdir");
         let path = dir.path().join("config.toml");
-        let roles = sample_roles();
-        seed_default_config(&path, Some(&roles)).expect("seed");
-        let contents = std::fs::read_to_string(&path).expect("read");
-
-        // Parsing TOML ignores comments, so the only `[agent.planner]` table
-        // visible in the parsed structure is the one we wrote.
-        let parsed: toml::Value = toml::from_str(&contents).expect("parse");
-        let planner = parsed
-            .get("agent")
-            .and_then(|v| v.as_table())
-            .and_then(|t| t.get("planner"))
-            .and_then(|v| v.as_table())
-            .expect("planner table present");
+        let mut roles = sample_roles();
+        roles.get_mut("planner").expect("planner").model.take();
+        let error = seed_default_config(&path, Some(&roles)).expect_err("missing model fails");
         assert!(
-            planner.get("model").is_none(),
-            "planner.model must be absent when None: {planner:?}"
+            error
+                .to_string()
+                .contains("custom crew role `planner` is missing required `model`")
         );
-        assert_eq!(
-            planner.get("provider").and_then(|v| v.as_str()),
-            Some("claude")
-        );
-        assert_eq!(
-            planner.get("backend").and_then(|v| v.as_str()),
-            Some("http")
-        );
+        assert!(!path.exists());
     }
 }

--- a/crates/orbit-core/src/config/mod.rs
+++ b/crates/orbit-core/src/config/mod.rs
@@ -22,5 +22,5 @@ mod runtime;
 
 pub(crate) use bootstrap::seed_default_config;
 pub(crate) use persistence::PersistenceConfig;
-pub use raw::RawAgentRoleConfig;
+pub use raw::{RawAgentRoleConfig, RawCrewEntry};
 pub(crate) use runtime::{CodexExecutionPolicy, ExecutionEnvPolicy, RuntimeConfig};

--- a/crates/orbit-core/src/config/raw.rs
+++ b/crates/orbit-core/src/config/raw.rs
@@ -14,13 +14,12 @@ pub(super) struct RawRuntimeConfig {
     pub(super) watch: Option<toml::Value>,
     pub(super) runtime: Option<RawRuntimeSection>,
     pub(super) workflow: Option<RawWorkflowConfig>,
-    /// `[agent.<role>]` tables, e.g. `[agent.reviewer]`. Keys are role names
-    /// (`reviewer`, `implementer`, `planner`, or any free-form string the
-    /// resolver chooses to honour). Values supply optional `provider`,
-    /// `model`, and `backend` overrides per role. Written by `orbit init`
-    /// from interactive prompts (T20260428-9) and consumed at v2 dispatch
-    /// time per ADR-029 / T20260428-12.
+    /// Removed in ORB-00058. Kept only so config loading can reject stale
+    /// `[agent.<role>]` tables with an explicit migration error.
     pub(super) agent: Option<BTreeMap<String, RawAgentRoleConfig>>,
+    /// `[crews.<name>]` registry. Each table supplies the three role
+    /// assignments Orbit resolves at task run start.
+    pub(super) crews: Option<BTreeMap<String, RawCrewEntry>>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -30,10 +29,12 @@ pub(super) struct RawWorkflowConfig {
     /// Repos that keep an `agent-main` buffer branch set this to
     /// `"agent-main"`.
     pub(super) base_branch: Option<String>,
+    /// Named crew used when a task does not declare `crew` and no CLI
+    /// override is provided.
+    pub(super) default_crew: Option<String>,
 }
 
-/// Schema for a single `[agent.<role>]` table in `config.toml`. All fields
-/// are optional so partial overrides round-trip cleanly.
+/// Schema for a single role assignment in `[crews.<name>]`.
 ///
 /// Serialize is derived so the writer in `bootstrap` can emit fresh entries
 /// without hand-rolling TOML. The struct is `pub` so the CLI can hand a map
@@ -47,6 +48,16 @@ pub struct RawAgentRoleConfig {
     pub model: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub backend: Option<String>,
+}
+
+#[derive(Debug, Clone, Default, Deserialize, Serialize, PartialEq, Eq)]
+pub struct RawCrewEntry {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub planner: Option<RawAgentRoleConfig>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub implementer: Option<RawAgentRoleConfig>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reviewer: Option<RawAgentRoleConfig>,
 }
 
 #[derive(Debug, Clone, Deserialize)]

--- a/crates/orbit-core/src/config/runtime.rs
+++ b/crates/orbit-core/src/config/runtime.rs
@@ -304,7 +304,22 @@ fn workflow_default_crew_from_raw(
 ) -> Result<Option<String>, OrbitError> {
     let value = raw.and_then(|workflow| workflow.default_crew.as_deref());
     let Some(value) = value else {
-        return Ok(Some("opus-codex".to_string()).filter(|name| crews.contains_key(name)));
+        // No explicit [workflow].default_crew. Fall back to the seeded default
+        // when its crew is still present; otherwise demand the user pick one
+        // explicitly so downstream `start`/`show` calls don't surprise them
+        // with a generic "no crew selected" error.
+        if crews.contains_key("opus-codex") {
+            return Ok(Some("opus-codex".to_string()));
+        }
+        if crews.is_empty() {
+            return Ok(None);
+        }
+        let mut names: Vec<&str> = crews.keys().map(String::as_str).collect();
+        names.sort();
+        return Err(OrbitError::InvalidInput(format!(
+            "[workflow].default_crew must be set when defining [crews.*]; choose one of: {}",
+            names.join(", ")
+        )));
     };
     let trimmed = value.trim();
     if trimmed.is_empty() {
@@ -808,6 +823,50 @@ default_crew = "missing"
 
         assert!(matches!(error, OrbitError::InvalidInputDiagnostic { .. }));
         assert_eq!(error.did_you_mean(), Some(&["opus-codex".to_string()][..]));
+    }
+
+    #[test]
+    fn default_crew_unset_with_custom_crews_fails_load() {
+        let global = tempdir().expect("global tempdir");
+        let workspace = tempdir().expect("workspace tempdir");
+        // Only a non-"opus-codex" crew defined; no [workflow] table at all.
+        write_config(
+            workspace.path(),
+            r#"
+[crews.my-team]
+planner = { model = "claude-opus-4-7", provider = "claude", backend = "cli" }
+implementer = { model = "gpt-5.5", provider = "codex", backend = "cli" }
+reviewer = { model = "gpt-5.5", provider = "codex", backend = "cli" }
+"#,
+        );
+
+        let error = RuntimeConfig::load_layered(global.path(), workspace.path())
+            .expect_err("missing default_crew with non-seeded crews must fail");
+
+        let message = error.to_string();
+        assert!(matches!(error, OrbitError::InvalidInput(_)), "{message}");
+        assert!(message.contains("[workflow].default_crew"), "{message}");
+        assert!(message.contains("my-team"), "{message}");
+    }
+
+    #[test]
+    fn default_crew_unset_with_seeded_crew_still_loads() {
+        let global = tempdir().expect("global tempdir");
+        let workspace = tempdir().expect("workspace tempdir");
+        // opus-codex is still present, so the historical fallback applies.
+        write_config(
+            workspace.path(),
+            r#"
+[crews.opus-codex]
+planner = { model = "claude-opus-4-7", provider = "claude", backend = "cli" }
+implementer = { model = "gpt-5.5", provider = "codex", backend = "cli" }
+reviewer = { model = "gpt-5.5", provider = "codex", backend = "cli" }
+"#,
+        );
+
+        let config =
+            RuntimeConfig::load_layered(global.path(), workspace.path()).expect("config loads");
+        assert_eq!(config.default_crew.as_deref(), Some("opus-codex"));
     }
 
     #[test]

--- a/crates/orbit-core/src/config/runtime.rs
+++ b/crates/orbit-core/src/config/runtime.rs
@@ -2,7 +2,9 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::fs;
 use std::path::Path;
 
-use orbit_common::types::{OrbitError, activity_job::Backend};
+use orbit_common::types::{
+    Crew, CrewRoleAssignment, OrbitError, activity_job::Backend, resolve_crew,
+};
 use orbit_common::utility::redaction::redact_home_dir;
 use orbit_engine::PrConfig;
 
@@ -10,7 +12,7 @@ use crate::paths;
 
 use super::persistence::PersistenceConfig;
 use super::raw::{
-    RawAgentRoleConfig, RawCodexExecutionConfig, RawExecutionEnvConfig, RawPrSection,
+    RawAgentRoleConfig, RawCodexExecutionConfig, RawCrewEntry, RawExecutionEnvConfig, RawPrSection,
     RawRuntimeConfig, RawRuntimeSection, RawTaskSection, RawWorkflowConfig,
 };
 
@@ -40,10 +42,9 @@ pub(crate) struct RuntimeConfig {
     /// from `[workflow] base_branch` in `config.toml`; defaults to `"main"`
     /// when no key is set.
     pub(crate) workflow_base_branch: String,
-    /// `[agent.<role>]` role-keyed overrides written by `orbit init` per
-    /// ADR-027 and consumed at v2 dispatch time per ADR-029. Empty when no
-    /// `[agent.*]` block is present.
-    pub(crate) agent_roles: BTreeMap<String, RawAgentRoleConfig>,
+    /// Named planner/implementer/reviewer lineups from `[crews.<name>]`.
+    pub(crate) crews: BTreeMap<String, Crew>,
+    pub(crate) default_crew: Option<String>,
 }
 
 impl Default for RuntimeConfig {
@@ -64,7 +65,8 @@ impl RuntimeConfig {
             graph_editing: DEFAULT_GRAPH_EDITING,
             v2_backend: None,
             workflow_base_branch: DEFAULT_WORKFLOW_BASE_BRANCH.to_string(),
-            agent_roles: BTreeMap::new(),
+            crews: default_crews(),
+            default_crew: Some("opus-codex".to_string()),
         }
     }
 
@@ -136,7 +138,11 @@ impl RuntimeConfig {
         validate_task_artifact_store_from_raw(parsed.task.as_ref())?;
         let v2_backend = runtime_backend_from_raw(parsed.runtime.as_ref())?;
 
+        reject_stale_agent_role_tables(parsed.agent.as_ref())?;
+
         let workflow_base_branch = workflow_base_branch_from_raw(parsed.workflow.as_ref())?;
+        let crews = crews_from_raw(parsed.crews.as_ref())?;
+        let default_crew = workflow_default_crew_from_raw(parsed.workflow.as_ref(), &crews)?;
         let pr = pr_config_from_raw(parsed.pr.as_ref());
 
         if parsed
@@ -147,8 +153,6 @@ impl RuntimeConfig {
         {
             warn_deprecated_task_id_pattern(&config_path);
         }
-
-        let agent_roles = parsed.agent.clone().unwrap_or_default();
 
         Ok(Self {
             execution_env: ExecutionEnvPolicy::from_raw(
@@ -164,7 +168,8 @@ impl RuntimeConfig {
             graph_editing,
             v2_backend,
             workflow_base_branch,
-            agent_roles,
+            crews,
+            default_crew,
         })
     }
 
@@ -182,10 +187,133 @@ impl RuntimeConfig {
     }
 }
 
+pub(crate) fn default_crews() -> BTreeMap<String, Crew> {
+    let mut crews = BTreeMap::new();
+    crews.insert(
+        "opus-codex".to_string(),
+        Crew {
+            name: "opus-codex".to_string(),
+            planner: crew_role("claude-opus-4-7", "claude", "cli"),
+            implementer: crew_role("gpt-5.5", "codex", "cli"),
+            reviewer: crew_role("gpt-5.5", "codex", "cli"),
+        },
+    );
+    crews.insert(
+        "all-claude".to_string(),
+        Crew {
+            name: "all-claude".to_string(),
+            planner: crew_role("claude-opus-4-7", "claude", "cli"),
+            implementer: crew_role("claude-sonnet-4-6", "claude", "cli"),
+            reviewer: crew_role("claude-opus-4-7", "claude", "cli"),
+        },
+    );
+    crews
+}
+
+fn crew_role(model: &str, provider: &str, backend: &str) -> CrewRoleAssignment {
+    CrewRoleAssignment {
+        model: model.to_string(),
+        provider: provider.to_string(),
+        backend: backend.to_string(),
+    }
+}
+
 fn pr_config_from_raw(raw: Option<&RawPrSection>) -> PrConfig {
     PrConfig {
         task_url_template: raw.and_then(|section| section.task_url_template.clone()),
     }
+}
+
+fn reject_stale_agent_role_tables(
+    raw: Option<&BTreeMap<String, RawAgentRoleConfig>>,
+) -> Result<(), OrbitError> {
+    if raw.is_some() {
+        return Err(OrbitError::InvalidInput(
+            "config schema changed in ORB-00058; remove [agent.<role>] tables and migrate to [crews.<name>] with [workflow].default_crew".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+fn crews_from_raw(
+    raw: Option<&BTreeMap<String, RawCrewEntry>>,
+) -> Result<BTreeMap<String, Crew>, OrbitError> {
+    let Some(raw_crews) = raw else {
+        return Ok(default_crews());
+    };
+    let mut crews = BTreeMap::new();
+    for (name, entry) in raw_crews {
+        let trimmed = name.trim();
+        if trimmed.is_empty() {
+            return Err(OrbitError::InvalidInput(
+                "[crews] names must not be empty".to_string(),
+            ));
+        }
+        let crew = Crew {
+            name: trimmed.to_string(),
+            planner: required_role_assignment(trimmed, "planner", entry.planner.as_ref())?,
+            implementer: required_role_assignment(
+                trimmed,
+                "implementer",
+                entry.implementer.as_ref(),
+            )?,
+            reviewer: required_role_assignment(trimmed, "reviewer", entry.reviewer.as_ref())?,
+        };
+        crews.insert(trimmed.to_string(), crew);
+    }
+    if crews.is_empty() {
+        return Err(OrbitError::InvalidInput(
+            "[crews] must define at least one crew".to_string(),
+        ));
+    }
+    Ok(crews)
+}
+
+fn required_role_assignment(
+    crew: &str,
+    role: &str,
+    raw: Option<&RawAgentRoleConfig>,
+) -> Result<CrewRoleAssignment, OrbitError> {
+    let raw = raw.ok_or_else(|| {
+        OrbitError::InvalidInput(format!(
+            "[crews.{crew}] must define {role} = {{ model, provider, backend }}"
+        ))
+    })?;
+    Ok(CrewRoleAssignment {
+        model: required_role_field(crew, role, "model", raw.model.as_deref())?,
+        provider: required_role_field(crew, role, "provider", raw.provider.as_deref())?,
+        backend: required_role_field(crew, role, "backend", raw.backend.as_deref())?,
+    })
+}
+
+fn required_role_field(
+    crew: &str,
+    role: &str,
+    field: &str,
+    value: Option<&str>,
+) -> Result<String, OrbitError> {
+    let value = value.map(str::trim).filter(|value| !value.is_empty());
+    value.map(ToOwned::to_owned).ok_or_else(|| {
+        OrbitError::InvalidInput(format!("[crews.{crew}].{role}.{field} must not be empty"))
+    })
+}
+
+fn workflow_default_crew_from_raw(
+    raw: Option<&RawWorkflowConfig>,
+    crews: &BTreeMap<String, Crew>,
+) -> Result<Option<String>, OrbitError> {
+    let value = raw.and_then(|workflow| workflow.default_crew.as_deref());
+    let Some(value) = value else {
+        return Ok(Some("opus-codex".to_string()).filter(|name| crews.contains_key(name)));
+    };
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        return Err(OrbitError::InvalidInput(
+            "workflow.default_crew must not be empty".to_string(),
+        ));
+    }
+    resolve_crew(trimmed, crews)?;
+    Ok(Some(trimmed.to_string()))
 }
 
 fn runtime_backend_from_raw(raw: Option<&RawRuntimeSection>) -> Result<Option<String>, OrbitError> {
@@ -624,6 +752,83 @@ mod tests {
         assert!(message.contains("[runtime] backend"));
         assert!(message.contains("clii"));
         assert!(message.contains("http, cli, auto"));
+    }
+
+    #[test]
+    fn crews_load_when_present_and_well_formed() {
+        let global = tempdir().expect("global tempdir");
+        let workspace = tempdir().expect("workspace tempdir");
+        write_config(
+            workspace.path(),
+            r#"
+[crews.opus-codex]
+planner = { model = "claude-opus-4-7", provider = "claude", backend = "cli" }
+implementer = { model = "gpt-5.5", provider = "codex", backend = "cli" }
+reviewer = { model = "gpt-5.5", provider = "codex", backend = "cli" }
+
+[workflow]
+default_crew = "opus-codex"
+"#,
+        );
+
+        let config =
+            RuntimeConfig::load_layered(global.path(), workspace.path()).expect("config loads");
+
+        assert_eq!(config.default_crew.as_deref(), Some("opus-codex"));
+        assert_eq!(
+            config
+                .crews
+                .get("opus-codex")
+                .expect("crew exists")
+                .implementer
+                .model,
+            "gpt-5.5"
+        );
+    }
+
+    #[test]
+    fn default_crew_must_reference_defined_crew() {
+        let global = tempdir().expect("global tempdir");
+        let workspace = tempdir().expect("workspace tempdir");
+        write_config(
+            workspace.path(),
+            r#"
+[crews.opus-codex]
+planner = { model = "claude-opus-4-7", provider = "claude", backend = "cli" }
+implementer = { model = "gpt-5.5", provider = "codex", backend = "cli" }
+reviewer = { model = "gpt-5.5", provider = "codex", backend = "cli" }
+
+[workflow]
+default_crew = "missing"
+"#,
+        );
+
+        let error = RuntimeConfig::load_layered(global.path(), workspace.path())
+            .expect_err("unknown default crew fails");
+
+        assert!(matches!(error, OrbitError::InvalidInputDiagnostic { .. }));
+        assert_eq!(error.did_you_mean(), Some(&["opus-codex".to_string()][..]));
+    }
+
+    #[test]
+    fn crews_with_incomplete_role_fail_load() {
+        let global = tempdir().expect("global tempdir");
+        let workspace = tempdir().expect("workspace tempdir");
+        write_config(
+            workspace.path(),
+            r#"
+[crews.opus-codex]
+planner = { model = "claude-opus-4-7", provider = "claude", backend = "cli" }
+implementer = { model = "gpt-5.5", provider = "codex", backend = "cli" }
+"#,
+        );
+
+        let error = RuntimeConfig::load_layered(global.path(), workspace.path())
+            .expect_err("incomplete crew fails");
+
+        assert!(matches!(error, OrbitError::InvalidInput(_)));
+        assert!(error.to_string().contains("[crews.opus-codex]"));
+        assert!(error.to_string().contains("reviewer"));
     }
 
     #[test]

--- a/crates/orbit-core/src/context.rs
+++ b/crates/orbit-core/src/context.rs
@@ -1,7 +1,7 @@
 use std::path::Path;
 use std::sync::Arc;
 
-use orbit_common::types::WorkspacePaths;
+use orbit_common::types::{Crew, WorkspacePaths};
 use orbit_embed::{EmbedWorker, VectorStore};
 use orbit_engine::PrConfig;
 use orbit_policy::PolicyEngine;
@@ -180,9 +180,8 @@ pub(crate) struct OrbitRuntimeSettings {
     /// Default base branch for ship/ship-auto/duel-plan workflows
     /// (`[workflow] base_branch` in `config.toml`, default `"main"`).
     workflow_base_branch: String,
-    /// `[agent.<role>]` overrides written by `orbit init` (ADR-027) and
-    /// consumed at v2 dispatch time (ADR-029).
-    agent_roles: std::collections::BTreeMap<String, crate::config::RawAgentRoleConfig>,
+    crews: std::collections::BTreeMap<String, Crew>,
+    default_crew: Option<String>,
 }
 
 impl OrbitRuntimeSettings {
@@ -197,7 +196,8 @@ impl OrbitRuntimeSettings {
         pr_config: PrConfig,
         v2_backend: Option<String>,
         workflow_base_branch: String,
-        agent_roles: std::collections::BTreeMap<String, crate::config::RawAgentRoleConfig>,
+        crews: std::collections::BTreeMap<String, Crew>,
+        default_crew: Option<String>,
     ) -> Self {
         Self {
             persistence,
@@ -209,7 +209,8 @@ impl OrbitRuntimeSettings {
             pr_config,
             v2_backend,
             workflow_base_branch,
-            agent_roles,
+            crews,
+            default_crew,
         }
     }
 
@@ -225,8 +226,12 @@ impl OrbitRuntimeSettings {
         &self.workflow_base_branch
     }
 
-    pub(crate) fn agent_role(&self, role: &str) -> Option<&crate::config::RawAgentRoleConfig> {
-        self.agent_roles.get(role)
+    pub(crate) fn crews(&self) -> &std::collections::BTreeMap<String, Crew> {
+        &self.crews
+    }
+
+    pub(crate) fn default_crew(&self) -> Option<&str> {
+        self.default_crew.as_deref()
     }
 }
 
@@ -333,11 +338,12 @@ impl OrbitContext {
         self.runtime.workflow_base_branch()
     }
 
-    /// `[agent.<role>]` lookup written by `orbit init` and consumed at v2
-    /// dispatch time (ADR-029). `None` means no `[agent.<role>]` block was
-    /// present for this role name.
-    pub(crate) fn agent_role(&self, role: &str) -> Option<&crate::config::RawAgentRoleConfig> {
-        self.runtime.agent_role(role)
+    pub(crate) fn crews(&self) -> &std::collections::BTreeMap<String, Crew> {
+        self.runtime.crews()
+    }
+
+    pub(crate) fn default_crew(&self) -> Option<&str> {
+        self.runtime.default_crew()
     }
 }
 

--- a/crates/orbit-core/src/lib.rs
+++ b/crates/orbit-core/src/lib.rs
@@ -75,3 +75,4 @@ pub use orbit_store::{
     LearningCreateParams, LearningSearchParams, LearningSearchResult, LearningUpdateParams,
 };
 pub use runtime::OrbitRuntime;
+pub use runtime::engine::ResolvedCrewProjection;

--- a/crates/orbit-core/src/runtime/builder.rs
+++ b/crates/orbit-core/src/runtime/builder.rs
@@ -107,7 +107,8 @@ pub(crate) fn build_context_from_roots(
     let pr_config = runtime_config.pr_config().clone();
     let v2_backend = runtime_config.v2_backend().map(ToString::to_string);
     let workflow_base_branch = runtime_config.workflow_base_branch().to_string();
-    let agent_roles = runtime_config.agent_roles.clone();
+    let crews = runtime_config.crews.clone();
+    let default_crew = runtime_config.default_crew.clone();
 
     Ok(OrbitContext::new(
         paths,
@@ -144,7 +145,8 @@ pub(crate) fn build_context_from_roots(
             pr_config,
             v2_backend,
             workflow_base_branch,
-            agent_roles,
+            crews,
+            default_crew,
         ),
     ))
 }

--- a/crates/orbit-core/src/runtime/engine/crew.rs
+++ b/crates/orbit-core/src/runtime/engine/crew.rs
@@ -3,6 +3,30 @@ use serde_json::Value;
 
 use crate::OrbitRuntime;
 
+/// Crew/role-model strings to surface on a task projection.
+///
+/// Decouples projection consumers from the full `Crew` type so this struct can
+/// also be hydrated directly from persisted run-record fields, which carry only
+/// the model strings (not provider/backend).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ResolvedCrewProjection {
+    pub name: String,
+    pub planner_model: String,
+    pub implementer_model: String,
+    pub reviewer_model: String,
+}
+
+impl ResolvedCrewProjection {
+    fn from_crew(crew: Crew) -> Self {
+        Self {
+            name: crew.name,
+            planner_model: crew.planner.model,
+            implementer_model: crew.implementer.model,
+            reviewer_model: crew.reviewer.model,
+        }
+    }
+}
+
 impl OrbitRuntime {
     pub fn validate_crew_name(&self, crew: Option<&str>) -> Result<(), OrbitError> {
         let Some(crew) = crew.map(str::trim).filter(|value| !value.is_empty()) else {
@@ -43,8 +67,50 @@ impl OrbitRuntime {
         self.resolve_crew_for_task(cli_override, task_crew.as_deref())
     }
 
-    pub fn resolved_crew_for_task_projection(&self, task: &Task) -> Result<Crew, OrbitError> {
+    /// Resolve a crew/role-model projection for `orbit.task.show` consumers.
+    ///
+    /// Audit-trail truth comes first: when the task points at a run record that
+    /// persisted the resolved crew, those four strings win — they reflect what
+    /// actually ran, even if the workspace registry has been edited since.
+    ///
+    /// Best-effort otherwise: if neither the task nor the workspace can name a
+    /// crew, `Ok(None)` so readers (CLI, MCP) can omit the fields instead of
+    /// failing the entire task readout. Genuine misconfigurations (stale crew
+    /// name in `task.crew` or `default_crew`) still surface as `Err`.
+    pub fn resolved_crew_projection(
+        &self,
+        task: &Task,
+    ) -> Result<Option<ResolvedCrewProjection>, OrbitError> {
+        if let Some(run_id) = task.job_run_id.as_deref()
+            && let Some(run) = self.get_job_run_backend(run_id)?
+            && let (
+                Some(resolved_crew),
+                Some(planner_model),
+                Some(implementer_model),
+                Some(reviewer_model),
+            ) = (
+                run.resolved_crew,
+                run.planner_model,
+                run.implementer_model,
+                run.reviewer_model,
+            )
+        {
+            return Ok(Some(ResolvedCrewProjection {
+                name: resolved_crew,
+                planner_model,
+                implementer_model,
+                reviewer_model,
+            }));
+        }
+
+        let has_resolvable_name = task.crew.is_some() || self.context.default_crew().is_some();
+        if !has_resolvable_name {
+            return Ok(None);
+        }
+
         self.resolve_crew_for_task(None, task.crew.as_deref())
+            .map(ResolvedCrewProjection::from_crew)
+            .map(Some)
     }
 
     pub(crate) fn record_run_crew_from_input(
@@ -62,6 +128,24 @@ impl OrbitRuntime {
             "crew resolved for run",
         );
         self.stores().jobs().record_run_crew(run_id, &crew)?;
+        Ok(crew)
+    }
+
+    pub(crate) fn resolve_and_log_crew_for_task_start(
+        &self,
+        task_id: &str,
+        crew_override: Option<&str>,
+        task_crew: Option<&str>,
+    ) -> Result<Crew, OrbitError> {
+        let crew = self.resolve_crew_for_task(crew_override, task_crew)?;
+        tracing::info!(
+            task_id,
+            resolved_crew = %crew.name,
+            planner_model = %crew.planner.model,
+            implementer_model = %crew.implementer.model,
+            reviewer_model = %crew.reviewer.model,
+            "crew resolved for task start",
+        );
         Ok(crew)
     }
 

--- a/crates/orbit-core/src/runtime/engine/crew.rs
+++ b/crates/orbit-core/src/runtime/engine/crew.rs
@@ -1,0 +1,81 @@
+use orbit_common::types::{Crew, OrbitError, Task, resolve_crew};
+use serde_json::Value;
+
+use crate::OrbitRuntime;
+
+impl OrbitRuntime {
+    pub fn validate_crew_name(&self, crew: Option<&str>) -> Result<(), OrbitError> {
+        let Some(crew) = crew.map(str::trim).filter(|value| !value.is_empty()) else {
+            return Ok(());
+        };
+        resolve_crew(crew, self.context.crews()).map(|_| ())
+    }
+
+    pub fn resolve_crew_for_task(
+        &self,
+        cli_override: Option<&str>,
+        task_crew: Option<&str>,
+    ) -> Result<Crew, OrbitError> {
+        let selected = cli_override
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .or_else(|| task_crew.map(str::trim).filter(|value| !value.is_empty()))
+            .or_else(|| self.context.default_crew());
+        let Some(selected) = selected else {
+            return Err(OrbitError::InvalidInput(
+                "no crew selected; set [workflow].default_crew, task.crew, or pass crew"
+                    .to_string(),
+            ));
+        };
+        resolve_crew(selected, self.context.crews())
+    }
+
+    pub(crate) fn resolve_crew_for_run_input(&self, input: &Value) -> Result<Crew, OrbitError> {
+        let cli_override = input
+            .get("crew")
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|value| !value.is_empty());
+        let task_crew = self
+            .task_id_from_run_input(input)?
+            .map(|task| task.crew)
+            .unwrap_or_default();
+        self.resolve_crew_for_task(cli_override, task_crew.as_deref())
+    }
+
+    pub fn resolved_crew_for_task_projection(&self, task: &Task) -> Result<Crew, OrbitError> {
+        self.resolve_crew_for_task(None, task.crew.as_deref())
+    }
+
+    pub(crate) fn record_run_crew_from_input(
+        &self,
+        run_id: &str,
+        input: &Value,
+    ) -> Result<Crew, OrbitError> {
+        let crew = self.resolve_crew_for_run_input(input)?;
+        tracing::info!(
+            run_id,
+            resolved_crew = %crew.name,
+            planner_model = %crew.planner.model,
+            implementer_model = %crew.implementer.model,
+            reviewer_model = %crew.reviewer.model,
+            "crew resolved for run",
+        );
+        self.stores().jobs().record_run_crew(run_id, &crew)?;
+        Ok(crew)
+    }
+
+    fn task_id_from_run_input(&self, input: &Value) -> Result<Option<Task>, OrbitError> {
+        for key in ["task_id", "taskId", "id"] {
+            let Some(task_id) = input.get(key).and_then(Value::as_str) else {
+                continue;
+            };
+            let task_id = task_id.trim();
+            if !task_id.starts_with("ORB-") {
+                continue;
+            }
+            return self.get_task(task_id).map(Some);
+        }
+        Ok(None)
+    }
+}

--- a/crates/orbit-core/src/runtime/engine/environment_host.rs
+++ b/crates/orbit-core/src/runtime/engine/environment_host.rs
@@ -1,10 +1,9 @@
-use orbit_common::types::OrbitError;
 use orbit_common::types::activity_job::{AgentRole, Backend, Provider};
+use orbit_common::types::{CrewRoleAssignment, OrbitError};
 use orbit_engine::{AgentRoleConfig, EnvironmentHost, ExecutorLookupHost};
 
 use super::paths::codex_workspace_write_writable_dirs;
 use crate::OrbitRuntime;
-use crate::config::RawAgentRoleConfig;
 
 impl EnvironmentHost for OrbitRuntime {
     fn agent_provider_config(&self) -> std::collections::HashMap<String, String> {
@@ -54,49 +53,52 @@ impl EnvironmentHost for OrbitRuntime {
     }
 
     fn agent_role_config(&self, role: AgentRole) -> Option<AgentRoleConfig> {
-        let raw = self.context.agent_role(role.as_str())?;
-        Some(typed_role_config_from_raw(role, raw))
+        let crew = self
+            .context
+            .default_crew()
+            .and_then(|name| self.context.crews().get(name))?;
+        let raw = crew.role(role.as_str())?;
+        Some(typed_role_config_from_assignment(role, raw))
     }
 }
 
-/// Convert the on-disk `[agent.<role>]` block (string fields) into the typed
+/// Convert a crew role assignment (string fields) into the typed
 /// [`AgentRoleConfig`] surface used by the engine resolver. Unrecognized
 /// `provider` / `backend` values yield `None` for that field with a warn-log
 /// — silently coercing dispatch onto a different runtime would defeat the
 /// point of the override.
-fn typed_role_config_from_raw(role: AgentRole, raw: &RawAgentRoleConfig) -> AgentRoleConfig {
-    let provider = raw.provider.as_deref().and_then(|raw_value| {
+pub(crate) fn typed_role_config_from_assignment(
+    role: AgentRole,
+    raw: &CrewRoleAssignment,
+) -> AgentRoleConfig {
+    let provider = Some(raw.provider.as_str()).and_then(|raw_value| {
         let parsed = parse_provider(raw_value);
         if parsed.is_none() {
             tracing::warn!(
-                target: "orbit.config.agent_role",
+                target: "orbit.config.crew",
                 role = role.as_str(),
                 raw = raw_value,
-                "[agent.<role>].provider has an unrecognized value; falling back to inline activity provider",
+                "[crews.<name>].provider has an unrecognized value; falling back to inline activity provider",
             );
         }
         parsed
     });
 
-    let backend = raw.backend.as_deref().and_then(|raw_value| {
+    let backend = Some(raw.backend.as_str()).and_then(|raw_value| {
         let parsed = Backend::parse(raw_value);
         if parsed.is_none() {
             tracing::warn!(
-                target: "orbit.config.agent_role",
+                target: "orbit.config.crew",
                 role = role.as_str(),
                 raw = raw_value,
-                "[agent.<role>].backend has an unrecognized value; falling back to inline activity backend",
+                "[crews.<name>].backend has an unrecognized value; falling back to inline activity backend",
             );
         }
         parsed
     });
 
-    let model = raw
-        .model
-        .as_deref()
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
-        .map(ToOwned::to_owned);
+    let model = raw.model.trim();
+    let model = (!model.is_empty()).then(|| model.to_string());
 
     AgentRoleConfig {
         provider,

--- a/crates/orbit-core/src/runtime/engine/mod.rs
+++ b/crates/orbit-core/src/runtime/engine/mod.rs
@@ -9,3 +9,5 @@ mod paths;
 mod runtime_host;
 mod summary;
 mod task_host;
+
+pub use crew::ResolvedCrewProjection;

--- a/crates/orbit-core/src/runtime/engine/mod.rs
+++ b/crates/orbit-core/src/runtime/engine/mod.rs
@@ -1,6 +1,7 @@
 mod agent_protocol_host;
+mod crew;
 mod envelope;
-mod environment_host;
+pub(crate) mod environment_host;
 mod identity;
 mod invocation;
 mod job_run_host;

--- a/crates/orbit-core/src/runtime/mod.rs
+++ b/crates/orbit-core/src/runtime/mod.rs
@@ -13,7 +13,7 @@
 
 pub mod audit;
 pub mod builder;
-mod engine;
+pub mod engine;
 pub mod event_bus;
 pub mod mutation;
 pub(crate) mod orbit_tool_host;

--- a/crates/orbit-core/src/runtime/orbit_tool_host/json.rs
+++ b/crates/orbit-core/src/runtime/orbit_tool_host/json.rs
@@ -128,43 +128,21 @@ fn insert_resolved_crew(
     task: &Task,
     object: &mut Map<String, Value>,
 ) -> Result<(), OrbitError> {
-    if let Some(run_id) = task.job_run_id.as_deref()
-        && let Some(run) = runtime.get_job_run_backend(run_id)?
-        && let (
-            Some(resolved_crew),
-            Some(planner_model),
-            Some(implementer_model),
-            Some(reviewer_model),
-        ) = (
-            run.resolved_crew,
-            run.planner_model,
-            run.implementer_model,
-            run.reviewer_model,
-        )
-    {
-        object.insert("resolved_crew".to_string(), Value::String(resolved_crew));
-        object.insert("planner_model".to_string(), Value::String(planner_model));
-        object.insert(
-            "implementer_model".to_string(),
-            Value::String(implementer_model),
-        );
-        object.insert("reviewer_model".to_string(), Value::String(reviewer_model));
+    let Some(projection) = runtime.resolved_crew_projection(task)? else {
         return Ok(());
-    }
-
-    let crew = runtime.resolved_crew_for_task_projection(task)?;
-    object.insert("resolved_crew".to_string(), Value::String(crew.name));
+    };
+    object.insert("resolved_crew".to_string(), Value::String(projection.name));
     object.insert(
         "planner_model".to_string(),
-        Value::String(crew.planner.model),
+        Value::String(projection.planner_model),
     );
     object.insert(
         "implementer_model".to_string(),
-        Value::String(crew.implementer.model),
+        Value::String(projection.implementer_model),
     );
     object.insert(
         "reviewer_model".to_string(),
-        Value::String(crew.reviewer.model),
+        Value::String(projection.reviewer_model),
     );
     Ok(())
 }

--- a/crates/orbit-core/src/runtime/orbit_tool_host/json.rs
+++ b/crates/orbit-core/src/runtime/orbit_tool_host/json.rs
@@ -82,6 +82,7 @@ pub(super) fn task_to_json(task: &Task, status_by_id: &BTreeMap<String, TaskStat
         "relations": task.relations,
         "source_task_id": task.source_task_id(),
         "job_run_id": task.job_run_id,
+        "crew": task.crew,
         "created_at": task.created_at.to_rfc3339(),
         "updated_at": task.updated_at.to_rfc3339(),
     })
@@ -107,6 +108,7 @@ pub(super) fn serialize_task(runtime: &OrbitRuntime, task: &Task) -> Result<Valu
         serde_json::to_value(runtime.get_task_review_threads(&task.id)?)
             .map_err(serialize_error("serialize review threads"))?,
     );
+    insert_resolved_crew(runtime, task, object)?;
     Ok(value)
 }
 
@@ -116,8 +118,55 @@ pub(super) fn task_lock_to_json(task: &Task) -> Value {
         "title": task.title,
         "status": task.status.to_string(),
         "job_run_id": task.job_run_id,
+        "crew": task.crew,
         "context_files": task.context_files,
     })
+}
+
+fn insert_resolved_crew(
+    runtime: &OrbitRuntime,
+    task: &Task,
+    object: &mut Map<String, Value>,
+) -> Result<(), OrbitError> {
+    if let Some(run_id) = task.job_run_id.as_deref()
+        && let Some(run) = runtime.get_job_run_backend(run_id)?
+        && let (
+            Some(resolved_crew),
+            Some(planner_model),
+            Some(implementer_model),
+            Some(reviewer_model),
+        ) = (
+            run.resolved_crew,
+            run.planner_model,
+            run.implementer_model,
+            run.reviewer_model,
+        )
+    {
+        object.insert("resolved_crew".to_string(), Value::String(resolved_crew));
+        object.insert("planner_model".to_string(), Value::String(planner_model));
+        object.insert(
+            "implementer_model".to_string(),
+            Value::String(implementer_model),
+        );
+        object.insert("reviewer_model".to_string(), Value::String(reviewer_model));
+        return Ok(());
+    }
+
+    let crew = runtime.resolved_crew_for_task_projection(task)?;
+    object.insert("resolved_crew".to_string(), Value::String(crew.name));
+    object.insert(
+        "planner_model".to_string(),
+        Value::String(crew.planner.model),
+    );
+    object.insert(
+        "implementer_model".to_string(),
+        Value::String(crew.implementer.model),
+    );
+    object.insert(
+        "reviewer_model".to_string(),
+        Value::String(crew.reviewer.model),
+    );
+    Ok(())
 }
 
 pub(super) fn serialize_task_lint_report(report: &TaskLintReport) -> Result<Value, OrbitError> {

--- a/crates/orbit-core/src/runtime/orbit_tool_host/task_tools.rs
+++ b/crates/orbit-core/src/runtime/orbit_tool_host/task_tools.rs
@@ -78,6 +78,7 @@ pub(super) fn add(
                 &input,
                 &["source_task_id", "source_task", "sourceTaskId"],
             )?,
+            crew: optional_string(&input, "crew")?,
         },
         agent,
         model,
@@ -197,12 +198,13 @@ pub(super) fn start(
     model: Option<String>,
 ) -> Result<Value, OrbitError> {
     let id = required_string(&input, &["id"], "id")?;
-    let task = runtime.start_task_with_identity(
+    let task = runtime.start_task_with_identity_and_crew(
         &id,
         optional_string(&input, "note")?,
         optional_string(&input, "comment")?,
         agent,
         model,
+        optional_string(&input, "crew")?,
     )?;
     serialize_task(runtime, &task)
 }
@@ -257,6 +259,7 @@ pub(super) fn update(
                 .map(empty_string_to_none),
             pr_status: optional_raw_string(&input, "pr_status")?.map(empty_string_to_none),
             job_run_id: optional_raw_string(&input, "job_run_id")?.map(empty_string_to_none),
+            crew: optional_raw_string(&input, "crew")?.map(empty_string_to_none),
             context_files: optional_csv_or_string_list_alias(
                 &input,
                 &["context_files", "context"],

--- a/crates/orbit-core/src/runtime/orbit_tool_host/test_support.rs
+++ b/crates/orbit-core/src/runtime/orbit_tool_host/test_support.rs
@@ -55,6 +55,7 @@ pub(super) fn create_task(
             task_type: TaskType::Chore,
             external_refs: Vec::new(),
             source_task_id: None,
+            crew: None,
             comments: Vec::new(),
         })
         .expect("create task")

--- a/crates/orbit-core/src/runtime/pipeline.rs
+++ b/crates/orbit-core/src/runtime/pipeline.rs
@@ -266,6 +266,7 @@ mod tests {
                 task_type: TaskType::Chore,
                 external_refs: Vec::new(),
                 source_task_id: None,
+                crew: None,
                 comments: Vec::new(),
             })
             .expect("create task");

--- a/crates/orbit-core/src/runtime/store_delegates.rs
+++ b/crates/orbit-core/src/runtime/store_delegates.rs
@@ -44,6 +44,7 @@ pub(crate) struct TaskRecordUpdateParams {
     pub(crate) pr_status: Option<Option<String>>,
     pub(crate) source_task_id: Option<Option<String>>,
     pub(crate) job_run_id: Option<Option<String>>,
+    pub(crate) crew: Option<Option<String>>,
     pub(crate) status_event: Option<String>,
     pub(crate) status_note: Option<String>,
     pub(crate) append_history: Vec<TaskHistoryEntry>,
@@ -73,6 +74,7 @@ impl TaskRecordUpdateParams {
             || self.pr_status.is_some()
             || self.source_task_id.is_some()
             || self.job_run_id.is_some()
+            || self.crew.is_some()
     }
 
     fn has_history_changes(&self) -> bool {
@@ -256,6 +258,7 @@ impl TaskRecords<'_> {
                     pr_status: params.pr_status.clone(),
                     source_task_id: params.source_task_id.clone(),
                     job_run_id: params.job_run_id.clone(),
+                    crew: params.crew.clone(),
                 },
             )?;
         }
@@ -459,6 +462,14 @@ impl JobRecords<'_> {
         metrics: KnowledgeRunMetrics,
     ) -> Result<bool, OrbitError> {
         self.run.record_job_run_knowledge_metrics(run_id, metrics)
+    }
+
+    pub(crate) fn record_run_crew(
+        &self,
+        run_id: &str,
+        crew: &orbit_common::types::Crew,
+    ) -> Result<bool, OrbitError> {
+        self.run.record_job_run_crew(run_id, crew)
     }
 
     pub(crate) fn finalize_run(

--- a/crates/orbit-core/src/runtime/task_reservation_cleanup.rs
+++ b/crates/orbit-core/src/runtime/task_reservation_cleanup.rs
@@ -183,6 +183,7 @@ mod tests {
                 task_type: TaskType::Chore,
                 external_refs: Vec::new(),
                 source_task_id: None,
+                crew: None,
                 comments: Vec::new(),
             })
             .expect("create task");

--- a/crates/orbit-core/src/runtime/v2_host/mod.rs
+++ b/crates/orbit-core/src/runtime/v2_host/mod.rs
@@ -168,6 +168,30 @@ impl V2RuntimeHost for OrbitRuntime {
         EnvironmentHost::agent_role_config(self, role)
     }
 
+    fn agent_role_config_for_input(
+        &self,
+        role: AgentRole,
+        input: &serde_json::Value,
+    ) -> Option<AgentRoleConfig> {
+        let crew = self
+            .resolve_crew_for_run_input(input)
+            .or_else(|error| {
+                tracing::warn!(
+                    target: "orbit.config.crew",
+                    error = %error,
+                    "failed to resolve crew for activity input; falling back to default role config",
+                );
+                Err(error)
+            })
+            .ok()?;
+        let assignment = crew.role(role.as_str())?;
+        Some(
+            crate::runtime::engine::environment_host::typed_role_config_from_assignment(
+                role, assignment,
+            ),
+        )
+    }
+
     fn api_key_for(&self, provider: &str) -> Result<String, DispatchError> {
         match provider {
             "anthropic" => {

--- a/crates/orbit-core/src/runtime/v2_host/test_support.rs
+++ b/crates/orbit-core/src/runtime/v2_host/test_support.rs
@@ -110,6 +110,7 @@ pub(crate) fn seed_list_backlog_task(
                 task_type,
                 external_refs: Vec::new(),
                 source_task_id: None,
+                crew: None,
                 comments: Vec::new(),
             })
             .expect("seed legacy friction task");

--- a/crates/orbit-embed/src/commands/related.rs
+++ b/crates/orbit-embed/src/commands/related.rs
@@ -184,6 +184,7 @@ mod tests {
             external_refs: Vec::new(),
             relations: Vec::new(),
             job_run_id: None,
+            crew: None,
             created_at: Utc::now(),
             updated_at: Utc::now(),
         }

--- a/crates/orbit-embed/src/commands/search.rs
+++ b/crates/orbit-embed/src/commands/search.rs
@@ -238,6 +238,7 @@ mod tests {
             external_refs: Vec::new(),
             relations: Vec::new(),
             job_run_id: None,
+            crew: None,
             created_at: Utc::now(),
             updated_at: Utc::now(),
         }

--- a/crates/orbit-engine/src/activity_job/agent_role.rs
+++ b/crates/orbit-engine/src/activity_job/agent_role.rs
@@ -1,16 +1,15 @@
 //! Per-role agent settings resolver (ADR-029).
 //!
 //! Bridges the role tag on an `agent_loop` / `groundhog` activity (or its
-//! enclosing `TargetStep`) to the `[agent.<role>]` block written by
-//! `orbit init` (ADR-027). The host returns parsed [`AgentRoleConfig`]
-//! values, and this module collapses them with the inline `provider`,
-//! `model`, and `backend` fields on the activity into a single
-//! [`ResolvedAgentSettings`] triple.
+//! enclosing `TargetStep`) to the selected `[crews.<name>]` role assignment.
+//! The host returns parsed [`AgentRoleConfig`] values, and this module
+//! collapses them with the inline `provider`, `model`, and `backend` fields
+//! on the activity into a single [`ResolvedAgentSettings`] triple.
 //!
 //! # Precedence
 //!
 //! For each field independently:
-//! 1. The matching field on `[agent.<role>]` if the host returned `Some`.
+//! 1. The matching field from the selected crew if the host returned `Some`.
 //! 2. Otherwise the inline value on the activity's [`AgentLoopSpec`].
 //!
 //! No validation happens here — `Provider`/`Backend` were already parsed at
@@ -39,8 +38,9 @@ pub fn resolve_agent_settings(
     role: AgentRole,
     host: &dyn V2RuntimeHost,
     inline: &AgentLoopSpec,
+    input: &serde_json::Value,
 ) -> ResolvedAgentSettings {
-    let config = host.agent_role_config(role);
+    let config = host.agent_role_config_for_input(role, input);
     resolve_from_config(config.as_ref(), inline)
 }
 

--- a/crates/orbit-engine/src/activity_job/dispatcher.rs
+++ b/crates/orbit-engine/src/activity_job/dispatcher.rs
@@ -148,7 +148,8 @@ pub trait V2RuntimeHost: Send + Sync {
         Ok(())
     }
 
-    /// Resolve `[agent.<role>]` from the active workspace's `config.toml`.
+    /// Resolve the selected crew role from the active workspace's
+    /// `config.toml`.
     /// Mirrors [`crate::context::EnvironmentHost::agent_role_config`]; the
     /// engine's job dispatcher receives only `&dyn V2RuntimeHost`, so this
     /// method is the seam dispatch consults at run time. Default returns
@@ -157,6 +158,14 @@ pub trait V2RuntimeHost: Send + Sync {
     /// hosts that have no role-config layer).
     fn agent_role_config(&self, _role: AgentRole) -> Option<AgentRoleConfig> {
         None
+    }
+
+    fn agent_role_config_for_input(
+        &self,
+        role: AgentRole,
+        _input: &Value,
+    ) -> Option<AgentRoleConfig> {
+        self.agent_role_config(role)
     }
 }
 

--- a/crates/orbit-engine/src/activity_job/job_executor/recovery.rs
+++ b/crates/orbit-engine/src/activity_job/job_executor/recovery.rs
@@ -98,7 +98,7 @@ pub(super) fn role_overridden_recovery_spec(
         return None;
     };
     let role = inline_spec.role?;
-    let resolved = resolve_agent_settings(role, ctx.host, inline_spec);
+    let resolved = resolve_agent_settings(role, ctx.host, inline_spec, &ctx.input);
     let mut spec = inline_spec.clone();
     apply_resolved_settings(&mut spec, &resolved);
     Some(ActivityV2Spec::AgentLoop(spec))

--- a/crates/orbit-engine/src/activity_job/job_executor/target.rs
+++ b/crates/orbit-engine/src/activity_job/job_executor/target.rs
@@ -204,7 +204,7 @@ pub(super) fn role_overridden_spec(t: &TargetStep, ctx: &ExecCtx<'_>) -> Option<
         return None;
     };
     let effective_role = t.role.or(inline_spec.role)?;
-    let resolved = resolve_agent_settings(effective_role, ctx.host, inline_spec);
+    let resolved = resolve_agent_settings(effective_role, ctx.host, inline_spec, &ctx.input);
     let mut spec = inline_spec.clone();
     apply_resolved_settings(&mut spec, &resolved);
     Some(spec)

--- a/crates/orbit-engine/src/context.rs
+++ b/crates/orbit-engine/src/context.rs
@@ -311,7 +311,7 @@ pub trait AgentProtocolHost {
     ) -> Result<Vec<u8>, OrbitError>;
 }
 
-/// Resolved `[agent.<role>]` block from `config.toml` (ADR-029). Each field
+/// Resolved crew role assignment from `config.toml`. Each field
 /// is independently optional — the resolver in
 /// `crate::activity_job::agent_role` falls back to the inline activity value
 /// for any field the config does not specify.
@@ -345,12 +345,12 @@ pub trait EnvironmentHost {
     fn cli_command_environment(&self, env_extra: &[String]) -> Vec<(String, String)>;
     fn missing_required_environment_vars(&self, required_env_vars: &[&str]) -> Vec<String>;
 
-    /// Resolved `[agent.<role>]` block from the active workspace's
-    /// `config.toml`, if any (ADR-029). The default returns `None`, which
-    /// means dispatch falls back to the inline `provider`/`model`/`backend`
-    /// on the activity. orbit-core's implementation reads
-    /// `RawRuntimeConfig.agent` (written by `orbit init` per ADR-027) and
-    /// parses the string fields into the strongly-typed activity-job enums.
+    /// Resolved crew role assignment from the active workspace's
+    /// `config.toml`, if any. The default returns `None`, which means
+    /// dispatch falls back to the inline `provider`/`model`/`backend` on the
+    /// activity. orbit-core's implementation reads the selected
+    /// `[crews.<name>]` entry and parses the string fields into the
+    /// strongly-typed activity-job enums.
     fn agent_role_config(&self, _role: AgentRole) -> Option<AgentRoleConfig> {
         None
     }

--- a/crates/orbit-engine/src/executor/automation/batch/parallel.rs
+++ b/crates/orbit-engine/src/executor/automation/batch/parallel.rs
@@ -1043,6 +1043,7 @@ mod tests {
             external_refs: Vec::new(),
             relations: Vec::new(),
             job_run_id: Some(batch_id.to_string()),
+            crew: None,
             created_at: now,
             updated_at: now,
         }

--- a/crates/orbit-engine/src/executor/automation/duel/planning_duel/runner.rs
+++ b/crates/orbit-engine/src/executor/automation/duel/planning_duel/runner.rs
@@ -626,6 +626,7 @@ mod tests {
             external_refs: Vec::new(),
             relations: Vec::new(),
             job_run_id: None,
+            crew: None,
             created_at: now,
             updated_at: now,
         }

--- a/crates/orbit-engine/src/executor/automation/review/sync_review/thread_sync.rs
+++ b/crates/orbit-engine/src/executor/automation/review/sync_review/thread_sync.rs
@@ -589,6 +589,7 @@ mod tests {
             external_refs: vec![ExternalRef::github_pr("42").expect("github pr ref")],
             relations: Vec::new(),
             job_run_id: None,
+            crew: None,
             created_at: now,
             updated_at: now,
         }

--- a/crates/orbit-engine/src/executor/automation/vcs/commit/mod.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/commit/mod.rs
@@ -740,6 +740,7 @@ mod tests {
             external_refs: Vec::new(),
             relations: Vec::new(),
             job_run_id: Some("batch-1".to_string()),
+            crew: None,
             created_at: now,
             updated_at: now,
         }

--- a/crates/orbit-engine/src/executor/automation/vcs/pr.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/pr.rs
@@ -951,6 +951,7 @@ mod tests {
             external_refs: Vec::new(),
             relations: Vec::new(),
             job_run_id: None,
+            crew: None,
             created_at: now,
             updated_at: now,
         }

--- a/crates/orbit-store/src/backend/contracts.rs
+++ b/crates/orbit-store/src/backend/contracts.rs
@@ -1,8 +1,8 @@
 use chrono::{DateTime, Utc};
 use orbit_common::types::{
-    Adr, AdrStatus, AuditEvent, ExecutorDef, ExternalRef, JobRun, JobRunState, KnowledgeRunMetrics,
-    Learning, LearningEvidence, LearningScope, LegacyValidation, OrbitError, OrbitId,
-    PipelineState, PolicyDef, ReviewThread, StoredTool, Task, TaskArtifact, TaskComment,
+    Adr, AdrStatus, AuditEvent, Crew, ExecutorDef, ExternalRef, JobRun, JobRunState,
+    KnowledgeRunMetrics, Learning, LearningEvidence, LearningScope, LegacyValidation, OrbitError,
+    OrbitId, PipelineState, PolicyDef, ReviewThread, StoredTool, Task, TaskArtifact, TaskComment,
     TaskComplexity, TaskHistoryEntry, TaskPriority, TaskStatus, TaskType, normalize_task_tags,
     task_matches_tags,
 };
@@ -72,6 +72,7 @@ pub struct TaskCreateParams {
     pub task_type: TaskType,
     pub external_refs: Vec<ExternalRef>,
     pub source_task_id: Option<String>,
+    pub crew: Option<String>,
     pub comments: Vec<TaskComment>,
 }
 
@@ -103,6 +104,7 @@ pub struct TaskDocumentUpdateParams {
     pub pr_status: Option<Option<String>>,
     pub source_task_id: Option<Option<String>>,
     pub job_run_id: Option<Option<String>>,
+    pub crew: Option<Option<String>>,
 }
 
 #[derive(Debug, Default, Clone)]
@@ -473,6 +475,7 @@ pub trait JobRunStoreBackend: Send + Sync {
         run_id: &str,
         metrics: KnowledgeRunMetrics,
     ) -> Result<bool, OrbitError>;
+    fn record_job_run_crew(&self, run_id: &str, crew: &Crew) -> Result<bool, OrbitError>;
     fn finalize_job_run(
         &self,
         run_id: &str,

--- a/crates/orbit-store/src/backend/factory.rs
+++ b/crates/orbit-store/src/backend/factory.rs
@@ -166,6 +166,7 @@ mod tests {
                 task_type: TaskType::Feature,
                 external_refs: Vec::new(),
                 source_task_id: None,
+                crew: None,
                 comments: Vec::new(),
             })
             .expect("create task");

--- a/crates/orbit-store/src/backend/file_backends.rs
+++ b/crates/orbit-store/src/backend/file_backends.rs
@@ -1,6 +1,6 @@
 use chrono::{DateTime, Utc};
 use orbit_common::types::{
-    Adr, AdrStatus, ExecutorDef, ExternalRef, JobRun, KnowledgeRunMetrics, Learning,
+    Adr, AdrStatus, Crew, ExecutorDef, ExternalRef, JobRun, KnowledgeRunMetrics, Learning,
     LearningStatus, OrbitError, PipelineState, PolicyDef, ReviewThread, Task, TaskArtifact,
     TaskComment, TaskHistoryEntry, TaskPriority, TaskStatus,
 };
@@ -218,6 +218,10 @@ impl JobRunStoreBackend for JobFileStore {
         metrics: KnowledgeRunMetrics,
     ) -> Result<bool, OrbitError> {
         self.record_job_run_knowledge_metrics(run_id, metrics)
+    }
+
+    fn record_job_run_crew(&self, run_id: &str, crew: &Crew) -> Result<bool, OrbitError> {
+        self.record_job_run_crew(run_id, crew)
     }
 
     fn finalize_job_run(

--- a/crates/orbit-store/src/file/friction_store.rs
+++ b/crates/orbit-store/src/file/friction_store.rs
@@ -534,6 +534,7 @@ mod tests {
             external_refs: Vec::new(),
             relations: Vec::new(),
             job_run_id: None,
+            crew: None,
             created_at: now,
             updated_at: now,
         }

--- a/crates/orbit-store/src/file/job_store/run.rs
+++ b/crates/orbit-store/src/file/job_store/run.rs
@@ -7,7 +7,8 @@ use std::path::{Path, PathBuf};
 
 use chrono::{DateTime, Utc};
 use orbit_common::types::{
-    JobRun, JobRunState, JobRunStep, KnowledgeRunMetrics, NotFoundKind, OrbitError, PipelineState,
+    Crew, JobRun, JobRunState, JobRunStep, KnowledgeRunMetrics, NotFoundKind, OrbitError,
+    PipelineState,
 };
 
 use crate::backend::JobRunStepParams;
@@ -45,6 +46,10 @@ impl JobFileStore {
             created_at: Utc::now(),
             steps: vec![],
             knowledge_metrics: None,
+            resolved_crew: None,
+            planner_model: None,
+            implementer_model: None,
+            reviewer_model: None,
         };
         self.write_run(job_id, &run)?;
         Ok(run)
@@ -156,6 +161,23 @@ impl JobFileStore {
         };
         let mut run = self.read_run_at(&run_dir)?;
         run.knowledge_metrics = Some(metrics);
+        self.write_run(&job_id, &run)?;
+        Ok(true)
+    }
+
+    pub(crate) fn record_job_run_crew(
+        &self,
+        run_id: &str,
+        crew: &Crew,
+    ) -> Result<bool, OrbitError> {
+        let Some((job_id, run_dir)) = self.find_run_path(run_id)? else {
+            return Ok(false);
+        };
+        let mut run = self.read_run_at(&run_dir)?;
+        run.resolved_crew = Some(crew.name.clone());
+        run.planner_model = Some(crew.planner.model.clone());
+        run.implementer_model = Some(crew.implementer.model.clone());
+        run.reviewer_model = Some(crew.reviewer.model.clone());
         self.write_run(&job_id, &run)?;
         Ok(true)
     }

--- a/crates/orbit-store/src/file/scoreboard/scoreboard_summary.rs
+++ b/crates/orbit-store/src/file/scoreboard/scoreboard_summary.rs
@@ -1035,6 +1035,7 @@ mod tests {
             external_refs: Vec::new(),
             relations: Vec::new(),
             job_run_id: None,
+            crew: None,
             created_at: Utc::now(),
             updated_at: Utc::now(),
         }
@@ -1061,6 +1062,10 @@ mod tests {
             input: None,
             retry_source_run_id: None,
             knowledge_metrics: None,
+            resolved_crew: None,
+            planner_model: None,
+            implementer_model: None,
+            reviewer_model: None,
             steps: Vec::new(),
         }
     }

--- a/crates/orbit-store/src/file/task_store/v2_bundle.rs
+++ b/crates/orbit-store/src/file/task_store/v2_bundle.rs
@@ -922,6 +922,7 @@ mod tests {
                 priority: TaskPriority::High,
                 complexity: None,
                 job_run_id: None,
+                crew: None,
                 relations: Vec::new(),
                 tags: vec!["task-artifacts".to_string()],
                 context_files: vec!["docs/design/task-artifacts/2_design.md".to_string()],

--- a/crates/orbit-store/src/file/task_store/v2_store.rs
+++ b/crates/orbit-store/src/file/task_store/v2_store.rs
@@ -86,6 +86,7 @@ impl TaskV2Store {
                 priority: params.priority,
                 complexity: params.complexity,
                 job_run_id: None,
+                crew: params.crew,
                 relations,
                 tags: normalize_task_tags(params.tags),
                 context_files: params.context_files,
@@ -323,6 +324,10 @@ impl TaskV2Store {
             }
             if let Some(value) = &fields.job_run_id {
                 bundle.envelope.job_run_id = value.clone();
+                envelope_changed = true;
+            }
+            if let Some(value) = &fields.crew {
+                bundle.envelope.crew = value.clone();
                 envelope_changed = true;
             }
             if let Some(value) = &fields.external_refs {
@@ -750,6 +755,7 @@ impl TaskV2Store {
             external_refs: bundle.envelope.external_refs,
             relations: bundle.envelope.relations,
             job_run_id: bundle.envelope.job_run_id,
+            crew: bundle.envelope.crew,
             created_at: bundle.envelope.created_at,
             updated_at: bundle.envelope.updated_at,
         })
@@ -1234,6 +1240,7 @@ mod tests {
                 ExternalRef::try_new("linear".to_string(), "ENG-123".to_string(), None).unwrap(),
             ],
             source_task_id: None,
+            crew: None,
             comments: vec![TaskComment {
                 at: now,
                 by: "daniel".to_string(),

--- a/crates/orbit-store/src/sqlite/task_registry.rs
+++ b/crates/orbit-store/src/sqlite/task_registry.rs
@@ -1304,6 +1304,7 @@ mod tests {
             priority: TaskPriority::High,
             complexity: None,
             job_run_id: None,
+            crew: None,
             relations,
             tags,
             context_files: Vec::new(),

--- a/crates/orbit-tools/src/builtin/orbit/task/add.rs
+++ b/crates/orbit-tools/src/builtin/orbit/task/add.rs
@@ -121,6 +121,12 @@ impl Tool for OrbitTaskAddTool {
                 param_type: "string".to_string(),
                 required: false,
             },
+            ToolParam {
+                name: "crew".to_string(),
+                description: "Optional named crew to use when running this task".to_string(),
+                param_type: "string".to_string(),
+                required: false,
+            },
         ];
         parameters.extend(super::super::model_identity_params());
 

--- a/crates/orbit-tools/src/builtin/orbit/task/start.rs
+++ b/crates/orbit-tools/src/builtin/orbit/task/start.rs
@@ -21,6 +21,12 @@ impl Tool for OrbitTaskStartTool {
                 param_type: "string".to_string(),
                 required: false,
             },
+            ToolParam {
+                name: "crew".to_string(),
+                description: "Optional crew override for this start".to_string(),
+                param_type: "string".to_string(),
+                required: false,
+            },
         ]);
         parameters.extend(super::super::identity_params());
 

--- a/crates/orbit-tools/src/builtin/orbit/task/update.rs
+++ b/crates/orbit-tools/src/builtin/orbit/task/update.rs
@@ -99,6 +99,13 @@ impl Tool for OrbitTaskUpdateTool {
                 required: false,
             },
             ToolParam {
+                name: "crew".to_string(),
+                description: "Named crew to use when running this task (empty string clears)"
+                    .to_string(),
+                param_type: "string".to_string(),
+                required: false,
+            },
+            ToolParam {
                 name: "context_files".to_string(),
                 description:
                     "Task context selectors as a comma-separated string or array of strings. Prefer canonical selectors: `file:path`, `dir:path`, or `symbol:path#name:kind`. Legacy raw paths are accepted and upgraded automatically."

--- a/crates/orbit-tools/tests/public_tool_surface.rs
+++ b/crates/orbit-tools/tests/public_tool_surface.rs
@@ -151,6 +151,10 @@ fn task_dependency_params_remain_in_agent_tool_schemas() {
 
         assert_eq!(dependency_param.param_type, "string_list");
         assert!(!dependency_param.required);
+        assert!(
+            schema.parameters.iter().any(|param| param.name == "crew"),
+            "{tool_name} should expose crew"
+        );
     }
 }
 

--- a/docs/design/agent-families/1_overview.md
+++ b/docs/design/agent-families/1_overview.md
@@ -4,43 +4,40 @@
 **Owner:** grok
 **Last updated:** 2026-05-16
 
-Orbit models certain AI coding agents as first-class "agent families". A family represents a coherent set of models, CLIs, configuration locations, sandbox requirements, and integration surfaces that Orbit treats with consistent behavior for attribution, execution, review, and analytics.
+Orbit models AI coding systems as first-class agent families and now groups concrete role assignments into named crews. Families answer "which provider/tooling is this model from?"; crews answer "which planner, implementer, and reviewer lineup should run this task?"
 
 ## 1. Motivation
 
-Orbit was initially built around three dominant agent CLIs: Claude Code, Codex (OpenAI), and Gemini. As more agents gained strong coding capabilities (including Grok via Grok Build and the xAI API), it became necessary to treat additional agents as peers rather than second-class or unknown entities.
+Orbit was initially built around three dominant agent CLIs: Claude Code, Codex (OpenAI), and Gemini. As more agents gained strong coding capabilities, including Grok via Grok Build and the xAI API, Orbit needed stable family identifiers for attribution, execution, review, and analytics.
 
-Treating an agent as a peer family ensures:
-- Correct provenance on tasks, review threads, commits, and friction reports
-- Participation in cross-agent workflows (planning duels, automated review)
-- Safe execution under `backend: cli` via dedicated executors and macOS sandbox profiles
-- First-class MCP and onboarding support via `orbit mcp init`
-- Model-pair resolution for orchestrator/helper roles in activities
+Family defaults were originally also used to pick activity role models, but that made per-task model experiments require editing workspace config. The crew registry introduced by [ORB-00058] separates model selection from family discovery: workspaces define named lineups in `[crews.<name>]`, tasks may pin `crew`, and operators may override the crew for a single run.
 
 ## 2. Core Concepts
 
-- **Agent Family**: A stable identifier (e.g. `claude`, `codex`, `gemini`, `grok`) used throughout the system for routing, attribution, and configuration.
-- **Model Inference**: `agent_from_model()` and `infer_agent_family_from_model()` map concrete model strings (e.g. `claude-opus-4-7`, `grok-4`, `gemini-3.1-pro-preview`) to families.
-- **Model Pair**: Each family has a default `(orchestrator, helper)` pair used by activity jobs and duel planning (see `resolve_agent_model_pair`).
-- **Executor**: A YAML definition in `crates/orbit-core/assets/executors/<family>.yaml` describing how to invoke the agent's CLI.
-- **Sandbox Surface**: Provider-specific state directories and lockfile rules required for safe `macos-sandbox-exec` execution.
+- **Agent Family:** A stable identifier such as `claude`, `codex`, `gemini`, or `grok` used for routing, attribution, and legacy model inference.
+- **Model Inference:** `agent_from_model()` and `infer_agent_family_from_model()` map concrete model strings to families. `infer_agent_family_from_model()` remains for legacy artifact recovery.
+- **Crew:** A named planner, implementer, and reviewer assignment loaded from `.orbit/config.toml` under `[crews.<name>]`.
+- **Default Crew:** `[workflow].default_crew` names the workspace fallback when a task does not specify `crew`.
+- **Executor:** A YAML definition in `crates/orbit-core/assets/executors/<family>.yaml` describing how to invoke an agent CLI.
+- **Sandbox Surface:** Provider-specific state directories and lockfile rules required for safe `macos-sandbox-exec` execution.
 
-## 3. Current Families (as of 2026-05)
+## 3. At a Glance
 
-| Family  | Primary Models                  | Provider | Notes |
-|---------|----------------------------------|----------|-------|
-| claude  | claude-*, opus-*, sonnet-*      | anthropic | Claude Code |
-| codex   | gpt-*, o1-*, o3-*               | openai    | Codex / OpenAI CLIs |
-| gemini  | gemini-*                        | google    | Gemini CLI |
-| grok    | grok-*, grok3*                  | xai       | Grok Build + xAI API (added ORB-00042) |
-
-The authoritative list lives in `all_agent_families()` in `crates/orbit-common/src/types/agent_pair.rs`. This is intentionally a fixed-size array so that adding a family forces review of all call sites.
+| Concern | File | Task |
+|---------|------|------|
+| Family inference and crew resolver | `crates/orbit-common/src/types/agent_pair.rs` | [ORB-00042], [ORB-00058] |
+| Task-level crew field | `crates/orbit-common/src/types/task.rs` | [ORB-00058] |
+| Runtime config loading | `crates/orbit-core/src/config/runtime.rs` | [ORB-00058] |
+| Default config template | `crates/orbit-core/assets/config/default-config.toml` | [ORB-00058] |
+| Run-time crew resolution | `crates/orbit-core/src/runtime/engine/crew.rs` | [ORB-00058] |
+| Tool and CLI crew surfaces | `crates/orbit-tools/src/builtin/orbit/task/` | [ORB-00058] |
+| Grok family onboarding | `crates/orbit-common/src/types/agent_pair.rs` | [ORB-00042] |
 
 ## Task References
 
-- ORB-00042: Onboard Grok (xAI) as a first-class supported agent family (epic)
-- ORB-00043: Add Grok to agent_from_model, all_agent_families, and provider_from_model
-- ORB-00048: Harden duels, scoreboards, review sync, friction stats, and analytics for the fourth family
-- ADR-0151: Add Grok (xAI) as a fourth peer agent family
+- ORB-00042: Onboard Grok (xAI) as a first-class supported agent family.
+- ORB-00043: Add Grok to agent_from_model, all_agent_families, and provider_from_model.
+- ORB-00048: Harden duels, scoreboards, review sync, friction stats, and analytics for the fourth family.
+- ORB-00058: Introduce per-task crew override for agent model selection.
 
 Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.

--- a/docs/design/agent-families/2_design.md
+++ b/docs/design/agent-families/2_design.md
@@ -4,12 +4,53 @@
 **Owner:** human
 **Last updated:** 2026-05-16
 
-<Scope of the current implementation.>
+This document describes the current implementation of Orbit agent families and crew-based role assignment. It covers the family registry, the workspace crew registry, task and CLI override surfaces, and where resolved run metadata is persisted.
 
-## 1. Current Implementation
+## 1. Family Registry
 
-## 2. Concerns & Honest Limitations
+The family registry lives in `crates/orbit-common/src/types/agent_pair.rs`. `all_agent_families()` returns the supported family identifiers, while `agent_from_model()` and `infer_agent_family_from_model()` map model prefixes to those families. Prefix inference remains intentionally conservative because older persisted artifacts may only contain a model string.
+
+Adding a family is still a cross-cutting change: executor assets, sandbox behavior, provider inference, review automation, and scoreboard code all need review. The fixed registry forces that audit instead of silently accepting unknown families.
+
+## 2. Crew Registry
+
+Workspace config now defines concrete role lineups under `[crews.<name>]`. Each crew has three role assignments:
+
+- `planner = { model, provider, backend }`
+- `implementer = { model, provider, backend }`
+- `reviewer = { model, provider, backend }`
+
+`crates/orbit-core/src/config/raw.rs` owns the TOML shape, and `crates/orbit-core/src/config/runtime.rs` materializes it into `Crew` values from `orbit-common`. Runtime loading rejects incomplete crews and rejects `[workflow].default_crew` when it does not name a defined crew.
+
+The repository default template and `.orbit/config.toml` use `[workflow].default_crew = "opus-codex"` and define at least `opus-codex` and `all-claude`.
+
+## 3. Task and Tool Surface
+
+`Task` has an optional `crew` field. `orbit.task.add` and `orbit.task.update` validate authored crew names against the current workspace registry, and `orbit.task.start` accepts a one-run `crew` override. The runtime re-validates at start time because the config registry can change between task creation and execution.
+
+The precedence chain is:
+
+1. CLI/tool start override `crew`
+2. `Task.crew`
+3. `[workflow].default_crew`
+
+`orbit.task.show` surfaces the task field and, when the current registry resolves it, the effective crew name plus planner, implementer, and reviewer model strings.
+
+## 4. Run Records
+
+Run-start code resolves the crew before dispatch, emits structured tracing fields for `resolved_crew`, `planner_model`, `implementer_model`, and `reviewer_model`, and persists those four strings on the job run record. Persisting resolved values protects audit trails from later config edits.
+
+Legacy records without crew fields still deserialize because the run-record fields are optional. Display code may use `infer_agent_family_from_model()` only as a recovery path for older artifacts.
+
+## 5. Concerns & Honest Limitations
+
+Crew names are workspace-local strings. Renaming or deleting a crew can break a task that still references the old name, though existing run records keep the resolved model strings.
+
+Duel-plan participant configuration still uses the older family walk and was deliberately left for a separate task. Task-level per-role overrides were also deferred; today a task picks an entire crew, not a single replacement planner or reviewer.
 
 ## Task References
+
+- ORB-00042: Onboard Grok (xAI) as a first-class supported agent family.
+- ORB-00058: Introduce per-task crew override for agent model selection.
 
 Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.

--- a/docs/design/agent-families/3_vision.md
+++ b/docs/design/agent-families/3_vision.md
@@ -4,16 +4,44 @@
 **Owner:** human
 **Last updated:** 2026-05-16
 
-<Scope of the forward-looking design.>
+The long-term direction is to keep family discovery small and explicit while moving experiment-friendly model selection into named crew configuration. Future work should reuse the registry instead of reintroducing hardcoded role defaults.
 
 ## 1. Open Questions
 
+1. Should duel-plan participant selection read directly from the crew registry, or should it use a separate experiment matrix that references crews by name?
+2. When a user wants to replace only the planner or reviewer for a task, should Orbit add per-role task overrides or require defining another named crew?
+3. Should Orbit eventually version crew definitions so run-start can detect that a task pinned an older semantic lineup?
+4. How much validation should occur at task authoring time versus run-start when remote config stores are introduced?
+
 ## 2. Prior Work
+
+### Agent Family Onboarding
+
+[ORB-00042] and follow-up tasks made `grok` a peer of `claude`, `codex`, and `gemini`. That work established the rule that adding a family is explicit and reviewed, not inferred from arbitrary strings.
+
+### Role Defaults
+
+Before [ORB-00058], default role models were split between `[agent.<role>]` config and hardcoded family pair resolution. That made model experiments global and temporary, which in turn made audit trails harder to interpret.
+
+### Task Metadata
+
+Task artifacts already supported optional fields that can be omitted from older YAML. The `crew` field follows that pattern so old tasks load while new tasks can express an intended lineup.
 
 ## 3. What May Be Distinctive
 
+Orbit treats crew resolution as part of task execution provenance rather than just configuration lookup. A run records the exact resolved crew and role models so later readers can understand what actually ran even after the workspace registry changes.
+
+The distinction between family and crew also lets future workflows ask two different questions cleanly: "which executors are supported?" and "which concrete lineup should this job use?"
+
 ## 4. References
 
+- Orbit internal: [1_overview.md](./1_overview.md), [2_design.md](./2_design.md), [4_decisions.md](./4_decisions.md)
+- Orbit internal: `crates/orbit-common/src/types/agent_pair.rs`
+- Orbit internal: `crates/orbit-core/src/runtime/engine/crew.rs`
+
 ## Task References
+
+- ORB-00042: Onboard Grok (xAI) as a first-class supported agent family.
+- ORB-00058: Introduce per-task crew override for agent model selection.
 
 Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.

--- a/docs/design/agent-families/4_decisions.md
+++ b/docs/design/agent-families/4_decisions.md
@@ -31,7 +31,8 @@ See full ADR-0151 for context, alternatives considered, and cost analysis.
 **Consequences.**
 - "Crew" was chosen over "profile" because profiles sound user-scoped, and over "pair" because the lineup contains planner, implementer, and reviewer.
 - Run records persist the resolved crew plus the three role model strings so audit trails survive later config edits.
-- Deferred: duel-plan participant configuration, per-role task overrides, and planner-vs-executor workflow split.
+- The v2 `agent_loop` dispatch path reads role models from the crew registry (`crates/orbit-core/src/runtime/engine/environment_host.rs`). The v1 envelope/identity path and the orbit-store scoreboard/friction projections still resolve through `resolve_agent_model_pair*` in `crates/orbit-common/src/types/agent_pair.rs`; those callers do not yet have access to a crew-aware context, so this PR keeps the legacy resolver as a scoreboard-rendering shim. Migrating them is tracked as a follow-up.
+- Deferred: duel-plan participant configuration, per-role task overrides, planner-vs-executor workflow split, and the legacy-resolver migration noted above.
 - Cost: old workspaces with only `[agent.planner]`, `[agent.implementer]`, and `[agent.reviewer]` must migrate before config load succeeds.
 
 ## Task References

--- a/docs/design/agent-families/4_decisions.md
+++ b/docs/design/agent-families/4_decisions.md
@@ -4,7 +4,7 @@
 **Owner:** grok
 **Last updated:** 2026-05-16
 
-ADR entries are append-only and ordered ascending.
+ADR entries are append-only and ordered ascending. New entries should follow the template in [../CONVENTIONS.md](../CONVENTIONS.md).
 
 ## ADR-0151 (2026-05-16)
 
@@ -20,6 +20,23 @@ ADR entries are append-only and ordered ascending.
 
 See full ADR-0151 for context, alternatives considered, and cost analysis.
 
+## ADR-0152 — Replace `[agent.<role>]` tables with named `[crews.*]` registry
+
+**Status:** Accepted · 2026-05 · [ORB-00058]
+
+**Context.** Workspace config previously selected planner, implementer, and reviewer models with three top-level `[agent.<role>]` tables, while task execution had no durable way to request a different lineup. Layering a new registry beside the old role tables would have forced Orbit to validate and explain two schemas for the same decision.
+
+**Decision.** Replace the role-keyed config shape wholesale with named `[crews.<name>]` entries and `[workflow].default_crew`. A task may store `crew`, and a run may override it with CLI/tool input; precedence is CLI override, then task field, then workspace default.
+
+**Consequences.**
+- "Crew" was chosen over "profile" because profiles sound user-scoped, and over "pair" because the lineup contains planner, implementer, and reviewer.
+- Run records persist the resolved crew plus the three role model strings so audit trails survive later config edits.
+- Deferred: duel-plan participant configuration, per-role task overrides, and planner-vs-executor workflow split.
+- Cost: old workspaces with only `[agent.planner]`, `[agent.implementer]`, and `[agent.reviewer]` must migrate before config load succeeds.
+
 ## Task References
+
+- ORB-00042: Onboard Grok (xAI) as a first-class supported agent family.
+- ORB-00058: Introduce per-task crew override for agent model selection.
 
 Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.


### PR DESCRIPTION
## Task

[ORB-00058](https://orbit-cli.com/tasks/ORB-00058) — Introduce per-task crew override for agent model selection

### Description

## Problem

Model/provider selection for the planner, implementer, and reviewer roles is hardcoded in `.orbit/config.toml` as three top-level role-keyed tables (`[agent.planner]`, `[agent.implementer]`, `[agent.reviewer]`). The workspace has one global default; trying a different model for a single task means editing `.orbit/config.toml` and reverting afterwards. There is no task-level surface for declaring which lineup runs a task, and the resolver in `crates/orbit-common/src/types/agent_pair.rs` is keyed by agent CLI family with the per-family defaults baked into code.

## Why It Matters

Switching models per task today is high-friction enough that experiments don't happen. A named **crew** abstraction (a bundle of the three role assignments — planner, implementer, reviewer) gives:

1. A registry in config so swapping a model in one place updates every task that uses that crew, decoupling config evolution from task content.
2. An optional `crew` field on the task so a single experiment doesn't require touching workspace config.
3. A CLI override (`--crew <name>`) so ops can force a one-off run without editing the task.
4. A foundation for parameterizing duel-plan participants later — the registry is what eventually replaces the hardcoded `all_agent_families()` walk (explicitly out of scope for this task).

## Design

### Config schema (replace, not coexist)

Drop the top-level `[agent.<role>]` blocks. Introduce `[crews.<name>]` tables and `default_crew = "<name>"` under `[workflow]`:

```toml
[crews.opus-codex]
planner     = { model = "claude-opus-4-7", provider = "claude", backend = "cli" }
implementer = { model = "gpt-5.5",         provider = "codex",  backend = "cli" }
reviewer    = { model = "claude-opus-4-7", provider = "claude",  backend = "cli" }

[crews.all-claude]
planner     = { model = "claude-opus-4-7",   provider = "claude", backend = "cli" }
implementer = { model = "claude-sonnet-4-6", provider = "claude", backend = "cli" }
reviewer    = { model = "claude-opus-4-7",   provider = "claude", backend = "cli" }

[crews.all-codex]
planner     = { model = "gpt-5.5",   provider = "codex", backend = "cli" }
implementer = { model = "gpt-5.5", provider = "codex", backend = "cli" }
reviewer    = { model = "gpt-5.5",   provider = "codex", backend = "cli" }

[crews.all-grok]
planner     = { model = "grok-4",   provider = "grok", backend = "cli" }
implementer = { model = "grok-4", provider = "grok", backend = "cli" }
reviewer    = { model = "grok-4",   provider = "grok", backend = "cli" }

[crews.all-gemini]
planner     = { model = "pro",   provider = "gemini", backend = "cli" }
implementer = { model = "pro", provider = "gemini", backend = "cli" }
reviewer    = { model = "pro",   provider = "gemini", backend = "cli" }

[workflow]
default_crew = "opus-codex"
```

Each crew entry's three role values use the existing role-config struct shape (`model`, `provider`, `backend`) from `crates/orbit-core/src/config/raw.rs`.

### Task schema

Add an optional `crew: Option<String>` field to `Task` in `crates/orbit-common/src/types/task.rs`, with `#[serde(default, skip_serializing_if = "Option::is_none")]`. When `None`, the workspace `default_crew` applies at run-start.

### CLI surface

`--crew <name>` on both `orbit.task.add` and `orbit.task.start`. Symmetric authoring matters — an operator creating a task should be able to pin a crew at creation.

### Precedence

CLI `--crew` flag > task field `crew` > `[workflow].default_crew`. Resolved name is logged at run start.

### Validation

- Config loader fails on load if `default_crew` does not reference a defined `[crews.<name>]`.
- `orbit.task.add` and `orbit.task.update` reject unknown crew names against the current registry; the error message lists valid crew names.
- `orbit.task.start` re-validates the resolved crew (registry may have changed between author and run).

### Resolver

The family-keyed `resolve_agent_model_pair_or` in `crates/orbit-common/src/types/agent_pair.rs` is replaced by a name-keyed `resolve_crew(name, &config) -> Crew` that returns the three role-model triples. The hardcoded per-family defaults at [agent_pair.rs:147–156](crates/orbit-common/src/types/agent_pair.rs#L147) are removed because `orbit init` now always writes a default crew. `infer_agent_family_from_model` is retained for legacy persisted-artifact recovery only; new tasks read `agent_cli`/provider from the resolved crew entry directly.

### Visibility

At run start, emit `tracing::info!(resolved_crew, planner_model, implementer_model, reviewer_model, ...)`. Persist the resolved crew name and per-role model strings on the run record so `orbit.task.show` and audit trails reflect what actually ran, not what was configured at author time.

### Migration

`orbit init` writes the new shape. The repo's own `.orbit/config.toml` is migrated as part of the task: define an `opus-codex` crew matching today's role-by-role assignments (`planner=claude-opus-4-7/claude`, `implementer=gpt-5.5/codex`, `reviewer=gpt-5.5/codex`), set `default_crew = "opus-codex"` under `[workflow]`, and delete the three `[agent.<role>]` blocks.

### ADR

This is a non-obvious schema break. Add an ADR under `docs/design/<feature>/` per `docs/design/CONVENTIONS.md` capturing: (a) why role-based config was replaced wholesale instead of layered, (b) why "crew" was chosen over "profile"/"pair", (c) the precedence chain, (d) what was explicitly deferred.

## Constraints / Notes

- **Out of scope for v1 (follow-ups, do not draft here):**
  - Duel-plan participant configuration. The crew registry is the foundation that unblocks it; wiring `crates/orbit-engine/src/executor/automation/duel/select_roles.rs` to read it is a separate task.
  - Per-role override on a task (e.g. swap only the planner). Add when someone asks.
  - Planner-vs-executor workflow split. Different concern entirely — see prior brainstorm notes.
- Keep `infer_agent_family_from_model` and its prefix-matching for legacy artifact recovery — older run records may persist bare model strings without crew attribution.
- Logging must use `tracing` structured fields (no `print_stdout`/`print_stderr` — fails `make ci`).
- All new code paths must respect `[workspace.lints.clippy].unwrap_used = warn` and `await_holding_lock = deny`.

### Acceptance Criteria

- `.orbit/config.toml` contains at least two `[crews.<name>]` tables and `[workflow].default_crew` set to a defined crew, with no remaining `[agent.planner]`/`[agent.implementer]`/`[agent.reviewer]` blocks. Verified via `grep '^\[agent\.' .orbit/config.toml` returning no matches AND `grep '^\[crews\.' .orbit/config.toml` returning at least two matches.
- `orbit init` writes a default config with `[crews.<default>]` tables and `default_crew` set; the default-config template at `crates/orbit-core/assets/config/default-config.toml` contains no `[agent.planner]`/`[agent.implementer]`/`[agent.reviewer]` headers. A unit test in `crates/orbit-core/src/config/bootstrap.rs` asserts the new shape (presence of `[crews.*]` and `default_crew`, absence of `[agent.<role>]`).
- The `Task` struct in `crates/orbit-common/src/types/task.rs` has a new field `pub crew: Option<String>` annotated with `#[serde(default, skip_serializing_if = "Option::is_none")]`. Verified by `rg 'pub crew: Option<String>' crates/orbit-common/src/types/task.rs` returning exactly one match.
- `orbit tool run orbit.task.add --input '{...,"crew":"opus-codex",...}'` succeeds and the persisted task YAML contains a `crew: opus-codex` line. `orbit tool run orbit.task.show --input '{"id":"<id>"}'` output includes the resolved crew name and the three role-model strings (planner/implementer/reviewer).
- `orbit tool run orbit.task.add --input '{...,"crew":"does-not-exist",...}'` exits non-zero and the stderr error message lists the defined crew names parsed from `.orbit/config.toml`.
- Starting a task with CLI override `orbit tool run orbit.task.start --input '{"id":"<id>","crew":"all-claude"}'` (where the task field is `opus-codex` or `None`) emits a run-start `tracing::info` event whose structured fields include `resolved_crew="all-claude"`, `planner_model="claude-opus-4-7"`, `implementer_model="claude-sonnet-4-6"`, `reviewer_model="claude-opus-4-7"`. CLI override beats both task field and `default_crew`.
- Starting a run on a task where `crew` is `None` resolves the crew from `[workflow].default_crew`; the run record file/store persists the resolved crew name and the three per-role model strings as separate fields (not just a free-form blob). Verified by reading the run record after a completed run and asserting the fields exist with the expected values.
- A `.orbit/config.toml` whose `default_crew` names a crew that is not defined in `[crews.*]` fails config load with a typed `OrbitError` variant (not a generic string error). Covered by a unit test in `crates/orbit-core/src/config/runtime.rs` (or `raw.rs`) that constructs such a config and asserts the typed error.
- A new unit-test module covers the name-keyed resolver: (a) resolving a known crew name returns the expected three role-model triples; (b) resolving an unknown crew name returns a typed error; (c) `infer_agent_family_from_model` still correctly resolves the existing prefix set (`claude-`, `gpt-`/`o1`/`o3`, `gemini-`, `grok-`/`grok3`) for legacy-artifact recovery.
- A new ADR under `docs/design/<feature>/` records the schema break: (a) why role-based config was replaced wholesale instead of layered, (b) why "crew" was chosen over "profile"/"pair", (c) the CLI > task > default precedence chain, (d) what was deferred (duel-plan integration, per-role override, planner-vs-executor split). ADR file follows `docs/design/CONVENTIONS.md` and is referenced from the task's commit message.
- `make ci-fast` passes locally before the task moves to `review`; the full `make ci` passes on the resulting PR via GitHub Actions.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Replaced role-keyed config with named crew config, migrated the default template and repo `.orbit/config.toml`, and added runtime validation for crews/default_crew.
- Added `Task.crew`, task add/update/start crew surfaces, crew resolution precedence, structured run-start logging, and persisted run-record crew/model fields.
- Updated task/job storage/projections, CLI/web output, tests, and agent-families design docs with ADR-0152.

Assessment: Implementation is validated by focused Rust tests, cargo check, a CLI smoke for crew add/show/unknown-crew rejection, and `make ci-fast`. Broader `cargo test -p orbit-cli` still fails on pre-existing stale design-doc findings outside ORB-00058 scope: activity-job/1_overview.md, activity-job/4_decisions.md, and auditability/2_design.md.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-00058-6a08c7b8`
- Behind base: 0
- Ahead of base: 1