### PR TITLE
Re-check task admission before gate dispatch

### DIFF
--- a/crates/orbit-core/assets/activities/invoke_and_wait.yaml
+++ b/crates/orbit-core/assets/activities/invoke_and_wait.yaml
@@ -16,7 +16,11 @@ spec:
     `failed`, `cancelled`, or `timeout`. A `timeout` here means the
     WAIT side of the activity exceeded `timeout_seconds`; the child
     Run itself may still be running — callers that care must inspect
-    `run_id` to decide follow-up.
+    `run_id` to decide follow-up. Gate workflows may pass
+    `admission_task_ids` and `admission_workflow` to re-check workflow
+    admission immediately before dispatch; stale `review` / `done` tasks
+    return a succeeded no-op output with `skipped: true` and do not submit a
+    child Run.
   input_schema_json:
     type: object
     required: [job_name, run_input]
@@ -35,6 +39,12 @@ spec:
       priority:
         type: string
         enum: [low, medium, high, critical]
+      admission_task_ids:
+        type: array
+        items:
+          type: string
+      admission_workflow:
+        type: string
   output_schema_json:
     type: object
     required: [status, run_id]
@@ -50,5 +60,13 @@ spec:
         type: object
       error:
         type: string
+      skipped:
+        type: boolean
+      reason:
+        type: string
+      task_statuses:
+        type: array
+        items:
+          type: object
   action: invoke_and_wait
   config: {}

--- a/crates/orbit-core/assets/jobs/task_gate_pipeline.yaml
+++ b/crates/orbit-core/assets/jobs/task_gate_pipeline.yaml
@@ -24,7 +24,10 @@
 #   the first child pipeline finishes.
 # - The dispatched child pipeline runs while the reservation is still valid;
 #   a fresh `orbit.task.locks.reserve` call from another bundle will either
-#   wait or surface `task.locks.reserve.denied`. After `invoke_and_wait`
+#   wait or surface `task.locks.reserve.denied`. `invoke_and_wait` re-checks
+#   worktree workflow admission immediately before child dispatch; stale
+#   `review` / `done` tasks return a succeeded no-op output so the reservation
+#   can be released without launching a child run. After `invoke_and_wait`
 #   returns a terminal child-run status, `release_reservation` frees the
 #   reservation immediately before `require_child_success` fails the gate on
 #   a non-succeeded child. TTL remains the fallback for abandoned/crashed runs.
@@ -82,6 +85,8 @@ spec:
           base_branch: "{{ input.base_branch }}"
           base_sync: "{{ input.base_sync }}"
           auto_push: true
+        admission_task_ids: "{{ input.task_ids }}"
+        admission_workflow: worktree_setup
         timeout_seconds: "{{ input.dispatch_timeout_seconds }}"
 
     - id: release_reservation

--- a/crates/orbit-core/src/command/job/catalog.rs
+++ b/crates/orbit-core/src/command/job/catalog.rs
@@ -544,6 +544,14 @@ spec:
                     input["job_name"],
                     Value::String("task_{{ input.mode }}_pipeline".to_string())
                 );
+                assert_eq!(
+                    input["admission_task_ids"],
+                    Value::String("{{ input.task_ids }}".to_string())
+                );
+                assert_eq!(
+                    input["admission_workflow"],
+                    Value::String("worktree_setup".to_string())
+                );
             }
             other => panic!("expected dispatch target ref, got {other:?}"),
         }

