### PR TITLE
Render ADR and learning body as markdown in dashboard Knowledge tab

### DIFF
--- a/crates/orbit-cli/assets/dashboard/app.js
+++ b/crates/orbit-cli/assets/dashboard/app.js
@@ -341,6 +341,23 @@ function syncNodes(container, newNodesArr) {
   }
 }
 
+function renderBodyBlock(body, fallbackClass) {
+  if (!body || !body.trim()) return null;
+  const isMarked = typeof marked !== "undefined";
+  const view = el(isMarked ? "div" : "pre", {
+    class: isMarked ? "markdown-body" : fallbackClass,
+  });
+  if (isMarked) {
+    view.innerHTML = marked.parse(body);
+  } else {
+    view.textContent = body;
+  }
+  return el("div", { class: "field-block" }, [
+    el("h4", { text: "body" }),
+    view,
+  ]);
+}
+
 function filterTasks(tasks) {
   const q = searchQuery;
   return tasks.filter((t) => {
@@ -1766,10 +1783,7 @@ function renderLearningDetail(learning) {
     el("div", { class: "learning-detail-scope" }, learningScopeNodes(learning)),
   ]);
 
-  const bodyBlock = el("div", { class: "field-block" }, [
-    el("h4", { text: "body" }),
-    el("pre", { class: "learning-detail-body", text: learning.body || "" }),
-  ]);
+  const bodyBlock = renderBodyBlock(learning.body, "learning-detail-body");
 
   const actions = el("div", { class: "actions" });
   const supersede = el("button", {
@@ -1785,7 +1799,10 @@ function renderLearningDetail(learning) {
   });
   actions.appendChild(supersede);
 
-  syncNodes(detail, [title, meta, scopeBlock, bodyBlock, actions]);
+  const nodes = [title, meta, scopeBlock];
+  if (bodyBlock) nodes.push(bodyBlock);
+  nodes.push(actions);
+  syncNodes(detail, nodes);
 }
 
 async function supersedeLearning(learning, by, btn, detail) {
@@ -2179,10 +2196,7 @@ function renderAdrDetail(adr) {
       ...(adr.superseded_by ? [`superseded_by ${adr.superseded_by}`] : []),
     ]),
   ]);
-  const bodyBlock = el("div", { class: "field-block" }, [
-    el("h4", { text: "body" }),
-    el("pre", { class: "adr-detail-body", text: adr.body || "" }),
-  ]);
+  const bodyBlock = renderBodyBlock(adr.body, "adr-detail-body");
 
   const actions = el("div", { class: "actions" });
   if (adr.status === "proposed") {
@@ -2208,7 +2222,8 @@ function renderAdrDetail(adr) {
     actions.appendChild(supersede);
   }
 
-  const nodes = [title, meta, featuresBlock, tasksBlock, edgesBlock, bodyBlock];
+  const nodes = [title, meta, featuresBlock, tasksBlock, edgesBlock];
+  if (bodyBlock) nodes.push(bodyBlock);
   if (actions.children.length > 0) nodes.push(actions);
   syncNodes(detail, nodes);
 }


### PR DESCRIPTION
## Task

[ORB-00083](https://orbit-cli.com/tasks/ORB-00083) — Render ADR and learning body as markdown in dashboard Knowledge tab

### Description

## Problem

In the web dashboard Knowledge tab, the `body` field of ADRs and learnings is rendered as raw text inside a `<pre>` element. Markdown syntax (`##` headings, `-` bullet lists, fenced code blocks, etc.) is shown literally instead of being formatted.

Example: viewing ORB-00019 in the Knowledge tab shows the body as raw markdown including the literal `## Context`, `## Decision`, `## Consequences` markers and unrendered bullet points.

Reference sites:
- `crates/orbit-cli/assets/dashboard/app.js:2182-2185` — `renderAdrDetail` builds `el("pre", { class: "adr-detail-body", text: adr.body || "" })`.
- `crates/orbit-cli/assets/dashboard/app.js:1769-1772` — `renderLearningDetail` builds `el("pre", { class: "learning-detail-body", text: learning.body || "" })`.

## Why It Matters

ADR and learning bodies are authored in markdown (`docs/design/CONVENTIONS.md`, `.orbit/learnings/*.yaml` body fields). The dashboard is the primary GUI for browsing them; raw-text rendering makes structure illegible and undercuts the value of the Knowledge tab.

## Constraints / Notes

- `marked` is already loaded via CDN in `crates/orbit-cli/assets/dashboard/index.html:10` and used elsewhere in `app.js` (task description at `app.js:614-617`, plan at `app.js:639-641`, execution summary at `app.js:649-651`, artifact preview at `app.js:523-530`).
- Follow the existing pattern: guard with `typeof marked !== "undefined"`; fall back to `<pre>` rendering when `marked` is absent (matches the task-detail behavior).
- Preserve the existing `.adr-detail-body` / `.learning-detail-body` class hooks if any styling references them (check `crates/orbit-cli/assets/dashboard/` CSS / inline styles in `index.html`); otherwise switch to the `markdown-body` class already used for rendered markdown blocks.
- Pure frontend change in `app.js`; no backend / API contract changes.
- Out of scope: editing markdown inline, syntax highlighting inside code fences, sanitization beyond what `marked` provides (note the file already uses `marked.parse(...)` -> `innerHTML` for trusted internal content — match that trust boundary).

### Acceptance Criteria

- Opening the Knowledge tab > ADRs in the dashboard and selecting an ADR whose `body` contains markdown (e.g. ORB-00019 with `## Context` / `## Decision` / `## Consequences` sections and bullet lists) renders the body as formatted HTML: `##` lines become `<h2>` headings and `-` lines become `<ul><li>` bullets — verified by inspecting the DOM under the body field block.
- Opening the Knowledge tab > Learnings in the dashboard and selecting a learning whose `body` contains markdown renders that body as formatted HTML using the same rendering path as ADRs.
- When `marked` is unavailable (e.g. CDN blocked, simulated by `window.marked = undefined` before `renderAdrDetail`/`renderLearningDetail` runs), the body still renders as readable plain text inside a `<pre>` (or visually equivalent) element rather than throwing or producing empty output — matches the fallback pattern used at `app.js:614-617`.
- An empty or missing `body` (e.g. `adr.body === ""` or `undefined`) renders without errors and without leaving an empty `<h2>body</h2>` block that is visually misleading — current empty-state behavior preserved or improved, not regressed.
- No backend code (`crates/orbit-*` Rust crates) is modified; only `crates/orbit-cli/assets/dashboard/app.js` (and dashboard CSS / `index.html` if class hooks need adjusting) changes. `git diff --stat` on the branch shows changes confined to `crates/orbit-cli/assets/dashboard/`.
- `make ci-fast` passes on the branch before the task moves to review.

## Execution Summary

<details>
<summary>Click to expand</summary>

Updated `app.js` to render ADR and learning bodies as formatted markdown using the existing global `marked` library. Introduced a reusable `renderBodyBlock` helper that conditionally parses markdown into a `.markdown-body` container. It includes a fallback to `<pre>` if `marked` is unavailable and safely omits the body section if the body is empty or missing, ensuring a clean and legible display.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-00083-6a09117f`
- Behind base: 0
- Ahead of base: 1