### PR TITLE
[ORB-00234] Expose orbit-create-task documented fields on orbit_task_add MCP schema

### DIFF
--- a/crates/orbit-mcp/src/adapter/schema.rs
+++ b/crates/orbit-mcp/src/adapter/schema.rs
@@ -82,6 +82,9 @@ const TASK_UPDATE_STATUS_ENUM: &[&str] = &[
     "rejected",
 ];
 
+const TASK_COMPLEXITY_ENUM: &[&str] = &["low", "medium", "hard"];
+const AGENT_FAMILY_ENUM: &[&str] = &["codex", "claude", "gemini", "grok"];
+
 pub(super) fn enum_values_for(
     tool_name: &str,
     param_name: &str,
@@ -91,6 +94,8 @@ pub(super) fn enum_values_for(
         ("orbit.task.update", "type") => Some(TASK_TYPE_ENUM),
         ("orbit.task.add", "status") => Some(TASK_ADD_STATUS_ENUM),
         ("orbit.task.update", "status") => Some(TASK_UPDATE_STATUS_ENUM),
+        ("orbit.task.add", "complexity") => Some(TASK_COMPLEXITY_ENUM),
+        (_, "model") => Some(AGENT_FAMILY_ENUM),
         _ => None,
     }
 }

--- a/crates/orbit-mcp/src/adapter/tests/schema.rs
+++ b/crates/orbit-mcp/src/adapter/tests/schema.rs
@@ -301,3 +301,75 @@ async fn orbit_learning_update_via_mcp_adapter_accepts_evidence_array_live_repro
     assert_eq!(ev[0]["ref"], "ORB-00022");
     assert_eq!(ev[0]["kind"], "task");
 }
+
+/// ORB-00234: MCP schema for orbit_task_add now advertises the documented
+/// create-task fields with correct enums (verifiable via claude debug surface
+/// or this direct build).
+#[test]
+fn task_add_mcp_schema_exposes_complexity_enum_and_model_and_other_fields() {
+    // Use representative params that the real add schema includes (the
+    // build_input_schema only cares about the ones passed for enum injection).
+    let params = vec![
+        param_with_type("title", "string"),
+        param_with_type("description", "string"),
+        param_with_type("workspace", "string"),
+        param_with_type("complexity", "string"),
+        param_with_type("model", "string"),
+        param_with_type("dependencies", "string_list"),
+        param_with_type("relations", "array"),
+        param_with_type("parent_id", "string"),
+        param_with_type("source_task_id", "string"),
+        param_with_type("tags", "string_list"),
+        param_with_type("context_files", "string_list"),
+        param_with_type("context", "string"),
+        param_with_type("type", "string"),
+        param_with_type("status", "string"),
+    ];
+    let schema = build_input_schema("orbit.task.add", &params);
+    let properties = schema
+        .get("properties")
+        .and_then(Value::as_object)
+        .expect("properties object");
+
+    // complexity must have the low/medium/hard enum
+    let comp = properties.get("complexity").expect("complexity in schema");
+    let comp_enum = comp
+        .get("enum")
+        .and_then(Value::as_array)
+        .expect("complexity enum array");
+    assert_eq!(
+        comp_enum,
+        &vec![
+            Value::String("low".into()),
+            Value::String("medium".into()),
+            Value::String("hard".into())
+        ]
+    );
+
+    // model must have the four families (injected for any tool's model)
+    let model = properties.get("model").expect("model in schema");
+    let model_enum = model
+        .get("enum")
+        .and_then(Value::as_array)
+        .expect("model enum array");
+    assert!(model_enum.iter().any(|v| v == "codex"));
+    assert!(model_enum.iter().any(|v| v == "grok"));
+
+    // other required fields for AC1 are present (real registry ToolParams carry
+    // descriptions; the partial synthetic list here proves the keys reach the
+    // MCP schema builder).
+    for key in [
+        "dependencies",
+        "relations",
+        "parent_id",
+        "source_task_id",
+        "tags",
+    ] {
+        properties.get(key).expect(&format!(
+            "{key} must appear in MCP schema properties for orbit.task.add"
+        ));
+    }
+
+    // (context desc rewrite verified via grep on the orbit-tools source per AC2;
+    // the MCP builder faithfully copies non-empty descriptions from ToolParam)
+}