--- a/crates/orbit-core/src/command/job/exec.rs
+++ b/crates/orbit-core/src/command/job/exec.rs
@@ -348,14 +348,22 @@ mod tests {
     use super::*;
 
     use std::collections::{BTreeMap, HashMap};
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::{Arc, Mutex};
 
     use chrono::Utc;
-    use orbit_common::types::{ExecutorDef, ExecutorType};
+    use orbit_common::types::{
+        AuditEventStatus, ExecutorDef, ExecutorType, TaskPriority, TaskStatus, TaskType,
+    };
+    use orbit_engine::{ResolvedCliExecutor, V2RuntimeHost};
     use orbit_store::InvocationQuery;
+    use orbit_tools::{FsAuditLogger, ToolContext};
     use serde_json::json;
     use tempfile::tempdir;
 
-    use crate::command::task::TaskAddParams;
+    use crate::command::activity::seed_default_activities;
+    use crate::command::job::seed_default_jobs;
+    use crate::command::task::{TaskAddParams, TaskUpdateParams};
 
     fn test_runtime() -> (tempfile::TempDir, OrbitRuntime, PathBuf, PathBuf) {
         let root = tempdir().expect("create tempdir");
@@ -367,6 +375,240 @@ mod tests {
         let runtime =
             OrbitRuntime::from_roots(&global_root, &workspace_root).expect("build test runtime");
         (root, runtime, repo_root, global_root)
+    }
+
+    fn seed_default_catalogs(global_root: &Path) {
+        seed_default_activities(&global_root.join("resources/activities"), true)
+            .expect("seed default activities");
+        seed_default_jobs(&global_root.join("resources/jobs"), true).expect("seed default jobs");
+    }
+
+    fn write_context_file(repo_root: &Path, relative_path: &str) {
+        let path = repo_root.join(relative_path);
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).expect("create context parent");
+        }
+        std::fs::write(path, "fixture\n").expect("write context file");
+    }
+
+    fn seed_gate_task(runtime: &OrbitRuntime, repo_root: &Path, status: TaskStatus) -> String {
+        write_context_file(repo_root, "src/lib.rs");
+        runtime
+            .add_task(TaskAddParams {
+                title: format!("Gate fixture {status}"),
+                description: "Fixture task for task_gate_pipeline admission.".to_string(),
+                acceptance_criteria: vec!["Gate behavior is observable.".to_string()],
+                plan: "Fixture execution plan.".to_string(),
+                context_files: vec!["src/lib.rs".to_string()],
+                workspace_path: Some(".".to_string()),
+                priority: TaskPriority::Medium,
+                task_type: Some(TaskType::Chore),
+                status: Some(status),
+                ..Default::default()
+            })
+            .expect("seed gate task")
+            .id
+    }
+
+    fn resolved_gate_job(runtime: &OrbitRuntime) -> orbit_common::types::activity_job::JobV2 {
+        let (_path, mut job) = runtime
+            .load_v2_job_asset_by_name("task_gate_pipeline")
+            .expect("load task gate pipeline");
+        let catalog = runtime.v2_activity_catalog().expect("activity catalog");
+        resolve_job_catalog_refs_for_execution(&mut job, &catalog)
+            .expect("resolve task gate activities");
+        job
+    }
+
+    fn execute_gate_job(
+        runtime: &OrbitRuntime,
+        repo_root: &Path,
+        host: &dyn V2RuntimeHost,
+        input: Value,
+        run_id: &str,
+    ) -> JobOutcome {
+        try_execute_gate_job(runtime, repo_root, host, input, run_id).expect("execute gate job")
+    }
+
+    fn try_execute_gate_job(
+        runtime: &OrbitRuntime,
+        repo_root: &Path,
+        host: &dyn V2RuntimeHost,
+        input: Value,
+        run_id: &str,
+    ) -> Result<JobOutcome, DispatchError> {
+        let job = resolved_gate_job(runtime);
+        let writer = V2AuditWriter::with_disk_sinks(
+            &runtime.paths().audit_dir,
+            run_id,
+            SYSTEM_AUDIT_IDENTITY,
+            Some(repo_root),
+        )
+        .expect("audit writer");
+        execute_job(&job, input, run_id, writer, host)
+    }
+
+    struct ReserveThenStatusHost<'a> {
+        runtime: &'a OrbitRuntime,
+        task_id: String,
+        status_after_reserve: TaskStatus,
+        reserve_calls: AtomicUsize,
+    }
+
+    impl ReserveThenStatusHost<'_> {
+        fn reserve_calls(&self) -> usize {
+            self.reserve_calls.load(Ordering::SeqCst)
+        }
+    }
+
+    impl V2RuntimeHost for ReserveThenStatusHost<'_> {
+        fn run_deterministic(
+            &self,
+            action: &str,
+            config: &Value,
+            input: &Value,
+            tool_context: ToolContext,
+        ) -> Result<Value, DispatchError> {
+            let output = <OrbitRuntime as V2RuntimeHost>::run_deterministic(
+                self.runtime,
+                action,
+                config,
+                input,
+                tool_context,
+            )?;
+            if action == "reserve_locks" && output["reserved"] == json!(true) {
+                self.reserve_calls.fetch_add(1, Ordering::SeqCst);
+                self.runtime
+                    .update_task(
+                        &self.task_id,
+                        TaskUpdateParams {
+                            status: Some(self.status_after_reserve),
+                            execution_summary: (self.status_after_reserve == TaskStatus::Review)
+                                .then(|| "Fixture reached review in a competing run.".to_string()),
+                            ..Default::default()
+                        },
+                    )
+                    .map_err(|err| DispatchError::DeterministicActionFailed {
+                        action: action.to_string(),
+                        message: format!("test status flip failed: {err}"),
+                    })?;
+            }
+            Ok(output)
+        }
+
+        fn api_key_for(&self, provider: &str) -> Result<String, DispatchError> {
+            <OrbitRuntime as V2RuntimeHost>::api_key_for(self.runtime, provider)
+        }
+
+        fn resolve_cli_executor(
+            &self,
+            provider: &str,
+        ) -> Result<ResolvedCliExecutor, DispatchError> {
+            <OrbitRuntime as V2RuntimeHost>::resolve_cli_executor(self.runtime, provider)
+        }
+
+        fn tool_context_for_activity(
+            &self,
+            run_id: Option<&str>,
+            fs_profile: Option<&str>,
+            fs_audit: Option<Arc<dyn FsAuditLogger>>,
+        ) -> ToolContext {
+            <OrbitRuntime as V2RuntimeHost>::tool_context_for_activity(
+                self.runtime,
+                run_id,
+                fs_profile,
+                fs_audit,
+            )
+        }
+    }
+
+    struct ScriptedGateHost<'a> {
+        runtime: &'a OrbitRuntime,
+        child_status: &'static str,
+        call_log: Mutex<Vec<String>>,
+    }
+
+    impl ScriptedGateHost<'_> {
+        fn new<'a>(runtime: &'a OrbitRuntime, child_status: &'static str) -> ScriptedGateHost<'a> {
+            ScriptedGateHost {
+                runtime,
+                child_status,
+                call_log: Mutex::new(Vec::new()),
+            }
+        }
+
+        fn call_count(&self, action: &str) -> usize {
+            self.call_log
+                .lock()
+                .expect("call log")
+                .iter()
+                .filter(|recorded| recorded.as_str() == action)
+                .count()
+        }
+    }
+
+    impl V2RuntimeHost for ScriptedGateHost<'_> {
+        fn run_deterministic(
+            &self,
+            action: &str,
+            config: &Value,
+            input: &Value,
+            tool_context: ToolContext,
+        ) -> Result<Value, DispatchError> {
+            self.call_log
+                .lock()
+                .expect("call log")
+                .push(action.to_string());
+            match action {
+                "reserve_locks" => Ok(json!({
+                    "reserved": true,
+                    "reservation_id": "reservation-scripted",
+                    "reserved_files": ["file:src/lib.rs"],
+                })),
+                "invoke_and_wait" => Ok(json!({
+                    "run_id": "jrun-scripted-child",
+                    "status": self.child_status,
+                    "error": (self.child_status != "succeeded")
+                        .then_some("scripted child failure"),
+                })),
+                "release_locks" => Ok(json!({ "released": true })),
+                "pipeline_success_guard" => <OrbitRuntime as V2RuntimeHost>::run_deterministic(
+                    self.runtime,
+                    action,
+                    config,
+                    input,
+                    tool_context,
+                ),
+                other => Err(DispatchError::DeterministicActionNotRegistered(
+                    other.to_string(),
+                )),
+            }
+        }
+
+        fn api_key_for(&self, provider: &str) -> Result<String, DispatchError> {
+            <OrbitRuntime as V2RuntimeHost>::api_key_for(self.runtime, provider)
+        }
+
+        fn resolve_cli_executor(
+            &self,
+            provider: &str,
+        ) -> Result<ResolvedCliExecutor, DispatchError> {
+            <OrbitRuntime as V2RuntimeHost>::resolve_cli_executor(self.runtime, provider)
+        }
+
+        fn tool_context_for_activity(
+            &self,
+            run_id: Option<&str>,
+            fs_profile: Option<&str>,
+            fs_audit: Option<Arc<dyn FsAuditLogger>>,
+        ) -> ToolContext {
+            <OrbitRuntime as V2RuntimeHost>::tool_context_for_activity(
+                self.runtime,
+                run_id,
+                fs_profile,
+                fs_audit,
+            )
+        }
     }
 
     fn write_job(path: &Path, name: &str, action: &str) {
@@ -457,6 +699,158 @@ spec:
             std::fs::read(&audit).expect("read source audit"),
         );
         bytes
