### PR TITLE
Remove API route inventory footer from dashboard

### DIFF
--- a/crates/orbit-cli/assets/dashboard/app.js
+++ b/crates/orbit-cli/assets/dashboard/app.js
@@ -3986,8 +3986,6 @@ async function refreshDashboard() {
   if (btn) btn.disabled = false;
   isRefreshing = false;
   if (activeTab === "tasks") fitLogPanelToViewport();
-  
-  $("footer").textContent = `orbit dashboard · auto-refresh 30s · GET /api/{tasks,tasks/locks,crews,learnings,adrs,frictions,frictions/stats,jobs,job-runs,audit?since|tool|status|role|execution_id|profile|q|limit|offset,audit/summary?since|denial_threshold,runs/:id,runs/:id/events?kind|limit|offset,runs/:id/logs?limit,scoreboard,diagnostics/{metrics,errors,friction,denials?since|kind|profile|agent}}`;
 }
 
 buildChips();

--- a/crates/orbit-cli/assets/dashboard/index.html
+++ b/crates/orbit-cli/assets/dashboard/index.html
@@ -2288,7 +2288,6 @@
         </section>
       </main>
     </section>
-    <footer id="footer"></footer>
     <div id="gantt-tooltip" role="tooltip" aria-hidden="true"></div>
     <script src="/static/app.js"></script>
   </body>


### PR DESCRIPTION
## Task

[ORB-00082](https://orbit-cli.com/tasks/ORB-00082) — Remove API route inventory footer from dashboard

### Description

## Problem

The Orbit dashboard renders a footer on **every tab/view** (and every 30s auto-refresh) that prints:

```
orbit dashboard · auto-refresh 30s · GET /api/{tasks,tasks/locks,crews,learnings,adrs,frictions,frictions/stats,jobs,job-runs,audit?since|tool|status|role|execution_id|profile|q|limit|offset,audit/summary?since|denial_threshold,runs/:id,runs/:id/events?kind|limit|offset,runs/:id/logs?limit,scoreboard,diagnostics/{metrics,errors,friction,denials?since|kind|profile|agent}}
```

The dashboard is a single-page app — the `<footer id="footer">` element lives in the shared shell (`index.html`) and is populated once by `app.js`, so the same string appears at the bottom of every tab (tasks, runs, frictions, diagnostics, etc.), not just the landing page.

The route-inventory portion is a hand-maintained string of every API endpoint the dashboard reads. It is not user-actionable, not authoritative API docs (it will drift the moment a route is added/changed without footer updates), takes up the entire bottom of the viewport across all views, and is dev-facing trivia for a UI aimed at operators monitoring task/run state.

Footer is set in `crates/orbit-cli/assets/dashboard/app.js` (~line 3990); the slot is `<footer id="footer"></footer>` in `crates/orbit-cli/assets/dashboard/index.html`. Added in commit `91c5038a` ("Fix dashboard load + add 30s auto-refresh") alongside the auto-refresh feature.

## Why It Matters

- Removes drift-prone, non-actionable dev string from the operator UI across the whole dashboard.
- Reclaims vertical space at the bottom of every dashboard view.
- Eliminates a doc surface (the route list) that nobody is responsible for keeping in sync.

## Scope

Remove the route-inventory text from the shared shell so it disappears from every tab. Two acceptable shapes — pick whichever is simplest at implementation time:

1. **Delete entirely** — drop the `$("footer").textContent = ...` assignment and the `<footer id="footer">` element. Preferred.
2. **Trim** to `orbit dashboard · auto-refresh 30s` (no route blob).

Implementer's call; default to option 1 unless there's a concrete reason to keep the auto-refresh label visible.

## Constraints / Notes

- Single-page app with a shared shell — fixing it once in `index.html` + `app.js` removes the footer from every view.
- Single-file JS asset; no build step. Changes are picked up on next server restart because `include_str!` embeds the asset at compile time.
- No tests cover this footer; verification is by loading the dashboard, navigating between tabs, and visually confirming the route string is gone everywhere.
- Do not touch unrelated dashboard rendering logic in the same change.

### Acceptance Criteria

- After the change, loading the dashboard and navigating to each tab/view (tasks, runs, frictions, diagnostics, learnings, adrs, scoreboard, etc.) shows no rendered text containing `GET /api/{tasks` on any view, including after at least one 30s auto-refresh cycle (verify via DOM inspection or rendered output on each tab).
- If option 1 is taken: `crates/orbit-cli/assets/dashboard/app.js` contains no assignment that writes a string containing `GET /api/` into the footer element, AND `crates/orbit-cli/assets/dashboard/index.html` contains no `<footer id="footer">` element (verify with `grep -n 'GET /api/' crates/orbit-cli/assets/dashboard/app.js` returning no matches and `grep -n 'id="footer"' crates/orbit-cli/assets/dashboard/index.html` returning no matches).
- If option 2 is taken: the only footer text rendered (on every view) is exactly `orbit dashboard · auto-refresh 30s` with no trailing `· GET ...` segment (verify by reading the assignment in app.js).
- No other dashboard behavior changes — the auto-refresh interval, fetched endpoints, and rendered tabs remain identical (verify by diff: changes confined to the footer assignment line in app.js and optionally the footer element in index.html).
- `make ci-fast` passes.

## Execution Summary

<details>
<summary>Click to expand</summary>

Removed the API route inventory from the shared dashboard footer (option 1: delete entirely).

Changes:
- Removed the entire `$("footer").textContent = `...GET /api/{...}`` assignment (the source of the drifting route list) from the end of refreshDashboard() in app.js.
- Removed the `<footer id="footer"></footer>` element from index.html (the shared shell rendered on every tab/view).

Why option 1: simplest, matches preferred path in task; the static "auto-refresh 30s" label added no value (live refresh status lives in header meta), and removing reclaims viewport space on all tabs.

Validation:
- `grep -n 'GET /api/' crates/orbit-cli/assets/dashboard/app.js` → no matches
- `grep -n 'id="footer"' crates/orbit-cli/assets/dashboard/index.html` → no matches
- `make ci-fast` → exit 0 (fmt-check + all guardrails passed)
- Confirmed no other source locations emit the string into rendered dashboard output (historical benchmark trace only)
- git diff confined exactly to the footer assignment line + the footer element line.

No prior related tasks or learnings required action. No learning checkpoint (no >10min debug, no contradicted assumptions, no recurring failure mode surfaced). Changes are picked up on next `orbit dashboard` restart via include_str! embed.

Execution agent: grok-build (this run).

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-00082-6a090ea5`
- Behind base: 0
- Ahead of base: 1