### PR TITLE
Unify ship/ship-local/ship-auto into one async `orbit run ship` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Features
+
+- **Unified async shipment command**: `orbit run ship` now handles both auto backlog flushing and explicit task IDs, dispatching `task_auto_pipeline` asynchronously and returning a run ID immediately. `ship-auto` now points to the unified command, and `ship-local` is no longer a workflow alias. ([ORB-00075])
+
 ### Chores
 
 - **Branching model flipped**: `main` is now the release/production branch; `agent-main` is the dev integration branch where task PRs land. Each release tags on `agent-main` then promotes to `main` via merge commit; hotfixes branch from `main` and back-merge to `agent-main`. Install URLs in `README.md` and the website now point at `main`. Retired stub `crates/orbit-core/assets/activities/examples/promote_agent_main.yaml` removed. See `RELEASING.md` §10b and §Hotfix flow. ([ORB-00054])

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The constraints are the point — they're what keep agent-assisted code shippabl
 
 - **Knowledge-graph–aware tooling.** Agents query a parsed, content-addressed graph (symbols, imports, callers, implementors) instead of grep. Branch-scoped and safe for parallel rebuild; numbers in [`benchmarks/graph/`](benchmarks/graph/). → [docs/design/knowledge-graph/](docs/design/knowledge-graph/)
 
-- **Conflict-aware parallel execution.** For `orbit run ship-auto`, each agent run lands in its own git worktree per task, and the gate pipeline reserves task `context_files` as locks before fanning out, rejecting overlapping reservations up front instead of producing merge conflicts later (see [merge throughput chart](docs/assets/merge-throughput.png)). → [docs/design/activity-job/](docs/design/activity-job/)
+- **Conflict-aware parallel execution.** For `orbit run ship`, each agent run lands in its own git worktree per task, and the gate pipeline reserves task `context_files` as locks before fanning out, rejecting overlapping reservations up front instead of producing merge conflicts later (see [merge throughput chart](docs/assets/merge-throughput.png)). → [docs/design/activity-job/](docs/design/activity-job/)
 
 - **Sandboxed-by-default execution.** Dispatched agent CLIs run under an OS-level sandbox out of the box — FS access scoped to the worktree, network egress gated by per-activity policy. **macOS only today** (via `sandbox-exec`); on Linux/Windows the agent subprocess runs unsandboxed, with in-process FS guards still covering HTTP tools. → [docs/design/policy-sandbox](docs/design/policy-sandbox/)
 
@@ -74,7 +74,7 @@ Paste the prompt below into your agent (Claude Code, Codex CLI, or Gemini CLI) *
 
 Not recommended unless you're a contrarian or you're in a highly restricted environment where you can't clone things. This way is harder and less flexible - really makes little sense to choose this route. But if you must:
 
-**Prerequisites:** at least one supported agent CLI (Codex, Claude Code, or Gemini CLI), authenticated. For PR-based workflows (i.e., `orbit run ship-auto`), `gh` installed and authenticated; otherwise use `--mode local`.
+**Prerequisites:** at least one supported agent CLI (Codex, Claude Code, or Gemini CLI), authenticated. For PR-based workflows (i.e., `orbit run ship` in the default `--mode pr`), `gh` installed and authenticated; otherwise use `--mode local`.
 
 <details>
 <summary><strong>Manual setup commands</strong> — copy these into your terminal (click to expand)</summary>
@@ -107,7 +107,7 @@ orbit task approve "$TASK_ID"
 orbit web serve
 
 # conflict-aware, parallel flush of the backlog tasks to PRs