+    }
+
+    #[test]
+    fn task_gate_noops_when_task_reaches_review_after_reservation() {
+        let (_root, runtime, repo_root, global_root) = test_runtime();
+        seed_default_catalogs(&global_root);
+        let task_id = seed_gate_task(&runtime, &repo_root, TaskStatus::Backlog);
+        let host = ReserveThenStatusHost {
+            runtime: &runtime,
+            task_id: task_id.clone(),
+            status_after_reserve: TaskStatus::Review,
+            reserve_calls: AtomicUsize::new(0),
+        };
+
+        let outcome = execute_gate_job(
+            &runtime,
+            &repo_root,
+            &host,
+            json!({
+                "task_ids": [task_id.clone()],
+                "mode": "pr",
+            }),
+            "jrun-gate-review-stale",
+        );
+
+        assert!(outcome.success);
+        assert_eq!(host.reserve_calls(), 1);
+        assert!(
+            runtime
+                .job_history("task_pr_pipeline")
+                .expect("child history")
+                .is_empty(),
+            "stale gate must not submit a child PR pipeline"
+        );
+        let dispatch = &outcome.pipeline["dispatch_child"];
+        assert_eq!(dispatch["status"], json!("succeeded"));
+        assert_eq!(dispatch["skipped"], json!(true));
+        let reason = dispatch["reason"].as_str().expect("stale reason");
+        assert!(reason.contains(&task_id), "{reason}");
+        assert!(reason.contains("review"), "{reason}");
+
+        let audit_events = runtime
+            .list_audit_events(None, None, Some(AuditEventStatus::Success), None, 32)
+            .expect("audit events");
+        assert!(audit_events.iter().any(|event| {
+            event.command == "gate.stale_noop"
+                && event
+                    .arguments_json
+                    .as_deref()
+                    .is_some_and(|payload| payload.contains(&task_id) && payload.contains("review"))
+        }));
+    }
+
+    #[test]
+    fn task_gate_noops_done_task_and_releases_reservation() {
+        let (_root, runtime, repo_root, global_root) = test_runtime();
+        seed_default_catalogs(&global_root);
+        let task_id = seed_gate_task(&runtime, &repo_root, TaskStatus::Done);
+
+        let outcome = execute_gate_job(
+            &runtime,
+            &repo_root,
+            &runtime,
+            json!({
+                "task_ids": [task_id.clone()],
+                "mode": "pr",
+            }),
+            "jrun-gate-done-stale",
+        );
+
+        assert!(outcome.success);
+        assert!(
+            runtime
+                .job_history("task_pr_pipeline")
+                .expect("child history")
+                .is_empty(),
+            "done stale gate must not submit a child PR pipeline"
+        );
+        assert_eq!(outcome.pipeline["dispatch_child"]["skipped"], json!(true));
+        let reason = outcome.pipeline["dispatch_child"]["reason"]
+            .as_str()
+            .expect("done stale reason");
+        assert!(reason.contains(&task_id), "{reason}");
+        assert!(reason.contains("done"), "{reason}");
+
+        let locks = runtime
+            .run_tool_with_context_and_role(
+                "orbit.task.locks",
+                json!({}),
+                orbit_common::types::Role::Admin,
+                ToolContext::default(),
+            )
+            .expect("list locks");
+        assert_eq!(locks["total_reservations"], json!(0));
+    }
+
+    #[test]
+    fn task_gate_dispatches_child_for_admissible_task() {
+        let (_root, runtime, repo_root, global_root) = test_runtime();
+        seed_default_catalogs(&global_root);
+        let host = ScriptedGateHost::new(&runtime, "succeeded");
+
+        let outcome = execute_gate_job(
+            &runtime,
+            &repo_root,
+            &host,
+            json!({
+                "task_ids": ["ORB-SCRIPTED"],
+                "mode": "pr",
+            }),
+            "jrun-gate-admissible",
+        );
+
+        assert!(outcome.success);
+        assert_eq!(host.call_count("reserve_locks"), 1);
+        assert_eq!(host.call_count("invoke_and_wait"), 1);
+        assert_eq!(host.call_count("release_locks"), 1);
+        assert_eq!(host.call_count("pipeline_success_guard"), 1);
+        assert_eq!(
+            outcome.pipeline["dispatch_child"]["status"],
+            json!("succeeded")
+        );
+    }
+
+    #[test]
+    fn task_gate_child_failure_still_fails_success_guard() {
+        let (_root, runtime, repo_root, global_root) = test_runtime();
+        seed_default_catalogs(&global_root);
+        let host = ScriptedGateHost::new(&runtime, "failed");
+
+        let err = try_execute_gate_job(
+            &runtime,
+            &repo_root,
+            &host,
+            json!({
+                "task_ids": ["ORB-SCRIPTED"],
+                "mode": "pr",
+            }),
+            "jrun-gate-child-failed",
+        )
+        .expect_err("failed child should fail the gate");
+
+        assert_eq!(host.call_count("invoke_and_wait"), 1);
+        assert_eq!(host.call_count("release_locks"), 1);
+        assert_eq!(host.call_count("pipeline_success_guard"), 1);
+        let message = err.to_string();
+        assert!(
+            message.contains("task_gate_pipeline child run"),
+            "{message}"
+        );
+        assert!(message.contains("jrun-scripted-child"), "{message}");
+        assert!(message.contains("status failed"), "{message}");
     }
 
     #[cfg(unix)]

