### PR TITLE
Add ADRs subtab to dashboard Knowledge tab with accept/supersede

### DIFF
--- a/crates/orbit-cli/assets/dashboard/app.js
+++ b/crates/orbit-cli/assets/dashboard/app.js
@@ -26,6 +26,7 @@ const DIAG_LIMIT = positiveIntParam("diag", 50);
 const AUDIT_LIMIT = positiveIntParam("audit", 50);
 const RUN_EVENTS_LIMIT = positiveIntParam("events", 100);
 const LEARNING_LIMIT = positiveIntParam("learnings", 100);
+const ADR_LIMIT = positiveIntParam("adrs", 100);
 
 const AUDIT_STATUSES = ["success", "failure", "denied"];
 const CANCELLABLE_RUN_STATES = new Set(["pending", "running"]);
@@ -40,6 +41,7 @@ let lastTasks = [];
 let lastRuns = [];
 let lastDiagnostics = { metrics: [], errors: [] };
 let lastLearningPayload = { stats: {}, items: [] };
+let lastAdrPayload = { stats: {}, items: [] };
 let activeTab = "tasks";
 let activeDiagSubtab = "runs";
 let activeKnowledgeSubtab = "learnings";
@@ -49,6 +51,8 @@ let isRefreshing = false;
 let taskActionNotice = null;
 let activeLearningId = null;
 let learningSearchQuery = "";
+let activeAdrId = null;
+let adrSearchQuery = "";
 
 // Audit tab state
 let lastAudit = [];
@@ -1492,6 +1496,239 @@ async function supersedeLearning(learning, by, btn, detail) {
   }
 }
 
