### PR TITLE
Make the Orbit workspace pass the full `make ci` gate cleanly (clippy -D warnings, tests, docs, guardrails)

### DIFF
--- a/crates/orbit-core/src/command/job/run/mod.rs
+++ b/crates/orbit-core/src/command/job/run/mod.rs
@@ -7,8 +7,6 @@
 //! - `owner` — process signalling, owner identity classification, liveness probes (Unix + shims).
 //! - `tests/*` — helpers and regression tests split by concern (cancel, reconcile, owner identity).
 
-pub(crate) use crate::OrbitRuntime;
-
 mod actions;
 mod owner;
 mod query;

--- a/crates/orbit-core/src/command/job/run/query.rs
+++ b/crates/orbit-core/src/command/job/run/query.rs
@@ -1,6 +1,5 @@
 //! Query, list, show, and history methods for job runs, with reconciliation.
 
-use chrono::Utc;
 use orbit_common::types::{JobRun, NotFoundKind, OrbitError};
 use orbit_store::JobRunQuery;
 

--- a/crates/orbit-core/src/command/job/run/tests/cancel.rs
+++ b/crates/orbit-core/src/command/job/run/tests/cancel.rs
@@ -1,6 +1,5 @@
 //! Cancellation behavior and process-group cancellation tests.
 
-use super::super::*;
 use super::*;
 
 #[cfg(unix)]

--- a/crates/orbit-core/src/command/job/run/tests/mod.rs
+++ b/crates/orbit-core/src/command/job/run/tests/mod.rs
@@ -10,8 +10,6 @@ use chrono::{DateTime, Utc};
 use orbit_common::types::{JobRun, JobRunState};
 use tempfile::tempdir;
 
