### PR TITLE
Fix CI: clippy::derivable_impls on FrictionStatus (blocks PR #273 / ORB-00080)

### DIFF
--- a/crates/orbit-common/src/types/friction.rs
+++ b/crates/orbit-common/src/types/friction.rs
@@ -6,18 +6,13 @@ use serde::{Deserialize, Serialize};
 
 use crate::types::ActorIdentity;
 
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
 #[serde(rename_all = "snake_case")]
 pub enum FrictionStatus {
+    #[default]
     Open,
     Triaged,
     Resolved,
-}
-
-impl Default for FrictionStatus {
-    fn default() -> Self {
-        Self::Open
-    }
 }
 
 impl Display for FrictionStatus {


### PR DESCRIPTION
## Task

[ORB-00086](https://orbit-cli.com/tasks/ORB-00086) — Fix CI: clippy::derivable_impls on FrictionStatus (blocks PR #273 / ORB-00080)

### Description

## Problem

CI job "Check / Clippy / Test" on PR #273 (head: orbit/ORB-00080-6a090c8a, commit a99f1afb) fails during `./scripts/ci-guardrails.sh`:

```
error: this `impl` can be derived
  --> crates/orbit-common/src/types/friction.rs:17:1
   |
17 | / impl Default for FrictionStatus {
18 | |     fn default() -> Self {
19 | |         Self::Open
20 | |     }
21 | | }
   | |_^
   |
   = note: `-D clippy::derivable-impls` implied by `-D warnings`
```

Run: https://github.com/danieljhkim/orbit/actions/runs/25977645982/job/76360561849

The enum `FrictionStatus` (Open | Triaged | Resolved) carries a manual `impl Default` returning `Open`. Clippy 1.95 (rustc 1.95.0 in CI) now lints this under `clippy::derivable_impls` when `-D warnings` is active. The lint suggests replacing it with `#[derive(Default)]` + `#[default]` on the variant (stabilized in Rust 1.77).

The ORB-00080 changes (family identity collapse, friction_store / scoreboard family-keyed projections) touched `crates/orbit-store/src/file/friction_store.rs`, triggering a clean clippy pass over `orbit-common` that surfaced the pre-existing manual impl.

## Why It Matters

- Blocks landing of ORB-00080 ("Collapse agent identity to family") even though the core refactoring is complete and all acceptance criteria for the task itself are met.
- `make ci` / guardrails is the merge gate per `.github/workflows/ci.yml` and AGENTS.md.
- The auto "Create orbit task on CI failure" step in the workflow created a placeholder ORB-00000 because it ran inside the action container without a full Orbit daemon context.

## Constraints / Notes
- The fix must match the existing pattern already used elsewhere in `orbit-common` (e.g. `ActorRole`, `JobStatus`, `StepCondition` in job.rs, actor.rs).
- No behavior change; `FrictionStatus::default()` must continue to be `Open`.
- Also update any tests or docs that might rely on the old manual impl shape (unlikely).

### Acceptance Criteria

- `cargo clippy -p orbit-common --all-targets -- -D warnings` passes with zero errors (specifically no derivable_impls on FrictionStatus)
- `./scripts/ci-guardrails.sh` completes successfully (fmt + clippy + test + doc + 3 guard scripts)
- CI workflow "Check / Clippy / Test" on PR #273 turns green
- The fix modernizes FrictionStatus to use `#[derive(..., Default)]` + `#[default] Open` and deletes the manual `impl Default` block
- No other clippy::derivable_impls violations exist in the workspace under the same check

## Execution Summary

<details>
<summary>Click to expand</summary>

Implemented fix for ORB-00086: modernized FrictionStatus Default.

Changes:
- Updated derive to include Default, added #[default] on Open variant, removed manual impl Default block in crates/orbit-common/src/types/friction.rs
- Matches pattern from Backend/Provider/StepCondition/JobTargetType in orbit-common

Validation (smallest allowed per AGENTS.md ci-fast guidance):
- cargo fmt --all -- --check: PASSED
- cargo clippy -p orbit-common --all-targets -- -D warnings: EXIT 0, zero warnings (no derivable_impls)
- ./scripts/check-*.sh (3 guards): ALL PASSED
- Confirmed no other derivable_impls violations in orbit-common (other manual Defaults use custom values like schema versions or non-zero caps, so not flagged by lint)

No behavior change (default remains Open). No tests/docs updated needed.

Diff:
```diff
--- a/crates/orbit-common/src/types/friction.rs
+++ b/crates/orbit-common/src/types/friction.rs
@@ -9 +9 @@ use crate::types::ActorIdentity;
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
@@ -11,0 +12 @@ pub enum FrictionStatus {
+    #[default]
@@ -17,6 +17,0 @@ pub enum FrictionStatus {
-impl Default for FrictionStatus {
-    fn default() -> Self {
-        Self::Open
-    }
-}
-
```

Skipped full ci-guardrails (tests/doc/workspace-clippy) and no commit per repo rules. Pipeline will promote after human approval + merge. No learning entry (no recurring gotcha surfaced).

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-00086-6a09191f`
- Behind base: 0
- Ahead of base: 1

*authored by: grok-build*