### PR TITLE
Code-quality cleanup for ORB-00276 v2 state SQLite migration

### DIFF
--- a/crates/orbit-agent/README.md
+++ b/crates/orbit-agent/README.md
@@ -23,7 +23,7 @@ crates/orbit-agent/src/loop_engine/
   session.rs        Session (id, provider, model, system_prompt, history)
   transport.rs      LoopTransport trait + Message/ContentBlock/TurnRequest/TurnResponse
   tool_dispatch.rs  Thin adapter around orbit_tools::ToolRegistry::execute
-  audit/            LoopAuditEvent, AuditSink, JsonlFileSink, BlobStore, redaction
+  audit/            LoopAuditEvent, AuditSink, InMemorySink, BlobStore, redaction
 ```
 
 - `AgentLoop::run(session, cfg, transport, registry, ctx, sink, prompt)`
@@ -132,18 +132,19 @@ Every event carries `run_id`, `session_id`, optional `task_id`, and
 
 ### Default sink layout
 
-`JsonlFileSink::open(audit_root, run_id)` prepares:
+Orbit runtime callers construct the v2 audit writer in `orbit-engine` with a
+SQLite-backed sink. Loop and envelope events are inserted into the v2 audit
+tables under the runtime audit database; redacted payload bodies still use the
+content-addressed blob store:
 
 ```
 {audit_root}/
