### PR TITLE
Add release signing key rotation support for installers

### DIFF
--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -23,6 +23,19 @@ release workflow signs `orbit-checksums.txt` as `orbit-checksums.txt.sig`;
 both `install.sh` and the npm postinstall authenticate that signature before
 trusting release-hosted SHA-256 values.
 
+The installers carry a small release-signing trust set, not a single forever
+key:
+
+- `orbit-release-2026-05-primary` — current signing path, valid through
+  `2027-12-31`, not revoked.
+- `orbit-release-2026-05-successor` — pre-staged successor signing path,
+  valid through `2028-12-31`, not revoked.
+
+During verification the installers try each known public key, then reject a
+matching key if its `not_after` date has passed or its `revoked_at` field is
+set. A signature that matches none of the trusted keys is rejected as
+untrusted.
+
 ## Steps to cut a release
 
 Each step names the exact file or command. Do them in order.
@@ -129,8 +142,49 @@ Installer environment overrides are trust-boundary changes:
   authenticity, so installers require
   `ORBIT_RELEASE_PUBLIC_KEY_FILE_ACKNOWLEDGE_TRUST_CHANGE=1` and log when the
   override is active.
-- Follow-up task `ORB-00270` tracks key rotation / multi-key support beyond
-  this first pinned release key.
+- `ORBIT_RELEASE_TRUSTED_KEYS_FILE` exists for deterministic installer tests
+  and emergency operations that need a full replacement trust set with key
+  IDs, `not_after`, and `revoked_at` metadata. Each record is
+  `key_id|not_after|revoked_at|public_key_path`; empty `not_after` means no
+  expiry and empty `revoked_at` means active. It also requires
+  `ORBIT_RELEASE_TRUSTED_KEYS_FILE_ACKNOWLEDGE_TRUST_CHANGE=1`.
+
+## Release signing key rotation and revocation
+
+Normal rotation uses an overlap window:
+
+1. Generate the successor keypair offline. Add the public half to the trust
+   set in both `install.sh` and
+   [`plugin/npm/scripts/install-binary.js`](../plugin/npm/scripts/install-binary.js)
+   with a new key ID and `not_after` date. Keep the old active key until at
+   least one npm package containing both keys has been published.
+2. Publish a release and npm package that still signs with the old key, but
+   whose installers trust both old and new keys.
+3. Update `ORBIT_RELEASE_SIGNING_KEY_PEM` and
+   [`plugin/npm/release-signing.pub`](../plugin/npm/release-signing.pub) to the
+   successor key. Cut the next release signed by the successor key.
+4. After the overlap window, remove the old key from the trusted set or set
+   its `revoked_at` date if it should remain visible for audit history.
+
+Emergency revocation is intentionally more disruptive:
+
+1. Mark the compromised key record with `revoked_at: YYYY-MM-DD` in both
+   installers and publish a patch release signed by a non-revoked key.
+2. Update `ORBIT_RELEASE_SIGNING_KEY_PEM` and `release-signing.pub` to the
+   replacement key before cutting that patch release.
+3. Deprecate every already-published npm version whose postinstall still
+   trusts the compromised key, for example:
+
+   ```bash
+   npm deprecate '@orbit-tools/cli@<=X.Y.Z' \
+     'Release signing key revoked; upgrade to a patched @orbit-tools/cli.'
+   ```
+
+   npm packages are immutable after publish. Deprecation warns users and
+   install tooling, but old package tarballs still contain their old trust
+   set. Users pinned to a deprecated package can still run that package's
+   postinstall unless their package manager blocks deprecations, so the
+   release announcement must tell them to upgrade.
 
 Because npm publish is manual, the on-tag smoke run will fail if it fires
 before step 7 completes. That is expected and not actionable on its own;

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -26,15 +26,28 @@ trusting release-hosted SHA-256 values.
 The installers carry a small release-signing trust set, not a single forever
 key:
 
-- `orbit-release-2026-05-primary` — current signing path, valid through
-  `2027-12-31`, not revoked.
-- `orbit-release-2026-05-successor` — pre-staged successor signing path,
-  valid through `2028-12-31`, not revoked.
+- `orbit-release-key-1` — current signing path, valid through `2027-12-31`,
+  not revoked.
+- `orbit-release-key-2` — pre-staged successor signing path, valid through
+  `2028-12-31`, not revoked.
+
+Key IDs are stable generation labels (`key-1`, `key-2`, …). The numeric suffix
+is a generation counter, not a date, so an ID survives the rotation that
+promotes it from successor to primary without becoming confusing.
 
 During verification the installers try each known public key, then reject a
 matching key if its `not_after` date has passed or its `revoked_at` field is
 set. A signature that matches none of the trusted keys is rejected as
 untrusted.
+
+> **Operator custody requirement.** Pre-staging the successor key only buys
+> rotation speed if the successor private key is held in *independent* custody
+> from the primary. If both private halves are stored together (same secrets
+> manager, same machine), a single compromise gets both and the trust set's
+> benefit collapses. The current `orbit-release-key-2` private half is held
+> offline and is only loaded into `ORBIT_RELEASE_SIGNING_KEY_PEM` when the
+> rotation runbook is executed. Future generations must preserve this
+> separation.
 
 ## Steps to cut a release
 
@@ -137,17 +150,19 @@ Installer environment overrides are trust-boundary changes:
   the URL transport is not a confidentiality boundary.
 - `ORBIT_BINARY_VERSION` in the npm package changes the selected release tag
   while retaining signature verification.
-- `ORBIT_RELEASE_PUBLIC_KEY_FILE` exists for tests and emergency operations.
-  Setting it means the caller trusts that replacement key for release
-  authenticity, so installers require
-  `ORBIT_RELEASE_PUBLIC_KEY_FILE_ACKNOWLEDGE_TRUST_CHANGE=1` and log when the
-  override is active.
-- `ORBIT_RELEASE_TRUSTED_KEYS_FILE` exists for deterministic installer tests
-  and emergency operations that need a full replacement trust set with key
-  IDs, `not_after`, and `revoked_at` metadata. Each record is
-  `key_id|not_after|revoked_at|public_key_path`; empty `not_after` means no
-  expiry and empty `revoked_at` means active. It also requires
+- `ORBIT_RELEASE_TRUSTED_KEYS_FILE` is the preferred override for
+  deterministic installer tests and emergency operations: a full replacement
+  trust set with key IDs, `not_after`, and `revoked_at` metadata. Each record
+  is `key_id|not_after|revoked_at|public_key_path`; empty `not_after` means
+  no expiry and empty `revoked_at` means active. It requires
   `ORBIT_RELEASE_TRUSTED_KEYS_FILE_ACKNOWLEDGE_TRUST_CHANGE=1`.
+- `ORBIT_RELEASE_PUBLIC_KEY_FILE` is **deprecated** in favor of
+  `ORBIT_RELEASE_TRUSTED_KEYS_FILE` — the trusted-keys manifest is a strict
+  superset (it can express the single-key case as a one-row file *plus*
+  expiry/revocation metadata). The old var is retained for back-compat and
+  still requires `ORBIT_RELEASE_PUBLIC_KEY_FILE_ACKNOWLEDGE_TRUST_CHANGE=1`;
+  installers log a deprecation notice when it's in use. Both overrides cannot
+  be set simultaneously.
 
 ## Release signing key rotation and revocation
 
@@ -168,6 +183,17 @@ Normal rotation uses an overlap window:
 
 Emergency revocation is intentionally more disruptive:
 
+> **⚠️ Emergency revocation only protects users who upgrade.** Already-published
+> npm packages contain their old trust set permanently. Marking a key as
+> `revoked_at` in the *current* trust set blocks **new** releases signed by the
+> compromised key — it does **not** retroactively block users from running an
+> already-published `@orbit-tools/cli@<old>` package, whose postinstall still
+> carries the old trust set. `npm deprecate` and the release announcement are
+> the only revocation mechanisms for those installs; even then, package
+> managers that ignore deprecations will continue to execute the old
+> postinstall. Plan the release announcement to push users to upgrade *before*
+> the deprecation lands.
+
 1. Mark the compromised key record with `revoked_at: YYYY-MM-DD` in both
    installers and publish a patch release signed by a non-revoked key.
 2. Update `ORBIT_RELEASE_SIGNING_KEY_PEM` and `release-signing.pub` to the
