### PR TITLE
Fix git author resolver: add grok arm, normalize codex to @orbit.local

### DIFF
--- a/crates/orbit-engine/src/executor/automation/vcs/commit/author.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/commit/author.rs
@@ -80,7 +80,8 @@ fn git_author_for_implemented_by(implemented_by: Option<&str>) -> Option<GitAuth
     match implementer_family(implemented_by).as_deref() {
         Some("claude") => Some(GitAuthor::new("claude", "claude@orbit.local")),
         Some("gemini") => Some(GitAuthor::new("gemini", "gemini@orbit.local")),
-        Some("codex") => Some(GitAuthor::new("codex", "codex@openai.com")),
+        Some("codex") => Some(GitAuthor::new("codex", "codex@orbit.local")),
+        Some("grok") => Some(GitAuthor::new("grok", "grok@orbit.local")),
         _ => {
             let slug = author_slug(implemented_by);
             Some(GitAuthor::new(slug.clone(), format!("{slug}@orbit.local")))

--- a/crates/orbit-engine/src/executor/automation/vcs/commit/mod.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/commit/mod.rs
@@ -496,7 +496,10 @@ mod tests {
         let cases = [
             ("claude-opus-4-7", "claude <claude@orbit.local>"),
             ("gemini-3.1-pro", "gemini <gemini@orbit.local>"),
-            ("gpt-5.5", "codex <codex@openai.com>"),
+            ("gpt-5.5", "codex <codex@orbit.local>"),
+            ("grok-4", "grok <grok@orbit.local>"),
+            ("grok-build", "grok <grok@orbit.local>"),
+            ("mystery-model", "mystery-model <mystery-model@orbit.local>"),
         ];
 
         for (implemented_by, expected_author) in cases {
@@ -594,8 +597,8 @@ mod tests {
             git_output(workspace, &["log", "-1", "--format=%an <%ae>"]).expect("read author");
         let actual_committer =
             git_output(workspace, &["log", "-1", "--format=%cn <%ce>"]).expect("read committer");
-        assert_eq!(actual_author, "codex <codex@openai.com>");
-        assert_eq!(actual_committer, "codex <codex@openai.com>");
+        assert_eq!(actual_author, "codex <codex@orbit.local>");
+        assert_eq!(actual_committer, "codex <codex@orbit.local>");
         assert_eq!(
             local_user_config_snapshot(workspace),
             local_user_config_before


### PR DESCRIPTION
## Task

[ORB-00088](https://orbit-cli.com/tasks/ORB-00088) — Fix git author resolver: add grok arm, normalize codex to @orbit.local

### Description

## Problem

[`git_author_for_implemented_by`](crates/orbit-engine/src/executor/automation/vcs/commit/author.rs#L74) returns a fabricated `GitAuthor` for the four agent families, but the match is wrong on two counts:

1. **Missing `grok` arm.** The match covers `claude`/`gemini`/`codex` only. When `implementer_family(implemented_by)` returns `Some("grok")` — which it does for any `grok-*` model string via [`infer_agent_family_from_model`](crates/orbit-common/src/types/agent_pair.rs#L136) — it falls through to the catch-all that slugifies the raw `implemented_by` string. Result: the self-reported model leaks into the git author identity.

   Concrete observation: commit [`10987127`](https://github.com/danieljhkim/orbit/commit/109871279610adb15d354b8cd4f975f96b5b5c21) (ORB-00086, run by grok) was authored by `grok-build <grok-build@orbit.local>` instead of `grok <grok@orbit.local>`.

   This contradicts the convention documented by ORB-00049 in [RELEASING.md](RELEASING.md) §8, which explicitly lists `grok <grok@orbit.local>` alongside the other three families.

2. **Inconsistent codex email.** Codex maps to `codex@openai.com` while every other family uses `@orbit.local`. `@openai.com` is a real domain OpenAI controls — using it for fabricated agent identities blurs "real OpenAI committer" vs. "Orbit-fabricated agent identity", and breaks the convention `@orbit.local` exists to enforce ("we made this identity up"). It also makes forensics inconsistent: `git log --author="@orbit.local"` silently misses codex commits.

   Historical note: the file was originally written by a commit whose own author was `codex <codex@openai.com>` (the Codex CLI's default git identity), and that incidental choice was never normalized.

## Why It Matters

- Git author identity is the durable, cross-repo signal of who wrote a commit. It surfaces in `git log`, GitHub PR commit lists, and `git blame` — including in repos that have nothing to do with Orbit's internal state. Drift here is the most visible form of the broader identity inconsistency that ORB-00080 is fixing in-process.
- Inconsistent emails defeat the "filter by agent" forensics pattern (`git log --author="@orbit.local"`).
- ORB-00049 already established `grok <grok@orbit.local>` as the documented convention; the code regressed against the doc.

## Constraints / Notes

- This is a small, mechanical fix and does not need to wait for ORB-00080's family-as-identity propagation to land. It is correct independently: even after `task.implemented_by` is normalized to a family enum, the resolver needs all four arms and a consistent email scheme.
- After ORB-00081's migration normalizes `implemented_by` to family strings on existing tasks, the catch-all `slug` branch will rarely fire — but it should still exist for forward-compat with unknown self-reported strings.
- Update the existing test table in [crates/orbit-engine/src/executor/automation/vcs/commit/mod.rs](crates/orbit-engine/src/executor/automation/vcs/commit/mod.rs#L497) (`git_commit_uses_scoped_identity_without_mutating_local_human_config`) to assert all four families, including the codex@orbit.local change.
- No external doc updates needed: RELEASING.md §8 already documents `codex <codex@orbit.local>` (per ORB-00049). The code is what's out of sync.

### Acceptance Criteria

- `git_author_for_implemented_by` in `crates/orbit-engine/src/executor/automation/vcs/commit/author.rs` returns `GitAuthor::new("grok", "grok@orbit.local")` when `implementer_family` returns `Some("grok")` — added as an explicit match arm, not via the catch-all.
- `git_author_for_implemented_by` returns `GitAuthor::new("codex", "codex@orbit.local")` (not `codex@openai.com`).
- The test table in `git_commit_uses_scoped_identity_without_mutating_local_human_config` (`crates/orbit-engine/src/executor/automation/vcs/commit/mod.rs`) includes one row per family: claude, gemini, codex, grok — each asserting `<family> <<family>@orbit.local>` for both author and committer. The codex row asserts `@orbit.local`, not `@openai.com`.
- A new test case asserts that an `implemented_by` value of `grok-build` (the self-reported model string observed in commit 10987127) resolves to author `grok <grok@orbit.local>`, not `grok-build <grok-build@orbit.local>`.
- The catch-all slugify branch is preserved (for unknown families) but no longer fires for any of the four canonical families. A test confirms an unknown string like `mystery-model` still falls through to a slug-based author.
- No other call sites of `GitAuthor::new` in `crates/orbit-engine/src/executor/automation/vcs/commit/` hardcode `@openai.com` (grep verifies). Test fixtures at `crates/orbit-engine/src/executor/automation/vcs/commit/mod.rs:497` are updated.
- `make ci-fast` passes.

## Execution Summary

<details>
<summary>Click to expand</summary>

Fixed `git_author_for_implemented_by` in author.rs:45 to explicitly match 'grok' (returning grok <grok@orbit.local>) and normalized 'codex' to use @orbit.local email. Updated test table in mod.rs:497 to cover all four families plus grok-build (the exact regression case from 10987127) and mystery-model for catch-all. Updated secondary test assertions. `make ci-fast` passed. Specific tests `git_commit_uses_scoped_identity...` and `git_commit_succeeds_without...` both pass with new expectations. No @openai.com remains in commit/ dir. Grep and direct execution confirm explicit arm and correct identities for grok-build etc.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-00088-6a091ee9`
- Behind base: 0
- Ahead of base: 1