### PR TITLE
Fuzzy-match fallback in orbit.graph.search

### DIFF
--- a/crates/orbit-core/assets/skills/orbit-graph/SKILL.md
+++ b/crates/orbit-core/assets/skills/orbit-graph/SKILL.md
@@ -66,6 +66,10 @@ Do not also run `overview`, `refs`, or `pack` unless they add information the ta
 
 If you are about to call `pack` or `show` on each candidate to verify which one matches, stop and reconsider — that is the verification-loop anti-pattern. Either rephrase the question as a `source_regex` enumeration, or use the appropriate relation tool (`callers`, `implementors`, `refs`).
 
+## Fuzzy Fallback
+
+Pass `allow_fuzzy: true` to recover from typos and partial recall in symbol names or file basenames. The fuzzy pass is case-insensitive and only runs when the deterministic pass returns zero results; when any exact result exists, no fuzzy candidate appears. Each fuzzy hit is tagged `match_kind: "fuzzy"` and carries a `score` in [0.0, 1.0] (higher is closer; 1.0 is reserved for exact, which would have hit the deterministic path). Off by default. Source-regex queries ignore the flag. The `format: "selectors"` projection returns only selectors, so it intentionally drops `match_kind` and `score`.
+
 ## When `fs.read` Is Acceptable
 
 - Graph returned `knowledge_unavailable`
@@ -80,6 +84,7 @@ If you are about to call `pack` or `show` on each candidate to verify which one 
 orbit tool run orbit.graph.search --input '{"query":"hello","type":"symbol","kind":"function","limit":10}'
 orbit tool run orbit.graph.show --input '{"selector":"symbol:src/lib.rs#hello:function"}'
 orbit tool run orbit.graph.search --input '{"query":"AgentRuntime","include_non_code":true}'
+orbit tool run orbit.graph.search --input '{"query":"AgentRuntmie","allow_fuzzy":true}'
 
 # Trait/interface implementations
 orbit tool run orbit.graph.implementors --input '{"trait_selector":"symbol:src/lib.rs#Greeter:trait"}'

