### PR TITLE
Add dashboard parity for `orbit metrics` (knowledge, activity, tools, task aggregates + invocation filters)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2141,6 +2141,7 @@ dependencies = [
  "futures-core",
  "orbit-common",
  "orbit-core",
+ "rusqlite",
  "serde",
  "serde_json",
  "serde_yaml",

--- a/crates/orbit-dashboard/Cargo.toml
+++ b/crates/orbit-dashboard/Cargo.toml
@@ -23,6 +23,7 @@ tokio.workspace = true
 url.workspace = true
 
 [dev-dependencies]
+rusqlite.workspace = true
 serde_yaml.workspace = true
 tempfile = "3"
 tower = { version = "0.5", features = ["util"] }

--- a/crates/orbit-dashboard/assets/dashboard/app.js
+++ b/crates/orbit-dashboard/assets/dashboard/app.js
@@ -5,6 +5,7 @@ import { el, statusPill, stateCell, fetchJson, requestJson, postJson, patchJson,
 import { buildChips, cacheCrewPayload, copyTaskIdWithNotice, hasCrewOptions, openVisibleTask, renderTasks, wireSearch } from './tasks.js';
 import { applyAuditHashQuery, buildAuditChips, buildAuditHash, fetchAndRenderAudit, fetchAndRenderPolicy, getActiveAuditSubtab, navigateToAuditExecution, renderAuditSummary, setActiveAuditSubtabFromButton, setAuditSubtab, syncAuditControls, wireAuditSearch, } from './audit.js';
 import { renderScoreboard } from './scoreboard.js';
+import { fetchAndRenderMetrics, initMetrics, renderMetrics } from './metrics.js';
 import { initLogTail, fitLogPanelToViewport } from './log-tail.js';
 import { renderDiagnostics, renderImplementOneCard as renderImplOne, } from './diagnostics.js';
 import { initRouter, initTabs as iT, navigateToRun as nTR, setActiveTab as sAT, setRunDetailSubtab, } from './router.js';
@@ -70,6 +71,7 @@ let lastAdrPayload = { stats: {}, items: [] };
 let lastFrictionPayload = { stats: {}, tags: [], items: [] };
 let activeTab = "tasks";
 let activeDiagSubtab = "runs";
+let activeMetricsSubtab = "knowledge";
 let activeKnowledgeSubtab = "learnings";
 let isRefreshing = false;
 let activeLearningId = null;
@@ -127,6 +129,14 @@ function diagnosticsContext() {
   };
 }
 
+function metricsContext() {
+  return {
+    getActiveMetricsSubtab: () => activeMetricsSubtab,
+    setActiveMetricsSubtab: (v) => { activeMetricsSubtab = v; },
+    fmtAbsTime,
+  };
+}
+
 function routerContext() {
   return {
     // getters/setters for router-owned state (kept in app.js per extraction contract)
@@ -134,6 +144,8 @@ function routerContext() {
     setTab: (v) => { activeTab = v; },
     getDiagSubtab: () => activeDiagSubtab,
     setDiagSubtab: (v) => { activeDiagSubtab = v; },
+    getMetricsSubtab: () => activeMetricsSubtab,
+    setMetricsSubtab: (v) => { activeMetricsSubtab = v; },
     getKnowledgeSubtab: () => activeKnowledgeSubtab,
     setKnowledgeSubtab: (v) => { activeKnowledgeSubtab = v; },
     getRunId: getActiveRunId,
@@ -155,6 +167,7 @@ function routerContext() {
     // callbacks (close over app.js scope)
     refreshDashboard,
     renderDiagnostics: () => renderDiagnostics(diagnosticsContext()),
+    renderMetrics: () => renderMetrics(metricsContext()),
     fitLogPanelToViewport,
 
     // audit pass-throughs (re-exported here for router; imported at top of this file)
@@ -1007,6 +1020,11 @@ function activeRefreshJobs() {
     return jobs;
   }
 
+  if (activeTab === "metrics") {
+    jobs.push(fetchAndRenderMetrics(metricsContext()));
+    return jobs;
+  }
+
   if (activeTab === "audit") {
     if (getActiveAuditSubtab() === "policy") {
       jobs.push(fetchAndRenderPolicy(auditContext()));
@@ -1220,6 +1238,7 @@ function renderSparkline(buckets) {
 
 function refreshLabel() {
   if (activeTab === "diagnostics") return `diagnostics/${activeDiagSubtab}`;
+  if (activeTab === "metrics") return `metrics/${activeMetricsSubtab}`;
   if (activeTab === "run-detail") return `run/${getActiveRunId() || "?"}`;
   return activeTab;
 }
@@ -1271,6 +1290,7 @@ $("refresh-btn").addEventListener("click", refreshDashboard);
 
 initRuns(runsContext());
 initRunDetail(runDetailContext());
+initMetrics(metricsContext());
 const rctx = routerContext();
 initRouter(rctx);
 iT();

--- a/crates/orbit-dashboard/assets/dashboard/dashboard.css
+++ b/crates/orbit-dashboard/assets/dashboard/dashboard.css
@@ -195,7 +195,8 @@
       #audit-search,
       #learning-search,
       #adr-search,
-      #friction-search {
+      #friction-search,
+      .metrics-form input {
         flex: 0 1 280px;
         min-width: 160px;
         background: var(--bg);
@@ -213,7 +214,8 @@
       #audit-search:focus,
       #learning-search:focus,
       #adr-search:focus,
-      #friction-search:focus {
+      #friction-search:focus,
+      .metrics-form input:focus {
         border-color: var(--accent);
       }
       
@@ -1134,6 +1136,104 @@
       .scoreboard-table-wrap table.scoreboard-table th,
       .scoreboard-table-wrap table.scoreboard-table td {
         padding: 6px 12px;
+      }
+
+      .metrics-controls {
+        align-items: stretch;
+      }
+
+      .metrics-form {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+        gap: 8px;
+        width: 100%;
+      }
+
+      .metrics-form.compact {
+        grid-template-columns: minmax(180px, 320px) max-content;
+        align-items: end;
+      }
+
+      .metrics-form label {
+        display: flex;
+        min-width: 0;
+        flex-direction: column;
+        gap: 4px;
+        color: var(--fg-dim);
+        font-family: var(--font-mono);
+        font-size: 10px;
+        letter-spacing: 0.05em;
+        text-transform: uppercase;
+      }
+
+      .metrics-form input {
+        width: 100%;
+        min-width: 0;
+        flex-basis: auto;
+        font-family: var(--font-mono);
+      }
+
+      .metrics-form .action {
+        align-self: end;
+        justify-self: start;
+      }
+
+      .metrics-summary {
+        display: grid;
+        gap: 14px;
+        padding: 14px 16px 18px;
+        background: var(--bg);
+      }
+
+      .metrics-summary-section {
+        border: 1px solid var(--border);
+        background: #050505;
+      }
+
+      .metrics-summary-section h3 {
+        margin: 0;
+        padding: 8px 10px;
+        border-bottom: 1px solid var(--border);
+        color: var(--fg-dim);
+        font-size: 11px;
+        font-weight: 600;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+      }
+
+      .metrics-kv-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+      }
+
+      .metrics-kv {
+        display: flex;
+        min-width: 0;
+        flex-direction: column;
+        gap: 3px;
+        padding: 10px;
+        border-right: 1px solid var(--border);
+        border-bottom: 1px solid var(--border);
+      }
+
+      .metrics-kv .label {
+        color: var(--fg-dim);
+        font-family: var(--font-mono);
+        font-size: 10px;
+        text-transform: uppercase;
+      }
+
+      .metrics-kv .value {
+        overflow: hidden;
+        color: var(--fg);
+        font-family: var(--font-mono);
+        font-size: 13px;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
+
+      .metrics-kv .value.accent {
+        color: var(--accent-hover);
       }
 
       table.sb-leaderboard {

--- a/crates/orbit-dashboard/assets/dashboard/index.html
+++ b/crates/orbit-dashboard/assets/dashboard/index.html
@@ -4,6 +4,7 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>orbit</title>
+    <link rel="icon" href="data:,">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
@@ -29,6 +30,7 @@
     <nav class="tabs" id="tabs">
       <button class="tab" data-tab="tasks" type="button">Tasks</button>
       <button class="tab" data-tab="scoreboard" type="button">Scoreboard</button>
+      <button class="tab" data-tab="metrics" type="button">Metrics</button>
       <button class="tab" data-tab="audit" type="button">Audit</button>
       <button class="tab" data-tab="diagnostics" type="button">Diagnostics</button>
       <button class="tab" data-tab="knowledge" type="button">Knowledge</button>
@@ -150,6 +152,47 @@
             </div>
           </section>
         </div>
+      </main>
+    </section>
+    <section class="tab-pane" data-tab="metrics">
+      <main style="grid-template-columns: 1fr;">
+        <section class="panel" id="metrics-panel">
+          <header><span id="metrics-title">Metrics</span><span class="count" id="metrics-count">-</span></header>
+          <nav class="subtabs" id="metrics-subtabs">
+            <button class="subtab" data-subtab="knowledge" type="button">Knowledge</button>
+            <button class="subtab" data-subtab="activity" type="button">Activity</button>
+            <button class="subtab" data-subtab="tools" type="button">Tools</button>
+            <button class="subtab" data-subtab="task" type="button">Task</button>
+            <button class="subtab" data-subtab="invocations" type="button">Invocations</button>
+          </nav>
+          <div class="controls metrics-controls" id="metrics-task-controls" style="display: none;">
+            <form class="metrics-form compact" id="metrics-task-form">
+              <label>task_id<input type="search" id="metrics-task-id" autocomplete="off" spellcheck="false" /></label>
+              <button class="action" type="submit">Apply</button>
+            </form>
+          </div>
+          <div class="controls metrics-controls" id="metrics-invocation-controls" style="display: none;">
+            <form class="metrics-form" id="metrics-invocation-form">
+              <label>since<input type="text" id="metrics-filter-since" autocomplete="off" spellcheck="false" /></label>
+              <label>until<input type="text" id="metrics-filter-until" autocomplete="off" spellcheck="false" /></label>
+              <label>job_run_id<input type="text" id="metrics-filter-job-run-id" autocomplete="off" spellcheck="false" /></label>
+              <label>activity_id<input type="text" id="metrics-filter-activity-id" autocomplete="off" spellcheck="false" /></label>
+              <label>task_id<input type="text" id="metrics-filter-task-id" autocomplete="off" spellcheck="false" /></label>
+              <label>agent<input type="text" id="metrics-filter-agent" autocomplete="off" spellcheck="false" /></label>
+              <label>model<input type="text" id="metrics-filter-model" autocomplete="off" spellcheck="false" /></label>
+              <label>tool_name<input type="text" id="metrics-filter-tool-name" autocomplete="off" spellcheck="false" /></label>
+              <label>limit<input type="number" id="metrics-filter-limit" min="1" max="500" value="50" /></label>
+              <button class="action" type="submit">Apply</button>
+            </form>
+          </div>
+          <div class="body scoreboard-table-wrap" id="metrics-body">
+            <div class="skeleton-state">
+              <div class="skeleton skeleton-row"></div>
+              <div class="skeleton skeleton-row" style="width: 80%"></div>
+              <div class="skeleton skeleton-row" style="width: 70%"></div>
+            </div>
+          </div>
+        </section>
       </main>
     </section>
     <section class="tab-pane" data-tab="run-detail">

--- a/crates/orbit-dashboard/assets/dashboard/metrics.js
+++ b/crates/orbit-dashboard/assets/dashboard/metrics.js
@@ -1,0 +1,372 @@
+// Orbit dashboard metrics-domain (CLI metrics parity tables + invocation filters).
+
+import { el, fetchJson, syncNodes } from './common.js';
+
+const $ = (id) => document.getElementById(id);
+
+const DEFAULT_KNOWLEDGE_LIMIT = 100;
+const DEFAULT_INVOCATION_LIMIT = 50;
+
+let lastMetrics = {
+  knowledge: null,
+  activity: [],
+  tools: [],
+  task: null,
+  invocations: [],
+};
+
+function activeSubtab(ctx) {
+  return ctx && typeof ctx.getActiveMetricsSubtab === "function"
+    ? ctx.getActiveMetricsSubtab()
+    : "knowledge";
+}
+
+function showNode(id, show) {
+  const node = $(id);
+  if (node) node.style.display = show ? "" : "none";
+}
+
+function countFor(sub) {
+  if (sub === "knowledge") {
+    return lastMetrics.knowledge ? String(lastMetrics.knowledge.total_runs || 0) : "-";
+  }
+  if (sub === "activity") return String(lastMetrics.activity.length);
+  if (sub === "tools") return String(lastMetrics.tools.length);
+  if (sub === "task") return lastMetrics.task ? String(lastMetrics.task.invocation_count || 0) : "-";
+  if (sub === "invocations") return String(lastMetrics.invocations.length);
+  return "-";
+}
+
+function formatNumber(value, digits = 0) {
+  const n = Number(value);
+  if (!Number.isFinite(n)) return "-";
+  if (!Number.isInteger(digits) || digits < 0 || digits > 20) digits = 0;
+  return n.toLocaleString(undefined, {
+    maximumFractionDigits: digits,
+    minimumFractionDigits: digits,
+  });
+}
+
+function formatDecimal(value) {
+  return formatNumber(value, 1);
+}
+
+function formatPercent(value, digits = 1) {
+  const n = Number(value);
+  if (!Number.isFinite(n)) return "-";
+  return `${(n * 100).toFixed(digits)}%`;
+}
+
+function formatRatio(value) {
+  return value == null ? "-" : `${formatDecimal(value)}x`;
+}
+
+function formatTimestamp(ctx, value) {
+  if (!value) return "-";
+  return ctx && typeof ctx.fmtAbsTime === "function" ? ctx.fmtAbsTime(value) : String(value);
+}
+
+function taskCount(row) {
+  return Array.isArray(row && row.task_ids) ? row.task_ids.length : 0;
+}
+
+function modelValue(value) {
+  return value || "-";
+}
+
+function emptyState(text) {
+  return el("div", { class: "empty-state" }, [
+    el("div", { class: "icon", text: "*" }),
+    el("div", { class: "text", text }),
+  ]);
+}
+
+function tableCell(col, row, ctx) {
+  const td = el("td", { class: col.num ? "num" : "" });
+  const value = col.render ? col.render(row[col.key], row, ctx) : row[col.key];
+  td.textContent = value == null ? "" : String(value);
+  if (col.title) td.title = col.title(row[col.key], row, ctx) || "";
+  return td;
+}
+
+function renderTable(rows, columns, emptyText, ctx) {
+  if (!Array.isArray(rows) || rows.length === 0) {
+    return emptyState(emptyText);
+  }
+
+  const table = el("table", { class: "scoreboard-table" });
+  const thead = el("thead");
+  const headRow = el("tr");
+  for (const col of columns) {
+    headRow.appendChild(el("th", { class: col.num ? "num" : "", text: col.label }));
+  }
+  thead.appendChild(headRow);
+  table.appendChild(thead);
+
+  const tbody = el("tbody");
+  rows.forEach((row, index) => {
+    const tr = el("tr");
+    for (const col of columns) tr.appendChild(tableCell(col, row, ctx));
+    tr.dataset.key = `metrics-row-${index}-${JSON.stringify(row).slice(0, 80)}`;
+    tr.dataset.hash = JSON.stringify(row);
+    tbody.appendChild(tr);
+  });
+  table.appendChild(tbody);
+  return table;
+}
+
+function kv(label, value, opts = {}) {
+  return el("div", { class: "metrics-kv" }, [
+    el("span", { class: "label", text: label }),
+    el("span", {
+      class: opts.accent ? "value accent" : "value",
+      text: value == null || value === "" ? "-" : String(value),
+      title: value == null ? "" : String(value),
+    }),
+  ]);
+}
+
+function summarySection(title, items) {
+  return el("section", { class: "metrics-summary-section" }, [
+    el("h3", { text: title }),
+    el("div", { class: "metrics-kv-grid" }, items),
+  ]);
+}
+
+function renderKnowledge(summary) {
+  if (!summary || Number(summary.total_runs || 0) === 0) {
+    return emptyState("No knowledge usage metrics found.");
+  }
+
+  const compression = summary.compression || {};
+  const doubleRead = summary.double_read || {};
+  const input = summary.total_llm_input_tokens || {};
+  return el("div", { class: "metrics-summary" }, [
+    summarySection("Runs", [
+      kv("total", formatNumber(summary.total_runs), { accent: true }),
+      kv("with pack", formatNumber(summary.pack_runs)),
+      kv("fallback", formatNumber(summary.fallback_runs)),
+      kv("fallback rate", formatPercent(summary.fallback_rate), { accent: true }),
+    ]),
+    summarySection("Compression (tokenized, cl100k_base)", [
+      kv("mean", formatRatio(compression.mean), { accent: true }),
+      kv("p50", formatRatio(compression.p50)),
+      kv("p90", formatRatio(compression.p90)),
+      kv("min", formatRatio(compression.min)),
+    ]),
+    summarySection("Double-read guard", [
+      kv("mean rate", `${formatNumber(doubleRead.mean_rate, 2)} (${formatPercent(doubleRead.mean_rate, 0)} baseline re-read)`, { accent: true }),
+      kv("runs >50%", `${formatNumber(doubleRead.runs_over_fifty_percent)} / ${formatNumber(doubleRead.measured_runs)}`),
+    ]),
+    summarySection("Total LLM input tokens per activity", [
+      kv("with pack avg", input.with_pack_avg == null ? "-" : `${formatNumber(input.with_pack_avg)} tokens`, { accent: true }),
+      kv("without pack avg", input.without_pack_avg == null ? "-" : `${formatNumber(input.without_pack_avg)} tokens`),
+      kv("estimated savings", input.estimated_savings == null ? "-" : formatPercent(input.estimated_savings, 0)),
+    ]),
+  ]);
+}
+
+function activityColumns() {
+  return [
+    { key: "activity_id", label: "activity" },
+    { key: "agent", label: "agent" },
+    { key: "model", label: "model", render: modelValue },
+    { key: "invocation_count", label: "invocations", num: true, render: formatNumber },
+    { key: "avg_tokens", label: "avg", num: true, render: formatDecimal },
+    { key: "p50_tokens", label: "p50", num: true, render: formatNumber },
+    { key: "p95_tokens", label: "p95", num: true, render: formatNumber },
+    { key: "total_tokens", label: "total", num: true, render: formatNumber },
+    { key: "total_input_tokens", label: "input", num: true, render: formatNumber },
+    { key: "total_cache_read_tokens", label: "cache read", num: true, render: formatNumber },
+    { key: "total_cache_create_tokens", label: "cache create", num: true, render: formatNumber },
+    { key: "total_output_tokens", label: "output", num: true, render: formatNumber },
+    { key: "total_tool_calls", label: "tools", num: true, render: formatNumber },
+  ];
+}
+
+function toolColumns() {
+  return [
+    { key: "activity_id", label: "activity" },
+    { key: "tool_name", label: "tool" },
+    { key: "call_count", label: "calls", num: true, render: formatNumber },
+    { key: "avg_result_bytes", label: "avg result bytes", num: true, render: formatDecimal },
+    { key: "total_result_bytes", label: "total result bytes", num: true, render: formatNumber },
+  ];
+}
+
+function taskColumns() {
+  return [
+    { key: "task_id", label: "task" },
+    { key: "invocation_count", label: "invocations", num: true, render: formatNumber },
+    { key: "total_tokens", label: "total", num: true, render: formatNumber },
+    { key: "total_input_tokens", label: "input", num: true, render: formatNumber },
+    { key: "total_cache_read_tokens", label: "cache read", num: true, render: formatNumber },
+    { key: "total_cache_create_tokens", label: "cache create", num: true, render: formatNumber },
+    { key: "total_output_tokens", label: "output", num: true, render: formatNumber },
+    { key: "total_tool_calls", label: "tools", num: true, render: formatNumber },
+  ];
+}
+
+function invocationColumns() {
+  return [
+    { key: "ts", label: "ts", render: (value, row, ctx) => formatTimestamp(ctx, value) },
+    { key: "job_run_id", label: "job run" },
+    { key: "activity_id", label: "activity" },
+    { key: "agent", label: "agent" },
+    { key: "model", label: "model", render: modelValue },
+    { key: "total_tokens", label: "total", num: true, render: formatNumber },
+    { key: "input_tokens", label: "input", num: true, render: formatNumber },
+    { key: "cache_read_tokens", label: "cache read", num: true, render: formatNumber },
+    { key: "cache_create_tokens", label: "cache create", num: true, render: formatNumber },
+    { key: "output_tokens", label: "output", num: true, render: formatNumber },
+    { key: "tool_call_count", label: "tools", num: true, render: formatNumber },
+    { key: "task_ids", label: "tasks", num: true, render: (_value, row) => formatNumber(taskCount(row)) },
+  ];
+}
+
+function taskIdFromForm() {
+  return ($("metrics-task-id")?.value || "").trim();
+}
+
+function setTaskId(value) {
+  const input = $("metrics-task-id");
+  if (input && value) input.value = value;
+}
+
+function invocationsParams() {
+  const fields = [
+    ["since", "metrics-filter-since"],
+    ["until", "metrics-filter-until"],
+    ["job_run_id", "metrics-filter-job-run-id"],
+    ["activity_id", "metrics-filter-activity-id"],
+    ["task_id", "metrics-filter-task-id"],
+    ["agent", "metrics-filter-agent"],
+    ["model", "metrics-filter-model"],
+    ["tool_name", "metrics-filter-tool-name"],
+    ["limit", "metrics-filter-limit"],
+  ];
+  const sp = new URLSearchParams();
+  for (const [key, id] of fields) {
+    const value = ($(id)?.value || "").trim();
+    if (value) sp.set(key, value);
+  }
+  if (!sp.has("limit")) sp.set("limit", String(DEFAULT_INVOCATION_LIMIT));
+  return sp;
+}
+
+function inferTaskId() {
+  const current = taskIdFromForm();
+  if (current) return Promise.resolve(current);
+  const fromRows = lastMetrics.invocations.find((row) => Array.isArray(row.task_ids) && row.task_ids[0]);
+  if (fromRows) {
+    setTaskId(fromRows.task_ids[0]);
+    return Promise.resolve(fromRows.task_ids[0]);
+  }
+  return fetchJson("/api/metrics/invocations?limit=1").then((rows) => {
+    const id = Array.isArray(rows) && rows[0] && Array.isArray(rows[0].task_ids)
+      ? rows[0].task_ids[0]
+      : "";
+    if (id) setTaskId(id);
+    return id || "";
+  });
+}
+
+function renderTask() {
+  return renderTable(
+    lastMetrics.task ? [lastMetrics.task] : [],
+    taskColumns(),
+    "No task metrics found.",
+  );
+}
+
+function renderMetrics(ctx = {}) {
+  const sub = activeSubtab(ctx);
+  const body = $("metrics-body");
+  if (!body) return;
+
+  showNode("metrics-task-controls", sub === "task");
+  showNode("metrics-invocation-controls", sub === "invocations");
+  const title = $("metrics-title");
+  if (title) title.textContent = `Metrics / ${sub}`;
+  const count = $("metrics-count");
+  if (count) count.textContent = countFor(sub);
+
+  let node;
+  if (sub === "knowledge") {
+    node = renderKnowledge(lastMetrics.knowledge);
+  } else if (sub === "activity") {
+    node = renderTable(lastMetrics.activity, activityColumns(), "No invocation metrics found.", ctx);
+  } else if (sub === "tools") {
+    node = renderTable(lastMetrics.tools, toolColumns(), "No tool call metrics found.", ctx);
+  } else if (sub === "task") {
+    node = renderTask();
+  } else {
+    node = renderTable(lastMetrics.invocations, invocationColumns(), "No invocation records found.", ctx);
+  }
+  node.dataset.key = `metrics-${sub}`;
+  node.dataset.hash = JSON.stringify(lastMetrics[sub] || null);
+  syncNodes(body, [node]);
+}
+
+function fetchAndRenderMetrics(ctx = {}) {
+  const sub = activeSubtab(ctx);
+  if (sub === "knowledge") {
+    return fetchJson(`/api/metrics/knowledge?limit=${DEFAULT_KNOWLEDGE_LIMIT}`).then((payload) => {
+      lastMetrics.knowledge = payload;
+      renderMetrics(ctx);
+    });
+  }
+  if (sub === "activity") {
+    return fetchJson("/api/metrics/activity").then((rows) => {
+      lastMetrics.activity = Array.isArray(rows) ? rows : [];
+      renderMetrics(ctx);
+    });
+  }
+  if (sub === "tools") {
+    return fetchJson("/api/metrics/tools").then((rows) => {
+      lastMetrics.tools = Array.isArray(rows) ? rows : [];
+      renderMetrics(ctx);
+    });
+  }
+  if (sub === "task") {
+    return inferTaskId().then((taskId) => {
+      if (!taskId) {
+        lastMetrics.task = null;
+        renderMetrics(ctx);
+        return null;
+      }
+      return fetchJson(`/api/metrics/task/${encodeURIComponent(taskId)}`).then((row) => {
+        lastMetrics.task = row;
+        renderMetrics(ctx);
+      });
+    });
+  }
+
+  return fetchJson(`/api/metrics/invocations?${invocationsParams().toString()}`).then((rows) => {
+    lastMetrics.invocations = Array.isArray(rows) ? rows : [];
+    renderMetrics(ctx);
+  });
+}
+
+function initMetrics(ctx = {}) {
+  const taskForm = $("metrics-task-form");
+  if (taskForm) {
+    taskForm.addEventListener("submit", (event) => {
+      event.preventDefault();
+      fetchAndRenderMetrics(ctx).catch(console.error);
+    });
+  }
+  const invocationsForm = $("metrics-invocation-form");
+  if (invocationsForm) {
+    invocationsForm.addEventListener("submit", (event) => {
+      event.preventDefault();
+      fetchAndRenderMetrics(ctx).catch(console.error);
+    });
+  }
+}
+
+export {
+  fetchAndRenderMetrics,
+  initMetrics,
+  renderMetrics,
+};

--- a/crates/orbit-dashboard/assets/dashboard/router.js
+++ b/crates/orbit-dashboard/assets/dashboard/router.js
@@ -2,7 +2,7 @@
 // Pure vanilla JS, split into ES module with no build step.
 //
 // Moved from app.js (router was the widest cross-cut for subsequent module splits).
-// Owns: TABS, DIAG_SUBTABS, RUN_DETAIL_SUBTABS, KNOWLEDGE_SUBTABS, parseHashRoute,
+// Owns: TABS, DIAG_SUBTABS, METRICS_SUBTABS, RUN_DETAIL_SUBTABS, KNOWLEDGE_SUBTABS, parseHashRoute,
 // setActiveTab, set*Subtab helpers, initTabs, navigateToRun.
 //
 // All mutable dashboard state remains in app.js. Router receives a context object
@@ -22,8 +22,9 @@ import { renderRuns } from './runs.js';
 
 const $ = (id) => document.getElementById(id);
 
-const TABS = ["tasks", "scoreboard", "audit", "diagnostics", "knowledge", "run-detail"];
+const TABS = ["tasks", "scoreboard", "metrics", "audit", "diagnostics", "knowledge", "run-detail"];
 const DIAG_SUBTABS = ["runs", "metrics", "errors"];
+const METRICS_SUBTABS = ["knowledge", "activity", "tools", "task", "invocations"];
 const RUN_DETAIL_SUBTABS = ["steps", "events"];
 const KNOWLEDGE_SUBTABS = ["learnings", "adrs", "frictions"];
 
@@ -80,6 +81,15 @@ function setDiagSubtabImpl(ctx, name) {
     $("runs-body").style.display = "none";
     ctx.renderDiagnostics();
   }
+}
+
+function setMetricsSubtabImpl(ctx, name) {
+  if (!METRICS_SUBTABS.includes(name)) name = "knowledge";
+  ctx.setMetricsSubtab(name);
+  for (const btn of document.querySelectorAll("#metrics-subtabs .subtab")) {
+    btn.classList.toggle("active", btn.dataset.subtab === name);
+  }
+  if (typeof ctx.renderMetrics === "function") ctx.renderMetrics();
 }
 
 function setKnowledgeSubtabImpl(ctx, name) {
@@ -169,6 +179,10 @@ function setActiveTabImpl(ctx, raw, opts = {}) {
     const sub = DIAG_SUBTABS.includes(segments[1]) ? segments[1] : ctx.getDiagSubtab();
     setDiagSubtabImpl(ctx, sub);
     hash = `#diagnostics/${sub}`;
+  } else if (top === "metrics") {
+    const sub = METRICS_SUBTABS.includes(segments[1]) ? segments[1] : ctx.getMetricsSubtab();
+    setMetricsSubtabImpl(ctx, sub);
+    hash = `#metrics/${sub}`;
   } else if (top === "audit") {
     ctx.applyAuditHashQuery(query);
     const sub = ["events", "policy"].includes(segments[1]) ? segments[1] : ctx.getActiveAuditSubtab();
@@ -210,6 +224,11 @@ function initTabsImpl(ctx) {
   for (const btn of document.querySelectorAll("#diag-subtabs .subtab")) {
     btn.addEventListener("click", () =>
       setActiveTabImpl(ctx, `diagnostics/${btn.dataset.subtab}`, { refresh: false }),
+    );
+  }
+  for (const btn of document.querySelectorAll("#metrics-subtabs .subtab")) {
+    btn.addEventListener("click", () =>
+      setActiveTabImpl(ctx, `metrics/${btn.dataset.subtab}`, { refresh: false }),
     );
   }
   for (const btn of document.querySelectorAll("#run-detail-subtabs .subtab")) {

--- a/crates/orbit-dashboard/src/api/metrics.rs
+++ b/crates/orbit-dashboard/src/api/metrics.rs
@@ -1,0 +1,123 @@
+//! `/metrics/*` parity endpoints for the retired CLI metrics views.
+
+use std::sync::Arc;
+
+use axum::extract::{Path, Query, State};
+use axum::response::{IntoResponse, Json, Response};
+use chrono::{DateTime, Utc};
+use orbit_core::command::job::JobRunListParams;
+use orbit_core::knowledge_stats::aggregate as aggregate_knowledge_stats;
+use orbit_core::{InvocationQuery, OrbitRuntime};
+use serde::Deserialize;
+
+use super::{LimitQuery, map_runtime_error, non_empty_string};
+
+const INVOCATIONS_DEFAULT_LIMIT: usize = 20;
+
+#[derive(Debug, Default, Deserialize)]
+pub(super) struct MetricsInvocationsQuery {
+    #[serde(default)]
+    since: Option<String>,
+    #[serde(default)]
+    until: Option<String>,
+    #[serde(default)]
+    job_run_id: Option<String>,
+    #[serde(default)]
+    activity_id: Option<String>,
+    #[serde(default)]
+    task_id: Option<String>,
+    #[serde(default)]
+    agent: Option<String>,
+    #[serde(default)]
+    model: Option<String>,
+    #[serde(default)]
+    tool_name: Option<String>,
+    #[serde(default)]
+    limit: Option<usize>,
+}
+
+pub(super) async fn knowledge_metrics(
+    State(runtime): State<Arc<OrbitRuntime>>,
+    Query(q): Query<LimitQuery>,
+) -> Response {
+    match runtime.list_job_runs(JobRunListParams {
+        limit: q.limit,
+        ..Default::default()
+    }) {
+        Ok(runs) => Json(aggregate_knowledge_stats(&runs)).into_response(),
+        Err(e) => map_runtime_error(e),
+    }
+}
+
+pub(super) async fn activity_metrics(State(runtime): State<Arc<OrbitRuntime>>) -> Response {
+    match runtime.activity_invocation_metrics() {
+        Ok(rows) => Json(rows).into_response(),
+        Err(e) => map_runtime_error(e),
+    }
+}
+
+pub(super) async fn tool_metrics(State(runtime): State<Arc<OrbitRuntime>>) -> Response {
+    match runtime.tool_invocation_metrics() {
+        Ok(rows) => Json(rows).into_response(),
+        Err(e) => map_runtime_error(e),
+    }
+}
+
+pub(super) async fn task_metrics(
+    State(runtime): State<Arc<OrbitRuntime>>,
+    Path(id): Path<String>,
+) -> Response {
+    match runtime.task_invocation_metrics(&id) {
+        Ok(row) => Json(row).into_response(),
+        Err(e) => map_runtime_error(e),
+    }
+}
+
+pub(super) async fn invocation_metrics(
+    State(runtime): State<Arc<OrbitRuntime>>,
+    Query(q): Query<MetricsInvocationsQuery>,
+) -> Response {
+    let query = match q.into_invocation_query() {
+        Ok(query) => query,
+        Err(e) => return map_runtime_error(e),
+    };
+    match runtime.invocation_records(query) {
+        Ok(rows) => Json(rows).into_response(),
+        Err(e) => map_runtime_error(e),
+    }
+}
+
+impl MetricsInvocationsQuery {
+    fn into_invocation_query(self) -> Result<InvocationQuery, orbit_core::OrbitError> {
+        Ok(InvocationQuery {
+            since: parse_rfc3339_opt(self.since, "since")?,
+            until: parse_rfc3339_opt(self.until, "until")?,
+            job_run_id: optional_query_string(self.job_run_id),
+            activity_id: optional_query_string(self.activity_id),
+            task_id: optional_query_string(self.task_id),
+            agent: optional_query_string(self.agent),
+            model: optional_query_string(self.model),
+            slot: None,
+            tool_name: optional_query_string(self.tool_name),
+            limit: self.limit.unwrap_or(INVOCATIONS_DEFAULT_LIMIT),
+        })
+    }
+}
+
+fn parse_rfc3339_opt(
+    value: Option<String>,
+    field_name: &str,
+) -> Result<Option<DateTime<Utc>>, orbit_core::OrbitError> {
+    match optional_query_string(value) {
+        Some(raw) => DateTime::parse_from_rfc3339(&raw)
+            .map(|dt| Some(dt.with_timezone(&Utc)))
+            .map_err(|error| {
+                orbit_core::OrbitError::InvalidInput(format!("invalid {field_name}: {error}"))
+            }),
+        None => Ok(None),
+    }
+}
+
+fn optional_query_string(value: Option<String>) -> Option<String> {
+    value.as_deref().and_then(non_empty_string)
+}

--- a/crates/orbit-dashboard/src/api/metrics_tests.rs
+++ b/crates/orbit-dashboard/src/api/metrics_tests.rs
@@ -1,0 +1,311 @@
+//! Test-only allowlist: endpoint tests use unwrap/expect for fixture setup.
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use axum::Router;
+use axum::body::{Body, to_bytes};
+use axum::http::{Request, StatusCode};
+use axum::response::Response;
+use orbit_common::types::KnowledgeRunMetrics;
+use orbit_core::command::job::JobRunListParams;
+use orbit_core::knowledge_stats::aggregate as aggregate_knowledge_stats;
+use orbit_core::{
+    ActivityInvocationMetrics, InvocationQuery, InvocationRecord, JobRun, JobRunState,
+    OrbitRuntime, TaskInvocationMetrics, ToolInvocationMetrics,
+};
+use rusqlite::{Connection, params};
+use tower::ServiceExt;
+
+use super::router;
+use super::test_support::{body_json, seed_run};
+
+const RUN_ID: &str = "jrun-metrics-api";
+const OTHER_RUN_ID: &str = "jrun-metrics-other";
+const JOB_ID: &str = "metrics_api";
+const TASK_ID: &str = "ORB-METRICS-1";
+
+async fn request_metrics(runtime: OrbitRuntime, uri: &str) -> Response {
+    Router::new()
+        .nest("/api", router())
+        .with_state(Arc::new(runtime))
+        .oneshot(
+            Request::builder()
+                .uri(format!("/api{uri}"))
+                .body(Body::empty())
+                .expect("request"),
+        )
+        .await
+        .expect("response")
+}
+
+async fn body_bytes(response: Response) -> Vec<u8> {
+    to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("read response body")
+        .to_vec()
+}
+
+fn seed_metrics_runtime() -> OrbitRuntime {
+    let runtime = OrbitRuntime::in_memory().expect("build runtime");
+    let mut run = seed_run(&runtime, RUN_ID, JOB_ID, JobRunState::Success);
+    run.knowledge_metrics = Some(KnowledgeRunMetrics {
+        raw_read_token_baseline: 1_000,
+        knowledge_pack_tokens: Some(250),
+        compression_ratio: Some(4.0),
+        actual_fs_read_tokens_during_run: 100,
+        double_read_rate: Some(0.25),
+        knowledge_pack_used: true,
+        knowledge_pack_unresolved_count: 0,
+        total_llm_input_tokens: 600,
+    });
+    write_seeded_run(&runtime, &run);
+
+    let mut fallback = seed_run(&runtime, OTHER_RUN_ID, JOB_ID, JobRunState::Success);
+    fallback.knowledge_metrics = Some(KnowledgeRunMetrics {
+        raw_read_token_baseline: 1_000,
+        knowledge_pack_tokens: None,
+        compression_ratio: None,
+        actual_fs_read_tokens_during_run: 700,
+        double_read_rate: Some(0.75),
+        knowledge_pack_used: false,
+        knowledge_pack_unresolved_count: 0,
+        total_llm_input_tokens: 1_200,
+    });
+    write_seeded_run(&runtime, &fallback);
+
+    seed_invocation(
+        &runtime,
+        "2026-05-05T03:29:45Z",
+        RUN_ID,
+        "implement_one",
+        "codex",
+        Some("gpt-5.5"),
+        1_234,
+        100,
+        25,
+        5,
+        20,
+        &[TASK_ID],
+        &[("fs.read", 321), ("orbit.task.show", 123)],
+    );
+    seed_invocation(
+        &runtime,
+        "2026-05-05T03:30:45Z",
+        OTHER_RUN_ID,
+        "plan",
+        "claude",
+        Some("claude-opus"),
+        2_000,
+        80,
+        0,
+        0,
+        40,
+        &["ORB-METRICS-OTHER"],
+        &[("fs.write", 64)],
+    );
+
+    runtime
+}
+
+#[derive(serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+struct JobRunDoc<'a> {
+    schema_version: u8,
+    run: &'a JobRun,
+}
+
+fn write_seeded_run(runtime: &OrbitRuntime, run: &JobRun) {
+    let run_dir = runtime
+        .data_root()
+        .join("state")
+        .join("job-runs")
+        .join(&run.job_id)
+        .join(&run.run_id);
+    let content = serde_yaml::to_string(&JobRunDoc {
+        schema_version: 1,
+        run,
+    })
+    .expect("serialize run yaml");
+    std::fs::write(run_dir.join("jrun.yaml"), content).expect("write run yaml");
+}
+
+fn audit_db_path(runtime: &OrbitRuntime) -> PathBuf {
+    runtime.persistence_config_json()["audit"]["path"]
+        .as_str()
+        .expect("audit db path")
+        .into()
+}
+
+#[allow(clippy::too_many_arguments)]
+fn seed_invocation(
+    runtime: &OrbitRuntime,
+    ts: &str,
+    job_run_id: &str,
+    activity_id: &str,
+    agent: &str,
+    model: Option<&str>,
+    duration_ms: u64,
+    input_tokens: u64,
+    cache_read_tokens: u64,
+    cache_create_tokens: u64,
+    output_tokens: u64,
+    task_ids: &[&str],
+    tool_calls: &[(&str, u64)],
+) {
+    let conn = Connection::open(audit_db_path(runtime)).expect("open audit db");
+    conn.execute(
+        r#"INSERT INTO invocations(
+            ts, job_run_id, activity_id, agent, model, slot, duration_ms,
+            input_tokens, cache_read_tokens, cache_create_tokens, output_tokens,
+            tool_call_count
+        ) VALUES (?1, ?2, ?3, ?4, ?5, NULL, ?6, ?7, ?8, ?9, ?10, ?11)"#,
+        params![
+            ts,
+            job_run_id,
+            activity_id,
+            agent,
+            model,
+            duration_ms as i64,
+            input_tokens as i64,
+            cache_read_tokens as i64,
+            cache_create_tokens as i64,
+            output_tokens as i64,
+            tool_calls.len() as i64,
+        ],
+    )
+    .expect("insert invocation");
+    let invocation_id = conn.last_insert_rowid();
+    for task_id in task_ids {
+        conn.execute(
+            "INSERT INTO invocation_tasks(invocation_id, task_id) VALUES (?1, ?2)",
+            params![invocation_id, task_id],
+        )
+        .expect("insert invocation task");
+    }
+    for (seq, (tool_name, result_bytes)) in tool_calls.iter().enumerate() {
+        conn.execute(
+            "INSERT INTO tool_calls(invocation_id, seq, tool_name, result_bytes) VALUES (?1, ?2, ?3, ?4)",
+            params![invocation_id, seq as i64, tool_name, *result_bytes as i64],
+        )
+        .expect("insert tool call");
+    }
+}
+
+#[tokio::test]
+async fn metrics_endpoints_return_runtime_shapes() {
+    let runtime = seed_metrics_runtime();
+
+    let knowledge = request_metrics(runtime.clone(), "/metrics/knowledge?limit=20").await;
+    assert_eq!(knowledge.status(), StatusCode::OK);
+    let knowledge_bytes = body_bytes(knowledge).await;
+    let expected_knowledge = aggregate_knowledge_stats(
+        &runtime
+            .list_job_runs(JobRunListParams {
+                limit: Some(20),
+                ..Default::default()
+            })
+            .expect("list job runs"),
+    );
+    let decoded_knowledge: orbit_core::knowledge_stats::KnowledgeStatsSummary =
+        serde_json::from_slice(&knowledge_bytes).expect("knowledge json");
+    assert_eq!(decoded_knowledge, expected_knowledge);
+    assert_eq!(
+        knowledge_bytes,
+        serde_json::to_vec(&expected_knowledge).expect("expected knowledge json")
+    );
+
+    let activity = request_metrics(runtime.clone(), "/metrics/activity").await;
+    assert_eq!(activity.status(), StatusCode::OK);
+    let activity_bytes = body_bytes(activity).await;
+    let expected_activity: Vec<ActivityInvocationMetrics> = runtime
+        .activity_invocation_metrics()
+        .expect("activity metrics");
+    let decoded_activity: Vec<ActivityInvocationMetrics> =
+        serde_json::from_slice(&activity_bytes).expect("activity json");
+    assert_eq!(decoded_activity, expected_activity);
+    assert_eq!(
+        activity_bytes,
+        serde_json::to_vec(&expected_activity).expect("expected activity json")
+    );
+
+    let tools = request_metrics(runtime.clone(), "/metrics/tools").await;
+    assert_eq!(tools.status(), StatusCode::OK);
+    let tools_bytes = body_bytes(tools).await;
+    let expected_tools: Vec<ToolInvocationMetrics> =
+        runtime.tool_invocation_metrics().expect("tool metrics");
+    let decoded_tools: Vec<ToolInvocationMetrics> =
+        serde_json::from_slice(&tools_bytes).expect("tools json");
+    assert_eq!(decoded_tools, expected_tools);
+    assert_eq!(
+        tools_bytes,
+        serde_json::to_vec(&expected_tools).expect("expected tools json")
+    );
+
+    let task = request_metrics(runtime.clone(), &format!("/metrics/task/{TASK_ID}")).await;
+    assert_eq!(task.status(), StatusCode::OK);
+    let task_bytes = body_bytes(task).await;
+    let expected_task: TaskInvocationMetrics = runtime
+        .task_invocation_metrics(TASK_ID)
+        .expect("task metrics");
+    let decoded_task: TaskInvocationMetrics =
+        serde_json::from_slice(&task_bytes).expect("task json");
+    assert_eq!(decoded_task, expected_task);
+    assert_eq!(
+        task_bytes,
+        serde_json::to_vec(&expected_task).expect("expected task json")
+    );
+
+    let invocations = request_metrics(runtime.clone(), "/metrics/invocations?limit=10").await;
+    assert_eq!(invocations.status(), StatusCode::OK);
+    let invocations_bytes = body_bytes(invocations).await;
+    let expected_invocations: Vec<InvocationRecord> = runtime
+        .invocation_records(InvocationQuery {
+            limit: 10,
+            ..Default::default()
+        })
+        .expect("invocation records");
+    let decoded_invocations: Vec<InvocationRecord> =
+        serde_json::from_slice(&invocations_bytes).expect("invocations json");
+    assert_eq!(decoded_invocations, expected_invocations);
+    assert_eq!(
+        invocations_bytes,
+        serde_json::to_vec(&expected_invocations).expect("expected invocations json")
+    );
+}
+
+#[tokio::test]
+async fn metrics_invocations_accepts_full_filter_set() {
+    let runtime = seed_metrics_runtime();
+    let since = "2026-05-05T03:00:00Z";
+    let until = "2026-05-05T04:00:00Z";
+    let uri = format!(
+        "/metrics/invocations?since={since}&until={until}&job_run_id={RUN_ID}&activity_id=implement_one&task_id={TASK_ID}&agent=codex&model=gpt-5.5&tool_name=fs.read&limit=1"
+    );
+
+    let response = request_metrics(runtime, &uri).await;
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let payload = body_json(response).await;
+    let rows = payload.as_array().expect("rows");
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0]["job_run_id"], RUN_ID);
+    assert_eq!(rows[0]["activity_id"], "implement_one");
+    assert_eq!(rows[0]["agent"], "codex");
+    assert_eq!(rows[0]["model"], "gpt-5.5");
+    assert_eq!(rows[0]["task_ids"][0], TASK_ID);
+    assert_eq!(rows[0]["tool_calls"][0]["tool_name"], "fs.read");
+}
+
+#[tokio::test]
+async fn metrics_invocations_reports_invalid_rfc3339_field() {
+    let runtime = seed_metrics_runtime();
+
+    let response = request_metrics(runtime, "/metrics/invocations?since=not-a-date").await;
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    let payload = body_json(response).await;
+    let message = payload["error"].as_str().expect("error message");
+    assert!(message.contains("invalid since:"));
+}

--- a/crates/orbit-dashboard/src/api/mod.rs
+++ b/crates/orbit-dashboard/src/api/mod.rs
@@ -32,6 +32,7 @@ mod frictions;
 mod jobs;
 mod learnings;
 mod log;
+mod metrics;
 mod runs;
 mod scoreboard;
 mod tasks;
@@ -345,6 +346,11 @@ pub(super) fn router() -> Router<Arc<OrbitRuntime>> {
         .route("/log/stream", get(log::stream_log))
         .route("/audit/summary", get(audit::audit_summary))
         .route("/scoreboard", get(scoreboard::scoreboard))
+        .route("/metrics/knowledge", get(metrics::knowledge_metrics))
+        .route("/metrics/activity", get(metrics::activity_metrics))
+        .route("/metrics/tools", get(metrics::tool_metrics))
+        .route("/metrics/task/:id", get(metrics::task_metrics))
+        .route("/metrics/invocations", get(metrics::invocation_metrics))
         .route(
             "/diagnostics/metrics",
             get(diagnostics::list_diagnostics_metrics),
@@ -649,6 +655,9 @@ default_crew = "silver"
         assert_eq!(response.status(), StatusCode::FORBIDDEN);
     }
 }
+
+#[cfg(test)]
+mod metrics_tests;
 
 #[cfg(test)]
 mod tasks_tests;

--- a/crates/orbit-dashboard/src/lib.rs
+++ b/crates/orbit-dashboard/src/lib.rs
@@ -32,6 +32,7 @@ const COMMON_JS: &str = include_str!("../assets/dashboard/common.js");
 const TASKS_JS: &str = include_str!("../assets/dashboard/tasks.js");
 const AUDIT_JS: &str = include_str!("../assets/dashboard/audit.js");
 const SCOREBOARD_JS: &str = include_str!("../assets/dashboard/scoreboard.js");
+const METRICS_JS: &str = include_str!("../assets/dashboard/metrics.js");
 const LOG_TAIL_JS: &str = include_str!("../assets/dashboard/log-tail.js");
 const DIAGNOSTICS_JS: &str = include_str!("../assets/dashboard/diagnostics.js");
 const ROUTER_JS: &str = include_str!("../assets/dashboard/router.js");
@@ -74,6 +75,7 @@ pub fn serve(runtime: &OrbitRuntime, args: ServeArgs) -> Result<(), OrbitError> 
         .route("/static/tasks.js", get(serve_tasks_js))
         .route("/static/audit.js", get(serve_audit_js))
         .route("/static/scoreboard.js", get(serve_scoreboard_js))
+        .route("/static/metrics.js", get(serve_metrics_js))
         .route("/static/log-tail.js", get(serve_log_tail_js))
         .route("/static/diagnostics.js", get(serve_diagnostics_js))
         .route("/static/router.js", get(serve_router_js))
@@ -184,6 +186,17 @@ async fn serve_scoreboard_js() -> Response {
             HeaderValue::from_static("application/javascript; charset=utf-8"),
         )],
         SCOREBOARD_JS,
+    )
+        .into_response()
+}
+
+async fn serve_metrics_js() -> Response {
+    (
+        [(
+            header::CONTENT_TYPE,
+            HeaderValue::from_static("application/javascript; charset=utf-8"),
+        )],
+        METRICS_JS,
     )
         .into_response()
 }

--- a/crates/orbit-store/src/sqlite/invocation_store/records.rs
+++ b/crates/orbit-store/src/sqlite/invocation_store/records.rs
@@ -357,7 +357,9 @@ impl InvocationListQuery {
         T: ToSql + 'static,
     {
         self.push_value(value);
-        self.conditions.push(format!("{sql}{}", self.len()));
+        // L20260520-1: nested EXISTS filters need the bind index inserted at the placeholder.
+        let placeholder = format!("?{}", self.len());
+        self.conditions.push(sql.replacen('?', &placeholder, 1));
     }
 
     fn push_value<T>(&mut self, value: T)
@@ -392,7 +394,7 @@ impl Store {
 
 #[cfg(test)]
 mod tests {
-    use orbit_common::types::{InvocationTrace, RoleSlot};
+    use orbit_common::types::{InvocationTrace, RoleSlot, TokenUsage, ToolCallTrace};
 
     use super::*;
 
@@ -449,5 +451,68 @@ mod tests {
             .expect("list records");
         assert_eq!(records.len(), 1);
         assert_eq!(records[0].slot, None);
+    }
+
+    #[test]
+    fn invocation_records_filter_by_nested_task_and_tool() {
+        let store = Store::open_in_memory().expect("open store");
+
+        store
+            .insert_invocation_trace_record(&InvocationInsertParams {
+                job_run_id: "jrun-filter-match".to_string(),
+                activity_id: "implement_one".to_string(),
+                agent: "codex".to_string(),
+                model: Some("gpt-5.5".to_string()),
+                slot: None,
+                task_ids: vec!["ORB-1".to_string()],
+                trace: InvocationTrace {
+                    usage: TokenUsage {
+                        input: 10,
+                        output: 5,
+                        ..Default::default()
+                    },
+                    tool_calls: vec![ToolCallTrace {
+                        seq: 0,
+                        tool_name: "fs.read".to_string(),
+                        result_bytes: 42,
+                        result_payload: None,
+                    }],
+                    duration_ms: 100,
+                },
+            })
+            .expect("insert matching invocation");
+        store
+            .insert_invocation_trace_record(&InvocationInsertParams {
+                job_run_id: "jrun-filter-other".to_string(),
+                activity_id: "implement_one".to_string(),
+                agent: "codex".to_string(),
+                model: Some("gpt-5.5".to_string()),
+                slot: None,
+                task_ids: vec!["ORB-2".to_string()],
+                trace: InvocationTrace {
+                    tool_calls: vec![ToolCallTrace {
+                        seq: 0,
+                        tool_name: "fs.write".to_string(),
+                        result_bytes: 9,
+                        result_payload: None,
+                    }],
+                    ..Default::default()
+                },
+            })
+            .expect("insert other invocation");
+
+        let records = store
+            .list_invocation_records(&InvocationQuery {
+                task_id: Some("ORB-1".to_string()),
+                tool_name: Some("fs.read".to_string()),
+                limit: 10,
+                ..Default::default()
+            })
+            .expect("list filtered records");
+
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].job_run_id, "jrun-filter-match");
+        assert_eq!(records[0].task_ids, vec!["ORB-1"]);
+        assert_eq!(records[0].tool_calls[0].tool_name, "fs.read");
     }
 }


### PR DESCRIPTION
## Task

[ORB-00191](https://orbit-cli.com/tasks/ORB-00191) — Add dashboard parity for `orbit metrics` (knowledge, activity, tools, task aggregates + invocation filters)

### Description

## Problem

The `orbit metrics` CLI command will be removed under `[ORB-00190]`. Before that removal can land, the dashboard must surface the metrics views that exist today only in the CLI, so the project owner (who works exclusively from the dashboard) does not lose visibility.

Concretely, the dashboard today only exposes `runtime.invocation_records()` via `GET /diagnostics/metrics` — and that endpoint flattens the row, filters only by month, and drops the cache/input/output token splits. Everything else from `orbit metrics` is missing.

## Why It Matters

Without this work, removing the CLI silently drops the following capabilities from every user-facing surface:

- **Knowledge-pack health**: compression ratios (mean / p50 / p90 / min), double-read guard rate, with-pack vs without-pack token savings, pack-vs-fallback rate. This is the only place these are computed today, and they are direct indicators of whether the knowledge pack is doing its job.
- **Per-activity token rollups**: avg / p50 / p95 tokens grouped by `(activity, agent, model)`, plus cache_read / cache_create / input / output splits and tool-call counts. The dashboard's `/scoreboard` surfaces duration p95 only, not token percentiles.
- **Per-tool usage**: call count + result bytes (avg, total) per `(activity, tool)`.
- **Per-task token totals**: per-task token rollups for cost attribution.
- **Rich invocation filtering**: the CLI's `metrics invocations` supports `since / until / job_run_id / activity_id / task_id / agent / model / tool_name / limit`. The dashboard's `/diagnostics/metrics` accepts month + limit only.

## In Scope

**Backend endpoints (under `crates/orbit-dashboard/src/api/`)**:

- `GET /metrics/knowledge?limit=<n>` — wraps `aggregate_knowledge_stats(runtime.list_job_runs(...))`, returns `KnowledgeStatsSummary` serialized as-is.
- `GET /metrics/activity` — wraps `runtime.activity_invocation_metrics()`, returns `Vec<ActivityInvocationMetrics>` serialized as-is.
- `GET /metrics/tools` — wraps `runtime.tool_invocation_metrics()`, returns `Vec<ToolInvocationMetrics>` serialized as-is.
- `GET /metrics/task/:id` — wraps `runtime.task_invocation_metrics(id)`, returns `TaskInvocationMetrics` serialized as-is.
- `GET /metrics/invocations` — wraps `runtime.invocation_records(InvocationQuery { ... })` with query params for the full `InvocationQuery` filter set (`since`, `until`, `job_run_id`, `activity_id`, `task_id`, `agent`, `model`, `tool_name`, `limit`). RFC3339 parsing matches the CLI's `parse_rfc3339_opt`. This endpoint is distinct from `/diagnostics/metrics` (which keeps its existing flattened shape and month-based behavior for the diagnostics view).
- Reuse `crates/orbit-dashboard/src/api/mod.rs::router()` registration pattern; gate behind the existing `require_localhost_origin` middleware.

**Frontend UI (under `crates/orbit-dashboard/assets/dashboard/`)**:

- New top-level tab (or sub-tab under an existing observability section — planner picks) named `metrics` rendering the four aggregate views. Tables can match the existing `scoreboard-table` styling used by `diagnostics.js`.
- Knowledge view: render the `KnowledgeStatsSummary` fields explicitly (compression mean/p50/p90/min, fallback rate, double-read mean rate + runs >50%, with-pack avg vs without-pack avg + estimated savings). Mirror the textual layout from the CLI's `print_knowledge_summary` so the information density matches.
- Activity / tools / task views: tables with the same columns the CLI surfaces today (see `print_activity_rows`, `print_tool_rows`, `print_task_metrics` in `crates/orbit-cli/src/command/observe/metrics.rs:314-380`).
- Invocations view: filter form for the full `InvocationQuery` field set, results table mirroring `print_invocation_rows` columns.
- Router registration in `crates/orbit-dashboard/assets/dashboard/router.js`.

**Tests**:

- API handler tests follow the existing pattern in `crates/orbit-dashboard/src/api/diagnostics_tests.rs` (seed runtime via `test_support::seed_run`, call endpoint, assert JSON shape).
- Each new endpoint gets at least one happy-path test asserting it returns the same shape as the corresponding runtime method's serde output (i.e. no lossy re-projection — the endpoint should be a thin pass-through, otherwise it diverges from the CLI's `--json` output).

## Out of Scope

- Removal of `orbit metrics` CLI itself — that is `[ORB-00190]`, which lists this task as a dependency.
- Changes to `/diagnostics/metrics` shape or behavior — that endpoint stays as-is for the existing diagnostics view.
- Changes to scoreboard or MetricsEntry JSONL ingestion.
- New aggregates not already present in `orbit metrics`. This task is parity, not expansion.

## Constraints / Notes

- Endpoint outputs should be thin serde pass-throughs of the underlying runtime types (`KnowledgeStatsSummary`, `ActivityInvocationMetrics`, `ToolInvocationMetrics`, `TaskInvocationMetrics`, `InvocationRecord`). Don't reshape; the parity acceptance test below depends on this.
- Branch targets `agent-main` per `CLAUDE.md`. Commit tag `[ORB-NNNNN]` once allocated.
- If the planner decides the UI work is large enough to split into its own task, do so explicitly with a `child_of` relation to this task, and update `[ORB-00190]`'s `dependencies` to gate on the full chain.
- `make ci-fast` must pass before review.

### Acceptance Criteria

- The five endpoints exist and respond with HTTP 200 on a runtime seeded via `test_support::seed_run`: `GET /metrics/knowledge`, `GET /metrics/activity`, `GET /metrics/tools`, `GET /metrics/task/:id`, `GET /metrics/invocations`. Verified by `cargo test -p orbit-dashboard`.
- `GET /metrics/invocations` accepts `since`, `until`, `job_run_id`, `activity_id`, `task_id`, `agent`, `model`, `tool_name`, and `limit` query parameters and passes them through to `runtime.invocation_records(InvocationQuery { ... })`. An RFC3339 parse failure on `since` or `until` returns HTTP 400 with the field name in the body (mirroring the CLI's `OrbitError::InvalidInput("invalid since: ...")` shape).
- Parity test: for at least one of the four aggregate endpoints (`/metrics/knowledge`, `/metrics/activity`, `/metrics/tools`, `/metrics/task/:id`), a test asserts the JSON body deserializes back into the underlying runtime type (`KnowledgeStatsSummary` / `ActivityInvocationMetrics` / etc.) and round-trips to bytewise-identical JSON. This proves the endpoint is a thin pass-through, not a lossy reshape.
- All five endpoints are mounted on the router in `crates/orbit-dashboard/src/api/mod.rs::router()` behind the existing `require_localhost_origin` middleware. `rg -n 'route\("/metrics/' crates/orbit-dashboard/src/api/mod.rs` returns exactly five hits.
- A `metrics` UI surface exists in `crates/orbit-dashboard/assets/dashboard/` that renders all four aggregate views (knowledge, activity, tools, task) plus the invocations view with the full filter form. Manual verification: starting the dashboard, navigating to the metrics surface, and confirming each sub-view populates from the corresponding endpoint without console errors.
- Knowledge view renders every field of `KnowledgeStatsSummary` that the CLI's `print_knowledge_summary` prints: compression mean/p50/p90/min, fallback rate, pack/total/fallback run counts, double-read mean rate and runs-over-50% count, and with-pack vs without-pack avg input tokens plus estimated savings. Verified by inspection against `crates/orbit-cli/src/command/observe/metrics.rs:262-312`.
- Invocations filter form includes inputs for every `InvocationQuery` field exposed by the CLI (`since`, `until`, `job_run_id`, `activity_id`, `task_id`, `agent`, `model`, `tool_name`, `limit`). Verified by inspection of the rendered form.
- `make ci-fast` passes on the final branch.
- After this task is `done`, `[ORB-00190]`'s `dependencies` are satisfied per `task_dependencies_ready` and that task is unblocked to start.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Added /metrics/knowledge, /metrics/activity, /metrics/tools, /metrics/task/:id, and /metrics/invocations pass-through API handlers with RFC3339 validation and router registration.
- Added a dashboard Metrics tab/UI module with knowledge, activity, tools, task, and invocations views plus the full InvocationQuery filter form; embedded /static/metrics.js.
- Added dashboard API tests for all five endpoints and full invocation filters; fixed the orbit-store nested EXISTS placeholder binding needed for task_id/tool_name filters, with store regression coverage.
- Added learning L20260520-1 for the placeholder gotcha.

Assessment: Endpoint and UI parity are implemented and validated by cargo test, node syntax checks, headless Chrome verification, store regression test, and make ci-fast.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-00191-6a0d31ca`
- Behind base: 0
- Ahead of base: 1