### PR TITLE
Wire learning-creation into agent activities and orbit-execute-task checkpoint

### DIFF
--- a/crates/orbit-core/assets/activities/agent_implement.yaml
+++ b/crates/orbit-core/assets/activities/agent_implement.yaml
@@ -49,12 +49,19 @@ spec:
     6. Respect repository instructions for validation. If tests are forbidden,
        do not add or run them. Use the smallest allowed validation that gives
        real confidence.
-    7. Persist an execution summary when useful, but do not move the task to
+    7. Before handoff, run the learning checkpoint: if this task surfaced a
+       contradicted assumption, recurring failure mode, non-obvious gotcha that
+       took more than 10 minutes to debug, or incident-style root cause, follow
+       the `orbit-learning` skill and call the `add` action on
+       `orbit.learning` (or use that skill's update/supersede flow when it
+       points to existing guidance).
+       Skip if none apply.
+    8. Persist an execution summary when useful, but do not move the task to
        `review`; the pipeline does that only after commit/merge or PR steps
        succeed. This envelope rule overrides the direct-execution review
        transition described in the `orbit-execute-task` skill's Step 5 and Exit
        Criteria.
-    8. Return a short structured summary. Include a `diff` string only when you
+    9. Return a short structured summary. Include a `diff` string only when you
        can produce it cheaply and accurately.
   tools:
     - orbit.task.*
@@ -64,6 +71,9 @@ spec:
     - orbit.learning.search
     - orbit.learning.show
     - orbit.learning.list
+    - orbit.learning.add
+    - orbit.learning.update
+    - orbit.learning.supersede
     - fs.read
     - fs.delete
     - proc.spawn

--- a/crates/orbit-core/assets/activities/agent_review.yaml
+++ b/crates/orbit-core/assets/activities/agent_review.yaml
@@ -64,7 +64,14 @@ spec:
     6. If a fix cannot be applied (ambiguity, missing context, scope
        boundary), leave the thread `open` and move on. Open threads will
        surface to human reviewers via the existing PR review-thread sync.
-    7. Stop when no further blocking issues remain. Do not synthesize a
+    7. Before stopping, run the learning checkpoint: if this review surfaced a
+       contradicted assumption, recurring failure mode, non-obvious gotcha that
+       took more than 10 minutes to debug, or incident-style root cause, follow
+       the `orbit-learning` skill and call the `add` action on
+       `orbit.learning` (or use that skill's update/supersede flow when it
+       points to existing guidance).
+       Skip if none apply.
+    8. Stop when no further blocking issues remain. Do not synthesize a
        summary in the response — the review-thread records are the result.
   tools:
     - orbit.task.*
@@ -74,6 +81,9 @@ spec:
     - orbit.learning.search
     - orbit.learning.show
     - orbit.learning.list
+    - orbit.learning.add
+    - orbit.learning.update
+    - orbit.learning.supersede
     - fs.read
     - fs.delete
     - proc.spawn

