### PR TITLE
Workflow path overwrites `implemented_by` with literal "system" instead of the driving agent's model

### DIFF
--- a/crates/orbit-core/src/runtime/engine/task_host.rs
+++ b/crates/orbit-core/src/runtime/engine/task_host.rs
@@ -2,7 +2,7 @@ use orbit_common::types::{
     ExternalRef, OrbitError, OrbitEvent, ReviewThread, Task, TaskComment, TaskHistoryEntry,
     TaskPriority, TaskStatus, normalize_optional_attribution_label, push_external_ref_if_missing,
 };
-use orbit_engine::{TaskAutomationUpdate, TaskReadHost, TaskWriteHost};
+use orbit_engine::{RuntimeHost, TaskAutomationUpdate, TaskReadHost, TaskWriteHost};
 
 use crate::OrbitRuntime;
 use crate::command::task::SYSTEM_ACTOR_LABEL;
@@ -109,6 +109,7 @@ impl TaskWriteHost for OrbitRuntime {
         }
         let (agent, model) = self
             .try_canonical_agent_model_identity(update.agent.as_deref(), update.model.as_deref())?;
+        let runtime_model_identity = <Self as RuntimeHost>::actor_model_identity(self);
         let _ = self.with_mutation(|| {
             let actor_label = SYSTEM_ACTOR_LABEL.to_string();
             let explicit_attribution_label = normalize_optional_attribution_label(
@@ -124,6 +125,7 @@ impl TaskWriteHost for OrbitRuntime {
                 Some(
                     explicit_attribution_label
                         .clone()
+                        .or_else(|| runtime_model_identity.clone())
                         .unwrap_or_else(|| actor_label.clone()),
                 )
             });
@@ -132,6 +134,7 @@ impl TaskWriteHost for OrbitRuntime {
                     .as_deref()
                     .or(existing_task.implemented_by.as_deref())
                     .or(explicit_attribution_label.as_deref())
+                    .or(runtime_model_identity.as_deref())
                     .or(Some(actor_label.as_str())),
                 model.as_deref(),
             );
@@ -625,6 +628,133 @@ mod tests {
             .find(|entry| entry.event == "commented")
             .expect("comment history");
         assert_eq!(comment_history.by, SYSTEM_ACTOR_LABEL);
+    }
+
+    #[test]
+    fn automation_update_under_agent_runtime_uses_model_identity_for_attribution() {
+        let (_root, runtime) = test_runtime();
+        let runtime = runtime.with_actor(crate::ActorIdentity::agent("gpt-agent-test"));
+        let task = runtime
+            .add_task(TaskAddParams {
+                title: "Agent-driven automation".to_string(),
+                description: "Exercise agent runtime attribution.".to_string(),
+                workspace_path: Some(".".to_string()),
+                ..Default::default()
+            })
+            .expect("add task");
+        let task = approve_for_execution(&runtime, &task);
+        runtime
+            .start_task(&task.id, Some("start task".to_string()), None)
+            .expect("start task");
+
+        runtime
+            .apply_task_automation_update(
+                &task.id,
+                TaskAutomationUpdate {
+                    plan: Some("Implement the task through workflow automation.".to_string()),
+                    ..TaskAutomationUpdate::default()
+                },
+            )
+            .expect("automation plan update");
+        let planned = runtime.get_task(&task.id).expect("reload planned task");
+        assert_eq!(planned.planned_by.as_deref(), Some("gpt-agent-test"));
+
+        runtime
+            .apply_task_automation_update(
+                &task.id,
+                TaskAutomationUpdate {
+                    status: Some(TaskStatus::Review),
+                    execution_summary: Some("Implemented through automation.".to_string()),
+                    ..TaskAutomationUpdate::default()
+                },
+            )
+            .expect("automation review update");
+
+        let updated = runtime.get_task(&task.id).expect("reload task");
+        assert_eq!(updated.implemented_by.as_deref(), Some("gpt-agent-test"));
+    }
+
+    #[test]
+    fn automation_update_without_agent_runtime_falls_back_to_system_attribution() {
+        let (_root, runtime) = test_runtime();
+        let task = runtime
+            .add_task(TaskAddParams {
+                title: "System automation".to_string(),
+                description: "Exercise non-agent workflow attribution.".to_string(),
+                workspace_path: Some(".".to_string()),
+                ..Default::default()
+            })
+            .expect("add task");
+        let task = approve_for_execution(&runtime, &task);
+        runtime
+            .start_task(&task.id, Some("start task".to_string()), None)
+            .expect("start task");
+
+        runtime
+            .apply_task_automation_update(
+                &task.id,
+                TaskAutomationUpdate {
+                    status: Some(TaskStatus::Review),
+                    execution_summary: Some("Implemented through system automation.".to_string()),
+                    ..TaskAutomationUpdate::default()
+                },
+            )
+            .expect("automation review update");
+
+        let updated = runtime.get_task(&task.id).expect("reload task");
+        assert_eq!(updated.implemented_by.as_deref(), Some(SYSTEM_ACTOR_LABEL));
+    }
+
+    #[test]
+    fn automation_review_done_transitions_preserve_existing_implemented_by_without_model() {
+        let (_root, runtime) = test_runtime();
+        let runtime = runtime.with_actor(crate::ActorIdentity::agent("gpt-agent-test"));
+        let task = runtime
+            .add_task(TaskAddParams {
+                title: "Preserve implementer".to_string(),
+                description: "Exercise existing implementer preservation.".to_string(),
+                workspace_path: Some(".".to_string()),
+                ..Default::default()
+            })
+            .expect("add task");
+        let task = approve_for_execution(&runtime, &task);
+        runtime
+            .start_task(&task.id, Some("start task".to_string()), None)
+            .expect("start task");
+        runtime
+            .update_task(
+                &task.id,
+                TaskUpdateParams {
+                    execution_summary: Some("Existing implementation summary.".to_string()),
+                    implemented_by: Some(Some("claude-opus-4-7".to_string())),
+                    ..Default::default()
+                },
+            )
+            .expect("seed existing implementation attribution");
+
+        runtime
+            .apply_task_automation_update(
+                &task.id,
+                TaskAutomationUpdate {
+                    status: Some(TaskStatus::Review),
+                    ..TaskAutomationUpdate::default()
+                },
+            )
+            .expect("automation review update");
+        let reviewed = runtime.get_task(&task.id).expect("reload reviewed task");
+        assert_eq!(reviewed.implemented_by.as_deref(), Some("claude-opus-4-7"));
+
+        runtime
+            .apply_task_automation_update(
+                &task.id,
+                TaskAutomationUpdate {
+                    status: Some(TaskStatus::Done),
+                    ..TaskAutomationUpdate::default()
+                },
+            )
+            .expect("automation done update");
+        let done = runtime.get_task(&task.id).expect("reload done task");
+        assert_eq!(done.implemented_by.as_deref(), Some("claude-opus-4-7"));
     }
 
     #[test]


### PR DESCRIPTION
## Task

[ORB-00067](https://orbit-cli.com/tasks/ORB-00067) — Workflow path overwrites `implemented_by` with literal "system" instead of the driving agent's model

### Description

## Symptom

Tasks executed through workflow automation paths (batch dispatch, parallel batch, VCS commit / worktree setup / PR open + merge, review sync) are being persisted with `implemented_by = "system"` even though the runtime is driven by a real model agent — e.g. `gpt-5.5` (most current cases) or `claude-opus-4-7`. Manual `orbit.task.update` / `orbit.task.approve` calls correctly record the model identity. Only the workflow path is mis-attributing.

This corrupts scoreboards (PR-count metrics use `implemented_by` as the key — see `crates/orbit-engine/src/executor/automation/vcs/pr.rs:142-174` `batch_author`) and lies in `git log --grep` / signature-line outputs that downstream tooling and humans rely on.

## Root Cause

In `apply_task_automation_update` at [crates/orbit-core/src/runtime/engine/task_host.rs:88-181](crates/orbit-core/src/runtime/engine/task_host.rs:88), the `implemented_by` fallback chain is:

```rust
// lines 130-137
let implemented_by = normalize_optional_attribution_label(
    model
        .as_deref()                                       // None on workflow path
        .or(existing_task.implemented_by.as_deref())      // None for fresh tasks
        .or(explicit_attribution_label.as_deref())        // None — built from update.agent/update.model which are also None
        .or(Some(actor_label.as_str())),                  // FALLS THROUGH to "system"
    model.as_deref(),
);
```

`actor_label` is hardcoded to `SYSTEM_ACTOR_LABEL` (= `"system"`) at line 113 (constant at [crates/orbit-core/src/command/task/helpers.rs:7](crates/orbit-core/src/command/task/helpers.rs:7)).

Workflow call sites in `orbit-engine` construct `TaskAutomationUpdate { ..Default::default() }` without populating `agent` / `model`. Representative offenders:
- [crates/orbit-engine/src/executor/automation/vcs/pr.rs:155-163](crates/orbit-engine/src/executor/automation/vcs/pr.rs:155) (batch PR merge — Review → Done transition)
- [crates/orbit-engine/src/executor/automation/vcs/pr.rs:252-260](crates/orbit-engine/src/executor/automation/vcs/pr.rs:252) (no-diff PR open: InProgress → Review)
- [crates/orbit-engine/src/executor/automation/vcs/worktree/setup.rs:58-60](crates/orbit-engine/src/executor/automation/vcs/worktree/setup.rs:58)
- batch dispatch / parallel batch in `crates/orbit-engine/src/executor/automation/batch/`

Critically, [`runtime_host.rs:166-171`](crates/orbit-core/src/runtime/engine/runtime_host.rs:166) already exposes `actor_model_identity()` on `OrbitRuntime` — it returns the driving model (e.g. `"gpt-5.5"`) when the runtime actor is `ActorKind::Agent`. The PR-body builder at `pr.rs:279` already uses it (`host.actor_model_identity()`). `apply_task_automation_update` is in the same crate and has access to `self`, but never consults it — so the available, correct identity is silently dropped in favor of the `"system"` constant.

Why the manual path works: `update_task_with_status_note_and_identity` ([crates/orbit-core/src/command/task/update.rs:58+](crates/orbit-core/src/command/task/update.rs:58)) takes explicit `agent`/`model` parameters from the MCP/CLI caller and computes `implemented_by` through `implementation_label` ([helpers.rs:63-74](crates/orbit-core/src/command/task/helpers.rs:63)), which preserves the existing value rather than overwriting with `"system"`.

The bug is also more dangerous than a missing-write — when a task already had a correct `implemented_by` (e.g. set by the implementing skill earlier in the run), the workflow's Review/Done transition at `task_host.rs:155-162` *overwrites* it with the freshly computed (wrong) `"system"` value, so even tasks that were correctly attributed mid-run get clobbered on the final transition.

## Proposed Fix

Single point fix in `apply_task_automation_update` (`task_host.rs:88-181`): insert the runtime's current agent identity into the fallback chain *above* the `actor_label` fallback. `OrbitRuntime` already implements `orbit_engine::RuntimeHost::actor_model_identity()` — use it.

Sketch:

```rust
let runtime_model_identity = <Self as orbit_engine::RuntimeHost>::actor_model_identity(self);
// existing explicit_attribution_label / planned_by code unchanged ...
let implemented_by = normalize_optional_attribution_label(
    model
        .as_deref()
        .or(existing_task.implemented_by.as_deref())
        .or(explicit_attribution_label.as_deref())
        .or(runtime_model_identity.as_deref())   // NEW: agent driving this workflow
        .or(Some(actor_label.as_str())),          // last-resort: true system actions only
    model.as_deref(),
);
```

`planned_by` (lines 123-129) should get the same treatment for symmetry. `actor` (the mutation actor recorded in history) can stay as `"system"` — it's a *legitimate* identifier for "the runtime applied this on behalf of a workflow step", and the issue is only with `implemented_by` / `planned_by`, which are claims about *who did the work*, not *who mutated the row*.

Rejected alternative: populating `TaskAutomationUpdate.agent` / `.model` at every call site. ~8 call sites in `orbit-engine` would need plumbing for an identity the host already knows; high churn, easy to forget on future call sites. The host-side fix is the right blast radius.

## Acceptance Criteria

- After running a workflow (batch dispatch → commit → PR open → PR merge) under an agent runtime, every touched task's `implemented_by` reflects the driving model (e.g. `gpt-5.5`), not `"system"`.
- A pre-existing `implemented_by` on a task is preserved through the Review/Done transition rather than overwritten.
- When the runtime actor is genuinely `ActorKind::System` (no agent driving), `implemented_by` falls back to `"system"` as before — confirmed by a unit test.
- Manual `orbit.task.update` behavior is unchanged.
- Regression test in `crates/orbit-core/src/runtime/engine/task_host.rs` covers: (a) workflow update under Agent actor → records model identity; (b) workflow update under System actor → records `"system"`; (c) workflow update preserves existing `implemented_by` when caller passes no agent/model.
- `make ci-fast` passes.

## Out of Scope

- Backfilling historic tasks whose `implemented_by` is already `"system"` — would require knowing which were really system vs. mis-attributed. File a separate task if needed.
- `created_by` attribution path (out of scope per ORB-00034 boundary).
- Pruning the `SYSTEM_ACTOR_LABEL` constant — it remains the correct fallback for true system actions.

### Acceptance Criteria

- Workflow-driven `apply_task_automation_update` records `implemented_by` as the runtime's `actor_model_identity()` (e.g. `gpt-5.5`) when an agent is driving, instead of `"system"`.
- Existing `implemented_by` on a task is preserved across the Review/Done transition when no explicit model is passed in the update.
- When `ActorKind::System` (no agent), `implemented_by` correctly falls back to `"system"` — covered by a unit test.
- Manual `orbit.task.update` path is unchanged — covered by existing tests staying green.
- New regression tests added to `crates/orbit-core/src/runtime/engine/task_host.rs` (or sibling `*_tests.rs`) for Agent actor, System actor, and `implemented_by` preservation cases.
- `planned_by` gets the same fallback fix for symmetry.
- `make ci-fast` passes; PR CI green.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Updated `apply_task_automation_update` to use the runtime `actor_model_identity()` as the attribution fallback before the literal `system` label for both `planned_by` and `implemented_by`.
- Added task-host regression tests covering agent runtime attribution, non-agent/system fallback attribution, and preservation of an existing `implemented_by` through Review and Done automation transitions.

Assessment: Focused host-side fix with regression coverage for the workflow attribution path and existing manual update behavior.

Validation:
- `cargo test -p orbit-core automation_update -- --nocapture`
- `cargo test -p orbit-core automation_review_done_transitions_preserve_existing_implemented_by_without_model -- --nocapture`
- `cargo test -p orbit-core runtime::engine::task_host::tests -- --nocapture`
- `cargo test -p orbit-core task_update_tool_ -- --nocapture`
- `make ci-fast`

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-00067-6a08dd80`
- Behind base: 0
- Ahead of base: 1