### PR TITLE
Close semantic companion freshness-check TOCTOU window

### DIFF
--- a/crates/orbit-search/src/commands/install.rs
+++ b/crates/orbit-search/src/commands/install.rs
@@ -75,7 +75,22 @@ pub fn run(params: SemanticInstallParams) -> Result<SemanticInstallResult, Orbit
     let current_companion = if params.force {
         None
     } else {
-        ManagedCompanion::open_current(&companion_path).ok()
+        match ManagedCompanion::open_current(&companion_path) {
+            Ok(companion) => Some(companion),
+            Err(error) => {
+                // Covers integrity mismatch, missing manifest, path validation
+                // failures, and genuine I/O errors. We treat all of them as
+                // "needs reinstall," but record the cause so debugging "why
+                // did this just reinstall" doesn't require re-running with a
+                // patched build.
+                tracing::debug!(
+                    companion_path = %companion_path.display(),
+                    error = %error,
+                    "managed companion failed integrity or open check; treating as needs-reinstall"
+                );
+                None
+            }
+        }
     };
     let (companion_changed, companion) = if let Some(companion) = current_companion {
         (false, companion)
@@ -448,7 +463,7 @@ impl ManagedCompanion {
         sha256_file(&self.file)
     }
 
-    fn download_model(&self, model: &str, model_dir: &Path) -> Result<(), OrbitError> {
+    pub(crate) fn download_model(&self, model: &str, model_dir: &Path) -> Result<(), OrbitError> {
         match companion_launch_mode() {
             CompanionLaunchMode::FileDescriptor => {
                 #[cfg(any(
@@ -514,7 +529,16 @@ pub(crate) fn companion_launch_mode() -> CompanionLaunchMode {
     target_os = "dragonfly"
 )))]
 pub(crate) fn path_execution_fallback_rationale() -> &'static str {
-    "this platform does not expose fexecve through libc, so the managed companion keeps the pre-existing path execution behavior after descriptor-based freshness validation"
+    // Named explicitly so release notes and operators are unambiguous about
+    // which platforms still carry the original ORB-00271 TOCTOU window.
+    // macOS and Windows are the practical impact set: macOS ships no stable
+    // libc fexecve, and Windows has no equivalent fd-exec primitive at all.
+    // Descriptor-based freshness validation runs on every platform, but the
+    // model-download exec on these targets still goes through the path, so
+    // a process with write access to ~/.orbit/embed/bin/ between freshness
+    // check and exec can still substitute the binary. Tracked for posix_spawn
+    // /dev/fd/N exploration as a follow-up to ORB-00271."
+    "this platform (notably macOS, plus Windows) does not expose fexecve through libc, so the managed companion keeps the pre-existing path execution behavior after descriptor-based freshness validation; the descriptor-vs-path TOCTOU window from ORB-00271 remains open on these targets"
 }
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -682,8 +706,19 @@ fn run_companion_fd_for_model_download(
     let fd = file.as_raw_fd();
 
     let pid = {
-        // SAFETY: fork has no Rust-side preconditions. The child path only calls
-        // async-signal-safe fexecve/_exit with argv/env buffers prepared before fork.
+        // SAFETY: fork() is invoked with no Rust-side preconditions, but the
+        // standard multi-threaded fork hazard applies: after fork() the child
+        // inherits only the calling thread, so any state owned by other
+        // threads (allocator mutexes, tracing dispatch locks, tokio runtime
+        // state, etc.) is in an indeterminate state in the child. We rely on
+        // `orbit semantic install` being invoked from a synchronous CLI path
+        // (no tokio runtime active on this thread, no Rust-side locks held by
+        // other threads at this point). The child path only calls
+        // async-signal-safe libc primitives (fexecve, _exit) on buffers
+        // (argv_ptrs, env_ptrs, fd) prepared in the parent before fork, so
+        // it never re-enters Rust drop glue or the allocator. If a future
+        // caller introduces a runtime here, swap this for posix_spawn — the
+        // /dev/fd/<N> path is the equivalent and portable fix.
         unsafe { libc::fork() }
     };
     if pid < 0 {

--- a/crates/orbit-search/src/commands/install.rs
+++ b/crates/orbit-search/src/commands/install.rs
@@ -1,6 +1,20 @@
+#[cfg(any(
+    target_os = "linux",
+    target_os = "android",
+    target_os = "freebsd",
+    target_os = "dragonfly"
+))]
+use std::ffi::{CString, OsStr};
 use std::fs;
