### PR TITLE
Hook-driven async steering: surface review-thread asks to executing agent

### DIFF
--- a/.orbit/adrs/accepted/ADR-0182/adr.yaml
+++ b/.orbit/adrs/accepted/ADR-0182/adr.yaml
@@ -1,0 +1,26 @@
+schema_version: 2
+id: ADR-0182
+title: Review-thread hook active task binding
+status: accepted
+owner: codex
+created_at: 2026-05-23T04:58:47.481921Z
+accepted_at: 2026-05-23T04:58:51.423546Z
+last_updated: 2026-05-23T04:58:51.423546Z
+related_features:
+- task-artifacts
+- project-learnings
+related_tasks:
+- ORB-00273
+tags:
+- hooks
+- review-threads
+- async-steering
+paths:
+- crates/orbit-core/src/command/review_thread_hook.rs
+- crates/orbit-core/src/command/learning_hook.rs
+- crates/orbit-engine/src/context.rs
+- crates/orbit-engine/src/activity_job/cli_runner/orchestrator.rs
+supersedes: []
+legacy_ids: []
+validation_warnings: []
+legacy_validation: none

--- a/.orbit/adrs/accepted/ADR-0182/body.md
+++ b/.orbit/adrs/accepted/ADR-0182/body.md
@@ -1,0 +1,10 @@
+## Context
+Review-thread reminders need a cheap way to know which task owns the current agent turn. Inferring from cwd or scanning task files would make every PreToolUse call depend on filesystem heuristics, while the engine already knows the executing task when it seeds ORBIT_TASK_ID.
+
+## Decision
+The hook treats ORBIT_ACTIVE_TASK_ID as the explicit active-task binding, with ORBIT_TASK_ID as a compatibility fallback for existing execution paths. Orbit execution code seeds both values when the activity input contains a task id, and hook state is still scoped by the existing session id plus parent-pid state-file key.
+
+## Consequences
+- Review-thread surfacing remains a local task-store read and does not perform network I/O or cwd inference.
+- Existing ORBIT_TASK_ID-spawned executions keep working while newer shims can depend on the clearer ORBIT_ACTIVE_TASK_ID name.
+- Cost: Orbit now has two task-id environment names during a compatibility window, so documentation and tests must keep their precedence explicit.

--- a/crates/orbit-cli/src/command/hook/tests/render.rs
+++ b/crates/orbit-cli/src/command/hook/tests/render.rs
@@ -1,4 +1,7 @@
 use crate::command::hook::render::HookOutputFormat;
+use chrono::Utc;
+use orbit_common::types::{LearningReminder, ReviewMessage, ReviewThread, ReviewThreadStatus};
+use orbit_core::command::review_thread_hook::reminders_from_threads;
 
 #[test]
 fn cli_format_converts_to_core_format() {
@@ -18,4 +21,44 @@ fn cli_format_converts_to_core_format() {
         orbit_core::command::learning_hook::HookOutputFormat::from(HookOutputFormat::Grok),
         orbit_core::command::learning_hook::HookOutputFormat::Grok
     );
+}
+
+#[test]
+fn core_renderer_combines_learning_and_review_thread_output_for_cli_formats() {
+    let learnings = vec![LearningReminder {
+        id: "L-0017".to_string(),
+        summary: "learning reminder".to_string(),
+        comments: Vec::new(),
+    }];
+    let review_threads = reminders_from_threads(
+        "ORB-00001",
+        vec![ReviewThread {
+            thread_id: "rt-1".to_string(),
+            path: None,
+            line: None,
+            status: ReviewThreadStatus::Open,
+            messages: vec![ReviewMessage {
+                message_id: "rm-1".to_string(),
+                at: Utc::now(),
+                by: "human".to_string(),
+                body: "async steering note".to_string(),
+                github_comment_id: None,
+            }],
+            github_thread_id: None,
+        }],
+    );
+
+    let output = orbit_core::command::learning_hook::render_hook_reminders(
+        HookOutputFormat::Codex.into(),
+        &learnings,
+        &review_threads,
+    )
+    .expect("render codex hook output");
+    let value: serde_json::Value = serde_json::from_str(&output).expect("parse codex JSON");
+    let context = value["hookSpecificOutput"]["additionalContext"]
+        .as_str()
+        .expect("additional context");
+    assert!(context.contains("learning reminder"));
+    assert!(context.contains("async steering note"));
+    assert!(context.contains("task-level"));
 }

--- a/crates/orbit-cli/tests/hook_pretooluse.rs
+++ b/crates/orbit-cli/tests/hook_pretooluse.rs
@@ -158,6 +158,120 @@ fn repeated_payload_with_same_session_dedups_and_skips_second_audit() {
 }
 
 #[test]
