### PR TITLE
Teach orbit-review-task to file friction when reviews reveal systemic prompt insufficiency

### DIFF
--- a/crates/orbit-core/assets/skills/orbit-review-task/SKILL.md
+++ b/crates/orbit-core/assets/skills/orbit-review-task/SKILL.md
@@ -82,6 +82,34 @@ Tag severity in the headline so the implementer can triage: `Spec compliance`, `
 
 End by reporting in chat: how many threads filed, which are blockers, overall verdict (approve / request changes). Do not add a `comment` to the task — review threads are the persistent surface; the chat summary is for the human running the review.
 
+### 5. Meta-review (systemic prompt insufficiency)
+
+After filing review threads, the reviewer checks whether the threads reveal a gap in an Orbit-authored agent instruction file (activity YAMLs under `crates/orbit-core/assets/activities/` such as `agent_implement.yaml` or `agent_review.yaml`, or skill `SKILL.md` files).
+
+**Trigger heuristic:** two or more review threads in this session map to the same gap in an instruction asset, OR a single thread the reviewer recognizes as recurring / a class of issue that will recur on the next implementer task without a prompt change.
+
+When the heuristic fires, file one friction via `orbit.friction.add` (MCP form: `orbit_friction_add`):
+
+```bash
+orbit tool run orbit.friction.add --input '{
+  "body": "crates/orbit-core/assets/activities/agent_implement.yaml step 5 says \"implement only the task's scoped work\" but does not define scope-drift or require surfacing it as a comment when the implementer deletes unrelated code. Threads 1, 3, 7 were instances of this gap. Suggested language: \"If you delete or modify code outside the task's listed context files, surface the drift as a comment before continuing.\"",
+  "tags": ["skill-guidance"],
+  "during_task": "<task-under-review>",
+  "model": "<reviewer-family>"
+}'
+```
+
+Filing a friction is **additive** to filing individual review threads — it is not a replacement and the reviewer must still file threads on the actual code issues. The threads document what the implementer must fix; the friction is the meta-signal so a later task can strengthen the instruction asset.
+
+**Negative cases — do not file a friction for:**
+- A single nit
+- A stylistic preference
+- A one-off coding mistake with no link to instruction text
+
+The bar (aligned with `orbit-track-issues` "report genuine friction only") is that the reviewer believes the class of issue would recur without an instruction change.
+
+This step runs after Summarize and is the final action before exiting the review session.
+
 ## Rules
 
 - **Never** transition the reviewed task's status (no `orbit.task.update --status …`). The implementer or human owns lifecycle.
@@ -94,7 +122,7 @@ End by reporting in chat: how many threads filed, which are blockers, overall ve
 ## When NOT to use this skill
 
 - Implementing a task (use `orbit-execute-task`).
-- Filing a friction report on Orbit tooling itself (use `orbit-track-issues`).
+- Filing a friction report on Orbit tooling itself (use `orbit-track-issues`). Filing a friction when review threads in aggregate reveal a systemic prompt insufficiency in an Orbit-authored agent instruction asset **is** in scope for the reviewer's session — the prior boundary is refined, not removed.
 - Approving a task in `review` status (that's a lifecycle transition the reviewee or human performs via `orbit.task.approve`).
 
 ## Exit Criteria

--- a/crates/orbit-core/assets/skills/orbit-track-issues/SKILL.md
+++ b/crates/orbit-core/assets/skills/orbit-track-issues/SKILL.md
@@ -21,6 +21,7 @@ Examples of issues worth tracking:
 - unclear error messages
 - unexpected runtime behavior
 - confusing seed instructions
+- insufficient or vague prompts in activity assets (e.g., `agent_implement.yaml`, `agent_review.yaml`) or skill `SKILL.md` files
 
 If Orbit tooling or Orbit-authored guidance slows the agent down, it should be tracked.
 


### PR DESCRIPTION
## Task

[ORB-00150](https://orbit-cli.com/tasks/ORB-00150) — Teach orbit-review-task to file friction when reviews reveal systemic prompt insufficiency

### Description

## Problem

The `orbit-review-task` skill at [crates/orbit-core/assets/skills/orbit-review-task/SKILL.md](crates/orbit-core/assets/skills/orbit-review-task/SKILL.md) teaches reviewers to file one review thread per distinct issue, tagged `Spec compliance` / `Code quality` / `Nit`. That works for surfacing individual findings, but there's no loop for the systemic case: when several review threads in one review (or a recurring pattern across reviews) point at the same gap in an Orbit-authored agent instruction file (e.g., `agent_implement.yaml`), the reviewer files N threads and moves on. The systemic-prompt-insufficiency signal stays implicit and the same review threads get written on the next task.

Concrete example, just observed:

ORB-00146 (Grok-as-implementer, Claude-as-reviewer) produced six review threads. Four were not nits and all mapped back to discipline that should have lived in the implementer prompt at [crates/orbit-core/assets/activities/agent_implement.yaml](crates/orbit-core/assets/activities/agent_implement.yaml):

- Scope drift (deleted an unrelated learning) → step 5 of `agent_implement.yaml` says "implement only the task's scoped work" but doesn't define scope-drift or require surfacing it as a comment
- 1,062 LOC of helper duplication → no threshold rule in the prompt
- `#[allow(dead_code)]` to defer cleanup → no policy in the prompt
- Direct-pinned `futures-core` instead of `workspace = true` → no workspace-convention reminder in the prompt

