### PR TITLE
Apply secret redaction to ADR + learning artifact tools before YAML persistence

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -117,6 +117,7 @@ ci-fast:
 	./scripts/check-cli-imports.sh
 	./scripts/check-stability.sh
 	./scripts/check-learning-layout.sh
+	./scripts/check-artifact-redaction-boundary.sh
 
 # Verify every workspace crate declares its stability tier
 stability:

--- a/crates/orbit-cli/src/output/json.rs
+++ b/crates/orbit-cli/src/output/json.rs
@@ -55,6 +55,7 @@ fn error_code(error: &OrbitError) -> &'static str {
         OrbitError::TaskApprovalRequired(_) => "task_approval_required",
         OrbitError::CompanionNotInstalled(_) => "companion_not_installed",
         OrbitError::InvalidInput(_) | OrbitError::InvalidInputDiagnostic { .. } => "invalid_input",
+        OrbitError::SensitiveInput(_) => "sensitive_input",
         OrbitError::SkillValidation(_) => "skill_validation_failed",
         OrbitError::JobValidation(_) => "job_validation_failed",
         OrbitError::AgentProtocolViolation(_) => "agent_protocol_violation",

--- a/crates/orbit-cli/tests/learning.rs
+++ b/crates/orbit-cli/tests/learning.rs
@@ -386,6 +386,76 @@ fn cli_update_then_show_reflects_changes() {
 }
 
 #[test]
+fn tool_run_redaction_audit_is_queryable_via_audit_list_json() {
+    let workspace = TestWorkspace::new();
+    let secret = "ghp_012345678901234567890123456789012345";
+    let input_path = workspace.work.join("learning-input.json");
+    fs::write(
+        &input_path,
+        serde_json::to_string(&json!({
+            "summary": format!("redact {secret}"),
+            "scope": {"tags": ["audit"]},
+            "model": "codex",
+        }))
+        .expect("serialize input"),
+    )
+    .expect("write input");
+
+    let mut command = cargo_bin_cmd!("orbit");
+    let output = command
+        .current_dir(&workspace.work)
+        .env("HOME", &workspace.home)
+        .env("USERPROFILE", &workspace.home)
+        .env("GITHUB_TOKEN", secret)
+        .env_remove("ORBIT_ROOT")
+        .args([
+            "tool",
+            "run",
+            "orbit.learning.add",
+            "--input-file",
+            input_path.to_str().expect("input path"),
+            "--full",
+        ])
+        .output()
+        .expect("run orbit tool");
+    assert!(
+        output.status.success(),
+        "tool run failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let added: Value = serde_json::from_slice(&output.stdout).expect("tool output JSON");
+    assert_eq!(added["redactions_applied"], true);
+    let id = added["id"].as_str().expect("learning id");
+
+    // L20260517-9: audit assertions use `orbit audit list --json`, not direct SQLite reads.
+    let audit = workspace.run_json(
+        &[
+            "audit",
+            "list",
+            "--json",
+            "--tool",
+            "orbit.learning.add",
+            "--limit",
+            "50",
+        ],
+        "audit list",
+    );
+    let redaction_event = audit
+        .as_array()
+        .expect("audit array")
+        .iter()
+        .find(|event| event["target_type"] == "artifact_redaction" && event["target_id"] == id)
+        .expect("redaction audit event");
+    let args = redaction_event["arguments_json"]
+        .as_str()
+        .expect("arguments_json");
+    assert!(args.contains("\"redaction_kinds\":[\"env\"]"));
+    assert!(!args.contains(secret));
+    assert!(!args.contains("[REDACTED_ENV]"));
+}
+
+#[test]
 fn cli_reindex_returns_rebuilt_count() {
     let workspace = TestWorkspace::new();
     workspace.add_learning("a", &[], &[]);

--- a/crates/orbit-common/src/types/error.rs
+++ b/crates/orbit-common/src/types/error.rs
@@ -57,6 +57,8 @@ pub enum OrbitError {
         message: String,
         did_you_mean: Vec<String>,
     },
+    #[error("sensitive input refused: {0}")]
+    SensitiveInput(String),
     #[error("skill validation failed: {0}")]
     SkillValidation(String),
     #[error("job validation failed: {0}")]

--- a/crates/orbit-common/src/types/learning.rs
+++ b/crates/orbit-common/src/types/learning.rs
@@ -393,12 +393,21 @@ pub fn normalize_learning_tags(raw_tags: Vec<String>) -> Vec<String> {
     let mut normalized = Vec::with_capacity(raw_tags.len());
     let mut seen = BTreeSet::new();
     for raw in raw_tags {
-        let tag = raw.trim().to_lowercase();
+        let trimmed = raw.trim();
+        let tag = if is_redaction_marker(trimmed) {
+            trimmed.to_string()
+        } else {
+            trimmed.to_lowercase()
+        };
         if !tag.is_empty() && seen.insert(tag.clone()) {
             normalized.push(tag);
         }
     }
     normalized
+}
+
+fn is_redaction_marker(value: &str) -> bool {
+    value.starts_with("[REDACTED_") && value.ends_with(']')
 }
 
 /// Trim + dedupe a list of path-glob strings, preserving the first occurrence
@@ -453,10 +462,11 @@ mod tests {
             "  Perf ".to_string(),
             "BENCH".to_string(),
             "perf".to_string(),
+            "[REDACTED_ENV]".to_string(),
             "   ".to_string(),
         ]);
 
-        assert_eq!(tags, vec!["perf", "bench"]);
+        assert_eq!(tags, vec!["perf", "bench", "[REDACTED_ENV]"]);
     }
 
     #[test]

--- a/crates/orbit-common/src/utility/redaction.rs
+++ b/crates/orbit-common/src/utility/redaction.rs
@@ -18,6 +18,9 @@
 //! - [`PatternRedactor`] — regex pattern scrubbing (HTTP / argv / JSON)
 //! - [`redact_all`] — env + default patterns in one pass (use when you don't
 //!   know what shape the input has and want maximum coverage)
+//! - [`is_high_confidence_credential_token`] — exact-token refusal heuristic
+//!   for write boundaries that should reject clear credential values instead
+//!   of masking them silently
 
 // ORB-00013: Existing expect calls in this module document local invariants; keep the allow scoped while the workspace lint is ratcheted.
 #![allow(clippy::expect_used)]
@@ -31,6 +34,9 @@ use crate::types::OrbitError;
 
 const REDACTED_ENV_VALUE: &str = "[REDACTED_ENV]";
 static DEFAULT_PATTERN_REDACTOR: OnceLock<PatternRedactor> = OnceLock::new();
+static OPENAI_KEY_PATTERN: OnceLock<Regex> = OnceLock::new();
+static GITHUB_TOKEN_PATTERN: OnceLock<Regex> = OnceLock::new();
+static SLACK_TOKEN_PATTERN: OnceLock<Regex> = OnceLock::new();
 
 // ---------------------------------------------------------------------------
 // Env-var value scrubbing
@@ -107,6 +113,7 @@ pub fn redact_sensitive_env_error(error: OrbitError) -> OrbitError {
                 .map(|suggestion| redact_sensitive_env_text(&suggestion))
                 .collect(),
         },
+        OrbitError::SensitiveInput(m) => OrbitError::SensitiveInput(redact_sensitive_env_text(&m)),
         OrbitError::SkillValidation(m) => {
             OrbitError::SkillValidation(redact_sensitive_env_text(&m))
         }
