### PR TITLE
Limit dashboard log stream concurrency

### DIFF
--- a/crates/orbit-dashboard/src/api/log.rs
+++ b/crates/orbit-dashboard/src/api/log.rs
@@ -5,16 +5,17 @@ use std::fs::File;
 use std::io::{self, BufRead, BufReader, Seek, SeekFrom};
 use std::path::PathBuf;
 use std::pin::Pin;
+use std::sync::{Arc, OnceLock};
 use std::task::{Context, Poll};
 use std::thread;
 use std::time::Duration as StdDuration;
 
 use axum::body::Body;
 use axum::extract::Query;
-use axum::http::{StatusCode, header};
+use axum::http::{HeaderValue, StatusCode, header};
 use axum::response::{IntoResponse, Json, Response};
 use futures_core::Stream;
-use tokio::sync::mpsc;
+use tokio::sync::{OwnedSemaphorePermit, Semaphore, mpsc};
 
 use super::{LogQuery, map_runtime_error, non_empty_string, server_error};
 use crate::log_format::{
@@ -26,6 +27,42 @@ const LOG_DEFAULT_LIMIT: usize = 50;
 pub(super) const LOG_MAX_LIMIT: usize = 500;
 const LOG_STREAM_CHANNEL_DEPTH: usize = 64;
 const LOG_STREAM_POLL_INTERVAL: StdDuration = StdDuration::from_millis(50);
+/// Maximum number of concurrent `/api/log/stream` clients. Each accepted
+/// stream pins one native polling thread, so this cap bounds thread/FD/CPU
+/// usage even if the dashboard is bound beyond loopback.
+pub(super) const LOG_STREAM_MAX_CONCURRENT: usize = 8;
+
+/// Connection gate for log SSE streams.
+///
+/// Wraps a `tokio::sync::Semaphore` so the handler can `try_acquire` a permit
+/// per accepted stream. The permit is held by the polling thread and released
+/// when the thread exits (which happens within one poll interval after the
+/// client disconnects). Excess clients receive `503 Service Unavailable`.
+pub(super) struct LogStreamGate {
+    sem: Arc<Semaphore>,
+}
+
+impl LogStreamGate {
+    pub(super) fn new(max: usize) -> Self {
+        Self {
+            sem: Arc::new(Semaphore::new(max)),
+        }
+    }
+
+    pub(super) fn try_acquire(&self) -> Option<OwnedSemaphorePermit> {
+        Arc::clone(&self.sem).try_acquire_owned().ok()
+    }
+
+    #[cfg(test)]
+    pub(super) fn available_permits(&self) -> usize {
+        self.sem.available_permits()
+    }
+}
+
+fn global_log_stream_gate() -> &'static LogStreamGate {
+    static GATE: OnceLock<LogStreamGate> = OnceLock::new();
+    GATE.get_or_init(|| LogStreamGate::new(LOG_STREAM_MAX_CONCURRENT))
+}
 
 pub(super) async fn get_log(Query(q): Query<LogQuery>) -> Response {
     let path = match resolve_log_path(None) {
@@ -39,6 +76,10 @@ pub(super) async fn get_log(Query(q): Query<LogQuery>) -> Response {
 }
 
 pub(super) async fn stream_log(Query(q): Query<LogQuery>) -> Response {
+    let permit = match global_log_stream_gate().try_acquire() {
+        Some(p) => p,
+        None => return log_stream_unavailable(),
+    };
     let path = match resolve_log_path(None) {
         Ok(path) => path,
         Err(e) => return map_runtime_error(e),
@@ -48,7 +89,7 @@ pub(super) async fn stream_log(Query(q): Query<LogQuery>) -> Response {
         Err(e) => return map_runtime_error(e),
     };
     let stream = ReceiverSseStream {
-        rx: spawn_log_sse_frames(path, filters),
+        rx: spawn_log_sse_frames(path, filters, permit),
     };
     match Response::builder()
         .status(StatusCode::OK)
@@ -61,6 +102,22 @@ pub(super) async fn stream_log(Query(q): Query<LogQuery>) -> Response {
             "build SSE response: {e}"
         ))),
     }
+}
+
+pub(super) fn log_stream_unavailable() -> Response {
+    let mut response = (
+        StatusCode::SERVICE_UNAVAILABLE,
+        Json(serde_json::json!({
+            "error": format!(
+                "log stream concurrency limit reached (max {LOG_STREAM_MAX_CONCURRENT}); retry shortly"
+            )
+        })),
+    )
+        .into_response();
+    response
+        .headers_mut()
+        .insert(header::RETRY_AFTER, HeaderValue::from_static("5"));
+    response
 }
 
 // Widened to pub(super) so tests under api/tests/ (per-module layout migration ORB-00224)
@@ -96,9 +153,16 @@ pub(super) fn log_filters(query: &LogQuery) -> Result<LogFilters, orbit_core::Or
     )
 }
 