--- a/crates/orbit-tools/src/builtin/orbit/mod.rs
+++ b/crates/orbit-tools/src/builtin/orbit/mod.rs
@@ -176,7 +176,7 @@ pub(super) fn model_identity_params() -> Vec<ToolParam> {
     vec![ToolParam {
         name: "model".to_string(),
         description:
-            "Preferred provenance field. Pass the canonical agent family (`codex`, `claude`, `gemini`, or `grok`); full model strings are accepted and auto-normalized."
+            "Preferred provenance field. Pass the canonical agent family (codex, claude, gemini, or grok); full model strings are accepted and auto-normalized."
                 .to_string(),
         param_type: "string".to_string(),
         required: false,

--- a/crates/orbit-tools/src/builtin/orbit/task/add.rs
+++ b/crates/orbit-tools/src/builtin/orbit/task/add.rs
@@ -82,7 +82,7 @@ impl Tool for OrbitTaskAddTool {
             ToolParam {
                 name: "context_files".to_string(),
                 description:
-                    "Optional task context selectors as a comma-separated string or array of strings. Prefer canonical selectors: `file:path`, `dir:path`, or `symbol:path#name:kind`. Legacy raw paths are accepted and upgraded automatically."
+                    "Optional task context selectors as a comma-separated string or array of strings. Add entries ONLY for existing files, directories, or symbols expected to be modified or deleted by the task. Do not add background-reading entries or files referenced only for context. Prefer canonical selectors: `file:path`, `dir:path`, or `symbol:path#name:kind`. Legacy raw paths are accepted and upgraded automatically."
                         .to_string(),
                 param_type: "string_list".to_string(),
                 required: false,
@@ -90,7 +90,7 @@ impl Tool for OrbitTaskAddTool {
             ToolParam {
                 name: "context".to_string(),
                 description:
-                    "Legacy alias for `context_files`. Accepts the same selector-first input forms."
+                    "Legacy alias for `context_files`. Add entries ONLY for existing files, directories, or symbols expected to be modified or deleted by the task. Do not add background-reading entries or files that are only relevant background context. Prefer canonical selectors: `file:path`, `dir:path`, or `symbol:path#name:kind`."
                         .to_string(),
                 param_type: "string".to_string(),
                 required: false,
@@ -103,7 +103,7 @@ impl Tool for OrbitTaskAddTool {
             },
             ToolParam {
                 name: "complexity".to_string(),
-                description: "Optional task complexity level".to_string(),
+                description: "Optional task complexity level (low, medium, or hard)".to_string(),
                 param_type: "string".to_string(),
                 required: false,
             },
@@ -154,3 +154,6 @@ impl Tool for OrbitTaskAddTool {
         super::super::execute_host_action(ctx, input, OrbitBuiltinAction::TaskAdd)
     }
 }
+
+#[cfg(test)]
+mod tests;

--- a/crates/orbit-tools/src/builtin/orbit/task/add/tests/fields.rs
+++ b/crates/orbit-tools/src/builtin/orbit/task/add/tests/fields.rs
@@ -1,0 +1,212 @@
+//! Schema exposure and round-trip call tests for the newly-surfaced fields on
+//! `orbit.task.add` (complexity enum, model, dependencies, relations, parent_id,
+//! source_task_id, tags, and strict context wording). Mirrors the style of
+//! sibling tests under `update/tests/`.
+
+use std::sync::{Arc, Mutex};
+
+use serde_json::{Value, json};
+
+use orbit_common::types::OrbitError;
+
+use super::super::OrbitTaskAddTool;
+use crate::{OrbitBuiltinAction, OrbitTaskScope, OrbitToolHost, Tool, ToolContext};
+
+#[derive(Clone, Default)]
+struct RecordingHost {
+    call: Arc<Mutex<Option<RecordedCall>>>,
+}
+
+#[derive(Debug)]
+struct RecordedCall {
+    action: OrbitBuiltinAction,
+    input: Value,
+    agent: Option<String>,
+    model: Option<String>,
+}
+
+impl OrbitToolHost for RecordingHost {
+    fn execute(
+        &self,
+        action: OrbitBuiltinAction,
+        input: Value,
+        agent: Option<String>,
+        model: Option<String>,
+        _reservation_owner: Option<crate::ReservationOwnerContext>,
+    ) -> Result<Value, OrbitError> {
+        *self.call.lock().expect("record call") = Some(RecordedCall {
+            action,
+            input,
+            agent,
+            model,
+        });
+        // Simulate success without touching disk (real YAML write exercised in
+        // orbit-core integration tests). Return shape compatible with host.
+        Ok(json!({ "id": "ORB-TEST", "title": "roundtrip" }))
+    }
+
+    fn task_scope(&self) -> OrbitTaskScope {
+        OrbitTaskScope::default()
+    }
+}
+
+fn mk_ctx(host: RecordingHost) -> ToolContext {
+    ToolContext {
+        cwd: None,
+        allowed_tools: vec![],
+        orbit_host: Some(Arc::new(host)),
+        ..Default::default()
+    }
+}
+
+#[test]
+fn schema_exposes_create_task_documented_fields() {
+    let schema = OrbitTaskAddTool.schema();
+
+    let names: Vec<_> = schema.parameters.iter().map(|p| p.name.as_str()).collect();
+    for required in [
+        "title",
+        "description",
+        "workspace",
+        "complexity",
+        "model",
+        "dependencies",
+        "relations",
+        "parent_id",
+        "source_task_id",
+        "tags",
+        "context_files",
+        "context",
+    ] {
+        assert!(
+            names.contains(&required),
+            "orbit.task.add schema must expose {required}"
+        );
+    }
+
+    let complexity = schema
+        .parameters
+        .iter()
+        .find(|p| p.name == "complexity")
+        .expect("complexity param");
+    assert_eq!(complexity.param_type, "string");
+    assert!(!complexity.required);
+    assert!(complexity.description.contains("low, medium, or hard"));
+
+    let model = schema
+        .parameters
+        .iter()
+        .find(|p| p.name == "model")
+        .expect("model param");
+    assert_eq!(model.param_type, "string");
+    assert!(!model.required);
+
+    let deps = schema
+        .parameters
+        .iter()
+        .find(|p| p.name == "dependencies")
+        .expect("dependencies");
+    assert_eq!(deps.param_type, "string_list");
+
+    let rels = schema
+        .parameters
+        .iter()
+        .find(|p| p.name == "relations")
+        .expect("relations");
+    assert_eq!(rels.param_type, "array");
+
+    let tags = schema
+        .parameters
+        .iter()
+        .find(|p| p.name == "tags")
+        .expect("tags");
+    assert_eq!(tags.param_type, "string_list");
+
+    let parent = schema
+        .parameters
+        .iter()
+        .find(|p| p.name == "parent_id")
+        .expect("parent_id");
+    assert_eq!(parent.param_type, "string");
+
+    let source = schema
+        .parameters
+        .iter()
+        .find(|p| p.name == "source_task_id")
+        .expect("source_task_id");
+    assert_eq!(source.param_type, "string");
+
+    // context (the one whose description we rewrote) must use modify-or-delete wording
+    let ctx = schema
+        .parameters
+        .iter()
+        .find(|p| p.name == "context")
+        .expect("context legacy param");
+    assert!(
+        ctx.description.contains("modified or deleted")
+            && ctx.description.contains("background-reading"),
+        "context desc must use skill's modify-or-delete + disallow background: {}",
+        ctx.description
+    );
+}
+
+#[test]
+fn add_call_with_all_fields_roundtrips_to_host() {
+    let host = RecordingHost::default();
+    let ctx = mk_ctx(host.clone());
+    let tool = OrbitTaskAddTool;
+
+    let input = json!({
+        "title": "Expose fields test",
+        "description": "Round-trip coverage for ORB-00234",
+        "workspace": "/tmp/test-ws",
+        "complexity": "medium",
+        "model": "grok",
+        "dependencies": ["ORB-00001"],
+        "relations": [{"type": "related_to", "target": "ORB-00002"}],
+        "parent_id": "ORB-00003",
+        "source_task_id": "ORB-00004",
+        "tags": ["mcp", "schema"],
+        "context_files": ["file:crates/orbit-tools/src/builtin/orbit/task/add.rs"],
+        "context": "file:crates/orbit-tools/src/builtin/orbit/task/add/tests/fields.rs",
+        "acceptance_criteria": ["MCP schema has enums", "roundtrip reaches host"],
+        "plan": "",
+        "priority": "medium",
+        "type": "chore",
+        "status": "proposed"
+    });
+
+    let res = tool.execute(&ctx, input.clone()).expect("execute succeeds");
+    assert_eq!(res["id"], "ORB-TEST");
+
+    let recorded = host
+        .call
+        .lock()
+        .expect("lock")
+        .take()
+        .expect("host was called");
+    assert_eq!(recorded.action, OrbitBuiltinAction::TaskAdd);
+    assert_eq!(recorded.model.as_deref(), Some("grok"));
+
+    // All newly-exposed (and context alias) fields must be present in the payload
+    // that reaches the host (which ultimately writes the task YAML).
+    let rec_input = recorded.input;
+    for key in [
+        "complexity",
+        "model",
+        "dependencies",
+        "relations",
+        "parent_id",
+        "source_task_id",
+        "tags",
+        "context_files",
+        "context",
+    ] {
+        assert!(
+            rec_input.get(key).is_some(),
+            "field {key} must survive the call to orbit.task.add and reach host for YAML persistence"
+        );
+    }
+    assert_eq!(rec_input["complexity"], "medium");
+    assert_eq!(rec_input["parent_id"], "ORB-00003");
+}

--- a/crates/orbit-tools/src/builtin/orbit/task/add/tests/mod.rs
+++ b/crates/orbit-tools/src/builtin/orbit/task/add/tests/mod.rs
@@ -1,0 +1,3 @@
+#![allow(missing_docs)]
+
+mod fields;

--- a/crates/orbit-tools/src/builtin/orbit/task/update.rs
+++ b/crates/orbit-tools/src/builtin/orbit/task/update.rs
@@ -122,9 +122,17 @@ impl Tool for OrbitTaskUpdateTool {
             ToolParam {
                 name: "context_files".to_string(),
                 description:
-                    "Task context selectors as a comma-separated string or array of strings. Prefer canonical selectors: `file:path`, `dir:path`, or `symbol:path#name:kind`. Legacy raw paths are accepted and upgraded automatically."
+                    "Task context selectors as a comma-separated string or array of strings. Add entries ONLY for existing files, directories, or symbols expected to be modified or deleted by the task. Do not add background-reading entries or files referenced only for context. Prefer canonical selectors: `file:path`, `dir:path`, or `symbol:path#name:kind`. Legacy raw paths are accepted and upgraded automatically."
                         .to_string(),
                 param_type: "string_list".to_string(),
+                required: false,
+            },
+            ToolParam {
+                name: "context".to_string(),
+                description:
+                    "Legacy alias for `context_files`. Add entries ONLY for existing files, directories, or symbols expected to be modified or deleted by the task. Do not add background-reading entries or files that are only relevant background context. Prefer canonical selectors: `file:path`, `dir:path`, or `symbol:path#name:kind`."
+                        .to_string(),
+                param_type: "string".to_string(),
                 required: false,
             },
             ToolParam {


### PR DESCRIPTION
## Summary

Surfaces `complexity`, `model` enum values on the `orbit_task_add` / `orbit_task_update` MCP schemas so agents loading the tool directly can pass them. Without this, tasks created via MCP silently miss `complexity`, breaking batching heuristics.

Also rewrites `context` / `context_files` parameter descriptions to match the `orbit-create-task` skill's stricter wording: only existing files/dirs/symbols the task will modify or delete — no background-reading entries.

## Changes

- `crates/orbit-mcp/src/adapter/schema.rs` — Add `TASK_COMPLEXITY_ENUM` (`low | medium | hard`) and `AGENT_FAMILY_ENUM` (`codex | claude | gemini | grok`); wire them into `enum_values_for` for `orbit.task.add` `complexity` and the global `model` param.
- `crates/orbit-tools/src/builtin/orbit/task/add.rs` — Rewrite `context` and `context_files` descriptions per skill wording; tighten `complexity` description.
- `crates/orbit-tools/src/builtin/orbit/task/update.rs` — Mirror the `context_files` rewrite; add legacy `context` alias for parity with add.
- `crates/orbit-tools/src/builtin/orbit/mod.rs` — Strip backticks from `model_identity_params` description (cosmetic).
- Tests: `crates/orbit-tools/src/builtin/orbit/task/add/tests/fields.rs` (round-trip across all newly-exposed fields), `crates/orbit-mcp/src/adapter/schema/tests.rs` (schema enum verification).

## Validation

- `cargo test -p orbit-core` — 411 lib + 6 integration, 0 failures.
- `cargo test -p orbit-tools -p orbit-mcp` — all pass (incl. new round-trip + schema-enum tests).
- `make ci-fast` — green (fmt, dep direction, cli imports, stability, learning layout, artifact redaction).

## Context

Implementation was produced by grok in `jrun-20260521-0456-4`. The Orbit pipeline's `pr_open` step failed because the task status was manually reverted to `proposed` mid-flight (see task history). PR is being raised manually after independent verification. Grok's earlier comment claiming 3 pre-existing `orbit-core` test failures could not be reproduced — `cargo test -p orbit-core` is fully green on this branch.

## Test plan

- [x] Unit tests pass (`cargo test -p orbit-core -p orbit-tools -p orbit-mcp`)
- [x] `make ci-fast` passes
- [ ] CI green on PR
- [ ] Reviewer confirms MCP schema enums render correctly in a fresh `claude mcp` session