### PR TITLE
Collapse leftover nested test layout in orbit-tools (task/add)

### DIFF
--- a/crates/orbit-tools/src/builtin/orbit/task/add.rs
+++ b/crates/orbit-tools/src/builtin/orbit/task/add.rs
@@ -154,6 +154,3 @@ impl Tool for OrbitTaskAddTool {
         super::super::execute_host_action(ctx, input, OrbitBuiltinAction::TaskAdd)
     }
 }
-
-#[cfg(test)]
-mod tests;

--- a/crates/orbit-tools/src/builtin/orbit/task/add/tests/mod.rs
+++ b/crates/orbit-tools/src/builtin/orbit/task/add/tests/mod.rs
@@ -1,3 +1,0 @@
-#![allow(missing_docs)]
-
-mod fields;

--- a/crates/orbit-tools/src/builtin/orbit/task/tests/add.rs
+++ b/crates/orbit-tools/src/builtin/orbit/task/tests/add.rs
@@ -2,6 +2,10 @@
 //! `orbit.task.add` (complexity enum, model, dependencies, relations, parent_id,
 //! source_task_id, tags, and strict context wording). Mirrors the style of
 //! sibling tests under `update/tests/`.
+//
+// Migrated from nested `task/add/tests/fields.rs` (anti-pattern)
+// to single sibling `task/tests/add.rs` per ORB-00248 and
+// docs/design-patterns/test_layout.md.
 
 use std::sync::{Arc, Mutex};
 
@@ -9,7 +13,7 @@ use serde_json::{Value, json};
 
 use orbit_common::types::OrbitError;
 
-use super::super::OrbitTaskAddTool;
+use super::super::add::OrbitTaskAddTool;
 use crate::{OrbitBuiltinAction, OrbitTaskScope, OrbitToolHost, Tool, ToolContext};
 
 #[derive(Clone, Default)]

--- a/crates/orbit-tools/src/builtin/orbit/task/tests/mod.rs
+++ b/crates/orbit-tools/src/builtin/orbit/task/tests/mod.rs
@@ -1,4 +1,5 @@
 #![allow(missing_docs)]
 
+mod add;
 mod artifact_put;
 mod update;


### PR DESCRIPTION
## Task

[ORB-00248](https://orbit-cli.com/tasks/ORB-00248) — Collapse leftover nested test layout in orbit-tools (task/add)

### Description

## Problem

`orbit-tools` has one leftover nested per-source `tests/` directory — the anti-pattern documented in [`docs/design-patterns/test_layout.md`](docs/design-patterns/test_layout.md) §"Anti-pattern: nested per-source `tests/`". The prior migration in ORB-00243 (which named both orbit-store and orbit-tools) missed this case.

```
crates/orbit-tools/src/builtin/orbit/task/
  add.rs                         # line 159: `mod tests;` (anti-pattern — child of single-file module)
  add/
    tests/
      mod.rs
      fields.rs
  tests/                         # the correct sibling directory already exists here
    mod.rs
    update.rs
    artifact_put.rs
```

The `task/` parent already has the correct sibling `tests/` directory with `tests/update.rs` and `tests/artifact_put.rs`. The work is to fold `add/tests/fields.rs` into a new `task/tests/add.rs` and delete the offending `add/` subdirectory.

## Fix

1. Move the contents of `crates/orbit-tools/src/builtin/orbit/task/add/tests/fields.rs` into a new file `crates/orbit-tools/src/builtin/orbit/task/tests/add.rs`. The filename mirrors the source (`add.rs`), per the convention's "one file per source" rule.
2. Update imports: replace whatever the file uses today with `use super::super::add::<item>;` (the sibling path from `task/tests/add.rs` up to `task/` and back down into `task::add`).
3. Remove the `mod tests;` declaration from line 159 of `crates/orbit-tools/src/builtin/orbit/task/add.rs`.
4. Delete the entire `crates/orbit-tools/src/builtin/orbit/task/add/` subdirectory.
5. Append `mod add;` to `crates/orbit-tools/src/builtin/orbit/task/tests/mod.rs`.
6. Confirm `task/mod.rs` declares `#[cfg(test)] mod tests;` once for the whole parent (line 16 already does — leave alone).

## Why It Matters

This is the last nested anti-pattern instance in `orbit-tools`. Cleaning it up closes the convention sweep for this crate and removes the only example a reader could cite to claim the anti-pattern is tolerated here.

## Constraints / Notes

- Follow the migration recipe in [`docs/design-patterns/test_layout.md`](docs/design-patterns/test_layout.md) §"For modules already migrated to the *nested* anti-pattern".
- The fix is small (one file move, one declaration removal) — scope tight, no surrounding cleanup.
- Related: ORB-00219 (convention), ORB-00243 (prior partial migration).

### Acceptance Criteria

- `crates/orbit-tools/src/builtin/orbit/task/add/` directory no longer exists.
- `crates/orbit-tools/src/builtin/orbit/task/add.rs` no longer contains a `mod tests;` declaration.
- `crates/orbit-tools/src/builtin/orbit/task/tests/add.rs` exists, contains the migrated test bodies originally in `add/tests/fields.rs`, and imports via `use super::super::add::<item>;` rather than `use super::*;`.
- `crates/orbit-tools/src/builtin/orbit/task/tests/mod.rs` declares `mod add;`.
- Running `for d in $(find crates/orbit-tools/src -type d -name tests); do p=$(dirname $d); n=$(basename $p); g=$(dirname $p); test -f "$g/$n.rs" && echo ANTI: $d; done` produces no output.
- `cargo test -p orbit-tools` passes.
- `make ci-fast` passes.

## Execution Summary

<details>
<summary>Click to expand</summary>

Implemented ORB-00248: collapsed nested test layout.

- Created crates/orbit-tools/src/builtin/orbit/task/tests/add.rs with migrated bodies (imports adjusted to `use super::super::add::OrbitTaskAddTool;`).
- Removed `#[cfg(test)] mod tests;` from add.rs.
- Added `mod add;` to task/tests/mod.rs (fmt order).
- Deleted crates/orbit-tools/src/builtin/orbit/task/add/ directory.

Validation: anti-pattern detector clean; `cargo test -p orbit-tools` (26 unit tests) passed; `make ci-fast` passed (fmt + guards).

No other files required changes. Followed test_layout.md recipe and envelope rules. No learnings to add (no contradicted assumptions surfaced).

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-00248-6a0fc0f7`
- Behind base: 0
- Ahead of base: 1