### PR TITLE
Apply env-aware redaction to persisted audit blobs

### DIFF
--- a/crates/orbit-agent/README.md
+++ b/crates/orbit-agent/README.md
@@ -118,8 +118,8 @@ first to trip wins.
 ## Audit model
 
 Every operation emits a structured event. Events carry sha256 pointers
-to verbatim payloads; full bodies live in a separate content-addressed
-store. Event kinds:
+to redacted payloads; full bodies live in a separate content-addressed
+store keyed by the post-redaction bytes. Event kinds:
 
 - `session_spawn`, `session_close`
 - `http_request`, `http_response`
@@ -137,7 +137,7 @@ Every event carries `run_id`, `session_id`, optional `task_id`, and
 ```
 {audit_root}/
   loop/{run_id}.jsonl              one JSON object per line, append-only, created on first event
-  blobs/{hash[..2]}/{hash}         content-addressed verbatim payloads
+  blobs/{hash[..2]}/{hash}         content-addressed redacted payloads
 ```
 
 The JSONL file and blob store are designed to be read by a later
@@ -150,18 +150,23 @@ examples use temporary roots under the system temp directory.
 
 ## Redaction
 
-Blob writes run through `RedactionMiddleware::default_redaction()`
-before the bytes reach disk. The default ruleset scrubs:
+Blob writes run through `redact_all()` before the bytes are hashed or reach
+disk. Callers can layer a stronger `PatternRedactor` on top, but cannot weaken
+the default env-value and pattern redaction. The default ruleset scrubs:
 
+- live sensitive environment variable values such as `*_TOKEN`, `*_SECRET`,
+  `*_PASSWORD`, `*_API_KEY`, auth/session/cookie names, and private keys
 - `"authorization": "..."`, `"x-api-key": "..."`, `"api_key": "..."`
   (JSON-shaped)
 - `Authorization: ...`, `x-api-key: ...`, `api_key: ...` (raw header
   lines)
 - `Bearer <token>` anywhere in the payload
+- high-confidence provider token shapes such as `sk-...`, `ghp_...`, and
+  `xox...` values
 
 Redaction runs at **write time**, not read time — the stored bytes are
-already safe, so a future `orbit.audit.loop.blob.get` tool does not need
-to re-apply it.
+already safe, and blob references point to the redacted content hash. A future
+`orbit.audit.loop.blob.get` tool does not need to re-apply redaction.
 
 ## Running the examples
 

--- a/crates/orbit-agent/src/loop_engine/audit/mod.rs
+++ b/crates/orbit-agent/src/loop_engine/audit/mod.rs
@@ -3,7 +3,7 @@
 //! The loop emits a fixed set of structured events — session lifecycle, HTTP
 //! request/response, tool-call request/result, iteration boundaries, policy
 //! denials — to any [`AuditSink`] implementation. Events carry sha256
-//! pointers to verbatim payloads stored in a [`BlobStore`]; full bodies live
+//! pointers to redacted payloads stored in a [`BlobStore`]; full bodies live
 //! in a separate content-addressed store so events stay small and queryable.
 //!
 //! [`JsonlFileSink`] writes one JSON object per line to
@@ -160,10 +160,11 @@ impl AuditSink for InMemorySink {
             .blob_store
             .write(content)
             .unwrap_or_else(|err| format!("error:{err}"));
+        let stored = self.blob_store.redact_for_storage(content);
         self.blobs
             .lock()
             .expect("blob mutex")
-            .push((hash.clone(), content.to_vec()));
+            .push((hash.clone(), stored));
         hash
     }
 }

--- a/crates/orbit-common/src/utility/blob_store.rs
+++ b/crates/orbit-common/src/utility/blob_store.rs
@@ -2,11 +2,13 @@
 //!
 //! Writes bytes to `{root}/{hash[..2]}/{hash}` keyed by sha256 of the
 //! post-redaction content. De-duplicates: if the target path already exists
-//! the write is a no-op. Intended for audit/verbatim payload storage where
+//! the write is a no-op. Intended for audit payload storage where
 //! events reference blobs by hash rather than path.
 //!
