### PR TITLE
[ORB-00288] Fix make ci: needless_borrow clippy + activity_v2 audit tests

### DIFF
--- a/crates/orbit-core/src/command/activity_v2.rs
+++ b/crates/orbit-core/src/command/activity_v2.rs
@@ -28,6 +28,7 @@ pub struct V2ActivityRunResult {
     pub success: bool,
     pub output: Value,
     pub message: Option<String>,
+    pub run_id: String,
     pub audit_jsonl: Option<PathBuf>,
     pub events_emitted: usize,
     /// Resolved execution backend applied to the asset at load time. `None`
@@ -37,8 +38,9 @@ pub struct V2ActivityRunResult {
 }
 
 impl OrbitRuntime {
-    /// Execute a v2 activity from a YAML path. Returns a structural result
-    /// plus the path to the persisted §7 envelope JSONL.
+    /// Execute a v2 activity from a YAML path. Returns a structural result.
+    /// Audit events for the run are queryable via `list_v2_audit_events` using
+    /// the `run_id` (the legacy envelope JSONL path is `None` post SQLite migration).
     ///
     /// `backend_flag` is the `--backend` invocation-level override; when
     /// `None`, the resolver falls through to env → config → default.
@@ -155,6 +157,7 @@ impl OrbitRuntime {
                 success: o.success,
                 output: o.output,
                 message: o.message,
+                run_id,
                 audit_jsonl,
                 events_emitted: events_count,
                 resolved_backend,
@@ -244,21 +247,17 @@ spec:
             .run_activity_v2_from_yaml(&yaml_path, json!({ "seconds": 0 }), None)
             .expect("direct activity run succeeds");
 
-        let audit_jsonl = result.audit_jsonl.as_ref().expect("audit jsonl path");
-        let first_line = std::fs::read_to_string(audit_jsonl)
-            .expect("read audit jsonl")
-            .lines()
-            .next()
-            .expect("audit jsonl has a first event")
-            .to_string();
-        let first_event: serde_json::Value =
-            serde_json::from_str(&first_line).expect("parse first audit event");
-        assert_eq!(
-            first_event
-                .get("agent_identity")
-                .and_then(serde_json::Value::as_str),
-            Some(SYSTEM_AUDIT_IDENTITY)
+        let events = runtime
+            .list_v2_audit_events(crate::V2AuditEventFilter {
+                run_id: Some(result.run_id.clone()),
+                ..Default::default()
+            })
+            .expect("list v2 audit events");
+        assert!(
+            !events.is_empty(),
+            "activity run should emit at least one audit event"
         );
+        assert_eq!(events[0].agent_identity, SYSTEM_AUDIT_IDENTITY);
     }
 
     #[cfg(unix)]
@@ -274,15 +273,19 @@ spec:
 
         assert!(!result.success);
         assert_eq!(result.message.as_deref(), Some("exit 7 not in [0]"));
-        let audit_jsonl = result.audit_jsonl.as_ref().expect("audit jsonl path");
-        let run_finished = std::fs::read_to_string(audit_jsonl)
-            .expect("read audit jsonl")
-            .lines()
-            .find(|line| line.contains(r#""body_kind":"run_finished""#))
-            .expect("run_finished audit event")
-            .to_string();
+
+        let events = runtime
+            .list_v2_audit_events(crate::V2AuditEventFilter {
+                run_id: Some(result.run_id.clone()),
+                ..Default::default()
+            })
+            .expect("list v2 audit events");
+        let run_finished = events
+            .iter()
+            .find(|e| e.payload_json.contains(r#""body_kind":"run_finished""#))
+            .expect("run_finished audit event");
         let event: serde_json::Value =
-            serde_json::from_str(&run_finished).expect("parse run_finished");
+            serde_json::from_str(&run_finished.payload_json).expect("parse run_finished");
         assert_eq!(
             event.get("outcome").and_then(serde_json::Value::as_str),
             Some("failed")

--- a/crates/orbit-dashboard/src/api/review_threads.rs
+++ b/crates/orbit-dashboard/src/api/review_threads.rs
@@ -136,7 +136,7 @@ pub(super) async fn reply_review_thread_action(
     if reply_body.is_empty() {
         return bad_request("reply body must not be empty".to_string());
     }
-    let task_status = match runtime.get_task(&validated_id) {
+    let task_status = match runtime.get_task(validated_id) {
         Ok(t) => t.status,
         Err(e) => return map_runtime_error(e),
     };
@@ -159,7 +159,7 @@ pub(super) async fn resolve_review_thread_action(
     if thread_id.trim().is_empty() {
         return bad_request("thread_id must not be empty".to_string());
     }
-    let task_status = match runtime.get_task(&validated_id) {
+    let task_status = match runtime.get_task(validated_id) {
         Ok(t) => t.status,
         Err(e) => return map_runtime_error(e),
     };
@@ -182,7 +182,7 @@ pub(super) async fn reopen_review_thread_action(
     if thread_id.trim().is_empty() {
         return bad_request("thread_id must not be empty".to_string());
     }
-    let task_status = match runtime.get_task(&validated_id) {
+    let task_status = match runtime.get_task(validated_id) {
         Ok(t) => t.status,
         Err(e) => return map_runtime_error(e),
     };


### PR DESCRIPTION
## Summary

Fixes two issues that were causing `make ci` (the canonical merge gate) to fail on `agent-main`:

1. **Clippy `-D warnings`**: 3× `clippy::needless_borrow` in `crates/orbit-dashboard/src/api/review_threads.rs` (the `get_task(&validated_id)` calls after `validate_id` returns `&str`).
2. **Test failures**: Hard panics in `orbit-core::command::activity_v2` tests that were still doing `.expect("audit jsonl path")` + `fs::read_to_string` on `result.audit_jsonl` (now always `None` after the v2 SQLite audit migration).

The activity test rewrite exactly implements plan item 3 of the still-open ORB-00282.

## Changes

- `crates/orbit-dashboard/src/api/review_threads.rs`: removed the three needless `&`.
- `crates/orbit-core/src/command/activity_v2.rs`: added `run_id: String` to `V2ActivityRunResult`, updated the runner + docs, rewrote the two tests to query via `runtime.list_v2_audit_events(V2AuditEventFilter { run_id: Some(...), .. })` and assert on the persisted rows (matching the pattern used in the dashboard API tests).

Only these two files are in the PR (scoped to the task).

## Verification

- `make ci-fast` ✅
- `cargo clippy --workspace --all-targets -D warnings` ✅ (clean across the entire workspace)
- `cargo test -p orbit-core command::activity_v2` (and under parallelism) ✅
- `cargo test -p orbit-cli --bin orbit -- --test-threads=4` ✅
- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --workspace` ✅

Task: ORB-00288 (created via the official `orbit tool run orbit.task.add` surface)

Ready for review.