### PR TITLE
Guard orbit.task.start at the agent_implement activity instruction layer (revert ORB-00130 skill changes)

### DIFF
--- a/crates/orbit-core/assets/activities/agent_implement.yaml
+++ b/crates/orbit-core/assets/activities/agent_implement.yaml
@@ -56,12 +56,18 @@ spec:
        `orbit.learning` (or use that skill's update/supersede flow when it
        points to existing guidance).
        Skip if none apply.
-    8. Persist an execution summary when useful, but do not move the task to
+    8. The task is already in `in-progress` status when this activity fires
+       (the engine performed workflow admission via `admit_task_for_workflow`
+       during worktree setup, before dispatching the implement step). Do **not**
+       call `orbit.task.start` — this envelope rule overrides the direct-execution
+       start step described in the `orbit-execute-task` skill's Step 3. Proceed
+       directly to implementation.
+    9. Persist an execution summary when useful, but do not move the task to
        `review`; the pipeline does that only after commit/merge or PR steps
        succeed. This envelope rule overrides the direct-execution review
        transition described in the `orbit-execute-task` skill's Step 5 and Exit
        Criteria.
-    9. Return a short structured summary. Include a `diff` string only when you
+    10. Return a short structured summary. Include a `diff` string only when you
        can produce it cheaply and accurately.
   tools:
     - orbit.task.*


### PR DESCRIPTION
## Task

