### PR TITLE
[ORB-00105] Refresh missing pack branch refs

### DIFF
--- a/crates/orbit-knowledge/src/commands/pack.rs
+++ b/crates/orbit-knowledge/src/commands/pack.rs
@@ -2,6 +2,7 @@ use serde_json::Value;
 
 use crate::commands::{GraphCommandContext, knowledge_error_from_orbit};
 use crate::graph::GraphReadOptions;
+use crate::graph::object_store::{GraphObjectStore, resolve_graph_read_target};
 use crate::{KnowledgeError, Selector};
 
 #[derive(Debug, Clone)]
@@ -16,13 +17,15 @@ pub struct PackInput {
 #[derive(Debug, Clone, PartialEq)]
 pub struct PackResult {
     pub pack: Value,
+    pub auto_refresh_skipped: bool,
 }
 
 pub fn run(input: PackInput) -> Result<PackResult, KnowledgeError> {
     let selectors = Selector::parse_many(&input.selectors)
         .map_err(|error| KnowledgeError::invalid_data(error.to_string()))?;
     let service = input.context.task_service();
-    let skip_auto_refresh = !input.refresh || input.context.explicit_knowledge_dir;
+    let auto_refresh_skipped = !input.refresh && current_branch_ref_available(&input.context);
+    let skip_auto_refresh = input.context.explicit_knowledge_dir || auto_refresh_skipped;
     let pack = service
         .pack_json(
             &selectors,
@@ -37,7 +40,32 @@ pub fn run(input: PackInput) -> Result<PackResult, KnowledgeError> {
         )
         .map_err(knowledge_error_from_orbit)?;
 
-    Ok(PackResult { pack })
+    Ok(PackResult {
+        pack,
+        auto_refresh_skipped,
+    })
+}
+
+fn current_branch_ref_available(context: &GraphCommandContext) -> bool {
+    if context.explicit_ref.is_some() || context.explicit_knowledge_dir {
+        return false;
+    }
+
+    let Some(workspace_root) = context.workspace_root.as_deref() else {
+        return false;
+    };
+    let Ok(read_target) = resolve_graph_read_target(Some(workspace_root), None) else {
+        return false;
+    };
+    let graph_store = GraphObjectStore::new(context.knowledge_dir.join("graph"));
+    if graph_store
+        .prepare_refs_layout(read_target.default.as_ref())
+        .is_err()
+    {
+        return false;
+    }
+
+    graph_store.ref_path(&read_target.requested).is_file()
 }
 
 #[cfg(test)]

--- a/crates/orbit-knowledge/src/service/task_graph.rs
+++ b/crates/orbit-knowledge/src/service/task_graph.rs
@@ -43,13 +43,13 @@ impl TaskGraphService {
         &self,
         selectors: &[Selector],
         workspace_root: Option<&Path>,
-        explicit_knowledge_dir: bool,
+        skip_auto_refresh: bool,
         explicit_ref: Option<&str>,
         read_options: GraphReadOptions,
         selector_timeout_ms: Option<u64>,
     ) -> Result<Value, OrbitError> {
         if explicit_ref.is_none() {
-            self.maybe_refresh_knowledge_graph(workspace_root, explicit_knowledge_dir);
+            self.maybe_refresh_knowledge_graph(workspace_root, skip_auto_refresh);
         }
 
         let read_target = resolve_graph_read_target(workspace_root, explicit_ref)?;
@@ -85,7 +85,7 @@ impl TaskGraphService {
                 } else {
                     match self.rebuild_default_knowledge_graph(
                         workspace_root,
-                        explicit_knowledge_dir,
+                        skip_auto_refresh,
                         &first_error,
                     ) {
                         Ok(true) => match pack_result() {
@@ -245,12 +245,8 @@ impl TaskGraphService {
         }
     }
 
-    fn maybe_refresh_knowledge_graph(
-        &self,
-        workspace_root: Option<&Path>,
-        explicit_knowledge_dir: bool,
-    ) {
-        if explicit_knowledge_dir {
+    fn maybe_refresh_knowledge_graph(&self, workspace_root: Option<&Path>, skip_refresh: bool) {
+        if skip_refresh {
             return;
         }
 
@@ -270,10 +266,10 @@ impl TaskGraphService {
     fn rebuild_default_knowledge_graph(
         &self,
         workspace_root: Option<&Path>,
-        explicit_knowledge_dir: bool,
+        skip_rebuild: bool,
         first_error: &KnowledgeError,
     ) -> Result<bool, String> {
-        if explicit_knowledge_dir {
+        if skip_rebuild {
             return Ok(false);
         }
 

--- a/crates/orbit-knowledge/tests/branch_refs.rs
+++ b/crates/orbit-knowledge/tests/branch_refs.rs
@@ -10,6 +10,8 @@ use std::thread;
 use std::time::Duration;
 
 use fs2::FileExt;
+use orbit_knowledge::commands::pack::{self, PackInput};
+use orbit_knowledge::commands::{GraphCommandContext, TaskGraphScope};
 use orbit_knowledge::graph::nodes::{
     BaseNodeFields, CodebaseGraphV1, DirNode, FileNode, LeafKind, LeafNode,
 };
@@ -390,6 +392,87 @@ fn branch_refs_ensure_fresh_rebuilds_clean_worktree_when_branch_ref_is_missing()
     assert_eq!(status, RefreshStatus::Rebuilt);
     let status = ensure_fresh(&knowledge_dir, &feature_worktree)?;
     assert_eq!(status, RefreshStatus::SkippedDirtyDebounce);
+    Ok(())
+}
+
+#[test]
+fn pack_default_refreshes_missing_worktree_ref_before_fallback()
+-> Result<(), Box<dyn std::error::Error>> {
+    let repo = init_repo()?;
+    let knowledge_dir = repo.path().join(".orbit/knowledge");
+    run_build(BuildConfig {
+        repo_path: repo.path().to_path_buf(),
+        output_dir: knowledge_dir.clone(),
+        incremental: false,
+        ref_name: None,
+    })?;
+
+    git(repo.path(), &["branch", "feature/pack-missing-ref"])?;
+    let feature_worktree = repo.path().join("wt-pack-missing-ref");
+    git(
+        repo.path(),
+        &[
+            "worktree",
+            "add",
+            feature_worktree.to_str().unwrap(),
+            "feature/pack-missing-ref",
+        ],
+    )?;
+    write_rust_source(&feature_worktree, "feature_pack_graph")?;
+    commit_all_with_date(
+        &feature_worktree,
+        "feature pack graph",
+        "2030-01-04T00:00:00Z",
+    )?;
+
+    let graph_store = GraphObjectStore::new(knowledge_dir.join("graph"));
+    let read_target = resolve_graph_read_target(Some(&feature_worktree), None)?;
+    assert_eq!(read_target.requested.as_str(), "feature/pack-missing-ref");
+    assert_eq!(
+        read_target.fallback.as_ref().map(RefName::as_str),
+        Some("main")
+    );
+    assert!(!graph_store.ref_path(&read_target.requested).exists());
+
+    let context = GraphCommandContext {
+        knowledge_dir: knowledge_dir.clone(),
+        workspace_root: Some(feature_worktree.clone()),
+        explicit_ref: None,
+        explicit_knowledge_dir: false,
+        task_scope: TaskGraphScope::default(),
+    };
+    let result = pack::run(PackInput {
+        context: context.clone(),
+        selectors: vec!["symbol:src/lib.rs#feature_pack_graph:function".to_string()],
+        hydrate_leaf_source: false,
+        refresh: false,
+        selector_timeout_ms: 15_000,
+    })?;
+
+    assert!(!result.auto_refresh_skipped);
+    assert!(graph_store.ref_path(&read_target.requested).is_file());
+    let resolved =
+        graph_store.resolve_ref(&read_target.requested, read_target.fallback.as_ref())?;
+    assert!(!resolved.used_fallback);
+    let entries = result
+        .pack
+        .get("entries")
+        .and_then(serde_json::Value::as_array)
+        .ok_or_else(|| io_error("pack entries missing".to_string()))?;
+    assert_eq!(entries.len(), 1);
+    assert_eq!(entries[0]["kind"], "leaf");
+    assert_eq!(entries[0]["name"], "feature_pack_graph");
+    assert!(result.pack.get("diagnostics").is_none());
+
+    let second = pack::run(PackInput {
+        context,
+        selectors: vec!["symbol:src/lib.rs#feature_pack_graph:function".to_string()],
+        hydrate_leaf_source: false,
+        refresh: false,
+        selector_timeout_ms: 15_000,
+    })?;
+    assert!(second.auto_refresh_skipped);
+    assert!(second.pack.get("diagnostics").is_none());
     Ok(())
 }
 

--- a/crates/orbit-tools/src/builtin/orbit/knowledge/pack.rs
+++ b/crates/orbit-tools/src/builtin/orbit/knowledge/pack.rs
@@ -65,18 +65,18 @@ impl Tool for OrbitKnowledgePackTool {
         let refresh = parse_refresh(&input)?;
         let explicit_ref = super::super::optional_string(&input, "ref")?;
         let explicit_knowledge_dir = super::has_explicit_knowledge_dir(&input);
-        let mut pack = pack::run(PackInput {
+        let pack_result = pack::run(PackInput {
             context: super::command_context(ctx, &input)?,
             selectors,
             hydrate_leaf_source: !summary,
             refresh,
             selector_timeout_ms,
         })
-        .map_err(super::knowledge_error_to_orbit)?
-        .pack;
+        .map_err(super::knowledge_error_to_orbit)?;
+        let mut pack = pack_result.pack;
         add_refresh_diagnostics(
             &mut pack,
-            refresh,
+            pack_result.auto_refresh_skipped,
             explicit_ref.as_deref(),
             explicit_knowledge_dir,
         );
@@ -144,11 +144,11 @@ fn parse_refresh(input: &Value) -> Result<bool, OrbitError> {
 
 fn add_refresh_diagnostics(
     pack: &mut Value,
-    refresh: bool,
+    auto_refresh_skipped: bool,
     explicit_ref: Option<&str>,
     explicit_knowledge_dir: bool,
 ) {
-    if refresh || explicit_ref.is_some() || explicit_knowledge_dir {
+    if !auto_refresh_skipped || explicit_ref.is_some() || explicit_knowledge_dir {
         return;
     }
     let Some(obj) = pack.as_object_mut() else {
@@ -199,4 +199,25 @@ fn summarize_pack_entry(entry: &mut Value) {
         return;
     };
     obj.insert("file".to_string(), Value::String(file_path));
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::add_refresh_diagnostics;
+
+    #[test]
+    fn refresh_diagnostics_only_report_actual_auto_refresh_skips() {
+        let mut refreshed_pack = json!({"entries": []});
+        add_refresh_diagnostics(&mut refreshed_pack, false, None, false);
+        assert!(refreshed_pack.get("diagnostics").is_none());
+
+        let mut skipped_pack = json!({"entries": []});
+        add_refresh_diagnostics(&mut skipped_pack, true, None, false);
+        assert_eq!(
+            skipped_pack["diagnostics"]["auto_refresh"]["status"],
+            "skipped"
+        );
+    }
 }


### PR DESCRIPTION
## Task
ORB-00105

## Summary
- Make `orbit.graph.pack` skip freshness checks only when the requested branch ref already exists.
- If the active worktree branch ref is missing, default `refresh:false` now allows `ensure_fresh` to build that ref before packing selectors.
- Carry an `auto_refresh_skipped` flag through the pack command so the tool only emits the skipped-refresh diagnostic when a refresh was actually skipped.
- Add a linked-worktree regression test proving default pack creates the missing worktree branch ref and reads the worktree-only symbol instead of falling back to `agent-main`.

## Root Cause
ORB-00099 fixed attribution once refresh ran, but `orbit.graph.pack` defaults to skipping auto-refresh. On a fresh worktree branch with no graph ref, pack resolved the requested branch, then `GraphObjectStore::resolve_ref` used the default branch fallback. That made the first pack call read `agent-main` even though `ensure_fresh` already knows how to rebuild missing branch refs.

## Validation
- `cargo fmt --check`
- `cargo test -p orbit-knowledge pack_default_refreshes_missing_worktree_ref_before_fallback`
- `cargo test -p orbit-tools refresh_diagnostics_only_report_actual_auto_refresh_skips`
- `cargo test -p orbit-knowledge`
- `cargo test -p orbit-tools`
- `make ci-fast`
- Manual e2e from `/Users/daniel/workspace/repos/orbit/.orbit/state/worktrees/orbit-jrun-20260517-0621-6` using the patched local CLI: `orbit.graph.pack` with default `refresh:false` created `/Users/daniel/workspace/repos/orbit/.orbit/knowledge/graph/refs/heads/orbit/ORB-00102-6a095e58.json`, and manifest `git_head_oid` matched the worktree HEAD.

## Notes
This intentionally preserves fast pack behavior when the requested branch ref exists; it only forces a refresh when there is no valid requested-branch snapshot to read.
