### PR TITLE
[codex] [ORB-00203] Add ADR tags and paths

### DIFF
--- a/.orbit/adrs/accepted/ADR-0001/adr.yaml
+++ b/.orbit/adrs/accepted/ADR-0001/adr.yaml
@@ -1,4 +1,4 @@
-schema_version: 1
+schema_version: 2
 id: ADR-0001
 title: Canonical v2 assets normalize into one execution contract
 status: accepted
@@ -19,6 +19,8 @@ related_tasks:
 - T20260426-0047
 - T20260428-8
 - T20260506-18
+tags: []
+paths: []
 supersedes: []
 legacy_ids:
 - activity-job/ADR-001

--- a/.orbit/adrs/accepted/ADR-0002/adr.yaml
+++ b/.orbit/adrs/accepted/ADR-0002/adr.yaml
@@ -1,4 +1,4 @@
-schema_version: 1
+schema_version: 2
 id: ADR-0002
 title: Host boundaries and agent dispatch stay explicit
 status: accepted
@@ -24,6 +24,8 @@ related_tasks:
 - T20260506-17
 - T20260505-22
 - T20260506-18
+tags: []
+paths: []
 supersedes: []
 legacy_ids:
 - activity-job/ADR-002

--- a/.orbit/adrs/accepted/ADR-0003/adr.yaml
+++ b/.orbit/adrs/accepted/ADR-0003/adr.yaml
@@ -1,4 +1,4 @@
-schema_version: 1
+schema_version: 2
 id: ADR-0003
 title: Run state, audit, and operator inspection are durable layers
 status: accepted
@@ -23,6 +23,8 @@ related_tasks:
 - T20260430-31
 - T20260505-8
 - T20260506-18
+tags: []
+paths: []
 supersedes: []
 legacy_ids:
 - activity-job/ADR-007

--- a/.orbit/adrs/accepted/ADR-0004/adr.yaml
+++ b/.orbit/adrs/accepted/ADR-0004/adr.yaml
@@ -1,4 +1,4 @@
-schema_version: 1
+schema_version: 2
 id: ADR-0004
 title: Seeded task-shipment workflows are deterministic, recoverable, and lock-aware
 status: accepted
@@ -25,6 +25,8 @@ related_tasks:
 - T20260505-10
 - T20260506-18
 - T20260509-14
+tags: []
+paths: []
 supersedes: []
 legacy_ids:
 - activity-job/ADR-023

--- a/.orbit/adrs/accepted/ADR-0005/adr.yaml
+++ b/.orbit/adrs/accepted/ADR-0005/adr.yaml
@@ -1,4 +1,4 @@
-schema_version: 1
+schema_version: 2
 id: ADR-0005
 title: One-task PR bodies start with the task contract
 status: accepted
@@ -10,6 +10,8 @@ related_features:
 - activity-job
 related_tasks:
 - T20260508-3
+tags: []
+paths: []
 supersedes: []
 legacy_ids:
 - activity-job/ADR-042

--- a/.orbit/adrs/accepted/ADR-0006/adr.yaml
+++ b/.orbit/adrs/accepted/ADR-0006/adr.yaml
@@ -1,4 +1,4 @@
-schema_version: 1
+schema_version: 2
 id: ADR-0006
 title: Epic review status is a shipped stop state
 status: accepted
@@ -10,6 +10,8 @@ related_features:
 - activity-job
 related_tasks:
 - T20260427-38
+tags: []
+paths: []
 supersedes: []
 legacy_ids:
 - activity-job/ADR-043

--- a/.orbit/adrs/accepted/ADR-0007/adr.yaml
+++ b/.orbit/adrs/accepted/ADR-0007/adr.yaml
@@ -1,4 +1,4 @@
-schema_version: 1
+schema_version: 2
 id: ADR-0007
 title: Epic orchestrator does not block on child runs
 status: accepted
@@ -10,6 +10,8 @@ related_features:
 - activity-job
 related_tasks:
 - T20260427-40
+tags: []
+paths: []
 supersedes: []
 legacy_ids:
 - activity-job/ADR-044

--- a/.orbit/adrs/accepted/ADR-0008/adr.yaml
+++ b/.orbit/adrs/accepted/ADR-0008/adr.yaml
@@ -1,4 +1,4 @@
-schema_version: 1
+schema_version: 2
 id: ADR-0008
 title: CLI subprocess cwd is runtime-owned workspace state
 status: accepted
@@ -10,6 +10,8 @@ related_features:
 - activity-job
 related_tasks:
 - T20260508-8
+tags: []
+paths: []
 supersedes: []
 legacy_ids:
 - activity-job/ADR-045

--- a/.orbit/adrs/accepted/ADR-0009/adr.yaml
+++ b/.orbit/adrs/accepted/ADR-0009/adr.yaml
@@ -1,4 +1,4 @@
-schema_version: 1
+schema_version: 2
 id: ADR-0009
 title: Job executor internals split by execution responsibility
 status: accepted
@@ -10,6 +10,8 @@ related_features:
 - activity-job
 related_tasks:
 - T20260509-2
+tags: []
+paths: []
 supersedes: []
 legacy_ids:
 - activity-job/ADR-046

--- a/.orbit/adrs/accepted/ADR-0010/adr.yaml
+++ b/.orbit/adrs/accepted/ADR-0010/adr.yaml
@@ -1,4 +1,4 @@
-schema_version: 1
+schema_version: 2
 id: ADR-0010
 title: Auto-populate `task.context_files` from the winning duel plan
 status: accepted
@@ -10,6 +10,8 @@ related_features:
 - activity-job
 related_tasks:
 - T20260509-9
+tags: []
+paths: []
 supersedes: []
 legacy_ids:
 - activity-job/ADR-048

--- a/.orbit/adrs/accepted/ADR-0011/adr.yaml
+++ b/.orbit/adrs/accepted/ADR-0011/adr.yaml
@@ -1,4 +1,4 @@
-schema_version: 1
+schema_version: 2
 id: ADR-0011
 title: Each new executor block ships with a sibling test module
 status: accepted
@@ -10,6 +10,8 @@ related_features:
 - activity-job
 related_tasks:
 - T20260509-7
+tags: []
+paths: []
 supersedes: []
 legacy_ids:
 - activity-job/ADR-047

--- a/.orbit/adrs/accepted/ADR-0012/adr.yaml
+++ b/.orbit/adrs/accepted/ADR-0012/adr.yaml
@@ -1,4 +1,4 @@
-schema_version: 1
+schema_version: 2
 id: ADR-0012
 title: Condition guards stay equality-only
 status: accepted
@@ -10,6 +10,8 @@ related_features:
 - activity-job
 related_tasks:
 - T20260509-11
+tags: []
+paths: []
 supersedes: []
 legacy_ids:
 - activity-job/ADR-049

--- a/.orbit/adrs/accepted/ADR-0013/adr.yaml
+++ b/.orbit/adrs/accepted/ADR-0013/adr.yaml
@@ -1,4 +1,4 @@
-schema_version: 1
+schema_version: 2
 id: ADR-0013
 title: CLI timeout supervision owns the subprocess group
 status: accepted
@@ -10,6 +10,8 @@ related_features:
 - activity-job
 related_tasks:
 - T20260509-40
+tags: []
+paths: []
 supersedes: []
 legacy_ids:
 - activity-job/ADR-050

--- a/.orbit/adrs/accepted/ADR-0014/adr.yaml
+++ b/.orbit/adrs/accepted/ADR-0014/adr.yaml
@@ -1,4 +1,4 @@
-schema_version: 1
+schema_version: 2
 id: ADR-0014
 title: Legacy parallel-batch workers use cancellable runs
 status: accepted
@@ -10,6 +10,8 @@ related_features:
 - activity-job
 related_tasks:
 - T20260509-38
+tags: []
+paths: []
 supersedes: []
 legacy_ids:
 - activity-job/ADR-051

--- a/.orbit/adrs/accepted/ADR-0026/adr.yaml
+++ b/.orbit/adrs/accepted/ADR-0026/adr.yaml
@@ -1,4 +1,4 @@
-schema_version: 1
+schema_version: 2
 id: ADR-0026
 title: Dedicated auditability design ownership
 status: accepted
@@ -10,6 +10,8 @@ related_features:
 - auditability
 related_tasks:
 - T20260426-0605
+tags: []
+paths: []
 supersedes: []
 legacy_ids:
 - auditability/ADR-001

--- a/.orbit/adrs/accepted/ADR-0027/adr.yaml
+++ b/.orbit/adrs/accepted/ADR-0027/adr.yaml
@@ -1,4 +1,4 @@
-schema_version: 1
+schema_version: 2
 id: ADR-0027
 title: Command audit rows stay compact and queryable
 status: accepted
@@ -10,6 +10,8 @@ related_features:
 - auditability
 related_tasks:
 - T20260426-0605
+tags: []
+paths: []
 supersedes: []
 legacy_ids:
 - auditability/ADR-002

--- a/.orbit/adrs/accepted/ADR-0028/adr.yaml
+++ b/.orbit/adrs/accepted/ADR-0028/adr.yaml
@@ -1,4 +1,4 @@
-schema_version: 1
+schema_version: 2
 id: ADR-0028
 title: V2 run structure and loop transcript detail are separate audit layers
 status: accepted
@@ -10,6 +10,8 @@ related_features:
 - auditability
 related_tasks:
 - T20260419-0002
+tags: []
+paths: []
 supersedes: []
 legacy_ids:
 - auditability/ADR-003

--- a/.orbit/adrs/accepted/ADR-0029/adr.yaml
+++ b/.orbit/adrs/accepted/ADR-0029/adr.yaml
@@ -1,4 +1,4 @@
-schema_version: 1
+schema_version: 2
 id: ADR-0029
 title: File-backed run traces are workspace-local state
 status: accepted
@@ -10,6 +10,8 @@ related_features:
 - auditability
 related_tasks:
 - T20260426-0519
+tags: []
+paths: []
 supersedes: []
 legacy_ids:
 - auditability/ADR-004

--- a/.orbit/adrs/accepted/ADR-0030/adr.yaml
+++ b/.orbit/adrs/accepted/ADR-0030/adr.yaml
@@ -1,4 +1,4 @@
-schema_version: 1
+schema_version: 2
 id: ADR-0030
 title: Redaction is a write-side durability boundary
 status: accepted
@@ -10,6 +10,8 @@ related_features:
 - auditability
 related_tasks:
 - T20260426-0605
+tags: []
+paths: []
 supersedes: []
 legacy_ids:
 - auditability/ADR-005

--- a/.orbit/adrs/accepted/ADR-0031/adr.yaml
+++ b/.orbit/adrs/accepted/ADR-0031/adr.yaml
@@ -1,4 +1,4 @@
-schema_version: 1
+schema_version: 2
 id: ADR-0031
 title: Invocation metrics are audit-adjacent primary records
 status: accepted
@@ -10,6 +10,8 @@ related_features:
 - auditability
 related_tasks:
 - T20260426-0526
+tags: []
+paths: []
 supersedes: []
 legacy_ids:
 - auditability/ADR-006

--- a/.orbit/adrs/accepted/ADR-0032/adr.yaml
+++ b/.orbit/adrs/accepted/ADR-0032/adr.yaml
@@ -1,4 +1,4 @@
-schema_version: 1
+schema_version: 2
 id: ADR-0032
 title: Run trace inspection stays separate from command audit
 status: accepted
@@ -11,6 +11,8 @@ related_features:
 related_tasks:
 - T20260426-0705
 - T20260426-0709
+tags: []
+paths: []
 supersedes: []
 legacy_ids:
 - auditability/ADR-007

--- a/.orbit/adrs/accepted/ADR-0033/adr.yaml
+++ b/.orbit/adrs/accepted/ADR-0033/adr.yaml
@@ -1,4 +1,4 @@
-schema_version: 1
+schema_version: 2
 id: ADR-0033
 title: Process tracing feed is global JSONL
 status: accepted
@@ -10,6 +10,8 @@ related_features:
 - auditability
 related_tasks:
 - T20260426-2343
+tags: []
+paths: []
 supersedes: []
 legacy_ids:
 - auditability/ADR-008

--- a/.orbit/adrs/accepted/ADR-0034/adr.yaml
+++ b/.orbit/adrs/accepted/ADR-0034/adr.yaml
@@ -1,4 +1,4 @@
-schema_version: 1
+schema_version: 2
 id: ADR-0034
 title: Tracing redaction is enforced by field formatting
 status: accepted
@@ -10,6 +10,8 @@ related_features:
 - auditability
 related_tasks:
 - T20260426-2349
+tags: []
+paths: []
 supersedes: []
 legacy_ids:
 - auditability/ADR-009

--- a/.orbit/adrs/accepted/ADR-0035/adr.yaml
+++ b/.orbit/adrs/accepted/ADR-0035/adr.yaml
@@ -1,4 +1,4 @@
-schema_version: 1
+schema_version: 2
 id: ADR-0035
 title: Canonical audit stores project high-signal events to tracing
 status: accepted
@@ -10,6 +10,8 @@ related_features:
 - auditability
 related_tasks:
 - T20260427-0023
+tags: []
+paths: []
 supersedes: []
 legacy_ids:
 - auditability/ADR-010

--- a/.orbit/adrs/accepted/ADR-0036/adr.yaml
+++ b/.orbit/adrs/accepted/ADR-0036/adr.yaml
@@ -1,4 +1,4 @@
-schema_version: 1
+schema_version: 2
 id: ADR-0036
 title: 'Unified log feed: producer completion + reader CLI'
 status: accepted
@@ -10,6 +10,8 @@ related_features:
 - auditability
 related_tasks:
 - T20260427-27
+tags: []
+paths: []
 supersedes: []
 legacy_ids:
 - auditability/ADR-011

--- a/.orbit/adrs/accepted/ADR-0038/adr.yaml
+++ b/.orbit/adrs/accepted/ADR-0038/adr.yaml
@@ -1,4 +1,4 @@
-schema_version: 1
+schema_version: 2
 id: ADR-0038
 title: Unified log feed exposes shared backend surfaces for dashboard UI
 status: accepted
@@ -11,6 +11,8 @@ related_features:
 related_tasks:
 - T20260427-44
 - T20260427-46
+tags: []
+paths: []
 supersedes: []
 legacy_ids:
 - auditability/ADR-013

--- a/.orbit/adrs/accepted/ADR-0039/adr.yaml
+++ b/.orbit/adrs/accepted/ADR-0039/adr.yaml
@@ -1,4 +1,4 @@
-schema_version: 1
+schema_version: 2
 id: ADR-0039
 title: Tool-call provenance is model-first
 status: accepted
@@ -10,6 +10,8 @@ related_features:
 - auditability
 related_tasks:
 - T20260427-52
+tags: []
+paths: []
 supersedes: []
 legacy_ids:
 - auditability/ADR-014

--- a/.orbit/adrs/accepted/ADR-0040/adr.yaml
+++ b/.orbit/adrs/accepted/ADR-0040/adr.yaml
@@ -1,4 +1,4 @@
-schema_version: 1
+schema_version: 2
 id: ADR-0040
 title: Task attribution can be corrected explicitly
 status: accepted
@@ -10,6 +10,8 @@ related_features:
 - auditability
 related_tasks:
 - T20260427-47
+tags: []
+paths: []
 supersedes: []
 legacy_ids:
 - auditability/ADR-015

--- a/.orbit/adrs/accepted/ADR-0041/adr.yaml
+++ b/.orbit/adrs/accepted/ADR-0041/adr.yaml
@@ -1,4 +1,4 @@
-schema_version: 1
+schema_version: 2
 id: ADR-0041
 title: Tool-invocation audit is owned by the runtime, with MCP preflight bracketing
 status: accepted
@@ -10,6 +10,8 @@ related_features:
 - auditability
 related_tasks:
 - T20260428-4
+tags: []
+paths: []
 supersedes: []
 legacy_ids:
 - auditability/ADR-016

--- a/.orbit/adrs/accepted/ADR-0042/adr.yaml
+++ b/.orbit/adrs/accepted/ADR-0042/adr.yaml
@@ -1,4 +1,4 @@
-schema_version: 1
+schema_version: 2
 id: ADR-0042
 title: Command-audit rows carry task / run / activity correlation IDs
 status: accepted
@@ -10,6 +10,8 @@ related_features:
 - auditability
 related_tasks:
 - T20260428-7
+tags: []
+paths: []
 supersedes: []
 legacy_ids:
 - auditability/ADR-017

--- a/.orbit/adrs/accepted/ADR-0043/adr.yaml
+++ b/.orbit/adrs/accepted/ADR-0043/adr.yaml
@@ -1,4 +1,4 @@
-schema_version: 1
+schema_version: 2
 id: ADR-0043
 title: Scoreboard tool-call totals project from command audit
 status: accepted
@@ -10,6 +10,8 @@ related_features:
 - auditability
 related_tasks:
 - T20260428-11
+tags: []
+paths: []
 supersedes: []
 legacy_ids:
 - auditability/ADR-018

--- a/.orbit/adrs/accepted/ADR-0044/adr.yaml
+++ b/.orbit/adrs/accepted/ADR-0044/adr.yaml
@@ -1,4 +1,4 @@
-schema_version: 1
+schema_version: 2
 id: ADR-0044
 title: Task-review feedback scores separately from PR review comments
 status: accepted
@@ -12,6 +12,8 @@ related_tasks:
 - T20260428-17
 - T20260430-4
 - T20260430-5
+tags: []
+paths: []
 supersedes: []
 legacy_ids:
 - auditability/ADR-019

--- a/.orbit/adrs/accepted/ADR-0045/adr.yaml
+++ b/.orbit/adrs/accepted/ADR-0045/adr.yaml
@@ -1,4 +1,4 @@
-schema_version: 1
+schema_version: 2
 id: ADR-0045
 title: Command-audit execution ids are process-disambiguated
 status: accepted
@@ -10,6 +10,8 @@ related_features:
 - auditability
 related_tasks:
 - T20260505-6
+tags: []
+paths: []
 supersedes: []
 legacy_ids:
 - auditability/ADR-020

--- a/.orbit/adrs/accepted/ADR-0046/adr.yaml
+++ b/.orbit/adrs/accepted/ADR-0046/adr.yaml
@@ -1,4 +1,4 @@
-schema_version: 1
+schema_version: 2
 id: ADR-0046
 title: Loop audit JSONL files materialize on first loop event
 status: accepted
@@ -10,6 +10,8 @@ related_features:
 - auditability
 related_tasks:
 - T20260506-2
+tags: []
+paths: []
 supersedes: []
 legacy_ids:
 - auditability/ADR-021

--- a/.orbit/adrs/accepted/ADR-0047/adr.yaml
+++ b/.orbit/adrs/accepted/ADR-0047/adr.yaml
@@ -1,4 +1,4 @@
-schema_version: 1
+schema_version: 2
 id: ADR-0047
 title: Automated git commits carry implementer authorship
 status: accepted
@@ -10,6 +10,8 @@ related_features:
 - auditability
 related_tasks:
 - T20260508-22
+tags: []
+paths: []
 supersedes: []
 legacy_ids:
 - auditability/ADR-022

--- a/.orbit/adrs/accepted/ADR-0048/adr.yaml
+++ b/.orbit/adrs/accepted/ADR-0048/adr.yaml
@@ -1,4 +1,4 @@
-schema_version: 1
+schema_version: 2
 id: ADR-0048
 title: Workflow git commit identity is process-scoped
 status: accepted
@@ -10,6 +10,8 @@ related_features:
 - auditability
 related_tasks:
 - T20260509-12
+tags: []
+paths: []
 supersedes: []
 legacy_ids:
 - auditability/ADR-023

--- a/.orbit/adrs/accepted/ADR-0049/adr.yaml
+++ b/.orbit/adrs/accepted/ADR-0049/adr.yaml
@@ -1,4 +1,4 @@
-schema_version: 1
+schema_version: 2
 id: ADR-0049
 title: Friction reports are append-only records, not lifecycle tasks
 status: accepted
@@ -10,6 +10,8 @@ related_features:
 - auditability
 related_tasks:
 - T20260510-13
+tags: []
+paths: []
 supersedes: []
 legacy_ids:
 - auditability/ADR-024

--- a/.orbit/adrs/accepted/ADR-0050/adr.yaml
+++ b/.orbit/adrs/accepted/ADR-0050/adr.yaml
@@ -1,4 +1,4 @@
-schema_version: 1
+schema_version: 2
 id: ADR-0050
 title: Dedicated Groundhog activity kind
 status: accepted
@@ -10,6 +10,8 @@ related_features:
 - groundhog
 related_tasks:
 - T20260420-0510-2
+tags: []
+paths: []
 supersedes: []
 legacy_ids:
 - groundhog/ADR-001

--- a/.orbit/adrs/accepted/ADR-0051/adr.yaml
+++ b/.orbit/adrs/accepted/ADR-0051/adr.yaml
@@ -1,4 +1,4 @@
-schema_version: 1
+schema_version: 2
 id: ADR-0051
 title: HTTP-only first ship
 status: accepted
@@ -10,6 +10,8 @@ related_features:
 - groundhog
 related_tasks:
 - T20260420-0510-2
+tags: []
+paths: []
 supersedes: []
 legacy_ids:
 - groundhog/ADR-002

--- a/.orbit/adrs/accepted/ADR-0052/adr.yaml
+++ b/.orbit/adrs/accepted/ADR-0052/adr.yaml
@@ -1,4 +1,4 @@
-schema_version: 1
+schema_version: 2
 id: ADR-0052
 title: Structured checkpoints live in the task plan
 status: accepted
@@ -11,6 +11,8 @@ related_features:
 related_tasks:
 - T20260420-0509-2
 - T20260420-0510-2
+tags: []
+paths: []
 supersedes: []
 legacy_ids:
 - groundhog/ADR-003

--- a/.orbit/adrs/accepted/ADR-0053/adr.yaml
+++ b/.orbit/adrs/accepted/ADR-0053/adr.yaml
@@ -1,4 +1,4 @@
-schema_version: 1
+schema_version: 2
 id: ADR-0053
 title: Git scratch branches for rewind
 status: accepted
@@ -10,6 +10,8 @@ related_features:
 - groundhog
 related_tasks:
 - T20260420-0509-4
+tags: []
+paths: []
 supersedes: []
 legacy_ids:
 - groundhog/ADR-004

--- a/.orbit/adrs/accepted/ADR-0054/adr.yaml
+++ b/.orbit/adrs/accepted/ADR-0054/adr.yaml
@@ -1,4 +1,4 @@
-schema_version: 1
+schema_version: 2
 id: ADR-0054
 title: Explicit Groundhog builtins close an attempt
 status: accepted
@@ -11,6 +11,8 @@ related_features:
 related_tasks:
 - T20260420-0509-3
 - T20260420-0510-2
+tags: []
+paths: []
 supersedes: []
 legacy_ids:
 - groundhog/ADR-005

--- a/.orbit/adrs/accepted/ADR-0055/adr.yaml
+++ b/.orbit/adrs/accepted/ADR-0055/adr.yaml
@@ -1,4 +1,4 @@
-schema_version: 1
+schema_version: 2
 id: ADR-0055
 title: Preserve an append-only chronicle serializer
 status: accepted