-use std::io::Write;
-use std::path::Path;
+use std::io::{Read, Seek, Write};
+#[cfg(any(
+    target_os = "linux",
+    target_os = "android",
+    target_os = "freebsd",
+    target_os = "dragonfly"
+))]
+use std::os::unix::ffi::OsStrExt;
+use std::path::{Path, PathBuf};
 use std::process::Command;
 
 use orbit_common::types::OrbitError;
@@ -58,11 +72,16 @@ pub fn run(params: SemanticInstallParams) -> Result<SemanticInstallResult, Orbit
     emit_stale_companion_hint(&paths);
 
     let companion_path = paths.companion_path();
-    let companion_changed = if params.force || companion_needs_install(&companion_path) {
-        install_companion(&companion_path)?;
-        true
+    let current_companion = if params.force {
+        None
     } else {
-        false
+        ManagedCompanion::open_current(&companion_path).ok()
+    };
+    let (companion_changed, companion) = if let Some(companion) = current_companion {
+        (false, companion)
+    } else {
+        install_companion(&companion_path)?;
+        (true, ManagedCompanion::open_current(&companion_path)?)
     };
 
     let model_dir = paths.model_dir(spec.alias);
@@ -71,7 +90,7 @@ pub fn run(params: SemanticInstallParams) -> Result<SemanticInstallResult, Orbit
         false
     } else {
         fs::create_dir_all(&model_dir).map_err(|error| OrbitError::Io(error.to_string()))?;
-        download_model_with_companion(&companion_path, spec.alias, &model_dir)?;
+        companion.download_model(spec.alias, &model_dir)?;
         true
     };
     fs::write(&paths.active_model_path, spec.alias)
@@ -400,13 +419,102 @@ fn legacy_platform_companion_filename() -> String {
     }
 }
 
