### PR TITLE
Scaffold tools/graph-equiv binary for v1↔v2 equivalence checks

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -31,6 +31,7 @@ flowchart LR
   MCP --> Common
   Dashboard["orbit-dashboard"] --> Core
   Dashboard --> Knowledge
+  GraphEquiv["graph-equiv"] --> Knowledge
   Core --> Common
   Registry["orbit-registry"] --> Common
 ```
@@ -55,6 +56,7 @@ flowchart LR
 - **orbit-engine**: activity/job execution, template rendering, retry logic, subprocess execution, and tool-aware automation. Owns the `backend: cli` subprocess runner (`activity_job::cli_runner`), which references `orbit-agent::{Agent, AgentConfig}` directly so orbit-core stays clean of orbit-agent types. Depends on `orbit-agent`, `orbit-common`, `orbit-exec`, `orbit-store`, and `orbit-tools`.
 - **orbit-core**: runtime bootstrap, config layering, command dispatch, default asset seeding, and thin command facades for graph, policy, tool, store, engine, and search features. Surfaces the `OrbitRuntime` API used by `orbit-cli`; does NOT depend on `orbit-agent`.
 - **orbit-cli**: clap-based CLI entry point.
+- **tools/graph-equiv**: internal workspace binary for the `orbit-knowledge` v1 to `orbit-graph` v2 equivalence harness. The scaffold depends only on `orbit-knowledge`; P6.1 owns the frozen corpus, diff logic, and CI wiring.
 
 ---
 
@@ -83,6 +85,7 @@ Each workspace crate declares a stability tier in its `Cargo.toml` under `[packa
 | orbit-dashboard       | internal     |
 | orbit-policy          | internal     |
 | orbit-tools           | internal     |
+| graph-equiv           | internal     |
 
 ---
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1133,6 +1133,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "graph-equiv"
+version = "0.7.1"
+dependencies = [
+ "orbit-knowledge",
+]
+
+[[package]]
 name = "h2"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ members = [
   "crates/orbit-tools",
   "crates/orbit-mcp",
   "crates/orbit-dashboard",
+  "tools/graph-equiv",
 ]
 resolver = "2"
 

--- a/scripts/check-dependency-direction.sh
+++ b/scripts/check-dependency-direction.sh
@@ -37,6 +37,9 @@ allowed_internal_deps() {
     orbit-dashboard)
       echo "orbit-common orbit-core orbit-knowledge"
       ;;
+    graph-equiv)
+      echo "orbit-knowledge"
+      ;;
     orbit-cli)
       echo "orbit-common orbit-core orbit-mcp orbit-dashboard"
       ;;
@@ -66,19 +69,22 @@ import sys
 metadata = json.load(sys.stdin)
 workspace_members = set(metadata["workspace_members"])
 workspace_crates = sorted(
-    package["name"]
+    (package["name"], package["manifest_path"])
     for package in metadata["packages"]
-    if package["id"] in workspace_members and package["name"].startswith("orbit-")
+    if package["id"] in workspace_members
+    and (package["name"].startswith("orbit-") or package["name"] == "graph-equiv")
 )
-for crate in workspace_crates:
-    print(crate)
+for crate, manifest_path in workspace_crates:
+    print(f"{crate}\t{manifest_path}")
 '
 }
 
 workspace_crates=()
-while IFS= read -r crate; do
+workspace_manifests=()
+while IFS=$'\t' read -r crate manifest; do
   if [[ -n "$crate" ]]; then
     workspace_crates+=("$crate")
+    workspace_manifests+=("$manifest")
   fi
 done < <(load_workspace_crates)
 
@@ -87,8 +93,9 @@ if [[ "${#workspace_crates[@]}" -eq 0 ]]; then
   exit 1
 fi
 
-for crate in "${workspace_crates[@]}"; do
-  manifest="$repo_root/crates/${crate}/Cargo.toml"
+for index in "${!workspace_crates[@]}"; do
+  crate="${workspace_crates[$index]}"
+  manifest="${workspace_manifests[$index]}"
   if [[ ! -f "$manifest" ]]; then
     echo "missing manifest for ${crate}: ${manifest}"
     fail=1

