### PR TITLE
Establish bench/baselines.json for orbit-graph perf gate

### DIFF
--- a/bench/README.md
+++ b/bench/README.md
@@ -1,0 +1,44 @@
+# Graph Benchmark Baselines
+
+`bench/baselines.json` is the committed source of truth for the orbit-graph
+performance gate described in
+`docs/design/orbit-graph/specs/GRAPH_SPEC.md` section 12. CI compares a run
+against these committed values, not against the previous merged run.
+
+## Runner Profile
+
+Baseline values are measured on the GitHub Actions runner profile from the
+spec:
+
+- Image: `ubuntu-24.04`
+- OS release for the captured run: `Ubuntu 24.04.4 LTS`
+- Logical cores: 4
+- Memory: 15989 MiB
+
+Local runs are useful for investigation, but local values are advisory only
+and must not be committed as baseline updates.
+
+## Capture Procedure
+
+Capture a new baseline from a recorded GitHub Actions run and include the run
+URL, job URL, and raw output in the Orbit task or PR notes before changing
+`bench/baselines.json`.
+
+For the initial v1 capture, the CI job built release binaries, ran
+`target/release/examples/graph_build --workspace "$PWD"`, measured the
+one-file incremental update with `orbit graph update`, measured query rows
+through the `orbit.graph.*` tool surface, and recorded
+`.orbit/knowledge/graph/graph_index.sqlite` size. The `impact depth=3` row uses
+`orbit.graph.callers` at depth 3 as the v1 proxy because `orbit-knowledge` does
+not expose an `impact` command.
+
+P6.2 owns wiring the permanent `graph_bench.rs` CI gate. Once that lands, use
+the gate artifact under `target/bench/` as the capture source instead of an
+ad-hoc capture script.
+
+## Updating Baselines
+
+A PR that changes `bench/baselines.json` must have the
+`bench-baseline-bump` label and a one-line justification in the PR body.
+Routine performance wins should bump the baseline down. Routine performance
+drift should not bump the baseline; fix the regression instead.