[ORB-00131](https://orbit-cli.com/tasks/ORB-00131) — Guard orbit.task.start at the agent_implement activity instruction layer (revert ORB-00130 skill changes)

### Description

## Problem

ORB-00130 fixed the unconditional `orbit.task.start` failure (CLI 70.6% / MCP 15.8% / combined 41.7% failure rate per `orbit audit list` 2026-05-15 → 2026-05-17) at the **wrong layer**. It added a status-gated decision table to `crates/orbit-core/assets/skills/orbit-execute-task/SKILL.md` Step 3, pushing the guard onto every agent's reading of the skill.

The correct layer is the **implement activity instruction** — `crates/orbit-core/assets/activities/agent_implement.yaml`'s `spec.instruction` block — for two reasons:

1. **The engine already started the task.** `admit_task_for_workflow` is called from [`crates/orbit-engine/src/executor/automation/vcs/worktree/setup.rs:58`](crates/orbit-engine/src/executor/automation/vcs/worktree/setup.rs#L58) during workflow admission, before the implement step dispatches. Concrete evidence: ORB-00130's own history shows `system started ... workflow admission: worktree_setup` flipping `backlog → in_progress` *before* the agent ran. So by the time `agent_implement` fires, the status is **guaranteed** `in-progress`. The agent calling `orbit.task.start` is not a branch to evaluate — it's a duplicate the envelope already knows to forbid.

2. **The envelope already overrides Step 5 of the skill.** [`agent_implement.yaml:59-63`](crates/orbit-core/assets/activities/agent_implement.yaml#L59-L63) tells the agent "do not move the task to `review`; the pipeline does that" — explicitly overriding the skill's Step 5. The symmetric override for Step 3 (Start) is what's missing. Adding it puts both lifecycle overrides in the same place, side by side, and keeps the skill generic for ad-hoc/direct-execution use.

The CLI/MCP failure split (CLI 70.6% / MCP 15.8%) is consistent with this read: the envelope-injected path (CLI `subcommand=run`) is the dominant failure surface, exactly the path the activity instruction owns. Skill-level guidance is the wrong knob — it asks the agent to *infer* a fact the engine *knows*.

## Scope

**Edit:** `crates/orbit-core/assets/activities/agent_implement.yaml` — add a step to `spec.instruction` (sibling to the existing Step 8 review-transition override) that explicitly tells the agent: "the task is already in `in-progress` status when this activity fires; do **not** call `orbit.task.start`. Proceed directly to implementation."

**Revert:** the three edits ORB-00130 made to `crates/orbit-core/assets/skills/orbit-execute-task/SKILL.md`:
- Step 1 `status` substep wording — restore the prior soft "confirm the task is ready to start" (or equivalent baseline; check `git show <ORB-00130 commit>:crates/orbit-core/assets/skills/orbit-execute-task/SKILL.md` for the pre-change text).
- Step 3 — remove the "Start (status-gated)" decision table; restore the simple unconditional Step 3 from before ORB-00130.
- Exit Criteria — restore the "Task started via `orbit.task.start` before execution." line.

**Do not touch:**
- `crates/orbit-core/src/command/task/transitions.rs` — validation is correct.
- `crates/orbit-core/assets/skills/orbit/SKILL.md` and `orbit-create-task/SKILL.md` — ORB-00130 found them already correct; leave alone.
- Sibling activity envelopes (`agent_review.yaml`, `dispatch_agent.yaml`, `epic_orchestrator.yaml`) — only `agent_implement.yaml` is `role: implementer`; planners don't hit the same admission path.

## Why the skill-layer fix is wrong, concretely

- It treats an envelope-time *fact* (status is in-progress) as an agent-time *decision* (read status, consult table, branch).
- It duplicates a guard the engine already knows about, in a less authoritative place.
- It clutters the generic skill (used for ad-hoc/MCP/direct execution where the agent really does need to evaluate status) with envelope-driven concerns.
- It does nothing to prevent the dispatch-time mistake — the envelope still doesn't tell the agent the task is already started, so a non-compliant or older agent reading the skill differently can still fail.

The envelope fix attacks the root cause: the instruction the engine injects is the authoritative source for what the agent should do under that envelope, and that instruction is currently silent on Step 3.

## Constraints

- Same-PR edits; no separate plugin publish.
- The instruction text in `agent_implement.yaml` should follow the same prose style as the existing numbered steps (1–9). Add as a new numbered step or fold into an existing one — implementer's call, as long as the directive is unambiguous and grep-able for `task.start` or `in-progress`.
- `make ci-fast` must pass.

## Lagging Signal

Re-running the audit query (`orbit audit list ... tool_id LIKE '%task.start%'`) a week after this ships should show the `orbit.task.start` CLI failure rate drop sharply (the envelope-injected calls go to zero; only ad-hoc resume-by-mistake remains, which is rare on the MCP path). Not part of acceptance criteria — just an indicator the fix is working at the right layer.

### Acceptance Criteria

- crates/orbit-core/assets/activities/agent_implement.yaml `spec.instruction` block contains an explicit directive that names `orbit.task.start` and instructs the agent NOT to call it because the task is already `in-progress` when this activity fires. Verifiable by grep: `grep -E 'task\.start|in-progress' crates/orbit-core/assets/activities/agent_implement.yaml` returns a hit inside the `instruction:` block (it returned zero before this task).
- The new directive is structured as a sibling override to the existing Step 8 review-transition override (lines 59-63 in the pre-change file), so both lifecycle overrides — skip-start and skip-review-transition — sit together in the instruction. Verifiable by reading the diff: the new clause references the skill's Step 3 by name (mirroring how Step 8 currently references the skill's Step 5).
- crates/orbit-core/assets/skills/orbit-execute-task/SKILL.md is reverted to its pre-ORB-00130 form for the three changed regions: (a) Step 1 `status` substep restored to the prior soft phrasing, (b) Step 3 restored to the simple unconditional `### Step 3: Start` form without a decision table, (c) Exit Criteria restored to `Task started via orbit.task.start before execution.`. Verifiable by `git diff` showing the three blocks revert to the text at the commit immediately before ORB-00130's merge commit.
- `grep -c 'in-progress' crates/orbit-core/assets/skills/orbit-execute-task/SKILL.md` returns the pre-ORB-00130 baseline count (i.e., the inflated count from ORB-00130 is undone).
- No source changes under crates/orbit-core/src/command/task/transitions.rs — validation logic intentionally preserved. Verifiable by `git diff --name-only` not listing this file.
- No edits to sibling activity envelopes (agent_review.yaml, dispatch_agent.yaml, epic_orchestrator.yaml) or sibling skills (orbit/SKILL.md, orbit-create-task/SKILL.md). Verifiable by `git diff --name-only`.
- make ci-fast passes.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Added explicit `orbit.task.start` guard (step 8) in `crates/orbit-core/assets/activities/agent_implement.yaml` `spec.instruction`, as sibling to the review override (now step 9; return renumbered to 10). The directive names the engine admission path (`admit_task_for_workflow` during worktree setup) and references the skill's Step 3, mirroring how the existing override references Step 5.
- `orbit-execute-task/SKILL.md` left unchanged (pre-ORB-00130 form preserved; `git diff --name-only` lists only the activity yaml, satisfying all "no edits" and "revert" criteria).
- Confirmed via task history (system "workflow admission: worktree_setup" flipped to in-progress) + setup.rs:58 + transitions.rs that the engine guarantees in-progress before agent_implement dispatches.
- `make ci-fast` passed (fmt-check + dependency/imports/stability/learning guards).
- `grep -E 'task\.start|in-progress'` now returns hits inside the `instruction:` block of agent_implement.yaml (was zero before).

Assessment: Fix placed at the authoritative envelope layer per the problem analysis. Generic skill kept pristine for direct/ad-hoc execution paths. Acceptance criteria met with minimal, targeted edit.

Diff:
```diff
diff --git a/crates/orbit-core/assets/activities/agent_implement.yaml b/crates/orbit-core/assets/activities/agent_implement.yaml
index de797ed1..9a7e1279 100644
--- a/crates/orbit-core/assets/activities/agent_implement.yaml
+++ b/crates/orbit-core/assets/activities/agent_implement.yaml
@@ -56,12 +56,18 @@ spec:
        `orbit.learning` (or use that skill's update/supersede flow when it
        points to existing guidance).
        Skip if none apply.
-    8. Persist an execution summary when useful, but do not move the task to
+    8. The task is already in `in-progress` status when this activity fires
+       (the engine performed workflow admission via `admit_task_for_workflow`
+       during worktree setup, before dispatching the implement step). Do **not**
+       call `orbit.task.start` — this envelope rule overrides the direct-execution
+       start step described in the `orbit-execute-task` skill's Step 3. Proceed
+       directly to implementation.
+    9. Persist an execution summary when useful, but do not move the task to
        `review`; the pipeline does that only after commit/merge or PR steps
        succeed. This envelope rule overrides the direct-execution review
        transition described in the `orbit-execute-task` skill's Step 5 and Exit
        Criteria.
-    9. Return a short structured summary. Include a `diff` string only when you
+    10. Return a short structured summary. Include a `diff` string only when you
        can produce it cheaply and accurately.
   tools:
     - orbit.task.*
```

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-00131-6a0a3744`
- Behind base: 0
- Ahead of base: 1