### PR TITLE
Dashboard: global task_id resolver in header

### DIFF
--- a/crates/orbit-dashboard/assets/dashboard/app.js
+++ b/crates/orbit-dashboard/assets/dashboard/app.js
@@ -2,7 +2,7 @@
 // Pure vanilla JS, split into ES modules with no build step.
 
 import { el, statusPill, stateCell, fetchJson, requestJson, postJson, patchJson, syncNodes, positiveIntParam } from './common.js';
-import { buildChips, cacheCrewPayload, copyTaskIdWithNotice, hasCrewOptions, openVisibleTask, renderTasks, wireSearch } from './tasks.js';
+import { buildChips, cacheCrewPayload, copyTaskIdWithNotice, hasCrewOptions, openVisibleTask, renderTasks, setPinnedExternalTask, wireSearch } from './tasks.js';
 import { applyAuditHashQuery, buildAuditChips, buildAuditHash, fetchAndRenderAudit, fetchAndRenderPolicy, getActiveAuditSubtab, navigateToAuditExecution, renderAuditSummary, setActiveAuditSubtabFromButton, setAuditSubtab, syncAuditControls, wireAuditSearch, } from './audit.js';
 import { renderScoreboard } from './scoreboard.js';
 import { fetchAndRenderMetrics, initMetrics, renderMetrics } from './metrics.js';
@@ -979,6 +979,83 @@ function wireFrictionSearch() {
   });
 }
 
+/* Global task ID resolver (ORB-00211).
+   - Only fires on exact ^ORB-\d{5}$ (case-insens) after trim/upper.
+   - 250ms debounce to avoid hammering dashboard_status_index full scan.
+   - On success: switch tab, clear per-tab search, freshen lastTasks, openVisible (active status)
+     or setPinnedExternalTask + render (for done/rejected/archived bypassing filter).
+   - Error: inline .error + span msg with ID, cleared on any next input.
+   - Works from any tab because header input + sAT('tasks').
+*/
+function wireGlobalTaskResolver() {
+  const input = $("global-task-id");
+  if (!input) return;
+  let debounce = null;
+  const ID_RE = /^ORB-\d{5}$/i;
+
+  function clearError() {
+    input.classList.remove("error");
+    const wrap = input.parentNode;
+    if (wrap && wrap.classList) wrap.classList.remove("error");
+    const err = $("global-task-id-error");
+    if (err) err.textContent = "";
+  }
+
+  input.addEventListener("input", () => {
+    clearError();
+    if (debounce) clearTimeout(debounce);
+    const raw = (input.value || "").trim();
+    if (!raw) return;
+    const candidate = raw.toUpperCase();
+    if (!ID_RE.test(candidate)) {
+      // partial input: explicitly do not fetch (per AC and CPU guard)
+      return;
+    }
+    // full match: debounce then fetch exactly once
+    debounce = setTimeout(() => {
+      const id = candidate;
+      fetch(`/api/tasks/${encodeURIComponent(id)}`, { headers: { accept: "application/json" } })
+        .then(async (res) => {
+          if (res.ok) {
+            const task = await res.json();
+            sAT("tasks");
+            searchQuery = "";
+            const ts = $("task-search");
+            if (ts) ts.value = "";
+            // freshen cache so open sees latest (incl sidecars)
+            const idx = lastTasks.findIndex((t) => t && t.id === task.id);
+            if (idx >= 0) lastTasks[idx] = task;
+            else lastTasks.push(task);
+            const ctx = taskContext();
+            if (activeStatuses.has(task.status)) {
+              openVisibleTask(task.id, ctx);
+            } else {
+              setPinnedExternalTask(task, ctx);
+              renderTasks(lastTasks, ctx);
+            }
+            // success: clear the jump input for next use
+            input.value = "";
+          } else if (res.status === 404) {
+            showGlobalIdError(id, `${id} not found`);
+          } else {
+            showGlobalIdError(id, `Error ${res.status} resolving ${id}`);
+          }
+        })
+        .catch(() => {
+          showGlobalIdError(id, `Network error resolving ${id}`);
+        });
+    }, 250);
+  });
+
+  function showGlobalIdError(id, msg) {
+    input.classList.add("error");
+    const wrap = input.parentNode;
+    if (wrap && wrap.classList) wrap.classList.add("error");
+    const err = $("global-task-id-error");
+    if (err) err.textContent = msg;
+  }
+}
+
 function fmtRelative(iso) {
   return fmtTimestamp(iso);
 }
