### PR TITLE
Strengthen agent_implement.yaml with scope, duplication, dead-code, and workspace-pin guardrails

### DIFF
--- a/crates/orbit-core/assets/activities/agent_implement.yaml
+++ b/crates/orbit-core/assets/activities/agent_implement.yaml
@@ -46,29 +46,51 @@ spec:
        override the task snapshot's paths.
     5. Implement only the task's scoped work. If a blocker appears, add a task
        comment with `orbit.task.update` before stopping.
-    6. Respect repository instructions for validation. If tests are forbidden,
+       Touching any file not named in `context_files` or required as a direct
+       dependency of those edits is scope drift. If you find such a file needs
+       changing, surface it as a task comment via `orbit.task.update` and stop —
+       do not change it silently. Deletions of unrelated artifacts (learnings,
+       ADRs, design docs, fixtures) are scope drift even when they look like
+       cleanup.
+    6. If implementing the task requires duplicating more than ~50 LOC of helper
+       code between crates, either (a) lift the shared portion to the appropriate
+       common crate (`orbit-common` or another existing shared crate) in this PR,
+       or (b) file a follow-up task with `orbit.task.add` and cite its ID in the
+       ADR's Consequences section. Do not characterize duplication of >50 LOC as
+       "minor" without surfacing the alternative as a rejected option in the ADR.
+    7. Do not add `#[allow(dead_code)]` or `#[allow(unused_imports)]` to suppress
+       warnings on items that became unused because the task moved them out.
+       Either delete the item in this PR, or surface a concrete reason it must
+       remain (e.g., another caller still depends on it) as a task comment.
+       `#[allow(dead_code)]` is for items the compiler can't see being used
+       (FFI, macro-generated), not for parked technical debt.
+    8. Any new third-party dependency must be registered in `[workspace.dependencies]`
+       at the root `Cargo.toml` and referenced as `<crate>.workspace = true` in
+       the consuming crate's manifest. Direct-pinned versions in crate manifests
+       (e.g., `serde = "1"` instead of `serde.workspace = true`) fail PR review.
+    9. Respect repository instructions for validation. If tests are forbidden,
        do not add or run them. Use the smallest allowed validation that gives
        real confidence.
-    7. Before handoff, run the learning checkpoint: if this task surfaced a
-       contradicted assumption, recurring failure mode, non-obvious gotcha that
-       took more than 10 minutes to debug, or incident-style root cause, follow
-       the `orbit-learning` skill and call the `add` action on
-       `orbit.learning` (or use that skill's update/supersede flow when it
-       points to existing guidance).
-       Skip if none apply.
-    8. The task is already in `in-progress` status when this activity fires
-       (the engine performed workflow admission via `admit_task_for_workflow`
-       during worktree setup, before dispatching the implement step). Do **not**
-       call `orbit.task.start` — this envelope rule overrides the direct-execution
-       start step described in the `orbit-execute-task` skill's Step 3. Proceed
-       directly to implementation.
-    9. Persist an execution summary when useful, but do not move the task to
-       `review`; the pipeline does that only after commit/merge or PR steps
-       succeed. This envelope rule overrides the direct-execution review
-       transition described in the `orbit-execute-task` skill's Step 5 and Exit
-       Criteria.
-    10. Return a short structured summary. Include a `diff` string only when you
-       can produce it cheaply and accurately.
+    10. Before handoff, run the learning checkpoint: if this task surfaced a
+        contradicted assumption, recurring failure mode, non-obvious gotcha that
+        took more than 10 minutes to debug, or incident-style root cause, follow
+        the `orbit-learning` skill and call the `add` action on
+        `orbit.learning` (or use that skill's update/supersede flow when it
+        points to existing guidance).
+        Skip if none apply.
+    11. The task is already in `in-progress` status when this activity fires
+        (the engine performed workflow admission via `admit_task_for_workflow`
+        during worktree setup, before dispatching the implement step). Do **not**
+        call `orbit.task.start` — this envelope rule overrides the direct-execution
+        start step described in the `orbit-execute-task` skill's Step 3. Proceed
+        directly to implementation.
+    12. Persist an execution summary when useful, but do not move the task to
+        `review`; the pipeline does that only after commit/merge or PR steps
+        succeed. This envelope rule overrides the direct-execution review
+        transition described in the `orbit-execute-task` skill's Step 5 and Exit
+        Criteria.
+    13. Return a short structured summary. Include a `diff` string only when you
+        can produce it cheaply and accurately.
   tools:
     - orbit.task.*
     - orbit.friction.*


