### PR TITLE
Crew resolver ignores single-entry task_ids pipeline input

### DIFF
--- a/crates/orbit-core/src/runtime/engine/crew.rs
+++ b/crates/orbit-core/src/runtime/engine/crew.rs
@@ -3,6 +3,7 @@ use serde::Serialize;
 use serde_json::Value;
 
 use crate::OrbitRuntime;
+use crate::runtime::run_input::{non_empty, singular_task_id_from_input};
 
 /// Runtime crew registry projection for dashboard/API consumers.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
@@ -200,16 +201,154 @@ impl OrbitRuntime {
     }
 
     fn task_id_from_run_input(&self, input: &Value) -> Result<Option<Task>, OrbitError> {
+        if let Some(task_id) = singular_task_id_from_input(input)
+            && task_id.starts_with("ORB-")
+        {
+            return self.get_task(task_id).map(Some);
+        }
+
         for key in ["task_id", "taskId", "id"] {
             let Some(task_id) = input.get(key).and_then(Value::as_str) else {
                 continue;
             };
-            let task_id = task_id.trim();
+            let Some(task_id) = non_empty(task_id) else {
+                continue;
+            };
             if !task_id.starts_with("ORB-") {
                 continue;
             }
             return self.get_task(task_id).map(Some);
         }
         Ok(None)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use chrono::Utc;
+    use serde_json::json;
+    use tempfile::{TempDir, tempdir};
+
+    use crate::OrbitRuntime;
+    use crate::command::task::TaskAddParams;
+
+    fn runtime_with_named_crews() -> (TempDir, OrbitRuntime) {
+        let root = tempdir().expect("create temp root");
+        let global_root = root.path().join("global");
+        let repo_root = root.path().join("repo");
+        let workspace_root = repo_root.join(".orbit");
+        std::fs::create_dir_all(&global_root).expect("create global root");
+        std::fs::create_dir_all(&workspace_root).expect("create workspace root");
+        std::fs::write(
+            workspace_root.join("config.toml"),
+            r#"
+[crews.opus-codex]
+planner = { model = "default-planner", provider = "codex", backend = "cli" }
+implementer = { model = "default-implementer", provider = "codex", backend = "cli" }
+reviewer = { model = "default-reviewer", provider = "codex", backend = "cli" }
+
+[crews.silver]
+planner = { model = "silver-planner", provider = "codex", backend = "cli" }
+implementer = { model = "silver-implementer", provider = "codex", backend = "cli" }
+reviewer = { model = "silver-reviewer", provider = "codex", backend = "cli" }
+
+[crews.bronze]
+planner = { model = "bronze-planner", provider = "codex", backend = "cli" }
+implementer = { model = "bronze-implementer", provider = "codex", backend = "cli" }
+reviewer = { model = "bronze-reviewer", provider = "codex", backend = "cli" }
+
+[workflow]
+default_crew = "opus-codex"
+"#,
+        )
+        .expect("write test config");
+        let runtime =
+            OrbitRuntime::from_roots(&global_root, &workspace_root).expect("build runtime");
+        (root, runtime)
+    }
+
+    fn add_task_with_crew(runtime: &OrbitRuntime, crew: &str) -> String {
+        runtime
+            .add_task(TaskAddParams {
+                title: format!("{crew} task"),
+                description: "Task fixture for crew resolution.".to_string(),
+                crew: Some(crew.to_string()),
+                ..Default::default()
+            })
+            .expect("add task")
+            .id
+    }
+
+    #[test]
+    fn run_input_task_ids_singleton_resolves_task_crew() {
+        let (_root, runtime) = runtime_with_named_crews();
+        let task_id = add_task_with_crew(&runtime, "silver");
+
+        let crew = runtime
+            .resolve_crew_for_run_input(&json!({ "task_ids": [task_id] }))
+            .expect("resolve crew");
+
+        assert_eq!(crew.name, "silver");
+        assert_eq!(crew.planner.model, "silver-planner");
+        assert_eq!(crew.implementer.model, "silver-implementer");
+        assert_eq!(crew.reviewer.model, "silver-reviewer");
+    }
+
+    #[test]
+    fn record_run_crew_persists_singleton_task_ids_task_crew_models() {
+        let (_root, runtime) = runtime_with_named_crews();
+        let task_id = add_task_with_crew(&runtime, "silver");
+        let input = json!({ "task_ids": [task_id] });
+        let run = runtime
+            .stores()
+            .jobs()
+            .insert_run("agent_implement", 1, Utc::now(), Some(input.clone()), None)
+            .expect("insert run");
+
+        let crew = runtime
+            .record_run_crew_from_input(&run.run_id, &input)
+            .expect("record crew");
+        let stored = runtime.show_job_run(&run.run_id).expect("show stored run");
+
+        assert_eq!(crew.name, "silver");
+        assert_eq!(stored.resolved_crew.as_deref(), Some("silver"));
+        assert_eq!(stored.planner_model.as_deref(), Some("silver-planner"));
+        assert_eq!(
+            stored.implementer_model.as_deref(),
+            Some("silver-implementer")
+        );
+        assert_eq!(stored.reviewer_model.as_deref(), Some("silver-reviewer"));
+    }
+
+    #[test]
+    fn explicit_crew_override_wins_over_singleton_task_ids_task_crew() {
+        let (_root, runtime) = runtime_with_named_crews();
+        let task_id = add_task_with_crew(&runtime, "silver");
+
+        let crew = runtime
+            .resolve_crew_for_run_input(&json!({
+                "crew": "bronze",
+                "task_ids": [task_id]
+            }))
+            .expect("resolve crew");
+
+        assert_eq!(crew.name, "bronze");
+        assert_eq!(crew.implementer.model, "bronze-implementer");
+    }
+
+    #[test]
+    fn multi_task_ids_without_override_falls_back_to_default_crew() {
+        let (_root, runtime) = runtime_with_named_crews();
+        let silver_task_id = add_task_with_crew(&runtime, "silver");
+        let bronze_task_id = add_task_with_crew(&runtime, "bronze");
+
+        let crew = runtime
+            .resolve_crew_for_run_input(&json!({
+                "task_ids": [silver_task_id, bronze_task_id]
+            }))
+            .expect("resolve crew");
+
+        assert_eq!(crew.name, "opus-codex");
+        assert_eq!(crew.implementer.model, "default-implementer");
     }
 }

