### PR TITLE
Admin dashboard: bidirectional review-thread message panel

### DIFF
--- a/crates/orbit-core/src/command/task/review.rs
+++ b/crates/orbit-core/src/command/task/review.rs
@@ -149,6 +149,42 @@ impl OrbitRuntime {
         agent: Option<String>,
         model: Option<String>,
     ) -> Result<ReviewThread, OrbitError> {
+        self.set_review_thread_status(
+            task_id,
+            thread_id,
+            ReviewThreadStatus::Resolved,
+            agent,
+            model,
+            "resolve",
+        )
+    }
+
+    pub fn reopen_review_thread(
+        &self,
+        task_id: &str,
+        thread_id: &str,
+        agent: Option<String>,
+        model: Option<String>,
+    ) -> Result<ReviewThread, OrbitError> {
+        self.set_review_thread_status(
+            task_id,
+            thread_id,
+            ReviewThreadStatus::Open,
+            agent,
+            model,
+            "reopen",
+        )
+    }
+
+    fn set_review_thread_status(
+        &self,
+        task_id: &str,
+        thread_id: &str,
+        status: ReviewThreadStatus,
+        agent: Option<String>,
+        model: Option<String>,
+        verb: &'static str,
+    ) -> Result<ReviewThread, OrbitError> {
         let threads = self.get_task_review_threads(task_id)?;
         let _existing = threads
             .iter()
@@ -159,11 +195,11 @@ impl OrbitRuntime {
                 ))
             })?;
 