-orbit run ship-auto
+orbit run ship
 ```
 
 </details>
@@ -152,7 +152,7 @@ Two install surfaces. The CLI gives you the full power of Orbit. Choose the plug
 | MCP registration | Automatic | Manual: `orbit workspace init --mcp` per workspace |
 | Web dashboard (`orbit web serve`) | No | Yes |
 | Works with Codex / Gemini CLI | No (Claude Code only) | Yes |
-| workflows (i.e. `orbit run ship-auto`) | No | Yes |
+| workflows (i.e. `orbit run ship`) | No | Yes |
 
 </details>
 

--- a/crates/orbit-cli/src/audit_middleware.rs
+++ b/crates/orbit-cli/src/audit_middleware.rs
@@ -579,17 +579,11 @@ pub fn extract_command_meta(cmd: &Commands) -> CommandMeta {
 
 fn run_command_meta(cmd: &crate::command::run::RunCommand) -> CommandMeta {
     use crate::command::run::RunSubcommand;
-    use crate::command::run::ship::ShipMode;
 
     let (subcommand, target_type, target_id) = match &cmd.command {
-        RunSubcommand::Ship(command) => {
-            let target_id = match command.mode {
-                ShipMode::Pr => "ship",
-                ShipMode::Local => "ship-local",
-            };
-            ("ship", Some("workflow"), Some(target_id))
-        }
+        RunSubcommand::Ship(_) => ("ship", Some("workflow"), Some("ship")),
         RunSubcommand::ShipAuto(_) => ("ship-auto", Some("workflow"), Some("ship-auto")),
+        RunSubcommand::ShipLocal(_) => ("ship-local", Some("workflow"), Some("ship-local")),
         RunSubcommand::DuelPlan(args) => ("duel-plan", Some("task"), Some(args.task_id.as_str())),
         RunSubcommand::History(args) => ("history", Some("job_run"), args.job_id.as_deref()),
         RunSubcommand::Show(args) => ("show", Some("job_run"), args.run_id.as_deref()),
@@ -683,7 +677,7 @@ mod tests {
     }
 
     #[test]
-    fn run_ship_audit_meta_uses_selected_mode_alias() {
+    fn run_ship_audit_meta_uses_unified_workflow_alias() {
         let pr = meta_for(&["orbit", "run", "ship", "T1"]);
         assert_eq!(pr.command, "run");
         assert_eq!(pr.subcommand.as_deref(), Some("ship"));
@@ -693,16 +687,25 @@ mod tests {
         let local = meta_for(&["orbit", "run", "ship", "-m", "local", "T1"]);
         assert_eq!(local.subcommand.as_deref(), Some("ship"));
         assert_eq!(local.target_type.as_deref(), Some("workflow"));
-        assert_eq!(local.target_id.as_deref(), Some("ship-local"));
+        assert_eq!(local.target_id.as_deref(), Some("ship"));
     }
 
     #[test]
-    fn run_ship_auto_audit_meta_uses_new_top_level_command() {
+    fn run_ship_auto_audit_meta_uses_deprecated_top_level_command() {
         let meta = meta_for(&["orbit", "run", "ship-auto"]);
         assert_eq!(meta.command, "run");
         assert_eq!(meta.subcommand.as_deref(), Some("ship-auto"));
         assert_eq!(meta.target_type.as_deref(), Some("workflow"));
         assert_eq!(meta.target_id.as_deref(), Some("ship-auto"));
+    }
+
+    #[test]
+    fn run_ship_local_audit_meta_uses_deprecated_top_level_command() {
+        let meta = meta_for(&["orbit", "run", "ship-local", "T1"]);
+        assert_eq!(meta.command, "run");
+        assert_eq!(meta.subcommand.as_deref(), Some("ship-local"));
+        assert_eq!(meta.target_type.as_deref(), Some("workflow"));
+        assert_eq!(meta.target_id.as_deref(), Some("ship-local"));
     }
 
     #[test]

--- a/crates/orbit-cli/src/command/mod.rs
+++ b/crates/orbit-cli/src/command/mod.rs
@@ -46,7 +46,7 @@ Environment:
   config      Show or update Orbit configuration
 
 Operate:
-  run         Run a workflow (ship, ship-auto, duel-plan, job)
+  run         Run a workflow (ship, duel-plan, job)
   task        Create, update, and manage tasks
   adr         Architecture Decision Record operations
   design      Design doc operations

--- a/crates/orbit-cli/src/command/run/duel.rs
+++ b/crates/orbit-cli/src/command/run/duel.rs
@@ -31,7 +31,7 @@ pub struct DuelPlanCommand {
 impl Execute for DuelPlanCommand {
     fn execute(self, runtime: &OrbitRuntime) -> Result<(), OrbitError> {
         let plan = build_duel_plan_run_plan(&self, runtime.workflow_base_branch())?;
-        let runs = dispatch_workflow(runtime, plan.workflow_alias, &plan.input, false, 1)?;
+        let runs = dispatch_workflow(runtime, plan.workflow_alias, &plan.input, false, true, 1)?;
         print_workflow_dispatch_results(plan.workflow_alias, &runs, self.json)
     }
 }

--- a/crates/orbit-cli/src/command/run/mod.rs
+++ b/crates/orbit-cli/src/command/run/mod.rs
@@ -27,8 +27,7 @@ use crate::command::Execute;
 
 const RUN_AFTER_HELP: &str = "\
 Workflow entrypoints:
-  orbit run ship <task_id> ...
-  orbit run ship-auto
+  orbit run ship [task_id ...]
   orbit run duel-plan <task_id>
   orbit run job <job_id> [--input key=value] [--json] [--debug]
 
@@ -43,7 +42,7 @@ Run history:
 
 #[derive(Args)]
 #[command(
-    about = "Run a job workflow (supports run ship / ship-auto / duel-plan / job)",
+    about = "Run a job workflow (supports run ship / duel-plan / job)",
     arg_required_else_help = true,
     subcommand_required = true,
     override_usage = "orbit run <COMMAND>",
@@ -54,8 +53,7 @@ Run history:
 {usage-heading} {usage}
 
 Workflows:
-  ship       Ship explicitly selected tasks through the task pipeline
-  ship-auto  Auto-select backlog tasks and ship them through the task pipeline
+  ship       Ship backlog or explicitly selected tasks through the gated task pipeline
   duel-plan  Run a planning duel for one task
   job        Run an arbitrary job by ID
 
@@ -83,11 +81,14 @@ impl Execute for RunCommand {
 
 #[derive(Subcommand)]
 pub enum RunSubcommand {
-    /// Ship explicitly selected tasks through the task pipeline
+    /// Ship backlog or explicitly selected tasks through the gated task pipeline
     Ship(ship::ShipCommand),
-    /// Auto-select backlog tasks and ship them through the task pipeline
-    #[command(name = "ship-auto")]
-    ShipAuto(ship::ShipAutoCommand),
+    /// Deprecated alias for `orbit run ship`
+    #[command(name = "ship-auto", hide = true)]
+    ShipAuto(ship::LegacyShipAutoCommand),
+    /// Deprecated alias for `orbit run ship --mode local`
+    #[command(name = "ship-local", hide = true)]
+    ShipLocal(ship::LegacyShipLocalCommand),
     /// Run a planning duel for one task
     #[command(name = "duel-plan")]
     DuelPlan(duel::DuelPlanCommand),
@@ -110,6 +111,7 @@ impl Execute for RunSubcommand {
         match self {
             RunSubcommand::Ship(command) => command.execute(runtime),
             RunSubcommand::ShipAuto(command) => command.execute(runtime),
+            RunSubcommand::ShipLocal(command) => command.execute(runtime),
             RunSubcommand::DuelPlan(command) => command.execute(runtime),
             RunSubcommand::History(command) => command.execute(runtime),
             RunSubcommand::Show(command) => command.execute(runtime),
@@ -141,6 +143,19 @@ mod tests {
     }
 
     #[test]
+    fn parses_ship_auto_mode_defaults() {
+        let command = parse_run(&["orbit", "run", "ship"]);
+        match command.command {
+            RunSubcommand::Ship(args) => {
+                assert!(args.task_ids.is_empty());
+                assert_eq!(args.mode, ship::ShipMode::Pr);
+                assert_eq!(args.base, None);
+            }
+            _ => panic!("expected ship"),
+        }
+    }
+
+    #[test]
     fn parses_explicit_ship_defaults() {
         let command = parse_run(&["orbit", "run", "ship", "T1", "T2"]);
         match command.command {
@@ -167,7 +182,7 @@ mod tests {
     }
 
     #[test]
-    fn parses_ship_auto_as_top_level_subcommand() {
+    fn parses_ship_auto_as_deprecated_top_level_subcommand() {
         let command = parse_run(&["orbit", "run", "ship-auto", "-m", "pr", "-b", "main"]);
         match command.command {
             RunSubcommand::ShipAuto(args) => {
@@ -175,6 +190,18 @@ mod tests {
                 assert_eq!(args.base.as_deref(), Some("main"));
             }
             _ => panic!("expected ship-auto"),
+        }
+    }
+
+    #[test]
+    fn parses_ship_local_as_deprecated_top_level_subcommand() {
+        let command = parse_run(&["orbit", "run", "ship-local", "-b", "main", "T1"]);
+        match command.command {
+            RunSubcommand::ShipLocal(args) => {
+                assert_eq!(args.task_ids, vec!["T1"]);
+                assert_eq!(args.base.as_deref(), Some("main"));
+            }
+            _ => panic!("expected ship-local"),
         }
     }
 

--- a/crates/orbit-cli/src/command/run/ship.rs
+++ b/crates/orbit-cli/src/command/run/ship.rs
@@ -1,4 +1,4 @@
-//! `orbit run ship` and `orbit run ship-auto` CLI entrypoints.
+//! `orbit run ship` CLI entrypoint.
 
 use std::collections::HashSet;
 
@@ -10,9 +10,7 @@ use crate::command::Execute;
 
 use super::support::{dispatch_workflow, print_workflow_dispatch_results};
 
-const SHIP_PR_WORKFLOW: &str = "ship";
-const SHIP_LOCAL_WORKFLOW: &str = "ship-local";
-const SHIP_AUTO_WORKFLOW: &str = "ship-auto";
+const SHIP_WORKFLOW: &str = "ship";
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, ValueEnum)]
 pub enum ShipMode {
@@ -27,29 +25,22 @@ impl ShipMode {
             ShipMode::Local => "local",
         }
     }
-
-    fn explicit_workflow_alias(self) -> &'static str {
-        match self {
-            ShipMode::Pr => SHIP_PR_WORKFLOW,
-            ShipMode::Local => SHIP_LOCAL_WORKFLOW,
-        }
-    }
 }
 
 #[derive(Args)]
 #[command(
-    about = "Ship explicitly selected tasks through the task pipeline",
-    override_usage = "orbit run ship <TASK_ID> [<TASK_ID>...] [OPTIONS]",
-    after_help = "Examples:\n  orbit run ship T123\n  orbit run ship T123 T456 --mode local\n  orbit run ship T123 --base main\n\nRun history moved to `orbit run history -j <JOB_ID>`."
+    about = "Ship backlog or explicitly selected tasks through the gated task pipeline",
+    override_usage = "orbit run ship [<TASK_ID>...] [OPTIONS]",
+    after_help = "Examples:\n  orbit run ship\n  orbit run ship T123\n  orbit run ship T123 T456 --mode local\n  orbit run ship T123 --base main\n\nInspect submitted runs with `orbit run history -j task_auto_pipeline` and `orbit run show <RUN_ID>`."
 )]
 pub struct ShipCommand {
-    /// Task IDs to process as one explicit task bundle.
+    /// Optional task IDs to seed explicit gated shipment. Omit for auto mode.
     #[arg(value_name = "TASK_ID", num_args = 0..)]
     pub task_ids: Vec<String>,
-    /// Pipeline mode for the selected task bundle.
+    /// Pipeline mode for selected or auto-discovered task bundles.
     #[arg(short = 'm', long, value_enum, default_value = "pr")]
     pub mode: ShipMode,
-    /// Base branch for the selected pipeline. Defaults to
+    /// Base branch for shipment. Defaults to
     /// `[workflow] base_branch` from `config.toml` (or `main` if unset).
     #[arg(short = 'b', long)]
     pub base: Option<String>,
@@ -61,35 +52,62 @@ pub struct ShipCommand {
 impl Execute for ShipCommand {
     fn execute(self, runtime: &OrbitRuntime) -> Result<(), OrbitError> {
         let plan = build_ship_run_plan(&self, runtime.workflow_base_branch())?;
-        let runs = dispatch_workflow(runtime, plan.workflow_alias, &plan.input, false, 1)?;
+        let runs = dispatch_workflow(runtime, plan.workflow_alias, &plan.input, false, false, 1)?;
         print_workflow_dispatch_results(plan.workflow_alias, &runs, self.json)
     }
 }
 
 #[derive(Args)]
 #[command(
-    about = "Auto-select backlog tasks and ship them through the task pipeline",
+    about = "Deprecated alias for `orbit run ship`",
     override_usage = "orbit run ship-auto [OPTIONS]",
-    after_help = "Examples:\n  orbit run ship-auto\n  orbit run ship-auto --mode local\n  orbit run ship-auto --base main\n\nOutput status labels: empty_backlog, gated_noop, gate_waiting, gate_failed, completed. Gated/no-op statuses keep exit code 0 and are reported explicitly in text and JSON output.\n\nRun history moved to `orbit run history -j task_auto_pipeline`."
+    after_help = "`orbit run ship-auto` was replaced by `orbit run ship`. Omit task ids for auto mode."
 )]
-pub struct ShipAutoCommand {
-    /// Pipeline mode for auto-selected task bundles.
+pub struct LegacyShipAutoCommand {
+    /// Deprecated. Use `orbit run ship --mode <MODE>`.
     #[arg(short = 'm', long, value_enum, default_value = "pr")]
     pub mode: ShipMode,
-    /// Base branch for auto-selected task bundles. Defaults to
-    /// `[workflow] base_branch` from `config.toml` (or `main` if unset).
+    /// Deprecated. Use `orbit run ship --base <BRANCH>`.
     #[arg(short = 'b', long)]
     pub base: Option<String>,
-    /// Output as JSON.
+    /// Deprecated.
     #[arg(long)]
     pub json: bool,
 }
 
-impl Execute for ShipAutoCommand {
-    fn execute(self, runtime: &OrbitRuntime) -> Result<(), OrbitError> {
-        let plan = build_ship_auto_run_plan(&self, runtime.workflow_base_branch())?;
-        let runs = dispatch_workflow(runtime, plan.workflow_alias, &plan.input, false, 1)?;
-        print_workflow_dispatch_results(plan.workflow_alias, &runs, self.json)
+impl Execute for LegacyShipAutoCommand {
+    fn execute(self, _runtime: &OrbitRuntime) -> Result<(), OrbitError> {
+        let _ = self;
+        Err(OrbitError::InvalidInput(
+            "`orbit run ship-auto` was replaced by `orbit run ship` (auto mode runs when no task ids are supplied)".to_string(),
+        ))
+    }
+}
+
+#[derive(Args)]
+#[command(
+    about = "Deprecated alias for `orbit run ship --mode local`",
+    override_usage = "orbit run ship-local [<TASK_ID>...] [OPTIONS]",
+    after_help = "`orbit run ship-local` was replaced by `orbit run ship --mode local`."
+)]
+pub struct LegacyShipLocalCommand {
+    /// Deprecated. Pass task IDs to `orbit run ship --mode local`.
+    #[arg(value_name = "TASK_ID", num_args = 0..)]
+    pub task_ids: Vec<String>,
+    /// Deprecated. Use `orbit run ship --mode local --base <BRANCH>`.
+    #[arg(short = 'b', long)]
+    pub base: Option<String>,
+    /// Deprecated.
+    #[arg(long)]
+    pub json: bool,
+}
+
+impl Execute for LegacyShipLocalCommand {
+    fn execute(self, _runtime: &OrbitRuntime) -> Result<(), OrbitError> {
+        let _ = self;
+        Err(OrbitError::InvalidInput(
+            "`orbit run ship-local` was replaced by `orbit run ship --mode local`".to_string(),
+        ))
     }
 }
 
@@ -103,36 +121,24 @@ pub(crate) fn build_ship_run_plan(
     args: &ShipCommand,
     config_base_branch: &str,
 ) -> Result<WorkflowRunPlan, OrbitError> {
-    validate_explicit_task_selection(&args.task_ids)?;
-    let workflow_alias = args.mode.explicit_workflow_alias();
+    validate_task_selection(&args.task_ids)?;
+    let workflow_alias = SHIP_WORKFLOW;
     ensure_workflow_exists(workflow_alias)?;
     let base = args.base.as_deref().unwrap_or(config_base_branch);
     Ok(WorkflowRunPlan {
         workflow_alias,
-        input: ship_input(args.mode, base, Some(&args.task_ids)),
+        input: ship_input(args.mode, base, &args.task_ids),
     })
 }
 
-pub(crate) fn build_ship_auto_run_plan(
-    args: &ShipAutoCommand,
-    config_base_branch: &str,
-) -> Result<WorkflowRunPlan, OrbitError> {
-    ensure_workflow_exists(SHIP_AUTO_WORKFLOW)?;
-    let base = args.base.as_deref().unwrap_or(config_base_branch);
-    Ok(WorkflowRunPlan {
-        workflow_alias: SHIP_AUTO_WORKFLOW,
-        input: ship_input(args.mode, base, None),
-    })
-}
-
-fn ship_input(mode: ShipMode, base: &str, task_ids: Option<&[String]>) -> Value {
+fn ship_input(mode: ShipMode, base: &str, task_ids: &[String]) -> Value {
     let mut map = serde_json::Map::new();
     map.insert(
         "mode".to_string(),
         Value::String(mode.as_input_value().to_string()),
     );
     map.insert("base_branch".to_string(), Value::String(base.to_string()));
-    if let Some(task_ids) = task_ids {
+    if !task_ids.is_empty() {
         map.insert(
             "task_ids".to_string(),
             Value::Array(task_ids.iter().cloned().map(Value::String).collect()),
@@ -141,13 +147,7 @@ fn ship_input(mode: ShipMode, base: &str, task_ids: Option<&[String]>) -> Value 
     Value::Object(map)
 }
 
-fn validate_explicit_task_selection(task_ids: &[String]) -> Result<(), OrbitError> {
-    if task_ids.is_empty() {
-        return Err(OrbitError::InvalidInput(
-            "`orbit run ship` requires at least one task ID; use `orbit run ship-auto` to auto-select backlog tasks".to_string(),
-        ));
-    }
-
+fn validate_task_selection(task_ids: &[String]) -> Result<(), OrbitError> {
     if let Some(legacy) = task_ids.first().and_then(|value| legacy_ship_form(value)) {
         return Err(OrbitError::InvalidInput(legacy.to_string()));
     }
@@ -170,6 +170,9 @@ fn legacy_ship_form(value: &str) -> Option<&'static str> {
             Some("`orbit run ship local` was replaced by `orbit run ship --mode local <TASK_ID>`")
         }
         "pr" => Some("`orbit run ship pr` was replaced by `orbit run ship --mode pr <TASK_ID>`"),
+        "auto" | "ship-auto" => Some(
+            "`orbit run ship auto` was replaced by `orbit run ship` (auto mode runs when no task ids are supplied)",
+        ),
         "list" | "show" => Some(
             "`orbit run ship list/show` was removed; use `orbit run history -j <JOB_ID>` and `orbit run show <RUN_ID>` for run inspection",
         ),
@@ -189,7 +192,7 @@ mod tests {
 
     use super::*;
 
-    fn explicit_args(task_ids: &[&str], mode: ShipMode, base: Option<&str>) -> ShipCommand {
+    fn ship_args(task_ids: &[&str], mode: ShipMode, base: Option<&str>) -> ShipCommand {
         ShipCommand {
             task_ids: task_ids.iter().map(|value| value.to_string()).collect(),
             mode,
@@ -198,23 +201,46 @@ mod tests {
         }
     }
 
-    fn auto_args(mode: ShipMode, base: Option<&str>) -> ShipAutoCommand {
-        ShipAutoCommand {
-            mode,
-            base: base.map(str::to_string),
-            json: false,
-        }
+    #[test]
+    fn ship_auto_mode_omits_task_ids_and_uses_pr_mode_by_default() {
+        let plan = build_ship_run_plan(&ship_args(&[], ShipMode::Pr, None), "agent-main")
+            .expect("build plan");
+
+        assert_eq!(plan.workflow_alias, SHIP_WORKFLOW);
+        assert_eq!(
+            plan.input,
+            json!({
+                "mode": "pr",
+                "base_branch": "agent-main",
+            })
+        );
     }
 
     #[test]
-    fn explicit_ship_falls_back_to_config_base_when_flag_absent() {
+    fn ship_auto_mode_preserves_local_mode_and_base_override() {
+        let plan =
+            build_ship_run_plan(&ship_args(&[], ShipMode::Local, Some("main")), "agent-main")
+                .expect("build plan");
+
+        assert_eq!(plan.workflow_alias, SHIP_WORKFLOW);
+        assert_eq!(
+            plan.input,
+            json!({
+                "mode": "local",
+                "base_branch": "main",
+            })
+        );
+    }
+
+    #[test]
+    fn explicit_ship_uses_unified_gated_workflow_with_pr_mode() {
         let plan = build_ship_run_plan(
-            &explicit_args(&["T20260425-2010", "T20260425-2011"], ShipMode::Pr, None),
+            &ship_args(&["T20260425-2010", "T20260425-2011"], ShipMode::Pr, None),
             "agent-main",
         )
         .expect("build plan");
 
-        assert_eq!(plan.workflow_alias, SHIP_PR_WORKFLOW);
+        assert_eq!(plan.workflow_alias, SHIP_WORKFLOW);
         assert_eq!(
             plan.input,
             json!({
@@ -226,14 +252,14 @@ mod tests {
     }
 
     #[test]
-    fn explicit_ship_flag_overrides_config_base() {
+    fn explicit_ship_preserves_local_mode_and_base_override() {
         let plan = build_ship_run_plan(
-            &explicit_args(&["T20260425-2010"], ShipMode::Local, Some("main")),
+            &ship_args(&["T20260425-2010"], ShipMode::Local, Some("main")),
             "agent-main",
         )
         .expect("build plan");
 
-        assert_eq!(plan.workflow_alias, SHIP_LOCAL_WORKFLOW);
+        assert_eq!(plan.workflow_alias, SHIP_WORKFLOW);
         assert_eq!(
             plan.input,
             json!({
@@ -245,30 +271,47 @@ mod tests {
     }
 
     #[test]
-    fn ship_auto_uses_auto_job_without_explicit_task_ids() {
-        let plan = build_ship_auto_run_plan(&auto_args(ShipMode::Pr, None), "agent-main")
-            .expect("build plan");
+    fn ship_auto_deprecation_returns_legacy_error() {
+        let runtime = OrbitRuntime::in_memory().expect("build runtime");
+        let err = LegacyShipAutoCommand {
+            mode: ShipMode::Pr,
+            base: None,
+            json: false,
+        }
+        .execute(&runtime)
+        .expect_err("deprecated command should fail");
+        assert!(
+            err.to_string().contains("orbit run ship"),
+            "unexpected error: {err}"
+        );
+    }
 
-        assert_eq!(plan.workflow_alias, SHIP_AUTO_WORKFLOW);
-        assert_eq!(
-            plan.input,
-            json!({
-                "mode": "pr",
-                "base_branch": "agent-main",
-            })
+    #[test]
+    fn ship_local_deprecation_returns_legacy_error() {
+        let runtime = OrbitRuntime::in_memory().expect("build runtime");
+        let err = LegacyShipLocalCommand {
+            task_ids: vec!["T20260425-2010".to_string()],
+            base: None,
+            json: false,
+        }
+        .execute(&runtime)
+        .expect_err("deprecated command should fail");
+        assert!(
+            err.to_string().contains("orbit run ship --mode local"),
+            "unexpected error: {err}"
         );
     }
 
     #[test]
     fn ship_rejects_removed_history_forms() {
-        let err = build_ship_run_plan(&explicit_args(&["list"], ShipMode::Pr, None), "agent-main")
+        let err = build_ship_run_plan(&ship_args(&["list"], ShipMode::Pr, None), "agent-main")
             .expect_err("legacy history form should fail");
         assert!(
             err.to_string().contains("orbit run history"),
             "unexpected error: {err}"
         );
 
-        let err = build_ship_run_plan(&explicit_args(&["show"], ShipMode::Pr, None), "agent-main")
+        let err = build_ship_run_plan(&ship_args(&["show"], ShipMode::Pr, None), "agent-main")
             .expect_err("legacy history form should fail");
         assert!(
             err.to_string().contains("orbit run history"),
@@ -278,7 +321,7 @@ mod tests {
 
     #[test]
     fn ship_rejects_removed_local_subcommand_form() {
-        let err = build_ship_run_plan(&explicit_args(&["local"], ShipMode::Pr, None), "agent-main")
+        let err = build_ship_run_plan(&ship_args(&["local"], ShipMode::Pr, None), "agent-main")
             .expect_err("legacy local form should fail");
         assert!(
             err.to_string().contains("--mode local"),
@@ -287,11 +330,11 @@ mod tests {
     }
 
     #[test]
-    fn ship_requires_explicit_task_ids() {
-        let err = build_ship_run_plan(&explicit_args(&[], ShipMode::Pr, None), "agent-main")
-            .expect_err("missing explicit task IDs should fail");
+    fn ship_rejects_removed_auto_positional_form() {
+        let err = build_ship_run_plan(&ship_args(&["auto"], ShipMode::Pr, None), "agent-main")
+            .expect_err("legacy auto form should fail");
         assert!(
-            err.to_string().contains("ship-auto"),
+            err.to_string().contains("orbit run ship"),
             "unexpected error: {err}"
         );
     }
@@ -299,7 +342,7 @@ mod tests {
     #[test]
     fn ship_rejects_duplicate_task_ids() {
         let err = build_ship_run_plan(
-            &explicit_args(&["T20260425-2010", "T20260425-2010"], ShipMode::Pr, None),
+            &ship_args(&["T20260425-2010", "T20260425-2010"], ShipMode::Pr, None),
             "agent-main",
         )
         .expect_err("duplicate task IDs should fail");

--- a/crates/orbit-cli/src/command/run/support.rs
+++ b/crates/orbit-cli/src/command/run/support.rs
@@ -4,7 +4,7 @@ use std::fmt::Write as _;
 use orbit_core::{JobRun, JobRunState, JobRunStep, OrbitError, OrbitRuntime, find_workflow};
 use serde_json::{Value, json};
 
-const SHIP_AUTO_WORKFLOW: &str = "ship-auto";
+const TASK_AUTO_PIPELINE_JOB: &str = "task_auto_pipeline";
 
 #[derive(Clone)]
 pub(crate) struct WorkflowDispatchResult {
@@ -87,6 +87,7 @@ pub(crate) fn dispatch_workflow(
     workflow_alias: &'static str,
     input: &Value,
     debug: bool,
+    wait_for_completion: bool,
     loop_count: u32,
 ) -> Result<Vec<WorkflowDispatchResult>, OrbitError> {
     let workflow = find_workflow(workflow_alias)
@@ -97,12 +98,26 @@ pub(crate) fn dispatch_workflow(
         ));
     }
 
-    let timeout_seconds = OrbitRuntime::normalize_pipeline_wait_timeout(None)?;
-    let poll_interval_seconds = OrbitRuntime::normalize_pipeline_wait_poll_interval(None);
-
     let mut results = Vec::with_capacity(loop_count as usize);
     for _ in 0..loop_count {
         let invoke = runtime.submit_pipeline_run(workflow.job_id, input.clone(), None, None)?;
+        if !wait_for_completion {
+            let state = if invoke.queued { "queued" } else { "submitted" };
+            results.push(WorkflowDispatchResult {
+                workflow_alias,
+                job_id: invoke.job_name,
+                run_id: invoke.run_id,
+                state: state.to_string(),
+                attempt: 1,
+                error_code: None,
+                error_message: None,
+                ship_auto: None,
+            });
+            continue;
+        }
+
+        let timeout_seconds = OrbitRuntime::normalize_pipeline_wait_timeout(None)?;
+        let poll_interval_seconds = OrbitRuntime::normalize_pipeline_wait_poll_interval(None);
         let wait = runtime.wait_pipeline_runs(
             std::slice::from_ref(&invoke.run_id),
             timeout_seconds,
@@ -128,7 +143,7 @@ pub(crate) fn dispatch_workflow(
                     .flatten()
                     .map(|state| state.pipeline)
             });
-        let ship_auto = if workflow_alias == SHIP_AUTO_WORKFLOW {
+        let ship_auto = if workflow.job_id == TASK_AUTO_PIPELINE_JOB {
             Some(derive_ship_auto_summary(runtime, pipeline.as_ref()))
         } else {
             None
@@ -248,6 +263,22 @@ fn workflow_dispatch_result_to_json(run: &WorkflowDispatchResult) -> Value {
 fn workflow_dispatch_result_lines(run: &WorkflowDispatchResult) -> Vec<String> {
     if let Some(summary) = &run.ship_auto {
         return ship_auto_dispatch_result_lines(run, summary);
+    }
+
+    if matches!(run.state.as_str(), "submitted" | "queued")
+        && run.error_code.is_none()
+        && run.error_message.is_none()
+    {
+        return vec![
+            format!("Workflow: {}", run.workflow_alias),
+            format!("Job ID: {}", run.job_id),
+            format!("Run ID: {}", run.run_id),
+            format!("State: {}", run.state),
+            format!(
+                "Inspect: orbit run history -j {} | orbit run show {}",
+                run.job_id, run.run_id
+            ),
+        ];
     }
 
     let error_code = run.error_code.clone().unwrap_or_else(|| "-".to_string());
@@ -647,12 +678,65 @@ impl ShipAutoConflict {
 
 #[cfg(test)]
 mod tests {
+    use std::time::{Duration, Instant};
+
     use super::*;
+
+    const SHIP_WORKFLOW: &str = "ship";
+
+    #[test]
+    fn async_ship_dispatch_returns_run_identity_without_waiting() {
+        let runtime = OrbitRuntime::in_memory().expect("build runtime");
+        let jobs_dir = runtime.data_root().join("resources/jobs");
+        std::fs::create_dir_all(&jobs_dir).expect("create jobs dir");
+        std::fs::write(
+            jobs_dir.join("task_auto_pipeline.yaml"),
+            r#"schemaVersion: 2
+kind: Job
+metadata:
+  name: task_auto_pipeline
+spec:
+  state: enabled
+  kind: workflow
+  steps:
+    - id: marker
+      spec:
+        type: deterministic
+        action: sleep
+        config:
+          seconds: 0
+"#,
+        )
+        .expect("write task_auto_pipeline fixture");
+        let started = Instant::now();
+        let runs = dispatch_workflow(
+            &runtime,
+            SHIP_WORKFLOW,
+            &json!({
+                "mode": "pr",
+                "base_branch": "main",
+            }),
+            false,
+            false,
+            1,
+        )
+        .expect("dispatch workflow");
+
+        assert!(
+            started.elapsed() < Duration::from_secs(1),
+            "dispatch waited too long"
+        );
+        assert_eq!(runs.len(), 1);
+        assert_eq!(runs[0].workflow_alias, SHIP_WORKFLOW);
+        assert_eq!(runs[0].job_id, TASK_AUTO_PIPELINE_JOB);
+        assert!(matches!(runs[0].state.as_str(), "submitted" | "queued"));
+        assert!(runs[0].ship_auto.is_none());
+    }
 
     fn ship_auto_run(summary: ShipAutoDispatchSummary) -> WorkflowDispatchResult {
         WorkflowDispatchResult {
-            workflow_alias: SHIP_AUTO_WORKFLOW,
-            job_id: "task_auto_pipeline".to_string(),
+            workflow_alias: SHIP_WORKFLOW,
+            job_id: TASK_AUTO_PIPELINE_JOB.to_string(),
             run_id: "jrun-parent".to_string(),
             state: "succeeded".to_string(),
             attempt: 1,
@@ -678,11 +762,44 @@ mod tests {
         ] {
             assert!(value.get(key).is_some(), "missing json key {key}");
         }
-        assert_eq!(value["workflow"], json!("ship-auto"));
+        assert_eq!(value["workflow"], json!("ship"));
         assert_eq!(value["job_id"], json!("task_auto_pipeline"));
         assert_eq!(value["run_id"], json!("jrun-parent"));
         assert_eq!(value["state"], json!("succeeded"));
         assert_eq!(value["attempt"], json!(1));
+    }
+
+    #[test]
+    fn async_dispatch_lines_point_to_history_and_show() {
+        let run = WorkflowDispatchResult {
+            workflow_alias: SHIP_WORKFLOW,
+            job_id: TASK_AUTO_PIPELINE_JOB.to_string(),
+            run_id: "jrun-submitted".to_string(),
+            state: "submitted".to_string(),
+            attempt: 1,
+            error_code: None,
+            error_message: None,
+            ship_auto: None,
+        };
+
+        assert_eq!(
+            workflow_dispatch_result_lines(&run),
+            vec![
+                "Workflow: ship",
+                "Job ID: task_auto_pipeline",
+                "Run ID: jrun-submitted",
+                "State: submitted",
+                "Inspect: orbit run history -j task_auto_pipeline | orbit run show jrun-submitted",
+            ]
+        );
+
+        let value = workflow_dispatch_result_to_json(&run);
+        assert_eq!(value["workflow"], json!("ship"));
+        assert_eq!(value["job_id"], json!("task_auto_pipeline"));
+        assert_eq!(value["state"], json!("submitted"));
+        assert_eq!(value["error_code"], Value::Null);
+        assert_eq!(value["error_message"], Value::Null);
+        assert!(value.get("ship_auto").is_none());
     }
 
     #[test]
@@ -715,7 +832,7 @@ mod tests {
         assert_eq!(
             lines,
             vec![
-                "Workflow: ship-auto",
+                "Workflow: ship",
                 "Job ID: task_auto_pipeline",
                 "Run ID: jrun-parent",
                 "Parent state: succeeded",

--- a/crates/orbit-core/assets/config/default-config.toml
+++ b/crates/orbit-core/assets/config/default-config.toml
@@ -27,7 +27,7 @@ enabled = true
 editing = false
 
 [workflow]
-# Default base branch for `orbit run ship`, `ship-auto`, and `duel-plan`.
+# Default base branch for `orbit run ship` and `duel-plan`.
 # Override per-invocation with `--base <branch>`. The Orbit repo itself uses
 # this two-branch pattern: `main` is the release/production branch, and
 # `agent-main` is the dev integration branch where task PRs land — set

--- a/crates/orbit-core/src/command/workflow.rs
+++ b/crates/orbit-core/src/command/workflow.rs
@@ -21,32 +21,10 @@ pub struct Workflow {
 pub const WORKFLOWS: &[Workflow] = &[
     Workflow {
         alias: "ship",
-        job_id: "task_pr_pipeline",
-        description: "Ship explicitly selected tasks through the PR pipeline",
-        supports_tasks: true,
-        supports_parallelism: false,
-        supports_base: true,
-        supports_pr_number: false,
-        requires_pr_number: false,
-        max_tasks: None,
-    },
-    Workflow {
-        alias: "ship-local",
-        job_id: "task_local_pipeline",
-        description: "Ship explicitly selected tasks through the local pipeline",
-        supports_tasks: true,
-        supports_parallelism: false,
-        supports_base: true,
-        supports_pr_number: false,
-        requires_pr_number: false,
-        max_tasks: None,
-    },
-    Workflow {
-        alias: "ship-auto",
         job_id: "task_auto_pipeline",
-        description: "Auto-select backlog tasks, gate them, and ship them",
+        description: "Gate and ship backlog or explicitly selected tasks",
         supports_tasks: true,
-        supports_parallelism: true,
+        supports_parallelism: false,
         supports_base: true,
         supports_pr_number: false,
         requires_pr_number: false,
@@ -205,4 +183,21 @@ pub fn build_workflow_input_for(
     }
 
     Ok(Value::Object(map))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ship_workflow_routes_to_auto_pipeline_only() {
+        let workflow = find_workflow("ship").expect("ship workflow");
+
+        assert_eq!(workflow.job_id, "task_auto_pipeline");
+        assert!(workflow.supports_tasks);
+        assert!(workflow.supports_base);
+        assert!(!workflow.supports_parallelism);
+        assert!(find_workflow("ship-auto").is_none());
+        assert!(find_workflow("ship-local").is_none());
+    }
 }

--- a/crates/orbit-core/src/config/raw.rs
+++ b/crates/orbit-core/src/config/raw.rs
@@ -25,8 +25,8 @@ pub(super) struct RawRuntimeConfig {
 
 #[derive(Debug, Clone, Deserialize)]
 pub(super) struct RawWorkflowConfig {
-    /// `workflow.base_branch` — repo-level default base branch for ship,
-    /// ship-auto, and duel-plan workflows. When absent, defaults to `main`.
+    /// `workflow.base_branch` — repo-level default base branch for ship and
+    /// duel-plan workflows. When absent, defaults to `main`.
     /// Repos that keep an `agent-main` buffer branch set this to
     /// `"agent-main"`.
     pub(super) base_branch: Option<String>,

--- a/crates/orbit-core/src/config/runtime.rs
+++ b/crates/orbit-core/src/config/runtime.rs
@@ -39,7 +39,7 @@ pub(crate) struct RuntimeConfig {
     /// `None` means "not configured"; the resolver falls through to the hard-
     /// coded `cli` default.
     pub(crate) v2_backend: Option<String>,
-    /// Default base branch for ship/ship-auto/duel-plan workflows. Sourced
+    /// Default base branch for ship/duel-plan workflows. Sourced
     /// from `[workflow] base_branch` in `config.toml`; defaults to `"main"`
     /// when no key is set.
     pub(crate) workflow_base_branch: String,

--- a/crates/orbit-core/src/context.rs
+++ b/crates/orbit-core/src/context.rs
@@ -177,7 +177,7 @@ pub(crate) struct OrbitRuntimeSettings {
     pr_config: PrConfig,
     /// Persisted default for the v2 `agent_loop` execution backend (§3.1).
     v2_backend: Option<String>,
-    /// Default base branch for ship/ship-auto/duel-plan workflows
+    /// Default base branch for ship/duel-plan workflows
     /// (`[workflow] base_branch` in `config.toml`, default `"main"`).
     workflow_base_branch: String,
     crews: std::collections::BTreeMap<String, Crew>,
@@ -338,7 +338,7 @@ impl OrbitContext {
         self.runtime.v2_backend()
     }
 
-    /// Default base branch for ship/ship-auto/duel-plan workflows. Sourced
+    /// Default base branch for ship/duel-plan workflows. Sourced
     /// from `[workflow] base_branch` in `config.toml`; falls back to
     /// `"main"` when the key is absent.
     pub(crate) fn workflow_base_branch(&self) -> &str {

--- a/crates/orbit-core/src/runtime/mod.rs
+++ b/crates/orbit-core/src/runtime/mod.rs
@@ -237,7 +237,7 @@ impl OrbitRuntime {
         self.context.v2_backend()
     }
 
-    /// Default base branch for ship/ship-auto/duel-plan workflows. Sourced
+    /// Default base branch for ship/duel-plan workflows. Sourced
     /// from `[workflow] base_branch` in the active `config.toml`; defaults
     /// to `"main"` when no key is present.
     pub fn workflow_base_branch(&self) -> &str {

--- a/docs/design/activity-job/2_design.md
+++ b/docs/design/activity-job/2_design.md
@@ -2,7 +2,7 @@
 
 **Status:** Draft
 **Owner:** codex
-**Last updated:** 2026-05-15
+**Last updated:** 2026-05-16
 
 This document describes the shipped Activity / Job substrate across `orbit-common`, `orbit-engine`, `orbit-core`, and `orbit-cli`: asset shape, normalization, dispatch boundaries, backend semantics, DAG execution, audit, and retained legacy edges. See [1_overview.md](./1_overview.md) for purpose and [3_vision.md](./3_vision.md) for open questions.
 
@@ -254,7 +254,7 @@ For `run_command` or any shell-based step, there is no implicit structured outpu
 
 `when` is evaluated once, before retry. A skipped step is a successful no-op and does not retry.
 
-After [T20260509-11], the shipped condition grammar remains equality-only (`==` / `!=`, combined with `&&` / `||`); skip-on-empty guards express emptiness as `!= 0` or `!= []` rather than numeric comparisons, preserving `ship-auto` empty-backlog no-op behavior.
+After [T20260509-11], the shipped condition grammar remains equality-only (`==` / `!=`, combined with `&&` / `||`); skip-on-empty guards express emptiness as `!= 0` or `!= []` rather than numeric comparisons, preserving the `orbit run ship` auto-mode empty-backlog no-op behavior.
 
 The retry wrapper re-runs the whole step body up to `max_attempts`, with exponential or linear backoff. Some errors bypass retry:
 
@@ -293,7 +293,7 @@ The body runs before `break_when`, so steps can populate fields the break expres
 
 ### 8.6 Persisted state for v2 job runs
 
-Persisted pipeline runs (`orbit run ship`, `ship-auto`, `duel-plan`, `orbit.pipeline.invoke` + `orbit.pipeline.wait`) go through `pipeline_run.rs`. Direct v2 runs (`orbit job run <job-id-or-yaml>`) also create durable `JobRun` bundles after [T20260423-2004-4] under `state/job-runs/<job_id>/<run_id>/`, so `orbit run history -j <job_id>` and `orbit run show <run_id>` can inspect the returned ID. Workflow-specific `orbit run <workflow> list/show` aliases were removed in [T20260425-2010], and duplicate job-level aliases in [T20260426-0742].
+Persisted pipeline runs (`orbit run ship`, `duel-plan`, `orbit.pipeline.invoke` + `orbit.pipeline.wait`) go through `pipeline_run.rs`. Direct v2 runs (`orbit job run <job-id-or-yaml>`) also create durable `JobRun` bundles after [T20260423-2004-4] under `state/job-runs/<job_id>/<run_id>/`, so `orbit run history -j <job_id>` and `orbit run show <run_id>` can inspect the returned ID. Workflow-specific `orbit run <workflow> list/show` aliases were removed in [T20260425-2010], and duplicate job-level aliases in [T20260426-0742].
 
 Before [T20260423-0445], early v2 failures could leave `steps: []` and no surfaced `error_message`. The current contract is:
 
@@ -304,7 +304,7 @@ Before [T20260423-0445], early v2 failures could leave `steps: []` and no surfac
 
 This operator-surface repair keeps `orbit run ship --json`, direct `orbit job run`, `orbit run history`, and `orbit run show` actionable without adding a second run-level error channel.
 
-After [T20260430-27], `orbit run ship-auto` also interprets the parent `task_auto_pipeline` snapshot for operator output. Text and JSON modes keep the persisted run state and exit-code semantics, but add `workflow_status` labels: `empty_backlog`, `gated_noop`, `gate_waiting`, `gate_failed`, and `completed`. `empty_backlog` means no candidates and no exclusions. `gated_noop` means zero dispatched bundles with one or more `list_backlog.excluded` entries. `gate_waiting` means a child `task_gate_pipeline` run is still pending/running or the parent wait timed out while the child remains active. `gate_failed` means a child gate run reached a failed or cancelled state. The output also carries dispatched bundle count, excluded task count, exclusion reasons, blocker summaries, and child gate run status so operators do not have to run `orbit run show` merely to tell no backlog from lock-gated work. After [T20260430-30], default text renders that data as labeled multi-line operator output, while `--json` remains the stable machine-readable surface with raw status fields.
+After [T20260430-27], the former `orbit run ship-auto` path interpreted the parent `task_auto_pipeline` snapshot for operator output. Text and JSON modes kept the persisted run state and exit-code semantics, but added `workflow_status` labels: `empty_backlog`, `gated_noop`, `gate_waiting`, `gate_failed`, and `completed`. `empty_backlog` means no candidates and no exclusions. `gated_noop` means zero dispatched bundles with one or more `list_backlog.excluded` entries. `gate_waiting` means a child `task_gate_pipeline` run is still pending/running or the parent wait timed out while the child remains active. `gate_failed` means a child gate run reached a failed or cancelled state. After [ORB-00075], `orbit run ship` is the single public shipment command: omitted task IDs run auto mode, provided task IDs seed explicit singleton bundles, and both forms submit `task_auto_pipeline` asynchronously. The dispatch output is now just workflow/job/run identity plus pointers to `orbit run history -j task_auto_pipeline` and `orbit run show <RUN_ID>`; waiting reasons and terminal details live on those durable inspection surfaces rather than in CLI dispatch output.
 
 After [T20260505-8], active job runs can be cancelled through the same durable run surface. `pending` and `running` runs transition to `cancelled`; terminal runs remain immutable. Pending cancellation only rewrites the run bundle and pipeline snapshot, so a later pipeline worker observes `cancelled` and exits without claiming the run. Running cancellation first validates the stored owner PID start-time token, then signals the owner process group on Unix with a bounded graceful period and `SIGKILL` escalation. `JobRunCancelled` audit payloads include run id, previous/final state, actor/source, whether signaling was attempted, and the signal outcome.
 
@@ -522,8 +522,8 @@ Read-only history does not need the same dependencies as live execution. [T20260
 - **[T20260430-15]** — Embed task-aware input and run context in backend: cli agent envelopes.
 - **[T20260430-19]** — Shorten the Activity / Job design docs while preserving required structure.
 - **[T20260430-26]** — Release task-gate reservations after terminal child shipment runs and expose active reservations through the lock view.
-- **[T20260430-27]** — Make `ship-auto` output distinguish empty backlog, gated no-op, and waiting gate children.
-- **[T20260430-30]** — Make `ship-auto` default text output human-readable while preserving JSON fields.
+- **[T20260430-27]** — Make the auto shipment output distinguish empty backlog, gated no-op, and waiting gate children.
+- **[T20260430-30]** — Make auto shipment default text output human-readable while preserving JSON fields.
 - **[T20260430-31]** — Require populated execution summaries before opening task PRs.
 - **[T20260505-2]** — Admit accepted backlog friction reports in automatic backlog listing.
 - **[T20260505-8]** — Add dashboard/runtime controls to cancel active job runs.
@@ -533,7 +533,8 @@ Read-only history does not need the same dependencies as live execution. [T20260
 - **[T20260508-8]** — Resolve backend: cli subprocess cwd from workspace context and record it in audit/tracing.
 - **[T20260509-2]** — Split the v2 job executor into responsibility-focused modules without changing runtime behavior.
 - **[T20260509-7]** — Establish focused test coverage for the activity/job DAG executor (linear, retry, parallel, fan-out, loop, pipeline durability) and the macOS sandbox / policy boundary.
-- **[T20260509-11]** — Keep condition guards on equality-only grammar and repair the `ship-auto` empty-backlog guard.
+- **[T20260509-11]** — Keep condition guards on equality-only grammar and repair the `task_auto_pipeline` empty-backlog guard.
+- **[ORB-00075]** — Unify ship aliases into async `orbit run ship`.
 - **[T20260509-30]** — Resolve the macOS `sandbox-exec` wrapper from a trusted absolute path before CLI spawn.
 - **[T20260509-38]** — Run legacy parallel-batch workers through cancellable pipeline runs so timeout failure paths return promptly.
 - **[T20260509-40]** — Run CLI subprocesses in killable process groups and bound timeout-path output reader joins.

--- a/docs/design/activity-job/4_decisions.md
+++ b/docs/design/activity-job/4_decisions.md
@@ -2,7 +2,7 @@
 
 **Status:** Draft
 **Owner:** codex
-**Last updated:** 2026-05-15
+**Last updated:** 2026-05-16
 
 This ADR log records the decisions that define the current Activity / Job substrate. Entries are append-only and stay in place when later ADRs supersede or fold them. See [1_overview.md](./1_overview.md) for the feature summary, [2_design.md](./2_design.md) for the current implementation, and [3_vision.md](./3_vision.md) for the questions that may force more decisions.
 
@@ -257,7 +257,7 @@ Folded instances:
 | ADR-029 | The first direct-shipment recovery default was deterministic and conservative. |
 | ADR-030 | Default recovery is step-scoped and agent-driven. |
 | ADR-033 | Auto-backlog lock exclusions are structured output. |
-| ADR-034 | `ship-auto` reports operator workflow status from durable pipeline state. |
+| ADR-034 | Auto shipment reports operator workflow status from durable pipeline state. |
 | ADR-035 | Gate reservations release after terminal child waits. |
 | ADR-037 | Accepted friction reports enter auto-backlog by status. |
 | ADR-039 | Run-owned task-lock reservations clean up at owner terminal. |
@@ -342,7 +342,7 @@ Folded into ADR-002's rollup for explicit agent dispatch boundaries.
 
 Folded into ADR-023's rollup for seeded task-shipment workflow automation.
 
-## ADR-034 — `ship-auto` reports operator workflow status from durable pipeline state
+## ADR-034 — Auto shipment reports operator workflow status from durable pipeline state
 
 **Status:** Superseded by ADR-023 (folded) · 2026-04 · [T20260430-27], [T20260430-30]
 
@@ -492,7 +492,7 @@ The plumbing adds a single optional field to `TaskAutomationUpdate` (`context_fi
 
 **Context.** `task_auto_pipeline` needed to skip its success guard for empty backlog runs, but its seeded `bundle_count > 0` guard rendered to an unsupported comparison and failed before the step could be skipped. Orbit could either extend the shared evaluator with numeric ordering or express the guard in the existing grammar.
 
