### PR TITLE
[codex] ORB-00206: Add doc corpus embeddings

### DIFF
--- a/.orbit/adrs/accepted/ADR-0180/adr.yaml
+++ b/.orbit/adrs/accepted/ADR-0180/adr.yaml
@@ -1,0 +1,26 @@
+schema_version: 2
+id: ADR-0180
+title: Doc corpus embeddings use docs index and opt-in hybrid search
+status: accepted
+owner: codex
+created_at: 2026-05-21T02:06:58.051542Z
+accepted_at: 2026-05-21T02:07:03.161740Z
+last_updated: 2026-05-21T02:10:33.828433Z
+related_features:
+- orbit-search
+- orbit-docs
+related_tasks:
+- ORB-00206
+tags:
+- orbit-search
+- orbit-docs
+- embeddings
+paths:
+- crates/orbit-core/src/command/docs.rs
+- crates/orbit-core/src/command/search.rs
+- crates/orbit-search/**
+- crates/orbit-cli/src/command/docs.rs
+supersedes: []
+legacy_ids: []
+validation_warnings: []
+legacy_validation: none

--- a/.orbit/adrs/accepted/ADR-0180/body.md
+++ b/.orbit/adrs/accepted/ADR-0180/body.md
@@ -1,0 +1,11 @@
+## Context
+Doc search was lexical-only after ORB-00202 unified the query surface, while the orbit-search store already had a source_kind discriminator that could hold docs. The alternatives were to keep semantic ranking deferred, add a separate docs search verb, or reuse the existing vector store behind the unified `orbit search --kind doc --hybrid` path.
+
+## Decision
+Use `orbit docs index` as the explicit admin verb that embeds configured docs roots into `source_kind = "doc"` rows, and keep retrieval opt-in through `orbit search <query> --kind doc --hybrid`. Lexical doc search remains the default, ADRs stay lifecycle-owned and lexical-only, and `[docs.search].semantic_weight` tunes the blend without adding another CLI flag.
+
+## Consequences
+- The old no-op docs indexing verb is retired rather than kept as a shim, so the docs lifecycle verb now matches `orbit semantic index`.
+- Doc embeddings reuse orbit-search storage and companion model selection without adding an orbit-search to orbit-core dependency.
+- Hybrid doc search can improve concept queries while preserving lexical fallback when the companion or doc rows are unavailable.
+- Cost: the docs index becomes a second freshness loop next to task semantic indexing; operators must run `orbit docs index` after substantial doc moves or edits until background indexing exists.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Breaking Changes
 
+- **Docs indexing verb renamed**: `orbit docs reindex` / `orbit.docs.reindex` is removed. Use `orbit docs index [--json] [--force] [--model <alias>]` / `orbit.docs.index` to build doc-corpus embeddings. ([ORB-00206])
 - **`orbit search` mode split and per-kind status syntax**: the query surface now has three visible CLI forms: `orbit search <query>`, `orbit search similar <id>`, and `orbit search path <path>`. The old `orbit search --semantic <id>` and `orbit search --path <path>` forms are removed. `--status` now requires `kind:value` tokens such as `task:open,doc:active,adr:proposed`; bare tokens like `--status open` are rejected. CLI `--field` / `--model` and MCP `field` / `embedding_model` are removed from `orbit search`; MCP `model` remains provenance-only. ADR-0179 supersedes ADR-0175. ([ORB-00205])
 - **Per-domain `search` subcommands removed; cross-kind filters on `orbit search`**: `orbit task search`, `orbit docs search`, `orbit learning search` (and the matching `orbit.task.search`, `orbit.docs.search`, `orbit.learning.search` MCP tools) are hard-removed. Replacement: `orbit search --kind {task,doc,learning,adr,all} <query>` for content-similarity, and `orbit <kind> list --filter` for structural filters. `orbit search` gains four new flags:
   - `--tag <T>` (repeatable, AND semantics; applies to task/doc/learning/ADR).
@@ -17,6 +18,7 @@
 
 ### Features
 
+- **Doc-corpus embeddings and hybrid doc search**: `orbit docs index` walks configured docs roots, embeds `{path,title,tags,body}` into `source_kind="doc"` rows, skips unchanged content hashes, and sweeps stale doc paths. `orbit search <query> --kind doc --hybrid` blends lexical doc scoring with cosine using `[docs.search].semantic_weight` (default `0.5`) and falls back to lexical with a warning when the companion or doc rows are unavailable. ([ORB-00206])
 - **ADR envelope v2 tags and paths**: ADR `adr.yaml` envelopes now carry `schema_version: 2` plus `tags` and `paths` fields. Existing ADR envelopes are backfilled with explicit empty lists, `orbit.adr.add` / `orbit.adr.update` accept the new fields, `orbit.adr.list` filters by `tag` and `path`, and the phase-2 `orbit search --tag/--path --kind adr` deferrals are closed. ([ORB-00203])
 - **`orbit-guide` first-time-setup skill** with explicit carve-out from the `orbit` router; seeded skill set 11 → 12. ([ORB-00126])
 - **Secret redaction at the artifact write boundary**: action-keyed sanitizer at the tool-host entrance covers ADR / learning / task / review-thread / friction writes; whole-token credentials reject via `OrbitError::SensitiveInput`; responses gain `redactions_applied: bool`. ([ORB-00138])

--- a/README.md
+++ b/README.md
@@ -135,17 +135,19 @@ Customizing crews (which model runs planner/implementer/reviewer), the base bran
 
 ## Semantic Search (optional)
 
-`orbit search` is the unified query surface for tasks, docs, learnings, and ADRs. It defaults to lexical matching. Opt into hybrid embedding + BM25 ranking over task fields with `--hybrid`, or find cosine-neighbor tasks with `orbit search similar <task-id>`. The embedder runs as a separate companion subprocess, so semantic search has zero cost when unused.
+`orbit search` is the unified query surface for tasks, docs, learnings, and ADRs. It defaults to lexical matching. Opt into hybrid embedding ranking over task fields or indexed docs with `--hybrid`, or find cosine-neighbor tasks with `orbit search similar <task-id>`. The embedder runs as a separate companion subprocess, so semantic search has zero cost when unused.
 
 ```bash
 orbit semantic install    # one-time: download companion + default model (bge-small)
 orbit semantic index      # backfill existing tasks
+orbit docs index          # backfill docs for --kind doc --hybrid
 orbit search "race in the scheduler when locks overlap"
 orbit search "race in the scheduler when locks overlap" --hybrid --kind task
+orbit search "why tasks serialize ORB ids" --hybrid --kind doc
 orbit search similar ORB-00042
 ```
 
-After install, task writes are embedded automatically in the background; `index` is only needed for the initial backfill. Companion + models live under `~/.orbit/embed/`; the per-workspace index at `.orbit/state/semantic.db`. Vector search is task-only today; docs, learnings, and ADRs remain lexical even when `--hybrid` is set.
+After install, task writes are embedded automatically in the background; `orbit semantic index` is only needed for the initial task backfill. Docs are indexed explicitly with `orbit docs index`, which skips unchanged content hashes and sweeps stale doc paths. Companion + models live under `~/.orbit/embed/`; the per-workspace index is `.orbit/state/semantic.db`. Learnings and ADRs remain lexical even when `--hybrid` is set.
 
 ---
 

--- a/crates/orbit-cli/src/audit_middleware.rs
+++ b/crates/orbit-cli/src/audit_middleware.rs
@@ -355,7 +355,7 @@ pub fn extract_command_meta(cmd: &Commands) -> CommandMeta {
                 DocsSubcommand::List(_) => ("list", None),
                 DocsSubcommand::Show(args) => ("show", Some(args.path.as_str())),
                 DocsSubcommand::Add(args) => ("add", Some(args.path.as_str())),
-                DocsSubcommand::Reindex(_) => ("reindex", None),
+                DocsSubcommand::Index(_) => ("index", None),
                 DocsSubcommand::Migrate(_) => ("migrate", None),
             };
             CommandMeta {

--- a/crates/orbit-cli/src/command/docs.rs
+++ b/crates/orbit-cli/src/command/docs.rs
@@ -1,6 +1,7 @@
 use std::str::FromStr;
 
 use clap::{Args, Subcommand};
+use orbit_core::command::docs::DocIndexParams;
 use orbit_core::{DocType, OrbitError, OrbitRuntime};
 use serde::Serialize;
 use serde_json::Value;
@@ -22,8 +23,9 @@ pub enum DocsSubcommand {
     Show(DocsShowArgs),
     /// Register an additional docs root in .orbit/config.toml
     Add(DocsAddArgs),
-    /// Rebuild the docs index (v1 is walk-on-demand)
-    Reindex(DocsReindexArgs),
+    // ADR-0180: docs embeddings are built by an explicit admin verb; the old no-op reindex verb is retired.
+    /// Build or refresh doc corpus embeddings
+    Index(DocsIndexArgs),
     /// Backfill locked docs frontmatter for legacy docs
     Migrate(DocsMigrateArgs),
 }
@@ -60,10 +62,16 @@ pub struct DocsAddArgs {
 }
 
 #[derive(Args)]
-pub struct DocsReindexArgs {
+pub struct DocsIndexArgs {
     /// Output as JSON
     #[arg(long)]
     pub json: bool,
+    /// Re-embed even when content hashes are unchanged
+    #[arg(long)]
+    pub force: bool,
+    /// Embedding model alias to use for indexing
+    #[arg(long)]
+    pub model: Option<String>,
 }
 
 #[derive(Args)]
@@ -82,7 +90,7 @@ impl Execute for DocsCommand {
             DocsSubcommand::List(args) => args.execute(runtime),
             DocsSubcommand::Show(args) => args.execute(runtime),
             DocsSubcommand::Add(args) => args.execute(runtime),
-            DocsSubcommand::Reindex(args) => args.execute(runtime),
+            DocsSubcommand::Index(args) => args.execute(runtime),
             DocsSubcommand::Migrate(args) => args.execute(runtime),
         }
     }
@@ -177,13 +185,23 @@ impl Execute for DocsAddArgs {
     }
 }
 
-impl Execute for DocsReindexArgs {
+impl Execute for DocsIndexArgs {
     fn execute(self, runtime: &OrbitRuntime) -> Result<(), OrbitError> {
-        let message = runtime.reindex_docs()?;
+        let result = runtime.index_docs(DocIndexParams {
+            model: self.model,
+            force: self.force,
+        })?;
         if self.json {
-            crate::output::json::print_pretty(&serde_json::json!({ "message": message }))
+            crate::output::json::print_pretty(&serde_json::json!(result))
         } else {
-            println!("{message}");
+            println!(
+                "Indexed docs: model={} indexed_sources={} embedded_chunks={} skipped_fields={} stale_sources={}",
+                result.model_id,
+                result.indexed_sources,
+                result.report.embedded_chunks,
+                result.report.skipped_fields,
+                result.stale_sources.len()
+            );
             Ok(())
         }
     }

--- a/crates/orbit-cli/src/command/mcp/mod.rs
+++ b/crates/orbit-cli/src/command/mcp/mod.rs
@@ -82,7 +82,7 @@ pub(crate) const DOCS_TOOL_NAMES: &[&str] = &[
     "orbit.docs.list",
     "orbit.docs.show",
     "orbit.docs.add",
-    "orbit.docs.reindex",
+    "orbit.docs.index",
     "orbit.docs.migrate",
 ];
 

--- a/crates/orbit-cli/src/command/mod.rs
+++ b/crates/orbit-cli/src/command/mod.rs
@@ -160,6 +160,7 @@ mod tests {
 
     use super::{
         Cli, Commands,
+        docs::DocsSubcommand,
         hook::HookSubcommand,
         mcp::McpSubcommand,
         search::{SearchKindArg, SearchSubcommand},
@@ -247,6 +248,26 @@ mod tests {
             },
             _ => panic!("expected top-level semantic command"),
         }
+    }
+
+    #[test]
+    fn cli_parses_docs_index() {
+        let cli = Cli::parse_from(["orbit", "docs", "index", "--force", "--model", "minilm-l6"]);
+        match cli.command {
+            Commands::Docs(command) => match command.command {
+                DocsSubcommand::Index(args) => {
+                    assert!(args.force);
+                    assert_eq!(args.model.as_deref(), Some("minilm-l6"));
+                }
+                _ => panic!("expected docs index"),
+            },
+            _ => panic!("expected top-level docs command"),
+        }
+    }
+
+    #[test]
+    fn cli_rejects_docs_reindex() {
+        assert!(Cli::try_parse_from(["orbit", "docs", "reindex"]).is_err());
     }
 
     #[test]

--- a/crates/orbit-cli/src/command/search.rs
+++ b/crates/orbit-cli/src/command/search.rs
@@ -7,7 +7,7 @@ use crate::command::Execute;
 #[command(
     about = "Search tasks, docs, learnings, and ADRs",
     subcommand_precedence_over_arg = true,
-    after_help = "Forms:\n  orbit search <query>\n  orbit search similar <id>\n  orbit search path <path>\n\nIndex coverage note: vector search runs against tasks only today; docs, learnings, and ADRs use lexical matching regardless of --hybrid."
+    after_help = "Forms:\n  orbit search <query>\n  orbit search similar <id>\n  orbit search path <path>\n\nIndex coverage note: learnings and ADRs use lexical matching regardless of --hybrid."
 )]
 pub struct SearchCommand {
     /// Free-text query. Defaults to lexical matching unless --hybrid is set.
@@ -18,7 +18,7 @@ pub struct SearchCommand {
     pub command: Option<SearchSubcommand>,
 
     // ADR-0179: free-text search keeps the hybrid ranker; neighbor/path modes are separate forms.
-    /// Use hybrid BM25 + cosine ranking for indexed task fields. Other kinds remain lexical.
+    /// Use hybrid lexical + cosine ranking for indexed task or doc fields.
     #[arg(long)]
     pub hybrid: bool,
     /// Restrict results to one corpus kind.

--- a/crates/orbit-cli/src/main.rs
+++ b/crates/orbit-cli/src/main.rs
@@ -170,7 +170,7 @@ fn json_error_output_preference(command: &Commands) -> Option<bool> {
             DocsSubcommand::List(args) => args.json.then_some(true),
             DocsSubcommand::Show(args) => args.json.then_some(true),
             DocsSubcommand::Add(args) => args.json.then_some(true),
-            DocsSubcommand::Reindex(args) => args.json.then_some(true),
+            DocsSubcommand::Index(args) => args.json.then_some(true),
             DocsSubcommand::Migrate(args) => args.json.then_some(true),
         },
         Commands::Search(SearchCommand { json: true, .. }) => Some(true),

--- a/crates/orbit-cli/tests/docs.rs
+++ b/crates/orbit-cli/tests/docs.rs
@@ -238,7 +238,7 @@ fn mcp_docs_tools_are_listed_and_callable_through_tool_run() {
         "orbit.docs.list",
         "orbit.docs.show",
         "orbit.docs.add",
-        "orbit.docs.reindex",
+        "orbit.docs.index",
         "orbit.docs.migrate",
     ] {
         assert!(names.contains(&name), "missing docs tool {name}");

--- a/crates/orbit-core/assets/skills/orbit-docs/SKILL.md
+++ b/crates/orbit-core/assets/skills/orbit-docs/SKILL.md
@@ -61,12 +61,12 @@ CLI and MCP forms are equivalent:
 | Show | `orbit docs show <path> --json` | `orbit.docs.show` |
 | Search | `orbit search --kind doc <query> --json --limit 20` (or `--kind all` / `--kind adr`) | `orbit.search` |
 | Add root | `orbit docs add <path>` | `orbit.docs.add` |
-| Reindex | `orbit docs reindex` | `orbit.docs.reindex` |
+| Index | `orbit docs index` | `orbit.docs.index` |
 | Migrate | `orbit docs migrate --dry-run` | `orbit.docs.migrate` |
 
 `orbit search <query> --kind all` federates doc and ADR hits in one call. Use `--kind doc` for doc-only matches, `--kind adr` for ADR-only matches, and `--kind adr --all` (or `--status adr:accepted,adr:superseded`) to include superseded ADRs for archaeology. See `orbit-search` for the full flag matrix (`--tag`, `orbit search path <path>`, `--status kind:value`).
 
-`reindex` is a v1 no-op because the indexer walks on demand. `migrate` backfills locked frontmatter for `docs/design/<feature>/*.md` and `docs/design-patterns/*.md`; it never touches `.orbit/`.
+`index` embeds the configured docs roots for `orbit search <query> --kind doc --hybrid`; reruns are idempotent through content hashes. `migrate` backfills locked frontmatter for `docs/design/<feature>/*.md` and `docs/design-patterns/*.md`; it never touches `.orbit/`.
 
 ## Workflow
 
@@ -74,4 +74,5 @@ CLI and MCP forms are equivalent:
 2. Use `orbit docs show <path> --json` for the full Markdown body.
 3. Use `orbit docs list --json --type <type>` or `--tag <tag>` when browsing.
 4. Use `orbit docs add <path>` only for existing non-`.orbit/` roots that should be searched going forward.
-5. Use `orbit docs migrate --dry-run` before writing frontmatter backfills, then rerun without `--dry-run` when the diff is expected.
+5. Use `orbit docs index --json` after substantial docs edits or moves when hybrid doc search needs fresh embeddings.
+6. Use `orbit docs migrate --dry-run` before writing frontmatter backfills, then rerun without `--dry-run` when the diff is expected.

--- a/crates/orbit-core/src/command/docs.rs
+++ b/crates/orbit-core/src/command/docs.rs
@@ -9,9 +9,12 @@ use std::str::FromStr;
 use orbit_common::types::{Adr, AdrStatus, OrbitError, Task};
 use orbit_common::utility::glob::{match_glob, normalize_glob_path};
 use orbit_common::utility::selector::anchor_path;
-pub use orbit_search::{AdrSearchResult, DocSearchResult, SearchResult};
+pub use orbit_search::{
+    AdrSearchResult, DocIndexParams, DocIndexResult, DocSearchResult, SearchResult,
+};
 use orbit_search::{
-    AdrSearchSource, DocSearchSource, score_adr_record, score_doc_record, sort_search_results,
+    AdrSearchSource, DocEmbeddingSource, DocSearchSource, score_adr_record, score_doc_record,
+    sort_search_results,
 };
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use serde_json::json;
@@ -235,11 +238,34 @@ struct DocsConfigFile {
 #[derive(Debug, Deserialize)]
 struct DocsConfigSection {
     roots: Option<Vec<String>>,
+    search: Option<DocsSearchConfigSection>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct DocsSearchConfig {
+    pub semantic_weight: f32,
+}
+
+impl Default for DocsSearchConfig {
+    fn default() -> Self {
+        Self {
+            semantic_weight: 0.5,
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct DocsSearchConfigSection {
+    semantic_weight: Option<f32>,
 }
 
 impl OrbitRuntime {
     pub fn docs_roots(&self) -> Result<Vec<String>, OrbitError> {
         read_docs_roots_from_config_path(&self.config_path())
+    }
+
+    pub fn docs_search_config(&self) -> Result<DocsSearchConfig, OrbitError> {
+        read_docs_search_config_from_config_path(&self.config_path())
     }
 
     pub fn list_docs(
@@ -330,8 +356,10 @@ impl OrbitRuntime {
         add_docs_root(&self.paths().repo_root, &self.config_path(), path)
     }
 
-    pub fn reindex_docs(&self) -> Result<String, OrbitError> {
-        Ok("indexer is walk-on-demand; nothing to do.".to_string())
+    pub fn index_docs(&self, params: DocIndexParams) -> Result<DocIndexResult, OrbitError> {
+        let roots = self.docs_roots()?;
+        let sources = doc_embedding_sources(&self.paths().repo_root, &roots)?;
+        orbit_search::doc_index(&self.stores().semantic_vector, &sources, params)
     }
 
     pub fn migrate_docs(&self, dry_run: bool) -> Result<DocMigrationReport, OrbitError> {
@@ -352,6 +380,24 @@ pub fn parse_docs_roots_from_config_toml(raw: &str) -> Result<Vec<String>, Orbit
         .unwrap_or_else(default_doc_roots))
 }
 
+pub fn parse_docs_search_config_from_config_toml(
+    raw: &str,
+) -> Result<DocsSearchConfig, OrbitError> {
+    if raw.trim().is_empty() {
+        return Ok(DocsSearchConfig::default());
+    }
+    let parsed = toml::from_str::<DocsConfigFile>(raw).map_err(|error| {
+        OrbitError::InvalidInput(format!("invalid docs config in config.toml: {error}"))
+    })?;
+    let semantic_weight = parsed
+        .docs
+        .and_then(|section| section.search)
+        .and_then(|section| section.semantic_weight)
+        .unwrap_or_else(|| DocsSearchConfig::default().semantic_weight)
+        .clamp(0.0, 1.0);
+    Ok(DocsSearchConfig { semantic_weight })
+}
+
 fn read_docs_roots_from_config_path(path: &Path) -> Result<Vec<String>, OrbitError> {
     if !path.exists() {
         return Ok(default_doc_roots());
@@ -359,6 +405,15 @@ fn read_docs_roots_from_config_path(path: &Path) -> Result<Vec<String>, OrbitErr
     let raw = fs::read_to_string(path)
         .map_err(|error| OrbitError::Io(format!("read {}: {error}", path.display())))?;
     parse_docs_roots_from_config_toml(&raw)
+}
+
+fn read_docs_search_config_from_config_path(path: &Path) -> Result<DocsSearchConfig, OrbitError> {
+    if !path.exists() {
+        return Ok(DocsSearchConfig::default());
+    }
+    let raw = fs::read_to_string(path)
+        .map_err(|error| OrbitError::Io(format!("read {}: {error}", path.display())))?;
+    parse_docs_search_config_from_config_toml(&raw)
 }
 
 fn read_task_context_docs_roots_from_config_path(path: &Path) -> Result<Vec<String>, OrbitError> {
@@ -863,6 +918,23 @@ fn doc_search_source(record: DocRecord) -> DocSearchSource {
             .map(|artifact| artifact.as_str().to_string())
             .collect(),
     }
+}
+
+fn doc_embedding_sources(
+    repo_root: &Path,
+    roots: &[String],
+) -> Result<Vec<DocEmbeddingSource>, OrbitError> {
+    let mut sources = Vec::new();
+    for record in walk_docs_roots(repo_root, roots)? {
+        let shown = show_doc(repo_root, roots, &record.path)?;
+        sources.push(DocEmbeddingSource {
+            path: record.path,
+            title: shown.frontmatter.summary,
+            tags: shown.frontmatter.tags,
+            body: shown.body,
+        });
+    }
+    Ok(sources)
 }
 
 fn adr_search_source(adr: Adr) -> AdrSearchSource {
@@ -1753,6 +1825,34 @@ mod tests {
             parse_docs_roots_from_config_toml("[docs]\nroots = [\"docs/\", \"apps/*/docs/\"]\n")
                 .unwrap(),
             vec!["docs/", "apps/*/docs/"]
