### PR TITLE
Docs: teach family-as-identity convention for the `model` field

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,7 +57,7 @@ Related lint work:
 
 - Use the agent commit identity (e.g. `codex`, `claude`) as author/committer.
 - Include the Orbit task ID in commit messages when applicable (e.g. `[ORB-00042]`). Task IDs are allocation-authority search keys (`git log --grep '[ORB-00042]'`); when a task has a linked `external_ref`, include that tag too (`[ORB-00042] [ENG-1234] ...`) — cross-engineer reviewers resolve the external tag, not the Orbit one.
-- Use your model name (e.g. `claude-opus-4-7`, `gpt-5.5`, `gemini-3.1-pro`) when authoring tasks or docs. Cite relevant task IDs in any doc you write.
+- Use your agent family (`codex`, `claude`, `gemini`, `grok`) for the `model` field when authoring tasks or docs. Full model strings are accepted and auto-normalized. Cite relevant task IDs in any doc you write.
 
 ## Orbit Workflow
 

--- a/crates/orbit-core/assets/agent-rules.md
+++ b/crates/orbit-core/assets/agent-rules.md
@@ -5,7 +5,7 @@ This block is managed by `orbit workspace init --inject-agent-rules`. Edit the a
 
 - **Task before work.** File an Orbit task before non-trivial code changes. Use the `orbit-create-task` skill (or `orbit.task.add`). Don't invent task IDs — `orbit.task.add` allocates them.
 - **Tool surface over file edits.** Use `orbit.task.*`, `orbit.adr.*`, `orbit.design.*`, `orbit.learning.*` for their respective artifacts. Never edit files under `.orbit/` directly; the audit log and indexes will drift.
-- **Commit attribution.** Set the author to the agent identity (`claude`, `codex`, model name like `gpt-5.5`). Include the relevant task ID in the commit message — `[ORB-NNNNN]` for repo-level tasks, `[T20260514-3]` for ad-hoc tasks. When a task has an `external_ref`, include that tag too for cross-engineer review.
+- **Commit attribution.** Set the author to the agent family (`codex`, `claude`, `gemini`, `grok`). Include the relevant task ID in the commit message — `[ORB-NNNNN]` for repo-level tasks, `[T20260514-3]` for ad-hoc tasks. When a task has an `external_ref`, include that tag too for cross-engineer review.
 - **Don't commit without approval.** Hold `git commit` until the Orbit task has been explicitly approved by the human. Mark the task `review` first; commit only after approval flips it to `done` (or the human says "commit").
 - **Route via the `orbit` skill.** Start sessions by reading the `orbit` skill (`<orbit-root>/skills/orbit/SKILL.md`). It is the entry point that lists every workflow skill (`orbit-create-task`, `orbit-execute-task`, `orbit-review-task`, `orbit-adr`, `orbit-design`, `orbit-learning`, `orbit-graph`, `orbit-semantic`, `orbit-track-issues`, `orbit-debug-job-failure`).
 <!-- orbit-managed:end -->

--- a/crates/orbit-core/assets/skills/orbit-track-issues/SKILL.md
+++ b/crates/orbit-core/assets/skills/orbit-track-issues/SKILL.md
@@ -55,7 +55,7 @@ orbit tool run orbit.friction.add --input '{
   "body": "<what happened, where, and why it caused friction>",
   "tags": ["<tooling|skill-guidance|docs|lifecycle|build|naming|policy|other>"],
   "during_task": "<optional task id>",
-  "model": "<model_name>" # gpt-5.4, claude-opus-4-6, gemini-2.5-pro, etc
+  "model": "<model_name>" # codex, claude, gemini, grok (full strings accepted)
 }'
 ```
 
@@ -66,7 +66,7 @@ orbit_friction_add({
   "body": "<what happened, where, and why it caused friction>",
   "tags": ["<tooling|skill-guidance|docs|lifecycle|build|naming|policy|other>"],
   "during_task": "<optional task id>",
-  "model": "<model_name>"
+  "model": "<model_name>"  # codex, claude, gemini, grok (full strings accepted)
 })
 ```
 


### PR DESCRIPTION
## Task

