### PR TITLE
Mark 15 ops/maintenance tools inactive in the registry and scrub references from README + agent skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,16 +201,22 @@ Two install surfaces. The CLI gives you the full power of Orbit. Choose the plug
 `orbit workspace init --mcp` registers the Orbit MCP server with the local agent CLI (Claude Code, Codex, Gemini), same as plugin. Expand below to see the full tool surface.
 
 <details>
-<summary><strong>Full tool reference</strong> — task, review, graph, search, semantic, adr, design, learning, friction (click to expand)
+<summary><strong>Full tool reference</strong> — task, review, graph, search, semantic, adr, learning, friction (click to expand)
 </summary>
+
+Agents discover project docs through `orbit.search`; docs, lock, semantic setup/index/status, graph history, learning sync/list, and friction stats operations are CLI-only admin/setup workflows.
 
 | Namespace | Tool | Purpose |
 |---|---|---|
 | **task** | `orbit.task.add` | Create a new task |
+| | `orbit.task.approve` | Approve a proposed or reviewed task |
+| | `orbit.task.reject` | Reject a proposed or reviewed task |
 | | `orbit.task.update` | Mutate task fields (status, plan, acceptance criteria) |
 | | `orbit.task.show` | Fetch full task detail |
 | | `orbit.task.list` | List tasks filtered by status / scope / `path` |
 | | `orbit.task.start` | Transition into in-progress |
+| | `orbit.task.delete` | Delete a task when explicitly allowed |
+| | `orbit.task.lint` | Validate task metadata |
 | | `orbit.task.artifact.put` | Attach a generated artifact to a task |
 | **review** | `orbit.task.review_thread.add` | Open a review thread on a task |
 | | `orbit.task.review_thread.list` | List review threads on a task |
@@ -223,36 +229,29 @@ Two install surfaces. The CLI gives you the full power of Orbit. Choose the plug
 | | `orbit.graph.deps` | List outbound dependencies |
 | | `orbit.graph.implementors` | List trait implementors |
 | | `orbit.graph.refs` | List references to a symbol |
-| | `orbit.graph.history` | Git history for a symbol |
 | | `orbit.graph.pack` | Bundle a connected slice of the graph for a prompt |
 | **search** | `orbit.search` | Unified search across tasks, docs, learnings, and ADRs. `kind` narrows the corpus; `hybrid: true` opts task results into BM25 + cosine ranking; `semantic: "<task-id>"` returns cosine neighbors. Cross-kind filters: `tag` (AND), `all` (kind-aware status widener), `status` (`kind:value` tokens), `path` (selector-mapping for tasks, glob-containment for learnings/ADRs; docs remain content-indexed). |
-| **semantic** | `orbit.semantic.install` | Install the local embedding companion and model |
-| | `orbit.semantic.uninstall` | Remove the embedding companion and/or models |
-| | `orbit.semantic.stats` | Show companion and index status |
-| | `orbit.semantic.index` | Rebuild task embeddings |
+| **semantic** | `orbit.semantic.uninstall` | Remove the embedding companion and/or models |
 | **adr** | `orbit.adr.add` | Author an Architecture Decision Record |
 | | `orbit.adr.update` | Edit an ADR |
 | | `orbit.adr.show` | Fetch an ADR |
 | | `orbit.adr.list` | List ADRs by status |
 | | `orbit.adr.supersede` | Mark an ADR superseded by another |
-| **design** | `orbit.design.init` | Scaffold a feature design-doc folder |
-| | `orbit.design.list` | List design-doc feature folders |
-| | `orbit.design.show` | Fetch one design-doc feature summary |
-| | `orbit.design.check` | Return structured stale-doc findings |
 | **learning** | `orbit.learning.add` | Author a project learning |
 | | `orbit.learning.update` | Edit a learning |
 | | `orbit.learning.show` | Fetch a learning |
-| | `orbit.learning.list` | List learnings by tag / scope / `path` (glob-containment) |
+| | `orbit.learning.upvote` | Mark a learning as useful |
+| | `orbit.learning.comment.add` | Add a comment to a learning |
+| | `orbit.learning.comment.list` | List comments on a learning |
+| | `orbit.learning.comment.delete` | Delete a learning comment |
 | | `orbit.learning.supersede` | Mark a learning superseded |
 | | `orbit.learning.prune` | Report or archive stale learnings |
-| | `orbit.learning.sync` | Reconcile the SQLite envelope index from YAML |
 | **friction** | `orbit.friction.add` | Record an operational friction |
 | | `orbit.friction.update` | Edit a friction |
 | | `orbit.friction.show` | Fetch a friction |
 | | `orbit.friction.list` | List frictions by tag / status |
-| | `orbit.friction.stats` | Aggregate frictions by tag and recency |
+| | `orbit.friction.tags` | List configured friction taxonomy tags |
 | | `orbit.friction.resolve` | Mark a friction resolved |
-| | `orbit.friction.delete` | Delete a friction |
 
 </details>
 

