### PR TITLE
Add a supported reopen path for mistakenly completed tasks

### DIFF
--- a/crates/orbit-cli/src/audit_middleware.rs
+++ b/crates/orbit-cli/src/audit_middleware.rs
@@ -302,6 +302,7 @@ pub fn extract_command_meta(cmd: &Commands) -> CommandMeta {
                 TaskSubcommand::Unarchive(args) => {
                     ("unarchive", Some("task"), Some(args.id.as_str()))
                 }
+                TaskSubcommand::Reopen(args) => ("reopen", Some("task"), Some(args.id.as_str())),
                 TaskSubcommand::Delete(args) => ("delete", Some("task"), Some(args.id.as_str())),
                 TaskSubcommand::Search(_) => ("search", None, None),
                 TaskSubcommand::Templates(_) => ("templates", None, None),

--- a/crates/orbit-cli/src/command/mcp/mod.rs
+++ b/crates/orbit-cli/src/command/mcp/mod.rs
@@ -39,6 +39,7 @@ pub(crate) const TASK_TOOL_NAMES: &[&str] = &[
     "orbit.task.locks.release",
     "orbit.task.locks.reserve",
     "orbit.task.reject",
+    "orbit.task.reopen",
     "orbit.task.review_thread.add",
     "orbit.task.review_thread.list",
     "orbit.task.review_thread.reply",

--- a/crates/orbit-cli/src/command/task/command.rs
+++ b/crates/orbit-cli/src/command/task/command.rs
@@ -6,8 +6,8 @@ use crate::command::Execute;
 use super::add::TaskAddArgs;
 use super::artifact::TaskArtifactCommand;
 use super::lifecycle::{
-    TaskApproveArgs, TaskArchiveArgs, TaskDeleteArgs, TaskRejectArgs, TaskSearchArgs,
-    TaskStartArgs, TaskUnarchiveArgs,
+    TaskApproveArgs, TaskArchiveArgs, TaskDeleteArgs, TaskRejectArgs, TaskReopenArgs,
+    TaskSearchArgs, TaskStartArgs, TaskUnarchiveArgs,
 };
 use super::lint::TaskLintArgs;
 use super::list::{TaskListArgs, TaskLocksArgs};
@@ -56,6 +56,8 @@ pub enum TaskSubcommand {
     Archive(TaskArchiveArgs),
     /// Unarchive a task (archived → backlog)
     Unarchive(TaskUnarchiveArgs),
+    /// Reopen a completed task (done → backlog)
+    Reopen(TaskReopenArgs),
     /// Delete a task permanently
     Delete(TaskDeleteArgs),
     /// Search tasks by title, description, or external ref ID
@@ -86,6 +88,7 @@ impl Execute for TaskSubcommand {
             TaskSubcommand::Reject(args) => args.execute(runtime),
             TaskSubcommand::Archive(args) => args.execute(runtime),
             TaskSubcommand::Unarchive(args) => args.execute(runtime),
+            TaskSubcommand::Reopen(args) => args.execute(runtime),
             TaskSubcommand::Delete(args) => args.execute(runtime),
             TaskSubcommand::Search(args) => args.execute(runtime),
             TaskSubcommand::Templates(cmd) => cmd.execute(runtime),
@@ -119,5 +122,25 @@ mod tests {
         );
         assert!(!help.contains("proposed → archived"), "{help}");
         assert!(!help.contains("review → backlog"), "{help}");
+        assert!(
+            help.contains("Reopen a completed task (done → backlog)"),
+            "{help}"
+        );
+    }
+
+    #[test]
+    fn task_reopen_help_describes_done_to_backlog() {
+        let err = match Cli::try_parse_from(["orbit", "task", "reopen", "--help"]) {
+            Ok(_) => panic!("task reopen help should exit before parsing args"),
+            Err(err) => err,
+        };
+
+        assert_eq!(err.kind(), ErrorKind::DisplayHelp);
+
+        let help = err.to_string();
+        assert!(
+            help.contains("Reopen a completed task (done → backlog)"),
+            "{help}"
+        );
     }
 }

--- a/crates/orbit-cli/src/command/task/lifecycle.rs
+++ b/crates/orbit-cli/src/command/task/lifecycle.rs
@@ -236,6 +236,46 @@ impl Execute for TaskUnarchiveArgs {
 }
 
 #[derive(Args)]
+#[command(about = "Reopen a completed task (done -> backlog)")]
+pub struct TaskReopenArgs {
+    /// Task ID
+    pub id: String,
+    /// Optional lifecycle note
+    #[arg(long)]
+    pub note: Option<String>,
+    /// Append a task comment
+    #[arg(long)]
+    pub comment: Option<String>,
+    /// Explicit agent name to persist on the task artifact
+    #[arg(long)]
+    pub agent: Option<String>,
+    /// Explicit agent model to persist on the task artifact
+    #[arg(long)]
+    pub model: Option<String>,
+    /// Output as JSON
+    #[arg(long)]
+    pub json: bool,
+}
+
+impl Execute for TaskReopenArgs {
+    fn execute(self, runtime: &OrbitRuntime) -> Result<(), OrbitError> {
+        let task = runtime.reopen_task_with_identity(
+            &self.id,
+            self.note,
+            self.comment,
+            self.agent,
+            self.model,
+        )?;
+        if self.json {
+            crate::output::json::print_pretty(&task_to_json_for_runtime(runtime, &task)?)
+        } else {
+            println!("Reopened task '{}'", task.id);
+            Ok(())
+        }
+    }
+}
+
+#[derive(Args)]
 pub struct TaskDeleteArgs {
     /// Task ID
     pub id: String,

--- a/crates/orbit-common/src/types/task.rs
+++ b/crates/orbit-common/src/types/task.rs
@@ -6,7 +6,8 @@
 //! violates one of the four invariants below.
 //!
 //! ### Invariants (blocklist)
-//! 1. **Done is terminal** — no transitions out of done.
+//! 1. **Done is terminal for ordinary status updates** — use the dedicated
+//!    reopen operation to move a mistakenly completed task back to backlog.
 //! 2. **Archived requires dedicated command** — use `orbit task archive`; the
 //!    bare `--status archived` path is rejected.
 //! 3. **Friction is legacy-only** — new friction reports are stored through
@@ -23,7 +24,7 @@
 //! | Someday      | Future-scoped — wanted but not yet actionable. Agents skip someday tasks. |
 //! | InProgress   | Actively being worked on. |
 //! | Review       | Implementation complete; awaiting review/merge. |
-//! | Done         | Accepted and closed. Terminal. |
+//! | Done         | Accepted and closed. Reopenable to Backlog through the dedicated command/tool only. |
 //! | Blocked      | Temporarily paused. |
 //! | Archived     | Soft-deleted. Restorable to Backlog. |
 //! | Rejected     | Declined. Can be re-opened. |
@@ -67,7 +68,7 @@ pub enum TaskStatus {
     InProgress,
     /// Implementation complete; awaiting review/merge.
     Review,
-    /// Accepted and closed. Terminal — no further transitions.
+    /// Accepted and closed. Reopenable through the dedicated command/tool only.
     Done,
     /// Temporarily paused (waiting on a dependency or decision).
     Blocked,
@@ -132,7 +133,8 @@ impl TaskStatus {
 
     /// Validates a status transition using a short blocklist of invariants:
     ///
-    /// 1. **Done is terminal** — no transitions out of done.
+    /// 1. **Done is terminal for ordinary status updates** — dedicated reopen
+    ///    command/tool code handles the audited Done -> Backlog recovery path.
     /// 2. **Archived requires dedicated command** — use `orbit task archive`, not a
     ///    bare status update (enforced upstream; blocked here as defense-in-depth).
     /// 3. **Friction is legacy-only** — new friction reports use
@@ -147,7 +149,7 @@ impl TaskStatus {
             return Ok(());
         }
 
-        // Done is terminal.
+        // Done is terminal for ordinary status updates.
         if *self == TaskStatus::Done {
             return Err(format!(
                 "invalid status transition: {} -> {} (done is terminal)",

--- a/crates/orbit-core/src/command/task/transitions.rs
+++ b/crates/orbit-core/src/command/task/transitions.rs
@@ -625,6 +625,58 @@ impl OrbitRuntime {
         })
     }
 
+    pub fn reopen_task(
+        &self,
+        id: &str,
+        note: Option<String>,
+        comment: Option<String>,
+    ) -> Result<Task, OrbitError> {
+        self.reopen_task_with_identity(id, note, comment, None, None)
+    }
+
+    pub fn reopen_task_with_identity(
+        &self,
+        id: &str,
+        note: Option<String>,
+        comment: Option<String>,
+        agent: Option<String>,
+        model: Option<String>,
+    ) -> Result<Task, OrbitError> {
+        let (canonical_agent, canonical_model) =
+            self.try_canonical_agent_model_identity(agent.as_deref(), model.as_deref())?;
+        let task = self.get_task(id)?;
+
+        if task.status != TaskStatus::Done {
+            return Err(OrbitError::InvalidInput(format!(
+                "task '{id}' is in status '{}'; reopen requires 'done'",
+                task.status
+            )));
+        }
+
+        let actor = self.actor().clone();
+        let effective_label = effective_actor_label(
+            &actor.label,
+            canonical_agent.as_deref(),
+            canonical_model.as_deref(),
+        );
+        let append_comments = build_task_comments(comment, effective_label.as_str())?;
+
+        self.with_mutation(|| {
+            let task = self.stores().tasks().update(
+                id,
+                StoreTaskUpdateParams {
+                    actor: effective_label.clone(),
+                    status: Some(TaskStatus::Backlog),
+                    status_event: Some("reopened".to_string()),
+                    status_note: note.clone(),
+                    append_comments: append_comments.clone(),
+                    ..Default::default()
+                },
+            )?;
+            Ok((task.clone(), OrbitEvent::TaskUpdated { id: id.to_string() }))
+        })
+    }
+
     pub fn delete_task(&self, id: &str) -> Result<(), OrbitError> {
         self.with_mutation(|| {
             let deleted = self.stores().tasks().delete(id)?;

--- a/crates/orbit-core/src/command/task/update.rs
+++ b/crates/orbit-core/src/command/task/update.rs
@@ -106,13 +106,13 @@ impl OrbitRuntime {
         }
         if params.has_any_mutation() && task.status == TaskStatus::Archived {
             return Err(OrbitError::InvalidInput(format!(
-                "task {id} is {} and cannot be modified; unarchive or reopen it first",
+                "task {id} is {} and cannot be modified; unarchive it first",
                 task.status
             )));
         }
         if params.has_non_comment_mutation() && task.status == TaskStatus::Done {
             return Err(OrbitError::InvalidInput(format!(
-                "task {id} is {} and cannot be modified; unarchive or reopen it first",
+                "task {id} is {} and cannot be modified; reopen it first",
                 task.status
             )));
         }

--- a/crates/orbit-core/src/runtime/orbit_tool_host/artifact_redaction.rs
+++ b/crates/orbit-core/src/runtime/orbit_tool_host/artifact_redaction.rs
@@ -222,6 +222,13 @@ fn policy_for_action(action: OrbitBuiltinAction) -> Option<ActionPolicy> {
             path_arrays: &[],
             nested_arrays: &[],
         }),
+        OrbitBuiltinAction::TaskReopen => Some(ActionPolicy {
+            free_text_fields: &["note", "comment"],
+            free_text_arrays: &[],
+            path_fields: &[],
+            path_arrays: &[],
+            nested_arrays: &[],
+        }),
         OrbitBuiltinAction::ReviewThreadAdd => Some(ActionPolicy {
             free_text_fields: &["body"],
             free_text_arrays: &[],
@@ -276,6 +283,7 @@ fn is_covered_mutating_action(action: OrbitBuiltinAction) -> bool {
             | OrbitBuiltinAction::TaskAdd
             | OrbitBuiltinAction::TaskUpdate
             | OrbitBuiltinAction::TaskReject
+            | OrbitBuiltinAction::TaskReopen
             | OrbitBuiltinAction::ReviewThreadAdd
             | OrbitBuiltinAction::ReviewThreadReply
             | OrbitBuiltinAction::FrictionAdd
@@ -514,7 +522,8 @@ fn artifact_target(
         }),
         OrbitBuiltinAction::TaskAdd
         | OrbitBuiltinAction::TaskUpdate
-        | OrbitBuiltinAction::TaskReject => {
+        | OrbitBuiltinAction::TaskReject
+        | OrbitBuiltinAction::TaskReopen => {
             let id = response_string(response, "id")?;
             Ok(ArtifactTarget {
                 artifact_type: "task",
@@ -574,6 +583,7 @@ fn tool_name(action: OrbitBuiltinAction) -> &'static str {
         OrbitBuiltinAction::TaskAdd => "orbit.task.add",
         OrbitBuiltinAction::TaskUpdate => "orbit.task.update",
         OrbitBuiltinAction::TaskReject => "orbit.task.reject",
+        OrbitBuiltinAction::TaskReopen => "orbit.task.reopen",
         OrbitBuiltinAction::ReviewThreadAdd => "orbit.task.review_thread.add",
         OrbitBuiltinAction::ReviewThreadReply => "orbit.task.review_thread.reply",
         OrbitBuiltinAction::FrictionAdd => "orbit.friction.add",

--- a/crates/orbit-core/src/runtime/orbit_tool_host/dispatch.rs
+++ b/crates/orbit-core/src/runtime/orbit_tool_host/dispatch.rs
@@ -95,6 +95,7 @@ pub(super) fn execute(
             super::task_locks::reserve(runtime, input, agent, model, reservation_owner)
         }
         OrbitBuiltinAction::TaskReject => super::task_tools::reject(runtime, input, agent, model),
+        OrbitBuiltinAction::TaskReopen => super::task_tools::reopen(runtime, input, agent, model),
         OrbitBuiltinAction::TaskShow => super::task_tools::show(runtime, input),
         OrbitBuiltinAction::TaskStart => super::task_tools::start(runtime, input, agent, model),
         OrbitBuiltinAction::TaskUpdate => super::task_tools::update(runtime, input, agent, model),

--- a/crates/orbit-core/src/runtime/orbit_tool_host/task_tools.rs
+++ b/crates/orbit-core/src/runtime/orbit_tool_host/task_tools.rs
@@ -182,6 +182,23 @@ pub(super) fn reject(
     serialize_task(runtime, &task)
 }
 
+pub(super) fn reopen(
+    runtime: &OrbitRuntime,
+    input: Value,
+    agent: Option<String>,
+    model: Option<String>,
+) -> Result<Value, OrbitError> {
+    let id = required_string(&input, &["id"], "id")?;
+    let task = runtime.reopen_task_with_identity(
+        &id,
+        optional_string(&input, "note")?,
+        optional_string(&input, "comment")?,
+        agent,
+        model,
+    )?;
+    serialize_task(runtime, &task)
+}
+
 pub(super) fn show(runtime: &OrbitRuntime, input: Value) -> Result<Value, OrbitError> {
     let id = required_string(&input, &["id"], "id")?;
     let task = runtime.get_task(&id)?;

--- a/crates/orbit-core/src/runtime/orbit_tool_host/task_tools_tests.rs
+++ b/crates/orbit-core/src/runtime/orbit_tool_host/task_tools_tests.rs
@@ -381,6 +381,118 @@ fn task_delete_tool_allows_forced_protected_statuses() {
 }
 
 #[test]
+fn task_reopen_tool_moves_done_task_to_backlog_with_history() {
+    let (_root, runtime, repo_root) = test_runtime();
+    let task = create_task(
+        &runtime,
+        &repo_root,
+        "Prematurely done task",
+        "A mistaken completion should be recoverable.",
+        TaskStatus::Done,
+        &[],
+    );
+
+    let message = invalid_input_message(runtime.execute_tool_command(
+        "orbit.task.update",
+        json!({
+            "id": task.id.clone(),
+            "title": "Still closed",
+        }),
+        Some("codex".to_string()),
+        Some("gpt-5.5".to_string()),
+    ));
+    assert_eq!(
+        message,
+        format!(
+            "task {} is done and cannot be modified; reopen it first",
+            task.id
+        )
+    );
+
+    runtime
+        .execute_tool_command(
+            "orbit.task.update",
+            json!({
+                "id": task.id.clone(),
+                "comment": "Comment-only updates remain allowed while done.",
+            }),
+            Some("codex".to_string()),
+            Some("gpt-5.5".to_string()),
+        )
+        .expect("comment-only update succeeds while done");
+
+    let output = runtime
+        .execute_tool_command(
+            "orbit.task.reopen",
+            json!({
+                "id": task.id.clone(),
+                "note": "Completion was premature.",
+                "comment": "Ready to work again.",
+            }),
+            Some("codex".to_string()),
+            Some("gpt-5.5".to_string()),
+        )
+        .expect("task reopen tool succeeds");
+
+    assert_eq!(
+        output.get("status").and_then(Value::as_str),
+        Some("backlog")
+    );
+    assert!(
+        output["comments"]
+            .as_array()
+            .expect("comments")
+            .iter()
+            .any(|comment| {
+                comment.get("message").and_then(Value::as_str) == Some("Ready to work again.")
+                    && comment.get("by").and_then(Value::as_str) == Some("codex")
+            })
+    );
+    assert!(
+        output["history"]
+            .as_array()
+            .expect("history")
+            .iter()
+            .any(|event| {
+                event.get("event").and_then(Value::as_str) == Some("reopened")
+                    && event.get("by").and_then(Value::as_str) == Some("codex")
+                    && event.get("from_status").and_then(Value::as_str) == Some("done")
+                    && event.get("to_status").and_then(Value::as_str) == Some("backlog")
+                    && event.get("note").and_then(Value::as_str)
+                        == Some("Completion was premature.")
+            })
+    );
+}
+
+#[test]
+fn task_reopen_tool_rejects_unsupported_statuses() {
+    let (_root, runtime, repo_root) = test_runtime();
+    let task = create_task(
+        &runtime,
+        &repo_root,
+        "Backlog task",
+        "Only completed tasks can be reopened.",
+        TaskStatus::Backlog,
+        &[],
+    );
+
+    let message = invalid_input_message(runtime.execute_tool_command(
+        "orbit.task.reopen",
+        json!({ "id": task.id.clone() }),
+        Some("codex".to_string()),
+        Some("gpt-5.5".to_string()),
+    ));
+
+    assert_eq!(
+        message,
+        format!(
+            "task '{}' is in status 'backlog'; reopen requires 'done'",
+            task.id
+        )
+    );
+}
+
+#[test]
 fn task_add_tool_persists_dependencies() {
     let (_root, runtime, repo_root) = test_runtime();
     let dependency = create_task(

--- a/crates/orbit-tools/src/builtin/orbit/mod.rs
+++ b/crates/orbit-tools/src/builtin/orbit/mod.rs
@@ -63,6 +63,7 @@ pub fn register(registry: &mut ToolRegistry) {
     registry.register(task::locks_release::OrbitTaskLocksReleaseTool);
     registry.register(task::start::OrbitTaskStartTool);
     registry.register(task::reject::OrbitTaskRejectTool);
+    registry.register(task::reopen::OrbitTaskReopenTool);
     registry.register(task::show::OrbitTaskShowTool);
     registry.register(task::list::OrbitTaskListTool);
     registry.register(task::search::OrbitTaskSearchTool);

--- a/crates/orbit-tools/src/builtin/orbit/task/mod.rs
+++ b/crates/orbit-tools/src/builtin/orbit/task/mod.rs
@@ -8,6 +8,7 @@ pub mod locks;
 pub mod locks_release;
 pub mod locks_reserve;
 pub mod reject;
+pub mod reopen;
 pub mod search;
 pub mod show;
 pub mod start;

--- a/crates/orbit-tools/src/builtin/orbit/task/reopen.rs
+++ b/crates/orbit-tools/src/builtin/orbit/task/reopen.rs
@@ -1,0 +1,40 @@
+use orbit_common::types::{OrbitError, ToolParam, ToolSchema};
+use serde_json::Value;
+
+use crate::{OrbitBuiltinAction, Tool, ToolContext};
+
+pub struct OrbitTaskReopenTool;
+
+impl Tool for OrbitTaskReopenTool {
+    fn schema(&self) -> ToolSchema {
+        let mut parameters = super::super::orbit_id_params("task");
+        parameters.extend([
+            ToolParam {
+                name: "note".to_string(),
+                description: "Optional lifecycle note for the reopen transition".to_string(),
+                param_type: "string".to_string(),
+                required: false,
+            },
+            ToolParam {
+                name: "comment".to_string(),
+                description: "Optional task comment to append".to_string(),
+                param_type: "string".to_string(),
+                required: false,
+            },
+        ]);
+        parameters.extend(super::super::identity_params());
+
+        ToolSchema {
+            name: "orbit.task.reopen".to_string(),
+            description:
+                "Reopen a completed Orbit task (done -> backlog) and return the updated task JSON"
+                    .to_string(),
+            parameters,
+            builtin: true,
+        }
+    }
+
+    fn execute(&self, ctx: &ToolContext, input: Value) -> Result<Value, OrbitError> {
+        super::super::execute_host_action(ctx, input, OrbitBuiltinAction::TaskReopen)
+    }
+}

--- a/crates/orbit-tools/src/lib.rs
+++ b/crates/orbit-tools/src/lib.rs
@@ -118,6 +118,7 @@ pub enum OrbitBuiltinAction {
     TaskLocksRelease,
     TaskLocksReserve,
     TaskReject,
+    TaskReopen,
     TaskShow,
     TaskStart,
     TaskUpdate,

--- a/crates/orbit-tools/tests/public_tool_surface.rs
+++ b/crates/orbit-tools/tests/public_tool_surface.rs
@@ -72,6 +72,7 @@ fn workflow_critical_tools_remain_registered() {
         "orbit.semantic.related",
         "orbit.semantic.search",
         "orbit.task.artifact.put",
+        "orbit.task.reopen",
         "proc.spawn",
     ] {
         assert!(
@@ -188,6 +189,29 @@ fn task_delete_schema_exposes_optional_force_boolean() {
 
     assert_eq!(force_param.param_type, "boolean");
     assert!(!force_param.required);
+}
+
+#[test]
+fn task_reopen_schema_documents_done_to_backlog_recovery() {
+    let mut registry = ToolRegistry::new();
+    registry.register_builtins();
+
+    let schema = registry
+        .get_schema("orbit.task.reopen")
+        .expect("task reopen schema");
+
+    assert!(schema.description.contains("done -> backlog"));
+    assert!(
+        schema.parameters.iter().any(|param| param.name == "model"),
+        "reopen should expose model attribution"
+    );
+    assert!(
+        schema
+            .parameters
+            .iter()
+            .any(|param| param.name == "comment"),
+        "reopen should support comments"
+    );
 }
 
 fn registered_tool_names() -> BTreeSet<String> {


### PR DESCRIPTION
## Task

[ORB-00189](https://orbit-cli.com/tasks/ORB-00189) — Add a supported reopen path for mistakenly completed tasks

### Description

## Problem

While implementing ORB-00183, the task had been marked `done` before the work was actually performed. `orbit.task.update` rejected non-comment updates with `task ORB-00183 is done and cannot be modified; unarchive or reopen it first`, but there is no exposed `orbit.task.reopen` tool, and the existing `orbit task unarchive` command only handles `archived -> backlog`. This leaves agents unable to follow the documented execute-task lifecycle when a task is prematurely completed.

## Why It Matters

- Agents need a provenance-preserving way to recover from mistaken `done` transitions without editing task files directly.
- The current error message promises a `reopen` path that is not available through the registered tool surface.
- Resolving this should close friction F2026-05-040 and make future task recovery auditable.

## Constraints / Notes

- Do not weaken `done` task immutability for ordinary field edits; require an explicit lifecycle transition for reopening.
- Keep the transition auditable and available through the Orbit tool registry, not just a direct CLI escape hatch.
- Decide whether reopening should target `backlog` or `review`; document the chosen lifecycle semantics in tests/help text.
- Related friction: F2026-05-040.

### Acceptance Criteria

- A supported task lifecycle operation exists for reopening a `done` task, exposed through the registered `orbit.task.*` tool surface and documented by `orbit tool list` or equivalent tool metadata.
- The CLI exposes the same supported recovery path, or the existing CLI help/error text no longer suggests an unavailable CLI path; verify with `orbit task --help` and the relevant subcommand help.
- Reopening a `done` task records a history event with actor/provenance and moves the task to the documented target status without allowing arbitrary non-comment mutations while still `done`.
- Attempting to use the reopen operation from unsupported statuses returns a clear error naming the allowed source statuses.
- Automated tests cover at least: `done -> <target status>` success, unsupported-status failure, and tool/CLI surface behavior for the new recovery path.
- When this task reaches `done`, relation side effects mark friction `F2026-05-040` resolved.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Added a dedicated `done -> backlog` reopen lifecycle path in core with actor/model provenance, optional note/comment support, and an explicit `reopened` history event.
- Exposed the recovery path through `orbit.task.reopen`, the MCP safe task surface, and `orbit task reopen`, with CLI audit metadata and help text updated.
- Tightened closed-task update errors so archived tasks point only to `unarchive` and done tasks point to `reopen`.
- Added coverage for done-task immutability before reopen, successful reopen history/comment output, unsupported-status errors, tool schema registration, MCP safe-surface registration, and CLI help.

Validation:
- `cargo test -p orbit-core task_reopen_tool -- --nocapture`
- `cargo test -p orbit-tools task_reopen_schema_documents_done_to_backlog_recovery -- --nocapture`
- `cargo test -p orbit-tools workflow_critical_tools_remain_registered -- --nocapture`
- `cargo test -p orbit-cli task_help_describes_reject_transition_to_rejected -- --nocapture`
- `cargo test -p orbit-cli task_reopen_help_describes_done_to_backlog -- --nocapture`
- `cargo test -p orbit-cli safe_surface_matches_runtime_graph_and_task_tools -- --nocapture`
- `./target/debug/orbit task --help`
- `./target/debug/orbit task reopen --help`
- `./target/debug/orbit tool list --json | rg 'orbit\.task\.reopen|done -> backlog'`
- `make ci-fast`

Assessment: The change keeps ordinary `done` task mutations blocked while providing a narrow, auditable recovery transition through both CLI and registered tool surfaces.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-00189-6a0d2bfe`
- Behind base: 0
- Ahead of base: 1