### PR TITLE
Add Knowledge tab and Learnings subtab to dashboard

### DIFF
--- a/crates/orbit-cli/assets/dashboard/app.js
+++ b/crates/orbit-cli/assets/dashboard/app.js
@@ -25,6 +25,7 @@ const JOB_RUN_LIMIT = positiveIntParam("runs", 25);
 const DIAG_LIMIT = positiveIntParam("diag", 50);
 const AUDIT_LIMIT = positiveIntParam("audit", 50);
 const RUN_EVENTS_LIMIT = positiveIntParam("events", 100);
+const LEARNING_LIMIT = positiveIntParam("learnings", 100);
 
 const AUDIT_STATUSES = ["success", "failure", "denied"];
 const CANCELLABLE_RUN_STATES = new Set(["pending", "running"]);
@@ -38,12 +39,16 @@ let activeStatuses = new Set(
 let lastTasks = [];
 let lastRuns = [];
 let lastDiagnostics = { metrics: [], errors: [] };
+let lastLearningPayload = { stats: {}, items: [] };
 let activeTab = "tasks";
 let activeDiagSubtab = "runs";
+let activeKnowledgeSubtab = "learnings";
 let runSort = { key: "when", dir: "desc" };
 let expandedTaskIds = new Set();
 let isRefreshing = false;
 let taskActionNotice = null;
+let activeLearningId = null;
+let learningSearchQuery = "";
 
 // Audit tab state
 let lastAudit = [];
@@ -126,11 +131,17 @@ function fetchJson(path) {
     });
 }
 