--- a/crates/orbit-core/src/runtime/mod.rs
+++ b/crates/orbit-core/src/runtime/mod.rs
@@ -20,6 +20,7 @@ pub(crate) mod orbit_tool_host;
 pub mod pipeline;
 mod resolve;
 pub mod run_audit;
+pub(crate) mod run_input;
 mod store_delegates;
 mod task_reservation_cleanup;
 mod v2_host;

--- a/crates/orbit-core/src/runtime/run_input.rs
+++ b/crates/orbit-core/src/runtime/run_input.rs
@@ -1,0 +1,51 @@
+use serde_json::Value;
+
+/// Extract the singular task id from run/activity input shapes that are meant
+/// to identify exactly one task.
+pub(crate) fn singular_task_id_from_input(input: &Value) -> Option<&str> {
+    input
+        .get("task_id")
+        .and_then(Value::as_str)
+        .and_then(non_empty)
+        .or_else(|| {
+            input
+                .get("task")
+                .and_then(|task| task.get("id"))
+                .and_then(Value::as_str)
+                .and_then(non_empty)
+        })
+        .or_else(|| {
+            let items = input.get("task_ids")?.as_array()?;
+            if items.len() == 1 {
+                items.first()?.as_str().and_then(non_empty)
+            } else {
+                None
+            }
+        })
+}
+
+pub(crate) fn non_empty(value: &str) -> Option<&str> {
+    let trimmed = value.trim();
+    (!trimmed.is_empty()).then_some(trimmed)
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::singular_task_id_from_input;
+
+    #[test]
+    fn singular_task_id_accepts_single_entry_task_ids() {
+        let input = json!({ "task_ids": [" ORB-00073 "] });
+
+        assert_eq!(singular_task_id_from_input(&input), Some("ORB-00073"));
+    }
+
+    #[test]
+    fn singular_task_id_rejects_multi_task_input() {
+        let input = json!({ "task_ids": ["ORB-00073", "ORB-00078"] });
+
+        assert_eq!(singular_task_id_from_input(&input), None);
+    }
+}

--- a/crates/orbit-core/src/runtime/v2_host/learning_reminders.rs
+++ b/crates/orbit-core/src/runtime/v2_host/learning_reminders.rs
@@ -10,13 +10,14 @@ use serde_json::Value;
 
 use crate::OrbitRuntime;
 use crate::command::task::{canonicalize_context_files_for_read, context_workspace_root};
