### PR TITLE
Update `orbit-create-task` skill to nudge agents toward behavior-driving optional fields (`complexity`, `dependencies`)

### DIFF
--- a/crates/orbit-core/assets/skills/orbit-create-task/SKILL.md
+++ b/crates/orbit-core/assets/skills/orbit-create-task/SKILL.md
@@ -47,6 +47,21 @@ See the `orbit` skill for the full mapping rule and surface coverage. Examples b
 - Orbit fills `created_by`, `planned_by`, and `implemented_by` automatically from execution context when those roles are authored during the task lifecycle.
 - Valid task types are `feature`, `bug`, `refactor`, and `chore`. Use `orbit-track-issues` for agent self-reported friction instead of task types.
 
+## Optional but Behavior-Affecting Fields
+
+### Tier 1 - Nudge
+- `complexity: "hard"` trigger: set when the task obviously cannot share a batch (large surface, multi-crate cross-cut, ambiguous design).
+  Behavior anchor: `crates/orbit-engine/src/executor/automation/batch/dispatch.rs` `task_prefers_single_batch`.
+- `dependencies: ["ORB-NNNN", ...]` trigger: set when prerequisite tasks must reach a dependency-satisfying status before this task starts.
+  Behavior anchor: `crates/orbit-common/src/types/task.rs` `task_dependencies_ready`.
+
+### Tier 2 - Mention
+- `parent_id: "ORB-NNNN"` metadata: only for real subtask-of relationships; display/list grouping and batch relatedness.
+- `source_task_id: "ORB-NNNN"` metadata: for `type: bug`, names the task that introduced the defect; display-only today.
+
+### Tier 3 - Tags
+Tags are indexed by `orbit.semantic.search`; use existing tags where they fit before inventing new ones, because speculative tag soup is costly.
+
 ## Task Quality Standards
 
 ### Validation Environment checklist
@@ -94,6 +109,7 @@ orbit tool run orbit.task.add --input '{
   "priority": "<low|medium|high|critical>",
   "type": "<feature|bug|refactor|chore>",
   "model": "<model_name>" # gpt-5.4, claude-opus-4-6, gemini-2.5-pro, etc
+  # Optional: complexity, dependencies, parent_id, source_task_id, tags - see "Optional but Behavior-Affecting Fields"
 }'
 ```
 
@@ -109,6 +125,7 @@ orbit_task_add({
   "priority": "<low|medium|high|critical>",
   "type": "<feature|bug|refactor|chore>",
   "model": "<model_name>"
+  # Optional: complexity, dependencies, parent_id, source_task_id, tags - see "Optional but Behavior-Affecting Fields"
 })
 ```
 


### PR DESCRIPTION
## Task