-fn companion_needs_install(path: &Path) -> bool {
-    if !path.exists() || validate_managed_companion_path(path).is_err() {
-        return true;
+#[derive(Debug)]
+pub(crate) struct ManagedCompanion {
+    path: PathBuf,
+    file: fs::File,
+}
+
+impl ManagedCompanion {
+    pub(crate) fn open_current(path: &Path) -> Result<Self, OrbitError> {
+        validate_managed_companion_path(path)?;
+        let file = fs::File::open(path).map_err(|error| OrbitError::Io(error.to_string()))?;
+        let companion = Self {
+            path: path.to_path_buf(),
+            file,
+        };
+        // L-0036: Avoid native version probes; the sidecar lets us decide "install needed"
+        // without executing an untrusted binary, but is not a tamper-detection mechanism.
+        if !installed_companion_integrity_matches(&companion)? {
+            return Err(OrbitError::Execution(format!(
+                "installed search companion integrity metadata is stale for {}",
+                path.display()
+            )));
+        }
+        Ok(companion)
     }
-    // L-0036: Avoid native version probes; the sidecar lets us decide "install needed"
-    // without executing an untrusted binary, but is not a tamper-detection mechanism.
-    !installed_companion_integrity_matches(path).unwrap_or(false)
+
+    pub(crate) fn descriptor_checksum(&self) -> Result<String, OrbitError> {
+        sha256_file(&self.file)
+    }
+
+    fn download_model(&self, model: &str, model_dir: &Path) -> Result<(), OrbitError> {
+        match companion_launch_mode() {
+            CompanionLaunchMode::FileDescriptor => {
+                #[cfg(any(
+                    target_os = "linux",
+                    target_os = "android",
+                    target_os = "freebsd",
+                    target_os = "dragonfly"
+                ))]
+                {
+                    download_model_with_companion_fd(self, model, model_dir)
+                }
+                #[cfg(not(any(
+                    target_os = "linux",
+                    target_os = "android",
+                    target_os = "freebsd",
+                    target_os = "dragonfly"
+                )))]
+                {
+                    unreachable!("file-descriptor launch mode is unavailable on this target")
+                }
+            }
+            CompanionLaunchMode::Path => {
+                #[cfg(not(any(
+                    target_os = "linux",
+                    target_os = "android",
+                    target_os = "freebsd",
+                    target_os = "dragonfly"
+                )))]
+                tracing::debug!(
+                    companion_path = %self.path.display(),
+                    reason = path_execution_fallback_rationale(),
+                    "executing managed search companion by path"
+                );
+                download_model_with_companion_path(&self.path, model, model_dir)
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum CompanionLaunchMode {
+    FileDescriptor,
+    Path,
+}
+
+pub(crate) fn companion_launch_mode() -> CompanionLaunchMode {
+    if cfg!(any(
+        target_os = "linux",
+        target_os = "android",
+        target_os = "freebsd",
+        target_os = "dragonfly"
+    )) {
+        CompanionLaunchMode::FileDescriptor
+    } else {
+        CompanionLaunchMode::Path
+    }
+}
+
+#[cfg(not(any(
+    target_os = "linux",
+    target_os = "android",
+    target_os = "freebsd",
+    target_os = "dragonfly"
+)))]
+pub(crate) fn path_execution_fallback_rationale() -> &'static str {
+    "this platform does not expose fexecve through libc, so the managed companion keeps the pre-existing path execution behavior after descriptor-based freshness validation"
 }
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -415,11 +523,11 @@ struct CompanionIntegrityManifest {
     sha256: String,
 }
 
-fn installed_companion_integrity_matches(path: &Path) -> Result<bool, OrbitError> {
-    let manifest_path = companion_integrity_path(path).ok_or_else(|| {
+fn installed_companion_integrity_matches(companion: &ManagedCompanion) -> Result<bool, OrbitError> {
+    let manifest_path = companion_integrity_path(&companion.path).ok_or_else(|| {
         OrbitError::InvalidInput(format!(
             "companion destination has no file name: {}",
-            path.display()
+            companion.path.display()
         ))
     })?;
     let manifest =
@@ -430,10 +538,30 @@ fn installed_companion_integrity_matches(path: &Path) -> Result<bool, OrbitError
                 "companion integrity manifest is not valid JSON: {error}"
             ))
         })?;
-    let bytes = fs::read(path).map_err(|error| OrbitError::Io(error.to_string()))?;
-    let checksum = sha256_hex(&bytes);
+    let checksum = companion.descriptor_checksum()?;
     Ok(manifest.version == env!("CARGO_PKG_VERSION")
         && normalize_sha256(&manifest.sha256)? == checksum)
+}
+
+fn sha256_file(file: &fs::File) -> Result<String, OrbitError> {
+    let mut reader = file
+        .try_clone()
+        .map_err(|error| OrbitError::Io(error.to_string()))?;
+    reader
+        .seek(std::io::SeekFrom::Start(0))
+        .map_err(|error| OrbitError::Io(error.to_string()))?;
+    let mut hasher = Sha256::new();
+    let mut buffer = [0; 8192];
+    loop {
+        let count = reader
+            .read(&mut buffer)
+            .map_err(|error| OrbitError::Io(error.to_string()))?;
+        if count == 0 {
+            break;
+        }
+        hasher.update(&buffer[..count]);
+    }
+    Ok(format!("{:x}", hasher.finalize()))
 }
 
 pub(crate) fn write_companion_integrity(path: &Path, checksum: &str) -> Result<(), OrbitError> {
@@ -487,7 +615,7 @@ fn replace_companion(temp_path: &Path, destination: &Path) -> Result<(), OrbitEr
     fs::rename(temp_path, destination).map_err(|error| OrbitError::Io(error.to_string()))
 }
 