@@ -179,12 +205,6 @@ Emergency revocation is intentionally more disruptive:
    npm deprecate '@orbit-tools/cli@<=X.Y.Z' \
      'Release signing key revoked; upgrade to a patched @orbit-tools/cli.'
    ```
-
-   npm packages are immutable after publish. Deprecation warns users and
-   install tooling, but old package tarballs still contain their old trust
-   set. Users pinned to a deprecated package can still run that package's
-   postinstall unless their package manager blocks deprecations, so the
-   release announcement must tell them to upgrade.
 
 Because npm publish is manual, the on-tag smoke run will fail if it fires
 before step 7 completes. That is expected and not actionable on its own;

--- a/install.sh
+++ b/install.sh
@@ -42,17 +42,8 @@ download() {
   fail "curl or wget is required to download Orbit releases"
 }
 
-write_trusted_public_key() {
+write_release_key_orbit_release_2026_05_primary() {
   destination="$1"
-
-  if [ -n "${ORBIT_RELEASE_PUBLIC_KEY_FILE:-}" ]; then
-    [ "${ORBIT_RELEASE_PUBLIC_KEY_FILE_ACKNOWLEDGE_TRUST_CHANGE:-}" = "1" ] \
-      || fail "ORBIT_RELEASE_PUBLIC_KEY_FILE requires ORBIT_RELEASE_PUBLIC_KEY_FILE_ACKNOWLEDGE_TRUST_CHANGE=1"
-    [ -f "$ORBIT_RELEASE_PUBLIC_KEY_FILE" ] || fail "ORBIT_RELEASE_PUBLIC_KEY_FILE does not exist: $ORBIT_RELEASE_PUBLIC_KEY_FILE"
-    warn "ORBIT_RELEASE_PUBLIC_KEY_FILE=$ORBIT_RELEASE_PUBLIC_KEY_FILE set; trusting replacement release signing key"
-    cat "$ORBIT_RELEASE_PUBLIC_KEY_FILE" > "$destination"
-    return
-  fi
 
   cat > "$destination" <<'EOF'
 -----BEGIN PUBLIC KEY-----
@@ -69,13 +60,107 @@ pYZDkW2dLqPeFj/WwGhZoYFHv0GOMIWdi6FNriQdkn4RAgMBAAE=
 EOF
 }
 
+write_release_key_orbit_release_2026_05_successor() {
+  destination="$1"
+
+  cat > "$destination" <<'EOF'
+-----BEGIN PUBLIC KEY-----
+MIIBojANBgkqhkiG9w0BAQEFAAOCAY8AMIIBigKCAYEA22OLkoJXb7PX/QwG7FzA
+eiDT0BctOq77WyXysUBlN1718pbjo30wLIW9d2h+cxPtld2PM35NQ4NMZJwl7lb2
+tZSWVUTRI9Se5eBhUEL6Gi4Rin4/In3NIx0YEVdA6SUA+x3OinPpe1BIN1pKGbpD
+P6GohwmrdbCUuZMv29UYPkREif6gnlehxj9ypZfZMVU7+VXOceeA5OT5iXbO4u29
+85bSys4JUN+SKtAao9BAjHCvMUJ4kL4mnGeteXRssmd5ehkEezUhWUNtP/uvKv+I
+5pjSto5vq6vqZMEpkOPDANPSUwz3F0CgyNmwHU8LKHtME+ZQqOP11xOC5Rgtw3zZ
+VQSAd3BLsSflu7ENV9lsbwPjvhSRDPlZsGUB4NGjUmFkUJPz7SGqT9LNXQqaRT2S
+8mHajs8Z/pkIMnOSOE339DHmT3xPz5eKRwZLBWttguJxHWFM50PT7g+K97Y6n9Zr
+zLEax5f3s3F9vPiWfA36hKJS5GzF564hCRViOQPqWnNlAgMBAAE=
+-----END PUBLIC KEY-----
+EOF
+}
+
+release_date_number() {
+  value="$1"
+
+  printf '%s' "$value" | awk '
+    /^[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]$/ {
+      gsub("-", "")
+      print
+      exit 0
+    }
+    { exit 1 }
+  ' || fail "invalid release signing key date: $value"
+}
+
+write_builtin_trusted_key_records() {
+  key_dir="${TMP_DIR}/trusted-release-keys"
+  mkdir -p "$key_dir"
+
+  primary_key_path="${key_dir}/orbit-release-2026-05-primary.pub"
+  successor_key_path="${key_dir}/orbit-release-2026-05-successor.pub"
+  write_release_key_orbit_release_2026_05_primary "$primary_key_path"
+  write_release_key_orbit_release_2026_05_successor "$successor_key_path"
+
+  printf 'orbit-release-2026-05-primary|2027-12-31||%s\n' "$primary_key_path"
+  printf 'orbit-release-2026-05-successor|2028-12-31||%s\n' "$successor_key_path"
+}
+
+trusted_key_records() {
+  if [ -n "${ORBIT_RELEASE_PUBLIC_KEY_FILE:-}" ] && [ -n "${ORBIT_RELEASE_TRUSTED_KEYS_FILE:-}" ]; then
+    fail "ORBIT_RELEASE_PUBLIC_KEY_FILE and ORBIT_RELEASE_TRUSTED_KEYS_FILE cannot both be set"
+  fi
+
+  if [ -n "${ORBIT_RELEASE_TRUSTED_KEYS_FILE:-}" ]; then
+    [ "${ORBIT_RELEASE_TRUSTED_KEYS_FILE_ACKNOWLEDGE_TRUST_CHANGE:-}" = "1" ] \
+      || fail "ORBIT_RELEASE_TRUSTED_KEYS_FILE requires ORBIT_RELEASE_TRUSTED_KEYS_FILE_ACKNOWLEDGE_TRUST_CHANGE=1"
+    [ -f "$ORBIT_RELEASE_TRUSTED_KEYS_FILE" ] || fail "ORBIT_RELEASE_TRUSTED_KEYS_FILE does not exist: $ORBIT_RELEASE_TRUSTED_KEYS_FILE"
+    warn "ORBIT_RELEASE_TRUSTED_KEYS_FILE=$ORBIT_RELEASE_TRUSTED_KEYS_FILE set; trusting replacement release signing key set"
+    cat "$ORBIT_RELEASE_TRUSTED_KEYS_FILE"
+    return
+  fi
+
+  if [ -n "${ORBIT_RELEASE_PUBLIC_KEY_FILE:-}" ]; then
+    [ "${ORBIT_RELEASE_PUBLIC_KEY_FILE_ACKNOWLEDGE_TRUST_CHANGE:-}" = "1" ] \
+      || fail "ORBIT_RELEASE_PUBLIC_KEY_FILE requires ORBIT_RELEASE_PUBLIC_KEY_FILE_ACKNOWLEDGE_TRUST_CHANGE=1"
+    [ -f "$ORBIT_RELEASE_PUBLIC_KEY_FILE" ] || fail "ORBIT_RELEASE_PUBLIC_KEY_FILE does not exist: $ORBIT_RELEASE_PUBLIC_KEY_FILE"
+    warn "ORBIT_RELEASE_PUBLIC_KEY_FILE=$ORBIT_RELEASE_PUBLIC_KEY_FILE set; trusting replacement release signing key"
+    printf 'override|||%s\n' "$ORBIT_RELEASE_PUBLIC_KEY_FILE"
+    return
+  fi
+
+  write_builtin_trusted_key_records
+}
+
 verify_checksum_signature() {
   checksum_path="$1"
   signature_path="$2"
-  public_key_path="$3"
+  records_path="${TMP_DIR}/trusted-release-key-records.txt"
+  today_number="$(release_date_number "$(date -u '+%Y-%m-%d')")"
 
-  openssl dgst -sha256 -verify "$public_key_path" -signature "$signature_path" "$checksum_path" >/dev/null 2>&1 \
-    || fail "release checksum signature verification failed for ${CHECKSUM_FILE}"
+  trusted_key_records > "$records_path"
+
+  while IFS='|' read -r key_id not_after revoked_at public_key_path; do
+    case "$key_id" in
+      "" | \#*)
+        continue
+        ;;
+    esac
+
+    [ -n "$public_key_path" ] || fail "trusted release signing key ${key_id} has no public key path"
+    [ -f "$public_key_path" ] || fail "trusted release signing key ${key_id} public key does not exist: $public_key_path"
+
+    if openssl dgst -sha256 -verify "$public_key_path" -signature "$signature_path" "$checksum_path" >/dev/null 2>&1; then
+      if [ -n "$revoked_at" ]; then
+        fail "release checksum signature was made by revoked release signing key ${key_id} (revoked ${revoked_at})"
+      fi
+      if [ -n "$not_after" ] && [ "$today_number" -gt "$(release_date_number "$not_after")" ]; then
+        fail "release checksum signature was made by expired release signing key ${key_id} (not_after ${not_after})"
+      fi
+      log "Authenticated ${CHECKSUM_FILE} with release signing key ${key_id}"
+      return
+    fi
+  done < "$records_path"
+
+  fail "release checksum signature verification failed for ${CHECKSUM_FILE}: no trusted release signing key matched"
 }
 
 compute_sha256() {
@@ -163,6 +248,7 @@ resolve_target() {
 }
 
 need_cmd awk
+need_cmd date
 need_cmd install
 need_cmd mktemp
 need_cmd openssl
@@ -193,13 +279,11 @@ fi
 ARCHIVE_PATH="${TMP_DIR}/${ARCHIVE_NAME}"
 CHECKSUM_PATH="${TMP_DIR}/${CHECKSUM_FILE}"
 SIGNATURE_PATH="${TMP_DIR}/${CHECKSUM_SIGNATURE_FILE}"
-PUBLIC_KEY_PATH="${TMP_DIR}/orbit-release-signing.pub"
 
 log "Downloading Orbit ${VERSION_LABEL} for ${TARGET}..."
 download "${BASE_URL}/${CHECKSUM_FILE}" "$CHECKSUM_PATH"
 download "${BASE_URL}/${CHECKSUM_SIGNATURE_FILE}" "$SIGNATURE_PATH"
-write_trusted_public_key "$PUBLIC_KEY_PATH"
-verify_checksum_signature "$CHECKSUM_PATH" "$SIGNATURE_PATH" "$PUBLIC_KEY_PATH"
+verify_checksum_signature "$CHECKSUM_PATH" "$SIGNATURE_PATH"
 download "${BASE_URL}/${ARCHIVE_NAME}" "$ARCHIVE_PATH"
 
 EXPECTED_SHA="$(awk -v asset="$ARCHIVE_NAME" '$2 == asset { print $1 }' "$CHECKSUM_PATH")"

--- a/install.sh
+++ b/install.sh
@@ -42,7 +42,10 @@ download() {
   fail "curl or wget is required to download Orbit releases"
 }
 
-write_release_key_orbit_release_2026_05_primary() {
+# Key IDs are stable labels carried alongside the public key blocks below.
+# The numeric suffix is a generation counter, not a date — IDs survive rotation
+# so a key that has been the "successor" for a year is still readable by ID.
+write_release_key_orbit_release_key_1() {
   destination="$1"
 
   cat > "$destination" <<'EOF'
@@ -60,7 +63,7 @@ pYZDkW2dLqPeFj/WwGhZoYFHv0GOMIWdi6FNriQdkn4RAgMBAAE=
 EOF
 }
 
-write_release_key_orbit_release_2026_05_successor() {
+write_release_key_orbit_release_key_2() {
   destination="$1"
 
   cat > "$destination" <<'EOF'
@@ -95,13 +98,13 @@ write_builtin_trusted_key_records() {
   key_dir="${TMP_DIR}/trusted-release-keys"
   mkdir -p "$key_dir"
 
-  primary_key_path="${key_dir}/orbit-release-2026-05-primary.pub"
-  successor_key_path="${key_dir}/orbit-release-2026-05-successor.pub"
-  write_release_key_orbit_release_2026_05_primary "$primary_key_path"
-  write_release_key_orbit_release_2026_05_successor "$successor_key_path"
+  primary_key_path="${key_dir}/orbit-release-key-1.pub"
+  successor_key_path="${key_dir}/orbit-release-key-2.pub"
+  write_release_key_orbit_release_key_1 "$primary_key_path"
+  write_release_key_orbit_release_key_2 "$successor_key_path"
 
-  printf 'orbit-release-2026-05-primary|2027-12-31||%s\n' "$primary_key_path"
-  printf 'orbit-release-2026-05-successor|2028-12-31||%s\n' "$successor_key_path"
+  printf 'orbit-release-key-1|2027-12-31||%s\n' "$primary_key_path"
+  printf 'orbit-release-key-2|2028-12-31||%s\n' "$successor_key_path"
 }
 
 trusted_key_records() {
@@ -123,6 +126,7 @@ trusted_key_records() {
       || fail "ORBIT_RELEASE_PUBLIC_KEY_FILE requires ORBIT_RELEASE_PUBLIC_KEY_FILE_ACKNOWLEDGE_TRUST_CHANGE=1"
     [ -f "$ORBIT_RELEASE_PUBLIC_KEY_FILE" ] || fail "ORBIT_RELEASE_PUBLIC_KEY_FILE does not exist: $ORBIT_RELEASE_PUBLIC_KEY_FILE"
     warn "ORBIT_RELEASE_PUBLIC_KEY_FILE=$ORBIT_RELEASE_PUBLIC_KEY_FILE set; trusting replacement release signing key"
+    warn "ORBIT_RELEASE_PUBLIC_KEY_FILE is deprecated; prefer ORBIT_RELEASE_TRUSTED_KEYS_FILE for the full trust set (key IDs, not_after, revoked_at)"
     printf 'override|||%s\n' "$ORBIT_RELEASE_PUBLIC_KEY_FILE"
     return
   fi

--- a/plugin/npm/README.md
+++ b/plugin/npm/README.md
@@ -33,9 +33,9 @@ Windows is not currently published. Use WSL or build from source.
 |---|---|
 | `ORBIT_BINARY` | Path to a local `orbit` binary; bypasses download and trusts that path as the binary source. |
 | `ORBIT_BINARY_VERSION` | Override the release tag to install (e.g. `v0.3.1`); this changes the release-selection trust boundary but still requires a valid Orbit checksum signature. |
-| `ORBIT_RELEASE_PUBLIC_KEY_FILE` | Test/operations override for the trusted checksum-signing public key; requires `ORBIT_RELEASE_PUBLIC_KEY_FILE_ACKNOWLEDGE_TRUST_CHANGE=1` and logs when active. |
+| `ORBIT_RELEASE_PUBLIC_KEY_FILE` | **Deprecated** in favor of `ORBIT_RELEASE_TRUSTED_KEYS_FILE`. Single-key override for the trusted checksum-signing public key; requires `ORBIT_RELEASE_PUBLIC_KEY_FILE_ACKNOWLEDGE_TRUST_CHANGE=1`, logs a deprecation notice when active. |
 | `ORBIT_RELEASE_PUBLIC_KEY_FILE_ACKNOWLEDGE_TRUST_CHANGE=1` | Required acknowledgement that `ORBIT_RELEASE_PUBLIC_KEY_FILE` replaces the release authenticity trust root. |
-| `ORBIT_RELEASE_TRUSTED_KEYS_FILE` | Test/operations override for the full trusted signing-key set, including key IDs, `not_after`, and `revoked_at`; requires `ORBIT_RELEASE_TRUSTED_KEYS_FILE_ACKNOWLEDGE_TRUST_CHANGE=1` and logs when active. |
+| `ORBIT_RELEASE_TRUSTED_KEYS_FILE` | Preferred test/operations override for the full trusted signing-key set, including key IDs, `not_after`, and `revoked_at`; requires `ORBIT_RELEASE_TRUSTED_KEYS_FILE_ACKNOWLEDGE_TRUST_CHANGE=1` and logs when active. |
 | `ORBIT_RELEASE_TRUSTED_KEYS_FILE_ACKNOWLEDGE_TRUST_CHANGE=1` | Required acknowledgement that `ORBIT_RELEASE_TRUSTED_KEYS_FILE` replaces the release authenticity trust root. |
 | `ORBIT_SKIP_DOWNLOAD=1` | Skip postinstall download (lazy install on first run still works). |
 

--- a/plugin/npm/README.md
+++ b/plugin/npm/README.md
@@ -4,7 +4,7 @@ npm proxy for the [Orbit](https://github.com/danieljhkim/orbit) CLI.
 
 On install, downloads the matching prebuilt `orbit` binary from
 [GitHub Releases](https://github.com/danieljhkim/orbit/releases), authenticates
-the signed `orbit-checksums.txt` with the package-pinned release public key,
+the signed `orbit-checksums.txt` with the package-pinned release trust set,
 verifies the archive SHA-256, and exposes it as the `orbit` command.
 
 ## Usage
@@ -35,6 +35,8 @@ Windows is not currently published. Use WSL or build from source.
 | `ORBIT_BINARY_VERSION` | Override the release tag to install (e.g. `v0.3.1`); this changes the release-selection trust boundary but still requires a valid Orbit checksum signature. |
 | `ORBIT_RELEASE_PUBLIC_KEY_FILE` | Test/operations override for the trusted checksum-signing public key; requires `ORBIT_RELEASE_PUBLIC_KEY_FILE_ACKNOWLEDGE_TRUST_CHANGE=1` and logs when active. |
 | `ORBIT_RELEASE_PUBLIC_KEY_FILE_ACKNOWLEDGE_TRUST_CHANGE=1` | Required acknowledgement that `ORBIT_RELEASE_PUBLIC_KEY_FILE` replaces the release authenticity trust root. |
+| `ORBIT_RELEASE_TRUSTED_KEYS_FILE` | Test/operations override for the full trusted signing-key set, including key IDs, `not_after`, and `revoked_at`; requires `ORBIT_RELEASE_TRUSTED_KEYS_FILE_ACKNOWLEDGE_TRUST_CHANGE=1` and logs when active. |
+| `ORBIT_RELEASE_TRUSTED_KEYS_FILE_ACKNOWLEDGE_TRUST_CHANGE=1` | Required acknowledgement that `ORBIT_RELEASE_TRUSTED_KEYS_FILE` replaces the release authenticity trust root. |
 | `ORBIT_SKIP_DOWNLOAD=1` | Skip postinstall download (lazy install on first run still works). |
 
 ## License

--- a/plugin/npm/scripts/install-binary.js
+++ b/plugin/npm/scripts/install-binary.js
@@ -28,7 +28,7 @@ const TRUSTED_PUBLIC_KEY_PATH = PUBLIC_KEY_OVERRIDE
 const TRUSTED_KEYS_OVERRIDE_PATH = TRUSTED_KEYS_OVERRIDE ? path.resolve(TRUSTED_KEYS_OVERRIDE) : null;
 const TRUSTED_RELEASE_KEYS = Object.freeze([
   Object.freeze({
-    id: 'orbit-release-2026-05-primary',
+    id: 'orbit-release-key-1',
     notAfter: '2027-12-31',
     revokedAt: null,
     publicKeyPem: `-----BEGIN PUBLIC KEY-----