+        );
+    }
+
+    #[test]
+    fn docs_search_config_defaults_and_clamps_semantic_weight() {
+        assert_eq!(
+            parse_docs_search_config_from_config_toml("")
+                .unwrap()
+                .semantic_weight,
+            0.5
+        );
+        assert_eq!(
+            parse_docs_search_config_from_config_toml("[docs.search]\nsemantic_weight = 0.7\n")
+                .unwrap()
+                .semantic_weight,
+            0.7
+        );
+        assert_eq!(
+            parse_docs_search_config_from_config_toml("[docs.search]\nsemantic_weight = -1.0\n")
+                .unwrap()
+                .semantic_weight,
+            0.0
+        );
+        assert_eq!(
+            parse_docs_search_config_from_config_toml("[docs.search]\nsemantic_weight = 2.0\n")
+                .unwrap()
+                .semantic_weight,
+            1.0
         );
     }
 

--- a/crates/orbit-core/src/command/search.rs
+++ b/crates/orbit-core/src/command/search.rs
@@ -1,8 +1,11 @@
+use std::collections::BTreeMap;
 use std::str::FromStr;
 
 use orbit_common::types::{AdrStatus, LearningStatus, OrbitError, TaskStatus};
 use orbit_common::utility::glob::compile_glob_regex;
-use orbit_search::{SemanticRelatedParams, SemanticSearchParams};
+use orbit_search::{
+    DocSemanticHit, DocSemanticSearchParams, SemanticRelatedParams, SemanticSearchParams,
+};
 use orbit_store::LearningSearchParams;
 use serde::Serialize;
 
@@ -10,6 +13,14 @@ use crate::{OrbitRuntime, SearchResult};
 
 const DEFAULT_LIMIT: usize = 10;
 const DOC_SEARCH_OVERFETCH: usize = 4;
