### PR TITLE
Add ADR-corpus embeddings: `orbit semantic index --kind adrs` + hybrid ADR search

### DIFF
--- a/.orbit/learnings/L-0031/learning.yaml
+++ b/.orbit/learnings/L-0031/learning.yaml
@@ -1,0 +1,20 @@
+schema_version: 1
+id: L-0031
+status: active
+scope:
+  paths:
+  - crates/orbit-core/src/command/docs.rs
+  - crates/orbit-search/src/vector/store/**
+  tags:
+  - adr
+  - embeddings
+  - search
+summary: Deduplicate live ADR records by ID before semantic indexing ADR fields
+body: ADR state can temporarily contain the same ADR id under multiple status directories, such as proposed/ and accepted/. When building semantic index sources, normalize to one live record per ADR id before generating field hashes; otherwise a second unchanged index pass can alternate duplicate field bodies and re-embed chunks instead of reporting embedded_chunks == 0.
+evidence:
+- kind: task
+  reference: ORB-00216
+created_at: 2026-05-21T04:24:02.663307Z
+updated_at: 2026-05-21T04:24:02.663307Z
+created_by: codex
+priority: 120

--- a/crates/orbit-cli/src/command/mod.rs
+++ b/crates/orbit-cli/src/command/mod.rs
@@ -268,18 +268,33 @@ mod tests {
     }
 
     #[test]
-    fn cli_semantic_index_rejects_future_kinds_at_clap_layer() {
+    fn cli_semantic_index_rejects_singular_kinds_at_clap_layer() {
         for kind in ["adr", "learning"] {
             let error = match Cli::try_parse_from(["orbit", "semantic", "index", "--kind", kind]) {
-                Ok(_) => panic!("future kinds should be rejected"),
+                Ok(_) => panic!("singular kinds should be rejected"),
                 Err(error) => error,
             };
             let message = error.to_string();
             assert!(message.contains("possible values"), "{message}");
             assert!(message.contains("tasks"), "{message}");
             assert!(message.contains("docs"), "{message}");
+            assert!(message.contains("adrs"), "{message}");
             assert!(message.contains("learnings"), "{message}");
             assert!(message.contains("all"), "{message}");
+        }
+    }
+
+    #[test]
+    fn cli_semantic_index_parses_adrs_kind() {
+        let cli = Cli::parse_from(["orbit", "semantic", "index", "--kind", "adrs"]);
+        match cli.command {
+            Commands::Semantic(command) => match command.command {
+                SemanticSubcommand::Index(args) => {
+                    assert_eq!(args.kind, SemanticIndexKindArg::Adrs);
+                }
+                _ => panic!("expected semantic index"),
+            },
+            _ => panic!("expected top-level semantic command"),
         }
     }
 
@@ -306,7 +321,7 @@ mod tests {
         let help = error.to_string();
         assert!(
             help.contains(
-                "--kind selects corpus: tasks (default), docs (same as `orbit docs index`), learnings, all (rebuilds all indexed corpora)."
+                "--kind selects corpus: tasks (default), docs (same as `orbit docs index`), adrs, learnings, all (rebuilds all indexed corpora)."
             ),
             "{help}"
         );

--- a/crates/orbit-cli/src/command/search.rs
+++ b/crates/orbit-cli/src/command/search.rs
@@ -7,7 +7,7 @@ use crate::command::Execute;
 #[command(
     about = "Search tasks, docs, learnings, and ADRs",
     subcommand_precedence_over_arg = true,
-    after_help = "Forms:\n  orbit search <query>\n  orbit search similar <id>\n  orbit search path <path>\n\nIndex coverage note: ADRs use lexical matching regardless of --hybrid."
+    after_help = "Forms:\n  orbit search <query>\n  orbit search similar <id>\n  orbit search path <path>"
 )]
 pub struct SearchCommand {
     /// Free-text query. Defaults to lexical matching unless --hybrid is set.
@@ -18,7 +18,7 @@ pub struct SearchCommand {
     pub command: Option<SearchSubcommand>,
 
     // ADR-0179: free-text search keeps the hybrid ranker; neighbor/path modes are separate forms.
-    /// Use hybrid lexical + cosine ranking for indexed task or doc fields.
+    /// Use hybrid lexical + cosine ranking for indexed task, doc, learning, or ADR fields.
     #[arg(long)]
     pub hybrid: bool,
     /// Restrict results to one corpus kind.

--- a/crates/orbit-cli/src/command/semantic.rs
+++ b/crates/orbit-cli/src/command/semantic.rs
@@ -59,7 +59,7 @@ pub struct SemanticIndexArgs {
         value_enum,
         default_value_t = SemanticIndexKindArg::Tasks,
         value_name = "KIND",
-        help = "--kind selects corpus: tasks (default), docs (same as `orbit docs index`), learnings, all (rebuilds all indexed corpora)."
+        help = "--kind selects corpus: tasks (default), docs (same as `orbit docs index`), adrs, learnings, all (rebuilds all indexed corpora)."
     )]
     pub kind: SemanticIndexKindArg,
     #[arg(long)]
@@ -70,6 +70,7 @@ pub struct SemanticIndexArgs {
 pub enum SemanticIndexKindArg {
     Tasks,
     Docs,
+    Adrs,
     Learnings,
     All,
 }
@@ -79,6 +80,7 @@ impl From<SemanticIndexKindArg> for IndexKind {
         match value {
             SemanticIndexKindArg::Tasks => Self::Tasks,
             SemanticIndexKindArg::Docs => Self::Docs,
+            SemanticIndexKindArg::Adrs => Self::Adrs,
             SemanticIndexKindArg::Learnings => Self::Learnings,
             SemanticIndexKindArg::All => Self::All,
         }
@@ -190,6 +192,21 @@ fn print_semantic_index_text(result: SemanticIndexResult) -> Result<(), OrbitErr
                 stale_sources.len()
             );
         }
+        SemanticIndexResult::Adrs {
+            model_id,
+            report,
+            indexed_sources,
+            stale_sources,
+        } => {
+            println!(
+                "Indexed ADRs: model={} indexed_sources={} embedded_chunks={} skipped_fields={} stale_sources={}",
+                model_id,
+                indexed_sources,
+                report.embedded_chunks,
+                report.skipped_fields,
+                stale_sources.len()
+            );
+        }
         SemanticIndexResult::Learnings {
             model_id,
             report,
@@ -208,10 +225,11 @@ fn print_semantic_index_text(result: SemanticIndexResult) -> Result<(), OrbitErr
         SemanticIndexResult::All {
             tasks,
             docs,
+            adrs,
             learnings,
         } => {
             println!(
-                "Indexed semantic search: tasks_model={} tasks_embedded_chunks={} tasks_skipped_fields={} docs_model={} docs_indexed_sources={} docs_embedded_chunks={} docs_skipped_fields={} docs_stale_sources={} learnings_model={} learnings_indexed_sources={} learnings_embedded_chunks={} learnings_skipped_fields={} learnings_stale_sources={}",
+                "Indexed semantic search: tasks_model={} tasks_embedded_chunks={} tasks_skipped_fields={} docs_model={} docs_indexed_sources={} docs_embedded_chunks={} docs_skipped_fields={} docs_stale_sources={} adrs_model={} adrs_indexed_sources={} adrs_embedded_chunks={} adrs_skipped_fields={} adrs_stale_sources={} learnings_model={} learnings_indexed_sources={} learnings_embedded_chunks={} learnings_skipped_fields={} learnings_stale_sources={}",
                 tasks.model_id,
                 tasks.report.embedded_chunks,
                 tasks.report.skipped_fields,
@@ -220,6 +238,11 @@ fn print_semantic_index_text(result: SemanticIndexResult) -> Result<(), OrbitErr
                 docs.report.embedded_chunks,
                 docs.report.skipped_fields,
                 docs.stale_sources.len(),
+                adrs.model_id,
+                adrs.indexed_sources,
+                adrs.report.embedded_chunks,
+                adrs.report.skipped_fields,
+                adrs.stale_sources.len(),
                 learnings.model_id,
                 learnings.indexed_sources,
                 learnings.report.embedded_chunks,

--- a/crates/orbit-cli/tests/docs.rs
+++ b/crates/orbit-cli/tests/docs.rs
@@ -74,7 +74,8 @@ fn cli_orbit_search_limit_help_describes_total_round_robin_limit() {
     assert!(help.contains("Maximum total results returned"));
     assert!(help.contains("round-robin per kind"));
     assert!(help.contains("[default: 10]"));
-    assert!(help.contains("ADRs use lexical matching regardless of --hybrid."));
+    assert!(!help.contains("ADRs use lexical matching regardless of --hybrid."));
+    assert!(!help.contains("Index coverage note"));
     assert!(!help.contains("learnings and ADRs use lexical matching"));
 }
 
@@ -199,6 +200,39 @@ fn cli_orbit_search_hybrid_learning_json_reports_lexical_fallback_note_missing_c
 }
 
 #[test]
+fn cli_orbit_search_hybrid_adr_json_reports_lexical_fallback_note_missing_companion() {
+    let workspace = TestWorkspace::new();
+    let adr_id = workspace.add_adr(
+        "hybrid-adr-note literal",
+        &["hybrid-adr-note"],
+        "## Decision\nHybrid ADR fallback remains lexical.\n",
+    );
+
+    let response = workspace.run_json(
+        &[
+            "search",
+            "hybrid-adr-note",
+            "--hybrid",
+            "--kind",
+            "adr",
+            "--json",
+        ],
+        "orbit search hybrid ADR missing companion",
+    );
+    let notes = response["notes"].as_array().expect("notes");
+    assert!(
+        notes.iter().any(|note| {
+            note.as_str()
+                .expect("note")
+                .contains("falling back to lexical")
+        }),
+        "hybrid ADR notes should preserve lexical fallback warning: {notes:?}"
+    );
+    assert_eq!(response["results"][0]["source"], "lexical");
+    assert_eq!(response["results"][0]["id"], adr_id);
+}
+
+#[test]
 #[cfg(unix)]
 fn cli_orbit_search_hybrid_learning_json_reports_lexical_fallback_note_empty_embeddings() {
     let workspace = TestWorkspace::new();
@@ -238,6 +272,41 @@ fn cli_orbit_search_hybrid_learning_json_reports_lexical_fallback_note_empty_emb
     );
     assert_eq!(response["results"][0]["source"], "lexical");
     assert_eq!(response["results"][0]["id"], learning["id"]);
+}
+
+#[test]
+#[cfg(unix)]
+fn cli_orbit_search_hybrid_adr_json_reports_lexical_fallback_note_empty_embeddings() {
+    let workspace = TestWorkspace::new();
+    workspace.write_mock_companion();
+    let adr_id = workspace.add_adr(
+        "hybrid-adr-empty literal",
+        &["hybrid-adr-empty"],
+        "## Decision\nHybrid ADR empty-index fallback remains lexical.\n",
+    );
+
+    let response = workspace.run_json_with_companion(
+        &[
+            "search",
+            "hybrid-adr-empty",
+            "--hybrid",
+            "--kind",
+            "adr",
+            "--json",
+        ],
+        "orbit search hybrid ADR empty embeddings",
+    );
+    let notes = response["notes"].as_array().expect("notes");
+    assert!(
+        notes.iter().any(|note| {
+            note.as_str()
+                .expect("note")
+                .contains("falling back to lexical")
+        }),
+        "hybrid ADR notes should preserve lexical fallback warning: {notes:?}"
+    );
+    assert_eq!(response["results"][0]["source"], "lexical");
+    assert_eq!(response["results"][0]["id"], adr_id);
 }
 
 #[test]
@@ -294,6 +363,45 @@ fn cli_orbit_search_hybrid_learning_ranking_differs_from_lexical() {
 
     assert_eq!(lexical["results"][0]["id"], literal["id"]);
     assert_eq!(hybrid["results"][0]["id"], semantic["id"]);
+    assert_ne!(lexical["results"][0]["id"], hybrid["results"][0]["id"]);
+}
+
+#[test]
+#[cfg(unix)]
+fn cli_orbit_search_hybrid_adr_ranking_differs_from_lexical() {
+    let workspace = TestWorkspace::new();
+    workspace.write_mock_companion();
+    let semantic_id = workspace.add_adr(
+        "Conceptual ADR",
+        &["semantic-adr"],
+        "## Decision\nsemantic-target operational insight.\n",
+    );
+    let literal_id = workspace.add_adr(
+        "foo literal ADR",
+        &["literal-adr"],
+        "## Decision\nliteral body.\n",
+    );
+    workspace.add_adr(
+        "foo secondary ADR",
+        &["literal-adr-secondary"],
+        "## Decision\nsecond literal body.\n",
+    );
+    workspace.run_json_with_companion(
+        &["semantic", "index", "--kind", "adrs", "--force", "--json"],
+        "semantic index ADRs",
+    );
+
+    let lexical = workspace.run_json(
+        &["search", "foo", "--kind", "adr", "--json"],
+        "ADR lexical search",
+    );
+    let hybrid = workspace.run_json_with_companion(
+        &["search", "foo", "--kind", "adr", "--hybrid", "--json"],
+        "ADR hybrid search",
+    );
+
+    assert_eq!(lexical["results"][0]["id"], literal_id);
+    assert_eq!(hybrid["results"][0]["id"], semantic_id);
     assert_ne!(lexical["results"][0]["id"], hybrid["results"][0]["id"]);
 }
 
@@ -548,8 +656,65 @@ fn cli_semantic_index_all_json_contains_tasks_and_docs() {
     );
     assert_eq!(result["docs"]["model_id"], "bge-small-en-v1.5");
     assert_eq!(result["docs"]["indexed_sources"], 1);
+    assert_eq!(result["adrs"]["model_id"], "bge-small-en-v1.5");
+    assert_eq!(result["adrs"]["indexed_sources"], 0);
     assert_eq!(result["learnings"]["model_id"], "bge-small-en-v1.5");
     assert_eq!(result["learnings"]["indexed_sources"], 0);
+}
+
+#[test]
+#[cfg(unix)]
+fn cli_semantic_index_adrs_is_idempotent_status_agnostic_and_sweeps_stale() {
+    let workspace = TestWorkspace::new();
+    workspace.write_mock_companion();
+    let old_id = workspace.add_adr(
+        "adr-index-old",
+        &["adr-index"],
+        "## Context\nOld context.\n\n## Decision\nKeep old ADR indexed.\n\n## Consequences\nSuperseded ADRs remain searchable when explicitly requested.\n",
+    );
+    let new_id = workspace.add_adr(
+        "adr-index-new",
+        &["adr-index"],
+        "## Context\nNew context.\n\n## Decision\nUse the replacement ADR.\n\n## Consequences\nThe old ADR moves to superseded state.\n",
+    );
+    workspace.accept_adr(&new_id);
+
+    let first = workspace.run_json_with_companion(
+        &["semantic", "index", "--kind", "adrs", "--json"],
+        "semantic index ADRs",
+    );
+    assert_eq!(first["indexed_sources"], 2);
+    assert!(
+        first["report"]["embedded_chunks"].as_u64().unwrap_or(0)
+            > adr_dir_count(&workspace.work) as u64
+    );
+    assert!(count_adr_embeddings(&workspace.work, None) > adr_dir_count(&workspace.work) as i64);
+
+    let second = workspace.run_json_with_companion(
+        &["semantic", "index", "--kind", "adrs", "--json"],
+        "semantic index ADRs idempotent",
+    );
+    assert_eq!(second["report"]["embedded_chunks"], 0);
+    assert!(second["report"]["skipped_fields"].as_u64().unwrap_or(0) > 0);
+
+    workspace.supersede_adr(&old_id, &new_id);
+    workspace.run_json_with_companion(
+        &["semantic", "index", "--kind", "adrs", "--json"],
+        "semantic index superseded ADRs",
+    );
+    assert!(
+        count_adr_embeddings(&workspace.work, Some(&old_id)) > 0,
+        "superseded ADR should remain indexed"
+    );
+
+    fs::remove_dir_all(workspace.work.join(".orbit/adrs/accepted").join(&new_id))
+        .expect("delete ADR directory");
+    workspace.run_json_with_companion(
+        &["semantic", "index", "--kind", "adrs", "--json"],
+        "semantic index after ADR deletion",
+    );
+    assert_eq!(count_adr_embeddings(&workspace.work, Some(&new_id)), 0);
+    assert!(count_adr_embeddings(&workspace.work, Some(&old_id)) > 0);
 }
 
 #[test]
@@ -872,6 +1037,23 @@ fn learning_dir_count(work: &std::path::Path) -> usize {
         .count()
 }
 
+fn adr_dir_count(work: &std::path::Path) -> usize {
+    ["proposed", "accepted", "superseded", "deleted"]
+        .into_iter()
+        .map(|status| work.join(".orbit/adrs").join(status))
+        .filter(|dir| dir.is_dir())
+        .flat_map(|dir| fs::read_dir(dir).expect("read ADR status dir"))
+        .filter_map(Result::ok)
+        .filter(|entry| entry.file_type().is_ok_and(|file_type| file_type.is_dir()))
+        .filter(|entry| {
+            entry
+                .file_name()
+                .to_str()
+                .is_some_and(|name| name.starts_with("ADR-"))
+        })
+        .count()
+}
+
 fn count_learning_embeddings(work: &std::path::Path, source_id: Option<&str>) -> i64 {
     let conn = Connection::open(work.join(".orbit/state/semantic.db")).expect("open semantic db");
     match source_id {
@@ -889,6 +1071,26 @@ fn count_learning_embeddings(work: &std::path::Path, source_id: Option<&str>) ->
                 |row| row.get(0),
             )
             .expect("count learning embeddings"),
+    }
+}
+
+fn count_adr_embeddings(work: &std::path::Path, source_id: Option<&str>) -> i64 {
+    let conn = Connection::open(work.join(".orbit/state/semantic.db")).expect("open semantic db");
+    match source_id {
+        Some(source_id) => conn
+            .query_row(
+                "SELECT COUNT(*) FROM embeddings WHERE source_kind = 'adr' AND source_id = ?1",
+                params![source_id],
+                |row| row.get(0),
+            )
+            .expect("count ADR source embeddings"),
+        None => conn
+            .query_row(
+                "SELECT COUNT(*) FROM embeddings WHERE source_kind = 'adr'",
+                [],
+                |row| row.get(0),
+            )
+            .expect("count ADR embeddings"),
     }
 }
 

--- a/crates/orbit-core/assets/skills/orbit-adr/SKILL.md
+++ b/crates/orbit-core/assets/skills/orbit-adr/SKILL.md
@@ -9,7 +9,7 @@ description: Use this whenever an Architecture Decision Record is being created,
 
 Create and maintain Orbit ADR artifacts through the registered tool surface. ADRs record decisions, not implementation plans: use them when a choice has a real alternative, constrains future work, and carries a non-trivial cost.
 
-ADRs and orbit-docs are sibling indexes by design. ADRs keep their stricter lifecycle and dedicated allocation through `orbit.adr.*`; `orbit search <query> --kind all` (and `--kind adr`) surfaces ADR metadata read-only alongside doc results. For the boundary rationale, run `orbit tool run orbit.adr.list --input '{"feature":"orbit-adr"}'` and inspect the accepted ADR covering the sibling-index search overlay.
+ADRs and orbit-docs are sibling indexes by design. ADRs keep their stricter lifecycle and dedicated allocation through `orbit.adr.*`; `orbit search <query> --kind all`, `--kind doc`, and `--kind adr` surface ADR metadata read-only alongside doc results. After `orbit semantic index --kind adrs`, `--hybrid` applies to `--kind adr` and to federated ADR results in `--kind doc` / `--kind all` queries. For the boundary rationale, run `orbit tool run orbit.adr.list --input '{"feature":"orbit-adr"}'` and inspect the accepted ADR covering the sibling-index search overlay.
 
 ADR artifact files are written into the current worktree's `.orbit/adrs/...`
 subtree, while IDs are allocated globally through the shared allocator. Stage
@@ -49,6 +49,7 @@ Both produce orphan decisions invisible to `orbit.adr.list`, `orbit.adr.show`, a
 1. Inspect nearby decisions before adding a new one.
    - `orbit tool run orbit.adr.list --input '{"feature":"<feature>","model":"<agent-family>"}'`
   - `orbit tool run orbit.adr.show --input '{"id":"<adr-id>","model":"<agent-family>"}'`
+   - Use `orbit search "<concept>" --kind adr --hybrid` for concept retrieval when the semantic companion is installed and ADRs have been indexed with `orbit semantic index --kind adrs`; without vectors, Orbit falls back to lexical ADR results with a note.
    - Use `legacy_id` lookup for migrated per-feature references, for example `{"legacy_id":"activity-job/ADR-039"}`.
 2. Decide whether this is a new ADR, an update to a proposed ADR, or a supersession.
    - New decision: `orbit.adr.add`.

--- a/crates/orbit-core/assets/skills/orbit-search/SKILL.md
+++ b/crates/orbit-core/assets/skills/orbit-search/SKILL.md
@@ -32,7 +32,7 @@ orbit search path crates/orbit-search/src/lib.rs --kind all
 orbit tool run orbit.search --input '{"tag":"perf","kind":"all","model":"<agent-family>"}'
 orbit tool run orbit.search --input '{"path":"crates/orbit-search/src/lib.rs","kind":"all","model":"<agent-family>"}'
 
-# Hybrid BM25 + cosine over task fields; other kinds remain lexical
+# Hybrid lexical + cosine over indexed task, doc, learning, or ADR fields
 orbit search "agent loop deadlock" --hybrid --kind task --limit 5
 orbit tool run orbit.search --input '{"query":"agent loop deadlock","hybrid":true,"kind":"task","limit":5,"model":"<agent-family>"}'
 
@@ -49,9 +49,7 @@ orbit tool run orbit.search --input '{"semantic":"<task-id>","limit":5,"model":"
 
 ## Index Coverage
 
-Lexical search covers tasks, docs, learnings, and ADRs. Vector search currently covers task fields only. When `--hybrid` is set for `--kind doc`, `--kind learning`, `--kind adr`, or those portions of `--kind all`, Orbit still uses lexical matching for those kinds.
-
-The help text for `orbit search --help` carries this asymmetry because it is user-visible behavior, not an implementation accident.
+Lexical search covers tasks, docs, learnings, and ADRs. Vector search covers task fields plus docs, learnings, and ADRs after their corpora are indexed with `orbit semantic index --kind docs|learnings|adrs`. When `--hybrid` is set and vectors are missing for a requested corpus, Orbit returns lexical results with a fallback note instead of failing the user search.
 
 ## When To Use
 
@@ -76,9 +74,9 @@ Do not use search for "find every symbol matching pattern X"; use `orbit.graph.s
 | Install companion/model | `orbit semantic install [--model MODEL] [--force]` | `orbit.semantic.install` |
 | Remove companion/model | `orbit semantic uninstall [--model MODEL] [--all]` | `orbit.semantic.uninstall` |
 | Show status | `orbit semantic stats` | `orbit.semantic.stats` |
-| Rebuild task embeddings | `orbit semantic index [--model MODEL] [--force]` | `orbit.semantic.index` |
+| Rebuild embeddings | `orbit semantic index --kind tasks|docs|learnings|adrs|all [--model MODEL] [--force]` | `orbit.semantic.index` |
 
-Do not run `install` without operator consent. If a semantic query fails because the companion is missing, fall back to plain `orbit search --kind task <query>` (lexical) and continue unless the user explicitly asked to enable embeddings.
+Do not run `install` without operator consent. If a semantic query fails because the companion is missing, fall back to plain `orbit search --kind <kind> <query>` (lexical) and continue unless the user explicitly asked to enable embeddings.
 
 ## Result Shape
 

--- a/crates/orbit-core/src/command/docs.rs
+++ b/crates/orbit-core/src/command/docs.rs
@@ -9,12 +9,13 @@ use std::str::FromStr;
 use orbit_common::types::{Adr, AdrStatus, OrbitError, Task};
 use orbit_common::utility::glob::{match_glob, normalize_glob_path};
 use orbit_common::utility::selector::anchor_path;
-pub use orbit_search::{
-    AdrSearchResult, DocIndexParams, DocIndexResult, DocSearchResult, SearchResult,
-};
 use orbit_search::{
-    AdrSearchSource, DocEmbeddingSource, DocSearchSource, score_adr_record, score_doc_record,
-    sort_search_results,
+    AdrEmbeddingSource, AdrSearchSource, DocEmbeddingSource, DocSearchSource, score_adr_record,
+    score_doc_record, sort_search_results,
+};
+pub use orbit_search::{
+    AdrIndexParams, AdrIndexResult, AdrSearchResult, DocIndexParams, DocIndexResult,
+    DocSearchResult, SearchResult,
 };
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use serde_json::json;
@@ -259,6 +260,34 @@ struct DocsSearchConfigSection {
     semantic_weight: Option<f32>,
 }
 
+#[derive(Debug, Deserialize)]
+struct AdrConfigFile {
+    adr: Option<AdrConfigSection>,
+}
+
+#[derive(Debug, Deserialize)]
+struct AdrConfigSection {
+    search: Option<AdrSearchConfigSection>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct AdrSearchConfig {
+    pub semantic_weight: f32,
+}
+
+impl Default for AdrSearchConfig {
+    fn default() -> Self {
+        Self {
+            semantic_weight: 0.5,
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct AdrSearchConfigSection {
+    semantic_weight: Option<f32>,
+}
+
 impl OrbitRuntime {
     pub fn docs_roots(&self) -> Result<Vec<String>, OrbitError> {
         read_docs_roots_from_config_path(&self.config_path())
@@ -266,6 +295,10 @@ impl OrbitRuntime {
 
     pub fn docs_search_config(&self) -> Result<DocsSearchConfig, OrbitError> {
         read_docs_search_config_from_config_path(&self.config_path())
+    }
+
+    pub fn adr_search_config(&self) -> Result<AdrSearchConfig, OrbitError> {
+        read_adr_search_config_from_config_path(&self.config_path())
     }
 
     pub fn list_docs(
@@ -362,6 +395,11 @@ impl OrbitRuntime {
         orbit_search::doc_index(&self.stores().semantic_vector, &sources, params)
     }
 
+    pub fn index_adrs(&self, params: AdrIndexParams) -> Result<AdrIndexResult, OrbitError> {
+        let sources = adr_embedding_sources(&self.paths().repo_root, self.stores().adrs().list()?)?;
+        orbit_search::adr_index(&self.stores().semantic_vector, &sources, params)
+    }
+
     pub fn migrate_docs(&self, dry_run: bool) -> Result<DocMigrationReport, OrbitError> {
         migrate_docs(&self.paths().repo_root, dry_run)
     }
@@ -398,6 +436,22 @@ pub fn parse_docs_search_config_from_config_toml(
     Ok(DocsSearchConfig { semantic_weight })
 }
 
+pub fn parse_adr_search_config_from_config_toml(raw: &str) -> Result<AdrSearchConfig, OrbitError> {
+    if raw.trim().is_empty() {
+        return Ok(AdrSearchConfig::default());
+    }
+    let parsed = toml::from_str::<AdrConfigFile>(raw).map_err(|error| {
+        OrbitError::InvalidInput(format!("invalid ADR config in config.toml: {error}"))
+    })?;
+    let semantic_weight = parsed
+        .adr
+        .and_then(|section| section.search)
+        .and_then(|section| section.semantic_weight)
+        .unwrap_or_else(|| AdrSearchConfig::default().semantic_weight)
+        .clamp(0.0, 1.0);
+    Ok(AdrSearchConfig { semantic_weight })
+}
+
 fn read_docs_roots_from_config_path(path: &Path) -> Result<Vec<String>, OrbitError> {
     if !path.exists() {
         return Ok(default_doc_roots());
@@ -414,6 +468,15 @@ fn read_docs_search_config_from_config_path(path: &Path) -> Result<DocsSearchCon
     let raw = fs::read_to_string(path)
         .map_err(|error| OrbitError::Io(format!("read {}: {error}", path.display())))?;
     parse_docs_search_config_from_config_toml(&raw)
+}
+
+fn read_adr_search_config_from_config_path(path: &Path) -> Result<AdrSearchConfig, OrbitError> {
+    if !path.exists() {
+        return Ok(AdrSearchConfig::default());
+    }
+    let raw = fs::read_to_string(path)
+        .map_err(|error| OrbitError::Io(format!("read {}: {error}", path.display())))?;
+    parse_adr_search_config_from_config_toml(&raw)
 }
 
 fn read_task_context_docs_roots_from_config_path(path: &Path) -> Result<Vec<String>, OrbitError> {
@@ -932,6 +995,30 @@ fn doc_embedding_sources(
             title: shown.frontmatter.summary,
             tags: shown.frontmatter.tags,
             body: shown.body,
+        });
+    }
+    Ok(sources)
+}
+
+fn adr_embedding_sources(
+    repo_root: &Path,
+    adrs: Vec<Adr>,
+) -> Result<Vec<AdrEmbeddingSource>, OrbitError> {
+    let mut sources = Vec::new();
+    // L-0028: ADR ids can briefly appear in multiple status directories; index one source per id.
+    let adrs = adrs
+        .into_iter()
+        .map(|adr| (adr.id.clone(), adr))
+        .collect::<BTreeMap<_, _>>();
+    for adr in adrs.into_values() {
+        let body_path = repo_root.join(adr_body_search_path(adr.status, &adr.id));
+        let body = fs::read_to_string(&body_path)
+            .map_err(|error| OrbitError::Io(format!("read {}: {error}", body_path.display())))?;
+        sources.push(AdrEmbeddingSource {
+            id: adr.id,
+            title: adr.title,
+            body,
+            tags: adr.tags,
         });
     }
     Ok(sources)
@@ -1850,6 +1937,34 @@ mod tests {
         );
         assert_eq!(
             parse_docs_search_config_from_config_toml("[docs.search]\nsemantic_weight = 2.0\n")
+                .unwrap()
+                .semantic_weight,
+            1.0
+        );
+    }
+
+    #[test]
+    fn adr_search_config_defaults_and_clamps_semantic_weight() {
+        assert_eq!(
+            parse_adr_search_config_from_config_toml("")
+                .unwrap()
+                .semantic_weight,
+            0.5
+        );
+        assert_eq!(
+            parse_adr_search_config_from_config_toml("[adr.search]\nsemantic_weight = 0.7\n")
+                .unwrap()
+                .semantic_weight,
+            0.7
+        );
+        assert_eq!(
+            parse_adr_search_config_from_config_toml("[adr.search]\nsemantic_weight = -1.0\n")
+                .unwrap()
+                .semantic_weight,
+            0.0
+        );
+        assert_eq!(
+            parse_adr_search_config_from_config_toml("[adr.search]\nsemantic_weight = 2.0\n")
                 .unwrap()
                 .semantic_weight,
             1.0

--- a/crates/orbit-core/src/command/search.rs
+++ b/crates/orbit-core/src/command/search.rs
@@ -4,8 +4,8 @@ use std::str::FromStr;
 use orbit_common::types::{AdrStatus, LearningStatus, OrbitError, TaskStatus};
 use orbit_common::utility::glob::compile_glob_regex;
 use orbit_search::{
-    DocSemanticHit, DocSemanticSearchParams, LearningSemanticHit, LearningSemanticSearchParams,
-    SemanticRelatedParams, SemanticSearchParams,
+    AdrSemanticHit, AdrSemanticSearchParams, DocSemanticHit, DocSemanticSearchParams,
+    LearningSemanticHit, LearningSemanticSearchParams, SemanticRelatedParams, SemanticSearchParams,
 };
 use orbit_store::LearningSearchParams;
 use serde::Serialize;
@@ -15,6 +15,7 @@ use crate::{OrbitRuntime, SearchResult};
 const DEFAULT_LIMIT: usize = 10;
 const DOC_SEARCH_OVERFETCH: usize = 4;
 const DOC_HYBRID_FALLBACK_NOTE: &str = "falling back to lexical doc search";
+const ADR_HYBRID_FALLBACK_NOTE: &str = "falling back to lexical ADR search";
 const LEARNING_HYBRID_FALLBACK_NOTE: &str = "falling back to lexical learning search";
 const DOC_SEARCH_MIN_CANDIDATES: usize = DEFAULT_LIMIT * DOC_SEARCH_OVERFETCH;
 
@@ -22,6 +23,9 @@ const DOC_SEARCH_MIN_CANDIDATES: usize = DEFAULT_LIMIT * DOC_SEARCH_OVERFETCH;
 thread_local! {
     static DOC_SEMANTIC_SEARCH_OVERRIDE:
         std::cell::RefCell<Option<Result<Vec<DocSemanticHit>, String>>> =
+        const { std::cell::RefCell::new(None) };
+    static ADR_SEMANTIC_SEARCH_OVERRIDE:
+        std::cell::RefCell<Option<Result<Vec<AdrSemanticHit>, String>>> =
         const { std::cell::RefCell::new(None) };
     static LEARNING_SEMANTIC_SEARCH_OVERRIDE:
         std::cell::RefCell<Option<Result<Vec<LearningSemanticHit>, String>>> =
@@ -230,14 +234,6 @@ impl OrbitRuntime {
             GlobalSearchMode::Lexical
         };
 
-        if params.hybrid && params.kind.includes_adrs() {
-            push_skip_note(
-                &mut notes,
-                "ADR hybrid vector",
-                "ADRs use lexical matching regardless of --hybrid",
-            );
-        }
-
         let mut branches = Vec::new();
 
         if params.kind.includes_tasks() {
@@ -276,6 +272,7 @@ impl OrbitRuntime {
                 query_owned.as_deref(),
                 &tag_filter,
                 limit,
+                &mut notes,
             )?);
         }
 
@@ -409,7 +406,16 @@ impl OrbitRuntime {
         let docs = self.search_docs(query, Some(docs_limit), true)?;
         if params.hybrid {
             // ADR-0180: doc vectors are opt-in and fall back to lexical rather than failing user search.
-            return self.hybrid_doc_hits(query, docs, tag_filter, docs_limit, limit, notes);
+            return self.hybrid_doc_hits(
+                query,
+                docs,
+                params,
+                status_filters,
+                tag_filter,
+                docs_limit,
+                limit,
+                notes,
+            );
         }
 
         let mut out = Vec::new();
@@ -437,13 +443,16 @@ impl OrbitRuntime {
         &self,
         query: &str,
         lexical_results: Vec<SearchResult>,
+        params: &GlobalSearchParams,
+        status_filters: &SearchStatusFilters,
         tag_filter: &[String],
         docs_limit: usize,
         limit: usize,
         notes: &mut Vec<String>,
     ) -> Result<Vec<GlobalSearchHit>, OrbitError> {
         let mut lexical_docs = BTreeMap::<String, orbit_search::DocSearchResult>::new();
-        let mut lexical_adrs = Vec::new();
+        let mut lexical_adrs = BTreeMap::<String, AdrHybridCandidate>::new();
+        let adr_statuses = resolve_adr_statuses(params, status_filters);
         for result in lexical_results {
             match result {
                 SearchResult::Doc(result) => {
@@ -461,8 +470,19 @@ impl OrbitRuntime {
                     lexical_docs.insert(result.record.path.clone(), result);
                 }
                 SearchResult::Adr(result) => {
+                    if !adr_statuses.contains(&result.status) {
+                        continue;
+                    }
                     if tag_filter.is_empty() || adr_result_has_all_tags(&result, tag_filter) {
-                        lexical_adrs.push(adr_result_to_global(result));
+                        lexical_adrs.insert(
+                            result.id.clone(),
+                            AdrHybridCandidate {
+                                hit: adr_result_to_global(result.clone(), "hybrid"),
+                                lexical_score: Some(result.score as f32),
+                                semantic_score: None,
+                                semantic: None,
+                            },
+                        );
                     }
                 }
             }
@@ -540,7 +560,17 @@ impl OrbitRuntime {
 
         let weight = self.docs_search_config()?.semantic_weight;
         let mut ranked = blend_doc_hybrid_candidates(candidates.into_values().collect(), weight);
-        ranked.extend(lexical_adrs);
+        let mut adr_ranked = self.hybrid_adr_hits_from_candidates(
+            query,
+            lexical_adrs,
+            params,
+            status_filters,
+            tag_filter,
+            limit,
+            notes,
+        )?;
+        ranked.append(&mut adr_ranked);
+        ranked.sort_by(compare_global_hits_by_score);
         ranked.truncate(limit);
         Ok(ranked)
     }
@@ -567,6 +597,34 @@ impl OrbitRuntime {
     }
 
     fn adr_branch(
+        &self,
+        params: &GlobalSearchParams,
+        status_filters: &SearchStatusFilters,
+        query: Option<&str>,
+        tag_filter: &[String],
+        limit: usize,
+        notes: &mut Vec<String>,
+    ) -> Result<Vec<GlobalSearchHit>, OrbitError> {
+        let lexical = self.adr_lexical_hits(params, status_filters, query, tag_filter, limit)?;
+        if !params.hybrid {
+            return Ok(lexical);
+        }
+        let Some(query) = query else {
+            return Ok(lexical);
+        };
+
+        self.hybrid_adr_hits(
+            query,
+            lexical,
+            params,
+            status_filters,
+            tag_filter,
+            limit,
+            notes,
+        )
+    }
+
+    fn adr_lexical_hits(
         &self,
         params: &GlobalSearchParams,
         status_filters: &SearchStatusFilters,
@@ -615,23 +673,137 @@ impl OrbitRuntime {
                 {
                     continue;
                 }
-                out.push(GlobalSearchHit {
-                    kind: "adr".to_string(),
-                    source: "lexical".to_string(),
-                    id: Some(result.id),
-                    path: Some(result.path.to_string_lossy().into_owned()),
-                    title: Some(result.title),
-                    summary: None,
-                    status: Some(result.status.to_string()),
-                    best_field: None,
-                    snippet: None,
-                    score: Some(result.score as f32),
-                    matched_by: Some(result.matched_by),
-                });
+                out.push(adr_result_to_global(result, "lexical"));
             }
         }
         out.truncate(limit);
         Ok(out)
+    }
+
+    fn hybrid_adr_hits(
+        &self,
+        query: &str,
+        lexical: Vec<GlobalSearchHit>,
+        params: &GlobalSearchParams,
+        status_filters: &SearchStatusFilters,
+        tag_filter: &[String],
+        limit: usize,
+        notes: &mut Vec<String>,
+    ) -> Result<Vec<GlobalSearchHit>, OrbitError> {
+        let lexical_count = lexical.len();
+        let mut lexical_adrs = BTreeMap::<String, AdrHybridCandidate>::new();
+        for (idx, hit) in lexical.into_iter().enumerate() {
+            let Some(id) = hit.id.clone() else {
+                continue;
+            };
+            let lexical_score = hit.score.or(Some((lexical_count - idx) as f32));
+            lexical_adrs.insert(
+                id,
+                AdrHybridCandidate {
+                    hit: GlobalSearchHit {
+                        source: "hybrid".to_string(),
+                        ..hit
+                    },
+                    lexical_score,
+                    semantic_score: None,
+                    semantic: None,
+                },
+            );
+        }
+
+        self.hybrid_adr_hits_from_candidates(
+            query,
+            lexical_adrs,
+            params,
+            status_filters,
+            tag_filter,
+            limit,
+            notes,
+        )
+    }
+
+    fn hybrid_adr_hits_from_candidates(
+        &self,
+        query: &str,
+        lexical_adrs: BTreeMap<String, AdrHybridCandidate>,
+        params: &GlobalSearchParams,
+        status_filters: &SearchStatusFilters,
+        tag_filter: &[String],
+        limit: usize,
+        notes: &mut Vec<String>,
+    ) -> Result<Vec<GlobalSearchHit>, OrbitError> {
+        let adr_limit = doc_search_candidate_limit(limit);
+        let semantic = match self.adr_semantic_hits(query, adr_limit) {
+            Ok(result) if result.is_empty() => {
+                warn_adr_hybrid_fallback(notes, "no ADR embeddings found");
+                return Ok(blend_adr_lexical_fallback(lexical_adrs, limit));
+            }
+            Ok(result) => result,
+            Err(error) => {
+                warn_adr_hybrid_fallback(notes, &error.to_string());
+                return Ok(blend_adr_lexical_fallback(lexical_adrs, limit));
+            }
+        };
+
+        let statuses = resolve_adr_statuses(params, status_filters);
+        let path = params.path.as_deref();
+        let mut candidates = lexical_adrs;
+        for hit in semantic {
+            let adr = match self.stores().adrs().get(&hit.source_id) {
+                Ok(Some(adr)) => adr,
+                Ok(None) | Err(_) => continue,
+            };
+            if !statuses.contains(&adr.status) {
+                continue;
+            }
+            if !tag_filter.is_empty() && !adr_has_all_tags(&adr, tag_filter) {
+                continue;
+            }
+            if let Some(path) = path
+                && !orbit_search::adr_paths_contain_path(&adr.paths, path)?
+            {
+                continue;
+            }
+
+            candidates
+                .entry(hit.source_id.clone())
+                .and_modify(|candidate| {
+                    candidate.semantic_score = Some(hit.score);
+                    candidate.semantic = Some(hit.clone());
+                })
+                .or_insert_with(|| AdrHybridCandidate {
+                    hit: adr_to_global_hit_with_source(adr, "hybrid", None),
+                    lexical_score: None,
+                    semantic_score: Some(hit.score),
+                    semantic: Some(hit),
+                });
+        }
+
+        let weight = self.adr_search_config()?.semantic_weight;
+        let mut ranked = blend_adr_hybrid_candidates(candidates.into_values().collect(), weight);
+        ranked.truncate(limit);
+        Ok(ranked)
+    }
+
+    fn adr_semantic_hits(
+        &self,
+        query: &str,
+        limit: usize,
+    ) -> Result<Vec<AdrSemanticHit>, OrbitError> {
+        #[cfg(test)]
+        if let Some(result) = ADR_SEMANTIC_SEARCH_OVERRIDE.with(|cell| cell.borrow().clone()) {
+            return result.map_err(OrbitError::Execution);
+        }
+
+        Ok(orbit_search::adr_semantic_search(
+            &self.stores().semantic_vector,
+            AdrSemanticSearchParams {
+                query: query.to_string(),
+                limit,
+                model: None,
+            },
+        )?
+        .results)
     }
 
     fn learning_branch(
@@ -952,16 +1124,24 @@ struct LearningHybridCandidate {
     semantic: Option<LearningSemanticHit>,
 }
 
+#[derive(Debug, Clone)]
+struct AdrHybridCandidate {
+    hit: GlobalSearchHit,
+    lexical_score: Option<f32>,
+    semantic_score: Option<f32>,
+    semantic: Option<AdrSemanticHit>,
+}
+
 fn lexical_doc_hits_with_adrs(
     lexical_docs: BTreeMap<String, orbit_search::DocSearchResult>,
-    lexical_adrs: Vec<GlobalSearchHit>,
+    lexical_adrs: BTreeMap<String, AdrHybridCandidate>,
     limit: usize,
 ) -> Vec<GlobalSearchHit> {
     let mut out = lexical_docs
         .into_values()
         .map(|result| doc_result_to_global(result.clone(), "lexical", Some(result.score as f32)))
         .collect::<Vec<_>>();
-    out.extend(lexical_adrs);
+    out.extend(blend_adr_lexical_fallback(lexical_adrs, limit));
     out.truncate(limit);
     out
 }
@@ -1046,6 +1226,65 @@ fn blend_learning_hybrid_candidates(
     out
 }
 
+fn blend_adr_hybrid_candidates(
+    candidates: Vec<AdrHybridCandidate>,
+    semantic_weight: f32,
+) -> Vec<GlobalSearchHit> {
+    let lexical_scores = normalized_doc_scores(candidates.iter().filter_map(|candidate| {
+        candidate
+            .hit
+            .id
+            .as_ref()
+            .zip(candidate.lexical_score)
+            .map(|(id, score)| (id.clone(), score))
+    }));
+    let semantic_scores = normalized_doc_scores(candidates.iter().filter_map(|candidate| {
+        candidate
+            .hit
+            .id
+            .as_ref()
+            .zip(candidate.semantic_score)
+            .map(|(id, score)| (id.clone(), score))
+    }));
+    let lexical_weight = 1.0 - semantic_weight;
+    let mut out = candidates
+        .into_iter()
+        .map(|mut candidate| {
+            let id = candidate.hit.id.as_deref().unwrap_or_default();
+            let lexical = lexical_scores.get(id).copied().unwrap_or(0.0);
+            let semantic = semantic_scores.get(id).copied().unwrap_or(0.0);
+            let score = semantic_weight.mul_add(semantic, lexical_weight * lexical);
+            candidate.hit.score = Some(score);
+            if let Some(semantic_hit) = candidate.semantic {
+                candidate.hit.best_field = Some(semantic_hit.best_field);
+                candidate.hit.snippet = Some(semantic_hit.snippet);
+            }
+            candidate.hit
+        })
+        .collect::<Vec<_>>();
+    out.sort_by(compare_global_hits_by_score);
+    out
+}
+
+fn blend_adr_lexical_fallback(
+    lexical_adrs: BTreeMap<String, AdrHybridCandidate>,
+    limit: usize,
+) -> Vec<GlobalSearchHit> {
+    let mut out = lexical_adrs
+        .into_values()
+        .map(|mut candidate| {
+            candidate.hit.source = "lexical".to_string();
+            if let Some(score) = candidate.lexical_score {
+                candidate.hit.score = Some(score);
+            }
+            candidate.hit
+        })
+        .collect::<Vec<_>>();
+    out.sort_by(compare_global_hits_by_score);
+    out.truncate(limit);
+    out
+}
+
 fn normalized_doc_scores(scores: impl IntoIterator<Item = (String, f32)>) -> BTreeMap<String, f32> {
     let raw = scores.into_iter().collect::<Vec<_>>();
     if raw.len() < 2 {
@@ -1102,6 +1341,19 @@ fn warn_doc_hybrid_fallback(notes: &mut Vec<String>, reason: &str) {
     );
 }
 
+fn warn_adr_hybrid_fallback(notes: &mut Vec<String>, reason: &str) {
+    orbit_common::tracing::warn!(
+        target: "orbit.search.adrs",
+        reason,
+        "falling back to lexical ADR search"
+    );
+    push_skip_note(
+        notes,
+        "ADR hybrid vector",
+        &format!("{ADR_HYBRID_FALLBACK_NOTE}: {reason}"),
+    );
+}
+
 fn warn_learning_hybrid_fallback(notes: &mut Vec<String>, reason: &str) {
     orbit_common::tracing::warn!(
         target: "orbit.search.learnings",
@@ -1139,10 +1391,10 @@ fn doc_result_to_global(
     }
 }
 
-fn adr_result_to_global(result: orbit_search::AdrSearchResult) -> GlobalSearchHit {
+fn adr_result_to_global(result: orbit_search::AdrSearchResult, source: &str) -> GlobalSearchHit {
     GlobalSearchHit {
         kind: "adr".to_string(),
-        source: "lexical".to_string(),
+        source: source.to_string(),
         id: Some(result.id),
         path: Some(result.path.to_string_lossy().into_owned()),
         title: Some(result.title),
@@ -1204,6 +1456,14 @@ fn adr_to_global_hit(
     adr: orbit_common::types::Adr,
     matched_by: Option<Vec<String>>,
 ) -> GlobalSearchHit {
+    adr_to_global_hit_with_source(adr, "lexical", matched_by)
+}
+
+fn adr_to_global_hit_with_source(
+    adr: orbit_common::types::Adr,
+    source: &str,
+    matched_by: Option<Vec<String>>,
+) -> GlobalSearchHit {
     let path = std::path::PathBuf::from(".orbit")
         .join("adrs")
         .join(adr.status.cli_name())
@@ -1211,7 +1471,7 @@ fn adr_to_global_hit(
         .join("body.md");
     GlobalSearchHit {
         kind: "adr".to_string(),
-        source: "lexical".to_string(),
+        source: source.to_string(),
         id: Some(adr.id),
         path: Some(path.to_string_lossy().into_owned()),
         title: Some(adr.title),
@@ -1643,6 +1903,15 @@ mod tests {
         }
     }
 
+    fn adr_semantic_hit(id: &str, score: f32) -> AdrSemanticHit {
+        AdrSemanticHit {
+            source_id: id.to_string(),
+            best_field: "decision".to_string(),
+            snippet: "semantic ADR snippet".to_string(),
+            score,
+        }
+    }
+
     fn learning_semantic_hit(id: &str, score: f32) -> LearningSemanticHit {
         LearningSemanticHit {
             source_id: id.to_string(),
@@ -1661,6 +1930,20 @@ mod tests {
         });
         let out = f();
         DOC_SEMANTIC_SEARCH_OVERRIDE.with(|cell| {
+            *cell.borrow_mut() = None;
+        });
+        out
+    }
+
+    fn with_adr_semantic_override<T>(
+        result: Result<Vec<AdrSemanticHit>, String>,
+        f: impl FnOnce() -> T,
+    ) -> T {
+        ADR_SEMANTIC_SEARCH_OVERRIDE.with(|cell| {
+            *cell.borrow_mut() = Some(result);
+        });
+        let out = f();
+        ADR_SEMANTIC_SEARCH_OVERRIDE.with(|cell| {
             *cell.borrow_mut() = None;
         });
         out
@@ -2118,6 +2401,283 @@ mod tests {
         assert_eq!(adr_hit.id.as_deref(), Some(adr_id.as_str()));
         assert_eq!(adr_hit.source, "lexical");
         assert_eq!(adr_hit.score, Some(lexical_adr.score as f32));
+    }
+
+    #[test]
+    fn global_search_adr_lexical_mode_keeps_legacy_json_shape() {
+        let runtime = OrbitRuntime::in_memory().expect("runtime");
+        let id = add_adr(
+            &runtime,
+            "lexadrstable literal ADR",
+            "## Decision\nBody should not affect lexical shape.\n",
+        );
+
+        let response =
+            with_adr_semantic_override(Err("semantic should not be called".to_string()), || {
+                runtime
+                    .global_search(GlobalSearchParams {
+                        query: Some("lexadrstable".to_string()),
+                        kind: GlobalSearchKind::Adr,
+                        limit: 5,
+                        ..Default::default()
+                    })
+                    .expect("ADR lexical search")
+            });
+
+        assert_eq!(response.mode, GlobalSearchMode::Lexical);
+        assert_eq!(
+            serde_json::to_value(&response.results).expect("serialize results"),
+            json!([
+                {
+                    "kind": "adr",
+                    "source": "lexical",
+                    "id": id,
+                    "path": format!(".orbit/adrs/proposed/{id}/body.md"),
+                    "title": "lexadrstable literal ADR",
+                    "status": "proposed",
+                    "score": 92.0,
+                    "matched_by": ["title"]
+                }
+            ])
+        );
+    }
+
+    #[test]
+    fn global_search_adr_hybrid_ranking_differs_from_lexical() {
+        let runtime = OrbitRuntime::in_memory().expect("runtime");
+        let semantic_id = add_adr(
+            &runtime,
+            "Conceptual async-lock ADR",
+            "## Decision\nUse scoped guards for await boundaries.\n",
+        );
+        let lexical_id = add_adr(
+            &runtime,
+            "rankadrfoo literal ADR",
+            "## Decision\nLiteral match only.\n",
+        );
+        add_adr(
+            &runtime,
+            "rankadrfoo secondary ADR",
+            "## Decision\nSecond literal match.\n",
+        );
+
+        let lexical = runtime
+            .global_search(GlobalSearchParams {
+                query: Some("rankadrfoo".to_string()),
+                kind: GlobalSearchKind::Adr,
+                limit: 2,
+                ..Default::default()
+            })
+            .expect("ADR lexical search");
+        let hybrid = with_adr_semantic_override(
+            Ok(vec![
+                adr_semantic_hit(&semantic_id, 1.0),
+                adr_semantic_hit(&lexical_id, 0.0),
+            ]),
+            || {
+                runtime
+                    .global_search(GlobalSearchParams {
+                        query: Some("rankadrfoo".to_string()),
+                        hybrid: true,
+                        kind: GlobalSearchKind::Adr,
+                        limit: 2,
+                        ..Default::default()
+                    })
+                    .expect("ADR hybrid search")
+            },
+        );
+
+        assert_eq!(lexical.results[0].id.as_deref(), Some(lexical_id.as_str()));
+        assert_eq!(hybrid.results[0].id.as_deref(), Some(semantic_id.as_str()));
+        assert_ne!(lexical.results[0].id, hybrid.results[0].id);
+    }
+
+    #[test]
+    fn global_search_doc_hybrid_ranks_federated_adr_semantic_hits() {
+        let runtime = OrbitRuntime::in_memory().expect("runtime");
+        add_doc(&runtime, "docs/fedadr-lexical.md", "fedadr lexical doc");
+        let adr_id = add_adr(
+            &runtime,
+            "Federated semantic ADR",
+            "## Decision\nConceptual match without the literal query.\n",
+        );
+        fs::write(
+            runtime.config_path(),
+            "[docs.search]\nsemantic_weight = 1.0\n[adr.search]\nsemantic_weight = 1.0\n",
+        )
+        .expect("write config");
+
+        let lexical = runtime
+            .global_search(GlobalSearchParams {
+                query: Some("fedadr".to_string()),
+                kind: GlobalSearchKind::Doc,
+                limit: 3,
+                ..Default::default()
+            })
+            .expect("doc lexical search");
+        let hybrid = with_doc_semantic_override(
+            Ok(vec![doc_semantic_hit("docs/fedadr-lexical.md", 0.0)]),
+            || {
+                with_adr_semantic_override(Ok(vec![adr_semantic_hit(&adr_id, 1.0)]), || {
+                    runtime
+                        .global_search(GlobalSearchParams {
+                            query: Some("fedadr".to_string()),
+                            hybrid: true,
+                            kind: GlobalSearchKind::Doc,
+                            limit: 3,
+                            ..Default::default()
+                        })
+                        .expect("doc hybrid search")
+                })
+            },
+        );
+
+        assert_eq!(lexical.results[0].kind, "doc");
+        assert_eq!(hybrid.results[0].kind, "adr");
+        assert_eq!(hybrid.results[0].id.as_deref(), Some(adr_id.as_str()));
+    }
+
+    #[test]
+    fn global_search_adr_hybrid_uses_adr_semantic_weight() {
+        let runtime = OrbitRuntime::in_memory().expect("runtime");
+        let semantic_id = add_adr(
+            &runtime,
+            "ADR weight conceptual",
+            "## Decision\nConceptual guidance.\n",
+        );
+        let lexical_id = add_adr(
+            &runtime,
+            "adrweight literal ADR",
+            "## Decision\nLiteral guidance.\n",
+        );
+        add_adr(
+            &runtime,
+            "adrweight secondary ADR",
+            "## Decision\nSecond literal guidance.\n",
+        );
+        let semantic = vec![
+            adr_semantic_hit(&semantic_id, 1.0),
+            adr_semantic_hit(&lexical_id, 0.0),
+        ];
+
+        let top_id = |weight: f32| {
+            fs::write(
+                runtime.config_path(),
+                format!("[adr.search]\nsemantic_weight = {weight:.1}\n"),
+            )
+            .expect("write config");
+            with_adr_semantic_override(Ok(semantic.clone()), || {
+                runtime
+                    .global_search(GlobalSearchParams {
+                        query: Some("adrweight".to_string()),
+                        hybrid: true,
+                        kind: GlobalSearchKind::Adr,
+                        limit: 2,
+                        ..Default::default()
+                    })
+                    .expect("ADR hybrid search")
+                    .results
+                    .into_iter()
+                    .next()
+                    .expect("top result")
+                    .id
+                    .expect("ADR id")
+            })
+        };
+
+        assert_eq!(top_id(0.0), lexical_id);
+        assert_eq!(top_id(1.0), semantic_id);
+        assert_eq!(top_id(0.5), semantic_id);
+    }
+
+    #[test]
+    fn global_search_adr_hybrid_falls_back_to_lexical_on_semantic_error() {
+        let runtime = OrbitRuntime::in_memory().expect("runtime");
+        let id = add_adr(
+            &runtime,
+            "adrfallback error literal",
+            "## Decision\nBody.\n",
+        );
+
+        let response = with_adr_semantic_override(Err("companion missing".to_string()), || {
+            runtime
+                .global_search(GlobalSearchParams {
+                    query: Some("adrfallback".to_string()),
+                    hybrid: true,
+                    kind: GlobalSearchKind::Adr,
+                    limit: 3,
+                    ..Default::default()
+                })
+                .expect("fallback search")
+        });
+
+        assert!(
+            response
+                .notes
+                .iter()
+                .any(|note| note.contains("falling back to lexical"))
+        );
+        assert_eq!(response.results[0].source, "lexical");
+        assert_eq!(response.results[0].id.as_deref(), Some(id.as_str()));
+    }
+
+    #[test]
+    fn global_search_adr_hybrid_falls_back_when_adr_embeddings_empty() {
+        let runtime = OrbitRuntime::in_memory().expect("runtime");
+        let id = add_adr(
+            &runtime,
+            "adrfallback empty literal",
+            "## Decision\nBody.\n",
+        );
+
+        let response = with_adr_semantic_override(Ok(Vec::new()), || {
+            runtime
+                .global_search(GlobalSearchParams {
+                    query: Some("adrfallback".to_string()),
+                    hybrid: true,
+                    kind: GlobalSearchKind::Adr,
+                    limit: 3,
+                    ..Default::default()
+                })
+                .expect("fallback search")
+        });
+
+        assert!(
+            response
+                .notes
+                .iter()
+                .any(|note| note.contains("falling back to lexical"))
+        );
+        assert_eq!(response.results[0].source, "lexical");
+        assert_eq!(response.results[0].id.as_deref(), Some(id.as_str()));
+    }
+
+    #[test]
+    fn adr_hybrid_handles_single_candidate_side() {
+        let hit = GlobalSearchHit {
+            kind: "adr".to_string(),
+            source: "hybrid".to_string(),
+            id: Some("ADR-0001".to_string()),
+            path: Some(".orbit/adrs/proposed/ADR-0001/body.md".to_string()),
+            title: None,
+            summary: None,
+            status: None,
+            best_field: None,
+            snippet: None,
+            score: None,
+            matched_by: None,
+        };
+        let out = blend_adr_hybrid_candidates(
+            vec![AdrHybridCandidate {
+                hit,
+                lexical_score: Some(0.42),
+                semantic_score: None,
+                semantic: None,
+            }],
+            0.5,
+        );
+
+        assert!((out[0].score.expect("score") - 0.21).abs() < 0.0001);
     }
 
     #[test]

--- a/crates/orbit-core/src/command/semantic.rs
+++ b/crates/orbit-core/src/command/semantic.rs
@@ -1,7 +1,7 @@
 use orbit_common::types::OrbitError;
 
 pub use orbit_search::{
-    CompanionStatus, IndexKind, LearningIndexResult, ScoreBreakdown, SemanticHit,
+    AdrIndexResult, CompanionStatus, IndexKind, LearningIndexResult, ScoreBreakdown, SemanticHit,
     SemanticIndexParams, SemanticIndexResult, SemanticInstallParams, SemanticInstallResult,
     SemanticRelatedParams, SemanticRelatedResult, SemanticSearchParams, SemanticSearchResult,
     SemanticStatsResult, SemanticUninstallParams, SemanticUninstallResult, TaskIndexResult,
@@ -35,22 +35,30 @@ impl OrbitRuntime {
             IndexKind::Docs => self
                 .semantic_index_docs(params)
                 .map(SemanticIndexResult::from),
+            IndexKind::Adrs => self
+                .semantic_index_adrs(params)
+                .map(SemanticIndexResult::from),
             IndexKind::Learnings => self
                 .semantic_index_learnings(params)
                 .map(SemanticIndexResult::from),
             IndexKind::All => {
                 let tasks = self.semantic_index_tasks(params.clone());
                 let docs = self.semantic_index_docs(params.clone());
+                let adrs = self.semantic_index_adrs(params.clone());
                 let learnings = self.semantic_index_learnings(params);
-                match (tasks, docs, learnings) {
-                    (Ok(tasks), Ok(docs), Ok(learnings)) => Ok(SemanticIndexResult::All {
-                        tasks,
-                        docs,
-                        learnings,
-                    }),
-                    (Err(error), _, _) => Err(error),
-                    (_, Err(error), _) => Err(error),
-                    (_, _, Err(error)) => Err(error),
+                match (tasks, docs, adrs, learnings) {
+                    (Ok(tasks), Ok(docs), Ok(adrs), Ok(learnings)) => {
+                        Ok(SemanticIndexResult::All {
+                            tasks,
+                            docs,
+                            adrs,
+                            learnings,
+                        })
+                    }
+                    (Err(error), _, _, _) => Err(error),
+                    (_, Err(error), _, _) => Err(error),
+                    (_, _, Err(error), _) => Err(error),
+                    (_, _, _, Err(error)) => Err(error),
                 }
             }
         }
@@ -69,6 +77,16 @@ impl OrbitRuntime {
         params: SemanticIndexParams,
     ) -> Result<orbit_search::DocIndexResult, OrbitError> {
         self.index_docs(orbit_search::DocIndexParams {
+            model: params.model,
+            force: params.force,
+        })
+    }
+
+    fn semantic_index_adrs(
+        &self,
+        params: SemanticIndexParams,
+    ) -> Result<AdrIndexResult, OrbitError> {
+        self.index_adrs(orbit_search::AdrIndexParams {
             model: params.model,
             force: params.force,
         })

--- a/crates/orbit-search/src/commands/adr_index.rs
+++ b/crates/orbit-search/src/commands/adr_index.rs
@@ -1,0 +1,78 @@
+use orbit_common::types::OrbitError;
+use serde::{Deserialize, Serialize};
+
+use crate::commands::parse_model;
+use crate::vector::{AdrEmbeddingSource, UpsertReport, VectorStore};
+use crate::{Embedder, SubprocessEmbedder};
+
+#[derive(Debug, Clone)]
+pub struct AdrIndexParams {
+    pub model: Option<String>,
+    pub force: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AdrIndexResult {
+    pub model_id: String,
+    pub report: UpsertReport,
+    pub indexed_sources: usize,
+    pub stale_sources: Vec<String>,
+}
+
+pub fn run(
+    vector_store: &VectorStore,
+    adrs: &[AdrEmbeddingSource],
+    params: AdrIndexParams,
+) -> Result<AdrIndexResult, OrbitError> {
+    let model = parse_model(params.model.as_deref())?;
+    let embedder = SubprocessEmbedder::with_model(model.alias)?;
+    run_with_embedder(vector_store, adrs, &embedder, params.force)
+}
+
+pub(crate) fn run_with_embedder(
+    vector_store: &VectorStore,
+    adrs: &[AdrEmbeddingSource],
+    embedder: &dyn Embedder,
+    force: bool,
+) -> Result<AdrIndexResult, OrbitError> {
+    let report = vector_store.reindex_adrs(adrs, embedder, force)?;
+    Ok(AdrIndexResult {
+        model_id: embedder.model_id().to_string(),
+        report: report.upsert,
+        indexed_sources: report.indexed_sources,
+        stale_sources: report.stale_sources,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::NoopEmbedder;
+
+    fn adr(id: &str, title: &str, body: &str) -> AdrEmbeddingSource {
+        AdrEmbeddingSource {
+            id: id.to_string(),
+            title: title.to_string(),
+            body: body.to_string(),
+            tags: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn adr_index_is_idempotent_by_content_hash() {
+        let store = VectorStore::open_in_memory().unwrap();
+        let embedder = NoopEmbedder::small();
+        let adrs = vec![adr(
+            "ADR-0001",
+            "Stable ADR",
+            "## Decision\nKeep the same decision.\n",
+        )];
+
+        let first = run_with_embedder(&store, &adrs, &embedder, false).unwrap();
+        let second = run_with_embedder(&store, &adrs, &embedder, false).unwrap();
+
+        assert!(first.report.embedded_chunks > 0);
+        assert_eq!(second.report.embedded_chunks, 0);
+        assert!(second.report.skipped_fields > 0);
+    }
+}

--- a/crates/orbit-search/src/commands/adr_search.rs
+++ b/crates/orbit-search/src/commands/adr_search.rs
@@ -1,0 +1,240 @@
+use std::collections::BTreeMap;
+
+use orbit_common::types::OrbitError;
+use serde::{Deserialize, Serialize};
+
+use crate::commands::resolve_query_model;
+use crate::vector::VectorStore;
+use crate::vector::query::{CosineHit, cosine_top_k, snippet_for_hit};
+use crate::vector::store::SOURCE_KIND_ADR;
+use crate::{Embedder, SubprocessEmbedder};
+
+const DEFAULT_LIMIT: usize = 10;
+const RETRIEVER_OVERFETCH: usize = 4;
+const SNIPPET_MAX_CHARS: usize = 280;
+
+#[derive(Debug, Clone)]
+pub struct AdrSemanticSearchParams {
+    pub query: String,
+    pub limit: usize,
+    pub model: Option<String>,
+}
+
+impl AdrSemanticSearchParams {
+    pub fn normalized_limit(&self) -> usize {
+        if self.limit == 0 {
+            DEFAULT_LIMIT
+        } else {
+            self.limit
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct AdrSemanticSearchResult {
+    pub results: Vec<AdrSemanticHit>,
+    pub model_id: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct AdrSemanticHit {
+    pub source_id: String,
+    pub best_field: String,
+    pub snippet: String,
+    pub score: f32,
+}
+
+pub fn run(
+    vector_store: &VectorStore,
+    params: AdrSemanticSearchParams,
+) -> Result<AdrSemanticSearchResult, OrbitError> {
+    let model = resolve_query_model(params.model.as_deref())?;
+    let embedder = SubprocessEmbedder::with_model(model.alias)?;
+    run_with_embedder(vector_store, &embedder, params)
+}
+
+pub(crate) fn run_with_embedder(
+    vector_store: &VectorStore,
+    embedder: &dyn Embedder,
+    params: AdrSemanticSearchParams,
+) -> Result<AdrSemanticSearchResult, OrbitError> {
+    let query = params.query.trim();
+    if query.is_empty() {
+        return Err(OrbitError::InvalidInput(
+            "ADR semantic search query must not be empty".to_string(),
+        ));
+    }
+
+    let vectors = embedder.embed(&[query])?;
+    let query_vector = vectors.into_iter().next().ok_or_else(|| {
+        OrbitError::Execution("embedder returned no vector for ADR semantic search".to_string())
+    })?;
+    let limit = params.normalized_limit();
+    let retriever_limit = limit.saturating_mul(RETRIEVER_OVERFETCH).max(limit);
+    let model_id = embedder.model_id().to_string();
+    let cosine = cosine_top_k(
+        vector_store,
+        &query_vector,
+        &model_id,
+        retriever_limit,
+        Some(SOURCE_KIND_ADR),
+    )?;
+    let hits = rollup_adr_hits(vector_store, cosine, limit)?;
+
+    Ok(AdrSemanticSearchResult {
+        results: hits,
+        model_id,
+    })
+}
+
+fn rollup_adr_hits(
+    vector_store: &VectorStore,
+    hits: Vec<CosineHit>,
+    limit: usize,
+) -> Result<Vec<AdrSemanticHit>, OrbitError> {
+    let mut best = BTreeMap::<String, CosineHit>::new();
+    for hit in hits {
+        best.entry(hit.source_id.clone())
+            .and_modify(|current| {
+                if crate::vector::query::cosine::compare_cosine_hits(&hit, current).is_lt() {
+                    *current = hit.clone();
+                }
+            })
+            .or_insert(hit);
+    }
+
+    let mut rolled = Vec::new();
+    for hit in best.into_values() {
+        let snippet = snippet_for_hit(
+            vector_store,
+            SOURCE_KIND_ADR,
+            &hit.source_id,
+            &hit.field,
+            Some(hit.chunk_idx),
+            None,
+        )?
+        .unwrap_or_default();
+        rolled.push(AdrSemanticHit {
+            source_id: hit.source_id,
+            best_field: hit.field,
+            snippet: truncate_snippet(&snippet),
+            score: hit.score,
+        });
+    }
+    rolled.sort_by(compare_adr_semantic_hits);
+    rolled.truncate(limit);
+    Ok(rolled)
+}
+
+fn compare_adr_semantic_hits(left: &AdrSemanticHit, right: &AdrSemanticHit) -> std::cmp::Ordering {
+    right
+        .score
+        .total_cmp(&left.score)
+        .then_with(|| left.source_id.cmp(&right.source_id))
+        .then_with(|| left.best_field.cmp(&right.best_field))
+}
+
+fn truncate_snippet(snippet: &str) -> String {
+    let trimmed = snippet.trim();
+    let mut end = 0;
+    for (idx, ch) in trimmed.char_indices() {
+        if idx > SNIPPET_MAX_CHARS {
+            break;
+        }
+        end = idx + ch.len_utf8();
+    }
+    if end >= trimmed.len() {
+        trimmed.to_string()
+    } else {
+        format!("{}...", trimmed[..end].trim_end())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use orbit_common::types::OrbitError;
+
+    use super::*;
+    use crate::vector::AdrEmbeddingSource;
+    use crate::{Embedder, NoopEmbedder};
+
+    struct KeywordEmbedder;
+
+    impl Embedder for KeywordEmbedder {
+        fn model_id(&self) -> &str {
+            "keyword"
+        }
+
+        fn dim(&self) -> usize {
+            2
+        }
+
+        fn max_input_tokens(&self) -> usize {
+            512
+        }
+
+        fn embed(&self, texts: &[&str]) -> Result<Vec<Vec<f32>>, OrbitError> {
+            Ok(texts
+                .iter()
+                .map(|text| {
+                    if text.to_ascii_lowercase().contains("concept") {
+                        vec![1.0, 0.0]
+                    } else {
+                        vec![0.0, 1.0]
+                    }
+                })
+                .collect())
+        }
+
+        fn token_count(&self, text: &str) -> Result<usize, OrbitError> {
+            Ok(text.split_whitespace().count().max(1))
+        }
+    }
+
+    fn adr(id: &str, body: &str) -> AdrEmbeddingSource {
+        AdrEmbeddingSource {
+            id: id.to_string(),
+            title: id.to_string(),
+            body: body.to_string(),
+            tags: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn adr_semantic_search_filters_to_adr_rows() {
+        let store = VectorStore::open_in_memory().unwrap();
+        let adr_embedder = KeywordEmbedder;
+        store
+            .reindex_adrs(
+                &[
+                    adr("ADR-0001", "## Decision\nconcept match\n"),
+                    adr("ADR-0002", "## Decision\nother body\n"),
+                ],
+                &adr_embedder,
+                false,
+            )
+            .unwrap();
+        store
+            .upsert_embeddings(
+                "task",
+                "ORB-00000",
+                &[crate::vector::EmbeddingField::new("title", "concept task")],
+                &NoopEmbedder::small(),
+                false,
+            )
+            .unwrap();
+
+        let result = run_with_embedder(
+            &store,
+            &adr_embedder,
+            AdrSemanticSearchParams {
+                query: "concept".to_string(),
+                limit: 1,
+                model: None,
+            },
+        )
+        .unwrap();
+
+        assert_eq!(result.results[0].source_id, "ADR-0001");
+    }
+}

--- a/crates/orbit-search/src/commands/mod.rs
+++ b/crates/orbit-search/src/commands/mod.rs
@@ -5,6 +5,8 @@
 //! top-level `OrbitRuntime` exposes thin delegates that build the runtime's
 //! shared state into these calls.
 
+mod adr_index;
+mod adr_search;
 mod doc_index;
 mod doc_search;
 mod install;
@@ -16,6 +18,8 @@ mod search;
 mod stats;
 mod uninstall;
 
+pub use adr_index::{AdrIndexParams, AdrIndexResult};
+pub use adr_search::{AdrSemanticHit, AdrSemanticSearchParams, AdrSemanticSearchResult};
 pub use doc_index::{DocIndexParams, DocIndexResult};
 pub use doc_search::{DocSemanticHit, DocSemanticSearchParams, DocSemanticSearchResult};
 pub use install::{SemanticInstallParams, SemanticInstallResult};
@@ -36,7 +40,7 @@ use std::fs;
 
 use orbit_common::types::{OrbitError, Task};
 
-use crate::vector::{DocEmbeddingSource, LearningEmbeddingSource, VectorStore};
+use crate::vector::{AdrEmbeddingSource, DocEmbeddingSource, LearningEmbeddingSource, VectorStore};
 use crate::{CompanionPaths, ModelSpec, default_model};
 
 pub(crate) const DEFAULT_RELEASE_BASE_URL: &str =
@@ -111,6 +115,14 @@ pub fn doc_index(
     doc_index::run(vector_store, docs, params)
 }
 
+pub fn adr_index(
+    vector_store: &VectorStore,
+    adrs: &[AdrEmbeddingSource],
+    params: AdrIndexParams,
+) -> Result<AdrIndexResult, OrbitError> {
+    adr_index::run(vector_store, adrs, params)
+}
+
 pub fn learning_index(
     vector_store: &VectorStore,
     learnings: &[LearningEmbeddingSource],
@@ -138,6 +150,13 @@ pub fn doc_semantic_search(
     params: DocSemanticSearchParams,
 ) -> Result<DocSemanticSearchResult, OrbitError> {
     doc_search::run(vector_store, params)
+}
+
+pub fn adr_semantic_search(
+    vector_store: &VectorStore,
+    params: AdrSemanticSearchParams,
+) -> Result<AdrSemanticSearchResult, OrbitError> {
+    adr_search::run(vector_store, params)
 }
 
 pub fn learning_semantic_search(

--- a/crates/orbit-search/src/commands/reindex.rs
+++ b/crates/orbit-search/src/commands/reindex.rs
@@ -2,6 +2,7 @@ use orbit_common::types::{OrbitError, Task};
 use serde::{Deserialize, Serialize};
 use std::str::FromStr;
 
+use crate::commands::adr_index::AdrIndexResult;
 use crate::commands::doc_index::DocIndexResult;
 use crate::commands::learning_index::LearningIndexResult;
 use crate::commands::parse_model;
@@ -13,6 +14,7 @@ use crate::{Embedder, SubprocessEmbedder};
 pub enum IndexKind {
     Tasks,
     Docs,
+    Adrs,
     Learnings,
     All,
 }
@@ -30,10 +32,11 @@ impl FromStr for IndexKind {
         match raw {
             "tasks" => Ok(Self::Tasks),
             "docs" => Ok(Self::Docs),
+            "adrs" => Ok(Self::Adrs),
             "learnings" => Ok(Self::Learnings),
             "all" => Ok(Self::All),
             value => Err(OrbitError::InvalidInput(format!(
-                "unsupported semantic index kind `{value}`; supported values: tasks, docs, learnings, all"
+                "unsupported semantic index kind `{value}`; supported values: tasks, docs, adrs, learnings, all"
             ))),
         }
     }
@@ -82,6 +85,12 @@ pub enum SemanticIndexResult {
         indexed_sources: usize,
         stale_sources: Vec<String>,
     },
+    Adrs {
+        model_id: String,
+        report: UpsertReport,
+        indexed_sources: usize,
+        stale_sources: Vec<String>,
+    },
     Learnings {
         model_id: String,
         report: UpsertReport,
@@ -91,6 +100,7 @@ pub enum SemanticIndexResult {
     All {
         tasks: TaskIndexResult,
         docs: DocIndexResult,
+        adrs: AdrIndexResult,
         learnings: LearningIndexResult,
     },
 }
@@ -107,6 +117,17 @@ impl From<TaskIndexResult> for SemanticIndexResult {
 impl From<DocIndexResult> for SemanticIndexResult {
     fn from(result: DocIndexResult) -> Self {
         Self::Docs {
+            model_id: result.model_id,
+            report: result.report,
+            indexed_sources: result.indexed_sources,
+            stale_sources: result.stale_sources,
+        }
+    }
+}
+
+impl From<AdrIndexResult> for SemanticIndexResult {
+    fn from(result: AdrIndexResult) -> Self {
+        Self::Adrs {
             model_id: result.model_id,
             report: result.report,
             indexed_sources: result.indexed_sources,
@@ -165,6 +186,10 @@ mod tests {
         assert_eq!(docs.kind, Some(IndexKind::Docs));
         assert_eq!(docs.resolved_kind(), IndexKind::Docs);
 
+        let adrs: SemanticIndexParams = serde_json::from_str(r#"{"kind":"adrs"}"#).unwrap();
+        assert_eq!(adrs.kind, Some(IndexKind::Adrs));
+        assert_eq!(adrs.resolved_kind(), IndexKind::Adrs);
+
         let learnings: SemanticIndexParams =
             serde_json::from_str(r#"{"kind":"learnings"}"#).unwrap();
         assert_eq!(learnings.kind, Some(IndexKind::Learnings));
@@ -181,6 +206,14 @@ mod tests {
 
         assert!(error.to_string().contains("`learning`"));
         assert!(error.to_string().contains("learnings"));
+    }
+
+    #[test]
+    fn semantic_index_kind_rejects_singular_adr() {
+        let error = IndexKind::from_str("adr").expect_err("singular kind should fail");
+
+        assert!(error.to_string().contains("`adr`"));
+        assert!(error.to_string().contains("adrs"));
     }
 
     #[test]

--- a/crates/orbit-search/src/lib.rs
+++ b/crates/orbit-search/src/lib.rs
@@ -36,16 +36,17 @@ mod subprocess;
 mod vector;
 
 pub use commands::{
-    CompanionStatus, DocIndexParams, DocIndexResult, DocSemanticHit, DocSemanticSearchParams,
-    DocSemanticSearchResult, IndexKind, LearningIndexParams, LearningIndexResult,
-    LearningSemanticHit, LearningSemanticSearchParams, LearningSemanticSearchResult,
-    ScoreBreakdown, SemanticHit, SemanticIndexParams, SemanticIndexResult, SemanticInstallParams,
-    SemanticInstallResult, SemanticReindexParams, SemanticReindexResult, SemanticRelatedParams,
-    SemanticRelatedResult, SemanticSearchParams, SemanticSearchResult, SemanticStatsResult,
-    SemanticUninstallParams, SemanticUninstallResult, TaskIndexResult, doc_index,
-    doc_semantic_search, learning_index, learning_semantic_search, semantic_index,
-    semantic_install, semantic_reindex, semantic_related, semantic_search, semantic_stats,
-    semantic_uninstall,
+    AdrIndexParams, AdrIndexResult, AdrSemanticHit, AdrSemanticSearchParams,
+    AdrSemanticSearchResult, CompanionStatus, DocIndexParams, DocIndexResult, DocSemanticHit,
+    DocSemanticSearchParams, DocSemanticSearchResult, IndexKind, LearningIndexParams,
+    LearningIndexResult, LearningSemanticHit, LearningSemanticSearchParams,
+    LearningSemanticSearchResult, ScoreBreakdown, SemanticHit, SemanticIndexParams,
+    SemanticIndexResult, SemanticInstallParams, SemanticInstallResult, SemanticReindexParams,
+    SemanticReindexResult, SemanticRelatedParams, SemanticRelatedResult, SemanticSearchParams,
+    SemanticSearchResult, SemanticStatsResult, SemanticUninstallParams, SemanticUninstallResult,
+    TaskIndexResult, adr_index, adr_semantic_search, doc_index, doc_semantic_search,
+    learning_index, learning_semantic_search, semantic_index, semantic_install, semantic_reindex,
+    semantic_related, semantic_search, semantic_stats, semantic_uninstall,
 };
 pub use companion::{
     CompanionPaths, INSTALL_REMEDIATION, locate_companion, platform_companion_filename, platform_id,
@@ -59,6 +60,7 @@ pub use noop::NoopEmbedder;
 pub use rpc::{RpcError, RpcRequest, RpcResponse, RpcResult};
 pub use subprocess::SubprocessEmbedder;
 pub use vector::{
-    DocEmbeddingSource, EmbedWorker, LearningEmbeddingSource, SOURCE_KIND_DOC,
-    SOURCE_KIND_LEARNING, SOURCE_KIND_TASK, SemanticStats, UpsertReport, VectorStore,
+    AdrEmbeddingSource, DocEmbeddingSource, EmbedWorker, LearningEmbeddingSource, SOURCE_KIND_ADR,
+    SOURCE_KIND_DOC, SOURCE_KIND_LEARNING, SOURCE_KIND_TASK, SemanticStats, UpsertReport,
+    VectorStore,
 };

--- a/crates/orbit-search/src/vector/adr_fields.rs
+++ b/crates/orbit-search/src/vector/adr_fields.rs
@@ -1,0 +1,117 @@
+//! Maps an ADR record to the per-field rows embedded for ADR search.
+
+use super::EmbeddingField;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AdrEmbeddingSource {
+    pub id: String,
+    pub title: String,
+    pub body: String,
+    pub tags: Vec<String>,
+}
+
+pub fn adr_embedding_fields(adr: &AdrEmbeddingSource) -> Vec<EmbeddingField> {
+    let mut fields = Vec::new();
+    push_field(&mut fields, "title", &adr.title);
+    if let Some(decision) = markdown_section(&adr.body, "decision") {
+        push_field(&mut fields, "decision", &decision);
+    }
+    if let Some(context) = markdown_section(&adr.body, "context") {
+        push_field(&mut fields, "context", &context);
+    }
+    if let Some(consequences) = markdown_section(&adr.body, "consequences") {
+        push_field(&mut fields, "consequences", &consequences);
+    }
+    if !adr.tags.is_empty() {
+        push_field(&mut fields, "tags", &adr.tags.join("\n"));
+    }
+    fields
+}
+
+fn push_field(fields: &mut Vec<EmbeddingField>, field: impl Into<String>, text: &str) {
+    if !text.trim().is_empty() {
+        fields.push(EmbeddingField::new(field, text.trim().to_string()));
+    }
+}
+
+fn markdown_section(body: &str, wanted: &str) -> Option<String> {
+    let mut active = false;
+    let mut lines = Vec::new();
+    for line in body.lines() {
+        if let Some(title) = markdown_heading_title(line) {
+            if active {
+                break;
+            }
+            active = normalize_heading(title) == normalize_heading(wanted);
+            continue;
+        }
+        if active {
+            lines.push(line);
+        }
+    }
+    let section = lines.join("\n");
+    if section.trim().is_empty() {
+        None
+    } else {
+        Some(section.trim().to_string())
+    }
+}
+
+fn markdown_heading_title(line: &str) -> Option<&str> {
+    let trimmed = line.trim_start();
+    let hashes = trimmed.chars().take_while(|ch| *ch == '#').count();
+    if hashes == 0 || hashes > 6 {
+        return None;
+    }
+    let rest = &trimmed[hashes..];
+    if !rest.starts_with(' ') {
+        return None;
+    }
+    Some(rest.trim())
+}
+
+fn normalize_heading(value: &str) -> String {
+    value.trim().to_ascii_lowercase().replace('-', " ")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn adr_embedding_fields_use_stable_section_names() {
+        let source = AdrEmbeddingSource {
+            id: "ADR-0001".to_string(),
+            title: "Keep task FTS task-bound".to_string(),
+            body: "## Context\nTasks need isolated lexical rows.\n\n## Decision\nKeep task FTS task-bound.\n\n## Consequences\nDocs use corpus_fts.\n".to_string(),
+            tags: vec!["search".to_string(), "adr".to_string()],
+        };
+
+        let field_names = adr_embedding_fields(&source)
+            .into_iter()
+            .map(|field| field.field)
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            field_names,
+            vec!["title", "decision", "context", "consequences", "tags"]
+        );
+    }
+
+    #[test]
+    fn adr_embedding_fields_skip_status_and_legacy_metadata() {
+        let source = AdrEmbeddingSource {
+            id: "ADR-0002".to_string(),
+            title: "Decision only".to_string(),
+            body: "No canonical sections yet.".to_string(),
+            tags: Vec::new(),
+        };
+
+        let field_names = adr_embedding_fields(&source)
+            .into_iter()
+            .map(|field| field.field)
+            .collect::<Vec<_>>();
+
+        assert_eq!(field_names, vec!["title"]);
+    }
+}

--- a/crates/orbit-search/src/vector/mod.rs
+++ b/crates/orbit-search/src/vector/mod.rs
@@ -12,6 +12,8 @@
 //!   `Task`.
 //! - [`doc_fields`] — extracts the per-field rows that get embedded for a
 //!   docs corpus record.
+//! - [`adr_fields`] — extracts the per-field rows that get embedded for
+//!   Architecture Decision Records.
 //! - [`learning_fields`] — extracts the per-field rows that get embedded for
 //!   project-learning records.
 //!
@@ -20,6 +22,7 @@
 //! (`cosine_similarity`, `encode_f32_blob`, `decode_f32_blob`) shared across
 //! those submodules.
 
+pub(crate) mod adr_fields;
 pub(crate) mod chunker;
 pub(crate) mod doc_fields;
 pub(crate) mod learning_fields;
@@ -28,9 +31,12 @@ pub(crate) mod store;
 pub(crate) mod task_fields;
 pub(crate) mod worker;
 
+pub use adr_fields::AdrEmbeddingSource;
 pub use doc_fields::DocEmbeddingSource;
 pub use learning_fields::LearningEmbeddingSource;
-pub use store::{SOURCE_KIND_DOC, SOURCE_KIND_LEARNING, SOURCE_KIND_TASK, VectorStore};
+pub use store::{
+    SOURCE_KIND_ADR, SOURCE_KIND_DOC, SOURCE_KIND_LEARNING, SOURCE_KIND_TASK, VectorStore,
+};
 pub use worker::EmbedWorker;
 
 use orbit_common::types::OrbitError;

--- a/crates/orbit-search/src/vector/store/adrs.rs
+++ b/crates/orbit-search/src/vector/store/adrs.rs
@@ -1,0 +1,126 @@
+//! ADR-corpus indexing entry points.
+
+use std::collections::BTreeSet;
+
+use orbit_common::types::OrbitError;
+
+use super::{SOURCE_KIND_ADR, VectorStore};
+use crate::Embedder;
+use crate::vector::UpsertReport;
+use crate::vector::adr_fields::{AdrEmbeddingSource, adr_embedding_fields};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AdrReindexReport {
+    pub upsert: UpsertReport,
+    pub indexed_sources: usize,
+    pub stale_sources: Vec<String>,
+}
+
+impl VectorStore {
+    pub fn index_adr(
+        &self,
+        adr: &AdrEmbeddingSource,
+        embedder: &dyn Embedder,
+        force: bool,
+    ) -> Result<UpsertReport, OrbitError> {
+        self.upsert_embeddings(
+            SOURCE_KIND_ADR,
+            &adr.id,
+            &adr_embedding_fields(adr),
+            embedder,
+            force,
+        )
+    }
+
+    pub fn reindex_adrs(
+        &self,
+        adrs: &[AdrEmbeddingSource],
+        embedder: &dyn Embedder,
+        force: bool,
+    ) -> Result<AdrReindexReport, OrbitError> {
+        let mut upsert = UpsertReport::default();
+        let live = adrs
+            .iter()
+            .map(|adr| adr.id.clone())
+            .collect::<BTreeSet<_>>();
+        for adr in adrs {
+            let report = self.index_adr(adr, embedder, force)?;
+            upsert.embedded_chunks += report.embedded_chunks;
+            upsert.skipped_fields += report.skipped_fields;
+        }
+
+        let mut stale_sources = Vec::new();
+        for source_id in self.source_ids(SOURCE_KIND_ADR)? {
+            if !live.contains(&source_id) {
+                self.delete_source(SOURCE_KIND_ADR, &source_id)?;
+                stale_sources.push(source_id);
+            }
+        }
+        Ok(AdrReindexReport {
+            upsert,
+            indexed_sources: live.len(),
+            stale_sources,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::NoopEmbedder;
+
+    fn adr(id: &str, title: &str, decision: &str) -> AdrEmbeddingSource {
+        AdrEmbeddingSource {
+            id: id.to_string(),
+            title: title.to_string(),
+            body: format!(
+                "## Context\nContext for {title}.\n\n## Decision\n{decision}\n\n## Consequences\nConsequences.\n"
+            ),
+            tags: vec!["search".to_string()],
+        }
+    }
+
+    #[test]
+    fn noop_adr_indexing_populates_adr_rows() {
+        let store = VectorStore::open_in_memory().unwrap();
+        let embedder = NoopEmbedder::small();
+
+        let report = store
+            .index_adr(
+                &adr("ADR-0001", "Semantic ADRs", "Index ADR decisions."),
+                &embedder,
+                false,
+            )
+            .unwrap();
+        let stats = store.stats(&[]).unwrap();
+
+        assert!(report.embedded_chunks >= 4);
+        assert_eq!(stats.counts[0].source_kind, "adr");
+        assert_eq!(stats.counts[0].model_id, "noop");
+    }
+
+    #[test]
+    fn reindex_adrs_removes_stale_sources() {
+        let store = VectorStore::open_in_memory().unwrap();
+        let embedder = NoopEmbedder::small();
+        store
+            .index_adr(
+                &adr("ADR-0001", "Old ADR", "Old decision"),
+                &embedder,
+                false,
+            )
+            .unwrap();
+
+        let report = store
+            .reindex_adrs(
+                &[adr("ADR-0002", "New ADR", "New decision")],
+                &embedder,
+                false,
+            )
+            .unwrap();
+        let source_ids = store.source_ids(SOURCE_KIND_ADR).unwrap();
+
+        assert_eq!(report.stale_sources, vec!["ADR-0001"]);
+        assert_eq!(source_ids.into_iter().collect::<Vec<_>>(), vec!["ADR-0002"]);
+    }
+}

--- a/crates/orbit-search/src/vector/store/mod.rs
+++ b/crates/orbit-search/src/vector/store/mod.rs
@@ -7,6 +7,7 @@
 //!   plus its private SQL helpers (`delete_field_rows`, content-hash check).
 //! - [`tasks`] — `index_task` / `reindex_tasks` task-corpus entry points.
 //! - [`docs`] — `index_doc` / `reindex_docs` docs-corpus entry points.
+//! - [`adrs`] — `index_adr` / `reindex_adrs` ADR-corpus entry points.
 //! - [`learning`] — `index_learning` / `reindex_learnings` project-learning
 //!   corpus entry points.
 //! - [`queries`] — `delete_source` and `stats` read/cascade operations.
@@ -15,6 +16,7 @@
 //! plumbing (`open`, `open_in_memory`, `connection`, the WAL pragma helper)
 //! and the small `pub(super)` constants shared across the submodules above.
 
+mod adrs;
 mod docs;
 mod learning;
 mod queries;
@@ -32,6 +34,7 @@ pub const SOURCE_KIND_TASK: &str = "task";
 // ADR-0180: docs share the embeddings table through source_kind, not a separate schema.
 pub const SOURCE_KIND_DOC: &str = "doc";
 pub const SOURCE_KIND_LEARNING: &str = "learning";
+pub const SOURCE_KIND_ADR: &str = "adr";
 
 #[derive(Clone)]
 pub struct VectorStore {


### PR DESCRIPTION
## Task

ORB-00216 — Add ADR-corpus embeddings: `orbit semantic index --kind adrs` + hybrid scoring for `--kind adr` and federated ADR results

## Execution Summary

Implemented ADR semantic indexing and hybrid ADR search. Added `orbit semantic index --kind adrs`, ADR embedding field extraction/storage, stale-source sweeping, idempotent reindexing, and status-agnostic ADR source collection.

Search now blends lexical ADR scores with cosine scores for `--kind adr --hybrid` and for federated ADRs in doc/all searches. Federated scoring uses the docs weight for doc rows and `[adr.search].semantic_weight` for ADR rows. CLI help, packaged search/ADR skill docs, and project learning coverage were updated.

Rebase note: the original branch conflicted with an `agent-main` learning that already owned `L-0028`; I preserved the base `L-0028` and re-added the ORB-00216 ADR indexing learning as `L-0031`.

## Validation

- Original implementation run reported targeted cargo tests, semantic ADR indexing/idempotency checks, sqlite ADR row count checks, dependency-direction checks, and `make ci-fast` passing before PR open failed on branch freshness.
- After branch refresh: rebased onto current `origin/agent-main`; verified branch is `0` behind and `1` ahead; verified no unresolved conflict markers in touched Orbit learning/code paths.
- `make ci-fast` currently stops on an inherited fmt-check diff in `crates/orbit-engine/src/executor/automation/duel/planning_duel/runner/tests/mod.rs`. This branch has no diff under `crates/orbit-engine/`, and `git diff origin/agent-main -- crates/orbit-engine/src/executor/automation/duel/planning_duel/runner/tests/mod.rs` is empty.

## Branch Freshness

- Base: `agent-main` (`origin/agent-main` at `c4985229`)
- Head: `orbit/ORB-00216-6a0e7fed` (`a0c027cc`)
- Behind base: `0`
- Ahead of base: `1`
