### PR TITLE
Restore scoreboard friction report counts from friction records

### DIFF
--- a/crates/orbit-cli/src/command/web/api/scoreboard.rs
+++ b/crates/orbit-cli/src/command/web/api/scoreboard.rs
@@ -66,6 +66,7 @@ pub(super) async fn scoreboard(State(runtime): State<Arc<OrbitRuntime>>) -> Resp
                     "duels": { "wins": 0, "losses": 0, "participated": 0 },
                     "pr": { "review_comments": 0, "merged_clean": 0, "merged_with_revision": 0 },
                     "task_review": { "threads": 0 },
+                    "friction": { "reported": 0 },
                     "tool_calls": 0,
                     "failed_tool_calls": 0,
                     "avg_step_duration_ms": extras.avg_duration_ms,

--- a/crates/orbit-core/src/runtime/engine/summary.rs
+++ b/crates/orbit-core/src/runtime/engine/summary.rs
@@ -39,6 +39,10 @@ impl OrbitRuntime {
             self.stores()
                 .adrs()
                 .list_filtered(None::<AdrStatus>, None, None, None, None, None)?;
+        let frictions = orbit_store::friction_store::list_frictions(
+            &self.data_root().join("frictions"),
+            &orbit_store::friction_store::FrictionListFilter::default(),
+        )?;
 
         let summary = orbit_store::scoreboard_summary::generate_summary_with_inputs(
             &self.paths().scoreboard_dir,
@@ -52,6 +56,7 @@ impl OrbitRuntime {
                 learnings: &learnings,
                 learning_vote_counts: &learning_vote_counts,
                 adrs: &adrs,
+                frictions: &frictions,
                 now: Some(now),
             },
         )?;

--- a/crates/orbit-store/src/file/scoreboard/scoreboard_summary.rs
+++ b/crates/orbit-store/src/file/scoreboard/scoreboard_summary.rs
@@ -12,6 +12,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 use super::planning_duel_scoreboard;
+use crate::friction_store::StoredFrictionRecord;
 use crate::{AuditToolCallCountsByRole, AuditToolCallCountsBySurfaceAndRole, AuditTopToolCall};
 use orbit_common::utility::fs::atomic_write_text_volatile as write_atomic;
 
@@ -19,8 +20,10 @@ const SUMMARY_FILENAME: &str = "summary.json";
 // v2 adds `task_review.threads`; v3 adds tasks_created/tasks_planned,
 // per-(role, surface) tool call counts, top-level workflows_run, and a
 // recent_7d window block. v4 adds per-agent knowledge counters and a
-// planning-duel head-to-head matrix. Older readers ignore unknown fields.
-const CURRENT_SCHEMA_VERSION: u32 = 4;
+// planning-duel head-to-head matrix. v5 adds per-agent `friction.reported`
+// (from append-only `.orbit/frictions/` records, matching `orbit.friction.stats`).
+// Older readers ignore unknown fields.
+const CURRENT_SCHEMA_VERSION: u32 = 5;
 const TASK_REVIEW_THREADS_METRIC: &str = "task-review-threads";
 const LEGACY_TASK_REVIEW_MESSAGES_METRIC: &str = "task-review-messages";
 const RECENT_WINDOW_DAYS: i64 = 7;
@@ -63,6 +66,15 @@ pub struct KnowledgeSummary {
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct FrictionSummary {
+    /// Number of append-only friction records reported by this agent family.
+    /// Sourced from `.orbit/frictions/` (via the same aggregation as
+    /// `orbit.friction.stats` / `friction_stats`), not from legacy task status
+    /// or `tool_calls_by_surface.friction`.
+    pub reported: u64,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
 pub struct AgentSummary {
     pub tasks_completed: u64,
     #[serde(default)]
@@ -76,6 +88,8 @@ pub struct AgentSummary {
     pub task_review: TaskReviewSummary,
     #[serde(default)]
     pub knowledge: KnowledgeSummary,
+    #[serde(default)]
+    pub friction: FrictionSummary,
     pub tool_calls: u64,
     #[serde(default)]
     pub failed_tool_calls: u64,
@@ -171,7 +185,7 @@ struct TokenAgentEntry {
 /// New callers should populate this struct;
 /// the older `generate_summary*` thin wrappers stay for tests and any
 /// caller that hasn't been updated yet.
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Clone)]
 pub struct ScoreboardInputs<'a> {
     /// Per-(role) tool-call totals — drives the legacy `tool_calls`/
     /// `failed_tool_calls` columns.
@@ -194,9 +208,37 @@ pub struct ScoreboardInputs<'a> {
     pub learning_vote_counts: &'a [(String, u64)],
     /// Workspace ADR records, used for knowledge-stewardship counters.
     pub adrs: &'a [Adr],
+    /// Append-only friction records from `.orbit/frictions/`. Used to populate
+    /// per-family `friction.reported` counts (so the dashboard `frict r` column
+    /// and `orbit.friction.stats` agree, without using tool call surface counts).
+    pub frictions: &'a [StoredFrictionRecord],
     /// Reference "now" for recency windowing. `None` means no recency
     /// section is emitted (used by legacy callers).
     pub now: Option<DateTime<Utc>>,
+}
+
+impl<'a> Default for ScoreboardInputs<'a> {
+    fn default() -> Self {
+        static EMPTY_AUDIT: [AuditToolCallCountsByRole; 0] = [];
+        static EMPTY_SURFACE: [AuditToolCallCountsBySurfaceAndRole; 0] = [];
+        static EMPTY_JOB: [JobRun; 0] = [];
+        static EMPTY_TOP: [AuditTopToolCall; 0] = [];
+        static EMPTY_LEARNING: [Learning; 0] = [];
+        static EMPTY_VOTES: [(String, u64); 0] = [];
+        static EMPTY_ADR: [Adr; 0] = [];
+        Self {
+            audit_tool_calls: &EMPTY_AUDIT,
+            audit_tool_calls_by_surface: &EMPTY_SURFACE,
+            audit_tool_calls_by_surface_recent: &EMPTY_SURFACE,
+            job_runs: &EMPTY_JOB,
+            top_tool_calls: &EMPTY_TOP,
+            learnings: &EMPTY_LEARNING,
+            learning_vote_counts: &EMPTY_VOTES,
+            adrs: &EMPTY_ADR,
+            frictions: &[],
+            now: None,
+        }
+    }
 }
 
 pub fn generate_summary(
@@ -327,6 +369,7 @@ pub fn generate_summary_with_inputs(
     }
 
     overlay_knowledge_counters(&mut agents, inputs);
+    overlay_friction_reported(&mut agents, inputs.frictions);
 
     for task in tasks {
         if matches!(task.status, TaskStatus::Done | TaskStatus::Archived)
@@ -605,6 +648,25 @@ fn overlay_knowledge_counters(
             summary.knowledge.adrs_proposed_open =
                 summary.knowledge.adrs_proposed_open.saturating_add(1);
         }
+    }
+}
+
+fn overlay_friction_reported(
+    agents: &mut BTreeMap<String, AgentSummary>,
+    frictions: &[StoredFrictionRecord],
+) {
+    let mut counts: BTreeMap<String, u64> = BTreeMap::new();
+    for stored in frictions {
+        let family = {
+            let normalized = normalize_optional_attribution_label(Some(&stored.record.model), None)
+                .unwrap_or_default();
+            infer_agent_family_from_model(&normalized).unwrap_or(normalized)
+        };
+        *counts.entry(family).or_insert(0) += 1;
+    }
+    for (family, count) in counts {
+        let summary = agents.entry(family).or_default();
+        summary.friction.reported = count;
     }
 }
 
@@ -1277,5 +1339,76 @@ mod tests {
 
         let reviewer = summary.agents.get("codex").expect("reviewer summary");
         assert_eq!(reviewer.task_review.threads, 2);
+    }
+
+    #[test]
+    fn summary_exposes_friction_reported_counts_from_records() {
+        // Deterministic test per ORB-00143: seeds friction records for >=2 families
+        // and asserts the generated scoreboard exposes nonzero `friction.reported`
+        // (and zero for families with none). Uses the inputs path so it does not
+        // depend on disk state or legacy task.status=friction.
+        let temp = tempfile::tempdir().expect("create tempdir");
+
+        let frictions: Vec<crate::friction_store::StoredFrictionRecord> = vec![
+            crate::friction_store::StoredFrictionRecord {
+                record: orbit_common::types::FrictionRecord {
+                    id: "F001".to_string(),
+                    model: "codex".to_string(),
+                    created_at: Utc::now(),
+                    status: orbit_common::types::FrictionStatus::Open,
+                    tags: vec![],
+                    resolved_at: None,
+                    during_task: None,
+                    resolved_by_task: None,
+                    body: "seed for codex family".to_string(),
+                },
+                path: std::path::PathBuf::from("frictions/2026-05/F001.md"),
+            },
+            crate::friction_store::StoredFrictionRecord {
+                record: orbit_common::types::FrictionRecord {
+                    id: "F002".to_string(),
+                    model: "claude-3-opus".to_string(),
+                    created_at: Utc::now(),
+                    status: orbit_common::types::FrictionStatus::Resolved,
+                    tags: vec!["test".to_string()],
+                    resolved_at: Some(Utc::now()),
+                    during_task: None,
+                    resolved_by_task: None,
+                    body: "seed for claude family (normalized)".to_string(),
+                },
+                path: std::path::PathBuf::from("frictions/2026-05/F002.md"),
+            },
+        ];
+
+        let summary = generate_summary_with_inputs(
+            temp.path(),
+            &[],
+            &ScoreboardInputs {
+                frictions: &frictions,
+                ..ScoreboardInputs::default()
+            },
+        )
+        .expect("generate summary with seeded frictions");
+
+        let codex = summary.agents.get("codex").expect("codex summary");
+        assert_eq!(
+            codex.friction.reported, 1,
+            "codex should report 1 friction record"
+        );
+
+        let claude = summary.agents.get("claude").expect("claude summary");
+        assert_eq!(
+            claude.friction.reported, 1,
+            "claude (from claude-3-opus) should report 1"
+        );
+
+        let gemini = summary.agents.get("gemini").expect("gemini summary");
+        assert_eq!(
+            gemini.friction.reported, 0,
+            "gemini with no records must expose 0, not fall back"
+        );
+
+        let grok = summary.agents.get("grok").expect("grok summary");
+        assert_eq!(grok.friction.reported, 0);
     }
 }

--- a/crates/orbit-store/src/lib.rs
+++ b/crates/orbit-store/src/lib.rs
@@ -67,10 +67,11 @@ pub mod task_review_scoreboard {
 
 pub mod scoreboard_summary {
     pub use crate::file::scoreboard::scoreboard_summary::{
-        AgentSummary, DuelSummary, KnowledgeSummary, PlanningDuelSummary, PrSummary, RecentSummary,
-        ScoreboardInputs, ScoreboardSummary, TaskReviewSummary, TokenSummary, TopToolCall,
-        WorkflowRunCount, generate_summary, generate_summary_with_audit_tool_calls,
-        generate_summary_with_inputs, summary_path, write_summary,
+        AgentSummary, DuelSummary, FrictionSummary, KnowledgeSummary, PlanningDuelSummary,
+        PrSummary, RecentSummary, ScoreboardInputs, ScoreboardSummary, TaskReviewSummary,
+        TokenSummary, TopToolCall, WorkflowRunCount, generate_summary,
+        generate_summary_with_audit_tool_calls, generate_summary_with_inputs, summary_path,
+        write_summary,
     };
 }
 


### PR DESCRIPTION
## Task

[ORB-00143](https://orbit-cli.com/tasks/ORB-00143) — Restore scoreboard friction report counts from friction records

### Description

## Problem
The dashboard primary scoreboard `frict r` column renders `0` for every agent even when append-only friction reports exist. In this workspace, `.orbit/frictions/2026-05/F001.md` through `F030.md` exist and `orbit tool run orbit.friction.stats --input {"model":"codex"}` reports 30 total records, including codex=27 and claude=3.

The dashboard column in `crates/orbit-cli/assets/dashboard/app.js` reads `friction.reported`, but `ScoreboardSummary::AgentSummary` in `crates/orbit-store/src/file/scoreboard/scoreboard_summary.rs` has no `friction` field. The generated `.orbit/state/scoreboard/summary.json` therefore has no `agents.<family>.friction.reported` value, so the dashboard formats the missing value as `0`. The summary does expose `tool_calls_by_surface.friction`, but that is a count of `orbit.friction.*` tool calls and is not the same metric as reported friction records.

## Why It Matters
The scoreboard currently hides the friction signal that ADR-0049 moved into `.orbit/frictions/`, making the `frict r` column misleading and making agent quality/operational review harder.

## Constraints / Notes
- Do not revive legacy friction tasks or `status: friction` counting as the primary source.
- Source reported counts from append-only friction records, or from the same aggregation used by `orbit.friction.stats`, so the scoreboard and Frictions tab agree.
- Preserve existing agent-family normalization semantics for codex/claude/gemini/grok/human/system rows.
- Update the summary schema/version or dashboard expectation if the serialized shape changes.
- Related search found ORB-00060, ORB-00024, and ORB-00062 as nearby dashboard/friction work, but no existing task for this exact scoreboard count regression.

### Acceptance Criteria

- A deterministic test seeds friction records for at least two families and asserts generated scoreboard output exposes nonzero reported counts per family, including zero for families with no records.
- For a workspace where `orbit.friction.stats` reports `by_family.<family>.frictions = N`, `/api/scoreboard` or `generate_scoreboard_summary` exposes the same `N` to the dashboard for that family.
- The dashboard `frict r` column renders reported friction-record counts and does not fall back to 0 for missing `friction.reported` when records exist; it must not use `tool_calls_by_surface.friction` as a substitute.
- The implementation preserves legacy task-status behavior: friction reports remain append-only records under `.orbit/frictions/`, and legacy `status: friction` tasks are not reintroduced as the source of truth.
- `make ci-fast` passes.

## Execution Summary

<details>
<summary>Click to expand</summary>

Implemented friction.reported on AgentSummary (v5 schema) sourced from append-only friction records via ScoreboardInputs. Added FrictionSummary struct, overlay_friction_reported, manual Default for inputs bundle, load in engine summary gen, augmentation for /api/scoreboard, and deterministic unit test per ACs. make ci-fast passes post-fmt. 4 files, +147/-7. Matches orbit.friction.stats counts for frict r dashboard column.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-00143-6a0a8c25`
- Behind base: 0
- Ahead of base: 1