### PR TITLE
Allocate ADRs for orbit-graph design decisions

### DIFF
--- a/.orbit/adrs/proposed/ADR-0184/adr.yaml
+++ b/.orbit/adrs/proposed/ADR-0184/adr.yaml
@@ -1,0 +1,19 @@
+schema_version: 2
+id: ADR-0184
+title: Graph is a derived index, not a versioned store
+status: proposed
+owner: codex
+created_at: 2026-05-24T21:04:25.374135Z
+last_updated: 2026-05-24T21:04:25.374135Z
+related_features:
+- orbit-graph
+related_tasks:
+- ORB-00294
+tags:
+- orbit-graph
+paths:
+- docs/design/orbit-graph/**
+supersedes: []
+legacy_ids: []
+validation_warnings: []
+legacy_validation: none

--- a/.orbit/adrs/proposed/ADR-0184/body.md
+++ b/.orbit/adrs/proposed/ADR-0184/body.md
@@ -1,0 +1,10 @@
+## Context
+`orbit-knowledge` was built as a git-like history layer: content-addressed objects, mutable refs, atomic swaps, lock protocols. In practice the graph is consumed as "fresh queryable index of the current code" — none of the version-store affordances are used by agents.
+
+## Decision
+Reframe the graph as a derived index, regenerable from `(file_contents, extractor_version)`. Delete object storage, mutable refs, and atomic-swap locking. Single SQLite file per worktree is the only durable state.
+
+## Consequences
+- Deletes ~3k LOC of object-store, lock, and ref-management code.
+- Removes the lock protocol's structural inability to coordinate same-branch worktrees (see knowledge-graph ADR-002 cost line).
+- Cost: **no history.** "What did the graph look like at commit X?" is no longer a query the graph can answer. Use git for that.

--- a/.orbit/adrs/proposed/ADR-0185/adr.yaml
+++ b/.orbit/adrs/proposed/ADR-0185/adr.yaml
@@ -1,0 +1,19 @@
+schema_version: 2
+id: ADR-0185
+title: Per-worktree DB filename embeds extractor version
+status: proposed
+owner: codex
+created_at: 2026-05-24T21:04:34.083775Z
+last_updated: 2026-05-24T21:04:34.083775Z
+related_features:
+- orbit-graph
+related_tasks:
+- ORB-00294
+tags:
+- orbit-graph
+paths:
+- docs/design/orbit-graph/**
+supersedes: []
+legacy_ids: []
+validation_warnings: []
+legacy_validation: none

--- a/.orbit/adrs/proposed/ADR-0185/body.md
+++ b/.orbit/adrs/proposed/ADR-0185/body.md
@@ -1,0 +1,10 @@
+## Context
+When extractor logic changes (new language, fixed parse bug, schema tweak), the on-disk DB becomes incompatible. The traditional fix is schema migration code; the V1 ethos is to keep complexity out of the storage layer.
+
+## Decision
+DB filename is `<branch>.<extractor_version>.db`. Bumping `EXTRACTOR_VERSION` makes old DBs invisible; they're deleted on next sync. No migration code.
+
+## Consequences
+- Extractor version bumps are zero-friction; agents never see migration failures.
+- Multiple extractor versions can coexist on disk temporarily during rollback testing.
+- Cost: **cold rebuild after every extractor bump.** For a 200k LOC repo that's ~3s, acceptable per the perf budget. For a much larger repo it could become noticeable; revisit if a user complains.

--- a/.orbit/adrs/proposed/ADR-0186/adr.yaml
+++ b/.orbit/adrs/proposed/ADR-0186/adr.yaml
@@ -1,0 +1,19 @@
+schema_version: 2
+id: ADR-0186
+title: Symbol IDs are ephemeral; resolution by qualified name
+status: proposed
+owner: codex
+created_at: 2026-05-24T21:04:43.097007Z
+last_updated: 2026-05-24T21:04:43.097007Z
+related_features:
+- orbit-graph
+related_tasks:
+- ORB-00294
+tags:
+- orbit-graph
+paths:
+- docs/design/orbit-graph/**
+supersedes: []
+legacy_ids: []
+validation_warnings: []
+legacy_validation: none

--- a/.orbit/adrs/proposed/ADR-0186/body.md
+++ b/.orbit/adrs/proposed/ADR-0186/body.md
@@ -1,0 +1,10 @@
+## Context
+With incremental sync, a file's symbol rows are deleted and re-inserted on change. If cross-file refs FK to `symbols.id`, every incremental rebuild orphans inbound refs from other files. The current `orbit-knowledge` schema has an `identity_key` column trying to paper over this; it doesn't fully work and adds complexity.
+
+## Decision
+No foreign key on `symbols.id` from any table. Refs and relations resolve by `target_qualified` (string lookup). A `target_symbol_hint INTEGER` column exists as a build-time cache but is non-authoritative.
+
+## Consequences
+- Incremental sync is correct by construction: dropping a file's symbols doesn't dangle anything.
+- No `identity_key` column or cross-build lineage tracking machinery.
+- Cost: **string lookups instead of integer FK joins.** SQLite's B-tree on `target_qualified` keeps this fast (low single-ms even on 100k symbols), but it's a real cost compared to the natural FK design. Rename tracking is a separate feature on top of git, not a graph affordance.

--- a/.orbit/adrs/proposed/ADR-0187/adr.yaml
+++ b/.orbit/adrs/proposed/ADR-0187/adr.yaml
@@ -1,0 +1,19 @@
+schema_version: 2
+id: ADR-0187
+title: Two ref tables, not one
+status: proposed
+owner: codex
+created_at: 2026-05-24T21:04:54.836382Z
+last_updated: 2026-05-24T21:04:54.836382Z
+related_features:
+- orbit-graph
+related_tasks:
+- ORB-00294
+tags:
+- orbit-graph
+paths:
+- docs/design/orbit-graph/**
+supersedes: []
+legacy_ids: []
+validation_warnings: []
+legacy_validation: none

--- a/.orbit/adrs/proposed/ADR-0187/body.md
+++ b/.orbit/adrs/proposed/ADR-0187/body.md
@@ -1,0 +1,10 @@
+## Context
+The original draft put all cross-symbol edges in one `refs` table with a `kind` column covering `call | type | impl | use | trait_bound`. Calls and type uses are anchored to `(file, span)`. Impl relations are anchored to `(concrete_symbol, trait_symbol)` with no useful span. Mixing them forces meaningless columns on the impl side.
+
+## Decision
+Split into `refs` (textual, `from_file + from_span_start/end`) and `relations` (symbol-to-symbol, `from_qualified + to_qualified`). CLI `--kind impl` is a routing alias to `relations`.
+
+## Consequences
+- "What implements X?" is a single `relations` index lookup, fast enough to be a hot path.
+- The two tables are independently extensible (e.g. adding `relations.kind = "annotates"` for TypeScript decorators) without inflating the `refs` shape.
+- Cost: **two indexes to maintain instead of one.** Schema is wider; the `refs` command needs to union two underlying queries. Acceptable for the correctness and ergonomics gain.

--- a/.orbit/adrs/proposed/ADR-0188/adr.yaml
+++ b/.orbit/adrs/proposed/ADR-0188/adr.yaml
@@ -1,0 +1,19 @@
+schema_version: 2
+id: ADR-0188
+title: Sync policy is a property of the Graph handle
+status: proposed
+owner: codex
+created_at: 2026-05-24T21:05:03.084033Z
+last_updated: 2026-05-24T21:05:03.084033Z
+related_features:
+- orbit-graph
+related_tasks:
+- ORB-00294
+tags:
+- orbit-graph
+paths:
+- docs/design/orbit-graph/**
+supersedes: []
+legacy_ids: []
+validation_warnings: []
+legacy_validation: none

--- a/.orbit/adrs/proposed/ADR-0188/body.md
+++ b/.orbit/adrs/proposed/ADR-0188/body.md
@@ -1,0 +1,10 @@
+## Context
+The original draft hardcoded "10ms stat budget at 5000 files; cache window 500ms" inside the query layer. The budget doesn't scale, and the policy mixes product decisions into the library.
+
+## Decision
+`Graph::open(root, policy: SyncPolicy)` where `SyncPolicy` is `Manual | OnRead | Windowed { window: Duration }`. CLI default: `Manual`. MCP server default: `Windowed { window: 500ms }`.
+
+## Consequences
+- Tests use `Manual` for determinism; long-lived processes use `Windowed`; one-shot scripts can use `OnRead` for paranoia.
+- The library no longer carries an implicit perf contract that breaks silently at scale.
+- Cost: **callers must choose.** No "just works" default beyond per-entry-point conventions. The conventions are documented but the choice is exposed.

--- a/.orbit/adrs/proposed/ADR-0189/adr.yaml
+++ b/.orbit/adrs/proposed/ADR-0189/adr.yaml
@@ -1,0 +1,19 @@
+schema_version: 2
+id: ADR-0189
+title: Performance gate is against committed baseline, not last run
+status: proposed
+owner: codex
+created_at: 2026-05-24T21:05:12.966719Z
+last_updated: 2026-05-24T21:05:12.966719Z
+related_features:
+- orbit-graph
+related_tasks:
+- ORB-00294
+tags:
+- orbit-graph
+paths:
+- docs/design/orbit-graph/**
+supersedes: []
+legacy_ids: []
+validation_warnings: []
+legacy_validation: none

--- a/.orbit/adrs/proposed/ADR-0189/body.md
+++ b/.orbit/adrs/proposed/ADR-0189/body.md
@@ -1,0 +1,10 @@
+## Context
+A perf regression gate that compares "this run vs previous merged run" ratchets up to whatever the latest measurement happened to be — slow degradation goes undetected.
+
+## Decision
+Baseline lives at `bench/baselines.json`, committed to the repo. Regression gate fires when a run is >20% slower than the *committed* baseline. Bumping the baseline requires a labeled PR and a one-line justification.
+
+## Consequences
+- Slow erosion is caught; cumulative drift requires an explicit acknowledgment.
+- Performance wins are realized by intentional baseline bumps, not silent improvements that immediately become the new floor.
+- Cost: **baseline updates are friction.** Every routine improvement requires a labeled PR. Acceptable — the friction is intentional and the alternative (no friction, no guarantee) is worse.

--- a/docs/design/orbit-graph/4_decisions.md
+++ b/docs/design/orbit-graph/4_decisions.md
@@ -19,17 +19,9 @@ Format for each entry: **Status · Date · Task(s)**, then *Context → Decision
 
 ---
 
-## ADR allocation pending
+## ADR-0184 — Graph is a derived index, not a versioned store
 
-No ADRs have been allocated yet. The decisions enumerated below are candidates — each is non-obvious, ruled out a real alternative, and carries a forward-shaping cost. They will be allocated via `orbit.adr.add` when the first migration step ([`GRAPH_SPEC.md`](./specs/GRAPH_SPEC.md) §16 Step 1) is task-tracked, then the headings here will be rewritten to use the allocated global IDs verbatim per [`docs/design/CONVENTIONS.md`](../CONVENTIONS.md) §4.
-
-Per the `orbit-adr` skill: **never hand-author headings under `## ADR-NNNN` without an `orbit.adr.add` allocation behind them.** The candidate list below uses placeholder `## (candidate)` headings to keep this file readable without violating the allocation contract.
-
----
-
-## (candidate) — Graph is a derived index, not a versioned store
-
-**Status:** Proposed · 2026-05 · (unscheduled)
+**Status:** Proposed · 2026-05 · [ORB-00294]
 
 **Context.** `orbit-knowledge` was built as a git-like history layer: content-addressed objects, mutable refs, atomic swaps, lock protocols. In practice the graph is consumed as "fresh queryable index of the current code" — none of the version-store affordances are used by agents.
 
@@ -40,9 +32,9 @@ Per the `orbit-adr` skill: **never hand-author headings under `## ADR-NNNN` with
 - Removes the lock protocol's structural inability to coordinate same-branch worktrees (see knowledge-graph ADR-002 cost line).
 - Cost: **no history.** "What did the graph look like at commit X?" is no longer a query the graph can answer. Use git for that.
 
-## (candidate) — Per-worktree DB filename embeds extractor version
+## ADR-0185 — Per-worktree DB filename embeds extractor version
 
-**Status:** Proposed · 2026-05 · (unscheduled)
+**Status:** Proposed · 2026-05 · [ORB-00294]
 
 **Context.** When extractor logic changes (new language, fixed parse bug, schema tweak), the on-disk DB becomes incompatible. The traditional fix is schema migration code; the V1 ethos is to keep complexity out of the storage layer.
 
@@ -53,9 +45,9 @@ Per the `orbit-adr` skill: **never hand-author headings under `## ADR-NNNN` with
 - Multiple extractor versions can coexist on disk temporarily during rollback testing.
 - Cost: **cold rebuild after every extractor bump.** For a 200k LOC repo that's ~3s, acceptable per the perf budget. For a much larger repo it could become noticeable; revisit if a user complains.
 
-## (candidate) — Symbol IDs are ephemeral; resolution by qualified name
+## ADR-0186 — Symbol IDs are ephemeral; resolution by qualified name
 
-**Status:** Proposed · 2026-05 · (unscheduled)
+**Status:** Proposed · 2026-05 · [ORB-00294]
 
 **Context.** With incremental sync, a file's symbol rows are deleted and re-inserted on change. If cross-file refs FK to `symbols.id`, every incremental rebuild orphans inbound refs from other files. The current `orbit-knowledge` schema has an `identity_key` column trying to paper over this; it doesn't fully work and adds complexity.
 
@@ -66,9 +58,9 @@ Per the `orbit-adr` skill: **never hand-author headings under `## ADR-NNNN` with
 - No `identity_key` column or cross-build lineage tracking machinery.
 - Cost: **string lookups instead of integer FK joins.** SQLite's B-tree on `target_qualified` keeps this fast (low single-ms even on 100k symbols), but it's a real cost compared to the natural FK design. Rename tracking is a separate feature on top of git, not a graph affordance.
 
-## (candidate) — Two ref tables, not one
+## ADR-0187 — Two ref tables, not one
 
-**Status:** Proposed · 2026-05 · (unscheduled)
+**Status:** Proposed · 2026-05 · [ORB-00294]
 
 **Context.** The original draft put all cross-symbol edges in one `refs` table with a `kind` column covering `call | type | impl | use | trait_bound`. Calls and type uses are anchored to `(file, span)`. Impl relations are anchored to `(concrete_symbol, trait_symbol)` with no useful span. Mixing them forces meaningless columns on the impl side.
 
@@ -79,9 +71,9 @@ Per the `orbit-adr` skill: **never hand-author headings under `## ADR-NNNN` with
 - The two tables are independently extensible (e.g. adding `relations.kind = "annotates"` for TypeScript decorators) without inflating the `refs` shape.
 - Cost: **two indexes to maintain instead of one.** Schema is wider; the `refs` command needs to union two underlying queries. Acceptable for the correctness and ergonomics gain.
 
-## (candidate) — Sync policy is a property of the Graph handle
+## ADR-0188 — Sync policy is a property of the Graph handle
 
-**Status:** Proposed · 2026-05 · (unscheduled)
+**Status:** Proposed · 2026-05 · [ORB-00294]
 
 **Context.** The original draft hardcoded "10ms stat budget at 5000 files; cache window 500ms" inside the query layer. The budget doesn't scale, and the policy mixes product decisions into the library.
 
@@ -92,9 +84,9 @@ Per the `orbit-adr` skill: **never hand-author headings under `## ADR-NNNN` with
 - The library no longer carries an implicit perf contract that breaks silently at scale.
 - Cost: **callers must choose.** No "just works" default beyond per-entry-point conventions. The conventions are documented but the choice is exposed.
 
-## (candidate) — Performance gate is against committed baseline, not last run
+## ADR-0189 — Performance gate is against committed baseline, not last run
 
-**Status:** Proposed · 2026-05 · (unscheduled)
+**Status:** Proposed · 2026-05 · [ORB-00294]
 
 **Context.** A perf regression gate that compares "this run vs previous merged run" ratchets up to whatever the latest measurement happened to be — slow degradation goes undetected.
 
@@ -109,6 +101,6 @@ Per the `orbit-adr` skill: **never hand-author headings under `## ADR-NNNN` with
 
 ## Task References
 
-No Orbit tasks have been allocated for this feature yet.
+- [ORB-00294] allocated the six initial orbit-graph ADR IDs (ADR-0184 through ADR-0189).
 
 Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.


### PR DESCRIPTION
## Task

[ORB-00294](https://orbit-cli.com/tasks/ORB-00294) — Allocate ADRs for orbit-graph design decisions

### Description

## Problem

[docs/design/orbit-graph/4_decisions.md](docs/design/orbit-graph/4_decisions.md) lists six candidate ADRs under placeholder `## (candidate)` headings:

1. Graph is a derived index, not a versioned store
2. Per-worktree DB filename embeds extractor version
3. Symbol IDs are ephemeral; resolution by qualified name
4. Two ref tables, not one
5. Sync policy is a property of the Graph handle
6. Performance gate is against committed baseline, not last run

Per the `orbit-adr` skill and [docs/design/CONVENTIONS.md](docs/design/CONVENTIONS.md) §4, ADR headings must be backed by an `orbit.adr.add` allocation before they take their final `## ADR-NNNN` form. Hand-authored headings without an allocation behind them violate the allocation contract.

## Why It Matters

This work gates Phase 1 of the orbit-graph migration ([docs/design/orbit-graph/specs/GRAPH_SPEC.md](docs/design/orbit-graph/specs/GRAPH_SPEC.md) §16 Step 1). Downstream tasks will cite these ADR IDs in commit messages, doc cross-references, and the ADR status-flip rule from CLAUDE.md ("Proposed → Accepted with task ID"). Allocating up front lets every later task reference stable IDs.

## Constraints

- Use `orbit.adr.add` once per ADR; do not hand-author the `## ADR-NNNN` heading.
- Preserve each candidate's body verbatim except for the heading and the "Status · Date · Task(s)" line, which should be updated with the allocated ID and this task's ID.
- The candidate ordering in the file is the proposed ADR ordering — keep it.
- Status stays `Proposed` for all six until an implementation task accepts them.

Part of the orbit-graph migration; see [docs/design/orbit-graph/](docs/design/orbit-graph/) and GRAPH_SPEC.md §16.

### Acceptance Criteria

- Six ADRs allocated via `orbit.adr.add`, covering the six candidates in [4_decisions.md](docs/design/orbit-graph/4_decisions.md) in document order
- [4_decisions.md](docs/design/orbit-graph/4_decisions.md) contains no `## (candidate)` heading; all six are `## ADR-NNNN — <title>`
- Each ADR's Task(s) line references this task ID
- The 'ADR allocation pending' preamble section is removed or rewritten to reflect allocation complete
- `grep -c '^## ADR-' docs/design/orbit-graph/4_decisions.md` returns 6

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Allocated six proposed orbit-graph ADRs via `orbit.adr.add` in document order: ADR-0184 through ADR-0189.
- Rewrote `docs/design/orbit-graph/4_decisions.md` to replace all six `## (candidate)` headings with allocated global ADR headings and updated each status line to cite `[ORB-00294]`.
- Removed the allocation-pending preamble and updated Task References to record ORB-00294 as the allocation task.

Validation:
- `grep -c "^## ADR-" docs/design/orbit-graph/4_decisions.md` returned `6`.
- No `## (candidate)` headings or `ADR allocation pending` text remain.
- `orbit.adr.show` returned all six allocated ADRs as `proposed` with `related_tasks: ["ORB-00294"]`.
- `make ci-fast` passed.

Assessment: The requested ADR allocation is complete and scoped to the orbit-graph decisions doc plus the six new ADR artifacts.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-00294-6a136748`
- Behind base: 0
- Ahead of base: 1