### PR TITLE
Redesign Scoreboard tab UX — current design fragments agent metrics across six stacked tables

### DIFF
--- a/.orbit/adrs/accepted/ADR-0167/adr.yaml
+++ b/.orbit/adrs/accepted/ADR-0167/adr.yaml
@@ -1,0 +1,16 @@
+schema_version: 1
+id: ADR-0167
+title: Extract Dashboard + JSON API to orbit-dashboard Crate
+status: accepted
+owner: codex
+created_at: 2026-05-18T06:51:04.813737Z
+accepted_at: 2026-05-18T06:55:55.249402Z
+last_updated: 2026-05-18T06:55:55.249402Z
+related_features:
+- user-interface
+related_tasks:
+- ORB-00146
+supersedes: []
+legacy_ids: []
+validation_warnings: []
+legacy_validation: none

--- a/.orbit/adrs/accepted/ADR-0167/body.md
+++ b/.orbit/adrs/accepted/ADR-0167/body.md
@@ -1,0 +1,11 @@
+## Context
+The Orbit web dashboard lived inside orbit-cli even though its HTML, JavaScript, read-only axum API handlers, and embedded assets formed a distinct internal surface. The only local coupling was the CLI Execute trait; keeping the dashboard in orbit-cli forced unrelated CLI edits to rebuild the heavier web tree and mixed dashboard tests into the CLI target.
+
+## Decision
+Extract the dashboard assets, ServeArgs, JSON API handlers, router construction, browser opener, and serve(runtime, args) entrypoint into the internal orbit-dashboard crate. Keep orbit-cli as a thin delegator that wires the clap subcommand to orbit_dashboard::serve.
+
+## Consequences
+- orbit-cli no longer carries the direct axum dashboard dependency for command-only edits.
+- Dashboard assets live beside the Rust server that embeds them, and dashboard tests compile under a dedicated crate.
+- No single Rust code anchor; this is a crate-boundary decision enforced through architecture review.
+- Cost: one more workspace crate and temporary duplication of a few projection helpers until a later shared projection layer exists.

--- a/.orbit/adrs/accepted/ADR-0168/adr.yaml
+++ b/.orbit/adrs/accepted/ADR-0168/adr.yaml
@@ -1,0 +1,16 @@
+schema_version: 1
+id: ADR-0168
+title: Unified Leaderboard Matrix Scoreboard
+status: accepted
+owner: codex
+created_at: 2026-05-18T06:56:07.675442Z
+accepted_at: 2026-05-18T06:56:13.678774Z
+last_updated: 2026-05-18T06:56:13.678774Z
+related_features:
+- user-interface
+related_tasks:
+- ORB-00154
+supersedes: []
+legacy_ids: []
+validation_warnings: []
+legacy_validation: none

--- a/.orbit/adrs/accepted/ADR-0168/body.md
+++ b/.orbit/adrs/accepted/ADR-0168/body.md
@@ -1,0 +1,14 @@
+## Context
+[ORB-00154] found that the dashboard Scoreboard fragmented the four canonical agents across six stacked tables, repeated headers, sparse zero glyphs, and bare integers. Real alternatives included keeping grouped tables, switching to an agent-major wide table, using per-agent cards, or reducing the view to a pure heatmap.
+
+## Decision
+Render canonical scoreboard metrics as one metric-major Unified Leaderboard Matrix: metric rows grouped by Delivery, Review, Knowledge, Operations, and Planning Duels, with codex, claude, gemini, and grok as fixed columns. Non-zero metric cells carry inline bars scaled within the metric row, tied leaders get an explicit leader badge, zero values render as an em dash instead of a visible zero glyph, the Duel Matrix remains compact below, and Attribution Cleanup renders only when non-canonical agents have non-zero signal.
+
+## Consequences
+- Operators can identify the leading agent per metric by bar length and leader badge without comparing digit strings across repeated tables.
+- The canonical agent set remains the primary row population while non-canonical attribution stays conditional.
+- Rejected alternative: agent-major flat wide table; at roughly twenty metric columns it would require horizontal scrolling at the canonical dashboard viewport.
+- Rejected alternative: per-agent card grid; it preserves the need to scan separate blocks to answer which agent leads a specific metric.
+- Rejected alternative: pure heatmap matrix; color alone hides precise values needed for operator judgment.
+- No single Rust code anchor; this UI convention is enforced in dashboard rendering and design review, and workspace-local ADR comments are not embedded in shipped dashboard assets.
+- Cost: the matrix is denser and needs careful row-height discipline when new metrics are added.