--- a/crates/orbit-core/assets/skills/orbit-execute-task/SKILL.md
+++ b/crates/orbit-core/assets/skills/orbit-execute-task/SKILL.md
@@ -92,6 +92,13 @@ First persist the execution summary (see template below):
 orbit tool run orbit.task.update --input '{"id": "<task-id>", "execution_summary": "<summary>", "model": "<model_name>"}'
 ```
 
+Learning checkpoint: after persisting the summary, consider whether the task
+surfaced a contradicted assumption, recurring failure mode, non-obvious gotcha
+that took more than 10 minutes to debug, or incident-style root cause. If so,
+follow the `orbit-learning` skill and call `orbit.learning.add` (or use that
+skill's update/supersede flow when it points to existing guidance). Skip if
+none apply.
+
 Then choose the lifecycle handoff path:
 
 - **Under an activity envelope** (for example, `agent_implement`): persist the
@@ -157,6 +164,8 @@ Recommended follow-ups:
 - Requested change implemented and validated.
 - Task started via `orbit.task.start` before execution.
 - Execution summary persisted via `orbit.task.update`.
+- Learning checkpoint considered; if a load-bearing insight was identified,
+  `orbit.learning.add` was called per the `orbit-learning` skill.
 - For direct execution, task advanced to `review`.
 - For envelope-driven execution, task left for the pipeline-owned review
   transition after commit/merge or PR steps succeed.


### PR DESCRIPTION
## Task

[ORB-00077](https://orbit-cli.com/tasks/ORB-00077) — Wire learning-creation into agent activities and orbit-execute-task checkpoint

### Description

## Problem

Agents are not creating learnings even when work surfaces load-bearing insights. Two structural gaps:

1. **Tool surface forbids it.** [agent_implement.yaml](crates/orbit-core/assets/activities/agent_implement.yaml) and [agent_review.yaml](crates/orbit-core/assets/activities/agent_review.yaml) only list `orbit.learning.search`, `orbit.learning.show`, `orbit.learning.list` in `tools:`. With `on_denial: terminate`, any attempted `orbit.learning.add` from inside these activities kills the activity mid-task.
2. **No checkpoint anywhere.** Neither the agent activity `instruction:` blocks nor [orbit-execute-task/SKILL.md](crates/orbit-core/assets/skills/orbit-execute-task/SKILL.md) include a moment that prompts the agent to consider whether a learning should be written. Skill auto-discovery only fires on explicit trigger phrases, which agents don't speak mid-task.

## Why It Matters

[ORB-00009](.orbit/state/tasks/ORB-00009.yaml) delivers the *read/inject* side of the learnings pipeline (L1 engine pre-prompt, L2 MCP sidecar, L3 Claude hook). That value is bounded by what's in the corpus. If implementers and reviewers never write learnings, push-injection has nothing to push — the agents doing the real work are also the ones who'd produce the highest-signal learnings, but the system currently blocks them from doing so and never prompts them to try.

## Constraints / Notes

- **Two YAMLs to change** — only the two `role: implementer` / `role: reviewer` agent-loop activities: `agent_implement.yaml` and `agent_review.yaml`. Do NOT change `epic_orchestrator.yaml`, `dispatch_agent.yaml`, or `step_failure_recovery.yaml` — those are orchestration, not the workers producing learnings.
- **Tool allowlist edit** — append `orbit.learning.add`, `orbit.learning.update`, `orbit.learning.supersede` to each of the two YAMLs' `tools:` arrays. Keep existing read-side entries.
- **Instruction-block checkpoint** — add a numbered step to each YAML's `instruction:` block, placed before the existing handoff step (step 7 in `agent_implement`, step 7 in `agent_review`). The step must name three things: (a) the trigger conditions (recurring failure mode, contradicted assumption, non-obvious gotcha that took >N minutes to debug, incident-style root cause); (b) the action — call `orbit.learning.add` per the `orbit-learning` skill; (c) the explicit skip-by-default branch.
- **Skill checkpoint** — add the same three-element checkpoint to `orbit-execute-task/SKILL.md` Step 5 ("Summarize and hand off"), and add an "Learning checkpoint considered" entry to the Exit Criteria list. Place it after the execution-summary persistence step and before the review transition.
- **Quality bar** — the existing `orbit-learning` skill already documents what a good learning looks like (directive summary, tight scope, evidence). The new checkpoint copy must point at that skill rather than re-document the authoring rules.
- **Out of scope** — auto-extraction from review threads; any change to learning storage, prune, or supersede flow; changes to non-implementer/reviewer activities.

### Acceptance Criteria

- agent_implement.yaml and agent_review.yaml each list orbit.learning.add, orbit.learning.update, and orbit.learning.supersede in their tools: array (in addition to the existing search/show/list entries). Verified by: grep -E 'orbit.learning.(add|update|supersede)' crates/orbit-core/assets/activities/agent_implement.yaml crates/orbit-core/assets/activities/agent_review.yaml prints six lines (three per file).
- Each of agent_implement.yaml and agent_review.yaml has a new numbered step inserted into the instruction: block before the existing final handoff step. The step must explicitly name (a) trigger conditions including 'contradicted assumption', 'recurring failure', and 'non-obvious gotcha'; (b) the action verb 'orbit.learning.add' and a pointer to the orbit-learning skill; (c) an explicit 'skip if none apply' branch. Verified by reading the diff and confirming all three elements appear in each YAML.
- crates/orbit-core/assets/skills/orbit-execute-task/SKILL.md Step 5 contains a new checkpoint paragraph or subsection that names the same three elements (trigger conditions, action via orbit-learning, skip branch). The checkpoint is placed after the execution-summary persistence command and before the review-transition command.
- crates/orbit-core/assets/skills/orbit-execute-task/SKILL.md Exit Criteria list contains a new line item referencing the learning checkpoint (e.g., 'Learning checkpoint considered; if a load-bearing insight was identified, orbit.learning.add was called.').
- The skill checkpoint and YAML instruction-block additions point readers to the orbit-learning skill for authoring guidance; they do NOT re-document the directive-summary / scope / evidence rules already in orbit-learning/SKILL.md. Verified by inspection — diff must not duplicate text from orbit-learning/SKILL.md.
- make ci-fast passes after the changes (fmt-check + guardrails). Per CLAUDE.md, full make ci is not required locally for yaml/markdown-only changes.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Added orbit.learning.add, orbit.learning.update, and orbit.learning.supersede to agent_implement and agent_review tool allowlists.
- Inserted learning checkpoint steps in the implementer/reviewer activity instructions before their handoff/final steps.
- Added the learning checkpoint to orbit-execute-task Step 5 after execution-summary persistence, plus an Exit Criteria item.

Validation:
- grep -E 'orbit.learning.(add|update|supersede)' crates/orbit-core/assets/activities/agent_implement.yaml crates/orbit-core/assets/activities/agent_review.yaml printed six tool lines.
- git diff --check passed.
- make ci-fast passed.

Assessment: YAML/Markdown-only change is scoped to the requested activity and skill assets.

Learning checkpoint: considered; no durable new learning was added because no recurring failure, contradicted project assumption, non-obvious gotcha, or incident-style root cause applied.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-00077-6a08fc00`
- Behind base: 0
- Ahead of base: 1