### PR TITLE
Web dashboard — add Locked Files panel above orbit.log on Tasks tab

### DIFF
--- a/crates/orbit-cli/assets/dashboard/app.js
+++ b/crates/orbit-cli/assets/dashboard/app.js
@@ -936,6 +936,71 @@ function renderTasks(tasks) {
   syncNodes(body, Array.from(frag.children));
 }
 
+function renderLocksPanel(payload) {
+  const body = $("locks-body");
+  const count = $("locks-count");
+  if (!body || !count) return;
+  const byTask = Array.isArray(payload && payload.by_task) ? payload.by_task : [];
+  const totalLocked = Number.isFinite(Number(payload && payload.total_locked))
+    ? Number(payload.total_locked)
+    : 0;
+  const totalTasks = Number.isFinite(Number(payload && payload.total_tasks))
+    ? Number(payload.total_tasks)
+    : byTask.length;
+  count.textContent = `${totalLocked} files / ${totalTasks} tasks`;
+
+  if (byTask.length === 0) {
+    const empty = el("div", { class: "locks-empty", text: "No files currently locked." });
+    empty.dataset.key = "locks-empty";
+    empty.dataset.hash = "locks-empty";
+    syncNodes(body, [empty]);
+    return;
+  }
+
+  const nodes = byTask.map((task) => {
+    const taskId = String(task.id || "");
+    const group = el("div", { class: "lock-task-group" });
+    group.dataset.key = `lock-task-${taskId}`;
+    group.dataset.hash = JSON.stringify(task);
+
+    const idButton = el("button", {
+      class: "lock-task-id mono",
+      text: `[${taskId}]`,
+      title: `Open ${taskId} in the task list`,
+    });
+    idButton.addEventListener("click", (e) => {
+      e.stopPropagation();
+      openVisibleTask(taskId);
+    });
+
+    const header = el("div", { class: "lock-task-header" }, [
+      idButton,
+      el("span", { class: "lock-separator", text: "·" }),
+      statusPill(task.status || "unknown"),
+    ]);
+    if (task.job_run_id) {
+      header.appendChild(el("span", { class: "lock-separator", text: "·" }));
+      header.appendChild(el("span", {
+        class: "lock-job mono",
+        text: `job_run=${task.job_run_id}`,
+        title: task.job_run_id,
+      }));
+    }
+    group.appendChild(header);
+
+    const files = Array.isArray(task.context_files) ? task.context_files : [];
+    for (const path of files) {
+      group.appendChild(el("div", {
+        class: "lock-file-row mono",
+        text: String(path),
+        title: String(path),
+      }));
+    }
+    return group;
+  });
+  syncNodes(body, nodes);
+}
+
 function fmtTimestamp(iso) {
   if (!iso) return "-";
   const d = new Date(iso);
@@ -2535,6 +2600,7 @@ function activeRefreshJobs() {
         renderTasks(tasks);
       }),
     );
+    if (!document.hidden) jobs.push(fetchAndRenderTaskLocks());
     return jobs;
   }
 
@@ -2612,6 +2678,10 @@ function fetchAndRenderRuns() {
     lastRuns = mergeRunsWithFriction(runs, frictionRows);
     renderRuns(lastRuns);
   });