[ORB-00090](https://orbit-cli.com/tasks/ORB-00090) — Docs: teach family-as-identity convention for the `model` field

### Description

## Problem

ORB-00080 settled the architectural convention: the persisted identity is the agent **family** (`codex`, `claude`, `gemini`, `grok`), not the full model string. Multiple agent-facing docs still teach the old "use your full model name" convention, with examples like `gpt-5.4, claude-opus-4-6, gemini-2.5-pro`.

This is purely a documentation alignment — runtime already accepts both forms (`infer_agent_family_from_model` normalizes full strings to family). The docs were drifting from the architectural intent.

## Why It Matters

- Every agent reading these docs absorbs the wrong pattern and writes raw model strings into `model` fields. Even with ORB-00080's runtime-collapse mechanism in place (and ORB-00089 to actually wire it up), the docs are the most-read source of truth for "what should I pass."
- The same docs were inconsistent internally: `CLAUDE.md` line 58 already said "agent commit identity (e.g. `codex`, `claude`)" but line 60 said "your model name (e.g. `claude-opus-4-7`)". Mixed signals.

## Scope

Three repo-side files updated (already edited in this session, awaiting commit):

- [`CLAUDE.md:60`](CLAUDE.md#L60) — "Use your model name (e.g. `claude-opus-4-7`, `gpt-5.5`, `gemini-3.1-pro`)" → "Use your agent family (`codex`, `claude`, `gemini`, `grok`)... Full strings accepted and auto-normalized."
- [`crates/orbit-core/assets/agent-rules.md:8`](crates/orbit-core/assets/agent-rules.md#L8) — "agent identity (`claude`, `codex`, model name like `gpt-5.5`)" → "agent family (`codex`, `claude`, `gemini`, `grok`)".
- [`crates/orbit-core/assets/skills/orbit-track-issues/SKILL.md:58,69`](crates/orbit-core/assets/skills/orbit-track-issues/SKILL.md#L58) — CLI and MCP example comments updated to list family names.

Two out-of-repo skill files were also updated in the same session for consistency (not part of this commit):
- `~/.claude/skills/orbit/SKILL.md` — expanded the "Always include `model`" callout to teach the family convention.
- `~/.claude/skills/orbit-create-task/SKILL.md` — updated CLI and MCP examples.

## Constraints / Notes

- **Tone**: "permissive with preference" — primarily teach the family convention but explicitly state that full model strings are accepted and auto-normalized. Reduces friction for agents that already pass full strings.
- **`agent-rules.md` is template-managed**: re-injected via `orbit workspace init --inject-agent-rules`. Repos that already ran `--inject-agent-rules` have the old text in their local copies until they re-inject. PR description should mention this.
- **No config changes**: `default-config.toml` crew definitions and `executors/*.yaml` `strong:`/`weak:` model aliases legitimately keep full model strings — those are configuration the CLI needs, not identity.
- **No code changes**: this is docs-only.
- **Doesn't depend on ORB-00089/ORB-00088/ORB-00081**: the docs change is forward-compatible regardless of runtime wire-up status.

### Acceptance Criteria

- `CLAUDE.md` line 60 teaches the family convention (`codex`, `claude`, `gemini`, `grok`) for the `model` field, with a brief note that full model strings are accepted and auto-normalized.
- `crates/orbit-core/assets/agent-rules.md` line 8 (Commit attribution bullet) uses 'agent family' phrasing and lists all four families, with no full-model-string examples.
- `crates/orbit-core/assets/skills/orbit-track-issues/SKILL.md` example comments in both CLI form (~line 58) and MCP form (~line 69) reference the four families instead of `gpt-5.4, claude-opus-4-6, gemini-2.5-pro`.
- No changes under `crates/orbit-core/assets/config/` or `crates/orbit-core/assets/executors/` — those legitimately retain full model strings as configuration.
- Commit message includes `[ORB-NNNNN]` for this task and uses an agent family (`claude`) as the author identity per the new convention being documented.
- `make ci-fast` passes (docs-only, should be trivially green).

## Execution Summary

<details>
<summary>Click to expand</summary>

Implemented ORB-00090 (docs-only alignment).

Updated three files to teach the agent-family convention for the `model` field (permissive: families preferred, full strings accepted+normalized):
- CLAUDE.md:60 (Commits & Authorship)
- crates/orbit-core/assets/agent-rules.md:8 (Commit attribution bullet)
- crates/orbit-core/assets/skills/orbit-track-issues/SKILL.md (~58 CLI, ~70 MCP examples)

`make ci-fast` passed (trivial for docs).

No changes to config/ or executors/ (per constraints). No commit performed (per AGENTS.md policy; awaiting human approval). No new learning added (no contradicted assumption or debug gotcha surfaced).

Diff (cheap git diff):
```diff
diff --git a/CLAUDE.md b/CLAUDE.md
index 85ba6f4a..b9779610 100644
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60 +60 @@ Related lint work:
-- Use your model name (e.g. `claude-opus-4-7`, `gpt-5.5`, `gemini-3.1-pro`) when authoring tasks or docs. Cite relevant task IDs in any doc you write.
+- Use your agent family (`codex`, `claude`, `gemini`, `grok`) for the `model` field when authoring tasks or docs. Full model strings are accepted and auto-normalized. Cite relevant task IDs in any doc you write.
diff --git a/crates/orbit-core/assets/agent-rules.md b/crates/orbit-core/assets/agent-rules.md
index 11d46395..9e4083b5 100644
--- a/crates/orbit-core/assets/agent-rules.md
+++ b/crates/orbit-core/assets/agent-rules.md
@@ -8 +8 @@ This block is managed by `orbit workspace init --inject-agent-rules`. Edit the a
-- **Commit attribution.** Set the author to the agent identity (`claude`, `codex`, model name like `gpt-5.5`). Include the relevant task ID in the commit message — `[ORB-NNNNN]` for repo-level tasks, `[T20260514-3]` for ad-hoc tasks. When a task has an `external_ref`, include that tag too for cross-engineer review.
+- **Commit attribution.** Set the author to the agent family (`codex`, `claude`, `gemini`, `grok`). Include the relevant task ID in the commit message — `[ORB-NNNNN]` for repo-level tasks, `[T20260514-3]` for ad-hoc tasks. When a task has an `external_ref`, include that tag too for cross-engineer review.
diff --git a/crates/orbit-core/assets/skills/orbit-track-issues/SKILL.md b/crates/orbit-core/assets/skills/orbit-track-issues/SKILL.md
index 0f9b4101..b630131c 100644
--- a/crates/orbit-core/assets/skills/orbit-track-issues/SKILL.md
+++ b/crates/orbit-core/assets/skills/orbit-track-issues/SKILL.md
@@ -58 +58 @@ orbit tool run orbit.friction.add --input '{
-  "model": "<model_name>" # gpt-5.4, claude-opus-4-6, gemini-2.5-pro, etc
+  "model": "<model_name>" # codex, claude, gemini, grok (full strings accepted)
@@ -69 +69 @@ orbit_friction_add({
-  "model": "<model_name>"
+  "model": "<model_name>"  # codex, claude, gemini, grok (full strings accepted)
```

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-00090-6a09255c`
- Behind base: 0
- Ahead of base: 1