### PR TITLE
[codex] [ORB-00106] Preserve ship task attribution

### DIFF
--- a/crates/orbit-engine/src/executor/automation/vcs/pr.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/pr.rs
@@ -139,16 +139,11 @@ pub(super) fn merge_batch_pr<H: RuntimeHost + TaskHost + ?Sized>(
         .collect::<Result<Vec<_>, _>>()?
         .into_iter()
         .any(|requires_revision| requires_revision);
-    let batch_author = batch_tasks.iter().find_map(|task| {
-        normalize_optional_attribution_label(
-            task.implemented_by
-                .as_deref()
-                .or(task.created_by.as_deref()),
-            task.implemented_by.as_deref(),
-        )
-    });
+    let batch_author = batch_tasks.iter().find_map(ship_done_attribution);
 
-    // Advance ALL batch tasks to Done status
+    // Preserve ship attribution per task across the Review -> Done transition.
+    // See `merge_batch_pr_preserves_task_attribution_per_task`: the source of
+    // truth is task.implemented_by -> task.created_by -> system fallback.
     for task in &batch_tasks {
         host.apply_task_automation_update(
             &task.id,
@@ -159,6 +154,7 @@ pub(super) fn merge_batch_pr<H: RuntimeHost + TaskHost + ?Sized>(
                     None
                 },
                 external_refs: vec![ExternalRef::github_pr(pr_number.clone())?],
+                model: ship_done_attribution(task),
                 ..TaskAutomationUpdate::default()
             },
         )?;
@@ -175,6 +171,15 @@ pub(super) fn merge_batch_pr<H: RuntimeHost + TaskHost + ?Sized>(
     }
 
     Ok(json!({ "merged": true }))
+}
+
+fn ship_done_attribution(task: &Task) -> Option<String> {
+    normalize_optional_attribution_label(
+        task.implemented_by
+            .as_deref()
+            .or(task.created_by.as_deref()),
+        task.implemented_by.as_deref(),
+    )
 }
 
 pub(super) fn open_batch_pr<H: RuntimeHost + TaskHost + ?Sized>(
@@ -682,6 +687,7 @@ mod tests {
     struct PrOpenTestHost {
         tasks: Mutex<Vec<Task>>,
         tool_calls: Mutex<Vec<ToolCall>>,
+        automation_updates: Mutex<Vec<(String, TaskAutomationUpdate)>>,
         repo_root: PathBuf,
         data_root: PathBuf,
         scoreboard_dir: PathBuf,
@@ -695,6 +701,7 @@ mod tests {
             Self {
                 tasks: Mutex::new(tasks),
                 tool_calls: Mutex::new(Vec::new()),
+                automation_updates: Mutex::new(Vec::new()),
                 repo_root,
                 data_root,
                 scoreboard_dir,
@@ -717,6 +724,13 @@ mod tests {
                         .map(ToOwned::to_owned)
                 })
                 .expect("github.pr.create body")
+        }
+
+        fn automation_updates(&self) -> Vec<(String, TaskAutomationUpdate)> {
+            self.automation_updates
+                .lock()
+                .expect("automation updates lock")
+                .clone()
         }
     }
 
@@ -819,11 +833,28 @@ mod tests {
             task_id: &str,
             update: TaskAutomationUpdate,
         ) -> Result<(), OrbitError> {
+            self.automation_updates
+                .lock()
+                .expect("automation updates lock")
+                .push((task_id.to_string(), update.clone()));
+
             let mut tasks = self.tasks.lock().expect("tasks lock");
             let task = tasks
                 .iter_mut()
                 .find(|task| task.id == task_id)
                 .ok_or_else(|| OrbitError::not_found(NotFoundKind::Task, task_id.to_string()))?;
+            let transition_implemented_by =
+                if matches!(update.status, Some(TaskStatus::Review | TaskStatus::Done)) {
+                    Some(
+                        update
+                            .model
+                            .clone()
+                            .or(update.agent.clone())
+                            .unwrap_or_else(|| "system".to_string()),
+                    )
+                } else {
+                    None
+                };
             if let Some(status) = update.status {
                 task.status = status;
             }
@@ -832,6 +863,9 @@ mod tests {
             }
             if let Some(execution_summary) = update.execution_summary {
                 task.execution_summary = execution_summary;
+            }
+            if let Some(implemented_by) = transition_implemented_by {
+                task.implemented_by = Some(implemented_by);
             }
             Ok(())
         }
@@ -896,6 +930,7 @@ mod tests {
 
             match name {
                 "git.push" => Ok(json!({})),
+                "github.pr.merge" => Ok(json!({})),
                 "github.pr.create" => Ok(json!({
                     "url": "https://github.example/orbit/orbit/pull/42"
                 })),
@@ -963,6 +998,21 @@ mod tests {
         let mut task = task(id, title, execution_summary);
         task.status = TaskStatus::InProgress;
         task.job_run_id = Some("batch-1".to_string());
+        task
+    }
+
+    fn review_batch_task(id: &str, implemented_by: Option<&str>, created_by: Option<&str>) -> Task {
+        let mut task = task(
+            id,
+            "Ship attribution",
+            "Outcome: success\n\nChanges:\n- Ready.",
+        );
+        task.status = TaskStatus::Review;
+        task.pr_status = Some("approved".to_string());
+        task.job_run_id = Some("batch-1".to_string());
+        task.implemented_by = implemented_by.map(ToOwned::to_owned);
+        task.created_by = created_by.map(ToOwned::to_owned);
+        task.external_refs = vec![ExternalRef::github_pr("42").expect("github pr ref")];
         task
     }
 
@@ -1051,6 +1101,15 @@ mod tests {
             "workspace_path": repo.to_string_lossy(),
             "job_run_id": "batch-1",
             "completed_task_ids": completed_task_ids,
+            "base": "agent-main",
+            "base_sync": "local",
+        })
+    }
+
+    fn merge_batch_pr_input(repo: &Path) -> Value {
+        json!({
+            "workspace_path": repo.to_string_lossy(),
+            "job_run_id": "batch-1",
             "base": "agent-main",
             "base_sync": "local",
         })
@@ -1410,6 +1469,81 @@ mod tests {
             .collect::<Vec<_>>();
 
         assert_eq!(signature_lines, vec!["*authored by: A*"]);
+    }
+
+    #[test]
+    fn merge_batch_pr_preserves_task_attribution_per_task() {
+        let workspace = pr_workspace();
+        let cases = [
+            ("T-CLAUDE", "claude"),
+            ("T-CODEX", "codex"),
+            ("T-GEMINI", "gemini"),
+            ("T-GROK", "grok"),
+        ];
+        let tasks = cases
+            .iter()
+            .map(|(id, implemented_by)| review_batch_task(id, Some(implemented_by), None))
+            .collect::<Vec<_>>();
+        let host = PrOpenTestHost::new(tasks, workspace.repo.clone());
+
+        let result =
+            merge_batch_pr(&host, &merge_batch_pr_input(&workspace.repo)).expect("merge batch pr");
+
+        assert_eq!(result["merged"], json!(true));
+        for (task_id, expected) in cases {
+            let task = host.get_task(task_id).expect("updated task");
+            assert_eq!(task.status, TaskStatus::Done, "{task_id}");
+            assert_eq!(task.implemented_by.as_deref(), Some(expected), "{task_id}");
+
+            let (_, update) = host
+                .automation_updates()
+                .into_iter()
+                .find(|(updated_task_id, _)| updated_task_id == task_id)
+                .expect("task automation update");
+            assert_eq!(update.model.as_deref(), Some(expected), "{task_id}");
+        }
+    }
+
+    #[test]
+    fn merge_batch_pr_uses_created_by_when_implemented_by_missing() {
+        let workspace = pr_workspace();
+        let host = PrOpenTestHost::new(
+            vec![review_batch_task("T-CREATED-BY", None, Some("codex"))],
+            workspace.repo.clone(),
+        );
+
+        merge_batch_pr(&host, &merge_batch_pr_input(&workspace.repo)).expect("merge batch pr");
+
+        let task = host.get_task("T-CREATED-BY").expect("updated task");
+        assert_eq!(task.status, TaskStatus::Done);
+        assert_eq!(task.implemented_by.as_deref(), Some("codex"));
+        let (_, update) = host
+            .automation_updates()
+            .into_iter()
+            .find(|(updated_task_id, _)| updated_task_id == "T-CREATED-BY")
+            .expect("task automation update");
+        assert_eq!(update.model.as_deref(), Some("codex"));
+    }
+
+    #[test]
+    fn merge_batch_pr_actorless_task_falls_back_to_system() {
+        let workspace = pr_workspace();
+        let host = PrOpenTestHost::new(
+            vec![review_batch_task("T-SYSTEM", None, None)],
+            workspace.repo.clone(),
+        );
+
+        merge_batch_pr(&host, &merge_batch_pr_input(&workspace.repo)).expect("merge batch pr");
+
+        let task = host.get_task("T-SYSTEM").expect("updated task");
+        assert_eq!(task.status, TaskStatus::Done);
+        assert_eq!(task.implemented_by.as_deref(), Some("system"));
+        let (_, update) = host
+            .automation_updates()
+            .into_iter()
+            .find(|(updated_task_id, _)| updated_task_id == "T-SYSTEM")
+            .expect("task automation update");
+        assert_eq!(update.model, None);
     }
 
     #[test]

--- a/docs/design/auditability/2_design.md
+++ b/docs/design/auditability/2_design.md
@@ -2,7 +2,7 @@
 
 **Status:** Draft
 **Owner:** codex
-**Last updated:** 2026-05-17 (ORB-00090)
+**Last updated:** 2026-05-17 (ORB-00106)
 
 This document describes Orbit's shipped auditability implementation across command audit rows, activity/job envelopes, loop-level provider/tool traces, blob storage, redaction, identity attribution, metrics-adjacent invocation records, and known limitations. See [1_overview.md](./1_overview.md) for the feature purpose and [3_vision.md](./3_vision.md) for future questions.
 
@@ -90,6 +90,8 @@ Orbit currently carries identity through related fields rather than one universa
 
 Task attribution remains automatic by default: non-empty plan writes stamp `planned_by`, and transitions into `review` or `done` stamp `implemented_by`. After [T20260427-47], `orbit.task.update` and direct `orbit task update` can explicitly set or clear those fields; explicit values win within the same update.
 
+For `orbit run ship`, the batch PR merge path preserves task-authored implementation provenance during the Review -> Done transition. The ship loop resolves attribution per task as `task.implemented_by` first, then `task.created_by`, then `system` only for genuinely actor-less automation, and passes that value through the automation update payload. This keeps mixed-family batches from collapsing to one ship actor while retaining the legitimate system fallback. [ORB-00106]
+
 After [T20260508-22] and [T20260509-12], `git_commit` automation carries that task attribution into git metadata. Per-task commits use process-scoped author and committer identity derived from `task.implemented_by` (`claude`, `gemini`, or `codex` family identities), leaving repository `git config user.name` and `user.email` untouched. Multi-implementer batch commits use `orbit <orbit@orbit.local>` as the aggregate author and committer and add `Co-Authored-By` trailers for each distinct implementer identity.
 
 The requirement is not to collapse every field into one value. It is that a reviewer can follow task state, command rows, run envelopes, provider/tool traces, and metrics back to a concrete human or agent family. A unified identity glossary and query join story remain open.
@@ -162,5 +164,6 @@ Each record contains timestamp, level, target, and structured fields. After [T20
 - **[T20260510-13]** — Move friction reports from task lifecycle state to append-only `.orbit/frictions/` records.
 - **[ORB-00062]** — Surface first-class friction artifacts in the dashboard Knowledge tab and add triage endpoints.
 - **[ORB-00090]** — Aligned agent-facing provenance wording with the family-as-identity convention.
+- **[ORB-00106]** — Preserve per-task implementer attribution when `orbit run ship` moves batch PR tasks from Review to Done.
 
 > Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.

--- a/docs/design/auditability/4_decisions.md
+++ b/docs/design/auditability/4_decisions.md
@@ -2,7 +2,7 @@
 
 **Status:** Draft
 **Owner:** codex
-**Last updated:** 2026-05-17 (ORB-00090)
+**Last updated:** 2026-05-17 (ORB-00106)
 
 This is the append-only ADR log for Auditability. Entries are ordered by ADR number. New entries should use the template in [../CONVENTIONS.md](../CONVENTIONS.md) and cite the task that made the decision real.
 
@@ -304,6 +304,21 @@ This is the append-only ADR log for Auditability. Entries are ordered by ADR num
 
 ---
 
+## ADR-0164 — Ship Done transitions preserve task implementer attribution
+
+**Status:** Accepted · 2026-05 · [ORB-00106]
+
+**Context.** `orbit run ship` reached the Review -> Done transition through system-owned automation even when each task already carried agent provenance. Prior attribution fixes in [ORB-00067], [ORB-00089], and [ORB-00091] covered adjacent automation paths, but the batch PR merge loop still had two real alternatives: trust the ship actor/runtime context, or carry each task provenance explicitly.
+
+**Decision.** Ship-path Done transitions use per-task provenance as the source of truth: `task.implemented_by` wins, then `task.created_by`, then the genuine actor-less fallback remains `system`. The merge loop passes that resolved value on the task update for each task, and the regression test exercises distinct identities in one batch so a batch-level author cannot homogenize them.
+
+**Consequences.**
+- Shipped task records, ship scoreboards, and follow-on git author derivation can preserve the implementer family that actually produced each task.
+- Actor-less automation still records `system` instead of panicking or fabricating a family label.
+- Cost: the ship pipeline must explicitly bridge task provenance into the automation update payload, so future edits to that loop need to preserve the regression test rather than assuming runtime actor context is enough.
+
+---
+
 ## Task References
 
 - **[T20260419-0002]** — Add workspace provenance and v2 audit envelope events for activity/job execution.
@@ -334,7 +349,11 @@ This is the append-only ADR log for Auditability. Entries are ordered by ADR num
 - **[T20260508-22]** — Use `task.implemented_by` to set git commit authors for automated task commits.
 - **[T20260509-12]** — Scope workflow git author and committer identity to the spawned commit process without writing repo-local Git config.
 - **[T20260510-13]** — Move friction reports from task lifecycle state to append-only `.orbit/frictions/` records.
+- **[ORB-00067]** — Earlier automation attribution work that did not close the ship batch PR Done transition gap.
+- **[ORB-00089]** — Earlier system-attribution gap that informed the ship-path fallback rule.
+- **[ORB-00091]** — Prior fix for automation-driven status attribution that did not cover the ship merge loop.
 - **[ORB-00080]** — Collapse Orbit agent identity to family and isolate exact model strings to invocation/configuration surfaces.
 - **[ORB-00090]** — Align agent-facing docs and tool descriptions with the family-as-identity convention.
+- **[ORB-00106]** — Preserve per-task implementer attribution when `orbit run ship` moves batch PR tasks from Review to Done.
 
 > Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.


### PR DESCRIPTION
## Summary
- Preserve per-task implementer attribution when `orbit run ship` advances batch PR tasks from Review to Done.
- Add regression coverage for mixed `claude`/`codex`/`gemini`/`grok` batches, `created_by` fallback, and actor-less `system` fallback.
- Document the attribution rule in auditability design docs with ADR-0164.

## Root Cause
`merge_batch_pr` computed a batch author for scoring, but the Review -> Done update loop did not pass attribution into `TaskAutomationUpdate`. In the ship automation context, the runtime fell back to the system actor, so shipped tasks could be stamped `implemented_by: "system"`.

## Validation
- `cargo test -p orbit-engine merge_batch_pr_ -- --nocapture`
- `make ci-fast`
- `git diff --check`

## Note
I did not run a live `orbit run ship` smoke for the PR-merge path because doing so safely would require invoking agents and/or pushing and merging a real GitHub PR. The deterministic regression exercises the merge transition directly.