### PR TITLE
orbit-engine: derive ship batch commit message from task artifact instead of "feat: parallel batch"

### DIFF
--- a/crates/orbit-engine/src/executor/automation/vcs/commit/message.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/commit/message.rs
@@ -1,4 +1,7 @@
-use orbit_common::types::Task;
+use orbit_common::types::{Task, TaskType};
+
+const BATCH_SUBJECT_BUDGET: usize = 72;
+const ELLIPSIS: char = '…';
 
 pub(super) fn task_commit_message(task: &Task) -> String {
     let mut message = format!("[{}] {}", task.id, task.title.trim());
@@ -39,6 +42,73 @@ pub(super) fn finalize_commit_message(tasks: &[Task]) -> String {
         .join("\n");
 
     format!("fix: finalize ship batch [{ids_joined}]\n\n{summaries}")
+}
+
+pub(super) fn batch_commit_message(task: &Task) -> String {
+    let commit_type = conventional_commit_type(task.task_type);
+    let title = task.title.trim();
+    let (subject_title, truncated) = truncate_title_for_subject(commit_type, title);
+
+    let mut subject = format!("{commit_type}: {subject_title} [{}]", task.id);
+    for external_ref in &task.external_refs {
+        subject.push(' ');
+        subject.push_str(&format!(
+            "[{}-{}]",
+            external_ref.system.to_ascii_uppercase(),
+            external_ref.id
+        ));
+    }
+
+    let mut sections = Vec::new();
+    if truncated {
+        sections.push(title.to_string());
+    }
+    if let Some(summary) = execution_summary_paragraph(task) {
+        sections.push(summary);
+    }
+    let trailers = batch_commit_trailers(task);
+    if !trailers.is_empty() {
+        sections.push(trailers.join("\n"));
+    }
+
+    if sections.is_empty() {
+        subject
+    } else {
+        format!("{subject}\n\n{}", sections.join("\n\n"))
+    }
+}
+
+fn conventional_commit_type(task_type: TaskType) -> &'static str {
+    match task_type {
+        TaskType::Feature => "feat",
+        TaskType::Bug => "fix",
+        TaskType::Refactor => "refactor",
+        TaskType::Chore => "chore",
+    }
+}
+
+fn truncate_title_for_subject(commit_type: &str, title: &str) -> (String, bool) {
+    let prefix_len = commit_type.chars().count() + ": ".chars().count();
+    let title_budget = BATCH_SUBJECT_BUDGET.saturating_sub(prefix_len);
+    if title.chars().count() <= title_budget {
+        return (title.to_string(), false);
+    }
+
+    let retained_chars = title_budget.saturating_sub(1);
+    let mut truncated = title.chars().take(retained_chars).collect::<String>();
+    truncated.push(ELLIPSIS);
+    (truncated, true)
+}
+
+fn batch_commit_trailers(task: &Task) -> Vec<String> {
+    let mut trailers = Vec::new();
+    if let Some(planned_by) = task.planned_by.as_deref() {
+        trailers.push(format!("Planned-By: {planned_by}"));
+    }
+    if let Some(implemented_by) = task.implemented_by.as_deref() {
+        trailers.push(format!("Implemented-By: {implemented_by}"));
+    }
+    trailers
 }
 
 fn execution_summary_paragraph(task: &Task) -> Option<String> {
@@ -90,4 +160,195 @@ fn single_line_summary(summary: &str) -> String {
         .join(" ")
         .trim()
         .to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use chrono::Utc;
+    use orbit_common::types::{ExternalRef, TaskPriority, TaskStatus};
+
+    use super::*;
+
+    #[test]
+    fn batch_commit_subject_uses_task_type() {
+        let cases = [
+            (TaskType::Feature, "feat"),
+            (TaskType::Bug, "fix"),
+            (TaskType::Refactor, "refactor"),
+            (TaskType::Chore, "chore"),
+        ];
+
+        for (task_type, expected_type) in cases {
+            let task = task_with_type(task_type, "Ship better commit messages");
+
+            assert_eq!(
+                batch_commit_message(&task),
+                format!("{expected_type}: Ship better commit messages [ORB-00107]")
+            );
+        }
+    }
+
+    #[test]
+    fn batch_commit_subject_keeps_short_title_unchanged() {
+        let task = task_with_type(TaskType::Feature, "Short title");
+
+        assert_eq!(batch_commit_message(&task), "feat: Short title [ORB-00107]");
+    }
+
+    #[test]
+    fn batch_commit_subject_truncates_long_title_with_ellipsis() {
+        let title = "a".repeat(145);
+        let task = task_with_type(TaskType::Feature, &title);
+        let message = batch_commit_message(&task);
+        let subject = message.lines().next().expect("message has subject");
+        let typed_subject = subject
+            .split(" [")
+            .next()
+            .expect("subject includes task tag");
+
+        assert_eq!(typed_subject.chars().count(), 72);
+        assert_eq!(typed_subject, format!("feat: {}{ELLIPSIS}", "a".repeat(65)));
+    }
+
+    #[test]
+    fn batch_commit_body_includes_full_title_only_when_truncated() {
+        let short_task = task_with_type(TaskType::Chore, "Short title");
+        assert_eq!(
+            batch_commit_message(&short_task),
+            "chore: Short title [ORB-00107]"
+        );
+
+        let title = "b".repeat(145);
+        let long_task = task_with_type(TaskType::Feature, &title);
+        assert_eq!(
+            batch_commit_message(&long_task),
+            format!(
+                "feat: {}{ELLIPSIS} [ORB-00107]\n\n{}",
+                "b".repeat(65),
+                title
+            )
+        );
+    }
+
+    #[test]
+    fn batch_commit_subject_appends_external_refs_in_declaration_order() {
+        let mut task = task_with_type(TaskType::Chore, "Wire external refs");
+        task.external_refs = vec![
+            external_ref("eng", "1234"),
+            external_ref("jira", "CORE-987"),
+        ];
+
+        assert_eq!(
+            batch_commit_message(&task),
+            "chore: Wire external refs [ORB-00107] [ENG-1234] [JIRA-CORE-987]"
+        );
+    }
+
+    #[test]
+    fn batch_commit_body_includes_execution_summary_when_present() {
+        let mut task = task_with_type(TaskType::Feature, "Summarize the work");
+        task.execution_summary =
+            "## Summary\n- Added deterministic batch commit messages.\n\n## Validation\n- cargo test"
+                .to_string();
+
+        assert_eq!(
+            batch_commit_message(&task),
+            "feat: Summarize the work [ORB-00107]\n\nAdded deterministic batch commit messages."
+        );
+    }
+
+    #[test]
+    fn batch_commit_body_omits_execution_summary_when_absent() {
+        let mut task = task_with_type(TaskType::Feature, "No summary available");
+        task.execution_summary = "## Validation\n- cargo test".to_string();
+
+        assert_eq!(
+            batch_commit_message(&task),
+            "feat: No summary available [ORB-00107]"
+        );
+    }
+
+    #[test]
+    fn batch_commit_body_orders_full_title_before_execution_summary() {
+        let title = "c".repeat(145);
+        let mut task = task_with_type(TaskType::Bug, &title);
+        task.execution_summary = "## Summary\n- Preserved the full task title.".to_string();
+
+        assert_eq!(
+            batch_commit_message(&task),
+            format!(
+                "fix: {}{ELLIPSIS} [ORB-00107]\n\n{}\n\nPreserved the full task title.",
+                "c".repeat(66),
+                title
+            )
+        );
+    }
+
+    #[test]
+    fn batch_commit_trailers_include_raw_planner_and_implementer() {
+        let mut task = task_with_type(TaskType::Refactor, "Record attribution");
+        task.planned_by = Some("codex".to_string());
+        task.implemented_by = Some("claude".to_string());
+
+        assert_eq!(
+            batch_commit_message(&task),
+            "refactor: Record attribution [ORB-00107]\n\nPlanned-By: codex\nImplemented-By: claude"
+        );
+    }
+
+    #[test]
+    fn batch_commit_trailers_omit_missing_fields() {
+        let mut planned_only = task_with_type(TaskType::Refactor, "Planner only");
+        planned_only.planned_by = Some("codex".to_string());
+        assert_eq!(
+            batch_commit_message(&planned_only),
+            "refactor: Planner only [ORB-00107]\n\nPlanned-By: codex"
+        );
+
+        let mut implemented_only = task_with_type(TaskType::Refactor, "Implementer only");
+        implemented_only.implemented_by = Some("claude".to_string());
+        assert_eq!(
+            batch_commit_message(&implemented_only),
+            "refactor: Implementer only [ORB-00107]\n\nImplemented-By: claude"
+        );
+
+        let neither = task_with_type(TaskType::Refactor, "No trailers");
+        assert_eq!(
+            batch_commit_message(&neither),
+            "refactor: No trailers [ORB-00107]"
+        );
+    }
+
+    fn task_with_type(task_type: TaskType, title: &str) -> Task {
+        let now = Utc::now();
+        Task {
+            id: "ORB-00107".to_string(),
+            title: title.to_string(),
+            description: String::new(),
+            acceptance_criteria: Vec::new(),
+            tags: Vec::new(),
+            plan: String::new(),
+            execution_summary: String::new(),
+            context_files: Vec::new(),
+            created_by: None,
+            planned_by: None,
+            implemented_by: None,
+            status: TaskStatus::InProgress,
+            priority: TaskPriority::Medium,
+            complexity: None,
+            task_type,
+            pr_status: None,
+            external_refs: Vec::new(),
+            relations: Vec::new(),
+            job_run_id: None,
+            crew: None,
+            created_at: now,
+            updated_at: now,
+        }
+    }
+
+    fn external_ref(system: &str, id: &str) -> ExternalRef {
+        ExternalRef::try_new(system.to_string(), id.to_string(), None)
+            .expect("external ref fixture is valid")
+    }
 }

--- a/crates/orbit-engine/src/executor/automation/vcs/commit/mod.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/commit/mod.rs
@@ -21,7 +21,7 @@ use git_ops::{
     ensure_named_branch, ensure_no_unmerged_changes, git_commit_with_identity, stage_paths,
     staged_changed_files,
 };
-use message::{finalize_commit_message, task_commit_message};
+use message::{batch_commit_message, finalize_commit_message, task_commit_message};
 use scope::{changed_files_for_task, collect_worktree_changes, filter_changed_files_for_task};
 
 #[cfg(test)]
@@ -176,9 +176,12 @@ pub(super) fn commit_batch_changes<H: TaskHost + RuntimeHost + ?Sized>(
 ) -> Result<Value, OrbitError> {
     let batch_id = required_job_run_id(input, "commit_batch_changes")?;
     let batch_tasks = host.list_tasks_filtered(None, None, None, Some(batch_id), None, None)?;
-    if batch_tasks.is_empty() {
-        return Ok(json!({}));
-    }
+    let [task] = batch_tasks.as_slice() else {
+        return Err(OrbitError::InvalidInput(format!(
+            "commit_batch_changes expected exactly one task for job_run_id '{batch_id}', got {}",
+            batch_tasks.len()
+        )));
+    };
 
     let workspace_path = resolve_workspace_path(host, input, batch_id)?;
     ensure_named_branch(&workspace_path)?;
@@ -192,20 +195,8 @@ pub(super) fn commit_batch_changes<H: TaskHost + RuntimeHost + ?Sized>(
         return Ok(json!({}));
     }
 
-    let mut task_lines = Vec::new();
-    let mut id_labels = Vec::new();
-    for task in &batch_tasks {
-        task_lines.push(format!("- {}: {}", task.id, task.title.trim()));
-        id_labels.push(task.id.clone());
-    }
-    let ids_joined = id_labels.join(", ");
-    let mut message = format!(
-        "feat: parallel batch [{}]\n\nTasks:\n{}",
-        ids_joined,
-        task_lines.join("\n")
-    );
-    let (author, coauthors) = commit_author_for_tasks(&batch_tasks);
-    append_co_author_trailers(&mut message, &coauthors);
+    let message = batch_commit_message(task);
+    let author = git_author_for_task(task);
 
     git_commit_with_identity(&workspace_path, &message, author.as_ref())?;
     Ok(json!({}))
@@ -247,8 +238,8 @@ mod tests {
 
     use chrono::Utc;
     use orbit_common::types::{
-        Activity, Job, JobTargetType, NotFoundKind, OrbitEvent, Role, TaskArtifact, TaskPriority,
-        TaskStatus, TaskType,
+        Activity, ExternalRef, Job, JobTargetType, NotFoundKind, OrbitEvent, Role, TaskArtifact,
+        TaskPriority, TaskStatus, TaskType,
     };
     use orbit_tools::ToolContext;
     use serde_json::{Value, json};
@@ -608,18 +599,22 @@ mod tests {
     }
 
     #[test]
-    fn git_commit_mixed_implementer_batch_uses_aggregate_identity_with_trailers() {
+    fn git_commit_batch_uses_templated_single_task_message() {
         let temp = initialized_git_repo();
         let workspace = temp.path();
         fs::create_dir_all(workspace.join("src")).unwrap();
-        fs::write(workspace.join("src/claude.txt"), "claude work\n").unwrap();
-        fs::write(workspace.join("src/gemini.txt"), "gemini work\n").unwrap();
+        fs::write(workspace.join("src/bug.txt"), "bug fix\n").unwrap();
 
-        let tasks = vec![
-            task_with_file("T1", "Claude task", "src/claude.txt", "claude-opus-4-7"),
-            task_with_file("T2", "Gemini task", "src/gemini.txt", "gemini-3.1-pro"),
-        ];
-        let host = CommitTestHost::new(tasks, workspace.to_path_buf());
+        let title = "a".repeat(145);
+        let mut task = task_with_file("ORB-00107", &title, "src/bug.txt", "claude");
+        task.task_type = TaskType::Bug;
+        task.planned_by = Some("codex".to_string());
+        task.implemented_by = Some("claude".to_string());
+        task.external_refs = vec![external_ref("eng", "1234")];
+        task.execution_summary =
+            "## Summary\n- Fixed deterministic batch commit messages.\n\n## Validation\n- cargo test"
+                .to_string();
+        let host = CommitTestHost::new(vec![task], workspace.to_path_buf());
         let input = json!({
             "scope": "all",
             "job_run_id": "batch-1",
@@ -635,13 +630,42 @@ mod tests {
         let actual_committer = git_output(workspace, &["log", "-1", "--format=%cn <%ce>"])
             .expect("read git committer");
         let body = git_output(workspace, &["log", "-1", "--format=%B"]).expect("read git body");
-        assert_eq!(actual_author, "orbit <orbit@orbit.local>");
-        assert_eq!(actual_committer, "orbit <orbit@orbit.local>");
-        assert!(body.contains("Co-Authored-By: claude <claude@orbit.local>"));
-        assert!(body.contains("Co-Authored-By: gemini <gemini@orbit.local>"));
+        let expected_body = format!(
+            "fix: {}… [ORB-00107] [ENG-1234]\n\n{}\n\nFixed deterministic batch commit messages.\n\nPlanned-By: codex\nImplemented-By: claude",
+            "a".repeat(66),
+            title
+        );
+        assert_eq!(actual_author, "claude <claude@orbit.local>");
+        assert_eq!(actual_committer, "claude <claude@orbit.local>");
+        assert_eq!(body, expected_body);
         assert_eq!(
             local_user_config_snapshot(workspace),
             local_user_config_before
+        );
+    }
+
+    #[test]
+    fn git_commit_batch_rejects_multiple_tasks() {
+        let temp = initialized_git_repo();
+        let workspace = temp.path();
+
+        let tasks = vec![
+            task_with_file("T1", "Claude task", "src/claude.txt", "claude-opus-4-7"),
+            task_with_file("T2", "Gemini task", "src/gemini.txt", "gemini-3.1-pro"),
+        ];
+        let host = CommitTestHost::new(tasks, workspace.to_path_buf());
+        let input = json!({
+            "scope": "all",
+            "job_run_id": "batch-1",
+            "workspace_path": workspace.to_string_lossy().to_string(),
+        });
+
+        let error = git_commit(&host, &input).expect_err("multi-task batch is rejected");
+
+        assert!(
+            error
+                .to_string()
+                .contains("commit_batch_changes expected exactly one task")
         );
     }
 
@@ -749,5 +773,10 @@ mod tests {
             created_at: now,
             updated_at: now,
         }
+    }
+
+    fn external_ref(system: &str, id: &str) -> ExternalRef {
+        ExternalRef::try_new(system.to_string(), id.to_string(), None)
+            .expect("external ref fixture is valid")
     }
 }


### PR DESCRIPTION
## Task

[ORB-00107](https://orbit-cli.com/tasks/ORB-00107) — orbit-engine: derive ship batch commit message from task artifact instead of "feat: parallel batch"

### Description

## Problem

`commit_batch_changes` in `crates/orbit-engine/src/executor/automation/vcs/commit/mod.rs:202-206` currently produces a hardcoded commit message of the form:

```
feat: parallel batch [ORB-00102]

Tasks:
- ORB-00102: <task title>
```

This is unhelpful because:
- `feat:` is wrong for `Bug` and `Refactor` tasks (no Conventional Commits type derivation).
- "parallel batch" describes the shipper, not the change.
- The actual task title is buried in a bullet list, even though every batch now contains exactly one task.
- There is no `why` body; `task.execution_summary` is available but unused.
- Authorship metadata (`planned_by`, `implemented_by`) is not surfaced as Git trailers.

## Why It Matters

Commit messages are the durable record. Today every shipped commit looks identical in `git log --oneline`. Cross-engineer reviewers, release-note builders, and `git log --grep` workflows all suffer.

## Constraints / Notes

- **Single-task batches only.** Going forward `commit_batch_changes` receives N=1 by construction. The implementation should assert this and not retain N>1 fallback paths.
- **No LLM generation.** The commit message must be derived deterministically from task artifact fields. No external calls, no synthesis.
- **Keep per-task path unchanged.** `task_commit_message` and `finalize_commit_message` in `commit/message.rs` are out of scope. Reuse `execution_summary_paragraph` (already in `message.rs`).
- **Honor CLAUDE.md tagging.** External refs stay in the subject line as `[<SYSTEM_UPPER>-<id>]` after `[ORB-id]` — this preserves the cross-engineer-reviewer ergonomics documented in CLAUDE.md ("cross-engineer reviewers resolve the external tag, not the Orbit one").
- **Use raw `planned_by` / `implemented_by` field values** in trailers — per project convention these are already family names (`codex`, `claude`, `gemini`, `grok`); no normalization at the message site.
- **Truncation budget** of 72 chars applies to the `<type>: <title…>` portion only. `[ORB-id]` and external ref tags spill past 72 without counting against the budget.
- **Simplify author derivation:** since every batch is single-task, replace `commit_author_for_tasks` + `append_co_author_trailers` with `git_author_for_task` (same helper used by the `per_task` scope). The Co-Authored-By branch in this path is dead code once N=1.
- **Related prior art:** ORB-00090 (commit tagging conventions), ORB-00088 (per-family author identity). Neither overlaps directly.

## Template

```
<type>: <title_truncated_to_72>… [ORB-id] [EXT-id]...

<full_title>                       # only present if subject was truncated

<execution_summary_paragraph>      # only present if non-empty

Planned-By: <planned_by>           # raw value; omit line if None
Implemented-By: <implemented_by>   # raw value; omit line if None
```

Type mapping: `Feature → feat`, `Bug → fix`, `Refactor → refactor`, `Chore → chore`.

## Out of Scope

- `per_task` and `per_task_finalize` message builders.
- CLAUDE.md edits (external-ref-in-subject convention already matches).
- A lint rule for max task title length — separate concern.
- Migration of historical commit messages.

### Acceptance Criteria

- A new helper (e.g. `batch_commit_message`) lives in `crates/orbit-engine/src/executor/automation/vcs/commit/message.rs` and takes `&Task`, returning the formatted commit message string per the template in the description.
- Subject line begins with `<type>: ` where `<type>` is derived from `task.task_type`: `Feature → feat`, `Bug → fix`, `Refactor → refactor`, `Chore → chore`. Verified by a parameterized unit test covering all four variants.
- Subject's `<type>: <title…>` portion is ≤72 chars. Titles longer than the available budget are truncated with a single `…` (U+2026) suffix. `[ORB-id]` and external ref tags are appended after the truncated subject and do not count against the 72-char budget. Verified by unit tests: (a) short title passes through unchanged, (b) 145-char title truncates with ellipsis.
- When and only when the subject was truncated, the full untruncated title appears as the first line of the commit body (separated from the subject by a blank line). Verified by unit tests for both truncated and non-truncated cases.
- External refs on the task appear in the subject in declaration order, formatted as `[<SYSTEM_UPPERCASE>-<id>]` after `[ORB-id]`, space-separated. Verified by a unit test with two external_refs (e.g. `eng` and `jira` systems).
- When `task.execution_summary` contains a parseable summary section (per the existing `execution_summary_paragraph` extractor in `message.rs`), the extracted paragraph appears in the body — after the optional full-title line if present, separated by a blank line. Verified by unit tests with summary present and absent.
- Trailer block at the end of the message contains `Planned-By: <planned_by>` and/or `Implemented-By: <implemented_by>` using the raw field values, separated from the body by exactly one blank line. Each trailer line is omitted when its field is `None`. Verified by unit tests covering: both present, only one present, neither present.
- `commit_batch_changes` in `crates/orbit-engine/src/executor/automation/vcs/commit/mod.rs` is simplified to: (a) assert/error when `batch_tasks.len() != 1`, (b) call the new `batch_commit_message` helper, (c) use `git_author_for_task` (not `commit_author_for_tasks`), (d) no longer call `append_co_author_trailers`. The existing batch-scope integration test `git_commit_mixed_implementer_batch_uses_aggregate_identity_with_trailers` is either updated to reflect single-task semantics or removed if obsolete; if removed, justification is in the PR description.
- An end-to-end test in `commit/mod.rs` (parallel to `git_commit_uses_scoped_identity_without_mutating_local_human_config`) drives `git_commit` with `scope: "all"` on a single `Task` whose `task_type = Bug`, title > 72 chars, one external_ref, `planned_by = Some("codex")`, `implemented_by = Some("claude")`, and a non-empty `execution_summary` Summary section. Test asserts the resulting `git log -1 --format=%B` matches the full templated message exactly.
- `make ci-fast` passes locally before the task moves to `review`.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Added deterministic batch commit message generation from task fields, including conventional type mapping, 72-character subject-title truncation with ellipsis, external-ref tags, execution-summary body text, and raw Planned-By / Implemented-By trailers.
- Simplified scope=all batch commits to require exactly one task, reuse per-task author selection, and drop aggregate co-author trailer handling from that path.
- Replaced the obsolete mixed-implementer batch test with single-task message and multi-task rejection coverage, plus focused unit tests for the message helper.

Assessment: Targeted commit tests and make ci-fast pass locally.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-00107-6a096b76`
- Behind base: 0
- Ahead of base: 1