### PR DESCRIPTION
## Task

[ORB-00148](https://orbit-cli.com/tasks/ORB-00148) — Strengthen agent_implement.yaml with scope, duplication, dead-code, and workspace-pin guardrails

### Description

## Problem

The implementer activity prompt at [crates/orbit-core/assets/activities/agent_implement.yaml:30-71](crates/orbit-core/assets/activities/agent_implement.yaml:30) currently has 10 numbered steps. Step 5 already says *"Implement only the task's scoped work. If a blocker appears, add a task comment with `orbit.task.update` before stopping."* — but the language is vague enough that recent implementer runs treated four distinct failure modes as compatible with it.

ORB-00146 (Grok-as-implementer; PR reviewed by Claude) surfaced four reviewable issues that all map to implementer hygiene the prompt currently fails to enforce. See review threads on ORB-00146:

1. **Scope drift.** Grok deleted `.orbit/learnings/L20260518-2/learning.yaml` — an unrelated learning about ORB-00145 dashboard tabs — while implementing the orbit-dashboard crate extraction. The deletion violated both the task's explicit "out of scope" clause and the "no behavior change" constraint. Caught only at review.
2. **Helper duplication shortcut.** Grok copied 1,062 LOC of helpers (`log_format.rs` 604 lines, `parse.rs` 99 lines, `projections.rs` 359 lines) into `orbit-dashboard` rather than lifting the pure-utility portions to `orbit-common`. ADR-0167 framed this as "minor duplication"; 1,062 lines is not minor. The choice between duplication and centralization was not surfaced as a decision before the work started.
3. **`#[allow(dead_code)]` to defer cleanup.** Grok sprinkled `#[allow(dead_code)]` / `#[allow(unused_imports)]` across `orbit-cli` to silence warnings on helpers the dashboard moved out — instead of deleting them. `#[allow(dead_code)]` is for code the compiler can't see being used (FFI, macro-generated); using it on items that are actually dead because the consumer moved away parks debt invisibly.
4. **Workspace-pin bypass.** Grok added `futures-core = "0.3"` directly to the new crate's `Cargo.toml` instead of registering it in `[workspace.dependencies]` and referencing as `futures-core.workspace = true`. Every other dep in the new crate is workspace-pinned; this one was the exception.

All four were caught in review, Grok fixed them, threads resolved. But the pattern is: each is the path of least resistance, and the current prompt does not push back. Strengthening the prompt is the right lever (not a per-agent GROK.md), because (a) the rules are agent-agnostic implementer hygiene and (b) Grok-as-planner is winning 5/5 — a per-agent file would risk bloating planner output.

See also: [docs/agent-observations/2026-05-18-agent-md-on-performance.md](docs/agent-observations/2026-05-18-agent-md-on-performance.md) for the broader role-vs-instruction-file analysis.

## Proposed deltas

Four additions to the implementer instruction. Treat the text as a starting point — the planner pass can adjust phrasing while preserving the substance.

### A. Sharpen step 5 (scope discipline)

Append to the existing step 5:

> Touching any file not named in `context_files` or required as a direct dependency of those edits is scope drift. If you find such a file needs changing, surface it as a task comment via `orbit.task.update` and stop — do not change it silently. Deletions of unrelated artifacts (learnings, ADRs, design docs, fixtures) are scope drift even when they look like cleanup.

### B. New step: duplication threshold

> If implementing the task requires duplicating more than ~50 LOC of helper code between crates, either (a) lift the shared portion to the appropriate common crate (`orbit-common` or another existing shared crate) in this PR, or (b) file a follow-up task with `orbit.task.add` and cite its ID in the ADR's Consequences section. Do not characterize duplication of >50 LOC as "minor" without surfacing the alternative as a rejected option in the ADR.

### C. New step: dead-code policy

> Do not add `#[allow(dead_code)]` or `#[allow(unused_imports)]` to suppress warnings on items that became unused because the task moved them out. Either delete the item in this PR, or surface a concrete reason it must remain (e.g., another caller still depends on it) as a task comment. `#[allow(dead_code)]` is for items the compiler can't see being used (FFI, macro-generated), not for parked technical debt.

### D. New step: workspace dependency convention

> Any new third-party dependency must be registered in `[workspace.dependencies]` at the root `Cargo.toml` and referenced as `<crate>.workspace = true` in the consuming crate's manifest. Direct-pinned versions in crate manifests (e.g., `serde = "1"` instead of `serde.workspace = true`) fail PR review.

## Why It Matters

Every one of these failure modes consumed reviewer time on ORB-00146 and added a round-trip the implementer should have caught itself. Strengthening the prompt:

- Front-loads the discipline reviewers currently apply post-hoc.
- Is agent-agnostic — applies equally to Claude, Codex, Gemini, Grok implementers — and avoids the drift cost of per-agent instruction files.
- Survives model updates better than per-agent files (instruction reread per run; per-agent files staled silently).
- Targets the role-context where the failure manifests (implementer prompt only; Grok-as-planner unaffected).

## Constraints / Notes

- Step renumbering: adding 3 new steps grows the list from 10 to 13. Keep numbering coherent; any cross-references in skills or docs to specific step numbers must be updated.
- The agent_implement activity is loaded as an asset; the change is data, not code. No Rust edits expected.
- Do not add agent-specific language (no "Gemini", "Grok", etc. in the prompt body). Per-agent quirk notes are a separate lever.
- Preserve existing step-5 sentence about blockers + `orbit.task.update`; the new language is additive.
- If `make ci` runs any YAML schema validation on activity assets, the change must continue to pass.
- ADR not required — this is a prompt-text change, not an architectural decision. (If reviewer disagrees during execution, surface as a comment.)

### Acceptance Criteria

- `crates/orbit-core/assets/activities/agent_implement.yaml` contains language in (the new or amended) step 5 prohibiting silent edits to files outside `context_files`, with an explicit requirement to surface scope-drift candidates via `orbit.task.update` and stop. Verified by `grep -E 'scope drift|surface (it )?as a task comment'` returning a match in the file.
- The file contains a numbered step (new) requiring duplication of >50 LOC to either be lifted to a shared crate in this PR or filed as a follow-up task whose ID is cited in the ADR's Consequences section. Verified by `grep -E '50 LOC|Consequences'` returning a match.
- The file contains a numbered step (new) prohibiting `#[allow(dead_code)]` and `#[allow(unused_imports)]` on items unused because the task moved them out, with explicit guidance to delete or surface as a blocker. Verified by `grep -E 'allow\(dead_code\)|allow\(unused_imports\)'` returning a match in the instruction body.
- The file contains a numbered step (new) requiring `[workspace.dependencies]` registration and `<crate>.workspace = true` references for any new third-party dependency. Verified by `grep -E 'workspace\.dependencies|workspace = true'` returning a match.
- Step numbering in the instruction list is contiguous (1, 2, 3, …) with no gaps or duplicate numbers after the additions. Verified by visual inspection of the file.
- The instruction body contains no agent-family names (`gemini`, `claude`, `codex`, `grok`). Verified by `grep -iE 'gemini|claude|codex|grok'` against the `instruction:` block returning no matches outside structural comments.
- Existing step 5 retains its current sentence about blockers and `orbit.task.update`; the scope-discipline addition is additive, not a replacement. Verified by `grep 'add a task comment with `orbit.task.update`'` still matching.
- Any existing test that loads `agent_implement.yaml` (e.g., activity-registry parse tests) continues to pass — the YAML still parses, the `instruction` field is non-empty, the `tools` array is unchanged. Verified by `cargo test -p orbit-core activity` (or the equivalent narrower target) passing.
- `make ci-fast` passes after the change.

## Execution Summary

<details>
<summary>Click to expand</summary>

Implemented ORB-00148 by editing crates/orbit-core/assets/activities/agent_implement.yaml: appended scope-drift discipline to step 5, inserted 3 new guardrail steps (6: >50LOC dup lift-or-file-followup; 7: no #[allow(dead_code)] for moved items; 8: workspace deps only), renumbered old 6-10 to 9-13. All 8 ACs satisfied (4 greps, contiguous 1-13, no agent names, blocker sentence retained, yaml parses with 13 steps+16 tools, cargo test activity + make ci-fast pass). Used graph.pack + fs fallback + semantic.related for context. No blockers; no learning surfaced. Only 1 file edited.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-00148-6a0aa1b6`
- Behind base: 0
- Ahead of base: 1