### PR TITLE
[codex] Rename orbit search flags [ORB-00204]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Breaking Changes
 
+- **`orbit search` flag rename**: free-text vector ranking is now `--hybrid` / `hybrid: true`; task-neighbor lookup is now `--semantic <id>` / `semantic: "<id>"`. The old `--semantic` boolean and `--related <id>` surfaces are hard-removed; JSON mode values are now `hybrid` and `neighbor`. Historical phase-1 audit payloads carrying `semantic: true` are orphaned by the no-shim rename. ([ORB-00204])
 - **Design-doc decay-check surface removed**: `orbit design check`, `orbit.design.check` MCP tool, the wrapper script, and `make check-design-docs` are gone. Use `orbit design init/list/show` + same-PR update rule. ([ORB-00112])
 - **Search namespace split**: `orbit.semantic.search`, `orbit.semantic.related`, and the `orbit-semantic` skill are removed in favor of `orbit.search` and `orbit-search`; `orbit semantic reindex` is now `orbit semantic index`. Historical `semantic.search` / `semantic.related` audit event names are orphaned by this hard break because there are no external audit-history consumers yet. ([ORB-00196])
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Paste the prompt below into your agent (Claude Code, Codex CLI, or Gemini CLI) *
 > 3. Clone `https://github.com/danieljhkim/orbit` into the location from step 1, then run `make install`. This builds with cargo and copies the `orbit` binary to `$INSTALL_BIN_DIR` (default: `~/.cargo/bin`). Confirm the install path with me before running. Verify with `orbit --version`.
 > 4. Run `orbit init` to initialize global state at `~/.orbit`.
 > 5. From *this* repository (not the Orbit clone), run `orbit workspace init --mcp`. This creates `.orbit/` here and auto-registers Orbit's MCP server with installed agent CLIs (Claude Code, Codex, Gemini).
-> 6. Ask me whether to enable semantic search (**optional**). `orbit semantic install` downloads a small embedder companion plus the default bge-small model (lives under `~/.orbit/embed/`) and powers `orbit search --semantic` / `orbit search --related` over tasks. Don't install without my OK. If I accept and tasks already exist in this workspace, also run `orbit semantic index` to backfill the corpus.
+> 6. Ask me whether to enable semantic search (**optional**). `orbit semantic install` downloads a small embedder companion plus the default bge-small model (lives under `~/.orbit/embed/`) and powers `orbit search --hybrid` / `orbit search --semantic <task-id>` over tasks. Don't install without my OK. If I accept and tasks already exist in this workspace, also run `orbit semantic index` to backfill the corpus.
 > 7. Read the key documents so you actually understand the model:
 >    - `README.md` — feature surface, install model, plugin vs CLI
 >    - `docs/POSITIONING.md` — what Orbit is for, what it isn't (especially "who this is for")
@@ -135,17 +135,17 @@ Customizing crews (which model runs planner/implementer/reviewer), the base bran
 
 ## Semantic Search (optional)
 
-`orbit search` is the unified query surface for tasks, docs, learnings, and ADRs. It defaults to lexical matching. Opt into hybrid embedding + BM25 ranking over task fields with `--semantic`, or find cosine-neighbor tasks with `--related`. The embedder runs as a separate companion subprocess, so semantic search has zero cost when unused.
+`orbit search` is the unified query surface for tasks, docs, learnings, and ADRs. It defaults to lexical matching. Opt into hybrid embedding + BM25 ranking over task fields with `--hybrid`, or find cosine-neighbor tasks with `--semantic <task-id>`. The embedder runs as a separate companion subprocess, so semantic search has zero cost when unused.
 
 ```bash
 orbit semantic install    # one-time: download companion + default model (bge-small)
 orbit semantic index      # backfill existing tasks
 orbit search "race in the scheduler when locks overlap"
-orbit search "race in the scheduler when locks overlap" --semantic --kind task
-orbit search --related ORB-00042
+orbit search "race in the scheduler when locks overlap" --hybrid --kind task
+orbit search --semantic ORB-00042
 ```
 
-After install, task writes are embedded automatically in the background; `index` is only needed for the initial backfill. Companion + models live under `~/.orbit/embed/`; the per-workspace index at `.orbit/state/semantic.db`. Vector search is task-only today; docs, learnings, and ADRs remain lexical even when `--semantic` is set.
+After install, task writes are embedded automatically in the background; `index` is only needed for the initial backfill. Companion + models live under `~/.orbit/embed/`; the per-workspace index at `.orbit/state/semantic.db`. Vector search is task-only today; docs, learnings, and ADRs remain lexical even when `--hybrid` is set.
 
 ---
 

--- a/crates/orbit-cli/src/command/mod.rs
+++ b/crates/orbit-cli/src/command/mod.rs
@@ -251,22 +251,49 @@ mod tests {
             "orbit",
             "search",
             "semantic search design",
-            "--semantic",
+            "--hybrid",
             "--kind",
             "task",
         ]);
         match cli.command {
             Commands::Search(args) => {
                 assert_eq!(args.query.as_deref(), Some("semantic search design"));
-                assert!(args.semantic);
+                assert!(args.hybrid);
+                assert_eq!(args.semantic, None);
             }
             _ => panic!("expected top-level search command"),
         }
     }
 
     #[test]
