### PR TITLE
MCP: ambient session context so workspace can default safely

### DIFF
--- a/.orbit/adrs/proposed/ADR-0181/adr.yaml
+++ b/.orbit/adrs/proposed/ADR-0181/adr.yaml
@@ -1,0 +1,24 @@
+schema_version: 2
+id: ADR-0181
+title: MCP ambient workspace session context
+status: proposed
+owner: codex
+created_at: 2026-05-22T04:04:38.463006Z
+last_updated: 2026-05-22T04:04:38.463006Z
+related_features:
+- mcp-session-context
+- task-artifacts
+related_tasks:
+- ORB-00256
+tags:
+- mcp
+- workspace
+paths:
+- crates/orbit-mcp/**
+- crates/orbit-tools/src/builtin/orbit/task/add.rs
+- crates/orbit-core/src/command/tool.rs
+- crates/orbit-cli/src/command/mcp/**
+supersedes: []
+legacy_ids: []
+validation_warnings: []
+legacy_validation: none

--- a/.orbit/adrs/proposed/ADR-0181/body.md
+++ b/.orbit/adrs/proposed/ADR-0181/body.md
@@ -1,0 +1,11 @@
+## Context
+MCP tools need CLI-like workspace ergonomics, but ADR-0149 makes process-cwd defaults unsafe because worktree cwd can bind to a different workspace_id. The viable alternatives were per-call workspace input forever, a one-shot workspace lookup tool that clients cache, or a deliberate session-level signal from the MCP client.
+
+## Decision
+MCP clients announce the canonical workspace path in initialize.params._meta.orbit.workspace. orbit-mcp stores that value in the server session context for the stdio session and passes it through ToolSessionContext into ToolContext; workspace-taking tools resolve explicit input first, then session context, then return a clear missing-workspace error. If explicit input and session context differ, the tool logs the mismatch at info level and honors explicit input.
+
+## Consequences
+- ADR-0149 remains the workspace_id binding invariant; this ADR changes only how MCP calls address that binding.
+- orbit.task.add and future workspace-taking tools can make workspace optional without defaulting to process cwd.
+- Clients that cannot send initialize metadata can continue passing workspace explicitly.
+- Cost: Orbit now carries MCP session metadata across the adapter, CLI host, runtime dispatch, and tool context, so new host surfaces must preserve that thread-through path.

--- a/crates/orbit-cli/src/command/mcp/mod.rs
+++ b/crates/orbit-cli/src/command/mcp/mod.rs
@@ -12,7 +12,7 @@ use std::sync::Arc;
 use std::time::Instant;
 
 use clap::{Args, Subcommand};
-use orbit_common::types::{AuditEventStatus, ToolSchema, audit_execution_id};
+use orbit_common::types::{AuditEventStatus, ToolSchema, ToolSessionContext, audit_execution_id};
 use orbit_core::command::tool::{ToolEntryPoint, audit_role_label};
 use orbit_core::{
     AuditEventInsertParams, NotFoundKind, OrbitError, OrbitRuntime, redact_sensitive_env_text,
@@ -237,8 +237,13 @@ impl McpHost for RuntimeMcpHost {
             .collect()
     }
 
-    fn call_tool(&self, name: &str, input: Value) -> Result<Value, OrbitError> {
-        audited_mcp_call(&self.runtime, name, input)
+    fn call_tool(
+        &self,
+        name: &str,
+        input: Value,
+        session_context: ToolSessionContext,
+    ) -> Result<Value, OrbitError> {
+        audited_mcp_call_with_session_context(&self.runtime, name, input, session_context)
     }
 }
 
@@ -252,14 +257,31 @@ impl McpHost for RuntimeMcpHost {
 /// then short-circuits. On the success path it delegates to the runtime,
 /// which owns the audit row (no dedup needed because `orbit mcp serve` is
 /// invoked outside any CLI [`crate::audit_middleware::AuditGuard`]).
+#[cfg(test)]
 fn audited_mcp_call(runtime: &OrbitRuntime, name: &str, input: Value) -> Result<Value, OrbitError> {
+    audited_mcp_call_with_session_context(runtime, name, input, ToolSessionContext::default())
+}
+
+fn audited_mcp_call_with_session_context(
+    runtime: &OrbitRuntime,
+    name: &str,
+    input: Value,
+    session_context: ToolSessionContext,
+) -> Result<Value, OrbitError> {
     if let Err(err) = ensure_mcp_tool_exposed(name) {
         record_mcp_preflight_failure(runtime, name, &input, &err);
         return Err(err);
     }
 
     runtime
-        .execute_tool_command_dispatch(name, input, None, None, ToolEntryPoint::Mcp)
+        .execute_tool_command_dispatch_with_session_context(
+            name,
+            input,
+            None,
+            None,
+            ToolEntryPoint::Mcp,
+            session_context,
+        )
         .map(|outcome| outcome.value)
 }
 
@@ -335,7 +357,12 @@ impl McpHost for EmptyMcpHost {
         Vec::new()
     }
 
-    fn call_tool(&self, name: &str, _input: Value) -> Result<Value, OrbitError> {
+    fn call_tool(
+        &self,
+        name: &str,
+        _input: Value,
+        _session_context: ToolSessionContext,
+    ) -> Result<Value, OrbitError> {
         Err(OrbitError::not_found(NotFoundKind::Tool, name.to_string()))
     }
 }

--- a/crates/orbit-cli/src/command/mcp/tests/mod.rs
+++ b/crates/orbit-cli/src/command/mcp/tests/mod.rs
@@ -238,6 +238,7 @@ mod audited_mcp_call_tests {
             .call_tool(
                 "orbit.search",
                 json!({ "query": "anything", "kind": "task" }),
+                Default::default(),
             )
             .expect("dispatch ok");
         assert!(
@@ -305,6 +306,7 @@ mod audited_mcp_call_tests {
         let result = host.call_tool(
             "orbit.task.delete",
             json!({ "id": task_id, "model": "gpt-5.5" }),
+            Default::default(),
         );
 
         let error = result.expect_err("unforced protected delete fails");
@@ -345,6 +347,7 @@ mod audited_mcp_call_tests {
                 .call_tool(
                     "orbit.task.delete",
                     json!({ "id": task_id, "model": "gpt-5.5" }),
+                    Default::default(),
                 )
                 .expect("unprotected delete succeeds");
             assert_eq!(value, json!({ "id": task_id, "deleted": true }));
@@ -372,6 +375,7 @@ mod audited_mcp_call_tests {
             .call_tool(
                 "orbit.task.delete",
                 json!({ "id": task_id, "force": true, "model": "gpt-5.5" }),
+                Default::default(),
             )
             .expect("forced protected delete succeeds");
 

--- a/crates/orbit-common/src/types/mod.rs
+++ b/crates/orbit-common/src/types/mod.rs
@@ -141,7 +141,7 @@ pub use task_artifacts::{
     validate_relative_artifact_path, validate_task_relations_for_source,
 };
 pub use task_plan::{TaskPlan, TaskPlanCheckpoint, TaskPlanSuccessCriterion, parse_task_plan};
-pub use tool::{ExecutionResult, StoredTool, ToolParam, ToolSchema};
+pub use tool::{ExecutionResult, StoredTool, ToolParam, ToolSchema, ToolSessionContext};
 pub use tool_input::{
     RETIRED_TASK_ADD_INPUT_FIELDS, optional_csv_or_string_list_alias, optional_raw_string,
     optional_string, optional_string_alias, optional_string_list_alias, optional_u32_alias,

--- a/crates/orbit-common/src/types/tool.rs
+++ b/crates/orbit-common/src/types/tool.rs
@@ -1,6 +1,20 @@
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ToolSessionContext {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub workspace: Option<String>,
+}
+
+impl ToolSessionContext {
+    pub fn with_workspace(workspace: impl Into<String>) -> Self {
+        Self {
+            workspace: Some(workspace.into()),
+        }
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ToolParam {
     pub name: String,

--- a/crates/orbit-core/src/command/tool.rs
+++ b/crates/orbit-core/src/command/tool.rs
@@ -4,7 +4,8 @@ use std::time::Instant;
 
 use orbit_common::types::{
     AuditEventStatus, NotFoundKind, OrbitError, OrbitEvent, Role, StoredTool, ToolParam,
-    audit_execution_id, normalize_agent_family_for_model, normalize_optional_attribution_label,
+    ToolSessionContext, audit_execution_id, normalize_agent_family_for_model,
+    normalize_optional_attribution_label,
 };
 use orbit_store::AuditEventInsertParams;
 use orbit_tools::{ReservationOwnerContext, ToolContext};
@@ -121,6 +122,25 @@ impl OrbitRuntime {
         model_override: Option<String>,
         entry_point: ToolEntryPoint,
     ) -> Result<ToolDispatchOutcome, OrbitError> {
+        self.execute_tool_command_dispatch_with_session_context(
+            name,
+            input,
+            agent_override,
+            model_override,
+            entry_point,
+            ToolSessionContext::default(),
+        )
+    }
+
+    pub fn execute_tool_command_dispatch_with_session_context(
+        &self,
+        name: &str,
+        input: Value,
+        agent_override: Option<String>,
+        model_override: Option<String>,
+        entry_point: ToolEntryPoint,
+        session_context: ToolSessionContext,
+    ) -> Result<ToolDispatchOutcome, OrbitError> {
         let start = Instant::now();
         let role_label =
             audit_role_label(&input, agent_override.as_deref(), model_override.as_deref());
@@ -144,6 +164,7 @@ impl OrbitRuntime {
                 .map(|path| path.to_string_lossy().into_owned());
             let tool_context = ToolContext {
                 cwd,
+                session_context,
                 allowed_tools,
                 agent_name,
                 model_name,

--- a/crates/orbit-core/src/runtime/orbit_tool_host/tests/task_tools.rs
+++ b/crates/orbit-core/src/runtime/orbit_tool_host/tests/task_tools.rs
@@ -1,9 +1,40 @@
 use std::fs;
+use std::path::{Path, PathBuf};
+use std::sync::{Mutex, MutexGuard, OnceLock};
 
-use orbit_common::types::TaskStatus;
+use orbit_common::types::{TaskStatus, ToolSessionContext};
+use orbit_store::sqlite::task_registry::read_workspace_config;
 use serde_json::{Value, json};
 
 use super::super::test_support::{create_task, invalid_input_message, test_runtime};
+use crate::command::tool::ToolEntryPoint;
+
+struct CurrentDirGuard {
+    _guard: MutexGuard<'static, ()>,
+    previous: PathBuf,
+}
+
+impl CurrentDirGuard {
+    fn enter(path: &Path) -> Self {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        let guard = LOCK
+            .get_or_init(|| Mutex::new(()))
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let previous = std::env::current_dir().expect("capture cwd");
+        std::env::set_current_dir(path).expect("enter test cwd");
+        Self {
+            _guard: guard,
+            previous,
+        }
+    }
+}
+
+impl Drop for CurrentDirGuard {
+    fn drop(&mut self) {
+        std::env::set_current_dir(&self.previous).expect("restore cwd");
+    }
+}
 
 fn assert_task_titles(output: &Value, expected: &[&str]) {
     let mut titles = output
@@ -98,6 +129,50 @@ fn task_add_tool_creates_proposed_tasks_for_agents() {
     assert_eq!(
         output.get("status").and_then(Value::as_str),
         Some("proposed")
+    );
+}
+
+#[test]
+fn mcp_task_add_uses_session_workspace_from_worktree_cwd() {
+    let (_root, runtime, repo_root) = test_runtime();
+    let worktree_cwd = repo_root
+        .join(".orbit")
+        .join("state")
+        .join("worktrees")
+        .join("orbit-jrun-test")
+        .join("nested");
+    fs::create_dir_all(&worktree_cwd).expect("create worktree cwd");
+    let _cwd = CurrentDirGuard::enter(&worktree_cwd);
+    let workspace_config =
+        read_workspace_config(&repo_root.join(".orbit")).expect("read canonical workspace config");
+    let repo_root_string = repo_root.to_string_lossy().into_owned();
+
+    let output = runtime
+        .execute_tool_command_dispatch_with_session_context(
+            "orbit.task.add",
+            json!({
+                "title": "Ambient worktree task",
+                "description": "Session workspace must beat process cwd."
+            }),
+            Some("codex".to_string()),
+            Some("gpt-5.5".to_string()),
+            ToolEntryPoint::Mcp,
+            ToolSessionContext::with_workspace(repo_root_string.clone()),
+        )
+        .expect("task add tool succeeds")
+        .value;
+
+    let task_id = output["id"].as_str().expect("task id");
+    assert!(
+        runtime
+            .global_root()
+            .join("tasks")
+            .join("workspaces")
+            .join(workspace_config.workspace_id)
+            .join(task_id)
+            .join("task.yaml")
+            .exists(),
+        "task bundle must be under the canonical workspace id"
     );
 }
 

--- a/crates/orbit-mcp/src/adapter/dispatch.rs
+++ b/crates/orbit-mcp/src/adapter/dispatch.rs
@@ -1,12 +1,12 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use orbit_common::types::{OrbitError, ToolSchema};
+use orbit_common::types::{OrbitError, ToolSchema, ToolSessionContext};
 use rmcp::ErrorData as McpError;
 use rmcp::ServerHandler;
 use rmcp::model::{
-    CallToolRequestParams, CallToolResult, Implementation, InitializeResult, ListToolsResult,
-    PaginatedRequestParams, ServerCapabilities, ServerInfo,
+    CallToolRequestParams, CallToolResult, Implementation, InitializeRequestParams,
+    InitializeResult, ListToolsResult, PaginatedRequestParams, ServerCapabilities, ServerInfo,
 };
 use rmcp::service::{RequestContext, RoleServer};
 use serde_json::{Map, Value};
@@ -46,6 +46,19 @@ impl OrbitToolServer {
         }
     }
 
+    pub(super) fn replace_session_context(&self, session_context: ToolSessionContext) {
+        if let Ok(mut guard) = self.session_context.write() {
+            *guard = session_context;
+        }
+    }
+
+    pub(super) fn session_context(&self) -> ToolSessionContext {
+        self.session_context
+            .read()
+            .map(|guard| guard.clone())
+            .unwrap_or_default()
+    }
+
     pub(super) fn canonical_name(&self, advertised: &str) -> Result<String, ToolNameCollision> {
         let schemas = self.host.list_tool_schemas();
         let map = match build_name_map(&schemas) {
@@ -75,8 +88,11 @@ impl OrbitToolServer {
 
         let host = Arc::clone(&self.host);
         let exec_name = canonical.clone();
+        let session_context = self.session_context();
         let input_for_learning = input.clone();
-        let join = tokio::task::spawn_blocking(move || host.call_tool(&exec_name, input)).await;
+        let join =
+            tokio::task::spawn_blocking(move || host.call_tool(&exec_name, input, session_context))
+                .await;
 
         match join {
             Ok(Ok(value)) => {
@@ -97,6 +113,18 @@ impl OrbitToolServer {
 }
 
 impl ServerHandler for OrbitToolServer {
+    fn initialize(
+        &self,
+        request: InitializeRequestParams,
+        context: RequestContext<RoleServer>,
+    ) -> impl std::future::Future<Output = Result<InitializeResult, McpError>> + Send + '_ {
+        self.replace_session_context(session_context_from_initialize(&request));
+        if context.peer.peer_info().is_none() {
+            context.peer.set_peer_info(request);
+        }
+        std::future::ready(Ok(self.get_info()))
+    }
+
     fn get_info(&self) -> ServerInfo {
         let implementation = Implementation::new("orbit-mcp", env!("CARGO_PKG_VERSION"));
         let capabilities = ServerCapabilities::builder().enable_tools().build();
@@ -129,4 +157,25 @@ impl ServerHandler for OrbitToolServer {
     ) -> Result<CallToolResult, McpError> {
         self.call_tool_request(req).await
     }
+}
+
+pub(super) fn session_context_from_initialize(
+    request: &InitializeRequestParams,
+) -> ToolSessionContext {
+    // ADR-0181: clients deliberately announce workspace through initialize `_meta`.
+    let workspace = request
+        .meta
+        .as_ref()
+        .and_then(|meta| {
+            meta.0
+                .get("orbit")
+                .and_then(|orbit| orbit.get("workspace"))
+                .or_else(|| meta.0.get("orbit.workspace"))
+                .and_then(Value::as_str)
+        })
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned);
+
+    ToolSessionContext { workspace }
 }

--- a/crates/orbit-mcp/src/adapter/learning_sidecar.rs
+++ b/crates/orbit-mcp/src/adapter/learning_sidecar.rs
@@ -2,7 +2,7 @@ use std::collections::BTreeMap;
 use std::sync::Arc;
 
 use orbit_common::types::{
-    LearningInjectionCaps, LearningInjectionState, LearningReminder, OrbitError,
+    LearningInjectionCaps, LearningInjectionState, LearningReminder, OrbitError, ToolSessionContext,
 };
 use orbit_common::utility::learning_session::{
     learning_session_state_path, read_learning_session_state, update_learning_session_state,
@@ -31,9 +31,11 @@ impl OrbitToolServer {
 
         let host = Arc::clone(&self.host);
         let caps = self.learning_caps;
-        let join =
-            tokio::task::spawn_blocking(move || search_learning_reminders(&*host, &paths, caps))
-                .await;
+        let session_context = self.session_context();
+        let join = tokio::task::spawn_blocking(move || {
+            search_learning_reminders(&*host, &paths, caps, session_context)
+        })
+        .await;
         let reminders = match join {
             Ok(Ok(reminders)) => reminders,
             Ok(Err(error)) => {
@@ -207,6 +209,7 @@ fn search_learning_reminders(
     host: &dyn McpHost,
     paths: &[String],
     caps: LearningInjectionCaps,
+    session_context: ToolSessionContext,
 ) -> Result<Vec<LearningReminder>, OrbitError> {
     // ORB-00202: per-domain `orbit.learning.search` was retired; the
     // applicability lookup re-homed onto `orbit.learning.list` with glob-
@@ -218,6 +221,7 @@ fn search_learning_reminders(
             json!({
                 "path": path,
             }),
+            session_context.clone(),
         )?;
         for candidate in parse_learning_list_candidates(&value) {
             by_id

--- a/crates/orbit-mcp/src/adapter/mod.rs
+++ b/crates/orbit-mcp/src/adapter/mod.rs
@@ -19,7 +19,7 @@ mod tests;
 use std::collections::HashMap;
 use std::sync::{Arc, RwLock};
 
-use orbit_common::types::{LearningInjectionCaps, LearningInjectionState};
+use orbit_common::types::{LearningInjectionCaps, LearningInjectionState, ToolSessionContext};
 
 use self::learning_sidecar::load_learning_state_for_session;
 use crate::McpHost;
@@ -44,6 +44,7 @@ use crate::McpHost;
 pub struct OrbitToolServer {
     host: Arc<dyn McpHost>,
     name_map: RwLock<HashMap<String, String>>,
+    session_context: RwLock<ToolSessionContext>,
     learning_session_id: Option<String>,
     learning_caps: LearningInjectionCaps,
     learning_states: tokio::sync::Mutex<HashMap<String, LearningInjectionState>>,
@@ -68,6 +69,7 @@ impl OrbitToolServer {
         Self {
             host,
             name_map: RwLock::new(HashMap::new()),
+            session_context: RwLock::new(ToolSessionContext::default()),
             learning_session_id,
             learning_caps,
             learning_states: tokio::sync::Mutex::new(learning_states),
@@ -89,6 +91,7 @@ impl OrbitToolServer {
         Self {
             host,
             name_map: RwLock::new(HashMap::new()),
+            session_context: RwLock::new(ToolSessionContext::default()),
             learning_session_id,
             learning_caps,
             learning_states: tokio::sync::Mutex::new(learning_states),

--- a/crates/orbit-mcp/src/adapter/test_support.rs
+++ b/crates/orbit-mcp/src/adapter/test_support.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use std::sync::Mutex as StdMutex;
 
-use orbit_common::types::{OrbitError, ToolParam, ToolSchema};
+use orbit_common::types::{OrbitError, ToolParam, ToolSchema, ToolSessionContext};
 use rmcp::model::CallToolRequestParams;
 use serde_json::{Value, json};
 
@@ -48,7 +48,12 @@ impl crate::McpHost for StubHost {
         self.schemas.clone()
     }
 
-    fn call_tool(&self, _name: &str, _input: Value) -> Result<Value, OrbitError> {
+    fn call_tool(
+        &self,
+        _name: &str,
+        _input: Value,
+        _session_context: ToolSessionContext,
+    ) -> Result<Value, OrbitError> {
         Ok(Value::Null)
     }
 }
@@ -62,7 +67,12 @@ impl crate::McpHost for EchoArrayHost {
         self.schemas.clone()
     }
 
-    fn call_tool(&self, name: &str, _input: Value) -> Result<Value, OrbitError> {
+    fn call_tool(
+        &self,
+        name: &str,
+        _input: Value,
+        _session_context: ToolSessionContext,
+    ) -> Result<Value, OrbitError> {
         Ok(json!([{ "tool": name }]))
     }
 }
@@ -93,7 +103,12 @@ impl crate::McpHost for LearningSidecarHost {
         ]
     }
 
-    fn call_tool(&self, name: &str, input: Value) -> Result<Value, OrbitError> {
+    fn call_tool(
+        &self,
+        name: &str,
+        input: Value,
+        _session_context: ToolSessionContext,
+    ) -> Result<Value, OrbitError> {
         self.calls
             .lock()
             .expect("calls lock")
@@ -133,6 +148,50 @@ impl LearningPersistenceHost {
     }
 }
 
+#[derive(Default)]
+pub(super) struct SessionContextHost {
+    calls: StdMutex<Vec<(String, Value, ToolSessionContext)>>,
+}
+
+impl SessionContextHost {
+    pub(super) fn calls(&self) -> Vec<(String, Value, ToolSessionContext)> {
+        self.calls.lock().expect("calls lock").clone()
+    }
+}
+
+impl crate::McpHost for SessionContextHost {
+    fn list_tool_schemas(&self) -> Vec<ToolSchema> {
+        vec![
+            tool_schema("orbit.task.list"),
+            tool_schema("orbit.task.add"),
+        ]
+    }
+
+    fn call_tool(
+        &self,
+        name: &str,
+        input: Value,
+        session_context: ToolSessionContext,
+    ) -> Result<Value, OrbitError> {
+        let effective_workspace = input
+            .get("workspace")
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(ToOwned::to_owned)
+            .or_else(|| session_context.workspace.clone());
+        self.calls.lock().expect("calls lock").push((
+            name.to_string(),
+            input.clone(),
+            session_context.clone(),
+        ));
+        Ok(json!({
+            "tool": name,
+            "effective_workspace": effective_workspace,
+        }))
+    }
+}
+
 impl crate::McpHost for LearningPersistenceHost {
     fn list_tool_schemas(&self) -> Vec<ToolSchema> {
         vec![
@@ -142,7 +201,12 @@ impl crate::McpHost for LearningPersistenceHost {
         ]
     }
 
-    fn call_tool(&self, name: &str, input: Value) -> Result<Value, OrbitError> {
+    fn call_tool(
+        &self,
+        name: &str,
+        input: Value,
+        _session_context: ToolSessionContext,
+    ) -> Result<Value, OrbitError> {
         let canonical = if name.contains("learning.add") {
             "orbit.learning.add"
         } else if name.contains("learning.update") {

--- a/crates/orbit-mcp/src/adapter/tests/schema.rs
+++ b/crates/orbit-mcp/src/adapter/tests/schema.rs
@@ -1,11 +1,16 @@
 use std::sync::Arc;
 
+use orbit_common::types::ToolSessionContext;
+use rmcp::model::{ClientCapabilities, Implementation, InitializeRequestParams, Meta};
+
+use super::super::dispatch::session_context_from_initialize;
 use super::super::schema::{build_input_schema, property_for, schema_to_tool};
 use serde_json::{Value, json};
 
 use super::super::OrbitToolServer;
 use super::super::test_support::{
-    LearningPersistenceHost, param, param_with_type, request_with_args, tool_schema,
+    LearningPersistenceHost, SessionContextHost, param, param_with_type, request_with_args,
+    tool_schema,
 };
 
 #[test]
@@ -80,6 +85,60 @@ fn task_dependency_schemas_accept_string_or_string_array() {
             .any(|schema| schema.get("type").and_then(Value::as_str) == Some("string")),
         "orbit.task.update dependencies must accept a string"
     );
+}
+
+fn initialize_params_with_meta(meta: Value) -> InitializeRequestParams {
+    let mut params = InitializeRequestParams::new(
+        ClientCapabilities::default(),
+        Implementation::new("orbit-test-client", "0"),
+    );
+    let Value::Object(object) = meta else {
+        panic!("test meta must be an object");
+    };
+    params.meta = Some(Meta(object));
+    params
+}
+
+#[test]
+fn initialize_meta_extracts_orbit_workspace_session_context() {
+    let params = initialize_params_with_meta(json!({
+        "orbit": {
+            "workspace": " /repo/main "
+        }
+    }));
+
+    let session_context = session_context_from_initialize(&params);
+
+    assert_eq!(session_context.workspace.as_deref(), Some("/repo/main"));
+}
+
+#[tokio::test]
+async fn mcp_session_context_reaches_tool_calls_without_workspace_input() {
+    let host = Arc::new(SessionContextHost::default());
+    let server = OrbitToolServer::new(host.clone());
+    server.replace_session_context(ToolSessionContext::with_workspace("/repo/main"));
+
+    let explicit = server
+        .call_tool_request(request_with_args(
+            "orbit.task.list",
+            json!({ "workspace": "/repo/main" }),
+        ))
+        .await
+        .expect("explicit workspace call succeeds")
+        .structured_content
+        .expect("explicit structured content");
+    let ambient = server
+        .call_tool_request(request_with_args("orbit.task.list", json!({})))
+        .await
+        .expect("ambient workspace call succeeds")
+        .structured_content
+        .expect("ambient structured content");
+
+    assert_eq!(ambient, explicit);
+    let calls = host.calls();
+    assert_eq!(calls.len(), 2);
+    assert_eq!(calls[1].2.workspace.as_deref(), Some("/repo/main"));
+    assert!(calls[1].1.get("workspace").is_none());
 }
 
 // --- ORB-00102 tests: object_list schema + loud fallback + e2e via MCP adapter ---

--- a/crates/orbit-mcp/src/lib.rs
+++ b/crates/orbit-mcp/src/lib.rs
@@ -38,7 +38,7 @@ mod error;
 
 use std::sync::Arc;
 
-use orbit_common::types::{OrbitError, ToolSchema};
+use orbit_common::types::{OrbitError, ToolSchema, ToolSessionContext};
 use rmcp::ServiceExt;
 use rmcp::transport::io::stdio;
 use serde_json::Value;
@@ -54,7 +54,12 @@ pub use adapter::OrbitToolServer;
 /// wants applied; the adapter will never bypass it.
 pub trait McpHost: Send + Sync + 'static {
     fn list_tool_schemas(&self) -> Vec<ToolSchema>;
-    fn call_tool(&self, name: &str, input: Value) -> Result<Value, OrbitError>;
+    fn call_tool(
+        &self,
+        name: &str,
+        input: Value,
+        session_context: ToolSessionContext,
+    ) -> Result<Value, OrbitError>;
 }
 
 /// Serve the given [`McpHost`] over an MCP stdio transport.

--- a/crates/orbit-tools/src/builtin/orbit/mod.rs
+++ b/crates/orbit-tools/src/builtin/orbit/mod.rs
@@ -240,6 +240,63 @@ pub(super) fn execute_host_action(
     )
 }
 
+pub(super) fn resolve_workspace_argument(
+    ctx: &ToolContext,
+    input: &mut Value,
+    tool_name: &str,
+) -> Result<String, OrbitError> {
+    // ADR-0181: MCP workspace defaults come from explicit session context, never process cwd.
+    let explicit = optional_string_alias(input, &["workspace"])?;
+    let session = ctx
+        .session_context
+        .workspace
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned);
+
+    match (explicit, session) {
+        (Some(workspace), Some(session_workspace)) => {
+            if workspace != session_workspace {
+                tracing::info!(
+                    target: "orbit.tools.workspace",
+                    tool_name,
+                    explicit_workspace = %workspace,
+                    session_workspace = %session_workspace,
+                    "explicit workspace overrides MCP session context"
+                );
+            }
+            set_input_workspace(input, &workspace)?;
+            Ok(workspace)
+        }
+        (Some(workspace), None) => {
+            set_input_workspace(input, &workspace)?;
+            Ok(workspace)
+        }
+        (None, Some(workspace)) => {
+            set_input_workspace(input, &workspace)?;
+            Ok(workspace)
+        }
+        (None, None) => Err(OrbitError::InvalidInput(
+            "missing `workspace`; provide it explicitly or initialize the MCP session with `_meta.orbit.workspace`"
+                .to_string(),
+        )),
+    }
+}
+
+fn set_input_workspace(input: &mut Value, workspace: &str) -> Result<(), OrbitError> {
+    let Some(object) = input.as_object_mut() else {
+        return Err(OrbitError::InvalidInput(
+            "tool input must be a JSON object".to_string(),
+        ));
+    };
+    object.insert(
+        "workspace".to_string(),
+        Value::String(workspace.to_string()),
+    );
+    Ok(())
+}
+
 pub(super) fn task_scope(ctx: &ToolContext) -> OrbitTaskScope {
     ctx.orbit_host
         .as_ref()

--- a/crates/orbit-tools/src/builtin/orbit/task/add.rs
+++ b/crates/orbit-tools/src/builtin/orbit/task/add.rs
@@ -23,13 +23,13 @@ impl Tool for OrbitTaskAddTool {
                 required: true,
             },
             // ADR-0149: `workspace` is the binding key for ~/.orbit/tasks/workspaces/<id>/
-            // home-store projection; defaulting to cwd would silently misroute tasks under
-            // worktrees, subdirectories, or non-default `workspace_id` in .orbit/config.yaml.
+            // home-store projection; ambient MCP session context may supply this field,
+            // but process cwd must never be used as the fallback.
             ToolParam {
                 name: "workspace".to_string(),
                 description: "Workspace path for the task".to_string(),
                 param_type: "string".to_string(),
-                required: true,
+                required: false,
             },
             ToolParam {
                 name: "acceptance_criteria".to_string(),
@@ -93,7 +93,7 @@ impl Tool for OrbitTaskAddTool {
         super::super::reject_agent_field(&input, "orbit.task.add")?;
         required_string(&input, &["title"], "title")?;
         required_string(&input, &["description"], "description")?;
-        required_string(&input, &["workspace"], "workspace")?;
+        super::super::resolve_workspace_argument(ctx, &mut input, "orbit.task.add")?;
 
         let ignored_fields = strip_retired_task_add_input_fields(&mut input);
         if !ignored_fields.is_empty() {

--- a/crates/orbit-tools/src/builtin/orbit/task/tests/add.rs
+++ b/crates/orbit-tools/src/builtin/orbit/task/tests/add.rs
@@ -4,7 +4,7 @@ use std::sync::{Arc, Mutex};
 
 use serde_json::{Value, json};
 
-use orbit_common::types::{OrbitError, RETIRED_TASK_ADD_INPUT_FIELDS};
+use orbit_common::types::{OrbitError, RETIRED_TASK_ADD_INPUT_FIELDS, ToolSessionContext};
 
 use super::super::add::OrbitTaskAddTool;
 use crate::{OrbitBuiltinAction, OrbitTaskScope, OrbitToolHost, Tool, ToolContext};
@@ -101,6 +101,51 @@ where
     (result, logs)
 }
 
+fn capture_info<F, T>(f: F) -> (T, String)
+where
+    F: FnOnce() -> T,
+{
+    use std::io::{self, Write};
+    use tracing_subscriber::filter::LevelFilter;
+    use tracing_subscriber::fmt::MakeWriter;
+
+    #[derive(Clone)]
+    struct CaptureMakeWriter(Arc<Mutex<Vec<u8>>>);
+    struct CaptureWriter(Arc<Mutex<Vec<u8>>>);
+
+    impl<'a> MakeWriter<'a> for CaptureMakeWriter {
+        type Writer = CaptureWriter;
+
+        fn make_writer(&'a self) -> Self::Writer {
+            CaptureWriter(Arc::clone(&self.0))
+        }
+    }
+
+    impl Write for CaptureWriter {
+        fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+            self.0.lock().expect("capture lock").extend_from_slice(buf);
+            Ok(buf.len())
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
+
+    let buffer = Arc::new(Mutex::new(Vec::new()));
+    let subscriber = tracing_subscriber::fmt()
+        .with_writer(CaptureMakeWriter(Arc::clone(&buffer)))
+        .with_max_level(LevelFilter::INFO)
+        .with_target(true)
+        .with_ansi(false)
+        .without_time()
+        .finish();
+    let result = tracing::subscriber::with_default(subscriber, f);
+    let logs =
+        String::from_utf8(buffer.lock().expect("capture buffer lock").clone()).expect("utf8 logs");
+    (result, logs)
+}
+
 #[test]
 fn schema_exposes_only_trimmed_create_task_fields() {
     let schema = OrbitTaskAddTool.schema();
@@ -129,7 +174,13 @@ fn schema_exposes_only_trimmed_create_task_fields() {
         .filter(|param| param.required)
         .map(|param| param.name.as_str())
         .collect();
-    assert_eq!(required, vec!["title", "description", "workspace"]);
+    assert_eq!(required, vec!["title", "description"]);
+    let workspace = schema
+        .parameters
+        .iter()
+        .find(|param| param.name == "workspace")
+        .expect("workspace param");
+    assert!(!workspace.required);
 
     for removed in RETIRED_TASK_ADD_INPUT_FIELDS {
         assert!(
@@ -249,6 +300,65 @@ fn add_call_with_retired_fields_warns_once_and_ignores_them() {
 }
 
 #[test]
+fn add_call_uses_session_workspace_when_input_omits_workspace() {
+    let host = RecordingHost::default();
+    let mut ctx = mk_ctx(host.clone());
+    ctx.session_context = ToolSessionContext::with_workspace("/tmp/canonical-ws");
+    let tool = OrbitTaskAddTool;
+
+    tool.execute(
+        &ctx,
+        json!({
+            "title": "Ambient workspace test",
+            "description": "MCP session context supplies workspace",
+            "model": "codex"
+        }),
+    )
+    .expect("session workspace should satisfy workspace");
+
+    let recorded = host
+        .call
+        .lock()
+        .expect("lock")
+        .take()
+        .expect("host was called");
+    assert_eq!(recorded.input["workspace"], "/tmp/canonical-ws");
+}
+
+#[test]
+fn explicit_workspace_overrides_mismatched_session_workspace() {
+    let host = RecordingHost::default();
+    let mut ctx = mk_ctx(host.clone());
+    ctx.session_context = ToolSessionContext::with_workspace("/tmp/session-ws");
+    let tool = OrbitTaskAddTool;
+
+    let (_res, logs) = capture_info(|| {
+        tool.execute(
+            &ctx,
+            json!({
+                "title": "Explicit workspace wins",
+                "description": "The caller can override session context",
+                "workspace": "/tmp/explicit-ws",
+                "model": "codex"
+            }),
+        )
+        .expect("explicit workspace should win")
+    });
+
+    let recorded = host
+        .call
+        .lock()
+        .expect("lock")
+        .take()
+        .expect("host was called");
+    assert_eq!(recorded.input["workspace"], "/tmp/explicit-ws");
+    assert!(
+        logs.contains("explicit workspace overrides MCP session context"),
+        "mismatch should be logged at info level: {logs}"
+    );
+}
+
+#[test]
 fn add_call_missing_required_fields_returns_required_field_error() {
     let cases = [
         (
@@ -263,13 +373,6 @@ fn add_call_missing_required_fields_returns_required_field_error() {
             json!({
                 "title": "missing description",
                 "workspace": "/tmp/test-ws"
-            }),
-        ),
-        (
-            "workspace",
-            json!({
-                "title": "missing workspace",
-                "description": "missing workspace"
             }),
         ),
     ];
@@ -291,4 +394,30 @@ fn add_call_missing_required_fields_returns_required_field_error() {
             "host must not be called when {missing} is missing"
         );
     }
+}
+
+#[test]
+fn add_call_missing_workspace_without_session_context_returns_clear_error() {
+    let host = RecordingHost::default();
+    let ctx = mk_ctx(host.clone());
+    let err = OrbitTaskAddTool
+        .execute(
+            &ctx,
+            json!({
+                "title": "missing workspace",
+                "description": "missing workspace"
+            }),
+        )
+        .expect_err("missing workspace and session context should fail");
+    match err {
+        OrbitError::InvalidInput(message) => {
+            assert!(message.contains("missing `workspace`"), "{message}");
+            assert!(message.contains("MCP session"), "{message}");
+        }
+        other => panic!("unexpected error for missing workspace: {other}"),
+    }
+    assert!(
+        host.call.lock().expect("lock").is_none(),
+        "host must not be called when workspace cannot be resolved"
+    );
 }

--- a/crates/orbit-tools/src/builtin/orbit/tests/identity.rs
+++ b/crates/orbit-tools/src/builtin/orbit/tests/identity.rs
@@ -19,6 +19,7 @@ fn runtime_identity_overwrites_self_reported_model_at_tool_boundary() {
 fn tool_context(agent: &str, model: &str) -> ToolContext {
     ToolContext {
         cwd: None,
+        session_context: Default::default(),
         allowed_tools: Vec::new(),
         workspace_root: None,
         agent_name: Some(agent.to_string()),

--- a/crates/orbit-tools/src/lib.rs
+++ b/crates/orbit-tools/src/lib.rs
@@ -193,6 +193,8 @@ pub struct ReservationOwnerContext {
 #[derive(Clone, Default)]
 pub struct ToolContext {
     pub cwd: Option<String>,
+    /// Ambient metadata asserted by the transport/session, not by tool input.
+    pub session_context: orbit_common::types::ToolSessionContext,
     /// If non-empty, only tools in this list may be called. Empty means unrestricted.
     pub allowed_tools: Vec<String>,
     /// When set, fs tools enforce that all paths resolve inside this directory.
@@ -232,6 +234,7 @@ impl std::fmt::Debug for ToolContext {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("ToolContext")
             .field("cwd", &self.cwd)
+            .field("session_context", &self.session_context)
             .field("allowed_tools", &self.allowed_tools)
             .field("workspace_root", &self.workspace_root)
             .field("agent_name", &self.agent_name)

--- a/docs/design/mcp-session-context/1_overview.md
+++ b/docs/design/mcp-session-context/1_overview.md
@@ -1,0 +1,52 @@
+---
+summary: "MCP Session Context — Overview"
+type: design
+title: "MCP Session Context — Overview"
+owner: codex
+last_updated: 2026-05-22
+status: Draft
+feature: mcp-session-context
+doc_role: overview
+tags: ["mcp-session-context", "mcp", "workspace"]
+paths: ["crates/orbit-mcp/**", "crates/orbit-tools/**", "crates/orbit-core/src/command/tool.rs", "crates/orbit-cli/src/command/mcp/**"]
+related_features: ["mcp-session-context", "task-artifacts"]
+related_artifacts: ["ORB-00256", "ADR-0181", "ADR-0149"]
+---
+
+# MCP Session Context — Overview
+
+MCP session context lets an MCP client announce the canonical Orbit workspace once during session initialization so workspace-taking tools can behave more like CLI commands without falling back to unsafe process cwd inference. The first use is workspace resolution for `orbit.task.add`, preserving the workspace-id binding invariant from [ADR-0149] while removing repeated per-call boilerplate for MCP clients.
+
+This document is the entry point. [2_design.md](./2_design.md) describes the live mechanism, [3_vision.md](./3_vision.md) records open questions, and [4_decisions.md](./4_decisions.md) captures the ADR log.
+
+---
+
+## 1. Motivation
+
+Orbit CLI commands can resolve workspace from the user's cwd because the process runs in the user's shell. MCP servers do not have that guarantee: the server cwd is wherever the client launched `orbit mcp serve`, while the agent may be working in a canonical checkout, a nested subdirectory, or an Orbit-managed worktree.
+
+Before [ORB-00256], every MCP call to `orbit.task.add` had to pass `workspace`. That avoided silent misroutes, but it made tool calls noisy and encouraged schema trimming before a safe default existed. Session context gives MCP a deliberate ambient channel: the client says which workspace it means, Orbit stores that for the session, and tool calls can omit `workspace` only when that deliberate signal exists.
+
+## 2. Core Concepts
+
+**Session context** is transport-owned metadata, not model-authored tool input. For MCP, it is parsed from `initialize.params._meta.orbit.workspace` and stored on `OrbitToolServer` for the stdio server session.
+
+**Workspace resolution** is the tool-level rule: explicit `workspace` input wins, then session context, then a clear `missing workspace` error. Process cwd is not part of the chain.
+
+**Binding invariant** remains owned by [ADR-0149]. The durable task binding key is still `.orbit/config.yaml`'s `workspace_id`; session context changes only how MCP calls name the intended workspace path.
+
+## 3. At a Glance
+
+| Concern | File | Task |
+|---|---|---|
+| MCP initialization parsing | `crates/orbit-mcp/src/adapter/dispatch.rs` | [ORB-00256] |
+| Session metadata DTO | `crates/orbit-common/src/types/tool.rs` | [ORB-00256] |
+| Runtime dispatch thread-through | `crates/orbit-core/src/command/tool.rs` | [ORB-00256] |
+| MCP host wiring | `crates/orbit-cli/src/command/mcp/mod.rs` | [ORB-00256] |
+| Tool workspace resolution | `crates/orbit-tools/src/builtin/orbit/mod.rs` | [ORB-00256] |
+
+## Task References
+
+- [ORB-00256] implemented MCP ambient workspace session context.
+
+Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.

--- a/docs/design/mcp-session-context/2_design.md
+++ b/docs/design/mcp-session-context/2_design.md
@@ -1,0 +1,70 @@
+---
+summary: "MCP Session Context — Design"
+type: design
+title: "MCP Session Context — Design"
+owner: codex
+last_updated: 2026-05-22
+status: Draft
+feature: mcp-session-context
+doc_role: design
+tags: ["mcp-session-context", "mcp", "workspace"]
+paths: ["crates/orbit-mcp/**", "crates/orbit-tools/**", "crates/orbit-core/src/command/tool.rs", "crates/orbit-cli/src/command/mcp/**"]
+related_features: ["mcp-session-context", "task-artifacts"]
+related_artifacts: ["ORB-00256", "ADR-0181", "ADR-0149"]
+---
+
+# MCP Session Context — Design
+
+MCP session context is a narrow metadata channel from the MCP initialize request to Orbit built-in tools. Its first field is the canonical workspace path used by workspace-taking tools.
+
+---
+
+## 1. Initialize Metadata
+
+Clients announce workspace with:
+
+```json
+{
+  "_meta": {
+    "orbit": {
+      "workspace": "/absolute/path/to/repo"
+    }
+  }
+}
+```
+
+`orbit-mcp` also accepts the compatibility key `_meta["orbit.workspace"]`. Empty strings are ignored, so a client that does not announce workspace behaves the same as an older client.
+
+## 2. Storage And Thread-Through
+
+`OrbitToolServer` stores a `ToolSessionContext` in an `RwLock` for the lifetime of the stdio session. Each `tools/call` snapshots that context and passes it to `McpHost::call_tool`.
+
+The CLI `RuntimeMcpHost` forwards the context into `OrbitRuntime::execute_tool_command_dispatch_with_session_context`, which places it on `ToolContext`. Orbit built-ins read it from `ToolContext`, not from environment variables or cwd.
+
+## 3. Workspace Resolution
+
+`crates/orbit-tools/src/builtin/orbit/mod.rs` owns the shared resolver:
+
+1. If the tool input has a non-empty `workspace`, use it.
+2. Else if `ToolContext.session_context.workspace` is non-empty, insert that value into the input passed to the runtime host.
+3. Else return a clear `missing workspace` error.
+
+When explicit input and session context differ, Orbit logs an info-level event and honors the explicit input. This preserves an operator escape hatch while making the mismatch visible in traces.
+
+## 4. Task Add
+
+`orbit.task.add` advertises `workspace` as optional over the tool schema while still accepting explicit callers unchanged. The host action still receives a concrete `workspace` field because the tool wrapper resolves or rejects before dispatch.
+
+This means existing explicit-workspace clients continue to work, while MCP clients with session context can call `orbit.task.add` without a `workspace` field.
+
+## 5. Concerns & Honest Limitations
+
+The session context currently covers stdio sessions; future HTTP or multi-session transports must preserve the same per-session isolation rather than promoting the value to process-global state.
+
+The channel carries a workspace path, not a workspace id. That keeps it compatible with the existing task-add API, but callers still depend on the workspace's `.orbit/config.yaml` binding to select the durable `workspace_id` from [ADR-0149].
+
+## Task References
+
+- [ORB-00256] implemented the initial session context channel and workspace resolver.
+
+Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.

--- a/docs/design/mcp-session-context/3_vision.md
+++ b/docs/design/mcp-session-context/3_vision.md
@@ -1,0 +1,54 @@
+---
+summary: "MCP Session Context — Vision"
+type: design
+title: "MCP Session Context — Vision"
+owner: codex
+last_updated: 2026-05-22
+status: Draft
+feature: mcp-session-context
+doc_role: vision
+tags: ["mcp-session-context", "mcp", "workspace"]
+paths: ["crates/orbit-mcp/**", "crates/orbit-tools/**", "crates/orbit-core/src/command/tool.rs", "crates/orbit-cli/src/command/mcp/**"]
+related_features: ["mcp-session-context", "task-artifacts"]
+related_artifacts: ["ORB-00256", "ADR-0181", "ADR-0149"]
+---
+
+# MCP Session Context — Vision
+
+Session context should stay small and deliberate: fields belong here only when they are session-scoped, trusted by the transport boundary, and safer than repeating low-signal inputs on every tool call.
+
+---
+
+## 1. Open Questions
+
+1. Should future MCP transports store context by transport session id rather than by server instance?
+2. Should workspace context eventually accept a workspace id as well as a path, or should the path remain the only MCP address and `.orbit/config.yaml` remain the binding source?
+3. Which additional low-noise fields, if any, are safe enough for session context rather than tool input?
+
+## 2. Prior Work
+
+### Task Artifacts
+
+[ADR-0149] established that `.orbit/config.yaml` stores the load-bearing `workspace_id` binding and that defaulting task writes from cwd can silently route to the wrong workspace.
+
+### MCP Schema Trimming
+
+[ORB-00255] motivated reducing repetitive tool fields, but workspace could not become optional until MCP had a deliberate ambient channel.
+
+## 3. What May Be Distinctive
+
+Orbit treats session context as a safety mechanism rather than a convenience cache. The resolver deliberately refuses to use process cwd, even when cwd would appear to work, because worktree and non-default binding cases are exactly where an implicit fallback is most dangerous.
+
+## 4. References
+
+- [ADR-0149] records the task-artifact workspace binding invariant.
+- [ADR-0181] records the MCP ambient workspace session context decision.
+- [ORB-00256] implemented the first session context field.
+- [ORB-00255] motivated the schema trimming pressure that made a safe default useful.
+
+## Task References
+
+- [ORB-00255] motivated reducing repetitive workspace boilerplate.
+- [ORB-00256] implemented the session context channel.
+
+Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.

--- a/docs/design/mcp-session-context/4_decisions.md
+++ b/docs/design/mcp-session-context/4_decisions.md
@@ -1,0 +1,40 @@
+---
+summary: "MCP Session Context — Decisions"
+type: design
+title: "MCP Session Context — Decisions"
+owner: codex
+last_updated: 2026-05-22
+status: Draft
+feature: mcp-session-context
+doc_role: decisions
+tags: ["mcp-session-context", "mcp", "workspace"]
+paths: ["crates/orbit-mcp/**", "crates/orbit-tools/**", "crates/orbit-core/src/command/tool.rs", "crates/orbit-cli/src/command/mcp/**"]
+related_features: ["mcp-session-context", "task-artifacts"]
+related_artifacts: ["ORB-00256", "ADR-0181", "ADR-0149"]
+---
+
+# MCP Session Context — Decisions
+
+ADR log for MCP session context. Format follows [docs/design/CONVENTIONS.md §4](../CONVENTIONS.md): each entry is `Context · Decision · Consequences`, every entry names at least one Cost, and numbers are append-only.
+
+---
+
+## ADR-0181 — MCP ambient workspace session context
+
+**Status:** Proposed · 2026-05 · [ORB-00256]
+
+**Context.** MCP tools need CLI-like workspace ergonomics, but [ADR-0149] makes process-cwd defaults unsafe because worktree cwd can bind to a different `workspace_id`. The viable alternatives were per-call workspace input forever, a one-shot workspace lookup tool that clients cache, or a deliberate session-level signal from the MCP client.
+
+**Decision.** MCP clients announce the canonical workspace path in `initialize.params._meta.orbit.workspace`. `orbit-mcp` stores that value in the server session context for the stdio session and passes it through `ToolSessionContext` into `ToolContext`; workspace-taking tools resolve explicit input first, then session context, then return a clear missing-workspace error. If explicit input and session context differ, the tool logs the mismatch at info level and honors explicit input.
+
+**Consequences.**
+- [ADR-0149] remains the `workspace_id` binding invariant; this ADR amends only how MCP calls address that binding.
+- `orbit.task.add` and future workspace-taking tools can make `workspace` optional without defaulting to process cwd.
+- Clients that cannot send initialize metadata can continue passing `workspace` explicitly.
+- Cost: Orbit now carries MCP session metadata across the adapter, CLI host, runtime dispatch, and tool context, so new host surfaces must preserve that thread-through path.
+
+## Task References
+
+- [ORB-00256] implemented MCP ambient workspace session context.
+
+Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.


### PR DESCRIPTION
## Task

[ORB-00256](https://orbit-cli.com/tasks/ORB-00256) — MCP: ambient session context so workspace can default safely

### Description

## Problem

`orbit.task.add` requires `workspace` as a mandatory parameter. The CLI does *not* require it — `orbit task add` resolves the workspace transparently via `OrbitRoot` (walks up from cwd, reads `.orbit/config.yaml`, returns the bound workspace path). The MCP/tool surface does not have this affordance because the MCP server's process cwd is not the agent's working directory; there is no ambient session context for the server to walk up from. Per [ADR-0149](.orbit/adrs/proposed/ADR-0149/body.md), defaulting `workspace` to process cwd is unsafe — this repo has worktrees under `.orbit/state/worktrees/orbit-jrun-*` whose paths resolve to different `workspace_id` bindings, and a silent default would route tasks to the worktree workspace instead of the canonical one.

The result is that every agent call to every workspace-taking tool re-passes the workspace string. That is mechanical friction without a corresponding safety benefit, *if* the agent is using an explicit ambient channel rather than process cwd.

## Why It Matters

This is the cheapest blocker between Orbit's MCP surface and the CLI's ergonomics. Agents authoring tasks (or running any other workspace-taking tool) carry `workspace` as boilerplate on every call, which is exactly the kind of repetitive low-signal field that the schema-trim discussion (see [ORB-00255](.orbit/tasks/ORB-00255.md)) is trying to eliminate. Removing it from add without solving the ambient-context problem first would resurrect the silent-misroute failure ADR-0149 explicitly guarded against. Solving the ambient-context problem first means `workspace` can become *optional* across the entire tool surface without giving up the misroute safety.

## Constraints / Notes

- Don't break ADR-0149's invariant: `workspace_id` is the durable binding key. The change is about *how the binding is named on a tool call*, not about *what the binding maps to*.
- Don't default to process cwd. The whole point is that cwd is ambiguous (worktree vs. canonical workspace). Ambient context must come from a *deliberate* signal the client sends.
- The session-context model is the destination. A cheaper intermediate — a read-only `orbit.workspace.current` tool that resolves and returns the canonical workspace path so agents can cache it for a session — was considered and rejected: it still forces every tool call to carry `workspace` as input. That trade is reasonable for a phase-1 if the session-context work is genuinely too large; if so, file the phase-1 as a follow-up. The default for this task is the destination shape.
- Precedence: explicit input always wins over session context. Mismatch (input says A, session says B) is logged but honored as the caller's intent — this gives operators an escape hatch and tools an audit trail.
- Out of scope: actually trimming `workspace` from the schemas. That's the *consequence* of this work, but lives in a follow-up so this task ships an additive capability (session context exists, workspace becomes optional in tool definitions, but the field is still accepted). The full schema removal pass can come after this lands and bakes.

## Open question (planner decides)

Where exactly does session-context attach in the MCP rmcp surface? Possible mechanisms: (a) an init parameter in the MCP `initialize` handshake, (b) a tool the client calls once per session to set context server-side, (c) per-call header/metadata. (a) is the cleanest if rmcp supports it; (c) is the most flexible but pushes complexity into every client. The planner should pick after a short rmcp surface-reading pass.

## Validation

The worktree regression test is the load-bearing check: prove that an agent running with cwd in a worktree subdir, but with session context pointing at the canonical workspace, can create a task that lands in the canonical workspace store and not the worktree store.

### Acceptance Criteria

- ADR proposed under docs/design/<feature>/4_decisions.md (allocate via orbit.adr.add) recording the chosen shape for MCP ambient session context: (a) what the client sends at session init (e.g., workspace path or workspace_id), (b) where the server stores it for the lifetime of the session, (c) how individual tool invocations resolve workspace when the field is absent from the input, (d) what happens when the client's announced workspace conflicts with an explicit workspace in a tool call (precedence: explicit input wins; mismatch is logged at info-level).
- MCP server in crates/orbit-mcp exposes a session-context channel matching the ADR's chosen shape. Concrete observable: a session that announces workspace at init can successfully call orbit.task.list with no workspace field in the JSON input and receive the same result as today's explicit-workspace call. A session that does not announce workspace and omits the field still gets a clear error (not a silent default to cwd, not a panic).
- OrbitTaskAddTool in crates/orbit-tools/src/builtin/orbit/task/add.rs marks workspace as optional (required: false) and the execute path resolves it from ambient session context when absent. Behavior: explicit input > session context > error. The misroute failure mode named in the [add.rs:59-61] comment (worktree subdir, repo with non-default workspace_id) is regression-tested: a session that announces workspace=/repo/main and a tool call from a worktree subdir still creates the task under the canonical workspace.
- Worktree regression test: launch orbit MCP from a process whose cwd is .orbit/state/worktrees/orbit-jrun-*, announce workspace=<canonical-orbit-root> at session init, call orbit.task.add without workspace, and assert the task is bound under the canonical workspace_id (read from canonical .orbit/config.yaml), not a worktree-derived id.
- All workspace-taking tools (use rg 'name: "workspace"' under crates/orbit-tools/src/builtin to enumerate the surface) consistently honor the same precedence rule. A single helper in orbit-tools resolves workspace from input | session_context | error and is called from each tool's execute path.
- Existing explicit-workspace callers continue to work unchanged. Concrete test: every existing test in crates/orbit-tools/src/builtin/orbit/task/tests/ that passes workspace explicitly still passes without modification.
- Documentation pass: docs/design/<feature>/ folder under docs/design/ following CONVENTIONS.md is created or updated to cover the session-context model. ADR-0149 is referenced (and either superseded or amended; planner decides which is correct given that the workspace_id binding semantics from -0149 do not change, only the way they are addressed from the MCP surface).
- make ci-fast and full cargo test -p orbit-mcp -p orbit-tools pass.

## Execution Summary

<details>
<summary>Click to expand</summary>

Implemented MCP ambient workspace session context for ORB-00256. Added ToolSessionContext in orbit-common, stored workspace from MCP initialize _meta.orbit.workspace (plus compatibility _meta["orbit.workspace"]) on OrbitToolServer, threaded it through McpHost, RuntimeMcpHost, OrbitRuntime dispatch, and ToolContext. Added the shared orbit-tools workspace resolver with explicit input > session context > clear error semantics and info-level mismatch logging, then made orbit.task.add workspace optional while preserving explicit callers. Added MCP adapter/tool/core regression coverage, including canonical-workspace task.add from a worktree cwd. Added docs/design/mcp-session-context and allocated ADR-0181 referencing ADR-0149 as an amended addressing model, not a changed workspace_id invariant. Validation: make ci-fast passed; cargo test -p orbit-mcp -p orbit-tools passed; cargo test -p orbit-core mcp_task_add_uses_session_workspace_from_worktree_cwd passed; cargo check -p orbit-cli --bin orbit passed. Also applied mechanical cargo fmt changes to unlisted orbit-core runtime files required by make ci-fast, with a scope comment recorded before the formatting change.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-00256-6a0fd2cf`
- Behind base: 0
- Ahead of base: 1

*authored by: codex*