### PR TITLE
Apply secret redaction to Orbit artifact write tools

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -117,6 +117,7 @@ ci-fast:
 	./scripts/check-cli-imports.sh
 	./scripts/check-stability.sh
 	./scripts/check-learning-layout.sh
+	./scripts/check-artifact-redaction-guardrail.sh
 
 # Verify every workspace crate declares its stability tier
 stability:

--- a/crates/orbit-cli/src/output/json.rs
+++ b/crates/orbit-cli/src/output/json.rs
@@ -55,6 +55,7 @@ fn error_code(error: &OrbitError) -> &'static str {
         OrbitError::TaskApprovalRequired(_) => "task_approval_required",
         OrbitError::CompanionNotInstalled(_) => "companion_not_installed",
         OrbitError::InvalidInput(_) | OrbitError::InvalidInputDiagnostic { .. } => "invalid_input",
+        OrbitError::SensitiveInput { .. } => "sensitive_input",
         OrbitError::SkillValidation(_) => "skill_validation_failed",
         OrbitError::JobValidation(_) => "job_validation_failed",
         OrbitError::AgentProtocolViolation(_) => "agent_protocol_violation",

--- a/crates/orbit-common/src/types/error.rs
+++ b/crates/orbit-common/src/types/error.rs
@@ -52,6 +52,8 @@ pub enum OrbitError {
     CompanionNotInstalled(String),
     #[error("invalid input: {0}")]
     InvalidInput(String),
+    #[error("sensitive input rejected for `{field}`: {reason}")]
+    SensitiveInput { field: String, reason: String },
     #[error("invalid input: {message}")]
     InvalidInputDiagnostic {
         message: String,

--- a/crates/orbit-common/src/utility/redaction.rs
+++ b/crates/orbit-common/src/utility/redaction.rs
@@ -31,6 +31,7 @@ use crate::types::OrbitError;
 
 const REDACTED_ENV_VALUE: &str = "[REDACTED_ENV]";
 static DEFAULT_PATTERN_REDACTOR: OnceLock<PatternRedactor> = OnceLock::new();
+static HIGH_CONFIDENCE_SINGLE_TOKEN_PATTERNS: OnceLock<Vec<Regex>> = OnceLock::new();
 
 // ---------------------------------------------------------------------------
 // Env-var value scrubbing
@@ -97,6 +98,10 @@ pub fn redact_sensitive_env_error(error: OrbitError) -> OrbitError {
             OrbitError::CompanionNotInstalled(redact_sensitive_env_text(&m))
         }
         OrbitError::InvalidInput(m) => OrbitError::InvalidInput(redact_sensitive_env_text(&m)),
+        OrbitError::SensitiveInput { field, reason } => OrbitError::SensitiveInput {
+            field: redact_sensitive_env_text(&field),
+            reason: redact_sensitive_env_text(&reason),
+        },
         OrbitError::InvalidInputDiagnostic {
             message,
             did_you_mean,
@@ -217,6 +222,18 @@ impl PatternRedactor {
                 Regex::new(r"(?im)^(\s*api[_-]?key\s*:\s*).+$").expect("valid regex"),
                 "${1}[REDACTED_AUTH]",
             ),
+            (
+                Regex::new(r"sk-[A-Za-z0-9_\-]{20,}").expect("valid regex"),
+                "[REDACTED_SECRET]",
+            ),
+            (
+                Regex::new(r"ghp_[A-Za-z0-9]{36}").expect("valid regex"),
+                "[REDACTED_SECRET]",
+            ),
+            (
+                Regex::new(r"xox[baprs]-[A-Za-z0-9\-]{10,}").expect("valid regex"),
+                "[REDACTED_SECRET]",
+            ),
         ];
         Self { patterns }
     }
@@ -275,6 +292,33 @@ pub fn redact_all(input: &str) -> String {
     default_pattern_redactor().apply_str(&env_scrubbed)
 }
 
+/// Return true when `input` is exactly one high-confidence credential token.
+///
+/// Callers that persist free-text artifacts can reject these whole-token values
+/// instead of merely masking them; embedded occurrences are still handled by
+/// [`redact_all`].
+pub fn is_high_confidence_single_token_credential(input: &str) -> bool {
+    let trimmed = input.trim();
+    if trimmed.is_empty() || trimmed.split_whitespace().count() != 1 {
+        return false;
+    }
+    high_confidence_single_token_patterns()
+        .iter()
+        .any(|pattern| pattern.is_match(trimmed))
+}
+
 pub(crate) fn default_pattern_redactor() -> &'static PatternRedactor {
     DEFAULT_PATTERN_REDACTOR.get_or_init(PatternRedactor::http_default)
+}
+
+fn high_confidence_single_token_patterns() -> &'static [Regex] {
+    HIGH_CONFIDENCE_SINGLE_TOKEN_PATTERNS
+        .get_or_init(|| {
+            vec![
+                Regex::new(r"^sk-[A-Za-z0-9_\-]{20,}$").expect("valid regex"),
+                Regex::new(r"^ghp_[A-Za-z0-9]{36}$").expect("valid regex"),
+                Regex::new(r"^xox[baprs]-[A-Za-z0-9\-]{10,}$").expect("valid regex"),
+            ]
+        })
+        .as_slice()
 }