+}
+
+function fetchAndRenderTaskLocks() {
+  return fetchJson("/api/tasks/locks").then(renderLocksPanel);
 }
 
 function fetchAndRenderRunDetail() {
@@ -3770,7 +3840,7 @@ async function refreshDashboard() {
   isRefreshing = false;
   if (activeTab === "tasks") fitLogPanelToViewport();
   
-  $("footer").textContent = `orbit dashboard · auto-refresh 30s · GET /api/{tasks,learnings,adrs,frictions,frictions/stats,jobs,job-runs,audit?since|tool|status|role|execution_id|profile|q|limit|offset,audit/summary?since|denial_threshold,runs/:id,runs/:id/events?kind|limit|offset,runs/:id/logs?limit,scoreboard,diagnostics/{metrics,errors,friction,denials?since|kind|profile|agent}}`;
+  $("footer").textContent = `orbit dashboard · auto-refresh 30s · GET /api/{tasks,tasks/locks,learnings,adrs,frictions,frictions/stats,jobs,job-runs,audit?since|tool|status|role|execution_id|profile|q|limit|offset,audit/summary?since|denial_threshold,runs/:id,runs/:id/events?kind|limit|offset,runs/:id/logs?limit,scoreboard,diagnostics/{metrics,errors,friction,denials?since|kind|profile|agent}}`;
 }
 
 buildChips();

--- a/crates/orbit-cli/assets/dashboard/index.html
+++ b/crates/orbit-cli/assets/dashboard/index.html
@@ -1738,6 +1738,7 @@
       .col-log {
         display: flex;
         flex-direction: column;
+        gap: 8px;
         min-height: 0;
         min-width: 0;
       }
@@ -1748,9 +1749,68 @@
         min-height: 0;
         min-width: 0;
       }
