### PR TITLE
Add learning-corpus embeddings: `orbit semantic index --kind learnings` + hybrid scoring for `--kind learning`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2073,6 +2073,7 @@ dependencies = [
  "orbit-mcp",
  "predicates",
  "regex",
+ "rusqlite",
  "serde",
  "serde_json",
  "serde_yaml",

--- a/crates/orbit-cli/Cargo.toml
+++ b/crates/orbit-cli/Cargo.toml
@@ -37,6 +37,7 @@ url.workspace = true
 [dev-dependencies]
 assert_cmd = "2"
 predicates = "3"
+rusqlite.workspace = true
 serde_json.workspace = true
 serde_yaml.workspace = true
 tempfile = "3"

--- a/crates/orbit-cli/src/command/mod.rs
+++ b/crates/orbit-cli/src/command/mod.rs
@@ -278,7 +278,22 @@ mod tests {
             assert!(message.contains("possible values"), "{message}");
             assert!(message.contains("tasks"), "{message}");
             assert!(message.contains("docs"), "{message}");
+            assert!(message.contains("learnings"), "{message}");
             assert!(message.contains("all"), "{message}");
+        }
+    }
+
+    #[test]
+    fn cli_semantic_index_parses_learnings_kind() {
+        let cli = Cli::parse_from(["orbit", "semantic", "index", "--kind", "learnings"]);
+        match cli.command {
+            Commands::Semantic(command) => match command.command {
+                SemanticSubcommand::Index(args) => {
+                    assert_eq!(args.kind, SemanticIndexKindArg::Learnings);
+                }
+                _ => panic!("expected semantic index"),
+            },
+            _ => panic!("expected top-level semantic command"),
         }
     }
 
@@ -291,7 +306,7 @@ mod tests {
         let help = error.to_string();
         assert!(
             help.contains(
-                "--kind selects corpus: tasks (default), docs (same as `orbit docs index`), all (rebuilds both)."
+                "--kind selects corpus: tasks (default), docs (same as `orbit docs index`), learnings, all (rebuilds all indexed corpora)."
             ),
             "{help}"
         );

--- a/crates/orbit-cli/src/command/search.rs
+++ b/crates/orbit-cli/src/command/search.rs
@@ -7,7 +7,7 @@ use crate::command::Execute;
 #[command(
     about = "Search tasks, docs, learnings, and ADRs",
     subcommand_precedence_over_arg = true,
-    after_help = "Forms:\n  orbit search <query>\n  orbit search similar <id>\n  orbit search path <path>\n\nIndex coverage note: learnings and ADRs use lexical matching regardless of --hybrid."
+    after_help = "Forms:\n  orbit search <query>\n  orbit search similar <id>\n  orbit search path <path>\n\nIndex coverage note: ADRs use lexical matching regardless of --hybrid."
 )]
 pub struct SearchCommand {
     /// Free-text query. Defaults to lexical matching unless --hybrid is set.

--- a/crates/orbit-cli/src/command/semantic.rs
+++ b/crates/orbit-cli/src/command/semantic.rs
@@ -59,7 +59,7 @@ pub struct SemanticIndexArgs {
         value_enum,
         default_value_t = SemanticIndexKindArg::Tasks,
         value_name = "KIND",
-        help = "--kind selects corpus: tasks (default), docs (same as `orbit docs index`), all (rebuilds both)."
+        help = "--kind selects corpus: tasks (default), docs (same as `orbit docs index`), learnings, all (rebuilds all indexed corpora)."
     )]
     pub kind: SemanticIndexKindArg,
     #[arg(long)]
@@ -70,6 +70,7 @@ pub struct SemanticIndexArgs {
 pub enum SemanticIndexKindArg {
     Tasks,
     Docs,
+    Learnings,
     All,
 }
 
@@ -78,6 +79,7 @@ impl From<SemanticIndexKindArg> for IndexKind {
         match value {
             SemanticIndexKindArg::Tasks => Self::Tasks,
             SemanticIndexKindArg::Docs => Self::Docs,
+            SemanticIndexKindArg::Learnings => Self::Learnings,
             SemanticIndexKindArg::All => Self::All,
         }
     }
@@ -188,9 +190,28 @@ fn print_semantic_index_text(result: SemanticIndexResult) -> Result<(), OrbitErr
                 stale_sources.len()
             );
         }
-        SemanticIndexResult::All { tasks, docs } => {
+        SemanticIndexResult::Learnings {
+            model_id,
+            report,
+            indexed_sources,
+            stale_sources,
+        } => {
             println!(
-                "Indexed semantic search: tasks_model={} tasks_embedded_chunks={} tasks_skipped_fields={} docs_model={} docs_indexed_sources={} docs_embedded_chunks={} docs_skipped_fields={} docs_stale_sources={}",
+                "Indexed learnings: model={} indexed_sources={} embedded_chunks={} skipped_fields={} stale_sources={}",
+                model_id,
+                indexed_sources,
+                report.embedded_chunks,
+                report.skipped_fields,
+                stale_sources.len()
+            );
+        }
+        SemanticIndexResult::All {
+            tasks,
+            docs,
+            learnings,
+        } => {
+            println!(
+                "Indexed semantic search: tasks_model={} tasks_embedded_chunks={} tasks_skipped_fields={} docs_model={} docs_indexed_sources={} docs_embedded_chunks={} docs_skipped_fields={} docs_stale_sources={} learnings_model={} learnings_indexed_sources={} learnings_embedded_chunks={} learnings_skipped_fields={} learnings_stale_sources={}",
                 tasks.model_id,
                 tasks.report.embedded_chunks,
                 tasks.report.skipped_fields,
@@ -198,7 +219,12 @@ fn print_semantic_index_text(result: SemanticIndexResult) -> Result<(), OrbitErr
                 docs.indexed_sources,
                 docs.report.embedded_chunks,
                 docs.report.skipped_fields,
-                docs.stale_sources.len()
+                docs.stale_sources.len(),
+                learnings.model_id,
+                learnings.indexed_sources,
+                learnings.report.embedded_chunks,
+                learnings.report.skipped_fields,
+                learnings.stale_sources.len()
             );
         }
     }

--- a/crates/orbit-cli/tests/docs.rs
+++ b/crates/orbit-cli/tests/docs.rs
@@ -6,6 +6,7 @@ use std::path::PathBuf;
 use std::process::Output;
 
 use assert_cmd::cargo::cargo_bin_cmd;
+use rusqlite::{Connection, params};
 use serde_json::{Value, json};
 use tempfile::{TempDir, tempdir};
 
@@ -73,6 +74,8 @@ fn cli_orbit_search_limit_help_describes_total_round_robin_limit() {
     assert!(help.contains("Maximum total results returned"));
     assert!(help.contains("round-robin per kind"));
     assert!(help.contains("[default: 10]"));
+    assert!(help.contains("ADRs use lexical matching regardless of --hybrid."));
+    assert!(!help.contains("learnings and ADRs use lexical matching"));
 }
 
 #[test]
@@ -137,6 +140,161 @@ fn cli_orbit_search_hybrid_doc_json_reports_lexical_fallback_note() {
         }),
         "hybrid doc notes should preserve lexical fallback warning: {notes:?}"
     );
+}
+
+#[test]
+fn cli_orbit_search_hybrid_learning_json_reports_lexical_fallback_note_missing_companion() {
+    let workspace = TestWorkspace::new();
+    let learning = workspace.run_json(
+        &[
+            "learning",
+            "add",
+            "--summary",
+            "hybrid-learning-note literal",
+            "--tag",
+            "hybrid-learning-note",
+            "--json",
+        ],
+        "add learning",
+    );
+
+    let response = workspace.run_json(
+        &[
+            "search",
+            "hybrid-learning-note",
+            "--hybrid",
+            "--kind",
+            "learning",
+            "--json",
+        ],
+        "orbit search hybrid learning missing companion",
+    );
+    let notes = response["notes"].as_array().expect("notes");
+    assert!(
+        notes.iter().any(|note| {
+            note.as_str()
+                .expect("note")
+                .contains("falling back to lexical")
+        }),
+        "hybrid learning notes should preserve lexical fallback warning: {notes:?}"
+    );
+    assert_eq!(response["results"][0]["source"], "lexical");
+    assert_eq!(response["results"][0]["id"], learning["id"]);
+
+    let output = workspace.run(
+        &[
+            "search",
+            "hybrid-learning-note",
+            "--hybrid",
+            "--kind",
+            "learning",
+        ],
+        "orbit search hybrid learning missing companion table",
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("note: ") && stderr.contains("falling back to lexical"),
+        "table-mode stderr should include fallback note: {stderr}"
+    );
+}
+
+#[test]
+#[cfg(unix)]
+fn cli_orbit_search_hybrid_learning_json_reports_lexical_fallback_note_empty_embeddings() {
+    let workspace = TestWorkspace::new();
+    workspace.write_mock_companion();
+    let learning = workspace.run_json(
+        &[
+            "learning",
+            "add",
+            "--summary",
+            "hybrid-learning-empty literal",
+            "--tag",
+            "hybrid-learning-empty",
+            "--json",
+        ],
+        "add learning",
+    );
+
+    let response = workspace.run_json_with_companion(
+        &[
+            "search",
+            "hybrid-learning-empty",
+            "--hybrid",
+            "--kind",
+            "learning",
+            "--json",
+        ],
+        "orbit search hybrid learning empty embeddings",
+    );
+    let notes = response["notes"].as_array().expect("notes");
+    assert!(
+        notes.iter().any(|note| {
+            note.as_str()
+                .expect("note")
+                .contains("falling back to lexical")
+        }),
+        "hybrid learning notes should preserve lexical fallback warning: {notes:?}"
+    );
+    assert_eq!(response["results"][0]["source"], "lexical");
+    assert_eq!(response["results"][0]["id"], learning["id"]);
+}
+
+#[test]
+#[cfg(unix)]
+fn cli_orbit_search_hybrid_learning_ranking_differs_from_lexical() {
+    let workspace = TestWorkspace::new();
+    workspace.write_mock_companion();
+    let semantic = workspace.run_json(
+        &[
+            "learning",
+            "add",
+            "--summary",
+            "conceptual guidance",
+            "--body",
+            "semantic-target operational insight",
+            "--json",
+        ],
+        "add semantic learning",
+    );
+    let literal = workspace.run_json(
+        &[
+            "learning",
+            "add",
+            "--summary",
+            "foo literal guidance",
+            "--body",
+            "literal body",
+            "--priority",
+            "100",
+            "--json",
+        ],
+        "add literal learning",
+    );
+    workspace.run_json_with_companion(
+        &[
+            "semantic",
+            "index",
+            "--kind",
+            "learnings",
+            "--force",
+            "--json",
+        ],
+        "semantic index learnings",
+    );
+
+    let lexical = workspace.run_json(
+        &["search", "foo", "--kind", "learning", "--json"],
+        "learning lexical search",
+    );
+    let hybrid = workspace.run_json_with_companion(
+        &["search", "foo", "--kind", "learning", "--hybrid", "--json"],
+        "learning hybrid search",
+    );
+
+    assert_eq!(lexical["results"][0]["id"], literal["id"]);
+    assert_eq!(hybrid["results"][0]["id"], semantic["id"]);
+    assert_ne!(lexical["results"][0]["id"], hybrid["results"][0]["id"]);
 }
 
 #[test]