--- a/crates/orbit-knowledge/src/commands/fuzzy.rs
+++ b/crates/orbit-knowledge/src/commands/fuzzy.rs
@@ -1,0 +1,153 @@
+use std::path::Path;
+
+use crate::graph::navigator::GraphNodeRef;
+use crate::graph::nodes::CodebaseGraphV1;
+use crate::service::GraphContextService;
+
+use super::search::DEFAULT_RANKING_HARD_CAP;
+
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct FuzzyCandidate {
+    pub(crate) selector: String,
+    pub(crate) name: String,
+    pub(crate) kind: String,
+    pub(crate) file: Option<String>,
+    pub(crate) score: f32,
+}
+
+pub(crate) fn fuzzy_name_candidates(
+    graph: &CodebaseGraphV1,
+    query: &str,
+    limit: usize,
+) -> Vec<FuzzyCandidate> {
+    if limit == 0 {
+        return Vec::new();
+    }
+
+    let query = query.trim().to_lowercase();
+    if query.is_empty() {
+        return Vec::new();
+    }
+
+    let svc = GraphContextService::new(graph);
+    let mut candidates = Vec::new();
+    let mut scanned = 0usize;
+
+    for leaf in &graph.leaves {
+        if scanned >= DEFAULT_RANKING_HARD_CAP {
+            break;
+        }
+        scanned += 1;
+        push_candidate(
+            &mut candidates,
+            CandidateInput {
+                selector: svc.selector_for_node(GraphNodeRef::Leaf(leaf)),
+                result_name: leaf.base.name.clone(),
+                match_name: leaf.base.name.as_str(),
+                kind: leaf.kind.to_string(),
+                file: leaf
+                    .base
+                    .location
+                    .split_once('#')
+                    .map(|(path, _)| path.to_string()),
+            },
+            &query,
+        );
+    }
+
+    for file in &graph.files {
+        if scanned >= DEFAULT_RANKING_HARD_CAP {
+            break;
+        }
+        scanned += 1;
+        let basename = Path::new(&file.base.location)
+            .file_name()
+            .and_then(|name| name.to_str())
+            .unwrap_or(file.base.name.as_str());
+        push_candidate(
+            &mut candidates,
+            CandidateInput {
+                selector: svc.selector_for_node(GraphNodeRef::File(file)),
+                result_name: file.base.name.clone(),
+                match_name: basename,
+                kind: "file".to_string(),
+                file: Some(file.base.location.clone()),
+            },
+            &query,
+        );
+    }
+
+    candidates.sort_by(|left, right| {
+        right
+            .score
+            .total_cmp(&left.score)
+            .then_with(|| left.selector.cmp(&right.selector))
+    });
+    candidates.truncate(limit);
+    candidates
+}
+
+struct CandidateInput<'a> {
+    selector: String,
+    result_name: String,
+    match_name: &'a str,
+    kind: String,
+    file: Option<String>,
+}
+
+fn push_candidate(candidates: &mut Vec<FuzzyCandidate>, input: CandidateInput<'_>, query: &str) {
+    let candidate = input.match_name.to_lowercase();
+    let query_len = query.chars().count();
+    let candidate_len = candidate.chars().count();
+    if candidate_len.abs_diff(query_len) > 2 {
+        return;
+    }
+
+    let distance = levenshtein_distance(query, &candidate);
+    if distance == 0 || distance > 2 {
+        return;
+    }
+
+    let max_len = candidate_len.max(query_len);
+    if max_len == 0 {
+        return;
+    }
+
+    let score = (1.0 - (distance as f32 / max_len as f32)).clamp(0.0, 1.0);
+    candidates.push(FuzzyCandidate {
+        selector: input.selector,
+        name: input.result_name,
+        kind: input.kind,
+        file: input.file,
+        score,
+    });
+}
+
+pub(crate) fn levenshtein_distance(left: &str, right: &str) -> usize {
+    if left == right {
+        return 0;
+    }
+    if left.is_empty() {
+        return right.chars().count();
+    }
+    if right.is_empty() {
+        return left.chars().count();
+    }
+
+    let right_chars = right.chars().collect::<Vec<_>>();
+    let mut previous = (0..=right_chars.len()).collect::<Vec<_>>();
+    let mut current = vec![0; right_chars.len() + 1];
+
+    for (left_index, left_char) in left.chars().enumerate() {
+        current[0] = left_index + 1;
+        for (right_index, right_char) in right_chars.iter().enumerate() {
+            let substitution = usize::from(left_char != *right_char);
+            current[right_index + 1] = (previous[right_index + 1] + 1)
+                .min(current[right_index] + 1)
+                .min(previous[right_index] + substitution);
+        }
+        std::mem::swap(&mut previous, &mut current);
+    }
+
+    previous[right_chars.len()]
+}

--- a/crates/orbit-knowledge/src/commands/mod.rs
+++ b/crates/orbit-knowledge/src/commands/mod.rs
@@ -14,6 +14,7 @@ use crate::{KnowledgeError, KnowledgeErrorKind};
 
 pub mod callers;
 pub mod deps;
+pub(crate) mod fuzzy;
 pub mod implementors;
 pub mod overview;
 pub mod pack;

--- a/crates/orbit-knowledge/src/commands/search.rs
+++ b/crates/orbit-knowledge/src/commands/search.rs
@@ -1,13 +1,13 @@
 use regex::Regex;
 
-use crate::commands::GraphCommandContext;
+use crate::commands::{GraphCommandContext, fuzzy};
 use crate::graph::navigator::GraphNodeRef;
 use crate::graph::{GraphIndexSearchRow, GraphReadOptions};
 use crate::service::{GraphContextService, MatchedLine, SearchHit};
 use crate::{KnowledgeError, graph::nodes::CodebaseGraphV1};
 
 const DEFAULT_RANKING_HEADROOM: usize = 10;
