### PR TITLE
Make duel-plan agent pool and per-family model configurable via [duel] in config.toml

### DIFF
--- a/crates/orbit-core/src/config/mod.rs
+++ b/crates/orbit-core/src/config/mod.rs
@@ -23,4 +23,4 @@ mod runtime;
 pub(crate) use bootstrap::seed_default_config;
 pub(crate) use persistence::PersistenceConfig;
 pub use raw::{RawAgentRoleConfig, RawCrewEntry};
-pub(crate) use runtime::{CodexExecutionPolicy, ExecutionEnvPolicy, RuntimeConfig};
+pub(crate) use runtime::{CodexExecutionPolicy, DuelConfig, ExecutionEnvPolicy, RuntimeConfig};

--- a/crates/orbit-core/src/config/raw.rs
+++ b/crates/orbit-core/src/config/raw.rs
@@ -14,6 +14,7 @@ pub(super) struct RawRuntimeConfig {
     pub(super) watch: Option<toml::Value>,
     pub(super) runtime: Option<RawRuntimeSection>,
     pub(super) workflow: Option<RawWorkflowConfig>,
+    pub(super) duel: Option<RawDuelSection>,
     /// Removed in ORB-00058. Kept only so config loading can reject stale
     /// `[agent.<role>]` tables with an explicit migration error.
     pub(super) agent: Option<BTreeMap<String, RawAgentRoleConfig>>,
@@ -32,6 +33,12 @@ pub(super) struct RawWorkflowConfig {
     /// Named crew used when a task does not declare `crew` and no CLI
     /// override is provided.
     pub(super) default_crew: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub(super) struct RawDuelSection {
+    pub(super) candidates: Option<Vec<String>>,
+    pub(super) models: Option<BTreeMap<String, String>>,
 }
 
 /// Schema for a single role assignment in `[crews.<name>]`.

--- a/crates/orbit-core/src/config/runtime.rs
+++ b/crates/orbit-core/src/config/runtime.rs
@@ -3,7 +3,7 @@ use std::fs;
 use std::path::Path;
 
 use orbit_common::types::{
-    Crew, CrewRoleAssignment, OrbitError, activity_job::Backend, resolve_crew,
+    Crew, CrewRoleAssignment, OrbitError, activity_job::Backend, all_agent_families, resolve_crew,
 };
 use orbit_common::utility::redaction::redact_home_dir;
 use orbit_engine::PrConfig;
@@ -12,8 +12,9 @@ use crate::paths;
 
 use super::persistence::PersistenceConfig;
 use super::raw::{
-    RawAgentRoleConfig, RawCodexExecutionConfig, RawCrewEntry, RawExecutionEnvConfig, RawPrSection,
-    RawRuntimeConfig, RawRuntimeSection, RawTaskSection, RawWorkflowConfig,
+    RawAgentRoleConfig, RawCodexExecutionConfig, RawCrewEntry, RawDuelSection,
+    RawExecutionEnvConfig, RawPrSection, RawRuntimeConfig, RawRuntimeSection, RawTaskSection,
+    RawWorkflowConfig,
 };
 
 const DEFAULT_ENV_INHERIT: bool = false;
@@ -45,6 +46,25 @@ pub(crate) struct RuntimeConfig {
     /// Named planner/implementer/reviewer lineups from `[crews.<name>]`.
     pub(crate) crews: BTreeMap<String, Crew>,
     pub(crate) default_crew: Option<String>,
+    pub(crate) duel: DuelConfig,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct DuelConfig {
+    pub(crate) candidates: Vec<String>,
+    pub(crate) models: BTreeMap<String, String>,
+}
+
+impl Default for DuelConfig {
+    fn default() -> Self {
+        Self {
+            candidates: all_agent_families()
+                .iter()
+                .map(|family| (*family).to_string())
+                .collect(),
+            models: BTreeMap::new(),
+        }
+    }
 }
 
 impl Default for RuntimeConfig {
@@ -67,6 +87,7 @@ impl RuntimeConfig {
             workflow_base_branch: DEFAULT_WORKFLOW_BASE_BRANCH.to_string(),
             crews: default_crews(),
             default_crew: Some("opus-codex".to_string()),
+            duel: DuelConfig::default(),
         }
     }
 
@@ -143,6 +164,7 @@ impl RuntimeConfig {
         let workflow_base_branch = workflow_base_branch_from_raw(parsed.workflow.as_ref())?;
         let crews = crews_from_raw(parsed.crews.as_ref())?;
         let default_crew = workflow_default_crew_from_raw(parsed.workflow.as_ref(), &crews)?;
+        let duel = duel_from_raw(parsed.duel.as_ref())?;
         let pr = pr_config_from_raw(parsed.pr.as_ref());
 
         if parsed
@@ -170,6 +192,7 @@ impl RuntimeConfig {
             workflow_base_branch,
             crews,
             default_crew,
+            duel,
         })
     }
 
@@ -184,6 +207,10 @@ impl RuntimeConfig {
 
     pub(crate) fn pr_config(&self) -> &PrConfig {
         &self.pr
+    }
+
+    pub(crate) fn duel_config(&self) -> &DuelConfig {
+        &self.duel
     }
 }
 
@@ -222,6 +249,92 @@ fn pr_config_from_raw(raw: Option<&RawPrSection>) -> PrConfig {
     PrConfig {
         task_url_template: raw.and_then(|section| section.task_url_template.clone()),
     }
+}
+
+fn duel_from_raw(raw: Option<&RawDuelSection>) -> Result<DuelConfig, OrbitError> {
+    let Some(raw) = raw else {
+        return Ok(DuelConfig::default());
+    };
+
+    let candidates = duel_candidates_from_raw(raw.candidates.as_deref())?;
+    let models = duel_models_from_raw(raw.models.as_ref(), &candidates)?;
+    Ok(DuelConfig { candidates, models })
+}
+
+fn duel_candidates_from_raw(raw: Option<&[String]>) -> Result<Vec<String>, OrbitError> {
+    let Some(raw_candidates) = raw else {
+        return Ok(DuelConfig::default().candidates);
+    };
+    if raw_candidates.is_empty() {
+        return Err(OrbitError::InvalidInput(format!(
+            "[duel] candidates must contain at least 3 entries; valid candidates: {}",
+            valid_duel_candidates()
+        )));
+    }
+
+    let valid: BTreeSet<&str> = all_agent_families().into_iter().collect();
+    let mut seen = BTreeSet::new();
+    let mut candidates = Vec::new();
+    for candidate in raw_candidates {
+        let normalized = candidate.trim().to_ascii_lowercase();
+        if !seen.insert(normalized.clone()) {
+            return Err(OrbitError::InvalidInput(format!(
+                "[duel] candidates contains duplicate '{normalized}' after normalization; valid candidates: {}",
+                valid_duel_candidates()
+            )));
+        }
+        if !valid.contains(normalized.as_str()) {
+            return Err(OrbitError::InvalidInput(format!(
+                "[duel] candidates contains unknown entry '{normalized}'; valid candidates: {}",
+                valid_duel_candidates()
+            )));
+        }
+        candidates.push(normalized);
+    }
+
+    if candidates.len() < 3 {
+        return Err(OrbitError::InvalidInput(format!(
+            "[duel] candidates must contain at least 3 distinct entries after normalization (got {}: {}); valid candidates: {}",
+            candidates.len(),
+            candidates.join(", "),
+            valid_duel_candidates()
+        )));
+    }
+
+    Ok(candidates)
+}
+
+fn duel_models_from_raw(
+    raw: Option<&BTreeMap<String, String>>,
+    candidates: &[String],
+) -> Result<BTreeMap<String, String>, OrbitError> {
+    let Some(raw_models) = raw else {
+        return Ok(BTreeMap::new());
+    };
+    let candidate_set: BTreeSet<&str> = candidates.iter().map(String::as_str).collect();
+    let candidate_list = candidates.join(", ");
+    let mut models = BTreeMap::new();
+    for (family, model) in raw_models {
+        let normalized_family = family.trim().to_ascii_lowercase();
+        if !candidate_set.contains(normalized_family.as_str()) {
+            return Err(OrbitError::InvalidInput(format!(
+                "[duel.models] contains key '{normalized_family}' that is not in resolved [duel].candidates ({candidate_list}); valid candidates: {}",
+                valid_duel_candidates()
+            )));
+        }
+        let trimmed_model = model.trim();
+        if trimmed_model.is_empty() {
+            return Err(OrbitError::InvalidInput(format!(
+                "[duel.models].{normalized_family} must not be empty (found '{model}'); configured candidates: {candidate_list}"
+            )));
+        }
+        models.insert(normalized_family, trimmed_model.to_string());
+    }
+    Ok(models)
+}
+
+fn valid_duel_candidates() -> String {
+    all_agent_families().join(", ")
 }
 
 fn reject_stale_agent_role_tables(
@@ -662,6 +775,133 @@ mod tests {
 
     fn write_config(dir: &Path, body: &str) {
         std::fs::write(dir.join("config.toml"), body).expect("write config");
+    }
+
+    fn load_config(body: &str) -> Result<RuntimeConfig, OrbitError> {
+        let global = tempdir().expect("global tempdir");
+        let workspace = tempdir().expect("workspace tempdir");
+        write_config(workspace.path(), body);
+        RuntimeConfig::load_layered(global.path(), workspace.path())
+    }
+
+    fn assert_invalid_duel_config(body: &str, substrings: &[&str]) {
+        let error = load_config(body).expect_err("invalid duel config must fail");
+        let message = error.to_string();
+        assert!(matches!(error, OrbitError::InvalidInput(_)), "{message}");
+        for substring in substrings {
+            assert!(
+                message.contains(substring),
+                "expected {message:?} to contain {substring:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn duel_config_loads_candidates_and_models() {
+        let config = load_config(
+            r#"
+[duel]
+candidates = [" Codex ", "CLAUDE", "gemini"]
+
+[duel.models]
+" Codex " = " gpt-5.5 "
+CLAUDE = " opus-4.7 "
+"#,
+        )
+        .expect("config loads");
+
+        let mut expected_models = BTreeMap::new();
+        expected_models.insert("claude".to_string(), "opus-4.7".to_string());
+        expected_models.insert("codex".to_string(), "gpt-5.5".to_string());
+        assert_eq!(
+            config.duel,
+            DuelConfig {
+                candidates: vec![
+                    "codex".to_string(),
+                    "claude".to_string(),
+                    "gemini".to_string()
+                ],
+                models: expected_models,
+            }
+        );
+    }
+
+    #[test]
+    fn duel_config_defaults_to_all_families_without_section() {
+        let config = load_config("[scoring]\nenabled = true\n").expect("config loads");
+
+        assert_eq!(
+            config.duel.candidates,
+            all_agent_families()
+                .iter()
+                .map(|family| (*family).to_string())
+                .collect::<Vec<_>>()
+        );
+        assert!(config.duel.models.is_empty());
+    }
+
+    #[test]
+    fn duel_config_rejects_empty_candidates() {
+        assert_invalid_duel_config(
+            "[duel]\ncandidates = []\n",
+            &["candidates", "at least 3", "codex, claude, gemini, grok"],
+        );
+    }
+
+    #[test]
+    fn duel_config_rejects_fewer_than_three_distinct_candidates() {
+        assert_invalid_duel_config(
+            "[duel]\ncandidates = [\"codex\", \"claude\"]\n",
+            &["3 distinct", "codex, claude", "codex, claude, gemini, grok"],
+        );
+    }
+
+    #[test]
+    fn duel_config_rejects_duplicate_candidates_after_normalization() {
+        assert_invalid_duel_config(
+            "[duel]\ncandidates = [\"codex\", \" Codex \", \"claude\"]\n",
+            &["duplicate", "codex", "codex, claude, gemini, grok"],
+        );
+    }
+
+    #[test]
+    fn duel_config_rejects_unknown_candidate() {
+        assert_invalid_duel_config(
+            "[duel]\ncandidates = [\"codex\", \"claude\", \"notabot\"]\n",
+            &["notabot", "valid candidates", "codex, claude, gemini, grok"],
+        );
+    }
+
+    #[test]
+    fn duel_config_rejects_model_key_outside_resolved_candidates() {
+        assert_invalid_duel_config(
+            r#"
+[duel]
+candidates = ["codex", "claude", "gemini"]
+
+[duel.models]
+grok = "grok-4"
+"#,
+            &[
+                "grok",
+                "resolved [duel].candidates",
+                "codex, claude, gemini",
+            ],
+        );
+    }
+
+    #[test]
+    fn duel_config_rejects_empty_model_value() {
+        assert_invalid_duel_config(
+            r#"
+[duel]
+candidates = ["codex", "claude", "gemini"]
+
+[duel.models]
+codex = "   "
+"#,
+            &["duel.models", "codex", "   "],
+        );
     }
 
     #[test]

--- a/crates/orbit-core/src/context.rs
+++ b/crates/orbit-core/src/context.rs
@@ -13,7 +13,7 @@ use orbit_store::{
 };
 use orbit_tools::ToolRegistry;
 
-use crate::config::{CodexExecutionPolicy, ExecutionEnvPolicy, PersistenceConfig};
+use crate::config::{CodexExecutionPolicy, DuelConfig, ExecutionEnvPolicy, PersistenceConfig};
 use crate::skill_catalog::SkillCatalog;
 
 const ORBIT_AGENT_NAME: &str = "ORBIT_AGENT_NAME";
@@ -182,6 +182,7 @@ pub(crate) struct OrbitRuntimeSettings {
     workflow_base_branch: String,
     crews: std::collections::BTreeMap<String, Crew>,
     default_crew: Option<String>,
+    duel: DuelConfig,
 }
 
 impl OrbitRuntimeSettings {
@@ -198,6 +199,7 @@ impl OrbitRuntimeSettings {
         workflow_base_branch: String,
         crews: std::collections::BTreeMap<String, Crew>,
         default_crew: Option<String>,
+        duel: DuelConfig,
     ) -> Self {
         Self {
             persistence,
@@ -211,6 +213,7 @@ impl OrbitRuntimeSettings {
             workflow_base_branch,
             crews,
             default_crew,
+            duel,
         }
     }
 
@@ -232,6 +235,10 @@ impl OrbitRuntimeSettings {
 
     pub(crate) fn default_crew(&self) -> Option<&str> {
         self.default_crew.as_deref()
+    }
+
+    pub(crate) fn duel_config(&self) -> &DuelConfig {
+        &self.duel
     }
 }
 
@@ -344,6 +351,10 @@ impl OrbitContext {
 
     pub(crate) fn default_crew(&self) -> Option<&str> {
         self.runtime.default_crew()
+    }
+
+    pub(crate) fn duel_config(&self) -> &DuelConfig {
+        self.runtime.duel_config()
     }
 }
 

--- a/crates/orbit-core/src/runtime/builder.rs
+++ b/crates/orbit-core/src/runtime/builder.rs
@@ -109,6 +109,7 @@ pub(crate) fn build_context_from_roots(
     let workflow_base_branch = runtime_config.workflow_base_branch().to_string();
     let crews = runtime_config.crews.clone();
     let default_crew = runtime_config.default_crew.clone();
+    let duel = runtime_config.duel_config().clone();
 
     Ok(OrbitContext::new(
         paths,
@@ -147,6 +148,7 @@ pub(crate) fn build_context_from_roots(
             workflow_base_branch,
             crews,
             default_crew,
+            duel,
         ),
     ))
 }

--- a/crates/orbit-core/src/runtime/engine/runtime_host.rs
+++ b/crates/orbit-core/src/runtime/engine/runtime_host.rs
@@ -64,6 +64,15 @@ impl RuntimeHost for OrbitRuntime {
         self.configured_agent_model_pair(agent_cli)
     }
 
+    fn duel_candidate_families(&self) -> Vec<String> {
+        self.duel_config().candidates.clone()
+    }
+
+    fn duel_orchestrator_model(&self, family: &str) -> Option<String> {
+        let family = family.trim().to_ascii_lowercase();
+        self.duel_config().models.get(&family).cloned()
+    }
+
     fn canonical_model_name(&self, agent_cli: &str, model: Option<&str>) -> Option<String> {
         self.canonical_model_for_agent(agent_cli, model)
     }

--- a/crates/orbit-core/src/runtime/mod.rs
+++ b/crates/orbit-core/src/runtime/mod.rs
@@ -244,6 +244,10 @@ impl OrbitRuntime {
         self.context.workflow_base_branch()
     }
 
+    pub(crate) fn duel_config(&self) -> &crate::config::DuelConfig {
+        self.context.duel_config()
+    }
+
     /// Build the activity catalog for `target: activity:<name>` resolution
     /// (Phase 4). Loads from the layered Orbit data dirs using §9.1
     /// `MergeByKey` semantics — global provides defaults, workspace overrides.

--- a/crates/orbit-engine/src/context.rs
+++ b/crates/orbit-engine/src/context.rs
@@ -5,7 +5,7 @@ use orbit_common::types::{
     Activity, AgentModelPair, ExecutorDef, ExternalRef, InvocationTrace, Job, JobRun, JobRunState,
     JobTargetType, KnowledgeRunMetrics, OrbitError, OrbitEvent, PipelineState, ReviewThread, Role,
     Task, TaskArtifact, TaskComment, TaskHistoryEntry, TaskPriority, TaskStatus,
-    resolve_agent_model_pair,
+    all_agent_families, resolve_agent_model_pair,
 };
 use orbit_common::utility::redaction::{redact_sensitive_env_json, redact_sensitive_env_option};
 use orbit_exec::EnvironmentMode;
@@ -467,6 +467,15 @@ pub trait RuntimeHost {
     ) -> Result<(), OrbitError>;
     fn resolved_agent_model_pair(&self, agent_cli: &str) -> Option<AgentModelPair> {
         resolve_agent_model_pair(agent_cli)
+    }
+    fn duel_candidate_families(&self) -> Vec<String> {
+        all_agent_families()
+            .iter()
+            .map(|family| (*family).to_string())
+            .collect()
+    }
+    fn duel_orchestrator_model(&self, _family: &str) -> Option<String> {
+        None
     }
     fn canonical_model_name(&self, _agent_cli: &str, model: Option<&str>) -> Option<String> {
         model
@@ -950,6 +959,14 @@ impl RuntimeHost for AutomationExecutorHost<'_> {
 
     fn resolved_agent_model_pair(&self, agent_cli: &str) -> Option<AgentModelPair> {
         self.runtime.resolved_agent_model_pair(agent_cli)
+    }
+
+    fn duel_candidate_families(&self) -> Vec<String> {
+        self.runtime.duel_candidate_families()
+    }
+
+    fn duel_orchestrator_model(&self, family: &str) -> Option<String> {
+        self.runtime.duel_orchestrator_model(family)
     }
 
     fn canonical_model_name(&self, agent_cli: &str, model: Option<&str>) -> Option<String> {

--- a/crates/orbit-engine/src/executor/automation/duel/planning_duel/roles.rs
+++ b/crates/orbit-engine/src/executor/automation/duel/planning_duel/roles.rs
@@ -3,9 +3,7 @@ use std::collections::VecDeque;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use chrono::Utc;
-use orbit_common::types::{
-    Activity, OrbitError, PlanningRoleAssignment, PlanningRoles, all_agent_families,
-};
+use orbit_common::types::{Activity, OrbitError, PlanningRoleAssignment, PlanningRoles};
 use serde_json::{Value, json};
 
 use crate::context::RuntimeHost;
@@ -110,8 +108,8 @@ thread_local! {
         const { RefCell::new(VecDeque::new()) };
 }
 
-fn next_permutation() -> Result<[usize; 3], OrbitError> {
-    let family_count = all_agent_families().len();
+fn next_permutation<H: RuntimeHost + ?Sized>(host: &H) -> Result<[usize; 3], OrbitError> {
+    let family_count = host.duel_candidate_families().len();
     let from_test = TEST_PERMUTATION_QUEUE.with(|cell| cell.borrow_mut().pop_front());
     if let Some(perm) = from_test {
         return validate_role_permutation(perm, family_count, "select_planning_duel_roles");
@@ -128,6 +126,9 @@ fn orchestrator_model_for<H: RuntimeHost + ?Sized>(
     host: &H,
     family: &str,
 ) -> Result<String, OrbitError> {
+    if let Some(model) = host.duel_orchestrator_model(family) {
+        return Ok(model);
+    }
     host.resolved_agent_model_pair(family)
         .map(|pair| pair.orchestrator)
         .ok_or_else(|| {
@@ -151,11 +152,11 @@ fn build_roles_output<H: RuntimeHost + ?Sized>(
     host: &H,
     perm: [usize; 3],
 ) -> Result<Value, OrbitError> {
-    let families = all_agent_families();
+    let families = host.duel_candidate_families();
     let perm = validate_role_permutation(perm, families.len(), "select_planning_duel_roles")?;
-    let planner_a = families[perm[0]];
-    let planner_b = families[perm[1]];
-    let arbiter = families[perm[2]];
+    let planner_a = families[perm[0]].as_str();
+    let planner_b = families[perm[1]].as_str();
+    let arbiter = families[perm[2]].as_str();
 
     let started_at = Utc::now().to_rfc3339();
 
@@ -295,7 +296,7 @@ pub(super) fn select_planning_duel_roles<H: RuntimeHost + ?Sized>(
     input: &Value,
 ) -> Result<Value, OrbitError> {
     let task_id = required_input_string(input, "task_id")?;
-    let perm = next_permutation()?;
+    let perm = next_permutation(host)?;
     let output = build_roles_output(host, perm)?;
 
     Ok(json!({
@@ -328,15 +329,21 @@ mod tests {
         data_root: PathBuf,
         scoreboard_dir: PathBuf,
         registry: ActivityExecutorRegistry,
+        duel_model: Option<String>,
     }
 
     impl TestHost {
         fn new() -> Self {
+            Self::with_duel_model(None)
+        }
+
+        fn with_duel_model(duel_model: Option<&str>) -> Self {
             let temp_root = std::env::temp_dir().join("orbit-planning-duel-role-test");
             Self {
                 scoreboard_dir: temp_root.join("scoreboard"),
                 data_root: temp_root,
                 registry: ActivityExecutorRegistry::default(),
+                duel_model: duel_model.map(ToOwned::to_owned),
             }
         }
     }
@@ -410,11 +417,19 @@ mod tests {
 
         fn resolved_agent_model_pair(&self, agent_cli: &str) -> Option<AgentModelPair> {
             match agent_cli {
-                "codex" => Some(AgentModelPair::new("gpt-5.5", "gpt-5.4-mini")),
+                "codex" => Some(AgentModelPair::new("M_exec", "_")),
                 "claude" => Some(AgentModelPair::new("opus-4.7", "sonnet-4.6")),
                 "gemini" => Some(AgentModelPair::new("pro", "flash")),
                 "grok" => Some(AgentModelPair::new("grok-4", "grok-3")),
                 _ => None,
+            }
+        }
+
+        fn duel_orchestrator_model(&self, family: &str) -> Option<String> {
+            if family == "codex" {
+                self.duel_model.clone()
+            } else {
+                None
             }
         }
 
@@ -445,5 +460,34 @@ mod tests {
         );
         assert_eq!(output["planner_b_agent_cli"], "codex");
         assert_eq!(output["arbiter_agent_cli"], "claude");
+    }
+
+    fn queue_permutation(perm: [usize; 3]) {
+        TEST_PERMUTATION_QUEUE.with(|cell| {
+            let mut queue = cell.borrow_mut();
+            queue.clear();
+            queue.push_back(perm);
+        });
+    }
+
+    #[test]
+    fn planning_duel_roles_prefer_duel_model_then_resolved_pair() {
+        queue_permutation([0, 1, 2]);
+        let host = TestHost::with_duel_model(Some("M_duel"));
+        let output = select_planning_duel_roles(&host, &json!({ "task_id": "ORB-TEST" }))
+            .expect("planning role selection uses duel model");
+        assert_eq!(
+            output["planning_duel_roles"]["planner_a"]["model"],
+            "M_duel"
+        );
+
+        queue_permutation([0, 1, 2]);
+        let host = TestHost::with_duel_model(None);
+        let output = select_planning_duel_roles(&host, &json!({ "task_id": "ORB-TEST" }))
+            .expect("planning role selection falls back to resolved pair");
+        assert_eq!(
+            output["planning_duel_roles"]["planner_a"]["model"],
+            "M_exec"
+        );
     }
 }

--- a/crates/orbit-engine/src/executor/automation/duel/select_roles.rs
+++ b/crates/orbit-engine/src/executor/automation/duel/select_roles.rs
@@ -11,7 +11,7 @@
 //! resolves the agent from task metadata — picks up the implementer for
 //! this run.
 //!
-//! Randomness source: `SystemTime` nanoseconds modulo the six possible
+//! Randomness source: `SystemTime` nanoseconds modulo the possible
 //! permutations. A thread-local test seam lets unit tests inject a
 //! deterministic queue of permutation indices, so behavior can be
 //! verified without patching the clock.
@@ -21,7 +21,7 @@ use std::collections::VecDeque;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use chrono::Utc;
-use orbit_common::types::{OrbitError, all_agent_families};
+use orbit_common::types::OrbitError;
 use serde_json::{Value, json};
 
 use crate::context::{RuntimeHost, TaskAutomationUpdate, TaskHost};
@@ -39,8 +39,8 @@ thread_local! {
 
 /// Pick the next permutation of family indices — test override first,
 /// otherwise derive from `SystemTime` nanoseconds.
-fn next_permutation() -> Result<[usize; 3], OrbitError> {
-    let family_count = all_agent_families().len();
+fn next_permutation<H: RuntimeHost + ?Sized>(host: &H) -> Result<[usize; 3], OrbitError> {
+    let family_count = host.duel_candidate_families().len();
     let from_test = TEST_PERMUTATION_QUEUE.with(|cell| cell.borrow_mut().pop_front());
     if let Some(perm) = from_test {
         return validate_role_permutation(perm, family_count, "select_duel_roles");
@@ -61,11 +61,11 @@ fn build_roles_output<H: RuntimeHost + ?Sized>(
     host: &H,
     perm: [usize; 3],
 ) -> Result<Value, OrbitError> {
-    let families = all_agent_families();
+    let families = host.duel_candidate_families();
     let perm = validate_role_permutation(perm, families.len(), "select_duel_roles")?;
-    let implementer = families[perm[0]];
-    let reviewer = families[perm[1]];
-    let arbiter = families[perm[2]];
+    let implementer = families[perm[0]].as_str();
+    let reviewer = families[perm[1]].as_str();
+    let arbiter = families[perm[2]].as_str();
 
     let implementer_model = orchestrator_model_for(host, implementer)?;
     let reviewer_model = orchestrator_model_for(host, reviewer)?;
@@ -97,6 +97,9 @@ fn orchestrator_model_for<H: RuntimeHost + ?Sized>(
     host: &H,
     family: &str,
 ) -> Result<String, OrbitError> {
+    if let Some(model) = host.duel_orchestrator_model(family) {
+        return Ok(model);
+    }
     host.resolved_agent_model_pair(family)
         .map(|pair| pair.orchestrator)
         .ok_or_else(|| {
@@ -113,7 +116,7 @@ pub(in crate::executor::automation) fn select_duel_roles<H: RuntimeHost + TaskHo
 ) -> Result<Value, OrbitError> {
     let task_id = required_input_string(input, "task_id")?;
 
-    let perm = next_permutation()?;
+    let perm = next_permutation(host)?;
     let output = build_roles_output(host, perm)?;
 
     // Stamp the implementer onto the task's actor identity so that the
@@ -138,4 +141,229 @@ pub(in crate::executor::automation) fn select_duel_roles<H: RuntimeHost + TaskHo
     )?;
 
     Ok(output)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::{Path, PathBuf};
+
+    use orbit_common::types::{
+        Activity, AgentModelPair, ExternalRef, Job, JobTargetType, OrbitEvent, Role, Task,
+        TaskArtifact, TaskPriority, TaskStatus,
+    };
+    use orbit_store::InvocationRecord;
+    use orbit_tools::ToolContext;
+
+    use crate::context::{
+        JobRunResult, RuntimeHost, TaskAutomationUpdate, TaskReadHost, TaskWriteHost,
+    };
+    use crate::executor::registry::ActivityExecutorRegistry;
+
+    use super::*;
+
+    struct TestHost {
+        data_root: PathBuf,
+        scoreboard_dir: PathBuf,
+        registry: ActivityExecutorRegistry,
+        duel_model: Option<String>,
+    }
+
+    impl TestHost {
+        fn new(duel_model: Option<&str>) -> Self {
+            let temp_root = std::env::temp_dir().join("orbit-duel-role-test");
+            Self {
+                scoreboard_dir: temp_root.join("scoreboard"),
+                data_root: temp_root,
+                registry: ActivityExecutorRegistry::default(),
+                duel_model: duel_model.map(ToOwned::to_owned),
+            }
+        }
+    }
+
+    impl RuntimeHost for TestHost {
+        fn record_event(&self, _event: OrbitEvent) -> Result<(), OrbitError> {
+            Ok(())
+        }
+
+        fn repo_root(&self) -> Result<String, OrbitError> {
+            Ok(self.data_root.to_string_lossy().to_string())
+        }
+
+        fn data_root(&self) -> &Path {
+            &self.data_root
+        }
+
+        fn activity_executor_registry(&self) -> &ActivityExecutorRegistry {
+            &self.registry
+        }
+
+        fn run_job_now_with_input_debug(
+            &self,
+            _job_id: &str,
+            _input: Value,
+            _debug: bool,
+        ) -> Result<JobRunResult, OrbitError> {
+            unimplemented!("not needed by duel role tests")
+        }
+
+        fn validate_activity_target_exists(
+            &self,
+            _target_type: JobTargetType,
+            _target_id: &str,
+        ) -> Result<Activity, OrbitError> {
+            unimplemented!("not needed by duel role tests")
+        }
+
+        fn get_job(&self, _job_id: &str) -> Result<Option<Job>, OrbitError> {
+            Ok(None)
+        }
+
+        fn invocation_records(
+            &self,
+            _query: orbit_store::InvocationQuery,
+        ) -> Result<Vec<InvocationRecord>, OrbitError> {
+            Ok(Vec::new())
+        }
+
+        fn run_tool_with_context_and_role(
+            &self,
+            _name: &str,
+            _input: Value,
+            _role: Role,
+            _tool_context: ToolContext,
+        ) -> Result<Value, OrbitError> {
+            unimplemented!("not needed by duel role tests")
+        }
+
+        fn maybe_create_failure_task(
+            &self,
+            _job_id: &str,
+            _run_id: &str,
+            _error_code: &str,
+            _error_message: &str,
+            _agent: Option<&str>,
+            _model: Option<&str>,
+        ) -> Result<(), OrbitError> {
+            Ok(())
+        }
+
+        fn resolved_agent_model_pair(&self, agent_cli: &str) -> Option<AgentModelPair> {
+            match agent_cli {
+                "codex" => Some(AgentModelPair::new("M_exec", "_")),
+                "claude" => Some(AgentModelPair::new("opus-4.7", "sonnet-4.6")),
+                "gemini" => Some(AgentModelPair::new("pro", "flash")),
+                _ => None,
+            }
+        }
+
+        fn duel_candidate_families(&self) -> Vec<String> {
+            ["codex", "claude", "gemini"]
+                .iter()
+                .map(|family| (*family).to_string())
+                .collect()
+        }
+
+        fn duel_orchestrator_model(&self, family: &str) -> Option<String> {
+            if family == "codex" {
+                self.duel_model.clone()
+            } else {
+                None
+            }
+        }
+
+        fn scoring_enabled(&self) -> bool {
+            false
+        }
+
+        fn graph_editing(&self) -> bool {
+            false
+        }
+
+        fn scoreboard_dir(&self) -> &Path {
+            &self.scoreboard_dir
+        }
+    }
+
+    impl TaskReadHost for TestHost {
+        fn get_task(&self, _task_id: &str) -> Result<Task, OrbitError> {
+            unimplemented!("not needed by duel role tests")
+        }
+
+        fn get_task_artifacts(&self, _task_id: &str) -> Result<Vec<TaskArtifact>, OrbitError> {
+            Ok(Vec::new())
+        }
+
+        fn list_tasks_filtered(
+            &self,
+            _status: Option<TaskStatus>,
+            _priority: Option<TaskPriority>,
+            _parent_id: Option<&str>,
+            _job_run_id: Option<&str>,
+            _external_ref: Option<&ExternalRef>,
+            _has_external_ref_system: Option<&str>,
+        ) -> Result<Vec<Task>, OrbitError> {
+            Ok(Vec::new())
+        }
+    }
+
+    impl TaskWriteHost for TestHost {
+        fn start_task(
+            &self,
+            _task_id: &str,
+            _note: Option<String>,
+            _comment: Option<String>,
+        ) -> Result<Task, OrbitError> {
+            unimplemented!("not needed by duel role tests")
+        }
+
+        fn admit_task_for_workflow(
+            &self,
+            _task_id: &str,
+            _workflow: &str,
+        ) -> Result<Task, OrbitError> {
+            unimplemented!("not needed by duel role tests")
+        }
+
+        fn update_task_from_activity(
+            &self,
+            _task_id: &str,
+            _status: TaskStatus,
+            _execution_summary: Option<String>,
+            _comment: Option<String>,
+            _note: Option<String>,
+        ) -> Result<Task, OrbitError> {
+            unimplemented!("not needed by duel role tests")
+        }
+
+        fn apply_task_automation_update(
+            &self,
+            _task_id: &str,
+            _update: TaskAutomationUpdate,
+        ) -> Result<(), OrbitError> {
+            Ok(())
+        }
+    }
+
+    fn queue_permutation(perm: [usize; 3]) {
+        TEST_PERMUTATION_QUEUE.with(|cell| {
+            let mut queue = cell.borrow_mut();
+            queue.clear();
+            queue.push_back(perm);
+        });
+    }
+
+    #[test]
+    fn select_duel_roles_prefers_duel_model_then_resolved_pair() {
+        queue_permutation([0, 1, 2]);
+        let host = TestHost::new(Some("M_duel"));
+        let output = select_duel_roles(&host, &json!({ "task_id": "ORB-TEST" }))
+            .expect("role selection uses duel model");
+        assert_eq!(output["duel_roles"]["implementer"]["model"], "M_duel");
+
+        queue_permutation([0, 1, 2]);
+        let host = TestHost::new(None);
+        let output = select_duel_roles(&host, &json!({ "task_id": "ORB-TEST" }))
+            .expect("role selection falls back to resolved pair");
+        assert_eq!(output["duel_roles"]["implementer"]["model"], "M_exec");
+    }
 }

--- a/docs/design/agent-families/1_overview.md
+++ b/docs/design/agent-families/1_overview.md
@@ -10,7 +10,7 @@ Orbit models AI coding systems as first-class agent families and now groups conc
 
 Orbit was initially built around three dominant agent CLIs: Claude Code, Codex (OpenAI), and Gemini. As more agents gained strong coding capabilities, including Grok via Grok Build and the xAI API, Orbit needed stable family identifiers for attribution, execution, review, and analytics.
 
-Family defaults were originally also used to pick activity role models, but that made per-task model experiments require editing workspace config. The crew registry introduced by [ORB-00058] separates model selection from family discovery: workspaces define named lineups in `[crews.<name>]`, tasks may pin `crew`, and operators may override the crew for a single run.
+Family defaults were originally also used to pick activity role models, but that made per-task model experiments require editing workspace config. The crew registry introduced by [ORB-00058] separates model selection from family discovery: workspaces define named lineups in `[crews.<name>]`, tasks may pin `crew`, and operators may override the crew for a single run. Duel-plan role selection has a narrower workspace knob under `[duel]`: operators can allowlist candidate families and pin duel-only orchestrator models without changing executor YAML or affecting non-duel callers.
 
 ## 2. Core Concepts
 
@@ -30,6 +30,7 @@ Family defaults were originally also used to pick activity role models, but that
 | Runtime config loading | `crates/orbit-core/src/config/runtime.rs` | [ORB-00058] |
 | Default config template | `crates/orbit-core/assets/config/default-config.toml` | [ORB-00058] |
 | Run-time crew resolution | `crates/orbit-core/src/runtime/engine/crew.rs` | [ORB-00058] |
+| Duel candidate and model config | `crates/orbit-core/src/config/runtime.rs` | [ORB-00072] |
 | Tool and CLI crew surfaces | `crates/orbit-tools/src/builtin/orbit/task/` | [ORB-00058] |
 | Grok family onboarding | `crates/orbit-common/src/types/agent_pair.rs` | [ORB-00042] |
 
@@ -39,5 +40,6 @@ Family defaults were originally also used to pick activity role models, but that
 - ORB-00043: Add Grok to agent_from_model, all_agent_families, and provider_from_model.
 - ORB-00048: Harden duels, scoreboards, review sync, friction stats, and analytics for the fourth family.
 - ORB-00058: Introduce per-task crew override for agent model selection.
+- ORB-00072: Make duel-plan agent pool and per-family model configurable via `[duel]`.
 
 Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.

--- a/docs/design/agent-families/2_design.md
+++ b/docs/design/agent-families/2_design.md
@@ -4,13 +4,15 @@
 **Owner:** human
 **Last updated:** 2026-05-16
 
-This document describes the current implementation of Orbit agent families and crew-based role assignment. It covers the family registry, the workspace crew registry, task and CLI override surfaces, and where resolved run metadata is persisted.
+This document describes the current implementation of Orbit agent families, crew-based role assignment, and duel-plan participant configuration. It covers the family registry, workspace config surfaces, task and CLI override surfaces, and where resolved run metadata is persisted.
 
 ## 1. Family Registry
 
 The family registry lives in `crates/orbit-common/src/types/agent_pair.rs`. `all_agent_families()` returns the supported family identifiers, while `agent_from_model()` and `infer_agent_family_from_model()` map model prefixes to those families. Prefix inference remains intentionally conservative because older persisted artifacts may only contain a model string.
 
 Adding a family is still a cross-cutting change: executor assets, sandbox behavior, provider inference, review automation, and scoreboard code all need review. The fixed registry forces that audit instead of silently accepting unknown families.
+
+`[duel].candidates` can narrow this fixed registry for duel-plan role selection. The configured list must still be a subset of `all_agent_families()` with at least three distinct normalized entries, so duel permutations remain well-defined.
 
 ## 2. Crew Registry
 
@@ -42,15 +44,28 @@ Run-start code resolves the crew before dispatch, emits structured tracing field
 
 Legacy records without crew fields still deserialize because the run-record fields are optional. Display code may use `infer_agent_family_from_model()` only as a recovery path for older artifacts.
 
-## 5. Concerns & Honest Limitations
+## 5. Duel-Plan Configuration
+
+Duel-plan has an explicit `[duel]` section in `.orbit/config.toml`. `candidates` controls the role-selection family pool, defaulting to `all_agent_families()` when absent. `[duel.models]` is a flat map from candidate family to duel-only orchestrator model.
+
+The duel model precedence is:
+
+1. `[duel.models.<family>]`
+2. `.orbit/executors/<family>.yaml::model_pair_override`
+3. `resolve_agent_model_pair()` builtin defaults
+
+This precedence is scoped to duel role selection through `RuntimeHost::duel_orchestrator_model`; non-duel model identity, envelope rendering, review sync, and task-review scoring continue to start at executor overrides and builtin defaults.
+
+## 6. Concerns & Honest Limitations
 
 Crew names are workspace-local strings. Renaming or deleting a crew can break a task that still references the old name, though existing run records keep the resolved model strings.
 
-Duel-plan participant configuration still uses the older family walk and was deliberately left for a separate task. Task-level per-role overrides were also deferred; today a task picks an entire crew, not a single replacement planner or reviewer.
+Task-level per-role overrides were deferred; today a task picks an entire crew, not a single replacement planner or reviewer. Duel-plan config is workspace-wide and config-only; there are no CLI flags for one-off duel candidates or model overrides.
 
 ## Task References
 
 - ORB-00042: Onboard Grok (xAI) as a first-class supported agent family.
 - ORB-00058: Introduce per-task crew override for agent model selection.
+- ORB-00072: Make duel-plan agent pool and per-family model configurable via `[duel]`.
 
 Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.

--- a/docs/design/agent-families/4_decisions.md
+++ b/docs/design/agent-families/4_decisions.md
@@ -35,9 +35,23 @@ See full ADR-0151 for context, alternatives considered, and cost analysis.
 - Deferred: duel-plan participant configuration, per-role task overrides, planner-vs-executor workflow split, and the legacy-resolver migration noted above.
 - Cost: old workspaces with only `[agent.planner]`, `[agent.implementer]`, and `[agent.reviewer]` must migrate before config load succeeds.
 
+## ADR-0153 — Scope duel-plan candidate and model overrides to `[duel]`
+
+**Status:** Accepted · 2026-05 · [ORB-00072]
+
+**Context.** Duel-plan previously walked the full `all_agent_families()` registry and used the same model-pair resolution chain as non-duel callers. That made local CLI availability load-bearing for every supported family and made reproducible planning-duel scoreboards depend on executor YAML state.
+
+**Decision.** Add a workspace `[duel]` section with `candidates` as a normalized subset of `all_agent_families()` and `[duel.models]` as flat orchestrator-only per-family overrides. Duel role selection reads those values through `RuntimeHost`; non-duel callers continue to use executor overrides and builtin model pairs.
+
+**Consequences.**
+- Duel permutations remain dynamic but require at least three distinct configured families.
+- `[duel.models]` wins only for duel role-model lookup; helper models and non-duel model identity are unchanged.
+- The crew registry remains separate from duel participant selection. Reusing `[crews.*]` for duels was rejected because duels need a family pool, not a fixed planner/implementer/reviewer lineup.
+
 ## Task References
 
 - ORB-00042: Onboard Grok (xAI) as a first-class supported agent family.
 - ORB-00058: Introduce per-task crew override for agent model selection.
+- ORB-00072: Make duel-plan agent pool and per-family model configurable via `[duel]`.
 
 Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.

--- a/docs/design/agent-families/references/glossary.md
+++ b/docs/design/agent-families/references/glossary.md
@@ -4,6 +4,8 @@
 
 **model pair** — The `(orchestrator, helper)` model duo resolved for a family via `resolve_agent_model_pair()`. Used by activity jobs and planning duels.
 
+**duel candidate** — A family in the active `[duel].candidates` allowlist. Defaults to `all_agent_families()` and must keep at least three distinct families so role permutations remain valid.
+
 **all_agent_families()** — The single source of truth function in `orbit-common` that returns the fixed-size array of supported families. Changing its size is intentionally high-friction.
 
 **executor** — The YAML definition (`crates/orbit-core/assets/executors/<family>.yaml`) that describes how `backend: cli` invokes an agent's CLI.


### PR DESCRIPTION
## Task

[ORB-00072](https://orbit-cli.com/tasks/ORB-00072) — Make duel-plan agent pool and per-family model configurable via [duel] in config.toml

### Description

## Problem

The `duel-plan` workflow's candidate agent pool is hardcoded in
`orbit_common::types::agent_pair::all_agent_families()` — a `const fn`
returning `["codex", "claude", "gemini", "grok"]`. Per-family orchestrator
models likewise come from the hardcoded match in
`resolve_agent_model_pair()` (or, when present, the per-machine
`.orbit/executors/<family>.yaml::model_pair_override`).

There is no way for an operator to:

- Narrow the duel pool (e.g. exclude `grok` when the CLI isn't installed
  locally — today the duel can pick it and fail).
- Override the duel's per-family orchestrator model from `config.toml`,
  alongside the existing `[crews.*]` and `[workflow]` sections, without
  hand-editing executor YAML.

## Why It Matters

- **Operability.** Each agent family in `all_agent_families()` is currently
  load-bearing for the duel: missing a CLI ⇒ failed runs. A config-driven
  allowlist lets users opt out per-workspace without touching code.
- **Reproducibility.** Pinning per-family orchestrator models in
  `config.toml` keeps planning-duel scoreboard rows (`.orbit/state/scoreboard/duel_plan.json`)
  comparable across machines and contributors.
- **Surface consistency.** `[crews.*]`, `[workflow]`, and the rest of the
  Orbit runtime story already live in `config.toml`; the duel pool is the
  outlier.

## Proposed Design

Resolution agreed with the requester (option **C** + flat orchestrator-only
+ `[duel]` wins precedence; see "Out of Scope" for what we are *not*
adding):

### New `config.toml` section

```toml
[duel]
candidates = ["codex", "claude", "gemini"]   # optional; defaults to all_agent_families()

[duel.models]                                # optional; flat orchestrator-only
codex  = "gpt-5.5"
claude = "opus-4.7"
gemini = "pro"
```

Semantics:

- `candidates`: must be a subset of `all_agent_families()`. Trimmed,
  lowercased, ≥ 3 distinct entries when present. Absent ⇒ today's full
  family list (current behavior preserved).
- `models`: each key must be a member of the resolved candidate set; each
  value must be a non-empty string. Absent ⇒ empty map (current behavior
  preserved). Only the orchestrator model is overridable here — the helper
  model continues to resolve via the existing
  `executors/*.yaml::model_pair_override` → builtin defaults chain.

### Precedence (duel role-model lookup only)

```
1. [duel.models.<family>] in config.toml             <- new
2. .orbit/executors/<family>.yaml::model_pair_override
3. orbit_common::types::resolve_agent_model_pair (builtin)
```

Non-duel call sites (`envelope.rs`, `review/sync_review/thread_sync.rs`,
`OrbitRuntime::canonical_model_for_agent`) **must not** observe step 1.
They keep starting at step 2.

### Implementation outline

1. **Config layer (`orbit-core`)**
   - Add `RawDuelSection { candidates: Option<Vec<String>>, models: Option<BTreeMap<String, String>> }` to `crates/orbit-core/src/config/raw.rs`.
   - Add `DuelConfig { candidates: Vec<String>, models: BTreeMap<String, String> }` field to `RuntimeConfig` in `crates/orbit-core/src/config/runtime.rs`.
   - New `duel_from_raw(...)` validator — see "Validation rules" below.
   - Expose `OrbitRuntime::duel_config(&self) -> &DuelConfig` (or equivalent accessor).

2. **Host trait surface (`orbit-engine::context::RuntimeHost`)**
   - Add two methods with default implementations so test hosts don't churn:
     - `fn duel_candidate_families(&self) -> Vec<String>` — default returns `all_agent_families()` collected to `Vec<String>`.
     - `fn duel_orchestrator_model(&self, family: &str) -> Option<String>` — default returns `None`.
   - `impl RuntimeHost for OrbitRuntime` overrides both, sourcing from `duel_config()`.

3. **Duel role selection (both sites)**
   - `crates/orbit-engine/src/executor/automation/duel/select_roles.rs`: replace `all_agent_families()` (line 43 area) with `host.duel_candidate_families()`. In `orchestrator_model_for`, try `host.duel_orchestrator_model(family)` first; on `None`, fall back to today's `host.resolved_agent_model_pair(family).orchestrator`.
   - `crates/orbit-engine/src/executor/automation/duel/planning_duel/roles.rs`: same swap (line 114 area) and same `orchestrator_model_for` change.
   - `role_permutation_at` / `validate_role_permutation` in `duel/mod.rs` already accept dynamic `family_count: usize` — no signature change needed.

### Validation rules (must reject at config load)

- `candidates` is `Some(vec)` but `vec.is_empty()`.
- `candidates` has fewer than 3 distinct entries after trim+lowercase.
- `candidates` contains a duplicate (post-normalization).
- `candidates` contains an entry not in `all_agent_families()`.
- `models` has a key that is not in the resolved candidate set.
- `models` has an empty-string or whitespace-only value.

Error messages must name the offending entry and the valid set.

## Constraints / Notes

- **Backward compatible.** Absent `[duel]` section ⇒ identical behavior to
  today (full family pool, no per-family override).
- **No CLI flag override.** Do not add `orbit run duel-plan --candidate`
  or `--model` flags in this task — config-only.
- **No helper-model override.** `[duel.models]` is flat orchestrator-only;
  helper models keep flowing through the existing chain.
- **Test seam unchanged.** The thread-local `TEST_PERMUTATION_QUEUE` test
  hooks in both `select_roles.rs` and `planning_duel/roles.rs` stay.
- **Decay docs.** If a `docs/design/<feature>/` doc references the duel
  agent pool, bump `Last updated:` and flip any affected ADR statuses in
  the same PR (per `CLAUDE.md` Design Docs rules).

## Out of Scope

- CLI flag override for candidates/models.
- Helper-model override in `[duel.models]`.
- Reworking `[crews.*]` to drive the duel (alternative option B,
  explicitly rejected).
- Any change to non-duel call sites of `resolve_agent_model_pair` or
  `RuntimeHost::resolved_agent_model_pair`.

### Acceptance Criteria

- Parsing `config.toml` with a valid `[duel]` section (candidates subset of all_agent_families() with >= 3 entries, optional flat `[duel.models]` map) populates `RuntimeConfig.duel: DuelConfig { candidates: Vec<String>, models: BTreeMap<String, String> }` exactly as declared (trimmed, lowercased). Verified by a new unit test in `crates/orbit-core/src/config/runtime.rs` (or sibling tests module) using an in-memory TOML string.
- Parsing rejects each of the following invalid `[duel]` configs with an `OrbitError::InvalidInput` whose message names the offending entry: (a) empty `candidates` array, (b) candidates with fewer than 3 distinct entries after normalization, (c) duplicate candidates, (d) candidate not in `all_agent_families()`, (e) `models` key not in the resolved candidate set, (f) `models` value that is empty or whitespace-only. Each failure case has a dedicated unit test asserting the variant and the substring of the offending key/value in the error message.
- Absent `[duel]` section in `config.toml` yields `RuntimeConfig.duel.candidates == all_agent_families().iter().map(|s| s.to_string()).collect::<Vec<_>>()` and `RuntimeConfig.duel.models.is_empty() == true`. Verified by a unit test that loads a config TOML containing no `[duel]` table.
- `RuntimeHost` (in `crates/orbit-engine/src/context.rs`) exposes two new methods with default implementations: `fn duel_candidate_families(&self) -> Vec<String>` returning `all_agent_families().iter().map(|s| (*s).to_string()).collect()`, and `fn duel_orchestrator_model(&self, family: &str) -> Option<String>` returning `None`. `impl RuntimeHost for OrbitRuntime` in `crates/orbit-core/src/runtime/engine/runtime_host.rs` overrides both to read from `duel_config()`.
- Both duel role-selection sites consume the new host methods instead of `all_agent_families()` directly: `crates/orbit-engine/src/executor/automation/duel/select_roles.rs::next_permutation` and `crates/orbit-engine/src/executor/automation/duel/planning_duel/roles.rs::next_permutation` both call `host.duel_candidate_families()`; both `orchestrator_model_for` helpers call `host.duel_orchestrator_model(family)` first and fall back to `host.resolved_agent_model_pair(family).map(|p| p.orchestrator)` on `None`. Verified by `grep -n 'all_agent_families' crates/orbit-engine/src/executor/automation/duel/` returning no matches outside the `#[cfg(test)]` module in `duel/mod.rs`.
- A unit test in `crates/orbit-engine/src/executor/automation/duel/select_roles.rs` (or sibling tests module) uses a stub `RuntimeHost` and the existing `TEST_PERMUTATION_QUEUE` seam to assert resolution precedence for a family that has all three layers configured: (1) when `duel_orchestrator_model` returns `Some("M_duel")`, the resulting role assignment's model field is `M_duel`; (2) when `duel_orchestrator_model` returns `None` and `resolved_agent_model_pair` returns `AgentModelPair::new("M_exec", "_")`, the model is `M_exec`. The planning-duel sibling site (`planning_duel/roles.rs`) has the analogous test.
- Non-duel callers of `resolved_agent_model_pair` are unchanged. Verified by inspection in the PR description and by `grep -n 'duel_orchestrator_model' crates/orbit-engine/src/executor/automation/review/sync_review/thread_sync.rs crates/orbit-core/src/runtime/engine/envelope.rs crates/orbit-core/src/runtime/engine/identity.rs crates/orbit-core/src/command/task/review.rs` returning zero matches.
- `make ci-fast` passes from the workspace root with the change applied.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Added `[duel]` runtime config parsing with normalized candidate allowlists, duel-only orchestrator model overrides, defaults, and InvalidInput validation coverage.
- Exposed duel candidate/model lookup through `RuntimeHost` and `OrbitRuntime`, including automation host delegation.
- Routed both duel role selectors through the new host methods while preserving fallback to existing resolved model pairs for non-duel behavior.
- Updated agent-family design docs to reflect duel-plan configuration and recorded the ORB-00072 decision.

Assessment: Focused implementation with targeted config and role-selection tests plus repo guardrails passing.

Design weaknesses / risks:
- `make check-design-docs` still reports unrelated stale docs outside `docs/design/agent-families`; the updated agent-family docs were not among the stale entries. | Severity: Low | Mitigation: `make ci-fast` passes and the stale-doc list is pre-existing/out of task scope.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-00072-6a08df9b`
- Behind base: 0
- Ahead of base: 1