### PR TITLE
Unify index verbs: `orbit semantic index --kind {tasks,docs,all}`, `orbit docs index` as alias

### DIFF
--- a/crates/orbit-cli/src/command/docs.rs
+++ b/crates/orbit-cli/src/command/docs.rs
@@ -1,7 +1,7 @@
 use std::str::FromStr;
 
 use clap::{Args, Subcommand};
-use orbit_core::command::docs::DocIndexParams;
+use orbit_core::command::semantic::{IndexKind, SemanticIndexParams, SemanticIndexResult};
 use orbit_core::{DocType, OrbitError, OrbitRuntime};
 use serde::Serialize;
 use serde_json::Value;
@@ -187,24 +187,40 @@ impl Execute for DocsAddArgs {
 
 impl Execute for DocsIndexArgs {
     fn execute(self, runtime: &OrbitRuntime) -> Result<(), OrbitError> {
-        let result = runtime.index_docs(DocIndexParams {
+        let result = runtime.semantic_index(SemanticIndexParams {
             model: self.model,
             force: self.force,
+            kind: Some(IndexKind::Docs),
         })?;
         if self.json {
             crate::output::json::print_pretty(&serde_json::json!(result))
         } else {
-            println!(
-                "Indexed docs: model={} indexed_sources={} embedded_chunks={} skipped_fields={} stale_sources={}",
-                result.model_id,
-                result.indexed_sources,
-                result.report.embedded_chunks,
-                result.report.skipped_fields,
-                result.stale_sources.len()
-            );
-            Ok(())
+            print_docs_index_text(result)
         }
     }
+}
+
+fn print_docs_index_text(result: SemanticIndexResult) -> Result<(), OrbitError> {
+    let SemanticIndexResult::Docs {
+        model_id,
+        report,
+        indexed_sources,
+        stale_sources,
+    } = result
+    else {
+        return Err(OrbitError::Execution(
+            "docs index alias returned a non-docs report".to_string(),
+        ));
+    };
+    println!(
+        "Indexed docs: model={} indexed_sources={} embedded_chunks={} skipped_fields={} stale_sources={}",
+        model_id,
+        indexed_sources,
+        report.embedded_chunks,
+        report.skipped_fields,
+        stale_sources.len()
+    );
+    Ok(())
 }
 
 impl Execute for DocsMigrateArgs {

--- a/crates/orbit-cli/src/command/mod.rs
+++ b/crates/orbit-cli/src/command/mod.rs
@@ -164,7 +164,7 @@ mod tests {
         hook::HookSubcommand,
         mcp::McpSubcommand,
         search::{SearchKindArg, SearchSubcommand},
-        semantic::SemanticSubcommand,
+        semantic::{SemanticIndexKindArg, SemanticSubcommand},
         web::WebSubcommand,
     };
 
@@ -240,14 +240,61 @@ mod tests {
 
     #[test]
     fn cli_parses_semantic_index() {
-        let cli = Cli::parse_from(["orbit", "semantic", "index", "--force"]);
+        let cli = Cli::parse_from(["orbit", "semantic", "index", "--force", "--kind", "docs"]);
         match cli.command {
             Commands::Semantic(command) => match command.command {
-                SemanticSubcommand::Index(args) => assert!(args.force),
+                SemanticSubcommand::Index(args) => {
+                    assert!(args.force);
+                    assert_eq!(args.kind, SemanticIndexKindArg::Docs);
+                }
                 _ => panic!("expected semantic index"),
             },
             _ => panic!("expected top-level semantic command"),
         }
+    }
+
+    #[test]
+    fn cli_semantic_index_defaults_kind_to_tasks() {
+        let cli = Cli::parse_from(["orbit", "semantic", "index"]);
+        match cli.command {
+            Commands::Semantic(command) => match command.command {
+                SemanticSubcommand::Index(args) => {
+                    assert_eq!(args.kind, SemanticIndexKindArg::Tasks);
+                }
+                _ => panic!("expected semantic index"),
+            },
+            _ => panic!("expected top-level semantic command"),
+        }
+    }
+
+    #[test]
+    fn cli_semantic_index_rejects_future_kinds_at_clap_layer() {
+        for kind in ["adr", "learning"] {
+            let error = match Cli::try_parse_from(["orbit", "semantic", "index", "--kind", kind]) {
+                Ok(_) => panic!("future kinds should be rejected"),
+                Err(error) => error,
+            };
+            let message = error.to_string();
+            assert!(message.contains("possible values"), "{message}");
+            assert!(message.contains("tasks"), "{message}");
+            assert!(message.contains("docs"), "{message}");
+            assert!(message.contains("all"), "{message}");
+        }
+    }
+
+    #[test]
+    fn cli_semantic_index_help_explains_kind_principle() {
+        let error = match Cli::try_parse_from(["orbit", "semantic", "index", "--help"]) {
+            Ok(_) => panic!("help exits before parsing"),
+            Err(error) => error,
+        };
+        let help = error.to_string();
+        assert!(
+            help.contains(
+                "--kind selects corpus: tasks (default), docs (same as `orbit docs index`), all (rebuilds both)."
+            ),
+            "{help}"
+        );
     }
 
     #[test]

--- a/crates/orbit-cli/src/command/semantic.rs
+++ b/crates/orbit-cli/src/command/semantic.rs
@@ -1,6 +1,7 @@
-use clap::{Args, Subcommand};
+use clap::{Args, Subcommand, ValueEnum};
 use orbit_core::command::semantic::{
-    SemanticInstallParams, SemanticReindexParams, SemanticUninstallParams,
+    IndexKind, SemanticIndexParams, SemanticIndexResult, SemanticInstallParams,
+    SemanticUninstallParams,
 };
 use orbit_core::{OrbitError, OrbitRuntime};
 use serde_json::json;
@@ -22,7 +23,7 @@ pub enum SemanticSubcommand {
     Uninstall(SemanticUninstallArgs),
     /// Show orbit-search index and companion status
     Stats(SemanticStatsArgs),
-    /// Rebuild task embeddings
+    /// Rebuild semantic embeddings
     Index(SemanticIndexArgs),
 }
 
@@ -53,8 +54,33 @@ pub struct SemanticIndexArgs {
     pub model: Option<String>,
     #[arg(long)]
     pub force: bool,
+    #[arg(
+        long,
+        value_enum,
+        default_value_t = SemanticIndexKindArg::Tasks,
+        value_name = "KIND",
+        help = "--kind selects corpus: tasks (default), docs (same as `orbit docs index`), all (rebuilds both)."
+    )]
+    pub kind: SemanticIndexKindArg,
     #[arg(long)]
     pub json: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub enum SemanticIndexKindArg {
+    Tasks,
+    Docs,
+    All,
+}
+
+impl From<SemanticIndexKindArg> for IndexKind {
+    fn from(value: SemanticIndexKindArg) -> Self {
+        match value {
+            SemanticIndexKindArg::Tasks => Self::Tasks,
+            SemanticIndexKindArg::Docs => Self::Docs,
+            SemanticIndexKindArg::All => Self::All,
+        }
+    }
 }
 
 #[derive(Args)]
@@ -126,20 +152,57 @@ impl Execute for SemanticUninstallArgs {
 
 impl Execute for SemanticIndexArgs {
     fn execute(self, runtime: &OrbitRuntime) -> Result<(), OrbitError> {
-        let result = runtime.semantic_reindex(SemanticReindexParams {
+        let result = runtime.semantic_index(SemanticIndexParams {
             model: self.model,
             force: self.force,
+            kind: Some(self.kind.into()),
         })?;
         if self.json {
             crate::output::json::print_pretty(&json!(result))
         } else {
-            println!(
-                "Indexed semantic search: model={} embedded_chunks={} skipped_fields={}",
-                result.model_id, result.report.embedded_chunks, result.report.skipped_fields
-            );
-            Ok(())
+            print_semantic_index_text(result)
         }
     }
+}
+
+fn print_semantic_index_text(result: SemanticIndexResult) -> Result<(), OrbitError> {
+    match result {
+        SemanticIndexResult::Tasks { model_id, report } => {
+            println!(
+                "Indexed semantic search: model={} embedded_chunks={} skipped_fields={}",
+                model_id, report.embedded_chunks, report.skipped_fields
+            );
+        }
+        SemanticIndexResult::Docs {
+            model_id,
+            report,
+            indexed_sources,
+            stale_sources,
+        } => {
+            println!(
+                "Indexed docs: model={} indexed_sources={} embedded_chunks={} skipped_fields={} stale_sources={}",
+                model_id,
+                indexed_sources,
+                report.embedded_chunks,
+                report.skipped_fields,
+                stale_sources.len()
+            );
+        }
+        SemanticIndexResult::All { tasks, docs } => {
+            println!(
+                "Indexed semantic search: tasks_model={} tasks_embedded_chunks={} tasks_skipped_fields={} docs_model={} docs_indexed_sources={} docs_embedded_chunks={} docs_skipped_fields={} docs_stale_sources={}",
+                tasks.model_id,
+                tasks.report.embedded_chunks,
+                tasks.report.skipped_fields,
+                docs.model_id,
+                docs.indexed_sources,
+                docs.report.embedded_chunks,
+                docs.report.skipped_fields,
+                docs.stale_sources.len()
+            );
+        }
+    }
+    Ok(())
 }
 
 impl Execute for SemanticStatsArgs {

--- a/crates/orbit-cli/tests/docs.rs
+++ b/crates/orbit-cli/tests/docs.rs
@@ -256,10 +256,118 @@ fn mcp_docs_tools_are_listed_and_callable_through_tool_run() {
     assert!(!output.as_array().expect("array").is_empty());
 }
 
+#[test]
+#[cfg(unix)]
+fn cli_docs_index_is_semantic_docs_alias_for_json_output() {
+    let workspace = TestWorkspace::new();
+    workspace.write_mock_companion();
+    workspace.write(
+        "docs/context.md",
+        "---\ntype: context\nsummary: Context document\ntags: [semantic]\n---\nBody\n",
+    );
+
+    let docs =
+        workspace.run_json_with_companion(&["docs", "index", "--force", "--json"], "docs index");
+    let semantic = workspace.run_json_with_companion(
+        &["semantic", "index", "--kind", "docs", "--force", "--json"],
+        "semantic index docs",
+    );
+
+    assert_eq!(semantic, docs);
+}
+
+#[test]
+#[cfg(unix)]
+fn cli_semantic_index_all_json_contains_tasks_and_docs() {
+    let workspace = TestWorkspace::new();
+    workspace.write_mock_companion();
+    workspace.write(
+        "docs/context.md",
+        "---\ntype: context\nsummary: Context document\ntags: [semantic]\n---\nBody\n",
+    );
+    workspace.run_json(
+        &[
+            "task",
+            "add",
+            "--title",
+            "Index all",
+            "--description",
+            "Exercise task indexing.",
+            "--acceptance-criteria",
+            "both corpora indexed",
+            "--json",
+        ],
+        "task add",
+    );
+
+    let result = workspace.run_json_with_companion(
+        &["semantic", "index", "--kind", "all", "--force", "--json"],
+        "semantic index all",
+    );
+
+    assert_eq!(result["tasks"]["model_id"], "bge-small-en-v1.5");
+    assert!(
+        result["tasks"]["report"]["embedded_chunks"]
+            .as_u64()
+            .expect("task chunks")
+            > 0
+    );
+    assert_eq!(result["docs"]["model_id"], "bge-small-en-v1.5");
+    assert_eq!(result["docs"]["indexed_sources"], 1);
+}
+
+#[test]
+#[cfg(unix)]
+fn cli_semantic_index_all_keeps_task_rows_when_docs_fail() {
+    let workspace = TestWorkspace::new();
+    workspace.write_mock_companion();
+    workspace.run_json(
+        &[
+            "task",
+            "add",
+            "--title",
+            "Partial progress",
+            "--description",
+            "Exercise all-kind resilience.",
+            "--acceptance-criteria",
+            "task rows persist",
+            "--json",
+        ],
+        "task add",
+    );
+    workspace.write(
+        "docs/broken.md",
+        "---\ntype: context\nsummary: Broken doc\n---\nBody\n",
+    );
+    let broken = workspace.work.join("docs/broken.md");
+    make_unreadable(&broken);
+
+    let output = workspace.run_failure_with_companion(
+        &["semantic", "index", "--kind", "all", "--json"],
+        "semantic index all with unreadable docs",
+    );
+    restore_readable(&broken);
+    assert!(
+        String::from_utf8_lossy(&output.stderr).contains("read"),
+        "stderr should explain docs read failure: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stats =
+        workspace.run_json_with_companion(&["semantic", "stats", "--json"], "semantic stats");
+    let rows = stats["rows"]["counts"].as_array().expect("counts");
+    assert!(
+        rows.iter()
+            .any(|row| row["source_kind"] == "task" && row["rows"].as_u64().unwrap_or(0) > 0),
+        "task rows should be present after docs failure: {rows:?}"
+    );
+}
+
 struct TestWorkspace {
     _temp: TempDir,
     home: PathBuf,
     work: PathBuf,
+    companion: PathBuf,
 }
 
 impl TestWorkspace {
@@ -267,12 +375,14 @@ impl TestWorkspace {
         let temp = tempdir().expect("tempdir");
         let home = temp.path().join("home");
         let work = temp.path().join("work");
+        let companion = temp.path().join("mock-companion");
         fs::create_dir_all(&home).expect("home");
         fs::create_dir_all(&work).expect("work");
         let workspace = Self {
             _temp: temp,
             home,
             work,
+            companion,
         };
         workspace.run(
             &["workspace", "init", "--name", "docs-cli-test"],
@@ -307,6 +417,75 @@ impl TestWorkspace {
                 String::from_utf8_lossy(&output.stderr)
             )
         })
+    }
+
+    #[cfg(unix)]
+    fn run_with_companion(&self, args: &[&str], label: &str) -> Output {
+        let output = run_orbit_with_companion(&self.work, &self.home, args, Some(&self.companion));
+        assert!(
+            output.status.success(),
+            "{label} failed\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        output
+    }
+
+    #[cfg(unix)]
+    fn run_json_with_companion(&self, args: &[&str], label: &str) -> Value {
+        let output = self.run_with_companion(args, label);
+        serde_json::from_slice(&output.stdout).unwrap_or_else(|error| {
+            panic!(
+                "{label} produced invalid JSON: {error}\nstdout:\n{}\nstderr:\n{}",
+                String::from_utf8_lossy(&output.stdout),
+                String::from_utf8_lossy(&output.stderr)
+            )
+        })
+    }
+
+    #[cfg(unix)]
+    fn run_failure_with_companion(&self, args: &[&str], label: &str) -> Output {
+        let output = run_orbit_with_companion(&self.work, &self.home, args, Some(&self.companion));
+        assert!(
+            !output.status.success(),
+            "{label} unexpectedly succeeded\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        output
+    }
+
+    #[cfg(unix)]
+    fn write_mock_companion(&self) {
+        write_executable(
+            &self.companion,
+            r#"#!/bin/sh
+while IFS= read -r line; do
+  id=$(printf '%s\n' "$line" | sed -n 's/.*"id":\([0-9][0-9]*\).*/\1/p')
+  if [ -z "$id" ]; then
+    id=0
+  fi
+  case "$line" in
+    *'"method":"info"'*)
+      printf '{"id":%s,"result":{"model_id":"bge-small-en-v1.5","dim":2,"max_input_tokens":512,"version":"0.3.1"}}\n' "$id"
+      ;;
+    *'"method":"token_count"'*)
+      printf '{"id":%s,"result":{"tokens":1}}\n' "$id"
+      ;;
+    *'"method":"embed"'*)
+      printf '{"id":%s,"result":{"vectors":[[1.0,0.0]]}}\n' "$id"
+      ;;
+    *'"method":"exit"'*)
+      printf '{"id":%s,"result":{"ok":true}}\n' "$id"
+      exit 0
+      ;;
+    *)
+      printf '{"id":%s,"error":{"code":"unknown","message":"unknown request"}}\n' "$id"
+      ;;
+  esac
+done
+"#,
+        );
     }
 
     fn tool_run(&self, tool: &str, input: Value, label: &str) -> Value {
@@ -353,12 +532,52 @@ impl TestWorkspace {
 }
 
 fn run_orbit(work: &PathBuf, home: &PathBuf, args: &[&str]) -> Output {
+    run_orbit_with_companion(work, home, args, None)
+}
+
+fn run_orbit_with_companion(
+    work: &PathBuf,
+    home: &PathBuf,
+    args: &[&str],
+    companion: Option<&std::path::Path>,
+) -> Output {
     let mut cmd = cargo_bin_cmd!("orbit");
     cmd.current_dir(work)
         .env("HOME", home)
         .env("ORBIT_HOME", home.join(".orbit-global"))
         .env_remove("ORBIT_ROOT")
-        .args(args)
-        .output()
-        .expect("run orbit")
+        .env_remove("ORBIT_SEARCH_COMPANION")
+        .args(args);
+    if let Some(path) = companion {
+        cmd.env("ORBIT_SEARCH_COMPANION", path);
+    }
+    cmd.output().expect("run orbit")
+}
+
+#[cfg(unix)]
+fn write_executable(path: &std::path::Path, content: &str) {
+    use std::os::unix::fs::PermissionsExt;
+
+    fs::write(path, content).expect("write executable");
+    let mut permissions = fs::metadata(path).expect("metadata").permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(path, permissions).expect("chmod executable");
+}
+
+#[cfg(unix)]
+fn make_unreadable(path: &std::path::Path) {
+    use std::os::unix::fs::PermissionsExt;
+
+    let mut permissions = fs::metadata(path).expect("metadata").permissions();
+    permissions.set_mode(0o000);
+    fs::set_permissions(path, permissions).expect("chmod unreadable");
+}
+
+#[cfg(unix)]
+fn restore_readable(path: &std::path::Path) {
+    use std::os::unix::fs::PermissionsExt;
+
+    let mut permissions = fs::metadata(path).expect("metadata").permissions();
+    permissions.set_mode(0o644);
+    fs::set_permissions(path, permissions).expect("chmod readable");
 }

--- a/crates/orbit-core/src/command/semantic.rs
+++ b/crates/orbit-core/src/command/semantic.rs
@@ -1,10 +1,10 @@
 use orbit_common::types::OrbitError;
 
 pub use orbit_search::{
-    CompanionStatus, ScoreBreakdown, SemanticHit, SemanticInstallParams, SemanticInstallResult,
-    SemanticReindexParams, SemanticReindexResult, SemanticRelatedParams, SemanticRelatedResult,
-    SemanticSearchParams, SemanticSearchResult, SemanticStatsResult, SemanticUninstallParams,
-    SemanticUninstallResult,
+    CompanionStatus, IndexKind, ScoreBreakdown, SemanticHit, SemanticIndexParams,
+    SemanticIndexResult, SemanticInstallParams, SemanticInstallResult, SemanticRelatedParams,
+    SemanticRelatedResult, SemanticSearchParams, SemanticSearchResult, SemanticStatsResult,
+    SemanticUninstallParams, SemanticUninstallResult, TaskIndexResult,
 };
 
 use crate::OrbitRuntime;
@@ -24,12 +24,45 @@ impl OrbitRuntime {
         orbit_search::semantic_uninstall(params)
     }
 
-    pub fn semantic_reindex(
+    pub fn semantic_index(
         &self,
-        params: SemanticReindexParams,
-    ) -> Result<SemanticReindexResult, OrbitError> {
+        params: SemanticIndexParams,
+    ) -> Result<SemanticIndexResult, OrbitError> {
+        match params.resolved_kind() {
+            IndexKind::Tasks => self
+                .semantic_index_tasks(params)
+                .map(SemanticIndexResult::from),
+            IndexKind::Docs => self
+                .semantic_index_docs(params)
+                .map(SemanticIndexResult::from),
+            IndexKind::All => {
+                let tasks = self.semantic_index_tasks(params.clone());
+                let docs = self.semantic_index_docs(params);
+                match (tasks, docs) {
+                    (Ok(tasks), Ok(docs)) => Ok(SemanticIndexResult::All { tasks, docs }),
+                    (Err(error), _) => Err(error),
+                    (_, Err(error)) => Err(error),
+                }
+            }
+        }
+    }
+
+    fn semantic_index_tasks(
+        &self,
+        params: SemanticIndexParams,
+    ) -> Result<TaskIndexResult, OrbitError> {
         let tasks = self.stores().tasks().list()?;
-        orbit_search::semantic_reindex(&self.stores().semantic_vector, &tasks, params)
+        orbit_search::semantic_index(&self.stores().semantic_vector, &tasks, params)
+    }
+
+    fn semantic_index_docs(
+        &self,
+        params: SemanticIndexParams,
+    ) -> Result<orbit_search::DocIndexResult, OrbitError> {
+        self.index_docs(orbit_search::DocIndexParams {
+            model: params.model,
+            force: params.force,
+        })
     }
 
     pub fn semantic_stats(&self) -> Result<SemanticStatsResult, OrbitError> {

--- a/crates/orbit-core/src/runtime/orbit_tool_host/docs_tools.rs
+++ b/crates/orbit-core/src/runtime/orbit_tool_host/docs_tools.rs
@@ -1,6 +1,7 @@
 use std::str::FromStr;
 
-use crate::command::docs::{DocIndexParams, DocType};
+use crate::command::docs::DocType;
+use crate::command::semantic::{IndexKind, SemanticIndexParams};
 use orbit_common::types::{OrbitError, optional_string, required_string};
 use serde_json::Value;
 
@@ -29,7 +30,11 @@ pub(super) fn add(runtime: &OrbitRuntime, input: Value) -> Result<Value, OrbitEr
 pub(super) fn index(runtime: &OrbitRuntime, input: Value) -> Result<Value, OrbitError> {
     let model = optional_string(&input, "model")?;
     let force = optional_bool_alias(&input, &["force"])?.unwrap_or(false);
-    to_json(runtime.index_docs(DocIndexParams { model, force })?)
+    to_json(runtime.semantic_index(SemanticIndexParams {
+        model,
+        force,
+        kind: Some(IndexKind::Docs),
+    })?)
 }
 
 pub(super) fn migrate(runtime: &OrbitRuntime, input: Value) -> Result<Value, OrbitError> {

--- a/crates/orbit-core/src/runtime/orbit_tool_host/semantic_tools.rs
+++ b/crates/orbit-core/src/runtime/orbit_tool_host/semantic_tools.rs
@@ -1,5 +1,9 @@
+use std::str::FromStr;
+
 use orbit_common::types::{OrbitError, optional_string_alias};
-use orbit_search::{SemanticInstallParams, SemanticReindexParams, SemanticUninstallParams};
+use orbit_search::{
+    IndexKind, SemanticIndexParams, SemanticInstallParams, SemanticUninstallParams,
+};
 use serde_json::Value;
 
 use crate::OrbitRuntime;
@@ -25,9 +29,13 @@ pub(super) fn stats(runtime: &OrbitRuntime) -> Result<Value, OrbitError> {
 }
 
 pub(super) fn index(runtime: &OrbitRuntime, input: Value) -> Result<Value, OrbitError> {
-    to_json(runtime.semantic_reindex(SemanticReindexParams {
+    let kind = optional_string_alias(&input, &["kind"])?
+        .map(|raw| IndexKind::from_str(&raw))
+        .transpose()?;
+    to_json(runtime.semantic_index(SemanticIndexParams {
         model: optional_string_alias(&input, &["model", "embedding_model", "embeddingModel"])?,
         force: optional_bool_alias(&input, &["force"])?.unwrap_or(false),
+        kind,
     })?)
 }
 

--- a/crates/orbit-search/src/commands/doc_index.rs
+++ b/crates/orbit-search/src/commands/doc_index.rs
@@ -1,5 +1,5 @@
 use orbit_common::types::OrbitError;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 use crate::commands::parse_model;
 use crate::vector::{DocEmbeddingSource, UpsertReport, VectorStore};
@@ -11,7 +11,7 @@ pub struct DocIndexParams {
     pub force: bool,
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct DocIndexResult {
     pub model_id: String,
     pub report: UpsertReport,

--- a/crates/orbit-search/src/commands/mod.rs
+++ b/crates/orbit-search/src/commands/mod.rs
@@ -17,7 +17,10 @@ mod uninstall;
 pub use doc_index::{DocIndexParams, DocIndexResult};
 pub use doc_search::{DocSemanticHit, DocSemanticSearchParams, DocSemanticSearchResult};
 pub use install::{SemanticInstallParams, SemanticInstallResult};
-pub use reindex::{SemanticReindexParams, SemanticReindexResult};
+pub use reindex::{
+    IndexKind, SemanticIndexParams, SemanticIndexResult, SemanticReindexParams,
+    SemanticReindexResult, TaskIndexResult,
+};
 pub use related::{SemanticRelatedParams, SemanticRelatedResult};
 pub use search::{ScoreBreakdown, SemanticHit, SemanticSearchParams, SemanticSearchResult};
 pub use stats::{CompanionStatus, SemanticStatsResult};
@@ -78,12 +81,20 @@ pub fn semantic_uninstall(
     uninstall::run(params)
 }
 
+pub fn semantic_index(
+    vector_store: &VectorStore,
+    tasks: &[Task],
+    params: SemanticIndexParams,
+) -> Result<TaskIndexResult, OrbitError> {
+    reindex::run(vector_store, tasks, params)
+}
+
 pub fn semantic_reindex(
     vector_store: &VectorStore,
     tasks: &[Task],
     params: SemanticReindexParams,
 ) -> Result<SemanticReindexResult, OrbitError> {
-    reindex::run(vector_store, tasks, params)
+    semantic_index(vector_store, tasks, params)
 }
 
 pub fn doc_index(

--- a/crates/orbit-search/src/commands/reindex.rs
+++ b/crates/orbit-search/src/commands/reindex.rs
@@ -1,32 +1,175 @@
 use orbit_common::types::{OrbitError, Task};
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
+use std::str::FromStr;
 
+use crate::commands::doc_index::DocIndexResult;
 use crate::commands::parse_model;
 use crate::vector::{UpsertReport, VectorStore};
 use crate::{Embedder, SubprocessEmbedder};
 
-#[derive(Debug, Clone)]
-pub struct SemanticReindexParams {
-    pub model: Option<String>,
-    pub force: bool,
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum IndexKind {
+    Tasks,
+    Docs,
+    All,
 }
 
-#[derive(Debug, Clone, Serialize)]
-pub struct SemanticReindexResult {
+impl Default for IndexKind {
+    fn default() -> Self {
+        Self::Tasks
+    }
+}
+
+impl FromStr for IndexKind {
+    type Err = OrbitError;
+
+    fn from_str(raw: &str) -> Result<Self, Self::Err> {
+        match raw {
+            "tasks" => Ok(Self::Tasks),
+            "docs" => Ok(Self::Docs),
+            "all" => Ok(Self::All),
+            value => Err(OrbitError::InvalidInput(format!(
+                "unsupported semantic index kind `{value}`; supported values: tasks, docs, all"
+            ))),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default)]
+pub struct SemanticIndexParams {
+    pub model: Option<String>,
+    pub force: bool,
+    pub kind: Option<IndexKind>,
+}
+
+impl Default for SemanticIndexParams {
+    fn default() -> Self {
+        Self {
+            model: None,
+            force: false,
+            kind: None,
+        }
+    }
+}
+
+impl SemanticIndexParams {
+    pub fn resolved_kind(&self) -> IndexKind {
+        self.kind.unwrap_or_default()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TaskIndexResult {
     pub model_id: String,
     pub report: UpsertReport,
 }
 
+#[derive(Debug, Clone, Serialize)]
+#[serde(untagged)]
+pub enum SemanticIndexResult {
+    Tasks {
+        model_id: String,
+        report: UpsertReport,
+    },
+    Docs {
+        model_id: String,
+        report: UpsertReport,
+        indexed_sources: usize,
+        stale_sources: Vec<String>,
+    },
+    All {
+        tasks: TaskIndexResult,
+        docs: DocIndexResult,
+    },
+}
+
+impl From<TaskIndexResult> for SemanticIndexResult {
+    fn from(result: TaskIndexResult) -> Self {
+        Self::Tasks {
+            model_id: result.model_id,
+            report: result.report,
+        }
+    }
+}
+
+impl From<DocIndexResult> for SemanticIndexResult {
+    fn from(result: DocIndexResult) -> Self {
+        Self::Docs {
+            model_id: result.model_id,
+            report: result.report,
+            indexed_sources: result.indexed_sources,
+            stale_sources: result.stale_sources,
+        }
+    }
+}
+
+pub type SemanticReindexParams = SemanticIndexParams;
+pub type SemanticReindexResult = TaskIndexResult;
+
 pub fn run(
     vector_store: &VectorStore,
     tasks: &[Task],
-    params: SemanticReindexParams,
-) -> Result<SemanticReindexResult, OrbitError> {
+    params: SemanticIndexParams,
+) -> Result<TaskIndexResult, OrbitError> {
     let model = parse_model(params.model.as_deref())?;
     let embedder = SubprocessEmbedder::with_model(model.alias)?;
     let report = vector_store.reindex_tasks(tasks, &embedder, params.force)?;
-    Ok(SemanticReindexResult {
+    Ok(TaskIndexResult {
         model_id: embedder.model_id().to_string(),
         report,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+
+    #[test]
+    fn semantic_index_params_serde_defaults_to_tasks_at_runtime() {
+        let empty: SemanticIndexParams = serde_json::from_str("{}").unwrap();
+        assert_eq!(empty.kind, None);
+        assert_eq!(empty.resolved_kind(), IndexKind::Tasks);
+
+        let model_only: SemanticIndexParams =
+            serde_json::from_str(r#"{"model":"bge-small"}"#).unwrap();
+        assert_eq!(model_only.model.as_deref(), Some("bge-small"));
+        assert_eq!(model_only.kind, None);
+        assert_eq!(model_only.resolved_kind(), IndexKind::Tasks);
+
+        let docs: SemanticIndexParams = serde_json::from_str(r#"{"kind":"docs"}"#).unwrap();
+        assert_eq!(docs.kind, Some(IndexKind::Docs));
+        assert_eq!(docs.resolved_kind(), IndexKind::Docs);
+
+        let all: SemanticIndexParams = serde_json::from_str(r#"{"kind":"all"}"#).unwrap();
+        assert_eq!(all.kind, Some(IndexKind::All));
+        assert_eq!(all.resolved_kind(), IndexKind::All);
+    }
+
+    #[test]
+    fn tasks_variant_serializes_like_legacy_reindex_result() {
+        let result = SemanticIndexResult::Tasks {
+            model_id: "bge-small-en-v1.5".to_string(),
+            report: UpsertReport {
+                embedded_chunks: 7,
+                skipped_fields: 2,
+            },
+        };
+
+        let expected = json!({
+                "model_id": "bge-small-en-v1.5",
+                "report": {
+                    "embedded_chunks": 7,
+                    "skipped_fields": 2
+                }
+        });
+        assert_eq!(serde_json::to_value(&result).unwrap(), expected);
+        assert_eq!(
+            serde_json::to_string(&result).unwrap(),
+            r#"{"model_id":"bge-small-en-v1.5","report":{"embedded_chunks":7,"skipped_fields":2}}"#
+        );
+    }
 }

--- a/crates/orbit-search/src/lib.rs
+++ b/crates/orbit-search/src/lib.rs
@@ -37,12 +37,12 @@ mod vector;
 
 pub use commands::{
     CompanionStatus, DocIndexParams, DocIndexResult, DocSemanticHit, DocSemanticSearchParams,
-    DocSemanticSearchResult, ScoreBreakdown, SemanticHit, SemanticInstallParams,
-    SemanticInstallResult, SemanticReindexParams, SemanticReindexResult, SemanticRelatedParams,
-    SemanticRelatedResult, SemanticSearchParams, SemanticSearchResult, SemanticStatsResult,
-    SemanticUninstallParams, SemanticUninstallResult, doc_index, doc_semantic_search,
-    semantic_install, semantic_reindex, semantic_related, semantic_search, semantic_stats,
-    semantic_uninstall,
+    DocSemanticSearchResult, IndexKind, ScoreBreakdown, SemanticHit, SemanticIndexParams,
+    SemanticIndexResult, SemanticInstallParams, SemanticInstallResult, SemanticReindexParams,
+    SemanticReindexResult, SemanticRelatedParams, SemanticRelatedResult, SemanticSearchParams,
+    SemanticSearchResult, SemanticStatsResult, SemanticUninstallParams, SemanticUninstallResult,
+    TaskIndexResult, doc_index, doc_semantic_search, semantic_index, semantic_install,
+    semantic_reindex, semantic_related, semantic_search, semantic_stats, semantic_uninstall,
 };
 pub use companion::{
     CompanionPaths, INSTALL_REMEDIATION, locate_companion, platform_companion_filename, platform_id,

--- a/crates/orbit-tools/src/builtin/orbit/docs.rs
+++ b/crates/orbit-tools/src/builtin/orbit/docs.rs
@@ -76,8 +76,9 @@ impl Tool for OrbitDocsIndexTool {
     fn schema(&self) -> ToolSchema {
         ToolSchema {
             name: "orbit.docs.index".to_string(),
-            description: "Build or refresh doc corpus embeddings under configured [docs].roots."
-                .to_string(),
+            description:
+                "Alias for orbit.semantic.index with kind=docs under configured [docs].roots."
+                    .to_string(),
             parameters: vec![
                 optional_param(
                     "model",

--- a/crates/orbit-tools/src/builtin/orbit/semantic/index.rs
+++ b/crates/orbit-tools/src/builtin/orbit/semantic/index.rs
@@ -9,7 +9,9 @@ impl Tool for OrbitSemanticIndexTool {
     fn schema(&self) -> ToolSchema {
         ToolSchema {
             name: "orbit.semantic.index".to_string(),
-            description: "Rebuild task embeddings for the active workspace.".to_string(),
+            description:
+                "Rebuild semantic embeddings for tasks, docs, or both in the active workspace."
+                    .to_string(),
             parameters: vec![
                 ToolParam {
                     name: "model".to_string(),
@@ -22,6 +24,12 @@ impl Tool for OrbitSemanticIndexTool {
                     name: "force".to_string(),
                     description: "Re-embed unchanged task fields.".to_string(),
                     param_type: "boolean".to_string(),
+                    required: false,
+                },
+                ToolParam {
+                    name: "kind".to_string(),
+                    description: "Corpus to rebuild: tasks (default), docs, or all.".to_string(),
+                    param_type: "string".to_string(),
                     required: false,
                 },
             ],


### PR DESCRIPTION
## Task

[ORB-00207](https://orbit-cli.com/tasks/ORB-00207) — Unify index verbs: `orbit semantic index --kind {tasks,docs,all}`, `orbit docs index` as alias

### Description

## Problem

After ORB-00206 lands there will be two index verbs at different surfaces:
- `orbit semantic index` — rebuilds task embeddings (tasks-only, no `--kind` flag).
- `orbit docs index` — rebuilds doc embeddings (added by ORB-00206).

The substrate is unified: one `.orbit/state/semantic.db`, one `embeddings` table, multi-tenant via `source_kind`. But the user-facing entry points are not. Once we add ADR and learning embeddings, the surface compounds to four parallel index verbs at four parallel surfaces. The alignment is cheaper to do with two corpora than with four.

## Why It Matters

- **Surface coherence.** Indexing writes to the semantic substrate (`embeddings` table); it belongs at `orbit semantic`. Corpus-local verbs (`docs list`, `docs add`, `task show`) are about authoring/reading the corpus, not the substrate. Anchoring on this rule before three more corpora arrive prevents drift.
- **Pattern lock-in.** Two corpora is enough signal to design the dispatcher. ADR + learning then slot in as additional `--kind` variants with already-implemented dispatch — no four-way reshuffle later.
- **Familiar muscle-memory preserved.** Corpus-local aliases (`orbit docs index`) keep working as a thin delegating wrapper, so users who think corpus-first don't have to relearn.

## Latest decisions (relative to ORB-00168's stale Step 4d sketch)

- **`--kind` values today: `tasks`, `docs`, `all`.** ADR and learning will be added by their respective embedding tasks; do not stub them here. Clap validation rejects `--kind adr` / `--kind learning` with a clear error pointing at the follow-up tasks (file new task IDs into the error text when those tasks exist).
- **Default `--kind tasks`.** Backward compatible with today's `orbit semantic index` (no flag) behavior. Existing CI / scripts unaffected.
- **`orbit docs index` stays.** Becomes a thin CLI-level alias that constructs `SemanticIndexParams { kind: Docs, .. }` and calls the same runtime entry. Two reasons: (a) muscle memory, (b) corpus-local `--help` discoverability for users who reach for `orbit docs *` first.
- **Result-type evolution.** `SemanticReindexResult` (struct today, single `report` + `model_id`) becomes an enum-shaped result: `SemanticIndexResult::Tasks { model_id, report }`, `::Docs { model_id, report }`, `::All { tasks, docs }`. **Preserve BC for `--kind tasks --json`** by ensuring the `Tasks` variant's JSON shape is byte-identical to today's `SemanticReindexResult` JSON (snapshot test).
- **Internal Rust naming.** Optional secondary cleanup: rename `runtime.semantic_reindex` → `runtime.semantic_index` and `SemanticReindexParams` → `SemanticIndexParams` in the same task. Defensible because the user-facing verb already standardized on `index`. Strict scope-keepers can defer; planner's call.
- **`--kind all` semantics.** Runs `Tasks` then `Docs` sequentially. If one side errors, return that error WITHOUT rolling back the other (idempotency means re-running is cheap; partial progress is acceptable). Matches the resilience pattern ORB-00168's plan landed on.
- **No companion-status changes.** The alignment task is a dispatcher only. Fallback / companion-missing semantics remain owned by the search-side path (handled by ORB-00206 for docs, already handled for tasks).

## Constraints / Notes

- **Depends on ORB-00206.** The docs-side runtime entry (`runtime.reindex_docs` or its renamed sibling) must exist before this dispatcher can route to it.
- **BC for serde callers.** `SemanticReindexParams` is the JSON-input shape for `orbit semantic index` and the in-process call. Add `kind: Option<IndexKind>` with `#[serde(default)]` so existing `{}` and `{"model":"..."}` JSON inputs continue to deserialize as `kind: None` → resolve to `Tasks`.
- **Help-text wording.** `orbit semantic index --help` should name the principle in one line: *"--kind selects corpus: tasks (default), docs (same as `orbit docs index`), all (rebuilds both)."*
- **Don't pre-build ADR/learning routing.** Each will be added by its own task. This task stops at tasks+docs.
- **`orbit semantic` surface for non-index verbs (`install`/`uninstall`/`stats`) is unchanged.** Stats already reports per-`source_kind` counts; if it doesn't, that's a separate task. Confirm by reading `crates/orbit-search/src/commands/stats.rs` during planning.

## Out of Scope

- ADR embeddings (separate task).
- Learning embeddings (separate task).
- Folding `orbit semantic stats` to be per-kind (separate task if needed).
- Changing the embedding model selection surface (`--model` flag shape stays).
- Adding a `--kind` flag to anything other than `orbit semantic index`.
- Removing `orbit docs index` — it stays as an alias.

## Pointers

- CLI: `crates/orbit-cli/src/command/semantic.rs` (`SemanticIndexArgs` at line 51), `crates/orbit-cli/src/command/docs.rs` (`DocsIndexArgs` after ORB-00206 renames it).
- Core: `crates/orbit-core/src/command/semantic.rs` (`SemanticReindexParams`, `SemanticReindexResult`, `OrbitRuntime::semantic_reindex` at line ~30), `crates/orbit-core/src/command/docs.rs` (`OrbitRuntime::reindex_docs` after ORB-00206 makes it real).
- Substrate (no edits needed, just context): `crates/orbit-search/src/commands/reindex.rs`, `crates/orbit-search/src/vector/store/upsert.rs`.
- Prior context: ORB-00168 (Step 4d sketched this; that task is superseded by ORB-00206), ORB-00192 (orbit-embed → orbit-search rename), ORB-00202 (search consolidation), ORB-00206 (docs embeddings, hard-dependency).

### Acceptance Criteria

- `orbit semantic index --help` lists a `--kind <KIND>` option with allowed values `tasks`, `docs`, `all` and default `tasks`.
- `orbit semantic index` (no flag) produces JSON output byte-identical to pre-change `orbit semantic index --json` for the same fixture corpus — verified by a snapshot test pinning the `SemanticIndexResult::Tasks` variant's serialization to today's `SemanticReindexResult` shape.
- `orbit semantic index --kind docs --json` and `orbit docs index --json` produce equivalent docs-side reports (modulo any top-level variant tag) — verified by `diff <(orbit semantic index --kind docs --json | jq -S .) <(orbit docs index --json | jq -S .)` showing no semantic difference in `model_id`, `embedded_chunks`, `skipped_fields`, `removed_sources`.
- `orbit semantic index --kind all --json` rebuilds both corpora in one call and emits a result containing both `tasks` and `docs` sub-reports.
- `orbit semantic index --kind all` continues to populate the second corpus when the first errors (partial-progress resilience) — verified by an integration test that injects a doc-side failure and asserts the tasks side completed.
- `orbit semantic index --kind adr` and `--kind learning` exit non-zero with a clap-level invalid-value error naming the supported values (`tasks`, `docs`, `all`).
- Serde BC: `serde_json::from_str::<SemanticIndexParams>("{}")` produces `kind: None` which resolves to `IndexKind::Tasks` at the runtime entry. Serde test covers `{}`, `{"model":"bge-small"}`, `{"kind":"docs"}`, `{"kind":"all"}` shapes.
- `orbit docs index` is still available and produces the same output as `orbit semantic index --kind docs` — verified by integration test diffing both invocations' JSON output.
- `orbit semantic index --help` text contains the one-line principle: *"--kind selects corpus: tasks (default), docs (same as `orbit docs index`), all (rebuilds both)."*
- Repo-wide grep for `SemanticReindexParams` / `SemanticReindexResult` / `semantic_reindex` shows either zero matches (if internal rename was included) OR only the type/function aliases (if internal names were kept for ABI stability). Planner's decision is documented in `execution_summary`.
- All existing tests in `crates/orbit-cli/src/command/semantic.rs` and `crates/orbit-core/src/command/semantic.rs` still pass.
- `make ci-fast` passes locally before the task moves to `review`.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Added `IndexKind` / `SemanticIndexParams` and a `SemanticIndexResult` enum so `orbit semantic index` can route tasks, docs, or all while preserving the tasks JSON shape.
- Wired `orbit semantic index --kind {tasks,docs,all}` through CLI, runtime, and tool-host surfaces; `orbit docs index` now delegates to the semantic docs route and keeps its output shape.
- Added CLI/help, serde/serialization, docs-alias equivalence, all-kind JSON, invalid-kind, and partial-progress integration coverage.

Strategic decisions:
- Kept `SemanticReindexParams` / `SemanticReindexResult` / `semantic_reindex` as orbit-search compatibility aliases only; all active call sites use the new `semantic_index` / `SemanticIndex*` names.

Assessment: The dispatcher is scoped to tasks/docs/all, does not prebuild ADR or learning routing, and keeps stats/model surfaces unchanged.

Validation:
- `cargo test -p orbit-search commands::reindex -- --nocapture`
- `cargo test -p orbit-cli command::tests::cli_semantic_index -- --nocapture`
- `cargo test -p orbit-cli command::tests::cli_parses_semantic_index -- --nocapture`
- `cargo test -p orbit-core command::semantic -- --nocapture`
- `cargo test -p orbit-cli --test docs -- --nocapture`
- `cargo fmt --check`
- `git diff --check`
- `rg -n "SemanticReindexParams|SemanticReindexResult|semantic_reindex" crates/orbit-search/src crates/orbit-core/src crates/orbit-cli/src crates/orbit-tools/src` shows only the orbit-search compatibility aliases/re-exports.
- `make ci-fast`

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-00207-6a0e6ec6`
- Behind base: 0
- Ahead of base: 1