@@ -45,7 +45,7 @@ pYZDkW2dLqPeFj/WwGhZoYFHv0GOMIWdi6FNriQdkn4RAgMBAAE=
 `,
   }),
   Object.freeze({
-    id: 'orbit-release-2026-05-successor',
+    id: 'orbit-release-key-2',
     notAfter: '2028-12-31',
     revokedAt: null,
     publicKeyPem: `-----BEGIN PUBLIC KEY-----
@@ -138,6 +138,7 @@ function acknowledgeTrustedPublicKeyOverride() {
   }
   if (!publicKeyOverrideLogged) {
     log(`ORBIT_RELEASE_PUBLIC_KEY_FILE=${TRUSTED_PUBLIC_KEY_PATH} set; trusting replacement release signing key`);
+    log('ORBIT_RELEASE_PUBLIC_KEY_FILE is deprecated; prefer ORBIT_RELEASE_TRUSTED_KEYS_FILE for the full trust set (key IDs, notAfter, revokedAt)');
     publicKeyOverrideLogged = true;
   }
 }
@@ -202,10 +203,21 @@ function normalizeTrustedReleaseKeys(trustedKeys) {
     if (!key || !key.id || !key.publicKeyPem) {
       throw new Error('trusted release signing keys require id and publicKeyPem');
     }
+    const notAfter = key.notAfter || null;
+    const revokedAt = key.revokedAt || null;
+    // Mirror the shell-side awk regex (release_date_number) so a malformed
+    // override like notAfter: "next month" fails closed instead of silently
+    // becoming "never expires" under lexicographic comparison.
+    if (notAfter !== null && !/^\d{4}-\d{2}-\d{2}$/.test(notAfter)) {
+      throw new Error(`trusted release signing key ${key.id} has invalid notAfter: ${notAfter} (expected YYYY-MM-DD)`);
+    }
+    if (revokedAt !== null && !/^\d{4}-\d{2}-\d{2}$/.test(revokedAt)) {
+      throw new Error(`trusted release signing key ${key.id} has invalid revokedAt: ${revokedAt} (expected YYYY-MM-DD)`);
+    }
     return {
       id: key.id,
-      notAfter: key.notAfter || null,
-      revokedAt: key.revokedAt || null,
+      notAfter,
+      revokedAt,
       publicKeyPem: key.publicKeyPem,
     };
   });