-        let resolve_thread = ReviewThread {
+        let status_thread = ReviewThread {
             thread_id: thread_id.to_string(),
             path: None,
             line: None,
-            status: ReviewThreadStatus::Resolved,
+            status,
             messages: vec![],
             github_thread_id: None,
         };
@@ -171,7 +207,7 @@ impl OrbitRuntime {
         self.update_task_with_identity(
             task_id,
             TaskUpdateParams {
-                append_review_threads: vec![resolve_thread],
+                append_review_threads: vec![status_thread],
                 ..Default::default()
             },
             agent,
@@ -181,9 +217,7 @@ impl OrbitRuntime {
         self.get_task_review_threads(task_id)?
             .into_iter()
             .find(|t| t.thread_id == thread_id)
-            .ok_or_else(|| {
-                OrbitError::Execution("review thread disappeared after resolve".to_string())
-            })
+            .ok_or_else(|| OrbitError::Execution(format!("review thread disappeared after {verb}")))
     }
 
     fn record_task_review_thread_score(&self, model: Option<&str>) {

--- a/crates/orbit-dashboard/assets/dashboard/app.js
+++ b/crates/orbit-dashboard/assets/dashboard/app.js
@@ -5,6 +5,7 @@ import { el, statusPill, stateCell, fetchJson, requestJson, postJson, patchJson,
 import { buildChips, cacheCrewPayload, copyTaskIdWithNotice, hasCrewOptions, openVisibleTask, renderTasks, setPinnedExternalTask, wireSearch } from './tasks.js';
 import { applyAuditHashQuery, buildAuditChips, buildAuditHash, fetchAndRenderAudit, fetchAndRenderPolicy, getActiveAuditSubtab, navigateToAuditExecution, renderAuditSummary, setActiveAuditSubtabFromButton, setAuditSubtab, syncAuditControls, wireAuditSearch, } from './audit.js';
 import { renderScoreboard } from './scoreboard.js';
+import { fetchAndRender as fetchAndRenderReviewThreads, initReviewThreads, markCurrentAgentThreadsSeen } from './review-threads.js';
 import { initLogTail, fitLogPanelToViewport } from './log-tail.js';
 import { renderDiagnostics, renderImplementOneCard as renderImplOne, } from './diagnostics.js';
 import { initRouter, initTabs as iT, navigateToRun as nTR, setActiveTab as sAT, setRunDetailSubtab, } from './router.js';
@@ -1071,7 +1072,14 @@ function fetchAndRenderTasks() {
 
 function activeRefreshJobs() {
   // The health strip is global; refresh on every tick alongside the active tab.
-  const jobs = [fetchAndRenderSummary()];
+  // Threads also refresh globally so the unread badge updates without visiting
+  // the Threads tab; mark-seen only fires while that tab is active (below).
+  const jobs = [
+    fetchAndRenderSummary(),
+    fetchAndRenderReviewThreads().then(() => {
+      if (activeTab === "threads") markCurrentAgentThreadsSeen();
+    }),
+  ];
 
   if (activeTab === "tasks") {
     jobs.push(fetchAndRenderTasks());
@@ -1081,6 +1089,11 @@ function activeRefreshJobs() {
 
   if (activeTab === "scoreboard") {
     jobs.push(fetchJson("/api/scoreboard").then(renderScoreboard));
+    return jobs;
+  }
+
+  if (activeTab === "threads") {
+    // Threads payload is already in the global jobs above; nothing extra needed.
     return jobs;
   }
 
@@ -1349,6 +1362,7 @@ $("refresh-btn").addEventListener("click", refreshDashboard);
 
 initRuns(runsContext());
 initRunDetail(runDetailContext());
+initReviewThreads();
 const rctx = routerContext();
 initRouter(rctx);
 iT();

--- a/crates/orbit-dashboard/assets/dashboard/dashboard.css
+++ b/crates/orbit-dashboard/assets/dashboard/dashboard.css
@@ -2349,3 +2349,98 @@
       .log-foot .filter-pill.on:hover { border-color: var(--accent-hover); }
       .log-foot .right { margin-left: auto; cursor: pointer; user-select: none; }
       .log-foot .right.on { color: var(--accent); }
+
+      .tab-badge {
+        display: inline-block;
+        margin-left: 6px;
+        padding: 0 6px;
+        min-width: 16px;
+        height: 16px;
+        line-height: 16px;
+        border-radius: 8px;
+        background: var(--status-open, #f59e0b);
+        color: #000;
+        font-family: var(--font-mono);
+        font-size: 10px;
+        font-weight: 600;
+        text-align: center;
+      }
+
+      #threads-filters {
+        display: flex;
+        gap: 16px;
+        flex-wrap: wrap;
+        padding: 8px 12px;
+      }
+      .thread-filter-group {
+        display: flex;
+        align-items: center;
+        gap: 6px;
+      }
+      .thread-filter-label {
+        font-family: var(--font-mono);
+        font-size: 11px;
+        color: var(--fg-dim);
+        text-transform: uppercase;
+        letter-spacing: 0.04em;
+      }
+
+      .review-thread-row {
+        display: grid;
+        grid-template-columns: minmax(110px, 130px) minmax(110px, 130px) minmax(140px, 1.2fr) minmax(220px, 2.5fr) 60px minmax(80px, 100px) minmax(120px, 140px);
+        align-items: center;
+        gap: 12px;
+        padding: 6px 12px;
+        border-bottom: 1px solid var(--border);
+        cursor: pointer;
+        font-size: 12px;
+      }
+      .review-thread-row.header {
+        cursor: default;
+        color: var(--fg-dim);
+        font-family: var(--font-mono);
+        font-size: 11px;
+        text-transform: uppercase;
+        letter-spacing: 0.04em;
+        background: #050505;
+      }
+      .review-thread-row:hover:not(.header) {
+        background: rgba(110, 159, 255, 0.05);
+      }
+      .review-thread-row.expanded {
+        background: rgba(110, 159, 255, 0.08);
+      }
+      .review-thread-preview {
+        color: var(--fg-dim);
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
+      .review-thread-meta {
+        font-family: var(--font-mono);
+        font-size: 11px;
+        color: var(--fg-dim);
+      }
+      .review-thread-detail {
+        padding: 12px 16px;
+        background: var(--bg-elev);
+        border-bottom: 1px solid var(--border);
+        display: flex;
+        flex-direction: column;
+        gap: 12px;
+      }
+      .review-thread-messages {
+        display: flex;
+        flex-direction: column;
+        gap: 4px;
+      }
+      .review-thread-reply textarea {
+        width: 100%;
+        background: #000;
+        color: var(--fg);
+        border: 1px solid var(--border);
+        padding: 6px 8px;
+        font-family: var(--font-mono);
+        font-size: 12px;
+        resize: vertical;
+      }

--- a/crates/orbit-dashboard/assets/dashboard/index.html
+++ b/crates/orbit-dashboard/assets/dashboard/index.html
@@ -34,6 +34,7 @@
     <nav class="tabs" id="tabs">
       <button class="tab" data-tab="tasks" type="button">Tasks</button>
       <button class="tab" data-tab="scoreboard" type="button">Scoreboard</button>
+      <button class="tab" data-tab="threads" type="button">Threads<span class="tab-badge" id="threads-unread-badge" style="display: none;">0</span></button>
       <button class="tab" data-tab="audit" type="button">Audit</button>
       <button class="tab" data-tab="diagnostics" type="button">Diagnostics</button>
       <button class="tab" data-tab="knowledge" type="button">Knowledge</button>
@@ -114,6 +115,21 @@
           <div class="body scoreboard-table-wrap" id="scoreboard-body">
             <div class="skeleton-state">
               <div class="skeleton skeleton-row"></div>
+              <div class="skeleton skeleton-row" style="width: 70%"></div>
+            </div>
+          </div>
+        </section>
+      </main>
+    </section>
+    <section class="tab-pane" data-tab="threads">
+      <main style="grid-template-columns: 1fr;">
+        <section class="panel" id="threads-panel">
+          <header><span>Review threads</span><span class="count" id="threads-count">-</span></header>
+          <div class="controls" id="threads-filters"></div>
+          <div class="body" id="threads-body">
+            <div class="skeleton-state">
+              <div class="skeleton skeleton-row"></div>
+              <div class="skeleton skeleton-row" style="width: 85%"></div>
               <div class="skeleton skeleton-row" style="width: 70%"></div>
             </div>
           </div>

--- a/crates/orbit-dashboard/assets/dashboard/review-threads.js
+++ b/crates/orbit-dashboard/assets/dashboard/review-threads.js
@@ -1,0 +1,321 @@
+// Cross-task review-thread panel for the dashboard.
+//
+// Lists threads from /api/review-threads with filters (status, author kind),
+// supports reply / resolve / re-open in place, and surfaces an unread badge
+// for agent-authored threads that appeared since the last visit to this tab.
+
+import { el, fetchJson, postJson, statusPill, syncNodes } from './common.js';
+
+const $ = (id) => document.getElementById(id);
+
+const SEEN_KEY = 'orbit-dashboard.review-threads.seen-agent-thread-ids';
+
+let lastPayload = { items: [], stats: {} };
+let statusFilter = 'open';
+let authorKindFilter = 'both';
+let pendingThreadId = null;
+let lastSeenAgentThreads = loadSeenAgentThreads();
+let pendingErrors = new Map();
+
+function loadSeenAgentThreads() {
+  try {
+    const raw = window.localStorage.getItem(SEEN_KEY);
+    if (!raw) return new Set();
+    const parsed = JSON.parse(raw);
+    return new Set(Array.isArray(parsed) ? parsed : []);
+  } catch (_) {
+    return new Set();
+  }
+}
+
+function persistSeenAgentThreads() {
+  try {
+    window.localStorage.setItem(
+      SEEN_KEY,
+      JSON.stringify(Array.from(lastSeenAgentThreads)),
+    );
+  } catch (_) {
+    // best-effort; localStorage may be unavailable
+  }
+}
+
+function agentAuthoredThreadIds(items) {
+  const ids = [];
+  for (const item of items) {
+    if (!item || !item.thread_id) continue;
+    const lastKind = String(item.last_author_kind || '').toLowerCase();
+    if (lastKind === 'agent') ids.push(item.thread_id);
+  }
+  return ids;
+}
+
+function computeUnreadCount(items) {
+  let unread = 0;
+  for (const id of agentAuthoredThreadIds(items)) {
+    if (!lastSeenAgentThreads.has(id)) unread += 1;
+  }
+  return unread;
+}
+
+export function markCurrentAgentThreadsSeen() {
+  let changed = false;
+  for (const id of agentAuthoredThreadIds(lastPayload.items)) {
+    if (!lastSeenAgentThreads.has(id)) {
+      lastSeenAgentThreads.add(id);
+      changed = true;
+    }
+  }
+  if (changed) {
+    persistSeenAgentThreads();
+    refreshBadge();
+  }
+}
+
+function refreshBadge() {
+  const unreadBadge = $('threads-unread-badge');
+  if (!unreadBadge) return;
+  const unread = computeUnreadCount(lastPayload.items);
+  if (unread > 0) {
+    unreadBadge.style.display = '';
+    unreadBadge.textContent = String(unread);
+  } else {
+    unreadBadge.style.display = 'none';
+  }
+}
+
+function locationLabel(item) {
+  const anchor = item.anchor || {};
+  if (anchor.kind === 'inline' && item.path && item.line != null) {
+    return `${item.path}:${item.line}`;
+  }
+  return 'task-level';
+}
+
+function authorLabel(kind, family) {
+  if (kind === 'agent') {
+    return family ? `agent (${family})` : 'agent';
+  }
+  return 'human';
+}
+
+function fmtAbs(iso) {
+  if (!iso) return '-';
+  const d = new Date(iso);
+  if (isNaN(d.getTime())) return iso;
+  const pad = (n) => String(n).padStart(2, '0');
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())} ${pad(d.getHours())}:${pad(d.getMinutes())}`;
+}
+
+function buildFilterControls() {
+  const wrap = $('threads-filters');
+  if (!wrap) return;
+  wrap.innerHTML = '';
+
+  const statusGroup = el('div', { class: 'thread-filter-group' });
+  statusGroup.appendChild(el('span', { class: 'thread-filter-label', text: 'status' }));
+  for (const value of ['open', 'resolved', 'all']) {
+    const chip = el('button', { class: 'chip', text: value });
+    if (value === statusFilter) chip.classList.add('active');
+    chip.addEventListener('click', () => {
+      statusFilter = value;
+      fetchAndRender().catch((err) => console.error(err));
+    });
+    statusGroup.appendChild(chip);
+  }
+  wrap.appendChild(statusGroup);
+
+  const authorGroup = el('div', { class: 'thread-filter-group' });
+  authorGroup.appendChild(el('span', { class: 'thread-filter-label', text: 'author' }));
+  for (const [label, value] of [['both', 'both'], ['human', 'human'], ['agent', 'agent']]) {
+    const chip = el('button', { class: 'chip', text: label });
+    if (value === authorKindFilter) chip.classList.add('active');
+    chip.addEventListener('click', () => {
+      authorKindFilter = value;
+      fetchAndRender().catch((err) => console.error(err));
+    });
+    authorGroup.appendChild(chip);
+  }
+  wrap.appendChild(authorGroup);
+}
+
+function buildMessageList(messages) {
+  const list = el('div', { class: 'review-thread-messages' });
+  for (const message of messages || []) {
+    const author = authorLabel(message.author_kind, message.agent_family);
+    const line = el('div', { class: 'comment-line' }, [
+      document.createTextNode(`[${fmtAbs(message.at)}] `),
+      el('span', { class: 'author', text: author }),
+      document.createTextNode(': '),
+      el('span', { class: 'review-thread-body', text: message.body || '' }),
+    ]);
+    list.appendChild(line);
+  }
+  return list;
+}
+
+function buildReplyForm(item) {
+  const form = el('div', { class: 'review-thread-reply' });
+  const textarea = el('textarea');
+  textarea.placeholder = 'Reply to this thread';
+  textarea.rows = 3;
+  const controls = el('div', { class: 'actions' });
+  const submit = el('button', { class: 'action approve', text: 'reply' });
+  submit.addEventListener('click', async (e) => {
+    e.stopPropagation();
+    const body = (textarea.value || '').trim();
+    if (!body) {
+      textarea.focus();
+      return;
+    }
+    submit.disabled = true;
+    textarea.disabled = true;
+    try {
+      await postJson(
+        `/api/tasks/${encodeURIComponent(item.task_id)}/review-threads/${encodeURIComponent(item.thread_id)}/reply`,
+        { body },
+      );
+      pendingErrors.delete(item.thread_id);
+      await fetchAndRender();
+    } catch (err) {
+      pendingErrors.set(item.thread_id, err.message || String(err));
+      submit.disabled = false;
+      textarea.disabled = false;
+      render();
+    }
+  });
+  controls.appendChild(submit);
+  form.appendChild(textarea);
+  form.appendChild(controls);
+  return form;
+}
+
+function buildActions(item) {
+  const actions = el('div', { class: 'actions' });
+  if (item.status === 'resolved') {
+    const btn = el('button', { class: 'action approve', text: 're-open' });
+    btn.addEventListener('click', async (e) => {
+      e.stopPropagation();
+      btn.disabled = true;
+      try {
+        await postJson(
+          `/api/tasks/${encodeURIComponent(item.task_id)}/review-threads/${encodeURIComponent(item.thread_id)}/reopen`,
+        );
+        await fetchAndRender();
+      } catch (err) {
+        pendingErrors.set(item.thread_id, err.message || String(err));
+        btn.disabled = false;
+        render();
+      }
+    });
+    actions.appendChild(btn);
+  } else {
+    const btn = el('button', { class: 'action archive', text: 'resolve' });
+    btn.addEventListener('click', async (e) => {
+      e.stopPropagation();
+      btn.disabled = true;
+      try {
+        await postJson(
+          `/api/tasks/${encodeURIComponent(item.task_id)}/review-threads/${encodeURIComponent(item.thread_id)}/resolve`,
+        );
+        await fetchAndRender();
+      } catch (err) {
+        pendingErrors.set(item.thread_id, err.message || String(err));
+        btn.disabled = false;
+        render();
+      }
+    });
+    actions.appendChild(btn);
+  }
+  return actions;
+}
+
+function render() {
+  const body = $('threads-body');
+  const countEl = $('threads-count');
+  if (!body) return;
+  const items = Array.isArray(lastPayload.items) ? lastPayload.items : [];
+  refreshBadge();
+
+  if (countEl) {
+    const stats = lastPayload.stats || {};
+    const visible = items.length;
+    const total = Number.isFinite(Number(stats.total)) ? Number(stats.total) : visible;
+    countEl.textContent = visible === total ? `${visible}` : `${visible}/${total}`;
+  }
+
+  if (items.length === 0) {
+    syncNodes(body, [el('div', { class: 'empty-state' }, [
+      el('div', { class: 'icon', text: '✧' }),
+      el('div', { class: 'text', text: 'No review threads match the current filter.' }),
+    ])]);
+    return;
+  }
+
+  const frag = document.createDocumentFragment();
+
+  const header = el('div', { class: 'review-thread-row header' }, [
+    el('span', { text: 'task' }),
+    el('span', { text: 'author' }),
+    el('span', { text: 'location' }),
+    el('span', { text: 'preview' }),
+    el('span', { class: 'review-thread-meta', text: 'msgs' }),
+    el('span', { text: 'status' }),
+    el('span', { class: 'review-thread-meta', text: 'updated' }),
+  ]);
+  header.dataset.key = 'review-thread-header';
+  header.dataset.hash = 'review-thread-header';
+  frag.appendChild(header);
+
+  for (const item of items) {
+    const row = el('div', { class: 'review-thread-row', title: item.task_title || item.task_id }, [
+      el('span', { class: 'mono', text: item.task_id }),
+      el('span', { class: 'mono', text: authorLabel(item.last_author_kind, item.last_author_family) }),
+      el('span', { class: 'mono', text: locationLabel(item) }),
+      el('span', { class: 'review-thread-preview', text: item.body_preview || '' }),
+      el('span', { class: 'review-thread-meta', text: String(item.message_count || 0) }),
+      statusPill(item.status || 'open'),
+      el('span', { class: 'review-thread-meta', text: fmtAbs(item.last_activity_at) }),
+    ]);
+    row.dataset.key = `thread-row-${item.thread_id}`;
+    row.dataset.hash = `${item.thread_id}-${item.status}-${item.message_count}-${item.last_activity_at}-${pendingThreadId === item.thread_id}`;
+    if (pendingThreadId === item.thread_id) row.classList.add('expanded');
+    row.addEventListener('click', () => {
+      pendingThreadId = pendingThreadId === item.thread_id ? null : item.thread_id;
+      render();
+    });
+    frag.appendChild(row);
+
+    if (pendingThreadId === item.thread_id) {
+      const detail = el('div', { class: 'review-thread-detail' });
+      detail.appendChild(buildMessageList(item.messages));
+      const errMsg = pendingErrors.get(item.thread_id);
+      if (errMsg) {
+        detail.appendChild(el('div', { class: 'action-error', text: errMsg }));
+      }
+      detail.appendChild(buildReplyForm(item));
+      detail.appendChild(buildActions(item));
+      detail.dataset.key = `thread-detail-${item.thread_id}`;
+      detail.dataset.hash = `${item.thread_id}-${item.status}-${item.message_count}-${item.last_activity_at}-${errMsg || ''}`;
+      detail.addEventListener('click', (e) => e.stopPropagation());
+      frag.appendChild(detail);
+    }
+  }
+
+  syncNodes(body, Array.from(frag.children));
+}
+
+export function fetchAndRender() {
+  const sp = new URLSearchParams();
+  sp.set('status', statusFilter);
+  sp.set('author_kind', authorKindFilter);
+  return fetchJson(`/api/review-threads?${sp.toString()}`).then((payload) => {
+    lastPayload = payload || { items: [], stats: {} };
+    buildFilterControls();
+    render();
+  });
+}
+
+export function initReviewThreads() {
+  buildFilterControls();
+  render();
+}

--- a/crates/orbit-dashboard/assets/dashboard/router.js
+++ b/crates/orbit-dashboard/assets/dashboard/router.js
@@ -22,7 +22,7 @@ import { renderRuns } from './runs.js';
 
 const $ = (id) => document.getElementById(id);
 
-const TABS = ["tasks", "scoreboard", "audit", "diagnostics", "knowledge", "run-detail"];
+const TABS = ["tasks", "scoreboard", "threads", "audit", "diagnostics", "knowledge", "run-detail"];
 const DIAG_SUBTABS = ["runs", "metrics", "errors"];
 const RUN_DETAIL_SUBTABS = ["steps", "events"];
 const KNOWLEDGE_SUBTABS = ["learnings", "adrs", "frictions"];

--- a/crates/orbit-dashboard/assets/dashboard/tasks.js
+++ b/crates/orbit-dashboard/assets/dashboard/tasks.js
@@ -338,9 +338,9 @@ function buildReviewThreads(threads, context) {
   const wrap = el("div", { class: "review-threads" });
   for (const thread of threads) {
     const messages = Array.isArray(thread.messages) ? thread.messages : [];
-    const location = thread.path
-      ? `${thread.path}${thread.line == null ? "" : `:${thread.line}`}`
-      : "general";
+    const location = thread.path && thread.line != null
+      ? `${thread.path}:${thread.line}`
+      : "task-level";
     const block = el("div", { class: "review-thread" });
     block.appendChild(el("div", {
       class: "review-thread-header",

--- a/crates/orbit-dashboard/src/api/mod.rs
+++ b/crates/orbit-dashboard/src/api/mod.rs
@@ -33,6 +33,7 @@ mod jobs;
 mod learnings;
 mod log;
 mod metrics;
+mod review_threads;
 mod runs;
 mod scoreboard;
 mod tasks;
@@ -367,6 +368,19 @@ pub(super) fn router() -> Router<Arc<OrbitRuntime>> {
             get(diagnostics::diagnostics_implement_one),
         )
         .route("/diagnostics/denials", get(denials::list_denials))
+        .route("/review-threads", get(review_threads::list_review_threads))
+        .route(
+            "/tasks/:id/review-threads/:thread_id/reply",
+            post(review_threads::reply_review_thread_action),
+        )
+        .route(
+            "/tasks/:id/review-threads/:thread_id/resolve",
+            post(review_threads::resolve_review_thread_action),
+        )
+        .route(
+            "/tasks/:id/review-threads/:thread_id/reopen",
+            post(review_threads::reopen_review_thread_action),
+        )
         .layer(middleware::from_fn(require_localhost_origin))
 }
 

--- a/crates/orbit-dashboard/src/api/review_threads.rs
+++ b/crates/orbit-dashboard/src/api/review_threads.rs
@@ -1,0 +1,393 @@
+//! Cross-task review-thread surface: list, reply, resolve, and re-open.
+//!
+//! The list endpoint walks all tasks and projects threads into a flat shape
+//! tagged with task id and author identity so the dashboard threads panel
+//! does not have to fan out across the per-task endpoints. Write paths
+//! delegate to the same `OrbitRuntime` methods the MCP tools use.
+
+use std::sync::Arc;
+
+use axum::extract::{Path, Query, State};
+use axum::response::{IntoResponse, Json, Response};
+use chrono::{DateTime, Utc};
+use orbit_common::types::{ReviewMessage, ReviewThread, ReviewThreadStatus, all_agent_families};
+use orbit_core::OrbitRuntime;
+use serde::Deserialize;
+use serde_json::{Value, json};
+
+use super::{bad_request, map_runtime_error, server_error, validate_id};
+
+#[derive(Deserialize, Default)]
+pub(super) struct ListQuery {
+    #[serde(default)]
+    pub(super) status: Option<String>,
+    /// `human`, `agent`, or `both`. Anything else is treated as `both`.
+    #[serde(default)]
+    pub(super) author_kind: Option<String>,
+    #[serde(default)]
+    pub(super) task_id: Option<String>,
+}
+
+#[derive(Deserialize)]
+pub(super) struct ReplyBody {
+    pub(super) body: String,
+}
+
+pub(super) async fn list_review_threads(
+    State(runtime): State<Arc<OrbitRuntime>>,
+    Query(q): Query<ListQuery>,
+) -> Response {
+    let status_filter = match parse_status_filter(q.status.as_deref()) {
+        Ok(value) => value,
+        Err(message) => return bad_request(message),
+    };
+    let author_kind = parse_author_kind(q.author_kind.as_deref());
+
+    let tasks = match q.task_id.as_deref() {
+        Some(raw) => {
+            let id = match validate_id(raw) {
+                Ok(id) => id,
+                Err(message) => return bad_request(message),
+            };
+            match runtime.get_task(id) {
+                Ok(task) => vec![task],
+                Err(e) => return map_runtime_error(e),
+            }
+        }
+        None => match runtime.list_tasks() {
+            Ok(list) => list,
+            Err(e) => return server_error(e),
+        },
+    };
+
+    let mut rows: Vec<Value> = Vec::new();
+    let mut open_count: usize = 0;
+    let mut resolved_count: usize = 0;
+    let mut human_count: usize = 0;
+    let mut agent_count: usize = 0;
+    for task in &tasks {
+        let threads = match runtime.get_task_review_threads(&task.id) {
+            Ok(t) => t,
+            Err(e) => return server_error(e),
+        };
+        for thread in threads {
+            let projection = project_thread(&task.id, task.title.as_str(), &thread);
+            match thread.status {
+                ReviewThreadStatus::Open => open_count += 1,
+                ReviewThreadStatus::Resolved => resolved_count += 1,
+            }
+            if projection.has_agent_message {
+                agent_count += 1;
+            }
+            if projection.has_human_message {
+                human_count += 1;
+            }
+            if status_filter.is_some_and(|want| thread.status != want) {
+                continue;
+            }
+            if !matches_author_kind(&projection, author_kind) {
+                continue;
+            }
+            rows.push(projection.value);
+        }
+    }
+
+    rows.sort_by(|a, b| {
+        let a_ts = a
+            .get("last_activity_at")
+            .and_then(Value::as_str)
+            .unwrap_or("");
+        let b_ts = b
+            .get("last_activity_at")
+            .and_then(Value::as_str)
+            .unwrap_or("");
+        b_ts.cmp(a_ts)
+    });
+
+    Json(json!({
+        "items": rows,
+        "stats": {
+            "open": open_count,
+            "resolved": resolved_count,
+            "total": open_count + resolved_count,
+            "agent_authored": agent_count,
+            "human_authored": human_count,
+        },
+    }))
+    .into_response()
+}
+
+pub(super) async fn reply_review_thread_action(
+    State(runtime): State<Arc<OrbitRuntime>>,
+    Path((task_id, thread_id)): Path<(String, String)>,
+    Json(body): Json<ReplyBody>,
+) -> Response {
+    let task_id = match validate_id(&task_id) {
+        Ok(id) => id,
+        Err(message) => return bad_request(message),
+    };
+    if thread_id.trim().is_empty() {
+        return bad_request("thread_id must not be empty".to_string());
+    }
+    let reply_body = body.body.trim().to_string();
+    if reply_body.is_empty() {
+        return bad_request("reply body must not be empty".to_string());
+    }
+    match runtime.reply_review_thread(task_id, &thread_id, reply_body, None, None) {
+        Ok(thread) => Json(project_thread(task_id, "", &thread).value).into_response(),
+        Err(e) => map_runtime_error(e),
+    }
+}
+
+pub(super) async fn resolve_review_thread_action(
+    State(runtime): State<Arc<OrbitRuntime>>,
+    Path((task_id, thread_id)): Path<(String, String)>,
+) -> Response {
+    let task_id = match validate_id(&task_id) {
+        Ok(id) => id,
+        Err(message) => return bad_request(message),
+    };
+    if thread_id.trim().is_empty() {
+        return bad_request("thread_id must not be empty".to_string());
+    }
+    match runtime.resolve_review_thread(task_id, &thread_id, None, None) {
+        Ok(thread) => Json(project_thread(task_id, "", &thread).value).into_response(),
+        Err(e) => map_runtime_error(e),
+    }
+}
+
+pub(super) async fn reopen_review_thread_action(
+    State(runtime): State<Arc<OrbitRuntime>>,
+    Path((task_id, thread_id)): Path<(String, String)>,
+) -> Response {
+    let task_id = match validate_id(&task_id) {
+        Ok(id) => id,
+        Err(message) => return bad_request(message),
+    };
+    if thread_id.trim().is_empty() {
+        return bad_request("thread_id must not be empty".to_string());
+    }
+    match runtime.reopen_review_thread(task_id, &thread_id, None, None) {
+        Ok(thread) => Json(project_thread(task_id, "", &thread).value).into_response(),
+        Err(e) => map_runtime_error(e),
+    }
+}
+
+#[derive(Copy, Clone, PartialEq, Eq)]
+enum AuthorKindFilter {
+    Both,
+    Human,
+    Agent,
+}
+
+fn parse_status_filter(raw: Option<&str>) -> Result<Option<ReviewThreadStatus>, String> {
+    let Some(raw) = raw.map(str::trim).filter(|value| !value.is_empty()) else {
+        return Ok(None);
+    };
+    if raw.eq_ignore_ascii_case("all") {
+        return Ok(None);
+    }
+    match raw.to_ascii_lowercase().as_str() {
+        "open" => Ok(Some(ReviewThreadStatus::Open)),
+        "resolved" => Ok(Some(ReviewThreadStatus::Resolved)),
+        other => Err(format!(
+            "status must be 'open', 'resolved', or 'all'; got '{other}'"
+        )),
+    }
+}
+
+fn parse_author_kind(raw: Option<&str>) -> AuthorKindFilter {
+    match raw.map(str::trim).map(str::to_ascii_lowercase).as_deref() {
+        Some("human") => AuthorKindFilter::Human,
+        Some("agent") => AuthorKindFilter::Agent,
+        _ => AuthorKindFilter::Both,
+    }
+}
+
+struct ThreadProjection {
+    value: Value,
+    has_agent_message: bool,
+    has_human_message: bool,
+}
+
+fn matches_author_kind(projection: &ThreadProjection, filter: AuthorKindFilter) -> bool {
+    match filter {
+        AuthorKindFilter::Both => true,
+        AuthorKindFilter::Human => projection.has_human_message,
+        AuthorKindFilter::Agent => projection.has_agent_message,
+    }
+}
+
+fn project_thread(task_id: &str, task_title: &str, thread: &ReviewThread) -> ThreadProjection {
+    let messages_json: Vec<Value> = thread
+        .messages
+        .iter()
+        .map(|message| {
+            let kind = classify_author(&message.by);
+            json!({
+                "message_id": message.message_id,
+                "at": message.at.to_rfc3339(),
+                "by": message.by,
+                "body": message.body,
+                "author_kind": kind.tag(),
+                "agent_family": kind.agent_family(),
+            })
+        })
+        .collect();
+
+    let has_agent_message = thread
+        .messages
+        .iter()
+        .any(|m| matches!(classify_author(&m.by), AuthorKind::Agent { .. }));
+    let has_human_message = thread
+        .messages
+        .iter()
+        .any(|m| matches!(classify_author(&m.by), AuthorKind::Human));
+
+    let last_message: Option<&ReviewMessage> = thread.messages.last();
+    let first_message: Option<&ReviewMessage> = thread.messages.first();
+    let last_activity_at: Option<DateTime<Utc>> = last_message.map(|m| m.at);
+    let last_kind = last_message
+        .map(|m| classify_author(&m.by))
+        .unwrap_or(AuthorKind::Human);
+    let anchor = if thread.path.is_some() && thread.line.is_some() {
+        json!({
+            "kind": "inline",
+            "path": thread.path,
+            "line": thread.line,
+        })
+    } else {
+        json!({ "kind": "task_level" })
+    };
+    let body_preview = first_message
+        .map(|m| preview_body(&m.body))
+        .unwrap_or_default();
+
+    let value = json!({
+        "task_id": task_id,
+        "task_title": task_title,
+        "thread_id": thread.thread_id,
+        "status": thread.status.to_string(),
+        "path": thread.path,
+        "line": thread.line,
+        "anchor": anchor,
+        "body_preview": body_preview,
+        "message_count": thread.messages.len(),
+        "last_activity_at": last_activity_at.map(|ts| ts.to_rfc3339()),
+        "last_author_kind": last_kind.tag(),
+        "last_author_family": last_kind.agent_family(),
+        "messages": messages_json,
+    });
+
+    ThreadProjection {
+        value,
+        has_agent_message,
+        has_human_message,
+    }
+}
+
+fn preview_body(body: &str) -> String {
+    const PREVIEW_LIMIT: usize = 160;
+    let collapsed: String = body
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+        .collect::<Vec<_>>()
+        .join(" ");
+    if collapsed.chars().count() <= PREVIEW_LIMIT {
+        collapsed
+    } else {
+        let truncated: String = collapsed.chars().take(PREVIEW_LIMIT).collect();
+        format!("{truncated}\u{2026}")
+    }
+}
+
+#[derive(Debug, Clone)]
+enum AuthorKind {
+    Human,
+    Agent { family: Option<String> },
+}
+
+impl AuthorKind {
+    fn tag(&self) -> &'static str {
+        match self {
+            AuthorKind::Human => "human",
+            AuthorKind::Agent { .. } => "agent",
+        }
+    }
+
+    fn agent_family(&self) -> Option<String> {
+        match self {
+            AuthorKind::Agent { family } => family.clone(),
+            AuthorKind::Human => None,
+        }
+    }
+}
+
+fn classify_author(label: &str) -> AuthorKind {
+    let trimmed = label.trim();
+    if trimmed.is_empty() {
+        return AuthorKind::Human;
+    }
+    let lower = trimmed.to_ascii_lowercase();
+    for family in all_agent_families() {
+        if lower == family {
+            return AuthorKind::Agent {
+                family: Some(family.to_string()),
+            };
+        }
+    }
+    if let Some(family) = orbit_common::types::infer_agent_family_from_model(trimmed) {
+        return AuthorKind::Agent {
+            family: Some(family),
+        };
+    }
+    AuthorKind::Human
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn classify_author_recognizes_known_families_and_models() {
+        assert!(matches!(
+            classify_author("claude"),
+            AuthorKind::Agent { .. }
+        ));
+        assert!(matches!(
+            classify_author("claude-opus-4-7"),
+            AuthorKind::Agent { .. }
+        ));
+        assert!(matches!(
+            classify_author("gpt-5.5"),
+            AuthorKind::Agent { .. }
+        ));
+        assert!(matches!(classify_author("daniel"), AuthorKind::Human));
+        assert!(matches!(classify_author(""), AuthorKind::Human));
+    }
+
+    #[test]
+    fn parse_status_filter_accepts_open_resolved_all() {
+        assert!(matches!(
+            parse_status_filter(Some("open")),
+            Ok(Some(ReviewThreadStatus::Open))
+        ));
+        assert!(matches!(
+            parse_status_filter(Some("resolved")),
+            Ok(Some(ReviewThreadStatus::Resolved))
+        ));
+        assert!(matches!(parse_status_filter(Some("all")), Ok(None)));
+        assert!(matches!(parse_status_filter(None), Ok(None)));
+        assert!(parse_status_filter(Some("bogus")).is_err());
+    }
+
+    #[test]
+    fn preview_body_collapses_and_truncates() {
+        assert_eq!(preview_body("hello\n\nworld"), "hello world");
+        let long: String = "a".repeat(500);
+        let preview = preview_body(&long);
+        assert!(preview.chars().count() <= 161);
+        assert!(preview.ends_with('\u{2026}'));
+    }
+}

--- a/crates/orbit-dashboard/src/api/tests/mod.rs
+++ b/crates/orbit-dashboard/src/api/tests/mod.rs
@@ -12,5 +12,6 @@ mod handlers;
 mod learnings;
 mod log;
 mod metrics;
+mod review_threads;
 mod runs;
 mod tasks;

--- a/crates/orbit-dashboard/src/api/tests/review_threads.rs
+++ b/crates/orbit-dashboard/src/api/tests/review_threads.rs
@@ -1,0 +1,264 @@
+//! Test-only allowlist (sibling test layout); mirrors learnings.rs.
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
+use std::sync::Arc;
+
+use axum::body::Body;
+use axum::http::{Method, Request, StatusCode, header};
+use orbit_core::OrbitRuntime;
+use orbit_core::command::task::TaskAddParams;
+use serde_json::Value;
+use tower::ServiceExt;
+
+use super::super::router;
+use super::test_support::body_json;
+
+fn seed_task(runtime: &OrbitRuntime) -> String {
+    runtime
+        .add_task(TaskAddParams {
+            title: "Threads panel".to_string(),
+            description: "Surface review threads in the dashboard.".to_string(),
+            workspace_path: Some(".".to_string()),
+            ..Default::default()
+        })
+        .expect("add task")
+        .id
+}
+
+async fn get(runtime: Arc<OrbitRuntime>, uri: &str) -> axum::response::Response {
+    router()
+        .with_state(runtime)
+        .oneshot(
+            Request::builder()
+                .method(Method::GET)
+                .uri(uri)
+                .body(Body::empty())
+                .expect("request"),
+        )
+        .await
+        .expect("response")
+}
+
+async fn post(
+    runtime: Arc<OrbitRuntime>,
+    uri: &str,
+    body: Option<Value>,
+) -> axum::response::Response {
+    let mut builder = Request::builder()
+        .method(Method::POST)
+        .uri(uri)
+        .header(header::ORIGIN, "http://localhost:7878");
+    let body = if let Some(value) = body {
+        builder = builder.header(header::CONTENT_TYPE, "application/json");
+        Body::from(value.to_string())
+    } else {
+        Body::empty()
+    };
+    router()
+        .with_state(runtime)
+        .oneshot(builder.body(body).expect("request"))
+        .await
+        .expect("response")
+}
+
+#[tokio::test]
+async fn list_review_threads_returns_threads_across_tasks() {
+    let runtime = OrbitRuntime::in_memory().expect("build runtime");
+    let task_id = seed_task(&runtime);
+    runtime
+        .add_review_thread(
+            &task_id,
+            "Initial agent ask.".to_string(),
+            Some("src/main.rs".to_string()),
+            Some(42),
+            Some("codex".to_string()),
+            Some("gpt-5.5".to_string()),
+        )
+        .expect("add agent thread");
+    runtime
+        .add_review_thread(
+            &task_id,
+            "Human follow-up thread.".to_string(),
+            None,
+            None,
+            None,
+            None,
+        )
+        .expect("add human thread");
+
+    let response = get(Arc::new(runtime), "/review-threads").await;
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = body_json(response).await;
+    let items = body["items"].as_array().expect("items array");
+    assert_eq!(items.len(), 2);
+
+    let agent_thread = items
+        .iter()
+        .find(|item| item["path"].as_str() == Some("src/main.rs"))
+        .expect("agent thread");
+    assert_eq!(agent_thread["last_author_kind"].as_str(), Some("agent"));
+    assert_eq!(agent_thread["status"].as_str(), Some("open"));
+    assert_eq!(agent_thread["task_id"].as_str().unwrap(), task_id);
+    assert_eq!(agent_thread["anchor"]["kind"].as_str(), Some("inline"));
+
+    let human_thread = items
+        .iter()
+        .find(|item| item["path"].is_null())
+        .expect("human thread");
+    assert_eq!(human_thread["last_author_kind"].as_str(), Some("human"));
+    assert_eq!(human_thread["anchor"]["kind"].as_str(), Some("task_level"));
+
+    let stats = &body["stats"];
+    assert_eq!(stats["open"].as_u64(), Some(2));
+    assert_eq!(stats["resolved"].as_u64(), Some(0));
+    assert_eq!(stats["agent_authored"].as_u64(), Some(1));
+    assert_eq!(stats["human_authored"].as_u64(), Some(1));
+}
+
+#[tokio::test]
+async fn list_review_threads_filters_by_status_and_author_kind() {
+    let runtime = OrbitRuntime::in_memory().expect("build runtime");
+    let task_id = seed_task(&runtime);
+    let agent_thread = runtime
+        .add_review_thread(
+            &task_id,
+            "Agent ask.".to_string(),
+            None,
+            None,
+            Some("codex".to_string()),
+            Some("gpt-5.5".to_string()),
+        )
+        .expect("add agent thread");
+    runtime
+        .add_review_thread(
+            &task_id,
+            "Human note.".to_string(),
+            None,
+            None,
+            None,
+            None,
+        )
+        .expect("add human thread");
+    runtime
+        .resolve_review_thread(&task_id, &agent_thread.thread_id, None, None)
+        .expect("resolve agent thread");
+
+    let runtime = Arc::new(runtime);
+
+    let open_only = get(runtime.clone(), "/review-threads?status=open").await;
+    let open_body = body_json(open_only).await;
+    let open_items = open_body["items"].as_array().expect("items");
+    assert_eq!(open_items.len(), 1);
+    assert_eq!(open_items[0]["last_author_kind"].as_str(), Some("human"));
+
+    let resolved_only = get(runtime.clone(), "/review-threads?status=resolved").await;
+    let resolved_body = body_json(resolved_only).await;
+    let resolved_items = resolved_body["items"].as_array().expect("items");
+    assert_eq!(resolved_items.len(), 1);
+    assert_eq!(resolved_items[0]["status"].as_str(), Some("resolved"));
+
+    let agent_only = get(runtime.clone(), "/review-threads?status=all&author_kind=agent").await;
+    let agent_body = body_json(agent_only).await;
+    let agent_items = agent_body["items"].as_array().expect("items");
+    assert_eq!(agent_items.len(), 1);
+    assert_eq!(agent_items[0]["last_author_family"].as_str(), Some("codex"));
+}
+
+#[tokio::test]
+async fn reply_resolve_reopen_review_thread_through_router() {
+    let runtime = OrbitRuntime::in_memory().expect("build runtime");
+    let task_id = seed_task(&runtime);
+    let thread = runtime
+        .add_review_thread(
+            &task_id,
+            "Agent ask.".to_string(),
+            Some("src/lib.rs".to_string()),
+            Some(7),
+            Some("codex".to_string()),
+            Some("gpt-5.5".to_string()),
+        )
+        .expect("add thread");
+    let runtime = Arc::new(runtime);
+
+    let reply_uri = format!("/tasks/{task_id}/review-threads/{}/reply", thread.thread_id);
+    let reply_resp = post(
+        runtime.clone(),
+        &reply_uri,
+        Some(serde_json::json!({"body": "Human reply"})),
+    )
+    .await;
+    assert_eq!(reply_resp.status(), StatusCode::OK);
+    let reply_body = body_json(reply_resp).await;
+    assert_eq!(reply_body["message_count"].as_u64(), Some(2));
+
+    let resolve_uri =
+        format!("/tasks/{task_id}/review-threads/{}/resolve", thread.thread_id);
+    let resolve_resp = post(runtime.clone(), &resolve_uri, None).await;
+    assert_eq!(resolve_resp.status(), StatusCode::OK);
+    let resolve_body = body_json(resolve_resp).await;
+    assert_eq!(resolve_body["status"].as_str(), Some("resolved"));
+
+    let reopen_uri = format!("/tasks/{task_id}/review-threads/{}/reopen", thread.thread_id);
+    let reopen_resp = post(runtime.clone(), &reopen_uri, None).await;
+    assert_eq!(reopen_resp.status(), StatusCode::OK);
+    let reopen_body = body_json(reopen_resp).await;
+    assert_eq!(reopen_body["status"].as_str(), Some("open"));
+}
+
+#[tokio::test]
+async fn reply_rejects_empty_body() {
+    let runtime = OrbitRuntime::in_memory().expect("build runtime");
+    let task_id = seed_task(&runtime);
+    let thread = runtime
+        .add_review_thread(
+            &task_id,
+            "Agent ask.".to_string(),
+            None,
+            None,
+            None,
+            None,
+        )
+        .expect("add thread");
+
+    let response = post(
+        Arc::new(runtime),
+        &format!("/tasks/{task_id}/review-threads/{}/reply", thread.thread_id),
+        Some(serde_json::json!({"body": "   "})),
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn cross_origin_post_is_forbidden() {
+    let runtime = OrbitRuntime::in_memory().expect("build runtime");
+    let task_id = seed_task(&runtime);
+    let thread = runtime
+        .add_review_thread(
+            &task_id,
+            "Agent ask.".to_string(),
+            None,
+            None,
+            None,
+            None,
+        )
+        .expect("add thread");
+    let runtime = Arc::new(runtime);
+
+    let response = router()
+        .with_state(runtime)
+        .oneshot(
+            Request::builder()
+                .method(Method::POST)
+                .uri(format!(
+                    "/tasks/{task_id}/review-threads/{}/resolve",
+                    thread.thread_id
+                ))
+                .header(header::ORIGIN, "http://evil.example.com")
+                .body(Body::empty())
+                .expect("request"),
+        )
+        .await
+        .expect("response");
+    assert_eq!(response.status(), StatusCode::FORBIDDEN);
+}

--- a/crates/orbit-dashboard/src/lib.rs
+++ b/crates/orbit-dashboard/src/lib.rs
@@ -40,6 +40,7 @@ const DIAGNOSTICS_JS: &str = include_str!("../assets/dashboard/diagnostics.js");
 const ROUTER_JS: &str = include_str!("../assets/dashboard/router.js");
 const RUNS_JS: &str = include_str!("../assets/dashboard/runs.js");
 const RUN_DETAIL_JS: &str = include_str!("../assets/dashboard/run-detail.js");
+const REVIEW_THREADS_JS: &str = include_str!("../assets/dashboard/review-threads.js");
 
 /// Arguments for `orbit web serve` (and the library entry point).
 #[derive(Args, Clone)]
@@ -82,6 +83,7 @@ pub fn serve(runtime: &OrbitRuntime, args: ServeArgs) -> Result<(), OrbitError> 
         .route("/static/router.js", get(serve_router_js))
         .route("/static/runs.js", get(serve_runs_js))
         .route("/static/run-detail.js", get(serve_run_detail_js))
+        .route("/static/review-threads.js", get(serve_review_threads_js))
         .route("/healthz", get(healthz))
         .nest("/api", api::router())
         .with_state(runtime);
@@ -242,6 +244,17 @@ async fn serve_run_detail_js() -> Response {
             HeaderValue::from_static("application/javascript; charset=utf-8"),
         )],
         RUN_DETAIL_JS,
+    )
+        .into_response()
+}
+
+async fn serve_review_threads_js() -> Response {
+    (
+        [(
+            header::CONTENT_TYPE,
+            HeaderValue::from_static("application/javascript; charset=utf-8"),
+        )],
+        REVIEW_THREADS_JS,
     )
         .into_response()
 }


### PR DESCRIPTION
## Task

[ORB-00274](https://orbit-cli.com/tasks/ORB-00274) — Admin dashboard: bidirectional review-thread message panel

### Description

## Problem

Orbit review-threads are addressable via CLI and MCP today, but the admin dashboard has no first-class surface for them. With async steering moving onto threads (see linked task [ORB-00273](.orbit/tasks/ORB-00273/)), humans need a place in the dashboard to:

1. See all open threads across active tasks at a glance.
2. Author or reply to threads without dropping to the CLI.
3. Get a notification when an agent opens a thread asking for human input.

The thread substrate and storage are unchanged. This task is read/write UI plus a notification path on top of existing data.

## Why It Matters

- Closes the loop on bidirectional async steering: hooks surface asks to agents ([ORB-00273](.orbit/tasks/ORB-00273/)); dashboard surfaces asks to humans (this task).
- Agent-opened threads ("intent unclear at <file:line>, defaulting to X") have zero value if the human never sees them. A notification path is the minimum viable signal.
- Mirrors what reviewers already expect from code-review UIs — same mental model, no retraining.

## Scope

1. **Threads panel** in the dashboard, surfaced as a top-level section or per-task tab (whichever fits existing layout). For each thread list: task ID, author identity (human vs. agent + agent family from `ReviewMessage`), `file:line` anchor or `task-level` marker, body preview, reply count, last-activity timestamp.
2. **Reply + resolve/re-open controls** inline. Reply textbox, resolve button, re-open button when status is resolved.
3. **Filters** by status (open / resolved / all) and by author kind (human / agent / both).
4. **Notification path** for new agent-authored threads: surface a count badge on the threads section, and use whatever cross-cutting notification surface the dashboard already has — inspect [`crates/orbit-dashboard/assets/dashboard/`](crates/orbit-dashboard/assets/dashboard/) for precedent before inventing one.
5. **Backend endpoints** in [`crates/orbit-dashboard/src/api/tasks.rs`](crates/orbit-dashboard/src/api/tasks.rs) (or a new sibling module if size warrants) for list/reply/resolve/re-open. Projections in [`crates/orbit-dashboard/src/projections.rs`](crates/orbit-dashboard/src/projections.rs) extended only if needed.
6. **Frontend wiring** in [`crates/orbit-dashboard/assets/dashboard/`](crates/orbit-dashboard/assets/dashboard/). [`tasks.js:332`](crates/orbit-dashboard/assets/dashboard/tasks.js) already has a `reviewThreadStatus(thread)` helper — extend or build a sibling module following existing patterns.

## Constraints / Notes

- Read [`app.js`](crates/orbit-dashboard/assets/dashboard/app.js), [`router.js`](crates/orbit-dashboard/assets/dashboard/router.js), and [`tasks.js`](crates/orbit-dashboard/assets/dashboard/tasks.js) before writing UI — follow the existing routing and rendering style. Do **not** introduce a new frontend framework.
- The write path is the existing `orbit.review-thread.*` toolset. The backend route handlers should call through the core surface at [`crates/orbit-core/src/command/task/review.rs`](crates/orbit-core/src/command/task/review.rs), not duplicate logic.
- The anchorless / task-level variant being added in [ORB-00273](.orbit/tasks/ORB-00273/) must render correctly here. Coordinate so this task can stub the variant until ORB-00273 lands, or sequence behind it.
- Per [`CLAUDE.md`](CLAUDE.md): `tracing` only for backend diagnostics; no `print!`/`eprint!`.
- This and [ORB-00273](.orbit/tasks/ORB-00273/) together implement "async bidirectional steering via review-threads". Link both via `related_to`.

### Acceptance Criteria

- Running the dashboard (`cargo run -p orbit-dashboard` or the existing run target) renders a threads panel listing all open threads across tasks, with the columns named in the scope section.
- Posting a reply via the dashboard reply control adds the reply to the thread, observable via `orbit tool run orbit.review-thread.list --input '{"task_id":"<id>"}'` showing the new message.
- Resolving a thread via the dashboard sets `ReviewThreadStatus::Resolved`, observable via the same `orbit.review-thread.list` JSON.
- Re-opening a resolved thread via the dashboard sets status back to open, observable via `orbit.review-thread.list`.
- A thread created via `orbit tool run orbit.review-thread.add` with an agent model appears in the dashboard within the standard refresh interval, rendered with author identity `agent (<family>)`.
- Notification path: count badge on the threads section reflects unread agent-authored threads. Verify by adding one and observing the badge increment in the running dashboard.
- Filter by status (open/resolved/all) and filter by author kind (human/agent/both) correctly narrow the rendered list — verify each combination by toggling and counting rendered rows against the underlying `orbit.review-thread.list` output.
- Task-level (anchorless) threads render with a `task-level` marker, not a malformed `file:line` stub.
- Backend endpoints return JSON shapes consumed by the frontend without ad-hoc shaping in JS — projections do any required reshaping.
- `make ci-fast` passes; the dashboard build (`cargo build -p orbit-dashboard`) succeeds; loading the dashboard in a browser yields no console errors on the threads panel.

## Execution Summary

<details>
<summary>Click to expand</summary>

Implementation of bidirectional review-thread dashboard panel.

Backend (orbit-core):
- Added `OrbitRuntime::reopen_review_thread`, factoring shared status-toggle logic into a private helper alongside `resolve_review_thread`.

Backend (orbit-dashboard):
- New `crates/orbit-dashboard/src/api/review_threads.rs` module exposing:
  - `GET  /api/review-threads` — cross-task projection with `status` (open/resolved/all), `author_kind` (human/agent/both), and optional `task_id` filters; rows include task_id/title, author kind + agent family, anchor (inline vs task_level), body preview, message count, last_activity_at, last_author_kind/family, full messages, and aggregate `stats`.
  - `POST /api/tasks/:id/review-threads/:thread_id/reply`
  - `POST /api/tasks/:id/review-threads/:thread_id/resolve`
  - `POST /api/tasks/:id/review-threads/:thread_id/reopen`
- Author classification uses `all_agent_families()` + `infer_agent_family_from_model()` so model strings (e.g. `claude-opus-4-7`, `gpt-5.5`, `grok-4`) tag as `agent`, with a derived family. Anchorless threads serialize as `{ anchor: { kind: "task_level" } }`.
- Unit tests cover author classification, status-filter parsing, and preview body truncation.

Frontend (assets/dashboard):
- New `review-threads.js` module: list with columns (task, author, location, preview, msgs, status, updated), inline expand to show all messages + reply textarea + resolve/re-open buttons, status filters (open/resolved/all), author-kind filters (both/human/agent).
- New top-level `Threads` tab in `index.html`; registered in router `TABS`. Tab badge (`#threads-unread-badge`) tracks agent-authored threads not yet seen via `localStorage`; cleared once the user lands on the Threads tab and a refresh completes.
- Review-thread fetch joins the always-on refresh cycle so the badge updates from any tab.
- Fixed existing per-task review-thread renderer in `tasks.js` to render `task-level` (instead of the previous malformed `path|general` fallback) when an anchor is missing.
- CSS additions for `.tab-badge`, threads grid layout, filter row, expanded detail.

Validation:
- `make ci-fast` passes.
- `cargo build -p orbit-dashboard` succeeds.
- `cargo test -p orbit-dashboard --lib review_threads` (3 tests pass).
- `cargo test -p orbit-core --lib review` (24 tests pass).

Notes:
- Did not exercise the dashboard in a live browser per envelope rules; manual browser smoke-test of badge/filters remains for the review step.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-00274-6a113a42`
- Behind base: 0
- Ahead of base: 1