### PR TITLE
Fix sandbox write roots for activity-exposed Orbit tool stores

### DIFF
--- a/crates/orbit-core/src/runtime/v2_host/sandbox.rs
+++ b/crates/orbit-core/src/runtime/v2_host/sandbox.rs
@@ -150,10 +150,14 @@ fn append_codex_side_write_roots(
 ///
 /// Gemini and Claude do not have a codex-style `--add-dir` side channel, but
 /// their MCP/tool calls still execute `orbit ...` as a sandbox-inherited child.
-/// Those child processes initialize the global audit/tool database, the global
-/// task registry + canonical task bundles, and the workspace-local semantic
-/// index before a planner can persist `planning-duel/<slot>.md`.
-/// Keep the grants path-shaped instead of re-allowing the whole home directory.
+/// Those child processes initialize global logs/databases/tasks plus the
+/// workspace stores exposed by activity tool allowlists.
+///
+/// Inventory boundary: this list follows currently activity-exposed Orbit write
+/// tools. Registered-but-not-exposed stores such as ADRs and graph write roots
+/// stay denied until the corresponding tools are added to those activity
+/// allowlists. Keep the grants path-shaped instead of re-allowing the whole
+/// home directory or workspace `.orbit` tree.
 #[cfg(target_os = "macos")]
 fn append_orbit_child_runtime_write_roots(
     runtime: &OrbitRuntime,
@@ -178,7 +182,10 @@ fn append_orbit_child_runtime_write_roots(
         format!("{global}/orbit.db*"),
         format!("{global}/tasks/**"),
         format!("{workspace}/tasks/**"),
+        format!("{workspace}/learnings/**"),
+        format!("{workspace}/frictions/**"),
         format!("{workspace}/state/audit/**"),
+        format!("{workspace}/state/job-runs/**"),
         format!("{workspace}/state/logs/**"),
         format!("{workspace}/state/semantic.db*"),
     ] {
@@ -413,19 +420,36 @@ mod tests {
             .unwrap_or_else(|_| runtime.paths().orbit_dir.clone())
             .display()
             .to_string();
+        let workspace_orbit_deny = format!("!{workspace_orbit}/**");
+        let deny_pos = modify
+            .iter()
+            .position(|entry| entry == &workspace_orbit_deny)
+            .unwrap_or_else(|| {
+                panic!(
+                    "default policy should deny workspace .orbit writes via {workspace_orbit_deny}; modify={modify:?}"
+                )
+            });
         let expected = [
             format!("{global}/state/logs/**"),
             format!("{global}/orbit.db*"),
             format!("{global}/tasks/**"),
             format!("{workspace_orbit}/tasks/**"),
+            format!("{workspace_orbit}/learnings/**"),
+            format!("{workspace_orbit}/frictions/**"),
             format!("{workspace_orbit}/state/audit/**"),
+            format!("{workspace_orbit}/state/job-runs/**"),
             format!("{workspace_orbit}/state/logs/**"),
             format!("{workspace_orbit}/state/semantic.db*"),
         ];
         for root in expected {
+            let allow_pos = modify.iter().position(|entry| entry == &root);
             assert!(
-                modify.iter().any(|entry| entry == &root),
+                allow_pos.is_some(),
                 "gemini sandbox should allow Orbit runtime root {root}; modify={modify:?}"
+            );
+            assert!(
+                deny_pos < allow_pos.expect("root position checked above"),
+                "Orbit runtime root {root} must be re-allowed after workspace .orbit deny: {modify:?}"
             );
         }
         assert!(
@@ -436,6 +460,20 @@ mod tests {
             !modify.iter().any(|entry| entry == &workspace_orbit),
             "gemini sandbox must not re-allow the whole workspace .orbit root: {modify:?}"
         );
+        // Registered-but-not-activity-exposed write stores are intentionally
+        // outside this child-runtime inventory. If agent_implement, agent_review,
+        // step_failure_recovery, or dispatch_agent exposes ADR or graph write
+        // tools, revisit this allowlist alongside those surfaces.
+        for excluded in [
+            format!("{workspace_orbit}/adrs/**"),
+            format!("{workspace_orbit}/knowledge/**"),
+            format!("{workspace_orbit}/state/knowledge/**"),
+        ] {
+            assert!(
+                !modify.iter().any(|entry| entry == &excluded),
+                "gemini sandbox must not allow non-activity-exposed Orbit store {excluded}: {modify:?}"
+            );
+        }
     }
 
     #[cfg(target_os = "macos")]

--- a/docs/design/policy-sandbox/1_overview.md
+++ b/docs/design/policy-sandbox/1_overview.md
@@ -2,7 +2,7 @@
 
 **Status:** Draft
 **Owner:** claude
-**Last updated:** 2026-05-16
+**Last updated:** 2026-05-17
 
 > **Sandbox backend status.** The only OS-level sandbox backend implemented today is `macos-sandbox-exec`. `ExecutorSandboxKind` (`crates/orbit-common/src/types/executor_def.rs`) defines no Linux or Windows variant, and `EnvironmentHost::resolve_executor_sandbox` (`crates/orbit-core/src/runtime/v2_host/sandbox.rs`) rejects `macos-sandbox-exec` on non-macOS platforms. On Linux and Windows the spawned agent subprocess runs without OS-level isolation; HTTP-tool `fs.*` enforcement and process supervision still apply. A Linux backend is named in [3_vision.md](./3_vision.md) as future work but is not in `2_design.md`'s shipped contract. [T20260505-23]
 
@@ -40,6 +40,8 @@ When an activity omits `fsProfile:`, the v2 host uses `UNRESTRICTED_FS_PROFILE`.
 
 HTTP activities enforce policy in the `orbit-tools` `fs.*` builtins before any read or modify. Denials return `OrbitError::PolicyDenied` and emit audit events. CLI activities do not call those builtins; they rely on harness delegation plus the configured executor sandbox, currently macOS `sandbox-exec` for supported CLI agents.
 
+When the default policy denies workspace `.orbit/**`, the v2 host re-allows only the narrow child Orbit runtime stores needed by currently activity-exposed write tools. It does not blanket-allow workspace `.orbit`; newly exposed Orbit write tools must add their store roots intentionally.
+
 ### 2.5 Exec supervision is not default OS isolation
 
 `orbit-exec::run_process` spawns a process-group leader, drains stdout/stderr, installs SIGINT/SIGTERM handlers, and on timeout or signal sends SIGTERM to the group with a 5 second grace before SIGKILL. The default `Sandbox` impl remains `NoSandbox`; OS isolation is added by specific executor wrappers, not the default runner.
@@ -72,5 +74,6 @@ HTTP activities enforce policy in the `orbit-tools` `fs.*` builtins before any r
 - **[T20260426-0605]** — Add the auditability design folder cross-linked from §3.
 - **[T20260426-0622]** — Add this policy & sandboxing design folder under claude ownership.
 - **[T20260430-23]** — Shorten the policy sandbox design docs while preserving the shipped contract and ADR history.
+- **[ORB-00129]** — Keep child Orbit runtime write roots narrow under the macOS sandbox while supporting activity-exposed learning, friction, and job-run state tools.
 
 > Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.

--- a/docs/design/policy-sandbox/2_design.md
+++ b/docs/design/policy-sandbox/2_design.md
@@ -2,7 +2,7 @@
 
 **Status:** Draft
 **Owner:** claude
-**Last updated:** 2026-05-16
+**Last updated:** 2026-05-17
 
 This document describes Orbit's shipped policy and sandboxing implementation: v2 `PolicyDef`, profile resolution, last-match-wins path evaluation, HTTP-tool enforcement, activity/job `fsProfile` binding, macOS CLI sandbox wrapping, and `orbit-exec` supervision. See [1_overview.md](./1_overview.md) for purpose and [3_vision.md](./3_vision.md) for forward-looking gaps.
 
@@ -120,11 +120,14 @@ The macOS wrapper resolves `sandbox-exec` from trusted absolute locations only, 
 The compiled macOS profile denies by default, allows broad reads required by agent CLIs and system libraries, allows process/signal/ipc/network/sysctl/iokit operations, and allows writes to:
 
 - scratch/cache roots (`/tmp`, `/private/tmp`, `/private/var/folders`, `/dev`, `$HOME/Library/Caches`)
-- `$HOME/.orbit` for inherited Orbit subprocess audit/state
+- `$HOME/.orbit/state/logs` for early inherited Orbit subprocess logging before runtime root resolution
 - provider state dirs: Codex (`$CODEX_HOME` or `$HOME/.codex`), Claude (`$CLAUDE_CONFIG_DIR` or `$HOME/.claude`), Gemini (`$HOME/.gemini`), and Grok (`$HOME/.grok`)
 - Claude `$HOME/.claude.json` sibling files (`.claude.json`, `.claude.json.lock`, atomic-write `.claude.json.tmp.<pid>.<ms_ts>`) when `CLAUDE_CONFIG_DIR` is unset, since these live at the home root rather than under `$HOME/.claude/` ([T20260508-13])
 - positive `modify` roots from the resolved profile
 - Codex side-write roots from runtime provider config, appended after policy denies so workflow state remains writable under the outer sandbox
+- narrow child Orbit runtime roots appended by the v2 host after policy denies: global logs, global `orbit.db*`, global tasks, workspace `.orbit/tasks/**`, workspace `.orbit/learnings/**`, workspace `.orbit/frictions/**`, workspace audit/logs, workspace semantic DB sidecars, and workspace `.orbit/state/job-runs/**`
+
+The child Orbit runtime roots are deliberately narrower than the workspace `.orbit` tree. They cover stores used by currently activity-exposed Orbit write tools: task/review/artifact/duel writes under `.orbit/tasks/**`, learning curation under `.orbit/learnings/**`, friction reporting under `.orbit/frictions/**`, `orbit.state.set` writes under `.orbit/state/job-runs/**`, and startup/runtime audit, log, semantic-index, and global database writes. Registered stores that are not exposed by the current activity allowlists, including `.orbit/adrs/**` and graph write roots, remain outside this inventory and must be revisited when those write tools are exposed.
 
 Negated `read` / `modify` rules become explicit SBPL denies after ordinary profile allows to preserve last-match-wins. Simple path and `/**` subtree denials compile to `subpath`; non-subpath globs such as `**/*.env` compile to `regex`. Host-owned provider side roots are the exception because the provider CLI and inherited Orbit subprocesses must write workflow state.
 
@@ -164,7 +167,8 @@ Risk-weighted regression tests sit beside the implementations they guard
   such as `../secret.txt`, `src/../secret.txt`, and their backslash-normalized
   equivalents are rejected as `OrbitError::InvalidInput` for both read and
   modify checks ([T20260509-27]).
-- `crates/orbit-exec/src/macos_sandbox.rs#tests` — trusted wrapper
+- `crates/orbit-exec/src/macos_sandbox/compile.rs#tests` and
+  `crates/orbit-exec/src/macos_sandbox/provider_dirs/tests.rs` — trusted wrapper
   resolution ignores `PATH`, including a macOS runtime test that places a fake
   `sandbox-exec` earlier on `PATH` and verifies the fake wrapper is not
   executed ([T20260509-30]). SBPL compilation tests
@@ -224,5 +228,6 @@ non-empty on Linux CI.
 - **[T20260509-7]** — Add `PolicyEngine::check` boundary tests and macOS sandbox `denyRead` / realistic agent-loop profile tests.
 - **[T20260509-28]** — Validate policy and executor resource names as safe file stems before file-store path construction.
 - **[T20260509-30]** — Resolve `sandbox-exec` from trusted absolute locations and keep availability errors fail-closed and explicit.
+- **[ORB-00129]** — Re-allow narrow workspace child Orbit runtime stores for activity-exposed learning, friction, and job-run state tools without removing the default workspace `.orbit/**` deny.
 
 > Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.


### PR DESCRIPTION
## Task

[ORB-00129](https://orbit-cli.com/tasks/ORB-00129) — Fix sandbox write roots for activity-exposed Orbit tool stores

### Description

A provider activity hit `io error: Operation not permitted (os error 1)` when `orbit.learning.add` attempted to persist a learning during `jrun-20260517-2100-3`. The run completed, but the tool surface advertised by `agent_implement`/`agent_review` is not fully usable under the macOS sandbox because `default.yaml` denies workspace `.orbit/**` and the child Orbit runtime reallow list omits some stores.\n\nWrite-path inventory from the incident:\n- Already re-allowed: global logs, global `orbit.db*`, global tasks, workspace `.orbit/tasks/**`, workspace audit, workspace logs, workspace semantic DB, and the active worktree root.\n- Missing for currently activity-exposed write tools: workspace `.orbit/learnings/**` for `orbit.learning.add/update/supersede/comment.*`, workspace `.orbit/frictions/**` for `orbit.friction.add/update/resolve`, and workspace `.orbit/state/job-runs/**` or an equivalently narrow job-run state path for `orbit.state.set` in `step_failure_recovery`.\n- Covered by existing roots: task/review/artifact/duel writes under `.orbit/tasks/**`; task locks and learning index writes under global `orbit.db*`; audit/log writes under existing state roots.\n- Not currently required by these activity allowlists: `.orbit/adrs/**` because `orbit.adr.*` is registered but not exposed by `agent_implement`, `agent_review`, `step_failure_recovery`, or `dispatch_agent`; graph write roots are not registered/allowlisted here; `docs/design/**` is outside `.orbit` and is handled by normal workspace writes when applicable.\n\nFix the sandbox resolver so all currently activity-exposed Orbit write tools can write their intended stores without allowing the entire workspace `.orbit` tree.

### Acceptance Criteria

- 1. The child Orbit runtime sandbox reallow list covers the missing activity-exposed write stores: workspace `.orbit/learnings/**`, workspace `.orbit/frictions/**`, and workspace `.orbit/state/job-runs/**` or an equivalently narrow path that supports `orbit.state.set`.\n2. The implementation keeps the broad workspace `.orbit/**` deny intact and does not replace it with a blanket workspace `.orbit` allow.\n3. Regression tests assert the generated macOS sandbox profile contains the deny and the new narrow reallows for a non-Codex provider activity, while preserving the existing task/audit/log/semantic/global DB roots.\n4. The test or code comments explicitly document the inventory boundary for registered but non-activity-exposed stores such as `.orbit/adrs/**` and graph writes, so future activity allowlist changes know which roots must be revisited.\n5. `docs/design/policy-sandbox/2_design.md` is updated, including its `Last updated` date, to describe the child Orbit runtime write roots and the rationale for learnings, frictions, and job-run state.\n6. Validation includes the relevant `orbit-core` sandbox tests plus `make ci-fast`.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Extended the child Orbit runtime sandbox reallow list with narrow workspace roots for `.orbit/learnings/**`, `.orbit/frictions/**`, and `.orbit/state/job-runs/**` while preserving the default workspace `.orbit/**` deny and avoiding a blanket workspace `.orbit` allow.
- Expanded the non-Codex macOS sandbox regression test to assert the deny, the existing runtime roots, the new activity-exposed store roots, and the intentionally excluded ADR/graph write-store boundary.
- Updated the policy-sandbox design docs with the child runtime write-root rationale and refreshed stale path references in the touched design area.
- Added project learning `L20260517-10` for the activity write-tool sandbox gotcha.

Assessment: `cargo test -p orbit-core runtime::v2_host::sandbox -- --nocapture` and `make ci-fast` pass. `make check-design-docs` still fails on pre-existing stale/missing docs outside the touched policy-sandbox files (agent-families, auditability, activity-job, knowledge-graph, semantic-search, task-artifacts, and task-sync).

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-00129-6a0a32dd`
- Behind base: 0
- Ahead of base: 1