### PR TITLE
orbit.task.update: persist source_task_id on existing tasks (currently silently dropped)

### DIFF
--- a/crates/orbit-core/src/command/task/params.rs
+++ b/crates/orbit-core/src/command/task/params.rs
@@ -69,6 +69,7 @@ pub struct TaskUpdateParams {
     pub comment: Option<String>,
     pub status: Option<TaskStatus>,
     pub task_type: Option<TaskType>,
+    pub source_task_id: Option<Option<String>>,
     pub planned_by: Option<Option<String>>,
     pub implemented_by: Option<Option<String>>,
     pub pr_status: Option<Option<String>>,
@@ -95,6 +96,7 @@ impl TaskUpdateParams {
             || self.execution_summary.is_some()
             || self.status.is_some()
             || self.task_type.is_some()
+            || self.source_task_id.is_some()
             || self.planned_by.is_some()
             || self.implemented_by.is_some()
             || self.pr_status.is_some()
@@ -123,6 +125,7 @@ impl From<TaskUpdateParams> for TaskRecordUpdateParams {
             execution_summary: p.execution_summary,
             status: p.status,
             task_type: p.task_type,
+            source_task_id: p.source_task_id,
             planned_by: p.planned_by,
             implemented_by: p.implemented_by,
             pr_status: p.pr_status,

--- a/crates/orbit-core/src/command/task/update.rs
+++ b/crates/orbit-core/src/command/task/update.rs
@@ -180,6 +180,10 @@ impl OrbitRuntime {
                 }
             })
         });
+        let source_task_id_changed = params
+            .source_task_id
+            .as_ref()
+            .is_some_and(|source_task_id| task.source_task_id() != source_task_id.as_deref());
 
         let mut append_history: Vec<TaskHistoryEntry> = if dropped_context_files.is_empty() {
             Vec::new()
@@ -190,6 +194,16 @@ impl OrbitRuntime {
             )]
         };
         append_history.extend(task_comment_history_entries(&append_comments));
+        if source_task_id_changed {
+            append_history.push(TaskHistoryEntry {
+                at: chrono::Utc::now(),
+                by: effective_label.clone(),
+                event: "updated".to_string(),
+                note: Some("source_task_id changed".to_string()),
+                from_status: None,
+                to_status: None,
+            });
+        }
         let updated = self.with_mutation(|| {
             let task = self.stores().tasks().update(
                 id,

--- a/crates/orbit-core/src/runtime/orbit_tool_host/task_tools.rs
+++ b/crates/orbit-core/src/runtime/orbit_tool_host/task_tools.rs
@@ -257,6 +257,11 @@ pub(super) fn update(
             task_type: optional_string_alias(&input, &["type", "task_type", "taskType"])?
                 .map(|value| parse_task_type("type", &value))
                 .transpose()?,
+            source_task_id: optional_raw_string_alias(
+                &input,
+                &["source_task_id", "source_task", "sourceTaskId"],
+            )?
+            .map(empty_string_to_none),
             planned_by: optional_raw_string(&input, "planned_by")?.map(empty_string_to_none),
             implemented_by: optional_raw_string(&input, "implemented_by")?
                 .map(empty_string_to_none),
@@ -290,4 +295,19 @@ fn parse_task_id_list(task_ids: Vec<String>) -> Result<Vec<String>, OrbitError> 
         ));
     }
     Ok(deduped.into_iter().collect())
+}
+
+fn optional_raw_string_alias(input: &Value, keys: &[&str]) -> Result<Option<String>, OrbitError> {
+    for key in keys {
+        if let Some(value) = input.get(*key) {
+            return match value {
+                Value::Null => Ok(None),
+                Value::String(raw) => Ok(Some(raw.to_string())),
+                _ => Err(OrbitError::InvalidInput(format!(
+                    "`{key}` must be a string"
+                ))),
+            };
+        }
+    }
+    Ok(None)
 }

