### PR TITLE
Move Selector parser from orbit-knowledge to orbit-graph-extract

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -20,6 +20,7 @@ flowchart LR
   Tools --> Exec["orbit-exec"]
   Tools --> Knowledge
   Tools --> Policy
+  Knowledge --> GraphExtract["orbit-graph-extract"]
   Exec --> Common["orbit-common"]
   Knowledge --> Common
   Policy --> Common
@@ -47,8 +48,8 @@ flowchart LR
   Retrieval and ranking live in `orbit-search`. `orbit-core` owns the domain (corpora, records, lifecycle) and projects records into search-source structs. `orbit-search` owns lexical (BM25), semantic (cosine), and hybrid scoring. CLI verbs are presets layered on the same backend.
 - **orbit-search-companion**: separately installed search companion binary. Depends on `orbit-search` and fastembed-rs; not linked into the default `orbit` CLI binary.
 - **orbit-registry**: generic replicated registry substrate for publication flows. Opaque-bytes payloads + caller-chosen merge classes; optional `transport-git2` feature for git-backed replicas. Depends only on `orbit-common`.
-- **orbit-graph-extract**: pure graph extraction contracts and language-specific tree-sitter extractors for the orbit-graph migration. Owns `Extractor`, `ExtractedFile`, and raw row shapes; no internal crate dependencies, storage, async, or filesystem traversal.
-- **orbit-knowledge**: knowledge/graph parsing and storage helpers. Multi-language source parsing (Rust, Go, Java, JavaScript/TypeScript, Python). Depends on `orbit-common`; consumed by `orbit-tools`, which exposes graph tool and CLI-use-case facades upstream.
+- **orbit-graph-extract**: pure graph extraction contracts and language-specific tree-sitter extractors for the orbit-graph migration. Owns `Extractor`, `ExtractedFile`, raw row shapes, and the stable `Selector` parser; no internal crate dependencies, storage, async, or filesystem traversal.
+- **orbit-knowledge**: knowledge/graph parsing and storage helpers. Multi-language source parsing (Rust, Go, Java, JavaScript/TypeScript, Python). Depends on `orbit-common` and temporarily on `orbit-graph-extract` for the selector parser during the orbit-graph dual-run migration; consumed by `orbit-tools`, which exposes graph tool and CLI-use-case facades upstream.
 - **orbit-store**: layered store pattern (YAML + SQLite). Match existing modules when adding new ones. Depends only on `orbit-common`; the semantic vector schema is owned by `orbit-search::vector` (not `orbit-store`).
 - **orbit-tools**: tool registry plus built-in graph, fs, and policy-aware exec tools. Depends on `orbit-common`, `orbit-exec`, `orbit-knowledge`, `orbit-policy`.
 - **orbit-mcp**: Model Context Protocol adapter using `rmcp`. Depends only on `orbit-common`; consumed by `orbit-cli` via `orbit mcp serve`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2239,6 +2239,10 @@ dependencies = [
 [[package]]
 name = "orbit-graph-extract"
 version = "0.7.1"
+dependencies = [
+ "serde",
+ "thiserror",
+]
 
 [[package]]
 name = "orbit-knowledge"
@@ -2250,6 +2254,7 @@ dependencies = [
  "libc",
  "lru",
  "orbit-common",
+ "orbit-graph-extract",
  "proptest",
  "rayon",
  "regex",

--- a/crates/orbit-graph-extract/Cargo.toml
+++ b/crates/orbit-graph-extract/Cargo.toml
@@ -9,3 +9,7 @@ stability = "internal"
 
 [lints]
 workspace = true
+
+[dependencies]
+serde.workspace = true
+thiserror.workspace = true

--- a/crates/orbit-graph-extract/src/lib.rs
+++ b/crates/orbit-graph-extract/src/lib.rs
@@ -10,10 +10,16 @@ use std::path::Path;
 pub mod extracted;
 /// Language-specific extractor implementations.
 pub mod languages;
+/// Stable selector parser shared by graph callers and extractors.
+pub mod selector;
 
 pub use extracted::{
     ExtractedFile, RawCommand, RawConfig, RawImport, RawRef, RawRelation, RawString, RawSymbol,
 };
+pub use selector::{Selector, SelectorParseError};
+
+#[cfg(test)]
+mod tests;
 
 /// Extracts graph rows from a single file's bytes.
 pub trait Extractor {

--- a/crates/orbit-graph-extract/src/selector.rs
+++ b/crates/orbit-graph-extract/src/selector.rs
@@ -1,0 +1,470 @@
+//! Selector parsing and filesystem-anchor helpers for graph queries.
+
+use std::fmt::{Display, Formatter};
+use std::path::{Path, PathBuf};
+use std::str::FromStr;
+
+use serde::Serialize;
+use thiserror::Error;
+
+/// Error returned when a selector or legacy path-like scope cannot be parsed.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Error)]
+#[error("invalid selector `{input}`: {reason}")]
+pub struct SelectorParseError {
+    /// The original selector input.
+    pub input: String,
+    /// Human-readable parse failure reason.
+    pub reason: String,
+}
+
+/// Canonical graph selector.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Selector {
+    /// Directory selector anchored at a workspace-relative or absolute path.
+    Dir {
+        /// Directory anchor path.
+        path: String,
+    },
+    /// File selector anchored at a workspace-relative or absolute path.
+    File {
+        /// File anchor path.
+        path: String,
+    },
+    /// Symbol selector anchored at a source path and symbol identity.
+    Symbol {
+        /// File anchor path.
+        path: String,
+        /// Opaque symbol name or qualified symbol path.
+        symbol: String,
+        /// Symbol kind, such as `function`, `method`, or `trait`.
+        kind: String,
+    },
+}
+
+impl Selector {
+    /// Parse a list of selector strings.
+    pub fn parse_many(raw_selectors: &[String]) -> Result<Vec<Self>, SelectorParseError> {
+        raw_selectors
+            .iter()
+            .map(|selector| selector.parse())
+            .collect()
+    }
+
+    /// Return the filesystem anchor path for this selector.
+    pub fn path(&self) -> &str {
+        match self {
+            Self::Dir { path } | Self::File { path } | Self::Symbol { path, .. } => path,
+        }
+    }
+
+    fn with_path(&self, path: String) -> Self {
+        match self {
+            Self::Dir { .. } => Self::Dir { path },
+            Self::File { .. } => Self::File { path },
+            Self::Symbol { symbol, kind, .. } => Self::Symbol {
+                path,
+                symbol: symbol.clone(),
+                kind: kind.clone(),
+            },
+        }
+    }
+
+    fn kind(&self) -> ParsedScopeKind {
+        match self {
+            Self::Dir { .. } => ParsedScopeKind::Dir,
+            Self::File { .. } => ParsedScopeKind::File,
+            Self::Symbol { .. } => ParsedScopeKind::Symbol,
+        }
+    }
+
+    /// Return the lookup key used by graph selector indexes.
+    pub fn lookup_key(&self) -> SelectorLookupKey {
+        match self {
+            Self::Dir { path } => SelectorLookupKey::Dir(path.clone()),
+            Self::File { path } => SelectorLookupKey::File(path.clone()),
+            Self::Symbol { path, symbol, kind } => {
+                SelectorLookupKey::Symbol(format!("{path}#{symbol}"), kind.clone())
+            }
+        }
+    }
+}
+
+impl Display for Selector {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Dir { path } => write!(f, "dir:{path}"),
+            Self::File { path } => write!(f, "file:{path}"),
+            Self::Symbol { path, symbol, kind } => write!(f, "symbol:{path}#{symbol}:{kind}"),
+        }
+    }
+}
+
+impl FromStr for Selector {
+    type Err = SelectorParseError;
+
+    fn from_str(selector: &str) -> Result<Self, Self::Err> {
+        let trimmed = selector.trim();
+        if let Some(path) = trimmed.strip_prefix("dir:") {
+            return Ok(Self::Dir {
+                path: normalize_selector_path(selector, path)?,
+            });
+        }
+
+        if let Some(path) = trimmed.strip_prefix("file:") {
+            return Ok(Self::File {
+                path: normalize_selector_path(selector, path)?,
+            });
+        }
+
+        if let Some(remainder) = trimmed.strip_prefix("symbol:") {
+            let (location, kind) =
+                remainder
+                    .rsplit_once(':')
+                    .ok_or_else(|| SelectorParseError {
+                        input: selector.to_string(),
+                        reason: "symbol selectors must use `symbol:<path>#<symbol>:<kind>`"
+                            .to_string(),
+                    })?;
+            if location.is_empty() || kind.is_empty() {
+                return Err(SelectorParseError {
+                    input: selector.to_string(),
+                    reason: "symbol selectors must include both a location and kind".to_string(),
+                });
+            }
+            let (path, symbol) = location.split_once('#').ok_or_else(|| SelectorParseError {
+                input: selector.to_string(),
+                reason: "symbol selectors must include `#<symbol>`".to_string(),
+            })?;
+            let path = normalize_selector_path(selector, path)?;
+            let symbol = symbol.trim();
+            let kind = kind.trim();
+            if path.is_empty() || symbol.is_empty() || kind.is_empty() {
+                return Err(SelectorParseError {
+                    input: selector.to_string(),
+                    reason: "symbol selectors must include non-empty path, symbol, and kind"
+                        .to_string(),
+                });
+            }
+            return Ok(Self::Symbol {
+                path,
+                symbol: symbol.to_string(),
+                kind: kind.to_string(),
+            });
+        }
+
+        Err(SelectorParseError {
+            input: selector.to_string(),
+            reason: "selectors must start with `dir:`, `file:`, or `symbol:`".to_string(),
+        })
+    }
+}
+
+/// Normalized graph selector index key.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum SelectorLookupKey {
+    /// Directory key.
+    Dir(String),
+    /// File key.
+    File(String),
+    /// Symbol(location, kind) where location = "path#symbol".
+    Symbol(String, String),
+}
+
+impl SelectorLookupKey {
+    /// Render this lookup key as a canonical selector string.
+    pub fn to_selector_string(&self) -> String {
+        match self {
+            Self::Dir(path) => format!("dir:{path}"),
+            Self::File(path) => format!("file:{path}"),
+            Self::Symbol(location, kind) => format!("symbol:{location}:{kind}"),
+        }
+    }
+}
+
+/// Convert a selector or legacy path-like input into canonical selector form.
+///
+/// Accepted inputs are canonical selectors (`file:`, `dir:`, `symbol:`), raw
+/// paths, and raw `path:line` / `path:start-end` references. Legacy path
+/// references canonicalize to `file:<path>` unless they end with `/` or point
+/// at `.` / `..`, in which case they canonicalize to `dir:<path>`.
+pub fn canonical_selector(input: &str) -> Result<String, SelectorParseError> {
+    Ok(match ParsedScope::parse(input)? {
+        ParsedScope::Selector(selector) => selector.to_string(),
+        ParsedScope::LegacyPath { path, is_dir_hint } => {
+            if is_dir_hint {
+                format!("dir:{path}")
+            } else {
+                format!("file:{path}")
+            }
+        }
+    })
+}
+
+/// Canonicalize a selector or legacy path against a workspace root.
+///
+/// This is stricter than [`canonical_selector`]: absolute anchors inside the
+/// workspace are rewritten to workspace-relative form, and legacy paths that
+/// resolve to directories on disk canonicalize to `dir:<path>`.
+pub fn canonical_selector_in_workspace(
+    input: &str,
+    workspace: &Path,
+) -> Result<String, SelectorParseError> {
+    let parsed = ParsedScope::parse(input)?;
+    match parsed {
+        ParsedScope::Selector(selector) => {
+            let path = normalize_workspace_anchor(selector.path(), workspace)?;
+            Ok(selector.with_path(path).to_string())
+        }
+        ParsedScope::LegacyPath { path, is_dir_hint } => {
+            let path = normalize_workspace_anchor(path.as_str(), workspace)?;
+            let resolved = resolve_workspace_path(workspace, Path::new(&path));
+            if is_dir_hint || resolved.is_dir() {
+                Ok(format!("dir:{path}"))
+            } else {
+                Ok(format!("file:{path}"))
+            }
+        }
+    }
+}
+
+/// Return the filesystem anchor path for a selector or legacy path-like input.
+///
+/// For `symbol:` selectors this strips the symbol metadata and returns only the
+/// backing file path. Legacy `path:line` references are reduced to their file
+/// path anchor.
+pub fn anchor_path(selector: &str) -> Result<PathBuf, SelectorParseError> {
+    Ok(PathBuf::from(ParsedScope::parse(selector)?.anchor_path()))
+}
+
+/// Return whether a selector's filesystem anchor exists in the given workspace.
+///
+/// Relative anchors are resolved against `workspace`; absolute anchors are
+/// checked as-is. Invalid selector strings return `false`.
+pub fn exists_in_workspace(selector: &str, workspace: &Path) -> bool {
+    let Ok(anchor) = anchor_path(selector) else {
+        return false;
+    };
+    resolve_workspace_path(workspace, anchor.as_path()).exists()
+}
+
+/// Return whether two selector/path scopes overlap on the same filesystem
+/// anchor or on an ancestor/descendant boundary.
+///
+/// `symbol:file.rs#one:function` overlaps `symbol:file.rs#two:function` and
+/// `file:file.rs`. `dir:src` overlaps any selector anchored under `src/`.
+/// Legacy raw paths are treated conservatively and may overlap descendants.
+pub fn overlaps(a: &str, b: &str) -> bool {
+    let Ok(left) = ParsedScope::parse(a) else {
+        return false;
+    };
+    let Ok(right) = ParsedScope::parse(b) else {
+        return false;
+    };
+
+    let left_anchor = left.anchor_path();
+    let right_anchor = right.anchor_path();
+    if left_anchor == right_anchor {
+        return true;
+    }
+
+    (is_path_ancestor(left_anchor, right_anchor) && left.can_contain_descendants())
+        || (is_path_ancestor(right_anchor, left_anchor) && right.can_contain_descendants())
+}
+
+/// Return the number of shared path segments between two selector anchors.
+pub fn shared_anchor_prefix_depth(left: &str, right: &str) -> usize {
+    let Ok(left) = anchor_path(left) else {
+        return 0;
+    };
+    let Ok(right) = anchor_path(right) else {
+        return 0;
+    };
+    let left = normalize_path_text(&left.to_string_lossy()).ok();
+    let right = normalize_path_text(&right.to_string_lossy()).ok();
+    let (Some(left), Some(right)) = (left, right) else {
+        return 0;
+    };
+
+    let mut depth = 0usize;
+    for (left_part, right_part) in left
+        .split('/')
+        .filter(|part| !part.is_empty() && *part != ".")
+        .zip(
+            right
+                .split('/')
+                .filter(|part| !part.is_empty() && *part != "."),
+        )
+    {
+        if left_part != right_part {
+            break;
+        }
+        depth += 1;
+    }
+    depth
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ParsedScopeKind {
+    Dir,
+    File,
+    Symbol,
+    Legacy,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum ParsedScope {
+    Selector(Selector),
+    LegacyPath { path: String, is_dir_hint: bool },
+}
+
+impl ParsedScope {
+    fn parse(input: &str) -> Result<Self, SelectorParseError> {
+        let trimmed = input.trim();
+        if trimmed.is_empty() {
+            return Err(SelectorParseError {
+                input: input.to_string(),
+                reason: "selector input must not be empty".to_string(),
+            });
+        }
+
+        if trimmed.starts_with("dir:")
+            || trimmed.starts_with("file:")
+            || trimmed.starts_with("symbol:")
+        {
+            return Ok(Self::Selector(trimmed.parse()?));
+        }
+
+        let (path_like, _had_position_suffix) = strip_position_suffix(trimmed);
+        let path = normalize_path_text(path_like).map_err(|reason| SelectorParseError {
+            input: input.to_string(),
+            reason,
+        })?;
+        let is_dir_hint = trimmed.ends_with('/') || matches!(path.as_str(), "." | "..");
+        Ok(Self::LegacyPath { path, is_dir_hint })
+    }
+
+    fn anchor_path(&self) -> &str {
+        match self {
+            Self::Selector(selector) => selector.path(),
+            Self::LegacyPath { path, .. } => path,
+        }
+    }
+
+    fn kind(&self) -> ParsedScopeKind {
+        match self {
+            Self::Selector(selector) => selector.kind(),
+            Self::LegacyPath { .. } => ParsedScopeKind::Legacy,
+        }
+    }
+
+    fn can_contain_descendants(&self) -> bool {
+        matches!(self.kind(), ParsedScopeKind::Dir | ParsedScopeKind::Legacy)
+    }
+}
+
+fn normalize_selector_path(
+    original_input: &str,
+    raw_path: &str,
+) -> Result<String, SelectorParseError> {
+    normalize_path_text(raw_path).map_err(|reason| SelectorParseError {
+        input: original_input.to_string(),
+        reason,
+    })
+}
+
+fn normalize_workspace_anchor(path: &str, workspace: &Path) -> Result<String, SelectorParseError> {
+    let normalized = normalize_path_text(path).map_err(|reason| SelectorParseError {
+        input: path.to_string(),
+        reason,
+    })?;
+    let resolved = PathBuf::from(&normalized);
+    if resolved.is_absolute() {
+        let stripped = resolved
+            .strip_prefix(workspace)
+            .ok()
+            .map(|path| path.to_string_lossy().replace('\\', "/"));
+        return Ok(stripped.unwrap_or(normalized));
+    }
+    Ok(normalized)
+}
+
+fn normalize_path_text(raw: &str) -> Result<String, String> {
+    let normalized = raw.trim().replace('\\', "/");
+    if normalized.is_empty() {
+        return Err("selector path must not be empty".to_string());
+    }
+
+    let is_absolute = normalized.starts_with('/');
+    let mut parts = Vec::new();
+    for part in normalized.split('/') {
+        match part {
+            "" | "." => {}
+            ".." => {
+                if let Some(last) = parts.last()
+                    && *last != ".."
+                {
+                    parts.pop();
+                } else if !is_absolute {
+                    parts.push("..");
+                }
+            }
+            other => parts.push(other),
+        }
+    }
+
+    if is_absolute {
+        return Ok(if parts.is_empty() {
+            "/".to_string()
+        } else {
+            format!("/{}", parts.join("/"))
+        });
+    }
+
+    Ok(if parts.is_empty() {
+        ".".to_string()
+    } else {
+        parts.join("/")
+    })
+}
+
+fn resolve_workspace_path(workspace: &Path, anchor: &Path) -> PathBuf {
+    if anchor.is_absolute() {
+        anchor.to_path_buf()
+    } else {
+        workspace.join(anchor)
+    }
+}
+
+fn strip_position_suffix(input: &str) -> (&str, bool) {
+    let mut candidate = input;
+    let mut stripped = false;
+
+    loop {
+        let Some((base, suffix)) = candidate.rsplit_once(':') else {
+            return (candidate, stripped);
+        };
+        if is_position_segment(suffix) {
+            candidate = base;
+            stripped = true;
+            continue;
+        }
+        return (candidate, stripped);
+    }
+}
+
+fn is_position_segment(segment: &str) -> bool {
+    is_numeric(segment)
+        || segment
+            .split_once('-')
+            .is_some_and(|(start, end)| is_numeric(start) && is_numeric(end))
+}
+
+fn is_numeric(input: &str) -> bool {
+    !input.is_empty() && input.chars().all(|ch| ch.is_ascii_digit())
+}
+
+fn is_path_ancestor(parent: &str, child: &str) -> bool {
+    child
+        .strip_prefix(parent)
+        .is_some_and(|suffix| suffix.starts_with('/'))
+}

--- a/crates/orbit-graph-extract/src/tests/mod.rs
+++ b/crates/orbit-graph-extract/src/tests/mod.rs
@@ -1,0 +1,1 @@
+mod selector;

--- a/crates/orbit-graph-extract/src/tests/selector.rs
+++ b/crates/orbit-graph-extract/src/tests/selector.rs
@@ -1,0 +1,34 @@
+use crate::Selector;
+
+const SELECTOR_CORPUS: &str = include_str!(concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/../../docs/design/orbit-graph/specs/selector_corpus.txt"
+));
+
+#[test]
+fn selector_audit_corpus_keeps_frozen_debug_output() {
+    let actual = SELECTOR_CORPUS
+        .lines()
+        .filter_map(|line| {
+            let selector = line.trim();
+            if selector.is_empty() || selector.starts_with('#') {
+                None
+            } else {
+                Some(selector)
+            }
+        })
+        .map(|line| match line.parse::<Selector>() {
+            Ok(selector) => format!("{selector:?}"),
+            Err(error) => panic!("selector corpus entry `{line}` did not parse: {error}"),
+        })
+        .collect::<Vec<_>>();
+
+    let expected = vec![
+        r#"Dir { path: "src/command" }"#,
+        r#"File { path: "src/lib.rs" }"#,
+        r#"Symbol { path: "src/lib.rs", symbol: "hello", kind: "function" }"#,
+        r#"Symbol { path: "src/lib.rs", symbol: "Greeter", kind: "trait" }"#,
+    ];
+
+    assert_eq!(actual, expected);
+}

--- a/crates/orbit-knowledge/Cargo.toml
+++ b/crates/orbit-knowledge/Cargo.toml
@@ -16,6 +16,7 @@ fs2.workspace = true
 ignore = "0.4.25"
 libc.workspace = true
 orbit-common = { path = "../orbit-common" }
+orbit-graph-extract = { path = "../orbit-graph-extract" }
 regex.workspace = true
 rusqlite.workspace = true
 serde.workspace = true

--- a/crates/orbit-knowledge/src/commands/callers.rs
+++ b/crates/orbit-knowledge/src/commands/callers.rs
@@ -1,8 +1,9 @@
+use crate::KnowledgeError;
 use crate::commands::GraphCommandContext;
 use crate::graph::GraphReadOptions;
 use crate::service::GraphContextService;
 use crate::service::callers::{CallerHit, MAX_CALLER_DEPTH, transitive_callers};
-use crate::{KnowledgeError, Selector};
+use orbit_graph_extract::Selector;
 
 const DEFAULT_DEPTH: usize = 2;
 

--- a/crates/orbit-knowledge/src/commands/implementors.rs
+++ b/crates/orbit-knowledge/src/commands/implementors.rs
@@ -1,8 +1,9 @@
+use crate::KnowledgeError;
 use crate::commands::GraphCommandContext;
 use crate::graph::GraphReadOptions;
 use crate::service::GraphContextService;
 use crate::service::implementors::{ImplementorHit, trait_implementors};
-use crate::{KnowledgeError, Selector};
+use orbit_graph_extract::Selector;
 
 #[derive(Debug, Clone)]
 pub struct ImplementorsInput {

--- a/crates/orbit-knowledge/src/commands/pack.rs
+++ b/crates/orbit-knowledge/src/commands/pack.rs
@@ -1,7 +1,8 @@
 use crate::commands::{GraphCommandContext, knowledge_error_from_orbit};
 use crate::graph::GraphReadOptions;
 use crate::graph::object_store::{GraphObjectStore, resolve_graph_read_target};
-use crate::{KnowledgeError, KnowledgePackResult, Selector};
+use crate::{KnowledgeError, KnowledgePackResult};
+use orbit_graph_extract::Selector;
 
 #[derive(Debug, Clone)]
 pub struct PackInput {

--- a/crates/orbit-knowledge/src/commands/refs.rs
+++ b/crates/orbit-knowledge/src/commands/refs.rs
@@ -1,10 +1,11 @@
 use std::collections::HashMap;
 use std::path::Path;
 
+use crate::KnowledgeError;
 use crate::commands::GraphCommandContext;
 use crate::graph::GraphReadOptions;
 use crate::service::GraphContextService;
-use crate::{KnowledgeError, Selector};
+use orbit_graph_extract::Selector;
 
 #[derive(Debug, Clone)]
 pub struct RefsInput {

--- a/crates/orbit-knowledge/src/commands/show.rs
+++ b/crates/orbit-knowledge/src/commands/show.rs
@@ -1,10 +1,11 @@
 use serde_json::Value;
 
+use crate::KnowledgeError;
 use crate::commands::GraphCommandContext;
 use crate::graph::object_store::{GraphObjectStore, resolve_graph_read_target};
 use crate::graph::{CodebaseGraphV1, GraphIndexNodeRow, GraphNode, GraphReadOptions, LeafKind};
 use crate::service::{GraphContextService, NodeContext};
-use crate::{KnowledgeError, Selector};
+use orbit_graph_extract::Selector;
 
 use super::fuzzy::levenshtein_distance;
 

--- a/crates/orbit-knowledge/src/commands/tests/show.rs
+++ b/crates/orbit-knowledge/src/commands/tests/show.rs
@@ -3,9 +3,10 @@
 // Tests for commands/show.rs live here as sibling under commands/tests/ per
 // docs/design-patterns/test_layout.md. Explicit imports.
 
+use crate::KnowledgeError;
 use crate::graph::{BaseNodeFields, CodebaseGraphV1, DirNode, FileNode, LeafKind, LeafNode};
 use crate::service::GraphContextService;
-use crate::{KnowledgeError, Selector};
+use orbit_graph_extract::Selector;
 
 use super::super::show::{DID_YOU_MEAN_LIMIT, invalid_selector_resolution_error};
 

--- a/crates/orbit-knowledge/src/commands/write.rs
+++ b/crates/orbit-knowledge/src/commands/write.rs
@@ -3,8 +3,9 @@ use std::path::PathBuf;
 use orbit_common::types::OrbitError;
 use serde_json::Value;
 
+use crate::KnowledgeError;
 use crate::commands::{GraphCommandContext, knowledge_error_from_orbit};
-use crate::{KnowledgeError, Selector};
+use orbit_graph_extract::Selector;
 
 #[derive(Debug, Clone)]
 pub struct MutationContext {

--- a/crates/orbit-knowledge/src/selector.rs
+++ b/crates/orbit-knowledge/src/selector.rs
@@ -1,2 +1,1 @@
-pub(crate) use orbit_common::utility::selector::SelectorLookupKey;
-pub use orbit_common::utility::selector::{Selector, SelectorParseError};
+pub use orbit_graph_extract::{Selector, SelectorParseError};

--- a/crates/orbit-knowledge/src/service/callers.rs
+++ b/crates/orbit-knowledge/src/service/callers.rs
@@ -18,7 +18,7 @@ use tree_sitter::{Node, Parser};
 use crate::error::KnowledgeError;
 use crate::graph::navigator::GraphNodeRef;
 use crate::graph::nodes::{CodebaseGraphV1, LeafKind};
-use crate::selector::Selector;
+use orbit_graph_extract::Selector;
 
 use super::GraphContextService;
 

--- a/crates/orbit-knowledge/src/service/implementors.rs
+++ b/crates/orbit-knowledge/src/service/implementors.rs
@@ -12,7 +12,7 @@ use tree_sitter::{Node, Parser};
 use crate::error::KnowledgeError;
 use crate::graph::navigator::GraphNodeRef;
 use crate::graph::nodes::{CodebaseGraphV1, LeafKind, LeafNode};
-use crate::selector::Selector;
+use orbit_graph_extract::Selector;
 
 use super::GraphContextService;
 

--- a/crates/orbit-knowledge/src/service/lineage.rs
+++ b/crates/orbit-knowledge/src/service/lineage.rs
@@ -9,8 +9,8 @@ use crate::error::KnowledgeError;
 use crate::graph::navigator::GraphNodeRef;
 use crate::graph::nodes::CodebaseGraphV1;
 use crate::graph::object_store::{GraphObjectStore, GraphReadOptions, resolve_graph_read_target};
-use crate::selector::Selector;
 use crate::service::GraphContextService;
+use orbit_graph_extract::Selector;
 
 /// Options for rendering a lineage pack.
 pub struct LineagePackOptions {

--- a/crates/orbit-knowledge/src/service/selectors.rs
+++ b/crates/orbit-knowledge/src/service/selectors.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use crate::error::KnowledgeError;
 use crate::graph::navigator::GraphNodeRef;
-use crate::selector::Selector;
+use orbit_graph_extract::Selector;
 
 use super::GraphContextService;
 

--- a/crates/orbit-knowledge/src/service/task_graph.rs
+++ b/crates/orbit-knowledge/src/service/task_graph.rs
@@ -1,13 +1,14 @@
 use std::path::{Path, PathBuf};
 
 use orbit_common::types::OrbitError;
+use orbit_graph_extract::Selector;
 
 use crate::extract::{self, Language};
 use crate::graph::object_store::{GraphObjectStore, GraphReadOptions, resolve_graph_read_target};
 use crate::lock::GraphLockGuard;
 use crate::pipeline::context::BuildConfig;
 use crate::{
-    KnowledgeError, KnowledgePackResult, KnowledgeStore, Selector, WorkingGraph, WorkingLeaf,
+    KnowledgeError, KnowledgePackResult, KnowledgeStore, WorkingGraph, WorkingLeaf,
     load_task_working_graph, overlay_pack_with_working_graph, pack_from_working_graph,
     save_task_working_graph,
 };

--- a/crates/orbit-knowledge/src/store.rs
+++ b/crates/orbit-knowledge/src/store.rs
@@ -16,7 +16,7 @@ mod types;
 use std::collections::HashMap;
 use std::path::PathBuf;
 
-use crate::selector::SelectorLookupKey;
+use orbit_graph_extract::selector::SelectorLookupKey;
 
 pub use object_cache::{
     DEFAULT_BLOB_CACHE_CAPACITY, DEFAULT_OBJECT_CACHE_CAPACITY, GraphObjectCache,

--- a/crates/orbit-knowledge/src/store/leaf_data.rs
+++ b/crates/orbit-knowledge/src/store/leaf_data.rs
@@ -1,6 +1,6 @@
 use serde_json::Value;
 
-use crate::selector::SelectorLookupKey;
+use orbit_graph_extract::selector::SelectorLookupKey;
 
 use super::KnowledgeStore;
 use super::graph_io::{extract_leaf_source, read_graph_object};

--- a/crates/orbit-knowledge/src/store/open.rs
+++ b/crates/orbit-knowledge/src/store/open.rs
@@ -5,7 +5,7 @@ use serde_json::Value;
 
 use crate::error::KnowledgeError;
 use crate::graph::object_store::{GraphObjectStore, RefName};
-use crate::selector::SelectorLookupKey;
+use orbit_graph_extract::selector::SelectorLookupKey;
 
 use super::KnowledgeStore;
 use super::graph_io::read_json_file;

--- a/crates/orbit-knowledge/src/store/pack.rs
+++ b/crates/orbit-knowledge/src/store/pack.rs
@@ -5,7 +5,8 @@ use serde_json::Value;
 
 use crate::error::KnowledgeError;
 use crate::graph::object_store::GraphReadOptions;
-use crate::selector::Selector;
+use orbit_graph_extract::Selector;
+use orbit_graph_extract::selector::SelectorLookupKey;
 
 use super::KnowledgeStore;
 use super::graph_io::{extract_leaf_source, read_graph_object};
@@ -174,7 +175,7 @@ impl KnowledgeStore {
         loop {
             if self
                 .selector_index
-                .contains_key(&crate::selector::SelectorLookupKey::Dir(candidate.clone()))
+                .contains_key(&SelectorLookupKey::Dir(candidate.clone()))
             {
                 return true;
             }

--- a/crates/orbit-knowledge/src/store/task_state.rs
+++ b/crates/orbit-knowledge/src/store/task_state.rs
@@ -4,8 +4,8 @@ use std::path::{Path, PathBuf};
 use orbit_common::types::OrbitError;
 
 use crate::io::write_text_atomic_durable;
-use crate::selector::Selector;
 use crate::working_graph::{WorkingGraph, WorkingLeaf};
+use orbit_graph_extract::Selector;
 
 use super::pack::unresolved_entry;
 use super::types::{KnowledgeEntryKind, KnowledgePack, KnowledgePackEntry};

--- a/crates/orbit-knowledge/src/store/types.rs
+++ b/crates/orbit-knowledge/src/store/types.rs
@@ -156,7 +156,7 @@ impl KnowledgePackResult {
 
     pub(crate) fn from_error(
         knowledge_dir: impl Into<String>,
-        selectors: &[crate::Selector],
+        selectors: &[orbit_graph_extract::Selector],
         error: crate::KnowledgeError,
     ) -> Self {
         let unresolved_selectors = selectors

--- a/crates/orbit-knowledge/src/workflows/observe.rs
+++ b/crates/orbit-knowledge/src/workflows/observe.rs
@@ -17,7 +17,8 @@ use serde_json::{Value, json};
 use crate::graph::navigator::GraphNodeRef;
 use crate::service::GraphContextService;
 use crate::workflows::{load_graph, parse_ref_name};
-use crate::{GraphReadOptions, KnowledgeError, Selector};
+use crate::{GraphReadOptions, KnowledgeError};
+use orbit_graph_extract::Selector;
 
 pub const REMOVED_GRAPH_HISTORY_MESSAGE: &str = "Knowledge-graph task attribution has been removed. Use `git log --grep '[T<task-id>]'` for local forward lookup, and use `external_refs` for cross-engineer task references.";
 

--- a/crates/orbit-knowledge/src/working_graph/model.rs
+++ b/crates/orbit-knowledge/src/working_graph/model.rs
@@ -3,8 +3,8 @@ use std::collections::HashMap;
 use serde::{Deserialize, Serialize};
 
 use crate::error::KnowledgeError;
-use crate::selector::Selector;
 use crate::store::KnowledgeStore;
+use orbit_graph_extract::Selector;
 
 /// A single edit in a leaf's version chain.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/orbit-knowledge/src/working_graph/ops.rs
+++ b/crates/orbit-knowledge/src/working_graph/ops.rs
@@ -2,7 +2,7 @@ use std::fs;
 use std::path::Path;
 
 use crate::extract::{self, Language};
-use crate::selector::Selector;
+use orbit_graph_extract::Selector;
 
 use super::model::{MoveResult, WorkingGraph, WriteError, WriteResult};
 use super::rewrite::{

--- a/crates/orbit-knowledge/src/working_graph/rewrite.rs
+++ b/crates/orbit-knowledge/src/working_graph/rewrite.rs
@@ -6,7 +6,7 @@ use crate::extract::{self, Language};
 use crate::io::{
     LineEnding, StagedTextFile, render_content as render_text_content, write_text_atomic_durable,
 };
-use crate::selector::Selector;
+use orbit_graph_extract::Selector;
 
 use super::model::{WorkingGraph, WorkingLeaf, WriteError, WriteResult};
 

--- a/docs/design/orbit-graph/specs/selector_corpus.txt
+++ b/docs/design/orbit-graph/specs/selector_corpus.txt
@@ -1,0 +1,4 @@
+dir:src/command
+file:src/lib.rs
+symbol:src/lib.rs#hello:function
+symbol:src/lib.rs#Greeter:trait

--- a/scripts/check-dependency-direction.sh
+++ b/scripts/check-dependency-direction.sh
@@ -13,8 +13,11 @@ allowed_internal_deps() {
     orbit-registry)
       echo "orbit-common"
       ;;
-    orbit-policy | orbit-exec | orbit-knowledge | orbit-store | orbit-search)
+    orbit-policy | orbit-exec | orbit-store | orbit-search)
       echo "orbit-common"
+      ;;
+    orbit-knowledge)
+      echo "orbit-common orbit-graph-extract"
       ;;
     orbit-search-companion)
       echo "orbit-common orbit-search"


### PR DESCRIPTION
## Task

[ORB-00300](https://orbit-cli.com/tasks/ORB-00300) — Move Selector parser from orbit-knowledge to orbit-graph-extract

### Description

## Problem

The `Selector` grammar is a hard public contract per [GRAPH_SPEC.md §14](docs/design/orbit-graph/specs/GRAPH_SPEC.md). [2_design.md §1](docs/design/orbit-graph/2_design.md) places the parser in `orbit-graph-extract` because skills parse selectors before any DB exists. Today the parser lives at [crates/orbit-knowledge/src/selector.rs](crates/orbit-knowledge/src/selector.rs); it has to move into the new extract crate so storage redesigns don't ripple through the selector API.

## Why It Matters

Every later orbit-graph task (queries, CLI, MCP wrappers) consumes `Selector` through orbit-graph-extract. Moving it now — before any language ports — keeps the selector and the per-language extractors in the same crate where the audit corpus from ORB-00295 can exercise both. Once moved, the fixture from ORB-00295 must continue to pass against the relocated parser; that's the release-blocker check from spec §14.

## Constraints

- Grammar preserved verbatim — every form from the ORB-00295 audit corpus parses identically with the same Debug repr.
- orbit-knowledge keeps re-exporting `Selector` from the new location (`pub use orbit_graph_extract::Selector;`) so its public surface doesn't break during the dual-run phase. Internal callers inside orbit-knowledge can switch to the new path directly.
- The new `orbit-knowledge → orbit-graph-extract` edge is intentional and documented in the migration plan ([GRAPH_SPEC.md §16](docs/design/orbit-graph/specs/GRAPH_SPEC.md)); no new ADR needed for it. The edge gets deleted along with orbit-knowledge in Step 4 (Phase 7).
- No grammar changes. If you find a bug, file a separate task — do not slip a fix into this refactor.
- Sibling test layout per [docs/design-patterns/test_layout.md](docs/design-patterns/test_layout.md).

Plan ID: P1.2. Depends on ORB-00298 (crate exists) and ORB-00295 (audit corpus ready).

### Acceptance Criteria

- crates/orbit-graph-extract/src/selector.rs exists with the parser moved verbatim (logic preserved)
- crates/orbit-knowledge/src/selector.rs is reduced to a back-compat re-export (`pub use orbit_graph_extract::Selector;`) OR removed if no external caller imports it from the old path
- All call sites inside crates/orbit-knowledge resolve through the new module path
- The audit fixture from ORB-00295 is exercised by a test in crates/orbit-graph-extract/ and the test passes
- cargo test -p orbit-graph-extract selector passes
- cargo test -p orbit-knowledge passes (no regression from the move)
- cargo clippy -p orbit-graph-extract -p orbit-knowledge -- -D warnings passes
- No grammar changes — every form in the ORB-00295 fixture parses with the same Debug output as before

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Added `orbit-graph-extract::selector` with the preserved selector parser, root re-exports for `Selector` and `SelectorParseError`, and a sibling-layout test that locks the ORB-00295 corpus Debug output.
- Pointed `orbit-knowledge` at `orbit-graph-extract` for internal selector use while keeping the public `orbit_knowledge::Selector` / `SelectorParseError` compatibility re-export.
- Restored the missing `docs/design/orbit-graph/specs/selector_corpus.txt` fixture in this worktree so the relocated parser has the release-blocker corpus test.
- Updated manifest, lockfile, architecture notes, and dependency-direction guard for the intentional `orbit-knowledge -> orbit-graph-extract` edge.

Assessment: The scoped move is implemented and validated. `orbit-common::utility::selector` remains untouched for existing non-knowledge callers; retiring that legacy helper surface should be handled by a later migration slice if desired.

Deviations from original plan:
- The current codebase had `orbit-knowledge` re-exporting the parser from `orbit-common` rather than owning the implementation directly. | Justification: I preserved non-knowledge callers and moved `orbit-knowledge` plus the new graph-extract surface without expanding the task into a workspace-wide selector API migration.

Validation:
- `cargo test -p orbit-graph-extract selector`
- `cargo test -p orbit-knowledge`
- `cargo clippy -p orbit-graph-extract -p orbit-knowledge -- -D warnings`
- `make ci-fast`
- `git diff --check`

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-00300-6a1372a9`
- Behind base: 0
- Ahead of base: 1