### PR TITLE
Wire runtime identity into activity-job ToolContext (close ORB-00080 mechanism gap)

### DIFF
--- a/crates/orbit-core/src/command/tool.rs
+++ b/crates/orbit-core/src/command/tool.rs
@@ -924,6 +924,42 @@ mod audit_tests {
     }
 
     #[test]
+    fn cli_tool_dispatch_env_identity_overwrites_task_update_self_reported_model() {
+        let _g = env_guard();
+        let runtime = fresh_runtime();
+        let task = runtime
+            .add_task(crate::command::task::TaskAddParams {
+                title: "identity regression".to_string(),
+                description: "exercise CLI tool identity overwrite".to_string(),
+                acceptance_criteria: vec!["implemented_by is canonical".to_string()],
+                plan: "Do the work.".to_string(),
+                status: Some(orbit_common::types::TaskStatus::InProgress),
+                ..Default::default()
+            })
+            .expect("seed in-progress task");
+        set_identity_env("grok", "grok-build");
+
+        runtime
+            .execute_tool_command_dispatch(
+                "orbit.task.update",
+                json!({
+                    "id": task.id.clone(),
+                    "status": "review",
+                    "execution_summary": "Done.",
+                    "model": "claude-opus-4-7"
+                }),
+                None,
+                None,
+                ToolEntryPoint::Cli,
+            )
+            .expect("task update succeeds");
+        clear_identity_env();
+
+        let updated = runtime.get_task(&task.id).expect("read updated task");
+        assert_eq!(updated.implemented_by.as_deref(), Some("grok"));
+    }
+
+    #[test]
     fn audit_role_label_defaults_to_agent_when_no_identity_available() {
         let _g = env_guard();
         clear_identity_env();

--- a/crates/orbit-core/src/runtime/v2_host/mod.rs
+++ b/crates/orbit-core/src/runtime/v2_host/mod.rs
@@ -224,3 +224,133 @@ fn role_slot_from_input(input: &Value) -> Option<RoleSlot> {
         .and_then(Value::as_str)
         .and_then(|value| value.parse().ok())
 }
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{Mutex, MutexGuard, OnceLock};
+
+    use orbit_common::types::activity_job::{AgentLoopSpec, Backend, OnDenial, Provider};
+    use orbit_common::types::{TaskPriority, TaskStatus, TaskType};
+    use orbit_engine::{V2AuditWriter, drive_agent_loop, reset_replay_transport};
+    use tempfile::NamedTempFile;
+
+    use super::test_support::{runtime_with_workspace_layout, seed_list_backlog_task};
+    use super::*;
+
+    fn replay_env_guard() -> MutexGuard<'static, ()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
+
+    struct ReplayFixtureGuard {
+        prior: Option<String>,
+    }
+
+    impl ReplayFixtureGuard {
+        fn set(path: &std::path::Path) -> Self {
+            let prior = std::env::var("ORBIT_V2_REPLAY_FIXTURE").ok();
+            // SAFETY: replay fixture env mutation is serialized by `replay_env_guard`.
+            unsafe {
+                std::env::set_var("ORBIT_V2_REPLAY_FIXTURE", path);
+            }
+            reset_replay_transport();
+            Self { prior }
+        }
+    }
+
+    impl Drop for ReplayFixtureGuard {
+        fn drop(&mut self) {
+            reset_replay_transport();
+            // SAFETY: replay fixture env mutation is serialized by `replay_env_guard`.
+            unsafe {
+                match &self.prior {
+                    Some(value) => std::env::set_var("ORBIT_V2_REPLAY_FIXTURE", value),
+                    None => std::env::remove_var("ORBIT_V2_REPLAY_FIXTURE"),
+                }
+            }
+        }
+    }
+
+    fn write_replay_fixture(value: Value) -> NamedTempFile {
+        let file = NamedTempFile::new().expect("fixture temp file");
+        std::fs::write(
+            file.path(),
+            serde_json::to_vec(&value).expect("serialize replay fixture"),
+        )
+        .expect("write replay fixture");
+        file
+    }
+
+    #[test]
+    fn http_agent_loop_tool_update_persists_runtime_identity_family() {
+        let _lock = replay_env_guard();
+        let (_root, runtime, _repo_root) = runtime_with_workspace_layout();
+        let task = seed_list_backlog_task(
+            &runtime,
+            "runtime identity regression",
+            TaskStatus::InProgress,
+            TaskPriority::Medium,
+            TaskType::Chore,
+            None,
+            Vec::new(),
+        );
+        let fixture = write_replay_fixture(serde_json::json!({
+            "turns": [
+                {
+                    "content": [{
+                        "kind": "tool_use",
+                        "id": "toolu_identity_update",
+                        "name": "orbit.task.update",
+                        "input": {
+                            "id": task.id.clone(),
+                            "status": "review",
+                            "execution_summary": "Identity regression covered.",
+                            "model": "grok-build"
+                        }
+                    }],
+                    "stop_reason": "tool_use"
+                },
+                {
+                    "content": [{ "kind": "text", "text": "done" }],
+                    "stop_reason": "end_turn"
+                }
+            ]
+        }));
+        let _guard = ReplayFixtureGuard::set(fixture.path());
+        let audit_dir = tempfile::tempdir().expect("audit tempdir");
+        let audit = V2AuditWriter::with_disk_sinks(
+            audit_dir.path(),
+            "http-identity-regression",
+            "claude:claude-opus-4-7".to_string(),
+            None,
+        )
+        .expect("audit writer");
+        let spec = AgentLoopSpec {
+            instruction: "exercise tool identity".to_string(),
+            tools: vec!["orbit.task.update".to_string()],
+            on_denial: OnDenial::Terminate,
+            model: Some("claude-opus-4-7".to_string()),
+            max_iterations: 2,
+            backend: Backend::Http,
+            provider: Provider::Claude,
+            wall_clock_timeout_seconds: 30,
+            role: None,
+        };
+
+        drive_agent_loop(
+            &spec,
+            None,
+            "http-identity-regression",
+            audit,
+            &serde_json::json!({ "prompt": "update the task" }),
+            &runtime,
+            None,
+        )
+        .expect("replay agent loop succeeds");
+
+        let updated = runtime.get_task(&task.id).expect("updated task");
+        assert_eq!(updated.implemented_by.as_deref(), Some("claude"));
+    }
+}

