### PR TITLE
Dashboard task tab: inline status + crew controls on row, drop priority/type columns

### DIFF
--- a/crates/orbit-dashboard/assets/dashboard/dashboard.css
+++ b/crates/orbit-dashboard/assets/dashboard/dashboard.css
@@ -322,7 +322,7 @@
       
       .row {
         display: grid;
-        grid-template-columns: minmax(80px, max-content) minmax(140px, 1fr) 72px 82px;
+        grid-template-columns: minmax(80px, max-content) minmax(140px, 1fr) minmax(108px, max-content) minmax(132px, max-content);
         gap: 12px;
         padding: 8px 16px;
         margin: 0;
@@ -362,14 +362,47 @@
         font-size: 13px;
         min-width: 0;
       }
-      .row .priority, .row .type { font-size: 12px; color: var(--fg-dim); text-align: right; }
+      .status-cell {
+        display: grid;
+        min-width: 0;
+      }
       .crew-cell {
         display: grid;
         gap: 4px;
         min-width: 0;
       }
+      .task-status-select {
+        width: 100%;
+        min-width: 104px;
+        max-width: 160px;
+        height: 28px;
+        border: 1px solid var(--border);
+        border-left-width: 2px;
+        border-radius: 2px;
+        background: var(--border);
+        font-size: 11px;
+        padding: 4px 24px 4px 8px;
+        outline: none;
+        overflow: hidden;
+        text-overflow: ellipsis;
+      }
+      .task-status-select:hover:not(:disabled),
+      .task-status-select:focus {
+        border-color: var(--accent);
+        border-left-color: currentColor;
+        outline: none;
+      }
+      .task-status-select:disabled {
+        color: var(--fg-dim);
+        opacity: 0.7;
+        cursor: not-allowed;
+      }
+      .task-status-select option {
+        color: var(--fg);
+        background: var(--bg);
+      }
       .task-crew-select {
-        width: auto;
+        width: 100%;
         min-width: 110px;
         max-width: 200px;
         height: 28px;
@@ -406,12 +439,6 @@
         white-space: nowrap;
       }
 