-//! Redaction runs at write time via a [`PatternRedactor`]; the stored bytes
-//! are already safe, so read-side tooling does not need to re-apply it.
+//! Redaction runs at write time via [`redact_all`] plus an optional
+//! caller-supplied [`PatternRedactor`]; the stored bytes are already safe, so
+//! read-side tooling does not need to re-apply it. Blob hashes are computed
+//! from those post-redaction bytes.
 
 use std::fs;
 use std::io::{self, Write};
@@ -14,23 +16,26 @@ use std::path::{Path, PathBuf};
 
 use sha2::{Digest, Sha256};
 
-use super::redaction::PatternRedactor;
+use super::redaction::{PatternRedactor, redact_all};
 
 pub struct BlobStore {
     root: PathBuf,
-    redactor: PatternRedactor,
+    extra_redactor: PatternRedactor,
 }
 
 impl BlobStore {
     pub fn new<P: Into<PathBuf>>(root: P) -> Self {
         Self {
             root: root.into(),
-            redactor: PatternRedactor::http_default(),
+            extra_redactor: PatternRedactor::empty(),
         }
     }
 
+    /// Add caller-specific pattern redaction on top of the mandatory
+    /// `redact_all()` pass. This cannot weaken the default env-value and HTTP
+    /// pattern redaction applied by [`BlobStore::write`].
     pub fn with_redaction(mut self, redactor: PatternRedactor) -> Self {
-        self.redactor = redactor;
+        self.extra_redactor = redactor;
         self
     }
 
@@ -39,7 +44,7 @@ impl BlobStore {
     }
 
     pub fn write(&self, content: &[u8]) -> io::Result<String> {
-        let redacted = self.redactor.apply_bytes(content);
+        let redacted = self.redact_for_storage(content);
         let hash = sha256_hex(&redacted);
         let dir = self.root.join(&hash[..2]);
         fs::create_dir_all(&dir)?;
@@ -60,6 +65,18 @@ impl BlobStore {
             f.flush()?;
         }
         Ok(hash)
+    }
+
+    /// Return the bytes that would be persisted for `content` after the
+    /// mandatory env/pattern redaction and any extra caller redactor.
+    pub fn redact_for_storage(&self, content: &[u8]) -> Vec<u8> {
+        match std::str::from_utf8(content) {
+            Ok(text) => self
+                .extra_redactor
+                .apply_str(&redact_all(text))
+                .into_bytes(),
+            Err(_) => self.extra_redactor.apply_bytes(content),
+        }
     }
 
     pub fn read(&self, sha256: &str) -> io::Result<Vec<u8>> {

--- a/crates/orbit-common/src/utility/redaction.rs
+++ b/crates/orbit-common/src/utility/redaction.rs
@@ -22,7 +22,7 @@
 // ORB-00013: Existing expect calls in this module document local invariants; keep the allow scoped while the workspace lint is ratcheted.
 #![allow(clippy::expect_used)]
 
-use std::{borrow::Cow, sync::OnceLock};
+use std::{borrow::Cow, ffi::OsString, sync::OnceLock};
 
 use regex::Regex;
 use serde_json::Value;
@@ -151,6 +151,19 @@ fn sensitive_env_values() -> Vec<String> {
     values.sort_by_key(|value| std::cmp::Reverse(value.len()));
     values.dedup();
     values
+}
+
+/// Return the current process environment with sensitive variable names
+/// removed. Provider subprocesses use this when they need normal runtime
+/// context such as `PATH`/`HOME` without inheriting ambient credentials.
+pub fn non_sensitive_env_vars() -> Vec<(OsString, OsString)> {
+    std::env::vars_os()
+        .filter(|(name, _)| {
+            name.to_str()
+                .map(|name| !is_sensitive_env_name(name))
+                .unwrap_or(true)
+        })
+        .collect()
 }
 
 fn is_redactable_value(value: &str) -> bool {

--- a/crates/orbit-common/src/utility/tests/blob_store.rs
+++ b/crates/orbit-common/src/utility/tests/blob_store.rs
@@ -1,0 +1,103 @@
+#![allow(missing_docs)]
+
+use std::ffi::OsString;
+
+use sha2::{Digest, Sha256};
+use tempfile::tempdir;
+
+use super::super::blob_store::BlobStore;
+use super::super::redaction::{PatternRedactor, redact_all};
+
+struct EnvVarGuard {
+    key: &'static str,
+    previous: Option<OsString>,
+}
+
+impl EnvVarGuard {
+    fn set(key: &'static str, value: &str) -> Self {
+        let previous = std::env::var_os(key);
+        // SAFETY: this test uses a dedicated variable name and restores the
+        // previous value on drop.
+        unsafe {
+            std::env::set_var(key, value);
+        }
+        Self { key, previous }
+    }
+}
+
+impl Drop for EnvVarGuard {
+    fn drop(&mut self) {
+        // SAFETY: see EnvVarGuard::set.
+        unsafe {
+            match &self.previous {
+                Some(value) => std::env::set_var(self.key, value),
+                None => std::env::remove_var(self.key),
+            }
+        }
+    }
+}
+
+#[test]
+fn write_hashes_and_stores_env_redacted_bytes() {
+    let temp = tempdir().expect("tempdir");
+    let secret = "live-audit-blob-secret-value";
+    let _guard = EnvVarGuard::set("ORBIT_BLOB_STORE_TEST_TOKEN", secret);
+    let store = BlobStore::new(temp.path());
+    let raw = format!("stdout contains {secret}\nAuthorization: Bearer pattern-secret-token\n");
+
+    let hash = store.write(raw.as_bytes()).expect("write blob");
+    let stored = store.read(&hash).expect("read blob");
+    let stored_text = String::from_utf8(stored).expect("stored utf8");
+
+    assert!(!stored_text.contains(secret));
+    assert!(!stored_text.contains("pattern-secret-token"));
+    assert!(stored_text.contains("[REDACTED_ENV]"));
+    assert!(stored_text.contains("[REDACTED_AUTH]"));
+    assert_eq!(hash, sha256_hex(redact_all(&raw).as_bytes()));
+}
+
+#[test]
+fn caller_redaction_cannot_weaken_default_redaction() {
+    let temp = tempdir().expect("tempdir");
+    let secret = "live-audit-blob-empty-redactor-secret";
+    let _guard = EnvVarGuard::set("ORBIT_BLOB_EMPTY_REDACTOR_TOKEN", secret);
+    let store = BlobStore::new(temp.path()).with_redaction(PatternRedactor::empty());
+    let raw = format!("{secret}\n{{\"api_key\":\"json-secret\"}}\n");
+
+    let hash = store.write(raw.as_bytes()).expect("write blob");
+    let stored = store.read(&hash).expect("read blob");
+    let stored_text = String::from_utf8(stored).expect("stored utf8");
+
+    assert!(!stored_text.contains(secret));
+    assert!(!stored_text.contains("json-secret"));
+    assert!(stored_text.contains("[REDACTED_ENV]"));
+    assert!(stored_text.contains("[REDACTED_AUTH]"));
+    assert_eq!(hash, sha256_hex(redact_all(&raw).as_bytes()));
+}
+
+#[test]
+fn caller_redaction_can_add_stronger_patterns() {
+    let temp = tempdir().expect("tempdir");
+    let store = BlobStore::new(temp.path()).with_redaction(PatternRedactor::with_argv_secrets());
+    let raw = "argv accidentally contains sk-short\n";
+
+    let hash = store.write(raw.as_bytes()).expect("write blob");
+    let stored = store.read(&hash).expect("read blob");
+    let stored_text = String::from_utf8(stored).expect("stored utf8");
+    let expected = PatternRedactor::with_argv_secrets().apply_str(&redact_all(raw));
+
+    assert!(!stored_text.contains("sk-short"));
+    assert!(stored_text.contains("[REDACTED_API_KEY]"));
+    assert_eq!(hash, sha256_hex(expected.as_bytes()));
+}
+
+fn sha256_hex(bytes: &[u8]) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(bytes);
+    let digest = hasher.finalize();
+    let mut out = String::with_capacity(64);
+    for byte in digest {
+        out.push_str(&format!("{:02x}", byte));
+    }
+    out
+}

--- a/crates/orbit-common/src/utility/tests/mod.rs
+++ b/crates/orbit-common/src/utility/tests/mod.rs
@@ -1,3 +1,4 @@
+mod blob_store;
 mod glob;
 mod logging;
 #[cfg(unix)]

--- a/crates/orbit-engine/src/activity_job/cli_runner/spawn.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/spawn.rs
@@ -2,6 +2,7 @@ use std::path::Path;
 use std::process::{Child, Command, Stdio};
 
 use orbit_common::types::{ExecutorSandboxKind, OrbitError};
+use orbit_common::utility::redaction::non_sensitive_env_vars;
 use orbit_exec::{
     MacosSandboxSpawnRequest, compile_macos_sandbox_profile, sandbox_exec_available,
     sandbox_exec_unavailable_message, spawn_under_macos_sandbox,
@@ -43,6 +44,8 @@ pub(crate) fn spawn_bare(
     let mut command = Command::new(program);
     command
         .args(args)
+        .env_clear()
+        .envs(non_sensitive_env_vars())
         .envs(env.iter().map(|(key, value)| (key, value)))
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())

--- a/crates/orbit-engine/src/activity_job/cli_runner/tests/orchestrator.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/tests/orchestrator.rs
@@ -1,9 +1,11 @@
 #![allow(missing_docs)]
 
 use std::collections::HashMap;
+use std::ffi::OsString;
 use std::sync::Arc;
 use std::time::Duration;
 
+use orbit_agent::loop_engine::JsonlFileSink;
 use orbit_agent::loop_engine::audit::AuditSink;
 use orbit_common::types::activity_job::{AgentRole, V2AuditEventKind};
 use tempfile::tempdir;
@@ -193,6 +195,63 @@ printf '%s\n' '{"api_key":"stdout-json-key"}'
         Some("blob-2"),
         "full stdout should remain available via blob ref"
     );
+}
+
+#[test]
+fn run_cli_backend_redacts_live_env_values_in_stored_blobs() {
+    let temp = tempdir().expect("tempdir");
+    let secret = "live-cli-blob-secret-value";
+    let _guard = EnvVarGuard::set("ORBIT_CLI_BLOB_TEST_TOKEN", secret);
+    let script = temp.path().join("codex");
+    write_executable(
+        &script,
+        &format!(
+            "#!/bin/sh\ncat > /dev/null\nprintf '%s\\n' 'stdout leak {secret}'\nprintf '%s\\n' 'stderr leak {secret}' >&2\n"
+        ),
+    );
+
+    let loop_sink = Arc::new(
+        JsonlFileSink::open(temp.path().join("audit"), "job-cli-blob-redaction")
+            .expect("open loop sink"),
+    );
+    let sink_for_writer: Arc<dyn AuditSink> = loop_sink.clone();
+    let audit = Arc::new(V2AuditWriter::new(
+        "job-cli-blob-redaction",
+        "codex:gpt-5.5",
+        sink_for_writer,
+    ));
+    let host = TestHost::with_command(script.display().to_string());
+    let spec = test_agent_loop_spec(Duration::from_secs(5));
+
+    let outcome = run_cli_backend(
+        &host,
+        &spec,
+        "job-cli-blob-redaction",
+        audit,
+        &serde_json::json!({"prompt": format!("provider stdin contains {secret}")}),
+        None,
+    )
+    .expect("run succeeds");
+
+    assert!(outcome.success);
+    for key in ["stdin_blob_ref", "stdout_blob_ref", "stderr_blob_ref"] {
+        let blob_ref = outcome.output[key].as_str().expect("blob ref");
+        let text = String::from_utf8(
+            loop_sink
+                .blob_store()
+                .read(blob_ref)
+                .expect("read stored blob"),
+        )
+        .expect("stored blob utf8");
+        assert!(
+            !text.contains(secret),
+            "{key} should not contain raw live env value: {text}"
+        );
+        assert!(
+            text.contains("[REDACTED_ENV]"),
+            "{key} should include env redaction marker: {text}"
+        );
+    }
 }
 
 #[test]
@@ -494,6 +553,35 @@ fi
 
     assert!(outcome.success);
     assert_eq!(outcome.output["provider"], "grok");
+}
+
+struct EnvVarGuard {
+    key: &'static str,
+    previous: Option<OsString>,
+}
+
+impl EnvVarGuard {
+    fn set(key: &'static str, value: &str) -> Self {
+        let previous = std::env::var_os(key);
+        // SAFETY: this test uses a dedicated variable name and restores the
+        // previous value on drop.
+        unsafe {
+            std::env::set_var(key, value);
+        }
+        Self { key, previous }
+    }
+}
+
+impl Drop for EnvVarGuard {
+    fn drop(&mut self) {
+        // SAFETY: see EnvVarGuard::set.
+        unsafe {
+            match &self.previous {
+                Some(value) => std::env::set_var(self.key, value),
+                None => std::env::remove_var(self.key),
+            }
+        }
+    }
 }
 
 /// Regression for T20260508-17: a CLI subprocess that exits 0 but emits an

