### PR TITLE
Implement orbit-graph SQLite schema + Graph::open initialization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2240,7 +2240,9 @@ dependencies = [
 name = "orbit-graph"
 version = "0.7.1"
 dependencies = [
+ "git2",
  "orbit-graph-extract",
+ "rusqlite",
 ]
 
 [[package]]

--- a/crates/orbit-graph/Cargo.toml
+++ b/crates/orbit-graph/Cargo.toml
@@ -11,4 +11,6 @@ stability = "internal"
 workspace = true
 
 [dependencies]
+git2.workspace = true
 orbit-graph-extract = { path = "../orbit-graph-extract" }
+rusqlite.workspace = true

--- a/crates/orbit-graph/src/lib.rs
+++ b/crates/orbit-graph/src/lib.rs
@@ -1,14 +1,18 @@
 //! SQLite-backed graph store and query API skeleton.
 //!
 //! This crate owns the durable graph database path contract, sync policy, and
-//! public query surface. Storage, sync, and query behavior lands in later
-//! phases; this task establishes the type contract those phases implement.
+//! public query surface. Query and sync behavior lands in later phases; this
+//! crate already owns database creation so downstream phases can write against
+//! the stable schema.
 
 use std::fmt::{Display, Formatter};
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 pub use orbit_graph_extract::Selector;
+use rusqlite::Connection;
+
+mod store;
 
 #[cfg(test)]
 mod tests;
@@ -22,14 +26,20 @@ pub const EXTRACTOR_VERSION: u32 = 1;
 
 /// Opaque handle to a worktree-scoped graph database.
 pub struct Graph {
-    _private: (),
+    _conn: Connection,
+    _db_path: GraphDbPath,
+    _policy: SyncPolicy,
 }
 
 impl Graph {
     /// Open the graph database for `worktree_root` using `policy`.
     pub fn open(worktree_root: &Path, policy: SyncPolicy) -> Result<Self, GraphError> {
-        let _ = (worktree_root, policy);
-        todo!("initialize graph storage")
+        let opened = store::open(worktree_root, policy)?;
+        Ok(Self {
+            _conn: opened.conn,
+            _db_path: opened.db_path,
+            _policy: policy,
+        })
     }
 
     /// Synchronize indexed rows with files on disk.
@@ -79,13 +89,60 @@ impl Graph {
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum GraphError {
+    /// A filesystem operation failed while opening graph storage.
+    Io {
+        /// Operation being performed.
+        operation: &'static str,
+        /// Filesystem path involved in the failed operation.
+        path: PathBuf,
+        /// Source error rendered as text for cloneable error propagation.
+        reason: String,
+    },
+    /// A SQLite operation failed while opening or initializing graph storage.
+    Sqlite {
+        /// Operation being performed.
+        operation: &'static str,
+        /// Source error rendered as text for cloneable error propagation.
+        reason: String,
+    },
     /// Placeholder variant until storage, sync, and query errors are defined.
     Unimplemented,
+}
+
+impl GraphError {
+    pub(crate) fn io(
+        operation: &'static str,
+        path: impl Into<PathBuf>,
+        source: std::io::Error,
+    ) -> Self {
+        Self::Io {
+            operation,
+            path: path.into(),
+            reason: source.to_string(),
+        }
+    }
+
+    pub(crate) fn sqlite(operation: &'static str, source: rusqlite::Error) -> Self {
+        Self::sqlite_message(operation, source.to_string())
+    }
+
+    pub(crate) fn sqlite_message(operation: &'static str, reason: impl Into<String>) -> Self {
+        Self::Sqlite {
+            operation,
+            reason: reason.into(),
+        }
+    }
 }
 
 impl Display for GraphError {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
+            Self::Io {
+                operation,
+                path,
+                reason,
+            } => write!(f, "{operation} at {}: {reason}", path.display()),
+            Self::Sqlite { operation, reason } => write!(f, "{operation}: {reason}"),
             Self::Unimplemented => f.write_str("graph operation is not implemented"),
         }
     }

--- a/crates/orbit-graph/src/store/mod.rs
+++ b/crates/orbit-graph/src/store/mod.rs
@@ -1,0 +1,103 @@
+//! SQLite connection setup for the graph store.
+
+pub(crate) mod schema;
+
+use std::fs;
+use std::path::Path;
+
+use git2::Repository;
+use rusqlite::Connection;
+
+use crate::{EXTRACTOR_VERSION, GraphDbPath, GraphError, SyncPolicy, resolve_db_path};
+
+pub(crate) struct OpenedGraph {
+    pub(crate) conn: Connection,
+    pub(crate) db_path: GraphDbPath,
+}
+
+pub(crate) fn open(worktree_root: &Path, _policy: SyncPolicy) -> Result<OpenedGraph, GraphError> {
+    let git = GitContext::for_worktree(worktree_root);
+    let db_path = resolve_db_path(worktree_root, git.branch.as_str(), EXTRACTOR_VERSION);
+
+    if let Some(parent) = db_path.path().parent() {
+        fs::create_dir_all(parent)
+            .map_err(|source| GraphError::io("create graph database directory", parent, source))?;
+    }
+
+    let mut conn = Connection::open(db_path.path())
+        .map_err(|source| GraphError::sqlite("open graph database", source))?;
+    configure_connection(&conn)?;
+
+    if schema::database_is_empty(&conn)? {
+        schema::initialize(
+            &mut conn,
+            &schema::InitialMeta {
+                extractor_version: EXTRACTOR_VERSION,
+                branch: git.branch.as_str(),
+                commit_sha: git.commit_sha.as_str(),
+            },
+        )?;
+    }
+
+    Ok(OpenedGraph { conn, db_path })
+}
+
+fn configure_connection(conn: &Connection) -> Result<(), GraphError> {
+    let journal_mode = conn
+        .pragma_update_and_check(None, "journal_mode", "WAL", |row| row.get::<_, String>(0))
+        .map_err(|source| GraphError::sqlite("set journal_mode=WAL", source))?;
+    if !journal_mode.eq_ignore_ascii_case("wal") {
+        return Err(GraphError::sqlite_message(
+            "set journal_mode=WAL",
+            format!("SQLite kept journal_mode={journal_mode}"),
+        ));
+    }
+
+    conn.pragma_update(None, "foreign_keys", "ON")
+        .map_err(|source| GraphError::sqlite("set foreign_keys=ON", source))?;
+    conn.pragma_update(None, "synchronous", "NORMAL")
+        .map_err(|source| GraphError::sqlite("set synchronous=NORMAL", source))?;
+    Ok(())
+}
+
+struct GitContext {
+    branch: String,
+    commit_sha: String,
+}
+
+impl GitContext {
+    fn for_worktree(worktree_root: &Path) -> Self {
+        let Ok(repo) = Repository::discover(worktree_root) else {
+            return Self::without_git();
+        };
+        let Ok(head) = repo.head() else {
+            return Self::without_git();
+        };
+
+        let branch = if head.is_branch() {
+            head.shorthand()
+                .filter(|name| !name.is_empty())
+                .unwrap_or("HEAD")
+                .to_string()
+        } else {
+            "HEAD".to_string()
+        };
+        let commit_sha = if head.is_branch() {
+            head.target().map(|oid| oid.to_string()).unwrap_or_default()
+        } else {
+            String::new()
+        };
+
+        Self { branch, commit_sha }
+    }
+
+    fn without_git() -> Self {
+        Self {
+            branch: "HEAD".to_string(),
+            commit_sha: String::new(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/orbit-graph/src/store/schema.rs
+++ b/crates/orbit-graph/src/store/schema.rs
@@ -1,0 +1,182 @@
+//! Graph SQLite schema from `GRAPH_SPEC.md` section 6.2.
+
+use rusqlite::{Connection, TransactionBehavior, params};
+
+use crate::GraphError;
+
+pub(crate) const SCHEMA_VERSION: u32 = 1;
+
+pub(crate) struct InitialMeta<'a> {
+    pub(crate) extractor_version: u32,
+    pub(crate) branch: &'a str,
+    pub(crate) commit_sha: &'a str,
+}
+
+pub(crate) const SCHEMA_SQL: &str = r#"
+-- Files actually indexed (post-orbitignore, post-language-filter).
+CREATE TABLE files (
+    path           TEXT PRIMARY KEY,
+    content_hash   BLOB NOT NULL,      -- blake3 of file bytes
+    mtime_ns       INTEGER NOT NULL,
+    lang           TEXT NOT NULL,      -- "rust", "typescript", "python", ...
+    byte_len       INTEGER NOT NULL,
+    extracted_at   INTEGER NOT NULL
+) STRICT;
+
+-- Symbols defined in files.
+CREATE TABLE symbols (
+    id             INTEGER PRIMARY KEY,
+    file_path      TEXT NOT NULL REFERENCES files(path) ON DELETE CASCADE,
+    name           TEXT NOT NULL,      -- "run_due_schedulers"
+    qualified      TEXT NOT NULL,      -- "orbit_core::scheduler::run_due_schedulers"
+    kind           TEXT NOT NULL,      -- "function" | "struct" | "enum" | "trait" |
+                                       -- "impl" | "method" | "module" | "const" |
+                                       -- "test" | "type_alias"
+    span_start     INTEGER NOT NULL,   -- byte offset into file at content_hash
+    span_end       INTEGER NOT NULL,   -- exclusive byte offset
+    signature      TEXT,               -- one-line normalized signature
+    parent_symbol  INTEGER REFERENCES symbols(id) ON DELETE CASCADE
+) STRICT;
+-- symbols.id is autoincrement and NOT stable across re-extracts.
+-- Use `qualified` for stable cross-build identity. See §6.3.
+
+CREATE INDEX symbols_name      ON symbols(name);
+CREATE INDEX symbols_qualified ON symbols(qualified);
+CREATE INDEX symbols_file      ON symbols(file_path);
+
+-- Textual references from a source location to a symbol name.
+-- Covers callers, type users, `use` statements, trait bounds — anything
+-- anchored to (file, span). Resolution to a concrete symbol is by
+-- `target_qualified` lookup, NOT by FK on symbols.id. `target_symbol_hint`
+-- is a build-time cache that may go stale after incremental sync; queries
+-- that need correctness re-resolve via `target_qualified`. See §6.3.
+CREATE TABLE refs (
+    id                  INTEGER PRIMARY KEY,
+    from_file           TEXT NOT NULL REFERENCES files(path) ON DELETE CASCADE,
+    from_span_start     INTEGER NOT NULL,   -- byte offset
+    from_span_end       INTEGER NOT NULL,   -- exclusive
+    target_name         TEXT NOT NULL,      -- short name; fallback for fuzzy
+    target_qualified    TEXT,               -- best-effort qualified name (authoritative)
+    target_symbol_hint  INTEGER,            -- non-authoritative; no FK
+    kind                TEXT NOT NULL,      -- "call" | "type" | "use" | "trait_bound"
+    confidence          TEXT NOT NULL       -- see §11
+) STRICT;
+
+CREATE INDEX refs_target_qualified ON refs(target_qualified) WHERE target_qualified IS NOT NULL;
+CREATE INDEX refs_target_name      ON refs(target_name);
+CREATE INDEX refs_from_file        ON refs(from_file);
+
+-- Symbol-to-symbol structural edges. No file:span source location.
+-- Covers `impl Trait for Type`, class `extends`, interface `implements`,
+-- supertype links. Both endpoints are qualified names; resolve to symbol
+-- IDs at read time. Anchored to the file containing the relation's
+-- definition site (e.g. the file with the `impl` block) for cascade.
+CREATE TABLE relations (
+    id              INTEGER PRIMARY KEY,
+    from_qualified  TEXT NOT NULL,          -- concrete type / subclass
+    to_qualified    TEXT NOT NULL,          -- trait / superclass / interface
+    kind            TEXT NOT NULL,          -- "impl" | "extends" | "implements"
+    def_file        TEXT NOT NULL REFERENCES files(path) ON DELETE CASCADE,
+    def_span_start  INTEGER NOT NULL,
+    def_span_end    INTEGER NOT NULL,
+    confidence      TEXT NOT NULL
+) STRICT;
+
+CREATE INDEX relations_from ON relations(from_qualified);
+CREATE INDEX relations_to   ON relations(to_qualified);
+CREATE INDEX relations_kind ON relations(kind);
+
+-- Imports / use statements. Module-level dependency edges.
+-- `target_path` is a language-specific opaque string. For Rust it's a
+-- `::`-joined path ("orbit_core::scheduler"); for TS it's the import
+-- specifier ("./utils/foo", "@orbit/core"); for Python it's the dotted
+-- module path. Comparison is exact-string only; cross-language matching
+-- is not in scope.
+CREATE TABLE imports (
+    from_file      TEXT NOT NULL REFERENCES files(path) ON DELETE CASCADE,
+    target_path    TEXT NOT NULL,
+    target_symbol  TEXT                -- "Scheduler" or NULL for whole-module
+) STRICT;
+
+-- Clap / CLI command surface, extracted structurally.
+CREATE TABLE commands (
+    name           TEXT PRIMARY KEY,
+    file_path      TEXT NOT NULL REFERENCES files(path) ON DELETE CASCADE,
+    span_start     INTEGER NOT NULL,
+    handler_symbol INTEGER REFERENCES symbols(id)
+) STRICT;
+
+-- Notable string literals — error messages, log lines, route paths.
+-- Filter: length >= 6, not all ASCII punctuation, not pure format string.
+CREATE TABLE strings (
+    id             INTEGER PRIMARY KEY,
+    file_path      TEXT NOT NULL REFERENCES files(path) ON DELETE CASCADE,
+    line           INTEGER NOT NULL,
+    value          TEXT NOT NULL,
+    context_symbol INTEGER REFERENCES symbols(id)
+) STRICT;
+
+-- Config keys: YAML / TOML / JSON / env var references.
+CREATE TABLE configs (
+    id             INTEGER PRIMARY KEY,
+    file_path      TEXT NOT NULL REFERENCES files(path) ON DELETE CASCADE,
+    line           INTEGER NOT NULL,
+    key            TEXT NOT NULL,
+    kind           TEXT NOT NULL       -- "yaml" | "toml" | "json" | "env" | "serde"
+) STRICT;
+
+-- Full-text search across the three high-value surfaces.
+CREATE VIRTUAL TABLE symbols_fts USING fts5(name, qualified, signature, content='symbols');
+CREATE VIRTUAL TABLE strings_fts USING fts5(value, content='strings');
+CREATE VIRTUAL TABLE configs_fts USING fts5(key, content='configs');
+
+-- Metadata.
+CREATE TABLE meta (
+    key   TEXT PRIMARY KEY,
+    value TEXT NOT NULL
+) STRICT;
+"#;
+
+pub(crate) fn database_is_empty(conn: &Connection) -> Result<bool, GraphError> {
+    let object_count: i64 = conn
+        .query_row(
+            "SELECT count(*) FROM sqlite_master WHERE name NOT LIKE 'sqlite_%'",
+            [],
+            |row| row.get(0),
+        )
+        .map_err(|source| GraphError::sqlite("check graph schema objects", source))?;
+    Ok(object_count == 0)
+}
+
+pub(crate) fn initialize(conn: &mut Connection, meta: &InitialMeta<'_>) -> Result<(), GraphError> {
+    let tx = conn
+        .transaction_with_behavior(TransactionBehavior::Immediate)
+        .map_err(|source| GraphError::sqlite("begin graph schema transaction", source))?;
+    tx.execute_batch(SCHEMA_SQL)
+        .map_err(|source| GraphError::sqlite("initialize graph schema", source))?;
+    insert_meta_rows(&tx, meta)?;
+    tx.commit()
+        .map_err(|source| GraphError::sqlite("commit graph schema transaction", source))?;
+    Ok(())
+}
+
+fn insert_meta_rows(conn: &Connection, meta: &InitialMeta<'_>) -> Result<(), GraphError> {
+    let rows = [
+        ("extractor_version", meta.extractor_version.to_string()),
+        ("schema_version", SCHEMA_VERSION.to_string()),
+        ("branch", meta.branch.to_string()),
+        ("commit_sha", meta.commit_sha.to_string()),
+        ("last_full_build_at", "0".to_string()),
+        ("last_incremental_at", "0".to_string()),
+    ];
+
+    for (key, value) in rows {
+        conn.execute(
+            "INSERT INTO meta (key, value) VALUES (?1, ?2)",
+            params![key, value],
+        )
+        .map_err(|source| GraphError::sqlite("insert graph metadata", source))?;
+    }
+
+    Ok(())
+}

--- a/crates/orbit-graph/src/store/tests/mod.rs
+++ b/crates/orbit-graph/src/store/tests/mod.rs
@@ -1,0 +1,1 @@
+mod schema;

--- a/crates/orbit-graph/src/store/tests/schema.rs
+++ b/crates/orbit-graph/src/store/tests/schema.rs
@@ -1,0 +1,368 @@
+use std::collections::{BTreeMap, BTreeSet};
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use git2::{Repository, RepositoryInitOptions, Signature};
+use rusqlite::Connection;
+
+use crate::store::schema::SCHEMA_VERSION;
+use crate::{EXTRACTOR_VERSION, Graph, SyncPolicy, resolve_db_path};
+
+#[test]
+fn graph_open_creates_documented_schema_and_initial_meta() {
+    let worktree = TestWorktree::new("creates-schema", "feat/schema-open");
+    let commit_sha = worktree.init_git_repo();
+
+    let graph = Graph::open(worktree.path(), SyncPolicy::Manual).expect("open graph");
+    drop(graph);
+
+    let db_path = resolve_db_path(worktree.path(), "feat/schema-open", EXTRACTOR_VERSION)
+        .path()
+        .to_path_buf();
+    let conn = open_test_connection(&db_path);
+
+    assert_eq!(
+        object_names(&conn, "table"),
+        BTreeSet::from([
+            "commands".to_string(),
+            "configs".to_string(),
+            "configs_fts".to_string(),
+            "configs_fts_config".to_string(),
+            "configs_fts_data".to_string(),
+            "configs_fts_docsize".to_string(),
+            "configs_fts_idx".to_string(),
+            "files".to_string(),
+            "imports".to_string(),
+            "meta".to_string(),
+            "refs".to_string(),
+            "relations".to_string(),
+            "strings".to_string(),
+            "strings_fts".to_string(),
+            "strings_fts_config".to_string(),
+            "strings_fts_data".to_string(),
+            "strings_fts_docsize".to_string(),
+            "strings_fts_idx".to_string(),
+            "symbols".to_string(),
+            "symbols_fts".to_string(),
+            "symbols_fts_config".to_string(),
+            "symbols_fts_data".to_string(),
+            "symbols_fts_docsize".to_string(),
+            "symbols_fts_idx".to_string(),
+        ])
+    );
+    assert_eq!(
+        object_names(&conn, "index"),
+        BTreeSet::from([
+            "refs_from_file".to_string(),
+            "refs_target_name".to_string(),
+            "refs_target_qualified".to_string(),
+            "relations_from".to_string(),
+            "relations_kind".to_string(),
+            "relations_to".to_string(),
+            "symbols_file".to_string(),
+            "symbols_name".to_string(),
+            "symbols_qualified".to_string(),
+        ])
+    );
+
+    for table in [
+        "files",
+        "symbols",
+        "refs",
+        "relations",
+        "imports",
+        "commands",
+        "strings",
+        "configs",
+        "meta",
+    ] {
+        assert!(
+            table_sql(&conn, table).contains("STRICT"),
+            "{table} table should be STRICT"
+        );
+    }
+    assert_eq!(
+        table_sql(&conn, "symbols_fts"),
+        "CREATE VIRTUAL TABLE symbols_fts USING fts5(name, qualified, signature, content='symbols')"
+    );
+    assert_eq!(
+        table_sql(&conn, "strings_fts"),
+        "CREATE VIRTUAL TABLE strings_fts USING fts5(value, content='strings')"
+    );
+    assert_eq!(
+        table_sql(&conn, "configs_fts"),
+        "CREATE VIRTUAL TABLE configs_fts USING fts5(key, content='configs')"
+    );
+
+    let meta = read_meta(&conn);
+    assert_eq!(
+        meta.get("extractor_version").map(String::as_str),
+        Some(EXTRACTOR_VERSION.to_string().as_str())
+    );
+    assert_eq!(
+        meta.get("schema_version").map(String::as_str),
+        Some(SCHEMA_VERSION.to_string().as_str())
+    );
+    assert_eq!(
+        meta.get("branch").map(String::as_str),
+        Some("feat/schema-open")
+    );
+    assert_eq!(
+        meta.get("commit_sha").map(String::as_str),
+        Some(commit_sha.as_str())
+    );
+    assert_eq!(
+        meta.get("last_full_build_at").map(String::as_str),
+        Some("0")
+    );
+    assert_eq!(
+        meta.get("last_incremental_at").map(String::as_str),
+        Some("0")
+    );
+}
+
+#[test]
+fn reopening_existing_db_preserves_meta_rows() {
+    let worktree = TestWorktree::new("preserves-meta", "main");
+    worktree.init_git_repo();
+
+    let graph = Graph::open(worktree.path(), SyncPolicy::Manual).expect("first open");
+    drop(graph);
+
+    let db_path = resolve_db_path(worktree.path(), "main", EXTRACTOR_VERSION)
+        .path()
+        .to_path_buf();
+    {
+        let conn = open_test_connection(&db_path);
+        conn.execute(
+            "UPDATE meta SET value = 'kept' WHERE key = 'last_full_build_at'",
+            [],
+        )
+        .expect("mutate meta before reopen");
+        conn.execute("UPDATE meta SET value = 'manual' WHERE key = 'branch'", [])
+            .expect("mutate branch before reopen");
+    }
+
+    let graph = Graph::open(worktree.path(), SyncPolicy::Manual).expect("second open");
+    drop(graph);
+
+    let conn = open_test_connection(&db_path);
+    let meta = read_meta(&conn);
+    assert_eq!(
+        meta.get("last_full_build_at").map(String::as_str),
+        Some("kept")
+    );
+    assert_eq!(meta.get("branch").map(String::as_str), Some("manual"));
+}
+
+#[test]
+fn refs_target_symbol_hint_has_no_symbol_foreign_key() {
+    let worktree = TestWorktree::new("refs-no-fk", "main");
+    worktree.init_git_repo();
+
+    let graph = Graph::open(worktree.path(), SyncPolicy::Manual).expect("open graph");
+    drop(graph);
+
+    let db_path = resolve_db_path(worktree.path(), "main", EXTRACTOR_VERSION)
+        .path()
+        .to_path_buf();
+    let conn = open_test_connection(&db_path);
+    let refs_sql = normalized_sql(&table_sql(&conn, "refs"));
+
+    assert!(refs_sql.contains("target_symbol_hint INTEGER"));
+    assert!(
+        !refs_sql.contains("target_symbol_hint INTEGER REFERENCES"),
+        "refs.target_symbol_hint must stay non-authoritative and must not reference symbols(id): {refs_sql}"
+    );
+}
+
+#[test]
+fn deleting_file_cascades_every_file_anchored_row() {
+    let worktree = TestWorktree::new("cascade-delete", "main");
+    worktree.init_git_repo();
+
+    let graph = Graph::open(worktree.path(), SyncPolicy::Manual).expect("open graph");
+    drop(graph);
+
+    let db_path = resolve_db_path(worktree.path(), "main", EXTRACTOR_VERSION)
+        .path()
+        .to_path_buf();
+    let conn = open_test_connection(&db_path);
+    insert_file_anchored_rows(&conn);
+
+    conn.execute("DELETE FROM files WHERE path = 'src/lib.rs'", [])
+        .expect("delete file row");
+
+    for table in [
+        "symbols",
+        "refs",
+        "relations",
+        "imports",
+        "commands",
+        "strings",
+        "configs",
+    ] {
+        assert_eq!(
+            row_count(&conn, table),
+            0,
+            "{table} should cascade on file delete"
+        );
+    }
+}
+
+fn insert_file_anchored_rows(conn: &Connection) {
+    conn.execute(
+        "INSERT INTO files (path, content_hash, mtime_ns, lang, byte_len, extracted_at)
+         VALUES ('src/lib.rs', x'00', 1, 'rust', 12, 2)",
+        [],
+    )
+    .expect("insert file");
+    conn.execute(
+        "INSERT INTO symbols (
+            id, file_path, name, qualified, kind, span_start, span_end, signature, parent_symbol
+         ) VALUES (1, 'src/lib.rs', 'run', 'crate::run', 'function', 0, 3, 'fn run()', NULL)",
+        [],
+    )
+    .expect("insert symbol");
+    conn.execute(
+        "INSERT INTO refs (
+            from_file, from_span_start, from_span_end, target_name, target_qualified,
+            target_symbol_hint, kind, confidence
+         ) VALUES ('src/lib.rs', 4, 7, 'run', 'crate::run', 1, 'call', 'exact')",
+        [],
+    )
+    .expect("insert ref");
+    conn.execute(
+        "INSERT INTO relations (
+            from_qualified, to_qualified, kind, def_file, def_span_start, def_span_end, confidence
+         ) VALUES ('crate::Type', 'crate::Trait', 'impl', 'src/lib.rs', 0, 10, 'exact')",
+        [],
+    )
+    .expect("insert relation");
+    conn.execute(
+        "INSERT INTO imports (from_file, target_path, target_symbol)
+         VALUES ('src/lib.rs', 'crate::other', 'Other')",
+        [],
+    )
+    .expect("insert import");
+    conn.execute(
+        "INSERT INTO commands (name, file_path, span_start, handler_symbol)
+         VALUES ('run', 'src/lib.rs', 0, 1)",
+        [],
+    )
+    .expect("insert command");
+    conn.execute(
+        "INSERT INTO strings (file_path, line, value, context_symbol)
+         VALUES ('src/lib.rs', 1, 'hello world', 1)",
+        [],
+    )
+    .expect("insert string");
+    conn.execute(
+        "INSERT INTO configs (file_path, line, key, kind)
+         VALUES ('src/lib.rs', 1, 'app.name', 'toml')",
+        [],
+    )
+    .expect("insert config");
+}
+
+fn open_test_connection(path: &Path) -> Connection {
+    let conn = Connection::open(path).expect("open test sqlite connection");
+    conn.pragma_update(None, "foreign_keys", "ON")
+        .expect("enable foreign keys");
+    conn
+}
+
+fn object_names(conn: &Connection, object_type: &str) -> BTreeSet<String> {
+    let mut stmt = conn
+        .prepare(
+            "SELECT name FROM sqlite_master
+             WHERE type = ?1 AND name NOT LIKE 'sqlite_%'
+             ORDER BY name",
+        )
+        .expect("prepare object name query");
+    stmt.query_map([object_type], |row| row.get::<_, String>(0))
+        .expect("query object names")
+        .collect::<Result<BTreeSet<_>, _>>()
+        .expect("collect object names")
+}
+
+fn table_sql(conn: &Connection, name: &str) -> String {
+    conn.query_row(
+        "SELECT sql FROM sqlite_master WHERE name = ?1",
+        [name],
+        |row| row.get(0),
+    )
+    .expect("read sqlite_master sql")
+}
+
+fn normalized_sql(sql: &str) -> String {
+    sql.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+fn read_meta(conn: &Connection) -> BTreeMap<String, String> {
+    let mut stmt = conn
+        .prepare("SELECT key, value FROM meta ORDER BY key")
+        .expect("prepare meta query");
+    stmt.query_map([], |row| Ok((row.get(0)?, row.get(1)?)))
+        .expect("query meta")
+        .collect::<Result<BTreeMap<_, _>, _>>()
+        .expect("collect meta")
+}
+
+fn row_count(conn: &Connection, table: &str) -> i64 {
+    let sql = format!("SELECT COUNT(*) FROM {table}");
+    conn.query_row(&sql, [], |row| row.get(0))
+        .expect("count table rows")
+}
+
+struct TestWorktree {
+    path: PathBuf,
+    branch: String,
+}
+
+impl TestWorktree {
+    fn new(name: &str, branch: &str) -> Self {
+        let mut path = std::env::temp_dir();
+        let stamp = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system time after epoch")
+            .as_nanos();
+        path.push(format!("orbit-graph-{name}-{}-{stamp}", std::process::id()));
+        fs::create_dir_all(&path).expect("create test worktree");
+        Self {
+            path,
+            branch: branch.to_string(),
+        }
+    }
+
+    fn path(&self) -> &Path {
+        self.path.as_path()
+    }
+
+    fn init_git_repo(&self) -> String {
+        let mut opts = RepositoryInitOptions::new();
+        opts.initial_head(self.branch.as_str());
+        let repo = Repository::init_opts(&self.path, &opts).expect("init git repo");
+        fs::write(self.path.join("README.md"), "test\n").expect("write initial file");
+
+        let mut index = repo.index().expect("open repo index");
+        index
+            .add_path(Path::new("README.md"))
+            .expect("add initial file");
+        index.write().expect("write index");
+        let tree_id = index.write_tree().expect("write tree");
+        let tree = repo.find_tree(tree_id).expect("find tree");
+        let sig = Signature::now("Orbit Test", "orbit@example.test").expect("test signature");
+        let oid = repo
+            .commit(Some("HEAD"), &sig, &sig, "initial", &tree, &[])
+            .expect("initial commit");
+        oid.to_string()
+    }
+}
+
+impl Drop for TestWorktree {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.path);
+    }
+}


### PR DESCRIPTION
## Task

[ORB-00308](https://orbit-cli.com/tasks/ORB-00308) — Implement orbit-graph SQLite schema + Graph::open initialization

### Description

## Problem

[GRAPH_SPEC.md §6.2](docs/design/orbit-graph/specs/GRAPH_SPEC.md) specifies the full SQLite schema for orbit-graph: 8 tables (`files`, `symbols`, `refs`, `relations`, `imports`, `commands`, `strings`, `configs`, `meta`), 3 FTS5 virtual tables (`symbols_fts`, `strings_fts`, `configs_fts`), and the documented index set. After [ORB-00307](.orbit/tasks/ORB-00307) (P2.1) lands the crate skeleton with `Graph::open` as `todo!()`, this task fills in schema initialization: open the SQLite file at the resolver-computed path, set required pragmas, apply schema in a single transaction if the DB is new, populate the `meta` table.

## Why It Matters

This is the boundary between "orbit-graph exists as types" and "orbit-graph is a real database." Every Phase 3 (sync) and Phase 4 (query) task writes against this schema; getting it right — table shapes, indexes, FTS5 content-table linkage, and the foreign-key cascade graph — saves rework across the entire downstream fan-out.

The cascade-delete semantics specifically (drop a file row → drop its symbols / refs / relations / strings / configs / commands) is what makes incremental sync correct by construction per [2_design.md §2.1](docs/design/orbit-graph/2_design.md): re-extracting a file deletes and re-inserts its rows without dangling references, because cross-file refs resolve by qualified name rather than FK.

## Constraints / Notes

- Schema **must** match [GRAPH_SPEC.md §6.2](docs/design/orbit-graph/specs/GRAPH_SPEC.md) verbatim: table names, column names, column types (`STRICT` mode where specified), index names, FTS5 `content='symbols'` / `content='strings'` / `content='configs'` linkage. Downstream queries (Phase 4) hardcode these identifiers.
- **No FK on `symbols.id` from `refs` or `relations`.** Resolution is by `target_qualified` (string), per the deliberate design choice in [2_design.md §2.1](docs/design/orbit-graph/2_design.md). Do not add such an FK even if it seems natural — it would break incremental sync.
- Pragmas: `journal_mode=WAL`, `foreign_keys=ON`, `synchronous=NORMAL`. Set on every open, not just first-time creation.
- Schema apply transaction runs **only** when the file is new (detect via `SELECT count(*) FROM sqlite_master` or by checking file existence before open). Existing DBs are opened as-is — extractor-version bumps land via P3 (deleting old DB files), not via P2 migration logic.
- `meta.commit_sha` is best-effort: read from git via the workspace `git2` dep if available, store empty string otherwise (per [GRAPH_SPEC.md §6.2](docs/design/orbit-graph/specs/GRAPH_SPEC.md) meta key docs).
- `last_full_build_at` and `last_incremental_at` initialize to 0 (or empty string — implementation choice but consistent); P3.* writes real values later.
- Use the workspace `rusqlite` dep (already declared in workspace [Cargo.toml](Cargo.toml)). Add it to crates/orbit-graph/Cargo.toml if P2.1 didn't.
- WAL files (`.db-wal`, `.db-shm`) are byproducts and must not be checked in — verify [.gitignore](.gitignore) covers `.orbit/` or add an explicit `.orbit/graph/*-wal` entry.
- No sync, no extraction, no queries. Only schema + `Graph::open`.
- Error translation per [docs/design-patterns/error_translation.md](docs/design-patterns/error_translation.md) — rusqlite errors become typed `GraphError` variants at the crate boundary.
- Sibling tests per [docs/design-patterns/test_layout.md](docs/design-patterns/test_layout.md).

Plan ID: P2.2. Depends on [ORB-00307](.orbit/tasks/ORB-00307) (skeleton + path resolver). Closes Phase 2. Gates Phase 3 (file scanner needs to read/write the `files` table).

### Acceptance Criteria

- src/store/schema.rs (or equivalent module path) defines the schema SQL matching GRAPH_SPEC.md §6.2 verbatim — 8 tables (files, symbols, refs, relations, imports, commands, strings, configs, meta), 3 FTS5 virtual tables (symbols_fts, strings_fts, configs_fts), and the documented index set
- Graph::open implementation: resolves DB path via the P2.1 resolver, opens with rusqlite, sets pragmas (journal_mode=WAL, foreign_keys=ON, synchronous=NORMAL) on every open, applies schema in a single transaction only if the DB is new, populates meta on first creation
- All meta keys from GRAPH_SPEC.md §6.2 are written on first open: extractor_version, schema_version, branch (unsanitized), commit_sha (best-effort via git2; empty string when unavailable), last_full_build_at (0), last_incremental_at (0 or empty)
- Re-opening an existing DB does not reapply schema and does not overwrite meta (verifiable by inspecting meta row contents before and after a second Graph::open)
- No foreign-key constraint exists from refs.target_symbol_hint to symbols.id — verify with a query against sqlite_master that the refs CREATE TABLE statement contains no REFERENCES symbols clause on target_symbol_hint
- Cascade-delete test: insert a row into files, insert a symbol referencing that file_path, delete the file row, assert the symbol row is gone; repeat for refs, relations, strings, configs, commands, imports — every cascade edge in §6.2 is exercised
- .gitignore excludes .orbit/graph/ artifacts (.db-wal, .db-shm); verify the existing .orbit entry covers it, or add an explicit entry if not
- cargo test -p orbit-graph store passes
- cargo clippy -p orbit-graph -- -D warnings passes

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Added orbit-graph SQLite dependencies (`rusqlite`, `git2`) through workspace dependency references and updated Cargo.lock.
- Added `store::schema` with the GRAPH_SPEC.md §6.2 DDL, first-open transactional initialization, schema version/meta population, and empty-DB detection.
- Wired `Graph::open` through the P2.1 DB path resolver, git branch/commit metadata capture, SQLite open, and required pragmas (`journal_mode=WAL`, `foreign_keys=ON`, `synchronous=NORMAL`) while leaving sync/query stubs unchanged.
- Added sibling-layout store tests covering schema objects/indexes/FTS tables, all initial meta keys, non-overwrite on reopen, no FK from `refs.target_symbol_hint` to `symbols`, and file-delete cascades for symbols, refs, relations, imports, commands, strings, and configs.
- Verified `.gitignore` already ignores `.orbit/graph/*.db-wal` and `.db-shm` via the existing `.orbit/*` rule.

Validation:
- cargo test -p orbit-graph store
- cargo test -p orbit-graph
- cargo clippy -p orbit-graph -- -D warnings
- git check-ignore -v .orbit/graph/main.1.db-wal .orbit/graph/main.1.db-shm
- make ci-fast

Assessment: P2.2 schema initialization is implemented and validated; no sync/extraction/query behavior was added beyond the requested `Graph::open` boundary.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-00308-6a13a02d`
- Behind base: 0
- Ahead of base: 1