### PR TITLE
Populate audit task_id and job_run_id correctly for lock-reservation and job-run events

### DIFF
--- a/crates/orbit-cli/src/audit_middleware.rs
+++ b/crates/orbit-cli/src/audit_middleware.rs
@@ -19,6 +19,7 @@ pub struct CommandMeta {
     pub target_id: Option<String>,
     pub role: String,
     pub arguments_json: Option<String>,
+    pub job_run_id: Option<String>,
 }
 
 /// Feeds the **persistent** SQLite audit event store on every CLI invocation.
@@ -119,7 +120,11 @@ impl Drop for AuditGuard<'_> {
             task_id: std::env::var("ORBIT_TASK_ID")
                 .ok()
                 .filter(|s| !s.is_empty()),
-            job_run_id: std::env::var("ORBIT_RUN_ID").ok().filter(|s| !s.is_empty()),
+            job_run_id: self
+                .meta
+                .job_run_id
+                .clone()
+                .or_else(|| std::env::var("ORBIT_RUN_ID").ok().filter(|s| !s.is_empty())),
             activity_id: std::env::var("ORBIT_ACTIVITY_ID")
                 .ok()
                 .filter(|s| !s.is_empty()),
@@ -159,6 +164,7 @@ pub fn extract_command_meta(cmd: &Commands) -> CommandMeta {
                 target_id: None,
                 role: "admin".to_string(),
                 arguments_json: None,
+                job_run_id: None,
             }
         }
         Commands::Init(_) => CommandMeta {
@@ -169,6 +175,7 @@ pub fn extract_command_meta(cmd: &Commands) -> CommandMeta {
             target_id: None,
             role: "admin".to_string(),
             arguments_json: None,
+            job_run_id: None,
         },
         Commands::Mcp(cmd) => {
             use crate::command::mcp::McpSubcommand;
@@ -185,6 +192,7 @@ pub fn extract_command_meta(cmd: &Commands) -> CommandMeta {
                 target_id: None,
                 role: "admin".to_string(),
                 arguments_json: None,
+                job_run_id: None,
             }
         }
         Commands::Tool(tool_cmd) => {
@@ -247,6 +255,7 @@ pub fn extract_command_meta(cmd: &Commands) -> CommandMeta {
                 target_id,
                 role,
                 arguments_json: None,
+                job_run_id: None,
             }
         }
         Commands::Task(task_cmd) => {
@@ -291,6 +300,7 @@ pub fn extract_command_meta(cmd: &Commands) -> CommandMeta {
                 target_id: target_id.map(String::from),
                 role: "admin".to_string(),
                 arguments_json: None,
+                job_run_id: None,
             }
         }
         Commands::Semantic(cmd) => {
@@ -311,6 +321,7 @@ pub fn extract_command_meta(cmd: &Commands) -> CommandMeta {
                 target_id: None,
                 role: "admin".to_string(),
                 arguments_json: None,
+                job_run_id: None,
             }
         }
         Commands::Adr(cmd) => {
@@ -326,6 +337,7 @@ pub fn extract_command_meta(cmd: &Commands) -> CommandMeta {
                 target_id: None,
                 role: "admin".to_string(),
                 arguments_json: None,
+                job_run_id: None,
             }
         }
         Commands::Design(cmd) => {
@@ -341,6 +353,7 @@ pub fn extract_command_meta(cmd: &Commands) -> CommandMeta {
                 target_id: None,
                 role: "admin".to_string(),
                 arguments_json: None,
+                job_run_id: None,
             }
         }
         Commands::Learning(cmd) => {
@@ -363,6 +376,7 @@ pub fn extract_command_meta(cmd: &Commands) -> CommandMeta {
                 target_id: None,
                 role: "admin".to_string(),
                 arguments_json: None,
+                job_run_id: None,
             }
         }
         Commands::Activity(cmd) => {
@@ -378,18 +392,25 @@ pub fn extract_command_meta(cmd: &Commands) -> CommandMeta {
                 target_id: target_id.map(String::from),
                 role: "admin".to_string(),
                 arguments_json: None,
+                job_run_id: None,
             }
         }
         Commands::Job(job_cmd) => {
             use crate::command::job::JobSubcommand;
-            let (sub, target_id) = match &job_cmd.command {
-                JobSubcommand::List(_) => ("list", None),
-                JobSubcommand::Show(args) => ("show", Some(args.job_id.as_str())),
-                JobSubcommand::Run(args) => ("run", Some(args.job_id.as_str())),
-                JobSubcommand::Replay(args) => ("replay", Some(args.run_id.as_str())),
-                JobSubcommand::RunPipelineWorker(args) => {
-                    ("run-pipeline-worker", Some(args.run_id.as_str()))
-                }
+            let (sub, target_id, job_run_id) = match &job_cmd.command {
+                JobSubcommand::List(_) => ("list", None, None),
+                JobSubcommand::Show(args) => ("show", Some(args.job_id.as_str()), None),
+                JobSubcommand::Run(args) => ("run", Some(args.job_id.as_str()), None),
+                JobSubcommand::Replay(args) => (
+                    "replay",
+                    Some(args.run_id.as_str()),
+                    Some(args.run_id.as_str()),
+                ),
+                JobSubcommand::RunPipelineWorker(args) => (
+                    "run-pipeline-worker",
+                    Some(args.run_id.as_str()),
+                    Some(args.run_id.as_str()),
+                ),
             };
             CommandMeta {
                 command: "job".to_string(),
@@ -403,6 +424,7 @@ pub fn extract_command_meta(cmd: &Commands) -> CommandMeta {
                 target_id: target_id.map(String::from),
                 role: "admin".to_string(),
                 arguments_json: None,
+                job_run_id: job_run_id.map(String::from),
             }
         }
         Commands::Skill(cmd) => {
@@ -422,6 +444,7 @@ pub fn extract_command_meta(cmd: &Commands) -> CommandMeta {
                 target_id: target_id.map(String::from),
                 role: "admin".to_string(),
                 arguments_json: None,
+                job_run_id: None,
             }
         }
         Commands::Executor(cmd) => {
@@ -438,6 +461,7 @@ pub fn extract_command_meta(cmd: &Commands) -> CommandMeta {
                 target_id: target_id.map(String::from),
                 role: "admin".to_string(),
                 arguments_json: None,
+                job_run_id: None,
             }
         }
         Commands::Metrics(cmd) => {
@@ -459,6 +483,7 @@ pub fn extract_command_meta(cmd: &Commands) -> CommandMeta {
                 target_id: target_id.map(String::from),
                 role: "admin".to_string(),
                 arguments_json: None,
+                job_run_id: None,
             }
         }
         Commands::Scoreboard(cmd) => {
@@ -474,6 +499,7 @@ pub fn extract_command_meta(cmd: &Commands) -> CommandMeta {
                 target_id: None,
                 role: "admin".to_string(),
                 arguments_json: None,
+                job_run_id: None,
             }
         }
         Commands::Graph(cmd) => {
@@ -492,6 +518,7 @@ pub fn extract_command_meta(cmd: &Commands) -> CommandMeta {
                 target_id: None,
                 role: "admin".to_string(),
                 arguments_json: None,
+                job_run_id: None,
             }
         }
         Commands::Policy(cmd) => {
@@ -509,6 +536,7 @@ pub fn extract_command_meta(cmd: &Commands) -> CommandMeta {
                 target_id: target_id.map(String::from),
                 role: "admin".to_string(),
                 arguments_json: None,
+                job_run_id: None,
             }
         }
         Commands::Run(cmd) => run_command_meta(cmd),
@@ -520,6 +548,7 @@ pub fn extract_command_meta(cmd: &Commands) -> CommandMeta {
             target_id: Some(cmd.run_id.clone()),
             role: "admin".to_string(),
             arguments_json: None,
+            job_run_id: None,
         },
         Commands::Artifacts(cmd) => CommandMeta {
             command: "artifacts".to_string(),
@@ -529,6 +558,7 @@ pub fn extract_command_meta(cmd: &Commands) -> CommandMeta {
             target_id: Some(cmd.id.clone()),
             role: "admin".to_string(),
             arguments_json: None,
+            job_run_id: None,
         },
         Commands::Web(cmd) => {
             use crate::command::web::WebSubcommand;
@@ -543,6 +573,7 @@ pub fn extract_command_meta(cmd: &Commands) -> CommandMeta {
                 target_id: None,
                 role: "admin".to_string(),
                 arguments_json: None,
+                job_run_id: None,
             }
         }
         Commands::Audit(_) => unreachable!("audit commands should not be audited"),
@@ -554,6 +585,7 @@ pub fn extract_command_meta(cmd: &Commands) -> CommandMeta {
             target_id: None,
             role: "admin".to_string(),
             arguments_json: None,
+            job_run_id: None,
         },
         Commands::Workspace(cmd) => {
             use crate::command::workspace::WorkspaceSubcommand;
@@ -572,6 +604,7 @@ pub fn extract_command_meta(cmd: &Commands) -> CommandMeta {
                 target_id: None,
                 role: "admin".to_string(),
                 arguments_json: None,
+                job_run_id: None,
             }
         }
     }
@@ -601,6 +634,7 @@ fn run_command_meta(cmd: &crate::command::run::RunCommand) -> CommandMeta {
         target_id: target_id.map(String::from),
         role: "admin".to_string(),
         arguments_json: None,
+        job_run_id: None,
     }
 }
 
@@ -665,7 +699,9 @@ fn tool_run_input_identity(
 #[cfg(test)]
 mod tests {
     use clap::Parser;
+    use orbit_common::types::AuditEvent;
     use serde_json::{Value, json};
+    use std::sync::{Mutex, MutexGuard, OnceLock};
 
     use crate::command::Cli;
 
@@ -674,6 +710,52 @@ mod tests {
     fn meta_for(args: &[&str]) -> CommandMeta {
         let cli = Cli::parse_from(args);
         extract_command_meta(&cli.command)
+    }
+
+    struct OrbitRunEnvGuard {
+        _lock: MutexGuard<'static, ()>,
+        saved: Option<String>,
+    }
+
+    fn unset_orbit_run_id() -> OrbitRunEnvGuard {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        let lock = LOCK
+            .get_or_init(|| Mutex::new(()))
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let saved = std::env::var("ORBIT_RUN_ID").ok();
+        // SAFETY: the guard serializes this test env mutation and restores the value on drop.
+        unsafe {
+            std::env::remove_var("ORBIT_RUN_ID");
+        }
+        OrbitRunEnvGuard { _lock: lock, saved }
+    }
+
+    impl Drop for OrbitRunEnvGuard {
+        fn drop(&mut self) {
+            // SAFETY: the guard holds the serialization lock for the full mutation window.
+            unsafe {
+                match &self.saved {
+                    Some(value) => std::env::set_var("ORBIT_RUN_ID", value),
+                    None => std::env::remove_var("ORBIT_RUN_ID"),
+                }
+            }
+        }
+    }
+
+    fn audit_event_for_meta_without_orbit_run_id(meta: CommandMeta) -> AuditEvent {
+        let _env = unset_orbit_run_id();
+        let runtime = OrbitRuntime::in_memory().expect("build in-memory runtime");
+        {
+            let mut guard = AuditGuard::new(&runtime, meta);
+            guard.mark_success();
+        }
+
+        let events = runtime
+            .list_audit_events(None, None, Some(AuditEventStatus::Success), None, 8)
+            .expect("list audit events");
+        assert_eq!(events.len(), 1);
+        events.into_iter().next().expect("single audit event")
     }
 
     #[test]
@@ -790,6 +872,38 @@ mod tests {
     }
 
     #[test]
+    fn job_run_pipeline_worker_audit_uses_static_run_id_without_env() {
+        let meta = meta_for(&["orbit", "job", "run-pipeline-worker", "jrun-worker"]);
+        assert_eq!(meta.command, "job");
+        assert_eq!(meta.subcommand.as_deref(), Some("run-pipeline-worker"));
+        assert_eq!(meta.target_type.as_deref(), Some("job_run"));
+        assert_eq!(meta.target_id.as_deref(), Some("jrun-worker"));
+        assert_eq!(meta.job_run_id.as_deref(), Some("jrun-worker"));
+
+        let row = audit_event_for_meta_without_orbit_run_id(meta);
+        assert_eq!(row.command, "job");
+        assert_eq!(row.subcommand.as_deref(), Some("run-pipeline-worker"));
+        assert_eq!(row.target_id.as_deref(), Some("jrun-worker"));
+        assert_eq!(row.job_run_id.as_deref(), Some("jrun-worker"));
+    }
+
+    #[test]
+    fn job_replay_audit_uses_static_run_id_without_env() {
+        let meta = meta_for(&["orbit", "job", "replay", "jrun-source"]);
+        assert_eq!(meta.command, "job");
+        assert_eq!(meta.subcommand.as_deref(), Some("replay"));
+        assert_eq!(meta.target_type.as_deref(), Some("job_run"));
+        assert_eq!(meta.target_id.as_deref(), Some("jrun-source"));
+        assert_eq!(meta.job_run_id.as_deref(), Some("jrun-source"));
+
+        let row = audit_event_for_meta_without_orbit_run_id(meta);
+        assert_eq!(row.command, "job");
+        assert_eq!(row.subcommand.as_deref(), Some("replay"));
+        assert_eq!(row.target_id.as_deref(), Some("jrun-source"));
+        assert_eq!(row.job_run_id.as_deref(), Some("jrun-source"));
+    }
+
+    #[test]
     fn audit_guard_event_json_shapes_are_snapshotted() {
         let events = vec![
             audit_guard_event_json(AuditEventStatus::Success),
@@ -843,6 +957,7 @@ mod tests {
             target_id: Some("orbit.task.update".to_string()),
             role: "gpt-5.5".to_string(),
             arguments_json: Some(r#"{"id":"ORB-00002","model":"gpt-5.5"}"#.to_string()),
+            job_run_id: None,
         }
     }
 
@@ -894,6 +1009,7 @@ mod tests {
                 target_id: Some(tool_name.to_string()),
                 role: "agent".to_string(),
                 arguments_json: None,
+                job_run_id: None,
             }
         }
 

--- a/crates/orbit-core/src/runtime/orbit_tool_host/task_locks.rs
+++ b/crates/orbit-core/src/runtime/orbit_tool_host/task_locks.rs
@@ -113,18 +113,24 @@ pub(super) fn release(
         })?;
     emit_expired_reservation_events(runtime, &result.expired_reservations)?;
     if result.released {
+        let released_task_id = result
+            .reservation
+            .as_ref()
+            .and_then(|reservation| first_task_id(&reservation.task_ids));
+        let owner_run_id = result
+            .reservation
+            .as_ref()
+            .and_then(|reservation| reservation.owner_run_id.clone());
         record_task_lock_audit_event(
             runtime,
             "task.locks.reserve.released",
             "orbit.task.locks.release",
             Some(reservation_id.as_str()),
+            released_task_id,
             AuditEventStatus::Success,
             json!({
                 "reservation_id": reservation_id,
-                "owner_run_id": result
-                    .reservation
-                    .as_ref()
-                    .and_then(|reservation| reservation.owner_run_id.clone()),
+                "owner_run_id": owner_run_id,
                 "release_reason": TaskReservationReleaseReason::Explicit.as_str(),
                 "released_at": result.released_at,
                 "released_by": reservation_actor_label(
@@ -170,12 +176,16 @@ pub(super) fn reserve(
         "task.locks.reserve.requested",
         "orbit.task.locks.reserve",
         None,
+        first_task_id(&task_ids),
         AuditEventStatus::Success,
         json!({
             "actor": actor.clone(),
             "task_ids": task_ids.clone(),
             "files": requested_files.clone(),
             "ttl_seconds": ttl_seconds,
+            "owner_run_id": reservation_owner
+                .as_ref()
+                .map(|owner| owner.owner_run_id.clone()),
         }),
     )?;
 
@@ -229,6 +239,7 @@ pub(super) fn reserve(
             "task.locks.reserve.granted",
             "orbit.task.locks.reserve",
             Some(reservation_id.as_str()),
+            first_task_id(&task_ids),
             AuditEventStatus::Success,
             json!({
                 "reservation_id": reservation_id,
@@ -254,12 +265,16 @@ pub(super) fn reserve(
             "task.locks.reserve.denied",
             "orbit.task.locks.reserve",
             None,
+            first_task_id(&task_ids),
             AuditEventStatus::Denied,
             json!({
                 "actor": actor,
                 "task_ids": task_ids.clone(),
                 "files": requested_files.clone(),
                 "conflicts": conflicts.clone(),
+                "owner_run_id": reservation_owner
+                    .as_ref()
+                    .map(|owner| owner.owner_run_id.clone()),
             }),
         )?;
         Ok(json!({
@@ -467,6 +482,7 @@ pub(crate) fn emit_expired_reservation_events(
             "task.locks.reserve.expired",
             "orbit.task.locks.reserve",
             Some(expired.reservation_id.as_str()),
+            None,
             AuditEventStatus::Success,
             json!({
                 "reservation_id": expired.reservation_id,
@@ -487,6 +503,7 @@ pub(crate) fn emit_task_lock_release_event(
         "task.locks.reserve.released",
         "orbit.task.locks.release",
         Some(reservation.reservation_id.as_str()),
+        first_task_id(&reservation.task_ids),
         AuditEventStatus::Success,
         json!({
             "reservation_id": reservation.reservation_id,
@@ -511,10 +528,13 @@ fn record_task_lock_audit_event(
     command: &str,
     tool_name: &str,
     target_id: Option<&str>,
+    task_id: Option<&str>,
     status: AuditEventStatus,
     payload: Value,
 ) -> Result<(), OrbitError> {
     let execution_id_prefix = format!("audit-{}", command.replace('.', "-"));
+    let job_run_id = owner_run_id_from_payload(&payload)
+        .or_else(|| std::env::var("ORBIT_RUN_ID").ok().filter(|s| !s.is_empty()));
     runtime.record_audit_event(&crate::AuditEventInsertParams {
         execution_id: audit_execution_id(&execution_id_prefix),
         command: command.to_string(),
@@ -542,8 +562,8 @@ fn record_task_lock_audit_event(
         host: std::env::var("HOSTNAME").ok(),
         pid: std::process::id(),
         session_id: None,
-        task_id: target_id.map(ToOwned::to_owned),
-        job_run_id: std::env::var("ORBIT_RUN_ID").ok().filter(|s| !s.is_empty()),
+        task_id: task_id.map(ToOwned::to_owned),
+        job_run_id,
         activity_id: std::env::var("ORBIT_ACTIVITY_ID")
             .ok()
             .filter(|s| !s.is_empty()),
@@ -551,4 +571,174 @@ fn record_task_lock_audit_event(
             .ok()
             .and_then(|s| s.parse().ok()),
     })
+}
+
+fn first_task_id(task_ids: &[String]) -> Option<&str> {
+    task_ids.first().map(String::as_str)
+}
+
+fn owner_run_id_from_payload(payload: &Value) -> Option<String> {
+    payload
+        .get("owner_run_id")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use orbit_common::types::{AuditEvent, Role, TaskStatus};
+    use orbit_tools::{ReservationOwnerContext, ToolContext};
+    use serde_json::{Value, json};
+
+    use super::super::test_support::{create_context_task, test_runtime, unmanaged_tool_env_guard};
+
+    fn task_lock_audit_event(runtime: &OrbitRuntime, tool_name: &str, command: &str) -> AuditEvent {
+        runtime
+            .list_audit_events(None, Some(tool_name.to_string()), None, None, 16)
+            .expect("list audit events")
+            .into_iter()
+            .find(|event| event.command == command)
+            .expect("task lock audit event")
+    }
+
+    fn reserve_files(runtime: &OrbitRuntime, owner_run_id: Option<&str>) -> String {
+        let input = json!({
+            "files": ["file:src/lib.rs"],
+            "ttl_seconds": 3600,
+            "model": "gpt-5.5",
+        });
+        let output = match owner_run_id {
+            Some(owner_run_id) => runtime
+                .run_tool_with_context_and_role(
+                    "orbit.task.locks.reserve",
+                    input,
+                    Role::Admin,
+                    ToolContext {
+                        reservation_owner: Some(ReservationOwnerContext {
+                            owner_run_id: owner_run_id.to_string(),
+                            owner_metadata_json: None,
+                        }),
+                        ..ToolContext::default()
+                    },
+                )
+                .expect("reserve direct file selectors with owner"),
+            None => runtime
+                .execute_tool_command("orbit.task.locks.reserve", input, None, None)
+                .expect("reserve direct file selectors"),
+        };
+
+        output
+            .get("reservation_id")
+            .and_then(Value::as_str)
+            .expect("reservation id")
+            .to_string()
+    }
+
+    #[test]
+    fn release_audit_without_owner_has_no_task_or_job_run_id() {
+        let _env = unmanaged_tool_env_guard();
+        let (_root, runtime, repo_root) = test_runtime();
+        std::fs::create_dir_all(repo_root.join("src")).expect("create src dir");
+        std::fs::write(repo_root.join("src/lib.rs"), "pub fn ok() {}\n")
+            .expect("write source file");
+
+        let reservation_id = reserve_files(&runtime, None);
+        let release = runtime
+            .execute_tool_command(
+                "orbit.task.locks.release",
+                json!({
+                    "reservation_id": reservation_id.clone(),
+                    "model": "gpt-5.5",
+                }),
+                None,
+                None,
+            )
+            .expect("release reservation");
+        assert_eq!(release["released"], true);
+
+        let row = task_lock_audit_event(
+            &runtime,
+            "orbit.task.locks.release",
+            "task.locks.reserve.released",
+        );
+        assert_eq!(row.target_id.as_deref(), Some(reservation_id.as_str()));
+        assert!(row.task_id.is_none());
+        assert!(row.job_run_id.is_none());
+    }
+
+    #[test]
+    fn release_audit_uses_reservation_owner_run_id() {
+        let _env = unmanaged_tool_env_guard();
+        let (_root, runtime, repo_root) = test_runtime();
+        std::fs::create_dir_all(repo_root.join("src")).expect("create src dir");
+        std::fs::write(repo_root.join("src/lib.rs"), "pub fn ok() {}\n")
+            .expect("write source file");
+
+        let reservation_id = reserve_files(&runtime, Some("jrun-owner"));
+        let release = runtime
+            .execute_tool_command(
+                "orbit.task.locks.release",
+                json!({
+                    "reservation_id": reservation_id.clone(),
+                    "model": "gpt-5.5",
+                }),
+                None,
+                None,
+            )
+            .expect("release reservation");
+        assert_eq!(release["released"], true);
+
+        let row = task_lock_audit_event(
+            &runtime,
+            "orbit.task.locks.release",
+            "task.locks.reserve.released",
+        );
+        assert_eq!(row.target_id.as_deref(), Some(reservation_id.as_str()));
+        assert!(row.task_id.is_none());
+        assert_eq!(row.job_run_id.as_deref(), Some("jrun-owner"));
+    }
+
+    #[test]
+    fn reserve_audit_for_task_scope_records_first_task_id() {
+        let _env = unmanaged_tool_env_guard();
+        let (_root, runtime, repo_root) = test_runtime();
+        std::fs::create_dir_all(repo_root.join("src")).expect("create src dir");
+        std::fs::write(repo_root.join("src/lib.rs"), "pub fn ok() {}\n")
+            .expect("write source file");
+        let task = create_context_task(
+            &runtime,
+            &repo_root,
+            TaskStatus::Backlog,
+            &["file:src/lib.rs"],
+        );
+
+        let reserve = runtime
+            .execute_tool_command(
+                "orbit.task.locks.reserve",
+                json!({
+                    "task_ids": [task.id.clone()],
+                    "ttl_seconds": 3600,
+                    "model": "gpt-5.5",
+                }),
+                None,
+                None,
+            )
+            .expect("reserve task scope");
+        assert_eq!(reserve["reserved"], true);
+        let reservation_id = reserve["reservation_id"]
+            .as_str()
+            .expect("reservation id")
+            .to_string();
+
+        let row = task_lock_audit_event(
+            &runtime,
+            "orbit.task.locks.reserve",
+            "task.locks.reserve.granted",
+        );
+        assert_eq!(row.target_id.as_deref(), Some(reservation_id.as_str()));
+        assert_eq!(row.task_id.as_deref(), Some(task.id.as_str()));
+    }
 }


### PR DESCRIPTION
## Task

[ORB-00085](https://orbit-cli.com/tasks/ORB-00085) — Populate audit task_id and job_run_id correctly for lock-reservation and job-run events

### Description

## Problem

Two distinct columns of the audit events stream are mis-populated for the lock-reservation and job-run-worker code paths. The dashboard renders `ev.task_id` and `ev.job_run_id` directly from the audit row, so the wrong values surface in the Knowledge / Audit tab detail view.

### Issue 1 — `orbit.task.locks.release` (and the sibling `task.locks.reserve.*` events)

In the Audit detail view for a `task.locks.reserve.released` event, the `task_id` field shows the reservation_id (e.g. `reservation-1778979598499415000`) and the `job_run_id` field is blank, even though the `arguments` JSON clearly carries `owner_run_id: "jrun-20260517-0059-2"`.

Root cause: `crates/orbit-core/src/runtime/orbit_tool_host/task_locks.rs` line 545 in `record_task_lock_audit_event` sets `task_id: target_id.map(ToOwned::to_owned)`. For the release path (line 116-136) `target_id` is the `reservation_id`, so the reservation id is copied into the `task_id` column — semantically wrong; a reservation_id is not a task_id. The same function at line 546 only consults `ORBIT_RUN_ID` for `job_run_id`, ignoring the `owner_run_id` value embedded in the payload (line 124-127) which is the canonical correlation back to the originating jrun.

### Issue 2 — `orbit job run-pipeline-worker`

The row in the audit table shows `jrun-20260517-0059-2` in the `target` column (good — that comes from `target_id`), but the expanded detail view shows `task_id: -` and `job_run_id: -`.

Root cause: `crates/orbit-cli/src/audit_middleware.rs` line 122 populates `job_run_id` only from `std::env::var("ORBIT_RUN_ID")`. For `job run-pipeline-worker` (and `job replay`) the run id is already known statically from `args.run_id` (audit_middleware.rs line 388-392), but it is never threaded into the `AuditEventInsertParams.job_run_id` field. Workers that did not inherit `ORBIT_RUN_ID` from their parent therefore leave `job_run_id` null, breaking click-through from the audit row to the run detail page (`#runs/<run_id>` link in `crates/orbit-cli/assets/dashboard/app.js:3455-3460`).

## Why It Matters

The Audit tab is the primary forensic surface for correlating tool invocations with task and run lifecycles. When `task_id` is populated with a reservation_id, every per-task audit filter and every downstream report that joins audit rows to `tasks.id` produces silently wrong results. When `job_run_id` is null for the very command that defines a job run, the dashboard cannot link audit events back to the run that produced them and per-run audit filtering misses these rows entirely.

## Constraints / Notes

- Fix sites:
  - `crates/orbit-core/src/runtime/orbit_tool_host/task_locks.rs` — function `record_task_lock_audit_event` (around line 509). Decouple `task_id` from `target_id`: only set `task_id` when the caller actually knows a real task id (e.g. when reservation scope is `TaskIds(_)` in `reserve`). For the release path, `task_id` should be `None` unless the originating reservation row is fetched and contributes a task id; the `reservation_id` belongs in `target_id` (already correct) and the payload (already correct). Source `job_run_id` from the payload (`owner_run_id` for release; `reservation_owner.owner_run_id` for reserve) before falling back to `ORBIT_RUN_ID`.
  - `crates/orbit-cli/src/audit_middleware.rs` — extend `CommandMeta` (and the `Job::RunPipelineWorker` / `Job::Replay` arms around line 383-407) so the resolved `run_id` is threaded into `AuditEventInsertParams.job_run_id` (line 122) when the meta carries it. The `ORBIT_RUN_ID` env fallback remains as-is for other paths.
- All call sites of `record_task_lock_audit_event` (locks.rs lines 116, 168, 227, 252, 465, 485) need to be re-audited — some pass `None`, some pass `Some(reservation_id)`. The semantic split is: `target_id` = reservation_id (always, when known); `task_id` = a real task id (only when scope is `TaskIds`); `job_run_id` = `owner_run_id` from the reservation row or payload, falling back to env.
- The audit row schema (`crates/orbit-store/src/sqlite/audit_event_store.rs` and `crates/orbit-common/src/types/audit_event.rs`) already has the right columns; no migration needed. This is purely a producer-side correctness fix.
- Do not introduce a new audit column (e.g. dedicated `reservation_id`) in this task — keep scope to correcting which existing column receives which value. If a dedicated `reservation_id` column is desired later, it is a separate ADR + migration task.
- The dashboard rendering at `crates/orbit-cli/assets/dashboard/app.js:3452-3463` is already correct; do not modify it. Verify the fix by re-emitting a lock release and a job run-pipeline-worker event and checking the audit detail view, not by adjusting the renderer.
- Frontend smoke-check: after fix, expanding a `task.locks.reserve.released` event in the Audit tab should show `task_id: -` (assuming the release was not scoped to a specific task id), `job_run_id: jrun-...` (linked, click-through to the run detail page works), and the existing `target` column still shows the reservation_id. Expanding a `job run-pipeline-worker` row should show `job_run_id: jrun-...` with a working link.

### Acceptance Criteria

- After the fix, running `orbit tool run orbit.task.locks.reserve` then `orbit tool run orbit.task.locks.release` produces audit rows in `.orbit/state/audit.sqlite3` (or the configured audit store) where: (a) `target_id` equals the reservation_id, (b) `task_id` is NULL unless the reservation scope was `TaskIds(_)` in which case it holds the canonical task id, (c) `job_run_id` equals the `owner_run_id` recorded on the reservation (or NULL when no owner_run_id exists). Verifiable via `sqlite3 <path> "SELECT target_id, task_id, job_run_id FROM audit_events WHERE command LIKE task.locks.% ORDER BY id DESC LIMIT 5"`.
- Running `orbit job run-pipeline-worker --run-id <jrun-id> ...` writes an audit row with `job_run_id = <jrun-id>` regardless of whether `ORBIT_RUN_ID` is set in the calling environment. Verifiable via the same `sqlite3` query filtered on `command = job` and `subcommand = run-pipeline-worker`.
- Opening the dashboard Audit tab and expanding a post-fix `task.locks.reserve.released` event shows: `task_id: -` (or a real task id, never a `reservation-...` string), `job_run_id: jrun-...` rendered as a clickable link to `#runs/<jrun-id>` whenever owner_run_id was known.
- Opening the dashboard Audit tab and expanding a post-fix `job run-pipeline-worker` event shows `job_run_id: <jrun-id>` rendered as a clickable link; the existing `target` column continues to display the same jrun id.
- Filtering the Audit tab by `execution_id` for the worker run no longer drops the workers own `job run-pipeline-worker` row (i.e. the row now correlates via `job_run_id` as well as via `target_id`).
- Unit tests added under `crates/orbit-core/src/runtime/orbit_tool_host/task_locks.rs` (`#[cfg(test)] mod tests`) cover: (a) release path with no owner_run_id sets task_id=None and job_run_id=None; (b) release path with owner_run_id sets task_id=None and job_run_id=Some(owner_run_id); (c) reserve path with TaskIds scope sets task_id=Some(first_task_id). Tests use the existing audit store fakes / temp sqlite harness used elsewhere in the crate — no real env mutation.
- Unit tests added under `crates/orbit-cli/src/audit_middleware.rs` (`#[cfg(test)] mod tests`) cover: (a) `Job::RunPipelineWorker { run_id }` produces `AuditEventInsertParams` with `job_run_id = Some(run_id)` even when `ORBIT_RUN_ID` is unset; (b) `Job::Replay { run_id }` same property. Match the existing test scaffolding pattern already present in this file (see assertions around line 685-717).
- No changes outside `crates/orbit-core/src/runtime/orbit_tool_host/task_locks.rs`, `crates/orbit-cli/src/audit_middleware.rs`, and their respective test surfaces. `git diff --stat` on the branch shows changes confined to these areas plus any necessary signature updates inside `orbit-core` callers of `record_task_lock_audit_event`.
- `make ci-fast` passes on the branch before the task moves to review.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Decoupled task lock audit `target_id`, `task_id`, and `job_run_id`: reservation IDs stay in `target_id`, real task IDs are recorded only from task-scoped reservations, and owner run IDs are read from the lock audit payload before falling back to `ORBIT_RUN_ID`.
- Added lock audit tests covering release events with and without owner run IDs and task-scoped reserve events with a real task id.
- Extended CLI `CommandMeta` with `job_run_id` and wired `job replay` / `job run-pipeline-worker` run IDs into guard-written audit rows ahead of the environment fallback.
- Added CLI audit middleware tests proving those job commands record `job_run_id` when `ORBIT_RUN_ID` is unset.

Validation:
- `cargo test -p orbit-core runtime::orbit_tool_host::task_locks -- --nocapture`
- `cargo test -p orbit-cli audit_middleware::tests -- --nocapture`
- `cargo fmt --check`
- `make ci-fast`

Assessment: The change is scoped to the two requested producer surfaces and their tests; audit schema and dashboard rendering are untouched.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-00085-6a09191f`
- Behind base: 0
- Ahead of base: 1