### PR TITLE
Restrict and sandbox v2 agent proc.spawn execution

### DIFF
--- a/crates/orbit-common/src/types/activity_job/activity_v2.rs
+++ b/crates/orbit-common/src/types/activity_job/activity_v2.rs
@@ -76,6 +76,12 @@ pub struct AgentLoopSpec {
     /// `TargetStep` takes precedence over this activity-level role.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub role: Option<AgentRole>,
+    /// Program allowlist enforced before `proc.spawn` executes a request.
+    /// `None` means `proc.spawn` is not constrained at the activity layer
+    /// (legacy / human-driven paths); an empty `Some(vec![])` denies all
+    /// programs (fail-closed). Mirrors `ShellSpec::allowed_programs`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub proc_allowed_programs: Option<Vec<String>>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -108,6 +114,10 @@ pub struct GroundhogSpec {
     /// Optional role tag (ADR-029). Mirrors `AgentLoopSpec::role`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub role: Option<AgentRole>,
+    /// Program allowlist enforced before `proc.spawn` executes a request.
+    /// Mirrors [`AgentLoopSpec::proc_allowed_programs`].
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub proc_allowed_programs: Option<Vec<String>>,
 }
 
 impl GroundhogSpec {
@@ -122,6 +132,7 @@ impl GroundhogSpec {
             provider: self.provider,
             wall_clock_timeout_seconds: self.wall_clock_timeout_seconds,
             role: self.role,
+            proc_allowed_programs: self.proc_allowed_programs.clone(),
         }
     }
 }

--- a/crates/orbit-common/src/types/activity_job/tests/activity_v2.rs
+++ b/crates/orbit-common/src/types/activity_job/tests/activity_v2.rs
@@ -34,3 +34,40 @@ fn agent_loop_spec_defaults_to_cli_backend() {
     let parsed: AgentLoopSpec = serde_yaml::from_str(yaml).expect("parse spec");
     assert_eq!(parsed.backend, Backend::Cli);
 }
+
+#[test]
+fn agent_loop_spec_proc_allowed_programs_defaults_to_none() {
+    let yaml = "instruction: hi\n";
+    let parsed: AgentLoopSpec = serde_yaml::from_str(yaml).expect("parse spec");
+    assert_eq!(parsed.proc_allowed_programs, None);
+}
+
+#[test]
+fn agent_loop_spec_proc_allowed_programs_round_trips() {
+    let yaml = "instruction: hi\nproc_allowed_programs:\n  - git\n  - rg\n";
+    let parsed: AgentLoopSpec = serde_yaml::from_str(yaml).expect("parse spec");
+    assert_eq!(
+        parsed.proc_allowed_programs,
+        Some(vec!["git".to_string(), "rg".to_string()])
+    );
+    let reserialized = serde_yaml::to_string(&parsed).expect("serialize spec");
+    let reparsed: AgentLoopSpec = serde_yaml::from_str(&reserialized).expect("re-parse spec");
+    assert_eq!(reparsed.proc_allowed_programs, parsed.proc_allowed_programs);
+}
+
+#[test]
+fn agent_loop_spec_proc_allowed_programs_accepts_empty_seq() {
+    // Empty Some(vec![]) is meaningful: fail-closed when activity-scoped.
+    let yaml = "instruction: hi\nproc_allowed_programs: []\n";
+    let parsed: AgentLoopSpec = serde_yaml::from_str(yaml).expect("parse spec");
+    assert_eq!(parsed.proc_allowed_programs, Some(Vec::<String>::new()));
+}
+
+#[test]
+fn groundhog_spec_mirrors_proc_allowed_programs_into_agent_loop() {
+    let yaml = "instruction: hi\nproc_allowed_programs:\n  - git\n";
+    let parsed: GroundhogSpec = serde_yaml::from_str(yaml).expect("parse groundhog spec");
+    assert_eq!(parsed.proc_allowed_programs, Some(vec!["git".to_string()]));
+    let derived = parsed.as_agent_loop_spec();
+    assert_eq!(derived.proc_allowed_programs, parsed.proc_allowed_programs);
+}

--- a/crates/orbit-core/assets/activities/agent_implement.yaml
+++ b/crates/orbit-core/assets/activities/agent_implement.yaml
@@ -113,6 +113,11 @@ spec:
     - fs.read
     - fs.delete
     - proc.spawn
+  proc_allowed_programs:
+    - git
+    - make
+    - cargo
+    - rg
   on_denial: terminate
   max_iterations: 25
   role: implementer

--- a/crates/orbit-core/assets/activities/agent_review.yaml
+++ b/crates/orbit-core/assets/activities/agent_review.yaml
@@ -90,6 +90,9 @@ spec:
     - fs.read
     - fs.delete
     - proc.spawn
+  proc_allowed_programs:
+    - git
+    - rg
   on_denial: terminate
   max_iterations: 20
   role: reviewer

--- a/crates/orbit-core/assets/activities/examples/agent_apply_fixes.yaml
+++ b/crates/orbit-core/assets/activities/examples/agent_apply_fixes.yaml
@@ -41,6 +41,11 @@ spec:
   tools:
     - fs.read
     - proc.spawn
