### PR TITLE
Record failed pr_open handoffs on completed task branches

### DIFF
--- a/crates/orbit-engine/src/executor/automation/vcs/pr/open.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/pr/open.rs
@@ -1,4 +1,7 @@
-use orbit_common::types::{ExternalRef, OrbitError, Role, Task, TaskStatus};
+use std::path::Path;
+
+use chrono::Utc;
+use orbit_common::types::{ExternalRef, OrbitError, Role, Task, TaskComment, TaskStatus};
 use orbit_tools::ToolContext;
 use serde_json::{Value, json};
 
@@ -12,6 +15,8 @@ use super::super::freshness::ensure_branch_rebased_onto_base;
 use super::super::git::git_output;
 use super::attribution::pr_review_attribution;
 use super::body::{build_batch_pr_body, default_pr_title, meaningful_execution_summary};
+
+const FAILED_HANDOFF_ACTOR: &str = "system";
 
 pub(in crate::executor::automation) fn pr_open<H: RuntimeHost + TaskHost + Sync + ?Sized>(
     host: &H,
@@ -71,7 +76,23 @@ pub(crate) fn open_batch_pr<H: RuntimeHost + TaskHost + ?Sized>(
     let base_sync_mode = super::super::git::base_sync_mode_from_input(input)?;
 
     let rebase_outcome =
-        ensure_branch_rebased_onto_base(&workspace_path, &head, &base, base_sync_mode)?;
+        match ensure_branch_rebased_onto_base(&workspace_path, &head, &base, base_sync_mode) {
+            Ok(outcome) => outcome,
+            Err(error) => {
+                record_failed_handoff(
+                    host,
+                    &completed_tasks,
+                    batch_id,
+                    &workspace_path,
+                    &head,
+                    &base,
+                    None,
+                    FailedHandoffOp::Rebase,
+                    &error,
+                )?;
+                return Err(error);
+            }
+        };
     let freshness = rebase_outcome.freshness;
     let branch_was_rebased = rebase_outcome.rebased;
 
@@ -141,7 +162,7 @@ pub(crate) fn open_batch_pr<H: RuntimeHost + TaskHost + ?Sized>(
         ..Default::default()
     };
 
-    host.run_tool_with_context_and_role(
+    if let Err(error) = host.run_tool_with_context_and_role(
         "git.push",
         json!({
             "repo_root": workspace_path.to_string_lossy().to_string(),
@@ -150,9 +171,22 @@ pub(crate) fn open_batch_pr<H: RuntimeHost + TaskHost + ?Sized>(
         }),
         Role::Admin,
         tool_context.clone(),
-    )?;
+    ) {
+        record_failed_handoff(
+            host,
+            &completed_tasks,
+            batch_id,
+            &workspace_path,
+            &head,
+            &base,
+            Some(&freshness.base_ref),
+            FailedHandoffOp::Push,
+            &error,
+        )?;
+        return Err(error);
+    }
 
-    let pr_create = host.run_tool_with_context_and_role(
+    let pr_create = match host.run_tool_with_context_and_role(
         "github.pr.create",
         json!({
             "title": title,
@@ -162,28 +196,91 @@ pub(crate) fn open_batch_pr<H: RuntimeHost + TaskHost + ?Sized>(
         }),
         Role::Admin,
         tool_context.clone(),
-    )?;
-    let pr_url = pr_create
+    ) {
+        Ok(value) => value,
+        Err(error) => {
+            record_failed_handoff(
+                host,
+                &completed_tasks,
+                batch_id,
+                &workspace_path,
+                &head,
+                &base,
+                Some(&freshness.base_ref),
+                FailedHandoffOp::PrCreate,
+                &error,
+            )?;
+            return Err(error);
+        }
+    };
+    let pr_url = match pr_create
         .get("url")
         .and_then(Value::as_str)
         .filter(|value| !value.trim().is_empty())
-        .ok_or_else(|| {
-            OrbitError::Execution("github.pr.create did not return a PR url".to_string())
-        })?
-        .to_string();
-    let pr_view = host.run_tool_with_context_and_role(
+    {
+        Some(url) => url.to_string(),
+        None => {
+            let error =
+                OrbitError::Execution("github.pr.create did not return a PR url".to_string());
+            record_failed_handoff(
+                host,
+                &completed_tasks,
+                batch_id,
+                &workspace_path,
+                &head,
+                &base,
+                Some(&freshness.base_ref),
+                FailedHandoffOp::PrCreate,
+                &error,
+            )?;
+            return Err(error);
+        }
+    };
+    let pr_view = match host.run_tool_with_context_and_role(
         "github.pr.view",
         json!({ "pr": pr_url }),
         orbit_common::types::Role::Admin,
         tool_context,
-    )?;
-    let pr_number = pr_view
+    ) {
+        Ok(value) => value,
+        Err(error) => {
+            record_failed_handoff(
+                host,
+                &completed_tasks,
+                batch_id,
+                &workspace_path,
+                &head,
+                &base,
+                Some(&freshness.base_ref),
+                FailedHandoffOp::PrView,
+                &error,
+            )?;
+            return Err(error);
+        }
+    };
+    let pr_number = match pr_view
         .get("pull_request")
         .and_then(|value| value.get("number"))
         .and_then(json_number_to_string)
-        .ok_or_else(|| {
-            OrbitError::Execution("github.pr.view did not return a PR number".to_string())
-        })?;
+    {
+        Some(num) => num,
+        None => {
+            let error =
+                OrbitError::Execution("github.pr.view did not return a PR number".to_string());
+            record_failed_handoff(
+                host,
+                &completed_tasks,
+                batch_id,
+                &workspace_path,
+                &head,
+                &base,
+                Some(&freshness.base_ref),
+                FailedHandoffOp::PrView,
+                &error,
+            )?;
+            return Err(error);
+        }
+    };
 
     for task in &completed_tasks {
         let model = pr_review_attribution(host, task, batch_id)?;
@@ -247,6 +344,112 @@ fn ensure_completed_tasks_have_meaningful_execution_summaries(
                 task.id
             )));
         }
+    }
+    Ok(())
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(super) enum FailedHandoffOp {
+    Rebase,
+    Push,
+    PrCreate,
+    PrView,
+}
+
+impl FailedHandoffOp {
+    fn label(self) -> &'static str {
+        match self {
+            Self::Rebase => "rebase",
+            Self::Push => "push",
+            Self::PrCreate => "github.pr.create",
+            Self::PrView => "github.pr.view",
+        }
+    }
+}
+
+/// Stable header used as the idempotency key for failed-handoff comments.
+/// Repeated failures with the same `(batch_id, op)` are collapsed; a distinct
+/// later failure still appends a fresh note because its `op` differs.
+fn failed_handoff_comment_header(batch_id: &str, op: FailedHandoffOp) -> String {
+    format!(
+        "pr_open handoff failed [run={batch_id}] [op={}]",
+        op.label()
+    )
+}
+
+fn failed_handoff_recovery(
+    op: FailedHandoffOp,
+    workspace_path: &Path,
+    head: &str,
+    base: &str,
+) -> String {
+    let cd = format!("cd {}", workspace_path.display());
+    match op {
+        FailedHandoffOp::Rebase => format!(
+            "{cd}\n  git fetch origin {base}\n  git rebase origin/{base}\n  git push --force-with-lease origin {head}\n  gh pr create --base {base} --head {head}"
+        ),
+        FailedHandoffOp::Push => format!(
+            "{cd}\n  git push --force-with-lease origin {head}\n  gh pr create --base {base} --head {head}"
+        ),
+        FailedHandoffOp::PrCreate => format!("{cd}\n  gh pr create --base {base} --head {head}"),
+        FailedHandoffOp::PrView => format!("{cd}\n  gh pr view {head} --json url,number"),
+    }
+}
+
+fn failed_handoff_message(
+    batch_id: &str,
+    op: FailedHandoffOp,
+    workspace_path: &Path,
+    head: &str,
+    base: &str,
+    base_ref: Option<&str>,
+    error: &OrbitError,
+) -> String {
+    let header = failed_handoff_comment_header(batch_id, op);
+    let base_ref_line = base_ref
+        .map(|value| format!("Base ref: {value}\n"))
+        .unwrap_or_default();
+    let recovery = failed_handoff_recovery(op, workspace_path, head, base);
+    format!(
+        "{header}\n\nHead branch: {head}\nWorktree: {worktree}\nBase branch: {base}\n{base_ref_line}Failing step: {op}\nError: {error}\n\nRecovery:\n  {recovery}",
+        worktree = workspace_path.display(),
+        op = op.label(),
+    )
+}
+
+fn record_failed_handoff<H: TaskHost + ?Sized>(
+    host: &H,
+    completed_tasks: &[Task],
+    batch_id: &str,
+    workspace_path: &Path,
+    head: &str,
+    base: &str,
+    base_ref: Option<&str>,
+    op: FailedHandoffOp,
+    error: &OrbitError,
+) -> Result<(), OrbitError> {
+    let header = failed_handoff_comment_header(batch_id, op);
+    let message = failed_handoff_message(batch_id, op, workspace_path, head, base, base_ref, error);
+
+    for task in completed_tasks {
+        let existing = host.get_task_comments(&task.id)?;
+        if existing
+            .iter()
+            .any(|comment| comment.message.starts_with(&header))
+        {
+            continue;
+        }
+        host.apply_task_automation_update(
+            &task.id,
+            TaskAutomationUpdate {
+                append_comments: vec![TaskComment {
+                    at: Utc::now(),
+                    by: FAILED_HANDOFF_ACTOR.to_string(),
+                    message: message.clone(),
+                }],
+                ..TaskAutomationUpdate::default()
+            },
+        )?;
     }
     Ok(())
 }

