### PR TITLE
[ORB-00099] Fix worktree graph attribution

### DIFF
--- a/crates/orbit-core/src/runtime/pipeline.rs
+++ b/crates/orbit-core/src/runtime/pipeline.rs
@@ -1,4 +1,5 @@
 use std::path::{Path, PathBuf};
+use std::process::Command;
 use std::sync::Arc;
 
 use orbit_common::types::{OrbitEvent, Role, activity_job::tool_allowed};
@@ -187,14 +188,19 @@ fn resolve_task_id_from_context(
 fn resolve_workspace_root_from_context(
     runtime: &OrbitRuntime,
     task_id: Option<&str>,
-    _tool_context: &ToolContext,
+    tool_context: &ToolContext,
 ) -> Result<Option<PathBuf>, OrbitError> {
+    let canonical_repo_root = canonical_repo_root(runtime);
+    if let Some(workspace_root) = active_git_checkout_root(&canonical_repo_root, tool_context) {
+        return Ok(Some(workspace_root));
+    }
+
     if let Some(task_id) = task_id
         && let Some(workspace_root) = resolve_task_workspace_root(runtime, task_id)
     {
         return Ok(Some(workspace_root));
     }
-    Ok(Some(canonical_repo_root(runtime)))
+    Ok(Some(canonical_repo_root))
 }
 
 fn canonical_repo_root(runtime: &OrbitRuntime) -> PathBuf {
@@ -210,6 +216,61 @@ fn resolve_task_workspace_root(runtime: &OrbitRuntime, task_id: &str) -> Option<
     let repo_root = canonical_repo_root(runtime);
     runtime.get_task(task_id).ok()?;
     Some(repo_root)
+}
+
+fn active_git_checkout_root(
+    canonical_repo_root: &Path,
+    tool_context: &ToolContext,
+) -> Option<PathBuf> {
+    let cwd = tool_context.cwd.as_deref()?;
+    let cwd = Path::new(cwd);
+    let checkout_root = git_checkout_root(cwd)?;
+    same_git_common_dir(&checkout_root, canonical_repo_root).then_some(checkout_root)
+}
+
+fn git_checkout_root(path: &Path) -> Option<PathBuf> {
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(path)
+        .args(["rev-parse", "--show-toplevel"])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let stdout = String::from_utf8(output.stdout).ok()?;
+    let raw_path = stdout.lines().next()?.trim();
+    if raw_path.is_empty() {
+        return None;
+    }
+    let path = PathBuf::from(raw_path);
+    Some(path.canonicalize().unwrap_or(path))
+}
+
+fn same_git_common_dir(left: &Path, right: &Path) -> bool {
+    match (git_common_dir(left), git_common_dir(right)) {
+        (Some(left), Some(right)) => left == right,
+        _ => false,
+    }
+}
+
+fn git_common_dir(path: &Path) -> Option<PathBuf> {
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(path)
+        .args(["rev-parse", "--path-format=absolute", "--git-common-dir"])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let stdout = String::from_utf8(output.stdout).ok()?;
+    let raw_path = stdout.lines().next()?.trim();
+    if raw_path.is_empty() {
+        return None;
+    }
+    let path = PathBuf::from(raw_path);
+    Some(path.canonicalize().unwrap_or(path))
 }
 
 fn task_workspace_matches(canonical_workspace: &Path, canonical_cwd: &Path) -> bool {
@@ -235,6 +296,7 @@ mod tests {
     use orbit_store::TaskCreateParams;
     use orbit_tools::ToolContext;
     use serde_json::json;
+    use tempfile::tempdir;
 
     use super::*;
 
@@ -289,5 +351,139 @@ mod tests {
             .expect("wildcard activity context should permit orbit.task.show");
 
         assert_eq!(output["id"], task.id);
+    }
+
+    #[test]
+    fn graph_tool_refresh_from_linked_worktree_attributes_to_worktree_branch() {
+        let fixture = GitWorktreeFixture::new();
+        let runtime = OrbitRuntime::from_roots(&fixture.global_root, &fixture.main_orbit)
+            .expect("build runtime");
+
+        runtime
+            .run_tool_with_context_and_role(
+                "orbit.graph.pack",
+                json!({
+                    "selectors": ["file:Cargo.toml"],
+                    "refresh": true,
+                }),
+                Role::Admin,
+                ToolContext {
+                    cwd: Some(fixture.worktree.to_string_lossy().into_owned()),
+                    ..Default::default()
+                },
+            )
+            .expect("pack from worktree");
+
+        assert!(
+            fixture
+                .main_orbit
+                .join("knowledge/graph/refs/heads/orbit/ORB-00099-test.json")
+                .is_file(),
+            "worktree branch ref should be written under shared knowledge dir"
+        );
+        assert_eq!(
+            manifest_head_oid(&fixture.main_orbit.join("knowledge/manifest.json")),
+            git_output(&fixture.worktree, &["rev-parse", "HEAD"])
+        );
+    }
+
+    struct GitWorktreeFixture {
+        _root: tempfile::TempDir,
+        global_root: PathBuf,
+        main_orbit: PathBuf,
+        worktree: PathBuf,
+    }
+
+    impl GitWorktreeFixture {
+        fn new() -> Self {
+            let root = tempdir().expect("create tempdir");
+            let global_root = root.path().join("global");
+            let main_repo = root.path().join("repo");
+            let worktree = main_repo.join(".orbit/state/worktrees/orb-00099-test");
+            std::fs::create_dir_all(main_repo.join("src")).expect("create src dir");
+            std::fs::create_dir_all(&global_root).expect("create global root");
+
+            run_git(
+                root.path(),
+                &["init", main_repo.to_str().expect("main repo path")],
+            );
+            run_git(&main_repo, &["config", "user.email", "test@example.com"]);
+            run_git(&main_repo, &["config", "user.name", "Test User"]);
+            std::fs::write(
+                main_repo.join("Cargo.toml"),
+                "[package]\nname = \"orb_00099_fixture\"\nversion = \"0.1.0\"\nedition = \"2021\"\n\n[lib]\npath = \"src/lib.rs\"\n",
+            )
+            .expect("write manifest");
+            std::fs::write(main_repo.join("src/lib.rs"), "pub fn main_branch() {}\n")
+                .expect("write lib");
+            run_git(&main_repo, &["add", "Cargo.toml", "src/lib.rs"]);
+            run_git(&main_repo, &["commit", "-m", "initial"]);
+            run_git(&main_repo, &["branch", "-M", "agent-main"]);
+
+            let main_orbit = main_repo.join(".orbit");
+            std::fs::create_dir_all(&main_orbit).expect("create main orbit dir");
+            run_git(
+                &main_repo,
+                &[
+                    "worktree",
+                    "add",
+                    "-b",
+                    "orbit/ORB-00099-test",
+                    worktree.to_str().expect("worktree path"),
+                ],
+            );
+            std::fs::write(worktree.join("src/lib.rs"), "pub fn worktree_branch() {}\n")
+                .expect("write worktree lib");
+            run_git(&worktree, &["add", "src/lib.rs"]);
+            run_git(&worktree, &["commit", "-m", "worktree change"]);
+
+            Self {
+                _root: root,
+                global_root,
+                main_orbit,
+                worktree,
+            }
+        }
+    }
+
+    fn run_git(cwd: &Path, args: &[&str]) {
+        let output = Command::new("git")
+            .args(args)
+            .current_dir(cwd)
+            .output()
+            .expect("run git");
+        assert!(
+            output.status.success(),
+            "git {:?} failed: {}",
+            args,
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    fn git_output(cwd: &Path, args: &[&str]) -> String {
+        let output = Command::new("git")
+            .args(args)
+            .current_dir(cwd)
+            .output()
+            .expect("run git");
+        assert!(
+            output.status.success(),
+            "git {:?} failed: {}",
+            args,
+            String::from_utf8_lossy(&output.stderr)
+        );
+        String::from_utf8(output.stdout)
+            .expect("git stdout is utf8")
+            .trim()
+            .to_string()
+    }
+
+    fn manifest_head_oid(path: &Path) -> String {
+        let raw = std::fs::read_to_string(path).expect("read manifest");
+        let manifest: serde_json::Value = serde_json::from_str(&raw).expect("parse manifest");
+        manifest["git_head_oid"]
+            .as_str()
+            .expect("manifest git_head_oid")
+            .to_string()
     }
 }

--- a/crates/orbit-knowledge/src/pipeline/mod.rs
+++ b/crates/orbit-knowledge/src/pipeline/mod.rs
@@ -58,6 +58,7 @@ pub(crate) struct GitCheckoutIdentity {
     pub tree_oid: String,
 }
 
+#[derive(Debug)]
 enum RefreshPlan {
     Fresh,
     SkipDirtyDebounce,
@@ -127,7 +128,10 @@ pub fn ensure_fresh(
     knowledge_dir: &Path,
     repo_path: &Path,
 ) -> Result<RefreshStatus, KnowledgeError> {
-    match compute_refresh_plan(knowledge_dir, repo_path)? {
+    let plan = compute_refresh_plan(knowledge_dir, repo_path)?;
+    log_refresh_plan(repo_path, &plan);
+
+    match plan {
         RefreshPlan::Fresh => return Ok(RefreshStatus::Fresh),
         RefreshPlan::SkipDirtyDebounce => return Ok(RefreshStatus::SkippedDirtyDebounce),
         RefreshPlan::Rebuild { .. } => {}
@@ -163,6 +167,27 @@ pub fn ensure_fresh(
         .map_err(|e| KnowledgeError::knowledge_unavailable(format!("auto-refresh failed: {e}")))?;
 
     Ok(RefreshStatus::Rebuilt)
+}
+
+fn log_refresh_plan(repo_path: &Path, plan: &RefreshPlan) {
+    let ref_name = resolve_graph_write_target(repo_path, None)
+        .map(|target| target.requested.to_string())
+        .unwrap_or_else(|_| "<unresolved>".to_string());
+    tracing::info!(
+        target: "orbit.knowledge.refresh",
+        repo_path = %repo_path.display(),
+        ref_name,
+        refresh_plan = refresh_plan_variant(plan),
+        "resolved knowledge graph refresh plan",
+    );
+}
+
+fn refresh_plan_variant(plan: &RefreshPlan) -> &'static str {
+    match plan {
+        RefreshPlan::Fresh => "Fresh",
+        RefreshPlan::SkipDirtyDebounce => "SkipDirtyDebounce",
+        RefreshPlan::Rebuild { .. } => "Rebuild",
+    }
 }
 
 fn git_checkout_identity(repo_path: &Path) -> Option<GitCheckoutIdentity> {
@@ -436,4 +461,133 @@ fn dirty_refresh_cooldown() -> Duration {
         .and_then(|value| value.trim().parse::<u64>().ok())
         .unwrap_or(DEFAULT_DIRTY_REFRESH_DEBOUNCE_SECS);
     Duration::from_secs(seconds)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fmt;
+    use std::path::{Path, PathBuf};
+    use std::process::Command;
+    use std::sync::{Arc, Mutex};
+
+    use tempfile::tempdir;
+    use tracing::field::{Field, Visit};
+    use tracing::span::{Attributes, Id, Record};
+    use tracing::{Event, Level, Metadata, Subscriber};
+
+    use super::*;
+
+    #[test]
+    fn ensure_fresh_logs_repo_ref_and_refresh_plan() {
+        let fixture = GitRepoFixture::new();
+        let captured = Arc::new(Mutex::new(Vec::new()));
+        let subscriber = CaptureSubscriber {
+            captured: Arc::clone(&captured),
+        };
+
+        tracing::subscriber::with_default(subscriber, || {
+            ensure_fresh(&fixture.knowledge_dir, &fixture.repo).expect("ensure fresh");
+        });
+
+        let logs = captured.lock().expect("lock captured logs").join("\n");
+        assert!(logs.contains("orbit.knowledge.refresh"));
+        assert!(logs.contains(&format!("repo_path={}", fixture.repo.display())));
+        assert!(logs.contains("ref_name"));
+        assert!(logs.contains("agent-main"));
+        assert!(logs.contains("refresh_plan"));
+        assert!(logs.contains("Rebuild"));
+    }
+
+    struct CaptureSubscriber {
+        captured: Arc<Mutex<Vec<String>>>,
+    }
+
+    impl Subscriber for CaptureSubscriber {
+        fn enabled(&self, metadata: &Metadata<'_>) -> bool {
+            metadata.target() == "orbit.knowledge.refresh" && *metadata.level() <= Level::INFO
+        }
+
+        fn new_span(&self, _span: &Attributes<'_>) -> Id {
+            Id::from_u64(1)
+        }
+
+        fn record(&self, _span: &Id, _values: &Record<'_>) {}
+
+        fn record_follows_from(&self, _span: &Id, _follows: &Id) {}
+
+        fn event(&self, event: &Event<'_>) {
+            if !self.enabled(event.metadata()) {
+                return;
+            }
+            let mut visitor = FieldCapture::default();
+            event.record(&mut visitor);
+            let fields = visitor.fields.join(" ");
+            self.captured
+                .lock()
+                .expect("lock captured events")
+                .push(format!("{} {fields}", event.metadata().target()));
+        }
+
+        fn enter(&self, _span: &Id) {}
+
+        fn exit(&self, _span: &Id) {}
+    }
+
+    #[derive(Default)]
+    struct FieldCapture {
+        fields: Vec<String>,
+    }
+
+    impl Visit for FieldCapture {
+        fn record_debug(&mut self, field: &Field, value: &dyn fmt::Debug) {
+            self.fields.push(format!("{}={value:?}", field.name()));
+        }
+    }
+
+    struct GitRepoFixture {
+        _root: tempfile::TempDir,
+        repo: PathBuf,
+        knowledge_dir: PathBuf,
+    }
+
+    impl GitRepoFixture {
+        fn new() -> Self {
+            let root = tempdir().expect("create tempdir");
+            let repo = root.path().join("repo");
+            let knowledge_dir = root.path().join("knowledge");
+            std::fs::create_dir_all(repo.join("src")).expect("create src dir");
+            run_git(root.path(), &["init", repo.to_str().expect("repo path")]);
+            run_git(&repo, &["config", "user.email", "test@example.com"]);
+            run_git(&repo, &["config", "user.name", "Test User"]);
+            std::fs::write(
+                repo.join("Cargo.toml"),
+                "[package]\nname = \"refresh_log_fixture\"\nversion = \"0.1.0\"\nedition = \"2021\"\n\n[lib]\npath = \"src/lib.rs\"\n",
+            )
+            .expect("write manifest");
+            std::fs::write(repo.join("src/lib.rs"), "pub fn fixture() {}\n").expect("write lib");
+            run_git(&repo, &["add", "Cargo.toml", "src/lib.rs"]);
+            run_git(&repo, &["commit", "-m", "initial"]);
+            run_git(&repo, &["branch", "-M", "agent-main"]);
+
+            Self {
+                _root: root,
+                repo,
+                knowledge_dir,
+            }
+        }
+    }
+
+    fn run_git(cwd: &Path, args: &[&str]) {
+        let output = Command::new("git")
+            .args(args)
+            .current_dir(cwd)
+            .output()
+            .expect("run git");
+        assert!(
+            output.status.success(),
+            "git {:?} failed: {}",
+            args,
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
 }

--- a/docs/design/knowledge-graph/4_decisions.md
+++ b/docs/design/knowledge-graph/4_decisions.md
@@ -2,7 +2,7 @@
 
 **Status:** Draft
 **Owner:** claude
-**Last updated:** 2026-05-10 (post-[T20260509-64], [T20260510-7])
+**Last updated:** 2026-05-17 ([ORB-00099])
 
 ADR-style log of non-obvious knowledge-graph decisions. Each entry names the pressure, the choice, and the tradeoff. Entries are append-only and keyed by number; superseded entries are marked, not deleted.
 
@@ -594,6 +594,23 @@ These entries were formerly ADR headings, but they are plain instances of ADR-00
 
 ---
 
+## ADR-039 — Attribute refreshes to the active git checkout, not the shared Orbit root
+
+**Status:** Accepted · 2026-05 · [ORB-00099]
+**Author:** codex
+
+**Context.** Linked worktrees intentionally resolve Orbit data through the main checkout's `.orbit/` directory so tasks, audit state, and knowledge objects stay shared. The read-side graph refresh path reused that same resolved root as `workspace_root`, so a graph tool invoked from `.orbit/state/worktrees/...` ran `git current-branch` against the main checkout and wrote `refs/heads/agent-main.json` even when the agent was on an `orbit/ORB-*` worktree branch.
+
+**Decision.** Keep `orbit_root`/`knowledge_dir` shared through main-worktree resolution, but derive graph read/write attribution from the active git checkout root associated with the tool call CWD. Runtime dispatch resolves `workspace_root` with `git rev-parse --show-toplevel` and accepts it only when its `--git-common-dir` matches the configured workspace repository. Knowledge refresh then treats that checkout root as the repo path for branch ref resolution, dirty fingerprinting, scanning, and manifest git identity.
+
+**Consequences.**
+- Worktree agents materialize branch refs such as `refs/heads/orbit/ORB-*.json` under the shared `.orbit/knowledge/graph/` object store.
+- The main checkout still owns the Orbit data root, so task state and graph objects remain shared across worktrees.
+- A CWD in an unrelated git repository cannot redirect Orbit's workspace boundary because the git common directory must match the configured repo.
+- Cost: runtime dispatch now shells out to `git` when filling a missing `ToolContext.workspace_root`; non-git or mismatched CWDs fall back to the configured repo root.
+
+---
+
 ## Task References
 
 Tasks cited by ADRs above:
@@ -653,5 +670,6 @@ Tasks cited by ADRs above:
 - **[T20260510-2]** — Restore SQL/fallback equivalence for `orbit.graph.show` `children` (forward leaf pointers).
 - **[T20260510-5]** — Extract `orbit_knowledge::commands::*` as the canonical graph command surface and thin graph tools to dispatch/envelope shaping.
 - **[T20260510-7]** — Make leaf IDs unique across extractors so SQL fast paths preserve every symbol.
+- **[ORB-00099]** — Decouple graph refresh branch attribution from shared `.orbit` root resolution for linked worktrees.
 
 Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.


### PR DESCRIPTION
## Task
ORB-00099

## Summary
- Derive graph tool `workspace_root` from the active git checkout behind `ToolContext.cwd` when the runtime has only the shared `.orbit` root.
- Keep `.orbit/knowledge` shared through the main checkout while attributing refresh branch refs to the linked worktree branch.
- Add `orbit.knowledge.refresh` info tracing with `repo_path`, `ref_name`, and `RefreshPlan` variant.
- Document the Fix A invariant in `docs/design/knowledge-graph/4_decisions.md` as ADR-039.

## Root Cause
Linked worktrees intentionally resolve Orbit data through the main checkout's `.orbit`, but the graph refresh path reused that shared root as the git workspace. That made `ensure_fresh` ask git for the main checkout branch and write `agent-main.json` instead of the active worktree branch ref.

## Validation
- `make ci-fast`
- `cargo test -p orbit-core graph_tool_refresh_from_linked_worktree_attributes_to_worktree_branch`
- `cargo test -p orbit-knowledge ensure_fresh_logs_repo_ref_and_refresh_plan`
- Earlier full `cargo test -p orbit-knowledge` passed before rebase.
- Manual e2e with patched CLI wrote `refs/heads/codex/ORB-00099-worktree-graph-attribution.json` and manifest HEAD matched the worktree HEAD.

## Note
Full `cargo test -p orbit-core` still has four unrelated local/environment failures recorded in the task execution summary: three missing review-scoreboard file panics and one `grok_cli` probe expectation mismatch.
