### PR TITLE
Wire `orbit docs` retrieval into `task.show --with-context` and `task.start`

### DIFF
--- a/crates/orbit-cli/src/command/task/show.rs
+++ b/crates/orbit-cli/src/command/task/show.rs
@@ -1,5 +1,6 @@
 use clap::Args;
-use orbit_core::{OrbitError, OrbitRuntime, build_task_status_index};
+use orbit_core::{OrbitError, OrbitRuntime, TaskRelatedDoc, build_task_status_index};
+use serde_json::Value;
 
 use crate::command::Execute;
 
@@ -19,6 +20,12 @@ pub struct TaskShowArgs {
     /// a single field returns that field as JSON and multiple fields return a JSON object.
     #[arg(long = "fields", alias = "field", value_delimiter = ',', num_args = 1..)]
     pub fields: Vec<String>,
+    /// Include docs matched from task context files and task feature tags
+    #[arg(long)]
+    pub with_context: bool,
+    /// Maximum related docs to include with --with-context (default 5)
+    #[arg(long)]
+    pub max_docs: Option<usize>,
 }
 
 impl Execute for TaskShowArgs {
@@ -28,6 +35,11 @@ impl Execute for TaskShowArgs {
         let fields = normalize_task_show_fields(&self.fields)?;
 
         if !fields.is_empty() {
+            if self.with_context {
+                return Err(OrbitError::InvalidInput(
+                    "`--with-context` cannot be combined with `--fields`".to_string(),
+                ));
+            }
             if self.json {
                 return crate::output::json::print_pretty(&task_fields_to_json(
                     runtime,
@@ -39,8 +51,17 @@ impl Execute for TaskShowArgs {
             return print_task_fields(runtime, &task, &fields, Some(&status_by_id));
         }
 
+        let related_docs = if self.with_context {
+            runtime.related_docs_for_task(&task, self.max_docs)?
+        } else {
+            Vec::new()
+        };
         if self.json {
-            crate::output::json::print_pretty(&task_to_json_for_runtime(runtime, &task)?)
+            let mut value = task_to_json_for_runtime(runtime, &task)?;
+            if self.with_context {
+                insert_related_docs(&mut value, related_docs)?;
+            }
+            crate::output::json::print_pretty(&value)
         } else {
             use crate::output::color::{bold, dimmed, priority_color, status_color};
             println!("{} {}", bold("ID:"), task.id);
@@ -111,6 +132,9 @@ impl Execute for TaskShowArgs {
             if !task.context_files.is_empty() {
                 println!("{} {}", bold("Context:"), task.context_files.join(", "));
             }
+            if self.with_context && !related_docs.is_empty() {
+                print_related_docs(&related_docs);
+            }
             if let Some(ref created_by) = task.created_by {
                 println!("{} {}", bold("Created By:"), created_by);
             }
@@ -161,6 +185,40 @@ impl Execute for TaskShowArgs {
             Ok(())
         }
     }
+}
+
+fn insert_related_docs(
+    value: &mut Value,
+    related_docs: Vec<TaskRelatedDoc>,
+) -> Result<(), OrbitError> {
+    let object = value.as_object_mut().ok_or_else(|| {
+        OrbitError::Execution("task JSON projection did not produce an object".to_string())
+    })?;
+    object.insert(
+        "related_docs".to_string(),
+        serde_json::to_value(related_docs).map_err(|error| {
+            OrbitError::Execution(format!("serialize related docs output: {error}"))
+        })?,
+    );
+    Ok(())
+}
+
+fn print_related_docs(related_docs: &[TaskRelatedDoc]) {
+    use crate::output::color::bold;
+    use comfy_table::Cell;
+
+    println!();
+    println!("{}", bold("Related Docs:"));
+    let mut table = crate::output::table::build_table(&["PATH", "TYPE", "SUMMARY", "EXCERPT"]);
+    for doc in related_docs {
+        table.add_row(vec![
+            Cell::new(&doc.path),
+            Cell::new(doc.doc_type.to_string()),
+            Cell::new(&doc.summary),
+            Cell::new(&doc.excerpt),
+        ]);
+    }
+    println!("{table}");
 }
 
 fn normalize_task_show_fields(fields: &[String]) -> Result<Vec<String>, OrbitError> {

--- a/crates/orbit-cli/tests/docs.rs
+++ b/crates/orbit-cli/tests/docs.rs
@@ -71,6 +71,93 @@ fn cli_docs_add_is_idempotent_and_rejects_dot_orbit() {
 }
 
 #[test]
+fn cli_task_show_with_context_includes_related_docs_json() {
+    let workspace = TestWorkspace::new();
+    workspace.write("crates/orbit-cli/src/command/docs.rs", "// fixture\n");
+    workspace.write(
+        "docs/cli.md",
+        "---\ntype: design\nsummary: CLI docs command design\npaths: [\"crates/orbit-cli/**\"]\n---\n# CLI Docs\n\nBody\n",
+    );
+
+    let task = workspace.run_json(
+        &[
+            "task",
+            "add",
+            "--title",
+            "Wire docs",
+            "--description",
+            "Exercise docs context injection.",
+            "--context",
+            "file:crates/orbit-cli/src/command/docs.rs",
+            "--json",
+        ],
+        "task add",
+    );
+    let task_id = task["id"].as_str().expect("task id");
+
+    let shown = workspace.run_json(
+        &[
+            "task",
+            "show",
+            task_id,
+            "--with-context",
+            "--max-docs",
+            "1",
+            "--json",
+        ],
+        "task show with context",
+    );
+    assert_eq!(
+        shown["related_docs"],
+        json!([
+            {
+                "path": "docs/cli.md",
+                "type": "design",
+                "summary": "CLI docs command design",
+                "excerpt": "CLI Docs",
+                "matched_by": ["path:crates/orbit-cli/**"]
+            }
+        ])
+    );
+
+    let plain = workspace.run_json(&["task", "show", task_id, "--json"], "task show");
+    assert!(plain.get("related_docs").is_none());
+}
+
+#[test]
+fn cli_task_show_with_context_returns_empty_docs_when_roots_are_empty() {
+    let workspace = TestWorkspace::new();
+    workspace.write(".orbit/config.toml", "[docs]\nroots = []\n");
+    workspace.write("crates/orbit-cli/src/command/docs.rs", "// fixture\n");
+    workspace.write(
+        "docs/cli.md",
+        "---\ntype: design\nsummary: CLI docs command design\npaths: [\"crates/orbit-cli/**\"]\n---\n# CLI Docs\n",
+    );
+    let task = workspace.run_json(
+        &[
+            "task",
+            "add",
+            "--title",
+            "No roots",
+            "--description",
+            "Exercise empty docs roots.",
+            "--context",
+            "file:crates/orbit-cli/src/command/docs.rs",
+            "--json",
+        ],
+        "task add",
+    );
+    let task_id = task["id"].as_str().expect("task id");
+
+    let shown = workspace.run_json(
+        &["task", "show", task_id, "--with-context", "--json"],
+        "task show with context",
+    );
+
+    assert_eq!(shown["related_docs"], json!([]));
+}
+
+#[test]
 fn mcp_docs_tools_are_listed_and_callable_through_tool_run() {
     let workspace = TestWorkspace::new();
     workspace.write(

--- a/crates/orbit-cli/tests/tool_list.rs
+++ b/crates/orbit-cli/tests/tool_list.rs
@@ -68,6 +68,46 @@ fn tool_list_json_includes_parameter_schema() {
 }
 
 #[test]
+fn tool_list_json_includes_task_show_context_parameters() {
+    let temp = tempdir().expect("tempdir");
+    let home = temp.path().join("home");
+    let work = temp.path().join("work");
+    std::fs::create_dir_all(&home).expect("create home");
+    std::fs::create_dir_all(&work).expect("create work");
+
+    let output = cargo_bin_cmd!("orbit")
+        .current_dir(&work)
+        .env("HOME", &home)
+        .env("USERPROFILE", &home)
+        .env_remove("ORBIT_ROOT")
+        .args(["tool", "list", "--json"])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+
+    let tools: Vec<serde_json::Value> = serde_json::from_slice(&output).expect("tool list JSON");
+    let task_show = tools
+        .iter()
+        .find(|tool| tool["name"] == "orbit.task.show")
+        .expect("task show tool");
+    let parameters = task_show["parameters"]
+        .as_array()
+        .expect("parameters array");
+    assert!(parameters.iter().any(|param| {
+        param["name"] == "with_context"
+            && param["param_type"] == "boolean"
+            && param["required"] == false
+    }));
+    assert!(parameters.iter().any(|param| {
+        param["name"] == "max_docs"
+            && param["param_type"] == "integer"
+            && param["required"] == false
+    }));
+}
+
+#[test]
 fn tool_show_displays_lock_reservation_shapes() {
     let temp = tempdir().expect("tempdir");
     let home = temp.path().join("home");

--- a/crates/orbit-core/src/command/docs.rs
+++ b/crates/orbit-core/src/command/docs.rs
@@ -1,4 +1,4 @@
-use std::collections::HashSet;
+use std::collections::{BTreeMap, BTreeSet, HashSet};
 use std::fmt;
 use std::fs;
 use std::io::Write;
@@ -6,7 +6,9 @@ use std::path::{Component, Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::str::FromStr;
 
-use orbit_common::types::OrbitError;
+use orbit_common::types::{OrbitError, Task};
+use orbit_common::utility::glob::{match_glob, normalize_glob_path};
+use orbit_common::utility::selector::anchor_path;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use serde_json::json;
 
@@ -14,6 +16,7 @@ use crate::OrbitRuntime;
 
 const DEFAULT_DOC_ROOT: &str = "docs/";
 const DOC_TYPES: &[&str] = &["design", "pattern", "context", "glossary", "runbook"];
+const DEFAULT_RELATED_DOC_LIMIT: usize = 5;
 
 #[cfg(test)]
 thread_local! {
@@ -165,6 +168,23 @@ pub struct DocSearchResult {
     pub matched_by: Vec<String>,
 }
 
+/// Related-doc projection emitted by `task show --with-context`.
+///
+/// JSON schema:
+/// `{"path": string, "type": string, "summary": string, "excerpt": string, "matched_by": string[]}`.
+/// The `type` value is one of `design`, `pattern`, `context`, `glossary`, or
+/// `runbook`. `matched_by` contains stable `path:<glob>` and `feature:<slug>`
+/// markers explaining why the doc was selected.
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct TaskRelatedDoc {
+    pub path: String,
+    #[serde(rename = "type")]
+    pub doc_type: DocType,
+    pub summary: String,
+    pub excerpt: String,
+    pub matched_by: Vec<String>,
+}
+
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 pub struct DocAddOutcome {
     pub path: String,
@@ -281,6 +301,27 @@ impl OrbitRuntime {
         Ok(scored)
     }
 
+    pub fn related_docs_for_task(
+        &self,
+        task: &Task,
+        limit: Option<usize>,
+    ) -> Result<Vec<TaskRelatedDoc>, OrbitError> {
+        let roots = read_task_context_docs_roots_from_config_path(&self.config_path())?;
+        if roots.is_empty() {
+            return Ok(Vec::new());
+        }
+        // Tasks do not yet have a first-class `related_features` field, so the
+        // agent-facing feature join uses normalized task tags as the feature
+        // selectors until that storage field exists.
+        related_docs_for_context(
+            &self.paths().repo_root,
+            &roots,
+            &task.context_files,
+            &task.tags,
+            limit,
+        )
+    }
+
     pub fn add_docs_root(&self, path: &str) -> Result<DocAddOutcome, OrbitError> {
         add_docs_root(&self.paths().repo_root, &self.config_path(), path)
     }
@@ -314,6 +355,28 @@ fn read_docs_roots_from_config_path(path: &Path) -> Result<Vec<String>, OrbitErr
     let raw = fs::read_to_string(path)
         .map_err(|error| OrbitError::Io(format!("read {}: {error}", path.display())))?;
     parse_docs_roots_from_config_toml(&raw)
+}
+
+fn read_task_context_docs_roots_from_config_path(path: &Path) -> Result<Vec<String>, OrbitError> {
+    if !path.exists() {
+        return Ok(default_doc_roots());
+    }
+    let raw = fs::read_to_string(path)
+        .map_err(|error| OrbitError::Io(format!("read {}: {error}", path.display())))?;
+    parse_task_context_docs_roots_from_config_toml(&raw)
+}
+
+fn parse_task_context_docs_roots_from_config_toml(raw: &str) -> Result<Vec<String>, OrbitError> {
+    if raw.trim().is_empty() {
+        return Ok(default_doc_roots());
+    }
+    let parsed = toml::from_str::<DocsConfigFile>(raw).map_err(|error| {
+        OrbitError::InvalidInput(format!("invalid docs config in config.toml: {error}"))
+    })?;
+    Ok(match parsed.docs {
+        Some(section) => section.roots.unwrap_or_default(),
+        None => default_doc_roots(),
+    })
 }
 
 fn default_doc_roots() -> Vec<String> {
@@ -807,6 +870,162 @@ fn score_doc_record(record: DocRecord, query_lower: &str) -> Option<DocSearchRes
         score,
         matched_by,
     })
+}
+
+#[derive(Debug)]
+struct RelatedDocCandidate {
+    record: DocRecord,
+    score: usize,
+    matched_by: BTreeSet<String>,
+}
+
+fn related_docs_for_context(
+    repo_root: &Path,
+    roots: &[String],
+    context_files: &[String],
+    related_features: &[String],
+    limit: Option<usize>,
+) -> Result<Vec<TaskRelatedDoc>, OrbitError> {
+    let limit = limit.unwrap_or(DEFAULT_RELATED_DOC_LIMIT);
+    if limit == 0 {
+        return Ok(Vec::new());
+    }
+
+    let context_paths = context_files
+        .iter()
+        .filter_map(|selector| context_selector_path(repo_root, selector))
+        .collect::<Vec<_>>();
+    let features = related_features
+        .iter()
+        .map(|feature| feature.trim().to_ascii_lowercase())
+        .filter(|feature| !feature.is_empty())
+        .collect::<BTreeSet<_>>();
+    if context_paths.is_empty() && features.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let mut candidates = BTreeMap::<String, RelatedDocCandidate>::new();
+    for record in walk_docs_roots(repo_root, roots)? {
+        let mut score = 0usize;
+        let mut matched_by = BTreeSet::new();
+
+        for glob in &record.frontmatter.paths {
+            let Some(normalized_glob) = normalize_doc_path_glob(glob) else {
+                continue;
+            };
+            for context_path in &context_paths {
+                if doc_path_glob_matches_context(&normalized_glob, context_path)? {
+                    score += 200 + normalized_glob.len();
+                    matched_by.insert(format!("path:{glob}"));
+                    break;
+                }
+            }
+        }
+
+        for feature in &record.frontmatter.related_features {
+            let normalized = feature.trim().to_ascii_lowercase();
+            if !normalized.is_empty() && features.contains(&normalized) {
+                score += 160 + normalized.len();
+                matched_by.insert(format!("feature:{feature}"));
+            }
+        }
+
+        if score == 0 {
+            continue;
+        }
+
+        candidates
+            .entry(record.path.clone())
+            .and_modify(|candidate| {
+                candidate.score += score;
+                candidate.matched_by.extend(matched_by.iter().cloned());
+            })
+            .or_insert(RelatedDocCandidate {
+                record,
+                score,
+                matched_by,
+            });
+    }
+
+    let mut ranked = candidates.into_values().collect::<Vec<_>>();
+    ranked.sort_by(|left, right| {
+        right
+            .score
+            .cmp(&left.score)
+            .then_with(|| left.record.path.cmp(&right.record.path))
+    });
+    ranked.truncate(limit);
+
+    ranked
+        .into_iter()
+        .map(|candidate| {
+            let shown = show_doc(repo_root, roots, &candidate.record.path)?;
+            Ok(TaskRelatedDoc {
+                path: candidate.record.path,
+                doc_type: candidate.record.frontmatter.doc_type,
+                summary: candidate.record.frontmatter.summary.clone(),
+                excerpt: doc_excerpt(&shown.body, &candidate.record.frontmatter.summary),
+                matched_by: candidate.matched_by.into_iter().collect(),
+            })
+        })
+        .collect()
+}
+
+fn context_selector_path(repo_root: &Path, selector: &str) -> Option<String> {
+    let anchor = anchor_path(selector).ok()?;
+    let relative = if anchor.is_absolute() {
+        anchor.strip_prefix(repo_root).ok()?.to_path_buf()
+    } else {
+        anchor
+    };
+    normalize_glob_path(&path_to_slash_string(&relative)).ok()
+}
+
+fn normalize_doc_path_glob(glob: &str) -> Option<String> {
+    normalize_glob_path(glob).ok()
+}
+
+fn doc_path_glob_matches_context(glob: &str, context_path: &str) -> Result<bool, OrbitError> {
+    if match_glob(glob, context_path)? {
+        return Ok(true);
+    }
+    let literal_prefix = glob.trim_end_matches('/');
+    Ok(!contains_glob_operator(literal_prefix)
+        && context_path
+            .strip_prefix(literal_prefix)
+            .is_some_and(|rest| rest.starts_with('/')))
+}
+
+fn contains_glob_operator(value: &str) -> bool {
+    value.contains('*') || value.contains('?')
+}
+
+fn doc_excerpt(body: &str, fallback: &str) -> String {
+    for line in body.lines() {
+        let trimmed = line
+            .trim()
+            .trim_start_matches('#')
+            .trim()
+            .trim_matches('`')
+            .trim();
+        if !trimmed.is_empty() && trimmed != "---" {
+            return truncate_excerpt(trimmed);
+        }
+    }
+    truncate_excerpt(fallback)
+}
+
+fn truncate_excerpt(value: &str) -> String {
+    const MAX_EXCERPT_CHARS: usize = 160;
+    let mut out = String::new();
+    for (index, ch) in value.chars().enumerate() {
+        if index == MAX_EXCERPT_CHARS {
+            out.push_str("...");
+            return out;
+        }
+        out.push(ch);
+    }
+    out
 }
 
 fn add_docs_root(
@@ -1494,6 +1713,74 @@ mod tests {
                 .unwrap(),
             vec!["docs/", "apps/*/docs/"]
         );
+    }
+
+    #[test]
+    fn task_context_docs_roots_skip_explicit_empty_or_unset_roots() {
+        assert_eq!(
+            parse_task_context_docs_roots_from_config_toml("[docs]\n").unwrap(),
+            Vec::<String>::new()
+        );
+        assert_eq!(
+            parse_task_context_docs_roots_from_config_toml("[docs]\nroots = []\n").unwrap(),
+            Vec::<String>::new()
+        );
+        assert_eq!(
+            parse_task_context_docs_roots_from_config_toml("").unwrap(),
+            vec!["docs/"]
+        );
+    }
+
+    #[test]
+    fn related_docs_match_context_files_against_doc_paths() {
+        let dir = tempdir().expect("tempdir");
+        let root = dir.path();
+        fs::create_dir_all(root.join("docs")).expect("docs dir");
+        fs::write(
+            root.join("docs/cli.md"),
+            "---\ntype: design\nsummary: CLI command design\npaths: [\"crates/orbit-cli/**\"]\n---\n# CLI Commands\n\nBody\n",
+        )
+        .expect("write doc");
+
+        let related = related_docs_for_context(
+            root,
+            &["docs/".to_string()],
+            &["file:crates/orbit-cli/src/command/docs.rs".to_string()],
+            &[],
+            Some(5),
+        )
+        .expect("related docs");
+
+        assert_eq!(related.len(), 1);
+        assert_eq!(related[0].path, "docs/cli.md");
+        assert_eq!(related[0].doc_type, DocType::Design);
+        assert_eq!(related[0].excerpt, "CLI Commands");
+        assert_eq!(related[0].matched_by, vec!["path:crates/orbit-cli/**"]);
+    }
+
+    #[test]
+    fn related_docs_match_task_features_against_doc_related_features() {
+        let dir = tempdir().expect("tempdir");
+        let root = dir.path();
+        fs::create_dir_all(root.join("docs")).expect("docs dir");
+        fs::write(
+            root.join("docs/orbit-docs.md"),
+            "---\ntype: context\nsummary: Orbit docs context\nrelated_features: [orbit-docs]\n---\nTask-time docs injection\n",
+        )
+        .expect("write doc");
+
+        let related = related_docs_for_context(
+            root,
+            &["docs/".to_string()],
+            &[],
+            &["Orbit-Docs".to_string()],
+            Some(5),
+        )
+        .expect("related docs");
+
+        assert_eq!(related.len(), 1);
+        assert_eq!(related[0].path, "docs/orbit-docs.md");
+        assert_eq!(related[0].matched_by, vec!["feature:orbit-docs"]);
     }
 
     #[test]

--- a/crates/orbit-core/src/lib.rs
+++ b/crates/orbit-core/src/lib.rs
@@ -51,7 +51,7 @@ pub use orbit_store::{
 
 pub use command::docs::{
     ArtifactRef, DocAddOutcome, DocFrontmatter, DocMigrationChange, DocMigrationReport, DocRecord,
-    DocSearchResult, DocShow, DocType,
+    DocSearchResult, DocShow, DocType, TaskRelatedDoc,
 };
 pub use command::learning::migrate_learning_layout_at;
 pub use command::task_template::TaskTemplate;

--- a/crates/orbit-core/src/runtime/orbit_tool_host/task_tools.rs
+++ b/crates/orbit-core/src/runtime/orbit_tool_host/task_tools.rs
@@ -186,11 +186,59 @@ pub(super) fn show(runtime: &OrbitRuntime, input: Value) -> Result<Value, OrbitE
     let id = required_string(&input, &["id"], "id")?;
     let task = runtime.get_task(&id)?;
     let fields = optional_csv_or_string_list_alias(&input, &["fields", "field"])?;
+    let with_context =
+        optional_bool_alias(&input, &["with_context", "withContext", "with-context"])?
+            .unwrap_or(false);
+    let max_docs = optional_usize_alias(&input, &["max_docs", "maxDocs", "max-docs"])?;
     if let Some(fields) = fields {
+        if with_context {
+            return Err(OrbitError::InvalidInput(
+                "`with_context` cannot be combined with `fields`".to_string(),
+            ));
+        }
         task_fields_to_json(runtime, &task, &fields)
+    } else if with_context {
+        let mut value = serialize_task(runtime, &task)?;
+        let object = value.as_object_mut().ok_or_else(|| {
+            OrbitError::Execution("task JSON projection did not produce an object".to_string())
+        })?;
+        object.insert(
+            "related_docs".to_string(),
+            serde_json::to_value(runtime.related_docs_for_task(&task, max_docs)?).map_err(
+                |error| OrbitError::Execution(format!("serialize related docs: {error}")),
+            )?,
+        );
+        Ok(value)
     } else {
         serialize_task(runtime, &task)
     }
+}
+
+fn optional_usize_alias(input: &Value, names: &[&str]) -> Result<Option<usize>, OrbitError> {
+    for name in names {
+        let Some(value) = input.get(*name) else {
+            continue;
+        };
+        return match value {
+            Value::Number(number) => number
+                .as_u64()
+                .ok_or_else(|| {
+                    OrbitError::InvalidInput(format!("`{name}` must be an unsigned integer"))
+                })
+                .and_then(|value| {
+                    usize::try_from(value)
+                        .map(Some)
+                        .map_err(|_| OrbitError::InvalidInput(format!("`{name}` is too large")))
+                }),
+            Value::String(raw) => raw.trim().parse::<usize>().map(Some).map_err(|error| {
+                OrbitError::InvalidInput(format!("`{name}` must be an unsigned integer: {error}"))
+            }),
+            _ => Err(OrbitError::InvalidInput(format!(
+                "`{name}` must be an unsigned integer"
+            ))),
+        };
+    }
+    Ok(None)
 }
 
 pub(super) fn start(

--- a/crates/orbit-core/src/runtime/orbit_tool_host/task_tools_tests.rs
+++ b/crates/orbit-core/src/runtime/orbit_tool_host/task_tools_tests.rs
@@ -1,3 +1,5 @@
+use std::fs;
+
 use orbit_common::types::TaskStatus;
 use serde_json::{Value, json};
 
@@ -463,6 +465,47 @@ fn task_show_tool_includes_empty_tags_array() {
         .expect("task show tool succeeds");
 
     assert_eq!(shown.get("tags"), Some(&json!([])));
+}
+
+#[test]
+fn task_show_tool_with_context_includes_related_docs() {
+    let (_root, runtime, repo_root) = test_runtime();
+    fs::create_dir_all(repo_root.join("docs")).expect("docs dir");
+    fs::write(
+        repo_root.join("docs/cli.md"),
+        "---\ntype: design\nsummary: CLI command design\npaths: [\"crates/orbit-cli/**\"]\n---\n# CLI Commands\n",
+    )
+    .expect("write doc");
+    let task = create_task(
+        &runtime,
+        &repo_root,
+        "Show related docs",
+        "Exercise MCP context injection.",
+        TaskStatus::Backlog,
+        &["file:crates/orbit-cli/src/command/docs.rs"],
+    );
+
+    let shown = runtime
+        .execute_tool_command(
+            "orbit.task.show",
+            json!({ "id": task.id, "with_context": true, "max_docs": 1 }),
+            Some("codex".to_string()),
+            Some("gpt-5.5".to_string()),
+        )
+        .expect("task show tool succeeds");
+
+    assert_eq!(
+        shown.get("related_docs"),
+        Some(&json!([
+            {
+                "path": "docs/cli.md",
+                "type": "design",
+                "summary": "CLI command design",
+                "excerpt": "CLI Commands",
+                "matched_by": ["path:crates/orbit-cli/**"]
+            }
+        ]))
+    );
 }
 
 #[test]

--- a/crates/orbit-tools/src/builtin/orbit/task/show.rs
+++ b/crates/orbit-tools/src/builtin/orbit/task/show.rs
@@ -28,6 +28,23 @@ impl Tool for OrbitTaskShowTool {
             param_type: "string".to_string(),
             required: false,
         });
+        parameters.push(ToolParam {
+            name: "with_context".to_string(),
+            description:
+                "Optional boolean. When true, include a `related_docs` array matched from task \
+                context selectors and feature tags."
+                    .to_string(),
+            param_type: "boolean".to_string(),
+            required: false,
+        });
+        parameters.push(ToolParam {
+            name: "max_docs".to_string(),
+            description:
+                "Optional cap for `related_docs` when `with_context` is true. Defaults to 5."
+                    .to_string(),
+            param_type: "integer".to_string(),
+            required: false,
+        });
         ToolSchema {
             name: "orbit.task.show".to_string(),
             description: "Fetch a single Orbit task as JSON. Use the optional `fields` projection \


### PR DESCRIPTION
## Task

[ORB-00166](https://orbit-cli.com/tasks/ORB-00166) — Wire `orbit docs` retrieval into `task.show --with-context` and `task.start`

### Description

## Problem

[ORB-00163](.orbit/tasks/ORB-00163/) shipped `orbit.docs.search` as a retrieval primitive but explicitly deferred *injection wiring*. Today an agent calling `orbit task show <id>` or `orbit task start <id>` gets task metadata, plan, acceptance criteria — but no relevant docs surfaced from the indexed corpus. The whole point of building the corpus was to let task-time surfaces inject relevant designs, patterns, and runbooks alongside the task body.

## Why It Matters

- Tasks like ORB-00163 carry a `context_files` field (e.g. `dir:crates/orbit-cli/src/command/learning`) and a `related_features` field. These are perfect join keys against doc frontmatter `paths` and `related_features` fields.
- Without injection, agents have to *know* to call `orbit docs search` manually. Most won't.
- The PreToolUse hook will eventually do the same job at every Edit/Read/Write — but that's a different injection surface (high-frequency, scoped). Task-show is the low-frequency, "load context once at the start of the task" surface.

## Approach Sketch

When `orbit task show <id> --with-context` (or `orbit task start <id>`) runs:

1. Pull the task's `context_files` selectors and `related_features` list.
2. For each `file:<path>` selector, walk to the longest common directory ancestor of the touched paths and search docs whose `paths` glob matches.
3. For each `related_features` entry, search docs whose `related_features` field contains it.
4. Score and dedupe; emit the top N (configurable, default 3-5) as a `## Related Docs` section in the `task show` output, with `path`, `type`, `summary`, and a one-line excerpt.
5. JSON variant: emit a `related_docs` array alongside the task body.

## Constraints / Notes

- This is *retrieval+rendering*, not a new corpus surface. Don't add new verbs.
- Respect the same `[docs].roots` configuration as `orbit docs list`.
- Default the cap to 5 docs to keep the output skimmable; let users override via `--max-docs N` on `task show`.
- **No injection at `task.start` for the implementer agent yet.** That's a load-bearing decision: the implementer should explicitly call `orbit task show` to load context. Wire `task show --with-context` first; we can decide later whether `task start` auto-injects into the implementer's initial prompt.
- Reuse `OrbitRuntime::search_docs` from [`crates/orbit-core/src/command/docs.rs`](crates/orbit-core/src/command/docs.rs:243); no public API changes needed in `orbit-core`.
- No new cross-crate dependency edges.

## Out of Scope

- PreToolUse hook integration (separate task — see follow-up).
- Semantic embeddings — v1 ranking is the BM25-ish tag/summary scoring already shipped.
- Auto-injection into the implementer agent's prompt at `task start`.

### Acceptance Criteria

- `orbit task show <id> --with-context` (CLI + MCP via `orbit.task.show`) returns a `related_docs` field (JSON) or `## Related Docs` section (table view) containing up to N matching docs.
- Matching uses both `context_files` → doc `paths` glob match and `related_features` → doc `related_features` set membership. Verified by unit tests for each match path.
- Default cap on returned docs is 5; override via `--max-docs N` (CLI) or `max_docs` field (MCP input). Cap is enforced after ranking.
- Empty matches return `related_docs: []` (or no section in table view), never an error.
- When `[docs].roots` is unset or empty, `--with-context` silently skips the related-docs lookup — no error.
- Existing `orbit task show <id>` (without `--with-context`) behavior is unchanged. Verified by an existing snapshot test or a new one pinning the unchanged shape.
- `task show --with-context --json` output schema is documented in the task body or in an inline doc-comment on the response struct. New consumers (downstream agents) can rely on the shape.
- `orbit.task.show` MCP tool schema includes the new `with_context` and `max_docs` parameters; both are optional. Verified by `orbit tool list --json | jq '.[] | select(.name=="orbit.task.show")'`.
- Integration test: create a task with `context_files: ["file:crates/orbit-cli/src/command/docs.rs"]`, create a doc with `paths: ["crates/orbit-cli/**"]`, run `orbit task show <id> --with-context --json`, assert the doc appears in `related_docs`.
- `make ci-fast` passes; full `make ci` is the PR-CI merge gate.
- No new cross-crate dependency edges. Verified with `cargo metadata --format-version=1 | jq` against `agent-main`.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Added `task show --with-context` / `--max-docs` support for CLI JSON and table output, emitting `related_docs` only when requested so default `task show` shape remains unchanged.
- Added core related-doc retrieval over configured docs roots with ranked/deduped matches from task `context_files` against doc `paths` globs and task feature tags against doc `related_features`, capped after ranking with default 5.
- Wired MCP `orbit.task.show` inputs `with_context` and `max_docs`, and exposed the tool schema.
- Added unit and integration coverage for path matching, feature matching, empty docs roots, unchanged default JSON shape, MCP output, and tool-list schema.

Assessment: Implementation is scoped to the task-show/docs path and validates cleanly with targeted tests plus `make ci-fast`.

Design weaknesses / risks:
- Tasks do not currently persist a first-class `related_features` field, so feature matching uses normalized task tags as the feature source for now. Severity: Low. Mitigation: documented inline in the core helper and covered by related-feature unit coverage.

Validation:
- `cargo test -p orbit-core related_docs`
- `cargo test -p orbit-core task_context_docs_roots_skip_explicit_empty_or_unset_roots`
- `cargo test -p orbit-cli --test docs cli_task_show_with_context`
- `cargo test -p orbit-cli --test tool_list task_show_context_parameters`
- `target/debug/orbit tool list --json | jq '.[] | select(.name=="orbit.task.show") | {name, parameters}'`
- `CARGO_HOME=/tmp/orbit-cargo-home-00166 cargo metadata --format-version=1 | jq '.packages[] | select(.name=="orbit-cli" or .name=="orbit-core" or .name=="orbit-tools") | {name, deps: [.dependencies[] | select(.source == null) | .name]}'`
- `git diff --check`
- `make ci-fast`

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-00166-6a0c1041`
- Behind base: 0
- Ahead of base: 1