--- a/tools/graph-equiv/Cargo.toml
+++ b/tools/graph-equiv/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "graph-equiv"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[package.metadata.orbit]
+stability = "internal"
+
+[lints]
+workspace = true
+
+[dependencies]
+orbit-knowledge = { path = "../../crates/orbit-knowledge" }

--- a/tools/graph-equiv/README.md
+++ b/tools/graph-equiv/README.md
@@ -1,0 +1,33 @@
+# graph-equiv
+
+`graph-equiv` is the scaffold for the `orbit-knowledge` v1 to `orbit-graph`
+v2 equivalence harness described in `docs/design/orbit-graph/specs/GRAPH_SPEC.md`
+§16.
+
+This crate intentionally lands only the harness shape:
+
+- a backend trait with `search`, `show`, `refs`, `callees`, and `impact`
+- a v1 backend wired to the current `orbit-knowledge` command surface for
+  `search`, `show`, and `refs`
+- a v2 backend whose methods are `unimplemented!("orbit-graph not yet wired")`
+- a local smoke command for checking that v1 can query a knowledge graph
+
+`callees` and `impact` are present on the backend trait so P6.1 can fill the
+equivalence table without changing the dispatch shape; the v1 backend returns
+an unsupported error for them until the exact v1 adapter is added. This scaffold
+does not include the frozen selector corpus, per-query diff logic, waivers, a
+Make target, or CI enforcement. The harness is not CI-enforced yet. P6.1 is the
+follow-on that will add the corpus, equivalence comparison, and CI wiring.
+
+Local checks:
+
+```sh
+cargo build -p graph-equiv
+cargo test -p graph-equiv
+```
+
+Optional v1 smoke check against an existing graph:
+
+```sh
+cargo run -p graph-equiv -- smoke --workspace . --query GraphCommandContext
+```

