### PR TITLE
Fix policy dashboard denial run identity and make denials actionable

### DIFF
--- a/crates/orbit-cli/assets/dashboard/app.js
+++ b/crates/orbit-cli/assets/dashboard/app.js
@@ -66,7 +66,13 @@ let auditFilter = {
 let expandedAuditIds = new Set();
 let activeAuditSubtab = "events";
 let lastAuditPolicy = null;
-let policySort = { by_profile: "count", by_target: "count", by_run: "count", by_agent: "count" };
+let policySort = {
+  by_profile: "count",
+  by_target: "count",
+  by_run: "count",
+  by_execution: "count",
+  by_agent: "count",
+};
 
 // Health strip state
 let lastSummary = null;
@@ -1751,12 +1757,41 @@ function renderSparkline(buckets) {
 }
 
 const POLICY_TABLES = [
-  { id: "by_profile", label: "By Profile",  nameField: "name",   filterKey: "profile" },
-  { id: "by_target",  label: "By Target",   nameField: "name",   filterKey: null },
-  // Real JobRun ids from the v2 audit envelope. Click routes to Run Detail
-  // rather than filtering Events (audit Events only knows execution_id).
-  { id: "by_run",     label: "By Run",      nameField: "run_id", navigateTo: "run" },
-  { id: "by_agent",   label: "By Agent",    nameField: "agent",  filterKey: "role" },
+  {
+    id: "by_profile",
+    label: "By Profile",
+    nameField: "name",
+    header: "profile",
+    filterKey: "profile",
+  },
+  {
+    id: "by_target",
+    label: "By Target",
+    nameField: "name",
+    header: "target",
+    filterKey: null,
+  },
+  {
+    id: "by_run",
+    label: "By JobRun",
+    nameField: "run_id",
+    header: "job_run_id",
+    navigateTo: "job_run",
+  },
+  {
+    id: "by_execution",
+    label: "By Audit Invocation",
+    nameField: "execution_id",
+    header: "execution_id",
+    navigateTo: "audit_execution",
+  },
+  {
+    id: "by_agent",
+    label: "By Agent",
+    nameField: "agent",
+    header: "agent",
+    filterKey: "role",
+  },
 ];
 
 function renderPolicy(data) {
@@ -1771,6 +1806,12 @@ function renderPolicy(data) {
     ])]);
     return;
   }