-fn spawn_log_sse_frames(path: PathBuf, filters: LogFilters) -> mpsc::Receiver<String> {
+fn spawn_log_sse_frames(
+    path: PathBuf,
+    filters: LogFilters,
+    permit: OwnedSemaphorePermit,
+) -> mpsc::Receiver<String> {
     let (tx, rx) = mpsc::channel(LOG_STREAM_CHANNEL_DEPTH);
     thread::spawn(move || {
+        // Permit is dropped when this thread exits, which happens within one
+        // poll interval of the client disconnecting (tx.is_closed()).
+        let _permit = permit;
         let mut offset = std::fs::metadata(&path).map(|m| m.len()).unwrap_or(0);
         let mut leftover = String::new();
         loop {

--- a/crates/orbit-dashboard/src/api/tests/log.rs
+++ b/crates/orbit-dashboard/src/api/tests/log.rs
@@ -3,11 +3,14 @@ use std::io::Write;
 use serde_json::json;
 use tempfile::tempdir;
 
+use axum::http::{StatusCode, header};
+
 use super::super::LogQuery;
 use super::super::log::{
-    LOG_MAX_LIMIT, format_sse_frame, read_appended_log_events, read_log_snapshot_from_path,
+    LOG_MAX_LIMIT, LogStreamGate, format_sse_frame, log_stream_unavailable,
+    read_appended_log_events, read_log_snapshot_from_path,
 };
-use super::test_support::write_lines;
+use super::test_support::{body_json, write_lines};
 use crate::log_format::Filters as LogFilters;
 
 #[test]
@@ -112,4 +115,51 @@ fn log_stream_framing_emits_one_data_frame_per_appended_line() {
     assert!(frame.ends_with("\n\n"));
     assert!(frame.contains("\"source\":\"job\""));
     assert!(frame.contains("build"));
+}
+
+#[test]
+fn log_stream_gate_caps_concurrent_acquisitions() {
+    let gate = LogStreamGate::new(2);
+    assert_eq!(gate.available_permits(), 2);
+
+    let p1 = gate.try_acquire().expect("first permit available");
+    let p2 = gate.try_acquire().expect("second permit available");
+    assert_eq!(gate.available_permits(), 0);
+
+    assert!(
+        gate.try_acquire().is_none(),
+        "third acquisition must be rejected when the cap is reached"
+    );
+
+    drop(p1);
+    assert_eq!(gate.available_permits(), 1);
+    let p3 = gate
+        .try_acquire()
+        .expect("permit available after one was released");
+
+    drop(p2);
+    drop(p3);
+    assert_eq!(
+        gate.available_permits(),
+        2,
+        "all permits return to the gate once stream owners drop them"
+    );
+}
+
+#[tokio::test]
+async fn log_stream_unavailable_returns_503_with_retry_after() {
+    let response = log_stream_unavailable();
+    assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+    let retry = response
+        .headers()
+        .get(header::RETRY_AFTER)
+        .expect("Retry-After header set");
+    assert_eq!(retry.to_str().expect("ascii Retry-After"), "5");
+    let body = body_json(response).await;
+    assert!(
+        body.get("error")
+            .and_then(|v| v.as_str())
+            .is_some_and(|s| s.contains("concurrency limit reached")),
+        "error message names the concurrency limit: {body}"
+    );
 }


### PR DESCRIPTION
## Task

[ORB-00269](https://orbit-cli.com/tasks/ORB-00269) — Limit dashboard log stream concurrency

### Description

Codex Security repository scan finding.

The dashboard `/api/log/stream` SSE endpoint spawns a native thread per connected client and polls until the client disconnects. There is no visible connection cap, timeout, shared broadcaster, or global stream budget.

Evidence:
- `crates/orbit-dashboard/src/api/log.rs:41` exposes the log stream handler.
- `crates/orbit-dashboard/src/api/log.rs:99` creates a channel per request and `log.rs:101` spawns a native thread per stream.
- `crates/orbit-dashboard/src/api/log.rs:104` loops until disconnect, sleeping at `log.rs:123`, with no concurrency limiter.

Security impact: many local or reachable clients can exhaust native threads, descriptors, or CPU in the dashboard process, especially when the dashboard is intentionally bound beyond loopback.

### Acceptance Criteria

- Dashboard log streaming enforces a bounded number of concurrent clients, uses a shared async broadcaster/tailer, or otherwise avoids one unbounded native thread per client.
- Excess clients receive a clear bounded failure response or are queued/closed according to documented behavior.
- Stream cleanup releases permits/resources promptly on client disconnect.
- Tests cover the configured max-stream behavior and resource cleanup path.
- `make ci-fast` passes.

## Execution Summary

<details>
<summary>Click to expand</summary>

Capped concurrent dashboard log SSE streams via a global `LogStreamGate` (`tokio::sync::Semaphore`, cap=8 in `LOG_STREAM_MAX_CONCURRENT`). `stream_log` now `try_acquire`s a permit before resolving the path/filters; excess clients receive `503 Service Unavailable` with `Retry-After: 5` and an explanatory JSON body via `log_stream_unavailable`. The permit is moved into the polling thread closure as `_permit`, so it is released only when the thread exits (within one 50ms poll interval after the client disconnects), bounding native threads to ≤8 regardless of incoming load. Added focused tests: `log_stream_gate_caps_concurrent_acquisitions` verifies cap + drop-releases-permit cleanup; `log_stream_unavailable_returns_503_with_retry_after` verifies status, header, and error body. `cargo build`, `cargo clippy -p orbit-dashboard --all-targets -- -D warnings`, and `make ci-fast` all pass.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-00269-6a10fe89`
- Behind base: 0
- Ahead of base: 1