@@ -390,6 +548,88 @@ fn cli_semantic_index_all_json_contains_tasks_and_docs() {
     );
     assert_eq!(result["docs"]["model_id"], "bge-small-en-v1.5");
     assert_eq!(result["docs"]["indexed_sources"], 1);
+    assert_eq!(result["learnings"]["model_id"], "bge-small-en-v1.5");
+    assert_eq!(result["learnings"]["indexed_sources"], 0);
+}
+
+#[test]
+#[cfg(unix)]
+fn cli_semantic_index_learnings_is_idempotent_status_agnostic_and_sweeps_stale() {
+    let workspace = TestWorkspace::new();
+    workspace.write_mock_companion();
+    let old = workspace.run_json(
+        &[
+            "learning",
+            "add",
+            "--summary",
+            "learning-index-old",
+            "--body",
+            "## Rule\nKeep the old rule indexed.\n\n## Why\nSuperseded records remain searchable when explicitly requested.\n",
+            "--tag",
+            "semantic",
+            "--json",
+        ],
+        "add old learning",
+    );
+    let new = workspace.run_json(
+        &[
+            "learning",
+            "add",
+            "--summary",
+            "learning-index-new",
+            "--body",
+            "## Rule\nReplacement rule.\n\n## How to apply\nUse the replacement.\n",
+            "--tag",
+            "semantic",
+            "--json",
+        ],
+        "add new learning",
+    );
+    let old_id = old["id"].as_str().expect("old id");
+    let new_id = new["id"].as_str().expect("new id");
+
+    let first = workspace.run_json_with_companion(
+        &["semantic", "index", "--kind", "learnings", "--json"],
+        "semantic index learnings",
+    );
+    assert_eq!(first["indexed_sources"], 2);
+    assert!(
+        first["report"]["embedded_chunks"].as_u64().unwrap_or(0)
+            > learning_dir_count(&workspace.work) as u64
+    );
+    assert!(
+        count_learning_embeddings(&workspace.work, None)
+            > learning_dir_count(&workspace.work) as i64
+    );
+
+    let second = workspace.run_json_with_companion(
+        &["semantic", "index", "--kind", "learnings", "--json"],
+        "semantic index learnings idempotent",
+    );
+    assert_eq!(second["report"]["embedded_chunks"], 0);
+    assert!(second["report"]["skipped_fields"].as_u64().unwrap_or(0) > 0);
+
+    workspace.run_json(
+        &["learning", "supersede", old_id, "--with", new_id, "--json"],
+        "supersede learning",
+    );
+    workspace.run_json_with_companion(
+        &["semantic", "index", "--kind", "learnings", "--json"],
+        "semantic index superseded learnings",
+    );
+    assert!(
+        count_learning_embeddings(&workspace.work, Some(old_id)) > 0,
+        "superseded learning should remain indexed"
+    );
+
+    fs::remove_dir_all(workspace.work.join(".orbit/learnings").join(new_id))
+        .expect("delete learning directory");
+    workspace.run_json_with_companion(
+        &["semantic", "index", "--kind", "learnings", "--json"],
+        "semantic index after learning deletion",
+    );
+    assert_eq!(count_learning_embeddings(&workspace.work, Some(new_id)), 0);
+    assert!(count_learning_embeddings(&workspace.work, Some(old_id)) > 0);
 }
 
 #[test]
@@ -549,7 +789,14 @@ while IFS= read -r line; do
       printf '{"id":%s,"result":{"tokens":1}}\n' "$id"
       ;;
     *'"method":"embed"'*)
-      printf '{"id":%s,"result":{"vectors":[[1.0,0.0]]}}\n' "$id"
+      case "$line" in
+        *'"texts":["foo"]'*|*semantic-target*)
+          printf '{"id":%s,"result":{"vectors":[[1.0,0.0]]}}\n' "$id"
+          ;;
+        *)
+          printf '{"id":%s,"result":{"vectors":[[0.0,1.0]]}}\n' "$id"
+          ;;
+      esac
       ;;
     *'"method":"exit"'*)
       printf '{"id":%s,"result":{"ok":true}}\n' "$id"