--- a/crates/orbit-core/src/runtime/orbit_tool_host/artifact_redaction.rs
+++ b/crates/orbit-core/src/runtime/orbit_tool_host/artifact_redaction.rs
@@ -1,0 +1,1007 @@
+use std::collections::BTreeSet;
+
+use orbit_common::types::{
+    AuditEventStatus, OrbitError, audit_execution_id, normalize_optional_attribution_label,
+};
+use orbit_common::utility::redaction::{
+    is_high_confidence_single_token_credential, redact_all, redact_home_dir,
+    redact_sensitive_env_text,
+};
+use orbit_tools::OrbitBuiltinAction;
+use serde_json::{Map, Value, json};
+
+use crate::{AuditEventInsertParams, OrbitRuntime};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub(super) enum ArtifactRedactionKind {
+    Env,
+    Pattern,
+    HomeDir,
+}
+
+impl ArtifactRedactionKind {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Env => "env",
+            Self::Pattern => "pattern",
+            Self::HomeDir => "home_dir",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct ArtifactRedactionField {
+    pub field_path: String,
+    pub kinds: BTreeSet<ArtifactRedactionKind>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub(super) struct ArtifactRedactionReport {
+    fields: Vec<ArtifactRedactionField>,
+}
+
+impl ArtifactRedactionReport {
+    pub(super) fn redactions_applied(&self) -> bool {
+        !self.fields.is_empty()
+    }
+
+    fn push(&mut self, field_path: String, kinds: BTreeSet<ArtifactRedactionKind>) {
+        if !kinds.is_empty() {
+            self.fields
+                .push(ArtifactRedactionField { field_path, kinds });
+        }
+    }
+}
+
+pub(super) fn sanitize_tool_input(
+    action: OrbitBuiltinAction,
+    input: Value,
+) -> Result<(Value, ArtifactRedactionReport), OrbitError> {
+    let Some(policy) = policy_for_action(action) else {
+        return Ok((input, ArtifactRedactionReport::default()));
+    };
+    let Value::Object(mut object) = input else {
+        return Ok((input, ArtifactRedactionReport::default()));
+    };
+
+    let mut report = ArtifactRedactionReport::default();
+    for field in policy.free_text_fields {
+        sanitize_string_field(&mut object, field, field, TextMode::Free, &mut report)?;
+    }
+    for field in policy.free_text_arrays {
+        sanitize_string_array_field(&mut object, field, field, TextMode::Free, &mut report)?;
+    }
+    for field in policy.path_fields {
+        sanitize_string_field(&mut object, field, field, TextMode::PathOnly, &mut report)?;
+    }
+    for field in policy.path_arrays {
+        sanitize_string_array_field(&mut object, field, field, TextMode::PathOnly, &mut report)?;
+    }
+    for nested in policy.nested_arrays {
+        sanitize_nested_string_array_field(&mut object, nested, &mut report)?;
+    }
+    Ok((Value::Object(object), report))
+}
+
+pub(super) fn finish_tool_response(
+    runtime: &OrbitRuntime,
+    action: OrbitBuiltinAction,
+    response: &mut Value,
+    report: &ArtifactRedactionReport,
+    agent: Option<&str>,
+    model: Option<&str>,
+) -> Result<(), OrbitError> {
+    if !is_covered_mutating_action(action) {
+        return Ok(());
+    }
+    if let Some(object) = response.as_object_mut() {
+        object.insert(
+            "redactions_applied".to_string(),
+            Value::Bool(report.redactions_applied()),
+        );
+    }
+    if report.redactions_applied() {
+        emit_audit_events(runtime, action, response, report, agent, model)?;
+    }
+    Ok(())
+}
+
+#[derive(Clone, Copy)]
+enum TextMode {
+    Free,
+    PathOnly,
+}
+
+#[derive(Clone, Copy)]
+struct NestedArrayPolicy {
+    array_key: &'static str,
+    field_key: &'static str,
+    field_alias: Option<&'static str>,
+    mode: TextMode,
+}
+
+struct ActionPolicy {
+    free_text_fields: &'static [&'static str],
+    free_text_arrays: &'static [&'static str],
+    path_fields: &'static [&'static str],
+    path_arrays: &'static [&'static str],
+    nested_arrays: &'static [NestedArrayPolicy],
+}
+
+const LEARNING_NESTED: &[NestedArrayPolicy] = &[
+    NestedArrayPolicy {
+        array_key: "scope",
+        field_key: "tags",
+        field_alias: None,
+        mode: TextMode::Free,
+    },
+    NestedArrayPolicy {
+        array_key: "scope",
+        field_key: "paths",
+        field_alias: None,
+        mode: TextMode::PathOnly,
+    },
+    NestedArrayPolicy {
+        array_key: "evidence",
+        field_key: "ref",
+        field_alias: Some("reference"),
+        mode: TextMode::Free,
+    },
+];
+
+const TASK_ADD_NESTED: &[NestedArrayPolicy] = &[
+    NestedArrayPolicy {
+        array_key: "external_refs",
+        field_key: "url",
+        field_alias: None,
+        mode: TextMode::PathOnly,
+    },
+    NestedArrayPolicy {
+        array_key: "externalRefs",
+        field_key: "url",
+        field_alias: None,
+        mode: TextMode::PathOnly,
+    },
+    NestedArrayPolicy {
+        array_key: "external-refs",
+        field_key: "url",
+        field_alias: None,
+        mode: TextMode::PathOnly,
+    },
+];
+
+fn policy_for_action(action: OrbitBuiltinAction) -> Option<ActionPolicy> {
+    match action {
+        OrbitBuiltinAction::AdrAdd | OrbitBuiltinAction::AdrUpdate => Some(ActionPolicy {
+            free_text_fields: &["title", "body"],
+            free_text_arrays: &[],
+            path_fields: &[],
+            path_arrays: &[],
+            nested_arrays: &[],
+        }),
+        OrbitBuiltinAction::LearningAdd | OrbitBuiltinAction::LearningUpdate => {
+            Some(ActionPolicy {
+                free_text_fields: &["summary", "body"],
+                free_text_arrays: &[],
+                path_fields: &[],
+                path_arrays: &[],
+                nested_arrays: LEARNING_NESTED,
+            })
+        }
+        OrbitBuiltinAction::LearningCommentAdd => Some(ActionPolicy {
+            free_text_fields: &["body"],
+            free_text_arrays: &[],
+            path_fields: &[],
+            path_arrays: &[],
+            nested_arrays: &[],
+        }),
+        OrbitBuiltinAction::TaskAdd => Some(ActionPolicy {
+            free_text_fields: &["title", "description", "plan", "comment"],
+            free_text_arrays: &["acceptance_criteria"],
+            path_fields: &[],
+            path_arrays: &["context_files", "context"],
+            nested_arrays: TASK_ADD_NESTED,
+        }),
+        OrbitBuiltinAction::TaskUpdate => Some(ActionPolicy {
+            free_text_fields: &[
+                "title",
+                "description",
+                "plan",
+                "execution_summary",
+                "comment",
+            ],
+            free_text_arrays: &["acceptance_criteria"],
+            path_fields: &[],
+            path_arrays: &["context_files", "context"],
+            nested_arrays: &[],
+        }),
+        OrbitBuiltinAction::TaskReject => Some(ActionPolicy {
+            free_text_fields: &["note", "comment"],
+            free_text_arrays: &[],
+            path_fields: &[],
+            path_arrays: &[],
+            nested_arrays: &[],
+        }),
+        OrbitBuiltinAction::ReviewThreadAdd => Some(ActionPolicy {
+            free_text_fields: &["body"],
+            free_text_arrays: &[],
+            path_fields: &["path"],
+            path_arrays: &[],
+            nested_arrays: &[],
+        }),
+        OrbitBuiltinAction::ReviewThreadReply => Some(ActionPolicy {
+            free_text_fields: &["body"],
+            free_text_arrays: &[],
+            path_fields: &[],
+            path_arrays: &[],
+            nested_arrays: &[],
+        }),
+        OrbitBuiltinAction::FrictionAdd => Some(ActionPolicy {
+            free_text_fields: &["body", "description"],
+            free_text_arrays: &[],
+            path_fields: &[],
+            path_arrays: &[],
+            nested_arrays: &[],
+        }),
+        OrbitBuiltinAction::FrictionUpdate => Some(ActionPolicy {
+            free_text_fields: &["body"],
+            free_text_arrays: &[],
+            path_fields: &[],
+            path_arrays: &[],
+            nested_arrays: &[],
+        }),
+        OrbitBuiltinAction::AdrSupersede | OrbitBuiltinAction::LearningSupersede => {
+            Some(ActionPolicy {
+                free_text_fields: &[],
+                free_text_arrays: &[],
+                path_fields: &[],
+                path_arrays: &[],
+                nested_arrays: &[],
+            })
+        }
+        _ => None,
+    }
+}
+
+fn is_covered_mutating_action(action: OrbitBuiltinAction) -> bool {
+    matches!(
+        action,
+        OrbitBuiltinAction::AdrAdd
+            | OrbitBuiltinAction::AdrUpdate
+            | OrbitBuiltinAction::AdrSupersede
+            | OrbitBuiltinAction::LearningAdd
+            | OrbitBuiltinAction::LearningUpdate
+            | OrbitBuiltinAction::LearningSupersede
+            | OrbitBuiltinAction::LearningCommentAdd
+            | OrbitBuiltinAction::TaskAdd
+            | OrbitBuiltinAction::TaskUpdate
+            | OrbitBuiltinAction::TaskReject
+            | OrbitBuiltinAction::ReviewThreadAdd
+            | OrbitBuiltinAction::ReviewThreadReply
+            | OrbitBuiltinAction::FrictionAdd
+            | OrbitBuiltinAction::FrictionUpdate
+    )
+}
+
+fn sanitize_string_field(
+    object: &mut Map<String, Value>,
+    key: &str,
+    field_path: &str,
+    mode: TextMode,
+    report: &mut ArtifactRedactionReport,
+) -> Result<(), OrbitError> {
+    let Some(Value::String(raw)) = object.get(key) else {
+        return Ok(());
+    };
+    let (sanitized, kinds) = sanitize_string(raw, field_path, mode)?;
+    if sanitized != *raw {
+        object.insert(key.to_string(), Value::String(sanitized));
+        report.push(field_path.to_string(), kinds);
+    }
+    Ok(())
+}
+
+fn sanitize_string_array_field(
+    object: &mut Map<String, Value>,
+    key: &str,
+    field_path: &str,
+    mode: TextMode,
+    report: &mut ArtifactRedactionReport,
+) -> Result<(), OrbitError> {
+    match object.get_mut(key) {
+        Some(Value::String(raw)) => {
+            let (sanitized, kinds) = sanitize_string(raw, field_path, mode)?;
+            if sanitized != *raw {
+                *raw = sanitized;
+                report.push(field_path.to_string(), kinds);
+            }
+        }
+        Some(Value::Array(items)) => {
+            for (index, item) in items.iter_mut().enumerate() {
+                let Value::String(raw) = item else {
+                    continue;
+                };
+                let item_path = format!("{field_path}[{index}]");
+                let (sanitized, kinds) = sanitize_string(raw, &item_path, mode)?;
+                if sanitized != *raw {
+                    *raw = sanitized;
+                    report.push(item_path, kinds);
+                }
+            }
+        }
+        _ => {}
+    }
+    Ok(())
+}
+
+fn sanitize_nested_string_array_field(
+    object: &mut Map<String, Value>,
+    policy: &NestedArrayPolicy,
+    report: &mut ArtifactRedactionReport,
+) -> Result<(), OrbitError> {
+    if policy.array_key == "scope" {
+        let Some(Value::Object(scope)) = object.get_mut("scope") else {
+            return Ok(());
+        };
+        return sanitize_string_array_field(
+            scope,
+            policy.field_key,
+            &format!("scope.{}", policy.field_key),
+            policy.mode,
+            report,
+        );
+    }
+
+    let Some(Value::Array(items)) = object.get_mut(policy.array_key) else {
+        return Ok(());
+    };
+    for (index, item) in items.iter_mut().enumerate() {
+        let Value::Object(entry) = item else {
+            continue;
+        };
+        let Some(key) = entry
+            .contains_key(policy.field_key)
+            .then_some(policy.field_key)
+            .or_else(|| {
+                policy
+                    .field_alias
+                    .filter(|alias| entry.contains_key(*alias))
+            })
+        else {
+            continue;
+        };
+        let Some(Value::String(raw)) = entry.get(key) else {
+            continue;
+        };
+        let field_path = format!("{}[{index}].{key}", policy.array_key);
+        let (sanitized, kinds) = sanitize_string(raw, &field_path, policy.mode)?;
+        if sanitized != *raw {
+            entry.insert(key.to_string(), Value::String(sanitized));
+            report.push(field_path, kinds);
+        }
+    }
+    Ok(())
+}
+
+fn sanitize_string(
+    raw: &str,
+    field_path: &str,
+    mode: TextMode,
+) -> Result<(String, BTreeSet<ArtifactRedactionKind>), OrbitError> {
+    match mode {
+        TextMode::PathOnly => {
+            let sanitized = redact_home_dir(raw);
+            let mut kinds = BTreeSet::new();
+            if sanitized != raw {
+                kinds.insert(ArtifactRedactionKind::HomeDir);
+            }
+            Ok((sanitized, kinds))
+        }
+        TextMode::Free => {
+            if is_high_confidence_single_token_credential(raw) {
+                return Err(OrbitError::SensitiveInput {
+                    field: field_path.to_string(),
+                    reason: "whole-token credentials must not be persisted in Orbit artifacts"
+                        .to_string(),
+                });
+            }
+            let env_scrubbed = redact_sensitive_env_text(raw);
+            let pattern_scrubbed = redact_all(raw);
+            let sanitized = redact_home_dir(&pattern_scrubbed);
+            let mut kinds = BTreeSet::new();
+            if env_scrubbed != raw {
+                kinds.insert(ArtifactRedactionKind::Env);
+            }
+            if pattern_scrubbed != env_scrubbed {
+                kinds.insert(ArtifactRedactionKind::Pattern);
+            }
+            if sanitized != pattern_scrubbed {
+                kinds.insert(ArtifactRedactionKind::HomeDir);
+            }
+            Ok((sanitized, kinds))
+        }
+    }
+}
+
+fn emit_audit_events(
+    runtime: &OrbitRuntime,
+    action: OrbitBuiltinAction,
+    response: &Value,
+    report: &ArtifactRedactionReport,
+    agent: Option<&str>,
+    model: Option<&str>,
+) -> Result<(), OrbitError> {
+    let tool_name = tool_name(action);
+    let artifact = artifact_target(action, response)?;
+    let actor = normalize_optional_attribution_label(model.or(agent), model)
+        .unwrap_or_else(|| runtime.actor_label().to_string());
+
+    for field in &report.fields {
+        let redaction_kinds = field
+            .kinds
+            .iter()
+            .map(|kind| kind.as_str())
+            .collect::<Vec<_>>();
+        let payload = json!({
+            "artifact_type": artifact.artifact_type,
+            "artifact_id": artifact.artifact_id,
+            "field_path": field.field_path,
+            "actor": actor,
+            "tool_name": tool_name,
+            "redaction_kinds": redaction_kinds,
+        });
+        runtime.record_audit_event(&AuditEventInsertParams {
+            execution_id: audit_execution_id("audit-artifact-redaction"),
+            command: "artifact_redaction".to_string(),
+            subcommand: Some("field".to_string()),
+            tool_name: Some(tool_name.to_string()),
+            target_type: Some(artifact.artifact_type.to_string()),
+            target_id: Some(artifact.artifact_id.to_string()),
+            role: actor.clone(),
+            status: AuditEventStatus::Success,
+            exit_code: 0,
+            duration_ms: 0,
+            working_directory: runtime.paths().repo_root.to_string_lossy().into_owned(),
+            arguments_json: Some(payload.to_string()),
+            stdout_truncated: None,
+            stderr_truncated: None,
+            error_message: None,
+            host: std::env::var("HOSTNAME").ok(),
+            pid: std::process::id(),
+            session_id: None,
+            task_id: artifact.task_id.map(ToOwned::to_owned),
+            job_run_id: std::env::var("ORBIT_RUN_ID").ok().filter(|s| !s.is_empty()),
+            activity_id: std::env::var("ORBIT_ACTIVITY_ID")
+                .ok()
+                .filter(|s| !s.is_empty()),
+            step_index: std::env::var("ORBIT_STEP_INDEX")
+                .ok()
+                .and_then(|s| s.parse().ok()),
+        })?;
+    }
+    Ok(())
+}
+
+struct ArtifactTarget<'a> {
+    artifact_type: &'static str,
+    artifact_id: &'a str,
+    task_id: Option<&'a str>,
+}
+
+fn artifact_target(
+    action: OrbitBuiltinAction,
+    response: &Value,
+) -> Result<ArtifactTarget<'_>, OrbitError> {
+    match action {
+        OrbitBuiltinAction::AdrAdd
+        | OrbitBuiltinAction::AdrUpdate
+        | OrbitBuiltinAction::AdrSupersede => Ok(ArtifactTarget {
+            artifact_type: "adr",
+            artifact_id: response_string(response, "id")?,
+            task_id: None,
+        }),
+        OrbitBuiltinAction::LearningAdd
+        | OrbitBuiltinAction::LearningUpdate
+        | OrbitBuiltinAction::LearningSupersede => Ok(ArtifactTarget {
+            artifact_type: "learning",
+            artifact_id: learning_response_id(action, response)?,
+            task_id: None,
+        }),
+        OrbitBuiltinAction::LearningCommentAdd => Ok(ArtifactTarget {
+            artifact_type: "learning_comment",
+            artifact_id: response_string(response, "id")?,
+            task_id: None,
+        }),
+        OrbitBuiltinAction::TaskAdd
+        | OrbitBuiltinAction::TaskUpdate
+        | OrbitBuiltinAction::TaskReject => {
+            let id = response_string(response, "id")?;
+            Ok(ArtifactTarget {
+                artifact_type: "task",
+                artifact_id: id,
+                task_id: Some(id),
+            })
+        }
+        OrbitBuiltinAction::ReviewThreadAdd | OrbitBuiltinAction::ReviewThreadReply => {
+            let id = response_string(response, "id")?;
+            Ok(ArtifactTarget {
+                artifact_type: "review_thread",
+                artifact_id: id,
+                task_id: Some(id),
+            })
+        }
+        OrbitBuiltinAction::FrictionAdd | OrbitBuiltinAction::FrictionUpdate => {
+            Ok(ArtifactTarget {
+                artifact_type: "friction",
+                artifact_id: response_string(response, "id")?,
+                task_id: None,
+            })
+        }
+        _ => Err(OrbitError::Execution(format!(
+            "unsupported redaction audit action: {action:?}"
+        ))),
+    }
+}
+
+fn learning_response_id(action: OrbitBuiltinAction, response: &Value) -> Result<&str, OrbitError> {
+    if action == OrbitBuiltinAction::LearningSupersede {
+        return response
+            .get("old")
+            .and_then(|value| value.get("id"))
+            .and_then(Value::as_str)
+            .ok_or_else(|| {
+                OrbitError::Execution("learning supersede response missing old.id".to_string())
+            });
+    }
+    response_string(response, "id")
+}
+
+fn response_string<'a>(response: &'a Value, field: &str) -> Result<&'a str, OrbitError> {
+    response.get(field).and_then(Value::as_str).ok_or_else(|| {
+        OrbitError::Execution(format!("redaction audit response missing string `{field}`"))
+    })
+}
+
+fn tool_name(action: OrbitBuiltinAction) -> &'static str {
+    match action {
+        OrbitBuiltinAction::AdrAdd => "orbit.adr.add",
+        OrbitBuiltinAction::AdrUpdate => "orbit.adr.update",
+        OrbitBuiltinAction::AdrSupersede => "orbit.adr.supersede",
+        OrbitBuiltinAction::LearningAdd => "orbit.learning.add",
+        OrbitBuiltinAction::LearningUpdate => "orbit.learning.update",
+        OrbitBuiltinAction::LearningSupersede => "orbit.learning.supersede",
+        OrbitBuiltinAction::LearningCommentAdd => "orbit.learning.comment.add",
+        OrbitBuiltinAction::TaskAdd => "orbit.task.add",
+        OrbitBuiltinAction::TaskUpdate => "orbit.task.update",
+        OrbitBuiltinAction::TaskReject => "orbit.task.reject",
+        OrbitBuiltinAction::ReviewThreadAdd => "orbit.task.review_thread.add",
+        OrbitBuiltinAction::ReviewThreadReply => "orbit.task.review_thread.reply",
+        OrbitBuiltinAction::FrictionAdd => "orbit.friction.add",
+        OrbitBuiltinAction::FrictionUpdate => "orbit.friction.update",
+        _ => "orbit.unknown",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::sync::{Mutex, MutexGuard, OnceLock};
+
+    use crate::runtime::orbit_tool_host::test_support::test_runtime;
+
+    struct EnvVarGuard {
+        _lock: MutexGuard<'static, ()>,
+        name: &'static str,
+        previous: Option<String>,
+    }
+
+    impl EnvVarGuard {
+        fn set(name: &'static str, value: &str) -> Self {
+            static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+            let lock = LOCK
+                .get_or_init(|| Mutex::new(()))
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            let previous = std::env::var(name).ok();
+            // SAFETY: this test guard serializes environment mutation and restores on drop.
+            unsafe {
+                std::env::set_var(name, value);
+            }
+            Self {
+                _lock: lock,
+                name,
+                previous,
+            }
+        }
+    }
+
+    impl Drop for EnvVarGuard {
+        fn drop(&mut self) {
+            // SAFETY: the guard holds the serialization lock for the full mutation window.
+            unsafe {
+                match &self.previous {
+                    Some(value) => std::env::set_var(self.name, value),
+                    None => std::env::remove_var(self.name),
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn sanitizer_covers_task_free_text_paths_and_skipped_tags() {
+        let home = std::env::var("HOME").expect("HOME for redaction test");
+        let input = json!({
+            "title": "uses sk-abcdefghijklmnopqrstuvwxyz",
+            "description": "plain",
+            "acceptance_criteria": ["keep ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZabcd123456"],
+            "context_files": [format!("{home}/repo/src/lib.rs"), "glob/[sk-abcdefghijklmnopqrstuvwxyz].rs"],
+            "tags": ["sk-abcdefghijklmnopqrstuvwxyz"],
+        });
+
+        let (sanitized, report) =
+            sanitize_tool_input(OrbitBuiltinAction::TaskAdd, input).expect("sanitize");
+
+        assert!(report.redactions_applied());
+        assert_eq!(sanitized["title"], "uses [REDACTED_SECRET]");
+        assert!(
+            sanitized["acceptance_criteria"][0]
+                .as_str()
+                .expect("criterion")
+                .contains("[REDACTED_SECRET]")
+        );
+        assert_eq!(sanitized["context_files"][0], "~/repo/src/lib.rs");
+        assert_eq!(
+            sanitized["context_files"][1],
+            "glob/[sk-abcdefghijklmnopqrstuvwxyz].rs"
+        );
+        assert_eq!(sanitized["tags"][0], "sk-abcdefghijklmnopqrstuvwxyz");
+    }
+
+    #[test]
+    fn whole_token_credentials_are_rejected_for_representative_free_text_surfaces() {
+        let cases = [
+            (
+                OrbitBuiltinAction::AdrAdd,
+                json!({
+                    "title": "sk-abcdefghijklmnopqrstuvwxyz",
+                    "body": "Body",
+                }),
+            ),
+            (
+                OrbitBuiltinAction::LearningAdd,
+                json!({
+                    "summary": "ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZabcd123456",
+                    "body": "Body",
+                }),
+            ),
+            (
+                OrbitBuiltinAction::TaskAdd,
+                json!({
+                    "title": "xoxb-0123456789",
+                    "description": "Body",
+                    "workspace": ".",
+                }),
+            ),
+            (
+                OrbitBuiltinAction::ReviewThreadAdd,
+                json!({
+                    "id": "ORB-00001",
+                    "body": "sk-abcdefghijklmnopqrstuvwxyz",
+                }),
+            ),
+            (
+                OrbitBuiltinAction::FrictionAdd,
+                json!({
+                    "body": "ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZabcd123456",
+                }),
+            ),
+        ];
+
+        for (action, input) in cases {
+            let err = sanitize_tool_input(action, input).expect_err("whole-token key rejected");
+
+            assert!(
+                matches!(err, OrbitError::SensitiveInput { .. }),
+                "{action:?}: {err:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn learning_policy_treats_tags_as_text_and_paths_as_paths() {
+        let home = std::env::var("HOME").expect("HOME for redaction test");
+        let input = json!({
+            "summary": "summary",
+            "scope": {
+                "tags": ["token ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZabcd123456"],
+                "paths": [format!("{home}/repo/**/*.rs"), "[ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZabcd123456]/**/*.rs"],
+            },
+            "evidence": [{"kind": "task", "ref": "see xoxb-0123456789"}],
+        });
+
+        let (sanitized, report) =
+            sanitize_tool_input(OrbitBuiltinAction::LearningAdd, input).expect("sanitize");
+
+        assert!(report.redactions_applied());
+        assert_eq!(sanitized["scope"]["tags"][0], "token [REDACTED_SECRET]");
+        assert_eq!(sanitized["scope"]["paths"][0], "~/repo/**/*.rs");
+        assert_eq!(
+            sanitized["scope"]["paths"][1],
+            "[ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZabcd123456]/**/*.rs"
+        );
+        assert_eq!(sanitized["evidence"][0]["ref"], "see [REDACTED_SECRET]");
+    }
+
+    #[test]
+    fn already_sanitized_input_is_idempotent() {
+        let input = json!({
+            "id": "ORB-00001",
+            "execution_summary": "token [REDACTED_ENV]",
+        });
+
+        let (_sanitized, report) =
+            sanitize_tool_input(OrbitBuiltinAction::TaskUpdate, input).expect("sanitize");
+
+        assert!(!report.redactions_applied());
+    }
+
+    #[test]
+    fn wrong_types_pass_through_to_existing_parsers() {
+        let input = json!({
+            "title": ["not", "a", "string"],
+            "body": "Body",
+        });
+
+        let (sanitized, report) =
+            sanitize_tool_input(OrbitBuiltinAction::AdrAdd, input.clone()).expect("sanitize");
+
+        assert_eq!(sanitized, input);
+        assert!(!report.redactions_applied());
+    }
+
+    #[test]
+    fn dispatch_redacts_live_github_token_before_task_persistence_and_audits() {
+        let token = "orbit-redaction-secret-value";
+        let _env = EnvVarGuard::set("GITHUB_TOKEN", token);
+        let (_root, runtime, _repo_root) = test_runtime();
+
+        let output = runtime
+            .execute_tool_command(
+                "orbit.task.add",
+                json!({
+                    "title": format!("leaked {token}"),
+                    "description": "body",
+                    "workspace": ".",
+                }),
+                Some("codex".to_string()),
+                Some("gpt-5.5".to_string()),
+            )
+            .expect("task add succeeds");
+
+        assert_eq!(output["redactions_applied"], true);
+        let id = output["id"].as_str().expect("task id");
+        let task = runtime.get_task(id).expect("task persisted");
+        assert_eq!(task.title, "leaked [REDACTED_ENV]");
+        assert!(!task.title.contains(token));
+
+        let events = runtime
+            .list_audit_events(None, Some("orbit.task.add".to_string()), None, None, 16)
+            .expect("L20260517-9: same backing query as `orbit audit list --json`");
+        let redaction_event = events
+            .iter()
+            .find(|event| event.command == "artifact_redaction")
+            .expect("redaction audit event");
+        let arguments = redaction_event
+            .arguments_json
+            .as_deref()
+            .expect("redaction audit payload");
+        assert!(arguments.contains("\"field_path\":\"title\""));
+        assert!(arguments.contains("\"env\""));
+        assert!(!arguments.contains(token));
+    }
+
+    #[test]
+    fn adr_and_learning_dispatch_redact_live_github_token_in_persisted_fields() {
+        let token = "orbit-adr-learning-secret-value";
+        let _env = EnvVarGuard::set("GITHUB_TOKEN", token);
+        let (_root, runtime, _repo_root) = test_runtime();
+
+        let adr = runtime
+            .execute_tool_command(
+                "orbit.adr.add",
+                json!({
+                    "title": format!("decision {token}"),
+                    "body": format!("## Context\n{token}"),
+                }),
+                Some("codex".to_string()),
+                Some("gpt-5.5".to_string()),
+            )
+            .expect("adr add succeeds");
+        assert_eq!(adr["redactions_applied"], true);
+        assert_eq!(adr["title"], "decision [REDACTED_ENV]");
+
+        let learning = runtime
+            .execute_tool_command(
+                "orbit.learning.add",
+                json!({
+                    "summary": format!("summary {token}"),
+                    "body": format!("body {token}"),
+                    "scope": { "tags": [format!("tag {token}")] },
+                    "evidence": [{ "kind": "task", "ref": format!("ref {token}") }],
+                }),
+                Some("codex".to_string()),
+                Some("gpt-5.5".to_string()),
+            )
+            .expect("learning add succeeds");
+        assert_eq!(learning["redactions_applied"], true);
+        assert_eq!(learning["summary"], "summary [REDACTED_ENV]");
+        assert_eq!(learning["body"], "body [REDACTED_ENV]");
+        assert_eq!(learning["scope"]["tags"][0], "tag [redacted_env]");
+        assert_eq!(learning["evidence"][0]["ref"], "ref [REDACTED_ENV]");
+    }
+
+    #[test]
+    fn dispatch_marks_false_and_emits_no_audit_when_input_is_already_sanitized() {
+        let (_root, runtime, _repo_root) = test_runtime();
+        let created = runtime
+            .execute_tool_command(
+                "orbit.task.add",
+                json!({
+                    "title": "plain",
+                    "description": "body",
+                    "workspace": ".",
+                }),
+                Some("codex".to_string()),
+                Some("gpt-5.5".to_string()),
+            )
+            .expect("task add succeeds");
+        let id = created["id"].as_str().expect("task id");
+
+        let output = runtime
+            .execute_tool_command(
+                "orbit.task.update",
+                json!({
+                    "id": id,
+                    "execution_summary": "already [REDACTED_ENV]",
+                }),
+                Some("codex".to_string()),
+                Some("gpt-5.5".to_string()),
+            )
+            .expect("task update succeeds");
+
+        assert_eq!(output["redactions_applied"], false);
+        let events = runtime
+            .list_audit_events(None, Some("orbit.task.update".to_string()), None, None, 16)
+            .expect("L20260517-9: same backing query as `orbit audit list --json`");
+        assert!(
+            events
+                .iter()
+                .all(|event| event.command != "artifact_redaction"),
+            "{events:?}"
+        );
+    }
+
+    #[test]
+    fn dispatch_adds_false_response_flags_for_each_covered_family() {
+        let (_root, runtime, _repo_root) = test_runtime();
+
+        let task = runtime
+            .execute_tool_command(
+                "orbit.task.add",
+                json!({
+                    "title": "plain",
+                    "description": "body",
+                    "workspace": ".",
+                }),
+                Some("codex".to_string()),
+                Some("gpt-5.5".to_string()),
+            )
+            .expect("task add succeeds");
+        assert_eq!(task["redactions_applied"], false);
+        let task_id = task["id"].as_str().expect("task id");
+
+        let adr = runtime
+            .execute_tool_command(
+                "orbit.adr.add",
+                json!({
+                    "title": "Decision",
+                    "body": "## Context\nBody",
+                }),
+                Some("codex".to_string()),
+                Some("gpt-5.5".to_string()),
+            )
+            .expect("adr add succeeds");
+        assert_eq!(adr["redactions_applied"], false);
+
+        let learning = runtime
+            .execute_tool_command(
+                "orbit.learning.add",
+                json!({
+                    "summary": "Always test the seam",
+                    "body": "Body",
+                    "scope": { "paths": ["crates/**"], "tags": ["testing"] },
+                }),
+                Some("codex".to_string()),
+                Some("gpt-5.5".to_string()),
+            )
+            .expect("learning add succeeds");
+        assert_eq!(learning["redactions_applied"], false);
+
+        let review = runtime
+            .execute_tool_command(
+                "orbit.task.review_thread.add",
+                json!({
+                    "id": task_id,
+                    "body": "Please tighten this.",
+                    "path": "src/lib.rs",
+                }),
+                Some("codex".to_string()),
+                Some("gpt-5.5".to_string()),
+            )
+            .expect("review thread add succeeds");
+        assert_eq!(review["redactions_applied"], false);
+
+        let friction = runtime
+            .execute_tool_command(
+                "orbit.friction.add",
+                json!({
+                    "body": "Plain friction report.",
+                    "tags": ["tooling"],
+                }),
+                Some("codex".to_string()),
+                Some("gpt-5.5".to_string()),
+            )
+            .expect("friction add succeeds");
+        assert_eq!(friction["redactions_applied"], false);
+    }
+
+    #[test]
+    fn friction_body_update_is_sanitized_but_tags_are_verbatim() {
+        let token = "orbit-friction-secret-value";
+        let _env = EnvVarGuard::set("GITHUB_TOKEN", token);
+        let (_root, runtime, _repo_root) = test_runtime();
+        let tag = "sk-abcdefghijklmnopqrstuvwx";
+        let frictions_root = runtime.data_root().join("frictions");
+        fs::create_dir_all(&frictions_root).expect("frictions root");
+        fs::write(
+            frictions_root.join("tags.yaml"),
+            format!("{tag}: \"synthetic test tag\"\n"),
+        )
+        .expect("custom friction taxonomy");
+        let created = runtime
+            .execute_tool_command(
+                "orbit.friction.add",
+                json!({
+                    "body": "Plain friction report.",
+                    "tags": [tag],
+                }),
+                Some("codex".to_string()),
+                Some("gpt-5.5".to_string()),
+            )
+            .expect("friction add succeeds");
+        assert_eq!(created["tags"], json!([tag]));
+
+        let updated = runtime
+            .execute_tool_command(
+                "orbit.friction.update",
+                json!({
+                    "id": created["id"],
+                    "body": format!("updated {token}"),
+                    "tags": [tag],
+                }),
+                Some("codex".to_string()),
+                Some("gpt-5.5".to_string()),
+            )
+            .expect("friction update succeeds");
+
+        assert_eq!(updated["redactions_applied"], true);
+        assert_eq!(updated["body"], "updated [REDACTED_ENV]");
+        assert_eq!(updated["tags"], json!([tag]));
+        assert!(
+            !updated["body"].as_str().expect("body").contains(token),
+            "{}",
+            updated
+        );
+    }
+}

--- a/crates/orbit-core/src/runtime/orbit_tool_host/design_tools.rs
+++ b/crates/orbit-core/src/runtime/orbit_tool_host/design_tools.rs
@@ -54,7 +54,6 @@ fn workspace_root(input: &Value) -> Result<std::path::PathBuf, OrbitError> {
 mod tests {
     use orbit_common::types::NotFoundKind;
     use serde_json::json;
-    use serde_json::json;
 
     use super::*;
     use crate::runtime::orbit_tool_host::test_support::test_runtime;

--- a/crates/orbit-core/src/runtime/orbit_tool_host/dispatch.rs
+++ b/crates/orbit-core/src/runtime/orbit_tool_host/dispatch.rs
@@ -13,7 +13,10 @@ pub(super) fn execute(
     model: Option<String>,
     reservation_owner: Option<ReservationOwnerContext>,
 ) -> Result<Value, OrbitError> {
-    match action {
+    let (input, redaction_report) = super::artifact_redaction::sanitize_tool_input(action, input)?;
+    let agent_for_audit = agent.clone();
+    let model_for_audit = model.clone();
+    let mut response = match action {
         OrbitBuiltinAction::AdrAdd => super::adr_tools::add(runtime, input, agent, model),
         OrbitBuiltinAction::AdrShow => super::adr_tools::show(runtime, input),
         OrbitBuiltinAction::AdrList => super::adr_tools::list(runtime, input),
@@ -92,5 +95,14 @@ pub(super) fn execute(
         OrbitBuiltinAction::TaskShow => super::task_tools::show(runtime, input),
         OrbitBuiltinAction::TaskStart => super::task_tools::start(runtime, input, agent, model),
         OrbitBuiltinAction::TaskUpdate => super::task_tools::update(runtime, input, agent, model),
-    }
+    }?;
+    super::artifact_redaction::finish_tool_response(
+        runtime,
+        action,
+        &mut response,
+        &redaction_report,
+        agent_for_audit.as_deref(),
+        model_for_audit.as_deref(),
+    )?;
+    Ok(response)
 }

--- a/crates/orbit-core/src/runtime/orbit_tool_host/friction_tools.rs
+++ b/crates/orbit-core/src/runtime/orbit_tool_host/friction_tools.rs
@@ -105,9 +105,10 @@ pub(super) fn update(runtime: &OrbitRuntime, input: Value) -> Result<Value, Orbi
         .map(|status| parse_status(&status))
         .transpose()?;
     let tags = optional_csv_or_string_list_alias(&input, &["tags", "tag"])?;
-    if status.is_none() && tags.is_none() {
+    let body = optional_string(&input, "body")?;
+    if status.is_none() && tags.is_none() && body.is_none() {
         return Err(OrbitError::InvalidInput(
-            "orbit.friction.update requires `status` or `tags`".to_string(),
+            "orbit.friction.update requires `status`, `tags`, or `body`".to_string(),
         ));
     }
     let stored = update_friction(
@@ -116,6 +117,7 @@ pub(super) fn update(runtime: &OrbitRuntime, input: Value) -> Result<Value, Orbi
         FrictionUpdateParams {
             status,
             tags,
+            body,
             resolved_by_task: None,
             updated_at: Utc::now(),
         },

--- a/crates/orbit-core/src/runtime/orbit_tool_host/mod.rs
+++ b/crates/orbit-core/src/runtime/orbit_tool_host/mod.rs
@@ -1,4 +1,5 @@
 mod adr_tools;
+mod artifact_redaction;
 mod design_tools;
 mod dispatch;
 mod friction_tools;

--- a/crates/orbit-mcp/src/error.rs
+++ b/crates/orbit-mcp/src/error.rs
@@ -46,6 +46,7 @@ fn error_code(err: &OrbitError) -> &'static str {
         OrbitError::PolicyDenied(_) => "policy_denied",
         OrbitError::TaskApprovalRequired(_) => "approval_required",
         OrbitError::InvalidInput(_) | OrbitError::InvalidInputDiagnostic { .. } => "invalid_input",
+        OrbitError::SensitiveInput { .. } => "sensitive_input",
         OrbitError::SkillValidation(_) | OrbitError::JobValidation(_) => "validation_failed",
         OrbitError::TaskStatusTransition(_)
         | OrbitError::JobRunStateTransition(_)

--- a/crates/orbit-store/src/file/friction_store.rs
+++ b/crates/orbit-store/src/file/friction_store.rs
@@ -38,6 +38,7 @@ pub struct FrictionListFilter {
 pub struct FrictionUpdateParams {
     pub status: Option<FrictionStatus>,
     pub tags: Option<Vec<String>>,
+    pub body: Option<String>,
     pub resolved_by_task: Option<String>,
     pub updated_at: DateTime<Utc>,
 }
@@ -180,6 +181,9 @@ pub fn update_friction(
             let taxonomy = load_tag_taxonomy(frictions_root)?;
             stored.record.tags = normalize_and_validate_tags(tags, &taxonomy)?;
         }
+        if let Some(body) = params.body {
+            stored.record.body = body;
+        }
         if let Some(status) = params.status {
             stored.record.status = status;
             stored.record.resolved_at = match status {
@@ -216,6 +220,7 @@ pub fn resolve_friction(
         FrictionUpdateParams {
             status: Some(FrictionStatus::Resolved),
             tags: None,
+            body: None,
             resolved_by_task: None,
             updated_at: resolved_at,
         },
@@ -234,6 +239,7 @@ pub fn resolve_friction_by_task(
         FrictionUpdateParams {
             status: Some(FrictionStatus::Resolved),
             tags: None,
+            body: None,
             resolved_by_task: Some(task_id.to_string()),
             updated_at: resolved_at,
         },

--- a/crates/orbit-tools/src/builtin/orbit/friction/update.rs
+++ b/crates/orbit-tools/src/builtin/orbit/friction/update.rs
@@ -33,6 +33,12 @@ impl Tool for OrbitFrictionUpdateTool {
                     param_type: "string_list".to_string(),
                     required: false,
                 },
+                ToolParam {
+                    name: "body".to_string(),
+                    description: "Optional replacement markdown body".to_string(),
+                    param_type: "string".to_string(),
+                    required: false,
+                },
             ],
             builtin: true,
         }

--- a/docs/design/auditability/2_design.md
+++ b/docs/design/auditability/2_design.md
@@ -2,7 +2,7 @@
 
 **Status:** Draft
 **Owner:** codex
-**Last updated:** 2026-05-17 (ORB-00106)
+**Last updated:** 2026-05-17 (ORB-00138)
 
 This document describes Orbit's shipped auditability implementation across command audit rows, activity/job envelopes, loop-level provider/tool traces, blob storage, redaction, identity attribution, metrics-adjacent invocation records, and known limitations. See [1_overview.md](./1_overview.md) for the feature purpose and [3_vision.md](./3_vision.md) for future questions.
 
@@ -73,7 +73,7 @@ Loop events reference hashes for request bodies, response bodies, tool inputs, a
 
 `crates/orbit-common/src/utility/blob_store.rs` writes content-addressed blobs under `{root}/{hash_prefix}/{hash}`. The hash is computed after redaction, and existing blob paths are reused.
 
-`crates/orbit-common/src/utility/redaction.rs` centralizes sensitive live environment value scrubbing plus regex-based HTTP/argv patterns for authorization headers, API keys, bearer tokens, JSON API-key fields, and bare `sk-...` tokens when argv scrubbing is requested. CLI audit errors, blob bytes, selected pipeline outputs/errors, and the default tracing subscriber all redact before persistence or terminal/JSONL output. The smoke example `crates/orbit-agent/examples/redaction_smoke.rs` verifies stored blob bytes omit the raw secret and contain a marker.
+`crates/orbit-common/src/utility/redaction.rs` centralizes sensitive live environment value scrubbing plus regex-based HTTP/argv patterns for authorization headers, API keys, bearer tokens, JSON API-key fields, and high-confidence provider token shapes. CLI audit errors, blob bytes, selected pipeline outputs/errors, artifact write tools, and the default tracing subscriber all redact before persistence or terminal/JSONL output. Artifact tool coverage and refuse-vs-mask rules live in [specs/artifact-redaction.md](./specs/artifact-redaction.md). The smoke example `crates/orbit-agent/examples/redaction_smoke.rs` verifies stored blob bytes omit the raw secret and contain a marker.
 
 Dashboard log previews added by [T20260508-14] are derived views over `.orbit/state/audit/v2_loop` and `.orbit/state/audit/blobs`; they do not duplicate full transcripts into SQLite. Preview responses are byte- and line-capped, apply defensive read-time redaction with the shared redactor, and preserve existing write-time redaction markers. The focused diagnostics error feed is also derived, combining global ERROR tracing rows with structured `ERROR <target>:` lines found in agent stderr blobs. No `.orbit/state/diagnostics/errors/` store exists in this design; retention remains bounded by the existing v2 audit, blob, and global log retention roots.
 

--- a/docs/design/auditability/specs/artifact-redaction.md
+++ b/docs/design/auditability/specs/artifact-redaction.md
@@ -1,0 +1,53 @@
+# Spec: Artifact Write Redaction
+
+Orbit artifact tools persist repo-backed YAML, markdown, and JSON. Their write boundary sanitizes selected input fields after `OrbitBuiltinAction` is known and before typed params are built. The sanitizer is action-keyed rather than field-blind, so structural IDs, statuses, tags, and artifact blobs keep their native validation rules.
+
+## Field Policy
+
+| Tool | Free text (`redact_all` + `redact_home_dir`) | Path-only (`redact_home_dir`) | Skip |
+|------|----------------------------------------------|-------------------------------|------|
+| `orbit.adr.add` / `orbit.adr.update` | `title`, `body` | - | status, owner, related ids/features/tasks, legacy ids |
+| `orbit.adr.supersede` | - | - | `old_id`, `new_id` |
+| `orbit.learning.add` / `orbit.learning.update` | `summary`, `body`, `scope.tags[]`, `evidence[].ref` | `scope.paths[]` | status, ids, priority, votes, model fields |
+| `orbit.learning.supersede` | - | - | `old_id`, `new_id` |
+| `orbit.learning.comment.add` | `body` | - | `learning_id`, `model` |
+| `orbit.task.add` | `title`, `description`, `plan`, `acceptance_criteria[]`, `comment` | `context_files[]`, `context`, `external_refs[].url` | workspace, ids, enums, dependency/relation targets, crew, tags |
+| `orbit.task.update` | `title`, `description`, `plan`, `execution_summary`, `acceptance_criteria[]`, `comment` | `context_files[]`, `context` | provenance/status/identity fields, tags, raw artifacts |
+| `orbit.task.reject` | `note`, `comment` | - | `id` |
+| `orbit.task.review_thread.add` | `body` | `path` | `id`, `line`, `model` |
+| `orbit.task.review_thread.reply` | `body` | - | `id`, `thread_id`, `model` |
+| `orbit.friction.add` | `body` | - | `model`, `during_task`, tags |
+| `orbit.friction.update` | `body` | - | `id`, status, tags |
+
+Task and friction tags are taxonomy fields and pass through verbatim. Learning `scope.tags[]` are matching metadata and are treated as free text.
+
+## Refuse vs Mask
+
+Free-text fields reject a value that is exactly one high-confidence credential token:
+
+- `^sk-[A-Za-z0-9_-]{20,}$`
+- `^ghp_[A-Za-z0-9]{36}$`
+- `^xox[baprs]-[A-Za-z0-9-]{10,}$`
+
+The rejection is a typed `OrbitError::SensitiveInput` and never includes the token value. The same token shapes embedded in larger prose are masked by the shared redaction module. Path-only fields only normalize HOME-prefixed strings; token-shaped globs and character classes are preserved.
+
+## Response and Audit Contract
+
+Covered mutating tools add `redactions_applied: bool` to object responses. It is `true` only when at least one persisted field changed from the caller's input. Re-running a write with already-redacted text is idempotent: no field changes means `redactions_applied: false` and no redaction audit event.
+
+When a field changes, Orbit emits one command-audit row per field. The payload contains only:
+
+- artifact type and id
+- field path
+- actor
+- tool name
+- redaction kinds: `env`, `pattern`, `home_dir`
+
+Original and redacted values are not recorded. Tests should inspect these rows through the same backing surface as `orbit audit list --json` per L20260517-9.
+
+## Non-Goals
+
+- Display-time/read-time redaction.
+- Raw task artifact blob redaction through `orbit.task.artifact.put` or task `artifacts` / `upsert_artifacts`.
+- General-purpose schema validation in the sanitizer; existing typed parsers keep reporting shape errors.
+- Auto-publish, commit, or remote cleanup behavior after a secret has already entered history.

--- a/docs/design/auditability/specs/redaction-retention.md
+++ b/docs/design/auditability/specs/redaction-retention.md
@@ -12,7 +12,9 @@ Auditability and secrecy pull in opposite directions. Orbit needs faithful recor
 - Command audit error messages are scrubbed for sensitive live environment values before insertion.
 - Pipeline outputs persisted by runtime helpers are scrubbed for sensitive live environment values.
 - HTTP-shaped payload redaction covers authorization headers, x-api-key headers, JSON API-key fields, and bearer tokens.
+- Shared pattern redaction covers high-confidence provider token shapes embedded in prose; exact whole-token artifact fields are rejected instead of persisted.
 - CLI argv redaction uses HTTP defaults plus bare `sk-...` token scrubbing when argv-shaped data is being persisted.
+- Orbit artifact write tools use the action-keyed field policy in [artifact-redaction.md](./artifact-redaction.md) before YAML/markdown/JSON persistence.
 - Default tracing output redacts string field values, `Debug`-formatted field values, and unstructured `message` fields before writing stderr or `~/.orbit/state/logs/orbit.jsonl`.
 - Readers should not need to apply the standard redactor again for normal stored blobs.
 

--- a/scripts/check-artifact-redaction-guardrail.sh
+++ b/scripts/check-artifact-redaction-guardrail.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$repo_root"
+
+targets=(
+  "crates/orbit-core/src/runtime/orbit_tool_host/adr_tools.rs"
+  "crates/orbit-core/src/runtime/orbit_tool_host/learning_tools.rs"
+  "crates/orbit-core/src/runtime/orbit_tool_host/task_tools.rs"
+  "crates/orbit-core/src/runtime/orbit_tool_host/review_threads.rs"
+  "crates/orbit-core/src/runtime/orbit_tool_host/friction_tools.rs"
+  "crates/orbit-tools/src/builtin/orbit/adr"
+  "crates/orbit-tools/src/builtin/orbit/learning"
+  "crates/orbit-tools/src/builtin/orbit/task"
+  "crates/orbit-tools/src/builtin/orbit/review_thread"
+  "crates/orbit-tools/src/builtin/orbit/friction"
+)
+
+if rg -n 'fn\s+redact_' "${targets[@]}"; then
+  cat >&2 <<'MSG'
+Artifact write redaction must flow through orbit_common::utility::redaction and the shared tool-host policy.
+Do not add surface-local `fn redact_*` helpers for ADR, learning, task, review-thread, or friction tools.
+MSG
+  exit 1
+fi

--- a/scripts/ci-guardrails.sh
+++ b/scripts/ci-guardrails.sh
@@ -20,3 +20,4 @@ RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --workspace
 "$repo_root/scripts/check-cli-imports.sh"
 "$repo_root/scripts/check-stability.sh"
 "$repo_root/scripts/check-learning-layout.sh"
+"$repo_root/scripts/check-artifact-redaction-guardrail.sh"


### PR DESCRIPTION
## Task

[ORB-00138](https://orbit-cli.com/tasks/ORB-00138) — Apply secret redaction to Orbit artifact write tools

### Description

## Problem

Multiple Orbit artifact write surfaces persist agent-supplied free text to repo-backed files without a shared write-time redaction boundary. This now covers the ADR and learning tools originally tracked by ORB-00137 plus the task, review-thread, and friction surfaces tracked here:

- `orbit.adr.add` / `orbit.adr.update` / `orbit.adr.supersede`
- `orbit.learning.add` / `orbit.learning.update` / `orbit.learning.supersede` / `orbit.learning.comment.add`
- `orbit.task.add` / `orbit.task.update` / `orbit.task.reject`
- `orbit.task.review_thread.add` / `orbit.task.review_thread.reply`
- `orbit.friction.add` / `orbit.friction.update`

These tools routinely receive raw error text, stack traces, command output, prose, evidence refs, and pasted file content. A `GITHUB_TOKEN` value, provider key, bearer token, or local HOME path can land in `.orbit/` YAML/markdown/JSON and then enter git history. ORB-00137 was rejected per human direction on 2026-05-17; this task is now the single redaction task for all of those artifact write surfaces.

## Why It Matters

Artifacts in `.orbit/` are meant to be shared through git. Once a secret is committed, every clone, branch, fork, remote, and later history consumer can inherit it. The risk exists today with manual commits and becomes more serious for auto-publish work such as ORB-00136.

## Approach

Design one shared write-time redaction boundary at the Orbit tool-host entrance. After `OrbitBuiltinAction` is known, sanitize the recognized persisted text fields according to an explicit per-action policy before typed params are built and before any store write occurs. This should cover both CLI and MCP entry points without putting field-blind redaction into CLI `audit_middleware` or generic raw registry dispatch.

Field policy:

| Tool | Free text (`redact_all` + `redact_home_dir`) | Path-only (`redact_home_dir`) | Skip |
|------|----------------------------------------------|-------------------------------|------|
| `orbit.adr.add` / `orbit.adr.update` | `title`, `body` | — | status, owner, related ids/features/tasks, legacy ids |
| `orbit.adr.supersede` | — | — | `old_id`, `new_id` |
| `orbit.learning.add` / `orbit.learning.update` | `summary`, `body`, `scope.tags[]`, `evidence[].ref` | `scope.paths[]` | status, ids, priority, votes, model fields |
| `orbit.learning.supersede` | — | — | `old_id`, `new_id` |
| `orbit.learning.comment.add` | `body` | — | `learning_id`, `model` |
| `orbit.task.add` | `title`, `description`, `plan`, `acceptance_criteria[]`, `comment` | `context_files[]`, `external_refs[].url` | workspace, ids, enums, dependency/relation targets, crew, tags |
| `orbit.task.update` | `title`, `description`, `plan`, `execution_summary`, `acceptance_criteria[]`, `comment` | `context_files[]` and `external_refs[].url` if update supports refs | provenance/status/identity fields, tags, raw `artifacts`/`upsert_artifacts` |
| `orbit.task.reject` | `note`, optional persisted `comment` | — | `id` |
| `orbit.task.review_thread.add` | `body` | `path` | `id`, `line`, `model` |
| `orbit.task.review_thread.reply` | `body` | — | `id`, `thread_id`, `model` |
| `orbit.friction.add` | `body` | — | `model`, `during_task`, tags |
| `orbit.friction.update` | optional `body` update field | — | `id`, status, tags |

High-confidence single-token credentials are refused with a typed `OrbitError`; embedded credentials or sensitive env values in larger prose are masked. Path-only fields normalize HOME paths but do not run pattern redaction, so path globs and token-shaped character classes survive intact. Task and friction tags remain verbatim; learning `scope.tags[]` remain in scope because they are free-text matching metadata in the learning model.

## Out of Scope

- Display-time/read-time redaction. Persisted artifacts should already be safe.
- Raw task artifact blobs (`orbit.task.artifact.put` and `upsert_artifacts`). Blob redaction needs separate binary/file-type/size policy.
- Auto-publish itself; ORB-00136 owns commit/push behavior and should depend on this consolidated task instead of ORB-00137.

### Acceptance Criteria

- A shared action-keyed sanitizer runs at the Orbit tool-host write entrance for covered artifact write tools, after `OrbitBuiltinAction` is known and before typed params are built; tests cover both CLI/tool-host dispatch and direct handler behavior where practical.
- ADR and learning write surfaces are covered: ADR `title`/`body`; learning `summary`/`body`/`scope.tags[]`/`evidence[].ref`; learning comment `body`; `scope.paths[]` is home-dir-only. Persisted YAML/markdown tests feed the live process's `GITHUB_TOKEN` and assert `[REDACTED_ENV]` appears instead of the raw value.
- Task, review-thread, and friction write surfaces are covered: task `title`, `description`, `plan`, `acceptance_criteria[]`, `execution_summary`, comments/notes; review-thread `body`; friction `body`. Persisted YAML/markdown/JSON tests feed the live process's `GITHUB_TOKEN` and assert `[REDACTED_ENV]` appears instead of the raw value.
- Path-bearing fields (`learning.scope.paths[]`, task `context_files[]`, task `external_refs[].url` where supported, and review-thread `path`) pass through `redact_home_dir` only; tests assert HOME-prefixed paths normalize to `~/...` while token-shaped path globs/character classes are preserved verbatim.
- High-confidence single-token credentials (`^sk-[A-Za-z0-9_-]{20,}$`, `^ghp_[A-Za-z0-9]{36}$`, `^xox[baprs]-[A-Za-z0-9-]{10,}$`) trigger a typed `OrbitError` and reject the write; partial or embedded forms in larger prose are masked. Tests cover both branches for ADR, learning, task, friction, and review-thread representatives.
- Each covered mutating tool response gains `redactions_applied: bool`, true iff at least one persisted field differs from input; tests assert true and false responses across every covered tool family, including tools with no free-text fields returning false where applicable.
- Re-redacting already-persisted redacted input is idempotent: rerunning a representative update with the same redacted value produces `redactions_applied == false` and no new redaction audit event.
- An audit event is emitted per redacted field with artifact type/id, field path, actor, tool name, and redaction kinds (`env` | `pattern` | `home_dir`); original and redacted values are never included. Tests assert through `orbit audit list --json` and cite L20260517-9 at the audit-query helper/site.
- Learning `scope.tags[]` are redacted as free-text matching metadata; task tags and friction tags are not redacted and pass through verbatim. Tests include token-looking task/friction tags that land unchanged.
- `orbit.friction.update` gains an optional body update path and redacts that body before persistence; status and tags remain structural/verbatim.
- All redaction algorithms go through `orbit_common::utility::redaction`; a guardrail test/script covers ADR, learning, task, review-thread, and friction surfaces and rejects parallel `fn redact_*` implementations outside the common module.
- Documentation extends the auditability/artifact-redaction design doc with the consolidated field table, tool-host entrance boundary, refuse-vs-mask heuristic, idempotence guarantee, audit payload shape, and non-goals. No new design folder is created.
- ORB-00136 dependency/readiness references this consolidated task rather than ORB-00137.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Added a shared `artifact_redaction` tool-host boundary that sanitizes action-keyed artifact write fields after `OrbitBuiltinAction` is known and before typed parsing, inserts `redactions_applied`, and emits field-level audit rows without values.
- Extended common redaction with high-confidence credential token detection/masking and added typed `OrbitError::SensitiveInput` handling in CLI/MCP error payloads.
- Covered ADR, learning, task, review-thread, and friction policies, including HOME-only path fields, learning tag free-text handling, task/friction tag passthrough, and optional `orbit.friction.update.body` persistence.
- Documented artifact redaction policy and added a guardrail script wired into `make ci-fast` / CI guardrails.

Validation:
- `env -u ORBIT_AGENT_NAME -u ORBIT_AGENT_MODEL -u ORBIT_MANAGED_RUN_CONTEXT -u ORBIT_TASK_ID -u ORBIT_RUN_ID -u ORBIT_ACTIVITY_ID -u ORBIT_STEP_INDEX cargo test -p orbit-core runtime::orbit_tool_host --lib`
- `cargo test -p orbit-store friction_store --lib`
- `cargo check --workspace`
- `cargo clippy -p orbit-core --lib --tests -- -D warnings`
- `cargo clippy -p orbit-cli -p orbit-mcp -- -D warnings`
- `make ci-fast`

Assessment: The scoped redaction boundary is implemented and validated with focused persisted-artifact, response-flag, audit, idempotence, and guardrail coverage. Direct `cargo test -p orbit-core runtime::orbit_tool_host --lib` without env cleanup was affected by managed `ORBIT_AGENT_*` variables, consistent with L20260517-3, so the passing run explicitly unset them.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-00138-6a0a4df5`
- Behind base: 0
- Ahead of base: 1