--- a/crates/orbit-core/src/runtime/v2_host/pipeline_actions.rs
+++ b/crates/orbit-core/src/runtime/v2_host/pipeline_actions.rs
@@ -1,10 +1,13 @@
-use orbit_common::types::{AuditEventStatus, Role, audit_execution_id};
-use orbit_engine::DispatchError;
+use orbit_common::types::{
+    AuditEventStatus, Role, TaskStatus, audit_execution_id, optional_string_list_alias,
+};
+use orbit_engine::{DispatchError, ensure_task_can_enter_workflow};
 use orbit_store::AuditEventInsertParams;
 use orbit_tools::ToolContext;
 use serde_json::Value;
 
 use crate::OrbitRuntime;
+use crate::runtime::orbit_tool_host::parse_task_ids;
 
 pub(super) fn validate_bundles(action: &str, input: &Value) -> Result<Value, DispatchError> {
     let bundles_raw = input
@@ -82,6 +85,10 @@ pub(super) fn invoke_and_wait(
     input: &Value,
     tool_context: ToolContext,
 ) -> Result<Value, DispatchError> {
+    if let Some(noop) = stale_gate_admission_noop(runtime, action, input)? {
+        return Ok(noop);
+    }
+
     let job_name = input
         .get("job_name")
         .and_then(Value::as_str)
@@ -159,6 +166,157 @@ pub(super) fn invoke_and_wait(
             })
         });
     Ok(first)