@@ -10,6 +10,8 @@ related_features:
 - groundhog
 related_tasks:
 - T20260420-0509
+tags: []
+paths: []
 supersedes: []
 legacy_ids:
 - groundhog/ADR-006

--- a/.orbit/adrs/accepted/ADR-0056/adr.yaml
+++ b/.orbit/adrs/accepted/ADR-0056/adr.yaml
@@ -1,4 +1,4 @@
-schema_version: 1
+schema_version: 2
 id: ADR-0056
 title: Mechanical criteria verify at the checkpoint boundary
 status: accepted
@@ -11,6 +11,8 @@ related_features:
 related_tasks:
 - T20260420-0510
 - T20260420-0510-2
+tags: []
+paths: []
 supersedes: []
 legacy_ids:
 - groundhog/ADR-007

--- a/.orbit/adrs/accepted/ADR-0059/adr.yaml
+++ b/.orbit/adrs/accepted/ADR-0059/adr.yaml
@@ -1,4 +1,4 @@
-schema_version: 1
+schema_version: 2
 id: ADR-0059
 title: Content-addressed objects + mutable refs
 status: accepted
@@ -11,6 +11,8 @@ related_features:
 related_tasks:
 - T20260407-0222
 - T20260411-0424
+tags: []
+paths: []
 supersedes: []
 legacy_ids:
 - knowledge-graph/ADR-001

--- a/.orbit/adrs/accepted/ADR-0060/adr.yaml
+++ b/.orbit/adrs/accepted/ADR-0060/adr.yaml
@@ -1,4 +1,4 @@
-schema_version: 1
+schema_version: 2
 id: ADR-0060
 title: Branch-scoped refs over a single shared ref
 status: accepted
@@ -11,6 +11,8 @@ related_features:
 related_tasks:
 - T20260421-0358
 - T20260505-1
+tags: []
+paths: []
 supersedes: []
 legacy_ids:
 - knowledge-graph/ADR-002

--- a/.orbit/adrs/accepted/ADR-0061/adr.yaml
+++ b/.orbit/adrs/accepted/ADR-0061/adr.yaml
@@ -1,4 +1,4 @@
-schema_version: 1
+schema_version: 2
 id: ADR-0061
 title: Tree-sitter extractors over an LSP backend
 status: accepted
@@ -17,6 +17,8 @@ related_tasks:
 - T20260505-14
 - T20260505-15
 - T20260505-16
+tags: []
+paths: []
 supersedes: []
 legacy_ids:
 - knowledge-graph/ADR-003

--- a/.orbit/adrs/accepted/ADR-0063/adr.yaml
+++ b/.orbit/adrs/accepted/ADR-0063/adr.yaml
@@ -1,4 +1,4 @@
-schema_version: 1
+schema_version: 2
 id: ADR-0063
 title: Working graph is in-memory, not persistent
 status: accepted
@@ -13,6 +13,8 @@ related_tasks:
 - T20260409-0656
 - T20260416-0236
 - T20260417-0302
+tags: []
+paths: []
 supersedes: []
 legacy_ids:
 - knowledge-graph/ADR-005

--- a/.orbit/adrs/accepted/ADR-0066/adr.yaml
+++ b/.orbit/adrs/accepted/ADR-0066/adr.yaml
@@ -1,4 +1,4 @@
-schema_version: 1
+schema_version: 2
 id: ADR-0066
 title: File-based lock store in `orbit-knowledge`, no standalone `orbit-lock` crate
 status: accepted
@@ -11,6 +11,8 @@ related_features:
 related_tasks:
 - T20260411-0424
 - T20260417-0301-2
+tags: []
+paths: []
 supersedes: []
 legacy_ids:
 - knowledge-graph/ADR-008

--- a/.orbit/adrs/accepted/ADR-0067/adr.yaml
+++ b/.orbit/adrs/accepted/ADR-0067/adr.yaml
@@ -1,4 +1,4 @@
-schema_version: 1
+schema_version: 2
 id: ADR-0067
 title: Debounced, single-flighted refresh
 status: accepted
@@ -13,6 +13,8 @@ related_tasks:
 - T20260416-0719
 - T20260417-0639
 - T20260505-1
+tags: []
+paths: []
 supersedes: []
 legacy_ids:
 - knowledge-graph/ADR-009

--- a/.orbit/adrs/accepted/ADR-0069/adr.yaml
+++ b/.orbit/adrs/accepted/ADR-0069/adr.yaml
@@ -1,4 +1,4 @@
-schema_version: 1
+schema_version: 2
 id: ADR-0069
 title: Non-code extraction via `FileKind`-dispatched extractors
 status: accepted
@@ -11,6 +11,8 @@ related_features:
 related_tasks:
 - T20260422-1540
 - T20260509-64
+tags: []
+paths: []
 supersedes: []
 legacy_ids:
 - knowledge-graph/ADR-011

--- a/.orbit/adrs/accepted/ADR-0070/adr.yaml
+++ b/.orbit/adrs/accepted/ADR-0070/adr.yaml
@@ -1,4 +1,4 @@
-schema_version: 1
+schema_version: 2
 id: ADR-0070
 title: Keep scan-time graph inclusion separate from runtime policy access
 status: accepted
@@ -10,6 +10,8 @@ related_features:
 - knowledge-graph
 related_tasks:
 - T20260423-0452
+tags: []
+paths: []
 supersedes: []
 legacy_ids:
 - knowledge-graph/ADR-012

--- a/.orbit/adrs/accepted/ADR-0071/adr.yaml
+++ b/.orbit/adrs/accepted/ADR-0071/adr.yaml
@@ -1,4 +1,4 @@
-schema_version: 1
+schema_version: 2
 id: ADR-0071
 title: Changed-path incremental leaf reuse
 status: accepted
@@ -10,6 +10,8 @@ related_features:
 - knowledge-graph
 related_tasks:
 - T20260426-0140
+tags: []
+paths: []
 supersedes: []
 legacy_ids:
 - knowledge-graph/ADR-013

--- a/.orbit/adrs/accepted/ADR-0072/adr.yaml
+++ b/.orbit/adrs/accepted/ADR-0072/adr.yaml
@@ -1,4 +1,4 @@
-schema_version: 1
+schema_version: 2
 id: ADR-0072
 title: Store-scoped LRU for graph objects and blobs
 status: accepted
@@ -10,6 +10,8 @@ related_features:
 - knowledge-graph
 related_tasks:
 - T20260426-0141
+tags: []
+paths: []
 supersedes: []
 legacy_ids:
 - knowledge-graph/ADR-014

--- a/.orbit/adrs/accepted/ADR-0073/adr.yaml
+++ b/.orbit/adrs/accepted/ADR-0073/adr.yaml
@@ -1,4 +1,4 @@
-schema_version: 1
+schema_version: 2
 id: ADR-0073
 title: Parallel per-file build work with ordered merge
 status: accepted
@@ -10,6 +10,8 @@ related_features:
 - knowledge-graph
 related_tasks:
 - T20260426-0139
+tags: []
+paths: []
 supersedes: []
 legacy_ids:
 - knowledge-graph/ADR-015

--- a/.orbit/adrs/accepted/ADR-0075/adr.yaml
+++ b/.orbit/adrs/accepted/ADR-0075/adr.yaml
@@ -1,4 +1,4 @@
-schema_version: 1
+schema_version: 2
 id: ADR-0075
 title: Local graph build benchmark scoreboard over CI regression gates
 status: accepted
@@ -10,6 +10,8 @@ related_features:
 - knowledge-graph
 related_tasks:
 - T20260426-0236
+tags: []
+paths: []
 supersedes: []
 legacy_ids:
 - knowledge-graph/ADR-017

--- a/.orbit/adrs/accepted/ADR-0076/adr.yaml
+++ b/.orbit/adrs/accepted/ADR-0076/adr.yaml
@@ -1,4 +1,4 @@
-schema_version: 1
+schema_version: 2
 id: ADR-0076
 title: Retain agent-facing `orbit_graph_*` MCP surface; provider-dependent value
 status: accepted
@@ -11,6 +11,8 @@ related_features:
 related_tasks:
 - T20260423-0524
 - T20260426-0402
+tags: []
+paths: []
 supersedes: []
 legacy_ids:
 - knowledge-graph/ADR-018

--- a/.orbit/adrs/accepted/ADR-0077/adr.yaml
+++ b/.orbit/adrs/accepted/ADR-0077/adr.yaml
@@ -1,4 +1,4 @@
-schema_version: 1
+schema_version: 2
 id: ADR-0077
 title: Keep the public graph surface read-only
 status: accepted
@@ -10,6 +10,8 @@ related_features:
 - knowledge-graph
 related_tasks:
 - T20260426-0453
+tags: []
+paths: []
 supersedes: []
 legacy_ids:
 - knowledge-graph/ADR-019

--- a/.orbit/adrs/accepted/ADR-0079/adr.yaml
+++ b/.orbit/adrs/accepted/ADR-0079/adr.yaml
@@ -1,4 +1,4 @@
-schema_version: 1
+schema_version: 2
 id: ADR-0079
 title: Route graph CLI through the tools facade
 status: accepted
@@ -10,6 +10,8 @@ related_features:
 - knowledge-graph
 related_tasks:
 - T20260426-2042
+tags: []
+paths: []
 supersedes: []
 legacy_ids:
 - knowledge-graph/ADR-021

--- a/.orbit/adrs/accepted/ADR-0081/adr.yaml
+++ b/.orbit/adrs/accepted/ADR-0081/adr.yaml
@@ -1,4 +1,4 @@
-schema_version: 1
+schema_version: 2
 id: ADR-0081
 title: Keep MCP graph exposure equal to the read-only graph tool set
 status: accepted
@@ -10,6 +10,8 @@ related_features:
 - knowledge-graph
 related_tasks:
 - T20260428-3
+tags: []
+paths: []
 supersedes: []
 legacy_ids:
 - knowledge-graph/ADR-023

--- a/.orbit/adrs/accepted/ADR-0082/adr.yaml
+++ b/.orbit/adrs/accepted/ADR-0082/adr.yaml
@@ -1,4 +1,4 @@
-schema_version: 1
+schema_version: 2
 id: ADR-0082
 title: Pack favors prompt-time responsiveness over inline refresh
 status: accepted
@@ -10,6 +10,8 @@ related_features:
 - knowledge-graph
 related_tasks:
 - T20260505-5
+tags: []
+paths: []
 supersedes: []
 legacy_ids:
 - knowledge-graph/ADR-025

--- a/.orbit/adrs/accepted/ADR-0083/adr.yaml
+++ b/.orbit/adrs/accepted/ADR-0083/adr.yaml
@@ -1,4 +1,4 @@
-schema_version: 1
+schema_version: 2
 id: ADR-0083
 title: Remove graph task attribution
 status: accepted
@@ -10,6 +10,8 @@ related_features:
 - knowledge-graph
 related_tasks:
 - T20260506-11
+tags: []
+paths: []
 supersedes:
 - ADR-0062
 - ADR-0064

--- a/.orbit/adrs/accepted/ADR-0084/adr.yaml
+++ b/.orbit/adrs/accepted/ADR-0084/adr.yaml
@@ -1,4 +1,4 @@
-schema_version: 1
+schema_version: 2
 id: ADR-0084
 title: Skip symlinked scan entries by default
 status: accepted
@@ -10,6 +10,8 @@ related_features:
 - knowledge-graph
 related_tasks:
 - T20260509-33
+tags: []
+paths: []
 supersedes: []
 legacy_ids:
 - knowledge-graph/ADR-030

--- a/.orbit/adrs/accepted/ADR-0085/adr.yaml
+++ b/.orbit/adrs/accepted/ADR-0085/adr.yaml
@@ -1,4 +1,4 @@
-schema_version: 1
+schema_version: 2
 id: ADR-0085
 title: Refresh freshness by checkout identity
 status: accepted
@@ -10,6 +10,8 @@ related_features:
 - knowledge-graph
 related_tasks:
 - T20260509-34
+tags: []
+paths: []
 supersedes: []
 legacy_ids:
 - knowledge-graph/ADR-031

--- a/.orbit/adrs/accepted/ADR-0086/adr.yaml
+++ b/.orbit/adrs/accepted/ADR-0086/adr.yaml
@@ -1,4 +1,4 @@
-schema_version: 1
+schema_version: 2
 id: ADR-0086
 title: Source hydration is explicit per graph read
 status: accepted
@@ -10,6 +10,8 @@ related_features:
 - knowledge-graph
 related_tasks:
 - T20260509-65
+tags: []
+paths: []
 supersedes: []
 legacy_ids:
 - knowledge-graph/ADR-032

--- a/.orbit/adrs/accepted/ADR-0087/adr.yaml
+++ b/.orbit/adrs/accepted/ADR-0087/adr.yaml
@@ -1,4 +1,4 @@
-schema_version: 1
+schema_version: 2
 id: ADR-0087
 title: Default search ranking uses a bounded candidate pool
 status: accepted
@@ -10,6 +10,8 @@ related_features:
 - knowledge-graph
 related_tasks:
 - T20260509-67
+tags: []
+paths: []
 supersedes: []
 legacy_ids:
 - knowledge-graph/ADR-033

--- a/.orbit/adrs/accepted/ADR-0088/adr.yaml
+++ b/.orbit/adrs/accepted/ADR-0088/adr.yaml
@@ -1,4 +1,4 @@
-schema_version: 1
+schema_version: 2
 id: ADR-0088
 title: SQLite sidecar for secondary graph indexes
 status: accepted
@@ -11,6 +11,8 @@ related_features:
 related_tasks:
 - T20260509-70
 - T20260509-72
+tags: []
+paths: []
 supersedes: []
 legacy_ids:
 - knowledge-graph/ADR-034

--- a/.orbit/adrs/accepted/ADR-0089/adr.yaml
+++ b/.orbit/adrs/accepted/ADR-0089/adr.yaml
@@ -1,4 +1,4 @@
-schema_version: 1
+schema_version: 2
 id: ADR-0089
 title: Search exact-name and path-prefix fast paths use SQLite
 status: accepted
@@ -10,6 +10,8 @@ related_features:
 - knowledge-graph
 related_tasks:
 - T20260509-73
+tags: []
+paths: []
 supersedes: []
 legacy_ids:
 - knowledge-graph/ADR-035

--- a/.orbit/adrs/accepted/ADR-0090/adr.yaml
+++ b/.orbit/adrs/accepted/ADR-0090/adr.yaml
@@ -1,4 +1,4 @@
-schema_version: 1
+schema_version: 2
 id: ADR-0090
 title: Knowledge commands are the canonical query boundary
 status: accepted
@@ -10,6 +10,8 @@ related_features:
 - knowledge-graph
 related_tasks:
 - T20260510-5
+tags: []
+paths: []
 supersedes: []
 legacy_ids:
 - knowledge-graph/ADR-036

--- a/.orbit/adrs/accepted/ADR-0091/adr.yaml
+++ b/.orbit/adrs/accepted/ADR-0091/adr.yaml
@@ -1,4 +1,4 @@
-schema_version: 1
+schema_version: 2
 id: ADR-0091
 title: Leaf IDs use language-natural qualifiers plus occurrence suffixes
 status: accepted
@@ -10,6 +10,8 @@ related_features:
 - knowledge-graph
 related_tasks:
 - T20260510-7
+tags: []
+paths: []
 supersedes: []
 legacy_ids:
 - knowledge-graph/ADR-037

--- a/.orbit/adrs/accepted/ADR-0092/adr.yaml
+++ b/.orbit/adrs/accepted/ADR-0092/adr.yaml
@@ -1,4 +1,4 @@
-schema_version: 1
+schema_version: 2
 id: ADR-0092
 title: Collapse YAML/JSON/TOML/CSV/TSV extraction to file-as-leaf
 status: accepted
@@ -10,6 +10,8 @@ related_features:
 - knowledge-graph
 related_tasks:
 - T20260509-64
+tags: []
+paths: []
 supersedes: []
 legacy_ids:
 - knowledge-graph/ADR-038

--- a/.orbit/adrs/accepted/ADR-0093/adr.yaml
+++ b/.orbit/adrs/accepted/ADR-0093/adr.yaml
@@ -1,4 +1,4 @@
-schema_version: 1
+schema_version: 2
 id: ADR-0093
 title: Dedicated policy & sandboxing design ownership
 status: accepted
@@ -10,6 +10,8 @@ related_features:
 - policy-sandbox
 related_tasks:
 - T20260426-0622
+tags: []
+paths: []
 supersedes: []
 legacy_ids:
 - policy-sandbox/ADR-001

--- a/.orbit/adrs/accepted/ADR-0094/adr.yaml
+++ b/.orbit/adrs/accepted/ADR-0094/adr.yaml
@@ -1,4 +1,4 @@
-schema_version: 1
+schema_version: 2
 id: ADR-0094
 title: Policy schema is v2-only with named profiles plus global denies
 status: accepted
@@ -10,6 +10,8 @@ related_features:
 - policy-sandbox
 related_tasks:
 - T20260416-0728
+tags: []
+paths: []
 supersedes: []
 legacy_ids:
 - policy-sandbox/ADR-002

--- a/.orbit/adrs/accepted/ADR-0095/adr.yaml
+++ b/.orbit/adrs/accepted/ADR-0095/adr.yaml
@@ -1,4 +1,4 @@
-schema_version: 1
+schema_version: 2
 id: ADR-0095
 title: Implicit `unrestricted` profile materializes when an activity omits `fsProfile:`
 status: accepted
@@ -10,6 +10,8 @@ related_features:
 - policy-sandbox
 related_tasks:
 - T20260419-0503
+tags: []
+paths: []
 supersedes: []
 legacy_ids:
 - policy-sandbox/ADR-003

--- a/.orbit/adrs/accepted/ADR-0096/adr.yaml
+++ b/.orbit/adrs/accepted/ADR-0096/adr.yaml
@@ -1,4 +1,4 @@
-schema_version: 1
+schema_version: 2
 id: ADR-0096
 title: Deny rules inject as negated profile rules with last-match-wins evaluation
 status: accepted
@@ -10,6 +10,8 @@ related_features:
 - policy-sandbox
 related_tasks:
 - T20260416-0728
+tags: []
+paths: []
 supersedes: []
 legacy_ids:
 - policy-sandbox/ADR-004

--- a/.orbit/adrs/accepted/ADR-0097/adr.yaml
+++ b/.orbit/adrs/accepted/ADR-0097/adr.yaml
@@ -1,4 +1,4 @@
-schema_version: 1
+schema_version: 2
 id: ADR-0097
 title: Modify rules must be covered by a read rule in the same profile
 status: accepted
@@ -10,6 +10,8 @@ related_features:
 - policy-sandbox
 related_tasks:
 - T20260416-0728
+tags: []
+paths: []
 supersedes: []
 legacy_ids:
 - policy-sandbox/ADR-005

--- a/.orbit/adrs/accepted/ADR-0098/adr.yaml
+++ b/.orbit/adrs/accepted/ADR-0098/adr.yaml
@@ -1,4 +1,4 @@
-schema_version: 1
+schema_version: 2
 id: ADR-0098
 title: Tool layer is the policy enforcement point for HTTP-backed activities
 status: accepted
@@ -10,6 +10,8 @@ related_features:
 - policy-sandbox
 related_tasks:
 - T20260419-0503
+tags: []
+paths: []
 supersedes: []
 legacy_ids:
 - policy-sandbox/ADR-006

--- a/.orbit/adrs/accepted/ADR-0099/adr.yaml
+++ b/.orbit/adrs/accepted/ADR-0099/adr.yaml
@@ -1,4 +1,4 @@
-schema_version: 1
+schema_version: 2
 id: ADR-0099
 title: Children spawn as process-group leaders so orphan subprocesses are reapable
 status: accepted
@@ -11,6 +11,8 @@ related_features:
 related_tasks:
 - T20260417-0558-4
 - T20260328-221810
+tags: []
+paths: []
 supersedes: []
 legacy_ids:
 - policy-sandbox/ADR-007

--- a/.orbit/adrs/accepted/ADR-0100/adr.yaml
+++ b/.orbit/adrs/accepted/ADR-0100/adr.yaml
@@ -1,4 +1,4 @@
-schema_version: 1
+schema_version: 2
 id: ADR-0100
 title: SIGTERM with 5-second grace, then SIGKILL for the whole group
 status: accepted
@@ -10,6 +10,8 @@ related_features:
 - policy-sandbox
 related_tasks:
 - T20260417-0558-4
+tags: []
+paths: []
 supersedes: []
 legacy_ids:
 - policy-sandbox/ADR-008

--- a/.orbit/adrs/accepted/ADR-0101/adr.yaml
+++ b/.orbit/adrs/accepted/ADR-0101/adr.yaml
@@ -1,4 +1,4 @@
-schema_version: 1
+schema_version: 2
 id: ADR-0101
 title: Signal handler installation is process-global and serialized
 status: accepted
@@ -10,6 +10,8 @@ related_features:
 - policy-sandbox
 related_tasks:
 - T20260417-0558-5
+tags: []
+paths: []
 supersedes: []
 legacy_ids:
 - policy-sandbox/ADR-009

--- a/.orbit/adrs/accepted/ADR-0102/adr.yaml
+++ b/.orbit/adrs/accepted/ADR-0102/adr.yaml
@@ -1,4 +1,4 @@
-schema_version: 1
+schema_version: 2
 id: ADR-0102
 title: '`NoSandbox` is the default `Sandbox` impl; real isolation is deferred'
 status: accepted
@@ -10,6 +10,8 @@ related_features:
 - policy-sandbox
 related_tasks:
 - T20260417-0550
+tags: []
+paths: []
 supersedes: []
 legacy_ids:
 - policy-sandbox/ADR-010

--- a/.orbit/adrs/accepted/ADR-0103/adr.yaml
+++ b/.orbit/adrs/accepted/ADR-0103/adr.yaml
@@ -1,4 +1,4 @@
-schema_version: 1
+schema_version: 2
 id: ADR-0103
 title: '`sandbox-exec` wraps cli-backend agent invocations on macOS'
 status: accepted
@@ -10,6 +10,8 @@ related_features:
 - policy-sandbox
 related_tasks:
 - T20260427-51
+tags: []
+paths: []
 supersedes: []
 legacy_ids:
 - policy-sandbox/ADR-011

--- a/.orbit/adrs/accepted/ADR-0104/adr.yaml
+++ b/.orbit/adrs/accepted/ADR-0104/adr.yaml
@@ -1,4 +1,4 @@
-schema_version: 1
+schema_version: 2
 id: ADR-0104
 title: Codex state and side roots are narrow sandbox write allowances
 status: accepted
@@ -10,6 +10,8 @@ related_features:
 - policy-sandbox
 related_tasks:
 - T20260428-10
+tags: []
+paths: []
 supersedes: []
 legacy_ids:
 - policy-sandbox/ADR-012

--- a/.orbit/adrs/accepted/ADR-0105/adr.yaml
+++ b/.orbit/adrs/accepted/ADR-0105/adr.yaml
@@ -1,4 +1,4 @@
-schema_version: 1
+schema_version: 2
 id: ADR-0105
 title: Per-provider state-dir allowances are emitted unconditionally for every supported CLI
 status: accepted
