### PR TITLE
Skip non-workspace paths in PreToolUse learning hook

### DIFF
--- a/crates/orbit-cli/src/command/hook/pretooluse.rs
+++ b/crates/orbit-cli/src/command/hook/pretooluse.rs
@@ -55,6 +55,13 @@ fn run_pretooluse(
     };
 
     let caps = caps_from_env();
+    if !runtime
+        .learning_hook_target_is_searchable(&payload.target_path)
+        .map_err(|error| format!("classify learning target path: {error}"))?
+    {
+        return Ok(());
+    }
+
     let results = runtime
         .search_learnings(LearningSearchParams {
             path: Some(payload.target_path.clone()),

--- a/crates/orbit-cli/tests/hook_pretooluse.rs
+++ b/crates/orbit-cli/tests/hook_pretooluse.rs
@@ -32,6 +32,41 @@ fn quiet_inputs_exit_successfully_without_stdout() {
 }
 
 #[test]
+fn global_skill_read_paths_exit_quietly_without_warning() {
+    let workspace = TestWorkspace::new();
+    workspace.add_learning("Catch-all reminders stay scoped to the workspace", &["**"]);
+    let absolute_skill = workspace.home.join(".orbit/skills/orbit/SKILL.md");
+
+    for (label, path) in [
+        (
+            "tilde global skill",
+            "~/.orbit/skills/orbit/SKILL.md".to_string(),
+        ),
+        (
+            "absolute global skill",
+            absolute_skill.to_string_lossy().to_string(),
+        ),
+    ] {
+        let payload = json!({"tool_name": "Read", "path": path}).to_string();
+        let output = workspace.run_hook(
+            &payload,
+            &[("ORBIT_SESSION_ID", "global-skill-session")],
+            label,
+        );
+        assert!(
+            output.stdout.is_empty(),
+            "{label} stdout: {}",
+            String::from_utf8_lossy(&output.stdout)
+        );
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(
+            !stderr.contains("learning hook failed open"),
+            "{label} stderr: {stderr}"
+        );
+    }
+}
+
+#[test]
 fn matching_payload_emits_reminder_state_and_audit_event() {
     let workspace = TestWorkspace::new();
     let learning = workspace.add_learning("Always keep hook reminders audited", &["src/**"]);
@@ -74,6 +109,34 @@ Read full body via `orbit.learning.show <id>` if needed.\n\
         serde_json::from_str(event["arguments_json"].as_str().expect("arguments_json"))
             .expect("audit arguments JSON");
     assert_eq!(arguments["learning_ids"], json!([learning_id]));
+}
+
+#[test]
+fn in_workspace_absolute_payload_still_emits_reminder() {
+    let workspace = TestWorkspace::new();
+    let learning = workspace.add_learning("Absolute workspace paths still match", &["src/**"]);
+    let learning_id = learning["id"].as_str().expect("learning id");
+    let target = workspace.work.join("src/lib.rs");
+    let payload =
+        json!({"tool_name": "Read", "path": target.to_string_lossy().to_string()}).to_string();
+
+    let output = workspace.run_hook(
+        &payload,
+        &[("ORBIT_SESSION_ID", "absolute-workspace-session")],
+        "absolute workspace hook",
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains(&format!(
+            "- [{learning_id}] Absolute workspace paths still match"
+        )),
+        "stdout: {stdout}"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !stderr.contains("learning hook failed open"),
+        "stderr: {stderr}"
+    );
 }
 
 #[test]

--- a/crates/orbit-core/src/command/learning.rs
+++ b/crates/orbit-core/src/command/learning.rs
@@ -343,27 +343,56 @@ fn normalize_learning_search_params(
 }
 
 fn normalize_learning_search_path(repo_root: &Path, path: &str) -> Result<String, OrbitError> {
+    match classify_learning_search_path(repo_root, path)? {
+        LearningSearchPathScope::Relative => Ok(path.to_string()),
+        LearningSearchPathScope::WorkspaceRelative(relative) => Ok(relative),
+        LearningSearchPathScope::OutsideWorkspace => Err(OrbitError::InvalidInput(format!(
+            "filesystem path `{path}` must stay inside the workspace root"
+        ))),
+    }
+}
+
+pub(crate) fn learning_search_path_matches_workspace(
+    repo_root: &Path,
+    path: &str,
+) -> Result<bool, OrbitError> {
+    Ok(!matches!(
+        classify_learning_search_path(repo_root, path)?,
+        LearningSearchPathScope::OutsideWorkspace
+    ))
+}
+
+enum LearningSearchPathScope {
+    Relative,
+    WorkspaceRelative(String),
+    OutsideWorkspace,
+}
+
+fn classify_learning_search_path(
+    repo_root: &Path,
+    path: &str,
+) -> Result<LearningSearchPathScope, OrbitError> {
     let trimmed = path.trim();
     let candidate = Path::new(trimmed);
     if !candidate.is_absolute() {
-        return Ok(path.to_string());
+        return Ok(LearningSearchPathScope::Relative);
     }
 
     let canonical_repo_root = canonicalize_with_missing_tail(repo_root)?;
     let canonical_candidate = canonicalize_with_missing_tail(candidate)?;
     if let Ok(relative) = canonical_candidate.strip_prefix(&canonical_repo_root) {
-        return Ok(workspace_relative_path_string(relative));
+        return Ok(LearningSearchPathScope::WorkspaceRelative(
+            workspace_relative_path_string(relative),
+        ));
     }
 
     if let Some(relative) =
         linked_worktree_relative_path(&canonical_repo_root, candidate, &canonical_candidate)
     {
-        return Ok(relative);
+        return Ok(LearningSearchPathScope::WorkspaceRelative(relative));
     }
 
-    Err(OrbitError::InvalidInput(format!(
-        "filesystem path `{path}` must stay inside the workspace root"
-    )))
+    Ok(LearningSearchPathScope::OutsideWorkspace)
 }
 
 fn normalize_learning_voter_model(raw: &str) -> Result<String, OrbitError> {

--- a/crates/orbit-core/src/command/learning_hook.rs
+++ b/crates/orbit-core/src/command/learning_hook.rs
@@ -1,6 +1,8 @@
 use std::path::{Path, PathBuf};
 
-use orbit_common::types::{LearningInjectionCaps, LearningInjectionState, LearningReminder};
+use orbit_common::types::{
+    LearningInjectionCaps, LearningInjectionState, LearningReminder, OrbitError,
+};
 use serde_json::Value;
 
 use crate::OrbitRuntime;
@@ -265,6 +267,21 @@ pub fn reminders_from_search_results(
 }
 
 impl OrbitRuntime {
+    pub fn learning_hook_target_is_searchable(
+        &self,
+        target_path: &str,
+    ) -> Result<bool, OrbitError> {
+        let normalized = target_path.trim().replace('\\', "/");
+        if normalized == "~" || normalized.starts_with("~/") {
+            return Ok(false);
+        }
+
+        crate::command::learning::learning_search_path_matches_workspace(
+            &self.paths().repo_root,
+            target_path,
+        )
+    }
+
     pub fn learning_hook_state_file_path(
         &self,
         session_id: Option<&str>,


### PR DESCRIPTION
## Task

[ORB-00236](https://orbit-cli.com/tasks/ORB-00236) — Skip non-workspace paths in PreToolUse learning hook

### Description

## Problem
The PreToolUse learning hook logs a fail-open warning when an agent reads global Orbit skill files such as `~/.orbit/skills/orbit/SKILL.md`. The hook extracts the absolute path from the `Read` payload and passes it to `OrbitRuntime::search_learnings`, whose path normalization only accepts workspace-relative paths, paths under the workspace root, or linked worktree paths.

## Proposed Fix
Make the hook treat non-workspace absolute paths as non-actionable for learning injection. Before calling `search_learnings`, normalize or classify the extracted target path against `runtime.paths().repo_root`; if the path is absolute and outside the workspace/linked-worktree boundary, return `Ok(())` without warning. Keep existing behavior for workspace-relative paths, in-workspace absolute paths, linked worktree paths, patch-derived paths, and command-derived paths.

A good implementation location is the hook layer (`crates/orbit-cli/src/command/hook/pretooluse.rs` or the shared parser helpers in `crates/orbit-core/src/command/learning_hook.rs`), because out-of-workspace paths are expected hook inputs, not invalid learning-store queries. Avoid broadening `search_learnings` to silently accept arbitrary absolute paths for normal callers.

## Why It Matters
Global seeded skills live outside each repository, and agents are instructed to read them. Those expected reads should not produce noisy warnings or make users think learning injection is broken.

## Constraints / Notes
- Preserve fail-open behavior for unexpected hook errors.
- Do not change the learning search contract for direct CLI/tool callers.
- Linkage: resolves friction `F2026-05-049`.

### Acceptance Criteria

- A PreToolUse hook invocation with payload `{"tool_name":"Read","path":"~/.orbit/skills/orbit/SKILL.md"}` exits successfully with no stdout and no `learning hook failed open` warning.
- Existing workspace-relative and in-workspace absolute hook payloads still search learnings and emit reminders when a matching active learning exists.
- Automated CLI hook coverage exists for the non-workspace absolute-path case and for at least one preserved in-workspace reminder case.
- `make ci-fast` passes before the task is moved to review.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Added hook-layer path classification so PreToolUse skips tilde/global skill paths and absolute paths outside the workspace or linked-worktree boundary before calling learning search.
- Kept direct learning search normalization strict by refactoring its existing workspace-boundary logic into a reusable classifier.
- Added CLI hook coverage for quiet global skill reads and preserved in-workspace absolute-path reminders.

Assessment: Focused hook behavior change; direct CLI/tool learning search still rejects out-of-workspace paths.

Validation:
- cargo test -p orbit-cli --test hook_pretooluse
- make ci-fast

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-00236-6a0e872e`
- Behind base: 0
- Ahead of base: 1