### PR TITLE
Spike dashboard JS module split: extract common.js + module-load app.js

### DIFF
--- a/crates/orbit-cli/assets/dashboard/app.js
+++ b/crates/orbit-cli/assets/dashboard/app.js
@@ -1,5 +1,7 @@
 // Orbit dashboard — terminal-dark, manually refreshed SPA.
-// Pure vanilla JS, no build step.
+// Pure vanilla JS, split into ES modules with no build step.
+
+import { el, statusPill, priorityCell, stateCell, fetchJson, requestJson, postJson, patchJson, syncNodes, positiveIntParam } from './common.js';
 
 const STATUS_ORDER = [
   "in-progress",
@@ -15,11 +17,6 @@ const STATUS_UPDATE_TARGETS = STATUS_ORDER
   .filter((status) => !["friction", "rejected", "archived"].includes(status))
   .concat(["done"]);
 
-const params = new URLSearchParams(window.location.search);
-function positiveIntParam(name, fallback) {
-  const parsed = parseInt(params.get(name) || String(fallback), 10);
-  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
-}
 const JOB_RUN_LIMIT = positiveIntParam("runs", 25);
 const DIAG_LIMIT = positiveIntParam("diag", 50);
 const AUDIT_LIMIT = positiveIntParam("audit", 50);
@@ -99,75 +96,6 @@ let activeRunEvents = [];
 let activeRunLogs = [];
 let activeRunSubtab = "steps";
 let expandedStepIndices = new Set();
-
-function el(tag, opts = {}, children = []) {
-  const node = document.createElement(tag);
-  if (opts.class) node.className = opts.class;
-  if (opts.text != null) node.textContent = opts.text;
-  if (opts.title != null) node.title = opts.title;
-  if (opts.style) Object.assign(node.style, opts.style);
-  for (const child of children) {
-    if (child == null) continue;
-    node.appendChild(typeof child === "string" ? document.createTextNode(child) : child);
-  }
-  return node;
-}
-
-function statusPill(status) {
-  const color = `var(--status-${status}, var(--fg))`;
-  const pill = el("span", { class: "pill mono", text: status });
-  pill.style.color = color;
-  pill.style.borderLeft = `2px solid ${color}`;
-  return pill;
-}
-
-function priorityCell(p) {
-  const node = el("span", { class: "priority mono", text: p });
-  node.style.color = `var(--priority-${p}, var(--fg-dim))`;
-  return node;
-}
-
-function stateCell(state) {
-  const node = el("span", { class: "mono", text: state });
-  node.style.color = `var(--state-${state}, var(--fg-dim))`;
-  return node;
-}
-
-function fetchJson(path) {
-  return fetch(path, { headers: { accept: "application/json" } })
-    .then(res => {
-      if (!res.ok) throw new Error(`${path}: HTTP ${res.status}`);
-      return res.json();
-    });
-}
-
-function requestJson(path, method, body) {
-  const headers = { accept: "application/json" };
-  const opts = {
-    method,
-    headers,
-  };
-  if (body !== undefined) {
-    headers["content-type"] = "application/json";
-    opts.body = JSON.stringify(body);
-  }
-  return fetch(path, opts).then(async (res) => {
-    const text = await res.text();
-    const body = text ? JSON.parse(text) : {};
-    if (!res.ok) {
-      throw new Error(body.error || `${path}: HTTP ${res.status}`);
-    }
-    return body;
-  });
-}
-
-function postJson(path, body) {
-  return requestJson(path, "POST", body);
-}
-
-function patchJson(path, body) {
-  return requestJson(path, "PATCH", body);
-}
 
 function normalizeCrewPayload(payload) {
   const crews = Array.isArray(payload && payload.crews)
@@ -300,43 +228,6 @@ async function replayRun(run, btn, host) {
   } finally {
     btn.disabled = false;
     btn.textContent = old;
-  }
-}
-
-function syncNodes(container, newNodesArr) {
-  const oldNodes = Array.from(container.children);
-  const oldMap = new Map();
-  for (const node of oldNodes) {
-    if (node.dataset.key) oldMap.set(node.dataset.key, node);
-  }
-
-  for (let i = 0; i < newNodesArr.length; i++) {
-    const newNode = newNodesArr[i];
-    const key = newNode.dataset.key;
-    let nodeToPlace = newNode;
-
-    if (key && oldMap.has(key)) {
-      const oldNode = oldMap.get(key);
-      if (oldNode.dataset.hash === newNode.dataset.hash) {
-        nodeToPlace = oldNode;
-      } else {
-        nodeToPlace.classList.add("data-changed");
-      }
-    } else if (key) {
-      nodeToPlace.classList.add("data-new");
-    }
-
-    if (container.children[i] !== nodeToPlace) {
-      if (container.children[i]) {
-        container.insertBefore(nodeToPlace, container.children[i]);
-      } else {
-        container.appendChild(nodeToPlace);
-      }
-    }
-  }
-
-  while (container.children.length > newNodesArr.length) {
-    container.removeChild(container.lastElementChild);
   }
 }
 

--- a/crates/orbit-cli/assets/dashboard/common.js
+++ b/crates/orbit-cli/assets/dashboard/common.js
@@ -1,0 +1,112 @@
+const params = new URLSearchParams(window.location.search);
+
+export function positiveIntParam(name, fallback) {
+  const parsed = parseInt(params.get(name) || String(fallback), 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+export function el(tag, opts = {}, children = []) {
+  const node = document.createElement(tag);
+  if (opts.class) node.className = opts.class;
+  if (opts.text != null) node.textContent = opts.text;
+  if (opts.title != null) node.title = opts.title;
+  if (opts.style) Object.assign(node.style, opts.style);
+  for (const child of children) {
+    if (child == null) continue;
+    node.appendChild(typeof child === "string" ? document.createTextNode(child) : child);
+  }
+  return node;
+}
+
+export function statusPill(status) {
+  const color = `var(--status-${status}, var(--fg))`;
+  const pill = el("span", { class: "pill mono", text: status });
+  pill.style.color = color;
+  pill.style.borderLeft = `2px solid ${color}`;
+  return pill;
+}
+
+export function priorityCell(p) {
+  const node = el("span", { class: "priority mono", text: p });
+  node.style.color = `var(--priority-${p}, var(--fg-dim))`;
+  return node;
+}
+
+export function stateCell(state) {
+  const node = el("span", { class: "mono", text: state });
+  node.style.color = `var(--state-${state}, var(--fg-dim))`;
+  return node;
+}
+
+export function fetchJson(path) {
+  return fetch(path, { headers: { accept: "application/json" } })
+    .then(res => {
+      if (!res.ok) throw new Error(`${path}: HTTP ${res.status}`);
+      return res.json();
+    });
+}
+
+export function requestJson(path, method, body) {
+  const headers = { accept: "application/json" };
+  const opts = {
+    method,
+    headers,
+  };
+  if (body !== undefined) {
+    headers["content-type"] = "application/json";
+    opts.body = JSON.stringify(body);
+  }
+  return fetch(path, opts).then(async (res) => {
+    const text = await res.text();
+    const body = text ? JSON.parse(text) : {};
+    if (!res.ok) {
+      throw new Error(body.error || `${path}: HTTP ${res.status}`);
+    }
+    return body;
+  });
+}
+
+export function postJson(path, body) {
+  return requestJson(path, "POST", body);
+}
+
+export function patchJson(path, body) {
+  return requestJson(path, "PATCH", body);
+}
+
+export function syncNodes(container, newNodesArr) {
+  const oldNodes = Array.from(container.children);
+  const oldMap = new Map();
+  for (const node of oldNodes) {
+    if (node.dataset.key) oldMap.set(node.dataset.key, node);
+  }
+
+  for (let i = 0; i < newNodesArr.length; i++) {
+    const newNode = newNodesArr[i];
+    const key = newNode.dataset.key;
+    let nodeToPlace = newNode;
+
+    if (key && oldMap.has(key)) {
+      const oldNode = oldMap.get(key);
+      if (oldNode.dataset.hash === newNode.dataset.hash) {
+        nodeToPlace = oldNode;
+      } else {
+        nodeToPlace.classList.add("data-changed");
+      }
+    } else if (key) {
+      nodeToPlace.classList.add("data-new");
+    }
+
+    if (container.children[i] !== nodeToPlace) {
+      if (container.children[i]) {
+        container.insertBefore(nodeToPlace, container.children[i]);
+      } else {
+        container.appendChild(nodeToPlace);
+      }
+    }
+  }
+
+  while (container.children.length > newNodesArr.length) {
+    container.removeChild(container.lastElementChild);
+  }
+}

--- a/crates/orbit-cli/assets/dashboard/index.html
+++ b/crates/orbit-cli/assets/dashboard/index.html
@@ -2402,6 +2402,6 @@
       </main>
     </section>
     <div id="gantt-tooltip" role="tooltip" aria-hidden="true"></div>
-    <script src="/static/app.js"></script>
+    <script type="module" src="/static/app.js"></script>
   </body>
 </html>

--- a/crates/orbit-cli/src/command/web/mod.rs
+++ b/crates/orbit-cli/src/command/web/mod.rs
@@ -20,6 +20,7 @@ use crate::command::Execute;
 
 const INDEX_HTML: &str = include_str!("../../../assets/dashboard/index.html");
 const APP_JS: &str = include_str!("../../../assets/dashboard/app.js");
+const COMMON_JS: &str = include_str!("../../../assets/dashboard/common.js");
 
 #[derive(Args)]
 #[command(
@@ -77,6 +78,7 @@ impl Execute for ServeArgs {
         let app = Router::new()
             .route("/", get(serve_index))
             .route("/static/app.js", get(serve_app_js))
+            .route("/static/common.js", get(serve_common_js))
             .route("/healthz", get(healthz))
             .nest("/api", api::router())
             .with_state(runtime);
@@ -125,6 +127,17 @@ async fn serve_app_js() -> Response {
             HeaderValue::from_static("application/javascript; charset=utf-8"),
         )],
         APP_JS,
+    )
+        .into_response()
+}
+
+async fn serve_common_js() -> Response {
+    (
+        [(
+            header::CONTENT_TYPE,
+            HeaderValue::from_static("application/javascript; charset=utf-8"),
+        )],
+        COMMON_JS,
     )
         .into_response()
 }


### PR DESCRIPTION
## Task

[ORB-00145](https://orbit-cli.com/tasks/ORB-00145) — Spike dashboard JS module split: extract common.js + module-load app.js

### Description

## Problem

`crates/orbit-cli/assets/dashboard/app.js` has grown to 4405 lines (148k) and is served as a single embedded blob from `crates/orbit-cli/src/command/web/mod.rs` (via `include_str!` and the `/static/app.js` axum route). It mixes shared primitives (DOM helpers, network helpers, formatters) with per-domain code (tasks, runs, scoreboard, audit, diagnostics, learnings, ADRs, friction, locks). Future per-domain splits need a working module-loading pattern first.

## Why It Matters

Establishing the loading mechanics in one small, low-risk slice de-risks the larger per-domain decomposition that follows. The bigger split is much cheaper to author and review once `common.js` exists and ES-module loading is proven against the embedded-assets serving model. Doing the whole decomposition in one PR would conflate "does the pattern work" with "is the seam in the right place."

## Scope

This task is a **spike** — the smallest end-to-end demonstration of:

1. Multiple JS files embedded via `include_str!` and served from `web/mod.rs` over their own `/static/<name>.js` routes.
2. `index.html` loading the entry file as `<script type="module">`.
3. The entry module importing helpers from `./common.js` via standard ES-module imports (no bundler, no build step).

Only the following helpers move into `common.js` for this spike. Everything else stays in `app.js` exactly as it is today:

- DOM: `el`
- Cell renderers: `statusPill`, `priorityCell`, `stateCell`
- Network: `fetchJson`, `requestJson`, `postJson`, `patchJson`
- DOM diff: `syncNodes`
- URL param: `positiveIntParam`

Formatters (`fmtTimestamp`, `fmtAbsTime`, `fmtDuration`, `fmtSize`), markdown helpers (`renderBodyBlock`), and per-domain code remain in `app.js`. They are explicit follow-ups, not this task.

## Constraints / Notes

- No bundler, no npm dependency, no build step. The project deliberately ships embedded vanilla JS.
- `app.js` continues to be the entry script. After this task, `<script src="/static/app.js">` becomes `<script type="module" src="/static/app.js">`, and `app.js`'s first statements are `import { ... } from "./common.js";`.
- Browsers fetch ES modules with strict MIME — the new route for `common.js` must serve `application/javascript; charset=utf-8`, matching the existing `serve_app_js` handler.
- The dashboard is currently global-scope (`var`/`let`/`const` at top level). Converting `app.js` to a module changes top-level binding visibility (module scope, not global). Any code that today relies on accidental global lookup must be audited. Inline `onclick=`/`onsubmit=` attributes in `index.html`, if any, will break under module scope and must either be rewired via `addEventListener` or have their handlers explicitly attached to `window`.
- Keep the file header comment in `app.js` (`// Orbit dashboard — terminal-dark, manually refreshed SPA.`) updated to mention the module split.
- This task does NOT extract per-domain modules (tasks/runs/audit/...). Those are future tasks.
- Rollback: revert the `web/mod.rs`, `index.html`, and `assets/dashboard/*` changes; no migrations, no persisted state involved.

## Out of Scope

- Per-domain module extraction (tasks.js, runs.js, audit.js, diagnostics.js, scoreboard.js, learnings.js, adrs.js, friction.js, locks.js).
- Moving formatters or `renderBodyBlock` into `common.js`.
- Any CSS or HTML refactor beyond the one `<script>` tag change.
- Source maps, minification, hashing, or cache-busting URLs.

### Acceptance Criteria

- File `crates/orbit-cli/assets/dashboard/common.js` exists and contains exactly these named exports, with the function bodies copied verbatim from app.js: `el`, `statusPill`, `priorityCell`, `stateCell`, `fetchJson`, `requestJson`, `postJson`, `patchJson`, `syncNodes`, `positiveIntParam`. Verified by `grep -n '^export function ' crates/orbit-cli/assets/dashboard/common.js` listing those 10 names and no others.
- File `crates/orbit-cli/assets/dashboard/app.js` no longer defines those 10 functions (their definitions are removed, not duplicated) and starts with a single `import { el, statusPill, priorityCell, stateCell, fetchJson, requestJson, postJson, patchJson, syncNodes, positiveIntParam } from './common.js';` statement. Verified by `grep -n '^function el\b\|^function statusPill\b\|^function fetchJson\b\|^function syncNodes\b\|^function positiveIntParam\b' crates/orbit-cli/assets/dashboard/app.js` returning zero matches.
- `crates/orbit-cli/src/command/web/mod.rs` declares a second `const COMMON_JS: &str = include_str!("../../../assets/dashboard/common.js");` alongside `APP_JS`, registers a `/static/common.js` route via `get(serve_common_js)`, and the new `serve_common_js` handler returns `Content-Type: application/javascript; charset=utf-8` (mirroring `serve_app_js` at mod.rs:121).
- `crates/orbit-cli/assets/dashboard/index.html` line 2362 changes `<script src="/static/app.js"></script>` to `<script type="module" src="/static/app.js"></script>`. No other `<script>` tags are added or removed.
- `make ci-fast` passes on the resulting tree (output captured in the task execution summary).
- After running `cargo run -p orbit-cli -- web serve --no-open --port 7879` and loading `http://127.0.0.1:7879/`, `curl -sI http://127.0.0.1:7879/static/common.js` returns HTTP 200 with `content-type: application/javascript; charset=utf-8`, and `curl -sI http://127.0.0.1:7879/static/app.js` returns the same. Captured `curl` output goes into the execution summary.
- Manual browser smoke test: with the dev server running, opening `http://127.0.0.1:7879/` produces zero `Uncaught ReferenceError`, `Failed to resolve module specifier`, or other module-loading errors in the DevTools console on initial load, AND each of the top-level tabs (Tasks, Runs, Diagnostics, Audit, Knowledge, Scoreboard) renders without console errors when clicked. Browser console screenshot or copied console output is attached to the task as an artifact via `orbit.task.artifact.put`.
- If any inline event-handler attribute in `index.html` (e.g. `onclick="..."`) depended on a top-level function from app.js, it is either rewired via `addEventListener` in `app.js` or the handler is explicitly attached to `window` with a one-line comment naming the inline attribute it serves. Verified by `grep -nE 'on(click|submit|change|input|keydown|keyup|load)=' crates/orbit-cli/assets/dashboard/index.html` either returning zero matches OR every match having a corresponding `window.<name> = <name>;` line in `app.js`.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Added `crates/orbit-cli/assets/dashboard/common.js` with `params` plus the 10 extracted helper exports, and updated `app.js` to import those helpers as its first statement after the header comments.
- Removed the extracted helper definitions from `app.js`, updated the dashboard entry script to `type="module"`, and served `/static/common.js` from the embedded axum dashboard with the same JavaScript MIME type as `/static/app.js`.

Assessment: The embedded no-bundler ES-module path is working. Existing dashboard top-level tabs are Tasks, Scoreboard, Audit, Diagnostics, and Knowledge; the validation plan's Runs coverage was exercised through Diagnostics > Recent Runs because no top-level Runs button exists in the current DOM. Captured this mismatch as learning `L20260518-2`.

Validation:
- `grep -n '^export function ' crates/orbit-cli/assets/dashboard/common.js`:
  `3:positiveIntParam`, `8:el`, `21:statusPill`, `29:priorityCell`, `35:stateCell`, `41:fetchJson`, `49:requestJson`, `69:postJson`, `73:patchJson`, `77:syncNodes`.
- `grep -n '^function positiveIntParam\b\|^function el\b\|^function statusPill\b\|^function priorityCell\b\|^function stateCell\b\|^function fetchJson\b\|^function requestJson\b\|^function postJson\b\|^function patchJson\b\|^function syncNodes\b' crates/orbit-cli/assets/dashboard/app.js` returned zero matches (exit 1).
- `grep -nE 'on(click|submit|change|input|keydown|keyup|load)=' crates/orbit-cli/assets/dashboard/index.html` returned zero matches (exit 1).
- `grep -n '<script' crates/orbit-cli/assets/dashboard/index.html` shows only the existing marked classic script and `<script type="module" src="/static/app.js"></script>`.
- `make ci-fast` passed:
  ```text
  cargo fmt --all -- --check
  ./scripts/check-dependency-direction.sh
  dependency direction guard passed
  ./scripts/check-cli-imports.sh
  orbit-cli import guard passed
  ./scripts/check-stability.sh
  crate                tier
  orbit-agent          internal
  orbit-cli            internal
  orbit-common         stable
  orbit-core           internal
  orbit-embed          internal
  orbit-embed-companion experimental
  orbit-engine         internal
  orbit-exec           internal
  orbit-knowledge      internal
  orbit-mcp            internal
  orbit-policy         internal
  orbit-registry       experimental
  orbit-store          stable
  orbit-tools          internal
  ./scripts/check-learning-layout.sh
  ./scripts/check-artifact-redaction-guardrail.sh
  ```
- `cargo run -p orbit-cli -- web serve --no-open --port 7879` served both JS assets. Raw curl output:
  ```text
  HTTP/1.1 200 OK
  content-type: application/javascript; charset=utf-8
  content-length: 3291
  date: Mon, 18 May 2026 03:39:44 GMT

  --- app ---
  HTTP/1.1 200 OK
  content-type: application/javascript; charset=utf-8
  content-length: 150448
  date: Mon, 18 May 2026 03:39:44 GMT
  ```
- Browser/CDP smoke artifact attached: `orbit-dashboard-console-smoke-jrun-20260518-0336-4.txt`. It confirmed `moduleScript=true`, `/static/common.js` fetched, all current top-level tabs plus Diagnostics > Recent Runs clicked, and `Console/log/error entries captured: 0` / `Suspicious/module/error entries: 0`.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-00145-6a0a8951`
- Behind base: 0
- Ahead of base: 1