+      #locks-panel {
+        flex: 0 0 auto;
+      }
+      #locks-body {
+        max-height: 180px;
+        overflow: auto;
+      }
+      .locks-empty {
+        padding: 10px 16px;
+        color: var(--fg-dim);
+        font-family: var(--font-mono);
+        font-size: 12px;
+        font-style: italic;
+      }
+      .lock-task-group {
+        padding: 8px 12px 9px;
+        border-bottom: 1px solid rgba(255, 255, 255, 0.04);
+      }
+      .lock-task-group:last-child {
+        border-bottom: none;
+      }
+      .lock-task-header {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        min-width: 0;
+        margin-bottom: 4px;
+      }
+      .lock-task-id {
+        border: 0;
+        background: transparent;
+        color: var(--accent);
+        cursor: pointer;
+        padding: 0;
+        font-size: 11px;
+      }
+      .lock-task-id:hover {
+        color: var(--accent-hover);
+        text-decoration: underline;
+      }
+      .lock-separator {
+        color: var(--fg-dim);
+        font-size: 11px;
+      }
+      .lock-job {
+        color: var(--fg-dim);
+        font-size: 11px;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
+      .lock-file-row {
+        padding: 2px 0 2px 16px;
+        color: var(--fg-dim);
+        font-size: 11px;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
       #log-panel {
-        height: var(--log-panel-height, calc(100dvh - 224px));
-        max-height: var(--log-panel-height, calc(100dvh - 224px));
+        height: var(--log-panel-height, calc(100dvh - 420px));
+        max-height: var(--log-panel-height, calc(100dvh - 420px));
       }
       .col-log .panel > header .title {
         display: flex; align-items: center; gap: 10px;
@@ -1913,6 +1973,10 @@
           </section>
         </div>
         <div class="col-log">
+          <section class="panel" id="locks-panel">
+            <header><span>Locked files</span><span class="count" id="locks-count">0 files / 0 tasks</span></header>
+            <div class="body" id="locks-body"></div>
+          </section>
           <section class="panel" id="log-panel">
             <header class="head">
               <div class="title"><span class="live-dot"></span>orbit.log <span style="color: var(--fg-dim); font-family: var(--font-mono); font-weight: 400; letter-spacing: 0; text-transform: none;">— tail -F</span></div>

--- a/crates/orbit-cli/src/command/task/list.rs
+++ b/crates/orbit-cli/src/command/task/list.rs
@@ -163,38 +163,50 @@ pub struct TaskLocksArgs {
 
 impl Execute for TaskLocksArgs {
     fn execute(self, runtime: &OrbitRuntime) -> Result<(), OrbitError> {
-        let mut tasks: Vec<_> = runtime
-            .list_tasks()?
-            .into_iter()
-            .filter(|task| matches!(task.status, TaskStatus::InProgress | TaskStatus::Review))
-            .collect();
-
-        tasks.sort_by_key(|task| {
-            (
-                task_lock_status_rank(task.status),
-                task.created_at,
-                task.id.clone(),
-            )
-        });
-
-        let locked_files: BTreeSet<String> = tasks
-            .iter()
-            .flat_map(|task| task.context_files.iter().cloned())
-            .collect();
-
         if self.json {
-            let json_by_task: Vec<Value> = tasks.iter().map(task_lock_to_json).collect();
-            crate::output::json::print_pretty(&json!({
-                "locked_files": locked_files.iter().cloned().collect::<Vec<_>>(),
-                "by_task": json_by_task,
-                "total_locked": locked_files.len(),
-                "total_tasks": tasks.len(),
-            }))
+            crate::output::json::print_pretty(&task_locks_json(runtime)?)
         } else {
+            let (tasks, locked_files) = task_locks(runtime)?;
             print_task_locks(&tasks, &locked_files);
             Ok(())
         }
     }
+}
+
+pub(crate) fn task_locks_json(runtime: &OrbitRuntime) -> Result<Value, OrbitError> {
+    let (tasks, locked_files) = task_locks(runtime)?;
+    let json_by_task: Vec<Value> = tasks.iter().map(task_lock_to_json).collect();
+    Ok(json!({
+        "locked_files": locked_files.iter().cloned().collect::<Vec<_>>(),
+        "by_task": json_by_task,
+        "total_locked": locked_files.len(),
+        "total_tasks": tasks.len(),
+    }))
+}
+
+fn task_locks(
+    runtime: &OrbitRuntime,
+) -> Result<(Vec<orbit_core::Task>, BTreeSet<String>), OrbitError> {
+    let mut tasks: Vec<_> = runtime
+        .list_tasks()?
+        .into_iter()
+        .filter(|task| matches!(task.status, TaskStatus::InProgress | TaskStatus::Review))
+        .collect();
+
+    tasks.sort_by_key(|task| {
+        (
+            task_lock_status_rank(task.status),
+            task.created_at,
+            task.id.clone(),
+        )
+    });
+
+    let locked_files: BTreeSet<String> = tasks
+        .iter()
+        .flat_map(|task| task.context_files.iter().cloned())
+        .collect();
+
+    Ok((tasks, locked_files))
 }
 
 fn task_lock_status_rank(status: TaskStatus) -> u8 {

--- a/crates/orbit-cli/src/command/task/mod.rs
+++ b/crates/orbit-cli/src/command/task/mod.rs
@@ -13,3 +13,4 @@ mod templates;
 mod update;
 
 pub use command::{TaskCommand, TaskSubcommand};
+pub(crate) use list::task_locks_json;

--- a/crates/orbit-cli/src/command/web/api/mod.rs
+++ b/crates/orbit-cli/src/command/web/api/mod.rs
@@ -297,6 +297,7 @@ pub(super) fn router() -> Router<Arc<OrbitRuntime>> {
             "/tasks",
             get(tasks::list_tasks).post(tasks::create_task_action),
         )
+        .route("/tasks/locks", get(tasks::list_task_locks))
         .route(
             "/tasks/:id",
             get(tasks::get_task).patch(tasks::update_task_action),

--- a/crates/orbit-cli/src/command/web/api/tasks.rs
+++ b/crates/orbit-cli/src/command/web/api/tasks.rs
@@ -16,6 +16,7 @@ use serde_json::{Value, json};
 
 use super::{bad_request, map_runtime_error, server_error, validate_id};
 use crate::command::task::output::task_to_json_with_sidecars;
+use crate::command::task::task_locks_json;
 
 const DASHBOARD_TASK_STATUSES: &[TaskStatus] = &[
     TaskStatus::InProgress,
@@ -134,6 +135,13 @@ pub(super) async fn list_tasks(State(runtime): State<Arc<OrbitRuntime>>) -> Resp
             }
             Err(e) => server_error(e),
         },
+        Err(e) => server_error(e),
+    }
+}
+
+pub(super) async fn list_task_locks(State(runtime): State<Arc<OrbitRuntime>>) -> Response {
+    match task_locks_json(&runtime) {
+        Ok(value) => Json(value).into_response(),
         Err(e) => server_error(e),
     }
 }

--- a/crates/orbit-cli/src/command/web/api/tasks_tests.rs
+++ b/crates/orbit-cli/src/command/web/api/tasks_tests.rs
@@ -5,7 +5,7 @@ use axum::http::{HeaderValue, Method, Request, StatusCode, header};
 use orbit_common::types::TaskArtifact;
 use orbit_core::command::task::{TaskAddParams, TaskUpdateParams};
 use orbit_core::{OrbitRuntime, TaskStatus};
-use serde_json::Value;
+use serde_json::{Value, json};
 use tower::ServiceExt;
 
 use super::test_support::body_json;
@@ -38,6 +38,53 @@ fn seed_task_with_artifact(runtime: &OrbitRuntime) -> orbit_core::Task {
         .expect("upsert artifact")
 }
 
+fn seed_lock_task(
+    runtime: &OrbitRuntime,
+    title: &str,
+    status: TaskStatus,
+    context_files: Vec<&str>,
+    job_run_id: Option<&str>,
+) -> orbit_core::Task {
+    for selector in &context_files {
+        if let Some(path) = selector.strip_prefix("file:") {
+            let path = runtime
+                .data_root()
+                .parent()
+                .expect("runtime data root has repo parent")
+                .join(path);
+            if let Some(parent) = path.parent() {
+                std::fs::create_dir_all(parent).expect("create context parent");
+            }
+            std::fs::write(path, "").expect("write context file");
+        }
+    }
+    let task = runtime
+        .add_task(TaskAddParams {
+            title: title.to_string(),
+            description: format!("Fixture for {title}."),
+            status: Some(status),
+            context_files: context_files.into_iter().map(str::to_string).collect(),
+            workspace_path: Some(".".to_string()),
+            ..Default::default()
+        })
+        .expect("create lock task");
+    if let Some(job_run_id) = job_run_id {
+        runtime
+            .update_task_with_identity(
+                &task.id,
+                TaskUpdateParams {
+                    job_run_id: Some(Some(job_run_id.to_string())),
+                    ..Default::default()
+                },
+                Some("codex".to_string()),
+                Some("gpt-5.5".to_string()),
+            )
+            .expect("set job run")
+    } else {
+        task
+    }
+}
+
 async fn request(runtime: OrbitRuntime, uri: &str) -> axum::response::Response {
     router()
         .with_state(Arc::new(runtime))
@@ -50,6 +97,61 @@ async fn request(runtime: OrbitRuntime, uri: &str) -> axum::response::Response {
         )
         .await
         .expect("response")
+}
+
+#[tokio::test]
+async fn task_locks_endpoint_matches_cli_json_contract() {
+    let runtime = OrbitRuntime::in_memory().expect("build runtime");
+    let review = seed_lock_task(
+        &runtime,
+        "Review task",
+        TaskStatus::Review,
+        vec!["file:src/b.rs", "file:src/shared.rs"],
+        Some("jrun-review"),
+    );
+    let in_progress = seed_lock_task(
+        &runtime,
+        "In progress task",
+        TaskStatus::InProgress,
+        vec!["file:src/a.rs", "file:src/shared.rs"],
+        None,
+    );
+    seed_lock_task(
+        &runtime,
+        "Backlog task",
+        TaskStatus::Backlog,
+        vec!["file:src/ignored.rs"],
+        None,
+    );
+    seed_lock_task(
+        &runtime,
+        "Done task",
+        TaskStatus::Done,
+        vec!["file:src/done.rs"],
+        None,
+    );
+    let expected = crate::command::task::task_locks_json(&runtime).expect("cli task locks json");
+
+    let response = request(runtime, "/tasks/locks").await;
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = body_json(response).await;
+    assert_eq!(body, expected);
+    assert_eq!(
+        body["locked_files"],
+        json!(["file:src/a.rs", "file:src/b.rs", "file:src/shared.rs"])
+    );
+    assert_eq!(body["total_locked"], json!(3));
+    assert_eq!(body["total_tasks"], json!(2));
+    let by_task = body["by_task"].as_array().expect("by_task array");
+    assert_eq!(by_task[0]["id"], json!(in_progress.id));
+    assert_eq!(by_task[1]["id"], json!(review.id));
+    assert!(
+        !by_task
+            .iter()
+            .any(|task| task["status"] == json!("backlog"))
+    );
+    assert!(!by_task.iter().any(|task| task["status"] == json!("done")));
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Task

[ORB-00073](https://orbit-cli.com/tasks/ORB-00073) — Web dashboard — add Locked Files panel above orbit.log on Tasks tab

### Description

## Problem

The Tasks tab in the web dashboard does not surface which files are currently locked by `in-progress` / `review` tasks. The information is available on the CLI (`orbit task locks` / `orbit.task.locks` MCP tool) and is critical for spotting potential cross-task file contention before claiming work, but a dashboard user has to drop to the shell to see it.

## Why It Matters

- Closes a visibility gap between CLI and dashboard for an operationally important signal (file contention across active tasks).
- The right column of the Tasks tab currently shows only `orbit.log`; there is room for a compact panel above it without crowding the layout.

## Scope

Backend (Rust) + frontend (vanilla JS).

### Backend

1. Add `GET /api/tasks/locks` in `crates/orbit-cli/src/command/web/api/tasks.rs`.
2. Handler mirrors `TaskLocksArgs::execute` (`crates/orbit-cli/src/command/task/list.rs:158`):
   - `runtime.list_tasks()` → filter `TaskStatus::InProgress | TaskStatus::Review`
   - Sort by `(task_lock_status_rank(status), created_at, id)` — same comparator already used by the CLI
   - Build `locked_files: BTreeSet<String>` from each task's `context_files`
   - Project each task with the existing `task_lock_to_json` helper
3. Response shape (must match `orbit task locks --json` byte-for-byte on the same fixture):
   ```json
   {
     "locked_files": ["path/a", "path/b"],
     "by_task": [{ "id": "...", "title": "...", "status": "...", "job_run_id": "...", "context_files": [...] }],
     "total_locked": 7,
     "total_tasks": 3
   }
   ```
4. No new types, no migrations, no changes to `task_to_json_with_sidecars`. Pure read endpoint.
5. Register the route in the same module that registers the other `/api/tasks` routes; localhost-origin / auth posture must match sibling endpoints.

### Frontend

1. DOM (in `crates/orbit-cli/assets/dashboard/index.html`, inserted in `.col-log` immediately above `#log-panel`):
   ```html
   <section class="panel" id="locks-panel">
     <header><span>Locked files</span>
       <span class="count" id="locks-count">0 files / 0 tasks</span>
     </header>
     <div class="body" id="locks-body"></div>
   </section>
   ```
2. Renderer in `crates/orbit-cli/assets/dashboard/app.js`:
   - New `renderLocksPanel(payload)` that builds one `.lock-task-group` per entry in `by_task`
   - Group header: `[ID]` (anchor/button that scrolls to and expands the matching row in the left tasks list, reusing the same scroll-and-expand helper planned for ORB-00068; falls back to a copy-to-clipboard toast if the target is not in the filtered list) · status pill (reuse existing status color classes) · optional `job_run=…` when `job_run_id` is set
   - Indented file rows: monospace, `text-overflow: ellipsis`, full path in `title=` tooltip
   - Empty state: single italic line `"No files currently locked."`, no skeleton flash on subsequent polls
   - Updates `#locks-count` text to `"{total_locked} files / {total_tasks} tasks"`
3. Refresh strategy:
   - Piggyback on the existing tasks-list refresh path (whatever currently triggers `refreshTasks()` — periodic poll and/or task-update event). On the same tick, `fetch('/api/tasks/locks')` and re-render.
   - No separate timer. No polling when the Tasks tab is hidden / document is hidden.
4. CSS additions inline in `index.html` `<style>` block (~25 LOC):
   - `#locks-panel { flex: 0 0 auto; }` and `#locks-body { max-height: 180px; overflow: auto; }`
   - `.lock-task-group`, `.lock-task-header`, `.lock-file-row` (mono, ellipsis), reuse existing status pill class
   - Adjust the existing `--log-panel-height` calc on `#log-panel` (currently `calc(100dvh - 224px)`) by subtracting the locks panel height (~188px including gap) so the log panel still reaches the bottom of the viewport — no scroll change, no gap.

## Constraints / Notes

- No new Rust types or persisted artifacts. Backend change is route handler + registration only.
- Wire format must match the CLI's JSON output exactly (the JSON path is the contract per `web/api/mod.rs` module doc).
- Path traversal / auth posture: identical to existing `/api/tasks` routes — this endpoint reads in-memory task state, not the filesystem, so no new path-safety concerns.
- Frontend must not introduce a new polling timer; reuse the existing tasks-tab refresh cadence and respect document-hidden suppression if the existing code does.
- "Click task ID to scroll+expand" reuses the same helper introduced by ORB-00068 (relation target click). If ORB-00068 has not yet landed when this task is picked up, implement a local copy of the helper here and refactor to share when ORB-00068 merges — do not block on it.

### Acceptance Criteria

- `GET /api/tasks/locks` returns `{ locked_files, by_task, total_locked, total_tasks }`; only tasks with status `in-progress` or `review` are included; output is byte-for-byte identical to `orbit task locks --json` on the same task fixture (verified by a test that runs both paths and `assert_eq!`s the parsed JSON).
- Tasks tab right column shows `#locks-panel` above `#log-panel`; the log panel still reaches the bottom of the viewport with no visible gap and no scroll-behavior regression (manual visual check noted in execution summary).
- With zero `in-progress` / `review` tasks, `#locks-body` renders a single italic line `No files currently locked.` and shows `0 files / 0 tasks` in `#locks-count`; subsequent polls do not flash the skeleton state.
- Each task ID in the locks panel is a clickable element; clicking it scrolls the matching row in the left tasks list into view and expands its detail dropdown when present in the filtered list; when not present, a copy-to-clipboard toast fires with the task ID.
- The locks panel refreshes on the same tick as the tasks list (no new `setInterval`); when the document is hidden or the Tasks tab is not active, no `/api/tasks/locks` request is issued (verified by inspecting Network tab while tab is backgrounded).
- Backend change does not add any new Rust types, persisted artifacts, or migrations; only a new route handler and its registration.
- `make ci-fast` passes.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Added a shared task locks JSON projection for the existing CLI contract and exposed it through `GET /api/tasks/locks`.
- Registered the new route and added a regression test that compares the parsed route response against the CLI locks JSON projection on the same active/inactive task fixture.
- Added the dashboard Locked files panel above `orbit.log`, including counts, empty state, grouped task/file rendering, clickable task IDs via the existing scroll/expand helper, and same-tick refresh that is suppressed when `document.hidden` or the Tasks tab is inactive.
- Added compact locks-panel CSS and adjusted the log panel height fallback; the existing viewport-fit logic continues sizing the log panel from its actual top edge.

Assessment: implementation is scoped to the requested backend route, route registration, focused CLI-contract test, and vanilla dashboard changes. No new Rust types, persisted artifacts, migrations, timers, or cross-crate dependencies were added.

Validation:
- `cargo test -p orbit-cli command::web::api::tasks_tests::task_locks_endpoint_matches_cli_json_contract`
- `node --check crates/orbit-cli/assets/dashboard/app.js`
- `cargo build -p orbit-cli`
- Served the dashboard on `127.0.0.1:7881` and checked `/api/tasks/locks`, `#locks-panel` before `#log-panel`, the adjusted log-panel height fallback, and static JS wiring with `curl`.
- `make ci-fast`

Deviations from original plan:
- Interactive Browser/Network-tab inspection was unavailable because the required node_repl browser surface was not exposed in this activity. I validated the no-extra-timer/no-hidden-document request path by source and served asset inspection: locks fetch is only added to the existing active Tasks refresh jobs and only when `!document.hidden`.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-00073-6a08f609`
- Behind base: 0
- Ahead of base: 1