--- a/crates/orbit-engine/src/activity_job/cli_runner/tests/spawn.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/tests/spawn.rs
@@ -1,5 +1,7 @@
 #![allow(missing_docs)]
 
+use std::ffi::OsString;
+
 use orbit_common::types::OrbitError;
 use tempfile::tempdir;
 
@@ -21,6 +23,30 @@ fn spawn_bare_runs_program_in_provided_cwd() {
     assert_eq!(
         String::from_utf8(output.stdout).expect("stdout utf8"),
         format!("{}\n", cwd.display())
+    );
+}
+
+#[test]
+fn spawn_bare_does_not_inherit_ambient_sensitive_env() {
+    let _guard = EnvVarGuard::set("ORBIT_SPAWN_BARE_TEST_TOKEN", "parent-process-secret-value");
+    let SpawnedChild {
+        child,
+        _profile_temp,
+    } = spawn_bare(
+        "/bin/sh",
+        &sh_args(
+            "if [ -z \"${ORBIT_SPAWN_BARE_TEST_TOKEN+x}\" ]; then printf unset; else printf 'leaked:%s' \"$ORBIT_SPAWN_BARE_TEST_TOKEN\"; fi",
+        ),
+        &[],
+        None,
+    )
+    .expect("spawn succeeds");
+
+    let output = child.wait_with_output().expect("wait succeeds");
+    assert!(output.status.success());
+    assert_eq!(
+        String::from_utf8(output.stdout).expect("stdout utf8"),
+        "unset"
     );
 }
 
