### PR TITLE
[codex] [ORB-00201] Add worktree-local artifacts

### DIFF
--- a/.orbit/adrs/accepted/ADR-0177/adr.yaml
+++ b/.orbit/adrs/accepted/ADR-0177/adr.yaml
@@ -1,0 +1,16 @@
+schema_version: 1
+id: ADR-0177
+title: Worktree-local ADR and learning bodies with shared ID allocation
+status: accepted
+owner: codex
+created_at: 2026-05-20T07:03:02.932764Z
+accepted_at: 2026-05-20T07:03:09.624062Z
+last_updated: 2026-05-20T07:03:09.624062Z
+related_features:
+- worktree-artifacts
+related_tasks:
+- ORB-00201
+supersedes: []
+legacy_ids: []
+validation_warnings: []
+legacy_validation: none

--- a/.orbit/adrs/accepted/ADR-0177/body.md
+++ b/.orbit/adrs/accepted/ADR-0177/body.md
@@ -1,0 +1,11 @@
+## Context
+Linked worktrees need ADR and learning bodies committed with the code branch that created them, but IDs must remain collision-free across all worktrees. ORB-00199 introduced shared/local root resolution and ORB-00200 introduced the shared SQLite allocator. The remaining choice is whether body files follow the allocator into shared_root or follow the editing branch into local_root.
+
+## Decision
+Write ADR and learning body files under the current worktree local_root while keeping ID allocation, migration, and allocation metadata in shared_root/.orbit/state/semantic.db. Lists read through id_allocations: default output includes only locally readable bodies, while include-remote returns stubs that name the recorded worktree and branch.
+
+## Consequences
+- ADR and learning files can be staged in the same PR as the implementation that created them.
+- Shared ID allocation still prevents cross-worktree collisions and records where each body lives.
+- Readers get predictable defaults without failing on missing sibling-worktree files.
+- Cost: list/show paths now carry a federation boundary and must handle body_path metadata, remote stubs, and stale worktree paths.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -97,3 +97,4 @@ Each workspace crate declares a stability tier in its `Cargo.toml` under `[packa
 | Command Audit   | GlobalOnly         | Single authoritative SQLite event trail          |
 | Semantic Index  | WorkspaceOnly      | Task-derived embeddings stay with the workspace  |
 | Run Traces      | WorkspaceOnly      | Per-repo activity/job JSONL and blob artifacts   |
+| ADR/Learning IDs | Shared allocator + worktree-local bodies | ID rows live in shared `.orbit/state/semantic.db`; body files live in the current worktree so they can be staged with code |

--- a/crates/orbit-cli/src/command/learning/list.rs
+++ b/crates/orbit-cli/src/command/learning/list.rs
@@ -2,7 +2,7 @@ use std::str::FromStr;
 
 use clap::Args;
 use orbit_common::utility::glob::{compile_glob_regex, normalize_glob_path};
-use orbit_core::{LearningStatus, OrbitError, OrbitRuntime};
+use orbit_core::{LearningListEntry, LearningStatus, OrbitError, OrbitRuntime};
 use serde_json::Value;
 
 use crate::command::Execute;
@@ -25,6 +25,9 @@ pub struct LearningListArgs {
     /// Output as JSON
     #[arg(long)]
     pub json: bool,
+    /// Include learnings whose body files are recorded in another worktree but not locally readable
+    #[arg(long)]
+    pub include_remote: bool,
 }
 
 impl Execute for LearningListArgs {
@@ -37,10 +40,13 @@ impl Execute for LearningListArgs {
         let tag = self.tag.as_deref().map(|t| t.trim().to_lowercase());
         let path_normalized = self.path.as_deref().map(normalize_glob_path).transpose()?;
 
-        let learnings = runtime.list_learnings(status)?;
+        let learnings = runtime.list_learning_entries(status, self.include_remote)?;
         let filtered: Vec<_> = learnings
             .into_iter()
-            .filter(|l| {
+            .filter(|entry| {
+                let LearningListEntry::Local(l) = entry else {
+                    return tag.is_none() && self.path.is_none();
+                };
                 if let Some(ref tag) = tag
                     && !l.scope.tags.iter().any(|t| t == tag)
                 {
@@ -56,16 +62,28 @@ impl Execute for LearningListArgs {
             .collect();
 
         if self.json {
-            let array = Value::Array(filtered.iter().map(learning_to_json).collect());
+            let array = Value::Array(filtered.iter().map(learning_entry_to_json).collect());
             crate::output::json::print_pretty(&array)
         } else {
-            for learning in &filtered {
-                println!(
-                    "{}\t{}\t{}",
-                    learning.id,
-                    learning.status.as_str(),
-                    learning.summary
-                );
+            for entry in &filtered {
+                match entry {
+                    LearningListEntry::Local(learning) => {
+                        println!(
+                            "{}\t{}\t{}",
+                            learning.id,
+                            learning.status.as_str(),
+                            learning.summary
+                        );
+                    }
+                    LearningListEntry::Remote(stub) => {
+                        println!(
+                            "{}\t{}\t[remote: {}]",
+                            stub.id,
+                            stub.status,
+                            stub.worktree_root.display()
+                        );
+                    }
+                }
             }
             Ok(())
         }
@@ -78,4 +96,30 @@ fn learning_scope_contains_path(learning: &orbit_core::Learning, path: &str) -> 
             .map(|regex| regex.is_match(path))
             .unwrap_or(false)
     })
+}
+
+fn learning_entry_to_json(entry: &LearningListEntry) -> Value {
+    match entry {
+        LearningListEntry::Local(learning) => {
+            let mut value = learning_to_json(learning);
+            if let Some(object) = value.as_object_mut() {
+                object.insert("remote".to_string(), Value::Bool(false));
+            }
+            value
+        }
+        LearningListEntry::Remote(stub) => serde_json::json!({
+            "id": stub.id,
+            "kind": stub.kind,
+            "status": stub.status,
+            "remote": true,
+            "remote_marker": format!("[remote: {}]", stub.worktree_root.display()),
+            "worktree_root": stub.worktree_root.to_string_lossy(),
+            "branch": stub.branch,
+            "body_path": stub.body_path.as_ref().map(|path| path.to_string_lossy().to_string()),
+            "summary": Value::Null,
+            "body": Value::Null,
+            "scope": Value::Null,
+            "evidence": Value::Null,
+        }),
+    }
 }

--- a/crates/orbit-cli/tests/learning.rs
+++ b/crates/orbit-cli/tests/learning.rs
@@ -125,7 +125,8 @@ fn cli_learning_comment_add_list_delete_round_trips_with_tombstone() {
         .join(".orbit/learnings")
         .join(id)
         .join("comments.jsonl");
-    assert!(!comments_path.exists());
+    assert!(comments_path.exists());
+    assert!(fs::read_to_string(&comments_path).unwrap().is_empty());
 
     let comment = workspace.run_json(
         &[
@@ -199,7 +200,7 @@ fn cli_learning_comment_add_list_delete_round_trips_with_tombstone() {
 }
 
 #[test]
-fn cli_learning_comment_rejects_missing_and_superseded_parents_without_creating_file() {
+fn cli_learning_comment_rejects_missing_and_superseded_parents_without_appending() {
     let workspace = TestWorkspace::new();
     let output = run_orbit(
         &workspace.work,
@@ -266,14 +267,13 @@ fn cli_learning_comment_rejects_missing_and_superseded_parents_without_creating_
         "stderr: {}",
         String::from_utf8_lossy(&output.stderr)
     );
-    assert!(
-        !workspace
-            .work
-            .join(".orbit/learnings")
-            .join(old["id"].as_str().unwrap())
-            .join("comments.jsonl")
-            .exists()
-    );
+    let comments_path = workspace
+        .work
+        .join(".orbit/learnings")
+        .join(old["id"].as_str().unwrap())
+        .join("comments.jsonl");
+    assert!(comments_path.exists());
+    assert!(fs::read_to_string(comments_path).unwrap().is_empty());
 }
 
 #[test]

--- a/crates/orbit-cli/tests/worktree_resolution.rs
+++ b/crates/orbit-cli/tests/worktree_resolution.rs
@@ -8,7 +8,7 @@ use std::process::Command as StdCommand;
 
 use assert_cmd::Command as AssertCommand;
 use assert_cmd::cargo::cargo_bin_cmd;
-use serde_json::Value;
+use serde_json::{Value, json};
 use tempfile::tempdir;
 
 #[test]
@@ -81,6 +81,168 @@ fn config_show_reports_shared_and_local_roots_for_git_worktrees_and_overrides() 
     );
 }
 
+#[test]
+fn linked_worktree_artifacts_write_locally_and_remote_lists_return_stubs() {
+    let temp = tempdir().expect("tempdir");
+    let home = temp.path().join("home");
+    let main_repo = temp.path().join("repo");
+    let linked_worktree = temp.path().join("repo-artifacts");
+    fs::create_dir_all(&home).expect("create home");
+    fs::create_dir_all(&main_repo).expect("create main repo");
+
+    init_git_repo(&main_repo);
+    run_git(
+        &main_repo,
+        &[
+            "worktree",
+            "add",
+            "-b",
+            "orbit-worktree-artifacts",
+            linked_worktree.to_str().expect("utf8 worktree path"),
+        ],
+    );
+    run_orbit_success(&main_repo, &home, &["workspace", "init"], None);
+
+    let main_repo = fs::canonicalize(&main_repo).expect("canonicalize main repo");
+    let linked_worktree = fs::canonicalize(&linked_worktree).expect("canonicalize linked worktree");
+    let main_orbit = main_repo.join(".orbit");
+    let linked_orbit = linked_worktree.join(".orbit");
+
+    let adr = run_orbit_json(
+        &linked_worktree,
+        &home,
+        &[
+            "tool",
+            "run",
+            "orbit.adr.add",
+            "--input",
+            r###"{"title":"Worktree artifact routing","owner":"codex","body":"## Context\nLinked worktree write.\n\n## Decision\nWrite locally.\n\n## Consequences\n- Body files are committable.\n- Cost: Readers need federation.\n","related_features":["worktree-artifacts"],"related_tasks":["ORB-00201"],"model":"codex"}"###,
+        ],
+        None,
+    );
+    let adr_id = string_field(&adr, "id").to_string();
+
+    let learning = run_orbit_json(
+        &linked_worktree,
+        &home,
+        &[
+            "learning",
+            "add",
+            "--summary",
+            "Stage worktree-local learning artifacts with the code change",
+            "--path",
+            "crates/**",
+            "--tag",
+            "worktree-artifacts",
+            "--evidence",
+            "task:ORB-00201",
+            "--json",
+        ],
+        None,
+    );
+    let learning_id = string_field(&learning, "id").to_string();
+    assert!(learning_id.starts_with("L-"));
+
+    let adr_dir = linked_orbit.join("adrs/proposed").join(&adr_id);
+    assert!(adr_dir.join("adr.yaml").is_file());
+    assert!(adr_dir.join("body.md").is_file());
+    assert!(!main_orbit.join("adrs/proposed").join(&adr_id).exists());
+
+    let learning_dir = linked_orbit.join("learnings").join(&learning_id);
+    assert!(learning_dir.join("learning.yaml").is_file());
+    assert!(learning_dir.join("votes.jsonl").is_file());
+    assert!(learning_dir.join("comments.jsonl").is_file());
+    assert!(!main_orbit.join("learnings").join(&learning_id).exists());
+
+    let local_orbit_entries = sorted_child_names(&linked_orbit);
+    assert_eq!(local_orbit_entries, vec!["adrs", "learnings"]);
+
+    run_git(
+        &main_repo,
+        &[
+            "worktree",
+            "remove",
+            "--force",
+            linked_worktree.to_str().expect("utf8 worktree path"),
+        ],
+    );
+
+    let adr_default = run_orbit_json(
+        &main_repo,
+        &home,
+        &[
+            "tool",
+            "run",
+            "orbit.adr.list",
+            "--input",
+            r#"{"model":"codex"}"#,
+        ],
+        None,
+    );
+    assert!(!array_contains_id(&adr_default, &adr_id));
+
+    let adr_remote = run_orbit_json(
+        &main_repo,
+        &home,
+        &[
+            "tool",
+            "run",
+            "orbit.adr.list",
+            "--input",
+            r#"{"include_remote":true,"model":"codex"}"#,
+        ],
+        None,
+    );
+    let adr_stub = find_id(&adr_remote, &adr_id);
+    assert_eq!(adr_stub["remote"], json!(true));
+    assert!(
+        adr_stub["remote_marker"]
+            .as_str()
+            .expect("marker")
+            .contains("[remote:")
+    );
+
+    let learning_default = run_orbit_json(&main_repo, &home, &["learning", "list", "--json"], None);
+    assert!(!array_contains_id(&learning_default, &learning_id));
+
+    let learning_remote = run_orbit_json(
+        &main_repo,
+        &home,
+        &["learning", "list", "--include-remote", "--json"],
+        None,
+    );
+    let learning_stub = find_id(&learning_remote, &learning_id);
+    assert_eq!(learning_stub["remote"], json!(true));
+    assert!(learning_stub["body"].is_null());
+
+    let show_output = run_orbit_output(
+        &main_repo,
+        &home,
+        &[
+            "tool",
+            "run",
+            "orbit.adr.show",
+            "--input",
+            &format!(r#"{{"id":"{adr_id}","model":"codex"}}"#),
+        ],
+        None,
+    );
+    assert!(!show_output.status.success());
+    let output_text = format!(
+        "{}{}",
+        String::from_utf8_lossy(&show_output.stdout),
+        String::from_utf8_lossy(&show_output.stderr)
+    );
+    assert!(
+        output_text.contains("worktree_root="),
+        "output: {output_text}"
+    );
+    assert!(
+        output_text.contains("orbit-worktree-artifacts"),
+        "output: {output_text}"
+    );
+}
+
 fn assert_root_fields(value: &Value, shared_root: &Path, local_root: &Path) {
     let shared = shared_root.to_string_lossy();
     let local = local_root.to_string_lossy();
@@ -130,6 +292,22 @@ fn run_orbit_json(cwd: &Path, home: &Path, args: &[&str], orbit_root: Option<&Pa
     serde_json::from_slice(&assert.get_output().stdout).expect("orbit json output")
 }
 
+fn run_orbit_output(
+    cwd: &Path,
+    home: &Path,
+    args: &[&str],
+    orbit_root: Option<&Path>,
+) -> std::process::Output {
+    let mut command = cargo_bin_cmd!("orbit");
+    command
+        .current_dir(cwd)
+        .env("HOME", home)
+        .env("USERPROFILE", home)
+        .args(args);
+    set_orbit_root_env(&mut command, orbit_root);
+    command.output().expect("run orbit")
+}
+
 fn set_orbit_root_env(command: &mut AssertCommand, orbit_root: Option<&Path>) {
     match orbit_root {
         Some(path) => {
@@ -156,4 +334,50 @@ fn run_git(cwd: &Path, args: &[&str]) {
         String::from_utf8_lossy(&output.stdout),
         String::from_utf8_lossy(&output.stderr)
     );
+}
+
+fn init_git_repo(main_repo: &Path) {
+    run_git(main_repo, &["init"]);
+    run_git(main_repo, &["config", "user.name", "Orbit Test"]);
+    run_git(
+        main_repo,
+        &["config", "user.email", "orbit-test@example.com"],
+    );
+    run_git(main_repo, &["config", "commit.gpgsign", "false"]);
+    fs::write(main_repo.join("README.md"), "# orbit\n").expect("write readme");
+    run_git(main_repo, &["add", "README.md"]);
+    run_git(main_repo, &["commit", "-m", "initial"]);
+}
+
+fn sorted_child_names(path: &Path) -> Vec<String> {
+    let mut entries = fs::read_dir(path)
+        .expect("read dir")
+        .map(|entry| {
+            entry
+                .expect("entry")
+                .file_name()
+                .to_str()
+                .expect("utf8")
+                .to_string()
+        })
+        .collect::<Vec<_>>();
+    entries.sort();
+    entries
+}
+
+fn array_contains_id(value: &Value, id: &str) -> bool {
+    value
+        .as_array()
+        .expect("array")
+        .iter()
+        .any(|item| item.get("id").and_then(Value::as_str) == Some(id))
+}
+
+fn find_id<'a>(value: &'a Value, id: &str) -> &'a Value {
+    value
+        .as_array()
+        .expect("array")
+        .iter()
+        .find(|item| item.get("id").and_then(Value::as_str) == Some(id))
+        .unwrap_or_else(|| panic!("missing id {id} in {value}"))
 }

--- a/crates/orbit-core/assets/skills/orbit-adr/SKILL.md
+++ b/crates/orbit-core/assets/skills/orbit-adr/SKILL.md
@@ -11,6 +11,12 @@ Create and maintain Orbit ADR artifacts through the registered tool surface. ADR
 
 ADRs and orbit-docs are sibling indexes by design. ADRs keep their stricter lifecycle and dedicated allocation through `orbit.adr.*`; `orbit search --kind all` (and `--kind adr`) surfaces ADR metadata read-only alongside doc results. For the boundary rationale, run `orbit tool run orbit.adr.list --input '{"feature":"orbit-adr"}'` and inspect the accepted ADR covering the sibling-index search overlay.
 
+ADR artifact files are written into the current worktree's `.orbit/adrs/...`
+subtree, while IDs are allocated globally through the shared allocator. Stage
+new ADR files from your task worktree alongside the code/doc change that
+motivated them; sibling worktrees will see remote stubs until that worktree's
+body files are locally readable.
+
 ## Tool Invocation
 
 Both surfaces accept the same JSON. Use the CLI examples below when shell access is available; use the MCP names when the Orbit plugin exposes them.
@@ -67,6 +73,9 @@ Both produce orphan decisions invisible to `orbit.adr.list`, `orbit.adr.show`, a
 
 - Never edit `.orbit/adrs/<status>/<id>/adr.yaml` or `body.md` directly.
 - Never invent the global ADR ID. `orbit.adr.add` allocates it.
+- Stage newly created ADR files from the current worktree together with the
+  implementation they justify; the allocator prevents cross-worktree ID
+  collisions, but the body files belong to the branch that created them.
 - Create an ADR only when all three are true:
   - A real alternative was on the table.
   - The choice constrains future work.

--- a/crates/orbit-core/assets/skills/orbit-learning/SKILL.md
+++ b/crates/orbit-core/assets/skills/orbit-learning/SKILL.md
@@ -11,6 +11,14 @@ Curate durable, scope-injected guidance that survives across sessions and agents
 
 Use this skill when the user reports a recurring failure mode, when a code review surfaces a non-obvious gotcha worth preserving, when an incident root-cause turns into a guardrail, or when a workflow insight ("we always X before Y in this crate") is worth pushing to future agents. Do **not** use it for one-off task notes — those belong on the task itself.
 
+Learning artifact files are written into the current worktree's
+`.orbit/learnings/L-NNNN/` subtree, while IDs are allocated globally through
+the shared allocator. Stage new learning files from your task worktree
+alongside the code/doc change that produced the guidance; sibling worktrees
+will see remote stubs until those body files are locally readable. The
+canonical learning ID format is `L-NNNN`; legacy `L<YYYYMMDD>-N` IDs were
+migrated by ORB-00200 and should only appear in `legacy_ids`.
+
 ## Tool Invocation
 
 Both surfaces accept the same JSON. Use the CLI examples when shell access is available; use the MCP names when the Orbit plugin exposes them.
@@ -67,6 +75,10 @@ Run `orbit tool list | grep orbit.learning` if you suspect the local tool surfac
 ## Operating Rules
 
 - **Never edit `.orbit/learnings/<id>/learning.yaml` directly.** All writes go through the tools so envelope cache, supersede pointers, and audit events stay consistent.
+- **Stage new learning artifacts from the current worktree.** `add` creates
+  `learning.yaml`, `votes.jsonl`, and `comments.jsonl` under
+  `.orbit/learnings/L-NNNN/` in the worktree where you ran the tool; commit
+  those files with the branch that needs the guidance.
 - **Use comments for footnotes, not rewrites.** `orbit.learning.comment.add` is for brief observations tied to the current wording of a learning; the body is capped at 500 characters. For corrections, delete the old comment and add a new one. For material guidance changes, create a replacement learning and use `orbit.learning.supersede`.
 - **Never invent learning IDs.** `add` allocates them; cite returned IDs verbatim.
 - **One learning, one piece of guidance.** If a record needs three sub-points, it is probably three learnings with overlapping scopes — easier to maintain and prune.

--- a/crates/orbit-core/src/command/learning.rs
+++ b/crates/orbit-core/src/command/learning.rs
@@ -14,9 +14,9 @@ use orbit_common::types::{
     LearningVoteSummary, all_agent_families, normalize_agent_family_for_model,
 };
 use orbit_store::{
-    LearningCommentAddParams, LearningCommentDeleteParams, LearningCreateParams,
+    LearningCommentAddParams, LearningCommentDeleteParams, LearningCreateParams, LearningListEntry,
     LearningSearchParams, LearningSearchResult, LearningUpdateParams, LearningUpvoteParams,
-    learning_layout::LearningLayoutMigrationReport,
+    RemoteArtifactStub, learning_layout::LearningLayoutMigrationReport,
 };
 
 use crate::OrbitRuntime;
@@ -29,10 +29,18 @@ impl OrbitRuntime {
     }
 
     pub fn get_learning(&self, id: &str) -> Result<Learning, OrbitError> {
-        self.stores()
-            .learnings()
-            .get(id)?
-            .ok_or_else(|| OrbitError::not_found(NotFoundKind::Learning, id.to_string()))
+        match self.stores().learnings().get_federated(id)? {
+            Some(learning) => Ok(learning),
+            None => {
+                if let Some(stub) = self.stores().learnings().remote_stub(id)? {
+                    return Err(remote_artifact_error("learning", &stub));
+                }
+                Err(OrbitError::not_found(
+                    NotFoundKind::Learning,
+                    id.to_string(),
+                ))
+            }
+        }
     }
 
     pub fn list_learnings(
@@ -40,6 +48,16 @@ impl OrbitRuntime {
         status: Option<LearningStatus>,
     ) -> Result<Vec<Learning>, OrbitError> {
         self.stores().learnings().list(status)
+    }
+
+    pub fn list_learning_entries(
+        &self,
+        status: Option<LearningStatus>,
+        include_remote: bool,
+    ) -> Result<Vec<LearningListEntry>, OrbitError> {
+        self.stores()
+            .learnings()
+            .list_entries(status, include_remote)
     }
 
     pub fn search_learnings(
@@ -168,6 +186,15 @@ impl OrbitRuntime {
         }
         Ok((stale, deleted))
     }
+}
+
+fn remote_artifact_error(kind: &str, stub: &RemoteArtifactStub) -> OrbitError {
+    OrbitError::Store(format!(
+        "{kind} {} is recorded in another worktree and its body is not locally readable; worktree_root={}, branch={}",
+        stub.id,
+        stub.worktree_root.display(),
+        stub.branch.as_deref().unwrap_or("<none>")
+    ))
 }
 
 pub fn migrate_learning_layout_at(

--- a/crates/orbit-core/src/lib.rs
+++ b/crates/orbit-core/src/lib.rs
@@ -82,7 +82,7 @@ pub use orbit_common::utility::redaction::{
 pub use orbit_store::learning_layout::LearningLayoutMigrationReport;
 pub use orbit_store::{AuditEventInsertParams, AuditRoleAggregate, AuditToolAggregate};
 pub use orbit_store::{
-    LearningCommentAddParams, LearningCommentDeleteParams, LearningCreateParams,
+    LearningCommentAddParams, LearningCommentDeleteParams, LearningCreateParams, LearningListEntry,
     LearningSearchParams, LearningSearchResult, LearningUpdateParams, LearningUpvoteParams,
 };
 pub use runtime::OrbitRuntime;

--- a/crates/orbit-core/src/runtime/builder.rs
+++ b/crates/orbit-core/src/runtime/builder.rs
@@ -72,16 +72,11 @@ pub(crate) fn build_context_from_roots(
     if !learning_id_migration.is_empty() {
         record_learning_id_migration_audit(&store, &paths, &learning_id_migration)?;
     }
-    let adr_store = workspace_adr_backends(
-        persistence.adr_dir.clone(),
-        store.clone(),
-        id_allocator.clone(),
-    );
-    let learning_store = workspace_learning_backend(
-        persistence.learning_dir.clone(),
-        store.clone(),
-        id_allocator,
-    )?;
+    let local_adr_dir = paths.local_dir.join("adrs");
+    let local_learning_dir = paths.local_dir.join("learnings");
+    let adr_store = workspace_adr_backends(local_adr_dir, store.clone(), id_allocator.clone());
+    let learning_store =
+        workspace_learning_backend(local_learning_dir, store.clone(), id_allocator)?;
     let semantic_vector_store = Arc::new(VectorStore::open(&persistence.semantic_db)?);
     let semantic_worker = Arc::new(EmbedWorker::start((*semantic_vector_store).clone()));
     let job_run_store = workspace_job_run_store(paths.jobs_dir.clone());

--- a/crates/orbit-core/src/runtime/orbit_tool_host/adr_tools.rs
+++ b/crates/orbit-core/src/runtime/orbit_tool_host/adr_tools.rs
@@ -10,7 +10,7 @@ use orbit_common::types::{
     audit_execution_id, normalize_optional_attribution_label, optional_string,
     optional_string_alias, optional_string_list_alias, required_string,
 };
-use orbit_store::{AdrCreateParams, AdrDocumentUpdateParams};
+use orbit_store::{AdrCreateParams, AdrDocumentUpdateParams, AdrListEntry, RemoteArtifactStub};
 use serde_json::{Value, json};
 
 use crate::OrbitRuntime;
@@ -76,8 +76,15 @@ pub(super) fn show(runtime: &OrbitRuntime, input: Value) -> Result<Value, OrbitE
             .next()
             .ok_or_else(|| OrbitError::not_found(NotFoundKind::Adr, id_value.clone()))?
     } else {
-        adrs.get(&id_value)?
-            .ok_or_else(|| OrbitError::not_found(NotFoundKind::Adr, id_value.clone()))?
+        match adrs.get_federated(&id_value)? {
+            Some(adr) => adr,
+            None => {
+                if let Some(stub) = adrs.remote_stub(&id_value)? {
+                    return Err(remote_artifact_error("ADR", &stub));
+                }
+                return Err(OrbitError::not_found(NotFoundKind::Adr, id_value.clone()));
+            }
+        }
     };
     Ok(adr_to_json(&adr))
 }
@@ -92,16 +99,20 @@ pub(super) fn list(runtime: &OrbitRuntime, input: Value) -> Result<Value, OrbitE
     let legacy_id = optional_string_alias(&input, &["legacy_id", "legacyId"])?;
     let validation_warned =
         super::input::optional_bool_alias(&input, &["validation_warned", "validation"])?;
+    let include_remote =
+        super::input::optional_bool_alias(&input, &["include_remote", "includeRemote"])?
+            .unwrap_or(false);
 
-    let adrs = runtime.stores().adrs().list_filtered(
+    let adrs = runtime.stores().adrs().list_entries_filtered(
         status,
         owner.as_deref(),
         feature.as_deref(),
         task_id.as_deref(),
         legacy_id.as_deref(),
         validation_warned,
+        include_remote,
     )?;
-    Ok(Value::Array(adrs.iter().map(adr_to_json).collect()))
+    Ok(Value::Array(adrs.iter().map(adr_entry_to_json).collect()))
 }
 
 pub(super) fn update(
@@ -265,6 +276,46 @@ fn adr_to_json(adr: &Adr) -> Value {
         "validation_warnings": adr.validation_warnings,
         "legacy_validation": adr.legacy_validation.to_string(),
     })
+}
+
+fn adr_entry_to_json(entry: &AdrListEntry) -> Value {
+    match entry {
+        AdrListEntry::Local(adr) => {
+            let mut value = adr_to_json(adr);
+            if let Some(object) = value.as_object_mut() {
+                object.insert("remote".to_string(), Value::Bool(false));
+            }
+            value
+        }
+        AdrListEntry::Remote(stub) => remote_stub_to_json(stub),
+    }
+}
+
+fn remote_stub_to_json(stub: &RemoteArtifactStub) -> Value {
+    json!({
+        "id": stub.id,
+        "kind": stub.kind,
+        "status": stub.status,
+        "remote": true,
+        "remote_marker": format!("[remote: {}]", stub.worktree_root.display()),
+        "worktree_root": stub.worktree_root.to_string_lossy(),
+        "branch": stub.branch,
+        "body_path": stub.body_path.as_ref().map(|path| path.to_string_lossy().to_string()),
+        "title": Value::Null,
+        "owner": Value::Null,
+        "related_features": Value::Null,
+        "related_tasks": Value::Null,
+        "legacy_ids": Value::Null,
+    })
+}
+
+fn remote_artifact_error(kind: &str, stub: &RemoteArtifactStub) -> OrbitError {
+    OrbitError::Store(format!(
+        "{kind} {} is recorded in another worktree and its body is not locally readable; worktree_root={}, branch={}",
+        stub.id,
+        stub.worktree_root.display(),
+        stub.branch.as_deref().unwrap_or("<none>")
+    ))
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -439,7 +490,7 @@ mod tests {
     }
 
     #[test]
-    fn add_adr_and_learning_keep_body_files_in_shared_root_when_local_root_differs() {
+    fn add_adr_and_learning_keep_body_files_in_local_root_when_local_root_differs() {
         let root = tempdir().expect("tempdir");
         let global_root = root.path().join("global");
         let shared_repo = root.path().join("repo");
@@ -472,21 +523,21 @@ mod tests {
             .expect("add learning");
 
         assert!(
-            shared_root
+            local_root
                 .join("adrs/proposed")
                 .join(adr_id)
                 .join("body.md")
                 .is_file()
         );
         assert!(
-            shared_root
+            local_root
                 .join("learnings")
                 .join(&learning.id)
                 .join("learning.yaml")
                 .is_file()
         );
-        assert!(!local_root.join("adrs").exists());
-        assert!(!local_root.join("learnings").exists());
+        assert!(!shared_root.join("adrs").exists());
+        assert!(!shared_root.join("learnings").exists());
     }
 
     #[test]

--- a/crates/orbit-core/src/runtime/orbit_tool_host/learning_tools.rs
+++ b/crates/orbit-core/src/runtime/orbit_tool_host/learning_tools.rs
@@ -12,7 +12,10 @@ use orbit_common::types::{
     EvidenceKind, LearningEvidence, LearningScope, LearningStatus, NotFoundKind, OrbitError,
     optional_string, optional_string_alias, required_string,
 };
-use orbit_store::{LearningCreateParams, LearningUpdateParams, LearningUpvoteParams};
+use orbit_store::{
+    LearningCreateParams, LearningListEntry, LearningUpdateParams, LearningUpvoteParams,
+    RemoteArtifactStub,
+};
 use serde_json::{Value, json};
 
 use crate::OrbitRuntime;
@@ -53,11 +56,7 @@ pub(super) fn add(
 
 pub(super) fn show(runtime: &OrbitRuntime, input: Value) -> Result<Value, OrbitError> {
     let id = required_string(&input, &["id"], "id")?;
-    let learning = runtime
-        .stores()
-        .learnings()
-        .get(&id)?
-        .ok_or_else(|| OrbitError::not_found(NotFoundKind::Learning, id.clone()))?;
+    let learning = runtime.get_learning(&id)?;
     let vote_summary = runtime.stores().learnings().vote_summary(&id)?;
     Ok(learning_show_to_json(&learning, &vote_summary))
 }
@@ -71,11 +70,16 @@ pub(super) fn list(runtime: &OrbitRuntime, input: Value) -> Result<Value, OrbitE
         .as_deref()
         .map(orbit_common::utility::glob::normalize_glob_path)
         .transpose()?;
+    let include_remote =
+        optional_bool_alias(&input, &["include_remote", "includeRemote"])?.unwrap_or(false);
 
-    let learnings = runtime.stores().learnings().list(status)?;
+    let learnings = runtime.list_learning_entries(status, include_remote)?;
     let filtered: Vec<_> = learnings
         .into_iter()
-        .filter(|l| {
+        .filter(|entry| {
+            let LearningListEntry::Local(l) = entry else {
+                return tag.is_none() && path_normalized.is_none();
+            };
             if let Some(ref tag) = tag
                 && !l.scope.tags.iter().any(|t| t == tag)
             {
@@ -94,8 +98,38 @@ pub(super) fn list(runtime: &OrbitRuntime, input: Value) -> Result<Value, OrbitE
         })
         .collect();
     Ok(Value::Array(
-        filtered.iter().map(learning_to_json).collect(),
+        filtered.iter().map(learning_entry_to_json).collect(),
     ))
+}
+
+fn learning_entry_to_json(entry: &LearningListEntry) -> Value {
+    match entry {
+        LearningListEntry::Local(learning) => {
+            let mut value = learning_to_json(learning);
+            if let Some(object) = value.as_object_mut() {
+                object.insert("remote".to_string(), Value::Bool(false));
+            }
+            value
+        }
+        LearningListEntry::Remote(stub) => remote_stub_to_json(stub),
+    }
+}
+
+fn remote_stub_to_json(stub: &RemoteArtifactStub) -> Value {
+    json!({
+        "id": stub.id,
+        "kind": stub.kind,
+        "status": stub.status,
+        "remote": true,
+        "remote_marker": format!("[remote: {}]", stub.worktree_root.display()),
+        "worktree_root": stub.worktree_root.to_string_lossy(),
+        "branch": stub.branch,
+        "body_path": stub.body_path.as_ref().map(|path| path.to_string_lossy().to_string()),
+        "summary": Value::Null,
+        "body": Value::Null,
+        "scope": Value::Null,
+        "evidence": Value::Null,
+    })
 }
 
 pub(super) fn upvote(

--- a/crates/orbit-core/src/runtime/store_delegates.rs
+++ b/crates/orbit-core/src/runtime/store_delegates.rs
@@ -6,14 +6,15 @@ use orbit_common::types::{
 };
 use orbit_search::{EmbedWorker, VectorStore};
 use orbit_store::{
-    AdrCreateParams, AdrDocumentUpdateParams, AdrStoreBackend, AuditEventFilter,
+    AdrCreateParams, AdrDocumentUpdateParams, AdrListEntry, AdrStoreBackend, AuditEventFilter,
     AuditEventInsertParams, AuditEventStoreBackend, ExecutorDefStoreBackend, JobRunQuery,
     JobRunStepParams, JobRunStoreBackend, LearningCommentAddParams, LearningCommentDeleteParams,
-    LearningCreateParams, LearningSearchParams, LearningSearchResult, LearningStoreBackend,
-    LearningUpdateParams, LearningUpvoteParams, PolicyDefStoreBackend, TaskArtifactStoreBackend,
-    TaskArtifactUpdateParams, TaskCreateParams, TaskDocumentStoreBackend, TaskDocumentUpdateParams,
-    TaskHistoryStoreBackend, TaskHistoryUpdateParams, TaskReservationCheckParams,
-    TaskReservationCheckResult, TaskReservationListResult, TaskReservationOwnedConflictsParams,
+    LearningCreateParams, LearningListEntry, LearningSearchParams, LearningSearchResult,
+    LearningStoreBackend, LearningUpdateParams, LearningUpvoteParams, PolicyDefStoreBackend,
+    RemoteArtifactStub, TaskArtifactStoreBackend, TaskArtifactUpdateParams, TaskCreateParams,
+    TaskDocumentStoreBackend, TaskDocumentUpdateParams, TaskHistoryStoreBackend,
+    TaskHistoryUpdateParams, TaskReservationCheckParams, TaskReservationCheckResult,
+    TaskReservationListResult, TaskReservationOwnedConflictsParams,
     TaskReservationOwnedConflictsResult, TaskReservationReleaseByOwnerParams,
     TaskReservationReleaseByOwnerResult, TaskReservationReleaseParams,
     TaskReservationReleaseResult, TaskReservationReserveParams, TaskReservationReserveResult,
@@ -718,6 +719,10 @@ impl AdrRecords<'_> {
         self.store.get_adr(id)
     }
 
+    pub(crate) fn get_federated(&self, id: &str) -> Result<Option<Adr>, OrbitError> {
+        self.store.get_adr_federated(id)
+    }
+
     /// Unfiltered list. The tool surface uses [`Self::list_filtered`]; this
     /// helper exists for maintenance / CLI tooling layered on top later.
     #[allow(dead_code)]
@@ -743,6 +748,32 @@ impl AdrRecords<'_> {
             legacy_id,
             validation_warned,
         )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn list_entries_filtered(
+        &self,
+        status: Option<AdrStatus>,
+        owner: Option<&str>,
+        feature: Option<&str>,
+        task_id: Option<&str>,
+        legacy_id: Option<&str>,
+        validation_warned: Option<bool>,
+        include_remote: bool,
+    ) -> Result<Vec<AdrListEntry>, OrbitError> {
+        self.store.list_adr_entries_filtered(
+            status,
+            owner,
+            feature,
+            task_id,
+            legacy_id,
+            validation_warned,
+            include_remote,
+        )
+    }
+
+    pub(crate) fn remote_stub(&self, id: &str) -> Result<Option<RemoteArtifactStub>, OrbitError> {
+        self.store.get_adr_remote_stub(id)
     }
 
     pub(crate) fn update_status(&self, id: &str, new_status: AdrStatus) -> Result<(), OrbitError> {
@@ -782,8 +813,24 @@ impl LearningRecords<'_> {
         self.store.get_learning(id)
     }
 
+    pub(crate) fn get_federated(&self, id: &str) -> Result<Option<Learning>, OrbitError> {
+        self.store.get_learning_federated(id)
+    }
+
     pub(crate) fn list(&self, status: Option<LearningStatus>) -> Result<Vec<Learning>, OrbitError> {
         self.store.list_learnings(status)
+    }
+
+    pub(crate) fn list_entries(
+        &self,
+        status: Option<LearningStatus>,
+        include_remote: bool,
+    ) -> Result<Vec<LearningListEntry>, OrbitError> {
+        self.store.list_learning_entries(status, include_remote)
+    }
+
+    pub(crate) fn remote_stub(&self, id: &str) -> Result<Option<RemoteArtifactStub>, OrbitError> {
+        self.store.get_learning_remote_stub(id)
     }
 
     pub(crate) fn search(

--- a/crates/orbit-store/src/backend/contracts.rs
+++ b/crates/orbit-store/src/backend/contracts.rs
@@ -8,6 +8,7 @@ use orbit_common::types::{
 };
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
+use std::path::PathBuf;
 
 use crate::sqlite::audit_event_store::{
     AuditEventFilter, AuditEventInsertParams, AuditRoleAggregate, AuditToolAggregate,
@@ -21,6 +22,28 @@ pub struct AdrCreateParams {
     pub related_features: Vec<String>,
     pub related_tasks: Vec<String>,
     pub body: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RemoteArtifactStub {
+    pub id: String,
+    pub kind: String,
+    pub status: String,
+    pub worktree_root: PathBuf,
+    pub branch: Option<String>,
+    pub body_path: Option<PathBuf>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AdrListEntry {
+    Local(Adr),
+    Remote(RemoteArtifactStub),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum LearningListEntry {
+    Local(Learning),
+    Remote(RemoteArtifactStub),
 }
 
 /// Parameters for a partial update to an existing ADR document.
@@ -336,6 +359,7 @@ pub trait TaskStoreBackend: Send + Sync {
 pub trait AdrStoreBackend: Send + Sync {
     fn add_adr(&self, params: AdrCreateParams) -> Result<Adr, OrbitError>;
     fn get_adr(&self, id: &str) -> Result<Option<Adr>, OrbitError>;
+    fn get_adr_federated(&self, id: &str) -> Result<Option<Adr>, OrbitError>;
     fn list_adrs(&self) -> Result<Vec<Adr>, OrbitError>;
     fn list_adrs_filtered(
         &self,
@@ -346,6 +370,18 @@ pub trait AdrStoreBackend: Send + Sync {
         legacy_id: Option<&str>,
         validation_warned: Option<bool>,
     ) -> Result<Vec<Adr>, OrbitError>;
+    #[allow(clippy::too_many_arguments)]
+    fn list_adr_entries_filtered(
+        &self,
+        status: Option<AdrStatus>,
+        owner: Option<&str>,
+        feature: Option<&str>,
+        task_id: Option<&str>,
+        legacy_id: Option<&str>,
+        validation_warned: Option<bool>,
+        include_remote: bool,
+    ) -> Result<Vec<AdrListEntry>, OrbitError>;
+    fn get_adr_remote_stub(&self, id: &str) -> Result<Option<RemoteArtifactStub>, OrbitError>;
     fn update_adr_status(&self, id: &str, new_status: AdrStatus) -> Result<(), OrbitError>;
     fn update_adr_document(
         &self,
@@ -672,10 +708,17 @@ pub struct LearningCommentDeleteParams {
 pub trait LearningStoreBackend: Send + Sync {
     fn create_learning(&self, params: LearningCreateParams) -> Result<Learning, OrbitError>;
     fn get_learning(&self, id: &str) -> Result<Option<Learning>, OrbitError>;
+    fn get_learning_federated(&self, id: &str) -> Result<Option<Learning>, OrbitError>;
     fn list_learnings(
         &self,
         status: Option<orbit_common::types::LearningStatus>,
     ) -> Result<Vec<Learning>, OrbitError>;
+    fn list_learning_entries(
+        &self,
+        status: Option<orbit_common::types::LearningStatus>,
+        include_remote: bool,
+    ) -> Result<Vec<LearningListEntry>, OrbitError>;
+    fn get_learning_remote_stub(&self, id: &str) -> Result<Option<RemoteArtifactStub>, OrbitError>;
     fn search_learnings(
         &self,
         params: LearningSearchParams,

--- a/crates/orbit-store/src/backend/file_backends.rs
+++ b/crates/orbit-store/src/backend/file_backends.rs
@@ -6,13 +6,14 @@ use orbit_common::types::{
 };
 
 use super::contracts::{
-    AdrCreateParams, AdrDocumentUpdateParams, AdrStoreBackend, ExecutorDefStoreBackend,
-    JobRunQuery, JobRunStepParams, JobRunStoreBackend, LearningCommentAddParams,
-    LearningCommentDeleteParams, LearningCreateParams, LearningSearchParams, LearningSearchResult,
-    LearningStoreBackend, LearningUpdateParams, LearningUpvoteParams, PolicyDefStoreBackend,
-    TaskArtifactStoreBackend, TaskArtifactUpdateParams, TaskCreateParams, TaskDocumentStoreBackend,
-    TaskDocumentUpdateParams, TaskHistoryStoreBackend, TaskHistoryUpdateParams,
-    TaskReviewStoreBackend, TaskReviewUpdateParams, TaskStoreBackend,
+    AdrCreateParams, AdrDocumentUpdateParams, AdrListEntry, AdrStoreBackend,
+    ExecutorDefStoreBackend, JobRunQuery, JobRunStepParams, JobRunStoreBackend,
+    LearningCommentAddParams, LearningCommentDeleteParams, LearningCreateParams, LearningListEntry,
+    LearningSearchParams, LearningSearchResult, LearningStoreBackend, LearningUpdateParams,
+    LearningUpvoteParams, PolicyDefStoreBackend, RemoteArtifactStub, TaskArtifactStoreBackend,
+    TaskArtifactUpdateParams, TaskCreateParams, TaskDocumentStoreBackend, TaskDocumentUpdateParams,
+    TaskHistoryStoreBackend, TaskHistoryUpdateParams, TaskReviewStoreBackend,
+    TaskReviewUpdateParams, TaskStoreBackend,
 };
 use crate::file::adr_store::AdrFileStore;
 use crate::file::executor_def_store::ExecutorDefFileStore;
@@ -314,6 +315,10 @@ impl AdrStoreBackend for AdrFileStore {
         resolve::<Adr, _>(self, id)
     }
 
+    fn get_adr_federated(&self, id: &str) -> Result<Option<Adr>, OrbitError> {
+        AdrFileStore::get_adr_federated(self, id)
+    }
+
     fn list_adrs(&self) -> Result<Vec<Adr>, OrbitError> {
         self.list_adrs()
     }
@@ -335,6 +340,32 @@ impl AdrStoreBackend for AdrFileStore {
             legacy_id,
             validation_warned,
         )
+    }
+
+    fn list_adr_entries_filtered(
+        &self,
+        status: Option<AdrStatus>,
+        owner: Option<&str>,
+        feature: Option<&str>,
+        task_id: Option<&str>,
+        legacy_id: Option<&str>,
+        validation_warned: Option<bool>,
+        include_remote: bool,
+    ) -> Result<Vec<AdrListEntry>, OrbitError> {
+        AdrFileStore::list_adr_entries_filtered(
+            self,
+            status,
+            owner,
+            feature,
+            task_id,
+            legacy_id,
+            validation_warned,
+            include_remote,
+        )
+    }
+
+    fn get_adr_remote_stub(&self, id: &str) -> Result<Option<RemoteArtifactStub>, OrbitError> {
+        AdrFileStore::get_adr_remote_stub(self, id)
     }
 
     fn update_adr_status(&self, id: &str, new_status: AdrStatus) -> Result<(), OrbitError> {
@@ -373,8 +404,24 @@ impl LearningStoreBackend for LearningFileStore {
         resolve::<Learning, _>(self, id)
     }
 
+    fn get_learning_federated(&self, id: &str) -> Result<Option<Learning>, OrbitError> {
+        LearningFileStore::get_learning_federated(self, id)
+    }
+
     fn list_learnings(&self, status: Option<LearningStatus>) -> Result<Vec<Learning>, OrbitError> {
         self.list_learnings(status)
+    }
+
+    fn list_learning_entries(
+        &self,
+        status: Option<LearningStatus>,
+        include_remote: bool,
+    ) -> Result<Vec<LearningListEntry>, OrbitError> {
+        LearningFileStore::list_learning_entries(self, status, include_remote)
+    }
+
+    fn get_learning_remote_stub(&self, id: &str) -> Result<Option<RemoteArtifactStub>, OrbitError> {
+        LearningFileStore::get_learning_remote_stub(self, id)
     }
 
     fn search_learnings(

--- a/crates/orbit-store/src/file/adr_store/api.rs
+++ b/crates/orbit-store/src/file/adr_store/api.rs
@@ -2,7 +2,7 @@
 #![allow(clippy::expect_used)]
 
 use std::fs;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use chrono::Utc;
 use orbit_common::types::{Adr, AdrStatus, LegacyValidation, NotFoundKind, OrbitError};
@@ -15,7 +15,7 @@ use super::layout::{AdrStateDir, adr_dir, state_dir_path, validate_adr_id};
 use super::lock::acquire_adr_lock;
 use crate::backend::{AdrCreateParams, AdrDocumentUpdateParams};
 use crate::file::layout::read_child_dirs;
-use crate::{IdAllocator, Store};
+use crate::{AdrListEntry, IdAllocationRecord, IdAllocator, RemoteArtifactStub, Store};
 
 pub(crate) struct AdrFileStore {
     root: PathBuf,
@@ -101,6 +101,8 @@ impl AdrFileStore {
 
         let target_dir = adr_dir(&self.root, AdrStateDir::Proposed, &id);
         write_bundle_at(&target_dir, &bundle)?;
+        self.id_allocator
+            .record_adr_body_path(&id, &super::layout::body_path(&target_dir))?;
 
         let adr = bundle_to_adr(bundle);
         self.upsert_index_row(&adr);
@@ -114,6 +116,16 @@ impl AdrFileStore {
         };
         let bundle = read_bundle_at(&dir)?;
         Ok(Some(bundle_to_adr(bundle)))
+    }
+
+    pub(crate) fn get_adr_federated(&self, id: &str) -> Result<Option<Adr>, OrbitError> {
+        validate_adr_id(id)?;
+        if let Some(record) = self.id_allocator.adr_allocation(id)?
+            && let Some(adr) = self.read_adr_allocation(&record)?
+        {
+            return Ok(Some(adr));
+        }
+        self.get_adr(id)
     }
 
     pub(crate) fn list_adrs(&self) -> Result<Vec<Adr>, OrbitError> {
@@ -192,6 +204,66 @@ impl AdrFileStore {
         Ok(adrs)
     }
 
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn list_adr_entries_filtered(
+        &self,
+        status: Option<AdrStatus>,
+        owner: Option<&str>,
+        feature: Option<&str>,
+        task_id: Option<&str>,
+        legacy_id: Option<&str>,
+        validation_warned: Option<bool>,
+        include_remote: bool,
+    ) -> Result<Vec<AdrListEntry>, OrbitError> {
+        let mut entries = Vec::new();
+        for record in self.id_allocator.adr_allocations()? {
+            if let Some(adr) = self.read_adr_allocation(&record)? {
+                if matches_filter(
+                    &adr,
+                    status,
+                    owner,
+                    feature,
+                    task_id,
+                    legacy_id,
+                    validation_warned,
+                ) {
+                    entries.push(AdrListEntry::Local(adr));
+                }
+                continue;
+            }
+
+            if include_remote
+                && remote_adr_matches_filter(
+                    &record,
+                    status,
+                    owner,
+                    feature,
+                    task_id,
+                    legacy_id,
+                    validation_warned,
+                )
+            {
+                entries.push(AdrListEntry::Remote(remote_stub_from_allocation(&record)));
+            }
+        }
+        entries.sort_by(|left, right| adr_entry_id(right).cmp(adr_entry_id(left)));
+        Ok(entries)
+    }
+
+    pub(crate) fn get_adr_remote_stub(
+        &self,
+        id: &str,
+    ) -> Result<Option<RemoteArtifactStub>, OrbitError> {
+        validate_adr_id(id)?;
+        let Some(record) = self.id_allocator.adr_allocation(id)? else {
+            return Ok(None);
+        };
+        if self.read_adr_allocation(&record)?.is_some() {
+            return Ok(None);
+        }
+        Ok(Some(remote_stub_from_allocation(&record)))
+    }
+
     /// Updates ADR status, moving the bundle between state directories and
     /// refreshing the index row. Index update is best-effort: a failure is
     /// logged but does not roll back the filesystem move.
@@ -227,6 +299,8 @@ impl AdrFileStore {
             bundle.doc.adr.accepted_at = Some(now);
         }
         write_bundle_at(&target_dir, &bundle)?;
+        self.id_allocator
+            .record_adr_body_path(id, &super::layout::body_path(&target_dir))?;
         self.upsert_index_row(&bundle.doc.adr);
         Ok(())
     }
@@ -373,6 +447,8 @@ impl AdrFileStore {
         moved.doc.adr.status = AdrStatus::Superseded;
         moved.doc.adr.last_updated = Utc::now();
         write_bundle_at(&target_dir, &moved)?;
+        self.id_allocator
+            .record_adr_body_path(old_id, &super::layout::body_path(&target_dir))?;
         self.upsert_index_row(&moved.doc.adr);
 
         // Append `old` to `new.supersedes` (idempotent — skip if already present).
@@ -420,6 +496,20 @@ impl AdrFileStore {
             }
         }
         Ok(None)
+    }
+
+    fn read_adr_allocation(&self, record: &IdAllocationRecord) -> Result<Option<Adr>, OrbitError> {
+        let Some(body_path) = record.resolved_body_path() else {
+            return self.get_adr(&record.id);
+        };
+        let Some(dir) = body_path.parent() else {
+            return Ok(None);
+        };
+        if !super::layout::adr_doc_path(dir).is_file() {
+            return Ok(None);
+        }
+        let bundle = read_bundle_at(dir)?;
+        Ok(Some(bundle_to_adr(bundle)))
     }
 
     fn upsert_index_row(&self, adr: &Adr) {
@@ -584,6 +674,63 @@ fn sort_by_id_desc(adrs: &mut [Adr]) {
     adrs.sort_by(|a, b| b.id.cmp(&a.id));
 }
 
+fn remote_stub_from_allocation(record: &IdAllocationRecord) -> RemoteArtifactStub {
+    RemoteArtifactStub {
+        id: record.id.clone(),
+        kind: record.kind.as_str().to_string(),
+        status: record.status.clone(),
+        worktree_root: record.worktree_root.clone(),
+        branch: record.branch.clone(),
+        body_path: record.body_path.clone(),
+    }
+}
+
+fn adr_entry_id(entry: &AdrListEntry) -> &str {
+    match entry {
+        AdrListEntry::Local(adr) => &adr.id,
+        AdrListEntry::Remote(stub) => &stub.id,
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn remote_adr_matches_filter(
+    record: &IdAllocationRecord,
+    status: Option<AdrStatus>,
+    owner: Option<&str>,
+    feature: Option<&str>,
+    task_id: Option<&str>,
+    legacy_id: Option<&str>,
+    validation_warned: Option<bool>,
+) -> bool {
+    if owner.is_some()
+        || feature.is_some()
+        || task_id.is_some()
+        || legacy_id.is_some()
+        || validation_warned.is_some()
+    {
+        return false;
+    }
+    if let Some(status) = status
+        && remote_adr_status(record.body_path.as_deref()) != Some(status)
+    {
+        return false;
+    }
+    true
+}
+
+fn remote_adr_status(body_path: Option<&Path>) -> Option<AdrStatus> {
+    let path = body_path?;
+    path.components()
+        .filter_map(|component| component.as_os_str().to_str())
+        .find_map(|component| match component {
+            "proposed" => Some(AdrStatus::Proposed),
+            "accepted" => Some(AdrStatus::Accepted),
+            "superseded" => Some(AdrStatus::Superseded),
+            "deleted" => Some(AdrStatus::Deleted),
+            _ => None,
+        })
+}
+
 fn insert_adr_row(conn: &rusqlite::Connection, adr: &Adr) -> Result<(), OrbitError> {
     let related_features = serde_json::to_string(&adr.related_features)
         .map_err(|e| OrbitError::Store(e.to_string()))?;
@@ -658,6 +805,19 @@ mod tests {
         let dir = tempdir.path().join("proposed").join("ADR-0001");
         assert!(dir.join("adr.yaml").is_file());
         assert!(dir.join("body.md").is_file());
+        let allocation = store
+            .id_allocator
+            .adr_allocation(&adr.id)
+            .expect("allocation")
+            .expect("allocation exists");
+        assert_eq!(
+            allocation.worktree_root,
+            std::fs::canonicalize(tempdir.path()).expect("canonical tempdir")
+        );
+        assert_eq!(
+            allocation.body_path.as_deref(),
+            Some(std::path::Path::new("proposed/ADR-0001/body.md"))
+        );
 
         let loaded = store
             .get_adr("ADR-0001")

--- a/crates/orbit-store/src/file/learning_store/api/comment_ops_tests.rs
+++ b/crates/orbit-store/src/file/learning_store/api/comment_ops_tests.rs
@@ -21,7 +21,8 @@ fn learning_comments_round_trip_and_create_file_lazily() {
         .create_learning(create_params("target", vec![], vec![]))
         .expect("create");
     let comments_path = comments_jsonl_path(dir.path(), &learning.id);
-    assert!(!comments_path.exists());
+    assert!(comments_path.exists());
+    assert_eq!(line_count(&comments_path), 0);
 
     let now = Utc.with_ymd_and_hms(2026, 5, 17, 12, 0, 0).unwrap();
     let comment = store
@@ -31,6 +32,7 @@ fn learning_comments_round_trip_and_create_file_lazily() {
     assert_eq!(comment.id, "C20260517-1");
     assert_eq!(comment.body, "useful note");
     assert!(comments_path.exists());
+    assert_eq!(line_count(&comments_path), 1);
     let listed = store
         .list_learning_comments(&learning.id, false)
         .expect("list");
@@ -87,7 +89,7 @@ fn learning_comment_rejects_superseded_parent_before_append() {
     assert!(
         matches!(error, OrbitError::InvalidInput(message) if message.contains("orbit.learning.supersede"))
     );
-    assert!(!comments_jsonl_path(dir.path(), &old.id).exists());
+    assert_eq!(line_count(&comments_jsonl_path(dir.path(), &old.id)), 0);
 }
 
 #[test]

--- a/crates/orbit-store/src/file/learning_store/api/crud.rs
+++ b/crates/orbit-store/src/file/learning_store/api/crud.rs
@@ -7,10 +7,13 @@ use orbit_common::types::{
     normalize_learning_tags,
 };
 
-use super::super::layout::{learning_doc_path, locate_learning, validate_learning_id};
+use super::super::layout::{
+    comments_jsonl_path, learning_doc_path, locate_learning, validate_learning_id, votes_jsonl_path,
+};
 use super::super::record::{read_learning_file, write_learning_file};
 use super::store::LearningFileStore;
 use crate::backend::{LearningCreateParams, LearningUpdateParams};
+use crate::{IdAllocationRecord, LearningListEntry, RemoteArtifactStub};
 
 impl LearningFileStore {
     pub(crate) fn create_learning(
@@ -63,6 +66,9 @@ impl LearningFileStore {
 
         let path = learning_doc_path(&self.root, &id);
         write_learning_file(&path, &learning, LearningStatus::Active)?;
+        ensure_empty_sidecar(&votes_jsonl_path(&self.root, &id))?;
+        ensure_empty_sidecar(&comments_jsonl_path(&self.root, &id))?;
+        self.id_allocator.record_learning_body_path(&id, &path)?;
         self.upsert_index_row(&learning);
         self.invalidate_envelope_cache();
         Ok(learning)
@@ -74,6 +80,16 @@ impl LearningFileStore {
             return Ok(None);
         };
         Ok(Some(read_learning_file(&path)?))
+    }
+
+    pub(crate) fn get_learning_federated(&self, id: &str) -> Result<Option<Learning>, OrbitError> {
+        validate_learning_id(id)?;
+        if let Some(record) = self.id_allocator.learning_allocation(id)?
+            && let Some(learning) = self.read_learning_allocation(&record)?
+        {
+            return Ok(Some(learning));
+        }
+        self.get_learning(id)
     }
 
     pub(crate) fn list_learnings(
@@ -116,6 +132,43 @@ impl LearningFileStore {
                 .then_with(|| a.id.cmp(&b.id))
         });
         Ok(out)
+    }
+
+    pub(crate) fn list_learning_entries(
+        &self,
+        status: Option<LearningStatus>,
+        include_remote: bool,
+    ) -> Result<Vec<LearningListEntry>, OrbitError> {
+        let mut entries = Vec::new();
+        for record in self.id_allocator.learning_allocations()? {
+            if let Some(learning) = self.read_learning_allocation(&record)? {
+                if status.is_none_or(|expected| learning.status == expected) {
+                    entries.push(LearningListEntry::Local(learning));
+                }
+                continue;
+            }
+            if include_remote && status.is_none() {
+                entries.push(LearningListEntry::Remote(remote_stub_from_allocation(
+                    &record,
+                )));
+            }
+        }
+        entries.sort_by(|left, right| learning_entry_id(right).cmp(learning_entry_id(left)));
+        Ok(entries)
+    }
+
+    pub(crate) fn get_learning_remote_stub(
+        &self,
+        id: &str,
+    ) -> Result<Option<RemoteArtifactStub>, OrbitError> {
+        validate_learning_id(id)?;
+        let Some(record) = self.id_allocator.learning_allocation(id)? else {
+            return Ok(None);
+        };
+        if self.read_learning_allocation(&record)?.is_some() {
+            return Ok(None);
+        }
+        Ok(Some(remote_stub_from_allocation(&record)))
     }
 
     pub(crate) fn update_learning(
@@ -168,5 +221,48 @@ impl LearningFileStore {
         self.upsert_index_row(&learning);
         self.invalidate_envelope_cache();
         Ok(learning)
+    }
+
+    fn read_learning_allocation(
+        &self,
+        record: &IdAllocationRecord,
+    ) -> Result<Option<Learning>, OrbitError> {
+        let Some(path) = record.resolved_body_path() else {
+            return self.get_learning(&record.id);
+        };
+        if !path.is_file() {
+            return Ok(None);
+        }
+        Ok(Some(read_learning_file(&path)?))
+    }
+}
+
+fn ensure_empty_sidecar(path: &std::path::Path) -> Result<(), OrbitError> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).map_err(|error| OrbitError::Io(error.to_string()))?;
+    }
+    std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(path)
+        .map(|_| ())
+        .map_err(|error| OrbitError::Io(error.to_string()))
+}
+
+fn remote_stub_from_allocation(record: &IdAllocationRecord) -> RemoteArtifactStub {
+    RemoteArtifactStub {
+        id: record.id.clone(),
+        kind: record.kind.as_str().to_string(),
+        status: record.status.clone(),
+        worktree_root: record.worktree_root.clone(),
+        branch: record.branch.clone(),
+        body_path: record.body_path.clone(),
+    }
+}
+
+fn learning_entry_id(entry: &LearningListEntry) -> &str {
+    match entry {
+        LearningListEntry::Local(learning) => &learning.id,
+        LearningListEntry::Remote(stub) => &stub.id,
     }
 }

--- a/crates/orbit-store/src/file/learning_store/api/crud_tests.rs
+++ b/crates/orbit-store/src/file/learning_store/api/crud_tests.rs
@@ -33,6 +33,22 @@ fn round_trip_persistence_preserves_all_fields_including_phase_two_reservations(
             priority: None,
         };
         let learning = store.create_learning(params).expect("create");
+        let learning_dir = path_root.join(&learning.id);
+        assert!(learning_dir.join("votes.jsonl").is_file());
+        assert!(learning_dir.join("comments.jsonl").is_file());
+        let allocation = store
+            .id_allocator
+            .learning_allocation(&learning.id)
+            .expect("allocation")
+            .expect("allocation exists");
+        assert_eq!(
+            allocation.worktree_root,
+            std::fs::canonicalize(&path_root).expect("canonical learning root")
+        );
+        assert_eq!(
+            allocation.body_path.as_deref(),
+            Some(std::path::Path::new("L-0001/learning.yaml"))
+        );
         (learning.id.clone(), learning)
     };
 

--- a/crates/orbit-store/src/file/learning_store/api/vote_ops_tests.rs
+++ b/crates/orbit-store/src/file/learning_store/api/vote_ops_tests.rs
@@ -21,7 +21,11 @@ fn upvote_creates_lazy_votes_file_and_show_summary_reads_it() {
         .create_learning(create_params("vote target", vec![], vec![]))
         .expect("create");
     let votes_path = votes_jsonl_path(dir.path(), &learning.id);
-    assert!(!votes_path.exists(), "votes file should be lazy");
+    assert!(
+        votes_path.exists(),
+        "votes file is created with the learning"
+    );
+    assert_eq!(line_count(&votes_path), 0);
 
     let now = Utc.with_ymd_and_hms(2026, 5, 17, 12, 0, 0).unwrap();
     let summary = store
@@ -78,7 +82,7 @@ fn upvote_rejects_missing_task_missing_learning_and_superseded_learning() {
     assert!(
         matches!(error, OrbitError::InvalidInput(message) if message.contains("free-floating votes"))
     );
-    assert!(!votes_jsonl_path(dir.path(), &learning.id).exists());
+    assert_eq!(line_count(&votes_jsonl_path(dir.path(), &learning.id)), 0);
 
     let error = store
         .upvote_learning(upvote_params("L-0404", "claude", Some("ORB-1")))

--- a/crates/orbit-store/src/lib.rs
+++ b/crates/orbit-store/src/lib.rs
@@ -114,23 +114,23 @@ pub mod learning_layout {
 use chrono::{DateTime, Utc};
 
 pub use backend::{
-    ActiveTaskReservation, AdrCreateParams, AdrDocumentUpdateParams, AdrStoreBackend,
+    ActiveTaskReservation, AdrCreateParams, AdrDocumentUpdateParams, AdrListEntry, AdrStoreBackend,
     AuditEventStoreBackend, ExecutorDefStoreBackend, ExpiredTaskReservation, JobRunQuery,
     JobRunStepParams, JobRunStoreBackend, LearningCommentAddParams, LearningCommentDeleteParams,
-    LearningCreateParams, LearningSearchParams, LearningSearchResult, LearningStoreBackend,
-    LearningUpdateParams, LearningUpvoteParams, PolicyDefStoreBackend, ReleasedTaskReservation,
-    TaskArtifactStoreBackend, TaskArtifactUpdateParams, TaskCreateParams, TaskDocumentStoreBackend,
-    TaskDocumentUpdateParams, TaskHistoryStoreBackend, TaskHistoryUpdateParams, TaskLockConflict,
-    TaskLockHolder, TaskReservationCheckParams, TaskReservationCheckResult,
-    TaskReservationListResult, TaskReservationOwnedConflictsParams,
-    TaskReservationOwnedConflictsResult, TaskReservationReleaseByOwnerParams,
-    TaskReservationReleaseByOwnerResult, TaskReservationReleaseParams,
-    TaskReservationReleaseReason, TaskReservationReleaseResult, TaskReservationReserveParams,
-    TaskReservationReserveResult, TaskReservationStoreBackend, TaskReviewStoreBackend,
-    TaskReviewUpdateParams, TaskStoreBackend, ToolStoreBackend, WorkspaceTaskBackends,
-    audit_event_store_sqlite, global_executor_def_store, global_policy_def_store,
-    layered_policy_def_store, task_reservation_store_sqlite, tool_store_sqlite,
-    workspace_adr_backends, workspace_job_run_store, workspace_learning_backend,
+    LearningCreateParams, LearningListEntry, LearningSearchParams, LearningSearchResult,
+    LearningStoreBackend, LearningUpdateParams, LearningUpvoteParams, PolicyDefStoreBackend,
+    ReleasedTaskReservation, RemoteArtifactStub, TaskArtifactStoreBackend,
+    TaskArtifactUpdateParams, TaskCreateParams, TaskDocumentStoreBackend, TaskDocumentUpdateParams,
+    TaskHistoryStoreBackend, TaskHistoryUpdateParams, TaskLockConflict, TaskLockHolder,
+    TaskReservationCheckParams, TaskReservationCheckResult, TaskReservationListResult,
+    TaskReservationOwnedConflictsParams, TaskReservationOwnedConflictsResult,
+    TaskReservationReleaseByOwnerParams, TaskReservationReleaseByOwnerResult,
+    TaskReservationReleaseParams, TaskReservationReleaseReason, TaskReservationReleaseResult,
+    TaskReservationReserveParams, TaskReservationReserveResult, TaskReservationStoreBackend,
+    TaskReviewStoreBackend, TaskReviewUpdateParams, TaskStoreBackend, ToolStoreBackend,
+    WorkspaceTaskBackends, audit_event_store_sqlite, global_executor_def_store,
+    global_policy_def_store, layered_policy_def_store, task_reservation_store_sqlite,
+    tool_store_sqlite, workspace_adr_backends, workspace_job_run_store, workspace_learning_backend,
     workspace_policy_def_store, workspace_task_backends,
 };
 pub use invocation_store_impl::{
@@ -144,8 +144,8 @@ pub use sqlite::audit_event_store::{
 };
 pub use sqlite::connection::{Store, StoreTx};
 pub use sqlite::id_allocator::{
-    IdAllocation, IdAllocationKind, IdAllocator, IdAllocatorConfig, LearningIdMigrationReport,
-    LearningIdRename, ensure_id_allocation_schema,
+    IdAllocation, IdAllocationKind, IdAllocationRecord, IdAllocator, IdAllocatorConfig,
+    LearningIdMigrationReport, LearningIdRename, ensure_id_allocation_schema,
 };
 
 pub(crate) fn parse_timestamp(raw: &str) -> rusqlite::Result<DateTime<Utc>> {

--- a/crates/orbit-store/src/sqlite/id_allocator.rs
+++ b/crates/orbit-store/src/sqlite/id_allocator.rs
@@ -8,7 +8,7 @@ use fs2::FileExt;
 use orbit_common::types::OrbitError;
 use orbit_common::utility::fs::atomic_write_text;
 use orbit_common::utility::git::{CurrentBranchStatus, current_branch};
-use rusqlite::{Connection, Transaction, TransactionBehavior, params};
+use rusqlite::{Connection, Transaction, TransactionBehavior, params, types::Type};
 use serde::{Deserialize, Serialize};
 use serde_yaml::{Mapping, Value};
 
@@ -38,6 +38,29 @@ pub struct IdAllocation {
     pub kind: IdAllocationKind,
     pub id: String,
     pub worktree_root: PathBuf,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct IdAllocationRecord {
+    pub kind: IdAllocationKind,
+    pub id: String,
+    pub allocated_at: i64,
+    pub worktree_root: PathBuf,
+    pub branch: Option<String>,
+    pub status: String,
+    pub body_path: Option<PathBuf>,
+}
+
+impl IdAllocationRecord {
+    pub fn resolved_body_path(&self) -> Option<PathBuf> {
+        self.body_path.as_ref().map(|body_path| {
+            if body_path.is_absolute() {
+                body_path.clone()
+            } else {
+                self.worktree_root.join(body_path)
+            }
+        })
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -163,6 +186,30 @@ impl IdAllocator {
         self.allocate(IdAllocationKind::Learning)
     }
 
+    pub fn record_adr_body_path(&self, id: &str, body_path: &Path) -> Result<(), OrbitError> {
+        self.record_body_path(IdAllocationKind::Adr, id, body_path)
+    }
+
+    pub fn record_learning_body_path(&self, id: &str, body_path: &Path) -> Result<(), OrbitError> {
+        self.record_body_path(IdAllocationKind::Learning, id, body_path)
+    }
+
+    pub fn adr_allocation(&self, id: &str) -> Result<Option<IdAllocationRecord>, OrbitError> {
+        self.allocation(IdAllocationKind::Adr, id)
+    }
+
+    pub fn learning_allocation(&self, id: &str) -> Result<Option<IdAllocationRecord>, OrbitError> {
+        self.allocation(IdAllocationKind::Learning, id)
+    }
+
+    pub fn adr_allocations(&self) -> Result<Vec<IdAllocationRecord>, OrbitError> {
+        self.allocations(IdAllocationKind::Adr)
+    }
+
+    pub fn learning_allocations(&self) -> Result<Vec<IdAllocationRecord>, OrbitError> {
+        self.allocations(IdAllocationKind::Learning)
+    }
+
     pub fn migrate_learning_ids(&self) -> Result<LearningIdMigrationReport, OrbitError> {
         let _lock = self.acquire_lock()?;
         let mut conn = self.lock_conn()?;
@@ -191,6 +238,7 @@ impl IdAllocator {
             &self.inner.worktree_root,
             best_effort_branch(&self.inner.worktree_root),
             STATUS_RESERVED,
+            None,
             false,
         )?;
         tx.commit()
@@ -230,6 +278,7 @@ impl IdAllocator {
                 }
                 let allocated_at =
                     yaml_epoch(&child.join("adr.yaml")).unwrap_or_else(|_| now_epoch());
+                let body_path = relative_to(&child.join("body.md"), &self.inner.shared_root);
                 insert_allocation(
                     tx,
                     IdAllocationKind::Adr,
@@ -238,7 +287,16 @@ impl IdAllocator {
                     &self.inner.shared_root,
                     None,
                     STATUS_MERGED,
+                    Some(&body_path),
                     true,
+                )?;
+                update_body_metadata_if_missing(
+                    tx,
+                    IdAllocationKind::Adr,
+                    id,
+                    &self.inner.shared_root,
+                    None,
+                    &body_path,
                 )?;
             }
         }
@@ -258,6 +316,7 @@ impl IdAllocator {
             }
             let allocated_at =
                 yaml_epoch(&child.join("learning.yaml")).unwrap_or_else(|_| now_epoch());
+            let body_path = relative_to(&child.join("learning.yaml"), &self.inner.shared_root);
             insert_allocation(
                 tx,
                 IdAllocationKind::Learning,
@@ -266,7 +325,16 @@ impl IdAllocator {
                 &self.inner.shared_root,
                 None,
                 STATUS_MERGED,
+                Some(&body_path),
                 true,
+            )?;
+            update_body_metadata_if_missing(
+                tx,
+                IdAllocationKind::Learning,
+                id,
+                &self.inner.shared_root,
+                None,
+                &body_path,
             )?;
         }
         Ok(())
@@ -349,11 +417,97 @@ impl IdAllocator {
                 &self.inner.shared_root,
                 None,
                 STATUS_MERGED,
+                Some(&relative_to(
+                    &new_dir.join("learning.yaml"),
+                    &self.inner.shared_root,
+                )),
                 true,
             )?;
         }
 
         Ok(LearningIdMigrationReport { renames })
+    }
+
+    fn record_body_path(
+        &self,
+        kind: IdAllocationKind,
+        id: &str,
+        body_path: &Path,
+    ) -> Result<(), OrbitError> {
+        let relative_body_path = relative_to(body_path, &self.inner.worktree_root);
+        let branch = best_effort_branch(&self.inner.worktree_root);
+        let _lock = self.acquire_lock()?;
+        let mut conn = self.lock_conn()?;
+        let tx = conn
+            .transaction_with_behavior(TransactionBehavior::Immediate)
+            .map_err(|error| OrbitError::Store(error.to_string()))?;
+        let updated = tx
+            .execute(
+                "UPDATE id_allocations
+                 SET worktree_root = ?3, branch = ?4, body_path = ?5
+                 WHERE kind = ?1 AND id = ?2",
+                params![
+                    kind.as_str(),
+                    id,
+                    self.inner.worktree_root.to_string_lossy(),
+                    branch,
+                    relative_body_path.to_string_lossy(),
+                ],
+            )
+            .map_err(|error| OrbitError::Store(error.to_string()))?;
+        if updated == 0 {
+            return Err(OrbitError::Store(format!(
+                "id allocation row missing for {} {id}",
+                kind.as_str()
+            )));
+        }
+        tx.commit()
+            .map_err(|error| OrbitError::Store(error.to_string()))?;
+        Ok(())
+    }
+
+    fn allocation(
+        &self,
+        kind: IdAllocationKind,
+        id: &str,
+    ) -> Result<Option<IdAllocationRecord>, OrbitError> {
+        let conn = self.lock_conn()?;
+        let mut stmt = conn
+            .prepare(
+                "SELECT kind, id, allocated_at, worktree_root, branch, status, body_path
+                 FROM id_allocations
+                 WHERE kind = ?1 AND id = ?2",
+            )
+            .map_err(|error| OrbitError::Store(error.to_string()))?;
+        let mut rows = stmt
+            .query_map(params![kind.as_str(), id], allocation_record_from_row)
+            .map_err(|error| OrbitError::Store(error.to_string()))?;
+        match rows.next() {
+            Some(row) => row
+                .map(Some)
+                .map_err(|error| OrbitError::Store(error.to_string())),
+            None => Ok(None),
+        }
+    }
+
+    fn allocations(&self, kind: IdAllocationKind) -> Result<Vec<IdAllocationRecord>, OrbitError> {
+        let conn = self.lock_conn()?;
+        let mut stmt = conn
+            .prepare(
+                "SELECT kind, id, allocated_at, worktree_root, branch, status, body_path
+                 FROM id_allocations
+                 WHERE kind = ?1
+                 ORDER BY id DESC",
+            )
+            .map_err(|error| OrbitError::Store(error.to_string()))?;
+        let rows = stmt
+            .query_map([kind.as_str()], allocation_record_from_row)
+            .map_err(|error| OrbitError::Store(error.to_string()))?;
+        let mut records = Vec::new();
+        for row in rows {
+            records.push(row.map_err(|error| OrbitError::Store(error.to_string()))?);
+        }
+        Ok(records)
     }
 
     fn acquire_lock(&self) -> Result<File, OrbitError> {
@@ -398,6 +552,7 @@ pub fn ensure_id_allocation_schema(conn: &Connection) -> Result<(), OrbitError> 
                 worktree_root TEXT NOT NULL,
                 branch TEXT,
                 status TEXT NOT NULL,
+                body_path TEXT,
                 PRIMARY KEY (kind, id),
                 CHECK (kind IN ('adr', 'learning')),
                 CHECK (status IN ('reserved', 'merged', 'abandoned'))
@@ -410,7 +565,9 @@ pub fn ensure_id_allocation_schema(conn: &Connection) -> Result<(), OrbitError> 
             ON id_allocations(allocated_at);
         "#,
     )
-    .map_err(|error| OrbitError::Store(error.to_string()))
+    .map_err(|error| OrbitError::Store(error.to_string()))?;
+    add_column_if_missing(conn, "id_allocations", "body_path", "TEXT")?;
+    Ok(())
 }
 
 fn next_id_for_kind(tx: &Transaction<'_>, kind: IdAllocationKind) -> Result<String, OrbitError> {
@@ -454,6 +611,7 @@ fn insert_allocation(
     worktree_root: &Path,
     branch: Option<String>,
     status: &str,
+    body_path: Option<&Path>,
     ignore_existing: bool,
 ) -> Result<(), OrbitError> {
     let verb = if ignore_existing {
@@ -462,8 +620,8 @@ fn insert_allocation(
         "INSERT"
     };
     let sql = format!(
-        "{verb} INTO id_allocations(kind, id, allocated_at, worktree_root, branch, status) \
-         VALUES (?1, ?2, ?3, ?4, ?5, ?6)"
+        "{verb} INTO id_allocations(kind, id, allocated_at, worktree_root, branch, status, body_path) \
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)"
     );
     tx.execute(
         &sql,
@@ -474,10 +632,85 @@ fn insert_allocation(
             worktree_root.to_string_lossy(),
             branch,
             status,
+            body_path.map(|path| path.to_string_lossy().into_owned()),
         ],
     )
     .map_err(|error| OrbitError::Store(error.to_string()))?;
     Ok(())
+}
+
+fn update_body_metadata_if_missing(
+    tx: &Transaction<'_>,
+    kind: IdAllocationKind,
+    id: &str,
+    worktree_root: &Path,
+    branch: Option<String>,
+    body_path: &Path,
+) -> Result<(), OrbitError> {
+    tx.execute(
+        "UPDATE id_allocations
+         SET worktree_root = ?3, branch = COALESCE(branch, ?4), body_path = ?5
+         WHERE kind = ?1 AND id = ?2 AND (body_path IS NULL OR body_path = '')",
+        params![
+            kind.as_str(),
+            id,
+            worktree_root.to_string_lossy(),
+            branch,
+            body_path.to_string_lossy(),
+        ],
+    )
+    .map_err(|error| OrbitError::Store(error.to_string()))?;
+    Ok(())
+}
+
+fn add_column_if_missing(
+    conn: &Connection,
+    table: &str,
+    column: &str,
+    column_type: &str,
+) -> Result<(), OrbitError> {
+    let mut stmt = conn
+        .prepare(&format!("PRAGMA table_info({table})"))
+        .map_err(|error| OrbitError::Store(error.to_string()))?;
+    let rows = stmt
+        .query_map([], |row| row.get::<_, String>(1))
+        .map_err(|error| OrbitError::Store(error.to_string()))?;
+    for row in rows {
+        if row.map_err(|error| OrbitError::Store(error.to_string()))? == column {
+            return Ok(());
+        }
+    }
+    conn.execute(
+        &format!("ALTER TABLE {table} ADD COLUMN {column} {column_type}"),
+        [],
+    )
+    .map_err(|error| OrbitError::Store(error.to_string()))?;
+    Ok(())
+}
+
+fn allocation_record_from_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<IdAllocationRecord> {
+    let kind_raw: String = row.get(0)?;
+    let kind = match kind_raw.as_str() {
+        KIND_ADR => IdAllocationKind::Adr,
+        KIND_LEARNING => IdAllocationKind::Learning,
+        _ => {
+            return Err(rusqlite::Error::InvalidColumnType(
+                0,
+                "kind".to_string(),
+                Type::Text,
+            ));
+        }
+    };
+    let body_path: Option<String> = row.get(6)?;
+    Ok(IdAllocationRecord {
+        kind,
+        id: row.get(1)?,
+        allocated_at: row.get(2)?,
+        worktree_root: PathBuf::from(row.get::<_, String>(3)?),
+        branch: row.get(4)?,
+        status: row.get(5)?,
+        body_path: body_path.map(PathBuf::from),
+    })
 }
 
 pub fn parse_adr_sequence(id: &str) -> Option<u32> {
@@ -632,6 +865,14 @@ fn absolutize(path: PathBuf) -> PathBuf {
     fs::canonicalize(&path).unwrap_or(path)
 }
 
+fn relative_to(path: &Path, root: &Path) -> PathBuf {
+    let path = absolutize(path.to_path_buf());
+    let root = absolutize(root.to_path_buf());
+    path.strip_prefix(&root)
+        .map(Path::to_path_buf)
+        .unwrap_or(path)
+}
+
 fn enable_best_effort_wal_mode(conn: &Connection) {
     match conn.pragma_update_and_check(None, "journal_mode", "WAL", |row| row.get::<_, String>(0)) {
         Ok(mode) if mode.eq_ignore_ascii_case("wal") => {}
@@ -680,6 +921,28 @@ mod tests {
             )
             .expect("table exists");
         assert_eq!(exists, 1);
+        assert!(id_allocations_has_column(&conn, "body_path"));
+    }
+
+    #[test]
+    fn schema_adds_body_path_to_existing_id_allocations_table() {
+        let conn = Connection::open_in_memory().expect("open db");
+        conn.execute_batch(
+            "CREATE TABLE id_allocations (
+                kind TEXT NOT NULL,
+                id TEXT NOT NULL,
+                allocated_at INTEGER NOT NULL,
+                worktree_root TEXT NOT NULL,
+                branch TEXT,
+                status TEXT NOT NULL,
+                PRIMARY KEY (kind, id)
+            );",
+        )
+        .expect("legacy allocation table");
+
+        ensure_id_allocation_schema(&conn).expect("schema");
+
+        assert!(id_allocations_has_column(&conn, "body_path"));
     }
 
     #[test]
@@ -898,6 +1161,18 @@ mod tests {
         let conn = Connection::open(db_path).expect("open db");
         conn.query_row("SELECT COUNT(*) FROM id_allocations", [], |row| row.get(0))
             .expect("count")
+    }
+
+    fn id_allocations_has_column(conn: &Connection, column: &str) -> bool {
+        let mut stmt = conn
+            .prepare("PRAGMA table_info(id_allocations)")
+            .expect("table info");
+        let rows = stmt
+            .query_map([], |row| row.get::<_, String>(1))
+            .expect("query columns");
+        rows.into_iter()
+            .map(|row| row.expect("column"))
+            .any(|name| name == column)
     }
 
     fn write_legacy_learning(

--- a/crates/orbit-tools/src/builtin/orbit/adr/list.rs
+++ b/crates/orbit-tools/src/builtin/orbit/adr/list.rs
@@ -52,6 +52,14 @@ impl Tool for OrbitAdrListTool {
                 param_type: "boolean".to_string(),
                 required: false,
             },
+            ToolParam {
+                name: "include_remote".to_string(),
+                description:
+                    "Include allocation rows whose body files are not locally readable as remote stubs."
+                        .to_string(),
+                param_type: "boolean".to_string(),
+                required: false,
+            },
         ];
         ToolSchema {
             name: "orbit.adr.list".to_string(),

--- a/crates/orbit-tools/src/builtin/orbit/learning/list.rs
+++ b/crates/orbit-tools/src/builtin/orbit/learning/list.rs
@@ -28,6 +28,14 @@ impl Tool for OrbitLearningListTool {
                 param_type: "string".to_string(),
                 required: false,
             },
+            ToolParam {
+                name: "include_remote".to_string(),
+                description:
+                    "Include allocation rows whose body files are not locally readable as remote stubs."
+                        .to_string(),
+                param_type: "boolean".to_string(),
+                required: false,
+            },
         ];
         ToolSchema {
             name: "orbit.learning.list".to_string(),

--- a/docs/design/CONVENTIONS.md
+++ b/docs/design/CONVENTIONS.md
@@ -1,7 +1,7 @@
 ---
 title: Design Doc Conventions
 owner: daniel
-last_updated: 2026-05-18
+last_updated: 2026-05-20
 status: Accepted
 ---
 
@@ -239,5 +239,6 @@ Until those exist: cross-review and author judgment are the quality mechanism. W
 | Task Lineage | [docs/design/task-lineage/](./task-lineage/) | claude |
 | Task Sync | [docs/design/task-sync/](./task-sync/) | claude |
 | User Interface | [docs/design/user-interface/](./user-interface/) | gemini |
+| Worktree Artifacts | [docs/design/worktree-artifacts/](./worktree-artifacts/) | codex |
 
 Ownership means: the lead is accountable for keeping the folder's docs in sync with implementation, for flipping ADR status when tasks ship, and for responding to cross-review comments. Ownership does not preclude other agents from editing — it names who's on the hook when things drift.

--- a/docs/design/worktree-artifacts/1_overview.md
+++ b/docs/design/worktree-artifacts/1_overview.md
@@ -1,0 +1,57 @@
+---
+summary: "Worktree Artifacts - Overview"
+type: design
+title: "Worktree Artifacts - Overview"
+owner: codex
+last_updated: 2026-05-20
+status: Accepted
+feature: worktree-artifacts
+doc_role: overview
+tags: ["worktree-artifacts"]
+paths: ["crates/orbit-core/**", "crates/orbit-store/**", "crates/orbit-cli/**"]
+related_features: ["worktree-artifacts"]
+related_artifacts: ["ORB-00199", "ORB-00200", "ORB-00201", "ADR-0177"]
+---
+
+# Worktree Artifacts - Overview
+
+Worktree artifacts let ADR and learning body files travel with the branch that created them while preserving one shared ID authority for the whole repository. Tasks, audit, scoreboards, and allocator state stay in the shared `.orbit/`; ADR and learning bodies live in the current worktree's `.orbit/`.
+
+## 1. Motivation
+
+Linked git worktrees let agents work on several branches at once, but the old single-root artifact model wrote every ADR and learning body into the main checkout. That made a branch's code change and its knowledge artifacts land in different working trees, so agents could not stage the full change together.
+
+The three-task sequence split this apart:
+
+- [ORB-00199] exposed `shared_root` and `local_root`.
+- [ORB-00200] moved ADR and learning ID allocation into a shared SQLite allocator and migrated learnings to `L-NNNN`.
+- [ORB-00201] writes ADR and learning bodies into `local_root` and reads them through allocation metadata.
+
+## 2. Core Concepts
+
+| Concept | Meaning |
+|---------|---------|
+| Shared root | The main checkout `.orbit/`, used for tasks, audit, scoreboards, semantic.db, and allocation authority. |
+| Local root | The current worktree `.orbit/`, used for ADR and learning body files. |
+| Allocation row | A row in `id_allocations` recording ID, kind, allocation status, recorded worktree, branch, and `body_path`. |
+| Local-readable artifact | An allocation whose recorded body path exists and can be read by the current process. |
+| Remote stub | A list row for an allocation whose body is not locally readable, shown only with `include_remote`. |
+
+## 3. At a Glance
+
+| Concern | File | Task |
+|---------|------|------|
+| Root split | `crates/orbit-core/src/runtime/resolve.rs` | [ORB-00199] |
+| Allocator and body metadata | `crates/orbit-store/src/sqlite/id_allocator.rs` | [ORB-00200], [ORB-00201] |
+| ADR body storage and federation | `crates/orbit-store/src/file/adr_store/api.rs` | [ORB-00201] |
+| Learning body storage and federation | `crates/orbit-store/src/file/learning_store/api/crud.rs` | [ORB-00201] |
+| CLI/tool remote listing | `crates/orbit-core/src/runtime/orbit_tool_host/` and `crates/orbit-cli/src/command/learning/` | [ORB-00201] |
+| Decision log | `docs/design/worktree-artifacts/4_decisions.md` | [ADR-0177] |
+
+## Task References
+
+- [ORB-00199] split Orbit runtime resolution into shared and local roots.
+- [ORB-00200] introduced the global ADR/Learning allocator and `L-NNNN` learning IDs.
+- [ORB-00201] moved ADR/Learning body writes to the current worktree and added read federation.
+
+Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.

--- a/docs/design/worktree-artifacts/2_design.md
+++ b/docs/design/worktree-artifacts/2_design.md
@@ -1,0 +1,64 @@
+---
+summary: "Worktree Artifacts - Design"
+type: design
+title: "Worktree Artifacts - Design"
+owner: codex
+last_updated: 2026-05-20
+status: Accepted
+feature: worktree-artifacts
+doc_role: design
+tags: ["worktree-artifacts"]
+paths: ["crates/orbit-core/**", "crates/orbit-store/**", "crates/orbit-cli/**"]
+related_features: ["worktree-artifacts"]
+related_artifacts: ["ORB-00199", "ORB-00200", "ORB-00201", "ADR-0177"]
+---
+
+# Worktree Artifacts - Design
+
+The current implementation treats ADR and learning bodies as branch-local files with globally allocated IDs. The shared root owns durable coordination state; the local root owns files that should be staged with the branch.
+
+## 1. Runtime Roots
+
+`OrbitRuntime` carries `shared_root` and `local_root`. On the main checkout they are equal. In a linked worktree, `shared_root` points to the main checkout `.orbit/`, and `local_root` points to the linked worktree `.orbit/`.
+
+Explicit `--root` and `ORBIT_ROOT` overrides pin both roots to preserve the old single-root mental model when the operator asks for it.
+
+## 2. Allocation Metadata
+
+`id_allocations` lives in `shared_root/.orbit/state/semantic.db`. The allocator serializes ID creation with a shared lock, then body writes update the row with:
+
+- `worktree_root`: the recorded worktree root for the body.
+- `branch`: best-effort current branch.
+- `body_path`: the body file path relative to `worktree_root`.
+
+Backfilled shared-root artifacts receive `body_path` during allocator initialization so old ADRs and migrated learnings remain readable from any worktree.
+
+## 3. Write Path
+
+ADR creation writes `adr.yaml` and `body.md` under `local_root/adrs/proposed/ADR-NNNN/`. Learning creation writes `learning.yaml`, `votes.jsonl`, and `comments.jsonl` under `local_root/learnings/L-NNNN/`.
+
+The first write into a linked worktree creates only the subtree needed for the artifact type. It does not scaffold local `state/`, `audit/`, `tasks/`, scoreboards, or registry files.
+
+## 4. Read Federation
+
+List and show paths consult allocation metadata to resolve body files. If the recorded body path is readable, the store returns the full artifact from that path. If the body is missing or unreadable, default list output omits the row. `include_remote` includes a stub with ID, kind, allocation status, recorded worktree, branch, and body path.
+
+`show` does not return a stub. A remote-only artifact is an error naming the recorded worktree and branch so the operator knows which worktree owns the body.
+
+## 5. Indexing Behavior
+
+Learning reindex and docs/ADR search operate on locally readable bodies. Remote-only allocation rows are skipped without error; once the recorded worktree is present and readable again, the same list/reindex path can read and index the body.
+
+## 6. Concerns & Honest Limitations
+
+Remote stubs are intentionally envelope-poor. They expose allocation metadata, not the artifact title, summary, or body, because those fields live in the unreadable body file. Filters that require body fields can only apply to locally readable artifacts.
+
+The `worktree_root` column preserves historical rows from earlier phases, so old shared-root rows may record a `.orbit/` path while new rows record a worktree root. Readers resolve `body_path` relative to the recorded value instead of normalizing that history away.
+
+## Task References
+
+- [ORB-00199] introduced the runtime root split.
+- [ORB-00200] introduced allocation metadata and the learning ID migration.
+- [ORB-00201] implemented local body writes and read federation.
+
+Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.

--- a/docs/design/worktree-artifacts/3_vision.md
+++ b/docs/design/worktree-artifacts/3_vision.md
@@ -1,0 +1,59 @@
+---
+summary: "Worktree Artifacts - Vision"
+type: design
+title: "Worktree Artifacts - Vision"
+owner: codex
+last_updated: 2026-05-20
+status: Accepted
+feature: worktree-artifacts
+doc_role: vision
+tags: ["worktree-artifacts"]
+paths: ["crates/orbit-core/**", "crates/orbit-store/**", "crates/orbit-cli/**"]
+related_features: ["worktree-artifacts"]
+related_artifacts: ["ORB-00199", "ORB-00200", "ORB-00201", "ADR-0177"]
+---
+
+# Worktree Artifacts - Vision
+
+The worktree artifact model should make knowledge artifacts feel like ordinary branch files without weakening Orbit's shared coordination state.
+
+## 1. Open Questions
+
+1. Should remote stubs grow an optional cached envelope so `include_remote` can show titles and summaries without reading body files?
+2. Should Orbit offer a repair command for stale `body_path` rows after users move or delete linked worktrees manually?
+3. Should ADR and learning updates refuse to mutate bodies outside the current worktree, or offer an explicit remote-edit mode?
+4. Should sync/hosted modes replace local filesystem body paths with content-addressed blobs?
+
+## 2. Prior Work
+
+### Runtime Roots
+
+[ORB-00199] established the root split that this design depends on. The important precedent is that existing shared state stays bound to `shared_root` unless a task deliberately flips it.
+
+### Allocation
+
+[ORB-00200] established SQLite as the ID authority and moved learning IDs to `L-NNNN`. That made per-worktree body storage possible without filesystem-scan collisions.
+
+### Artifact Discipline
+
+The ADR and learning skills already require tool-mediated writes instead of direct YAML edits. [ORB-00201] changes where those tool-mediated writes land, not the authorship rule.
+
+## 3. What May Be Distinctive
+
+The model separates artifact identity from artifact body locality. IDs and allocation rows are global enough for cross-worktree references; bodies stay branch-local enough for normal git staging and review.
+
+The remote-stub behavior also gives agents a gentle failure mode: they can see that an artifact exists without pretending to know its unreadable content.
+
+## 4. References
+
+- [1_overview.md](./1_overview.md) summarizes the root and artifact split.
+- [2_design.md](./2_design.md) describes the implemented read/write paths.
+- [4_decisions.md](./4_decisions.md) records the accepted architectural choice.
+
+## Task References
+
+- [ORB-00199] introduced shared/local root resolution.
+- [ORB-00200] introduced shared ID allocation and `L-NNNN`.
+- [ORB-00201] implemented local artifact bodies and federation.
+
+Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.

--- a/docs/design/worktree-artifacts/4_decisions.md
+++ b/docs/design/worktree-artifacts/4_decisions.md
@@ -1,0 +1,40 @@
+---
+summary: "Worktree Artifacts - Decisions"
+type: design
+title: "Worktree Artifacts - Decisions"
+owner: codex
+last_updated: 2026-05-20
+status: Accepted
+feature: worktree-artifacts
+doc_role: decisions
+tags: ["worktree-artifacts"]
+paths: ["crates/orbit-core/**", "crates/orbit-store/**", "crates/orbit-cli/**"]
+related_features: ["worktree-artifacts"]
+related_artifacts: ["ORB-00199", "ORB-00200", "ORB-00201", "ADR-0177"]
+---
+
+# Worktree Artifacts - Decisions
+
+ADR-style log for worktree artifact storage. Entries use globally allocated ADR IDs; the corresponding `.orbit/adrs/...` artifact is the source of truth for lifecycle metadata.
+
+## ADR-0177 - Worktree-local ADR and learning bodies with shared ID allocation
+
+**Status:** Accepted - 2026-05 - [ORB-00201]
+
+**Context.** Linked worktrees need ADR and learning bodies committed with the code branch that created them, but IDs must remain collision-free across all worktrees. [ORB-00199] introduced shared/local root resolution and [ORB-00200] introduced the shared SQLite allocator. The remaining choice was whether body files follow the allocator into `shared_root` or follow the editing branch into `local_root`.
+
+**Decision.** Write ADR and learning body files under the current worktree `local_root` while keeping ID allocation, migration, and allocation metadata in `shared_root/.orbit/state/semantic.db`. Lists read through `id_allocations`: default output includes only locally readable bodies, while `include_remote` returns stubs that name the recorded worktree and branch.
+
+**Consequences.**
+- ADR and learning files can be staged in the same PR as the implementation that created them.
+- Shared ID allocation still prevents cross-worktree collisions and records where each body lives.
+- Readers get predictable defaults without failing on missing sibling-worktree files.
+- Cost: list/show paths now carry a federation boundary and must handle `body_path` metadata, remote stubs, and stale worktree paths.
+
+## Task References
+
+- [ORB-00199] introduced shared/local root resolution.
+- [ORB-00200] introduced shared ID allocation and `L-NNNN`.
+- [ORB-00201] implemented this decision.
+
+Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.


### PR DESCRIPTION
## Summary

- Write ADR and learning body files into the invoking worktree local `.orbit/` tree while keeping global ID allocation in shared `semantic.db`.
- Add allocation `body_path` metadata plus federated ADR/Learning list/show behavior, including `--include-remote` stubs and remote-only show errors.
- Update learning sidecar creation, public tool schemas, CLI output, Orbit skills, architecture/design docs, and add accepted ADR-0177 under `docs/design/worktree-artifacts/`.

## Notes

- `orbit-adr` and `orbit-learning` skill assets now describe staging new artifacts from the current worktree and the learning `L-NNNN` ID format.
- Reviewed `CLAUDE.md`; it did not contain a single-root ADR/Learning storage assumption that needed editing. `ARCHITECTURE.md` now calls out the shared allocator plus worktree-local body split.
- ORB-00199 and ORB-00200 were confirmed done before moving ORB-00201 to review.

## Validation

- `cargo check -p orbit-store -p orbit-core -p orbit-tools -p orbit-cli`
- `cargo test -p orbit-store`
- `cargo test -p orbit-core`
- `cargo test -p orbit-tools`
- `cargo test -p orbit-cli --test worktree_resolution`
- `cargo test -p orbit-cli --test learning`
- `make ci-fast`
- `git diff --check`
