### PR TITLE
Make `orbit run duel-plan` submit non-blocking by default

### DIFF
--- a/crates/orbit-cli/src/command/run/duel.rs
+++ b/crates/orbit-cli/src/command/run/duel.rs
@@ -14,7 +14,7 @@ const DUEL_PLAN_WORKFLOW: &str = "duel-plan";
 #[command(
     about = "Run a planning duel for one task",
     override_usage = "orbit run duel-plan <TASK_ID> [OPTIONS]",
-    after_help = "Examples:\n  orbit run duel-plan T20260409-0310\n  orbit run duel-plan T20260409-0310 --base main --json"
+    after_help = "Examples:\n  orbit run duel-plan T20260409-0310\n  orbit run duel-plan T20260409-0310 --base main --json\n  orbit run duel-plan T20260409-0310 --wait\n\nBy default this submits the planning-duel pipeline and returns a run ID immediately. Use `orbit run show <RUN_ID>` to inspect it, or pass `--wait` to block until it finishes."
 )]
 pub struct DuelPlanCommand {
     /// Task ID for the planning duel.
@@ -23,6 +23,9 @@ pub struct DuelPlanCommand {
     /// `[workflow] base_branch` from `config.toml` (or `main` if unset).
     #[arg(short = 'b', long)]
     pub base: Option<String>,
+    /// Wait for the planning-duel pipeline to finish before returning.
+    #[arg(long)]
+    pub wait: bool,
     /// Output as JSON.
     #[arg(long)]
     pub json: bool,
@@ -31,7 +34,14 @@ pub struct DuelPlanCommand {
 impl Execute for DuelPlanCommand {
     fn execute(self, runtime: &OrbitRuntime) -> Result<(), OrbitError> {
         let plan = build_duel_plan_run_plan(&self, runtime.workflow_base_branch())?;
-        let runs = dispatch_workflow(runtime, plan.workflow_alias, &plan.input, false, true, 1)?;
+        let runs = dispatch_workflow(
+            runtime,
+            plan.workflow_alias,
+            &plan.input,
+            false,
+            plan.wait_for_completion,
+            1,
+        )?;
         print_workflow_dispatch_results(plan.workflow_alias, &runs, self.json)
     }
 }
@@ -40,6 +50,7 @@ impl Execute for DuelPlanCommand {
 pub(crate) struct DuelPlanRunPlan {
     pub workflow_alias: &'static str,
     pub input: Value,
+    pub wait_for_completion: bool,
 }
 
 pub(crate) fn build_duel_plan_run_plan(
@@ -57,26 +68,32 @@ pub(crate) fn build_duel_plan_run_plan(
             "task_ids": [args.task_id.clone()],
             "base_branch": base,
         }),
+        wait_for_completion: args.wait,
     })
 }
 
 #[cfg(test)]
 mod tests {
+    use std::time::{Duration, Instant};
+
+    use orbit_core::OrbitRuntime;
     use serde_json::json;
 
     use super::*;
 
+    fn duel_plan_args(base: Option<&str>, wait: bool) -> DuelPlanCommand {
+        DuelPlanCommand {
+            task_id: "T20260425-2010".to_string(),
+            base: base.map(str::to_string),
+            wait,
+            json: false,
+        }
+    }
+
     #[test]
     fn duel_plan_uses_explicit_base_when_flag_set() {
-        let plan = build_duel_plan_run_plan(
-            &DuelPlanCommand {
-                task_id: "T20260425-2010".to_string(),
-                base: Some("main".to_string()),
-                json: false,
-            },
-            "agent-main",
-        )
-        .expect("build duel-plan run plan");
+        let plan = build_duel_plan_run_plan(&duel_plan_args(Some("main"), false), "agent-main")
+            .expect("build duel-plan run plan");
 
         assert_eq!(plan.workflow_alias, DUEL_PLAN_WORKFLOW);
         assert_eq!(
@@ -91,15 +108,8 @@ mod tests {
 
     #[test]
     fn duel_plan_falls_back_to_config_base_when_flag_absent() {
-        let plan = build_duel_plan_run_plan(
-            &DuelPlanCommand {
-                task_id: "T20260425-2010".to_string(),
-                base: None,
-                json: false,
-            },
-            "agent-main",
-        )
-        .expect("build duel-plan run plan");
+        let plan = build_duel_plan_run_plan(&duel_plan_args(None, false), "agent-main")
+            .expect("build duel-plan run plan");
 
         assert_eq!(
             plan.input,
@@ -109,5 +119,72 @@ mod tests {
                 "base_branch": "agent-main",
             })
         );
+    }
+
+    #[test]
+    fn duel_plan_dispatch_defaults_to_non_blocking() {
+        let plan = build_duel_plan_run_plan(&duel_plan_args(None, false), "agent-main")
+            .expect("build duel-plan run plan");
+
+        assert!(!plan.wait_for_completion);
+    }
+
+    #[test]
+    fn duel_plan_wait_flag_requests_blocking_dispatch() {
+        let plan = build_duel_plan_run_plan(&duel_plan_args(None, true), "agent-main")
+            .expect("build duel-plan run plan");
+
+        assert!(plan.wait_for_completion);
+    }
+
+    #[test]
+    fn default_duel_plan_dispatch_returns_submitted_run_identity() {
+        let runtime = OrbitRuntime::in_memory().expect("build runtime");
+        let jobs_dir = runtime.data_root().join("resources/jobs");
+        std::fs::create_dir_all(&jobs_dir).expect("create jobs dir");
+        std::fs::write(
+            jobs_dir.join("job_duel_plan_pipeline.yaml"),
+            r#"schemaVersion: 2
+kind: Job
+metadata:
+  name: job_duel_plan_pipeline
+spec:
+  state: enabled
+  kind: workflow
+  steps:
+    - id: marker
+      spec:
+        type: deterministic
+        action: sleep
+        config:
+          seconds: 0
+"#,
+        )
+        .expect("write job_duel_plan_pipeline fixture");
+        let plan = build_duel_plan_run_plan(&duel_plan_args(None, false), "agent-main")
+            .expect("build duel-plan run plan");
+
+        let started = Instant::now();
+        let runs = dispatch_workflow(
+            &runtime,
+            plan.workflow_alias,
+            &plan.input,
+            false,
+            plan.wait_for_completion,
+            1,
+        )
+        .expect("dispatch duel-plan workflow");
+
+        assert!(
+            started.elapsed() < Duration::from_secs(1),
+            "default duel-plan dispatch waited too long"
+        );
+        assert_eq!(runs.len(), 1);
+        assert_eq!(runs[0].workflow_alias, DUEL_PLAN_WORKFLOW);
+        assert_eq!(runs[0].job_id, "job_duel_plan_pipeline");
+        assert!(matches!(runs[0].state.as_str(), "submitted" | "queued"));
+        assert_eq!(runs[0].attempt, 1);
+        assert!(runs[0].error_code.is_none());
+        assert!(runs[0].error_message.is_none());
     }
 }

--- a/crates/orbit-cli/src/command/run/mod.rs
+++ b/crates/orbit-cli/src/command/run/mod.rs
@@ -212,6 +212,19 @@ mod tests {
             RunSubcommand::DuelPlan(args) => {
                 assert_eq!(args.task_id, "T1");
                 assert_eq!(args.base.as_deref(), Some("main"));
+                assert!(!args.wait);
+            }
+            _ => panic!("expected duel-plan"),
+        }
+    }
+
+    #[test]
+    fn parses_duel_plan_wait_flag() {
+        let command = parse_run(&["orbit", "run", "duel-plan", "T1", "--wait"]);
+        match command.command {
+            RunSubcommand::DuelPlan(args) => {
+                assert_eq!(args.task_id, "T1");
+                assert!(args.wait);
             }
             _ => panic!("expected duel-plan"),
         }

--- a/website/src/content/docs/getting-started/workflows.md
+++ b/website/src/content/docs/getting-started/workflows.md
@@ -24,12 +24,15 @@ Underlying job: `task_auto_pipeline`, which fans into `task_gate_pipeline` and t
 
 ## `orbit run duel-plan`
 
-Run a planning duel for a single task: two planner agents draft proposals independently, an arbiter picks the winner, and the winning plan lands on the task.
+Submit a planning duel for a single task: two planner agents draft proposals independently, an arbiter picks the winner, and the winning plan lands on the task. The command returns a run ID immediately by default; pass `--wait` when you want the terminal to block until the duel finishes and report the terminal wait status.
 
 ```bash
 orbit run duel-plan T20260506-1
 orbit run duel-plan T20260506-1 --base main --json
+orbit run duel-plan T20260506-1 --wait
 ```
+
+Default text output includes `Workflow`, `Job ID`, `Run ID`, `State`, and an `Inspect:` command. JSON output returns the submitted dispatch result with `workflow`, `job_id`, `run_id`, `state`, and `attempt` fields.
 
 Underlying job: `job_duel_plan_pipeline`. Outcomes are recorded on the planning-duel scoreboard.
 
@@ -49,6 +52,7 @@ Every workflow run is durable. Inspect with:
 
 ```bash
 orbit run history -j task_auto_pipeline
+orbit run history -j job_duel_plan_pipeline
 orbit run show <RUN_ID>
 orbit run logs <RUN_ID>
 ```

--- a/website/src/content/docs/reference/cli.md
+++ b/website/src/content/docs/reference/cli.md
@@ -20,7 +20,8 @@ sidebar:
 | `orbit run job <job_id>` | Run an arbitrary job by ID. |
 | `orbit run ship [task_id ...]` | Submit backlog or explicitly selected tasks through the gated shipment pipeline and return a run ID immediately. |
 | `orbit run ship --mode local [task_id ...]` | Run the local-only task path for backlog or explicitly selected tasks. |
-| `orbit run duel-plan <task_id>` | Run a planning duel for one task. |
+| `orbit run duel-plan <task_id>` | Submit a planning duel for one task and return a run ID immediately. |
+| `orbit run duel-plan <task_id> --wait` | Submit a planning duel and wait for its terminal status before returning. |
 | `orbit task` | Create, update, and manage tasks. |
 | `orbit task artifact put <task_id> <source_path>` | Store a UTF-8 file under a task's artifacts directory. |
 


### PR DESCRIPTION
## Task

[ORB-00125](https://orbit-cli.com/tasks/ORB-00125) — Make `orbit run duel-plan` submit non-blocking by default

### Description

## Problem
`orbit run duel-plan <TASK_ID>` currently dispatches the persisted `duel-plan` workflow with `wait_for_completion = true`, so the CLI can block for the whole planning duel instead of returning the durable run ID immediately. This differs from `orbit run ship`, which submits the pipeline and tells the user how to inspect it.

## Why It Matters
Planning duels can take a long time and should not occupy the caller terminal by default. Non-blocking submission makes the command friendlier for humans and scripts while preserving durable job-run inspection through `orbit run history`, `orbit run show`, logs, events, and trace.

## Constraints / Notes
- Make the default `orbit run duel-plan <TASK_ID>` behavior submit `job_duel_plan_pipeline` and return run metadata immediately.
- Preserve JSON output using the existing workflow dispatch result shape where practical.
- Preserve the old blocking behavior behind an explicit opt-in flag such as `--wait`.
- Update CLI help and workflow docs so users know to inspect the returned run ID.
- Keep the change within the existing persisted workflow/pipeline-run architecture; do not introduce new cross-crate dependencies.

### Acceptance Criteria

- `cargo test -p orbit-cli run::duel` passes with targeted coverage showing default `DuelPlanCommand` dispatch requests non-blocking execution and `--wait` requests blocking execution.
- A default `orbit run duel-plan <TASK_ID>` invocation returns after pipeline submission with `Workflow`, `Job ID`, `Run ID`, `State: submitted` or `State: queued`, and an `Inspect:` command, rather than waiting for the planning-duel pipeline to finish.
- `orbit run duel-plan <TASK_ID> --json` returns the submitted workflow dispatch result with `workflow`, `job_id`, `run_id`, `state`, and `attempt` fields without waiting for terminal pipeline status.
- `orbit run duel-plan <TASK_ID> --wait` retains the previous blocking behavior and reports the terminal wait status for the run.
- `orbit run duel-plan --help`, `website/src/content/docs/getting-started/workflows.md`, and `website/src/content/docs/reference/cli.md` document the non-blocking default and the explicit wait option.
- `make ci-fast` passes before moving the task to review.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Added a `--wait` flag to `orbit run duel-plan` and changed default dispatch to submit the persisted `duel-plan` workflow without waiting for completion.
- Carried the wait/non-wait choice through the duel-plan run plan and added unit coverage for non-blocking default dispatch, `--wait` blocking intent, and parser handling.
- Updated CLI help and website workflow/reference docs to describe immediate run-ID submission, JSON dispatch metadata, inspection commands, and explicit `--wait`.

Assessment: Targeted CLI tests and repository fast checks pass; the change stays within the existing persisted workflow dispatch path.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-00125-6a0a1f98`
- Behind base: 0
- Ahead of base: 1