@@ -63,4 +89,33 @@ fn spawn_macos_sandboxed_falls_back_to_bare_exec_when_allow_fallback_set() {
     // because the sandbox-exec wrapper was bypassed.
     assert!(spawned._profile_temp.is_none());
     let _ = spawned.child.wait();
+}
+
+struct EnvVarGuard {
+    key: &'static str,
+    previous: Option<OsString>,
+}
+
+impl EnvVarGuard {
+    fn set(key: &'static str, value: &str) -> Self {
+        let previous = std::env::var_os(key);
+        // SAFETY: this test uses a dedicated variable name and restores the
+        // previous value on drop.
+        unsafe {
+            std::env::set_var(key, value);
+        }
+        Self { key, previous }
+    }
+}
+
+impl Drop for EnvVarGuard {
+    fn drop(&mut self) {
+        // SAFETY: see EnvVarGuard::set.
+        unsafe {
+            match &self.previous {
+                Some(value) => std::env::set_var(self.key, value),
+                None => std::env::remove_var(self.key),
+            }
+        }
+    }
 }

--- a/crates/orbit-exec/src/macos_sandbox/spawn.rs
+++ b/crates/orbit-exec/src/macos_sandbox/spawn.rs
@@ -2,6 +2,7 @@ use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
 
 use orbit_common::types::OrbitError;