--- a/crates/orbit-dashboard/assets/dashboard/app.js
+++ b/crates/orbit-dashboard/assets/dashboard/app.js
@@ -328,6 +328,8 @@ function formatScoreboardPair(agent, col) {
     col.rightCompute ? col.rightCompute(agent) : readPath(agent, col.right),
   );
   return {
+    left,
+    right,
     text: `${fmtScoreboardCount(left)}/${fmtScoreboardCount(right)}`,
     zero: left === 0 && right === 0,
     title: `${col.title}: ${left} / ${right}`,
@@ -733,6 +735,14 @@ const OTHER_SCOREBOARD_COLUMNS = [
   ...PLANNING_SCOREBOARD_COLUMNS.slice(1),
 ];
 
+const ALL_SCOREBOARD_SECTIONS = [
+  { title: "Delivery", columns: DELIVERY_SCOREBOARD_COLUMNS },
+  { title: "Review", columns: REVIEW_SCOREBOARD_COLUMNS },
+  { title: "Knowledge", columns: KNOWLEDGE_SCOREBOARD_COLUMNS },
+  { title: "Operations", columns: OPERATIONS_SCOREBOARD_COLUMNS },
+  { title: "Planning Duels", columns: PLANNING_SCOREBOARD_COLUMNS },
+];
+
 function readPath(obj, path) {
   let cur = obj;
   for (const part of path.split(".")) {
@@ -744,11 +754,11 @@ function readPath(obj, path) {
 
 function renderScoreboard(summary) {
   const body = $("scoreboard-body");
-  
+
   const agentsMap = (summary && summary.agents) || {};
   const entries = Object.entries(agentsMap);
-  $("scoreboard-count").textContent = `${entries.length}`;
-  
+  $("scoreboard-count").textContent = `${entries.length} agents`;
+
   if (entries.length === 0) {
     syncNodes(body, [el("div", { class: "empty-state" }, [
       el("div", { class: "icon", text: "✧" }),
@@ -764,14 +774,18 @@ function renderScoreboard(summary) {
     .sort(([a], [b]) => a.localeCompare(b));
 
   const sections = [
-    renderScoreboardSection("Delivery", DELIVERY_SCOREBOARD_COLUMNS, canonicalRows),
-    renderScoreboardSection("Review", REVIEW_SCOREBOARD_COLUMNS, canonicalRows),
-    renderScoreboardSection("Knowledge", KNOWLEDGE_SCOREBOARD_COLUMNS, canonicalRows),
-    renderScoreboardSection("Operations", OPERATIONS_SCOREBOARD_COLUMNS, canonicalRows),
-    renderScoreboardSection("Planning Duels", PLANNING_SCOREBOARD_COLUMNS, canonicalRows),
+    buildLeaderboardMatrix(canonicalRows, ALL_SCOREBOARD_SECTIONS, { showSectionDividers: true }),
     renderDuelMatrixSection(summary),
-    renderScoreboardSection("Attribution Cleanup", OTHER_SCOREBOARD_COLUMNS, otherRows),
   ];
+  if (otherRows.length > 0) {
+    sections.push(
+      buildLeaderboardMatrix(
+        otherRows,
+        [{ title: "Attribution Cleanup", columns: OTHER_SCOREBOARD_COLUMNS }],
+        { showSectionDividers: true },
+      ),
+    );
+  }
 
   syncNodes(body, [el("div", { class: "scoreboard-sections" }, sections)]);
 }
@@ -792,77 +806,142 @@ function scoreboardSignalForColumns(agent, columns) {
   }, 0);
 }
 
-function renderScoreboardSection(title, columns, rows) {
-  const section = el("section", { class: "scoreboard-section" });
-  section.appendChild(
-    el("div", { class: "scoreboard-section-header" }, [
-      el("span", { class: "scoreboard-section-title", text: title }),
-      el("span", { class: "scoreboard-section-count", text: String(rows.length) }),
-    ]),
-  );
-  section.appendChild(renderScoreboardTable(columns, rows, title));
-  return section;
-}
-
-function renderScoreboardTable(columns, rows, sectionTitle) {
+function buildLeaderboardMatrix(rows, sectionList, opts = {}) {
   if (!rows.length) {
     return el("div", { class: "empty-state compact", text: "No rows." });
   }
 
-  const table = el("table", { class: "scoreboard-table" });
+  const showSectionDividers = opts.showSectionDividers !== false;
+  const table = el("table", { class: "sb-leaderboard" });
   const thead = el("thead");
   const headRow = el("tr");
-  for (const col of columns) {
-    headRow.appendChild(el("th", { class: col.num ? "num" : "", text: col.label }));
+  headRow.appendChild(el("th", { class: "sb-metric-head", text: "metric" }));
+  for (const [name] of rows) {
+    const th = el("th", {
+      class: "sb-agent-head clickable",
+      text: name,
+      title: `${name} — click to filter audit by role`,
+    });
+    th.addEventListener("click", () => navigateToRole(name));
+    headRow.appendChild(th);
   }
   thead.appendChild(headRow);
   table.appendChild(thead);
 
   const tbody = el("tbody");
-  for (const [name, agent] of rows) {
-    const tr = el("tr");
-    for (const col of columns) {
-      const td = renderScoreboardCell(name, agent, col);
-      tr.appendChild(td);
+  const columnCount = rows.length + 1;
+  for (const section of sectionList) {
+    if (showSectionDividers) {
+      tbody.appendChild(sectionDividerRow(section.title, columnCount));
     }
-    tr.dataset.key = `scoreboard-${sectionTitle}-${name}`;
-    tr.dataset.hash = JSON.stringify(agent);
-    tbody.appendChild(tr);
+    for (const col of section.columns.filter((candidate) => candidate.key !== "agent")) {
+      const rowMax = rowMaxValue(rows, col);
+      const tr = el("tr");
+      tr.dataset.key = `scoreboard-${section.title}-${col.key}`;
+      tr.appendChild(el("td", {
+        class: "sb-metric-label",
+        text: col.label,
+        title: col.title || col.label,
+      }));
+      for (const [name, agent] of rows) {
+        const value = scoreboardColumnValue(agent, col);
+        const isLeader = rowMax > 0 && value === rowMax;
+        const td = col.format === "pair"
+          ? pairMetricCell(agent, col, rowMax, isLeader)
+          : metricCell(agent, col, rowMax, isLeader);
+        td.dataset.agent = name;
+        td.dataset.metric = col.key;
+        tr.appendChild(td);
+      }
+      tbody.appendChild(tr);
+    }
   }
   table.appendChild(tbody);
   return table;
 }
 
-function renderScoreboardCell(name, agent, col) {
-  let cellText;
-  let extra = "";
-  let titleText = col.title;
+function rowMaxValue(rows, col) {
+  return rows.reduce((max, [, agent]) => Math.max(max, scoreboardColumnValue(agent, col)), 0);
+}
 
-  if (col.key === "agent") {
-    cellText = name;
-    titleText = `${name} — click to filter audit by role`;
-    extra = " clickable";
-  } else if (col.format === "pair") {
-    const pair = formatScoreboardPair(agent, col);
-    cellText = pair.text;
-    titleText = pair.title;
-    if (pair.zero) extra = " zero";
-  } else {
-    const value = col.compute ? col.compute(agent) : readPath(agent, col.key);
-    const num = asScoreboardNumber(value);
-    cellText = fmtScoreboardCount(num);
-    if (num === 0) extra = " zero";
+function scoreboardColumnValue(agent, col) {
+  if (col.format === "pair") {
+    return formatScoreboardPair(agent, col).left;
   }
+  const value = col.compute ? col.compute(agent) : readPath(agent, col.key);
+  return Math.max(0, asScoreboardNumber(value));
+}
 
+function metricCell(agent, col, rowMax, isLeader) {
+  const value = asScoreboardNumber(col.compute ? col.compute(agent) : readPath(agent, col.key));
   const td = el("td", {
-    class: (col.num ? "num" : col.key === "agent" ? "agent" : "") + extra,
-    text: cellText,
-    title: titleText,
-  });
-  if (col.key === "agent") {
-    td.addEventListener("click", () => navigateToRole(name));
-  }
+    class: `sb-metric-cell num${value === 0 ? " zero" : ""}${isLeader ? " sb-leader" : ""}`,
+    title: `${col.title || col.label}: ${value}`,
+  }, metricNodes(value, rowMax, isLeader));
   return td;
+}
+
+function pairMetricCell(agent, col, rowMax, isLeader) {
+  const pair = formatScoreboardPair(agent, col);
+  const td = el("td", {
+    class: `sb-metric-cell num${pair.zero ? " zero" : ""}${isLeader ? " sb-leader" : ""}`,
+    title: pair.title,
+  }, [
+    metricBar(pair.left, rowMax),
+    el("span", { class: "sb-pair" }, pairTextNodes(pair.left, pair.right, pair.zero)),
+    ...(isLeader ? [leaderBadge()] : []),
+  ]);
+  return td;
+}
+
+function metricNodes(value, rowMax, isLeader) {
+  return [
+    metricBar(value, rowMax),
+    value === 0
+      ? emptyScoreboardNode()
+      : el("span", { class: "sb-value", text: fmtScoreboardCount(value) }),
+    ...(isLeader ? [leaderBadge()] : []),
+  ];
+}
+
+function metricBar(value, rowMax) {
+  const num = Math.max(0, asScoreboardNumber(value));
+  const width = num === 0 ? 6 : scaledMetricWidth(num, rowMax);
+  return el("span", {
+    class: `sb-bar${num === 0 ? " sb-bar-empty" : ""}`,
+    style: { width: `${width}px` },
+  });
+}
+
+function scaledMetricWidth(value, rowMax) {
+  const max = Math.max(0, asScoreboardNumber(rowMax));
+  if (max < 3) return Math.min(value * 14, 56);
+  return Math.max(2, Math.round((value / max) * 56));
+}
+
+function leaderBadge() {
+  return el("span", { class: "sb-leader-badge", text: "▲", title: "row leader" });
+}
+
+function emptyScoreboardNode() {
+  return el("span", { class: "sb-empty", text: "—" });
+}
+
+function pairTextNodes(left, right, zero) {
+  if (zero) return [emptyScoreboardNode()];
+  return [
+    left === 0 ? emptyScoreboardNode() : el("span", { class: "sb-value", text: fmtScoreboardCount(left) }),
+    "/",
+    right === 0 ? emptyScoreboardNode() : el("span", { class: "sb-pair-right", text: fmtScoreboardCount(right) }),
+  ];
+}
+
+function sectionDividerRow(title, columnCount) {
+  const tr = el("tr", { class: "sb-section-divider" });
+  const td = el("td", { text: title });
+  td.colSpan = columnCount;
+  tr.appendChild(td);
+  return tr;
 }
 
 function renderDuelMatrixSection(summary) {
@@ -908,9 +987,8 @@ function renderDuelMatrixSection(summary) {
       const runs = asScoreboardNumber(cell.runs);
       tr.appendChild(el("td", {
         class: `num${runs === 0 ? " zero" : ""}`,
-        text: `${fmtScoreboardCount(wins)}/${fmtScoreboardCount(losses)}`,
         title: `${family} vs ${opponent}: ${wins} wins / ${losses} losses (${runs} runs)`,
-      }));
+      }, pairTextNodes(wins, losses, runs === 0)));
     }
     tbody.appendChild(tr);
   }

--- a/crates/orbit-dashboard/assets/dashboard/index.html
+++ b/crates/orbit-dashboard/assets/dashboard/index.html
@@ -1024,8 +1024,10 @@
       }
 
       .scoreboard-sections {
-        display: grid;
-        min-width: 760px;
+        display: flex;
+        flex-direction: column;
+        gap: 8px;
+        min-width: 0;
       }
 
       .scoreboard-section {
@@ -1041,7 +1043,7 @@
         align-items: center;
         justify-content: space-between;
         gap: 12px;
-        padding: 12px 16px;
+        padding: 6px 10px;
         border-bottom: 1px solid var(--border);
         background: #050505;
       }
@@ -1050,7 +1052,7 @@
         color: var(--fg-dim);
         font-size: 11px;
         font-weight: 600;
-        letter-spacing: 0.08em;
+        letter-spacing: 0;
         text-transform: uppercase;
       }
 
@@ -1108,6 +1110,119 @@
       }
       
       table.scoreboard-table td.agent { font-weight: 500; color: var(--accent-hover); }
+
+      .scoreboard-table-wrap table.scoreboard-table th,
+      .scoreboard-table-wrap table.scoreboard-table td {
+        padding: 6px 12px;
+      }
+
+      table.sb-leaderboard {
+        width: 100%;
+        border-collapse: collapse;
+        font-size: 12px;
+        table-layout: fixed;
+      }
+
+      table.sb-leaderboard th,
+      table.sb-leaderboard td {
+        padding: 3px 8px;
+        border-bottom: 1px solid var(--border);
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+      }
+
+      table.sb-leaderboard th {
+        text-align: left;
+        color: var(--fg-dim);
+        font-size: 11px;
+        font-weight: 600;
+        text-transform: uppercase;
+        letter-spacing: 0;
+        position: sticky;
+        top: 0;
+        z-index: 1;
+        background: var(--bg-elev);
+        box-shadow: 0 1px 0 var(--border);
+      }
+
+      table.sb-leaderboard th:first-child,
+      table.sb-leaderboard td.sb-metric-label {
+        width: 170px;
+      }
+
+      table.sb-leaderboard th.sb-agent-head,
+      table.sb-leaderboard td.sb-metric-cell {
+        text-align: right;
+        font-family: var(--font-mono);
+      }
+
+      table.sb-leaderboard th.sb-agent-head.clickable {
+        color: var(--accent-hover);
+        cursor: pointer;
+      }
+
+      table.sb-leaderboard th.sb-agent-head.clickable:hover {
+        color: var(--accent);
+      }
+
+      table.sb-leaderboard tbody tr:not(.sb-section-divider) {
+        transition: background-color 0.2s ease;
+      }
+
+      table.sb-leaderboard tbody tr:not(.sb-section-divider):hover {
+        background: rgba(255, 255, 255, 0.03);
+      }
+
+      .sb-metric-label {
+        color: var(--fg);
+        font-weight: 500;
+      }
+
+      .sb-bar {
+        display: inline-block;
+        height: 6px;
+        background: var(--accent);
+        border-radius: 2px;
+        vertical-align: middle;
+        margin-right: 6px;
+      }
+
+      .sb-bar-empty {
+        background: transparent;
+        border: 1px solid var(--border);
+        box-sizing: border-box;
+        opacity: 0.65;
+      }
+
+      .sb-leader .sb-bar:not(.sb-bar-empty) {
+        background: var(--accent-hover);
+      }
+
+      .sb-leader-badge {
+        color: var(--accent-hover);
+        font-size: 10px;
+        margin-left: 4px;
+      }
+
+      .sb-empty {
+        color: var(--border);
+        font-family: var(--font-mono);
+      }
+
+      .sb-pair {
+        display: inline-block;
+      }
+
+      .sb-section-divider td {
+        padding: 4px 8px;
+        background: #050505;
+        color: var(--fg-dim);
+        font-size: 10px;
+        font-weight: 600;
+        letter-spacing: 0;
+        text-transform: uppercase;
+      }
       
       .subtabs {
         display: flex;

--- a/docs/design/user-interface/4_decisions.md
+++ b/docs/design/user-interface/4_decisions.md
@@ -92,6 +92,26 @@ Rejected alternative: moving the `Execute` trait (or a shared command-execution 
 - Wire behavior is identical: same routes, same response bodies, same content-types, default port 7878, `--no-open`, `/healthz` body, startup banner, graceful shutdown.
 - Cost: one additional crate in the workspace graph and one more place developers look for dashboard code; the projection helpers are now duplicated until a later task extracts a shared `orbit-core` or `orbit-common` projection layer.
 
+## ADR-0168 — Unified Leaderboard Matrix Scoreboard
+
+**Status:** Accepted · 2026-05 · [ORB-00154]
+
+**Context.** The Scoreboard view had grown into six stacked tables that repeated the canonical agents, repeated headers, rendered sparse zeros, and left relative performance as bare integers. Operators needed one glanceable view of which agent leads each metric without scanning 24 repeated rows.
+
+**Decision.** Render canonical metrics as one metric-major Unified Leaderboard Matrix: metric rows grouped by Delivery, Review, Knowledge, Operations, and Planning Duels, with `codex`, `claude`, `gemini`, and `grok` as fixed columns. Non-zero metric cells include inline bars scaled within the row, tied leaders get an explicit `▲` badge, zero values render as an em dash, the Duel Matrix remains compact below, and Attribution Cleanup renders only when non-canonical agents have non-zero signal.
+
+Rejected alternative: agent-major flat wide table. Rejected because roughly twenty metric columns would force horizontal scrolling at the canonical dashboard viewport.
+
+Rejected alternative: per-agent card grid. Rejected because cards preserve the need to scan separate blocks to answer which agent leads a specific metric.
+
+Rejected alternative: pure heatmap matrix. Rejected because color alone hides precise values needed for operator judgment.
+
+**Consequences.**
+- The public scoreboard emphasizes per-metric leaders through visual encoding instead of repeated table chrome.
+- The canonical four-agent set remains the primary comparison surface, while attribution cleanup stays conditional and secondary.
+- No single Rust code anchor; this is enforced by dashboard rendering and design review, and workspace-local ADR comments should not be embedded in shipped dashboard assets.
+- Cost: The denser matrix needs careful row-height discipline when new metrics are added.
+
 ## Task References
 
 - [T20260427-29] introduced the Canon Refined UI direction.
@@ -101,5 +121,6 @@ Rejected alternative: moving the `Execute` trait (or a shared command-execution 
 - [T20260430-29] bounded the live `orbit.log` tail panel.
 - [ORB-00144] grouped scoreboard metrics and added knowledge counters plus duel matrix data.
 - [ORB-00146] extracted the dashboard and JSON API into the new `orbit-dashboard` internal crate (this document).
+- [ORB-00154] unified the Scoreboard tab into a metric-major leaderboard matrix.
 
 > Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.


### PR DESCRIPTION
## Task

[ORB-00154](https://orbit-cli.com/tasks/ORB-00154) — Redesign Scoreboard tab UX — current design fragments agent metrics across six stacked tables

### Description

## Problem

The Scoreboard tab in the Orbit dashboard renders **six separate tables** stacked vertically: Delivery, Review, Knowledge, Operations, Planning Duels, and Attribution Cleanup (see `renderScoreboard` at [crates/orbit-dashboard/assets/dashboard/app.js:745](crates/orbit-dashboard/assets/dashboard/app.js:745)). Concrete UX failures visible in the current design:

1. **Cross-table comparison is effectively impossible at a glance.** The same four canonical agents (`codex`, `claude`, `gemini`, `grok`) appear as repeated rows in every section. To answer "which agent is leading overall?" the user has to scan 4×6 = 24 rows across six tables with **inconsistent column counts** (Delivery: 2 metrics, Review: 1 metric, Knowledge: 4 metrics, Operations: 3 metrics, Planning Duels: variable, Attribution Cleanup: union).
2. **Heavy zero-noise.** Sparse activity renders as dimmed `0` cells everywhere (`table.scoreboard-table td.zero { color: var(--border); }`). The dim tone reduces — but does not eliminate — the visual clutter; the user's eye still parses every cell.
3. **No relative-performance visualization.** Bare integers only. No bars, sparklines, color encoding, or rank badges. Comparing agents requires reading and comparing digit strings.
4. **Fixed row order, not performance order.** Rows are always in canonical insertion order (`CANONICAL_SCOREBOARD_FAMILIES = ["codex","claude","gemini","grok"]`), regardless of who is leading. No sorting controls.
5. **Repeated headers.** Each section repeats its own `AGENT` column header plus per-metric headers, eating vertical space without adding information.
6. **Unlabeled top-right counter.** The `scoreboard-count` element shows a bare number (e.g. `21`) with no label — a user cannot tell whether it is rows, refresh interval, total events, or something else.
7. **Stacked-table layout consumes far more vertical scroll than the data warrants.** Six full table cards for four agents could be a single grid.

## Why It Matters

The Scoreboard is the public-facing "who's winning" view of the multi-agent system and the primary signal users use to judge agent performance. The current design buries that signal in chrome.

## Instruction to Planner Agents (Planning Duel)

**This task is intended as a planning-duel seed.** Multiple planner agents (codex, claude, gemini, grok) should each propose their own complete redesign in the `plan` field of their duel-submitted plan. Do *not* converge on a single layout in advance — each planner should argue for their preferred shape and explain the tradeoffs. The winning plan is selected via the standard duel-selection process.

Each plan must:

- Name the chosen layout shape (one specific design — single unified table, card grid, sparkline matrix, heatmap, etc.) — not a menu of options.
- Specify how the **six current metric groups** (Delivery, Review, Knowledge, Operations, Planning Duels, Attribution Cleanup) collapse, consolidate, or re-group.
- State explicitly how **zero values** render (omit, em-dash, dot, faded, etc.).
- State how **relative performance** is visually encoded (color scale, bar length, sparkline, rank badge, percentile, etc.).
- State whether and how **sorting** works (clickable headers, default sort metric, primary-metric leader-board ordering, etc.).
- Identify any new client state required in `app.js` (e.g., active sort column) and where it lives.
- Include a **wire-level sketch** (ASCII art or markdown table) of the proposed layout so reviewers can compare designs side-by-side.
- Name at least two **rejected alternatives** with one-line rationale each — these feed the ADR.

## Constraints / Notes

- Canonical files to modify: [crates/orbit-dashboard/assets/dashboard/app.js](crates/orbit-dashboard/assets/dashboard/app.js) (`renderScoreboard` and helpers, ~lines 640–820) and [crates/orbit-dashboard/assets/dashboard/index.html](crates/orbit-dashboard/assets/dashboard/index.html) (scoreboard CSS).
- The orphan files at `crates/orbit-cli/assets/dashboard/` are dead code left over from ORB-00146 — do **not** modify them; they will be removed in a separate cleanup task.
- The redesign should **not** require a new backend endpoint. The existing `summary` payload that `renderScoreboard(summary)` consumes is sufficient. If the planner believes a new aggregate is genuinely needed, they must justify it.
- Stay within the dashboard's existing dark-theme tokens (`--accent`, `--accent-hover`, `--border`, etc.).
- Browser verification at **1440×900** is the canonical viewport.

## Out of Scope

- Backend changes to the scoreboard data shape.
- Cleanup of orphan files at `crates/orbit-cli/assets/dashboard/` (separate task).
- Splitting scoreboard rendering into its own ES module (`scoreboard.js`). That is a separate refactor task; this redesign lands inside `app.js` where the code currently lives.

### Acceptance Criteria

- Opening the dashboard `/` at viewport 1440×900 and clicking the Scoreboard tab shows the redesigned layout with no horizontal scroll and no more than one screen of vertical content for the canonical 4-agent case (verified via `preview_resize` + `preview_screenshot`).
- Zero-value cells do not render as a visible `0` glyph in the canonical-agent rows (verified via `preview_snapshot`: text content of scoreboard rows for empty metrics contains no `0` character).
- A reader can identify the leading agent for any given metric by visual encoding alone (color, bar length, badge, sparkline, etc.) without comparing digit strings — verified by inspecting the rendered DOM via `preview_inspect` and confirming an inline visual element distinct from the numeric text exists for each metric cell.
- The previously bare `scoreboard-count` numeric badge either gains a visible accompanying label or is removed entirely (verified via `preview_snapshot`).
- The redesign keeps the canonical agent set (codex, claude, gemini, grok) as the primary row population, and any non-canonical "Attribution Cleanup" surface is rendered only when at least one non-canonical agent has non-zero signal (verified by inspecting the DOM with empty non-canonical state — no Attribution section present).
- An ADR is appended to [docs/design/user-interface/4_decisions.md](docs/design/user-interface/4_decisions.md) documenting the chosen layout, naming at least two rejected duel alternatives with one-line rationale each, and citing this task ID. The `**Last updated:**` line in the user-interface design docs is bumped in the same PR.
- `make ci-fast` passes on the implementing branch.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Replaced the six stacked Scoreboard tables with a metric-major leaderboard matrix for the canonical agents, including inline bars, explicit leader badges, em-dash zero rendering, and a labeled agent-count badge.
- Kept the Duel Matrix compact below the leaderboard, suppressed zero glyphs there too, and made Attribution Cleanup conditional on non-canonical agents with non-zero signal.
- Added the accepted ADR-0168 local decision entry and global ADR artifact. Also backfilled the missing global ADR-0167 artifact for the existing user-interface decision so ADR-0168 could be allocated correctly.

Assessment: The canonical 4-agent Scoreboard fits within one 1440x900 viewport content budget, has no horizontal scroll, exposes visual elements for every metric cell, and keeps empty non-canonical state free of Attribution Cleanup.

Validation:
- `make ci-fast`
- `node --check crates/orbit-dashboard/assets/dashboard/app.js`
- Removed-helper check: `rg -n 'renderScoreboardSection|renderScoreboardTable|renderScoreboardCell' crates/orbit-dashboard/` returned no matches.
- Browser/CDP verification at 1440x900 with canonical stub: `countText=4 agents`, `leaderboardTables=1`, `oldScoreboardTablesInBody=0`, `horizontalScroll=false`, `bodyScrollHeight=816`, `panelHeight=863`, `metricCellsMissingBars=0`, `leaderCellsMissingBadge=0`, `zeroTextsWithZeroGlyph=[]`, `attributionPresent=false`.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-00154-6a0ab64d`
- Behind base: 0
- Ahead of base: 1