+use crate::runtime::run_input::singular_task_id_from_input;
 
 pub(super) fn learning_reminders_for_task(
     runtime: &OrbitRuntime,
     input: &Value,
     caps: LearningInjectionCaps,
 ) -> Result<Vec<LearningReminder>, DispatchError> {
-    let Some(task_id) = super::task_context::singular_task_id_from_input(input) else {
+    let Some(task_id) = singular_task_id_from_input(input) else {
         return Ok(Vec::new());
     };
     let task = runtime.get_task(task_id).map_err(|err| {

--- a/crates/orbit-core/src/runtime/v2_host/task_context.rs
+++ b/crates/orbit-core/src/runtime/v2_host/task_context.rs
@@ -6,6 +6,7 @@ use serde_json::Value;
 
 use crate::OrbitRuntime;
 use crate::command::task::{canonicalize_context_files_for_read, context_workspace_root};
+use crate::runtime::run_input::singular_task_id_from_input;
 
 pub(super) fn associated_task_ids(input: &Value) -> Vec<String> {
     let mut task_ids = Vec::new();
@@ -54,33 +55,6 @@ pub(super) fn task_context_for_agent_input(
         input,
         &runtime.paths().repo_root,
     )))
-}
-
-pub(super) fn singular_task_id_from_input(input: &Value) -> Option<&str> {
-    fn non_empty(value: &str) -> Option<&str> {
-        let trimmed = value.trim();
-        (!trimmed.is_empty()).then_some(trimmed)
-    }
-
-    input
-        .get("task_id")
-        .and_then(Value::as_str)
-        .and_then(non_empty)
-        .or_else(|| {
-            input
-                .get("task")
-                .and_then(|task| task.get("id"))
-                .and_then(Value::as_str)
-                .and_then(non_empty)
-        })
-        .or_else(|| {
-            let items = input.get("task_ids")?.as_array()?;
-            if items.len() == 1 {
-                items.first()?.as_str().and_then(non_empty)
-            } else {
-                None
-            }
-        })
 }
 
 fn agent_task_context_json(task: &Task, input: &Value, fallback_repo_root: &Path) -> Value {


### PR DESCRIPTION
## Task

[ORB-00078](https://orbit-cli.com/tasks/ORB-00078) — Crew resolver ignores single-entry task_ids pipeline input

### Description

## Problem

A single-task pipeline run can ignore the task's explicit `crew` and fall back to the workspace default crew.

Observed on `jrun-20260516-2256-6` for `ORB-00073`: the task has `crew: silver`, but the run persisted `resolved_crew: opus-codex` and launched the implementer as `gpt-5.5`. The run input was:

```json
{ "task_ids": ["ORB-00073"], "base_branch": "agent-main", "base_sync": "remote", "auto_push": true }
```

`OrbitRuntime::resolve_crew_for_run_input` calls its private `task_id_from_run_input`, which only recognizes `task_id`, `taskId`, and `id`. It does not recognize a single-entry `task_ids` array, even though the V2 task-context path already treats that shape as a singular task via `singular_task_id_from_input`.

## Why It Matters

- Operators can assign a task to a named crew such as `silver`, then a normal single-task pipeline run still executes under `[workflow].default_crew`.
- The run record persists the wrong `resolved_crew`, which then overrides the task projection because run audit truth correctly takes precedence after `job_run_id` is attached.
- The same resolver feeds activity role config selection, so this affects both displayed metadata and the actual planner/implementer/reviewer model choices.

## Evidence

- Friction report: `F2026-05-020`.
- Affected run: `jrun-20260516-2256-6`.
- Affected task: `ORB-00073`.
- Current inconsistent behavior: `task_context::singular_task_id_from_input` handles `task_ids: [id]`; `engine::crew::task_id_from_run_input` does not.

## Scope

Fix crew resolution for single-task run inputs without changing multi-task semantics.

Expected approach:

- Teach the crew resolver to recognize the same singular task input shapes used by task-context injection, especially `task_ids` arrays with exactly one non-empty task ID.
- Prefer reusing or centralizing the existing singular task-id extraction logic if crate/module visibility allows it cleanly; otherwise keep the behavior in sync with a focused helper and tests.
- Preserve explicit `crew` override precedence over task `crew`, and preserve workspace default fallback when no singular task crew is available.

## Constraints / Notes

- Do not rewrite job-run records or mutate historical audit evidence as part of the fix.
- Do not change behavior for multi-task inputs with more than one `task_ids` entry unless an explicit `crew` override is present.
- Keep the fix in `orbit-core`; no cross-crate dependency changes should be needed.

### Acceptance Criteria

- A deterministic unit test constructs a task with `crew: "silver"` and calls `resolve_crew_for_run_input` with `{ "task_ids": ["<task-id>"] }`; the returned crew name is `silver` rather than the configured default crew.
- A deterministic unit or integration test verifies run recording/model selection behavior for a pipeline-style input with `task_ids: ["<task-id>"]`: `record_run_crew_from_input` or the relevant public run path persists `resolved_crew: "silver"` and the silver planner/implementer/reviewer model strings.
- Existing explicit override precedence is preserved by a test: input `{ "crew": "<other-crew>", "task_ids": ["<task-id-with-silver>"] }` resolves to `<other-crew>`.
- Multi-task input remains unambiguous: input with more than one `task_ids` entry and no explicit `crew` does not silently pick one task's crew; it falls back to the same behavior used before for no singular task input, or returns the existing default crew when configured.
- The task-context and crew-resolution singular task-id behavior are documented in code or covered by adjacent tests so future changes do not let them drift again.
- `make ci-fast` passes.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Added shared runtime run-input singular task-id extraction for task-context, learning reminder, and crew-resolution callers.
- Updated crew resolution to honor single-entry `task_ids` pipeline input while preserving explicit crew override precedence, legacy `taskId`/root `id` support, and default fallback for multi-task input.
- Added deterministic crew-resolution and run-recording tests covering `silver` task crews, silver role model persistence, explicit override, multi-task fallback, and shared helper behavior.

Assessment: The scoped behavior is covered by targeted unit tests, and `make ci-fast` passes.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-00078-6a09003c`
- Behind base: 0
- Ahead of base: 1