### PR TITLE
Remove retired ship-auto run subcommand from CLI suggestions

### DIFF
--- a/crates/orbit-cli/src/audit_middleware.rs
+++ b/crates/orbit-cli/src/audit_middleware.rs
@@ -623,7 +623,6 @@ fn run_command_meta(cmd: &crate::command::run::RunCommand) -> CommandMeta {
 
     let (subcommand, target_type, target_id) = match &cmd.command {
         RunSubcommand::Ship(_) => ("ship", Some("workflow"), Some("ship")),
-        RunSubcommand::ShipAuto(_) => ("ship-auto", Some("workflow"), Some("ship-auto")),
         RunSubcommand::ShipLocal(_) => ("ship-local", Some("workflow"), Some("ship-local")),
         RunSubcommand::DuelPlan(args) => ("duel-plan", Some("task"), Some(args.task_id.as_str())),
         RunSubcommand::History(args) => ("history", Some("job_run"), args.job_id.as_deref()),
@@ -778,15 +777,6 @@ mod tests {
         assert_eq!(local.subcommand.as_deref(), Some("ship"));
         assert_eq!(local.target_type.as_deref(), Some("workflow"));
         assert_eq!(local.target_id.as_deref(), Some("ship"));
-    }
-
-    #[test]
-    fn run_ship_auto_audit_meta_uses_deprecated_top_level_command() {
-        let meta = meta_for(&["orbit", "run", "ship-auto"]);
-        assert_eq!(meta.command, "run");
-        assert_eq!(meta.subcommand.as_deref(), Some("ship-auto"));
-        assert_eq!(meta.target_type.as_deref(), Some("workflow"));
-        assert_eq!(meta.target_id.as_deref(), Some("ship-auto"));
     }
 
     #[test]

--- a/crates/orbit-cli/src/command/run/mod.rs
+++ b/crates/orbit-cli/src/command/run/mod.rs
@@ -86,9 +86,6 @@ impl Execute for RunCommand {
 pub enum RunSubcommand {
     /// Ship backlog or explicitly selected tasks through the gated task pipeline
     Ship(ship::ShipCommand),
-    /// Deprecated alias for `orbit run ship`
-    #[command(name = "ship-auto", hide = true)]
-    ShipAuto(ship::LegacyShipAutoCommand),
     /// Deprecated alias for `orbit run ship --mode local`
     #[command(name = "ship-local", hide = true)]
     ShipLocal(ship::LegacyShipLocalCommand),
@@ -113,7 +110,6 @@ impl Execute for RunSubcommand {
     fn execute(self, runtime: &OrbitRuntime) -> Result<(), OrbitError> {
         match self {
             RunSubcommand::Ship(command) => command.execute(runtime),
-            RunSubcommand::ShipAuto(command) => command.execute(runtime),
             RunSubcommand::ShipLocal(command) => command.execute(runtime),
             RunSubcommand::DuelPlan(command) => command.execute(runtime),
             RunSubcommand::History(command) => command.execute(runtime),
@@ -181,18 +177,6 @@ mod tests {
                 assert_eq!(args.base.as_deref(), Some("main"));
             }
             _ => panic!("expected ship"),
-        }
-    }
-
-    #[test]
-    fn parses_ship_auto_as_deprecated_top_level_subcommand() {
-        let command = parse_run(&["orbit", "run", "ship-auto", "-m", "pr", "-b", "main"]);
-        match command.command {
-            RunSubcommand::ShipAuto(args) => {
-                assert_eq!(args.mode, ship::ShipMode::Pr);
-                assert_eq!(args.base.as_deref(), Some("main"));
-            }
-            _ => panic!("expected ship-auto"),
         }
     }
 

--- a/crates/orbit-cli/src/command/run/ship.rs
+++ b/crates/orbit-cli/src/command/run/ship.rs
@@ -59,33 +59,6 @@ impl Execute for ShipCommand {
 
 #[derive(Args)]
 #[command(
-    about = "Deprecated alias for `orbit run ship`",
-    override_usage = "orbit run ship-auto [OPTIONS]",
-    after_help = "`orbit run ship-auto` was replaced by `orbit run ship`. Omit task ids for auto mode."
-)]
-pub struct LegacyShipAutoCommand {
-    /// Deprecated. Use `orbit run ship --mode <MODE>`.
-    #[arg(short = 'm', long, value_enum, default_value = "pr")]
-    pub mode: ShipMode,
-    /// Deprecated. Use `orbit run ship --base <BRANCH>`.
-    #[arg(short = 'b', long)]
-    pub base: Option<String>,
-    /// Deprecated.
-    #[arg(long)]
-    pub json: bool,
-}
-
-impl Execute for LegacyShipAutoCommand {
-    fn execute(self, _runtime: &OrbitRuntime) -> Result<(), OrbitError> {
-        let _ = self;
-        Err(OrbitError::InvalidInput(
-            "`orbit run ship-auto` was replaced by `orbit run ship` (auto mode runs when no task ids are supplied)".to_string(),
-        ))
-    }
-}
-
-#[derive(Args)]
-#[command(
     about = "Deprecated alias for `orbit run ship --mode local`",
     override_usage = "orbit run ship-local [<TASK_ID>...] [OPTIONS]",
     after_help = "`orbit run ship-local` was replaced by `orbit run ship --mode local`."
@@ -267,22 +240,6 @@ mod tests {
                 "base_branch": "main",
                 "task_ids": ["T20260425-2010"],
             })
-        );
-    }
-
-    #[test]
-    fn ship_auto_deprecation_returns_legacy_error() {
-        let runtime = OrbitRuntime::in_memory().expect("build runtime");
-        let err = LegacyShipAutoCommand {
-            mode: ShipMode::Pr,
-            base: None,
-            json: false,
-        }
-        .execute(&runtime)
-        .expect_err("deprecated command should fail");
-        assert!(
-            err.to_string().contains("orbit run ship"),
-            "unexpected error: {err}"
         );
     }
 


### PR DESCRIPTION
## Task

[ORB-00194](https://orbit-cli.com/tasks/ORB-00194) — Remove retired ship-auto run subcommand from CLI suggestions

### Description

## Problem
`orbit run ship]` currently reports `ship-auto` as a similar subcommand even though `ship-auto` has been retired in favor of `orbit run ship`. The visible `orbit run --help` output no longer lists it, but the hidden clap subcommand still participates in typo suggestions.

## Why It Matters
Operators who mistype `orbit run ship` get nudged toward an obsolete command, which makes the CLI feel inconsistent with the current shipment workflow.

## Constraints / Notes
- Treat this as follow-up cleanup from ORB-00075, which unified `ship`, `ship-local`, and `ship-auto` under `orbit run ship`.
- Remove the active hidden `ship-auto` parser surface, its legacy command plumbing, and any audit/parser tests that only exist for that retired command.
- Preserve historical docs/ADRs that mention `ship-auto` as past context unless they are presented as current operator guidance.
- Consider whether `ship-local` should remain as a hidden deprecated command separately; this task is specifically about ensuring `ship-auto` is not suggested or callable as a run subcommand.

### Acceptance Criteria

- Running `orbit run ship] 2>&1` reports the typo without including `ship-auto` anywhere in stderr.
- Running `orbit run ship-auto 2>&1` no longer reaches the legacy replacement error; it is treated as an unrecognized run subcommand.
- Active CLI code under `crates/orbit-cli/src/command/run/` and run audit metadata in `crates/orbit-cli/src/audit_middleware.rs` no longer registers or dispatches a `ship-auto` subcommand.
- Relevant parser/audit tests are updated or removed, and `cargo test -p orbit-cli command::run::tests` passes.
- `make ci-fast` passes.

## Execution Summary

<details>
<summary>Click to expand</summary>

Removed hidden `ship-auto` RunSubcommand variant, LegacyShipAutoCommand parser/executor, matching arms in Execute and run_command_meta, and the two dedicated parser/audit tests for the retired alias. ship-local retained. Verified: `orbit run ship]` suggests only ship/ship-local (no ship-auto); `orbit run ship-auto` now yields unrecognized subcommand error (not legacy); cargo test -p orbit-cli for run tests passes (24/24); all ci-fast guardrails + fmt-check pass. No other files edited; docs/ADRs/CHANGELOG/support.rs/core left per scope and preservation rules. Reinforced audit metadata update per L20260517-13.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-00194-6a0d3616`
- Behind base: 0
- Ahead of base: 1