### PR TITLE
Web dashboard — render tags, external_refs, relations, job_run_id, review_threads in task detail dropdown

### DIFF
--- a/crates/orbit-cli/assets/dashboard/app.js
+++ b/crates/orbit-cli/assets/dashboard/app.js
@@ -289,9 +289,142 @@ const TASK_META_FIELDS = [
   ["created_by", "created_by"],
   ["pr_number", "pr"],
   ["pr_status", "pr_status"],
+  ["job_run_id", "job_run"],
   ["created_at", "created"],
   ["updated_at", "updated"],
 ];
+
+const RELATION_GROUPS = [
+  ["blocked_by", "BlockedBy"],
+  ["child_of", "ChildOf"],
+  ["spawned_from", "SpawnedFrom"],
+  ["regression_from", "RegressionFrom"],
+  ["supersedes", "Supersedes"],
+  ["related_to", "RelatedTo"],
+];
+const RELATION_GROUP_LABELS = new Map(RELATION_GROUPS);
+
+function relationTypeKey(value) {
+  if (!value) return "";
+  return String(value)
+    .replace(/([a-z0-9])([A-Z])/g, "$1_$2")
+    .replace(/-/g, "_")
+    .toLowerCase();
+}
+
+function copyTaskIdWithNotice(taskId) {
+  if (navigator.clipboard && navigator.clipboard.writeText) {
+    navigator.clipboard.writeText(taskId).catch(() => {});
+  }
+  taskActionNotice = `${taskId} is not in the filtered task list; copied ID`;
+  renderTasks(lastTasks);
+}
+
+function findTaskRow(taskId) {
+  return Array.from(document.querySelectorAll("#tasks-body .row"))
+    .find((row) => row.dataset.key === `task-${taskId}`) || null;
+}
+
+function openVisibleTask(taskId) {
+  const visible = filterTasks(lastTasks).some((task) => task.id === taskId);
+  if (!visible) {
+    copyTaskIdWithNotice(taskId);
+    return;
+  }
+  expandedTaskIds.add(taskId);
+  renderTasks(lastTasks);
+  requestAnimationFrame(() => {
+    const row = findTaskRow(taskId);
+    if (!row) return;
+    row.scrollIntoView({ behavior: "smooth", block: "center" });
+    row.classList.add("data-changed");
+    setTimeout(() => row.classList.remove("data-changed"), 1200);
+  });
+}
+
+function buildTagRow(tags) {
+  const wrap = el("div", { class: "detail-tag-row" });
+  for (const tag of tags) {
+    wrap.appendChild(el("span", { class: "chip", text: tag }));
+  }
+  return wrap;
+}
+
+function buildExternalRefs(refs) {
+  const wrap = el("div");
+  for (const ref of refs) {
+    const label = `${ref.system || "external"}:${ref.id || ""}`;
+    const line = el("div", { class: "external-ref-line" });
+    if (ref.url) {
+      const link = el("a", { text: label });
+      link.href = ref.url;
+      line.appendChild(link);
+    } else {
+      line.textContent = label;
+    }
+    wrap.appendChild(line);
+  }
+  return wrap;
+}
+
+function buildRelations(relations) {
+  const byType = new Map(RELATION_GROUPS.map(([key]) => [key, []]));
+  for (const relation of relations) {
+    const key = relationTypeKey(relation.relation_type || relation.type);
+    const target = relation.target == null ? "" : String(relation.target);
+    if (!RELATION_GROUP_LABELS.has(key) || !target) continue;
+    byType.get(key).push(target);
+  }
+
+  const wrap = el("div");
+  for (const [key, label] of RELATION_GROUPS) {
+    const targets = byType.get(key);
+    if (!targets || targets.length === 0) continue;
+    const group = el("div", { class: "relation-group" }, [
+      el("span", { class: "label", text: label }),
+    ]);
+    for (const target of targets) {
+      const btn = el("button", { class: "relation-target mono", text: target });
+      btn.addEventListener("click", (e) => {
+        e.stopPropagation();
+        openVisibleTask(target);
+      });
+      group.appendChild(btn);
+    }
+    wrap.appendChild(group);
+  }
+  return wrap;
+}
+
+function reviewThreadStatus(thread) {
+  const status = String(thread.status || "open").toLowerCase();
+  return status === "resolved" ? "resolved" : "open";
+}
+
+function buildReviewThreads(threads) {
+  const wrap = el("div", { class: "review-threads" });
+  for (const thread of threads) {
+    const messages = Array.isArray(thread.messages) ? thread.messages : [];
+    const location = thread.path
+      ? `${thread.path}${thread.line == null ? "" : `:${thread.line}`}`
+      : "general";
+    const block = el("div", { class: "review-thread" });
+    block.appendChild(el("div", {
+      class: "review-thread-header",
+      text: `[${reviewThreadStatus(thread)}] ${location} · ${messages.length} messages`,
+    }));
+    for (const msg of messages) {
+      const line = el("div", { class: "comment-line" }, [
+        document.createTextNode(`[${fmtAbsTime(msg.at)}] `),
+        el("span", { class: "author", text: msg.by || "?" }),
+        document.createTextNode(`: ${msg.body || ""}`),
+      ]);
+      block.appendChild(line);
+    }
+    wrap.appendChild(block);
+  }
+  return wrap;
+}
 
 function buildTaskDetail(task) {
   const detail = el("div", { class: "row-detail split-layout" });
@@ -361,20 +494,45 @@ function buildTaskDetail(task) {
     addField(leftCol, "execution summary", view, true, true);
   }
 
+  if (Array.isArray(task.review_threads) && task.review_threads.length > 0) {
+    addField(leftCol, "review threads", buildReviewThreads(task.review_threads), true, true);
+  }
+
+  if (Array.isArray(task.tags) && task.tags.length > 0) {
+    rightCol.appendChild(buildTagRow(task.tags));
+  }
+
   const meta = el("div", { class: "meta-list" });
   let metaCount = 0;
   for (const [key, label] of TASK_META_FIELDS) {
     const v = task[key];
     if (v == null || v === "") continue;
     const display = key.endsWith("_at") ? fmtAbsTime(v) : String(v);
+    const value = el("span", { class: "value" });
+    if (key === "job_run_id") {
+      const link = el("a", { text: display });
+      link.href = `#runs?run_id=${encodeURIComponent(display)}`;
+      value.appendChild(link);
+    } else {
+      value.textContent = display;
+    }
     const span = el("div", { class: "meta-item" }, [
       el("span", { class: "label", text: `${label}` }),
-      el("span", { class: "value", text: display }),
+      value,
     ]);
     meta.appendChild(span);
     metaCount++;
   }
   if (metaCount > 0) addField(rightCol, "details", meta);
+
+  if (Array.isArray(task.external_refs) && task.external_refs.length > 0) {
+    addField(rightCol, "external refs", buildExternalRefs(task.external_refs));
+  }
+
+  if (Array.isArray(task.relations) && task.relations.length > 0) {
+    const relations = buildRelations(task.relations);
+    if (relations.children.length > 0) addField(rightCol, "relations", relations);
+  }
 
   if (Array.isArray(task.context_files) && task.context_files.length > 0) {
     const ul = el("ul", { class: "file-list" });
@@ -1412,6 +1570,9 @@ function parseHashRoute(raw) {
 function setActiveTab(raw, opts = {}) {
   const { segments, query } = parseHashRoute(raw);
   const head = segments[0] || "tasks";
+  if (head === "runs" && !segments[1] && query.get("run_id")) {
+    segments[1] = encodeURIComponent(query.get("run_id"));
+  }
   let top;
   if (head === "runs" && segments[1]) {
     top = "run-detail";

--- a/crates/orbit-cli/assets/dashboard/index.html
+++ b/crates/orbit-cli/assets/dashboard/index.html
@@ -404,6 +404,57 @@
         font-size: 11px;
         text-align: right;
       }
+      .detail-side .meta-item .value a,
+      .external-ref-line a {
+        color: var(--accent);
+        text-decoration: none;
+      }
+      .detail-side .meta-item .value a:hover,
+      .external-ref-line a:hover {
+        text-decoration: underline;
+      }
+      .detail-tag-row {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 6px;
+      }
+      .detail-tag-row .chip {
+        cursor: default;
+      }
+      .external-ref-line {
+        font-family: var(--font-mono);
+        font-size: 12px;
+        line-height: 1.6;
+        overflow-wrap: anywhere;
+      }
+      .relation-group {
+        display: flex;
+        flex-wrap: wrap;
+        align-items: center;
+        gap: 6px;
+        margin-bottom: 8px;
+      }
+      .relation-group:last-child {
+        margin-bottom: 0;
+      }
+      .relation-group .label {
+        min-width: 112px;
+        color: var(--fg-dim);
+        font-family: var(--font-mono);
+        font-size: 11px;
+      }
+      .relation-target {
+        border: 1px solid var(--border);
+        border-radius: 2px;
+        background: var(--bg);
+        color: var(--accent);
+        cursor: pointer;
+        padding: 3px 7px;
+        font-size: 11px;
+      }
+      .relation-target:hover {
+        border-color: var(--accent);
+      }
       
       .row-detail .meta-line {
         font-family: var(--font-mono);
@@ -566,6 +617,19 @@
       
       .row-detail .history-line .actor,
       .row-detail .comment-line .author { color: var(--accent-hover); font-weight: 500; }
+      .review-thread {
+        margin-bottom: 12px;
+      }
+      .review-thread:last-child {
+        margin-bottom: 0;
+      }
+      .review-thread-header {
+        color: var(--fg);
+        font-family: var(--font-mono);
+        font-size: 12px;
+        margin-bottom: 6px;
+        overflow-wrap: anywhere;
+      }
       
       .row-detail .actions {
         display: flex;


### PR DESCRIPTION
## Task

[ORB-00068](https://orbit-cli.com/tasks/ORB-00068) — Web dashboard — render tags, external_refs, relations, job_run_id, review_threads in task detail dropdown

### Description

## Problem

The Orbit web dashboard's expanded task drop-down (`buildTaskDetail` in [crates/orbit-cli/assets/dashboard/app.js:279](crates/orbit-cli/assets/dashboard/app.js)) does not render several task fields that are already serialized over the wire by `task_to_json_with_sidecars` ([crates/orbit-cli/src/command/task/output.rs:63](crates/orbit-cli/src/command/task/output.rs)): `tags`, `external_refs`, `relations`, `job_run_id`, `review_threads`.

Users viewing a task in the dashboard cannot see its tags, linked PRs/Jira tickets, parent/dep/regression relationships, originating job run, or review feedback without dropping back to the CLI.

## Why It Matters

The dashboard is becoming the primary surface for backlog triage and review. Hiding these fields makes the dashboard a strictly inferior view of a task vs `orbit task show`, which undermines its purpose. All data is already on the wire — this is a pure rendering gap.

## Scope

Frontend-only. No Rust changes. No new API endpoints.

## Render Spec

### Right column (`detail-side`)

- **tags** — chip row using existing `.chip` class, placed above the `details` meta-list. Render only when `task.tags` is non-empty.
- **external_refs** — own `field-block`, one line per ref. Format: `<a href={url}>{system}:{id}</a>` when `url` is present, else plain text `{system}:{id}`. Use class `.external-ref-line` per row.
- **relations** — own `field-block`. Group by `relation_type` (BlockedBy, ChildOf, SpawnedFrom, RegressionFrom, Supersedes, RelatedTo). Each group rendered only when its array is non-empty. Use class `.relation-group` per group. Each target task ID is a click target that:
  1. Scrolls to the matching row in the task list and expands it (reusing whatever the existing row-click does).
  2. Falls back to copying the ID to clipboard with a flash toast when the target is not in the current filtered list.
- **job_run_id** — add new entry to `TASK_META_FIELDS` ([app.js:269](crates/orbit-cli/assets/dashboard/app.js)). Rendered in the meta-list as `<a href="#runs?run_id={id}">{id}</a>`. Add a one-liner in the runs panel init to auto-select the run on hash match.

### Left column (`detail-main`)

- **review_threads** — collapsible `field-block`, collapsed by default. One sub-block per thread with header `[open|resolved] {path}:{line} · {n} messages` (use class `.review-thread-header`). Message lines reuse `.comment-line` styling. **Read-only** — no reply UI in this task.

## CSS

Add to inline `<style>` block in [crates/orbit-cli/assets/dashboard/index.html](crates/orbit-cli/assets/dashboard/index.html): `.relation-group`, `.review-thread-header`, `.external-ref-line`. ~30 LOC.

## Constraints / Notes

- Do not introduce a frontend framework; keep the existing vanilla-JS + `el()` helper style consistent with the rest of `app.js`.
- Do not change the API response shape.
- Do not write reply / status-flip controls for review threads in this task — that's a separate feature.
- Existing `.chip`, `.field-block`, `.meta-item`, `.comment-line` classes already exist; reuse them.

### Acceptance Criteria

- When `task.tags` is a non-empty array, the task detail dropdown renders a row of chips (one per tag) above the right-column `details` meta-list, using the existing `.chip` CSS class.
- When `task.external_refs` is non-empty, the dropdown renders an `external refs` field-block in the right column with one line per ref; each ref with a `url` value renders as an anchor `<a href={url}>{system}:{id}</a>`, and refs without a `url` render as plain text `{system}:{id}`.
- When `task.relations` is non-empty, the dropdown renders a `relations` field-block grouped by relation_type; only groups with at least one entry are rendered; clicking a target task id scrolls to and expands that task's row in the visible task list, or copies the id to the clipboard and shows a flash toast when the target is not in the filtered list.
- When `task.job_run_id` is set, the right-column meta-list shows a `job_run` row rendered as `<a href="#runs?run_id={id}">{id}</a>`; clicking it navigates to the runs tab and selects that run via hash matching.
- When `task.review_threads` is a non-empty array, the dropdown renders a collapsible `review threads` field-block in the left column, collapsed by default; expanding it shows one sub-block per thread with header `[open|resolved] {path}:{line} · {n} messages` and message lines styled with `.comment-line`; no reply or status-change controls are present.
- No Rust files are modified; `cargo check` output is identical to baseline; `git diff --stat` for the PR touches only `crates/orbit-cli/assets/dashboard/app.js` and `crates/orbit-cli/assets/dashboard/index.html`.
- `make ci-fast` passes against the branch.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Rendered tags, external refs, grouped task relations, job_run links, and read-only review threads in the dashboard task detail dropdown.
- Added relation target navigation/copy fallback and #runs?run_id=... hash support.
- Added dashboard CSS for the new relation, external ref, tag, and review thread rows.

Assessment: Frontend-only change; git diff touches only crates/orbit-cli/assets/dashboard/app.js and crates/orbit-cli/assets/dashboard/index.html. node --check, git diff --check, cargo check --workspace, quiet cargo check output comparison, and make ci-fast pass.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-00068-6a08dd80`
- Behind base: 0
- Ahead of base: 1