[ORB-00070](https://orbit-cli.com/tasks/ORB-00070) — Update `orbit-create-task` skill to nudge agents toward behavior-driving optional fields (`complexity`, `dependencies`)

### Description

## Problem

The `orbit-create-task` skill ([crates/orbit-core/assets/skills/orbit-create-task/SKILL.md](crates/orbit-core/assets/skills/orbit-create-task/SKILL.md)) only documents `title`, `description`, `acceptance_criteria`, `plan`, `context_files`, `workspace`, `priority`, `type`, and `model` (see CLI / MCP examples at lines 84-113). The `orbit.task.add` schema accepts several more fields — some of which change runtime behavior — but the skill never mentions them, so agents skip them and the engine ends up running on partial signal.

Concretely (see investigation in this chat against [crates/orbit-core/src/command/task/params.rs](crates/orbit-core/src/command/task/params.rs)):

- `complexity` — drives batch routing in [crates/orbit-engine/src/executor/automation/batch/dispatch.rs:275-280](crates/orbit-engine/src/executor/automation/batch/dispatch.rs:275). `Some(TaskComplexity::Hard)` is one of the triggers that forces a task into its own batch via `task_prefers_single_batch`. Without it, dispatch only sees the proxy signals (context-files count, AC count).
- `dependencies` — surfaces as `BlockedBy` relations on the task ([crates/orbit-store/src/file/task_store/v2_store.rs:911-915](crates/orbit-store/src/file/task_store/v2_store.rs:911)) and gates readiness via `task_dependencies_ready` at [crates/orbit-common/src/types/task.rs:790-796](crates/orbit-common/src/types/task.rs:790). Without it, the engine can pick a task whose prerequisites aren't done.
- `parent_id` — surfaces as a `ChildOf` relation. Used for list-by-parent filtering and as a relatedness signal in batch dispatch ([dispatch.rs:287-288](crates/orbit-engine/src/executor/automation/batch/dispatch.rs:287)). Only matters when a genuine subtask relationship exists.
- `source_task_id` — surfaces as a `RegressionFrom` relation. Persisted and displayed in `orbit task show` ([crates/orbit-cli/src/command/task/show.rs:148](crates/orbit-cli/src/command/task/show.rs:148)) but no code path acts on it — lineage metadata for humans.
- `tags` — not consumed by scheduling/routing, but indexed by `orbit.semantic.search` (BM25 + cosine) and useful for faceted browsing. Risk: tag soup without a shared convention.

Other relation types defined in [crates/orbit-common/src/types/task_artifacts.rs:101-108](crates/orbit-common/src/types/task_artifacts.rs:101) (`SpawnedFrom`, `Supersedes`, `RelatedTo`) don't have a sugar input field, so they're out of scope for this skill update.

## Proposed Change

Add one short section to `SKILL.md` (placement: between "Operating Rules" and "Task Quality Standards"), titled **"Optional but Behavior-Affecting Fields"**, tiered so agents can decide quickly:

**Tier 1 — Nudge (set when it applies, drives engine behavior):**
- `complexity: "hard"` — when the task obviously can't share a batch (large surface, multi-crate cross-cuts, ambiguous design). Drives `task_prefers_single_batch` in batch dispatch.
- `dependencies: ["ORB-NNNN", ...]` — when other tasks must reach a dependency-satisfying status before this one can move to `in-progress`. Gates readiness.

**Tier 2 — Mention (set when accurate, mostly metadata):**
- `parent_id: "ORB-NNNN"` — only for real subtask-of relationships; doubles as a relatedness signal in batch dispatch.
- `source_task_id: "ORB-NNNN"` — for `type: bug` tasks, names the task whose work introduced the defect. Display-only today.

**Tier 3 — Tags:**
- One line: "Tags are indexed by `orbit.semantic.search`; use existing tags where they fit before inventing new ones. Avoid speculative tags — tag soup is a real cost."

The existing CLI / MCP example payloads (lines 84-113) should NOT be expanded — that would push agents to over-fill every task. Keep the examples minimal; rely on the new section for opt-in guidance.

Also update the example payloads' field-list comment trail to nod at the new section: a single line like `# Optional: complexity, dependencies, parent_id, source_task_id, tags — see "Optional but Behavior-Affecting Fields"` after the `model` line.

## Out of Scope

- Schema changes — all of these fields already exist in `orbit.task.add` params.
- Exposing `SpawnedFrom` / `Supersedes` / `RelatedTo` through sugar input fields — file a separate task if needed.
- Adding tag-vocabulary controls (allowlist, lints) — separate scope.
- Backfilling these fields on existing tasks.

## Notes

- Skill text is concise by convention; the new section should be ~10-15 lines of markdown, not a wall of text. The tier headings carry most of the signal.
- Cite the behavior anchors (`dispatch.rs` line for complexity, `task.rs` line for dependencies-ready) in the skill as inline references so a later skill-author can verify the claims without re-deriving them.

### Acceptance Criteria

- A new section titled "Optional but Behavior-Affecting Fields" is added to `crates/orbit-core/assets/skills/orbit-create-task/SKILL.md`, placed between "Operating Rules" and "Task Quality Standards".
- The new section is organized into three tiers (Nudge / Mention / Tags) and is no more than ~15 lines of markdown including headings.
- Tier 1 (Nudge) names `complexity` (specifically `"hard"`) and `dependencies`, each with a one-line trigger (when to set) and a one-line behavior anchor citing the source file path that proves the field changes engine behavior.
- Tier 2 (Mention) names `parent_id` and `source_task_id`, each marked as 'metadata' with no behavior claim beyond display / batch-relatedness.
- Tier 3 (Tags) is a single sentence noting semantic-search payoff and the tag-soup risk; no convention is mandated.
- The existing CLI and MCP example payloads at lines 84-113 are NOT expanded to include the optional fields — only a single trailing comment line (after `model`) points readers to the new section.
- The Operating Rules list is unchanged (no new required field).
- `make check-design-docs` passes (no design-doc decay introduced).
- Skill content reviewed for length: the file grows by no more than ~25 lines net.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Added the Optional but Behavior-Affecting Fields section between Operating Rules and Task Quality Standards, organized into Nudge, Mention, and Tags tiers.
- Added one optional-fields pointer comment after the model line in both task-add examples without expanding the payloads.

Assessment: Scope is docs-only; Operating Rules are unchanged and the skill file grows by 17 net lines.

Validation:
- git diff --check passed.
- make check-design-docs failed on pre-existing stale design docs unrelated to this docs-only change: activity-job, auditability, knowledge-graph, semantic-search, task-artifacts, and task-sync docs reference newer 2026-05-16 code.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-00070-6a08d7a6`
- Behind base: 0
- Ahead of base: 1