### PR TITLE
Dashboard: collapse two-column layout to single column at ~1000px viewport width

### DIFF
--- a/crates/orbit-cli/assets/dashboard/index.html
+++ b/crates/orbit-cli/assets/dashboard/index.html
@@ -135,7 +135,7 @@
         margin: 0 auto;
       }
       
-      @media (max-width: 1250px) {
+      @media (max-width: 1000px) {
         main { grid-template-columns: 1fr !important; }
       }
       


### PR DESCRIPTION
## Task

[ORB-00114](https://orbit-cli.com/tasks/ORB-00114) — Dashboard: collapse two-column layout to single column at ~1000px viewport width

### Description

## Problem

The web dashboard `main` grid uses a 2-column layout (`minmax(0, 2.5fr) minmax(0, 1fr)`) that collapses to single column only at `max-width: 1250px` ([crates/orbit-cli/assets/dashboard/index.html:131,138](crates/orbit-cli/assets/dashboard/index.html:131)). At viewport widths above that breakpoint but below ~1250px the two columns get squeezed enough that the side panels (LOCKED FILES, ORBIT.LOG) and the task rows both become cramped — overflowing controls, truncated log lines, chips wrapping awkwardly.

The simplest fix is to move the collapse threshold so the two-column layout only applies on screens that are actually wide enough to host it.

## Fix

Change the existing media-query breakpoint from `max-width: 1250px` to `max-width: 1000px` (or thereabouts — pick the value that makes the 2-column layout look correct on a standard 1280px+ laptop and collapses cleanly below that).

This is a one-line CSS change in [crates/orbit-cli/assets/dashboard/index.html](crates/orbit-cli/assets/dashboard/index.html) around line 138.

## Why It Matters

Dashboard is the primary human triage surface. At common split-screen widths the current breakpoint leaves users with a cramped 2-column view when a single-column view would be more usable.

## Constraints / Notes

- Do not change the desktop 2-column proportions (`minmax(0, 2.5fr) minmax(0, 1fr)`) or `max-width: 1800px` container.
- Do not touch the row-level `@media (max-width: 760px)` and `@media (max-width: 520px)` rules or the `.row-detail.split-layout` rule at `@media (max-width: 1000px)`.
- Static-asset only; no Rust crate changes. Skip `make build`.

### Acceptance Criteria

- The `@media (max-width: 1250px)` block in [crates/orbit-cli/assets/dashboard/index.html](crates/orbit-cli/assets/dashboard/index.html) that forces `main { grid-template-columns: 1fr !important; }` is updated to trigger at approximately 1000px viewport width.
- At viewport widths ≥1000px (e.g. 1280px laptop), `main` keeps the existing 2-column `minmax(0, 2.5fr) minmax(0, 1fr)` layout — verified visually.
- At viewport widths <1000px (e.g. resizing the browser narrower), `main` collapses to a single column — verified visually.
- No other CSS rules in `index.html` are modified; the change is a single breakpoint-value edit.
- `make ci-fast` passes.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Updated `crates/orbit-cli/assets/dashboard/index.html` so the global `main` grid collapse media query now uses `max-width: 1000px` instead of `1250px`.

Validation:
- `make ci-fast` passed.
- Headless Chrome layout check confirmed the global `main` rule renders two columns at 1280px and one column at 900px.
- `git diff --check` passed.

Assessment: Scoped one-line CSS breakpoint edit; no Rust build needed for this static asset change.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-00114-6a0a0d92`
- Behind base: 0
- Ahead of base: 1