--- a/crates/orbit-engine/src/activity_job/agent_loop_driver.rs
+++ b/crates/orbit-engine/src/activity_job/agent_loop_driver.rs
@@ -55,13 +55,15 @@ pub fn drive_agent_loop(
     fs_profile: Option<&str>,
 ) -> Result<LoopOutcome, DispatchError> {
     let model = resolve_model(spec);
-    let provider = expected_provider();
+    let provider = spec.provider.as_str();
     let mut session = Session::new(provider, model.clone(), &spec.instruction, None);
     let mut tool_ctx = host.tool_context_for_activity(
         Some(run_id),
         fs_profile,
         Some(v2_fs_audit_logger(audit.clone())),
     );
+    tool_ctx.agent_name = Some(provider.to_string());
+    tool_ctx.model_name = Some(model);
     tool_ctx.role_slot = role_slot_from_input(input);
     drive_inner(
         spec,
@@ -91,11 +93,15 @@ pub fn drive_agent_loop_with_session(
     host: &dyn V2RuntimeHost,
     fs_profile: Option<&str>,
 ) -> Result<LoopOutcome, DispatchError> {
+    let model = resolve_model(spec);
+    let provider = spec.provider.as_str();
     let mut tool_ctx = host.tool_context_for_activity(
         Some(run_id),
         fs_profile,
         Some(v2_fs_audit_logger(audit.clone())),
     );
+    tool_ctx.agent_name = Some(provider.to_string());
+    tool_ctx.model_name = Some(model);
     tool_ctx.role_slot = role_slot_from_input(input);
     drive_inner(
         spec,
@@ -131,8 +137,15 @@ pub fn drive_agent_loop_with_tool_context(
     tool_ctx: ToolContext,
 ) -> Result<LoopOutcome, DispatchError> {
     let model = resolve_model(spec);
-    let provider = expected_provider();
+    let provider = spec.provider.as_str();
     let mut session = Session::new(provider, model.clone(), &spec.instruction, None);
+    let mut tool_ctx = tool_ctx;
+    if tool_ctx.agent_name.is_none() {
+        tool_ctx.agent_name = Some(provider.to_string());
+    }
+    if tool_ctx.model_name.is_none() {
+        tool_ctx.model_name = Some(model);
+    }
     drive_inner(
         spec,
         api_key,
@@ -262,14 +275,6 @@ fn resolve_model(spec: &AgentLoopSpec) -> String {
     spec.model
         .clone()
         .unwrap_or_else(|| DEFAULT_ANTHROPIC_MODEL.to_string())
-}
-
-fn expected_provider() -> &'static str {
-    if replay_active() {
-        "replay"
-    } else {
-        "anthropic"
-    }
 }
 
 fn replay_active() -> bool {

--- a/crates/orbit-engine/src/activity_job/cli_runner/orchestrator.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/orchestrator.rs
@@ -54,7 +54,9 @@ pub fn run_cli_backend(
     });
 
     let task_ctx = host.task_context_for_agent_input(input)?;
-    let tool_ctx = host.tool_context_for_activity(Some(run_id), fs_profile, None);
+    let mut tool_ctx = host.tool_context_for_activity(Some(run_id), fs_profile, None);
+    tool_ctx.agent_name = Some(provider.clone());
+    tool_ctx.model_name = spec.model.as_deref().map(str::to_string);
     // Resolve the subprocess cwd before sandbox compilation so the host can
     // re-allow the active worktree subpath after the policy deny rules. The
     // sandbox's `denyModify .orbit/**` rule otherwise blocks every non-codex
@@ -148,6 +150,12 @@ pub fn run_cli_backend(
         ("ORBIT_RUN_ID".to_string(), run_id.to_string()),
         ("ORBIT_MANAGED_RUN_CONTEXT".to_string(), "1".to_string()),
     ];
+    if let Some(agent_name) = tool_ctx.agent_name.as_deref() {
+        child_env.push(("ORBIT_AGENT_NAME".to_string(), agent_name.to_string()));
+    }
+    if let Some(model_name) = tool_ctx.model_name.as_deref() {
+        child_env.push(("ORBIT_AGENT_MODEL".to_string(), model_name.to_string()));
+    }
     if let Some(session_id) = learning_context.session_id {
         child_env.push(("ORBIT_SESSION_ID".to_string(), session_id));
     }

--- a/crates/orbit-engine/src/activity_job/cli_runner/tests/orchestrator_tests.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/tests/orchestrator_tests.rs
@@ -448,6 +448,54 @@ fn run_cli_backend_passes_model_to_grok_and_captures_well_formed_stdout() {
     );
 }
 
+#[test]
+fn run_cli_backend_exports_runtime_identity_for_subprocess_tools() {
+    let temp = tempdir().expect("tempdir");
+    let script = temp.path().join("grok");
+    write_executable(
+        &script,
+        r#"#!/bin/sh
+cat > /dev/null
+if [ "$ORBIT_AGENT_NAME" = "grok" ] && [ "$ORBIT_AGENT_MODEL" = "grok-build" ]; then
+  printf '%s\n' '{"schemaVersion":1,"status":"success","result":{"identity":"ok"},"error":null}'
+else
+  printf '%s\n' '{"schemaVersion":1,"status":"failed","error":{"code":"identity_env_missing","message":"runtime identity env was not propagated","details":null}}'
+  exit 1
+fi
+"#,
+    );
+
+    let sink = Arc::new(RecordingSink::default());
+    let sink_for_writer: Arc<dyn AuditSink> = sink;
+    let audit = Arc::new(V2AuditWriter::new(
+        "job-grok-identity-env",
+        "grok:grok-build",
+        sink_for_writer,
+    ));
+    let host = TestHost {
+        command: script.display().to_string(),
+        executor_args: Vec::new(),
+        provider_config: HashMap::new(),
+        sandbox: None,
+        task_context: None,
+    };
+    let mut spec = test_agent_loop_spec_for("grok", Duration::from_secs(5));
+    spec.model = Some("grok-build".to_string());
+
+    let outcome = run_cli_backend(
+        &host,
+        &spec,
+        "job-grok-identity-env",
+        audit,
+        &serde_json::json!({"prompt": "hi"}),
+        None,
+    )
+    .expect("run succeeds");
+
+    assert!(outcome.success);
+    assert_eq!(outcome.output["provider"], "grok");
+}
+
 /// Regression for T20260508-17: a CLI subprocess that exits 0 but emits an
 /// embedded Orbit response envelope reporting `status: "failed"` must NOT
 /// be classified as success. Pre-fix, dispatch returned `success: true`

--- a/crates/orbit-engine/src/activity_job/job_executor/target.rs
+++ b/crates/orbit-engine/src/activity_job/job_executor/target.rs
@@ -45,11 +45,7 @@ pub(super) fn run_target(
                     .model
                     .clone()
                     .unwrap_or_else(|| DEFAULT_MODEL_FOR_SESSION.to_string());
-                let provider = if replay_active() {
-                    "replay"
-                } else {
-                    "anthropic"
-                };
+                let provider = agent_spec.provider.as_str();
                 Session::new(provider, model, &agent_spec.instruction, None)
             });
             let api_key = ctx.host.api_key_for("anthropic").ok();
@@ -190,6 +186,7 @@ pub(super) fn run_agent_loop_outcome(
     })
 }
 
+#[cfg(test)]
 pub(super) fn replay_active() -> bool {
     std::env::var("ORBIT_V2_REPLAY").is_ok() || std::env::var("ORBIT_V2_REPLAY_FIXTURE").is_ok()
 }


### PR DESCRIPTION
## Task

[ORB-00089](https://orbit-cli.com/tasks/ORB-00089) — Wire runtime identity into activity-job ToolContext (close ORB-00080 mechanism gap)

### Description

## Problem

ORB-00080 added a runtime-boundary overwrite that collapses an agent's self-reported `model` to its canonical family at the tool surface, via [`resolve_identity`](crates/orbit-tools/src/builtin/orbit/mod.rs#L109). That collapse is **gated on `ctx.agent_name` / `ctx.model_name` being populated** ([mod.rs:124](crates/orbit-tools/src/builtin/orbit/mod.rs#L124)); when both are `None`, control falls through to `input_has_identity` and the agent's self-report passes through unchanged.

[`tool_context_for_activity`](crates/orbit-core/src/runtime/v2_host/mod.rs#L91) — the function that builds the `ToolContext` for every activity-job tool invocation — sets `policy_engine`, `fs_profile`, `reservation_owner`, `orbit_host`, then leaves `agent_name` and `model_name` to `..Default::default()` (i.e. `None`). Both call sites of `tool_context_for_activity` patch `role_slot` after construction but never identity:

- HTTP-direct path: [`agent_loop_driver.rs:60-65`](crates/orbit-engine/src/activity_job/agent_loop_driver.rs#L60). `resolve_model(spec)` and `expected_provider()` are computed on lines 57-58 of the same function but discarded.
- CLI subprocess path: [`cli_runner/orchestrator.rs:57`](crates/orbit-engine/src/activity_job/cli_runner/orchestrator.rs#L57). `provider` is on line 40 and `spec.model.as_deref()` on line 102, neither propagated.

Result: ORB-00080's collapse is dead code on the real activity-job paths. The unit test [`runtime_identity_overwrites_self_reported_model_at_tool_boundary`](crates/orbit-tools/src/builtin/orbit/mod.rs#L243) passes because it builds a `ToolContext` with both fields set by hand — that path isn't exercised in production.

## Evidence

[`.orbit/tasks/ORB-00086/task.yaml`](.orbit/tasks/ORB-00086/task.yaml) was completed at `2026-05-17T01:29:24Z`, **8 minutes after** ORB-00080 merged to `agent-main` (`da82dc1f`, `2026-05-17T01:21:28Z`). The persisted record:

```yaml
created_by: grok-build
implemented_by: grok-build
```

Both fields are the agent's self-reported model string, not the canonical family `grok`. The downstream consequence is visible in commit [`10987127`](https://github.com/danieljhkim/orbit/commit/109871279610adb15d354b8cd4f975f96b5b5c21), authored by `grok-build <grok-build@orbit.local>` — the leak propagates all the way to durable git history (ORB-00088 covers the matching gap in the git-author resolver, but the upstream fix is here).

## Why It Matters

- Every new task completed under any activity-job path is being written with raw model strings (`grok-build`, `claude-opus-4-7`, `gpt-5.5`, `gemini-3.1-pro`, …) instead of the four canonical families. ORB-00080's persistence-schema change is being defeated at the write boundary on every single run.
- ORB-00081 (existing-data migration) is partially wasted without this fix: even after backfill, the next workflow run reintroduces raw model strings. ORB-00081 should land **after** this task.
- The git-author leak (ORB-00088) and any other downstream consumer that branches on `implemented_by` (scoreboards, friction projections, attribution displays) all keep seeing the noisy raw string regardless of ORB-00080.

## Constraints / Notes

- The fix is small (two call sites, plus a possible refactor to push the wire-up into `tool_context_for_activity` itself if both callers want it). Prefer threading identity into `tool_context_for_activity` via new parameters over patching each caller — keeps callers honest and prevents the next caller from forgetting the patch.
- `expected_provider()` in `agent_loop_driver.rs` returns a hard-coded `"claude"` today (HTTP-direct path is Claude-only). Use the actual provider name from the spec, not a hard-coded string, so this remains correct when other providers add HTTP-direct paths.
- For the CLI subprocess path, `provider` (line 40) is the family name (`codex`, `claude`, `gemini`, `grok`), and `spec.model` is the configured model (`gpt-5.5`, `claude-opus-4-7`, etc). Both should be threaded in — `resolve_identity` will then collapse `model → family` via `normalize_agent_family_for_model`.
- A regression test must drive a real activity-job invocation (not just a unit-level `ToolContext` synthesized in a test) and assert that the persisted `implemented_by` on the resulting task is the family enum string, not the model string. The existing unit test does not catch this class of bug.
- Do not change `resolve_identity` — its contract is correct. The defect is upstream wire-up.

### Acceptance Criteria

- `tool_context_for_activity` in `crates/orbit-core/src/runtime/v2_host/mod.rs` accepts (or its callers patch in) the canonical agent family and model identifiers, so that the returned `ToolContext` has `agent_name` and `model_name` populated for every activity-job invocation.
- HTTP-direct path: `drive_agent_loop` and `drive_agent_loop_with_session` in `crates/orbit-engine/src/activity_job/agent_loop_driver.rs` populate `tool_ctx.agent_name` (provider) and `tool_ctx.model_name` (the model resolved by `resolve_model(spec)`) before calling `drive_inner`. The hard-coded `expected_provider()` is replaced with the actual provider from `spec`.
- CLI subprocess path: `crates/orbit-engine/src/activity_job/cli_runner/orchestrator.rs` populates `tool_ctx.agent_name` (provider, line 40) and `tool_ctx.model_name` (spec.model, line 102) before the CLI invocation.
- End-to-end regression test (not a unit-level synthesized `ToolContext`): drive an activity-job invocation that issues an `orbit.task.update` with `model: "grok-build"` (or any non-family alias) and assert the persisted `task.implemented_by` equals `"grok"` (or the matching family for the alias used), not the raw input. Cover at least one HTTP-direct path test and one CLI-subprocess path test.
- The existing unit test `runtime_identity_overwrites_self_reported_model_at_tool_boundary` at `crates/orbit-tools/src/builtin/orbit/mod.rs:243` still passes unchanged.
- Re-running an equivalent of ORB-00086's update flow against the patched binary writes `implemented_by: grok` to the task.yaml — verified manually with a transcript line or scripted assertion in the PR description.
- `make ci-fast` passes.
- Description of the PR explicitly cites ORB-00081 and notes that the data migration in ORB-00081 should land after this task to avoid re-corruption.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Wired HTTP-direct activity jobs to stamp `ToolContext.agent_name` from `spec.provider.as_str()` and `ToolContext.model_name` from `resolve_model(spec)` before running the loop; removed the hard-coded `expected_provider()` path and aligned persisted session identity for HTTP job sessions with the activity provider.
- Wired CLI backend activity jobs to stamp `ToolContext` identity from the activity spec and export `ORBIT_AGENT_NAME` / `ORBIT_AGENT_MODEL` to the spawned provider process, so subprocess `orbit tool run` calls inherit runtime identity instead of trusting self-reported tool input.
- Added regressions covering an HTTP replay-driven `orbit.task.update` that persists canonical `implemented_by`, CLI subprocess identity env propagation for `grok:grok-build`, and CLI tool dispatch overwriting a self-reported task update model from runtime env.

Validation:
- `cargo test -p orbit-core http_agent_loop_tool_update_persists_runtime_identity_family`
- `cargo test -p orbit-core cli_tool_dispatch_env_identity_overwrites_task_update_self_reported_model`
- `cargo test -p orbit-engine run_cli_backend_exports_runtime_identity_for_subprocess_tools`
- `cargo test -p orbit-tools runtime_identity_overwrites_self_reported_model_at_tool_boundary`
- `cargo test -p orbit-engine activity_job::agent_loop_driver`
- `cargo test -p orbit-engine role_override_does_not_disable_replay_short_circuit`
- `make ci-fast`

Strategic decisions:
- CLI subprocess tools cross a process boundary, so identity must be carried both in the in-process `ToolContext` and in `ORBIT_AGENT_*` env vars. The regression in `cli_tool_dispatch_env_identity_overwrites_task_update_self_reported_model` is the scripted ORB-00086-equivalent assertion: with runtime env `grok:grok-build`, a task update self-reporting another model persists `implemented_by: grok`.
- PR description should explicitly cite ORB-00081 and note that the ORB-00081 migration must land after ORB-00089 to avoid re-corrupting migrated attribution.

Learning checkpoint:
- Added learning `L20260517-2` for the CLI subprocess identity propagation gotcha.
- Filed friction `F2026-05-022` for the `orbit.learning.add` MCP schema exposing `evidence` as a string even though the tool requires an array.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-00089-6a09202e`
- Behind base: 0
- Ahead of base: 1