### PR TITLE
Surface waiting-reason fields on job status output

### DIFF
--- a/crates/orbit-cli/src/command/run/format.rs
+++ b/crates/orbit-cli/src/command/run/format.rs
@@ -1,3 +1,5 @@
+use orbit_common::types::{JobRunState, PipelineState};
+
 pub(crate) fn summarize_error_message(raw: Option<&str>) -> String {
     let value = raw.unwrap_or("-").replace('\n', " ");
     if value.chars().count() <= 120 {
@@ -17,4 +19,86 @@ pub(crate) fn format_duration(value: Option<u64>) -> String {
     value
         .map(|duration| format!("{duration}ms"))
         .unwrap_or_else(|| "-".to_string())
+}
+
+pub(crate) fn format_waiting_line(
+    run_state: JobRunState,
+    state: Option<&PipelineState>,
+) -> Option<String> {
+    if run_state.is_terminal() {
+        return None;
+    }
+    let state = state?;
+    let deps = state
+        .waiting_on_deps
+        .as_deref()
+        .unwrap_or_default()
+        .iter()
+        .map(String::as_str)
+        .filter(|value| !value.trim().is_empty())
+        .collect::<Vec<_>>();
+    let locks = state
+        .waiting_on_locks
+        .as_deref()
+        .unwrap_or_default()
+        .iter()
+        .map(String::as_str)
+        .filter(|value| !value.trim().is_empty())
+        .collect::<Vec<_>>();
+
+    let mut parts = Vec::new();
+    if !deps.is_empty() {
+        parts.push(format!("deps: {}", deps.join(", ")));
+    }
+    if !locks.is_empty() {
+        parts.push(format!("locks: {}", locks.join(", ")));
+    }
+    (!parts.is_empty()).then(|| format!("Waiting on {}", parts.join("; ")))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use serde_json::json;
+
+    fn state_with_waiting(deps: Option<Vec<&str>>, locks: Option<Vec<&str>>) -> PipelineState {
+        let mut state =
+            PipelineState::new("jrun-test".to_string(), "job-test".to_string(), json!({}));
+        state.set_waiting_reasons(
+            deps.map(|values| values.into_iter().map(str::to_string).collect()),
+            locks.map(|values| values.into_iter().map(str::to_string).collect()),
+        );
+        state
+    }
+
+    #[test]
+    fn waiting_line_lists_deps_and_locks_for_waiting_run() {
+        let state = state_with_waiting(Some(vec!["ORB-1", "ORB-2"]), Some(vec!["file:src/lib.rs"]));
+
+        assert_eq!(
+            format_waiting_line(JobRunState::Running, Some(&state)),
+            Some("Waiting on deps: ORB-1, ORB-2; locks: file:src/lib.rs".to_string())
+        );
+    }
+
+    #[test]
+    fn waiting_line_omits_non_waiting_run() {
+        let state = PipelineState::new("jrun-test".to_string(), "job-test".to_string(), json!({}));
+
+        assert_eq!(
+            format_waiting_line(JobRunState::Running, Some(&state)),
+            None
+        );
+    }
+
+    #[test]
+    fn waiting_line_omits_terminal_run_even_with_stale_reasons() {
+        let state = state_with_waiting(Some(vec!["ORB-1"]), Some(vec!["file:src/lib.rs"]));
+
+        assert_eq!(
+            format_waiting_line(JobRunState::Success, Some(&state)),
+            None
+        );
+    }
 }

--- a/crates/orbit-cli/src/command/run/history.rs
+++ b/crates/orbit-cli/src/command/run/history.rs
@@ -5,8 +5,8 @@ use serde_json::json;
 
 use crate::command::Execute;
 
-use super::format::{format_timestamp, summarize_error_message};
-use super::job::job_run_to_json;
+use super::format::{format_timestamp, format_waiting_line, summarize_error_message};
+use super::job::job_run_to_json_with_state;
 
 pub(crate) const DEFAULT_HISTORY_LIMIT: usize = 50;
 
@@ -52,8 +52,17 @@ pub(crate) fn print_run_history(
         })?,
     };
 
