### PR TITLE
Dashboard JS split: extract tasks.js (per-domain split, round 1)

### DIFF
--- a/crates/orbit-dashboard/assets/dashboard/app.js
+++ b/crates/orbit-dashboard/assets/dashboard/app.js
@@ -1,7 +1,8 @@
 // Orbit dashboard — terminal-dark, manually refreshed SPA.
 // Pure vanilla JS, split into ES modules with no build step.
 
-import { el, statusPill, priorityCell, stateCell, fetchJson, requestJson, postJson, patchJson, syncNodes, positiveIntParam } from './common.js';
+import { el, statusPill, stateCell, fetchJson, requestJson, postJson, patchJson, syncNodes, positiveIntParam } from './common.js';
+import { buildChips, cacheCrewPayload, copyTaskIdWithNotice, hasCrewOptions, openVisibleTask, renderTasks, wireSearch } from './tasks.js';
 
 const STATUS_ORDER = [
   "in-progress",
@@ -36,7 +37,6 @@ let activeStatuses = new Set(
   STATUS_ORDER.filter((s) => !DEFAULT_INACTIVE_STATUSES.has(s)),
 );
 let lastTasks = [];
-let lastCrewPayload = { default_crew: null, crews: [] };
 let lastRuns = [];
 let lastDiagnostics = { metrics: [], errors: [], implement_one: [] };
 let lastLearningPayload = { stats: {}, items: [] };
@@ -46,10 +46,7 @@ let activeTab = "tasks";
 let activeDiagSubtab = "runs";
 let activeKnowledgeSubtab = "learnings";
 let runSort = { key: "when", dir: "desc" };
-let expandedTaskIds = new Set();
 let isRefreshing = false;
-let taskActionNotice = null;
-let crewUpdateErrors = new Map();
 let activeLearningId = null;
 let learningSearchQuery = "";
 let activeAdrId = null;
@@ -97,55 +94,24 @@ let activeRunLogs = [];
 let activeRunSubtab = "steps";
 let expandedStepIndices = new Set();
 
-function normalizeCrewPayload(payload) {
-  const crews = Array.isArray(payload && payload.crews)
-    ? payload.crews
-      .filter((crew) => crew && crew.name)
-      .map((crew) => ({
-        name: String(crew.name),
-        planner_model: crew.planner_model == null ? "" : String(crew.planner_model),
-        implementer_model: crew.implementer_model == null ? "" : String(crew.implementer_model),
-        reviewer_model: crew.reviewer_model == null ? "" : String(crew.reviewer_model),
-        is_default: Boolean(crew.is_default),
-      }))
-    : [];
-  crews.sort((a, b) => a.name.localeCompare(b.name));
+function taskContext() {
   return {
-    default_crew: payload && payload.default_crew ? String(payload.default_crew) : null,
-    crews,
+    getTasks: () => lastTasks,
+    replaceTask: (updatedTask) => {
+      const index = lastTasks.findIndex((task) => task.id === updatedTask.id);
+      if (index >= 0) {
+        lastTasks[index] = updatedTask;
+      }
+    },
+    getSearchQuery: () => searchQuery,
+    setSearchQuery: (value) => { searchQuery = value; },
+    getActiveStatuses: () => activeStatuses,
+    setActiveStatuses: (statuses) => { activeStatuses = statuses; },
+    statusOrder: STATUS_ORDER,
+    statusUpdateTargets: STATUS_UPDATE_TARGETS,
+    fmtAbsTime,
+    refreshDashboard,
   };
-}
-
-function crewOptionsSignature() {
-  return JSON.stringify(lastCrewPayload);
-}
-
-function explicitCrewValue(task) {
-  return task && task.crew ? String(task.crew) : "";
-}
-
-function resolvedCrewName(task) {
-  if (lastCrewPayload.default_crew) return lastCrewPayload.default_crew;
-  if (!explicitCrewValue(task) && task && task.resolved_crew) {
-    return String(task.resolved_crew);
-  }
-  return "workspace";
-}
-
-function crewOptionTitle(crew) {
-  const parts = [
-    `planner=${crew.planner_model || "-"}`,
-    `implementer=${crew.implementer_model || "-"}`,
-    `reviewer=${crew.reviewer_model || "-"}`,
-  ];
-  return parts.join(" · ");
-}
-
-function applyUpdatedTask(updatedTask) {
-  const index = lastTasks.findIndex((task) => task.id === updatedTask.id);
-  if (index >= 0) {
-    lastTasks[index] = updatedTask;
-  }
 }
 
 function runIsCancellable(run) {
@@ -248,738 +214,6 @@ function renderBodyBlock(body, fallbackClass) {
   ]);
 }
 
-function filterTasks(tasks) {
-  const q = searchQuery;
-  return tasks.filter((t) => {
-    if (!activeStatuses.has(t.status)) return false;
-    if (!q) return true;
-    return (
-      (t.id && t.id.toLowerCase().includes(q)) ||
-      (t.title && t.title.toLowerCase().includes(q))
-    );
-  });
-}
-
-const TASK_META_FIELDS = [
-  ["implemented_by", "implemented_by"],
-  ["planned_by", "planned_by"],
-  ["created_by", "created_by"],
-  ["pr_number", "pr"],
-  ["pr_status", "pr_status"],
-  ["job_run_id", "job_run"],
-  ["created_at", "created"],
-  ["updated_at", "updated"],
-];
-
-const RELATION_GROUPS = [
-  ["blocked_by", "BlockedBy"],
-  ["child_of", "ChildOf"],
-  ["spawned_from", "SpawnedFrom"],
-  ["regression_from", "RegressionFrom"],
-  ["supersedes", "Supersedes"],
-  ["related_to", "RelatedTo"],
-];
-const RELATION_GROUP_LABELS = new Map(RELATION_GROUPS);
-
-function relationTypeKey(value) {
-  if (!value) return "";
-  return String(value)
-    .replace(/([a-z0-9])([A-Z])/g, "$1_$2")
-    .replace(/-/g, "_")
-    .toLowerCase();
-}
-
-function copyTaskIdWithNotice(taskId) {
-  if (navigator.clipboard && navigator.clipboard.writeText) {
-    navigator.clipboard.writeText(taskId).catch(() => {});
-  }
-  taskActionNotice = `${taskId} is not in the filtered task list; copied ID`;
-  renderTasks(lastTasks);
-}
-
-function findTaskRow(taskId) {
-  return Array.from(document.querySelectorAll("#tasks-body .row"))
-    .find((row) => row.dataset.key === `task-${taskId}`) || null;
-}
-
-function openVisibleTask(taskId) {
-  const visible = filterTasks(lastTasks).some((task) => task.id === taskId);
-  if (!visible) {
-    copyTaskIdWithNotice(taskId);
-    return;
-  }
-  expandedTaskIds.add(taskId);
-  renderTasks(lastTasks);
-  requestAnimationFrame(() => {
-    const row = findTaskRow(taskId);
-    if (!row) return;
-    row.scrollIntoView({ behavior: "smooth", block: "center" });
-    row.classList.add("data-changed");
-    setTimeout(() => row.classList.remove("data-changed"), 1200);
-  });
-}
-
-function buildTagRow(tags) {
-  const wrap = el("div", { class: "detail-tag-row" });
-  for (const tag of tags) {
-    wrap.appendChild(el("span", { class: "chip", text: tag }));
-  }
-  return wrap;
-}
-
-function buildExternalRefs(refs) {
-  const wrap = el("div");
-  for (const ref of refs) {
-    const label = `${ref.system || "external"}:${ref.id || ""}`;
-    const line = el("div", { class: "external-ref-line" });
-    if (ref.url) {
-      const link = el("a", { text: label });
-      link.href = ref.url;
-      line.appendChild(link);
-    } else {
-      line.textContent = label;
-    }
-    wrap.appendChild(line);
-  }
-  return wrap;
-}
-
-function buildRelations(relations) {
-  const byType = new Map(RELATION_GROUPS.map(([key]) => [key, []]));
-  for (const relation of relations) {
-    const key = relationTypeKey(relation.relation_type || relation.type);
-    const target = relation.target == null ? "" : String(relation.target);
-    if (!RELATION_GROUP_LABELS.has(key) || !target) continue;
-    byType.get(key).push(target);
-  }
-
-  const wrap = el("div");
-  for (const [key, label] of RELATION_GROUPS) {
-    const targets = byType.get(key);
-    if (!targets || targets.length === 0) continue;
-    const group = el("div", { class: "relation-group" }, [
-      el("span", { class: "label", text: label }),
-    ]);
-    for (const target of targets) {
-      const btn = el("button", { class: "relation-target mono", text: target });
-      btn.addEventListener("click", (e) => {
-        e.stopPropagation();
-        openVisibleTask(target);
-      });
-      group.appendChild(btn);
-    }
-    wrap.appendChild(group);
-  }
-  return wrap;
-}
-
-function reviewThreadStatus(thread) {
-  const status = String(thread.status || "open").toLowerCase();
-  return status === "resolved" ? "resolved" : "open";
-}
-
-function buildReviewThreads(threads) {
-  const wrap = el("div", { class: "review-threads" });
-  for (const thread of threads) {
-    const messages = Array.isArray(thread.messages) ? thread.messages : [];
-    const location = thread.path
-      ? `${thread.path}${thread.line == null ? "" : `:${thread.line}`}`
-      : "general";
-    const block = el("div", { class: "review-thread" });
-    block.appendChild(el("div", {
-      class: "review-thread-header",
-      text: `[${reviewThreadStatus(thread)}] ${location} · ${messages.length} messages`,
-    }));
-    for (const msg of messages) {
-      const line = el("div", { class: "comment-line" }, [
-        document.createTextNode(`[${fmtAbsTime(msg.at)}] `),
-        el("span", { class: "author", text: msg.by || "?" }),
-        document.createTextNode(`: ${msg.body || ""}`),
-      ]);
-      block.appendChild(line);
-    }
-    wrap.appendChild(block);
-  }
-  return wrap;
-}
-
-function fmtSize(bytes) {
-  const value = Number(bytes);
-  if (!Number.isFinite(value) || value < 0) return "0 bytes";
-  if (value < 1024) return `${value} bytes`;
-  const kb = value / 1024;
-  if (kb < 1024) return `${kb.toFixed(kb < 10 ? 1 : 0)} KB`;
-  const mb = kb / 1024;
-  return `${mb.toFixed(mb < 10 ? 1 : 0)} MB`;
-}
-
-function artifactUrl(taskId, path) {
-  const encodedPath = String(path)
-    .split("/")
-    .map((part) => encodeURIComponent(part))
-    .join("/");
-  return `/api/tasks/${encodeURIComponent(taskId)}/artifacts/${encodedPath}`;
-}
-
-function artifactMediaType(artifact, response) {
-  return String(
-    response.headers.get("content-type") || artifact.media_type || "application/octet-stream",
-  ).split(";")[0].trim().toLowerCase();
-}
-
-function renderArtifactText(mediaType, text) {
-  if (mediaType === "text/markdown" && typeof marked !== "undefined") {
-    const view = el("div", { class: "markdown-body" });
-    view.innerHTML = marked.parse(text);
-    return view;
-  }
-  return el("pre", { text });
-}
-
-function buildArtifactPreview(artifact, response) {
-  const mediaType = artifactMediaType(artifact, response);
-  if (
-    mediaType === "text/markdown" ||
-    mediaType === "application/json" ||
-    mediaType.endsWith("/yaml") ||
-    mediaType.endsWith("+yaml") ||
-    mediaType.startsWith("text/")
-  ) {
-    return response.text().then((text) => renderArtifactText(mediaType, text));
-  }
-  return response.blob().then((blob) => {
-    const link = el("a", { text: `Download ${artifact.path}` });
-    link.href = URL.createObjectURL(blob);
-    link.download = String(artifact.path).split("/").pop() || artifact.path;
-    return link;
-  });
-}
-
-function buildArtifacts(task) {
-  const wrap = el("div", { class: "artifacts" });
-  for (const artifact of task.artifacts) {
-    const path = String(artifact.path || "");
-    const mediaType = String(artifact.media_type || "application/octet-stream");
-    const row = el("div", {
-      class: "artifact-row",
-      text: `${path} · ${mediaType} · ${fmtSize(artifact.size_bytes)}`,
-    });
-    const preview = el("div", { class: "artifact-preview" });
-    preview.hidden = true;
-    row.addEventListener("click", async (e) => {
-      e.stopPropagation();
-      if (preview.dataset.loaded === "true" && !preview.hidden) {
-        preview.hidden = true;
-        return;
-      }
-      if (preview.dataset.loaded === "true") {
-        preview.hidden = false;
-        return;
-      }
-      preview.hidden = false;
-      preview.textContent = "loading...";
-      try {
-        const response = await fetch(artifactUrl(task.id, path));
-        if (!response.ok) throw new Error(`HTTP ${response.status}`);
-        preview.replaceChildren(await buildArtifactPreview(artifact, response));
-        preview.dataset.loaded = "true";
-      } catch (error) {
-        preview.textContent = `Unable to load ${path}: ${error.message}`;
-      }
-    });
-    wrap.appendChild(row);
-    wrap.appendChild(preview);
-  }
-  return wrap;
-}
-
-function buildTaskDetail(task) {
-  const detail = el("div", { class: "row-detail split-layout" });
-  detail.addEventListener("click", (e) => e.stopPropagation());
-
-  const leftCol = el("div", { class: "detail-main" });
-  const rightCol = el("div", { class: "detail-side" });
-
-  const addField = (parent, title, child, collapsible = false, collapsed = false) => {
-    let classes = "field-block";
-    if (collapsible) classes += " collapsible";
-    if (collapsed) classes += " collapsed";
-    const block = el("div", { class: classes });
-    const h4 = el("h4", { text: title });
-    if (collapsible) {
-      h4.addEventListener("click", (e) => {
-        e.stopPropagation();
-        block.classList.toggle("collapsed");
-      });
-    }
-    block.appendChild(h4);
-    block.appendChild(child);
-    parent.appendChild(block);
-  };
-
-  if (task.description && task.description.trim()) {
-    const view = el("div", { class: "markdown-body" });
-    if (typeof marked !== "undefined") {
-      view.innerHTML = marked.parse(task.description);
-    } else {
-      view.textContent = task.description;
-    }
-    addField(leftCol, "description", view);
-  }
-
-  if (Array.isArray(task.acceptance_criteria) && task.acceptance_criteria.length > 0) {
-    const ul = el("ul", { class: "ac-list" });
-    for (const ac of task.acceptance_criteria) {
-      if (typeof marked !== "undefined") {
-        const li = el("li");
-        li.innerHTML = marked.parseInline(ac);
-        ul.appendChild(li);
-      } else {
-        ul.appendChild(el("li", { text: ac }));
-      }
-    }
-    addField(leftCol, "acceptance criteria", ul, true, true);
-  }
-
-  if (task.plan && task.plan.trim()) {
-    const view = el("div", { class: "markdown-body" });
-    if (typeof marked !== "undefined") {
-      view.innerHTML = marked.parse(task.plan);
-    } else {
-      view.textContent = task.plan;
-    }
-    addField(leftCol, "plan", view, true, true);
-  }
-
-  if (task.execution_summary && task.execution_summary.trim()) {
-    const view = el("div", { class: "markdown-body" });
-    if (typeof marked !== "undefined") {
-      view.innerHTML = marked.parse(task.execution_summary);
-    } else {
-      view.textContent = task.execution_summary;
-    }
-    addField(leftCol, "execution summary", view, true, true);
-  }
-
-  if (Array.isArray(task.review_threads) && task.review_threads.length > 0) {
-    addField(leftCol, "review threads", buildReviewThreads(task.review_threads), true, true);
-  }
-
-  if (Array.isArray(task.artifacts) && task.artifacts.length > 0) {
-    addField(leftCol, "artifacts", buildArtifacts(task), true, true);
-  }
-
-  if (Array.isArray(task.tags) && task.tags.length > 0) {
-    rightCol.appendChild(buildTagRow(task.tags));
-  }
-
-  const meta = el("div", { class: "meta-list" });
-  let metaCount = 0;
-  for (const [key, label] of TASK_META_FIELDS) {
-    const v = task[key];
-    if (v == null || v === "") continue;
-    const display = key.endsWith("_at") ? fmtAbsTime(v) : String(v);
-    const value = el("span", { class: "value" });
-    if (key === "job_run_id") {
-      const link = el("a", { text: display });
-      link.href = `#runs?run_id=${encodeURIComponent(display)}`;
-      value.appendChild(link);
-    } else {
-      value.textContent = display;
-    }
-    const span = el("div", { class: "meta-item" }, [
-      el("span", { class: "label", text: `${label}` }),
-      value,
-    ]);
-    meta.appendChild(span);
-    metaCount++;
-  }
-  if (metaCount > 0) addField(rightCol, "details", meta);
-
-  if (Array.isArray(task.external_refs) && task.external_refs.length > 0) {
-    addField(rightCol, "external refs", buildExternalRefs(task.external_refs));
-  }
-
-  if (Array.isArray(task.relations) && task.relations.length > 0) {
-    const relations = buildRelations(task.relations);
-    if (relations.children.length > 0) addField(rightCol, "relations", relations);
-  }
-
-  if (Array.isArray(task.context_files) && task.context_files.length > 0) {
-    const ul = el("ul", { class: "file-list" });
-    for (const path of task.context_files) {
-      ul.appendChild(el("li", { text: path }));
-    }
-    addField(rightCol, "context files", ul);
-  }
-
-  if (Array.isArray(task.history) && task.history.length > 0) {
-    const wrap = el("div");
-    const recent = task.history.slice(-5).reverse();
-    for (const h of recent) {
-      const note = h.note ? ` (${h.note})` : "";
-      const line = el("div", { class: "history-line" }, [
-        document.createTextNode(`[${fmtAbsTime(h.at)}] `),
-        el("span", { class: "actor", text: h.by || "?" }),
-        document.createTextNode(`: ${h.event}${note}`),
-      ]);
-      wrap.appendChild(line);
-    }
-    addField(rightCol, "recent history", wrap);
-  }
-
-  if (Array.isArray(task.comments) && task.comments.length > 0) {
-    const wrap = el("div");
-    for (const c of task.comments) {
-      const line = el("div", { class: "comment-line" }, [
-        document.createTextNode(`[${fmtAbsTime(c.at)}] `),
-        el("span", { class: "author", text: c.by || "?" }),
-        document.createTextNode(`: ${c.message || ""}`),
-      ]);
-      wrap.appendChild(line);
-    }
-    addField(rightCol, "comments", wrap);
-  }
-
-  detail.appendChild(leftCol);
-  detail.appendChild(rightCol);
-  detail.appendChild(buildActionsRow(task, detail));
-
-  return detail;
-}
-
-const APPROVE_STATUSES = new Set(["proposed", "review"]);
-const REJECT_STATUSES = new Set(["proposed", "review", "backlog"]);
-
-function buildActionsRow(task, detail) {
-  const actions = el("div", { class: "actions" });
-  if (APPROVE_STATUSES.has(task.status)) {
-    const btn = el("button", { class: "action approve", text: "approve" });
-    btn.addEventListener("click", (e) => {
-      e.stopPropagation();
-      runAction(task, "approve", detail, null, btn);
-    });
-    actions.appendChild(btn);
-  }
-  if (REJECT_STATUSES.has(task.status)) {
-    const btn = el("button", { class: "action reject", text: "reject" });
-    btn.addEventListener("click", (e) => {
-      e.stopPropagation();
-      showRejectForm(task, detail, actions);
-    });
-    actions.appendChild(btn);
-  }
-  if (task.status !== "archived") {
-    const btn = el("button", { class: "action archive", text: "archive" });
-    btn.addEventListener("click", (e) => {
-      e.stopPropagation();
-      if (window.confirm(`Archive task ${task.id}?`)) {
-        runAction(task, "archive", detail, null, btn);
-      }
-    });
-    actions.appendChild(btn);
-  }
-  const statusSelect = buildStatusUpdateControl(task, detail);
-  if (statusSelect) actions.appendChild(statusSelect);
-  return actions;
-}
-
-function buildStatusUpdateControl(task, detail) {
-  const targets = STATUS_UPDATE_TARGETS.filter((status) => status !== task.status);
-  if (targets.length === 0) return null;
-
-  const select = el("select", {
-    class: "action status-update",
-    title: `Update status for ${task.id}`,
-  });
-  const placeholder = el("option", { text: "set status" });
-  placeholder.value = "";
-  placeholder.disabled = true;
-  placeholder.selected = true;
-  select.appendChild(placeholder);
-
-  for (const status of targets) {
-    const option = el("option", { text: status });
-    option.value = status;
-    select.appendChild(option);
-  }
-
-  select.addEventListener("click", (e) => e.stopPropagation());
-  select.addEventListener("change", (e) => {
-    e.stopPropagation();
-    const targetStatus = select.value;
-    if (!targetStatus) return;
-    runAction(
-      task,
-      "status",
-      detail,
-      { status: targetStatus },
-      select,
-      {
-        method: "PATCH",
-        path: `/api/tasks/${encodeURIComponent(task.id)}`,
-        collapseOnSuccess: targetStatus === "done",
-        successNotice: targetStatus === "done"
-          ? `Task ${task.id} marked done; it is no longer shown in the default dashboard list.`
-          : null,
-        onFailure: () => {
-          select.value = "";
-        },
-      },
-    );
-  });
-  return select;
-}
-
-function buildCrewUpdateControl(task) {
-  const cell = el("span", { class: "crew-cell" });
-  const select = el("select", {
-    class: "task-crew-select mono",
-    title: `Update crew for ${task.id}`,
-  });
-  const currentValue = explicitCrewValue(task);
-  select.dataset.currentValue = currentValue;
-
-  const defaultOption = el("option", {
-    text: `default: ${resolvedCrewName(task)}`,
-  });
-  defaultOption.value = "";
-  select.appendChild(defaultOption);
-
-  const crews = Array.isArray(lastCrewPayload.crews) ? lastCrewPayload.crews : [];
-  for (const crew of crews) {
-    const option = el("option", {
-      text: crew.name,
-      title: crewOptionTitle(crew),
-    });
-    option.value = crew.name;
-    select.appendChild(option);
-  }
-
-  if (currentValue && !crews.some((crew) => crew.name === currentValue)) {
-    const option = el("option", {
-      text: currentValue,
-      title: "Configured crew no longer found",
-    });
-    option.value = currentValue;
-    select.appendChild(option);
-  }
-
-  if (crews.length === 0) {
-    select.disabled = true;
-    defaultOption.textContent = "crew unavailable";
-  }
-
-  select.value = currentValue;
-  for (const eventName of ["pointerdown", "mousedown", "click", "keydown"]) {
-    select.addEventListener(eventName, (event) => event.stopPropagation());
-  }
-  select.addEventListener("change", (event) => {
-    event.stopPropagation();
-    updateTaskCrew(task, select);
-  });
-
-  cell.appendChild(select);
-  const error = crewUpdateErrors.get(task.id);
-  if (error) {
-    cell.appendChild(el("span", { class: "crew-error", text: error }));
-  }
-  return cell;
-}
-
-async function updateTaskCrew(task, select) {
-  const previousValue = select.dataset.currentValue || "";
-  const nextValue = select.value || "";
-  if (nextValue === previousValue) return;
-
-  crewUpdateErrors.delete(task.id);
-  select.disabled = true;
-  try {
-    const updatedTask = await patchJson(`/api/tasks/${encodeURIComponent(task.id)}`, {
-      crew: nextValue || null,
-    });
-    applyUpdatedTask(updatedTask);
-    crewUpdateErrors.delete(task.id);
-    renderTasks(lastTasks);
-  } catch (error) {
-    select.value = previousValue;
-    select.dataset.currentValue = previousValue;
-    select.disabled = false;
-    crewUpdateErrors.set(
-      task.id,
-      `crew update failed: ${error.message || String(error)}`,
-    );
-    renderTasks(lastTasks);
-    console.error(error);
-  }
-}
-
-function showRejectForm(task, detail, actions) {
-  const form = el("div", { class: "reject-form" });
-  form.addEventListener("click", (e) => e.stopPropagation());
-  const ta = el("textarea");
-  ta.placeholder = "reason for rejection";
-  const buttons = el("div", { class: "actions" });
-  const submit = el("button", { class: "action reject", text: "submit" });
-  const cancel = el("button", { class: "action cancel", text: "cancel" });
-  submit.addEventListener("click", (e) => {
-    e.stopPropagation();
-    const note = ta.value.trim();
-    if (!note) {
-      ta.focus();
-      return;
-    }
-    runAction(task, "reject", detail, { note }, submit);
-  });
-  cancel.addEventListener("click", (e) => {
-    e.stopPropagation();
-    form.replaceWith(actions);
-  });
-  buttons.appendChild(submit);
-  buttons.appendChild(cancel);
-  form.appendChild(ta);
-  form.appendChild(buttons);
-  actions.replaceWith(form);
-  ta.focus();
-}
-
-async function runAction(task, kind, detail, body, btnNode, opts = {}) {
-  // Disable action controls while in flight to prevent double-clicks.
-  for (const b of detail.querySelectorAll(".action")) b.disabled = true;
-  let oldText = "";
-  if (btnNode && btnNode.tagName === "BUTTON") {
-    oldText = btnNode.textContent;
-    btnNode.innerHTML = `<span class="spinner"></span>wait`;
-  }
-  // Clear any prior error
-  const prior = detail.querySelector(".action-error");
-  if (prior) prior.remove();
-  try {
-    const res = await fetch(opts.path || `/api/tasks/${encodeURIComponent(task.id)}/${kind}`, {
-      method: opts.method || "POST",
-      headers: body ? { "content-type": "application/json" } : undefined,
-      body: body ? JSON.stringify(body) : undefined,
-    });
-    if (!res.ok) {
-      let msg = `${kind} failed: HTTP ${res.status}`;
-      try {
-        const errBody = await res.json();
-        if (errBody && errBody.error) msg = `${kind} failed: ${errBody.error}`;
-      } catch (_) {
-        /* keep generic msg */
-      }
-      throw new Error(msg);
-    }
-    if (opts.collapseOnSuccess !== false) expandedTaskIds.delete(task.id);
-    if (opts.successNotice) taskActionNotice = opts.successNotice;
-    await refreshDashboard();
-  } catch (err) {
-    for (const b of detail.querySelectorAll(".action")) b.disabled = false;
-    if (btnNode && btnNode.tagName === "BUTTON") btnNode.textContent = oldText;
-    if (opts.onFailure) opts.onFailure();
-    const errEl = el("div", { class: "action-error", text: String(err.message || err) });
-    detail.prepend(errEl);
-  }
-}
-
-function takeTaskActionNotice() {
-  if (!taskActionNotice) return null;
-  const notice = el("div", { class: "task-action-notice", text: taskActionNotice });
-  notice.dataset.key = "task-action-notice";
-  notice.dataset.hash = taskActionNotice;
-  taskActionNotice = null;
-  return notice;
-}
-
-function renderTasks(tasks) {
-  const body = $("tasks-body");
-  const frag = document.createDocumentFragment();
-  const notice = takeTaskActionNotice();
-  
-  const filtered = filterTasks(tasks);
-  $("tasks-count").textContent =
-    filtered.length === tasks.length
-      ? `${tasks.length}`
-      : `${filtered.length}/${tasks.length}`;
-  if (filtered.length === 0) {
-    const defaultText = tasks.length === 0 ? "No tasks available." : "No tasks match filter.";
-    const emptyState = el("div", { class: "empty-state" }, [
-      el("div", { class: "icon", text: "✧" }),
-      el("div", { class: "text", text: defaultText })
-    ]);
-    syncNodes(body, notice ? [notice, emptyState] : [emptyState]);
-    return;
-  }
-  const groups = new Map();
-  if (notice) frag.appendChild(notice);
-  for (const t of filtered) {
-    if (!groups.has(t.status)) groups.set(t.status, []);
-    groups.get(t.status).push(t);
-  }
-  const ordered = STATUS_ORDER.filter((s) => groups.has(s)).concat(
-    [...groups.keys()].filter((s) => !STATUS_ORDER.includes(s)),
-  );
-  for (const status of ordered) {
-    const group = groups.get(status);
-    const header = el("div", { class: "group-header" }, [
-      statusPill(status),
-      el("span", { class: "group-count", text: `${group.length}` }),
-    ]);
-    header.dataset.key = `header-${status}`;
-    header.dataset.hash = `${status}-${group.length}`;
-    frag.appendChild(header);
-    for (const t of group) {
-      const idSpan = el("span", { class: "id mono", text: t.id, title: "Click to copy ID" });
-      idSpan.addEventListener("click", (e) => {
-        e.stopPropagation();
-        navigator.clipboard.writeText(t.id).catch(() => {});
-        const oldText = idSpan.textContent;
-        idSpan.textContent = "copied!";
-        idSpan.style.color = "var(--state-success)";
-        setTimeout(() => {
-          idSpan.textContent = oldText;
-          idSpan.style.color = "";
-        }, 1000);
-      });
-      const row = el("div", { class: "row", title: t.title }, [
-        idSpan,
-        el("span", { class: "title", text: t.title }),
-        priorityCell(t.priority),
-        el("span", { class: "type mono", text: t.type }),
-        buildCrewUpdateControl(t),
-      ]);
-      row.dataset.key = `task-${t.id}`;
-      // Basic hash based on row presentation parameters + expanded state
-      row.dataset.hash = `${t.id}-${t.title}-${t.priority}-${t.type}-${t.crew || ""}-${t.resolved_crew || ""}-${crewOptionsSignature()}-${crewUpdateErrors.get(t.id) || ""}-${expandedTaskIds.has(t.id)}`;
-      row.addEventListener("click", () => {
-        const toggle = () => {
-          if (expandedTaskIds.has(t.id)) expandedTaskIds.delete(t.id);
-          else expandedTaskIds.add(t.id);
-          renderTasks(lastTasks);
-        };
-        if (document.startViewTransition) {
-          row.style.viewTransitionName = `task-row-${t.id}`;
-          document.startViewTransition(toggle).finished.then(() => {
-            row.style.viewTransitionName = "";
-          });
-        } else {
-          toggle();
-        }
-      });
-      if (expandedTaskIds.has(t.id)) row.classList.add("expanded");
-      frag.appendChild(row);
-      if (expandedTaskIds.has(t.id)) {
-        const detail = buildTaskDetail(t);
-        detail.dataset.key = `detail-${t.id}`;
-        // Diff by full task object stringified
-        detail.dataset.hash = JSON.stringify(t);
-        frag.appendChild(detail);
-      }
-    }
-  }
-  syncNodes(body, Array.from(frag.children));
-}
-
 function renderLocksPanel(payload) {
   const body = $("locks-body");
   const count = $("locks-count");
@@ -1014,7 +248,7 @@ function renderLocksPanel(payload) {
     });
     idButton.addEventListener("click", (e) => {
       e.stopPropagation();
-      openVisibleTask(taskId);
+      openVisibleTask(taskId, taskContext());
     });
 
     const header = el("div", { class: "lock-task-header" }, [
@@ -2164,14 +1398,14 @@ function openTaskFromKnowledge(taskId) {
   const taskSearch = $("task-search");
   if (taskSearch) taskSearch.value = "";
   setActiveTab("tasks", { refresh: false });
-  const open = () => openVisibleTask(taskId);
-  if (lastTasks.length > 0 && lastCrewPayload.crews.length > 0) {
+  const open = () => openVisibleTask(taskId, taskContext());
+  if (lastTasks.length > 0 && hasCrewOptions()) {
     open();
     return;
   }
   fetchAndRenderTasks().then(() => {
     open();
-  }).catch(() => copyTaskIdWithNotice(taskId));
+  }).catch(() => copyTaskIdWithNotice(taskId, taskContext()));
 }
 
 function renderAdrDetail(adr) {
@@ -2289,52 +1523,6 @@ async function runAdrAction(adr, btn, detail, action, fallbackMessage) {
     btn.disabled = false;
     btn.textContent = oldText;
   }
-}
-
-function refreshChips() {
-  for (const chip of document.querySelectorAll("#task-filter .chip")) {
-    const status = chip.dataset.status;
-    const isAll = chip.dataset.role === "all";
-    const allOn = activeStatuses.size === STATUS_ORDER.length;
-    const on = isAll ? allOn : activeStatuses.has(status);
-    chip.classList.toggle("active", on);
-  }
-}
-
-function buildChips() {
-  const container = $("task-filter");
-  container.innerHTML = "";
-  const allChip = el("button", { class: "chip", text: "all" });
-  allChip.dataset.role = "all";
-  allChip.addEventListener("click", () => {
-    activeStatuses = new Set(STATUS_ORDER);
-    refreshChips();
-    renderTasks(lastTasks);
-  });
-  container.appendChild(allChip);
-  for (const status of STATUS_ORDER) {
-    const chip = el("button", { class: "chip", text: status });
-    chip.dataset.status = status;
-    chip.style.borderLeft = `2px solid var(--status-${status}, var(--border))`;
-    chip.addEventListener("click", () => {
-      if (activeStatuses.has(status)) {
-        activeStatuses.delete(status);
-      } else {
-        activeStatuses.add(status);
-      }
-      refreshChips();
-      renderTasks(lastTasks);
-    });
-    container.appendChild(chip);
-  }
-  refreshChips();
-}
-
-function wireSearch() {
-  $("task-search").addEventListener("input", (e) => {
-    searchQuery = e.target.value.trim().toLowerCase();
-    renderTasks(lastTasks);
-  });
 }
 
 function wireLearningSearch() {
@@ -2816,8 +2004,7 @@ function renderImplementOneCard(container, rows) {
 
 function fetchAndCacheCrews() {
   return fetchJson("/api/crews").then((payload) => {
-    lastCrewPayload = normalizeCrewPayload(payload);
-    return lastCrewPayload;
+    return cacheCrewPayload(payload);
   });
 }
 
@@ -2827,7 +2014,7 @@ function fetchAndRenderTasks() {
     fetchAndCacheCrews(),
   ]).then(([tasks]) => {
     lastTasks = tasks;
-    renderTasks(tasks);
+    renderTasks(tasks, taskContext());
   });
 }
 
@@ -4217,8 +3404,9 @@ async function refreshDashboard() {
   if (activeTab === "tasks") fitLogPanelToViewport();
 }
 
-buildChips();
-wireSearch();
+const tasksContext = taskContext();
+buildChips(tasksContext);
+wireSearch(tasksContext);
 wireLearningSearch();
 wireAdrSearch();
 wireFrictionSearch();

--- a/crates/orbit-dashboard/assets/dashboard/tasks.js
+++ b/crates/orbit-dashboard/assets/dashboard/tasks.js
@@ -1,0 +1,900 @@
+// Orbit dashboard task-domain rendering and actions.
+// Pure vanilla JS, split into ES modules with no build step.
+
+import { el, statusPill, priorityCell, patchJson, syncNodes } from './common.js';
+
+const $ = (id) => document.getElementById(id);
+
+let lastCrewPayload = { default_crew: null, crews: [] };
+let expandedTaskIds = new Set();
+let taskActionNotice = null;
+let crewUpdateErrors = new Map();
+
+function taskList(context) {
+  return context && typeof context.getTasks === "function" ? context.getTasks() : [];
+}
+
+function searchQueryValue(context) {
+  return context && typeof context.getSearchQuery === "function"
+    ? context.getSearchQuery()
+    : "";
+}
+
+function activeStatusSet(context) {
+  return context && typeof context.getActiveStatuses === "function"
+    ? context.getActiveStatuses()
+    : new Set();
+}
+
+function setSearchQuery(context, value) {
+  if (context && typeof context.setSearchQuery === "function") context.setSearchQuery(value);
+}
+
+function setActiveStatuses(context, statuses) {
+  if (context && typeof context.setActiveStatuses === "function") context.setActiveStatuses(statuses);
+}
+
+function statusOrder(context) {
+  return context && Array.isArray(context.statusOrder) ? context.statusOrder : [];
+}
+
+function statusUpdateTargets(context) {
+  return context && Array.isArray(context.statusUpdateTargets)
+    ? context.statusUpdateTargets
+    : [];
+}
+
+function fmtAbsTimeValue(context, value) {
+  return context && typeof context.fmtAbsTime === "function"
+    ? context.fmtAbsTime(value)
+    : (value || "-");
+}
+
+function refreshTasks(context) {
+  return context && typeof context.refreshDashboard === "function"
+    ? context.refreshDashboard()
+    : Promise.resolve();
+}
+
+export function normalizeCrewPayload(payload) {
+  const crews = Array.isArray(payload && payload.crews)
+    ? payload.crews
+      .filter((crew) => crew && crew.name)
+      .map((crew) => ({
+        name: String(crew.name),
+        planner_model: crew.planner_model == null ? "" : String(crew.planner_model),
+        implementer_model: crew.implementer_model == null ? "" : String(crew.implementer_model),
+        reviewer_model: crew.reviewer_model == null ? "" : String(crew.reviewer_model),
+        is_default: Boolean(crew.is_default),
+      }))
+    : [];
+  crews.sort((a, b) => a.name.localeCompare(b.name));
+  return {
+    default_crew: payload && payload.default_crew ? String(payload.default_crew) : null,
+    crews,
+  };
+}
+
+export function cacheCrewPayload(payload) {
+  lastCrewPayload = normalizeCrewPayload(payload);
+  return lastCrewPayload;
+}
+
+export function hasCrewOptions() {
+  return Array.isArray(lastCrewPayload.crews) && lastCrewPayload.crews.length > 0;
+}
+
+function crewOptionsSignature() {
+  return JSON.stringify(lastCrewPayload);
+}
+
+function explicitCrewValue(task) {
+  return task && task.crew ? String(task.crew) : "";
+}
+
+function resolvedCrewName(task) {
+  if (lastCrewPayload.default_crew) return lastCrewPayload.default_crew;
+  if (!explicitCrewValue(task) && task && task.resolved_crew) {
+    return String(task.resolved_crew);
+  }
+  return "workspace";
+}
+
+function crewOptionTitle(crew) {
+  const parts = [
+    `planner=${crew.planner_model || "-"}`,
+    `implementer=${crew.implementer_model || "-"}`,
+    `reviewer=${crew.reviewer_model || "-"}`,
+  ];
+  return parts.join(" · ");
+}
+
+function applyUpdatedTask(updatedTask, context) {
+  if (context && typeof context.replaceTask === "function") {
+    context.replaceTask(updatedTask);
+  }
+}
+
+function filterTasks(tasks, context) {
+  const q = searchQueryValue(context);
+  const activeStatuses = activeStatusSet(context);
+  return tasks.filter((t) => {
+    if (!activeStatuses.has(t.status)) return false;
+    if (!q) return true;
+    return (
+      (t.id && t.id.toLowerCase().includes(q)) ||
+      (t.title && t.title.toLowerCase().includes(q))
+    );
+  });
+}
+
+const TASK_META_FIELDS = [
+  ["implemented_by", "implemented_by"],
+  ["planned_by", "planned_by"],
+  ["created_by", "created_by"],
+  ["pr_number", "pr"],
+  ["pr_status", "pr_status"],
+  ["job_run_id", "job_run"],
+  ["created_at", "created"],
+  ["updated_at", "updated"],
+];
+
+const RELATION_GROUPS = [
+  ["blocked_by", "BlockedBy"],
+  ["child_of", "ChildOf"],
+  ["spawned_from", "SpawnedFrom"],
+  ["regression_from", "RegressionFrom"],
+  ["supersedes", "Supersedes"],
+  ["related_to", "RelatedTo"],
+];
+const RELATION_GROUP_LABELS = new Map(RELATION_GROUPS);
+
+function relationTypeKey(value) {
+  if (!value) return "";
+  return String(value)
+    .replace(/([a-z0-9])([A-Z])/g, "$1_$2")
+    .replace(/-/g, "_")
+    .toLowerCase();
+}
+
+export function copyTaskIdWithNotice(taskId, context) {
+  if (navigator.clipboard && navigator.clipboard.writeText) {
+    navigator.clipboard.writeText(taskId).catch(() => {});
+  }
+  taskActionNotice = `${taskId} is not in the filtered task list; copied ID`;
+  renderTasks(taskList(context), context);
+}
+
+function findTaskRow(taskId) {
+  return Array.from(document.querySelectorAll("#tasks-body .row"))
+    .find((row) => row.dataset.key === `task-${taskId}`) || null;
+}
+
+export function openVisibleTask(taskId, context) {
+  const visible = filterTasks(taskList(context), context).some((task) => task.id === taskId);
+  if (!visible) {
+    copyTaskIdWithNotice(taskId, context);
+    return;
+  }
+  expandedTaskIds.add(taskId);
+  renderTasks(taskList(context), context);
+  requestAnimationFrame(() => {
+    const row = findTaskRow(taskId);
+    if (!row) return;
+    row.scrollIntoView({ behavior: "smooth", block: "center" });
+    row.classList.add("data-changed");
+    setTimeout(() => row.classList.remove("data-changed"), 1200);
+  });
+}
+
+function refreshChips(context) {
+  for (const chip of document.querySelectorAll("#task-filter .chip")) {
+    const status = chip.dataset.status;
+    const isAll = chip.dataset.role === "all";
+    const activeStatuses = activeStatusSet(context);
+    const allOn = activeStatuses.size === statusOrder(context).length;
+    const on = isAll ? allOn : activeStatuses.has(status);
+    chip.classList.toggle("active", on);
+  }
+}
+
+export function buildChips(context) {
+  const container = $("task-filter");
+  container.innerHTML = "";
+  const allChip = el("button", { class: "chip", text: "all" });
+  allChip.dataset.role = "all";
+  allChip.addEventListener("click", () => {
+    setActiveStatuses(context, new Set(statusOrder(context)));
+    refreshChips(context);
+    renderTasks(taskList(context), context);
+  });
+  container.appendChild(allChip);
+  for (const status of statusOrder(context)) {
+    const chip = el("button", { class: "chip", text: status });
+    chip.dataset.status = status;
+    chip.style.borderLeft = `2px solid var(--status-${status}, var(--border))`;
+    chip.addEventListener("click", () => {
+      const activeStatuses = activeStatusSet(context);
+      if (activeStatuses.has(status)) {
+        activeStatuses.delete(status);
+      } else {
+        activeStatuses.add(status);
+      }
+      refreshChips(context);
+      renderTasks(taskList(context), context);
+    });
+    container.appendChild(chip);
+  }
+  refreshChips(context);
+}
+
+export function wireSearch(context) {
+  $("task-search").addEventListener("input", (e) => {
+    setSearchQuery(context, e.target.value.trim().toLowerCase());
+    renderTasks(taskList(context), context);
+  });
+}
+
+function buildTagRow(tags) {
+  const wrap = el("div", { class: "detail-tag-row" });
+  for (const tag of tags) {
+    wrap.appendChild(el("span", { class: "chip", text: tag }));
+  }
+  return wrap;
+}
+
+function buildExternalRefs(refs) {
+  const wrap = el("div");
+  for (const ref of refs) {
+    const label = `${ref.system || "external"}:${ref.id || ""}`;
+    const line = el("div", { class: "external-ref-line" });
+    if (ref.url) {
+      const link = el("a", { text: label });
+      link.href = ref.url;
+      line.appendChild(link);
+    } else {
+      line.textContent = label;
+    }
+    wrap.appendChild(line);
+  }
+  return wrap;
+}
+
+function buildRelations(relations, context) {
+  const byType = new Map(RELATION_GROUPS.map(([key]) => [key, []]));
+  for (const relation of relations) {
+    const key = relationTypeKey(relation.relation_type || relation.type);
+    const target = relation.target == null ? "" : String(relation.target);
+    if (!RELATION_GROUP_LABELS.has(key) || !target) continue;
+    byType.get(key).push(target);
+  }
+
+  const wrap = el("div");
+  for (const [key, label] of RELATION_GROUPS) {
+    const targets = byType.get(key);
+    if (!targets || targets.length === 0) continue;
+    const group = el("div", { class: "relation-group" }, [
+      el("span", { class: "label", text: label }),
+    ]);
+    for (const target of targets) {
+      const btn = el("button", { class: "relation-target mono", text: target });
+      btn.addEventListener("click", (e) => {
+        e.stopPropagation();
+        openVisibleTask(target, context);
+      });
+      group.appendChild(btn);
+    }
+    wrap.appendChild(group);
+  }
+  return wrap;
+}
+
+function reviewThreadStatus(thread) {
+  const status = String(thread.status || "open").toLowerCase();
+  return status === "resolved" ? "resolved" : "open";
+}
+
+function buildReviewThreads(threads, context) {
+  const wrap = el("div", { class: "review-threads" });
+  for (const thread of threads) {
+    const messages = Array.isArray(thread.messages) ? thread.messages : [];
+    const location = thread.path
+      ? `${thread.path}${thread.line == null ? "" : `:${thread.line}`}`
+      : "general";
+    const block = el("div", { class: "review-thread" });
+    block.appendChild(el("div", {
+      class: "review-thread-header",
+      text: `[${reviewThreadStatus(thread)}] ${location} · ${messages.length} messages`,
+    }));
+    for (const msg of messages) {
+      const line = el("div", { class: "comment-line" }, [
+        document.createTextNode(`[${fmtAbsTimeValue(context, msg.at)}] `),
+        el("span", { class: "author", text: msg.by || "?" }),
+        document.createTextNode(`: ${msg.body || ""}`),
+      ]);
+      block.appendChild(line);
+    }
+    wrap.appendChild(block);
+  }
+  return wrap;
+}
+
+function fmtSize(bytes) {
+  const value = Number(bytes);
+  if (!Number.isFinite(value) || value < 0) return "0 bytes";
+  if (value < 1024) return `${value} bytes`;
+  const kb = value / 1024;
+  if (kb < 1024) return `${kb.toFixed(kb < 10 ? 1 : 0)} KB`;
+  const mb = kb / 1024;
+  return `${mb.toFixed(mb < 10 ? 1 : 0)} MB`;
+}
+
+function artifactUrl(taskId, path) {
+  const encodedPath = String(path)
+    .split("/")
+    .map((part) => encodeURIComponent(part))
+    .join("/");
+  return `/api/tasks/${encodeURIComponent(taskId)}/artifacts/${encodedPath}`;
+}
+
+function artifactMediaType(artifact, response) {
+  return String(
+    response.headers.get("content-type") || artifact.media_type || "application/octet-stream",
+  ).split(";")[0].trim().toLowerCase();
+}
+
+function renderArtifactText(mediaType, text) {
+  if (mediaType === "text/markdown" && typeof marked !== "undefined") {
+    const view = el("div", { class: "markdown-body" });
+    view.innerHTML = marked.parse(text);
+    return view;
+  }
+  return el("pre", { text });
+}
+
+function buildArtifactPreview(artifact, response) {
+  const mediaType = artifactMediaType(artifact, response);
+  if (
+    mediaType === "text/markdown" ||
+    mediaType === "application/json" ||
+    mediaType.endsWith("/yaml") ||
+    mediaType.endsWith("+yaml") ||
+    mediaType.startsWith("text/")
+  ) {
+    return response.text().then((text) => renderArtifactText(mediaType, text));
+  }
+  return response.blob().then((blob) => {
+    const link = el("a", { text: `Download ${artifact.path}` });
+    link.href = URL.createObjectURL(blob);
+    link.download = String(artifact.path).split("/").pop() || artifact.path;
+    return link;
+  });
+}
+
+function buildArtifacts(task) {
+  const wrap = el("div", { class: "artifacts" });
+  for (const artifact of task.artifacts) {
+    const path = String(artifact.path || "");
+    const mediaType = String(artifact.media_type || "application/octet-stream");
+    const row = el("div", {
+      class: "artifact-row",
+      text: `${path} · ${mediaType} · ${fmtSize(artifact.size_bytes)}`,
+    });
+    const preview = el("div", { class: "artifact-preview" });
+    preview.hidden = true;
+    row.addEventListener("click", async (e) => {
+      e.stopPropagation();
+      if (preview.dataset.loaded === "true" && !preview.hidden) {
+        preview.hidden = true;
+        return;
+      }
+      if (preview.dataset.loaded === "true") {
+        preview.hidden = false;
+        return;
+      }
+      preview.hidden = false;
+      preview.textContent = "loading...";
+      try {
+        const response = await fetch(artifactUrl(task.id, path));
+        if (!response.ok) throw new Error(`HTTP ${response.status}`);
+        preview.replaceChildren(await buildArtifactPreview(artifact, response));
+        preview.dataset.loaded = "true";
+      } catch (error) {
+        preview.textContent = `Unable to load ${path}: ${error.message}`;
+      }
+    });
+    wrap.appendChild(row);
+    wrap.appendChild(preview);
+  }
+  return wrap;
+}
+
+function buildTaskDetail(task, context) {
+  const detail = el("div", { class: "row-detail split-layout" });
+  detail.addEventListener("click", (e) => e.stopPropagation());
+
+  const leftCol = el("div", { class: "detail-main" });
+  const rightCol = el("div", { class: "detail-side" });
+
+  const addField = (parent, title, child, collapsible = false, collapsed = false) => {
+    let classes = "field-block";
+    if (collapsible) classes += " collapsible";
+    if (collapsed) classes += " collapsed";
+    const block = el("div", { class: classes });
+    const h4 = el("h4", { text: title });
+    if (collapsible) {
+      h4.addEventListener("click", (e) => {
+        e.stopPropagation();
+        block.classList.toggle("collapsed");
+      });
+    }
+    block.appendChild(h4);
+    block.appendChild(child);
+    parent.appendChild(block);
+  };
+
+  if (task.description && task.description.trim()) {
+    const view = el("div", { class: "markdown-body" });
+    if (typeof marked !== "undefined") {
+      view.innerHTML = marked.parse(task.description);
+    } else {
+      view.textContent = task.description;
+    }
+    addField(leftCol, "description", view);
+  }
+
+  if (Array.isArray(task.acceptance_criteria) && task.acceptance_criteria.length > 0) {
+    const ul = el("ul", { class: "ac-list" });
+    for (const ac of task.acceptance_criteria) {
+      if (typeof marked !== "undefined") {
+        const li = el("li");
+        li.innerHTML = marked.parseInline(ac);
+        ul.appendChild(li);
+      } else {
+        ul.appendChild(el("li", { text: ac }));
+      }
+    }
+    addField(leftCol, "acceptance criteria", ul, true, true);
+  }
+
+  if (task.plan && task.plan.trim()) {
+    const view = el("div", { class: "markdown-body" });
+    if (typeof marked !== "undefined") {
+      view.innerHTML = marked.parse(task.plan);
+    } else {
+      view.textContent = task.plan;
+    }
+    addField(leftCol, "plan", view, true, true);
+  }
+
+  if (task.execution_summary && task.execution_summary.trim()) {
+    const view = el("div", { class: "markdown-body" });
+    if (typeof marked !== "undefined") {
+      view.innerHTML = marked.parse(task.execution_summary);
+    } else {
+      view.textContent = task.execution_summary;
+    }
+    addField(leftCol, "execution summary", view, true, true);
+  }
+
+  if (Array.isArray(task.review_threads) && task.review_threads.length > 0) {
+    addField(leftCol, "review threads", buildReviewThreads(task.review_threads, context), true, true);
+  }
+
+  if (Array.isArray(task.artifacts) && task.artifacts.length > 0) {
+    addField(leftCol, "artifacts", buildArtifacts(task), true, true);
+  }
+
+  if (Array.isArray(task.tags) && task.tags.length > 0) {
+    rightCol.appendChild(buildTagRow(task.tags));
+  }
+
+  const meta = el("div", { class: "meta-list" });
+  let metaCount = 0;
+  for (const [key, label] of TASK_META_FIELDS) {
+    const v = task[key];
+    if (v == null || v === "") continue;
+    const display = key.endsWith("_at") ? fmtAbsTimeValue(context, v) : String(v);
+    const value = el("span", { class: "value" });
+    if (key === "job_run_id") {
+      const link = el("a", { text: display });
+      link.href = `#runs?run_id=${encodeURIComponent(display)}`;
+      value.appendChild(link);
+    } else {
+      value.textContent = display;
+    }
+    const span = el("div", { class: "meta-item" }, [
+      el("span", { class: "label", text: `${label}` }),
+      value,
+    ]);
+    meta.appendChild(span);
+    metaCount++;
+  }
+  if (metaCount > 0) addField(rightCol, "details", meta);
+
+  if (Array.isArray(task.external_refs) && task.external_refs.length > 0) {
+    addField(rightCol, "external refs", buildExternalRefs(task.external_refs));
+  }
+
+  if (Array.isArray(task.relations) && task.relations.length > 0) {
+    const relations = buildRelations(task.relations, context);
+    if (relations.children.length > 0) addField(rightCol, "relations", relations);
+  }
+
+  if (Array.isArray(task.context_files) && task.context_files.length > 0) {
+    const ul = el("ul", { class: "file-list" });
+    for (const path of task.context_files) {
+      ul.appendChild(el("li", { text: path }));
+    }
+    addField(rightCol, "context files", ul);
+  }
+
+  if (Array.isArray(task.history) && task.history.length > 0) {
+    const wrap = el("div");
+    const recent = task.history.slice(-5).reverse();
+    for (const h of recent) {
+      const note = h.note ? ` (${h.note})` : "";
+      const line = el("div", { class: "history-line" }, [
+        document.createTextNode(`[${fmtAbsTimeValue(context, h.at)}] `),
+        el("span", { class: "actor", text: h.by || "?" }),
+        document.createTextNode(`: ${h.event}${note}`),
+      ]);
+      wrap.appendChild(line);
+    }
+    addField(rightCol, "recent history", wrap);
+  }
+
+  if (Array.isArray(task.comments) && task.comments.length > 0) {
+    const wrap = el("div");
+    for (const c of task.comments) {
+      const line = el("div", { class: "comment-line" }, [
+        document.createTextNode(`[${fmtAbsTimeValue(context, c.at)}] `),
+        el("span", { class: "author", text: c.by || "?" }),
+        document.createTextNode(`: ${c.message || ""}`),
+      ]);
+      wrap.appendChild(line);
+    }
+    addField(rightCol, "comments", wrap);
+  }
+
+  detail.appendChild(leftCol);
+  detail.appendChild(rightCol);
+  detail.appendChild(buildActionsRow(task, detail, context));
+
+  return detail;
+}
+
+const APPROVE_STATUSES = new Set(["proposed", "review"]);
+const REJECT_STATUSES = new Set(["proposed", "review", "backlog"]);
+
+function buildActionsRow(task, detail, context) {
+  const actions = el("div", { class: "actions" });
+  if (APPROVE_STATUSES.has(task.status)) {
+    const btn = el("button", { class: "action approve", text: "approve" });
+    btn.addEventListener("click", (e) => {
+      e.stopPropagation();
+      runAction(task, "approve", detail, null, btn, context);
+    });
+    actions.appendChild(btn);
+  }
+  if (REJECT_STATUSES.has(task.status)) {
+    const btn = el("button", { class: "action reject", text: "reject" });
+    btn.addEventListener("click", (e) => {
+      e.stopPropagation();
+      showRejectForm(task, detail, actions, context);
+    });
+    actions.appendChild(btn);
+  }
+  if (task.status !== "archived") {
+    const btn = el("button", { class: "action archive", text: "archive" });
+    btn.addEventListener("click", (e) => {
+      e.stopPropagation();
+      if (window.confirm(`Archive task ${task.id}?`)) {
+        runAction(task, "archive", detail, null, btn, context);
+      }
+    });
+    actions.appendChild(btn);
+  }
+  const statusSelect = buildStatusUpdateControl(task, detail, context);
+  if (statusSelect) actions.appendChild(statusSelect);
+  return actions;
+}
+
+function buildStatusUpdateControl(task, detail, context) {
+  const targets = statusUpdateTargets(context).filter((status) => status !== task.status);
+  if (targets.length === 0) return null;
+
+  const select = el("select", {
+    class: "action status-update",
+    title: `Update status for ${task.id}`,
+  });
+  const placeholder = el("option", { text: "set status" });
+  placeholder.value = "";
+  placeholder.disabled = true;
+  placeholder.selected = true;
+  select.appendChild(placeholder);
+
+  for (const status of targets) {
+    const option = el("option", { text: status });
+    option.value = status;
+    select.appendChild(option);
+  }
+
+  select.addEventListener("click", (e) => e.stopPropagation());
+  select.addEventListener("change", (e) => {
+    e.stopPropagation();
+    const targetStatus = select.value;
+    if (!targetStatus) return;
+    runAction(
+      task,
+      "status",
+      detail,
+      { status: targetStatus },
+      select,
+      context,
+      {
+        method: "PATCH",
+        path: `/api/tasks/${encodeURIComponent(task.id)}`,
+        collapseOnSuccess: targetStatus === "done",
+        successNotice: targetStatus === "done"
+          ? `Task ${task.id} marked done; it is no longer shown in the default dashboard list.`
+          : null,
+        onFailure: () => {
+          select.value = "";
+        },
+      },
+    );
+  });
+  return select;
+}
+
+function buildCrewUpdateControl(task, context) {
+  const cell = el("span", { class: "crew-cell" });
+  const select = el("select", {
+    class: "task-crew-select mono",
+    title: `Update crew for ${task.id}`,
+  });
+  const currentValue = explicitCrewValue(task);
+  select.dataset.currentValue = currentValue;
+
+  const defaultOption = el("option", {
+    text: `default: ${resolvedCrewName(task)}`,
+  });
+  defaultOption.value = "";
+  select.appendChild(defaultOption);
+
+  const crews = Array.isArray(lastCrewPayload.crews) ? lastCrewPayload.crews : [];
+  for (const crew of crews) {
+    const option = el("option", {
+      text: crew.name,
+      title: crewOptionTitle(crew),
+    });
+    option.value = crew.name;
+    select.appendChild(option);
+  }
+
+  if (currentValue && !crews.some((crew) => crew.name === currentValue)) {
+    const option = el("option", {
+      text: currentValue,
+      title: "Configured crew no longer found",
+    });
+    option.value = currentValue;
+    select.appendChild(option);
+  }
+
+  if (crews.length === 0) {
+    select.disabled = true;
+    defaultOption.textContent = "crew unavailable";
+  }
+
+  select.value = currentValue;
+  for (const eventName of ["pointerdown", "mousedown", "click", "keydown"]) {
+    select.addEventListener(eventName, (event) => event.stopPropagation());
+  }
+  select.addEventListener("change", (event) => {
+    event.stopPropagation();
+    updateTaskCrew(task, select, context);
+  });
+
+  cell.appendChild(select);
+  const error = crewUpdateErrors.get(task.id);
+  if (error) {
+    cell.appendChild(el("span", { class: "crew-error", text: error }));
+  }
+  return cell;
+}
+
+async function updateTaskCrew(task, select, context) {
+  const previousValue = select.dataset.currentValue || "";
+  const nextValue = select.value || "";
+  if (nextValue === previousValue) return;
+
+  crewUpdateErrors.delete(task.id);
+  select.disabled = true;
+  try {
+    const updatedTask = await patchJson(`/api/tasks/${encodeURIComponent(task.id)}`, {
+      crew: nextValue || null,
+    });
+    applyUpdatedTask(updatedTask, context);
+    crewUpdateErrors.delete(task.id);
+    renderTasks(taskList(context), context);
+  } catch (error) {
+    select.value = previousValue;
+    select.dataset.currentValue = previousValue;
+    select.disabled = false;
+    crewUpdateErrors.set(
+      task.id,
+      `crew update failed: ${error.message || String(error)}`,
+    );
+    renderTasks(taskList(context), context);
+    console.error(error);
+  }
+}
+
+function showRejectForm(task, detail, actions, context) {
+  const form = el("div", { class: "reject-form" });
+  form.addEventListener("click", (e) => e.stopPropagation());
+  const ta = el("textarea");
+  ta.placeholder = "reason for rejection";
+  const buttons = el("div", { class: "actions" });
+  const submit = el("button", { class: "action reject", text: "submit" });
+  const cancel = el("button", { class: "action cancel", text: "cancel" });
+  submit.addEventListener("click", (e) => {
+    e.stopPropagation();
+    const note = ta.value.trim();
+    if (!note) {
+      ta.focus();
+      return;
+    }
+    runAction(task, "reject", detail, { note }, submit, context);
+  });
+  cancel.addEventListener("click", (e) => {
+    e.stopPropagation();
+    form.replaceWith(actions);
+  });
+  buttons.appendChild(submit);
+  buttons.appendChild(cancel);
+  form.appendChild(ta);
+  form.appendChild(buttons);
+  actions.replaceWith(form);
+  ta.focus();
+}
+
+async function runAction(task, kind, detail, body, btnNode, context, opts = {}) {
+  // Disable action controls while in flight to prevent double-clicks.
+  for (const b of detail.querySelectorAll(".action")) b.disabled = true;
+  let oldText = "";
+  if (btnNode && btnNode.tagName === "BUTTON") {
+    oldText = btnNode.textContent;
+    btnNode.innerHTML = `<span class="spinner"></span>wait`;
+  }
+  // Clear any prior error
+  const prior = detail.querySelector(".action-error");
+  if (prior) prior.remove();
+  try {
+    const res = await fetch(opts.path || `/api/tasks/${encodeURIComponent(task.id)}/${kind}`, {
+      method: opts.method || "POST",
+      headers: body ? { "content-type": "application/json" } : undefined,
+      body: body ? JSON.stringify(body) : undefined,
+    });
+    if (!res.ok) {
+      let msg = `${kind} failed: HTTP ${res.status}`;
+      try {
+        const errBody = await res.json();
+        if (errBody && errBody.error) msg = `${kind} failed: ${errBody.error}`;
+      } catch (_) {
+        /* keep generic msg */
+      }
+      throw new Error(msg);
+    }
+    if (opts.collapseOnSuccess !== false) expandedTaskIds.delete(task.id);
+    if (opts.successNotice) taskActionNotice = opts.successNotice;
+    await refreshTasks(context);
+  } catch (err) {
+    for (const b of detail.querySelectorAll(".action")) b.disabled = false;
+    if (btnNode && btnNode.tagName === "BUTTON") btnNode.textContent = oldText;
+    if (opts.onFailure) opts.onFailure();
+    const errEl = el("div", { class: "action-error", text: String(err.message || err) });
+    detail.prepend(errEl);
+  }
+}
+
+function takeTaskActionNotice() {
+  if (!taskActionNotice) return null;
+  const notice = el("div", { class: "task-action-notice", text: taskActionNotice });
+  notice.dataset.key = "task-action-notice";
+  notice.dataset.hash = taskActionNotice;
+  taskActionNotice = null;
+  return notice;
+}
+
+export function renderTasks(tasks, context) {
+  const body = $("tasks-body");
+  const frag = document.createDocumentFragment();
+  const notice = takeTaskActionNotice();
+  
+  const filtered = filterTasks(tasks, context);
+  $("tasks-count").textContent =
+    filtered.length === tasks.length
+      ? `${tasks.length}`
+      : `${filtered.length}/${tasks.length}`;
+  if (filtered.length === 0) {
+    const defaultText = tasks.length === 0 ? "No tasks available." : "No tasks match filter.";
+    const emptyState = el("div", { class: "empty-state" }, [
+      el("div", { class: "icon", text: "✧" }),
+      el("div", { class: "text", text: defaultText })
+    ]);
+    syncNodes(body, notice ? [notice, emptyState] : [emptyState]);
+    return;
+  }
+  const groups = new Map();
+  if (notice) frag.appendChild(notice);
+  for (const t of filtered) {
+    if (!groups.has(t.status)) groups.set(t.status, []);
+    groups.get(t.status).push(t);
+  }
+  const order = statusOrder(context);
+  const ordered = order.filter((s) => groups.has(s)).concat(
+    [...groups.keys()].filter((s) => !order.includes(s)),
+  );
+  for (const status of ordered) {
+    const group = groups.get(status);
+    const header = el("div", { class: "group-header" }, [
+      statusPill(status),
+      el("span", { class: "group-count", text: `${group.length}` }),
+    ]);
+    header.dataset.key = `header-${status}`;
+    header.dataset.hash = `${status}-${group.length}`;
+    frag.appendChild(header);
+    for (const t of group) {
+      const idSpan = el("span", { class: "id mono", text: t.id, title: "Click to copy ID" });
+      idSpan.addEventListener("click", (e) => {
+        e.stopPropagation();
+        navigator.clipboard.writeText(t.id).catch(() => {});
+        const oldText = idSpan.textContent;
+        idSpan.textContent = "copied!";
+        idSpan.style.color = "var(--state-success)";
+        setTimeout(() => {
+          idSpan.textContent = oldText;
+          idSpan.style.color = "";
+        }, 1000);
+      });
+      const row = el("div", { class: "row", title: t.title }, [
+        idSpan,
+        el("span", { class: "title", text: t.title }),
+        priorityCell(t.priority),
+        el("span", { class: "type mono", text: t.type }),
+        buildCrewUpdateControl(t, context),
+      ]);
+      row.dataset.key = `task-${t.id}`;
+      // Basic hash based on row presentation parameters + expanded state
+      row.dataset.hash = `${t.id}-${t.title}-${t.priority}-${t.type}-${t.crew || ""}-${t.resolved_crew || ""}-${crewOptionsSignature()}-${crewUpdateErrors.get(t.id) || ""}-${expandedTaskIds.has(t.id)}`;
+      row.addEventListener("click", () => {
+        const toggle = () => {
+          if (expandedTaskIds.has(t.id)) expandedTaskIds.delete(t.id);
+          else expandedTaskIds.add(t.id);
+          renderTasks(taskList(context), context);
+        };
+        if (document.startViewTransition) {
+          row.style.viewTransitionName = `task-row-${t.id}`;
+          document.startViewTransition(toggle).finished.then(() => {
+            row.style.viewTransitionName = "";
+          });
+        } else {
+          toggle();
+        }
+      });
+      if (expandedTaskIds.has(t.id)) row.classList.add("expanded");
+      frag.appendChild(row);
+      if (expandedTaskIds.has(t.id)) {
+        const detail = buildTaskDetail(t, context);
+        detail.dataset.key = `detail-${t.id}`;
+        // Diff by full task object stringified
+        detail.dataset.hash = JSON.stringify(t);
+        frag.appendChild(detail);
+      }
+    }
+  }
+  syncNodes(body, Array.from(frag.children));
+}
+

--- a/crates/orbit-dashboard/src/lib.rs
+++ b/crates/orbit-dashboard/src/lib.rs
@@ -27,6 +27,7 @@ use orbit_core::{OrbitError, OrbitRuntime};
 const INDEX_HTML: &str = include_str!("../assets/dashboard/index.html");
 const APP_JS: &str = include_str!("../assets/dashboard/app.js");
 const COMMON_JS: &str = include_str!("../assets/dashboard/common.js");
+const TASKS_JS: &str = include_str!("../assets/dashboard/tasks.js");
 
 /// Arguments for `orbit web serve` (and the library entry point).
 #[derive(Args, Clone)]
@@ -60,6 +61,7 @@ pub fn serve(runtime: &OrbitRuntime, args: ServeArgs) -> Result<(), OrbitError> 
         .route("/", get(serve_index))
         .route("/static/app.js", get(serve_app_js))
         .route("/static/common.js", get(serve_common_js))
+        .route("/static/tasks.js", get(serve_tasks_js))
         .route("/healthz", get(healthz))
         .nest("/api", api::router())
         .with_state(runtime);
@@ -121,6 +123,17 @@ async fn serve_common_js() -> Response {
             HeaderValue::from_static("application/javascript; charset=utf-8"),
         )],
         COMMON_JS,
+    )
+        .into_response()
+}
+
+async fn serve_tasks_js() -> Response {
+    (
+        [(
+            header::CONTENT_TYPE,
+            HeaderValue::from_static("application/javascript; charset=utf-8"),
+        )],
+        TASKS_JS,
     )
         .into_response()
 }