-use super::super::*; // OrbitRuntime, JobRunState, etc. (pub items + reexports)
-
 pub(crate) fn test_runtime() -> (tempfile::TempDir, OrbitRuntime) {
     let root = tempdir().expect("create tempdir");
     let global_root = root.path().join("global");

--- a/crates/orbit-core/src/command/job/run/tests/owner_identity.rs
+++ b/crates/orbit-core/src/command/job/run/tests/owner_identity.rs
@@ -1,12 +1,11 @@
 //! Timezone and probe-outcome regression coverage for owner identity classification.
 
-use super::super::*;
 use super::*;
 
+use super::super::JobRunListParams;
+
 #[cfg(unix)]
-use super::super::owner::{
-    OwnerIdentity, classify_run_owner_with_probes, process_is_alive, stale_job_run_message,
-};
+use super::super::owner::{OwnerIdentity, classify_run_owner_with_probes, stale_job_run_message};
 use chrono::{Duration, Utc};
 use orbit_common::types::JobRunState;
 #[cfg(unix)]
@@ -15,10 +14,6 @@ use orbit_common::utility::process_identity::ProbeOutcome;
 use orbit_common::utility::process_identity::{STABLE_TOKEN_PREFIX, process_start_identity_token};
 #[cfg(unix)]
 use std::process::{Command, Stdio};
-#[cfg(unix)]
-use std::time::Duration as StdDuration;
-#[cfg(unix)]
-use tempfile::tempdir;
 
 static TZ_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 

--- a/crates/orbit-core/src/command/job/run/tests/reconcile.rs
+++ b/crates/orbit-core/src/command/job/run/tests/reconcile.rs
@@ -1,6 +1,5 @@
 //! Stale read/list behavior and terminal timing repair tests.
 
-use super::super::*;
 use super::*;
 
 use super::super::JobRunListParams;

--- a/crates/orbit-exec/src/macos_sandbox/compile.rs
+++ b/crates/orbit-exec/src/macos_sandbox/compile.rs
@@ -151,7 +151,8 @@ pub(super) fn compile_macos_sandbox_profile_with_env(
 #[cfg(test)]
 mod tests {
     use super::super::test_support::*;
-    use super::*;
+    #[cfg(target_os = "macos")]
+    use super::compile_macos_sandbox_profile;
     #[cfg(target_os = "macos")]
     use orbit_common::types::ResolvedFsProfile;
     #[test]

--- a/crates/orbit-exec/src/macos_sandbox/provider_dirs.rs
+++ b/crates/orbit-exec/src/macos_sandbox/provider_dirs.rs
@@ -177,7 +177,5 @@ fn emit_grok_json_file_allow(state_dir: &Path, file_name: &str, out: &mut String
 /// the kernel may lose the profile mid-run.
 /// When `cwd` is set, it is applied to the outer `sandbox-exec` wrapper and
 /// inherited by the wrapped child.
-///
-
 #[cfg(test)]
 mod tests;

--- a/crates/orbit-store/src/file/learning_store/api/crud_tests.rs
+++ b/crates/orbit-store/src/file/learning_store/api/crud_tests.rs
@@ -1,15 +1,11 @@
 //! CRUD-focused tests for LearningFileStore (split from monolithic api.rs per ORB-00116).
 
-use chrono::{DateTime, TimeZone, Utc};
-use orbit_common::types::{
-    EvidenceKind, LearningEvidence, LearningScope, LearningStatus, NotFoundKind, OrbitError,
-};
+use chrono::{TimeZone as _, Utc};
+use orbit_common::types::{EvidenceKind, LearningEvidence, LearningScope, LearningStatus};
 use tempfile::tempdir;
 
 use super::store::LearningFileStore;
-use super::test_support::{
-    create_params, legacy_learning_yaml, line_count, set_half_life_env, store_with_index,
-};
+use super::test_support::{create_params, store_with_index};
 use crate::Store;
 use crate::backend::{LearningCreateParams, LearningSearchParams, LearningUpdateParams};
 

--- a/crates/orbit-store/src/file/learning_store/api/lifecycle_tests.rs
+++ b/crates/orbit-store/src/file/learning_store/api/lifecycle_tests.rs
@@ -1,6 +1,6 @@
 //! Lifecycle (supersede/archive/delete) tests split per ORB-00116.
 
-use orbit_common::types::{LearningStatus, OrbitError};
+use orbit_common::types::LearningStatus;
 use tempfile::tempdir;
 
 use super::super::record::read_learning_file;

--- a/crates/orbit-store/src/file/learning_store/api/search_index_tests.rs
+++ b/crates/orbit-store/src/file/learning_store/api/search_index_tests.rs
@@ -4,8 +4,7 @@ use std::time::Instant;
 
 use orbit_common::types::LearningScope;
 
-use super::store::LearningFileStore;
-use super::test_support::{create_params, store_with_index};
+use super::test_support::store_with_index;
 use crate::backend::{LearningCreateParams, LearningSearchParams};
 
 #[test]

--- a/crates/orbit-store/src/file/learning_store/api/test_support.rs
+++ b/crates/orbit-store/src/file/learning_store/api/test_support.rs
@@ -1,10 +1,10 @@
 // Shared test fixtures and helpers for the split learning_store/api test suite.
 // Keep this file small; individual *_tests.rs pull only what they need.
 
-use std::sync::{Arc, Mutex, MutexGuard, OnceLock};
+use std::sync::{Mutex, MutexGuard, OnceLock};
 
 use crate::backend::{LearningCommentAddParams, LearningCreateParams, LearningUpvoteParams};
-use chrono::{DateTime, TimeZone, Utc};
+use chrono::{DateTime, Utc};
 use orbit_common::types::{LearningScope, LearningVoteRow};
 use tempfile::{TempDir, tempdir};
 

--- a/crates/orbit-store/src/file/learning_store/api/vote_ops_tests.rs
+++ b/crates/orbit-store/src/file/learning_store/api/vote_ops_tests.rs
@@ -3,11 +3,11 @@
 use std::sync::Arc;
 use std::thread;
 
-use chrono::{DateTime, TimeZone, Utc};
+use chrono::{TimeZone as _, Utc};
 use orbit_common::types::{NotFoundKind, OrbitError};
 
 use super::super::layout::votes_jsonl_path;
-use super::super::votes::{append_vote_row, read_vote_rows};
+use super::super::votes::append_vote_row;
 use super::store::LearningFileStore;
 use super::test_support::{
     create_params, line_count, set_half_life_env, store_with_index, upvote_params, vote_row,


### PR DESCRIPTION
## Task

[ORB-00128](https://orbit-cli.com/tasks/ORB-00128) — Make the Orbit workspace pass the full `make ci` gate cleanly (clippy -D warnings, tests, docs, guardrails)

### Description

## Problem

The canonical merge gate is `make ci` (defined in `scripts/ci-guardrails.sh` and executed on every PR via `.github/workflows/ci.yml`).

Running the exact CI lint command (`cargo clippy --workspace --all-targets -- -D warnings`) currently produces 11 hard errors that abort the build:

**orbit-store (10 unused import errors in `learning_store/api/` test modules):**
- `crud_tests.rs:3,5,11`
- `lifecycle_tests.rs:3`
- `search_index_tests.rs:7,8`
- `test_support.rs:4,7`
- `vote_ops_tests.rs:6,10`

**orbit-exec (1 lint error):**
- `macos_sandbox/provider_dirs.rs:180` — `clippy::empty_line_after_doc_comments`

(Full per-error file:line list is in the task comments.)

These (plus any additional issues that surface after the first wave is fixed) cause `make ci` to fail because the guardrail runs clippy, nextest, doc tests, and rustdoc all under `-D warnings`.

`make ci-fast` (fmt-check + the four guardrail scripts) currently passes cleanly.

## Why It Matters

- Every PR is blocked until the GitHub "CI" check is green.
- The project strictly treats warnings as errors (`-D warnings`).
- Dead imports and small formatting nits accumulate and create repeated friction.

## Scope

Drive the workspace to a state where the full `./scripts/ci-guardrails.sh` (equivalently `make ci`) passes with exit 0, and a PR targeting `agent-main` shows a green CI status.

## Constraints / Notes
- Minimal, obvious fixes only (delete unused imports, remove the stray blank line after the doc comment).
- No new `#[allow(...)]` attributes without a justification comment and review discussion.
- Platform differences (macOS dev vs Linux CI) must be handled correctly.
- `make ci-fast` must stay green after every change.

### Acceptance Criteria

- `make ci-fast` passes with exit 0 (fmt-check + four guardrail scripts)
- `./scripts/ci-guardrails.sh` completes with exit 0 (runs fmt --check, clippy -D warnings, nextest, doc tests, rustdoc -D warnings, and the four guardrails)
- `cargo clippy --workspace --all-targets -- -D warnings` produces no warnings or errors
- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --workspace` succeeds with no warnings
- A GitHub PR targeting `agent-main` shows a green "Check / Clippy / Test" (CI) status check
- No new `#[allow(...)]` or `#[allow(clippy::...)]` attributes are added without an accompanying justification comment and review-thread discussion

## Execution Summary

<details>
<summary>Click to expand</summary>

Fixed 11+ clippy unused-import and empty_line_after_doc_comments errors blocking `make ci` / `./scripts/ci-guardrails.sh`.

- Deleted dead imports in 5 learning_store/api/*_tests.rs and test_support.rs (per exact list in task comments).
- Replaced named `TimeZone` with `TimeZone as _` in dispatch sites (crud_tests, vote_ops_tests) to keep `Utc.with_ymd_and_hms` working while silencing unused_imports.
- Removed orphaned doc comment + stray blank line in provider_dirs.rs:180 (also fixed potential rustdoc issues).
- Removed dead re-export in orbit-core/command/job/run/mod.rs:10 and stray Utc in query.rs:3.
- Replaced dead `use super::super::*;` globs + dead names in 4 test files under orbit-core/.../run/tests/ with minimal explicit imports (JobRunListParams only where referenced).

All changes are pure deletions or the `as _` idiom; no behavior change, no new allows.

Validation:
- `cargo clippy --workspace --all-targets -- -D warnings` : exit 0, 0 errors
- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --workspace` : exit 0
- `make ci-fast` : exit 0 (fmt + 4 guardrails)
- `cargo fmt -- --check` : clean

No learning added (tool IO denied in worktree); the TimeZone-as-_ + glob pitfalls are noted in thinking trace for future.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-00128-6a0a2c5a`
- Behind base: 0
- Ahead of base: 1