+    let states = runs
+        .iter()
+        .map(|run| runtime.read_run_state(&run.run_id))
+        .collect::<Result<Vec<_>, _>>()?;
+
     if json_output {
-        let values = runs.iter().map(job_run_to_json).collect::<Vec<_>>();
+        let values = runs
+            .iter()
+            .zip(states.iter())
+            .map(|(run, state)| job_run_to_json_with_state(run, state.as_ref()))
+            .collect::<Vec<_>>();
         return crate::output::json::print_pretty(&json!({ "runs": values }));
     }
 
@@ -101,5 +110,10 @@ pub(crate) fn print_run_history(
         table.add_row(row);
     }
     println!("{table}");
+    for (run, state) in runs.iter().zip(states.iter()) {
+        if let Some(line) = format_waiting_line(run.state, state.as_ref()) {
+            println!("{line}");
+        }
+    }
     Ok(())
 }

--- a/crates/orbit-cli/src/command/run/job.rs
+++ b/crates/orbit-cli/src/command/run/job.rs
@@ -2,6 +2,7 @@ use std::path::PathBuf;
 
 use clap::Args;
 use orbit_common::types::JobKind;
+use orbit_common::types::PipelineState;
 use orbit_core::command::job::JobCatalogEntry;
 use orbit_core::{JobRun, OrbitError, OrbitRuntime};
 use serde_json::{Value, json};