-function postJson(path) {
-  return fetch(path, {
+function postJson(path, body) {
+  const headers = { accept: "application/json" };
+  const opts = {
     method: "POST",
-    headers: { accept: "application/json" },
-  }).then(async (res) => {
+    headers,
+  };
+  if (body !== undefined) {
+    headers["content-type"] = "application/json";
+    opts.body = JSON.stringify(body);
+  }
+  return fetch(path, opts).then(async (res) => {
     const text = await res.text();
     const body = text ? JSON.parse(text) : {};
     if (!res.ok) {
@@ -1160,6 +1171,169 @@ function renderScoreboard(summary) {
   syncNodes(tbody, Array.from(frag.children));
 }
 
+function evidenceCount(learning) {
+  return Array.isArray(learning && learning.evidence) ? learning.evidence.length : 0;
+}
+
+function learningScopeNodes(learning) {
+  const scope = (learning && learning.scope) || {};
+  const paths = Array.isArray(scope.paths) ? scope.paths : [];
+  const tags = Array.isArray(scope.tags) ? scope.tags : [];
+  const chips = [];
+  for (const tag of tags.slice(0, 3)) {
+    chips.push(el("span", { class: "pill", text: `#${tag}`, title: tag }));
+  }
+  for (const path of paths.slice(0, Math.max(0, 4 - chips.length))) {
+    chips.push(el("span", { class: "pill", text: truncate(path, 28), title: path }));
+  }
+  if (paths.length + tags.length > chips.length) {
+    chips.push(el("span", { class: "pill", text: `+${paths.length + tags.length - chips.length}` }));
+  }
+  if (chips.length === 0) chips.push(el("span", { class: "pill", text: "global" }));
+  return chips;
+}
+
+function renderLearningStats(stats = {}) {
+  $("learning-total-value").textContent = formatBigInt(stats.total || 0);
+  $("learning-superseded-value").textContent = formatBigInt(stats.superseded || 0);
+  $("learning-last-indexed-value").textContent = stats.last_indexed
+    ? fmtTimestamp(stats.last_indexed)
+    : "-";
+}
+
+function renderLearnings(payload) {
+  const body = $("learnings-body");
+  if (!body) return;
+  const items = Array.isArray(payload && payload.items) ? payload.items : [];
+  const stats = (payload && payload.stats) || {};
+  renderLearningStats(stats);
+  $("knowledge-count").textContent = `${items.length}/${stats.total || items.length}`;
+
+  if (items.length > 0 && !items.some((item) => item.id === activeLearningId)) {
+    activeLearningId = items[0].id;
+  }
+  if (items.length === 0) activeLearningId = null;
+
+  if (items.length === 0) {
+    syncNodes(body, [el("div", { class: "empty-state" }, [
+      el("div", { class: "icon", text: "✧" }),
+      el("div", { class: "text", text: "No learnings match the current filter." }),
+    ])]);
+    renderLearningDetail(null);
+    return;
+  }
+
+  const frag = document.createDocumentFragment();
+  const header = el("div", { class: "learning-row header" }, [
+    el("span", { text: "id" }),
+    el("span", { text: "scope" }),
+    el("span", { class: "evidence", text: "evidence" }),
+    el("span", { text: "status" }),
+    el("span", { class: "updated", text: "updated" }),
+  ]);
+  header.dataset.key = "learning-header";
+  header.dataset.hash = "learning-header";
+  frag.appendChild(header);
+
+  for (const learning of items) {
+    const row = el("div", { class: "learning-row", title: learning.summary || learning.id }, [
+      el("span", { class: "id", text: learning.id, title: learning.id }),
+      el("span", { class: "scope" }, learningScopeNodes(learning)),
+      el("span", { class: "evidence", text: String(evidenceCount(learning)) }),
+      statusPill(learning.status || "active"),
+      el("span", { class: "updated", text: fmtTimestamp(learning.updated_at), title: fmtAbsTime(learning.updated_at) }),
+    ]);
+    row.dataset.key = `learning-${learning.id}`;
+    row.dataset.hash = `${learning.id}-${learning.status}-${learning.updated_at}-${activeLearningId === learning.id}`;
+    if (activeLearningId === learning.id) row.classList.add("active");
+    row.addEventListener("click", () => {
+      activeLearningId = learning.id;
+      renderLearnings(lastLearningPayload);
+    });
+    frag.appendChild(row);
+  }
+
+  syncNodes(body, Array.from(frag.children));
+  renderLearningDetail(items.find((item) => item.id === activeLearningId) || items[0]);
+}
+
+function renderLearningDetail(learning) {
+  const detail = $("learning-detail");
+  if (!detail) return;
+  const count = $("learning-detail-count");
+  if (!learning) {
+    if (count) count.textContent = "-";
+    syncNodes(detail, [el("div", { class: "empty-state" }, [
+      el("div", { class: "icon", text: "✧" }),
+      el("div", { class: "text", text: "No learning selected." }),
+    ])]);
+    return;
+  }
+  if (count) count.textContent = learning.status || "active";
+
+  const title = el("div", { class: "field-block" }, [
+    el("h4", { text: learning.id }),
+    el("div", { class: "markdown-body", text: learning.summary || "" }),
+  ]);
+
+  const meta = el("div", { class: "learning-detail-meta" });
+  const addMeta = (label, value) => {
+    if (value == null || value === "") return;
+    meta.appendChild(el("span", {}, [
+      document.createTextNode(`${label}: `),
+      el("span", { class: "value", text: String(value) }),
+    ]));
+  };
+  addMeta("status", learning.status || "active");
+  addMeta("evidence", evidenceCount(learning));
+  addMeta("updated", fmtAbsTime(learning.updated_at));
+  addMeta("superseded_by", learning.superseded_by);
+  addMeta("supersedes", learning.supersedes);
+
+  const scopeBlock = el("div", { class: "field-block" }, [
+    el("h4", { text: "scope" }),
+    el("div", { class: "learning-detail-scope" }, learningScopeNodes(learning)),
+  ]);
+
+  const bodyBlock = el("div", { class: "field-block" }, [
+    el("h4", { text: "body" }),
+    el("pre", { class: "learning-detail-body", text: learning.body || "" }),
+  ]);
+
+  const actions = el("div", { class: "actions" });
+  const supersede = el("button", {
+    class: "action archive",
+    text: "Supersede",
+    title: `Supersede ${learning.id}`,
+  });
+  supersede.disabled = learning.status === "superseded";
+  supersede.addEventListener("click", () => {
+    const by = window.prompt(`Replacement learning ID for ${learning.id}`);
+    if (!by || !by.trim()) return;
+    supersedeLearning(learning, by.trim(), supersede, detail);
+  });
+  actions.appendChild(supersede);
+
+  syncNodes(detail, [title, meta, scopeBlock, bodyBlock, actions]);
+}
+
+async function supersedeLearning(learning, by, btn, detail) {
+  const oldText = btn.textContent;
+  btn.disabled = true;
+  btn.innerHTML = `<span class="spinner"></span>wait`;
+  for (const node of detail.querySelectorAll(".action-error")) node.remove();
+  try {
+    await postJson(`/api/learnings/${encodeURIComponent(learning.id)}/supersede`, { by });
+    activeLearningId = learning.id;
+    await fetchAndRenderLearnings();
+  } catch (e) {
+    detail.prepend(el("div", { class: "action-error", text: e.message || "supersede failed" }));
+  } finally {
+    btn.disabled = false;
+    btn.textContent = oldText;
+  }
+}
+
 function refreshChips() {
   for (const chip of document.querySelectorAll("#task-filter .chip")) {
     const status = chip.dataset.status;
@@ -1206,10 +1380,24 @@ function wireSearch() {
   });
 }
 
-const TABS = ["tasks", "scoreboard", "audit", "diagnostics", "run-detail"];
+function wireLearningSearch() {
+  const input = $("learning-search");
+  if (!input) return;
+  let debounce = null;
+  input.addEventListener("input", (e) => {
+    learningSearchQuery = e.target.value.trim();
+    if (debounce) clearTimeout(debounce);
+    debounce = setTimeout(() => {
+      if (activeTab === "knowledge") fetchAndRenderLearnings().catch(console.error);
+    }, 200);
+  });
+}
+
+const TABS = ["tasks", "scoreboard", "audit", "diagnostics", "knowledge", "run-detail"];
 const DIAG_SUBTABS = ["runs", "metrics", "errors"];
 const RUN_DETAIL_SUBTABS = ["steps", "events"];
 const AUDIT_SUBTABS = ["events", "policy"];
+const KNOWLEDGE_SUBTABS = ["learnings"];
 
 function parseHashRoute(raw) {
   const trimmed = String(raw || "").replace(/^#/, "");
@@ -1292,6 +1480,10 @@ function setActiveTab(raw, opts = {}) {
     hash = `#runs/${encodeURIComponent(activeRunId || "")}` +
       (activeRunSubtab !== "steps" ? `/${activeRunSubtab}` : "");
     if (query.get("step") != null) hash += `?step=${encodeURIComponent(query.get("step"))}`;
+  } else if (top === "knowledge") {
+    const sub = KNOWLEDGE_SUBTABS.includes(segments[1]) ? segments[1] : activeKnowledgeSubtab;
+    setKnowledgeSubtab(sub);
+    hash = sub === "learnings" ? "#knowledge/learnings" : `#knowledge/${sub}`;
   } else {
     hash = `#${top}`;
   }
@@ -1392,6 +1584,14 @@ function setDiagSubtab(name) {
   }
 }
 
+function setKnowledgeSubtab(name) {
+  if (!KNOWLEDGE_SUBTABS.includes(name)) name = "learnings";
+  activeKnowledgeSubtab = name;
+  for (const btn of document.querySelectorAll("#knowledge-subtabs .subtab")) {
+    btn.classList.toggle("active", btn.dataset.subtab === name);
+  }
+}
+
 function initTabs() {
   for (const tab of document.querySelectorAll(".tab")) {
     tab.addEventListener("click", () => setActiveTab(tab.dataset.tab, { refresh: false }));
@@ -1421,6 +1621,11 @@ function initTabs() {
         refreshDashboard();
       }
     });
+  }
+  for (const btn of document.querySelectorAll("#knowledge-subtabs .subtab")) {
+    btn.addEventListener("click", () =>
+      setActiveTab(`knowledge/${btn.dataset.subtab}`, { refresh: false }),
+    );
   }
   window.addEventListener("hashchange", () => {
     setActiveTab(window.location.hash);
@@ -1583,6 +1788,11 @@ function activeRefreshJobs() {
     return jobs;
   }
 
+  if (activeTab === "knowledge") {
+    jobs.push(fetchAndRenderLearnings());
+    return jobs;
+  }
+
   if (activeTab === "run-detail") {
     if (!activeRunId) {
       renderRunDetailEmpty("No run selected.");
@@ -1704,6 +1914,16 @@ function fetchAndRenderPolicy() {
   return fetchJson(`/api/diagnostics/denials?${sp.toString()}`).then((data) => {
     lastAuditPolicy = data;
     renderPolicy(data);
+  });
+}
+
+function fetchAndRenderLearnings() {
+  const sp = new URLSearchParams();
+  sp.set("limit", String(LEARNING_LIMIT));
+  if (learningSearchQuery) sp.set("q", learningSearchQuery);
+  return fetchJson(`/api/learnings?${sp.toString()}`).then((payload) => {
+    lastLearningPayload = payload || { stats: {}, items: [] };
+    renderLearnings(lastLearningPayload);
   });
 }
 
@@ -2756,11 +2976,12 @@ async function refreshDashboard() {
   isRefreshing = false;
   if (activeTab === "tasks") fitLogPanelToViewport();
   
-  $("footer").textContent = `orbit dashboard · auto-refresh 30s · GET /api/{tasks,jobs,job-runs,audit?since|tool|status|role|execution_id|profile|q|limit|offset,audit/summary?since|denial_threshold,runs/:id,runs/:id/events?kind|limit|offset,runs/:id/logs?limit,scoreboard,diagnostics/{metrics,errors,friction,denials?since|kind|profile|agent}}`;
+  $("footer").textContent = `orbit dashboard · auto-refresh 30s · GET /api/{tasks,learnings,jobs,job-runs,audit?since|tool|status|role|execution_id|profile|q|limit|offset,audit/summary?since|denial_threshold,runs/:id,runs/:id/events?kind|limit|offset,runs/:id/logs?limit,scoreboard,diagnostics/{metrics,errors,friction,denials?since|kind|profile|agent}}`;
 }
 
 buildChips();
 wireSearch();
+wireLearningSearch();
 buildAuditChips();
 wireAuditSearch();
 $("refresh-btn").addEventListener("click", refreshDashboard);

--- a/crates/orbit-cli/assets/dashboard/index.html
+++ b/crates/orbit-cli/assets/dashboard/index.html
@@ -196,7 +196,9 @@
         background: var(--bg);
       }
       
-      #task-search {
+      #task-search,
+      #audit-search,
+      #learning-search {
         flex: 1 1 200px;
         min-width: 160px;
         background: var(--bg);
@@ -210,7 +212,9 @@
         transition: all 0.2s ease;
       }
       
-      #task-search:focus {
+      #task-search:focus,
+      #audit-search:focus,
+      #learning-search:focus {
         border-color: var(--accent);
       }
       
@@ -1438,6 +1442,100 @@
       .knowledge-grid .value.ratio { color: var(--accent-hover); }
       .knowledge-empty { color: var(--fg-dim); font-family: var(--font-mono); font-size: 12px; }
 
+      /* Knowledge tab */
+      .learning-stats {
+        display: grid;
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+        border-bottom: 1px solid var(--border);
+      }
+      @media (max-width: 800px) {
+        .learning-stats { grid-template-columns: 1fr; }
+        .learning-row { grid-template-columns: 120px minmax(0, 1fr) 76px; }
+        .learning-row .evidence,
+        .learning-row .updated { display: none; }
+      }
+      .learning-row {
+        display: grid;
+        grid-template-columns: 140px minmax(180px, 1fr) 96px 110px 110px;
+        gap: 12px;
+        padding: 9px 16px;
+        align-items: center;
+        border-bottom: 1px solid rgba(255, 255, 255, 0.04);
+        font-family: var(--font-mono);
+        font-size: 12px;
+        cursor: pointer;
+      }
+      .learning-row:hover { background: rgba(255, 255, 255, 0.03); }
+      .learning-row.active { background: rgba(110, 159, 255, 0.06); }
+      .learning-row.header {
+        color: var(--fg-dim);
+        font-size: 10px;
+        font-weight: 600;
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        cursor: default;
+        position: sticky;
+        top: 0;
+        background: var(--bg-elev);
+        z-index: 1;
+      }
+      .learning-row .id,
+      .learning-row .updated {
+        color: var(--fg-dim);
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
+      .learning-row .scope {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 6px;
+        min-width: 0;
+      }
+      .learning-row .evidence {
+        color: var(--fg-dim);
+        text-align: right;
+      }
+      #learning-detail {
+        padding: 16px;
+        display: grid;
+        gap: 12px;
+      }
+      .learning-detail-meta {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 10px;
+        font-family: var(--font-mono);
+        font-size: 11px;
+        color: var(--fg-dim);
+      }
+      .learning-detail-meta .value {
+        color: var(--fg);
+        background: rgba(255, 255, 255, 0.05);
+        padding: 2px 6px;
+        border-radius: 2px;
+      }
+      .learning-detail-scope {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 6px;
+      }
+      .learning-detail-body {
+        margin: 0;
+        background: var(--bg);
+        border: 1px solid var(--border);
+        border-radius: 2px;
+        padding: 10px 12px;
+        font-family: var(--font-mono);
+        font-size: 12px;
+        line-height: 1.5;
+        color: var(--fg);
+        white-space: pre-wrap;
+        word-break: break-word;
+        max-height: 420px;
+        overflow: auto;
+      }
+
       /* Custom scrollbar */
       ::-webkit-scrollbar { width: 8px; height: 8px; }
       ::-webkit-scrollbar-track { background: transparent; }
@@ -1590,6 +1688,7 @@
       <button class="tab" data-tab="scoreboard" type="button">Scoreboard</button>
       <button class="tab" data-tab="audit" type="button">Audit</button>
       <button class="tab" data-tab="diagnostics" type="button">Diagnostics</button>
+      <button class="tab" data-tab="knowledge" type="button">Knowledge</button>
     </nav>
     <section class="health-strip" id="health-strip" aria-label="Audit health summary">
       <div class="tile" id="tile-events">
@@ -1743,6 +1842,52 @@
             <div class="skeleton-state">
               <div class="skeleton skeleton-row"></div>
               <div class="skeleton skeleton-row" style="width: 80%"></div>
+            </div>
+          </div>
+        </section>
+      </main>
+    </section>
+    <section class="tab-pane" data-tab="knowledge">
+      <main style="grid-template-columns: minmax(0, 1.6fr) minmax(320px, 0.9fr);">
+        <section class="panel" id="knowledge-panel">
+          <header><span>Knowledge</span><span class="count" id="knowledge-count">-</span></header>
+          <nav class="subtabs" id="knowledge-subtabs">
+            <button class="subtab" data-subtab="learnings" type="button">Learnings</button>
+          </nav>
+          <div class="learning-stats" id="learning-stats">
+            <div class="tile">
+              <span class="label">Total</span>
+              <span class="value" id="learning-total-value">-</span>
+              <span class="glyph">LRN</span>
+            </div>
+            <div class="tile">
+              <span class="label">Superseded</span>
+              <span class="value" id="learning-superseded-value">-</span>
+              <span class="glyph">SUP</span>
+            </div>
+            <div class="tile">
+              <span class="label">Last Indexed</span>
+              <span class="value" id="learning-last-indexed-value">-</span>
+              <span class="glyph">IDX</span>
+            </div>
+          </div>
+          <div class="controls">
+            <input type="search" id="learning-search" placeholder="Search learnings..." autocomplete="off" spellcheck="false" />
+          </div>
+          <div class="body scoreboard-table-wrap" id="learnings-body">
+            <div class="skeleton-state">
+              <div class="skeleton skeleton-row"></div>
+              <div class="skeleton skeleton-row" style="width: 80%"></div>
+              <div class="skeleton skeleton-row" style="width: 70%"></div>
+            </div>
+          </div>
+        </section>
+        <section class="panel" id="learning-detail-panel">
+          <header><span>Learning Detail</span><span class="count" id="learning-detail-count">-</span></header>
+          <div class="body" id="learning-detail">
+            <div class="empty-state">
+              <div class="icon">✧</div>
+              <div class="text">No learning selected.</div>
             </div>
           </div>
         </section>

--- a/crates/orbit-cli/src/command/learning/mod.rs
+++ b/crates/orbit-cli/src/command/learning/mod.rs
@@ -1,7 +1,7 @@
 mod add;
 mod command;
 mod list;
-mod output;
+pub(crate) mod output;
 mod prune;
 mod reindex;
 mod search;

--- a/crates/orbit-cli/src/command/learning/output.rs
+++ b/crates/orbit-cli/src/command/learning/output.rs
@@ -8,7 +8,7 @@
 use orbit_core::{EvidenceKind, Learning, LearningSearchResult};
 use serde_json::{Value, json};
 
-pub(super) fn learning_to_json(learning: &Learning) -> Value {
+pub(crate) fn learning_to_json(learning: &Learning) -> Value {
     json!({
         "id": learning.id,
         "status": learning.status.as_str(),
@@ -34,7 +34,7 @@ pub(super) fn learning_to_json(learning: &Learning) -> Value {
     })
 }
 
-pub(super) fn learning_search_result_to_json(result: &LearningSearchResult) -> Value {
+pub(crate) fn learning_search_result_to_json(result: &LearningSearchResult) -> Value {
     let learning = &result.learning;
     json!({
         "id": learning.id,

--- a/crates/orbit-cli/src/command/web/api/learnings.rs
+++ b/crates/orbit-cli/src/command/web/api/learnings.rs
@@ -1,0 +1,154 @@
+//! Learning scan and curation handlers.
+
+use std::sync::Arc;
+
+use axum::extract::{Path, Query, State};
+use axum::response::{IntoResponse, Json, Response};
+use orbit_core::{Learning, LearningSearchParams, OrbitRuntime};
+use serde::Deserialize;
+use serde_json::{Value, json};
+
+use super::{bad_request, bounded_limit, map_runtime_error, non_empty_string, server_error};
+use crate::command::learning::output::learning_to_json;
+
+const LEARNINGS_DEFAULT_LIMIT: usize = 100;
+
+#[derive(Deserialize, Default)]
+pub(super) struct LearningsQuery {
+    #[serde(default)]
+    q: Option<String>,
+    #[serde(default)]
+    scope: Option<String>,
+    #[serde(default)]
+    tag: Option<String>,
+    #[serde(default)]
+    limit: Option<usize>,
+    #[serde(default)]
+    offset: Option<usize>,
+}
+
+#[derive(Deserialize, Default)]
+pub(super) struct SupersedeLearningBody {
+    #[serde(default)]
+    by: Option<String>,
+    #[serde(default)]
+    reason: Option<String>,
+}
+
+pub(super) async fn list_learnings(
+    State(runtime): State<Arc<OrbitRuntime>>,
+    Query(query): Query<LearningsQuery>,
+) -> Response {
+    let all = match runtime.list_learnings(None) {
+        Ok(learnings) => learnings,
+        Err(e) => return server_error(e),
+    };
+
+    let stats = learning_stats_to_json(&all);
+    let limit = bounded_limit(query.limit, LEARNINGS_DEFAULT_LIMIT);
+    let offset = query.offset.unwrap_or(0);
+    let q = query.q.as_deref().and_then(non_empty_string);
+    let scope = query.scope.as_deref().and_then(non_empty_string);
+    let tag = query.tag.as_deref().and_then(non_empty_string);
+
+    let rows = if q.is_some() || scope.is_some() || tag.is_some() {
+        let search_limit = offset.saturating_add(limit);
+        let results = match runtime.search_learnings(LearningSearchParams {
+            path: scope,
+            tag,
+            query: q,
+            limit: Some(search_limit),
+        }) {
+            Ok(results) => results,
+            Err(e) => return map_runtime_error(e),
+        };
+        let mut rows = Vec::with_capacity(results.len());
+        for result in results {
+            match runtime.get_learning(&result.learning.id) {
+                Ok(learning) => rows.push(learning),
+                Err(e) => return map_runtime_error(e),
+            }
+        }
+        rows
+    } else {
+        all.clone()
+    };
+
+    let items = rows
+        .iter()
+        .skip(offset)
+        .take(limit)
+        .map(learning_to_json)
+        .collect::<Vec<_>>();
+
+    Json(json!({
+        "stats": stats,
+        "items": items,
+    }))
+    .into_response()
+}
+
+pub(super) async fn get_learning(
+    State(runtime): State<Arc<OrbitRuntime>>,
+    Path(id): Path<String>,
+) -> Response {
+    match runtime.get_learning(&id) {
+        Ok(learning) => Json(learning_to_json(&learning)).into_response(),
+        Err(e) => map_runtime_error(e),
+    }
+}
+
+pub(super) async fn supersede_learning_action(
+    State(runtime): State<Arc<OrbitRuntime>>,
+    Path(id): Path<String>,
+    body: Option<Json<SupersedeLearningBody>>,
+) -> Response {
+    let Some(Json(body)) = body else {
+        return bad_request("request body must include `by`".to_string());
+    };
+    let Some(by) = body.by.as_deref().and_then(non_empty_string) else {
+        return bad_request("request body must include non-empty `by`".to_string());
+    };
+    let _reason = body.reason.as_deref().and_then(non_empty_string);
+
+    match runtime.supersede_learning(&id, &by) {
+        Ok(()) => {
+            let old = match runtime.get_learning(&id) {
+                Ok(learning) => learning,
+                Err(e) => return map_runtime_error(e),
+            };
+            let new = match runtime.get_learning(&by) {
+                Ok(learning) => learning,
+                Err(e) => return map_runtime_error(e),
+            };
+            Json(json!({
+                "old": learning_to_json(&old),
+                "new": learning_to_json(&new),
+            }))
+            .into_response()
+        }
+        Err(e) => map_runtime_error(e),
+    }
+}
+
+fn learning_stats_to_json(learnings: &[Learning]) -> Value {
+    let superseded = learnings
+        .iter()
+        .filter(|learning| learning.status.as_str() == "superseded")
+        .count();
+    let last_indexed = learnings
+        .iter()
+        .map(|learning| learning.updated_at)
+        .max()
+        .map(|ts| ts.to_rfc3339());
+
+    json!({
+        "total": learnings.len(),
+        "superseded": superseded,
+        "last_indexed": last_indexed,
+    })
+}
+
+#[cfg(test)]
+#[path = "learnings_tests.rs"]
+mod tests;

--- a/crates/orbit-cli/src/command/web/api/learnings_tests.rs
+++ b/crates/orbit-cli/src/command/web/api/learnings_tests.rs
@@ -1,0 +1,178 @@
+use std::sync::Arc;
+
+use axum::body::Body;
+use axum::http::{Method, Request, StatusCode, header};
+use orbit_core::{
+    EvidenceKind, Learning, LearningCreateParams, LearningEvidence, LearningScope, LearningStatus,
+    OrbitRuntime,
+};
+use serde_json::{Value, json};
+use tower::ServiceExt;
+
+use super::super::router;
+use super::super::test_support::body_json;
+
+fn seed_learning(runtime: &OrbitRuntime, summary: &str) -> Learning {
+    runtime
+        .create_learning(LearningCreateParams {
+            summary: summary.to_string(),
+            scope: LearningScope {
+                paths: vec!["crates/orbit-cli/**".to_string()],
+                tags: vec!["dashboard".to_string()],
+                ..Default::default()
+            },
+            body: format!("Body for {summary}."),
+            evidence: vec![LearningEvidence {
+                kind: EvidenceKind::Task,
+                reference: "ORB-00061".to_string(),
+            }],
+            created_by: Some("gpt-5.5".to_string()),
+            priority: Some(3),
+        })
+        .expect("seed learning")
+}
+
+async fn request_supersede(
+    runtime: OrbitRuntime,
+    id: &str,
+    origin: Option<&str>,
+    body: Option<Value>,
+) -> axum::response::Response {
+    let mut builder = Request::builder()
+        .method(Method::POST)
+        .uri(format!("/learnings/{id}/supersede"));
+    if let Some(origin) = origin {
+        builder = builder.header(header::ORIGIN, origin);
+    }
+    let request = if let Some(body) = body {
+        builder
+            .header(header::CONTENT_TYPE, "application/json")
+            .body(Body::from(body.to_string()))
+            .expect("request")
+    } else {
+        builder.body(Body::empty()).expect("request")
+    };
+
+    router()
+        .with_state(Arc::new(runtime))
+        .oneshot(request)
+        .await
+        .expect("response")
+}
+
+#[tokio::test]
+async fn supersede_requires_localhost_origin() {
+    let runtime = OrbitRuntime::in_memory().expect("build runtime");
+    let old = seed_learning(&runtime, "Old dashboard learning");
+    let new = seed_learning(&runtime, "New dashboard learning");
+
+    let response = request_supersede(
+        runtime.clone(),
+        &old.id,
+        None,
+        Some(json!({ "by": new.id })),
+    )
+    .await;
+
+    assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    let stored = runtime.get_learning(&old.id).expect("read old");
+    assert_eq!(stored.status, LearningStatus::Active);
+    assert_eq!(stored.superseded_by, None);
+}
+
+#[tokio::test]
+async fn supersede_rejects_missing_or_malformed_by() {
+    let cases = [
+        (json!({}), "missing by"),
+        (json!({ "by": "" }), "empty by"),
+        (json!({ "by": "bad" }), "malformed by"),
+    ];
+
+    for (body, label) in cases {
+        let runtime = OrbitRuntime::in_memory().expect("build runtime");
+        let old = seed_learning(&runtime, "Old dashboard learning");
+
+        let response = request_supersede(
+            runtime.clone(),
+            &old.id,
+            Some("http://localhost:7878"),
+            Some(body),
+        )
+        .await;
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST, "{label}");
+        let stored = runtime.get_learning(&old.id).expect("read old");
+        assert_eq!(stored.status, LearningStatus::Active, "{label}");
+        assert_eq!(stored.superseded_by, None, "{label}");
+    }
+}
+
+#[tokio::test]
+async fn supersede_returns_not_found_when_target_id_is_missing() {
+    let runtime = OrbitRuntime::in_memory().expect("build runtime");
+    let replacement = seed_learning(&runtime, "Replacement dashboard learning");
+
+    let response = request_supersede(
+        runtime,
+        "L20260516-9999",
+        Some("http://localhost:7878"),
+        Some(json!({ "by": replacement.id })),
+    )
+    .await;
+
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn supersede_updates_target_record() {
+    let runtime = OrbitRuntime::in_memory().expect("build runtime");
+    let old = seed_learning(&runtime, "Old dashboard learning");
+    let new = seed_learning(&runtime, "New dashboard learning");
+
+    let response = request_supersede(
+        runtime.clone(),
+        &old.id,
+        Some("http://127.0.0.1:7878"),
+        Some(json!({ "by": new.id, "reason": "duplicate" })),
+    )
+    .await;
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let payload = body_json(response).await;
+    assert_eq!(payload["old"]["id"], old.id);
+    assert_eq!(payload["old"]["status"], "superseded");
+    assert_eq!(payload["old"]["superseded_by"], new.id);
+
+    let stored = runtime.get_learning(&old.id).expect("read superseded");
+    assert_eq!(stored.status, LearningStatus::Superseded);
+    assert_eq!(stored.superseded_by.as_deref(), Some(new.id.as_str()));
+}
+
+#[tokio::test]
+async fn list_learnings_returns_stats_and_rows() {
+    let runtime = OrbitRuntime::in_memory().expect("build runtime");
+    let old = seed_learning(&runtime, "Old dashboard learning");
+    let new = seed_learning(&runtime, "New dashboard learning");
+    runtime
+        .supersede_learning(&old.id, &new.id)
+        .expect("supersede fixture");
+
+    let response = router()
+        .with_state(Arc::new(runtime))
+        .oneshot(
+            Request::builder()
+                .method(Method::GET)
+                .uri("/learnings")
+                .body(Body::empty())
+                .expect("request"),
+        )
+        .await
+        .expect("response");
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let payload = body_json(response).await;
+    assert_eq!(payload["stats"]["total"], 2);
+    assert_eq!(payload["stats"]["superseded"], 1);
+    assert!(payload["stats"]["last_indexed"].as_str().is_some());
+    assert_eq!(payload["items"].as_array().expect("items").len(), 2);
+}

--- a/crates/orbit-cli/src/command/web/api/mod.rs
+++ b/crates/orbit-cli/src/command/web/api/mod.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 
 use axum::Router;
 use axum::body::Body;
-use axum::http::{Request, StatusCode, header};
+use axum::http::{Method, Request, StatusCode, header};
 use axum::middleware::{self, Next};
 use axum::response::{IntoResponse, Json, Response};
 use axum::routing::{get, post};
@@ -22,6 +22,7 @@ mod audit;
 mod denials;
 mod diagnostics;
 mod jobs;
+mod learnings;
 mod log;
 mod runs;
 mod scoreboard;
@@ -234,6 +235,10 @@ pub(super) fn map_runtime_error(e: orbit_core::OrbitError) -> Response {
             kind: orbit_core::NotFoundKind::JobRun,
             id,
         } => not_found(format!("run not found: {id}")),
+        orbit_core::OrbitError::NotFound {
+            kind: orbit_core::NotFoundKind::Learning,
+            id,
+        } => not_found(format!("learning not found: {id}")),
         other => server_error(other),
     }
 }
@@ -255,22 +260,24 @@ pub(super) fn server_error(e: orbit_core::OrbitError) -> Response {
 }
 
 async fn require_localhost_origin(request: Request<Body>, next: Next) -> Response {
-    if let Some(origin) = request.headers().get(header::ORIGIN) {
-        let allowed = origin
-            .to_str()
-            .ok()
-            .and_then(|origin| Url::parse(origin).ok())
-            .is_some_and(|origin| {
-                origin.scheme() == "http"
-                    && matches!(origin.host_str(), Some("localhost" | "127.0.0.1"))
-            });
-        if !allowed {
-            return (
-                StatusCode::FORBIDDEN,
-                Json(json!({"error": "cross-origin requests not allowed"})),
-            )
-                .into_response();
-        }
+    let unsafe_method = matches!(
+        *request.method(),
+        Method::POST | Method::PUT | Method::PATCH | Method::DELETE
+    );
+    let origin = request.headers().get(header::ORIGIN);
+    let allowed = origin
+        .and_then(|origin| origin.to_str().ok())
+        .and_then(|origin| Url::parse(origin).ok())
+        .is_some_and(|origin| {
+            origin.scheme() == "http"
+                && matches!(origin.host_str(), Some("localhost" | "127.0.0.1"))
+        });
+    if !allowed && (unsafe_method || origin.is_some()) {
+        return (
+            StatusCode::FORBIDDEN,
+            Json(json!({"error": "cross-origin requests not allowed"})),
+        )
+            .into_response();
     }
     next.run(request).await
 }
@@ -288,6 +295,12 @@ pub(super) fn router() -> Router<Arc<OrbitRuntime>> {
         .route("/tasks/:id/approve", post(tasks::approve_task_action))
         .route("/tasks/:id/reject", post(tasks::reject_task_action))
         .route("/tasks/:id/archive", post(tasks::archive_task_action))
+        .route("/learnings", get(learnings::list_learnings))
+        .route("/learnings/:id", get(learnings::get_learning))
+        .route(
+            "/learnings/:id/supersede",
+            post(learnings::supersede_learning_action),
+        )
         .route("/jobs", get(jobs::list_jobs))
         .route("/job-runs", get(jobs::list_job_runs))
         .route("/runs/:id", get(runs::get_run))

--- a/docs/design/project-learnings/2_design.md
+++ b/docs/design/project-learnings/2_design.md
@@ -2,7 +2,7 @@
 
 **Status:** Draft
 **Owner:** claude
-**Last updated:** 2026-05-15
+**Last updated:** 2026-05-16 (ORB-00061)
 
 This document specifies phase-1 project-learnings: the placement of learning storage in `orbit-store`, the schema of a learning record, the phase-1 scope-matching algorithm (path globs + tags), the three-layer push-injection pipeline (engine pre-prompt + MCP sidecar + optional Claude Code hook), the pull surface (skill + tools), the curation lifecycle, and the concerns the design deliberately leaves to follow-ups.
 
@@ -290,6 +290,16 @@ The skill is the pull complement to push. Push handles the "agent doesn't know i
 
 Agents that don't load skills can call `orbit.learning.search` directly via MCP. The tool's input schema is documented; its output shape matches §5.3.
 
+### 6.3 Dashboard
+
+The local dashboard exposes learnings under Knowledge > Learnings. The HTTP surface is deliberately thin over the same runtime helpers used by CLI/MCP:
+
+- `GET /api/learnings` lists records with optional `q`, `scope`, `tag`, `limit`, and `offset` filters and returns dashboard stats (`total`, `superseded`, `last_indexed`).
+- `GET /api/learnings/:id` returns the full record.
+- `POST /api/learnings/:id/supersede` accepts `{ "by": "<replacement-learning-id>" }` and runs the same atomic supersession path described in §7.2.
+
+The dashboard is a pull and curation surface, not an injection layer. It lets operators scan stale or duplicate records before review without changing the phase-1 push semantics.
+
 ---
 
 ## 7. Curation Lifecycle
@@ -371,5 +381,6 @@ Learnings are workspace-scoped and checked into the repo. They travel exactly wh
 
 - [T20260510-11] — Design + build project-learnings system as native Orbit primitive. The task that produced this folder.
 - [T20260510-12] — Add `tags` field to `Task` schema. Hard prerequisite for Layer 1's tag-axis matching ([§4.1](#41-layer-1--engine-pre-prompt-injection-universal)).
+- [ORB-00061] — Add Knowledge tab and Learnings subtab to dashboard.
 
 Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.

--- a/docs/design/user-interface/2_design.md
+++ b/docs/design/user-interface/2_design.md
@@ -2,7 +2,7 @@
 
 **Status:** Draft
 **Owner:** gemini
-**Last updated:** 2026-05-16 (ORB-00060)
+**Last updated:** 2026-05-16 (ORB-00061)
 
 This document describes the current Orbit UI implementation: the local dashboard assets, the Canon Refined visual rules they rely on, and the telemetry behaviors that must stay consistent with backend data.
 
@@ -32,6 +32,8 @@ Diagnostics has an Errors sub-tab after [T20260508-14]. It renders recent backen
 
 Diagnostics no longer has a Friction sub-tab after [ORB-00060]. The Friction name is reserved for append-only `.orbit/frictions/` artifacts, while audit-derived negative run signals stay visible in Recent Runs. Recent Runs joins `/api/job-runs` with `/api/diagnostics/friction` client-side by run id (`run_id`/`job_run`) and keeps the table sortable across `denials`, `tool fails`, and `duration`; the duration cell can carry the long-run flag when the diagnostics source supplies one. This preserves column continuity with the existing compact dashboard telemetry direction from [T20260428-15].
 
+Knowledge is now a top-level dashboard tab after [ORB-00061]. Its first sub-tab, Learnings, mirrors the dense task-list pattern: a left scan table backed by `/api/learnings`, a right detail panel backed by the same learning JSON shape as CLI/MCP output, and compact stats tiles for `total`, `superseded`, and `last indexed`. Supersession stays an explicit local action (`POST /api/learnings/:id/supersede`) guarded by the localhost-origin middleware, so curation can happen without leaving the dashboard.
+
 ## 6. Concerns & Honest Limitations
 
 Accessibility still needs a real WCAG pass; responsive behavior remains optimized for wide desktop viewports; raw HTML, CSS variables, and dashboard JavaScript keep the runtime simple but leave duplication across project surfaces.
@@ -45,5 +47,6 @@ Accessibility still needs a real WCAG pass; responsive behavior remains optimize
 - [T20260430-29] bounded the live `orbit.log` panel to the viewport.
 - [T20260508-14] added Run Detail agent-log previews and Diagnostics > Errors.
 - [ORB-00060] collapsed Diagnostics > Friction into Recent Runs diagnostics columns.
+- [ORB-00061] added the Knowledge tab and Learnings curation surface.
 
 > Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.


### PR DESCRIPTION
## Task

[ORB-00061](https://orbit-cli.com/tasks/ORB-00061) — Add Knowledge tab and Learnings subtab to dashboard

### Description

## Problem
The new first-class `Learning` artifact (`.orbit/learnings/*.yaml`, indexed in SQLite) has full MCP/CLI coverage via `orbit.learning.*` but no presence in the local dashboard. Users wanting to scan, search, and supersede learnings have to drop to the CLI.

## Why It Matters
Learnings are now load-bearing for agent runs (push-at-moment-of-action). Operators need a scan surface to spot stale or duplicate learnings; reviewers need to see what was added before approving a PR. Dashboard parity with Tasks closes that loop.

## Constraints / Notes
- This task introduces the new top-level `Knowledge` tab (one subtab today; Frictions and ADRs land in follow-up tasks).
- New handler module `crates/orbit-cli/src/command/web/api/learnings.rs`. Handlers must delegate to existing `*_to_json` helpers in `orbit-tools` (or extend them there) — no business logic in the HTTP layer, per the module doc-comment in `web/api/mod.rs:1-4`.
- Endpoints: `GET /api/learnings` (q, scope, tag, limit, offset), `GET /api/learnings/:id`, `POST /api/learnings/:id/supersede` (body `{by, reason?}`). All behind the existing `require_localhost_origin` middleware.
- Search backend: pass `q` through to `orbit.learning.search` semantics (BM25 + cosine if embed companion installed; graceful degrade otherwise).
- Panel shape: mirror Tasks (left list / right detail). Stats strip with three tiles: `total`, `superseded`, `last indexed`. Reuse existing `.tile` and `.panel` CSS — no new CSS variables.
- Detail panel renders body as `<pre>` for v1 (lifting a markdown renderer is a separate decision).

### Acceptance Criteria

- `crates/orbit-cli/src/command/web/api/mod.rs` registers `GET /learnings`, `GET /learnings/:id`, `POST /learnings/:id/supersede` and the new module compiles under `make build`.
- Each POST handler rejects requests without a localhost `Origin` header with `403` (mirroring `runs_tests.rs::require_localhost_origin_*`), verified by a new `learnings_tests.rs`.
- `POST /learnings/:id/supersede` returns `400` when `by` is absent or malformed, `404` when the id does not exist, and on success the targeted record's status is `superseded` and `superseded_by` points to `body.by` — asserted via direct store read in a test.
- Dashboard nav shows a `Knowledge` button between `Diagnostics` and the right-aligned items in `index.html`; clicking it activates a tab pane containing a `Learnings` subtab (only subtab in this task).
- `Learnings` subtab renders a stats strip (`total`, `superseded`, `last indexed`), a list with columns (id, scope chips, evidence count, status, updated), and a detail panel with a `Supersede` button that POSTs to `/api/learnings/:id/supersede`.
- `make ci-fast` passes locally and via the PR `ci` workflow.
- Dashboard smoke check: with at least one learning in `.orbit/learnings/`, `cargo run -p orbit-cli -- web` shows the record in the new subtab; the Supersede button transitions status without a page reload.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Added the dashboard learnings API module and registered `GET /api/learnings`, `GET /api/learnings/:id`, and `POST /api/learnings/:id/supersede`.
- Reused the existing learning JSON serializer for HTTP responses, mapped learning not-found errors to 404, and tightened localhost-origin middleware so unsafe requests without a localhost Origin are rejected with 403.
- Added focused learnings API tests for origin enforcement, missing/malformed `by`, missing target ids, successful supersession, and list stats.
- Added the Knowledge top-level dashboard tab with a Learnings subtab, stats tiles, scan table, detail panel, and Supersede action posting to the new API without a page reload.
- Updated user-interface and project-learnings design docs for the new dashboard pull/curation surface.

Assessment: The scoped backend, frontend, docs, and smoke path are implemented and validated. `make check-design-docs` still reports unrelated stale design docs outside ORB-00061; `make ci-fast` passed.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-00061-6a08d937`
- Behind base: 0
- Ahead of base: 1