### PR TITLE
Re-expose 6 over-hidden tools from MCP_HIDDEN_TOOL_NAMES (correction to ORB-00272)

### DIFF
--- a/crates/orbit-cli/src/command/mcp/mod.rs
+++ b/crates/orbit-cli/src/command/mcp/mod.rs
@@ -117,11 +117,6 @@ pub(crate) const MCP_HIDDEN_TOOL_NAMES: &[&str] = &[
     "orbit.learning.sync",
     "orbit.learning.list",
     "orbit.friction.stats",
-    "orbit.friction.resolve",
-    "orbit.friction.show",
-    "orbit.friction.tags",
-    "orbit.friction.update",
-    "orbit.friction.list",
 ];
 
 pub(crate) fn safe_mcp_tool_names() -> Vec<&'static str> {

--- a/crates/orbit-cli/src/command/mcp/tests/mod.rs
+++ b/crates/orbit-cli/src/command/mcp/tests/mod.rs
@@ -13,6 +13,32 @@ use super::{
     is_mcp_tool_exposed, safe_mcp_tool_names,
 };
 
+const EXPECTED_MCP_HIDDEN_TOOL_NAMES: &[&str] = &[
+    "orbit.docs.index",
+    "orbit.docs.migrate",
+    "orbit.docs.add",
+    "orbit.docs.list",
+    "orbit.docs.show",
+    "orbit.task.locks",
+    "orbit.task.locks.release",
+    "orbit.task.locks.reserve",
+    "orbit.semantic.index",
+    "orbit.semantic.install",
+    "orbit.semantic.stats",
+    "orbit.graph.history",
+    "orbit.learning.sync",
+    "orbit.learning.list",
+    "orbit.friction.stats",
+];
+
+const REEXPOSED_FRICTION_TOOL_NAMES: &[&str] = &[
+    "orbit.friction.list",
+    "orbit.friction.resolve",
+    "orbit.friction.show",
+    "orbit.friction.tags",
+    "orbit.friction.update",
+];
+
 const REQUIRED_AGENT_FACING_TOOL_NAMES: &[&str] = &[
     "orbit.search",
     "orbit.task.add",
@@ -35,6 +61,11 @@ const REQUIRED_AGENT_FACING_TOOL_NAMES: &[&str] = &[
     "orbit.learning.comment.add",
     "orbit.learning.comment.list",
     "orbit.friction.add",
+    "orbit.friction.list",
+    "orbit.friction.resolve",
+    "orbit.friction.show",
+    "orbit.friction.tags",
+    "orbit.friction.update",
 ];
 
 fn is_runtime_mcp_category_tool(name: &str) -> bool {
@@ -45,6 +76,23 @@ fn is_runtime_mcp_category_tool(name: &str) -> bool {
         || name.starts_with("orbit.semantic.")
         || name.starts_with("orbit.docs.")
         || name.starts_with("orbit.learning.")
+}
+
+#[test]
+fn mcp_hidden_denylist_matches_intended_ops_surface() {
+    assert_eq!(MCP_HIDDEN_TOOL_NAMES.len(), 15);
+    assert_eq!(MCP_HIDDEN_TOOL_NAMES, EXPECTED_MCP_HIDDEN_TOOL_NAMES);
+
+    for name in REEXPOSED_FRICTION_TOOL_NAMES {
+        assert!(
+            !MCP_HIDDEN_TOOL_NAMES.contains(name),
+            "agent-facing friction workflow should be visible over MCP: {name}"
+        );
+    }
+    assert!(
+        MCP_HIDDEN_TOOL_NAMES.contains(&"orbit.learning.list"),
+        "orbit.learning.list remains hidden; use orbit.search --kind learning for agent discovery"
+    );
 }
 
 #[test]
@@ -291,6 +339,14 @@ mod audited_mcp_call_tests {
             value.get("results").is_some(),
             "orbit.search returns wrapped results"
         );
+    }
+
+    #[test]
+    fn friction_list_is_exposed_to_mcp_dispatch() {
+        let runtime = OrbitRuntime::in_memory().expect("build test runtime");
+        let value = audited_mcp_call(&runtime, "orbit.friction.list", json!({ "limit": 1 }))
+            .expect("orbit.friction.list dispatch ok");
+        assert!(value.is_array(), "orbit.friction.list returns JSON array");
     }
 
     #[test]

--- a/crates/orbit-dashboard/src/api/tests/review_threads.rs
+++ b/crates/orbit-dashboard/src/api/tests/review_threads.rs
@@ -130,14 +130,7 @@ async fn list_review_threads_filters_by_status_and_author_kind() {
         )
         .expect("add agent thread");
     runtime
-        .add_review_thread(
-            &task_id,
-            "Human note.".to_string(),
-            None,
-            None,
-            None,
-            None,
-        )
+        .add_review_thread(&task_id, "Human note.".to_string(), None, None, None, None)
         .expect("add human thread");
     runtime
         .resolve_review_thread(&task_id, &agent_thread.thread_id, None, None)
@@ -157,7 +150,11 @@ async fn list_review_threads_filters_by_status_and_author_kind() {
     assert_eq!(resolved_items.len(), 1);
     assert_eq!(resolved_items[0]["status"].as_str(), Some("resolved"));
 
-    let agent_only = get(runtime.clone(), "/review-threads?status=all&author_kind=agent").await;
+    let agent_only = get(
+        runtime.clone(),
+        "/review-threads?status=all&author_kind=agent",
+    )
+    .await;
     let agent_body = body_json(agent_only).await;
     let agent_items = agent_body["items"].as_array().expect("items");
     assert_eq!(agent_items.len(), 1);
@@ -191,14 +188,19 @@ async fn reply_resolve_reopen_review_thread_through_router() {
     let reply_body = body_json(reply_resp).await;
     assert_eq!(reply_body["message_count"].as_u64(), Some(2));
 
-    let resolve_uri =
-        format!("/tasks/{task_id}/review-threads/{}/resolve", thread.thread_id);
+    let resolve_uri = format!(
+        "/tasks/{task_id}/review-threads/{}/resolve",
+        thread.thread_id
+    );
     let resolve_resp = post(runtime.clone(), &resolve_uri, None).await;
     assert_eq!(resolve_resp.status(), StatusCode::OK);
     let resolve_body = body_json(resolve_resp).await;
     assert_eq!(resolve_body["status"].as_str(), Some("resolved"));
 
-    let reopen_uri = format!("/tasks/{task_id}/review-threads/{}/reopen", thread.thread_id);
+    let reopen_uri = format!(
+        "/tasks/{task_id}/review-threads/{}/reopen",
+        thread.thread_id
+    );
     let reopen_resp = post(runtime.clone(), &reopen_uri, None).await;
     assert_eq!(reopen_resp.status(), StatusCode::OK);
     let reopen_body = body_json(reopen_resp).await;
@@ -210,14 +212,7 @@ async fn reply_rejects_empty_body() {
     let runtime = OrbitRuntime::in_memory().expect("build runtime");
     let task_id = seed_task(&runtime);
     let thread = runtime
-        .add_review_thread(
-            &task_id,
-            "Agent ask.".to_string(),
-            None,
-            None,
-            None,
-            None,
-        )
+        .add_review_thread(&task_id, "Agent ask.".to_string(), None, None, None, None)
         .expect("add thread");
 
     let response = post(
@@ -234,14 +229,7 @@ async fn cross_origin_post_is_forbidden() {
     let runtime = OrbitRuntime::in_memory().expect("build runtime");
     let task_id = seed_task(&runtime);
     let thread = runtime
-        .add_review_thread(
-            &task_id,
-            "Agent ask.".to_string(),
-            None,
-            None,
-            None,
-            None,
-        )
+        .add_review_thread(&task_id, "Agent ask.".to_string(), None, None, None, None)
         .expect("add thread");
     let runtime = Arc::new(runtime);
 


### PR DESCRIPTION
## Task

[ORB-00278](https://orbit-cli.com/tasks/ORB-00278) — Re-expose 6 over-hidden tools from MCP_HIDDEN_TOOL_NAMES (correction to ORB-00272)

### Description

## Problem

ORB-00272 hid 20 ops/maintenance tools from the MCP-advertised catalog via a centralized `MCP_HIDDEN_TOOL_NAMES` denylist in `crates/orbit-cli/src/command/mcp/mod.rs:104`. On review, the scope was over-broad: **5 of those 20 tools are legitimate agent-facing workflows** and should remain visible.

Narrow the denylist to the intended 15 tools. The mechanism, tests, and structure from ORB-00272 stay — only the denylist contents shrink.

## Tools to re-expose (5)

```
orbit.friction.list
orbit.friction.resolve
orbit.friction.show
orbit.friction.tags
orbit.friction.update
```

## Tools that stay hidden (15, expanded from ORB-00272's intent)

```
orbit.docs.index
orbit.docs.migrate
orbit.docs.add
orbit.docs.list
orbit.docs.show
orbit.task.locks
orbit.task.locks.release
orbit.task.locks.reserve
orbit.semantic.index
orbit.semantic.install
orbit.semantic.stats
orbit.graph.history
orbit.learning.sync
orbit.learning.list
orbit.friction.stats
```

## Why It Matters

The 5 re-exposed tools cover active agent workflows that the over-broad hide breaks:

- **`friction.list` / `.show`** — Agents browse open friction (e.g. before reporting a duplicate, or when triaging during execution).
- **`friction.update`** — Agents update triage metadata (severity, tags, status) on friction they previously added.
- **`friction.resolve`** — Agents mark a friction resolved when the work that fixed it lands. Per `orbit-create-task` SKILL, this is the canonical resolve path when not using a `resolves` task relation.
- **`friction.tags`** — Agents fetch the taxonomy before adding/updating to use the right tag.

## Why `learning.list` stays hidden

Learning discovery for agents goes through `orbit.search --kind learning <query>` (with optional `--hybrid` for lexical + cosine ranking). Raw `list` only adds "show all learnings without a query" — a human/admin browse pattern, not an agent need. Agents should find learnings *by relevance to current work*, which is exactly what `orbit.search` provides.

## Mechanism

Mechanical edit. In `crates/orbit-cli/src/command/mcp/mod.rs:104`, remove these 5 entries from the `MCP_HIDDEN_TOOL_NAMES` const array:

```rust
"orbit.friction.list",
"orbit.friction.resolve",
"orbit.friction.show",
"orbit.friction.tags",
"orbit.friction.update",
```

Leave `"orbit.learning.list"` in the denylist.

Update the test in `crates/orbit-cli/src/command/mcp/tests/mod.rs` that asserts the denylist contents — the expected count drops from 20 to 15.

No ADR needed — this is a scope correction within the same mechanism, not a design change.

## Constraints / Notes

- Don't touch `agent_facing` flag, registry tagging, or anything in `orbit-tools` / `orbit-mcp`. The denylist is the only edit point.
- Confirm the test guard at `crates/orbit-tools/tests/public_tool_surface.rs` doesn't need a parallel change — it likely asserts presence in the registry (which is unchanged) rather than presence on the MCP surface (which expands by 5).
- Downstream cleanup (out of scope): `.claude/settings.json` deny list can drop the 5 re-exposed entries in a separate config-only PR.

### Acceptance Criteria

- After change, `MCP_HIDDEN_TOOL_NAMES` in `crates/orbit-cli/src/command/mcp/mod.rs` contains exactly 15 entries: `orbit.docs.index`, `orbit.docs.migrate`, `orbit.docs.add`, `orbit.docs.list`, `orbit.docs.show`, `orbit.task.locks`, `orbit.task.locks.release`, `orbit.task.locks.reserve`, `orbit.semantic.index`, `orbit.semantic.install`, `orbit.semantic.stats`, `orbit.graph.history`, `orbit.learning.sync`, `orbit.learning.list`, `orbit.friction.stats`.
- A fresh MCP client connected to `orbit mcp serve` issuing `tools/list` DOES include all 5 re-exposed tools (`orbit.friction.list`, `orbit.friction.resolve`, `orbit.friction.show`, `orbit.friction.tags`, `orbit.friction.update`).
- The MCP client `tools/list` response continues to NOT include any of the 15 hidden tools listed above. Specifically verify `orbit.learning.list` remains absent.
- Tests in `crates/orbit-cli/src/command/mcp/tests/mod.rs` that reference `MCP_HIDDEN_TOOL_NAMES` or `safe_mcp_tool_names` are updated to reflect the 15-entry denylist and the corresponding agent surface; all tests pass.
- Each of the 5 re-exposed tools is callable via MCP: confirm via a single live `tools/call` to `orbit.friction.list` returning structured JSON.
- `make ci-fast` passes on the PR branch.
- PR description names the 5 tools re-exposed (and `orbit.learning.list` as intentionally still hidden because `orbit.search --kind learning` covers the access pattern) and links back to ORB-00272.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Narrowed `MCP_HIDDEN_TOOL_NAMES` from 20 entries to the intended 15 by re-exposing `orbit.friction.list`, `orbit.friction.resolve`, `orbit.friction.show`, `orbit.friction.tags`, and `orbit.friction.update` while keeping `orbit.learning.list` hidden.
- Updated MCP denylist/safe-surface tests to assert the exact 15 hidden tools, require the five friction workflow tools on the agent-visible surface, and verify `orbit.friction.list` dispatches successfully through the MCP path.
- Confirmed the `orbit-tools` public registry guard remains a registration check and needs no semantic change; included only rustfmt-required formatting in `crates/orbit-dashboard/src/api/tests/review_threads.rs` so `make ci-fast` passes.

Validation:
- `cargo test -p orbit-cli command::mcp::tests -- --nocapture`
- Live MCP smoke with fresh `orbit mcp serve`: `tools/list` exposed the five friction tools, hid all 15 denylisted tools including `orbit.learning.list`, and `tools/call` to `orbit.friction.list` returned structured JSON.
- `cargo test -p orbit-tools --test public_tool_surface -- --nocapture`
- `make ci-fast`

PR description note:
- Name the five re-exposed tools above, mention `orbit.learning.list` remains intentionally hidden because `orbit.search --kind learning` covers agent learning discovery, and link back to ORB-00272.

Assessment: Low-risk scoped correction to the existing MCP denylist mechanism, with runtime-style MCP coverage added for the re-exposed friction list workflow.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-00278-6a113cf1`
- Behind base: 0
- Ahead of base: 1