### PR TITLE
Mitigate concurrent worktree setup Git config lock failures

### DIFF
--- a/crates/orbit-core/assets/jobs/task_local_pipeline.yaml
+++ b/crates/orbit-core/assets/jobs/task_local_pipeline.yaml
@@ -32,6 +32,11 @@ spec:
   steps:
     - id: worktree
       target: activity:worktree_setup
+      retry:
+        max_attempts: 4
+        initial_backoff_ms: 200
+        backoff_cap_ms: 2000
+        backoff_strategy: exponential
       default_input:
         task_ids: "{{ input.task_ids }}"
         base: "{{ input.base_branch }}"

--- a/crates/orbit-core/assets/jobs/task_pr_pipeline.yaml
+++ b/crates/orbit-core/assets/jobs/task_pr_pipeline.yaml
@@ -32,6 +32,11 @@ spec:
   steps:
     - id: worktree
       target: activity:worktree_setup
+      retry:
+        max_attempts: 4
+        initial_backoff_ms: 200
+        backoff_cap_ms: 2000
+        backoff_strategy: exponential
       default_input:
         task_ids: "{{ input.task_ids }}"
         base: "{{ input.base_branch }}"

--- a/crates/orbit-engine/src/executor/automation/vcs/worktree/setup.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/worktree/setup.rs
@@ -7,7 +7,10 @@ use sha2::{Digest, Sha256};
 use crate::context::{RuntimeHost, TaskAutomationUpdate, TaskHost};
 use crate::executor::automation::input::{input_string_field, required_input_string};
 
-use super::super::git::{base_sync_mode_from_input, git_success, resolve_worktree_start_point};
+use super::super::git::{
+    base_sync_mode_from_input, git_command_success, git_output, git_success,
+    resolve_worktree_start_point,
+};
 use super::resolve_worktree_path_from_prefix;
 
 const DEFAULT_BASE: &str = "main";
@@ -115,14 +118,35 @@ fn ensure_worktree(
     start_point: &str,
     branch_name: &str,
 ) -> Result<(), OrbitError> {
+    let target = git_output(
+        repo_root,
+        &[
+            "rev-parse",
+            "--verify",
+            &format!("{start_point}^{{commit}}"),
+        ],
+    )?;
+
     if worktree_path.exists() {
-        let target = super::super::git::git_output(repo_root, &["rev-parse", start_point])?;
-        git_success(
-            worktree_path,
-            &["checkout", "-B", branch_name, target.trim()],
-        )?;
-        git_success(worktree_path, &["clean", "-fd"])?;
-        return Ok(());
+        if git_command_success(worktree_path, &["rev-parse", "--is-inside-work-tree"])? {
+            git_success(worktree_path, &["checkout", "-B", branch_name, &target])?;
+            git_success(worktree_path, &["clean", "-fd"])?;
+            return Ok(());
+        }
+
+        if is_empty_dir(worktree_path)? {
+            std::fs::remove_dir(worktree_path).map_err(|error| {
+                OrbitError::Execution(format!(
+                    "failed to remove empty invalid worktree path '{}': {error}",
+                    worktree_path.display()
+                ))
+            })?;
+        } else {
+            return Err(OrbitError::Execution(format!(
+                "worktree path '{}' exists but is not a Git worktree; move it aside or remove it before retrying",
+                worktree_path.display()
+            )));
+        }
     }
 
     if let Some(parent) = worktree_path.parent() {
@@ -134,6 +158,8 @@ fn ensure_worktree(
         })?;
     }
 
