### PR TITLE
Make learning ID allocation collision-proof across concurrent worktrees

### DIFF
--- a/crates/orbit-store/src/file/learning_store/api/crud.rs
+++ b/crates/orbit-store/src/file/learning_store/api/crud.rs
@@ -10,7 +10,9 @@ use orbit_common::types::{
 use super::super::layout::{
     comments_jsonl_path, learning_doc_path, locate_learning, validate_learning_id, votes_jsonl_path,
 };
-use super::super::record::{read_learning_file, write_learning_file};
+use super::super::record::{
+    create_learning_file_exclusive, read_learning_file, write_learning_file,
+};
 use super::store::LearningFileStore;
 use crate::backend::{LearningCreateParams, LearningUpdateParams};
 use crate::{IdAllocationRecord, LearningListEntry, RemoteArtifactStub};
@@ -42,36 +44,41 @@ impl LearningFileStore {
             )));
         }
 
-        let id = self.id_allocator.allocate_learning()?.id;
-
         let mut scope = params.scope;
         scope.paths = normalize_learning_paths(scope.paths);
         scope.tags = normalize_learning_tags(scope.tags);
 
-        let learning = Learning {
-            id: id.clone(),
-            status: LearningStatus::Active,
-            scope,
-            summary: params.summary,
-            body: params.body,
-            evidence: params.evidence,
-            supersedes: None,
-            superseded_by: None,
-            legacy_ids: Vec::new(),
-            created_at: now,
-            updated_at: now,
-            created_by: params.created_by,
-            priority: params.priority,
-        };
+        loop {
+            let id = self.id_allocator.allocate_learning()?.id;
+            let learning = Learning {
+                id: id.clone(),
+                status: LearningStatus::Active,
+                scope: scope.clone(),
+                summary: params.summary.clone(),
+                body: params.body.clone(),
+                evidence: params.evidence.clone(),
+                supersedes: None,
+                superseded_by: None,
+                legacy_ids: Vec::new(),
+                created_at: now,
+                updated_at: now,
+                created_by: params.created_by.clone(),
+                priority: params.priority,
+            };
 
-        let path = learning_doc_path(&self.root, &id);
-        write_learning_file(&path, &learning, LearningStatus::Active)?;
-        ensure_empty_sidecar(&votes_jsonl_path(&self.root, &id))?;
-        ensure_empty_sidecar(&comments_jsonl_path(&self.root, &id))?;
-        self.id_allocator.record_learning_body_path(&id, &path)?;
-        self.upsert_index_row(&learning);
-        self.invalidate_envelope_cache();
-        Ok(learning)
+            let path = learning_doc_path(&self.root, &id);
+            if !create_learning_file_exclusive(&path, &learning, LearningStatus::Active)? {
+                self.adopt_or_reject_existing_learning_path(&id, &path)?;
+                continue;
+            }
+
+            ensure_empty_sidecar(&votes_jsonl_path(&self.root, &id))?;
+            ensure_empty_sidecar(&comments_jsonl_path(&self.root, &id))?;
+            self.id_allocator.record_learning_body_path(&id, &path)?;
+            self.upsert_index_row(&learning);
+            self.invalidate_envelope_cache();
+            return Ok(learning);
+        }
     }
 
     pub(crate) fn get_learning(&self, id: &str) -> Result<Option<Learning>, OrbitError> {
@@ -234,6 +241,35 @@ impl LearningFileStore {
             return Ok(None);
         }
         Ok(Some(read_learning_file(&path)?))
+    }
+
+    fn adopt_or_reject_existing_learning_path(
+        &self,
+        id: &str,
+        path: &std::path::Path,
+    ) -> Result<(), OrbitError> {
+        let existing = match read_learning_file(path) {
+            Ok(existing) => existing,
+            Err(error) => {
+                self.id_allocator.abandon_learning(id)?;
+                return Err(OrbitError::Store(format!(
+                    "allocated learning id {id} conflicts with unreadable existing path '{}': {error}",
+                    path.display()
+                )));
+            }
+        };
+        if existing.id != id {
+            self.id_allocator.abandon_learning(id)?;
+            return Err(OrbitError::Store(format!(
+                "allocated learning id {id} conflicts with existing path '{}' containing learning '{}'",
+                path.display(),
+                existing.id
+            )));
+        }
+        self.id_allocator.record_learning_body_path(id, path)?;
+        self.upsert_index_row(&existing);
+        self.invalidate_envelope_cache();
+        Ok(())
     }
 }
 