-      .assignment {
-        display: flex;
-        align-items: center;
-        gap: 8px;
-        min-width: 0;
-      }
       .detail-side .complexity {
         flex-shrink: 0;
         font-size: 12px;
@@ -419,23 +446,27 @@
 
       @media (max-width: 760px) {
         .row {
-          grid-template-columns: minmax(min-content, max-content) minmax(0, 1fr) auto auto;
+          grid-template-columns: minmax(min-content, max-content) minmax(0, 1fr) minmax(104px, max-content) minmax(120px, max-content);
           gap: 4px 8px;
         }
-        .row .priority { text-align: left; }
-        .row .type { text-align: left; }
         #task-filter { max-width: none; }
       }
 
       @media (max-width: 520px) {
         .row {
-          grid-template-columns: minmax(min-content, max-content) minmax(0, 1fr);
+          grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
           grid-template-areas:
             "id title"
-            "priority type";
+            "status crew";
         }
-        .row .priority { grid-area: priority; text-align: left; }
-        .row .type { grid-area: type; text-align: left; }
+        .row .id { grid-area: id; }
+        .row .title { grid-area: title; }
+        .row .status-cell { grid-area: status; }
+        .row .crew-cell { grid-area: crew; }
+        .task-status-select,
+        .task-crew-select {
+          max-width: none;
+        }
       }
 
       .row.header {
@@ -456,8 +487,8 @@
       }
       .row.header .id,
       .row.header .title,
-      .row.header .priority,
-      .row.header .type {
+      .row.header .status-cell,
+      .row.header .crew-cell {
         font-size: inherit;
         color: inherit;
         font-family: var(--font-sans);
@@ -854,23 +885,6 @@
         color: var(--fg); 
       }
 
-      .action.status-update {
-        border: 1px solid var(--accent);
-        color: var(--accent-hi);
-        background: var(--bg);
-        min-width: 128px;
-      }
-      .action.status-update:hover:not(:disabled),
-      .action.status-update:focus {
-        border-color: var(--accent-hover);
-        color: var(--fg);
-        outline: none;
-      }
-      .action.status-update option {
-        color: var(--fg);
-        background: var(--bg);
-      }
-      
       .action.cancel { 
         border: 1px solid transparent; 
         color: var(--fg-dim); 

--- a/crates/orbit-dashboard/assets/dashboard/tasks.js
+++ b/crates/orbit-dashboard/assets/dashboard/tasks.js
@@ -1,7 +1,7 @@
 // Orbit dashboard task-domain rendering and actions.
 // Pure vanilla JS, split into ES modules with no build step.
 
-import { el, priorityCell, statusPill, patchJson, syncNodes } from './common.js';
+import { el, statusPill, patchJson, syncNodes } from './common.js';
 
 const $ = (id) => document.getElementById(id);
 
@@ -111,8 +111,18 @@ function crewOptionTitle(crew) {
 }
 
 function applyUpdatedTask(updatedTask, context) {
+  if (!updatedTask || !updatedTask.id) return;
   if (context && typeof context.replaceTask === "function") {
     context.replaceTask(updatedTask);
+  }
+  if (pinnedExternalTask && pinnedExternalTask.task && pinnedExternalTask.task.id === updatedTask.id) {
+    pinnedExternalTask.task = updatedTask;
+  }
+}
+
+function stopRowInteraction(node) {
+  for (const eventName of ["pointerdown", "mousedown", "click", "keydown"]) {
+    node.addEventListener(eventName, (event) => event.stopPropagation());
   }
 }
 
@@ -505,9 +515,7 @@ function buildTaskDetail(task, context) {
     rightCol.appendChild(buildTagRow(task.tags));
   }
 
-  // Details before Assignment (per task: read-only meta first, mutating control second).
-  // Assignment contains *only* the crew dropdown (complexityCell removed; it lives in
-  // TASK_META_FIELDS inside Details).
+  // Routine status/crew controls live inline on the task row; details remain read-only.
   const meta = el("div", { class: "meta-list" });
   let metaCount = 0;
   for (const [key, label] of TASK_META_FIELDS) {
@@ -530,10 +538,6 @@ function buildTaskDetail(task, context) {
     metaCount++;
   }
   if (metaCount > 0) addField(rightCol, "details", meta);
-
-  const assignment = el("div", { class: "assignment" });
-  assignment.appendChild(buildCrewUpdateControl(task, context));
-  addField(rightCol, "assignment", assignment);
 
   if (Array.isArray(task.external_refs) && task.external_refs.length > 0) {
     addField(rightCol, "external refs", buildExternalRefs(task.external_refs));
@@ -618,23 +622,26 @@ function buildActionsRow(task, detail, context) {
     });
     actions.appendChild(btn);
   }
-  const statusSelect = buildStatusUpdateControl(task, detail, context);
-  if (statusSelect) actions.appendChild(statusSelect);
   return actions;
 }
 
-function buildStatusUpdateControl(task, detail, context) {
+function buildStatusUpdateControl(task, context) {
+  const cell = el("span", { class: "status-cell" });
   const targets = statusUpdateTargets(context).filter((status) => status !== task.status);
-  if (targets.length === 0) return null;
-
+  const color = `var(--status-${task.status}, var(--fg))`;
   const select = el("select", {
-    class: "action status-update",
+    class: "task-status-select mono",
     title: `Update status for ${task.id}`,
+    style: {
+      color,
+      borderLeftColor: color,
+    },
   });
-  const placeholder = el("option", { text: "set status" });
+  const placeholder = el("option", { text: task.status || "status" });
   placeholder.value = "";
   placeholder.disabled = true;
   placeholder.selected = true;
+  placeholder.hidden = true;
   select.appendChild(placeholder);
 
   for (const status of targets) {
@@ -643,32 +650,20 @@ function buildStatusUpdateControl(task, detail, context) {
     select.appendChild(option);
   }
 
-  select.addEventListener("click", (e) => e.stopPropagation());
-  select.addEventListener("change", (e) => {
-    e.stopPropagation();
+  if (targets.length === 0) {
+    select.disabled = true;
+  }
+
+  stopRowInteraction(cell);
+  stopRowInteraction(select);
+  select.addEventListener("change", (event) => {
+    event.stopPropagation();
     const targetStatus = select.value;
     if (!targetStatus) return;
-    runAction(
-      task,
-      "status",
-      detail,
-      { status: targetStatus },
-      select,
-      context,
-      {
-        method: "PATCH",
-        path: `/api/tasks/${encodeURIComponent(task.id)}`,
-        collapseOnSuccess: targetStatus === "done",
-        successNotice: targetStatus === "done"
-          ? `Task ${task.id} marked done; it is no longer shown in the default dashboard list.`
-          : null,
-        onFailure: () => {
-          select.value = "";
-        },
-      },
-    );
+    updateTaskStatus(task, select, context);
   });
-  return select;
+  cell.appendChild(select);
+  return cell;
 }
 
 function buildCrewUpdateControl(task, context) {
@@ -711,9 +706,8 @@ function buildCrewUpdateControl(task, context) {
   }
 
   select.value = currentValue;
-  for (const eventName of ["pointerdown", "mousedown", "click", "keydown"]) {
-    select.addEventListener(eventName, (event) => event.stopPropagation());
-  }
+  stopRowInteraction(cell);
+  stopRowInteraction(select);
   select.addEventListener("change", (event) => {
     event.stopPropagation();
     updateTaskCrew(task, select, context);
@@ -725,6 +719,24 @@ function buildCrewUpdateControl(task, context) {
     cell.appendChild(el("span", { class: "crew-error", text: error }));
   }
   return cell;
+}
+
+async function updateTaskStatus(task, select, context) {
+  const nextStatus = select.value || "";
+  if (!nextStatus || nextStatus === task.status) return;
+
+  select.disabled = true;
+  try {
+    const updatedTask = await patchJson(`/api/tasks/${encodeURIComponent(task.id)}`, {
+      status: nextStatus,
+    });
+    applyUpdatedTask(updatedTask, context);
+    renderTasks(taskList(context), context);
+  } catch (error) {
+    select.value = "";
+    select.disabled = false;
+    console.error(error);
+  }
 }
 
 async function updateTaskCrew(task, select, context) {
@@ -859,12 +871,14 @@ export function renderTasks(tasks, context) {
     }, [
       el("span", { class: "id mono", text: ptask.id }),
       el("span", { class: "title", text: ptask.title }),
-      statusPill(ptask.status),
+      buildStatusUpdateControl(ptask, context),
+      buildCrewUpdateControl(ptask, context),
     ]);
     pRow.addEventListener("click", (e) => {
       e.stopPropagation();
       if (navigator.clipboard) navigator.clipboard.writeText(ptask.id).catch(() => {});
     });
+    pRow.dataset.hash = `${ptask.id}-${ptask.title}-${ptask.status}-${ptask.crew || ""}-${ptask.resolved_crew || ""}-${crewOptionsSignature()}-${crewUpdateErrors.get(ptask.id) || ""}`;
     const pDetail = buildTaskDetail(ptask, context);
     // Dismiss button to close the global detail without affecting chips
     const dismiss = el("button", { class: "action", text: "Close" });
@@ -882,6 +896,7 @@ export function renderTasks(tasks, context) {
     acts.appendChild(dismiss);
     const pWrap = el("div", { class: "pinned-task-wrap" }, [pRow, pDetail]);
     pWrap.dataset.key = `pinned-${ptask.id}`;
+    pWrap.dataset.hash = `${pRow.dataset.hash}-${JSON.stringify(ptask)}`;
     frag.appendChild(pWrap);
   }
 
@@ -903,12 +918,12 @@ export function renderTasks(tasks, context) {
   if (notice) frag.appendChild(notice);
 
   // Column header strip (once, before first group-header). Uses .row.header so grid
-  // (and all @media overrides) are identical to data rows; labels sit over ID/Title/Priority/Type.
+  // (and all @media overrides) are identical to data rows; labels sit over ID/Title/Status/Crew.
   const colHeader = el("div", { class: "row header" }, [
     el("span", { class: "id", text: "ID" }),
     el("span", { class: "title", text: "Title" }),
-    el("span", { class: "priority", text: "Priority" }),
-    el("span", { class: "type", text: "Type" }),
+    el("span", { class: "status-cell", text: "Status" }),
+    el("span", { class: "crew-cell", text: "Crew" }),
   ]);
   colHeader.dataset.key = "task-col-header";
   frag.appendChild(colHeader);
@@ -946,12 +961,12 @@ export function renderTasks(tasks, context) {
       const row = el("div", { class: "row", title: t.title }, [
         idSpan,
         el("span", { class: "title", text: t.title }),
-        priorityCell(t.priority),
-        el("span", { class: "type mono", text: t.type }),
+        buildStatusUpdateControl(t, context),
+        buildCrewUpdateControl(t, context),
       ]);
       row.dataset.key = `task-${t.id}`;
       // Basic hash based on row presentation parameters + expanded state
-      row.dataset.hash = `${t.id}-${t.title}-${t.priority}-${t.type}-${t.complexity || ""}-${t.crew || ""}-${t.resolved_crew || ""}-${crewOptionsSignature()}-${crewUpdateErrors.get(t.id) || ""}-${expandedTaskIds.has(t.id)}`;
+      row.dataset.hash = `${t.id}-${t.title}-${t.status}-${t.crew || ""}-${t.resolved_crew || ""}-${crewOptionsSignature()}-${crewUpdateErrors.get(t.id) || ""}-${expandedTaskIds.has(t.id)}`;
       row.addEventListener("click", () => {
         const toggle = () => {
           if (expandedTaskIds.has(t.id)) expandedTaskIds.delete(t.id);
@@ -980,4 +995,3 @@ export function renderTasks(tasks, context) {
   }
   syncNodes(body, Array.from(frag.children));
 }
-


### PR DESCRIPTION
## Task

[ORB-00253](https://orbit-cli.com/tasks/ORB-00253) — Dashboard task tab: inline status + crew controls on row, drop priority/type columns

### Description

## Problem

The task tab in the web dashboard requires expanding each row (`buildTaskDetail` in [tasks.js](crates/orbit-dashboard/assets/dashboard/tasks.js)) to change status or reassign crew. The expanded `.row-detail.split-layout` is tall (description + AC + plan + meta + actions row at the bottom), so updating several tasks in a row means click → wait for expand → scroll down to the `set status` `<select>` (built by `buildStatusUpdateControl`) → pick → row collapses → scroll back to where you were → find next task. The status pill on the row is decorative-only today; the crew dropdown lives in the expanded `.assignment` field-block at the bottom of the right column. Priority and type columns occupy two of the four `.row` grid cells (`grid-template-columns: minmax(80px, max-content) minmax(140px, 1fr) 72px 82px` in [dashboard.css:325](crates/orbit-dashboard/assets/dashboard/dashboard.css:325)) but are read-only labels that rarely drive the next action.

## Why It Matters

The dominant verbs on the task tab are "change a task's status" (approve / reject / move-to-done) and "reassign crew." Both are buried behind an expansion that scrolls the rest of the list out of view. The CLI is currently a better triage surface than the dashboard for this workflow, which works against using the dashboard as the primary surface humans drive Orbit from.

## Constraints / Notes

- **Complexity (recommended): `medium`.** Single-crate frontend work (tasks.js + dashboard.css), no cross-crate edges, but real moving parts: interactive status menu, crew dropdown relocation, `row.dataset.hash` reshape, expanded-detail dedup, two `@media` breakpoints to update. Not stored as a structured field on the task because the MCP `orbit_task_add` schema does not expose `complexity` and `orbit.task.update` silently drops it on existing tasks — see "Tooling gap" below.
- Reuse the existing `PATCH /api/tasks/{id}` contract already used by `buildStatusUpdateControl` and `buildCrewUpdateControl` — no new HTTP routes, no audit-semantics changes.
- Keep row expansion for reading task detail (description, AC, plan, history, comments, artifacts). Only the routine *update* controls move inline.
- The narrow-viewport `@media` rules in [dashboard.css:420-439](crates/orbit-dashboard/assets/dashboard/dashboard.css:420) move `.priority` / `.type` to a stacked second grid row at the 520px breakpoint; the replacement Status + Crew cells must degrade equivalently.
- `crewUpdateErrors` (Map keyed by task ID, see [tasks.js:723](crates/orbit-dashboard/assets/dashboard/tasks.js:723)) currently surfaces inside the expanded `.assignment` block; it must surface beside the inline control instead so errors are visible without expanding.
- Status pill colors come from `--status-{name}` tokens via `statusPill` in `common.js`; the new interactive pill must retain that color affordance.
- `row.dataset.hash` in `renderTasks` ([tasks.js:954](crates/orbit-dashboard/assets/dashboard/tasks.js:954)) is consumed by `syncNodes` for diff-based DOM updates — its composition must change to match the new row contents (drop `priority` / `type`, add `status` since inline updates may not move the task between groups).
- Don't ship duplicate control surfaces: when an inline status/crew control exists on the row, remove the corresponding controls from the expanded `actions` row (`buildStatusUpdateControl` call site) and `.assignment` field-block (`buildCrewUpdateControl` call site in `buildTaskDetail`). The approve / reject / archive buttons in the expanded actions row stay — they're per-task judgments that benefit from being on the detail screen.
- Group headers stay; an inline status change moves the task to a different group on the next render via the existing grouping logic in `renderTasks`.

## Open question (planner decides)

Should the row also surface hover-only ✓ approve / ✕ reject micro-buttons for `proposed` / `review` rows? Originally proposed alongside the inline status control; not required to fix the core scroll-loop friction. Recommendation: defer to a follow-up task once the inline status menu lands and proves the pattern.

## Tooling gap (context for future task authors)

The MCP `orbit_task_add` parameter schema does not list `complexity` even though `orbit task add --complexity` works on the CLI. `orbit.task.update` (both MCP and CLI) has no complexity-setting surface and silently drops the field when present in JSON input. Net effect: tasks authored through the MCP path uniformly end up with `complexity: None` (252 of 252 existing tasks at the time this task was written). Until that's fixed, complexity recommendations sit in the description body rather than the structured field.

### Acceptance Criteria

- The `.row` grid in `dashboard.css` is `ID | Title | Status | Crew`. The `.priority` and `.type` cells are removed from the `.row.header` and all `.row` instances rendered by `renderTasks` in `tasks.js`; `grid-template-columns` and the `@media (max-width: 760px)` / `@media (max-width: 520px)` overrides are updated to match the new four-cell layout with no orphaned `.priority` / `.type` selectors.
- Clicking the status cell on a row opens a status-transition control (floating menu or compact select) listing `context.statusUpdateTargets` minus the row's current `task.status`. The click does not trigger row expansion (pointerdown/mousedown/click/keydown stopPropagation). Selecting a target fires `PATCH /api/tasks/{id}` with `{status: <target>}` through the same code path as the existing `buildStatusUpdateControl` flow, updates the row via `context.replaceTask` followed by `renderTasks`, and preserves the task's expanded/collapsed state across the update.
- The crew dropdown produced today by `buildCrewUpdateControl` renders inline in the row's Crew cell with the same option set (resolved-default + `lastCrewPayload.crews` + a `crew unavailable` disabled state when crews are empty). Selecting a crew fires the existing `updateTaskCrew` PATCH; pointerdown/mousedown/click/keydown continue to stopPropagation. Failure messages from `crewUpdateErrors.get(task.id)` render next to the inline control (visible without expanding the row).
- Inline updates do not double-render: the duplicate status `<select>` built by `buildStatusUpdateControl` is removed from `buildActionsRow`, and the crew dropdown call inside the expanded `.assignment` field-block is removed from `buildTaskDetail`. The expanded approve / reject / archive buttons in `buildActionsRow` are retained.
- `row.dataset.hash` composition in `renderTasks` is updated: drops `priority` and `type`, keeps `expandedTaskIds.has(t.id)`, `crew`, `resolved_crew`, `crewUpdateErrors.get(t.id)`, `crewOptionsSignature()`, and adds the row's current `status` so the `syncNodes` diff catches inline status changes that do not re-group the task.
- Manual verification: `make ci-fast` passes; launching the dashboard locally (e.g. `orbit dashboard` or the equivalent dev path) shows the task tab with the new four-column row layout; a task can be moved from one status to another and reassigned to a non-default crew without expanding the row, with no console errors and no surrounding-list scroll movement.
- Narrow-viewport check: at 760px and 520px viewport widths, the inline Status and Crew controls remain reachable — either inline at 760px or stacked into a second grid row at 520px analogous to today's priority/type stacking — with no clipping of the crew dropdown's option list and no horizontal overflow on `.row`.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Replaced task row Priority/Type cells with inline Status and Crew controls in the ID | Title | Status | Crew layout.
- Moved status updates onto the row via the existing status-control helper, PATCHing `/api/tasks/{id}` with `{status}` and rerendering through `context.replaceTask` without collapsing expanded rows.
- Moved the existing crew dropdown inline, preserved its option/error behavior, and removed duplicate expanded-detail status/crew controls.
- Updated row diff hashing and responsive CSS so status/crew changes are detected and the controls remain reachable at 760px and 520px.

Assessment: `make ci-fast` passes. A local dashboard asset harness in headless Chrome verified inline status and crew PATCHes, row propagation blocking, preserved expansion, no scroll movement for crew reassignment, no console errors, and no row/horizontal overflow at 760px or 520px.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-00253-6a0fcbab`
- Behind base: 0
- Ahead of base: 1