@@ -173,20 +180,21 @@ pub fn is_sensitive_env_name(name: &str) -> bool {
 // Pattern-based redaction (HTTP + argv)
 // ---------------------------------------------------------------------------
 
-/// Regex-driven scrubber for HTTP-shape and argv-shape secrets.
+/// Regex-driven scrubber for HTTP-shape and credential-shaped secrets.
 ///
 /// Builds to `default()` give you the same coverage as the former
 /// `RedactionMiddleware` (Authorization / x-api-key / Bearer / raw header
-/// lines). Use [`PatternRedactor::with_argv_secrets`] to also catch bare
-/// `sk-…` tokens — needed when scrubbing subprocess argv where a provider
-/// key sometimes ends up mis-configured.
+/// lines) plus high-confidence provider tokens that may appear inside prose.
+/// Use [`PatternRedactor::with_argv_secrets`] when scrubbing subprocess argv;
+/// it retains compatibility with the old argv-specific constructor.
 pub struct PatternRedactor {
     patterns: Vec<(Regex, &'static str)>,
 }
 
 impl PatternRedactor {
-    /// HTTP-only default: Authorization / x-api-key / api_key / Bearer in
-    /// both JSON and raw-header form.
+    /// Authorization / x-api-key / api_key / Bearer in both JSON and
+    /// raw-header form, plus common provider token shapes that may appear
+    /// inside free text.
     pub fn http_default() -> Self {
         let patterns = vec![
             (
@@ -216,6 +224,18 @@ impl PatternRedactor {
             (
                 Regex::new(r"(?im)^(\s*api[_-]?key\s*:\s*).+$").expect("valid regex"),
                 "${1}[REDACTED_AUTH]",
+            ),
+            (
+                Regex::new(r"sk-[A-Za-z0-9_\-]{20,}").expect("valid regex"),
+                "[REDACTED_API_KEY]",
+            ),
+            (
+                Regex::new(r"ghp_[A-Za-z0-9]{36}").expect("valid regex"),
+                "[REDACTED_API_KEY]",
+            ),
+            (
+                Regex::new(r"xox[baprs]-[A-Za-z0-9\-]{10,}").expect("valid regex"),
+                "[REDACTED_API_KEY]",
             ),
         ];
         Self { patterns }
@@ -277,4 +297,78 @@ pub fn redact_all(input: &str) -> String {
 
 pub(crate) fn default_pattern_redactor() -> &'static PatternRedactor {
     DEFAULT_PATTERN_REDACTOR.get_or_init(PatternRedactor::http_default)
+}
+
+/// Returns `true` when the whole trimmed value is a known credential token.
+///
+/// Callers use this to refuse writes where the entire field is plainly a
+/// credential. The same token embedded in larger prose is left to
+/// [`redact_all`] so the surrounding context can be preserved.
+pub fn is_high_confidence_credential_token(input: &str) -> bool {
+    let trimmed = input.trim();
+    openai_key_pattern().is_match(trimmed)
+        || github_token_pattern().is_match(trimmed)
+        || slack_token_pattern().is_match(trimmed)
+}
+
+fn openai_key_pattern() -> &'static Regex {
+    OPENAI_KEY_PATTERN.get_or_init(|| Regex::new(r"^sk-[A-Za-z0-9_\-]{20,}$").expect("valid regex"))
+}
+
+fn github_token_pattern() -> &'static Regex {
+    GITHUB_TOKEN_PATTERN.get_or_init(|| Regex::new(r"^ghp_[A-Za-z0-9]{36}$").expect("valid regex"))
+}
+
+fn slack_token_pattern() -> &'static Regex {
+    SLACK_TOKEN_PATTERN
+        .get_or_init(|| Regex::new(r"^xox[baprs]-[A-Za-z0-9\-]{10,}$").expect("valid regex"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn redact_all_masks_embedded_provider_tokens() {
+        let input = concat!(
+            "OpenAI sk-0123456789abcdefghijklmn ",
+            "GitHub ghp_012345678901234567890123456789012345 ",
+            "Slack xoxb-0123456789-abcd"
+        );
+
+        let redacted = redact_all(input);
+
+        assert!(!redacted.contains("sk-0123456789abcdefghijklmn"));
+        assert!(!redacted.contains("ghp_012345678901234567890123456789012345"));
+        assert!(!redacted.contains("xoxb-0123456789-abcd"));
+        assert!(redacted.contains("[REDACTED_API_KEY]"));
+    }
+
+    #[test]
+    fn high_confidence_credential_detection_is_whole_token_only() {
+        assert!(is_high_confidence_credential_token(
+            "sk-0123456789abcdefghijklmn"
+        ));
+        assert!(is_high_confidence_credential_token(
+            "ghp_012345678901234567890123456789012345"
+        ));
+        assert!(is_high_confidence_credential_token("xoxb-0123456789-abcd"));
+        assert!(!is_high_confidence_credential_token(
+            "token sk-0123456789abcdefghijklmn in prose"
+        ));
+    }
+
+    #[test]
+    fn redact_all_is_idempotent_for_fixture_inputs() {
+        let fixtures = [
+            "Authorization: Bearer abcdef012345",
+            r#"{"api_key":"abcdef012345"}"#,
+            "sk-0123456789abcdefghijklmn",
+            "already [REDACTED_ENV] and [REDACTED_API_KEY]",
+        ];
+
+        for fixture in fixtures {
+            assert_eq!(redact_all(&redact_all(fixture)), redact_all(fixture));
+        }
+    }
 }

--- a/crates/orbit-core/src/runtime/orbit_tool_host/adr_tools.rs
+++ b/crates/orbit-core/src/runtime/orbit_tool_host/adr_tools.rs
@@ -15,18 +15,30 @@ use serde_json::{Value, json};
 
 use crate::OrbitRuntime;
 
+use super::artifact_redaction::{
+    ArtifactRedactionReport, emit_redaction_audits, flag_without_redactions, redactions_flagged,
+    sanitize_free_text_field,
+};
+
 pub(super) fn add(
     runtime: &OrbitRuntime,
     input: Value,
     agent: Option<String>,
     model: Option<String>,
 ) -> Result<Value, OrbitError> {
-    let title = required_string(&input, &["title"], "title")?;
+    let mut redactions = ArtifactRedactionReport::default();
+    let title = redactions.absorb(sanitize_free_text_field(
+        "title",
+        required_string(&input, &["title"], "title")?,
+    )?);
     let owner = match optional_string(&input, "owner")? {
         Some(value) => value,
         None => actor_label(runtime, agent.as_deref(), model.as_deref()),
     };
-    let body = required_string(&input, &["body"], "body")?;
+    let body = redactions.absorb(sanitize_free_text_field(
+        "body",
+        required_string(&input, &["body"], "body")?,
+    )?);
     let related_features =
         optional_string_list_alias(&input, &["related_features", "features"])?.unwrap_or_default();
     let related_tasks =
@@ -39,7 +51,16 @@ pub(super) fn add(
         related_tasks,
         body,
     })?;
-    Ok(adr_to_json(&adr))
+    emit_redaction_audits(
+        runtime,
+        "orbit.adr.add",
+        "adr",
+        &adr.id,
+        &redactions,
+        agent.as_deref(),
+        model.as_deref(),
+    )?;
+    Ok(redactions_flagged(adr_to_json(&adr), &redactions))
 }
 
 pub(super) fn show(runtime: &OrbitRuntime, input: Value) -> Result<Value, OrbitError> {
@@ -119,10 +140,19 @@ pub(super) fn update(
         .map(|raw| AdrStatus::from_str(&raw).map_err(OrbitError::InvalidInput))
         .transpose()?;
 
+    let mut redactions = ArtifactRedactionReport::default();
     let fields = AdrDocumentUpdateParams {
-        title: optional_string(&input, "title")?,
+        title: optional_string(&input, "title")?
+            .map(|value| {
+                sanitize_free_text_field("title", value).map(|field| redactions.absorb(field))
+            })
+            .transpose()?,
         owner: optional_string(&input, "owner")?,
-        body: optional_string(&input, "body")?,
+        body: optional_string(&input, "body")?
+            .map(|value| {
+                sanitize_free_text_field("body", value).map(|field| redactions.absorb(field))
+            })
+            .transpose()?,
         related_features: optional_string_list_alias(&input, &["related_features", "features"])?,
         related_tasks: optional_string_list_alias(&input, &["related_tasks", "tasks"])?,
         supersedes: optional_string_list_alias(&input, &["supersedes"])?,
@@ -139,6 +169,15 @@ pub(super) fn update(
 
     if has_document_changes(&fields) {
         adrs.update_document(&id, &fields)?;
+        emit_redaction_audits(
+            runtime,
+            "orbit.adr.update",
+            "adr",
+            &id,
+            &redactions,
+            agent.as_deref(),
+            model.as_deref(),
+        )?;
     }
 
     if let Some(target) = new_status {
@@ -193,7 +232,7 @@ pub(super) fn update(
     let updated = adrs
         .get(&id)?
         .ok_or_else(|| OrbitError::not_found(NotFoundKind::Adr, id.clone()))?;
-    Ok(adr_to_json(&updated))
+    Ok(redactions_flagged(adr_to_json(&updated), &redactions))
 }
 
 pub(super) fn supersede(
@@ -223,7 +262,7 @@ pub(super) fn supersede(
     let updated = adrs
         .get(&old_id)?
         .ok_or_else(|| OrbitError::not_found(NotFoundKind::Adr, old_id.clone()))?;
-    Ok(adr_to_json(&updated))
+    Ok(flag_without_redactions(adr_to_json(&updated)))
 }
 
 fn parse_status_filter(raw: &str) -> Result<AdrStatus, OrbitError> {
@@ -328,7 +367,7 @@ fn record_transition_audit(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::runtime::orbit_tool_host::test_support::test_runtime;
+    use crate::runtime::orbit_tool_host::test_support::{env_var_guard, test_runtime};
     use orbit_common::types::NotFoundKind;
 
     fn assert_adr_field(value: &Value, field: &str, expected: &str) {
@@ -642,5 +681,109 @@ mod tests {
         )
         .expect_err("rejects non-accepted target");
         assert!(matches!(err, OrbitError::AdrInvalidTransition(_)));
+    }
+
+    #[test]
+    fn add_and_update_redact_title_and_body_before_persistence() {
+        let secret = "ghp_012345678901234567890123456789012345";
+        let _env = env_var_guard(&[("GITHUB_TOKEN", Some(secret))]);
+        let (_guard, runtime, _repo_root) = test_runtime();
+
+        let created = add(
+            &runtime,
+            json!({
+                "title": format!("Decision {secret}"),
+                "owner": "claude",
+                "body": format!("## Context\nBearer abcdef and {secret}."),
+            }),
+            Some("claude".to_string()),
+            None,
+        )
+        .expect("add with secret");
+
+        assert_eq!(created["redactions_applied"], true);
+        let id = created["id"].as_str().expect("id");
+        let adr_dir = runtime.paths().adrs_dir.join("proposed").join(id);
+        let yaml = std::fs::read_to_string(adr_dir.join("adr.yaml")).expect("read adr yaml");
+        let body = std::fs::read_to_string(adr_dir.join("body.md")).expect("read adr body");
+        assert!(yaml.contains("[REDACTED_ENV]"));
+        assert!(!yaml.contains(secret));
+        assert!(body.contains("[REDACTED_ENV]"));
+        assert!(body.contains("Bearer [REDACTED_AUTH]"));
+        assert!(!body.contains(secret));
+
+        let updated = update(
+            &runtime,
+            json!({
+                "id": id,
+                "body": "The embedded key sk-0123456789abcdefghijklmn is masked.",
+            }),
+            None,
+            None,
+        )
+        .expect("update body");
+        assert_eq!(updated["redactions_applied"], true);
+        let body = std::fs::read_to_string(adr_dir.join("body.md")).expect("read updated body");
+        assert!(body.contains("[REDACTED_API_KEY]"));
+        assert!(!body.contains("sk-0123456789abcdefghijklmn"));
+    }
+
+    #[test]
+    fn exact_credential_title_is_rejected_before_adr_write() {
+        let (_guard, runtime, _repo_root) = test_runtime();
+        let err = add(
+            &runtime,
+            json!({
+                "title": "sk-0123456789abcdefghijklmn",
+                "owner": "claude",
+                "body": "body",
+            }),
+            None,
+            None,
+        )
+        .expect_err("reject exact credential");
+
+        assert!(matches!(err, OrbitError::SensitiveInput(_)));
+        assert!(!runtime.paths().adrs_dir.join("proposed/ADR-0001").exists());
+    }
+
+    #[test]
+    fn supersede_response_reports_no_redactions() {
+        let (_guard, runtime, _repo_root) = test_runtime();
+        let old = add(
+            &runtime,
+            json!({"title": "Old", "owner": "claude", "body": "b"}),
+            None,
+            None,
+        )
+        .expect("old");
+        let new = add(
+            &runtime,
+            json!({"title": "New", "owner": "claude", "body": "b"}),
+            None,
+            None,
+        )
+        .expect("new");
+        update(
+            &runtime,
+            json!({
+                "id": new["id"],
+                "status": "accepted",
+                "related_tasks": ["T20260511-1"],
+            }),
+            None,
+            None,
+        )
+        .expect("accept new");
+
+        let response = supersede(
+            &runtime,
+            json!({"old_id": old["id"], "new_id": new["id"]}),
+            None,
+            None,
+        )
+        .expect("supersede");
+
+        assert_eq!(response["redactions_applied"], false);
     }
 }

--- a/crates/orbit-core/src/runtime/orbit_tool_host/artifact_redaction.rs
+++ b/crates/orbit-core/src/runtime/orbit_tool_host/artifact_redaction.rs
@@ -1,0 +1,182 @@
+use orbit_common::types::{
+    AuditEventStatus, OrbitError, audit_execution_id, normalize_optional_attribution_label,
+};
+use orbit_common::utility::redaction::{
+    is_high_confidence_credential_token, redact_all, redact_home_dir, redact_sensitive_env_text,
+};
+use serde_json::{Value, json};
+
+use crate::{AuditEventInsertParams, OrbitRuntime};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ArtifactRedactionKind {
+    Env,
+    Pattern,
+    HomeDir,
+}
+
+impl ArtifactRedactionKind {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Env => "env",
+            Self::Pattern => "pattern",
+            Self::HomeDir => "home_dir",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct FieldRedaction {
+    field: &'static str,
+    kinds: Vec<ArtifactRedactionKind>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub(super) struct ArtifactRedactionReport {
+    fields: Vec<FieldRedaction>,
+}
+
+impl ArtifactRedactionReport {
+    pub(super) fn absorb(&mut self, field: SanitizedArtifactField) -> String {
+        if !field.kinds.is_empty() {
+            self.fields.push(FieldRedaction {
+                field: field.field,
+                kinds: field.kinds,
+            });
+        }
+        field.value
+    }
+
+    pub(super) fn applied(&self) -> bool {
+        !self.fields.is_empty()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct SanitizedArtifactField {
+    field: &'static str,
+    value: String,
+    kinds: Vec<ArtifactRedactionKind>,
+}
+
+pub(super) fn sanitize_free_text_field(
+    field: &'static str,
+    input: String,
+) -> Result<SanitizedArtifactField, OrbitError> {
+    let env_scrubbed = redact_sensitive_env_text(&input);
+    if env_scrubbed == input && is_high_confidence_credential_token(&input) {
+        return Err(OrbitError::SensitiveInput(format!(
+            "`{field}` is a complete credential token; remove it or embed only non-sensitive context"
+        )));
+    }
+
+    let all_scrubbed = redact_all(&input);
+    let home_scrubbed = redact_home_dir(&all_scrubbed);
+
+    let mut kinds = Vec::new();
+    if env_scrubbed != input {
+        kinds.push(ArtifactRedactionKind::Env);
+    }
+    if all_scrubbed != env_scrubbed {
+        kinds.push(ArtifactRedactionKind::Pattern);
+    }
+    if home_scrubbed != all_scrubbed {
+        kinds.push(ArtifactRedactionKind::HomeDir);
+    }
+
+    Ok(SanitizedArtifactField {
+        field,
+        value: home_scrubbed,
+        kinds,
+    })
+}
+
+pub(super) fn sanitize_path_field(field: &'static str, input: String) -> SanitizedArtifactField {
+    let home_scrubbed = redact_home_dir(&input);
+    let kinds = if home_scrubbed != input {
+        vec![ArtifactRedactionKind::HomeDir]
+    } else {
+        Vec::new()
+    };
+    SanitizedArtifactField {
+        field,
+        value: home_scrubbed,
+        kinds,
+    }
+}
+
+pub(super) fn redactions_flagged(mut value: Value, report: &ArtifactRedactionReport) -> Value {
+    if let Some(object) = value.as_object_mut() {
+        object.insert(
+            "redactions_applied".to_string(),
+            Value::Bool(report.applied()),
+        );
+    }
+    value
+}
+
+pub(super) fn flag_without_redactions(value: Value) -> Value {
+    redactions_flagged(value, &ArtifactRedactionReport::default())
+}
+
+pub(super) fn emit_redaction_audits(
+    runtime: &OrbitRuntime,
+    tool_name: &str,
+    artifact_type: &str,
+    artifact_id: &str,
+    report: &ArtifactRedactionReport,
+    agent: Option<&str>,
+    model: Option<&str>,
+) -> Result<(), OrbitError> {
+    let actor = normalize_optional_attribution_label(model.or(agent), model)
+        .unwrap_or_else(|| runtime.actor_label().to_string());
+    for field in &report.fields {
+        let kinds = field
+            .kinds
+            .iter()
+            .map(|kind| kind.as_str())
+            .collect::<Vec<_>>();
+        let payload = json!({
+            "artifact_type": artifact_type,
+            "artifact_id": artifact_id,
+            "field": field.field,
+            "redaction_kinds": kinds,
+            "actor": actor,
+        });
+        let arguments_json = serde_json::to_string(&payload).map_err(|error| {
+            OrbitError::Execution(format!(
+                "serialize artifact redaction audit payload: {error}"
+            ))
+        })?;
+
+        runtime.record_audit_event(&AuditEventInsertParams {
+            execution_id: audit_execution_id("audit-artifact-redaction"),
+            command: "artifact".to_string(),
+            subcommand: Some("redaction".to_string()),
+            tool_name: Some(tool_name.to_string()),
+            target_type: Some("artifact_redaction".to_string()),
+            target_id: Some(artifact_id.to_string()),
+            role: actor.clone(),
+            status: AuditEventStatus::Success,
+            exit_code: 0,
+            duration_ms: 0,
+            working_directory: runtime.paths().repo_root.to_string_lossy().into_owned(),
+            arguments_json: Some(arguments_json),
+            stdout_truncated: None,
+            stderr_truncated: None,
+            error_message: None,
+            host: std::env::var("HOSTNAME").ok(),
+            pid: std::process::id(),
+            session_id: None,
+            task_id: None,
+            job_run_id: std::env::var("ORBIT_RUN_ID").ok().filter(|s| !s.is_empty()),
+            activity_id: std::env::var("ORBIT_ACTIVITY_ID")
+                .ok()
+                .filter(|s| !s.is_empty()),
+            step_index: std::env::var("ORBIT_STEP_INDEX")
+                .ok()
+                .and_then(|s| s.parse().ok()),
+        })?;
+    }
+    Ok(())
+}

--- a/crates/orbit-core/src/runtime/orbit_tool_host/design_tools.rs
+++ b/crates/orbit-core/src/runtime/orbit_tool_host/design_tools.rs
@@ -54,7 +54,6 @@ fn workspace_root(input: &Value) -> Result<std::path::PathBuf, OrbitError> {
 mod tests {
     use orbit_common::types::NotFoundKind;
     use serde_json::json;
-    use serde_json::json;
 
     use super::*;
     use crate::runtime::orbit_tool_host::test_support::test_runtime;

--- a/crates/orbit-core/src/runtime/orbit_tool_host/learning_tools.rs
+++ b/crates/orbit-core/src/runtime/orbit_tool_host/learning_tools.rs
@@ -19,6 +19,10 @@ use serde_json::{Value, json};
 
 use crate::OrbitRuntime;
 
+use super::artifact_redaction::{
+    ArtifactRedactionReport, emit_redaction_audits, flag_without_redactions, redactions_flagged,
+    sanitize_free_text_field, sanitize_path_field,
+};
 use super::input::optional_bool_alias;
 use super::json::{
     learning_comment_to_json, learning_search_result_to_json, learning_show_to_json,
@@ -31,14 +35,24 @@ pub(super) fn add(
     _agent: Option<String>,
     model: Option<String>,
 ) -> Result<Value, OrbitError> {
-    let summary = required_string(&input, &["summary"], "summary")?;
+    let mut redactions = ArtifactRedactionReport::default();
+    let summary = redactions.absorb(sanitize_free_text_field(
+        "summary",
+        required_string(&input, &["summary"], "summary")?,
+    )?);
     let scope_value = input
         .get("scope")
         .cloned()
         .unwrap_or(Value::Object(Default::default()));
-    let scope = parse_scope_value(scope_value)?;
-    let body = optional_string(&input, "body")?.unwrap_or_default();
-    let evidence = parse_evidence_value(input.get("evidence"))?;
+    let scope = sanitize_scope(parse_scope_value(scope_value)?, &mut redactions)?;
+    let body = redactions.absorb(sanitize_free_text_field(
+        "body",
+        optional_string(&input, "body")?.unwrap_or_default(),
+    )?);
+    let evidence = sanitize_evidence(
+        parse_evidence_value(input.get("evidence"))?,
+        &mut redactions,
+    )?;
     let priority = parse_optional_priority(&input)?;
     let created_by = optional_string_alias(&input, &["created_by", "createdBy"])?.or(model);
 
@@ -50,7 +64,16 @@ pub(super) fn add(
         created_by,
         priority,
     })?;
-    Ok(learning_to_json(&learning))
+    emit_redaction_audits(
+        runtime,
+        "orbit.learning.add",
+        "learning",
+        &learning.id,
+        &redactions,
+        None,
+        learning.created_by.as_deref(),
+    )?;
+    Ok(redactions_flagged(learning_to_json(&learning), &redactions))
 }
 
 pub(super) fn show(runtime: &OrbitRuntime, input: Value) -> Result<Value, OrbitError> {
@@ -137,16 +160,32 @@ pub(super) fn comment_add(
     model: Option<String>,
 ) -> Result<Value, OrbitError> {
     let learning_id = required_string(&input, &["learning_id", "learningId", "id"], "learning_id")?;
-    let body = required_string(&input, &["body"], "body")?;
+    let mut redactions = ArtifactRedactionReport::default();
+    let body = redactions.absorb(sanitize_free_text_field(
+        "body",
+        required_string(&input, &["body"], "body")?,
+    )?);
     let author_model = optional_string(&input, "model")?.or(model).ok_or_else(|| {
         OrbitError::InvalidInput("learning comment add requires `model`".to_string())
     })?;
-    let comment = runtime.add_learning_comment(learning_id, body, author_model)?;
-    Ok(json!({
-        "id": comment.id,
-        "learning_id": comment.learning_id,
-        "created_at": comment.created_at.to_rfc3339(),
-    }))
+    let comment = runtime.add_learning_comment(learning_id, body, author_model.clone())?;
+    emit_redaction_audits(
+        runtime,
+        "orbit.learning.comment.add",
+        "learning_comment",
+        &comment.id,
+        &redactions,
+        None,
+        Some(&author_model),
+    )?;
+    Ok(redactions_flagged(
+        json!({
+            "id": comment.id,
+            "learning_id": comment.learning_id,
+            "created_at": comment.created_at.to_rfc3339(),
+        }),
+        &redactions,
+    ))
 }
 
 pub(super) fn comment_list(runtime: &OrbitRuntime, input: Value) -> Result<Value, OrbitError> {
@@ -179,15 +218,28 @@ pub(super) fn update(
     _model: Option<String>,
 ) -> Result<Value, OrbitError> {
     let id = required_string(&input, &["id"], "id")?;
-    let summary = optional_string(&input, "summary")?;
+    let mut redactions = ArtifactRedactionReport::default();
+    let summary = optional_string(&input, "summary")?
+        .map(|value| {
+            sanitize_free_text_field("summary", value).map(|field| redactions.absorb(field))
+        })
+        .transpose()?;
     let scope = match input.get("scope") {
         Some(Value::Null) | None => None,
-        Some(value) => Some(parse_scope_value(value.clone())?),
+        Some(value) => Some(sanitize_scope(
+            parse_scope_value(value.clone())?,
+            &mut redactions,
+        )?),
     };
-    let body = optional_string(&input, "body")?;
+    let body = optional_string(&input, "body")?
+        .map(|value| sanitize_free_text_field("body", value).map(|field| redactions.absorb(field)))
+        .transpose()?;
     let evidence = match input.get("evidence") {
         Some(Value::Null) | None => None,
-        Some(value) => Some(parse_evidence_value(Some(value))?),
+        Some(value) => Some(sanitize_evidence(
+            parse_evidence_value(Some(value))?,
+            &mut redactions,
+        )?),
     };
     let priority = parse_optional_priority_field(&input)?;
 
@@ -201,7 +253,16 @@ pub(super) fn update(
             priority,
         },
     )?;
-    Ok(learning_to_json(&updated))
+    emit_redaction_audits(
+        runtime,
+        "orbit.learning.update",
+        "learning",
+        &id,
+        &redactions,
+        None,
+        None,
+    )?;
+    Ok(redactions_flagged(learning_to_json(&updated), &redactions))
 }
 
 pub(super) fn supersede(
@@ -228,10 +289,10 @@ pub(super) fn supersede(
         .learnings()
         .get(&with)?
         .ok_or_else(|| OrbitError::not_found(NotFoundKind::Learning, with.clone()))?;
-    Ok(json!({
+    Ok(flag_without_redactions(json!({
         "old": learning_to_json(&old),
         "new": learning_to_json(&new),
-    }))
+    })))
 }
 
 pub(super) fn reindex(runtime: &OrbitRuntime, _input: Value) -> Result<Value, OrbitError> {
@@ -284,6 +345,39 @@ fn parse_scope_value(value: Value) -> Result<LearningScope, OrbitError> {
         scope.semantic_seed = Some(seed.clone());
     }
     Ok(scope)
+}
+
+fn sanitize_scope(
+    mut scope: LearningScope,
+    redactions: &mut ArtifactRedactionReport,
+) -> Result<LearningScope, OrbitError> {
+    scope.paths = scope
+        .paths
+        .into_iter()
+        .map(|path| redactions.absorb(sanitize_path_field("scope.paths", path)))
+        .collect();
+    scope.tags = scope
+        .tags
+        .into_iter()
+        .map(|tag| {
+            sanitize_free_text_field("scope.tags", tag).map(|field| redactions.absorb(field))
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    Ok(scope)
+}
+
+fn sanitize_evidence(
+    evidence: Vec<LearningEvidence>,
+    redactions: &mut ArtifactRedactionReport,
+) -> Result<Vec<LearningEvidence>, OrbitError> {
+    evidence
+        .into_iter()
+        .map(|mut item| {
+            item.reference =
+                redactions.absorb(sanitize_free_text_field("evidence.ref", item.reference)?);
+            Ok(item)
+        })
+        .collect()
 }
 
 fn parse_string_list(field: &str, value: &Value) -> Result<Vec<String>, OrbitError> {

--- a/crates/orbit-core/src/runtime/orbit_tool_host/learning_tools_tests.rs
+++ b/crates/orbit-core/src/runtime/orbit_tool_host/learning_tools_tests.rs
@@ -24,7 +24,7 @@ use orbit_store::{LearningCreateParams, LearningSearchParams};
 use orbit_tools::ToolRegistry;
 use serde_json::{Value, json};
 
-use super::test_support::test_runtime;
+use super::test_support::{env_var_guard, test_runtime};
 use crate::OrbitRuntime;
 
 fn registry_with_builtins() -> ToolRegistry {
@@ -266,6 +266,182 @@ fn comment_tools_add_list_and_delete() {
     )
     .expect("deleted comments");
     assert_eq!(deleted.as_array().expect("array").len(), 1);
+}
+
+#[test]
+fn add_redacts_learning_fields_and_home_only_paths_before_yaml_persistence() {
+    let secret = "ghp_012345678901234567890123456789012345";
+    let home = std::env::var("HOME").expect("HOME set for redaction test");
+    let _env = env_var_guard(&[("GITHUB_TOKEN", Some(secret))]);
+    let (_guard, runtime, _repo_root) = test_runtime();
+    let home_glob = format!("{home}/workspace/[A-Za-z0-9_-]{{20,}}/**/*.rs");
+
+    let created = super::learning_tools::add(
+        &runtime,
+        json!({
+            "summary": format!("summary {secret}"),
+            "scope": {
+                "paths": [home_glob],
+                "tags": [format!("tag-{secret}")],
+            },
+            "body": format!("body {secret} and Bearer abcdef012345"),
+            "evidence": [{"kind": "external", "ref": format!("ref {secret}")}],
+            "model": "codex",
+        }),
+        None,
+        Some("codex".to_string()),
+    )
+    .expect("add redacted learning");
+
+    assert_eq!(created["redactions_applied"], true);
+    let id = created["id"].as_str().expect("id");
+    let yaml_path = runtime.paths().learnings_dir.join(id).join("learning.yaml");
+    let yaml = std::fs::read_to_string(yaml_path).expect("read learning yaml");
+    assert!(yaml.contains("[REDACTED_ENV]"));
+    assert!(yaml.contains("Bearer [REDACTED_AUTH]"));
+    assert!(yaml.contains("~/workspace/[A-Za-z0-9_-]{20,}/**/*.rs"));
+    assert!(!yaml.contains(secret));
+    assert!(
+        yaml.contains("[A-Za-z0-9_-]{20,}"),
+        "path glob character class should be preserved"
+    );
+}
+
+#[test]
+fn update_comment_and_response_flags_cover_redacted_and_plain_invocations() {
+    let secret = "ghp_012345678901234567890123456789012345";
+    let _env = env_var_guard(&[("GITHUB_TOKEN", Some(secret))]);
+    let (_guard, runtime, _repo_root) = test_runtime();
+
+    let plain = super::learning_tools::add(
+        &runtime,
+        json!({
+            "summary": "plain",
+            "scope": {"tags": ["security"]},
+            "model": "codex",
+        }),
+        None,
+        Some("codex".to_string()),
+    )
+    .expect("plain add");
+    assert_eq!(plain["redactions_applied"], false);
+    let id = plain["id"].as_str().expect("id");
+
+    let updated = super::learning_tools::update(
+        &runtime,
+        json!({
+            "id": id,
+            "summary": format!("updated {secret}"),
+            "evidence": [{"kind": "external", "ref": format!("evidence {secret}")}],
+        }),
+        None,
+        None,
+    )
+    .expect("update");
+    assert_eq!(updated["redactions_applied"], true);
+
+    let comment = super::learning_tools::comment_add(
+        &runtime,
+        json!({
+            "learning_id": id,
+            "body": format!("comment {secret}"),
+            "model": "codex",
+        }),
+        None,
+        None,
+    )
+    .expect("comment add");
+    assert_eq!(comment["redactions_applied"], true);
+
+    let yaml =
+        std::fs::read_to_string(runtime.paths().learnings_dir.join(id).join("learning.yaml"))
+            .expect("read yaml");
+    assert!(yaml.contains("[REDACTED_ENV]"));
+    assert!(!yaml.contains(secret));
+
+    let comments = std::fs::read_to_string(
+        runtime
+            .paths()
+            .learnings_dir
+            .join(id)
+            .join("comments.jsonl"),
+    )
+    .expect("read comments");
+    assert!(comments.contains("[REDACTED_ENV]"));
+    assert!(!comments.contains(secret));
+}
+
+#[test]
+fn exact_credential_is_rejected_but_embedded_credential_is_masked() {
+    let (_guard, runtime, _repo_root) = test_runtime();
+
+    let err = super::learning_tools::add(
+        &runtime,
+        json!({
+            "summary": "sk-0123456789abcdefghijklmn",
+            "scope": {"tags": ["security"]},
+            "model": "codex",
+        }),
+        None,
+        Some("codex".to_string()),
+    )
+    .expect_err("reject exact credential");
+    assert!(matches!(err, OrbitError::SensitiveInput(_)));
+
+    let created = super::learning_tools::add(
+        &runtime,
+        json!({
+            "summary": "embedded sk-0123456789abcdefghijklmn token",
+            "scope": {"tags": ["security"]},
+            "model": "codex",
+        }),
+        None,
+        Some("codex".to_string()),
+    )
+    .expect("mask embedded credential");
+    assert_eq!(created["redactions_applied"], true);
+    assert_eq!(created["summary"], "embedded [REDACTED_API_KEY] token");
+}
+
+#[test]
+fn redaction_audit_events_do_not_include_secret_values() {
+    let secret = "ghp_012345678901234567890123456789012345";
+    let _env = env_var_guard(&[("GITHUB_TOKEN", Some(secret))]);
+    let (_guard, runtime, _repo_root) = test_runtime();
+
+    let created = super::learning_tools::add(
+        &runtime,
+        json!({
+            "summary": format!("summary {secret}"),
+            "scope": {"tags": ["audit"]},
+            "model": "codex",
+        }),
+        None,
+        Some("codex".to_string()),
+    )
+    .expect("add");
+    let id = created["id"].as_str().expect("id");
+    let events = runtime
+        .list_audit_events(
+            None,
+            Some("orbit.learning.add".to_string()),
+            Some(orbit_common::types::AuditEventStatus::Success),
+            None,
+            16,
+        )
+        .expect("list audit events");
+    let event = events
+        .iter()
+        .find(|event| {
+            event.target_type.as_deref() == Some("artifact_redaction")
+                && event.target_id.as_deref() == Some(id)
+        })
+        .expect("redaction audit event");
+    let args = event.arguments_json.as_ref().expect("arguments json");
+    assert!(args.contains("\"artifact_id\""));
+    assert!(args.contains("\"redaction_kinds\":[\"env\"]"));
+    assert!(!args.contains(secret));
+    assert!(!args.contains("[REDACTED_ENV]"));
 }
 
 // --- AC #4: scope-OR with dedup --------------------------------------

--- a/crates/orbit-core/src/runtime/orbit_tool_host/mod.rs
+++ b/crates/orbit-core/src/runtime/orbit_tool_host/mod.rs
@@ -1,4 +1,5 @@
 mod adr_tools;
+mod artifact_redaction;
 mod design_tools;
 mod dispatch;
 mod friction_tools;

--- a/crates/orbit-core/src/runtime/orbit_tool_host/test_support.rs
+++ b/crates/orbit-core/src/runtime/orbit_tool_host/test_support.rs
@@ -130,3 +130,44 @@ impl Drop for UnmanagedToolEnvGuard {
         }
     }
 }
+
+pub(super) struct EnvVarGuard {
+    _lock: MutexGuard<'static, ()>,
+    vars: Vec<(&'static str, Option<String>)>,
+}
+
+pub(super) fn env_var_guard(updates: &[(&'static str, Option<&str>)]) -> EnvVarGuard {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    let lock = LOCK
+        .get_or_init(|| Mutex::new(()))
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let vars = updates
+        .iter()
+        .map(|(name, _)| (*name, std::env::var(name).ok()))
+        .collect::<Vec<_>>();
+    // SAFETY: the guard serializes these test env mutations and restores values on drop.
+    unsafe {
+        for (name, value) in updates {
+            match value {
+                Some(value) => std::env::set_var(name, value),
+                None => std::env::remove_var(name),
+            }
+        }
+    }
+    EnvVarGuard { _lock: lock, vars }
+}
+
+impl Drop for EnvVarGuard {
+    fn drop(&mut self) {
+        // SAFETY: the guard holds the serialization lock for the full mutation window.
+        unsafe {
+            for (name, value) in &self.vars {
+                match value {
+                    Some(value) => std::env::set_var(name, value),
+                    None => std::env::remove_var(name),
+                }
+            }
+        }
+    }
+}

--- a/crates/orbit-mcp/src/error.rs
+++ b/crates/orbit-mcp/src/error.rs
@@ -46,6 +46,7 @@ fn error_code(err: &OrbitError) -> &'static str {
         OrbitError::PolicyDenied(_) => "policy_denied",
         OrbitError::TaskApprovalRequired(_) => "approval_required",
         OrbitError::InvalidInput(_) | OrbitError::InvalidInputDiagnostic { .. } => "invalid_input",
+        OrbitError::SensitiveInput(_) => "sensitive_input",
         OrbitError::SkillValidation(_) | OrbitError::JobValidation(_) => "validation_failed",
         OrbitError::TaskStatusTransition(_)
         | OrbitError::JobRunStateTransition(_)

--- a/docs/design/auditability/2_design.md
+++ b/docs/design/auditability/2_design.md
@@ -2,7 +2,7 @@
 
 **Status:** Draft
 **Owner:** codex
-**Last updated:** 2026-05-17 (ORB-00106)
+**Last updated:** 2026-05-17 (ORB-00106, ORB-00137)
 
 This document describes Orbit's shipped auditability implementation across command audit rows, activity/job envelopes, loop-level provider/tool traces, blob storage, redaction, identity attribution, metrics-adjacent invocation records, and known limitations. See [1_overview.md](./1_overview.md) for the feature purpose and [3_vision.md](./3_vision.md) for future questions.
 
@@ -73,7 +73,7 @@ Loop events reference hashes for request bodies, response bodies, tool inputs, a
 
 `crates/orbit-common/src/utility/blob_store.rs` writes content-addressed blobs under `{root}/{hash_prefix}/{hash}`. The hash is computed after redaction, and existing blob paths are reused.
 
-`crates/orbit-common/src/utility/redaction.rs` centralizes sensitive live environment value scrubbing plus regex-based HTTP/argv patterns for authorization headers, API keys, bearer tokens, JSON API-key fields, and bare `sk-...` tokens when argv scrubbing is requested. CLI audit errors, blob bytes, selected pipeline outputs/errors, and the default tracing subscriber all redact before persistence or terminal/JSONL output. The smoke example `crates/orbit-agent/examples/redaction_smoke.rs` verifies stored blob bytes omit the raw secret and contain a marker.
+`crates/orbit-common/src/utility/redaction.rs` centralizes sensitive live environment value scrubbing plus regex-based HTTP, argv, and credential-token patterns for authorization headers, API keys, bearer tokens, JSON API-key fields, `sk-...`, `ghp_...`, and `xox...` tokens. CLI audit errors, blob bytes, selected pipeline outputs/errors, artifact write text, and the default tracing subscriber all redact before persistence or terminal/JSONL output. The smoke example `crates/orbit-agent/examples/redaction_smoke.rs` verifies stored blob bytes omit the raw secret and contain a marker. Artifact write specifics live in [specs/artifact-redaction.md](./specs/artifact-redaction.md). [ORB-00137]
 
 Dashboard log previews added by [T20260508-14] are derived views over `.orbit/state/audit/v2_loop` and `.orbit/state/audit/blobs`; they do not duplicate full transcripts into SQLite. Preview responses are byte- and line-capped, apply defensive read-time redaction with the shared redactor, and preserve existing write-time redaction markers. The focused diagnostics error feed is also derived, combining global ERROR tracing rows with structured `ERROR <target>:` lines found in agent stderr blobs. No `.orbit/state/diagnostics/errors/` store exists in this design; retention remains bounded by the existing v2 audit, blob, and global log retention roots.
 

--- a/docs/design/auditability/specs/artifact-redaction.md
+++ b/docs/design/auditability/specs/artifact-redaction.md
@@ -1,0 +1,65 @@
+# Spec: Artifact Write Redaction
+
+ADR and learning artifact tools redact user-supplied free text before writing
+YAML, markdown, or JSONL artifact files. This is a write-boundary guarantee:
+once persisted, the redacted form is canonical and read paths do not need to
+repair it.
+
+## Tool Fields
+
+- `orbit.adr.add` and `orbit.adr.update`: redact `title` and `body`.
+- `orbit.adr.supersede`: no free-text artifact fields; the success response
+  still reports `redactions_applied: false`.
+- `orbit.learning.add` and `orbit.learning.update`: redact `summary`, `body`,
+  `scope.tags`, and `evidence[].ref`.
+- `orbit.learning.add` and `orbit.learning.update`: apply only home-directory
+  normalization to `scope.paths` so glob syntax is preserved.
+- `orbit.learning.comment.add`: redact `body`.
+- `orbit.learning.supersede`: no free-text artifact fields; the success
+  response still reports `redactions_applied: false`.
+
+Every redacted write response includes `redactions_applied: true` when any
+persisted field differs from the caller's input. Unchanged writes include
+`redactions_applied: false`.
+
+## Refuse Versus Mask
+
+All masking goes through `orbit_common::utility::redaction::redact_all` followed
+by `redact_home_dir`, except `scope.paths`, which uses `redact_home_dir` only.
+The default pattern redactor masks embedded credential-shaped tokens in prose.
+
+A field is refused with `OrbitError::SensitiveInput` when the entire trimmed
+value is one high-confidence credential token and it was not already scrubbed
+as a live sensitive environment value. The explicit token formats are:
+
+- `^sk-[A-Za-z0-9_-]{20,}$`
+- `^ghp_[A-Za-z0-9]{36}$`
+- `^xox[baprs]-[A-Za-z0-9-]{10,}$`
+
+The same token embedded in larger prose is masked in place, not rejected. A
+live `GITHUB_TOKEN` value is also masked as `[REDACTED_ENV]` instead of being
+refused, because the environment redactor can prove the source of the value.
+
+## Idempotence
+
+Redaction markers are stable. Running `redact_all(redact_all(x))` must equal
+`redact_all(x)` for artifact fixtures, and learning tag normalization preserves
+`[REDACTED_*]` markers rather than lowercasing them.
+
+## Audit Events
+
+Each field that changes emits a command-audit event with
+`target_type: artifact_redaction`, the artifact ID, the field name, and the
+redaction kinds applied: `env`, `pattern`, and/or `home_dir`. Audit payloads
+must not contain either original values or redacted values.
+
+## Non-Goals
+
+Structural IDs, lifecycle statuses, owner/model identity, related task IDs,
+related feature names, legacy IDs, validation warnings, priorities, evidence
+kinds, supersession IDs, and comment parent IDs are not redacted by this
+artifact-write boundary.
+
+## Task References
+
+- [ORB-00137]

--- a/docs/design/auditability/specs/redaction-retention.md
+++ b/docs/design/auditability/specs/redaction-retention.md
@@ -13,6 +13,8 @@ Auditability and secrecy pull in opposite directions. Orbit needs faithful recor
 - Pipeline outputs persisted by runtime helpers are scrubbed for sensitive live environment values.
 - HTTP-shaped payload redaction covers authorization headers, x-api-key headers, JSON API-key fields, and bearer tokens.
 - CLI argv redaction uses HTTP defaults plus bare `sk-...` token scrubbing when argv-shaped data is being persisted.
+- ADR and learning artifact write tools redact free-text fields before YAML,
+  markdown, or JSONL persistence; see [artifact-redaction.md](./artifact-redaction.md).
 - Default tracing output redacts string field values, `Debug`-formatted field values, and unstructured `message` fields before writing stderr or `~/.orbit/state/logs/orbit.jsonl`.
 - Readers should not need to apply the standard redactor again for normal stored blobs.
 

--- a/scripts/check-artifact-redaction-boundary.sh
+++ b/scripts/check-artifact-redaction-boundary.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$repo_root"
+
+targets=(
+  "crates/orbit-core/src/runtime/orbit_tool_host"
+  "crates/orbit-tools/src/builtin/orbit/adr"
+  "crates/orbit-tools/src/builtin/orbit/learning"
+  "crates/orbit-store/src/file/adr_store"
+  "crates/orbit-store/src/file/learning_store"
+)
+
+if hits="$(rg -n 'fn[[:space:]]+redact_[A-Za-z0-9_]*' "${targets[@]}" --glob '*.rs')"; then
+  cat >&2 <<EOF
+Artifact write surfaces must use orbit_common::utility::redaction instead of
+defining local redact_* helpers:
+
+$hits
+EOF
+  exit 1
+fi

--- a/scripts/ci-guardrails.sh
+++ b/scripts/ci-guardrails.sh
@@ -20,3 +20,4 @@ RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --workspace
 "$repo_root/scripts/check-cli-imports.sh"
 "$repo_root/scripts/check-stability.sh"
 "$repo_root/scripts/check-learning-layout.sh"
+"$repo_root/scripts/check-artifact-redaction-boundary.sh"


### PR DESCRIPTION
## Task

[ORB-00137](https://orbit-cli.com/tasks/ORB-00137) — Apply secret redaction to ADR + learning artifact tools before YAML persistence

### Description

## Problem

`orbit.adr.add`, `orbit.adr.update`, `orbit.adr.supersede`, `orbit.learning.add`, `orbit.learning.update`, `orbit.learning.supersede`, `orbit.learning.comment.add` all accept arbitrary agent-supplied free text (title, body, summary, comment, evidence ref) and persist it verbatim to `.orbit/adrs/<id>/body.md` / `.orbit/learnings/<id>/learning.yaml`. None of these tools currently invoke the unified redaction module that already exists at `crates/orbit-common/src/utility/redaction.rs`.

Grep confirms the gap: `crates/orbit-tools/src/builtin/orbit/{learning,adr}/` contains zero references to `redact*`.

Result: an agent-supplied body containing a `sk-...` provider key, a `Bearer ...` token, the live process's `GITHUB_TOKEN` value, or a `/Users/<name>/...` HOME path lands in git history unredacted. Once committed, the secret is permanent — rewriting history is destructive and remote-visible if pushed.

ORB-00136 (auto-publish) amplifies this risk to `origin/agent-main` on every artifact write. But the risk exists *today* for any artifact that gets committed manually — the recent uncommitted pile (L20260517-13, ADR-0165, etc.) would have committed verbatim with whatever an agent happened to paste in.

## Why It Matters

ADRs and learnings are explicitly designed for cross-workspace sharing via git history — that's the point of keeping them in-repo. Every leaked secret reaches every fork, clone, and consumer indefinitely. The redaction primitives are already built; they just aren't wired into the artifact write path.

## Approach (suggested, not prescriptive)

At the boundary in each artifact tool where user-supplied text is about to be serialized into YAML or markdown:

1. Run `orbit_common::utility::redaction::redact_all` on the value (env-var scrub + default `PatternRedactor`).
2. Run `redact_home_dir` on the same value to normalize `$HOME` / `$USERPROFILE` to `~`.
3. If the result still contains a high-confidence single-token secret (e.g. the entire value matches `^sk-[A-Za-z0-9_-]{20,}$` or similar known formats), return a typed `OrbitError` refusing the write — force the agent to fix at source rather than silently masking what is clearly meant as a credential.
4. Otherwise, persist the redacted form.

Fields in scope:

- ADR: `title`, `body` (markdown). Structural fields (`related_features`, `related_tasks`, `legacy_ids`, `status`, `owner`) are controlled enums/IDs — no redaction needed.
- Learning: `summary`, `body` (markdown), `scope.tags` (free text), `evidence[].ref` (free text). `scope.paths` glob patterns should run through `redact_home_dir` only (do not pattern-scrub; a path that *looks* like a token shape is still a path).
- Learning comment: `body`.

## Constraints / Notes

- **Reuse the existing module.** Do NOT introduce a parallel redactor. `crates/orbit-common/src/utility/redaction.rs` is the documented single source of truth.
- **Idempotent.** Re-redacting an already-redacted string is a no-op; tests should cover that running `redact_all` twice yields the same output.
- **Tool boundary, not display boundary.** Redaction happens before write, not at read/render time. Once persisted, the redacted form is canonical.
- **Don't silently truncate.** If redaction changes the payload, the tool's success response includes a `redactions_applied: true` flag so the caller knows the persisted form differs from input.
- **Audit.** Emit one audit event per redaction with the artifact ID and the kinds of redaction applied (`env`, `pattern`, `home_dir`); do not log the original or redacted values.
- **Refusal vs mask.** High-confidence credentials → refuse with typed error. Embedded env values, partial patterns → mask in place. The line between the two is the heuristic call — document it in the design doc.

## Relationship to ORB-00136

ORB-00136 (auto-publish) must list this task as a hard dependency. Auto-publish to `origin` without redaction is a remote-visible secret exposure waiting to happen. This task stands on its own merits even if auto-publish never ships — committed-but-not-pushed artifacts are still in local history forever.

### Acceptance Criteria

- All artifact write tools (`orbit.adr.add|update|supersede`, `orbit.learning.add|update|supersede|comment.add`) call `orbit_common::utility::redaction::redact_all` and `redact_home_dir` on every user-supplied free-text field before serializing to YAML/markdown. Test: feed a field containing the live process's `GITHUB_TOKEN` value and assert the on-disk YAML contains `[REDACTED_ENV]` instead.
- Fields covered: ADR `title` + `body`; learning `summary` + `body` + `scope.tags` + `evidence[].ref`; comment `body`. Test asserts redaction on each field via a fixture covering all of them.
- `scope.paths` glob entries pass through `redact_home_dir` only (not pattern redaction); a path like `/Users/<name>/workspace/...` lands as `~/workspace/...` in YAML. Test asserts a HOME-prefixed path is normalized but a glob that happens to contain a token-shape character class is preserved verbatim.
- High-confidence single-token credentials (input value matches a known credential format end-to-end, e.g. `^sk-[A-Za-z0-9_-]{20,}$`, `^ghp_[A-Za-z0-9]{36}$`, `^xox[baprs]-[A-Za-z0-9-]{10,}$`) trigger a typed `OrbitError` and reject the write; the partial form embedded in larger prose is masked, not rejected. Test covers both branches with explicit fixtures.
- The tool's success response gains a `redactions_applied: bool` flag set to `true` when any field's persisted form differs from input. Test asserts the flag's presence and value across redacted and unredacted invocations.
- Re-redacting an already-redacted payload is idempotent: running `redact_all(redact_all(x))` equals `redact_all(x)` for fixture inputs. Test asserts equality.
- An audit event is emitted per redaction with the artifact ID and a list of redaction kinds applied (`env` | `pattern` | `home_dir`); the original and redacted values are NOT included in the event. Assert via `orbit audit list --json` (per L20260517-9, do not query `.orbit/orbit.db` directly).
- A short design doc under `docs/design/<feature-folder>/` describes: which fields are redacted on which tools, the refuse-vs-mask heuristic with explicit credential format regexes, the idempotence guarantee, and a non-goal section listing what is NOT redacted (structural IDs, statuses, etc.).
- No new redaction code paths are introduced; all redaction goes through `orbit_common::utility::redaction`. A grep-based guardrail test (similar to existing guardrails) asserts no other crate defines a function matching `fn redact_*` for artifact fields.
- L20260517-9 cited at any new audit-querying code site.
- Once this task is `done`, ORB-00136's dependency-readiness check passes.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Added artifact write sanitization at the ADR and learning tool-host boundary using orbit_common::utility::redaction for env, pattern, and home-dir scrubbing.
- Added SensitiveInput refusal for whole-field credential tokens while masking embedded token shapes in prose.
- Added redactions_applied response flags and per-field artifact_redaction audit events without raw or redacted values.
- Covered ADR title/body, learning summary/body/scope.tags/evidence refs, learning scope.paths home-only normalization, and learning comment bodies with tests.
- Documented the artifact redaction contract under docs/design/auditability/specs/ and added a guardrail script to prevent local redact_* helpers on artifact write surfaces.

Assessment: Targeted tests, cargo check, CLI audit-list coverage, and make ci-fast pass. A broad orbit_tool_host test sweep also ran; the new redaction tests passed, while three unrelated environment-sensitive review/task identity tests failed under this activity environment.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-00137-6a0a46be`
- Behind base: 0
- Ahead of base: 1