--- a/crates/orbit-store/src/file/learning_store/api/tests/crud.rs
+++ b/crates/orbit-store/src/file/learning_store/api/tests/crud.rs
@@ -1,5 +1,8 @@
 //! CRUD-focused tests for LearningFileStore (split from monolithic api.rs per ORB-00116).
 
+use std::collections::BTreeSet;
+use std::sync::{Arc, Barrier};
+
 use chrono::{TimeZone as _, Utc};
 use orbit_common::types::{EvidenceKind, LearningEvidence, LearningScope, LearningStatus};
 use tempfile::tempdir;
@@ -8,6 +11,7 @@ use super::super::store::LearningFileStore;
 use super::test_support::{create_params, store_with_index};
 use crate::Store;
 use crate::backend::{LearningCreateParams, LearningSearchParams, LearningUpdateParams};
+use crate::{IdAllocator, IdAllocatorConfig, LearningListEntry};
 
 #[test]
 fn round_trip_persistence_preserves_all_fields_including_phase_two_reservations() {
@@ -132,6 +136,108 @@ fn id_format_increments_within_a_day() {
 }
 
 #[test]
+fn create_learning_retries_after_adopting_existing_local_path_collision() {
+    let dir = tempdir().expect("tempdir");
+    let store = LearningFileStore::new(dir.path().to_path_buf());
+    let path = dir.path().join("L-0001").join("learning.yaml");
+    std::fs::create_dir_all(path.parent().expect("learning parent")).expect("learning dir");
+    std::fs::write(
+        &path,
+        super::test_support::legacy_learning_yaml("L-0001", "active", "Existing", 1),
+    )
+    .expect("preexisting learning");
+
+    let created = store
+        .create_learning(create_params("New", vec![], vec![]))
+        .expect("create");
+
+    assert_eq!(created.id, "L-0002");
+    let existing = store
+        .get_learning("L-0001")
+        .expect("get existing")
+        .expect("existing");
+    assert_eq!(existing.summary, "Existing");
+    let allocation = store
+        .id_allocator
+        .learning_allocation("L-0001")
+        .expect("allocation")
+        .expect("adopted allocation");
+    assert_eq!(
+        allocation.body_path.as_deref(),
+        Some(std::path::Path::new("L-0001/learning.yaml"))
+    );
+}
+
+#[test]
+fn shared_allocator_assigns_distinct_learning_ids_across_divergent_worktrees() {
+    let dir = tempdir().expect("tempdir");
+    let shared_orbit = dir.path().join("shared/.orbit");
+    let worktree_a = dir.path().join("worktree-a");
+    let worktree_b = dir.path().join("worktree-b");
+    std::fs::create_dir_all(shared_orbit.join("learnings")).expect("shared learnings");
+    std::fs::create_dir_all(worktree_a.join(".orbit/learnings")).expect("worktree a");
+    std::fs::create_dir_all(worktree_b.join(".orbit/learnings")).expect("worktree b");
+
+    let barrier = Arc::new(Barrier::new(2));
+    let child_a = spawn_learning_add(
+        shared_orbit.clone(),
+        worktree_a.clone(),
+        "from worktree a",
+        barrier.clone(),
+    );
+    let child_b = spawn_learning_add(
+        shared_orbit.clone(),
+        worktree_b.clone(),
+        "from worktree b",
+        barrier,
+    );
+    let learning_a = child_a.join().expect("join a");
+    let learning_b = child_b.join().expect("join b");
+
+    assert_ne!(learning_a.id, learning_b.id);
+    let ids: BTreeSet<_> = [learning_a.id.clone(), learning_b.id.clone()]
+        .into_iter()
+        .collect();
+    assert_eq!(
+        ids,
+        BTreeSet::from(["L-0001".to_string(), "L-0002".to_string()])
+    );
+    assert!(
+        worktree_a
+            .join(".orbit/learnings")
+            .join(&learning_a.id)
+            .join("learning.yaml")
+            .is_file()
+    );
+    assert!(
+        worktree_b
+            .join(".orbit/learnings")
+            .join(&learning_b.id)
+            .join("learning.yaml")
+            .is_file()
+    );
+
+    let store_a = learning_store_for_worktree(&shared_orbit, &worktree_a);
+    let entries = store_a
+        .list_learning_entries(None, true)
+        .expect("entries while both worktrees are present");
+    assert!(entry_is_local(&entries, &learning_a.id));
+    assert!(entry_is_local(&entries, &learning_b.id));
+
+    std::fs::remove_dir_all(&worktree_b).expect("remove remote worktree");
+    let entries = store_a
+        .list_learning_entries(None, true)
+        .expect("entries with remote stub");
+    assert!(entry_is_local(&entries, &learning_a.id));
+    assert!(entry_is_remote(&entries, &learning_b.id));
+    let default_entries = store_a
+        .list_learning_entries(None, false)
+        .expect("default entries");
+    assert!(entry_is_local(&default_entries, &learning_a.id));
+    assert!(!entry_has_id(&default_entries, &learning_b.id));
+}
+
+#[test]
 fn learnings_index_partial_index_present_after_apply_schema() {
     let store = Store::open_in_memory().expect("open in-memory store");
     let conn_arc = store.connection();
@@ -169,6 +275,60 @@ fn learnings_index_partial_index_present_after_apply_schema() {
         }
     }
     assert!(found_partial, "expected learnings_active partial index");
+}
+
+fn spawn_learning_add(
+    shared_orbit: std::path::PathBuf,
+    worktree_root: std::path::PathBuf,
+    summary: &'static str,
+    barrier: Arc<Barrier>,
+) -> std::thread::JoinHandle<orbit_common::types::Learning> {
+    std::thread::spawn(move || {
+        barrier.wait();
+        let store = learning_store_for_worktree(&shared_orbit, &worktree_root);
+        store
+            .create_learning(create_params(summary, vec![], vec![]))
+            .expect("create learning")
+    })
+}
+
+fn learning_store_for_worktree(
+    shared_orbit: &std::path::Path,
+    worktree_root: &std::path::Path,
+) -> LearningFileStore {
+    let allocator = IdAllocator::open(IdAllocatorConfig::new(
+        shared_orbit.join("state/semantic.db"),
+        shared_orbit.join("state/.id_alloc.lock"),
+        shared_orbit.to_path_buf(),
+        worktree_root.to_path_buf(),
+        shared_orbit.join("adrs"),
+        shared_orbit.join("learnings"),
+    ))
+    .expect("allocator");
+    LearningFileStore::new_with_index_and_allocator(
+        worktree_root.join(".orbit/learnings"),
+        Store::open_in_memory().expect("index"),
+        allocator,
+    )
+}
+
+fn entry_is_local(entries: &[LearningListEntry], id: &str) -> bool {
+    entries
+        .iter()
+        .any(|entry| matches!(entry, LearningListEntry::Local(learning) if learning.id == id))
+}
+
+fn entry_is_remote(entries: &[LearningListEntry], id: &str) -> bool {
+    entries
+        .iter()
+        .any(|entry| matches!(entry, LearningListEntry::Remote(stub) if stub.id == id))
+}
+
+fn entry_has_id(entries: &[LearningListEntry], id: &str) -> bool {
+    entries.iter().any(|entry| match entry {
+        LearningListEntry::Local(learning) => learning.id == id,
+        LearningListEntry::Remote(stub) => stub.id == id,
+    })
 }
 
 #[test]