+}
+
+fn stale_gate_admission_noop(
+    runtime: &OrbitRuntime,
+    action: &str,
+    input: &Value,
+) -> Result<Option<Value>, DispatchError> {
+    let raw_task_ids = optional_string_list_alias(
+        input,
+        &[
+            "admission_task_ids",
+            "admissionTaskIds",
+            "admission-task-ids",
+        ],
+    )
+    .map_err(|err| action_failed(action, err.to_string()))?;
+    let Some(raw_task_ids) = raw_task_ids else {
+        return Ok(None);
+    };
+    let task_ids = parse_task_ids(&serde_json::json!({ "task_ids": raw_task_ids }))
+        .map_err(|err| action_failed(action, err.to_string()))?;
+    let workflow = input
+        .get("admission_workflow")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .unwrap_or("worktree_setup");
+
+    let mut task_statuses = Vec::with_capacity(task_ids.len());
+    let mut stale_statuses = Vec::new();
+    let mut admission_errors = Vec::new();
+
+    for task_id in &task_ids {
+        match ensure_task_can_enter_workflow(runtime, task_id, workflow) {
+            Ok(task) => {
+                task_statuses.push(serde_json::json!({
+                    "task_id": task.id,
+                    "status": task.status.to_string(),
+                    "admissible": true,
+                }));
+            }
+            Err(error) => match runtime.get_task(task_id) {
+                Ok(task) => {
+                    let status = task.status;
+                    task_statuses.push(serde_json::json!({
+                        "task_id": task.id,
+                        "status": status.to_string(),
+                        "admissible": false,
+                    }));
+                    if matches!(status, TaskStatus::Review | TaskStatus::Done) {
+                        stale_statuses.push((task_id.clone(), status.to_string()));
+                    } else {
+                        admission_errors.push(error.to_string());
+                    }
+                }
+                Err(_) => admission_errors.push(error.to_string()),
+            },
+        }
+    }
+
+    if !admission_errors.is_empty() {
+        return Err(action_failed(
+            action,
+            format!(
+                "workflow admission check before child dispatch failed: {}",
+                admission_errors.join("; ")
+            ),
+        ));
+    }
+
+    if stale_statuses.is_empty() {
+        return Ok(None);
+    }
+
+    let status_summary = stale_statuses
+        .iter()
+        .map(|(task_id, status)| format!("{task_id}={status}"))
+        .collect::<Vec<_>>()
+        .join(", ");
+    let reason = format!(
+        "task_gate_pipeline stale/no-op: workflow admission for '{workflow}' skipped child dispatch because {status_summary}"
+    );
+    record_gate_stale_noop(runtime, action, input, &task_ids, &task_statuses, &reason)?;
+    let parent_run_id = input
+        .get("run_id")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .unwrap_or("unknown");
+
+    Ok(Some(serde_json::json!({
+        "status": "succeeded",
+        "run_id": format!("stale-noop-{parent_run_id}"),
+        "skipped": true,
+        "reason": reason,
+        "task_statuses": task_statuses,
+    })))
+}
+
+fn record_gate_stale_noop(
+    runtime: &OrbitRuntime,
+    action: &str,
+    input: &Value,
+    task_ids: &[String],
+    task_statuses: &[Value],
+    reason: &str,
+) -> Result<(), DispatchError> {
+    let parent_run_id = input
+        .get("run_id")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned);
+    let payload = serde_json::json!({
+        "task_ids": task_ids,
+        "task_statuses": task_statuses,
+        "reason": reason,
+        "parent_run_id": parent_run_id,
+    });
+    let arguments_json = serde_json::to_string(&payload).map_err(|err| {
+        action_failed(action, format!("serialize gate.stale_noop payload: {err}"))
+    })?;
+    let execution_id = audit_execution_id("audit-gate-stale-noop");
+    let working_directory = runtime.paths().repo_root.to_string_lossy().into_owned();
+
+    runtime
+        .record_audit_event(&AuditEventInsertParams {
+            execution_id,
+            command: "gate.stale_noop".to_string(),
+            subcommand: None,
+            tool_name: None,
+            target_type: Some("task_bundle".to_string()),
+            target_id: task_ids.first().cloned(),
+            role: "admin".to_string(),
+            status: AuditEventStatus::Success,
+            exit_code: 0,
+            duration_ms: 0,
+            working_directory,
+            arguments_json: Some(arguments_json),
+            stdout_truncated: None,
+            stderr_truncated: None,
+            error_message: None,
+            host: std::env::var("HOSTNAME").ok(),
+            pid: std::process::id(),
+            session_id: None,
+            task_id: task_ids.first().cloned(),
+            job_run_id: parent_run_id,
+            activity_id: None,
+            step_index: None,
+        })
+        .map_err(|err| action_failed(action, format!("record gate.stale_noop audit: {err}")))
 }
 
 pub(super) fn pipeline_wait(
@@ -273,6 +431,13 @@ fn pipeline_wait_entry_failure(label: &str, entry: &Value) -> Option<String> {
         Some(error) => format!("{label} run {run_id} status {status}: {error}"),
         None => format!("{label} run {run_id} status {status}"),
     })