+use orbit_common::utility::redaction::non_sensitive_env_vars;
 use tempfile::NamedTempFile;
 
 const TRUSTED_SANDBOX_EXEC_PATHS: &[&str] = &["/usr/bin/sandbox-exec"];
@@ -57,6 +58,8 @@ pub fn spawn_under_macos_sandbox(
         .arg(&profile_path)
         .arg(program)
         .args(args)
+        .env_clear()
+        .envs(non_sensitive_env_vars())
         .envs(env.iter().map(|(key, value)| (key, value)))
         .stdin(stdin)
         .stdout(stdout)


### PR DESCRIPTION
## Task

[ORB-00267](https://orbit-cli.com/tasks/ORB-00267) — Apply env-aware redaction to persisted audit blobs

### Description

Codex Security repository scan finding.

Audit blob storage uses `BlobStore::new`, which applies the pattern-only `PatternRedactor::http_default()` before writing bytes. Other surfaces use `redact_all()` to combine pattern redaction with live sensitive environment-value redaction, but blob writes for loop/tool payloads and CLI stdin/stdout/stderr do not apply that env-value layer. The CLI runner also spawns provider CLIs without clearing inherited environment, then persists stdout/stderr blobs.

Evidence:
- `crates/orbit-common/src/utility/blob_store.rs:25` constructs blob stores with `PatternRedactor::http_default()` only, and `blob_store.rs:41` applies only that redactor on write.
- `crates/orbit-common/src/utility/redaction.rs:290` shows the stronger `redact_all()` path that combines env and pattern scrubbing.
- `crates/orbit-agent/src/loop_engine/agent_loop.rs:329`/`:343` persist tool input/output blobs, and `agent_loop.rs:471`/`:485` persist provider request/response blobs.
- `crates/orbit-engine/src/activity_job/cli_runner/orchestrator.rs:137`, `:180`, and `:181` persist CLI stdin/stdout/stderr blobs.
- `crates/orbit-engine/src/activity_job/cli_runner/spawn.rs:43` builds a child command and `spawn.rs:46` adds env vars but does not clear inherited sensitive env before running provider CLIs.

Security impact: secret values that do not match the narrow HTTP/token regex patterns, but are present in live sensitive environment variables or provider/CLI output, can be durably stored in `.orbit/state/audit/blobs`.

### Acceptance Criteria

- Persisted audit blobs use a redaction strategy at least as strong as `redact_all()` or an equivalent env-value plus pattern redactor before computing/storing blob content.
- CLI provider subprocess environment handling is reviewed so secrets are not unnecessarily inherited; if inheritance is required, blob redaction tests cover emitted env values.
- Tests demonstrate that a live sensitive env var value printed to CLI stdout/stderr or included in a tool/provider payload is redacted in the stored blob, not only in previews.
- Blob hash behavior and downstream blob lookup semantics are updated/documented for post-redaction hashing if needed.
- `make ci-fast` passes.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Switched BlobStore writes to mandatory env-aware redact_all() before hashing/storing, with optional extra PatternRedactor only adding coverage and InMemorySink retaining redacted blob bytes.
- Added child-environment sanitization for CLI provider subprocesses in bare and macOS sandbox paths so ambient sensitive env vars are not inherited while explicit ORBIT_* runtime identity still flows.
- Added blob-store and CLI-runner tests proving live sensitive env values are redacted from stored stdin/stdout/stderr blobs and that ambient sensitive env vars are stripped from subprocesses.
- Updated audit blob documentation to state blob refs hash post-redaction bytes.

Assessment: Scoped security fix with focused tests and repo fast checks passing.

Validation:
- cargo test -p orbit-common utility::tests::blob_store --lib
- cargo test -p orbit-engine activity_job::cli_runner::tests::spawn --lib
- cargo test -p orbit-engine activity_job::cli_runner::tests::orchestrator::run_cli_backend_redacts_live_env_values_in_stored_blobs --lib
- cargo test -p orbit-agent loop_engine::audit::tests --lib
- cargo test -p orbit-engine activity_job::cli_runner::tests::orchestrator --lib
- cargo test -p orbit-exec macos_sandbox::tests::spawn --lib
- make ci-fast

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-00267-6a10fc34`
- Behind base: 0
- Ahead of base: 1