+  proc_allowed_programs:
+    - git
+    - make
+    - cargo
+    - rg
   on_denial: terminate
   max_iterations: 3
   role: implementer

--- a/crates/orbit-core/assets/activities/step_failure_recovery.yaml
+++ b/crates/orbit-core/assets/activities/step_failure_recovery.yaml
@@ -86,6 +86,9 @@ spec:
     - fs.read
     - fs.delete
     - proc.spawn
+  proc_allowed_programs:
+    - git
+    - rg
   on_denial: terminate
   max_iterations: 8
   role: reviewer

--- a/crates/orbit-core/src/command/job/exec.rs
+++ b/crates/orbit-core/src/command/job/exec.rs
@@ -512,12 +512,14 @@ mod tests {
             run_id: Option<&str>,
             fs_profile: Option<&str>,
             fs_audit: Option<Arc<dyn FsAuditLogger>>,
+            proc_allowed_programs: Option<&[String]>,
         ) -> ToolContext {
             <OrbitRuntime as V2RuntimeHost>::tool_context_for_activity(
                 self.runtime,
                 run_id,
                 fs_profile,
                 fs_audit,
+                proc_allowed_programs,
             )
         }
     }
@@ -601,12 +603,14 @@ mod tests {
             run_id: Option<&str>,
             fs_profile: Option<&str>,
             fs_audit: Option<Arc<dyn FsAuditLogger>>,
+            proc_allowed_programs: Option<&[String]>,
         ) -> ToolContext {
             <OrbitRuntime as V2RuntimeHost>::tool_context_for_activity(
                 self.runtime,
                 run_id,
                 fs_profile,
                 fs_audit,
+                proc_allowed_programs,
             )
         }
     }