--- a/plugin/npm/scripts/install-binary.js
+++ b/plugin/npm/scripts/install-binary.js
@@ -20,10 +20,50 @@ const BIN_DIR = path.join(PKG_ROOT, 'binaries');
 const BIN_PATH = path.join(BIN_DIR, process.platform === 'win32' ? 'orbit.exe' : 'orbit');
 const PUBLIC_KEY_OVERRIDE = process.env.ORBIT_RELEASE_PUBLIC_KEY_FILE;
 const PUBLIC_KEY_OVERRIDE_ACK_ENV = 'ORBIT_RELEASE_PUBLIC_KEY_FILE_ACKNOWLEDGE_TRUST_CHANGE';
+const TRUSTED_KEYS_OVERRIDE = process.env.ORBIT_RELEASE_TRUSTED_KEYS_FILE;
+const TRUSTED_KEYS_OVERRIDE_ACK_ENV = 'ORBIT_RELEASE_TRUSTED_KEYS_FILE_ACKNOWLEDGE_TRUST_CHANGE';
 const TRUSTED_PUBLIC_KEY_PATH = PUBLIC_KEY_OVERRIDE
   ? path.resolve(PUBLIC_KEY_OVERRIDE)
   : path.join(PKG_ROOT, 'release-signing.pub');
+const TRUSTED_KEYS_OVERRIDE_PATH = TRUSTED_KEYS_OVERRIDE ? path.resolve(TRUSTED_KEYS_OVERRIDE) : null;
+const TRUSTED_RELEASE_KEYS = Object.freeze([
+  Object.freeze({
+    id: 'orbit-release-2026-05-primary',
+    notAfter: '2027-12-31',
+    revokedAt: null,
+    publicKeyPem: `-----BEGIN PUBLIC KEY-----
+MIIBojANBgkqhkiG9w0BAQEFAAOCAY8AMIIBigKCAYEAuZ8vNa+DusYhrFBXNhBh
+RSqn81AYe7tYEtCKImWGuy/6ziMHqDzDKHSku0sBMwcdLXBzI0RjNBacLCbbYr4H
+icmYrsKqqfLGf+CWfrqDqY9d3hwUPtVMRp/ynVNW6nwKAmNl5dTgUc6ZBAZTtQtt
+qwMD1JIOsrJ3vVDL9o3alcXcg/RyL0pGUo+vep2QZOjXnCGoJN3NeytQHag3zJyd
+Wq4psc7j2H1Nb5EoyY/I/7vpdwME3Mrv2ffwtDmr0/+73q1yWUDf4btY9Ba7sOhE
+Ir2UHm3bEboo1ErAYjjiDDuF/NjzZcZpJtuNbdj0vI7pHDyDZ7sKiEX7RkUO+e2c
+IouiSfRJRrwnjpuergrq3ehNjkxcn5dFST1l23FOXGsy4F7ilrF6P9cgaAsE8dc7
+CS9YgUE1ErfGJLZtfDDGKs6+E+7JiC1C3z7xwmfzOgv9gEvSlfrx2BbGl8esypKm
+pYZDkW2dLqPeFj/WwGhZoYFHv0GOMIWdi6FNriQdkn4RAgMBAAE=
+-----END PUBLIC KEY-----
+`,
+  }),
+  Object.freeze({
+    id: 'orbit-release-2026-05-successor',
+    notAfter: '2028-12-31',
+    revokedAt: null,
+    publicKeyPem: `-----BEGIN PUBLIC KEY-----
+MIIBojANBgkqhkiG9w0BAQEFAAOCAY8AMIIBigKCAYEA22OLkoJXb7PX/QwG7FzA
+eiDT0BctOq77WyXysUBlN1718pbjo30wLIW9d2h+cxPtld2PM35NQ4NMZJwl7lb2
+tZSWVUTRI9Se5eBhUEL6Gi4Rin4/In3NIx0YEVdA6SUA+x3OinPpe1BIN1pKGbpD
+P6GohwmrdbCUuZMv29UYPkREif6gnlehxj9ypZfZMVU7+VXOceeA5OT5iXbO4u29
+85bSys4JUN+SKtAao9BAjHCvMUJ4kL4mnGeteXRssmd5ehkEezUhWUNtP/uvKv+I
+5pjSto5vq6vqZMEpkOPDANPSUwz3F0CgyNmwHU8LKHtME+ZQqOP11xOC5Rgtw3zZ
+VQSAd3BLsSflu7ENV9lsbwPjvhSRDPlZsGUB4NGjUmFkUJPz7SGqT9LNXQqaRT2S
+8mHajs8Z/pkIMnOSOE339DHmT3xPz5eKRwZLBWttguJxHWFM50PT7g+K97Y6n9Zr
+zLEax5f3s3F9vPiWfA36hKJS5GzF564hCRViOQPqWnNlAgMBAAE=
+-----END PUBLIC KEY-----
+`,
+  }),
+]);
 let publicKeyOverrideLogged = false;