-    fn cli_rejects_search_query_with_related() {
-        assert!(Cli::try_parse_from(["orbit", "search", "query", "--related", "ORB-1"]).is_err());
+    fn cli_parses_top_level_search_semantic_neighbor() {
+        let cli = Cli::parse_from(["orbit", "search", "--semantic", "ORB-1"]);
+        match cli.command {
+            Commands::Search(args) => {
+                assert_eq!(args.query, None);
+                assert_eq!(args.semantic.as_deref(), Some("ORB-1"));
+            }
+            _ => panic!("expected top-level search command"),
+        }
+    }
+
+    #[test]
+    fn cli_rejects_search_query_with_semantic_neighbor() {
+        assert!(Cli::try_parse_from(["orbit", "search", "query", "--semantic", "ORB-1"]).is_err());
+    }
+
+    #[test]
+    fn cli_rejects_search_related_flag() {
+        let legacy_flag = concat!("--", "related");
+        assert!(Cli::try_parse_from(["orbit", "search", legacy_flag, "ORB-1"]).is_err());
+    }
+
+    #[test]
+    fn cli_rejects_search_semantic_without_value() {
+        assert!(
+            Cli::try_parse_from(["orbit", "search", "query", "--semantic", "--kind", "task"])
+                .is_err()
+        );
     }
 
     #[test]

--- a/crates/orbit-cli/src/command/search.rs
+++ b/crates/orbit-cli/src/command/search.rs
@@ -6,24 +6,26 @@ use crate::command::Execute;
 #[derive(Args)]
 #[command(
     about = "Search tasks, docs, learnings, and ADRs",
-    after_help = "Index coverage note: vector search runs against tasks only today; docs, learnings, and ADRs use lexical matching regardless of --semantic."
+    after_help = "Index coverage note: vector search runs against tasks only today; docs, learnings, and ADRs use lexical matching regardless of --hybrid."
 )]
 #[command(group(
     ArgGroup::new("search_input")
