### PR TITLE
Tighten task-row layout: ID column leaves dead space before title

### DIFF
--- a/crates/orbit-cli/assets/dashboard/index.html
+++ b/crates/orbit-cli/assets/dashboard/index.html
@@ -317,7 +317,7 @@
       
       .row {
         display: grid;
-        grid-template-columns: 130px minmax(140px, 1fr) 72px 82px minmax(138px, 180px);
+        grid-template-columns: minmax(80px, max-content) minmax(140px, 1fr) 72px 82px minmax(138px, 180px);
         gap: 12px;
         padding: 8px 16px;
         margin: 0;
@@ -327,17 +327,17 @@
         transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1);
         border-bottom: 1px solid var(--border);
       }
-      
+
       .row:hover { 
         background: rgba(255, 255, 255, 0.03); 
         border-color: rgba(255, 255, 255, 0.05);
       }
-      
+
       .row.expanded {
         background: rgba(110, 159, 255, 0.05);
         border-color: var(--border);
       }
-      
+
       .row .id {
         color: var(--fg-dim);
         font-size: 12px;
@@ -400,7 +400,7 @@
 
       @media (max-width: 760px) {
         .row {
-          grid-template-columns: minmax(84px, 0.7fr) minmax(0, 1fr) minmax(128px, 0.8fr);
+          grid-template-columns: minmax(min-content, max-content) minmax(0, 1fr) minmax(128px, 0.8fr);
           grid-template-areas:
             "id title crew"
             "priority type crew";
@@ -415,7 +415,7 @@
 
       @media (max-width: 520px) {
         .row {
-          grid-template-columns: minmax(74px, 0.65fr) minmax(0, 1fr);
+          grid-template-columns: minmax(min-content, max-content) minmax(0, 1fr);
           grid-template-areas:
             "id title"
             "priority crew"


### PR DESCRIPTION
## Task

[ORB-00097](https://orbit-cli.com/tasks/ORB-00097) — Tighten task-row layout: ID column leaves dead space before title

### Description

## Problem

In the dashboard task list, each task row reserves a fixed 130px for the task-ID column. `ORB-NNNNN` at 12px monospace renders roughly 70–80px wide, so every row shows ~50–60px of empty space (plus the 12px column gap) between the ID and the title. The effect is visible in the in-progress group screenshot the user flagged: `ORB-00095` is followed by a large empty gap before `Rank learnings by decay-weighted …`.

The relevant CSS rule is at `crates/orbit-cli/assets/dashboard/index.html` ~line 320:

```css
.row {
  display: grid;
  grid-template-columns: 130px minmax(140px, 1fr) 72px 82px minmax(138px, 180px);
  gap: 12px;
  …
}
```

## Why It Matters

The extra whitespace breaks the visual association between an ID and its title, increases eye-travel when skimming a long list, and wastes horizontal real estate that the title column could use (titles already truncate with ellipsis at narrow widths).

## Constraints / Notes

- Keep ellipsis truncation working for IDs and titles at all viewport widths (the existing `overflow: hidden; text-overflow: ellipsis; white-space: nowrap; min-width: 0` on `.row .id` and `.row .title` must continue to apply).
- Do not regress the `@media (max-width: 760px)` mobile layout (`grid-template-areas` at index.html ~line 401), nor the further `@media (max-width: 500px)` rule at ~line 417.
- The same fixed-first-column pattern exists on `.learning-row`, `.adr-row`, `.friction-row` (~lines 1649–1655). Out of scope for this task but worth noting for a follow-up if the same fix should apply there.
- Group header (`IN-PROGRESS` pill + count) is rendered by `statusPill()` in `app.js` and is not the source of the gap — the gap is inside the task row beneath the header.

### Acceptance Criteria

- On desktop widths (> 760px) the gap between a task ID like `ORB-00095` and its title is visually tight: the ID column sizes to its content (e.g. `max-content`, `auto`, or a fixed value ≤ 90px) and the title abuts the column gap rather than starting ~50px later. Verified by loading the dashboard and inspecting the in-progress group in DevTools.
- Long IDs and long titles still truncate with `…` rather than overflowing the row or pushing later columns (`priority`, `type`, `crew`) off-grid. Verified by temporarily injecting a 20-char ID and a 200-char title via DevTools.
- The `@media (max-width: 760px)` and `@media (max-width: 500px)` layouts at `crates/orbit-cli/assets/dashboard/index.html:401` and `:417` still place ID and title in the expected grid-areas with no visual regression. Verified by resizing the viewport across both breakpoints.
- The change is CSS-only inside `crates/orbit-cli/assets/dashboard/index.html`; `app.js` rendering of `renderTasks` / `.row` / `.id` / `.title` is not modified.
- `make ci-fast` passes.

## Execution Summary

<details>
<summary>Click to expand</summary>

Tightened task-row layout in the dashboard by replacing the fixed 130px ID column with `minmax(80px, max-content)`.

Changes:
- Modified `crates/orbit-cli/assets/dashboard/index.html`:
    - Updated `.row` `grid-template-columns` to use `minmax(80px, max-content)` for the ID column.
    - Updated `@media (max-width: 760px)` and `@media (max-width: 520px)` to use `minmax(min-content, max-content)` for the ID column, ensuring consistent tightening across breakpoints while preserving grid area layouts.
    - Verified that `overflow: hidden; text-overflow: ellipsis; white-space: nowrap; min-width: 0` remains on `.row .id` and `.row .title` to handle long strings correctly.
- `make ci-fast` passed.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-00097-6a095e58`
- Behind base: 0
- Ahead of base: 1