--- a/crates/orbit-agent/src/loop_engine/tool_dispatch.rs
+++ b/crates/orbit-agent/src/loop_engine/tool_dispatch.rs
@@ -28,7 +28,7 @@ pub fn build_tool_specs(registry: &ToolRegistry, allowlist: &[String]) -> Vec<To
     let mut seen = HashSet::new();
     let mut specs = Vec::new();
     for entry in allowlist {
-        if let Some(schema) = registry.get_schema(entry) {
+        if let Some(schema) = registry.get_active_schema(entry) {
             push_tool_spec(&mut specs, &mut seen, &schema);
         }
         if entry.ends_with('*') && validate_tool_allowlist(std::slice::from_ref(entry)).is_ok() {

--- a/crates/orbit-cli/src/command/definitions/tool.rs
+++ b/crates/orbit-cli/src/command/definitions/tool.rs
@@ -3,6 +3,7 @@ use std::path::{Path, PathBuf};
 
 use clap::{Args, Subcommand, ValueEnum};
 use orbit_common::types::ToolParam;
+use orbit_core::command::tool::ToolInfo;
 use orbit_core::{OrbitError, OrbitRuntime};
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value, json};
@@ -81,11 +82,18 @@ pub struct ToolListArgs {
     /// Output as JSON
     #[arg(long)]
     pub json: bool,
+    /// Include inactive tools that are hidden from the default agent surface
+    #[arg(long, alias = "include-hidden")]
+    pub all: bool,
 }
 
 impl Execute for ToolListArgs {
     fn execute(self, runtime: &OrbitRuntime) -> Result<(), OrbitError> {
-        let tools = runtime.list_tools()?;
+        let tools = if self.all {
+            runtime.list_all_tools()?
+        } else {
+            runtime.list_tools()?
+        };
 
         if self.json {
             let json_tools: Vec<Value> = tools
@@ -95,6 +103,8 @@ impl Execute for ToolListArgs {
                         "name": t.name,
                         "description": t.description,
                         "enabled": t.enabled,
+                        "active": t.active,
+                        "status": tool_status(t),
                         "builtin": t.builtin,
                         "parameters": &t.parameters,
                     })
@@ -104,7 +114,7 @@ impl Execute for ToolListArgs {
         } else {
             let mut table = crate::output::table::build_table(&[
                 "NAME",
-                "ENABLED",
+                "STATUS",
                 "BUILTIN",
                 "REQUIRED INPUT",
                 "DESCRIPTION",
@@ -113,11 +123,7 @@ impl Execute for ToolListArgs {
                 use comfy_table::Cell;
                 table.add_row(vec![
                     Cell::new(&tool.name),
-                    crate::output::color::job_state_color_cell(if tool.enabled {
-                        "active"
-                    } else {
-                        "disabled"
-                    }),
+                    crate::output::color::job_state_color_cell(tool_status(tool)),
                     Cell::new(if tool.builtin { "yes" } else { "no" }),
                     Cell::new(format_required_tool_input_summary(&tool.parameters)),
                     Cell::new(&tool.description),
@@ -126,6 +132,16 @@ impl Execute for ToolListArgs {
             println!("{table}");
             Ok(())
         }
+    }
+}
+
+fn tool_status(tool: &ToolInfo) -> &'static str {
+    if !tool.active {
+        "inactive"
+    } else if !tool.enabled {
+        "disabled"
+    } else {
+        "active"
     }
 }
 
@@ -180,8 +196,8 @@ impl Execute for ToolShowArgs {
         );
         println!(
             "{} {}",
-            bold("Enabled:"),
-            job_state_color(if tool.enabled { "active" } else { "disabled" })
+            bold("Status:"),
+            job_state_color(tool_status(&tool))
         );
 
         if tool.parameters.is_empty() {

--- a/crates/orbit-cli/src/command/mcp/mod.rs
+++ b/crates/orbit-cli/src/command/mcp/mod.rs
@@ -35,9 +35,6 @@ pub(crate) const TASK_TOOL_NAMES: &[&str] = &[
     "orbit.task.delete",
     "orbit.task.lint",
     "orbit.task.list",
-    "orbit.task.locks",
-    "orbit.task.locks.release",
-    "orbit.task.locks.reserve",
     "orbit.task.reject",
     "orbit.task.review_thread.add",
     "orbit.task.review_thread.list",
@@ -53,7 +50,6 @@ pub(crate) const FRICTION_TOOL_NAMES: &[&str] = &[
     "orbit.friction.list",
     "orbit.friction.resolve",
     "orbit.friction.show",
-    "orbit.friction.stats",
     "orbit.friction.tags",
     "orbit.friction.update",
 ];
@@ -61,7 +57,6 @@ pub(crate) const FRICTION_TOOL_NAMES: &[&str] = &[
 pub(crate) const GRAPH_READ_TOOL_NAMES: &[&str] = &[
     "orbit.graph.callers",
     "orbit.graph.deps",
-    "orbit.graph.history",
     "orbit.graph.implementors",
     "orbit.graph.overview",
     "orbit.graph.pack",
@@ -72,51 +67,28 @@ pub(crate) const GRAPH_READ_TOOL_NAMES: &[&str] = &[
 
 pub(crate) const SEARCH_TOOL_NAMES: &[&str] = &["orbit.search"];
 
-pub(crate) const SEMANTIC_TOOL_NAMES: &[&str] = &[
-    "orbit.semantic.index",
-    "orbit.semantic.install",
-    "orbit.semantic.stats",
-    "orbit.semantic.uninstall",
+pub(crate) const SEMANTIC_TOOL_NAMES: &[&str] = &["orbit.semantic.uninstall"];
+
+pub(crate) const ADR_TOOL_NAMES: &[&str] = &[
+    "orbit.adr.add",
+    "orbit.adr.list",
+    "orbit.adr.show",
+    "orbit.adr.supersede",
+    "orbit.adr.update",
 ];
 
-pub(crate) const DOCS_TOOL_NAMES: &[&str] = &[
-    "orbit.docs.list",
-    "orbit.docs.show",
-    "orbit.docs.add",
-    "orbit.docs.index",
-    "orbit.docs.migrate",
-];
+pub(crate) const DOCS_TOOL_NAMES: &[&str] = &[];
 
 pub(crate) const LEARNING_TOOL_NAMES: &[&str] = &[
     "orbit.learning.add",
     "orbit.learning.comment.add",
     "orbit.learning.comment.delete",
     "orbit.learning.comment.list",
-    "orbit.learning.list",
     "orbit.learning.show",
     "orbit.learning.update",
     "orbit.learning.supersede",
     "orbit.learning.upvote",
     "orbit.learning.prune",
-    "orbit.learning.sync",
-];
-
-pub(crate) const MCP_HIDDEN_TOOL_NAMES: &[&str] = &[
-    "orbit.docs.index",
-    "orbit.docs.migrate",
-    "orbit.docs.add",
-    "orbit.docs.list",
-    "orbit.docs.show",
-    "orbit.task.locks",
-    "orbit.task.locks.release",
-    "orbit.task.locks.reserve",
-    "orbit.semantic.index",
-    "orbit.semantic.install",
-    "orbit.semantic.stats",
-    "orbit.graph.history",
-    "orbit.learning.sync",
-    "orbit.learning.list",
-    "orbit.friction.stats",
 ];
 
 pub(crate) fn safe_mcp_tool_names() -> Vec<&'static str> {
@@ -126,6 +98,7 @@ pub(crate) fn safe_mcp_tool_names() -> Vec<&'static str> {
             + GRAPH_READ_TOOL_NAMES.len()
             + SEARCH_TOOL_NAMES.len()
             + SEMANTIC_TOOL_NAMES.len()
+            + ADR_TOOL_NAMES.len()
             + DOCS_TOOL_NAMES.len()
             + LEARNING_TOOL_NAMES.len(),
     );
@@ -134,21 +107,21 @@ pub(crate) fn safe_mcp_tool_names() -> Vec<&'static str> {
     names.extend_from_slice(GRAPH_READ_TOOL_NAMES);
     names.extend_from_slice(SEARCH_TOOL_NAMES);
     names.extend_from_slice(SEMANTIC_TOOL_NAMES);
+    names.extend_from_slice(ADR_TOOL_NAMES);
     names.extend_from_slice(DOCS_TOOL_NAMES);
     names.extend_from_slice(LEARNING_TOOL_NAMES);
-    names.retain(|name| !MCP_HIDDEN_TOOL_NAMES.contains(name));
     names
 }
 
 pub(crate) fn is_mcp_tool_exposed(name: &str) -> bool {
-    !MCP_HIDDEN_TOOL_NAMES.contains(&name)
-        && (TASK_TOOL_NAMES.contains(&name)
-            || FRICTION_TOOL_NAMES.contains(&name)
-            || GRAPH_READ_TOOL_NAMES.contains(&name)
-            || SEARCH_TOOL_NAMES.contains(&name)
-            || SEMANTIC_TOOL_NAMES.contains(&name)
-            || DOCS_TOOL_NAMES.contains(&name)
-            || LEARNING_TOOL_NAMES.contains(&name))
+    TASK_TOOL_NAMES.contains(&name)
+        || FRICTION_TOOL_NAMES.contains(&name)
+        || GRAPH_READ_TOOL_NAMES.contains(&name)
+        || SEARCH_TOOL_NAMES.contains(&name)
+        || SEMANTIC_TOOL_NAMES.contains(&name)
+        || ADR_TOOL_NAMES.contains(&name)
+        || DOCS_TOOL_NAMES.contains(&name)
+        || LEARNING_TOOL_NAMES.contains(&name)
 }
 
 fn ensure_mcp_tool_exposed(name: &str) -> Result<(), OrbitError> {

--- a/crates/orbit-cli/src/command/mcp/tests/mod.rs
+++ b/crates/orbit-cli/src/command/mcp/tests/mod.rs
@@ -8,12 +8,12 @@ use orbit_core::OrbitRuntime;
 use orbit_mcp::McpHost;
 
 use super::{
-    DOCS_TOOL_NAMES, FRICTION_TOOL_NAMES, GRAPH_READ_TOOL_NAMES, LEARNING_TOOL_NAMES,
-    MCP_HIDDEN_TOOL_NAMES, RuntimeMcpHost, SEARCH_TOOL_NAMES, SEMANTIC_TOOL_NAMES, TASK_TOOL_NAMES,
+    ADR_TOOL_NAMES, DOCS_TOOL_NAMES, FRICTION_TOOL_NAMES, GRAPH_READ_TOOL_NAMES,
+    LEARNING_TOOL_NAMES, RuntimeMcpHost, SEARCH_TOOL_NAMES, SEMANTIC_TOOL_NAMES, TASK_TOOL_NAMES,
     is_mcp_tool_exposed, safe_mcp_tool_names,
 };
 
-const EXPECTED_MCP_HIDDEN_TOOL_NAMES: &[&str] = &[
+const EXPECTED_INACTIVE_TOOL_NAMES: &[&str] = &[
     "orbit.docs.index",
     "orbit.docs.migrate",
     "orbit.docs.add",
@@ -31,17 +31,14 @@ const EXPECTED_MCP_HIDDEN_TOOL_NAMES: &[&str] = &[
     "orbit.friction.stats",
 ];
 
-const REEXPOSED_FRICTION_TOOL_NAMES: &[&str] = &[
-    "orbit.friction.list",
-    "orbit.friction.resolve",
-    "orbit.friction.show",
-    "orbit.friction.tags",
-    "orbit.friction.update",
-];
-
 const REQUIRED_AGENT_FACING_TOOL_NAMES: &[&str] = &[
     "orbit.search",
     "orbit.task.add",
+    "orbit.task.approve",
+    "orbit.task.artifact.put",
+    "orbit.task.delete",
+    "orbit.task.lint",
+    "orbit.task.reject",
     "orbit.task.show",
     "orbit.task.update",
     "orbit.task.list",
@@ -51,15 +48,26 @@ const REQUIRED_AGENT_FACING_TOOL_NAMES: &[&str] = &[
     "orbit.task.review_thread.resolve",
     "orbit.task.start",
     "orbit.graph.search",
+    "orbit.graph.show",
+    "orbit.graph.pack",
+    "orbit.graph.overview",
     "orbit.graph.refs",
     "orbit.graph.callers",
+    "orbit.graph.deps",
     "orbit.graph.implementors",
+    "orbit.adr.add",
+    "orbit.adr.list",
+    "orbit.adr.show",
+    "orbit.adr.supersede",
+    "orbit.adr.update",
     "orbit.learning.add",
     "orbit.learning.show",
     "orbit.learning.update",
     "orbit.learning.upvote",
     "orbit.learning.comment.add",
     "orbit.learning.comment.list",
+    "orbit.learning.comment.delete",
+    "orbit.learning.prune",
     "orbit.friction.add",
     "orbit.friction.list",
     "orbit.friction.resolve",
@@ -73,26 +81,27 @@ fn is_runtime_mcp_category_tool(name: &str) -> bool {
         || name.starts_with("orbit.task.")
         || name.starts_with("orbit.friction.")
         || name.starts_with("orbit.graph.")
+        || name.starts_with("orbit.adr.")
         || name.starts_with("orbit.semantic.")
         || name.starts_with("orbit.docs.")
         || name.starts_with("orbit.learning.")
 }
 
 #[test]
-fn mcp_hidden_denylist_matches_intended_ops_surface() {
-    assert_eq!(MCP_HIDDEN_TOOL_NAMES.len(), 15);
-    assert_eq!(MCP_HIDDEN_TOOL_NAMES, EXPECTED_MCP_HIDDEN_TOOL_NAMES);
+fn inactive_tools_are_not_in_the_mcp_safe_surface() {
+    let safe_names: BTreeSet<&str> = safe_mcp_tool_names().into_iter().collect();
+    assert_eq!(EXPECTED_INACTIVE_TOOL_NAMES.len(), 15);
 
-    for name in REEXPOSED_FRICTION_TOOL_NAMES {
+    for name in EXPECTED_INACTIVE_TOOL_NAMES {
         assert!(
-            !MCP_HIDDEN_TOOL_NAMES.contains(name),
-            "agent-facing friction workflow should be visible over MCP: {name}"
+            !safe_names.contains(name),
+            "inactive tool leaked into safe MCP names: {name}"
+        );
+        assert!(
+            !is_mcp_tool_exposed(name),
+            "inactive tool exposed by MCP preflight: {name}"
         );
     }
-    assert!(
-        MCP_HIDDEN_TOOL_NAMES.contains(&"orbit.learning.list"),
-        "orbit.learning.list remains hidden; use orbit.search --kind learning for agent discovery"
-    );
 }
 
 #[test]
@@ -104,8 +113,14 @@ fn safe_surface_matches_runtime_graph_and_task_tools() {
         .into_iter()
         .map(|tool| tool.name)
         .collect();
+    let all_names: BTreeSet<String> = runtime
+        .list_all_tools()
+        .expect("list all tools")
+        .into_iter()
+        .map(|tool| tool.name)
+        .collect();
     let safe_names: BTreeSet<&str> = safe_mcp_tool_names().into_iter().collect();
-    let hidden_names: BTreeSet<&str> = MCP_HIDDEN_TOOL_NAMES.iter().copied().collect();
+    let inactive_names: BTreeSet<&str> = EXPECTED_INACTIVE_TOOL_NAMES.iter().copied().collect();
 
     for name in TASK_TOOL_NAMES
         .iter()
@@ -113,6 +128,7 @@ fn safe_surface_matches_runtime_graph_and_task_tools() {
         .chain(GRAPH_READ_TOOL_NAMES)
         .chain(SEARCH_TOOL_NAMES)
         .chain(SEMANTIC_TOOL_NAMES)
+        .chain(ADR_TOOL_NAMES)
         .chain(DOCS_TOOL_NAMES)
         .chain(LEARNING_TOOL_NAMES)
     {
@@ -122,18 +138,18 @@ fn safe_surface_matches_runtime_graph_and_task_tools() {
         );
     }
 
-    for name in MCP_HIDDEN_TOOL_NAMES {
+    for name in EXPECTED_INACTIVE_TOOL_NAMES {
         assert!(
-            names.contains(*name),
-            "MCP-hidden tool should remain registered for CLI use: {name}"
+            !names.contains(*name),
+            "inactive tool leaked into default runtime list: {name}"
         );
         assert!(
-            !safe_names.contains(*name),
-            "MCP-hidden tool leaked into safe MCP names: {name}"
+            all_names.contains(*name),
+            "inactive tool should remain registered for inspection: {name}"
         );
         assert!(
             !is_mcp_tool_exposed(name),
-            "MCP-hidden tool exposed by preflight: {name}"
+            "inactive tool exposed by MCP preflight: {name}"
         );
     }
 
@@ -156,7 +172,7 @@ fn safe_surface_matches_runtime_graph_and_task_tools() {
         .iter()
         .filter(|name| is_runtime_mcp_category_tool(name))
     {
-        let should_expose = !hidden_names.contains(name.as_str());
+        let should_expose = !inactive_names.contains(name.as_str());
         assert!(
             safe_names.contains(name.as_str()) == should_expose,
             "runtime tool MCP exposure mismatch for {name}"
@@ -208,10 +224,10 @@ fn runtime_mcp_host_lists_safe_graph_tools_for_clients() {
         );
     }
 
-    for name in MCP_HIDDEN_TOOL_NAMES {
+    for name in EXPECTED_INACTIVE_TOOL_NAMES {
         assert!(
             !listed.contains(*name),
-            "client-visible MCP tool list exposes hidden ops tool: {name}"
+            "client-visible MCP tool list exposes inactive ops tool: {name}"
         );
     }
 
@@ -339,6 +355,27 @@ mod audited_mcp_call_tests {
             value.get("results").is_some(),
             "orbit.search returns wrapped results"
         );
+    }
+
+    #[test]
+    fn inactive_tool_is_rejected_over_mcp_dispatch() {
+        let runtime = OrbitRuntime::in_memory().expect("build test runtime");
+        let error = audited_mcp_call(&runtime, "orbit.learning.list", json!({ "model": "codex" }))
+            .expect_err("inactive tool is not callable over MCP");
+        assert!(error.to_string().contains("tool"));
+
+        let events = runtime
+            .list_audit_events(
+                None,
+                Some("orbit.learning.list".to_string()),
+                None,
+                None,
+                16,
+            )
+            .expect("list audit events");
+        assert_eq!(events.len(), 1, "preflight failure produced one audit row");
+        assert_eq!(events[0].subcommand.as_deref(), Some("run-mcp"));
+        assert_eq!(events[0].status, AuditEventStatus::Failure);
     }
 
     #[test]

--- a/crates/orbit-cli/src/command/task/list.rs
+++ b/crates/orbit-cli/src/command/task/list.rs
@@ -1,6 +1,6 @@
 use std::collections::BTreeSet;
 
-use clap::{ArgAction, Args};
+use clap::{ArgAction, Args, Subcommand};
 use orbit_core::{
     ExternalRef, OrbitError, OrbitRuntime, TaskPriority, TaskStatus, TaskType,
     build_task_status_index, task_dependencies_ready, task_selectors_contain_path,
@@ -167,6 +167,23 @@ fn default_task_list_status_filter<'a>(
 
 #[derive(Args)]
 pub struct TaskLocksArgs {
+    #[command(subcommand)]
+    pub command: Option<TaskLocksSubcommand>,
+    /// Output as JSON
+    #[arg(long)]
+    pub json: bool,
+}
+
+#[derive(Subcommand)]
+pub enum TaskLocksSubcommand {
+    /// Release an active reservation by id
+    Release(TaskLocksReleaseArgs),
+}
+
+#[derive(Args)]
+pub struct TaskLocksReleaseArgs {
+    /// Reservation id to release
+    pub reservation_id: String,
     /// Output as JSON
     #[arg(long)]
     pub json: bool,
@@ -174,11 +191,45 @@ pub struct TaskLocksArgs {
 
 impl Execute for TaskLocksArgs {
     fn execute(self, runtime: &OrbitRuntime) -> Result<(), OrbitError> {
+        if let Some(command) = self.command {
+            return command.execute(runtime);
+        }
         if self.json {
             crate::output::json::print_pretty(&task_locks_json(runtime)?)
         } else {
             let (tasks, locked_files) = task_locks(runtime)?;
             print_task_locks(&tasks, &locked_files);
+            Ok(())
+        }
+    }
+}
+
+impl Execute for TaskLocksSubcommand {
+    fn execute(self, runtime: &OrbitRuntime) -> Result<(), OrbitError> {
+        match self {
+            Self::Release(args) => args.execute(runtime),
+        }
+    }
+}
+
+impl Execute for TaskLocksReleaseArgs {
+    fn execute(self, runtime: &OrbitRuntime) -> Result<(), OrbitError> {
+        let value = runtime.run_tool(
+            "orbit.task.locks.release",
+            json!({ "reservation_id": self.reservation_id }),
+        )?;
+        if self.json {
+            crate::output::json::print_pretty(&value)
+        } else {
+            let released = value
+                .get("released")
+                .and_then(Value::as_bool)
+                .unwrap_or(false);
+            if released {
+                println!("Released reservation {}", self.reservation_id);
+            } else {
+                println!("No active reservation found for {}", self.reservation_id);
+            }
             Ok(())
         }
     }

--- a/crates/orbit-cli/tests/docs.rs
+++ b/crates/orbit-cli/tests/docs.rs
@@ -562,7 +562,7 @@ fn cli_task_show_with_context_returns_empty_docs_when_roots_are_empty() {
 }
 
 #[test]
-fn mcp_docs_tools_are_listed_and_callable_through_tool_run() {
+fn docs_tools_are_cli_only_and_visible_in_tool_list_all() {
     let workspace = TestWorkspace::new();
     workspace.write(
         "docs/context.md",
@@ -570,12 +570,14 @@ fn mcp_docs_tools_are_listed_and_callable_through_tool_run() {
     );
 
     let tools = workspace.run_json(&["tool", "list", "--json"], "tool list");
-    let names = tools
+    let default_names = tools
         .as_array()
         .expect("tools")
         .iter()
         .map(|tool| tool["name"].as_str().expect("name"))
         .collect::<Vec<_>>();
+    let all_tools = workspace.run_json(&["tool", "list", "--json", "--all"], "tool list --all");
+    let all_tools = all_tools.as_array().expect("all tools");
     for name in [
         "orbit.docs.list",
         "orbit.docs.show",
@@ -583,18 +585,34 @@ fn mcp_docs_tools_are_listed_and_callable_through_tool_run() {
         "orbit.docs.index",
         "orbit.docs.migrate",
     ] {
-        assert!(names.contains(&name), "missing docs tool {name}");
+        assert!(
+            !default_names.contains(&name),
+            "docs tool must be hidden from default tool list: {name}"
+        );
+        let tool = all_tools
+            .iter()
+            .find(|tool| tool["name"] == name)
+            .unwrap_or_else(|| panic!("missing docs tool from --all: {name}"));
+        assert_eq!(tool["status"], "inactive");
     }
     // ORB-00202: `orbit.docs.search` deleted in phase 2.
     assert!(
-        !names.contains(&"orbit.docs.search"),
+        !default_names.contains(&"orbit.docs.search"),
         "orbit.docs.search must be deleted in phase 2"
     );
 
-    let output = workspace.run_json(
+    let output = run_orbit(
+        &workspace.work,
+        &workspace.home,
         &["tool", "run", "orbit.docs.list", "--input", "{}"],
-        "tool run docs list",
     );
+    assert!(
+        !output.status.success(),
+        "inactive docs tool unexpectedly succeeded through tool run"
+    );
+    assert!(String::from_utf8_lossy(&output.stdout).contains("inactive"));
+
+    let output = workspace.run_json(&["docs", "list", "--json"], "docs list");
     assert!(!output.as_array().expect("array").is_empty());
 }
 

--- a/crates/orbit-cli/tests/tool_list.rs
+++ b/crates/orbit-cli/tests/tool_list.rs
@@ -8,7 +8,7 @@ use assert_cmd::cargo::cargo_bin_cmd;
 use predicates::prelude::*;
 use tempfile::tempdir;
 
-const MCP_HIDDEN_CLI_TOOL_NAMES: &[&str] = &[
+const INACTIVE_TOOL_NAMES: &[&str] = &[
     "orbit.docs.index",
     "orbit.docs.migrate",
     "orbit.docs.add",
@@ -24,15 +24,10 @@ const MCP_HIDDEN_CLI_TOOL_NAMES: &[&str] = &[
     "orbit.learning.sync",
     "orbit.learning.list",
     "orbit.friction.stats",
-    "orbit.friction.resolve",
-    "orbit.friction.show",
-    "orbit.friction.tags",
-    "orbit.friction.update",
-    "orbit.friction.list",
 ];
 
 #[test]
-fn tool_list_shows_lock_reservation_without_required_input_shape() {
+fn tool_list_all_shows_inactive_lock_reservation_with_required_input_shape() {
     let temp = tempdir().expect("tempdir");
     let home = temp.path().join("home");
     let work = temp.path().join("work");
@@ -44,18 +39,19 @@ fn tool_list_shows_lock_reservation_without_required_input_shape() {
         .env("HOME", &home)
         .env("USERPROFILE", &home)
         .env_remove("ORBIT_ROOT")
-        .args(["tool", "list"])
+        .args(["tool", "list", "--all"])
         .assert()
         .success()
         .stdout(predicate::str::contains("orbit.task.locks.reserve"))
-        .stdout(predicate::str::contains("REQUIRED INPUT"))
+        .stdout(predicate::str::contains("STATUS"))
+        .stdout(predicate::str::contains("inactive"))
         .stdout(predicate::str::contains(
             "Exactly one of `task_ids` or `files`",
         ));
 }
 
 #[test]
-fn tool_list_json_keeps_mcp_hidden_tools_on_cli_surface() {
+fn tool_list_json_hides_inactive_tools_by_default() {
     let temp = tempdir().expect("tempdir");
     let home = temp.path().join("home");
     let work = temp.path().join("work");
@@ -80,16 +76,16 @@ fn tool_list_json_keeps_mcp_hidden_tools_on_cli_surface() {
         .map(|tool| tool["name"].as_str().expect("tool name").to_string())
         .collect::<BTreeSet<_>>();
 
-    for retained in MCP_HIDDEN_CLI_TOOL_NAMES {
+    for inactive in INACTIVE_TOOL_NAMES {
         assert!(
-            names.contains(*retained),
-            "MCP-hidden tool must remain visible through `orbit tool list`: {retained}"
+            !names.contains(*inactive),
+            "inactive tool must not be visible through default `orbit tool list`: {inactive}"
         );
     }
 }
 
 #[test]
-fn tool_list_json_includes_parameter_schema() {
+fn tool_list_json_all_includes_inactive_tools_with_status() {
     let temp = tempdir().expect("tempdir");
     let home = temp.path().join("home");
     let work = temp.path().join("work");
@@ -101,7 +97,39 @@ fn tool_list_json_includes_parameter_schema() {
         .env("HOME", &home)
         .env("USERPROFILE", &home)
         .env_remove("ORBIT_ROOT")
-        .args(["tool", "list", "--json"])
+        .args(["tool", "list", "--json", "--all"])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+
+    let tools: Vec<serde_json::Value> = serde_json::from_slice(&output).expect("tool list JSON");
+
+    for inactive in INACTIVE_TOOL_NAMES {
+        let tool = tools
+            .iter()
+            .find(|tool| tool["name"] == *inactive)
+            .unwrap_or_else(|| panic!("inactive tool missing from --all: {inactive}"));
+        assert_eq!(tool["status"], "inactive");
+        assert_eq!(tool["active"], false);
+    }
+}
+
+#[test]
+fn tool_list_json_all_includes_parameter_schema_for_inactive_tools() {
+    let temp = tempdir().expect("tempdir");
+    let home = temp.path().join("home");
+    let work = temp.path().join("work");
+    std::fs::create_dir_all(&home).expect("create home");
+    std::fs::create_dir_all(&work).expect("create work");
+
+    let output = cargo_bin_cmd!("orbit")
+        .current_dir(&work)
+        .env("HOME", &home)
+        .env("USERPROFILE", &home)
+        .env_remove("ORBIT_ROOT")
+        .args(["tool", "list", "--json", "--all"])
         .assert()
         .success()
         .get_output()
@@ -182,10 +210,37 @@ fn tool_show_displays_lock_reservation_shapes() {
         .args(["tool", "show", "orbit.task.locks.reserve"])
         .assert()
         .success()
+        .stdout(predicate::str::contains("Status:"))
+        .stdout(predicate::str::contains("inactive"))
         .stdout(predicate::str::contains("task_ids"))
         .stdout(predicate::str::contains("files"))
         .stdout(predicate::str::contains("optional"))
         .stdout(predicate::str::contains(
             "Exactly one of `task_ids` or `files`",
         ));
+}
+
+#[test]
+fn tool_run_rejects_inactive_tools() {
+    let temp = tempdir().expect("tempdir");
+    let home = temp.path().join("home");
+    let work = temp.path().join("work");
+    std::fs::create_dir_all(&home).expect("create home");
+    std::fs::create_dir_all(&work).expect("create work");
+
+    cargo_bin_cmd!("orbit")
+        .current_dir(&work)
+        .env("HOME", &home)
+        .env("USERPROFILE", &home)
+        .env_remove("ORBIT_ROOT")
+        .args([
+            "tool",
+            "run",
+            "orbit.learning.list",
+            "--input",
+            "{\"model\":\"codex\"}",
+        ])
+        .assert()
+        .failure()
+        .stdout(predicate::str::contains("inactive"));
 }

--- a/crates/orbit-core/assets/activities/agent_implement.yaml
+++ b/crates/orbit-core/assets/activities/agent_implement.yaml
@@ -101,9 +101,7 @@ spec:
     - orbit.friction.*
     - orbit.graph.*
     - orbit.search
-    - orbit.semantic.*
     - orbit.learning.show
-    - orbit.learning.list
     - orbit.learning.add
     - orbit.learning.comment.add
     - orbit.learning.comment.list

--- a/crates/orbit-core/assets/activities/agent_review.yaml
+++ b/crates/orbit-core/assets/activities/agent_review.yaml
@@ -78,9 +78,7 @@ spec:
     - orbit.friction.*
     - orbit.graph.*
     - orbit.search
-    - orbit.semantic.*
     - orbit.learning.show
-    - orbit.learning.list
     - orbit.learning.add
     - orbit.learning.comment.add
     - orbit.learning.comment.list

--- a/crates/orbit-core/assets/skills/orbit-debug-job-failure/references/common_failures.md
+++ b/crates/orbit-core/assets/skills/orbit-debug-job-failure/references/common_failures.md
@@ -10,13 +10,13 @@ Symptoms:
 
 - A gate, auto, or task run repeatedly emits `task.locks.reserve.denied`.
 - Conflicts name `held_by: "reservation"` with the same `held_by_id` on each retry.
-- `orbit.task.locks` shows the blocking reservation belongs to a different task that is already `done`, `failed`, or otherwise no longer active.
+- CLI-only `orbit task locks` or reservation-store inspection shows the blocking reservation belongs to a different task that is already `done`, `failed`, or otherwise no longer active.
 - The reservation has `owner_run_id: null`, so terminal run cleanup cannot release it by owner.
 
 Confirm:
 
 ```bash
-orbit tool run orbit.task.locks --input '{"model":"codex"}'
+orbit task locks --json
 orbit tool run orbit.task.show --full --input '{"id":"<blocking_task_id>","model":"codex"}'
 rg -n '<reservation_id>|task.locks.reserve.denied|<blocked_task_id>' .orbit/state/audit/v2_loop
 ```
@@ -33,10 +33,10 @@ sqlite3 -header -column ~/.orbit/orbit.db \
 Solution:
 
 1. Verify the blocking task is not actively running and the reservation is stale.
-2. Release through the tool surface, not by editing SQLite:
+2. Release through the CLI-only lock admin surface, not by editing SQLite:
 
    ```bash
-   orbit tool run orbit.task.locks.release --input '{"reservation_id":"<reservation_id>","model":"codex"}'
+   orbit task locks release <reservation_id>
    ```
 
 3. Re-run or re-check the blocked run. The next reserve attempt should either acquire a fresh reservation with `owner_run_id` set or reveal a different conflict.
@@ -122,7 +122,7 @@ Confirm:
 ```bash
 orbit run show <run_id> --json
 rg -n 'step_failure_recovery|semantic.db|orbit.db|invalid L-|learning' .orbit/state/audit/v2_loop/<run_id>.jsonl
-orbit tool run orbit.learning.list --input '{"model":"codex"}'
+orbit learning list --json
 ```
 
 Solution:

--- a/crates/orbit-core/assets/skills/orbit-docs/SKILL.md
+++ b/crates/orbit-core/assets/skills/orbit-docs/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: orbit-docs
-description: Use when searching, listing, showing, registering, reindexing, or migrating the human-authored docs corpus via `orbit.docs.*`. Covers the locked frontmatter schema, recommended docs layout, learning-vs-doc boundaries, and ADR routing.
+description: Use when searching, listing, showing, registering, reindexing, or migrating the human-authored docs corpus. Agents discover docs with `orbit.search --kind doc`; admin/setup workflows use the `orbit docs ...` CLI. Covers the locked frontmatter schema, recommended docs layout, learning-vs-doc boundaries, and ADR routing.
 ---
 
 # Orbit Docs
@@ -40,9 +40,9 @@ Orbit-docs indexes any configured Markdown root with valid frontmatter; it does 
 
 ## Learning vs Doc
 
-Learning = a load-bearing rule with a known failure mode. It is managed through `orbit.learning.*`, has scope-glob push injection, and can be updated, superseded, or pruned.
+Learning = a load-bearing rule with a known failure mode. It is managed through the active `orbit.learning.add/show/update/upvote/supersede/prune/comment.*` tools plus CLI-only audit/list workflows, has scope-glob push injection, and can be updated, superseded, or pruned.
 
-Doc = explanatory context. It is PR-reviewed Markdown, retrieved through `orbit.docs.*`, and has no supersede flow. Link to load-bearing learnings with `related_artifacts: [L-NNNN]` when useful.
+Doc = explanatory context. It is PR-reviewed Markdown, retrieved by agents through `orbit.search --kind doc`, and has no supersede flow. Link to load-bearing learnings with `related_artifacts: [L-NNNN]` when useful.
 
 ## Routing Notes
 
@@ -53,16 +53,16 @@ Doc = explanatory context. It is PR-reviewed Markdown, retrieved through `orbit.
 
 ## Tool Invocation
 
-CLI and MCP forms are equivalent:
+Agents use `orbit.search` for retrieval. The `orbit docs ...` commands below are CLI-only human/admin workflows.
 
-| Verb | CLI | MCP |
+| Verb | Surface | Form |
 | --- | --- | --- |
-| List | `orbit docs list --json` | `orbit.docs.list` |
-| Show | `orbit docs show <path> --json` | `orbit.docs.show` |
-| Search | `orbit search --kind doc <query> --json --limit 20` (or `--kind all` / `--kind adr`) | `orbit.search` |
-| Add root | `orbit docs add <path>` | `orbit.docs.add` |
-| Index | `orbit docs index` | `orbit.docs.index` |
-| Migrate | `orbit docs migrate --dry-run` | `orbit.docs.migrate` |
+| Search | Agent tool / CLI | `orbit.search` or `orbit search --kind doc <query> --json --limit 20` (also `--kind all` / `--kind adr`) |
+| List | CLI-only | `orbit docs list --json` |
+| Show | CLI-only | `orbit docs show <path> --json` |
+| Add root | CLI-only | `orbit docs add <path>` |
+| Index | CLI-only | `orbit docs index` |
+| Migrate | CLI-only | `orbit docs migrate --dry-run` |
 
 `orbit search <query> --kind all` federates doc and ADR hits in one call. Use `--kind doc` for doc-only matches, `--kind adr` for ADR-only matches, and `--kind adr --all` (or `--status adr:accepted,adr:superseded`) to include superseded ADRs for archaeology. See `orbit-search` for the full flag matrix (`--tag`, `orbit search path <path>`, `--status kind:value`).
 

--- a/crates/orbit-core/assets/skills/orbit-graph/SKILL.md
+++ b/crates/orbit-core/assets/skills/orbit-graph/SKILL.md
@@ -27,7 +27,7 @@ Graph **write** tools (build/update) are CLI-only — not exposed over MCP.
    - `orbit.graph.callers` for transitive caller-chain questions
    - `orbit.graph.refs` for usages or cross-file symbol references; it returns `code_refs` by default and fills `doc_refs` / `config_refs` only when you pass `include`
    - `orbit.graph.deps` for crate-level dependency direction
-   - `orbit.graph.history` is a compatibility stub for removed task attribution; for task-to-commit lookup use `git log --grep '[T<task-id>]'`
+   - `orbit.graph.history` has been removed from the agent tool surface; for task-to-commit lookup use `git log --grep '[T<task-id>]'`
 4. **Gather only when needed** — Use `orbit.graph.pack` only for a small set of exact selectors when you need multi-symbol context for synthesis, editing, or review. `file:` selectors return metadata and symbol summaries, not full file source, and leaf bodies stay hidden unless you pass `summary: false`.
 5. **Orient only when scope is unclear** — Use `orbit.graph.overview` when the subtree is unfamiliar or the task is architectural. Broad scopes default to `summary`; ask for `format: "full"` only when you need per-file symbol lists.
 
@@ -122,7 +122,7 @@ Common symbol kinds: `function`, `method`, `struct`, `trait`, `impl`, `field`, `
 - Using `orbit.graph.refs` for trait-implementation questions instead of `orbit.graph.implementors`
 - Using `orbit.graph.refs` for caller-chain questions instead of `orbit.graph.callers`
 - Using `orbit.graph.refs` for crate dependency questions instead of `orbit.graph.deps`
-- Expecting `orbit.graph.history` or `orbit.graph.search` to answer task attribution questions; use `git log --grep '[T<task-id>]'` for local task-to-commit lookup
+- Expecting `orbit.graph.history` or `orbit.graph.search` to answer task attribution questions; `orbit.graph.history` is not agent-callable, and local task-to-commit lookup belongs to `git log --grep '[T<task-id>]'`
 - Packing broad directories or many selectors just to explore
 - Reading full files after `show` or `pack` already gave the needed context
 - Falling back to `fs.read` globally when only some selectors failed

--- a/crates/orbit-core/assets/skills/orbit-learning/SKILL.md
+++ b/crates/orbit-core/assets/skills/orbit-learning/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: orbit-learning
-description: Use this when creating, searching, updating, superseding, or pruning Orbit project learnings via `orbit.learning.*`. Covers scope-OR matching (path globs / tags), evidence shape, the `update` vs `supersede` boundary, the YAML-source-of-truth + SQLite-index model, and why never to edit `.orbit/learnings/` files directly.
+description: Use this when creating, searching, updating, superseding, pruning, or auditing Orbit project learnings. Agent tools cover `orbit.learning.add/show/update/upvote/supersede/prune/comment.*` plus `orbit.search`; list/sync are CLI-only operator workflows. Covers scope-OR matching (path globs / tags), evidence shape, the `update` vs `supersede` boundary, the YAML-source-of-truth + SQLite-index model, and why never to edit `.orbit/learnings/` files directly.
 ---
 
 # Orbit Learning
@@ -23,11 +23,10 @@ migrated by ORB-00200 and should only appear in `legacy_ids`.
 
 Both surfaces accept the same JSON. Use the CLI examples when shell access is available; use the MCP names when the Orbit plugin exposes them.
 
-| Tool | MCP | CLI |
+| Tool / workflow | MCP | CLI |
 |------|-----|-----|
 | `orbit.learning.add` | `orbit_learning_add({...})` | `orbit learning add --summary "..." --path "crates/orbit-core/**/*.rs" --tag rust --body-file note.md` |
-| `orbit.learning.list` | `orbit_learning_list({...})` | `orbit learning list --status active --tag rust` (also `--path <glob-or-file>`) |
-| `orbit.search` | `orbit_search({...})` | `orbit search --kind learning <text>` (lexical free-text match; add `--hybrid` after `orbit semantic index --kind learnings` for lexical + semantic ranking) |
+| Search learnings | `orbit_search({...})` | `orbit search --kind learning <text>` (lexical free-text match; add `--hybrid` after `orbit semantic index --kind learnings` for lexical + semantic ranking) |
 | `orbit.learning.show` | `orbit_learning_show({...})` | `orbit learning show --id L-0001` |
 | `orbit.learning.comment.add` | `orbit_learning_comment_add({...})` | `orbit learning comment add --learning-id L-0001 --body "Narrow note" --model codex` |
 | `orbit.learning.comment.list` | `orbit_learning_comment_list({...})` | `orbit learning comment list --learning-id L-0001` |
@@ -35,11 +34,12 @@ Both surfaces accept the same JSON. Use the CLI examples when shell access is av
 | `orbit.learning.update` | `orbit_learning_update({...})` | `orbit learning update --id L-0001 --priority 200` |
 | `orbit.learning.supersede` | `orbit_learning_supersede({...})` | `orbit learning supersede --id L-0001 --with L-0007` |
 | `orbit.learning.prune` | `orbit_learning_prune({...})` | `orbit learning prune --stale-only` |
-| `orbit.learning.sync` | `orbit_learning_sync({...})` | `orbit learning sync` |
+| List/audit learnings | CLI-only | `orbit learning list --status active --tag rust` (also `--path <glob-or-file>`) |
+| Sync YAML envelope index | CLI-only | `orbit learning sync` |
 
 Mapping rule: `orbit.learning.<verb>` ↔ `orbit_learning_<verb>`. Always include `model` in JSON inputs when the tool accepts it; pass your agent family (`codex`, `claude`, `gemini`, or `grok`). Prefer `--body-file` for `add` and body-changing `update` calls so multi-line markdown is not mangled by shell quoting.
 
-Run `orbit tool list | grep orbit.learning` if you suspect the local tool surface has drifted; do not assume tools beyond the commands above unless the registry shows them.
+Run `orbit tool list | grep orbit.learning` if you suspect the local active tool surface has drifted; use `orbit tool list --all` when auditing CLI-only inactive tools.
 
 ## Workflow
 
@@ -71,7 +71,7 @@ Run `orbit tool list | grep orbit.learning` if you suspect the local tool surfac
 
 6. **Prune for stale.** Run `orbit learning prune --stale-only` periodically to surface learnings whose `scope.paths` no longer resolve to any tracked file (per the `§7.3` staleness rules in the design doc). Combine with `--delete` to archive flagged records by flipping their status to `superseded` with `superseded_by: null` — only do this after reading the candidates and deciding none are still load-bearing.
 
-7. **Sync when YAML is touched out-of-band.** YAML under `.orbit/learnings/` is the source of truth; SQLite is a rebuildable envelope index. If a merge, branch switch, or external script edits the YAML directly, run `orbit learning sync` to re-sync the index — otherwise `list` and `search` will return stale results.
+7. **Sync when YAML is touched out-of-band.** YAML under `.orbit/learnings/` is the source of truth; SQLite is a rebuildable envelope index. If a merge, branch switch, or external script edits the YAML directly, a human/operator can run the CLI-only `orbit learning sync` to re-sync the index — otherwise `list` and `search` will return stale results.
 
 ## Operating Rules
 
@@ -150,7 +150,7 @@ orbit learning prune --stale-only
 | `update` to "fix" a fundamental change in advice | Loses the supersede chain; readers cannot see the old guidance was reversed | `orbit learning supersede --id <old> --with <new>` |
 | Calling `update` on a superseded record | Tool rejects with a typed error | `supersede` from the head of the chain instead |
 | `scope` with no `paths` and no `tags` | Never injects — record is invisible to push | Include at least one `path` glob or one `tag` |
-| Editing YAML directly to "quickly tweak wording" | Index goes stale; next `search` returns old envelope | Use `update`; if YAML must be touched, run `reindex` after |
+| Editing YAML directly to "quickly tweak wording" | Index goes stale; next `search` returns old envelope | Use `update`; if YAML must be touched, run CLI-only `orbit learning sync` after |
 | Treating `priority` as importance | It is the secondary search-ranking key, not a tier | Leave unset unless tuning ranking |
 
 ## Exit Criteria

--- a/crates/orbit-core/assets/skills/orbit-search/SKILL.md
+++ b/crates/orbit-core/assets/skills/orbit-search/SKILL.md
@@ -69,12 +69,12 @@ Do not use search for "find every symbol matching pattern X"; use `orbit.graph.s
 
 `orbit semantic` manages the local embedding companion. It is not the query namespace.
 
-| Purpose | CLI | MCP |
-|---------|-----|-----|
-| Install companion/model | `orbit semantic install [--model MODEL] [--force]` | `orbit.semantic.install` |
-| Remove companion/model | `orbit semantic uninstall [--model MODEL] [--all]` | `orbit.semantic.uninstall` |
-| Show status | `orbit semantic stats` | `orbit.semantic.stats` |
-| Rebuild embeddings | `orbit semantic index --kind tasks|docs|learnings|adrs|all [--model MODEL] [--force]` | `orbit.semantic.index` |
+| Purpose | Surface | Form |
+|---------|---------|------|
+| Install companion/model | CLI-only | `orbit semantic install [--model MODEL] [--force]` |
+| Remove companion/model | CLI-only | `orbit semantic uninstall [--model MODEL] [--all]` |
+| Show status | CLI-only | `orbit semantic stats` |
+| Rebuild embeddings | CLI-only | `orbit semantic index --kind tasks|docs|learnings|adrs|all [--model MODEL] [--force]` |
 
 Do not run `install` without operator consent. If a semantic query fails because the companion is missing, fall back to plain `orbit search --kind <kind> <query>` (lexical) and continue unless the user explicitly asked to enable embeddings.
 

--- a/crates/orbit-core/assets/skills/orbit/SKILL.md
+++ b/crates/orbit-core/assets/skills/orbit/SKILL.md
@@ -26,9 +26,9 @@ Orbit tools are reachable via two surfaces. Both accept identical JSON arguments
 
 - Task lifecycle (`orbit.task.*`): both surfaces.
 - ADR artifacts (`orbit.adr.*`): both surfaces.
-- Graph read tools (`search`, `show`, `pack`, `callers`, `refs`, `implementors`, `deps`, `overview`, `history`): both surfaces.
+- Graph read tools (`search`, `show`, `pack`, `callers`, `refs`, `implementors`, `deps`, `overview`): both surfaces. Task-to-commit lookup is not a graph tool; use `git log --grep '[T<task-id>]'`.
 - Unified search (`orbit.search`): both surfaces. Lexical search works without setup; `hybrid: true` and `semantic: "<task-id>"` require the search companion (`orbit semantic install`).
-- Semantic lifecycle tools (`orbit.semantic.install`, `orbit.semantic.uninstall`, `orbit.semantic.stats`, `orbit.semantic.index`): registered tool surface for managing the local embedding companion.
+- Semantic lifecycle is CLI-only (`orbit semantic install|stats|index|uninstall`); agents discover via `orbit.search --hybrid`.
 - State handoff (`orbit.state.*`), graph writes, and duel/scoreboard tools: **CLI only** — used inside activity steps where the agent has shell access.
 
 **Always include `model` in the JSON** so Orbit can attribute the call to the right agent family. Here `model` means the canonical agent family: pass `codex`, `claude`, `gemini`, or `grok`. Full model strings are accepted and auto-normalized, but the family is the persisted identity.
@@ -107,7 +107,7 @@ Command surface determines provenance by default:
 
 - `orbit-create-task`: Create a new task with description, acceptance criteria, and context.
 - `orbit-adr`: Create, update, inspect, accept, or supersede ADR artifacts through `orbit.adr.*`.
-- `orbit-docs`: Search, show, register, reindex, or migrate the human-authored docs corpus through `orbit.docs.*`. Use for docs retrieval over `docs/`; ADRs remain owned by `orbit-adr`.
+- `orbit-docs`: Search the human-authored docs corpus through `orbit.search --kind doc`; use `orbit docs ...` CLI for human/admin list, show, root registration, indexing, or migration workflows. ADRs remain owned by `orbit-adr`.
 - `orbit-debug-job-failure`: Diagnose failed, stuck, cancelled, or suspicious Orbit job runs.
 - `orbit-execute-task`: Carry a change through implementation, validation, and review.
 - `orbit-review-task`: Review someone else's work and file findings as review threads, without transitioning the task.

--- a/crates/orbit-core/src/command/tool.rs
+++ b/crates/orbit-core/src/command/tool.rs
@@ -23,6 +23,7 @@ pub struct ToolInfo {
     pub name: String,
     pub description: String,
     pub enabled: bool,
+    pub active: bool,
     pub builtin: bool,
     pub parameters: Vec<orbit_common::types::ToolParam>,
 }
@@ -156,6 +157,7 @@ impl OrbitRuntime {
         // surrounding `AuditGuard` to fall back on — would fail without any
         // audit row at all when identity setup is the cause.
         let result: Result<Value, OrbitError> = (|| {
+            self.ensure_tool_agent_facing(name)?;
             let allowed_tools = read_activity_tools_from_env();
             let (agent_name, model_name) = resolve_agent_identity(agent_override, model_override)?;
             let proc_allowed_programs = read_proc_allowed_programs_from_env();
@@ -443,7 +445,22 @@ fn read_input_identity(input: &Value) -> (Option<String>, Option<String>) {
 
 impl OrbitRuntime {
     pub fn list_tools(&self) -> Result<Vec<ToolInfo>, OrbitError> {
-        let registry_schemas = self.tool_registry().schemas();
+        self.list_tools_with_inactive(false)
+    }
+
+    pub fn list_all_tools(&self) -> Result<Vec<ToolInfo>, OrbitError> {
+        self.list_tools_with_inactive(true)
+    }
+
+    fn list_tools_with_inactive(
+        &self,
+        include_inactive: bool,
+    ) -> Result<Vec<ToolInfo>, OrbitError> {
+        let registry_schemas = if include_inactive {
+            self.tool_registry().all_schemas()
+        } else {
+            self.tool_registry().schemas()
+        };
         let stored_tools = self.stores().tools().list()?;
 
         let mut tools: Vec<ToolInfo> = registry_schemas
@@ -451,10 +468,12 @@ impl OrbitRuntime {
             .map(|schema| {
                 let stored = stored_tools.iter().find(|s| s.name == schema.name);
                 let enabled = stored.is_none_or(|s| s.enabled);
+                let active = self.tool_registry().is_active(&schema.name);
                 ToolInfo {
                     name: schema.name.clone(),
                     description: schema.description.clone(),
                     enabled,
+                    active,
                     builtin: schema.builtin,
                     parameters: schema.parameters,
                 }
@@ -468,6 +487,7 @@ impl OrbitRuntime {
                     name: stored.name.clone(),
                     description: stored.description.clone(),
                     enabled: stored.enabled,
+                    active: true,
                     builtin: false,
                     parameters: stored.parameters.clone(),
                 });
@@ -486,11 +506,13 @@ impl OrbitRuntime {
 
         let stored = self.stores().tools().get(name)?;
         let enabled = stored.is_none_or(|s| s.enabled);
+        let active = self.tool_registry().is_active(&schema.name);
 
         Ok(ToolInfo {
             name: schema.name,
             description: schema.description,
             enabled,
+            active,
             builtin: schema.builtin,
             parameters: schema.parameters,
         })
@@ -615,6 +637,18 @@ impl OrbitRuntime {
 
     pub fn disable_tool(&self, name: &str) -> Result<(), OrbitError> {
         self.set_tool_enabled_state(name, false)
+    }
+
+    pub fn ensure_tool_agent_facing(&self, name: &str) -> Result<(), OrbitError> {
+        if self.tool_registry().is_active(name) {
+            return Ok(());
+        }
+        if self.tool_registry().has(name) {
+            return Err(OrbitError::Execution(format!(
+                "tool '{name}' is inactive on the agent tool surface; use the corresponding `orbit <subcommand>` CLI path for human/admin workflows"
+            )));
+        }
+        Err(OrbitError::not_found(NotFoundKind::Tool, name.to_string()))
     }
 
     fn set_tool_enabled_state(&self, name: &str, enabled: bool) -> Result<(), OrbitError> {

--- a/crates/orbit-core/src/runtime/orbit_tool_host/tests/learning_tools.rs
+++ b/crates/orbit-core/src/runtime/orbit_tool_host/tests/learning_tools.rs
@@ -60,7 +60,7 @@ fn create_minimal(
 #[test]
 fn registry_exposes_learning_tools_with_documented_schema_fields() {
     let registry = registry_with_builtins();
-    let schemas = registry.schemas();
+    let schemas = registry.all_schemas();
     let names: Vec<&str> = schemas
         .iter()
         .map(|s| s.name.as_str())

--- a/crates/orbit-core/src/runtime/pipeline.rs
+++ b/crates/orbit-core/src/runtime/pipeline.rs
@@ -116,6 +116,7 @@ impl OrbitRuntime {
     }
 
     pub fn run_tool_dry_run(&self, name: &str, input: &Value) -> Result<DryRunResult, OrbitError> {
+        self.ensure_tool_agent_facing(name)?;
         self.check_tool_enabled(name)?;
 
         let schema = self

--- a/crates/orbit-tools/src/builtin/orbit/mod.rs
+++ b/crates/orbit-tools/src/builtin/orbit/mod.rs
@@ -38,11 +38,11 @@ pub fn register(registry: &mut ToolRegistry) {
     registry.register(adr::show::OrbitAdrShowTool);
     registry.register(adr::supersede::OrbitAdrSupersedeTool);
     registry.register(adr::update::OrbitAdrUpdateTool);
-    registry.register(docs::OrbitDocsListTool);
-    registry.register(docs::OrbitDocsShowTool);
-    registry.register(docs::OrbitDocsAddTool);
-    registry.register(docs::OrbitDocsIndexTool);
-    registry.register(docs::OrbitDocsMigrateTool);
+    registry.register_inactive(docs::OrbitDocsListTool);
+    registry.register_inactive(docs::OrbitDocsShowTool);
+    registry.register_inactive(docs::OrbitDocsAddTool);
+    registry.register_inactive(docs::OrbitDocsIndexTool);
+    registry.register_inactive(docs::OrbitDocsMigrateTool);
     registry.register(groundhog::checkpoint_success::OrbitGroundhogCheckpointSuccessTool);
     registry.register(groundhog::checkpoint_failure::OrbitGroundhogCheckpointFailureTool);
     registry.register(groundhog::side_effect::OrbitGroundhogSideEffectTool);
@@ -50,7 +50,7 @@ pub fn register(registry: &mut ToolRegistry) {
     registry.register(friction::list::OrbitFrictionListTool);
     registry.register(friction::resolve::OrbitFrictionResolveTool);
     registry.register(friction::show::OrbitFrictionShowTool);
-    registry.register(friction::stats::OrbitFrictionStatsTool);
+    registry.register_inactive(friction::stats::OrbitFrictionStatsTool);
     registry.register(friction::tags::OrbitFrictionTagsTool);
     registry.register(friction::update::OrbitFrictionUpdateTool);
     registry.register(task::add::OrbitTaskAddTool);
@@ -58,9 +58,9 @@ pub fn register(registry: &mut ToolRegistry) {
     registry.register(task::approve::OrbitTaskApproveTool);
     registry.register(task::delete::OrbitTaskDeleteTool);
     registry.register(task::lint::OrbitTaskLintTool);
-    registry.register(task::locks::OrbitTaskLocksTool);
-    registry.register(task::locks_reserve::OrbitTaskLocksReserveTool);
-    registry.register(task::locks_release::OrbitTaskLocksReleaseTool);
+    registry.register_inactive(task::locks::OrbitTaskLocksTool);
+    registry.register_inactive(task::locks_reserve::OrbitTaskLocksReserveTool);
+    registry.register_inactive(task::locks_release::OrbitTaskLocksReleaseTool);
     registry.register(task::start::OrbitTaskStartTool);
     registry.register(task::reject::OrbitTaskRejectTool);
     registry.register(task::show::OrbitTaskShowTool);
@@ -68,7 +68,7 @@ pub fn register(registry: &mut ToolRegistry) {
     registry.register(task::update::OrbitTaskUpdateTool);
     registry.register(duel::plan_add::OrbitDuelPlanAddTool);
     registry.register(duel::plan_winner::OrbitDuelPlanWinnerTool);
-    registry.register(graph_history::OrbitGraphHistoryTool);
+    registry.register_inactive(graph_history::OrbitGraphHistoryTool);
     registry.register(knowledge::callers::OrbitKnowledgeCallersTool);
     registry.register(knowledge::deps::OrbitKnowledgeDepsTool);
     registry.register(knowledge::implementors::OrbitKnowledgeImplementorsTool);
@@ -81,9 +81,9 @@ pub fn register(registry: &mut ToolRegistry) {
     registry.register(learning::comment_add::OrbitLearningCommentAddTool);
     registry.register(learning::comment_delete::OrbitLearningCommentDeleteTool);
     registry.register(learning::comment_list::OrbitLearningCommentListTool);
-    registry.register(learning::list::OrbitLearningListTool);
+    registry.register_inactive(learning::list::OrbitLearningListTool);
     registry.register(learning::prune::OrbitLearningPruneTool);
-    registry.register(learning::sync::OrbitLearningSyncTool);
+    registry.register_inactive(learning::sync::OrbitLearningSyncTool);
     registry.register(learning::show::OrbitLearningShowTool);
     registry.register(learning::supersede::OrbitLearningSupersedeTool);
     registry.register(learning::update::OrbitLearningUpdateTool);
@@ -99,10 +99,10 @@ pub fn register(registry: &mut ToolRegistry) {
     registry.register(review_thread::resolve::OrbitReviewThreadResolveTool);
     registry.register(review_thread::resolve::OrbitReviewThreadResolveAliasTool);
     registry.register(search::OrbitSearchTool);
-    registry.register(semantic::install::OrbitSemanticInstallTool);
+    registry.register_inactive(semantic::install::OrbitSemanticInstallTool);
     registry.register(semantic::uninstall::OrbitSemanticUninstallTool);
-    registry.register(semantic::stats::OrbitSemanticStatsTool);
-    registry.register(semantic::index::OrbitSemanticIndexTool);
+    registry.register_inactive(semantic::stats::OrbitSemanticStatsTool);
+    registry.register_inactive(semantic::index::OrbitSemanticIndexTool);
     registry.register(state::get::OrbitStateGetTool);
     registry.register(state::set::OrbitStateSetTool);
 }

--- a/crates/orbit-tools/src/registry.rs
+++ b/crates/orbit-tools/src/registry.rs
@@ -6,9 +6,26 @@ use serde_json::Value;
 
 use crate::{Tool, ToolContext};
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ToolAvailability {
+    Active,
+    Inactive,
+}
+
+impl ToolAvailability {
+    pub fn is_active(self) -> bool {
+        matches!(self, Self::Active)
+    }
+}
+
+struct ToolEntry {
+    tool: Arc<dyn Tool>,
+    availability: ToolAvailability,
+}
+
 #[derive(Default)]
 pub struct ToolRegistry {
-    tools: HashMap<String, Arc<dyn Tool>>,
+    tools: HashMap<String, ToolEntry>,
 }
 
 impl ToolRegistry {
@@ -19,8 +36,26 @@ impl ToolRegistry {
     }
 
     pub fn register<T: Tool + 'static>(&mut self, tool: T) {
+        self.register_with_availability(tool, ToolAvailability::Active);
+    }
+
+    pub fn register_inactive<T: Tool + 'static>(&mut self, tool: T) {
+        self.register_with_availability(tool, ToolAvailability::Inactive);
+    }
+
+    fn register_with_availability<T: Tool + 'static>(
+        &mut self,
+        tool: T,
+        availability: ToolAvailability,
+    ) {
         let schema = tool.schema();
-        self.tools.insert(schema.name, Arc::new(tool));
+        self.tools.insert(
+            schema.name,
+            ToolEntry {
+                tool: Arc::new(tool),
+                availability,
+            },
+        );
     }
 
     pub fn register_builtins(&mut self) {
@@ -37,15 +72,31 @@ impl ToolRegistry {
             .tools
             .get(name)
             .ok_or_else(|| OrbitError::not_found(NotFoundKind::Tool, name.to_string()))?;
-        tool.execute(ctx, input)
+        tool.tool.execute(ctx, input)
     }
 
     pub fn get_schema(&self, name: &str) -> Option<ToolSchema> {
-        self.tools.get(name).map(|t| t.schema())
+        self.tools.get(name).map(|entry| entry.tool.schema())
+    }
+
+    pub fn get_active_schema(&self, name: &str) -> Option<ToolSchema> {
+        self.tools
+            .get(name)
+            .filter(|entry| entry.availability.is_active())
+            .map(|entry| entry.tool.schema())
     }
 
     pub fn has(&self, name: &str) -> bool {
         self.tools.contains_key(name)
+    }
+
+    pub fn availability(&self, name: &str) -> Option<ToolAvailability> {
+        self.tools.get(name).map(|entry| entry.availability)
+    }
+
+    pub fn is_active(&self, name: &str) -> bool {
+        self.availability(name)
+            .is_some_and(ToolAvailability::is_active)
     }
 
     pub fn unregister(&mut self, name: &str) -> bool {
@@ -53,6 +104,17 @@ impl ToolRegistry {
     }
 
     pub fn schemas(&self) -> Vec<ToolSchema> {
-        self.tools.values().map(|t| t.schema()).collect()
+        self.tools
+            .values()
+            .filter(|entry| entry.availability.is_active())
+            .map(|entry| entry.tool.schema())
+            .collect()
+    }
+
+    pub fn all_schemas(&self) -> Vec<ToolSchema> {
+        self.tools
+            .values()
+            .map(|entry| entry.tool.schema())
+            .collect()
     }
 }

--- a/crates/orbit-tools/tests/public_tool_surface.rs
+++ b/crates/orbit-tools/tests/public_tool_surface.rs
@@ -7,7 +7,7 @@ use std::collections::BTreeSet;
 use orbit_common::types::RETIRED_TASK_ADD_INPUT_FIELDS;
 use orbit_tools::ToolRegistry;
 
-const MCP_HIDDEN_CLI_TOOL_NAMES: &[&str] = &[
+const INACTIVE_TOOL_NAMES: &[&str] = &[
     "orbit.docs.index",
     "orbit.docs.migrate",
     "orbit.docs.add",
@@ -23,11 +23,6 @@ const MCP_HIDDEN_CLI_TOOL_NAMES: &[&str] = &[
     "orbit.learning.sync",
     "orbit.learning.list",
     "orbit.friction.stats",
-    "orbit.friction.resolve",
-    "orbit.friction.show",
-    "orbit.friction.tags",
-    "orbit.friction.update",
-    "orbit.friction.list",
 ];
 
 #[test]
@@ -120,13 +115,35 @@ fn workflow_critical_tools_remain_registered() {
 }
 
 #[test]
-fn mcp_hidden_ops_tools_remain_registered_for_cli_surface() {
+fn inactive_ops_tools_are_hidden_from_default_registry_surface() {
     let names = registered_tool_names();
 
-    for retained in MCP_HIDDEN_CLI_TOOL_NAMES {
+    for inactive in INACTIVE_TOOL_NAMES {
         assert!(
-            names.contains(*retained),
-            "MCP-hidden tool must remain registered for CLI use: {retained}"
+            !names.contains(*inactive),
+            "inactive tool must be hidden from default registry schemas: {inactive}"
+        );
+    }
+}
+
+#[test]
+fn inactive_ops_tools_remain_auditable_in_full_registry_surface() {
+    let mut registry = ToolRegistry::new();
+    registry.register_builtins();
+    let all_names = registry
+        .all_schemas()
+        .into_iter()
+        .map(|schema| schema.name)
+        .collect::<BTreeSet<_>>();
+
+    for inactive in INACTIVE_TOOL_NAMES {
+        assert!(
+            all_names.contains(*inactive),
+            "inactive tool must remain registered for inspection: {inactive}"
+        );
+        assert!(
+            !registry.is_active(inactive),
+            "inactive tool must be marked inactive in the registry: {inactive}"
         );
     }
 }
@@ -158,7 +175,6 @@ fn friction_surface_supports_artifact_triage() {
         "orbit.friction.list",
         "orbit.friction.resolve",
         "orbit.friction.show",
-        "orbit.friction.stats",
         "orbit.friction.tags",
         "orbit.friction.update",
     ] {
@@ -174,6 +190,10 @@ fn friction_surface_supports_artifact_triage() {
             "destructive friction tool registered: {removed}"
         );
     }
+    assert!(
+        !names.contains("orbit.friction.stats"),
+        "friction stats is CLI-only and must stay hidden from the default registry surface"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Task

[ORB-00280](https://orbit-cli.com/tasks/ORB-00280) — Mark 15 ops/maintenance tools inactive in the registry and scrub references from README + agent skills

### Description

## Problem

ORB-00272 hid 15 ops/maintenance tools from the MCP `tools/list` response by adding a `MCP_HIDDEN_TOOL_NAMES` denylist in `orbit-cli`. By design, codex kept these tools visible in `orbit tool list` and callable via `orbit tool run`. ORB-00278 was filed to narrow the denylist further but did not address the deeper issue.

Desired end state: **these 15 tools are inactive at the registry layer**, which means:
- They do NOT appear in `orbit tool list` (default invocation).
- They are NOT callable via `orbit tool run <name>` or MCP `tools/call`.
- They are NOT advertised on the MCP `tools/list` response.
- The corresponding `orbit <subcommand>` CLI paths (`orbit docs list`, `orbit task locks`, `orbit semantic install`, `orbit graph history`, `orbit learning sync`, `orbit friction stats`) continue to work for humans/admins — these are separate code paths from the tool registry.
- Inspection escape hatch (`orbit tool list --all` or `--include-hidden`) shows the inactive tools so an operator can audit the full registry.

In parallel, **README.md and agent skill instructions stop referencing these tools** in agent-callable contexts. Where the underlying operation is still meaningful to a human, references point at the CLI subcommand.

This task supersedes ORB-00278.

## Tools to mark inactive (15)

```
orbit.docs.index
orbit.docs.migrate
orbit.docs.add
orbit.docs.list
orbit.docs.show
orbit.task.locks
orbit.task.locks.release
orbit.task.locks.reserve
orbit.semantic.index
orbit.semantic.install
orbit.semantic.stats
orbit.graph.history
orbit.learning.sync
orbit.learning.list
orbit.friction.stats
```

## Mechanism (executor decides)

Flavors that fit the codebase shape:

1. **Per-tool attribute on the tool definition** (e.g. `agent_facing: false` or `default_enabled: false`). At registration time, the registry stores the flag; default views filter by it; `--all` overrides. Probably cleanest.
2. **Inactive at startup via the existing `enabled` boolean** (`crates/orbit-store/src/sqlite/tool_store.rs:100` `set_tool_enabled`). Builtins normally register active; this would have them register inactive. Pairs with a one-time migration for existing workspaces.
3. **Registry-level denylist applied at both `orbit tool list` rendering and MCP `tools/list` build** — extension of the current `MCP_HIDDEN_TOOL_NAMES` to both surfaces. Lowest-risk, but `enabled=true` would still be reported by `tool show`, which is misleading.

Choose whichever fits the existing pattern; prefer (1) if there's no existing precedent. Document the choice in the PR.

If (1) is chosen, the existing `MCP_HIDDEN_TOOL_NAMES` denylist in `crates/orbit-cli/src/command/mcp/mod.rs` can be REMOVED — the registry filter is upstream and covers MCP too.

## README updates

The "Orbit MCP Tool Surface" table currently lists all 15 tools as agent-callable. Either:

- (Preferred) **Remove the 15 rows entirely** from the table. The table represents what agents see; CLI-only operations live in a separate section.
- OR move the 15 to a clearly labelled "CLI-only (not exposed to agents)" sub-table.

Add a one-line note explaining the boundary: agents discover via `orbit.search`; CLI-only operations are admin/setup workflows.

## Skill instruction updates

Each skill file currently references these tools as if agent-callable. Update each to point at the right alternative:

- **`orbit/SKILL.md`** (router) — Line 31's "Semantic lifecycle tools (`orbit.semantic.install`, ...): registered tool surface for managing the local embedding companion" needs revision. New phrasing: "Semantic lifecycle is CLI-only (`orbit semantic install|stats|index|uninstall`); agents discover via `orbit.search --hybrid`."
- **`orbit-docs/SKILL.md`** — Heavy rewrite. The skill's tool-reference table maps `orbit docs list/show/add/index/migrate` to MCP forms; remove the MCP column entirely or annotate the rows as "CLI-only". Reframe the skill's agent-callable surface as `orbit.search --kind doc`. Lines 60-65 (table) and 74-78 (numbered guidance) need editing.
- **`orbit-search/SKILL.md`** — Lines 74-77 (the semantic lifecycle table) should be CLI-only (drop the MCP form column). Line 8's lifecycle reference can stay since it already uses CLI form.
- **`orbit-learning/SKILL.md`** — Lines 30 (search reference is fine — `orbit.search`), 38 (`orbit.learning.sync` row in the tool table — remove or annotate CLI-only), 50 (`orbit semantic index` reference is already CLI — fine), 74 (sync guidance — keep but reframe as CLI-only operator note). Remove the `orbit.learning.list` row from the tool table or annotate it as CLI-only.
- **`orbit-adr/SKILL.md`** — Lines 12 and 52 reference `orbit semantic index --kind adrs` — already CLI form, but verify no MCP `orbit.semantic.*` invocations remain.
- **`orbit-graph/SKILL.md`** — Lines 30 and 125 mention `orbit.graph.history`. Strengthen to "removed from agent surface; use `git log --grep '[T<task-id>]'` for task-to-commit lookup." Drop any phrasing that implies it's callable.
- **`orbit-guide/SKILL.md`** — Line 64's `orbit semantic stats` is already CLI form; verify no MCP references.
- **`orbit-debug-job-failure/references/common_failures.md`** — Lines 13, 19, 39 reference `orbit.task.locks` and `orbit.task.locks.release`. Reframe as CLI-only: `orbit task locks` / `orbit task locks release <reservation_id>`. The diagnostic workflow remains valid for human operators.

## Constraints / Notes

- **Don't break CLI subcommands.** The `orbit docs list`, `orbit task locks`, `orbit semantic install` etc. CLI paths must continue to function for humans. They're separate code paths from the tool registry — verify with smoke tests.
- **Architecture compliance.** Don't add cross-crate dependencies. The change should live in `orbit-tools` (per-tool attribute) and `orbit-cli` (display filtering) — follow [`ARCHITECTURE.md`](ARCHITECTURE.md).
- **Same-PR doc updates.** Per CLAUDE.md "Same-PR updates," the README and skill changes must land in the same PR as the registry change. If the mechanism introduces a new "agent-facing" concept, capture it as an ADR under `docs/design/<feature>/4_decisions.md`.
- **Downstream cleanup (out of scope).** After this lands, `.claude/settings.json` (and equivalents) can drop the 15 deny entries — but that's a separate config-only PR.

## Suggested scoping pass before planning

Use `codegraph_search` on `register_builtins`, `ToolSchema`, and `set_tool_enabled` to confirm the registration shape. Check whether tool definitions carry any existing attribute that could be reused (e.g. an `agent_facing` or `default_enabled` field) before inventing a new one.

### Acceptance Criteria

- After change, `orbit tool list` (default invocation, no flags) does NOT list any of the 15 named tools: `orbit.docs.index`, `orbit.docs.migrate`, `orbit.docs.add`, `orbit.docs.list`, `orbit.docs.show`, `orbit.task.locks`, `orbit.task.locks.release`, `orbit.task.locks.reserve`, `orbit.semantic.index`, `orbit.semantic.install`, `orbit.semantic.stats`, `orbit.graph.history`, `orbit.learning.sync`, `orbit.learning.list`, `orbit.friction.stats`.
- An inspection escape hatch (e.g. `orbit tool list --all` or `--include-hidden`) DOES list all 15 with a clear status marker indicating they are inactive / hidden by default.
- Calling any of the 15 tools via `orbit tool run <name>` returns an error (e.g. "tool inactive" or "not found"), not a successful execution.
- The MCP `tools/list` response from `orbit mcp serve` does NOT include any of the 15 tools.
- All other previously-exposed tools remain present in both surfaces. Specifically verify `orbit.search`, all `orbit.task.*` except `locks*`, all `orbit.graph.*` except `history`, all `orbit.adr.*`, `orbit.learning.add/update/show/upvote/supersede/prune/comment.*`, and `orbit.friction.add/list/show/update/resolve/tags`.
- Each of the affected CLI subcommands still functions for humans. Smoke test: run `orbit docs list --help`, `orbit task locks --help`, `orbit semantic install --help`, `orbit graph history --help`, `orbit learning sync --help`, `orbit learning list --help`, `orbit friction stats --help`. Each exits 0 and prints usage.
- `README.md` "Orbit MCP Tool Surface" table either removes the 15 rows entirely or relocates them to a clearly labelled "CLI-only (not exposed to agents)" sub-table. The remaining table accurately reflects what `orbit mcp serve` advertises.
- Agent skill instructions updated per the description (orbit, orbit-docs, orbit-search, orbit-learning, orbit-adr, orbit-graph, orbit-guide, orbit-debug-job-failure). Specifically: no MCP-form examples for any of the 15 inactive tools; references redirect to either `orbit.search` (for discovery) or the appropriate `orbit <subcommand>` CLI (for admin/setup workflows).
- Test guards updated: `crates/orbit-tools/tests/public_tool_surface.rs`, `crates/orbit-cli/tests/tool_list.rs`, and `crates/orbit-cli/src/command/mcp/tests/mod.rs` reflect the new inactive state and assert the 15 named tools are absent from default views.
- `make ci-fast` passes on the PR branch.
- PR description names the chosen mechanism (per-tool attribute, registration-time disable, etc.) and the inspection flag (`--all` / `--include-hidden`). Notes whether `MCP_HIDDEN_TOOL_NAMES` was removed or retained.
- Follow-up note in the task execution summary: the 15 entries can be removed from `.claude/settings.json` (and equivalent `.codex/.grok/.gemini/` configs) in a separate PR.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Added registry-level `ToolAvailability` so builtins can be active or inactive; the 15 ops/maintenance tools now register inactive, stay visible through full inspection, and are hidden from default registry schemas.
- Added `orbit tool list --all` with `--include-hidden` alias plus `active`/`status` JSON fields and an inactive table marker; public `orbit tool run` and dry-run reject inactive tools.
- Removed `MCP_HIDDEN_TOOL_NAMES`; MCP exposure now omits inactive tools at the safe-list/category layer, adds the ADR tool family, and relies on the registry default list for advertised schemas.
- Kept human/admin CLI paths working, including a CLI-only `orbit task locks release <reservation_id>` wrapper for stale reservation cleanup.
- Updated README, bundled skills, and agent activity allowlists to steer agents toward `orbit.search` or CLI-only admin commands instead of inactive MCP/tool-run forms.
- Updated public surface, CLI list, MCP, docs, learning registry, and agent dispatch tests for inactive/default-vs-all behavior.

Strategic decisions:
- Chosen mechanism: registry-level per-tool inactive availability, defaulting to active.
- Inspection flag: `orbit tool list --all`; `--include-hidden` is an alias.
- `MCP_HIDDEN_TOOL_NAMES` was removed rather than retained.

Validation:
- `cargo test -p orbit-tools --test public_tool_surface`
- `cargo test -p orbit-cli --test tool_list`
- `cargo test -p orbit-cli command::mcp::tests`
- `cargo test -p orbit-cli --test docs`
- `cargo test -p orbit-core registry_exposes_learning_tools_with_documented_schema_fields`
- `cargo test -p orbit-core default_activity_catalog_allowlists_resolve_registered_tools`
- `cargo test -p orbit-agent build_tool_specs`
- Smoke-tested the required CLI help commands, default/all tool-list checks, `--include-hidden`, and all 15 inactive `orbit tool run <name>` failures with `target/debug/orbit`.
- `make ci-fast`

Recommended follow-ups:
- The 15 entries can be removed from `.claude/settings.json` and equivalent `.codex/.grok/.gemini/` configs in a separate config-only PR.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-00280-6a114523`
- Behind base: 0
- Ahead of base: 1