+let trustedKeysOverrideLogged = false;
 
 function log(msg) {
   process.stderr.write(`@orbit-tools/cli: ${msg}\n`);
@@ -87,6 +127,9 @@ function parseChecksums(text) {
 }
 
 function acknowledgeTrustedPublicKeyOverride() {
+  if (PUBLIC_KEY_OVERRIDE && TRUSTED_KEYS_OVERRIDE) {
+    throw new Error('ORBIT_RELEASE_PUBLIC_KEY_FILE and ORBIT_RELEASE_TRUSTED_KEYS_FILE cannot both be set');
+  }
   if (!PUBLIC_KEY_OVERRIDE) {
     return;
   }
@@ -99,18 +142,122 @@ function acknowledgeTrustedPublicKeyOverride() {
   }
 }
 
-function readTrustedPublicKey() {
-  acknowledgeTrustedPublicKeyOverride();
-  return fs.readFileSync(TRUSTED_PUBLIC_KEY_PATH, 'utf8');
+function acknowledgeTrustedKeysOverride() {
+  if (PUBLIC_KEY_OVERRIDE && TRUSTED_KEYS_OVERRIDE) {
+    throw new Error('ORBIT_RELEASE_PUBLIC_KEY_FILE and ORBIT_RELEASE_TRUSTED_KEYS_FILE cannot both be set');
+  }
+  if (!TRUSTED_KEYS_OVERRIDE) {
+    return;
+  }
+  if (process.env[TRUSTED_KEYS_OVERRIDE_ACK_ENV] !== '1') {
+    throw new Error(`ORBIT_RELEASE_TRUSTED_KEYS_FILE requires ${TRUSTED_KEYS_OVERRIDE_ACK_ENV}=1`);
+  }
+  if (!trustedKeysOverrideLogged) {
+    log(`ORBIT_RELEASE_TRUSTED_KEYS_FILE=${TRUSTED_KEYS_OVERRIDE_PATH} set; trusting replacement release signing key set`);
+    trustedKeysOverrideLogged = true;
+  }
 }
 
-function verifyChecksumSignature(checksumText, signatureBuf, publicKeyPem = readTrustedPublicKey()) {
+function readTrustedKeysManifest(manifestPath) {
+  const manifestDir = path.dirname(manifestPath);
+  return fs
+    .readFileSync(manifestPath, 'utf8')
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0 && !line.startsWith('#'))
+    .map((line) => {
+      const [id, notAfter, revokedAt, publicKeyPath, ...extra] = line.split('|');
+      if (!id || !publicKeyPath || extra.length > 0) {
+        throw new Error(`invalid trusted release signing key record: ${line}`);
+      }
+      const resolvedPublicKeyPath = path.isAbsolute(publicKeyPath)
+        ? publicKeyPath
+        : path.resolve(manifestDir, publicKeyPath);
+      return {
+        id,
+        notAfter: notAfter || null,
+        revokedAt: revokedAt || null,
+        publicKeyPem: fs.readFileSync(resolvedPublicKeyPath, 'utf8'),
+      };
+    });
+}
+
+function normalizeTrustedReleaseKeys(trustedKeys) {
+  if (typeof trustedKeys === 'string') {
+    return [
+      {
+        id: 'override',
+        notAfter: null,
+        revokedAt: null,
+        publicKeyPem: trustedKeys,
+      },
+    ];
+  }
+
+  if (!Array.isArray(trustedKeys) || trustedKeys.length === 0) {
+    throw new Error('at least one trusted release signing key is required');
+  }
+
+  return trustedKeys.map((key) => {
+    if (!key || !key.id || !key.publicKeyPem) {
+      throw new Error('trusted release signing keys require id and publicKeyPem');
+    }
+    return {
+      id: key.id,
+      notAfter: key.notAfter || null,
+      revokedAt: key.revokedAt || null,
+      publicKeyPem: key.publicKeyPem,
+    };
+  });
+}
+
+function readTrustedReleaseKeys() {
+  acknowledgeTrustedPublicKeyOverride();
+  acknowledgeTrustedKeysOverride();
+
+  if (PUBLIC_KEY_OVERRIDE) {
+    return normalizeTrustedReleaseKeys(fs.readFileSync(TRUSTED_PUBLIC_KEY_PATH, 'utf8'));
+  }
+  if (TRUSTED_KEYS_OVERRIDE_PATH) {
+    return normalizeTrustedReleaseKeys(readTrustedKeysManifest(TRUSTED_KEYS_OVERRIDE_PATH));
+  }
+  return TRUSTED_RELEASE_KEYS;
+}
+
+function releaseDateString(date = new Date()) {
+  return date.toISOString().slice(0, 10);
+}
+
+function assertTrustedKeyUsable(key, verificationDate = new Date()) {
+  if (key.revokedAt) {
+    throw new Error(`release checksum signature was made by revoked release signing key ${key.id} (revoked ${key.revokedAt})`);
+  }
+  if (key.notAfter && releaseDateString(verificationDate) > key.notAfter) {
+    throw new Error(`release checksum signature was made by expired release signing key ${key.id} (not_after ${key.notAfter})`);
+  }
+}
+
+function verifyWithPublicKey(checksumText, signatureBuf, publicKeyPem) {
   const verifier = crypto.createVerify('RSA-SHA256');
   verifier.update(checksumText, 'utf8');
   verifier.end();
-  if (!verifier.verify(publicKeyPem, signatureBuf)) {
-    throw new Error(`release checksum signature verification failed for ${CHECKSUM_FILE}`);
+  return verifier.verify(publicKeyPem, signatureBuf);
+}
+
+function verifyChecksumSignature(
+  checksumText,
+  signatureBuf,
+  trustedKeys = readTrustedReleaseKeys(),
+  verificationDate = new Date()
+) {
+  for (const key of normalizeTrustedReleaseKeys(trustedKeys)) {
+    if (verifyWithPublicKey(checksumText, signatureBuf, key.publicKeyPem)) {
+      assertTrustedKeyUsable(key, verificationDate);
+      log(`authenticated ${CHECKSUM_FILE} with release signing key ${key.id}`);
+      return key.id;
+    }
   }
+  throw new Error(`release checksum signature verification failed for ${CHECKSUM_FILE}: no trusted release signing key matched`);
 }
 
 function verifyArchiveChecksum(asset, archiveBuf, checksumText) {
@@ -244,10 +391,14 @@ if (require.main === module) {
 }
 
 module.exports = {
+  TRUSTED_RELEASE_KEYS,
   parseChecksums,
   sha256,
   acknowledgeTrustedPublicKeyOverride,
+  acknowledgeTrustedKeysOverride,
   extractTarGz,
+  normalizeTrustedReleaseKeys,
+  readTrustedReleaseKeys,
   validateArchiveMembers,
   validateExtractedBinary,
   verifyArchiveChecksum,

--- a/scripts/check-installer-pubkey.sh
+++ b/scripts/check-installer-pubkey.sh
@@ -64,13 +64,32 @@ fi
 assert_contains_canonical_key "install.sh" "$install_keys"
 assert_contains_canonical_key "install-binary.js" "$npm_keys"
 
-grep -q "orbit-release-2026-05-primary" "$repo_root/install.sh"
-grep -q "orbit-release-2026-05-successor" "$repo_root/install.sh"
-grep -q "orbit-release-2026-05-primary" "$repo_root/plugin/npm/scripts/install-binary.js"
-grep -q "orbit-release-2026-05-successor" "$repo_root/plugin/npm/scripts/install-binary.js"
-grep -q "notAfter: '2027-12-31'" "$repo_root/plugin/npm/scripts/install-binary.js"
-grep -q "notAfter: '2028-12-31'" "$repo_root/plugin/npm/scripts/install-binary.js"
-grep -q "2027-12-31" "$repo_root/install.sh"
-grep -q "2028-12-31" "$repo_root/install.sh"
+# Read the canonical key IDs out of install-binary.js (the structured source of
+# truth), then require each ID to appear in install.sh. This avoids hardcoding
+# specific key IDs in the guardrail — every legitimate rotation that updates
+# both files in lockstep continues to pass, while a drift between the two
+# installers fails closed.
+npm_key_ids="$(awk "/id:[[:space:]]*'orbit-release-/ { match(\$0, /'[^']+'/); if (RSTART > 0) print substr(\$0, RSTART + 1, RLENGTH - 2) }" "$repo_root/plugin/npm/scripts/install-binary.js")"
+if [ -z "$npm_key_ids" ]; then
+  echo "check-installer-pubkey: could not extract any orbit-release-* key IDs from install-binary.js" >&2
+  exit 1
+fi
+
+npm_id_count=0
+while IFS= read -r key_id; do
+  [ -n "$key_id" ] || continue
+  npm_id_count=$((npm_id_count + 1))
+  if ! grep -q -F "$key_id" "$repo_root/install.sh"; then
+    echo "check-installer-pubkey: key ID '$key_id' is in install-binary.js but missing from install.sh" >&2
+    exit 1
+  fi
+done <<EOF
+$npm_key_ids
+EOF
+
+if [ "$npm_id_count" -lt 2 ]; then
+  echo "check-installer-pubkey: expected at least two orbit-release-* key IDs in install-binary.js, found $npm_id_count" >&2
+  exit 1
+fi
 
 echo "check-installer-pubkey: ok"

--- a/scripts/check-installer-pubkey.sh
+++ b/scripts/check-installer-pubkey.sh
@@ -3,28 +3,74 @@ set -euo pipefail
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 canonical_key="$repo_root/plugin/npm/release-signing.pub"
-extracted_key="$(mktemp)"
-trap 'rm -f "$extracted_key"' EXIT
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
 
-key_count="$(awk '/^-----BEGIN PUBLIC KEY-----$/ { count++ } END { print count + 0 }' "$repo_root/install.sh")"
-if [ "$key_count" != "1" ]; then
-  echo "check-installer-pubkey: expected exactly one public key block in install.sh, found $key_count" >&2
+extract_pem_blocks() {
+  local source="$1"
+  local destination="$2"
+
+  awk '
+    /-----BEGIN PUBLIC KEY-----/ { in_key = 1 }
+    in_key { print }
+    /-----END PUBLIC KEY-----/ { found = 1; in_key = 0 }
+    END { if (!found) exit 1 }
+  ' "$source" > "$destination"
+}
+
+assert_contains_canonical_key() {
+  local label="$1"
+  local extracted_keys="$2"
+
+  awk '
+    NR == FNR {
+      canonical = canonical $0 "\n"
+      next
+    }
+    {
+      extracted = extracted $0 "\n"
+    }
+    END {
+      exit(index(extracted, canonical) ? 0 : 1)
+    }
+  ' "$canonical_key" "$extracted_keys" || {
+    echo "check-installer-pubkey: $label must include plugin/npm/release-signing.pub" >&2
+    exit 1
+  }
+}
+
+install_keys="$tmp_dir/install-sh-keys.pem"
+npm_keys="$tmp_dir/npm-install-keys.pem"
+extract_pem_blocks "$repo_root/install.sh" "$install_keys" || {
+  echo "check-installer-pubkey: could not extract release signing public keys from install.sh" >&2
   exit 1
-fi
-
-awk '
-  /^-----BEGIN PUBLIC KEY-----$/ { in_key = 1 }
-  in_key { print }
-  /^-----END PUBLIC KEY-----$/ { found = 1; in_key = 0 }
-  END { if (!found) exit 1 }
-' "$repo_root/install.sh" > "$extracted_key" || {
-  echo "check-installer-pubkey: could not extract release signing public key from install.sh" >&2
+}
+extract_pem_blocks "$repo_root/plugin/npm/scripts/install-binary.js" "$npm_keys" || {
+  echo "check-installer-pubkey: could not extract release signing public keys from install-binary.js" >&2
   exit 1
 }
 
-if ! diff -u "$canonical_key" "$extracted_key"; then
-  echo "check-installer-pubkey: install.sh public key must match plugin/npm/release-signing.pub" >&2
+install_key_count="$(awk '/-----BEGIN PUBLIC KEY-----/ { count++ } END { print count + 0 }' "$install_keys")"
+npm_key_count="$(awk '/-----BEGIN PUBLIC KEY-----/ { count++ } END { print count + 0 }' "$npm_keys")"
+if [ "$install_key_count" -lt 2 ]; then
+  echo "check-installer-pubkey: expected at least two public key blocks in install.sh, found $install_key_count" >&2
   exit 1
 fi
+if [ "$npm_key_count" -lt 2 ]; then
+  echo "check-installer-pubkey: expected at least two public key blocks in install-binary.js, found $npm_key_count" >&2
+  exit 1
+fi
+
+assert_contains_canonical_key "install.sh" "$install_keys"
+assert_contains_canonical_key "install-binary.js" "$npm_keys"
+
+grep -q "orbit-release-2026-05-primary" "$repo_root/install.sh"
+grep -q "orbit-release-2026-05-successor" "$repo_root/install.sh"
+grep -q "orbit-release-2026-05-primary" "$repo_root/plugin/npm/scripts/install-binary.js"
+grep -q "orbit-release-2026-05-successor" "$repo_root/plugin/npm/scripts/install-binary.js"
+grep -q "notAfter: '2027-12-31'" "$repo_root/plugin/npm/scripts/install-binary.js"
+grep -q "notAfter: '2028-12-31'" "$repo_root/plugin/npm/scripts/install-binary.js"
+grep -q "2027-12-31" "$repo_root/install.sh"
+grep -q "2028-12-31" "$repo_root/install.sh"
 
 echo "check-installer-pubkey: ok"

--- a/scripts/test-installer-security.sh
+++ b/scripts/test-installer-security.sh
@@ -58,9 +58,10 @@ BIN
 }
 
 sign_checksums() {
-  local checksums="$1"
-  local signature="$2"
-  openssl dgst -sha256 -sign "$PRIVATE_KEY" -out "$signature" "$checksums"
+  local private_key="$1"
+  local checksums="$2"
+  local signature="$3"
+  openssl dgst -sha256 -sign "$private_key" -out "$signature" "$checksums"
 }
 
 make_regular_archive() {
@@ -94,6 +95,7 @@ prepare_release_dir() {
   local name="$1"
   local archive_kind="$2"
   local checksum_kind="$3"
+  local signing_key="$4"
   local release_dir="$TMP_ROOT/$name"
   local asset="orbit-${TARGET}.tar.gz"
   local archive="$release_dir/$asset"
@@ -118,7 +120,7 @@ prepare_release_dir() {
       ;;
   esac
 
-  sign_checksums "$release_dir/orbit-checksums.txt" "$release_dir/orbit-checksums.txt.sig"
+  sign_checksums "$signing_key" "$release_dir/orbit-checksums.txt" "$release_dir/orbit-checksums.txt.sig"
   echo "$release_dir"
 }
 
@@ -128,8 +130,8 @@ run_shell_install() {
   local marker="$3"
   ORBIT_INSTALL_BASE_URL="file://$release_dir" \
     ORBIT_INSTALL_DIR="$install_dir" \
-    ORBIT_RELEASE_PUBLIC_KEY_FILE="$PUBLIC_KEY" \
-    ORBIT_RELEASE_PUBLIC_KEY_FILE_ACKNOWLEDGE_TRUST_CHANGE=1 \
+    ORBIT_RELEASE_TRUSTED_KEYS_FILE="$TRUSTED_KEYS_FILE" \
+    ORBIT_RELEASE_TRUSTED_KEYS_FILE_ACKNOWLEDGE_TRUST_CHANGE=1 \
     ORBIT_TEST_EXEC_MARKER="$marker" \
     sh "$ROOT/install.sh"
 }
@@ -152,19 +154,46 @@ expect_shell_failure() {
   fi
 }
 
-PRIVATE_KEY="$TMP_ROOT/release-signing.key"
-PUBLIC_KEY="$TMP_ROOT/release-signing.pub"
-openssl genpkey -algorithm RSA -pkeyopt rsa_keygen_bits:2048 -out "$PRIVATE_KEY" >/dev/null 2>&1
-openssl rsa -pubout -in "$PRIVATE_KEY" -out "$PUBLIC_KEY" >/dev/null 2>&1
+CURRENT_PRIVATE_KEY="$TMP_ROOT/current-release-signing.key"
+CURRENT_PUBLIC_KEY="$TMP_ROOT/current-release-signing.pub"
+EXPIRED_PRIVATE_KEY="$TMP_ROOT/expired-release-signing.key"
+EXPIRED_PUBLIC_KEY="$TMP_ROOT/expired-release-signing.pub"
+REVOKED_PRIVATE_KEY="$TMP_ROOT/revoked-release-signing.key"
+REVOKED_PUBLIC_KEY="$TMP_ROOT/revoked-release-signing.pub"
+UNTRUSTED_PRIVATE_KEY="$TMP_ROOT/untrusted-release-signing.key"
+UNTRUSTED_PUBLIC_KEY="$TMP_ROOT/untrusted-release-signing.pub"
+TRUSTED_KEYS_FILE="$TMP_ROOT/trusted-release-keys.txt"
+
+openssl genpkey -algorithm RSA -pkeyopt rsa_keygen_bits:2048 -out "$CURRENT_PRIVATE_KEY" >/dev/null 2>&1
+openssl rsa -pubout -in "$CURRENT_PRIVATE_KEY" -out "$CURRENT_PUBLIC_KEY" >/dev/null 2>&1
+openssl genpkey -algorithm RSA -pkeyopt rsa_keygen_bits:2048 -out "$EXPIRED_PRIVATE_KEY" >/dev/null 2>&1
+openssl rsa -pubout -in "$EXPIRED_PRIVATE_KEY" -out "$EXPIRED_PUBLIC_KEY" >/dev/null 2>&1
+openssl genpkey -algorithm RSA -pkeyopt rsa_keygen_bits:2048 -out "$REVOKED_PRIVATE_KEY" >/dev/null 2>&1
+openssl rsa -pubout -in "$REVOKED_PRIVATE_KEY" -out "$REVOKED_PUBLIC_KEY" >/dev/null 2>&1
+openssl genpkey -algorithm RSA -pkeyopt rsa_keygen_bits:2048 -out "$UNTRUSTED_PRIVATE_KEY" >/dev/null 2>&1
+openssl rsa -pubout -in "$UNTRUSTED_PRIVATE_KEY" -out "$UNTRUSTED_PUBLIC_KEY" >/dev/null 2>&1
+
+printf 'current|2099-12-31||%s\n' "$CURRENT_PUBLIC_KEY" > "$TRUSTED_KEYS_FILE"
+printf 'expired|2000-01-01||%s\n' "$EXPIRED_PUBLIC_KEY" >> "$TRUSTED_KEYS_FILE"
+printf 'revoked|2099-12-31|2026-05-23|%s\n' "$REVOKED_PUBLIC_KEY" >> "$TRUSTED_KEYS_FILE"
+
+PRIVATE_KEY="$CURRENT_PRIVATE_KEY"
+PUBLIC_KEY="$CURRENT_PUBLIC_KEY"
 
 TARGET="$(target_name)"
 
-good_release="$(prepare_release_dir good regular correct)"
-bad_checksum_release="$(prepare_release_dir bad-checksum regular wrong)"
-symlink_release="$(prepare_release_dir symlink symlink correct)"
-traversal_release="$(prepare_release_dir traversal traversal correct)"
+good_release="$(prepare_release_dir good regular correct "$CURRENT_PRIVATE_KEY")"
+bad_checksum_release="$(prepare_release_dir bad-checksum regular wrong "$CURRENT_PRIVATE_KEY")"
+expired_key_release="$(prepare_release_dir expired-key regular correct "$EXPIRED_PRIVATE_KEY")"
+revoked_key_release="$(prepare_release_dir revoked-key regular correct "$REVOKED_PRIVATE_KEY")"
+untrusted_key_release="$(prepare_release_dir untrusted-key regular correct "$UNTRUSTED_PRIVATE_KEY")"
+symlink_release="$(prepare_release_dir symlink symlink correct "$CURRENT_PRIVATE_KEY")"
+traversal_release="$(prepare_release_dir traversal traversal correct "$CURRENT_PRIVATE_KEY")"
 
 expect_shell_failure "$bad_checksum_release" "checksum-mismatch"
+expect_shell_failure "$expired_key_release" "expired-key"
+expect_shell_failure "$revoked_key_release" "revoked-key"
+expect_shell_failure "$untrusted_key_release" "untrusted-key"
 expect_shell_failure "$symlink_release" "symlink-member"
 expect_shell_failure "$traversal_release" "traversal-member"
 
@@ -178,13 +207,25 @@ npm_checksums="$TMP_ROOT/npm-checksums.txt"
 npm_signature="$TMP_ROOT/npm-checksums.txt.sig"
 good_archive="$good_release/orbit-${TARGET}.tar.gz"
 printf '%s  %s\n' "$(sha256_file "$good_archive")" "orbit-${TARGET}.tar.gz" > "$npm_checksums"
-sign_checksums "$npm_checksums" "$npm_signature"
+sign_checksums "$CURRENT_PRIVATE_KEY" "$npm_checksums" "$npm_signature"
+
+npm_expired_signature="$TMP_ROOT/npm-checksums-expired.sig"
+npm_revoked_signature="$TMP_ROOT/npm-checksums-revoked.sig"
+npm_untrusted_signature="$TMP_ROOT/npm-checksums-untrusted.sig"
+sign_checksums "$EXPIRED_PRIVATE_KEY" "$npm_checksums" "$npm_expired_signature"
+sign_checksums "$REVOKED_PRIVATE_KEY" "$npm_checksums" "$npm_revoked_signature"
+sign_checksums "$UNTRUSTED_PRIVATE_KEY" "$npm_checksums" "$npm_untrusted_signature"
 
 ROOT="$ROOT" \
   TMP_ROOT="$TMP_ROOT" \
   PUBLIC_KEY="$PUBLIC_KEY" \
+  EXPIRED_PUBLIC_KEY="$EXPIRED_PUBLIC_KEY" \
+  REVOKED_PUBLIC_KEY="$REVOKED_PUBLIC_KEY" \
   CHECKSUMS="$npm_checksums" \
   SIGNATURE="$npm_signature" \
+  EXPIRED_SIGNATURE="$npm_expired_signature" \
+  REVOKED_SIGNATURE="$npm_revoked_signature" \
+  UNTRUSTED_SIGNATURE="$npm_untrusted_signature" \
   GOOD_ARCHIVE="$good_archive" \
   SYMLINK_ARCHIVE="$symlink_release/orbit-${TARGET}.tar.gz" \
   TRAVERSAL_ARCHIVE="$traversal_release/orbit-${TARGET}.tar.gz" \
@@ -227,12 +268,22 @@ function expectExtractFailure(archivePath, pattern, label) {
 }
 
 const publicKey = fs.readFileSync(process.env.PUBLIC_KEY, 'utf8');
+const expiredPublicKey = fs.readFileSync(process.env.EXPIRED_PUBLIC_KEY, 'utf8');
+const revokedPublicKey = fs.readFileSync(process.env.REVOKED_PUBLIC_KEY, 'utf8');
 const checksumText = fs.readFileSync(process.env.CHECKSUMS, 'utf8');
 const signature = fs.readFileSync(process.env.SIGNATURE);
+const expiredSignature = fs.readFileSync(process.env.EXPIRED_SIGNATURE);
+const revokedSignature = fs.readFileSync(process.env.REVOKED_SIGNATURE);
+const untrustedSignature = fs.readFileSync(process.env.UNTRUSTED_SIGNATURE);
 const goodArchive = fs.readFileSync(process.env.GOOD_ARCHIVE);
 const asset = `orbit-${process.env.TARGET}.tar.gz`;
+const trustedKeys = [
+  { id: 'current', notAfter: '2099-12-31', revokedAt: null, publicKeyPem: publicKey },
+  { id: 'expired', notAfter: '2000-01-01', revokedAt: null, publicKeyPem: expiredPublicKey },
+  { id: 'revoked', notAfter: '2099-12-31', revokedAt: '2026-05-23', publicKeyPem: revokedPublicKey },
+];
 
-installer.verifyChecksumSignature(checksumText, signature, publicKey);
+installer.verifyChecksumSignature(checksumText, signature, trustedKeys);
 installer.verifyArchiveChecksum(asset, goodArchive, checksumText);
 installer.validateArchiveMembers(process.env.GOOD_ARCHIVE);
 withTempDir('npm-good-archive-extract', (dir) => {
@@ -246,10 +297,29 @@ withTempDir('npm-good-archive-extract', (dir) => {
 const tamperedSignature = Buffer.from(signature);
 tamperedSignature[0] = tamperedSignature[0] ^ 0xff;
 expectThrow(
-  () => installer.verifyChecksumSignature(checksumText, tamperedSignature, publicKey),
+  () => installer.verifyChecksumSignature(checksumText, tamperedSignature, trustedKeys),
   /signature verification failed/,
   'npm signature failure'
 );
+expectThrow(
+  () => installer.verifyChecksumSignature(checksumText, expiredSignature, trustedKeys),
+  /expired release signing key expired/,
+  'npm expired key rejection'
+);
+expectThrow(
+  () => installer.verifyChecksumSignature(checksumText, revokedSignature, trustedKeys),
+  /revoked release signing key revoked/,
+  'npm revoked key rejection'
+);
+expectThrow(
+  () => installer.verifyChecksumSignature(checksumText, untrustedSignature, trustedKeys),
+  /no trusted release signing key matched/,
+  'npm untrusted key rejection'
+);
+installer.verifyChecksumSignature(checksumText, signature, publicKey);
+if (!Array.isArray(installer.TRUSTED_RELEASE_KEYS) || installer.TRUSTED_RELEASE_KEYS.length < 2) {
+  throw new Error('npm installer must expose at least two trusted release signing keys');
+}
 expectThrow(
   () => installer.verifyArchiveChecksum(asset, goodArchive, `0000000000000000000000000000000000000000000000000000000000000000  ${asset}\n`),
   /checksum mismatch/,
@@ -281,5 +351,20 @@ ORBIT_RELEASE_PUBLIC_KEY_FILE="$PUBLIC_KEY" \
   node -e 'const path = require("node:path"); const installer = require(path.join(process.env.ROOT, "plugin/npm/scripts/install-binary.js")); installer.acknowledgeTrustedPublicKeyOverride();' \
   > "$TMP_ROOT/npm-key-override-ack.log" 2>&1
 grep -q "trusting replacement release signing key" "$TMP_ROOT/npm-key-override-ack.log"
+
+if ORBIT_RELEASE_TRUSTED_KEYS_FILE="$TRUSTED_KEYS_FILE" \
+  ROOT="$ROOT" \
+  node -e 'const path = require("node:path"); const installer = require(path.join(process.env.ROOT, "plugin/npm/scripts/install-binary.js")); installer.acknowledgeTrustedKeysOverride();' \
+  > "$TMP_ROOT/npm-keys-override-missing-ack.log" 2>&1; then
+  echo "FAIL: npm installer accepted ORBIT_RELEASE_TRUSTED_KEYS_FILE without acknowledgement" >&2
+  exit 1
+fi
+
+ORBIT_RELEASE_TRUSTED_KEYS_FILE="$TRUSTED_KEYS_FILE" \
+  ORBIT_RELEASE_TRUSTED_KEYS_FILE_ACKNOWLEDGE_TRUST_CHANGE=1 \
+  ROOT="$ROOT" \
+  node -e 'const path = require("node:path"); const installer = require(path.join(process.env.ROOT, "plugin/npm/scripts/install-binary.js")); installer.acknowledgeTrustedKeysOverride();' \
+  > "$TMP_ROOT/npm-keys-override-ack.log" 2>&1
+grep -q "trusting replacement release signing key set" "$TMP_ROOT/npm-keys-override-ack.log"
 
 echo "test-installer-security: ok"

--- a/website/src/content/docs/getting-started/install.md
+++ b/website/src/content/docs/getting-started/install.md
@@ -61,6 +61,10 @@ protects artifact integrity, not transport confidentiality.
 `ORBIT_RELEASE_PUBLIC_KEY_FILE` replaces the trusted checksum-signing key,
 requires `ORBIT_RELEASE_PUBLIC_KEY_FILE_ACKNOWLEDGE_TRUST_CHANGE=1`, and should
 be limited to tests or emergency operations.
+`ORBIT_RELEASE_TRUSTED_KEYS_FILE` replaces the full trusted signing-key set,
+including key IDs, `not_after`, and `revoked_at`; it requires
+`ORBIT_RELEASE_TRUSTED_KEYS_FILE_ACKNOWLEDGE_TRUST_CHANGE=1` and should be
+limited to tests or emergency operations.
 
 ## Initialize State
 

--- a/website/src/content/docs/getting-started/install.md
+++ b/website/src/content/docs/getting-started/install.md
@@ -58,13 +58,13 @@ release source the installer trusts, so use them only for pinned releases,
 forks, or controlled test mirrors. `ORBIT_INSTALL_BASE_URL` may use any
 downloader-supported scheme, including `file://` for tests; the signature check
 protects artifact integrity, not transport confidentiality.
-`ORBIT_RELEASE_PUBLIC_KEY_FILE` replaces the trusted checksum-signing key,
-requires `ORBIT_RELEASE_PUBLIC_KEY_FILE_ACKNOWLEDGE_TRUST_CHANGE=1`, and should
+`ORBIT_RELEASE_TRUSTED_KEYS_FILE` is the preferred override for the full
+trusted signing-key set, including key IDs, `not_after`, and `revoked_at`; it
+requires `ORBIT_RELEASE_TRUSTED_KEYS_FILE_ACKNOWLEDGE_TRUST_CHANGE=1` and should
 be limited to tests or emergency operations.
-`ORBIT_RELEASE_TRUSTED_KEYS_FILE` replaces the full trusted signing-key set,
-including key IDs, `not_after`, and `revoked_at`; it requires
-`ORBIT_RELEASE_TRUSTED_KEYS_FILE_ACKNOWLEDGE_TRUST_CHANGE=1` and should be
-limited to tests or emergency operations.
+`ORBIT_RELEASE_PUBLIC_KEY_FILE` is **deprecated** in favor of the trusted-keys
+file (which is a strict superset); it still works for the single-key case and
+requires `ORBIT_RELEASE_PUBLIC_KEY_FILE_ACKNOWLEDGE_TRUST_CHANGE=1`.
 
 ## Initialize State
 


### PR DESCRIPTION
## Task

[ORB-00270](https://orbit-cli.com/tasks/ORB-00270) — Add release signing key rotation support for installers

### Description

## Problem
PR #410 adds a single baked-in release signing public key for install.sh and the npm package. That authenticates current releases, but there is no multi-key, expiry, or revocation path if the key is compromised. Old npm packages already published with the compromised key would continue trusting it until deprecated.

## Why It Matters
Installer authenticity depends on a durable key lifecycle, not only a first key. Rotation needs to preserve secure upgrades for current users and make compromised or expired keys observable.

## Constraints / Notes
- Spawned from review feedback on PR #410 / ORB-00266.
- Evaluate either a keys directory with key IDs and not-after dates, or Sigstore/cosign verification pinned to a stable Fulcio identity.
- Keep installer behavior deterministic and covered by local fixtures; do not require live release assets in tests.

### Acceptance Criteria

- An inspector can identify more than one trusted release-signing key or an equivalent external trust identity, including each key or identity expiry/revocation behavior.
- install.sh rejects signatures from expired, revoked, or otherwise untrusted release-signing material while accepting a valid current signing path in deterministic local fixtures.
- plugin/npm/scripts/install-binary.js rejects signatures from expired, revoked, or otherwise untrusted release-signing material while accepting a valid current signing path in deterministic local fixtures.
- docs/RELEASE.md documents the key rotation and emergency revocation procedure, including impact on already-published npm packages.
- make ci-fast passes.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Added multi-key release checksum signature verification to install.sh and the npm postinstall. Both installers now carry key IDs, not-after dates, and revocation metadata, accept either active trusted key, reject expired/revoked/untrusted signers, and keep explicit trust-set override paths behind acknowledgement env vars.
- Extended deterministic installer security fixtures to exercise current, expired, revoked, untrusted, checksum-mismatch, and malicious archive paths across shell and npm verification.
- Updated release docs with the active trust set, normal key rotation steps, emergency revocation steps, and the immutable npm package/deprecation impact; refreshed npm and install docs for the new trust-set override.
- Updated the installer pubkey guardrail to require a multi-key trust set and canonical current key presence in both installers.

Validation:
- sh -n install.sh; bash -n scripts/test-installer-security.sh scripts/check-installer-pubkey.sh; node --check plugin/npm/scripts/install-binary.js
- ./scripts/check-installer-pubkey.sh
- ./scripts/test-installer-security.sh
- make ci-fast
- npm_config_cache=/tmp/orbit-npm-cache npm pack --dry-run --loglevel=warn

Assessment: The installers now have a deterministic rotation/revocation path with local regression coverage for the signer lifecycle cases requested by ORB-00270.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-00270-6a1116cd`
- Behind base: 0
- Ahead of base: 1