-fn download_model_with_companion(
+fn download_model_with_companion_path(
     companion_path: &Path,
     model: &str,
     model_dir: &Path,
@@ -510,6 +638,154 @@ fn download_model_with_companion(
         )));
     }
     Ok(())
+}
+
+#[cfg(any(
+    target_os = "linux",
+    target_os = "android",
+    target_os = "freebsd",
+    target_os = "dragonfly"
+))]
+fn download_model_with_companion_fd(
+    companion: &ManagedCompanion,
+    model: &str,
+    model_dir: &Path,
+) -> Result<(), OrbitError> {
+    if !run_companion_fd_for_model_download(&companion.file, &companion.path, model, model_dir)? {
+        return Err(OrbitError::Execution(format!(
+            "search companion failed to download model `{model}`"
+        )));
+    }
+    Ok(())
+}
+
+#[cfg(any(
+    target_os = "linux",
+    target_os = "android",
+    target_os = "freebsd",
+    target_os = "dragonfly"
+))]
+fn run_companion_fd_for_model_download(
+    file: &fs::File,
+    companion_path: &Path,
+    model: &str,
+    model_dir: &Path,
+) -> Result<bool, OrbitError> {
+    use std::os::fd::AsRawFd;
+
+    let argv = companion_argv(companion_path, model, model_dir)?;
+    let mut argv_ptrs = argv.iter().map(|arg| arg.as_ptr()).collect::<Vec<_>>();
+    argv_ptrs.push(std::ptr::null());
+    let env = companion_env()?;
+    let mut env_ptrs = env.iter().map(|value| value.as_ptr()).collect::<Vec<_>>();
+    env_ptrs.push(std::ptr::null());
+    let fd = file.as_raw_fd();
+
+    let pid = {
+        // SAFETY: fork has no Rust-side preconditions. The child path only calls
+        // async-signal-safe fexecve/_exit with argv/env buffers prepared before fork.
+        unsafe { libc::fork() }
+    };
+    if pid < 0 {
+        return Err(OrbitError::Execution(format!(
+            "failed to start search companion for model download: {}",
+            std::io::Error::last_os_error()
+        )));
+    }
+    if pid == 0 {
+        // SAFETY: fd references the opened companion file, argv/envp are
+        // null-terminated pointer arrays whose CString storage is alive across fork.
+        unsafe {
+            libc::fexecve(fd, argv_ptrs.as_ptr(), env_ptrs.as_ptr());
+            libc::_exit(127);
+        }
+    }
+    wait_for_companion(pid)
+}
+
+#[cfg(any(
+    target_os = "linux",
+    target_os = "android",
+    target_os = "freebsd",
+    target_os = "dragonfly"
+))]
+fn companion_argv(
+    companion_path: &Path,
+    model: &str,
+    model_dir: &Path,
+) -> Result<Vec<CString>, OrbitError> {
+    Ok(vec![
+        cstring_from_os(companion_path.as_os_str(), "companion path")?,
+        CString::new("--model").map_err(|error| OrbitError::InvalidInput(error.to_string()))?,
+        CString::new(model).map_err(|error| {
+            OrbitError::InvalidInput(format!("model identifier contains a NUL byte: {error}"))
+        })?,
+        CString::new("--model-path")
+            .map_err(|error| OrbitError::InvalidInput(error.to_string()))?,
+        cstring_from_os(model_dir.as_os_str(), "model path")?,
+        CString::new("--download-model")
+            .map_err(|error| OrbitError::InvalidInput(error.to_string()))?,
+    ])
+}
+
+#[cfg(any(
+    target_os = "linux",
+    target_os = "android",
+    target_os = "freebsd",
+    target_os = "dragonfly"
+))]
+fn companion_env() -> Result<Vec<CString>, OrbitError> {
+    std::env::vars_os()
+        .map(|(name, value)| {
+            let mut entry = name.as_os_str().as_bytes().to_vec();
+            entry.push(b'=');
+            entry.extend(value.as_os_str().as_bytes());
+            CString::new(entry).map_err(|error| {
+                OrbitError::InvalidInput(format!(
+                    "environment contains a NUL byte and cannot be passed to the companion: {error}"
+                ))
+            })
+        })
+        .collect()
+}
+
+#[cfg(any(
+    target_os = "linux",
+    target_os = "android",
+    target_os = "freebsd",
+    target_os = "dragonfly"
+))]
+fn cstring_from_os(value: &OsStr, label: &str) -> Result<CString, OrbitError> {
+    CString::new(value.as_bytes())
+        .map_err(|error| OrbitError::InvalidInput(format!("{label} contains a NUL byte: {error}")))
+}
+
+#[cfg(any(
+    target_os = "linux",
+    target_os = "android",
+    target_os = "freebsd",
+    target_os = "dragonfly"
+))]
+fn wait_for_companion(pid: libc::pid_t) -> Result<bool, OrbitError> {
+    let mut status = 0;
+    loop {
+        let waited = {
+            // SAFETY: waitpid is called for the child pid returned by fork with a valid
+            // pointer to collect its status.
+            unsafe { libc::waitpid(pid, &mut status, 0) }
+        };
+        if waited == pid {
+            break;
+        }
+        let error = std::io::Error::last_os_error();
+        if waited == -1 && error.raw_os_error() == Some(libc::EINTR) {
+            continue;
+        }
+        return Err(OrbitError::Execution(format!(
+            "failed to wait for search companion: {error}"
+        )));
+    }
+    Ok(libc::WIFEXITED(status) && libc::WEXITSTATUS(status) == 0)
 }
 
 #[cfg(unix)]