-  loop/{run_id}.jsonl              one JSON object per line, append-only, created on first event
   blobs/{hash[..2]}/{hash}         content-addressed redacted payloads
 ```
 
-The JSONL file and blob store are designed to be read by a later
-`orbit.audit.loop.*` query tool family (split to its own follow-up
-task). Humans can inspect them today as JSONL/blob files; `orbit audit`
-queries the separate SQLite command-audit store.
+The SQLite rows and blob store are designed to be read by Orbit's v2 audit
+query surfaces. Humans can inspect blob payloads by hash; event metadata and
+payload JSON are queried from SQLite rather than per-run JSONL files.
 
 Orbit runtime callers pass `.orbit/state/audit` as `audit_root`; standalone
 examples use temporary roots under the system temp directory.

--- a/crates/orbit-cli/src/command/run/job.rs
+++ b/crates/orbit-cli/src/command/run/job.rs
@@ -46,11 +46,6 @@ impl Execute for JobRunArgs {
                 ));
             }
             let result = runtime.run_job_v2_from_yaml(&direct_path, input, backend_flag)?;
-            let audit_jsonl_str = result
-                .audit_jsonl
-                .as_ref()
-                .map(|p| p.display().to_string())
-                .unwrap_or_else(|| "-".to_string());
             let backend_str = result.resolved_backend.as_str();
             if self.json {
                 return crate::output::json::print_pretty(&json!({
@@ -60,18 +55,12 @@ impl Execute for JobRunArgs {
                     "success": result.success,
                     "message": result.message,
                     "pipeline": result.pipeline,
-                    "audit_jsonl": audit_jsonl_str,
                     "events_emitted": result.events_emitted,
                 }));
             }
             println!(
-                "run_id={};job={};backend={};success={};events={};audit_jsonl={}",
-                result.run_id,
-                result.job_name,
-                backend_str,
-                result.success,
-                result.events_emitted,
-                audit_jsonl_str,
+                "run_id={};job={};backend={};success={};events={}",
+                result.run_id, result.job_name, backend_str, result.success, result.events_emitted,
             );
             if let Some(msg) = &result.message {
                 println!("message: {msg}");
@@ -93,11 +82,6 @@ impl Execute for JobRunArgs {
             return Err(OrbitError::InvalidInput(build_subroutine_run_error(&job)));
         }
         let result = runtime.run_job_v2_from_yaml(&job.path, input, backend_flag)?;
-        let audit_jsonl_str = result
-            .audit_jsonl
-            .as_ref()
-            .map(|p| p.display().to_string())
-            .unwrap_or_else(|| "-".to_string());
         let backend_str = result.resolved_backend.as_str();
         if self.json {
             crate::output::json::print_pretty(&json!({
@@ -108,19 +92,17 @@ impl Execute for JobRunArgs {
                 "success": result.success,
                 "message": result.message,
                 "pipeline": result.pipeline,
-                "audit_jsonl": audit_jsonl_str,
                 "events_emitted": result.events_emitted,
             }))
         } else {
             println!(
-                "run_id={};job_id={};kind={};backend={};success={};events={};audit_jsonl={}",
+                "run_id={};job_id={};kind={};backend={};success={};events={}",
                 result.run_id,
                 job.job_id.as_str(),
                 job.kind(),
                 backend_str,
                 result.success,
                 result.events_emitted,
-                audit_jsonl_str,
             );
             if let Some(msg) = &result.message {
                 println!("message: {msg}");
@@ -148,11 +130,6 @@ impl Execute for JobReplayArgs {
     fn execute(self, runtime: &OrbitRuntime) -> Result<(), OrbitError> {
         let source_run_id = self.run_id;
         let result = runtime.replay_job_run(&source_run_id)?;
-        let audit_jsonl_str = result
-            .audit_jsonl
-            .as_ref()
-            .map(|p| p.display().to_string())
-            .unwrap_or_else(|| "-".to_string());
         let backend_str = result.resolved_backend.as_str();
         if self.json {
             return crate::output::json::print_pretty(&json!({
@@ -163,19 +140,17 @@ impl Execute for JobReplayArgs {
                 "success": result.success,
                 "message": result.message,
                 "pipeline": result.pipeline,
-                "audit_jsonl": audit_jsonl_str,
                 "events_emitted": result.events_emitted,
             }));
         }
         println!(
-            "run_id={};replayed_from={};job={};backend={};success={};events={};audit_jsonl={}",
+            "run_id={};replayed_from={};job={};backend={};success={};events={}",
             result.run_id,
             source_run_id,
             result.job_name,
             backend_str,
             result.success,
             result.events_emitted,
-            audit_jsonl_str,
         );
         if let Some(msg) = &result.message {
             println!("message: {msg}");

--- a/crates/orbit-common/src/types/activity_job/audit_envelope.rs
+++ b/crates/orbit-common/src/types/activity_job/audit_envelope.rs
@@ -6,6 +6,15 @@ use serde::{Deserialize, Serialize};
 /// versioned independently. This constant is the envelope schema itself.
 pub const AUDIT_ENVELOPE_SCHEMA_VERSION: u32 = 1;
 
+pub const V2_EVENT_TYPE_FS_CALL_DENIED: &str = "fs.call.denied";
+pub const V2_EVENT_TYPE_TOOL_DENIED: &str = "tool.denied";
+pub const V2_EVENT_TYPE_STEP_DENIED: &str = "step.denied";
+pub const V2_DENIAL_EVENT_TYPES: &[&str] = &[
+    V2_EVENT_TYPE_FS_CALL_DENIED,
+    V2_EVENT_TYPE_TOOL_DENIED,
+    V2_EVENT_TYPE_STEP_DENIED,
+];
+
 /// Common envelope fields wrapping every v2 audit event (§7).
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct V2AuditEnvelope {
@@ -175,6 +184,39 @@ pub enum V2AuditEventKind {
         harness_version: Option<String>,
         timed_out: bool,
     },
+}
+
+impl V2AuditEventKind {
+    pub fn event_type(&self) -> &'static str {
+        match self {
+            V2AuditEventKind::RunStarted { .. } => "run.started",
+            V2AuditEventKind::RunFinished { .. } => "run.finished",
+            V2AuditEventKind::StepStarted { .. } => "step.started",
+            V2AuditEventKind::StepFinished { .. } => "step.finished",
+            V2AuditEventKind::StepSkipped { .. } => "step.skipped",
+            V2AuditEventKind::StepRetry { .. } => "step.retry",
+            V2AuditEventKind::StepRecoveryAttempted { .. } => "step.recovery_attempted",
+            V2AuditEventKind::StepDenied { .. } => V2_EVENT_TYPE_STEP_DENIED,
+            V2AuditEventKind::StepJoin { .. } => "step.join",
+            V2AuditEventKind::FanoutDispatched { .. } => "fanout.dispatched",
+            V2AuditEventKind::WorkerState { .. } => "worker.state",
+            V2AuditEventKind::FaninJoined { .. } => "fanin.joined",
+            V2AuditEventKind::LoopIterationStart { .. } => "loop.iteration.start",
+            V2AuditEventKind::LoopIterationEnd { .. } => "loop.iteration.end",
+            V2AuditEventKind::LoopDidNotConverge { .. } => "loop.did_not_converge",
+            V2AuditEventKind::ActivityStarted { .. } => "activity.started",
+            V2AuditEventKind::ActivityFinished { .. } => "activity.finished",
+            V2AuditEventKind::FsCallRequest { .. } => "fs.call.request",
+            V2AuditEventKind::FsCallResult { .. } => "fs.call.result",
+            V2AuditEventKind::FsCallDenied { .. } => V2_EVENT_TYPE_FS_CALL_DENIED,
+            V2AuditEventKind::ToolDenied { .. } => V2_EVENT_TYPE_TOOL_DENIED,
+            V2AuditEventKind::ToolAllowlistHarnessDelegated { .. } => {
+                "tool_allowlist.harness_delegated"
+            }
+            V2AuditEventKind::CliInvocationStarted { .. } => "cli.invocation.started",
+            V2AuditEventKind::CliInvocationFinished { .. } => "cli.invocation.finished",
+        }
+    }
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]

--- a/crates/orbit-common/src/types/activity_job/mod.rs
+++ b/crates/orbit-common/src/types/activity_job/mod.rs
@@ -17,7 +17,9 @@ pub use asset_loader::{
     ActivityAsset, AssetLoadError, JobAsset, load_activity_asset, load_job_asset,
 };
 pub use audit_envelope::{
-    AUDIT_ENVELOPE_SCHEMA_VERSION, BranchOutcome, V2AuditEnvelope, V2AuditEvent, V2AuditEventKind,
+    AUDIT_ENVELOPE_SCHEMA_VERSION, BranchOutcome, V2_DENIAL_EVENT_TYPES,
+    V2_EVENT_TYPE_FS_CALL_DENIED, V2_EVENT_TYPE_STEP_DENIED, V2_EVENT_TYPE_TOOL_DENIED,
+    V2AuditEnvelope, V2AuditEvent, V2AuditEventKind,
 };
 pub use backend::{
     BackendConstraintError, HttpOnlyFeature, resolve_activity_backends, resolve_job_backends,

--- a/crates/orbit-core/src/command/activity_v2.rs
+++ b/crates/orbit-core/src/command/activity_v2.rs
@@ -8,7 +8,7 @@
 //! Loop + envelope audit sink construction is delegated to
 //! `V2AuditWriter::with_disk_sinks` — this file never names orbit-agent types.
 
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 use orbit_common::types::activity_job::{
     Backend, V2AuditEventKind, load_activity_asset, resolve_activity_backends,
@@ -29,7 +29,6 @@ pub struct V2ActivityRunResult {
     pub output: Value,
     pub message: Option<String>,
     pub run_id: String,
-    pub audit_jsonl: Option<PathBuf>,
     pub events_emitted: usize,
     /// Resolved execution backend applied to the asset at load time. `None`
     /// when the activity isn't `agent_loop` (deterministic/shell ignore
@@ -40,7 +39,7 @@ pub struct V2ActivityRunResult {
 impl OrbitRuntime {
     /// Execute a v2 activity from a YAML path. Returns a structural result.
     /// Audit events for the run are queryable via `list_v2_audit_events` using
-    /// the `run_id` (the legacy envelope JSONL path is `None` post SQLite migration).
+    /// the `run_id`.
     ///
     /// `backend_flag` is the `--backend` invocation-level override; when
     /// `None`, the resolver falls through to env → config → default.
@@ -102,8 +101,6 @@ impl OrbitRuntime {
             Some(workspace_path.as_path()),
         )
         .map_err(|err| OrbitError::Execution(format!("audit sinks: {err}")))?;
-        let audit_jsonl = writer.envelope_log_path();
-
         // Record the standard orbit-core activity-run lifecycle events so v2
         // runs appear in the same audit stream v1 runs use.
         self.record_event(OrbitEvent::ActivityRunStarted {
@@ -158,7 +155,6 @@ impl OrbitRuntime {
                 output: o.output,
                 message: o.message,
                 run_id,
-                audit_jsonl,
                 events_emitted: events_count,
                 resolved_backend,
             }),
@@ -170,6 +166,8 @@ impl OrbitRuntime {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    use std::path::PathBuf;
 
     use crate::V2AuditEventFilter;
     use serde_json::json;

--- a/crates/orbit-core/src/command/job/exec.rs
+++ b/crates/orbit-core/src/command/job/exec.rs
@@ -5,7 +5,7 @@
 //! orbit-core never names orbit-agent types — transport/session construction
 //! lives below the boundary in `orbit_engine::job_executor`.
 
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 use orbit_common::types::activity_job::{
     Backend, V2AuditEventKind, load_job_asset, resolve_job_backends,
@@ -30,7 +30,6 @@ pub struct V2JobRunResult {
     pub success: bool,
     pub pipeline: Value,
     pub message: Option<String>,
-    pub audit_jsonl: Option<PathBuf>,
     pub events_emitted: usize,
     /// Resolved backend applied at load time to every `agent_loop` step in
     /// the DAG. Recorded so smokes can inspect the precedence outcome.
@@ -38,9 +37,9 @@ pub struct V2JobRunResult {
 }
 
 impl OrbitRuntime {
-    /// Execute a v2 Job from a YAML file. Returns a structural result and the
-    /// path to the persisted §7 envelope JSONL. The file must declare
-    /// `schemaVersion: 2` and `kind: Job`; v1 files are rejected.
+    /// Execute a v2 Job from a YAML file. Returns a structural result. The
+    /// file must declare `schemaVersion: 2` and `kind: Job`; v1 files are
+    /// rejected.
     pub fn run_job_v2_from_yaml(
         &self,
         yaml_path: &Path,
@@ -241,8 +240,6 @@ impl OrbitRuntime {
             Some(workspace_path.as_path()),
         )
         .map_err(|err| OrbitError::Execution(format!("audit sinks: {err}")))?;
-        let audit_jsonl = writer.envelope_log_path();
-
         self.record_event(OrbitEvent::ActivityRunStarted {
             id: asset.name.clone(),
         })?;
@@ -281,7 +278,6 @@ impl OrbitRuntime {
                 success: o.success,
                 pipeline: o.pipeline,
                 message: o.message,
-                audit_jsonl,
                 events_emitted: events_count,
                 resolved_backend: resolution.backend,
             }),
@@ -350,6 +346,7 @@ mod tests {
     use super::*;
 
     use std::collections::HashMap;
+    use std::path::PathBuf;
     use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::{Arc, Mutex};
 
@@ -885,7 +882,6 @@ printf '%s\n' '{"type":"turn.completed","usage":{"input_tokens":100,"cached_inpu
         assert!(state.pipeline.get("nap").is_some());
         assert!(state.step_outputs.contains_key(&0));
 
-        assert!(result.audit_jsonl.is_none());
         let first_event: serde_json::Value = serde_json::from_str(
             &v2_events(&runtime, &result.run_id, "run.started")
                 .first()

--- a/crates/orbit-core/src/lib.rs
+++ b/crates/orbit-core/src/lib.rs
@@ -44,8 +44,8 @@ pub use orbit_store::duel_scoreboard;
 pub use orbit_store::scoreboard_summary;
 pub use orbit_store::skill_store as skill_catalog;
 pub use orbit_store::{
-    ActivityInvocationMetrics, InvocationQuery, InvocationRecord, InvocationToolCallRecord,
-    TaskInvocationMetrics, ToolInvocationMetrics,
+    ActivityInvocationMetrics, InvocationInsertParams, InvocationQuery, InvocationRecord,
+    InvocationToolCallRecord, TaskInvocationMetrics, ToolInvocationMetrics,
 };
 
 pub use command::docs::{

--- a/crates/orbit-core/src/runtime/engine/invocation.rs
+++ b/crates/orbit-core/src/runtime/engine/invocation.rs
@@ -1,7 +1,7 @@
 use orbit_common::types::OrbitError;
 use orbit_store::{
-    ActivityInvocationMetrics, AgentInvocationMetrics, InvocationQuery, InvocationRecord, Store,
-    TaskInvocationMetrics, ToolInvocationMetrics,
+    ActivityInvocationMetrics, AgentInvocationMetrics, InvocationInsertParams, InvocationQuery,
+    InvocationRecord, Store, TaskInvocationMetrics, ToolInvocationMetrics,
 };
 use serde_json::Value;
 
@@ -68,6 +68,13 @@ impl OrbitRuntime {
         query: InvocationQuery,
     ) -> Result<Vec<InvocationRecord>, OrbitError> {
         open_invocation_store(self)?.list_invocation_records(&query)
+    }
+
+    pub fn insert_invocation_trace_record(
+        &self,
+        params: &InvocationInsertParams,
+    ) -> Result<(), OrbitError> {
+        open_invocation_store(self)?.insert_invocation_trace_record(params)
     }
 }
 

--- a/crates/orbit-core/src/runtime/mod.rs
+++ b/crates/orbit-core/src/runtime/mod.rs
@@ -247,7 +247,7 @@ impl OrbitRuntime {
         self.context.persistence().as_json_value()
     }
 
-    pub(crate) fn sqlite_store(&self) -> Result<Store, OrbitError> {
+    pub fn sqlite_store(&self) -> Result<Store, OrbitError> {
         Store::open(&self.context.persistence().audit_db)
     }
 

--- a/crates/orbit-dashboard/src/api/denials.rs
+++ b/crates/orbit-dashboard/src/api/denials.rs
@@ -7,6 +7,9 @@ use std::sync::Arc;
 use axum::extract::{Query, State};
 use axum::response::{IntoResponse, Json, Response};
 use chrono::{DateTime, Utc};
+use orbit_common::types::activity_job::{
+    V2_DENIAL_EVENT_TYPES, V2_EVENT_TYPE_FS_CALL_DENIED, V2_EVENT_TYPE_STEP_DENIED,
+};
 use orbit_core::{AuditEventStatus, OrbitRuntime, V2AuditEventFilter};
 use serde_json::{Value, json};
 
@@ -69,11 +72,11 @@ pub(super) fn scan_v2_loop_denials(
     agent_filter: Option<&str>,
 ) -> Result<Vec<DenialRow>, orbit_core::OrbitError> {
     let mut rows = Vec::new();
-    for event_type in ["fs.call.denied", "tool.denied"] {
+    for event_type in v2_denial_event_types() {
         let events = runtime.list_v2_audit_events(V2AuditEventFilter {
             workspace_id: String::new(),
             since,
-            event_type: Some(event_type.to_string()),
+            event_type: Some((*event_type).to_string()),
             limit: Some(SQLITE_DENIAL_SCAN_LIMIT),
             ..Default::default()
         })?;
@@ -82,11 +85,7 @@ pub(super) fn scan_v2_loop_denials(
                 Ok(value) => value,
                 Err(_) => continue,
             };
-            let kind = if event.event_type == "fs.call.denied" {
-                "fs"
-            } else {
-                "tool"
-            };
+            let kind = v2_denial_kind(&event.event_type);
             let (profile, target) = match kind {
                 "fs" => (
                     value
@@ -96,6 +95,14 @@ pub(super) fn scan_v2_loop_denials(
                         .to_string(),
                     value
                         .get("path")
+                        .and_then(Value::as_str)
+                        .unwrap_or("")
+                        .to_string(),
+                ),
+                _ if event.event_type == V2_EVENT_TYPE_STEP_DENIED => (
+                    "tool".to_string(),
+                    value
+                        .get("step_id")
                         .and_then(Value::as_str)
                         .unwrap_or("")
                         .to_string(),
@@ -134,6 +141,18 @@ pub(super) fn scan_v2_loop_denials(
         }
     }
     Ok(rows)
+}
+
+pub(super) fn v2_denial_event_types() -> &'static [&'static str] {
+    V2_DENIAL_EVENT_TYPES
+}
+
+fn v2_denial_kind(event_type: &str) -> &'static str {
+    if event_type == V2_EVENT_TYPE_FS_CALL_DENIED {
+        "fs"
+    } else {
+        "tool"
+    }
 }
 
 pub(super) fn collect_denial_rows(

--- a/crates/orbit-dashboard/src/api/tests/denials.rs
+++ b/crates/orbit-dashboard/src/api/tests/denials.rs
@@ -1,8 +1,39 @@
 use chrono::{Duration, Utc};
+use orbit_common::types::activity_job::{V2_DENIAL_EVENT_TYPES, V2AuditEventKind};
 use orbit_core::{AuditEventStatus, OrbitRuntime, V2AuditEventInsertParams};
 use serde_json::json;
 
-use super::super::denials::{SQLITE_FS_BOUNDARY_PROFILE, collect_denial_rows, denials_payload};
+use super::super::denials::{
+    SQLITE_FS_BOUNDARY_PROFILE, collect_denial_rows, denials_payload, v2_denial_event_types,
+};
+
+#[test]
+fn v2_denial_filter_matches_audit_event_denial_variants() {
+    let denial_variants = [
+        V2AuditEventKind::FsCallDenied {
+            profile: "restricted".to_string(),
+            op: "read".to_string(),
+            path: "./secret.txt".to_string(),
+            allowed: false,
+            matched_rule: "deny".to_string(),
+        },
+        V2AuditEventKind::ToolDenied {
+            tool_name: "github.pr.merge".to_string(),
+            reason: "not allowed".to_string(),
+        },
+        V2AuditEventKind::StepDenied {
+            step_id: "implement".to_string(),
+            reason: "tool denied".to_string(),
+        },
+    ];
+    let expected = denial_variants
+        .iter()
+        .map(V2AuditEventKind::event_type)
+        .collect::<Vec<_>>();
+
+    assert_eq!(expected, V2_DENIAL_EVENT_TYPES);
+    assert_eq!(v2_denial_event_types(), expected.as_slice());
+}
 
 #[test]
 fn denials_payload_combines_v2_and_sqlite_denials() {
@@ -41,6 +72,23 @@ fn denials_payload_combines_v2_and_sqlite_denials() {
         }),
         now,
     );
+    seed_v2_denial(
+        &runtime,
+        "evt-step-denied",
+        "step.denied",
+        json!({
+            "schemaVersion": 1,
+            "event_type": "step.denied",
+            "event_id": "evt-step-denied",
+            "ts": now.to_rfc3339(),
+            "run_id": "run-v2-denials",
+            "agent_identity": "codex / gpt-5",
+            "body_kind": "step_denied",
+            "step_id": "implement",
+            "reason": "tool denied"
+        }),
+        now,
+    );
     runtime
         .record_audit_event(&orbit_core::AuditEventInsertParams {
             execution_id: "exec-sqlite-fs".to_string(),
@@ -71,10 +119,11 @@ fn denials_payload_combines_v2_and_sqlite_denials() {
     let since = now - Duration::minutes(5);
     let rows = collect_denial_rows(&runtime, Some(since), None, None).expect("collect denials");
     let payload = denials_payload(&rows, None, Some(since));
-    assert_eq!(payload["total"], 3);
+    assert_eq!(payload["total"], 4);
     assert!(payload["by_target"].to_string().contains("/usr/bin/false"));
     assert!(payload["by_target"].to_string().contains("./secret.txt"));
     assert!(payload["by_target"].to_string().contains("github.pr.merge"));
+    assert!(payload["by_target"].to_string().contains("implement"));
 
     let fs_payload = denials_payload(&rows, Some("fs"), Some(since));
     assert_eq!(fs_payload["total"], 2);
@@ -86,7 +135,7 @@ fn denials_payload_combines_v2_and_sqlite_denials() {
     assert!(fs_payload["by_profile"].to_string().contains("restricted"));
 
     let tool_payload = denials_payload(&rows, Some("tool"), Some(since));
-    assert_eq!(tool_payload["total"], 1);
+    assert_eq!(tool_payload["total"], 2);
 
     let sqlite_only = collect_denial_rows(
         &runtime,

--- a/crates/orbit-dashboard/src/api/tests/metrics.rs
+++ b/crates/orbit-dashboard/src/api/tests/metrics.rs
@@ -1,21 +1,20 @@
 //! Test-only allowlist: endpoint tests use unwrap/expect for fixture setup.
 #![allow(clippy::expect_used, clippy::unwrap_used)]
 
-use std::path::PathBuf;
 use std::sync::Arc;
 
 use axum::Router;
 use axum::body::{Body, to_bytes};
 use axum::http::{Request, StatusCode};
 use axum::response::Response;
-use orbit_common::types::KnowledgeRunMetrics;
+use chrono::{Duration, SecondsFormat};
+use orbit_common::types::{InvocationTrace, KnowledgeRunMetrics, TokenUsage, ToolCallTrace};
 use orbit_core::command::job::JobRunListParams;
 use orbit_core::{
-    ActivityInvocationMetrics, InvocationQuery, InvocationRecord, JobRunState, OrbitRuntime,
-    TaskInvocationMetrics, ToolInvocationMetrics,
+    ActivityInvocationMetrics, InvocationInsertParams, InvocationQuery, InvocationRecord,
+    JobRunState, OrbitRuntime, TaskInvocationMetrics, ToolInvocationMetrics,
 };
 use orbit_knowledge::metrics::{KnowledgeStatsSummary, aggregate as aggregate_knowledge_stats};
-use rusqlite::{Connection, params};
 use tower::ServiceExt;
 
 use super::super::router;
@@ -77,98 +76,89 @@ fn seed_metrics_runtime() -> OrbitRuntime {
 
     seed_invocation(
         &runtime,
-        "2026-05-05T03:29:45Z",
-        RUN_ID,
-        "implement_one",
-        "codex",
-        Some("gpt-5.5"),
-        1_234,
-        100,
-        25,
-        5,
-        20,
-        &[TASK_ID],
-        &[("fs.read", 321), ("orbit.task.show", 123)],
+        SeedInvocation {
+            job_run_id: RUN_ID,
+            activity_id: "implement_one",
+            agent: "codex",
+            model: Some("gpt-5.5"),
+            duration_ms: 1_234,
+            input_tokens: 100,
+            cache_read_tokens: 25,
+            cache_create_tokens: 5,
+            output_tokens: 20,
+            task_ids: &[TASK_ID],
+            tool_calls: &[("fs.read", 321), ("orbit.task.show", 123)],
+        },
     );
     seed_invocation(
         &runtime,
-        "2026-05-05T03:30:45Z",
-        OTHER_RUN_ID,
-        "plan",
-        "claude",
-        Some("claude-opus"),
-        2_000,
-        80,
-        0,
-        0,
-        40,
-        &["ORB-METRICS-OTHER"],
-        &[("fs.write", 64)],
+        SeedInvocation {
+            job_run_id: OTHER_RUN_ID,
+            activity_id: "plan",
+            agent: "claude",
+            model: Some("claude-opus"),
+            duration_ms: 2_000,
+            input_tokens: 80,
+            cache_read_tokens: 0,
+            cache_create_tokens: 0,
+            output_tokens: 40,
+            task_ids: &["ORB-METRICS-OTHER"],
+            tool_calls: &[("fs.write", 64)],
+        },
     );
 
     runtime
 }
 
-fn audit_db_path(runtime: &OrbitRuntime) -> PathBuf {
-    runtime.persistence_config_json()["audit"]["path"]
-        .as_str()
-        .expect("audit db path")
-        .into()
-}
-
-#[allow(clippy::too_many_arguments)]
-fn seed_invocation(
-    runtime: &OrbitRuntime,
-    ts: &str,
-    job_run_id: &str,
-    activity_id: &str,
-    agent: &str,
-    model: Option<&str>,
+struct SeedInvocation<'a> {
+    job_run_id: &'a str,
+    activity_id: &'a str,
+    agent: &'a str,
+    model: Option<&'a str>,
     duration_ms: u64,
     input_tokens: u64,
     cache_read_tokens: u64,
     cache_create_tokens: u64,
     output_tokens: u64,
-    task_ids: &[&str],
-    tool_calls: &[(&str, u64)],
-) {
-    let conn = Connection::open(audit_db_path(runtime)).expect("open audit db");
-    conn.execute(
-        r#"INSERT INTO invocations(
-            ts, job_run_id, activity_id, agent, model, slot, duration_ms,
-            input_tokens, cache_read_tokens, cache_create_tokens, output_tokens,
-            tool_call_count
-        ) VALUES (?1, ?2, ?3, ?4, ?5, NULL, ?6, ?7, ?8, ?9, ?10, ?11)"#,
-        params![
-            ts,
-            job_run_id,
-            activity_id,
-            agent,
-            model,
-            duration_ms as i64,
-            input_tokens as i64,
-            cache_read_tokens as i64,
-            cache_create_tokens as i64,
-            output_tokens as i64,
-            tool_calls.len() as i64,
-        ],
-    )
-    .expect("insert invocation");
-    let invocation_id = conn.last_insert_rowid();
-    for task_id in task_ids {
-        conn.execute(
-            "INSERT INTO invocation_tasks(invocation_id, task_id) VALUES (?1, ?2)",
-            params![invocation_id, task_id],
-        )
-        .expect("insert invocation task");
-    }
-    for (seq, (tool_name, result_bytes)) in tool_calls.iter().enumerate() {
-        conn.execute(
-            "INSERT INTO tool_calls(invocation_id, seq, tool_name, result_bytes) VALUES (?1, ?2, ?3, ?4)",
-            params![invocation_id, seq as i64, tool_name, *result_bytes as i64],
-        )
-        .expect("insert tool call");
-    }
+    task_ids: &'a [&'a str],
+    tool_calls: &'a [(&'a str, u64)],
+}
+
+fn seed_invocation(runtime: &OrbitRuntime, seed: SeedInvocation<'_>) {
+    runtime
+        .insert_invocation_trace_record(&InvocationInsertParams {
+            job_run_id: seed.job_run_id.to_string(),
+            activity_id: seed.activity_id.to_string(),
+            agent: seed.agent.to_string(),
+            model: seed.model.map(ToOwned::to_owned),
+            slot: None,
+            task_ids: seed
+                .task_ids
+                .iter()
+                .map(|task_id| (*task_id).to_string())
+                .collect(),
+            trace: InvocationTrace {
+                usage: TokenUsage {
+                    input: seed.input_tokens,
+                    cache_read: seed.cache_read_tokens,
+                    cache_create: seed.cache_create_tokens,
+                    output: seed.output_tokens,
+                },
+                tool_calls: seed
+                    .tool_calls
+                    .iter()
+                    .enumerate()
+                    .map(|(seq, (tool_name, result_bytes))| ToolCallTrace {
+                        seq: seq as u32,
+                        tool_name: (*tool_name).to_string(),
+                        result_bytes: *result_bytes,
+                        result_payload: None,
+                    })
+                    .collect(),
+                duration_ms: seed.duration_ms,
+            },
+        })
+        .expect("insert invocation");
 }
 
 #[tokio::test]
@@ -257,8 +247,19 @@ async fn metrics_endpoints_return_runtime_shapes() {
 #[tokio::test]
 async fn metrics_invocations_accepts_full_filter_set() {
     let runtime = seed_metrics_runtime();
-    let since = "2026-05-05T03:00:00Z";
-    let until = "2026-05-05T04:00:00Z";
+    let record = runtime
+        .invocation_records(InvocationQuery {
+            job_run_id: Some(RUN_ID.to_string()),
+            activity_id: Some("implement_one".to_string()),
+            limit: 1,
+            ..Default::default()
+        })
+        .expect("invocation record")
+        .into_iter()
+        .next()
+        .expect("seeded invocation");
+    let since = (record.ts - Duration::minutes(1)).to_rfc3339_opts(SecondsFormat::Millis, true);
+    let until = (record.ts + Duration::minutes(1)).to_rfc3339_opts(SecondsFormat::Millis, true);
     let uri = format!(
         "/metrics/invocations?since={since}&until={until}&job_run_id={RUN_ID}&activity_id=implement_one&task_id={TASK_ID}&agent=codex&model=gpt-5.5&tool_name=fs.read&limit=1"
     );

--- a/crates/orbit-dashboard/src/api/tests/test_support.rs
+++ b/crates/orbit-dashboard/src/api/tests/test_support.rs
@@ -4,7 +4,6 @@ use axum::body::to_bytes;
 use axum::response::Response;
 use chrono::Utc;
 use orbit_core::{JobRun, JobRunState, OrbitRuntime};
-use rusqlite::{Connection, params};
 use serde_json::Value;
 
 pub(super) fn write_lines(path: &std::path::Path, lines: &[String]) {
@@ -84,50 +83,12 @@ pub(super) fn seed_run(
 }
 
 pub(super) fn write_seeded_run(runtime: &OrbitRuntime, run: &JobRun) {
-    let conn = Connection::open(runtime.global_root().join("orbit.db")).expect("open orbit db");
     let workspace_id = runtime.workspace_id().expect("workspace id");
-    let input_json = run
-        .input
-        .as_ref()
-        .map(serde_json::to_string)
-        .transpose()
-        .expect("serialize input");
-    let knowledge_metrics_json = run
-        .knowledge_metrics
-        .as_ref()
-        .map(serde_json::to_string)
-        .transpose()
-        .expect("serialize knowledge metrics");
-    conn.execute(
-        r#"INSERT OR REPLACE INTO job_runs(
-            run_id, workspace_id, job_id, attempt, state, scheduled_at, started_at,
-            finished_at, duration_ms, created_at, pid, pid_start_time, input_json,
-            retry_source_run_id, knowledge_metrics_json, resolved_crew, planner_model,
-            implementer_model, reviewer_model, pipeline_state_json
-        ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19, NULL)"#,
-        params![
-            run.run_id,
-            workspace_id,
-            run.job_id,
-            i64::from(run.attempt),
-            run.state.to_string(),
-            run.scheduled_at.to_rfc3339(),
-            run.started_at.map(|value| value.to_rfc3339()),
-            run.finished_at.map(|value| value.to_rfc3339()),
-            run.duration_ms.map(|value| value as i64),
-            run.created_at.to_rfc3339(),
-            run.pid.map(i64::from),
-            run.pid_start_time,
-            input_json,
-            run.retry_source_run_id,
-            knowledge_metrics_json,
-            run.resolved_crew,
-            run.planner_model,
-            run.implementer_model,
-            run.reviewer_model,
-        ],
-    )
-    .expect("insert job run");
+    runtime
+        .sqlite_store()
+        .expect("sqlite store")
+        .upsert_job_run_for_workspace(&workspace_id, run, None)
+        .expect("insert job run");
 }
 
 pub(super) async fn body_json(response: Response) -> Value {

--- a/crates/orbit-engine/src/activity_job/audit_writer.rs
+++ b/crates/orbit-engine/src/activity_job/audit_writer.rs
@@ -281,32 +281,5 @@ impl Drop for ParentStackGuard<'_> {
 }
 
 fn event_type_of(kind: &V2AuditEventKind) -> &'static str {
-    match kind {
-        V2AuditEventKind::RunStarted { .. } => "run.started",
-        V2AuditEventKind::RunFinished { .. } => "run.finished",
-        V2AuditEventKind::StepStarted { .. } => "step.started",
-        V2AuditEventKind::StepFinished { .. } => "step.finished",
-        V2AuditEventKind::StepSkipped { .. } => "step.skipped",
-        V2AuditEventKind::StepRetry { .. } => "step.retry",
-        V2AuditEventKind::StepRecoveryAttempted { .. } => "step.recovery_attempted",
-        V2AuditEventKind::StepDenied { .. } => "step.denied",
-        V2AuditEventKind::StepJoin { .. } => "step.join",
-        V2AuditEventKind::FanoutDispatched { .. } => "fanout.dispatched",
-        V2AuditEventKind::WorkerState { .. } => "worker.state",
-        V2AuditEventKind::FaninJoined { .. } => "fanin.joined",
-        V2AuditEventKind::LoopIterationStart { .. } => "loop.iteration.start",
-        V2AuditEventKind::LoopIterationEnd { .. } => "loop.iteration.end",
-        V2AuditEventKind::LoopDidNotConverge { .. } => "loop.did_not_converge",
-        V2AuditEventKind::ActivityStarted { .. } => "activity.started",
-        V2AuditEventKind::ActivityFinished { .. } => "activity.finished",
-        V2AuditEventKind::FsCallRequest { .. } => "fs.call.request",
-        V2AuditEventKind::FsCallResult { .. } => "fs.call.result",
-        V2AuditEventKind::FsCallDenied { .. } => "fs.call.denied",
-        V2AuditEventKind::ToolDenied { .. } => "tool.denied",
-        V2AuditEventKind::ToolAllowlistHarnessDelegated { .. } => {
-            "tool_allowlist.harness_delegated"
-        }
-        V2AuditEventKind::CliInvocationStarted { .. } => "cli.invocation.started",
-        V2AuditEventKind::CliInvocationFinished { .. } => "cli.invocation.finished",
-    }
+    kind.event_type()
 }

--- a/crates/orbit-store/src/sqlite/job_run_store/mod.rs
+++ b/crates/orbit-store/src/sqlite/job_run_store/mod.rs
@@ -6,6 +6,7 @@ use orbit_common::types::{
     OrbitError, PipelineState, RunEvent,
 };
 use orbit_common::utility::process_identity::process_start_identity_token;
+use rusqlite::TransactionBehavior;
 
 use crate::backend::{JobRunQuery, JobRunStepParams, JobRunStoreBackend};
 use crate::file::layout::validate_path_stem;
@@ -35,13 +36,17 @@ impl SqliteJobRunStore {
         run_id: &str,
         update: impl FnOnce(&mut JobRun) -> Result<(), OrbitError>,
     ) -> Result<bool, OrbitError> {
-        let Some(mut run) = self.read_run(run_id)? else {
-            return Ok(false);
-        };
-        update(&mut run)?;
         self.store
-            .upsert_job_run_for_workspace(&self.workspace_id, &run, None)?;
-        Ok(true)
+            .with_transaction_behavior(TransactionBehavior::Immediate, |tx| {
+                let Some(mut run) =
+                    get_job_run_for_workspace_conn(&tx.tx, &self.workspace_id, run_id)?
+                else {
+                    return Ok(false);
+                };
+                update(&mut run)?;
+                upsert_job_run_for_workspace_conn(&tx.tx, &self.workspace_id, &run, None)?;
+                Ok(true)
+            })
     }
 
     fn next_run_id(&self, job_id: &str) -> Result<String, OrbitError> {
@@ -352,65 +357,11 @@ impl Store {
         run: &JobRun,
         pipeline_state: Option<&PipelineState>,
     ) -> Result<(), OrbitError> {
-        let input_json = optional_json(&run.input, "job run input")?;
-        let knowledge_metrics_json =
-            optional_json(&run.knowledge_metrics, "job run knowledge metrics")?;
-        let pipeline_state_json = optional_json(&pipeline_state, "job run pipeline state")?;
         let conn = self
             .conn
             .lock()
             .map_err(|e| OrbitError::Store(format!("mutex poisoned: {e}")))?;
-        conn.execute(
-            r#"INSERT INTO job_runs(
-                run_id, workspace_id, job_id, attempt, state, scheduled_at,
-                started_at, finished_at, duration_ms, created_at, pid, pid_start_time,
-                input_json, retry_source_run_id, knowledge_metrics_json, resolved_crew,
-                planner_model, implementer_model, reviewer_model, pipeline_state_json
-            ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19, ?20)
-            ON CONFLICT(workspace_id, run_id) DO UPDATE SET
-                job_id = excluded.job_id,
-                attempt = excluded.attempt,
-                state = excluded.state,
-                scheduled_at = excluded.scheduled_at,
-                started_at = excluded.started_at,
-                finished_at = excluded.finished_at,
-                duration_ms = excluded.duration_ms,
-                created_at = excluded.created_at,
-                pid = excluded.pid,
-                pid_start_time = excluded.pid_start_time,
-                input_json = excluded.input_json,
-                retry_source_run_id = excluded.retry_source_run_id,
-                knowledge_metrics_json = excluded.knowledge_metrics_json,
-                resolved_crew = excluded.resolved_crew,
-                planner_model = excluded.planner_model,
-                implementer_model = excluded.implementer_model,
-                reviewer_model = excluded.reviewer_model,
-                pipeline_state_json = COALESCE(excluded.pipeline_state_json, job_runs.pipeline_state_json)"#,
-            rusqlite::params![
-                run.run_id,
-                workspace_id,
-                run.job_id,
-                i64::from(run.attempt),
-                run.state.to_string(),
-                run.scheduled_at.to_rfc3339(),
-                run.started_at.map(|ts| ts.to_rfc3339()),
-                run.finished_at.map(|ts| ts.to_rfc3339()),
-                run.duration_ms.map(|value| value as i64),
-                run.created_at.to_rfc3339(),
-                run.pid.map(i64::from),
-                run.pid_start_time,
-                input_json,
-                run.retry_source_run_id,
-                knowledge_metrics_json,
-                run.resolved_crew,
-                run.planner_model,
-                run.implementer_model,
-                run.reviewer_model,
-                pipeline_state_json,
-            ],
-        )
-        .map_err(|e| OrbitError::Store(e.to_string()))?;
-        Ok(())
+        upsert_job_run_for_workspace_conn(&conn, workspace_id, run, pipeline_state)
     }
 
     pub fn upsert_job_run_step_for_workspace(
@@ -470,22 +421,7 @@ impl Store {
             .conn
             .lock()
             .map_err(|e| OrbitError::Store(format!("mutex poisoned: {e}")))?;
-        let mut stmt = conn
-            .prepare(
-                "SELECT run_id, job_id, attempt, state, scheduled_at, started_at, finished_at, \
-                 duration_ms, created_at, pid, pid_start_time, input_json, retry_source_run_id, \
-                 knowledge_metrics_json, resolved_crew, planner_model, implementer_model, reviewer_model \
-                 FROM job_runs WHERE workspace_id = ?1 AND run_id = ?2",
-            )
-            .map_err(|e| OrbitError::Store(e.to_string()))?;
-        let mut run = match stmt.query_row(rusqlite::params![workspace_id, run_id], row_to_job_run)
-        {
-            Ok(run) => run,
-            Err(rusqlite::Error::QueryReturnedNoRows) => return Ok(None),
-            Err(err) => return Err(OrbitError::Store(err.to_string())),
-        };
-        run.steps = read_steps(&conn, workspace_id, run_id)?;
-        Ok(Some(run))
+        get_job_run_for_workspace_conn(&conn, workspace_id, run_id)
     }
 
     pub fn list_job_runs_for_workspace(
@@ -608,6 +544,91 @@ impl Store {
         .map(|count| count > 0)
         .map_err(|e| OrbitError::Store(e.to_string()))
     }
+}
+
+fn upsert_job_run_for_workspace_conn(
+    conn: &rusqlite::Connection,
+    workspace_id: &str,
+    run: &JobRun,
+    pipeline_state: Option<&PipelineState>,
+) -> Result<(), OrbitError> {
+    let input_json = optional_json(&run.input, "job run input")?;
+    let knowledge_metrics_json =
+        optional_json(&run.knowledge_metrics, "job run knowledge metrics")?;
+    let pipeline_state_json = optional_json(&pipeline_state, "job run pipeline state")?;
+    conn.execute(
+        r#"INSERT INTO job_runs(
+            run_id, workspace_id, job_id, attempt, state, scheduled_at,
+            started_at, finished_at, duration_ms, created_at, pid, pid_start_time,
+            input_json, retry_source_run_id, knowledge_metrics_json, resolved_crew,
+            planner_model, implementer_model, reviewer_model, pipeline_state_json
+        ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19, ?20)
+        ON CONFLICT(workspace_id, run_id) DO UPDATE SET
+            job_id = excluded.job_id,
+            attempt = excluded.attempt,
+            state = excluded.state,
+            scheduled_at = excluded.scheduled_at,
+            started_at = excluded.started_at,
+            finished_at = excluded.finished_at,
+            duration_ms = excluded.duration_ms,
+            created_at = excluded.created_at,
+            pid = excluded.pid,
+            pid_start_time = excluded.pid_start_time,
+            input_json = excluded.input_json,
+            retry_source_run_id = excluded.retry_source_run_id,
+            knowledge_metrics_json = excluded.knowledge_metrics_json,
+            resolved_crew = excluded.resolved_crew,
+            planner_model = excluded.planner_model,
+            implementer_model = excluded.implementer_model,
+            reviewer_model = excluded.reviewer_model,
+            pipeline_state_json = COALESCE(excluded.pipeline_state_json, job_runs.pipeline_state_json)"#,
+        rusqlite::params![
+            run.run_id,
+            workspace_id,
+            run.job_id,
+            i64::from(run.attempt),
+            run.state.to_string(),
+            run.scheduled_at.to_rfc3339(),
+            run.started_at.map(|ts| ts.to_rfc3339()),
+            run.finished_at.map(|ts| ts.to_rfc3339()),
+            run.duration_ms.map(|value| value as i64),
+            run.created_at.to_rfc3339(),
+            run.pid.map(i64::from),
+            run.pid_start_time,
+            input_json,
+            run.retry_source_run_id,
+            knowledge_metrics_json,
+            run.resolved_crew,
+            run.planner_model,
+            run.implementer_model,
+            run.reviewer_model,
+            pipeline_state_json,
+        ],
+    )
+    .map_err(|e| OrbitError::Store(e.to_string()))?;
+    Ok(())
+}
+
+fn get_job_run_for_workspace_conn(
+    conn: &rusqlite::Connection,
+    workspace_id: &str,
+    run_id: &str,
+) -> Result<Option<JobRun>, OrbitError> {
+    let mut stmt = conn
+        .prepare(
+            "SELECT run_id, job_id, attempt, state, scheduled_at, started_at, finished_at, \
+             duration_ms, created_at, pid, pid_start_time, input_json, retry_source_run_id, \
+             knowledge_metrics_json, resolved_crew, planner_model, implementer_model, reviewer_model \
+             FROM job_runs WHERE workspace_id = ?1 AND run_id = ?2",
+        )
+        .map_err(|e| OrbitError::Store(e.to_string()))?;
+    let mut run = match stmt.query_row(rusqlite::params![workspace_id, run_id], row_to_job_run) {
+        Ok(run) => run,
+        Err(rusqlite::Error::QueryReturnedNoRows) => return Ok(None),
+        Err(err) => return Err(OrbitError::Store(err.to_string())),
+    };
+    run.steps = read_steps(conn, workspace_id, run_id)?;
+    Ok(Some(run))
 }
 
 fn row_to_job_run(row: &rusqlite::Row<'_>) -> rusqlite::Result<JobRun> {
@@ -744,8 +765,13 @@ fn parse_job_target_type(raw: &str) -> rusqlite::Result<JobTargetType> {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::{Arc, Barrier};
+    use std::thread;
+    use std::time::Duration;
+
     use chrono::Utc;
     use orbit_common::types::JobTargetType;
+    use tempfile::TempDir;
 
     use super::*;
 
@@ -792,5 +818,58 @@ mod tests {
             .expect("some");
         assert_eq!(loaded.state, JobRunState::Success);
         assert_eq!(loaded.steps.len(), 1);
+    }
+
+    #[test]
+    fn update_run_serializes_concurrent_mutations_without_torn_write() {
+        let temp = TempDir::new().expect("tempdir");
+        let db_path = temp.path().join("orbit.db");
+        let backend_a = SqliteJobRunStore::new(Store::open(&db_path).expect("store a"), "ws_a");
+        let backend_b = SqliteJobRunStore::new(Store::open(&db_path).expect("store b"), "ws_a");
+        let scheduled_at = Utc::now();
+        let run = backend_a
+            .insert_job_run("job-a", 1, scheduled_at, None, None)
+            .expect("insert");
+        let run_id = run.run_id.clone();
+        let barrier = Arc::new(Barrier::new(2));
+
+        let run_id_a = run_id.clone();
+        let barrier_a = Arc::clone(&barrier);
+        let writer_a = thread::spawn(move || {
+            backend_a.update_run(&run_id_a, |run| {
+                run.resolved_crew = Some("crew-a".to_string());
+                barrier_a.wait();
+                thread::sleep(Duration::from_millis(100));
+                Ok(())
+            })
+        });
+
+        barrier.wait();
+        let run_id_b = run_id.clone();
+        let writer_b = thread::spawn(move || {
+            backend_b.update_run(&run_id_b, |run| {
+                run.knowledge_metrics = Some(KnowledgeRunMetrics {
+                    raw_read_token_baseline: 100,
+                    knowledge_pack_tokens: Some(50),
+                    compression_ratio: Some(2.0),
+                    actual_fs_read_tokens_during_run: 25,
+                    double_read_rate: Some(0.0),
+                    knowledge_pack_used: true,
+                    knowledge_pack_unresolved_count: 0,
+                    total_llm_input_tokens: 75,
+                });
+                Ok(())
+            })
+        });
+
+        assert!(writer_a.join().expect("writer a").expect("update a"));
+        assert!(writer_b.join().expect("writer b").expect("update b"));
+
+        let loaded = SqliteJobRunStore::new(Store::open(&db_path).expect("store c"), "ws_a")
+            .get_job_run(&run_id)
+            .expect("read")
+            .expect("run");
+        assert_eq!(loaded.resolved_crew.as_deref(), Some("crew-a"));
+        assert!(loaded.knowledge_metrics.is_some());
     }
 }

--- a/crates/orbit-store/src/sqlite/migration/mod.rs
+++ b/crates/orbit-store/src/sqlite/migration/mod.rs
@@ -644,5 +644,4 @@ fn table_has_foreign_key_to(
 }
 
 #[cfg(test)]
-#[cfg(test)]
 mod tests;

--- a/crates/orbit-store/src/sqlite/task_registry/tests/mod.rs
+++ b/crates/orbit-store/src/sqlite/task_registry/tests/mod.rs
@@ -386,8 +386,11 @@ fn workspace_id_for_orbit_dir_missing_file_names_path_and_key() {
 
     let err = workspace_id_for_orbit_dir(&orbit_dir).expect_err("missing config");
     let message = err.to_string();
+    let config_path = workspace_config_path(&orbit_dir).display().to_string();
     assert!(message.contains("config.yaml"));
     assert!(message.contains("workspace_id"));
+    assert!(message.contains(&config_path));
+    assert_eq!(message.matches(&config_path).count(), 1);
 }
 
 #[test]

--- a/crates/orbit-store/src/sqlite/task_registry/workspace_config.rs
+++ b/crates/orbit-store/src/sqlite/task_registry/workspace_config.rs
@@ -41,12 +41,10 @@ pub fn read_workspace_config(orbit_dir: &Path) -> Result<WorkspaceConfig, OrbitE
 }
 
 pub fn workspace_id_for_orbit_dir(orbit_dir: &Path) -> Result<String, OrbitError> {
-    let path = workspace_config_path(orbit_dir);
     let config = read_workspace_config(orbit_dir).map_err(|err| match err {
-        OrbitError::InvalidInput(message) => OrbitError::InvalidInput(format!(
-            "{message} (expected key `workspace_id` in {})",
-            path.display()
-        )),
+        OrbitError::InvalidInput(message) => {
+            OrbitError::InvalidInput(format!("{message} (expected key `workspace_id`)"))
+        }
         other => other,
     })?;
     Ok(config.workspace_id)

--- a/crates/orbit-store/src/state_io/import.rs
+++ b/crates/orbit-store/src/state_io/import.rs
@@ -18,7 +18,9 @@ pub struct ImportReport {
     pub audit_events_inserted: usize,
     pub audit_events_skipped: usize,
     pub job_runs_inserted: usize,
+    pub job_runs_skipped: usize,
     pub job_run_steps_inserted: usize,
+    pub job_run_steps_skipped: usize,
     pub session_learning_state_inserted: usize,
 }
 
@@ -31,7 +33,7 @@ impl ImportReport {
     }
 
     pub fn skipped_records(&self) -> bool {
-        self.audit_events_skipped > 0
+        self.audit_events_skipped > 0 || self.job_runs_skipped > 0 || self.job_run_steps_skipped > 0
     }
 }
 
@@ -272,16 +274,22 @@ fn import_job_runs(
                 Ok(raw) => raw,
                 Err(_) => continue,
             };
-            let doc = serde_yaml::from_str::<JobRunFileDocument>(&raw).map_err(|err| {
-                OrbitError::Store(format!(
-                    "invalid jrun.yaml '{}': {err}",
-                    jrun_path.display()
-                ))
-            })?;
+            let doc = match serde_yaml::from_str::<JobRunFileDocument>(&raw) {
+                Ok(doc) => doc,
+                Err(err) => {
+                    report.job_runs_skipped += 1;
+                    orbit_common::tracing::warn!(
+                        path = %jrun_path.display(),
+                        error = %err,
+                        "skipping malformed legacy job run"
+                    );
+                    continue;
+                }
+            };
             let pipeline_state = read_pipeline_state(&run_path)?;
             store.upsert_job_run_for_workspace(workspace_id, &doc.run, pipeline_state.as_ref())?;
             report.job_runs_inserted += 1;
-            for step in read_steps(&run_path)? {
+            for step in read_steps(&run_path, report)? {
                 store.upsert_job_run_step_for_workspace(workspace_id, &doc.run.run_id, &step)?;
                 report.job_run_steps_inserted += 1;
             }
@@ -304,7 +312,7 @@ fn read_pipeline_state(run_path: &Path) -> Result<Option<PipelineState>, OrbitEr
     })
 }
 
-fn read_steps(run_path: &Path) -> Result<Vec<JobRunStep>, OrbitError> {
+fn read_steps(run_path: &Path, report: &mut ImportReport) -> Result<Vec<JobRunStep>, OrbitError> {
     let steps_dir = run_path.join("steps");
     let entries = match fs::read_dir(&steps_dir) {
         Ok(entries) => entries,
@@ -325,15 +333,31 @@ fn read_steps(run_path: &Path) -> Result<Vec<JobRunStep>, OrbitError> {
     for path in paths {
         let raw = fs::read_to_string(&path).map_err(|err| OrbitError::Io(err.to_string()))?;
         let step = if path.extension().and_then(|value| value.to_str()) == Some("json") {
-            serde_json::from_str::<JobRunStep>(&raw).map_err(|err| {
-                OrbitError::Store(format!("invalid step file '{}': {err}", path.display()))
-            })?
+            match serde_json::from_str::<JobRunStep>(&raw) {
+                Ok(step) => step,
+                Err(err) => {
+                    report.job_run_steps_skipped += 1;
+                    orbit_common::tracing::warn!(
+                        path = %path.display(),
+                        error = %err,
+                        "skipping malformed legacy job run step"
+                    );
+                    continue;
+                }
+            }
         } else {
-            serde_yaml::from_str::<JobRunStepFileDocument>(&raw)
-                .map_err(|err| {
-                    OrbitError::Store(format!("invalid step file '{}': {err}", path.display()))
-                })?
-                .step
+            match serde_yaml::from_str::<JobRunStepFileDocument>(&raw) {
+                Ok(doc) => doc.step,
+                Err(err) => {
+                    report.job_run_steps_skipped += 1;
+                    orbit_common::tracing::warn!(
+                        path = %path.display(),
+                        error = %err,
+                        "skipping malformed legacy job run step"
+                    );
+                    continue;
+                }
+            }
         };
         steps.push(step);
     }
@@ -480,6 +504,61 @@ mod tests {
 
         let second = import_legacy_v2_state(&store, &orbit, "ws_a").expect("second");
         assert!(second.skipped);
+    }
+
+    #[test]
+    fn import_skips_malformed_job_run_and_step_files() {
+        let temp = TempDir::new().expect("tempdir");
+        let orbit = temp.path().join(".orbit");
+
+        let valid_run = JobRun {
+            run_id: "run-good".to_string(),
+            job_id: "job-a".to_string(),
+            attempt: 1,
+            state: JobRunState::Success,
+            scheduled_at: Utc::now(),
+            started_at: None,
+            finished_at: None,
+            duration_ms: None,
+            created_at: Utc::now(),
+            pid: None,
+            pid_start_time: None,
+            input: None,
+            retry_source_run_id: None,
+            knowledge_metrics: None,
+            resolved_crew: None,
+            planner_model: None,
+            implementer_model: None,
+            reviewer_model: None,
+            steps: Vec::new(),
+        };
+        let valid_dir = orbit.join("state/job-runs/job-a/run-good");
+        fs::create_dir_all(valid_dir.join("steps")).expect("valid run dir");
+        fs::write(
+            valid_dir.join("jrun.yaml"),
+            serde_yaml::to_string(&serde_json::json!({"schema_version": 1, "run": valid_run}))
+                .expect("serialize run"),
+        )
+        .expect("write valid run");
+        fs::write(valid_dir.join("steps/000.json"), "not-json\n").expect("write bad step");
+
+        let malformed_dir = orbit.join("state/job-runs/job-a/run-bad");
+        fs::create_dir_all(&malformed_dir).expect("malformed run dir");
+        fs::write(malformed_dir.join("jrun.yaml"), "run: [").expect("write bad run");
+
+        let store = Store::open_in_memory().expect("store");
+        let report = import_legacy_v2_state(&store, &orbit, "ws_a").expect("import");
+
+        assert_eq!(report.job_runs_inserted, 1);
+        assert_eq!(report.job_runs_skipped, 1);
+        assert_eq!(report.job_run_steps_inserted, 0);
+        assert_eq!(report.job_run_steps_skipped, 1);
+        assert!(report.skipped_records());
+        let loaded = store
+            .get_job_run_for_workspace("ws_a", "run-good")
+            .expect("read valid run")
+            .expect("valid run inserted");
+        assert_eq!(loaded.job_id, "job-a");
     }
 
     #[test]


### PR DESCRIPTION
## Task

[ORB-00284](https://orbit-cli.com/tasks/ORB-00284) — Code-quality cleanup for ORB-00276 v2 state SQLite migration

### Description

## Problem

Review of ORB-00276 (commit `ecd7dede`, merged to `agent-main`) flagged a set of code-quality items that aren't correctness regressions but should be cleaned up before they ossify. Pairs with the blockers task that handles the actual correctness defects.

1. **Dead `audit_jsonl` field threaded through CLI output.** `V2AuditWriter::envelope_log_path()` (`crates/orbit-engine/src/activity_job/audit_writer.rs:119-121`) always returns `None`. The value is captured into `JobRunResult.audit_jsonl` (`crates/orbit-core/src/command/job/exec.rs:33,244,284` and `crates/orbit-core/src/command/activity_v2.rs:31,103,158`) and printed by the CLI as the literal string `audit_jsonl=-` for every run (`crates/orbit-cli/src/command/run/job.rs:49-74,96-124,151-178`). The field also appears in the CLI's `--json` output as `"audit_jsonl": null`. Users now see a permanent dash; the field itself is no longer load-bearing.

2. **Dashboard `write_seeded_run` opens a second `Connection` to `~/.orbit/orbit.db` directly.** `crates/orbit-dashboard/src/api/tests/test_support.rs:86-131` does `Connection::open(runtime.global_root().join("orbit.db"))` and re-inlines JSON serialization helpers. Bypasses the production `Store::upsert_job_run_for_workspace`, contends with the runtime's `Mutex<Connection>`, and is schema-fragile.

3. **Importer is asymmetric about malformed legacy artifacts.** `crates/orbit-store/src/state_io/import.rs` skip-counts malformed audit JSONL lines (lines 143-148, 159-170) but a single un-parseable `jrun.yaml` (lines 271-276) or `steps/*.json` (lines 322-326) returns `Err(OrbitError::Store(...))` and aborts the entire import. After the blockers task lands the marker gating fix (#2 there), this asymmetry becomes more visible: one bad step file blocks the importer from making any progress.

4. **`SqliteJobRunStore::update_run` (`crates/orbit-store/src/sqlite/job_run_store/mod.rs:33-45`) is not transactional.** It reads → mutates in closure → upserts without `BEGIN/COMMIT`. Concurrent `mark_job_run_running` + `finalize_job_run` against the same `(workspace_id, run_id)` is last-writer-wins. File backend had the same race at the inode level (parity), but moving everything under a global SQLite mutex tightens the window.

5. **Stale README in `crates/orbit-agent/README.md`** at lines 26, 135, 139 documents `JsonlFileSink::open(audit_root, run_id)` and the `loop/{run_id}.jsonl` layout. Both were deleted in ORB-00276. Per CLAUDE.md, docs update in the same PR — slipped here.

6. **Duplicate `#[cfg(test)]` attribute** at `crates/orbit-store/src/sqlite/migration/mod.rs:646-648`. Compiler ignores it; copy-paste artifact.

7. **Dashboard denial event_type list is hard-coded** at `crates/orbit-dashboard/src/api/denials.rs:72` as `["fs.call.denied", "tool.denied"]`. The full set of `V2AuditEventKind` denial-shaped variants lives in `crates/orbit-engine/src/activity_job/audit_writer.rs:283-312` (`StepDenied` is another). Adding a new denial variant in the future silently bypasses the dashboard.

8. **`workspace_id_for_orbit_dir` error message double-stamps the file path.** `crates/orbit-store/src/sqlite/task_registry/workspace_config.rs:43-53` wraps `read_workspace_config`'s `"workspace config is missing: <path>"` with `(expected key \`workspace_id\` in <path>)`. The path appears twice in the user-facing error.

## Why It Matters

None of these is a correctness bug, but each ages poorly:
- (#1) The `audit_jsonl=-` line in CLI output is a permanent visible regression to anyone scripting against `orbit run job`.
- (#2) Dashboard tests using a second `Connection` will silently desync when the schema migrates again.
- (#3) The importer becoming partially-failing on bad step files is an unpleasant footgun once Release N has shipped to users with old `.orbit/state/job-runs/` artifacts.
- (#4) The non-transactional update is a latent race that's easier to hit under SQLite contention than under inode contention.
- (#5–#8) Drift between docs and code, copy-paste artifacts, hard-coded enum lists, and double-stamped error messages all increase the cost of the next change.

## Constraints / Notes

- **No ADR change.** Implementing the design correctly, not revising it.
- **(#1) Pick one:** (a) delete `audit_jsonl` from `JobRunResult` + the activity_v2 result struct + CLI output; or (b) repurpose as `audit_source: String` returning `"sqlite"`. Option (a) is the smaller diff and aligns with the post-migration reality.
- **(#2) `write_seeded_run` should call** `runtime.sqlite_store()?.upsert_job_run_for_workspace(workspace_id, &run, pipeline_state.as_ref())` — same path production uses. Drop the inline JSON serialization helpers.
- **(#3) Step/jrun parse errors** should follow the audit-line precedent: increment a new `job_runs_skipped` / `job_run_steps_skipped` counter on `ImportReport` and `continue`, log via `tracing::warn!` with the offending file path.
- **(#4) Use** `Store::with_transaction` if it exists; otherwise add a private `update_run_in_transaction` helper that opens a SQLite transaction, reads, mutates, upserts, commits. The closure should run under the transaction so the read and write are atomic.
- **(#7) Pull denial-variant strings** from a single source of truth — either a `const &[&str]` next to `event_type_of` in `audit_writer.rs` or a method on `V2AuditEventKind`. Dashboard imports it.
- **(#8) Either remove the path-stamping wrapper** in `workspace_id_for_orbit_dir` (the underlying `read_workspace_config` error already names the path) or change the wrapper to *replace* the inner message rather than append.
- Tests use temp DB paths only.
- `OrbitError` propagation at crate boundaries; no `unwrap()` / `expect()` on touched paths.

## Out of scope

- The four correctness regressions covered by the blockers task (MCP sidecar split, importer marker gating, broken `activity_v2.rs` tests, synthetic session_learning_state rows).
- Test layout migration (inline tests → sibling `tests/` directory) for the golden test in `crates/orbit-cli/src/command/observe/audit.rs:372-440` and the importer test in `crates/orbit-store/src/state_io/import.rs:368-453` — deferred to a dedicated layout-cleanup task.
- Silent error swallowing in `audit_writer.rs:151` and `sqlite_sink.rs:118-122` — that's a policy decision (audit-write failure shouldn't crash the run), not a bug.
- N+1 query in `list_job_runs_for_workspace` (`crates/orbit-store/src/sqlite/job_run_store/mod.rs:537-539`) — defer to a perf task with a benchmark.
- `JobRunStoreBackend` method-count discrepancy (plan said 19, actual is 18) — verification only, not a fix.
- Friction reports remain untouched.

### Acceptance Criteria

- `JobRunResult.audit_jsonl` field is removed (or repurposed as a non-misleading `audit_source` indicator). `crates/orbit-cli/src/command/run/job.rs` no longer prints `audit_jsonl=-` or `"audit_jsonl": null`. Verified by `rg -n 'audit_jsonl' crates/` returning no matches in production code paths.
- `crates/orbit-dashboard/src/api/tests/test_support.rs::write_seeded_run` uses `runtime.sqlite_store()?.upsert_job_run_for_workspace(...)` (or an equivalent runtime-routed helper) instead of opening a second `Connection`. `rg -n 'Connection::open' crates/orbit-dashboard/` returns no matches outside opt-in admin tooling.
- Importer step / jrun parse failures increment `ImportReport::job_runs_skipped` / `ImportReport::job_run_steps_skipped` and continue (asymmetry with the audit-line skip path resolved). Verified by an integration test that seeds a workspace with one valid `jrun.yaml` and one malformed `jrun.yaml`, runs the importer, and asserts the valid run is inserted and the malformed one is counted as skipped.
- `SqliteJobRunStore::update_run` performs the read → mutate → upsert under a single SQLite transaction. Verified by a unit test that uses a SQL trace hook or a test that simulates two concurrent updates and asserts atomic last-state wins, not a torn write.
- `crates/orbit-agent/README.md` no longer mentions `JsonlFileSink` or `loop/<run_id>.jsonl`. Mentions of the v2 audit writer accurately reflect the SQLite sink shape.
- `crates/orbit-store/src/sqlite/migration/mod.rs:646-648` no longer has a duplicate `#[cfg(test)]` line.
- Dashboard denial filter pulls event-type strings from a single source of truth shared with `crates/orbit-engine/src/activity_job/audit_writer.rs::event_type_of`. A unit test enumerates the denial variants and asserts the dashboard filter set matches.
- `workspace_id_for_orbit_dir` error message names the file path exactly once. Verified by extending the existing unit test in `crates/orbit-store/src/sqlite/task_registry/tests/mod.rs::workspace_id_for_orbit_dir_missing_file_names_path_and_key` to assert the path string appears only once.
- `make ci-fast` passes; full CI green on the PR.
- Commit message references both ORB-00276 (the original migration) and this task's ID.
- Friction reports under `.orbit/frictions/` remain untouched.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Removed the stale `audit_jsonl` result field and CLI text/JSON output; v2 activity/job results now report emitted events without a permanent legacy JSONL placeholder.
- Routed dashboard seeded job runs through `OrbitRuntime::sqlite_store()` and seeded invocation metrics through a runtime helper instead of opening SQLite connections in dashboard tests.
- Added shared v2 denial event-type constants/methods on `V2AuditEventKind`, had the engine writer and dashboard use them, and covered the dashboard filter against fs/tool/step denial variants.
- Made legacy `jrun.yaml` and step parse failures warn, increment `job_runs_skipped` / `job_run_steps_skipped`, and continue importing valid runs.
- Wrapped SQLite job-run read/mutate/upsert in an immediate transaction and added a concurrent update test that preserves both writers' changes.
- Updated the orbit-agent README for SQLite-backed v2 audit persistence, removed the duplicate migration `#[cfg(test)]`, and adjusted `workspace_id_for_orbit_dir` errors/tests so the config path appears once.

Validation:
- `cargo test -p orbit-dashboard api::tests::denials`
- `cargo test -p orbit-dashboard api::tests::metrics`
- `cargo test -p orbit-store state_io::import::tests`
- `cargo test -p orbit-store sqlite::job_run_store::tests`
- `cargo test -p orbit-store sqlite::task_registry::tests::workspace_id_for_orbit_dir_missing_file_names_path_and_key`
- `cargo test -p orbit-core command::activity_v2::tests`
- `cargo test -p orbit-core command::job::exec::tests::direct_yaml_run_persists_history_and_run_state`
- `cargo check -p orbit-cli`
- `rg -n 'audit_jsonl' crates/` returned no matches
- `rg -n 'Connection::open' crates/orbit-dashboard/` returned no matches
- `make ci-fast`

Assessment: Scoped cleanup is implemented and locally validated; full CI remains the PR merge gate.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-00284-6a1225d0`
- Behind base: 0
- Ahead of base: 1

*authored by: codex*