--- a/crates/orbit-store/src/file/learning_store/record.rs
+++ b/crates/orbit-store/src/file/learning_store/record.rs
@@ -1,7 +1,8 @@
 use std::collections::{BTreeMap, BTreeSet};
 use std::fs::{self, OpenOptions};
 use std::io::{BufRead, BufReader, Write};
-use std::path::Path;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
 
 use orbit_common::types::{
     Learning, LearningComment, LearningCommentEvent, LearningStatus, NotFoundKind, OrbitError,
@@ -11,6 +12,8 @@ use super::constants::LEARNING_SCHEMA_VERSION;
 use super::doc::{LearningFileDocument, serialize_learning_doc_yaml};
 use super::layout::validate_learning_id;
 use crate::file::yaml_doc::{read_yaml_with, write_yaml_atomic_with};
+
+static LEARNING_CREATE_TEMP_COUNTER: AtomicU64 = AtomicU64::new(0);
 
 /// Read a learning YAML file at the given path. Returns a learning not-found error
 /// when the file is missing on disk.
@@ -56,6 +59,80 @@ pub(super) fn write_learning_file(
         learning: learning.clone(),
     };
     write_yaml_atomic_with(path, &doc, serialize_learning_doc_yaml)
+}
+
+/// Create a learning record at `path` without clobbering an existing body.
+///
+/// Returns `Ok(false)` when the target path already exists. The no-clobber
+/// write stages the full YAML in the same directory, then hard-links it into
+/// place so the final file appears atomically only if the destination is absent.
+pub(super) fn create_learning_file_exclusive(
+    path: &Path,
+    learning: &Learning,
+    expected_state: LearningStatus,
+) -> Result<bool, OrbitError> {
+    validate_learning_id(&learning.id)?;
+    if learning.status != expected_state {
+        return Err(OrbitError::Store(format!(
+            "learning '{}' status {:?} does not match destination state {:?}",
+            learning.id, learning.status, expected_state
+        )));
+    }
+    let parent = path.parent().ok_or_else(|| {
+        OrbitError::Store(format!(
+            "cannot determine learning file parent for '{}'",
+            path.display()
+        ))
+    })?;
+    fs::create_dir_all(parent).map_err(|e| OrbitError::Io(e.to_string()))?;
+
+    let doc = LearningFileDocument {
+        schema_version: LEARNING_SCHEMA_VERSION,
+        learning: learning.clone(),
+    };
+    let yaml = serialize_learning_doc_yaml(&doc)?;
+    let temp_path = exclusive_temp_path(path);
+    let mut file = OpenOptions::new()
+        .create_new(true)
+        .write(true)
+        .open(&temp_path)
+        .map_err(|error| OrbitError::Io(error.to_string()))?;
+    file.write_all(yaml.as_bytes())
+        .and_then(|_| file.flush())
+        .map_err(|error| OrbitError::Io(error.to_string()))?;
+    drop(file);
+
+    match fs::hard_link(&temp_path, path) {
+        Ok(()) => {
+            fs::remove_file(&temp_path).map_err(|error| OrbitError::Io(error.to_string()))?;
+            Ok(true)
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
+            let _ = fs::remove_file(&temp_path);
+            Ok(false)
+        }
+        Err(error) => {
+            let _ = fs::remove_file(&temp_path);
+            Err(OrbitError::Io(format!(
+                "link {} to {}: {error}",
+                temp_path.display(),
+                path.display()
+            )))
+        }
+    }
+}
+
+fn exclusive_temp_path(path: &Path) -> PathBuf {
+    let counter = LEARNING_CREATE_TEMP_COUNTER.fetch_add(1, Ordering::Relaxed);
+    let file_name = path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("learning.yaml");
+    path.with_file_name(format!(
+        ".{file_name}.{}.{}.tmp",
+        std::process::id(),
+        counter
+    ))
 }
 
 pub(super) fn append_jsonl_comment_row(

--- a/crates/orbit-store/src/sqlite/id_allocator/mod.rs
+++ b/crates/orbit-store/src/sqlite/id_allocator/mod.rs
@@ -14,6 +14,7 @@ use serde_yaml::{Mapping, Value};
 
 const KIND_ADR: &str = "adr";
 const KIND_LEARNING: &str = "learning";
+const STATUS_ABANDONED: &str = "abandoned";
 const STATUS_MERGED: &str = "merged";
 const STATUS_RESERVED: &str = "reserved";
 
@@ -194,6 +195,10 @@ impl IdAllocator {
         self.record_body_path(IdAllocationKind::Learning, id, body_path)
     }
 
+    pub fn abandon_learning(&self, id: &str) -> Result<(), OrbitError> {
+        self.abandon(IdAllocationKind::Learning, id)
+    }
+
     pub fn adr_allocation(&self, id: &str) -> Result<Option<IdAllocationRecord>, OrbitError> {
         self.allocation(IdAllocationKind::Adr, id)
     }
@@ -297,6 +302,7 @@ impl IdAllocator {
                     &self.inner.shared_root,
                     None,
                     &body_path,
+                    STATUS_MERGED,
                 )?;
             }
         }