+fn review_threads_surface_once_replies_reopen_and_resolve_suppresses() {
+    let workspace = TestWorkspace::new();
+    let task_id = workspace.add_task("Review hook task");
+    workspace.add_review_thread(&task_id, "Human steering note.", "human");
+    let thread_id = workspace.review_thread_id(&task_id);
+    let payload = r#"{"tool_name":"Edit","file_path":"src/lib.rs"}"#;
+
+    let first = workspace.run_hook(
+        payload,
+        &[
+            ("ORBIT_SESSION_ID", "review-thread-session"),
+            ("ORBIT_ACTIVE_TASK_ID", &task_id),
+        ],
+        "review thread first",
+    );
+    let stdout = String::from_utf8_lossy(&first.stdout);
+    assert!(stdout.contains("Review threads awaiting agent attention"));
+    assert!(stdout.contains("Human steering note."));
+    assert!(stdout.contains("human [human]"));
+
+    let second = workspace.run_hook(
+        payload,
+        &[
+            ("ORBIT_SESSION_ID", "review-thread-session"),
+            ("ORBIT_ACTIVE_TASK_ID", &task_id),
+        ],
+        "review thread second",
+    );
+    assert!(second.stdout.is_empty());
+
+    workspace.reply_review_thread(&task_id, &thread_id, "Agent folded it in.", "codex");
+    workspace.resolve_review_thread(&task_id, &thread_id);
+    let resolved = workspace.run_hook(
+        payload,
+        &[
+            ("ORBIT_SESSION_ID", "review-thread-session"),
+            ("ORBIT_ACTIVE_TASK_ID", &task_id),
+        ],
+        "review thread resolved",
+    );
+    assert!(resolved.stdout.is_empty());
+
+    workspace.reply_review_thread(&task_id, &thread_id, "Please revisit this.", "human");
+    let reopened = workspace.run_hook(
+        payload,
+        &[
+            ("ORBIT_SESSION_ID", "review-thread-session"),
+            ("ORBIT_ACTIVE_TASK_ID", &task_id),
+        ],
+        "review thread reopened",
+    );
+    let stdout = String::from_utf8_lossy(&reopened.stdout);
+    assert!(stdout.contains("Please revisit this."));
+
+    let final_pass = workspace.run_hook(
+        payload,
+        &[
+            ("ORBIT_SESSION_ID", "review-thread-session"),
+            ("ORBIT_ACTIVE_TASK_ID", &task_id),
+        ],
+        "review thread reopened dedup",
+    );
+    assert!(final_pass.stdout.is_empty());
+
+    let events = workspace.run_json(
+        &[
+            "audit",
+            "list",
+            "--kind",
+            "review_thread_surfaced",
+            "--json",
+        ],
+        "audit list",
+    );
+    let rows = events.as_array().expect("audit rows");
+    assert_eq!(rows.len(), 2, "audit rows: {events}");
+    let mut seqs = rows
+        .iter()
+        .map(|row| {
+            let arguments: Value =
+                serde_json::from_str(row["arguments_json"].as_str().expect("arguments_json"))
+                    .expect("audit arguments JSON");
+            assert_eq!(arguments["task_id"], json!(task_id));
+            assert_eq!(arguments["thread_id"], json!(thread_id));
+            arguments["last_seen_message_seq"].as_u64().expect("seq")
+        })
+        .collect::<Vec<_>>();
+    seqs.sort_unstable();
+    assert_eq!(seqs, [1, 3]);
+}
+
+#[test]
+fn combined_learning_and_review_thread_output_renders_both_paths() {
+    let workspace = TestWorkspace::new();
+    workspace.add_learning("Combined learning reminder", &["src/**"]);
+    let task_id = workspace.add_task("Combined hook task");
+    workspace.add_review_thread(&task_id, "Combined review note.", "human");
+
+    let output = workspace.run_hook(
+        r#"{"tool_name":"Read","path":"src/lib.rs"}"#,
+        &[
+            ("ORBIT_SESSION_ID", "combined-session"),
+            ("ORBIT_ACTIVE_TASK_ID", &task_id),
+        ],
+        "combined hook",
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("Project learnings relevant to this task"));
+    assert!(stdout.contains("Combined learning reminder"));
+    assert!(stdout.contains("Review threads awaiting agent attention"));
+    assert!(stdout.contains("Combined review note."));
+}
+
+#[test]
 fn per_call_cap_limits_rendered_learning_count() {
     let workspace = TestWorkspace::new();
     for idx in 0..6 {
@@ -309,6 +423,71 @@ impl TestWorkspace {
         self.run_json(&args, "add learning")
     }
 
+    fn add_task(&self, title: &str) -> String {
+        let input = json!({
+            "title": title,
+            "description": "Hook review thread fixture task.",
+            "workspace": self.work.to_string_lossy(),
+            "model": "codex"
+        })
+        .to_string();
+        let task = self.run_json(
+            &["tool", "run", "orbit.task.add", "--input", &input],
+            "add task",
+        );
+        task["id"].as_str().expect("task id").to_string()
+    }
+
+    fn add_review_thread(&self, task_id: &str, body: &str, model: &str) {
+        let input = json!({ "task_id": task_id, "body": body, "model": model }).to_string();
+        self.run_json(
+            &["tool", "run", "orbit.review-thread.add", "--input", &input],
+            "add review thread",
+        );
+    }
+
+    fn reply_review_thread(&self, task_id: &str, thread_id: &str, body: &str, model: &str) {
+        let input =
+            json!({ "task_id": task_id, "thread_id": thread_id, "body": body, "model": model })
+                .to_string();
+        self.run_json(
+            &[
+                "tool",
+                "run",
+                "orbit.review-thread.reply",
+                "--input",
+                &input,
+            ],
+            "reply review thread",
+        );
+    }
+
+    fn resolve_review_thread(&self, task_id: &str, thread_id: &str) {
+        let input = json!({ "task_id": task_id, "thread_id": thread_id }).to_string();
+        self.run_json(
+            &[
+                "tool",
+                "run",
+                "orbit.review-thread.resolve",
+                "--input",
+                &input,
+            ],
+            "resolve review thread",
+        );
+    }
+
+    fn review_thread_id(&self, task_id: &str) -> String {
+        let input = json!({ "task_id": task_id }).to_string();
+        let threads = self.run_json(
+            &["tool", "run", "orbit.review-thread.list", "--input", &input],
+            "list review threads",
+        );
+        threads[0]["thread_id"]
+            .as_str()
+            .expect("thread id")
+            .to_string()
+    }
+
     fn run_hook(&self, stdin: &str, envs: &[(&str, &str)], label: &str) -> Output {
         self.run(&["hook", "pretooluse"], Some(stdin), envs, label)
     }
@@ -367,6 +546,13 @@ fn run_orbit(
         .env("HOME", home)
         .env("USERPROFILE", home)
         .env_remove("ORBIT_ROOT")
+        .env_remove("ORBIT_TASK_ID")
+        .env_remove("ORBIT_ACTIVE_TASK_ID")
+        .env_remove("ORBIT_RUN_ID")
+        .env_remove("ORBIT_ACTIVITY_ID")
+        .env_remove("ORBIT_STEP_INDEX")
+        .env_remove("ORBIT_AGENT_NAME")
+        .env_remove("ORBIT_AGENT_MODEL")
         .env_remove("ORBIT_SESSION_ID")
         .env_remove("ORBIT_LEARNING_PER_CALL_CAP")
         .env_remove("ORBIT_LEARNING_SESSION_CAP")

--- a/crates/orbit-common/src/types/mod.rs
+++ b/crates/orbit-common/src/types/mod.rs
@@ -122,8 +122,8 @@ pub use run_state::PipelineState;
 pub use skill::Skill;
 pub use task::{
     ExternalRef, GITHUB_PR_EXTERNAL_REF_SYSTEM, ResolvedTaskDependency, ReviewMessage,
-    ReviewThread, ReviewThreadStatus, Task, TaskArtifact, TaskComment, TaskComplexity,
-    TaskHistoryEntry, TaskPriority, TaskStatus, TaskType, build_task_status_index,
+    ReviewThread, ReviewThreadAnchor, ReviewThreadStatus, Task, TaskArtifact, TaskComment,
+    TaskComplexity, TaskHistoryEntry, TaskPriority, TaskStatus, TaskType, build_task_status_index,
     media_type_for_artifact_path, normalize_task_dependencies, normalize_task_tags,
     prune_missing_context_files, push_external_ref_if_missing, resolve_task_dependencies,
     task_dependencies_ready, task_matches_tags, unmet_task_dependencies,

--- a/crates/orbit-common/src/types/task.rs
+++ b/crates/orbit-common/src/types/task.rs
@@ -41,6 +41,7 @@ use std::sync::OnceLock;
 
 use chrono::{DateTime, Utc};
 use regex::Regex;
+use serde::ser::SerializeStruct;
 use serde::{Deserialize, Serialize};
 use url::Url;
 
@@ -332,11 +333,19 @@ pub struct ReviewMessage {
     pub github_comment_id: Option<u64>,
 }
 
+/// Anchor kind for a [`ReviewThread`].
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum ReviewThreadAnchor {
+    Inline { path: String, line: u64 },
+    TaskLevel,
+}
+
 /// A review thread on a task, replacing direct GitHub review comments.
 ///
 /// Threads with `path` and `line` are inline (file-specific) comments.
 /// Threads without are general comments (e.g. review summaries).
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
 pub struct ReviewThread {
     pub thread_id: String,
     /// File path relative to repo root. `None` for general comments.
@@ -350,6 +359,38 @@ pub struct ReviewThread {
     /// GitHub review thread/comment ID, set after first sync.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub github_thread_id: Option<u64>,
+}
+
+impl ReviewThread {
+    pub fn anchor(&self) -> ReviewThreadAnchor {
+        match (&self.path, self.line) {
+            (Some(path), Some(line)) => ReviewThreadAnchor::Inline {
+                path: path.clone(),
+                line,
+            },
+            _ => ReviewThreadAnchor::TaskLevel,
+        }
+    }
+}
+
+impl Serialize for ReviewThread {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        let mut state = serializer.serialize_struct("ReviewThread", 7)?;
+        state.serialize_field("thread_id", &self.thread_id)?;
+        state.serialize_field("anchor", &self.anchor())?;
+        if let Some(path) = &self.path {
+            state.serialize_field("path", path)?;
+        }
+        if let Some(line) = self.line {
+            state.serialize_field("line", &line)?;
+        }
+        state.serialize_field("status", &self.status)?;
+        state.serialize_field("messages", &self.messages)?;
+        if let Some(github_thread_id) = self.github_thread_id {
+            state.serialize_field("github_thread_id", &github_thread_id)?;
+        }
+        state.end()
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]

--- a/crates/orbit-core/src/command/learning_hook.rs
+++ b/crates/orbit-core/src/command/learning_hook.rs
@@ -67,10 +67,20 @@ pub fn render_reminders(
     format: HookOutputFormat,
     admitted: &[LearningReminder],
 ) -> Result<String, OrbitError> {
+    render_hook_reminders(format, admitted, &[])
+}
+
+pub fn render_hook_reminders(
+    format: HookOutputFormat,
+    admitted: &[LearningReminder],
+    review_threads: &[crate::command::review_thread_hook::ReviewThreadReminder],
+) -> Result<String, OrbitError> {
     match format {
-        HookOutputFormat::Claude | HookOutputFormat::Grok => Ok(render_claude(admitted)),
-        HookOutputFormat::Codex => render_codex(admitted),
-        HookOutputFormat::Gemini => render_gemini(admitted),
+        HookOutputFormat::Claude | HookOutputFormat::Grok => {
+            Ok(render_text_context(admitted, review_threads))
+        }
+        HookOutputFormat::Codex => render_codex_context(admitted, review_threads),
+        HookOutputFormat::Gemini => render_gemini_context(admitted, review_threads),
     }
 }
 
@@ -79,14 +89,28 @@ pub fn render_claude(admitted: &[LearningReminder]) -> String {
 }
 
 pub fn render_codex(admitted: &[LearningReminder]) -> Result<String, OrbitError> {
-    render_json_context("PreToolUse", admitted)
+    render_codex_context(admitted, &[])
 }
 
 pub fn render_gemini(admitted: &[LearningReminder]) -> Result<String, OrbitError> {
+    render_gemini_context(admitted, &[])
+}
+
+pub fn render_codex_context(
+    admitted: &[LearningReminder],
+    review_threads: &[crate::command::review_thread_hook::ReviewThreadReminder],
+) -> Result<String, OrbitError> {
+    render_json_context("PreToolUse", admitted, review_threads)
+}
+
+pub fn render_gemini_context(
+    admitted: &[LearningReminder],
+    review_threads: &[crate::command::review_thread_hook::ReviewThreadReminder],
+) -> Result<String, OrbitError> {
     // Gemini CLI names its documented pre-tool hook event `BeforeTool`; the
     // renderer stays separate so the wiring can change when Gemini's hook
     // context surface settles.
-    render_json_context("BeforeTool", admitted)
+    render_json_context("BeforeTool", admitted, review_threads)
 }
 
 pub fn parse_payload(stdin: &str) -> Option<HookPayload> {
@@ -287,11 +311,83 @@ pub(crate) fn run_pretooluse_input(
     };
 
     let caps = caps_from_env();
+    let session_id = std::env::var(ORBIT_SESSION_ID_ENV)
+        .ok()
+        .filter(|value| !value.trim().is_empty());
+    let tmpdir = learning_hook_tmpdir();
+    let ppid = parent_process_id();
+
+    let admitted = match admitted_learning_reminders(
+        runtime,
+        &payload,
+        caps,
+        session_id.as_deref(),
+        &tmpdir,
+        ppid,
+    ) {
+        Ok(admitted) => admitted,
+        Err(error) => {
+            tracing::warn!(error = %redact_sensitive_env_text(&error), "learning hook reminder path failed open");
+            Vec::new()
+        }
+    };
+    let review_thread_admitted = match admitted_review_thread_reminders(
+        runtime,
+        &payload,
+        session_id.as_deref(),
+        &tmpdir,
+        ppid,
+    ) {
+        Ok(admitted) => admitted,
+        Err(error) => {
+            tracing::warn!(error = %redact_sensitive_env_text(&error), "review-thread hook reminder path failed open");
+            Vec::new()
+        }
+    };
+
+    if admitted.is_empty() && review_thread_admitted.is_empty() {
+        return Ok(None);
+    }
+
+    if !admitted.is_empty() {
+        emit_learning_injected_audit(
+            runtime,
+            &payload.tool_name,
+            &payload.target_path,
+            session_id.as_deref(),
+            &admitted,
+            start.elapsed(),
+        )?;
+    }
+    for reminder in &review_thread_admitted {
+        crate::command::review_thread_hook::emit_review_thread_surfaced_audit(
+            runtime,
+            &payload.tool_name,
+            &payload.target_path,
+            session_id.as_deref(),
+            reminder,
+            start.elapsed(),
+        )?;
+    }
+
+    render_hook_reminders(format, &admitted, &review_thread_admitted)
+        .map(Some)
+        .map_err(|error| format!("render reminders: {error}"))
+}
+
+fn admitted_learning_reminders(
+    runtime: &OrbitRuntime,
+    payload: &HookPayload,
+    caps: LearningInjectionCaps,
+    session_id: Option<&str>,
+    tmpdir: &Path,
+    ppid: u32,
+) -> Result<Vec<LearningReminder>, String> {
     if !runtime
         .learning_hook_target_is_searchable(&payload.target_path)
         .map_err(|error| format!("classify learning target path: {error}"))?
     {
-        return Ok(None);
+        return Ok(Vec::new());
     }
 
     let results = runtime
@@ -303,33 +399,42 @@ pub(crate) fn run_pretooluse_input(
         })
         .map_err(|error| format!("search learnings: {error}"))?;
     if results.is_empty() {
-        return Ok(None);
+        return Ok(Vec::new());
     }
 
     let candidates = reminders_from_search_results(results);
-    let session_id = std::env::var(ORBIT_SESSION_ID_ENV)
-        .ok()
-        .filter(|value| !value.trim().is_empty());
-    let tmpdir = learning_hook_tmpdir();
-    let state_path =
-        runtime.learning_hook_state_file_path(session_id.as_deref(), &tmpdir, parent_process_id());
-    let admitted = update_state_file(&state_path, &candidates, caps)?;
-    if admitted.is_empty() {
-        return Ok(None);
+    let state_path = runtime.learning_hook_state_file_path(session_id, tmpdir, ppid);
+    update_state_file(&state_path, &candidates, caps)
+}
+
+fn admitted_review_thread_reminders(
+    runtime: &OrbitRuntime,
+    payload: &HookPayload,
+    session_id: Option<&str>,
+    tmpdir: &Path,
+    ppid: u32,
+) -> Result<Vec<crate::command::review_thread_hook::ReviewThreadReminder>, String> {
+    let Some(task_id) = crate::command::review_thread_hook::active_task_id_from_env() else {
+        return Ok(Vec::new());
+    };
+    let threads = runtime
+        .list_review_threads(&task_id, None)
+        .map_err(|error| format!("list review threads for hook: {error}"))?;
+    if threads.is_empty() {
+        return Ok(Vec::new());
     }
 
-    emit_learning_injected_audit(
-        runtime,
-        &payload.tool_name,
-        &payload.target_path,
-        session_id.as_deref(),
-        &admitted,
-        start.elapsed(),
-    )?;
-
-    render_reminders(format, &admitted)
-        .map(Some)
-        .map_err(|error| format!("render reminders: {error}"))
+    let candidates = crate::command::review_thread_hook::reminders_from_threads(&task_id, threads);
+    let state_path = runtime.review_thread_hook_state_file_path(session_id, tmpdir, ppid);
+    let admitted = crate::command::review_thread_hook::update_state_file(&state_path, &candidates)?;
+    tracing::debug!(
+        tool_name = %payload.tool_name,
+        target_path = %payload.target_path,
+        task_id = %task_id,
+        admitted = admitted.len(),
+        "review-thread hook admission completed",
+    );
+    Ok(admitted)
 }
 
 pub(crate) fn accepted_tools(format: HookOutputFormat) -> &'static [&'static str] {
@@ -349,11 +454,27 @@ pub(crate) fn learning_hook_tmpdir() -> PathBuf {
         .unwrap_or_else(|| PathBuf::from("/tmp"))
 }
 
+fn render_text_context(
+    admitted: &[LearningReminder],
+    review_threads: &[crate::command::review_thread_hook::ReviewThreadReminder],
+) -> String {
+    let learning_block = render_claude(admitted);
+    let review_thread_block =
+        crate::command::review_thread_hook::render_review_thread_block(review_threads);
+    match (learning_block.is_empty(), review_thread_block.is_empty()) {
+        (true, true) => String::new(),
+        (false, true) => learning_block,
+        (true, false) => review_thread_block,
+        (false, false) => format!("{learning_block}\n\n{review_thread_block}"),
+    }
+}
+
 fn render_json_context(
     event_name: &str,
     admitted: &[LearningReminder],
+    review_threads: &[crate::command::review_thread_hook::ReviewThreadReminder],
 ) -> Result<String, OrbitError> {
-    let block = render_claude(admitted);
+    let block = render_text_context(admitted, review_threads);
     serde_json::to_string(&json!({
         "hookSpecificOutput": {
             "hookEventName": event_name,

--- a/crates/orbit-core/src/command/mod.rs
+++ b/crates/orbit-core/src/command/mod.rs
@@ -28,6 +28,7 @@ pub mod learning;
 pub mod learning_hook;
 pub mod pipeline_run;
 pub mod policy;
+pub mod review_thread_hook;
 pub mod search;
 pub mod semantic;
 pub mod skill;

--- a/crates/orbit-core/src/command/review_thread_hook.rs
+++ b/crates/orbit-core/src/command/review_thread_hook.rs
@@ -1,0 +1,382 @@
+use std::collections::BTreeMap;
+use std::fs::{self, File, OpenOptions};
+use std::io::{Read, Seek, SeekFrom, Write};
+use std::path::{Path, PathBuf};
+use std::time::{Duration, Instant};
+
+use fs2::FileExt;
+use orbit_common::types::{
+    AuditEventStatus, ReviewMessage, ReviewThread, ReviewThreadAnchor, ReviewThreadStatus,
+    all_agent_families, infer_agent_family_from_model,
+};
+use orbit_store::AuditEventInsertParams;
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+
+use crate::OrbitRuntime;
+
+const LOCK_RETRY_INTERVAL: Duration = Duration::from_millis(5);
+const LOCK_RETRY_BUDGET: Duration = Duration::from_millis(50);
+
+pub const ORBIT_ACTIVE_TASK_ID_ENV: &str = "ORBIT_ACTIVE_TASK_ID";
+pub const ORBIT_TASK_ID_ENV: &str = "ORBIT_TASK_ID";
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+pub struct ReviewThreadHookState {
+    #[serde(default)]
+    pub tasks: BTreeMap<String, BTreeMap<String, ReviewThreadCursor>>,
+}
+
+impl ReviewThreadHookState {
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ReviewThreadCursor {
+    pub last_seen_message_seq: u64,
+    pub status: ReviewThreadStatus,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ReviewThreadReminder {
+    pub task_id: String,
+    pub thread_id: String,
+    pub anchor: ReviewThreadAnchor,
+    pub status: ReviewThreadStatus,
+    pub last_seen_message_seq: u64,
+    pub messages: Vec<ReviewThreadReminderMessage>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ReviewThreadReminderMessage {
+    pub seq: u64,
+    pub by: String,
+    pub author_identity: String,
+    pub body: String,
+}
+
+pub fn active_task_id_from_env() -> Option<String> {
+    // ADR-0182: ORBIT_ACTIVE_TASK_ID is the explicit hook binding; ORBIT_TASK_ID
+    // remains a compatibility fallback while older execution paths catch up.
+    [ORBIT_ACTIVE_TASK_ID_ENV, ORBIT_TASK_ID_ENV]
+        .into_iter()
+        .find_map(|name| {
+            std::env::var(name)
+                .ok()
+                .map(|value| value.trim().to_string())
+                .filter(|value| !value.is_empty())
+        })
+}
+
+pub fn state_file_path(
+    repo_root: &Path,
+    session_id: Option<&str>,
+    tmpdir: &Path,
+    ppid: u32,
+) -> PathBuf {
+    match session_id.map(str::trim).filter(|value| !value.is_empty()) {
+        Some(session_id) => repo_root
+            .join(".orbit")
+            .join("state")
+            .join("sessions")
+            .join(session_id)
+            .join("review-threads.json"),
+        None => tmpdir.join(format!("orbit-review-thread-hook-{ppid}.json")),
+    }
+}
+
+pub fn parse_state_json(raw: &str) -> ReviewThreadHookState {
+    serde_json::from_str::<ReviewThreadHookState>(raw.trim()).unwrap_or_default()
+}
+
+pub fn reminders_from_threads(
+    task_id: &str,
+    threads: Vec<ReviewThread>,
+) -> Vec<ReviewThreadReminder> {
+    threads
+        .into_iter()
+        .filter(|thread| !thread.thread_id.trim().is_empty())
+        .map(|thread| {
+            let last_seen_message_seq = thread.messages.len() as u64;
+            let anchor = thread.anchor();
+            ReviewThreadReminder {
+                task_id: task_id.to_string(),
+                thread_id: thread.thread_id,
+                anchor,
+                status: thread.status,
+                last_seen_message_seq,
+                messages: reminder_messages(thread.messages),
+            }
+        })
+        .collect()
+}
+
+pub fn merge_state(
+    mut prior: ReviewThreadHookState,
+    candidates: &[ReviewThreadReminder],
+) -> (ReviewThreadHookState, Vec<ReviewThreadReminder>) {
+    let mut admitted = Vec::new();
+    for candidate in candidates {
+        let task_state = prior.tasks.entry(candidate.task_id.clone()).or_default();
+        let previous = task_state.get(&candidate.thread_id);
+        let previous_seq = previous
+            .map(|cursor| cursor.last_seen_message_seq)
+            .unwrap_or(0);
+        let should_admit = candidate.status == ReviewThreadStatus::Open
+            && candidate.last_seen_message_seq > previous_seq;
+
+        if candidate.last_seen_message_seq > previous_seq
+            || previous.is_none()
+            || previous.is_some_and(|cursor| cursor.status != candidate.status)
+        {
+            task_state.insert(
+                candidate.thread_id.clone(),
+                ReviewThreadCursor {
+                    last_seen_message_seq: candidate.last_seen_message_seq,
+                    status: candidate.status,
+                },
+            );
+        }
+
+        if should_admit {
+            admitted.push(candidate.clone());
+        }
+    }
+
+    (prior, admitted)
+}
+
+pub(crate) fn update_state_file(
+    state_path: &Path,
+    candidates: &[ReviewThreadReminder],
+) -> Result<Vec<ReviewThreadReminder>, String> {
+    if let Some(parent) = state_path.parent() {
+        fs::create_dir_all(parent).map_err(|error| {
+            format!(
+                "create review-thread state dir {}: {error}",
+                parent.display()
+            )
+        })?;
+    }
+
+    let mut file = OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .truncate(false)
+        .open(state_path)
+        .map_err(|error| {
+            format!(
+                "open review-thread state file {}: {error}",
+                state_path.display()
+            )
+        })?;
+
+    try_lock_exclusive(&file)?;
+    let update_result = update_locked_state(&mut file, candidates);
+    let unlock_result = file.unlock().map_err(|error| {
+        format!(
+            "unlock review-thread state file {}: {error}",
+            state_path.display()
+        )
+    });
+    match (update_result, unlock_result) {
+        (Ok(admitted), Ok(())) => Ok(admitted),
+        (Err(error), _) => Err(error),
+        (Ok(_), Err(error)) => Err(error),
+    }
+}
+
+pub fn render_review_thread_block(reminders: &[ReviewThreadReminder]) -> String {
+    if reminders.is_empty() {
+        return String::new();
+    }
+
+    let mut out = String::from("<system-reminder>\n");
+    out.push_str("Review threads awaiting agent attention:\n\n");
+    for reminder in reminders {
+        out.push_str(&format!(
+            "- Task {} thread {} ({}, last_seen_message_seq={}):\n",
+            reminder.task_id,
+            reminder.thread_id,
+            render_anchor(&reminder.anchor),
+            reminder.last_seen_message_seq
+        ));
+        for message in &reminder.messages {
+            out.push_str(&format!(
+                "  - message #{} by {} [{}]: {}\n",
+                message.seq,
+                message.by,
+                message.author_identity,
+                first_line_or_body(&message.body)
+            ));
+            for line in message.body.lines().skip(1) {
+                out.push_str("    ");
+                out.push_str(line);
+                out.push('\n');
+            }
+        }
+    }
+    out.push('\n');
+    out.push_str("Action: incorporate trivial asks directly. For non-trivial scope, propose a follow-up with `orbit.task.add` and `relations: [{\"type\":\"spawned_from\",\"target\":\"<task_id>\"}]`.\n");
+    out.push_str("Reply on the review thread with the decision, then resolve it by default; a human can re-open by adding a new reply if unsatisfied.\n");
+    out.push_str("</system-reminder>");
+    out
+}
+
+impl OrbitRuntime {
+    pub fn review_thread_hook_state_file_path(
+        &self,
+        session_id: Option<&str>,
+        tmpdir: &Path,
+        ppid: u32,
+    ) -> PathBuf {
+        state_file_path(&self.paths().repo_root, session_id, tmpdir, ppid)
+    }
+}
+
+pub(crate) fn emit_review_thread_surfaced_audit(
+    runtime: &OrbitRuntime,
+    tool_name: &str,
+    target_path: &str,
+    session_id: Option<&str>,
+    reminder: &ReviewThreadReminder,
+    duration: Duration,
+) -> Result<(), String> {
+    let arguments_json = serde_json::to_string(&json!({
+        "task_id": reminder.task_id,
+        "thread_id": reminder.thread_id,
+        "last_seen_message_seq": reminder.last_seen_message_seq,
+        "target_path": target_path,
+    }))
+    .map_err(|error| format!("serialize review-thread audit arguments: {error}"))?;
+    let working_directory = std::env::current_dir()
+        .map(|path| path.to_string_lossy().to_string())
+        .unwrap_or_else(|_| ".".to_string());
+
+    let params = AuditEventInsertParams {
+        execution_id: orbit_common::types::audit_execution_id("review-thread-hook"),
+        command: "hook".to_string(),
+        subcommand: Some("pretooluse".to_string()),
+        tool_name: Some(tool_name.to_string()),
+        target_type: Some("review_thread_surfaced".to_string()),
+        target_id: Some(reminder.thread_id.clone()),
+        role: "hook".to_string(),
+        status: AuditEventStatus::Success,
+        exit_code: 0,
+        duration_ms: duration.as_millis() as i64,
+        working_directory,
+        arguments_json: Some(arguments_json),
+        stdout_truncated: None,
+        stderr_truncated: None,
+        error_message: None,
+        host: std::env::var("HOSTNAME").ok(),
+        pid: std::process::id(),
+        session_id: session_id.map(ToOwned::to_owned),
+        task_id: Some(reminder.task_id.clone()),
+        job_run_id: std::env::var("ORBIT_RUN_ID")
+            .ok()
+            .filter(|value| !value.is_empty()),
+        activity_id: std::env::var("ORBIT_ACTIVITY_ID")
+            .ok()
+            .filter(|value| !value.is_empty()),
+        step_index: std::env::var("ORBIT_STEP_INDEX")
+            .ok()
+            .and_then(|value| value.parse().ok()),
+    };
+
+    runtime
+        .record_audit_event(&params)
+        .map_err(|error| format!("record review-thread audit event: {error}"))
+}
+
+fn reminder_messages(messages: Vec<ReviewMessage>) -> Vec<ReviewThreadReminderMessage> {
+    messages
+        .into_iter()
+        .enumerate()
+        .map(|(index, message)| ReviewThreadReminderMessage {
+            seq: (index + 1) as u64,
+            author_identity: author_identity(&message.by),
+            by: message.by,
+            body: message.body,
+        })
+        .collect()
+}
+
+fn author_identity(by: &str) -> String {
+    let label = by.trim();
+    if label.eq_ignore_ascii_case("human") {
+        return "human".to_string();
+    }
+    if let Some(family) = infer_agent_family_from_model(label) {
+        return format!("agent family {family}");
+    }
+    if all_agent_families()
+        .into_iter()
+        .any(|family| label.eq_ignore_ascii_case(family))
+    {
+        return format!("agent family {}", label.to_ascii_lowercase());
+    }
+    format!("human ({label})")
+}
+
+fn render_anchor(anchor: &ReviewThreadAnchor) -> String {
+    match anchor {
+        ReviewThreadAnchor::Inline { path, line } => format!("{path}:{line}"),
+        ReviewThreadAnchor::TaskLevel => "task-level".to_string(),
+    }
+}
+
+fn first_line_or_body(body: &str) -> String {
+    let mut lines = body.lines();
+    let first = lines.next().unwrap_or("").trim();
+    if first.is_empty() {
+        return "(empty message)".to_string();
+    }
+    first.to_string()
+}
+
+fn try_lock_exclusive(file: &File) -> Result<(), String> {
+    let started = Instant::now();
+    loop {
+        match file.try_lock_exclusive() {
+            Ok(()) => return Ok(()),
+            Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                if started.elapsed() >= LOCK_RETRY_BUDGET {
+                    return Err("review-thread state file lock timed out".to_string());
+                }
+                std::thread::sleep(LOCK_RETRY_INTERVAL);
+            }
+            Err(error) => return Err(format!("lock review-thread state file: {error}")),
+        }
+    }
+}
+
+fn update_locked_state(
+    file: &mut File,
+    candidates: &[ReviewThreadReminder],
+) -> Result<Vec<ReviewThreadReminder>, String> {
+    file.seek(SeekFrom::Start(0))
+        .map_err(|error| format!("seek review-thread state file: {error}"))?;
+    let mut raw = String::new();
+    file.read_to_string(&mut raw)
+        .map_err(|error| format!("read review-thread state file: {error}"))?;
+
+    let prior = parse_state_json(&raw);
+    let (next_state, admitted) = merge_state(prior, candidates);
+
+    file.seek(SeekFrom::Start(0))
+        .map_err(|error| format!("rewind review-thread state file: {error}"))?;
+    file.set_len(0)
+        .map_err(|error| format!("truncate review-thread state file: {error}"))?;
+    serde_json::to_writer_pretty(&mut *file, &next_state)
+        .map_err(|error| format!("serialize review-thread state file: {error}"))?;
+    file.write_all(b"\n")
+        .map_err(|error| format!("write review-thread state file: {error}"))?;
+    file.flush()
+        .map_err(|error| format!("flush review-thread state file: {error}"))?;
+
+    Ok(admitted)
+}

--- a/crates/orbit-core/src/command/task/review.rs
+++ b/crates/orbit-core/src/command/task/review.rs
@@ -89,7 +89,7 @@ impl OrbitRuntime {
         let (canonical_agent, canonical_model) =
             self.try_canonical_agent_model_identity(agent.as_deref(), model.as_deref())?;
         let threads = self.get_task_review_threads(task_id)?;
-        let existing = threads
+        let _existing = threads
             .iter()
             .find(|t| t.thread_id == thread_id)
             .ok_or_else(|| {
@@ -113,7 +113,7 @@ impl OrbitRuntime {
             thread_id: thread_id.to_string(),
             path: None,
             line: None,
-            status: existing.status,
+            status: ReviewThreadStatus::Open,
             messages: vec![ReviewMessage {
                 message_id,
                 at: now,

--- a/crates/orbit-core/src/command/tests/learning_hook.rs
+++ b/crates/orbit-core/src/command/tests/learning_hook.rs
@@ -2,8 +2,11 @@ use std::fs::OpenOptions;
 use std::path::{Path, PathBuf};
 use std::sync::{Mutex, MutexGuard, OnceLock};
 
+use chrono::Utc;
 use fs2::FileExt;
-use orbit_common::types::{LearningInjectionCaps, LearningReminder};
+use orbit_common::types::{
+    LearningInjectionCaps, LearningReminder, ReviewMessage, ReviewThread, ReviewThreadStatus,
+};
 
 use super::super::learning_hook::{
     CODEX_PRETOOLUSE_TOOLS, HookOutputFormat, ORBIT_LEARNING_PER_CALL_CAP_ENV,
@@ -11,6 +14,7 @@ use super::super::learning_hook::{
     parse_payload, parse_payload_with_tools, parse_state_json, render_codex, render_gemini,
     render_reminders, state_file_path, update_state_file,
 };
+use super::super::review_thread_hook::reminders_from_threads;
 
 #[test]
 fn parse_payload_accepts_tool_and_path_variants() {
@@ -263,6 +267,77 @@ fn renderers_preserve_per_agent_hook_output() {
     assert_eq!(
         gemini["hookSpecificOutput"]["hookEventName"].as_str(),
         Some("BeforeTool")
+    );
+}
+
+#[test]
+fn render_hook_reminders_combines_learnings_and_review_threads() {
+    let learnings = reminders(&["L-0017"]);
+    let review_threads = reminders_from_threads(
+        "ORB-00001",
+        vec![ReviewThread {
+            thread_id: "rt-1".to_string(),
+            path: None,
+            line: None,
+            status: ReviewThreadStatus::Open,
+            messages: vec![ReviewMessage {
+                message_id: "rm-1".to_string(),
+                at: Utc::now(),
+                by: "human".to_string(),
+                body: "Please adjust course.".to_string(),
+                github_comment_id: None,
+            }],
+            github_thread_id: None,
+        }],
+    );
+
+    let claude = super::super::learning_hook::render_hook_reminders(
+        HookOutputFormat::Claude,
+        &learnings,
+        &review_threads,
+    )
+    .expect("render claude");
+    assert!(claude.contains("Project learnings relevant to this task"));
+    assert!(claude.contains("Review threads awaiting agent attention"));
+    assert!(claude.contains("Please adjust course."));
+
+    let grok = super::super::learning_hook::render_hook_reminders(
+        HookOutputFormat::Grok,
+        &learnings,
+        &review_threads,
+    )
+    .expect("render grok");
+    assert_eq!(grok, claude);
+
+    let codex = super::super::learning_hook::render_hook_reminders(
+        HookOutputFormat::Codex,
+        &learnings,
+        &review_threads,
+    )
+    .expect("render codex");
+    let codex: serde_json::Value = serde_json::from_str(&codex).expect("parse codex");
+    let additional_context = codex["hookSpecificOutput"]["additionalContext"]
+        .as_str()
+        .expect("additional context");
+    assert!(additional_context.contains("Project learnings relevant to this task"));
+    assert!(additional_context.contains("Review threads awaiting agent attention"));
+
+    let gemini = super::super::learning_hook::render_hook_reminders(
+        HookOutputFormat::Gemini,
+        &learnings,
+        &review_threads,
+    )
+    .expect("render gemini");
+    let gemini: serde_json::Value = serde_json::from_str(&gemini).expect("parse gemini");
+    assert_eq!(
+        gemini["hookSpecificOutput"]["hookEventName"].as_str(),
+        Some("BeforeTool")
+    );
+    assert!(
+        gemini["hookSpecificOutput"]["additionalContext"]
+            .as_str()
+            .expect("additional context")
+            .contains("Review threads awaiting agent attention")
     );
 }
 

--- a/crates/orbit-core/src/command/tests/mod.rs
+++ b/crates/orbit-core/src/command/tests/mod.rs
@@ -1,2 +1,3 @@
 mod hook_install;
 mod learning_hook;
+mod review_thread_hook;

--- a/crates/orbit-core/src/command/tests/review_thread_hook.rs
+++ b/crates/orbit-core/src/command/tests/review_thread_hook.rs
@@ -1,0 +1,208 @@
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+use std::sync::{Mutex, MutexGuard, OnceLock};
+
+use chrono::Utc;
+use orbit_common::types::{ReviewMessage, ReviewThread, ReviewThreadStatus};
+
+use super::super::review_thread_hook::{
+    ORBIT_ACTIVE_TASK_ID_ENV, ORBIT_TASK_ID_ENV, ReviewThreadCursor, ReviewThreadHookState,
+    active_task_id_from_env, merge_state, parse_state_json, reminders_from_threads,
+    render_review_thread_block, state_file_path, update_state_file,
+};
+
+#[test]
+fn active_task_id_prefers_explicit_env_and_falls_back_to_task_id() {
+    let _guard = EnvGuard::set(&[
+        (ORBIT_ACTIVE_TASK_ID_ENV, Some("ORB-00001")),
+        (ORBIT_TASK_ID_ENV, Some("ORB-00002")),
+    ]);
+    assert_eq!(active_task_id_from_env().as_deref(), Some("ORB-00001"));
+    drop(_guard);
+
+    let _guard = EnvGuard::set(&[
+        (ORBIT_ACTIVE_TASK_ID_ENV, None),
+        (ORBIT_TASK_ID_ENV, Some("ORB-00002")),
+    ]);
+    assert_eq!(active_task_id_from_env().as_deref(), Some("ORB-00002"));
+}
+
+#[test]
+fn state_file_path_matches_session_and_tmp_layouts() {
+    let repo_root = Path::new("/repo");
+    let tmpdir = Path::new("/tmp");
+    assert_eq!(
+        state_file_path(repo_root, Some("session-1"), tmpdir, 123),
+        PathBuf::from("/repo/.orbit/state/sessions/session-1/review-threads.json")
+    );
+    assert_eq!(
+        state_file_path(repo_root, None, tmpdir, 123),
+        PathBuf::from("/tmp/orbit-review-thread-hook-123.json")
+    );
+}
+
+#[test]
+fn merge_state_tracks_last_seen_message_seq_not_thread_existence() {
+    let first = reminders_from_threads(
+        "ORB-00001",
+        vec![thread("rt-1", 1, ReviewThreadStatus::Open)],
+    );
+    let (state, admitted) = merge_state(ReviewThreadHookState::new(), &first);
+    assert_eq!(admitted.len(), 1);
+    assert_eq!(admitted[0].last_seen_message_seq, 1);
+
+    let (_state, admitted) = merge_state(state.clone(), &first);
+    assert!(admitted.is_empty());
+
+    let reply = reminders_from_threads(
+        "ORB-00001",
+        vec![thread("rt-1", 2, ReviewThreadStatus::Open)],
+    );
+    let (state, admitted) = merge_state(state, &reply);
+    assert_eq!(admitted.len(), 1);
+    assert_eq!(admitted[0].last_seen_message_seq, 2);
+    assert_eq!(state.tasks["ORB-00001"]["rt-1"].last_seen_message_seq, 2);
+}
+
+#[test]
+fn merge_state_advances_cursor_on_resolve_without_resurfacing() {
+    let mut state = ReviewThreadHookState::new();
+    state.tasks.insert(
+        "ORB-00001".to_string(),
+        BTreeMap::from([(
+            "rt-1".to_string(),
+            ReviewThreadCursor {
+                last_seen_message_seq: 1,
+                status: ReviewThreadStatus::Open,
+            },
+        )]),
+    );
+
+    let resolved = reminders_from_threads(
+        "ORB-00001",
+        vec![thread("rt-1", 2, ReviewThreadStatus::Resolved)],
+    );
+    let (state, admitted) = merge_state(state, &resolved);
+    assert!(admitted.is_empty());
+    let cursor = &state.tasks["ORB-00001"]["rt-1"];
+    assert_eq!(cursor.last_seen_message_seq, 2);
+    assert_eq!(cursor.status, ReviewThreadStatus::Resolved);
+}
+
+#[test]
+fn update_state_file_persists_watermark_across_invocations() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let state_path = temp.path().join("state").join("review-threads.json");
+    let first = reminders_from_threads(
+        "ORB-00001",
+        vec![thread("rt-1", 1, ReviewThreadStatus::Open)],
+    );
+    let admitted = update_state_file(&state_path, &first).expect("first update");
+    assert_eq!(admitted.len(), 1);
+
+    let admitted = update_state_file(&state_path, &first).expect("second update");
+    assert!(admitted.is_empty());
+
+    let persisted = std::fs::read_to_string(&state_path).expect("read state");
+    let state = parse_state_json(&persisted);
+    assert_eq!(state.tasks["ORB-00001"]["rt-1"].last_seen_message_seq, 1);
+}
+
+#[test]
+fn render_review_thread_block_marks_task_level_and_author_identity() {
+    let reminders = reminders_from_threads(
+        "ORB-00001",
+        vec![ReviewThread {
+            thread_id: "rt-task".to_string(),
+            path: None,
+            line: None,
+            status: ReviewThreadStatus::Open,
+            messages: vec![
+                ReviewMessage {
+                    message_id: "rm-1".to_string(),
+                    at: Utc::now(),
+                    by: "human".to_string(),
+                    body: "Please steer this task.".to_string(),
+                    github_comment_id: None,
+                },
+                ReviewMessage {
+                    message_id: "rm-2".to_string(),
+                    at: Utc::now(),
+                    by: "gpt-5.5".to_string(),
+                    body: "Acknowledged.".to_string(),
+                    github_comment_id: None,
+                },
+            ],
+            github_thread_id: None,
+        }],
+    );
+
+    let block = render_review_thread_block(&reminders);
+    assert!(block.contains("task-level"));
+    assert!(block.contains("Please steer this task."));
+    assert!(block.contains("by human [human]"));
+    assert!(block.contains("by gpt-5.5 [agent family codex]"));
+    assert!(block.contains("Reply on the review thread with the decision"));
+}
+
+fn thread(id: &str, message_count: usize, status: ReviewThreadStatus) -> ReviewThread {
+    ReviewThread {
+        thread_id: id.to_string(),
+        path: Some("src/lib.rs".to_string()),
+        line: Some(7),
+        status,
+        messages: (1..=message_count)
+            .map(|seq| ReviewMessage {
+                message_id: format!("rm-{seq}"),
+                at: Utc::now(),
+                by: "human".to_string(),
+                body: format!("message {seq}"),
+                github_comment_id: None,
+            })
+            .collect(),
+        github_thread_id: None,
+    }
+}
+
+struct EnvGuard {
+    _lock: MutexGuard<'static, ()>,
+    saved: Vec<(&'static str, Option<String>)>,
+}
+
+impl EnvGuard {
+    fn set(values: &[(&'static str, Option<&str>)]) -> Self {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        let lock = LOCK
+            .get_or_init(|| Mutex::new(()))
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let saved = values
+            .iter()
+            .map(|(name, _)| (*name, std::env::var(name).ok()))
+            .collect::<Vec<_>>();
+        for (name, value) in values {
+            // SAFETY: EnvGuard serializes these process-wide mutations and restores them on drop.
+            unsafe {
+                match value {
+                    Some(value) => std::env::set_var(name, value),
+                    None => std::env::remove_var(name),
+                }
+            }
+        }
+        Self { _lock: lock, saved }
+    }
+}
+
+impl Drop for EnvGuard {
+    fn drop(&mut self) {
+        for (name, value) in &self.saved {
+            // SAFETY: EnvGuard holds the serialization lock until all saved values are restored.
+            unsafe {
+                match value {
+                    Some(value) => std::env::set_var(name, value),
+                    None => std::env::remove_var(name),
+                }
+            }
+        }
+    }
+}

--- a/crates/orbit-core/src/lib.rs
+++ b/crates/orbit-core/src/lib.rs
@@ -68,11 +68,11 @@ pub use orbit_common::types::{
     Activity, AuditEvent, AuditEventStatus, AuditStats, EvidenceKind, ExecutorDef, ExternalRef,
     GITHUB_PR_EXTERNAL_REF_SYSTEM, Job, JobRun, JobRunState, JobRunStep, JobScheduleState, JobStep,
     JobTargetType, Learning, LearningEvidence, LearningScope, LearningStatus, LearningVoteSummary,
-    ResolvedTaskDependency, ReviewMessage, ReviewThread, ReviewThreadStatus, Role, Skill, Task,
-    TaskComment, TaskComplexity, TaskPriority, TaskStatus, TaskType, build_task_status_index,
-    normalize_task_dependencies, normalize_task_tags, push_external_ref_if_missing,
-    resolve_task_dependencies, task_dependencies_ready, task_matches_tags, unmet_task_dependencies,
-    validate_task_dependencies,
+    ResolvedTaskDependency, ReviewMessage, ReviewThread, ReviewThreadAnchor, ReviewThreadStatus,
+    Role, Skill, Task, TaskComment, TaskComplexity, TaskPriority, TaskStatus, TaskType,
+    build_task_status_index, normalize_task_dependencies, normalize_task_tags,
+    push_external_ref_if_missing, resolve_task_dependencies, task_dependencies_ready,
+    task_matches_tags, unmet_task_dependencies, validate_task_dependencies,
 };
 pub use orbit_common::types::{LearningComment, NotFoundKind, OrbitError};
 pub use orbit_common::utility::redaction::{

--- a/crates/orbit-core/src/runtime/orbit_tool_host/review_threads.rs
+++ b/crates/orbit-core/src/runtime/orbit_tool_host/review_threads.rs
@@ -14,7 +14,7 @@ pub(super) fn add(
     model: Option<String>,
 ) -> Result<Value, OrbitError> {
     require_review_model(model.as_deref(), "orbit.task.review_thread.add")?;
-    let id = required_string(&input, &["id"], "id")?;
+    let id = review_thread_task_id(&input)?;
     let body = required_string(&input, &["body"], "body")?;
     let path = optional_string(&input, "path")?;
     let line = optional_string(&input, "line")?
@@ -29,7 +29,7 @@ pub(super) fn add(
 }
 
 pub(super) fn list(runtime: &OrbitRuntime, input: Value) -> Result<Value, OrbitError> {
-    let id = required_string(&input, &["id"], "id")?;
+    let id = review_thread_task_id(&input)?;
     let status = optional_string(&input, "status")?
         .map(|value| ReviewThreadStatus::from_str(&value))
         .transpose()
@@ -45,7 +45,7 @@ pub(super) fn reply(
     model: Option<String>,
 ) -> Result<Value, OrbitError> {
     require_review_model(model.as_deref(), "orbit.task.review_thread.reply")?;
-    let id = required_string(&input, &["id"], "id")?;
+    let id = review_thread_task_id(&input)?;
     let thread_id = required_string(&input, &["thread_id"], "thread_id")?;
     let body = required_string(&input, &["body"], "body")?;
     runtime.reply_review_thread(&id, &thread_id, body, agent, model)?;
@@ -58,7 +58,7 @@ pub(super) fn resolve(
     agent: Option<String>,
     model: Option<String>,
 ) -> Result<Value, OrbitError> {
-    let id = required_string(&input, &["id"], "id")?;
+    let id = review_thread_task_id(&input)?;
     let thread_id = required_string(&input, &["thread_id"], "thread_id")?;
     runtime.resolve_review_thread(&id, &thread_id, agent, model)?;
     serialize_task(runtime, &runtime.get_task(&id)?)
@@ -72,4 +72,18 @@ fn require_review_model(model: Option<&str>, tool_name: &str) -> Result<(), Orbi
         )));
     }
     Ok(())
+}
+
+fn review_thread_task_id(input: &Value) -> Result<String, OrbitError> {
+    match required_string(input, &["id", "task_id"], "id") {
+        Ok(task_id) => Ok(task_id),
+        Err(OrbitError::InvalidInput(message)) if message == "missing `id`" => {
+            crate::command::review_thread_hook::active_task_id_from_env().ok_or_else(|| {
+                OrbitError::InvalidInput(format!(
+                    "{message}; or set ORBIT_ACTIVE_TASK_ID for active-task review-thread operations"
+                ))
+            })
+        }
+        Err(error) => Err(error),
+    }
 }

--- a/crates/orbit-core/src/runtime/orbit_tool_host/test_support.rs
+++ b/crates/orbit-core/src/runtime/orbit_tool_host/test_support.rs
@@ -100,6 +100,9 @@ pub(super) fn unmanaged_tool_env_guard() -> UnmanagedToolEnvGuard {
     let names = [
         "ORBIT_MANAGED_RUN_CONTEXT",
         "ORBIT_TASK_ID",
+        "ORBIT_ACTIVE_TASK_ID",
+        "ORBIT_AGENT_NAME",
+        "ORBIT_AGENT_MODEL",
         "ORBIT_RUN_ID",
         "ORBIT_ACTIVITY_ID",
         "ORBIT_STEP_INDEX",

--- a/crates/orbit-core/src/runtime/orbit_tool_host/tests/review_threads.rs
+++ b/crates/orbit-core/src/runtime/orbit_tool_host/tests/review_threads.rs
@@ -1,10 +1,11 @@
 use orbit_common::types::{OrbitError, TaskStatus};
 use serde_json::{Value, json};
 
-use super::super::test_support::{create_task, test_runtime};
+use super::super::test_support::{create_task, test_runtime, unmanaged_tool_env_guard};
 
 #[test]
 fn review_thread_add_rejects_missing_model() {
+    let _env = unmanaged_tool_env_guard();
     let (_root, runtime, repo_root) = test_runtime();
     let task = create_task(
         &runtime,
@@ -37,6 +38,7 @@ fn review_thread_add_rejects_missing_model() {
 
 #[test]
 fn review_thread_add_rejects_empty_model() {
+    let _env = unmanaged_tool_env_guard();
     let (_root, runtime, repo_root) = test_runtime();
     let task = create_task(
         &runtime,
@@ -72,6 +74,7 @@ fn review_thread_add_rejects_empty_model() {
 
 #[test]
 fn review_thread_reply_rejects_missing_model() {
+    let _env = unmanaged_tool_env_guard();
     let (_root, runtime, repo_root) = test_runtime();
     let task = create_task(
         &runtime,
@@ -116,6 +119,7 @@ fn review_thread_reply_rejects_missing_model() {
 
 #[test]
 fn review_thread_add_accepts_human_model() {
+    let _env = unmanaged_tool_env_guard();
     let (_root, runtime, repo_root) = test_runtime();
     let task = create_task(
         &runtime,
@@ -143,4 +147,83 @@ fn review_thread_add_accepts_human_model() {
         output.get("id").and_then(Value::as_str),
         Some(task.id.as_str())
     );
+}
+
+#[test]
+fn review_thread_list_round_trips_task_level_anchor_kind() {
+    let _env = unmanaged_tool_env_guard();
+    let (_root, runtime, repo_root) = test_runtime();
+    let task = create_task(
+        &runtime,
+        &repo_root,
+        "Task-level review",
+        "Exercise anchorless review thread output.",
+        TaskStatus::Review,
+        &[],
+    );
+
+    runtime
+        .execute_tool_command(
+            "orbit.review-thread.add",
+            json!({
+                "id": task.id,
+                "body": "Task-level ask.",
+                "model": "human",
+            }),
+            None,
+            None,
+        )
+        .expect("add task-level thread");
+
+    let output = runtime
+        .execute_tool_command(
+            "orbit.review-thread.list",
+            json!({ "task_id": task.id }),
+            None,
+            None,
+        )
+        .expect("list review threads");
+    assert_eq!(output[0]["anchor"]["kind"], "task_level");
+    assert_eq!(output[0]["path"], Value::Null);
+    assert_eq!(output[0]["line"], Value::Null);
+}
+
+#[test]
+fn review_thread_add_uses_active_task_env_when_id_is_omitted() {
+    let _env = unmanaged_tool_env_guard();
+    let (_root, runtime, repo_root) = test_runtime();
+    let task = create_task(
+        &runtime,
+        &repo_root,
+        "Active task review",
+        "Exercise active-task review-thread input.",
+        TaskStatus::Review,
+        &[],
+    );
+    // SAFETY: unmanaged_tool_env_guard serializes and restores this env mutation.
+    unsafe {
+        std::env::set_var("ORBIT_ACTIVE_TASK_ID", &task.id);
+    }
+
+    runtime
+        .execute_tool_command(
+            "orbit.review-thread.add",
+            json!({
+                "body": "Active task ask.",
+                "model": "human",
+            }),
+            None,
+            None,
+        )
+        .expect("active task add succeeds");
+
+    let output = runtime
+        .execute_tool_command(
+            "orbit.review-thread.list",
+            json!({ "task_id": task.id }),
+            None,
+            None,
+        )
+        .expect("list review threads");
+    assert_eq!(output[0]["messages"][0]["body"], "Active task ask.");
 }

--- a/crates/orbit-engine/src/activity_job/cli_runner/orchestrator.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/orchestrator.rs
@@ -164,6 +164,12 @@ pub fn run_cli_backend(
     if let Some(session_id) = learning_context.session_id {
         child_env.push(("ORBIT_SESSION_ID".to_string(), session_id));
     }
+    if let Some(task_id) = task_id_from_input(input) {
+        // ADR-0182: external CLI agents get the same active-task hook binding
+        // as direct-agent executions.
+        child_env.push(("ORBIT_TASK_ID".to_string(), task_id.to_string()));
+        child_env.push(("ORBIT_ACTIVE_TASK_ID".to_string(), task_id.to_string()));
+    }
     let (stdout, stderr, exit_code, duration, timed_out) =
         spawn_with_timeout(SpawnWithTimeoutRequest {
             program: &invocation.program,

--- a/crates/orbit-engine/src/context.rs
+++ b/crates/orbit-engine/src/context.rs
@@ -1141,6 +1141,9 @@ pub fn state_env_vars(execution: &ExecutionContext) -> Vec<(String, String)> {
         .filter(|s| !s.is_empty())
     {
         vars.push(("ORBIT_TASK_ID".to_string(), task_id.to_string()));
+        // ADR-0182: hooks read the explicit active-task binding while older
+        // audit/tool code continues to consume ORBIT_TASK_ID.
+        vars.push(("ORBIT_ACTIVE_TASK_ID".to_string(), task_id.to_string()));
     }
 
     // Run-state vars only exist for steps inside a real job run, so they
@@ -1255,6 +1258,10 @@ mod state_env_var_tests {
             vars.get("ORBIT_TASK_ID").map(String::as_str),
             Some("T20260428-7")
         );
+        assert_eq!(
+            vars.get("ORBIT_ACTIVE_TASK_ID").map(String::as_str),
+            Some("T20260428-7")
+        );
         assert!(!vars.contains_key("ORBIT_RUN_ID"));
     }
 
@@ -1263,6 +1270,10 @@ mod state_env_var_tests {
         let exec = execution_with(json!({ "task_id": "T-abc" }), Some("jrun-42"));
         let vars: HashMap<String, String> = state_env_vars(&exec).into_iter().collect();
         assert_eq!(vars.get("ORBIT_TASK_ID").map(String::as_str), Some("T-abc"));
+        assert_eq!(
+            vars.get("ORBIT_ACTIVE_TASK_ID").map(String::as_str),
+            Some("T-abc")
+        );
         assert_eq!(
             vars.get("ORBIT_RUN_ID").map(String::as_str),
             Some("jrun-42")
@@ -1283,5 +1294,6 @@ mod state_env_var_tests {
             Some("agent_implement")
         );
         assert!(!vars.contains_key("ORBIT_TASK_ID"));
+        assert!(!vars.contains_key("ORBIT_ACTIVE_TASK_ID"));
     }
 }

--- a/crates/orbit-tools/src/builtin/orbit/mod.rs
+++ b/crates/orbit-tools/src/builtin/orbit/mod.rs
@@ -91,9 +91,13 @@ pub fn register(registry: &mut ToolRegistry) {
     registry.register(pipeline::invoke::OrbitPipelineInvokeTool);
     registry.register(pipeline::wait::OrbitPipelineWaitTool);
     registry.register(review_thread::add::OrbitReviewThreadAddTool);
+    registry.register(review_thread::add::OrbitReviewThreadAddAliasTool);
     registry.register(review_thread::list::OrbitReviewThreadListTool);
+    registry.register(review_thread::list::OrbitReviewThreadListAliasTool);
     registry.register(review_thread::reply::OrbitReviewThreadReplyTool);
+    registry.register(review_thread::reply::OrbitReviewThreadReplyAliasTool);
     registry.register(review_thread::resolve::OrbitReviewThreadResolveTool);
+    registry.register(review_thread::resolve::OrbitReviewThreadResolveAliasTool);
     registry.register(search::OrbitSearchTool);
     registry.register(semantic::install::OrbitSemanticInstallTool);
     registry.register(semantic::uninstall::OrbitSemanticUninstallTool);

--- a/crates/orbit-tools/src/builtin/orbit/review_thread/add.rs
+++ b/crates/orbit-tools/src/builtin/orbit/review_thread/add.rs
@@ -4,39 +4,60 @@ use serde_json::Value;
 use crate::{OrbitBuiltinAction, Tool, ToolContext};
 
 pub struct OrbitReviewThreadAddTool;
+pub struct OrbitReviewThreadAddAliasTool;
 
 impl Tool for OrbitReviewThreadAddTool {
     fn schema(&self) -> ToolSchema {
-        let mut parameters = super::super::orbit_id_params("task");
-        parameters.push(ToolParam {
-            name: "body".to_string(),
-            description: "Review comment body".to_string(),
-            param_type: "string".to_string(),
-            required: true,
-        });
-        parameters.push(ToolParam {
-            name: "path".to_string(),
-            description: "File path for inline review comment".to_string(),
-            param_type: "string".to_string(),
-            required: false,
-        });
-        parameters.push(ToolParam {
-            name: "line".to_string(),
-            description: "Line number for inline review comment".to_string(),
-            param_type: "string".to_string(),
-            required: false,
-        });
-        parameters.extend(super::super::scored_identity_params());
-
-        ToolSchema {
-            name: "orbit.task.review_thread.add".to_string(),
-            description: "Create a new review thread on an Orbit task".to_string(),
-            parameters,
-            builtin: true,
-        }
+        add_schema("orbit.task.review_thread.add")
     }
 
     fn execute(&self, ctx: &ToolContext, input: Value) -> Result<Value, OrbitError> {
         super::super::execute_host_action(ctx, input, OrbitBuiltinAction::ReviewThreadAdd)
+    }
+}
+
+impl Tool for OrbitReviewThreadAddAliasTool {
+    fn schema(&self) -> ToolSchema {
+        add_schema("orbit.review-thread.add")
+    }
+
+    fn execute(&self, ctx: &ToolContext, input: Value) -> Result<Value, OrbitError> {
+        super::super::execute_host_action(ctx, input, OrbitBuiltinAction::ReviewThreadAdd)
+    }
+}
+
+fn add_schema(name: &str) -> ToolSchema {
+    let mut parameters = super::super::orbit_id_params("task");
+    parameters.push(ToolParam {
+        name: "task_id".to_string(),
+        description: "Task ID alias for id".to_string(),
+        param_type: "string".to_string(),
+        required: false,
+    });
+    parameters.push(ToolParam {
+        name: "body".to_string(),
+        description: "Review comment body".to_string(),
+        param_type: "string".to_string(),
+        required: true,
+    });
+    parameters.push(ToolParam {
+        name: "path".to_string(),
+        description: "File path for inline review comment".to_string(),
+        param_type: "string".to_string(),
+        required: false,
+    });
+    parameters.push(ToolParam {
+        name: "line".to_string(),
+        description: "Line number for inline review comment".to_string(),
+        param_type: "string".to_string(),
+        required: false,
+    });
+    parameters.extend(super::super::scored_identity_params());
+
+    ToolSchema {
+        name: name.to_string(),
+        description: "Create a new review thread on an Orbit task".to_string(),
+        parameters,
+        builtin: true,
     }
 }

--- a/crates/orbit-tools/src/builtin/orbit/review_thread/list.rs
+++ b/crates/orbit-tools/src/builtin/orbit/review_thread/list.rs
@@ -4,27 +4,48 @@ use serde_json::Value;
 use crate::{OrbitBuiltinAction, Tool, ToolContext};
 
 pub struct OrbitReviewThreadListTool;
+pub struct OrbitReviewThreadListAliasTool;
 
 impl Tool for OrbitReviewThreadListTool {
     fn schema(&self) -> ToolSchema {
-        let mut parameters = super::super::orbit_id_params("task");
-        parameters.push(ToolParam {
-            name: "status".to_string(),
-            description: "Filter by thread status: open or resolved".to_string(),
-            param_type: "string".to_string(),
-            required: false,
-        });
-        parameters.extend(super::super::identity_params());
-
-        ToolSchema {
-            name: "orbit.task.review_thread.list".to_string(),
-            description: "List review threads on an Orbit task".to_string(),
-            parameters,
-            builtin: true,
-        }
+        list_schema("orbit.task.review_thread.list")
     }
 
     fn execute(&self, ctx: &ToolContext, input: Value) -> Result<Value, OrbitError> {
         super::super::execute_host_action(ctx, input, OrbitBuiltinAction::ReviewThreadList)
+    }
+}
+
+impl Tool for OrbitReviewThreadListAliasTool {
+    fn schema(&self) -> ToolSchema {
+        list_schema("orbit.review-thread.list")
+    }
+
+    fn execute(&self, ctx: &ToolContext, input: Value) -> Result<Value, OrbitError> {
+        super::super::execute_host_action(ctx, input, OrbitBuiltinAction::ReviewThreadList)
+    }
+}
+
+fn list_schema(name: &str) -> ToolSchema {
+    let mut parameters = super::super::orbit_id_params("task");
+    parameters.push(ToolParam {
+        name: "task_id".to_string(),
+        description: "Task ID alias for id".to_string(),
+        param_type: "string".to_string(),
+        required: false,
+    });
+    parameters.push(ToolParam {
+        name: "status".to_string(),
+        description: "Filter by thread status: open or resolved".to_string(),
+        param_type: "string".to_string(),
+        required: false,
+    });
+    parameters.extend(super::super::identity_params());
+
+    ToolSchema {
+        name: name.to_string(),
+        description: "List review threads on an Orbit task".to_string(),
+        parameters,
+        builtin: true,
     }
 }

--- a/crates/orbit-tools/src/builtin/orbit/review_thread/reply.rs
+++ b/crates/orbit-tools/src/builtin/orbit/review_thread/reply.rs
@@ -4,33 +4,54 @@ use serde_json::Value;
 use crate::{OrbitBuiltinAction, Tool, ToolContext};
 
 pub struct OrbitReviewThreadReplyTool;
+pub struct OrbitReviewThreadReplyAliasTool;
 
 impl Tool for OrbitReviewThreadReplyTool {
     fn schema(&self) -> ToolSchema {
-        let mut parameters = super::super::orbit_id_params("task");
-        parameters.push(ToolParam {
-            name: "thread_id".to_string(),
-            description: "Review thread ID to reply to".to_string(),
-            param_type: "string".to_string(),
-            required: true,
-        });
-        parameters.push(ToolParam {
-            name: "body".to_string(),
-            description: "Reply body".to_string(),
-            param_type: "string".to_string(),
-            required: true,
-        });
-        parameters.extend(super::super::scored_identity_params());
-
-        ToolSchema {
-            name: "orbit.task.review_thread.reply".to_string(),
-            description: "Reply to an existing review thread on an Orbit task".to_string(),
-            parameters,
-            builtin: true,
-        }
+        reply_schema("orbit.task.review_thread.reply")
     }
 
     fn execute(&self, ctx: &ToolContext, input: Value) -> Result<Value, OrbitError> {
         super::super::execute_host_action(ctx, input, OrbitBuiltinAction::ReviewThreadReply)
+    }
+}
+
+impl Tool for OrbitReviewThreadReplyAliasTool {
+    fn schema(&self) -> ToolSchema {
+        reply_schema("orbit.review-thread.reply")
+    }
+
+    fn execute(&self, ctx: &ToolContext, input: Value) -> Result<Value, OrbitError> {
+        super::super::execute_host_action(ctx, input, OrbitBuiltinAction::ReviewThreadReply)
+    }
+}
+
+fn reply_schema(name: &str) -> ToolSchema {
+    let mut parameters = super::super::orbit_id_params("task");
+    parameters.push(ToolParam {
+        name: "task_id".to_string(),
+        description: "Task ID alias for id".to_string(),
+        param_type: "string".to_string(),
+        required: false,
+    });
+    parameters.push(ToolParam {
+        name: "thread_id".to_string(),
+        description: "Review thread ID to reply to".to_string(),
+        param_type: "string".to_string(),
+        required: true,
+    });
+    parameters.push(ToolParam {
+        name: "body".to_string(),
+        description: "Reply body".to_string(),
+        param_type: "string".to_string(),
+        required: true,
+    });
+    parameters.extend(super::super::scored_identity_params());
+
+    ToolSchema {
+        name: name.to_string(),
+        description: "Reply to an existing review thread on an Orbit task".to_string(),
+        parameters,
+        builtin: true,
     }
 }

--- a/crates/orbit-tools/src/builtin/orbit/review_thread/resolve.rs
+++ b/crates/orbit-tools/src/builtin/orbit/review_thread/resolve.rs
@@ -4,27 +4,48 @@ use serde_json::Value;
 use crate::{OrbitBuiltinAction, Tool, ToolContext};
 
 pub struct OrbitReviewThreadResolveTool;
+pub struct OrbitReviewThreadResolveAliasTool;
 
 impl Tool for OrbitReviewThreadResolveTool {
     fn schema(&self) -> ToolSchema {
-        let mut parameters = super::super::orbit_id_params("task");
-        parameters.push(ToolParam {
-            name: "thread_id".to_string(),
-            description: "Review thread ID to resolve".to_string(),
-            param_type: "string".to_string(),
-            required: true,
-        });
-        parameters.extend(super::super::identity_params());
-
-        ToolSchema {
-            name: "orbit.task.review_thread.resolve".to_string(),
-            description: "Resolve a review thread on an Orbit task".to_string(),
-            parameters,
-            builtin: true,
-        }
+        resolve_schema("orbit.task.review_thread.resolve")
     }
 
     fn execute(&self, ctx: &ToolContext, input: Value) -> Result<Value, OrbitError> {
         super::super::execute_host_action(ctx, input, OrbitBuiltinAction::ReviewThreadResolve)
+    }
+}
+
+impl Tool for OrbitReviewThreadResolveAliasTool {
+    fn schema(&self) -> ToolSchema {
+        resolve_schema("orbit.review-thread.resolve")
+    }
+
+    fn execute(&self, ctx: &ToolContext, input: Value) -> Result<Value, OrbitError> {
+        super::super::execute_host_action(ctx, input, OrbitBuiltinAction::ReviewThreadResolve)
+    }
+}
+
+fn resolve_schema(name: &str) -> ToolSchema {
+    let mut parameters = super::super::orbit_id_params("task");
+    parameters.push(ToolParam {
+        name: "task_id".to_string(),
+        description: "Task ID alias for id".to_string(),
+        param_type: "string".to_string(),
+        required: false,
+    });
+    parameters.push(ToolParam {
+        name: "thread_id".to_string(),
+        description: "Review thread ID to resolve".to_string(),
+        param_type: "string".to_string(),
+        required: true,
+    });
+    parameters.extend(super::super::identity_params());
+
+    ToolSchema {
+        name: name.to_string(),
+        description: "Resolve a review thread on an Orbit task".to_string(),
+        parameters,
+        builtin: true,
     }
 }

--- a/crates/orbit-tools/src/builtin/orbit/tests/identity.rs
+++ b/crates/orbit-tools/src/builtin/orbit/tests/identity.rs
@@ -26,6 +26,7 @@ fn tool_context(agent: &str, model: &str) -> ToolContext {
         model_name: Some(model.to_string()),
         role_slot: None,
         proc_allowed_programs: Vec::new(),
+        proc_spawn_activity_scoped: false,
         policy_engine: None,
         fs_profile: None,
         fs_audit: None,

--- a/docs/design/task-artifacts/4_decisions.md
+++ b/docs/design/task-artifacts/4_decisions.md
@@ -3,7 +3,7 @@ summary: "Task Artifacts — Decisions"
 type: design
 title: "Task Artifacts — Decisions"
 owner: codex
-last_updated: 2026-05-17
+last_updated: 2026-05-23
 status: Draft
 feature: task-artifacts
 doc_role: decisions
@@ -179,8 +179,24 @@ Each `Plan` is monotonically versioned within a single lineage. Cross-lineage re
 
 ---
 
+## ADR-0182 — Review-thread hook active task binding
+
+**Status:** Accepted · 2026-05 · [ORB-00273]
+
+**Context.** Review-thread reminders need a cheap way to know which task owns the current agent turn. Inferring from cwd or scanning task files would make every PreToolUse call depend on filesystem heuristics, while the engine already knows the executing task when it seeds `ORBIT_TASK_ID`.
+
+**Decision.** The hook treats `ORBIT_ACTIVE_TASK_ID` as the explicit active-task binding, with `ORBIT_TASK_ID` as a compatibility fallback for existing execution paths. Orbit execution code seeds both values when the activity input contains a task id, and hook state is still scoped by the existing session id plus parent-pid state-file key.
+
+**Consequences.**
+- Review-thread surfacing remains a local task-store read and does not perform network I/O or cwd inference.
+- Existing `ORBIT_TASK_ID`-spawned executions keep working while newer shims can depend on the clearer `ORBIT_ACTIVE_TASK_ID` name.
+- Cost: Orbit now has two task-id environment names during a compatibility window, so documentation and tests must keep their precedence explicit.
+
+---
+
 ## Task References
 
 - ORB-00093
+- ORB-00273
 
 Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.


### PR DESCRIPTION
## Task

[ORB-00273](https://orbit-cli.com/tasks/ORB-00273) — Hook-driven async steering: surface review-thread asks to executing agent

### Description

## Problem

Agents executing long Orbit tasks have no async steering channel. A human (or another agent) who wants to redirect or add scope mid-implementation has only two options today: interrupt the session, or wait until the agent stops. Both are bad — interrupting fragments the trace, and waiting means the agent commits work that's already off-target.

Orbit already has review-threads as a substrate (`add`, `list`, `reply`, `resolve` over MCP and CLI via [`crates/orbit-tools/src/builtin/orbit/review_thread/`](crates/orbit-tools/src/builtin/orbit/review_thread/)). Reuse that substrate to give agents an async inbox: new or unaddressed threads on the active task surface on the next tool turn through the existing `orbit hook pretooluse` channel, and the agent's reply on the thread becomes the durable record of the decision.

This task is the agent-side / hook-side half of the feature. The dashboard-side half is tracked in [ORB-00274](.orbit/tasks/ORB-00274/) and linked via `related_to`.

## Why It Matters

- Steering without interruption: humans can drop a thread on a task overnight and the agent picks it up next turn.
- Decision audit trail: agent's reply on the thread ("folded into commit abc123", "spawned T-NNN", "won't do — reason") is anchored to the original ask, not buried in a tool-result blob.
- Symmetric with normal code review: same mechanism whether the thread came mid-implementation or post-hoc.
- Bidirectional: agent can also open a thread on ambiguity ("intent unclear at <file:line>, defaulting to X") and a human reply surfaces on the next tool turn — the missing primitive for non-blocking async questions from agents.

## Reuse / Reference

The existing `orbit hook pretooluse` learning-injection path is the reference architecture. Mirror its shape; do not invent a parallel system.

- Entry: [`crates/orbit-cli/src/command/hook/pretooluse.rs`](crates/orbit-cli/src/command/hook/pretooluse.rs) `run_pretooluse` (reads stdin payload, classifies relevance, searches, admits via state-file dedup, audits, renders).
- State-file locking: `update_state_file` / `update_locked_state` in the same file use `fs2::FileExt` for exclusive locks with a 50ms retry budget — copy this pattern for the thread watermark.
- Per-agent rendering: [`crates/orbit-cli/src/command/hook/render.rs`](crates/orbit-cli/src/command/hook/render.rs) `render_reminders` dispatches `HookOutputFormat::{Claude, Codex, Gemini, Grok}` — extend (or add sibling) so each agent format receives review-thread reminders in its native hook channel.
- Core helpers: [`orbit_core::command::learning_hook`](crates/orbit-core/src/command/learning_hook/) owns parse/admission helpers. Add a sibling `review_thread_hook` module for the analogous logic; keep the CLI a thin wrapper.
- Audit emission: `emit_learning_injected_audit` in `pretooluse.rs` is the template for `emit_review_thread_surfaced_audit`.
- Hook wiring is **already done** by [`crates/orbit-cli/src/command/hook/install.rs`](crates/orbit-cli/src/command/hook/install.rs) — `orbit hook install` generates the shim that calls `orbit hook pretooluse`. Adding thread surfacing inside that subcommand requires no changes to `install.rs` or `plugin/hooks/hooks.json` unless a separate hook surface is justified (default: no).

## Scope

1. **Extend `orbit hook pretooluse`** at [`crates/orbit-cli/src/command/hook/pretooluse.rs`](crates/orbit-cli/src/command/hook/pretooluse.rs) so that after the existing learning search, it also queries unresolved review-thread asks for the active task and admits any new ones via a parallel state-file dedup. Print both reminder kinds through the same per-agent render path.
2. **`review_thread_hook` module in `orbit-core`** mirroring `learning_hook`: payload parsing, state schema, admission/merge logic, audit insert params. Keep CLI logic-free.
3. **Watermark state** per `(task_id, thread_id, last_seen_message_seq)` so each ask surfaces once and new replies re-surface. Store in a sibling state file under the same tmpdir as learning hook state; reuse the lock pattern from `update_state_file`.
4. **Active-task detection**: define how the hook learns which task is active. Existing precedent: `ORBIT_SESSION_ID_ENV` + parent pid for the learning state-file key. Propose `ORBIT_ACTIVE_TASK_ID` (seeded by `orbit-execute-task`), task-file inference from cwd, or another mechanism — pick one and document under [`docs/design/`](docs/design/) with an ADR.
5. **Anchorless / task-level thread variant** — current [`ReviewThread`](crates/orbit-common/src/types/task.rs) is anchor-bearing; add an explicit task-level mode for asks that pre-date the code they reference. Propagate through tool layer at [`crates/orbit-tools/src/builtin/orbit/review_thread/`](crates/orbit-tools/src/builtin/orbit/review_thread/) and core surface [`crates/orbit-core/src/command/task/review.rs`](crates/orbit-core/src/command/task/review.rs).
6. **Rendering**: extend [`render.rs`](crates/orbit-cli/src/command/hook/render.rs) so each `HookOutputFormat` emits review-thread reminders with explicit author attribution (human vs. agent + family) and the recommended action — trivial → incorporate; non-trivial → propose follow-up task via `orbit.task.add` and link via `relations: spawned_from`. The rendering layer is the trust boundary: thread text rides on the same channel the agent already treats as a hook reminder, not as tool-result content.
7. **Resolution convention** documented in the surfaced message: agent resolves on reply by default; human can re-open if unsatisfied.

## Constraints / Notes

- Hook must remain cheap — single local SQLite/file read for threads on top of the existing learning search. PreToolUse fires on every tool call.
- `tracing` only; no `print!`/`eprint!` per [`CLAUDE.md`](CLAUDE.md) (the existing `println!` for hook stdout output is the documented exception — the same exception applies here).
- Agent-as-author of threads is **already supported** by [`crates/orbit-tools/src/builtin/orbit/review_thread/add.rs`](crates/orbit-tools/src/builtin/orbit/review_thread/add.rs) — no new authoring surface needed; the hook just needs to surface *replies* to agent-opened threads on the next turn.
- Test layout per [`docs/design-patterns/test_layout.md`](docs/design-patterns/test_layout.md) — sibling `tests/` directory mirroring source filenames (existing pattern at [`crates/orbit-cli/src/command/hook/tests/pretooluse.rs`](crates/orbit-cli/src/command/hook/tests/pretooluse.rs)).
- Pairs with [ORB-00274](.orbit/tasks/ORB-00274/) for the human-facing dashboard view of the same threads.

### Acceptance Criteria

- Adding a thread with `orbit tool run orbit.review-thread.add` against the active task causes the next `orbit hook pretooluse` invocation to emit a hook-formatted reminder whose body contains the thread text and explicit author identity (human or agent family) — exactly once per (task_id, thread_id, last_seen_message_seq).
- After the agent replies via `orbit tool run orbit.review-thread.reply` and resolves via `orbit tool run orbit.review-thread.resolve`, subsequent `orbit hook pretooluse` invocations on the same task do not re-surface that thread (verified by piping representative payloads through stdin and inspecting stdout).
- Adding a *new reply* on an already-surfaced thread causes the thread to re-surface exactly once on the next pretooluse invocation — watermark tracks `last_seen_message_seq`, not just thread existence.
- A thread created with no `file:line` anchor (task-level variant) is accepted by `orbit tool run orbit.review-thread.add` and surfaces through the hook with a `task-level` marker. Verify with `orbit tool run orbit.review-thread.list --input '{"task_id":"<id>"}'` JSON output round-tripping the new variant kind.
- `orbit hook pretooluse --format claude < payload.json` emits both learning reminders (pre-existing) and review-thread reminders when both are admissible — neither path regresses (extend the existing test fixtures under [`crates/orbit-cli/src/command/hook/tests/`](crates/orbit-cli/src/command/hook/tests/) to cover the combined output).
- Watermark state survives process exit: invoke pretooluse twice across separate processes — the second invocation must not re-surface a thread admitted in the first. Uses the `fs2::FileExt`-based lock pattern from `update_state_file`.
- Hook performs no network I/O. Verify by code-review of the new module and by confirming only `OrbitRuntime` core APIs (already in-process) are called.
- `orbit hook install` is **idempotent after the change** — running it before and after this work yields no diff in the generated hook shim (the existing `orbit hook pretooluse` invocation already covers thread surfacing).
- Audit event is emitted on thread surfacing, mirroring `emit_learning_injected_audit` shape, with task_id, thread_id, and last_seen_message_seq fields. Verify via `orbit audit list --json`.
- Sibling unit tests under [`crates/orbit-cli/src/command/hook/tests/`](crates/orbit-cli/src/command/hook/tests/) and the `review_thread_hook` core module cover: watermark cursor advance on reply; watermark cursor advance on resolve; anchorless thread round-trip; combined output with learnings; and per-agent render format for each `HookOutputFormat` variant.
- `make ci-fast` passes after changes.

## Execution Summary

<details>
<summary>Click to expand</summary>

Implemented hook-driven async steering for active-task review threads.

Changes:
- Added core review-thread hook admission, fs2-locked watermark state, rendering, and audit emission, then wired pretooluse to emit learning and review reminders together.
- Added active task binding via ORBIT_ACTIVE_TASK_ID with ORBIT_TASK_ID fallback, including engine seeding for direct and CLI activity execution.
- Added task-level review-thread anchors, task_id input aliases, orbit.review-thread.* aliases, and reply re-open semantics.
- Documented the active-task binding in ADR-0182.
- Added coverage for watermark persistence and reply/resolve behavior, task-level round trip, combined learning/review output, per-agent formats, audit rows, hook-install idempotency, and the touched review-thread tool package.

Validation:
- cargo test -p orbit-cli --test hook_pretooluse -- --nocapture
- cargo test -p orbit-core review_thread_hook -- --nocapture
- cargo test -p orbit-core learning_hook -- --nocapture
- cargo test -p orbit-core runtime::orbit_tool_host::tests::review_threads -- --nocapture
- cargo test -p orbit-tools review_thread -- --nocapture
- cargo test -p orbit-cli hook::tests -- --nocapture
- cargo test -p orbit-cli --test hook_install -- --nocapture
- cargo test -p orbit-cli --test tool_list -- --nocapture
- cargo test -p orbit-cli command::mcp::tests -- --nocapture
- cargo test -p orbit-engine state_env_vars -- --nocapture
- cargo test -p orbit-engine run_cli_backend_exports_runtime_identity_for_subprocess_tools -- --nocapture
- cargo fmt --all --check
- git diff --check
- make ci-fast

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-00273-6a1132cc`
- Behind base: 0
- Ahead of base: 1