+}
+
+fn action_failed(action: &str, message: String) -> DispatchError {
+    DispatchError::DeterministicActionFailed {
+        action: action.to_string(),
+        message,
+    }
 }
 
 pub(super) fn gate_starvation_fail(

--- a/crates/orbit-engine/src/context.rs
+++ b/crates/orbit-engine/src/context.rs
@@ -311,6 +311,30 @@ pub trait TaskHost: TaskReadHost + TaskWriteHost {}
 
 impl<T> TaskHost for T where T: TaskReadHost + TaskWriteHost + ?Sized {}
 
+pub fn ensure_task_can_enter_workflow<H: TaskReadHost + ?Sized>(
+    host: &H,
+    task_id: &str,
+    workflow: &str,
+) -> Result<Task, OrbitError> {
+    let task = host.get_task(task_id)?;
+    if matches!(
+        task.status,
+        TaskStatus::Proposed
+            | TaskStatus::Friction
+            | TaskStatus::Backlog
+            | TaskStatus::Rejected
+            | TaskStatus::Archived
+            | TaskStatus::InProgress
+    ) {
+        return Ok(task);
+    }
+
+    Err(OrbitError::InvalidInput(format!(
+        "task '{}' is in status '{}'; workflow admission for '{workflow}' requires 'proposed', 'friction', 'backlog', 'rejected', 'archived', or 'in-progress'",
+        task.id, task.status
+    )))
+}
+
 pub trait AgentProtocolHost {
     fn build_agent_stdin_envelope_payload(
         &self,

--- a/crates/orbit-engine/src/executor/automation/duel/planning_duel/runner/tests/mod.rs
+++ b/crates/orbit-engine/src/executor/automation/duel/planning_duel/runner/tests/mod.rs
@@ -21,8 +21,8 @@ use crate::context::{
 };
 use crate::executor::registry::ActivityExecutorRegistry;
 
-use crate::executor::automation::duel::planning_duel::artifacts;
 use super::super::run_planning_duel;
+use crate::executor::automation::duel::planning_duel::artifacts;
 
 struct PlanningDuelHost {
     task: Mutex<Task>,

--- a/crates/orbit-engine/src/executor/automation/vcs/worktree/setup.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/worktree/setup.rs
@@ -1,10 +1,10 @@
 use std::path::Path;
 
-use orbit_common::types::{OrbitError, TaskStatus};
+use orbit_common::types::OrbitError;
 use serde_json::{Value, json};
 use sha2::{Digest, Sha256};
 
-use crate::context::{RuntimeHost, TaskAutomationUpdate, TaskHost};
+use crate::context::{RuntimeHost, TaskAutomationUpdate, TaskHost, ensure_task_can_enter_workflow};
 use crate::executor::automation::input::{input_string_field, required_input_string};
 
 use super::super::git::{
@@ -86,30 +86,6 @@ fn worktree_setup_output(
         "head_ref": head_ref,
         "base_ref": base_ref,
     })
-}
-
-fn ensure_task_can_enter_workflow<H: TaskHost + ?Sized>(
-    host: &H,
-    task_id: &str,
-    workflow: &str,
-) -> Result<(), OrbitError> {
-    let task = host.get_task(task_id)?;
-    if matches!(
-        task.status,
-        TaskStatus::Proposed
-            | TaskStatus::Friction
-            | TaskStatus::Backlog
-            | TaskStatus::Rejected
-            | TaskStatus::Archived
-            | TaskStatus::InProgress
-    ) {
-        return Ok(());
-    }
-
-    Err(OrbitError::InvalidInput(format!(
-        "task '{}' is in status '{}'; workflow admission for '{workflow}' requires 'proposed', 'friction', 'backlog', 'rejected', 'archived', or 'in-progress'",
-        task.id, task.status
-    )))
 }
 
 fn ensure_worktree(

--- a/crates/orbit-engine/src/lib.rs
+++ b/crates/orbit-engine/src/lib.rs
@@ -58,7 +58,7 @@ pub use context::{
     AgentRoleConfig, AttemptOutcome, DirectActivityRunOutcome, EngineHost, EnvironmentHost,
     ExecutionContext, ExecutorHost, ExecutorLookupHost, JobRunHost, JobRunResult, PrConfig,
     RuntimeHost, STALE_RUN_GRACE_SECONDS, TaskActivityUpdate, TaskAutomationUpdate, TaskHost,
-    TaskReadHost, TaskWriteHost, execution_working_directory,
+    TaskReadHost, TaskWriteHost, ensure_task_can_enter_workflow, execution_working_directory,
     execution_working_directory_with_task, input_workspace_path, redact_attempt_outcome,
 };
 pub use executor::automation::{


### PR DESCRIPTION
## Task

[ORB-00235](https://orbit-cli.com/tasks/ORB-00235) — Re-check task admission before gate dispatch

### Description

## Problem

`task_gate_pipeline` can wait for a lock window, acquire a reservation, and then dispatch `task_pr_pipeline` even though the task has already advanced past workflow admission in another run. The child then fails immediately in `worktree_setup`, and the parent fails in `require_child_success`.

Recent examples:
- `jrun-20260521-0404-3` dispatched ORB-00226 after the task had already moved to `review`; the child failed in `worktree_setup` admission.
- `jrun-20260521-0404-5` dispatched ORB-00228 after the task had already moved to `done`; the child failed in `worktree_setup` admission.
- Existing friction `F2026-05-047` records the same stale-parent pattern for ORB-00209.

## Why It Matters

These are false-negative pipeline failures: the original task work may already be complete or under review, but stale parent gate runs report failure, obscure the real state, and create noisy follow-up investigation.

## Constraints / Notes

- Reuse the same workflow-admission policy as `worktree_setup` instead of duplicating an inconsistent status list.
- Re-check admission after `wait_for_window` / reservation and immediately before child dispatch.
- For tasks that are already `review` or `done`, treat the gate as a stale/no-op outcome: do not launch a child PR/local pipeline, release any reservation, and surface a clear audit/state reason with the task IDs and current statuses.
- Unexpected non-admissible statuses should remain explicit failures with a useful error, not silent skips.
- This task resolves friction `F2026-05-047` when complete.

### Acceptance Criteria

- A deterministic test covers a `task_gate_pipeline` run where a task becomes `review` after the reservation wait and before dispatch; the run does not create an `invoke_and_wait` child and records a clear stale/no-op reason with the task ID and status.
- A deterministic test covers the same stale gate path for a task already `done`; the run does not create an `invoke_and_wait` child and releases the reservation if one was acquired.
- Existing successful gate behavior is preserved: a task in an admissible status still dispatches the configured child pipeline and `require_child_success` still fails the gate when that child genuinely fails.
- The admission check used before gate dispatch is shared with or delegated to the existing `worktree_setup` workflow-admission policy; the implementation does not introduce a second hand-maintained status list.
- `make ci-fast` passes.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Shared the worktree workflow-admission preflight as `ensure_task_can_enter_workflow` and reused it from both `worktree_setup` and the gate dispatch re-check.
- Added optional `admission_task_ids` / `admission_workflow` handling to `invoke_and_wait`; stale `review` / `done` tasks now emit `gate.stale_noop`, return a succeeded `skipped` output with task statuses, avoid `orbit.pipeline.invoke`, and let the gate release its reservation.
- Wired `task_gate_pipeline` to pass admission task IDs and added deterministic coverage for review-after-reservation stale gates, already-done stale gates, admissible child dispatch, and child failure propagation through `pipeline_success_guard`.

Validation:
- `cargo test -p orbit-core task_gate -- --nocapture`
- `cargo test -p orbit-core gate_pipeline -- --nocapture`
- `cargo test -p orbit-core pipeline_success_guard -- --nocapture`
- `cargo test -p orbit-engine worktree_setup_output_includes_legacy_batch_id_alias`
- `make ci-fast`

Assessment: Gate runs now report stale terminal task states as clear no-op successes while preserving real child-run failure behavior.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-00235-6a0e88c4`
- Behind base: 0
- Ahead of base: 1