@@ -188,12 +189,25 @@ impl Execute for JobReplayArgs {
 }
 
 pub(crate) fn job_run_to_json(run: &JobRun) -> Value {
+    job_run_to_json_with_state(run, None)
+}
+
+pub(crate) fn job_run_to_json_with_state(run: &JobRun, state: Option<&PipelineState>) -> Value {
     let last = run.steps.last();
+    let state = (!run.state.is_terminal()).then_some(state).flatten();
+    let waiting_on_deps = state
+        .and_then(|state| state.waiting_on_deps.as_ref())
+        .filter(|values| !values.is_empty());
+    let waiting_on_locks = state
+        .and_then(|state| state.waiting_on_locks.as_ref())
+        .filter(|values| !values.is_empty());
     json!({
         "run_id": run.run_id,
         "job_id": run.job_id,
         "attempt": run.attempt,
         "state": run.state.to_string(),
+        "waiting_on_deps": waiting_on_deps,
+        "waiting_on_locks": waiting_on_locks,
         "scheduled_at": run.scheduled_at.to_rfc3339(),
         "started_at": run.started_at.map(|v| v.to_rfc3339()),
         "finished_at": run.finished_at.map(|v| v.to_rfc3339()),
@@ -267,7 +281,34 @@ fn build_job_run_input(pairs: &[String]) -> Result<Value, OrbitError> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use chrono::Utc;
+    use orbit_common::types::JobRunState;
     use orbit_core::NotFoundKind;
+
+    fn test_run(state: JobRunState) -> JobRun {
+        let now = Utc::now();
+        JobRun {
+            run_id: "jrun-test".to_string(),
+            job_id: "task_gate_pipeline".to_string(),
+            attempt: 1,
+            state,
+            scheduled_at: now,
+            started_at: Some(now),
+            finished_at: None,
+            duration_ms: None,
+            created_at: now,
+            pid: None,
+            pid_start_time: None,
+            input: None,
+            retry_source_run_id: None,
+            knowledge_metrics: None,
+            resolved_crew: None,
+            planner_model: None,
+            implementer_model: None,
+            reviewer_model: None,
+            steps: Vec::new(),
+        }
+    }
 
     fn write_replay_job(runtime: &OrbitRuntime, name: &str) -> PathBuf {
         let jobs_dir = runtime.data_root().join("resources/jobs");
@@ -294,6 +335,36 @@ spec:
         )
         .expect("write replay job");
         path
+    }
+
+    #[test]
+    fn job_run_json_includes_waiting_reasons_from_state() {
+        let run = test_run(JobRunState::Running);
+        let mut state = PipelineState::new(run.run_id.clone(), run.job_id.clone(), json!({}));
+        state.set_waiting_reasons(
+            Some(vec!["ORB-1".to_string()]),
+            Some(vec!["file:src/lib.rs".to_string()]),
+        );
+
+        let value = job_run_to_json_with_state(&run, Some(&state));
+
+        assert_eq!(value["waiting_on_deps"], json!(["ORB-1"]));
+        assert_eq!(value["waiting_on_locks"], json!(["file:src/lib.rs"]));
+    }
+
+    #[test]
+    fn job_run_json_omits_stale_waiting_reasons_for_terminal_run() {
+        let run = test_run(JobRunState::Success);
+        let mut state = PipelineState::new(run.run_id.clone(), run.job_id.clone(), json!({}));
+        state.set_waiting_reasons(
+            Some(vec!["ORB-1".to_string()]),
+            Some(vec!["file:src/lib.rs".to_string()]),
+        );
+
+        let value = job_run_to_json_with_state(&run, Some(&state));
+
+        assert_eq!(value["waiting_on_deps"], Value::Null);
+        assert_eq!(value["waiting_on_locks"], Value::Null);
     }
 
     #[test]

--- a/crates/orbit-cli/src/command/run/show.rs
+++ b/crates/orbit-cli/src/command/run/show.rs
@@ -4,10 +4,10 @@ use serde_json::{Value, json};
 
 use crate::command::Execute;
 
-use super::job::job_run_to_json;
+use super::job::job_run_to_json_with_state;
 use super::steps::{
-    filtered_steps, legacy_step_to_json, print_run_header, print_step_record,
-    print_step_summary_table, resolve_run, resolve_run_step,
+    filtered_steps, legacy_step_to_json, print_run_header, print_run_header_with_state,
+    print_step_record, print_step_summary_table, resolve_run, resolve_run_step,
 };
 
 #[derive(Args)]
@@ -58,12 +58,12 @@ pub(crate) fn print_run_show(
 
     if json_output {
         return crate::output::json::print_pretty(&json!({
-            "run": job_run_to_json(&run),
+            "run": job_run_to_json_with_state(&run, state.as_ref()),
             "pipeline_state": state,
         }));
     }
 
-    print_run_header(&run);
+    print_run_header_with_state(&run, state.as_ref());
     if let Some(state) = &state {
         println!(
             "{} iteration={} step_outputs={} updated_at={}",

--- a/crates/orbit-cli/src/command/run/steps.rs
+++ b/crates/orbit-cli/src/command/run/steps.rs
@@ -1,9 +1,12 @@
+use orbit_common::types::PipelineState;
 use orbit_core::command::job::JobRunListParams;
 use orbit_core::runtime::run_audit::RunAuditStep;
 use orbit_core::{JobRun, JobRunStep, JobTargetType, NotFoundKind, OrbitError, OrbitRuntime};
 use serde_json::{Value, json};
 
-use super::format::{format_duration, format_timestamp, summarize_error_message};
+use super::format::{
+    format_duration, format_timestamp, format_waiting_line, summarize_error_message,
+};
 
 pub(crate) fn resolve_run(
     runtime: &OrbitRuntime,
@@ -151,6 +154,10 @@ impl RunStepRecord {
 }
 
 pub(crate) fn print_run_header(run: &JobRun) {
+    print_run_header_with_state(run, None);
+}
+
+pub(crate) fn print_run_header_with_state(run: &JobRun, state: Option<&PipelineState>) {
     use crate::output::color::{bold, dimmed, job_state_color};
     println!("{} {}", bold("Run ID:"), run.run_id);
     println!("{} {}", bold("Job ID:"), run.job_id);
@@ -170,6 +177,9 @@ pub(crate) fn print_run_header(run: &JobRun) {
         dimmed(&format_timestamp(run.finished_at))
     );
     println!("{} {}", bold("Duration:"), format_duration(run.duration_ms));
+    if let Some(line) = format_waiting_line(run.state, state) {
+        println!("{line}");
+    }
 }
 
 pub(crate) fn print_step_summary_table(steps: &[&JobRunStep]) -> Result<(), OrbitError> {

--- a/crates/orbit-common/src/types/run_state.rs
+++ b/crates/orbit-common/src/types/run_state.rs
@@ -40,6 +40,12 @@ pub struct PipelineState {
     /// Current loop iteration (0-based). Updated at each loop boundary.
     #[serde(default)]
     pub iteration: u32,
+    /// Task dependencies currently blocking this run, when the run is parked.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub waiting_on_deps: Option<Vec<String>>,
+    /// Task lock resource identifiers currently blocking this run, when parked.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub waiting_on_locks: Option<Vec<String>>,
     pub updated_at: DateTime<Utc>,
 }
 
@@ -57,6 +63,8 @@ impl PipelineState {
             next_step_index: 0,
             previous_step_state: None,
             iteration: 0,
+            waiting_on_deps: None,
+            waiting_on_locks: None,
             updated_at: Utc::now(),
         }
     }
@@ -94,6 +102,22 @@ impl PipelineState {
 
     pub fn set_iteration(&mut self, iteration: u32) {
         self.iteration = iteration;
+        self.updated_at = Utc::now();
+    }
+
+    pub fn set_waiting_reasons(
+        &mut self,
+        waiting_on_deps: Option<Vec<String>>,
+        waiting_on_locks: Option<Vec<String>>,
+    ) {
+        self.waiting_on_deps = waiting_on_deps;
+        self.waiting_on_locks = waiting_on_locks;
+        self.updated_at = Utc::now();
+    }
+
+    pub fn clear_waiting_reasons(&mut self) {
+        self.waiting_on_deps = None;
+        self.waiting_on_locks = None;
         self.updated_at = Utc::now();
     }
 

--- a/crates/orbit-core/src/command/job/run.rs
+++ b/crates/orbit-core/src/command/job/run.rs
@@ -168,6 +168,7 @@ impl OrbitRuntime {
                 );
                 object.insert("cancelled".to_string(), Value::Bool(true));
             }
+            state.clear_waiting_reasons();
             state.updated_at = Utc::now();
             self.stores().jobs().write_run_state(&run.run_id, &state)?;
         } else if run.input.is_some() {

--- a/crates/orbit-core/src/runtime/v2_host/dispatch.rs
+++ b/crates/orbit-core/src/runtime/v2_host/dispatch.rs
@@ -1,7 +1,9 @@
-use std::collections::HashMap;
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::time::{Duration, Instant};
 
-use orbit_common::types::Role;
+use orbit_common::types::{
+    OrbitError, Role, build_task_status_index, optional_string_list_alias, unmet_task_dependencies,
+};
 use orbit_engine::DispatchError;
 use orbit_engine::{StateExecutionContext, execute_deterministic_action};
 use orbit_tools::ToolContext;
@@ -196,17 +198,44 @@ pub(super) fn run_deterministic(
         // `steps.<id>.output.reserved` directly without leaking the
         // generic `{tool_name, args}` envelope into the activity's
         // input_schema.
-        "reserve_locks" => runtime
-            .run_tool_with_context_and_role(
-                "orbit.task.locks.reserve",
-                input.clone(),
-                Role::Admin,
-                tool_context,
-            )
-            .map_err(|err| DispatchError::DeterministicActionFailed {
-                action: action.to_string(),
-                message: format!("{err}"),
-            }),
+        "reserve_locks" => {
+            let waiting_on_deps =
+                unmet_dependency_ids_for_input(runtime, input).map_err(|err| {
+                    DispatchError::DeterministicActionFailed {
+                        action: action.to_string(),
+                        message: format!("{err}"),
+                    }
+                })?;
+            if !waiting_on_deps.is_empty() {
+                update_run_waiting_reasons(
+                    runtime,
+                    input,
+                    Some(waiting_on_deps.clone()),
+                    None,
+                    action,
+                )?;
+                return Ok(serde_json::json!({
+                    "reserved": false,
+                    "waiting_on_deps": waiting_on_deps,
+                    "conflicts": [],
+                }));
+            }
+
+            let output = runtime
+                .run_tool_with_context_and_role(
+                    "orbit.task.locks.reserve",
+                    input.clone(),
+                    Role::Admin,
+                    tool_context,
+                )
+                .map_err(|err| DispatchError::DeterministicActionFailed {
+                    action: action.to_string(),
+                    message: format!("{err}"),
+                })?;
+            let waiting_on_locks = waiting_locks_from_reserve_output(&output);
+            update_run_waiting_reasons(runtime, input, None, non_empty(waiting_on_locks), action)?;
+            Ok(output)
+        }
         // Thin passthrough over `orbit.task.locks.release` so workflows
         // can free admission-window reservations after child runs finish.
         "release_locks" => runtime
@@ -247,9 +276,35 @@ pub(super) fn run_deterministic(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::command::task::TaskAddParams;
+    use chrono::Utc;
+    use orbit_common::types::{PipelineState, TaskPriority, TaskStatus, TaskType};
     use orbit_engine::V2RuntimeHost;
     use orbit_tools::ToolContext;
     use serde_json::json;
+
+    fn seed_task(
+        runtime: &OrbitRuntime,
+        title: &str,
+        status: TaskStatus,
+        dependencies: Vec<String>,
+    ) -> String {
+        runtime
+            .add_task(TaskAddParams {
+                title: title.to_string(),
+                description: format!("Fixture task: {title}"),
+                acceptance_criteria: vec!["Fixture task is observable.".to_string()],
+                dependencies,
+                plan: "Fixture plan.".to_string(),
+                workspace_path: Some(".".to_string()),
+                priority: TaskPriority::Medium,
+                task_type: Some(TaskType::Chore),
+                status: Some(status),
+                ..Default::default()
+            })
+            .expect("seed task")
+            .id
+    }
 
     #[test]
     fn run_planning_duel_is_registered_for_v2_deterministic_dispatch() {
@@ -349,4 +404,148 @@ mod tests {
             other => panic!("expected registered action failure, got {other}"),
         }
     }
+
+    #[test]
+    fn reserve_locks_records_unmet_dependencies_in_run_state() {
+        let runtime = OrbitRuntime::in_memory().expect("build runtime");
+        let dependency = seed_task(&runtime, "Dependency", TaskStatus::Backlog, Vec::new());
+        let blocked = seed_task(
+            &runtime,
+            "Blocked",
+            TaskStatus::Backlog,
+            vec![dependency.clone()],
+        );
+        let run = runtime
+            .stores()
+            .jobs()
+            .insert_run("task_gate_pipeline", 1, Utc::now(), Some(json!({})), None)
+            .expect("insert run");
+        runtime
+            .stores()
+            .jobs()
+            .write_run_state(
+                &run.run_id,
+                &PipelineState::new(run.run_id.clone(), run.job_id.clone(), json!({})),
+            )
+            .expect("write state");
+
+        let output = runtime
+            .run_deterministic(
+                "reserve_locks",
+                &json!({}),
+                &json!({
+                    "run_id": run.run_id,
+                    "task_ids": [blocked],
+                }),
+                ToolContext::default(),
+            )
+            .expect("reserve locks");
+
+        assert_eq!(output["reserved"], json!(false));
+        assert_eq!(output["waiting_on_deps"], json!([dependency]));
+        let state = runtime
+            .read_run_state(&run.run_id)
+            .expect("read run state")
+            .expect("state exists");
+        assert_eq!(state.waiting_on_deps, Some(vec![dependency]));
+        assert_eq!(state.waiting_on_locks, None);
+    }
+
+    #[test]
+    fn waiting_locks_from_reserve_output_extracts_unique_conflict_files() {
+        let locks = waiting_locks_from_reserve_output(&json!({
+            "reserved": false,
+            "conflicts": [
+                { "file": "file:src/lib.rs", "held_by_id": "ORB-1" },
+                { "file": "file:src/lib.rs", "held_by_id": "reservation-1" },
+                { "file": "dir:crates/orbit-core/src", "held_by_id": "ORB-2" }
+            ],
+        }));
+
+        assert_eq!(
+            locks,
+            vec![
+                "dir:crates/orbit-core/src".to_string(),
+                "file:src/lib.rs".to_string()
+            ]
+        );
+    }
+}
+
+fn unmet_dependency_ids_for_input(
+    runtime: &OrbitRuntime,
+    input: &Value,
+) -> Result<Vec<String>, OrbitError> {
+    let Some(raw_task_ids) =
+        optional_string_list_alias(input, &["task_ids", "taskIds", "task-ids"])?
+    else {
+        return Ok(Vec::new());
+    };
+    let task_ids = parse_task_ids(&serde_json::json!({ "task_ids": raw_task_ids }))?;
+    let tasks = runtime.stores().tasks().list()?;
+    let status_by_id = build_task_status_index(&tasks);
+    let task_by_id = tasks
+        .into_iter()
+        .map(|task| (task.id.clone(), task))
+        .collect::<BTreeMap<_, _>>();
+    let mut unmet = BTreeSet::new();
+    for task_id in task_ids {
+        let task = task_by_id
+            .get(&task_id)
+            .ok_or_else(|| OrbitError::not_found(crate::NotFoundKind::Task, task_id.clone()))?;
+        for dependency in unmet_task_dependencies(task, &status_by_id) {
+            unmet.insert(dependency.id);
+        }
+    }
+    Ok(unmet.into_iter().collect())
+}
+
+fn waiting_locks_from_reserve_output(output: &Value) -> Vec<String> {
+    output
+        .get("conflicts")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+        .filter_map(|conflict| conflict.get("file").and_then(Value::as_str))
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect()
+}
+
+fn update_run_waiting_reasons(
+    runtime: &OrbitRuntime,
+    input: &Value,
+    waiting_on_deps: Option<Vec<String>>,
+    waiting_on_locks: Option<Vec<String>>,
+    action: &str,
+) -> Result<(), DispatchError> {
+    let Some(run_id) = input.get("run_id").and_then(Value::as_str) else {
+        return Ok(());
+    };
+    let Some(mut state) =
+        runtime
+            .read_run_state(run_id)
+            .map_err(|err| DispatchError::DeterministicActionFailed {
+                action: action.to_string(),
+                message: format!("{err}"),
+            })?
+    else {
+        return Ok(());
+    };
+    state.set_waiting_reasons(waiting_on_deps, waiting_on_locks);
+    runtime
+        .stores()
+        .jobs()
+        .write_run_state(run_id, &state)
+        .map_err(|err| DispatchError::DeterministicActionFailed {
+            action: action.to_string(),
+            message: format!("{err}"),
+        })
+}
+
+fn non_empty(values: Vec<String>) -> Option<Vec<String>> {
+    (!values.is_empty()).then_some(values)
 }

--- a/crates/orbit-store/src/file/job_store/run.rs
+++ b/crates/orbit-store/src/file/job_store/run.rs
@@ -119,6 +119,7 @@ impl JobFileStore {
             .map_err(OrbitError::JobRunStateTransition)?;
         run.finished_at = Some(finished_at);
         self.write_run(&job_id, &run)?;
+        clear_run_waiting_reasons_at(&run_dir)?;
         Ok(true)
     }
 
@@ -195,6 +196,7 @@ impl JobFileStore {
         let mut run = self.read_run_at(&run_dir)?;
         // Preserve existing no-op behavior for terminal states.
         if run.state.is_terminal() {
+            clear_run_waiting_reasons_at(&run_dir)?;
             return Ok(true);
         }
         let event = match state {
@@ -216,6 +218,7 @@ impl JobFileStore {
         run.finished_at = Some(finished_at);
         run.duration_ms = duration_ms;
         self.write_run(&job_id, &run)?;
+        clear_run_waiting_reasons_at(&run_dir)?;
         Ok(true)
     }
 
@@ -517,4 +520,25 @@ fn encode_step_target_id_for_filename(target_id: &str) -> String {
 
 fn validate_run_id(run_id: &str) -> Result<(), OrbitError> {
     validate_path_stem(run_id, "job run")
+}
+
+fn clear_run_waiting_reasons_at(run_dir: &Path) -> Result<(), OrbitError> {
+    let state_path = run_dir.join("state.json");
+    if !state_path.exists() {
+        return Ok(());
+    }
+    let raw = fs::read_to_string(&state_path).map_err(|e| OrbitError::Io(e.to_string()))?;
+    let mut state: PipelineState = serde_json::from_str(&raw).map_err(|e| {
+        OrbitError::Store(format!(
+            "invalid state.json '{}': {e}",
+            state_path.display()
+        ))
+    })?;
+    if state.waiting_on_deps.is_none() && state.waiting_on_locks.is_none() {
+        return Ok(());
+    }
+    state.clear_waiting_reasons();
+    let content =
+        serde_json::to_string_pretty(&state).map_err(|e| OrbitError::Store(e.to_string()))?;
+    write_atomic(&state_path, &content).map_err(Into::into)
 }

--- a/crates/orbit-store/src/state_io.rs
+++ b/crates/orbit-store/src/state_io.rs
@@ -99,3 +99,65 @@ fn write_state_file(state_dir: &Path, state: &PipelineState) -> Result<(), Orbit
 fn state_path(state_dir: &Path) -> PathBuf {
     state_dir.join("state.json")
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use serde_json::json;
+
+    fn test_state() -> PipelineState {
+        PipelineState::new("jrun-test".to_string(), "job-test".to_string(), json!({}))
+    }
+
+    #[test]
+    fn pipeline_state_waiting_reasons_round_trip_populated() {
+        let mut state = test_state();
+        state.set_waiting_reasons(
+            Some(vec!["ORB-1".to_string(), "ORB-2".to_string()]),
+            Some(vec!["file:src/lib.rs".to_string()]),
+        );
+
+        let encoded = serde_json::to_value(&state).expect("serialize state");
+        assert_eq!(encoded["waiting_on_deps"], json!(["ORB-1", "ORB-2"]));
+        assert_eq!(encoded["waiting_on_locks"], json!(["file:src/lib.rs"]));
+
+        let decoded: PipelineState = serde_json::from_value(encoded).expect("deserialize state");
+        assert_eq!(
+            decoded.waiting_on_deps,
+            Some(vec!["ORB-1".to_string(), "ORB-2".to_string()])
+        );
+        assert_eq!(
+            decoded.waiting_on_locks,
+            Some(vec!["file:src/lib.rs".to_string()])
+        );
+    }
+
+    #[test]
+    fn pipeline_state_waiting_reasons_round_trip_empty_arrays() {
+        let mut state = test_state();
+        state.set_waiting_reasons(Some(Vec::new()), Some(Vec::new()));
+
+        let encoded = serde_json::to_value(&state).expect("serialize state");
+        assert_eq!(encoded["waiting_on_deps"], json!([]));
+        assert_eq!(encoded["waiting_on_locks"], json!([]));
+
+        let decoded: PipelineState = serde_json::from_value(encoded).expect("deserialize state");
+        assert_eq!(decoded.waiting_on_deps, Some(Vec::new()));
+        assert_eq!(decoded.waiting_on_locks, Some(Vec::new()));
+    }
+
+    #[test]
+    fn pipeline_state_waiting_reasons_round_trip_none_absent() {
+        let state = test_state();
+
+        let encoded = serde_json::to_value(&state).expect("serialize state");
+        let object = encoded.as_object().expect("state object");
+        assert!(!object.contains_key("waiting_on_deps"));
+        assert!(!object.contains_key("waiting_on_locks"));
+
+        let decoded: PipelineState = serde_json::from_value(encoded).expect("deserialize state");
+        assert_eq!(decoded.waiting_on_deps, None);
+        assert_eq!(decoded.waiting_on_locks, None);
+    }
+}


### PR DESCRIPTION
## Task

[ORB-00074](https://orbit-cli.com/tasks/ORB-00074) — Surface waiting-reason fields on job status output

### Description

## Problem

The `task_auto_pipeline` job gates execution on task dependencies and lock availability. When the job is parked in a waiting state, the operator-facing surfaces (`orbit run history -j <ID>` and `orbit run show <RUN_ID>`) report only that the job is waiting — they do not surface *what* it is waiting on. Operators must read job logs or job-state internals to discover which dependency or lock is blocking progress.

## Why It Matters

- A pending convergence of `ship`/`ship-local`/`ship-auto` into one async-by-default `orbit run ship` (filed as the follow-on task that depends on this one) will turn the queue-and-wait state into the common path, not the exception. Without visible waiting reasons, gated jobs become silent stalls and the unified command's UX is strictly worse than today's fail-fast behavior on `orbit run ship <TASK_IDS>`.
- Independent of the convergence, the visibility gap already affects today's `ship-auto` operators who hit a parked job.

## Constraints / Notes

- **Scope.** Storage/state model + status output formatters. Do **not** change the CLI command surface or the workflow registry (`crates/orbit-core/src/command/workflow.rs`).
- **Field shape.** Exact names and shape are left to the implementer. Suggested form: `waiting_on_deps: [task_id, ...]` and `waiting_on_locks: [resource_identifier, ...]`, both emitted as `null` / absent when the job is not in a waiting state. Structured records (with timestamps, source, etc.) are also acceptable if better justified.
- **Producer.** The `task_auto_pipeline` job is the producer of the waiting state. The batch-parallel executor in `crates/orbit-engine/src/executor/automation/batch/parallel.rs` is the likely emission site; final placement is for the implementer to choose during planning.
- **Carrier.** Storage layer in `crates/orbit-store/` carries the persisted state. Exact module is for the implementer to pin down.
- **Consumer.** Both text and JSON output of `orbit run history -j <ID>` and `orbit run show <RUN_ID>` must reflect the new field(s).
- **No CLI surface changes.** This task does not add new flags, subcommands, or workflow aliases.

## Out of Scope

- Unifying the ship CLI surface (handled by the follow-on task).
- Changing the max-wait timeout behavior.
- New dashboard surfaces.

### Acceptance Criteria

- Job state schema exposes structured waiting reasons covering at minimum unmet task dependencies and held locks; the schema change is reflected in the relevant `orbit-store` module(s) and covered by serde round-trip tests in that crate.
- `orbit run history -j <JOB_ID> --json` against a job parked on an unmet dependency emits JSON containing the unmet dependency task ID(s) in a named field (suggested: `waiting_on_deps`).
- `orbit run history -j <JOB_ID> --json` against a job parked on a held lock emits JSON containing the locked resource identifier(s) in a named field (suggested: `waiting_on_locks`).
- Text (non-JSON) output of `orbit run history -j <JOB_ID>` and `orbit run show <RUN_ID>` includes a human-readable waiting line listing deps and locks (e.g. `Waiting on deps: T20260101-1234; locks: src/foo.rs`) when the job is in a waiting state, and omits the line entirely when the job is not waiting.
- Unit tests cover (a) serde serialization of the new field(s) for populated, empty, and `None` cases and (b) text-formatter output for waiting vs non-waiting states; all tests use in-memory fakes or temp directories (no reliance on `.orbit/knowledge/` or pre-existing on-disk artifacts).
- `make ci-fast` passes on the task branch before review.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Added optional `waiting_on_deps` and `waiting_on_locks` fields to persisted pipeline state, with store-level serde round-trip coverage for populated, empty, and absent cases.
- Updated gate lock reservation to record unmet task dependencies or held lock files into the run state while a gate run is parked, and clear waiting reasons on successful reservation/terminal run cleanup.
- Surfaced waiting reasons in `orbit run history` / `orbit run show` JSON and text output, with formatter tests for waiting and non-waiting states.

Assessment: Focused implementation with targeted unit coverage and `make ci-fast` passing.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-00074-6a08f609`
- Behind base: 0
- Ahead of base: 1