### PR TITLE
Close ORB-00080 coverage gaps: end-to-end duel regression test, crew-driven CLI invocation test, projection labeling

### DIFF
--- a/crates/orbit-common/src/types/friction.rs
+++ b/crates/orbit-common/src/types/friction.rs
@@ -47,6 +47,7 @@ impl FromStr for FrictionStatus {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct FrictionRecord {
     pub id: String,
+    /// Model identifier for this friction record (per-invocation actual execution).
     pub model: String,
     pub created_at: DateTime<Utc>,
     #[serde(default)]

--- a/crates/orbit-engine/src/activity_job/cli_runner/tests/orchestrator_tests.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/tests/orchestrator_tests.rs
@@ -5,9 +5,10 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use orbit_agent::loop_engine::audit::AuditSink;
-use orbit_common::types::activity_job::V2AuditEventKind;
+use orbit_common::types::activity_job::{AgentRole, V2AuditEventKind};
 use tempfile::tempdir;
 
+use super::super::super::agent_role::{apply_resolved_settings, resolve_agent_settings};
 use super::super::super::audit_writer::V2AuditWriter;
 use super::super::super::dispatcher::DispatchError;
 use super::super::run_cli_backend;
@@ -546,5 +547,138 @@ fn run_cli_backend_keeps_success_when_envelope_reports_success() {
     assert!(
         outcome.success,
         "envelope status=success must keep dispatch success on exit 0"
+    );
+}
+
+/// Crew-driven regression test for ORB-00080 AC #15: `opus-codex` crew must
+/// produce `--model claude-opus-4-7` for planner and `--model gpt-5.5` for
+/// implementer (identity attribution stays family; no leakage of family name
+/// into the --model flag that reaches the CLI).
+#[test]
+fn crew_opus_codex_drives_exact_models_to_planner_and_implementer() {
+    let temp = tempdir().expect("tempdir");
+    let claude_script = temp.path().join("claude");
+    let codex_script = temp.path().join("codex");
+    write_executable(
+        &claude_script,
+        "#!/bin/sh\nprintf '{\"schemaVersion\":1,\"status\":\"success\"}\\n'\n",
+    );
+    write_executable(
+        &codex_script,
+        "#!/bin/sh\nprintf '{\"schemaVersion\":1,\"status\":\"success\"}\\n'\n",
+    );
+
+    // planner leg via opus-codex crew
+    let sink_for_writer_p: Arc<dyn AuditSink> = Arc::new(RecordingSink::default());
+    let audit_p = Arc::new(V2AuditWriter::new(
+        "job-crew-planner",
+        "claude:claude-opus-4-7",
+        sink_for_writer_p,
+    ));
+    let host_p = TestHost::with_command(claude_script.display().to_string());
+    let mut spec_p = test_agent_loop_spec_for("claude", Duration::from_secs(5));
+    spec_p.role = Some(AgentRole::Planner);
+    let input_p = serde_json::json!({
+        "prompt": "draft plan",
+        "crew": "opus-codex",
+        "task_id": "T-crew"
+    });
+    let resolved_p = resolve_agent_settings(AgentRole::Planner, &host_p, &spec_p, &input_p);
+    assert_eq!(resolved_p.model.as_deref(), Some("claude-opus-4-7"));
+    let mut spec_p_run = spec_p.clone();
+    apply_resolved_settings(&mut spec_p_run, &resolved_p);
+    let _ = run_cli_backend(
+        &host_p,
+        &spec_p_run,
+        "job-crew-planner",
+        audit_p.clone(),
+        &input_p,
+        None,
+    )
+    .expect("planner cli run");
+
+    let events_p = audit_p.events_snapshot().expect("planner events");
+    let argv_p = events_p
+        .iter()
+        .find_map(|e| match &e.kind {
+            V2AuditEventKind::CliInvocationStarted {
+                argv_redacted,
+                provider,
+                ..
+            } => {
+                assert_eq!(
+                    provider, "claude",
+                    "identity attribution must be claude family"
+                );
+                Some(argv_redacted.clone())
+            }
+            _ => None,
+        })
+        .expect("planner started event");
+    let model_idx_p = argv_p
+        .iter()
+        .position(|a| a == "--model")
+        .expect("planner argv has --model");
+    assert_eq!(
+        argv_p.get(model_idx_p + 1).map(String::as_str),
+        Some("claude-opus-4-7"),
+        "planner --model must be exact claude-opus-4-7, not family"
+    );
+
+    // implementer leg via same crew
+    let sink_for_writer_i: Arc<dyn AuditSink> = Arc::new(RecordingSink::default());
+    let audit_i = Arc::new(V2AuditWriter::new(
+        "job-crew-impl",
+        "codex:gpt-5.5",
+        sink_for_writer_i,
+    ));
+    let host_i = TestHost::with_command(codex_script.display().to_string());
+    let mut spec_i = test_agent_loop_spec_for("codex", Duration::from_secs(5));
+    spec_i.role = Some(AgentRole::Implementer);
+    let input_i = serde_json::json!({
+        "prompt": "implement",
+        "crew": "opus-codex",
+        "task_id": "T-crew"
+    });
+    let resolved_i = resolve_agent_settings(AgentRole::Implementer, &host_i, &spec_i, &input_i);
+    assert_eq!(resolved_i.model.as_deref(), Some("gpt-5.5"));
+    let mut spec_i_run = spec_i.clone();
+    apply_resolved_settings(&mut spec_i_run, &resolved_i);
+    let _ = run_cli_backend(
+        &host_i,
+        &spec_i_run,
+        "job-crew-impl",
+        audit_i.clone(),
+        &input_i,
+        None,
+    )
+    .expect("implementer cli run");
+
+    let events_i = audit_i.events_snapshot().expect("impl events");
+    let argv_i = events_i
+        .iter()
+        .find_map(|e| match &e.kind {
+            V2AuditEventKind::CliInvocationStarted {
+                argv_redacted,
+                provider,
+                ..
+            } => {
+                assert_eq!(
+                    provider, "codex",
+                    "identity attribution must be codex family"
+                );
+                Some(argv_redacted.clone())
+            }
+            _ => None,
+        })
+        .expect("impl started event");
+    let model_idx_i = argv_i
+        .iter()
+        .position(|a| a == "--model")
+        .expect("impl argv has --model");
+    assert_eq!(
+        argv_i.get(model_idx_i + 1).map(String::as_str),
+        Some("gpt-5.5"),
+        "implementer --model must be exact gpt-5.5, not family"
     );
 }

--- a/crates/orbit-engine/src/activity_job/cli_runner/tests/test_support.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/tests/test_support.rs
@@ -11,9 +11,10 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
+use crate::context::AgentRoleConfig;
 use orbit_agent::loop_engine::audit::{AuditSink, LoopAuditEvent};
 use orbit_common::types::ExecutorSandboxKind;
-use orbit_common::types::activity_job::{AgentLoopSpec, Backend, OnDenial, Provider};
+use orbit_common::types::activity_job::{AgentLoopSpec, AgentRole, Backend, OnDenial, Provider};
 use orbit_common::utility::logging::RedactingFields;
 #[cfg(target_os = "macos")]
 use orbit_exec::sandbox_exec_path;
@@ -289,6 +290,30 @@ impl V2RuntimeHost for TestHost {
 
     fn task_context_for_agent_input(&self, _input: &Value) -> Result<Option<Value>, DispatchError> {
         Ok(self.task_context.clone())
+    }
+
+    fn agent_role_config_for_input(
+        &self,
+        role: AgentRole,
+        input: &Value,
+    ) -> Option<AgentRoleConfig> {
+        let crew = input.get("crew").and_then(|v| v.as_str()).unwrap_or("");
+        if crew != "opus-codex" {
+            return None;
+        }
+        match role {
+            AgentRole::Planner => Some(AgentRoleConfig {
+                provider: Some(Provider::Claude),
+                model: Some("claude-opus-4-7".to_string()),
+                backend: None,
+            }),
+            AgentRole::Implementer => Some(AgentRoleConfig {
+                provider: Some(Provider::Codex),
+                model: Some("gpt-5.5".to_string()),
+                backend: None,
+            }),
+            _ => None,
+        }
     }
 
     fn tool_context_for_activity(

--- a/crates/orbit-engine/src/executor/automation/duel/planning_duel/roles.rs
+++ b/crates/orbit-engine/src/executor/automation/duel/planning_duel/roles.rs
@@ -317,7 +317,10 @@ mod tests {
     use std::collections::BTreeMap;
     use std::path::{Path, PathBuf};
 
-    use orbit_common::types::{Activity, AgentModelPair, Job, JobTargetType, OrbitEvent, Role};
+    use orbit_common::types::{
+        Activity, AgentFamily, AgentModelPair, Job, JobTargetType, OrbitError, OrbitEvent,
+        PlanningRoles, Role, RoleSlot, TaskArtifact,
+    };
     use orbit_store::InvocationRecord;
     use orbit_tools::ToolContext;
 
@@ -513,5 +516,78 @@ mod tests {
             );
             assert!(output["planning_duel_roles"]["planner_a"]["model"].is_null());
         }
+    }
+
+    fn plan_artifact_local(path: &str, family: &str, slot: &str) -> TaskArtifact {
+        TaskArtifact::from_text(
+            path,
+            format!("*authored by: {family} / {slot}*\n## Plan\nDo the thing.\n"),
+        )
+    }
+
+    #[test]
+    fn planning_duel_e2e_select_roles_produces_assignment_that_validates_artifact() {
+        // [2,0,1] places gemini in planner_a (matches the alias test above)
+        for configured in ["pro", "gemini-3.1-pro"] {
+            queue_permutation([2, 0, 1]);
+            let host = TestHost::with_family_duel_model("gemini", configured);
+            let output = select_planning_duel_roles(&host, &json!({ "task_id": "ORB-TEST" }))
+                .expect("select_planning_duel_roles with gemini duel model");
+
+            let roles_value = output
+                .get("planning_duel_roles")
+                .expect("planning_duel_roles in output");
+            let planning_roles: PlanningRoles =
+                serde_json::from_value(roles_value.clone()).expect("parse PlanningRoles");
+            let assignment = planning_roles.planner_a.clone();
+            assert_eq!(assignment.family, AgentFamily::Gemini);
+
+            // simulate artifact written with matching gemini signature for planner_a
+            let raw_artifacts = vec![plan_artifact_local(
+                "planning-duel/planner_a.md",
+                "gemini",
+                "planner_a",
+            )];
+            let plan_artifacts =
+                super::super::artifacts::planning_duel_plan_artifacts(&raw_artifacts)
+                    .expect("planning_duel_plan_artifacts parses");
+            let matched = super::super::artifacts::plan_artifact_for_assignment(
+                &plan_artifacts,
+                &assignment,
+                RoleSlot::PlannerA,
+            )
+            .expect("plan_artifact_for_assignment succeeds when family+slot match");
+            assert_eq!(matched.path, "planning-duel/planner_a.md");
+        }
+
+        // mismatch variant: gemini assigned but claude artifact present
+        queue_permutation([2, 0, 1]);
+        let host = TestHost::with_family_duel_model("gemini", "pro");
+        let output =
+            select_planning_duel_roles(&host, &json!({ "task_id": "ORB-TEST" })).expect("select");
+        let roles_value = output.get("planning_duel_roles").expect("roles");
+        let planning_roles: PlanningRoles =
+            serde_json::from_value(roles_value.clone()).expect("parse");
+        let assignment = planning_roles.planner_a.clone();
+
+        let raw_artifacts = vec![plan_artifact_local(
+            "planning-duel/planner_a.md",
+            "claude",
+            "planner_a",
+        )];
+        let plan_artifacts =
+            super::super::artifacts::planning_duel_plan_artifacts(&raw_artifacts).expect("parse");
+        let err = super::super::artifacts::plan_artifact_for_assignment(
+            &plan_artifacts,
+            &assignment,
+            RoleSlot::PlannerA,
+        )
+        .expect_err("mismatch must fail");
+        let msg = match err {
+            OrbitError::InvalidInput(m) => m,
+            other => panic!("expected InvalidInput, got {other:?}"),
+        };
+        assert!(msg.contains("expected gemini"), "msg={msg}");
+        assert!(msg.contains("has family claude"), "msg={msg}");
     }
 }

--- a/crates/orbit-store/src/file/friction_store.rs
+++ b/crates/orbit-store/src/file/friction_store.rs
@@ -40,6 +40,7 @@ pub struct FrictionUpdateParams {
 }
 
 #[derive(Debug, Clone)]
+/// Persisted friction record wrapper. The identity in `record.model` is per-invocation actual execution (sourced from the friction add call site).
 pub struct StoredFrictionRecord {
     pub record: FrictionRecord,
     pub path: PathBuf,

--- a/crates/orbit-store/src/file/scoreboard/scoreboard_summary.rs
+++ b/crates/orbit-store/src/file/scoreboard/scoreboard_summary.rs
@@ -136,6 +136,7 @@ struct TokenScoreboardFile {
 struct TokenAgentEntry {
     #[serde(rename = "agent")]
     _agent: String,
+    /// Model key used for this token scoreboard row; per-invocation actual execution (from audit/token metrics, not run-level lineup).
     #[serde(default)]
     model: Option<String>,
     #[serde(default)]


### PR DESCRIPTION
## Task

[ORB-00087](https://orbit-cli.com/tasks/ORB-00087) — Close ORB-00080 coverage gaps: end-to-end duel regression test, crew-driven CLI invocation test, projection labeling

### Description

## Problem

PR #273 ([ORB-00080](https://orbit-cli.com/tasks/ORB-00080)) shipped 15 of 18 acceptance criteria cleanly but left three gaps surfaced in review (see review threads on ORB-00080):

1. **AC #6 — no end-to-end regression test for the original bug.** The PR has unit tests for role selection ([select_roles.rs:356-368](crates/orbit-engine/src/executor/automation/duel/select_roles.rs:356)) and unit tests for artifact validation ([artifacts.rs:659](crates/orbit-engine/src/executor/automation/duel/planning_duel/artifacts.rs:659)) but nothing wiring them together. The bug `jrun-20260516-2300` lived precisely in the seam between those two stages. Without an integration test exercising that seam, a future regression that re-introduces model leakage through role selection would not be caught — the per-stage unit tests would still pass.

2. **AC #15 — no crew-driven CLI invocation test.** AC #15 required a deterministic test that drives crew `opus-codex` through one planner invocation and one implementer invocation, asserting the `--model` flag is `claude-opus-4-7` and `gpt-5.5` respectively. This test does not exist; `--model` is verified piecemeal elsewhere but never in the crew-driven shape that proves the identity collapse did not leak into the CLI invocation layer.

3. **AC #14 — projection labeling clarity gap.** `StoredFrictionRecord::model` (and projection fields in `scoreboard_summary.rs`) carry no doc comments explaining whether they represent per-invocation actual-execution data or run-level selected-lineup data. Behavior is correct; narrative isn't.

The first two are regression-prevention obligations the original task accepted in writing. The third is doc polish.

## Scope

### In scope

**Test #1 — end-to-end planning-duel regression (closes AC #6):**
- Single integration test under `crates/orbit-engine/src/executor/automation/duel/planning_duel/` (new file or extending an existing test module).
- Configures `[duel.models] gemini = "pro"` on a fake runtime host.
- Runs the full `select_planning_duel_roles` path to produce a `PlanningRoleAssignment` for Gemini in slot `planner_a`.
- Simulates an artifact written via `orbit.duel.plan.add` (or its in-process equivalent) with signature `*authored by: gemini / planner_a*` at path `planning-duel/planner_a.md`.
- Asserts `plan_artifact_for_assignment` succeeds.
- Variant 2: same flow with `gemini = "gemini-3.1-pro"` — also succeeds.
- Variant 3: mismatched signature (`*authored by: claude / planner_a*` when Gemini was assigned) — fails with an error message naming both expected (`gemini`) and actual (`claude`) family.

**Test #2 — crew-driven CLI invocation (closes AC #15):**
- Test in `crates/orbit-engine/src/activity_job/cli_runner/tests/` (extend `orchestrator_tests.rs` or add a new sibling file).
- Constructs a fake `argv` recorder.
- Drives a fake job with crew `opus-codex` through one planner activity and one implementer activity.
- Asserts the `--model` argument in the recorded planner CLI call is exactly `claude-opus-4-7`.
- Asserts the `--model` argument in the recorded implementer CLI call is exactly `gpt-5.5`.
- Confirms the family/identity attribution recorded for each invocation is `claude` / `codex` respectively (the collapse didn't leak into CLI flags).

**Doc fix #3 — projection labeling (closes AC #14):**
- Add a one-line doc comment above each identity-bearing field in `StoredFrictionRecord` ([friction_store.rs:42](crates/orbit-store/src/file/friction_store.rs:42)), `FrictionRecord` (orbit-common), and the projection fields in `crates/orbit-store/src/file/scoreboard/scoreboard_summary.rs`.
- Each comment names which projection source the field represents: "per-invocation actual execution" or "run-level selected lineup".
- Doc-only change; no behavior change.

### Out of scope

- Refactoring the existing test scaffolding.
- Adding additional ACs beyond the three identified above.
- Changing field names (purely doc comments; field-rename is a separate concern).

## Why It Matters

- AC #6's missing test is the exact regression test the production incident deserves. Shipping ORB-00080 without it means the bug class can recur silently — the per-stage unit tests will not catch it.
- AC #15's missing test is the proof that the family-collapse did not break CLI invocation behavior. Without it, a future change that accidentally invokes `claude --model claude` (instead of `claude --model claude-opus-4-7`) would not be caught at test time.
- AC #14 is small but real — downstream consumers of friction stats and scoreboards need to know which value represents what.

## Constraints / Notes

- Hard dependency on ORB-00080 (the code being tested must already be merged).
- No new test infrastructure if existing scaffolding fits — extend, don't reinvent.
- All new tests must be deterministic (no live CLI invocation, no network).
- Single small PR — three closely related test additions and three doc comments.

### Acceptance Criteria

- A deterministic integration test exists that: (a) configures `[duel.models] gemini = "pro"` on a fake runtime host, (b) runs the full `select_planning_duel_roles` path to produce a Gemini `PlanningRoleAssignment` in slot `planner_a`, (c) simulates an artifact at `planning-duel/planner_a.md` with first line `*authored by: gemini / planner_a*`, (d) asserts `plan_artifact_for_assignment` succeeds. Lives under `crates/orbit-engine/src/executor/automation/duel/planning_duel/`.
- The same end-to-end test (or a sibling variant) covers `gemini = "gemini-3.1-pro"` and asserts success.
- A third variant of the end-to-end test asserts that a mismatched signature (`*authored by: claude / planner_a*` when Gemini was assigned to `planner_a`) fails with an error message that names both the expected family (`gemini`) and the actual family (`claude`).
- A deterministic test exists in `crates/orbit-engine/src/activity_job/cli_runner/tests/` that: (a) constructs a fake `argv` recorder, (b) drives crew `opus-codex` through one planner activity and one implementer activity, (c) asserts the `--model` argument in the recorded planner CLI call equals exactly `claude-opus-4-7`, (d) asserts the `--model` argument in the recorded implementer CLI call equals exactly `gpt-5.5`, (e) asserts the recorded identity attribution for each invocation is `claude` and `codex` respectively (no family-as-model leakage into CLI flags).
- Identity-bearing fields in `StoredFrictionRecord` ([crates/orbit-store/src/file/friction_store.rs:42](crates/orbit-store/src/file/friction_store.rs:42)), `FrictionRecord` (in orbit-common), and projection fields in `crates/orbit-store/src/file/scoreboard/scoreboard_summary.rs` each carry a one-line doc comment naming the projection source: "per-invocation actual execution" or "run-level selected lineup".
- All three review threads on ORB-00080 (`rt-20260517-012147-086001000`, `rt-20260517-012200-572393000`, `rt-20260517-012208-447744000`) are resolved with replies pointing to the PR that closes this task.
- `make ci-fast` passes.

## Execution Summary

<details>
<summary>Click to expand</summary>

Implemented all three coverage gaps from ORB-00080:

1. Added deterministic e2e test `planning_duel_e2e_select_roles_produces_assignment_that_validates_artifact` in roles.rs tests (under planning_duel/). Wires select_planning_duel_roles (with gemini="pro" and "gemini-3.1-pro" via TestHost) to produce PlanningRoleAssignment, simulates matching artifact, asserts plan_artifact_for_assignment succeeds; mismatch variant asserts error names both families.

2. Added crew-driven test `crew_opus_codex_drives_exact_models_to_planner_and_implementer` in orchestrator_tests.rs. Extended TestHost with agent_role_config_for_input for "opus-codex" crew; drives resolve_agent_settings + apply + run_cli_backend for Planner (claude-opus-4-7) and Implementer (gpt-5.5); asserts --model in argv_redacted and provider attribution (claude/codex) with no family leakage.

3. Added one-line doc comments on identity fields: FrictionRecord::model (per-invocation actual execution), StoredFrictionRecord (delegates to record), and TokenAgentEntry::model in scoreboard_summary.rs.

All new tests deterministic, use existing scaffolding, pass. make ci-fast passes. Review threads on ORB-00080 noted in summary (tooling prevented direct reply on done task).

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-00087-6a09191f`
- Behind base: 0
- Ahead of base: 1