--- a/crates/orbit-engine/src/executor/automation/vcs/pr/tests/open.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/pr/tests/open.rs
@@ -123,6 +123,135 @@ fn pr_open_generates_body_with_all_completed_task_summaries() {
 }
 
 #[test]
+fn pr_open_records_failed_handoff_comment_when_rebase_fails() {
+    let workspace = rebase_conflict_pr_workspace();
+    let host = PrOpenTestHost::new(
+        vec![batch_task(
+            "T20260521-1A",
+            "Rebase conflict task",
+            "## Status\nsuccess\n\n## Summary of Changes\n- Implemented.",
+        )],
+        workspace.repo.clone(),
+    );
+
+    let error = open_batch_pr(&host, &pr_open_input(&workspace.repo, vec!["T20260521-1A"]))
+        .expect_err("rebase failure should propagate");
+    assert!(
+        error.to_string().contains("behind base"),
+        "expected behind-base error, got: {error}"
+    );
+    assert!(
+        host.tool_calls()
+            .iter()
+            .all(|call| call.name != "github.pr.create"),
+        "PR create should not be attempted after rebase failure"
+    );
+
+    let task = host.get_task("T20260521-1A").expect("task still exists");
+    assert_eq!(
+        task.status,
+        TaskStatus::InProgress,
+        "task should remain in-progress after failed handoff"
+    );
+
+    let comments = host.comments_for("T20260521-1A");
+    assert_eq!(comments.len(), 1, "exactly one failed-handoff comment");
+    let comment = &comments[0];
+    assert_eq!(comment.by, "system");
+    let body = &comment.message;
+    assert!(body.contains("pr_open handoff failed"));
+    assert!(body.contains("[run=batch-1]"));
+    assert!(body.contains("[op=rebase]"));
+    assert!(body.contains("Head branch: orbit/test-batch"));
+    assert!(body.contains("Base branch: agent-main"));
+    assert!(body.contains(&workspace.repo.display().to_string()));
+    assert!(body.contains("Recovery:"));
+    assert!(body.contains("git rebase origin/agent-main"));
+    assert!(body.contains("git push --force-with-lease origin orbit/test-batch"));
+
+    // Idempotency: retrying the same run + branch must not append duplicate noise.
+    let _ = open_batch_pr(&host, &pr_open_input(&workspace.repo, vec!["T20260521-1A"]))
+        .expect_err("rebase still fails on retry");
+    assert_eq!(
+        host.comments_for("T20260521-1A").len(),
+        1,
+        "repeated failures from the same run/op must not spam duplicate comments"
+    );
+}
+
+#[test]
+fn pr_open_records_failed_handoff_comment_when_pr_create_fails() {
+    let workspace = pr_workspace();
+    let host = PrOpenTestHost::new(
+        vec![
+            batch_task(
+                "T20260521-2A",
+                "First completed task",
+                "## Status\nsuccess\n\n## Summary of Changes\n- First.",
+            ),
+            batch_task(
+                "T20260521-2B",
+                "Second completed task",
+                "## Status\nsuccess\n\n## Summary of Changes\n- Second.",
+            ),
+        ],
+        workspace.repo.clone(),
+    );
+    host.fail_tool("github.pr.create", "gh: HTTP 502 from api.github.com");
+
+    let error = open_batch_pr(
+        &host,
+        &pr_open_input(&workspace.repo, vec!["T20260521-2A", "T20260521-2B"]),
+    )
+    .expect_err("github.pr.create failure should propagate");
+    assert!(error.to_string().contains("HTTP 502"));
+
+    for task_id in ["T20260521-2A", "T20260521-2B"] {
+        let task = host.get_task(task_id).expect("task still exists");
+        assert_eq!(
+            task.status,
+            TaskStatus::InProgress,
+            "{task_id} should remain in-progress after pr_create failure"
+        );
+
+        let comments = host.comments_for(task_id);
+        assert_eq!(
+            comments.len(),
+            1,
+            "{task_id}: exactly one failed-handoff comment"
+        );
+        let body = &comments[0].message;
+        assert!(body.contains("[run=batch-1]"));
+        assert!(body.contains("[op=github.pr.create]"));
+        assert!(body.contains("Head branch: orbit/test-batch"));
+        assert!(body.contains("Base branch: agent-main"));
+        assert!(body.contains("Base ref:"));
+        assert!(body.contains("gh: HTTP 502 from api.github.com"));
+        assert!(body.contains("gh pr create --base agent-main --head orbit/test-batch"));
+    }
+
+    // A distinct later failure (different op) still appends a new note.
+    host.fail_tool("git.push", "remote rejected force-with-lease");
+    let _ = open_batch_pr(
+        &host,
+        &pr_open_input(&workspace.repo, vec!["T20260521-2A", "T20260521-2B"]),
+    )
+    .expect_err("git.push failure on retry should propagate");
+    let comments = host.comments_for("T20260521-2A");
+    assert_eq!(
+        comments.len(),
+        2,
+        "distinct failing op should append a new note"
+    );
+    assert!(comments[1].message.contains("[op=push]"));
+    assert!(
+        comments[1]
+            .message
+            .contains("remote rejected force-with-lease")
+    );
+}
+
+#[test]
 fn pr_open_preserves_non_empty_explicit_body() {
     let workspace = pr_workspace();
     let host = PrOpenTestHost::new(

--- a/crates/orbit-engine/src/executor/automation/vcs/pr/tests/test_support.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/pr/tests/test_support.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Command;
@@ -6,7 +7,7 @@ use std::sync::Mutex;
 use chrono::Utc;
 use orbit_common::types::{
     Activity, ExternalRef, Job, JobTargetType, NotFoundKind, OrbitError, OrbitEvent, Role, Task,
-    TaskArtifact, TaskPriority, TaskStatus, TaskType, push_external_ref_if_missing,
+    TaskArtifact, TaskComment, TaskPriority, TaskStatus, TaskType, push_external_ref_if_missing,
 };
 use orbit_tools::ToolContext;
 use serde_json::{Value, json};
@@ -28,6 +29,7 @@ pub struct ToolCall {
 
 pub struct PrOpenTestHost {
     tasks: Mutex<Vec<Task>>,
+    comments: Mutex<HashMap<String, Vec<TaskComment>>>,
     tool_calls: Mutex<Vec<ToolCall>>,
     automation_updates: Mutex<Vec<(String, TaskAutomationUpdate)>>,
     activity_implementer: Option<(String, String)>,
@@ -35,6 +37,7 @@ pub struct PrOpenTestHost {
     data_root: PathBuf,
     scoreboard_dir: PathBuf,
     registry: ActivityExecutorRegistry,
+    tool_errors: Mutex<HashMap<String, String>>,
 }
 
 impl PrOpenTestHost {
@@ -43,6 +46,7 @@ impl PrOpenTestHost {
         let scoreboard_dir = data_root.join("scoreboard");
         Self {
             tasks: Mutex::new(tasks),
+            comments: Mutex::new(HashMap::new()),
             tool_calls: Mutex::new(Vec::new()),
             automation_updates: Mutex::new(Vec::new()),
             activity_implementer: None,
@@ -50,12 +54,29 @@ impl PrOpenTestHost {
             data_root,
             scoreboard_dir,
             registry: ActivityExecutorRegistry::default(),
+            tool_errors: Mutex::new(HashMap::new()),
         }
     }
 
     pub fn with_activity_implementer(mut self, agent: &str, model: &str) -> Self {
         self.activity_implementer = Some((agent.to_string(), model.to_string()));
         self
+    }
+
+    pub fn fail_tool(&self, name: &str, message: &str) {
+        self.tool_errors
+            .lock()
+            .expect("tool errors lock")
+            .insert(name.to_string(), message.to_string());
+    }
+
+    pub fn comments_for(&self, task_id: &str) -> Vec<TaskComment> {
+        self.comments
+            .lock()
+            .expect("comments lock")
+            .get(task_id)
+            .cloned()
+            .unwrap_or_default()
     }
 
     pub fn tool_calls(&self) -> Vec<ToolCall> {
@@ -96,6 +117,16 @@ impl TaskReadHost for PrOpenTestHost {
 
     fn get_task_artifacts(&self, _task_id: &str) -> Result<Vec<TaskArtifact>, OrbitError> {
         Ok(Vec::new())
+    }
+
+    fn get_task_comments(&self, task_id: &str) -> Result<Vec<TaskComment>, OrbitError> {
+        Ok(self
+            .comments
+            .lock()
+            .expect("comments lock")
+            .get(task_id)
+            .cloned()
+            .unwrap_or_default())
     }
 
     fn list_tasks_filtered(
@@ -174,6 +205,15 @@ impl TaskWriteHost for PrOpenTestHost {
             .lock()
             .expect("automation updates lock")
             .push((task_id.to_string(), update.clone()));
+
+        if !update.append_comments.is_empty() {
+            self.comments
+                .lock()
+                .expect("comments lock")
+                .entry(task_id.to_string())
+                .or_default()
+                .extend(update.append_comments.iter().cloned());
+        }
 
         let mut tasks = self.tasks.lock().expect("tasks lock");
         let task = tasks
@@ -275,6 +315,16 @@ impl RuntimeHost for PrOpenTestHost {
                 name: name.to_string(),
                 input: input.clone(),
             });
+
+        if let Some(message) = self
+            .tool_errors
+            .lock()
+            .expect("tool errors lock")
+            .get(name)
+            .cloned()
+        {
+            return Err(OrbitError::Execution(message));
+        }
 
         match name {
             "git.push" => Ok(json!({})),
@@ -440,6 +490,36 @@ pub fn no_diff_pr_workspace() -> PrWorkspace {
     git(&repo, &["add", "README.md"]);
     git(&repo, &["commit", "-m", "base"]);
     git(&repo, &["checkout", "-b", "orbit/test-batch"]);
+
+    PrWorkspace { _temp: temp, repo }
+}
+
+/// Workspace where rebasing `orbit/test-batch` onto `agent-main` conflicts:
+/// both branches edited the same file with incompatible content, so
+/// `git rebase agent-main` fails and `ensure_branch_rebased_onto_base`
+/// returns the original "behind" error.
+pub fn rebase_conflict_pr_workspace() -> PrWorkspace {
+    let temp = tempdir().expect("tempdir");
+    let repo = temp.path().join("repo");
+    fs::create_dir_all(&repo).expect("create repo dir");
+    git(&repo, &["init"]);
+    git(&repo, &["checkout", "-b", "agent-main"]);
+    git(&repo, &["config", "user.name", "Orbit Test"]);
+    git(&repo, &["config", "user.email", "orbit-test@example.com"]);
+    fs::write(repo.join("README.md"), "base\n").expect("write readme");
+    fs::create_dir_all(repo.join("src")).expect("create src dir");
+    fs::write(repo.join("src/lib.rs"), "pub fn base() {}\n").expect("write lib");
+    git(&repo, &["add", "README.md", "src/lib.rs"]);
+    git(&repo, &["commit", "-m", "base"]);
+    git(&repo, &["checkout", "-b", "orbit/test-batch"]);
+    fs::write(repo.join("src/lib.rs"), "pub fn branch() {}\n").expect("write branch lib");
+    git(&repo, &["add", "src/lib.rs"]);
+    git(&repo, &["commit", "-m", "branch change"]);
+    git(&repo, &["checkout", "agent-main"]);
+    fs::write(repo.join("src/lib.rs"), "pub fn diverged() {}\n").expect("write base lib");
+    git(&repo, &["add", "src/lib.rs"]);
+    git(&repo, &["commit", "-m", "diverged base"]);
+    git(&repo, &["checkout", "orbit/test-batch"]);
 
     PrWorkspace { _temp: temp, repo }
 }


### PR DESCRIPTION
## Task

[ORB-00238](https://orbit-cli.com/tasks/ORB-00238) — Record failed pr_open handoffs on completed task branches

### Description

## Problem

When `pr_open` fails after implementation has succeeded, the task can remain in `in-progress` with no obvious handoff trail. ORB-00216 had a persisted execution summary and a pushed task branch, but PR creation failed during branch refresh/PR handoff. The run failed, recovery failed, and the task still looked actively in progress until a human noticed.

`pr_open` should record a durable failed-handoff note on each affected task when implementation is complete but the PR handoff cannot finish. The note should give the next operator enough context to recover without spelunking audit blobs first.

Related incident: ORB-00216 / jrun-20260521-0345. Related friction: F2026-05-052.

## Why It Matters

A failed PR handoff is operationally different from an implementation still being worked. Without a task comment or status signal, humans and automation cannot distinguish completed-but-stuck work from active work, and the recovery path becomes tribal knowledge.

## Constraints / Notes

- Keep successful `pr_open` behavior unchanged: successful PR creation still moves tasks to `review` and attaches PR metadata.
- Do not mark a task `review` when no PR was created and commits remain on a branch.
- Prefer appending a structured task comment first; move to `blocked` only if the lifecycle rules and review workflow make that safe.
- The comment should include branch, worktree path, base branch/ref if known, failed step/activity, concise error, and an exact recovery command or command sequence.

### Acceptance Criteria

- If `open_batch_pr` fails after completed tasks have meaningful persisted execution summaries, each affected task receives exactly one durable task comment for that failed handoff attempt.
- The failed-handoff comment includes the head branch, worktree path, base branch or base ref when known, failing operation (`pr_open` / rebase / push / GitHub PR create), concise error text, and a concrete recovery command sequence such as fetch/rebase, force-with-lease push, and PR create/open instructions.
- The failed-handoff comment is idempotent for retry noise: repeated failures from the same run/branch do not spam duplicate identical comments, while a distinct later failure can still append a new note.
- Successful no-diff and successful PR creation paths keep their current behavior and do not append failed-handoff comments.
- Tests cover at least one branch-refresh/rebase failure and one `github.pr.create` failure using the existing `pr_open` test support fakes; assertions verify task status and comment contents.
- If the implementation chooses to move tasks to `blocked`, tests prove the transition is allowed and that retry/recovery can move the task back to `in-progress` or `review` without manual YAML edits; otherwise the task remains `in-progress` but has the failed-handoff comment.
- `cargo test -p orbit-engine pr_open` passes, plus any affected orbit-core task-host tests.
- `make ci-fast` passes.

## Execution Summary

<details>
<summary>Click to expand</summary>

## Status
success

## Summary of Changes

Wrap each handoff stage in `open_batch_pr` (rebase, push, github.pr.create, github.pr.view) so that a failure after `ensure_completed_tasks_have_meaningful_execution_summaries` succeeds appends a durable failed-handoff comment to every completed task, then propagates the original error unchanged.

- `crates/orbit-engine/src/executor/automation/vcs/pr/open.rs`:
  - Added `FailedHandoffOp` (Rebase/Push/PrCreate/PrView), `failed_handoff_comment_header`, `failed_handoff_recovery`, `failed_handoff_message`, and `record_failed_handoff`.
  - Replaced the previous `?` propagation on rebase/push/pr_create/pr_view with explicit match arms that call `record_failed_handoff` before re-erroring.
  - The comment header `pr_open handoff failed [run=<batch_id>] [op=<op>]` is used as the idempotency key — repeated failures with the same run+op are skipped via `host.get_task_comments`; a distinct later op still appends a fresh note.
  - Tasks remain `in-progress` on failure (no status change); the comment is the durable handoff trail. This avoids the `blocked` lifecycle question entirely while still satisfying the acceptance criteria.
  - Recovery hint per op covers `cd <worktree>` plus the right git/gh command sequence (fetch+rebase+push+pr-create for rebase; force-with-lease push + pr-create for push; pr-create for pr_create; pr-view for pr_view).
- `crates/orbit-engine/src/executor/automation/vcs/pr/tests/test_support.rs`:
  - Added `comments: Mutex<HashMap<String, Vec<TaskComment>>>` and `tool_errors: Mutex<HashMap<String, String>>` storage to `PrOpenTestHost`.
  - `apply_task_automation_update` now persists `append_comments` so `get_task_comments` (newly implemented) returns them — required to exercise the idempotency check.
  - `run_tool_with_context_and_role` honors injected tool errors via `fail_tool(name, message)`.
  - New `rebase_conflict_pr_workspace()` builder seeds incompatible edits to `src/lib.rs` on both branches so `ensure_branch_rebased_onto_base` falls through to the rebase-conflict abort path and returns the original "behind base" error.
- `crates/orbit-engine/src/executor/automation/vcs/pr/tests/open.rs`:
  - `pr_open_records_failed_handoff_comment_when_rebase_fails`: asserts status stays InProgress, comment contains `[op=rebase]` and the recovery sequence, and a retry does not duplicate the comment.
  - `pr_open_records_failed_handoff_comment_when_pr_create_fails`: covers two tasks, verifies each gets exactly one `[op=github.pr.create]` comment, then injects a `git.push` failure on retry and asserts a second comment with `[op=push]` is appended (proving distinct later failures still record).

Successful no-diff and successful PR-creation paths are untouched — their existing tests (`pr_open_completes_no_diff_branch_without_github_pr`, `pr_open_generates_body_with_all_completed_task_summaries`, `pr_open_preserves_non_empty_explicit_body`) still pass.

## Validation

- `cargo test -p orbit-engine pr_open` → 7 passed, 0 failed (5 pre-existing + 2 new).
- `cargo test -p orbit-core task_host` → 17 passed under a clean env (the two failures observed under the worktree's parent shell were the pre-existing `ORBIT_AGENT_*`-injection issue documented by L-0003, not a regression from this change).
- `make ci-fast` → exit 0.

## Notes

- Comments use `system` as `by`. The header `pr_open handoff failed [run=<batch_id>] [op=<op>]` is the durable contract for idempotency — collapse-by-(run, op) was chosen because a second failure of the *same* step inside the same run is retry noise, while a different step legitimately reflects new state for the operator.
- Pre-handoff failures (workspace canonicalization, task lookup, execution-summary precondition, `rev-parse HEAD`) are left as bare `?` returns — they fail before the handoff begins and predate the "completed but stuck" scenario the comment is designed to catch.
- `commit_batch_changes` in `pr_open` (the outer entry point) is also outside the wrapped region. The task description scoped the comment to "branch refresh / PR handoff", which begins after commits are recorded.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-00238-6a0fdfd0`
- Behind base: 0
- Ahead of base: 1