-**Decision.** Keep the shared condition grammar to `==` and `!=`, with `&&` and `||` composition, and express skip-on-empty guards with equality-compatible forms such as `!= 0` and `!= []`. The `ship-auto` guard uses `{{ steps.validate_bundles.output.bundle_count }} != 0`, so zero bundles skip the guard and populated fan-out still checks child gate success.
+**Decision.** Keep the shared condition grammar to `==` and `!=`, with `&&` and `||` composition, and express skip-on-empty guards with equality-compatible forms such as `!= 0` and `!= []`. The `task_auto_pipeline` guard uses `{{ steps.validate_bundles.output.bundle_count }} != 0`, so zero bundles skip the guard and populated fan-out still checks child gate success.
 
 **Consequences.**
 - The evaluator stays string-based and shared between `StepCondition::Expr`, v2 `when:`, and loop `break_when:` without adding numeric coercion rules.
@@ -524,6 +524,20 @@ The plumbing adds a single optional field to `TaskAutomationUpdate` (`context_fi
 - Timeout return no longer depends on the worker's thread or agent process eventually exiting.
 - Timed-out child work gets the same run-cancellation path operators use elsewhere, including bounded process-group signaling for running pipeline workers.
 - Cost: the retained legacy path now depends on the v2 pipeline tool surface and polls active workers, so completion can lag by the polling interval rather than waking on an in-process channel send.
+
+## ADR-052 — Unified async ship dispatch
+
+**Status:** Proposed · 2026-05 · [ORB-00075]
+
+**Context.** Orbit had three shipment aliases: `ship`, `ship-local`, and `ship-auto`. Operators used the auto path because it already queued behind dependency and lock gates, while explicit shipment still failed fast before the waiting-reason surfaces could explain parked work.
+
+**Decision.** Use `orbit run ship` as the only public shipment command. Omitted task IDs run backlog auto mode, provided task IDs seed explicit singleton bundles, and both forms submit `task_auto_pipeline`; mode still routes inside `task_gate_pipeline` to `task_{{ input.mode }}_pipeline`. The companion global ADR is ADR-0152.
+
+**Consequences.**
+- Explicit task selection now waits inside the gated job path instead of failing at CLI dispatch time.
+- `orbit run ship` returns after `submit_pipeline_run`, and operators inspect waiting or terminal state with `orbit run history -j task_auto_pipeline` and `orbit run show <RUN_ID>`.
+- The deprecated `ship-auto` CLI form errors toward `orbit run ship`, and `ship-local` is no longer a workflow alias.
+- Cost: dispatch output no longer contains the former synchronous auto-shipment summary because terminal pipeline state is unavailable at submit time.
 
 ---
 
@@ -574,8 +588,8 @@ The plumbing adds a single optional field to `TaskAutomationUpdate` (`context_fi
 - **[T20260430-15]** — Embed task-aware input and run context in backend: cli agent envelopes.
 - **[T20260430-19]** — Shorten the Activity / Job design docs while preserving required structure.
 - **[T20260430-26]** — Release task-gate reservations after terminal child shipment runs and expose active reservations through the lock view.
-- **[T20260430-27]** — Make `ship-auto` output distinguish empty backlog, gated no-op, and waiting gate children.
-- **[T20260430-30]** — Make `ship-auto` default text output human-readable while preserving JSON fields.
+- **[T20260430-27]** — Make auto shipment output distinguish empty backlog, gated no-op, and waiting gate children.
+- **[T20260430-30]** — Make auto shipment default text output human-readable while preserving JSON fields.
 - **[T20260430-31]** — Require populated execution summaries before opening task PRs.
 - **[T20260505-2]** — Admit accepted backlog friction reports in automatic backlog listing.
 - **[T20260505-8]** — Add dashboard/runtime controls to cancel active job runs.
@@ -589,7 +603,8 @@ The plumbing adds a single optional field to `TaskAutomationUpdate` (`context_fi
 - **[T20260509-2]** — Split the v2 job executor into responsibility-focused modules without changing runtime behavior.
 - **[T20260509-7]** — Establish focused test coverage for the activity/job DAG executor (linear, retry, parallel, fan-out, loop, pipeline durability) and the macOS sandbox / policy boundary.
 - **[T20260509-9]** — Auto-populate `task.context_files` from the winning planning-duel plan after resolution.
-- **[T20260509-11]** — Keep condition guards on equality-only grammar and repair the `ship-auto` empty-backlog guard.
+- **[T20260509-11]** — Keep condition guards on equality-only grammar and repair the `task_auto_pipeline` empty-backlog guard.
+- **[ORB-00075]** — Unify ship aliases into async `orbit run ship`.
 - **[T20260509-38]** — Run legacy parallel-batch workers through cancellable pipeline runs so timeout failure paths return promptly.
 - **[T20260509-40]** — Run CLI subprocesses in killable process groups and bound timeout-path output reader joins.
 

--- a/website/scripts/sync-scoreboard.mjs
+++ b/website/scripts/sync-scoreboard.mjs
@@ -282,7 +282,7 @@ function renderPrsTable(agents) {
   const headline = `**${num(total)} PRs landed via the Orbit ship workflow.**`;
   return section(
     'PRs landed',
-    'Pull requests merged through `orbit run ship` / `orbit run ship-auto`. Clean rate = `merged_clean / (merged_clean + merged_with_revision)`. Sorted by total.',
+    'Pull requests merged through `orbit run ship`. Clean rate = `merged_clean / (merged_clean + merged_with_revision)`. Sorted by total.',
     headline,
     ['Agent', 'Total', 'Clean', 'With revision', 'Clean rate'],
     sortRows(rows),

--- a/website/src/content/docs/getting-started/index.md
+++ b/website/src/content/docs/getting-started/index.md
@@ -20,7 +20,7 @@ Use this section when you are setting up Orbit for the first time.
   </a>
   <a class="orbit-card" href="./workflows/">
     <h3>Default Workflows</h3>
-    <p>Run ship, ship-auto, and duel-plan.</p>
+    <p>Run ship and duel-plan.</p>
   </a>
 </div>
 

--- a/website/src/content/docs/getting-started/workflows.md
+++ b/website/src/content/docs/getting-started/workflows.md
@@ -1,39 +1,26 @@
 ---
 title: Default Workflows
-description: "Built-in workflows under orbit run: ship, ship-auto, and duel-plan."
+description: "Built-in workflows under orbit run: ship and duel-plan."
 sidebar:
   order: 4
 ---
 
-Orbit ships three default workflows under `orbit run`. Each wraps a seeded job pipeline under `crates/orbit-core/assets/jobs/`; the same pipelines are runnable directly via `orbit run job <name>`.
+Orbit ships two default workflows under `orbit run`. Each wraps a seeded job pipeline under `crates/orbit-core/assets/jobs/`; the same pipelines are runnable directly via `orbit run job <name>`.
 
 All three workflows default `--base` to `agent-main` — the convention for agent-targeted long-lived branches that humans merge into `main` after review. Pass `--base <branch>` to target a different branch.
 
 ## `orbit run ship`
 
-Carry one or more named tasks from `backlog` through `done`. The default mode opens a PR; `--mode local` ships in-place.
+Submit backlog tasks or one or more named tasks through the gated shipment pipeline. The default mode opens PRs; `--mode local` ships in-place. The command returns a run ID immediately, while dependency and lock waits happen inside the job.
 
 ```bash
+orbit run ship
 orbit run ship T20260506-1
 orbit run ship T20260506-1 T20260506-2 --mode local
 orbit run ship T20260506-1 --base main
 ```
 
-Underlying job: `task_pr_pipeline` (PR mode) or `task_local_pipeline` (`--mode local`).
-
-## `orbit run ship-auto`
-
-Pick eligible tasks from the backlog, group them into bundles, and run each bundle through the same gate pipeline as `ship`. No task IDs are required.
-
-```bash
-orbit run ship-auto
-orbit run ship-auto --mode local
-orbit run ship-auto --base main
-```
-
-Output statuses: `empty_backlog`, `gated_noop`, `gate_waiting`, `gate_failed`, `completed`. Gated and no-op statuses keep exit code 0 and are reported explicitly in both text and `--json` output.
-
-Underlying job: `task_auto_pipeline`.
+Underlying job: `task_auto_pipeline`, which fans into `task_gate_pipeline` and then routes to `task_pr_pipeline` or `task_local_pipeline` from `--mode`.
 
 ## `orbit run duel-plan`
 

--- a/website/src/content/docs/reference/cli.md
+++ b/website/src/content/docs/reference/cli.md
@@ -18,9 +18,8 @@ sidebar:
 | Command | Purpose |
 |---------|---------|
 | `orbit run job <job_id>` | Run an arbitrary job by ID. |
-| `orbit run ship <task_id> ...` | Ship explicitly selected tasks through the PR pipeline by default. |
-| `orbit run ship --mode local <task_id> ...` | Run the local-only task path for explicitly selected tasks. |
-| `orbit run ship-auto` | Auto-select backlog tasks, print a human-readable status summary, and support structured details with `--json`. |
+| `orbit run ship [task_id ...]` | Submit backlog or explicitly selected tasks through the gated shipment pipeline and return a run ID immediately. |
+| `orbit run ship --mode local [task_id ...]` | Run the local-only task path for backlog or explicitly selected tasks. |
 | `orbit run duel-plan <task_id>` | Run a planning duel for one task. |
 | `orbit task` | Create, update, and manage tasks. |
 | `orbit task artifact put <task_id> <source_path>` | Store a UTF-8 file under a task's artifacts directory. |


### PR DESCRIPTION
## Task

[ORB-00075](https://orbit-cli.com/tasks/ORB-00075) — Unify ship/ship-local/ship-auto into one async `orbit run ship` command

### Description

## Problem

The ship CLI surface has three workflow aliases:

| Alias | Backing job | CLI command |
|---|---|---|
| `ship` | `task_pr_pipeline` | `orbit run ship <TASK_IDS> [--mode pr\|local] [--base ...]` |
| `ship-local` | `task_local_pipeline` | (legacy — invoked via `--mode local`) |
| `ship-auto` | `task_auto_pipeline` | `orbit run ship-auto [--mode ...] [--base ...]` |

See [`crates/orbit-core/src/command/workflow.rs:21-77`](crates/orbit-core/src/command/workflow.rs) and [`crates/orbit-cli/src/command/run/ship.rs`](crates/orbit-cli/src/command/run/ship.rs).

The explicit form (`orbit run ship <TASK_IDS>`) is fail-fast on readiness: if a selected task's dependencies or locks aren't satisfied at dispatch time, the command errors. The auto form scans the backlog and gates on dependencies, parking jobs in a waiting state instead.

In actual operator usage, the explicit fail-fast form has fallen out of use — operators run `ship-auto` to flush the backlog. The explicit primitive is redundant: agents that want to ship a specific task can manipulate task state (priority / ready-state) and re-run `ship-auto`, achieving the same outcome through the queue rather than a separate CLI surface.

## Design Decision

Collapse to a single `orbit run ship` command:

- **With task IDs** (`orbit run ship T123 T456`): explicit selection, but gated on both task dependencies *and* locks. The job parks in a waiting state until all gates clear or the existing max-wait timeout fires. **No fail-fast.**
- **Without task IDs** (`orbit run ship`): auto mode — current `ship-auto` behavior.
- **Async dispatch.** Command returns a job-id immediately in both modes. Wait happens inside the job, not the CLI.
- **Flags preserved.** `--mode pr|local` and `--base` carry over unchanged.
- **`ship-local` and `ship-auto` aliases removed**, with friendly deprecation errors following the `legacy_ship_form` pattern at [`crates/orbit-cli/src/command/run/ship.rs:163-175`](crates/orbit-cli/src/command/run/ship.rs).

## Why It Matters

- One mental model for shipping. The args determine the mode, not the command name.
- Agents and the eventual dashboard get a fire-and-forget surface — submit intent, the dispatcher decides when to execute.
- Eliminates the silent-stall failure mode introduced by gating: visible waiting reasons are delivered by the foundation task **ORB-00074** (this task's hard dependency), so operators can see *why* a job is parked.

## Constraints / Notes

- **Hard dependency on ORB-00074.** The waiting-reason surface must land first, or the queue-and-wait semantics this task introduces will be opaque and strictly worse than today's fail-fast UX.
- **Job routing decision.** Today `ship-auto` uses `task_auto_pipeline`. The unified command needs to route explicit task IDs to a gated path. Implementer chooses one of:
  1. Extend `task_auto_pipeline` to accept explicit task IDs as a filter/seed (preferred if straightforward — collapses to one job).
  2. Keep `task_pr_pipeline` / `task_local_pipeline` but add the same dep+lock gating ship-auto uses.
  The decision and its rationale must be documented in the companion ADR.
- **Async return contract.** Command returns a job-id immediately. Existing `orbit run history -j <ID>` and `orbit run show <RUN_ID>` are the inspection surfaces. The CLI must not block on job completion.
- **Companion ADR.** Documents (a) consolidation of three aliases into one, (b) the semantic change from fail-fast to queue-and-wait for explicit selection, (c) async-by-default return contract, (d) job-routing decision from above. Implementer chooses ADR home — likely a new `docs/design/ship/` feature folder, or attached to `docs/design/activity-job/` (which already references `ship-auto` in its 2_design.md and 4_decisions.md). Allocate via `orbit.adr.*` tools per the `orbit-adr` skill — don't hand-edit `.orbit/adrs/` files.
- **Deprecation pattern.** Old invocations (`orbit run ship-auto`, and if removed at the workflow registry level, also `ship-local` as a workflow alias) must return a clear error message pointing operators to the new form. Follow the existing `legacy_ship_form` shape.
- **Same-PR doc updates.** Bump `Last updated:` on any design doc that references `ship-auto` (currently `docs/design/activity-job/2_design.md` and `docs/design/activity-job/4_decisions.md`); flip ADR statuses as needed per CONVENTIONS.md.

## Out of Scope

- Changing the max-wait timeout default value or its policy.
- Adding new dashboard buttons (separate downstream conversation).
- Modifying `review-pr` or `duel-plan` workflows.
- Changing the `--mode pr|local` distinction's semantics; just preserve the flag.

### Acceptance Criteria

- `ShipCommand` and `ShipAutoCommand` in `crates/orbit-cli/src/command/run/ship.rs` are collapsed into a single `ShipCommand` whose positional `<TASK_ID>...` arg is optional; absent → auto mode, present → explicit gated mode.
- The unified command preserves `--mode pr|local` (default `pr`) and `--base <branch>` (default from config) flags with their existing semantics.
- Invoking `orbit run ship` (with or without task IDs) returns a job-id immediately and exits with code 0; the CLI does not block on job completion (verifiable by `time orbit run ship T<existing-id>` completing in under one second after dispatch acknowledgement, modulo runtime startup).
- Explicit-mode jobs with unmet task dependencies or held locks enter a waiting state visible via `orbit run history -j <JOB_ID>` (using the surface delivered by ORB-00074) and do NOT return a non-zero exit code at CLI dispatch time.
- The `ship` and `ship-local` workflow aliases are removed from `crates/orbit-core/src/command/workflow.rs`; the `ship-auto` alias is either renamed to `ship` or replaced by a `ship` alias with `ship-auto` retained as a deprecated alias that errors with a message pointing to `orbit run ship`. The chosen approach is documented in the companion ADR.
- Running the removed forms (`orbit run ship-auto`, and if applicable a workflow dispatch of alias `ship-local`) returns a clear error message naming the replacement command, following the `legacy_ship_form` pattern at `crates/orbit-cli/src/command/run/ship.rs:163-175`.
- A companion ADR is created via the `orbit.adr.*` tooling that documents: (a) the three-into-one alias consolidation, (b) the fail-fast → queue-and-wait semantic change for explicit selection, (c) the async-by-default return contract, (d) the job-routing decision (extend `task_auto_pipeline` vs. add gating to the explicit-path job).
- Any design docs referencing `ship-auto` (`docs/design/activity-job/2_design.md`, `docs/design/activity-job/4_decisions.md`, and any others surfaced by `grep -rln "ship-auto\|ship-local" docs/`) have their `Last updated:` date bumped and content updated to reference the unified command; `make check-design-docs` passes.
- Unit tests cover (a) `build_*_run_plan`-equivalent logic for both empty-task-ids and populated-task-ids paths, (b) the deprecation error for `ship-auto` invocation, and (c) the `--mode pr|local` flag behavior under both task-id presence/absence; tests use in-memory fakes or temp directories.
- `make ci-fast` passes on the task branch before review; full `make ci` is the merge gate via PR CI.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Unified `orbit run ship` so empty task IDs run auto mode and explicit task IDs seed the same gated `task_auto_pipeline` path.
- Made ship dispatch asynchronous by submitting the pipeline run without `wait_pipeline_runs`; output now returns workflow/job/run identity and history/show pointers.
- Removed `ship-auto` and `ship-local` from the workflow registry, retaining hidden deprecated CLI forms that return replacement-command errors.
- Preserved `--mode pr|local` and `--base` inputs across auto and explicit forms, updated audit metadata, help text, README/website docs, config comments, changelog, and activity-job design docs.
- Created companion ADR ADR-0152 with legacy id `activity-job/ADR-052`.

Strategic decisions:
- Route unified ship through `task_auto_pipeline` for both modes | Rationale: explicit `task_ids` already flow through `list_backlog_tasks` as singleton bundles and then through `task_gate_pipeline`, preserving dependency/lock gating and mode routing.

Validation:
- `cargo test -p orbit-cli ship -- --nocapture` passed.
- `cargo test -p orbit-core ship_workflow_routes_to_auto_pipeline_only -- --nocapture` passed.
- `cargo test -p orbit-core list_backlog_tasks_omits_excluded_for_explicit_task_ids -- --nocapture` passed.
- `target/debug/orbit run --help` and `target/debug/orbit run ship --help` show the unified command surface.
- `make ci-fast` passed.
- `make check-design-docs` was run and still fails on unrelated stale design docs outside this task scope; evidence was recorded in a task comment.

Assessment: The scoped implementation and required fast validation are complete. The remaining design-doc decay failure appears pre-existing/unrelated, so I did not broaden the patch by bumping unrelated Last updated dates.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-00075-6a08fc00`
- Behind base: 0
- Ahead of base: 1