The pattern was only recognized when a human (out-of-band, in conversation) noticed the four threads were structurally related. That recognition is what produced ORB-00148 to strengthen the implementer prompt. Without that conversation, the threads would have been resolved on this PR and the same issues would recur on the next implementer task.

We want this meta-feedback loop to be a reproducible reviewer behavior, not a one-off human observation.

## Why It Matters

- Class-of-issue signal is more valuable than per-issue signal. One friction record naming a prompt gap is the input that strengthens the prompt for every future implementer; N review threads on one PR fix one PR.
- Without this loop, every agent making the same mistake gets reviewed individually, the same prose gets written N times, and the prompt stays unchanged.
- This is exactly the kind of recurring-pain-point artifact `orbit.friction.add` exists for. The skill at [crates/orbit-core/assets/skills/orbit-track-issues/SKILL.md](crates/orbit-core/assets/skills/orbit-track-issues/SKILL.md) already accepts the `skill-guidance` tag ("misleading or incorrect skill instructions") — activity instruction insufficiency is the same shape on a different surface.

## Proposed shape

Add a "meta-review" step to `orbit-review-task` between or after the current Workflow steps:

1. **Trigger heuristic.** After filing review threads, the reviewer asks: do two or more of these threads (or this single thread plus a known prior instance) map to a gap in an Orbit-authored agent instruction file? Common targets are activity asset YAMLs under `crates/orbit-core/assets/activities/` (e.g., `agent_implement.yaml`, `agent_review.yaml`) and skill `SKILL.md` files under `crates/orbit-core/assets/skills/`.
2. **Action.** File one friction record via `orbit.friction.add` naming:
   - the asset path (e.g., `crates/orbit-core/assets/activities/agent_implement.yaml`)
   - the specific step or section that is too vague or missing
   - the language the reviewer believes would prevent the class of issue (one or two sentences)
   - the review threads (by `thread_id`) that motivated the observation
   - `during_task: <task-under-review>` and `model: <reviewer family>`
   - tag `skill-guidance` (broad reading: Orbit-authored agent instruction). If a planner concludes a new tag like `activity-prompt` is warranted, it can be added to `orbit-track-issues` in the same PR.
3. **Boundary.** Filing the friction is **additive** to filing individual review threads — it never replaces them. The threads still document the actual code issues for the implementer to address; the friction is the meta-signal so the prompt itself can be strengthened in a follow-up task that the friction `resolves`.
4. **Negative cases.** Do not file a friction for a single nit, a stylistic preference, or a one-off coding mistake unrelated to instruction text. Per `orbit-track-issues`: "report genuine friction only" — the bar is the reviewer believing the issue would recur on the next implementer task without an instruction change.

Also: extend `orbit-track-issues` minimally (one sentence in the "Examples of issues worth tracking" list) to make the activity-asset path explicit, so reviewers reading either skill in isolation see the route.

This closes the same loop the human conversation just did: review → recognize class → file friction → friction spawns a prompt-strengthening task → next implementer benefits.

## Constraints / Notes