--- a/crates/orbit-core/src/runtime/v2_host/mod.rs
+++ b/crates/orbit-core/src/runtime/v2_host/mod.rs
@@ -94,12 +94,18 @@ impl V2RuntimeHost for OrbitRuntime {
         run_id: Option<&str>,
         fs_profile: Option<&str>,
         fs_audit: Option<Arc<dyn FsAuditLogger>>,
+        proc_allowed_programs: Option<&[String]>,
     ) -> ToolContext {
         let workspace_root = self
             .paths()
             .repo_root
             .canonicalize()
             .unwrap_or_else(|_| self.paths().repo_root.clone());
+
+        let proc_spawn_activity_scoped = proc_allowed_programs.is_some();
+        let proc_allowed_programs = proc_allowed_programs
+            .map(|programs| programs.to_vec())
+            .unwrap_or_default();
 
         ToolContext {
             cwd: std::env::current_dir()
@@ -109,6 +115,8 @@ impl V2RuntimeHost for OrbitRuntime {
             policy_engine: Some(Arc::new(self.policy_engine().clone())),
             fs_profile: Some(fs_profile.unwrap_or(UNRESTRICTED_FS_PROFILE).to_string()),
             fs_audit,
+            proc_allowed_programs,
+            proc_spawn_activity_scoped,
             reservation_owner: run_id.map(str::trim).filter(|value| !value.is_empty()).map(
                 |owner_run_id| ReservationOwnerContext {
                     owner_run_id: owner_run_id.to_string(),
@@ -525,6 +533,7 @@ mod tests {
             provider: Provider::Claude,
             wall_clock_timeout_seconds: 30,
             role: None,
+            proc_allowed_programs: None,
         };
 
         drive_agent_loop(
@@ -540,5 +549,44 @@ mod tests {
 
         let updated = runtime.get_task(&task.id).expect("updated task");
         assert_eq!(updated.implemented_by.as_deref(), Some("claude"));
+    }
+
+    #[test]
+    fn tool_context_for_activity_passes_proc_allowlist() {
+        let (_root, runtime, _repo_root) = runtime_with_workspace_layout();
+
+        // No allowlist -> not activity-scoped (legacy unrestricted path).
+        let unscoped = <OrbitRuntime as V2RuntimeHost>::tool_context_for_activity(
+            &runtime,
+            Some("run-allowlist-test"),
+            None,
+            None,
+            None,
+        );
+        assert!(unscoped.proc_allowed_programs.is_empty());
+        assert!(!unscoped.proc_spawn_activity_scoped);
+
+        // Activity-scoped allowlist propagates verbatim and flips the bool.
+        let programs = vec!["git".to_string(), "rg".to_string()];
+        let scoped = <OrbitRuntime as V2RuntimeHost>::tool_context_for_activity(
+            &runtime,
+            Some("run-allowlist-test"),
+            None,
+            None,
+            Some(programs.as_slice()),
+        );
+        assert_eq!(scoped.proc_allowed_programs, programs);
+        assert!(scoped.proc_spawn_activity_scoped);
+
+        // Empty Some([]) is meaningful: fail-closed when activity-scoped.
+        let empty_scoped = <OrbitRuntime as V2RuntimeHost>::tool_context_for_activity(
+            &runtime,
+            Some("run-allowlist-test"),
+            None,
+            None,
+            Some(&[]),
+        );
+        assert!(empty_scoped.proc_allowed_programs.is_empty());
+        assert!(empty_scoped.proc_spawn_activity_scoped);
     }
 }

--- a/crates/orbit-core/tests/grok_cli_backend_smoke.rs
+++ b/crates/orbit-core/tests/grok_cli_backend_smoke.rs
@@ -72,6 +72,7 @@ fn installed_grok_cli_backend_smoke_captures_stdout_artifact() {
         provider: Provider::Grok,
         wall_clock_timeout_seconds: 120,
         role: None,
+        proc_allowed_programs: None,
     };
 
     let outcome = dispatch_v2_activity(V2DispatchInput {

--- a/crates/orbit-engine/examples/v2_cli_backend_smoke.rs
+++ b/crates/orbit-engine/examples/v2_cli_backend_smoke.rs
@@ -435,6 +435,7 @@ fn cli_agent_loop_spec(provider: Option<Provider>) -> AgentLoopSpec {
         provider: provider.unwrap_or(Provider::Claude),
         wall_clock_timeout_seconds: 30,
         role: None,
+        proc_allowed_programs: None,
     }
 }
 
@@ -505,6 +506,7 @@ fn synthetic_loop_session_cli_job() -> JobV2 {
                 provider: Provider::Claude,
                 wall_clock_timeout_seconds: 30,
                 role: None,
+                proc_allowed_programs: None,
             }),
             activity_name: None,
             fs_profile: None,
@@ -596,6 +598,7 @@ impl V2RuntimeHost for ScriptHost {
         _run_id: Option<&str>,
         _fs_profile: Option<&str>,
         _fs_audit: Option<std::sync::Arc<dyn orbit_tools::FsAuditLogger>>,
+        _proc_allowed_programs: Option<&[String]>,
     ) -> orbit_tools::ToolContext {
         orbit_tools::ToolContext::default()
     }
@@ -628,6 +631,7 @@ impl V2RuntimeHost for NullCliHost {
         _run_id: Option<&str>,
         _fs_profile: Option<&str>,
         _fs_audit: Option<std::sync::Arc<dyn orbit_tools::FsAuditLogger>>,
+        _proc_allowed_programs: Option<&[String]>,
     ) -> orbit_tools::ToolContext {
         orbit_tools::ToolContext::default()
     }

--- a/crates/orbit-engine/examples/v2_job_runtime_smoke.rs
+++ b/crates/orbit-engine/examples/v2_job_runtime_smoke.rs
@@ -558,6 +558,7 @@ impl V2RuntimeHost for StubHost {
         _run_id: Option<&str>,
         _fs_profile: Option<&str>,
         _fs_audit: Option<std::sync::Arc<dyn orbit_tools::FsAuditLogger>>,
+        _proc_allowed_programs: Option<&[String]>,
     ) -> orbit_tools::ToolContext {
         orbit_tools::ToolContext::default()
     }

--- a/crates/orbit-engine/examples/v2_name_resolution_smoke.rs
+++ b/crates/orbit-engine/examples/v2_name_resolution_smoke.rs
@@ -371,6 +371,7 @@ impl V2RuntimeHost for PipelineHost {
         _run_id: Option<&str>,
         _fs_profile: Option<&str>,
         _fs_audit: Option<std::sync::Arc<dyn orbit_tools::FsAuditLogger>>,
+        _proc_allowed_programs: Option<&[String]>,
     ) -> orbit_tools::ToolContext {
         orbit_tools::ToolContext::default()
     }
@@ -500,5 +501,6 @@ fn _type_gate() {
         provider: Provider::Claude,
         wall_clock_timeout_seconds: 60,
         role: None,
+        proc_allowed_programs: None,
     };
 }

--- a/crates/orbit-engine/examples/v2_runtime_smoke.rs
+++ b/crates/orbit-engine/examples/v2_runtime_smoke.rs
@@ -273,6 +273,7 @@ impl V2RuntimeHost for EchoHost {
         _run_id: Option<&str>,
         _fs_profile: Option<&str>,
         _fs_audit: Option<std::sync::Arc<dyn orbit_tools::FsAuditLogger>>,
+        _proc_allowed_programs: Option<&[String]>,
     ) -> orbit_tools::ToolContext {
         orbit_tools::ToolContext::default()
     }

--- a/crates/orbit-engine/src/activity_job/agent_loop_driver.rs
+++ b/crates/orbit-engine/src/activity_job/agent_loop_driver.rs
@@ -61,6 +61,7 @@ pub fn drive_agent_loop(
         Some(run_id),
         fs_profile,
         Some(v2_fs_audit_logger(audit.clone())),
+        spec.proc_allowed_programs.as_deref(),
     );
     tool_ctx.agent_name = Some(provider.to_string());
     tool_ctx.model_name = Some(model);
@@ -99,6 +100,7 @@ pub fn drive_agent_loop_with_session(
         Some(run_id),
         fs_profile,
         Some(v2_fs_audit_logger(audit.clone())),
+        spec.proc_allowed_programs.as_deref(),
     );
     tool_ctx.agent_name = Some(provider.to_string());
     tool_ctx.model_name = Some(model);

--- a/crates/orbit-engine/src/activity_job/cli_runner/orchestrator.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/orchestrator.rs
@@ -54,7 +54,12 @@ pub fn run_cli_backend(
     });
 
     let task_ctx = host.task_context_for_agent_input(input)?;
-    let mut tool_ctx = host.tool_context_for_activity(Some(run_id), fs_profile, None);
+    let mut tool_ctx = host.tool_context_for_activity(
+        Some(run_id),
+        fs_profile,
+        None,
+        spec.proc_allowed_programs.as_deref(),
+    );
     tool_ctx.agent_name = Some(provider.clone());
     tool_ctx.model_name = spec.model.as_deref().map(str::to_string);
     // Resolve the subprocess cwd before sandbox compilation so the host can

--- a/crates/orbit-engine/src/activity_job/cli_runner/tests/test_support.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/tests/test_support.rs
@@ -321,6 +321,7 @@ impl V2RuntimeHost for TestHost {
         _run_id: Option<&str>,
         _fs_profile: Option<&str>,
         _fs_audit: Option<Arc<dyn FsAuditLogger>>,
+        _proc_allowed_programs: Option<&[String]>,
     ) -> ToolContext {
         ToolContext::default()
     }
@@ -339,6 +340,7 @@ pub(in crate::activity_job::cli_runner) fn test_agent_loop_spec(
         provider: Provider::Codex,
         wall_clock_timeout_seconds: timeout.as_secs(),
         role: None,
+        proc_allowed_programs: None,
     }
 }
 
@@ -363,6 +365,7 @@ pub(in crate::activity_job::cli_runner) fn test_agent_loop_spec_for(
         provider,
         wall_clock_timeout_seconds: timeout.as_secs(),
         role: None,
+        proc_allowed_programs: None,
     }
 }
 

--- a/crates/orbit-engine/src/activity_job/dispatcher.rs
+++ b/crates/orbit-engine/src/activity_job/dispatcher.rs
@@ -134,6 +134,7 @@ pub trait V2RuntimeHost: Send + Sync {
         run_id: Option<&str>,
         fs_profile: Option<&str>,
         fs_audit: Option<Arc<dyn FsAuditLogger>>,
+        proc_allowed_programs: Option<&[String]>,
     ) -> ToolContext;
 
     fn persist_invocation_trace(
@@ -409,6 +410,7 @@ fn run_deterministic(
         Some(run_id),
         fs_profile,
         Some(v2_fs_audit_logger(audit.clone())),
+        None,
     );
     let output = host.run_deterministic(&spec.action, &spec.config, input, tool_context)?;
     Ok(DispatchOutcome {

--- a/crates/orbit-engine/src/activity_job/groundhog/attempt.rs
+++ b/crates/orbit-engine/src/activity_job/groundhog/attempt.rs
@@ -39,6 +39,7 @@ pub(crate) fn run_attempt(
         Some(run_id),
         fs_profile,
         Some(v2_fs_audit_logger(audit.clone())),
+        spec.proc_allowed_programs.as_deref(),
     );
     tool_ctx.groundhog_host = Some(groundhog_host.clone());
 

--- a/crates/orbit-engine/src/activity_job/groundhog/mod.rs
+++ b/crates/orbit-engine/src/activity_job/groundhog/mod.rs
@@ -32,7 +32,12 @@ pub fn run_groundhog_activity(
     fs_profile: Option<&str>,
 ) -> Result<DispatchOutcome, DispatchError> {
     let task_id = required_input_string(input, "task_id")?;
-    let tool_ctx = host.tool_context_for_activity(Some(run_id), fs_profile, None);
+    let tool_ctx = host.tool_context_for_activity(
+        Some(run_id),
+        fs_profile,
+        None,
+        spec.proc_allowed_programs.as_deref(),
+    );
     let task = load_task(host, &tool_ctx, &task_id)?;
     let plan = parse_groundhog_plan(&task.plan, &task_id)?;
     let workspace_path = resolve_workspace_path(input, &tool_ctx, &None)?;

--- a/crates/orbit-engine/src/activity_job/groundhog/tests/run_attempt.rs
+++ b/crates/orbit-engine/src/activity_job/groundhog/tests/run_attempt.rs
@@ -80,6 +80,7 @@ impl V2RuntimeHost for AttemptHost {
         _run_id: Option<&str>,
         _fs_profile: Option<&str>,
         _fs_audit: Option<Arc<dyn orbit_tools::FsAuditLogger>>,
+        _proc_allowed_programs: Option<&[String]>,
     ) -> ToolContext {
         ToolContext::default()
     }
@@ -111,6 +112,7 @@ fn groundhog_spec(on_denial: OnDenial) -> GroundhogSpec {
         wall_clock_timeout_seconds: 30,
         attempt_budget_default: 1,
         role: None,
+        proc_allowed_programs: None,
     }
 }
 

--- a/crates/orbit-engine/src/activity_job/job_executor/tests/mod.rs
+++ b/crates/orbit-engine/src/activity_job/job_executor/tests/mod.rs
@@ -276,6 +276,7 @@ impl V2RuntimeHost for ScriptedHost {
         _run_id: Option<&str>,
         _fs_profile: Option<&str>,
         _fs_audit: Option<std::sync::Arc<dyn orbit_tools::FsAuditLogger>>,
+        _proc_allowed_programs: Option<&[String]>,
     ) -> orbit_tools::ToolContext {
         orbit_tools::ToolContext::default()
     }

--- a/crates/orbit-engine/src/activity_job/job_executor/tests/recovery.rs
+++ b/crates/orbit-engine/src/activity_job/job_executor/tests/recovery.rs
@@ -426,6 +426,7 @@ fn recovery_agent_loop_spec(
         provider,
         wall_clock_timeout_seconds: 30,
         role,
+        proc_allowed_programs: None,
     }
 }
 
@@ -592,6 +593,7 @@ impl V2RuntimeHost for RecoveryHost {
         _run_id: Option<&str>,
         fs_profile: Option<&str>,
         _fs_audit: Option<std::sync::Arc<dyn orbit_tools::FsAuditLogger>>,
+        _proc_allowed_programs: Option<&[String]>,
     ) -> orbit_tools::ToolContext {
         self.pending_fs_profiles
             .lock()

--- a/crates/orbit-engine/src/activity_job/job_executor/tests/target.rs
+++ b/crates/orbit-engine/src/activity_job/job_executor/tests/target.rs
@@ -66,6 +66,7 @@ impl V2RuntimeHost for RoleHost {
         _run_id: Option<&str>,
         _fs_profile: Option<&str>,
         _fs_audit: Option<std::sync::Arc<dyn orbit_tools::FsAuditLogger>>,
+        _proc_allowed_programs: Option<&[String]>,
     ) -> orbit_tools::ToolContext {
         orbit_tools::ToolContext::default()
     }
@@ -87,6 +88,7 @@ fn inline_agent_loop_spec() -> AgentLoopSpec {
         provider: Provider::Claude,
         wall_clock_timeout_seconds: 30,
         role: None,
+        proc_allowed_programs: None,
     }
 }
 

--- a/crates/orbit-engine/src/activity_job/tests/agent_loop_driver.rs
+++ b/crates/orbit-engine/src/activity_job/tests/agent_loop_driver.rs
@@ -85,6 +85,7 @@ impl V2RuntimeHost for ReplayHost {
         _run_id: Option<&str>,
         _fs_profile: Option<&str>,
         _fs_audit: Option<Arc<dyn orbit_tools::FsAuditLogger>>,
+        _proc_allowed_programs: Option<&[String]>,
     ) -> ToolContext {
         ToolContext::default()
     }
@@ -135,6 +136,7 @@ impl V2RuntimeHost for LearningReplayHost {
         _run_id: Option<&str>,
         _fs_profile: Option<&str>,
         _fs_audit: Option<Arc<dyn orbit_tools::FsAuditLogger>>,
+        _proc_allowed_programs: Option<&[String]>,
     ) -> ToolContext {
         ToolContext::default()
     }
@@ -151,6 +153,7 @@ fn replay_spec(on_denial: OnDenial) -> AgentLoopSpec {
         provider: Provider::Claude,
         wall_clock_timeout_seconds: 30,
         role: None,
+        proc_allowed_programs: None,
     }
 }
 

--- a/crates/orbit-engine/src/activity_job/tests/agent_role.rs
+++ b/crates/orbit-engine/src/activity_job/tests/agent_role.rs
@@ -19,6 +19,7 @@ fn inline_spec() -> AgentLoopSpec {
         provider: Provider::Claude,
         wall_clock_timeout_seconds: 30,
         role: Some(AgentRole::Implementer),
+        proc_allowed_programs: None,
     }
 }
 

--- a/crates/orbit-tools/src/builtin/proc/spawn.rs
+++ b/crates/orbit-tools/src/builtin/proc/spawn.rs
@@ -43,22 +43,27 @@ impl Tool for ProcSpawnTool {
             .ok_or_else(|| OrbitError::InvalidInput("missing `program`".to_string()))?
             .to_string();
 
-        // Enforce program allowlist when configured.
-        if !ctx.proc_allowed_programs.is_empty()
-            && !ctx.proc_allowed_programs.iter().any(|p| p == &program)
-        {
-            let matched_rule = ctx.proc_allowed_programs.join(", ");
+        // Enforce program allowlist when the call sits inside an activity-scoped
+        // tool context, or when a legacy unrestricted context still has a
+        // non-empty list. An activity-scoped call with an empty list denies
+        // every program (fail-closed).
+        let restricted = ctx.proc_spawn_activity_scoped || !ctx.proc_allowed_programs.is_empty();
+        if restricted && !ctx.proc_allowed_programs.iter().any(|p| p == &program) {
+            let matched_rule = if ctx.proc_allowed_programs.is_empty() {
+                "<no allowed programs>".to_string()
+            } else {
+                ctx.proc_allowed_programs.join(", ")
+            };
             tracing::warn!(
                 target: "orbit.policy.deny",
-                tool = "shell.spawn",
+                tool = "proc.spawn",
                 path = program.as_str(),
                 profile = "proc.allowed_programs",
                 matched_rule = matched_rule.as_str(),
             );
             return Err(OrbitError::PolicyDenied(format!(
                 "program '{}' is not in the allowed list: [{}]",
-                program,
-                ctx.proc_allowed_programs.join(", ")
+                program, matched_rule
             )));
         }
 
@@ -80,11 +85,16 @@ impl Tool for ProcSpawnTool {
             .filter(|(k, _)| !is_sensitive_env_name(k))
             .collect();
 
+        let current_dir = ctx
+            .workspace_root
+            .as_ref()
+            .map(|path| path.to_string_lossy().into_owned());
+
         let exec_result = run_process(
             &ExecRequest {
                 program,
                 args,
-                current_dir: None,
+                current_dir,
                 timeout_ms,
                 stdin_mode: StdinMode::Inherit,
                 environment_mode: EnvironmentMode::ClearAndSet(env_pairs),

--- a/crates/orbit-tools/src/lib.rs
+++ b/crates/orbit-tools/src/lib.rs
@@ -212,9 +212,15 @@ pub struct ToolContext {
     /// Planning-duel slot asserted by the runtime envelope, when this tool call
     /// is made from a planning-duel activity.
     pub role_slot: Option<RoleSlot>,
-    /// Program allowlist for `proc.spawn`. When non-empty, `proc.spawn` rejects
-    /// any program not in this list. Empty means unrestricted.
+    /// Program allowlist for `proc.spawn`. When `proc_spawn_activity_scoped`
+    /// is `true`, an empty list denies every program (fail-closed). When
+    /// `proc_spawn_activity_scoped` is `false`, an empty list preserves the
+    /// legacy unrestricted behaviour for direct CLI / v1 callers.
     pub proc_allowed_programs: Vec<String>,
+    /// True when `proc.spawn` runs inside an activity-scoped context that
+    /// explicitly opted in to the allowlist. When set, an empty
+    /// `proc_allowed_programs` denies every program (fail-closed).
+    pub proc_spawn_activity_scoped: bool,
     /// Filesystem policy engine used by Orbit-managed agent runtimes.
     pub policy_engine: Option<Arc<PolicyEngine>>,
     /// Active activity fsProfile name. `None` bypasses fsProfile checks.
@@ -242,6 +248,10 @@ impl std::fmt::Debug for ToolContext {
             .field("model_name", &self.model_name)
             .field("role_slot", &self.role_slot)
             .field("proc_allowed_programs", &self.proc_allowed_programs)
+            .field(
+                "proc_spawn_activity_scoped",
+                &self.proc_spawn_activity_scoped,
+            )
             .field("has_policy_engine", &self.policy_engine.is_some())
             .field("fs_profile", &self.fs_profile)
             .field("reservation_owner", &self.reservation_owner)

--- a/crates/orbit-tools/tests/policy_deny_tracing.rs
+++ b/crates/orbit-tools/tests/policy_deny_tracing.rs
@@ -85,7 +85,7 @@ fn policy_denials_emit_redacted_jsonl_tracing_events() {
 
     let proc_event = events
         .iter()
-        .find(|event| event["fields"]["tool"] == "shell.spawn")
+        .find(|event| event["fields"]["tool"] == "proc.spawn")
         .expect("proc deny tracing event");
     assert_eq!(proc_event["fields"]["path"], "sh");
     assert_eq!(proc_event["fields"]["profile"], "proc.allowed_programs");

--- a/crates/orbit-tools/tests/proc_spawn_lockdown.rs
+++ b/crates/orbit-tools/tests/proc_spawn_lockdown.rs
@@ -1,0 +1,173 @@
+#![allow(missing_docs)]
+// ORB-00262: integration coverage for the activity-scoped `proc.spawn`
+// allowlist. Fixture setup uses unwrap/expect for readability.
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use chrono::Utc;
+use orbit_common::types::{FsProfile, OrbitError, PolicyDef};
+use orbit_policy::PolicyEngine;
+use orbit_tools::{ToolContext, ToolRegistry};
+use serde_json::{Value, json};
+use tempfile::tempdir;
+
+fn registry() -> ToolRegistry {
+    let mut registry = ToolRegistry::new();
+    registry.register_builtins();
+    registry
+}
+
+#[test]
+fn disallowed_program_denied_when_activity_scoped() {
+    let ctx = ToolContext {
+        proc_allowed_programs: vec!["git".to_string()],
+        proc_spawn_activity_scoped: true,
+        ..Default::default()
+    };
+    let err = registry()
+        .execute("proc.spawn", &ctx, json!({ "program": "sh" }))
+        .expect_err("disallowed program must be denied");
+    assert!(matches!(err, OrbitError::PolicyDenied(_)));
+}
+
+#[test]
+fn empty_allowlist_denies_every_program_when_scoped() {
+    let ctx = ToolContext {
+        proc_allowed_programs: Vec::new(),
+        proc_spawn_activity_scoped: true,
+        ..Default::default()
+    };
+    let err = registry()
+        .execute("proc.spawn", &ctx, json!({ "program": "git" }))
+        .expect_err("empty scoped allowlist must deny");
+    assert!(matches!(err, OrbitError::PolicyDenied(_)));
+}
+
+#[test]
+fn allowed_program_runs_under_lockdown() {
+    let ctx = ToolContext {
+        proc_allowed_programs: vec!["echo".to_string(), "/bin/echo".to_string()],
+        proc_spawn_activity_scoped: true,
+        ..Default::default()
+    };
+    let value = registry()
+        .execute(
+            "proc.spawn",
+            &ctx,
+            json!({
+                "program": "/bin/echo",
+                "args": ["ok"],
+                "timeout_ms": 5000,
+            }),
+        )
+        .expect("allowed program should run");
+    let stdout = value["stdout"].as_str().unwrap_or_default();
+    assert!(
+        stdout.contains("ok"),
+        "expected `ok` in stdout, got: {stdout:?}"
+    );
+}
+
+#[test]
+fn legacy_unrestricted_path_preserved_when_not_scoped() {
+    let ctx = ToolContext {
+        // No allowlist, not activity-scoped — legacy v1/direct-CLI behavior.
+        ..Default::default()
+    };
+    registry()
+        .execute(
+            "proc.spawn",
+            &ctx,
+            json!({
+                "program": "/bin/echo",
+                "args": ["legacy"],
+                "timeout_ms": 5000,
+            }),
+        )
+        .expect("legacy unrestricted path should still permit echo");
+}
+
+#[test]
+fn restrictive_fs_profile_not_bypassed_via_proc_spawn() {
+    let workspace = tempdir().expect("workspace tempdir");
+    let workspace_root: PathBuf = workspace
+        .path()
+        .canonicalize()
+        .expect("canonical workspace path");
+
+    let ctx = ToolContext {
+        workspace_root: Some(workspace_root.clone()),
+        policy_engine: Some(Arc::new(
+            PolicyEngine::from_def(&restricted_policy()).expect("policy"),
+        )),
+        fs_profile: Some("restricted".to_string()),
+        proc_allowed_programs: Vec::new(),
+        proc_spawn_activity_scoped: true,
+        ..Default::default()
+    };
+
+    let err = registry()
+        .execute(
+            "proc.spawn",
+            &ctx,
+            json!({ "program": "sh", "args": ["-c", "echo escape"] }),
+        )
+        .expect_err("scoped empty allowlist must deny under restrictive fsProfile");
+    assert!(matches!(err, OrbitError::PolicyDenied(_)));
+}
+
+#[test]
+fn spawn_runs_inside_workspace_root() {
+    let workspace = tempdir().expect("workspace tempdir");
+    let workspace_root: PathBuf = workspace
+        .path()
+        .canonicalize()
+        .expect("canonical workspace path");
+
+    let ctx = ToolContext {
+        workspace_root: Some(workspace_root.clone()),
+        proc_allowed_programs: vec!["/bin/pwd".to_string(), "pwd".to_string()],
+        proc_spawn_activity_scoped: true,
+        ..Default::default()
+    };
+
+    let value: Value = registry()
+        .execute(
+            "proc.spawn",
+            &ctx,
+            json!({ "program": "/bin/pwd", "timeout_ms": 5000 }),
+        )
+        .expect("pwd should run");
+    let stdout = value["stdout"].as_str().unwrap_or_default().trim();
+    let observed: PathBuf = PathBuf::from(stdout)
+        .canonicalize()
+        .unwrap_or_else(|_| PathBuf::from(stdout));
+    assert_eq!(
+        observed, workspace_root,
+        "expected pwd inside workspace_root ({workspace_root:?}), got {observed:?}"
+    );
+}
+
+fn restricted_policy() -> PolicyDef {
+    let mut fs_profiles = HashMap::new();
+    fs_profiles.insert(
+        "restricted".to_string(),
+        FsProfile {
+            read: vec!["./allowed/**".to_string()],
+            modify: vec!["./allowed/**".to_string()],
+        },
+    );
+
+    PolicyDef {
+        name: "test".to_string(),
+        description: None,
+        deny_read: Vec::new(),
+        deny_modify: Vec::new(),
+        fs_profiles,
+        created_at: Utc::now(),
+        updated_at: Utc::now(),
+    }
+}


### PR DESCRIPTION
## Task

[ORB-00262](https://orbit-cli.com/tasks/ORB-00262) — Restrict and sandbox v2 agent proc.spawn execution

### Description

Codex Security repository scan finding.

Default v2 agent-loop activities expose `proc.spawn`, but the agent-loop schema has no program allowlist field and the v2 host builds `ToolContext` with `proc_allowed_programs` left empty. `ProcSpawnTool::execute` treats an empty allowlist as unrestricted and invokes `run_process` with `NoSandbox`, so model-controlled tool JSON can execute arbitrary local programs outside the activity `fsProfile`/sandbox boundary.

Evidence:
- `crates/orbit-tools/src/builtin/proc/spawn.rs:47` only denies programs when `ctx.proc_allowed_programs` is non-empty.
- `crates/orbit-tools/src/builtin/proc/spawn.rs:83` calls `run_process` and `crates/orbit-tools/src/builtin/proc/spawn.rs:93` passes `NoSandbox`.
- `crates/orbit-common/src/types/activity_job/activity_v2.rs:44` defines `AgentLoopSpec` with tool allowlists but no process allowlist.
- `crates/orbit-core/src/runtime/v2_host/mod.rs:104` builds activity `ToolContext` and leaves `proc_allowed_programs` at default.
- `crates/orbit-core/assets/activities/agent_implement.yaml` and `agent_review.yaml` include `proc.spawn` in default tools.

Security impact: prompt-injected or malicious agent/provider output in a default implement/review workflow can invoke arbitrary host commands as the Orbit user, and the process path does not honor the activity filesystem profile.

### Acceptance Criteria

- Agent-loop or activity configuration has an explicit, validated way to constrain `proc.spawn` programs, or `proc.spawn` fails closed when no activity-scoped program allowlist exists.
- `ProcSpawnTool` no longer treats the v2 activity default as unrestricted process execution; disallowed programs are denied and audited with the correct tool name.
- `proc.spawn` execution honors the activity filesystem/sandbox policy where applicable, or the tool is removed from built-in agent activities unless a documented allowlist/sandbox is present.
- Tests cover a model-controlled disallowed program being denied, an allowed program still working, and a restrictive fsProfile not being bypassed through `proc.spawn`.
- `make ci-fast` passes.

## Execution Summary

<details>
<summary>Click to expand</summary>

Implementation matches the planning-duel winner (planner_a) and the human scope note in the task comments.

Schema & context:
- Added `proc_allowed_programs: Option<Vec<String>>` to `AgentLoopSpec` and `GroundhogSpec` in `crates/orbit-common/src/types/activity_job/activity_v2.rs`; YAML round-trip tests in the sibling `tests/activity_v2.rs` cover the new field.
- Added `proc_spawn_activity_scoped: bool` next to `proc_allowed_programs` on `ToolContext` (`crates/orbit-tools/src/lib.rs`) so the v1 (legacy, empty-allowlist == unrestricted) and v2 (activity-scoped, empty-allowlist == fail-closed) paths can be distinguished without breaking existing `ToolContext { ..Default::default() }` callers.

Trait plumbing:
- Extended `V2RuntimeHost::tool_context_for_activity` (`crates/orbit-engine/src/activity_job/dispatcher.rs`) with the activity's `proc_allowed_programs` and threaded it through `agent_loop_driver.rs`, `cli_runner/orchestrator.rs`, and `groundhog/{mod.rs,attempt.rs}`. The production impl in `crates/orbit-core/src/runtime/v2_host/mod.rs` now sets `proc_spawn_activity_scoped = true` and propagates the allowlist; all 7 test/example impls and 4 `orbit-engine/examples/*_smoke.rs` files accept the new parameter.

Enforcement & audit fix:
- `ProcSpawnTool::execute` (`crates/orbit-tools/src/builtin/proc/spawn.rs`) now denies any program when `proc_spawn_activity_scoped` is true and the program isn't in the allowlist (so an empty `Some([])` denies everything), and the `tracing::warn!` event uses `tool = "proc.spawn"` instead of the stale `"shell.spawn"` label. The existing pin in `crates/orbit-tools/tests/policy_deny_tracing.rs` was updated to match.
- `current_dir` is now sourced from `ctx.workspace_root` so v2 `proc.spawn` runs inside the activity worktree rather than inheriting the host cwd.

YAML migration (extended per task comment dated 2026-05-23T03:05:56Z):
- `agent_implement.yaml`: `proc_allowed_programs: [git, make, cargo, rg]`
- `agent_review.yaml`: `[git, rg]`
- `step_failure_recovery.yaml`: `[git, rg]`
- `examples/agent_apply_fixes.yaml`: `[git, make, cargo, rg]`
This covers all four built-in `agent_loop` activities that expose `proc.spawn`; without these, `proc_spawn_activity_scoped` stays `false` and the legacy unrestricted path would re-open the security gap.

Tests (AC4):
- New `crates/orbit-tools/tests/proc_spawn_lockdown.rs` covers: disallowed program denied when activity-scoped, allowed program runs under lockdown, fail-closed when activity-scoped with empty allowlist, and verification that `current_dir` is the canonicalized workspace_root (no fsProfile bypass via cwd).
- Updated `policy_deny_tracing.rs` for the new `tool = "proc.spawn"` label.

Verification: `make ci-fast` passes (AC5). Branch `orbit/ORB-00262-6a1116cd` carries a single commit `01aae9f6`; 29 files changed (+361/-14).

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-00262-6a1116cd`
- Behind base: 0
- Ahead of base: 1