+    git_success(repo_root, &["worktree", "prune"])?;
+    let worktree_path_arg = worktree_path.to_string_lossy();
     git_success(
         repo_root,
         &[
@@ -141,10 +167,30 @@ fn ensure_worktree(
             "add",
             "-B",
             branch_name,
-            &worktree_path.to_string_lossy(),
-            start_point,
+            &worktree_path_arg,
+            &target,
         ],
     )
+}
+
+fn is_empty_dir(path: &Path) -> Result<bool, OrbitError> {
+    let metadata = std::fs::symlink_metadata(path).map_err(|error| {
+        OrbitError::Execution(format!(
+            "failed to inspect worktree path '{}': {error}",
+            path.display()
+        ))
+    })?;
+    if !metadata.is_dir() {
+        return Ok(false);
+    }
+
+    let mut entries = std::fs::read_dir(path).map_err(|error| {
+        OrbitError::Execution(format!(
+            "failed to read worktree path '{}': {error}",
+            path.display()
+        ))
+    })?;
+    Ok(entries.next().is_none())
 }
 
 fn task_ids_from_input(input: &Value) -> Result<Vec<String>, OrbitError> {
@@ -230,6 +276,85 @@ mod tests {
     }
 
     #[test]
+    fn ensure_worktree_reuses_orphan_branch_from_failed_attempt() {
+        let temp = tempdir().unwrap();
+        let repo = temp.path().join("repo");
+        let worktree = temp.path().join("worktree");
+        init_repo(&repo, "agent-main");
+        let first_base = commit_file(&repo, "base.txt", "v1");
+        git(&repo, &["branch", "orbit/test", &first_base]);
+
+        let second_base = commit_file(&repo, "base.txt", "v2");
+        ensure_worktree(&repo, &worktree, &second_base, "orbit/test").unwrap();
+
+        assert_eq!(git(&worktree, &["rev-parse", "HEAD"]), second_base);
+    }
+
+    #[test]
+    fn ensure_worktree_prunes_dangling_metadata_from_failed_attempt() {
+        let temp = tempdir().unwrap();
+        let repo = temp.path().join("repo");
+        let worktree = temp.path().join("worktree");
+        init_repo(&repo, "agent-main");
+        let base = commit_file(&repo, "base.txt", "v1");
+
+        ensure_worktree(&repo, &worktree, &base, "orbit/test").unwrap();
+        fs::remove_dir_all(&worktree).unwrap();
+
+        ensure_worktree(&repo, &worktree, &base, "orbit/test").unwrap();
+
+        assert_eq!(git(&worktree, &["rev-parse", "HEAD"]), base);
+    }
+
+    #[test]
+    fn ensure_worktree_reuses_empty_path_from_failed_attempt() {
+        let temp = tempdir().unwrap();
+        let repo = temp.path().join("repo");
+        let worktree = temp.path().join("worktree");
+        init_repo(&repo, "agent-main");
+        let base = commit_file(&repo, "base.txt", "v1");
+        fs::create_dir_all(&worktree).unwrap();
+
+        ensure_worktree(&repo, &worktree, &base, "orbit/test").unwrap();
+
+        assert_eq!(git(&worktree, &["rev-parse", "HEAD"]), base);
+    }
+
+    #[test]
+    fn ensure_worktree_uses_commit_start_point_without_upstream_config() {
+        let temp = tempdir().unwrap();
+        let remote = temp.path().join("remote.git");
+        let seed = temp.path().join("seed");
+        let local = temp.path().join("local");
+        let worktree = temp.path().join("worktree");
+
+        git(temp.path(), &["init", "--bare", remote.to_str().unwrap()]);
+        init_repo(&seed, "agent-main");
+        let remote_head = commit_file(&seed, "base.txt", "v1");
+        git(
+            &seed,
+            &["remote", "add", "origin", remote.to_str().unwrap()],
+        );
+        git(&seed, &["push", "-u", "origin", "agent-main"]);
+        git(
+            temp.path(),
+            &[
+                "clone",
+                "--branch",
+                "agent-main",
+                remote.to_str().unwrap(),
+                local.to_str().unwrap(),
+            ],
+        );
+
+        ensure_worktree(&local, &worktree, "origin/agent-main", "orbit/test").unwrap();
+
+        assert_eq!(git(&worktree, &["rev-parse", "HEAD"]), remote_head);
+        assert_git_fails(&local, &["config", "--get", "branch.orbit/test.remote"]);
+        assert_git_fails(&local, &["config", "--get", "branch.orbit/test.merge"]);
+    }
+
+    #[test]
     fn worktree_setup_output_includes_legacy_batch_id_alias() {
         let output = worktree_setup_output(
             "jrun-test",
@@ -272,5 +397,21 @@ mod tests {
             String::from_utf8_lossy(&output.stderr)
         );
         String::from_utf8_lossy(&output.stdout).trim().to_string()
+    }
+
+    fn assert_git_fails(current_dir: &Path, args: &[&str]) {
+        let output = Command::new("git")
+            .args(args)
+            .current_dir(current_dir)
+            .output()
+            .unwrap();
+        assert!(
+            !output.status.success(),
+            "git {} unexpectedly succeeded in {}:\nstdout: {}\nstderr: {}",
+            args.join(" "),
+            current_dir.display(),
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
     }
 }


### PR DESCRIPTION
## Task

[ORB-00059](https://orbit-cli.com/tasks/ORB-00059) — Mitigate concurrent worktree setup Git config lock failures

### Description

## Problem
Parallel task pipeline fanout can start multiple `worktree_setup` actions against the same repository at nearly the same time. In `jrun-20260516-1753-7`, `git worktree add -B orbit/ORB-00045-6a08af23 ... origin/agent-main` failed before implementation because Git could not lock `.git/config` while writing upstream branch metadata. The run left a partial local branch and caused parent gate/auto runs to fail even though the task work itself never started.

## Why It Matters
This makes task automation flaky under normal parallel execution. A transient repo-level Git config lock should not permanently fail a task pipeline or leave cleanup work for the operator.

## Evidence
- Primary failed run: `jrun-20260516-1753-7` for `ORB-00045`
- Downstream gate failure: `jrun-20260516-1753-3`
- Top-level auto failure: `jrun-20260516-1753`
- Friction report: `F2026-05-015`
- Key error: `error: could not lock config file .git/config: File exists` followed by `error: unable to write upstream branch configuration`

## Suggested Approach
- Add bounded retry with exponential backoff to the `worktree` step in task PR/local pipelines.
- Make new worktree creation avoid unnecessary `.git/config` writes, for example by resolving the start point to a commit SHA before `git worktree add -B` instead of passing a remote-tracking branch that triggers upstream config writes.
- If needed, serialize the small repo-level Git mutation window with the existing file-lock utility rather than reducing overall task parallelism.
- Make retry idempotent after partial failures, including stale branch/path artifacts from a failed first attempt.

## Constraints / Notes
- Do not reduce pipeline fanout globally unless there is no narrower fix.
- Do not add a new dependency for file locking; `orbit-common` already has `with_exclusive_file_lock`.
- Preserve existing behavior for successful worktree reuse and base sync modes.

### Acceptance Criteria

- `crates/orbit-core/assets/jobs/task_pr_pipeline.yaml` and `crates/orbit-core/assets/jobs/task_local_pipeline.yaml` define a bounded retry policy on the `worktree` step with exponential backoff.
- New worktree creation in `worktree_setup` no longer triggers Git upstream configuration writes for remote base refs, or otherwise serializes that repo-level config mutation so concurrent runs cannot fail with `.git/config` lock contention.
- A deterministic test using temp repositories or fakes covers a transient worktree setup failure and verifies a retry or idempotent second attempt succeeds without leaving an invalid worktree path.
- A deterministic test or inspection asserts partial branch/path artifacts from a failed `git worktree add -B` are safely reused, cleaned, or reported with an actionable non-destructive error.
- The fix is validated with `cargo test -p orbit-engine worktree` and `make ci-fast` before moving the task to review.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Added bounded exponential retry to the `worktree` step in both task PR and task local pipelines.
- Updated `ensure_worktree` to resolve the requested start point to a commit SHA before `git worktree add -B`, avoiding remote-tracking start points that make Git write upstream branch config.
- Made worktree setup idempotent across failed attempts by pruning stale worktree metadata before add, reusing orphan branches via `-B`, removing empty invalid worktree paths, and reporting non-empty invalid paths with a non-destructive error.
- Added temp-repository tests for orphan branch reuse, dangling worktree metadata pruning, empty path cleanup, and absence of upstream config writes for `origin/<base>` start points.

Assessment: The scoped retry and SHA-based start point remove the observed `.git/config` lock failure path without reducing task fanout. Validation passed with `cargo test -p orbit-engine worktree` and `make ci-fast`.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-00059-6a08d683`
- Behind base: 0
- Ahead of base: 1