--- a/bench/baselines.json
+++ b/bench/baselines.json
@@ -1,0 +1,211 @@
+{
+  "schema_version": 1,
+  "spec": "docs/design/orbit-graph/specs/GRAPH_SPEC.md#12-performance-budget-ci-enforced",
+  "captured_at": "2026-05-24T21:16:23Z",
+  "source": {
+    "run_url": "https://github.com/danieljhkim/orbit/actions/runs/26372840240",
+    "job_url": "https://github.com/danieljhkim/orbit/actions/runs/26372840240/job/77627936558",
+    "temporary_pr": "https://github.com/danieljhkim/orbit/pull/437",
+    "head_sha": "30dc0673462fdb037ebdb1044894ab58a3035f7d",
+    "merge_sha": "49107531fe4f5ba560278d5f4542dc22eba7dee7",
+    "runner": {
+      "image": "ubuntu-24.04",
+      "os_release": "Ubuntu 24.04.4 LTS",
+      "logical_core_count": 4,
+      "memory_mib": 15989
+    }
+  },
+  "rows": [
+    {
+      "id": "cold_full_build",
+      "operation": "Cold full build",
+      "spec_context": "200k LOC, 10 langs",
+      "target": {
+        "operator": "<",
+        "value": 3000,
+        "unit": "ms"
+      },
+      "baseline": {
+        "value": 3403,
+        "unit": "ms",
+        "statistic": "single_run"
+      },
+      "source": {
+        "field": "graph_bench_record.scenarios.cold_build.wall_time_ms"
+      }
+    },
+    {
+      "id": "incremental_no_changes",
+      "operation": "Incremental sync (no changes)",
+      "spec_context": "5000 files stat",
+      "target": {
+        "operator": "<",
+        "value": 100,
+        "unit": "ms"
+      },
+      "baseline": {
+        "value": 5230,
+        "unit": "ms",
+        "statistic": "single_run"
+      },
+      "source": {
+        "field": "graph_bench_record.scenarios.warm_incremental_noop.wall_time_ms"
+      }
+    },
+    {
+      "id": "incremental_one_file_changed",
+      "operation": "Incremental sync (1 file changed)",
+      "spec_context": "re-extract + write",
+      "target": {
+        "operator": "<",
+        "value": 50,
+        "unit": "ms",
+        "statistic": "p95"
+      },
+      "baseline": {
+        "value": 5518,
+        "unit": "ms",
+        "statistic": "p95"
+      },
+      "source": {
+        "field": "measurements.incremental_one_file_changed_ms_p95",
+        "samples": [
+          5481,
+          5518,
+          5332,
+          5472,
+          4941
+        ]
+      }
+    },
+    {
+      "id": "search",
+      "operation": "search",
+      "spec_context": "FTS5 over ~100k symbols",
+      "target": {
+        "operator": "<",
+        "value": 5,
+        "unit": "ms",
+        "statistic": "p95"
+      },
+      "baseline": {
+        "value": 81,
+        "unit": "ms",
+        "statistic": "p95"
+      },
+      "source": {
+        "command": "orbit tool run orbit.graph.search",
+        "query": "GraphCommandContext",
+        "field": "measurements.search_ms_p95",
+        "samples": [
+          81,
+          80,
+          80,
+          81,
+          80,
+          80,
+          80
+        ]
+      }
+    },
+    {
+      "id": "refs",
+      "operation": "refs",
+      "spec_context": "indexed lookup",
+      "target": {
+        "operator": "<",
+        "value": 10,
+        "unit": "ms",
+        "statistic": "p95"
+      },
+      "baseline": {
+        "value": 6226,
+        "unit": "ms",
+        "statistic": "p95"
+      },
+      "source": {
+        "command": "orbit tool run orbit.graph.refs",
+        "selector": "symbol:crates/orbit-knowledge/src/graph_bench.rs#run_benchmark_with_child_process:function",
+        "field": "measurements.refs_ms_p95",
+        "samples": [
+          797,
+          728,
+          728,
+          727,
+          731,
+          729,
+          6226
+        ]
+      }
+    },
+    {
+      "id": "impact_depth_3",
+      "operation": "impact depth=3",
+      "spec_context": "BFS over ~100 nodes",
+      "target": {
+        "operator": "<",
+        "value": 50,
+        "unit": "ms",
+        "statistic": "p95"
+      },
+      "baseline": {
+        "value": 6628,
+        "unit": "ms",
+        "statistic": "p95"
+      },
+      "source": {
+        "command": "orbit tool run orbit.graph.callers",
+        "selector": "symbol:crates/orbit-knowledge/src/graph_bench.rs#append_scoreboard:function",
+        "depth": 3,
+        "field": "measurements.impact_depth_3_ms_p95",
+        "note": "orbit-knowledge has no impact command; callers depth=3 is the v1 traversal proxy for this baseline row.",
+        "samples": [
+          1668,
+          1680,
+          1659,
+          6628,
+          1641,
+          1654,
+          1645
+        ]
+      }
+    },
+    {
+      "id": "resident_memory",
+      "operation": "Resident memory",
+      "spec_context": "sync + idle",
+      "target": {
+        "operator": "<",
+        "value": 102400,
+        "unit": "KiB"
+      },
+      "baseline": {
+        "value": 152340,
+        "unit": "KiB",
+        "statistic": "single_run_peak_rss"
+      },
+      "source": {
+        "field": "graph_bench_record.scenarios.warm_incremental_noop.peak_rss_kib"
+      }
+    },
+    {
+      "id": "db_size",
+      "operation": "DB size",
+      "spec_context": "200k LOC, 10 langs",
+      "target": {
+        "operator": "<",
+        "value": 52428800,
+        "unit": "bytes"
+      },
+      "baseline": {
+        "value": 26079232,
+        "unit": "bytes",
+        "statistic": "single_run"
+      },
+      "source": {
+        "path": ".orbit/knowledge/graph/graph_index.sqlite",
+        "field": "measurements.graph_index_sqlite_size_bytes"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Task

[ORB-00296](https://orbit-cli.com/tasks/ORB-00296) — Establish bench/baselines.json for orbit-graph perf gate

### Description

## Problem

[GRAPH_SPEC.md](docs/design/orbit-graph/specs/GRAPH_SPEC.md) §12 specifies a CI perf gate that compares each run against a committed baseline, **not** the previous merged run — otherwise the gate ratchets up to whatever the last commit happened to measure and the budget silently erodes. The baseline file (`bench/baselines.json`) does not exist yet, and there's no documented process for bumping it.

## Why It Matters

Without a committed baseline before v2 lands, the perf gate (wired in P6.2) has nothing to compare against. Capturing the current `orbit-knowledge` numbers as the floor lets us measure v2 against a real reference instead of arbitrary thresholds, and means any v1↔v2 perf regression is visible from the first dual-run. The candidate ADR-6 in [4_decisions.md](docs/design/orbit-graph/4_decisions.md) hinges on this file existing before v2 hits CI.

## Constraints

- Numbers measured on the GitHub Actions runner profile (`ubuntu-24.04`, 4-core, 16GB) per spec §12. Local dev measurements are advisory only and must not be the source of the committed values.
- One row per operation listed in the GRAPH_SPEC.md §12 table (cold full build, incremental no-changes, incremental 1-file, search, refs, impact depth=3, resident memory, DB size).
- The committed values must come from a recorded CI run — attach a link to the run, or paste the raw output in the task body, so the source is auditable.
- The bump workflow (`bench-baseline-bump` PR label + one-line justification in PR body) must be documented in bench/README.md before P6.2 wires the gate; P6.2 will enforce the label, this task only documents it.
- No CI changes in this task — P6.2 owns wiring `graph_bench.rs` to CI.

Part of the orbit-graph migration; see [docs/design/orbit-graph/](docs/design/orbit-graph/) and GRAPH_SPEC.md §12, §16.

### Acceptance Criteria

- bench/baselines.json committed with one entry per row in GRAPH_SPEC.md §12 table
- bench/README.md documents (a) the runner profile values are measured on, (b) the capture procedure, (c) the `bench-baseline-bump` label + justification workflow
- Each baseline value is traceable to a specific CI run (URL or artifact reference recorded in this task's notes)
- No changes to .github/workflows/*.yml in this task
- `jq . bench/baselines.json` parses without error

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Added `bench/baselines.json` with the eight GRAPH_SPEC.md §12 rows: cold full build, incremental no-changes, incremental 1-file, search, refs, impact depth=3, resident memory, and DB size.
- Added `bench/README.md` documenting the GitHub Actions runner profile, capture procedure, and `bench-baseline-bump` label + one-line justification workflow.
- Recorded the traceability note on the task with CI run/job URLs and the raw capture output from run 26372840240. The temporary capture PR was closed after recording the data.

Assessment: Baselines are parseable JSON, traceable to a GitHub Actions ubuntu-24.04 run, and no workflow files were changed. `impact depth=3` uses `orbit.graph.callers` as the documented v1 proxy because `orbit-knowledge` has no impact command.

Validation:
- `jq . bench/baselines.json`
- `jq -e '.rows | length == 8' bench/baselines.json`
- `test -z "$(git diff --name-only -- .github/workflows)"`
- `make ci-fast`

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-00296-6a136748`
- Behind base: 0
- Ahead of base: 1