@@ -10,6 +10,8 @@ related_features:
 - policy-sandbox
 related_tasks:
 - T20260428-14
+tags: []
+paths: []
 supersedes: []
 legacy_ids:
 - policy-sandbox/ADR-013

--- a/.orbit/adrs/accepted/ADR-0106/adr.yaml
+++ b/.orbit/adrs/accepted/ADR-0106/adr.yaml
@@ -1,4 +1,4 @@
-schema_version: 1
+schema_version: 2
 id: ADR-0106
 title: Claude state surface includes `$HOME/.claude.json` siblings, not just `$HOME/.claude/`
 status: accepted
@@ -10,6 +10,8 @@ related_features:
 - policy-sandbox
 related_tasks:
 - T20260508-13
+tags: []
+paths: []
 supersedes: []
 legacy_ids:
 - policy-sandbox/ADR-014

--- a/.orbit/adrs/accepted/ADR-0107/adr.yaml
+++ b/.orbit/adrs/accepted/ADR-0107/adr.yaml
@@ -1,4 +1,4 @@
-schema_version: 1
+schema_version: 2
 id: ADR-0107
 title: macOS sandbox wrapper resolves from trusted absolute locations
 status: accepted
@@ -10,6 +10,8 @@ related_features:
 - policy-sandbox
 related_tasks:
 - T20260509-30
+tags: []
+paths: []
 supersedes: []
 legacy_ids:
 - policy-sandbox/ADR-015

--- a/.orbit/adrs/accepted/ADR-0108/adr.yaml
+++ b/.orbit/adrs/accepted/ADR-0108/adr.yaml
@@ -1,4 +1,4 @@
-schema_version: 1
+schema_version: 2
 id: ADR-0108
 title: Push-based discovery via context injection, not pull-only via search
 status: accepted
@@ -10,6 +10,8 @@ related_features:
 - project-learnings
 related_tasks:
 - T20260510-11
+tags: []
+paths: []
 supersedes: []
 legacy_ids:
 - project-learnings/ADR-001

--- a/.orbit/adrs/accepted/ADR-0109/adr.yaml
+++ b/.orbit/adrs/accepted/ADR-0109/adr.yaml
@@ -1,4 +1,4 @@
-schema_version: 1
+schema_version: 2
 id: ADR-0109
 title: Native Orbit primitive (`learning` resource) over a flat markdown directory
 status: accepted
@@ -10,6 +10,8 @@ related_features:
 - project-learnings
 related_tasks:
 - T20260510-11
+tags: []
+paths: []
 supersedes: []
 legacy_ids:
 - project-learnings/ADR-002

--- a/.orbit/adrs/accepted/ADR-0110/adr.yaml
+++ b/.orbit/adrs/accepted/ADR-0110/adr.yaml
@@ -1,4 +1,4 @@
-schema_version: 1
+schema_version: 2
 id: ADR-0110
 title: Workspace-scoped, checked into git (not workspace-private state)
 status: accepted
@@ -10,6 +10,8 @@ related_features:
 - project-learnings
 related_tasks:
 - T20260510-11
+tags: []
+paths: []
 supersedes: []
 legacy_ids:
 - project-learnings/ADR-003

--- a/.orbit/adrs/accepted/ADR-0111/adr.yaml
+++ b/.orbit/adrs/accepted/ADR-0111/adr.yaml
@@ -1,4 +1,4 @@
-schema_version: 1
+schema_version: 2
 id: ADR-0111
 title: Phase-1 scope = path globs + tags, ranked by recency; semantic and symbol-aware deferred
 status: accepted
@@ -10,6 +10,8 @@ related_features:
 - project-learnings
 related_tasks:
 - T20260510-11
+tags: []
+paths: []
 supersedes: []
 legacy_ids:
 - project-learnings/ADR-004

--- a/.orbit/adrs/accepted/ADR-0112/adr.yaml
+++ b/.orbit/adrs/accepted/ADR-0112/adr.yaml
@@ -1,4 +1,4 @@
-schema_version: 1
+schema_version: 2
 id: ADR-0112
 title: Three-layer push pipeline (engine pre-prompt + MCP sidecar + Claude Code hook), not single-layer
 status: accepted
@@ -10,6 +10,8 @@ related_features:
 - project-learnings
 related_tasks:
 - T20260510-11
+tags: []
+paths: []
 supersedes: []
 legacy_ids:
 - project-learnings/ADR-005

--- a/.orbit/adrs/accepted/ADR-0113/adr.yaml
+++ b/.orbit/adrs/accepted/ADR-0113/adr.yaml
@@ -1,4 +1,4 @@
-schema_version: 1
+schema_version: 2
 id: ADR-0113
 title: fastembed-rs ONNX backend over Candle, llama.cpp, or external ollama
 status: accepted
@@ -11,6 +11,8 @@ related_features:
 related_tasks:
 - T20260510-3
 - T20260510-9
+tags: []
+paths: []
 supersedes: []
 legacy_ids:
 - semantic-search/ADR-001

--- a/.orbit/adrs/accepted/ADR-0114/adr.yaml
+++ b/.orbit/adrs/accepted/ADR-0114/adr.yaml
@@ -1,4 +1,4 @@
-schema_version: 1
+schema_version: 2
 id: ADR-0114
 title: Brute-force cosine over SQLite BLOBs; `sqlite-vec` reserved as phase-2 upgrade
 status: accepted
@@ -11,6 +11,8 @@ related_features:
 related_tasks:
 - T20260510-3
 - T20260510-9
+tags: []
+paths: []
 supersedes: []
 legacy_ids:
 - semantic-search/ADR-002

--- a/.orbit/adrs/accepted/ADR-0115/adr.yaml
+++ b/.orbit/adrs/accepted/ADR-0115/adr.yaml
@@ -1,4 +1,4 @@
-schema_version: 1
+schema_version: 2
 id: ADR-0115
 title: Per-field embeddings with chunked overflow, not whole-bundle concatenation
 status: accepted
@@ -11,6 +11,8 @@ related_features:
 related_tasks:
 - T20260510-3
 - T20260510-9
+tags: []
+paths: []
 supersedes: []
 legacy_ids:
 - semantic-search/ADR-003

--- a/.orbit/adrs/accepted/ADR-0116/adr.yaml
+++ b/.orbit/adrs/accepted/ADR-0116/adr.yaml
@@ -1,4 +1,4 @@
-schema_version: 1
+schema_version: 2
 id: ADR-0116
 title: Hybrid retrieval (FTS5 BM25 + cosine, fused via RRF) from day one
 status: accepted
@@ -11,6 +11,8 @@ related_features:
 related_tasks:
 - T20260510-3
 - T20260510-9
+tags: []
+paths: []
 supersedes: []
 legacy_ids:
 - semantic-search/ADR-004

--- a/.orbit/adrs/accepted/ADR-0117/adr.yaml
+++ b/.orbit/adrs/accepted/ADR-0117/adr.yaml
@@ -1,4 +1,4 @@
-schema_version: 1
+schema_version: 2
 id: ADR-0117
 title: Companion binary installed on demand, rather than bundled in `orbit`
 status: accepted
@@ -11,6 +11,8 @@ related_features:
 related_tasks:
 - T20260510-3
 - T20260510-9
+tags: []
+paths: []
 supersedes: []
 legacy_ids:
 - semantic-search/ADR-005

--- a/.orbit/adrs/accepted/ADR-0118/adr.yaml
+++ b/.orbit/adrs/accepted/ADR-0118/adr.yaml
@@ -1,4 +1,4 @@
-schema_version: 1
+schema_version: 2
 id: ADR-0118
 title: Workspace-local semantic DB separate from global audit/tool DB
 status: accepted
@@ -10,6 +10,8 @@ related_features:
 - semantic-search
 related_tasks:
 - T20260510-9
+tags: []
+paths: []
 supersedes: []
 legacy_ids:
 - semantic-search/ADR-006

--- a/.orbit/adrs/accepted/ADR-0120/adr.yaml
+++ b/.orbit/adrs/accepted/ADR-0120/adr.yaml
@@ -1,4 +1,4 @@
-schema_version: 1
+schema_version: 2
 id: ADR-0120
 title: Version-aware companion refresh and quiet background indexing
 status: accepted
@@ -10,6 +10,8 @@ related_features:
 - semantic-search
 related_tasks:
 - T20260510-26
+tags: []
+paths: []
 supersedes: []
 legacy_ids:
 - semantic-search/ADR-008

--- a/.orbit/adrs/accepted/ADR-0140/adr.yaml
+++ b/.orbit/adrs/accepted/ADR-0140/adr.yaml
@@ -1,4 +1,4 @@
-schema_version: 1
+schema_version: 2
 id: ADR-0140
 title: Unified Denial Sources for Policy Dashboard
 status: accepted
@@ -10,6 +10,8 @@ related_features:
 - user-interface
 related_tasks:
 - T20260428-13
+tags: []
+paths: []
 supersedes: []
 legacy_ids:
 - user-interface/ADR-002

--- a/.orbit/adrs/accepted/ADR-0141/adr.yaml
+++ b/.orbit/adrs/accepted/ADR-0141/adr.yaml
@@ -1,4 +1,4 @@
-schema_version: 1
+schema_version: 2
 id: ADR-0141
 title: Compact Scoreboard Ratio Columns
 status: accepted
@@ -10,6 +10,8 @@ related_features:
 - user-interface
 related_tasks:
 - T20260428-15
+tags: []
+paths: []
 supersedes: []
 legacy_ids:
 - user-interface/ADR-003

--- a/.orbit/adrs/accepted/ADR-0142/adr.yaml
+++ b/.orbit/adrs/accepted/ADR-0142/adr.yaml
@@ -1,4 +1,4 @@
-schema_version: 1
+schema_version: 2
 id: ADR-0142
 title: Bounded Live Log Tail
 status: accepted
@@ -10,6 +10,8 @@ related_features:
 - user-interface
 related_tasks:
 - T20260430-29
+tags: []
+paths: []
 supersedes: []
 legacy_ids:
 - user-interface/ADR-004

--- a/.orbit/adrs/accepted/ADR-0150/adr.yaml
+++ b/.orbit/adrs/accepted/ADR-0150/adr.yaml
@@ -1,4 +1,4 @@
-schema_version: 1
+schema_version: 2
 id: ADR-0150
 title: First-class design-doc tooling surface
 status: accepted
@@ -10,6 +10,8 @@ related_features:
 - design-docs
 related_tasks:
 - ORB-00019
+tags: []
+paths: []
 supersedes: []
 legacy_ids: []
 validation_warnings: []

--- a/.orbit/adrs/accepted/ADR-0151/adr.yaml
+++ b/.orbit/adrs/accepted/ADR-0151/adr.yaml
@@ -1,4 +1,4 @@
-schema_version: 1
+schema_version: 2
 id: ADR-0151
 title: Add Grok (xAI) as a fourth peer agent family
 status: accepted
@@ -19,6 +19,8 @@ related_tasks:
 - ORB-00049
 - ORB-00050
 - ORB-00052
+tags: []
+paths: []
 supersedes: []
 legacy_ids:
 - agent-families/ADR-0151

--- a/.orbit/adrs/accepted/ADR-0153/adr.yaml
+++ b/.orbit/adrs/accepted/ADR-0153/adr.yaml
@@ -1,4 +1,4 @@
-schema_version: 1
+schema_version: 2
 id: ADR-0153
 title: Allocate ADR IDs globally via orbit.adr.add before authoring feature decision entries
 status: accepted
@@ -12,6 +12,8 @@ related_features:
 related_tasks:
 - ORB-00098
 - ORB-00019
+tags: []
+paths: []
 supersedes: []
 legacy_ids: []
 validation_warnings: []

--- a/.orbit/adrs/accepted/ADR-0154/adr.yaml
+++ b/.orbit/adrs/accepted/ADR-0154/adr.yaml
@@ -1,4 +1,4 @@
-schema_version: 1
+schema_version: 2
 id: ADR-0154
 title: Replace `[agent.<role>]` tables with named `[crews.*]` registry
 status: accepted
@@ -10,6 +10,8 @@ related_features:
 - agent-families
 related_tasks:
 - ORB-00058
+tags: []
+paths: []
 supersedes: []
 legacy_ids:
 - agent-families/ADR-0152

--- a/.orbit/adrs/accepted/ADR-0155/adr.yaml
+++ b/.orbit/adrs/accepted/ADR-0155/adr.yaml
@@ -1,4 +1,4 @@
-schema_version: 1
+schema_version: 2
 id: ADR-0155
 title: Scope duel-plan candidate and model overrides to `[duel]`
 status: accepted
@@ -10,6 +10,8 @@ related_features:
 - agent-families
 related_tasks:
 - ORB-00072
+tags: []
+paths: []
 supersedes: []
 legacy_ids:
 - agent-families/ADR-0153

--- a/.orbit/adrs/accepted/ADR-0156/adr.yaml
+++ b/.orbit/adrs/accepted/ADR-0156/adr.yaml
@@ -1,4 +1,4 @@
-schema_version: 1
+schema_version: 2
 id: ADR-0156
 title: Collapse agent identity to family and move model strings to configuration
 status: accepted
@@ -10,6 +10,8 @@ related_features:
 - agent-families
 related_tasks:
 - ORB-00080
+tags: []
+paths: []
 supersedes: []
 legacy_ids:
 - agent-families/ADR-0154

--- a/.orbit/adrs/accepted/ADR-0157/adr.yaml
+++ b/.orbit/adrs/accepted/ADR-0157/adr.yaml
@@ -1,4 +1,4 @@
-schema_version: 1
+schema_version: 2
 id: ADR-0157
 title: Rank matched learnings by task-anchored decay-weighted upvotes
 status: accepted
@@ -10,6 +10,8 @@ related_features:
 - project-learnings
 related_tasks:
 - ORB-00095
+tags: []
+paths: []
 supersedes: []
 legacy_ids:
 - project-learnings/ADR-006

--- a/.orbit/adrs/accepted/ADR-0158/adr.yaml
+++ b/.orbit/adrs/accepted/ADR-0158/adr.yaml
@@ -1,4 +1,4 @@
-schema_version: 1
+schema_version: 2
 id: ADR-0158
 title: Four numbered docs with strict role separation
 status: accepted
@@ -10,6 +10,8 @@ related_features:
 - design-docs
 related_tasks:
 - ORB-00103
+tags: []
+paths: []
 supersedes: []
 legacy_ids:
 - design-docs/ADR-001

--- a/.orbit/adrs/accepted/ADR-0159/adr.yaml
+++ b/.orbit/adrs/accepted/ADR-0159/adr.yaml
@@ -1,4 +1,4 @@
-schema_version: 1
+schema_version: 2
 id: ADR-0159
 title: Decay anchor is the `Last updated:` frontmatter field, not git mtime
 status: accepted
@@ -10,6 +10,8 @@ related_features:
 - design-docs
 related_tasks:
 - ORB-00103
+tags: []
+paths: []
 supersedes: []
 legacy_ids:
 - design-docs/ADR-002

--- a/.orbit/adrs/accepted/ADR-0160/adr.yaml
+++ b/.orbit/adrs/accepted/ADR-0160/adr.yaml
@@ -1,4 +1,4 @@
-schema_version: 1
+schema_version: 2
 id: ADR-0160
 title: ADRs earned by 3-of-3 rule, not append-permissive
 status: accepted
@@ -10,6 +10,8 @@ related_features:
 - design-docs
 related_tasks:
 - ORB-00103
+tags: []
+paths: []
 supersedes: []
 legacy_ids:
 - design-docs/ADR-003

--- a/.orbit/adrs/accepted/ADR-0161/adr.yaml
+++ b/.orbit/adrs/accepted/ADR-0161/adr.yaml
@@ -1,4 +1,4 @@
-schema_version: 1
+schema_version: 2
 id: ADR-0161
 title: Folder names lowercase, hyphenated, singular
 status: accepted
@@ -10,6 +10,8 @@ related_features:
 - design-docs
 related_tasks:
 - ORB-00103
+tags: []
+paths: []
 supersedes: []
 legacy_ids:
 - design-docs/ADR-004

--- a/.orbit/adrs/accepted/ADR-0163/adr.yaml
+++ b/.orbit/adrs/accepted/ADR-0163/adr.yaml
@@ -1,4 +1,4 @@
-schema_version: 1
+schema_version: 2
 id: ADR-0163
 title: '`init_feature` refuses to clobber an existing folder'
 status: accepted
@@ -11,6 +11,8 @@ related_features:
 related_tasks:
 - ORB-00019
 - ORB-00103
+tags: []
+paths: []
 supersedes: []
 legacy_ids:
 - design-docs/ADR-006

--- a/.orbit/adrs/accepted/ADR-0164/adr.yaml
+++ b/.orbit/adrs/accepted/ADR-0164/adr.yaml
@@ -1,4 +1,4 @@
-schema_version: 1
+schema_version: 2
 id: ADR-0164
 title: Ship PR transitions preserve task implementer attribution
 status: accepted
@@ -10,6 +10,8 @@ related_features:
 - auditability
 related_tasks:
 - ORB-00106
+tags: []
+paths: []
 supersedes: []
 legacy_ids: []
 validation_warnings: []

--- a/.orbit/adrs/accepted/ADR-0165/adr.yaml
+++ b/.orbit/adrs/accepted/ADR-0165/adr.yaml
@@ -1,4 +1,4 @@
-schema_version: 1
+schema_version: 2
 id: ADR-0165
 title: Remove per-PR design-doc decay checks
 status: accepted
@@ -10,6 +10,8 @@ related_features:
 - design-docs
 related_tasks:
 - ORB-00112
+tags: []
+paths: []
 supersedes:
 - ADR-0162
 legacy_ids: []

--- a/.orbit/adrs/accepted/ADR-0166/adr.yaml
+++ b/.orbit/adrs/accepted/ADR-0166/adr.yaml
@@ -1,4 +1,4 @@
-schema_version: 1
+schema_version: 2
 id: ADR-0166
 title: Grouped Scoreboard Sections
 status: accepted
@@ -10,6 +10,8 @@ related_features:
 - user-interface
 related_tasks:
 - ORB-00144
+tags: []
+paths: []
 supersedes: []
 legacy_ids: []
 validation_warnings: []

--- a/.orbit/adrs/accepted/ADR-0167/adr.yaml
+++ b/.orbit/adrs/accepted/ADR-0167/adr.yaml
@@ -1,4 +1,4 @@
-schema_version: 1
+schema_version: 2
 id: ADR-0167
 title: Extract Dashboard + JSON API to orbit-dashboard Crate
 status: accepted
@@ -10,6 +10,8 @@ related_features:
 - user-interface
 related_tasks:
 - ORB-00146
+tags: []
+paths: []
 supersedes: []
 legacy_ids: []
 validation_warnings: []

--- a/.orbit/adrs/accepted/ADR-0168/adr.yaml
+++ b/.orbit/adrs/accepted/ADR-0168/adr.yaml
@@ -1,4 +1,4 @@
-schema_version: 1
+schema_version: 2
 id: ADR-0168
 title: Unified Leaderboard Matrix Scoreboard
 status: accepted
@@ -10,6 +10,8 @@ related_features:
 - user-interface
 related_tasks:
 - ORB-00154
+tags: []
+paths: []
 supersedes: []
 legacy_ids: []
 validation_warnings: []

--- a/.orbit/adrs/accepted/ADR-0172/adr.yaml
+++ b/.orbit/adrs/accepted/ADR-0172/adr.yaml
@@ -1,4 +1,4 @@
-schema_version: 1
+schema_version: 2
 id: ADR-0172
 title: Retrieval crate renamed `orbit-search`; all ranking logic relocated out of `orbit-core`
 status: accepted
@@ -11,6 +11,8 @@ related_features:
 - orbit-docs
 related_tasks:
 - ORB-00192
+tags: []
+paths: []
 supersedes:
 - ADR-0119
 legacy_ids: []

--- a/.orbit/adrs/accepted/ADR-0173/adr.yaml
+++ b/.orbit/adrs/accepted/ADR-0173/adr.yaml
@@ -1,4 +1,4 @@
-schema_version: 1
+schema_version: 2
 id: ADR-0173
 title: Dashboard owns invocation metrics surfaces
 status: accepted
@@ -11,6 +11,8 @@ related_features:
 - activity-job
 related_tasks:
 - ORB-00190
+tags: []
+paths: []
 supersedes: []
 legacy_ids: []
 validation_warnings: []

--- a/.orbit/adrs/accepted/ADR-0174/adr.yaml
+++ b/.orbit/adrs/accepted/ADR-0174/adr.yaml
@@ -1,4 +1,4 @@
-schema_version: 1
+schema_version: 2
 id: ADR-0174
 title: Split lifecycle and query search namespaces
 status: accepted
@@ -10,6 +10,8 @@ related_features:
 - orbit-search
 related_tasks:
 - ORB-00196
+tags: []
+paths: []
 supersedes: []
 legacy_ids: []
 validation_warnings: []

--- a/.orbit/adrs/accepted/ADR-0175/adr.yaml
+++ b/.orbit/adrs/accepted/ADR-0175/adr.yaml
@@ -1,4 +1,4 @@
-schema_version: 1
+schema_version: 2
 id: ADR-0175
 title: Rename search mode and neighbor flags
 status: accepted
@@ -10,6 +10,8 @@ related_features:
 - orbit-search
 related_tasks:
 - ORB-00204
+tags: []
+paths: []
 supersedes: []
 legacy_ids: []
 validation_warnings: []

--- a/.orbit/adrs/accepted/ADR-0175/adr.yaml
+++ b/.orbit/adrs/accepted/ADR-0175/adr.yaml
@@ -1,0 +1,16 @@
+schema_version: 1
+id: ADR-0175
+title: Rename search mode and neighbor flags
+status: accepted
+owner: codex
+created_at: 2026-05-20T06:25:06.704684Z
+accepted_at: 2026-05-20T06:25:13.487959Z
+last_updated: 2026-05-20T06:25:13.487959Z
+related_features:
+- orbit-search
+related_tasks:
+- ORB-00204
+supersedes: []
+legacy_ids: []
+validation_warnings: []
+legacy_validation: none

--- a/.orbit/adrs/accepted/ADR-0175/body.md
+++ b/.orbit/adrs/accepted/ADR-0175/body.md
@@ -1,0 +1,11 @@
+## Context
+Phase 1 shipped `orbit search --semantic` as the hybrid BM25 plus cosine mode toggle and `orbit search --related <id>` as the cosine-neighbor task lookup. That inverted the intuitive reading of semantic search: users expect semantic plus an ID to mean nearest neighbors, while hybrid is the honest name for the ranking algorithm.
+
+## Decision
+Rename the free-text ranking toggle to `--hybrid` / `hybrid: true` and rename task-neighbor lookup to `--semantic <id>` / `semantic: "<id>"`. Keep lexical search as the default and report JSON mode `hybrid` for hybrid free-text search and `neighbor` for cosine-only task-neighbor lookup.
+
+## Consequences
+- The CLI and MCP surfaces match user vocabulary before external consumers depend on the phase-1 names.
+- Historical phase-1 audit payloads that carried `semantic: true` are orphaned by the hard break, matching the no-shim policy for this young surface.
+- Documentation and packaged skills must distinguish the `orbit semantic` lifecycle command from the `--semantic <id>` search flag.
+- Cost: Agents and docs written against phase 1 need a one-time rename sweep, and ORB-00202 may need a rebase because it edits adjacent search surfaces.