--- a/tools/graph-equiv/src/backend.rs
+++ b/tools/graph-equiv/src/backend.rs
@@ -1,0 +1,307 @@
+use std::error::Error;
+use std::fmt;
+use std::path::PathBuf;
+
+use orbit_knowledge::KnowledgeError;
+use orbit_knowledge::commands::refs::{self, RefInclude, RefsInput};
+use orbit_knowledge::commands::search::{self, SearchInput};
+use orbit_knowledge::commands::show::{self, ShowInput, ShowNodeDetails};
+use orbit_knowledge::commands::{GraphCommandContext, TaskGraphScope, default_knowledge_dir};
+
+pub(crate) type BackendResult<T> = Result<T, BackendError>;
+pub(crate) type SearchOutput = Vec<SearchEntry>;
+pub(crate) type ShowOutput = Option<String>;
+pub(crate) type RefsOutput = Vec<(String, Option<u32>, String)>;
+pub(crate) type CalleesOutput = Vec<(String, Option<u32>, String)>;
+pub(crate) type ImpactOutput = Vec<String>;
+
+pub(crate) trait Backend {
+    fn search(&self, query: &str) -> BackendResult<SearchOutput>;
+    fn show(&self, selector: &str) -> BackendResult<ShowOutput>;
+    fn refs(&self, selector: &str) -> BackendResult<RefsOutput>;
+    fn callees(&self, selector: &str) -> BackendResult<CalleesOutput>;
+    fn impact(&self, selector: &str, depth: u8) -> BackendResult<ImpactOutput>;
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct V1Backend {
+    context: GraphCommandContext,
+    limit: usize,
+}
+
+impl V1Backend {
+    pub(crate) fn for_workspace(workspace_root: PathBuf, knowledge_dir: Option<PathBuf>) -> Self {
+        let knowledge_dir =
+            knowledge_dir.unwrap_or_else(|| default_knowledge_dir(&workspace_root, None));
+        Self::new(GraphCommandContext {
+            knowledge_dir,
+            workspace_root: Some(workspace_root),
+            explicit_ref: None,
+            explicit_knowledge_dir: false,
+            task_scope: TaskGraphScope::default(),
+        })
+    }
+
+    pub(crate) fn new(context: GraphCommandContext) -> Self {
+        Self { context, limit: 20 }
+    }
+}
+
+impl Backend for V1Backend {
+    fn search(&self, query: &str) -> BackendResult<SearchOutput> {
+        let result = search::run(SearchInput {
+            context: self.context.clone(),
+            query: query.to_string(),
+            node_type: None,
+            kind_filter: None,
+            prefix: None,
+            source_regex: None,
+            include_non_code: false,
+            allow_fuzzy: false,
+            limit: self.limit,
+        })?;
+
+        Ok(result
+            .hits
+            .into_iter()
+            .map(|hit| SearchEntry {
+                selector: hit.selector,
+                kind: hit.kind,
+                file: hit.file,
+                name: hit.name,
+            })
+            .collect())
+    }
+
+    fn show(&self, selector: &str) -> BackendResult<ShowOutput> {
+        let result = show::run(ShowInput {
+            context: self.context.clone(),
+            selector: selector.to_string(),
+            depth: 0,
+            max_siblings: 0,
+            max_children: 0,
+        })?;
+
+        let source = match result.details {
+            ShowNodeDetails::Leaf { source, .. } => Some(source),
+            ShowNodeDetails::File { source, .. } => source,
+            ShowNodeDetails::Dir => None,
+        };
+        Ok(source)
+    }
+
+    fn refs(&self, selector: &str) -> BackendResult<RefsOutput> {
+        let result = refs::run(RefsInput {
+            context: self.context.clone(),
+            selector: selector.to_string(),
+            include_simple_name: true,
+            include: RefInclude::code_only(),
+            limit: self.limit,
+            per_file_limit: 5,
+        })?;
+
+        Ok(result
+            .code_refs
+            .into_iter()
+            .map(|hit| (hit.file, None, hit.kind))
+            .collect())
+    }
+
+    fn callees(&self, _selector: &str) -> BackendResult<CalleesOutput> {
+        Err(BackendError::Unsupported(
+            "orbit-knowledge does not expose a callees command yet",
+        ))
+    }
+
+    fn impact(&self, _selector: &str, _depth: u8) -> BackendResult<ImpactOutput> {
+        Err(BackendError::Unsupported(
+            "orbit-knowledge does not expose an impact command yet",
+        ))
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct V2Backend;
+
+impl Backend for V2Backend {
+    fn search(&self, _query: &str) -> BackendResult<SearchOutput> {
+        unimplemented!("orbit-graph not yet wired")
+    }
+
+    fn show(&self, _selector: &str) -> BackendResult<ShowOutput> {
+        unimplemented!("orbit-graph not yet wired")
+    }
+
+    fn refs(&self, _selector: &str) -> BackendResult<RefsOutput> {
+        unimplemented!("orbit-graph not yet wired")
+    }
+
+    fn callees(&self, _selector: &str) -> BackendResult<CalleesOutput> {
+        unimplemented!("orbit-graph not yet wired")
+    }
+
+    fn impact(&self, _selector: &str, _depth: u8) -> BackendResult<ImpactOutput> {
+        unimplemented!("orbit-graph not yet wired")
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct SearchEntry {
+    pub(crate) selector: String,
+    pub(crate) kind: String,
+    pub(crate) file: Option<String>,
+    pub(crate) name: String,
+}
+
+#[derive(Debug)]
+pub(crate) enum BackendError {
+    Knowledge(KnowledgeError),
+    Unsupported(&'static str),
+}
+
+impl fmt::Display for BackendError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Knowledge(error) => write!(f, "{error}"),
+            Self::Unsupported(message) => f.write_str(message),
+        }
+    }
+}
+
+impl Error for BackendError {}
+
+impl From<KnowledgeError> for BackendError {
+    fn from(error: KnowledgeError) -> Self {
+        Self::Knowledge(error)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+    use std::path::PathBuf;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    use orbit_knowledge::commands::{GraphCommandContext, TaskGraphScope};
+    use orbit_knowledge::graph::object_store::{GraphObjectStore, RefName};
+    use orbit_knowledge::graph::{
+        BaseNodeFields, CodebaseGraphV1, DirNode, FileNode, LeafKind, LeafNode,
+    };
+
+    use super::{Backend, V1Backend};
+
+    #[test]
+    fn v1_backend_returns_real_search_and_show_results() -> Result<(), Box<dyn std::error::Error>> {
+        let temp_path = unique_temp_path()?;
+        fs::create_dir_all(&temp_path)?;
+
+        let result = run_v1_smoke(&temp_path);
+        let cleanup_result = fs::remove_dir_all(&temp_path);
+
+        result?;
+        cleanup_result?;
+        Ok(())
+    }
+
+    fn run_v1_smoke(temp_path: &PathBuf) -> Result<(), Box<dyn std::error::Error>> {
+        let store = GraphObjectStore::new(temp_path.join("graph"));
+        let current_ref = store.write_graph(&smoke_graph())?;
+        let ref_name = RefName::new("graph-equiv-smoke")?;
+        store.write_ref_atomic(&ref_name, &current_ref)?;
+
+        let backend = V1Backend::new(GraphCommandContext {
+            knowledge_dir: temp_path.clone(),
+            workspace_root: None,
+            explicit_ref: Some(ref_name.as_str().to_string()),
+            explicit_knowledge_dir: true,
+            task_scope: TaskGraphScope::default(),
+        });
+
+        let search = backend.search("fixture_fn")?;
+        assert!(search.iter().any(|hit| hit.name == "fixture_fn"));
+
+        let show = backend.show("symbol:src/fixture.rs#fixture_fn:function")?;
+        assert_eq!(show.as_deref(), Some("fn fixture_fn() {}\n"));
+
+        Ok(())
+    }
+
+    fn unique_temp_path() -> Result<PathBuf, Box<dyn std::error::Error>> {
+        let nanos = SystemTime::now().duration_since(UNIX_EPOCH)?.as_nanos();
+        Ok(std::env::temp_dir().join(format!("graph-equiv-{}-{nanos}", std::process::id())))
+    }
+
+    fn smoke_graph() -> CodebaseGraphV1 {
+        let root_id = "dir:.".to_string();
+        let file_id = "file:src/fixture.rs".to_string();
+        let leaf_id = "symbol:src/fixture.rs#fixture_fn:function".to_string();
+
+        CodebaseGraphV1 {
+            root_dir_id: root_id.clone(),
+            dirs: vec![DirNode {
+                base: base_node(&root_id, ".", ".", "", None),
+                dir_children: Vec::new(),
+                file_children: vec![file_id.clone()],
+            }],
+            files: vec![FileNode {
+                base: base_node(
+                    &file_id,
+                    "fixture.rs",
+                    "src/fixture.rs",
+                    "rust",
+                    Some(root_id),
+                ),
+                extension: Some("rs".to_string()),
+                source_blob_hash: None,
+                source: "fn fixture_fn() {}\n".to_string(),
+                imports: Vec::new(),
+                exports: Vec::new(),
+                re_exports: Vec::new(),
+                leaf_children: vec![leaf_id.clone()],
+            }],
+            leaves: vec![LeafNode {
+                base: base_node(
+                    &leaf_id,
+                    "fixture_fn",
+                    "src/fixture.rs#fixture_fn",
+                    "rust",
+                    Some(file_id),
+                ),
+                kind: LeafKind::Function,
+                source: "fn fixture_fn() {}\n".to_string(),
+                source_blob_hash: None,
+                source_hash: None,
+                file_hash_at_capture: None,
+                history: Vec::new(),
+                input_signature: Vec::new(),
+                output_signature: Vec::new(),
+                start_line: Some(1),
+                end_line: Some(1),
+                children: Vec::new(),
+            }],
+        }
+    }
+
+    fn base_node(
+        id: &str,
+        name: &str,
+        location: &str,
+        language: &str,
+        parent_id: Option<String>,
+    ) -> BaseNodeFields {
+        BaseNodeFields {
+            id: id.to_string(),
+            identity_key: id.to_string(),
+            object_hash: None,
+            name: name.to_string(),
+            location: location.to_string(),
+            language: language.to_string(),
+            description: String::new(),
+            parent_id,
+            is_locked: false,
+            lineage_locked: false,
+            lock_owner: None,
+            lock_reason: String::new(),
+        }
+    }
+}

--- a/tools/graph-equiv/src/main.rs
+++ b/tools/graph-equiv/src/main.rs
@@ -1,0 +1,109 @@
+//! Binary scaffold for the orbit-graph equivalence harness.
+
+mod backend;
+
+use std::env;
+use std::error::Error;
+use std::io::Write;
+use std::path::PathBuf;
+use std::process::ExitCode;
+
+use backend::{Backend, V1Backend, V2Backend};
+
+fn main() -> ExitCode {
+    match try_main() {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(error) => {
+            let _ = writeln!(std::io::stderr(), "{error}");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+fn try_main() -> Result<(), Box<dyn Error>> {
+    let mut args = env::args().skip(1);
+    match args.next().as_deref() {
+        None | Some("smoke") => run_smoke(SmokeOptions::parse(args)?),
+        Some("--help") | Some("-h") => Ok(()),
+        Some(other) => Err(input_error(format!("unknown command `{other}`"))),
+    }
+}
+
+fn run_smoke(options: SmokeOptions) -> Result<(), Box<dyn Error>> {
+    match options.backend.as_str() {
+        "v1" => smoke_backend(
+            &V1Backend::for_workspace(options.workspace, options.knowledge_dir),
+            &options.query,
+        ),
+        "v2" => smoke_backend(&V2Backend, &options.query),
+        other => Err(input_error(format!(
+            "`--backend` must be `v1` or `v2`, got `{other}`"
+        ))),
+    }
+}
+
+fn smoke_backend(backend: &dyn Backend, query: &str) -> Result<(), Box<dyn Error>> {
+    let search = backend.search(query)?;
+    let Some(first_hit) = search.first() else {
+        return Err(input_error(format!(
+            "v1 smoke search returned no results for `{query}`"
+        )));
+    };
+    let _show = backend.show(&first_hit.selector)?;
+    let _ = backend.refs(&first_hit.selector);
+    let _ = backend.callees(&first_hit.selector);
+    let _ = backend.impact(&first_hit.selector, 3);
+    Ok(())
+}
+
+struct SmokeOptions {
+    backend: String,
+    workspace: PathBuf,
+    knowledge_dir: Option<PathBuf>,
+    query: String,
+}
+
+impl SmokeOptions {
+    fn parse(args: impl Iterator<Item = String>) -> Result<Self, Box<dyn Error>> {
+        let mut backend = "v1".to_string();
+        let mut workspace = env::current_dir()?;
+        let mut knowledge_dir = None;
+        let mut query = "GraphCommandContext".to_string();
+        let mut args = args.peekable();
+
+        while let Some(arg) = args.next() {
+            match arg.as_str() {
+                "--backend" => backend = required_value(&mut args, "--backend")?,
+                "--workspace" => {
+                    workspace = PathBuf::from(required_value(&mut args, "--workspace")?)
+                }
+                "--knowledge-dir" => {
+                    knowledge_dir =
+                        Some(PathBuf::from(required_value(&mut args, "--knowledge-dir")?));
+                }
+                "--query" => query = required_value(&mut args, "--query")?,
+                "--help" | "-h" => {}
+                other => return Err(input_error(format!("unknown smoke option `{other}`"))),
+            }
+        }
+
+        Ok(Self {
+            backend,
+            workspace,
+            knowledge_dir,
+            query,
+        })
+    }
+}
+
+fn required_value(
+    args: &mut impl Iterator<Item = String>,
+    flag: &str,
+) -> Result<String, Box<dyn Error>> {
+    args.next()
+        .ok_or_else(|| input_error(format!("missing value for `{flag}`")))
+}
+
+fn input_error(message: String) -> Box<dyn Error> {
+    std::io::Error::new(std::io::ErrorKind::InvalidInput, message).into()
+}


### PR DESCRIPTION
## Task

[ORB-00297](https://orbit-cli.com/tasks/ORB-00297) — Scaffold tools/graph-equiv binary for v1↔v2 equivalence checks

### Description

## Problem

[GRAPH_SPEC.md](docs/design/orbit-graph/specs/GRAPH_SPEC.md) §16 Step 2 requires a CI-enforced harness that runs both `orbit-knowledge` (v1) and `orbit-graph` (v2) against a frozen corpus of selectors and fails on diffs outside the documented tolerances. The harness directory does not exist; landing the skeleton now keeps Step 2 from doing both "land v2" and "invent the parity harness" in the same blast radius.

## Why It Matters

The equivalence rules in §16's table are the gate that promotes v2 to default in Step 3. Doing the harness scaffold up front means P6.1 only needs to fill the corpus and per-query diff logic — not also design the binary, backend trait, and CI integration shape while v2 is in flight. Landing it early also surfaces any ARCHITECTURE.md questions (workspace member layering for the `tools/` directory) before they block real migration work.

## Constraints

- Skeleton only — no corpus, no real queries, no CI gating. P6.1 owns those.
- Path: `tools/graph-equiv/` per [ARCHITECTURE.md](ARCHITECTURE.md) workspace layering. Workspace `Cargo.toml` updated to include it.
- Backend trait covers exactly the five operations in the §16 table: `search`, `show`, `refs`, `callees`, `impact`. Trait lives in the binary crate; no new shared library.
- v1 backend wires through the current `orbit-knowledge` surface so it actually runs.
- v2 backend is a stub: every method is `unimplemented!("orbit-graph not yet wired")`. It exists so the dispatch shape is ready for P6.1 to fill once `orbit-graph` lands.
- Do not add a Make target or CI job that runs this binary — P6.1 will. README in the tool directory must explicitly state the harness is not yet CI-enforced.
- No new cross-crate dependency edges beyond `graph-equiv → orbit-knowledge`. Document any unexpected coupling in the task notes; do not add an edge into another orbit crate without an ADR per CLAUDE.md.

Part of the orbit-graph migration; see [docs/design/orbit-graph/](docs/design/orbit-graph/) and GRAPH_SPEC.md §16.

### Acceptance Criteria

- tools/graph-equiv/ exists with Cargo.toml, src/main.rs, src/backend.rs (or equivalent)
- Backend trait exposes `search`, `show`, `refs`, `callees`, `impact` with signatures matching the §16 equivalence table inputs
- v1 backend implementation calls into the current orbit-knowledge query surface and returns real results for a smoke-test selector
- v2 backend implementation compiles and each method returns `unimplemented!()`
- `cargo build -p graph-equiv` (or whatever name lands) succeeds locally
- `cargo test -p graph-equiv` passes (any test count is fine; just no failures)
- tools/graph-equiv/README.md documents the deferred CI wire-up and references P6.1 as the follow-on
- Workspace root Cargo.toml lists the new member; `cargo metadata` resolves it

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Added `tools/graph-equiv` as a workspace binary crate with a local backend trait covering `search`, `show`, `refs`, `callees`, and `impact`.
- Implemented the v1 backend against the available `orbit-knowledge` command surface (`search`, `show`, `refs`) and added a unit smoke test that writes a tiny knowledge graph and verifies real search/show results.
- Added the v2 backend stub with each method using `unimplemented!("orbit-graph not yet wired")`.
- Documented the non-CI scaffold status and P6.1 follow-on in `tools/graph-equiv/README.md`.
- Registered the workspace member, refreshed `Cargo.lock`, and aligned `ARCHITECTURE.md` plus `scripts/check-dependency-direction.sh` for the new `graph-equiv -> orbit-knowledge` edge.

Strategic decisions:
- Kept v1 `callees` and `impact` as unsupported placeholders because `orbit-knowledge` does not expose exact commands for those operations today. Rationale: this preserves the P6.1 dispatch shape without inventing parity semantics in the scaffold task.

Validation:
- `cargo metadata --format-version 1 --no-deps --manifest-path Cargo.toml`
- `cargo build -p graph-equiv`
- `cargo test -p graph-equiv`
- `make ci-fast`

Assessment: The scaffold is buildable, tested, and intentionally not wired into CI; P6.1 can add the corpus and diff logic without changing the workspace/dependency shape.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-00297-6a136748`
- Behind base: 0
- Ahead of base: 1