### PR DESCRIPTION
## Task

[ORB-00149](https://orbit-cli.com/tasks/ORB-00149) — Dashboard JS split: extract tasks.js (per-domain split, round 1)

### Description

## Problem

After ORB-00145 (common.js helper extraction) and ORB-00146 (orbit-dashboard crate), the dashboard JS is one 4434-line `app.js` plus a small `common.js`. The next step on the agreed decomposition plan is the first per-domain extraction. Tasks is by far the largest single domain (~890 lines, [`crates/orbit-dashboard/assets/dashboard/app.js`](crates/orbit-dashboard/assets/dashboard/app.js) lines ~100–993). Splitting it out cuts the entry file by 20% and proves the per-domain pattern at scale before doing the smaller domains (runs, audit, diagnostics, learnings, adrs, friction, scoreboard, locks) as near-mechanical follow-ups.

## Why It Matters

- `app.js` is still the discoverability bottleneck for anyone editing the dashboard.
- Tasks is the right first domain because it's the biggest (highest ROI for one PR) and the one with the most state coupling (validates that shared-state handoff actually works before we propagate the pattern to 7+ other modules).
- The mechanical follow-ups become trivially reviewable once the state-passing pattern is settled.

## Scope

Extract task-domain code into `crates/orbit-dashboard/assets/dashboard/tasks.js`, leaving `app.js` as the entry module. Symbols to move (grouped):

- **Crew helpers:** `normalizeCrewPayload`, `crewOptionsSignature`, `explicitCrewValue`, `resolvedCrewName`, `crewOptionTitle`, `updateTaskCrew`
- **Task state operations:** `applyUpdatedTask`, `filterTasks`, `copyTaskIdWithNotice`, `findTaskRow`, `openVisibleTask`, `takeTaskActionNotice`, `relationTypeKey`
- **Constants:** `TASK_META_FIELDS`, `RELATION_GROUPS`, `RELATION_GROUP_LABELS`, `APPROVE_STATUSES`, `REJECT_STATUSES`
- **Builders:** `buildTagRow`, `buildExternalRefs`, `buildRelations`, `buildReviewThreads`, `reviewThreadStatus`, `buildArtifacts`, `buildTaskDetail`, `buildActionsRow`, `buildStatusUpdateControl`, `buildCrewUpdateControl`, `showRejectForm`, `runAction`
- **Artifact helpers (currently task-only):** `fmtSize`, `artifactUrl`, `artifactMediaType`, `renderArtifactText`, `buildArtifactPreview`
- **Top-level entry:** `renderTasks`

State variables and how to handle them — this is the central design decision for this PR:

- **Task-only state** (`lastCrewPayload`, `crewUpdateErrors`, `expandedTaskIds`, `taskActionNotice`) moves into `tasks.js` as module-local `let` bindings, with named exports for reads/writes other modules genuinely need.
- **Cross-module state** (`lastTasks`, `searchQuery`, `activeStatuses`, `activeTab`) stays in `app.js`. Functions exported from `tasks.js` accept what they need as arguments, OR `app.js` exposes getter/setter accessors imported by `tasks.js`. Implementer picks one approach and applies it consistently.
- `renderBodyBlock` is used by other domains (learnings, adrs) and stays in `app.js` until those domains extract.

## Constraints / Notes

- **No behavior change.** Every tab still renders, every action still works, every keyboard shortcut still fires. ES-module conversion is a packaging change only.
- **Same loading mechanism as ORB-00145.** `app.js` remains the entry module (`<script type="module" src="/static/app.js">` in `index.html`). `tasks.js` is a sibling module that `app.js` imports from. Both files served via `include_str!` + their own route in `crates/orbit-dashboard/src/lib.rs`, mirroring the existing `serve_common_js` handler.
- **Imports in `tasks.js`:** it imports the helpers it needs from `./common.js` directly (e.g. `el`, `fetchJson`, `postJson`, `patchJson`, `syncNodes`, `statusPill`). It does not re-import via `app.js`.
- **No bundler, no npm dep, no build step** — consistent with the established pattern.
- **Asset duplication cleanup is OUT of scope.** The orphaned copies at `crates/orbit-cli/assets/dashboard/{app.js, common.js, index.html}` (left behind by ORB-00146) are a separate follow-up; do not delete them in this PR. Touch only `crates/orbit-dashboard/assets/dashboard/` and `crates/orbit-dashboard/src/lib.rs`.

## Out of Scope

- Extracting any other domain module (runs.js, audit.js, diagnostics.js, learnings.js, adrs.js, friction.js, scoreboard.js, locks.js). Those are explicit future tasks.
- Renaming `app.js` to `main.js` — it stays `app.js`.
- Cleaning up the orphaned `crates/orbit-cli/assets/dashboard/` copies from ORB-00146.
- Type annotations, build pipelines, source maps, or any new browser-side dependencies.
- Behavior changes to anything Tasks-related (no UX tweaks, no new fields, no rendering polish).

### Acceptance Criteria

- File `crates/orbit-dashboard/assets/dashboard/tasks.js` exists and is loaded as an ES module. Verified by (a) the file existing, (b) `grep -nE '^import .* from .\./common\.js.' crates/orbit-dashboard/assets/dashboard/tasks.js` returning at least one match, (c) `crates/orbit-dashboard/assets/dashboard/app.js` containing `import` statement(s) referencing `./tasks.js`.
- `crates/orbit-dashboard/assets/dashboard/app.js` no longer defines any of these functions or constants (their definitions are removed, not duplicated): `normalizeCrewPayload`, `crewOptionsSignature`, `explicitCrewValue`, `resolvedCrewName`, `crewOptionTitle`, `updateTaskCrew`, `applyUpdatedTask`, `filterTasks`, `copyTaskIdWithNotice`, `findTaskRow`, `openVisibleTask`, `takeTaskActionNotice`, `relationTypeKey`, `reviewThreadStatus`, `buildTagRow`, `buildExternalRefs`, `buildRelations`, `buildReviewThreads`, `buildArtifacts`, `buildTaskDetail`, `buildActionsRow`, `buildStatusUpdateControl`, `buildCrewUpdateControl`, `showRejectForm`, `runAction`, `fmtSize`, `artifactUrl`, `artifactMediaType`, `renderArtifactText`, `buildArtifactPreview`, `renderTasks`, `TASK_META_FIELDS`, `RELATION_GROUPS`, `RELATION_GROUP_LABELS`, `APPROVE_STATUSES`, `REJECT_STATUSES`. Verified by `grep -nE '^(function|async function|const) (normalizeCrewPayload|crewOptionsSignature|filterTasks|buildTaskDetail|buildActionsRow|renderTasks|TASK_META_FIELDS|RELATION_GROUPS|APPROVE_STATUSES|REJECT_STATUSES)\b' crates/orbit-dashboard/assets/dashboard/app.js` returning zero matches.
- `crates/orbit-dashboard/assets/dashboard/app.js` line count drops by at least 800 lines compared to its current 4434. Verified by `wc -l crates/orbit-dashboard/assets/dashboard/app.js` returning ≤ 3634.
- `crates/orbit-dashboard/src/lib.rs` declares `const TASKS_JS: &str = include_str!("../assets/dashboard/tasks.js");` (mirroring `APP_JS`/`COMMON_JS`), registers a `/static/tasks.js` route via `get(serve_tasks_js)`, and the new `serve_tasks_js` handler returns `Content-Type: application/javascript; charset=utf-8`. Verified by `grep -nE 'TASKS_JS|serve_tasks_js|static/tasks\.js' crates/orbit-dashboard/src/lib.rs` returning at least three matches across the const, route, and handler.
- Behavior parity smoke: with `cargo run --release -p orbit-cli -- web serve --no-open --port 7879` running, all three asset endpoints return HTTP 200 with `application/javascript; charset=utf-8`: `curl -sI http://127.0.0.1:7879/static/app.js`, `curl -sI http://127.0.0.1:7879/static/common.js`, `curl -sI http://127.0.0.1:7879/static/tasks.js`. Captured outputs included in execution summary.
- Browser smoke: loading `http://127.0.0.1:7879/` in a Chromium-based browser produces zero `Uncaught ReferenceError`, `Failed to resolve module specifier`, or other module-loading errors in the DevTools console on initial load. The Tasks tab renders the existing task list, expanding a task shows its detail (description, plan, execution summary, relations, review threads, artifacts), and at least one task action (approve, reject, or status-update) is exercised and succeeds end-to-end. Console screenshot or copied console output attached to the task as an artifact via `orbit.task.artifact.put`.
- `make ci` passes on the resulting tree. Captured output included in execution summary.
- The orphan asset cleanup is explicitly NOT done by this PR. Verified by `ls crates/orbit-cli/assets/dashboard/ 2>/dev/null` still listing the three orphaned files (`app.js`, `common.js`, `index.html`) on the PR branch — those are a separate follow-up.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success with upstream validation caveat

Changes:
- Added `crates/orbit-dashboard/assets/dashboard/tasks.js` as the task-domain ES module. It owns task-local state (`lastCrewPayload`, crew errors, expanded task IDs, task notices), imports shared helpers directly from `./common.js`, and exports the task entry points used by `app.js`.
- Reworked `app.js` into the entry module for task rendering: cross-module task state remains there and is passed to `tasks.js` through a small context object; task filter chips/search moved with the task domain as part of the same state boundary.
- Added `TASKS_JS`, `/static/tasks.js`, and `serve_tasks_js` in `crates/orbit-dashboard/src/lib.rs` using the existing dashboard asset-serving pattern.

Validation:
- `node --check` passed for `app.js`, `tasks.js`, and `common.js`.
- Extraction greps passed: `tasks.js` imports from `./common.js`; `app.js` imports `./tasks.js`; the removed task definitions grep returned zero matches; `wc -l crates/orbit-dashboard/assets/dashboard/app.js` returned `3622`.
- Rust asset grep passed with `TASKS_JS` at line 30, `/static/tasks.js` at line 64, and `serve_tasks_js` at line 130.
- `cargo check -p orbit-dashboard` passed.
- `cargo run --release -p orbit-cli -- web serve --no-open --port 7879` served the dashboard; header smoke returned HTTP 200 and `application/javascript; charset=utf-8` for `/static/app.js`, `/static/common.js`, and `/static/tasks.js`.
- Browser smoke passed in headless Chrome: Tasks rendered, a task detail showed description/plan/execution summary/relations/review threads/artifacts, artifact preview loaded, a reject action succeeded end-to-end, and console/module error arrays were empty. Attached artifacts: `orbit-dashboard-console.txt` and `orbit-dashboard-smoke.png`. The temporary smoke task `ORB-00152` was deleted after validation.
- `make ci-fast` passed.
- `make ci` was run twice and failed in existing `orbit-cli` tests unrelated to this dashboard split. First run also exposed inherited `ORBIT_AGENT_MODEL=gpt-5.5`; after unsetting Orbit agent env vars, the remaining failures were `command::environment::workspace::*` tests rooted at `workspace_init_design_flag_seeds_conventions` expecting `**Owner:** human` in generated design conventions, followed by ENV_LOCK poisoning. This is outside the touched dashboard files.
- Orphan asset check passed: `ls crates/orbit-cli/assets/dashboard/` still lists `app.js`, `common.js`, and `index.html`.

Assessment: The dashboard split is implemented and smoke-tested; the only unmet validation is the pre-existing full-suite failure outside this task's scope.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-00149-6a0aa1b6`
- Behind base: 0
- Ahead of base: 1