### PR TITLE
Install PreToolUse learning-injection hooks for Claude/Codex/Gemini/Grok on `orbit workspace init`

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -5,3 +5,11 @@ args = [
 ]
 command = "orbit"
 enabled = true
+
+[[hooks.PreToolUse]]
+matcher = "^(Bash|apply_patch|mcp__.*|mcp\\..*)$"
+
+[[hooks.PreToolUse.hooks]]
+type = "command"
+command = '"$(git rev-parse --show-toplevel)/.codex/hooks/orbit-learning-reminder"'
+statusMessage = "Loading Orbit learnings"

--- a/.codex/hooks/orbit-learning-reminder
+++ b/.codex/hooks/orbit-learning-reminder
@@ -1,0 +1,3 @@
+#!/bin/sh
+# Orbit project-learning PreToolUse hook.
+exec "${ORBIT_BIN:-orbit}" hook pretooluse --format codex "$@"

--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,12 @@
 agentspace
 !.claude/settings.json
 !.claude/hooks/
+!.codex/
+.codex/*
 !.codex/config.toml
+!.codex/hooks/
+.codex/hooks/*
+!.codex/hooks/orbit-learning-reminder
 !.gemini/settings.json
 !.grok/
 !.grok/config.toml

--- a/.orbit/learnings/L20260519-2/learning.yaml
+++ b/.orbit/learnings/L20260519-2/learning.yaml
@@ -1,0 +1,19 @@
+schema_version: 1
+id: L20260519-2
+status: active
+scope:
+  paths:
+  - .gitignore
+  - .codex/hooks/**
+  tags:
+  - codex
+  - hooks
+  - gitignore
+summary: When tracking Codex hook shims, unignore `.codex/` narrowly so local Codex state stays ignored
+body: |
+  When tracking a repository-local Codex hook, unignore the parent `.codex/` directory and then re-ignore `.codex/*` / `.codex/hooks/*` before adding narrow negations for `config.toml` and the hook shim. A negated file path alone is not enough when the parent directory is still ignored, while a bare `!.codex/` can accidentally expose all Codex state.
+evidence:
+- kind: task
+  reference: ORB-00162
+created_at: 2026-05-19T04:48:07.323530Z
+updated_at: 2026-05-19T04:48:07.323530Z

--- a/crates/orbit-cli/src/command/environment/workspace.rs
+++ b/crates/orbit-cli/src/command/environment/workspace.rs
@@ -43,6 +43,9 @@ pub struct WorkspaceInitArgs {
     /// Set up MCP client integrations for auto-detected providers.
     #[arg(long)]
     pub mcp: bool,
+    /// Set up PreToolUse learning hooks for auto-detected agent providers.
+    #[arg(long)]
+    pub hooks: bool,
     /// Seed docs/design/CONVENTIONS.md when it does not already exist.
     #[arg(long)]
     pub design: bool,
@@ -98,6 +101,7 @@ impl WorkspaceInitArgs {
             OrbitRuntime::resolve_bootstrap_roots_for_cwd(&cwd, root_override)?;
         let registry_path = workspace_registry::registry_path_for(&global_root);
         let mcp = self.mcp;
+        let hooks = self.hooks;
         let inject_rules = self.inject_agent_rules;
         let init_result = self.execute_at_path(&cwd, &orbit_dir, &global_root, &registry_path)?;
 
@@ -118,6 +122,18 @@ impl WorkspaceInitArgs {
             }
         } else {
             println!("  mcp:       skipped (pass --mcp to set up integrations)");
+        }
+
+        if hooks {
+            let providers =
+                crate::command::hook::install::install_for_workspace(&init_result.root)?;
+            if providers.is_empty() {
+                println!("  hooks:     no providers auto-detected");
+            } else {
+                println!("  hooks:     {}", providers.join(", "));
+            }
+        } else {
+            println!("  hooks:     skipped (pass --hooks to set up integrations)");
         }
 
         if inject_rules {
@@ -256,6 +272,7 @@ mod tests {
             name: None,
             base_branch: "main".to_string(),
             mcp: true,
+            hooks: false,
             design: false,
             inject_agent_rules: false,
             refresh_defaults: false,
@@ -319,6 +336,7 @@ mod tests {
             name: None,
             base_branch: "main".to_string(),
             mcp: false,
+            hooks: false,
             design: false,
             inject_agent_rules: false,
             refresh_defaults: false,
@@ -374,6 +392,7 @@ mod tests {
             name: None,
             base_branch: "main".to_string(),
             mcp: false,
+            hooks: false,
             design: false,
             inject_agent_rules: false,
             refresh_defaults: false,
@@ -422,6 +441,7 @@ mod tests {
             name: None,
             base_branch: "main".to_string(),
             mcp: false,
+            hooks: false,
             design: false,
             inject_agent_rules: false,
             refresh_defaults: false,
@@ -466,6 +486,7 @@ mod tests {
             name: None,
             base_branch: "main".to_string(),
             mcp: false,
+            hooks: false,
             design: false,
             inject_agent_rules: false,
             refresh_defaults: false,
@@ -510,6 +531,7 @@ mod tests {
             name: None,
             base_branch: "main".to_string(),
             mcp: false,
+            hooks: false,
             design: false,
             inject_agent_rules: false,
             refresh_defaults: false,
@@ -554,6 +576,7 @@ mod tests {
             name: Some("custom-root".to_string()),
             base_branch: "main".to_string(),
             mcp: false,
+            hooks: false,
             design: false,
             inject_agent_rules: false,
             refresh_defaults: false,
@@ -620,6 +643,7 @@ mod tests {
             name: None,
             base_branch: "main".to_string(),
             mcp: false,
+            hooks: false,
             design: false,
             inject_agent_rules: false,
             refresh_defaults: false,
@@ -662,6 +686,7 @@ mod tests {
             name: None,
             base_branch: "main".to_string(),
             mcp: false,
+            hooks: false,
             design: true,
             inject_agent_rules: false,
             refresh_defaults: false,
@@ -709,6 +734,7 @@ mod tests {
             name: None,
             base_branch: "main".to_string(),
             mcp: false,
+            hooks: false,
             design: false,
             inject_agent_rules: false,
             refresh_defaults: false,
@@ -759,6 +785,7 @@ mod tests {
             name: None,
             base_branch: "main".to_string(),
             mcp: false,
+            hooks: false,
             design: false,
             inject_agent_rules: false,
             refresh_defaults: false,
@@ -807,6 +834,7 @@ mod tests {
             name: Some("custom-root-git".to_string()),
             base_branch: "main".to_string(),
             mcp: false,
+            hooks: false,
             design: false,
             inject_agent_rules: false,
             refresh_defaults: false,
@@ -989,13 +1017,22 @@ impl Execute for WorkspaceTeardownArgs {
             }
         }
 
-        // 3. Delete .orbit/ directory
+        // 3. Remove repo-local hook integrations while preserving user-authored hook entries
+        let hook_providers = crate::command::hook::install::uninstall_for_workspace(repo_root)?;
+        if !hook_providers.is_empty() {
+            removed.push(format!(
+                "removed hook integrations for {}",
+                hook_providers.join(", ")
+            ));
+        }
+
+        // 4. Delete .orbit/ directory
         if orbit_dir.is_dir() {
             std::fs::remove_dir_all(&orbit_dir).map_err(|e| OrbitError::Io(e.to_string()))?;
             removed.push(format!("deleted {}", orbit_dir.display()));
         }
 
-        // 4. Print summary
+        // 5. Print summary
         println!("teardown complete:");
         for item in &removed {
             println!("  - {item}");

--- a/crates/orbit-cli/src/command/hook/command.rs
+++ b/crates/orbit-cli/src/command/hook/command.rs
@@ -20,7 +20,7 @@ impl Execute for HookCommand {
 
 #[derive(Subcommand)]
 pub enum HookSubcommand {
-    /// Inject project-learning reminders for Claude Code PreToolUse hooks
+    /// Inject project-learning reminders for agent PreToolUse hooks
     #[command(name = "pretooluse")]
     Pretooluse(PretooluseArgs),
 }

--- a/crates/orbit-cli/src/command/hook/install.rs
+++ b/crates/orbit-cli/src/command/hook/install.rs
@@ -1,0 +1,587 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use orbit_core::{OrbitError, redact_sensitive_env_text};
+use serde_json::{Map as JsonMap, Value as JsonValue};
+use toml::{Table as TomlTable, Value as TomlValue};
+
+const HOOK_FILE_NAME: &str = "orbit-learning-reminder";
+const SHIM_COMMENT: &str = "# Orbit project-learning PreToolUse hook.";
+
+#[derive(Debug, Clone, Copy)]
+enum HookAgent {
+    Claude,
+    Codex,
+    Gemini,
+    Grok,
+}
+
+impl HookAgent {
+    fn all() -> &'static [Self] {
+        &[Self::Claude, Self::Codex, Self::Gemini, Self::Grok]
+    }
+
+    fn label(self) -> &'static str {
+        match self {
+            Self::Claude => "claude",
+            Self::Codex => "codex",
+            Self::Gemini => "gemini",
+            Self::Grok => "grok",
+        }
+    }
+
+    fn dir(self) -> &'static str {
+        match self {
+            Self::Claude => ".claude",
+            Self::Codex => ".codex",
+            Self::Gemini => ".gemini",
+            Self::Grok => ".grok",
+        }
+    }
+
+    fn config_path(self, workspace_root: &Path) -> PathBuf {
+        match self {
+            Self::Claude => workspace_root.join(".claude").join("settings.json"),
+            Self::Codex => workspace_root.join(".codex").join("config.toml"),
+            Self::Gemini => workspace_root.join(".gemini").join("settings.json"),
+            Self::Grok => workspace_root.join(".grok").join("config.toml"),
+        }
+    }
+
+    fn shim_path(self, workspace_root: &Path) -> PathBuf {
+        workspace_root
+            .join(self.dir())
+            .join("hooks")
+            .join(HOOK_FILE_NAME)
+    }
+
+    fn command(self) -> String {
+        match self {
+            Self::Claude => ".claude/hooks/orbit-learning-reminder".to_string(),
+            Self::Codex => {
+                "\"$(git rev-parse --show-toplevel)/.codex/hooks/orbit-learning-reminder\""
+                    .to_string()
+            }
+            Self::Gemini => ".gemini/hooks/orbit-learning-reminder".to_string(),
+            Self::Grok => ".grok/hooks/orbit-learning-reminder".to_string(),
+        }
+    }
+
+    fn command_marker(self) -> &'static str {
+        match self {
+            Self::Claude => ".claude/hooks/orbit-learning-reminder",
+            Self::Codex => ".codex/hooks/orbit-learning-reminder",
+            Self::Gemini => ".gemini/hooks/orbit-learning-reminder",
+            Self::Grok => ".grok/hooks/orbit-learning-reminder",
+        }
+    }
+
+    fn shim_format(self) -> Option<&'static str> {
+        match self {
+            Self::Claude => None,
+            Self::Codex => Some("codex"),
+            Self::Gemini => Some("gemini"),
+            Self::Grok => Some("grok"),
+        }
+    }
+}
+
+pub(crate) fn install_for_workspace(workspace_root: &Path) -> Result<Vec<String>, OrbitError> {
+    let mut installed = Vec::new();
+    for agent in HookAgent::all() {
+        if !workspace_root.join(agent.dir()).is_dir() {
+            continue;
+        }
+        match install_agent(workspace_root, *agent) {
+            Ok(()) => installed.push(agent.label().to_string()),
+            Err(error) => warn_agent_failure("install", *agent, &error),
+        }
+    }
+    Ok(installed)
+}
+
+pub(crate) fn uninstall_for_workspace(workspace_root: &Path) -> Result<Vec<String>, OrbitError> {
+    let mut uninstalled = Vec::new();
+    for agent in HookAgent::all() {
+        match uninstall_agent(workspace_root, *agent) {
+            Ok(removed) => {
+                if removed {
+                    uninstalled.push(agent.label().to_string());
+                }
+            }
+            Err(error) => warn_agent_failure("uninstall", *agent, &error),
+        }
+    }
+    Ok(uninstalled)
+}
+
+fn warn_agent_failure(action: &str, agent: HookAgent, error: &OrbitError) {
+    tracing::warn!(
+        action,
+        agent = agent.label(),
+        error = %redact_sensitive_env_text(&error.to_string()),
+        "workspace hook integration failed open",
+    );
+}
+
+fn install_agent(workspace_root: &Path, agent: HookAgent) -> Result<(), OrbitError> {
+    write_shim(&agent.shim_path(workspace_root), agent.shim_format())?;
+    match agent {
+        HookAgent::Claude => merge_json_hook(
+            &agent.config_path(workspace_root),
+            "PreToolUse",
+            "Edit|Write|Read",
+            &agent.command(),
+            agent.command_marker(),
+            None,
+        ),
+        HookAgent::Gemini => merge_json_hook(
+            &agent.config_path(workspace_root),
+            "BeforeTool",
+            "*",
+            &agent.command(),
+            agent.command_marker(),
+            Some("orbit-learning-reminder"),
+        ),
+        HookAgent::Codex => merge_toml_hook(
+            &agent.config_path(workspace_root),
+            "PreToolUse",
+            "^(Bash|apply_patch|mcp__.*|mcp\\..*)$",
+            &agent.command(),
+            agent.command_marker(),
+        ),
+        HookAgent::Grok => merge_toml_hook(
+            &agent.config_path(workspace_root),
+            "PreToolUse",
+            "Edit|Write|Read",
+            &agent.command(),
+            agent.command_marker(),
+        ),
+    }
+}
+
+fn uninstall_agent(workspace_root: &Path, agent: HookAgent) -> Result<bool, OrbitError> {
+    let mut removed = false;
+    let shim_path = agent.shim_path(workspace_root);
+    if shim_path.exists() {
+        fs::remove_file(&shim_path).map_err(|error| {
+            OrbitError::Io(format!(
+                "failed to remove '{}': {error}",
+                shim_path.display()
+            ))
+        })?;
+        removed = true;
+    }
+
+    let demerged = match agent {
+        HookAgent::Claude => remove_json_hook(
+            &agent.config_path(workspace_root),
+            "PreToolUse",
+            agent.command_marker(),
+        )?,
+        HookAgent::Gemini => remove_json_hook(
+            &agent.config_path(workspace_root),
+            "BeforeTool",
+            agent.command_marker(),
+        )?,
+        HookAgent::Codex => remove_toml_hook(
+            &agent.config_path(workspace_root),
+            "PreToolUse",
+            agent.command_marker(),
+        )?,
+        HookAgent::Grok => remove_toml_hook(
+            &agent.config_path(workspace_root),
+            "PreToolUse",
+            agent.command_marker(),
+        )?,
+    };
+    Ok(removed || demerged)
+}
+
+fn write_shim(path: &Path, format: Option<&str>) -> Result<(), OrbitError> {
+    let parent = path.parent().ok_or_else(|| {
+        OrbitError::InvalidInput(format!("hook path has no parent: {}", path.display()))
+    })?;
+    fs::create_dir_all(parent).map_err(|error| {
+        OrbitError::Io(format!("failed to create '{}': {error}", parent.display()))
+    })?;
+
+    let command = match format {
+        Some(format) => {
+            format!("exec \"${{ORBIT_BIN:-orbit}}\" hook pretooluse --format {format} \"$@\"")
+        }
+        None => "exec \"${ORBIT_BIN:-orbit}\" hook pretooluse \"$@\"".to_string(),
+    };
+    let contents = format!("#!/bin/sh\n{SHIM_COMMENT}\n{command}\n");
+    fs::write(path, contents).map_err(|error| {
+        OrbitError::Io(format!("failed to write '{}': {error}", path.display()))
+    })?;
+    make_executable(path)
+}
+
+#[cfg(unix)]
+fn make_executable(path: &Path) -> Result<(), OrbitError> {
+    use std::os::unix::fs::PermissionsExt;
+
+    let mut permissions = fs::metadata(path)
+        .map_err(|error| OrbitError::Io(format!("failed to stat '{}': {error}", path.display())))?
+        .permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(path, permissions).map_err(|error| {
+        OrbitError::Io(format!(
+            "failed to set executable permissions on '{}': {error}",
+            path.display()
+        ))
+    })
+}
+
+#[cfg(not(unix))]
+fn make_executable(_path: &Path) -> Result<(), OrbitError> {
+    Ok(())
+}
+
+fn merge_json_hook(
+    path: &Path,
+    event: &str,
+    matcher: &str,
+    command: &str,
+    marker: &str,
+    name: Option<&str>,
+) -> Result<(), OrbitError> {
+    let mut root = load_json_object(path)?;
+    if json_contains_command(&JsonValue::Object(root.clone()), marker) {
+        return write_json_object(path, &root);
+    }
+    let hooks = ensure_json_object(&mut root, "hooks")?;
+    let event_hooks = ensure_json_array(hooks, event)?;
+    event_hooks.push(json_hook_entry(matcher, command, name));
+    write_json_object(path, &root)
+}
+
+fn remove_json_hook(path: &Path, event: &str, marker: &str) -> Result<bool, OrbitError> {
+    if !path.exists() {
+        return Ok(false);
+    }
+    let mut root = load_json_object(path)?;
+    let Some(hooks) = root.get_mut("hooks").and_then(JsonValue::as_object_mut) else {
+        return Ok(false);
+    };
+    let Some(event_hooks) = hooks.get_mut(event).and_then(JsonValue::as_array_mut) else {
+        return Ok(false);
+    };
+
+    let mut removed = false;
+    for entry in event_hooks.iter_mut() {
+        if let Some(commands) = entry.get_mut("hooks").and_then(JsonValue::as_array_mut) {
+            let command_count = commands.len();
+            commands.retain(|hook| !json_contains_command(hook, marker));
+            removed |= commands.len() != command_count;
+        }
+    }
+    let before = event_hooks.len();
+    event_hooks.retain(|entry| {
+        entry
+            .get("hooks")
+            .and_then(JsonValue::as_array)
+            .map(|commands| !commands.is_empty())
+            .unwrap_or(true)
+    });
+    removed |= event_hooks.len() != before;
+
+    if event_hooks.is_empty() {
+        hooks.remove(event);
+    }
+    if hooks.is_empty() {
+        root.remove("hooks");
+    }
+    write_or_remove_json_object(path, &root)?;
+    Ok(removed)
+}
+
+fn json_hook_entry(matcher: &str, command: &str, name: Option<&str>) -> JsonValue {
+    let mut hook = JsonMap::from_iter([
+        ("type".to_string(), JsonValue::String("command".to_string())),
+        (
+            "command".to_string(),
+            JsonValue::String(command.to_string()),
+        ),
+    ]);
+    if let Some(name) = name {
+        hook.insert("name".to_string(), JsonValue::String(name.to_string()));
+    }
+    JsonValue::Object(JsonMap::from_iter([
+        (
+            "matcher".to_string(),
+            JsonValue::String(matcher.to_string()),
+        ),
+        (
+            "hooks".to_string(),
+            JsonValue::Array(vec![JsonValue::Object(hook)]),
+        ),
+    ]))
+}
+
+fn json_contains_command(value: &JsonValue, marker: &str) -> bool {
+    match value {
+        JsonValue::Object(object) => object.iter().any(|(key, value)| {
+            (key == "command"
+                && value
+                    .as_str()
+                    .map(|command| command.contains(marker))
+                    .unwrap_or(false))
+                || json_contains_command(value, marker)
+        }),
+        JsonValue::Array(values) => values
+            .iter()
+            .any(|value| json_contains_command(value, marker)),
+        _ => false,
+    }
+}
+
+fn load_json_object(path: &Path) -> Result<JsonMap<String, JsonValue>, OrbitError> {
+    if !path.exists() {
+        return Ok(JsonMap::new());
+    }
+    let raw = fs::read_to_string(path)
+        .map_err(|error| OrbitError::Io(format!("failed to read '{}': {error}", path.display())))?;
+    if raw.trim().is_empty() {
+        return Ok(JsonMap::new());
+    }
+    let value: JsonValue = serde_json::from_str(&raw).map_err(|error| {
+        OrbitError::InvalidInput(format!("invalid JSON '{}': {error}", path.display()))
+    })?;
+    value.as_object().cloned().ok_or_else(|| {
+        OrbitError::InvalidInput(format!(
+            "expected top-level JSON object in '{}'",
+            path.display()
+        ))
+    })
+}
+
+fn write_json_object(path: &Path, root: &JsonMap<String, JsonValue>) -> Result<(), OrbitError> {
+    let parent = path.parent().ok_or_else(|| {
+        OrbitError::InvalidInput(format!("path has no parent: {}", path.display()))
+    })?;
+    fs::create_dir_all(parent).map_err(|error| {
+        OrbitError::Io(format!("failed to create '{}': {error}", parent.display()))
+    })?;
+    let mut rendered =
+        serde_json::to_string_pretty(&JsonValue::Object(root.clone())).map_err(|error| {
+            OrbitError::Execution(format!("serialize JSON '{}': {error}", path.display()))
+        })?;
+    rendered.push('\n');
+    fs::write(path, rendered)
+        .map_err(|error| OrbitError::Io(format!("failed to write '{}': {error}", path.display())))
+}
+
+fn write_or_remove_json_object(
+    path: &Path,
+    root: &JsonMap<String, JsonValue>,
+) -> Result<(), OrbitError> {
+    if root.is_empty() {
+        if path.exists() {
+            fs::remove_file(path).map_err(|error| {
+                OrbitError::Io(format!("failed to remove '{}': {error}", path.display()))
+            })?;
+        }
+        return Ok(());
+    }
+    write_json_object(path, root)
+}
+
+fn ensure_json_object<'a>(
+    root: &'a mut JsonMap<String, JsonValue>,
+    key: &str,
+) -> Result<&'a mut JsonMap<String, JsonValue>, OrbitError> {
+    let value = root
+        .entry(key.to_string())
+        .or_insert_with(|| JsonValue::Object(JsonMap::new()));
+    value
+        .as_object_mut()
+        .ok_or_else(|| OrbitError::InvalidInput(format!("expected '{key}' to be a JSON object")))
+}
+
+fn ensure_json_array<'a>(
+    root: &'a mut JsonMap<String, JsonValue>,
+    key: &str,
+) -> Result<&'a mut Vec<JsonValue>, OrbitError> {
+    let value = root
+        .entry(key.to_string())
+        .or_insert_with(|| JsonValue::Array(Vec::new()));
+    value
+        .as_array_mut()
+        .ok_or_else(|| OrbitError::InvalidInput(format!("expected '{key}' to be a JSON array")))
+}
+
+fn merge_toml_hook(
+    path: &Path,
+    event: &str,
+    matcher: &str,
+    command: &str,
+    marker: &str,
+) -> Result<(), OrbitError> {
+    let mut root = load_toml_table(path)?;
+    if toml_contains_command_in_table(&root, marker) {
+        return write_toml_table(path, &root);
+    }
+    let hooks = ensure_toml_table(&mut root, "hooks")?;
+    let event_hooks = ensure_toml_array(hooks, event)?;
+    event_hooks.push(TomlValue::Table(toml_hook_entry(matcher, command)));
+    write_toml_table(path, &root)
+}
+
+fn remove_toml_hook(path: &Path, event: &str, marker: &str) -> Result<bool, OrbitError> {
+    if !path.exists() {
+        return Ok(false);
+    }
+    let mut root = load_toml_table(path)?;
+    let Some(hooks) = root.get_mut("hooks").and_then(TomlValue::as_table_mut) else {
+        return Ok(false);
+    };
+    let Some(event_hooks) = hooks.get_mut(event).and_then(TomlValue::as_array_mut) else {
+        return Ok(false);
+    };
+
+    let mut removed = false;
+    for entry in event_hooks.iter_mut().filter_map(TomlValue::as_table_mut) {
+        if let Some(commands) = entry.get_mut("hooks").and_then(TomlValue::as_array_mut) {
+            let command_count = commands.len();
+            commands.retain(|hook| !toml_contains_command(hook, marker));
+            removed |= commands.len() != command_count;
+        }
+    }
+    let before = event_hooks.len();
+    event_hooks.retain(|entry| {
+        entry
+            .as_table()
+            .and_then(|table| table.get("hooks"))
+            .and_then(TomlValue::as_array)
+            .map(|commands| !commands.is_empty())
+            .unwrap_or(true)
+    });
+    removed |= event_hooks.len() != before;
+    if event_hooks.is_empty() {
+        hooks.remove(event);
+    }
+    if hooks.is_empty() {
+        root.remove("hooks");
+    }
+    write_or_remove_toml_table(path, &root)?;
+    Ok(removed)
+}
+
+fn toml_hook_entry(matcher: &str, command: &str) -> TomlTable {
+    TomlTable::from_iter([
+        (
+            "matcher".to_string(),
+            TomlValue::String(matcher.to_string()),
+        ),
+        (
+            "hooks".to_string(),
+            TomlValue::Array(vec![TomlValue::Table(TomlTable::from_iter([
+                ("type".to_string(), TomlValue::String("command".to_string())),
+                (
+                    "command".to_string(),
+                    TomlValue::String(command.to_string()),
+                ),
+                (
+                    "statusMessage".to_string(),
+                    TomlValue::String("Loading Orbit learnings".to_string()),
+                ),
+            ]))]),
+        ),
+    ])
+}
+
+fn toml_contains_command_in_table(table: &TomlTable, marker: &str) -> bool {
+    table
+        .values()
+        .any(|value| toml_contains_command(value, marker))
+}
+
+fn toml_contains_command(value: &TomlValue, marker: &str) -> bool {
+    match value {
+        TomlValue::Table(table) => table.iter().any(|(key, value)| {
+            (key == "command"
+                && value
+                    .as_str()
+                    .map(|command| command.contains(marker))
+                    .unwrap_or(false))
+                || toml_contains_command(value, marker)
+        }),
+        TomlValue::Array(values) => values
+            .iter()
+            .any(|value| toml_contains_command(value, marker)),
+        _ => false,
+    }
+}
+
+fn load_toml_table(path: &Path) -> Result<TomlTable, OrbitError> {
+    if !path.exists() {
+        return Ok(TomlTable::new());
+    }
+    let raw = fs::read_to_string(path)
+        .map_err(|error| OrbitError::Io(format!("failed to read '{}': {error}", path.display())))?;
+    if raw.trim().is_empty() {
+        return Ok(TomlTable::new());
+    }
+    let value: TomlValue = toml::from_str(&raw).map_err(|error| {
+        OrbitError::InvalidInput(format!("invalid TOML '{}': {error}", path.display()))
+    })?;
+    value.as_table().cloned().ok_or_else(|| {
+        OrbitError::InvalidInput(format!(
+            "expected top-level TOML table in '{}'",
+            path.display()
+        ))
+    })
+}
+
+fn write_toml_table(path: &Path, root: &TomlTable) -> Result<(), OrbitError> {
+    let parent = path.parent().ok_or_else(|| {
+        OrbitError::InvalidInput(format!("path has no parent: {}", path.display()))
+    })?;
+    fs::create_dir_all(parent).map_err(|error| {
+        OrbitError::Io(format!("failed to create '{}': {error}", parent.display()))
+    })?;
+    let rendered = toml::to_string_pretty(&TomlValue::Table(root.clone())).map_err(|error| {
+        OrbitError::Execution(format!("serialize TOML '{}': {error}", path.display()))
+    })?;
+    fs::write(path, rendered)
+        .map_err(|error| OrbitError::Io(format!("failed to write '{}': {error}", path.display())))
+}
+
+fn write_or_remove_toml_table(path: &Path, root: &TomlTable) -> Result<(), OrbitError> {
+    if root.is_empty() {
+        if path.exists() {
+            fs::remove_file(path).map_err(|error| {
+                OrbitError::Io(format!("failed to remove '{}': {error}", path.display()))
+            })?;
+        }
+        return Ok(());
+    }
+    write_toml_table(path, root)
+}
+
+fn ensure_toml_table<'a>(
+    root: &'a mut TomlTable,
+    key: &str,
+) -> Result<&'a mut TomlTable, OrbitError> {
+    let value = root
+        .entry(key.to_string())
+        .or_insert_with(|| TomlValue::Table(TomlTable::new()));
+    value
+        .as_table_mut()
+        .ok_or_else(|| OrbitError::InvalidInput(format!("expected '{key}' to be a TOML table")))
+}
+
+fn ensure_toml_array<'a>(
+    root: &'a mut TomlTable,
+    key: &str,
+) -> Result<&'a mut Vec<TomlValue>, OrbitError> {
+    let value = root
+        .entry(key.to_string())
+        .or_insert_with(|| TomlValue::Array(Vec::new()));
+    value
+        .as_array_mut()
+        .ok_or_else(|| OrbitError::InvalidInput(format!("expected '{key}' to be a TOML array")))
+}

--- a/crates/orbit-cli/src/command/hook/mod.rs
+++ b/crates/orbit-cli/src/command/hook/mod.rs
@@ -1,4 +1,6 @@
 mod command;
+pub(crate) mod install;
 mod pretooluse;
+mod render;
 
 pub use command::{HookCommand, HookSubcommand};

--- a/crates/orbit-cli/src/command/hook/pretooluse.rs
+++ b/crates/orbit-cli/src/command/hook/pretooluse.rs
@@ -7,7 +7,8 @@ use clap::Args;
 use fs2::FileExt;
 use orbit_common::types::{AuditEventStatus, LearningInjectionCaps, LearningReminder};
 use orbit_core::command::learning_hook::{
-    ORBIT_SESSION_ID_ENV, caps_from_env, merge_state, parse_payload, parse_state_json,
+    CLAUDE_PRETOOLUSE_TOOLS, CODEX_PRETOOLUSE_TOOLS, GEMINI_PRETOOLUSE_TOOLS, ORBIT_SESSION_ID_ENV,
+    caps_from_env, merge_state, parse_payload_with_tools, parse_state_json,
     reminders_from_search_results,
 };
 use orbit_core::{
@@ -17,30 +18,39 @@ use orbit_core::{
 use serde_json::json;
 
 use crate::command::Execute;
+use crate::command::hook::render::{HookOutputFormat, render_reminders};
 
 const LOCK_RETRY_INTERVAL: Duration = Duration::from_millis(5);
 const LOCK_RETRY_BUDGET: Duration = Duration::from_millis(50);
 
 #[derive(Args)]
-pub struct PretooluseArgs {}
+pub struct PretooluseArgs {
+    /// Render output in the hook format expected by this agent.
+    #[arg(long, value_enum, default_value_t = HookOutputFormat::Claude)]
+    pub format: HookOutputFormat,
+}
 
 impl Execute for PretooluseArgs {
     fn execute(self, runtime: &OrbitRuntime) -> Result<(), OrbitError> {
         let start = Instant::now();
-        if let Err(error) = run_pretooluse(runtime, start) {
+        if let Err(error) = run_pretooluse(runtime, start, self.format) {
             tracing::warn!(error = %redact_sensitive_env_text(&error), "learning hook failed open");
         }
         Ok(())
     }
 }
 
-fn run_pretooluse(runtime: &OrbitRuntime, start: Instant) -> Result<(), String> {
+fn run_pretooluse(
+    runtime: &OrbitRuntime,
+    start: Instant,
+    format: HookOutputFormat,
+) -> Result<(), String> {
     let mut stdin = String::new();
     std::io::stdin()
         .read_to_string(&mut stdin)
         .map_err(|error| format!("read stdin: {error}"))?;
 
-    let Some(payload) = parse_payload(&stdin) else {
+    let Some(payload) = parse_payload_with_tools(&stdin, accepted_tools(format)) else {
         return Ok(());
     };
 
@@ -78,9 +88,18 @@ fn run_pretooluse(runtime: &OrbitRuntime, start: Instant) -> Result<(), String> 
         start.elapsed(),
     )?;
 
-    let block = orbit_common::types::render_reminder_block(&admitted);
-    println!("{block}");
+    let output = render_reminders(format, &admitted)
+        .map_err(|error| format!("render reminders: {error}"))?;
+    println!("{output}");
     Ok(())
+}
+
+fn accepted_tools(format: HookOutputFormat) -> &'static [&'static str] {
+    match format {
+        HookOutputFormat::Claude | HookOutputFormat::Grok => CLAUDE_PRETOOLUSE_TOOLS,
+        HookOutputFormat::Codex => CODEX_PRETOOLUSE_TOOLS,
+        HookOutputFormat::Gemini => GEMINI_PRETOOLUSE_TOOLS,
+    }
 }
 
 fn learning_hook_tmpdir() -> PathBuf {

--- a/crates/orbit-cli/src/command/hook/render.rs
+++ b/crates/orbit-cli/src/command/hook/render.rs
@@ -1,0 +1,100 @@
+use clap::ValueEnum;
+use orbit_common::types::LearningReminder;
+use orbit_core::OrbitError;
+use serde_json::json;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub enum HookOutputFormat {
+    Claude,
+    Codex,
+    Gemini,
+    Grok,
+}
+
+pub fn render_reminders(
+    format: HookOutputFormat,
+    admitted: &[LearningReminder],
+) -> Result<String, OrbitError> {
+    match format {
+        HookOutputFormat::Claude | HookOutputFormat::Grok => Ok(render_claude(admitted)),
+        HookOutputFormat::Codex => render_codex(admitted),
+        HookOutputFormat::Gemini => render_gemini(admitted),
+    }
+}
+
+pub fn render_claude(admitted: &[LearningReminder]) -> String {
+    orbit_common::types::render_reminder_block(admitted)
+}
+
+pub fn render_codex(admitted: &[LearningReminder]) -> Result<String, OrbitError> {
+    render_json_context("PreToolUse", admitted)
+}
+
+pub fn render_gemini(admitted: &[LearningReminder]) -> Result<String, OrbitError> {
+    // Gemini CLI names its documented pre-tool hook event `BeforeTool`; the
+    // renderer stays separate so the wiring can change when Gemini's hook
+    // context surface settles.
+    render_json_context("BeforeTool", admitted)
+}
+
+fn render_json_context(
+    event_name: &str,
+    admitted: &[LearningReminder],
+) -> Result<String, OrbitError> {
+    let block = render_claude(admitted);
+    serde_json::to_string(&json!({
+        "hookSpecificOutput": {
+            "hookEventName": event_name,
+            "additionalContext": block,
+        }
+    }))
+    .map_err(|error| OrbitError::Execution(format!("serialize hook output: {error}")))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn reminders() -> Vec<LearningReminder> {
+        vec![LearningReminder {
+            id: "L20260519-1".to_string(),
+            summary: "Use JSON hook context for Codex".to_string(),
+            comments: Vec::new(),
+        }]
+    }
+
+    #[test]
+    fn codex_renderer_wraps_reminder_block_in_json_envelope() {
+        let rendered = render_codex(&reminders()).expect("render codex");
+        let value: serde_json::Value = serde_json::from_str(&rendered).expect("parse JSON");
+        assert_eq!(
+            value["hookSpecificOutput"]["hookEventName"].as_str(),
+            Some("PreToolUse")
+        );
+        assert!(
+            value["hookSpecificOutput"]["additionalContext"]
+                .as_str()
+                .expect("additional context")
+                .contains("- [L20260519-1] Use JSON hook context for Codex")
+        );
+    }
+
+    #[test]
+    fn grok_renderer_matches_claude_renderer() {
+        let reminders = reminders();
+        assert_eq!(
+            render_reminders(HookOutputFormat::Grok, &reminders).expect("render grok"),
+            render_reminders(HookOutputFormat::Claude, &reminders).expect("render claude"),
+        );
+    }
+
+    #[test]
+    fn gemini_renderer_uses_before_tool_event() {
+        let rendered = render_gemini(&reminders()).expect("render gemini");
+        let value: serde_json::Value = serde_json::from_str(&rendered).expect("parse JSON");
+        assert_eq!(
+            value["hookSpecificOutput"]["hookEventName"].as_str(),
+            Some("BeforeTool")
+        );
+    }
+}

--- a/crates/orbit-cli/src/command/mod.rs
+++ b/crates/orbit-cli/src/command/mod.rs
@@ -206,7 +206,7 @@ mod tests {
 
     #[test]
     fn cli_parses_hook_pretooluse() {
-        let cli = Cli::parse_from(["orbit", "hook", "pretooluse"]);
+        let cli = Cli::parse_from(["orbit", "hook", "pretooluse", "--format", "codex"]);
         match cli.command {
             Commands::Hook(command) => match command.command {
                 HookSubcommand::Pretooluse(_) => {}

--- a/crates/orbit-cli/tests/hook_install.rs
+++ b/crates/orbit-cli/tests/hook_install.rs
@@ -1,0 +1,353 @@
+#![allow(missing_docs)]
+// ORB-00013: Tests use unwrap/expect to keep fixture setup readable.
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Output;
+
+use assert_cmd::cargo::cargo_bin_cmd;
+use serde_json::{Value, json};
+use tempfile::{TempDir, tempdir};
+
+#[test]
+fn workspace_init_seeds_hooks_for_detected_agents() {
+    let workspace = TestWorkspace::new();
+    workspace.seed_agent_dirs(&[".claude", ".codex", ".gemini", ".grok"]);
+
+    workspace.run(
+        &["workspace", "init", "--name", "hooks", "--hooks"],
+        "init hooks",
+    );
+
+    for path in [
+        ".claude/hooks/orbit-learning-reminder",
+        ".codex/hooks/orbit-learning-reminder",
+        ".gemini/hooks/orbit-learning-reminder",
+        ".grok/hooks/orbit-learning-reminder",
+    ] {
+        assert!(workspace.work.join(path).exists(), "missing {path}");
+    }
+
+    assert_json_hook(
+        &workspace.work.join(".claude/settings.json"),
+        "PreToolUse",
+        ".claude/hooks/orbit-learning-reminder",
+    );
+    assert_json_hook(
+        &workspace.work.join(".gemini/settings.json"),
+        "BeforeTool",
+        ".gemini/hooks/orbit-learning-reminder",
+    );
+    assert_toml_hook(
+        &workspace.work.join(".codex/config.toml"),
+        "PreToolUse",
+        ".codex/hooks/orbit-learning-reminder",
+    );
+    assert_toml_hook(
+        &workspace.work.join(".grok/config.toml"),
+        "PreToolUse",
+        ".grok/hooks/orbit-learning-reminder",
+    );
+}
+
+#[test]
+fn workspace_init_hooks_is_idempotent() {
+    let workspace = TestWorkspace::new();
+    workspace.seed_agent_dirs(&[".claude", ".codex", ".gemini", ".grok"]);
+
+    workspace.run(
+        &["workspace", "init", "--name", "hooks", "--hooks"],
+        "init hooks",
+    );
+    let first = workspace.read_configs();
+    workspace.run(
+        &["workspace", "init", "--name", "hooks", "--hooks"],
+        "init hooks again",
+    );
+    let second = workspace.read_configs();
+
+    assert_eq!(first, second);
+}
+
+#[test]
+fn workspace_init_hooks_preserves_user_entries() {
+    let workspace = TestWorkspace::new();
+    workspace.seed_agent_dirs(&[".claude"]);
+    fs::write(
+        workspace.work.join(".claude/settings.json"),
+        serde_json::to_string_pretty(&json!({
+            "hooks": {
+                "PreToolUse": [{
+                    "matcher": "Write",
+                    "hooks": [{
+                        "type": "command",
+                        "command": ".claude/hooks/user-hook"
+                    }]
+                }]
+            },
+            "theme": "dark"
+        }))
+        .expect("serialize settings"),
+    )
+    .expect("write settings");
+
+    workspace.run(
+        &["workspace", "init", "--name", "hooks", "--hooks"],
+        "init hooks",
+    );
+
+    let settings: Value = serde_json::from_str(
+        &fs::read_to_string(workspace.work.join(".claude/settings.json")).expect("read settings"),
+    )
+    .expect("parse settings");
+    assert_eq!(settings["theme"], "dark");
+    assert_json_value_contains_command(&settings, ".claude/hooks/user-hook");
+    assert_json_value_contains_command(&settings, ".claude/hooks/orbit-learning-reminder");
+}
+
+#[test]
+fn workspace_init_hooks_skips_absent_agent_dirs() {
+    let workspace = TestWorkspace::new();
+    workspace.seed_agent_dirs(&[".claude"]);
+
+    workspace.run(
+        &["workspace", "init", "--name", "hooks", "--hooks"],
+        "init hooks",
+    );
+
+    assert!(
+        workspace
+            .work
+            .join(".claude/hooks/orbit-learning-reminder")
+            .exists()
+    );
+    assert!(
+        !workspace
+            .work
+            .join(".codex/hooks/orbit-learning-reminder")
+            .exists()
+    );
+    assert!(
+        !workspace
+            .work
+            .join(".gemini/hooks/orbit-learning-reminder")
+            .exists()
+    );
+    assert!(
+        !workspace
+            .work
+            .join(".grok/hooks/orbit-learning-reminder")
+            .exists()
+    );
+}
+
+#[test]
+fn workspace_init_hooks_failure_is_warned_not_fatal() {
+    let workspace = TestWorkspace::new();
+    workspace.seed_agent_dirs(&[".claude", ".codex", ".gemini", ".grok"]);
+    fs::write(workspace.work.join(".claude/settings.json"), "{ not json")
+        .expect("write malformed settings");
+
+    workspace.run(
+        &["workspace", "init", "--name", "hooks", "--hooks"],
+        "init hooks",
+    );
+
+    assert!(
+        workspace
+            .work
+            .join(".codex/hooks/orbit-learning-reminder")
+            .exists()
+    );
+    assert!(
+        workspace
+            .work
+            .join(".gemini/hooks/orbit-learning-reminder")
+            .exists()
+    );
+    assert!(
+        workspace
+            .work
+            .join(".grok/hooks/orbit-learning-reminder")
+            .exists()
+    );
+    assert_json_hook(
+        &workspace.work.join(".gemini/settings.json"),
+        "BeforeTool",
+        ".gemini/hooks/orbit-learning-reminder",
+    );
+}
+
+#[test]
+fn workspace_teardown_removes_orbit_hooks_only() {
+    let workspace = TestWorkspace::new();
+    workspace.seed_agent_dirs(&[".claude"]);
+    fs::write(
+        workspace.work.join(".claude/settings.json"),
+        serde_json::to_string_pretty(&json!({
+            "hooks": {
+                "PreToolUse": [{
+                    "matcher": "Write",
+                    "hooks": [{
+                        "type": "command",
+                        "command": ".claude/hooks/user-hook"
+                    }]
+                }]
+            }
+        }))
+        .expect("serialize settings"),
+    )
+    .expect("write settings");
+
+    workspace.run(
+        &["workspace", "init", "--name", "hooks", "--hooks"],
+        "init hooks",
+    );
+    workspace.run(&["workspace", "teardown", "--confirm"], "teardown hooks");
+
+    assert!(
+        !workspace
+            .work
+            .join(".claude/hooks/orbit-learning-reminder")
+            .exists()
+    );
+    let settings: Value = serde_json::from_str(
+        &fs::read_to_string(workspace.work.join(".claude/settings.json")).expect("read settings"),
+    )
+    .expect("parse settings");
+    assert_json_value_contains_command(&settings, ".claude/hooks/user-hook");
+    assert!(!json_value_contains_command(
+        &settings,
+        ".claude/hooks/orbit-learning-reminder"
+    ));
+}
+
+fn assert_json_hook(path: &Path, event: &str, command: &str) {
+    let settings: Value =
+        serde_json::from_str(&fs::read_to_string(path).expect("read JSON config"))
+            .expect("parse JSON config");
+    let entries = settings["hooks"][event].as_array().expect("event hooks");
+    assert!(
+        entries
+            .iter()
+            .any(|entry| json_value_contains_command(entry, command)),
+        "{path:?} missing command {command}"
+    );
+}
+
+fn assert_toml_hook(path: &Path, event: &str, command: &str) {
+    let config: toml::Value = toml::from_str(&fs::read_to_string(path).expect("read TOML config"))
+        .expect("parse TOML config");
+    let entries = config["hooks"][event].as_array().expect("event hooks");
+    assert!(
+        entries
+            .iter()
+            .any(|entry| toml_value_contains_command(entry, command)),
+        "{path:?} missing command {command}"
+    );
+}
+
+fn assert_json_value_contains_command(value: &Value, command: &str) {
+    assert!(
+        json_value_contains_command(value, command),
+        "missing command {command} in {value}"
+    );
+}
+
+fn json_value_contains_command(value: &Value, command: &str) -> bool {
+    match value {
+        Value::Object(object) => object.iter().any(|(key, value)| {
+            (key == "command"
+                && value
+                    .as_str()
+                    .map(|candidate| candidate.contains(command))
+                    .unwrap_or(false))
+                || json_value_contains_command(value, command)
+        }),
+        Value::Array(values) => values
+            .iter()
+            .any(|value| json_value_contains_command(value, command)),
+        _ => false,
+    }
+}
+
+fn toml_value_contains_command(value: &toml::Value, command: &str) -> bool {
+    match value {
+        toml::Value::Table(table) => table.iter().any(|(key, value)| {
+            (key == "command"
+                && value
+                    .as_str()
+                    .map(|candidate| candidate.contains(command))
+                    .unwrap_or(false))
+                || toml_value_contains_command(value, command)
+        }),
+        toml::Value::Array(values) => values
+            .iter()
+            .any(|value| toml_value_contains_command(value, command)),
+        _ => false,
+    }
+}
+
+struct TestWorkspace {
+    _temp: TempDir,
+    home: PathBuf,
+    work: PathBuf,
+}
+
+impl TestWorkspace {
+    fn new() -> Self {
+        let temp = tempdir().expect("tempdir");
+        let home = temp.path().join("home");
+        let work = temp.path().join("work");
+        fs::create_dir_all(&home).expect("create home");
+        fs::create_dir_all(&work).expect("create work");
+        Self {
+            _temp: temp,
+            home,
+            work,
+        }
+    }
+
+    fn seed_agent_dirs(&self, dirs: &[&str]) {
+        for dir in dirs {
+            fs::create_dir_all(self.work.join(dir)).expect("create agent dir");
+        }
+    }
+
+    fn read_configs(&self) -> Vec<(String, String)> {
+        [
+            ".claude/settings.json",
+            ".codex/config.toml",
+            ".gemini/settings.json",
+            ".grok/config.toml",
+        ]
+        .into_iter()
+        .map(|path| {
+            (
+                path.to_string(),
+                fs::read_to_string(self.work.join(path)).expect("read config"),
+            )
+        })
+        .collect()
+    }
+
+    fn run(&self, args: &[&str], label: &str) -> Output {
+        let mut command = cargo_bin_cmd!("orbit");
+        let output = command
+            .current_dir(&self.work)
+            .env("HOME", &self.home)
+            .env("USERPROFILE", &self.home)
+            .env_remove("ORBIT_ROOT")
+            .args(args)
+            .output()
+            .expect("run orbit");
+        assert!(
+            output.status.success(),
+            "{label} failed\nargs: {args:?}\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        output
+    }
+}

--- a/crates/orbit-cli/tests/hook_pretooluse.rs
+++ b/crates/orbit-cli/tests/hook_pretooluse.rs
@@ -117,6 +117,72 @@ fn per_call_cap_limits_rendered_learning_count() {
     assert_eq!(rendered, 2, "stdout: {stdout}");
 }
 
+#[test]
+fn codex_format_emits_json_envelope_and_audit_event() {
+    let workspace = TestWorkspace::new();
+    let learning = workspace.add_learning("Codex hook output must be JSON", &["src/**"]);
+    let learning_id = learning["id"].as_str().expect("learning id");
+
+    let output = workspace.run_hook_with_args(
+        &["--format", "codex"],
+        r#"{"tool_name":"Bash","tool_input":{"command":"cat src/lib.rs"}}"#,
+        &[("ORBIT_SESSION_ID", "codex-format")],
+        "codex format hook",
+    );
+    let rendered: Value = serde_json::from_slice(&output.stdout).expect("codex JSON stdout");
+    assert_eq!(
+        rendered["hookSpecificOutput"]["hookEventName"].as_str(),
+        Some("PreToolUse")
+    );
+    assert!(
+        rendered["hookSpecificOutput"]["additionalContext"]
+            .as_str()
+            .expect("additional context")
+            .contains(&format!("- [{learning_id}] Codex hook output must be JSON"))
+    );
+
+    let events = workspace.run_json(
+        &["audit", "list", "--kind", "learning_injected", "--json"],
+        "audit list",
+    );
+    let event = &events.as_array().expect("audit rows")[0];
+    assert_eq!(event["tool_name"], "Bash");
+    assert_eq!(event["target_id"], "src/lib.rs");
+}
+
+#[test]
+fn grok_format_matches_claude_plaintext_and_gemini_uses_json() {
+    let workspace = TestWorkspace::new();
+    workspace.add_learning("Shared format test learning", &["src/**"]);
+    let payload = r#"{"tool_name":"Read","path":"src/lib.rs"}"#;
+
+    let claude = workspace.run_hook_with_args(
+        &["--format", "claude"],
+        payload,
+        &[("ORBIT_SESSION_ID", "format-claude")],
+        "claude format hook",
+    );
+    let grok = workspace.run_hook_with_args(
+        &["--format", "grok"],
+        payload,
+        &[("ORBIT_SESSION_ID", "format-grok")],
+        "grok format hook",
+    );
+    assert_eq!(claude.stdout, grok.stdout);
+
+    let gemini = workspace.run_hook_with_args(
+        &["--format", "gemini"],
+        r#"{"tool_name":"read_file","tool_input":{"path":"src/lib.rs"}}"#,
+        &[("ORBIT_SESSION_ID", "format-gemini")],
+        "gemini format hook",
+    );
+    let rendered: Value = serde_json::from_slice(&gemini.stdout).expect("gemini JSON stdout");
+    assert_eq!(
+        rendered["hookSpecificOutput"]["hookEventName"].as_str(),
+        Some("BeforeTool")
+    );
+}
+
 #[cfg(unix)]
 #[test]
 fn missing_session_uses_tmpdir_parent_pid_state_file() {
@@ -182,6 +248,18 @@ impl TestWorkspace {
 
     fn run_hook(&self, stdin: &str, envs: &[(&str, &str)], label: &str) -> Output {
         self.run(&["hook", "pretooluse"], Some(stdin), envs, label)
+    }
+
+    fn run_hook_with_args(
+        &self,
+        extra_args: &[&str],
+        stdin: &str,
+        envs: &[(&str, &str)],
+        label: &str,
+    ) -> Output {
+        let mut args = vec!["hook", "pretooluse"];
+        args.extend_from_slice(extra_args);
+        self.run(&args, Some(stdin), envs, label)
     }
 
     fn run_json(&self, args: &[&str], label: &str) -> Value {

--- a/crates/orbit-core/src/command/learning_hook.rs
+++ b/crates/orbit-core/src/command/learning_hook.rs
@@ -18,11 +18,29 @@ pub struct HookPayload {
     pub target_path: String,
 }
 
+pub const CLAUDE_PRETOOLUSE_TOOLS: &[&str] = &["Edit", "Write", "Read"];
+pub const CODEX_PRETOOLUSE_TOOLS: &[&str] = &["Bash", "apply_patch", "mcp"];
+pub const GEMINI_PRETOOLUSE_TOOLS: &[&str] = &[
+    "read_file",
+    "write_file",
+    "edit",
+    "replace",
+    "run_shell_command",
+    "Read",
+    "Write",
+    "Edit",
+    "Bash",
+];
+
 pub fn parse_payload(stdin: &str) -> Option<HookPayload> {
+    parse_payload_with_tools(stdin, CLAUDE_PRETOOLUSE_TOOLS)
+}
+
+pub fn parse_payload_with_tools(stdin: &str, accepted_tools: &[&str]) -> Option<HookPayload> {
     let value: Value = serde_json::from_str(stdin.trim()).ok()?;
     let object = value.as_object()?;
     let tool_name = string_field(&value, &["tool_name", "toolName"])?;
-    if !matches!(tool_name, "Edit" | "Write" | "Read") {
+    if !tool_name_allowed(tool_name, accepted_tools) {
         return None;
     }
 
@@ -31,17 +49,81 @@ pub fn parse_payload(stdin: &str) -> Option<HookPayload> {
         .or_else(|| object.get("toolInput"))
         .and_then(Value::as_object);
     let target_path = tool_input
-        .and_then(|input| {
-            ["file_path", "filePath", "path"]
-                .iter()
-                .find_map(|key| input.get(*key).and_then(trimmed_string))
+        .and_then(first_path_in_object)
+        .or_else(|| first_path_in_value(&value))
+        .or_else(|| {
+            tool_input
+                .and_then(|input| {
+                    ["patch", "diff"]
+                        .iter()
+                        .find_map(|key| input.get(*key).and_then(trimmed_string))
+                })
+                .and_then(path_from_patch)
         })
-        .or_else(|| string_field(&value, &["file_path", "filePath", "path"]))?;
+        .or_else(|| {
+            tool_input
+                .and_then(|input| {
+                    ["command", "cmd"]
+                        .iter()
+                        .find_map(|key| input.get(*key).and_then(trimmed_string))
+                })
+                .and_then(path_from_shell_command)
+        })?;
 
     Some(HookPayload {
         tool_name: tool_name.to_string(),
         target_path: target_path.to_string(),
     })
+}
+
+fn tool_name_allowed(tool_name: &str, accepted_tools: &[&str]) -> bool {
+    accepted_tools.iter().any(|accepted| {
+        tool_name == *accepted
+            || (*accepted == "mcp" && tool_name.starts_with("mcp__"))
+            || (*accepted == "mcp" && tool_name.starts_with("mcp."))
+    })
+}
+
+fn first_path_in_value(value: &Value) -> Option<&str> {
+    let object = value.as_object()?;
+    first_path_in_object(object)
+}
+
+fn first_path_in_object(object: &serde_json::Map<String, Value>) -> Option<&str> {
+    const STRING_KEYS: &[&str] = &[
+        "file_path",
+        "filePath",
+        "path",
+        "absolute_file_path",
+        "absoluteFilePath",
+        "fileName",
+        "filename",
+        "name",
+    ];
+    const ARRAY_KEYS: &[&str] = &[
+        "file_paths",
+        "filePaths",
+        "paths",
+        "files",
+        "fileNames",
+        "filenames",
+        "absolute_file_paths",
+        "absoluteFilePaths",
+    ];
+
+    STRING_KEYS
+        .iter()
+        .find_map(|key| object.get(*key).and_then(trimmed_string))
+        .or_else(|| {
+            ARRAY_KEYS.iter().find_map(|key| {
+                object
+                    .get(*key)
+                    .and_then(Value::as_array)
+                    .into_iter()
+                    .flatten()
+                    .find_map(trimmed_string)
+            })
+        })
 }
 
 fn string_field<'a>(value: &'a Value, names: &[&str]) -> Option<&'a str> {
@@ -55,6 +137,49 @@ fn trimmed_string(value: &Value) -> Option<&str> {
         .as_str()
         .map(str::trim)
         .filter(|value| !value.is_empty())
+}
+
+fn path_from_patch(patch: &str) -> Option<&str> {
+    patch.lines().find_map(|line| {
+        let line = line.trim();
+        [
+            "*** Update File: ",
+            "*** Add File: ",
+            "*** Delete File: ",
+            "*** Move to: ",
+        ]
+        .iter()
+        .find_map(|prefix| line.strip_prefix(prefix).map(str::trim))
+        .filter(|value| !value.is_empty())
+    })
+}
+
+fn path_from_shell_command(command: &str) -> Option<&str> {
+    command
+        .split_whitespace()
+        .map(|token| {
+            token.trim_matches(|ch: char| {
+                matches!(
+                    ch,
+                    '"' | '\'' | '`' | ',' | ';' | ':' | '(' | ')' | '[' | ']' | '{' | '}'
+                )
+            })
+        })
+        .filter(|token| !token.is_empty())
+        .find(|token| looks_like_path(token))
+}
+
+fn looks_like_path(token: &str) -> bool {
+    if token.starts_with('-') || matches!(token, "|" | ">" | "<" | "&&" | "||") {
+        return false;
+    }
+    token.contains('/')
+        || token.starts_with('.')
+        || [
+            ".rs", ".toml", ".json", ".md", ".yaml", ".yml", ".txt", ".sh", ".py",
+        ]
+        .iter()
+        .any(|suffix| token.ends_with(suffix))
 }
 
 pub fn caps_from_env() -> LearningInjectionCaps {
@@ -184,6 +309,32 @@ mod tests {
         assert!(parse_payload(r#"{"tool_name":"Bash","path":"src/lib.rs"}"#).is_none());
         assert!(parse_payload(r#"{"tool_name":"Edit","path":"   "}"#).is_none());
         assert!(parse_payload(r#"{"tool_name":"Edit"}"#).is_none());
+    }
+
+    #[test]
+    fn parse_payload_with_tools_accepts_codex_path_shapes() {
+        let bash = parse_payload_with_tools(
+            r#"{"tool_name":"Bash","tool_input":{"command":"sed -n '1,20p' crates/orbit-core/src/lib.rs"}}"#,
+            CODEX_PRETOOLUSE_TOOLS,
+        )
+        .expect("bash payload");
+        assert_eq!(bash.tool_name, "Bash");
+        assert_eq!(bash.target_path, "crates/orbit-core/src/lib.rs");
+
+        let patch = parse_payload_with_tools(
+            r#"{"tool_name":"apply_patch","tool_input":{"patch":"*** Begin Patch\n*** Update File: crates/orbit-cli/src/main.rs\n@@\n*** End Patch\n"}}"#,
+            CODEX_PRETOOLUSE_TOOLS,
+        )
+        .expect("patch payload");
+        assert_eq!(patch.tool_name, "apply_patch");
+        assert_eq!(patch.target_path, "crates/orbit-cli/src/main.rs");
+
+        let mcp = parse_payload_with_tools(
+            r#"{"tool_name":"mcp__plugin_orbit__fs_read","tool_input":{"filePaths":["README.md","Cargo.toml"]}}"#,
+            CODEX_PRETOOLUSE_TOOLS,
+        )
+        .expect("mcp payload");
+        assert_eq!(mcp.target_path, "README.md");
     }
 
     #[test]


### PR DESCRIPTION
## Task

[ORB-00162](https://orbit-cli.com/tasks/ORB-00162) — Install PreToolUse learning-injection hooks for Claude/Codex/Gemini/Grok on `orbit workspace init`

### Description

## Problem

ORB-00160 ported the Claude PreToolUse learning-injection hook to a `orbit hook pretooluse` subcommand and replaced `.claude/hooks/orbit-learning-reminder` with a 3-line shim. That work explicitly scoped out the *installer* — the shim file and the `.claude/settings.json` `hooks` block are still hand-rolled artifacts that have to be copy-pasted into each new workspace, and only Claude is covered.

Three structural gaps remain:

1. **No installer.** `orbit workspace init` already auto-detects MCP providers (`--mcp` flag → `mcp::init_auto_for_workspace`) and seeds `.claude/settings.json`, `.codex/config.toml`, `.gemini/settings.json`, `.grok/config.toml` with the orbit MCP server. The PreToolUse hook gets no equivalent treatment. New contributors have to know the hook exists and wire it manually.

2. **Codex still runs the 116-line python script.** `.codex/hooks/orbit-learning-reminder` is a parallel implementation of what ORB-00160 just deleted on the Claude side — same `fcntl`-only locking, same python3 dependency, same audit-free behavior. L20260519-1 documents that Codex specifically needs JSON `hookSpecificOutput.additionalContext` output, *not* the plaintext stdout block Claude renders. So porting it isn't just "point the shim at the same subcommand" — the subcommand needs format dispatch.

3. **Gemini and Grok have no hook surface seeded at all.** Their workspace configs today only contain MCP server entries. Whether their CLIs expose PreToolUse-equivalent events, and what config schema and output format they expect, is unverified.

## Why It Matters

The PreToolUse hook is currently the most reliable surface for surfacing project learnings (triggers on actual file access, not declared task metadata). Without an installer:

- The hook silently no-ops for every contributor who hasn't manually copied the wiring. The audit-trail evidence we built in ORB-00160 (`learning_injected` events, `--kind` filter) is unfalsifiable across contributors because we can't tell "no events emitted because nothing matched" from "no events emitted because the hook was never installed."
- The codex hook surface is a regression risk: every future change to `orbit hook pretooluse` invariants (state shape, env vars, fail-open behavior) has to be mirrored into the python script by hand. The next divergence is one PR away.
- Gemini/Grok are de facto unsupported even though they show up in MCP-installer parity tests, undermining the multi-CLI story.

## Approach

Two coordinated pieces:

1. **Extend `orbit hook pretooluse` with format dispatch.** Add a way to render the matched-learnings block in each agent CLI's expected format. Claude (current) emits the plaintext `<system-reminder>` block to stdout. Codex emits a JSON object with `hookSpecificOutput.hookEventName = "PreToolUse"` and `additionalContext: "<block>"` (per L20260519-1). Gemini/Grok formats TBD by planner — see open questions. All formats share the same matching, dedup, audit, and fail-open logic from ORB-00160.

2. **Add a hook installer to `orbit workspace init`.** Mirror the existing `--mcp` flag mechanically: a `--hooks` flag, auto-detection by agent-dir presence (`.claude/`, `.codex/`, `.gemini/`, `.grok/`), per-agent functions that (a) write the per-agent shim into the right `hooks/` subdir and (b) merge the hook-wiring entry into the agent's settings/config file without clobbering user customization. The installer is fully idempotent — re-running `orbit workspace init --hooks` on an already-installed workspace is a no-op.

The shim file format stays the 3-line POSIX `exec` shape from ORB-00160. Each agent's shim differs only in the `--format` argument it passes (and the agent-specific path it lives at).

## Constraints / Notes

- **Reuse the `--mcp` installer's scaffolding.** [crates/orbit-cli/src/command/mcp/mod.rs](crates/orbit-cli/src/command/mcp/mod.rs) `init_auto_for_workspace` is the precedent — same detection logic (dir presence), same idempotency contract, same "return list of providers seeded" return shape. Don't invent a parallel pattern; extend or generalize.
- **No clobber.** If the user already has a `PreToolUse` hooks array in `.claude/settings.json`, our entry must merge in (or be skipped if already present), not replace. Same for `.codex/config.toml` and the other configs. The codex L20260519-1 learning notes "Keep matcher config in repo `.codex/config.toml` and prefer git-root command paths because Codex can start from subdirectories" — so paths in the config must be repo-root-relative or absolute, not cwd-relative.
- **Codex output format is load-bearing.** L20260519-1 was authored by ORB-00159 specifically to capture that codex's PreToolUse hook ignores plaintext stdout and requires JSON `hookSpecificOutput.additionalContext`. The `--format codex` rendering must match that contract, verified by a test that parses the subcommand's stdout as JSON.
- **Gemini/Grok hook formats are unverified.** Today their workspace configs only carry MCP entries; whether the CLIs even fire PreToolUse-equivalent events is an open question. The planner should resolve before scoping (see Open Questions below). If unsupported, this task ships a stub or skips them with a documented exit; doesn't invent a phantom format.
- **Workspace lints apply** (per [CLAUDE.md](CLAUDE.md) §Rust Practices) — no `unwrap_used`/`expect_used` outside scoped allowlists, no `print_stdout`/`print_stderr` in non-CLI paths, no `await_holding_lock`.
- **Tests must mirror the existing `workspace_init_seeds_auto_detected_mcp_configs` shape.** That test (in [crates/orbit-cli/src/command/environment/workspace.rs](crates/orbit-cli/src/command/environment/workspace.rs)) is the precedent for asserting per-agent artifact presence after init. The hook installer needs an analogous test for each agent it claims to support.
- **Audit-trail coverage extends to all four agents.** Each agent's hook, once installed, must emit `learning_injected` audit events with the same field shape ORB-00160 established. The `--kind learning_injected --json` query should not need agent-specific filters to find a codex injection.
- **Fail-open at every layer.** Installer failures during `workspace init` should warn but not abort the init. Hook shim execution failures (already covered by ORB-00160) continue to exit 0.

## Open Questions (planner to resolve before backlog)

1. **Gemini/Grok hook surfaces.** Do their CLIs expose PreToolUse-equivalent events today? If yes, what's the config schema and output format? If no, does this task install a script that no-ops for them, or explicitly skip them with documentation? Verifying via each CLI's docs is in scope of planning.
2. **Flag shape.** `--hooks` parallel to `--mcp`? Bundle into a combined `--integrations` flag? Auto-on with workspace init (no flag)? The `--mcp` precedent argues for parallel opt-in.
3. **Subcommand format dispatch.** Add `--format claude|codex|gemini|grok` to `orbit hook pretooluse` (one subcommand, branching renderer), or sibling subcommands (`pretooluse-codex`, etc., shared core)? The matching/dedup/audit logic is identical across all four — argues for `--format`.
4. **Audit `tool_name` field for non-Claude agents.** Claude payloads use `Edit|Write|Read`. Codex uses `Bash|apply_patch|MCP-style paths` per L20260519-1. The audit event's `tool_name` should record whatever each agent surfaces — but the planner should confirm the normalization story (do we keep agent-native names, or normalize to a canonical set?).
5. **Teardown reversal.** Should `orbit workspace teardown` remove the installed hook shims and de-merge the settings entries? Or is teardown's existing "remove all orbit artifacts" scope sufficient? Likely yes-and-yes; planner to verify.

## Out of Scope

- New `orbit hooks install` / `orbit hooks uninstall` top-level commands. Installation rides on `orbit workspace init`; uninstall rides on `workspace teardown`. Standalone hook lifecycle commands are a follow-up if needed.
- Hook events beyond PreToolUse (PostToolUse, SessionStart, etc.). Only the learning-reminder PreToolUse surface is in scope.
- MCP-surface auto-injection of learnings. Separate design thread.
- Telemetry dashboards consuming `learning_injected` events. Follow-up.
- Removal of the existing `.codex/hooks/orbit-learning-reminder` python script — that's part of this task (replaced by the shim) but flagged here to be explicit: don't leave the legacy python script behind.

### Acceptance Criteria

- `orbit workspace init --hooks` (or whatever flag shape the planner selects) auto-detects which of `.claude/`, `.codex/`, `.gemini/`, `.grok/` are present and seeds the PreToolUse learning hook for each. Verified by a test mirroring `workspace_init_seeds_auto_detected_mcp_configs` that asserts the per-agent shim file exists and the per-agent settings file has the hook entry.
- `orbit hook pretooluse` supports per-agent output format dispatch. Given the same matching payload, the subcommand renders the Claude plaintext block when invoked with the Claude format and the Codex JSON `hookSpecificOutput.additionalContext` envelope when invoked with the Codex format (verified by snapshot tests for each format). Gemini and Grok format rendering is either implemented and snapshotted, or explicitly stubbed with a comment citing the planner's open-question resolution.
- Idempotent install: running `orbit workspace init --hooks` twice on the same workspace produces no duplicate entries in any of the four agent settings/config files. Verified by a test that runs init twice and parses the resulting JSON/TOML.
- Existing user customization in `.claude/settings.json` (and the equivalent codex/gemini/grok files) is preserved across install — additional hook entries the user has authored are not removed, and our entry is added alongside (or skipped if already present). Verified by a test that pre-populates the settings file with an unrelated hook and asserts both entries are present after init.
- `.codex/hooks/orbit-learning-reminder` is replaced with the same 3-line POSIX `exec` shim shape used for Claude (just pointing at the codex format flag). `grep -c python3 .codex/hooks/orbit-learning-reminder` returns 0. The legacy 116-line python script is removed.
- Each successful injection from each installed agent emits a `learning_injected` audit event queryable via `orbit audit list --kind learning_injected --json` — same field shape as ORB-00160 (`session_id`, `learning_ids`, `tool_name`, `target_path` populated by the agent's actual payload), with the agent identity inferable from at least one field (planner picks the field). Verified by an integration test per agent that the subcommand can be exercised for.
- Failures during hook install do not abort `orbit workspace init`. If, e.g., `.claude/settings.json` is malformed and unparseable, the installer logs a warning and continues with the remaining agents. Verified by a test that places malformed JSON at the path and asserts init still returns Ok with the other agents seeded.
- `orbit workspace teardown` removes the installed shim files and de-merges the hook entries from each agent's settings file, leaving any user-authored entries intact. Verified by a test that installs, then tears down, then asserts only user entries remain.
- `make ci-fast` passes. PR CI's `make ci` is the canonical merge gate per `CLAUDE.md`.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Added `orbit hook pretooluse --format claude|codex|gemini|grok`, with Codex/Gemini JSON envelopes, Grok sharing the Claude plaintext renderer, and widened Codex/Gemini payload path extraction for shell, patch, and MCP-style payloads.
- Added `orbit workspace init --hooks` and workspace teardown hook de-merge support. The installer auto-detects `.claude/`, `.codex/`, `.gemini/`, and `.grok/`, writes per-agent POSIX shims, merges settings/config entries idempotently, preserves user hook entries, and fails open per agent.
- Replaced the tracked Codex hook with a three-line shim and added Codex hook TOML wiring. Added focused integration coverage for install/idempotency/preservation/fail-open/teardown and renderer/audit behavior.
- Added learning `L20260519-2` for the `.codex/` gitignore gotcha discovered while tracking the new shim.

Assessment: The hook lifecycle is now CLI-owned and tested across the four agent surfaces in scope, with `make ci-fast` passing.

Validation:
- cargo test -p orbit-core command::learning_hook --lib
- cargo test -p orbit-cli --test hook_pretooluse
- cargo test -p orbit-cli --test hook_install
- cargo test -p orbit-cli cli_parses_hook_pretooluse
- cargo test -p orbit-cli command::hook::render::tests
- cargo clippy -p orbit-cli -p orbit-core --all-targets -- -D warnings
- grep -c python3 .codex/hooks/orbit-learning-reminder || true (0)
- make ci-fast

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-00162-6a0be815`
- Behind base: 0
- Ahead of base: 1