### PR TITLE
Collapse agent identity to family; isolate model strings to invocation surface

### DIFF
--- a/crates/orbit-cli/src/command/observe/metrics.rs
+++ b/crates/orbit-cli/src/command/observe/metrics.rs
@@ -233,6 +233,7 @@ impl Execute for MetricsInvocationsArgs {
             task_id: self.task_id,
             agent: self.agent,
             model: self.model,
+            slot: None,
             tool_name: self.tool_name,
             limit: self.limit,
         };

--- a/crates/orbit-cli/src/command/web/api/diagnostics_tests.rs
+++ b/crates/orbit-cli/src/command/web/api/diagnostics_tests.rs
@@ -93,6 +93,7 @@ fn diagnostics_metrics_values_adapt_invocation_records() {
         activity_id: "implement_one".to_string(),
         agent: "codex".to_string(),
         model: Some("gpt-5.5".to_string()),
+        slot: None,
         duration_ms: 1234,
         input_tokens: 100,
         cache_read_tokens: 0,

--- a/crates/orbit-common/src/types/agent_family.rs
+++ b/crates/orbit-common/src/types/agent_family.rs
@@ -1,0 +1,68 @@
+use std::fmt::{Display, Formatter};
+use std::str::FromStr;
+
+use serde::{Deserialize, Serialize};
+
+use super::OrbitError;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum AgentFamily {
+    Codex,
+    Claude,
+    Gemini,
+    Grok,
+}
+
+impl AgentFamily {
+    pub const ALL: [Self; 4] = [Self::Codex, Self::Claude, Self::Gemini, Self::Grok];
+
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Codex => "codex",
+            Self::Claude => "claude",
+            Self::Gemini => "gemini",
+            Self::Grok => "grok",
+        }
+    }
+
+    pub fn parse(value: &str) -> Result<Self, OrbitError> {
+        value.parse()
+    }
+}
+
+impl Display for AgentFamily {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl FromStr for AgentFamily {
+    type Err = OrbitError;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value.trim().to_ascii_lowercase().as_str() {
+            "codex" => Ok(Self::Codex),
+            "claude" => Ok(Self::Claude),
+            "gemini" => Ok(Self::Gemini),
+            "grok" => Ok(Self::Grok),
+            other => Err(OrbitError::InvalidInput(format!(
+                "unknown agent family '{other}'; expected one of codex, claude, gemini, grok"
+            ))),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn agent_family_serializes_as_lowercase_and_rejects_aliases() {
+        assert_eq!(
+            serde_json::to_string(&AgentFamily::Gemini).expect("serialize family"),
+            "\"gemini\""
+        );
+        assert!(AgentFamily::from_str("pro").is_err());
+    }
+}

--- a/crates/orbit-common/src/types/agent_pair.rs
+++ b/crates/orbit-common/src/types/agent_pair.rs
@@ -14,7 +14,7 @@ use std::path::Path;
 
 use serde::{Deserialize, Serialize};
 
-use super::OrbitError;
+use super::{AgentFamily, OrbitError};
 
 /// A resolved (orchestrator, helper) duo for a given agent family.
 ///
@@ -92,7 +92,12 @@ pub fn resolve_crew(name: &str, registry: &BTreeMap<String, Crew>) -> Result<Cre
 /// changing the array size, which in turn surfaces any call site that
 /// made assumptions about the previous number of families.
 pub const fn all_agent_families() -> [&'static str; 4] {
-    ["codex", "claude", "gemini", "grok"]
+    [
+        AgentFamily::Codex.as_str(),
+        AgentFamily::Claude.as_str(),
+        AgentFamily::Gemini.as_str(),
+        AgentFamily::Grok.as_str(),
+    ]
 }
 
 /// Normalize an `agent_cli` value into a stable, lowercased family identifier
@@ -163,39 +168,6 @@ pub fn normalize_agent_family_for_model(
     }
 
     Ok(agent.or(inferred))
-}
-
-/// Resolve the orchestrator/helper model pair for an `agent_cli`.
-///
-/// Returns `None` for unknown agent families. Callers that need a fallback
-/// (for example, the runtime envelope renderer) decide what placeholder text
-/// to inject when no mapping is registered.
-pub fn resolve_agent_model_pair(agent_cli: &str) -> Option<AgentModelPair> {
-    resolve_agent_model_pair_or(agent_cli, None)
-}
-
-/// Resolve the orchestrator/helper model pair for an `agent_cli`, allowing a
-/// caller-supplied override to replace the built-in defaults.
-///
-/// This is the config-aware hook used by upstream crates that have access to
-/// runtime configuration. `orbit-common::types` remains the fallback source of
-/// truth for default model pairs.
-pub fn resolve_agent_model_pair_or(
-    agent_cli: &str,
-    config_override: Option<&AgentModelPair>,
-) -> Option<AgentModelPair> {
-    if let Some(override_pair) = config_override {
-        return Some(override_pair.clone());
-    }
-
-    let family = agent_family_from_cli(agent_cli);
-    match family.as_str() {
-        "codex" => Some(AgentModelPair::new("gpt-5.5", "gpt-5.4-mini")),
-        "claude" => Some(AgentModelPair::new("opus-4.7", "sonnet-4.6")),
-        "gemini" => Some(AgentModelPair::new("pro", "flash")),
-        "grok" => Some(AgentModelPair::new("grok-4", "grok-3")),
-        _ => None,
-    }
 }
 
 #[cfg(test)]

--- a/crates/orbit-common/src/types/duel.rs
+++ b/crates/orbit-common/src/types/duel.rs
@@ -26,7 +26,7 @@
 //! must bump `schema_version` on the enclosing scoreboard file and add a
 //! migration path in `orbit-store::file::duel_scoreboard`.
 
-use crate::types::invocation::TokenUsage;
+use crate::types::{AgentFamily, OrbitError, invocation::TokenUsage};
 use serde::{Deserialize, Serialize};
 
 // ============================================================================
@@ -285,6 +285,54 @@ pub enum PlannerSlot {
     PlannerB,
 }
 
+/// Role slot for a planning-duel participant.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[serde(rename_all = "snake_case")]
+pub enum RoleSlot {
+    PlannerA,
+    PlannerB,
+    Arbiter,
+}
+
+impl RoleSlot {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::PlannerA => "planner_a",
+            Self::PlannerB => "planner_b",
+            Self::Arbiter => "arbiter",
+        }
+    }
+
+    pub const fn planner_slot(self) -> Option<PlannerSlot> {
+        match self {
+            Self::PlannerA => Some(PlannerSlot::PlannerA),
+            Self::PlannerB => Some(PlannerSlot::PlannerB),
+            Self::Arbiter => None,
+        }
+    }
+}
+
+impl std::fmt::Display for RoleSlot {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl std::str::FromStr for RoleSlot {
+    type Err = crate::types::OrbitError;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value.trim() {
+            "planner_a" => Ok(Self::PlannerA),
+            "planner_b" => Ok(Self::PlannerB),
+            "arbiter" => Ok(Self::Arbiter),
+            other => Err(crate::types::OrbitError::InvalidInput(format!(
+                "unknown planning-duel role slot '{other}'; expected planner_a, planner_b, or arbiter"
+            ))),
+        }
+    }
+}
+
 /// Reusable efficiency payload for a single role in a planning duel.
 ///
 /// Token usage is stored exactly when available. When the runtime cannot
@@ -325,21 +373,67 @@ impl EfficiencyMetrics {
     }
 }
 
-/// Agent/model assignment for one side of a planning duel.
+/// Agent-family assignment for one side of a planning duel.
+///
+/// The field that contains this assignment (`planner_a`, `planner_b`, or
+/// `arbiter`) is the role slot. Exact model strings live in invocation
+/// configuration and are intentionally absent from this identity schema.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 #[serde(deny_unknown_fields)]
 pub struct PlanningRoleAssignment {
-    pub agent: String,
-    pub model: String,
+    pub family: AgentFamily,
 }
 
 /// The three role assignments for a planning duel.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(deny_unknown_fields)]
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 pub struct PlanningRoles {
     pub planner_a: PlanningRoleAssignment,
     pub planner_b: PlanningRoleAssignment,
     pub arbiter: PlanningRoleAssignment,
+}
+
+impl<'de> Deserialize<'de> for PlanningRoles {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        #[derive(Deserialize)]
+        #[serde(deny_unknown_fields)]
+        struct RawPlanningRoles {
+            planner_a: serde_json::Value,
+            planner_b: serde_json::Value,
+            arbiter: serde_json::Value,
+        }
+
+        let raw = RawPlanningRoles::deserialize(deserializer)?;
+        Ok(Self {
+            planner_a: deserialize_planning_assignment(raw.planner_a)
+                .map_err(serde::de::Error::custom)?,
+            planner_b: deserialize_planning_assignment(raw.planner_b)
+                .map_err(serde::de::Error::custom)?,
+            arbiter: deserialize_planning_assignment(raw.arbiter)
+                .map_err(serde::de::Error::custom)?,
+        })
+    }
+}
+
+fn deserialize_planning_assignment(
+    value: serde_json::Value,
+) -> Result<PlanningRoleAssignment, OrbitError> {
+    if let Ok(assignment) = serde_json::from_value::<PlanningRoleAssignment>(value.clone()) {
+        return Ok(assignment);
+    }
+
+    let serde_json::Value::Object(map) = value else {
+        return Err(OrbitError::InvalidInput(
+            "planning role assignment must be an object".to_string(),
+        ));
+    };
+    if let Some(family) = map.get("agent").and_then(serde_json::Value::as_str) {
+        return Ok(PlanningRoleAssignment {
+            family: family.parse()?,
+        });
+    }
+    Err(OrbitError::InvalidInput(
+        "planning role assignment must contain `family`".to_string(),
+    ))
 }
 
 /// Arbiter outcome for a planning duel.
@@ -366,13 +460,55 @@ pub struct PlanningDuelRun {
     pub run_id: String,
     pub task_id: String,
     pub completed_at: chrono::DateTime<chrono::Utc>,
+    /// Family selected for each planning-duel slot.
     pub roles: PlanningRoles,
     /// Artifact path for planner A's proposal markdown.
     pub planner_a_artifact_path: String,
     /// Artifact path for planner B's proposal markdown.
     pub planner_b_artifact_path: String,
     pub outcome: PlanningOutcome,
+    /// "Who actually ran?" metrics, attributed by invocation family + slot.
     pub efficiency: PlanningEfficiency,
+}
+
+#[cfg(test)]
+mod planning_schema_tests {
+    use std::str::FromStr;
+
+    use serde_json::json;
+
+    use super::*;
+
+    #[test]
+    fn planning_assignment_is_family_only_and_rejects_model_field() {
+        let assignment = PlanningRoleAssignment {
+            family: AgentFamily::Gemini,
+        };
+        let value = serde_json::to_value(&assignment).expect("serialize assignment");
+        assert_eq!(value, json!({ "family": "gemini" }));
+
+        let round_trip: PlanningRoleAssignment =
+            serde_json::from_value(value).expect("deserialize assignment");
+        assert_eq!(round_trip, assignment);
+
+        let with_model = serde_json::from_value::<PlanningRoleAssignment>(json!({
+            "family": "gemini",
+            "model": "pro"
+        }));
+        assert!(with_model.is_err());
+    }
+
+    #[test]
+    fn role_slot_serializes_as_snake_case() {
+        assert_eq!(
+            serde_json::to_string(&RoleSlot::PlannerA).expect("serialize slot"),
+            "\"planner_a\""
+        );
+        assert_eq!(
+            RoleSlot::from_str("arbiter").expect("parse slot"),
+            RoleSlot::Arbiter
+        );
+    }
 }
 
 // ============================================================================

--- a/crates/orbit-common/src/types/mod.rs
+++ b/crates/orbit-common/src/types/mod.rs
@@ -24,6 +24,7 @@ pub mod activity;
 pub mod activity_job;
 pub mod actor;
 pub mod adr;
+pub mod agent_family;
 pub mod agent_pair;
 pub mod audit;
 pub mod audit_event;
@@ -64,18 +65,18 @@ pub use actor::{
     normalize_optional_attribution_label, provider_from_model,
 };
 pub use adr::{Adr, AdrStatus, LegacyValidation, legacy_id_for, validate_adr_id};
+pub use agent_family::AgentFamily;
 pub use agent_pair::{
     AgentModelPair, Crew, CrewRoleAssignment, agent_family_from_cli, all_agent_families,
-    infer_agent_family_from_model, normalize_agent_family_for_model, resolve_agent_model_pair,
-    resolve_crew,
+    infer_agent_family_from_model, normalize_agent_family_for_model, resolve_crew,
 };
 pub use audit::Audit;
 pub use audit_event::{AuditEvent, AuditEventStatus, AuditStats, audit_execution_id};
 pub use duel::{
     Ambiguity, ArbiterVerdict, Cost, Decision, DuelRun, EfficiencyMetrics, ImplementerStats,
     Outcome, PerCommentVerdict, PlannerSlot, PlanningDuelRun, PlanningEfficiency, PlanningOutcome,
-    PlanningRoleAssignment, PlanningRoles, ReviewerStats, RoleAssignment, Roles, Scores, Severity,
-    TaskClass, TaskScope, ValidIssuesBySeverity, Verdict,
+    PlanningRoleAssignment, PlanningRoles, ReviewerStats, RoleAssignment, RoleSlot, Roles, Scores,
+    Severity, TaskClass, TaskScope, ValidIssuesBySeverity, Verdict,
 };
 pub use error::{NotFoundKind, OrbitError};
 pub use event::OrbitEvent;

--- a/crates/orbit-core/src/command/tool.rs
+++ b/crates/orbit-core/src/command/tool.rs
@@ -311,7 +311,11 @@ fn resolve_agent_identity(
         (env_agent_name, env_model_name)
     };
     let agent = normalize_agent_family_for_model(agent.as_deref(), model.as_deref())?;