@@ -1284,6 +1361,7 @@ wireSearch(tasksContext);
 wireLearningSearch();
 wireAdrSearch();
 wireFrictionSearch();
+wireGlobalTaskResolver();
 buildAuditChips(auditContext());
 wireAuditSearch(auditContext());
 $("refresh-btn").addEventListener("click", refreshDashboard);

--- a/crates/orbit-dashboard/assets/dashboard/dashboard.css
+++ b/crates/orbit-dashboard/assets/dashboard/dashboard.css
@@ -117,7 +117,17 @@
         cursor: wait;
         opacity: 0.55;
       }
-      
+
+      /* ORB-00211 global resolver (added after task comment; minimal to make input usable in header + error visible + pinned distinguishable) */
+      header .global-id-wrap { position: relative; display: inline-block; margin: 0 2px; }
+      #global-task-id { width: 142px; height: 26px; font: 12px/1.2 var(--font-mono); background: var(--bg); color: var(--fg); border: 1px solid var(--border); border-radius: 2px; padding: 3px 6px; vertical-align: middle; }
+      #global-task-id:focus { border-color: var(--accent); outline: none; }
+      #global-task-id.error { border-color: #f66; }
+      .global-id-error { position: absolute; top: 28px; left: 0; font-size: 10px; color: #f66; white-space: nowrap; background: var(--bg-elev); border: 1px solid var(--border); padding: 1px 4px; border-radius: 2px; z-index: 150; display: none; }
+      .global-id-wrap.error .global-id-error { display: block; }
+      .pinned-task-wrap { margin-bottom: 6px; border: 1px solid var(--accent); border-radius: 2px; background: var(--bg-elev); }
+      .pinned-task-wrap .row.pinned-external { background: var(--bg-elev); }
+
       main {
         display: grid;
         grid-template-columns: minmax(0, 2.5fr) minmax(0, 1fr);

--- a/crates/orbit-dashboard/assets/dashboard/index.html
+++ b/crates/orbit-dashboard/assets/dashboard/index.html
@@ -24,6 +24,10 @@
       <div class="meta" id="meta">
         <span id="conn-status" class="status-dot orange"></span>
         <span id="meta-text">connecting&hellip;</span>
+        <div class="global-id-wrap">
+          <input type="search" id="global-task-id" placeholder="Jump to ORB-NNNNN" autocomplete="off" spellcheck="false" />
+          <span id="global-task-id-error" class="global-id-error"></span>
+        </div>
         <button id="refresh-btn" class="refresh-btn" type="button">Refresh</button>
       </div>
     </header>

--- a/crates/orbit-dashboard/assets/dashboard/tasks.js
+++ b/crates/orbit-dashboard/assets/dashboard/tasks.js
@@ -9,6 +9,7 @@ let lastCrewPayload = { default_crew: null, crews: [] };
 let expandedTaskIds = new Set();
 let taskActionNotice = null;
 let crewUpdateErrors = new Map();
+let pinnedExternalTask = null;
 
 function taskList(context) {
   return context && typeof context.getTasks === "function" ? context.getTasks() : [];
@@ -186,6 +187,20 @@ export function openVisibleTask(taskId, context) {
     row.classList.add("data-changed");
     setTimeout(() => row.classList.remove("data-changed"), 1200);
   });
+}
+
+/* Global ID resolver support (ORB-00211): allow rendering detail for a task whose status
+   is outside the active chip filter (done/rejected/archived) without adding it to the
+   bulk-loaded list or mutating DASHBOARD_TASK_STATUSES. The pinned detail appears in a
+   highlighted block at top of #tasks-body; auto-clears if user later enables matching chip. */
+export function setPinnedExternalTask(task, context) {
+  if (!task || !task.id) return;
+  pinnedExternalTask = { task, id: task.id };
+}
+
+export function clearPinnedExternalTask(context) {
+  pinnedExternalTask = null;
+  if (context) renderTasks(taskList(context), context);
 }
 
 function refreshChips(context) {
@@ -816,15 +831,64 @@ function takeTaskActionNotice() {
 
 export function renderTasks(tasks, context) {
   const body = $("tasks-body");
+  if (!body) return;
+
+  // Auto-clear pinned external (global resolver) if its status+search now makes it
+  // visible in the normal filtered list (user enabled the chip or cleared search).
+  if (pinnedExternalTask && pinnedExternalTask.task) {
+    const p = pinnedExternalTask.task;
+    const q = (searchQueryValue(context) || "").toLowerCase();
+    const act = activeStatusSet(context);
+    const matchesQ = !q || (p.id && p.id.toLowerCase().includes(q)) || (p.title && p.title.toLowerCase().includes(q));
+    if (act.has(p.status) && matchesQ) {
+      pinnedExternalTask = null;
+    }
+  }
+
   const frag = document.createDocumentFragment();
   const notice = takeTaskActionNotice();
-  
+
+  // Render pinned external task detail (for statuses outside active filter) at top.
+  if (pinnedExternalTask && pinnedExternalTask.task) {
+    const ptask = pinnedExternalTask.task;
+    const pRow = el("div", {
+      class: "row pinned-external",
+      title: `${ptask.title} (global resolver; status ${ptask.status})`
+    }, [
+      el("span", { class: "id mono", text: ptask.id }),
+      el("span", { class: "title", text: ptask.title }),
+      statusPill(ptask.status),
+    ]);
+    pRow.addEventListener("click", (e) => {
+      e.stopPropagation();
+      if (navigator.clipboard) navigator.clipboard.writeText(ptask.id).catch(() => {});
+    });
+    const pDetail = buildTaskDetail(ptask, context);
+    // Dismiss button to close the global detail without affecting chips
+    const dismiss = el("button", { class: "action", text: "Close" });
+    dismiss.title = "Dismiss global task detail";
+    dismiss.addEventListener("click", (ev) => {
+      ev.stopPropagation();
+      pinnedExternalTask = null;
+      renderTasks(taskList(context), context);
+    });
+    let acts = pDetail.querySelector(".actions");
+    if (!acts) {
+      acts = el("div", { class: "actions" });
+      pDetail.appendChild(acts);
+    }
+    acts.appendChild(dismiss);
+    const pWrap = el("div", { class: "pinned-task-wrap" }, [pRow, pDetail]);
+    pWrap.dataset.key = `pinned-${ptask.id}`;
+    frag.appendChild(pWrap);
+  }
+
   const filtered = filterTasks(tasks, context);
   $("tasks-count").textContent =
     filtered.length === tasks.length
       ? `${tasks.length}`
       : `${filtered.length}/${tasks.length}`;
-  if (filtered.length === 0) {
+  if (filtered.length === 0 && frag.children.length === 0) {
     const defaultText = tasks.length === 0 ? "No tasks available." : "No tasks match filter.";
     const emptyState = el("div", { class: "empty-state" }, [
       el("div", { class: "icon", text: "✧" }),


### PR DESCRIPTION
## Task

[ORB-00211](https://orbit-cli.com/tasks/ORB-00211) — Dashboard: global task_id resolver in header

### Description

## Problem

The dashboard task search at `index.html:67` only filters the currently-loaded task list, which excludes `done`, `rejected`, and `archived` tasks (those statuses were removed from `DASHBOARD_TASK_STATUSES` in `crates/orbit-dashboard/src/api/tasks.rs:20` because loading them overloaded CPU). Pasting an ORB-NNNNN from a commit message, PR, or chat into the existing per-tab search silently misses any task outside the active chip filter — `openVisibleTask` at `crates/orbit-dashboard/assets/dashboard/tasks.js:174` falls through to a `copyTaskIdWithNotice` no-op.

Add a global ID resolver in the dashboard header that fetches a single task by ID via the existing `GET /api/tasks/:id` endpoint (`crates/orbit-dashboard/src/api/tasks.rs:162`) and opens the task detail panel out-of-band, bypassing the chip-filter and working for any status.

## Why It Matters

Task IDs are the canonical handle users paste from external surfaces. The current dashboard makes them unresolvable whenever the underlying task is in a hidden status, which is the exact case users hit most often ("I want to look at that task we finished last week"). The fix is cheap because the backing endpoint already serves single tasks regardless of status — no bulk-load regression risk that triggered the original CPU problem.

## Constraints / Notes

- **Debounce on full-ID match only.** `GET /api/tasks/:id` invokes `dashboard_status_index` at `tasks.rs:171`, which under the hood runs a full `list_tasks()` scan to compute sidecar relation statuses. Firing per-keystroke would recreate the load problem. Resolve only when the input matches the canonical task ID regex (`^ORB-\d{5}$`) and after a short debounce (~250ms). Partial input must NOT hit the endpoint.
- **Out-of-scope: showing done/rejected/archived in the chip-filtered list.** That was the original CPU regression; do not re-introduce it.
- **Out-of-scope: multi-kind search** (ADR / learning / friction). Single task_id lookup only for v1.
- **Out-of-scope: `dashboard_status_index` perf cleanup.** If the full-scan-per-resolve becomes the bottleneck under real use, file a follow-up task; do not bundle.
- Place the input in the existing `<header>` block (`index.html:14`), next to `meta`/`refresh-btn`. Do not co-locate with the per-tab `#task-search` — the global resolver must work from any tab.
- Error feedback must be visible (not silent). When the endpoint returns 404 or any error, surface a transient inline message (`"ORB-NNNNN not found"`) on the input itself.

## Suggested Approach

1. Add `<input type="search" id="global-task-id" placeholder="Jump to ORB-NNNNN">` to the header in `index.html`.
2. Wire an input handler in `app.js` that:
   - Trims and uppercases the value.
   - On match against `/^ORB-\d{5}$/`, debounces 250ms, then `fetch("/api/tasks/<id>")`.
   - On 200, switches to the tasks tab if not active, scrolls/opens the detail panel by reusing existing detail rendering (`openVisibleTask` may need a sibling that does not gate on `filterTasks`).
   - On 404 / non-OK, sets an inline error message on the input that clears on next input event.
3. No server-side change.

### Acceptance Criteria

- A new `<input id="global-task-id">` exists inside the `<header>` block of `crates/orbit-dashboard/assets/dashboard/index.html`, with placeholder text mentioning `ORB-`.
- Typing a string that does not match `^ORB-\d{5}$` (case-insensitive) into the global input does NOT trigger any `fetch("/api/tasks/<id>")` call, verified by an automated unit test or a documented manual check that monitors the browser network tab while typing `ORB`, `ORB-1`, and `ORB-1234`.
- Typing a full ID (e.g. `ORB-00099`) into the global input issues exactly one `GET /api/tasks/ORB-00099` after a debounce window of approximately 250ms (>=200ms, <=500ms), verified by a unit test on the debounce wrapper or a documented manual repro with the network tab.
- When the resolved task has status `done`, `rejected`, or `archived`, the task detail panel opens and renders that task without first requiring the user to enable a chip filter. Verified by a documented manual repro: create or pick three tasks in those three statuses, paste each ID into the global input, confirm each opens.
- When the ID does not exist, an inline error message containing the typed ID (e.g. `ORB-99999 not found`) appears attached to the global input within 1s of the failed request, and clears on the next input event. Verified by manual repro against a known-bad ID.
- The global resolver works from every tab (`tasks`, `scoreboard`, `metrics`, `audit`, `diagnostics`, `knowledge`): pasting a valid ID from the audit or knowledge tab switches to the tasks tab and opens the detail panel. Verified by a documented manual matrix covering all six tabs.
- `DASHBOARD_TASK_STATUSES` in `crates/orbit-dashboard/src/api/tasks.rs` is unchanged by this task (regression guard against re-introducing the original CPU problem).
- `make ci-fast` passes.

## Execution Summary

<details>
<summary>Click to expand</summary>

Implemented global task ID resolver per spec:
- Added <input id="global-task-id" placeholder="Jump to ORB-NNNNN"> in header (index.html:27).
- Wired debounce+fetch-only-on-full-ID-match in app.js (wireGlobalTaskResolver, 250ms).
- Partial inputs (ORB, ORB-1, ORB-1234) explicitly no-op, no fetch.
- On 200: sAT('tasks'), clear per-tab search, freshen lastTasks, openVisibleTask for active-status or setPinnedExternalTask+render for done/rejected/archived.
- Introduced pinnedExternalTask + render support in tasks.js so detail shows without mutating activeStatuses or bulk list (satisfies AC without reintroducing CPU load).
- Error: inline msg e.g. "ORB-99999 not found" attached via .global-id-error, clears on input.
- Works from all 6 tabs; no change to tasks.rs DASHBOARD_TASK_STATUSES.
- CSS minimal additions for input/error/pinned (recorded via task comment).
- JS syntax validated (node --check), make ci-fast passed.
- No new modules (L-0021 not triggered). Diff: 4 files, +160/-4 lines.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-00211-6a0e6ec6`
- Behind base: 0
- Ahead of base: 1