### PR TITLE
Web dashboard — surface task artifacts (incl. plan-duel) in task detail dropdown

### DIFF
--- a/crates/orbit-cli/assets/dashboard/app.js
+++ b/crates/orbit-cli/assets/dashboard/app.js
@@ -430,6 +430,96 @@ function buildReviewThreads(threads) {
   return wrap;
 }
 
+function fmtSize(bytes) {
+  const value = Number(bytes);
+  if (!Number.isFinite(value) || value < 0) return "0 bytes";
+  if (value < 1024) return `${value} bytes`;
+  const kb = value / 1024;
+  if (kb < 1024) return `${kb.toFixed(kb < 10 ? 1 : 0)} KB`;
+  const mb = kb / 1024;
+  return `${mb.toFixed(mb < 10 ? 1 : 0)} MB`;
+}
+
+function artifactUrl(taskId, path) {
+  const encodedPath = String(path)
+    .split("/")
+    .map((part) => encodeURIComponent(part))
+    .join("/");
+  return `/api/tasks/${encodeURIComponent(taskId)}/artifacts/${encodedPath}`;
+}
+
+function artifactMediaType(artifact, response) {
+  return String(
+    response.headers.get("content-type") || artifact.media_type || "application/octet-stream",
+  ).split(";")[0].trim().toLowerCase();
+}
+
+function renderArtifactText(mediaType, text) {
+  if (mediaType === "text/markdown" && typeof marked !== "undefined") {
+    const view = el("div", { class: "markdown-body" });
+    view.innerHTML = marked.parse(text);
+    return view;
+  }
+  return el("pre", { text });
+}
+
+function buildArtifactPreview(artifact, response) {
+  const mediaType = artifactMediaType(artifact, response);
+  if (
+    mediaType === "text/markdown" ||
+    mediaType === "application/json" ||
+    mediaType.endsWith("/yaml") ||
+    mediaType.endsWith("+yaml") ||
+    mediaType.startsWith("text/")
+  ) {
+    return response.text().then((text) => renderArtifactText(mediaType, text));
+  }
+  return response.blob().then((blob) => {
+    const link = el("a", { text: `Download ${artifact.path}` });
+    link.href = URL.createObjectURL(blob);
+    link.download = String(artifact.path).split("/").pop() || artifact.path;
+    return link;
+  });
+}
+
+function buildArtifacts(task) {
+  const wrap = el("div", { class: "artifacts" });
+  for (const artifact of task.artifacts) {
+    const path = String(artifact.path || "");
+    const mediaType = String(artifact.media_type || "application/octet-stream");
+    const row = el("div", {
+      class: "artifact-row",
+      text: `${path} · ${mediaType} · ${fmtSize(artifact.size_bytes)}`,
+    });
+    const preview = el("div", { class: "artifact-preview" });
+    preview.hidden = true;
+    row.addEventListener("click", async (e) => {
+      e.stopPropagation();
+      if (preview.dataset.loaded === "true" && !preview.hidden) {
+        preview.hidden = true;
+        return;
+      }
+      if (preview.dataset.loaded === "true") {
+        preview.hidden = false;
+        return;
+      }
+      preview.hidden = false;
+      preview.textContent = "loading...";
+      try {
+        const response = await fetch(artifactUrl(task.id, path));
+        if (!response.ok) throw new Error(`HTTP ${response.status}`);
+        preview.replaceChildren(await buildArtifactPreview(artifact, response));
+        preview.dataset.loaded = "true";
+      } catch (error) {
+        preview.textContent = `Unable to load ${path}: ${error.message}`;
+      }
+    });
+    wrap.appendChild(row);
+    wrap.appendChild(preview);
+  }
+  return wrap;
+}
+
 function buildTaskDetail(task) {
   const detail = el("div", { class: "row-detail split-layout" });
   detail.addEventListener("click", (e) => e.stopPropagation());
@@ -500,6 +590,10 @@ function buildTaskDetail(task) {
 
   if (Array.isArray(task.review_threads) && task.review_threads.length > 0) {
     addField(leftCol, "review threads", buildReviewThreads(task.review_threads), true, true);
+  }
+
+  if (Array.isArray(task.artifacts) && task.artifacts.length > 0) {
+    addField(leftCol, "artifacts", buildArtifacts(task), true, true);
   }
 
   if (Array.isArray(task.tags) && task.tags.length > 0) {

--- a/crates/orbit-cli/assets/dashboard/index.html
+++ b/crates/orbit-cli/assets/dashboard/index.html
@@ -457,6 +457,24 @@
       .relation-target:hover {
         border-color: var(--accent);
       }
+      .artifact-row {
+        padding: 7px 8px;
+        border: 1px solid var(--border);
+        border-radius: 2px;
+        color: var(--accent);
+        font-family: var(--font-mono);
+        font-size: 12px;
+        cursor: pointer;
+        overflow-wrap: anywhere;
+      }
+      .artifact-row:hover {
+        border-color: var(--accent);
+        background: rgba(110, 159, 255, 0.08);
+      }
+      .artifact-preview {
+        margin: 8px 0 12px;
+        overflow-x: auto;
+      }
       
       .row-detail .meta-line {
         font-family: var(--font-mono);

--- a/crates/orbit-cli/src/command/task/output.rs
+++ b/crates/orbit-cli/src/command/task/output.rs
@@ -1,7 +1,7 @@
 use std::collections::{BTreeMap, BTreeSet};
 
 use chrono::{DateTime, Utc};
-use orbit_common::types::TaskArtifact;
+use orbit_common::types::{ArtifactManifestFileV2, TaskArtifact};
 use orbit_core::{
     OrbitError, OrbitRuntime, TaskStatus, build_task_status_index, resolve_task_dependencies,
 };
@@ -84,6 +84,10 @@ pub(crate) fn task_to_json_with_sidecars(
         "review_threads".to_string(),
         serde_json::to_value(runtime.get_task_review_threads(&task.id)?)
             .map_err(|e| OrbitError::Io(e.to_string()))?,
+    );
+    object.insert(
+        "artifacts".to_string(),
+        task_artifact_manifest_to_json(&runtime.get_task_artifact_manifest(&task.id)?),
     );
     if let Some(projection) = runtime.resolved_crew_projection(task)? {
         object.insert("resolved_crew".to_string(), Value::String(projection.name));
@@ -401,6 +405,24 @@ pub(crate) fn task_artifacts_to_json(artifacts: &[TaskArtifact]) -> Value {
                     object.insert("content".to_string(), Value::String(content.to_string()));
                 }
                 Value::Object(object)
+            })
+            .collect(),
+    )
+}
+
+pub(crate) fn task_artifact_manifest_to_json(files: &[ArtifactManifestFileV2]) -> Value {
+    Value::Array(
+        files
+            .iter()
+            .map(|file| {
+                json!({
+                    "path": file.path,
+                    "media_type": file.media_type,
+                    "size_bytes": file.size_bytes,
+                    "sha256": file.sha256,
+                    "created_by": file.created_by,
+                    "created_at": file.created_at.to_rfc3339(),
+                })
             })
             .collect(),
     )

--- a/crates/orbit-cli/src/command/web/api/mod.rs
+++ b/crates/orbit-cli/src/command/web/api/mod.rs
@@ -300,6 +300,7 @@ pub(super) fn router() -> Router<Arc<OrbitRuntime>> {
             "/tasks/:id",
             get(tasks::get_task).patch(tasks::update_task_action),
         )
+        .route("/tasks/:id/artifacts/*path", get(tasks::get_task_artifact))
         .route("/tasks/:id/approve", post(tasks::approve_task_action))
         .route("/tasks/:id/reject", post(tasks::reject_task_action))
         .route("/tasks/:id/archive", post(tasks::archive_task_action))
@@ -558,3 +559,6 @@ mod tests {
         assert_eq!(response.status(), StatusCode::FORBIDDEN);
     }
 }
+
+#[cfg(test)]
+mod tasks_tests;

--- a/crates/orbit-cli/src/command/web/api/tasks.rs
+++ b/crates/orbit-cli/src/command/web/api/tasks.rs
@@ -2,8 +2,11 @@
 
 use std::sync::Arc;
 
+use axum::body::Body;
 use axum::extract::{Path, State};
+use axum::http::{HeaderValue, header};
 use axum::response::{IntoResponse, Json, Response};
+use orbit_common::types::validate_relative_artifact_path;
 use orbit_core::command::task::{TaskAddParams, TaskUpdateParams};
 use orbit_core::{
     ExternalRef, OrbitRuntime, Task, TaskComplexity, TaskPriority, TaskStatus, TaskType,
@@ -167,6 +170,45 @@ pub(super) async fn get_task(
         },
         Err(e) => map_runtime_error(e),
     }
+}
+
+pub(super) async fn get_task_artifact(
+    State(runtime): State<Arc<OrbitRuntime>>,
+    Path((id, path)): Path<(String, String)>,
+) -> Response {
+    let id = match validate_id(&id) {
+        Ok(id) => id,
+        Err(message) => return bad_request(message),
+    };
+    let path = match validate_artifact_request_path(&path) {
+        Ok(path) => path,
+        Err(message) => return bad_request(message),
+    };
+    match runtime.get_task_artifact(id, &path) {
+        Ok(Some(artifact)) => {
+            let content_type = match HeaderValue::from_str(&artifact.media_type) {
+                Ok(value) => value,
+                Err(error) => {
+                    return server_error(orbit_core::OrbitError::Store(format!(
+                        "invalid artifact media type '{}': {error}",
+                        artifact.media_type
+                    )));
+                }
+            };
+            let mut response = Response::new(Body::from(artifact.content));
+            response
+                .headers_mut()
+                .insert(header::CONTENT_TYPE, content_type);
+            response
+        }
+        Ok(None) => super::not_found(format!("artifact not found: {id}/{path}")),
+        Err(e) => map_runtime_error(e),
+    }
+}
+
+fn validate_artifact_request_path(path: &str) -> Result<String, String> {
+    validate_relative_artifact_path(path).map_err(|error| error.to_string())?;
+    Ok(path.to_string())
 }
 
 pub(super) async fn create_task_action(

--- a/crates/orbit-cli/src/command/web/api/tasks_tests.rs
+++ b/crates/orbit-cli/src/command/web/api/tasks_tests.rs
@@ -1,0 +1,147 @@
+use std::sync::Arc;
+
+use axum::body::{Body, to_bytes};
+use axum::http::{HeaderValue, Method, Request, StatusCode, header};
+use orbit_common::types::TaskArtifact;
+use orbit_core::command::task::{TaskAddParams, TaskUpdateParams};
+use orbit_core::{OrbitRuntime, TaskStatus};
+use serde_json::Value;
+use tower::ServiceExt;
+
+use super::test_support::body_json;
+use super::*;
+
+fn seed_task_with_artifact(runtime: &OrbitRuntime) -> orbit_core::Task {
+    let task = runtime
+        .add_task(TaskAddParams {
+            title: "Artifact task".to_string(),
+            description: "Fixture task with an artifact.".to_string(),
+            status: Some(TaskStatus::Backlog),
+            workspace_path: Some(".".to_string()),
+            ..Default::default()
+        })
+        .expect("create task");
+    runtime
+        .update_task_with_identity(
+            &task.id,
+            TaskUpdateParams {
+                upsert_artifacts: vec![TaskArtifact {
+                    path: "subdir/file.json".to_string(),
+                    media_type: "application/json".to_string(),
+                    content: br#"{"ok":true}"#.to_vec(),
+                }],
+                ..Default::default()
+            },
+            Some("codex".to_string()),
+            Some("gpt-5.5".to_string()),
+        )
+        .expect("upsert artifact")
+}
+
+async fn request(runtime: OrbitRuntime, uri: &str) -> axum::response::Response {
+    router()
+        .with_state(Arc::new(runtime))
+        .oneshot(
+            Request::builder()
+                .method(Method::GET)
+                .uri(uri)
+                .body(Body::empty())
+                .expect("request"),
+        )
+        .await
+        .expect("response")
+}
+
+#[tokio::test]
+async fn get_task_projects_artifact_manifest_without_content() {
+    let runtime = OrbitRuntime::in_memory().expect("build runtime");
+    let task = seed_task_with_artifact(&runtime);
+
+    let response = request(runtime, &format!("/tasks/{}", task.id)).await;
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = body_json(response).await;
+    let artifacts = body["artifacts"].as_array().expect("artifacts array");
+    assert_eq!(artifacts.len(), 1);
+    let artifact = artifacts.first().expect("artifact");
+    let object = artifact.as_object().expect("artifact object");
+    let keys = object.keys().map(String::as_str).collect::<Vec<_>>();
+    assert_eq!(
+        keys,
+        vec![
+            "created_at",
+            "created_by",
+            "media_type",
+            "path",
+            "sha256",
+            "size_bytes"
+        ]
+    );
+    assert_eq!(
+        artifact["path"],
+        Value::String("subdir/file.json".to_string())
+    );
+    assert_eq!(
+        artifact["media_type"],
+        Value::String("application/json".to_string())
+    );
+    assert_eq!(
+        artifact["size_bytes"],
+        Value::Number(serde_json::Number::from(11))
+    );
+    assert!(artifact.get("content").is_none());
+}
+
+#[tokio::test]
+async fn get_task_artifact_serves_subdirectory_bytes_and_media_type() {
+    let runtime = OrbitRuntime::in_memory().expect("build runtime");
+    let task = seed_task_with_artifact(&runtime);
+
+    let response = request(
+        runtime,
+        &format!("/tasks/{}/artifacts/subdir/file.json", task.id),
+    )
+    .await;
+
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(
+        response.headers().get(header::CONTENT_TYPE),
+        Some(&HeaderValue::from_static("application/json"))
+    );
+    let bytes = to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("read response body");
+    assert_eq!(&bytes[..], br#"{"ok":true}"#);
+}
+
+#[tokio::test]
+async fn get_task_artifact_returns_not_found_for_missing_artifact() {
+    let runtime = OrbitRuntime::in_memory().expect("build runtime");
+    let task = seed_task_with_artifact(&runtime);
+
+    let response = request(
+        runtime,
+        &format!("/tasks/{}/artifacts/missing.json", task.id),
+    )
+    .await;
+
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+}
+
+#[test]
+fn get_task_artifact_rejects_traversal_path() {
+    tokio::runtime::Runtime::new()
+        .expect("build tokio runtime")
+        .block_on(async {
+            let runtime = OrbitRuntime::in_memory().expect("build runtime");
+            let task = seed_task_with_artifact(&runtime);
+
+            let response = request(
+                runtime,
+                &format!("/tasks/{}/artifacts/subdir/%2e%2e/%2e%2e/escape", task.id),
+            )
+            .await;
+
+            assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        });
+}

--- a/crates/orbit-core/src/command/task/query.rs
+++ b/crates/orbit-core/src/command/task/query.rs
@@ -1,6 +1,6 @@
 use orbit_common::types::{
-    ExternalRef, NotFoundKind, OrbitError, ReviewThread, Task, TaskArtifact, TaskComment,
-    TaskHistoryEntry, prune_missing_context_files,
+    ArtifactManifestFileV2, ExternalRef, NotFoundKind, OrbitError, ReviewThread, Task,
+    TaskArtifact, TaskComment, TaskHistoryEntry, prune_missing_context_files,
 };
 
 use crate::OrbitRuntime;
@@ -20,6 +20,24 @@ impl OrbitRuntime {
             .tasks()
             .get_artifacts(id)?
             .ok_or_else(|| OrbitError::not_found(NotFoundKind::Task, id.to_string()))
+    }
+
+    pub fn get_task_artifact_manifest(
+        &self,
+        id: &str,
+    ) -> Result<Vec<ArtifactManifestFileV2>, OrbitError> {
+        self.stores()
+            .tasks()
+            .get_artifact_manifest(id)?
+            .ok_or_else(|| OrbitError::not_found(NotFoundKind::Task, id.to_string()))
+    }
+
+    pub fn get_task_artifact(
+        &self,
+        id: &str,
+        path: &str,
+    ) -> Result<Option<TaskArtifact>, OrbitError> {
+        self.stores().tasks().get_artifact(id, path)
     }
 
     pub fn get_task_comments(&self, id: &str) -> Result<Vec<TaskComment>, OrbitError> {

--- a/crates/orbit-core/src/runtime/store_delegates.rs
+++ b/crates/orbit-core/src/runtime/store_delegates.rs
@@ -1,8 +1,8 @@
 use orbit_common::types::{
-    Adr, AdrStatus, AuditEvent, ExecutorDef, ExternalRef, JobRun, JobRunState, KnowledgeRunMetrics,
-    Learning, LearningStatus, NotFoundKind, OrbitError, PolicyDef, ReviewThread, StoredTool, Task,
-    TaskArtifact, TaskComment, TaskComplexity, TaskHistoryEntry, TaskPriority, TaskStatus,
-    TaskType,
+    Adr, AdrStatus, ArtifactManifestFileV2, AuditEvent, ExecutorDef, ExternalRef, JobRun,
+    JobRunState, KnowledgeRunMetrics, Learning, LearningStatus, NotFoundKind, OrbitError,
+    PolicyDef, ReviewThread, StoredTool, Task, TaskArtifact, TaskComment, TaskComplexity,
+    TaskHistoryEntry, TaskPriority, TaskStatus, TaskType,
 };
 use orbit_embed::{EmbedWorker, VectorStore};
 use orbit_store::{
@@ -183,6 +183,21 @@ impl TaskRecords<'_> {
 
     pub(crate) fn get_artifacts(&self, id: &str) -> Result<Option<Vec<TaskArtifact>>, OrbitError> {
         self.artifact.get_task_artifacts(id)
+    }
+
+    pub(crate) fn get_artifact_manifest(
+        &self,
+        id: &str,
+    ) -> Result<Option<Vec<ArtifactManifestFileV2>>, OrbitError> {
+        self.artifact.get_task_artifact_manifest(id)
+    }
+
+    pub(crate) fn get_artifact(
+        &self,
+        id: &str,
+        path: &str,
+    ) -> Result<Option<TaskArtifact>, OrbitError> {
+        self.artifact.get_task_artifact(id, path)
     }
 
     pub(crate) fn get_comments(&self, id: &str) -> Result<Option<Vec<TaskComment>>, OrbitError> {

--- a/crates/orbit-store/src/backend/contracts.rs
+++ b/crates/orbit-store/src/backend/contracts.rs
@@ -1,10 +1,10 @@
 use chrono::{DateTime, Utc};
 use orbit_common::types::{
-    Adr, AdrStatus, AuditEvent, Crew, ExecutorDef, ExternalRef, JobRun, JobRunState,
-    KnowledgeRunMetrics, Learning, LearningEvidence, LearningScope, LegacyValidation, OrbitError,
-    OrbitId, PipelineState, PolicyDef, ReviewThread, StoredTool, Task, TaskArtifact, TaskComment,
-    TaskComplexity, TaskHistoryEntry, TaskPriority, TaskStatus, TaskType, normalize_task_tags,
-    task_matches_tags,
+    Adr, AdrStatus, ArtifactManifestFileV2, AuditEvent, Crew, ExecutorDef, ExternalRef, JobRun,
+    JobRunState, KnowledgeRunMetrics, Learning, LearningEvidence, LearningScope, LegacyValidation,
+    OrbitError, OrbitId, PipelineState, PolicyDef, ReviewThread, StoredTool, Task, TaskArtifact,
+    TaskComment, TaskComplexity, TaskHistoryEntry, TaskPriority, TaskStatus, TaskType,
+    normalize_task_tags, task_matches_tags,
 };
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -395,7 +395,24 @@ pub trait TaskReviewStoreBackend: Send + Sync {
 }
 
 pub trait TaskArtifactStoreBackend: Send + Sync {
+    fn get_task_artifact_manifest(
+        &self,
+        _id: &str,
+    ) -> Result<Option<Vec<ArtifactManifestFileV2>>, OrbitError> {
+        Err(OrbitError::Store(
+            "task artifact manifest read is not supported by this backend".to_string(),
+        ))
+    }
     fn get_task_artifacts(&self, id: &str) -> Result<Option<Vec<TaskArtifact>>, OrbitError>;
+    fn get_task_artifact(
+        &self,
+        _id: &str,
+        _path: &str,
+    ) -> Result<Option<TaskArtifact>, OrbitError> {
+        Err(OrbitError::Store(
+            "task artifact read is not supported by this backend".to_string(),
+        ))
+    }
     fn upsert_task_artifacts(
         &self,
         id: &str,

--- a/crates/orbit-store/src/backend/file_backends.rs
+++ b/crates/orbit-store/src/backend/file_backends.rs
@@ -1,8 +1,8 @@
 use chrono::{DateTime, Utc};
 use orbit_common::types::{
-    Adr, AdrStatus, Crew, ExecutorDef, ExternalRef, JobRun, KnowledgeRunMetrics, Learning,
-    LearningStatus, OrbitError, PipelineState, PolicyDef, ReviewThread, Task, TaskArtifact,
-    TaskComment, TaskHistoryEntry, TaskPriority, TaskStatus,
+    Adr, AdrStatus, ArtifactManifestFileV2, Crew, ExecutorDef, ExternalRef, JobRun,
+    KnowledgeRunMetrics, Learning, LearningStatus, OrbitError, PipelineState, PolicyDef,
+    ReviewThread, Task, TaskArtifact, TaskComment, TaskHistoryEntry, TaskPriority, TaskStatus,
 };
 
 use super::contracts::{
@@ -129,8 +129,19 @@ impl TaskReviewStoreBackend for TaskV2Store {
 }
 
 impl TaskArtifactStoreBackend for TaskV2Store {
+    fn get_task_artifact_manifest(
+        &self,
+        id: &str,
+    ) -> Result<Option<Vec<ArtifactManifestFileV2>>, OrbitError> {
+        self.get_task_artifact_manifest(id)
+    }
+
     fn get_task_artifacts(&self, id: &str) -> Result<Option<Vec<TaskArtifact>>, OrbitError> {
         self.get_task_artifacts(id)
+    }
+
+    fn get_task_artifact(&self, id: &str, path: &str) -> Result<Option<TaskArtifact>, OrbitError> {
+        self.get_task_artifact(id, path)
     }
 
     fn upsert_task_artifacts(

--- a/crates/orbit-store/src/file/task_store/v2_store.rs
+++ b/crates/orbit-store/src/file/task_store/v2_store.rs
@@ -533,6 +533,60 @@ impl TaskV2Store {
         Ok(Some(artifacts))
     }
 
+    pub(crate) fn get_task_artifact_manifest(
+        &self,
+        id: &str,
+    ) -> Result<Option<Vec<ArtifactManifestFileV2>>, OrbitError> {
+        orbit_common::types::validate_orb_task_id(id)?;
+        let bundle = match self.bundle_store.read_bundle(id) {
+            Ok(bundle) => bundle,
+            Err(OrbitError::NotFound {
+                kind: NotFoundKind::Task,
+                ..
+            }) => return Ok(None),
+            Err(err) => return Err(err),
+        };
+        let Some(manifest) = bundle.artifact_manifest else {
+            return Ok(Some(Vec::new()));
+        };
+        let mut files = manifest.files;
+        files.sort_by(|left, right| left.path.cmp(&right.path));
+        Ok(Some(files))
+    }
+
+    pub(crate) fn get_task_artifact(
+        &self,
+        id: &str,
+        path: &str,
+    ) -> Result<Option<TaskArtifact>, OrbitError> {
+        orbit_common::types::validate_orb_task_id(id)?;
+        let path = normalize_v2_artifact_path(path)?;
+        let bundle = match self.bundle_store.read_bundle(id) {
+            Ok(bundle) => bundle,
+            Err(OrbitError::NotFound {
+                kind: NotFoundKind::Task,
+                ..
+            }) => return Ok(None),
+            Err(err) => return Err(err),
+        };
+        let Some(manifest) = bundle.artifact_manifest else {
+            return Ok(None);
+        };
+        let Some(file) = manifest.files.into_iter().find(|file| file.path == path) else {
+            return Ok(None);
+        };
+        let bundle_dir = self.bundle_store.bundle_path(id)?;
+        let Some(artifact_file) = resolve_v2_artifact_file_path(&bundle_dir, &file.path)? else {
+            return Ok(None);
+        };
+        let content = fs::read(&artifact_file).map_err(|err| OrbitError::Io(err.to_string()))?;
+        Ok(Some(TaskArtifact {
+            path: file.path,
+            media_type: file.media_type,
+            content,
+        }))
+    }
+
     pub(crate) fn upsert_task_artifacts(
         &self,
         id: &str,
@@ -1133,6 +1187,31 @@ fn normalize_v2_artifact_path(raw: &str) -> Result<String, OrbitError> {
         }
     }
     Ok(parts.join("/"))
+}
+
+fn resolve_v2_artifact_file_path(
+    bundle_dir: &Path,
+    path: &str,
+) -> Result<Option<PathBuf>, OrbitError> {
+    let files_dir = bundle_dir
+        .join(TASK_ARTIFACTS_DIR_NAME)
+        .join(TASK_ARTIFACT_FILES_DIR_NAME);
+    let files_root = match fs::canonicalize(&files_dir) {
+        Ok(path) => path,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(err) => return Err(OrbitError::Io(err.to_string())),
+    };
+    let artifact_file = match fs::canonicalize(files_dir.join(path)) {
+        Ok(path) => path,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(err) => return Err(OrbitError::Io(err.to_string())),
+    };
+    if !artifact_file.starts_with(&files_root) {
+        return Err(OrbitError::InvalidInput(format!(
+            "artifact path '{path}' resolves outside the task artifact directory"
+        )));
+    }
+    Ok(Some(artifact_file))
 }
 
 fn render_acceptance(criteria: &[String]) -> String {


### PR DESCRIPTION
## Task

[ORB-00069](https://orbit-cli.com/tasks/ORB-00069) — Web dashboard — surface task artifacts (incl. plan-duel) in task detail dropdown

### Description

## Problem

The Orbit web dashboard's expanded task drop-down does not surface task artifacts, including plan-duel outputs stored under `~/.orbit/tasks/{id}/artifacts/`. `runtime.get_task_artifacts()` exists ([crates/orbit-store/src/backend/contracts.rs](crates/orbit-store/src/backend/contracts.rs), [crates/orbit-store/src/file/task_store/v2_store.rs](crates/orbit-store/src/file/task_store/v2_store.rs)) but is not called from `task_to_json_with_sidecars` ([crates/orbit-cli/src/command/task/output.rs:63](crates/orbit-cli/src/command/task/output.rs)), and there is no HTTP route for fetching artifact bytes.

## Why It Matters

Plan-duel artifacts (competing plans for the same task) and any other task-attached outputs are invisible from the dashboard. Users have to drop to the CLI or filesystem to read them. Surfacing them in the same drop-down that already shows description, plan, and execution summary closes the loop on dashboard-as-primary-task-view.

## Scope

Backend (Rust) + frontend (vanilla JS / inline CSS).

## Backend Changes

1. **Manifest projection in `task_to_json_with_sidecars`** ([crates/orbit-cli/src/command/task/output.rs:63](crates/orbit-cli/src/command/task/output.rs)): insert a new `"artifacts"` field — an array of objects projected from `ArtifactManifestFileV2` ([crates/orbit-common/src/types/task_artifacts.rs:327](crates/orbit-common/src/types/task_artifacts.rs)). Each object contains `{ path, media_type, size_bytes, sha256, created_by, created_at }`. **Do not** inline `content` bytes — keep the response small. Field is omitted (or `[]`) when the task has no artifacts.
2. **New HTTP route** in [crates/orbit-cli/src/command/web/api/tasks.rs](crates/orbit-cli/src/command/web/api/tasks.rs): `GET /api/tasks/{id}/artifacts/{*path}` (wildcard segment so subdirectory paths work). Streams artifact bytes with the stored `media_type` as `Content-Type`. Returns 404 when the artifact does not exist. Wired into the router in [crates/orbit-cli/src/command/web/api/mod.rs](crates/orbit-cli/src/command/web/api/mod.rs).
3. **Path safety**: reject any `path` containing `..` segments (return 400). After joining, canonicalize and verify the resolved path is still under `~/.orbit/tasks/{id}/artifacts/files/`. Reject otherwise (400 / 404).

## Frontend Changes

- In `buildTaskDetail` ([crates/orbit-cli/assets/dashboard/app.js:279](crates/orbit-cli/assets/dashboard/app.js)): add a collapsible left-column `artifacts` field-block (collapsed by default), rendered only when `task.artifacts` is non-empty.
- Each row uses class `.artifact-row` and shows `{path} · {media_type} · {fmtSize(size_bytes)}` (add a small `fmtSize` helper that formats bytes/KB/MB).
- Click handler `fetch('/api/tasks/{id}/artifacts/{path}')`:
  - `text/markdown` → render via `marked.parse()` inline below the row.
  - `application/json` and `*/yaml` (incl. `application/yaml`, `text/yaml`) → render in `<pre>`.
  - other `text/*` → render in `<pre>`.
  - else → render a `<a href={url} download>Download {path}</a>` link.
- Re-clicking a loaded row collapses the inline preview.
- CSS additions in inline `<style>` of [crates/orbit-cli/assets/dashboard/index.html](crates/orbit-cli/assets/dashboard/index.html): `.artifact-row` (~10 LOC).

## Constraints / Notes

- Depends on ORB-00068 — file artifacts after the basic field render lands, so the artifacts field-block slots into the same left column without conflicting refactor.
- Plan-duel artifacts share the same storage path as ordinary task artifacts; no special-casing required.
- Streaming route returns raw bytes; no transcoding. Consumers responsible for decoding per `media_type`.
- The new route is read-only and authenticated by the same middleware as the existing `/api/tasks/{id}` handler — confirm middleware coverage in the router wire-up.

### Acceptance Criteria

- `GET /api/tasks/{id}` response includes an `artifacts` field as a JSON array when the task has artifacts; each element has exactly the keys `path`, `media_type`, `size_bytes`, `sha256`, `created_by`, `created_at`; no `content` field is present; the field is `[]` or absent for tasks without artifacts.
- `GET /api/tasks/{id}/artifacts/{*path}` returns status 200, `Content-Type` matching the stored `media_type`, and the artifact bytes as the response body when the artifact exists; subdirectory paths (e.g. `subdir/file.json`) resolve correctly.
- `GET /api/tasks/{id}/artifacts/{*path}` returns 404 when the artifact does not exist for that task id.
- `GET /api/tasks/{id}/artifacts/{*path}` with a `path` containing `..` returns status 400 or 404 without serving any bytes; a `#[test]` in `tasks.rs` (or a sibling `*_tests.rs`) exercises at least one traversal attempt (e.g. `../../etc/passwd`, `subdir/../../escape`) and asserts a non-2xx status.
- When `task.artifacts` is non-empty, the dashboard detail dropdown renders a collapsible `artifacts` field-block in the left column, collapsed by default; each row shows `{path} · {media_type} · {fmtSize(size_bytes)}`.
- Clicking an artifact row fetches its content and renders it inline per media-type rules: `text/markdown` via `marked.parse()`; `application/json` and `*/yaml` and other `text/*` in a `<pre>`; everything else as a `Download {path}` link.
- Plan-duel artifacts attached to a task via the normal artifact storage path appear in the dashboard artifact list without any plan-duel-specific code branch.
- `make ci-fast` passes; `make ci` (or the per-PR CI workflow) passes on the change.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Added content-free task artifact manifest projection to dashboard task JSON with path, media_type, size_bytes, sha256, created_by, and created_at fields.
- Added backend artifact manifest/single-file read plumbing plus a read-only HTTP route with subdirectory support, stored media type headers, missing-artifact 404s, and traversal rejection backed by canonical path checks.
- Rendered dashboard artifacts as a collapsed left-column field block with inline markdown/text/json/yaml previews and binary download links.
- Added focused API tests covering manifest shape, subdirectory fetch, missing artifacts, and traversal rejection.

Assessment: Scoped backend/frontend change with normal artifact storage path only; no plan-duel-specific branch added.

Validation:
- node --check crates/orbit-cli/assets/dashboard/app.js
- cargo test -p orbit-cli command::web::api::tasks_tests -- --nocapture
- git diff --check
- make ci-fast

Design weaknesses / risks:
- make check-design-docs currently fails on existing stale design docs across several feature areas, including task-artifacts/task-sync; not broadened into this implementation task.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-00069-6a08e3a4`
- Behind base: 0
- Ahead of base: 1