-    Ok((agent, model))
+    // Tool-call identity crosses a trust boundary: agent-supplied `model`
+    // strings are telemetry at best and may be aliases. Persist the canonical
+    // family in the model slot for tool dispatch so comparisons never depend
+    // on self-reported model text.
+    Ok((agent.clone(), agent))
 }
 
 fn read_proc_allowed_programs_from_env() -> Vec<String> {
@@ -343,11 +347,12 @@ fn read_activity_tools_from_env() -> Vec<String> {
         .unwrap_or_default()
 }
 
-/// Resolve the audit `role` label for a tool invocation. Mirrors the precedence
-/// of the CLI's `tool_run_actor_role` exactly:
-/// 1. input JSON `agent`/`model` fields, then
-/// 2. flag overrides (CLI `--agent`/`--model`; MCP passes `None`), then
-/// 3. `ORBIT_AGENT_NAME`/`ORBIT_AGENT_MODEL` env vars.
+/// Resolve the audit `role` label for a tool invocation.
+///
+/// Runtime envelope identity (`ORBIT_AGENT_*`) is authoritative for agent
+/// activities and overwrites any self-reported `model` field in tool JSON.
+/// Manual CLI/MCP calls without an envelope keep the legacy input/flag
+/// precedence.
 pub fn audit_role_label(
     input: &Value,
     agent_override: Option<&str>,
@@ -363,7 +368,14 @@ pub fn audit_role_label(
     let has_input_identity = input_agent.is_some() || input_model.is_some();
     let has_flag_identity = agent_override.is_some_and(|value| !value.trim().is_empty())
         || model_override.is_some_and(|value| !value.trim().is_empty());
-    let (agent, model) = if has_input_identity {
+    let has_env_identity = env_agent.is_some() || env_model.is_some();
+    let (agent, model) = if has_env_identity && !has_flag_identity {
+        let agent = normalize_agent_family_for_model(env_agent.as_deref(), env_model.as_deref())
+            .ok()
+            .flatten()
+            .or(env_agent);
+        (agent.clone(), agent)
+    } else if has_input_identity {
         (input_agent, input_model)
     } else if has_flag_identity {
         (
@@ -899,7 +911,16 @@ mod audit_tests {
         set_identity_env("claude", "opus-4.6");
         let role = audit_role_label(&json!({ "query": "x" }), None, None);
         clear_identity_env();
-        assert_eq!(role, "opus-4.6");
+        assert_eq!(role, "claude");
+    }
+
+    #[test]
+    fn audit_role_label_overwrites_self_reported_model_with_env_family() {
+        let _g = env_guard();
+        set_identity_env("claude", "claude-opus-4-7");
+        let role = audit_role_label(&json!({ "model": "opus-4.7" }), None, None);
+        clear_identity_env();
+        assert_eq!(role, "claude");
     }
 
     #[test]

--- a/crates/orbit-core/src/runtime/engine/crew.rs
+++ b/crates/orbit-core/src/runtime/engine/crew.rs
@@ -120,9 +120,10 @@ impl OrbitRuntime {
 
     /// Resolve a crew/role-model projection for `orbit.task.show` consumers.
     ///
-    /// Audit-trail truth comes first: when the task points at a run record that
+    /// Selection truth comes first: when the task points at a run record that
     /// persisted the resolved crew, those four strings win — they reflect what
-    /// actually ran, even if the workspace registry has been edited since.
+    /// was selected for routing, even if the workspace registry has been edited
+    /// since. "Who actually ran?" projections read invocation records instead.
     ///
     /// Best-effort otherwise: if neither the task nor the workspace can name a
     /// crew, `Ok(None)` so readers (CLI, MCP) can omit the fields instead of

--- a/crates/orbit-core/src/runtime/engine/envelope.rs
+++ b/crates/orbit-core/src/runtime/engine/envelope.rs
@@ -2,7 +2,6 @@ use std::path::{Path, PathBuf};
 
 use orbit_common::types::{
     Activity, AgentModelPair, OrbitError, Task, agent_family_from_cli, prune_missing_context_files,
-    resolve_agent_model_pair,
 };
 use orbit_engine::{ExecutionContext, TaskHost};
 use serde::Serialize;
@@ -158,7 +157,6 @@ fn activity_envelope_json_for_execution_with_pair(
     agent_cli: &str,
     pair: Option<AgentModelPair>,
 ) -> Value {
-    let pair = pair.or_else(|| resolve_agent_model_pair(agent_cli));
     let family = agent_family_from_cli(agent_cli);
     let orchestrator = pair.as_ref().map(|p| p.orchestrator.as_str()).unwrap_or("");
     let helper = pair.as_ref().map(|p| p.helper.as_str()).unwrap_or("");

--- a/crates/orbit-core/src/runtime/engine/identity.rs
+++ b/crates/orbit-core/src/runtime/engine/identity.rs
@@ -1,7 +1,4 @@
-use orbit_common::types::{
-    AgentModelPair, OrbitError, agent_family_from_cli, normalize_agent_family_for_model,
-    resolve_agent_model_pair,
-};
+use orbit_common::types::{AgentModelPair, OrbitError, normalize_agent_family_for_model};
 
 use crate::OrbitRuntime;
 
@@ -24,41 +21,6 @@ impl OrbitRuntime {
                 def.model_pair_override()
                     .map(|pair| AgentModelPair::new(pair.strong.clone(), pair.weak.clone()))
             })
-            .or_else(|| resolve_agent_model_pair(agent_cli))
-    }
-
-    pub(crate) fn canonical_model_for_agent(
-        &self,
-        agent_cli: &str,
-        model: Option<&str>,
-    ) -> Option<String> {
-        let requested = model.map(str::trim).filter(|value| !value.is_empty())?;
-        let pair = self.configured_agent_model_pair(agent_cli);
-        let family = agent_family_from_cli(agent_cli);
-
-        if requested.eq_ignore_ascii_case("strong") {
-            return pair.map(|pair| pair.orchestrator);
-        }
-        if requested.eq_ignore_ascii_case("weak") {
-            return pair.map(|pair| pair.helper);
-        }
-
-        if let Some(pair) = pair {
-            if requested.eq_ignore_ascii_case(&pair.orchestrator) {
-                return Some(pair.orchestrator);
-            }
-            if requested.eq_ignore_ascii_case(&pair.helper) {
-                return Some(pair.helper);
-            }
-            if matches_model_alias(&family, requested, &pair.orchestrator, true) {
-                return Some(pair.orchestrator);
-            }
-            if matches_model_alias(&family, requested, &pair.helper, false) {
-                return Some(pair.helper);
-            }
-        }
-
-        Some(requested.to_string())
     }
 
     pub(crate) fn canonical_agent_model_identity(
@@ -76,11 +38,10 @@ impl OrbitRuntime {
         model: Option<&str>,
     ) -> Result<(Option<String>, Option<String>), OrbitError> {
         let agent = normalize_agent_family_for_model(agent_cli, model)?;
-        let requested_model = model.map(str::trim).filter(|value| !value.is_empty());
-        let model = agent
-            .as_deref()
-            .and_then(|agent| self.canonical_model_for_agent(agent, requested_model))
-            .or_else(|| requested_model.map(ToOwned::to_owned));
+        let model = model
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(ToOwned::to_owned);
         Ok((agent, model))
     }
 
@@ -92,59 +53,10 @@ impl OrbitRuntime {
         let agent = agent_cli
             .map(normalize_agent_name)
             .filter(|value| !value.trim().is_empty());
-        let model = agent
-            .as_deref()
-            .and_then(|agent| self.canonical_model_for_agent(agent, model))
-            .or_else(|| {
-                model
-                    .map(str::trim)
-                    .filter(|value| !value.is_empty())
-                    .map(ToOwned::to_owned)
-            });
+        let model = model
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(ToOwned::to_owned);
         (agent, model)
     }
-}
-
-fn matches_model_alias(family: &str, requested: &str, configured: &str, strong: bool) -> bool {
-    if requested.eq_ignore_ascii_case(configured) {
-        return true;
-    }
-
-    if let Some(default_pair) = resolve_agent_model_pair(family) {
-        let fallback = if strong {
-            default_pair.orchestrator
-        } else {
-            default_pair.helper
-        };
-        if requested.eq_ignore_ascii_case(&fallback) {
-            return true;
-        }
-    }
-
-    match (family, strong) {
-        ("claude", true) => {
-            requested.eq_ignore_ascii_case("opus")
-                || claude_cli_full_model_name(configured)
-                    .is_some_and(|value| requested.eq_ignore_ascii_case(&value))
-        }
-        ("claude", false) => {
-            requested.eq_ignore_ascii_case("sonnet")
-                || claude_cli_full_model_name(configured)
-                    .is_some_and(|value| requested.eq_ignore_ascii_case(&value))
-        }
-        ("gemini", true) => requested.eq_ignore_ascii_case("gemini-3.1-pro"),
-        ("gemini", false) => requested.eq_ignore_ascii_case("gemini-3-flash"),
-        _ => false,
-    }
-}
-
-fn claude_cli_full_model_name(model: &str) -> Option<String> {
-    let trimmed = model.trim();
-    if let Some(version) = trimmed.strip_prefix("opus-") {
-        return Some(format!("claude-opus-{}", version.replace('.', "-")));
-    }
-    if let Some(version) = trimmed.strip_prefix("sonnet-") {
-        return Some(format!("claude-sonnet-{}", version.replace('.', "-")));
-    }
-    None
 }

--- a/crates/orbit-core/src/runtime/engine/runtime_host.rs
+++ b/crates/orbit-core/src/runtime/engine/runtime_host.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use orbit_common::types::{
     Activity, AgentModelPair, InvocationTrace, JobRunState, JobTargetType, OrbitError, OrbitEvent,
-    Role,
+    Role, RoleSlot,
 };
 use orbit_engine::{ActivityInvocationResult, ExecutionContext, ExecutorHost, RuntimeHost};
 use orbit_store::{InvocationInsertParams, InvocationQuery, InvocationRecord, token_scoreboard};
@@ -74,7 +74,11 @@ impl RuntimeHost for OrbitRuntime {
     }
 
     fn canonical_model_name(&self, agent_cli: &str, model: Option<&str>) -> Option<String> {
-        self.canonical_model_for_agent(agent_cli, model)
+        let _ = agent_cli;
+        model
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(ToOwned::to_owned)
     }
 
     fn invocation_records(
@@ -202,6 +206,7 @@ impl RuntimeHost for OrbitRuntime {
             activity_id: execution.activity.id.clone(),
             agent: agent.unwrap_or_else(|| normalize_agent_name(&execution.agent_cli)),
             model,
+            slot: role_slot_from_input(&execution.input),
             task_ids: associated_task_ids(&execution.input),
             trace: trace.clone(),
         })?;
@@ -218,6 +223,15 @@ impl RuntimeHost for OrbitRuntime {
 
         Ok(())
     }
+}
+
+fn role_slot_from_input(input: &Value) -> Option<RoleSlot> {
+    input
+        .get("planning_duel_slot")
+        .or_else(|| input.get("role_slot"))
+        .or_else(|| input.get("slot"))
+        .and_then(Value::as_str)
+        .and_then(|value| value.parse().ok())
 }
 
 fn is_planning_duel_agent_activity(activity_id: &str) -> bool {

--- a/crates/orbit-core/src/runtime/orbit_tool_host/task_tools_tests.rs
+++ b/crates/orbit-core/src/runtime/orbit_tool_host/task_tools_tests.rs
@@ -108,13 +108,14 @@ fn duel_plan_add_persists_gemini_planner_artifact() {
         TaskStatus::InProgress,
         &[],
     );
-    let content = "*authored by: gemini / gemini-3.1-pro*\n## Plan\nPersist through Orbit tools.";
+    let content = "## Plan\nPersist through Orbit tools.";
 
     runtime
         .execute_tool_command(
             "orbit.duel.plan.add",
             json!({
                 "id": task.id.clone(),
+                "planning_duel_slot": "planner_a",
                 "content": content,
             }),
             Some("gemini".to_string()),
@@ -127,9 +128,12 @@ fn duel_plan_add_persists_gemini_planner_artifact() {
         .expect("read task artifacts");
     let artifact = artifacts
         .iter()
-        .find(|artifact| artifact.path == "planning-duel/gemini-gemini-3.1-pro.md")
+        .find(|artifact| artifact.path == "planning-duel/planner_a.md")
         .expect("gemini planner artifact");
-    assert_eq!(artifact.text_content(), Some(content));
+    assert_eq!(
+        artifact.text_content(),
+        Some("*authored by: gemini / planner_a*\n## Plan\nPersist through Orbit tools.")
+    );
 }
 
 #[test]
@@ -153,8 +157,7 @@ fn duel_plan_winner_persists_gemini_arbiter_artifact() {
             "orbit.duel.plan.winner",
             json!({
                 "id": task.id.clone(),
-                "winner_agent_cli": "claude",
-                "winner_model": "claude-opus-4-7",
+                "winner_slot": "planner_a",
                 "arbiter_rationale": "Tighter scope and clearer staged plan.",
             }),
             Some("gemini".to_string()),
@@ -173,14 +176,9 @@ fn duel_plan_winner_persists_gemini_arbiter_artifact() {
         .text_content()
         .expect("winner.json must be text content");
     let payload: Value = serde_json::from_str(raw).expect("winner.json is valid JSON");
-    assert_eq!(payload["winner_agent_cli"], "claude");
-    assert_eq!(payload["winner_model"], "claude-opus-4-7");
-    assert_eq!(payload["arbiter_agent_cli"], "gemini");
-    assert_eq!(payload["arbiter_model"], "gemini-3.1-pro");
-    assert_eq!(
-        payload["artifact_path"],
-        "planning-duel/claude-claude-opus-4-7.md"
-    );
+    assert_eq!(payload["winner_slot"], "planner_a");
+    assert_eq!(payload["arbiter_family"], "gemini");
+    assert_eq!(payload["artifact_path"], "planning-duel/planner_a.md");
     assert_eq!(
         payload["arbiter_rationale"],
         "Tighter scope and clearer staged plan."
@@ -244,7 +242,7 @@ fn friction_add_writes_markdown_record_and_validates_tags() {
     let raw = std::fs::read_to_string(path).expect("read friction markdown");
     assert!(raw.starts_with("---\n"), "{raw}");
     assert!(raw.contains("id: F"), "{raw}");
-    assert!(raw.contains("model: gpt-5.5"), "{raw}");
+    assert!(raw.contains("model: codex"), "{raw}");
     assert!(raw.contains("tooling"), "{raw}");
     assert!(raw.contains("skill-guidance"), "{raw}");
 
@@ -281,7 +279,7 @@ fn friction_stats_does_not_write_state_scoreboard_file() {
         )
         .expect("stats succeeds");
     assert_eq!(
-        stats["by_model"]["gpt-zero"]["frictions_per_10_tasks"],
+        stats["by_family"]["codex"]["frictions_per_10_tasks"],
         json!("n/a")
     );
     assert!(

--- a/crates/orbit-core/src/runtime/v2_host/mod.rs
+++ b/crates/orbit-core/src/runtime/v2_host/mod.rs
@@ -24,7 +24,7 @@ use std::sync::Arc;
 
 use orbit_common::types::activity_job::AgentRole;
 use orbit_common::types::{
-    InvocationTrace, LearningInjectionCaps, LearningReminder, UNRESTRICTED_FS_PROFILE,
+    InvocationTrace, LearningInjectionCaps, LearningReminder, RoleSlot, UNRESTRICTED_FS_PROFILE,
 };
 use orbit_engine::{AgentRoleConfig, EnvironmentHost};
 use orbit_engine::{DispatchError, ResolvedCliExecutor, ResolvedSandbox, V2RuntimeHost};
@@ -144,6 +144,7 @@ impl V2RuntimeHost for OrbitRuntime {
                 activity_id: activity_id.to_string(),
                 agent: agent.unwrap_or_else(|| provider.to_ascii_lowercase()),
                 model,
+                slot: role_slot_from_input(input),
                 task_ids: task_context::associated_task_ids(input),
                 trace: trace.clone(),
             })
@@ -213,4 +214,13 @@ impl V2RuntimeHost for OrbitRuntime {
             ))),
         }
     }
+}
+
+fn role_slot_from_input(input: &Value) -> Option<RoleSlot> {
+    input
+        .get("planning_duel_slot")
+        .or_else(|| input.get("role_slot"))
+        .or_else(|| input.get("slot"))
+        .and_then(Value::as_str)
+        .and_then(|value| value.parse().ok())
 }

--- a/crates/orbit-core/src/runtime/v2_host/sandbox.rs
+++ b/crates/orbit-core/src/runtime/v2_host/sandbox.rs
@@ -152,7 +152,7 @@ fn append_codex_side_write_roots(
 /// their MCP/tool calls still execute `orbit ...` as a sandbox-inherited child.
 /// Those child processes initialize the global audit/tool database, the global
 /// task registry + canonical task bundles, and the workspace-local semantic
-/// index before a planner can persist `planning-duel/<agent>-<model>.md`.
+/// index before a planner can persist `planning-duel/<slot>.md`.
 /// Keep the grants path-shaped instead of re-allowing the whole home directory.
 #[cfg(target_os = "macos")]
 fn append_orbit_child_runtime_write_roots(

--- a/crates/orbit-embed/src/vector/store/tasks.rs
+++ b/crates/orbit-embed/src/vector/store/tasks.rs
@@ -70,6 +70,7 @@ mod tests {
             external_refs: Vec::new(),
             relations: Vec::new(),
             job_run_id: None,
+            crew: None,
             tags: Vec::new(),
             created_at: Utc::now(),
             updated_at: Utc::now(),

--- a/crates/orbit-embed/src/vector/task_fields.rs
+++ b/crates/orbit-embed/src/vector/task_fields.rs
@@ -58,6 +58,7 @@ mod tests {
             external_refs: Vec::new(),
             relations: Vec::new(),
             job_run_id: None,
+            crew: None,
             tags: Vec::new(),
             created_at: Utc::now(),
             updated_at: Utc::now(),

--- a/crates/orbit-embed/tests/parity.rs
+++ b/crates/orbit-embed/tests/parity.rs
@@ -35,6 +35,7 @@ fn fixture_task(id: &str) -> Task {
         external_refs: Vec::new(),
         relations: Vec::new(),
         job_run_id: None,
+        crew: None,
         tags: Vec::new(),
         created_at: Utc::now(),
         updated_at: Utc::now(),

--- a/crates/orbit-engine/src/activity_job/agent_loop_driver.rs
+++ b/crates/orbit-engine/src/activity_job/agent_loop_driver.rs
@@ -26,7 +26,9 @@ use orbit_agent::loop_engine::{
 };
 use orbit_agent::providers::anthropic::AnthropicMessagesTransport;
 use orbit_common::types::activity_job::AgentLoopSpec;
-use orbit_common::types::{LearningInjectionCaps, LearningReminder, prepend_reminder_block};
+use orbit_common::types::{
+    LearningInjectionCaps, LearningReminder, RoleSlot, prepend_reminder_block,
+};
 use orbit_common::utility::learning_session::{
     learning_session_state_path, write_learning_session_state,
 };
@@ -55,11 +57,12 @@ pub fn drive_agent_loop(
     let model = resolve_model(spec);
     let provider = expected_provider();
     let mut session = Session::new(provider, model.clone(), &spec.instruction, None);
-    let tool_ctx = host.tool_context_for_activity(
+    let mut tool_ctx = host.tool_context_for_activity(
         Some(run_id),
         fs_profile,
         Some(v2_fs_audit_logger(audit.clone())),
     );
+    tool_ctx.role_slot = role_slot_from_input(input);
     drive_inner(
         spec,
         api_key,
@@ -88,11 +91,12 @@ pub fn drive_agent_loop_with_session(
     host: &dyn V2RuntimeHost,
     fs_profile: Option<&str>,
 ) -> Result<LoopOutcome, DispatchError> {
-    let tool_ctx = host.tool_context_for_activity(
+    let mut tool_ctx = host.tool_context_for_activity(
         Some(run_id),
         fs_profile,
         Some(v2_fs_audit_logger(audit.clone())),
     );
+    tool_ctx.role_slot = role_slot_from_input(input);
     drive_inner(
         spec,
         api_key,
@@ -103,6 +107,15 @@ pub fn drive_agent_loop_with_session(
         tool_ctx,
         Some(host),
     )
+}
+
+fn role_slot_from_input(input: &Value) -> Option<RoleSlot> {
+    input
+        .get("planning_duel_slot")
+        .or_else(|| input.get("role_slot"))
+        .or_else(|| input.get("slot"))
+        .and_then(Value::as_str)
+        .and_then(|value| value.parse().ok())
 }
 
 /// Drive a v2 agent_loop activity with a caller-supplied ToolContext.

--- a/crates/orbit-engine/src/context.rs
+++ b/crates/orbit-engine/src/context.rs
@@ -5,7 +5,7 @@ use orbit_common::types::{
     Activity, AgentModelPair, ExecutorDef, ExternalRef, InvocationTrace, Job, JobRun, JobRunState,
     JobTargetType, KnowledgeRunMetrics, OrbitError, OrbitEvent, PipelineState, ReviewThread, Role,
     Task, TaskArtifact, TaskComment, TaskHistoryEntry, TaskPriority, TaskStatus,
-    all_agent_families, resolve_agent_model_pair,
+    all_agent_families,
 };
 use orbit_common::utility::redaction::{redact_sensitive_env_json, redact_sensitive_env_option};
 use orbit_exec::EnvironmentMode;
@@ -466,7 +466,8 @@ pub trait RuntimeHost {
         model: Option<&str>,
     ) -> Result<(), OrbitError>;
     fn resolved_agent_model_pair(&self, agent_cli: &str) -> Option<AgentModelPair> {
-        resolve_agent_model_pair(agent_cli)
+        let _ = agent_cli;
+        None
     }
     fn duel_candidate_families(&self) -> Vec<String> {
         all_agent_families()

--- a/crates/orbit-engine/src/executor/automation/duel/planning_duel/artifacts.rs
+++ b/crates/orbit-engine/src/executor/automation/duel/planning_duel/artifacts.rs
@@ -3,8 +3,8 @@ use std::path::{Path, PathBuf};
 
 use chrono::Utc;
 use orbit_common::types::{
-    OrbitError, OrbitEvent, PlannerSlot, PlanningRoleAssignment, PlanningRoles, Role, TaskArtifact,
-    TaskComment,
+    AgentFamily, OrbitError, OrbitEvent, PlanningRoleAssignment, PlanningRoles, Role, RoleSlot,
+    TaskArtifact, TaskComment,
 };
 use orbit_tools::ToolContext;
 use serde_json::{Value, json};
@@ -26,7 +26,52 @@ const TASK_ARTIFACTS_DIR_NAME: &str = "artifacts";
 const AUTHOR_SIGNATURE_PREFIX: &str = "*authored by: ";
 const AUTHOR_SIGNATURE_SEPARATOR: &str = " / ";
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) struct PlanningDuelSignature {
+    pub family: AgentFamily,
+    pub slot: RoleSlot,
+}
+
 pub(super) fn parse_planning_duel_signature(
+    content: &str,
+) -> Result<PlanningDuelSignature, OrbitError> {
+    let first_line = content
+        .lines()
+        .next()
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+        .ok_or_else(|| {
+            OrbitError::InvalidInput(
+                "planning duel artifact must start with an authored-by signature line".to_string(),
+            )
+        })?;
+    let signature = first_line
+        .strip_prefix(AUTHOR_SIGNATURE_PREFIX)
+        .and_then(|value| value.strip_suffix('*'))
+        .ok_or_else(|| {
+            OrbitError::InvalidInput(format!(
+                "planning duel artifact signature must match `{AUTHOR_SIGNATURE_PREFIX}<family> / <slot>*`"
+            ))
+        })?;
+    let (family, slot) = signature
+        .split_once(AUTHOR_SIGNATURE_SEPARATOR)
+        .ok_or_else(|| {
+            OrbitError::InvalidInput(format!(
+                "planning duel artifact signature must contain `{AUTHOR_SIGNATURE_SEPARATOR}`"
+            ))
+        })?;
+    if family.trim().is_empty() || slot.trim().is_empty() {
+        return Err(OrbitError::InvalidInput(
+            "planning duel artifact signature must include both family and slot".to_string(),
+        ));
+    }
+    Ok(PlanningDuelSignature {
+        family: family.trim().parse()?,
+        slot: slot.trim().parse()?,
+    })
+}
+
+fn parse_legacy_planning_duel_signature(
     content: &str,
 ) -> Result<PlanningRoleAssignment, OrbitError> {
     let first_line = content
@@ -43,26 +88,27 @@ pub(super) fn parse_planning_duel_signature(
         .strip_prefix(AUTHOR_SIGNATURE_PREFIX)
         .and_then(|value| value.strip_suffix('*'))
         .ok_or_else(|| {
-            OrbitError::InvalidInput(format!(
-                "planning duel artifact signature must match `{AUTHOR_SIGNATURE_PREFIX}<agent> / <model>*`"
-            ))
+            OrbitError::InvalidInput(
+                "legacy planning duel artifact signature is malformed".to_string(),
+            )
         })?;
-    let (agent, model) = signature
+    let (agent, _) = signature
         .split_once(AUTHOR_SIGNATURE_SEPARATOR)
         .ok_or_else(|| {
-            OrbitError::InvalidInput(format!(
-                "planning duel artifact signature must contain `{AUTHOR_SIGNATURE_SEPARATOR}`"
-            ))
+            OrbitError::InvalidInput(
+                "legacy planning duel artifact signature must contain agent and model".to_string(),
+            )
         })?;
-    if agent.trim().is_empty() || model.trim().is_empty() {
-        return Err(OrbitError::InvalidInput(
-            "planning duel artifact signature must include both agent and model".to_string(),
-        ));
-    }
     Ok(PlanningRoleAssignment {
-        agent: agent.trim().to_string(),
-        model: model.trim().to_string(),
+        family: agent.trim().parse()?,
     })
+}
+
+fn role_slot_from_artifact_path(path: &str) -> Option<RoleSlot> {
+    let name = path
+        .strip_prefix(PLANNING_DUEL_ARTIFACT_PREFIX)?
+        .strip_suffix(PLANNING_DUEL_PLAN_EXTENSION)?;
+    name.parse().ok()
 }
 
 pub(super) fn planning_duel_plan_artifacts(
@@ -81,10 +127,24 @@ pub(super) fn planning_duel_plan_artifacts(
                     artifact.path
                 ))
             })?;
+            let parsed = parse_planning_duel_signature(content);
+            let (author, slot) = match parsed {
+                Ok(signature) => (
+                    PlanningRoleAssignment {
+                        family: signature.family,
+                    },
+                    Some(signature.slot),
+                ),
+                Err(_) => (
+                    parse_legacy_planning_duel_signature(content)?,
+                    role_slot_from_artifact_path(&artifact.path),
+                ),
+            };
             Ok(PlanningDuelPlanArtifact {
                 path: artifact.path.clone(),
                 content: content.to_string(),
-                author: parse_planning_duel_signature(content)?,
+                author,
+                slot,
             })
         })
         .collect::<Result<Vec<_>, OrbitError>>()?;
@@ -100,20 +160,24 @@ pub(super) fn planning_duel_plan_artifacts(
 pub(super) fn plan_artifact_for_assignment<'a>(
     plan_artifacts: &'a [PlanningDuelPlanArtifact],
     assignment: &PlanningRoleAssignment,
+    expected_slot: RoleSlot,
 ) -> Result<&'a PlanningDuelPlanArtifact, OrbitError> {
     let matches = plan_artifacts
         .iter()
-        .filter(|artifact| artifact.author == *assignment)
+        .filter(|artifact| artifact.slot == Some(expected_slot))
         .collect::<Vec<_>>();
     match matches.as_slice() {
-        [artifact] => Ok(*artifact),
+        [artifact] if artifact.author.family == assignment.family => Ok(*artifact),
+        [artifact] => Err(OrbitError::InvalidInput(format!(
+            "planning duel artifact for slot {expected_slot} has family {} but expected {}",
+            artifact.author.family, assignment.family
+        ))),
         [] => Err(OrbitError::InvalidInput(format!(
-            "missing planning duel artifact for {}/{}",
-            assignment.agent, assignment.model
+            "missing planning duel artifact for {} / {}",
+            assignment.family, expected_slot
         ))),
         _ => Err(OrbitError::InvalidInput(format!(
-            "found multiple planning duel artifacts for {}/{}",
-            assignment.agent, assignment.model
+            "found multiple planning duel artifacts for slot {expected_slot}"
         ))),
     }
 }
@@ -156,50 +220,25 @@ fn optional_winner_marker_field(
         .transpose()
 }
 
-fn arbiter_identity_from_marker(
-    marker_agent: Option<String>,
-    marker_model: Option<String>,
-    roles: Option<&PlanningRoles>,
-) -> Result<PlanningRoleAssignment, OrbitError> {
-    match roles {
-        Some(roles) => {
-            if let Some(agent) = marker_agent.as_deref()
-                && agent != roles.arbiter.agent.as_str()
-            {
-                return Err(OrbitError::InvalidInput(format!(
-                    "winner artifact arbiter {}/{} does not match recorded arbiter {}/{}",
-                    agent,
-                    marker_model.as_deref().unwrap_or("<unspecified>"),
-                    roles.arbiter.agent,
-                    roles.arbiter.model
-                )));
-            }
-            if let Some(model) = marker_model.as_deref()
-                && model != roles.arbiter.model.as_str()
-            {
-                return Err(OrbitError::InvalidInput(format!(
-                    "winner artifact arbiter {}/{} does not match recorded arbiter {}/{}",
-                    marker_agent.as_deref().unwrap_or("<unspecified>"),
-                    model,
-                    roles.arbiter.agent,
-                    roles.arbiter.model
-                )));
-            }
-            Ok(roles.arbiter.clone())
-        }
-        None => Ok(PlanningRoleAssignment {
-            agent: marker_agent.ok_or_else(|| {
-                OrbitError::InvalidInput(
-                    "planning duel winner marker requires `arbiter_agent_cli` when `planning_duel_roles` are unavailable".to_string(),
-                )
-            })?,
-            model: marker_model.ok_or_else(|| {
-                OrbitError::InvalidInput(
-                    "planning duel winner marker requires `arbiter_model` when `planning_duel_roles` are unavailable".to_string(),
-                )
-            })?,
-        }),
+fn assignment_for_slot(roles: &PlanningRoles, slot: RoleSlot) -> &PlanningRoleAssignment {
+    match slot {
+        RoleSlot::PlannerA => &roles.planner_a,
+        RoleSlot::PlannerB => &roles.planner_b,
+        RoleSlot::Arbiter => &roles.arbiter,
     }
+}
+
+fn family_from_legacy_identity(
+    value: Option<String>,
+    field: &str,
+) -> Result<Option<AgentFamily>, OrbitError> {
+    value
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+        .map(|value| required_winner_marker_field(&value, field))
+        .transpose()?
+        .map(|value| value.parse())
+        .transpose()
 }
 
 fn normalize_winner_marker(
@@ -208,52 +247,122 @@ fn normalize_winner_marker(
     roles: Option<&PlanningRoles>,
 ) -> Result<PlanningDuelWinnerArtifact, OrbitError> {
     let PlanningDuelWinnerMarker {
+        winner_slot,
         winner_agent_cli,
-        winner_model,
+        winner_model: _,
         artifact_path,
         arbiter_agent_cli,
-        arbiter_model,
+        arbiter_model: _,
+        arbiter_family,
         arbiter_rationale,
     } = marker;
 
-    let winner_agent_cli = required_winner_marker_field(&winner_agent_cli, "winner_agent_cli")?;
-    let winner_model = required_winner_marker_field(&winner_model, "winner_model")?;
     let arbiter_rationale = required_winner_marker_field(&arbiter_rationale, "arbiter_rationale")?;
-    let winner_assignment = PlanningRoleAssignment {
-        agent: winner_agent_cli.clone(),
-        model: winner_model.clone(),
+    let legacy_winner_family =
+        family_from_legacy_identity(Some(winner_agent_cli), "winner_agent_cli")?;
+    let winner_slot = winner_slot.or_else(|| {
+        artifact_path
+            .as_deref()
+            .and_then(role_slot_from_artifact_path)
+    });
+    let (winner_family, winner_slot) = match (roles, winner_slot, legacy_winner_family) {
+        (Some(roles), Some(slot), legacy_family) => {
+            let family = assignment_for_slot(roles, slot).family;
+            if let Some(legacy_family) = legacy_family
+                && legacy_family != family
+            {
+                return Err(OrbitError::InvalidInput(format!(
+                    "winner artifact family {legacy_family} does not match recorded {slot} family {family}"
+                )));
+            }
+            (family, Some(slot))
+        }
+        (Some(roles), None, Some(legacy_family)) => {
+            let assignment = PlanningRoleAssignment {
+                family: legacy_family,
+            };
+            let slot = winner_slot_for_assignment(roles, &assignment)?;
+            (legacy_family, Some(slot))
+        }
+        (Some(_), None, None) => {
+            return Err(OrbitError::InvalidInput(
+                "planning duel winner marker requires `winner_slot`".to_string(),
+            ));
+        }
+        (None, Some(slot), Some(legacy_family)) => (legacy_family, Some(slot)),
+        (None, Some(slot), None) => {
+            let artifact = plan_artifacts
+                .iter()
+                .find(|artifact| artifact.slot == Some(slot))
+                .ok_or_else(|| {
+                    OrbitError::InvalidInput(format!(
+                        "missing planning duel artifact for winner slot {slot}"
+                    ))
+                })?;
+            (artifact.author.family, Some(slot))
+        }
+        (None, None, Some(legacy_family)) => (legacy_family, None),
+        (None, None, None) => {
+            return Err(OrbitError::InvalidInput(
+                "planning duel winner marker requires `winner_slot` or legacy `winner_agent_cli`"
+                    .to_string(),
+            ));
+        }
     };
 
     let artifact_path = match optional_winner_marker_field(artifact_path, "artifact_path")? {
         Some(artifact_path) => {
             let winning_artifact = plan_artifact_by_path(plan_artifacts, &artifact_path)?;
-            if winning_artifact.author != winner_assignment {
+            if winning_artifact.author.family != winner_family {
                 return Err(OrbitError::InvalidInput(format!(
-                    "winner artifact `{}` is authored by {}/{} instead of declared winner {}/{}",
-                    artifact_path,
-                    winning_artifact.author.agent,
-                    winning_artifact.author.model,
-                    winner_assignment.agent,
-                    winner_assignment.model
+                    "winner artifact `{}` is authored by {} instead of declared winner {}",
+                    artifact_path, winning_artifact.author.family, winner_family
                 )));
             }
             artifact_path
         }
-        None => plan_artifact_for_assignment(plan_artifacts, &winner_assignment)?
+        None => {
+            let slot = winner_slot.ok_or_else(|| {
+                OrbitError::InvalidInput(
+                    "planning duel winner marker requires artifact_path when winner_slot is unavailable"
+                        .to_string(),
+                )
+            })?;
+            plan_artifact_for_assignment(
+                plan_artifacts,
+                &PlanningRoleAssignment {
+                    family: winner_family,
+                },
+                slot,
+            )?
             .path
-            .clone(),
+            .clone()
+        }
     };
 
-    let arbiter_agent_cli = optional_winner_marker_field(arbiter_agent_cli, "arbiter_agent_cli")?;
-    let arbiter_model = optional_winner_marker_field(arbiter_model, "arbiter_model")?;
-    let arbiter = arbiter_identity_from_marker(arbiter_agent_cli, arbiter_model, roles)?;
+    let legacy_arbiter_family =
+        family_from_legacy_identity(arbiter_agent_cli, "arbiter_agent_cli")?;
+    let arbiter_family = match (roles, arbiter_family.or(legacy_arbiter_family)) {
+        (Some(roles), Some(marker_family)) if marker_family != roles.arbiter.family => {
+            return Err(OrbitError::InvalidInput(format!(
+                "winner artifact arbiter {marker_family} does not match recorded arbiter {}",
+                roles.arbiter.family
+            )));
+        }
+        (Some(roles), _) => roles.arbiter.family,
+        (None, Some(marker_family)) => marker_family,
+        (None, None) => {
+            return Err(OrbitError::InvalidInput(
+                "planning duel winner marker requires `arbiter_family` when `planning_duel_roles` are unavailable".to_string(),
+            ));
+        }
+    };
 
     Ok(PlanningDuelWinnerArtifact {
-        winner_agent_cli,
-        winner_model,
+        winner_family,
+        winner_slot,
         artifact_path,
-        arbiter_agent_cli: arbiter.agent,
-        arbiter_model: arbiter.model,
+        arbiter_family,
         arbiter_rationale,
     })
 }
@@ -287,24 +396,23 @@ pub(super) fn winner_artifact_from_artifacts(
 
 pub(super) fn winner_assignment(winner: &PlanningDuelWinnerArtifact) -> PlanningRoleAssignment {
     PlanningRoleAssignment {
-        agent: winner.winner_agent_cli.clone(),
-        model: winner.winner_model.clone(),
+        family: winner.winner_family,
     }
 }
 
 pub(super) fn winner_slot_for_assignment(
     roles: &PlanningRoles,
     winner: &PlanningRoleAssignment,
-) -> Result<PlannerSlot, OrbitError> {
+) -> Result<RoleSlot, OrbitError> {
     if roles.planner_a == *winner {
-        return Ok(PlannerSlot::PlannerA);
+        return Ok(RoleSlot::PlannerA);
     }
     if roles.planner_b == *winner {
-        return Ok(PlannerSlot::PlannerB);
+        return Ok(RoleSlot::PlannerB);
     }
     Err(OrbitError::InvalidInput(format!(
-        "winner {}/{} does not match the current planner assignments",
-        winner.agent, winner.model
+        "winner {} does not match the current planner assignments",
+        winner.family
     )))
 }
 
@@ -418,21 +526,17 @@ pub(super) fn writeback_planning_duel_task<H: TaskHost + RuntimeHost + ?Sized>(
     let winner_assignment = winner_assignment(&winner);
     let plan_artifacts = planning_duel_plan_artifacts(&artifacts)?;
     let winning_artifact = plan_artifact_by_path(&plan_artifacts, &winner.artifact_path)?;
-    if winning_artifact.author != winner_assignment {
+    if winning_artifact.author.family != winner_assignment.family {
         return Err(OrbitError::InvalidInput(format!(
-            "winner artifact `{}` is authored by {}/{} instead of declared winner {}/{}",
-            winner.artifact_path,
-            winning_artifact.author.agent,
-            winning_artifact.author.model,
-            winner_assignment.agent,
-            winner_assignment.model
+            "winner artifact `{}` is authored by {} instead of declared winner {}",
+            winner.artifact_path, winning_artifact.author.family, winner_assignment.family
         )));
     }
-    let winner_slot = if let Some(roles) = roles.as_ref() {
-        Some(winner_slot_for_assignment(roles, &winner_assignment)?)
-    } else {
-        None
-    };
+    let winner_slot = roles
+        .as_ref()
+        .map(|roles| winner_slot_for_assignment(roles, &winner_assignment))
+        .transpose()?
+        .or(winner.winner_slot);
     let winning_plan = normalize_winning_plan_for_task(&winning_artifact.content);
     let extraction = extract_context_files_from_plan(&winning_plan);
     let context_files = extraction.as_ref().map(|e| e.canonical_entries.clone());
@@ -447,20 +551,15 @@ pub(super) fn writeback_planning_duel_task<H: TaskHost + RuntimeHost + ?Sized>(
         }
     }
 
-    let winner_label = winner_slot
-        .map(|slot| match slot {
-            PlannerSlot::PlannerA => "planner_a",
-            PlannerSlot::PlannerB => "planner_b",
-        })
-        .unwrap_or("planner");
+    let winner_label = winner_slot.map(|slot| slot.as_str()).unwrap_or("planner");
 
     let status_note = format!(
-        "planning duel winner={winner_label} ({}/{})",
-        winner_assignment.agent, winner_assignment.model
+        "planning duel winner={winner_label} ({})",
+        winner_assignment.family
     );
     let comment_message = format!(
-        "Planning duel resolved.\n\nWinner: {winner_label} ({}/{})\n\nRationale: {}\n\nWinning plan persisted to task.plan. Task status remains {current_status}.",
-        winner_assignment.agent, winner_assignment.model, winner.arbiter_rationale
+        "Planning duel resolved.\n\nWinner: {winner_label} ({})\n\nRationale: {}\n\nWinning plan persisted to task.plan. Task status remains {current_status}.",
+        winner_assignment.family, winner.arbiter_rationale
     );
 
     host.apply_task_automation_update(
@@ -475,11 +574,11 @@ pub(super) fn writeback_planning_duel_task<H: TaskHost + RuntimeHost + ?Sized>(
             )),
             append_comments: vec![TaskComment {
                 at: Utc::now(),
-                by: winner.arbiter_agent_cli.clone(),
+                by: winner.arbiter_family.to_string(),
                 message: comment_message,
             }],
-            agent: Some(winner_assignment.agent.clone()),
-            model: Some(winner_assignment.model.clone()),
+            agent: Some(winner_assignment.family.to_string()),
+            model: Some(winner_assignment.family.to_string()),
             ..TaskAutomationUpdate::default()
         },
     )?;
@@ -487,25 +586,27 @@ pub(super) fn writeback_planning_duel_task<H: TaskHost + RuntimeHost + ?Sized>(
     Ok(json!({
         "task_id": task_id,
         "task_status": host.get_task(task_id)?.status.to_string(),
-        "winner_agent_cli": winner_assignment.agent,
-        "winner_model": winner_assignment.model,
+        "winner_family": winner_assignment.family,
+        "winner_slot": winner_slot.map(|slot| slot.as_str().to_string()),
     }))
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use orbit_common::types::{PlanningRoleAssignment, PlanningRoles, TaskArtifact};
+    use orbit_common::types::{
+        AgentFamily, PlanningRoleAssignment, PlanningRoles, RoleSlot, TaskArtifact,
+    };
     use serde_json::{Value, json};
 
     fn task_artifact(path: &str, content: String) -> TaskArtifact {
         TaskArtifact::from_text(path, content)
     }
 
-    fn plan_artifact(path: &str, agent: &str, model: &str) -> TaskArtifact {
+    fn plan_artifact(path: &str, family: &str, slot: &str) -> TaskArtifact {
         task_artifact(
             path,
-            format!("*authored by: {agent} / {model}*\n## Plan\nDo the thing.\n"),
+            format!("*authored by: {family} / {slot}*\n## Plan\nDo the thing.\n"),
         )
     }
 
@@ -516,28 +617,21 @@ mod tests {
     fn planning_roles() -> PlanningRoles {
         PlanningRoles {
             planner_a: PlanningRoleAssignment {
-                agent: "codex".to_string(),
-                model: "gpt-5.5".to_string(),
+                family: AgentFamily::Codex,
             },
             planner_b: PlanningRoleAssignment {
-                agent: "claude".to_string(),
-                model: "claude-opus-4-7".to_string(),
+                family: AgentFamily::Claude,
             },
             arbiter: PlanningRoleAssignment {
-                agent: "gemini".to_string(),
-                model: "gemini-3.1-pro".to_string(),
+                family: AgentFamily::Gemini,
             },
         }
     }
 
     fn planning_duel_artifacts(winner_payload: Value) -> Vec<TaskArtifact> {
         vec![
-            plan_artifact("planning-duel/codex-gpt-5.5.md", "codex", "gpt-5.5"),
-            plan_artifact(
-                "planning-duel/claude-claude-opus-4-7.md",
-                "claude",
-                "claude-opus-4-7",
-            ),
+            plan_artifact("planning-duel/planner_a.md", "codex", "planner_a"),
+            plan_artifact("planning-duel/planner_b.md", "claude", "planner_b"),
             winner_marker(winner_payload),
         ]
     }
@@ -550,26 +644,71 @@ mod tests {
     }
 
     #[test]
+    fn planning_duel_signature_extracts_family_and_slot() {
+        let signature = parse_planning_duel_signature("*authored by: gemini / planner_a*\n## Plan")
+            .expect("signature parses");
+        assert_eq!(signature.family, AgentFamily::Gemini);
+        assert_eq!(signature.slot, RoleSlot::PlannerA);
+
+        assert!(parse_planning_duel_signature("*authored by: gemini*\n").is_err());
+        assert!(parse_planning_duel_signature("*authored by: / planner_a*\n").is_err());
+        assert!(parse_planning_duel_signature("*authored by: pro / planner_a*\n").is_err());
+    }
+
+    #[test]
+    fn plan_artifact_validation_uses_family_and_slot_not_configured_model() {
+        let artifacts = planning_duel_plan_artifacts(&[
+            plan_artifact("planning-duel/planner_a.md", "gemini", "planner_a"),
+            plan_artifact("planning-duel/planner_b.md", "codex", "planner_b"),
+        ])
+        .expect("plan artifacts parse");
+        let assignment = PlanningRoleAssignment {
+            family: AgentFamily::Gemini,
+        };
+
+        let artifact = plan_artifact_for_assignment(&artifacts, &assignment, RoleSlot::PlannerA)
+            .expect("matching family and slot validate");
+
+        assert_eq!(artifact.path, "planning-duel/planner_a.md");
+    }
+
+    #[test]
+    fn plan_artifact_validation_reports_family_mismatch() {
+        let artifacts = planning_duel_plan_artifacts(&[plan_artifact(
+            "planning-duel/planner_a.md",
+            "claude",
+            "planner_a",
+        )])
+        .expect("plan artifacts parse");
+        let assignment = PlanningRoleAssignment {
+            family: AgentFamily::Gemini,
+        };
+
+        let message = invalid_input_message(
+            plan_artifact_for_assignment(&artifacts, &assignment, RoleSlot::PlannerA)
+                .expect_err("mismatched family fails"),
+        );
+
+        assert!(message.contains("expected gemini"), "{message}");
+        assert!(message.contains("has family claude"), "{message}");
+    }
+
+    #[test]
     fn planning_duel_winner_marker_omits_derived_fields_when_roles_available() {
         let roles = planning_roles();
         let artifacts = planning_duel_artifacts(json!({
             "id": "T20260427-47",
-            "winner_agent_cli": "claude",
-            "winner_model": "claude-opus-4-7",
+            "winner_slot": "planner_b",
             "arbiter_rationale": "Claude provided a more comprehensive diagnosis."
         }));
 
         let winner = winner_artifact_from_artifacts(&artifacts, Some(&roles))
             .expect("minimal winner marker should normalize");
 
-        assert_eq!(winner.winner_agent_cli, "claude");
-        assert_eq!(winner.winner_model, "claude-opus-4-7");
-        assert_eq!(
-            winner.artifact_path,
-            "planning-duel/claude-claude-opus-4-7.md"
-        );
-        assert_eq!(winner.arbiter_agent_cli, "gemini");
-        assert_eq!(winner.arbiter_model, "gemini-3.1-pro");
+        assert_eq!(winner.winner_family, AgentFamily::Claude);
+        assert_eq!(winner.winner_slot, Some(RoleSlot::PlannerB));
+        assert_eq!(winner.artifact_path, "planning-duel/planner_b.md");
+        assert_eq!(winner.arbiter_family, AgentFamily::Gemini);
         assert_eq!(
             winner.arbiter_rationale,
             "Claude provided a more comprehensive diagnosis."
@@ -580,10 +719,8 @@ mod tests {
     fn planning_duel_winner_marker_rejects_explicit_arbiter_mismatch() {
         let roles = planning_roles();
         let artifacts = planning_duel_artifacts(json!({
-            "winner_agent_cli": "claude",
-            "winner_model": "claude-opus-4-7",
+            "winner_slot": "planner_b",
             "arbiter_agent_cli": "codex",
-            "arbiter_model": "gpt-5.5",
             "arbiter_rationale": "Claude provided a more comprehensive diagnosis."
         }));
 
@@ -593,9 +730,8 @@ mod tests {
         );
 
         assert!(
-            message.contains(
-                "winner artifact arbiter codex/gpt-5.5 does not match recorded arbiter gemini/gemini-3.1-pro"
-            ),
+            message
+                .contains("winner artifact arbiter codex does not match recorded arbiter gemini"),
             "{message}"
         );
     }
@@ -603,8 +739,7 @@ mod tests {
     #[test]
     fn planning_duel_winner_marker_requires_arbiter_identity_without_roles() {
         let artifacts = planning_duel_artifacts(json!({
-            "winner_agent_cli": "claude",
-            "winner_model": "claude-opus-4-7",
+            "winner_slot": "planner_b",
             "arbiter_rationale": "Claude provided a more comprehensive diagnosis."
         }));
 
@@ -615,7 +750,7 @@ mod tests {
 
         assert!(
             message.contains(
-                "planning duel winner marker requires `arbiter_agent_cli` when `planning_duel_roles` are unavailable"
+                "planning duel winner marker requires `arbiter_family` when `planning_duel_roles` are unavailable"
             ),
             "{message}"
         );
@@ -626,7 +761,7 @@ mod tests {
         let artifacts = planning_duel_artifacts(json!({
             "winner_agent_cli": "claude",
             "winner_model": "claude-opus-4-7",
-            "artifact_path": "planning-duel/claude-claude-opus-4-7.md",
+            "artifact_path": "planning-duel/planner_b.md",
             "arbiter_agent_cli": "gemini",
             "arbiter_model": "gemini-3.1-pro",
             "arbiter_rationale": "Claude provided a more comprehensive diagnosis."
@@ -635,13 +770,8 @@ mod tests {
         let winner = winner_artifact_from_artifacts(&artifacts, None)
             .expect("legacy full winner payload should still normalize");
 
-        assert_eq!(winner.winner_agent_cli, "claude");
-        assert_eq!(winner.winner_model, "claude-opus-4-7");
-        assert_eq!(
-            winner.artifact_path,
-            "planning-duel/claude-claude-opus-4-7.md"
-        );
-        assert_eq!(winner.arbiter_agent_cli, "gemini");
-        assert_eq!(winner.arbiter_model, "gemini-3.1-pro");
+        assert_eq!(winner.winner_family, AgentFamily::Claude);
+        assert_eq!(winner.artifact_path, "planning-duel/planner_b.md");
+        assert_eq!(winner.arbiter_family, AgentFamily::Gemini);
     }
 }

--- a/crates/orbit-engine/src/executor/automation/duel/planning_duel/metrics.rs
+++ b/crates/orbit-engine/src/executor/automation/duel/planning_duel/metrics.rs
@@ -2,7 +2,7 @@ use std::collections::BTreeMap;
 
 use orbit_common::types::{
     OrbitError, PlanningDuelRun, PlanningEfficiency, PlanningOutcome, PlanningRoleAssignment,
-    PlanningRoles,
+    PlanningRoles, RoleSlot,
 };
 use orbit_store::{InvocationRecord, planning_duel_scoreboard};
 use serde_json::{Value, json};
@@ -41,12 +41,13 @@ fn efficiency_from_invocation(invocation: &ActivityInvocationResult) -> Planning
 
 pub(super) fn role_metrics_from_invocation(
     role: &PlanningRoleAssignment,
+    slot: RoleSlot,
     activity_id: &str,
     invocation: &ActivityInvocationResult,
 ) -> PlanningDuelRoleMetrics {
     PlanningDuelRoleMetrics {
-        agent: role.agent.clone(),
-        model: role.model.clone(),
+        family: role.family,
+        slot,
         activity_id: activity_id.to_string(),
         efficiency: efficiency_from_invocation(invocation),
     }
@@ -92,31 +93,39 @@ fn role_metrics_for_activity<H: RuntimeHost + ?Sized>(
     host: &H,
     job_run_id: &str,
     role_id: &PlanningRoleAssignment,
+    slot: RoleSlot,
     activity_id: &str,
 ) -> Result<PlanningDuelRoleMetrics, OrbitError> {
     let all_records = host.invocation_records_for_job_run_and_activity(job_run_id, activity_id)?;
-    let matching_records = all_records
-        .iter()
-        .filter(|record| {
-            record.agent == role_id.agent && record.model.as_deref() == Some(role_id.model.as_str())
-        })
-        .cloned()
-        .collect::<Vec<_>>();
+    let matching_records = matching_role_records(&all_records, role_id, slot);
 
     if matching_records.is_empty() && !all_records.is_empty() {
         return Err(OrbitError::Execution(format!(
             "activity '{activity_id}' for job run '{job_run_id}' did not produce invocations \
              attributed to expected {}/{}",
-            role_id.agent, role_id.model
+            role_id.family, slot
         )));
     }
 
     Ok(PlanningDuelRoleMetrics {
-        agent: role_id.agent.clone(),
-        model: role_id.model.clone(),
+        family: role_id.family,
+        slot,
         activity_id: activity_id.to_string(),
         efficiency: summarize_role_metrics(&matching_records),
     })
+}
+
+#[allow(dead_code)]
+fn matching_role_records(
+    records: &[InvocationRecord],
+    role_id: &PlanningRoleAssignment,
+    slot: RoleSlot,
+) -> Vec<InvocationRecord> {
+    records
+        .iter()
+        .filter(|record| record.agent == role_id.family.as_str() && record.slot == Some(slot))
+        .cloned()
+        .collect()
 }
 
 #[allow(dead_code)]
@@ -139,18 +148,21 @@ pub(super) fn record_planning_duel_efficiency<H: RuntimeHost + ?Sized>(
         host,
         &job_run_id,
         &planning_roles.planner_a,
+        RoleSlot::PlannerA,
         &planner_a_activity_id,
     )?;
     let planner_b_metrics = role_metrics_for_activity(
         host,
         &job_run_id,
         &planning_roles.planner_b,
+        RoleSlot::PlannerB,
         &planner_b_activity_id,
     )?;
     let arbiter_metrics = role_metrics_for_activity(
         host,
         &job_run_id,
         &planning_roles.arbiter,
+        RoleSlot::Arbiter,
         &arbiter_activity_id,
     )?;
 
@@ -208,35 +220,32 @@ pub(super) fn record_planning_duel_scores<H: RuntimeHost + TaskHost + ?Sized>(
     .map_err(|err| OrbitError::InvalidInput(format!("invalid roles.arbiter payload: {err}")))?;
 
     let PlanningDuelRoleMetrics {
-        agent: planner_a_agent,
-        model: planner_a_model,
+        family: planner_a_family,
+        slot: _,
         activity_id: _,
         efficiency: planner_a_efficiency,
     } = planner_a_role;
     let PlanningDuelRoleMetrics {
-        agent: planner_b_agent,
-        model: planner_b_model,
+        family: planner_b_family,
+        slot: _,
         activity_id: _,
         efficiency: planner_b_efficiency,
     } = planner_b_role;
     let PlanningDuelRoleMetrics {
-        agent: arbiter_agent,
-        model: arbiter_model,
+        family: arbiter_family,
+        slot: _,
         activity_id: _,
         efficiency: arbiter_efficiency,
     } = arbiter_role;
     let roles = PlanningRoles {
         planner_a: PlanningRoleAssignment {
-            agent: planner_a_agent,
-            model: planner_a_model,
+            family: planner_a_family,
         },
         planner_b: PlanningRoleAssignment {
-            agent: planner_b_agent,
-            model: planner_b_model,
+            family: planner_b_family,
         },
         arbiter: PlanningRoleAssignment {
-            agent: arbiter_agent,
-            model: arbiter_model,
+            family: arbiter_family,
         },
     };
     let artifacts = host.get_task_artifacts(task_id)?;
@@ -244,34 +253,27 @@ pub(super) fn record_planning_duel_scores<H: RuntimeHost + TaskHost + ?Sized>(
     let winner = winner_artifact_from_artifacts(&artifacts, Some(&roles))?;
     let winner_assignment = winner_assignment(&winner);
     let winner_plan = plan_artifact_by_path(&plan_artifacts, &winner.artifact_path)?;
-    if winner_plan.author != winner_assignment {
+    if winner_plan.author.family != winner_assignment.family {
         return Err(OrbitError::InvalidInput(format!(
-            "winner artifact `{}` is authored by {}/{} instead of declared winner {}/{}",
-            winner.artifact_path,
-            winner_plan.author.agent,
-            winner_plan.author.model,
-            winner_assignment.agent,
-            winner_assignment.model
+            "winner artifact `{}` is authored by {} instead of declared winner {}",
+            winner.artifact_path, winner_plan.author.family, winner_assignment.family
         )));
     }
     let winner_slot = winner_slot_for_assignment(&roles, &winner_assignment)?;
-    if winner.arbiter_agent_cli != roles.arbiter.agent
-        || winner.arbiter_model != roles.arbiter.model
-    {
+    if winner.arbiter_family != roles.arbiter.family {
         return Err(OrbitError::InvalidInput(format!(
-            "winner artifact arbiter {}/{} does not match recorded arbiter {}/{}",
-            winner.arbiter_agent_cli,
-            winner.arbiter_model,
-            roles.arbiter.agent,
-            roles.arbiter.model
+            "winner artifact arbiter {} does not match recorded arbiter {}",
+            winner.arbiter_family, roles.arbiter.family
         )));
     }
-    let planner_a_artifact_path = plan_artifact_for_assignment(&plan_artifacts, &roles.planner_a)?
-        .path
-        .clone();
-    let planner_b_artifact_path = plan_artifact_for_assignment(&plan_artifacts, &roles.planner_b)?
-        .path
-        .clone();
+    let planner_a_artifact_path =
+        plan_artifact_for_assignment(&plan_artifacts, &roles.planner_a, RoleSlot::PlannerA)?
+            .path
+            .clone();
+    let planner_b_artifact_path =
+        plan_artifact_for_assignment(&plan_artifacts, &roles.planner_b, RoleSlot::PlannerB)?
+            .path
+            .clone();
 
     let completed_at = chrono::Utc::now();
     let run = PlanningDuelRun {
@@ -282,7 +284,9 @@ pub(super) fn record_planning_duel_scores<H: RuntimeHost + TaskHost + ?Sized>(
         planner_a_artifact_path,
         planner_b_artifact_path,
         outcome: PlanningOutcome {
-            winner: winner_slot,
+            winner: winner_slot.planner_slot().ok_or_else(|| {
+                OrbitError::InvalidInput("planning duel winner cannot be arbiter".to_string())
+            })?,
             arbiter_rationale: winner.arbiter_rationale,
         },
         efficiency: PlanningEfficiency {
@@ -298,4 +302,71 @@ pub(super) fn record_planning_duel_scores<H: RuntimeHost + TaskHost + ?Sized>(
         "run_id": run.run_id,
         "recorded": true,
     }))
+}
+
+#[cfg(test)]
+mod tests {
+    use chrono::Utc;
+    use orbit_common::types::AgentFamily;
+
+    use super::*;
+
+    #[test]
+    fn metrics_attribute_invocations_by_family_and_slot_not_model() {
+        let role = PlanningRoleAssignment {
+            family: AgentFamily::Gemini,
+        };
+        let records = vec![
+            invocation_record(
+                "propose_duel_plan",
+                "gemini",
+                Some("gemini-3.1-pro"),
+                Some(RoleSlot::PlannerA),
+            ),
+            invocation_record(
+                "propose_duel_plan",
+                "gemini",
+                Some("pro"),
+                Some(RoleSlot::PlannerB),
+            ),
+            invocation_record(
+                "propose_duel_plan",
+                "claude",
+                Some("claude-opus-4-7"),
+                Some(RoleSlot::PlannerA),
+            ),
+        ];
+
+        let matching = matching_role_records(&records, &role, RoleSlot::PlannerA);
+
+        assert_eq!(matching.len(), 1);
+        assert_eq!(matching[0].model.as_deref(), Some("gemini-3.1-pro"));
+        assert_eq!(matching[0].slot, Some(RoleSlot::PlannerA));
+    }
+
+    fn invocation_record(
+        activity_id: &str,
+        agent: &str,
+        model: Option<&str>,
+        slot: Option<RoleSlot>,
+    ) -> InvocationRecord {
+        InvocationRecord {
+            id: 1,
+            ts: Utc::now(),
+            job_run_id: "jrun-1".to_string(),
+            activity_id: activity_id.to_string(),
+            agent: agent.to_string(),
+            model: model.map(ToOwned::to_owned),
+            slot,
+            duration_ms: 100,
+            input_tokens: 1,
+            cache_read_tokens: 0,
+            cache_create_tokens: 0,
+            output_tokens: 1,
+            total_tokens: 2,
+            tool_call_count: 1,
+            task_ids: Vec::new(),
+            tool_calls: Vec::new(),
+        }
+    }
 }

--- a/crates/orbit-engine/src/executor/automation/duel/planning_duel/roles.rs
+++ b/crates/orbit-engine/src/executor/automation/duel/planning_duel/roles.rs
@@ -3,7 +3,9 @@ use std::collections::VecDeque;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use chrono::Utc;
-use orbit_common::types::{Activity, OrbitError, PlanningRoleAssignment, PlanningRoles};
+use orbit_common::types::{
+    Activity, AgentFamily, OrbitError, PlanningRoleAssignment, PlanningRoles, RoleSlot,
+};
 use serde_json::{Value, json};
 
 use crate::context::RuntimeHost;
@@ -17,7 +19,7 @@ pub(super) const ARBITER_ACTIVITY_ID: &str = "arbitrate_duel_plan";
 pub(super) const PLANNER_TIMEOUT_SECONDS: u64 = 1800;
 pub(super) const ARBITER_TIMEOUT_SECONDS: u64 = 900;
 
-const PLANNING_DUEL_INSTRUCTION: &str = r#"Only use skills listed in this activity's skill_refs. Ignore all others.
+const PLANNING_DUEL_INSTRUCTION: &str = r###"Only use skills listed in this activity's skill_refs. Ignore all others.
 You are a PLANNER in an Orbit planning duel. Inspect the task and surrounding
 code, draft one implementation-ready proposal, and persist it to the task's
 `artifacts/` directory. Do not edit source files, open PRs, or rely on your
@@ -28,11 +30,10 @@ Steps:
    - Call orbit.task.show with input: {"id": "<task_id>"} to fetch the task title,
      description, plan, acceptance_criteria, context_files, and workspace_path.
 
-2. Determine your artifact path from the active agent signature:
+2. Determine your artifact path from the active slot:
    - Your active agent family is `{{agent_family}}`.
-   - Your active orchestrator model is `{{orchestrator_model}}`.
-   - Your plan artifact path must be `planning-duel/{{agent_family}}-{{orchestrator_model}}.md`.
-   - Do not invent a role-specific filename such as `planner_a.md` or `planner_b.md`.
+   - Your active planning-duel slot is in input.planning_duel_slot.
+   - Your plan artifact path must be `planning-duel/<slot>.md`.
 
 3. Gather context with the graph surface first:
    - Build graph selectors from task.context_files and call orbit.graph.pack.
@@ -44,8 +45,7 @@ Steps:
      the graph has the needed knowledge.
 
 4. Draft exactly one proposal as markdown:
-   - The first line must be exactly: `*authored by: {{agent_family}} / {{orchestrator_model}}*`
-   - Then include these sections:
+   - Include these sections:
      ## Plan
      ## Context Files
      ## Risks
@@ -53,16 +53,16 @@ Steps:
    - Ignore any existing planner artifact for the other role. Your proposal must be independently reasoned.
 
 5. Persist the proposal as a task artifact:
-   - Use orbit.duel.plan.add to write the artifact under the signature-derived path.
+   - Use orbit.duel.plan.add to write the artifact under the slot-derived path. Orbit stamps the signature line.
    - Exact example:
-     {"id":"<task_id>","content":"*authored by: {{agent_family}} / {{orchestrator_model}}*\n## Plan\n..."}
+     {"id":"<task_id>","planning_duel_slot":"planner_a","content":"## Plan\n..."}
 
 6. Stay narrowly scoped:
    - Do not edit source files, update task.plan, or touch PR state.
    - The only permitted mutation is writing your own planner artifact via orbit.duel.plan.add.
 
 7. Structured output is optional:
-   - The workflow does not depend on your response payload. Persist the artifact correctly even if you return null."#;
+   - The workflow does not depend on your response payload. Persist the artifact correctly even if you return null."###;
 const ARBITER_INSTRUCTION: &str = r#"Only use skills listed in this activity's skill_refs. Ignore all others.
 You are the ARBITER in an Orbit planning duel. Your job is to compare the
 two submitted planner artifacts, choose the better one, and persist the
@@ -80,8 +80,8 @@ Steps:
    - Treat both planner artifacts as read-only inputs. Do not invent a third plan.
 
 3. Infer planner identity from the artifact signatures:
-   - The first line of each planner artifact must be `*authored by: <agent> / <model>*`.
-   - Parse those lines to recover each planner's agent CLI family and model.
+   - The first line of each planner artifact must be `*authored by: <family> / <slot>*`.
+   - Parse those lines to recover each planner's family and slot.
    - The artifact signature is the canonical planner identity source.
 
 4. Use the graph surface to verify claims:
@@ -97,7 +97,7 @@ Steps:
 6. Persist the winner marker:
    - Use orbit.duel.plan.winner to write `planning-duel/winner.json`.
    - Exact example:
-     {"id":"<task_id>","winner_agent_cli":"codex","winner_model":"gpt-5.4","arbiter_rationale":"More concrete writeback and test coverage."}
+     {"id":"<task_id>","winner_slot":"planner_a","arbiter_rationale":"More concrete writeback and test coverage."}
 
 7. Stay narrowly scoped:
    - Do not edit source files, update task.plan directly, or open PRs.
@@ -142,9 +142,9 @@ fn build_role_assignment<H: RuntimeHost + ?Sized>(
     host: &H,
     family: &str,
 ) -> Result<PlanningRoleAssignment, OrbitError> {
+    let _ = orchestrator_model_for(host, family)?;
     Ok(PlanningRoleAssignment {
-        agent: family.to_string(),
-        model: orchestrator_model_for(host, family)?,
+        family: AgentFamily::parse(family)?,
     })
 }
 
@@ -249,12 +249,12 @@ pub(super) fn arbiter_activity() -> Activity {
     )
 }
 
-pub(super) fn planner_input(task_id: &str) -> Value {
-    json!({ "task_id": task_id })
+pub(super) fn planner_input_for_slot(task_id: &str, slot: RoleSlot) -> Value {
+    json!({ "task_id": task_id, "planning_duel_slot": slot.as_str() })
 }
 
 pub(super) fn arbiter_input(task_id: &str) -> Value {
-    json!({ "task_id": task_id })
+    json!({ "task_id": task_id, "planning_duel_slot": RoleSlot::Arbiter.as_str() })
 }
 
 pub(super) fn parse_planning_duel_roles(input: &Value) -> Result<PlanningRoles, OrbitError> {
@@ -314,6 +314,7 @@ pub(super) fn select_planning_duel_roles<H: RuntimeHost + ?Sized>(
 
 #[cfg(test)]
 mod tests {
+    use std::collections::BTreeMap;
     use std::path::{Path, PathBuf};
 
     use orbit_common::types::{Activity, AgentModelPair, Job, JobTargetType, OrbitEvent, Role};
@@ -329,7 +330,7 @@ mod tests {
         data_root: PathBuf,
         scoreboard_dir: PathBuf,
         registry: ActivityExecutorRegistry,
-        duel_model: Option<String>,
+        duel_models: BTreeMap<String, String>,
     }
 
     impl TestHost {
@@ -338,12 +339,26 @@ mod tests {
         }
 
         fn with_duel_model(duel_model: Option<&str>) -> Self {
+            let mut duel_models = BTreeMap::new();
+            if let Some(duel_model) = duel_model {
+                duel_models.insert("codex".to_string(), duel_model.to_string());
+            }
+            Self::with_duel_models(duel_models)
+        }
+
+        fn with_family_duel_model(family: &str, model: &str) -> Self {
+            let mut duel_models = BTreeMap::new();
+            duel_models.insert(family.to_string(), model.to_string());
+            Self::with_duel_models(duel_models)
+        }
+
+        fn with_duel_models(duel_models: BTreeMap<String, String>) -> Self {
             let temp_root = std::env::temp_dir().join("orbit-planning-duel-role-test");
             Self {
                 scoreboard_dir: temp_root.join("scoreboard"),
                 data_root: temp_root,
                 registry: ActivityExecutorRegistry::default(),
-                duel_model: duel_model.map(ToOwned::to_owned),
+                duel_models,
             }
         }
     }
@@ -426,11 +441,7 @@ mod tests {
         }
 
         fn duel_orchestrator_model(&self, family: &str) -> Option<String> {
-            if family == "codex" {
-                self.duel_model.clone()
-            } else {
-                None
-            }
+            self.duel_models.get(family).cloned()
         }
 
         fn scoring_enabled(&self) -> bool {
@@ -453,11 +464,8 @@ mod tests {
 
         assert_eq!(output["planner_a_agent_cli"], "grok");
         assert_eq!(output["planner_a_model"], "grok-4");
-        assert_eq!(output["planning_duel_roles"]["planner_a"]["agent"], "grok");
-        assert_eq!(
-            output["planning_duel_roles"]["planner_a"]["model"],
-            "grok-4"
-        );
+        assert_eq!(output["planning_duel_roles"]["planner_a"]["family"], "grok");
+        assert!(output["planning_duel_roles"]["planner_a"]["model"].is_null());
         assert_eq!(output["planner_b_agent_cli"], "codex");
         assert_eq!(output["arbiter_agent_cli"], "claude");
     }
@@ -476,18 +484,34 @@ mod tests {
         let host = TestHost::with_duel_model(Some("M_duel"));
         let output = select_planning_duel_roles(&host, &json!({ "task_id": "ORB-TEST" }))
             .expect("planning role selection uses duel model");
+        assert_eq!(output["planner_a_model"], "M_duel");
         assert_eq!(
-            output["planning_duel_roles"]["planner_a"]["model"],
-            "M_duel"
+            output["planning_duel_roles"]["planner_a"]["family"],
+            "codex"
         );
 
         queue_permutation([0, 1, 2]);
         let host = TestHost::with_duel_model(None);
         let output = select_planning_duel_roles(&host, &json!({ "task_id": "ORB-TEST" }))
             .expect("planning role selection falls back to resolved pair");
-        assert_eq!(
-            output["planning_duel_roles"]["planner_a"]["model"],
-            "M_exec"
-        );
+        assert_eq!(output["planner_a_model"], "M_exec");
+    }
+
+    #[test]
+    fn planning_duel_role_selection_keeps_family_identity_for_model_aliases() {
+        for model in ["pro", "gemini-3.1-pro"] {
+            queue_permutation([2, 0, 1]);
+            let host = TestHost::with_family_duel_model("gemini", model);
+            let output = select_planning_duel_roles(&host, &json!({ "task_id": "ORB-TEST" }))
+                .expect("planning role selection uses configured gemini model");
+
+            assert_eq!(output["planner_a_agent_cli"], "gemini");
+            assert_eq!(output["planner_a_model"], model);
+            assert_eq!(
+                output["planning_duel_roles"]["planner_a"]["family"],
+                "gemini"
+            );
+            assert!(output["planning_duel_roles"]["planner_a"]["model"].is_null());
+        }
     }
 }

--- a/crates/orbit-engine/src/executor/automation/duel/planning_duel/runner.rs
+++ b/crates/orbit-engine/src/executor/automation/duel/planning_duel/runner.rs
@@ -1,6 +1,6 @@
 use std::collections::BTreeMap;
 
-use orbit_common::types::{OrbitError, PlanningRoleAssignment};
+use orbit_common::types::{OrbitError, PlanningRoleAssignment, RoleSlot};
 use serde_json::{Value, json};
 
 use super::types::PlanningDuelPlanArtifact;
@@ -23,9 +23,10 @@ fn join_activity_result(
 fn require_plan_artifact_for_assignment<'a>(
     plan_artifacts: &'a [PlanningDuelPlanArtifact],
     assignment: &PlanningRoleAssignment,
+    slot: RoleSlot,
     invocation: &ActivityInvocationResult,
 ) -> Result<&'a PlanningDuelPlanArtifact, OrbitError> {
-    artifacts::plan_artifact_for_assignment(plan_artifacts, assignment).map_err(|error| {
+    artifacts::plan_artifact_for_assignment(plan_artifacts, assignment, slot).map_err(|error| {
         OrbitError::Execution(format!(
             "{error}; {}",
             planner_invocation_diagnostics(invocation)
@@ -110,8 +111,16 @@ pub(crate) fn run_planning_duel<H: RuntimeHost + TaskHost + Sync + ?Sized>(
     let planning_roles = roles::parse_planning_duel_roles(&roles_output)?;
 
     let planner_activity = roles::planner_activity();
-    let planner_a_input = roles::planner_input(task_id);
-    let planner_b_input = roles::planner_input(task_id);
+    let planner_a_input = roles::planner_input_for_slot(task_id, RoleSlot::PlannerA);
+    let planner_b_input = roles::planner_input_for_slot(task_id, RoleSlot::PlannerB);
+    let planner_a_model = roles_output["planner_a_model"]
+        .as_str()
+        .ok_or_else(|| OrbitError::Execution("missing planner_a_model".to_string()))?
+        .to_string();
+    let planner_b_model = roles_output["planner_b_model"]
+        .as_str()
+        .ok_or_else(|| OrbitError::Execution("missing planner_b_model".to_string()))?
+        .to_string();
     let (planner_a_result, planner_b_result) = std::thread::scope(|scope| {
         let planner_a = planning_roles.planner_a.clone();
         let planner_b = planning_roles.planner_b.clone();
@@ -120,8 +129,8 @@ pub(crate) fn run_planning_duel<H: RuntimeHost + TaskHost + Sync + ?Sized>(
         let handle_a = scope.spawn(move || {
             host.invoke_activity(
                 planner_activity_a,
-                &planner_a.agent,
-                Some(planner_a.model.as_str()),
+                planner_a.family.as_str(),
+                Some(planner_a_model.as_str()),
                 planner_a_input,
                 roles::PLANNER_TIMEOUT_SECONDS,
                 debug,
@@ -130,8 +139,8 @@ pub(crate) fn run_planning_duel<H: RuntimeHost + TaskHost + Sync + ?Sized>(
         let handle_b = scope.spawn(move || {
             host.invoke_activity(
                 planner_activity_b,
-                &planner_b.agent,
-                Some(planner_b.model.as_str()),
+                planner_b.family.as_str(),
+                Some(planner_b_model.as_str()),
                 planner_b_input,
                 roles::PLANNER_TIMEOUT_SECONDS,
                 debug,
@@ -150,18 +159,24 @@ pub(crate) fn run_planning_duel<H: RuntimeHost + TaskHost + Sync + ?Sized>(
     let _ = require_plan_artifact_for_assignment(
         &plan_artifacts,
         &planning_roles.planner_a,
+        RoleSlot::PlannerA,
         &planner_a_result,
     )?;
     let _ = require_plan_artifact_for_assignment(
         &plan_artifacts,
         &planning_roles.planner_b,
+        RoleSlot::PlannerB,
         &planner_b_result,
     )?;
+    let arbiter_model = roles_output["arbiter_model"]
+        .as_str()
+        .ok_or_else(|| OrbitError::Execution("missing arbiter_model".to_string()))?
+        .to_string();
 
     let arbiter_result = host.invoke_activity(
         roles::arbiter_activity(),
-        &planning_roles.arbiter.agent,
-        Some(planning_roles.arbiter.model.as_str()),
+        planning_roles.arbiter.family.as_str(),
+        Some(arbiter_model.as_str()),
         roles::arbiter_input(task_id),
         roles::ARBITER_TIMEOUT_SECONDS,
         debug,
@@ -176,6 +191,7 @@ pub(crate) fn run_planning_duel<H: RuntimeHost + TaskHost + Sync + ?Sized>(
             "planner_a".to_string(),
             metrics::role_metrics_from_invocation(
                 &planning_roles.planner_a,
+                RoleSlot::PlannerA,
                 roles::PLANNER_ACTIVITY_ID,
                 &planner_a_result,
             ),
@@ -184,6 +200,7 @@ pub(crate) fn run_planning_duel<H: RuntimeHost + TaskHost + Sync + ?Sized>(
             "planner_b".to_string(),
             metrics::role_metrics_from_invocation(
                 &planning_roles.planner_b,
+                RoleSlot::PlannerB,
                 roles::PLANNER_ACTIVITY_ID,
                 &planner_b_result,
             ),
@@ -192,6 +209,7 @@ pub(crate) fn run_planning_duel<H: RuntimeHost + TaskHost + Sync + ?Sized>(
             "arbiter".to_string(),
             metrics::role_metrics_from_invocation(
                 &planning_roles.arbiter,
+                RoleSlot::Arbiter,
                 roles::ARBITER_ACTIVITY_ID,
                 &arbiter_result,
             ),
@@ -218,8 +236,8 @@ pub(crate) fn run_planning_duel<H: RuntimeHost + TaskHost + Sync + ?Sized>(
         "task_id": task_id,
         "run_id": job_run_id,
         "task_status": writeback["task_status"].clone(),
-        "winner_agent_cli": winner.winner_agent_cli,
-        "winner_model": winner.winner_model,
+        "winner_family": winner.winner_family,
+        "winner_slot": winner.winner_slot.map(|slot| slot.as_str().to_string()),
         "recorded": true,
     }))
 }
@@ -455,6 +473,17 @@ mod tests {
             Ok(None)
         }
 
+        fn duel_orchestrator_model(&self, family: &str) -> Option<String> {
+            let model = match family {
+                "codex" => "gpt-5.5",
+                "claude" => "claude-opus-4-7",
+                "gemini" => "gemini-3.1-pro",
+                "grok" => "grok-4",
+                _ => return None,
+            };
+            Some(model.to_string())
+        }
+
         fn invocation_records(
             &self,
             _query: InvocationQuery,
@@ -479,13 +508,17 @@ mod tests {
             activity: Activity,
             agent_cli: &str,
             model: Option<&str>,
-            _input: Value,
+            input: Value,
             _timeout_seconds: u64,
             _debug: bool,
         ) -> Result<ActivityInvocationResult, orbit_common::types::OrbitError> {
-            let model = model.unwrap_or("unknown-model");
+            let _model = model.unwrap_or("unknown-model");
             match activity.id.as_str() {
                 "propose_duel_plan" => {
+                    let slot = input
+                        .get("planning_duel_slot")
+                        .and_then(Value::as_str)
+                        .unwrap_or("planner_a");
                     let should_omit = self
                         .omit_planner_artifacts
                         .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |remaining| {
@@ -497,15 +530,15 @@ mod tests {
                             .lock()
                             .expect("artifacts lock")
                             .push(TaskArtifact::from_text(
-                                format!("planning-duel/{agent_cli}-{model}.md"),
+                                format!("planning-duel/{slot}.md"),
                                 format!(
-                                    "*authored by: {agent_cli} / {model}*\n## Plan\nPreserve task status.\n"
+                                    "*authored by: {agent_cli} / {slot}*\n## Plan\nPreserve task status.\n"
                                 ),
                             ));
                     }
                 }
                 "arbitrate_duel_plan" => {
-                    let winner =
+                    let _winner =
                         first_planner_assignment(&self.artifacts.lock().expect("artifacts lock"))?;
                     self.artifacts
                         .lock()
@@ -513,8 +546,7 @@ mod tests {
                         .push(TaskArtifact::from_text(
                             "planning-duel/winner.json",
                             json!({
-                                "winner_agent_cli": winner.agent,
-                                "winner_model": winner.model,
+                                "winner_slot": "planner_a",
                                 "arbiter_rationale": "Preserves lifecycle state."
                             })
                             .to_string(),
@@ -584,23 +616,14 @@ mod tests {
             .ok_or_else(|| {
                 orbit_common::types::OrbitError::Execution("missing planner artifact".to_string())
             })?;
-        let name = artifact
-            .path
-            .strip_prefix("planning-duel/")
-            .and_then(|value| value.strip_suffix(".md"))
-            .ok_or_else(|| {
-                orbit_common::types::OrbitError::Execution(
-                    "invalid planner artifact path".to_string(),
-                )
-            })?;
-        let (agent, model) = name.split_once('-').ok_or_else(|| {
+        let content = artifact.text_content().ok_or_else(|| {
             orbit_common::types::OrbitError::Execution(
-                "invalid planner artifact signature".to_string(),
+                "planner artifact content must be utf-8".to_string(),
             )
         })?;
+        let signature = super::artifacts::parse_planning_duel_signature(content)?;
         Ok(PlanningRoleAssignment {
-            agent: agent.to_string(),
-            model: model.to_string(),
+            family: signature.family,
         })
     }
 
@@ -721,18 +744,17 @@ mod tests {
         let mut artifacts = host.artifacts.lock().expect("artifacts lock");
         artifacts.clear();
         artifacts.push(TaskArtifact::from_text(
-            "planning-duel/codex-gpt-5.5.md",
-            "*authored by: codex / gpt-5.5*\n## Plan\nLoser plan.\n",
+            "planning-duel/planner_a.md",
+            "*authored by: codex / planner_a*\n## Plan\nLoser plan.\n",
         ));
         artifacts.push(TaskArtifact::from_text(
-            "planning-duel/claude-claude-opus-4-7.md",
-            format!("*authored by: claude / claude-opus-4-7*\n{plan_body}"),
+            "planning-duel/planner_b.md",
+            format!("*authored by: claude / planner_b*\n{plan_body}"),
         ));
         artifacts.push(TaskArtifact::from_text(
             "planning-duel/winner.json",
             json!({
-                "winner_agent_cli": "claude",
-                "winner_model": "claude-opus-4-7",
+                "winner_slot": "planner_b",
                 "arbiter_rationale": "Claude provided more detail."
             })
             .to_string(),
@@ -745,9 +767,9 @@ mod tests {
             &json!({
                 "task_id": "T20260430-STATUS",
                 "planning_duel_roles": {
-                    "planner_a": { "agent": "codex", "model": "gpt-5.5" },
-                    "planner_b": { "agent": "claude", "model": "claude-opus-4-7" },
-                    "arbiter":   { "agent": "gemini", "model": "gemini-3.1-pro" }
+                    "planner_a": { "family": "codex" },
+                    "planner_b": { "family": "claude" },
+                    "arbiter":   { "family": "gemini" }
                 }
             }),
         )

--- a/crates/orbit-engine/src/executor/automation/duel/planning_duel/types.rs
+++ b/crates/orbit-engine/src/executor/automation/duel/planning_duel/types.rs
@@ -1,10 +1,10 @@
-use orbit_common::types::EfficiencyMetrics;
+use orbit_common::types::{AgentFamily, EfficiencyMetrics, PlanningRoleAssignment, RoleSlot};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub(super) struct PlanningDuelRoleMetrics {
-    pub agent: String,
-    pub model: String,
+    pub family: AgentFamily,
+    pub slot: RoleSlot,
     pub activity_id: String,
     pub efficiency: PlanningDuelEfficiency,
 }
@@ -24,17 +24,20 @@ pub(super) struct PlanningDuelEfficiency {
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub(super) struct PlanningDuelWinnerArtifact {
-    pub winner_agent_cli: String,
-    pub winner_model: String,
+    pub winner_family: AgentFamily,
+    pub winner_slot: Option<RoleSlot>,
     pub artifact_path: String,
-    pub arbiter_agent_cli: String,
-    pub arbiter_model: String,
+    pub arbiter_family: AgentFamily,
     pub arbiter_rationale: String,
 }
 
 #[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
 pub(super) struct PlanningDuelWinnerMarker {
+    #[serde(default)]
+    pub winner_slot: Option<RoleSlot>,
+    #[serde(default)]
     pub winner_agent_cli: String,
+    #[serde(default)]
     pub winner_model: String,
     #[serde(default)]
     pub artifact_path: Option<String>,
@@ -42,6 +45,8 @@ pub(super) struct PlanningDuelWinnerMarker {
     pub arbiter_agent_cli: Option<String>,
     #[serde(default)]
     pub arbiter_model: Option<String>,
+    #[serde(default)]
+    pub arbiter_family: Option<AgentFamily>,
     pub arbiter_rationale: String,
 }
 
@@ -49,7 +54,8 @@ pub(super) struct PlanningDuelWinnerMarker {
 pub(super) struct PlanningDuelPlanArtifact {
     pub path: String,
     pub content: String,
-    pub author: orbit_common::types::PlanningRoleAssignment,
+    pub author: PlanningRoleAssignment,
+    pub slot: Option<RoleSlot>,
 }
 
 pub(super) fn into_efficiency_metrics(value: PlanningDuelEfficiency) -> EfficiencyMetrics {

--- a/crates/orbit-engine/src/executor/automation/duel/select_roles.rs
+++ b/crates/orbit-engine/src/executor/automation/duel/select_roles.rs
@@ -105,7 +105,7 @@ fn orchestrator_model_for<H: RuntimeHost + ?Sized>(
         .ok_or_else(|| {
             OrbitError::Execution(format!(
                 "no registered model pair for agent family '{family}' — \
-                 update orbit_common::types::agent_pair::resolve_agent_model_pair"
+                 add [duel.models].{family} or configure an executor model-pair override"
             ))
         })
 }

--- a/crates/orbit-exec/src/macos_sandbox.rs
+++ b/crates/orbit-exec/src/macos_sandbox.rs
@@ -1060,7 +1060,7 @@ mod tests {
         let db_wal_path = global.join("orbit.db-wal");
         let artifact_path = global
             .join("tasks/workspaces/orbit-test/ORB-00009/artifacts/files/planning-duel")
-            .join("gemini-gemini-3.1-pro.md");
+            .join("planner_a.md");
         let semantic_wal_path = workspace.join("state/semantic.db-wal");
         let denied_path = global.join("not-allowed.txt");
 

--- a/crates/orbit-store/src/file/friction_store.rs
+++ b/crates/orbit-store/src/file/friction_store.rs
@@ -6,7 +6,7 @@ use chrono::{DateTime, Datelike, TimeZone, Utc};
 use orbit_common::friction::DEFAULT_FRICTION_TAGS;
 use orbit_common::types::{
     FrictionFrontmatter, FrictionRecord, FrictionStatus, OrbitError, Task, TaskStatus,
-    all_agent_families, normalize_optional_attribution_label, resolve_agent_model_pair,
+    all_agent_families, infer_agent_family_from_model, normalize_optional_attribution_label,
 };
 use orbit_common::utility::fs::{atomic_write_text, with_exclusive_file_lock};
 use serde_json::{Value, json};
@@ -243,41 +243,40 @@ pub fn friction_stats(frictions_root: &Path, tasks: &[Task]) -> Result<Value, Or
             resolved_at >= month_start && resolved_at < next_month_start
         })
         .count() as u64;
-    let tasks_done = completed_tasks_by_model(tasks);
-    let mut frictions_by_model: BTreeMap<String, u64> = BTreeMap::new();
-    let mut frictions_by_tag_model: BTreeMap<String, BTreeMap<String, u64>> = BTreeMap::new();
-    let mut models = BTreeSet::new();
+    let tasks_done = completed_tasks_by_family(tasks);
+    let mut frictions_by_family: BTreeMap<String, u64> = BTreeMap::new();
+    let mut frictions_by_tag_family: BTreeMap<String, BTreeMap<String, u64>> = BTreeMap::new();
+    let mut families = BTreeSet::new();
 
     for stored in &records {
-        models.insert(stored.record.model.clone());
-        *frictions_by_model
-            .entry(stored.record.model.clone())
-            .or_insert(0) += 1;
+        let family = friction_family_key(&stored.record.model);
+        families.insert(family.clone());
+        *frictions_by_family.entry(family.clone()).or_insert(0) += 1;
         for tag in &stored.record.tags {
-            *frictions_by_tag_model
+            *frictions_by_tag_family
                 .entry(tag.clone())
                 .or_default()
-                .entry(stored.record.model.clone())
+                .entry(family.clone())
                 .or_insert(0) += 1;
         }
     }
-    models.extend(tasks_done.keys().cloned());
-    models.extend(known_family_model_keys());
+    families.extend(tasks_done.keys().cloned());
+    families.extend(known_family_keys());
 
-    let mut by_model = serde_json::Map::new();
-    for model in &models {
-        let frictions = frictions_by_model.get(model).copied().unwrap_or(0);
-        let done = tasks_done.get(model).copied().unwrap_or(0);
-        by_model.insert(model.clone(), rate_row(frictions, done));
+    let mut by_family = serde_json::Map::new();
+    for family in &families {
+        let frictions = frictions_by_family.get(family).copied().unwrap_or(0);
+        let done = tasks_done.get(family).copied().unwrap_or(0);
+        by_family.insert(family.clone(), rate_row(frictions, done));
     }
 
     let mut by_tag = serde_json::Map::new();
-    for (tag, by_model_counts) in frictions_by_tag_model {
+    for (tag, by_family_counts) in frictions_by_tag_family {
         let mut tag_map = serde_json::Map::new();
-        for model in &models {
-            let frictions = by_model_counts.get(model).copied().unwrap_or(0);
-            let done = tasks_done.get(model).copied().unwrap_or(0);
-            tag_map.insert(model.clone(), rate_row(frictions, done));
+        for family in &families {
+            let frictions = by_family_counts.get(family).copied().unwrap_or(0);
+            let done = tasks_done.get(family).copied().unwrap_or(0);
+            tag_map.insert(family.clone(), rate_row(frictions, done));
         }
         by_tag.insert(tag, Value::Object(tag_map));
     }
@@ -288,7 +287,7 @@ pub fn friction_stats(frictions_root: &Path, tasks: &[Task]) -> Result<Value, Or
         "triaged": triaged,
         "resolved": resolved,
         "resolved_this_month": resolved_this_month,
-        "by_model": Value::Object(by_model),
+        "by_family": Value::Object(by_family),
         "by_tag": Value::Object(by_tag),
     }))
 }
@@ -536,7 +535,7 @@ fn validate_friction_id(id: &str) -> Result<(), OrbitError> {
     }
 }
 
-fn completed_tasks_by_model(tasks: &[Task]) -> BTreeMap<String, u64> {
+fn completed_tasks_by_family(tasks: &[Task]) -> BTreeMap<String, u64> {
     let mut counts = BTreeMap::new();
     for task in tasks {
         if !matches!(task.status, TaskStatus::Done | TaskStatus::Archived) {
@@ -548,17 +547,20 @@ fn completed_tasks_by_model(tasks: &[Task]) -> BTreeMap<String, u64> {
         ) else {
             continue;
         };
-        *counts.entry(model).or_insert(0) += 1;
+        *counts.entry(friction_family_key(&model)).or_insert(0) += 1;
     }
     counts
 }
 
-fn known_family_model_keys() -> impl Iterator<Item = String> {
-    all_agent_families().into_iter().map(|family| {
-        resolve_agent_model_pair(family)
-            .map(|pair| pair.orchestrator)
-            .unwrap_or_else(|| family.to_string())
-    })
+fn friction_family_key(value: &str) -> String {
+    let normalized = normalize_optional_attribution_label(Some(value), None).unwrap_or_default();
+    infer_agent_family_from_model(&normalized).unwrap_or(normalized)
+}
+
+fn known_family_keys() -> impl Iterator<Item = String> {
+    all_agent_families()
+        .into_iter()
+        .map(|family| family.to_string())
 }
 
 fn rate_row(frictions: u64, tasks_done: u64) -> Value {
@@ -616,17 +618,17 @@ mod tests {
     fn stats_render_zero_task_model_rate_as_na() {
         let temp = tempfile::tempdir().expect("tempdir");
         let root = temp.path();
-        add_friction(root, params("gpt-zero", Utc::now(), vec!["tooling"])).expect("add friction");
+        add_friction(root, params("grok", Utc::now(), vec!["tooling"])).expect("add friction");
         let mut done = task("T1", TaskStatus::Done);
-        done.implemented_by = Some("gpt-done".to_string());
+        done.implemented_by = Some("codex".to_string());
 
         let stats = friction_stats(root, &[done]).expect("stats");
         assert_eq!(
-            stats["by_model"]["gpt-zero"]["frictions_per_10_tasks"],
+            stats["by_family"]["grok"]["frictions_per_10_tasks"],
             json!("n/a")
         );
         assert_eq!(
-            stats["by_model"]["gpt-done"]["frictions_per_10_tasks"],
+            stats["by_family"]["codex"]["frictions_per_10_tasks"],
             json!(0.0)
         );
     }
@@ -638,10 +640,10 @@ mod tests {
 
         let stats = friction_stats(root, &[]).expect("stats");
 
-        assert_eq!(stats["by_model"]["grok-4"]["frictions"], json!(0));
-        assert_eq!(stats["by_model"]["grok-4"]["tasks_done"], json!(0));
+        assert_eq!(stats["by_family"]["grok"]["frictions"], json!(0));
+        assert_eq!(stats["by_family"]["grok"]["tasks_done"], json!(0));
         assert_eq!(
-            stats["by_model"]["grok-4"]["frictions_per_10_tasks"],
+            stats["by_family"]["grok"]["frictions_per_10_tasks"],
             json!("n/a")
         );
     }

--- a/crates/orbit-store/src/file/scoreboard/duel_scoreboard.rs
+++ b/crates/orbit-store/src/file/scoreboard/duel_scoreboard.rs
@@ -32,7 +32,6 @@ use std::process::Command;
 
 use orbit_common::types::{
     Ambiguity, Decision, DuelRun, OrbitError, TaskScope, Verdict, all_agent_families,
-    resolve_agent_model_pair,
 };
 use serde::{Deserialize, Serialize};
 
@@ -393,9 +392,7 @@ pub fn aggregate(runs: &[DuelRun], filter: AggregateFilter) -> Aggregates {
 }
 
 fn default_orchestrator_model(family: &str) -> String {
-    resolve_agent_model_pair(family)
-        .map(|pair| pair.orchestrator)
-        .unwrap_or_else(|| family.to_string())
+    family.to_string()
 }
 
 fn segment_key_for(run: &DuelRun, axis: SegmentBy) -> String {
@@ -538,15 +535,15 @@ mod tests {
 
         assert!(aggregates.rows.iter().any(|row| row.role == "implementer"
             && row.agent == "grok"
-            && row.model == "grok-4"
+            && row.model == "grok"
             && row.runs == 0));
         assert!(aggregates.rows.iter().any(|row| row.role == "reviewer"
             && row.agent == "grok"
-            && row.model == "grok-4"
+            && row.model == "grok"
             && row.runs == 0));
         assert!(aggregates.rows.iter().any(|row| row.role == "arbiter"
             && row.agent == "grok"
-            && row.model == "grok-4"
+            && row.model == "grok"
             && row.runs == 0));
     }
 

--- a/crates/orbit-store/src/file/scoreboard/planning_duel_scoreboard.rs
+++ b/crates/orbit-store/src/file/scoreboard/planning_duel_scoreboard.rs
@@ -9,9 +9,7 @@ use std::collections::BTreeMap;
 use std::fs;
 use std::path::Path;
 
-use orbit_common::types::{
-    OrbitError, PlannerSlot, PlanningDuelRun, all_agent_families, resolve_agent_model_pair,
-};
+use orbit_common::types::{OrbitError, PlannerSlot, PlanningDuelRun, all_agent_families};
 use serde::{Deserialize, Serialize};
 
 use orbit_common::utility::fs::{
@@ -57,8 +55,7 @@ pub struct AggregateFilter {
 #[derive(Debug, Clone, PartialEq, Serialize)]
 pub struct AggregateRow {
     pub role: &'static str,
-    pub agent: String,
-    pub model: String,
+    pub family: String,
     pub runs: u32,
     pub points: u32,
     pub avg_wall_seconds: f64,
@@ -69,7 +66,7 @@ pub struct AggregateRow {
     pub avg_byte_proxy_total: Option<f64>,
 }
 
-/// Aggregation result. Rows are sorted by role, agent, and model for
+/// Aggregation result. Rows are sorted by role and family for
 /// deterministic rendering.
 #[derive(Debug, Clone, PartialEq, Serialize)]
 pub struct Aggregates {
@@ -129,7 +126,7 @@ fn load_scoreboard_file(path: &Path) -> Result<PlanningDuelScoreboardFile, Orbit
 
 /// Reduce `runs` into an [`Aggregates`] report.
 pub fn aggregate(runs: &[PlanningDuelRun], filter: AggregateFilter) -> Aggregates {
-    let mut buckets: BTreeMap<(String, &'static str, String, String), Bucket> = BTreeMap::new();
+    let mut buckets: BTreeMap<(String, &'static str, String), Bucket> = BTreeMap::new();
 
     let roles_to_emit: &[RoleAxis] = match filter.role {
         Some(RoleAxis::PlannerA) => &[RoleAxis::PlannerA],
@@ -169,8 +166,7 @@ pub fn aggregate(runs: &[PlanningDuelRun], filter: AggregateFilter) -> Aggregate
             let key = (
                 role_name.to_string(),
                 role_name,
-                assignment.agent.clone(),
-                assignment.model.clone(),
+                assignment.family.to_string(),
             );
             let bucket = buckets.entry(key).or_default();
             bucket.runs += 1;
@@ -190,12 +186,11 @@ pub fn aggregate(runs: &[PlanningDuelRun], filter: AggregateFilter) -> Aggregate
 
     let rows = buckets
         .into_iter()
-        .map(|((_, role, agent, model), b)| {
+        .map(|((_, role, family), b)| {
             let runs = b.runs.max(1) as f64;
             AggregateRow {
                 role,
-                agent,
-                model,
+                family,
                 runs: b.runs,
                 points: b.points,
                 avg_wall_seconds: (b.wall_ms_sum as f64 / runs) / 1_000.0,
@@ -218,19 +213,14 @@ pub fn aggregate(runs: &[PlanningDuelRun], filter: AggregateFilter) -> Aggregate
 }
 
 fn seed_zero_family_rows(
-    buckets: &mut BTreeMap<(String, &'static str, String, String), Bucket>,
+    buckets: &mut BTreeMap<(String, &'static str, String), Bucket>,
     roles_to_emit: &[RoleAxis],
 ) {
     for role in roles_to_emit {
         let role_name = role_name(*role);
         for family in all_agent_families() {
             buckets
-                .entry((
-                    role_name.to_string(),
-                    role_name,
-                    family.to_string(),
-                    default_orchestrator_model(family),
-                ))
+                .entry((role_name.to_string(), role_name, family.to_string()))
                 .or_default();
         }
     }
@@ -242,12 +232,6 @@ fn role_name(role: RoleAxis) -> &'static str {
         RoleAxis::PlannerB => "planner_b",
         RoleAxis::Arbiter => "arbiter",
     }
-}
-
-fn default_orchestrator_model(family: &str) -> String {
-    resolve_agent_model_pair(family)
-        .map(|pair| pair.orchestrator)
-        .unwrap_or_else(|| family.to_string())
 }
 
 // ============================================================================
@@ -262,7 +246,7 @@ mod tests {
 
     use chrono::Utc;
     use orbit_common::types::{
-        EfficiencyMetrics, PlannerSlot, PlanningEfficiency, PlanningOutcome,
+        AgentFamily, EfficiencyMetrics, PlannerSlot, PlanningEfficiency, PlanningOutcome,
         PlanningRoleAssignment, PlanningRoles,
     };
 
@@ -305,18 +289,24 @@ mod tests {
     fn aggregate_emits_zero_rows_for_known_families() {
         let aggregates = aggregate(&[], AggregateFilter::default());
 
-        assert!(aggregates.rows.iter().any(|row| row.role == "planner_a"
-            && row.agent == "grok"
-            && row.model == "grok-4"
-            && row.runs == 0));
-        assert!(aggregates.rows.iter().any(|row| row.role == "planner_b"
-            && row.agent == "grok"
-            && row.model == "grok-4"
-            && row.runs == 0));
-        assert!(aggregates.rows.iter().any(|row| row.role == "arbiter"
-            && row.agent == "grok"
-            && row.model == "grok-4"
-            && row.runs == 0));
+        assert!(
+            aggregates
+                .rows
+                .iter()
+                .any(|row| row.role == "planner_a" && row.family == "grok" && row.runs == 0)
+        );
+        assert!(
+            aggregates
+                .rows
+                .iter()
+                .any(|row| row.role == "planner_b" && row.family == "grok" && row.runs == 0)
+        );
+        assert!(
+            aggregates
+                .rows
+                .iter()
+                .any(|row| row.role == "arbiter" && row.family == "grok" && row.runs == 0)
+        );
     }
 
     fn test_run(run_id: String) -> PlanningDuelRun {
@@ -325,9 +315,9 @@ mod tests {
             task_id: "T-test".to_string(),
             completed_at: Utc::now(),
             roles: PlanningRoles {
-                planner_a: role("codex", "gpt-5.5"),
-                planner_b: role("claude", "opus"),
-                arbiter: role("gemini", "pro"),
+                planner_a: role(AgentFamily::Codex),
+                planner_b: role(AgentFamily::Claude),
+                arbiter: role(AgentFamily::Gemini),
             },
             planner_a_artifact_path: "artifacts/planner-a.md".to_string(),
             planner_b_artifact_path: "artifacts/planner-b.md".to_string(),
@@ -343,11 +333,8 @@ mod tests {
         }
     }
 
-    fn role(agent: &str, model: &str) -> PlanningRoleAssignment {
-        PlanningRoleAssignment {
-            agent: agent.to_string(),
-            model: model.to_string(),
-        }
+    fn role(family: AgentFamily) -> PlanningRoleAssignment {
+        PlanningRoleAssignment { family }
     }
 
     fn metrics() -> EfficiencyMetrics {

--- a/crates/orbit-store/src/file/scoreboard/scoreboard_summary.rs
+++ b/crates/orbit-store/src/file/scoreboard/scoreboard_summary.rs
@@ -5,7 +5,8 @@ use std::path::Path;
 use chrono::{DateTime, Duration, Utc};
 use orbit_common::types::{
     JobRun, JobRunState, OrbitError, PlannerSlot, Task, TaskStatus, all_agent_families,
-    normalize_attribution_label, normalize_optional_attribution_label, resolve_agent_model_pair,
+    infer_agent_family_from_model, normalize_attribution_label,
+    normalize_optional_attribution_label,
 };
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -23,7 +24,7 @@ const TASK_REVIEW_THREADS_METRIC: &str = "task-review-threads";
 const LEGACY_TASK_REVIEW_MESSAGES_METRIC: &str = "task-review-messages";
 const RECENT_WINDOW_DAYS: i64 = 7;
 
-type ModelScoreboard = BTreeMap<String, BTreeMap<String, u64>>;
+type FamilyScoreboard = BTreeMap<String, BTreeMap<String, u64>>;
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
 pub struct TokenSummary {
@@ -237,7 +238,7 @@ pub fn generate_summary_with_inputs(
         let Some(model) = token_row
             .model
             .as_deref()
-            .map(model_key)
+            .map(family_key)
             .filter(|value| !value.is_empty())
         else {
             continue;
@@ -256,38 +257,41 @@ pub fn generate_summary_with_inputs(
     overlay_audit_tool_calls(&mut agents, audit_tool_calls);
     overlay_audit_tool_calls_by_surface(&mut agents, inputs.audit_tool_calls_by_surface);
 
+    // Planning-duel rows are the "who actually ran?" scoreboard projection:
+    // metrics are recorded from invocation family + slot, while the stored
+    // roles identify the selected family for each slot.
     for run in planning_duel_scoreboard::load_runs(scoreboard_dir)? {
         let planner_a = agents
-            .entry(model_key(&run.roles.planner_a.model))
+            .entry(run.roles.planner_a.family.to_string())
             .or_default();
         planner_a.duels.participated = planner_a.duels.participated.saturating_add(1);
         let planner_b = agents
-            .entry(model_key(&run.roles.planner_b.model))
+            .entry(run.roles.planner_b.family.to_string())
             .or_default();
         planner_b.duels.participated = planner_b.duels.participated.saturating_add(1);
         let arbiter = agents
-            .entry(model_key(&run.roles.arbiter.model))
+            .entry(run.roles.arbiter.family.to_string())
             .or_default();
         arbiter.duels.participated = arbiter.duels.participated.saturating_add(1);
 
         match run.outcome.winner {
             PlannerSlot::PlannerA => {
                 let planner_a = agents
-                    .entry(model_key(&run.roles.planner_a.model))
+                    .entry(run.roles.planner_a.family.to_string())
                     .or_default();
                 planner_a.duels.wins = planner_a.duels.wins.saturating_add(1);
                 let planner_b = agents
-                    .entry(model_key(&run.roles.planner_b.model))
+                    .entry(run.roles.planner_b.family.to_string())
                     .or_default();
                 planner_b.duels.losses = planner_b.duels.losses.saturating_add(1);
             }
             PlannerSlot::PlannerB => {
                 let planner_b = agents
-                    .entry(model_key(&run.roles.planner_b.model))
+                    .entry(run.roles.planner_b.family.to_string())
                     .or_default();
                 planner_b.duels.wins = planner_b.duels.wins.saturating_add(1);
                 let planner_a = agents
-                    .entry(model_key(&run.roles.planner_a.model))
+                    .entry(run.roles.planner_a.family.to_string())
                     .or_default();
                 planner_a.duels.losses = planner_a.duels.losses.saturating_add(1);
             }
@@ -301,7 +305,7 @@ pub fn generate_summary_with_inputs(
                 task.implemented_by.as_deref(),
             )
         {
-            let summary = agents.entry(model_key(&model)).or_default();
+            let summary = agents.entry(family_key(&model)).or_default();
             summary.tasks_completed = summary.tasks_completed.saturating_add(1);
         }
 
@@ -313,7 +317,7 @@ pub fn generate_summary_with_inputs(
             .map(|raw| normalize_attribution_label(raw, None))
             .filter(|value| !value.is_empty())
         {
-            let summary = agents.entry(label).or_default();
+            let summary = agents.entry(family_key(&label)).or_default();
             summary.tasks_created = summary.tasks_created.saturating_add(1);
         }
         if let Some(label) = task
@@ -322,7 +326,7 @@ pub fn generate_summary_with_inputs(
             .map(|raw| normalize_attribution_label(raw, None))
             .filter(|value| !value.is_empty())
         {
-            let summary = agents.entry(label).or_default();
+            let summary = agents.entry(family_key(&label)).or_default();
             summary.tasks_planned = summary.tasks_planned.saturating_add(1);
         }
     }
@@ -442,15 +446,15 @@ pub fn summary_path(scoreboard_dir: &Path) -> std::path::PathBuf {
 fn read_model_scoreboard(
     scoreboard_dir: &Path,
     file_name: &str,
-) -> Result<ModelScoreboard, OrbitError> {
+) -> Result<FamilyScoreboard, OrbitError> {
     let path = scoreboard_dir.join(file_name);
     if !path.exists() {
-        return Ok(ModelScoreboard::new());
+        return Ok(FamilyScoreboard::new());
     }
     let raw =
         fs::read_to_string(&path).map_err(|e| OrbitError::Io(format!("read {file_name}: {e}")))?;
     if raw.trim().is_empty() {
-        return Ok(ModelScoreboard::new());
+        return Ok(FamilyScoreboard::new());
     }
     let parsed: Value = serde_json::from_str(&raw)
         .map_err(|e| OrbitError::Io(format!("parse {file_name}: {e}")))?;
@@ -474,16 +478,16 @@ fn read_token_agents(scoreboard_dir: &Path) -> Result<Vec<TokenAgentEntry>, Orbi
 
 fn overlay_nested_metric(
     agents: &mut BTreeMap<String, AgentSummary>,
-    scoreboard: &ModelScoreboard,
+    scoreboard: &FamilyScoreboard,
     metric: &str,
     mut apply: impl FnMut(&mut AgentSummary, u64),
 ) {
-    let Some(by_model) = scoreboard.get(metric) else {
+    let Some(by_family) = scoreboard.get(metric) else {
         return;
     };
 
-    for (model, value) in by_model {
-        let summary = agents.entry(model_key(model)).or_default();
+    for (family, value) in by_family {
+        let summary = agents.entry(family_key(family)).or_default();
         apply(summary, *value);
     }
 }
@@ -493,11 +497,11 @@ fn overlay_audit_tool_calls_by_surface(
     rows: &[AuditToolCallCountsBySurfaceAndRole],
 ) {
     for row in rows {
-        let model = model_key(&row.role);
-        if model.is_empty() {
+        let family = family_key(&row.role);
+        if family.is_empty() {
             continue;
         }
-        let summary = agents.entry(model).or_default();
+        let summary = agents.entry(family).or_default();
         let entry = summary
             .tool_calls_by_surface
             .entry(row.surface.clone())
@@ -510,43 +514,38 @@ fn overlay_audit_tool_calls(
     agents: &mut BTreeMap<String, AgentSummary>,
     audit_tool_calls: &[AuditToolCallCountsByRole],
 ) {
-    let mut by_model: BTreeMap<String, (u64, u64)> = BTreeMap::new();
+    let mut by_family: BTreeMap<String, (u64, u64)> = BTreeMap::new();
     for row in audit_tool_calls {
-        let model = model_key(&row.role);
-        if model.is_empty() {
+        let family = family_key(&row.role);
+        if family.is_empty() {
             continue;
         }
-        let entry = by_model.entry(model).or_default();
+        let entry = by_family.entry(family).or_default();
         entry.0 = entry.0.saturating_add(row.total);
         entry.1 = entry.1.saturating_add(row.failed);
     }
 
-    for (model, (total, failed)) in by_model {
-        let summary = agents.entry(model).or_default();
+    for (family, (total, failed)) in by_family {
+        let summary = agents.entry(family).or_default();
         // Total competes with token scoreboard data; failures only exist in audit rows.
         summary.tool_calls = summary.tool_calls.max(total);
         summary.failed_tool_calls = summary.failed_tool_calls.saturating_add(failed);
     }
 }
 
-fn model_key(model: &str) -> String {
-    normalize_attribution_label(model, None)
+fn family_key(label: &str) -> String {
+    let normalized = normalize_attribution_label(label, None);
+    infer_agent_family_from_model(&normalized).unwrap_or(normalized)
 }
 
 fn seed_known_family_agents(agents: &mut BTreeMap<String, AgentSummary>) {
     for family in all_agent_families() {
-        let model = resolve_agent_model_pair(family)
-            .map(|pair| pair.orchestrator)
-            .unwrap_or_else(|| family.to_string());
-        let key = model_key(&model);
-        if !key.is_empty() {
-            agents.entry(key).or_default();
-        }
+        agents.entry(family.to_string()).or_default();
     }
 }
 
-fn normalize_model_scoreboard(parsed: Value) -> Result<ModelScoreboard, OrbitError> {
-    let mut normalized = ModelScoreboard::new();
+fn normalize_model_scoreboard(parsed: Value) -> Result<FamilyScoreboard, OrbitError> {
+    let mut normalized = FamilyScoreboard::new();
     let Value::Object(metrics) = parsed else {
         return Err(OrbitError::Io(
             "scoreboard json must be an object".to_string(),
@@ -557,7 +556,7 @@ fn normalize_model_scoreboard(parsed: Value) -> Result<ModelScoreboard, OrbitErr
         let Value::Object(entries) = metric_value else {
             continue;
         };
-        let model_entries = normalized
+        let family_entries = normalized
             .entry(canonical_scoreboard_metric(&metric).to_string())
             .or_default();
         for (first_key, first_value) in entries {
@@ -566,17 +565,17 @@ fn normalize_model_scoreboard(parsed: Value) -> Result<ModelScoreboard, OrbitErr
                     let value = number.as_u64().ok_or_else(|| {
                         OrbitError::Io("scoreboard counter must be u64".to_string())
                     })?;
-                    *model_entries.entry(first_key).or_insert(0) += value;
+                    *family_entries.entry(family_key(&first_key)).or_insert(0) += value;
                 }
                 Value::Object(inner) => {
-                    for (model, value) in inner {
+                    for (family, value) in inner {
                         let Value::Number(number) = value else {
                             continue;
                         };
                         let count = number.as_u64().ok_or_else(|| {
                             OrbitError::Io("scoreboard counter must be u64".to_string())
                         })?;
-                        *model_entries.entry(model).or_insert(0) += count;
+                        *family_entries.entry(family_key(&family)).or_insert(0) += count;
                     }
                 }
                 _ => {}
@@ -620,9 +619,9 @@ mod tests {
         )
         .expect("generate summary");
 
-        let gpt5 = summary.agents.get("gpt-5").expect("gpt-5 summary");
-        assert_eq!(gpt5.tool_calls, 3);
-        assert_eq!(gpt5.failed_tool_calls, 2);
+        let codex = summary.agents.get("codex").expect("codex summary");
+        assert_eq!(codex.tool_calls, 3);
+        assert_eq!(codex.failed_tool_calls, 2);
     }
 
     #[test]
@@ -631,10 +630,38 @@ mod tests {
 
         let summary = generate_summary(temp.path(), &[]).expect("generate summary");
 
-        let grok = summary.agents.get("grok-4").expect("grok summary");
+        let grok = summary.agents.get("grok").expect("grok summary");
         assert_eq!(grok.tasks_completed, 0);
         assert_eq!(grok.duels.participated, 0);
         assert_eq!(grok.task_review.threads, 0);
+    }
+
+    #[test]
+    fn summary_agent_keys_are_families_not_models() {
+        let temp = tempfile::tempdir().expect("create tempdir");
+        fs::create_dir_all(temp.path()).expect("create scoreboard dir");
+        fs::write(
+            temp.path().join("tokens.json"),
+            r#"{
+              "agents": [
+                { "agent": "codex", "model": "gpt-5.5", "total_tokens": 1 },
+                { "agent": "claude", "model": "claude-opus-4-7", "total_tokens": 1 },
+                { "agent": "grok", "model": "grok-4", "total_tokens": 1 }
+              ]
+            }"#,
+        )
+        .expect("write tokens scoreboard");
+
+        let summary = generate_summary(temp.path(), &[]).expect("generate summary");
+        for forbidden in ["grok-4", "claude-opus-4-7", "gpt-5.5"] {
+            assert!(
+                !summary.agents.contains_key(forbidden),
+                "model key leaked into summary agents: {forbidden}"
+            );
+        }
+        for family in ["codex", "claude", "gemini", "grok"] {
+            assert!(summary.agents.contains_key(family));
+        }
     }
 
     #[test]
@@ -668,11 +695,11 @@ mod tests {
         )
         .expect("generate summary");
 
-        let gpt5 = summary.agents.get("gpt-5").expect("gpt-5 summary");
-        assert_eq!(gpt5.tokens.total, 10);
-        assert_eq!(gpt5.tokens.output, 4);
-        assert_eq!(gpt5.tool_calls, 5);
-        assert_eq!(gpt5.failed_tool_calls, 2);
+        let codex = summary.agents.get("codex").expect("codex summary");
+        assert_eq!(codex.tokens.total, 10);
+        assert_eq!(codex.tokens.output, 4);
+        assert_eq!(codex.tool_calls, 5);
+        assert_eq!(codex.failed_tool_calls, 2);
     }
 
     #[test]
@@ -706,11 +733,11 @@ mod tests {
         )
         .expect("generate summary");
 
-        let gpt5 = summary.agents.get("gpt-5").expect("gpt-5 summary");
-        assert_eq!(gpt5.tokens.total, 10);
-        assert_eq!(gpt5.tokens.output, 4);
-        assert_eq!(gpt5.tool_calls, 7);
-        assert_eq!(gpt5.failed_tool_calls, 3);
+        let codex = summary.agents.get("codex").expect("codex summary");
+        assert_eq!(codex.tokens.total, 10);
+        assert_eq!(codex.tokens.output, 4);
+        assert_eq!(codex.tool_calls, 7);
+        assert_eq!(codex.failed_tool_calls, 3);
     }
 
     #[test]
@@ -731,10 +758,7 @@ mod tests {
         let summary = generate_summary(temp.path(), &[]).expect("generate summary");
 
         assert_eq!(summary.schema_version, CURRENT_SCHEMA_VERSION);
-        let reviewer = summary
-            .agents
-            .get("gpt-reviewer")
-            .expect("reviewer summary");
+        let reviewer = summary.agents.get("codex").expect("reviewer summary");
         assert_eq!(reviewer.task_review.threads, 2);
         assert_eq!(reviewer.pr.review_comments, 1);
     }
@@ -759,10 +783,7 @@ mod tests {
 
         let summary = generate_summary(temp.path(), &tasks).expect("generate summary");
 
-        let claude = summary
-            .agents
-            .get("claude-opus-4-7")
-            .expect("claude summary");
+        let claude = summary.agents.get("claude").expect("claude summary");
         // Three tasks were created by claude (Done, Backlog, Rejected).
         assert_eq!(claude.tasks_created, 3);
         // Two were planned by claude (Done, Rejected).
@@ -774,7 +795,7 @@ mod tests {
         // attribute to Completed.
         assert_eq!(claude.tasks_completed, 0);
 
-        let codex = summary.agents.get("gpt-5.5").expect("codex summary");
+        let codex = summary.agents.get("codex").expect("codex summary");
         assert_eq!(codex.tasks_created, 1); // T4
         assert_eq!(codex.tasks_planned, 2); // T2, T4
 
@@ -818,14 +839,11 @@ mod tests {
         )
         .expect("generate summary");
 
-        let claude = summary
-            .agents
-            .get("claude-opus-4-7")
-            .expect("claude summary");
+        let claude = summary.agents.get("claude").expect("claude summary");
         assert_eq!(claude.tool_calls_by_surface.get("graph").copied(), Some(56));
         assert_eq!(claude.tool_calls_by_surface.get("task"), None);
 
-        let codex = summary.agents.get("gpt-5.5").expect("codex summary");
+        let codex = summary.agents.get("codex").expect("codex summary");
         assert_eq!(codex.tool_calls_by_surface.get("graph").copied(), Some(697));
         assert_eq!(codex.tool_calls_by_surface.get("task").copied(), Some(410));
     }
@@ -1082,10 +1100,7 @@ mod tests {
 
         let summary = generate_summary(temp.path(), &[]).expect("generate summary");
 
-        let reviewer = summary
-            .agents
-            .get("gpt-reviewer")
-            .expect("reviewer summary");
+        let reviewer = summary.agents.get("codex").expect("reviewer summary");
         assert_eq!(reviewer.task_review.threads, 2);
     }
 }

--- a/crates/orbit-store/src/sqlite/invocation_store/records.rs
+++ b/crates/orbit-store/src/sqlite/invocation_store/records.rs
@@ -1,9 +1,10 @@
 use std::collections::HashMap;
+use std::str::FromStr;
 
 use chrono::{DateTime, Utc};
 use rusqlite::{params, types::ToSql};
 
-use orbit_common::types::OrbitError;
+use orbit_common::types::{OrbitError, RoleSlot};
 
 use crate::{Store, now_string};
 
@@ -26,16 +27,17 @@ impl Store {
 
         tx.execute(
             r#"INSERT INTO invocations(
-                ts, job_run_id, activity_id, agent, model, duration_ms,
+                ts, job_run_id, activity_id, agent, model, slot, duration_ms,
                 input_tokens, cache_read_tokens, cache_create_tokens,
                 output_tokens, tool_call_count
-            ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)"#,
+            ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)"#,
             params![
                 now_string(),
                 params.job_run_id,
                 params.activity_id,
                 params.agent,
                 params.model,
+                params.slot.map(|slot| slot.as_str().to_string()),
                 params.trace.duration_ms as i64,
                 params.trace.usage.input as i64,
                 params.trace.usage.cache_read as i64,
@@ -202,6 +204,9 @@ fn build_invocation_list_query(filter: &InvocationQuery) -> (String, Vec<Box<dyn
     if let Some(model) = &filter.model {
         query.push_filter("i.model = ?", model.clone());
     }
+    if let Some(slot) = filter.slot {
+        query.push_filter("i.slot = ?", slot.as_str().to_string());
+    }
     if let Some(tool_name) = &filter.tool_name {
         query.push_filter(
             "EXISTS (SELECT 1 FROM tool_calls tc WHERE tc.invocation_id = i.id AND tc.tool_name = ?)",
@@ -213,7 +218,7 @@ fn build_invocation_list_query(filter: &InvocationQuery) -> (String, Vec<Box<dyn
     query.push_value(limit as i64);
 
     let sql = format!(
-        "SELECT i.id, i.ts, i.job_run_id, i.activity_id, i.agent, i.model, i.duration_ms, \
+        "SELECT i.id, i.ts, i.job_run_id, i.activity_id, i.agent, i.model, i.slot, i.duration_ms, \
          i.input_tokens, i.cache_read_tokens, i.cache_create_tokens, i.output_tokens, \
          i.tool_call_count \
          FROM invocations i {} ORDER BY i.ts DESC, i.id DESC LIMIT ?{}",
@@ -226,8 +231,9 @@ fn build_invocation_list_query(filter: &InvocationQuery) -> (String, Vec<Box<dyn
 
 fn map_invocation_record(row: &rusqlite::Row<'_>) -> rusqlite::Result<InvocationRecord> {
     let ts_raw: String = row.get(1)?;
-    let input_tokens = row.get::<_, i64>(7)? as u64;
-    let output_tokens = row.get::<_, i64>(10)? as u64;
+    let slot_raw: Option<String> = row.get(6)?;
+    let input_tokens = row.get::<_, i64>(8)? as u64;
+    let output_tokens = row.get::<_, i64>(11)? as u64;
 
     Ok(InvocationRecord {
         id: row.get(0)?,
@@ -236,13 +242,24 @@ fn map_invocation_record(row: &rusqlite::Row<'_>) -> rusqlite::Result<Invocation
         activity_id: row.get(3)?,
         agent: row.get(4)?,
         model: row.get(5)?,
-        duration_ms: row.get::<_, i64>(6)? as u64,
+        slot: slot_raw
+            .as_deref()
+            .map(RoleSlot::from_str)
+            .transpose()
+            .map_err(|error| {
+                rusqlite::Error::FromSqlConversionFailure(
+                    6,
+                    rusqlite::types::Type::Text,
+                    Box::new(error),
+                )
+            })?,
+        duration_ms: row.get::<_, i64>(7)? as u64,
         input_tokens,
-        cache_read_tokens: row.get::<_, i64>(8)? as u64,
-        cache_create_tokens: row.get::<_, i64>(9)? as u64,
+        cache_read_tokens: row.get::<_, i64>(9)? as u64,
+        cache_create_tokens: row.get::<_, i64>(10)? as u64,
         output_tokens,
         total_tokens: input_tokens.saturating_add(output_tokens),
-        tool_call_count: row.get::<_, i64>(11)? as u64,
+        tool_call_count: row.get::<_, i64>(12)? as u64,
         task_ids: Vec::new(),
         tool_calls: Vec::new(),
     })
@@ -370,5 +387,67 @@ impl Store {
         self.conn
             .lock()
             .map_err(|e| OrbitError::Store(format!("mutex poisoned: {e}")))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use orbit_common::types::{InvocationTrace, RoleSlot};
+
+    use super::*;
+
+    #[test]
+    fn invocation_records_persist_planning_duel_slot() {
+        let store = Store::open_in_memory().expect("open store");
+
+        store
+            .insert_invocation_trace_record(&InvocationInsertParams {
+                job_run_id: "jrun-1".to_string(),
+                activity_id: "propose_duel_plan".to_string(),
+                agent: "gemini".to_string(),
+                model: Some("gemini-3.1-pro".to_string()),
+                slot: Some(RoleSlot::PlannerA),
+                task_ids: vec!["ORB-1".to_string()],
+                trace: InvocationTrace::default(),
+            })
+            .expect("insert invocation");
+
+        let records = store
+            .list_invocation_records(&InvocationQuery {
+                job_run_id: Some("jrun-1".to_string()),
+                slot: Some(RoleSlot::PlannerA),
+                limit: 10,
+                ..InvocationQuery::default()
+            })
+            .expect("list records");
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].slot, Some(RoleSlot::PlannerA));
+    }
+
+    #[test]
+    fn invocation_records_persist_non_duel_slot_as_null() {
+        let store = Store::open_in_memory().expect("open store");
+
+        store
+            .insert_invocation_trace_record(&InvocationInsertParams {
+                job_run_id: "jrun-2".to_string(),
+                activity_id: "implement_one".to_string(),
+                agent: "codex".to_string(),
+                model: Some("gpt-5.5".to_string()),
+                slot: None,
+                task_ids: vec!["ORB-2".to_string()],
+                trace: InvocationTrace::default(),
+            })
+            .expect("insert invocation");
+
+        let records = store
+            .list_invocation_records(&InvocationQuery {
+                job_run_id: Some("jrun-2".to_string()),
+                limit: 10,
+                ..InvocationQuery::default()
+            })
+            .expect("list records");
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].slot, None);
     }
 }

--- a/crates/orbit-store/src/sqlite/invocation_store/types.rs
+++ b/crates/orbit-store/src/sqlite/invocation_store/types.rs
@@ -1,7 +1,7 @@
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
-use orbit_common::types::InvocationTrace;
+use orbit_common::types::{InvocationTrace, RoleSlot};
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
 pub struct InvocationQuery {
@@ -12,6 +12,7 @@ pub struct InvocationQuery {
     pub task_id: Option<String>,
     pub agent: Option<String>,
     pub model: Option<String>,
+    pub slot: Option<RoleSlot>,
     pub tool_name: Option<String>,
     pub limit: usize,
 }
@@ -22,6 +23,7 @@ pub struct InvocationInsertParams {
     pub activity_id: String,
     pub agent: String,
     pub model: Option<String>,
+    pub slot: Option<RoleSlot>,
     pub task_ids: Vec<String>,
     pub trace: InvocationTrace,
 }
@@ -42,6 +44,7 @@ pub struct InvocationRecord {
     pub activity_id: String,
     pub agent: String,
     pub model: Option<String>,
+    pub slot: Option<RoleSlot>,
     pub duration_ms: u64,
     pub input_tokens: u64,
     pub cache_read_tokens: u64,

--- a/crates/orbit-store/src/sqlite/migration.rs
+++ b/crates/orbit-store/src/sqlite/migration.rs
@@ -82,6 +82,7 @@ pub(crate) fn apply_schema(conn: &Connection) -> Result<(), OrbitError> {
                 activity_id TEXT NOT NULL,
                 agent TEXT NOT NULL,
                 model TEXT,
+                slot TEXT,
                 duration_ms INTEGER NOT NULL DEFAULT 0,
                 input_tokens INTEGER NOT NULL DEFAULT 0,
                 cache_read_tokens INTEGER NOT NULL DEFAULT 0,
@@ -393,6 +394,7 @@ fn ensure_audit_events_schema(conn: &Connection) -> Result<(), OrbitError> {
 }
 
 fn ensure_invocation_schema(conn: &Connection) -> Result<(), OrbitError> {
+    add_column_if_missing(conn, "ALTER TABLE invocations ADD COLUMN slot TEXT")?;
     conn.execute_batch(
         r#"
             CREATE INDEX IF NOT EXISTS idx_invocations_job_run_id

--- a/crates/orbit-tools/src/builtin/orbit/duel/plan_add.rs
+++ b/crates/orbit-tools/src/builtin/orbit/duel/plan_add.rs
@@ -1,44 +1,64 @@
-use orbit_common::types::{OrbitError, ToolParam, ToolSchema};
+use orbit_common::types::{AgentFamily, OrbitError, RoleSlot, ToolParam, ToolSchema};
 use serde_json::{Value, json};
 
 use crate::{OrbitBuiltinAction, Tool, ToolContext};
 
 pub struct OrbitDuelPlanAddTool;
 
-fn expected_signature(agent: &str, model: &str) -> String {
-    format!("*authored by: {agent} / {model}*")
+fn expected_signature(family: AgentFamily, slot: RoleSlot) -> String {
+    format!("*authored by: {} / {}*", family.as_str(), slot.as_str())
+}
+
+fn role_slot(ctx: &ToolContext, input: &Value) -> Result<RoleSlot, OrbitError> {
+    if let Some(slot) = ctx.role_slot {
+        return Ok(slot);
+    }
+    input
+        .get("planning_duel_slot")
+        .or_else(|| input.get("role_slot"))
+        .or_else(|| input.get("slot"))
+        .and_then(Value::as_str)
+        .ok_or_else(|| {
+            OrbitError::InvalidInput(
+                "orbit.duel.plan.add requires planning_duel_slot to derive the artifact path"
+                    .to_string(),
+            )
+        })?
+        .parse()
 }
 
 fn build_update_input(ctx: &ToolContext, input: &Value) -> Result<Value, OrbitError> {
     let identity = super::super::resolve_identity(ctx, input)?;
-    let agent = identity.agent.clone().ok_or_else(|| {
+    let family = identity.agent.as_deref().ok_or_else(|| {
         OrbitError::InvalidInput(
             "orbit.duel.plan.add requires agent identity to derive the artifact path".to_string(),
         )
     })?;
-    let model = identity.model.clone().ok_or_else(|| {
-        OrbitError::InvalidInput(
-            "orbit.duel.plan.add requires model identity to derive the artifact path".to_string(),
-        )
-    })?;
+    let family = AgentFamily::parse(family)?;
+    let slot = role_slot(ctx, input)?;
+    if slot.planner_slot().is_none() {
+        return Err(OrbitError::InvalidInput(
+            "orbit.duel.plan.add only accepts planner_a or planner_b slots".to_string(),
+        ));
+    }
     let id = super::super::required_string(input, &["id"], "id")?;
     let content = super::super::required_string(input, &["content", "plan"], "content")?;
     let first_line = content.lines().next().map(str::trim).unwrap_or_default();
-    let expected = expected_signature(&agent, &model);
-    if first_line != expected {
-        return Err(OrbitError::InvalidInput(format!(
-            "planner artifact content must start with `{expected}`"
-        )));
-    }
+    let expected = expected_signature(family, slot);
+    let content = if first_line == expected {
+        content
+    } else {
+        format!("{expected}\n{}", content.trim_start())
+    };
 
     Ok(json!({
         "id": id,
         "artifacts": [{
-            "path": format!("planning-duel/{agent}-{model}.md"),
+            "path": format!("planning-duel/{}.md", slot.as_str()),
             "content": content,
         }],
-        "agent": agent,
-        "model": model,
+        "agent": family.as_str(),
+        "model": family.as_str(),
     }))
 }
 
@@ -47,14 +67,21 @@ impl Tool for OrbitDuelPlanAddTool {
         let mut parameters = super::super::orbit_id_params("task");
         parameters.push(ToolParam {
             name: "content".to_string(),
-            description: "Planner markdown to persist. The first line must match the caller identity as `*authored by: <agent> / <model>*`.".to_string(),
+            description: "Planner markdown body to persist. Orbit stamps `*authored by: <family> / <slot>*` as the first line when absent.".to_string(),
             param_type: "string".to_string(),
             required: true,
+        });
+        parameters.push(ToolParam {
+            name: "planning_duel_slot".to_string(),
+            description: "Planning-duel slot for this proposal: planner_a or planner_b."
+                .to_string(),
+            param_type: "string".to_string(),
+            required: false,
         });
         parameters.extend(super::super::identity_params());
         ToolSchema {
             name: "orbit.duel.plan.add".to_string(),
-            description: "Persist one planning-duel proposal under `planning-duel/<agent>-<model>.md` for the calling agent/model.".to_string(),
+            description: "Persist one planning-duel proposal under `planning-duel/<slot>.md` for the calling family and slot.".to_string(),
             parameters,
             builtin: true,
         }

--- a/crates/orbit-tools/src/builtin/orbit/duel/plan_winner.rs
+++ b/crates/orbit-tools/src/builtin/orbit/duel/plan_winner.rs
@@ -1,7 +1,7 @@
 // ORB-00013: Existing expect calls in this module document local invariants; keep the allow scoped while the workspace lint is ratcheted.
 #![allow(clippy::expect_used)]
 
-use orbit_common::types::{OrbitError, ToolParam, ToolSchema};
+use orbit_common::types::{AgentFamily, OrbitError, RoleSlot, ToolParam, ToolSchema};
 use serde_json::{Value, json};
 
 use crate::{OrbitBuiltinAction, Tool, ToolContext};
@@ -10,41 +10,73 @@ pub struct OrbitDuelPlanWinnerTool;
 
 fn build_update_input(ctx: &ToolContext, input: &Value) -> Result<Value, OrbitError> {
     let identity = super::super::resolve_identity(ctx, input)?;
-    let arbiter_agent = identity.agent.clone().ok_or_else(|| {
+    let arbiter_family = identity.agent.as_deref().ok_or_else(|| {
         OrbitError::InvalidInput(
             "orbit.duel.plan.winner requires agent identity to record the arbiter".to_string(),
         )
     })?;
-    let arbiter_model = identity.model.clone().ok_or_else(|| {
-        OrbitError::InvalidInput(
-            "orbit.duel.plan.winner requires model identity to record the arbiter".to_string(),
-        )
-    })?;
+    let arbiter_family = AgentFamily::parse(arbiter_family)?;
     let id = super::super::required_string(input, &["id"], "id")?;
-    let winner_agent_cli =
-        super::super::required_string(input, &["winner_agent_cli"], "winner_agent_cli")?;
-    let winner_model = super::super::required_string(input, &["winner_model"], "winner_model")?;
+    let winner_slot = input
+        .get("winner_slot")
+        .or_else(|| input.get("winner_role_slot"))
+        .and_then(Value::as_str)
+        .map(str::parse::<RoleSlot>)
+        .transpose()?;
+    let winner_agent_cli = super::super::optional_string_alias(input, &["winner_agent_cli"])?;
+    let winner_model = super::super::optional_string_alias(input, &["winner_model"])?;
+    if winner_slot.is_none() && (winner_agent_cli.is_none() || winner_model.is_none()) {
+        return Err(OrbitError::InvalidInput(
+            "orbit.duel.plan.winner requires winner_slot (or legacy winner_agent_cli and winner_model)"
+                .to_string(),
+        ));
+    }
     let arbiter_rationale = super::super::required_string(
         input,
         &["arbiter_rationale", "rationale"],
         "arbiter_rationale",
     )?;
-    let winner_payload = json!({
-        "winner_agent_cli": winner_agent_cli,
-        "winner_model": winner_model,
-        "artifact_path": format!("planning-duel/{}-{}.md", winner_agent_cli, winner_model),
-        "arbiter_agent_cli": arbiter_agent,
-        "arbiter_model": arbiter_model,
-        "arbiter_rationale": arbiter_rationale,
-    });
+    let mut winner_payload = serde_json::Map::new();
+    if let Some(slot) = winner_slot {
+        if slot.planner_slot().is_none() {
+            return Err(OrbitError::InvalidInput(
+                "winner_slot must be planner_a or planner_b".to_string(),
+            ));
+        }
+        winner_payload.insert(
+            "winner_slot".to_string(),
+            Value::String(slot.as_str().to_string()),
+        );
+        winner_payload.insert(
+            "artifact_path".to_string(),
+            Value::String(format!("planning-duel/{}.md", slot.as_str())),
+        );
+    }
+    if let Some(winner_agent_cli) = winner_agent_cli {
+        winner_payload.insert(
+            "winner_agent_cli".to_string(),
+            Value::String(winner_agent_cli),
+        );
+    }
+    if let Some(winner_model) = winner_model {
+        winner_payload.insert("winner_model".to_string(), Value::String(winner_model));
+    }
+    winner_payload.insert(
+        "arbiter_family".to_string(),
+        Value::String(arbiter_family.as_str().to_string()),
+    );
+    winner_payload.insert(
+        "arbiter_rationale".to_string(),
+        Value::String(arbiter_rationale),
+    );
     Ok(json!({
         "id": id,
         "artifacts": [{
             "path": "planning-duel/winner.json",
             "content": serde_json::to_string(&winner_payload).expect("winner payload serializes"),
         }],
-        "agent": identity.agent,
-        "model": identity.model,
+        "agent": arbiter_family.as_str(),
+        "model": arbiter_family.as_str(),
     }))
 }
 
@@ -53,18 +85,24 @@ impl Tool for OrbitDuelPlanWinnerTool {
         let mut parameters = super::super::orbit_id_params("task");
         parameters.extend([
             ToolParam {
+                name: "winner_slot".to_string(),
+                description: "Winning planner slot: planner_a or planner_b.".to_string(),
+                param_type: "string".to_string(),
+                required: false,
+            },
+            ToolParam {
                 name: "winner_agent_cli".to_string(),
-                description: "Agent CLI family parsed from the winning planner artifact signature."
+                description: "Deprecated legacy winner family field; prefer winner_slot."
                     .to_string(),
                 param_type: "string".to_string(),
-                required: true,
+                required: false,
             },
             ToolParam {
                 name: "winner_model".to_string(),
-                description: "Model parsed from the winning planner artifact signature."
+                description: "Deprecated legacy winner model field; prefer winner_slot."
                     .to_string(),
                 param_type: "string".to_string(),
-                required: true,
+                required: false,
             },
             ToolParam {
                 name: "arbiter_rationale".to_string(),

--- a/crates/orbit-tools/src/builtin/orbit/mod.rs
+++ b/crates/orbit-tools/src/builtin/orbit/mod.rs
@@ -112,19 +112,28 @@ pub(super) fn resolve_identity(
 ) -> Result<OrbitIdentity, OrbitError> {
     let input_agent = optional_string_alias(input, &["agent"])?;
     let input_model = optional_string_alias(input, &["model"])?;
+    let context_agent = trimmed_optional(ctx.agent_name.clone());
+    let context_model = trimmed_optional(ctx.model_name.clone());
+    let context_has_identity = context_agent.is_some() || context_model.is_some();
     let input_has_identity = input_agent
         .as_deref()
         .is_some_and(|value| !value.trim().is_empty())
         || input_model
             .as_deref()
             .is_some_and(|value| !value.trim().is_empty());
-    let (agent, model) = if input_has_identity {
+    let (agent, model) = if context_has_identity {
+        let agent =
+            normalize_agent_family_for_model(context_agent.as_deref(), context_model.as_deref())?;
+        // Runtime-provided identity is authoritative at the tool boundary. If
+        // an agent self-reports a `model` argument, Orbit overwrites it with
+        // the canonical family string so downstream persistence compares
+        // family identity, not unstable model aliases.
+        let model = agent.clone();
+        (agent, model)
+    } else if input_has_identity {
         (trimmed_optional(input_agent), trimmed_optional(input_model))
     } else {
-        (
-            trimmed_optional(ctx.agent_name.clone()),
-            trimmed_optional(ctx.model_name.clone()),
-        )
+        (None, None)
     };
     let agent = normalize_agent_family_for_model(agent.as_deref(), model.as_deref())?;
     let actor_label = build_actor_label(agent.as_deref(), model.as_deref());
@@ -222,6 +231,43 @@ pub(super) fn execute_host_action(
         identity.model,
         ctx.reservation_owner.clone(),
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+
+    #[test]
+    fn runtime_identity_overwrites_self_reported_model_at_tool_boundary() {
+        let ctx = tool_context("claude", "claude-opus-4-7");
+
+        let identity =
+            resolve_identity(&ctx, &json!({ "model": "opus-4.7" })).expect("identity resolves");
+
+        assert_eq!(identity.agent.as_deref(), Some("claude"));
+        assert_eq!(identity.model.as_deref(), Some("claude"));
+        assert_eq!(identity.actor_label.as_deref(), Some("claude"));
+    }
+
+    fn tool_context(agent: &str, model: &str) -> ToolContext {
+        ToolContext {
+            cwd: None,
+            allowed_tools: Vec::new(),
+            workspace_root: None,
+            agent_name: Some(agent.to_string()),
+            model_name: Some(model.to_string()),
+            role_slot: None,
+            proc_allowed_programs: Vec::new(),
+            policy_engine: None,
+            fs_profile: None,
+            fs_audit: None,
+            reservation_owner: None,
+            orbit_host: None,
+            groundhog_host: None,
+        }
+    }
 }
 
 pub(super) fn task_scope(ctx: &ToolContext) -> OrbitTaskScope {

--- a/crates/orbit-tools/src/lib.rs
+++ b/crates/orbit-tools/src/lib.rs
@@ -47,7 +47,7 @@ use std::sync::Arc;
 use orbit_policy::PolicyEngine;
 use serde_json::{Map, Value};
 
-use orbit_common::types::{OrbitError, ToolSchema};
+use orbit_common::types::{OrbitError, RoleSlot, ToolSchema};
 
 /// Fast operation timeout (1 s). Used for local command resolution (e.g. `which`).
 pub const TIMEOUT_FAST_MS: u64 = 1_000;
@@ -200,6 +200,9 @@ pub struct ToolContext {
     /// Resolved model identifier (e.g. `"opus-4.6"`). Used alongside `agent_name`
     /// for the attribution footer.
     pub model_name: Option<String>,
+    /// Planning-duel slot asserted by the runtime envelope, when this tool call
+    /// is made from a planning-duel activity.
+    pub role_slot: Option<RoleSlot>,
     /// Program allowlist for `proc.spawn`. When non-empty, `proc.spawn` rejects
     /// any program not in this list. Empty means unrestricted.
     pub proc_allowed_programs: Vec<String>,
@@ -227,6 +230,7 @@ impl std::fmt::Debug for ToolContext {
             .field("workspace_root", &self.workspace_root)
             .field("agent_name", &self.agent_name)
             .field("model_name", &self.model_name)
+            .field("role_slot", &self.role_slot)
             .field("proc_allowed_programs", &self.proc_allowed_programs)
             .field("has_policy_engine", &self.policy_engine.is_some())
             .field("fs_profile", &self.fs_profile)

--- a/docs/design/agent-families/4_decisions.md
+++ b/docs/design/agent-families/4_decisions.md
@@ -2,7 +2,7 @@
 
 **Status:** Draft
 **Owner:** grok
-**Last updated:** 2026-05-16
+**Last updated:** 2026-05-17
 
 ADR entries are append-only and ordered ascending. New entries should follow the template in [../CONVENTIONS.md](../CONVENTIONS.md).
 
@@ -31,8 +31,8 @@ See full ADR-0151 for context, alternatives considered, and cost analysis.
 **Consequences.**
 - "Crew" was chosen over "profile" because profiles sound user-scoped, and over "pair" because the lineup contains planner, implementer, and reviewer.
 - Run records persist the resolved crew plus the three role model strings so audit trails survive later config edits.
-- The v2 `agent_loop` dispatch path reads role models from the crew registry (`crates/orbit-core/src/runtime/engine/environment_host.rs`). The v1 envelope/identity path and the orbit-store scoreboard/friction projections still resolve through `resolve_agent_model_pair*` in `crates/orbit-common/src/types/agent_pair.rs`; those callers do not yet have access to a crew-aware context, so this PR keeps the legacy resolver as a scoreboard-rendering shim. Migrating them is tracked as a follow-up.
-- Deferred: duel-plan participant configuration, per-role task overrides, planner-vs-executor workflow split, and the legacy-resolver migration noted above.
+- The v2 `agent_loop` dispatch path reads role models from the crew registry (`crates/orbit-core/src/runtime/engine/environment_host.rs`). Scoreboard and friction projections use family identity after ADR-0154; exact model strings remain visible through resolved crew/run configuration.
+- Deferred: duel-plan participant configuration, per-role task overrides, and planner-vs-executor workflow split.
 - Cost: old workspaces with only `[agent.planner]`, `[agent.implementer]`, and `[agent.reviewer]` must migrate before config load succeeds.
 
 ## ADR-0153 — Scope duel-plan candidate and model overrides to `[duel]`
@@ -48,10 +48,26 @@ See full ADR-0151 for context, alternatives considered, and cost analysis.
 - `[duel.models]` wins only for duel role-model lookup; helper models and non-duel model identity are unchanged.
 - The crew registry remains separate from duel participant selection. Reusing `[crews.*]` for duels was rejected because duels need a family pool, not a fixed planner/implementer/reviewer lineup.
 
+## ADR-0154 — Collapse agent identity to family and move model strings to configuration
+
+**Status:** Accepted · 2026-05 · [ORB-00080]
+
+**Context.** Planning-duel artifacts and scoreboards compared model strings even though model names drift across aliases, CLI shorthand, and self-reported tool payloads. A Gemini planner configured as `pro` could produce an artifact stamped `gemini-3.1-pro`; both values describe the same family but failed equality checks. Alias tables (`resolve_agent_model_pair*`, `matches_model_alias`, `canonical_model_for_agent`) treated the symptom and grew with every provider change.
+
+**Decision.** Family is identity, model is configuration, and slot is role. Orbit identity surfaces use exactly `codex`, `claude`, `gemini`, or `grok`. Planning-duel assignments persist `family`; `planner_a`, `planner_b`, and `arbiter` are explicit slots used in artifact paths and signatures. Exact model strings stay in crew config, `[duel.models]`, CLI invocation translation, and resolved-crew run records.
+
+**Consequences.**
+- New planning-duel artifacts are written as `planning-duel/{slot}.md` and signed `*authored by: {family} / {slot}*`; historical model-path artifacts remain a legacy read concern.
+- Runtime tool boundaries treat envelope identity as authoritative. Agent-supplied `model` fields are overwritten with the canonical family before persistence/comparison so self-report drift cannot affect validation.
+- Scoreboard and friction projections are family-keyed (`by_family`) when they answer "who actually ran?". Resolved-crew projections remain the source for "who was selected?" because they describe configured routing.
+- The legacy resolver and alias-canonicalization surfaces are deleted from production code. `infer_agent_family_from_model` remains for legacy artifact recovery and CLI invocation translation.
+- ORB-00079 and ORB-00071 are superseded by this structural identity change.
+
 ## Task References
 
 - ORB-00042: Onboard Grok (xAI) as a first-class supported agent family.
 - ORB-00058: Introduce per-task crew override for agent model selection.
 - ORB-00072: Make duel-plan agent pool and per-family model configurable via `[duel]`.
+- ORB-00080: Collapse agent identity to family; isolate model strings to invocation surface.
 
 Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.


### PR DESCRIPTION
## Task

[ORB-00080](https://orbit-cli.com/tasks/ORB-00080) — Collapse agent identity to family; isolate model strings to invocation surface

### Description

## Problem

Agent identity is currently a model string, and model strings are unstable along multiple axes:

- **Alias drift**: `[duel.models] gemini = "pro"` selects a planner whose actual artifact is signed `gemini-3.1-pro`. Equality check fails, planner work is discarded. See evidence run `jrun-20260516-2300`.
- **Self-report drift**: agents stamp identity strings into ad-hoc tool calls (`grok-build` vs `grok-4`, `opus-4.7` vs `claude-opus-4-7`). The orchestrator launched one; the agent reports another. The scoreboard agent dropdown currently mixes `gpt-5.5`, `gpt-5-codex`, `claude-opus-4-7`, `opus-4.7`, `gemini-3.1-pro`, `pro`, `grok-4`, `grok-build`, `human`, `admin`, `system`, `agent` in a single column.
- **Schema overload**: the `model` column simultaneously holds model identifiers, model aliases, actor types (`human`, `admin`, `system`), and short-form CLI flag values. Comparisons across this column cannot be reliable.
- **Canonicalization sprawl**: `matches_model_alias`, `canonical_model_for_agent`, `resolve_agent_model_pair`, and per-family arm tables exist to reconcile names that should not need reconciliation.

ORB-00079 (alias canonicalization in planning-duel) and ORB-00071 (delete `resolve_agent_model_pair*`) are both attempting partial fixes inside this broken model. This task supersedes both with a structural fix.

## Direction

**Family is identity. Model is configuration. Slot is role.**

- **Identity** propagates through tasks, planning-duel artifacts, scoreboards, friction events, audit events, and invocation records as one of four canonical values: `codex | claude | gemini | grok`.
- **Configuration** (exact model strings: `claude-opus-4-7`, `gemini-3.1-pro`, `grok-build`, `gpt-5.5`, etc.) survives only in crew config, the CLI invocation translator, and the `resolved_crew` field on run records.
- **Slot** (positional role discriminator) is what distinguishes parties in a duel: planning-duel uses `planner_a`, `planner_b`, `arbiter`. The slot, not the model, is how the artifact signature, the artifact filename, and metrics attribution link a planner output back to its assignment.

Any model string an agent self-reports via a tool call is overwritten at the runtime boundary with the family inferred from the envelope's invocation context. Agent-supplied identity is informational, not authoritative.

## Scope Detail

### Schema changes

- `PlanningRoleAssignment` (`crates/orbit-common/src/types/duel.rs:331`) loses its `model: String` field. The `agent: String` field is replaced by `family: AgentFamily` (new enum: `Codex | Claude | Gemini | Grok`). Slot is structural — encoded by which field of `PlanningRoles` holds the assignment.
- Persisted `planning_duel_roles.json` schema updates correspondingly: `{ planner_a: { family }, planner_b: { family }, arbiter: { family } }`. Existing JSON with `agent` and `model` fields is migrated on read with a one-shot fold (`agent` → `family`, drop `model`).
- Add `AgentFamily` enum to `crates/orbit-common/src/types/`. Serialize as lowercase string. `from_str` accepts the four canonical values only.

### Planning-duel signature & artifact path

- Artifact filename becomes `planning-duel/{slot}.md` (slot in `{planner_a, planner_b, arbiter}`). No model in the path.
- Signature line becomes exactly `*authored by: {family} / {slot}*` (e.g. `*authored by: gemini / planner_a*`).
- `plan_artifact_for_assignment` (`crates/orbit-engine/src/executor/automation/duel/planning_duel/artifacts.rs:177`) validates `marker_family == assignment.family && marker_slot == expected_slot`. No model comparison.
- Planner instruction in `crates/orbit-engine/src/executor/automation/duel/planning_duel/roles.rs` updated: agent is told its family + slot, not its model. The runtime stamps the signature line via `orbit.duel.plan.add` on write — the agent's prose body starts after the signature.

### Metrics & invocation linkage

- `metrics.rs:101` filters invocation records by `record.family == role.family && record.slot == role.slot`, not by model.
- Invocation records gain a `slot: Option<RoleSlot>` field. The `model: Option<String>` field is preserved as telemetry but is not used for identity comparison anywhere.
- Optional `self_reported_model: Option<String>` on invocation records for drift telemetry. Set when an agent's self-reported identity disagrees with envelope-stamped identity. Out of scope for this task if it becomes complex — may be a follow-up.

### Deletions

- Delete `resolve_agent_model_pair` and `resolve_agent_model_pair_or` from `crates/orbit-common/src/types/agent_pair.rs`.
- Delete `matches_model_alias` and `canonical_model_for_agent` from `crates/orbit-core/src/runtime/engine/identity.rs`. The functions exist solely to reconcile alias drift; under family-only identity there is nothing to reconcile.
- Delete the `configured_agent_model_pair` / canonical-pair fallback branches that the above depend on.

### Surfaces that keep model strings (these are correct, do not change)

- Crew config (`Crew { planner: { model, provider, backend }, ... }`) — it's a routing definition.
- CLI invocation translator (`crates/orbit-engine/src/activity_job/cli_runner/argv.rs` and the agent-loop driver) — it has to emit a real `--model` flag.
- `resolved_crew` field on run records — names the crew, which transitively names the models.

### Scoreboard & friction

- `friction_store.rs` `known_family_model_keys` and the field name `by_model` rename to `known_family_keys` / `by_family`. Same for `scoreboard_summary.rs` `seed_known_family_agents`. The agent dropdown collapses to four entries.
- For "who actually ran?" projections, read invocation records by family + slot. For "who was selected?" projections, read `resolved_crew`. Both surfaces label themselves explicitly.

### Documentation

- Amend ADR-0152 (`docs/design/agent-families/4_decisions.md`) or append a new ADR recording: family as identity, model as configuration, slot as role, and the rationale for collapsing.

## Why It Matters

- Fixes the planning-duel artifact-validation bug class permanently. The bug recurs every time a new model alias ships.
- Eliminates ~200 lines of alias-reconciliation code (`matches_model_alias` arms, `canonical_model_for_agent`, the pair-default fallback chain).
- Restores meaning to the `model` / `agent` column — it stops being a soup of model names, aliases, actor types, and CLI flag values.
- Unblocks the next provider/model rollout (Claude 5, Gemini 4, etc.) without requiring code changes to alias tables.

## Constraints / Notes

- **No change to crew config schema or `[duel.models]` config keys.** Operators continue writing `[duel.models] gemini = "pro"` if they want; the value is consumed only by the CLI translator at invocation time.
- **No change to CLI invocation behavior.** Whatever `--model` flag the Gemini CLI receives today, it receives tomorrow.
- **Migration of historical artifacts is out of scope.** Existing `planning-duel/gemini-pro.md` files in `.orbit/tasks/*/artifacts/` are read with the legacy parser; new artifacts use the new path/signature.
- **Same-family duels are explicitly supported** via slot. Two `claude` planners with different models can run a duel — the artifacts are `planner_a.md` and `planner_b.md`, the assignments are distinguishable by slot.
- **`infer_agent_family_from_model` is preserved** — used by legacy artifact recovery and by CLI invocation translator for `agent --model X` discovery flows.
- Supersedes ORB-00079 (alias-canonicalization, obsolete) and ORB-00071 (resolver deletion, subsumed). Close both after this task is approved.
- Do not skip the schema migration for in-flight runs; if any persisted `planning_duel_roles.json` has the old shape, the read path translates and the write path emits the new shape.

### Acceptance Criteria

- `AgentFamily` enum is defined in `crates/orbit-common/src/types/` with exactly four variants (`Codex`, `Claude`, `Gemini`, `Grok`), serialized as lowercase strings. A unit test asserts `serde_json::to_string(&AgentFamily::Gemini)` returns `"\"gemini\""` and `AgentFamily::from_str("pro")` returns an error (aliases are not accepted at this layer).
- `PlanningRoleAssignment` (in `crates/orbit-common/src/types/duel.rs`) has fields `{ family: AgentFamily }` and no `model` field. A round-trip serde test asserts the JSON shape `{"family":"gemini"}` and that any input JSON containing a `model` key is rejected by `deny_unknown_fields`.
- `RoleSlot` enum (or equivalent) is defined for planning-duel with variants `PlannerA`, `PlannerB`, `Arbiter`, serialized as `planner_a`, `planner_b`, `arbiter`. Used by signature parsing and artifact-path construction.
- Planning-duel artifact filenames follow `planning-duel/{slot}.md` (e.g. `planning-duel/planner_a.md`). No model string appears in artifact paths. A test asserts the filename emitted by `orbit.duel.plan.add` for a `planner_a` assignment is exactly `planning-duel/planner_a.md` regardless of which family is assigned to that slot.
- Planning-duel artifact signature is exactly `*authored by: {family} / {slot}*` (e.g. `*authored by: gemini / planner_a*`). A test parses this signature and asserts both family and slot are extracted; a malformed signature (missing slot, missing family, unknown family) fails parsing with a typed error.
- `plan_artifact_for_assignment` validates `(marker_family, marker_slot)` against `(assignment.family, expected_slot)`. A deterministic test configures `[duel.models] gemini = "pro"`, runs role selection, and asserts the artifact-validation step succeeds against a simulated artifact signed `*authored by: gemini / planner_a*`. The same test variant with `gemini = "gemini-3.1-pro"` also succeeds. A third variant with a mismatched signature (`*authored by: claude / planner_a*` when Gemini was assigned) fails with an explicit error naming both the expected and actual family.
- `crates/orbit-engine/src/executor/automation/duel/planning_duel/metrics.rs` filters invocation records by `(family, slot)` rather than by model. A test asserts that a `planner_a` invocation with `model = "gemini-3.1-pro"` and family `gemini` is correctly attributed to the `planner_a` role even when the role assignment carries no model.
- Invocation records carry an optional `slot: Option<RoleSlot>` field. The agent_loop dispatcher populates it from envelope context for planning-duel activities. A test asserts a planner_a invocation persists `slot: planner_a` and a non-duel activity persists `slot: null`.
- Runtime boundary overwrite: any tool call whose JSON arguments include a `model` field has that value replaced by the envelope's canonical family (or dropped) before persistence or comparison. A unit test simulates a tool call with `{"model": "opus-4.7"}` arriving under a `claude` envelope and asserts the persisted/effective family is `claude` regardless of the supplied string. The implementation explicitly chooses between overwrite and drop and documents the choice in code comments.
- `rg "resolve_agent_model_pair" crates/` returns zero matches outside of CLI-invocation-translator code paths and documentation/comment text deliberately referencing the removed function.
- `rg "matches_model_alias|canonical_model_for_agent" crates/` returns zero matches in production code; any historical mentions exist only in commit messages, ADR text, or test fixtures explicitly verifying legacy artifact recovery.
- `infer_agent_family_from_model` remains intact and its existing tests pass; it is used by legacy artifact recovery and by the CLI invocation translator.
- Scoreboard projections rename `by_model` to `by_family` (or equivalent family-keyed shape). `known_family_model_keys` in `friction_store.rs` and `seed_known_family_agents` in `scoreboard_summary.rs` seed family names, not model strings. Tests under `crates/orbit-store/src/file/scoreboard/` and `crates/orbit-store/src/file/friction_store.rs` are updated to assert family-keyed shapes; a regression test confirms no `grok-4` / `claude-opus-4-7` / `gpt-5.5` strings appear in any scoreboard projection key set.
- "Who actually ran?" scoreboard projection reads from invocation records by `(family, slot)`. "Who was selected?" projection reads from `resolved_crew`. Both are labeled with their projection source in code comments and in any field name visible to downstream consumers.
- CLI invocation behavior is preserved: a deterministic test launches a fake CLI runner with crew `opus-codex` and asserts the `--model` flag passed to the underlying CLI is `claude-opus-4-7` for planner activities and `gpt-5.5` for implementer activities, even though both invocations are attributed to families (`claude`, `codex`) respectively.
- ADR-0152 in `docs/design/agent-families/4_decisions.md` is amended (or a new ADR is appended) recording: family as identity, model as configuration, slot as role; the rationale; the deletion of the resolver and alias-canonicalization surfaces; and the migration path for historical artifacts.
- Both ORB-00079 and ORB-00071 are closed (status `done` if their goals are subsumed by this task's acceptance, else `rejected` with a note pointing to this task ID) as part of the merge of this task. No new work tracked under those IDs.
- `make ci-fast` passes.

## Execution Summary

<details>
<summary>Click to expand</summary>

Implemented family-first agent identity across planning-duel assignments, artifact signatures/paths, invocation slot persistence, metrics attribution, runtime identity overwrite, and scoreboard/friction family projections. Added AgentFamily/RoleSlot schemas and legacy read migration for old planning_duel_roles.json assignment objects. Deleted production alias resolver/canonicalization surfaces and amended docs/design/agent-families ADRs. Validation: cargo check -q; cargo test -q -p orbit-engine --lib planning_duel; cargo test -q -p orbit-store --lib; cargo test -q -p orbit-core --lib duel_plan_; cargo test -q -p orbit-core --lib friction_; cargo test -q -p orbit-core --lib audit_role_label; cargo test -q -p orbit-tools --lib runtime_identity_overwrites_self_reported_model_at_tool_boundary; targeted orbit-common schema tests; make ci-fast. Full cargo test was not used as a gate because existing unrelated design-check/process/env-sensitive tests failed outside this task scope.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-00080-6a090c8a`
- Behind base: 0
- Ahead of base: 1