### PR TITLE
Track Gemini learning hook shim for job worktrees

### DIFF
--- a/.gemini/hooks/orbit-learning-reminder
+++ b/.gemini/hooks/orbit-learning-reminder
@@ -1,0 +1,3 @@
+#!/bin/sh
+# Orbit project-learning PreToolUse hook.
+exec "${ORBIT_BIN:-orbit}" hook pretooluse --format gemini "$@"

--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,12 @@ agentspace
 !.codex/hooks/
 .codex/hooks/*
 !.codex/hooks/orbit-learning-reminder
+!.gemini/
+.gemini/*
 !.gemini/settings.json
+!.gemini/hooks/
+.gemini/hooks/*
+!.gemini/hooks/orbit-learning-reminder
 !.grok/
 !.grok/config.toml
 !.grok/hooks/


### PR DESCRIPTION
## Task

[ORB-00171](https://orbit-cli.com/tasks/ORB-00171) — Track Gemini learning hook shim for job worktrees

### Description

## Problem
`jrun-20260519-0629-5` failed before implementing `ORB-00170` because the all-gemini task pipeline worktree contained tracked `.gemini/settings.json`, which configures the BeforeTool hook command `.gemini/hooks/orbit-learning-reminder`, but did not contain the hook script. In the root workspace the script exists locally, but `.gitignore` ignores `.gemini/` and only unignores `.gemini/settings.json`.

As a result, Gemini blocked every tool call with `HOOK_EXECUTION_BLOCKED` / `No such file or directory`, then returned a failed envelope despite process exit code 0. The parent gate run `jrun-20260519-0629-2` only failed as downstream fallout.

## Why It Matters
Any Orbit job worktree that uses the tracked Gemini hook config without the hook script can fail before an agent can inspect files, run commands, or implement the task. This breaks the task PR pipeline for all-gemini crews and leaves unrelated tasks stuck in progress.

## Constraints / Notes
- Resolve friction report `F2026-05-035` through this task lifecycle.
- Mirror the narrow tracked-hook pattern already used for Codex/Grok so local Gemini state remains ignored.
- Preserve executable hook permissions for the tracked shim.
- Verify from a clean worktree or job-worktree-like checkout, not only the current root workspace where the ignored hook already exists locally.

### Acceptance Criteria

- `.gitignore` narrowly unignores the Gemini hook directory and `.gemini/hooks/orbit-learning-reminder` while continuing to ignore unrelated `.gemini/` local state; verify with `git check-ignore -v` or equivalent evidence in the execution summary.
- `.gemini/hooks/orbit-learning-reminder` is tracked by Git, executable, and invokes `orbit hook pretooluse --format gemini`; verify with `git ls-files --stage .gemini/hooks/orbit-learning-reminder` and a file inspection.
- A fresh worktree or job-worktree-like checkout from the branch contains both `.gemini/settings.json` and `.gemini/hooks/orbit-learning-reminder`; running the hook path directly does not fail with `No such file or directory`.
- The fix does not expose unrelated Gemini local files; include evidence from `git status --ignored .gemini` or an equivalent ignored-file check.
- Task relations include `resolves -> F2026-05-035`, and `orbit.task.lint` reports no findings for this task.
- `make ci-fast` passes.

## Execution Summary

<details>
<summary>Click to expand</summary>

Tracked Gemini PreToolUse learning hook shim (mirrors Codex narrow unignore).

Changes:
- .gitignore: added narrow !.gemini/ + .gemini/* + hooks dir/file exceptions (Codex pattern); only settings.json + orbit-learning-reminder are unignored under .gemini/; all other local Gemini state stays ignored.
- Added .gemini/hooks/orbit-learning-reminder (100755, tracked) with `exec ... orbit hook pretooluse --format gemini`

Verifications performed:
- `git ls-files --stage .gemini/hooks/orbit-learning-reminder`: 100755 ... (executable)
- `git check-ignore -v`: allowed paths emit no output; unrelated .gemini/* and .gemini/hooks/* are ignored (e.g. matched by .gitignore:19:.gemini/* and :22:.gemini/hooks/*)
- `git status --ignored .gemini` (with demo local files): locals listed under Ignored files; hook not (would be committed)
- Fresh worktree sim (`git checkout-index` into /tmp/...): both .gemini/settings.json + hook present; `/.gemini/hooks/orbit-learning-reminder` runs (errors on missing `orbit` in PATH, exit 127; no "No such file or directory" for hook itself)
- `orbit task lint ORB-00171`: "No lint findings for 'ORB-00171'"
- `make ci-fast`: exit 0 (fmt-check + all guardrails passed)
- Hook invokes correct `--format gemini`; relations already include resolves -> F2026-05-035

Diff:
```diff
diff --git a/.gemini/hooks/orbit-learning-reminder b/.gemini/hooks/orbit-learning-reminder
new file mode 100755
index 00000000..9b324668
--- /dev/null
+++ b/.gemini/hooks/orbit-learning-reminder
@@ -0,0 +1,3 @@
+#!/bin/sh
+# Orbit project-learning PreToolUse hook.
+exec "${ORBIT_BIN:-orbit}" hook pretooluse --format gemini "$@"
diff --git a/.gitignore b/.gitignore
index 0d9bb872..e66448d1 100644
--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,12 @@ agentspace
 !.codex/hooks/
 .codex/hooks/*
 !.codex/hooks/orbit-learning-reminder
+!.gemini/
+.gemini/*
 !.gemini/settings.json
+!.gemini/hooks/
+.gemini/hooks/*
+!.gemini/hooks/orbit-learning-reminder
 !.grok/
 !.grok/config.toml
 !.grok/hooks/
```

All ACs satisfied. No scope drift; only edited .gitignore (context) and added the required hook shim under mentioned .gemini/.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-00171-6a0c0a02`
- Behind base: 0
- Ahead of base: 1

*authored by: grok*