### PR TITLE
Bound dashboard run-events JSONL reads

### DIFF
--- a/crates/orbit-dashboard/src/api/runs.rs
+++ b/crates/orbit-dashboard/src/api/runs.rs
@@ -1,5 +1,6 @@
 //! Run lifecycle: detail, cancel, replay, events, logs.
 
+use std::io::{BufRead, BufReader, Read};
 use std::path::{Path as FsPath, PathBuf};
 use std::sync::Arc;
 
@@ -18,6 +19,13 @@ use super::{
 use crate::projections::job_run_to_json;
 
 const RUN_EVENTS_DEFAULT_LIMIT: usize = 100;
+/// Hard cap on bytes scanned from a single run's audit JSONL per request.
+/// Streaming stops once this many bytes have been consumed; if the requested
+/// page is not yet full at that point, the endpoint returns 413.
+pub(super) const RUN_EVENTS_MAX_SCAN_BYTES: usize = 8 * 1024 * 1024;
+/// Hard cap on lines scanned from a single run's audit JSONL per request.
+/// Bounds CPU on pathological many-tiny-lines files.
+pub(super) const RUN_EVENTS_MAX_SCAN_LINES: usize = 50_000;
 /// Maximum bytes included in stdout/stderr previews returned by run-log APIs.
 const RUN_LOG_PREVIEW_MAX_BYTES: usize = 8192;
 /// Maximum lines included in stdout/stderr previews returned by run-log APIs.
@@ -150,8 +158,8 @@ pub(super) async fn list_run_events(
         Ok(None) => return Json(Value::Array(Vec::new())).into_response(),
         Err(e) => return map_runtime_error(e),
     };
-    let raw = match std::fs::read_to_string(&path) {
-        Ok(raw) => raw,
+    let file = match std::fs::File::open(&path) {
+        Ok(file) => file,
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
             return Json(Value::Array(Vec::new())).into_response();
         }
@@ -163,8 +171,36 @@ pub(super) async fn list_run_events(
         }
     };
 
-    let mut events: Vec<Value> = Vec::new();
-    for line in raw.lines() {
+    // Cap total bytes read from the file so an oversized JSONL cannot inflate
+    // process memory or saturate this task. `take` is the structural memory
+    // bound; `bytes_scanned` / `lines_scanned` below are the request-budget
+    // counters that drive the 413 response when the page can't be filled
+    // within the budget.
+    let bounded = file.take(RUN_EVENTS_MAX_SCAN_BYTES as u64 + 1);
+    let reader = BufReader::new(bounded);
+
+    let mut page: Vec<Value> = Vec::with_capacity(limit.min(64));
+    let mut matched: usize = 0;
+    let mut bytes_scanned: usize = 0;
+    let mut lines_scanned: usize = 0;
+    let mut budget_exceeded = false;
+
+    for line_result in reader.lines() {
+        let line = match line_result {
+            Ok(line) => line,
+            Err(e) => {
+                return server_error(orbit_core::OrbitError::Io(format!(
+                    "read {}: {e}",
+                    path.display()
+                )));
+            }
+        };
+        bytes_scanned = bytes_scanned.saturating_add(line.len()).saturating_add(1);
+        lines_scanned = lines_scanned.saturating_add(1);
+        if bytes_scanned > RUN_EVENTS_MAX_SCAN_BYTES || lines_scanned > RUN_EVENTS_MAX_SCAN_LINES {
+            budget_exceeded = true;
+            break;
+        }
         let trimmed = line.trim();
         if trimmed.is_empty() {
             continue;
@@ -179,14 +215,27 @@ pub(super) async fn list_run_events(
                 continue;
             }
         }
-        events.push(value);
+        if matched < offset {
+            matched = matched.saturating_add(1);
+            continue;
+        }
+        page.push(value);
+        matched = matched.saturating_add(1);
+        if page.len() >= limit {
+            break;
+        }
     }
 
-    if offset >= events.len() {
-        return Json(Value::Array(Vec::new())).into_response();
+    if budget_exceeded && page.len() < limit {
+        return (
+            StatusCode::PAYLOAD_TOO_LARGE,
+            Json(json!({
+                "error": "run-events audit log exceeds bounded scan budget; narrow the kind filter or reduce offset"
+            })),
+        )
+            .into_response();
     }
-    let end = offset.saturating_add(limit).min(events.len());
-    let page: Vec<Value> = events.drain(offset..end).collect();
+
     Json(Value::Array(page)).into_response()
 }
 

--- a/crates/orbit-dashboard/src/api/tests/runs.rs
+++ b/crates/orbit-dashboard/src/api/tests/runs.rs
@@ -46,12 +46,20 @@ async fn request_replay(runtime: OrbitRuntime, run_id: &str, origin: Option<&str
 }
 
 async fn request_dashboard_run_events(runtime: OrbitRuntime, encoded_run_id: &str) -> Response {
+    request_dashboard_run_events_query(runtime, encoded_run_id, "").await
+}
+
+async fn request_dashboard_run_events_query(
+    runtime: OrbitRuntime,
+    encoded_run_id: &str,
+    query: &str,
+) -> Response {
     Router::new()
         .nest("/api", router())
         .with_state(Arc::new(runtime))
         .oneshot(
             Request::builder()
-                .uri(format!("/api/runs/{encoded_run_id}/events"))
+                .uri(format!("/api/runs/{encoded_run_id}/events{query}"))
                 .body(Body::empty())
                 .expect("request"),
         )
@@ -184,6 +192,140 @@ async fn list_run_events_rejects_id_with_slashes() {
 
         assert_eq!(response.status(), StatusCode::BAD_REQUEST, "{label}");
     }
+}
+
+#[tokio::test]
+async fn list_run_events_streams_small_page_from_oversized_fixture() {
+    // Audit JSONL is larger than `RUN_EVENTS_MAX_SCAN_BYTES`. The bounded
+    // reader must fill a small page from events at the head of the file
+    // without scanning past the budget — proving the implementation does not
+    // load or accumulate the entire file before slicing.
+    let runtime = OrbitRuntime::in_memory().expect("build runtime");
+    let run_id = "jrun-events-oversize";
+    let audit_dir = runtime.data_root().join("state/audit/v2_loop");
+    std::fs::create_dir_all(&audit_dir).expect("create audit dir");
+    let path = audit_dir.join(format!("{run_id}.jsonl"));
+
+    let mut content = String::new();
+    for index in 0..10usize {
+        content.push_str(
+            &json!({
+                "schemaVersion": 1,
+                "event_type": "step.started",
+                "event_id": format!("evt-{index}"),
+                "run_id": run_id,
+                "body_kind": "step_started"
+            })
+            .to_string(),
+        );
+        content.push('\n');
+    }
+    let pad_bytes = super::super::runs::RUN_EVENTS_MAX_SCAN_BYTES + (1024 * 1024);
+    content.reserve(pad_bytes);
+    for _ in 0..pad_bytes {
+        content.push('x');
+    }
+    std::fs::write(&path, content).expect("write fixture");
+
+    let response = request_dashboard_run_events_query(runtime, run_id, "?limit=5").await;
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let payload = body_json(response).await;
+    let events = payload.as_array().expect("events array");
+    assert_eq!(events.len(), 5);
+    for (index, event) in events.iter().enumerate() {
+        assert_eq!(event["event_id"], format!("evt-{index}"));
+        assert_eq!(event["body_kind"], "step_started");
+    }
+}
+
+#[tokio::test]
+async fn list_run_events_returns_payload_too_large_when_scan_budget_exceeded() {
+    // Fill the file with valid events whose `body_kind` does NOT match the
+    // requested filter, forcing the streamer to walk past the budget without
+    // ever filling the page. The endpoint must enforce the budget and surface
+    // a clear 413 response instead of returning a misleading empty page after
+    // doing the full scan.
+    let runtime = OrbitRuntime::in_memory().expect("build runtime");
+    let run_id = "jrun-events-budget";
+    let audit_dir = runtime.data_root().join("state/audit/v2_loop");
+    std::fs::create_dir_all(&audit_dir).expect("create audit dir");
+    let path = audit_dir.join(format!("{run_id}.jsonl"));
+
+    let line = json!({
+        "schemaVersion": 1,
+        "event_type": "step.started",
+        "event_id": "evt-x",
+        "run_id": run_id,
+        "body_kind": "step_started"
+    })
+    .to_string();
+    let line_with_newline = format!("{line}\n");
+    let target_bytes = super::super::runs::RUN_EVENTS_MAX_SCAN_BYTES + line_with_newline.len();
+    let line_count = target_bytes / line_with_newline.len() + 1;
+    let mut content = String::with_capacity(line_count * line_with_newline.len());
+    for _ in 0..line_count {
+        content.push_str(&line_with_newline);
+    }
+    std::fs::write(&path, content).expect("write fixture");
+
+    let response =
+        request_dashboard_run_events_query(runtime, run_id, "?kind=does_not_match").await;
+
+    assert_eq!(response.status(), StatusCode::PAYLOAD_TOO_LARGE);
+    let payload = body_json(response).await;
+    let error = payload["error"].as_str().expect("error message");
+    assert!(
+        error.contains("bounded scan budget"),
+        "unexpected error: {error}"
+    );
+}
+
+#[tokio::test]
+async fn list_run_events_kind_filter_still_works_with_streaming() {
+    // Confirms AC3: streaming preserves kind filtering correctness.
+    let runtime = OrbitRuntime::in_memory().expect("build runtime");
+    let run_id = "jrun-events-kind";
+    let audit_dir = runtime.data_root().join("state/audit/v2_loop");
+    std::fs::create_dir_all(&audit_dir).expect("create audit dir");
+    write_lines(
+        &audit_dir.join(format!("{run_id}.jsonl")),
+        &[
+            json!({
+                "schemaVersion": 1,
+                "event_type": "run.started",
+                "event_id": "evt-run",
+                "run_id": run_id,
+                "body_kind": "run_started"
+            })
+            .to_string(),
+            json!({
+                "schemaVersion": 1,
+                "event_type": "step.started",
+                "event_id": "evt-step-a",
+                "run_id": run_id,
+                "body_kind": "step_started"
+            })
+            .to_string(),
+            json!({
+                "schemaVersion": 1,
+                "event_type": "step.started",
+                "event_id": "evt-step-b",
+                "run_id": run_id,
+                "body_kind": "step_started"
+            })
+            .to_string(),
+        ],
+    );
+
+    let response = request_dashboard_run_events_query(runtime, run_id, "?kind=step_started").await;
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let payload = body_json(response).await;
+    let events = payload.as_array().expect("events array");
+    assert_eq!(events.len(), 2);
+    assert_eq!(events[0]["event_id"], "evt-step-a");
+    assert_eq!(events[1]["event_id"], "evt-step-b");
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Task

[ORB-00268](https://orbit-cli.com/tasks/ORB-00268) — Bound dashboard run-events JSONL reads

### Description

Codex Security repository scan finding.

The dashboard `/api/runs/:id/events` endpoint enforces response pagination, but it first reads the entire v2 audit JSONL file into memory and accumulates every matching parsed event before slicing the requested page.

Evidence:
- `crates/orbit-dashboard/src/api/runs.rs:138` bounds the response `limit`.
- `crates/orbit-dashboard/src/api/runs.rs:153` calls `std::fs::read_to_string` on the whole audit file.
- `crates/orbit-dashboard/src/api/runs.rs:166` creates an unbounded `Vec<Value>` and `runs.rs:182` pushes every matching event before `runs.rs:185` applies offset/limit.

Security impact: a large or attacker-amplified audit file can make a local or reachable dashboard API request consume excessive memory and CPU despite paginated output.

### Acceptance Criteria

- The run-events handler reads audit JSONL in a memory-bounded way, applying offset/limit or tail/window semantics during streaming rather than after loading all content.
- The endpoint enforces a maximum bytes/lines/events budget per request and returns a clear error or truncated response when exceeded.
- Kind filtering remains correct under the bounded implementation.
- Tests cover an oversized JSONL fixture and prove the response path does not load/accumulate the entire file for a small page.
- `make ci-fast` passes.

## Execution Summary

<details>
<summary>Click to expand</summary>

Replaced the unbounded `std::fs::read_to_string` + `Vec<Value>` accumulation in `list_run_events` (`crates/orbit-dashboard/src/api/runs.rs`) with a streaming `BufReader` over `File::take(RUN_EVENTS_MAX_SCAN_BYTES + 1)`. Two new bounds — `RUN_EVENTS_MAX_SCAN_BYTES = 8 MiB` (structural memory cap via `take`, also the request-budget byte counter) and `RUN_EVENTS_MAX_SCAN_LINES = 50_000` (per-request CPU cap) — are tracked while scanning. Offset/limit are applied during streaming so we stop reading as soon as the requested page is full; kind filtering moves before page accumulation and remains correct. When the budget is exhausted before a full page is filled, the endpoint returns `413 PAYLOAD_TOO_LARGE` with a guidance message; otherwise the (possibly short) page is returned normally. Added test cases in `crates/orbit-dashboard/src/api/tests/runs.rs` covering an oversized JSONL fixture proving the bounded path, kind-filter correctness under the new code path, offset/limit behavior, and the 413 response. `make ci-fast` passes.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-00268-6a10fda2`
- Behind base: 0
- Ahead of base: 1