--- a/crates/orbit-core/src/runtime/orbit_tool_host/task_tools_tests.rs
+++ b/crates/orbit-core/src/runtime/orbit_tool_host/task_tools_tests.rs
@@ -700,6 +700,197 @@ fn task_update_tool_replaces_dependencies() {
 }
 
 #[test]
+fn task_update_tool_persists_source_task_id_and_history() {
+    let (_root, runtime, repo_root) = test_runtime();
+    let source = create_task(
+        &runtime,
+        &repo_root,
+        "Regression source",
+        "Existing task that introduced the defect.",
+        TaskStatus::Done,
+        &[],
+    );
+    let added = runtime
+        .execute_tool_command(
+            "orbit.task.add",
+            json!({
+                "title": "Bug without source",
+                "description": "A bug whose source is discovered later.",
+                "workspace": ".",
+                "type": "bug",
+            }),
+            Some("codex".to_string()),
+            Some("gpt-5.5".to_string()),
+        )
+        .expect("task add tool succeeds");
+    let task_id = added["id"].as_str().expect("task id").to_string();
+    let created_updated_at = added["updated_at"]
+        .as_str()
+        .expect("created updated_at")
+        .to_string();
+    assert_eq!(added.get("type").and_then(Value::as_str), Some("bug"));
+    assert_eq!(added.get("source_task_id"), Some(&Value::Null));
+
+    let output = runtime
+        .execute_tool_command(
+            "orbit.task.update",
+            json!({
+                "id": task_id,
+                "model": "claude",
+                "source_task_id": source.id.clone(),
+            }),
+            None,
+            None,
+        )
+        .expect("task update tool succeeds");
+
+    assert_eq!(
+        output.get("source_task_id").and_then(Value::as_str),
+        Some(source.id.as_str())
+    );
+    assert_ne!(
+        output.get("updated_at").and_then(Value::as_str),
+        Some(created_updated_at.as_str())
+    );
+    assert!(
+        output["history"]
+            .as_array()
+            .expect("history")
+            .iter()
+            .any(|event| {
+                event.get("event").and_then(Value::as_str) == Some("updated")
+                    && event
+                        .get("note")
+                        .and_then(Value::as_str)
+                        .is_some_and(|note| note.contains("source_task_id"))
+            })
+    );
+
+    let shown = runtime
+        .execute_tool_command(
+            "orbit.task.show",
+            json!({ "id": output["id"].as_str().expect("task id") }),
+            Some("codex".to_string()),
+            Some("gpt-5.5".to_string()),
+        )
+        .expect("task show tool succeeds");
+    assert_eq!(
+        shown.get("source_task_id").and_then(Value::as_str),
+        Some(source.id.as_str())
+    );
+}
+
+#[test]
+fn task_update_tool_clears_source_task_id_with_empty_string() {
+    let (_root, runtime, repo_root) = test_runtime();
+    let source = create_task(
+        &runtime,
+        &repo_root,
+        "Regression source",
+        "Existing task that introduced the defect.",
+        TaskStatus::Done,
+        &[],
+    );
+    let added = runtime
+        .execute_tool_command(
+            "orbit.task.add",
+            json!({
+                "title": "Bug with source",
+                "description": "A bug whose source should be cleared.",
+                "workspace": ".",
+                "type": "bug",
+                "source_task_id": source.id,
+            }),
+            Some("codex".to_string()),
+            Some("gpt-5.5".to_string()),
+        )
+        .expect("task add tool succeeds");
+
+    let output = runtime
+        .execute_tool_command(
+            "orbit.task.update",
+            json!({
+                "id": added["id"].as_str().expect("task id"),
+                "source_task_id": "",
+            }),
+            Some("codex".to_string()),
+            Some("gpt-5.5".to_string()),
+        )
+        .expect("task update tool succeeds");
+
+    assert_eq!(output.get("source_task_id"), Some(&Value::Null));
+    assert!(
+        output["history"]
+            .as_array()
+            .expect("history")
+            .iter()
+            .any(|event| {
+                event.get("event").and_then(Value::as_str) == Some("updated")
+                    && event
+                        .get("note")
+                        .and_then(Value::as_str)
+                        .is_some_and(|note| note.contains("source_task_id"))
+            })
+    );
+}
+
+#[test]
+fn task_update_tool_stores_unresolved_source_task_id_matching_add() {
+    let (_root, runtime, _repo_root) = test_runtime();
+    let unresolved_from_update = "ORB-99999";
+    let unresolved_from_add = "ORB-99998";
+
+    let added = runtime
+        .execute_tool_command(
+            "orbit.task.add",
+            json!({
+                "title": "Bug without resolved source",
+                "description": "A bug whose source ID is known before its task exists.",
+                "workspace": ".",
+                "type": "bug",
+                "source_task_id": unresolved_from_add,
+            }),
+            Some("codex".to_string()),
+            Some("gpt-5.5".to_string()),
+        )
+        .expect("add stores a loose source reference");
+    assert_eq!(
+        added.get("source_task_id").and_then(Value::as_str),
+        Some(unresolved_from_add)
+    );
+
+    let update_target = runtime
+        .execute_tool_command(
+            "orbit.task.add",
+            json!({
+                "title": "Bug with later loose source",
+                "description": "Exercise update-side loose reference parity.",
+                "workspace": ".",
+                "type": "bug",
+            }),
+            Some("codex".to_string()),
+            Some("gpt-5.5".to_string()),
+        )
+        .expect("task add tool succeeds");
+    let output = runtime
+        .execute_tool_command(
+            "orbit.task.update",
+            json!({
+                "id": update_target["id"].as_str().expect("task id"),
+                "source_task_id": unresolved_from_update,
+            }),
+            Some("codex".to_string()),
+            Some("gpt-5.5".to_string()),
+        )
+        .expect("update stores a loose source reference just like add");
+
+    assert_eq!(
+        output.get("source_task_id").and_then(Value::as_str),
+        Some(unresolved_from_update)
+    );
+}
+
+#[test]
 fn task_update_tool_replaces_tags() {
     let (_root, runtime, _repo_root) = test_runtime();
 

--- a/crates/orbit-store/src/file/task_store/v2_store.rs
+++ b/crates/orbit-store/src/file/task_store/v2_store.rs
@@ -1791,6 +1791,72 @@ mod tests {
     }
 
     #[test]
+    fn document_update_sets_and_clears_source_task_id() {
+        let temp = TempDir::new().expect("tempdir");
+        let store = store(&temp);
+        let source = store
+            .create_task(create_params("Source", TaskStatus::Done))
+            .expect("create source");
+        store
+            .create_task(create_params("Bug", TaskStatus::Backlog))
+            .expect("create bug");
+
+        store
+            .update_task_document(
+                "ORB-00001",
+                &TaskDocumentUpdateParams {
+                    actor: "codex:gpt-5.5".to_string(),
+                    source_task_id: Some(Some(source.id.clone())),
+                    ..Default::default()
+                },
+            )
+            .expect("set source task");
+
+        let task = store
+            .get_task("ORB-00001")
+            .expect("get task")
+            .expect("task exists");
+        assert_eq!(task.source_task_id(), Some(source.id.as_str()));
+        let envelope = store
+            .bundle_store
+            .read_bundle("ORB-00001")
+            .expect("read bundle")
+            .envelope;
+        assert!(envelope.relations.iter().any(|relation| {
+            relation.relation_type == TaskRelationType::RegressionFrom
+                && relation.target == source.id
+        }));
+
+        store
+            .update_task_document(
+                "ORB-00001",
+                &TaskDocumentUpdateParams {
+                    actor: "codex:gpt-5.5".to_string(),
+                    source_task_id: Some(None),
+                    ..Default::default()
+                },
+            )
+            .expect("clear source task");
+
+        let task = store
+            .get_task("ORB-00001")
+            .expect("get task")
+            .expect("task exists");
+        assert_eq!(task.source_task_id(), None);
+        let envelope = store
+            .bundle_store
+            .read_bundle("ORB-00001")
+            .expect("read bundle")
+            .envelope;
+        assert!(
+            envelope
+                .relations
+                .iter()
+                .all(|relation| relation.relation_type != TaskRelationType::RegressionFrom)
+        );
+    }
+
+    #[test]
     fn history_update_appends_comments_and_status_events() {
         let temp = TempDir::new().expect("tempdir");
         let store = store(&temp);

--- a/crates/orbit-tools/src/builtin/orbit/task/update.rs
+++ b/crates/orbit-tools/src/builtin/orbit/task/update.rs
@@ -67,6 +67,13 @@ impl Tool for OrbitTaskUpdateTool {
                 required: false,
             },
             ToolParam {
+                name: "source_task_id".to_string(),
+                description: "For bug tasks: originating task ID that introduced the defect (empty string clears)"
+                    .to_string(),
+                param_type: "string".to_string(),
+                required: false,
+            },
+            ToolParam {
                 name: "planned_by".to_string(),
                 description: "Explicit planning attribution label (empty string clears)"
                     .to_string(),
@@ -143,5 +150,173 @@ impl Tool for OrbitTaskUpdateTool {
     fn execute(&self, ctx: &ToolContext, input: Value) -> Result<Value, OrbitError> {
         super::super::reject_agent_field(&input, "orbit.task.update")?;
         super::super::execute_host_action(ctx, input, OrbitBuiltinAction::TaskUpdate)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{Arc, Mutex};
+
+    use serde_json::{Value, json};
+
+    use crate::{OrbitTaskScope, OrbitToolHost};
+
+    use super::*;
+
+    #[derive(Debug, Clone)]
+    struct FakeTask {
+        id: String,
+        source_task_id: Option<String>,
+        updated_at: String,
+        history: Vec<Value>,
+    }
+
+    struct FakeTaskHost {
+        task: Mutex<FakeTask>,
+    }
+
+    impl FakeTaskHost {
+        fn seeded(source_task_id: Option<&str>) -> Self {
+            Self {
+                task: Mutex::new(FakeTask {
+                    id: "ORB-00001".to_string(),
+                    source_task_id: source_task_id.map(ToOwned::to_owned),
+                    updated_at: "2026-05-17T00:00:00Z".to_string(),
+                    history: Vec::new(),
+                }),
+            }
+        }
+    }
+
+    impl OrbitToolHost for FakeTaskHost {
+        fn execute(
+            &self,
+            action: OrbitBuiltinAction,
+            input: Value,
+            _agent: Option<String>,
+            _model: Option<String>,
+            _reservation_owner: Option<crate::ReservationOwnerContext>,
+        ) -> Result<Value, OrbitError> {
+            assert_eq!(action, OrbitBuiltinAction::TaskUpdate);
+            let id = input.get("id").and_then(Value::as_str).expect("id");
+            let mut task = self.task.lock().expect("task lock");
+            assert_eq!(id, task.id);
+
+            if let Some(value) = input.get("source_task_id") {
+                let raw = value.as_str().ok_or_else(|| {
+                    OrbitError::InvalidInput("`source_task_id` must be a string".to_string())
+                })?;
+                let next_source_task_id = (!raw.is_empty()).then(|| raw.to_string());
+                if task.source_task_id != next_source_task_id {
+                    task.updated_at = "2026-05-17T00:00:01Z".to_string();
+                    task.history.push(json!({
+                        "event": "updated",
+                        "note": "source_task_id changed",
+                    }));
+                }
+                task.source_task_id = next_source_task_id;
+            }
+
+            Ok(json!({
+                "id": task.id.clone(),
+                "type": "bug",
+                "source_task_id": task.source_task_id.clone(),
+                "updated_at": task.updated_at.clone(),
+                "history": task.history.clone(),
+            }))
+        }
+
+        fn task_scope(&self) -> OrbitTaskScope {
+            OrbitTaskScope::default()
+        }
+    }
+
+    fn update_tool_context(host: Arc<FakeTaskHost>) -> ToolContext {
+        ToolContext {
+            orbit_host: Some(host),
+            ..ToolContext::default()
+        }
+    }
+
+    #[test]
+    fn schema_exposes_source_task_id() {
+        let schema = OrbitTaskUpdateTool.schema();
+
+        let param = schema
+            .parameters
+            .iter()
+            .find(|param| param.name == "source_task_id")
+            .expect("source_task_id param");
+
+        assert_eq!(param.param_type, "string");
+        assert!(!param.required);
+        assert!(param.description.contains("originating task ID"));
+    }
+
+    #[test]
+    fn update_handler_persists_source_task_id() {
+        let host = Arc::new(FakeTaskHost::seeded(None));
+        let output = OrbitTaskUpdateTool
+            .execute(
+                &update_tool_context(Arc::clone(&host)),
+                json!({
+                    "id": "ORB-00001",
+                    "model": "codex",
+                    "source_task_id": "ORB-00000",
+                }),
+            )
+            .expect("update succeeds");
+
+        assert_eq!(output.get("type").and_then(Value::as_str), Some("bug"));
+        assert_eq!(
+            output.get("source_task_id").and_then(Value::as_str),
+            Some("ORB-00000")
+        );
+        assert_eq!(
+            host.task
+                .lock()
+                .expect("task lock")
+                .source_task_id
+                .as_deref(),
+            Some("ORB-00000")
+        );
+    }
+
+    #[test]
+    fn update_handler_clears_source_task_id_with_empty_string() {
+        let host = Arc::new(FakeTaskHost::seeded(Some("ORB-00000")));
+        let output = OrbitTaskUpdateTool
+            .execute(
+                &update_tool_context(Arc::clone(&host)),
+                json!({
+                    "id": "ORB-00001",
+                    "model": "codex",
+                    "source_task_id": "",
+                }),
+            )
+            .expect("update succeeds");
+
+        assert_eq!(output.get("source_task_id"), Some(&Value::Null));
+        assert_eq!(host.task.lock().expect("task lock").source_task_id, None);
+    }
+
+    #[test]
+    fn update_handler_stores_unresolved_source_task_id_like_add() {
+        let host = Arc::new(FakeTaskHost::seeded(None));
+        let output = OrbitTaskUpdateTool
+            .execute(
+                &update_tool_context(Arc::clone(&host)),
+                json!({
+                    "id": "ORB-00001",
+                    "model": "codex",
+                    "source_task_id": "ORB-99999",
+                }),
+            )
+            .expect("loose source reference is stored");
+
+        assert_eq!(
+            output.get("source_task_id").and_then(Value::as_str),
+            Some("ORB-99999")
+        );
     }
 }


### PR DESCRIPTION
## Task

[ORB-00101](https://orbit-cli.com/tasks/ORB-00101) — orbit.task.update: persist source_task_id on existing tasks (currently silently dropped)

### Description

## Problem

The `orbit.task.update` tool surface (MCP: `orbit_task_update`, CLI: `orbit tool run orbit.task.update`) silently drops the `source_task_id` field when callers pass it on an existing task. The MCP schema accepts the parameter via the tool's `additionalProperties: true` envelope and documents it as "originating task ID that introduced the defect (for bug tasks)", so callers reasonably expect it to persist — but the update handler never reads it.

## Why It Matters

Forensic workflows where a bug is filed first and the regression source is identified later (the most common pattern for bisecting regressions) can't retroactively populate `source_task_id` via the tool surface. Cross-references fall back to free-text comments, which the executing agent can read but which dashboards, semantic search, and any downstream tooling that consumes the structured field cannot index.

Concrete repro that motivated this filing:
- Created ORB-00099 (bug, no `source_task_id` at creation).
- Later identified the regression-introducing commit and its closest associated task (ORB-00015 via task-artifact-v2 cutover).
- Called `orbit_task_update({id: "ORB-00099", model: "claude", source_task_id: "ORB-00015"})` twice. Both calls returned `"source_task_id": null`; the second (isolated) call did not even bump `updated_at`.
- Confirmed reported as **F2026-05-024** (`/Users/daniel/workspace/repos/orbit/.orbit/frictions/2026-05/F024.md`, tag `tooling`, during_task ORB-00099).

## Root Cause (verified, not hypothesized)

`crates/orbit-tools/src/builtin/orbit/task/update.rs` parses no `source_task_id` field. The string `source_task_id` appears once in the `orbit-tools` task surface — in `add.rs:120` (the create path's schema) — and **zero times in `update.rs`**. The update handler enumerates the fields it merges into `TaskUpdateParams` (title, description, status, plan, comment, tags, dependencies, context_files, …) and simply never includes `source_task_id` in that list.

The MCP schema for `orbit_task_update` advertises the field as accepted because the tool's parameter schema permits `additionalProperties: true`, not because the handler explicitly opts it in. Result: callers pass it, JSON-Schema validation accepts it, the handler ignores it, the response object reflects pre-call state.

Add-side handler reference (works correctly): `crates/orbit-tools/src/builtin/orbit/task/add.rs:120` reads `source_task_id` and threads it into `TaskCreateParams`.

## Constraints / Notes

- The fix is a **field-add**, not a schema redesign: mirror the existing parsing pattern used in `add.rs:120` inside `update.rs` and thread `source_task_id` through `TaskUpdateParams` into the underlying store calls (`v2_store::apply_update` and/or `task_registry::update`).
- An empty-string clear semantics for `source_task_id` should match the convention other update fields use (`description`, `plan`, `crew`, `job_run_id` already use `""` to clear — see their tool schema descriptions). For `source_task_id`, `""` should set the persisted value to `None`.
- The MCP schema for `orbit_task_update` should explicitly list `source_task_id` as a settable property (not rely on `additionalProperties`) so the schema-advertised contract matches the implementation. Symmetry with `add.rs`'s parameter list is the bar.
- Add an update-path history event when `source_task_id` changes, matching the granularity of other field-change events already emitted by `update.rs` (the file already differentiates `commented` from `status_changed` from generic `updated` events — pick the right shape).
- `[Task].source_task_id` is plain string-or-null on the artifact-v2 DTO (`crates/orbit-common/src/types/task.rs`). No new sqlite column needed; the field already round-trips via `add.rs` and `task_to_json_with_sidecars` ([crates/orbit-cli/src/command/task/output.rs](crates/orbit-cli/src/command/task/output.rs)). This is purely a handler-side wiring bug.
- Scope guard: don't add other "missed" fields in the same PR. If audit reveals other update-side gaps (likely candidates: `parent_id`, `external_refs`, `relations`), file them separately — keep this task to the one field with a concrete repro.

## Related

- Triggered by friction **F2026-05-024** (`/Users/daniel/workspace/repos/orbit/.orbit/frictions/2026-05/F024.md`).
- Surfaced during forensic work on **ORB-00099** (this conversation).
- `source_task_id` is set on this task at creation to validate the fix indirectly — the executor can verify `add.rs`-side handling is intact while debugging.

### Acceptance Criteria

- A new unit test in `crates/orbit-tools/src/builtin/orbit/task/update.rs` (`#[cfg(test)] mod tests`) creates a bug-type task with `source_task_id: None`, then calls the update handler with `source_task_id: "<other-task-id>"`. The post-update task fetched via `orbit.task.show` (or the equivalent in-test path) reports `source_task_id == Some("<other-task-id>")`. Verifiable as a passing `cargo test -p orbit-tools` line.
- A second unit test passes `source_task_id: ""` to clear a previously-set value and asserts the persisted task ends with `source_task_id == None`, matching the empty-string-clears convention used by sibling fields (`description`, `plan`, `crew`, `job_run_id`).
- A third unit test passes `source_task_id` referencing a non-existent task ID. Behavior choice (pick one in planning, document in the test): EITHER (a) update succeeds and stores the unresolved ID — matches the loose-reference behavior `add.rs` already exhibits — OR (b) update returns `OrbitError::InvalidInput` naming the missing task. Whichever is chosen, it must match `add.rs`'s behavior for the same input shape; symmetric handling between create and update is the bar.
- The MCP tool schema for `orbit_task_update` explicitly enumerates `source_task_id` as a settable property in the JSON-Schema parameter list (parity with `orbit_task_add`'s schema entry). Verifiable by inspecting `mcp__orbit__orbit_task_update`'s `parameters.properties.source_task_id` via `orbit tool show orbit.task.update` (or the equivalent introspection path).
- Live e2e repro from F2026-05-024 is fixed: calling `orbit_task_update({id: "<any-bug-task-id>", model: "claude", source_task_id: "<some-valid-id>"})` returns a response whose `source_task_id` field equals the input value, AND `updated_at` advances, AND a history event is appended recording the change.
- When `source_task_id` changes via update, a corresponding history event is appended to the task's `history` list. The event's shape is consistent with how `update.rs` records other single-field changes today (verifiable by reading the post-update task and inspecting `history[].event`). Acceptable shapes: a generic `updated` event with a note naming the field, or a dedicated `source_task_id_set`-style event — match nearby convention.
- `cargo test -p orbit-tools` and `cargo test -p orbit-store` pass. `make ci-fast` passes. No new clippy warnings under `-D warnings`.
- No changes outside `crates/orbit-tools/src/builtin/orbit/task/update.rs`, `crates/orbit-store/src/file/task_store/v2_store.rs`, `crates/orbit-store/src/sqlite/task_registry.rs`, and their respective test surfaces. `git diff --stat` on the branch confirms scope. (Adjust if the executor finds the right wiring point lives elsewhere, but flag it before expanding scope.)

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Added explicit `source_task_id` support to `orbit.task.update` schema and runtime parsing/wiring.
- Threaded update values through `TaskUpdateParams` / `TaskRecordUpdateParams` so v2 task documents set or clear the `RegressionFrom` relation.
- Empty-string update input now clears the field; unresolved IDs are stored to match add-side loose-reference behavior.
- Source-task changes append a generic `updated` history event with a `source_task_id` note.
- Added focused orbit-tools schema/handler tests, orbit-core runtime e2e tests, and orbit-store document update tests.

Strategic decisions:
- Chose loose unresolved-ID persistence for update because `orbit.task.add` already accepts the same shape without target validation.

Deviations from original plan:
- The actual parsing/wiring point was in `crates/orbit-core`, while `crates/orbit-tools/src/builtin/orbit/task/update.rs` only declares schema and delegates to the host. Scope expansion was noted in a task comment before editing.

Validation:
- `cargo test -p orbit-tools` passed.
- `cargo test -p orbit-store` passed.
- `cargo test -p orbit-core runtime::orbit_tool_host::task_tools_tests::task_update_tool_` passed.
- `make ci-fast` passed.
- Full `cargo test -p orbit-core` was also attempted; the new source-task tests passed, but the suite failed in unrelated environment-sensitive job-run/review-scoreboard/agent-detect tests.

Learning checkpoint:
- Added learning `L20260517-6` for the schema-wrapper vs runtime-host parser split.
- Reported friction `F2026-05-026` for the `orbit.learning.add` MCP evidence schema mismatch.

Assessment: the scoped source_task_id update path is implemented and covered; required validations passed.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-00101-6a095e58`
- Behind base: 0
- Ahead of base: 1