-        .args(["query", "related"])
+        .args(["query", "semantic"])
         .required(true)
         .multiple(false)
 ))]
 pub struct SearchCommand {
-    /// Free-text query. Defaults to lexical matching unless --semantic is set.
+    /// Free-text query. Defaults to lexical matching unless --hybrid is set.
     #[arg(value_name = "query")]
     pub query: Option<String>,
+    // ADR-0175: `--hybrid` names the free-text BM25 + cosine ranker.
     /// Use hybrid BM25 + cosine ranking for indexed task fields. Other kinds remain lexical.
     #[arg(long)]
-    pub semantic: bool,
-    /// Find cosine-neighbor tasks for a known task ID. Implies semantic mode.
+    pub hybrid: bool,
+    // ADR-0175: `--semantic <id>` names task-neighbor lookup.
+    /// Find cosine-neighbor tasks for a known task ID. Requires task vectors.
     #[arg(long, value_name = "id")]
-    pub related: Option<String>,
+    pub semantic: Option<String>,
     /// Restrict results to one corpus kind.
     #[arg(long, value_enum, default_value_t = SearchKindArg::All)]
     pub kind: SearchKindArg,
@@ -78,8 +80,8 @@ impl Execute for SearchCommand {
     fn execute(self, runtime: &OrbitRuntime) -> Result<(), OrbitError> {
         let response = runtime.global_search(GlobalSearchParams {
             query: self.query,
+            hybrid: self.hybrid,
             semantic: self.semantic,
-            related: self.related,
             kind: self.kind.into(),
             limit: self.limit,
             field: self.field,

--- a/crates/orbit-cli/tests/semantic_companion.rs
+++ b/crates/orbit-cli/tests/semantic_companion.rs
@@ -60,7 +60,7 @@ fn direct_search_semantic_command_surfaces_companion_stderr() {
     let output = run_orbit(
         &workspace.work,
         &workspace.home,
-        &["search", "anything", "--semantic", "--kind", "task"],
+        &["search", "anything", "--hybrid", "--kind", "task"],
         Some(&workspace.companion),
     );
 

--- a/crates/orbit-core/assets/activities/agent_implement.yaml
+++ b/crates/orbit-core/assets/activities/agent_implement.yaml
@@ -39,7 +39,7 @@ spec:
        `context_files` as Orbit graph selectors: prefer `orbit.graph.pack` to
        gather context, and fall back to `fs.read` only for selectors that stay
        unresolved or when the knowledge graph is unavailable. If `orbit.search`
-       is available, call it with `related: "<task-id>"` to surface prior tasks
+       is available, call it with `semantic: "<task-id>"` to surface prior tasks
        not linked via `context_files` (past decisions, related review threads);
        skip if the companion binary is not installed.
     4. Use `input.workspace_path` and `input.repo_root` when provided; they

--- a/crates/orbit-core/assets/activities/agent_review.yaml
+++ b/crates/orbit-core/assets/activities/agent_review.yaml
@@ -47,7 +47,7 @@ spec:
        files. Read context selectors via `orbit.graph.pack`, falling back
        to `fs.read` only when the graph is unavailable or a selector is
        unresolved. If `orbit.search` is available, optionally call it with
-       `related: "<task-id>"` to surface prior similar tasks whose review
+       `semantic: "<task-id>"` to surface prior similar tasks whose review
        threads or decisions may inform this review; skip if the companion
        binary is not installed.
     3. For each blocking issue you find — correctness bug, broken contract,

--- a/crates/orbit-core/assets/activities/dispatch_agent.yaml
+++ b/crates/orbit-core/assets/activities/dispatch_agent.yaml
@@ -59,7 +59,7 @@ spec:
        `orbit.task.show` is available if you need a task's full description
        to decide an ambiguous case — use it sparingly. When two tasks share
        no `context_files` but their titles look superficially related,
-       `orbit.search` with `related: "<task-id>"` can confirm or refute the
+       `orbit.search` with `semantic: "<task-id>"` can confirm or refute the
        overlap; use only on genuinely ambiguous pairs, and skip if the
        companion binary is not installed.
     2. **Disjoint tasks go in separate bundles.** If two tasks share no

--- a/crates/orbit-core/assets/activities/epic_orchestrator.yaml
+++ b/crates/orbit-core/assets/activities/epic_orchestrator.yaml
@@ -62,7 +62,7 @@ spec:
        - it is not already represented by a child run you dispatched in
          this cycle.
        When dependency direction is ambiguous from the descriptions alone,
-       `orbit.search` with `related: "<subtask-id>"` (if available) can
+       `orbit.search` with `semantic: "<subtask-id>"` (if available) can
        surface prior tasks that establish ordering; skip if the companion
        binary is not installed.
 

--- a/crates/orbit-core/assets/skills/orbit-create-task/SKILL.md
+++ b/crates/orbit-core/assets/skills/orbit-create-task/SKILL.md
@@ -21,7 +21,7 @@ See the `orbit` skill for the full mapping rule and surface coverage. Examples b
 ## Workflow
 
 1. Confirm objective, constraints, and done criteria.
-2. Inspect codebase context before creating the task. If you want background on prior related work, `orbit.search` is available; use `semantic: true` with `kind: "task"` when the proposed work might overlap with a task whose title uses different vocabulary. Optional, not required. See `orbit-search`.
+2. Inspect codebase context before creating the task. If you want background on prior related work, `orbit.search` is available; use `hybrid: true` with `kind: "task"` when the proposed work might overlap with a task whose title uses different vocabulary. Optional, not required. See `orbit-search`.
 3. Write clear acceptance criteria that define observable success.
 4. Choose task metadata while the scope is fresh: set `complexity` to `low`, `medium`, or `hard` whenever you can make a reasonable call. Leave it unset only when the current context is too thin to classify.
 5. Add assumptions, risks, and rollback notes to the description when they matter.

--- a/crates/orbit-core/assets/skills/orbit-execute-task/SKILL.md
+++ b/crates/orbit-core/assets/skills/orbit-execute-task/SKILL.md
@@ -56,7 +56,7 @@ orbit tool run orbit.task.list --input '{"status": "backlog", "model": "<agent-f
 - `context_files` — treat these as selectors first. Prefer `file:`, `dir:`, or `symbol:` forms, use `orbit.graph.pack` when available, and fall back to `fs.read` only for unresolved selectors.
 - `status` — confirm the task is ready to start.
 
-Then, if `orbit.search` is available, call it with `related: "<task-id>"` and `limit: 5`. Rationale: surface prior tasks the original author may not have linked via `context_files` — past decisions, prior attempts at the same problem, related review threads. Skim snippets; usually one hit is genuinely useful and the rest are noise. **This step is non-blocking** — if the companion binary is missing (install-pointer error) or no hit is relevant, continue. See `orbit-search`.
+Then, if `orbit.search` is available, call it with `semantic: "<task-id>"` and `limit: 5`. Rationale: surface prior tasks the original author may not have linked via `context_files` — past decisions, prior attempts at the same problem, related review threads. Skim snippets; usually one hit is genuinely useful and the rest are noise. **This step is non-blocking** — if the companion binary is missing (install-pointer error) or no hit is relevant, continue. See `orbit-search`.
 
 **If this is a new task** (no task ID), clarify intent and success criteria with the human, then create via `orbit-create-task`.
 

--- a/crates/orbit-core/assets/skills/orbit-review-task/SKILL.md
+++ b/crates/orbit-core/assets/skills/orbit-review-task/SKILL.md
@@ -50,7 +50,7 @@ MCP form: `orbit_task_review_thread_add({...})` / `orbit_task_review_thread_repl
 
 Read the task with `orbit.task.show`. Pull the `description`, `acceptance_criteria`, `plan`, and `execution_summary`. Inspect the diff (`git diff` or PR view) and the changed files. Run `make build` and the relevant test target to confirm the change actually works.
 
-Optional: if `orbit.search` is available, call it with `related: "<task-id>"` to surface prior similar tasks whose decisions or review threads may inform this review. Skim snippets; ignore if no hit is relevant. No mandate — review threads remain grounded in the diff plus the task's own acceptance criteria. See `orbit-search`.
+Optional: if `orbit.search` is available, call it with `semantic: "<task-id>"` to surface prior similar tasks whose decisions or review threads may inform this review. Skim snippets; ignore if no hit is relevant. No mandate — review threads remain grounded in the diff plus the task's own acceptance criteria. See `orbit-search`.
 
 ### 2. Two-stage review
 

--- a/crates/orbit-core/assets/skills/orbit-search/SKILL.md
+++ b/crates/orbit-core/assets/skills/orbit-search/SKILL.md
@@ -27,19 +27,19 @@ orbit search "slow inference after model swap" --limit 5
 orbit tool run orbit.search --input '{"query":"slow inference after model swap","limit":5,"model":"<agent-family>"}'
 
 # Hybrid BM25 + cosine over task fields; other kinds remain lexical
-orbit search "agent loop deadlock" --semantic --kind task --limit 5
-orbit tool run orbit.search --input '{"query":"agent loop deadlock","semantic":true,"kind":"task","limit":5,"model":"<agent-family>"}'
+orbit search "agent loop deadlock" --hybrid --kind task --limit 5
+orbit tool run orbit.search --input '{"query":"agent loop deadlock","hybrid":true,"kind":"task","limit":5,"model":"<agent-family>"}'
 
 # Cosine neighbors of a known task
-orbit search --related "<task-id>" --limit 5
-orbit tool run orbit.search --input '{"related":"<task-id>","limit":5,"model":"<agent-family>"}'
+orbit search --semantic "<task-id>" --limit 5
+orbit tool run orbit.search --input '{"semantic":"<task-id>","limit":5,"model":"<agent-family>"}'
 ```
 
-`--related <id>` is mutually exclusive with a positional query and implies semantic mode. It requires task vectors and therefore requires the companion.
+`--semantic <id>` is mutually exclusive with a positional query and uses task vectors, so it requires the companion.
 
 ## Index Coverage
 
-Lexical search covers tasks, docs, learnings, and ADRs. Vector search currently covers task fields only. When `--semantic` is set for `--kind doc`, `--kind learning`, `--kind adr`, or those portions of `--kind all`, Orbit still uses lexical matching for those kinds.
+Lexical search covers tasks, docs, learnings, and ADRs. Vector search currently covers task fields only. When `--hybrid` is set for `--kind doc`, `--kind learning`, `--kind adr`, or those portions of `--kind all`, Orbit still uses lexical matching for those kinds.
 
 The help text for `orbit search --help` carries this asymmetry because it is user-visible behavior, not an implementation accident.
 
@@ -47,8 +47,8 @@ The help text for `orbit search --help` carries this asymmetry because it is use
 
 Three patterns cover almost every call:
 
-1. **Pre-create context check.** Before adding a new task, query the proposed title or description to find related prior work. Use `--semantic --kind task` when vocabulary mismatch is likely; use plain lexical search when looking for exact names, errors, or paths.
-2. **Pre-execute related lookup.** After `orbit.task.show` loads a task, call `orbit.search` with `related` on that task ID to surface prior tasks the original author may not have linked in `context_files`. Skim the top 3-5; ignore irrelevant hits.
+1. **Pre-create context check.** Before adding a new task, query the proposed title or description to find related prior work. Use `--hybrid --kind task` when vocabulary mismatch is likely; use plain lexical search when looking for exact names, errors, or paths.
+2. **Pre-execute related lookup.** After `orbit.task.show` loads a task, call `orbit.search` with `semantic` set to that task ID to surface prior tasks the original author may not have linked in `context_files`. Skim the top 3-5; ignore irrelevant hits.
 3. **Ad-hoc project search.** "Where did we decide X?" or "didn't we have a doc about Y?" starts with `orbit search "X" --kind all`.
 
 ## Stop Rule
@@ -83,7 +83,7 @@ Treat scores as relative ordering signals, not absolute confidence thresholds. S
 | Calling lifecycle commands to search | `orbit semantic` manages the companion | Use `orbit search` or `orbit.search` |
 | Aborting when the companion is not installed | Embeddings are optional infrastructure | Fall back to lexical search unless the user opted in |
 | Using semantic search for exact identifiers | Lexical matching is cheaper and more predictable for names, paths, and error strings | Use plain `orbit search` or `orbit.graph.search` |
-| Calling `--related` on a brand-new task before indexing completes | New tasks may not have embeddings yet | Search the task title/description with `--semantic --kind task` |
+| Calling `--semantic <id>` on a brand-new task before indexing completes | New tasks may not have embeddings yet | Search the task title/description with `--hybrid --kind task` |
 
 ## Cross-References
 

--- a/crates/orbit-core/assets/skills/orbit/SKILL.md
+++ b/crates/orbit-core/assets/skills/orbit/SKILL.md
@@ -27,7 +27,7 @@ Orbit tools are reachable via two surfaces. Both accept identical JSON arguments
 - Task lifecycle (`orbit.task.*`): both surfaces.
 - ADR artifacts (`orbit.adr.*`): both surfaces.
 - Graph read tools (`search`, `show`, `pack`, `callers`, `refs`, `implementors`, `deps`, `overview`, `history`): both surfaces.
-- Unified search (`orbit.search`): both surfaces. Lexical search works without setup; `semantic: true` and `related` require the search companion (`orbit semantic install`).
+- Unified search (`orbit.search`): both surfaces. Lexical search works without setup; `hybrid: true` and `semantic: "<task-id>"` require the search companion (`orbit semantic install`).
 - Semantic lifecycle tools (`orbit.semantic.install`, `orbit.semantic.uninstall`, `orbit.semantic.stats`, `orbit.semantic.index`): registered tool surface for managing the local embedding companion.
 - State handoff (`orbit.state.*`), graph writes, and duel/scoreboard tools: **CLI only** — used inside activity steps where the agent has shell access.
 
@@ -54,8 +54,8 @@ orbit tool run orbit.task.show --input '{"id": "<id>", "field": "plan", "model":
 orbit tool run orbit.task.list --input '{"status": "backlog", "model": "<agent-family>"}'       # List by status
 orbit tool run orbit.task.search --input '{"query": "search text", "model": "<agent-family>"}'  # Lexical title/description substring match
 orbit tool run orbit.search --input '{"query": "topic phrase", "limit": 5, "model": "<agent-family>"}'  # Lexical global search across tasks, docs, learnings, and ADRs
-orbit tool run orbit.search --input '{"query": "topic phrase", "semantic": true, "kind": "task", "limit": 5, "model": "<agent-family>"}'  # Hybrid BM25 + cosine over indexed task fields
-orbit tool run orbit.search --input '{"related": "<task-id>", "limit": 5, "model": "<agent-family>"}'        # Cosine neighbors of an indexed task
+orbit tool run orbit.search --input '{"query": "topic phrase", "hybrid": true, "kind": "task", "limit": 5, "model": "<agent-family>"}'  # Hybrid BM25 + cosine over indexed task fields
+orbit tool run orbit.search --input '{"semantic": "<task-id>", "limit": 5, "model": "<agent-family>"}'        # Cosine neighbors of an indexed task
 orbit tool run orbit.task.add --input '{"title": "...", "description": "...", "acceptance_criteria": ["..."], "workspace": ".", "model": "<agent-family>"}'
 orbit tool run orbit.task.update --input '{"id": "<id>", "plan": "...", "model": "<agent-family>"}'
 orbit tool run orbit.task.start --input '{"id": "<id>", "note": "...", "model": "<agent-family>"}' # backlog -> in-progress

--- a/crates/orbit-core/src/command/search.rs
+++ b/crates/orbit-core/src/command/search.rs
@@ -75,15 +75,16 @@ impl FromStr for GlobalSearchKind {
 #[serde(rename_all = "lowercase")]
 pub enum GlobalSearchMode {
     Lexical,
-    Semantic,
-    Related,
+    Hybrid,
+    Neighbor,
 }
 
 #[derive(Debug, Clone)]
 pub struct GlobalSearchParams {
     pub query: Option<String>,
-    pub semantic: bool,
-    pub related: Option<String>,
+    // ADR-0175: hybrid free-text ranking and task-neighbor lookup are distinct modes.
+    pub hybrid: bool,
+    pub semantic: Option<String>,
     pub kind: GlobalSearchKind,
     pub limit: usize,
     pub field: Option<String>,
@@ -141,29 +142,29 @@ impl OrbitRuntime {
         let mut results = Vec::new();
         let mut notes = Vec::new();
 
-        if let Some(related_id) = params.related {
+        if let Some(semantic_id) = params.semantic {
             if params
                 .query
                 .as_deref()
                 .is_some_and(|query| !query.trim().is_empty())
             {
                 return Err(OrbitError::InvalidInput(
-                    "`query` and `related` are mutually exclusive".to_string(),
+                    "`query` and `semantic` are mutually exclusive".to_string(),
                 ));
             }
             if !matches!(params.kind, GlobalSearchKind::Task | GlobalSearchKind::All) {
                 return Err(OrbitError::InvalidInput(
-                    "`related` only supports --kind task or --kind all".to_string(),
+                    "`semantic` only supports --kind task or --kind all".to_string(),
                 ));
             }
             let related = self.semantic_related(SemanticRelatedParams {
-                task_id: related_id,
+                task_id: semantic_id,
                 limit,
                 model: params.model,
             })?;
             results.extend(related.results.into_iter().map(semantic_hit_to_global));
             return Ok(GlobalSearchResponse {
-                mode: GlobalSearchMode::Related,
+                mode: GlobalSearchMode::Neighbor,
                 kind: params.kind,
                 results,
                 notes,
@@ -178,21 +179,21 @@ impl OrbitRuntime {
             .ok_or_else(|| {
                 OrbitError::InvalidInput("search query must not be empty".to_string())
             })?;
-        let mode = if params.semantic {
-            GlobalSearchMode::Semantic
+        let mode = if params.hybrid {
+            GlobalSearchMode::Hybrid
         } else {
             GlobalSearchMode::Lexical
         };
 
-        if params.semantic && !matches!(params.kind, GlobalSearchKind::Task) {
+        if params.hybrid && !matches!(params.kind, GlobalSearchKind::Task) {
             notes.push(
-                "semantic vector search currently runs against tasks only; docs, learnings, and ADRs use lexical matching"
+                "hybrid vector search currently runs against tasks only; docs, learnings, and ADRs use lexical matching"
                     .to_string(),
             );
         }
 
         if params.kind.includes_tasks() {
-            if params.semantic {
+            if params.hybrid {
                 let search = self.semantic_search(SemanticSearchParams {
                     query: query.to_string(),
                     limit,
@@ -305,5 +306,28 @@ fn semantic_hit_to_global(hit: orbit_search::SemanticHit) -> GlobalSearchHit {
         snippet: Some(hit.snippet),
         score: Some(hit.score),
         matched_by: None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+
+    #[test]
+    fn search_modes_serialize_with_public_flag_names() {
+        assert_eq!(
+            serde_json::to_value(GlobalSearchMode::Lexical).expect("serialize mode"),
+            json!("lexical")
+        );
+        assert_eq!(
+            serde_json::to_value(GlobalSearchMode::Hybrid).expect("serialize mode"),
+            json!("hybrid")
+        );
+        assert_eq!(
+            serde_json::to_value(GlobalSearchMode::Neighbor).expect("serialize mode"),
+            json!("neighbor")
+        );
     }
 }

--- a/crates/orbit-core/src/runtime/orbit_tool_host/search_tools.rs
+++ b/crates/orbit-core/src/runtime/orbit_tool_host/search_tools.rs
@@ -8,9 +8,15 @@ use crate::{GlobalSearchKind, GlobalSearchParams, OrbitRuntime};
 use super::input::optional_bool_alias;
 
 pub(super) fn search(runtime: &OrbitRuntime, input: Value) -> Result<Value, OrbitError> {
-    let related = optional_string_alias(&input, &["related", "id", "task_id", "taskId"])?;
-    let semantic =
-        optional_bool_alias(&input, &["semantic"])?.unwrap_or(false) || related.is_some();
+    // ADR-0175: hard-break the retired neighbor parameter; no compatibility shim.
+    if input.get("related").is_some() {
+        return Err(OrbitError::InvalidInput(
+            "unknown parameter `related`; use `semantic` for task-neighbor lookup".to_string(),
+        ));
+    }
+
+    let semantic = optional_string_alias(&input, &["semantic", "id", "task_id", "taskId"])?;
+    let hybrid = optional_bool_alias(&input, &["hybrid"])?.unwrap_or(false);
     let kind = optional_string_alias(&input, &["kind"])?
         .map(|kind| GlobalSearchKind::from_str(&kind).map_err(OrbitError::InvalidInput))
         .transpose()?
@@ -18,8 +24,8 @@ pub(super) fn search(runtime: &OrbitRuntime, input: Value) -> Result<Value, Orbi
 
     let result = runtime.global_search(GlobalSearchParams {
         query: optional_string_alias(&input, &["query"])?,
+        hybrid,
         semantic,
-        related,
         kind,
         limit: optional_u32_alias(&input, &["limit"])?
             .map(|limit| limit as usize)
@@ -39,4 +45,32 @@ pub(super) fn search(runtime: &OrbitRuntime, input: Value) -> Result<Value, Orbi
     })?;
     serde_json::to_value(result)
         .map_err(|error| OrbitError::Execution(format!("serialize search result: {error}")))
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+
+    #[test]
+    fn search_tool_rejects_legacy_related_param() {
+        let runtime = OrbitRuntime::in_memory().expect("build runtime");
+        let error = search(&runtime, json!({ "related": "ORB-00001" }))
+            .expect_err("legacy related parameter should be rejected");
+
+        assert!(error.to_string().contains("unknown parameter `related`"));
+    }
+
+    #[test]
+    fn search_tool_rejects_boolean_semantic_param() {
+        let runtime = OrbitRuntime::in_memory().expect("build runtime");
+        let mut input = serde_json::Map::new();
+        input.insert("query".to_string(), json!("anything"));
+        input.insert("semantic".to_string(), json!(true));
+        let error = search(&runtime, Value::Object(input))
+            .expect_err("semantic parameter should require a task ID string");
+
+        assert!(error.to_string().contains("`semantic` must be a string"));
+    }
 }

--- a/crates/orbit-tools/src/builtin/orbit/search.rs
+++ b/crates/orbit-tools/src/builtin/orbit/search.rs
@@ -10,14 +10,14 @@ impl Tool for OrbitSearchTool {
         let mut parameters = vec![
             ToolParam {
                 name: "query".to_string(),
-                description:
-                    "Free-text query. Defaults to lexical matching unless semantic is true."
-                        .to_string(),
+                description: "Free-text query. Defaults to lexical matching unless hybrid is true."
+                    .to_string(),
                 param_type: "string".to_string(),
                 required: false,
             },
             ToolParam {
-                name: "semantic".to_string(),
+                // ADR-0175: expose the free-text vector ranker as hybrid, not semantic.
+                name: "hybrid".to_string(),
                 description:
                     "Opt into hybrid BM25 + cosine ranking for task vectors; other kinds remain lexical."
                         .to_string(),
@@ -25,9 +25,10 @@ impl Tool for OrbitSearchTool {
                 required: false,
             },
             ToolParam {
-                name: "related".to_string(),
+                // ADR-0175: semantic carries the task ID for cosine-neighbor lookup.
+                name: "semantic".to_string(),
                 description:
-                    "Task ID for cosine-neighbor lookup. Mutually exclusive with query and implies semantic mode."
+                    "Task ID for cosine-neighbor lookup. Mutually exclusive with query."
                         .to_string(),
                 param_type: "string".to_string(),
                 required: false,
@@ -73,5 +74,24 @@ impl Tool for OrbitSearchTool {
 
     fn execute(&self, ctx: &ToolContext, input: Value) -> Result<Value, OrbitError> {
         super::execute_host_action(ctx, input, OrbitBuiltinAction::Search)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn search_schema_uses_hybrid_and_semantic_task_id_params() {
+        let schema = OrbitSearchTool.schema();
+        let params = schema
+            .parameters
+            .iter()
+            .map(|param| (param.name.as_str(), param.param_type.as_str()))
+            .collect::<Vec<_>>();
+
+        assert!(params.contains(&("hybrid", "boolean")));
+        assert!(params.contains(&("semantic", "string")));
+        assert!(!params.iter().any(|(name, _)| *name == "related"));
     }
 }

--- a/docs/design/orbit-search/2_design.md
+++ b/docs/design/orbit-search/2_design.md
@@ -251,8 +251,8 @@ Either retriever alone has a failure mode the other doesn't. RRF resolves both a
 ```
 orbit semantic install   [--model bge-small | minilm-l6 | nomic-v1.5] [--force]
 orbit semantic uninstall [--model MODEL] [--all]
-orbit search <query> [--semantic] [--kind task|doc|learning|adr|all] [--limit N] [--field FIELD]
-orbit search --related <task-id> [--limit N]
+orbit search <query> [--hybrid] [--kind task|doc|learning|adr|all] [--limit N] [--field FIELD]
+orbit search --semantic <task-id> [--limit N]
 orbit semantic index     [--force] [--model MODEL]
 orbit semantic stats
 ```
@@ -261,13 +261,13 @@ orbit semantic stats
 
 `uninstall` removes the companion binary and (by default) the currently active model. `--model M` removes only model M. `--all` removes the companion plus every installed model.
 
-`orbit search` defaults to lexical matching across tasks, docs, learnings, and ADRs. `--semantic --kind task` runs the hybrid pipeline over task vectors; non-task kinds remain lexical even when `--semantic` is set. `--related` embeds the target task's `purpose + summary` and runs cosine-only against other tasks (lexical fusion adds noise here). `orbit semantic index` rebuilds the `embeddings` rows; `--force` ignores `content_hash` and re-embeds everything. `stats` reports row counts, model distribution, stale-row count, and companion-install status.
+`orbit search` defaults to lexical matching across tasks, docs, learnings, and ADRs. `--hybrid --kind task` runs the hybrid pipeline over task vectors; non-task kinds remain lexical even when `--hybrid` is set. `--semantic <task-id>` embeds the target task's `purpose + summary` and runs cosine-only against other tasks (lexical fusion adds noise here). `orbit semantic index` rebuilds the `embeddings` rows; `--force` ignores `content_hash` and re-embeds everything. `stats` reports row counts, model distribution, stale-row count, and companion-install status.
 
-If the companion is not installed, `orbit search --semantic`, `orbit search --related`, and `orbit semantic index` exit non-zero with: `"Semantic search not enabled. Run \`orbit semantic install\` to download the inference companion."`
+If the companion is not installed, `orbit search --hybrid`, `orbit search --semantic <task-id>`, and `orbit semantic index` exit non-zero with: `"Semantic search not enabled. Run \`orbit semantic install\` to download the inference companion."`
 
 ### 6.2 MCP tools
 
-- `orbit.search` — `(query?, semantic?, related?, kind?, limit?, field?)` → ranked results with snippets.
+- `orbit.search` — `(query?, hybrid?, semantic?, kind?, limit?, field?)` → ranked results with snippets.
 - `orbit.semantic.install`, `orbit.semantic.uninstall`, `orbit.semantic.stats`, `orbit.semantic.index` — companion lifecycle.
 
 `orbit.search` is read-only. Indexing is implicit (on task mutation) or explicit (`orbit semantic index` / `orbit.semantic.index`).
@@ -405,7 +405,7 @@ Three loops at increasing scope:
 
 This section deliberately does not commit to:
 
-- **Symbol → ADR back-link as a precomputed edge.** Falls out of a future `orbit search --kind adr --semantic` path once ADRs are vector-indexed. Precomputing top-k matches per symbol is a phase-3 optimization tied to the task-lineage feature, not a v1 requirement.
+- **Symbol → ADR back-link as a precomputed edge.** Falls out of a future vector-ranked ADR search path once ADRs are vector-indexed. Precomputing top-k matches per symbol is a phase-3 optimization tied to the task-lineage feature, not a v1 requirement.
 - **Code-aware embedding model.** CodeBERT, voyage-code, and similar outperform general-text models on code retrieval but are larger and weaker on English. v1 ships with the BGE-small default ([ADR-001](./4_decisions.md#adr-001--fastembed-rs-onnx-backend-over-candle-llamacpp-or-external-ollama)) and revisits if recall on code queries underperforms.
 - **HNSW upgrade.** The graph corpus may cross the brute-force ceiling. Schema is already forward-compatible with `sqlite-vec` per [ADR-002](./4_decisions.md#adr-002--brute-force-cosine-over-sqlite-blobs-sqlite-vec-reserved-as-phase-2-upgrade); the decision to switch is a separate ADR at the point of operational evidence — see [3_vision.md §1.3](./3_vision.md).
 - **Free-floating file-scope comments.** Comments not attached to any leaf's source span (e.g. section dividers between two `fn`s) are not embedded. The project convention is "default to no comments" so this gap is small and low-signal.

--- a/docs/design/orbit-search/3_vision.md
+++ b/docs/design/orbit-search/3_vision.md
@@ -60,7 +60,7 @@ The schema is ready for any answer; the UX is not yet chosen.
 
 ### 1.5 Cross-task semantic links
 
-Once embeddings exist, the cheapest possible feature is "show me tasks similar to this one" — already in scope as `orbit search --related`. Less obvious:
+Once embeddings exist, the cheapest possible feature is "show me tasks similar to this one" — already in scope as `orbit search --semantic <task-id>`. Less obvious:
 
 - **Auto-detect duplicate task creation.** Run the new task's `purpose` through cosine before insert; if a high-similarity match exists, warn the user.
 - **Auto-suggest dependencies.** A new task's content is highly similar to an in-progress task — should it depend on it?

--- a/docs/design/orbit-search/4_decisions.md
+++ b/docs/design/orbit-search/4_decisions.md
@@ -195,7 +195,7 @@ Compare to the analogous knowledge-graph crate: `orbit-knowledge` owns its data 
 **Consequences.**
 - Re-running `orbit semantic install` after upgrading Orbit naturally refreshes stale companions without requiring users to uninstall first.
 - Task mutation output stays trustworthy: background indexing remains best-effort and cannot leak companion stderr into successful `task.add` / `task.update` command output.
-- Direct commands such as `orbit search --semantic`, `orbit search --related`, and `orbit semantic index` still show actionable companion stderr because they use the inherited-stderr path.
+- Direct commands such as `orbit search --hybrid`, `orbit search --semantic <task-id>`, and `orbit semantic index` still show actionable companion stderr because they use the inherited-stderr path.
 - Cost: install now trusts the companion's `--version-info` protocol. If a broken companion cannot answer the probe, Orbit conservatively replaces it, which can redownload or recopy the binary even when the file might have been usable for embeddings.
 
 ---
@@ -206,13 +206,29 @@ Compare to the analogous knowledge-graph crate: `orbit-knowledge` owns its data 
 
 **Context.** `orbit semantic` mixed embedding-companion lifecycle (`install`, `uninstall`, `stats`, `index`) with user query verbs (`search`, `related`). The phase-1 search engine now owns both lexical and vector ranking, so leaving queries under `semantic` would make users choose an implementation detail before they search.
 
-**Decision.** `orbit semantic` is only the lifecycle namespace for the local embedding companion. `orbit search` is the unified query surface; lexical ranking is the default, `--semantic` opts into hybrid BM25 plus cosine for task vectors, and `--related <id>` performs cosine-neighbor lookup for indexed tasks.
+**Decision.** `orbit semantic` is only the lifecycle namespace for the local embedding companion. `orbit search` is the unified query surface; lexical ranking is the default, `--hybrid` opts into hybrid BM25 plus cosine for task vectors, and `--semantic <id>` performs cosine-neighbor lookup for indexed tasks.
 
 **Consequences.**
 - Establishes a precedent that lifecycle namespaces manage local subsystems while query namespaces describe what users are trying to do.
 - `orbit semantic search`, `orbit semantic related`, and `orbit semantic reindex` are hard breaks with no shim because there are no known external consumers yet.
 - Per-domain search commands stay untouched for phase 1; a later task decides whether they thin-wrap `orbit search`, demote to filters, or retire.
-- Vector index coverage remains task-only today; docs, learnings, and ADRs continue to use lexical matching even when `--semantic` is set.
+- Vector index coverage remains task-only today; docs, learnings, and ADRs continue to use lexical matching even when `--hybrid` is set.
+
+---
+
+## ADR-0175 — Rename search mode and neighbor flags
+
+**Status:** Accepted · 2026-05-20 · [ORB-00204]
+
+**Context.** Phase 1 used the semantic name for the hybrid BM25 plus cosine mode toggle and a separate related-task flag for cosine-neighbor lookup. That inverted the intuitive reading of semantic search: users expect semantic plus an ID to mean nearest neighbors, while hybrid is the honest name for the ranking algorithm.
+
+**Decision.** Rename the free-text ranking toggle to `--hybrid` / `hybrid: true` and rename task-neighbor lookup to `--semantic <id>` / `semantic: "<id>"`. Keep lexical search as the default and report JSON mode `hybrid` for hybrid free-text search and `neighbor` for cosine-only task-neighbor lookup.
+
+**Consequences.**
+- The CLI and MCP surfaces match user vocabulary before external consumers depend on the phase-1 names.
+- Historical phase-1 audit payloads that carried `semantic: true` are orphaned by the hard break, matching the no-shim policy for this young surface.
+- Documentation and packaged skills must distinguish the `orbit semantic` lifecycle command from the `--semantic <id>` search flag.
+- Cost: Agents and docs written against phase 1 need a one-time rename sweep, and ORB-00202 may need a rebase because it edits adjacent search surfaces.
 - Cost: historical audit event names `semantic.search` and `semantic.related` become orphaned event types, accepted because no external audit-history consumers exist yet.
 
 ---
@@ -224,5 +240,6 @@ Compare to the analogous knowledge-graph crate: `orbit-knowledge` owns its data 
 - [T20260510-20] — Refactor: relocate orbit-search ownership to orbit-embed (vector store + commands). The task that accepted and implemented ADR-007.
 - [T20260510-26] — Make semantic companion install/update quiet and version-aware. The task that accepted and implemented ADR-008.
 - [ORB-00196] — Split `orbit semantic` lifecycle from the unified `orbit search` query surface. The task that accepted and implemented ADR-0174.
+- [ORB-00204] — Rename `orbit search` flags to `--hybrid` for free-text vector ranking and `--semantic <id>` for task-neighbor lookup. The task that accepted and implemented ADR-0175.
 
 Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.

--- a/website/src/content/docs/reference/cli.md
+++ b/website/src/content/docs/reference/cli.md
@@ -25,7 +25,7 @@ sidebar:
 | `orbit run duel-plan <task_id> --wait` | Submit a planning duel and wait for its terminal status before returning. |
 | `orbit task` | Create, update, and manage tasks. |
 | `orbit task artifact put <task_id> <source_path>` | Store a UTF-8 file under a task's artifacts directory. |
-| `orbit search <query>` | Search tasks, docs, learnings, and ADRs; add `--semantic` for task-vector ranking or `--related <id>` for task neighbors. |
+| `orbit search <query>` | Search tasks, docs, learnings, and ADRs; add `--hybrid` for task-vector ranking or use `orbit search --semantic <id>` for task neighbors. |
 | `orbit docs` | Search and manage the indexed docs corpus. |
 | `orbit learning` | Create, search, and curate project learnings. |
 


### PR DESCRIPTION
## Task

ORB-00204: hard-break rename for the unified `orbit search` non-lexical flags.

## Execution Summary

- Renamed the free-text vector-ranking toggle from `--semantic` / `semantic: true` to `--hybrid` / `hybrid: true` across CLI parsing, core runtime params, MCP schema, and tool-host parsing.
- Renamed task-neighbor lookup from `--related <id>` / `related` to `--semantic <id>` / `semantic: "<id>"`, with old MCP `related` rejected and boolean `semantic` type-errors.
- Updated JSON modes to `lexical`, `hybrid`, and `neighbor`; `neighbor` is used for task-neighbor lookup because that path is cosine-only, not hybrid BM25 + cosine ranking.
- Allocated and accepted ADR-0175, updated the orbit-search design docs, and swept README, website docs, skills, activity YAML, and CHANGELOG references.

## Validation

- `cargo test -p orbit-core search`
- `cargo test -p orbit-cli search`
- `cargo test -p orbit-tools search_schema_uses_hybrid_and_semantic_task_id_params`
- `cargo test -p orbit-search related`
- `cargo build -p orbit-cli`
- `make ci-fast` after rebasing onto `origin/agent-main`
- `git diff --check`
- Manual checks with `target/debug/orbit`: help usage, JSON modes, old CLI/MCP failures, and tool schema.

## Branch Freshness

Rebased onto `origin/agent-main` at `9a5414ba` before commit/push.