-const DEFAULT_RANKING_HARD_CAP: usize = 5_000;
+pub(crate) const DEFAULT_RANKING_HARD_CAP: usize = 5_000;
 pub const SOURCE_REGEX_UNBOUNDED_LIMIT_MAX: usize = 200;
 
 #[derive(Debug, Clone)]
@@ -19,6 +19,7 @@ pub struct SearchInput {
     pub prefix: Option<String>,
     pub source_regex: Option<Regex>,
     pub include_non_code: bool,
+    pub allow_fuzzy: bool,
     pub limit: usize,
 }
 
@@ -30,24 +31,27 @@ pub struct DefaultSearchInput<'a> {
     pub include_non_code: bool,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct SearchResult {
     pub total: usize,
     pub hits: Vec<SearchResultItem>,
     pub used_index: bool,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct SearchResultItem {
     pub selector: String,
     pub name: String,
     pub kind: String,
     pub file: Option<String>,
     pub matched_lines: Vec<MatchedLine>,
+    pub match_kind: Option<String>,
+    pub score: Option<f32>,
 }
 
 pub fn run(input: SearchInput) -> Result<SearchResult, KnowledgeError> {
     let has_source_regex = input.source_regex.is_some();
+    let allow_fuzzy = input.allow_fuzzy && !has_source_regex && !input.query.trim().is_empty();
     let use_default_ranking = input.node_type.is_none()
         && input.kind_filter.is_none()
         && input.prefix.is_none()
@@ -61,7 +65,7 @@ pub fn run(input: SearchInput) -> Result<SearchResult, KnowledgeError> {
             input.limit,
         )?
     {
-        return Ok(result);
+        return maybe_fuzzy_fallback(&input, result, allow_fuzzy, None);
     }
 
     let graph = input.context.read_graph(GraphReadOptions {
@@ -119,11 +123,12 @@ pub fn run(input: SearchInput) -> Result<SearchResult, KnowledgeError> {
             .take(input.limit)
             .map(|node| search_item_for_node(&svc, node, Vec::new()))
             .collect();
-        Ok(SearchResult {
+        let result = SearchResult {
             total,
             hits,
             used_index: false,
-        })
+        };
+        maybe_fuzzy_fallback(&input, result, allow_fuzzy, Some(&graph))
     } else {
         let hits = if use_exact_symbol_definition_ranking {
             rank_exact_symbol_definition_hits(hits, &input.query)
@@ -133,15 +138,58 @@ pub fn run(input: SearchInput) -> Result<SearchResult, KnowledgeError> {
         } else {
             hits
         };
-        Ok(SearchResult {
+        let result = SearchResult {
             total: service_total,
             hits: hits
                 .into_iter()
                 .map(|hit| search_item_for_hit(&svc, hit))
                 .collect(),
             used_index: false,
-        })
+        };
+        maybe_fuzzy_fallback(&input, result, allow_fuzzy, Some(&graph))
     }
+}
+
+fn maybe_fuzzy_fallback(
+    input: &SearchInput,
+    result: SearchResult,
+    allow_fuzzy: bool,
+    graph: Option<&CodebaseGraphV1>,
+) -> Result<SearchResult, KnowledgeError> {
+    if !allow_fuzzy || result.total != 0 {
+        return Ok(result);
+    }
+
+    let owned_graph;
+    let graph = if let Some(graph) = graph {
+        graph
+    } else {
+        owned_graph = input.context.read_graph(GraphReadOptions {
+            hydrate_file_source: false,
+            hydrate_leaf_source: false,
+        })?;
+        &owned_graph
+    };
+
+    let hits = fuzzy::fuzzy_name_candidates(graph, &input.query, input.limit)
+        .into_iter()
+        .map(|candidate| SearchResultItem {
+            selector: candidate.selector,
+            name: candidate.name,
+            kind: candidate.kind,
+            file: candidate.file,
+            matched_lines: Vec::new(),
+            match_kind: Some("fuzzy".to_string()),
+            score: Some(candidate.score),
+        })
+        .collect::<Vec<_>>();
+    let total = hits.len();
+
+    Ok(SearchResult {
+        total,
+        hits,
+        used_index: false,
+    })
 }
 
 pub fn default_search(input: DefaultSearchInput<'_>) -> Result<SearchResult, KnowledgeError> {
@@ -228,6 +276,8 @@ fn search_item_for_node(
         kind,
         file,
         matched_lines,
+        match_kind: None,
+        score: None,
     }
 }
 
@@ -241,6 +291,8 @@ fn search_item_for_row(row: GraphIndexSearchRow) -> SearchResultItem {
         kind,
         file,
         matched_lines: Vec::new(),
+        match_kind: None,
+        score: None,
     }
 }
 
@@ -464,11 +516,12 @@ fn is_non_code_path(path: &str) -> bool {
 
 #[cfg(test)]
 mod tests {
+    use crate::commands::{GraphCommandContext, TaskGraphScope};
     use crate::graph::GraphIndexReader;
     use crate::graph::nodes::{
         BaseNodeFields, CodebaseGraphV1, DirNode, FileNode, LeafKind, LeafNode,
     };
-    use crate::graph::object_store::GraphObjectStore;
+    use crate::graph::object_store::{GraphObjectStore, RefName};
     use crate::service::GraphContextService;
 
     use super::*;
@@ -711,6 +764,78 @@ mod tests {
         );
     }
 
+    #[test]
+    fn fuzzy_pass_returns_orbit_error_for_orbit_erorr_query() {
+        let graph = graph_with_named_leaves(&[("OrbitError", LeafKind::Struct)]);
+        let (_temp_dir, context) = context_for_graph(&graph);
+
+        let result =
+            run(search_input(context, "OrbitErorr", true, 5)).expect("fuzzy search result");
+
+        assert_eq!(result.hits.len(), 1);
+        assert_eq!(result.hits[0].name, "OrbitError");
+        assert_eq!(result.hits[0].match_kind.as_deref(), Some("fuzzy"));
+        let score = result.hits[0].score.expect("fuzzy score");
+        assert!(score > 0.0);
+        assert!(score <= 1.0);
+    }
+
+    #[test]
+    fn exact_match_suppresses_fuzzy_candidates() {
+        let graph = graph_with_named_leaves(&[
+            ("OrbitError", LeafKind::Struct),
+            ("OrbitErrorKind", LeafKind::Enum),
+        ]);
+        let (_temp_dir, context) = context_for_graph(&graph);
+
+        let result =
+            run(search_input(context, "OrbitError", true, 5)).expect("exact search result");
+
+        assert!(!result.hits.is_empty());
+        assert!(result.hits.iter().all(|hit| hit.match_kind.is_none()));
+    }
+
+    #[test]
+    fn allow_fuzzy_false_preserves_zero_result_behavior() {
+        let graph = graph_with_named_leaves(&[("OrbitError", LeafKind::Struct)]);
+        let (_temp_dir, context) = context_for_graph(&graph);
+
+        let result =
+            run(search_input(context, "OrbitErorr", false, 5)).expect("non-fuzzy search result");
+
+        assert!(result.hits.is_empty());
+    }
+
+    #[test]
+    fn fuzzy_pass_returns_empty_for_no_plausible_match() {
+        let graph = graph_with_named_leaves(&[
+            ("Widget", LeafKind::Struct),
+            ("Adapter", LeafKind::Struct),
+            ("Runtime", LeafKind::Struct),
+        ]);
+        let (_temp_dir, context) = context_for_graph(&graph);
+
+        let result =
+            run(search_input(context, "zzzzzzzzzz", true, 5)).expect("fuzzy search result");
+
+        assert!(result.hits.is_empty());
+    }
+
+    #[test]
+    fn fuzzy_results_break_score_ties_alphabetically() {
+        let graph =
+            graph_with_named_leaves(&[("Baz", LeafKind::Struct), ("Bar", LeafKind::Struct)]);
+        let (_temp_dir, context) = context_for_graph(&graph);
+
+        let result = run(search_input(context, "Bax", true, 5)).expect("fuzzy search result");
+
+        assert_eq!(result.hits.len(), 2);
+        assert_eq!(result.hits[0].score, result.hits[1].score);
+        assert!(result.hits[0].selector < result.hits[1].selector);
+        assert_eq!(result.hits[0].name, "Bar");
+        assert_eq!(result.hits[1].name, "Baz");
+    }
+
     fn sql_substring_selectors(
         reader: &GraphIndexReader,
         query: &str,
@@ -746,6 +871,85 @@ mod tests {
         .into_iter()
         .map(|hit| hit.selector)
         .collect()
+    }
+
+    fn search_input(
+        context: GraphCommandContext,
+        query: &str,
+        allow_fuzzy: bool,
+        limit: usize,
+    ) -> SearchInput {
+        SearchInput {
+            context,
+            query: query.to_string(),
+            node_type: None,
+            kind_filter: None,
+            prefix: None,
+            source_regex: None,
+            include_non_code: false,
+            allow_fuzzy,
+            limit,
+        }
+    }
+
+    fn context_for_graph(graph: &CodebaseGraphV1) -> (tempfile::TempDir, GraphCommandContext) {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let store = GraphObjectStore::new(temp_dir.path().join("graph"));
+        let current_ref = store.write_graph(graph).expect("write graph");
+        let ref_name = RefName::new("search-test").expect("valid ref name");
+        store
+            .write_ref_atomic(&ref_name, &current_ref)
+            .expect("write graph ref");
+        let context = GraphCommandContext {
+            knowledge_dir: temp_dir.path().to_path_buf(),
+            workspace_root: None,
+            explicit_ref: Some(ref_name.as_str().to_string()),
+            explicit_knowledge_dir: true,
+            task_scope: TaskGraphScope::default(),
+        };
+        (temp_dir, context)
+    }
+
+    fn graph_with_named_leaves(named_leaves: &[(&str, LeafKind)]) -> CodebaseGraphV1 {
+        let root_id = "dir:.".to_string();
+        let mut file_ids = Vec::with_capacity(named_leaves.len());
+        let mut files = Vec::with_capacity(named_leaves.len());
+        let mut leaves = Vec::with_capacity(named_leaves.len());
+
+        for (index, (name, kind)) in named_leaves.iter().enumerate() {
+            let stem = name.to_ascii_lowercase();
+            let file_location = format!("src/{stem}.rs");
+            let file_id = format!("file:{file_location}");
+            let leaf_location = format!("{file_location}#{name}");
+            let leaf_id = format!("symbol:{leaf_location}:{kind}");
+            file_ids.push(file_id.clone());
+            files.push(file_node(
+                &file_id,
+                &format!("{stem}.rs"),
+                &file_location,
+                Some(&root_id),
+                vec![leaf_id.clone()],
+            ));
+            leaves.push(leaf_node_with_kind(
+                &leaf_id,
+                name,
+                &leaf_location,
+                Some(&file_id),
+                (index + 1) as u32,
+                kind.clone(),
+            ));
+        }
+
+        CodebaseGraphV1 {
+            root_dir_id: root_id.clone(),
+            dirs: vec![DirNode {
+                base: base_node(&root_id, ".", ".", "", None),
+                dir_children: Vec::new(),
+                file_children: file_ids,
+            }],
+            files,
+            leaves,
+        }
     }
 
     fn graph_for_default_ranking_snapshot() -> CodebaseGraphV1 {

--- a/crates/orbit-knowledge/src/commands/show.rs
+++ b/crates/orbit-knowledge/src/commands/show.rs
@@ -6,6 +6,8 @@ use crate::graph::{CodebaseGraphV1, GraphIndexNodeRow, GraphNode, GraphReadOptio
 use crate::service::{GraphContextService, NodeContext};
 use crate::{KnowledgeError, Selector};
 
+use super::fuzzy::levenshtein_distance;
+
 /// Diagnostic suggestions are intentionally capped so failed lookups stay cheap
 /// and payloads remain small for agent callers.
 const DID_YOU_MEAN_LIMIT: usize = 5;
@@ -209,35 +211,6 @@ fn string_affinity_rank(needle: &str, candidate: &str) -> u8 {
     } else {
         2
     }
-}
-
-fn levenshtein_distance(left: &str, right: &str) -> usize {
-    if left == right {
-        return 0;
-    }
-    if left.is_empty() {
-        return right.chars().count();
-    }
-    if right.is_empty() {
-        return left.chars().count();
-    }
-
-    let right_chars = right.chars().collect::<Vec<_>>();
-    let mut previous = (0..=right_chars.len()).collect::<Vec<_>>();
-    let mut current = vec![0; right_chars.len() + 1];
-
-    for (left_index, left_char) in left.chars().enumerate() {
-        current[0] = left_index + 1;
-        for (right_index, right_char) in right_chars.iter().enumerate() {
-            let substitution = usize::from(left_char != *right_char);
-            current[right_index + 1] = (previous[right_index + 1] + 1)
-                .min(current[right_index] + 1)
-                .min(previous[right_index] + substitution);
-        }
-        std::mem::swap(&mut previous, &mut current);
-    }
-
-    previous[right_chars.len()]
 }
 
 fn try_show_via_sql_index(

--- a/crates/orbit-tools/src/builtin/orbit/knowledge/search.rs
+++ b/crates/orbit-tools/src/builtin/orbit/knowledge/search.rs
@@ -60,6 +60,14 @@ impl Tool for OrbitKnowledgeSearchTool {
                     required: false,
                 },
                 ToolParam {
+                    name: "allow_fuzzy".to_string(),
+                    description:
+                        "Enable fuzzy name fallback when the deterministic pass returns zero results."
+                            .to_string(),
+                    param_type: "boolean".to_string(),
+                    required: false,
+                },
+                ToolParam {
                     name: "format".to_string(),
                     description: "structured/selectors.".to_string(),
                     param_type: "string".to_string(),
@@ -97,6 +105,10 @@ impl Tool for OrbitKnowledgeSearchTool {
             .get("include_non_code")
             .and_then(Value::as_bool)
             .unwrap_or(false);
+        let allow_fuzzy = input
+            .get("allow_fuzzy")
+            .and_then(Value::as_bool)
+            .unwrap_or(false);
         let format = super::super::optional_string(&input, "format")?;
         let use_selectors = format.as_deref() == Some("selectors");
 
@@ -108,6 +120,7 @@ impl Tool for OrbitKnowledgeSearchTool {
             prefix,
             source_regex,
             include_non_code,
+            allow_fuzzy,
             limit,
         })
         .map_err(super::knowledge_error_to_orbit)?;
@@ -131,6 +144,12 @@ impl Tool for OrbitKnowledgeSearchTool {
                     });
                     if let Some(file) = hit.file {
                         obj["file"] = json!(file);
+                    }
+                    if let Some(match_kind) = hit.match_kind {
+                        obj["match_kind"] = json!(match_kind);
+                    }
+                    if let Some(score) = hit.score {
+                        obj["score"] = json!(score);
                     }
                     if has_source_regex {
                         obj["matched_lines"] = json!(


### PR DESCRIPTION
## Task

[ORB-00186](https://orbit-cli.com/tasks/ORB-00186) — Fuzzy-match fallback in orbit.graph.search

### Description

## Problem

`orbit.graph.search` fails closed on misspelled or partially-remembered names. A query like `OrbitErorr` or `dispach_v2_activity` returns 0 results and the caller has no recovery path inside the tool. Agents then fall back to grep, which is slower and bypasses the structured index.

## Why It Matters

Agents driving Orbit hit cold starts every session and have no accumulated codebase memory. Typo tolerance and partial recall are common failure modes — and they are *deterministic* problems that do not require embeddings, semantic indexes, or any of the heavier P1 work to fix.

## Approach

When the deterministic pass (exact / prefix / source_regex) returns 0 results AND the caller opted in via a new `allow_fuzzy: bool` flag, run a bounded fuzzy pass over the symbol/file name index (trigram or normalized Levenshtein, edit distance ≤ 2) and return up to `limit` candidates tagged `match_kind: "fuzzy"` with a similarity `score` in [0,1].

Do not silently replace exact results. Keep the deterministic surface deterministic — fuzzy matches only appear in `results` when exact matching produces nothing AND the caller asked for them.

## Constraints / Notes

- Off by default (`allow_fuzzy: false`). The `orbit-graph` skill must be updated in the same PR before the flag becomes useful.
- When exact pass returns ≥1 hit, the fuzzy pass MUST be skipped entirely (no fuzzy candidates in output, regardless of `allow_fuzzy`).
- Stable tie-break on equal similarity scores (alphabetical by selector) so identical inputs produce identical outputs.
- Scope: name-level fuzziness only (symbol name, file basename). Source-regex queries are not in scope — those failures usually mean the regex is wrong, not the symbol name.
- This is a precursor to ORB-XXXX (semantic search for code) but does NOT block it; the two features are independent.

### Acceptance Criteria

- Input schema for `orbit.graph.search` accepts a new optional boolean field `allow_fuzzy` (default `false`). Existing callers unaffected.
- When `allow_fuzzy=true` AND the deterministic pass returns 0 results, response `results` contains up to `limit` candidates, each with `match_kind: "fuzzy"` and a numeric `score` in [0.0, 1.0].
- When the deterministic pass returns ≥1 result, response contains zero entries with `match_kind: "fuzzy"` regardless of `allow_fuzzy`.
- Identical inputs produce byte-identical output: ties in fuzzy score break alphabetically by selector.
- In-file unit tests under `#[cfg(test)] mod tests` in `crates/orbit-knowledge/src/commands/search.rs` cover at minimum: (a) `OrbitErorr` returns `OrbitError` as a top fuzzy candidate when `allow_fuzzy=true`; (b) exact match suppresses fuzzy candidates; (c) `allow_fuzzy=false` preserves current 0-result behavior; (d) query with no plausible match returns empty `results`.
- Validation command: `cargo test -p orbit-knowledge --test search` (or the existing crate-local test target) passes without `--ignored`.
- Validation command: `make ci-fast` passes (fmt-check + guardrail scripts).
- `orbit-graph` skill content (`crates/orbit-core/assets/skills/orbit-graph/SKILL.md` or canonical location) documents the new `allow_fuzzy` field, including the no-fuzzy-when-exact-hits contract and the score semantics.
- No new cross-crate dependencies introduced (`ARCHITECTURE.md` rule). Implementation lives in `orbit-knowledge`; the tool schema surface in `orbit-tools` only forwards the new param.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Added an opt-in `allow_fuzzy` fallback to `orbit.graph.search` that runs only when deterministic search returns zero results.
- Moved the shared Levenshtein helper into `crates/orbit-knowledge/src/commands/fuzzy.rs` and reused it from `show.rs`.
- Added fuzzy result metadata (`match_kind: "fuzzy"`, `score`) through orbit-tools structured output while leaving selectors-only output unchanged.
- Documented `allow_fuzzy` in the canonical `orbit-graph` skill, including exact-hit suppression, score semantics, source-regex behavior, and selectors-only projection behavior.
- Added in-file unit coverage for typo recovery, exact-hit suppression, default-off zero-result behavior, no-match behavior, and fuzzy tie-breaking by selector.

Assessment: Implementation is scoped to orbit-knowledge plus the orbit-tools forwarding/schema surface and skill docs; no new dependencies or cross-crate dependency edges were introduced.

Deviations from original plan:
- Live smoke command `orbit knowledge build` is not present in the current CLI; recorded friction `F2026-05-041` and used `target/debug/orbit graph build` plus `cargo run -p orbit-cli -- tool run orbit.graph.search ...` for smoke validation.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-00186-6a0d31c9`
- Behind base: 0
- Ahead of base: 1