### PR TITLE
Admin dashboard: bidirectional review-thread message panel

### DIFF
--- a/crates/orbit-dashboard/src/api/tests/review_threads.rs
+++ b/crates/orbit-dashboard/src/api/tests/review_threads.rs
@@ -5,6 +5,7 @@ use std::sync::Arc;
 
 use axum::body::Body;
 use axum::http::{Method, Request, StatusCode, header};
+use orbit_core::ActorIdentity;
 use orbit_core::OrbitRuntime;
 use orbit_core::command::task::TaskAddParams;
 use serde_json::Value;
@@ -12,6 +13,15 @@ use tower::ServiceExt;
 
 use super::super::router;
 use super::test_support::body_json;
+
+fn human_runtime() -> OrbitRuntime {
+    // Force a human actor so threads created without an explicit model land
+    // with `by="human"`. Without this, ambient `ORBIT_AGENT_MODEL` env vars
+    // (e.g., from CI) leak in and break author-kind assertions.
+    OrbitRuntime::in_memory()
+        .expect("build runtime")
+        .with_actor(ActorIdentity::human("human"))
+}
 
 fn seed_task(runtime: &OrbitRuntime) -> String {
     runtime
@@ -63,7 +73,7 @@ async fn post(
 
 #[tokio::test]
 async fn list_review_threads_returns_threads_across_tasks() {
-    let runtime = OrbitRuntime::in_memory().expect("build runtime");
+    let runtime = human_runtime();
     let task_id = seed_task(&runtime);
     runtime
         .add_review_thread(
@@ -117,7 +127,7 @@ async fn list_review_threads_returns_threads_across_tasks() {
 
 #[tokio::test]
 async fn list_review_threads_filters_by_status_and_author_kind() {
-    let runtime = OrbitRuntime::in_memory().expect("build runtime");
+    let runtime = human_runtime();
     let task_id = seed_task(&runtime);
     let agent_thread = runtime
         .add_review_thread(
@@ -130,14 +140,7 @@ async fn list_review_threads_filters_by_status_and_author_kind() {
         )
         .expect("add agent thread");
     runtime
-        .add_review_thread(
-            &task_id,
-            "Human note.".to_string(),
-            None,
-            None,
-            None,
-            None,
-        )
+        .add_review_thread(&task_id, "Human note.".to_string(), None, None, None, None)
         .expect("add human thread");
     runtime
         .resolve_review_thread(&task_id, &agent_thread.thread_id, None, None)
@@ -157,7 +160,11 @@ async fn list_review_threads_filters_by_status_and_author_kind() {
     assert_eq!(resolved_items.len(), 1);
     assert_eq!(resolved_items[0]["status"].as_str(), Some("resolved"));
 
-    let agent_only = get(runtime.clone(), "/review-threads?status=all&author_kind=agent").await;
+    let agent_only = get(
+        runtime.clone(),
+        "/review-threads?status=all&author_kind=agent",
+    )
+    .await;
     let agent_body = body_json(agent_only).await;
     let agent_items = agent_body["items"].as_array().expect("items");
     assert_eq!(agent_items.len(), 1);
@@ -166,7 +173,7 @@ async fn list_review_threads_filters_by_status_and_author_kind() {
 
 #[tokio::test]
 async fn reply_resolve_reopen_review_thread_through_router() {
-    let runtime = OrbitRuntime::in_memory().expect("build runtime");
+    let runtime = human_runtime();
     let task_id = seed_task(&runtime);
     let thread = runtime
         .add_review_thread(
@@ -191,14 +198,19 @@ async fn reply_resolve_reopen_review_thread_through_router() {
     let reply_body = body_json(reply_resp).await;
     assert_eq!(reply_body["message_count"].as_u64(), Some(2));
 
-    let resolve_uri =
-        format!("/tasks/{task_id}/review-threads/{}/resolve", thread.thread_id);
+    let resolve_uri = format!(
+        "/tasks/{task_id}/review-threads/{}/resolve",
+        thread.thread_id
+    );
     let resolve_resp = post(runtime.clone(), &resolve_uri, None).await;
     assert_eq!(resolve_resp.status(), StatusCode::OK);
     let resolve_body = body_json(resolve_resp).await;
     assert_eq!(resolve_body["status"].as_str(), Some("resolved"));
 
-    let reopen_uri = format!("/tasks/{task_id}/review-threads/{}/reopen", thread.thread_id);
+    let reopen_uri = format!(
+        "/tasks/{task_id}/review-threads/{}/reopen",
+        thread.thread_id
+    );
     let reopen_resp = post(runtime.clone(), &reopen_uri, None).await;
     assert_eq!(reopen_resp.status(), StatusCode::OK);
     let reopen_body = body_json(reopen_resp).await;
@@ -207,17 +219,10 @@ async fn reply_resolve_reopen_review_thread_through_router() {
 
 #[tokio::test]
 async fn reply_rejects_empty_body() {
-    let runtime = OrbitRuntime::in_memory().expect("build runtime");
+    let runtime = human_runtime();
     let task_id = seed_task(&runtime);
     let thread = runtime
-        .add_review_thread(
-            &task_id,
-            "Agent ask.".to_string(),
-            None,
-            None,
-            None,
-            None,
-        )
+        .add_review_thread(&task_id, "Agent ask.".to_string(), None, None, None, None)
         .expect("add thread");
 
     let response = post(
@@ -231,17 +236,10 @@ async fn reply_rejects_empty_body() {
 
 #[tokio::test]
 async fn cross_origin_post_is_forbidden() {
-    let runtime = OrbitRuntime::in_memory().expect("build runtime");
+    let runtime = human_runtime();
     let task_id = seed_task(&runtime);
     let thread = runtime
-        .add_review_thread(
-            &task_id,
-            "Agent ask.".to_string(),
-            None,
-            None,
-            None,
-            None,
-        )
+        .add_review_thread(&task_id, "Agent ask.".to_string(), None, None, None, None)
         .expect("add thread");
     let runtime = Arc::new(runtime);
 


### PR DESCRIPTION
## Task

[ORB-00274](https://orbit-cli.com/tasks/ORB-00274) — Admin dashboard: bidirectional review-thread message panel

### Description

## Problem

Orbit review-threads are addressable via CLI and MCP today, but the admin dashboard has no first-class surface for them. With async steering moving onto threads (see linked task [ORB-00273](.orbit/tasks/ORB-00273/)), humans need a place in the dashboard to:

1. See all open threads across active tasks at a glance.
2. Author or reply to threads without dropping to the CLI.
3. Get a notification when an agent opens a thread asking for human input.

The thread substrate and storage are unchanged. This task is read/write UI plus a notification path on top of existing data.

## Why It Matters

- Closes the loop on bidirectional async steering: hooks surface asks to agents ([ORB-00273](.orbit/tasks/ORB-00273/)); dashboard surfaces asks to humans (this task).
- Agent-opened threads ("intent unclear at <file:line>, defaulting to X") have zero value if the human never sees them. A notification path is the minimum viable signal.
- Mirrors what reviewers already expect from code-review UIs — same mental model, no retraining.

## Scope

1. **Threads panel** in the dashboard, surfaced as a top-level section or per-task tab (whichever fits existing layout). For each thread list: task ID, author identity (human vs. agent + agent family from `ReviewMessage`), `file:line` anchor or `task-level` marker, body preview, reply count, last-activity timestamp.
2. **Reply + resolve/re-open controls** inline. Reply textbox, resolve button, re-open button when status is resolved.
3. **Filters** by status (open / resolved / all) and by author kind (human / agent / both).
4. **Notification path** for new agent-authored threads: surface a count badge on the threads section, and use whatever cross-cutting notification surface the dashboard already has — inspect [`crates/orbit-dashboard/assets/dashboard/`](crates/orbit-dashboard/assets/dashboard/) for precedent before inventing one.
5. **Backend endpoints** in [`crates/orbit-dashboard/src/api/tasks.rs`](crates/orbit-dashboard/src/api/tasks.rs) (or a new sibling module if size warrants) for list/reply/resolve/re-open. Projections in [`crates/orbit-dashboard/src/projections.rs`](crates/orbit-dashboard/src/projections.rs) extended only if needed.
6. **Frontend wiring** in [`crates/orbit-dashboard/assets/dashboard/`](crates/orbit-dashboard/assets/dashboard/). [`tasks.js:332`](crates/orbit-dashboard/assets/dashboard/tasks.js) already has a `reviewThreadStatus(thread)` helper — extend or build a sibling module following existing patterns.

## Constraints / Notes

- Read [`app.js`](crates/orbit-dashboard/assets/dashboard/app.js), [`router.js`](crates/orbit-dashboard/assets/dashboard/router.js), and [`tasks.js`](crates/orbit-dashboard/assets/dashboard/tasks.js) before writing UI — follow the existing routing and rendering style. Do **not** introduce a new frontend framework.
- The write path is the existing `orbit.review-thread.*` toolset. The backend route handlers should call through the core surface at [`crates/orbit-core/src/command/task/review.rs`](crates/orbit-core/src/command/task/review.rs), not duplicate logic.
- The anchorless / task-level variant being added in [ORB-00273](.orbit/tasks/ORB-00273/) must render correctly here. Coordinate so this task can stub the variant until ORB-00273 lands, or sequence behind it.
- Per [`CLAUDE.md`](CLAUDE.md): `tracing` only for backend diagnostics; no `print!`/`eprint!`.
- This and [ORB-00273](.orbit/tasks/ORB-00273/) together implement "async bidirectional steering via review-threads". Link both via `related_to`.

### Acceptance Criteria

- Running the dashboard (`cargo run -p orbit-dashboard` or the existing run target) renders a threads panel listing all open threads across tasks, with the columns named in the scope section.
- Posting a reply via the dashboard reply control adds the reply to the thread, observable via `orbit tool run orbit.review-thread.list --input '{"task_id":"<id>"}'` showing the new message.
- Resolving a thread via the dashboard sets `ReviewThreadStatus::Resolved`, observable via the same `orbit.review-thread.list` JSON.
- Re-opening a resolved thread via the dashboard sets status back to open, observable via `orbit.review-thread.list`.
- A thread created via `orbit tool run orbit.review-thread.add` with an agent model appears in the dashboard within the standard refresh interval, rendered with author identity `agent (<family>)`.
- Notification path: count badge on the threads section reflects unread agent-authored threads. Verify by adding one and observing the badge increment in the running dashboard.
- Filter by status (open/resolved/all) and filter by author kind (human/agent/both) correctly narrow the rendered list — verify each combination by toggling and counting rendered rows against the underlying `orbit.review-thread.list` output.
- Task-level (anchorless) threads render with a `task-level` marker, not a malformed `file:line` stub.
- Backend endpoints return JSON shapes consumed by the frontend without ad-hoc shaping in JS — projections do any required reshaping.
- `make ci-fast` passes; the dashboard build (`cargo build -p orbit-dashboard`) succeeds; loading the dashboard in a browser yields no console errors on the threads panel.

## Execution Summary

<details>
<summary>Click to expand</summary>

Implementation of bidirectional review-thread dashboard panel.

Backend (orbit-core):
- Added `OrbitRuntime::reopen_review_thread`, factoring shared status-toggle logic into a private helper alongside `resolve_review_thread`.

Backend (orbit-dashboard):
- New `crates/orbit-dashboard/src/api/review_threads.rs` module exposing:
  - `GET  /api/review-threads` — cross-task projection with `status` (open/resolved/all), `author_kind` (human/agent/both), and optional `task_id` filters; rows include task_id/title, author kind + agent family, anchor (inline vs task_level), body preview, message count, last_activity_at, last_author_kind/family, full messages, and aggregate `stats`.
  - `POST /api/tasks/:id/review-threads/:thread_id/reply`
  - `POST /api/tasks/:id/review-threads/:thread_id/resolve`
  - `POST /api/tasks/:id/review-threads/:thread_id/reopen`
- Author classification uses `all_agent_families()` + `infer_agent_family_from_model()` so model strings (e.g. `claude-opus-4-7`, `gpt-5.5`, `grok-4`) tag as `agent`, with a derived family. Anchorless threads serialize as `{ anchor: { kind: "task_level" } }`.
- Unit tests cover author classification, status-filter parsing, and preview body truncation.

Frontend (assets/dashboard):
- New `review-threads.js` module: list with columns (task, author, location, preview, msgs, status, updated), inline expand to show all messages + reply textarea + resolve/re-open buttons, status filters (open/resolved/all), author-kind filters (both/human/agent).
- New top-level `Threads` tab in `index.html`; registered in router `TABS`. Tab badge (`#threads-unread-badge`) tracks agent-authored threads not yet seen via `localStorage`; cleared once the user lands on the Threads tab and a refresh completes.
- Review-thread fetch joins the always-on refresh cycle so the badge updates from any tab.
- Fixed existing per-task review-thread renderer in `tasks.js` to render `task-level` (instead of the previous malformed `path|general` fallback) when an anchor is missing.
- CSS additions for `.tab-badge`, threads grid layout, filter row, expanded detail.

Validation:
- `make ci-fast` passes.
- `cargo build -p orbit-dashboard` succeeds.
- `cargo test -p orbit-dashboard --lib review_threads` (3 tests pass).
- `cargo test -p orbit-core --lib review` (24 tests pass).

Notes:
- Did not exercise the dashboard in a live browser per envelope rules; manual browser smoke-test of badge/filters remains for the review step.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-00274-6a113a42`
- Behind base: 0
- Ahead of base: 1

*authored by: claude*