+
+  const sections = [];
+  const recent = buildRecentDenials(data.recent_denials || []);
+  const causes = buildTopCauses(data.top_causes || []);
+  if (recent) sections.push(recent);
+  if (causes) sections.push(causes);
 
   const grid = el("div", { class: "policy-grid" });
   for (const tbl of POLICY_TABLES) {
@@ -1787,14 +1828,15 @@ function renderPolicy(data) {
     cell.appendChild(buildPolicyTable(tbl, rawRows, sortMode));
     grid.appendChild(cell);
   }
-  syncNodes(body, [grid]);
+  sections.push(grid);
+  syncNodes(body, sections);
 }
 
 function buildPolicyTable(spec, rows, sortMode) {
   const table = el("table", { class: "policy-table" });
   const thead = el("thead");
   const headRow = el("tr");
-  const nameTh = el("th", { text: spec.nameField });
+  const nameTh = el("th", { text: spec.header || spec.nameField });
   if (sortMode === "name") {
     const arrow = el("span", { class: "sort-arrow", text: "▼" });
     nameTh.appendChild(arrow);
@@ -1830,11 +1872,14 @@ function buildPolicyTable(spec, rows, sortMode) {
       const tr = el("tr", { title: name });
       tr.appendChild(el("td", { class: "value-name", text: name }));
       tr.appendChild(el("td", { class: "num", text: String(row.count || 0) }));
-      if (spec.navigateTo === "run") {
-        tr.style.cursor = "pointer";
+      if (spec.navigateTo === "job_run") {
+        tr.classList.add("clickable");
         tr.addEventListener("click", () => navigateToRun(name));
+      } else if (spec.navigateTo === "audit_execution") {
+        tr.classList.add("clickable");
+        tr.addEventListener("click", () => navigateToAuditExecution(name));
       } else if (spec.filterKey) {
-        tr.style.cursor = "pointer";
+        tr.classList.add("clickable");
         tr.addEventListener("click", () => {
           auditFilter[spec.filterKey] = name;
           activeAuditSubtab = "events";
@@ -1846,6 +1891,121 @@ function buildPolicyTable(spec, rows, sortMode) {
   }
   table.appendChild(tbody);
   return table;
+}
+
+function buildTopCauses(rows) {
+  if (!rows.length) return null;
+  const section = el("div", { class: "policy-section" });
+  section.appendChild(el("h5", { text: "Top Causes" }));
+  const table = el("table", { class: "policy-table policy-cause-table" });
+  const thead = el("thead");
+  const headRow = el("tr");
+  for (const label of ["cause", "target", "count", "latest"]) {
+    headRow.appendChild(el("th", { class: label === "count" ? "num" : "", text: label }));
+  }
+  thead.appendChild(headRow);
+  table.appendChild(thead);
+  const tbody = el("tbody");
+  for (const row of rows) {
+    const tr = el("tr");
+    tr.appendChild(el("td", {
+      class: "value-name",
+      text: row.cause || "-",
+      title: row.cause || "",
+    }));
+    tr.appendChild(el("td", {
+      class: "value-name muted",
+      text: row.target || "-",
+      title: row.target || "",
+    }));
+    tr.appendChild(el("td", { class: "num", text: String(row.count || 0) }));
+    tr.appendChild(el("td", {
+      class: "muted mono",
+      text: row.latest_ts ? fmtRelative(row.latest_ts) : "-",
+    }));
+    tbody.appendChild(tr);
+  }
+  table.appendChild(tbody);
+  section.appendChild(table);
+  return section;
+}
+
+function buildRecentDenials(rows) {
+  if (!rows.length) return null;
+  const section = el("div", { class: "policy-section" });
+  section.appendChild(el("h5", { text: "Recent Denials" }));
+  const table = el("table", { class: "policy-table policy-recent-table" });
+  const thead = el("thead");
+  const headRow = el("tr");
+  for (const label of ["time", "target", "cause", "identity", "details"]) {
+    headRow.appendChild(el("th", { text: label }));
+  }
+  thead.appendChild(headRow);
+  table.appendChild(thead);
+  const tbody = el("tbody");
+  for (const row of rows) {
+    const tr = el("tr");
+    tr.appendChild(el("td", {
+      class: "muted mono",
+      text: row.timestamp ? fmtRelative(row.timestamp) : "-",
+    }));
+    tr.appendChild(el("td", {
+      class: "value-name",
+      text: row.target || "-",
+      title: row.target || "",
+    }));
+    tr.appendChild(el("td", {
+      class: "value-name",
+      text: row.cause || row.denial_kind || "-",
+      title: row.cause || "",
+    }));
+    const identity = el("td");
+    identity.appendChild(buildPolicyIdentityAction(row));
+    tr.appendChild(identity);
+    const details = policyDetailText(row);
+    tr.appendChild(el("td", { class: "policy-detail", text: details, title: details }));
+    tbody.appendChild(tr);
+  }
+  table.appendChild(tbody);
+  section.appendChild(table);
+  return section;
+}
+
+function buildPolicyIdentityAction(row) {
+  const identityId = row.identity_id || row.job_run_id || row.execution_id || "";
+  if (!identityId) return el("span", { class: "muted", text: "-" });
+  const isJobRun = row.identity_type === "job_run" && row.job_run_id;
+  const label = isJobRun ? "JobRun" : "Audit";
+  const btn = el("button", {
+    class: "policy-link",
+    text: `${label} ${truncate(identityId, 18)}`,
+    title: identityId,
+  });
+  btn.addEventListener("click", (event) => {
+    event.stopPropagation();
+    if (isJobRun) navigateToRun(identityId);
+    else navigateToAuditExecution(identityId);
+  });
+  return btn;
+}
+
+function policyDetailText(row) {
+  const parts = [];
+  if (row.actor) parts.push(`actor ${row.actor}`);
+  const taskIds = row.requested_task_ids || [];
+  if (taskIds.length) parts.push(`tasks ${taskIds.join(", ")}`);
+  const files = row.requested_files || [];
+  if (files.length) {
+    const suffix = files.length > 2 ? " +" + (files.length - 2) : "";
+    parts.push(`files ${files.slice(0, 2).join(", ")}${suffix}`);
+  }
+  const conflicts = row.conflicts || [];
+  if (conflicts.length) {
+    const first = conflicts[0] || {};
+    const holder = [first.held_by, first.held_by_id].filter(Boolean).join(" ");
+    parts.push(holder ? `held by ${holder}` : `${conflicts.length} conflicts`);
+  }
+  return parts.join(" · ") || row.denial_kind || "-";
 }
 
 function refreshLabel() {
@@ -1860,6 +2020,22 @@ function navigateToRun(runId) {
   activeRunDetail = null;
   activeRunEvents = [];
   setActiveTab(`runs/${encodeURIComponent(runId)}`);
+}
+
+function navigateToAuditExecution(executionId) {
+  auditFilter = {
+    status: null,
+    q: "",
+    tool: null,
+    role: null,
+    execution_id: executionId,
+    profile: null,
+    since: null,
+    policyKind: null,
+  };
+  activeAuditSubtab = "events";
+  syncAuditControls();
+  window.location.hash = buildAuditHash();
 }
 
 /// Navigates to the Audit tab pre-filtered by `role` (audit `role` ≈ scoreboard

--- a/crates/orbit-cli/assets/dashboard/index.html
+++ b/crates/orbit-cli/assets/dashboard/index.html
@@ -1251,15 +1251,22 @@
         grid-template-columns: repeat(2, minmax(0, 1fr));
         gap: 1px;
         background: var(--border);
+        margin-top: 1px;
       }
       @media (max-width: 1100px) {
         .policy-grid { grid-template-columns: 1fr; }
       }
-      .policy-cell {
+      .policy-cell,
+      .policy-section {
         background: var(--bg-elev);
         padding: 0;
       }
-      .policy-cell h5 {
+      .policy-section {
+        border-bottom: 1px solid var(--border);
+        overflow-x: auto;
+      }
+      .policy-cell h5,
+      .policy-section h5 {
         margin: 0;
         padding: 10px 16px;
         font-family: var(--font-sans);
@@ -1293,7 +1300,9 @@
       }
       table.policy-table th.num { text-align: right; }
       table.policy-table th .sort-arrow { color: var(--accent); margin-left: 4px; }
-      table.policy-table tbody tr { cursor: pointer; transition: background 0.15s ease; }
+      table.policy-table tbody tr { transition: background 0.15s ease; }
+      table.policy-table tbody tr.clickable { cursor: pointer; }
+      table.policy-table tbody tr.clickable:hover,
       table.policy-table tbody tr:hover { background: rgba(255, 255, 255, 0.04); }
       table.policy-table td.value-name {
         max-width: 360px;
@@ -1302,9 +1311,42 @@
         font-family: var(--font-mono);
         color: var(--fg);
       }
+      table.policy-table td.muted {
+        color: var(--fg-dim);
+      }
+      table.policy-table td.mono {
+        font-family: var(--font-mono);
+      }
+      table.policy-table td.policy-detail {
+        max-width: 480px;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        color: var(--fg-dim);
+      }
       table.policy-table td.num {
         text-align: right;
         font-family: var(--font-mono);
+        color: var(--accent-hover);
+      }
+      table.policy-table.policy-recent-table th,
+      table.policy-table.policy-recent-table td,
+      table.policy-table.policy-cause-table th,
+      table.policy-table.policy-cause-table td {
+        white-space: nowrap;
+      }
+      .policy-link {
+        appearance: none;
+        border: 1px solid var(--border);
+        background: rgba(110, 159, 255, 0.08);
+        color: var(--accent);
+        border-radius: 2px;
+        padding: 2px 6px;
+        font-family: var(--font-mono);
+        font-size: 11px;
+        cursor: pointer;
+      }
+      .policy-link:hover {
+        border-color: var(--accent);
         color: var(--accent-hover);
       }
 

--- a/crates/orbit-cli/src/command/web/api/denials.rs
+++ b/crates/orbit-cli/src/command/web/api/denials.rs
@@ -27,8 +27,34 @@ pub(super) struct DenialRow {
     kind: &'static str,
     profile: String,
     target: String,
-    run_id: String,
+    job_run_id: Option<String>,
+    execution_id: Option<String>,
     agent: String,
+    timestamp: Option<DateTime<Utc>>,
+    diagnostics: DenialDiagnostics,
+}
+
+#[derive(Debug, Clone)]
+struct DenialDiagnostics {
+    denial_kind: String,
+    cause: String,
+    actor: Option<String>,
+    requested_task_ids: Vec<String>,
+    requested_files: Vec<String>,
+    conflicts: Vec<Value>,
+}
+
+impl Default for DenialDiagnostics {
+    fn default() -> Self {
+        Self {
+            denial_kind: "unknown".to_string(),
+            cause: "unknown".to_string(),
+            actor: None,
+            requested_task_ids: Vec::new(),
+            requested_files: Vec::new(),
+            conflicts: Vec::new(),
+        }
+    }
 }
 
 impl DenialRow {
@@ -104,8 +130,8 @@ pub(super) fn scan_v2_loop_denials(
             let run_id = value
                 .get("run_id")
                 .and_then(Value::as_str)
-                .unwrap_or("")
-                .to_string();
+                .filter(|s| !s.is_empty())
+                .map(ToOwned::to_owned);
             let agent = value
                 .get("agent_identity")
                 .and_then(Value::as_str)
@@ -147,10 +173,13 @@ pub(super) fn scan_v2_loop_denials(
             }
             out.push(DenialRow {
                 kind,
+                diagnostics: v2_denial_diagnostics(kind, &profile, &target),
                 profile,
                 target,
-                run_id,
+                job_run_id: run_id,
+                execution_id: None,
                 agent,
+                timestamp: ts,
             });
         }
     }
@@ -201,16 +230,17 @@ fn scan_sqlite_denials(
 
 fn sqlite_denial_row(event: &orbit_core::AuditEvent) -> DenialRow {
     let kind = sqlite_denial_kind(event);
+    let arguments_json = parse_arguments_json(event.arguments_json.as_deref());
+    let diagnostics = sqlite_denial_diagnostics(event, kind, arguments_json.as_ref());
     DenialRow {
         kind,
-        profile: sqlite_denial_profile(event, kind),
-        target: sqlite_denial_target(event, kind),
-        run_id: event
-            .job_run_id
-            .clone()
-            .filter(|value| !value.is_empty())
-            .unwrap_or_else(|| event.execution_id.clone()),
+        profile: sqlite_denial_profile(event, kind, arguments_json.as_ref()),
+        target: sqlite_denial_target(event, kind, arguments_json.as_ref()),
+        job_run_id: event.job_run_id.clone().filter(|value| !value.is_empty()),
+        execution_id: Some(event.execution_id.clone()).filter(|value| !value.is_empty()),
         agent: event.role.clone(),
+        timestamp: Some(event.timestamp),
+        diagnostics,
     }
 }
 
@@ -223,11 +253,15 @@ fn sqlite_denial_kind(event: &orbit_core::AuditEvent) -> &'static str {
     }
 }
 
-fn sqlite_denial_profile(event: &orbit_core::AuditEvent, kind: &str) -> String {
+fn sqlite_denial_profile(
+    event: &orbit_core::AuditEvent,
+    kind: &str,
+    arguments_json: Option<&Value>,
+) -> String {
     if kind != "fs" {
         return SQLITE_TOOL_DENIAL_PROFILE.to_string();
     }
-    if let Some(profile) = arguments_json_profile(event.arguments_json.as_deref()) {
+    if let Some(profile) = arguments_json_profile(arguments_json) {
         return profile;
     }
     if let Some(profile) = extract_fs_profile_from_policy_message(event.error_message.as_deref()) {
@@ -236,11 +270,25 @@ fn sqlite_denial_profile(event: &orbit_core::AuditEvent, kind: &str) -> String {
     SQLITE_FS_BOUNDARY_PROFILE.to_string()
 }
 
-fn sqlite_denial_target(event: &orbit_core::AuditEvent, kind: &str) -> String {
+fn sqlite_denial_target(
+    event: &orbit_core::AuditEvent,
+    kind: &str,
+    arguments_json: Option<&Value>,
+) -> String {
     if kind == "fs"
         && let Some(path) = extract_fs_path_from_policy_message(event.error_message.as_deref())
     {
         return path;
+    }
+    if is_task_lock_reserve_denial(event) {
+        let requested_files = string_array_field(arguments_json, "files");
+        if let Some(file) = requested_files.first() {
+            return file.clone();
+        }
+        let task_ids = string_array_field(arguments_json, "task_ids");
+        if !task_ids.is_empty() {
+            return task_ids.join(", ");
+        }
     }
     event
         .target_id
@@ -250,11 +298,13 @@ fn sqlite_denial_target(event: &orbit_core::AuditEvent, kind: &str) -> String {
         .unwrap_or_else(|| event.command.clone())
 }
 
-fn arguments_json_profile(raw: Option<&str>) -> Option<String> {
-    let raw = raw?;
-    let value = serde_json::from_str::<Value>(raw).ok()?;
+fn parse_arguments_json(raw: Option<&str>) -> Option<Value> {
+    serde_json::from_str(raw?).ok()
+}
+
+fn arguments_json_profile(value: Option<&Value>) -> Option<String> {
     const KEYS: &[&str] = &["fsProfile", "fs_profile", "profile"];
-    let obj = value.as_object()?;
+    let obj = value?.as_object()?;
     for key in KEYS {
         if let Some(Value::String(found)) = obj.get(*key)
             && !found.is_empty()
@@ -263,6 +313,114 @@ fn arguments_json_profile(raw: Option<&str>) -> Option<String> {
         }
     }
     None
+}
+
+fn v2_denial_diagnostics(kind: &str, profile: &str, target: &str) -> DenialDiagnostics {
+    match kind {
+        "fs" => DenialDiagnostics {
+            denial_kind: "fs_policy".to_string(),
+            cause: if profile.is_empty() {
+                "fs_denied".to_string()
+            } else {
+                profile.to_string()
+            },
+            requested_files: if target.is_empty() {
+                Vec::new()
+            } else {
+                vec![target.to_string()]
+            },
+            ..DenialDiagnostics::default()
+        },
+        _ => DenialDiagnostics {
+            denial_kind: "tool_policy".to_string(),
+            cause: if target.is_empty() {
+                "tool_denied".to_string()
+            } else {
+                target.to_string()
+            },
+            ..DenialDiagnostics::default()
+        },
+    }
+}
+
+fn sqlite_denial_diagnostics(
+    event: &orbit_core::AuditEvent,
+    kind: &str,
+    arguments_json: Option<&Value>,
+) -> DenialDiagnostics {
+    if is_task_lock_reserve_denial(event) {
+        let conflicts = value_array_field(arguments_json, "conflicts");
+        return DenialDiagnostics {
+            denial_kind: "task_lock_reserve".to_string(),
+            cause: if conflicts.is_empty() {
+                "task_lock_denied".to_string()
+            } else {
+                "task_lock_conflict".to_string()
+            },
+            actor: string_field(arguments_json, "actor"),
+            requested_task_ids: string_array_field(arguments_json, "task_ids"),
+            requested_files: string_array_field(arguments_json, "files"),
+            conflicts,
+        };
+    }
+
+    if kind == "fs" {
+        let profile = sqlite_denial_profile(event, kind, arguments_json);
+        return DenialDiagnostics {
+            denial_kind: "fs_policy".to_string(),
+            cause: profile,
+            requested_files: extract_fs_path_from_policy_message(event.error_message.as_deref())
+                .into_iter()
+                .collect(),
+            ..DenialDiagnostics::default()
+        };
+    }
+
+    DenialDiagnostics {
+        denial_kind: "tool_policy".to_string(),
+        cause: event
+            .tool_name
+            .clone()
+            .or_else(|| event.subcommand.clone())
+            .unwrap_or_else(|| "tool_denied".to_string()),
+        ..DenialDiagnostics::default()
+    }
+}
+
+fn is_task_lock_reserve_denial(event: &orbit_core::AuditEvent) -> bool {
+    event.tool_name.as_deref() == Some("orbit.task.locks.reserve")
+        || event.command == "task.locks.reserve.denied"
+}
+
+fn string_field(value: Option<&Value>, key: &str) -> Option<String> {
+    value?
+        .get(key)
+        .and_then(Value::as_str)
+        .filter(|s| !s.is_empty())
+        .map(ToOwned::to_owned)
+}
+
+fn string_array_field(value: Option<&Value>, key: &str) -> Vec<String> {
+    value
+        .and_then(|value| value.get(key))
+        .and_then(Value::as_array)
+        .map(|items| {
+            items
+                .iter()
+                .filter_map(Value::as_str)
+                .filter(|s| !s.is_empty())
+                .map(ToOwned::to_owned)
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+fn value_array_field(value: Option<&Value>, key: &str) -> Vec<Value> {
+    value
+        .and_then(|value| value.get(key))
+        .and_then(Value::as_array)
+        .cloned()
+        .unwrap_or_default()
 }
 
 fn extract_fs_profile_from_policy_message(message: Option<&str>) -> Option<String> {
@@ -365,14 +523,26 @@ fn denials_payload(rows: &[DenialRow], kind: Option<&str>, since: Option<DateTim
 
     let by_profile = aggregate_by(&filtered, |r| r.profile.clone());
     let by_target = aggregate_by(&filtered, |r| r.target.clone());
-    let by_run = aggregate_by(&filtered, |r| r.run_id.clone());
+    let by_run = aggregate_by_optional(&filtered, |r| r.job_run_id.clone());
+    let by_execution = aggregate_by_optional(&filtered, |r| {
+        if r.job_run_id.is_none() {
+            r.execution_id.clone()
+        } else {
+            None
+        }
+    });
     let by_agent = aggregate_by(&filtered, |r| r.agent.clone());
+    let top_causes = top_causes_to_value(&filtered);
+    let recent_denials = recent_denials_to_value(&filtered, 12);
 
     json!({
         "by_profile": rows_to_value(&by_profile, "name"),
         "by_target": rows_to_value(&by_target, "name"),
         "by_run": rows_to_value(&by_run, "run_id"),
+        "by_execution": rows_to_value(&by_execution, "execution_id"),
         "by_agent": rows_to_value(&by_agent, "agent"),
+        "top_causes": top_causes,
+        "recent_denials": recent_denials,
         "total": filtered.len(),
         "kind": kind,
         "since": since.map(|s| s.to_rfc3339()),
@@ -392,9 +562,18 @@ fn aggregate_by<F>(rows: &[&DenialRow], key: F) -> Vec<(String, i64)>
 where
     F: Fn(&DenialRow) -> String,
 {
+    aggregate_by_optional(rows, |row| Some(key(row)))
+}
+
+fn aggregate_by_optional<F>(rows: &[&DenialRow], key: F) -> Vec<(String, i64)>
+where
+    F: Fn(&DenialRow) -> Option<String>,
+{
     let mut counts: BTreeMap<String, i64> = BTreeMap::new();
     for row in rows {
-        let k = key(row);
+        let Some(k) = key(row) else {
+            continue;
+        };
         if k.is_empty() {
             continue;
         }
@@ -411,6 +590,103 @@ fn rows_to_value(rows: &[(String, i64)], key_label: &str) -> Value {
             .map(|(name, count)| json!({ key_label: name, "count": count }))
             .collect(),
     )
+}
+
+#[derive(Debug, Default)]
+struct CauseAggregate {
+    count: i64,
+    latest: Option<DateTime<Utc>>,
+    targets: BTreeMap<String, i64>,
+}
+
+fn top_causes_to_value(rows: &[&DenialRow]) -> Value {
+    let mut by_cause: BTreeMap<String, CauseAggregate> = BTreeMap::new();
+    for row in rows {
+        let cause = row.diagnostics.cause.clone();
+        if cause.is_empty() {
+            continue;
+        }
+        let entry = by_cause.entry(cause).or_default();
+        entry.count += 1;
+        if row.timestamp > entry.latest {
+            entry.latest = row.timestamp;
+        }
+        if !row.target.is_empty() {
+            *entry.targets.entry(row.target.clone()).or_insert(0) += 1;
+        }
+    }
+
+    let mut out: Vec<_> = by_cause.into_iter().collect();
+    out.sort_by(|(left_cause, left), (right_cause, right)| {
+        right
+            .count
+            .cmp(&left.count)
+            .then_with(|| right.latest.cmp(&left.latest))
+            .then_with(|| left_cause.cmp(right_cause))
+    });
+    Value::Array(
+        out.into_iter()
+            .take(8)
+            .map(|(cause, aggregate)| {
+                let target = aggregate
+                    .targets
+                    .into_iter()
+                    .max_by(|left, right| left.1.cmp(&right.1).then_with(|| right.0.cmp(&left.0)))
+                    .map(|(target, _count)| target);
+                json!({
+                    "cause": cause,
+                    "target": target,
+                    "count": aggregate.count,
+                    "latest_ts": aggregate.latest.map(|ts| ts.to_rfc3339()),
+                })
+            })
+            .collect(),
+    )
+}
+
+fn recent_denials_to_value(rows: &[&DenialRow], limit: usize) -> Value {
+    let mut rows = rows.to_vec();
+    rows.sort_by(|left, right| {
+        right
+            .timestamp
+            .cmp(&left.timestamp)
+            .then_with(|| left.target.cmp(&right.target))
+    });
+    Value::Array(
+        rows.into_iter()
+            .take(limit)
+            .map(denial_row_to_value)
+            .collect(),
+    )
+}
+
+fn denial_row_to_value(row: &DenialRow) -> Value {
+    let (identity_type, identity_id) = if let Some(job_run_id) = row.job_run_id.as_deref() {
+        ("job_run", Some(job_run_id))
+    } else if let Some(execution_id) = row.execution_id.as_deref() {
+        ("audit_execution", Some(execution_id))
+    } else {
+        ("none", None)
+    };
+
+    json!({
+        "kind": row.kind,
+        "profile": row.profile.clone(),
+        "target": row.target.clone(),
+        "run_id": row.job_run_id.clone(),
+        "job_run_id": row.job_run_id.clone(),
+        "execution_id": row.execution_id.clone(),
+        "identity_type": identity_type,
+        "identity_id": identity_id,
+        "agent": row.agent.clone(),
+        "timestamp": row.timestamp.map(|ts| ts.to_rfc3339()),
+        "denial_kind": row.diagnostics.denial_kind.clone(),
+        "cause": row.diagnostics.cause.clone(),
+        "actor": row.diagnostics.actor.clone(),
+        "requested_task_ids": row.diagnostics.requested_task_ids.clone(),
+        "requested_files": row.diagnostics.requested_files.clone(),
+        "conflicts": row.diagnostics.conflicts.clone(),
+    })
 }
 
 #[cfg(test)]
@@ -511,5 +787,134 @@ mod tests {
         .expect("collect filtered sqlite denials");
         assert_eq!(sqlite_only.len(), 1);
         assert_eq!(sqlite_only[0].target(), "/usr/bin/false");
+    }
+
+    #[test]
+    fn denials_payload_distinguishes_job_runs_from_audit_executions() {
+        let runtime = OrbitRuntime::in_memory().expect("build runtime");
+        let since = Utc::now() - Duration::minutes(5);
+        runtime
+            .record_audit_event(&orbit_core::AuditEventInsertParams {
+                execution_id: "exec-linked-to-run".to_string(),
+                command: "tool".to_string(),
+                subcommand: Some("orbit.task.update".to_string()),
+                tool_name: Some("orbit.task.update".to_string()),
+                target_type: Some("task".to_string()),
+                target_id: Some("ORB-00001".to_string()),
+                role: "codex".to_string(),
+                status: AuditEventStatus::Denied,
+                exit_code: 1,
+                duration_ms: 7,
+                working_directory: "/workspace".to_string(),
+                arguments_json: None,
+                stdout_truncated: None,
+                stderr_truncated: None,
+                error_message: Some("denied by policy".to_string()),
+                host: None,
+                pid: 123,
+                session_id: None,
+                task_id: Some("ORB-00001".to_string()),
+                job_run_id: Some("jrun-real-policy".to_string()),
+                activity_id: Some("agent_implement".to_string()),
+                step_index: Some(0),
+            })
+            .expect("record linked denial");
+        runtime
+            .record_audit_event(&orbit_core::AuditEventInsertParams {
+                execution_id: "audit-task-locks-reserve-denied-test".to_string(),
+                command: "task.locks.reserve.denied".to_string(),
+                subcommand: None,
+                tool_name: Some("orbit.task.locks.reserve".to_string()),
+                target_type: Some("task_reservation".to_string()),
+                target_id: None,
+                role: "admin".to_string(),
+                status: AuditEventStatus::Denied,
+                exit_code: 1,
+                duration_ms: 0,
+                working_directory: "/workspace".to_string(),
+                arguments_json: Some(
+                    json!({
+                        "actor": "codex / gpt-5.5",
+                        "task_ids": ["ORB-00001"],
+                        "files": ["file:crates/orbit-cli/src/lib.rs"],
+                        "conflicts": [{
+                            "file": "file:crates/orbit-cli/src/lib.rs",
+                            "held_by": "task",
+                            "held_by_id": "ORB-00002"
+                        }]
+                    })
+                    .to_string(),
+                ),
+                stdout_truncated: None,
+                stderr_truncated: None,
+                error_message: None,
+                host: None,
+                pid: 123,
+                session_id: None,
+                task_id: None,
+                job_run_id: None,
+                activity_id: None,
+                step_index: None,
+            })
+            .expect("record task-lock denial");
+
+        let rows = collect_denial_rows(&runtime, Some(since), None, None).expect("collect denials");
+        let payload = denials_payload(&rows, None, Some(since));
+
+        let by_run = payload["by_run"].as_array().expect("by_run array");
+        assert_eq!(by_run.len(), 1);
+        assert_eq!(by_run[0]["run_id"], "jrun-real-policy");
+        assert!(
+            !payload["by_run"]
+                .to_string()
+                .contains("audit-task-locks-reserve-denied-test"),
+            "audit execution IDs must not be rendered as JobRun IDs"
+        );
+
+        let by_execution = payload["by_execution"]
+            .as_array()
+            .expect("by_execution array");
+        assert_eq!(by_execution.len(), 1);
+        assert_eq!(
+            by_execution[0]["execution_id"],
+            "audit-task-locks-reserve-denied-test"
+        );
+
+        let recent = payload["recent_denials"]
+            .as_array()
+            .expect("recent_denials array");
+        let invocation = recent
+            .iter()
+            .find(|row| row["execution_id"] == "audit-task-locks-reserve-denied-test")
+            .expect("task-lock row");
+        assert_eq!(invocation["identity_type"], "audit_execution");
+        assert_eq!(
+            invocation["identity_id"],
+            "audit-task-locks-reserve-denied-test"
+        );
+        assert!(invocation["job_run_id"].is_null());
+        assert!(invocation["run_id"].is_null());
+        assert_eq!(invocation["denial_kind"], "task_lock_reserve");
+        assert_eq!(invocation["cause"], "task_lock_conflict");
+        assert_eq!(invocation["actor"], "codex / gpt-5.5");
+        assert_eq!(invocation["requested_task_ids"][0], "ORB-00001");
+        assert_eq!(
+            invocation["requested_files"][0],
+            "file:crates/orbit-cli/src/lib.rs"
+        );
+        assert_eq!(invocation["conflicts"][0]["held_by_id"], "ORB-00002");
+
+        let linked = recent
+            .iter()
+            .find(|row| row["job_run_id"] == "jrun-real-policy")
+            .expect("linked JobRun row");
+        assert_eq!(linked["identity_type"], "job_run");
+        assert_eq!(linked["identity_id"], "jrun-real-policy");
+
+        assert!(
+            payload["top_causes"]
+                .to_string()
+                .contains("task_lock_conflict")
+        );
     }
 }


### PR DESCRIPTION
## Task

[ORB-00066](https://orbit-cli.com/tasks/ORB-00066) — Fix policy dashboard denial run identity and make denials actionable

### Description

## Problem
The dashboard Audit > Policy tab labels denial groups as `By Run` and routes clicks to Run Detail, but the denials API currently collapses real JobRun IDs and CLI audit execution IDs into the same `run_id` field. When a denial has no `job_run_id`, the API falls back to `execution_id`, producing synthetic values such as `audit-task-locks-reserve-denied-...`; clicking those opens an empty Run Detail view.

The tab is also low-signal: it shows profile, target, run, and agent counts, but does not explain what was denied, why it was denied, or whether a row is linked to a real JobRun or only to an audit invocation.

## Why It Matters
Operators use the policy dashboard to diagnose why agents are blocked. Fake run links waste time and make the audit surface feel untrustworthy. Task-lock denials already carry useful details such as requested files, task IDs, and conflicts; the dashboard should expose those details instead of hiding them behind opaque IDs.

## Constraints / Notes
- Preserve existing Audit Events filtering by `execution_id`; do not reinterpret `execution_id` as a JobRun ID.
- Only navigate to Run Detail for IDs that are confirmed real JobRun IDs.
- Keep API changes backwards-compatible where practical, but prefer explicit fields over the current overloaded `run_id`.
- Task-lock denial payloads are emitted from `orbit.task.locks.reserve` and include `task_ids`, `files`, and `conflicts` in `arguments_json`.

### Acceptance Criteria

- The denials API no longer falls back from missing `job_run_id` to `execution_id` when constructing run-linked policy rows; response data distinguishes real `job_run_id` values from audit `execution_id` values.
- The Policy tab no longer displays synthetic audit execution IDs under a clickable JobRun-oriented `By Run` table; real JobRun IDs still navigate to Run Detail, while invocation-only denials filter or link to Audit Events by `execution_id`.
- Policy denial rows expose actionable diagnostic fields for at least task-lock reserve denials: requested task IDs, requested files, conflicts or held-by information, actor or agent, and denial kind/cause.
- The dashboard presents a more informative policy view than the current four count-only tables, for example by adding a Recent Denials or Top Causes section that shows target, reason/cause, identity link type, and count/time context.
- Deterministic tests or fixtures cover mixed real JobRun denials and invocation-only task-lock denials, verifying that invocation-only IDs do not open empty Run Detail pages.
- `make ci-fast` passes after the implementation.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Split policy denial identity into explicit job_run_id and execution_id fields; by_run now aggregates only real JobRun IDs, while invocation-only rows aggregate under by_execution.
- Extract task-lock reserve denial diagnostics from arguments_json, including actor, requested task IDs/files, conflicts, denial kind, cause, and timestamp context.
- Updated the dashboard Policy tab with Recent Denials, Top Causes, By JobRun, and By Audit Invocation views; only real JobRun identities navigate to Run Detail, and audit invocation identities route to Audit Events filtered by execution_id.
- Added deterministic mixed JobRun/task-lock coverage proving audit execution IDs do not appear as JobRun links.

Assessment: The scoped API/UI behavior is implemented and validated with focused tests plus ci-fast.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-00066-6a08d683`
- Behind base: 0
- Ahead of base: 1