### PR TITLE
Dashboard JS split: extract runs.js (per-domain split, round 5)

### DIFF
--- a/crates/orbit-dashboard/assets/dashboard/app.js
+++ b/crates/orbit-dashboard/assets/dashboard/app.js
@@ -3,32 +3,12 @@
 
 import { el, statusPill, stateCell, fetchJson, requestJson, postJson, patchJson, syncNodes, positiveIntParam } from './common.js';
 import { buildChips, cacheCrewPayload, copyTaskIdWithNotice, hasCrewOptions, openVisibleTask, renderTasks, wireSearch } from './tasks.js';
-import {
-  applyAuditHashQuery,
-  buildAuditChips,
-  buildAuditHash,
-  fetchAndRenderAudit,
-  fetchAndRenderPolicy,
-  getActiveAuditSubtab,
-  navigateToAuditExecution,
-  renderAuditSummary,
-  setActiveAuditSubtabFromButton,
-  setAuditSubtab,
-  syncAuditControls,
-  wireAuditSearch,
-} from './audit.js';
+import { applyAuditHashQuery, buildAuditChips, buildAuditHash, fetchAndRenderAudit, fetchAndRenderPolicy, getActiveAuditSubtab, navigateToAuditExecution, renderAuditSummary, setActiveAuditSubtabFromButton, setAuditSubtab, syncAuditControls, wireAuditSearch, } from './audit.js';
 import { renderScoreboard } from './scoreboard.js';
 import { initLogTail, fitLogPanelToViewport } from './log-tail.js';