@@ -609,6 +856,40 @@ done
 
 fn run_orbit(work: &PathBuf, home: &PathBuf, args: &[&str]) -> Output {
     run_orbit_with_companion(work, home, args, None)
+}
+
+fn learning_dir_count(work: &std::path::Path) -> usize {
+    fs::read_dir(work.join(".orbit/learnings"))
+        .expect("read learnings")
+        .filter_map(Result::ok)
+        .filter(|entry| entry.file_type().is_ok_and(|file_type| file_type.is_dir()))
+        .filter(|entry| {
+            entry
+                .file_name()
+                .to_str()
+                .is_some_and(|name| name.starts_with("L-"))
+        })
+        .count()
+}
+
+fn count_learning_embeddings(work: &std::path::Path, source_id: Option<&str>) -> i64 {
+    let conn = Connection::open(work.join(".orbit/state/semantic.db")).expect("open semantic db");
+    match source_id {
+        Some(source_id) => conn
+            .query_row(
+                "SELECT COUNT(*) FROM embeddings WHERE source_kind = 'learning' AND source_id = ?1",
+                params![source_id],
+                |row| row.get(0),
+            )
+            .expect("count learning source embeddings"),
+        None => conn
+            .query_row(
+                "SELECT COUNT(*) FROM embeddings WHERE source_kind = 'learning'",
+                [],
+                |row| row.get(0),
+            )
+            .expect("count learning embeddings"),
+    }
 }
 
 fn run_orbit_with_companion(

--- a/crates/orbit-core/assets/skills/orbit-learning/SKILL.md
+++ b/crates/orbit-core/assets/skills/orbit-learning/SKILL.md
@@ -27,7 +27,7 @@ Both surfaces accept the same JSON. Use the CLI examples when shell access is av
 |------|-----|-----|
 | `orbit.learning.add` | `orbit_learning_add({...})` | `orbit learning add --summary "..." --path "crates/orbit-core/**/*.rs" --tag rust --body-file note.md` |
 | `orbit.learning.list` | `orbit_learning_list({...})` | `orbit learning list --status active --tag rust` (also `--path <glob-or-file>`) |
-| `orbit.search` | `orbit_search({...})` | `orbit search --kind learning <text>` (free-text content match) |
+| `orbit.search` | `orbit_search({...})` | `orbit search --kind learning <text>` (lexical free-text match; add `--hybrid` after `orbit semantic index --kind learnings` for lexical + semantic ranking) |
 | `orbit.learning.show` | `orbit_learning_show({...})` | `orbit learning show --id L-0001` |
 | `orbit.learning.comment.add` | `orbit_learning_comment_add({...})` | `orbit learning comment add --learning-id L-0001 --body "Narrow note" --model codex` |
 | `orbit.learning.comment.list` | `orbit_learning_comment_list({...})` | `orbit learning comment list --learning-id L-0001` |
@@ -46,7 +46,8 @@ Run `orbit tool list | grep orbit.learning` if you suspect the local tool surfac
 1. **Search before adding.** Before creating a new learning, check whether one already covers the same scope:
    - `orbit learning list --path <path-you-care-about>` for path-anchored guidance (glob-containment).
    - `orbit learning list --tag <tag>` for cross-cutting topics.
-   - `orbit search --kind learning <substring>` for content match against `summary` and body (case-insensitive).
+   - `orbit search --kind learning <substring>` for lexical content match against `summary` and body (case-insensitive).
+   - `orbit search --kind learning --hybrid <query>` when the semantic companion is installed and learning embeddings have been indexed with `orbit semantic index --kind learnings`; this blends lexical ranking with semantic matches over learning summary/body/tags and falls back to lexical results when vectors are unavailable.
    If a near-match exists, prefer `update` (refine the existing record) or `supersede` (replace it with a new ID) over creating a duplicate.
 
 2. **Add with tight scope.** A learning is only useful when its `scope` triggers the right injections — not too broad (noise) and not too narrow (never fires). `scope: { paths?, tags? }` matches as **paths OR tags** (a record fires when *any* path glob OR *any* tag hits). Include `evidence: [{ kind: "task"|"commit"|"external", ref: "..." }]` whenever the learning came from a real incident, PR, or task — future readers (and prune logic) lean on it. Use `priority` (0–255) sparingly; it is the secondary search ranking key, not a "this is important" badge.

--- a/crates/orbit-core/src/command/learning.rs
+++ b/crates/orbit-core/src/command/learning.rs
@@ -5,6 +5,7 @@
 //! dispatch layer. Tool-host and CLI both reach into
 //! `runtime.stores().learnings()`, which is the single source of truth.
 
+use std::fs;
 use std::path::{Path, PathBuf};
 
 use orbit_common::types::{
@@ -18,8 +19,37 @@ use orbit_store::{
     LearningSearchParams, LearningSearchResult, LearningUpdateParams, LearningUpvoteParams,
     RemoteArtifactStub, learning_layout::LearningLayoutMigrationReport,
 };
+use serde::Deserialize;
 
 use crate::OrbitRuntime;
+
+#[derive(Debug, Deserialize)]
+struct LearningConfigFile {
+    learning: Option<LearningConfigSection>,
+}
+
+#[derive(Debug, Deserialize)]
+struct LearningConfigSection {
+    search: Option<LearningSearchConfigSection>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct LearningSearchConfig {
+    pub semantic_weight: f32,
+}
+
+impl Default for LearningSearchConfig {
+    fn default() -> Self {
+        Self {
+            semantic_weight: 0.5,
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct LearningSearchConfigSection {
+    semantic_weight: Option<f32>,
+}
 
 impl OrbitRuntime {
     pub fn create_learning(&self, params: LearningCreateParams) -> Result<Learning, OrbitError> {
@@ -66,6 +96,10 @@ impl OrbitRuntime {
     ) -> Result<Vec<LearningSearchResult>, OrbitError> {
         let params = normalize_learning_search_params(&self.paths().repo_root, params)?;
         self.stores().learnings().search(params)
+    }
+
+    pub fn learning_search_config(&self) -> Result<LearningSearchConfig, OrbitError> {
+        read_learning_search_config_from_config_path(&self.config_path())
     }
 
     pub fn upvote_learning(
@@ -186,6 +220,35 @@ impl OrbitRuntime {
         }
         Ok((stale, deleted))
     }
+}
+
+pub fn parse_learning_search_config_from_config_toml(
+    raw: &str,
+) -> Result<LearningSearchConfig, OrbitError> {
+    if raw.trim().is_empty() {
+        return Ok(LearningSearchConfig::default());
+    }
+    let parsed = toml::from_str::<LearningConfigFile>(raw).map_err(|error| {
+        OrbitError::InvalidInput(format!("invalid learning config in config.toml: {error}"))
+    })?;
+    let semantic_weight = parsed
+        .learning
+        .and_then(|section| section.search)
+        .and_then(|section| section.semantic_weight)
+        .unwrap_or_else(|| LearningSearchConfig::default().semantic_weight)
+        .clamp(0.0, 1.0);
+    Ok(LearningSearchConfig { semantic_weight })
+}
+
+fn read_learning_search_config_from_config_path(
+    path: &Path,
+) -> Result<LearningSearchConfig, OrbitError> {
+    if !path.exists() {
+        return Ok(LearningSearchConfig::default());
+    }
+    let raw = fs::read_to_string(path)
+        .map_err(|error| OrbitError::Io(format!("read {}: {error}", path.display())))?;
+    parse_learning_search_config_from_config_toml(&raw)
 }
 
 fn remote_artifact_error(kind: &str, stub: &RemoteArtifactStub) -> OrbitError {
@@ -391,4 +454,43 @@ fn canonicalize_with_missing_tail(path: &Path) -> Result<PathBuf, OrbitError> {
         canonical.push(component);
     }
     Ok(canonical)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn learning_search_config_defaults_and_clamps_semantic_weight() {
+        assert_eq!(
+            parse_learning_search_config_from_config_toml("")
+                .unwrap()
+                .semantic_weight,
+            0.5
+        );
+        assert_eq!(
+            parse_learning_search_config_from_config_toml(
+                "[learning.search]\nsemantic_weight = 0.7\n"
+            )
+            .unwrap()
+            .semantic_weight,
+            0.7
+        );
+        assert_eq!(
+            parse_learning_search_config_from_config_toml(
+                "[learning.search]\nsemantic_weight = -1.0\n"
+            )
+            .unwrap()
+            .semantic_weight,
+            0.0
+        );
+        assert_eq!(
+            parse_learning_search_config_from_config_toml(
+                "[learning.search]\nsemantic_weight = 2.0\n"
+            )
+            .unwrap()
+            .semantic_weight,
+            1.0
+        );
+    }
 }

--- a/crates/orbit-core/src/command/search.rs
+++ b/crates/orbit-core/src/command/search.rs
@@ -4,7 +4,8 @@ use std::str::FromStr;
 use orbit_common::types::{AdrStatus, LearningStatus, OrbitError, TaskStatus};
 use orbit_common::utility::glob::compile_glob_regex;
 use orbit_search::{
-    DocSemanticHit, DocSemanticSearchParams, SemanticRelatedParams, SemanticSearchParams,
+    DocSemanticHit, DocSemanticSearchParams, LearningSemanticHit, LearningSemanticSearchParams,
+    SemanticRelatedParams, SemanticSearchParams,
 };
 use orbit_store::LearningSearchParams;
 use serde::Serialize;
@@ -14,12 +15,16 @@ use crate::{OrbitRuntime, SearchResult};
 const DEFAULT_LIMIT: usize = 10;
 const DOC_SEARCH_OVERFETCH: usize = 4;
 const DOC_HYBRID_FALLBACK_NOTE: &str = "falling back to lexical doc search";
+const LEARNING_HYBRID_FALLBACK_NOTE: &str = "falling back to lexical learning search";
 const DOC_SEARCH_MIN_CANDIDATES: usize = DEFAULT_LIMIT * DOC_SEARCH_OVERFETCH;
 
 #[cfg(test)]
 thread_local! {
     static DOC_SEMANTIC_SEARCH_OVERRIDE:
         std::cell::RefCell<Option<Result<Vec<DocSemanticHit>, String>>> =
+        const { std::cell::RefCell::new(None) };
+    static LEARNING_SEMANTIC_SEARCH_OVERRIDE:
+        std::cell::RefCell<Option<Result<Vec<LearningSemanticHit>, String>>> =
         const { std::cell::RefCell::new(None) };
 }
 
@@ -225,11 +230,11 @@ impl OrbitRuntime {
             GlobalSearchMode::Lexical
         };
 
-        if params.hybrid && (params.kind.includes_learnings() || params.kind.includes_adrs()) {
+        if params.hybrid && params.kind.includes_adrs() {
             push_skip_note(
                 &mut notes,
-                "learning/ADR hybrid vector",
-                "learnings and ADRs use lexical matching regardless of --hybrid",
+                "ADR hybrid vector",
+                "ADRs use lexical matching regardless of --hybrid",
             );
         }
 
@@ -281,6 +286,7 @@ impl OrbitRuntime {
                 query_owned.as_deref(),
                 &tag_filter,
                 limit,
+                &mut notes,
             )?);
         }
 
@@ -635,6 +641,35 @@ impl OrbitRuntime {
         query: Option<&str>,
         tag_filter: &[String],
         limit: usize,
+        notes: &mut Vec<String>,
+    ) -> Result<Vec<GlobalSearchHit>, OrbitError> {
+        let lexical =
+            self.learning_lexical_hits(params, status_filters, query, tag_filter, limit)?;
+        if !params.hybrid {
+            return Ok(lexical);
+        }
+        let Some(query) = query else {
+            return Ok(lexical);
+        };
+
+        self.hybrid_learning_hits(
+            query,
+            lexical,
+            params,
+            status_filters,
+            tag_filter,
+            limit,
+            notes,
+        )
+    }
+
+    fn learning_lexical_hits(
+        &self,
+        params: &GlobalSearchParams,
+        status_filters: &SearchStatusFilters,
+        query: Option<&str>,
+        tag_filter: &[String],
+        limit: usize,
     ) -> Result<Vec<GlobalSearchHit>, OrbitError> {
         let statuses = resolve_learning_statuses(params, status_filters);
         let active_only = statuses == vec![LearningStatus::Active];
@@ -718,6 +753,124 @@ impl OrbitRuntime {
         out.truncate(limit);
         Ok(out)
     }
+
+    fn hybrid_learning_hits(
+        &self,
+        query: &str,
+        lexical: Vec<GlobalSearchHit>,
+        params: &GlobalSearchParams,
+        status_filters: &SearchStatusFilters,
+        tag_filter: &[String],
+        limit: usize,
+        notes: &mut Vec<String>,
+    ) -> Result<Vec<GlobalSearchHit>, OrbitError> {
+        let learning_limit = doc_search_candidate_limit(limit);
+        let lexical_fallback = lexical.clone();
+        let mut lexical_learnings = BTreeMap::<String, LearningHybridCandidate>::new();
+        let lexical_count = lexical.len();
+        for (idx, hit) in lexical.into_iter().enumerate() {
+            let Some(id) = hit.id.clone() else {
+                continue;
+            };
+            lexical_learnings.insert(
+                id,
+                LearningHybridCandidate {
+                    hit: GlobalSearchHit {
+                        source: "hybrid".to_string(),
+                        ..hit
+                    },
+                    lexical_score: Some((lexical_count - idx) as f32),
+                    semantic_score: None,
+                    semantic: None,
+                },
+            );
+        }
+
+        let semantic = match self.learning_semantic_hits(query, learning_limit) {
+            Ok(result) if result.is_empty() => {
+                warn_learning_hybrid_fallback(notes, "no learning embeddings found");
+                return Ok(lexical_fallback);
+            }
+            Ok(result) => result,
+            Err(error) => {
+                warn_learning_hybrid_fallback(notes, &error.to_string());
+                return Ok(lexical_fallback);
+            }
+        };
+
+        let statuses = resolve_learning_statuses(params, status_filters);
+        let path = params.path.as_deref();
+        let mut candidates = lexical_learnings;
+        for hit in semantic {
+            let learning = match self.get_learning(&hit.source_id) {
+                Ok(learning) => learning,
+                Err(_) => continue,
+            };
+            if !statuses.contains(&learning.status) {
+                continue;
+            }
+            if !tag_filter.is_empty() && !learning_has_all_tags(&learning, tag_filter) {
+                continue;
+            }
+            if let Some(path) = path
+                && !learning_scope_contains_path(&learning, path)?
+            {
+                continue;
+            }
+
+            candidates
+                .entry(hit.source_id.clone())
+                .and_modify(|candidate| {
+                    candidate.semantic_score = Some(hit.score);
+                    candidate.semantic = Some(hit.clone());
+                })
+                .or_insert_with(|| LearningHybridCandidate {
+                    hit: GlobalSearchHit {
+                        kind: "learning".to_string(),
+                        source: "hybrid".to_string(),
+                        id: Some(learning.id),
+                        path: None,
+                        title: None,
+                        summary: Some(learning.summary),
+                        status: Some(learning.status.as_str().to_string()),
+                        best_field: None,
+                        snippet: None,
+                        score: None,
+                        matched_by: None,
+                    },
+                    lexical_score: None,
+                    semantic_score: Some(hit.score),
+                    semantic: Some(hit),
+                });
+        }
+
+        let weight = self.learning_search_config()?.semantic_weight;
+        let mut ranked =
+            blend_learning_hybrid_candidates(candidates.into_values().collect(), weight);
+        ranked.truncate(limit);
+        Ok(ranked)
+    }
+
+    fn learning_semantic_hits(
+        &self,
+        query: &str,
+        limit: usize,
+    ) -> Result<Vec<LearningSemanticHit>, OrbitError> {
+        #[cfg(test)]
+        if let Some(result) = LEARNING_SEMANTIC_SEARCH_OVERRIDE.with(|cell| cell.borrow().clone()) {
+            return result.map_err(OrbitError::Execution);
+        }
+
+        Ok(orbit_search::learning_semantic_search(
+            &self.stores().semantic_vector,
+            LearningSemanticSearchParams {
+                query: query.to_string(),
+                limit,
+                model: None,
+            },
+        )?
+        .results)
+    }
 }
 
 fn lexical_task_hit(task: &orbit_common::types::Task) -> GlobalSearchHit {
@@ -791,6 +944,14 @@ struct DocHybridCandidate {
     semantic: Option<DocSemanticHit>,
 }
 
+#[derive(Debug, Clone)]
+struct LearningHybridCandidate {
+    hit: GlobalSearchHit,
+    lexical_score: Option<f32>,
+    semantic_score: Option<f32>,
+    semantic: Option<LearningSemanticHit>,
+}
+
 fn lexical_doc_hits_with_adrs(
     lexical_docs: BTreeMap<String, orbit_search::DocSearchResult>,
     lexical_adrs: Vec<GlobalSearchHit>,
@@ -832,6 +993,46 @@ fn blend_doc_hybrid_candidates(
             let path = candidate.hit.path.as_deref().unwrap_or_default();
             let lexical = lexical_scores.get(path).copied().unwrap_or(0.0);
             let semantic = semantic_scores.get(path).copied().unwrap_or(0.0);
+            let score = semantic_weight.mul_add(semantic, lexical_weight * lexical);
+            candidate.hit.score = Some(score);
+            if let Some(semantic_hit) = candidate.semantic {
+                candidate.hit.best_field = Some(semantic_hit.best_field);
+                candidate.hit.snippet = Some(semantic_hit.snippet);
+            }
+            candidate.hit
+        })
+        .collect::<Vec<_>>();
+    out.sort_by(compare_global_hits_by_score);
+    out
+}
+
+fn blend_learning_hybrid_candidates(
+    candidates: Vec<LearningHybridCandidate>,
+    semantic_weight: f32,
+) -> Vec<GlobalSearchHit> {
+    let lexical_scores = normalized_doc_scores(candidates.iter().filter_map(|candidate| {
+        candidate
+            .hit
+            .id
+            .as_ref()
+            .zip(candidate.lexical_score)
+            .map(|(id, score)| (id.clone(), score))
+    }));
+    let semantic_scores = normalized_doc_scores(candidates.iter().filter_map(|candidate| {
+        candidate
+            .hit
+            .id
+            .as_ref()
+            .zip(candidate.semantic_score)
+            .map(|(id, score)| (id.clone(), score))
+    }));
+    let lexical_weight = 1.0 - semantic_weight;
+    let mut out = candidates
+        .into_iter()
+        .map(|mut candidate| {
+            let id = candidate.hit.id.as_deref().unwrap_or_default();
+            let lexical = lexical_scores.get(id).copied().unwrap_or(0.0);
+            let semantic = semantic_scores.get(id).copied().unwrap_or(0.0);
             let score = semantic_weight.mul_add(semantic, lexical_weight * lexical);
             candidate.hit.score = Some(score);
             if let Some(semantic_hit) = candidate.semantic {
@@ -898,6 +1099,19 @@ fn warn_doc_hybrid_fallback(notes: &mut Vec<String>, reason: &str) {
         notes,
         "doc hybrid vector",
         &format!("{DOC_HYBRID_FALLBACK_NOTE}: {reason}"),
+    );
+}
+
+fn warn_learning_hybrid_fallback(notes: &mut Vec<String>, reason: &str) {
+    orbit_common::tracing::warn!(
+        target: "orbit.search.learnings",
+        reason,
+        "falling back to lexical learning search"
+    );
+    push_skip_note(
+        notes,
+        "learning hybrid vector",
+        &format!("{LEARNING_HYBRID_FALLBACK_NOTE}: {reason}"),
     );
 }
 
@@ -1356,14 +1570,26 @@ mod tests {
     }
 
     fn add_learning(runtime: &OrbitRuntime, summary: &str) -> String {
+        add_learning_with(runtime, summary, &[], None)
+    }
+
+    fn add_learning_with(
+        runtime: &OrbitRuntime,
+        summary: &str,
+        tags: &[&str],
+        priority: Option<u8>,
+    ) -> String {
         runtime
             .create_learning(LearningCreateParams {
                 summary: summary.to_string(),
-                scope: LearningScope::default(),
+                scope: LearningScope {
+                    tags: tags.iter().map(|tag| (*tag).to_string()).collect(),
+                    ..Default::default()
+                },
                 body: format!("{summary} body"),
                 evidence: Vec::new(),
                 created_by: Some("test".to_string()),
-                priority: None,
+                priority,
             })
             .expect("add learning")
             .id
@@ -1417,6 +1643,15 @@ mod tests {
         }
     }
 
+    fn learning_semantic_hit(id: &str, score: f32) -> LearningSemanticHit {
+        LearningSemanticHit {
+            source_id: id.to_string(),
+            best_field: "summary".to_string(),
+            snippet: "semantic learning snippet".to_string(),
+            score,
+        }
+    }
+
     fn with_doc_semantic_override<T>(
         result: Result<Vec<DocSemanticHit>, String>,
         f: impl FnOnce() -> T,
@@ -1426,6 +1661,20 @@ mod tests {
         });
         let out = f();
         DOC_SEMANTIC_SEARCH_OVERRIDE.with(|cell| {
+            *cell.borrow_mut() = None;
+        });
+        out
+    }
+
+    fn with_learning_semantic_override<T>(
+        result: Result<Vec<LearningSemanticHit>, String>,
+        f: impl FnOnce() -> T,
+    ) -> T {
+        LEARNING_SEMANTIC_SEARCH_OVERRIDE.with(|cell| {
+            *cell.borrow_mut() = Some(result);
+        });
+        let out = f();
+        LEARNING_SEMANTIC_SEARCH_OVERRIDE.with(|cell| {
             *cell.borrow_mut() = None;
         });
         out
@@ -1888,6 +2137,212 @@ mod tests {
         };
         let out = blend_doc_hybrid_candidates(
             vec![DocHybridCandidate {
+                hit,
+                lexical_score: Some(0.42),
+                semantic_score: None,
+                semantic: None,
+            }],
+            0.5,
+        );
+
+        assert!((out[0].score.expect("score") - 0.21).abs() < 0.0001);
+    }
+
+    #[test]
+    fn global_search_learning_lexical_mode_keeps_legacy_json_shape() {
+        let runtime = OrbitRuntime::in_memory().expect("runtime");
+        let id = add_learning_with(
+            &runtime,
+            "lexstable literal learning",
+            &["lexstable"],
+            Some(50),
+        );
+
+        let response = with_learning_semantic_override(
+            Err("semantic should not be called".to_string()),
+            || {
+                runtime
+                    .global_search(GlobalSearchParams {
+                        query: Some("lexstable".to_string()),
+                        kind: GlobalSearchKind::Learning,
+                        limit: 5,
+                        ..Default::default()
+                    })
+                    .expect("learning lexical search")
+            },
+        );
+
+        assert_eq!(response.mode, GlobalSearchMode::Lexical);
+        assert_eq!(
+            serde_json::to_value(&response.results).expect("serialize results"),
+            json!([
+                {
+                    "kind": "learning",
+                    "source": "lexical",
+                    "id": id,
+                    "summary": "lexstable literal learning",
+                    "status": "active",
+                    "matched_by": ["query:summary"]
+                }
+            ])
+        );
+    }
+
+    #[test]
+    fn global_search_learning_hybrid_ranking_differs_from_lexical() {
+        let runtime = OrbitRuntime::in_memory().expect("runtime");
+        let semantic_id = add_learning(&runtime, "conceptual async-lock guidance");
+        let lexical_id =
+            add_learning_with(&runtime, "rankdiff literal foo guidance", &[], Some(100));
+
+        let lexical = runtime
+            .global_search(GlobalSearchParams {
+                query: Some("rankdiff".to_string()),
+                kind: GlobalSearchKind::Learning,
+                limit: 2,
+                ..Default::default()
+            })
+            .expect("learning lexical search");
+        let hybrid = with_learning_semantic_override(
+            Ok(vec![
+                learning_semantic_hit(&semantic_id, 1.0),
+                learning_semantic_hit(&lexical_id, 0.0),
+            ]),
+            || {
+                runtime
+                    .global_search(GlobalSearchParams {
+                        query: Some("rankdiff".to_string()),
+                        hybrid: true,
+                        kind: GlobalSearchKind::Learning,
+                        limit: 2,
+                        ..Default::default()
+                    })
+                    .expect("learning hybrid search")
+            },
+        );
+
+        assert_eq!(lexical.results[0].id.as_deref(), Some(lexical_id.as_str()));
+        assert_eq!(hybrid.results[0].id.as_deref(), Some(semantic_id.as_str()));
+        assert_ne!(lexical.results[0].id, hybrid.results[0].id);
+    }
+
+    #[test]
+    fn global_search_learning_hybrid_uses_learning_semantic_weight() {
+        let runtime = OrbitRuntime::in_memory().expect("runtime");
+        let semantic_id = add_learning(&runtime, "learningweight conceptual guidance");
+        let lexical_id = add_learning_with(
+            &runtime,
+            "learningweight literal foo guidance",
+            &[],
+            Some(100),
+        );
+        let semantic = vec![
+            learning_semantic_hit(&semantic_id, 1.0),
+            learning_semantic_hit(&lexical_id, 0.0),
+        ];
+
+        let top_id = |weight: f32| {
+            fs::write(
+                runtime.config_path(),
+                format!("[learning.search]\nsemantic_weight = {weight:.1}\n"),
+            )
+            .expect("write config");
+            with_learning_semantic_override(Ok(semantic.clone()), || {
+                runtime
+                    .global_search(GlobalSearchParams {
+                        query: Some("learningweight".to_string()),
+                        hybrid: true,
+                        kind: GlobalSearchKind::Learning,
+                        limit: 2,
+                        ..Default::default()
+                    })
+                    .expect("learning hybrid search")
+                    .results
+                    .into_iter()
+                    .next()
+                    .expect("top result")
+                    .id
+                    .expect("learning id")
+            })
+        };
+
+        assert_eq!(top_id(0.0), lexical_id);
+        assert_eq!(top_id(1.0), semantic_id);
+        assert_eq!(top_id(0.5), semantic_id);
+    }
+
+    #[test]
+    fn global_search_learning_hybrid_falls_back_to_lexical_on_semantic_error() {
+        let runtime = OrbitRuntime::in_memory().expect("runtime");
+        let id = add_learning(&runtime, "learnfallback error literal");
+
+        let response =
+            with_learning_semantic_override(Err("companion missing".to_string()), || {
+                runtime
+                    .global_search(GlobalSearchParams {
+                        query: Some("learnfallback".to_string()),
+                        hybrid: true,
+                        kind: GlobalSearchKind::Learning,
+                        limit: 3,
+                        ..Default::default()
+                    })
+                    .expect("fallback search")
+            });
+
+        assert!(
+            response
+                .notes
+                .iter()
+                .any(|note| note.contains("falling back to lexical"))
+        );
+        assert_eq!(response.results[0].source, "lexical");
+        assert_eq!(response.results[0].id.as_deref(), Some(id.as_str()));
+    }
+
+    #[test]
+    fn global_search_learning_hybrid_falls_back_when_learning_embeddings_empty() {
+        let runtime = OrbitRuntime::in_memory().expect("runtime");
+        let id = add_learning(&runtime, "learnfallback empty literal");
+
+        let response = with_learning_semantic_override(Ok(Vec::new()), || {
+            runtime
+                .global_search(GlobalSearchParams {
+                    query: Some("learnfallback".to_string()),
+                    hybrid: true,
+                    kind: GlobalSearchKind::Learning,
+                    limit: 3,
+                    ..Default::default()
+                })
+                .expect("fallback search")
+        });
+
+        assert!(
+            response
+                .notes
+                .iter()
+                .any(|note| note.contains("falling back to lexical"))
+        );
+        assert_eq!(response.results[0].source, "lexical");
+        assert_eq!(response.results[0].id.as_deref(), Some(id.as_str()));
+    }
+
+    #[test]
+    fn learning_hybrid_handles_single_candidate_side() {
+        let hit = GlobalSearchHit {
+            kind: "learning".to_string(),
+            source: "hybrid".to_string(),
+            id: Some("L-0001".to_string()),
+            path: None,
+            title: None,
+            summary: None,
+            status: None,
+            best_field: None,
+            snippet: None,
+            score: None,
+            matched_by: None,
+        };
+        let out = blend_learning_hybrid_candidates(
+            vec![LearningHybridCandidate {
                 hit,
                 lexical_score: Some(0.42),
                 semantic_score: None,

--- a/crates/orbit-core/src/command/semantic.rs
+++ b/crates/orbit-core/src/command/semantic.rs
@@ -1,10 +1,10 @@
 use orbit_common::types::OrbitError;
 
 pub use orbit_search::{
-    CompanionStatus, IndexKind, ScoreBreakdown, SemanticHit, SemanticIndexParams,
-    SemanticIndexResult, SemanticInstallParams, SemanticInstallResult, SemanticRelatedParams,
-    SemanticRelatedResult, SemanticSearchParams, SemanticSearchResult, SemanticStatsResult,
-    SemanticUninstallParams, SemanticUninstallResult, TaskIndexResult,
+    CompanionStatus, IndexKind, LearningIndexResult, ScoreBreakdown, SemanticHit,
+    SemanticIndexParams, SemanticIndexResult, SemanticInstallParams, SemanticInstallResult,
+    SemanticRelatedParams, SemanticRelatedResult, SemanticSearchParams, SemanticSearchResult,
+    SemanticStatsResult, SemanticUninstallParams, SemanticUninstallResult, TaskIndexResult,
 };
 
 use crate::OrbitRuntime;
@@ -35,13 +35,22 @@ impl OrbitRuntime {
             IndexKind::Docs => self
                 .semantic_index_docs(params)
                 .map(SemanticIndexResult::from),
+            IndexKind::Learnings => self
+                .semantic_index_learnings(params)
+                .map(SemanticIndexResult::from),
             IndexKind::All => {
                 let tasks = self.semantic_index_tasks(params.clone());
-                let docs = self.semantic_index_docs(params);
-                match (tasks, docs) {
-                    (Ok(tasks), Ok(docs)) => Ok(SemanticIndexResult::All { tasks, docs }),
-                    (Err(error), _) => Err(error),
-                    (_, Err(error)) => Err(error),
+                let docs = self.semantic_index_docs(params.clone());
+                let learnings = self.semantic_index_learnings(params);
+                match (tasks, docs, learnings) {
+                    (Ok(tasks), Ok(docs), Ok(learnings)) => Ok(SemanticIndexResult::All {
+                        tasks,
+                        docs,
+                        learnings,
+                    }),
+                    (Err(error), _, _) => Err(error),
+                    (_, Err(error), _) => Err(error),
+                    (_, _, Err(error)) => Err(error),
                 }
             }
         }
@@ -63,6 +72,25 @@ impl OrbitRuntime {
             model: params.model,
             force: params.force,
         })
+    }
+
+    fn semantic_index_learnings(
+        &self,
+        params: SemanticIndexParams,
+    ) -> Result<LearningIndexResult, OrbitError> {
+        let sources = self
+            .list_learnings(None)?
+            .iter()
+            .map(orbit_search::LearningEmbeddingSource::from)
+            .collect::<Vec<_>>();
+        orbit_search::learning_index(
+            &self.stores().semantic_vector,
+            &sources,
+            orbit_search::LearningIndexParams {
+                model: params.model,
+                force: params.force,
+            },
+        )
     }
 
     pub fn semantic_stats(&self) -> Result<SemanticStatsResult, OrbitError> {

--- a/crates/orbit-search/src/commands/learning_index.rs
+++ b/crates/orbit-search/src/commands/learning_index.rs
@@ -1,0 +1,74 @@
+use orbit_common::types::OrbitError;
+use serde::{Deserialize, Serialize};
+
+use crate::commands::parse_model;
+use crate::vector::{LearningEmbeddingSource, UpsertReport, VectorStore};
+use crate::{Embedder, SubprocessEmbedder};
+
+#[derive(Debug, Clone)]
+pub struct LearningIndexParams {
+    pub model: Option<String>,
+    pub force: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LearningIndexResult {
+    pub model_id: String,
+    pub report: UpsertReport,
+    pub indexed_sources: usize,
+    pub stale_sources: Vec<String>,
+}
+
+pub fn run(
+    vector_store: &VectorStore,
+    learnings: &[LearningEmbeddingSource],
+    params: LearningIndexParams,
+) -> Result<LearningIndexResult, OrbitError> {
+    let model = parse_model(params.model.as_deref())?;
+    let embedder = SubprocessEmbedder::with_model(model.alias)?;
+    run_with_embedder(vector_store, learnings, &embedder, params.force)
+}
+
+pub(crate) fn run_with_embedder(
+    vector_store: &VectorStore,
+    learnings: &[LearningEmbeddingSource],
+    embedder: &dyn Embedder,
+    force: bool,
+) -> Result<LearningIndexResult, OrbitError> {
+    let report = vector_store.reindex_learnings(learnings, embedder, force)?;
+    Ok(LearningIndexResult {
+        model_id: embedder.model_id().to_string(),
+        report: report.upsert,
+        indexed_sources: report.indexed_sources,
+        stale_sources: report.stale_sources,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::NoopEmbedder;
+
+    fn learning(id: &str, summary: &str) -> LearningEmbeddingSource {
+        LearningEmbeddingSource {
+            id: id.to_string(),
+            summary: summary.to_string(),
+            body: "same body".to_string(),
+            tags: vec!["search".to_string()],
+        }
+    }
+
+    #[test]
+    fn learning_index_is_idempotent_by_content_hash() {
+        let store = VectorStore::open_in_memory().unwrap();
+        let embedder = NoopEmbedder::small();
+        let learnings = vec![learning("L-0001", "same summary")];
+
+        let first = run_with_embedder(&store, &learnings, &embedder, false).unwrap();
+        let second = run_with_embedder(&store, &learnings, &embedder, false).unwrap();
+
+        assert!(first.report.embedded_chunks > 0);
+        assert_eq!(second.report.embedded_chunks, 0);
+        assert!(second.report.skipped_fields > 0);
+    }
+}

--- a/crates/orbit-search/src/commands/learning_search.rs
+++ b/crates/orbit-search/src/commands/learning_search.rs
@@ -1,0 +1,245 @@
+use std::collections::BTreeMap;
+
+use orbit_common::types::OrbitError;
+use serde::{Deserialize, Serialize};
+
+use crate::commands::resolve_query_model;
+use crate::vector::VectorStore;
+use crate::vector::query::{CosineHit, cosine_top_k, snippet_for_hit};
+use crate::vector::store::SOURCE_KIND_LEARNING;
+use crate::{Embedder, SubprocessEmbedder};
+
+const DEFAULT_LIMIT: usize = 10;
+const RETRIEVER_OVERFETCH: usize = 4;
+const SNIPPET_MAX_CHARS: usize = 280;
+
+#[derive(Debug, Clone)]
+pub struct LearningSemanticSearchParams {
+    pub query: String,
+    pub limit: usize,
+    pub model: Option<String>,
+}
+
+impl LearningSemanticSearchParams {
+    pub fn normalized_limit(&self) -> usize {
+        if self.limit == 0 {
+            DEFAULT_LIMIT
+        } else {
+            self.limit
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct LearningSemanticSearchResult {
+    pub results: Vec<LearningSemanticHit>,
+    pub model_id: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct LearningSemanticHit {
+    pub source_id: String,
+    pub best_field: String,
+    pub snippet: String,
+    pub score: f32,
+}
+
+pub fn run(
+    vector_store: &VectorStore,
+    params: LearningSemanticSearchParams,
+) -> Result<LearningSemanticSearchResult, OrbitError> {
+    let model = resolve_query_model(params.model.as_deref())?;
+    let embedder = SubprocessEmbedder::with_model(model.alias)?;
+    run_with_embedder(vector_store, &embedder, params)
+}
+
+pub(crate) fn run_with_embedder(
+    vector_store: &VectorStore,
+    embedder: &dyn Embedder,
+    params: LearningSemanticSearchParams,
+) -> Result<LearningSemanticSearchResult, OrbitError> {
+    let query = params.query.trim();
+    if query.is_empty() {
+        return Err(OrbitError::InvalidInput(
+            "learning semantic search query must not be empty".to_string(),
+        ));
+    }
+
+    let vectors = embedder.embed(&[query])?;
+    let query_vector = vectors.into_iter().next().ok_or_else(|| {
+        OrbitError::Execution(
+            "embedder returned no vector for learning semantic search".to_string(),
+        )
+    })?;
+    let limit = params.normalized_limit();
+    let retriever_limit = limit.saturating_mul(RETRIEVER_OVERFETCH).max(limit);
+    let model_id = embedder.model_id().to_string();
+    let cosine = cosine_top_k(
+        vector_store,
+        &query_vector,
+        &model_id,
+        retriever_limit,
+        Some(SOURCE_KIND_LEARNING),
+    )?;
+    let hits = rollup_learning_hits(vector_store, cosine, limit)?;
+
+    Ok(LearningSemanticSearchResult {
+        results: hits,
+        model_id,
+    })
+}
+
+fn rollup_learning_hits(
+    vector_store: &VectorStore,
+    hits: Vec<CosineHit>,
+    limit: usize,
+) -> Result<Vec<LearningSemanticHit>, OrbitError> {
+    let mut best = BTreeMap::<String, CosineHit>::new();
+    for hit in hits {
+        best.entry(hit.source_id.clone())
+            .and_modify(|current| {
+                if crate::vector::query::cosine::compare_cosine_hits(&hit, current).is_lt() {
+                    *current = hit.clone();
+                }
+            })
+            .or_insert(hit);
+    }
+
+    let mut rolled = Vec::new();
+    for hit in best.into_values() {
+        let snippet = snippet_for_hit(
+            vector_store,
+            SOURCE_KIND_LEARNING,
+            &hit.source_id,
+            &hit.field,
+            Some(hit.chunk_idx),
+            None,
+        )?
+        .unwrap_or_default();
+        rolled.push(LearningSemanticHit {
+            source_id: hit.source_id,
+            best_field: hit.field,
+            snippet: truncate_snippet(&snippet),
+            score: hit.score,
+        });
+    }
+    rolled.sort_by(compare_learning_semantic_hits);
+    rolled.truncate(limit);
+    Ok(rolled)
+}
+
+fn compare_learning_semantic_hits(
+    left: &LearningSemanticHit,
+    right: &LearningSemanticHit,
+) -> std::cmp::Ordering {
+    right
+        .score
+        .total_cmp(&left.score)
+        .then_with(|| left.source_id.cmp(&right.source_id))
+        .then_with(|| left.best_field.cmp(&right.best_field))
+}
+
+fn truncate_snippet(snippet: &str) -> String {
+    let trimmed = snippet.trim();
+    let mut end = 0;
+    for (idx, ch) in trimmed.char_indices() {
+        if idx > SNIPPET_MAX_CHARS {
+            break;
+        }
+        end = idx + ch.len_utf8();
+    }
+    if end >= trimmed.len() {
+        trimmed.to_string()
+    } else {
+        format!("{}...", trimmed[..end].trim_end())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use orbit_common::types::OrbitError;
+
+    use super::*;
+    use crate::vector::LearningEmbeddingSource;
+    use crate::{Embedder, NoopEmbedder};
+
+    struct KeywordEmbedder;
+
+    impl Embedder for KeywordEmbedder {
+        fn model_id(&self) -> &str {
+            "keyword"
+        }
+
+        fn dim(&self) -> usize {
+            2
+        }
+
+        fn max_input_tokens(&self) -> usize {
+            512
+        }
+
+        fn embed(&self, texts: &[&str]) -> Result<Vec<Vec<f32>>, OrbitError> {
+            Ok(texts
+                .iter()
+                .map(|text| {
+                    if text.to_ascii_lowercase().contains("concept") {
+                        vec![1.0, 0.0]
+                    } else {
+                        vec![0.0, 1.0]
+                    }
+                })
+                .collect())
+        }
+
+        fn token_count(&self, text: &str) -> Result<usize, OrbitError> {
+            Ok(text.split_whitespace().count().max(1))
+        }
+    }
+
+    fn learning(id: &str, body: &str) -> LearningEmbeddingSource {
+        LearningEmbeddingSource {
+            id: id.to_string(),
+            summary: id.to_string(),
+            body: body.to_string(),
+            tags: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn learning_semantic_search_filters_to_learning_rows() {
+        let store = VectorStore::open_in_memory().unwrap();
+        let learning_embedder = KeywordEmbedder;
+        store
+            .reindex_learnings(
+                &[
+                    learning("L-0001", "concept match"),
+                    learning("L-0002", "other body"),
+                ],
+                &learning_embedder,
+                false,
+            )
+            .unwrap();
+        store
+            .upsert_embeddings(
+                "task",
+                "ORB-00000",
+                &[crate::vector::EmbeddingField::new("title", "concept task")],
+                &NoopEmbedder::small(),
+                false,
+            )
+            .unwrap();
+
+        let result = run_with_embedder(
+            &store,
+            &learning_embedder,
+            LearningSemanticSearchParams {
+                query: "concept".to_string(),
+                limit: 1,
+                model: None,
+            },
+        )
+        .unwrap();
+
+        assert_eq!(result.results[0].source_id, "L-0001");
+    }
+}

--- a/crates/orbit-search/src/commands/mod.rs
+++ b/crates/orbit-search/src/commands/mod.rs
@@ -8,6 +8,8 @@
 mod doc_index;
 mod doc_search;
 mod install;
+mod learning_index;
+mod learning_search;
 mod reindex;
 mod related;
 mod search;
@@ -17,6 +19,10 @@ mod uninstall;
 pub use doc_index::{DocIndexParams, DocIndexResult};
 pub use doc_search::{DocSemanticHit, DocSemanticSearchParams, DocSemanticSearchResult};
 pub use install::{SemanticInstallParams, SemanticInstallResult};
+pub use learning_index::{LearningIndexParams, LearningIndexResult};
+pub use learning_search::{
+    LearningSemanticHit, LearningSemanticSearchParams, LearningSemanticSearchResult,
+};
 pub use reindex::{
     IndexKind, SemanticIndexParams, SemanticIndexResult, SemanticReindexParams,
     SemanticReindexResult, TaskIndexResult,
@@ -30,7 +36,7 @@ use std::fs;
 
 use orbit_common::types::{OrbitError, Task};
 
-use crate::vector::{DocEmbeddingSource, VectorStore};
+use crate::vector::{DocEmbeddingSource, LearningEmbeddingSource, VectorStore};
 use crate::{CompanionPaths, ModelSpec, default_model};
 
 pub(crate) const DEFAULT_RELEASE_BASE_URL: &str =
@@ -105,6 +111,14 @@ pub fn doc_index(
     doc_index::run(vector_store, docs, params)
 }
 
+pub fn learning_index(
+    vector_store: &VectorStore,
+    learnings: &[LearningEmbeddingSource],
+    params: LearningIndexParams,
+) -> Result<LearningIndexResult, OrbitError> {
+    learning_index::run(vector_store, learnings, params)
+}
+
 pub fn semantic_stats(
     vector_store: &VectorStore,
     task_ids: &[String],
@@ -124,6 +138,13 @@ pub fn doc_semantic_search(
     params: DocSemanticSearchParams,
 ) -> Result<DocSemanticSearchResult, OrbitError> {
     doc_search::run(vector_store, params)
+}
+
+pub fn learning_semantic_search(
+    vector_store: &VectorStore,
+    params: LearningSemanticSearchParams,
+) -> Result<LearningSemanticSearchResult, OrbitError> {
+    learning_search::run(vector_store, params)
 }
 
 pub fn semantic_related(

--- a/crates/orbit-search/src/commands/reindex.rs
+++ b/crates/orbit-search/src/commands/reindex.rs
@@ -3,6 +3,7 @@ use serde::{Deserialize, Serialize};
 use std::str::FromStr;
 
 use crate::commands::doc_index::DocIndexResult;
+use crate::commands::learning_index::LearningIndexResult;
 use crate::commands::parse_model;
 use crate::vector::{UpsertReport, VectorStore};
 use crate::{Embedder, SubprocessEmbedder};
@@ -12,6 +13,7 @@ use crate::{Embedder, SubprocessEmbedder};
 pub enum IndexKind {
     Tasks,
     Docs,
+    Learnings,
     All,
 }
 
@@ -28,9 +30,10 @@ impl FromStr for IndexKind {
         match raw {
             "tasks" => Ok(Self::Tasks),
             "docs" => Ok(Self::Docs),
+            "learnings" => Ok(Self::Learnings),
             "all" => Ok(Self::All),
             value => Err(OrbitError::InvalidInput(format!(
-                "unsupported semantic index kind `{value}`; supported values: tasks, docs, all"
+                "unsupported semantic index kind `{value}`; supported values: tasks, docs, learnings, all"
             ))),
         }
     }
@@ -79,9 +82,16 @@ pub enum SemanticIndexResult {
         indexed_sources: usize,
         stale_sources: Vec<String>,
     },
+    Learnings {
+        model_id: String,
+        report: UpsertReport,
+        indexed_sources: usize,
+        stale_sources: Vec<String>,
+    },
     All {
         tasks: TaskIndexResult,
         docs: DocIndexResult,
+        learnings: LearningIndexResult,
     },
 }
 
@@ -97,6 +107,17 @@ impl From<TaskIndexResult> for SemanticIndexResult {
 impl From<DocIndexResult> for SemanticIndexResult {
     fn from(result: DocIndexResult) -> Self {
         Self::Docs {
+            model_id: result.model_id,
+            report: result.report,
+            indexed_sources: result.indexed_sources,
+            stale_sources: result.stale_sources,
+        }
+    }
+}
+
+impl From<LearningIndexResult> for SemanticIndexResult {
+    fn from(result: LearningIndexResult) -> Self {
+        Self::Learnings {
             model_id: result.model_id,
             report: result.report,
             indexed_sources: result.indexed_sources,
@@ -144,9 +165,22 @@ mod tests {
         assert_eq!(docs.kind, Some(IndexKind::Docs));
         assert_eq!(docs.resolved_kind(), IndexKind::Docs);
 
+        let learnings: SemanticIndexParams =
+            serde_json::from_str(r#"{"kind":"learnings"}"#).unwrap();
+        assert_eq!(learnings.kind, Some(IndexKind::Learnings));
+        assert_eq!(learnings.resolved_kind(), IndexKind::Learnings);
+
         let all: SemanticIndexParams = serde_json::from_str(r#"{"kind":"all"}"#).unwrap();
         assert_eq!(all.kind, Some(IndexKind::All));
         assert_eq!(all.resolved_kind(), IndexKind::All);
+    }
+
+    #[test]
+    fn semantic_index_kind_rejects_singular_learning() {
+        let error = IndexKind::from_str("learning").expect_err("singular kind should fail");
+
+        assert!(error.to_string().contains("`learning`"));
+        assert!(error.to_string().contains("learnings"));
     }
 
     #[test]

--- a/crates/orbit-search/src/lib.rs
+++ b/crates/orbit-search/src/lib.rs
@@ -37,12 +37,15 @@ mod vector;
 
 pub use commands::{
     CompanionStatus, DocIndexParams, DocIndexResult, DocSemanticHit, DocSemanticSearchParams,
-    DocSemanticSearchResult, IndexKind, ScoreBreakdown, SemanticHit, SemanticIndexParams,
-    SemanticIndexResult, SemanticInstallParams, SemanticInstallResult, SemanticReindexParams,
-    SemanticReindexResult, SemanticRelatedParams, SemanticRelatedResult, SemanticSearchParams,
-    SemanticSearchResult, SemanticStatsResult, SemanticUninstallParams, SemanticUninstallResult,
-    TaskIndexResult, doc_index, doc_semantic_search, semantic_index, semantic_install,
-    semantic_reindex, semantic_related, semantic_search, semantic_stats, semantic_uninstall,
+    DocSemanticSearchResult, IndexKind, LearningIndexParams, LearningIndexResult,
+    LearningSemanticHit, LearningSemanticSearchParams, LearningSemanticSearchResult,
+    ScoreBreakdown, SemanticHit, SemanticIndexParams, SemanticIndexResult, SemanticInstallParams,
+    SemanticInstallResult, SemanticReindexParams, SemanticReindexResult, SemanticRelatedParams,
+    SemanticRelatedResult, SemanticSearchParams, SemanticSearchResult, SemanticStatsResult,
+    SemanticUninstallParams, SemanticUninstallResult, TaskIndexResult, doc_index,
+    doc_semantic_search, learning_index, learning_semantic_search, semantic_index,
+    semantic_install, semantic_reindex, semantic_related, semantic_search, semantic_stats,
+    semantic_uninstall,
 };
 pub use companion::{
     CompanionPaths, INSTALL_REMEDIATION, locate_companion, platform_companion_filename, platform_id,
@@ -56,6 +59,6 @@ pub use noop::NoopEmbedder;
 pub use rpc::{RpcError, RpcRequest, RpcResponse, RpcResult};
 pub use subprocess::SubprocessEmbedder;
 pub use vector::{
-    DocEmbeddingSource, EmbedWorker, SOURCE_KIND_DOC, SOURCE_KIND_TASK, SemanticStats,
-    UpsertReport, VectorStore,
+    DocEmbeddingSource, EmbedWorker, LearningEmbeddingSource, SOURCE_KIND_DOC,
+    SOURCE_KIND_LEARNING, SOURCE_KIND_TASK, SemanticStats, UpsertReport, VectorStore,
 };

--- a/crates/orbit-search/src/vector/learning_fields.rs
+++ b/crates/orbit-search/src/vector/learning_fields.rs
@@ -1,0 +1,136 @@
+//! Maps a project-learning record to the per-field rows embedded for learning search.
+
+use super::EmbeddingField;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LearningEmbeddingSource {
+    pub id: String,
+    pub summary: String,
+    pub body: String,
+    pub tags: Vec<String>,
+}
+
+impl From<&orbit_common::types::Learning> for LearningEmbeddingSource {
+    fn from(learning: &orbit_common::types::Learning) -> Self {
+        Self {
+            id: learning.id.clone(),
+            summary: learning.summary.clone(),
+            body: learning.body.clone(),
+            tags: learning.scope.tags.clone(),
+        }
+    }
+}
+
+pub fn learning_embedding_fields(learning: &LearningEmbeddingSource) -> Vec<EmbeddingField> {
+    let mut fields = Vec::new();
+    push_field(&mut fields, "summary", &learning.summary);
+
+    let mut section_count = 0;
+    if let Some(rule) = markdown_section(&learning.body, "rule") {
+        push_field(&mut fields, "rule", &rule);
+        section_count += 1;
+    }
+    if let Some(why) = markdown_section(&learning.body, "why") {
+        push_field(&mut fields, "why", &why);
+        section_count += 1;
+    }
+    if let Some(how_to_apply) = markdown_section(&learning.body, "how to apply") {
+        push_field(&mut fields, "how_to_apply", &how_to_apply);
+        section_count += 1;
+    }
+    if section_count == 0 {
+        push_field(&mut fields, "details", &learning.body);
+    }
+    if !learning.tags.is_empty() {
+        push_field(&mut fields, "tags", &learning.tags.join("\n"));
+    }
+    fields
+}
+
+fn push_field(fields: &mut Vec<EmbeddingField>, field: impl Into<String>, text: &str) {
+    if !text.trim().is_empty() {
+        fields.push(EmbeddingField::new(field, text.trim().to_string()));
+    }
+}
+
+fn markdown_section(body: &str, wanted: &str) -> Option<String> {
+    let mut active = false;
+    let mut lines = Vec::new();
+    for line in body.lines() {
+        if let Some(title) = markdown_heading_title(line) {
+            if active {
+                break;
+            }
+            active = normalize_heading(title) == normalize_heading(wanted);
+            continue;
+        }
+        if active {
+            lines.push(line);
+        }
+    }
+    let section = lines.join("\n");
+    if section.trim().is_empty() {
+        None
+    } else {
+        Some(section.trim().to_string())
+    }
+}
+
+fn markdown_heading_title(line: &str) -> Option<&str> {
+    let trimmed = line.trim_start();
+    let hashes = trimmed.chars().take_while(|ch| *ch == '#').count();
+    if hashes == 0 || hashes > 6 {
+        return None;
+    }
+    let rest = &trimmed[hashes..];
+    if !rest.starts_with(' ') {
+        return None;
+    }
+    Some(rest.trim())
+}
+
+fn normalize_heading(value: &str) -> String {
+    value.trim().to_ascii_lowercase().replace('-', " ")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn learning_embedding_fields_use_stable_section_names() {
+        let source = LearningEmbeddingSource {
+            id: "L-0001".to_string(),
+            summary: "Use async-aware locks".to_string(),
+            body: "## Rule\nNever hold std Mutex across await.\n\n## Why\nIt can deadlock.\n\n## How to apply\nDrop the guard before await.\n".to_string(),
+            tags: vec!["rust".to_string(), "async".to_string()],
+        };
+
+        let field_names = learning_embedding_fields(&source)
+            .into_iter()
+            .map(|field| field.field)
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            field_names,
+            vec!["summary", "rule", "why", "how_to_apply", "tags"]
+        );
+    }
+
+    #[test]
+    fn learning_embedding_fields_fallback_to_details_for_plain_body() {
+        let source = LearningEmbeddingSource {
+            id: "L-0002".to_string(),
+            summary: "Keep fixtures tracked".to_string(),
+            body: "Avoid .orbit fixture paths.".to_string(),
+            tags: Vec::new(),
+        };
+
+        let field_names = learning_embedding_fields(&source)
+            .into_iter()
+            .map(|field| field.field)
+            .collect::<Vec<_>>();
+
+        assert_eq!(field_names, vec!["summary", "details"]);
+    }
+}

--- a/crates/orbit-search/src/vector/mod.rs
+++ b/crates/orbit-search/src/vector/mod.rs
@@ -12,6 +12,8 @@
 //!   `Task`.
 //! - [`doc_fields`] — extracts the per-field rows that get embedded for a
 //!   docs corpus record.
+//! - [`learning_fields`] — extracts the per-field rows that get embedded for
+//!   project-learning records.
 //!
 //! This file holds the small data types (`EmbeddingField`, `UpsertReport`,
 //! `SemanticStats`, `SourceModelCount`) and stateless helpers
@@ -20,13 +22,15 @@
 
 pub(crate) mod chunker;
 pub(crate) mod doc_fields;
+pub(crate) mod learning_fields;
 pub(crate) mod query;
 pub(crate) mod store;
 pub(crate) mod task_fields;
 pub(crate) mod worker;
 
 pub use doc_fields::DocEmbeddingSource;
-pub use store::{SOURCE_KIND_DOC, SOURCE_KIND_TASK, VectorStore};
+pub use learning_fields::LearningEmbeddingSource;
+pub use store::{SOURCE_KIND_DOC, SOURCE_KIND_LEARNING, SOURCE_KIND_TASK, VectorStore};
 pub use worker::EmbedWorker;
 
 use orbit_common::types::OrbitError;

--- a/crates/orbit-search/src/vector/store/learning.rs
+++ b/crates/orbit-search/src/vector/store/learning.rs
@@ -1,0 +1,117 @@
+//! Project-learning corpus indexing entry points.
+
+use std::collections::BTreeSet;
+
+use orbit_common::types::OrbitError;
+
+use super::{SOURCE_KIND_LEARNING, VectorStore};
+use crate::Embedder;
+use crate::vector::UpsertReport;
+use crate::vector::learning_fields::{LearningEmbeddingSource, learning_embedding_fields};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LearningReindexReport {
+    pub upsert: UpsertReport,
+    pub indexed_sources: usize,
+    pub stale_sources: Vec<String>,
+}
+
+impl VectorStore {
+    pub fn index_learning(
+        &self,
+        learning: &LearningEmbeddingSource,
+        embedder: &dyn Embedder,
+        force: bool,
+    ) -> Result<UpsertReport, OrbitError> {
+        self.upsert_embeddings(
+            SOURCE_KIND_LEARNING,
+            &learning.id,
+            &learning_embedding_fields(learning),
+            embedder,
+            force,
+        )
+    }
+
+    pub fn reindex_learnings(
+        &self,
+        learnings: &[LearningEmbeddingSource],
+        embedder: &dyn Embedder,
+        force: bool,
+    ) -> Result<LearningReindexReport, OrbitError> {
+        let mut upsert = UpsertReport::default();
+        let live = learnings
+            .iter()
+            .map(|learning| learning.id.clone())
+            .collect::<BTreeSet<_>>();
+        for learning in learnings {
+            let report = self.index_learning(learning, embedder, force)?;
+            upsert.embedded_chunks += report.embedded_chunks;
+            upsert.skipped_fields += report.skipped_fields;
+        }
+
+        let mut stale_sources = Vec::new();
+        for source_id in self.source_ids(SOURCE_KIND_LEARNING)? {
+            if !live.contains(&source_id) {
+                self.delete_source(SOURCE_KIND_LEARNING, &source_id)?;
+                stale_sources.push(source_id);
+            }
+        }
+        Ok(LearningReindexReport {
+            upsert,
+            indexed_sources: live.len(),
+            stale_sources,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::NoopEmbedder;
+
+    fn learning(id: &str, summary: &str) -> LearningEmbeddingSource {
+        LearningEmbeddingSource {
+            id: id.to_string(),
+            summary: summary.to_string(),
+            body: "## Why\nConcept retrieval matters.\n\n## How to apply\nSearch by intent.\n"
+                .to_string(),
+            tags: vec!["search".to_string()],
+        }
+    }
+
+    #[test]
+    fn noop_learning_indexing_populates_learning_rows() {
+        let store = VectorStore::open_in_memory().unwrap();
+        let embedder = NoopEmbedder::small();
+
+        let report = store
+            .index_learning(
+                &learning("L-0001", "semantic learning body"),
+                &embedder,
+                false,
+            )
+            .unwrap();
+        let stats = store.stats(&[]).unwrap();
+
+        assert!(report.embedded_chunks >= 3);
+        assert_eq!(stats.counts[0].source_kind, "learning");
+        assert_eq!(stats.counts[0].model_id, "noop");
+    }
+
+    #[test]
+    fn reindex_learnings_removes_stale_sources() {
+        let store = VectorStore::open_in_memory().unwrap();
+        let embedder = NoopEmbedder::small();
+        store
+            .index_learning(&learning("L-0001", "old learning"), &embedder, false)
+            .unwrap();
+
+        let report = store
+            .reindex_learnings(&[learning("L-0002", "new learning")], &embedder, false)
+            .unwrap();
+        let source_ids = store.source_ids(SOURCE_KIND_LEARNING).unwrap();
+
+        assert_eq!(report.stale_sources, vec!["L-0001"]);
+        assert_eq!(source_ids.into_iter().collect::<Vec<_>>(), vec!["L-0002"]);
+    }
+}

--- a/crates/orbit-search/src/vector/store/mod.rs
+++ b/crates/orbit-search/src/vector/store/mod.rs
@@ -7,6 +7,8 @@
 //!   plus its private SQL helpers (`delete_field_rows`, content-hash check).
 //! - [`tasks`] — `index_task` / `reindex_tasks` task-corpus entry points.
 //! - [`docs`] — `index_doc` / `reindex_docs` docs-corpus entry points.
+//! - [`learning`] — `index_learning` / `reindex_learnings` project-learning
+//!   corpus entry points.
 //! - [`queries`] — `delete_source` and `stats` read/cascade operations.
 //!
 //! This file owns the `VectorStore` struct itself plus the connection-handle
@@ -14,6 +16,7 @@
 //! and the small `pub(super)` constants shared across the submodules above.
 
 mod docs;
+mod learning;
 mod queries;
 mod schema;
 mod tasks;
@@ -28,6 +31,7 @@ use rusqlite::Connection;
 pub const SOURCE_KIND_TASK: &str = "task";
 // ADR-0180: docs share the embeddings table through source_kind, not a separate schema.
 pub const SOURCE_KIND_DOC: &str = "doc";
+pub const SOURCE_KIND_LEARNING: &str = "learning";
 
 #[derive(Clone)]
 pub struct VectorStore {

--- a/crates/orbit-tools/src/builtin/orbit/search.rs
+++ b/crates/orbit-tools/src/builtin/orbit/search.rs
@@ -19,7 +19,7 @@ impl Tool for OrbitSearchTool {
                 // ADR-0179: expose the free-text vector ranker as hybrid, not semantic.
                 name: "hybrid".to_string(),
                 description:
-                    "Opt into hybrid lexical + cosine ranking for indexed task and doc vectors; learnings and ADRs remain lexical."
+                    "Opt into hybrid lexical + cosine ranking for indexed task, doc, and learning vectors; ADRs remain lexical."
                         .to_string(),
                 param_type: "boolean".to_string(),
                 required: false,
@@ -83,7 +83,7 @@ impl Tool for OrbitSearchTool {
         ToolSchema {
             name: "orbit.search".to_string(),
             description:
-                "Search tasks, docs, learnings, and ADRs. Hybrid vector ranking applies to indexed tasks and docs."
+                "Search tasks, docs, learnings, and ADRs. Hybrid vector ranking applies to indexed tasks, docs, and learnings."
                     .to_string(),
             parameters,
             builtin: true,

--- a/crates/orbit-tools/src/builtin/orbit/semantic/index.rs
+++ b/crates/orbit-tools/src/builtin/orbit/semantic/index.rs
@@ -10,7 +10,7 @@ impl Tool for OrbitSemanticIndexTool {
         ToolSchema {
             name: "orbit.semantic.index".to_string(),
             description:
-                "Rebuild semantic embeddings for tasks, docs, or both in the active workspace."
+                "Rebuild semantic embeddings for tasks, docs, learnings, or all indexed corpora in the active workspace."
                     .to_string(),
             parameters: vec![
                 ToolParam {
@@ -28,7 +28,8 @@ impl Tool for OrbitSemanticIndexTool {
                 },
                 ToolParam {
                     name: "kind".to_string(),
-                    description: "Corpus to rebuild: tasks (default), docs, or all.".to_string(),
+                    description: "Corpus to rebuild: tasks (default), docs, learnings, or all."
+                        .to_string(),
                     param_type: "string".to_string(),
                     required: false,
                 },


### PR DESCRIPTION
## Task

[ORB-00217](https://orbit-cli.com/tasks/ORB-00217) — Add learning-corpus embeddings: `orbit semantic index --kind learnings` + hybrid scoring for `--kind learning`

### Description

## Problem

Learnings are lexical-only today. The `orbit search` help footer confirms it: *"Index coverage note: learnings and ADRs use lexical matching regardless of --hybrid."* `orbit semantic index --kind` accepts only `tasks`, `docs`, `all` (ORB-00207). `--kind learning` on the search side silently runs lexical-only when `--hybrid` is set.

The substrate is ready (`source_kind="learning"` is a free addition); no code populates it.

## Why It Matters

- Learnings are short, dense, scoped rules. Concept retrieval matters because learnings often describe *patterns* ("don't hold a std Mutex across .await") whose retrieval-time queries ("can I lock during async work?") rarely contain the exact rule's vocabulary.
- Push-injection quality depends on learning retrieval. Better ranking → fewer irrelevant rules pushed into agent context → less system-reminder budget waste.
- Pattern is established by ORB-00206 (docs) and ORB-00207 (dispatcher). Smallest follow-on of the four corpora.

## Latest decisions

- **Index everything.** Index all learnings regardless of status (active / superseded). Query-side `--all` and `--status learning:active` continue to decide what surfaces. Mirrors ORB-00206's stance.
- **Indexer entry: `orbit semantic index --kind learnings`** (plural, matching the existing `tasks`/`docs`/`all` enum). Clap rejects `--kind learning` from the indexer — singular form belongs to `orbit search --kind learning`.
- **No corpus-local indexer verb.** Do not add `orbit learning index`. Learnings have a corpus-local verb tree (`orbit learning {add, list, show, supersede, prune}`) but the index belongs at `orbit semantic`, consistent with the principle ORB-00207 anchored on.
- **Hybrid in the per-kind query path.** `orbit search foo --kind learning --hybrid` blends learning lexical scoring with cosine over `source_kind="learning"`. No cross-kind federation to worry about (unlike ADRs).
- **Fallback when companion missing OR no learning embeddings exist.** `--hybrid` with `--kind learning` silently degrades to lexical with a single `tracing::warn!` + stderr note via the `push_skip_note` helper (ORB-00209). Does not error. `orbit semantic index --kind learnings` itself errors when companion is missing (admin verb, opt-in).
- **Hybrid weight config.** Add `[learning.search] semantic_weight = 0.5` to `.orbit/config.toml` parsing (mirror the `[docs.search]` shape). Default 0.5, clamp to [0.0, 1.0]. Same hybrid math as docs: min-max normalize per side, pass through unscaled when one side has fewer than 2 candidates.
- **Stale-source sweep.** After indexing, diff `SELECT DISTINCT source_id FROM embeddings WHERE source_kind="learning"` against the live learning set, `delete_source("learning", stale)` for each removed learning id. Idempotent via existing `content_hash` skip.
- **Embedding fields.** Suggested: `rule`/`summary`, `why`, `how_to_apply`, `tags` (joined). Avoid embedding `scope.paths` glob strings as content (paths are filter inputs, not retrieval text). Avoid embedding `evidence` blocks (long, often code-quoted, noisy). Field names participate in the content-hash idempotency key — pick once and don't churn.

## Constraints / Notes

- **Help-text footer update.** Drop learnings from the `orbit search` `after_help` footer. If the ADR-embeddings task lands first, the resulting footer becomes empty — remove the line entirely. If this lands first, the footer becomes *"ADRs use lexical matching regardless of --hybrid."*
- **Mirror ORB-00206 patterns exactly.** New `SOURCE_KIND_LEARNING` constant, new `learning_fields.rs`, new `LearningEmbeddingSource` projection struct in orbit-search to avoid a `orbit-search → orbit-core` dep edge, new index-side module under `crates/orbit-search/src/commands/`.
- **No new cross-crate edges.** `cargo metadata` check that `orbit-search` does not gain `orbit-core` as a dependency.
- **Coexists with the ADR embeddings task.** Both extend the ORB-00207 dispatcher by one variant and follow the same shape; they can land in either order. If both land, only the first to merge needs to update the index dispatcher tests for the new variant pattern; the second inherits.
- **Coexists with ORB-00209.** Reuse the `push_skip_note` helper for the lexical-fallback warning.

## Out of Scope

- ADR embeddings (separate task — files concurrently with this one).
- Making `--hybrid` the default for any kind.
- Embedding learning `evidence` blocks (they're code-heavy and noisy).
- Embedding learning `scope.paths` (filter-side, not retrieval-side data).
- Adding `orbit learning index` as a corpus-local alias.
- Changing learning lifecycle filtering at query time (existing `--all` + `--status learning:active` flow unchanged).
- Updating the push-injection ranker to use the new embeddings (separate task if/when push-injection is rewired to use hybrid scoring).

## Pointers

- Substrate: `crates/orbit-search/src/vector/store/mod.rs` (`SOURCE_KIND_TASK`/`SOURCE_KIND_DOC`/`SOURCE_KIND_ADR` if the ADR task lands first; add `SOURCE_KIND_LEARNING`).
- Field-shape mirror: `crates/orbit-search/src/vector/doc_fields.rs` (added by ORB-00206) → new `learning_fields.rs`.
- Build entry mirror: `crates/orbit-search/src/commands/` (look for the docs-side sibling added by ORB-00206) → new learning sibling.
- Cosine reuse: `crates/orbit-search/src/vector/query/cosine.rs` already kind-filtered.
- Index dispatcher: `crates/orbit-core/src/command/semantic.rs` → add `Learnings` variant.
- Learning lexical scoring: `crates/orbit-store/src/file/learning_store/api/search_index.rs` (or whatever the current entry is).
- Search runtime: `crates/orbit-core/src/command/search.rs::OrbitRuntime::global_search` (the `learning_branch` helper).
- CLI surfaces: `crates/orbit-cli/src/command/semantic.rs` (`SemanticIndexArgs` `--kind` enum), `crates/orbit-cli/src/command/search.rs` (`after_help` footer).
- Config: mirror `[docs.search]` parsing as `[learning.search]`.
- Skill that documents the surface: `crates/orbit-core/assets/skills/orbit-learning/SKILL.md`.
- Prior context: ORB-00192 (orbit-embed → orbit-search rename), ORB-00202 (search consolidation), ORB-00206 (doc embeddings — copy this), ORB-00207 (index dispatcher — extend this), ORB-00209 (skip-note helper — reuse this).

### Acceptance Criteria

- `orbit semantic index --kind learnings` exists and is listed as a valid value in `orbit semantic index --help` alongside `tasks`, `docs`, `all`.
- Running `orbit semantic index --kind learnings` on this repo populates `source_kind="learning"` rows in `.orbit/state/semantic.db` — verified by `sqlite3 .orbit/state/semantic.db "SELECT COUNT(*) FROM embeddings WHERE source_kind='learning'"` returning a value greater than the count of learnings under `.orbit/learnings/`.
- Running `orbit semantic index --kind learnings` a second time on an unchanged corpus reports `embedded_chunks == 0` and `skipped_fields > 0` (idempotency).
- Superseding a learning and re-running `orbit semantic index --kind learnings` does NOT delete its row — superseded learnings remain indexed (indexer is status-agnostic). Verified by integration test.
- Deleting a learning entirely and re-running the indexer removes its row from `embeddings WHERE source_kind="learning"` (stale-source sweep). Verified by integration test.
- `orbit search foo --kind learning --hybrid --json` returns a ranking that differs from `orbit search foo --kind learning --json` (lexical-only) on a fixture set where the top semantic match does not contain the literal query phrase — verified by integration test asserting `results[0].id` differs between the two modes.
- `orbit search foo --kind learning --json` (no `--hybrid`) returns byte-identical results to today's lexical-only behavior — verified by snapshot test against a pre-change fixture.
- `orbit search foo --kind learning --hybrid` with the companion uninstalled emits a stderr note via the `push_skip_note` helper (ORB-00209) containing the phrase `falling back to lexical` and returns lexical results without erroring.
- `orbit search foo --kind learning --hybrid` with the companion installed but `embeddings WHERE source_kind="learning"` empty emits the same fallback warning and returns lexical results without erroring.
- `[learning.search] semantic_weight = 0.7` in `.orbit/config.toml` is honored by hybrid scoring — verified by integration test comparing rankings at `0.0` vs `1.0` vs `0.5`.
- Hybrid handles single-candidate sides without score collapse (mirror the docs-side test pattern).
- `orbit search` `after_help` footer no longer claims learnings are lexical-only. If ADRs are still lexical-only at merge time, the footer reads *"ADRs use lexical matching regardless of --hybrid."*; if ADRs have already converged, drop the line entirely.
- No new cross-crate dependency edge: `cargo metadata --format-version 1 | jq -e '.packages[]|select(.name=="orbit-search").dependencies[]|select(.name=="orbit-core")|halt_error(1)'` exits 0.
- `tasks_fts` schema is unchanged: `rg -n 'tasks_fts' crates/orbit-search/src/vector/store/` returns only pre-existing references.
- `orbit-learning` skill (`crates/orbit-core/assets/skills/orbit-learning/SKILL.md`) is updated to document that `--hybrid` now applies to `--kind learning`.
- All existing tests under `crates/orbit-store/src/file/learning_store/` and `crates/orbit-core/src/command/search.rs` still pass.
- `make ci-fast` passes locally before the task moves to `review`.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Added learning embedding projection, `SOURCE_KIND_LEARNING`, learning index/search command modules, stale-source sweep, idempotent content-hash indexing, and public orbit-search exports.
- Extended `orbit semantic index --kind learnings` through runtime, CLI, and tool schemas; `all` now includes learnings.
- Added `orbit search --kind learning --hybrid` ranking with lexical fallback notes, `[learning.search].semantic_weight`, semantic-only candidates, status/tag/path filtering, and ADR-only hybrid footer text.
- Updated orbit-learning skill docs to document learning hybrid search and added CLI/core/orbit-search integration and unit coverage for indexing, stale sweep, fallback, weighting, ranking, and lexical shape preservation.

Validation:
- `cargo test -p orbit-search`
- `cargo test -p orbit-core command::search::tests -- --nocapture`
- `cargo test -p orbit-core command::learning::tests -- --nocapture`
- `cargo test -p orbit-store learning_store`
- `cargo test -p orbit-cli --test docs -- --nocapture`
- `cargo test -p orbit-cli cli_semantic_index -- --nocapture`
- `cargo test -p orbit-tools search_schema -- --nocapture`
- `target/debug/orbit semantic index --kind learnings --json` twice: second run reported embedded_chunks=0, skipped_fields=81; semantic.db learning rows=84 vs 26 learning YAML files.
- `target/debug/orbit semantic index --help` lists tasks, docs, learnings, all; singular `learning` is rejected by clap.
- Equivalent cargo-metadata check confirmed `orbit-search` has no `orbit-core` dependency; `rg -n tasks_fts crates/orbit-search/src/vector/store/` returned no references.
- `make ci-fast`

Assessment: Learning embeddings and hybrid learning search are implemented with focused coverage and no orbit-search -> orbit-core dependency edge.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-00217-6a0e798d`
- Behind base: 0
- Ahead of base: 1