+function adrList(adr, field) {
+  return Array.isArray(adr && adr[field]) ? adr[field] : [];
+}
+
+function adrPrimaryFeature(adr) {
+  const features = adrList(adr, "related_features");
+  if (features.length === 0) return "-";
+  if (features.length === 1) return features[0];
+  return `${features[0]} +${features.length - 1}`;
+}
+
+function renderAdrStats(stats = {}) {
+  $("adr-proposed-value").textContent = formatBigInt(stats.proposed || 0);
+  $("adr-accepted-value").textContent = formatBigInt(stats.accepted || 0);
+  $("adr-superseded-value").textContent = formatBigInt(stats.superseded || 0);
+}
+
+function renderAdrs(payload) {
+  const body = $("adrs-body");
+  if (!body) return;
+  const items = Array.isArray(payload && payload.items) ? payload.items : [];
+  const stats = (payload && payload.stats) || {};
+  renderAdrStats(stats);
+  $("knowledge-count").textContent = `${items.length}/${stats.total || items.length}`;
+
+  if (items.length > 0 && !items.some((item) => item.id === activeAdrId)) {
+    activeAdrId = items[0].id;
+  }
+  if (items.length === 0) activeAdrId = null;
+
+  if (items.length === 0) {
+    syncNodes(body, [el("div", { class: "empty-state" }, [
+      el("div", { class: "icon", text: "✧" }),
+      el("div", { class: "text", text: "No ADRs match the current filter." }),
+    ])]);
+    renderAdrDetail(null);
+    return;
+  }
+
+  const frag = document.createDocumentFragment();
+  const header = el("div", { class: "adr-row header" }, [
+    el("span", { text: "id" }),
+    el("span", { text: "title" }),
+    el("span", { text: "status" }),
+    el("span", { class: "feature", text: "feature" }),
+    el("span", { class: "accepted", text: "accepted-at" }),
+  ]);
+  header.dataset.key = "adr-header";
+  header.dataset.hash = "adr-header";
+  frag.appendChild(header);
+
+  for (const adr of items) {
+    const feature = adrPrimaryFeature(adr);
+    const accepted = adr.accepted_at ? fmtTimestamp(adr.accepted_at) : "-";
+    const row = el("div", { class: "adr-row", title: adr.title || adr.id }, [
+      el("span", { class: "id", text: adr.id, title: adr.id }),
+      el("span", { class: "title", text: adr.title || "" }),
+      statusPill(adr.status || "proposed"),
+      el("span", { class: "feature", text: feature, title: adrList(adr, "related_features").join(", ") }),
+      el("span", { class: "accepted", text: accepted, title: fmtAbsTime(adr.accepted_at) }),
+    ]);
+    row.dataset.key = `adr-${adr.id}`;
+    row.dataset.hash = `${adr.id}-${adr.status}-${adr.accepted_at || ""}-${adr.superseded_by || ""}-${activeAdrId === adr.id}`;
+    if (activeAdrId === adr.id) row.classList.add("active");
+    row.addEventListener("click", () => {
+      activeAdrId = adr.id;
+      renderAdrs(lastAdrPayload);
+    });
+    frag.appendChild(row);
+  }
+
+  syncNodes(body, Array.from(frag.children));
+  renderAdrDetail(items.find((item) => item.id === activeAdrId) || items[0]);
+}
+
+function buildAdrValueList(values, opts = {}) {
+  const wrap = el("div", { class: "adr-detail-list" });
+  if (!values || values.length === 0) {
+    wrap.appendChild(el("span", { class: "pill", text: "-" }));
+    return wrap;
+  }
+  for (const value of values) {
+    if (opts.taskLinks) {
+      const btn = el("button", { class: "relation-target mono", text: value, title: `Open task ${value}` });
+      btn.addEventListener("click", (e) => {
+        e.stopPropagation();
+        openTaskFromKnowledge(value);
+      });
+      wrap.appendChild(btn);
+    } else {
+      wrap.appendChild(el("span", { class: "pill mono", text: value, title: value }));
+    }
+  }
+  return wrap;
+}
+
+function openTaskFromKnowledge(taskId) {
+  activeStatuses = new Set(STATUS_ORDER);
+  searchQuery = "";
+  const taskSearch = $("task-search");
+  if (taskSearch) taskSearch.value = "";
+  setActiveTab("tasks", { refresh: false });
+  const open = () => openVisibleTask(taskId);
+  if (lastTasks.length > 0) {
+    open();
+    return;
+  }
+  fetchJson("/api/tasks").then((tasks) => {
+    lastTasks = tasks;
+    renderTasks(tasks);
+    open();
+  }).catch(() => copyTaskIdWithNotice(taskId));
+}
+
+function renderAdrDetail(adr) {
+  const detail = $("adr-detail");
+  if (!detail) return;
+  const count = $("adr-detail-count");
+  if (!adr) {
+    if (count) count.textContent = "-";
+    syncNodes(detail, [el("div", { class: "empty-state" }, [
+      el("div", { class: "icon", text: "✧" }),
+      el("div", { class: "text", text: "No ADR selected." }),
+    ])]);
+    return;
+  }
+  if (count) count.textContent = adr.status || "proposed";
+
+  const title = el("div", { class: "field-block" }, [
+    el("h4", { text: adr.id }),
+    el("div", { class: "markdown-body", text: adr.title || "" }),
+  ]);
+
+  const meta = el("div", { class: "adr-detail-meta" });
+  const addMeta = (label, value) => {
+    if (value == null || value === "") return;
+    meta.appendChild(el("span", {}, [
+      document.createTextNode(`${label}: `),
+      el("span", { class: "value", text: String(value) }),
+    ]));
+  };
+  addMeta("status", adr.status || "proposed");
+  addMeta("owner", adr.owner);
+  addMeta("created", fmtAbsTime(adr.created_at));
+  addMeta("accepted", fmtAbsTime(adr.accepted_at));
+  addMeta("updated", fmtAbsTime(adr.last_updated));
+
+  const featuresBlock = el("div", { class: "field-block" }, [
+    el("h4", { text: "related_features" }),
+    buildAdrValueList(adrList(adr, "related_features")),
+  ]);
+  const tasksBlock = el("div", { class: "field-block" }, [
+    el("h4", { text: "related_tasks" }),
+    buildAdrValueList(adrList(adr, "related_tasks"), { taskLinks: true }),
+  ]);
+  const edgesBlock = el("div", { class: "field-block" }, [
+    el("h4", { text: "supersession" }),
+    buildAdrValueList([
+      ...adrList(adr, "supersedes").map((id) => `supersedes ${id}`),
+      ...(adr.superseded_by ? [`superseded_by ${adr.superseded_by}`] : []),
+    ]),
+  ]);
+  const bodyBlock = el("div", { class: "field-block" }, [
+    el("h4", { text: "body" }),
+    el("pre", { class: "adr-detail-body", text: adr.body || "" }),
+  ]);
+
+  const actions = el("div", { class: "actions" });
+  if (adr.status === "proposed") {
+    const accept = el("button", {
+      class: "action approve",
+      text: "Accept",
+      title: `Accept ${adr.id}`,
+    });
+    accept.addEventListener("click", () => acceptAdr(adr, accept, detail));
+    actions.appendChild(accept);
+  }
+  if (adr.status === "accepted") {
+    const supersede = el("button", {
+      class: "action archive",
+      text: "Supersede",
+      title: `Supersede ${adr.id}`,
+    });
+    supersede.addEventListener("click", () => {
+      const by = window.prompt(`Replacement ADR ID for ${adr.id}`);
+      if (!by || !by.trim()) return;
+      supersedeAdr(adr, by.trim(), supersede, detail);
+    });
+    actions.appendChild(supersede);
+  }
+
+  const nodes = [title, meta, featuresBlock, tasksBlock, edgesBlock, bodyBlock];
+  if (actions.children.length > 0) nodes.push(actions);
+  syncNodes(detail, nodes);
+}
+
+async function acceptAdr(adr, btn, detail) {
+  await runAdrAction(
+    adr,
+    btn,
+    detail,
+    () => postJson(`/api/adrs/${encodeURIComponent(adr.id)}/accept`),
+    "accept failed",
+  );
+}
+
+async function supersedeAdr(adr, by, btn, detail) {
+  await runAdrAction(
+    adr,
+    btn,
+    detail,
+    () => postJson(`/api/adrs/${encodeURIComponent(adr.id)}/supersede`, { by }),
+    "supersede failed",
+  );
+}
+
+async function runAdrAction(adr, btn, detail, action, fallbackMessage) {
+  const oldText = btn.textContent;
+  btn.disabled = true;
+  btn.innerHTML = `<span class="spinner"></span>wait`;
+  for (const node of detail.querySelectorAll(".action-error")) node.remove();
+  try {
+    await action();
+    activeAdrId = adr.id;
+    await fetchAndRenderAdrs();
+  } catch (e) {
+    detail.prepend(el("div", { class: "action-error", text: e.message || fallbackMessage }));
+  } finally {
+    btn.disabled = false;
+    btn.textContent = oldText;
+  }
+}
+
 function refreshChips() {
   for (const chip of document.querySelectorAll("#task-filter .chip")) {
     const status = chip.dataset.status;
@@ -1551,11 +1788,24 @@ function wireLearningSearch() {
   });
 }
 