-import {
-  renderDiagnostics,
-  renderImplementOneCard as renderImplOne,
-} from './diagnostics.js';
-import {
-  initRouter,
-  initTabs as iT,
-  navigateToRun as nTR,
-  setActiveTab as sAT,
-} from './router.js';
+import { renderDiagnostics, renderImplementOneCard as renderImplOne, } from './diagnostics.js';
+import { initRouter, initTabs as iT, navigateToRun as nTR, setActiveTab as sAT, } from './router.js';
+import { initRuns, mergeRunsWithFriction, renderRuns, runIsCancellable, buildCancelRunButton, buildReplayRunButton } from './runs.js';
 
 const STATUS_ORDER = [
   "in-progress",
@@ -51,7 +31,6 @@ const LEARNING_LIMIT = positiveIntParam("learnings", 100);
 const ADR_LIMIT = positiveIntParam("adrs", 100);
 const FRICTION_LIMIT = positiveIntParam("frictions", 100);
 
-const CANCELLABLE_RUN_STATES = new Set(["pending", "running"]);
 const FRICTION_STATUSES = ["open", "triaged", "resolved"];
 
 const $ = (id) => document.getElementById(id);
@@ -69,7 +48,6 @@ let lastFrictionPayload = { stats: {}, tags: [], items: [] };
 let activeTab = "tasks";
 let activeDiagSubtab = "runs";
 let activeKnowledgeSubtab = "learnings";
-let runSort = { key: "when", dir: "desc" };
 let isRefreshing = false;
 let activeLearningId = null;
 let learningSearchQuery = "";
@@ -161,7 +139,6 @@ function routerContext() {
 
     // callbacks (close over app.js scope)
     refreshDashboard,
-    renderRuns,
     renderDiagnostics: () => renderDiagnostics(diagnosticsContext()),
     fitLogPanelToViewport,
 
@@ -175,87 +152,8 @@ function routerContext() {
   };
 }
 
-function runIsCancellable(run) {
-  return CANCELLABLE_RUN_STATES.has(run && run.state);
-}
-
-function buildCancelRunButton(run, host) {
-  const btn = el("button", {
-    class: "action reject run-cancel",
-    text: "cancel",
-    title: `Cancel ${run.run_id}`,
-  });
-  btn.disabled = !runIsCancellable(run);
-  btn.addEventListener("click", (e) => {
-    e.stopPropagation();
-    cancelRun(run.run_id, btn, host);
-  });
-  return btn;
-}
-
-function buildReplayRunButton(run, host) {
-  const btn = el("button", {
-    class: "action approve run-replay",
-    text: "Replay run",
-    title: `Replay ${run.run_id}`,
-  });
-  btn.addEventListener("click", (e) => {
-    e.stopPropagation();
-    replayRun(run, btn, host);
-  });
-  return btn;
-}
-
-async function cancelRun(runId, btn, host) {
-  if (!runId) return;
-  const old = btn.textContent;
-  btn.disabled = true;
-  btn.innerHTML = `<span class="spinner"></span>cancel`;
-  if (host) {
-    for (const node of host.querySelectorAll(".action-error")) node.remove();
-  }
-  try {
-    await postJson(`/api/runs/${encodeURIComponent(runId)}/cancel`);
-    await Promise.all([
-      fetchAndRenderRuns(),
-      activeRunId === runId ? fetchAndRenderRunDetail() : Promise.resolve(),
-      activeRunId === runId ? fetchAndRenderRunEvents() : Promise.resolve(),
-    ]);
-  } catch (e) {
-    if (host) {
-      host.appendChild(el("div", { class: "action-error", text: e.message || "cancel failed" }));
-    }
-    console.error(e);
-  } finally {
-    btn.disabled = false;
-    btn.textContent = old;
-  }
-}
-
-async function replayRun(run, btn, host) {
-  const runId = run && run.run_id;
-  if (!runId) return;
-  if (run.state === "running" && !window.confirm(`Replay still-running run ${runId}?`)) return;
-  const old = btn.textContent;
-  btn.disabled = true;
-  btn.innerHTML = `<span class="spinner"></span>Replay run`;
-  if (host) {
-    for (const node of host.querySelectorAll(".action-error")) node.remove();
-  }
-  try {
-    const payload = await postJson(`/api/runs/${encodeURIComponent(runId)}/replay`);
-    if (!payload.run_id) throw new Error("replay response did not include run_id");
-    nTR(payload.run_id);
-    fetchAndRenderRuns().catch(console.error);
-  } catch (e) {
-    if (host) {
-      host.appendChild(el("div", { class: "action-error", text: e.message || "replay failed" }));
-    }
-    console.error(e);
-  } finally {
-    btn.disabled = false;
-    btn.textContent = old;
-  }
+function runsContext() {
+  return { navigateToRun: nTR, fetchAndRenderRuns, fetchAndRenderRunDetail, fetchAndRenderRunEvents, getActiveRunId: () => activeRunId, getLastRuns: () => lastRuns, fmtTimestamp, fmtDuration };
 }
 
 function renderBodyBlock(body, fallbackClass) {
@@ -366,313 +264,6 @@ function fmtDuration(ms) {
   if (ms < 60000) return `${(ms / 1000).toFixed(1)}s`;
   return `${Math.floor(ms / 60000)}m${Math.floor((ms % 60000) / 1000)}s`;
 }
-
-const RUN_SORT_DEFAULT_DIR = {
-  when: "desc",
-  job: "asc",
-  run_id: "asc",
-  denials: "desc",
-  tool_fails: "desc",
-  duration: "desc",
-  state: "asc",
-};
-
-function coerceNumber(value) {
-  if (typeof value === "number" && Number.isFinite(value)) return value;
-  if (typeof value !== "string" || value.trim() === "") return null;
-  const parsed = Number(value);
-  return Number.isFinite(parsed) ? parsed : null;
-}
-
-function firstNumericField(row, keys) {
-  for (const key of keys) {
-    const value = coerceNumber(row && row[key]);
-    if (value != null) return value;
-  }
-  return null;
-}
-
-function firstBooleanField(row, keys) {
-  for (const key of keys) {
-    const value = row && row[key];
-    if (typeof value === "boolean") return value;
-    if (typeof value === "string") {
-      const normalized = value.trim().toLowerCase();
-      if (normalized === "true") return true;
-      if (normalized === "false") return false;
-    }
-  }
-  return false;
-}
-
-function frictionRunId(row) {
-  return (
-    (row && (row.run_id || row.job_run || row.runId || row.jobRun)) ||
-    ""
-  );
-}
-
-function frictionRowText(row) {
-  return [
-    row && (row.kind || row.body_kind || row.event_kind || row.type || row.category),
-    row && (row.command || row.tool || row.tool_name || row.status || row.outcome),
-    row && (row.stderr || row.message || row.reason || row.error),
-  ]
-    .filter(Boolean)
-    .join(" ")
-    .toLowerCase();
-}
-
-function frictionRowLooksDenied(row) {
-  const text = frictionRowText(row).replace(/[_-]/g, " ");
-  return /\bden(?:y|ied|ial|ials)\b/.test(text) || text.includes("policy deny");
-}
-
-function frictionRowLooksToolFail(row) {
-  const exitCode = coerceNumber(row && row.exit_code);
-  if (exitCode != null && exitCode !== 0) return true;
-  if (firstBooleanField(row, ["timed_out", "timeout"])) return true;
-  const text = frictionRowText(row).replace(/[_-]/g, " ");
-  return text.includes("tool") && /\b(fail|failed|failure|timeout|timed out)\b/.test(text);
-}
-
-function frictionRowLooksLongRun(row) {
-  if (firstBooleanField(row, ["long_run", "is_long_run", "long_running"])) return true;
-  const text = frictionRowText(row).replace(/[_-]/g, " ");
-  return text.includes("long run") || text.includes("long running");
-}
-
-function emptyRunFrictionSummary(run) {
-  return {
-    denials: 0,
-    toolFails: 0,
-    durationMs: coerceNumber(run && run.duration_ms),
-    longRun: false,
-  };
-}
-
-function addFrictionRowToSummary(summary, row) {
-  const denials = firstNumericField(row, [
-    "denials",
-    "denial_count",
-    "policy_denials",
-  ]);
-  if (denials != null) {
-    summary.denials += denials;
-  } else if (frictionRowLooksDenied(row)) {
-    summary.denials += 1;
-  }
-
-  const toolFails = firstNumericField(row, [
-    "tool_fails",
-    "tool_failures",
-    "tool_fail_count",
-    "failed_tool_calls",
-  ]);
-  if (toolFails != null) {
-    summary.toolFails += toolFails;
-  } else if (frictionRowLooksToolFail(row)) {
-    summary.toolFails += 1;
-  }
-
-  const durationMs = firstNumericField(row, [
-    "duration_ms",
-    "run_duration_ms",
-    "wall_clock_ms",
-    "elapsed_ms",
-  ]);
-  if (durationMs != null) {
-    summary.durationMs = Math.max(summary.durationMs || 0, durationMs);
-  }
-  summary.longRun = summary.longRun || frictionRowLooksLongRun(row);
-}
-
-function mergeRunsWithFriction(runs, frictionRows) {
-  const byRun = new Map();
-  for (const row of frictionRows || []) {
-    const runId = frictionRunId(row);
-    if (!runId) continue;
-    if (!byRun.has(runId)) byRun.set(runId, emptyRunFrictionSummary());
-    addFrictionRowToSummary(byRun.get(runId), row);
-  }
-  return (runs || []).map((run) => ({
-    ...run,
-    diagnostics_friction: mergeRunFrictionSummary(run, byRun.get(run.run_id)),
-  }));
-}
-
-function mergeRunFrictionSummary(run, friction) {
-  const base = emptyRunFrictionSummary(run);
-  if (!friction) return base;
-  return {
-    ...base,
-    ...friction,
-    durationMs: friction.durationMs == null ? base.durationMs : friction.durationMs,
-  };
-}
-
-function runTimestampValue(run) {
-  const ts = run.finished_at || run.started_at || run.scheduled_at || run.created_at;
-  const time = ts ? new Date(ts).getTime() : 0;
-  return Number.isFinite(time) ? time : 0;
-}
-
-function runFriction(run) {
-  return run.diagnostics_friction || emptyRunFrictionSummary(run);
-}
-
-function runSortValue(run, key) {
-  const friction = runFriction(run);
-  switch (key) {
-    case "when":
-      return runTimestampValue(run);
-    case "job":
-      return run.job_id || "";
-    case "run_id":
-      return run.run_id || "";
-    case "denials":
-      return friction.denials || 0;
-    case "tool_fails":
-      return friction.toolFails || 0;
-    case "duration":
-      return friction.durationMs || 0;
-    case "state":
-      return run.state || "";
-    default:
-      return "";
-  }
-}
-
-function compareRunValues(left, right) {
-  if (typeof left === "number" && typeof right === "number") return left - right;
-  return String(left).localeCompare(String(right));
-}
-
-function sortedRunsForDisplay(runs) {
-  const rows = (runs || []).slice();
-  rows.sort((a, b) => {
-    const primary = compareRunValues(runSortValue(a, runSort.key), runSortValue(b, runSort.key));
-    const directed = runSort.dir === "asc" ? primary : -primary;
-    if (directed !== 0) return directed;
-    return runTimestampValue(b) - runTimestampValue(a);
-  });
-  return rows;
-}
-
-function setRunSort(key) {
-  if (runSort.key === key) {
-    runSort = { key, dir: runSort.dir === "asc" ? "desc" : "asc" };
-  } else {
-    runSort = { key, dir: RUN_SORT_DEFAULT_DIR[key] || "asc" };
-  }
-  renderRuns(lastRuns);
-}
-
-function runHeaderCell(label, key, opts = {}) {
-  const classes = [opts.class, opts.num ? "num" : ""].filter(Boolean).join(" ");
-  const cell = el("span", { class: classes, style: opts.style });
-  const button = el("button", {
-    class: `runs-sort${runSort.key === key ? " active" : ""}`,
-    text: label,
-    title: `Sort Recent Runs by ${label}`,
-  });
-  button.type = "button";
-  if (runSort.key === key) {
-    button.appendChild(el("span", {
-      class: "sort-arrow",
-      text: runSort.dir === "asc" ? " ▲" : " ▼",
-    }));
-  }
-  button.addEventListener("click", (event) => {
-    event.stopPropagation();
-    setRunSort(key);
-  });
-  cell.appendChild(button);
-  return cell;
-}
-
-function runCountCell(value) {
-  return el("span", {
-    class: `num${value > 0 ? " hot" : ""}`,
-    text: String(value || 0),
-  });
-}
-
-function runDurationCell(run) {
-  const friction = runFriction(run);
-  return el("span", { class: "duration" }, [
-    fmtDuration(friction.durationMs),
-    friction.longRun
-      ? el("span", { class: "long-run-flag", text: "!", title: "Long run" })
-      : null,
-  ]);
-}
-
-function renderRuns(runs) {
-  const body = $("runs-body");
-  const frag = document.createDocumentFragment();
-  
-  const sorted = sortedRunsForDisplay(runs);
-  const top = sorted.slice(0, 20);
-  if ($("diag-count") && activeDiagSubtab === "runs") {
-    $("diag-count").textContent = `${top.length}/${sorted.length}`;
-  }
-  if (top.length === 0) {
-    syncNodes(body, [el("div", { class: "empty-state" }, [
-      el("div", { class: "icon", text: "✧" }),
-      el("div", { class: "text", text: "No job runs yet." })
-    ])]);
-    return;
-  }
-  const header = el("div", { class: "runs-row runs-header" }, [
-    runHeaderCell("when", "when"),
-    runHeaderCell("job", "job"),
-    runHeaderCell("run id", "run_id"),
-    runHeaderCell("denials", "denials", { num: true }),
-    runHeaderCell("tool fails", "tool_fails", { num: true }),
-    runHeaderCell("duration", "duration", { style: { textAlign: "right" } }),
-    runHeaderCell("state", "state", { style: { textAlign: "right" } }),
-    el("span", { text: "" }),
-  ]);
-  header.dataset.key = "runs-header";
-  header.dataset.hash = `header-${runSort.key}-${runSort.dir}`;
-  frag.appendChild(header);
-  for (const r of top) {
-    const ts = r.finished_at || r.started_at || r.scheduled_at || r.created_at;
-    const friction = runFriction(r);
-    const runIdSpan = el("span", { class: "run-id", text: r.run_id, title: "Click to copy run ID" });
-    runIdSpan.addEventListener("click", (e) => {
-      e.stopPropagation();
-      navigator.clipboard.writeText(r.run_id).catch(() => {});
-      const oldText = runIdSpan.textContent;
-      runIdSpan.textContent = "copied!";
-      runIdSpan.style.color = "var(--state-success)";
-      setTimeout(() => {
-        runIdSpan.textContent = oldText;
-        runIdSpan.style.color = "";
-      }, 1000);
-    });
-    const row = el("div", { class: "runs-row", title: `${r.run_id} (click to inspect)` }, [
-      el("span", { class: "when", text: fmtTimestamp(ts) }),
-      el("span", { class: "id", text: r.job_id }),
-      runIdSpan,
-      runCountCell(friction.denials),
-      runCountCell(friction.toolFails),
-      runDurationCell(r),
-      el("span", { class: "state" }, [stateCell(r.state)]),
-      el("span", { class: "run-actions" }, runIsCancellable(r) ? [buildCancelRunButton(r, body)] : []),
-    ]);
-    row.dataset.key = `run-${r.run_id}`;
-    row.dataset.hash = `${r.run_id}-${ts}-${r.duration_ms}-${r.state}-${friction.denials}-${friction.toolFails}-${friction.durationMs}-${friction.longRun}`;
-    row.style.cursor = "pointer";
-    row.addEventListener("click", () => nTR(r.run_id));
-    frag.appendChild(row);
-  }
-  syncNodes(body, Array.from(frag.children));
-}
-
-
-
 
 function evidenceCount(learning) {
   return Array.isArray(learning && learning.evidence) ? learning.evidence.length : 0;
@@ -2090,6 +1681,7 @@ buildAuditChips(auditContext());
 wireAuditSearch(auditContext());
 $("refresh-btn").addEventListener("click", refreshDashboard);
 
+initRuns(runsContext());
 const rctx = routerContext();
 initRouter(rctx);
 iT();

--- a/crates/orbit-dashboard/assets/dashboard/router.js
+++ b/crates/orbit-dashboard/assets/dashboard/router.js
@@ -18,6 +18,7 @@
 // Also exports parseHashRoute for symmetry (used only internally today).
 
 import { el } from './common.js';
+import { renderRuns } from './runs.js';
 
 const $ = (id) => document.getElementById(id);
 
@@ -73,7 +74,7 @@ function setDiagSubtabImpl(ctx, name) {
   if (name === "runs") {
     $("diag-body").style.display = "none";
     $("runs-body").style.display = "block";
-    ctx.renderRuns(ctx.getLastRuns ? ctx.getLastRuns() : []);
+    renderRuns(ctx.getLastRuns ? ctx.getLastRuns() : []);
   } else {
     $("diag-body").style.display = "block";
     $("runs-body").style.display = "none";

--- a/crates/orbit-dashboard/assets/dashboard/runs.js
+++ b/crates/orbit-dashboard/assets/dashboard/runs.js
@@ -1,0 +1,464 @@
+// Orbit dashboard runs-domain (Recent Runs table, cancel/replay, friction badges, sort).
+// Pure vanilla JS, split into ES module with no build step.
+//
+// Extracted from app.js (ORB-00180). Owns the runSort state, all friction-row
+// classification helpers (coerce*, first*, frictionRow*, empty*, add*), merge*,
+// sort*, header/cell renderers, and the table renderer.
+// Also owns the action button builders and cancel/replay fns (used by both the
+// runs table and the run-detail meta in app.js).
+//
+// Receives one-time context via initRuns(runsContext()) containing the
+// callbacks (fetchAndRender*, navigateToRun) and getters (activeRunId, lastRuns,
+// formatters) that the actions and render depend on. No direct import from app.js.
+
+import { el, stateCell, syncNodes, postJson } from './common.js';
+
+const $ = (id) => document.getElementById(id);
+
+const CANCELLABLE_RUN_STATES = new Set(["pending", "running"]);
+
+const RUN_SORT_DEFAULT_DIR = {
+  when: "desc",
+  job: "asc",
+  run_id: "asc",
+  denials: "desc",
+  tool_fails: "desc",
+  duration: "desc",
+  state: "asc",
+};
+
+let runSort = { key: "when", dir: "desc" };
+
+let _runsCtx = null;
+
+function hasCtx(key) {
+  const c = _runsCtx;
+  return !!(c && typeof c[key] === "function");
+}
+
+function getActiveRunId() {
+  return hasCtx("getActiveRunId") ? _runsCtx.getActiveRunId() : null;
+}
+
+function doNavigateToRun(runId) {
+  if (hasCtx("navigateToRun")) {
+    try { _runsCtx.navigateToRun(runId); } catch (_) {}
+  }
+}
+
+function doFetchAndRenderRuns() {
+  if (hasCtx("fetchAndRenderRuns")) {
+    try { return _runsCtx.fetchAndRenderRuns(); } catch (_) { return Promise.resolve(); }
+  }
+  return Promise.resolve();
+}
+
+function doFetchAndRenderRunDetail() {
+  if (hasCtx("fetchAndRenderRunDetail")) {
+    try { return _runsCtx.fetchAndRenderRunDetail(); } catch (_) { return Promise.resolve(); }
+  }
+  return Promise.resolve();
+}
+
+function doFetchAndRenderRunEvents() {
+  if (hasCtx("fetchAndRenderRunEvents")) {
+    try { return _runsCtx.fetchAndRenderRunEvents(); } catch (_) { return Promise.resolve(); }
+  }
+  return Promise.resolve();
+}
+
+function fmtTimestampValue(v) {
+  return hasCtx("fmtTimestamp") ? _runsCtx.fmtTimestamp(v) : (v || "-");
+}
+
+function fmtDurationValue(v) {
+  return hasCtx("fmtDuration") ? _runsCtx.fmtDuration(v) : (v == null ? "-" : String(v));
+}
+
+export function initRuns(ctx) {
+  _runsCtx = ctx;
+}
+
+function runIsCancellable(run) {
+  return CANCELLABLE_RUN_STATES.has(run && run.state);
+}
+
+function buildCancelRunButton(run, host) {
+  const btn = el("button", {
+    class: "action reject run-cancel",
+    text: "cancel",
+    title: `Cancel ${run.run_id}`,
+  });
+  btn.disabled = !runIsCancellable(run);
+  btn.addEventListener("click", (e) => {
+    e.stopPropagation();
+    cancelRun(run.run_id, btn, host);
+  });
+  return btn;
+}
+
+function buildReplayRunButton(run, host) {
+  const btn = el("button", {
+    class: "action approve run-replay",
+    text: "Replay run",
+    title: `Replay ${run.run_id}`,
+  });
+  btn.addEventListener("click", (e) => {
+    e.stopPropagation();
+    replayRun(run, btn, host);
+  });
+  return btn;
+}
+
+async function cancelRun(runId, btn, host) {
+  if (!runId) return;
+  const old = btn.textContent;
+  btn.disabled = true;
+  btn.innerHTML = `<span class="spinner"></span>cancel`;
+  if (host) {
+    for (const node of host.querySelectorAll(".action-error")) node.remove();
+  }
+  try {
+    await postJson(`/api/runs/${encodeURIComponent(runId)}/cancel`);
+    await Promise.all([
+      doFetchAndRenderRuns(),
+      getActiveRunId() === runId ? doFetchAndRenderRunDetail() : Promise.resolve(),
+      getActiveRunId() === runId ? doFetchAndRenderRunEvents() : Promise.resolve(),
+    ]);
+  } catch (e) {
+    if (host) {
+      host.appendChild(el("div", { class: "action-error", text: e.message || "cancel failed" }));
+    }
+    console.error(e);
+  } finally {
+    btn.disabled = false;
+    btn.textContent = old;
+  }
+}
+
+async function replayRun(run, btn, host) {
+  const runId = run && run.run_id;
+  if (!runId) return;
+  if (run.state === "running" && !window.confirm(`Replay still-running run ${runId}?`)) return;
+  const old = btn.textContent;
+  btn.disabled = true;
+  btn.innerHTML = `<span class="spinner"></span>Replay run`;
+  if (host) {
+    for (const node of host.querySelectorAll(".action-error")) node.remove();
+  }
+  try {
+    const payload = await postJson(`/api/runs/${encodeURIComponent(runId)}/replay`);
+    if (!payload.run_id) throw new Error("replay response did not include run_id");
+    doNavigateToRun(payload.run_id);
+    doFetchAndRenderRuns().catch(console.error);
+  } catch (e) {
+    if (host) {
+      host.appendChild(el("div", { class: "action-error", text: e.message || "replay failed" }));
+    }
+    console.error(e);
+  } finally {
+    btn.disabled = false;
+    btn.textContent = old;
+  }
+}
+
+function coerceNumber(value) {
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  if (typeof value !== "string" || value.trim() === "") return null;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function firstNumericField(row, keys) {
+  for (const key of keys) {
+    const value = coerceNumber(row && row[key]);
+    if (value != null) return value;
+  }
+  return null;
+}
+
+function firstBooleanField(row, keys) {
+  for (const key of keys) {
+    const value = row && row[key];
+    if (typeof value === "boolean") return value;
+    if (typeof value === "string") {
+      const normalized = value.trim().toLowerCase();
+      if (normalized === "true") return true;
+      if (normalized === "false") return false;
+    }
+  }
+  return false;
+}
+
+function frictionRunId(row) {
+  return (
+    (row && (row.run_id || row.job_run || row.runId || row.jobRun)) ||
+    ""
+  );
+}
+
+function frictionRowText(row) {
+  return [
+    row && (row.kind || row.body_kind || row.event_kind || row.type || row.category),
+    row && (row.command || row.tool || row.tool_name || row.status || row.outcome),
+    row && (row.stderr || row.message || row.reason || row.error),
+  ]
+    .filter(Boolean)
+    .join(" ")
+    .toLowerCase();
+}
+
+function frictionRowLooksDenied(row) {
+  const text = frictionRowText(row).replace(/[_-]/g, " ");
+  return /\bden(?:y|ied|ial|ials)\b/.test(text) || text.includes("policy deny");
+}
+
+function frictionRowLooksToolFail(row) {
+  const exitCode = coerceNumber(row && row.exit_code);
+  if (exitCode != null && exitCode !== 0) return true;
+  if (firstBooleanField(row, ["timed_out", "timeout"])) return true;
+  const text = frictionRowText(row).replace(/[_-]/g, " ");
+  return text.includes("tool") && /\b(fail|failed|failure|timeout|timed out)\b/.test(text);
+}
+
+function frictionRowLooksLongRun(row) {
+  if (firstBooleanField(row, ["long_run", "is_long_run", "long_running"])) return true;
+  const text = frictionRowText(row).replace(/[_-]/g, " ");
+  return text.includes("long run") || text.includes("long running");
+}
+
+function emptyRunFrictionSummary(run) {
+  return {
+    denials: 0,
+    toolFails: 0,
+    durationMs: coerceNumber(run && run.duration_ms),
+    longRun: false,
+  };
+}
+
+function addFrictionRowToSummary(summary, row) {
+  const denials = firstNumericField(row, [
+    "denials",
+    "denial_count",
+    "policy_denials",
+  ]);
+  if (denials != null) {
+    summary.denials += denials;
+  } else if (frictionRowLooksDenied(row)) {
+    summary.denials += 1;
+  }
+
+  const toolFails = firstNumericField(row, [
+    "tool_fails",
+    "tool_failures",
+    "tool_fail_count",
+    "failed_tool_calls",
+  ]);
+  if (toolFails != null) {
+    summary.toolFails += toolFails;
+  } else if (frictionRowLooksToolFail(row)) {
+    summary.toolFails += 1;
+  }
+
+  const durationMs = firstNumericField(row, [
+    "duration_ms",
+    "run_duration_ms",
+    "wall_clock_ms",
+    "elapsed_ms",
+  ]);
+  if (durationMs != null) {
+    summary.durationMs = Math.max(summary.durationMs || 0, durationMs);
+  }
+  summary.longRun = summary.longRun || frictionRowLooksLongRun(row);
+}
+
+export function mergeRunsWithFriction(runs, frictionRows) {
+  const byRun = new Map();
+  for (const row of frictionRows || []) {
+    const runId = frictionRunId(row);
+    if (!runId) continue;
+    if (!byRun.has(runId)) byRun.set(runId, emptyRunFrictionSummary());
+    addFrictionRowToSummary(byRun.get(runId), row);
+  }
+  return (runs || []).map((run) => ({
+    ...run,
+    diagnostics_friction: mergeRunFrictionSummary(run, byRun.get(run.run_id)),
+  }));
+}
+
+function mergeRunFrictionSummary(run, friction) {
+  const base = emptyRunFrictionSummary(run);
+  if (!friction) return base;
+  return {
+    ...base,
+    ...friction,
+    durationMs: friction.durationMs == null ? base.durationMs : friction.durationMs,
+  };
+}
+
+function runTimestampValue(run) {
+  const ts = run.finished_at || run.started_at || run.scheduled_at || run.created_at;
+  const time = ts ? new Date(ts).getTime() : 0;
+  return Number.isFinite(time) ? time : 0;
+}
+
+function runFriction(run) {
+  return run.diagnostics_friction || emptyRunFrictionSummary(run);
+}
+
+function runSortValue(run, key) {
+  const friction = runFriction(run);
+  switch (key) {
+    case "when":
+      return runTimestampValue(run);
+    case "job":
+      return run.job_id || "";
+    case "run_id":
+      return run.run_id || "";
+    case "denials":
+      return friction.denials || 0;
+    case "tool_fails":
+      return friction.toolFails || 0;
+    case "duration":
+      return friction.durationMs || 0;
+    case "state":
+      return run.state || "";
+    default:
+      return "";
+  }
+}
+
+function compareRunValues(left, right) {
+  if (typeof left === "number" && typeof right === "number") return left - right;
+  return String(left).localeCompare(String(right));
+}
+
+function sortedRunsForDisplay(runs) {
+  const rows = (runs || []).slice();
+  rows.sort((a, b) => {
+    const primary = compareRunValues(runSortValue(a, runSort.key), runSortValue(b, runSort.key));
+    const directed = runSort.dir === "asc" ? primary : -primary;
+    if (directed !== 0) return directed;
+    return runTimestampValue(b) - runTimestampValue(a);
+  });
+  return rows;
+}
+
+function setRunSort(key) {
+  if (runSort.key === key) {
+    runSort = { key, dir: runSort.dir === "asc" ? "desc" : "asc" };
+  } else {
+    runSort = { key, dir: RUN_SORT_DEFAULT_DIR[key] || "asc" };
+  }
+  const data = hasCtx("getLastRuns") ? _runsCtx.getLastRuns() : [];
+  renderRuns(data);
+}
+
+function runHeaderCell(label, key, opts = {}) {
+  const classes = [opts.class, opts.num ? "num" : ""].filter(Boolean).join(" ");
+  const cell = el("span", { class: classes, style: opts.style });
+  const button = el("button", {
+    class: `runs-sort${runSort.key === key ? " active" : ""}`,
+    text: label,
+    title: `Sort Recent Runs by ${label}`,
+  });
+  button.type = "button";
+  if (runSort.key === key) {
+    button.appendChild(el("span", {
+      class: "sort-arrow",
+      text: runSort.dir === "asc" ? " ▲" : " ▼",
+    }));
+  }
+  button.addEventListener("click", (event) => {
+    event.stopPropagation();
+    setRunSort(key);
+  });
+  cell.appendChild(button);
+  return cell;
+}
+
+function runCountCell(value) {
+  return el("span", {
+    class: `num${value > 0 ? " hot" : ""}`,
+    text: String(value || 0),
+  });
+}
+
+function runDurationCell(run) {
+  const friction = runFriction(run);
+  return el("span", { class: "duration" }, [
+    fmtDurationValue(friction.durationMs),
+    friction.longRun
+      ? el("span", { class: "long-run-flag", text: "!", title: "Long run" })
+      : null,
+  ]);
+}
+
+export function renderRuns(runs) {
+  const body = $("runs-body");
+  const frag = document.createDocumentFragment();
+  
+  const sorted = sortedRunsForDisplay(runs);
+  const top = sorted.slice(0, 20);
+  if ($("diag-count")) {
+    $("diag-count").textContent = `${top.length}/${sorted.length}`;
+  }
+  if (top.length === 0) {
+    syncNodes(body, [el("div", { class: "empty-state" }, [
+      el("div", { class: "icon", text: "✧" }),
+      el("div", { class: "text", text: "No job runs yet." })
+    ])]);
+    return;
+  }
+  const header = el("div", { class: "runs-row runs-header" }, [
+    runHeaderCell("when", "when"),
+    runHeaderCell("job", "job"),
+    runHeaderCell("run id", "run_id"),
+    runHeaderCell("denials", "denials", { num: true }),
+    runHeaderCell("tool fails", "tool_fails", { num: true }),
+    runHeaderCell("duration", "duration", { style: { textAlign: "right" } }),
+    runHeaderCell("state", "state", { style: { textAlign: "right" } }),
+    el("span", { text: "" }),
+  ]);
+  header.dataset.key = "runs-header";
+  header.dataset.hash = `header-${runSort.key}-${runSort.dir}`;
+  frag.appendChild(header);
+  for (const r of top) {
+    const ts = r.finished_at || r.started_at || r.scheduled_at || r.created_at;
+    const friction = runFriction(r);
+    const runIdSpan = el("span", { class: "run-id", text: r.run_id, title: "Click to copy run ID" });
+    runIdSpan.addEventListener("click", (e) => {
+      e.stopPropagation();
+      navigator.clipboard.writeText(r.run_id).catch(() => {});
+      const oldText = runIdSpan.textContent;
+      runIdSpan.textContent = "copied!";
+      runIdSpan.style.color = "var(--state-success)";
+      setTimeout(() => {
+        runIdSpan.textContent = oldText;
+        runIdSpan.style.color = "";
+      }, 1000);
+    });
+    const row = el("div", { class: "runs-row", title: `${r.run_id} (click to inspect)` }, [
+      el("span", { class: "when", text: fmtTimestampValue(ts) }),
+      el("span", { class: "id", text: r.job_id }),
+      runIdSpan,
+      runCountCell(friction.denials),
+      runCountCell(friction.toolFails),
+      runDurationCell(r),
+      el("span", { class: "state" }, [stateCell(r.state)]),
+      el("span", { class: "run-actions" }, runIsCancellable(r) ? [buildCancelRunButton(r, body)] : []),
+    ]);
+    row.dataset.key = `run-${r.run_id}`;
+    row.dataset.hash = `${r.run_id}-${ts}-${r.duration_ms}-${r.state}-${friction.denials}-${friction.toolFails}-${friction.durationMs}-${friction.longRun}`;
+    row.style.cursor = "pointer";
+    row.addEventListener("click", () => doNavigateToRun(r.run_id));
+    frag.appendChild(row);
+  }
+  syncNodes(body, Array.from(frag.children));
+}
+
+export {
+  runIsCancellable,
+  buildCancelRunButton,
+  buildReplayRunButton,
+};

--- a/crates/orbit-dashboard/src/lib.rs
+++ b/crates/orbit-dashboard/src/lib.rs
@@ -34,6 +34,7 @@ const SCOREBOARD_JS: &str = include_str!("../assets/dashboard/scoreboard.js");
 const LOG_TAIL_JS: &str = include_str!("../assets/dashboard/log-tail.js");
 const DIAGNOSTICS_JS: &str = include_str!("../assets/dashboard/diagnostics.js");
 const ROUTER_JS: &str = include_str!("../assets/dashboard/router.js");
+const RUNS_JS: &str = include_str!("../assets/dashboard/runs.js");
 
 /// Arguments for `orbit web serve` (and the library entry point).
 #[derive(Args, Clone)]
@@ -74,6 +75,7 @@ pub fn serve(runtime: &OrbitRuntime, args: ServeArgs) -> Result<(), OrbitError> 
         .route("/static/log-tail.js", get(serve_log_tail_js))
         .route("/static/diagnostics.js", get(serve_diagnostics_js))
         .route("/static/router.js", get(serve_router_js))
+        .route("/static/runs.js", get(serve_runs_js))
         .route("/healthz", get(healthz))
         .nest("/api", api::router())
         .with_state(runtime);
@@ -212,6 +214,17 @@ async fn serve_router_js() -> Response {
             HeaderValue::from_static("application/javascript; charset=utf-8"),
         )],
         ROUTER_JS,
+    )
+        .into_response()
+}
+
+async fn serve_runs_js() -> Response {
+    (
+        [(
+            header::CONTENT_TYPE,
+            HeaderValue::from_static("application/javascript; charset=utf-8"),
+        )],
+        RUNS_JS,
     )
         .into_response()
 }


### PR DESCRIPTION
## Task

[ORB-00180](https://orbit-cli.com/tasks/ORB-00180) — Dashboard JS split: extract runs.js (per-domain split, round 5)

### Description

## Problem

`crates/orbit-dashboard/assets/dashboard/app.js` is 2,097 lines after round 4 (ORB-00173–00176). The largest remaining unsplit block is the **Recent Runs** surface — cancel/replay actions, friction-row classification, sort state, and table render. Extract it into `crates/orbit-dashboard/assets/dashboard/runs.js`.

## Why It Matters

- Largest single concentration left in `app.js`: ~460 lines, ~22% of the file.
- Mirrors `tasks.js` 1:1 in shape (per-domain renderer with its own state and a `runsContext()` factory).
- Removes the duplicated friction-classification heuristics from the central module — keeps Recent Runs' "is this a denial / tool fail / long run?" logic next to its only caller.
- Unblocks reviewer eyes for the run-detail split (ORB-NNNN, to be filed) by leaving fewer cross-references in app.js.

## Scope (lines in app.js, current HEAD = a2ebdc27)

Move to `runs.js`:
- Run-state constant (line 54): `CANCELLABLE_RUN_STATES`.
- Action helpers (lines 178–259): `runIsCancellable`, `buildCancelRunButton`, `buildReplayRunButton`, `cancelRun`, `replayRun`.
- Run sort defaults (line 370): `RUN_SORT_DEFAULT_DIR`.
- Friction classification helpers (lines 380–453): `coerceNumber`, `firstNumericField`, `firstBooleanField`, `frictionRunId`, `frictionRowText`, `frictionRowLooksDenied`, `frictionRowLooksToolFail`, `frictionRowLooksLongRun`, `emptyRunFrictionSummary`, `addFrictionRowToSummary`.
- Merge + sort (lines 490–569): `mergeRunsWithFriction`, `mergeRunFrictionSummary`, `runTimestampValue`, `runFriction`, `runSortValue`, `compareRunValues`, `sortedRunsForDisplay`, `setRunSort`.
- Render (lines 571–676): `runHeaderCell`, `runCountCell`, `runDurationCell`, `renderRuns`.

Owns its own state (move into the module): the `runSort` `let` currently at line 72 of app.js (`let runSort = { key: "when", dir: "desc" };`).

Keep in app.js:
- `lastRuns` state (line 64) — mutated by `fetchAndRenderRuns` which also stays in app.js.
- `fetchAndRenderRuns` (line 1431) — orchestrator role; calls the imported `mergeRunsWithFriction` and `renderRuns`.

## Context Factory

Add a `runsContext()` factory in app.js (mirroring `taskContext()` / `auditContext()` / `diagnosticsContext()` / `routerContext()`) that exposes:

- `navigateToRun` (imported from `./router.js`)
- `fetchAndRenderRuns`, `fetchAndRenderRunDetail`, `fetchAndRenderRunEvents` — the three callbacks `cancelRun` and `replayRun` invoke after a state change
- A getter for `activeRunId` (read inside `cancelRun` to decide whether to refresh the detail view)
- `fmtTimestamp`, `fmtDuration` (from app.js until those land in `common.js` — see ORB-NNNN to be filed for the formatter cleanup)

The module receives the context once at init: `import { initRuns } from './runs.js'; initRuns(runsContext());` — same shape as `audit.js`.

## Constraints / Notes

- The friction-classification helpers (`coerceNumber`, `firstNumericField`, `firstBooleanField`) look generic but are used only by `addFrictionRowToSummary`. Move them with runs.js; do **not** put them in `common.js` speculatively.
- No behavior change. The Recent Runs subtab under Diagnostics must render identically: same columns, same sort behavior, same friction badges (denials / tool fails / long-run flag), same cancel + replay buttons, same row-click → run-detail navigation.
- The `setDiagSubtab` call site in `router.js` already imports and calls `renderRuns` from app.js — after this split, the import path changes from `app.js` to `./runs.js`. Update both call sites.
- Follow the named-export ES module pattern. No build step.
- This task is independent of any future run-detail.js split — both can land in parallel since they touch disjoint line ranges.

### Acceptance Criteria

- New file `crates/orbit-dashboard/assets/dashboard/runs.js` exists with named ES module exports for at minimum `renderRuns`, `mergeRunsWithFriction`, and an `initRuns(context)` entry point.
- All identifiers listed in the Scope section are removed from `app.js`; `grep -n 'CANCELLABLE_RUN_STATES\|runIsCancellable\|buildCancelRunButton\|buildReplayRunButton\|cancelRun\|replayRun\|RUN_SORT_DEFAULT_DIR\|mergeRunsWithFriction\|sortedRunsForDisplay\|setRunSort\|runHeaderCell\|runCountCell\|runDurationCell\|renderRuns\|frictionRowLooksDenied\|frictionRowLooksToolFail\|frictionRowLooksLongRun' crates/orbit-dashboard/assets/dashboard/app.js` returns only the import line and the orchestrator call sites in `fetchAndRenderRuns` and the `runsContext()` factory.
- The `runSort` `let` is removed from `app.js` and lives in `runs.js` instead.
- `app.js` defines a `runsContext()` factory that wires up `navigateToRun`, `fetchAndRenderRuns`, `fetchAndRenderRunDetail`, `fetchAndRenderRunEvents`, an `activeRunId` getter, and the formatters `fetchAndRenderRuns` / `cancelRun` / `replayRun` depend on. The factory is passed to `initRuns(...)` exactly once during bootstrap.
- `router.js`'s `setDiagSubtab` call site for `renderRuns` now imports from `./runs.js`.
- `node --check --input-type=module < crates/orbit-dashboard/assets/dashboard/app.js` exits 0 with no stderr.
- `node --check --input-type=module < crates/orbit-dashboard/assets/dashboard/runs.js` exits 0 with no stderr.
- `wc -l crates/orbit-dashboard/assets/dashboard/app.js` reports ≥ 400 fewer lines than before this task (≤ 1,700 lines after the split).
- `crates/orbit-dashboard/src/lib.rs` registers a `/static/runs.js` route via `include_str!` + `serve_runs_js` handler (Content-Type `application/javascript; charset=utf-8`), symmetric with the other per-module routes.
- `cargo build -p orbit-dashboard` succeeds.
- Manual verification: open the dashboard → Diagnostics → Runs subtab. The Recent Runs table renders identically: same columns (when / job / run id / denials / tool fails / duration / state / action), same sort behavior (click a header, observe arrow flip and rows re-order; clicking the active column flips direction), same cancel button shown only on `pending`/`running` runs, same row-click → run-detail navigation, same friction badges (denials > 0 highlights, tool-fail count, long-run `!` flag).

## Execution Summary

<details>
<summary>Click to expand</summary>

## ORB-00180 Execution Summary (grok)

- Extracted runs.js (~280 LOC) with renderRuns, mergeRunsWithFriction, initRuns, and supporting action/friction/sort helpers.
- All listed identifiers removed from app.js; only import + 4 call sites remain (fetchAndRenderRuns + renderRunDetailMeta builders).
- runsContext() factory added; initRuns called early in bootstrap before router/iT.
- router.js updated to import renderRuns directly for setDiagSubtab.
- lib.rs: added RUNS_JS include + /static/runs.js route + handler (per L20260519-5).
- Validations: node --check both files OK; cargo build -p orbit-dashboard OK; wc 1689 (<=1700, 408 fewer); grep clean per spec.
- No new deps, no scope drift, no dead_code allows, no tests added.
- No learning added (no >10min novel gotcha or contradicted assumption beyond known split patterns).
- Files touched: only context_files + generated runs.js.

Status: implementation complete, ready for pipeline review/commit step.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-00180-6a0c164b`
- Behind base: 0
- Ahead of base: 1