### PR TITLE
Dashboard: task table column headers + reorder right panel (Details above Assignment)

### DIFF
--- a/crates/orbit-dashboard/assets/dashboard/common.js
+++ b/crates/orbit-dashboard/assets/dashboard/common.js
@@ -32,18 +32,6 @@ export function priorityCell(p) {
   return node;
 }
 
-export function complexityCell(c) {
-  const text = c ? String(c) : "—";
-  const node = el("span", { class: "complexity mono", text });
-  if (c) {
-    node.style.color = `var(--complexity-${c}, var(--fg-dim))`;
-  } else {
-    node.style.color = "var(--fg-dim)";
-    node.style.opacity = "0.55";
-  }
-  return node;
-}
-
 export function stateCell(state) {
   const node = el("span", { class: "mono", text: state });
   node.style.color = `var(--state-${state}, var(--fg-dim))`;

--- a/crates/orbit-dashboard/assets/dashboard/dashboard.css
+++ b/crates/orbit-dashboard/assets/dashboard/dashboard.css
@@ -437,7 +437,36 @@
         .row .priority { grid-area: priority; text-align: left; }
         .row .type { grid-area: type; text-align: left; }
       }
-      
+
+      .row.header {
+        cursor: default;
+        background: transparent;
+        border-bottom: 1px solid var(--border);
+        padding: 2px 16px 6px;
+        font-size: 10px;
+        font-weight: 600;
+        text-transform: uppercase;
+        letter-spacing: 0.06em;
+        color: var(--fg-dim);
+        pointer-events: none;
+      }
+      .row.header:hover {
+        background: transparent;
+        border-color: var(--border);
+      }
+      .row.header .id,
+      .row.header .title,
+      .row.header .priority,
+      .row.header .type {
+        font-size: inherit;
+        color: inherit;
+        font-family: var(--font-sans);
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        /* text-align + grid-area (in narrow) inherited from .row.* + @media rules so columns align with data rows */
+      }
+
       .row-detail {
         padding: 16px 20px;
         background: #050505;

--- a/crates/orbit-dashboard/assets/dashboard/tasks.js
+++ b/crates/orbit-dashboard/assets/dashboard/tasks.js
@@ -1,7 +1,7 @@
 // Orbit dashboard task-domain rendering and actions.
 // Pure vanilla JS, split into ES modules with no build step.
 
-import { complexityCell, el, priorityCell, statusPill, patchJson, syncNodes } from './common.js';
+import { el, priorityCell, statusPill, patchJson, syncNodes } from './common.js';
 
 const $ = (id) => document.getElementById(id);
 
@@ -505,11 +505,9 @@ function buildTaskDetail(task, context) {
     rightCol.appendChild(buildTagRow(task.tags));
   }
 
-  const assignment = el("div", { class: "assignment" });
-  assignment.appendChild(complexityCell(task.complexity));
-  assignment.appendChild(buildCrewUpdateControl(task, context));
-  addField(rightCol, "assignment", assignment);
-
+  // Details before Assignment (per task: read-only meta first, mutating control second).
+  // Assignment contains *only* the crew dropdown (complexityCell removed; it lives in
+  // TASK_META_FIELDS inside Details).
   const meta = el("div", { class: "meta-list" });
   let metaCount = 0;
   for (const [key, label] of TASK_META_FIELDS) {
@@ -532,6 +530,10 @@ function buildTaskDetail(task, context) {
     metaCount++;
   }
   if (metaCount > 0) addField(rightCol, "details", meta);
+
+  const assignment = el("div", { class: "assignment" });
+  assignment.appendChild(buildCrewUpdateControl(task, context));
+  addField(rightCol, "assignment", assignment);
 
   if (Array.isArray(task.external_refs) && task.external_refs.length > 0) {
     addField(rightCol, "external refs", buildExternalRefs(task.external_refs));
@@ -899,6 +901,18 @@ export function renderTasks(tasks, context) {
   }
   const groups = new Map();
   if (notice) frag.appendChild(notice);
+
+  // Column header strip (once, before first group-header). Uses .row.header so grid
+  // (and all @media overrides) are identical to data rows; labels sit over ID/Title/Priority/Type.
+  const colHeader = el("div", { class: "row header" }, [
+    el("span", { class: "id", text: "ID" }),
+    el("span", { class: "title", text: "Title" }),
+    el("span", { class: "priority", text: "Priority" }),
+    el("span", { class: "type", text: "Type" }),
+  ]);
+  colHeader.dataset.key = "task-col-header";
+  frag.appendChild(colHeader);
+
   for (const t of filtered) {
     if (!groups.has(t.status)) groups.set(t.status, []);
     groups.get(t.status).push(t);


### PR DESCRIPTION
## Task

[ORB-00213](https://orbit-cli.com/tasks/ORB-00213) — Dashboard: task table column headers + reorder right panel (Details above Assignment)

### Description

## Problem

Two small but cumulative ergonomics gaps in the dashboard tasks view:

1. **No column titles on the task table.** Each row in `tasks-body` renders four visual cells (id, title, priority, type — see `crates/orbit-dashboard/assets/dashboard/tasks.js:868`) but there is no header strip above them, so users have to infer what each column means. Rows are visually grouped by status via `group-header` (`tasks.js:848`), but the per-row columns themselves are unlabeled.

2. **Right-side detail panel order is upside-down and complexity is duplicated.** In the expanded task detail (`buildTaskDetail`), the Assignment block is appended before Details (`tasks.js:493`-`tasks.js:519`). Worse, `complexityCell(task.complexity)` is shown as a badge in the Assignment block (`tasks.js:494`) AND `complexity` is rendered again as a row inside Details via `TASK_META_FIELDS` (`tasks.js:140`). Complexity should live only in Details; Assignment should sit below Details and contain only the crew dropdown.

## Why It Matters

Column headers let new users read the task table without hovering or guessing. Reordering Details above Assignment matches the users mental model (read-only metadata first, mutating control second) and removing the duplicated complexity badge cleans up the right column. Both changes are pure frontend, scoped to `tasks.js` plus the matching CSS rules; no backend or perf surface.

## Constraints / Notes

- **Column headers must align with the row grid.** Whatever CSS grid / flex layout drives `.row` in `dashboard.css` must drive the header row as well. Do not hardcode pixel widths that drift from the row.
- **Header placement:** put the header strip once at the top of `tasks-body` (before the first `group-header`), not duplicated per status group. If the executor finds per-group headers read better with status groupings, that is acceptable; document the choice in the PR description.
- **Sticky header is nice-to-have, not required.** A non-sticky header is fine for v1.
- **Assignment block keeps only the crew dropdown.** Remove the `complexityCell` append at `tasks.js:494`. Complexity stays in Details where `TASK_META_FIELDS` already places it (no Details change needed).
- **Reorder is two lines.** Move the `addField(rightCol, "assignment", ...)` call so it executes after the `addField(rightCol, "details", meta)` call. Do not move other right-column appends (tags above, external_refs / relations below) unless their relative order is wrong — they are out of scope.
- **Row hash compatibility.** The `row.dataset.hash` at `tasks.js:876` includes `t.complexity`; leave it alone — even though the badge moves out of Assignment, complexity still changes the rows rendered state via Details.

## Suggested Approach

1. In `tasks.js` `renderTasks` (around line 818-848), insert a header row above the body before the loop that emits `group-header`s. Match the row class structure so CSS grid alignment is inherited.
2. In `tasks.js` `buildTaskDetail` (around line 493-519), remove the `complexityCell` line and swap the order of the `assignment` and `details` `addField` calls.
3. Add or adjust CSS in `dashboard.css` for the new header row (likely a `.row.header` modifier or a sibling `.row-header` class).

### Acceptance Criteria

- A header strip appears above the first status group in `#tasks-body` showing four labels (`ID`, `Title`, `Priority`, `Type`) aligned with the same columns as the rows below. Verified by manual repro: open the tasks tab, confirm headers are visible and each label sits over its column.
- Column header alignment is driven by the same CSS layout rule as `.row` (no header-specific fixed widths). Verified by changing the viewport width by ~150px in DevTools and confirming header and row columns continue to align.
- In the expanded task detail view, the `Details` panel renders above the `Assignment` panel in the right column. Verified by manual repro: expand any task row and inspect right-column order top-to-bottom.
- The Assignment panel no longer contains the complexity badge — it contains only the crew dropdown (`buildCrewUpdateControl`). Verified by reading the rendered DOM: `.assignment > .complexity-cell` (or equivalent) is absent.
- Complexity continues to render as a row inside the Details panel via `TASK_META_FIELDS`. Verified by manual repro: expand a task with `complexity: hard` (or `low`/`medium`) and confirm a `complexity` row appears in Details.
- Existing right-column items above Assignment (tags row) and below Details (external_refs, relations) keep their current relative positions. Verified by expanding a task that has all four to confirm order: tags → details → assignment → external_refs → relations.
- `row.dataset.hash` at `tasks.js:876` is unchanged (regression guard — task row diffing must keep complexity as a hash input even though the badge moved).
- `make ci-fast` passes.

## Execution Summary

<details>
<summary>Click to expand</summary>

Implemented column headers via .row.header (grid-inherited) inserted once before first group-header in renderTasks; reordered Details above Assignment + removed complexityCell from assignment (now only crew control) in buildTaskDetail; added matching .row.header CSS; deleted dead complexityCell from common.js (noted in comments). row.dataset.hash untouched. make ci-fast passed. Changes scoped, no new deps/edges. Diff captured for summary.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-00213-6a0e701e`
- Behind base: 0
- Ahead of base: 1