- This is a skill-content change. No Rust edits expected.
- The skill currently has 4 numbered workflow steps + a "When NOT to use" section. Insert the meta-review as step 5 (after "Summarize") so it does not interrupt the existing review-thread workflow, but is the last thing the reviewer does before exiting.
- The skill must still explicitly forbid resolving review threads the reviewer authored (existing rule). Filing a friction is a separate write surface.
- Do not require the reviewer to also file the prompt-revision task. That's a separate downstream concern — the friction is the input that motivates a future task; whoever picks up the friction (or sees it via `orbit.friction.list`) decides whether/how to file the revision task.
- `orbit-track-issues` description must continue to say "MUST use this skill" so the friction is not silently skipped.
- No agent-family-specific language in the new content (no "Gemini", "Grok", etc.). The loop applies regardless of which family is reviewing or being reviewed.

### Acceptance Criteria

- `crates/orbit-core/assets/skills/orbit-review-task/SKILL.md` contains a new workflow step (positioned after the existing "Summarize" step) named meta-review or equivalent, describing the trigger heuristic for filing a friction when review threads reveal systemic prompt insufficiency. Verified by `grep -E 'meta-review|systemic prompt|systemic instruction'` returning a match.
- The new step names a concrete trigger heuristic: two or more review threads in this session mapping to the same gap in an Orbit-authored agent instruction file (activity YAML or skill SKILL.md), OR a single thread the reviewer recognizes as recurring. Verified by `grep -E 'two or more|recurring|class of issue'` matching in the new section.
- The new step gives a `orbit.friction.add` JSON example showing the required fields: `body` naming the asset path + the specific step/section + the missing language + the motivating review-thread IDs, `tags` (defaulting to `skill-guidance`), `during_task`, and `model`. Verified by `grep -E 'orbit\.friction\.add|skill-guidance'` matching in the new section.
- The new step explicitly states that filing a friction is **additive** to filing individual review threads — never a replacement, and never causes the reviewer to skip filing threads on the actual code issues. Verified by `grep -E 'additive|not (a )?replacement|still file'` matching.
- The new step lists negative cases (do not file friction for single nits, stylistic preferences, one-off coding mistakes that are not instruction-text gaps), aligned with `orbit-track-issues`'s "report genuine friction only" rule. Verified by `grep -E 'do not|nit|stylistic'` matching in the negative-cases language.
- `crates/orbit-core/assets/skills/orbit-track-issues/SKILL.md` is updated (minimally) so its "Examples of issues worth tracking" list or scope description names activity-asset prompts (e.g., `agent_implement.yaml`, `agent_review.yaml`) explicitly, so a reviewer reading orbit-track-issues in isolation sees the route. Verified by `grep -E 'agent_implement\.yaml|activity (asset|prompt|instruction)'` matching in the file.
- The "When NOT to use this skill" section of orbit-review-task is updated to add a clarifying line: filing a friction (via orbit-track-issues) when review threads in aggregate reveal a systemic prompt insufficiency IS still in scope for the reviewer's session — i.e., the previous boundary against "filing a friction report on Orbit tooling" is refined, not removed. Verified by `grep 'aggregate'` or equivalent in the updated section.
- The new content contains no agent-family names (`gemini`, `claude`, `codex`, `grok`). Verified by `grep -iE 'gemini|claude|codex|grok'` against the new section returning no matches outside structural / pre-existing examples.
- Existing skill content (review-thread workflow, severity tags, exit criteria, the "do not resolve threads you authored" rule) is preserved bit-for-bit. Verified by `git diff` showing only additions plus the minimal edit to the "When NOT to use" section.
- `make ci-fast` passes.

## Execution Summary

<details>
<summary>Click to expand</summary>

Added Meta-review step (5) to orbit-review-task after Summarize. New step defines trigger heuristic (two+ threads or recognized recurring class mapping to gap in activity YAML or skill SKILL.md), provides orbit.friction.add example with skill-guidance tag, states friction is additive (still file per-issue threads), lists negative cases (nits/stylistic/one-offs). Updated When NOT section with aggregate clarification so systemic prompt friction filing remains in scope for reviewers. Added one sentence to orbit-track-issues Examples list naming activity assets (agent_implement.yaml etc.). make ci-fast passed. All AC greps pass. Diff is pure additions + one-line refinement. No learning added (no contradicted assumption or debug gotcha surfaced).

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-00150-6a0aab43`
- Behind base: 0
- Ahead of base: 1