### PR TITLE
orbit.task.add: trim schema to 9 fields + model identity (drop 9 low-value params)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2312,6 +2312,8 @@ dependencies = [
  "sha2",
  "tempfile",
  "thiserror",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/crates/orbit-common/src/types/mod.rs
+++ b/crates/orbit-common/src/types/mod.rs
@@ -143,8 +143,9 @@ pub use task_artifacts::{
 pub use task_plan::{TaskPlan, TaskPlanCheckpoint, TaskPlanSuccessCriterion, parse_task_plan};
 pub use tool::{ExecutionResult, StoredTool, ToolParam, ToolSchema};
 pub use tool_input::{
-    optional_csv_or_string_list_alias, optional_raw_string, optional_string, optional_string_alias,
-    optional_string_list_alias, optional_u32_alias, required_string, split_csv,
+    RETIRED_TASK_ADD_INPUT_FIELDS, optional_csv_or_string_list_alias, optional_raw_string,
+    optional_string, optional_string_alias, optional_string_list_alias, optional_u32_alias,
+    required_string, split_csv, strip_retired_task_add_input_fields,
 };
 pub use workspace::{Workspace, WorkspacePaths, WorkspaceRegistry, WorkspaceStatus};
 

--- a/crates/orbit-common/src/types/tool_input.rs
+++ b/crates/orbit-common/src/types/tool_input.rs
@@ -2,6 +2,32 @@ use serde_json::Value;
 
 use crate::types::OrbitError;
 
+pub const RETIRED_TASK_ADD_INPUT_FIELDS: &[&str] = &[
+    "plan",
+    "status",
+    "crew",
+    "parent_id",
+    "source_task_id",
+    "external_refs",
+    "context",
+    "comment",
+    "dependencies",
+];
+
+pub fn strip_retired_task_add_input_fields(input: &mut Value) -> Vec<&'static str> {
+    let Some(object) = input.as_object_mut() else {
+        return Vec::new();
+    };
+
+    let mut ignored = Vec::new();
+    for field in RETIRED_TASK_ADD_INPUT_FIELDS {
+        if object.remove(*field).is_some() {
+            ignored.push(*field);
+        }
+    }
+    ignored
+}
+
 pub fn required_string(
     input: &Value,
     keys: &[&str],

--- a/crates/orbit-core/src/runtime/orbit_tool_host/input.rs
+++ b/crates/orbit-core/src/runtime/orbit_tool_host/input.rs
@@ -2,9 +2,9 @@ use std::path::PathBuf;
 use std::str::FromStr;
 
 use orbit_common::types::{
-    ExternalRef, NotFoundKind, OrbitError, TaskArtifact, TaskComplexity, TaskPriority,
-    TaskRelation, TaskStatus, TaskType, media_type_for_artifact_path, optional_string,
-    optional_string_alias, optional_u32_alias,
+    NotFoundKind, OrbitError, TaskArtifact, TaskComplexity, TaskPriority, TaskRelation, TaskStatus,
+    TaskType, media_type_for_artifact_path, optional_string, optional_string_alias,
+    optional_u32_alias,
 };
 use orbit_store::state_io;
 use orbit_tools::OrbitTaskScope;
@@ -185,25 +185,6 @@ fn parse_artifact_content(value: &Value) -> Result<Vec<u8>, OrbitError> {
             .collect(),
         _ => Err(OrbitError::InvalidInput(
             "`artifacts` entries must include string or byte-array `content` values".to_string(),
-        )),
-    }
-}
-
-pub(super) fn parse_external_refs(input: &Value) -> Result<Vec<ExternalRef>, OrbitError> {
-    let Some(value) = input
-        .get("external_refs")
-        .or_else(|| input.get("externalRefs"))
-        .or_else(|| input.get("external-refs"))
-    else {
-        return Ok(Vec::new());
-    };
-
-    match value {
-        Value::Null => Ok(Vec::new()),
-        Value::Array(_) => serde_json::from_value::<Vec<ExternalRef>>(value.clone())
-            .map_err(|error| OrbitError::InvalidInput(format!("invalid `external_refs`: {error}"))),
-        _ => Err(OrbitError::InvalidInput(
-            "`external_refs` must be an array of {system, id, url?} objects".to_string(),
         )),
     }
 }

--- a/crates/orbit-core/src/runtime/orbit_tool_host/task_tools.rs
+++ b/crates/orbit-core/src/runtime/orbit_tool_host/task_tools.rs
@@ -3,7 +3,7 @@ use std::collections::BTreeSet;
 use orbit_common::types::{
     OrbitError, TaskPriority, build_task_status_index, optional_csv_or_string_list_alias,
     optional_raw_string, optional_string, optional_string_alias, optional_string_list_alias,
-    required_string, task_dependencies_ready,
+    required_string, strip_retired_task_add_input_fields, task_dependencies_ready,
 };
 use serde_json::{Value, json};
 
@@ -11,36 +11,34 @@ use crate::OrbitRuntime;
 use crate::command::task::{TaskAddParams, TaskUpdateParams, compute_task_add_warnings};
 
 use super::input::{
-    empty_string_to_none, optional_bool_alias, parse_artifacts, parse_external_refs,
-    parse_relations, parse_task_complexity, parse_task_priority, parse_task_status,
-    parse_task_type,
+    empty_string_to_none, optional_bool_alias, parse_artifacts, parse_relations,
+    parse_task_complexity, parse_task_priority, parse_task_status, parse_task_type,
 };
 use super::json::{serialize_task, serialize_task_lint_report, task_fields_to_json, task_to_json};
 
 pub(super) fn add(
     runtime: &OrbitRuntime,
-    input: Value,
+    mut input: Value,
     agent: Option<String>,
     model: Option<String>,
 ) -> Result<Value, OrbitError> {
+    let ignored_fields = strip_retired_task_add_input_fields(&mut input);
+    if !ignored_fields.is_empty() {
+        tracing::warn!(
+            target: "orbit.core.task.add",
+            ignored_fields = ?ignored_fields,
+            "ignored retired orbit.task.add fields"
+        );
+    }
+
     let title = required_string(&input, &["title"], "title")?;
     let description = required_string(&input, &["description"], "description")?;
     let workspace = required_string(&input, &["workspace"], "workspace")?;
-    let plan = match input.get("plan") {
-        Some(Value::String(value)) => value.clone(),
-        Some(Value::Null) | None => String::new(),
-        Some(_) => {
-            return Err(OrbitError::InvalidInput(
-                "`plan` must be a string".to_string(),
-            ));
-        }
-    };
     let raw_context_files =
-        optional_csv_or_string_list_alias(&input, &["context_files", "context"])?
-            .unwrap_or_default();
+        optional_csv_or_string_list_alias(&input, &["context_files"])?.unwrap_or_default();
     let task = runtime.add_task_with_identity(
         TaskAddParams {
-            parent_id: optional_string_alias(&input, &["parent_id", "parent", "parentId"])?,
+            parent_id: None,
             title,
             description,
             acceptance_criteria: optional_string_list_alias(
@@ -52,12 +50,11 @@ pub(super) fn add(
                 ],
             )?
             .unwrap_or_default(),
-            dependencies: optional_csv_or_string_list_alias(&input, &["dependencies"])?
-                .unwrap_or_default(),
+            dependencies: Vec::new(),
             relations: parse_relations(&input)?.unwrap_or_default(),
             tags: optional_csv_or_string_list_alias(&input, &["tags", "tag"])?.unwrap_or_default(),
-            plan,
-            comment: optional_string(&input, "comment")?,
+            plan: String::new(),
+            comment: None,
             context_files: raw_context_files.clone(),
             workspace_path: Some(workspace),
             priority: optional_string(&input, "priority")?
@@ -70,16 +67,11 @@ pub(super) fn add(
             task_type: optional_string_alias(&input, &["type", "task_type", "taskType"])?
                 .map(|value| parse_task_type("type", &value))
                 .transpose()?,
-            status: optional_string(&input, "status")?
-                .map(|value| parse_task_status("status", &value))
-                .transpose()?,
+            status: None,
             system_created: false,
-            external_refs: parse_external_refs(&input)?,
-            source_task_id: optional_string_alias(
-                &input,
-                &["source_task_id", "source_task", "sourceTaskId"],
-            )?,
-            crew: optional_string(&input, "crew")?,
+            external_refs: Vec::new(),
+            source_task_id: None,
+            crew: None,
         },
         agent,
         model,

--- a/crates/orbit-core/src/runtime/orbit_tool_host/task_tools_tests.rs
+++ b/crates/orbit-core/src/runtime/orbit_tool_host/task_tools_tests.rs
@@ -190,7 +190,7 @@ fn duel_plan_winner_persists_gemini_arbiter_artifact() {
 }
 
 #[test]
-fn task_add_tool_rejects_dropped_task_types_and_friction_status() {
+fn task_add_tool_rejects_dropped_task_types_and_ignores_retired_status() {
     let (_root, runtime, _repo_root) = test_runtime();
 
     for dropped_type in ["task", "epic", "issue", "friction"] {
@@ -212,18 +212,23 @@ fn task_add_tool_rejects_dropped_task_types_and_friction_status() {
         );
     }
 
-    let message = invalid_input_message(runtime.execute_tool_command(
-        "orbit.task.add",
-        json!({
-            "title": "Legacy friction status",
-            "description": "Should use the new friction record surface.",
-            "workspace": ".",
-            "status": "friction",
-        }),
-        Some("codex".to_string()),
-        Some("gpt-5.5".to_string()),
-    ));
-    assert!(message.contains("orbit.friction.add"), "{message}");
+    let output = runtime
+        .execute_tool_command(
+            "orbit.task.add",
+            json!({
+                "title": "Legacy friction status",
+                "description": "Should ignore retired task-add status.",
+                "workspace": ".",
+                "status": "friction",
+            }),
+            Some("codex".to_string()),
+            Some("gpt-5.5".to_string()),
+        )
+        .expect("retired status field is ignored");
+    assert_eq!(
+        output.get("status").and_then(Value::as_str),
+        Some("proposed")
+    );
 }
 
 #[test]
@@ -383,7 +388,7 @@ fn task_delete_tool_allows_forced_protected_statuses() {
 }
 
 #[test]
-fn task_add_tool_persists_dependencies() {
+fn task_add_tool_ignores_retired_dependencies() {
     let (_root, runtime, repo_root) = test_runtime();
     let dependency = create_task(
         &runtime,
@@ -408,10 +413,7 @@ fn task_add_tool_persists_dependencies() {
         )
         .expect("task add tool succeeds");
 
-    assert_eq!(
-        output.get("dependencies"),
-        Some(&json!([dependency.id.as_str()]))
-    );
+    assert_eq!(output.get("dependencies"), Some(&json!([])));
 }
 
 #[test]
@@ -532,7 +534,7 @@ fn task_add_tool_normalizes_tags_at_write_time() {
 }
 
 #[test]
-fn task_add_tool_persists_external_refs() {
+fn task_add_tool_ignores_retired_external_refs() {
     let (_root, runtime, _repo_root) = test_runtime();
 
     let output = runtime
@@ -552,13 +554,7 @@ fn task_add_tool_persists_external_refs() {
         )
         .expect("task add tool succeeds");
 
-    assert_eq!(
-        output.get("external_refs"),
-        Some(&json!([
-            {"system": "jira", "id": "ENG-1234", "url": "https://example.com/browse/ENG-1234"},
-            {"system": "linear", "id": "LIN-567"}
-        ]))
-    );
+    assert_eq!(output.get("external_refs"), Some(&json!([])));
 }
 
 #[test]
@@ -844,12 +840,26 @@ fn task_update_tool_clears_source_task_id_with_empty_string() {
                 "description": "A bug whose source should be cleared.",
                 "workspace": ".",
                 "type": "bug",
-                "source_task_id": source.id,
             }),
             Some("codex".to_string()),
             Some("gpt-5.5".to_string()),
         )
         .expect("task add tool succeeds");
+    let seeded = runtime
+        .execute_tool_command(
+            "orbit.task.update",
+            json!({
+                "id": added["id"].as_str().expect("task id"),
+                "source_task_id": source.id.clone(),
+            }),
+            Some("codex".to_string()),
+            Some("gpt-5.5".to_string()),
+        )
+        .expect("task update tool sets source task");
+    assert_eq!(
+        seeded.get("source_task_id").and_then(Value::as_str),
+        Some(source.id.as_str())
+    );
 
     let output = runtime
         .execute_tool_command(
@@ -880,43 +890,29 @@ fn task_update_tool_clears_source_task_id_with_empty_string() {
 }
 
 #[test]
-fn task_update_tool_stores_unresolved_source_task_id_matching_add() {
+fn task_update_tool_stores_unresolved_source_task_id() {
     let (_root, runtime, _repo_root) = test_runtime();
     let unresolved_from_update = "ORB-99999";
-    let unresolved_from_add = "ORB-99998";
-
-    let added = runtime
-        .execute_tool_command(
-            "orbit.task.add",
-            json!({
-                "title": "Bug without resolved source",
-                "description": "A bug whose source ID is known before its task exists.",
-                "workspace": ".",
-                "type": "bug",
-                "source_task_id": unresolved_from_add,
-            }),
-            Some("codex".to_string()),
-            Some("gpt-5.5".to_string()),
-        )
-        .expect("add stores a loose source reference");
-    assert_eq!(
-        added.get("source_task_id").and_then(Value::as_str),
-        Some(unresolved_from_add)
-    );
 
     let update_target = runtime
         .execute_tool_command(
             "orbit.task.add",
             json!({
-                "title": "Bug with later loose source",
-                "description": "Exercise update-side loose reference parity.",
+                "title": "Bug without resolved source",
+                "description": "A bug whose retired add-side source ID should be ignored.",
                 "workspace": ".",
                 "type": "bug",
+                "source_task_id": "ORB-99998",
             }),
             Some("codex".to_string()),
             Some("gpt-5.5".to_string()),
         )
         .expect("task add tool succeeds");
+    assert_eq!(
+        update_target.get("source_task_id"),
+        Some(&Value::Null),
+        "retired add-side source_task_id must be ignored"
+    );
     let output = runtime
         .execute_tool_command(
             "orbit.task.update",

--- a/crates/orbit-mcp/src/adapter/schema.rs
+++ b/crates/orbit-mcp/src/adapter/schema.rs
@@ -59,17 +59,6 @@ pub(super) fn build_input_schema(tool_name: &str, params: &[ToolParam]) -> JsonO
 
 const TASK_TYPE_ENUM: &[&str] = &["feature", "bug", "refactor", "chore"];
 
-const TASK_ADD_STATUS_ENUM: &[&str] = &[
-    "proposed",
-    "backlog",
-    "someday",
-    "in-progress",
-    "review",
-    "done",
-    "blocked",
-    "rejected",
-];
-
 const TASK_UPDATE_STATUS_ENUM: &[&str] = &[
     "proposed",
     "friction",
@@ -92,7 +81,6 @@ pub(super) fn enum_values_for(
     match (tool_name, param_name) {
         ("orbit.task.add", "type") => Some(TASK_TYPE_ENUM),
         ("orbit.task.update", "type") => Some(TASK_TYPE_ENUM),
-        ("orbit.task.add", "status") => Some(TASK_ADD_STATUS_ENUM),
         ("orbit.task.update", "status") => Some(TASK_UPDATE_STATUS_ENUM),
         ("orbit.task.add", "complexity") => Some(TASK_COMPLEXITY_ENUM),
         (_, "model") => Some(AGENT_FAMILY_ENUM),

--- a/crates/orbit-mcp/src/adapter/tests/schema.rs
+++ b/crates/orbit-mcp/src/adapter/tests/schema.rs
@@ -9,7 +9,7 @@ use super::super::test_support::{
 };
 
 #[test]
-fn task_add_schema_excludes_legacy_friction_enums() {
+fn task_add_schema_excludes_legacy_friction_and_status_enums() {
     let schema = build_input_schema("orbit.task.add", &[param("type"), param("status")]);
     let properties = schema
         .get("properties")
@@ -19,10 +19,10 @@ fn task_add_schema_excludes_legacy_friction_enums() {
     let type_enum = properties["type"]["enum"].as_array().expect("type enum");
     assert!(!type_enum.iter().any(|value| value == "friction"));
 
-    let status_enum = properties["status"]["enum"]
-        .as_array()
-        .expect("status enum");
-    assert!(!status_enum.iter().any(|value| value == "friction"));
+    assert!(
+        properties["status"].get("enum").is_none(),
+        "orbit.task.add no longer advertises status at all"
+    );
 }
 
 #[test]
@@ -46,40 +46,40 @@ fn schema_to_tool_keeps_dotted_orbit_tools_advertised_with_underscores() {
 
 #[test]
 fn task_dependency_schemas_accept_string_or_string_array() {
-    for tool_name in ["orbit.task.add", "orbit.task.update"] {
-        let schema =
-            build_input_schema(tool_name, &[param_with_type("dependencies", "string_list")]);
-        let properties = schema
-            .get("properties")
-            .and_then(Value::as_object)
-            .expect("properties");
-        let dependencies = properties
-            .get("dependencies")
-            .and_then(Value::as_object)
-            .expect("dependencies property");
-        let any_of = dependencies
-            .get("anyOf")
-            .and_then(Value::as_array)
-            .expect("string-list union");
+    let schema = build_input_schema(
+        "orbit.task.update",
+        &[param_with_type("dependencies", "string_list")],
+    );
+    let properties = schema
+        .get("properties")
+        .and_then(Value::as_object)
+        .expect("properties");
+    let dependencies = properties
+        .get("dependencies")
+        .and_then(Value::as_object)
+        .expect("dependencies property");
+    let any_of = dependencies
+        .get("anyOf")
+        .and_then(Value::as_array)
+        .expect("string-list union");
 
-        assert!(
-            any_of.iter().any(|schema| {
-                schema.get("type").and_then(Value::as_str) == Some("array")
-                    && schema
-                        .get("items")
-                        .and_then(|items| items.get("type"))
-                        .and_then(Value::as_str)
-                        == Some("string")
-            }),
-            "{tool_name} dependencies must accept an array of strings"
-        );
-        assert!(
-            any_of
-                .iter()
-                .any(|schema| schema.get("type").and_then(Value::as_str) == Some("string")),
-            "{tool_name} dependencies must accept a string"
-        );
-    }
+    assert!(
+        any_of.iter().any(|schema| {
+            schema.get("type").and_then(Value::as_str) == Some("array")
+                && schema
+                    .get("items")
+                    .and_then(|items| items.get("type"))
+                    .and_then(Value::as_str)
+                    == Some("string")
+        }),
+        "orbit.task.update dependencies must accept an array of strings"
+    );
+    assert!(
+        any_of
+            .iter()
+            .any(|schema| schema.get("type").and_then(Value::as_str) == Some("string")),
+        "orbit.task.update dependencies must accept a string"
+    );
 }
 
 // --- ORB-00102 tests: object_list schema + loud fallback + e2e via MCP adapter ---
@@ -302,34 +302,49 @@ async fn orbit_learning_update_via_mcp_adapter_accepts_evidence_array_live_repro
     assert_eq!(ev[0]["kind"], "task");
 }
 
-/// ORB-00234: MCP schema for orbit_task_add now advertises the documented
-/// create-task fields with correct enums (verifiable via claude debug surface
-/// or this direct build).
+/// ORB-00234/ORB-00255: MCP schema for orbit_task_add advertises the trimmed
+/// create-task fields with correct enums (verifiable via debug surfaces or this
+/// direct build).
 #[test]
-fn task_add_mcp_schema_exposes_complexity_enum_and_model_and_other_fields() {
+fn task_add_mcp_schema_exposes_trimmed_fields_with_complexity_and_model_enums() {
     // Use representative params that the real add schema includes (the
     // build_input_schema only cares about the ones passed for enum injection).
     let params = vec![
         param_with_type("title", "string"),
         param_with_type("description", "string"),
         param_with_type("workspace", "string"),
-        param_with_type("complexity", "string"),
-        param_with_type("model", "string"),
-        param_with_type("dependencies", "string_list"),
-        param_with_type("relations", "array"),
-        param_with_type("parent_id", "string"),
-        param_with_type("source_task_id", "string"),
+        param_with_type("acceptance_criteria", "string_list"),
         param_with_type("tags", "string_list"),
         param_with_type("context_files", "string_list"),
-        param_with_type("context", "string"),
+        param_with_type("priority", "string"),
+        param_with_type("complexity", "string"),
         param_with_type("type", "string"),
-        param_with_type("status", "string"),
+        param_with_type("relations", "array"),
+        param_with_type("model", "string"),
     ];
     let schema = build_input_schema("orbit.task.add", &params);
     let properties = schema
         .get("properties")
         .and_then(Value::as_object)
         .expect("properties object");
+
+    let property_names = properties.keys().map(String::as_str).collect::<Vec<_>>();
+    assert_eq!(
+        property_names,
+        vec![
+            "acceptance_criteria",
+            "complexity",
+            "context_files",
+            "description",
+            "model",
+            "priority",
+            "relations",
+            "tags",
+            "title",
+            "type",
+            "workspace",
+        ]
+    );
 
     // complexity must have the low/medium/hard enum
     let comp = properties.get("complexity").expect("complexity in schema");
@@ -355,21 +370,20 @@ fn task_add_mcp_schema_exposes_complexity_enum_and_model_and_other_fields() {
     assert!(model_enum.iter().any(|v| v == "codex"));
     assert!(model_enum.iter().any(|v| v == "grok"));
 
-    // other required fields for AC1 are present (real registry ToolParams carry
-    // descriptions; the partial synthetic list here proves the keys reach the
-    // MCP schema builder).
-    for key in [
-        "dependencies",
-        "relations",
+    for removed in [
+        "plan",
+        "status",
+        "crew",
         "parent_id",
         "source_task_id",
-        "tags",
+        "external_refs",
+        "context",
+        "comment",
+        "dependencies",
     ] {
-        properties.get(key).expect(&format!(
-            "{key} must appear in MCP schema properties for orbit.task.add"
-        ));
+        assert!(
+            !properties.contains_key(removed),
+            "{removed} must not appear in MCP schema properties for orbit.task.add"
+        );
     }
-
-    // (context desc rewrite verified via grep on the orbit-tools source per AC2;
-    // the MCP builder faithfully copies non-empty descriptions from ToolParam)
 }

--- a/crates/orbit-tools/Cargo.toml
+++ b/crates/orbit-tools/Cargo.toml
@@ -21,7 +21,9 @@ serde.workspace = true
 serde_json.workspace = true
 sha2.workspace = true
 thiserror.workspace = true
+tracing.workspace = true
 
 [dev-dependencies]
 rusqlite.workspace = true
 tempfile = "3"
+tracing-subscriber.workspace = true

--- a/crates/orbit-tools/src/builtin/orbit/task/add.rs
+++ b/crates/orbit-tools/src/builtin/orbit/task/add.rs
@@ -1,4 +1,6 @@
-use orbit_common::types::{OrbitError, ToolParam, ToolSchema};
+use orbit_common::types::{
+    OrbitError, ToolParam, ToolSchema, required_string, strip_retired_task_add_input_fields,
+};
 use serde_json::Value;
 
 use crate::{OrbitBuiltinAction, Tool, ToolContext};
@@ -20,42 +22,6 @@ impl Tool for OrbitTaskAddTool {
                 param_type: "string".to_string(),
                 required: true,
             },
-            ToolParam {
-                name: "acceptance_criteria".to_string(),
-                description: "Optional acceptance criteria as a string or array of strings"
-                    .to_string(),
-                param_type: "string_list".to_string(),
-                required: false,
-            },
-            ToolParam {
-                name: "dependencies".to_string(),
-                description: "Optional dependency task IDs as a string or array of strings"
-                    .to_string(),
-                param_type: "string_list".to_string(),
-                required: false,
-            },
-            ToolParam {
-                name: "relations".to_string(),
-                description:
-                    "Optional typed task relations as an array of {type, target} objects"
-                        .to_string(),
-                param_type: "array".to_string(),
-                required: false,
-            },
-            ToolParam {
-                name: "tags".to_string(),
-                description: "Optional tags as a string or array of strings".to_string(),
-                param_type: "string_list".to_string(),
-                required: false,
-            },
-            ToolParam {
-                name: "plan".to_string(),
-                description:
-                    "Optional task plan markdown. Leave blank for the executing agent to author."
-                        .to_string(),
-                param_type: "string".to_string(),
-                required: false,
-            },
             // ADR-0149: `workspace` is the binding key for ~/.orbit/tasks/workspaces/<id>/
             // home-store projection; defaulting to cwd would silently misroute tasks under
             // worktrees, subdirectories, or non-default `workspace_id` in .orbit/config.yaml.
@@ -66,17 +32,16 @@ impl Tool for OrbitTaskAddTool {
                 required: true,
             },
             ToolParam {
-                name: "comment".to_string(),
-                description: "Optional initial task comment".to_string(),
-                param_type: "string".to_string(),
+                name: "acceptance_criteria".to_string(),
+                description: "Optional acceptance criteria as a string or array of strings"
+                    .to_string(),
+                param_type: "string_list".to_string(),
                 required: false,
             },
             ToolParam {
-                name: "external_refs".to_string(),
-                description:
-                    "Optional external tracker refs as an array of {system, id, url?} objects"
-                        .to_string(),
-                param_type: "array".to_string(),
+                name: "tags".to_string(),
+                description: "Optional tags as a string or array of strings".to_string(),
+                param_type: "string_list".to_string(),
                 required: false,
             },
             ToolParam {
@@ -85,14 +50,6 @@ impl Tool for OrbitTaskAddTool {
                     "Optional task context selectors as a comma-separated string or array of strings. Add entries ONLY for existing files, directories, or symbols expected to be modified or deleted by the task. Do not add background-reading entries or files referenced only for context. Prefer canonical selectors: `file:`, `dir:`, or `symbol:path#name:kind`. Legacy raw paths are accepted and upgraded automatically."
                         .to_string(),
                 param_type: "string_list".to_string(),
-                required: false,
-            },
-            ToolParam {
-                name: "context".to_string(),
-                description:
-                    "Deprecated legacy alias for `context_files`. Prefer `context_files`. Add entries ONLY for existing files, directories, or symbols expected to be modified or deleted by the task. Do not add background-reading entries or files that are only relevant background context. Prefer canonical selectors: `file:`, `dir:`, or `symbol:path#name:kind`."
-                        .to_string(),
-                param_type: "string".to_string(),
                 required: false,
             },
             ToolParam {
@@ -114,28 +71,11 @@ impl Tool for OrbitTaskAddTool {
                 required: false,
             },
             ToolParam {
-                name: "status".to_string(),
-                description: "Optional initial task status".to_string(),
-                param_type: "string".to_string(),
-                required: false,
-            },
-            ToolParam {
-                name: "source_task_id".to_string(),
-                description: "For bug tasks: originating task ID that introduced the defect"
-                    .to_string(),
-                param_type: "string".to_string(),
-                required: false,
-            },
-            ToolParam {
-                name: "parent_id".to_string(),
-                description: "Optional parent task ID for a subtask relationship".to_string(),
-                param_type: "string".to_string(),
-                required: false,
-            },
-            ToolParam {
-                name: "crew".to_string(),
-                description: "Optional named crew to use when running this task".to_string(),
-                param_type: "string".to_string(),
+                name: "relations".to_string(),
+                description:
+                    "Optional typed task relations as an array of {type, target} objects"
+                        .to_string(),
+                param_type: "array".to_string(),
                 required: false,
             },
         ];
@@ -149,8 +89,21 @@ impl Tool for OrbitTaskAddTool {
         }
     }
 
-    fn execute(&self, ctx: &ToolContext, input: Value) -> Result<Value, OrbitError> {
+    fn execute(&self, ctx: &ToolContext, mut input: Value) -> Result<Value, OrbitError> {
         super::super::reject_agent_field(&input, "orbit.task.add")?;
+        required_string(&input, &["title"], "title")?;
+        required_string(&input, &["description"], "description")?;
+        required_string(&input, &["workspace"], "workspace")?;
+
+        let ignored_fields = strip_retired_task_add_input_fields(&mut input);
+        if !ignored_fields.is_empty() {
+            tracing::warn!(
+                target: "orbit.tools.task.add",
+                ignored_fields = ?ignored_fields,
+                "ignored retired orbit.task.add fields"
+            );
+        }
+
         super::super::execute_host_action(ctx, input, OrbitBuiltinAction::TaskAdd)
     }
 }

--- a/crates/orbit-tools/src/builtin/orbit/task/tests/add.rs
+++ b/crates/orbit-tools/src/builtin/orbit/task/tests/add.rs
@@ -1,17 +1,10 @@
-//! Schema exposure and round-trip call tests for the newly-surfaced fields on
-//! `orbit.task.add` (complexity enum, model, dependencies, relations, parent_id,
-//! source_task_id, tags, and strict context wording). Mirrors the style of
-//! sibling tests under `update/tests/`.
-//
-// Migrated from nested `task/add/tests/fields.rs` (anti-pattern)
-// to single sibling `task/tests/add.rs` per ORB-00248 and
-// docs/design-patterns/test_layout.md.
+//! Schema exposure and compatibility tests for `orbit.task.add`.
 
 use std::sync::{Arc, Mutex};
 
 use serde_json::{Value, json};
 
-use orbit_common::types::OrbitError;
+use orbit_common::types::{OrbitError, RETIRED_TASK_ADD_INPUT_FIELDS};
 
 use super::super::add::OrbitTaskAddTool;
 use crate::{OrbitBuiltinAction, OrbitTaskScope, OrbitToolHost, Tool, ToolContext};
@@ -63,28 +56,85 @@ fn mk_ctx(host: RecordingHost) -> ToolContext {
     }
 }
 
+fn capture_warnings<F, T>(f: F) -> (T, String)
+where
+    F: FnOnce() -> T,
+{
+    use std::io::{self, Write};
+    use tracing_subscriber::filter::LevelFilter;
+    use tracing_subscriber::fmt::MakeWriter;
+
+    #[derive(Clone)]
+    struct CaptureMakeWriter(Arc<Mutex<Vec<u8>>>);
+    struct CaptureWriter(Arc<Mutex<Vec<u8>>>);
+
+    impl<'a> MakeWriter<'a> for CaptureMakeWriter {
+        type Writer = CaptureWriter;
+
+        fn make_writer(&'a self) -> Self::Writer {
+            CaptureWriter(Arc::clone(&self.0))
+        }
+    }
+
+    impl Write for CaptureWriter {
+        fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+            self.0.lock().expect("capture lock").extend_from_slice(buf);
+            Ok(buf.len())
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
+
+    let buffer = Arc::new(Mutex::new(Vec::new()));
+    let subscriber = tracing_subscriber::fmt()
+        .with_writer(CaptureMakeWriter(Arc::clone(&buffer)))
+        .with_max_level(LevelFilter::WARN)
+        .with_target(true)
+        .with_ansi(false)
+        .without_time()
+        .finish();
+    let result = tracing::subscriber::with_default(subscriber, f);
+    let logs =
+        String::from_utf8(buffer.lock().expect("capture buffer lock").clone()).expect("utf8 logs");
+    (result, logs)
+}
+
 #[test]
-fn schema_exposes_create_task_documented_fields() {
+fn schema_exposes_only_trimmed_create_task_fields() {
     let schema = OrbitTaskAddTool.schema();
 
     let names: Vec<_> = schema.parameters.iter().map(|p| p.name.as_str()).collect();
-    for required in [
-        "title",
-        "description",
-        "workspace",
-        "complexity",
-        "model",
-        "dependencies",
-        "relations",
-        "parent_id",
-        "source_task_id",
-        "tags",
-        "context_files",
-        "context",
-    ] {
+    assert_eq!(
+        names,
+        vec![
+            "title",
+            "description",
+            "workspace",
+            "acceptance_criteria",
+            "tags",
+            "context_files",
+            "priority",
+            "complexity",
+            "type",
+            "relations",
+            "model",
+        ]
+    );
+
+    let required: Vec<_> = schema
+        .parameters
+        .iter()
+        .filter(|param| param.required)
+        .map(|param| param.name.as_str())
+        .collect();
+    assert_eq!(required, vec!["title", "description", "workspace"]);
+
+    for removed in RETIRED_TASK_ADD_INPUT_FIELDS {
         assert!(
-            names.contains(&required),
-            "orbit.task.add schema must expose {required}"
+            !names.contains(removed),
+            "orbit.task.add schema must not expose retired field {removed}"
         );
     }
 
@@ -97,91 +147,64 @@ fn schema_exposes_create_task_documented_fields() {
     assert!(!complexity.required);
     assert!(complexity.description.contains("low, medium, or hard"));
 
-    let model = schema
-        .parameters
-        .iter()
-        .find(|p| p.name == "model")
-        .expect("model param");
-    assert_eq!(model.param_type, "string");
-    assert!(!model.required);
-
-    let deps = schema
-        .parameters
-        .iter()
-        .find(|p| p.name == "dependencies")
-        .expect("dependencies");
-    assert_eq!(deps.param_type, "string_list");
-
-    let rels = schema
+    let relations = schema
         .parameters
         .iter()
         .find(|p| p.name == "relations")
         .expect("relations");
-    assert_eq!(rels.param_type, "array");
+    assert_eq!(relations.param_type, "array");
 
-    let tags = schema
+    let context_files = schema
         .parameters
         .iter()
-        .find(|p| p.name == "tags")
-        .expect("tags");
-    assert_eq!(tags.param_type, "string_list");
-
-    let parent = schema
-        .parameters
-        .iter()
-        .find(|p| p.name == "parent_id")
-        .expect("parent_id");
-    assert_eq!(parent.param_type, "string");
-
-    let source = schema
-        .parameters
-        .iter()
-        .find(|p| p.name == "source_task_id")
-        .expect("source_task_id");
-    assert_eq!(source.param_type, "string");
-
-    // context (the one whose description we rewrote) must use modify-or-delete wording
-    let ctx = schema
-        .parameters
-        .iter()
-        .find(|p| p.name == "context")
-        .expect("context legacy param");
-    assert!(
-        ctx.description.contains("modified or deleted")
-            && ctx.description.contains("background-reading"),
-        "context desc must use skill's modify-or-delete + disallow background: {}",
-        ctx.description
-    );
+        .find(|p| p.name == "context_files")
+        .expect("context_files");
+    assert_eq!(context_files.param_type, "string_list");
 }
 
 #[test]
-fn add_call_with_all_fields_roundtrips_to_host() {
+fn add_call_with_retired_fields_warns_once_and_ignores_them() {
     let host = RecordingHost::default();
     let ctx = mk_ctx(host.clone());
     let tool = OrbitTaskAddTool;
 
     let input = json!({
-        "title": "Expose fields test",
-        "description": "Round-trip coverage for ORB-00234",
+        "title": "Trimmed add fields test",
+        "description": "Compatibility coverage for ORB-00255",
         "workspace": "/tmp/test-ws",
-        "complexity": "medium",
-        "model": "grok",
-        "dependencies": ["ORB-00001"],
-        "relations": [{"type": "related_to", "target": "ORB-00002"}],
-        "parent_id": "ORB-00003",
-        "source_task_id": "ORB-00004",
+        "acceptance_criteria": ["MCP schema is trimmed", "retired fields are ignored"],
         "tags": ["mcp", "schema"],
         "context_files": ["file:crates/orbit-tools/src/builtin/orbit/task/add.rs"],
-        "context": "file:crates/orbit-tools/src/builtin/orbit/task/add/tests/fields.rs",
-        "acceptance_criteria": ["MCP schema has enums", "roundtrip reaches host"],
-        "plan": "",
         "priority": "medium",
+        "complexity": "medium",
         "type": "chore",
-        "status": "proposed"
+        "relations": [{"type": "related_to", "target": "ORB-00002"}],
+        "model": "grok",
+        "plan": "ignored plan",
+        "status": "done",
+        "crew": "ignored-crew",
+        "parent_id": "ORB-00003",
+        "source_task_id": "ORB-00004",
+        "external_refs": [{"system": "ENG", "id": "123"}],
+        "context": "file:legacy-alias.rs",
+        "comment": "ignored comment",
+        "dependencies": ["ORB-00001"]
     });
 
-    let res = tool.execute(&ctx, input.clone()).expect("execute succeeds");
+    let (res, logs) = capture_warnings(|| tool.execute(&ctx, input).expect("execute succeeds"));
     assert_eq!(res["id"], "ORB-TEST");
+    assert_eq!(
+        logs.matches("ignored retired orbit.task.add fields")
+            .count(),
+        1,
+        "compatibility warning must fire once per execute call: {logs}"
+    );
+    for removed in RETIRED_TASK_ADD_INPUT_FIELDS {
+        assert!(
+            logs.contains(*removed),
+            "compatibility warning must name retired field {removed}: {logs}"
+        );
+    }
 
     let recorded = host
         .call
@@ -190,27 +213,82 @@ fn add_call_with_all_fields_roundtrips_to_host() {
         .take()
         .expect("host was called");
     assert_eq!(recorded.action, OrbitBuiltinAction::TaskAdd);
+    assert_eq!(recorded.agent.as_deref(), None);
     assert_eq!(recorded.model.as_deref(), Some("grok"));
 
-    // All newly-exposed (and context alias) fields must be present in the payload
-    // that reaches the host (which ultimately writes the task YAML).
     let rec_input = recorded.input;
-    for key in [
-        "complexity",
-        "model",
-        "dependencies",
-        "relations",
-        "parent_id",
-        "source_task_id",
+    for removed in RETIRED_TASK_ADD_INPUT_FIELDS {
+        assert!(
+            rec_input.get(*removed).is_none(),
+            "retired field {removed} must be stripped before host execution"
+        );
+    }
+    for kept in [
+        "title",
+        "description",
+        "workspace",
+        "acceptance_criteria",
         "tags",
         "context_files",
-        "context",
+        "priority",
+        "complexity",
+        "type",
+        "relations",
+        "model",
     ] {
         assert!(
-            rec_input.get(key).is_some(),
-            "field {key} must survive the call to orbit.task.add and reach host for YAML persistence"
+            rec_input.get(kept).is_some(),
+            "kept field {kept} must survive host execution"
         );
     }
     assert_eq!(rec_input["complexity"], "medium");
-    assert_eq!(rec_input["parent_id"], "ORB-00003");
+    assert_eq!(
+        rec_input["context_files"][0],
+        "file:crates/orbit-tools/src/builtin/orbit/task/add.rs"
+    );
+}
+
+#[test]
+fn add_call_missing_required_fields_returns_required_field_error() {
+    let cases = [
+        (
+            "title",
+            json!({
+                "description": "missing title",
+                "workspace": "/tmp/test-ws"
+            }),
+        ),
+        (
+            "description",
+            json!({
+                "title": "missing description",
+                "workspace": "/tmp/test-ws"
+            }),
+        ),
+        (
+            "workspace",
+            json!({
+                "title": "missing workspace",
+                "description": "missing workspace"
+            }),
+        ),
+    ];
+
+    for (missing, input) in cases {
+        let host = RecordingHost::default();
+        let ctx = mk_ctx(host.clone());
+        let err = OrbitTaskAddTool
+            .execute(&ctx, input)
+            .expect_err("missing required field should fail");
+        match err {
+            OrbitError::InvalidInput(message) => {
+                assert_eq!(message, format!("missing `{missing}`"));
+            }
+            other => panic!("unexpected error for missing {missing}: {other}"),
+        }
+        assert!(
+            host.call.lock().expect("lock").is_none(),
+            "host must not be called when {missing} is missing"
+        );
+    }
 }

--- a/crates/orbit-tools/tests/public_tool_surface.rs
+++ b/crates/orbit-tools/tests/public_tool_surface.rs
@@ -4,6 +4,7 @@
 
 use std::collections::BTreeSet;
 
+use orbit_common::types::RETIRED_TASK_ADD_INPUT_FIELDS;
 use orbit_tools::ToolRegistry;
 
 #[test]
@@ -146,27 +147,63 @@ fn friction_surface_supports_artifact_triage() {
 }
 
 #[test]
-fn task_dependency_params_remain_in_agent_tool_schemas() {
+fn task_add_schema_uses_trimmed_authoring_surface() {
     let mut registry = ToolRegistry::new();
     registry.register_builtins();
 
-    for tool_name in ["orbit.task.add", "orbit.task.update"] {
-        let schema = registry
-            .get_schema(tool_name)
-            .unwrap_or_else(|| panic!("{tool_name} schema"));
-        let dependency_param = schema
-            .parameters
-            .iter()
-            .find(|param| param.name == "dependencies")
-            .unwrap_or_else(|| panic!("{tool_name} dependencies param"));
+    let schema = registry
+        .get_schema("orbit.task.add")
+        .expect("orbit.task.add schema");
+    let names = schema
+        .parameters
+        .iter()
+        .map(|param| param.name.as_str())
+        .collect::<Vec<_>>();
 
-        assert_eq!(dependency_param.param_type, "string_list");
-        assert!(!dependency_param.required);
+    assert_eq!(
+        names,
+        vec![
+            "title",
+            "description",
+            "workspace",
+            "acceptance_criteria",
+            "tags",
+            "context_files",
+            "priority",
+            "complexity",
+            "type",
+            "relations",
+            "model",
+        ]
+    );
+    for removed in RETIRED_TASK_ADD_INPUT_FIELDS {
         assert!(
-            schema.parameters.iter().any(|param| param.name == "crew"),
-            "{tool_name} should expose crew"
+            !names.contains(removed),
+            "orbit.task.add schema must not expose retired param {removed}"
         );
     }
+}
+
+#[test]
+fn task_update_dependency_params_remain_in_agent_tool_schema() {
+    let mut registry = ToolRegistry::new();
+    registry.register_builtins();
+
+    let schema = registry
+        .get_schema("orbit.task.update")
+        .expect("orbit.task.update schema");
+    let dependency_param = schema
+        .parameters
+        .iter()
+        .find(|param| param.name == "dependencies")
+        .expect("orbit.task.update dependencies param");
+
+    assert_eq!(dependency_param.param_type, "string_list");
+    assert!(!dependency_param.required);
+    assert!(
+        schema.parameters.iter().any(|param| param.name == "crew"),
+        "orbit.task.update should expose crew"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Task

[ORB-00255](https://orbit-cli.com/tasks/ORB-00255) — orbit.task.add: trim schema to 9 fields + model identity (drop 9 low-value params)

### Description

## Problem

`orbit.task.add` declares 19 parameters in [add.rs](crates/orbit-tools/src/builtin/orbit/task/add.rs) (counting the model_identity_params extension), only 3 of which are required. The schema is wide enough that low-value fields crowd out the Tier-1 signals (`complexity`, `acceptance_criteria`, `context_files`) that the orbit-create-task skill explicitly tells authors to set: across the 254 tasks in this workspace, `complexity` is populated on 45 of them (~18% — 24 hard, 12 medium, 9 low) while `acceptance_criteria` is populated on 253 (~99.6%). The AC gap is small; the complexity gap is large, and the skill-vs-reality delta is consistent with agents trimming fields that look optional when the schema is long.

Three of the removed top-level params (`dependencies`, `parent_id`, `source_task_id`) are structurally redundant: each is a projection over `relations` of a specific `TaskRelationType` (`BlockedBy`, `ChildOf`, `RegressionFrom` respectively — see [task.rs:671-681](crates/orbit-common/src/types/task.rs:671)). They're not storage — they're convenience accessors over the same underlying `relations` field, which **stays** on the schema. So removing them does not drop data-model capability; cross-task wiring continues to flow through `relations`.

The remaining six removed params (`plan`, `status`, `crew`, `external_refs`, `context`, `comment`) are deferrable to `orbit.task.update` (its CLI already exposes `--plan / --status / --crew / --ref / --context / --comment`), or — in the case of `context` — a legacy alias for `context_files` that should never have been a separate param.

## Why It Matters

Schema width is an agent UX problem, not a typing problem. Narrowing the surface raises the prominence of the Tier-1 fields and removes "two ways to say the same thing" — a class of confusion the schema currently invites through the four redundant projection aliases (`context`, `dependencies`, `parent_id`, `source_task_id`).

## Removed (9)

- `plan` — skill says "leave blank unless you have a compelling reason." Defer to `orbit.task.update --plan`.
- `status` — most tasks start `proposed`; the rare non-default-start case can use `orbit.task.update --status` immediately after add.
- `crew` — workspace/group decision typically applied at triage, not authoring. CLI exposes `--crew` on update.
- `parent_id` — projection over `relations[type=ChildOf]`. Same data, two surfaces. Use `relations`.
- `source_task_id` — projection over `relations[type=RegressionFrom]`. Same. Use `relations`. (This also closes the friction class behind [F2026-05-024](.orbit/frictions/F2026-05-024) — the field-silently-dropped-on-update problem — by removing the field entirely.)
- `external_refs` — usually attached after triage. Defer to update.
- `context` — legacy alias of `context_files`. Same data, redundant param.
- `comment` — initial-comment use case is niche and covered by `orbit.task.update --comment`.
- `dependencies` — projection over `relations[type=BlockedBy]`. Use `relations`.

## Kept (9 + model identity)

Required: `title`, `description`, `workspace`.
Optional (Tier-1 / authoring-time signals): `acceptance_criteria`, `tags`, `context_files`, `priority`, `complexity`, `type`, `relations`.
Plus whatever `model_identity_params()` adds (identity-aliases, typically auto-derived from execution context).

`relations` stays because the `resolves`-a-friction lifecycle side-effect (auto-close friction when task reaches `done`) is creation-time-relevant, and `relations` is the canonical home for what `parent_id` / `dependencies` / `source_task_id` were doing redundantly.

## Constraints / Notes

- Don't break in-flight scripted callers. The execute path should ignore the removed keys (with a one-line warn) rather than reject. After a cleanup window the warn can become a hard error, but that's a follow-up task, not this one.
- Out of scope: the CLI flag surface in orbit-cli. CLI flags map to JSON payload keys; some flags (`--dependencies`, `--parent`, `--source-task`) need a translation layer if they're kept (translate to `relations` entries before invoking the tool). Decision deferred — see AC #6.
- ADR consideration: the relations-as-canonical-cross-task-wiring decision is implicit in the current model but isn't called out in a dedicated ADR. If a reviewer flags it, write an ADR alongside this change to record "top-level redundant aliases removed in favor of typed relations." Otherwise, mention it in the PR description.
- After this lands, the orbit-create-task skill at ~/.claude/skills/orbit-create-task/SKILL.md needs updating: remove references to the deleted params and the `source_task_id` Tier-2 entry. Out of scope for this task — file a follow-up.

## Validation

`cargo test -p orbit-tools -p orbit-mcp` and `make ci-fast` are the gating checks. No new integration tests are needed; the existing public-tool-surface test at crates/orbit-tools/tests/public_tool_surface.rs is the canonical schema-shape guard.

### Acceptance Criteria

- After the change, the parameters vector built in OrbitTaskAddTool::schema in crates/orbit-tools/src/builtin/orbit/task/add.rs contains exactly these param names (in addition to whatever super::super::model_identity_params() extends): title (required), description (required), workspace (required), acceptance_criteria, tags, context_files, priority, complexity, type, relations. The removed nine params are absent: plan, status, crew, parent_id, source_task_id, external_refs, context, comment, dependencies.
- In crates/orbit-mcp/src/adapter/schema.rs enum_values_for, the ('orbit.task.add', 'status') match arm is removed; the ('orbit.task.add', 'type') and ('orbit.task.add', 'complexity') arms remain unchanged.
- The execute path (OrbitBuiltinAction::TaskAdd handler reachable from crates/orbit-tools/src/builtin/orbit/task/add.rs:154) ignores the nine removed keys when they appear in incoming JSON input rather than panicking or returning an error, so existing scripted callers don't break mid-flight. A tracing::warn! is emitted naming each ignored field; the warning fires at most once per execute call regardless of how many removed fields were present.
- Unit tests in crates/orbit-tools/src/builtin/orbit/task/tests/add.rs cover: (a) a schema-shape assertion that lists exactly the kept parameter names, (b) a positive test that an input containing all nine removed fields still produces a task (with the removed fields ignored and a warning emitted), (c) a negative test that an input missing one of the three required fields (title / description / workspace) returns the existing required-field error.
- The MCP-side schema test at crates/orbit-mcp/src/adapter/tests/schema.rs (the ORB-00234 schema-advertisement test referenced at line 305) is updated to reflect the trimmed parameter set; cargo test -p orbit-tools -p orbit-mcp passes locally.
- Out of scope for this task and explicitly documented in the PR description: the CLI flag surface in crates/orbit-cli (orbit task add --plan / --comment / --crew / --dependencies / --status / --parent / --source-task / --ref / --context). The CLI is a separate code path; if those flags are kept, they should translate their input into the tool's allowed shape (e.g., --dependencies and --parent translate to relations entries of BlockedBy / ChildOf at the CLI boundary before invoking the tool). Decision deferred to a follow-up task.
- make ci-fast passes.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Trimmed `orbit.task.add` schema to title, description, workspace, acceptance_criteria, tags, context_files, priority, complexity, type, relations, plus model identity.
- Removed MCP `orbit.task.add` status enum injection while preserving type and complexity enum mappings.
- Added shared retired-field stripping for the nine removed `orbit.task.add` inputs; the tool wrapper and runtime host ignore them and emit one warning naming all ignored fields per call.
- Updated orbit-tools, MCP schema, public surface, and runtime-host tests for the trimmed schema and compatibility behavior.

Assessment: Acceptance validation passed. `cargo test -p orbit-tools -p orbit-mcp`, `make ci-fast`, `cargo check -p orbit-core`, and targeted runtime task-tool tests passed.

Recommended follow-ups:
- Decide the deferred `orbit-cli` flag behavior for `orbit task add --plan/--comment/--crew/--dependencies/--status/--parent/--source-task/--ref/--context`; if kept, translate CLI-only aliases to the allowed tool shape at the CLI boundary.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-00255-6a0fca26`
- Behind base: 0
- Ahead of base: 1