--- a/crates/orbit-search/src/commands/tests/install.rs
+++ b/crates/orbit-search/src/commands/tests/install.rs
@@ -1,8 +1,16 @@
 //! Unit tests for `install` — sibling layout under commands/tests/.
 
+#[cfg(not(any(
+    target_os = "linux",
+    target_os = "android",
+    target_os = "freebsd",
+    target_os = "dragonfly"
+)))]
+use super::super::install::path_execution_fallback_rationale;
 use super::super::install::{
-    CompanionIntegrity, SemanticInstallParams, checksum_from_manifest, resolve_download_source,
-    run, sha256_hex, verify_release_checksum_signature_with_key,
+    CompanionIntegrity, CompanionLaunchMode, ManagedCompanion, SemanticInstallParams,
+    checksum_from_manifest, companion_launch_mode, resolve_download_source, run, sha256_hex,
+    verify_release_checksum_signature_with_key,
 };
 
 use crate::companion::unsafe_companion_overrides_enabled;
@@ -80,6 +88,57 @@ fn current_companion_is_left_in_place_without_force() {
             .expect("read kept companion")
             .contains("replacement-marker: kept-current")
     );
+}
+
+#[test]
+#[cfg(unix)]
+fn current_companion_freshness_hash_uses_open_descriptor() {
+    let _guard = EnvGuard::new();
+    let fixture = InstallFixture::new();
+    fixture.write_installed_companion(env!("CARGO_PKG_VERSION"), "descriptor-held");
+
+    let companion = ManagedCompanion::open_current(&fixture.paths.companion_path())
+        .expect("current install should verify");
+    let original_checksum = companion
+        .descriptor_checksum()
+        .expect("hash opened descriptor");
+    fixture.replace_installed_companion(env!("CARGO_PKG_VERSION"), "path-swapped");
+    let path_checksum = sha256_hex(
+        &std::fs::read(fixture.paths.companion_path()).expect("read swapped companion path"),
+    );
+
+    assert_ne!(original_checksum, path_checksum);
+    assert_eq!(
+        companion
+            .descriptor_checksum()
+            .expect("hash retained descriptor"),
+        original_checksum
+    );
+}
+
+#[test]
+fn companion_launch_mode_matches_platform_support() {
+    #[cfg(any(
+        target_os = "linux",
+        target_os = "android",
+        target_os = "freebsd",
+        target_os = "dragonfly"
+    ))]
+    assert_eq!(companion_launch_mode(), CompanionLaunchMode::FileDescriptor);
+
+    #[cfg(not(any(
+        target_os = "linux",
+        target_os = "android",
+        target_os = "freebsd",
+        target_os = "dragonfly"
+    )))]
+    {
+        assert_eq!(companion_launch_mode(), CompanionLaunchMode::Path);
+        assert!(
+            path_execution_fallback_rationale().contains("fexecve"),
+            "fallback rationale should name the missing fd-exec primitive"
+        );
+    }
 }
 
 #[test]