+function wireAdrSearch() {
+  const input = $("adr-search");
+  if (!input) return;
+  let debounce = null;
+  input.addEventListener("input", (e) => {
+    adrSearchQuery = e.target.value.trim();
+    if (debounce) clearTimeout(debounce);
+    debounce = setTimeout(() => {
+      if (activeTab === "knowledge") fetchAndRenderAdrs().catch(console.error);
+    }, 200);
+  });
+}
+
 const TABS = ["tasks", "scoreboard", "audit", "diagnostics", "knowledge", "run-detail"];
 const DIAG_SUBTABS = ["runs", "metrics", "errors"];
 const RUN_DETAIL_SUBTABS = ["steps", "events"];
 const AUDIT_SUBTABS = ["events", "policy"];
-const KNOWLEDGE_SUBTABS = ["learnings"];
+const KNOWLEDGE_SUBTABS = ["learnings", "adrs"];
 
 function parseHashRoute(raw) {
   const trimmed = String(raw || "").replace(/^#/, "");
@@ -1751,6 +2001,19 @@ function setKnowledgeSubtab(name) {
   for (const btn of document.querySelectorAll("#knowledge-subtabs .subtab")) {
     btn.classList.toggle("active", btn.dataset.subtab === name);
   }
+  const isAdrs = name === "adrs";
+  const toggle = (id, show) => {
+    const node = $(id);
+    if (node) node.style.display = show ? "" : "none";
+  };
+  toggle("learning-stats", !isAdrs);
+  toggle("learning-search", !isAdrs);
+  toggle("learnings-body", !isAdrs);
+  toggle("learning-detail-panel", !isAdrs);
+  toggle("adr-stats", isAdrs);
+  toggle("adr-search", isAdrs);
+  toggle("adrs-body", isAdrs);
+  toggle("adr-detail-panel", isAdrs);
 }
 
 function initTabs() {
@@ -1950,7 +2213,7 @@ function activeRefreshJobs() {
   }
 
   if (activeTab === "knowledge") {
-    jobs.push(fetchAndRenderLearnings());
+    jobs.push(activeKnowledgeSubtab === "adrs" ? fetchAndRenderAdrs() : fetchAndRenderLearnings());
     return jobs;
   }
 
@@ -2085,6 +2348,16 @@ function fetchAndRenderLearnings() {
   return fetchJson(`/api/learnings?${sp.toString()}`).then((payload) => {
     lastLearningPayload = payload || { stats: {}, items: [] };
     renderLearnings(lastLearningPayload);
+  });
+}
+
+function fetchAndRenderAdrs() {
+  const sp = new URLSearchParams();
+  sp.set("limit", String(ADR_LIMIT));
+  if (adrSearchQuery) sp.set("q", adrSearchQuery);
+  return fetchJson(`/api/adrs?${sp.toString()}`).then((payload) => {
+    lastAdrPayload = payload || { stats: {}, items: [] };
+    renderAdrs(lastAdrPayload);
   });
 }
 
@@ -3137,12 +3410,13 @@ async function refreshDashboard() {
   isRefreshing = false;
   if (activeTab === "tasks") fitLogPanelToViewport();
   
-  $("footer").textContent = `orbit dashboard · auto-refresh 30s · GET /api/{tasks,learnings,jobs,job-runs,audit?since|tool|status|role|execution_id|profile|q|limit|offset,audit/summary?since|denial_threshold,runs/:id,runs/:id/events?kind|limit|offset,runs/:id/logs?limit,scoreboard,diagnostics/{metrics,errors,friction,denials?since|kind|profile|agent}}`;
+  $("footer").textContent = `orbit dashboard · auto-refresh 30s · GET /api/{tasks,learnings,adrs,jobs,job-runs,audit?since|tool|status|role|execution_id|profile|q|limit|offset,audit/summary?since|denial_threshold,runs/:id,runs/:id/events?kind|limit|offset,runs/:id/logs?limit,scoreboard,diagnostics/{metrics,errors,friction,denials?since|kind|profile|agent}}`;
 }
 
 buildChips();
 wireSearch();
 wireLearningSearch();
+wireAdrSearch();
 buildAuditChips();
 wireAuditSearch();
 $("refresh-btn").addEventListener("click", refreshDashboard);

--- a/crates/orbit-cli/assets/dashboard/index.html
+++ b/crates/orbit-cli/assets/dashboard/index.html
@@ -198,7 +198,8 @@
       
       #task-search,
       #audit-search,
-      #learning-search {
+      #learning-search,
+      #adr-search {
         flex: 1 1 200px;
         min-width: 160px;
         background: var(--bg);
@@ -214,7 +215,8 @@
       
       #task-search:focus,
       #audit-search:focus,
-      #learning-search:focus {
+      #learning-search:focus,
+      #adr-search:focus {
         border-color: var(--accent);
       }
       
@@ -1507,20 +1509,25 @@
       .knowledge-empty { color: var(--fg-dim); font-family: var(--font-mono); font-size: 12px; }
 
       /* Knowledge tab */
-      .learning-stats {
+      .learning-stats,
+      .adr-stats {
         display: grid;
         grid-template-columns: repeat(3, minmax(0, 1fr));
         border-bottom: 1px solid var(--border);
       }
       @media (max-width: 800px) {
-        .learning-stats { grid-template-columns: 1fr; }
-        .learning-row { grid-template-columns: 120px minmax(0, 1fr) 76px; }
+        .learning-stats,
+        .adr-stats { grid-template-columns: 1fr; }
+        .learning-row,
+        .adr-row { grid-template-columns: 120px minmax(0, 1fr) 76px; }
         .learning-row .evidence,
-        .learning-row .updated { display: none; }
+        .learning-row .updated,
+        .adr-row .feature,
+        .adr-row .accepted { display: none; }
       }
-      .learning-row {
+      .learning-row,
+      .adr-row {
         display: grid;
-        grid-template-columns: 140px minmax(180px, 1fr) 96px 110px 110px;
         gap: 12px;
         padding: 9px 16px;
         align-items: center;
@@ -1529,9 +1536,18 @@
         font-size: 12px;
         cursor: pointer;
       }
-      .learning-row:hover { background: rgba(255, 255, 255, 0.03); }
-      .learning-row.active { background: rgba(110, 159, 255, 0.06); }
-      .learning-row.header {
+      .learning-row {
+        grid-template-columns: 140px minmax(180px, 1fr) 96px 110px 110px;
+      }
+      .adr-row {
+        grid-template-columns: 120px minmax(220px, 1.2fr) 110px 140px 130px;
+      }
+      .learning-row:hover,
+      .adr-row:hover { background: rgba(255, 255, 255, 0.03); }
+      .learning-row.active,
+      .adr-row.active { background: rgba(110, 159, 255, 0.06); }
+      .learning-row.header,
+      .adr-row.header {
         color: var(--fg-dim);
         font-size: 10px;
         font-weight: 600;
@@ -1544,12 +1560,17 @@
         z-index: 1;
       }
       .learning-row .id,
-      .learning-row .updated {
+      .learning-row .updated,
+      .adr-row .id,
+      .adr-row .title,
+      .adr-row .feature,
+      .adr-row .accepted {
         color: var(--fg-dim);
         overflow: hidden;
         text-overflow: ellipsis;
         white-space: nowrap;
       }
+      .adr-row .title { color: var(--fg); }
       .learning-row .scope {
         display: flex;
         flex-wrap: wrap;
@@ -1560,12 +1581,14 @@
         color: var(--fg-dim);
         text-align: right;
       }
-      #learning-detail {
+      #learning-detail,
+      #adr-detail {
         padding: 16px;
         display: grid;
         gap: 12px;
       }
-      .learning-detail-meta {
+      .learning-detail-meta,
+      .adr-detail-meta {
         display: flex;
         flex-wrap: wrap;
         gap: 10px;
@@ -1573,18 +1596,21 @@
         font-size: 11px;
         color: var(--fg-dim);
       }
-      .learning-detail-meta .value {
+      .learning-detail-meta .value,
+      .adr-detail-meta .value {
         color: var(--fg);
         background: rgba(255, 255, 255, 0.05);
         padding: 2px 6px;
         border-radius: 2px;
       }
-      .learning-detail-scope {
+      .learning-detail-scope,
+      .adr-detail-list {
         display: flex;
         flex-wrap: wrap;
         gap: 6px;
       }
-      .learning-detail-body {
+      .learning-detail-body,
+      .adr-detail-body {
         margin: 0;
         background: var(--bg);
         border: 1px solid var(--border);
@@ -1917,6 +1943,7 @@
           <header><span>Knowledge</span><span class="count" id="knowledge-count">-</span></header>
           <nav class="subtabs" id="knowledge-subtabs">
             <button class="subtab" data-subtab="learnings" type="button">Learnings</button>
+            <button class="subtab" data-subtab="adrs" type="button">ADRs</button>
           </nav>
           <div class="learning-stats" id="learning-stats">
             <div class="tile">
@@ -1935,10 +1962,35 @@
               <span class="glyph">IDX</span>
             </div>
           </div>
+          <div class="adr-stats" id="adr-stats" style="display: none;">
+            <div class="tile">
+              <span class="label">Proposed</span>
+              <span class="value" id="adr-proposed-value">-</span>
+              <span class="glyph">PRP</span>
+            </div>
+            <div class="tile">
+              <span class="label">Accepted</span>
+              <span class="value" id="adr-accepted-value">-</span>
+              <span class="glyph">ACC</span>
+            </div>
+            <div class="tile">
+              <span class="label">Superseded</span>
+              <span class="value" id="adr-superseded-value">-</span>
+              <span class="glyph">SUP</span>
+            </div>
+          </div>
           <div class="controls">
             <input type="search" id="learning-search" placeholder="Search learnings..." autocomplete="off" spellcheck="false" />
+            <input type="search" id="adr-search" placeholder="Search ADRs..." autocomplete="off" spellcheck="false" style="display: none;" />
           </div>
           <div class="body scoreboard-table-wrap" id="learnings-body">
+            <div class="skeleton-state">
+              <div class="skeleton skeleton-row"></div>
+              <div class="skeleton skeleton-row" style="width: 80%"></div>
+              <div class="skeleton skeleton-row" style="width: 70%"></div>
+            </div>
+          </div>
+          <div class="body scoreboard-table-wrap" id="adrs-body" style="display: none;">
             <div class="skeleton-state">
               <div class="skeleton skeleton-row"></div>
               <div class="skeleton skeleton-row" style="width: 80%"></div>
@@ -1952,6 +2004,15 @@
             <div class="empty-state">
               <div class="icon">✧</div>
               <div class="text">No learning selected.</div>
+            </div>
+          </div>
+        </section>
+        <section class="panel" id="adr-detail-panel" style="display: none;">
+          <header><span>ADR Detail</span><span class="count" id="adr-detail-count">-</span></header>
+          <div class="body" id="adr-detail">
+            <div class="empty-state">
+              <div class="icon">✧</div>
+              <div class="text">No ADR selected.</div>
             </div>
           </div>
         </section>

--- a/crates/orbit-cli/src/command/web/api/adrs.rs
+++ b/crates/orbit-cli/src/command/web/api/adrs.rs
@@ -1,0 +1,266 @@
+//! ADR scan and lifecycle handlers.
+
+use std::fs;
+use std::io::ErrorKind;
+use std::sync::Arc;
+
+use axum::extract::{Path, Query, State};
+use axum::response::{IntoResponse, Json, Response};
+use orbit_core::{OrbitError, OrbitRuntime};
+use serde::Deserialize;
+use serde_json::{Map, Value, json};
+
+use super::{bad_request, bounded_limit, map_runtime_error, non_empty_string};
+
+const ADRS_DEFAULT_LIMIT: usize = 100;
+const ADR_TOOL_MODEL: &str = "gpt-5.5";
+
+#[derive(Deserialize, Default)]
+pub(super) struct AdrsQuery {
+    #[serde(default)]
+    status: Option<String>,
+    #[serde(default)]
+    feature: Option<String>,
+    #[serde(default)]
+    q: Option<String>,
+    #[serde(default)]
+    limit: Option<usize>,
+    #[serde(default)]
+    offset: Option<usize>,
+}
+
+#[derive(Deserialize, Default)]
+pub(super) struct SupersedeAdrBody {
+    #[serde(default)]
+    by: Option<String>,
+    #[serde(default)]
+    reason: Option<String>,
+}
+
+pub(super) async fn list_adrs(
+    State(runtime): State<Arc<OrbitRuntime>>,
+    Query(query): Query<AdrsQuery>,
+) -> Response {
+    let all = match adr_list(&runtime, Map::new()) {
+        Ok(adrs) => adrs,
+        Err(e) => return map_runtime_error(e),
+    };
+    let stats = adr_stats_to_json(&all);
+
+    let mut input = Map::new();
+    if let Some(status) = query.status.as_deref().and_then(non_empty_string) {
+        input.insert("status".to_string(), Value::String(status));
+    }
+    if let Some(feature) = query.feature.as_deref().and_then(non_empty_string) {
+        input.insert("feature".to_string(), Value::String(feature));
+    }
+
+    let mut rows = if input.is_empty() {
+        all.clone()
+    } else {
+        match adr_list(&runtime, input) {
+            Ok(adrs) => adrs,
+            Err(e) => return map_runtime_error(e),
+        }
+    };
+
+    if let Some(q) = query.q.as_deref().and_then(non_empty_string) {
+        rows.retain(|adr| adr_matches_query(adr, &q));
+    }
+
+    let limit = bounded_limit(query.limit, ADRS_DEFAULT_LIMIT);
+    let offset = query.offset.unwrap_or(0);
+    let mut items = rows
+        .into_iter()
+        .skip(offset)
+        .take(limit)
+        .collect::<Vec<_>>();
+    for adr in &mut items {
+        if let Err(e) = attach_body(&runtime, adr) {
+            return map_runtime_error(e);
+        }
+    }
+
+    Json(json!({
+        "stats": stats,
+        "items": items,
+    }))
+    .into_response()
+}
+
+pub(super) async fn get_adr(
+    State(runtime): State<Arc<OrbitRuntime>>,
+    Path(id): Path<String>,
+) -> Response {
+    match adr_show(&runtime, &id) {
+        Ok(adr) => Json(adr).into_response(),
+        Err(e) => map_runtime_error(e),
+    }
+}
+
+pub(super) async fn accept_adr_action(
+    State(runtime): State<Arc<OrbitRuntime>>,
+    Path(id): Path<String>,
+) -> Response {
+    let result = run_adr_tool(
+        &runtime,
+        "orbit.adr.update",
+        json!({
+            "id": id,
+            "status": "accepted",
+        }),
+    );
+    match result {
+        Ok(mut adr) => match attach_body(&runtime, &mut adr) {
+            Ok(()) => Json(adr).into_response(),
+            Err(e) => map_runtime_error(e),
+        },
+        Err(e) => map_runtime_error(e),
+    }
+}
+
+pub(super) async fn supersede_adr_action(
+    State(runtime): State<Arc<OrbitRuntime>>,
+    Path(id): Path<String>,
+    body: Option<Json<SupersedeAdrBody>>,
+) -> Response {
+    let Some(Json(body)) = body else {
+        return bad_request("request body must include `by`".to_string());
+    };
+    let Some(by) = body.by.as_deref().and_then(non_empty_string) else {
+        return bad_request("request body must include non-empty `by`".to_string());
+    };
+    let _reason = body.reason.as_deref().and_then(non_empty_string);
+
+    let result = run_adr_tool(
+        &runtime,
+        "orbit.adr.supersede",
+        json!({
+            "old_id": id,
+            "new_id": by,
+        }),
+    );
+
+    match result {
+        Ok(mut old) => {
+            if let Err(e) = attach_body(&runtime, &mut old) {
+                return map_runtime_error(e);
+            }
+            let new_id = old
+                .get("superseded_by")
+                .and_then(Value::as_str)
+                .unwrap_or(by.as_str());
+            let new = match adr_show(&runtime, new_id) {
+                Ok(adr) => adr,
+                Err(e) => return map_runtime_error(e),
+            };
+            Json(json!({
+                "old": old,
+                "new": new,
+            }))
+            .into_response()
+        }
+        Err(e) => map_runtime_error(e),
+    }
+}
+
+fn adr_list(runtime: &OrbitRuntime, input: Map<String, Value>) -> Result<Vec<Value>, OrbitError> {
+    let value = run_adr_tool(runtime, "orbit.adr.list", Value::Object(input))?;
+    match value {
+        Value::Array(adrs) => Ok(adrs),
+        other => Err(OrbitError::Execution(format!(
+            "orbit.adr.list returned non-array JSON: {other}"
+        ))),
+    }
+}
+
+fn adr_show(runtime: &OrbitRuntime, id: &str) -> Result<Value, OrbitError> {
+    let mut adr = run_adr_tool(runtime, "orbit.adr.show", json!({ "id": id }))?;
+    attach_body(runtime, &mut adr)?;
+    Ok(adr)
+}
+
+fn run_adr_tool(runtime: &OrbitRuntime, name: &str, mut input: Value) -> Result<Value, OrbitError> {
+    if let Some(object) = input.as_object_mut() {
+        object
+            .entry("model".to_string())
+            .or_insert_with(|| Value::String(ADR_TOOL_MODEL.to_string()));
+    }
+    runtime.run_tool(name, input)
+}
+
+fn attach_body(runtime: &OrbitRuntime, adr: &mut Value) -> Result<(), OrbitError> {
+    let id = adr.get("id").and_then(Value::as_str).unwrap_or_default();
+    let status = adr
+        .get("status")
+        .and_then(Value::as_str)
+        .unwrap_or_default();
+    let body_path = runtime
+        .data_root()
+        .join("adrs")
+        .join(status)
+        .join(id)
+        .join("body.md");
+    let body = match fs::read_to_string(&body_path) {
+        Ok(body) => body,
+        Err(e) if e.kind() == ErrorKind::NotFound => String::new(),
+        Err(e) => {
+            return Err(OrbitError::Io(format!("read ADR body for {id}: {}", e)));
+        }
+    };
+    if let Some(object) = adr.as_object_mut() {
+        object.insert("body".to_string(), Value::String(body));
+    }
+    Ok(())
+}
+
+fn adr_stats_to_json(adrs: &[Value]) -> Value {
+    let mut proposed = 0;
+    let mut accepted = 0;
+    let mut superseded = 0;
+    for adr in adrs {
+        match adr.get("status").and_then(Value::as_str) {
+            Some("proposed") => proposed += 1,
+            Some("accepted") => accepted += 1,
+            Some("superseded") => superseded += 1,
+            _ => {}
+        }
+    }
+
+    json!({
+        "total": adrs.len(),
+        "proposed": proposed,
+        "accepted": accepted,
+        "superseded": superseded,
+    })
+}
+
+fn adr_matches_query(adr: &Value, query: &str) -> bool {
+    let query = query.to_lowercase();
+    let fields = ["id", "title", "owner", "status"];
+    if fields.iter().any(|field| {
+        adr.get(*field)
+            .and_then(Value::as_str)
+            .is_some_and(|value| value.to_lowercase().contains(&query))
+    }) {
+        return true;
+    }
+
+    ["related_features", "related_tasks", "legacy_ids"]
+        .iter()
+        .any(|field| {
+            adr.get(*field)
+                .and_then(Value::as_array)
+                .is_some_and(|values| {
+                    values.iter().any(|value| {
+                        value
+                            .as_str()
+                            .is_some_and(|value| value.to_lowercase().contains(&query))
+                    })
+                })
+        })
+}
+
+#[cfg(test)]
+#[path = "adrs_tests.rs"]
+mod tests;

--- a/crates/orbit-cli/src/command/web/api/adrs_tests.rs
+++ b/crates/orbit-cli/src/command/web/api/adrs_tests.rs
@@ -1,0 +1,237 @@
+use std::sync::Arc;
+
+use axum::body::Body;
+use axum::http::{Method, Request, StatusCode, header};
+use orbit_core::OrbitRuntime;
+use serde_json::{Value, json};
+use tower::ServiceExt;
+
+use super::super::router;
+use super::super::test_support::body_json;
+
+const ADR_BODY: &str = "## Context\nFixture context.\n\n## Decision\nFixture decision.\n\n## Consequences\n- Dashboard behavior is observable.\n- Cost: Test fixtures carry enough ADR shape to pass validation.\n";
+
+fn seed_adr(runtime: &OrbitRuntime, title: &str, related_tasks: Vec<&str>) -> Value {
+    runtime
+        .execute_tool_command(
+            "orbit.adr.add",
+            json!({
+                "title": title,
+                "body": ADR_BODY,
+                "owner": "gpt-5.5",
+                "related_features": ["dashboard"],
+                "related_tasks": related_tasks,
+            }),
+            None,
+            Some("gpt-5.5".to_string()),
+        )
+        .expect("seed ADR")
+}
+
+fn accept_adr(runtime: &OrbitRuntime, id: &str) -> Value {
+    runtime
+        .execute_tool_command(
+            "orbit.adr.update",
+            json!({
+                "id": id,
+                "status": "accepted",
+            }),
+            None,
+            Some("gpt-5.5".to_string()),
+        )
+        .expect("accept ADR")
+}
+
+fn adr_id(adr: &Value) -> &str {
+    adr["id"].as_str().expect("ADR id")
+}
+
+async fn request_accept(
+    runtime: OrbitRuntime,
+    id: &str,
+    origin: Option<&str>,
+) -> axum::response::Response {
+    let mut builder = Request::builder()
+        .method(Method::POST)
+        .uri(format!("/adrs/{id}/accept"));
+    if let Some(origin) = origin {
+        builder = builder.header(header::ORIGIN, origin);
+    }
+
+    router()
+        .with_state(Arc::new(runtime))
+        .oneshot(builder.body(Body::empty()).expect("request"))
+        .await
+        .expect("response")
+}
+
+async fn request_supersede(
+    runtime: OrbitRuntime,
+    id: &str,
+    origin: Option<&str>,
+    body: Option<Value>,
+) -> axum::response::Response {
+    let mut builder = Request::builder()
+        .method(Method::POST)
+        .uri(format!("/adrs/{id}/supersede"));
+    if let Some(origin) = origin {
+        builder = builder.header(header::ORIGIN, origin);
+    }
+    let request = if let Some(body) = body {
+        builder
+            .header(header::CONTENT_TYPE, "application/json")
+            .body(Body::from(body.to_string()))
+            .expect("request")
+    } else {
+        builder.body(Body::empty()).expect("request")
+    };
+
+    router()
+        .with_state(Arc::new(runtime))
+        .oneshot(request)
+        .await
+        .expect("response")
+}
+
+#[tokio::test]
+async fn post_adr_routes_require_localhost_origin() {
+    let runtime = OrbitRuntime::in_memory().expect("build runtime");
+    let proposed = seed_adr(&runtime, "Proposed dashboard ADR", vec!["ORB-00063"]);
+
+    let response = request_accept(runtime.clone(), adr_id(&proposed), None).await;
+
+    assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    let stored = runtime
+        .execute_tool_command(
+            "orbit.adr.show",
+            json!({ "id": adr_id(&proposed) }),
+            None,
+            Some("gpt-5.5".to_string()),
+        )
+        .expect("show proposed");
+    assert_eq!(stored["status"], "proposed");
+
+    let old = seed_adr(&runtime, "Old dashboard ADR", vec!["ORB-00063"]);
+    let new = seed_adr(&runtime, "New dashboard ADR", vec!["ORB-00063"]);
+    accept_adr(&runtime, adr_id(&old));
+    accept_adr(&runtime, adr_id(&new));
+
+    let response = request_supersede(
+        runtime.clone(),
+        adr_id(&old),
+        None,
+        Some(json!({ "by": adr_id(&new) })),
+    )
+    .await;
+
+    assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    let stored = runtime
+        .execute_tool_command(
+            "orbit.adr.show",
+            json!({ "id": adr_id(&old) }),
+            None,
+            Some("gpt-5.5".to_string()),
+        )
+        .expect("show old");
+    assert_eq!(stored["status"], "accepted");
+}
+
+#[tokio::test]
+async fn accept_returns_bad_request_when_tool_rejects_missing_related_tasks() {
+    let runtime = OrbitRuntime::in_memory().expect("build runtime");
+    let adr = seed_adr(&runtime, "Needs task linkage", vec![]);
+
+    let response = request_accept(runtime, adr_id(&adr), Some("http://localhost:7878")).await;
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    let payload = body_json(response).await;
+    let error = payload["error"].as_str().expect("error");
+    assert!(
+        error.contains(&format!(
+            "Invalid ADR status transition: {}: proposed -> accepted requires non-empty related_tasks",
+            adr_id(&adr)
+        )),
+        "{error}"
+    );
+}
+
+#[tokio::test]
+async fn supersede_returns_not_found_for_unknown_source_id() {
+    let runtime = OrbitRuntime::in_memory().expect("build runtime");
+    let replacement = seed_adr(&runtime, "Replacement dashboard ADR", vec!["ORB-00063"]);
+    accept_adr(&runtime, adr_id(&replacement));
+
+    let response = request_supersede(
+        runtime,
+        "ADR-9999",
+        Some("http://localhost:7878"),
+        Some(json!({ "by": adr_id(&replacement) })),
+    )
+    .await;
+
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn supersede_rejects_malformed_by() {
+    let runtime = OrbitRuntime::in_memory().expect("build runtime");
+    let old = seed_adr(&runtime, "Old dashboard ADR", vec!["ORB-00063"]);
+    accept_adr(&runtime, adr_id(&old));
+
+    let response = request_supersede(
+        runtime.clone(),
+        adr_id(&old),
+        Some("http://127.0.0.1:7878"),
+        Some(json!({ "by": "bad" })),
+    )
+    .await;
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    let stored = runtime
+        .execute_tool_command(
+            "orbit.adr.show",
+            json!({ "id": adr_id(&old) }),
+            None,
+            Some("gpt-5.5".to_string()),
+        )
+        .expect("show old");
+    assert_eq!(stored["status"], "accepted");
+}
+
+#[tokio::test]
+async fn supersede_moves_source_to_superseded_and_populates_edge() {
+    let runtime = OrbitRuntime::in_memory().expect("build runtime");
+    let old = seed_adr(&runtime, "Old dashboard ADR", vec!["ORB-00063"]);
+    let new = seed_adr(&runtime, "New dashboard ADR", vec!["ORB-00063"]);
+    accept_adr(&runtime, adr_id(&old));
+    accept_adr(&runtime, adr_id(&new));
+
+    let response = request_supersede(
+        runtime.clone(),
+        adr_id(&old),
+        Some("http://localhost:7878"),
+        Some(json!({ "by": adr_id(&new), "reason": "replacement" })),
+    )
+    .await;
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let payload = body_json(response).await;
+    assert_eq!(payload["old"]["id"], adr_id(&old));
+    assert_eq!(payload["old"]["status"], "superseded");
+    assert_eq!(payload["old"]["superseded_by"], adr_id(&new));
+    assert_eq!(payload["new"]["id"], adr_id(&new));
+    assert_eq!(payload["new"]["supersedes"][0], adr_id(&old));
+
+    let superseded_dir = runtime
+        .data_root()
+        .join("adrs")
+        .join("superseded")
+        .join(adr_id(&old));
+    assert!(superseded_dir.is_dir(), "{}", superseded_dir.display());
+    let accepted_dir = runtime
+        .data_root()
+        .join("adrs")
+        .join("accepted")
+        .join(adr_id(&old));
+    assert!(!accepted_dir.exists(), "{}", accepted_dir.display());
+}

--- a/crates/orbit-cli/src/command/web/api/mod.rs
+++ b/crates/orbit-cli/src/command/web/api/mod.rs
@@ -18,6 +18,7 @@ use serde::Deserialize;
 use serde_json::json;
 use url::Url;
 
+mod adrs;
 mod audit;
 mod denials;
 mod diagnostics;
@@ -239,6 +240,13 @@ pub(super) fn map_runtime_error(e: orbit_core::OrbitError) -> Response {
             kind: orbit_core::NotFoundKind::Learning,
             id,
         } => not_found(format!("learning not found: {id}")),
+        orbit_core::OrbitError::NotFound {
+            kind: orbit_core::NotFoundKind::Adr,
+            id,
+        } => not_found(format!("ADR not found: {id}")),
+        orbit_core::OrbitError::AdrInvalidTransition(message) => {
+            bad_request(format!("Invalid ADR status transition: {message}"))
+        }
         other => server_error(other),
     }
 }
@@ -301,6 +309,10 @@ pub(super) fn router() -> Router<Arc<OrbitRuntime>> {
             "/learnings/:id/supersede",
             post(learnings::supersede_learning_action),
         )
+        .route("/adrs", get(adrs::list_adrs))
+        .route("/adrs/:id", get(adrs::get_adr))
+        .route("/adrs/:id/accept", post(adrs::accept_adr_action))
+        .route("/adrs/:id/supersede", post(adrs::supersede_adr_action))
         .route("/jobs", get(jobs::list_jobs))
         .route("/job-runs", get(jobs::list_job_runs))
         .route("/runs/:id", get(runs::get_run))


### PR DESCRIPTION
## Task

[ORB-00063](https://orbit-cli.com/tasks/ORB-00063) — Add ADRs subtab to dashboard Knowledge tab with accept/supersede

### Description

## Problem
The ADR artifact (`.orbit/adrs/{proposed,accepted,superseded}/ADR-NNNN/`) has full `orbit.adr.*` coverage but no dashboard view. Reviewers want to scan proposed ADRs, accept them inline when related tasks are in place, and see supersession chains without grepping the filesystem.

## Why It Matters
ADRs are now the canonical home of architecture decisions (per the adr-artifact design); making them scannable is part of the v2 cutover. Inline accept/supersede closes the most common lifecycle path without leaving the dashboard.

## Constraints / Notes
- Depends on ORB-00061 (Knowledge tab scaffolding). Coordinates with ORB-00062 so the Knowledge tab ships with all three subtabs at once when this lands.
- New handler module `crates/orbit-cli/src/command/web/api/adrs.rs`.
- Endpoints: `GET /api/adrs` (status, feature, q, limit, offset), `GET /api/adrs/:id`, `POST /api/adrs/:id/accept`, `POST /api/adrs/:id/supersede` (body `{by, reason?}`).
- Accept validation: per ADR-0023 in `docs/design/adr-artifact/4_decisions.md`, `proposed → accepted` requires non-empty `related_tasks`. Let the tool layer enforce; surface its `OrbitError::InvalidInput` as `400 Bad Request` — do not duplicate validation in the HTTP layer.
- `review_thread.*` is explicitly out of scope for v1.
- Detail panel shows status badge, body as `<pre>`, related_features, related_tasks (deep-link to Tasks tab when present), supersedes/superseded_by edges.
- Accept and Supersede buttons are gated by current status: only show `Accept` on `proposed`, only show `Supersede` on `accepted`.

### Acceptance Criteria

- `crates/orbit-cli/src/command/web/api/mod.rs` registers `GET /adrs`, `GET /adrs/:id`, `POST /adrs/:id/accept`, `POST /adrs/:id/supersede` and the new module compiles under `make build`.
- `adrs_tests.rs` covers: localhost-origin guard on POST routes (403), `POST /adrs/:id/accept` returns 400 when the underlying tool errors on missing related_tasks (assert the body contains the tool's error message verbatim), `POST /adrs/:id/supersede` returns 404 for unknown id, 400 for malformed `by`, and on success moves the source to `superseded/` with `superseded_by` populated.
- `Knowledge > ADRs` subtab renders a stats strip (`proposed`, `accepted`, `superseded`), a list with columns (id, title, status badge, feature, accepted-at), and a detail panel.
- `Accept` button appears only when the loaded ADR has status `proposed`; `Supersede` button appears only when status is `accepted`. Both POST to their respective endpoints and refresh the panel on success.
- Each `related_task` in the detail panel is a clickable link that switches the dashboard to the Tasks tab and selects the linked task (no page reload).
- `make ci-fast` passes locally and via the PR `ci` workflow.
- Dashboard smoke check: with `.orbit/adrs/proposed/ADR-NNNN` present, the subtab lists it; clicking Accept (with related_tasks populated) moves the directory to `accepted/` and the row's status badge updates without a page reload.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Added ADR dashboard API handlers for list/show/accept/supersede, including ADR body loading and HTTP mapping for ADR not-found and invalid-transition errors.
- Added focused API tests for POST origin guard, accept missing related_tasks error propagation, supersede not-found/malformed-by handling, and successful supersede filesystem movement/edge population.
- Extended the Knowledge tab with an ADRs subtab, stats strip, list/detail rendering, status-gated Accept/Supersede actions, and related-task deep links into the Tasks tab.

Assessment: Targeted ADR API tests, make build, make ci-fast, JS syntax check, and served dashboard/API smoke checks pass. Smoke used a copied Orbit root to list a proposed ADR and accept it through /api/adrs/:id/accept, verifying the accepted/ move and refreshed accepted status without mutating the real workspace ADRs. The Browser plugin Node REPL surface was unavailable in this session, so browser automation could not be used for an actual click.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-00063-6a08df9b`
- Behind base: 0
- Ahead of base: 1