### PR TITLE
Web dashboard — add per-task crew selector on Tasks tab

### DIFF
--- a/crates/orbit-cli/assets/dashboard/app.js
+++ b/crates/orbit-cli/assets/dashboard/app.js
@@ -40,6 +40,7 @@ let activeStatuses = new Set(
   STATUS_ORDER.filter((s) => !DEFAULT_INACTIVE_STATUSES.has(s)),
 );
 let lastTasks = [];
+let lastCrewPayload = { default_crew: null, crews: [] };
 let lastRuns = [];
 let lastDiagnostics = { metrics: [], errors: [] };
 let lastLearningPayload = { stats: {}, items: [] };
@@ -52,6 +53,7 @@ let runSort = { key: "when", dir: "desc" };
 let expandedTaskIds = new Set();
 let isRefreshing = false;
 let taskActionNotice = null;
+let crewUpdateErrors = new Map();
 let activeLearningId = null;
 let learningSearchQuery = "";
 let activeAdrId = null;
@@ -166,6 +168,57 @@ function postJson(path, body) {
 
 function patchJson(path, body) {
   return requestJson(path, "PATCH", body);
+}
+
+function normalizeCrewPayload(payload) {
+  const crews = Array.isArray(payload && payload.crews)
+    ? payload.crews
+      .filter((crew) => crew && crew.name)
+      .map((crew) => ({
+        name: String(crew.name),
+        planner_model: crew.planner_model == null ? "" : String(crew.planner_model),
+        implementer_model: crew.implementer_model == null ? "" : String(crew.implementer_model),
+        reviewer_model: crew.reviewer_model == null ? "" : String(crew.reviewer_model),
+        is_default: Boolean(crew.is_default),
+      }))
+    : [];
+  crews.sort((a, b) => a.name.localeCompare(b.name));
+  return {
+    default_crew: payload && payload.default_crew ? String(payload.default_crew) : null,
+    crews,
+  };
+}
+
+function crewOptionsSignature() {
+  return JSON.stringify(lastCrewPayload);
+}
+
+function explicitCrewValue(task) {
+  return task && task.crew ? String(task.crew) : "";
+}
+
+function resolvedCrewName(task) {
+  if (lastCrewPayload.default_crew) return lastCrewPayload.default_crew;
+  if (!explicitCrewValue(task) && task && task.resolved_crew) {
+    return String(task.resolved_crew);
+  }
+  return "workspace";
+}
+
+function crewOptionTitle(crew) {
+  const parts = [
+    `planner=${crew.planner_model || "-"}`,
+    `implementer=${crew.implementer_model || "-"}`,
+    `reviewer=${crew.reviewer_model || "-"}`,
+  ];
+  return parts.join(" · ");
+}
+
+function applyUpdatedTask(updatedTask) {
+  const index = lastTasks.findIndex((task) => task.id === updatedTask.id);
+  if (index >= 0) {
+    lastTasks[index] = updatedTask;
+  }
 }
 
 function runIsCancellable(run) {
@@ -771,6 +824,89 @@ function buildStatusUpdateControl(task, detail) {
   return select;
 }
 
+function buildCrewUpdateControl(task) {
+  const cell = el("span", { class: "crew-cell" });
+  const select = el("select", {
+    class: "task-crew-select mono",
+    title: `Update crew for ${task.id}`,
+  });
+  const currentValue = explicitCrewValue(task);
+  select.dataset.currentValue = currentValue;
+
+  const defaultOption = el("option", {
+    text: `default: ${resolvedCrewName(task)}`,
+  });
+  defaultOption.value = "";
+  select.appendChild(defaultOption);
+
+  const crews = Array.isArray(lastCrewPayload.crews) ? lastCrewPayload.crews : [];
+  for (const crew of crews) {
+    const option = el("option", {
+      text: crew.name,
+      title: crewOptionTitle(crew),
+    });
+    option.value = crew.name;
+    select.appendChild(option);
+  }
+
+  if (currentValue && !crews.some((crew) => crew.name === currentValue)) {
+    const option = el("option", {
+      text: currentValue,
+      title: "Configured crew no longer found",
+    });
+    option.value = currentValue;
+    select.appendChild(option);
+  }
+
+  if (crews.length === 0) {
+    select.disabled = true;
+    defaultOption.textContent = "crew unavailable";
+  }
+
+  select.value = currentValue;
+  for (const eventName of ["pointerdown", "mousedown", "click", "keydown"]) {
+    select.addEventListener(eventName, (event) => event.stopPropagation());
+  }
+  select.addEventListener("change", (event) => {
+    event.stopPropagation();
+    updateTaskCrew(task, select);
+  });
+
+  cell.appendChild(select);
+  const error = crewUpdateErrors.get(task.id);
+  if (error) {
+    cell.appendChild(el("span", { class: "crew-error", text: error }));
+  }
+  return cell;
+}
+
+async function updateTaskCrew(task, select) {
+  const previousValue = select.dataset.currentValue || "";
+  const nextValue = select.value || "";
+  if (nextValue === previousValue) return;
+
+  crewUpdateErrors.delete(task.id);
+  select.disabled = true;
+  try {
+    const updatedTask = await patchJson(`/api/tasks/${encodeURIComponent(task.id)}`, {
+      crew: nextValue || null,
+    });
+    applyUpdatedTask(updatedTask);
+    crewUpdateErrors.delete(task.id);
+    renderTasks(lastTasks);
+  } catch (error) {
+    select.value = previousValue;
+    select.dataset.currentValue = previousValue;
+    select.disabled = false;
+    crewUpdateErrors.set(
+      task.id,
+      `crew update failed: ${error.message || String(error)}`,
+    );
+    renderTasks(lastTasks);
+    console.error(error);
+  }
+}
+
 function showRejectForm(task, detail, actions) {
   const form = el("div", { class: "reject-form" });
   form.addEventListener("click", (e) => e.stopPropagation());
@@ -903,10 +1039,11 @@ function renderTasks(tasks) {
         el("span", { class: "title", text: t.title }),
         priorityCell(t.priority),
         el("span", { class: "type mono", text: t.type }),
+        buildCrewUpdateControl(t),
       ]);
       row.dataset.key = `task-${t.id}`;
       // Basic hash based on row presentation parameters + expanded state
-      row.dataset.hash = `${t.id}-${t.title}-${t.priority}-${t.type}-${expandedTaskIds.has(t.id)}`;
+      row.dataset.hash = `${t.id}-${t.title}-${t.priority}-${t.type}-${t.crew || ""}-${t.resolved_crew || ""}-${crewOptionsSignature()}-${crewUpdateErrors.get(t.id) || ""}-${expandedTaskIds.has(t.id)}`;
       row.addEventListener("click", () => {
         const toggle = () => {
           if (expandedTaskIds.has(t.id)) expandedTaskIds.delete(t.id);
@@ -1985,13 +2122,11 @@ function openTaskFromKnowledge(taskId) {
   if (taskSearch) taskSearch.value = "";
   setActiveTab("tasks", { refresh: false });
   const open = () => openVisibleTask(taskId);
-  if (lastTasks.length > 0) {
+  if (lastTasks.length > 0 && lastCrewPayload.crews.length > 0) {
     open();
     return;
   }
-  fetchJson("/api/tasks").then((tasks) => {
-    lastTasks = tasks;
-    renderTasks(tasks);
+  fetchAndRenderTasks().then(() => {
     open();
   }).catch(() => copyTaskIdWithNotice(taskId));
 }
@@ -2589,17 +2724,29 @@ function renderDiagnostics() {
   );
 }
 
+function fetchAndCacheCrews() {
+  return fetchJson("/api/crews").then((payload) => {
+    lastCrewPayload = normalizeCrewPayload(payload);
+    return lastCrewPayload;
+  });
+}
+
+function fetchAndRenderTasks() {
+  return Promise.all([
+    fetchJson("/api/tasks"),
+    fetchAndCacheCrews(),
+  ]).then(([tasks]) => {
+    lastTasks = tasks;
+    renderTasks(tasks);
+  });
+}
+
 function activeRefreshJobs() {
   // The health strip is global; refresh on every tick alongside the active tab.
   const jobs = [fetchAndRenderSummary()];
 
   if (activeTab === "tasks") {
-    jobs.push(
-      fetchJson("/api/tasks").then((tasks) => {
-        lastTasks = tasks;
-        renderTasks(tasks);
-      }),
-    );
+    jobs.push(fetchAndRenderTasks());
     if (!document.hidden) jobs.push(fetchAndRenderTaskLocks());
     return jobs;
   }
@@ -3840,7 +3987,7 @@ async function refreshDashboard() {
   isRefreshing = false;
   if (activeTab === "tasks") fitLogPanelToViewport();
   
-  $("footer").textContent = `orbit dashboard · auto-refresh 30s · GET /api/{tasks,tasks/locks,learnings,adrs,frictions,frictions/stats,jobs,job-runs,audit?since|tool|status|role|execution_id|profile|q|limit|offset,audit/summary?since|denial_threshold,runs/:id,runs/:id/events?kind|limit|offset,runs/:id/logs?limit,scoreboard,diagnostics/{metrics,errors,friction,denials?since|kind|profile|agent}}`;
+  $("footer").textContent = `orbit dashboard · auto-refresh 30s · GET /api/{tasks,tasks/locks,crews,learnings,adrs,frictions,frictions/stats,jobs,job-runs,audit?since|tool|status|role|execution_id|profile|q|limit|offset,audit/summary?since|denial_threshold,runs/:id,runs/:id/events?kind|limit|offset,runs/:id/logs?limit,scoreboard,diagnostics/{metrics,errors,friction,denials?since|kind|profile|agent}}`;
 }
 
 buildChips();

--- a/crates/orbit-cli/assets/dashboard/index.html
+++ b/crates/orbit-cli/assets/dashboard/index.html
@@ -317,12 +317,12 @@
       
       .row {
         display: grid;
-        grid-template-columns: 130px 1fr 80px 80px;
+        grid-template-columns: 130px minmax(140px, 1fr) 72px 82px minmax(138px, 180px);
         gap: 12px;
         padding: 8px 16px;
         margin: 0;
         border-radius: 0;
-        align-items: baseline;
+        align-items: center;
         cursor: pointer;
         transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1);
         border-bottom: 1px solid var(--border);
@@ -338,10 +338,90 @@
         border-color: var(--border);
       }
       
-      .row .id { color: var(--fg-dim); font-size: 12px; transition: color 0.1s ease; }
+      .row .id {
+        color: var(--fg-dim);
+        font-size: 12px;
+        transition: color 0.1s ease;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+        min-width: 0;
+      }
       .row .id:hover { color: var(--accent); cursor: copy; }
-      .row .title { color: var(--fg); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font-weight: 500; font-size: 13px; }
+      .row .title {
+        color: var(--fg);
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+        font-weight: 500;
+        font-size: 13px;
+        min-width: 0;
+      }
       .row .priority, .row .type { font-size: 12px; color: var(--fg-dim); text-align: right; }
+      .row .crew-cell {
+        display: grid;
+        gap: 4px;
+        min-width: 0;
+      }
+      .task-crew-select {
+        width: 100%;
+        min-width: 0;
+        height: 28px;
+        border: 1px solid var(--border);
+        border-radius: 2px;
+        background: var(--bg);
+        color: var(--fg);
+        font-size: 11px;
+        padding: 4px 24px 4px 8px;
+        outline: none;
+      }
+      .task-crew-select:hover:not(:disabled),
+      .task-crew-select:focus {
+        border-color: var(--accent);
+      }
+      .task-crew-select:disabled {
+        color: var(--fg-dim);
+        opacity: 0.7;
+        cursor: not-allowed;
+      }
+      .task-crew-select option {
+        color: var(--fg);
+        background: var(--bg);
+      }
+      .crew-error {
+        color: var(--state-failed);
+        font-family: var(--font-mono);
+        font-size: 10px;
+        line-height: 1.25;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
+
+      @media (max-width: 760px) {
+        .row {
+          grid-template-columns: minmax(84px, 0.7fr) minmax(0, 1fr) minmax(128px, 0.8fr);
+          grid-template-areas:
+            "id title crew"
+            "priority type crew";
+          gap: 4px 8px;
+        }
+        .row .id { grid-area: id; }
+        .row .title { grid-area: title; }
+        .row .priority { grid-area: priority; text-align: left; }
+        .row .type { grid-area: type; text-align: left; }
+        .row .crew-cell { grid-area: crew; align-self: stretch; }
+      }
+
+      @media (max-width: 520px) {
+        .row {
+          grid-template-columns: minmax(74px, 0.65fr) minmax(0, 1fr);
+          grid-template-areas:
+            "id title"
+            "priority crew"
+            "type crew";
+        }
+      }
       
       .row-detail {
         padding: 16px 20px;

--- a/crates/orbit-cli/src/command/web/api/crews.rs
+++ b/crates/orbit-cli/src/command/web/api/crews.rs
@@ -1,0 +1,11 @@
+//! Crew registry handlers.
+
+use std::sync::Arc;
+
+use axum::extract::State;
+use axum::response::{IntoResponse, Json, Response};
+use orbit_core::OrbitRuntime;
+
+pub(super) async fn list_crews(State(runtime): State<Arc<OrbitRuntime>>) -> Response {
+    Json(runtime.configured_crew_registry_projection()).into_response()
+}

--- a/crates/orbit-cli/src/command/web/api/mod.rs
+++ b/crates/orbit-cli/src/command/web/api/mod.rs
@@ -20,6 +20,7 @@ use url::Url;
 
 mod adrs;
 mod audit;
+mod crews;
 mod denials;
 mod diagnostics;
 mod frictions;
@@ -302,6 +303,7 @@ pub(super) fn router() -> Router<Arc<OrbitRuntime>> {
             "/tasks/:id",
             get(tasks::get_task).patch(tasks::update_task_action),
         )
+        .route("/crews", get(crews::list_crews))
         .route("/tasks/:id/artifacts/*path", get(tasks::get_task_artifact))
         .route("/tasks/:id/approve", post(tasks::approve_task_action))
         .route("/tasks/:id/reject", post(tasks::reject_task_action))
@@ -395,6 +397,50 @@ mod tests {
             .expect("response")
     }
 
+    async fn request_crews(runtime: OrbitRuntime) -> Response {
+        router()
+            .with_state(Arc::new(runtime))
+            .oneshot(
+                Request::builder()
+                    .method(Method::GET)
+                    .uri("/crews")
+                    .body(Body::empty())
+                    .expect("request"),
+            )
+            .await
+            .expect("response")
+    }
+
+    fn runtime_with_custom_crews() -> (tempfile::TempDir, OrbitRuntime) {
+        let root = tempfile::tempdir().expect("create tempdir");
+        let global_root = root.path().join("global");
+        let repo_root = root.path().join("repo");
+        let workspace_root = repo_root.join(".orbit");
+        std::fs::create_dir_all(&global_root).expect("create global root");
+        std::fs::create_dir_all(&workspace_root).expect("create workspace root");
+        std::fs::write(
+            workspace_root.join("config.toml"),
+            r#"
+[crews.silver]
+planner = { model = "claude-silver-plan", provider = "claude", backend = "cli" }
+implementer = { model = "codex-silver-impl", provider = "codex", backend = "cli" }
+reviewer = { model = "codex-silver-review", provider = "codex", backend = "cli" }
+
+[crews.alpha]
+planner = { model = "alpha-plan-model", provider = "claude", backend = "cli" }
+implementer = { model = "alpha-impl-model", provider = "codex", backend = "cli" }
+reviewer = { model = "alpha-review-model", provider = "codex", backend = "cli" }
+
+[workflow]
+default_crew = "silver"
+"#,
+        )
+        .expect("write config");
+        let runtime =
+            OrbitRuntime::from_roots(&global_root, &workspace_root).expect("build test runtime");
+        (root, runtime)
+    }
+
     fn seed_task(
         runtime: &OrbitRuntime,
         title: &str,
@@ -411,6 +457,29 @@ mod tests {
                 ..Default::default()
             })
             .expect("create task")
+    }
+
+    #[tokio::test]
+    async fn crews_endpoint_returns_sorted_runtime_registry() {
+        let (_root, runtime) = runtime_with_custom_crews();
+
+        let response = request_crews(runtime).await;
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = body_json(response).await;
+        assert_eq!(body["default_crew"], json!("silver"));
+        let crews = body["crews"].as_array().expect("crews array");
+        assert_eq!(crews.len(), 2);
+        assert_eq!(crews[0]["name"], json!("alpha"));
+        assert_eq!(crews[0]["is_default"], json!(false));
+        assert_eq!(crews[0]["planner_model"], json!("alpha-plan-model"));
+        assert_eq!(crews[0]["implementer_model"], json!("alpha-impl-model"));
+        assert_eq!(crews[0]["reviewer_model"], json!("alpha-review-model"));
+        assert_eq!(crews[1]["name"], json!("silver"));
+        assert_eq!(crews[1]["is_default"], json!(true));
+        assert_eq!(crews[1]["planner_model"], json!("claude-silver-plan"));
+        assert_eq!(crews[1]["implementer_model"], json!("codex-silver-impl"));
+        assert_eq!(crews[1]["reviewer_model"], json!("codex-silver-review"));
     }
 
     #[tokio::test]

--- a/crates/orbit-core/src/lib.rs
+++ b/crates/orbit-core/src/lib.rs
@@ -75,4 +75,6 @@ pub use orbit_store::{
     LearningCreateParams, LearningSearchParams, LearningSearchResult, LearningUpdateParams,
 };
 pub use runtime::OrbitRuntime;
-pub use runtime::engine::ResolvedCrewProjection;
+pub use runtime::engine::{
+    ConfiguredCrewProjection, ConfiguredCrewRegistryProjection, ResolvedCrewProjection,
+};

--- a/crates/orbit-core/src/runtime/engine/crew.rs
+++ b/crates/orbit-core/src/runtime/engine/crew.rs
@@ -1,7 +1,37 @@
 use orbit_common::types::{Crew, OrbitError, Task, resolve_crew};
+use serde::Serialize;
 use serde_json::Value;
 
 use crate::OrbitRuntime;
+
+/// Runtime crew registry projection for dashboard/API consumers.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct ConfiguredCrewRegistryProjection {
+    pub default_crew: Option<String>,
+    pub crews: Vec<ConfiguredCrewProjection>,
+}
+
+/// Named crew and role-model strings from the active runtime configuration.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct ConfiguredCrewProjection {
+    pub name: String,
+    pub planner_model: String,
+    pub implementer_model: String,
+    pub reviewer_model: String,
+    pub is_default: bool,
+}
+
+impl ConfiguredCrewProjection {
+    fn from_crew(crew: &Crew, is_default: bool) -> Self {
+        Self {
+            name: crew.name.clone(),
+            planner_model: crew.planner.model.clone(),
+            implementer_model: crew.implementer.model.clone(),
+            reviewer_model: crew.reviewer.model.clone(),
+            is_default,
+        }
+    }
+}
 
 /// Crew/role-model strings to surface on a task projection.
 ///
@@ -28,6 +58,26 @@ impl ResolvedCrewProjection {
 }
 
 impl OrbitRuntime {
+    pub fn configured_crew_registry_projection(&self) -> ConfiguredCrewRegistryProjection {
+        let default_crew = self.context.default_crew().map(ToString::to_string);
+        let mut crews = self
+            .context
+            .crews()
+            .values()
+            .map(|crew| {
+                ConfiguredCrewProjection::from_crew(
+                    crew,
+                    default_crew.as_deref() == Some(crew.name.as_str()),
+                )
+            })
+            .collect::<Vec<_>>();
+        crews.sort_by(|left, right| left.name.cmp(&right.name));
+        ConfiguredCrewRegistryProjection {
+            default_crew,
+            crews,
+        }
+    }
+
     pub fn validate_crew_name(&self, crew: Option<&str>) -> Result<(), OrbitError> {
         let Some(crew) = crew.map(str::trim).filter(|value| !value.is_empty()) else {
             return Ok(());

--- a/crates/orbit-core/src/runtime/engine/mod.rs
+++ b/crates/orbit-core/src/runtime/engine/mod.rs
@@ -10,4 +10,6 @@ mod runtime_host;
 mod summary;
 mod task_host;
 
-pub use crew::ResolvedCrewProjection;
+pub use crew::{
+    ConfiguredCrewProjection, ConfiguredCrewRegistryProjection, ResolvedCrewProjection,
+};


### PR DESCRIPTION
## Task

[ORB-00076](https://orbit-cli.com/tasks/ORB-00076) — Web dashboard — add per-task crew selector on Tasks tab

### Description

## Problem

The Tasks tab shows task status and metadata, and the dashboard API already supports patching a task's `crew`, but there is no UI control for assigning or clearing a task crew. Operators currently have to use the CLI/MCP task update path to move work between configured crews, which interrupts dashboard triage.

## Why It Matters

- Makes crew assignment a first-class dashboard workflow beside the existing status control.
- Reduces mistakes when dispatching tasks to named planner/implementer/reviewer lineups such as `silver`.
- Keeps task routing visible while scanning the backlog, instead of hiding the selected crew only in raw task JSON or CLI output.

## Scope

Backend + frontend for the vanilla JS dashboard.

### Backend

Add a read endpoint for configured crews so the browser does not hard-code workspace-local names from `.orbit/config.toml`:

- Register `GET /api/crews` in `crates/orbit-cli/src/command/web/api/mod.rs`.
- Return the current workspace crew registry and default crew from `OrbitRuntime` using a small projection, for example:
  ```json
  {
    "default_crew": "opus-codex",
    "crews": [
      { "name": "opus-codex", "planner_model": "...", "implementer_model": "...", "reviewer_model": "...", "is_default": true }
    ]
  }
  ```
- Sort crews by name for deterministic rendering.
- Do not read `.orbit/config.toml` directly from the web layer; use runtime/config APIs. If the required runtime accessor does not exist, add a narrow public projection method rather than exposing mutable config internals.

The existing `PATCH /api/tasks/:id` already accepts `crew`; use that surface for updates unless implementation discovers a concrete gap.

### Frontend

- Fetch crew options as part of the Tasks tab refresh path and cache the most recent payload.
- Add a crew `<select>` control for each rendered task row (or an equivalent per-task row action if the final layout requires a compact variant). The control must be visible without opening raw task JSON.
- The first option represents the workspace default, e.g. `default: opus-codex`; choosing it clears the explicit task crew by sending `PATCH /api/tasks/:id` with `{ "crew": null }`.
- Explicit crew options send `{ "crew": "<name>" }`.
- The selected value reflects `task.crew` when set; otherwise it shows the default/resolved crew state.
- The task row still toggles expansion when clicked, while clicking or changing the crew selector does not toggle the row.
- Surface update failures near the task row/detail and restore the previous selection.

## Constraints / Notes

- Crew names are workspace-local. Do not hard-code `silver`, `opus-codex`, or any other crew into dashboard JavaScript.
- Keep the control compact; the existing row grid is already dense, so adjust column widths/responsive CSS intentionally.
- Preserve the existing status selector behavior and refresh cadence; no new polling timer.
- No new persisted artifacts or migrations.

### Acceptance Criteria

- `GET /api/crews` returns `{ default_crew, crews }` from runtime configuration, with crews sorted by `name`; an API test seeds at least two crews and asserts the default flag/model fields are deterministic and not hard-coded.
- On the Tasks tab, every rendered task row exposes a crew selector whose options include a default-clearing option plus every configured crew from `/api/crews`; selecting `silver` or any other configured crew sends `PATCH /api/tasks/:id` with `{ "crew": "<name>" }`.
- Selecting the default option sends `PATCH /api/tasks/:id` with `{ "crew": null }`, and the refreshed task row shows the default/resolved crew state rather than a stale explicit crew.
- Clicking or keyboard-operating the crew selector does not expand/collapse the task row; normal row click-to-expand behavior and the existing status selector continue to work.
- If a crew update request fails, the selector returns to its previous value and an inline or task-scoped error message is visible without requiring the browser console.
- The task row layout remains readable at desktop width and at a narrow/mobile viewport: title text ellipsizes, selector text fits its control, and no row content overlaps.
- `make ci-fast` passes.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Added a runtime-backed configured crew registry projection and dashboard GET /api/crews route with sorted crew output and default flags.
- Added a Tasks-tab crew selector that fetches cached crew options, PATCHes explicit crew names or null for default, preserves row expand behavior, rolls back on failure, and shows inline row errors.
- Adjusted task row layout/CSS so the added selector remains compact while titles ellipsize across desktop and narrow viewports.
- Covered the new crew endpoint with a custom two-crew runtime API test.

Assessment: Targeted API coverage, dashboard JavaScript syntax validation, git diff whitespace check, and make ci-fast passed.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-00076-6a08f953`
- Behind base: 0
- Ahead of base: 1