@@ -322,6 +381,15 @@ impl InstallFixture {
     #[cfg(unix)]
     fn write_installed_companion(&self, version: &str, marker: &str) {
         write_mock_companion(&self.paths.companion_path(), version, marker);
+        write_test_companion_integrity(&self.paths.companion_path(), version);
+    }
+
+    #[cfg(unix)]
+    fn replace_installed_companion(&self, version: &str, marker: &str) {
+        let replacement_path = self.paths.bin_dir.join("replacement-companion");
+        write_mock_companion(&replacement_path, version, marker);
+        std::fs::rename(&replacement_path, self.paths.companion_path())
+            .expect("replace installed companion");
         write_test_companion_integrity(&self.paths.companion_path(), version);
     }
 

--- a/crates/orbit-search/src/commands/tests/install.rs
+++ b/crates/orbit-search/src/commands/tests/install.rs
@@ -116,6 +116,55 @@ fn current_companion_freshness_hash_uses_open_descriptor() {
     );
 }
 
+/// End-to-end coverage for the fexecve launch path on platforms that
+/// actually use it. Writes a mock companion that records its own marker on
+/// `--download-model`, opens it as a `ManagedCompanion`, swaps the binary at
+/// the install path, then drives the model download. The marker file proves
+/// the fd-held binary ran, not the path-swapped one.
+#[test]
+#[cfg(any(
+    target_os = "linux",
+    target_os = "android",
+    target_os = "freebsd",
+    target_os = "dragonfly"
+))]
+fn fd_launch_executes_descriptor_not_path_after_swap() {
+    let _guard = EnvGuard::new();
+    let fixture = InstallFixture::new();
+    let model_dir = fixture.paths.models_dir.join("test-model");
+    std::fs::create_dir_all(&model_dir).expect("create model dir");
+
+    write_marker_companion(
+        &fixture.paths.companion_path(),
+        env!("CARGO_PKG_VERSION"),
+        "original",
+    );
+    write_test_companion_integrity(&fixture.paths.companion_path(), env!("CARGO_PKG_VERSION"));
+
+    let companion = ManagedCompanion::open_current(&fixture.paths.companion_path())
+        .expect("current install should verify");
+
+    // Swap the binary at the install path. A path-based exec would now pick
+    // up the "swapped" variant; an fd-based exec must still run "original".
+    let replacement_path = fixture.paths.bin_dir.join("replacement-companion");
+    write_marker_companion(&replacement_path, env!("CARGO_PKG_VERSION"), "swapped");
+    std::fs::rename(&replacement_path, fixture.paths.companion_path())
+        .expect("rename replacement into place");
+    write_test_companion_integrity(&fixture.paths.companion_path(), env!("CARGO_PKG_VERSION"));
+
+    companion
+        .download_model("test-model", &model_dir)
+        .expect("fd-based model download succeeds");
+
+    let marker = std::fs::read_to_string(model_dir.join("companion-identity.txt"))
+        .expect("mock companion should have written its identity marker");
+    assert_eq!(
+        marker.trim(),
+        "original",
+        "fexecve must run the descriptor held by ManagedCompanion, not the path-swapped binary"
+    );
+}
+
 #[test]
 fn companion_launch_mode_matches_platform_support() {
     #[cfg(any(
@@ -457,6 +506,51 @@ exit 0
     let mut permissions = std::fs::metadata(path).expect("metadata").permissions();
     permissions.set_mode(0o755);
     std::fs::set_permissions(path, permissions).expect("chmod companion");
+}
+
+/// A companion variant that records its identity to `<model_dir>/companion-identity.txt`
+/// on `--download-model`, used by the fd-launch end-to-end test. Argument parsing
+/// is minimal because the real companion accepts `--model X --model-path Y --download-model`.
+#[cfg(any(
+    target_os = "linux",
+    target_os = "android",
+    target_os = "freebsd",
+    target_os = "dragonfly"
+))]
+fn write_marker_companion(path: &std::path::Path, version: &str, marker: &str) {
+    use std::os::unix::fs::PermissionsExt;
+
+    let script = format!(
+        r#"#!/bin/sh
+# marker-companion: {marker}
+model_path=""
+download=0
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --model-path)
+      shift
+      model_path="$1"
+      ;;
+    --download-model)
+      download=1
+      ;;
+  esac
+  shift
+done
+if [ "$1" = "--version-info" ] || [ "$2" = "--version-info" ]; then
+  printf '%s\n' '{{"id":0,"result":{{"model_id":"bge-small-en-v1.5","dim":0,"max_input_tokens":0,"version":"{version}"}}}}'
+  exit 0
+fi
+if [ "$download" = "1" ] && [ -n "$model_path" ]; then
+  printf '%s\n' '{marker}' > "$model_path/companion-identity.txt"
+fi
+exit 0
+"#
+    );
+    std::fs::write(path, script).expect("write marker companion");
+    let mut permissions = std::fs::metadata(path).expect("metadata").permissions();
+    permissions.set_mode(0o755);
+    std::fs::set_permissions(path, permissions).expect("chmod marker companion");
 }
 
 #[cfg(unix)]


