### PR TITLE
Fix dashboard status updates to in-progress returning HTTP 422

### DIFF
--- a/crates/orbit-common/src/types/task.rs
+++ b/crates/orbit-common/src/types/task.rs
@@ -63,6 +63,7 @@ pub enum TaskStatus {
     Backlog,
     /// Actively being worked on.
     #[cfg_attr(feature = "clap", value(name = "in-progress", alias = "in_progress"))]
+    #[serde(alias = "in-progress")]
     InProgress,
     /// Implementation complete; awaiting review/merge.
     Review,
@@ -906,7 +907,8 @@ fn find_dependency_path(
 #[cfg(test)]
 mod tests {
     use super::{
-        ExternalRef, Task, TaskArtifact, normalize_task_tags, push_external_ref_if_missing,
+        ExternalRef, Task, TaskArtifact, TaskStatus, normalize_task_tags,
+        push_external_ref_if_missing,
     };
 
     #[test]
@@ -1112,5 +1114,18 @@ updated_at: 2026-01-01T00:00:00Z
         assert_eq!(artifact.path, "binary.bin");
         assert_eq!(artifact.content, vec![0xff, 0xfe, 0xfd]);
         assert_eq!(artifact.media_type, "application/octet-stream");
+    }
+
+    #[test]
+    fn task_status_deserializes_both_hyphen_and_snake_for_in_progress() {
+        let snake: TaskStatus = serde_json::from_str("\"in_progress\"").expect("snake de");
+        let hyphen: TaskStatus = serde_json::from_str("\"in-progress\"").expect("hyphen de");
+        assert_eq!(snake, TaskStatus::InProgress);
+        assert_eq!(hyphen, TaskStatus::InProgress);
+        // serialize remains snake_case for persisted history/events compat with prior records
+        assert_eq!(
+            serde_json::to_string(&TaskStatus::InProgress).expect("ser"),
+            "\"in_progress\""
+        );
     }
 }

--- a/crates/orbit-dashboard/src/api/tasks_tests.rs
+++ b/crates/orbit-dashboard/src/api/tasks_tests.rs
@@ -251,3 +251,56 @@ fn get_task_artifact_rejects_traversal_path() {
             assert_eq!(response.status(), StatusCode::BAD_REQUEST);
         });
 }
+
+/// Exercises PATCH /api/tasks/:id with the dashboard's emitted spelling {"status":"in-progress"}
+/// against a backlog task. Before the serde alias fix this produced 422 on JSON extraction;
+/// now it succeeds and the response continues to surface status as the display form "in-progress".
+#[tokio::test]
+async fn patch_api_accepts_in_progress_hyphen_from_dashboard_and_returns_in_progress() {
+    use axum::Router;
+    use axum::http::{Method, Request, header};
+
+    let runtime = OrbitRuntime::in_memory().expect("build runtime");
+    let created = runtime
+        .add_task(TaskAddParams {
+            title: "Dashboard status update test".to_string(),
+            description: "backlog task to be moved via PATCH with hyphen spelling".to_string(),
+            status: Some(TaskStatus::Backlog),
+            workspace_path: Some(".".to_string()),
+            ..Default::default()
+        })
+        .expect("seed backlog task");
+    let task_id = created.id;
+
+    // Wrap to exercise the literal /api/tasks path per acceptance criteria
+    let app = Router::new()
+        .nest("/api", router())
+        .with_state(Arc::new(runtime));
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method(Method::PATCH)
+                .uri(format!("/api/tasks/{}", task_id))
+                .header(header::CONTENT_TYPE, "application/json")
+                .header(header::ORIGIN, "http://localhost:7878")
+                .body(Body::from(r#"{"status":"in-progress"}"#))
+                .expect("build patch request"),
+        )
+        .await
+        .expect("oneshot");
+
+    assert_eq!(
+        response.status(),
+        StatusCode::OK,
+        "PATCH with in-progress must succeed (not 422)"
+    );
+
+    let body = body_json(response).await;
+    assert_eq!(body["id"], serde_json::json!(task_id));
+    assert_eq!(
+        body["status"],
+        serde_json::json!("in-progress"),
+        "response must continue to expose dashboard display spelling"
+    );
+}


### PR DESCRIPTION
## Task

[ORB-00185](https://orbit-cli.com/tasks/ORB-00185) — Fix dashboard status updates to in-progress returning HTTP 422

### Description

## Problem
The web dashboard status selector can send `PATCH /api/tasks/:id` with `{"status":"in-progress"}` when the user chooses in-progress. The dashboard uses the CLI/display spelling from `STATUS_ORDER` and the task JSON projection, but `UpdateTaskBody.status` deserializes directly into `TaskStatus`, whose Serde representation is `snake_case`. For `TaskStatus::InProgress`, that means Serde expects `in_progress`, not the dashboard-emitted `in-progress`, so Axum rejects the request during JSON extraction and returns HTTP 422 before lifecycle validation runs.

## Why It Matters
The dashboard exposes status updates as a first-class task workflow control. A backlog task can be moved to in-progress from CLI/tooling, but the web UI fails on that same transition because its visible status vocabulary and API input vocabulary disagree.

## Constraints / Notes
- Keep the dashboard-visible task status label as `in-progress` unless a broader status contract migration is intentionally designed.
- The fix should align the API and dashboard contract rather than treating the lifecycle transition itself as invalid. A proposed/someday/blocked task may still require a plan before in-progress, but that should be a normal validation response, not an Axum 422 JSON rejection.
- Root-cause evidence: `crates/orbit-dashboard/assets/dashboard/app.js` defines `STATUS_ORDER` with `in-progress`; `crates/orbit-dashboard/assets/dashboard/tasks.js` sends the selected value as `{ status: targetStatus }`; `crates/orbit-dashboard/src/api/tasks.rs` deserializes `status: Option<TaskStatus>`; `crates/orbit-common/src/types/task.rs` uses `#[serde(rename_all = "snake_case")]` for `TaskStatus` while only Clap/FromStr accept the hyphen spelling.

### Acceptance Criteria

- A dashboard API test exercises `PATCH /api/tasks/:id` with JSON `{"status":"in-progress"}` against a backlog task and observes a successful transition to in-progress rather than HTTP 422.
- The response JSON for the successful transition continues to expose the task status as `in-progress`, matching the dashboard display vocabulary.
- At least one deterministic test covers the accepted input spelling for `TaskStatus::InProgress` at the API boundary or shared status deserialization boundary, so this regression cannot silently return.
- `make ci-fast` passes after the fix.

## Execution Summary

<details>
<summary>Click to expand</summary>

Fixed TaskStatus deserialization to accept dashboard's 'in-progress' spelling (aliased) while preserving snake_case serialization. Added covering tests at unit and API boundary. All acceptance criteria met.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-00185-6a0d2ad2`
- Behind base: 0
- Ahead of base: 1