### PR TITLE
Serve dashboard task artifacts as untrusted content

### DIFF
--- a/crates/orbit-dashboard/src/api/tasks.rs
+++ b/crates/orbit-dashboard/src/api/tasks.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 
 use axum::body::Body;
 use axum::extract::{Path, State};
-use axum::http::{HeaderValue, header};
+use axum::http::{HeaderName, HeaderValue, header};
 use axum::response::{IntoResponse, Json, Response};
 use orbit_common::types::validate_relative_artifact_path;
 use orbit_core::command::task::{TaskAddParams, TaskUpdateParams};
@@ -27,6 +27,11 @@ const DASHBOARD_TASK_STATUSES: &[TaskStatus] = &[
     TaskStatus::Someday,
     TaskStatus::Rejected,
 ];
+
+struct ArtifactResponsePolicy {
+    content_type: &'static str,
+    attachment: bool,
+}
 
 #[derive(Deserialize, Default)]
 pub(super) struct ApproveBody {
@@ -202,24 +207,61 @@ pub(super) async fn get_task_artifact(
     };
     match runtime.get_task_artifact(id, &path) {
         Ok(Some(artifact)) => {
-            let content_type = match HeaderValue::from_str(&artifact.media_type) {
-                Ok(value) => value,
-                Err(error) => {
-                    return server_error(orbit_core::OrbitError::Store(format!(
-                        "invalid artifact media type '{}': {error}",
-                        artifact.media_type
-                    )));
-                }
-            };
+            let policy = artifact_response_policy(&artifact.media_type);
             let mut response = Response::new(Body::from(artifact.content));
-            response
-                .headers_mut()
-                .insert(header::CONTENT_TYPE, content_type);
+            response.headers_mut().insert(
+                header::CONTENT_TYPE,
+                HeaderValue::from_static(policy.content_type),
+            );
+            response.headers_mut().insert(
+                HeaderName::from_static("x-content-type-options"),
+                HeaderValue::from_static("nosniff"),
+            );
+            if policy.attachment {
+                response.headers_mut().insert(
+                    header::CONTENT_DISPOSITION,
+                    HeaderValue::from_static("attachment"),
+                );
+            }
             response
         }
         Ok(None) => super::not_found(format!("artifact not found: {id}/{path}")),
         Err(e) => map_runtime_error(e),
     }
+}
+
+fn artifact_response_policy(media_type: &str) -> ArtifactResponsePolicy {
+    let content_type = inline_safe_artifact_content_type(media_type);
+    ArtifactResponsePolicy {
+        content_type: content_type.unwrap_or("application/octet-stream"),
+        attachment: content_type.is_none(),
+    }
+}
+
+fn inline_safe_artifact_content_type(media_type: &str) -> Option<&'static str> {
+    match normalized_media_type(media_type).as_deref() {
+        Some("application/json") => Some("application/json"),
+        Some("application/toml") => Some("application/toml"),
+        Some("application/yaml") => Some("application/yaml"),
+        Some("image/gif") => Some("image/gif"),
+        Some("image/jpeg") => Some("image/jpeg"),
+        Some("image/png") => Some("image/png"),
+        Some("image/webp") => Some("image/webp"),
+        Some("text/csv") => Some("text/csv"),
+        Some("text/plain") => Some("text/plain"),
+        _ => None,
+    }
+}
+
+fn normalized_media_type(media_type: &str) -> Option<String> {
+    let base = media_type
+        .split_once(';')
+        .map_or(media_type, |(base, _params)| base)
+        .trim();
+    if base.is_empty() {
+        return None;
+    }
+    Some(base.to_ascii_lowercase())
 }
 
 fn validate_artifact_request_path(path: &str) -> Result<String, String> {

--- a/crates/orbit-dashboard/src/api/tests/tasks.rs
+++ b/crates/orbit-dashboard/src/api/tests/tasks.rs
@@ -15,6 +15,20 @@ use super::super::router;
 use super::test_support::body_json;
 
 fn seed_task_with_artifact(runtime: &OrbitRuntime) -> orbit_core::Task {
+    seed_task_with_artifact_payload(
+        runtime,
+        "subdir/file.json",
+        "application/json",
+        br#"{"ok":true}"#.to_vec(),
+    )
+}
+
+fn seed_task_with_artifact_payload(
+    runtime: &OrbitRuntime,
+    path: &str,
+    media_type: &str,
+    content: Vec<u8>,
+) -> orbit_core::Task {
     let task = runtime
         .add_task(TaskAddParams {
             title: "Artifact task".to_string(),
@@ -29,9 +43,9 @@ fn seed_task_with_artifact(runtime: &OrbitRuntime) -> orbit_core::Task {
             &task.id,
             TaskUpdateParams {
                 upsert_artifacts: vec![TaskArtifact {
-                    path: "subdir/file.json".to_string(),
-                    media_type: "application/json".to_string(),
-                    content: br#"{"ok":true}"#.to_vec(),
+                    path: path.to_string(),
+                    media_type: media_type.to_string(),
+                    content,
                     created_by: None,
                 }],
                 ..Default::default()
@@ -214,10 +228,162 @@ async fn get_task_artifact_serves_subdirectory_bytes_and_media_type() {
         response.headers().get(header::CONTENT_TYPE),
         Some(&HeaderValue::from_static("application/json"))
     );
+    assert_eq!(
+        response.headers().get("x-content-type-options"),
+        Some(&HeaderValue::from_static("nosniff"))
+    );
+    assert!(
+        response
+            .headers()
+            .get(header::CONTENT_DISPOSITION)
+            .is_none()
+    );
     let bytes = to_bytes(response.into_body(), usize::MAX)
         .await
         .expect("read response body");
     assert_eq!(&bytes[..], br#"{"ok":true}"#);
+}
+
+#[tokio::test]
+async fn get_task_artifact_normalizes_text_plain_and_keeps_it_inline() {
+    let runtime = OrbitRuntime::in_memory().expect("build runtime");
+    let task = seed_task_with_artifact_payload(
+        &runtime,
+        "notes/output.txt",
+        "Text/Plain; Charset=UTF-8",
+        b"plain artifact".to_vec(),
+    );
+
+    let response = request(
+        runtime,
+        &format!("/tasks/{}/artifacts/notes/output.txt", task.id),
+    )
+    .await;
+
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(
+        response.headers().get(header::CONTENT_TYPE),
+        Some(&HeaderValue::from_static("text/plain"))
+    );
+    assert_eq!(
+        response.headers().get("x-content-type-options"),
+        Some(&HeaderValue::from_static("nosniff"))
+    );
+    assert!(
+        response
+            .headers()
+            .get(header::CONTENT_DISPOSITION)
+            .is_none()
+    );
+    let bytes = to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("read response body");
+    assert_eq!(&bytes[..], b"plain artifact");
+}
+
+#[tokio::test]
+async fn get_task_artifact_downloads_html_instead_of_serving_inline() {
+    let runtime = OrbitRuntime::in_memory().expect("build runtime");
+    let task = seed_task_with_artifact_payload(
+        &runtime,
+        "reports/payload.html",
+        "text/html; charset=utf-8",
+        br#"<script>fetch("/api/tasks")</script>"#.to_vec(),
+    );
+
+    let response = request(
+        runtime,
+        &format!("/tasks/{}/artifacts/reports/payload.html", task.id),
+    )
+    .await;
+
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(
+        response.headers().get(header::CONTENT_TYPE),
+        Some(&HeaderValue::from_static("application/octet-stream"))
+    );
+    assert_eq!(
+        response.headers().get("x-content-type-options"),
+        Some(&HeaderValue::from_static("nosniff"))
+    );
+    assert_eq!(
+        response.headers().get(header::CONTENT_DISPOSITION),
+        Some(&HeaderValue::from_static("attachment"))
+    );
+    let bytes = to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("read response body");
+    assert_eq!(&bytes[..], br#"<script>fetch("/api/tasks")</script>"#);
+}
+
+#[tokio::test]
+async fn get_task_artifact_downloads_script_media_types() {
+    let runtime = OrbitRuntime::in_memory().expect("build runtime");
+    let task = seed_task_with_artifact_payload(
+        &runtime,
+        "reports/payload.js",
+        "application/javascript",
+        b"fetch('/api/tasks')".to_vec(),
+    );
+
+    let response = request(
+        runtime,
+        &format!("/tasks/{}/artifacts/reports/payload.js", task.id),
+    )
+    .await;
+
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(
+        response.headers().get(header::CONTENT_TYPE),
+        Some(&HeaderValue::from_static("application/octet-stream"))
+    );
+    assert_eq!(
+        response.headers().get("x-content-type-options"),
+        Some(&HeaderValue::from_static("nosniff"))
+    );
+    assert_eq!(
+        response.headers().get(header::CONTENT_DISPOSITION),
+        Some(&HeaderValue::from_static("attachment"))
+    );
+    let bytes = to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("read response body");
+    assert_eq!(&bytes[..], b"fetch('/api/tasks')");
+}
+
+#[tokio::test]
+async fn get_task_artifact_downloads_unknown_media_types() {
+    let runtime = OrbitRuntime::in_memory().expect("build runtime");
+    let task = seed_task_with_artifact_payload(
+        &runtime,
+        "reports/payload.custom",
+        "application/x-orbit-preview",
+        b"custom artifact".to_vec(),
+    );
+
+    let response = request(
+        runtime,
+        &format!("/tasks/{}/artifacts/reports/payload.custom", task.id),
+    )
+    .await;
+
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(
+        response.headers().get(header::CONTENT_TYPE),
+        Some(&HeaderValue::from_static("application/octet-stream"))
+    );
+    assert_eq!(
+        response.headers().get("x-content-type-options"),
+        Some(&HeaderValue::from_static("nosniff"))
+    );
+    assert_eq!(
+        response.headers().get(header::CONTENT_DISPOSITION),
+        Some(&HeaderValue::from_static("attachment"))
+    );
+    let bytes = to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("read response body");
+    assert_eq!(&bytes[..], b"custom artifact");
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Task

[ORB-00264](https://orbit-cli.com/tasks/ORB-00264) — Serve dashboard task artifacts as untrusted content

### Description

Codex Security repository scan finding.

Task artifacts can be written by the Orbit tool host with caller-supplied `media_type`, and the dashboard artifact route serves artifact bytes from the dashboard origin with that stored `Content-Type`. There is no media-type allowlist, `Content-Disposition: attachment`, `X-Content-Type-Options: nosniff`, or equivalent isolation for active content.

Evidence:
- `crates/orbit-core/src/runtime/orbit_tool_host/task_tools.rs:313` accepts `upsert_artifacts` from tool input.
- `crates/orbit-core/src/runtime/orbit_tool_host/input.rs:151` accepts caller-supplied `media_type`/`mediaType`.
- `crates/orbit-store/src/file/task_store/v2/artifacts.rs:140` persists the artifact media type.
- `crates/orbit-dashboard/src/api/tasks.rs:214` builds the artifact response body and `tasks.rs:217` sets `Content-Type` directly from stored metadata.

Security impact: if an agent or malicious repository content causes a task artifact such as `text/html` to be stored, viewing that artifact through the dashboard can execute script in the dashboard origin and call same-origin dashboard APIs.

### Acceptance Criteria

- Dashboard artifact responses treat stored task artifacts as untrusted by default: active/scripting media types are downloaded or isolated rather than rendered inline.
- Responses include `X-Content-Type-Options: nosniff`, and active media types get `Content-Disposition: attachment` or an equivalent safe handling policy.
- Artifact media types are normalized/allowlisted before serving; unsafe or unknown values cannot cause trusted-origin script execution.
- Tests cover `text/html`/script-capable artifacts being non-executable inline and benign artifacts such as `text/plain` or JSON remaining inspectable as intended.
- `make ci-fast` passes.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Dashboard task artifact responses now normalize stored media types against a small inline allowlist, add X-Content-Type-Options: nosniff, and force unsafe or unknown media types to application/octet-stream with Content-Disposition: attachment.
- Added dashboard API regression tests for JSON, normalized text/plain, text/html, application/javascript, unknown media types, and traversal/not-found behavior.

Assessment: The vulnerable stored media type is no longer reflected as trusted response content; HTML/script-capable artifacts are delivered as downloads while benign JSON and text/plain remain inspectable.

Validation:
- cargo test -p orbit-dashboard api::tests::tasks::get_task_artifact -- --nocapture
- make ci-fast
- cargo clippy -p orbit-dashboard --all-targets -- -D warnings

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-00264-6a10fc34`
- Behind base: 0
- Ahead of base: 1