--- a/.orbit/adrs/accepted/ADR-0177/adr.yaml
+++ b/.orbit/adrs/accepted/ADR-0177/adr.yaml
@@ -1,4 +1,4 @@
-schema_version: 1
+schema_version: 2
 id: ADR-0177
 title: Worktree-local ADR and learning bodies with shared ID allocation
 status: accepted
@@ -10,6 +10,8 @@ related_features:
 - worktree-artifacts
 related_tasks:
 - ORB-00201
+tags: []
+paths: []
 supersedes: []
 legacy_ids: []
 validation_warnings: []

--- a/.orbit/adrs/accepted/ADR-0178/adr.yaml
+++ b/.orbit/adrs/accepted/ADR-0178/adr.yaml
@@ -1,0 +1,27 @@
+schema_version: 2
+id: ADR-0178
+title: ADR envelope tags and paths
+status: accepted
+owner: codex
+created_at: 2026-05-21T00:52:08.848684Z
+accepted_at: 2026-05-21T00:57:25.507617Z
+last_updated: 2026-05-21T00:57:25.507617Z
+related_features:
+- adr-artifact
+- orbit-search
+related_tasks:
+- ORB-00203
+tags:
+- adr-schema
+- cross-cutting
+- orbit-search
+- perf
+paths:
+- crates/orbit-search/**
+- crates/orbit-store/**
+- crates/orbit-core/src/command/search.rs
+- docs/design/adr-artifact/**
+supersedes: []
+legacy_ids: []
+validation_warnings: []
+legacy_validation: none

--- a/.orbit/adrs/accepted/ADR-0178/body.md
+++ b/.orbit/adrs/accepted/ADR-0178/body.md
@@ -1,0 +1,12 @@
+## Context
+Phase 2 left `--tag` and `--path` as no-op filters for ADRs because ADR envelopes had no free-form labels or applicability paths. Reusing `related_features` would collapse constrained feature-folder references into loose tags, and it still would not answer pre-edit path applicability queries.
+
+## Decision
+Add `tags: [string]` and `paths: [string]` to ADR envelope YAML, bump newly written envelopes to `schema_version: 2`, and keep v1 readers compatible by treating missing fields as empty lists. `orbit.adr.list` and `orbit search` filter ADRs through these fields with case-insensitive tag equality and glob-containment path semantics.
+
+## Consequences
+- Cross-artifact label and path queries can include ADRs alongside tasks, docs, and learnings.
+- Existing ADR envelopes are backfilled with explicit empty defaults; owners populate meaningful tags and paths when they next touch a decision.
+- No automatic inference from title, body, or related_features is attempted, keeping false labels out of durable decision metadata.
+- No single code anchor owns this behavior; it is enforced across the ADR store schema, tool schemas, search command, and their focused tests.
+- Cost: The schema bump touches every ADR envelope and adds two author-maintained metadata axes that can drift if reviewers do not keep them current.

--- a/.orbit/adrs/proposed/ADR-0015/adr.yaml
+++ b/.orbit/adrs/proposed/ADR-0015/adr.yaml
@@ -1,4 +1,4 @@
-schema_version: 1
+schema_version: 2
 id: ADR-0015
 title: Defer implementation to v2; v1 ships docs only
 status: proposed
@@ -8,6 +8,8 @@ last_updated: 2026-05-11T02:06:39.298191Z
 related_features:
 - adr-artifact
 related_tasks: []
+tags: []
+paths: []
 supersedes: []
 legacy_ids:
 - adr-artifact/ADR-001

--- a/.orbit/adrs/proposed/ADR-0016/adr.yaml
+++ b/.orbit/adrs/proposed/ADR-0016/adr.yaml
@@ -1,4 +1,4 @@
-schema_version: 1
+schema_version: 2
 id: ADR-0016
 title: Global ADR numbering, not per-feature
 status: proposed
@@ -8,6 +8,8 @@ last_updated: 2026-05-11T02:06:39.299168Z
 related_features:
 - adr-artifact
 related_tasks: []
+tags: []
+paths: []
 supersedes: []
 legacy_ids:
 - adr-artifact/ADR-002

--- a/.orbit/adrs/proposed/ADR-0017/adr.yaml
+++ b/.orbit/adrs/proposed/ADR-0017/adr.yaml
@@ -1,4 +1,4 @@
-schema_version: 1
+schema_version: 2
 id: ADR-0017
 title: Three lifecycle states; no `rejected` or `withdrawn`
 status: proposed
@@ -8,6 +8,8 @@ last_updated: 2026-05-11T02:06:39.300073Z
 related_features:
 - adr-artifact
 related_tasks: []
+tags: []
+paths: []
 supersedes: []
 legacy_ids:
 - adr-artifact/ADR-003

--- a/.orbit/adrs/proposed/ADR-0018/adr.yaml
+++ b/.orbit/adrs/proposed/ADR-0018/adr.yaml
@@ -1,4 +1,4 @@
-schema_version: 1
+schema_version: 2
 id: ADR-0018
 title: Markdown body, structured envelope
 status: proposed
@@ -8,6 +8,8 @@ last_updated: 2026-05-11T02:06:39.300899Z
 related_features:
 - adr-artifact
 related_tasks: []
+tags: []
+paths: []
 supersedes: []
 legacy_ids:
 - adr-artifact/ADR-004

--- a/.orbit/adrs/proposed/ADR-0019/adr.yaml
+++ b/.orbit/adrs/proposed/ADR-0019/adr.yaml
@@ -1,4 +1,4 @@
-schema_version: 1
+schema_version: 2
 id: ADR-0019
 title: Directory-per-ADR layout
 status: proposed
@@ -8,6 +8,8 @@ last_updated: 2026-05-11T02:06:39.301709Z
 related_features:
 - adr-artifact
 related_tasks: []
+tags: []
+paths: []
 supersedes: []
 legacy_ids:
 - adr-artifact/ADR-005

--- a/.orbit/adrs/proposed/ADR-0020/adr.yaml
+++ b/.orbit/adrs/proposed/ADR-0020/adr.yaml
@@ -1,4 +1,4 @@
-schema_version: 1
+schema_version: 2
 id: ADR-0020
 title: Auto-generate per-feature `4_decisions.md` index
 status: proposed
@@ -8,6 +8,8 @@ last_updated: 2026-05-11T02:06:39.302388Z
 related_features:
 - adr-artifact
 related_tasks: []
+tags: []
+paths: []
 supersedes: []
 legacy_ids:
 - adr-artifact/ADR-006

--- a/.orbit/adrs/proposed/ADR-0021/adr.yaml
+++ b/.orbit/adrs/proposed/ADR-0021/adr.yaml
@@ -1,4 +1,4 @@
-schema_version: 1
+schema_version: 2
 id: ADR-0021
 title: Cross-cutting ADRs use a dedicated `cross-cutting` index
 status: proposed
@@ -8,6 +8,8 @@ last_updated: 2026-05-11T02:06:39.304559Z
 related_features:
 - adr-artifact
 related_tasks: []
+tags: []
+paths: []
 supersedes: []
 legacy_ids:
 - adr-artifact/ADR-007

--- a/.orbit/adrs/proposed/ADR-0022/adr.yaml
+++ b/.orbit/adrs/proposed/ADR-0022/adr.yaml
@@ -1,4 +1,4 @@
-schema_version: 1
+schema_version: 2
 id: ADR-0022
 title: ADR creation does not require task linkage
 status: proposed
@@ -8,6 +8,8 @@ last_updated: 2026-05-11T02:06:39.305196Z
 related_features:
 - adr-artifact
 related_tasks: []
+tags: []
+paths: []
 supersedes: []
 legacy_ids:
 - adr-artifact/ADR-008

--- a/.orbit/adrs/proposed/ADR-0023/adr.yaml
+++ b/.orbit/adrs/proposed/ADR-0023/adr.yaml
@@ -1,4 +1,4 @@
-schema_version: 1
+schema_version: 2
 id: ADR-0023
 title: Review threads on ADRs
 status: proposed
@@ -8,6 +8,8 @@ last_updated: 2026-05-11T02:06:39.305811Z
 related_features:
 - adr-artifact
 related_tasks: []
+tags: []
+paths: []
 supersedes: []
 legacy_ids:
 - adr-artifact/ADR-009

--- a/.orbit/adrs/proposed/ADR-0024/adr.yaml
+++ b/.orbit/adrs/proposed/ADR-0024/adr.yaml
@@ -1,4 +1,4 @@
-schema_version: 1
+schema_version: 2
 id: ADR-0024
 title: '`orbit.adr.search` lives in `orbit-embed`, registered into `orbit-tools`'
 status: proposed
@@ -8,6 +8,8 @@ last_updated: 2026-05-11T02:06:39.306588Z
 related_features:
 - adr-artifact
 related_tasks: []
+tags: []
+paths: []
 supersedes: []
 legacy_ids:
 - adr-artifact/ADR-010

--- a/.orbit/adrs/proposed/ADR-0025/adr.yaml
+++ b/.orbit/adrs/proposed/ADR-0025/adr.yaml
@@ -1,4 +1,4 @@
-schema_version: 1
+schema_version: 2
 id: ADR-0025
 title: Lenient migration mode as default
 status: proposed
@@ -8,6 +8,8 @@ last_updated: 2026-05-11T02:06:39.307444Z
 related_features:
 - adr-artifact
 related_tasks: []
+tags: []
+paths: []
 supersedes: []
 legacy_ids:
 - adr-artifact/ADR-011

--- a/.orbit/adrs/proposed/ADR-0037/adr.yaml
+++ b/.orbit/adrs/proposed/ADR-0037/adr.yaml
@@ -1,4 +1,4 @@
-schema_version: 1
+schema_version: 2
 id: ADR-0037
 title: Friction scorekeeping derives from lifecycle history
 status: proposed
@@ -9,6 +9,8 @@ related_features:
 - auditability
 related_tasks:
 - T20260510-13
+tags: []
+paths: []
 supersedes: []
 legacy_ids:
 - auditability/ADR-012

--- a/.orbit/adrs/proposed/ADR-0057/adr.yaml
+++ b/.orbit/adrs/proposed/ADR-0057/adr.yaml
@@ -1,4 +1,4 @@
-schema_version: 1
+schema_version: 2
 id: ADR-0057
 title: Groundhog v1 excludes executor-authored deviation and retry critic
 status: proposed
@@ -10,6 +10,8 @@ related_features:
 related_tasks:
 - T20260420-0510-2
 - T20260426-0603
+tags: []
+paths: []
 supersedes: []
 legacy_ids:
 - groundhog/ADR-008

--- a/.orbit/adrs/proposed/ADR-0058/adr.yaml
+++ b/.orbit/adrs/proposed/ADR-0058/adr.yaml
@@ -1,4 +1,4 @@
-schema_version: 1
+schema_version: 2
 id: ADR-0058
 title: Separate prompt-facing memory from audit record
 status: proposed
@@ -10,6 +10,8 @@ related_features:
 related_tasks:
 - T20260420-0509
 - T20260420-0510-2
+tags: []
+paths: []
 supersedes: []
 legacy_ids:
 - groundhog/ADR-009

--- a/.orbit/adrs/proposed/ADR-0068/adr.yaml
+++ b/.orbit/adrs/proposed/ADR-0068/adr.yaml
@@ -1,4 +1,4 @@
-schema_version: 1
+schema_version: 2
 id: ADR-0068
 title: Orbit-owned symbol-level write operations
 status: proposed
@@ -9,6 +9,8 @@ related_features:
 - knowledge-graph
 related_tasks:
 - T20260421-0543
+tags: []
+paths: []
 supersedes: []
 legacy_ids:
 - knowledge-graph/ADR-010

--- a/.orbit/adrs/proposed/ADR-0121/adr.yaml
+++ b/.orbit/adrs/proposed/ADR-0121/adr.yaml
@@ -1,4 +1,4 @@
-schema_version: 1
+schema_version: 2
 id: ADR-0121
 title: Restore code-graph task attribution as the lineage consumer
 status: proposed
@@ -8,6 +8,8 @@ last_updated: 2026-05-11T02:06:39.428279Z
 related_features:
 - task-lineage
 related_tasks: []
+tags: []
+paths: []
 supersedes: []
 legacy_ids:
 - task-lineage/ADR-001

--- a/.orbit/adrs/proposed/ADR-0122/adr.yaml
+++ b/.orbit/adrs/proposed/ADR-0122/adr.yaml
@@ -1,4 +1,4 @@
-schema_version: 1
+schema_version: 2
 id: ADR-0122
 title: Typed edges over flat `related_task_ids`
 status: proposed
@@ -8,6 +8,8 @@ last_updated: 2026-05-11T02:06:39.429168Z
 related_features:
 - task-lineage
 related_tasks: []
+tags: []
+paths: []
 supersedes: []
 legacy_ids:
 - task-lineage/ADR-002

--- a/.orbit/adrs/proposed/ADR-0123/adr.yaml
+++ b/.orbit/adrs/proposed/ADR-0123/adr.yaml
@@ -1,4 +1,4 @@
-schema_version: 1
+schema_version: 2
 id: ADR-0123
 title: Derivation-first edges; declared edges are the exception
 status: proposed
@@ -8,6 +8,8 @@ last_updated: 2026-05-11T02:06:39.429901Z
 related_features:
 - task-lineage
 related_tasks: []
+tags: []
+paths: []
 supersedes: []
 legacy_ids:
 - task-lineage/ADR-003

--- a/.orbit/adrs/proposed/ADR-0124/adr.yaml
+++ b/.orbit/adrs/proposed/ADR-0124/adr.yaml
@@ -1,4 +1,4 @@
-schema_version: 1
+schema_version: 2
 id: ADR-0124
 title: SQLite edge table, not per-task YAML
 status: proposed
@@ -8,6 +8,8 @@ last_updated: 2026-05-11T02:06:39.430623Z
 related_features:
 - task-lineage
 related_tasks: []
+tags: []
+paths: []
 supersedes: []
 legacy_ids:
 - task-lineage/ADR-004

--- a/.orbit/adrs/proposed/ADR-0125/adr.yaml
+++ b/.orbit/adrs/proposed/ADR-0125/adr.yaml
@@ -1,4 +1,4 @@
-schema_version: 1
+schema_version: 2
 id: ADR-0125
 title: Lineage is workspace-local; cross-machine reach via external_refs render
 status: proposed
@@ -8,6 +8,8 @@ last_updated: 2026-05-11T02:06:39.431406Z
 related_features:
 - task-lineage
 related_tasks: []
+tags: []
+paths: []
 supersedes: []
 legacy_ids:
 - task-lineage/ADR-005

--- a/.orbit/adrs/proposed/ADR-0126/adr.yaml
+++ b/.orbit/adrs/proposed/ADR-0126/adr.yaml
@@ -1,4 +1,4 @@
-schema_version: 1
+schema_version: 2
 id: ADR-0126
 title: Closure operations as primary surface; raw edges as escape hatch
 status: proposed
@@ -8,6 +8,8 @@ last_updated: 2026-05-11T02:06:39.432173Z
 related_features:
 - task-lineage
 related_tasks: []
+tags: []
+paths: []
 supersedes: []
 legacy_ids:
 - task-lineage/ADR-006

--- a/.orbit/adrs/proposed/ADR-0127/adr.yaml
+++ b/.orbit/adrs/proposed/ADR-0127/adr.yaml
@@ -1,4 +1,4 @@
-schema_version: 1
+schema_version: 2
 id: ADR-0127
 title: 'Bipartite graph: tasks and code as one structure, not two stitched'
 status: proposed
@@ -8,6 +8,8 @@ last_updated: 2026-05-11T02:06:39.432944Z
 related_features:
 - task-lineage
 related_tasks: []
+tags: []
+paths: []
 supersedes: []
 legacy_ids:
 - task-lineage/ADR-007

--- a/.orbit/adrs/proposed/ADR-0128/adr.yaml
+++ b/.orbit/adrs/proposed/ADR-0128/adr.yaml
@@ -1,4 +1,4 @@
-schema_version: 1
+schema_version: 2
 id: ADR-0128
 title: Symbol-biography surface is the minimal Phase 1 read surface
 status: proposed
@@ -8,6 +8,8 @@ last_updated: 2026-05-11T02:06:39.433708Z
 related_features:
 - task-lineage
 related_tasks: []
+tags: []
+paths: []
 supersedes: []
 legacy_ids:
 - task-lineage/ADR-008

--- a/.orbit/adrs/proposed/ADR-0129/adr.yaml
+++ b/.orbit/adrs/proposed/ADR-0129/adr.yaml
@@ -1,4 +1,4 @@
-schema_version: 1
+schema_version: 2
 id: ADR-0129
 title: Deterministic, templated renderer in Phase 1; LLM summarization deferred
 status: proposed
@@ -8,6 +8,8 @@ last_updated: 2026-05-11T02:06:39.434466Z
 related_features:
 - task-lineage
 related_tasks: []
+tags: []
+paths: []
 supersedes: []
 legacy_ids:
 - task-lineage/ADR-009

--- a/.orbit/adrs/proposed/ADR-0130/adr.yaml
+++ b/.orbit/adrs/proposed/ADR-0130/adr.yaml
@@ -1,4 +1,4 @@
-schema_version: 1
+schema_version: 2
 id: ADR-0130
 title: Symbol identity stability is a load-bearing assumption; failure modes are named, not designed away
 status: proposed
@@ -8,6 +8,8 @@ last_updated: 2026-05-11T02:06:39.435248Z
 related_features:
 - task-lineage
 related_tasks: []
+tags: []
+paths: []
 supersedes: []
 legacy_ids:
 - task-lineage/ADR-010

--- a/.orbit/adrs/proposed/ADR-0131/adr.yaml
+++ b/.orbit/adrs/proposed/ADR-0131/adr.yaml
@@ -1,4 +1,4 @@
-schema_version: 1
+schema_version: 2
 id: ADR-0131
 title: Orphan branch as registry mechanism
 status: proposed
@@ -9,6 +9,8 @@ related_features:
 - task-sync
 related_tasks:
 - T20260505-12
+tags: []
+paths: []
 supersedes: []
 legacy_ids:
 - task-sync/ADR-001

--- a/.orbit/adrs/proposed/ADR-0132/adr.yaml
+++ b/.orbit/adrs/proposed/ADR-0132/adr.yaml
@@ -1,4 +1,4 @@
-schema_version: 1
+schema_version: 2
 id: ADR-0132
 title: Operation-aware replay over text-merge or event sourcing
 status: proposed
@@ -9,6 +9,8 @@ related_features:
 - task-sync
 related_tasks:
 - T20260505-12
+tags: []
+paths: []
 supersedes: []
 legacy_ids:
 - task-sync/ADR-002

--- a/.orbit/adrs/proposed/ADR-0133/adr.yaml
+++ b/.orbit/adrs/proposed/ADR-0133/adr.yaml
@@ -1,4 +1,4 @@
-schema_version: 1
+schema_version: 2
 id: ADR-0133
 title: Sync scope is task bundles + companion files + artifacts
 status: proposed
@@ -9,6 +9,8 @@ related_features:
 - task-sync
 related_tasks:
 - T20260505-12
+tags: []
+paths: []
 supersedes: []
 legacy_ids:
 - task-sync/ADR-003

--- a/.orbit/adrs/proposed/ADR-0134/adr.yaml
+++ b/.orbit/adrs/proposed/ADR-0134/adr.yaml
@@ -1,4 +1,4 @@
-schema_version: 1
+schema_version: 2
 id: ADR-0134
 title: ID allocation against fetched registry; format unchanged
 status: proposed
@@ -9,6 +9,8 @@ related_features:
 - task-sync
 related_tasks:
 - T20260505-12
+tags: []
+paths: []
 supersedes: []
 legacy_ids:
 - task-sync/ADR-004

--- a/.orbit/adrs/proposed/ADR-0135/adr.yaml
+++ b/.orbit/adrs/proposed/ADR-0135/adr.yaml
@@ -1,4 +1,4 @@
-schema_version: 1
+schema_version: 2
 id: ADR-0135
 title: Auth piggybacks on git remote credential helper
 status: proposed
@@ -9,6 +9,8 @@ related_features:
 - task-sync
 related_tasks:
 - T20260505-12
+tags: []
+paths: []
 supersedes: []
 legacy_ids:
 - task-sync/ADR-005

--- a/.orbit/adrs/proposed/ADR-0136/adr.yaml
+++ b/.orbit/adrs/proposed/ADR-0136/adr.yaml
@@ -1,4 +1,4 @@
-schema_version: 1
+schema_version: 2
 id: ADR-0136
 title: '`git2` (libgit2) over shelling to `git`'
 status: proposed
@@ -9,6 +9,8 @@ related_features:
 - task-sync
 related_tasks:
 - T20260505-12
+tags: []
+paths: []
 supersedes: []
 legacy_ids:
 - task-sync/ADR-006

--- a/.orbit/adrs/proposed/ADR-0137/adr.yaml
+++ b/.orbit/adrs/proposed/ADR-0137/adr.yaml
@@ -1,4 +1,4 @@
-schema_version: 1
+schema_version: 2
 id: ADR-0137
 title: Sync ships in v2; v1 is per-engineer
 status: proposed
@@ -9,6 +9,8 @@ related_features:
 - task-sync
 related_tasks:
 - T20260505-12
+tags: []
+paths: []
 supersedes: []
 legacy_ids:
 - task-sync/ADR-007

--- a/.orbit/adrs/proposed/ADR-0138/adr.yaml
+++ b/.orbit/adrs/proposed/ADR-0138/adr.yaml
@@ -1,4 +1,4 @@
-schema_version: 1
+schema_version: 2
 id: ADR-0138
 title: Deletion writes a tombstone, not a hard removal
 status: proposed
@@ -9,6 +9,8 @@ related_features:
 - task-sync
 related_tasks:
 - T20260505-12
+tags: []
+paths: []
 supersedes: []
 legacy_ids:
 - task-sync/ADR-008

--- a/.orbit/adrs/proposed/ADR-0139/adr.yaml
+++ b/.orbit/adrs/proposed/ADR-0139/adr.yaml
@@ -1,4 +1,4 @@
-schema_version: 1
+schema_version: 2
 id: ADR-0139
 title: Canon Refined Aesthetic
 status: proposed
@@ -9,6 +9,8 @@ related_features:
 - user-interface
 related_tasks:
 - T20260427-29
+tags: []
+paths: []
 supersedes: []
 legacy_ids:
 - user-interface/ADR-001

--- a/.orbit/adrs/proposed/ADR-0143/adr.yaml
+++ b/.orbit/adrs/proposed/ADR-0143/adr.yaml
@@ -1,4 +1,4 @@
-schema_version: 1
+schema_version: 2
 id: ADR-0143
 title: Authority-scoped `ORB-00000` task IDs
 status: proposed
@@ -8,6 +8,8 @@ last_updated: 2026-05-11T04:45:33.101933Z
 related_features:
 - task-artifacts
 related_tasks: []
+tags: []
+paths: []
 supersedes: []
 legacy_ids:
 - task-artifacts/ADR-001

--- a/.orbit/adrs/proposed/ADR-0144/adr.yaml
+++ b/.orbit/adrs/proposed/ADR-0144/adr.yaml
@@ -1,4 +1,4 @@
-schema_version: 1
+schema_version: 2
 id: ADR-0144
 title: Envelope YAML plus Markdown sidecars for prose
 status: proposed
@@ -8,6 +8,8 @@ last_updated: 2026-05-11T04:36:09.005916Z
 related_features:
 - task-artifacts
 related_tasks: []
+tags: []
+paths: []
 supersedes: []
 legacy_ids:
 - task-artifacts/ADR-002

--- a/.orbit/adrs/proposed/ADR-0145/adr.yaml
+++ b/.orbit/adrs/proposed/ADR-0145/adr.yaml
@@ -1,4 +1,4 @@
-schema_version: 1
+schema_version: 2
 id: ADR-0145
 title: Status-neutral task directories
 status: proposed
@@ -8,6 +8,8 @@ last_updated: 2026-05-11T04:45:33.205604Z
 related_features:
 - task-artifacts
 related_tasks: []
+tags: []
+paths: []
 supersedes: []
 legacy_ids:
 - task-artifacts/ADR-003

--- a/.orbit/adrs/proposed/ADR-0146/adr.yaml
+++ b/.orbit/adrs/proposed/ADR-0146/adr.yaml
@@ -1,4 +1,4 @@
-schema_version: 1
+schema_version: 2
 id: ADR-0146
 title: Append-heavy task data leaves `task.yaml`
 status: proposed
@@ -8,6 +8,8 @@ last_updated: 2026-05-11T04:36:09.226467Z
 related_features:
 - task-artifacts
 related_tasks: []
+tags: []
+paths: []
 supersedes: []
 legacy_ids:
 - task-artifacts/ADR-004

--- a/.orbit/adrs/proposed/ADR-0147/adr.yaml
+++ b/.orbit/adrs/proposed/ADR-0147/adr.yaml
@@ -1,4 +1,4 @@
-schema_version: 1
+schema_version: 2
 id: ADR-0147
 title: Typed relations over scattered link fields
 status: proposed
@@ -8,6 +8,8 @@ last_updated: 2026-05-11T04:36:09.329212Z
 related_features:
 - task-artifacts
 related_tasks: []
+tags: []
+paths: []
 supersedes: []
 legacy_ids:
 - task-artifacts/ADR-005

--- a/.orbit/adrs/proposed/ADR-0148/adr.yaml
+++ b/.orbit/adrs/proposed/ADR-0148/adr.yaml
@@ -1,4 +1,4 @@
-schema_version: 1
+schema_version: 2
 id: ADR-0148
 title: Artifact manifest with binary-capable files
 status: proposed
@@ -8,6 +8,8 @@ last_updated: 2026-05-11T04:03:45.924692Z
 related_features:
 - task-artifacts
 related_tasks: []
+tags: []
+paths: []
 supersedes: []
 legacy_ids:
 - task-artifacts/ADR-006

--- a/.orbit/adrs/proposed/ADR-0149/adr.yaml
+++ b/.orbit/adrs/proposed/ADR-0149/adr.yaml
@@ -1,4 +1,4 @@
-schema_version: 1
+schema_version: 2
 id: ADR-0149
 title: Home task store with workspace symlink projection
 status: proposed
@@ -8,6 +8,8 @@ last_updated: 2026-05-11T04:45:33.306928Z
 related_features:
 - task-artifacts
 related_tasks: []
+tags: []
+paths: []
 supersedes: []
 legacy_ids:
 - task-artifacts/ADR-007

--- a/.orbit/adrs/proposed/ADR-0152/adr.yaml
+++ b/.orbit/adrs/proposed/ADR-0152/adr.yaml
@@ -1,4 +1,4 @@
-schema_version: 1
+schema_version: 2
 id: ADR-0152
 title: Unify task shipment under async ship dispatch
 status: proposed
@@ -9,6 +9,8 @@ related_features:
 - activity-job
 related_tasks:
 - ORB-00075
+tags: []
+paths: []
 supersedes: []
 legacy_ids:
 - activity-job/ADR-052

--- a/.orbit/adrs/proposed/ADR-0167/adr.yaml
+++ b/.orbit/adrs/proposed/ADR-0167/adr.yaml
@@ -1,4 +1,4 @@
-schema_version: 1
+schema_version: 2
 id: ADR-0167
 title: Favor claude (opus) for planner role on planning duels and design-shaped plans
 status: proposed
@@ -8,6 +8,8 @@ last_updated: 2026-05-18T07:14:47.374554Z
 related_features:
 - agent-families
 related_tasks: []
+tags: []
+paths: []
 supersedes: []
 legacy_ids: []
 validation_warnings: []

--- a/.orbit/adrs/proposed/ADR-0169/adr.yaml
+++ b/.orbit/adrs/proposed/ADR-0169/adr.yaml
@@ -1,4 +1,4 @@
-schema_version: 1
+schema_version: 2
 id: ADR-0169
 title: Locked orbit-docs frontmatter schema
 status: proposed
@@ -9,6 +9,8 @@ related_features:
 - orbit-docs
 related_tasks:
 - ORB-00163
+tags: []
+paths: []
 supersedes: []
 legacy_ids: []
 validation_warnings: []

--- a/.orbit/adrs/proposed/ADR-0170/adr.yaml
+++ b/.orbit/adrs/proposed/ADR-0170/adr.yaml
@@ -1,4 +1,4 @@
-schema_version: 1
+schema_version: 2
 id: ADR-0170
 title: '`.orbit/` for tool-managed artifacts; `docs/` for human-authored content'
 status: proposed
@@ -9,6 +9,8 @@ related_features:
 - orbit-docs
 related_tasks:
 - ORB-00163
+tags: []
+paths: []
 supersedes: []
 legacy_ids: []
 validation_warnings: []

--- a/.orbit/adrs/proposed/ADR-0171/adr.yaml
+++ b/.orbit/adrs/proposed/ADR-0171/adr.yaml
@@ -1,4 +1,4 @@
-schema_version: 1
+schema_version: 2
 id: ADR-0171
 title: ID-prefix dispatch for orbit-docs `related_artifacts`
 status: proposed
@@ -9,6 +9,8 @@ related_features:
 - orbit-docs
 related_tasks:
 - ORB-00163
+tags: []
+paths: []
 supersedes: []
 legacy_ids: []
 validation_warnings: []

--- a/.orbit/adrs/superseded/ADR-0062/adr.yaml
+++ b/.orbit/adrs/superseded/ADR-0062/adr.yaml
@@ -1,4 +1,4 @@
-schema_version: 1
+schema_version: 2
 id: ADR-0062
 title: Shell out to the `git` CLI instead of an in-process library
 status: superseded
@@ -10,6 +10,8 @@ related_features:
 - knowledge-graph
 related_tasks:
 - T20260421-0528
+tags: []
+paths: []
 supersedes: []
 superseded_by: ADR-0083
 legacy_ids:

--- a/.orbit/adrs/superseded/ADR-0064/adr.yaml
+++ b/.orbit/adrs/superseded/ADR-0064/adr.yaml
@@ -1,4 +1,4 @@
-schema_version: 1
+schema_version: 2
 id: ADR-0064
 title: Hunk-to-symbol attribution by line-range overlap only
 status: superseded
@@ -10,6 +10,8 @@ related_features:
 - knowledge-graph
 related_tasks:
 - T20260421-0528
+tags: []
+paths: []
 supersedes: []
 superseded_by: ADR-0083
 legacy_ids:

--- a/.orbit/adrs/superseded/ADR-0065/adr.yaml
+++ b/.orbit/adrs/superseded/ADR-0065/adr.yaml
@@ -1,4 +1,4 @@
-schema_version: 1
+schema_version: 2
 id: ADR-0065
 title: Task-ID attribution is a flat union, not state-aware
 status: superseded
@@ -10,6 +10,8 @@ related_features:
 - knowledge-graph
 related_tasks:
 - T20260421-0528
+tags: []
+paths: []
 supersedes: []
 superseded_by: ADR-0083
 legacy_ids:

--- a/.orbit/adrs/superseded/ADR-0074/adr.yaml
+++ b/.orbit/adrs/superseded/ADR-0074/adr.yaml
@@ -1,4 +1,4 @@
-schema_version: 1
+schema_version: 2
 id: ADR-0074
 title: Task-id graph search as a scan filter, not a sidecar index
 status: superseded
@@ -10,6 +10,8 @@ related_features:
 - knowledge-graph
 related_tasks:
 - T20260426-0220
+tags: []
+paths: []
 supersedes: []
 superseded_by: ADR-0083
 legacy_ids:

--- a/.orbit/adrs/superseded/ADR-0078/adr.yaml
+++ b/.orbit/adrs/superseded/ADR-0078/adr.yaml
@@ -1,4 +1,4 @@
-schema_version: 1
+schema_version: 2
 id: ADR-0078
 title: Configurable task-ID extraction with manifest-driven backfill
 status: superseded
@@ -10,6 +10,8 @@ related_features:
 - knowledge-graph
 related_tasks:
 - T20260426-0507
+tags: []
+paths: []
 supersedes: []
 superseded_by: ADR-0083
 legacy_ids:

--- a/.orbit/adrs/superseded/ADR-0080/adr.yaml
+++ b/.orbit/adrs/superseded/ADR-0080/adr.yaml
@@ -1,4 +1,4 @@
-schema_version: 1
+schema_version: 2
 id: ADR-0080
 title: Align graph task-ID grammar with task-store IDs
 status: superseded
@@ -10,6 +10,8 @@ related_features:
 - knowledge-graph
 related_tasks:
 - T20260428-1
+tags: []
+paths: []
 supersedes: []
 superseded_by: ADR-0083
 legacy_ids:

--- a/.orbit/adrs/superseded/ADR-0119/adr.yaml
+++ b/.orbit/adrs/superseded/ADR-0119/adr.yaml
@@ -1,4 +1,4 @@
-schema_version: 1
+schema_version: 2
 id: ADR-0119
 title: Semantic-search ownership relocated to `orbit-embed`
 status: superseded
@@ -10,6 +10,8 @@ related_features:
 - semantic-search
 related_tasks:
 - T20260510-20
+tags: []
+paths: []
 supersedes: []
 superseded_by: ADR-0172
 legacy_ids:

--- a/.orbit/adrs/superseded/ADR-0162/adr.yaml
+++ b/.orbit/adrs/superseded/ADR-0162/adr.yaml
@@ -1,4 +1,4 @@
-schema_version: 1
+schema_version: 2
 id: ADR-0162
 title: Promote python decay checker to first-class `orbit design` CLI + MCP
 status: superseded
@@ -11,6 +11,8 @@ related_features:
 related_tasks:
 - ORB-00019
 - ORB-00103
+tags: []
+paths: []
 supersedes: []
 superseded_by: ADR-0165
 legacy_ids:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,10 @@
 ### Breaking Changes
 
 - **Per-domain `search` subcommands removed; cross-kind filters on `orbit search`**: `orbit task search`, `orbit docs search`, `orbit learning search` (and the matching `orbit.task.search`, `orbit.docs.search`, `orbit.learning.search` MCP tools) are hard-removed. Replacement: `orbit search --kind {task,doc,learning,adr,all} <query>` for content-similarity, and `orbit <kind> list --filter` for structural filters. `orbit search` gains four new flags:
-  - `--tag <T>` (repeatable, AND semantics; applies to task/doc/learning; ADR returns empty until phase 3).
+  - `--tag <T>` (repeatable, AND semantics; applies to task/doc/learning/ADR).
   - `--all` — kind-aware status widener (task: adds `done,rejected,archived`; learning + adr: adds `superseded`; doc: no-op).
   - `--status <comma-set>` — explicit per-kind override.
-  - `--path <P>` — cross-kind applicability filter (task: selector-mapping over `context_files`; learning: glob-containment over `scope.paths`; ADR/doc no-op until phase 3).
+  - `--path <P>` — cross-kind applicability filter (task: selector-mapping over `context_files`; learning: glob-containment over `scope.paths`; ADR: glob-containment over `paths`; doc remains content-indexed and returns empty).
   The old `--include-superseded` mental model is covered by `orbit search --kind adr --all`. `orbit task list` and `orbit.task.list` gain a new `--path` parameter (selector-mapping). **Behavior change** (called out): `orbit learning list --path` flips from exact-match to glob-containment — a learning with `scope.paths: ['src/auth/**']` now returns on `--path src/auth/login.rs` (previously returned only on exact `src/auth/**` match). Audit event names `orbit.task.search` / `orbit.docs.search` / `orbit.learning.search` are orphaned by the no-shim deletion. ([ORB-00202])
 - **`orbit search` flag rename**: free-text vector ranking is now `--hybrid` / `hybrid: true`; task-neighbor lookup is now `--semantic <id>` / `semantic: "<id>"`. The old `--semantic` boolean and `--related <id>` surfaces are hard-removed; JSON mode values are now `hybrid` and `neighbor`. Historical phase-1 audit payloads carrying `semantic: true` are orphaned by the no-shim rename. ([ORB-00204])
 - **Design-doc decay-check surface removed**: `orbit design check`, `orbit.design.check` MCP tool, the wrapper script, and `make check-design-docs` are gone. Use `orbit design init/list/show` + same-PR update rule. ([ORB-00112])
@@ -16,6 +16,7 @@
 
 ### Features
 
+- **ADR envelope v2 tags and paths**: ADR `adr.yaml` envelopes now carry `schema_version: 2` plus `tags` and `paths` fields. Existing ADR envelopes are backfilled with explicit empty lists, `orbit.adr.add` / `orbit.adr.update` accept the new fields, `orbit.adr.list` filters by `tag` and `path`, and the phase-2 `orbit search --tag/--path --kind adr` deferrals are closed. ([ORB-00203])
 - **`orbit-guide` first-time-setup skill** with explicit carve-out from the `orbit` router; seeded skill set 11 → 12. ([ORB-00126])
 - **Secret redaction at the artifact write boundary**: action-keyed sanitizer at the tool-host entrance covers ADR / learning / task / review-thread / friction writes; whole-token credentials reject via `OrbitError::SensitiveInput`; responses gain `redactions_applied: bool`. ([ORB-00138])
 - **`orbit run duel-plan` non-blocking by default**; `--wait` opts back in. ([ORB-00125])

--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ Two install surfaces. The CLI gives you the full power of Orbit. Choose the plug
 | | `orbit.graph.refs` | List references to a symbol |
 | | `orbit.graph.history` | Git history for a symbol |
 | | `orbit.graph.pack` | Bundle a connected slice of the graph for a prompt |
-| **search** | `orbit.search` | Unified search across tasks, docs, learnings, and ADRs. `kind` narrows the corpus; `hybrid: true` opts task results into BM25 + cosine ranking; `semantic: "<task-id>"` returns cosine neighbors. Cross-kind filters: `tag` (AND), `all` (kind-aware status widener), `status` (explicit set), `path` (selector-mapping for tasks, glob-containment for learnings; ADR/doc no-op until phase 3). |
+| **search** | `orbit.search` | Unified search across tasks, docs, learnings, and ADRs. `kind` narrows the corpus; `hybrid: true` opts task results into BM25 + cosine ranking; `semantic: "<task-id>"` returns cosine neighbors. Cross-kind filters: `tag` (AND), `all` (kind-aware status widener), `status` (explicit set), `path` (selector-mapping for tasks, glob-containment for learnings/ADRs; docs remain content-indexed). |
 | **semantic** | `orbit.semantic.install` | Install the local embedding companion and model |
 | | `orbit.semantic.uninstall` | Remove the embedding companion and/or models |
 | | `orbit.semantic.stats` | Show companion and index status |

--- a/crates/orbit-cli/src/command/mod.rs
+++ b/crates/orbit-cli/src/command/mod.rs
@@ -159,8 +159,8 @@ mod tests {
     use clap::Parser;
 
     use super::{
-        Cli, Commands, hook::HookSubcommand, mcp::McpSubcommand, semantic::SemanticSubcommand,
-        web::WebSubcommand,
+        Cli, Commands, hook::HookSubcommand, mcp::McpSubcommand, search::SearchKindArg,
+        semantic::SemanticSubcommand, web::WebSubcommand,
     };
 
     #[test]
@@ -272,6 +272,19 @@ mod tests {
             Commands::Search(args) => {
                 assert_eq!(args.query, None);
                 assert_eq!(args.semantic.as_deref(), Some("ORB-1"));
+            }
+            _ => panic!("expected top-level search command"),
+        }
+    }
+
+    #[test]
+    fn cli_parses_top_level_search_tag_only_filter() {
+        let cli = Cli::parse_from(["orbit", "search", "--tag", "perf", "--kind", "adr"]);
+        match cli.command {
+            Commands::Search(args) => {
+                assert_eq!(args.query, None);
+                assert_eq!(args.tags, vec!["perf"]);
+                assert_eq!(args.kind, SearchKindArg::Adr);
             }
             _ => panic!("expected top-level search command"),
         }

--- a/crates/orbit-cli/src/command/search.rs
+++ b/crates/orbit-cli/src/command/search.rs
@@ -6,7 +6,7 @@ use crate::command::Execute;
 #[derive(Args)]
 #[command(
     about = "Search tasks, docs, learnings, and ADRs",
-    after_help = "Index coverage note: vector search runs against tasks only today; docs, learnings, and ADRs use lexical matching regardless of --hybrid.\n\nADR support for --tag and --path is deferred to phase 3 (ORB-00203); for --kind adr those filters return empty."
+    after_help = "Index coverage note: vector search runs against tasks only today; docs, learnings, and ADRs use lexical matching regardless of --hybrid."
 )]
 #[command(group(
     ArgGroup::new("query_mode")
@@ -15,7 +15,7 @@ use crate::command::Execute;
 ))]
 #[command(group(
     ArgGroup::new("search_input")
-        .args(["query", "semantic", "path"])
+        .args(["query", "semantic", "path", "tags"])
         .required(true)
         .multiple(true)
 ))]
@@ -43,8 +43,7 @@ pub struct SearchCommand {
     /// Optional semantic embedding model alias, such as bge-small.
     #[arg(long)]
     pub model: Option<String>,
-    /// Filter by tag (AND semantics). Applies to task, doc, learning; ADR
-    /// is deferred to phase 3 and returns empty when this is set.
+    /// Filter by tag (AND semantics). Applies to task, doc, learning, and ADR.
     #[arg(long = "tag", action = ArgAction::Append, value_delimiter = ',')]
     pub tags: Vec<String>,
     /// Include normally-hidden statuses for the queried kind. Task adds
@@ -58,8 +57,8 @@ pub struct SearchCommand {
     pub status: Vec<String>,
     /// Filter to artifacts applicable to this filesystem path. Task: selector
     /// containment over `context_files`. Learning: glob-containment over
-    /// `scope.paths`. ADR: deferred to phase 3 (returns empty). Doc: out of
-    /// scope (returns empty).
+    /// `scope.paths`. ADR: glob-containment over `paths`. Doc: out of scope
+    /// (returns empty).
     #[arg(long)]
     pub path: Option<String>,
     /// Output as JSON.

--- a/crates/orbit-common/src/types/adr.rs
+++ b/crates/orbit-common/src/types/adr.rs
@@ -23,6 +23,7 @@
 //!
 //! See [`AdrStatus::validate_transition`] for the implementation.
 
+use std::collections::BTreeSet;
 use std::fmt::{Display, Formatter};
 use std::str::FromStr;
 
@@ -167,6 +168,10 @@ pub struct Adr {
     #[serde(default)]
     pub related_tasks: Vec<String>,
     #[serde(default)]
+    pub tags: Vec<String>,
+    #[serde(default)]
+    pub paths: Vec<String>,
+    #[serde(default)]
     pub supersedes: Vec<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub superseded_by: Option<String>,
@@ -225,6 +230,35 @@ pub fn validate_adr_id(id: &str) -> Result<(), OrbitError> {
 /// natural width.
 pub fn legacy_id_for(feature: &str, local_number: u32) -> String {
     format!("{feature}/ADR-{local_number:03}")
+}
+
+/// Lowercase + trim + dedupe ADR tag strings.
+///
+/// ADR tags share the task/learning free-form label semantics, while
+/// `related_features` remains the constrained structural feature reference.
+pub fn normalize_adr_tags(raw_tags: Vec<String>) -> Vec<String> {
+    let mut normalized = Vec::with_capacity(raw_tags.len());
+    let mut seen = BTreeSet::new();
+    for raw in raw_tags {
+        let tag = raw.trim().to_lowercase();
+        if !tag.is_empty() && seen.insert(tag.clone()) {
+            normalized.push(tag);
+        }
+    }
+    normalized
+}
+
+/// Trim + dedupe ADR applicability path globs, preserving case.
+pub fn normalize_adr_paths(raw_paths: Vec<String>) -> Vec<String> {
+    let mut normalized = Vec::with_capacity(raw_paths.len());
+    let mut seen = BTreeSet::new();
+    for raw in raw_paths {
+        let path = raw.trim().to_string();
+        if !path.is_empty() && seen.insert(path.clone()) {
+            normalized.push(path);
+        }
+    }
+    normalized
 }
 
 #[cfg(test)]
@@ -355,6 +389,8 @@ mod tests {
             last_updated: ts(2026, 5, 12),
             related_features: vec!["knowledge-graph".to_string()],
             related_tasks: vec!["T20260511-1".to_string()],
+            tags: vec!["schema".to_string(), "cross-cutting".to_string()],
+            paths: vec!["crates/orbit-store/**".to_string()],
             supersedes: vec!["ADR-0001".to_string()],
             superseded_by: None,
             legacy_ids: vec![
@@ -386,6 +422,8 @@ last_updated: 2026-05-11T00:00:00Z
         assert!(adr.superseded_by.is_none());
         assert!(adr.related_features.is_empty());
         assert!(adr.related_tasks.is_empty());
+        assert!(adr.tags.is_empty());
+        assert!(adr.paths.is_empty());
         assert!(adr.supersedes.is_empty());
         assert!(adr.legacy_ids.is_empty());
         assert!(adr.validation_warnings.is_empty());

--- a/crates/orbit-common/src/types/mod.rs
+++ b/crates/orbit-common/src/types/mod.rs
@@ -65,7 +65,10 @@ pub use actor::{
     ActorIdentity, agent_from_model, normalize_attribution_label,
     normalize_optional_attribution_label, provider_from_model,
 };
-pub use adr::{Adr, AdrStatus, LegacyValidation, legacy_id_for, validate_adr_id};
+pub use adr::{
+    Adr, AdrStatus, LegacyValidation, legacy_id_for, normalize_adr_paths, normalize_adr_tags,
+    validate_adr_id,
+};
 pub use agent_family::AgentFamily;
 pub use agent_pair::{
     AgentModelPair, Crew, CrewRoleAssignment, agent_family_from_cli, all_agent_families,

--- a/crates/orbit-core/assets/skills/orbit-adr/SKILL.md
+++ b/crates/orbit-core/assets/skills/orbit-adr/SKILL.md
@@ -57,8 +57,10 @@ Both produce orphan decisions invisible to `orbit.adr.list`, `orbit.adr.show`, a
 3. Write the body with exactly the required sections: `## Context`, `## Decision`, `## Consequences`.
 4. Include at least one consequences bullet starting with `Cost:`.
 5. Set `related_features` to feature folder names such as `task-artifacts`, `activity-job`, or `policy-sandbox`.
-6. Leave `related_tasks` empty for speculative proposed ADRs when no task exists yet. Do not create or invent a task just to satisfy an ADR proposal. Acceptance requires a real related task.
-7. **Close the loop with a source citation when the ADR has a code anchor.** If the ADR encodes a constraint enforced at a small set of code sites — a `ToolParam` requiring a field, a validation check, a guarded code path — drop a one-line citation comment at each enforcement site in the Rust source so the next reader of that line sees the rationale before they reason their way to weakening it:
+6. Populate `tags` with free-form labels when the decision should join cross-artifact label queries such as `orbit search --tag auth --kind all`. Keep `related_features` for structural feature-folder names.
+7. Populate `paths` with repo-relative globs when the decision constrains specific code or docs areas and should appear in pre-edit `orbit search --path <file> --kind all` lookups.
+8. Leave `related_tasks` empty for speculative proposed ADRs when no task exists yet. Do not create or invent a task just to satisfy an ADR proposal. Acceptance requires a real related task.
+9. **Close the loop with a source citation when the ADR has a code anchor.** If the ADR encodes a constraint enforced at a small set of code sites — a `ToolParam` requiring a field, a validation check, a guarded code path — drop a one-line citation comment at each enforcement site in the Rust source so the next reader of that line sees the rationale before they reason their way to weakening it:
 
    ```rust
    // <adr-id>: <one-line rationale>
@@ -114,6 +116,8 @@ Create a proposed ADR:
   "owner": "codex",
   "related_features": ["task-artifacts"],
   "related_tasks": [],
+  "tags": ["task-artifacts"],
+  "paths": ["crates/orbit-store/**"],
   "model": "<agent-family>"
 }
 ```

--- a/crates/orbit-core/assets/skills/orbit-search/SKILL.md
+++ b/crates/orbit-core/assets/skills/orbit-search/SKILL.md
@@ -26,6 +26,12 @@ Use these shapes:
 orbit search "slow inference after model swap" --limit 5
 orbit tool run orbit.search --input '{"query":"slow inference after model swap","limit":5,"model":"<agent-family>"}'
 
+# Cross-artifact label and path filters
+orbit search --tag perf --kind all
+orbit search --path crates/orbit-search/src/lib.rs --kind all
+orbit tool run orbit.search --input '{"tag":"perf","kind":"all","model":"<agent-family>"}'
+orbit tool run orbit.search --input '{"path":"crates/orbit-search/src/lib.rs","kind":"all","model":"<agent-family>"}'
+
 # Hybrid BM25 + cosine over task fields; other kinds remain lexical
 orbit search "agent loop deadlock" --hybrid --kind task --limit 5
 orbit tool run orbit.search --input '{"query":"agent loop deadlock","hybrid":true,"kind":"task","limit":5,"model":"<agent-family>"}'
@@ -36,6 +42,8 @@ orbit tool run orbit.search --input '{"semantic":"<task-id>","limit":5,"model":"
 ```
 
 `--semantic <id>` is mutually exclusive with a positional query and uses task vectors, so it requires the companion.
+
+`--tag` uses AND semantics when repeated. `--path` is an applicability filter: task results use selector containment over `context_files`; learning and ADR results use glob-containment over their stored path scopes; docs are content-indexed and do not match by applicability path.
 
 ## Index Coverage
 

--- a/crates/orbit-core/src/command/docs.rs
+++ b/crates/orbit-core/src/command/docs.rs
@@ -871,6 +871,8 @@ fn adr_search_source(adr: Adr) -> AdrSearchSource {
         id: adr.id,
         title: adr.title,
         status: adr.status,
+        tags: adr.tags,
+        paths: adr.paths,
         related_features: adr.related_features,
     }
 }

--- a/crates/orbit-core/src/command/search.rs
+++ b/crates/orbit-core/src/command/search.rs
@@ -91,8 +91,7 @@ pub struct GlobalSearchParams {
     pub field: Option<String>,
     pub model: Option<String>,
     /// AND-filter by tag. Repeat for multi-tag AND semantics. Applies to
-    /// task, doc, learning (and `all`). ADR is a no-op until phase 3 adds a
-    /// free-form `tags` field to ADR frontmatter.
+    /// task, doc, learning, ADR (and `all`).
     pub tags: Vec<String>,
     /// Include normally-hidden statuses for the queried kind(s). Mutually
     /// overridden by `status`.
@@ -101,9 +100,8 @@ pub struct GlobalSearchParams {
     /// takes precedence over the `all` widener.
     pub status: Vec<String>,
     /// Cross-kind applicability filter. Task: selector-mapping against
-    /// `context_files`. Learning: glob-containment against `scope.paths`.
-    /// ADR: deferred to phase 3 (returns empty). Doc: out of scope
-    /// (returns empty).
+    /// `context_files`. Learning and ADR: glob-containment against
+    /// applicability path globs. Doc: out of scope (returns empty).
     pub path: Option<String>,
 }
 
@@ -194,10 +192,16 @@ impl OrbitRuntime {
             .filter(|q| !q.is_empty())
             .map(str::to_string);
         let has_path = params.path.is_some();
+        let tag_filter: Vec<String> = params
+            .tags
+            .iter()
+            .map(|tag| tag.trim().to_lowercase())
+            .filter(|tag| !tag.is_empty())
+            .collect();
 
-        if query_owned.is_none() && !has_path {
+        if query_owned.is_none() && !has_path && tag_filter.is_empty() {
             return Err(OrbitError::InvalidInput(
-                "search requires either a query or --path".to_string(),
+                "search requires a query, --path, or --tag".to_string(),
             ));
         }
 
@@ -213,13 +217,6 @@ impl OrbitRuntime {
                     .to_string(),
             );
         }
-
-        let tag_filter: Vec<String> = params
-            .tags
-            .iter()
-            .map(|tag| tag.trim().to_lowercase())
-            .filter(|tag| !tag.is_empty())
-            .collect();
 
         if params.kind.includes_tasks() {
             results.extend(self.task_branch(
@@ -244,11 +241,7 @@ impl OrbitRuntime {
         }
 
         if params.kind.includes_adrs() {
-            // ADR `--tag` and `--path` are deferred to phase 3 — skip the ADR
-            // branch entirely when either filter is set.
-            if !has_path && tag_filter.is_empty() {
-                results.extend(self.adr_branch(&params, query_owned.as_deref(), limit)?);
-            }
+            results.extend(self.adr_branch(&params, query_owned.as_deref(), &tag_filter, limit)?);
         }
 
         if params.kind.includes_learnings() {
@@ -343,9 +336,32 @@ impl OrbitRuntime {
         limit: usize,
     ) -> Result<Vec<GlobalSearchHit>, OrbitError> {
         let Some(query) = query else {
-            // Without a query, no doc results — docs are content-indexed, not
-            // applicability-indexed.
-            return Ok(Vec::new());
+            if tag_filter.is_empty() {
+                // Without a query or tag filter, no doc results — docs are
+                // content-indexed, not applicability-indexed.
+                return Ok(Vec::new());
+            }
+            let mut out = Vec::new();
+            for record in self.list_docs(None, None)? {
+                if !doc_has_all_tags(&record, tag_filter) {
+                    continue;
+                }
+                out.push(GlobalSearchHit {
+                    kind: "doc".to_string(),
+                    source: "lexical".to_string(),
+                    id: None,
+                    path: Some(record.path),
+                    title: None,
+                    summary: Some(record.frontmatter.summary),
+                    status: Some(record.frontmatter.doc_type.as_str().to_string()),
+                    best_field: None,
+                    snippet: None,
+                    score: None,
+                    matched_by: Some(tag_filter.iter().map(|tag| format!("tag:{tag}")).collect()),
+                });
+            }
+            out.truncate(limit);
+            return Ok(out);
         };
 
         let docs_limit = limit.saturating_mul(DOC_SEARCH_OVERFETCH).max(limit);
@@ -355,10 +371,11 @@ impl OrbitRuntime {
             if let SearchResult::Doc(result) = result {
                 if !tag_filter.is_empty() {
                     let record_tags = &result.record.tags;
-                    if !tag_filter
-                        .iter()
-                        .all(|tag| record_tags.iter().any(|candidate| candidate == tag))
-                    {
+                    if !tag_filter.iter().all(|tag| {
+                        record_tags
+                            .iter()
+                            .any(|candidate| candidate.eq_ignore_ascii_case(tag))
+                    }) {
                         continue;
                     }
                 }
@@ -385,12 +402,32 @@ impl OrbitRuntime {
         &self,
         params: &GlobalSearchParams,
         query: Option<&str>,
+        tag_filter: &[String],
         limit: usize,
     ) -> Result<Vec<GlobalSearchHit>, OrbitError> {
-        let Some(query) = query else {
-            return Ok(Vec::new());
-        };
         let statuses = resolve_adr_statuses(params)?;
+        let path = params.path.as_deref();
+
+        let Some(query) = query else {
+            let mut out = Vec::new();
+            for adr in self.stores().adrs().list()? {
+                if !statuses.contains(&adr.status) {
+                    continue;
+                }
+                if !tag_filter.is_empty() && !adr_has_all_tags(&adr, tag_filter) {
+                    continue;
+                }
+                if let Some(path) = path
+                    && !orbit_search::adr_paths_contain_path(&adr.paths, path)?
+                {
+                    continue;
+                }
+                out.push(adr_to_global_hit(adr, filter_matched_by(tag_filter, path)));
+            }
+            out.truncate(limit);
+            return Ok(out);
+        };
+
         let docs_limit = limit.saturating_mul(DOC_SEARCH_OVERFETCH).max(limit);
         // Pass `true` so the underlying lexical pass admits superseded ADRs;
         // we apply the status filter ourselves below.
@@ -399,6 +436,14 @@ impl OrbitRuntime {
         for result in docs {
             if let SearchResult::Adr(result) = result {
                 if !statuses.contains(&result.status) {
+                    continue;
+                }
+                if !tag_filter.is_empty() && !adr_result_has_all_tags(&result, tag_filter) {
+                    continue;
+                }
+                if let Some(path) = path
+                    && !orbit_search::adr_paths_contain_path(&result.paths, path)?
+                {
                     continue;
                 }
                 out.push(GlobalSearchHit {
@@ -561,6 +606,70 @@ fn learning_has_all_tags(learning: &orbit_common::types::Learning, tag_filter: &
     })
 }
 
+fn doc_has_all_tags(record: &crate::DocRecord, tag_filter: &[String]) -> bool {
+    tag_filter.iter().all(|needle| {
+        record
+            .frontmatter
+            .tags
+            .iter()
+            .any(|candidate| candidate.eq_ignore_ascii_case(needle))
+    })
+}
+
+fn adr_has_all_tags(adr: &orbit_common::types::Adr, tag_filter: &[String]) -> bool {
+    tag_filter.iter().all(|needle| {
+        adr.tags
+            .iter()
+            .any(|candidate| candidate.eq_ignore_ascii_case(needle))
+    })
+}
+
+fn adr_result_has_all_tags(result: &orbit_search::AdrSearchResult, tag_filter: &[String]) -> bool {
+    tag_filter.iter().all(|needle| {
+        result
+            .tags
+            .iter()
+            .any(|candidate| candidate.eq_ignore_ascii_case(needle))
+    })
+}
+
+fn adr_to_global_hit(
+    adr: orbit_common::types::Adr,
+    matched_by: Option<Vec<String>>,
+) -> GlobalSearchHit {
+    let path = std::path::PathBuf::from(".orbit")
+        .join("adrs")
+        .join(adr.status.cli_name())
+        .join(&adr.id)
+        .join("body.md");
+    GlobalSearchHit {
+        kind: "adr".to_string(),
+        source: "lexical".to_string(),
+        id: Some(adr.id),
+        path: Some(path.to_string_lossy().into_owned()),
+        title: Some(adr.title),
+        summary: None,
+        status: Some(adr.status.to_string()),
+        best_field: None,
+        snippet: None,
+        score: None,
+        matched_by,
+    }
+}
+
+fn filter_matched_by(tag_filter: &[String], path: Option<&str>) -> Option<Vec<String>> {
+    let mut matched = Vec::new();
+    matched.extend(tag_filter.iter().map(|tag| format!("tag:{tag}")));
+    if let Some(path) = path {
+        matched.push(format!("path:{path}"));
+    }
+    if matched.is_empty() {
+        None
+    } else {
+        Some(matched)
+    }
+}
+
 /// Test whether any of a task's `context_files` selectors apply to `query_path`.
 ///
 /// Selectors take three forms: `file:<path>`, `dir:<path>`, and
@@ -711,6 +820,7 @@ fn resolve_adr_statuses(params: &GlobalSearchParams) -> Result<Vec<AdrStatus>, O
 
 #[cfg(test)]
 mod tests {
+    use orbit_store::AdrCreateParams;
     use serde_json::json;
 
     use super::*;
@@ -728,6 +838,113 @@ mod tests {
         assert_eq!(
             serde_json::to_value(GlobalSearchMode::Neighbor).expect("serialize mode"),
             json!("neighbor")
+        );
+    }
+
+    fn add_tagged_adr(runtime: &OrbitRuntime) -> String {
+        runtime
+            .stores()
+            .adrs()
+            .add(AdrCreateParams {
+                title: "ADR tag path bridge".to_string(),
+                owner: "codex".to_string(),
+                related_features: Vec::new(),
+                related_tasks: Vec::new(),
+                tags: vec!["Perf".to_string(), "orbit-search".to_string()],
+                paths: vec!["crates/orbit-search/**".to_string()],
+                body: "## Context\n\nTest.\n".to_string(),
+            })
+            .expect("add adr")
+            .id
+    }
+
+    #[test]
+    fn global_search_adr_tag_filter_matches_case_insensitive() {
+        let runtime = OrbitRuntime::in_memory().expect("runtime");
+        let adr_id = add_tagged_adr(&runtime);
+
+        let response = runtime
+            .global_search(GlobalSearchParams {
+                kind: GlobalSearchKind::Adr,
+                tags: vec!["perf".to_string()],
+                ..Default::default()
+            })
+            .expect("search by tag");
+
+        assert_eq!(response.results.len(), 1);
+        assert_eq!(response.results[0].id.as_deref(), Some(adr_id.as_str()));
+        assert_eq!(
+            response.results[0].matched_by.as_deref(),
+            Some(&["tag:perf".to_string()][..])
+        );
+
+        let negative = runtime
+            .global_search(GlobalSearchParams {
+                kind: GlobalSearchKind::Adr,
+                tags: vec!["security".to_string()],
+                ..Default::default()
+            })
+            .expect("search by missing tag");
+        assert!(negative.results.is_empty());
+    }
+
+    #[test]
+    fn global_search_adr_path_filter_matches_glob_containment() {
+        let runtime = OrbitRuntime::in_memory().expect("runtime");
+        let adr_id = add_tagged_adr(&runtime);
+
+        let response = runtime
+            .global_search(GlobalSearchParams {
+                kind: GlobalSearchKind::Adr,
+                path: Some("crates/orbit-search/src/lib.rs".to_string()),
+                ..Default::default()
+            })
+            .expect("search by path");
+
+        assert_eq!(response.results.len(), 1);
+        assert_eq!(response.results[0].id.as_deref(), Some(adr_id.as_str()));
+        assert_eq!(
+            response.results[0].matched_by.as_deref(),
+            Some(&["path:crates/orbit-search/src/lib.rs".to_string()][..])
+        );
+
+        let negative = runtime
+            .global_search(GlobalSearchParams {
+                kind: GlobalSearchKind::Adr,
+                path: Some("crates/orbit-core/src/lib.rs".to_string()),
+                ..Default::default()
+            })
+            .expect("search by missing path");
+        assert!(negative.results.is_empty());
+    }
+
+    #[test]
+    fn global_search_all_unions_adr_hits_for_tag_and_path_filters() {
+        let runtime = OrbitRuntime::in_memory().expect("runtime");
+        let adr_id = add_tagged_adr(&runtime);
+
+        let response = runtime
+            .global_search(GlobalSearchParams {
+                kind: GlobalSearchKind::All,
+                tags: vec!["perf".to_string()],
+                path: Some("crates/orbit-search/src/lib.rs".to_string()),
+                ..Default::default()
+            })
+            .expect("search all by tag and path");
+
+        let adr_hit = response
+            .results
+            .iter()
+            .find(|hit| hit.kind == "adr" && hit.id.as_deref() == Some(adr_id.as_str()))
+            .expect("adr hit");
+        assert_eq!(
+            adr_hit.matched_by.as_deref(),
+            Some(
+                &[
+                    "tag:perf".to_string(),
+                    "path:crates/orbit-search/src/lib.rs".to_string(),
+                ][..]
+            )
         );
     }
 

--- a/crates/orbit-core/src/runtime/engine/summary.rs
+++ b/crates/orbit-core/src/runtime/engine/summary.rs
@@ -35,10 +35,16 @@ impl OrbitRuntime {
             let vote_count = self.learning_vote_summary(&learning.id)?.vote_count as u64;
             learning_vote_counts.push((learning.id.clone(), vote_count));
         }
-        let adrs =
-            self.stores()
-                .adrs()
-                .list_filtered(None::<AdrStatus>, None, None, None, None, None)?;
+        let adrs = self.stores().adrs().list_filtered(
+            None::<AdrStatus>,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        )?;
         let frictions = orbit_store::friction_store::list_frictions(
             &self.data_root().join("frictions"),
             &orbit_store::friction_store::FrictionListFilter::default(),

--- a/crates/orbit-core/src/runtime/orbit_tool_host/adr_tools.rs
+++ b/crates/orbit-core/src/runtime/orbit_tool_host/adr_tools.rs
@@ -31,12 +31,16 @@ pub(super) fn add(
         optional_string_list_alias(&input, &["related_features", "features"])?.unwrap_or_default();
     let related_tasks =
         optional_string_list_alias(&input, &["related_tasks", "tasks"])?.unwrap_or_default();
+    let tags = optional_string_list_alias(&input, &["tags"])?.unwrap_or_default();
+    let paths = optional_string_list_alias(&input, &["paths"])?.unwrap_or_default();
 
     let adr = runtime.stores().adrs().add(AdrCreateParams {
         title,
         owner,
         related_features,
         related_tasks,
+        tags,
+        paths,
         body,
     })?;
     runtime.record_id_allocation_audit("adr", &adr.id)?;
@@ -64,7 +68,8 @@ pub(super) fn show(runtime: &OrbitRuntime, input: Value) -> Result<Value, OrbitE
 
     let adrs = runtime.stores().adrs();
     let adr = if by_legacy {
-        let matches = adrs.list_filtered(None, None, None, None, Some(&id_value), None)?;
+        let matches =
+            adrs.list_filtered(None, None, None, None, Some(&id_value), None, None, None)?;
         if matches.len() > 1 {
             return Err(OrbitError::InvalidInput(format!(
                 "legacy_id `{id_value}` resolves to {} ADRs; specify the canonical id",
@@ -97,6 +102,8 @@ pub(super) fn list(runtime: &OrbitRuntime, input: Value) -> Result<Value, OrbitE
     let feature = optional_string(&input, "feature")?;
     let task_id = optional_string_alias(&input, &["task_id", "task"])?;
     let legacy_id = optional_string_alias(&input, &["legacy_id", "legacyId"])?;
+    let tag = optional_string(&input, "tag")?;
+    let path = optional_string(&input, "path")?;
     let validation_warned =
         super::input::optional_bool_alias(&input, &["validation_warned", "validation"])?;
     let include_remote =
@@ -109,6 +116,8 @@ pub(super) fn list(runtime: &OrbitRuntime, input: Value) -> Result<Value, OrbitE
         feature.as_deref(),
         task_id.as_deref(),
         legacy_id.as_deref(),
+        tag.as_deref(),
+        path.as_deref(),
         validation_warned,
         include_remote,
     )?;
@@ -137,6 +146,8 @@ pub(super) fn update(
         body: optional_string(&input, "body")?,
         related_features: optional_string_list_alias(&input, &["related_features", "features"])?,
         related_tasks: optional_string_list_alias(&input, &["related_tasks", "tasks"])?,
+        tags: optional_string_list_alias(&input, &["tags"])?,
+        paths: optional_string_list_alias(&input, &["paths"])?,
         supersedes: optional_string_list_alias(&input, &["supersedes"])?,
         superseded_by: None, // see below: clients use orbit.adr.supersede
         legacy_ids: optional_string_list_alias(&input, &["legacy_ids", "legacyIds"])?,
@@ -248,6 +259,8 @@ fn has_document_changes(fields: &AdrDocumentUpdateParams) -> bool {
         || fields.body.is_some()
         || fields.related_features.is_some()
         || fields.related_tasks.is_some()
+        || fields.tags.is_some()
+        || fields.paths.is_some()
         || fields.supersedes.is_some()
         || fields.legacy_ids.is_some()
         || fields.validation_warnings.is_some()
@@ -270,6 +283,8 @@ fn adr_to_json(adr: &Adr) -> Value {
         "last_updated": adr.last_updated.to_rfc3339(),
         "related_features": adr.related_features,
         "related_tasks": adr.related_tasks,
+        "tags": adr.tags,
+        "paths": adr.paths,
         "supersedes": adr.supersedes,
         "superseded_by": adr.superseded_by,
         "legacy_ids": adr.legacy_ids,
@@ -305,6 +320,8 @@ fn remote_stub_to_json(stub: &RemoteArtifactStub) -> Value {
         "owner": Value::Null,
         "related_features": Value::Null,
         "related_tasks": Value::Null,
+        "tags": Value::Null,
+        "paths": Value::Null,
         "legacy_ids": Value::Null,
     })
 }
@@ -636,6 +653,55 @@ mod tests {
         let arr = listed.as_array().expect("array");
         assert_eq!(arr.len(), 1);
         assert_eq!(arr[0]["id"], b["id"]);
+    }
+
+    #[test]
+    fn list_filters_by_tag_and_path() {
+        let (_guard, runtime, _repo_root) = test_runtime();
+        let target = add(
+            &runtime,
+            json!({
+                "title": "Tagged",
+                "owner": "codex",
+                "body": "b",
+                "tags": ["Perf", "orbit-search"],
+                "paths": ["crates/orbit-search/**"],
+            }),
+            None,
+            None,
+        )
+        .expect("target");
+        let _other = add(
+            &runtime,
+            json!({
+                "title": "Other",
+                "owner": "codex",
+                "body": "b",
+                "tags": ["security"],
+                "paths": ["crates/orbit-core/**"],
+            }),
+            None,
+            None,
+        )
+        .expect("other");
+
+        let by_tag = list(&runtime, json!({"tag": "PERF"})).expect("list by tag");
+        let tag_rows = by_tag.as_array().expect("tag array");
+        assert_eq!(tag_rows.len(), 1);
+        assert_eq!(tag_rows[0]["id"], target["id"]);
+
+        let by_path = list(&runtime, json!({"path": "crates/orbit-search/src/lib.rs"}))
+            .expect("list by path");
+        let path_rows = by_path.as_array().expect("path array");
+        assert_eq!(path_rows.len(), 1);
+        assert_eq!(path_rows[0]["id"], target["id"]);
+
+        let missing = list(
+            &runtime,
+            json!({"tag": "PERF", "path": "crates/orbit-core/src/lib.rs"}),
+        )
+        .expect("list by negative intersection");
+        assert!(missing.as_array().expect("missing array").is_empty());
     }
 
     #[test]

--- a/crates/orbit-core/src/runtime/store_delegates.rs
+++ b/crates/orbit-core/src/runtime/store_delegates.rs
@@ -738,6 +738,8 @@ impl AdrRecords<'_> {
         feature: Option<&str>,
         task_id: Option<&str>,
         legacy_id: Option<&str>,
+        tag: Option<&str>,
+        path: Option<&str>,
         validation_warned: Option<bool>,
     ) -> Result<Vec<Adr>, OrbitError> {
         self.store.list_adrs_filtered(
@@ -746,6 +748,8 @@ impl AdrRecords<'_> {
             feature,
             task_id,
             legacy_id,
+            tag,
+            path,
             validation_warned,
         )
     }
@@ -758,6 +762,8 @@ impl AdrRecords<'_> {
         feature: Option<&str>,
         task_id: Option<&str>,
         legacy_id: Option<&str>,
+        tag: Option<&str>,
+        path: Option<&str>,
         validation_warned: Option<bool>,
         include_remote: bool,
     ) -> Result<Vec<AdrListEntry>, OrbitError> {
@@ -767,6 +773,8 @@ impl AdrRecords<'_> {
             feature,
             task_id,
             legacy_id,
+            tag,
+            path,
             validation_warned,
             include_remote,
         )

--- a/crates/orbit-search/src/lexical/docs.rs
+++ b/crates/orbit-search/src/lexical/docs.rs
@@ -1,6 +1,7 @@
 use std::path::PathBuf;
 
-use orbit_common::types::AdrStatus;
+use orbit_common::types::{AdrStatus, OrbitError};
+use orbit_common::utility::glob::{compile_glob_regex, normalize_glob_path};
 use serde::Serialize;
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
@@ -25,6 +26,8 @@ pub struct AdrSearchSource {
     pub title: String,
     pub status: AdrStatus,
     pub path: PathBuf,
+    pub tags: Vec<String>,
+    pub paths: Vec<String>,
     pub related_features: Vec<String>,
 }
 
@@ -48,6 +51,8 @@ pub struct AdrSearchResult {
     pub title: String,
     pub status: AdrStatus,
     pub path: PathBuf,
+    pub tags: Vec<String>,
+    pub paths: Vec<String>,
     pub related_features: Vec<String>,
     pub score: usize,
     pub matched_by: Vec<String>,
@@ -103,6 +108,16 @@ pub fn score_adr_record(adr: AdrSearchSource, query_lower: &str) -> Option<AdrSe
             matched_by.push(format!("related_feature:{feature}"));
         }
     }
+    for tag in &adr.tags {
+        let lower = tag.to_ascii_lowercase();
+        if lower == query_lower {
+            score += 120;
+            matched_by.push(format!("tag:{tag}"));
+        } else if lower.contains(query_lower) {
+            score += 60;
+            matched_by.push(format!("tag:{tag}"));
+        }
+    }
     let status = adr.status.cli_name();
     if status.contains(query_lower) {
         score += 30;
@@ -116,10 +131,21 @@ pub fn score_adr_record(adr: AdrSearchSource, query_lower: &str) -> Option<AdrSe
         title: adr.title,
         status: adr.status,
         path: adr.path,
+        tags: adr.tags,
+        paths: adr.paths,
         related_features: adr.related_features,
         score,
         matched_by,
     })
+}
+
+pub fn adr_paths_contain_path(rules: &[String], query_path: &str) -> Result<bool, OrbitError> {
+    let normalized = normalize_glob_path(query_path)?;
+    Ok(rules.iter().any(|rule| {
+        compile_glob_regex(rule)
+            .map(|regex| regex.is_match(&normalized))
+            .unwrap_or(false)
+    }))
 }
 
 pub fn sort_search_results(results: &mut [SearchResult]) {
@@ -163,6 +189,8 @@ mod tests {
                 .join(status.cli_name())
                 .join(id)
                 .join("body.md"),
+            tags: Vec::new(),
+            paths: Vec::new(),
             related_features: related_features
                 .into_iter()
                 .map(ToString::to_string)
@@ -270,5 +298,38 @@ mod tests {
             })
             .collect::<Vec<_>>();
         assert_eq!(ids, vec!["ADR-0001", "ADR-0002"]);
+    }
+
+    #[test]
+    fn score_adr_record_matches_tags() {
+        let mut adr = adr_fixture(
+            "ADR-0001",
+            "Boundary",
+            AdrStatus::Accepted,
+            vec!["orbit-docs"],
+        );
+        adr.tags = vec!["adr-schema".to_string(), "Cross-Cutting".to_string()];
+
+        let result = score_adr_record(adr, "cross-cutting").expect("tag match");
+
+        assert_eq!(result.score, 120);
+        assert_eq!(result.matched_by, vec!["tag:Cross-Cutting"]);
+    }
+
+    #[test]
+    fn adr_paths_containment_matches_positive_and_negative_cases() {
+        let paths = vec![
+            "crates/orbit-search/**".to_string(),
+            "docs/design/adr-artifact/**".to_string(),
+        ];
+
+        assert!(
+            adr_paths_contain_path(&paths, "crates/orbit-search/src/lib.rs")
+                .expect("positive match")
+        );
+        assert!(
+            !adr_paths_contain_path(&paths, "crates/orbit-core/src/lib.rs")
+                .expect("negative match")
+        );
     }
 }

--- a/crates/orbit-search/src/lib.rs
+++ b/crates/orbit-search/src/lib.rs
@@ -48,7 +48,7 @@ pub use companion::{
 pub use embedder::{DEFAULT_MODEL, Embedder, ModelSpec, default_model, supported_models};
 pub use lexical::docs::{
     AdrSearchResult, AdrSearchSource, DocSearchResult, DocSearchSource, SearchResult,
-    score_adr_record, score_doc_record, sort_search_results,
+    adr_paths_contain_path, score_adr_record, score_doc_record, sort_search_results,
 };
 pub use noop::NoopEmbedder;
 pub use rpc::{RpcError, RpcRequest, RpcResponse, RpcResult};

--- a/crates/orbit-store/src/backend/contracts.rs
+++ b/crates/orbit-store/src/backend/contracts.rs
@@ -21,6 +21,8 @@ pub struct AdrCreateParams {
     pub owner: String,
     pub related_features: Vec<String>,
     pub related_tasks: Vec<String>,
+    pub tags: Vec<String>,
+    pub paths: Vec<String>,
     pub body: String,
 }
 
@@ -58,6 +60,8 @@ pub struct AdrDocumentUpdateParams {
     pub body: Option<String>,
     pub related_features: Option<Vec<String>>,
     pub related_tasks: Option<Vec<String>>,
+    pub tags: Option<Vec<String>>,
+    pub paths: Option<Vec<String>>,
     pub supersedes: Option<Vec<String>>,
     pub superseded_by: Option<Option<String>>,
     pub legacy_ids: Option<Vec<String>>,
@@ -368,6 +372,8 @@ pub trait AdrStoreBackend: Send + Sync {
         feature: Option<&str>,
         task_id: Option<&str>,
         legacy_id: Option<&str>,
+        tag: Option<&str>,
+        path: Option<&str>,
         validation_warned: Option<bool>,
     ) -> Result<Vec<Adr>, OrbitError>;
     #[allow(clippy::too_many_arguments)]
@@ -378,6 +384,8 @@ pub trait AdrStoreBackend: Send + Sync {
         feature: Option<&str>,
         task_id: Option<&str>,
         legacy_id: Option<&str>,
+        tag: Option<&str>,
+        path: Option<&str>,
         validation_warned: Option<bool>,
         include_remote: bool,
     ) -> Result<Vec<AdrListEntry>, OrbitError>;

--- a/crates/orbit-store/src/backend/file_backends.rs
+++ b/crates/orbit-store/src/backend/file_backends.rs
@@ -330,6 +330,8 @@ impl AdrStoreBackend for AdrFileStore {
         feature: Option<&str>,
         task_id: Option<&str>,
         legacy_id: Option<&str>,
+        tag: Option<&str>,
+        path: Option<&str>,
         validation_warned: Option<bool>,
     ) -> Result<Vec<Adr>, OrbitError> {
         self.list_adrs_filtered(
@@ -338,6 +340,8 @@ impl AdrStoreBackend for AdrFileStore {
             feature,
             task_id,
             legacy_id,
+            tag,
+            path,
             validation_warned,
         )
     }
@@ -349,6 +353,8 @@ impl AdrStoreBackend for AdrFileStore {
         feature: Option<&str>,
         task_id: Option<&str>,
         legacy_id: Option<&str>,
+        tag: Option<&str>,
+        path: Option<&str>,
         validation_warned: Option<bool>,
         include_remote: bool,
     ) -> Result<Vec<AdrListEntry>, OrbitError> {
@@ -359,6 +365,8 @@ impl AdrStoreBackend for AdrFileStore {
             feature,
             task_id,
             legacy_id,
+            tag,
+            path,
             validation_warned,
             include_remote,
         )

--- a/crates/orbit-store/src/file/adr_store/api.rs
+++ b/crates/orbit-store/src/file/adr_store/api.rs
@@ -5,7 +5,11 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 use chrono::Utc;
-use orbit_common::types::{Adr, AdrStatus, LegacyValidation, NotFoundKind, OrbitError};
+use orbit_common::types::{
+    Adr, AdrStatus, LegacyValidation, NotFoundKind, OrbitError, normalize_adr_paths,
+    normalize_adr_tags,
+};
+use orbit_common::utility::glob::{compile_glob_regex, normalize_glob_path};
 use rusqlite::params;
 
 use super::bundle::{AdrBundle, bundle_to_adr, read_bundle_at, validate_bundle, write_bundle_at};
@@ -84,6 +88,8 @@ impl AdrFileStore {
             last_updated: now,
             related_features: params.related_features,
             related_tasks: params.related_tasks,
+            tags: normalize_adr_tags(params.tags),
+            paths: normalize_adr_paths(params.paths),
             supersedes: Vec::new(),
             superseded_by: None,
             legacy_ids: Vec::new(),
@@ -164,8 +170,11 @@ impl AdrFileStore {
         feature: Option<&str>,
         task_id: Option<&str>,
         legacy_id: Option<&str>,
+        tag: Option<&str>,
+        path: Option<&str>,
         validation_warned: Option<bool>,
     ) -> Result<Vec<Adr>, OrbitError> {
+        let normalized_path = normalized_filter_path(path)?;
         if self.index.is_none() {
             // Fall back to filesystem walk + in-memory filter. Preserves
             // test ergonomics where `AdrFileStore::new` skips the index.
@@ -178,6 +187,8 @@ impl AdrFileStore {
                     feature,
                     task_id,
                     legacy_id,
+                    tag,
+                    normalized_path.as_deref(),
                     validation_warned,
                 )
             });
@@ -196,7 +207,19 @@ impl AdrFileStore {
 
         let mut adrs = Vec::with_capacity(ids.len());
         for id in ids {
-            if let Some(adr) = self.get_adr(&id)? {
+            if let Some(adr) = self.get_adr(&id)?
+                && matches_filter(
+                    &adr,
+                    status,
+                    owner,
+                    feature,
+                    task_id,
+                    legacy_id,
+                    tag,
+                    normalized_path.as_deref(),
+                    validation_warned,
+                )
+            {
                 adrs.push(adr);
             }
         }
@@ -212,9 +235,12 @@ impl AdrFileStore {
         feature: Option<&str>,
         task_id: Option<&str>,
         legacy_id: Option<&str>,
+        tag: Option<&str>,
+        path: Option<&str>,
         validation_warned: Option<bool>,
         include_remote: bool,
     ) -> Result<Vec<AdrListEntry>, OrbitError> {
+        let normalized_path = normalized_filter_path(path)?;
         let mut entries = Vec::new();
         for record in self.id_allocator.adr_allocations()? {
             if let Some(adr) = self.read_adr_allocation(&record)? {
@@ -225,6 +251,8 @@ impl AdrFileStore {
                     feature,
                     task_id,
                     legacy_id,
+                    tag,
+                    normalized_path.as_deref(),
                     validation_warned,
                 ) {
                     entries.push(AdrListEntry::Local(adr));
@@ -240,6 +268,8 @@ impl AdrFileStore {
                     feature,
                     task_id,
                     legacy_id,
+                    tag,
+                    normalized_path.as_deref(),
                     validation_warned,
                 )
             {
@@ -335,6 +365,12 @@ impl AdrFileStore {
         }
         if let Some(ref tasks) = fields.related_tasks {
             bundle.doc.adr.related_tasks = tasks.clone();
+        }
+        if let Some(ref tags) = fields.tags {
+            bundle.doc.adr.tags = normalize_adr_tags(tags.clone());
+        }
+        if let Some(ref paths) = fields.paths {
+            bundle.doc.adr.paths = normalize_adr_paths(paths.clone());
         }
         if let Some(ref supersedes) = fields.supersedes {
             bundle.doc.adr.supersedes = supersedes.clone();
@@ -634,6 +670,8 @@ fn matches_filter(
     feature: Option<&str>,
     task_id: Option<&str>,
     legacy_id: Option<&str>,
+    tag: Option<&str>,
+    normalized_path: Option<&str>,
     validation_warned: Option<bool>,
 ) -> bool {
     if let Some(status) = status
@@ -661,6 +699,20 @@ fn matches_filter(
     {
         return false;
     }
+    if let Some(tag) = tag
+        && !tag.trim().is_empty()
+        && !adr
+            .tags
+            .iter()
+            .any(|candidate| candidate.eq_ignore_ascii_case(tag))
+    {
+        return false;
+    }
+    if let Some(path) = normalized_path
+        && !adr_paths_contain_path(&adr.paths, path)
+    {
+        return false;
+    }
     if let Some(warned) = validation_warned {
         let is_warned = matches!(adr.legacy_validation, LegacyValidation::Warned);
         if warned != is_warned {
@@ -668,6 +720,18 @@ fn matches_filter(
         }
     }
     true
+}
+
+fn normalized_filter_path(path: Option<&str>) -> Result<Option<String>, OrbitError> {
+    path.map(normalize_glob_path).transpose()
+}
+
+fn adr_paths_contain_path(rules: &[String], normalized_path: &str) -> bool {
+    rules.iter().any(|rule| {
+        compile_glob_regex(rule)
+            .map(|regex| regex.is_match(normalized_path))
+            .unwrap_or(false)
+    })
 }
 
 fn sort_by_id_desc(adrs: &mut [Adr]) {
@@ -700,12 +764,16 @@ fn remote_adr_matches_filter(
     feature: Option<&str>,
     task_id: Option<&str>,
     legacy_id: Option<&str>,
+    tag: Option<&str>,
+    normalized_path: Option<&str>,
     validation_warned: Option<bool>,
 ) -> bool {
     if owner.is_some()
         || feature.is_some()
         || task_id.is_some()
         || legacy_id.is_some()
+        || tag.is_some()
+        || normalized_path.is_some()
         || validation_warned.is_some()
     {
         return false;
@@ -736,6 +804,8 @@ fn insert_adr_row(conn: &rusqlite::Connection, adr: &Adr) -> Result<(), OrbitErr
         .map_err(|e| OrbitError::Store(e.to_string()))?;
     let related_tasks =
         serde_json::to_string(&adr.related_tasks).map_err(|e| OrbitError::Store(e.to_string()))?;
+    let tags = serde_json::to_string(&adr.tags).map_err(|e| OrbitError::Store(e.to_string()))?;
+    let paths = serde_json::to_string(&adr.paths).map_err(|e| OrbitError::Store(e.to_string()))?;
     let legacy_ids =
         serde_json::to_string(&adr.legacy_ids).map_err(|e| OrbitError::Store(e.to_string()))?;
     let supersedes =
@@ -746,10 +816,10 @@ fn insert_adr_row(conn: &rusqlite::Connection, adr: &Adr) -> Result<(), OrbitErr
     conn.execute(
         "INSERT INTO adrs (
             id, status, title, owner,
-            related_features, related_tasks, legacy_ids, supersedes,
+            related_features, related_tasks, tags, paths, legacy_ids, supersedes,
             superseded_by, validation_warnings, legacy_validation,
             created_at, accepted_at, last_updated
-        ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14)",
+        ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16)",
         params![
             adr.id,
             adr.status.cli_name(),
@@ -757,6 +827,8 @@ fn insert_adr_row(conn: &rusqlite::Connection, adr: &Adr) -> Result<(), OrbitErr
             adr.owner,
             related_features,
             related_tasks,
+            tags,
+            paths,
             legacy_ids,
             supersedes,
             adr.superseded_by,
@@ -785,6 +857,8 @@ mod tests {
             owner: "claude".to_string(),
             related_features: Vec::new(),
             related_tasks: Vec::new(),
+            tags: Vec::new(),
+            paths: Vec::new(),
             body: body.to_string(),
         }
     }
@@ -1026,7 +1100,7 @@ mod tests {
         assert_eq!(count_index_rows(&store), 1);
 
         let listed = store
-            .list_adrs_filtered(None, None, None, None, None, None)
+            .list_adrs_filtered(None, None, None, None, None, None, None, None)
             .expect("list filtered");
         let ids: Vec<String> = listed.iter().map(|a| a.id.clone()).collect();
         assert_eq!(ids, vec![adr.id]);
@@ -1043,13 +1117,31 @@ mod tests {
             .expect("accept");
 
         let accepted = store
-            .list_adrs_filtered(Some(AdrStatus::Accepted), None, None, None, None, None)
+            .list_adrs_filtered(
+                Some(AdrStatus::Accepted),
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+            )
             .expect("list accepted");
         assert_eq!(accepted.len(), 1);
         assert_eq!(accepted[0].id, adr.id);
 
         let proposed = store
-            .list_adrs_filtered(Some(AdrStatus::Proposed), None, None, None, None, None)
+            .list_adrs_filtered(
+                Some(AdrStatus::Proposed),
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+            )
             .expect("list proposed");
         assert!(proposed.is_empty(), "no proposed ADRs after promotion");
     }
@@ -1065,7 +1157,7 @@ mod tests {
         assert_eq!(count_index_rows(&store), 0);
 
         let listed = store
-            .list_adrs_filtered(None, None, None, None, None, None)
+            .list_adrs_filtered(None, None, None, None, None, None, None, None)
             .expect("list filtered");
         assert!(listed.is_empty());
     }
@@ -1079,6 +1171,8 @@ mod tests {
                 owner: "claude".to_string(),
                 related_features: Vec::new(),
                 related_tasks: Vec::new(),
+                tags: Vec::new(),
+                paths: Vec::new(),
                 body: "body".to_string(),
             })
             .expect("add claude");
@@ -1088,12 +1182,14 @@ mod tests {
                 owner: "codex".to_string(),
                 related_features: Vec::new(),
                 related_tasks: Vec::new(),
+                tags: Vec::new(),
+                paths: Vec::new(),
                 body: "body".to_string(),
             })
             .expect("add codex");
 
         let filtered = store
-            .list_adrs_filtered(None, Some("claude"), None, None, None, None)
+            .list_adrs_filtered(None, Some("claude"), None, None, None, None, None, None)
             .expect("filter by owner");
         assert_eq!(filtered.len(), 1);
         assert_eq!(filtered[0].id, claude.id);
@@ -1121,7 +1217,16 @@ mod tests {
             .expect("set legacy id");
 
         let filtered = store
-            .list_adrs_filtered(None, None, None, None, Some("activity-job/ADR-039"), None)
+            .list_adrs_filtered(
+                None,
+                None,
+                None,
+                None,
+                Some("activity-job/ADR-039"),
+                None,
+                None,
+                None,
+            )
             .expect("filter by legacy id");
         assert_eq!(filtered.len(), 1);
         assert_eq!(filtered[0].id, target.id);
@@ -1147,7 +1252,7 @@ mod tests {
         assert_eq!(count_index_rows(&store), 3);
 
         let listed = store
-            .list_adrs_filtered(None, None, None, None, None, None)
+            .list_adrs_filtered(None, None, None, None, None, None, None, None)
             .expect("list rebuilt");
         let mut ids: Vec<String> = listed.iter().map(|a| a.id.clone()).collect();
         ids.sort();
@@ -1171,13 +1276,22 @@ mod tests {
             .expect("accept b");
 
         let accepted = store
-            .list_adrs_filtered(Some(AdrStatus::Accepted), None, None, None, None, None)
+            .list_adrs_filtered(
+                Some(AdrStatus::Accepted),
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+            )
             .expect("fallback filter");
         assert_eq!(accepted.len(), 1);
         assert_eq!(accepted[0].id, b.id);
 
         let all = store
-            .list_adrs_filtered(None, None, None, None, None, None)
+            .list_adrs_filtered(None, None, None, None, None, None, None, None)
             .expect("fallback list");
         // ID-desc sort: b was allocated after a.
         let ids: Vec<String> = all.iter().map(|adr| adr.id.clone()).collect();

--- a/crates/orbit-store/src/file/adr_store/bundle.rs
+++ b/crates/orbit-store/src/file/adr_store/bundle.rs
@@ -83,6 +83,8 @@ mod tests {
                     last_updated: ts,
                     related_features: vec![],
                     related_tasks: vec![],
+                    tags: vec![],
+                    paths: vec![],
                     supersedes: vec![],
                     superseded_by: None,
                     legacy_ids: vec![],

--- a/crates/orbit-store/src/file/adr_store/constants.rs
+++ b/crates/orbit-store/src/file/adr_store/constants.rs
@@ -1,3 +1,3 @@
 pub(super) const ADR_YAML: &str = "adr.yaml";
 pub(super) const BODY_MD: &str = "body.md";
-pub(super) const ADR_SCHEMA_VERSION: u8 = 1;
+pub(super) const ADR_SCHEMA_VERSION: u8 = 2;

--- a/crates/orbit-store/src/file/adr_store/doc.rs
+++ b/crates/orbit-store/src/file/adr_store/doc.rs
@@ -40,6 +40,8 @@ mod tests {
                 last_updated: ts,
                 related_features: vec![],
                 related_tasks: vec![],
+                tags: vec![],
+                paths: vec![],
                 supersedes: vec![],
                 superseded_by: None,
                 legacy_ids: vec![],
@@ -51,13 +53,33 @@ mod tests {
 
     #[test]
     fn round_trip_through_yaml_preserves_schema_version() {
-        let doc = sample_doc();
+        let mut doc = sample_doc();
+        doc.adr.tags = vec!["adr-schema".to_string(), "cross-cutting".to_string()];
+        doc.adr.paths = vec!["crates/orbit-store/**".to_string()];
         let yaml = serialize_adr_doc_yaml(&doc).expect("serialize");
         assert!(
-            yaml.contains("schema_version: 1"),
-            "yaml should contain schema_version: 1; got:\n{yaml}"
+            yaml.contains("schema_version: 2"),
+            "yaml should contain schema_version: 2; got:\n{yaml}"
         );
         let back: AdrFileDocument = serde_yaml::from_str(&yaml).expect("deserialize");
         assert_eq!(back, doc);
+    }
+
+    #[test]
+    fn v1_yaml_without_tags_or_paths_defaults_to_empty_lists() {
+        let yaml = r#"schema_version: 1
+id: ADR-0001
+title: Test decision
+status: proposed
+owner: claude
+created_at: 2026-05-11T00:00:00Z
+last_updated: 2026-05-11T00:00:00Z
+"#;
+
+        let doc: AdrFileDocument = serde_yaml::from_str(yaml).expect("deserialize v1");
+
+        assert_eq!(doc.schema_version, 1);
+        assert!(doc.adr.tags.is_empty());
+        assert!(doc.adr.paths.is_empty());
     }
 }

--- a/crates/orbit-store/src/file/scoreboard/scoreboard_summary.rs
+++ b/crates/orbit-store/src/file/scoreboard/scoreboard_summary.rs
@@ -1286,6 +1286,8 @@ mod tests {
             last_updated: Utc::now(),
             related_features: Vec::new(),
             related_tasks: Vec::new(),
+            tags: Vec::new(),
+            paths: Vec::new(),
             supersedes: Vec::new(),
             superseded_by: None,
             legacy_ids: Vec::new(),

--- a/crates/orbit-store/src/sqlite/migration.rs
+++ b/crates/orbit-store/src/sqlite/migration.rs
@@ -109,9 +109,9 @@ pub(crate) fn apply_schema(conn: &Connection) -> Result<(), OrbitError> {
 
             -- ADR envelope index. Bodies live on disk under <root>/<state>/<id>/body.md;
             -- this table indexes the YAML envelope fields for filter queries.
-            -- Arrays (related_features, related_tasks, legacy_ids, supersedes,
-            -- validation_warnings) are stored as JSON-encoded strings so filters
-            -- can use `LIKE '%"<value>"%'` until the corpus warrants junction
+            -- Arrays (related_features, related_tasks, tags, paths, legacy_ids,
+            -- supersedes, validation_warnings) are stored as JSON-encoded strings
+            -- so filters can use `LIKE '%"<value>"%'` until the corpus warrants junction
             -- tables. Per ADR-010 in docs/design/adr-artifact, FTS5 over body
             -- content is owned by `orbit-search::vector`, not this schema.
             CREATE TABLE IF NOT EXISTS adrs (
@@ -121,6 +121,8 @@ pub(crate) fn apply_schema(conn: &Connection) -> Result<(), OrbitError> {
                 owner TEXT NOT NULL,
                 related_features TEXT NOT NULL DEFAULT '[]',
                 related_tasks TEXT NOT NULL DEFAULT '[]',
+                tags TEXT NOT NULL DEFAULT '[]',
+                paths TEXT NOT NULL DEFAULT '[]',
                 legacy_ids TEXT NOT NULL DEFAULT '[]',
                 supersedes TEXT NOT NULL DEFAULT '[]',
                 superseded_by TEXT,
@@ -139,12 +141,24 @@ pub(crate) fn apply_schema(conn: &Connection) -> Result<(), OrbitError> {
 
     ensure_agent_sessions_schema(conn)?;
     ensure_tools_schema(conn)?;
+    ensure_adr_index_schema(conn)?;
     ensure_audit_events_schema(conn)?;
     ensure_task_reservations_schema(conn)?;
     ensure_learning_index_schema(conn)?;
     ensure_invocation_schema(conn)?;
 
     Ok(())
+}
+
+fn ensure_adr_index_schema(conn: &Connection) -> Result<(), OrbitError> {
+    add_column_if_missing(
+        conn,
+        "ALTER TABLE adrs ADD COLUMN tags TEXT NOT NULL DEFAULT '[]'",
+    )?;
+    add_column_if_missing(
+        conn,
+        "ALTER TABLE adrs ADD COLUMN paths TEXT NOT NULL DEFAULT '[]'",
+    )
 }
 
 fn ensure_learning_index_schema(conn: &Connection) -> Result<(), OrbitError> {
@@ -623,6 +637,8 @@ mod tests {
             })
             .collect();
         assert_eq!(primary_key_columns, vec!["id"]);
+        assert!(table_has_column(&conn, "adrs", "tags").expect("tags column"));
+        assert!(table_has_column(&conn, "adrs", "paths").expect("paths column"));
 
         for index_name in ["idx_adrs_status", "idx_adrs_owner"] {
             let count: i64 = conn

--- a/crates/orbit-tools/src/builtin/orbit/adr/add.rs
+++ b/crates/orbit-tools/src/builtin/orbit/adr/add.rs
@@ -46,6 +46,22 @@ impl Tool for OrbitAdrAddTool {
                 param_type: "string_list".to_string(),
                 required: false,
             },
+            ToolParam {
+                name: "tags".to_string(),
+                description:
+                    "Free-form ADR labels. Defaults to an empty list when omitted."
+                        .to_string(),
+                param_type: "string_list".to_string(),
+                required: false,
+            },
+            ToolParam {
+                name: "paths".to_string(),
+                description:
+                    "Repo-relative glob patterns for code or docs areas constrained by this ADR. Defaults to an empty list when omitted."
+                        .to_string(),
+                param_type: "string_list".to_string(),
+                required: false,
+            },
         ];
         parameters.extend(super::super::model_identity_params());
         ToolSchema {

--- a/crates/orbit-tools/src/builtin/orbit/adr/list.rs
+++ b/crates/orbit-tools/src/builtin/orbit/adr/list.rs
@@ -45,6 +45,22 @@ impl Tool for OrbitAdrListTool {
                 required: false,
             },
             ToolParam {
+                name: "tag".to_string(),
+                description:
+                    "Filter by free-form ADR tag. Case-insensitive equality against any tag."
+                        .to_string(),
+                param_type: "string".to_string(),
+                required: false,
+            },
+            ToolParam {
+                name: "path".to_string(),
+                description:
+                    "Filter by repo-relative path contained by any ADR `paths` glob."
+                        .to_string(),
+                param_type: "string".to_string(),
+                required: false,
+            },
+            ToolParam {
                 name: "validation_warned".to_string(),
                 description:
                     "When true, return only ADRs with `legacy_validation = warned`. When false, exclude them."
@@ -64,7 +80,7 @@ impl Tool for OrbitAdrListTool {
         ToolSchema {
             name: "orbit.adr.list".to_string(),
             description:
-                "List ADRs filtered by status, owner, feature, task_id, legacy_id, or validation flag. Returns envelope-only records sorted descending by global ID."
+                "List ADRs filtered by status, owner, feature, task_id, legacy_id, tag, path, or validation flag. Returns envelope-only records sorted descending by global ID."
                     .to_string(),
             parameters,
             builtin: true,

--- a/crates/orbit-tools/src/builtin/orbit/adr/update.rs
+++ b/crates/orbit-tools/src/builtin/orbit/adr/update.rs
@@ -55,6 +55,22 @@ impl Tool for OrbitAdrUpdateTool {
                 required: false,
             },
             ToolParam {
+                name: "tags".to_string(),
+                description:
+                    "Replacement free-form ADR labels. Empty list clears existing tags; absence leaves them unchanged."
+                        .to_string(),
+                param_type: "string_list".to_string(),
+                required: false,
+            },
+            ToolParam {
+                name: "paths".to_string(),
+                description:
+                    "Replacement repo-relative applicability globs. Empty list clears existing paths; absence leaves them unchanged."
+                        .to_string(),
+                param_type: "string_list".to_string(),
+                required: false,
+            },
+            ToolParam {
                 name: "supersedes".to_string(),
                 description: "Replacement supersedes list.".to_string(),
                 param_type: "string_list".to_string(),

--- a/crates/orbit-tools/src/builtin/orbit/search.rs
+++ b/crates/orbit-tools/src/builtin/orbit/search.rs
@@ -63,7 +63,7 @@ impl Tool for OrbitSearchTool {
             ToolParam {
                 name: "tag".to_string(),
                 description:
-                    "AND-filter by tag. Repeat or pass an array. Applies to task, doc, learning; ADR is deferred to phase 3."
+                    "AND-filter by tag. Repeat or pass an array. Applies to task, doc, learning, and ADR."
                         .to_string(),
                 param_type: "string_list".to_string(),
                 required: false,
@@ -87,7 +87,7 @@ impl Tool for OrbitSearchTool {
             ToolParam {
                 name: "path".to_string(),
                 description:
-                    "Filter to artifacts applicable to this filesystem path. Task: selector containment. Learning: glob-containment over scope.paths. ADR deferred (returns empty); doc out of scope (returns empty)."
+                    "Filter to artifacts applicable to this filesystem path. Task: selector containment. Learning and ADR: glob-containment over applicability globs. Doc out of scope (returns empty)."
                         .to_string(),
                 param_type: "string".to_string(),
                 required: false,

--- a/docs/design/adr-artifact/1_overview.md
+++ b/docs/design/adr-artifact/1_overview.md
@@ -3,7 +3,7 @@ summary: "ADR Artifact — Overview"
 type: design
 title: "ADR Artifact — Overview"
 owner: claude
-last_updated: 2026-05-20
+last_updated: 2026-05-21
 status: Draft
 feature: adr-artifact
 doc_role: overview
@@ -53,7 +53,9 @@ A typed record with structured metadata and a markdown body:
 - `supersedes` / `superseded_by` — optional ID references for chains
 - `related_features` — list of feature folder names this decision touches (N:M, not 1:1)
 - `related_tasks` — list of Orbit task IDs that proposed or shipped the decision
-- `legacy_id` — optional, set during migration (e.g. `"activity-job/ADR-017"`) so historical references resolve
+- `tags` — free-form labels for cross-artifact queries, distinct from constrained `related_features`
+- `paths` — repo-relative glob patterns for code or docs areas constrained by the decision
+- `legacy_ids` — optional aliases set during migration (e.g. `"activity-job/ADR-017"`) so historical references resolve
 
 Numbering is **global, not per-feature.** The current per-feature scheme (`ADR-001` exists in multiple folders) makes cross-folder reference ambiguous and is the first thing migration breaks. Globally unique IDs let any doc cite any ADR without folder qualification.
 

--- a/docs/design/adr-artifact/2_design.md
+++ b/docs/design/adr-artifact/2_design.md
@@ -3,7 +3,7 @@ summary: "ADR Artifact — Design"
 type: design
 title: "ADR Artifact — Design"
 owner: claude
-last_updated: 2026-05-20
+last_updated: 2026-05-21
 status: Draft
 feature: adr-artifact
 doc_role: design
@@ -29,6 +29,7 @@ An ADR is a per-ADR directory containing a YAML envelope and a markdown body. Th
 `adr.yaml`:
 
 ```yaml
+schema_version: 2
 id: ADR-0042
 title: Resolve sandbox-exec wrapper from a trusted absolute path
 status: accepted
@@ -38,11 +39,15 @@ accepted_at: 2026-05-09T18:01:00Z
 last_updated: 2026-05-09T18:01:00Z
 related_features: [activity-job, policy-sandbox]
 related_tasks: [T20260509-30]
+tags: [sandbox, policy]
+paths: [crates/orbit-exec/**, crates/orbit-policy/**]
 supersedes: []
 superseded_by: null
 legacy_ids:
   - activity-job/ADR-039
 ```
+
+`schema_version: 2` adds the two free-form retrieval axes: `tags` and `paths`. `tags` are label vocabulary for cross-artifact search and are distinct from `related_features`, which remains a structural reference to feature folder names. `paths` are repo-relative glob patterns for areas constrained by the decision. Readers accept v1 envelopes that omit both fields for one compatibility window, treating absence as empty lists; writers emit v2.
 
 `legacy_ids` is an array, not a scalar. A normal ADR migrates with one entry; a CONVENTIONS §4a **rollup** carries one entry per folded source heading. This is what lets `activity-job/ADR-003` (a folded heading with body removed) and `activity-job/ADR-005` (the rollup that absorbed it) both resolve through `orbit.adr.list --legacy-id=...` without producing body-less artifacts. See [ADR-0016](./4_decisions.md#adr-002--global-adr-numbering-not-per-feature).
 
@@ -106,7 +111,7 @@ Six tools, contracts below. All return structured JSON; CLI surfaces are thin wr
 
 ### 4.1 `orbit.adr.add`
 
-Creates a `proposed` ADR. Input: `title`, `owner`, `related_features`, optional `related_tasks`, optional initial body sections. Output: assigned `id`. Errors: invalid feature name, missing required field.
+Creates a `proposed` ADR. Input: `title`, `owner`, `related_features`, optional `related_tasks`, optional `tags`, optional `paths`, optional initial body sections. Omitted `tags` and `paths` default to empty lists. Output: assigned `id`. Errors: invalid feature name, missing required field.
 
 ### 4.2 `orbit.adr.show`
 
@@ -114,11 +119,11 @@ Input: `id`. Output: full envelope + body. Errors: not found.
 
 ### 4.3 `orbit.adr.list`
 
-Input: optional filters (`feature`, `status`, `owner`, `task_id`, `since`). Output: array of envelopes (no body). Sort: by `id` descending by default.
+Input: optional filters (`feature`, `status`, `owner`, `task_id`, `tag`, `path`, `since`). `tag` is case-insensitive equality against any element of `tags`; `path` is glob-containment against `paths`. Output: array of envelopes (no body). Sort: by `id` descending by default.
 
 ### 4.4 `orbit.adr.update`
 
-Input: `id`, plus any subset of (`status`, body sections, `related_tasks`, `related_features`, `owner`). Status transitions enforced:
+Input: `id`, plus any subset of (`status`, body sections, `related_tasks`, `related_features`, `tags`, `paths`, `owner`). Empty `tags` or `paths` clears the field; absence leaves it unchanged. Status transitions enforced:
 
 - `proposed → accepted` requires non-empty `related_tasks` on the update payload (the task that shipped it).
 - `proposed → superseded` and `accepted → superseded` go through `adr.supersede` instead — direct status writes to `superseded` are rejected.

--- a/docs/design/adr-artifact/4_decisions.md
+++ b/docs/design/adr-artifact/4_decisions.md
@@ -3,7 +3,7 @@ summary: "ADR Artifact — Decisions"
 type: design
 title: "ADR Artifact — Decisions"
 owner: claude
-last_updated: 2026-05-10
+last_updated: 2026-05-21
 status: Draft
 feature: adr-artifact
 doc_role: decisions
@@ -216,9 +216,28 @@ In-place amendment policy: ADRs in `Proposed` status may be refined directly bef
 
 ---
 
+## ADR-0178 — ADR envelope tags and paths
+
+**Status:** Accepted · 2026-05 · [ORB-00203]
+
+**Context.** Phase 2 left `--tag` and `--path` as no-op filters for ADRs because ADR envelopes had no free-form labels or applicability paths. Reusing `related_features` would collapse constrained feature-folder references into loose tags, and it still would not answer pre-edit path applicability queries.
+
+**Decision.** Add `tags: [string]` and `paths: [string]` to ADR envelope YAML, bump newly written envelopes to `schema_version: 2`, and keep v1 readers compatible by treating missing fields as empty lists. `orbit.adr.list` and `orbit search` filter ADRs through these fields with case-insensitive tag equality and glob-containment path semantics.
+
+**Consequences.**
+
+- Cross-artifact label and path queries can include ADRs alongside tasks, docs, and learnings.
+- Existing ADR envelopes are backfilled with explicit empty defaults; owners populate meaningful tags and paths when they next touch a decision.
+- No automatic inference from title, body, or `related_features` is attempted, keeping false labels out of durable decision metadata.
+- No single code anchor owns this behavior; it is enforced across the ADR store schema, tool schemas, search command, and their focused tests.
+- Cost: the schema bump touches every ADR envelope and adds two author-maintained metadata axes that can drift if reviewers do not keep them current.
+
+---
+
 ## Task References
 
 - [T20260510-27] — Drafted the adr-artifact design folder as a v2 proposal. The original nine ADRs (001–009) are all `Proposed`; each will be flipped to `Accepted` and cite its shipping task ID as v2 implementation work lands.
 - [T20260510-28] — Addressed codex P1/P2 review findings: ADR-002 amended in place to cover `legacy_ids` array and rollup aliasing; ADR-006 amended in place with two named canonical orders; ADR-010 added (search tool placement in `orbit-embed`); ADR-011 added (lenient migration mode as default).
+- [ORB-00203] — Added ADR envelope `tags` and `paths`, v2 schema writing, explicit-empty backfill, and ADR tag/path filters in `orbit.adr.list` and `orbit search`.
 
 Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.

--- a/docs/design/orbit-search/4_decisions.md
+++ b/docs/design/orbit-search/4_decisions.md
@@ -3,7 +3,7 @@ summary: "Semantic Search — Decisions"
 type: design
 title: "Semantic Search — Decisions"
 owner: claude
-last_updated: 2026-05-20
+last_updated: 2026-05-21
 status: Accepted
 feature: orbit-search
 doc_role: decisions
@@ -239,15 +239,15 @@ Compare to the analogous knowledge-graph crate: `orbit-knowledge` owns its data 
 
 **Context.** After [ADR-0174] and [ADR-0175] consolidated `orbit search` as the unified query surface, the per-domain `task`, `docs`, and `learning` `search` subcommands of `orbit` became redundant for content-similarity queries. The `learning` variant in particular bundled three unrelated operations under one verb: substring search (content), path-glob applicability lookup (structural), and tag filter (structural). Agents pre-edit also need a single cross-kind command that answers *"given this file path, what tasks / learnings / ADRs apply here?"* — the context-pack query.
 
-**Decision.** Hard-remove the per-domain `task`, `docs`, and `learning` `search` subcommands of `orbit` (CLI + MCP). Re-home their filters under universal flags on `orbit search`: `--tag <T>` (AND semantics, repeatable, case-insensitive), `--all` (kind-aware status widener), `--status <comma-set>` (explicit per-kind override), and `--path <P>` (cross-kind applicability filter — selector-mapping for tasks, glob-containment for learnings, deferred to phase 3 for ADRs, out of scope for docs). Add `orbit task list --path`; flip `orbit learning list --path` from exact-match to glob-containment. The old `--include-superseded` mental model from the retired per-domain doc surface is replaced by `orbit search --kind adr --all`. The structural-vs-content split — `search` for indexed content, `list` for structural filters — is enforced by the flag layout.
+**Decision.** Hard-remove the per-domain `task`, `docs`, and `learning` `search` subcommands of `orbit` (CLI + MCP). Re-home their filters under universal flags on `orbit search`: `--tag <T>` (AND semantics, repeatable, case-insensitive), `--all` (kind-aware status widener), `--status <comma-set>` (explicit per-kind override), and `--path <P>` (cross-kind applicability filter — selector-mapping for tasks, glob-containment for learnings and ADRs after [ORB-00203], out of scope for docs). Add `orbit task list --path`; flip `orbit learning list --path` from exact-match to glob-containment. The old `--include-superseded` mental model from the retired per-domain doc surface is replaced by `orbit search --kind adr --all`. The structural-vs-content split — `search` for indexed content, `list` for structural filters — is enforced by the flag layout.
 
 **Consequences.**
 - One mental model: `orbit search` queries indexed content, `orbit <kind> list` filters structural metadata.
 - The agent context-pack query collapses to a single command (`orbit search --path <file> --kind all`).
 - Universal `--all` / `--status` vocabulary replaces the patchwork of kind-specific flags (`--include-superseded`).
-- Phase-3 (ORB-00203) gets a clean specification: `--path X --kind adr` and `--tag X --kind adr` already exist as no-op branches; phase 3 fills them in by adding ADR frontmatter fields, without changing the public surface.
+- ORB-00203 fills the ADR filter branches by adding ADR `tags` and `paths`, without changing the public search surface.
 - Cost: the `learning list --path` semantics flip is the only observable behavior change. Scripts calling `orbit learning list --path 'src/auth/**'` expecting exact-match scoped lookups will now also see paths *inside* that glob. The migration target for ex-`learning search --path` callers is unchanged because the new semantics match what that deleted command already did.
-- Cost: ADR carries `--tag` and `--path` no-ops in two flag positions, documented in `--help`, until phase 3 lights them up.
+- Cost: during phase 2, ADR carried `--tag` and `--path` placeholders in two flag positions; ORB-00203 closes that gap by making those positions real filters.
 - Cost: `AdrStatus` has no `Deprecated` variant, so `--all` adds `Superseded` only on ADRs. Asymmetric with task widening (which gets multiple terminal states); revisited if a deprecated state ever becomes load-bearing.
 
 ---
@@ -261,5 +261,6 @@ Compare to the analogous knowledge-graph crate: `orbit-knowledge` owns its data 
 - [ORB-00196] — Split `orbit semantic` lifecycle from the unified `orbit search` query surface. The task that accepted and implemented ADR-0174.
 - [ORB-00204] — Rename `orbit search` flags to `--hybrid` for free-text vector ranking and `--semantic <id>` for task-neighbor lookup. The task that accepted and implemented ADR-0175.
 - [ORB-00202] — Consolidate per-domain search subcommands and add cross-kind `--path` / `--tag` filters. The task that proposed and implemented ADR-0176.
+- [ORB-00203] — Add ADR envelope `tags` and `paths` so ADRs participate in cross-kind `--tag` / `--path` search filters.
 
 Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.


### PR DESCRIPTION
## Summary
- Add ADR envelope `tags` and `paths` fields with schema v2 writing and v1 read compatibility.
- Extend `orbit.adr.add`, `orbit.adr.update`, and `orbit.adr.list` to handle the new metadata and filters.
- Wire ADR tag/path matching into `orbit search --kind adr|all`, including tag-only CLI searches and match annotations.
- Backfill existing ADR envelopes with explicit empty `tags` and `paths`, and add accepted ADR-0178 documenting the decision.

## Why
ORB-00202 left ADR `--tag` and `--path` filtering deferred because ADR envelopes had no free-form labels or path applicability metadata. ORB-00203 closes that gap so cross-kind context queries can surface ADRs alongside tasks, docs, and learnings.

## Impact
Agents and users can now run ADR-aware queries such as `orbit search --tag perf --kind adr`, `orbit search --path crates/orbit-search/src/lib.rs --kind adr`, and combined `--kind all` searches. Existing ADRs remain compatible and are backfilled with empty defaults for discoverability.

## Validation
- `cargo test -p orbit-store adr_store`
- `cargo test -p orbit-search lexical::docs`
- `cargo test -p orbit-core command::search::tests`
- `cargo test -p orbit-core runtime::orbit_tool_host::adr_tools::tests`
- `cargo test -p orbit-cli search`
- `cargo build -p orbit-cli --bin orbit`
- `make ci-fast`
- `git diff --check`

Manual sanity checks confirmed ADR-0178 appears for tag-only, path-only, and combined `--kind all` search filters.
