### PR TITLE
Record knowledge run metrics for the Metrics / Knowledge dashboard

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2127,6 +2127,7 @@ dependencies = [
  "serde_yaml",
  "sha2",
  "tempfile",
+ "tiktoken-rs",
  "toml",
  "tracing",
 ]

--- a/crates/orbit-core/Cargo.toml
+++ b/crates/orbit-core/Cargo.toml
@@ -30,6 +30,7 @@ serde.workspace = true
 serde_yaml.workspace = true
 sha2.workspace = true
 tempfile = "3"
+tiktoken-rs.workspace = true
 toml.workspace = true
 tracing.workspace = true
 

--- a/crates/orbit-core/src/knowledge_stats.rs
+++ b/crates/orbit-core/src/knowledge_stats.rs
@@ -1,7 +1,8 @@
 use std::cmp::Ordering;
 
-use orbit_common::types::JobRun;
+use orbit_common::types::{InvocationTrace, JobRun, KnowledgeRunMetrics, ToolCallTrace};
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct RatioSummary {
@@ -34,6 +35,66 @@ pub struct KnowledgeStatsSummary {
     pub compression: Option<RatioSummary>,
     pub double_read: DoubleReadSummary,
     pub total_llm_input_tokens: TokenInputSummary,
+}
+
+#[derive(Debug, Default)]
+struct KnowledgeMetricsDelta {
+    saw_knowledge_tool: bool,
+    saw_pack: bool,
+    resolved_pack_entries: u64,
+    explicit_raw_read_baseline: u64,
+    explicit_pack_tokens: u64,
+    estimated_pack_tokens: u64,
+    fs_read_tokens: u64,
+    unresolved_count: u32,
+    total_llm_input_tokens: u64,
+}
+
+pub fn merge_invocation_knowledge_metrics(
+    existing: Option<&KnowledgeRunMetrics>,
+    trace: &InvocationTrace,
+) -> Option<KnowledgeRunMetrics> {
+    let delta = KnowledgeMetricsDelta::from_trace(trace);
+    if existing.is_none() && !delta.saw_knowledge_tool {
+        return None;
+    }
+
+    let mut metrics = existing.cloned().unwrap_or_default();
+    metrics.raw_read_token_baseline = metrics
+        .raw_read_token_baseline
+        .saturating_add(delta.raw_read_token_baseline());
+    metrics.actual_fs_read_tokens_during_run = metrics
+        .actual_fs_read_tokens_during_run
+        .saturating_add(delta.fs_read_tokens);
+    metrics.knowledge_pack_used = metrics.knowledge_pack_used
+        || (delta.saw_pack && (delta.resolved_pack_entries > 0 || delta.unresolved_count == 0));
+    metrics.knowledge_pack_unresolved_count = metrics
+        .knowledge_pack_unresolved_count
+        .saturating_add(delta.unresolved_count);
+    metrics.total_llm_input_tokens = metrics
+        .total_llm_input_tokens
+        .saturating_add(delta.total_llm_input_tokens);
+
+    if delta.saw_pack || metrics.knowledge_pack_tokens.is_some() {
+        let current = metrics.knowledge_pack_tokens.unwrap_or_default();
+        metrics.knowledge_pack_tokens = Some(current.saturating_add(delta.knowledge_pack_tokens()));
+    }
+
+    metrics.compression_ratio = metrics
+        .knowledge_pack_used
+        .then(|| {
+            ratio(
+                metrics.raw_read_token_baseline,
+                metrics.knowledge_pack_tokens.unwrap_or(0),
+            )
+        })
+        .flatten();
+    metrics.double_read_rate = ratio(
+        metrics.actual_fs_read_tokens_during_run,
+        metrics.raw_read_token_baseline,
+    );
+
+    Some(metrics)
 }
 
 pub fn aggregate(runs: &[JobRun]) -> KnowledgeStatsSummary {
@@ -128,4 +189,211 @@ fn percentile(sorted: &[f64], pct: usize) -> f64 {
 
 fn ratio(numerator: u64, denominator: u64) -> Option<f64> {
     (denominator != 0).then_some(numerator as f64 / denominator as f64)
+}
+
+impl KnowledgeMetricsDelta {
+    fn from_trace(trace: &InvocationTrace) -> Self {
+        let mut delta = Self {
+            total_llm_input_tokens: trace
+                .usage
+                .input
+                .saturating_add(trace.usage.cache_read)
+                .saturating_add(trace.usage.cache_create),
+            ..Self::default()
+        };
+
+        for call in &trace.tool_calls {
+            match call.tool_name.as_str() {
+                "orbit.graph.pack" => delta.observe_pack_call(call),
+                "fs.read" => delta.observe_fs_read_call(call),
+                _ => {}
+            }
+        }
+
+        delta
+    }
+
+    fn observe_pack_call(&mut self, call: &ToolCallTrace) {
+        self.saw_knowledge_tool = true;
+        self.saw_pack = true;
+        let estimated_tokens = tool_result_tokens(call);
+        self.estimated_pack_tokens = self.estimated_pack_tokens.saturating_add(estimated_tokens);
+
+        if let Some(payload) = call.result_payload.as_ref() {
+            self.explicit_raw_read_baseline = self
+                .explicit_raw_read_baseline
+                .saturating_add(sum_metric_fields(payload, RAW_BASELINE_KEYS));
+            self.explicit_pack_tokens = self
+                .explicit_pack_tokens
+                .saturating_add(sum_metric_fields(payload, PACK_TOKEN_KEYS));
+            self.unresolved_count = self
+                .unresolved_count
+                .saturating_add(count_unresolved_selectors(payload));
+            self.resolved_pack_entries = self
+                .resolved_pack_entries
+                .saturating_add(count_pack_entries(payload));
+        }
+    }
+
+    fn observe_fs_read_call(&mut self, call: &ToolCallTrace) {
+        self.saw_knowledge_tool = true;
+        self.fs_read_tokens = self.fs_read_tokens.saturating_add(tool_result_tokens(call));
+    }
+
+    fn knowledge_pack_tokens(&self) -> u64 {
+        if self.explicit_pack_tokens > 0 {
+            self.explicit_pack_tokens
+        } else {
+            self.estimated_pack_tokens
+        }
+    }
+
+    fn raw_read_token_baseline(&self) -> u64 {
+        if !self.saw_pack {
+            return self.fs_read_tokens;
+        }
+
+        let pack_baseline = if self.explicit_raw_read_baseline > 0 {
+            self.explicit_raw_read_baseline
+        } else {
+            self.knowledge_pack_tokens()
+        };
+
+        if self.unresolved_count > 0 {
+            pack_baseline.saturating_add(self.fs_read_tokens)
+        } else {
+            pack_baseline.max(self.fs_read_tokens)
+        }
+    }
+}
+
+const RAW_BASELINE_KEYS: &[&str] = &[
+    "raw_read_token_baseline",
+    "rawReadTokenBaseline",
+    "raw_read_tokens",
+    "rawReadTokens",
+    "baseline_tokens",
+    "baselineTokens",
+    "source_tokens",
+    "sourceTokens",
+];
+
+const PACK_TOKEN_KEYS: &[&str] = &[
+    "knowledge_pack_tokens",
+    "knowledgePackTokens",
+    "pack_tokens",
+    "packTokens",
+    "compressed_tokens",
+    "compressedTokens",
+];
+
+fn tool_result_tokens(call: &ToolCallTrace) -> u64 {
+    call.result_payload
+        .as_ref()
+        .map(value_token_count)
+        .unwrap_or_else(|| bytes_to_token_estimate(call.result_bytes))
+}
+
+fn value_token_count(value: &Value) -> u64 {
+    let text = match value {
+        Value::String(text) => text.clone(),
+        other => match serde_json::to_string(other) {
+            Ok(text) => text,
+            Err(_) => return 0,
+        },
+    };
+
+    tiktoken_rs::cl100k_base_singleton()
+        .encode_with_special_tokens(&text)
+        .len() as u64
+}
+
+fn bytes_to_token_estimate(bytes: u64) -> u64 {
+    bytes.saturating_add(3) / 4
+}
+
+fn sum_metric_fields(value: &Value, keys: &[&str]) -> u64 {
+    match value {
+        Value::Object(map) => {
+            let direct = keys
+                .iter()
+                .filter_map(|key| map.get(*key))
+                .filter_map(value_as_u64)
+                .fold(0u64, u64::saturating_add);
+            if direct > 0 {
+                return direct;
+            }
+            map.values()
+                .map(|child| sum_metric_fields(child, keys))
+                .fold(0u64, u64::saturating_add)
+        }
+        Value::Array(items) => items
+            .iter()
+            .map(|child| sum_metric_fields(child, keys))
+            .fold(0u64, u64::saturating_add),
+        _ => 0,
+    }
+}
+
+fn count_unresolved_selectors(value: &Value) -> u32 {
+    fn count(value: &Value) -> u64 {
+        match value {
+            Value::Object(map) => map
+                .iter()
+                .map(|(key, child)| {
+                    if matches!(key.as_str(), "unresolved_selectors" | "unresolvedSelectors") {
+                        child
+                            .as_array()
+                            .map(|items| items.len() as u64)
+                            .unwrap_or(0)
+                    } else if matches!(
+                        key.as_str(),
+                        "knowledge_pack_unresolved_count"
+                            | "knowledgePackUnresolvedCount"
+                            | "unresolved_count"
+                            | "unresolvedCount"
+                    ) {
+                        value_as_u64(child).unwrap_or(0)
+                    } else {
+                        count(child)
+                    }
+                })
+                .fold(0u64, u64::saturating_add),
+            Value::Array(items) => items.iter().map(count).fold(0u64, u64::saturating_add),
+            _ => 0,
+        }
+    }
+
+    count(value).min(u32::MAX as u64) as u32
+}
+
+fn count_pack_entries(value: &Value) -> u64 {
+    match value {
+        Value::Object(map) => {
+            let direct = map
+                .get("entries")
+                .and_then(Value::as_array)
+                .map(|items| items.len() as u64)
+                .unwrap_or(0);
+            if direct > 0 {
+                return direct;
+            }
+            map.values()
+                .map(count_pack_entries)
+                .fold(0u64, u64::saturating_add)
+        }
+        Value::Array(items) => items
+            .iter()
+            .map(count_pack_entries)
+            .fold(0u64, u64::saturating_add),
+        _ => 0,
+    }
+}
+
+fn value_as_u64(value: &Value) -> Option<u64> {
+    match value {
+        Value::Number(number) => number.as_u64(),
+        Value::String(raw) => raw.parse::<u64>().ok(),
+        _ => None,
+    }
 }

--- a/crates/orbit-core/src/runtime/v2_host/mod.rs
+++ b/crates/orbit-core/src/runtime/v2_host/mod.rs
@@ -33,6 +33,7 @@ use orbit_tools::{FsAuditLogger, ReservationOwnerContext, ToolContext};
 use serde_json::Value;
 
 use crate::OrbitRuntime;
+use crate::knowledge_stats::merge_invocation_knowledge_metrics;
 use crate::runtime::build_orbit_tool_host;
 
 impl V2RuntimeHost for OrbitRuntime {
@@ -162,6 +163,23 @@ impl V2RuntimeHost for OrbitRuntime {
             );
         }
 
+        let existing = self
+            .get_job_run_backend(job_run_id)
+            .map_err(|error| {
+                DispatchError::JobExecution(format!("read job run for knowledge metrics: {error}"))
+            })?
+            .and_then(|run| run.knowledge_metrics);
+        if let Some(metrics) = merge_invocation_knowledge_metrics(existing.as_ref(), trace) {
+            self.stores()
+                .jobs()
+                .record_run_knowledge_metrics(job_run_id, metrics)
+                .map_err(|error| {
+                    DispatchError::JobExecution(format!(
+                        "record job-run knowledge metrics: {error}"
+                    ))
+                })?;
+        }
+
         Ok(())
     }
 
@@ -230,7 +248,9 @@ mod tests {
     use std::sync::{Mutex, MutexGuard, OnceLock};
 
     use orbit_common::types::activity_job::{AgentLoopSpec, Backend, OnDenial, Provider};
-    use orbit_common::types::{TaskPriority, TaskStatus, TaskType};
+    use orbit_common::types::{
+        InvocationTrace, JobRunState, TaskPriority, TaskStatus, TaskType, TokenUsage, ToolCallTrace,
+    };
     use orbit_engine::{V2AuditWriter, drive_agent_loop, reset_replay_transport};
     use tempfile::NamedTempFile;
 
@@ -281,6 +301,167 @@ mod tests {
         )
         .expect("write replay fixture");
         file
+    }
+
+    fn seed_running_job_run(runtime: &OrbitRuntime, job_id: &str) -> String {
+        let run = runtime
+            .stores()
+            .jobs()
+            .insert_run(job_id, 1, chrono::Utc::now(), None, None)
+            .expect("insert job run");
+        runtime
+            .stores()
+            .jobs()
+            .mark_run_running(&run.run_id, chrono::Utc::now(), std::process::id())
+            .expect("mark run running");
+        run.run_id
+    }
+
+    fn payload_tool_call(seq: u32, tool_name: &str, payload: Value) -> ToolCallTrace {
+        ToolCallTrace {
+            seq,
+            tool_name: tool_name.to_string(),
+            result_bytes: serde_json::to_vec(&payload)
+                .expect("serialize payload")
+                .len() as u64,
+            result_payload: Some(payload),
+        }
+    }
+
+    fn byte_count_tool_call(seq: u32, tool_name: &str, result_bytes: u64) -> ToolCallTrace {
+        ToolCallTrace {
+            seq,
+            tool_name: tool_name.to_string(),
+            result_bytes,
+            result_payload: None,
+        }
+    }
+
+    fn trace_with_tool_calls(input_tokens: u64, tool_calls: Vec<ToolCallTrace>) -> InvocationTrace {
+        InvocationTrace {
+            usage: TokenUsage {
+                input: input_tokens,
+                cache_read: 0,
+                cache_create: 0,
+                output: 0,
+            },
+            tool_calls,
+            duration_ms: 10,
+        }
+    }
+
+    fn persist_test_trace(runtime: &OrbitRuntime, run_id: &str, trace: &InvocationTrace) {
+        V2RuntimeHost::persist_invocation_trace(
+            runtime,
+            run_id,
+            "knowledge_step",
+            "codex",
+            Some("gpt-test"),
+            &serde_json::json!({ "task_id": "ORB-KNOWLEDGE-TEST" }),
+            trace,
+        )
+        .expect("persist invocation trace");
+    }
+
+    #[test]
+    fn persist_invocation_trace_records_pack_metrics_before_terminal_state() {
+        let (_root, runtime, repo_root) = runtime_with_workspace_layout();
+        let run_id = seed_running_job_run(&runtime, "knowledge_pack_job");
+        let trace = trace_with_tool_calls(
+            155,
+            vec![payload_tool_call(
+                1,
+                "orbit.graph.pack",
+                serde_json::json!({
+                    "raw_read_token_baseline": 400,
+                    "knowledge_pack_tokens": 100,
+                    "entries": [{ "selector": "file:src/lib.rs", "source": "pub fn demo() {}" }],
+                    "unresolved_selectors": [],
+                }),
+            )],
+        );
+
+        persist_test_trace(&runtime, &run_id, &trace);
+
+        let run = runtime.show_job_run(&run_id).expect("show job run");
+        assert_eq!(run.state, JobRunState::Running);
+        let metrics = run.knowledge_metrics.expect("knowledge metrics recorded");
+        assert!(metrics.knowledge_pack_used);
+        assert_eq!(metrics.raw_read_token_baseline, 400);
+        assert_eq!(metrics.knowledge_pack_tokens, Some(100));
+        assert_eq!(metrics.compression_ratio, Some(4.0));
+        assert_eq!(metrics.actual_fs_read_tokens_during_run, 0);
+        assert_eq!(metrics.double_read_rate, Some(0.0));
+        assert_eq!(metrics.knowledge_pack_unresolved_count, 0);
+        assert_eq!(metrics.total_llm_input_tokens, 155);
+
+        let jrun = repo_root
+            .join(".orbit/state/job-runs/knowledge_pack_job")
+            .join(&run_id)
+            .join("jrun.yaml");
+        let stored = std::fs::read_to_string(jrun).expect("read jrun yaml");
+        assert!(stored.contains("knowledge_metrics:"));
+    }
+
+    #[test]
+    fn persist_invocation_trace_records_fallback_and_double_read_metrics() {
+        let (_root, runtime, _repo_root) = runtime_with_workspace_layout();
+
+        let double_read_run_id = seed_running_job_run(&runtime, "knowledge_double_read_job");
+        let double_read_trace = trace_with_tool_calls(
+            90,
+            vec![
+                payload_tool_call(
+                    1,
+                    "orbit.graph.pack",
+                    serde_json::json!({
+                        "raw_read_token_baseline": 100,
+                        "knowledge_pack_tokens": 25,
+                        "entries": [{ "selector": "file:src/main.rs" }],
+                        "unresolved_selectors": ["file:src/missing.rs"],
+                    }),
+                ),
+                byte_count_tool_call(2, "fs.read", 80),
+            ],
+        );
+
+        persist_test_trace(&runtime, &double_read_run_id, &double_read_trace);
+
+        let double_read_run = runtime
+            .show_job_run(&double_read_run_id)
+            .expect("show double-read job run");
+        let metrics = double_read_run
+            .knowledge_metrics
+            .expect("double-read metrics recorded");
+        assert!(metrics.knowledge_pack_used);
+        assert_eq!(metrics.raw_read_token_baseline, 120);
+        assert_eq!(metrics.knowledge_pack_tokens, Some(25));
+        assert_eq!(metrics.knowledge_pack_unresolved_count, 1);
+        assert_eq!(metrics.actual_fs_read_tokens_during_run, 20);
+        assert!(
+            metrics
+                .double_read_rate
+                .is_some_and(|rate| (rate - (20.0 / 120.0)).abs() < f64::EPSILON)
+        );
+
+        let fallback_run_id = seed_running_job_run(&runtime, "knowledge_fallback_job");
+        let fallback_trace =
+            trace_with_tool_calls(50, vec![byte_count_tool_call(1, "fs.read", 120)]);
+
+        persist_test_trace(&runtime, &fallback_run_id, &fallback_trace);
+
+        let fallback_run = runtime
+            .show_job_run(&fallback_run_id)
+            .expect("show fallback job run");
+        let metrics = fallback_run
+            .knowledge_metrics
+            .expect("fallback metrics recorded");
+        assert!(!metrics.knowledge_pack_used);
+        assert_eq!(metrics.raw_read_token_baseline, 30);
+        assert_eq!(metrics.knowledge_pack_tokens, None);
+        assert_eq!(metrics.actual_fs_read_tokens_during_run, 30);
+        assert_eq!(metrics.double_read_rate, Some(1.0));
+        assert_eq!(metrics.total_llm_input_tokens, 50);
     }
 
     #[test]

--- a/crates/orbit-dashboard/src/api/metrics_tests.rs
+++ b/crates/orbit-dashboard/src/api/metrics_tests.rs
@@ -211,6 +211,7 @@ async fn metrics_endpoints_return_runtime_shapes() {
     let decoded_knowledge: orbit_core::knowledge_stats::KnowledgeStatsSummary =
         serde_json::from_slice(&knowledge_bytes).expect("knowledge json");
     assert_eq!(decoded_knowledge, expected_knowledge);
+    assert!(decoded_knowledge.total_runs > 0);
     assert_eq!(
         knowledge_bytes,
         serde_json::to_vec(&expected_knowledge).expect("expected knowledge json")


### PR DESCRIPTION
## Task

[ORB-00210](https://orbit-cli.com/tasks/ORB-00210) — Record knowledge run metrics for the Metrics / Knowledge dashboard

### Description

## Problem
The dashboard Metrics / Knowledge tab fetches `/api/metrics/knowledge`, and that endpoint aggregates `JobRun.knowledge_metrics` through `orbit_core::knowledge_stats::aggregate`. The UI empty state is displayed because the aggregate reports `total_runs: 0`.

Investigation found the producer side is missing: `record_job_run_knowledge_metrics` exists only as host/store plumbing, and source search shows no production caller that constructs or records `KnowledgeRunMetrics`. The current workspace has 380 job-run bundles under `.orbit/state/job-runs`, but `rg ^knowledge_metrics: .orbit/state/job-runs` returns 0 matches, so there is no persisted data for the endpoint to display.

## Why It Matters
The public metrics surface claims knowledge usage is read from job-run state, but normal runs never populate that state. Operators cannot see knowledge-pack adoption, fallback rate, compression, double-read rate, or token savings even after Orbit jobs execute.

## Constraints / Notes
- The dashboard empty state in `crates/orbit-dashboard/assets/dashboard/metrics.js` is a symptom, not the root cause.
- `docs/design/activity-job/2_design.md` states that `/api/metrics/knowledge` reads knowledge usage from job-run state, not audit JSONL scraping.
- Existing `KnowledgeRunMetrics` fields live on `JobRun`; prefer filling the existing run-level field instead of inventing a parallel metrics store.
- Keep validation deterministic; tests should seed temp job runs and mock/fake invocation traces instead of depending on the developer workspace `.orbit/knowledge` graph.

### Acceptance Criteria

- A v2 job run that uses `orbit.graph.pack` and/or falls back to `fs.read` persists non-null `knowledge_metrics` in its run bundle before the run reaches a terminal state; `orbit run show <run-id> --json` includes that field.
- `/api/metrics/knowledge?limit=N` returns `total_runs > 0` for seeded runs with knowledge metrics, and the dashboard Metrics / Knowledge tab renders summary sections instead of `No knowledge usage metrics found.` for that response.
- Automated coverage exercises the producer path with deterministic fake or seeded invocation traces, including at least one knowledge-pack run and one fallback/double-read scenario; tests do not require a real local `.orbit/knowledge` directory.
- `make ci-fast` passes after the fix.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Added producer-side merging from v2 invocation traces into JobRun.knowledge_metrics, covering orbit.graph.pack and fs.read traces with cl100k_base token counts, fallback/unresolved counts, compression, double-read rate, and total LLM input tokens.
- Wired v2 persist_invocation_trace to write merged knowledge metrics into the active job-run bundle before finalization.
- Added deterministic producer tests for pack, fallback, and double-read traces, plus a dashboard metrics API assertion that seeded knowledge metrics produce total_runs > 0.

Assessment: The Metrics / Knowledge endpoint now has real run-state data to aggregate, and make ci-fast plus focused producer/API tests pass.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-00210-6a0e65d6`
- Behind base: 0
- Ahead of base: 1