### PR DESCRIPTION
## Task

[ORB-00271](https://orbit-cli.com/tasks/ORB-00271) — Close semantic companion freshness-check TOCTOU window

### Description

Follow-up from PR #411 review for ORB-00265. `orbit semantic install` now avoids executing an installed companion during freshness checks by hashing the binary and reading the sidecar manifest, but a process with write access to `~/.orbit/embed/bin/` could still swap the binary between that hash/read check and the later model-download execution. This is defense-in-depth because write access to the install directory is already highly privileged, but Unix platforms can reduce the window by hashing from an opened file descriptor and executing the same descriptor where supported.

### Acceptance Criteria

- The managed companion freshness path avoids a path-based hash-then-exec gap where the platform provides a safe file-descriptor execution primitive.
- Unsupported platforms retain the current path-based behavior with an explicit documented rationale.
- Tests cover the chosen platform abstraction or fallback behavior without executing arbitrary `$PATH` candidates.
- `make ci-fast` passes after the implementation.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Reworked semantic companion install freshness to open the managed companion once, hash that opened descriptor against the sidecar manifest, and retain the handle used for model download.
- Added a file-descriptor launch path using `fexecve` on Linux/Android/FreeBSD/DragonFly, with unsupported targets explicitly retaining path execution and documenting the missing `fexecve` primitive as the rationale.
- Added focused install tests proving the freshness hash is tied to the opened descriptor after a path swap, plus launch-mode/fallback coverage without executing `$PATH` candidates.

Assessment: The managed-install TOCTOU window is closed on platforms with fd execution while existing unsupported-platform behavior remains intentional and documented.

Validation:
- `cargo fmt --check`
- `cargo test -p orbit-search -- --quiet`
- `cargo clippy -p orbit-search --all-targets -- -D warnings`
- `make ci-fast`
- `git diff --check`

Notes:
- Attempted `cargo check -p orbit-search --target x86_64-unknown-linux-gnu --lib`; it was blocked by missing cross OpenSSL/sqlite toolchain configuration on this macOS host, before checking crate code.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-00271-6a1116cd`
- Behind base: 0
- Ahead of base: 1