### PR TITLE
Dashboard responsiveness breaks at mid-width: overflowing crew select, cramped filter chips, truncated log column

### DIFF
--- a/crates/orbit-cli/assets/dashboard/index.html
+++ b/crates/orbit-cli/assets/dashboard/index.html
@@ -229,6 +229,7 @@
         display: flex;
         gap: 6px;
         flex-wrap: wrap;
+        max-width: 480px;
       }
       
       .chip {
@@ -366,6 +367,7 @@
       .task-crew-select {
         width: 100%;
         min-width: 0;
+        max-width: 100%;
         height: 28px;
         border: 1px solid var(--border);
         border-radius: 2px;
@@ -374,6 +376,8 @@
         font-size: 11px;
         padding: 4px 24px 4px 8px;
         outline: none;
+        overflow: hidden;
+        text-overflow: ellipsis;
       }
       .task-crew-select:hover:not(:disabled),
       .task-crew-select:focus {
@@ -411,6 +415,7 @@
         .row .priority { grid-area: priority; text-align: left; }
         .row .type { grid-area: type; text-align: left; }
         .row .crew-cell { grid-area: crew; align-self: stretch; }
+        #task-filter { max-width: none; }
       }
 
       @media (max-width: 520px) {
@@ -1920,7 +1925,7 @@
       }
       .log-line {
         display: grid;
-        grid-template-columns: 64px 72px 36px minmax(0, 1fr);
+        grid-template-columns: 64px 72px 42px minmax(120px, 1fr);
         gap: 10px;
         padding: 0 16px;
         font-size: 11.5px; line-height: 22px;


### PR DESCRIPTION
## Task

[ORB-00113](https://orbit-cli.com/tasks/ORB-00113) — Dashboard responsiveness breaks at mid-width: overflowing crew select, cramped filter chips, truncated log column

### Description

## Problem

At narrow-desktop / tablet viewport widths (roughly 600–1250px, before the single-column breakpoint at `@media (max-width: 1250px)` in [crates/orbit-cli/assets/dashboard/index.html:138](crates/orbit-cli/assets/dashboard/index.html:138)), the web dashboard layout has three visible defects:

1. **Crew `<select>` overflows the task card.** The control built in [`buildCrewUpdateControl`](crates/orbit-cli/assets/dashboard/app.js:843) renders `default: <crew name>` (e.g. `default: opus`) at its natural width and visually escapes the proposed-task card, producing the orphaned `default: opu…` tooltip-like fragment seen overlapping `ORB-00112`. The select needs to be constrained to its cell with `min-width: 0` / `max-width: 100%` and proper ellipsis behavior on the rendered option text.
2. **Filter chips wrap onto multiple rows in a column.** `#task-filter` (index.html ~line 228) is `display: flex; flex-wrap: wrap` with no `max-width` discipline; combined with the narrow `col-side` column on the left, the chips (`ALL`, `IN-PROGRESS`, `REVIEW`, `BLOCKED`, `PROPOSED`, `BACKLOG`, `SOMEDAY`) stack 1-per-row and dominate vertical space.
3. **`ORBIT.LOG` body column is too narrow to be readable.** The middle column of the log row (the source label) reserves enough space that the message column ends up as `unk…`, making the panel useless at this width. The right-hand side panel (`grid-template-columns: minmax(0, 2.5fr) minmax(0, 1fr)` at index.html:131) gets squeezed to ~1fr of a narrow window and the inner log row needs its own grid to be revisited.

Screenshot evidence: user-supplied capture shows all three defects simultaneously at a width below the 1250px breakpoint but above the implicit narrow-mobile thresholds.

## Why It Matters

The dashboard is the primary UI surface humans use to triage Orbit tasks and watch agent activity. At common laptop split-screen widths (e.g. 1280px × half-width ≈ 640px) it currently fails to deliver the two things it exists to do: show task metadata and stream logs. This is a low-effort, high-visibility polish task.

## Constraints / Notes

- Preserve the existing single-column collapse at `max-width: 1250px` ([index.html:138](crates/orbit-cli/assets/dashboard/index.html:138)) — the fix should improve the *band below* that breakpoint, not move it.
- Preserve the row-level responsive grid already present at `max-width: 760px` and `max-width: 520px` ([index.html:401, 416](crates/orbit-cli/assets/dashboard/index.html:401)) and the ellipsis-truncation contract from ORB-00097 on `.row .id` / `.row .title`.
- Do not regress the desktop layout at ≥1250px or the mobile layout at ≤520px.
- The crew `<select>` already has `class="task-crew-select mono"`; constrain via CSS, not by mutating the option text.
- This is a static-asset change in `crates/orbit-cli/assets/dashboard/`; no Rust crate changes expected. Skip `make build` per the project doc-change convention.

### Acceptance Criteria

- At viewport widths between 600px and 1250px, the crew `<select>` (`.task-crew-select`) is fully contained inside its task-row cell — verified by loading the dashboard, resizing the window to 900px wide, and confirming no `default: <crew>` text visually escapes the task card or overlaps adjacent rows.
- The `#task-filter` chip row at viewport widths between 600px and 1250px wraps to at most 2 rows total (not 1-chip-per-row), verified visually with the standard set of 7 filter chips (`ALL`, `IN-PROGRESS`, `REVIEW`, `BLOCKED`, `PROPOSED`, `BACKLOG`, `SOMEDAY`).
- At viewport widths between 600px and 1250px, the `ORBIT.LOG` message column shows at least the first 12 characters of the log message before any ellipsis — verified by inspecting a rendered log row in DevTools and confirming the message cell is wider than the source/level cells combined.
- Desktop layout at ≥1250px is visually unchanged: `main` keeps its `minmax(0, 2.5fr) minmax(0, 1fr)` two-column grid, and tasks panel + side column render at their current proportions (verified by before/after screenshot at 1440px).
- Mobile layout at ≤520px remains unchanged: row-level `grid-template-areas` collapse from [index.html:416–420](crates/orbit-cli/assets/dashboard/index.html:416) still applies, and `.row .id` / `.row .title` keep the ORB-00097 ellipsis truncation behavior.
- Change is confined to `crates/orbit-cli/assets/dashboard/index.html` and/or `crates/orbit-cli/assets/dashboard/app.js`; no Rust crates touched and `make ci-fast` passes.

## Execution Summary

<details>
<summary>Click to expand</summary>

Implemented responsive layout fixes for the dashboard at mid-width viewports. Constrained the `#task-filter` to `max-width: 480px` to prevent excessive vertical wrapping of chips, resetting it below 760px. Updated the `.task-crew-select` element with `max-width: 100%`, `overflow: hidden`, and `text-overflow: ellipsis` to stop it from overflowing its grid cell. Adjusted `.log-line` grid columns, giving the message column a `minmax(120px, 1fr)` width to ensure log readability on narrow screens without aggressive truncation. Verified existing mobile and desktop behaviors are preserved.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-00113-6a0a087f`
- Behind base: 0
- Ahead of base: 1