@@ -335,6 +341,7 @@ impl IdAllocator {
                 &self.inner.shared_root,
                 None,
                 &body_path,
+                STATUS_MERGED,
             )?;
         }
         Ok(())
@@ -466,6 +473,34 @@ impl IdAllocator {
         Ok(())
     }
 
+    fn abandon(&self, kind: IdAllocationKind, id: &str) -> Result<(), OrbitError> {
+        let _lock = self.acquire_lock()?;
+        let mut conn = self.lock_conn()?;
+        let tx = conn
+            .transaction_with_behavior(TransactionBehavior::Immediate)
+            .map_err(|error| OrbitError::Store(error.to_string()))?;
+        let updated = tx
+            .execute(
+                "UPDATE id_allocations
+                 SET status = ?3
+                 WHERE kind = ?1
+                   AND id = ?2
+                   AND status = ?4
+                   AND (body_path IS NULL OR body_path = '')",
+                params![kind.as_str(), id, STATUS_ABANDONED, STATUS_RESERVED],
+            )
+            .map_err(|error| OrbitError::Store(error.to_string()))?;
+        if updated == 0 {
+            return Err(OrbitError::Store(format!(
+                "cannot abandon {} {id}: allocation is missing or already has a body path",
+                kind.as_str()
+            )));
+        }
+        tx.commit()
+            .map_err(|error| OrbitError::Store(error.to_string()))?;
+        Ok(())
+    }
+
     fn allocation(
         &self,
         kind: IdAllocationKind,
@@ -476,11 +511,14 @@ impl IdAllocator {
             .prepare(
                 "SELECT kind, id, allocated_at, worktree_root, branch, status, body_path
                  FROM id_allocations
-                 WHERE kind = ?1 AND id = ?2",
+                 WHERE kind = ?1 AND id = ?2 AND status != ?3",
             )
             .map_err(|error| OrbitError::Store(error.to_string()))?;
         let mut rows = stmt
-            .query_map(params![kind.as_str(), id], allocation_record_from_row)
+            .query_map(
+                params![kind.as_str(), id, STATUS_ABANDONED],
+                allocation_record_from_row,
+            )
             .map_err(|error| OrbitError::Store(error.to_string()))?;
         match rows.next() {
             Some(row) => row
@@ -496,12 +534,15 @@ impl IdAllocator {
             .prepare(
                 "SELECT kind, id, allocated_at, worktree_root, branch, status, body_path
                  FROM id_allocations
-                 WHERE kind = ?1
+                 WHERE kind = ?1 AND status != ?2
                  ORDER BY id DESC",
             )
             .map_err(|error| OrbitError::Store(error.to_string()))?;
         let rows = stmt
-            .query_map([kind.as_str()], allocation_record_from_row)
+            .query_map(
+                params![kind.as_str(), STATUS_ABANDONED],
+                allocation_record_from_row,
+            )
             .map_err(|error| OrbitError::Store(error.to_string()))?;
         let mut records = Vec::new();
         for row in rows {
@@ -646,17 +687,28 @@ fn update_body_metadata_if_missing(
     worktree_root: &Path,
     branch: Option<String>,
     body_path: &Path,
+    status_if_missing: &str,
 ) -> Result<(), OrbitError> {
     tx.execute(
         "UPDATE id_allocations
-         SET worktree_root = ?3, branch = COALESCE(branch, ?4), body_path = ?5
-         WHERE kind = ?1 AND id = ?2 AND (body_path IS NULL OR body_path = '')",
+         SET worktree_root = ?3,
+             branch = COALESCE(branch, ?4),
+             body_path = ?5,
+             status = CASE
+                 WHEN status = ?6 THEN ?7
+                 ELSE status
+             END
+         WHERE kind = ?1
+           AND id = ?2
+           AND (body_path IS NULL OR body_path = '' OR status = ?6)",
         params![
             kind.as_str(),
             id,
             worktree_root.to_string_lossy(),
             branch,
             body_path.to_string_lossy(),
+            STATUS_ABANDONED,
+            status_if_missing,
         ],
     )
     .map_err(|error| OrbitError::Store(error.to_string()))?;

--- a/crates/orbit-store/src/sqlite/id_allocator/tests/id_allocator.rs
+++ b/crates/orbit-store/src/sqlite/id_allocator/tests/id_allocator.rs
@@ -100,6 +100,34 @@ fn allocates_dense_adr_and_learning_ids() {
 }
 
 #[test]
+fn abandoned_learning_allocation_advances_sequence_but_is_hidden() {
+    let temp = TempDir::new().expect("tempdir");
+    let allocator = IdAllocator::open(allocator_config(temp.path())).expect("allocator");
+
+    let first = allocator.allocate_learning().expect("first");
+    allocator
+        .abandon_learning(&first.id)
+        .expect("abandon first");
+    let second = allocator.allocate_learning().expect("second");
+
+    assert_eq!(first.id, "L-0001");
+    assert_eq!(second.id, "L-0002");
+    assert!(
+        allocator
+            .learning_allocation(&first.id)
+            .expect("first allocation")
+            .is_none()
+    );
+    let visible: Vec<_> = allocator
+        .learning_allocations()
+        .expect("allocations")
+        .into_iter()
+        .map(|record| record.id)
+        .collect();
+    assert_eq!(visible, vec!["L-0002"]);
+}
+
+#[test]
 fn backfills_existing_adrs_idempotently_and_allocates_after_max() {
     let temp = TempDir::new().expect("tempdir");
     let shared_root = temp.path().join(".orbit");
@@ -211,7 +239,7 @@ fn assert_multi_process_dense(kind: IdAllocationKind) {
     let mut child_a = Command::new(&exe)
         .args([
             "--exact",
-            "sqlite::id_allocator::tests::allocate_ids_child",
+            "sqlite::id_allocator::tests::id_allocator::allocate_ids_child",
             "--nocapture",
         ])
         .env("ORBIT_ID_ALLOCATOR_CHILD_KIND", kind_name)
@@ -223,7 +251,7 @@ fn assert_multi_process_dense(kind: IdAllocationKind) {
     let mut child_b = Command::new(&exe)
         .args([
             "--exact",
-            "sqlite::id_allocator::tests::allocate_ids_child",
+            "sqlite::id_allocator::tests::id_allocator::allocate_ids_child",
             "--nocapture",
         ])
         .env("ORBIT_ID_ALLOCATOR_CHILD_KIND", kind_name)


### PR DESCRIPTION
## Task

[ORB-00237](https://orbit-cli.com/tasks/ORB-00237) — Make learning ID allocation collision-proof across concurrent worktrees

### Description

## Problem

Concurrent Orbit task worktrees can still produce duplicate project learning IDs. ORB-00216 demonstrated the failure mode: one branch added `.orbit/learnings/L-0028/learning.yaml` while another branch landed a different `L-0028` on `agent-main`, so the completed implementation branch could not rebase cleanly and PR creation stalled.

The learning store now has a SQLite-backed id allocator and remote-stub concepts, but the behavior needs to be made collision-proof and covered by a concurrency/rebase-shaped regression test. `orbit.learning.add` must allocate from a locked shared allocator that is independent of the branch-local visible `.orbit/learnings` tree, and it must not have a scan-then-write window that can choose an ID already allocated by another active worktree.

Related friction: F2026-05-052.

## Why It Matters

Learning artifacts are committed with task branches. A duplicate `L-NNNN` is not a harmless local race: it becomes an add/add git conflict during branch refresh, can block `pr_open`, and leaves completed tasks stuck in `in-progress` even though implementation succeeded.

## Constraints / Notes

- Preserve the existing `L-NNNN` sequential ID shape.
- Do not solve this by silently overwriting or renaming an existing learning file during ordinary reads.
- Prefer the existing SQLite id allocator/lock model over adding another source of truth.
- Make the failure mode deterministic in tests; do not depend on wall-clock timing or a real GitHub remote.

### Acceptance Criteria

- `orbit.learning.add` allocates learning IDs through a shared, locked allocator rooted in shared Orbit state, not by scanning only the branch-local `.orbit/learnings` tree.
- A deterministic test simulates two concurrent task worktrees sharing one Orbit root/allocation state but with divergent learning directories; two `orbit.learning.add` calls produce distinct `L-NNNN` IDs and both resulting learning bodies are retrievable or represented as remote stubs as appropriate.
- The allocation and body-path recording flow has no scan-then-create race: if a chosen learning path already exists unexpectedly, the operation returns a typed error or retries with a newly allocated ID without corrupting either learning.
- Existing learning migration/backfill behavior remains intact: legacy learning IDs are backfilled into the allocator, and `orbit learning list --include-remote --json` continues to include remote allocation stubs for bodies that are not present in the current worktree.
- Regression coverage includes `cargo test -p orbit-store id_allocator` and the relevant learning-store CRUD tests.
- `make ci-fast` passes.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Routed learning creation through the shared SQLite allocator in a retry loop that uses an exclusive no-clobber body write; an unexpected existing `learning.yaml` is adopted when valid or rejected without overwrite/corruption when invalid.
- Added hidden abandoned allocation handling so rejected collision reservations still advance the sequence without surfacing as remote stubs, while shared backfill can recover them if a real body later appears.
- Added deterministic regression coverage for divergent worktree learning roots sharing allocator state, local path-collision retry/adoption, and fixed the id allocator child-test exact path so the required allocator regression command exercises the child process.

Assessment: The scoped store changes preserve the `L-NNNN` sequence, remote-stub listing behavior, and legacy backfill path while removing the write-time clobber window.

Validation:
- `cargo test -p orbit-store id_allocator`
- `cargo test -p orbit-store learning_store::api::tests::crud`
- `cargo test -p orbit-store`
- `make ci-fast`

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-00237-6a0e91c7`
- Behind base: 0
- Ahead of base: 1