### PR TITLE
Rename default crews in default-config.toml to family names; drop opus-codex/silver/bronze

### DIFF
--- a/crates/orbit-common/src/types/tests/agent_pair.rs
+++ b/crates/orbit-common/src/types/tests/agent_pair.rs
@@ -15,18 +15,18 @@ mod resolution {
     fn registry() -> BTreeMap<String, Crew> {
         let mut registry = BTreeMap::new();
         registry.insert(
-            "opus-codex".to_string(),
+            "codex".to_string(),
             Crew {
-                name: "opus-codex".to_string(),
-                planner: assignment("claude-opus-4-7", "claude"),
+                name: "codex".to_string(),
+                planner: assignment("gpt-5.5", "codex"),
                 implementer: assignment("gpt-5.5", "codex"),
-                reviewer: assignment("claude-opus-4-7", "claude"),
+                reviewer: assignment("gpt-5.5", "codex"),
             },
         );
         registry.insert(
-            "all-claude".to_string(),
+            "claude".to_string(),
             Crew {
-                name: "all-claude".to_string(),
+                name: "claude".to_string(),
                 planner: assignment("claude-opus-4-7", "claude"),
                 implementer: assignment("claude-sonnet-4-6", "claude"),
                 reviewer: assignment("claude-opus-4-7", "claude"),
@@ -37,10 +37,10 @@ mod resolution {
 
     #[test]
     fn resolve_crew_returns_assignments_for_known_name() {
-        let crew = resolve_crew("opus-codex", &registry()).expect("crew resolves");
+        let crew = resolve_crew("codex", &registry()).expect("crew resolves");
 
-        assert_eq!(crew.name, "opus-codex");
-        assert_eq!(crew.planner.model, "claude-opus-4-7");
+        assert_eq!(crew.name, "codex");
+        assert_eq!(crew.planner.model, "gpt-5.5");
         assert_eq!(crew.implementer.provider, "codex");
         assert_eq!(crew.reviewer.backend, "cli");
     }
@@ -51,7 +51,7 @@ mod resolution {
 
         match error {
             OrbitError::InvalidInputDiagnostic { did_you_mean, .. } => {
-                assert_eq!(did_you_mean, vec!["all-claude", "opus-codex"]);
+                assert_eq!(did_you_mean, vec!["claude", "codex"]);
             }
             other => panic!("expected InvalidInputDiagnostic, got {other:?}"),
         }

--- a/crates/orbit-common/src/types/tests/task.rs
+++ b/crates/orbit-common/src/types/tests/task.rs
@@ -188,7 +188,7 @@ context_files: []
 status: backlog
 priority: medium
 task_type: chore
-crew: opus-codex
+crew: codex
 created_at: 2026-01-01T00:00:00Z
 updated_at: 2026-01-01T00:00:00Z
 "#,
@@ -199,7 +199,7 @@ updated_at: 2026-01-01T00:00:00Z
         let reparsed = serde_yaml::from_str::<Task>(&serialized).expect("reparse task");
 
         assert_eq!(reparsed, task);
-        assert_eq!(reparsed.crew.as_deref(), Some("opus-codex"));
+        assert_eq!(reparsed.crew.as_deref(), Some("codex"));
     }
 
     #[test]

--- a/crates/orbit-core/assets/config/default-config.toml
+++ b/crates/orbit-core/assets/config/default-config.toml
@@ -33,39 +33,24 @@ editing = false
 # `agent-main` is the dev integration branch where task PRs land — set
 # `base_branch = "agent-main"` for the same layout in your own repo.
 base_branch = "main"
-default_crew = "opus-codex"
+default_crew = "codex"
 
-[crews.opus-codex]
-planner = { model = "claude-opus-4-7", provider = "claude", backend = "cli" }
-implementer = { model = "gpt-5.5", provider = "codex", backend = "cli" }
-reviewer = { model = "claude-opus-4-7", provider = "claude", backend = "cli" }
-
-[crews.silver]
-planner = { model = "pro", provider = "gemini", backend = "cli" }
-implementer = { model = "grok-build", provider = "grok", backend = "cli" }
-reviewer = { model = "pro", provider = "gemini", backend = "cli" }
-
-[crews.bronze]
-planner = { model = "sonnet", provider = "claude", backend = "cli" }
-implementer = { model = "sonnet", provider = "claude", backend = "cli" }
-reviewer = { model = "sonnet", provider = "claude", backend = "cli" }
-
-[crews.all-claude]
+[crews.claude]
 planner = { model = "claude-opus-4-7", provider = "claude", backend = "cli" }
 implementer = { model = "claude-opus-4-7", provider = "claude", backend = "cli" }
 reviewer = { model = "claude-opus-4-7", provider = "claude", backend = "cli" }
 
-[crews.all-codex]
+[crews.codex]
 planner = { model = "gpt-5.5", provider = "codex", backend = "cli" }
 implementer = { model = "gpt-5.5", provider = "codex", backend = "cli" }
 reviewer = { model = "gpt-5.5", provider = "codex", backend = "cli" }
 
-[crews.all-gemini]
+[crews.gemini]
 planner = { model = "pro", provider = "gemini", backend = "cli" }
 implementer = { model = "pro", provider = "gemini", backend = "cli" }
 reviewer = { model = "pro", provider = "gemini", backend = "cli" }
 
-[crews.all-grok]
+[crews.grok]
 planner = { model = "grok-build", provider = "grok", backend = "cli" }
 implementer = { model = "grok-build", provider = "grok", backend = "cli" }
 reviewer = { model = "grok-build", provider = "grok", backend = "cli" }

--- a/crates/orbit-core/src/command/init.rs
+++ b/crates/orbit-core/src/command/init.rs
@@ -881,9 +881,11 @@ mod tests {
                 "unexpected uncommented agent section: {line}",
             );
         }
-        assert!(contents.contains("[crews.opus-codex]"));
-        assert!(contents.contains("[crews.all-claude]"));
-        assert!(contents.contains("default_crew = \"opus-codex\""));
+        assert!(contents.contains("[crews.claude]"));
+        assert!(contents.contains("[crews.codex]"));
+        assert!(contents.contains("[crews.gemini]"));
+        assert!(contents.contains("[crews.grok]"));
+        assert!(contents.contains("default_crew = \"codex\""));
     }
 
     fn assert_skill_link_exists(path: PathBuf) {

--- a/crates/orbit-core/src/config/bootstrap.rs
+++ b/crates/orbit-core/src/config/bootstrap.rs
@@ -48,7 +48,7 @@ fn render_with_role_settings(
     );
     let custom_crew = toml::to_string(&CrewConfig { crews })
         .map_err(|err| OrbitError::Io(format!("serialize [crews.<name>] sections: {err}")))?;
-    let mut body = template.replace("default_crew = \"opus-codex\"", "default_crew = \"custom\"");
+    let mut body = template.replace("default_crew = \"codex\"", "default_crew = \"custom\"");
     if !body.ends_with('\n') {
         body.push('\n');
     }

--- a/crates/orbit-core/src/config/runtime.rs
+++ b/crates/orbit-core/src/config/runtime.rs
@@ -25,6 +25,7 @@ const DEFAULT_TASK_APPROVAL_DELEGATE_APPROVAL: bool = false;
 const DEFAULT_SCORING_ENABLED: bool = true;
 const DEFAULT_GRAPH_EDITING: bool = false;
 const DEFAULT_WORKFLOW_BASE_BRANCH: &str = "main";
+const DEFAULT_WORKFLOW_CREW: &str = "codex";
 
 #[derive(Debug, Clone)]
 pub(crate) struct RuntimeConfig {
@@ -86,7 +87,7 @@ impl RuntimeConfig {
             v2_backend: None,
             workflow_base_branch: DEFAULT_WORKFLOW_BASE_BRANCH.to_string(),
             crews: default_crews(),
-            default_crew: Some("opus-codex".to_string()),
+            default_crew: Some(DEFAULT_WORKFLOW_CREW.to_string()),
             duel: DuelConfig::default(),
         }
     }
@@ -217,21 +218,39 @@ impl RuntimeConfig {
 pub(crate) fn default_crews() -> BTreeMap<String, Crew> {
     let mut crews = BTreeMap::new();
     crews.insert(
-        "opus-codex".to_string(),
+        "claude".to_string(),
         Crew {
-            name: "opus-codex".to_string(),
+            name: "claude".to_string(),
             planner: crew_role("claude-opus-4-7", "claude", "cli"),
+            implementer: crew_role("claude-opus-4-7", "claude", "cli"),
+            reviewer: crew_role("claude-opus-4-7", "claude", "cli"),
+        },
+    );
+    crews.insert(
+        "codex".to_string(),
+        Crew {
+            name: "codex".to_string(),
+            planner: crew_role("gpt-5.5", "codex", "cli"),
             implementer: crew_role("gpt-5.5", "codex", "cli"),
             reviewer: crew_role("gpt-5.5", "codex", "cli"),
         },
     );
     crews.insert(
-        "all-claude".to_string(),
+        "gemini".to_string(),
         Crew {
-            name: "all-claude".to_string(),
-            planner: crew_role("claude-opus-4-7", "claude", "cli"),
-            implementer: crew_role("claude-sonnet-4-6", "claude", "cli"),
-            reviewer: crew_role("claude-opus-4-7", "claude", "cli"),
+            name: "gemini".to_string(),
+            planner: crew_role("pro", "gemini", "cli"),
+            implementer: crew_role("pro", "gemini", "cli"),
+            reviewer: crew_role("pro", "gemini", "cli"),
+        },
+    );
+    crews.insert(
+        "grok".to_string(),
+        Crew {
+            name: "grok".to_string(),
+            planner: crew_role("grok-build", "grok", "cli"),
+            implementer: crew_role("grok-build", "grok", "cli"),
+            reviewer: crew_role("grok-build", "grok", "cli"),
         },
     );
     crews
@@ -411,7 +430,7 @@ fn required_role_field(
     })
 }
 
-fn workflow_default_crew_from_raw(
+pub(super) fn workflow_default_crew_from_raw(
     raw: Option<&RawWorkflowConfig>,
     crews: &BTreeMap<String, Crew>,
 ) -> Result<Option<String>, OrbitError> {
@@ -421,8 +440,8 @@ fn workflow_default_crew_from_raw(
         // when its crew is still present; otherwise demand the user pick one
         // explicitly so downstream `start`/`show` calls don't surprise them
         // with a generic "no crew selected" error.
-        if crews.contains_key("opus-codex") {
-            return Ok(Some("opus-codex".to_string()));
+        if crews.contains_key(DEFAULT_WORKFLOW_CREW) {
+            return Ok(Some(DEFAULT_WORKFLOW_CREW.to_string()));
         }
         if crews.is_empty() {
             return Ok(None);

--- a/crates/orbit-core/src/config/tests/bootstrap.rs
+++ b/crates/orbit-core/src/config/tests/bootstrap.rs
@@ -41,9 +41,11 @@ fn seed_with_no_role_settings_matches_template() {
     let contents = std::fs::read_to_string(&path).expect("read");
     assert_eq!(contents, DEFAULT_CONFIG_TEMPLATE);
     assert!(no_active_role_section(&contents));
-    assert!(contents.contains("[crews.opus-codex]"));
-    assert!(contents.contains("[crews.all-claude]"));
-    assert!(contents.contains("default_crew = \"opus-codex\""));
+    assert!(contents.contains("[crews.claude]"));
+    assert!(contents.contains("[crews.codex]"));
+    assert!(contents.contains("[crews.gemini]"));
+    assert!(contents.contains("[crews.grok]"));
+    assert!(contents.contains("default_crew = \"codex\""));
 }
 
 fn no_active_role_section(contents: &str) -> bool {

--- a/crates/orbit-core/src/config/tests/runtime.rs
+++ b/crates/orbit-core/src/config/tests/runtime.rs
@@ -247,24 +247,24 @@ fn crews_load_when_present_and_well_formed() {
     write_config(
         workspace.path(),
         r#"
-[crews.opus-codex]
-planner = { model = "claude-opus-4-7", provider = "claude", backend = "cli" }
+[crews.codex]
+planner = { model = "gpt-5.5", provider = "codex", backend = "cli" }
 implementer = { model = "gpt-5.5", provider = "codex", backend = "cli" }
 reviewer = { model = "gpt-5.5", provider = "codex", backend = "cli" }
 
 [workflow]
-default_crew = "opus-codex"
+default_crew = "codex"
 "#,
     );
 
     let config =
         RuntimeConfig::load_layered(global.path(), workspace.path()).expect("config loads");
 
-    assert_eq!(config.default_crew.as_deref(), Some("opus-codex"));
+    assert_eq!(config.default_crew.as_deref(), Some("codex"));
     assert_eq!(
         config
             .crews
-            .get("opus-codex")
+            .get("codex")
             .expect("crew exists")
             .implementer
             .model,
@@ -279,8 +279,8 @@ fn default_crew_must_reference_defined_crew() {
     write_config(
         workspace.path(),
         r#"
-[crews.opus-codex]
-planner = { model = "claude-opus-4-7", provider = "claude", backend = "cli" }
+[crews.codex]
+planner = { model = "gpt-5.5", provider = "codex", backend = "cli" }
 implementer = { model = "gpt-5.5", provider = "codex", backend = "cli" }
 reviewer = { model = "gpt-5.5", provider = "codex", backend = "cli" }
 
@@ -293,14 +293,14 @@ default_crew = "missing"
         .expect_err("unknown default crew fails");
 
     assert!(matches!(error, OrbitError::InvalidInputDiagnostic { .. }));
-    assert_eq!(error.did_you_mean(), Some(&["opus-codex".to_string()][..]));
+    assert_eq!(error.did_you_mean(), Some(&["codex".to_string()][..]));
 }
 
 #[test]
 fn default_crew_unset_with_custom_crews_fails_load() {
     let global = tempdir().expect("global tempdir");
     let workspace = tempdir().expect("workspace tempdir");
-    // Only a non-"opus-codex" crew defined; no [workflow] table at all.
+    // Only a non-seeded crew defined; no [workflow] table at all.
     write_config(
         workspace.path(),
         r#"
@@ -324,12 +324,12 @@ reviewer = { model = "gpt-5.5", provider = "codex", backend = "cli" }
 fn default_crew_unset_with_seeded_crew_still_loads() {
     let global = tempdir().expect("global tempdir");
     let workspace = tempdir().expect("workspace tempdir");
-    // opus-codex is still present, so the historical fallback applies.
+    // The seeded codex crew is present, so the default-crew fallback applies.
     write_config(
         workspace.path(),
         r#"
-[crews.opus-codex]
-planner = { model = "claude-opus-4-7", provider = "claude", backend = "cli" }
+[crews.codex]
+planner = { model = "gpt-5.5", provider = "codex", backend = "cli" }
 implementer = { model = "gpt-5.5", provider = "codex", backend = "cli" }
 reviewer = { model = "gpt-5.5", provider = "codex", backend = "cli" }
 "#,
@@ -337,7 +337,17 @@ reviewer = { model = "gpt-5.5", provider = "codex", backend = "cli" }
 
     let config =
         RuntimeConfig::load_layered(global.path(), workspace.path()).expect("config loads");
-    assert_eq!(config.default_crew.as_deref(), Some("opus-codex"));
+    assert_eq!(config.default_crew.as_deref(), Some("codex"));
+}
+
+#[test]
+fn workflow_default_crew_no_crews_defined_is_noop() {
+    let crews = BTreeMap::new();
+
+    let default_crew =
+        workflow_default_crew_from_raw(None, &crews).expect("empty registry is allowed");
+
+    assert_eq!(default_crew, None);
 }
 
 #[test]
@@ -347,8 +357,8 @@ fn crews_with_incomplete_role_fail_load() {
     write_config(
         workspace.path(),
         r#"
-[crews.opus-codex]
-planner = { model = "claude-opus-4-7", provider = "claude", backend = "cli" }
+[crews.codex]
+planner = { model = "gpt-5.5", provider = "codex", backend = "cli" }
 implementer = { model = "gpt-5.5", provider = "codex", backend = "cli" }
 "#,
     );
@@ -357,7 +367,7 @@ implementer = { model = "gpt-5.5", provider = "codex", backend = "cli" }
         .expect_err("incomplete crew fails");
 
     assert!(matches!(error, OrbitError::InvalidInput(_)));
-    assert!(error.to_string().contains("[crews.opus-codex]"));
+    assert!(error.to_string().contains("[crews.codex]"));
     assert!(error.to_string().contains("reviewer"));
 }
 

--- a/crates/orbit-core/src/runtime/builder.rs
+++ b/crates/orbit-core/src/runtime/builder.rs
@@ -321,4 +321,3 @@ fn load_external_tools(store: &Store, registry: &mut ToolRegistry) -> Result<(),
     }
     Ok(())
 }
-

--- a/crates/orbit-core/src/runtime/engine/crew.rs
+++ b/crates/orbit-core/src/runtime/engine/crew.rs
@@ -278,4 +278,3 @@ fn family_from_assignment(assignment: &CrewRoleAssignment) -> Option<String> {
 
     infer_agent_family_from_model(&assignment.model)
 }
-

--- a/crates/orbit-core/src/runtime/engine/envelope.rs
+++ b/crates/orbit-core/src/runtime/engine/envelope.rs
@@ -217,4 +217,3 @@ fn render_agent_pair_placeholders(
         .replace("{{orchestrator_model}}", &orchestrator_value)
         .replace("{{helper_model}}", &helper_value)
 }
-

--- a/crates/orbit-core/src/runtime/engine/runtime_host.rs
+++ b/crates/orbit-core/src/runtime/engine/runtime_host.rs
@@ -250,4 +250,3 @@ fn retired_invoke_activity_error(activity_id: &str) -> OrbitError {
         "v1 invoke_activity is retired; activity '{activity_id}' cannot be dispatched via RuntimeHost"
     ))
 }
-

--- a/crates/orbit-core/src/runtime/engine/task_host.rs
+++ b/crates/orbit-core/src/runtime/engine/task_host.rs
@@ -181,4 +181,3 @@ impl TaskWriteHost for OrbitRuntime {
         Ok(())
     }
 }
-

--- a/crates/orbit-core/src/runtime/engine/tests/crew.rs
+++ b/crates/orbit-core/src/runtime/engine/tests/crew.rs
@@ -17,28 +17,27 @@ fn runtime_with_named_crews() -> (TempDir, OrbitRuntime) {
     std::fs::write(
         workspace_root.join("config.toml"),
         r#"
-[crews.opus-codex]
+[crews.primary]
 planner = { model = "default-planner", provider = "codex", backend = "cli" }
 implementer = { model = "default-implementer", provider = "codex", backend = "cli" }
 reviewer = { model = "default-reviewer", provider = "codex", backend = "cli" }
 
-[crews.silver]
-planner = { model = "silver-planner", provider = "codex", backend = "cli" }
-implementer = { model = "silver-implementer", provider = "codex", backend = "cli" }
-reviewer = { model = "silver-reviewer", provider = "codex", backend = "cli" }
+[crews.beta]
+planner = { model = "beta-planner", provider = "codex", backend = "cli" }
+implementer = { model = "beta-implementer", provider = "codex", backend = "cli" }
+reviewer = { model = "beta-reviewer", provider = "codex", backend = "cli" }
 
-[crews.bronze]
-planner = { model = "bronze-planner", provider = "codex", backend = "cli" }
-implementer = { model = "bronze-implementer", provider = "codex", backend = "cli" }
-reviewer = { model = "bronze-reviewer", provider = "codex", backend = "cli" }
+[crews.gamma]
+planner = { model = "gamma-planner", provider = "codex", backend = "cli" }
+implementer = { model = "gamma-implementer", provider = "codex", backend = "cli" }
+reviewer = { model = "gamma-reviewer", provider = "codex", backend = "cli" }
 
 [workflow]
-default_crew = "opus-codex"
+default_crew = "primary"
 "#,
     )
     .expect("write test config");
-    let runtime =
-        OrbitRuntime::from_roots(&global_root, &workspace_root).expect("build runtime");
+    let runtime = OrbitRuntime::from_roots(&global_root, &workspace_root).expect("build runtime");
     (root, runtime)
 }
 
@@ -57,22 +56,22 @@ fn add_task_with_crew(runtime: &OrbitRuntime, crew: &str) -> String {
 #[test]
 fn run_input_task_ids_singleton_resolves_task_crew() {
     let (_root, runtime) = runtime_with_named_crews();
-    let task_id = add_task_with_crew(&runtime, "silver");
+    let task_id = add_task_with_crew(&runtime, "beta");
 
     let crew = runtime
         .resolve_crew_for_run_input(&json!({ "task_ids": [task_id] }))
         .expect("resolve crew");
 
-    assert_eq!(crew.name, "silver");
-    assert_eq!(crew.planner.model, "silver-planner");
-    assert_eq!(crew.implementer.model, "silver-implementer");
-    assert_eq!(crew.reviewer.model, "silver-reviewer");
+    assert_eq!(crew.name, "beta");
+    assert_eq!(crew.planner.model, "beta-planner");
+    assert_eq!(crew.implementer.model, "beta-implementer");
+    assert_eq!(crew.reviewer.model, "beta-reviewer");
 }
 
 #[test]
 fn record_run_crew_persists_singleton_task_ids_task_crew_models() {
     let (_root, runtime) = runtime_with_named_crews();
-    let task_id = add_task_with_crew(&runtime, "silver");
+    let task_id = add_task_with_crew(&runtime, "beta");
     let input = json!({ "task_ids": [task_id] });
     let run = runtime
         .stores()
@@ -85,44 +84,44 @@ fn record_run_crew_persists_singleton_task_ids_task_crew_models() {
         .expect("record crew");
     let stored = runtime.show_job_run(&run.run_id).expect("show stored run");
 
-    assert_eq!(crew.name, "silver");
-    assert_eq!(stored.resolved_crew.as_deref(), Some("silver"));
-    assert_eq!(stored.planner_model.as_deref(), Some("silver-planner"));
+    assert_eq!(crew.name, "beta");
+    assert_eq!(stored.resolved_crew.as_deref(), Some("beta"));
+    assert_eq!(stored.planner_model.as_deref(), Some("beta-planner"));
     assert_eq!(
         stored.implementer_model.as_deref(),
-        Some("silver-implementer")
+        Some("beta-implementer")
     );
-    assert_eq!(stored.reviewer_model.as_deref(), Some("silver-reviewer"));
+    assert_eq!(stored.reviewer_model.as_deref(), Some("beta-reviewer"));
 }
 
 #[test]
 fn explicit_crew_override_wins_over_singleton_task_ids_task_crew() {
     let (_root, runtime) = runtime_with_named_crews();
-    let task_id = add_task_with_crew(&runtime, "silver");
+    let task_id = add_task_with_crew(&runtime, "beta");
 
     let crew = runtime
         .resolve_crew_for_run_input(&json!({
-            "crew": "bronze",
+            "crew": "gamma",
             "task_ids": [task_id]
         }))
         .expect("resolve crew");
 
-    assert_eq!(crew.name, "bronze");
-    assert_eq!(crew.implementer.model, "bronze-implementer");
+    assert_eq!(crew.name, "gamma");
+    assert_eq!(crew.implementer.model, "gamma-implementer");
 }
 
 #[test]
 fn multi_task_ids_without_override_falls_back_to_default_crew() {
     let (_root, runtime) = runtime_with_named_crews();
-    let silver_task_id = add_task_with_crew(&runtime, "silver");
-    let bronze_task_id = add_task_with_crew(&runtime, "bronze");
+    let beta_task_id = add_task_with_crew(&runtime, "beta");
+    let gamma_task_id = add_task_with_crew(&runtime, "gamma");
 
     let crew = runtime
         .resolve_crew_for_run_input(&json!({
-            "task_ids": [silver_task_id, bronze_task_id]
+            "task_ids": [beta_task_id, gamma_task_id]
         }))
         .expect("resolve crew");
 
-    assert_eq!(crew.name, "opus-codex");
+    assert_eq!(crew.name, "primary");
     assert_eq!(crew.implementer.model, "default-implementer");
 }

--- a/crates/orbit-core/src/runtime/engine/tests/envelope.rs
+++ b/crates/orbit-core/src/runtime/engine/tests/envelope.rs
@@ -69,8 +69,7 @@ fn test_runtime() -> (tempfile::TempDir, OrbitRuntime, PathBuf, PathBuf) {
     let workspace_root = repo_root.join(".orbit");
     fs::create_dir_all(&global_root).expect("create global root");
     fs::create_dir_all(&workspace_root).expect("create workspace root");
-    let runtime =
-        OrbitRuntime::from_roots(&global_root, &workspace_root).expect("build runtime");
+    let runtime = OrbitRuntime::from_roots(&global_root, &workspace_root).expect("build runtime");
     (root, runtime, global_root, workspace_root)
 }
 

--- a/crates/orbit-core/src/runtime/engine/tests/task_host.rs
+++ b/crates/orbit-core/src/runtime/engine/tests/task_host.rs
@@ -6,9 +6,11 @@ use std::path::Path;
 use std::process::Command;
 
 use chrono::Utc;
-use orbit_common::types::{Task, TaskStatus};
 use orbit_common::types::activity_job::{ActivityV2Spec, DeterministicSpec};
-use orbit_engine::{TaskActivityUpdate, TaskAutomationUpdate, TaskWriteHost, V2AuditWriter, V2DispatchInput};
+use orbit_common::types::{Task, TaskStatus};
+use orbit_engine::{
+    TaskActivityUpdate, TaskAutomationUpdate, TaskWriteHost, V2AuditWriter, V2DispatchInput,
+};
 use serde_json::{Value, json};
 use tempfile::tempdir;
 
@@ -43,14 +45,14 @@ fn test_runtime_with_config(config: &str) -> (tempfile::TempDir, OrbitRuntime) {
 fn attribution_test_config() -> &'static str {
     r#"
 [workflow]
-default_crew = "all-claude"
+default_crew = "claude-team"
 
-[crews.all-claude]
+[crews.claude-team]
 planner = { model = "claude-opus-4-7", provider = "claude", backend = "cli" }
 implementer = { model = "claude-sonnet-4-6", provider = "claude", backend = "cli" }
 reviewer = { model = "claude-opus-4-7", provider = "claude", backend = "cli" }
 
-[crews.all-codex]
+[crews.codex-team]
 planner = { model = "gpt-5.5", provider = "codex", backend = "cli" }
 implementer = { model = "gpt-5.5", provider = "codex", backend = "cli" }
 reviewer = { model = "gpt-5.5", provider = "codex", backend = "cli" }
@@ -202,8 +204,7 @@ fn apply_task_automation_update_replaces_context_files_when_set() {
     let task = runtime
         .add_task(TaskAddParams {
             title: "Replace context_files".to_string(),
-            description: "Exercise context_files replacement via automation update."
-                .to_string(),
+            description: "Exercise context_files replacement via automation update.".to_string(),
             workspace_path: Some(".".to_string()),
             context_files: vec!["Cargo.toml".to_string()],
             ..Default::default()
@@ -457,7 +458,7 @@ fn v2_update_task_activity_uses_resolved_crew_implementer_identity() {
             title: "Review attributed update".to_string(),
             description: "Exercise update_task activity implementer attribution.".to_string(),
             workspace_path: Some(".".to_string()),
-            crew: Some("all-claude".to_string()),
+            crew: Some("claude-team".to_string()),
             ..Default::default()
         })
         .expect("add task");
@@ -513,7 +514,7 @@ fn v2_update_task_activity_preserves_existing_implemented_by() {
             title: "Preserve existing implementer".to_string(),
             description: "Exercise review to done automation attribution.".to_string(),
             workspace_path: Some(".".to_string()),
-            crew: Some("all-codex".to_string()),
+            crew: Some("codex-team".to_string()),
             ..Default::default()
         })
         .expect("add task");

--- a/crates/orbit-core/src/runtime/orbit_tool_host/tests/learning_tools.rs
+++ b/crates/orbit-core/src/runtime/orbit_tool_host/tests/learning_tools.rs
@@ -165,7 +165,8 @@ fn round_trip_add_show_preserves_every_field() {
         })
         .expect("create");
 
-    let response = super::super::learning_tools::show(&runtime, json!({"id": learning.id})).expect("show");
+    let response =
+        super::super::learning_tools::show(&runtime, json!({"id": learning.id})).expect("show");
     assert_eq!(response["id"], learning.id);
     assert_eq!(response["summary"], "Verify perf parity before swapping");
     assert_eq!(response["scope"]["paths"], json!(["foo/**"]));
@@ -204,11 +205,13 @@ fn upvote_records_vote_stats_on_show_but_not_list() {
     .expect("duplicate");
     assert_eq!(duplicate["vote_count"], 1);
 
-    let shown = super::super::learning_tools::show(&runtime, json!({"id": learning.id})).expect("show");
+    let shown =
+        super::super::learning_tools::show(&runtime, json!({"id": learning.id})).expect("show");
     assert_eq!(shown["vote_count"], 1);
     assert!(shown["last_voted_at"].as_str().is_some());
 
-    let listed = super::super::learning_tools::list(&runtime, json!({"status": "active"})).expect("list");
+    let listed =
+        super::super::learning_tools::list(&runtime, json!({"status": "active"})).expect("list");
     let row = find_id(&listed, &learning.id).expect("listed row");
     assert!(row.get("vote_count").is_none());
     assert!(row.get("last_voted_at").is_none());
@@ -232,9 +235,11 @@ fn comment_tools_add_list_and_delete() {
     .expect("comment add");
     let comment_id = added["id"].as_str().expect("comment id").to_string();
 
-    let listed =
-        super::super::learning_tools::comment_list(&runtime, json!({"learning_id": learning.id.clone()}))
-            .expect("comment list");
+    let listed = super::super::learning_tools::comment_list(
+        &runtime,
+        json!({"learning_id": learning.id.clone()}),
+    )
+    .expect("comment list");
     assert_eq!(listed.as_array().expect("array").len(), 1);
     assert_eq!(listed[0]["id"], comment_id);
     assert_eq!(listed[0]["body"], "note from tool");
@@ -246,9 +251,11 @@ fn comment_tools_add_list_and_delete() {
         Some("codex".to_string()),
     )
     .expect("comment delete");
-    let active =
-        super::super::learning_tools::comment_list(&runtime, json!({"learning_id": learning.id.clone()}))
-            .expect("active comments");
+    let active = super::super::learning_tools::comment_list(
+        &runtime,
+        json!({"learning_id": learning.id.clone()}),
+    )
+    .expect("active comments");
     assert!(active.as_array().expect("array").is_empty());
     let deleted = super::super::learning_tools::comment_list(
         &runtime,
@@ -266,8 +273,8 @@ fn list_path_filter_uses_glob_containment() {
     let scoped = create_minimal(&runtime, "scoped", &["foo/**"], &[]);
     let unscoped = create_minimal(&runtime, "unscoped", &["bar/**"], &[]);
 
-    let results =
-        super::super::learning_tools::list(&runtime, json!({"path": "foo/bar.rs"})).expect("by path");
+    let results = super::super::learning_tools::list(&runtime, json!({"path": "foo/bar.rs"}))
+        .expect("by path");
     let ids = ids_from_array(&results);
     assert!(
         ids.contains(&scoped.id),
@@ -285,7 +292,8 @@ fn list_tag_filter_uses_case_insensitive_equality() {
     let tagged = create_minimal(&runtime, "tagged", &[], &["perf"]);
     let untagged = create_minimal(&runtime, "untagged", &[], &["other"]);
 
-    let results = super::super::learning_tools::list(&runtime, json!({"tag": "perf"})).expect("by tag");
+    let results =
+        super::super::learning_tools::list(&runtime, json!({"tag": "perf"})).expect("by tag");
     let ids = ids_from_array(&results);
     assert!(ids.contains(&tagged.id));
     assert!(!ids.contains(&untagged.id));
@@ -299,17 +307,22 @@ fn supersede_excludes_from_default_list_but_surfaces_under_status_superseded() {
     let old = create_minimal(&runtime, "old", &["foo/**"], &[]);
     let new = create_minimal(&runtime, "new", &["foo/**"], &[]);
 
-    super::super::learning_tools::supersede(&runtime, json!({"id": old.id, "with": new.id}), None, None)
-        .expect("supersede");
+    super::super::learning_tools::supersede(
+        &runtime,
+        json!({"id": old.id, "with": new.id}),
+        None,
+        None,
+    )
+    .expect("supersede");
 
-    let active =
-        super::super::learning_tools::list(&runtime, json!({"status": "active"})).expect("active list");
+    let active = super::super::learning_tools::list(&runtime, json!({"status": "active"}))
+        .expect("active list");
     let ids = ids_from_array(&active);
     assert!(!ids.contains(&old.id));
     assert!(ids.contains(&new.id));
 
-    let superseded =
-        super::super::learning_tools::list(&runtime, json!({"status": "superseded"})).expect("list");
+    let superseded = super::super::learning_tools::list(&runtime, json!({"status": "superseded"}))
+        .expect("list");
     let ids = ids_from_array(&superseded);
     assert!(ids.contains(&old.id));
 }
@@ -325,7 +338,8 @@ fn sync_rebuilds_index_after_truncation() {
     assert!(response["rebuilt_count"].as_u64().unwrap() >= 1);
 
     // Pre-condition holds: list still finds the learning by tag.
-    let results = super::super::learning_tools::list(&runtime, json!({"tag": "alpha"})).expect("list");
+    let results =
+        super::super::learning_tools::list(&runtime, json!({"tag": "alpha"})).expect("list");
     let ids = ids_from_array(&results);
     assert!(ids.contains(&learning.id));
 }
@@ -448,7 +462,8 @@ fn prune_stale_only_reports_without_modifying_and_delete_archives_via_supersede_
     assert!(report["deleted"].as_array().unwrap().is_empty());
 
     // delete: true archives the stale ones.
-    let result = super::super::learning_tools::prune(&runtime, json!({"delete": true})).expect("delete");
+    let result =
+        super::super::learning_tools::prune(&runtime, json!({"delete": true})).expect("delete");
     let deleted_ids: Vec<String> = result["deleted"]
         .as_array()
         .unwrap()

--- a/crates/orbit-core/src/runtime/pipeline.rs
+++ b/crates/orbit-core/src/runtime/pipeline.rs
@@ -289,4 +289,3 @@ pub struct DryRunResult {
     pub policy_allowed: bool,
     pub missing_params: Vec<String>,
 }
-

--- a/crates/orbit-core/src/runtime/resolve.rs
+++ b/crates/orbit-core/src/runtime/resolve.rs
@@ -402,4 +402,3 @@ pub(crate) fn try_resolve_initialized_roots(
 
     Ok(None)
 }
-

--- a/crates/orbit-core/src/runtime/run_audit.rs
+++ b/crates/orbit-core/src/runtime/run_audit.rs
@@ -325,4 +325,3 @@ fn read_blob_text(blob_store: &BlobStore, blob_ref: &str) -> Result<String, Orbi
 fn read_blob_text_best_effort(blob_store: &BlobStore, blob_ref: &str) -> String {
     read_blob_text(blob_store, blob_ref).unwrap_or_default()
 }
-

--- a/crates/orbit-core/src/runtime/run_input.rs
+++ b/crates/orbit-core/src/runtime/run_input.rs
@@ -28,4 +28,3 @@ pub(crate) fn non_empty(value: &str) -> Option<&str> {
     let trimmed = value.trim();
     (!trimmed.is_empty()).then_some(trimmed)
 }
-

--- a/crates/orbit-core/src/runtime/task_reservation_cleanup.rs
+++ b/crates/orbit-core/src/runtime/task_reservation_cleanup.rs
@@ -128,4 +128,3 @@ impl OrbitRuntime {
         Ok(released)
     }
 }
-

--- a/crates/orbit-core/src/runtime/tests/builder.rs
+++ b/crates/orbit-core/src/runtime/tests/builder.rs
@@ -19,8 +19,7 @@ fn v2_runtime() -> (tempfile::TempDir, PathBuf, PathBuf, OrbitRuntime) {
     let workspace_root = repo_root.join(".orbit");
     std::fs::create_dir_all(&global_root).expect("create global root");
     std::fs::create_dir_all(&workspace_root).expect("create workspace root");
-    let runtime =
-        OrbitRuntime::from_roots(&global_root, &workspace_root).expect("build runtime");
+    let runtime = OrbitRuntime::from_roots(&global_root, &workspace_root).expect("build runtime");
     (root, global_root, workspace_root, runtime)
 }
 
@@ -106,8 +105,7 @@ fn v2_task_backend_persists_workspace_binding_across_runtime_rebuild() {
     assert!(workspace_id.starts_with("repo-"), "{workspace_id}");
     assert_eq!(workspace_id.len(), "repo-000000".len());
 
-    let rebuilt =
-        OrbitRuntime::from_roots(&global_root, &workspace_root).expect("rebuild runtime");
+    let rebuilt = OrbitRuntime::from_roots(&global_root, &workspace_root).expect("rebuild runtime");
     let fetched = rebuilt.get_task(&task.id).expect("get task after rebuild");
     assert_eq!(fetched.title, "Persistent v2 task");
     assert_eq!(
@@ -133,8 +131,7 @@ fn v2_task_backend_rebinds_when_workspace_config_is_missing() {
         read_workspace_config_optional(&workspace_root).expect("read workspace config");
     std::fs::remove_file(workspace_root.join("config.yaml")).expect("remove workspace config");
 
-    let rebuilt =
-        OrbitRuntime::from_roots(&global_root, &workspace_root).expect("rebuild runtime");
+    let rebuilt = OrbitRuntime::from_roots(&global_root, &workspace_root).expect("rebuild runtime");
     let fetched = rebuilt.get_task(&task.id).expect("get task after rebind");
 
     assert_eq!(fetched.title, "Rebind v2 task");

--- a/crates/orbit-core/src/runtime/tests/pipeline.rs
+++ b/crates/orbit-core/src/runtime/tests/pipeline.rs
@@ -3,9 +3,9 @@
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
+use crate::OrbitRuntime;
 use orbit_common::types::Role;
 use orbit_tools::ToolContext;
-use crate::OrbitRuntime;
 
 use orbit_common::types::{TaskPriority, TaskStatus, TaskType};
 use orbit_store::TaskCreateParams;
@@ -68,8 +68,8 @@ fn run_tool_context_allowlist_honors_task_wildcard() {
 #[test]
 fn graph_tool_refresh_from_linked_worktree_attributes_to_worktree_branch() {
     let fixture = GitWorktreeFixture::new();
-    let runtime = OrbitRuntime::from_roots(&fixture.global_root, &fixture.main_orbit)
-        .expect("build runtime");
+    let runtime =
+        OrbitRuntime::from_roots(&fixture.global_root, &fixture.main_orbit).expect("build runtime");
 
     runtime
         .run_tool_with_context_and_role(

--- a/crates/orbit-core/src/runtime/tests/resolve.rs
+++ b/crates/orbit-core/src/runtime/tests/resolve.rs
@@ -10,7 +10,8 @@ use tempfile::tempdir;
 use orbit_common::types::OrbitError;
 
 use super::super::resolve::{
-    resolve_bootstrap_roots, resolve_initialize_roots, try_resolve_initialized_roots, ResolvedOrbitRoots,
+    ResolvedOrbitRoots, resolve_bootstrap_roots, resolve_initialize_roots,
+    try_resolve_initialized_roots,
 };
 
 static ENV_LOCK: Mutex<()> = Mutex::new(());
@@ -21,8 +22,7 @@ fn explicit_root_with_initialized_child_orbit_resolves_to_child() {
     let orbit_root = repo.path().join(".orbit");
     seed_initialized_workspace_root(&orbit_root);
 
-    let resolved =
-        resolve_initialize_roots(repo.path(), Some(repo.path())).expect("resolve root");
+    let resolved = resolve_initialize_roots(repo.path(), Some(repo.path())).expect("resolve root");
 
     assert_pinned_roots(&resolved, &orbit_root);
 }
@@ -32,11 +32,9 @@ fn explicit_root_prefers_initialized_child_orbit_over_polluted_repo_root() {
     let repo = tempdir().expect("repo tempdir");
     let orbit_root = repo.path().join(".orbit");
     seed_initialized_workspace_root(&orbit_root);
-    fs::write(repo.path().join("config.toml"), "polluted = true\n")
-        .expect("write root pollution");
+    fs::write(repo.path().join("config.toml"), "polluted = true\n").expect("write root pollution");
 
-    let resolved =
-        resolve_initialize_roots(repo.path(), Some(repo.path())).expect("resolve root");
+    let resolved = resolve_initialize_roots(repo.path(), Some(repo.path())).expect("resolve root");
 
     assert_pinned_roots(&resolved, &orbit_root);
 }
@@ -66,8 +64,7 @@ fn explicit_root_with_initialized_orbit_root_resolves_as_is() {
     let orbit_root = repo.path().join(".orbit");
     seed_initialized_workspace_root(&orbit_root);
 
-    let resolved =
-        resolve_initialize_roots(repo.path(), Some(&orbit_root)).expect("resolve root");
+    let resolved = resolve_initialize_roots(repo.path(), Some(&orbit_root)).expect("resolve root");
 
     assert_pinned_roots(&resolved, &orbit_root);
 }
@@ -130,8 +127,7 @@ fn worktree_main_orbit_precedes_worktree_local_orbit() {
     seed_initialized_workspace_root(&main_orbit);
     seed_initialized_workspace_root(&worktree_orbit);
 
-    let resolved =
-        resolve_initialize_roots(worktree.path(), None).expect("resolve worktree root");
+    let resolved = resolve_initialize_roots(worktree.path(), None).expect("resolve worktree root");
 
     assert_roots(&resolved, &main_orbit, &worktree_orbit);
 }
@@ -144,8 +140,7 @@ fn worktree_without_orbit_uses_main_repo_legacy_orbit_path() {
     let worktree = tempdir().expect("worktree tempdir");
     seed_fake_git_worktree(main_repo.path(), worktree.path());
 
-    let resolved =
-        resolve_bootstrap_roots(worktree.path(), None).expect("resolve worktree root");
+    let resolved = resolve_bootstrap_roots(worktree.path(), None).expect("resolve worktree root");
 
     assert_roots(
         &resolved,
@@ -248,8 +243,8 @@ fn try_resolve_finds_initialized_workspace_via_walk_up() {
     let orbit_root = repo.path().join(".orbit");
     seed_initialized_workspace_root(&orbit_root);
 
-    let resolved = try_resolve_initialized_roots(&nested, None)
-        .expect("try_resolve completes without error");
+    let resolved =
+        try_resolve_initialized_roots(&nested, None).expect("try_resolve completes without error");
 
     assert_optional_pinned_roots(&resolved, &orbit_root);
 }

--- a/crates/orbit-core/src/runtime/tests/run_audit.rs
+++ b/crates/orbit-core/src/runtime/tests/run_audit.rs
@@ -1,7 +1,7 @@
 //! Sibling tests for `run_audit.rs` (migrated per ORB-00246 / docs/design-patterns/test_layout.md).
 
-use orbit_common::utility::blob_store::BlobStore;
 use crate::OrbitRuntime;
+use orbit_common::utility::blob_store::BlobStore;
 
 use serde_json::json;
 

--- a/crates/orbit-core/src/runtime/tests/task_reservation_cleanup.rs
+++ b/crates/orbit-core/src/runtime/tests/task_reservation_cleanup.rs
@@ -1,14 +1,12 @@
 //! Sibling tests for `task_reservation_cleanup.rs` (migrated per ORB-00246 / docs/design-patterns/test_layout.md).
 
+use crate::OrbitRuntime;
 use chrono::Utc;
 use orbit_common::types::JobRunState;
 use orbit_store::TaskReservationReleaseReason;
 use serde_json::json;
-use crate::OrbitRuntime;
 
-use super::super::orbit_tool_host::{
-    workspace_orbit_dir, workspace_task_reservation_id,
-};
+use super::super::orbit_tool_host::{workspace_orbit_dir, workspace_task_reservation_id};
 
 use chrono::Duration;
 use orbit_common::types::{AuditEventStatus, Role, TaskPriority, TaskStatus, TaskType};
@@ -91,11 +89,7 @@ fn insert_running_run(
         .expect("run exists")
 }
 
-fn reserve_via_tool_for_owner(
-    runtime: &OrbitRuntime,
-    owner_run_id: &str,
-    task_id: &str,
-) -> String {
+fn reserve_via_tool_for_owner(runtime: &OrbitRuntime, owner_run_id: &str, task_id: &str) -> String {
     let output = runtime
         .run_tool_with_context_and_role(
             "orbit.task.locks.reserve",

--- a/crates/orbit-core/src/runtime/v2_host/backlog_exclusion.rs
+++ b/crates/orbit-core/src/runtime/v2_host/backlog_exclusion.rs
@@ -428,4 +428,3 @@ fn task_root_id(task: &Task, task_lookup: &BTreeMap<String, Task>) -> String {
 #[cfg(test)]
 #[path = "backlog_exclusion_tests.rs"]
 mod tests;
-

--- a/crates/orbit-dashboard/src/api/tests/handlers.rs
+++ b/crates/orbit-dashboard/src/api/tests/handlers.rs
@@ -62,10 +62,10 @@ fn runtime_with_custom_crews() -> (tempfile::TempDir, OrbitRuntime) {
     std::fs::write(
         workspace_root.join("config.toml"),
         r#"
-[crews.silver]
-planner = { model = "claude-silver-plan", provider = "claude", backend = "cli" }
-implementer = { model = "codex-silver-impl", provider = "codex", backend = "cli" }
-reviewer = { model = "codex-silver-review", provider = "codex", backend = "cli" }
+[crews.beta]
+planner = { model = "claude-beta-plan", provider = "claude", backend = "cli" }
+implementer = { model = "codex-beta-impl", provider = "codex", backend = "cli" }
+reviewer = { model = "codex-beta-review", provider = "codex", backend = "cli" }
 
 [crews.alpha]
 planner = { model = "alpha-plan-model", provider = "claude", backend = "cli" }
@@ -73,7 +73,7 @@ implementer = { model = "alpha-impl-model", provider = "codex", backend = "cli" 
 reviewer = { model = "alpha-review-model", provider = "codex", backend = "cli" }
 
 [workflow]
-default_crew = "silver"
+default_crew = "beta"
 "#,
     )
     .expect("write config");
@@ -108,7 +108,7 @@ async fn crews_endpoint_returns_sorted_runtime_registry() {
 
     assert_eq!(response.status(), StatusCode::OK);
     let body = body_json(response).await;
-    assert_eq!(body["default_crew"], json!("silver"));
+    assert_eq!(body["default_crew"], json!("beta"));
     let crews = body["crews"].as_array().expect("crews array");
     assert_eq!(crews.len(), 2);
     assert_eq!(crews[0]["name"], json!("alpha"));
@@ -116,11 +116,11 @@ async fn crews_endpoint_returns_sorted_runtime_registry() {
     assert_eq!(crews[0]["planner_model"], json!("alpha-plan-model"));
     assert_eq!(crews[0]["implementer_model"], json!("alpha-impl-model"));
     assert_eq!(crews[0]["reviewer_model"], json!("alpha-review-model"));
-    assert_eq!(crews[1]["name"], json!("silver"));
+    assert_eq!(crews[1]["name"], json!("beta"));
     assert_eq!(crews[1]["is_default"], json!(true));
-    assert_eq!(crews[1]["planner_model"], json!("claude-silver-plan"));
-    assert_eq!(crews[1]["implementer_model"], json!("codex-silver-impl"));
-    assert_eq!(crews[1]["reviewer_model"], json!("codex-silver-review"));
+    assert_eq!(crews[1]["planner_model"], json!("claude-beta-plan"));
+    assert_eq!(crews[1]["implementer_model"], json!("codex-beta-impl"));
+    assert_eq!(crews[1]["reviewer_model"], json!("codex-beta-review"));
 }
 
 #[tokio::test]

--- a/crates/orbit-engine/src/activity_job/cli_runner/tests/orchestrator.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/tests/orchestrator.rs
@@ -598,12 +598,12 @@ fn run_cli_backend_keeps_success_when_envelope_reports_success() {
     );
 }
 
-/// Crew-driven regression test for ORB-00080 AC #15: `opus-codex` crew must
+/// Crew-driven regression test for ORB-00080 AC #15: a mixed fixture crew must
 /// produce `--model claude-opus-4-7` for planner and `--model gpt-5.5` for
 /// implementer (identity attribution stays family; no leakage of family name
 /// into the --model flag that reaches the CLI).
 #[test]
-fn crew_opus_codex_drives_exact_models_to_planner_and_implementer() {
+fn mixed_crew_drives_exact_models_to_planner_and_implementer() {
     let temp = tempdir().expect("tempdir");
     let claude_script = temp.path().join("claude");
     let codex_script = temp.path().join("codex");
@@ -616,7 +616,7 @@ fn crew_opus_codex_drives_exact_models_to_planner_and_implementer() {
         "#!/bin/sh\nprintf '{\"schemaVersion\":1,\"status\":\"success\"}\\n'\n",
     );
 
-    // planner leg via opus-codex crew
+    // planner leg via mixed fixture crew
     let sink_for_writer_p: Arc<dyn AuditSink> = Arc::new(RecordingSink::default());
     let audit_p = Arc::new(V2AuditWriter::new(
         "job-crew-planner",
@@ -628,7 +628,7 @@ fn crew_opus_codex_drives_exact_models_to_planner_and_implementer() {
     spec_p.role = Some(AgentRole::Planner);
     let input_p = serde_json::json!({
         "prompt": "draft plan",
-        "crew": "opus-codex",
+        "crew": "mixed-fixture",
         "task_id": "T-crew"
     });
     let resolved_p = resolve_agent_settings(AgentRole::Planner, &host_p, &spec_p, &input_p);
@@ -685,7 +685,7 @@ fn crew_opus_codex_drives_exact_models_to_planner_and_implementer() {
     spec_i.role = Some(AgentRole::Implementer);
     let input_i = serde_json::json!({
         "prompt": "implement",
-        "crew": "opus-codex",
+        "crew": "mixed-fixture",
         "task_id": "T-crew"
     });
     let resolved_i = resolve_agent_settings(AgentRole::Implementer, &host_i, &spec_i, &input_i);

--- a/crates/orbit-engine/src/activity_job/cli_runner/tests/test_support.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/tests/test_support.rs
@@ -298,7 +298,7 @@ impl V2RuntimeHost for TestHost {
         input: &Value,
     ) -> Option<AgentRoleConfig> {
         let crew = input.get("crew").and_then(|v| v.as_str()).unwrap_or("");
-        if crew != "opus-codex" {
+        if crew != "mixed-fixture" {
             return None;
         }
         match role {

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -24,7 +24,7 @@ The workspace identity file `.orbit/config.yaml` is a separate artifact (it stor
 ```toml
 [workflow]
 base_branch = "main"        # default merge-base for ship / duel-plan
-default_crew = "opus-codex" # fallback crew when a task has no `crew` set
+default_crew = "codex"      # fallback crew when a task has no `crew` set
 ```
 
 - **`base_branch`** — the branch `orbit run ship` and `duel-plan` rebase against and target with PRs. Override per-invocation with `--base <branch>`. If your repo uses a two-branch pattern like this repo does (`main` = release, `agent-main` = dev integration), set `base_branch = "agent-main"`.
@@ -42,18 +42,18 @@ A **crew** assigns models to the three roles in the ship pipeline: `planner`, `i
 | `provider` | Agent family | `claude`, `codex`, `gemini`, `grok` |
 | `backend` | How Orbit dispatches the agent | `cli` (today the only supported value for these roles) |
 
-Example — a mixed crew using Claude for planning and review, Codex for implementation:
+Example — a single-family Codex crew:
 
 ```toml
-[crews.opus-codex]
-planner     = { model = "claude-opus-4-7", provider = "claude", backend = "cli" }
+[crews.codex]
+planner     = { model = "gpt-5.5",         provider = "codex",  backend = "cli" }
 implementer = { model = "gpt-5.5",         provider = "codex",  backend = "cli" }
-reviewer    = { model = "claude-opus-4-7", provider = "claude", backend = "cli" }
+reviewer    = { model = "gpt-5.5",         provider = "codex",  backend = "cli" }
 ```
 
 You can define any number of crews. Set the workspace-wide fallback with `workflow.default_crew`; assign a specific crew to individual tasks via the [per-task crew override](#per-task-crew-override). Common patterns:
 
-- **Single-vendor crew** (`all-claude`, `all-codex`, `all-gemini`, `all-grok`) — useful when you only have one CLI authenticated, or when you want consistent behaviour end-to-end.
+- **Single-family crew** (`claude`, `codex`, `gemini`, `grok`) — useful when you only have one CLI authenticated, or when you want consistent behaviour end-to-end.
 - **Mixed crew** — different model for each role, e.g. a strong planner with a fast implementer, or a different vendor for review than implementation so the reviewer isn't reviewing its own output.
 
 Crews are validated at load time: each role must have non-empty `model`, `provider`, and `backend`; `workflow.default_crew` must name a defined crew.
@@ -70,7 +70,7 @@ Crews are validated at load time: each role must have non-empty `model`, `provid
 2. `[workflow].default_crew` from `config.toml`, otherwise
 3. error: `no crew selected; set [workflow].default_crew, task.crew, or pass crew`.
 
-This means you can mix-and-match in a single ship run: route a tricky refactor to `all-claude` while routing routine cleanups to `opus-codex` — both go through the same `orbit run ship` invocation, each picking its own crew at dispatch time.
+This means you can mix-and-match in a single ship run: route a tricky refactor to `claude` while routing routine cleanups to `codex` — both go through the same `orbit run ship` invocation, each picking its own crew at dispatch time.
 
 ### Setting `task.crew`
 
@@ -82,7 +82,7 @@ Three equivalent surfaces:
 | **CLI** | `orbit task add --crew <name> …` at creation, or `orbit task update <id> --crew <name>` later. Pass `--crew ""` to `task update` to clear the field. (`orbit task start --crew <name>` exists but only validates the name and logs it — it does **not** persist onto `task.crew` or affect later `orbit run ship` dispatch. Use `task update` if you want the choice to stick.) |
 | **MCP / agent** | `orbit.task.add` and `orbit.task.update` accept a `crew` parameter; an empty string on update clears it. Useful when an agent is filing or amending tasks programmatically. |
 
-The dropdown label `default: opus-codex` in the dashboard means *the task has no `crew` set* and will inherit `[workflow].default_crew`. Picking a named crew writes it onto the task and the label updates accordingly.
+The dropdown label `default: codex` in the dashboard means *the task has no `crew` set* and will inherit `[workflow].default_crew`. Picking a named crew writes it onto the task and the label updates accordingly.
 
 ### What "ran" vs what "was selected"
 

--- a/docs/design/agent-families/2_design.md
+++ b/docs/design/agent-families/2_design.md
@@ -3,7 +3,7 @@ summary: "Agent Families — Design"
 type: design
 title: "Agent Families — Design"
 owner: human
-last_updated: 2026-05-16
+last_updated: 2026-05-22
 status: Draft
 feature: agent-families
 doc_role: design
@@ -32,7 +32,7 @@ Workspace config now defines concrete role lineups under `[crews.<name>]`. Each 
 
 `crates/orbit-core/src/config/raw.rs` owns the TOML shape, and `crates/orbit-core/src/config/runtime.rs` materializes it into `Crew` values from `orbit-common`. Runtime loading rejects incomplete crews and rejects `[workflow].default_crew` when it does not name a defined crew.
 
-The repository default template and `.orbit/config.toml` use `[workflow].default_crew = "opus-codex"` and define at least `opus-codex` and `all-claude`.
+The repository default template and `.orbit/config.toml` use `[workflow].default_crew = "codex"` and seed single-family crews named `claude`, `codex`, `gemini`, and `grok`.
 
 ## 3. Task and Tool Surface
 


### PR DESCRIPTION
## Task

[ORB-00245](https://orbit-cli.com/tasks/ORB-00245) — Rename default crews in default-config.toml to family names; drop opus-codex/silver/bronze

### Description

## Problem

The seeded `[crews.*]` template in `crates/orbit-core/assets/config/default-config.toml` currently ships five crews with mixed/legacy names (`opus-codex`, `silver`, `bronze`, `all-claude`, `all-codex`, `all-gemini`, `all-grok`) and `default_crew = "opus-codex"`. The repo wants the default template to instead be four single-family crews keyed by family name with `default_crew = "codex"`.

Desired final shape of the `[workflow]` + `[crews.*]` section:

```toml
base_branch = "main"
default_crew = "codex"

[crews.claude]
planner = { model = "claude-opus-4-7", provider = "claude", backend = "cli" }
implementer = { model = "claude-opus-4-7", provider = "claude", backend = "cli" }
reviewer = { model = "claude-opus-4-7", provider = "claude", backend = "cli" }

[crews.codex]
planner = { model = "gpt-5.5", provider = "codex", backend = "cli" }
implementer = { model = "gpt-5.5", provider = "codex", backend = "cli" }
reviewer = { model = "gpt-5.5", provider = "codex", backend = "cli" }

[crews.gemini]
planner = { model = "pro", provider = "gemini", backend = "cli" }
implementer = { model = "pro", provider = "gemini", backend = "cli" }
reviewer = { model = "pro", provider = "gemini", backend = "cli" }

[crews.grok]
planner = { model = "grok-build", provider = "grok", backend = "cli" }
implementer = { model = "grok-build", provider = "grok", backend = "cli" }
reviewer = { model = "grok-build", provider = "grok", backend = "cli" }
```

The `default-config.toml` edit itself is already staged locally (see `git diff crates/orbit-core/assets/config/default-config.toml`). The work below is the propagation required to make the rename land cleanly under `make ci`.

## Why It Matters

The `opus-codex` name has been historically load-bearing as both the seeded default and the silent fallback when `[workflow].default_crew` is unset. After this rename, two non-test code paths will silently degrade if not updated:

1. `crates/orbit-core/src/config/runtime.rs:414` — `workflow_default_crew_from_raw` falls back to `"opus-codex"` when `default_crew` is missing and that crew is present. After the rename this fallback never matches in fresh installs, which changes the error a user sees on a minimal config from "use this default" to "choose one of: ...".
2. `crates/orbit-core/src/config/bootstrap.rs:50` — `orbit init --interactive` does a string replace on `default_crew = "opus-codex"` in the seeded template. After the template flips to `default_crew = "codex"`, that replace silently no-ops and the generated `custom` crew never becomes the active default.

Additionally, several tests and one runtime crew-listing path under `crates/orbit-core/src/runtime/engine/{crew.rs,task_host.rs}` and `crates/orbit-core/src/command/init.rs` assert the old crew names; they will fail unless updated alongside the template.

## Constraints / Notes

- **Historical docs are immutable.** Do **not** rewrite past task records under `website/src/content/docs/tasks/ORB-*.md` (e.g. ORB-00058, ORB-00076, ORB-00078, ORB-00080, ORB-00081, ORB-00087, ORB-00091) or `docs/architecture/design/agent-families/2_design.md`. Those refer to historical state when `opus-codex` was the canonical default; leaving them alone is correct. Only update human-authored design docs where the reference is presented as *current* template guidance, not historical narrative.
- **No new crew aliases.** Do not introduce a backwards-compatibility alias layer mapping `opus-codex -> codex` etc. The dropped crews (`opus-codex` mixed claude/codex, `silver` gemini-grok, `bronze` all-sonnet) were template suggestions, not API. The task is a hard rename of the seeded shape; downstream users with hand-edited `.orbit/config.toml` keep working because `resolve_crew` already takes whatever names the user defines.
- **Fallback policy decision required.** Pick one of:
  - (a) Keep the historical fallback line but key it on `"codex"` instead of `"opus-codex"`, matching the new default_crew. This preserves the "missing default_crew silently uses the seeded one" behavior.
  - (b) Delete the special-case fallback entirely and always require an explicit `default_crew` when crews are defined. More predictable but slightly less forgiving on hand-trimmed configs.
  Document the choice in the task PR description and in any updated test names/comments. Default recommendation: (a) — minimal behavior change.
- **Test scope.** All hard-coded crew-name strings in test fixtures must be updated to the new vocabulary or to neutral fixture names that do not collide with template guidance. Where a test specifically exercises did-you-mean / suggestion behavior, the suggestion set should still be deterministic and meaningful.
- **CI must pass.** `make ci-fast` clean plus the full test suite green across `orbit-core`, `orbit-common`, `orbit-engine`, `orbit-dashboard`. Do not skip `await_holding_lock` / `unwrap_used` audits during the touch-up.

## Known Touchpoints

These are the files that reference the old crew names today; consult each when scoping the change. Not all need edits — some are historical task narratives that must stay untouched.

### Must update (non-historical)
- [crates/orbit-core/assets/config/default-config.toml](crates/orbit-core/assets/config/default-config.toml) — seeded template (already staged locally).
- [crates/orbit-core/src/config/runtime.rs:414](crates/orbit-core/src/config/runtime.rs) — `workflow_default_crew_from_raw` fallback; also lines 89, 220, 222, 229, 231 in test fixtures.
- [crates/orbit-core/src/config/bootstrap.rs:50](crates/orbit-core/src/config/bootstrap.rs) — string-replace in seeded template; update both the literal and any assertions in `crates/orbit-core/src/config/tests/bootstrap.rs`.
- [crates/orbit-core/src/config/tests/runtime.rs](crates/orbit-core/src/config/tests/runtime.rs) — multiple fixtures hard-code `opus-codex`.
- [crates/orbit-core/src/runtime/engine/crew.rs:301](crates/orbit-core/src/runtime/engine/crew.rs) — test TOML fixture mentions `opus-codex`/`silver`/`bronze`.
- [crates/orbit-core/src/runtime/engine/task_host.rs:229](crates/orbit-core/src/runtime/engine/task_host.rs) — test TOML fixture uses `all-claude`/`all-codex`.
- [crates/orbit-core/src/command/init.rs:884](crates/orbit-core/src/command/init.rs) — assertions on bootstrapped config contents.
- [crates/orbit-common/src/types/tests/agent_pair.rs](crates/orbit-common/src/types/tests/agent_pair.rs) — `resolve_crew` + did-you-mean fixtures.
- [crates/orbit-common/src/types/tests/task.rs:191](crates/orbit-common/src/types/tests/task.rs) — round-trip serialisation test for `crew: opus-codex`.
- [crates/orbit-engine/src/activity_job/cli_runner/tests/test_support.rs:301](crates/orbit-engine/src/activity_job/cli_runner/tests/test_support.rs) and [orchestrator.rs:601,619,631,688](crates/orbit-engine/src/activity_job/cli_runner/tests/orchestrator.rs) — crew-driven regression tests for AC#15 of ORB-00080. These exercise the planner=claude/implementer=codex mixing that `opus-codex` provided; the new template has no mixed crew. Either (i) define a mixed fixture crew locally inside the test (preferred — keeps regression intent intact without leaking template policy into tests), or (ii) rewrite the test to drive `claude` + `codex` crews via separate invocations.
- [crates/orbit-dashboard/src/api/tests/handlers.rs:65](crates/orbit-dashboard/src/api/tests/handlers.rs) — `[crews.silver]` fixture; rename to a non-template fixture name.

### Leave alone (historical)
- All files under `website/src/content/docs/tasks/ORB-*.md` and `docs/architecture/design/agent-families/2_design.md` that recount past template state.

### Acceptance Criteria

- After the change, `crates/orbit-core/assets/config/default-config.toml` matches the desired final shape in the description verbatim: `default_crew = "codex"` and exactly four `[crews.<name>]` blocks named `claude`, `codex`, `gemini`, `grok`, each with planner/implementer/reviewer entries identical to the description block.
- `grep -rn --include="*.rs" -E "\"opus-codex\"|\"all-claude\"|\"all-codex\"|\"all-gemini\"|\"all-grok\"|crews\.silver|crews\.bronze" crates/` returns zero matches outside of comments that explicitly document historical state.
- `workflow_default_crew_from_raw` in `crates/orbit-core/src/config/runtime.rs` either (a) falls back to `"codex"` when `[workflow].default_crew` is unset and the `codex` crew is present, or (b) always errors when `default_crew` is unset and crews are defined; whichever option is chosen, two unit tests (one for the fallback-applies case, one for the no-crews-defined no-op case) live in `crates/orbit-core/src/config/tests/runtime.rs` and pass.
- `orbit init --interactive` (exercised through the existing test path in `crates/orbit-core/src/config/tests/bootstrap.rs` and `crates/orbit-core/src/command/init.rs`) produces a generated config whose `default_crew` value matches the user-selected crew name when the user picks a custom default, and matches `"codex"` when the user accepts the seeded default. The string-replace target in `bootstrap.rs:50` is updated to `default_crew = "codex"`.
- The crew-driven CLI-runner regression test originally added for ORB-00080 AC#15 (planner=claude-opus-4-7 / implementer=gpt-5.5) still exists and passes. It must drive a mixed planner/implementer crew end-to-end and assert the exact `--model` flag passed to the CLI subprocess for both legs; the mixed crew may be defined inline in the test fixture and need not exist in the seeded template.
- `make ci-fast` completes with exit code 0.
- `cargo test -p orbit-core -p orbit-common -p orbit-engine -p orbit-dashboard` completes with all tests green; no test is marked `#[ignore]` or `#[should_panic]` as part of this task.
- Commit message ends with the agent-author identity (`claude` or `codex`) and includes the task ID tag in the form `[ORB-NNNNN]`.
- No file under `website/src/content/docs/tasks/ORB-*.md` is modified by this PR (historical task narratives are immutable).

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Renamed the seeded template and runtime defaults to the four family crews (`claude`, `codex`, `gemini`, `grok`) with `default_crew = "codex"`.
- Kept the unset `[workflow].default_crew` fallback policy, now keyed to `codex`, and added runtime tests for both the fallback-applies case and the empty-registry no-op case.
- Updated bootstrap/init/config/dashboard/common fixtures and preserved the mixed planner/implementer CLI-runner regression with an inline `mixed-fixture` crew asserting exact `--model` flags.
- Updated current config/design guidance docs; historical task docs under `website/src/content/docs/tasks/ORB-*.md` were not modified.
- Ran `cargo fmt`; extra runtime files are formatting-only changes required by `make ci-fast` fmt-check.

Assessment: The scoped crew rename is implemented and targeted validation passes. `make ci-fast` passes. The requested full package test command was run but does not complete green on this worktree because unrelated pre-existing `orbit-core` tests fail in job-run owner identity and task-tool dependency/external-ref/source-task behavior; targeted affected tests pass.

Strategic decisions:
- Fallback policy (a) retained | Rationale: matches the new seeded default while minimizing behavior change for configs that omit `[workflow].default_crew`.

Validation:
- PASS: `make ci-fast` (with managed Orbit env vars unset for validation).
- PASS: `grep -rn --include="*.rs" -E "\"opus-codex\"|\"all-claude\"|\"all-codex\"|\"all-gemini\"|\"all-grok\"|crews\.silver|crews\.bronze" crates/` returned no matches.
- PASS: targeted `cargo test -p orbit-core config::tests`, `cargo test -p orbit-core command::init::tests::global_init_without_role_settings_writes_clean_template`, `cargo test -p orbit-core runtime::engine::tests::crew`, and `cargo test -p orbit-engine mixed_crew_drives_exact_models_to_planner_and_implementer`.
- FAIL (unrelated): `cargo test -p orbit-core -p orbit-common -p orbit-engine -p orbit-dashboard` fails in 8 existing `orbit-core` tests unrelated to this crew rename.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-00245-6a0fd2cf`
- Behind base: 0
- Ahead of base: 1