### PR TITLE
Add --planner-a / --planner-b / --arbiter override flags to `orbit run duel-plan`

### DIFF
--- a/crates/orbit-cli/src/command/run/duel.rs
+++ b/crates/orbit-cli/src/command/run/duel.rs
@@ -1,6 +1,7 @@
 //! `orbit run duel-plan` CLI entrypoint.
 
 use clap::Args;
+use orbit_common::types::AgentFamily;
 use orbit_core::{OrbitError, OrbitRuntime, find_workflow};
 use serde_json::{Value, json};
 
@@ -29,11 +30,24 @@ pub struct DuelPlanCommand {
     /// Output as JSON.
     #[arg(long)]
     pub json: bool,
+    /// Agent family for planner A role (codex|claude|gemini|grok). Must be supplied together with --planner-b and --arbiter.
+    #[arg(long = "planner-a", value_name = "FAMILY")]
+    pub planner_a: Option<String>,
+    /// Agent family for planner B role (codex|claude|gemini|grok). Must be supplied together with --planner-a and --arbiter.
+    #[arg(long = "planner-b", value_name = "FAMILY")]
+    pub planner_b: Option<String>,
+    /// Agent family for arbiter role (codex|claude|gemini|grok). Must be supplied together with --planner-a and --planner-b.
+    #[arg(long, value_name = "FAMILY")]
+    pub arbiter: Option<String>,
 }
 
 impl Execute for DuelPlanCommand {
     fn execute(self, runtime: &OrbitRuntime) -> Result<(), OrbitError> {
-        let plan = build_duel_plan_run_plan(&self, runtime.workflow_base_branch())?;
+        let plan = build_duel_plan_run_plan(
+            &self,
+            runtime.workflow_base_branch(),
+            &runtime.duel_candidate_families(),
+        )?;
         let runs = dispatch_workflow(
             runtime,
             plan.workflow_alias,
@@ -53,21 +67,98 @@ pub(crate) struct DuelPlanRunPlan {
     pub wait_for_completion: bool,
 }
 
+/// Validates explicit --planner-a/--planner-b/--arbiter when any are present.
+/// Returns Ok(Some((a,b,arb))) when all three valid and distinct and in candidates;
+/// Ok(None) when none present (caller uses random path);
+/// Err for partial, bad parse, dup, or not-in-candidates.
+fn explicit_duel_role_families(
+    args: &DuelPlanCommand,
+    candidates: &[String],
+) -> Result<Option<(String, String, String)>, OrbitError> {
+    let pa = args.planner_a.as_deref();
+    let pb = args.planner_b.as_deref();
+    let arb = args.arbiter.as_deref();
+
+    let present_count = [pa, pb, arb].iter().filter(|o| o.is_some()).count();
+    if present_count == 0 {
+        return Ok(None);
+    }
+    if present_count < 3 {
+        let mut missing = Vec::new();
+        if pa.is_none() {
+            missing.push("--planner-a");
+        }
+        if pb.is_none() {
+            missing.push("--planner-b");
+        }
+        if arb.is_none() {
+            missing.push("--arbiter");
+        }
+        return Err(OrbitError::InvalidInput(format!(
+            "duel-plan explicit roles require all three of --planner-a, --planner-b, --arbiter; missing {}",
+            missing.join(", ")
+        )));
+    }
+
+    // All three present: parse and validate
+    let fa = AgentFamily::parse(pa.unwrap())?;
+    let fb = AgentFamily::parse(pb.unwrap())?;
+    let fc = AgentFamily::parse(arb.unwrap())?;
+
+    let sa = fa.as_str();
+    let sb = fb.as_str();
+    let sc = fc.as_str();
+
+    if sa == sb || sa == sc || sb == sc {
+        let dup = if sa == sb || sa == sc { sa } else { sb };
+        return Err(OrbitError::InvalidInput(format!(
+            "duel-plan explicit roles must use distinct families; '{dup}' appears more than once"
+        )));
+    }
+
+    for (flag, fam) in [("--planner-a", sa), ("--planner-b", sb), ("--arbiter", sc)] {
+        if !candidates.iter().any(|c| c == fam) {
+            return Err(OrbitError::InvalidInput(format!(
+                "{flag} value '{fam}' is not in [duel] candidates {candidates:?}"
+            )));
+        }
+    }
+
+    Ok(Some((sa.to_string(), sb.to_string(), sc.to_string())))
+}
+
 pub(crate) fn build_duel_plan_run_plan(
     args: &DuelPlanCommand,
     config_base_branch: &str,
+    duel_candidates: &[String],
 ) -> Result<DuelPlanRunPlan, OrbitError> {
     find_workflow(DUEL_PLAN_WORKFLOW).ok_or_else(|| {
         OrbitError::InvalidInput(format!("unknown workflow '{DUEL_PLAN_WORKFLOW}'"))
     })?;
     let base = args.base.as_deref().unwrap_or(config_base_branch);
-    Ok(DuelPlanRunPlan {
-        workflow_alias: DUEL_PLAN_WORKFLOW,
-        input: json!({
+
+    let input = if let Some((planner_a_family, planner_b_family, arbiter_family)) =
+        explicit_duel_role_families(args, duel_candidates)?
+    {
+        json!({
             "task_id": args.task_id.clone(),
             "task_ids": [args.task_id.clone()],
             "base_branch": base,
-        }),
+            "planner_a_family": planner_a_family,
+            "planner_b_family": planner_b_family,
+            "arbiter_family": arbiter_family,
+        })
+    } else {
+        json!({
+            "task_id": args.task_id.clone(),
+            "task_ids": [args.task_id.clone()],
+            "base_branch": base,
+        })
+    };
+
+    Ok(DuelPlanRunPlan {
+        workflow_alias: DUEL_PLAN_WORKFLOW,
+        input,
         wait_for_completion: args.wait,
     })
 }
@@ -87,13 +178,25 @@ mod tests {
             base: base.map(str::to_string),
             wait,
             json: false,
+            planner_a: None,
+            planner_b: None,
+            arbiter: None,
         }
     }
 
     #[test]
     fn duel_plan_uses_explicit_base_when_flag_set() {
-        let plan = build_duel_plan_run_plan(&duel_plan_args(Some("main"), false), "agent-main")
-            .expect("build duel-plan run plan");
+        let plan = build_duel_plan_run_plan(
+            &duel_plan_args(Some("main"), false),
+            "agent-main",
+            &[
+                "codex".to_string(),
+                "claude".to_string(),
+                "gemini".to_string(),
+                "grok".to_string(),
+            ],
+        )
+        .expect("build duel-plan run plan");
 
         assert_eq!(plan.workflow_alias, DUEL_PLAN_WORKFLOW);
         assert_eq!(
@@ -108,8 +211,17 @@ mod tests {
 
     #[test]
     fn duel_plan_falls_back_to_config_base_when_flag_absent() {
-        let plan = build_duel_plan_run_plan(&duel_plan_args(None, false), "agent-main")
-            .expect("build duel-plan run plan");
+        let plan = build_duel_plan_run_plan(
+            &duel_plan_args(None, false),
+            "agent-main",
+            &[
+                "codex".to_string(),
+                "claude".to_string(),
+                "gemini".to_string(),
+                "grok".to_string(),
+            ],
+        )
+        .expect("build duel-plan run plan");
 
         assert_eq!(
             plan.input,
@@ -123,16 +235,34 @@ mod tests {
 
     #[test]
     fn duel_plan_dispatch_defaults_to_non_blocking() {
-        let plan = build_duel_plan_run_plan(&duel_plan_args(None, false), "agent-main")
-            .expect("build duel-plan run plan");
+        let plan = build_duel_plan_run_plan(
+            &duel_plan_args(None, false),
+            "agent-main",
+            &[
+                "codex".to_string(),
+                "claude".to_string(),
+                "gemini".to_string(),
+                "grok".to_string(),
+            ],
+        )
+        .expect("build duel-plan run plan");
 
         assert!(!plan.wait_for_completion);
     }
 
     #[test]
     fn duel_plan_wait_flag_requests_blocking_dispatch() {
-        let plan = build_duel_plan_run_plan(&duel_plan_args(None, true), "agent-main")
-            .expect("build duel-plan run plan");
+        let plan = build_duel_plan_run_plan(
+            &duel_plan_args(None, true),
+            "agent-main",
+            &[
+                "codex".to_string(),
+                "claude".to_string(),
+                "gemini".to_string(),
+                "grok".to_string(),
+            ],
+        )
+        .expect("build duel-plan run plan");
 
         assert!(plan.wait_for_completion);
     }
@@ -161,8 +291,17 @@ spec:
 "#,
         )
         .expect("write job_duel_plan_pipeline fixture");
-        let plan = build_duel_plan_run_plan(&duel_plan_args(None, false), "agent-main")
-            .expect("build duel-plan run plan");
+        let plan = build_duel_plan_run_plan(
+            &duel_plan_args(None, false),
+            "agent-main",
+            &[
+                "codex".to_string(),
+                "claude".to_string(),
+                "gemini".to_string(),
+                "grok".to_string(),
+            ],
+        )
+        .expect("build duel-plan run plan");
 
         let started = Instant::now();
         let runs = dispatch_workflow(
@@ -186,5 +325,98 @@ spec:
         assert_eq!(runs[0].attempt, 1);
         assert!(runs[0].error_code.is_none());
         assert!(runs[0].error_message.is_none());
+    }
+
+    fn full_candidates() -> Vec<String> {
+        vec![
+            "codex".to_string(),
+            "claude".to_string(),
+            "gemini".to_string(),
+            "grok".to_string(),
+        ]
+    }
+
+    #[test]
+    fn duel_plan_explicit_all_three_populates_family_overrides_in_input() {
+        let mut args = duel_plan_args(None, true);
+        args.planner_a = Some("gemini".to_string());
+        args.planner_b = Some("codex".to_string());
+        args.arbiter = Some("grok".to_string());
+
+        let plan = build_duel_plan_run_plan(&args, "main", &full_candidates())
+            .expect("explicit roles build");
+
+        assert_eq!(plan.input["planner_a_family"], "gemini");
+        assert_eq!(plan.input["planner_b_family"], "codex");
+        assert_eq!(plan.input["arbiter_family"], "grok");
+        assert!(
+            !plan
+                .input
+                .as_object()
+                .unwrap()
+                .contains_key("planner_a_agent_cli")
+        ); // no roles yet
+    }
+
+    #[test]
+    fn duel_plan_explicit_partial_flags_errors_with_missing_names() {
+        let mut args = duel_plan_args(None, false);
+        args.planner_a = Some("gemini".to_string());
+        // planner_b and arbiter absent
+        let err = build_duel_plan_run_plan(&args, "main", &full_candidates()).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("missing --planner-b, --arbiter"), "msg={msg}");
+    }
+
+    #[test]
+    fn duel_plan_explicit_invalid_family_errors_with_expected_list() {
+        let mut args = duel_plan_args(None, false);
+        args.planner_a = Some("xyz".to_string());
+        args.planner_b = Some("codex".to_string());
+        args.arbiter = Some("grok".to_string());
+        let err = build_duel_plan_run_plan(&args, "main", &full_candidates()).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("unknown agent family 'xyz'"), "msg={msg}");
+        assert!(msg.contains("codex, claude, gemini, grok"), "msg={msg}");
+    }
+
+    #[test]
+    fn duel_plan_explicit_family_not_in_candidates_errors_with_name_and_list() {
+        let mut args = duel_plan_args(None, false);
+        args.planner_a = Some("gemini".to_string());
+        args.planner_b = Some("codex".to_string());
+        args.arbiter = Some("claude".to_string());
+        let cands = vec![
+            "codex".to_string(),
+            "gemini".to_string(),
+            "grok".to_string(),
+        ];
+        let err = build_duel_plan_run_plan(&args, "main", &cands).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("claude"), "msg={msg}");
+        assert!(msg.contains("candidates"), "msg={msg}");
+    }
+
+    #[test]
+    fn duel_plan_explicit_duplicate_family_errors_with_duplicated_name() {
+        let mut args = duel_plan_args(None, false);
+        args.planner_a = Some("gemini".to_string());
+        args.planner_b = Some("gemini".to_string());
+        args.arbiter = Some("codex".to_string());
+        let err = build_duel_plan_run_plan(&args, "main", &full_candidates()).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("'gemini' appears more than once"), "msg={msg}");
+    }
+
+    #[test]
+    fn duel_plan_no_explicit_flags_omits_family_keys_from_input() {
+        let plan =
+            build_duel_plan_run_plan(&duel_plan_args(None, false), "main", &full_candidates())
+                .expect("no-override");
+
+        let obj = plan.input.as_object().unwrap();
+        assert!(!obj.contains_key("planner_a_family"));
+        assert!(!obj.contains_key("planner_b_family"));
+        assert!(!obj.contains_key("arbiter_family"));
     }
 }

--- a/crates/orbit-core/assets/jobs/job_duel_plan_pipeline.yaml
+++ b/crates/orbit-core/assets/jobs/job_duel_plan_pipeline.yaml
@@ -15,6 +15,9 @@ spec:
   default_input:
     task_id: null
     base_branch: main
+    planner_a_family: null
+    planner_b_family: null
+    arbiter_family: null
 
   steps:
     - id: run_planning_duel
@@ -22,3 +25,6 @@ spec:
       default_input:
         task_id: "{{ input.task_id }}"
         base_branch: "{{ input.base_branch }}"
+        planner_a_family: "{{ input.planner_a_family }}"
+        planner_b_family: "{{ input.planner_b_family }}"
+        arbiter_family: "{{ input.arbiter_family }}"

--- a/crates/orbit-core/src/runtime/mod.rs
+++ b/crates/orbit-core/src/runtime/mod.rs
@@ -245,6 +245,12 @@ impl OrbitRuntime {
         self.context.workflow_base_branch()
     }
 
+    /// Returns the configured `[duel] candidates` list (e.g. ["codex", "claude", "gemini", "grok"]).
+    /// Used by `orbit run duel-plan --planner-a ...` overrides to validate explicit families.
+    pub fn duel_candidate_families(&self) -> Vec<String> {
+        self.context.duel_config().candidates.clone()
+    }
+
     pub(crate) fn duel_config(&self) -> &crate::config::DuelConfig {
         self.context.duel_config()
     }

--- a/crates/orbit-engine/src/executor/automation/duel/planning_duel/roles.rs
+++ b/crates/orbit-engine/src/executor/automation/duel/planning_duel/roles.rs
@@ -325,19 +325,73 @@ pub(super) fn select_planning_duel_roles<H: RuntimeHost + ?Sized>(
     input: &Value,
 ) -> Result<Value, OrbitError> {
     let task_id = required_input_string(input, "task_id")?;
-    let perm = next_permutation(host)?;
-    let output = build_roles_output(host, perm)?;
+
+    let pa = input_string_field(input, "planner_a_family");
+    let pb = input_string_field(input, "planner_b_family");
+    let ar = input_string_field(input, "arbiter_family");
+
+    let roles_output = if let (Some(a), Some(b), Some(c)) =
+        (pa.as_deref(), pb.as_deref(), ar.as_deref())
+    {
+        // explicit assignment path (CLI or direct workflow); all-or-nothing already enforced by caller,
+        // but defend here for partial YAML / direct activity calls
+        if a == b || a == c || b == c {
+            let dup = if a == b || a == c { a } else { b };
+            return Err(OrbitError::InvalidInput(format!(
+                "select_planning_duel_roles explicit roles must use distinct families; '{dup}' appears more than once"
+            )));
+        }
+
+        let families = host.duel_candidate_families();
+        let ia = families.iter().position(|f| f == a).ok_or_else(|| {
+            OrbitError::InvalidInput(format!(
+                "planner_a_family value '{a}' is not in [duel] candidates {families:?}"
+            ))
+        })?;
+        let ib = families.iter().position(|f| f == b).ok_or_else(|| {
+            OrbitError::InvalidInput(format!(
+                "planner_b_family value '{b}' is not in [duel] candidates {families:?}"
+            ))
+        })?;
+        let ic = families.iter().position(|f| f == c).ok_or_else(|| {
+            OrbitError::InvalidInput(format!(
+                "arbiter_family value '{c}' is not in [duel] candidates {families:?}"
+            ))
+        })?;
+
+        let perm = [ia, ib, ic];
+        validate_role_permutation(perm, families.len(), "select_planning_duel_roles")?;
+        build_roles_output(host, perm)?
+    } else if pa.is_some() || pb.is_some() || ar.is_some() {
+        let mut missing = vec![];
+        if pa.is_none() {
+            missing.push("planner_a_family");
+        }
+        if pb.is_none() {
+            missing.push("planner_b_family");
+        }
+        if ar.is_none() {
+            missing.push("arbiter_family");
+        }
+        return Err(OrbitError::InvalidInput(format!(
+            "select_planning_duel_roles explicit roles require all three of planner_a_family, planner_b_family, arbiter_family; missing {}",
+            missing.join(", ")
+        )));
+    } else {
+        let perm = next_permutation(host)?;
+        build_roles_output(host, perm)?
+    };
 
     Ok(json!({
         "task_id": task_id,
-        "planning_duel_started_at": output["planning_duel_started_at"].clone(),
-        "planner_a_agent_cli": output["planner_a_agent_cli"].clone(),
-        "planner_a_model": output["planner_a_model"].clone(),
-        "planner_b_agent_cli": output["planner_b_agent_cli"].clone(),
-        "planner_b_model": output["planner_b_model"].clone(),
-        "arbiter_agent_cli": output["arbiter_agent_cli"].clone(),
-        "arbiter_model": output["arbiter_model"].clone(),
-        "planning_duel_roles": output["planning_duel_roles"].clone(),
+        "planning_duel_started_at": roles_output["planning_duel_started_at"].clone(),
+        "planner_a_agent_cli": roles_output["planner_a_agent_cli"].clone(),
+        "planner_a_model": roles_output["planner_a_model"].clone(),
+        "planner_b_agent_cli": roles_output["planner_b_agent_cli"].clone(),
+        "planner_b_model": roles_output["planner_b_model"].clone(),
+        "arbiter_agent_cli": roles_output["arbiter_agent_cli"].clone(),
+        "arbiter_model": roles_output["arbiter_model"].clone(),
+        "planning_duel_roles": roles_output["planning_duel_roles"].clone(),
     }))
 }
 
@@ -618,5 +672,50 @@ mod tests {
         };
         assert!(msg.contains("expected gemini"), "msg={msg}");
         assert!(msg.contains("has family claude"), "msg={msg}");
+    }
+
+    #[test]
+    fn planning_duel_roles_explicit_assignment_returns_requested_families_without_permutation_queue()
+     {
+        // Explicit families provided in input; must NOT require seeding TEST_PERMUTATION_QUEUE
+        // and must bypass next_permutation entirely.
+        let host = TestHost::new();
+        let input = json!({
+            "task_id": "ORB-TEST-EXPLICIT",
+            "planner_a_family": "gemini",
+            "planner_b_family": "codex",
+            "arbiter_family": "grok"
+        });
+
+        let output = select_planning_duel_roles(&host, &input)
+            .expect("explicit assignment path succeeds without queue");
+
+        assert_eq!(output["planner_a_agent_cli"], "gemini");
+        assert_eq!(output["planner_b_agent_cli"], "codex");
+        assert_eq!(output["arbiter_agent_cli"], "grok");
+        assert_eq!(
+            output["planning_duel_roles"]["planner_a"]["family"],
+            "gemini"
+        );
+        assert_eq!(
+            output["planning_duel_roles"]["planner_b"]["family"],
+            "codex"
+        );
+        assert_eq!(output["planning_duel_roles"]["arbiter"]["family"], "grok");
+    }
+
+    #[test]
+    fn planning_duel_roles_no_override_still_uses_queued_permutation_path() {
+        // No override fields -> must still go through next_permutation (test seeds queue)
+        queue_permutation([0, 2, 3]); // codex, gemini, grok
+        let host = TestHost::new();
+        let input = json!({ "task_id": "ORB-TEST-NO-OVERRIDE" });
+
+        let output =
+            select_planning_duel_roles(&host, &input).expect("no-override still uses permutation");
+
+        assert_eq!(output["planner_a_agent_cli"], "codex");
+        assert_eq!(output["planner_b_agent_cli"], "gemini");
+        assert_eq!(output["arbiter_agent_cli"], "grok");
     }
 }

--- a/crates/orbit-engine/src/executor/automation/duel/planning_duel/runner.rs
+++ b/crates/orbit-engine/src/executor/automation/duel/planning_duel/runner.rs
@@ -107,7 +107,21 @@ pub(crate) fn run_planning_duel<H: RuntimeHost + TaskHost + Sync + ?Sized>(
 
     artifacts::cleanup_stale_planning_duel_artifacts(host, task_id)?;
 
-    let roles_output = roles::select_planning_duel_roles(host, &json!({ "task_id": task_id }))?;
+    let roles_input = {
+        let mut m = serde_json::Map::new();
+        m.insert("task_id".to_string(), json!(task_id));
+        if let Some(v) = input_string_field(input, "planner_a_family") {
+            m.insert("planner_a_family".to_string(), json!(v));
+        }
+        if let Some(v) = input_string_field(input, "planner_b_family") {
+            m.insert("planner_b_family".to_string(), json!(v));
+        }
+        if let Some(v) = input_string_field(input, "arbiter_family") {
+            m.insert("arbiter_family".to_string(), json!(v));
+        }
+        Value::Object(m)
+    };
+    let roles_output = roles::select_planning_duel_roles(host, &roles_input)?;
     let planning_roles = roles::parse_planning_duel_roles(&roles_output)?;
 
     let planner_activity = roles::planner_activity();


### PR DESCRIPTION
## Task

[ORB-00147](https://orbit-cli.com/tasks/ORB-00147) — Add --planner-a / --planner-b / --arbiter override flags to `orbit run duel-plan`

### Description

## Problem

`orbit run duel-plan <TASK_ID>` currently has no way to force a specific role lineup. Roles are picked by `next_permutation` at [roles.rs:111](crates/orbit-engine/src/executor/automation/duel/planning_duel/roles.rs:111), which reads `SystemTime::now().as_nanos()` and modulos it against the `[duel].candidates` pool — effectively random.

For any controlled experiment about a single agent (e.g., "does Gemini's plan quality move with new GEMINI.md content?", "does a stable model alias change Gemini's win rate vs preview?", "does a tightened PLANNING_DUEL_INSTRUCTION lift Codex disproportionately?"), we need to fix the lineup. With 3 candidates today (codex/gemini/grok), Gemini lands in a planner slot in only 4/6 random permutations — 33% of runs are wasted as far as a per-agent experiment is concerned.

The duplicate-candidates workaround does not exist: the config loader at [config/runtime.rs:280](crates/orbit-core/src/config/runtime.rs:280) explicitly rejects duplicate entries in `[duel].candidates`, and `[duel.models]` is a flat one-model-per-family map.

## Why It Matters

Without this, every agent-tuning experiment (GEMINI.md content, planning-prompt changes, executor-config tweaks, model-alias swaps) requires either loop-and-discard runs or temporary config gymnastics that pollute `git status`. This is currently blocking the GEMINI.md content hypothesis described in [docs/agent-observations/2026-05-18-agent-md-on-performance.md](docs/agent-observations/2026-05-18-agent-md-on-performance.md) and is a recurring need for any future per-agent investigation.

## Scope / Notes

- All-or-nothing: the three flags must be provided together. Any partial subset is an error. This keeps the runner from having to merge a partial manual lineup with a random fill-in.
- Distinct-families constraint preserved. Reuse `validate_role_permutation` at [mod.rs:44](crates/orbit-engine/src/executor/automation/duel/mod.rs:44) — same-family-in-two-slots stays rejected. A separate task can relax that if Gemini-vs-Gemini variance experiments are ever wanted.
- Family values must be in resolved `[duel].candidates`. Asking for `claude` when claude is not in the pool should fail at CLI dispatch, not silently fall through.
- Plumbing path: CLI flag → workflow input JSON → engine reads explicit fields in `select_planning_duel_roles` at [roles.rs:294](crates/orbit-engine/src/executor/automation/duel/planning_duel/roles.rs:294) and skips `next_permutation` when present. Existing `TEST_PERMUTATION_QUEUE` thread_local is the test seam — do not reuse it for CLI-originated runs (different lifecycle).
- The flag overrides only role assignment. Model resolution per family still flows through `[duel.models]` → `duel_orchestrator_model` unchanged.
- Existing behavior (no flags) must be preserved bit-for-bit — `next_permutation` still runs, scoreboard JSON shape unchanged.

### Acceptance Criteria

- `orbit run duel-plan --help` lists three new flags: `--planner-a <FAMILY>`, `--planner-b <FAMILY>`, `--arbiter <FAMILY>`, each with a one-line description naming valid values (codex|claude|gemini|grok). Verified by running the command and inspecting stdout.
- Invoking `orbit run duel-plan <TASK_ID> --planner-a gemini --planner-b codex --arbiter grok --wait --json` produces a planning-duel run whose entry in `.orbit/state/scoreboard/duel_plan.json` has `roles.planner_a.family == "gemini"`, `roles.planner_b.family == "codex"`, and `roles.arbiter.family == "grok"` — verified by `jq` on the run record.
- Specifying any one or two of the three flags (but not all three) exits non-zero with a stderr message naming which flag(s) are missing. Verified by running `orbit run duel-plan <TASK_ID> --planner-a gemini` and `orbit run duel-plan <TASK_ID> --planner-a gemini --planner-b codex`.
- Specifying a value that is not a recognized agent family exits non-zero with a stderr message listing valid families. Verified by `orbit run duel-plan <TASK_ID> --planner-a gemini --planner-b codex --arbiter xyz`.
- Specifying a recognized family that is not in resolved `[duel].candidates` exits non-zero with a stderr message naming the offending family and the current candidates list. Verified by setting `[duel].candidates = ["codex", "gemini", "grok"]` and running with `--arbiter claude`.
- Specifying the same family twice across the three flags exits non-zero with a stderr message naming the duplicated family. Verified by `--planner-a gemini --planner-b gemini --arbiter codex`.
- When all three flags are omitted, the existing random-permutation behavior is preserved: an integration test (or rerun smoke) shows `roles.planner_a.family` populated by `next_permutation` over the configured candidates. Verified by inspecting `.orbit/state/scoreboard/duel_plan.json` for a no-flag run.
- A unit test in `crates/orbit-engine/src/executor/automation/duel/planning_duel/roles.rs` exercises the new explicit-assignment path: given a workflow input carrying `planner_a_family`, `planner_b_family`, `arbiter_family`, `select_planning_duel_roles` returns the matching `planning_duel_roles` without consulting `next_permutation` (i.e., test does not need to seed `TEST_PERMUTATION_QUEUE`).
- `make ci-fast` passes.

## Execution Summary

<details>
<summary>Click to expand</summary>

Implemented --planner-a/--planner-b/--arbiter override flags for `orbit run duel-plan` (ORB-00147). Extended DuelPlanCommand + build_duel_plan_run_plan with all-or-nothing validation, AgentFamily parse, candidates check, dup rejection. Exposed duel_candidate_families() on OrbitRuntime (no new deps). Updated YAML workflow to forward nullable fields. Runner forwards overrides to select_planning_duel_roles. Roles explicit path (family->index, name-dup check before validate, defensive partial error) before next_permutation; absent -> unchanged random path. 8 new unit tests (CLI errors+success, roles explicit without queue, no-flag still queues). --help, error cases, ci-fast, unit tests all pass. No learning surfaced.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-00147-6a0aa1b6`
- Behind base: 0
- Ahead of base: 1