+const DOC_HYBRID_FALLBACK_NOTE: &str = "falling back to lexical doc search";
+
+#[cfg(test)]
+thread_local! {
+    static DOC_SEMANTIC_SEARCH_OVERRIDE:
+        std::cell::RefCell<Option<Result<Vec<DocSemanticHit>, String>>> =
+        const { std::cell::RefCell::new(None) };
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "lowercase")]
@@ -210,11 +221,9 @@ impl OrbitRuntime {
             GlobalSearchMode::Lexical
         };
 
-        if params.hybrid && !matches!(params.kind, GlobalSearchKind::Task) {
-            notes.push(
-                "hybrid vector search currently runs against tasks only; docs, learnings, and ADRs use lexical matching"
-                    .to_string(),
-            );
+        if params.hybrid && (params.kind.includes_learnings() || params.kind.includes_adrs()) {
+            notes
+                .push("learnings and ADRs use lexical matching regardless of --hybrid".to_string());
         }
 
         if params.kind.includes_tasks() {
@@ -237,6 +246,7 @@ impl OrbitRuntime {
                     query_owned.as_deref(),
                     &tag_filter,
                     limit,
+                    &mut notes,
                 )?);
             }
         }
@@ -339,11 +349,12 @@ impl OrbitRuntime {
 
     fn doc_branch(
         &self,
-        _params: &GlobalSearchParams,
+        params: &GlobalSearchParams,
         status_filters: &SearchStatusFilters,
         query: Option<&str>,
         tag_filter: &[String],
         limit: usize,
+        notes: &mut Vec<String>,
     ) -> Result<Vec<GlobalSearchHit>, OrbitError> {
         let _doc_status_active = status_filters.doc_active.unwrap_or(true);
         let Some(query) = query else {
@@ -377,6 +388,11 @@ impl OrbitRuntime {
 
         let docs_limit = limit.saturating_mul(DOC_SEARCH_OVERFETCH).max(limit);
         let docs = self.search_docs(query, Some(docs_limit), true)?;
+        if params.hybrid {
+            // ADR-0180: doc vectors are opt-in and fall back to lexical rather than failing user search.
+            return self.hybrid_doc_hits(query, docs, tag_filter, docs_limit, limit, notes);
+        }
+
         let mut out = Vec::new();
         for result in docs {
             if let SearchResult::Doc(result) = result {
@@ -390,23 +406,145 @@ impl OrbitRuntime {
                         continue;
                     }
                 }
-                out.push(GlobalSearchHit {
-                    kind: "doc".to_string(),
-                    source: "lexical".to_string(),
-                    id: None,
-                    path: Some(result.record.path),
-                    title: None,
-                    summary: Some(result.record.summary),
-                    status: Some(result.record.doc_type),
-                    best_field: None,
-                    snippet: None,
-                    score: Some(result.score as f32),
-                    matched_by: Some(result.matched_by),
-                });
+                let score = result.score as f32;
+                out.push(doc_result_to_global(result, "lexical", Some(score)));
             }
         }
         out.truncate(limit);
         Ok(out)
+    }
+
+    fn hybrid_doc_hits(
+        &self,
+        query: &str,
+        lexical_results: Vec<SearchResult>,
+        tag_filter: &[String],
+        docs_limit: usize,
+        limit: usize,
+        notes: &mut Vec<String>,
+    ) -> Result<Vec<GlobalSearchHit>, OrbitError> {
+        let mut lexical_docs = BTreeMap::<String, orbit_search::DocSearchResult>::new();
+        let mut lexical_adrs = Vec::new();
+        for result in lexical_results {
+            match result {
+                SearchResult::Doc(result) => {
+                    if !tag_filter.is_empty()
+                        && !tag_filter.iter().all(|tag| {
+                            result
+                                .record
+                                .tags
+                                .iter()
+                                .any(|candidate| candidate.eq_ignore_ascii_case(tag))
+                        })
+                    {
+                        continue;
+                    }
+                    lexical_docs.insert(result.record.path.clone(), result);
+                }
+                SearchResult::Adr(result) => {
+                    if tag_filter.is_empty() || adr_result_has_all_tags(&result, tag_filter) {
+                        lexical_adrs.push(adr_result_to_global(result));
+                    }
+                }
+            }
+        }
+
+        let semantic = match self.doc_semantic_hits(query, docs_limit) {
+            Ok(result) if result.is_empty() => {
+                warn_doc_hybrid_fallback(notes, "no doc embeddings found");
+                return Ok(lexical_doc_hits_with_adrs(
+                    lexical_docs,
+                    lexical_adrs,
+                    limit,
+                ));
+            }
+            Ok(result) => result,
+            Err(error) => {
+                warn_doc_hybrid_fallback(notes, &error.to_string());
+                return Ok(lexical_doc_hits_with_adrs(
+                    lexical_docs,
+                    lexical_adrs,
+                    limit,
+                ));
+            }
+        };
+
+        let records = self
+            .list_docs(None, None)?
+            .into_iter()
+            .map(|record| (record.path.clone(), record))
+            .collect::<BTreeMap<_, _>>();
+        let mut candidates = BTreeMap::<String, DocHybridCandidate>::new();
+        for (path, result) in lexical_docs {
+            candidates.insert(
+                path,
+                DocHybridCandidate {
+                    hit: doc_result_to_global(result.clone(), "hybrid", None),
+                    lexical_score: Some(result.score as f32),
+                    semantic_score: None,
+                    semantic: None,
+                },
+            );
+        }
+        for hit in semantic {
+            let Some(record) = records.get(&hit.source_id) else {
+                continue;
+            };
+            if !tag_filter.is_empty() && !doc_has_all_tags(record, tag_filter) {
+                continue;
+            }
+            candidates
+                .entry(hit.source_id.clone())
+                .and_modify(|candidate| {
+                    candidate.semantic_score = Some(hit.score);
+                    candidate.semantic = Some(hit.clone());
+                })
+                .or_insert_with(|| DocHybridCandidate {
+                    hit: GlobalSearchHit {
+                        kind: "doc".to_string(),
+                        source: "hybrid".to_string(),
+                        id: None,
+                        path: Some(record.path.clone()),
+                        title: None,
+                        summary: Some(record.frontmatter.summary.clone()),
+                        status: Some(record.frontmatter.doc_type.as_str().to_string()),
+                        best_field: None,
+                        snippet: None,
+                        score: None,
+                        matched_by: None,
+                    },
+                    lexical_score: None,
+                    semantic_score: Some(hit.score),
+                    semantic: Some(hit),
+                });
+        }
+
+        let weight = self.docs_search_config()?.semantic_weight;
+        let mut ranked = blend_doc_hybrid_candidates(candidates.into_values().collect(), weight);
+        ranked.extend(lexical_adrs);
+        ranked.truncate(limit);
+        Ok(ranked)
+    }
+
+    fn doc_semantic_hits(
+        &self,
+        query: &str,
+        limit: usize,
+    ) -> Result<Vec<DocSemanticHit>, OrbitError> {
+        #[cfg(test)]
+        if let Some(result) = DOC_SEMANTIC_SEARCH_OVERRIDE.with(|cell| cell.borrow().clone()) {
+            return result.map_err(OrbitError::Execution);
+        }
+
+        Ok(orbit_search::doc_semantic_search(
+            &self.stores().semantic_vector,
+            DocSemanticSearchParams {
+                query: query.to_string(),
+                limit,
+                model: None,
+            },
+        )?
+        .results)
     }
 
     fn adr_branch(
@@ -598,6 +736,156 @@ fn semantic_hit_to_global(hit: orbit_search::SemanticHit) -> GlobalSearchHit {
         snippet: Some(hit.snippet),
         score: Some(hit.score),
         matched_by: None,
+    }
+}
+
+#[derive(Debug, Clone)]
+struct DocHybridCandidate {
+    hit: GlobalSearchHit,
+    lexical_score: Option<f32>,
+    semantic_score: Option<f32>,
+    semantic: Option<DocSemanticHit>,
+}
+
+fn lexical_doc_hits_with_adrs(
+    lexical_docs: BTreeMap<String, orbit_search::DocSearchResult>,
+    lexical_adrs: Vec<GlobalSearchHit>,
+    limit: usize,
+) -> Vec<GlobalSearchHit> {
+    let mut out = lexical_docs
+        .into_values()
+        .map(|result| doc_result_to_global(result.clone(), "lexical", Some(result.score as f32)))
+        .collect::<Vec<_>>();
+    out.extend(lexical_adrs);
+    out.truncate(limit);
+    out
+}
+
+fn blend_doc_hybrid_candidates(
+    candidates: Vec<DocHybridCandidate>,
+    semantic_weight: f32,
+) -> Vec<GlobalSearchHit> {
+    let lexical_scores = normalized_doc_scores(candidates.iter().filter_map(|candidate| {
+        candidate
+            .hit
+            .path
+            .as_ref()
+            .zip(candidate.lexical_score)
+            .map(|(path, score)| (path.clone(), score))
+    }));
+    let semantic_scores = normalized_doc_scores(candidates.iter().filter_map(|candidate| {
+        candidate
+            .hit
+            .path
+            .as_ref()
+            .zip(candidate.semantic_score)
+            .map(|(path, score)| (path.clone(), score))
+    }));
+    let lexical_weight = 1.0 - semantic_weight;
+    let mut out = candidates
+        .into_iter()
+        .map(|mut candidate| {
+            let path = candidate.hit.path.as_deref().unwrap_or_default();
+            let lexical = lexical_scores.get(path).copied().unwrap_or(0.0);
+            let semantic = semantic_scores.get(path).copied().unwrap_or(0.0);
+            let score = semantic_weight.mul_add(semantic, lexical_weight * lexical);
+            candidate.hit.score = Some(score);
+            if let Some(semantic_hit) = candidate.semantic {
+                candidate.hit.best_field = Some(semantic_hit.best_field);
+                candidate.hit.snippet = Some(semantic_hit.snippet);
+            }
+            candidate.hit
+        })
+        .collect::<Vec<_>>();
+    out.sort_by(compare_global_hits_by_score);
+    out
+}
+
+fn normalized_doc_scores(scores: impl IntoIterator<Item = (String, f32)>) -> BTreeMap<String, f32> {
+    let raw = scores.into_iter().collect::<Vec<_>>();
+    if raw.len() < 2 {
+        return raw.into_iter().collect();
+    }
+    let min = raw
+        .iter()
+        .map(|(_, score)| *score)
+        .fold(f32::INFINITY, f32::min);
+    let max = raw
+        .iter()
+        .map(|(_, score)| *score)
+        .fold(f32::NEG_INFINITY, f32::max);
+    if (max - min).abs() <= f32::EPSILON {
+        return raw.into_iter().map(|(path, _score)| (path, 1.0)).collect();
+    }
+    raw.into_iter()
+        .map(|(path, score)| (path, (score - min) / (max - min)))
+        .collect()
+}
+
+fn compare_global_hits_by_score(
+    left: &GlobalSearchHit,
+    right: &GlobalSearchHit,
+) -> std::cmp::Ordering {
+    right
+        .score
+        .unwrap_or(0.0)
+        .total_cmp(&left.score.unwrap_or(0.0))
+        .then_with(|| {
+            left.path
+                .as_deref()
+                .unwrap_or_default()
+                .cmp(right.path.as_deref().unwrap_or_default())
+        })
+        .then_with(|| {
+            left.id
+                .as_deref()
+                .unwrap_or_default()
+                .cmp(right.id.as_deref().unwrap_or_default())
+        })
+}
+
+fn warn_doc_hybrid_fallback(notes: &mut Vec<String>, reason: &str) {
+    orbit_common::tracing::warn!(
+        target: "orbit.search.docs",
+        reason,
+        "falling back to lexical doc search"
+    );
+    notes.push(format!("{DOC_HYBRID_FALLBACK_NOTE}: {reason}"));
+}
+
+fn doc_result_to_global(
+    result: orbit_search::DocSearchResult,
+    source: &str,
+    score: Option<f32>,
+) -> GlobalSearchHit {
+    GlobalSearchHit {
+        kind: "doc".to_string(),
+        source: source.to_string(),
+        id: None,
+        path: Some(result.record.path),
+        title: None,
+        summary: Some(result.record.summary),
+        status: Some(result.record.doc_type),
+        best_field: None,
+        snippet: None,
+        score,
+        matched_by: Some(result.matched_by),
+    }
+}
+
+fn adr_result_to_global(result: orbit_search::AdrSearchResult) -> GlobalSearchHit {
+    GlobalSearchHit {
+        kind: "adr".to_string(),
+        source: "lexical".to_string(),
+        id: Some(result.id),
+        path: Some(result.path.to_string_lossy().into_owned()),
+        title: Some(result.title),
+        summary: None,
+        status: Some(result.status.to_string()),
+        best_field: None,
+        snippet: None,
+        score: Some(result.score as f32),
+        matched_by: Some(result.matched_by),
     }
 }
 
@@ -997,13 +1285,45 @@ mod tests {
     }
 
     fn add_doc(runtime: &OrbitRuntime, path: &str, summary: &str) {
+        add_doc_with_tags(runtime, path, summary, &[]);
+    }
+
+    fn add_doc_with_tags(runtime: &OrbitRuntime, path: &str, summary: &str, tags: &[&str]) {
         let doc_path = runtime.paths().repo_root.join(path);
         fs::create_dir_all(doc_path.parent().expect("doc parent")).expect("create doc parent");
+        let tags_line = if tags.is_empty() {
+            String::new()
+        } else {
+            format!("tags: [{}]\n", tags.join(", "))
+        };
         fs::write(
             doc_path,
-            format!("---\ntype: context\nsummary: {summary}\n---\n\nneedle doc body\n"),
+            format!("---\ntype: context\nsummary: {summary}\n{tags_line}---\n\nneedle doc body\n"),
         )
         .expect("write doc");
+    }
+
+    fn doc_semantic_hit(path: &str, score: f32) -> DocSemanticHit {
+        DocSemanticHit {
+            source_id: path.to_string(),
+            best_field: "body".to_string(),
+            snippet: "semantic snippet".to_string(),
+            score,
+        }
+    }
+
+    fn with_doc_semantic_override<T>(
+        result: Result<Vec<DocSemanticHit>, String>,
+        f: impl FnOnce() -> T,
+    ) -> T {
+        DOC_SEMANTIC_SEARCH_OVERRIDE.with(|cell| {
+            *cell.borrow_mut() = Some(result);
+        });
+        let out = f();
+        DOC_SEMANTIC_SEARCH_OVERRIDE.with(|cell| {
+            *cell.borrow_mut() = None;
+        });
+        out
     }
 
     #[test]
@@ -1178,6 +1498,146 @@ mod tests {
         assert!(!ids.contains(&accepted_adr.as_str()));
         assert!(paths.contains(&"docs/status-active.md"));
         assert!(!paths.contains(&"docs/status-other.md"));
+    }
+
+    #[test]
+    fn global_search_doc_hybrid_uses_docs_semantic_weight() {
+        let runtime = OrbitRuntime::in_memory().expect("runtime");
+        add_doc_with_tags(&runtime, "docs/z-lexical.md", "Literal primary", &["foo"]);
+        add_doc(&runtime, "docs/y-lexical.md", "foo secondary");
+        add_doc(&runtime, "docs/a-semantic.md", "Conceptual match");
+        let semantic = vec![
+            doc_semantic_hit("docs/a-semantic.md", 1.0),
+            doc_semantic_hit("docs/y-lexical.md", 0.2),
+        ];
+
+        let top_path = |weight: f32| {
+            fs::write(
+                runtime.config_path(),
+                format!("[docs.search]\nsemantic_weight = {weight:.1}\n"),
+            )
+            .expect("write config");
+            with_doc_semantic_override(Ok(semantic.clone()), || {
+                runtime
+                    .global_search(GlobalSearchParams {
+                        query: Some("foo".to_string()),
+                        hybrid: true,
+                        kind: GlobalSearchKind::Doc,
+                        limit: 3,
+                        ..Default::default()
+                    })
+                    .expect("doc hybrid search")
+                    .results
+                    .into_iter()
+                    .next()
+                    .expect("top result")
+                    .path
+                    .expect("doc path")
+            })
+        };
+
+        assert_eq!(top_path(0.0), "docs/z-lexical.md");
+        assert_eq!(top_path(1.0), "docs/a-semantic.md");
+        assert_eq!(top_path(0.5), "docs/a-semantic.md");
+    }
+
+    #[test]
+    fn global_search_doc_hybrid_falls_back_to_lexical_on_semantic_error() {
+        let runtime = OrbitRuntime::in_memory().expect("runtime");
+        add_doc_with_tags(
+            &runtime,
+            "docs/fallback-z-lexical.md",
+            "Fallback primary",
+            &["fallbackneedle"],
+        );
+
+        let response = with_doc_semantic_override(Err("companion missing".to_string()), || {
+            runtime
+                .global_search(GlobalSearchParams {
+                    query: Some("fallbackneedle".to_string()),
+                    hybrid: true,
+                    kind: GlobalSearchKind::Doc,
+                    limit: 3,
+                    ..Default::default()
+                })
+                .expect("fallback search")
+        });
+
+        assert!(
+            response
+                .notes
+                .iter()
+                .any(|note| note.contains("falling back to lexical"))
+        );
+        assert_eq!(response.results[0].source, "lexical");
+        assert_eq!(
+            response.results[0].path.as_deref(),
+            Some("docs/fallback-z-lexical.md")
+        );
+    }
+
+    #[test]
+    fn global_search_doc_hybrid_preserves_adr_lexical_hits() {
+        let runtime = OrbitRuntime::in_memory().expect("runtime");
+        let adr_id = add_adr(&runtime, "foo ADR", "## Context\n\nBody.\n");
+        let lexical_adr = runtime
+            .search_docs("foo", Some(5), true)
+            .expect("direct docs search")
+            .into_iter()
+            .find_map(|result| match result {
+                SearchResult::Adr(result) => Some(result),
+                SearchResult::Doc(_) => None,
+            })
+            .expect("lexical adr");
+
+        let response = with_doc_semantic_override(Ok(Vec::new()), || {
+            runtime
+                .global_search(GlobalSearchParams {
+                    query: Some("foo".to_string()),
+                    hybrid: true,
+                    kind: GlobalSearchKind::Doc,
+                    limit: 5,
+                    ..Default::default()
+                })
+                .expect("hybrid doc search")
+        });
+        let adr_hit = response
+            .results
+            .iter()
+            .find(|hit| hit.kind == "adr")
+            .expect("adr hit");
+
+        assert_eq!(adr_hit.id.as_deref(), Some(adr_id.as_str()));
+        assert_eq!(adr_hit.source, "lexical");
+        assert_eq!(adr_hit.score, Some(lexical_adr.score as f32));
+    }
+
+    #[test]
+    fn hybrid_handles_single_candidate_side() {
+        let hit = GlobalSearchHit {
+            kind: "doc".to_string(),
+            source: "hybrid".to_string(),
+            id: None,
+            path: Some("docs/only.md".to_string()),
+            title: None,
+            summary: None,
+            status: None,
+            best_field: None,
+            snippet: None,
+            score: None,
+            matched_by: None,
+        };
+        let out = blend_doc_hybrid_candidates(
+            vec![DocHybridCandidate {
+                hit,
+                lexical_score: Some(0.42),
+                semantic_score: None,
+                semantic: None,
+            }],
+            0.5,
+        );
+
+        assert!((out[0].score.expect("score") - 0.21).abs() < 0.0001);
     }
 
     #[test]

--- a/crates/orbit-core/src/lib.rs
+++ b/crates/orbit-core/src/lib.rs
@@ -51,7 +51,8 @@ pub use orbit_store::{
 
 pub use command::docs::{
     AdrSearchResult, ArtifactRef, DocAddOutcome, DocFrontmatter, DocMigrationChange,
-    DocMigrationReport, DocRecord, DocSearchResult, DocShow, DocType, SearchResult, TaskRelatedDoc,
+    DocMigrationReport, DocRecord, DocSearchResult, DocShow, DocType, DocsSearchConfig,
+    SearchResult, TaskRelatedDoc,
 };
 pub use command::learning::migrate_learning_layout_at;
 pub use command::search::{

--- a/crates/orbit-core/src/runtime/orbit_tool_host/dispatch.rs
+++ b/crates/orbit-core/src/runtime/orbit_tool_host/dispatch.rs
@@ -27,7 +27,7 @@ pub(super) fn execute(
         OrbitBuiltinAction::DocsList => super::docs_tools::list(runtime, input),
         OrbitBuiltinAction::DocsShow => super::docs_tools::show(runtime, input),
         OrbitBuiltinAction::DocsAdd => super::docs_tools::add(runtime, input),
-        OrbitBuiltinAction::DocsReindex => super::docs_tools::reindex(runtime, input),
+        OrbitBuiltinAction::DocsIndex => super::docs_tools::index(runtime, input),
         OrbitBuiltinAction::DocsMigrate => super::docs_tools::migrate(runtime, input),
         OrbitBuiltinAction::FrictionAdd => super::friction_tools::add(runtime, input, model),
         OrbitBuiltinAction::FrictionList => super::friction_tools::list(runtime, input),

--- a/crates/orbit-core/src/runtime/orbit_tool_host/docs_tools.rs
+++ b/crates/orbit-core/src/runtime/orbit_tool_host/docs_tools.rs
@@ -1,8 +1,8 @@
 use std::str::FromStr;
 
-use crate::command::docs::DocType;
+use crate::command::docs::{DocIndexParams, DocType};
 use orbit_common::types::{OrbitError, optional_string, required_string};
-use serde_json::{Value, json};
+use serde_json::Value;
 
 use crate::OrbitRuntime;
 
@@ -26,8 +26,10 @@ pub(super) fn add(runtime: &OrbitRuntime, input: Value) -> Result<Value, OrbitEr
     to_json(runtime.add_docs_root(&path)?)
 }
 
-pub(super) fn reindex(runtime: &OrbitRuntime, _input: Value) -> Result<Value, OrbitError> {
-    Ok(json!({ "message": runtime.reindex_docs()? }))
+pub(super) fn index(runtime: &OrbitRuntime, input: Value) -> Result<Value, OrbitError> {
+    let model = optional_string(&input, "model")?;
+    let force = optional_bool_alias(&input, &["force"])?.unwrap_or(false);
+    to_json(runtime.index_docs(DocIndexParams { model, force })?)
 }
 
 pub(super) fn migrate(runtime: &OrbitRuntime, input: Value) -> Result<Value, OrbitError> {

--- a/crates/orbit-search/src/commands/doc_index.rs
+++ b/crates/orbit-search/src/commands/doc_index.rs
@@ -1,0 +1,74 @@
+use orbit_common::types::OrbitError;
+use serde::Serialize;
+
+use crate::commands::parse_model;
+use crate::vector::{DocEmbeddingSource, UpsertReport, VectorStore};
+use crate::{Embedder, SubprocessEmbedder};
+
+#[derive(Debug, Clone)]
+pub struct DocIndexParams {
+    pub model: Option<String>,
+    pub force: bool,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct DocIndexResult {
+    pub model_id: String,
+    pub report: UpsertReport,
+    pub indexed_sources: usize,
+    pub stale_sources: Vec<String>,
+}
+
+pub fn run(
+    vector_store: &VectorStore,
+    docs: &[DocEmbeddingSource],
+    params: DocIndexParams,
+) -> Result<DocIndexResult, OrbitError> {
+    let model = parse_model(params.model.as_deref())?;
+    let embedder = SubprocessEmbedder::with_model(model.alias)?;
+    run_with_embedder(vector_store, docs, &embedder, params.force)
+}
+
+pub(crate) fn run_with_embedder(
+    vector_store: &VectorStore,
+    docs: &[DocEmbeddingSource],
+    embedder: &dyn Embedder,
+    force: bool,
+) -> Result<DocIndexResult, OrbitError> {
+    let report = vector_store.reindex_docs(docs, embedder, force)?;
+    Ok(DocIndexResult {
+        model_id: embedder.model_id().to_string(),
+        report: report.upsert,
+        indexed_sources: report.indexed_sources,
+        stale_sources: report.stale_sources,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::NoopEmbedder;
+
+    fn doc(path: &str, title: &str, body: &str) -> DocEmbeddingSource {
+        DocEmbeddingSource {
+            path: path.to_string(),
+            title: title.to_string(),
+            tags: Vec::new(),
+            body: body.to_string(),
+        }
+    }
+
+    #[test]
+    fn doc_index_is_idempotent_by_content_hash() {
+        let store = VectorStore::open_in_memory().unwrap();
+        let embedder = NoopEmbedder::small();
+        let docs = vec![doc("docs/example.md", "Example", "same body")];
+
+        let first = run_with_embedder(&store, &docs, &embedder, false).unwrap();
+        let second = run_with_embedder(&store, &docs, &embedder, false).unwrap();
+
+        assert!(first.report.embedded_chunks > 0);
+        assert_eq!(second.report.embedded_chunks, 0);
+        assert!(second.report.skipped_fields > 0);
+    }
+}

--- a/crates/orbit-search/src/commands/doc_search.rs
+++ b/crates/orbit-search/src/commands/doc_search.rs
@@ -1,0 +1,240 @@
+use std::collections::BTreeMap;
+
+use orbit_common::types::OrbitError;
+use serde::{Deserialize, Serialize};
+
+use crate::commands::resolve_query_model;
+use crate::vector::VectorStore;
+use crate::vector::query::{CosineHit, cosine_top_k, snippet_for_hit};
+use crate::vector::store::SOURCE_KIND_DOC;
+use crate::{Embedder, SubprocessEmbedder};
+
+const DEFAULT_LIMIT: usize = 10;
+const RETRIEVER_OVERFETCH: usize = 4;
+const SNIPPET_MAX_CHARS: usize = 280;
+
+#[derive(Debug, Clone)]
+pub struct DocSemanticSearchParams {
+    pub query: String,
+    pub limit: usize,
+    pub model: Option<String>,
+}
+
+impl DocSemanticSearchParams {
+    pub fn normalized_limit(&self) -> usize {
+        if self.limit == 0 {
+            DEFAULT_LIMIT
+        } else {
+            self.limit
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct DocSemanticSearchResult {
+    pub results: Vec<DocSemanticHit>,
+    pub model_id: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct DocSemanticHit {
+    pub source_id: String,
+    pub best_field: String,
+    pub snippet: String,
+    pub score: f32,
+}
+
+pub fn run(
+    vector_store: &VectorStore,
+    params: DocSemanticSearchParams,
+) -> Result<DocSemanticSearchResult, OrbitError> {
+    let model = resolve_query_model(params.model.as_deref())?;
+    let embedder = SubprocessEmbedder::with_model(model.alias)?;
+    run_with_embedder(vector_store, &embedder, params)
+}
+
+pub(crate) fn run_with_embedder(
+    vector_store: &VectorStore,
+    embedder: &dyn Embedder,
+    params: DocSemanticSearchParams,
+) -> Result<DocSemanticSearchResult, OrbitError> {
+    let query = params.query.trim();
+    if query.is_empty() {
+        return Err(OrbitError::InvalidInput(
+            "doc semantic search query must not be empty".to_string(),
+        ));
+    }
+
+    let vectors = embedder.embed(&[query])?;
+    let query_vector = vectors.into_iter().next().ok_or_else(|| {
+        OrbitError::Execution("embedder returned no vector for doc semantic search".to_string())
+    })?;
+    let limit = params.normalized_limit();
+    let retriever_limit = limit.saturating_mul(RETRIEVER_OVERFETCH).max(limit);
+    let model_id = embedder.model_id().to_string();
+    let cosine = cosine_top_k(
+        vector_store,
+        &query_vector,
+        &model_id,
+        retriever_limit,
+        Some(SOURCE_KIND_DOC),
+    )?;
+    let hits = rollup_doc_hits(vector_store, cosine, limit)?;
+
+    Ok(DocSemanticSearchResult {
+        results: hits,
+        model_id,
+    })
+}
+
+fn rollup_doc_hits(
+    vector_store: &VectorStore,
+    hits: Vec<CosineHit>,
+    limit: usize,
+) -> Result<Vec<DocSemanticHit>, OrbitError> {
+    let mut best = BTreeMap::<String, CosineHit>::new();
+    for hit in hits {
+        best.entry(hit.source_id.clone())
+            .and_modify(|current| {
+                if crate::vector::query::cosine::compare_cosine_hits(&hit, current).is_lt() {
+                    *current = hit.clone();
+                }
+            })
+            .or_insert(hit);
+    }
+
+    let mut rolled = Vec::new();
+    for hit in best.into_values() {
+        let snippet = snippet_for_hit(
+            vector_store,
+            SOURCE_KIND_DOC,
+            &hit.source_id,
+            &hit.field,
+            Some(hit.chunk_idx),
+            None,
+        )?
+        .unwrap_or_default();
+        rolled.push(DocSemanticHit {
+            source_id: hit.source_id,
+            best_field: hit.field,
+            snippet: truncate_snippet(&snippet),
+            score: hit.score,
+        });
+    }
+    rolled.sort_by(compare_doc_semantic_hits);
+    rolled.truncate(limit);
+    Ok(rolled)
+}
+
+fn compare_doc_semantic_hits(left: &DocSemanticHit, right: &DocSemanticHit) -> std::cmp::Ordering {
+    right
+        .score
+        .total_cmp(&left.score)
+        .then_with(|| left.source_id.cmp(&right.source_id))
+        .then_with(|| left.best_field.cmp(&right.best_field))
+}
+
+fn truncate_snippet(snippet: &str) -> String {
+    let trimmed = snippet.trim();
+    let mut end = 0;
+    for (idx, ch) in trimmed.char_indices() {
+        if idx > SNIPPET_MAX_CHARS {
+            break;
+        }
+        end = idx + ch.len_utf8();
+    }
+    if end >= trimmed.len() {
+        trimmed.to_string()
+    } else {
+        format!("{}...", trimmed[..end].trim_end())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use orbit_common::types::OrbitError;
+
+    use super::*;
+    use crate::vector::DocEmbeddingSource;
+    use crate::{Embedder, NoopEmbedder};
+
+    struct KeywordEmbedder;
+
+    impl Embedder for KeywordEmbedder {
+        fn model_id(&self) -> &str {
+            "keyword"
+        }
+
+        fn dim(&self) -> usize {
+            2
+        }
+
+        fn max_input_tokens(&self) -> usize {
+            512
+        }
+
+        fn embed(&self, texts: &[&str]) -> Result<Vec<Vec<f32>>, OrbitError> {
+            Ok(texts
+                .iter()
+                .map(|text| {
+                    if text.to_ascii_lowercase().contains("concept") {
+                        vec![1.0, 0.0]
+                    } else {
+                        vec![0.0, 1.0]
+                    }
+                })
+                .collect())
+        }
+
+        fn token_count(&self, text: &str) -> Result<usize, OrbitError> {
+            Ok(text.split_whitespace().count().max(1))
+        }
+    }
+
+    fn doc(path: &str, body: &str) -> DocEmbeddingSource {
+        DocEmbeddingSource {
+            path: path.to_string(),
+            title: path.to_string(),
+            tags: Vec::new(),
+            body: body.to_string(),
+        }
+    }
+
+    #[test]
+    fn doc_semantic_search_filters_to_doc_rows() {
+        let store = VectorStore::open_in_memory().unwrap();
+        let doc_embedder = KeywordEmbedder;
+        store
+            .reindex_docs(
+                &[
+                    doc("docs/concept.md", "concept match"),
+                    doc("docs/other.md", "other body"),
+                ],
+                &doc_embedder,
+                false,
+            )
+            .unwrap();
+        store
+            .upsert_embeddings(
+                "task",
+                "ORB-00000",
+                &[crate::vector::EmbeddingField::new("title", "concept task")],
+                &NoopEmbedder::small(),
+                false,
+            )
+            .unwrap();
+
+        let result = run_with_embedder(
+            &store,
+            &doc_embedder,
+            DocSemanticSearchParams {
+                query: "concept".to_string(),
+                limit: 1,
+                model: None,
+            },
+        )
+        .unwrap();
+
+        assert_eq!(result.results[0].source_id, "docs/concept.md");
+    }
+}

--- a/crates/orbit-search/src/commands/mod.rs
+++ b/crates/orbit-search/src/commands/mod.rs
@@ -5,6 +5,8 @@
 //! top-level `OrbitRuntime` exposes thin delegates that build the runtime's
 //! shared state into these calls.
 
+mod doc_index;
+mod doc_search;
 mod install;
 mod reindex;
 mod related;
@@ -12,6 +14,8 @@ mod search;
 mod stats;
 mod uninstall;
 
+pub use doc_index::{DocIndexParams, DocIndexResult};
+pub use doc_search::{DocSemanticHit, DocSemanticSearchParams, DocSemanticSearchResult};
 pub use install::{SemanticInstallParams, SemanticInstallResult};
 pub use reindex::{SemanticReindexParams, SemanticReindexResult};
 pub use related::{SemanticRelatedParams, SemanticRelatedResult};
@@ -23,7 +27,7 @@ use std::fs;
 
 use orbit_common::types::{OrbitError, Task};
 
-use crate::vector::VectorStore;
+use crate::vector::{DocEmbeddingSource, VectorStore};
 use crate::{CompanionPaths, ModelSpec, default_model};
 
 pub(crate) const DEFAULT_RELEASE_BASE_URL: &str =
@@ -82,6 +86,14 @@ pub fn semantic_reindex(
     reindex::run(vector_store, tasks, params)
 }
 
+pub fn doc_index(
+    vector_store: &VectorStore,
+    docs: &[DocEmbeddingSource],
+    params: DocIndexParams,
+) -> Result<DocIndexResult, OrbitError> {
+    doc_index::run(vector_store, docs, params)
+}
+
 pub fn semantic_stats(
     vector_store: &VectorStore,
     task_ids: &[String],
@@ -94,6 +106,13 @@ pub fn semantic_search(
     params: SemanticSearchParams,
 ) -> Result<SemanticSearchResult, OrbitError> {
     search::run(vector_store, params)
+}
+
+pub fn doc_semantic_search(
+    vector_store: &VectorStore,
+    params: DocSemanticSearchParams,
+) -> Result<DocSemanticSearchResult, OrbitError> {
+    doc_search::run(vector_store, params)
 }
 
 pub fn semantic_related(

--- a/crates/orbit-search/src/lib.rs
+++ b/crates/orbit-search/src/lib.rs
@@ -36,11 +36,13 @@ mod subprocess;
 mod vector;
 
 pub use commands::{
-    CompanionStatus, ScoreBreakdown, SemanticHit, SemanticInstallParams, SemanticInstallResult,
-    SemanticReindexParams, SemanticReindexResult, SemanticRelatedParams, SemanticRelatedResult,
-    SemanticSearchParams, SemanticSearchResult, SemanticStatsResult, SemanticUninstallParams,
-    SemanticUninstallResult, semantic_install, semantic_reindex, semantic_related, semantic_search,
-    semantic_stats, semantic_uninstall,
+    CompanionStatus, DocIndexParams, DocIndexResult, DocSemanticHit, DocSemanticSearchParams,
+    DocSemanticSearchResult, ScoreBreakdown, SemanticHit, SemanticInstallParams,
+    SemanticInstallResult, SemanticReindexParams, SemanticReindexResult, SemanticRelatedParams,
+    SemanticRelatedResult, SemanticSearchParams, SemanticSearchResult, SemanticStatsResult,
+    SemanticUninstallParams, SemanticUninstallResult, doc_index, doc_semantic_search,
+    semantic_install, semantic_reindex, semantic_related, semantic_search, semantic_stats,
+    semantic_uninstall,
 };
 pub use companion::{
     CompanionPaths, INSTALL_REMEDIATION, locate_companion, platform_companion_filename, platform_id,
@@ -53,4 +55,7 @@ pub use lexical::docs::{
 pub use noop::NoopEmbedder;
 pub use rpc::{RpcError, RpcRequest, RpcResponse, RpcResult};
 pub use subprocess::SubprocessEmbedder;
-pub use vector::{EmbedWorker, SemanticStats, UpsertReport, VectorStore};
+pub use vector::{
+    DocEmbeddingSource, EmbedWorker, SOURCE_KIND_DOC, SOURCE_KIND_TASK, SemanticStats,
+    UpsertReport, VectorStore,
+};

--- a/crates/orbit-search/src/vector/doc_fields.rs
+++ b/crates/orbit-search/src/vector/doc_fields.rs
@@ -1,0 +1,50 @@
+//! Maps a docs corpus record to the per-field rows embedded for doc search.
+
+use super::EmbeddingField;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DocEmbeddingSource {
+    pub path: String,
+    pub title: String,
+    pub tags: Vec<String>,
+    pub body: String,
+}
+
+pub fn doc_embedding_fields(doc: &DocEmbeddingSource) -> Vec<EmbeddingField> {
+    let mut fields = Vec::new();
+    push_field(&mut fields, "path", &doc.path);
+    push_field(&mut fields, "title", &doc.title);
+    if !doc.tags.is_empty() {
+        push_field(&mut fields, "tags", &doc.tags.join("\n"));
+    }
+    push_field(&mut fields, "body", &doc.body);
+    fields
+}
+
+fn push_field(fields: &mut Vec<EmbeddingField>, field: impl Into<String>, text: &str) {
+    if !text.trim().is_empty() {
+        fields.push(EmbeddingField::new(field, text.trim().to_string()));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn doc_embedding_fields_use_stable_names() {
+        let source = DocEmbeddingSource {
+            path: "docs/example.md".to_string(),
+            title: "Example Summary".to_string(),
+            tags: vec!["search".to_string(), "docs".to_string()],
+            body: "Body text".to_string(),
+        };
+
+        let field_names = doc_embedding_fields(&source)
+            .into_iter()
+            .map(|field| field.field)
+            .collect::<Vec<_>>();
+
+        assert_eq!(field_names, vec!["path", "title", "tags", "body"]);
+    }
+}

--- a/crates/orbit-search/src/vector/mod.rs
+++ b/crates/orbit-search/src/vector/mod.rs
@@ -10,6 +10,8 @@
 //! - [`query`] — brute-force cosine, FTS5 BM25, RRF, and task-result rollup.
 //! - [`task_fields`] — extracts the per-field rows that get embedded for a
 //!   `Task`.
+//! - [`doc_fields`] — extracts the per-field rows that get embedded for a
+//!   docs corpus record.
 //!
 //! This file holds the small data types (`EmbeddingField`, `UpsertReport`,
 //! `SemanticStats`, `SourceModelCount`) and stateless helpers
@@ -17,12 +19,14 @@
 //! those submodules.
 
 pub(crate) mod chunker;
+pub(crate) mod doc_fields;
 pub(crate) mod query;
 pub(crate) mod store;
 pub(crate) mod task_fields;
 pub(crate) mod worker;
 
-pub use store::VectorStore;
+pub use doc_fields::DocEmbeddingSource;
+pub use store::{SOURCE_KIND_DOC, SOURCE_KIND_TASK, VectorStore};
 pub use worker::EmbedWorker;
 
 use orbit_common::types::OrbitError;

--- a/crates/orbit-search/src/vector/store/docs.rs
+++ b/crates/orbit-search/src/vector/store/docs.rs
@@ -1,0 +1,119 @@
+//! Docs-corpus indexing entry points.
+
+use std::collections::BTreeSet;
+
+use orbit_common::types::OrbitError;
+
+use super::{SOURCE_KIND_DOC, VectorStore};
+use crate::Embedder;
+use crate::vector::UpsertReport;
+use crate::vector::doc_fields::{DocEmbeddingSource, doc_embedding_fields};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DocReindexReport {
+    pub upsert: UpsertReport,
+    pub indexed_sources: usize,
+    pub stale_sources: Vec<String>,
+}
+
+impl VectorStore {
+    pub fn index_doc(
+        &self,
+        doc: &DocEmbeddingSource,
+        embedder: &dyn Embedder,
+        force: bool,
+    ) -> Result<UpsertReport, OrbitError> {
+        self.upsert_embeddings(
+            SOURCE_KIND_DOC,
+            &doc.path,
+            &doc_embedding_fields(doc),
+            embedder,
+            force,
+        )
+    }
+
+    pub fn reindex_docs(
+        &self,
+        docs: &[DocEmbeddingSource],
+        embedder: &dyn Embedder,
+        force: bool,
+    ) -> Result<DocReindexReport, OrbitError> {
+        let mut upsert = UpsertReport::default();
+        let live = docs
+            .iter()
+            .map(|doc| doc.path.clone())
+            .collect::<BTreeSet<_>>();
+        for doc in docs {
+            let report = self.index_doc(doc, embedder, force)?;
+            upsert.embedded_chunks += report.embedded_chunks;
+            upsert.skipped_fields += report.skipped_fields;
+        }
+
+        let mut stale_sources = Vec::new();
+        for source_id in self.source_ids(SOURCE_KIND_DOC)? {
+            if !live.contains(&source_id) {
+                self.delete_source(SOURCE_KIND_DOC, &source_id)?;
+                stale_sources.push(source_id);
+            }
+        }
+        Ok(DocReindexReport {
+            upsert,
+            indexed_sources: live.len(),
+            stale_sources,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::NoopEmbedder;
+
+    fn doc(path: &str, title: &str, body: &str) -> DocEmbeddingSource {
+        DocEmbeddingSource {
+            path: path.to_string(),
+            title: title.to_string(),
+            tags: vec!["docs".to_string()],
+            body: body.to_string(),
+        }
+    }
+
+    #[test]
+    fn noop_doc_indexing_populates_doc_rows() {
+        let store = VectorStore::open_in_memory().unwrap();
+        let embedder = NoopEmbedder::small();
+
+        let report = store
+            .index_doc(
+                &doc("docs/example.md", "Example", "semantic docs body"),
+                &embedder,
+                false,
+            )
+            .unwrap();
+        let stats = store.stats(&[]).unwrap();
+
+        assert!(report.embedded_chunks >= 3);
+        assert_eq!(stats.counts[0].source_kind, "doc");
+        assert_eq!(stats.counts[0].model_id, "noop");
+    }
+
+    #[test]
+    fn reindex_docs_removes_stale_sources() {
+        let store = VectorStore::open_in_memory().unwrap();
+        let embedder = NoopEmbedder::small();
+        store
+            .index_doc(&doc("docs/old.md", "Old", "old body"), &embedder, false)
+            .unwrap();
+
+        let report = store
+            .reindex_docs(&[doc("docs/new.md", "New", "new body")], &embedder, false)
+            .unwrap();
+        let source_ids = store.source_ids(SOURCE_KIND_DOC).unwrap();
+
+        assert_eq!(report.stale_sources, vec!["docs/old.md"]);
+        assert_eq!(
+            source_ids.into_iter().collect::<Vec<_>>(),
+            vec!["docs/new.md"]
+        );
+    }
+}

--- a/crates/orbit-search/src/vector/store/mod.rs
+++ b/crates/orbit-search/src/vector/store/mod.rs
@@ -6,12 +6,14 @@
 //! - [`upsert`] — `upsert_embeddings`, the BLAKE3-deduped per-field write path,
 //!   plus its private SQL helpers (`delete_field_rows`, content-hash check).
 //! - [`tasks`] — `index_task` / `reindex_tasks` task-corpus entry points.
+//! - [`docs`] — `index_doc` / `reindex_docs` docs-corpus entry points.
 //! - [`queries`] — `delete_source` and `stats` read/cascade operations.
 //!
 //! This file owns the `VectorStore` struct itself plus the connection-handle
 //! plumbing (`open`, `open_in_memory`, `connection`, the WAL pragma helper)
 //! and the small `pub(super)` constants shared across the submodules above.
 
+mod docs;
 mod queries;
 mod schema;
 mod tasks;
@@ -23,7 +25,9 @@ use std::sync::{Arc, Mutex};
 use orbit_common::types::OrbitError;
 use rusqlite::Connection;
 
-pub(super) const SOURCE_KIND_TASK: &str = "task";
+pub const SOURCE_KIND_TASK: &str = "task";
+// ADR-0180: docs share the embeddings table through source_kind, not a separate schema.
+pub const SOURCE_KIND_DOC: &str = "doc";
 
 #[derive(Clone)]
 pub struct VectorStore {

--- a/crates/orbit-search/src/vector/store/queries.rs
+++ b/crates/orbit-search/src/vector/store/queries.rs
@@ -14,6 +14,24 @@ use super::VectorStore;
 use crate::vector::{SemanticStats, SourceModelCount};
 
 impl VectorStore {
+    pub fn source_ids(&self, source_kind: &str) -> Result<BTreeSet<String>, OrbitError> {
+        let conn = self.connection();
+        let conn = conn
+            .lock()
+            .map_err(|error| OrbitError::Store(format!("mutex poisoned: {error}")))?;
+        let mut stmt = conn
+            .prepare("SELECT DISTINCT source_id FROM embeddings WHERE source_kind = ?1")
+            .map_err(|error| OrbitError::Store(error.to_string()))?;
+        let rows = stmt
+            .query_map(params![source_kind], |row| row.get::<_, String>(0))
+            .map_err(|error| OrbitError::Store(error.to_string()))?;
+        let mut source_ids = BTreeSet::new();
+        for row in rows {
+            source_ids.insert(row.map_err(|error| OrbitError::Store(error.to_string()))?);
+        }
+        Ok(source_ids)
+    }
+
     pub fn delete_source(&self, source_kind: &str, source_id: &str) -> Result<(), OrbitError> {
         let conn = self.connection();
         let conn = conn

--- a/crates/orbit-tools/src/builtin/orbit/docs.rs
+++ b/crates/orbit-tools/src/builtin/orbit/docs.rs
@@ -6,7 +6,7 @@ use crate::{OrbitBuiltinAction, Tool, ToolContext};
 pub struct OrbitDocsListTool;
 pub struct OrbitDocsShowTool;
 pub struct OrbitDocsAddTool;
-pub struct OrbitDocsReindexTool;
+pub struct OrbitDocsIndexTool;
 pub struct OrbitDocsMigrateTool;
 
 impl Tool for OrbitDocsListTool {
@@ -72,18 +72,30 @@ impl Tool for OrbitDocsAddTool {
     }
 }
 
-impl Tool for OrbitDocsReindexTool {
+impl Tool for OrbitDocsIndexTool {
     fn schema(&self) -> ToolSchema {
         ToolSchema {
-            name: "orbit.docs.reindex".to_string(),
-            description: "No-op v1 docs reindex surface; docs are walked on demand.".to_string(),
-            parameters: Vec::new(),
+            name: "orbit.docs.index".to_string(),
+            description: "Build or refresh doc corpus embeddings under configured [docs].roots."
+                .to_string(),
+            parameters: vec![
+                optional_param(
+                    "model",
+                    "Embedding model alias to use for indexing.",
+                    "string",
+                ),
+                optional_param(
+                    "force",
+                    "Re-embed even when content hashes are unchanged.",
+                    "boolean",
+                ),
+            ],
             builtin: true,
         }
     }
 
     fn execute(&self, ctx: &ToolContext, input: Value) -> Result<Value, OrbitError> {
-        super::execute_host_action(ctx, input, OrbitBuiltinAction::DocsReindex)
+        super::execute_host_action(ctx, input, OrbitBuiltinAction::DocsIndex)
     }
 }
 

--- a/crates/orbit-tools/src/builtin/orbit/mod.rs
+++ b/crates/orbit-tools/src/builtin/orbit/mod.rs
@@ -41,7 +41,7 @@ pub fn register(registry: &mut ToolRegistry) {
     registry.register(docs::OrbitDocsListTool);
     registry.register(docs::OrbitDocsShowTool);
     registry.register(docs::OrbitDocsAddTool);
-    registry.register(docs::OrbitDocsReindexTool);
+    registry.register(docs::OrbitDocsIndexTool);
     registry.register(docs::OrbitDocsMigrateTool);
     registry.register(groundhog::checkpoint_success::OrbitGroundhogCheckpointSuccessTool);
     registry.register(groundhog::checkpoint_failure::OrbitGroundhogCheckpointFailureTool);

--- a/crates/orbit-tools/src/builtin/orbit/search.rs
+++ b/crates/orbit-tools/src/builtin/orbit/search.rs
@@ -19,7 +19,7 @@ impl Tool for OrbitSearchTool {
                 // ADR-0179: expose the free-text vector ranker as hybrid, not semantic.
                 name: "hybrid".to_string(),
                 description:
-                    "Opt into hybrid BM25 + cosine ranking for task vectors; other kinds remain lexical."
+                    "Opt into hybrid lexical + cosine ranking for indexed task and doc vectors; learnings and ADRs remain lexical."
                         .to_string(),
                 param_type: "boolean".to_string(),
                 required: false,
@@ -83,7 +83,7 @@ impl Tool for OrbitSearchTool {
         ToolSchema {
             name: "orbit.search".to_string(),
             description:
-                "Search tasks, docs, learnings, and ADRs. Semantic vector search currently applies to tasks only."
+                "Search tasks, docs, learnings, and ADRs. Hybrid vector ranking applies to indexed tasks and docs."
                     .to_string(),
             parameters,
             builtin: true,

--- a/crates/orbit-tools/src/lib.rs
+++ b/crates/orbit-tools/src/lib.rs
@@ -76,7 +76,7 @@ pub enum OrbitBuiltinAction {
     DocsList,
     DocsShow,
     DocsAdd,
-    DocsReindex,
+    DocsIndex,
     DocsMigrate,
     FrictionAdd,
     FrictionList,

--- a/crates/orbit-tools/tests/public_tool_surface.rs
+++ b/crates/orbit-tools/tests/public_tool_surface.rs
@@ -46,6 +46,12 @@ fn unused_tools_are_not_registered_in_public_surface() {
             "removed tool still registered: {name}"
         );
     }
+
+    let removed_docs_reindex = ["orbit.docs", "reindex"].join(".");
+    assert!(
+        !names.contains(removed_docs_reindex.as_str()),
+        "removed docs reindex tool still registered"
+    );
 }
 
 #[test]
@@ -76,6 +82,7 @@ fn workflow_critical_tools_remain_registered() {
         "orbit.groundhog.checkpoint_failure",
         "orbit.groundhog.checkpoint_success",
         "orbit.groundhog.side_effect",
+        "orbit.docs.index",
         "orbit.pipeline.invoke",
         "orbit.pipeline.wait",
         "orbit.search",

--- a/docs/design/orbit-docs/1_overview.md
+++ b/docs/design/orbit-docs/1_overview.md
@@ -1,7 +1,7 @@
 ---
 title: "Orbit Docs — Overview"
 owner: claude
-last_updated: 2026-05-20
+last_updated: 2026-05-21
 status: Draft
 feature: orbit-docs
 doc_role: overview
@@ -9,7 +9,7 @@ type: design
 summary: "Orbit Docs — what the human-authored docs corpus is, why it exists alongside learnings and ADRs, and how agents retrieve from it."
 tags: [orbit-docs]
 related_features: [orbit-docs]
-related_artifacts: [ORB-00163, ADR-0169, ADR-0170, ADR-0171]
+related_artifacts: [ORB-00163, ORB-00206, ADR-0169, ADR-0170, ADR-0171, ADR-0180]
 ---
 
 # Orbit Docs — Overview
@@ -18,7 +18,7 @@ Orbit Docs is the human-authored knowledge corpus for an Orbit workspace. It ind
 
 The system is **pull-first**: agents call `orbit search --kind doc` (or `--kind all` for federated doc+ADR) or `orbit docs show` when they need context. Push-style injection (PreToolUse hook surfaces, `task show --with-context`) is a downstream feature, designed but not yet wired ([ORB-00166], [ORB-00167]).
 
-Phase 1 ships the corpus, the locked frontmatter schema, the six-verb surface, the `orbit-docs` skill, and a one-shot migrator that backfills legacy `docs/design/<feature>/` and `docs/design-patterns/` files. [2_design.md](./2_design.md) specifies the schema, walker, surface, and tolerant indexer; [3_vision.md](./3_vision.md) names open questions and the v2 roadmap (semantic ranking, ADR folding, hook integration); [4_decisions.md](./4_decisions.md) is the ADR log.
+Phase 1 ships the corpus, the locked frontmatter schema, the six-verb surface, the `orbit-docs` skill, doc-corpus embeddings via `orbit docs index`, and a one-shot migrator that backfills legacy `docs/design/<feature>/` and `docs/design-patterns/` files. [2_design.md](./2_design.md) specifies the schema, walker, surface, tolerant indexer, and hybrid search path; [3_vision.md](./3_vision.md) names open questions and the remaining roadmap (ADR folding, hook integration); [4_decisions.md](./4_decisions.md) is the ADR log.
 
 ---
 
@@ -73,9 +73,9 @@ Strict parsing still applies if you opt in via the `migrate` verb or by writing 
 |------|---------|
 | `orbit docs list` | Walk configured roots; return all records (with optional `--type` and `--tag` filters). |
 | `orbit docs show <path>` | Render one doc with parsed frontmatter and body. |
-| `orbit search --kind doc <query>` | Ranked matches against `summary`, `tags`, and `type`. Substring + tag-exact + type-exact scoring; semantic ranking deferred to v2 ([ORB-00168]). |
+| `orbit search --kind doc <query>` | Ranked matches against `summary`, `tags`, and `type`. Add `--hybrid` to blend lexical doc scoring with doc embeddings from `orbit docs index`. |
 | `orbit docs add <path>` | Append `<path>` to `[docs].roots`. Idempotent. Refuses `.orbit/` paths and non-existent paths. |
-| `orbit docs reindex` | v1 no-op for forward compatibility; the walker is on-demand. Slot reserved for the v2 embeddings index. |
+| `orbit docs index` | Walk configured roots, embed doc fields into `.orbit/state/semantic.db`, and sweep stale doc rows. |
 | `orbit docs migrate [--dry-run]` | One-shot frontmatter backfill for legacy `docs/design/<feature>/*.md` and `docs/design-patterns/*.md`. Idempotent. Never touches `.orbit/`. |
 
 Each verb has an MCP twin (`orbit.docs.list`, etc.) registered in the safe MCP surface. CLI and MCP shapes are identical.

--- a/docs/design/orbit-docs/2_design.md
+++ b/docs/design/orbit-docs/2_design.md
@@ -1,21 +1,21 @@
 ---
 title: "Orbit Docs — Design"
 owner: claude
-last_updated: 2026-05-20
+last_updated: 2026-05-21
 status: Draft
 feature: orbit-docs
 doc_role: design
 type: design
-summary: "Orbit Docs — frontmatter schema, walker, tolerant indexer, six-verb surface, and the `.orbit/` exclusion invariant."
+summary: "Orbit Docs — frontmatter schema, walker, doc embeddings index, hybrid search, and the `.orbit/` exclusion invariant."
 tags: [orbit-docs]
 paths: ["crates/orbit-core/src/command/docs.rs", "crates/orbit-cli/src/command/docs.rs"]
 related_features: [orbit-docs]
-related_artifacts: [ORB-00163, ADR-0169, ADR-0170, ADR-0171]
+related_artifacts: [ORB-00163, ORB-00206, ADR-0169, ADR-0170, ADR-0171, ADR-0180]
 ---
 
 # Orbit Docs — Design
 
-This document specifies what [ORB-00163] shipped: the locked frontmatter schema, the strict-then-tolerant parser, the walker (including the `.orbit/` exclusion invariant), the six-verb CLI / MCP surface, and the migration verb that backfills legacy docs. It also names the v1 limitations the v2 follow-ups ([ORB-00164] through [ORB-00169]) address.
+This document specifies what [ORB-00163] and [ORB-00206] ship: the locked frontmatter schema, the strict-then-tolerant parser, the walker (including the `.orbit/` exclusion invariant), the six-verb CLI / MCP surface, doc-corpus embeddings, hybrid doc search, and the migration verb that backfills legacy docs. It also names the remaining limitations the follow-ups ([ORB-00164] through [ORB-00169]) address.
 
 The design lives in two files: [crates/orbit-core/src/command/docs.rs](../../../crates/orbit-core/src/command/docs.rs) (~1290 lines, parser + walker + verb implementations + tests) and [crates/orbit-cli/src/command/docs.rs](../../../crates/orbit-cli/src/command/docs.rs) (~250 lines, clap argument shapes + table rendering). The MCP twin lives in [crates/orbit-core/src/runtime/orbit_tool_host/docs_tools.rs](../../../crates/orbit-core/src/runtime/orbit_tool_host/docs_tools.rs).
 
@@ -213,15 +213,15 @@ JSON shape: `{ "path", "frontmatter", "body" }`.
 
 ### 6.3 `orbit search --kind doc <query>`
 
-See §5. Returns the ranked list with `score` and `matched_by` (list of which fields hit).
+See §5. Returns the ranked list with `score` and `matched_by` (list of which fields hit). Without `--hybrid`, the output is lexical-only. With `--hybrid`, Orbit embeds the query, retrieves `source_kind = "doc"` rows, min-max normalizes lexical and cosine scores, and blends them with `[docs.search].semantic_weight` (default `0.5`, clamped to `[0.0, 1.0]`). If the companion is missing or no doc embeddings exist, the command warns and falls back to lexical results.
 
 ### 6.4 `orbit docs add <path>`
 
 Idempotently appends a normalized path to `[docs].roots`. Refuses non-existent paths and `.orbit/` paths. Writes back to `.orbit/config.toml`, preserving the rest of the file by round-tripping through `toml::Value`. Idempotency is determined by normalized path comparison (trailing `/` and case ignored on the candidate-vs-existing check).
 
-### 6.5 `orbit docs reindex`
+### 6.5 `orbit docs index [--json] [--force] [--model <alias>]`
 
-v1 no-op. Returns `"indexer is walk-on-demand; nothing to do."`. The verb exists so the surface is stable for [ORB-00168] (semantic embeddings index).
+Walks configured docs roots, reads each Markdown body through the tolerant parser, maps each doc to `{path, title, tags, body}`, and calls the orbit-search vector store with `source_kind = "doc"`. `--force` bypasses the existing `content_hash` skip, while the default path is idempotent. After indexing, the command deletes stale doc rows whose `source_id` no longer appears in the live docs corpus.
 
 ### 6.6 `orbit docs migrate [--dry-run]`
 
@@ -244,7 +244,7 @@ Five tools, registered in `safe_mcp_tool_names` ([crates/orbit-cli/src/command/m
 orbit.docs.list
 orbit.docs.show
 orbit.docs.add
-orbit.docs.reindex
+orbit.docs.index
 orbit.docs.migrate
 ```
 
@@ -260,20 +260,23 @@ The per-domain doc-search MCP tool was retired by [ORB-00202]; content-similarit
 [docs]
 roots = ["docs/"]                     # default when section absent
 # roots = ["docs/", "apps/*/docs/"]   # monorepo example
+
+[docs.search]
+semantic_weight = 0.5                 # default; clamped to 0.0..1.0
 ```
 
-When the section is absent or the file is empty, the default is `["docs/"]`. `parse_docs_roots_from_config_toml` is the inner parser; `OrbitRuntime::docs_roots` is the call site that resolves the configured path.
+When the section is absent or the file is empty, the default root is `["docs/"]` and the default hybrid semantic weight is `0.5`. `parse_docs_roots_from_config_toml` and `parse_docs_search_config_from_config_toml` are the inner parsers; `OrbitRuntime::docs_roots` and `OrbitRuntime::docs_search_config` are the call sites that resolve the configured path.
 
 ---
 
 ## 9. Concerns & Honest Limitations
 
-- **No body indexing.** Search is summary + tags + type only. A doc whose body contains the queried concept but whose frontmatter doesn't will not surface. This is by design until semantic ranking exists ([ORB-00168]).
+- **Lexical search is still frontmatter-only.** Plain `orbit search --kind doc` scores summary + tags + type only. Body-level concept recall requires `orbit docs index` plus `orbit search --kind doc --hybrid`.
 - **`migration_diff` is not a real diff.** It prints the first 12 lines of `before` and first 16 lines of `after` glued together with `@@` markers. Misleading label. [ORB-00164] tracks the fix.
 - **`update_existing_frontmatter` hand-edits YAML by line.** Works for simple `key: scalar` legacy headers. Will misbehave on multi-line block scalars (`description: |`) and quoted values containing colons. [ORB-00164] tracks the round-trip-through-`serde_yaml` fix.
 - **`is_git_ignored` shells out per file.** Acceptable at ~100 docs. Will degrade at thousands. [ORB-00164] tracks the batched-stdin or `ignore`-crate fix.
 - **No hook-time or task-time injection yet.** The retrieval primitive ships in v1; injection is [ORB-00166] and [ORB-00167].
-- **No semantic ranking.** v1 is BM25-ish substring + exact-match. v2 is [ORB-00168].
+- **Doc semantic freshness is explicit.** Task writes enqueue background embeddings, but docs require `orbit docs index` until a future watcher/background indexer exists.
 - **ADRs are not in the corpus.** [ORB-00169] is the design question.
 
 ---

--- a/docs/design/orbit-docs/3_vision.md
+++ b/docs/design/orbit-docs/3_vision.md
@@ -1,20 +1,20 @@
 ---
 title: "Orbit Docs — Vision"
 owner: claude
-last_updated: 2026-05-20
+last_updated: 2026-05-21
 status: Draft
 feature: orbit-docs
 doc_role: vision
 type: design
-summary: "Orbit Docs — open questions, the v2 roadmap (semantic ranking, injection, ADR folding), and prior work in the agent-knowledge-base space."
+summary: "Orbit Docs — open questions, the remaining roadmap (injection, ADR folding), and prior work in the agent-knowledge-base space."
 tags: [orbit-docs]
 related_features: [orbit-docs]
-related_artifacts: [ORB-00164, ORB-00165, ORB-00166, ORB-00167, ORB-00168, ORB-00169]
+related_artifacts: [ORB-00164, ORB-00165, ORB-00166, ORB-00167, ORB-00168, ORB-00169, ORB-00206, ADR-0180]
 ---
 
 # Orbit Docs — Vision
 
-The v1 from [ORB-00163] is the corpus and the retrieval primitive. The injection wiring, the semantic ranker, and the ADR-folding question are all v2. This document names the open questions, the planned follow-up work, the prior art that shaped the design, and the dimensions on which orbit-docs differs from sibling tools.
+The v1 from [ORB-00163] is the corpus and the retrieval primitive; [ORB-00206] adds doc embeddings and opt-in hybrid ranking. Injection wiring and the ADR-folding question remain future work. This document names the open questions, the planned follow-up work, the prior art that shaped the design, and the dimensions on which orbit-docs differs from sibling tools.
 
 ---
 

--- a/docs/design/orbit-docs/4_decisions.md
+++ b/docs/design/orbit-docs/4_decisions.md
@@ -1,15 +1,15 @@
 ---
 title: "Orbit Docs — Decisions"
 owner: claude
-last_updated: 2026-05-19
+last_updated: 2026-05-21
 status: Draft
 feature: orbit-docs
 doc_role: decisions
 type: design
-summary: "Orbit Docs — accepted ADRs: locked frontmatter schema, `.orbit/` vs `docs/` locating principle, ID-prefix dispatch for `related_artifacts`."
+summary: "Orbit Docs — accepted ADRs: locked frontmatter schema, `.orbit/` vs `docs/` locating principle, ID-prefix dispatch, and doc embeddings indexing."
 tags: [orbit-docs]
 related_features: [orbit-docs]
-related_artifacts: [ADR-0169, ADR-0170, ADR-0171, ORB-00163]
+related_artifacts: [ADR-0169, ADR-0170, ADR-0171, ADR-0180, ORB-00163, ORB-00206]
 ---
 
 # Orbit Docs — Decisions
@@ -67,8 +67,25 @@ ADR allocation is non-negotiable: the global ID is minted via `orbit.adr.add` *b
 
 ---
 
+## ADR-0180 — Doc corpus embeddings use `docs index` and opt-in hybrid search
+
+**Status:** Accepted · 2026-05-21 · [ORB-00206]
+
+**Context.** Doc search was lexical-only after [ORB-00202] unified the query surface, while the orbit-search store already had a `source_kind` discriminator that could hold docs. The alternatives were to keep semantic ranking deferred, add a separate docs search verb, or reuse the existing vector store behind the unified `orbit search --kind doc --hybrid` path.
+
+**Decision.** Use `orbit docs index` as the explicit admin verb that embeds configured docs roots into `source_kind = "doc"` rows, and keep retrieval opt-in through `orbit search <query> --kind doc --hybrid`. Lexical doc search remains the default, ADRs stay lifecycle-owned and lexical-only, and `[docs.search].semantic_weight` tunes the blend without adding another CLI flag.
+
+**Consequences.**
+- The old no-op docs indexing verb is retired rather than kept as a shim, so the docs lifecycle verb now matches `orbit semantic index`.
+- Doc embeddings reuse orbit-search storage and companion model selection without adding an orbit-search to orbit-core dependency.
+- Hybrid doc search can improve concept queries while preserving lexical fallback when the companion or doc rows are unavailable.
+- Cost: the docs index becomes a second freshness loop next to task semantic indexing; operators must run `orbit docs index` after substantial doc moves or edits until background indexing exists.
+
+---
+
 ## Task References
 
 - [ORB-00163] — Introduce `orbit docs` indexed knowledge base and `orbit-docs` skill
+- [ORB-00206] — Add doc-corpus embeddings: `orbit docs index` and hybrid scoring for `orbit search --kind doc`
 
 Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.

--- a/docs/design/orbit-search/2_design.md
+++ b/docs/design/orbit-search/2_design.md
@@ -255,6 +255,7 @@ orbit search <query> [--hybrid] [--kind task|doc|learning|adr|all] [--limit N]
 orbit search similar <task-id> [--limit N]
 orbit search path <path> [--kind task|doc|learning|adr|all] [--limit N]
 orbit semantic index     [--force] [--model MODEL]
+orbit docs index         [--force] [--model MODEL]
 orbit semantic stats
 ```
 
@@ -262,16 +263,17 @@ orbit semantic stats
 
 `uninstall` removes the companion binary and (by default) the currently active model. `--model M` removes only model M. `--all` removes the companion plus every installed model.
 
-`orbit search` defaults to lexical matching across tasks, docs, learnings, and ADRs. `--hybrid --kind task` runs the hybrid pipeline over task vectors; non-task kinds remain lexical even when `--hybrid` is set. `orbit search similar <task-id>` embeds the target task's `purpose + summary` and runs cosine-only against other tasks (lexical fusion adds noise here). `orbit search path <path>` performs applicability lookup over path-scoped artifacts. `orbit semantic index` rebuilds the `embeddings` rows; `--force` ignores `content_hash` and re-embeds everything. `stats` reports row counts, model distribution, stale-row count, and companion-install status.
+`orbit search` defaults to lexical matching across tasks, docs, learnings, and ADRs. `--hybrid --kind task` runs the hybrid pipeline over task vectors; `--hybrid --kind doc` blends docs lexical scoring with cosine over rows built by `orbit docs index`; learnings and ADRs remain lexical. `orbit search similar <task-id>` embeds the target task's `purpose + summary` and runs cosine-only against other tasks (lexical fusion adds noise here). `orbit search path <path>` performs applicability lookup over path-scoped artifacts. `orbit semantic index` rebuilds task `embeddings` rows; `orbit docs index` rebuilds doc rows and sweeps stale doc paths. `--force` ignores `content_hash` and re-embeds everything. `stats` reports row counts, model distribution, stale-row count, and companion-install status.
 
-If the companion is not installed, `orbit search --hybrid`, `orbit search similar <task-id>`, and `orbit semantic index` exit non-zero with: `"Semantic search not enabled. Run \`orbit semantic install\` to download the inference companion."`
+If the companion is not installed, task-hybrid search, `orbit search similar <task-id>`, `orbit semantic index`, and `orbit docs index` exit non-zero with: `"Semantic search not enabled. Run \`orbit semantic install\` to download the inference companion."` Doc-hybrid search is softer: it emits a warning/note and falls back to lexical doc results.
 
 ### 6.2 MCP tools
 
 - `orbit.search` — `(query?, hybrid?, semantic?, kind?, limit?, tag?, all?, status?, path?)` → ranked results with snippets.
 - `orbit.semantic.install`, `orbit.semantic.uninstall`, `orbit.semantic.stats`, `orbit.semantic.index` — companion lifecycle.
+- `orbit.docs.index` — docs-corpus embedding build and stale-source sweep.
 
-`orbit.search` is read-only. Indexing is implicit (on task mutation) or explicit (`orbit semantic index` / `orbit.semantic.index`).
+`orbit.search` is read-only. Task indexing is implicit (on task mutation) or explicit (`orbit semantic index` / `orbit.semantic.index`); docs indexing is explicit (`orbit docs index` / `orbit.docs.index`).
 
 ### 6.3 Result shape
 

--- a/docs/design/orbit-search/4_decisions.md
+++ b/docs/design/orbit-search/4_decisions.md
@@ -212,7 +212,7 @@ Compare to the analogous knowledge-graph crate: `orbit-knowledge` owns its data 
 - Establishes a precedent that lifecycle namespaces manage local subsystems while query namespaces describe what users are trying to do.
 - `orbit semantic search`, `orbit semantic related`, and `orbit semantic reindex` are hard breaks with no shim because there are no known external consumers yet.
 - Per-domain search commands stay untouched for phase 1; a later task decides whether they thin-wrap `orbit search`, demote to filters, or retire.
-- Vector index coverage remains task-only today; docs, learnings, and ADRs continue to use lexical matching even when `--hybrid` is set.
+- At this phase, docs, learnings, and ADRs used lexical matching even when `--hybrid` was set; ADR-0180 later adds opt-in doc vectors while keeping learnings and ADRs lexical.
 
 ---
 
@@ -270,6 +270,22 @@ Compare to the analogous knowledge-graph crate: `orbit-knowledge` owns its data 
 
 ---
 
+## ADR-0180 — Doc corpus embeddings use `docs index` and opt-in hybrid search
+
+**Status:** Accepted · 2026-05-21 · [ORB-00206]
+
+**Context.** Doc search was lexical-only after [ORB-00202] unified the query surface, while the orbit-search store already had a `source_kind` discriminator that could hold docs. The alternatives were to keep semantic ranking deferred, add a separate docs search verb, or reuse the existing vector store behind the unified `orbit search --kind doc --hybrid` path.
+
+**Decision.** Use `orbit docs index` as the explicit admin verb that embeds configured docs roots into `source_kind = "doc"` rows, and keep retrieval opt-in through `orbit search <query> --kind doc --hybrid`. Lexical doc search remains the default, ADRs stay lifecycle-owned and lexical-only, and `[docs.search].semantic_weight` tunes the blend without adding another CLI flag.
+
+**Consequences.**
+- `orbit docs index` shares the semantic companion, model catalog, and `embeddings` table with task vectors rather than creating a doc-specific store.
+- The search crate owns doc field extraction and stale-source sweeping, but does not depend on orbit-core; core passes a small `DocEmbeddingSource`.
+- Hybrid doc search falls back to lexical when the companion or doc rows are unavailable, preserving read-path ergonomics while making the admin indexing verb fail clearly.
+- Cost: docs now have a manual freshness loop separate from task mutation indexing. Background docs indexing remains a future task.
+
+---
+
 ## Task References
 
 - [T20260510-3] — Design semantic search over task artifacts and graph (v2). The task that produced this folder.
@@ -281,5 +297,6 @@ Compare to the analogous knowledge-graph crate: `orbit-knowledge` owns its data 
 - [ORB-00202] — Consolidate per-domain search subcommands and add cross-kind `--path` / `--tag` filters. The task that proposed and implemented ADR-0176.
 - [ORB-00203] — Add ADR envelope `tags` and `paths` so ADRs participate in cross-kind `--tag` / `--path` search filters.
 - [ORB-00205] — Split `orbit search` into query / similar / path forms and require per-kind `--status` syntax. The task that accepted and implemented ADR-0179.
+- [ORB-00206] — Add doc-corpus embeddings through `orbit docs index` and `orbit search --kind doc --hybrid`. The task that accepted and implemented ADR-0180.
 
 Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.

--- a/website/src/content/docs/reference/cli.md
+++ b/website/src/content/docs/reference/cli.md
@@ -25,8 +25,8 @@ sidebar:
 | `orbit run duel-plan <task_id> --wait` | Submit a planning duel and wait for its terminal status before returning. |
 | `orbit task` | Create, update, and manage tasks. |
 | `orbit task artifact put <task_id> <source_path>` | Store a UTF-8 file under a task's artifacts directory. |
-| `orbit search <query>` | Search tasks, docs, learnings, and ADRs; add `--hybrid` for task-vector ranking, use `orbit search similar <id>` for task neighbors, or `orbit search path <path>` for applicability lookup. |
-| `orbit docs` | Search and manage the indexed docs corpus. |
+| `orbit search <query>` | Search tasks, docs, learnings, and ADRs; add `--hybrid` for task/doc vector ranking, use `orbit search similar <id>` for task neighbors, or `orbit search path <path>` for applicability lookup. |
+| `orbit docs` | List, show, add, index, and migrate the docs corpus. |
 | `orbit learning` | Create, search, and curate project learnings. |
 
 ## Observe


### PR DESCRIPTION
## Summary

- Replace the no-op `orbit docs reindex` / `orbit.docs.reindex` surface with `orbit docs index` / `orbit.docs.index`.
- Populate `source_kind="doc"` embeddings with content-hash idempotency and stale-source cleanup.
- Add `orbit search --kind doc --hybrid` lexical + cosine blending with `[docs.search].semantic_weight`, fallback warnings/notes, single-candidate handling, and ADR lexical passthrough.
- Update CLI/MCP help text, README, website reference docs, Orbit docs skill guidance, and design docs with ADR-0180.

## Validation

- `cargo fmt --check`
- `git diff --check`
- `cargo check -p orbit-search -p orbit-core -p orbit-cli -p orbit-tools`
- Focused unit/integration tests across `orbit-search`, `orbit-core`, `orbit-cli`, and `orbit-tools`
- CLI smoke checks for `docs index`, rejected `docs reindex`, search help, semantic stats, doc hybrid results, and missing-companion fallback
- Dependency guard confirming `orbit-search` does not depend on `orbit-core`
- `make ci-fast`

Orbit task: `ORB-00206` is in `review`.