### PR TITLE
Implement orbit-graph callees query (outbound calls from a symbol)

### DIFF
--- a/crates/orbit-graph/src/lib.rs
+++ b/crates/orbit-graph/src/lib.rs
@@ -10,7 +10,7 @@ use std::path::{Path, PathBuf};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 pub use orbit_graph_extract::Selector;
-use rusqlite::Connection;
+use rusqlite::{params, Connection};
 
 mod store;
 mod sync;
@@ -98,8 +98,45 @@ impl Graph {
 
     /// Return outbound call edges from `sel`.
     pub fn callees(&self, sel: &Selector) -> Result<Vec<CalleeEdge>, GraphError> {
-        let _ = (self, sel);
-        todo!("query graph callees")
+        self.ensure_synced()?;
+
+        let symbol = match resolve_symbol_span(self.db_path.path(), sel)? {
+            Some(s) => s,
+            None => return Ok(vec![]),
+        };
+
+        let conn = Connection::open(self.db_path.path())
+            .map_err(|source| GraphError::sqlite("open graph database for callees", source))?;
+
+        let mut stmt = conn
+            .prepare_cached(
+                "SELECT target_name, target_qualified, confidence, from_span_start
+                 FROM refs
+                 WHERE from_file = ?1
+                   AND from_span_start >= ?2
+                   AND from_span_end <= ?3
+                   AND kind = 'call'
+                 ORDER BY from_span_start",
+            )
+            .map_err(|source| GraphError::sqlite("prepare callees query", source))?;
+
+        let edges = stmt
+            .query_map(
+                params![symbol.file_path, symbol.span_start, symbol.span_end],
+                |row| {
+                    Ok(CalleeEdge {
+                        target_name: row.get(0)?,
+                        target_qualified: row.get(1)?,
+                        confidence: row.get(2)?,
+                        from_span: row.get(3)?,
+                    })
+                },
+            )
+            .map_err(|source| GraphError::sqlite("execute callees query", source))?
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|source| GraphError::sqlite("collect callees edges", source))?;
+
+        Ok(edges)
     }
 
     /// Return the bounded impact set around `sel`.
@@ -150,6 +187,68 @@ fn now_epoch_nanos(operation: &'static str) -> Result<i64, GraphError> {
         })?;
     i64::try_from(duration.as_nanos())
         .map_err(|error| GraphError::invalid_data(operation, error.to_string()))
+}
+
+/// Internal result of resolving a Selector to a symbol's file and span for
+/// span-containment queries like callees.
+#[derive(Debug, Clone)]
+struct SymbolSpan {
+    file_path: String,
+    span_start: i64,
+    span_end: i64,
+}
+
+/// Resolve a Selector to a single symbol's (file_path, span) if it exists in
+/// the graph. Returns None for selectors that do not map to a stored symbol
+/// (including non-Symbol variants and unknown names). Used by read queries
+/// that then perform containment or adjacency lookups.
+fn resolve_symbol_span(db_path: &Path, sel: &Selector) -> Result<Option<SymbolSpan>, GraphError> {
+    let Selector::Symbol { path, symbol, kind } = sel else {
+        return Ok(None);
+    };
+
+    let conn = Connection::open(db_path)
+        .map_err(|source| GraphError::sqlite("open graph database for symbol resolve", source))?;
+
+    // Match on either short name or qualified; apply kind filter when provided.
+    // Paths in DB are normalized (slash-separated, relative to worktree).
+    let mut sql = String::from(
+        "SELECT file_path, span_start, span_end FROM symbols
+         WHERE file_path = ?1 AND (name = ?2 OR qualified = ?2)",
+    );
+    let has_kind = !kind.trim().is_empty();
+    if has_kind {
+        sql.push_str(" AND kind = ?3");
+    }
+    sql.push_str(" ORDER BY id LIMIT 1");
+
+    let mut stmt = conn
+        .prepare(&sql)
+        .map_err(|source| GraphError::sqlite("prepare symbol resolve for query", source))?;
+
+    let row = if has_kind {
+        stmt.query_row(params![path, symbol, kind.trim()], |r| {
+            Ok(SymbolSpan {
+                file_path: r.get(0)?,
+                span_start: r.get(1)?,
+                span_end: r.get(2)?,
+            })
+        })
+    } else {
+        stmt.query_row(params![path, symbol], |r| {
+            Ok(SymbolSpan {
+                file_path: r.get(0)?,
+                span_start: r.get(1)?,
+                span_end: r.get(2)?,
+            })
+        })
+    };
+
+    match row {
+        Ok(s) => Ok(Some(s)),
+        Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
+        Err(source) => Err(GraphError::sqlite("resolve symbol for query", source)),
+    }
 }
 
 /// Graph crate error surface.
@@ -330,7 +429,16 @@ pub struct RefResult;
 
 /// Outbound call edge returned by [`Graph::callees`].
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct CalleeEdge;
+pub struct CalleeEdge {
+    /// Short target name as written in the call site.
+    pub target_name: String,
+    /// Resolved qualified name (authoritative when present); None for fuzzy/unresolved.
+    pub target_qualified: Option<String>,
+    /// Confidence label emitted verbatim by the resolver (P3.3) at write time.
+    pub confidence: String,
+    /// Start byte offset of the call site span inside its source file (minimum for attribution).
+    pub from_span: i64,
+}
 
 /// Bounded impact result returned by [`Graph::impact`].
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/crates/orbit-graph/src/tests/lib.rs
+++ b/crates/orbit-graph/src/tests/lib.rs
@@ -6,7 +6,7 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use rusqlite::{Connection, params};
 
 use crate::sync::{fail_next_sync_after_scan, sync_leader_count};
-use crate::{EXTRACTOR_VERSION, Graph, GraphError, SyncPolicy, resolve_db_path};
+use crate::{CalleeEdge, EXTRACTOR_VERSION, Graph, GraphError, Selector, SyncPolicy, resolve_db_path};
 
 #[test]
 fn db_path_sanitizes_branch_slashes_and_preserves_raw_branch() {
@@ -229,4 +229,110 @@ impl Drop for TestWorktree {
     fn drop(&mut self) {
         let _ = fs::remove_dir_all(&self.path);
     }
+}
+
+fn populate_callees_fixture(conn: &Connection, file_path: &str) {
+            conn.execute(
+                "INSERT INTO files (path, content_hash, mtime_ns, lang, byte_len, extracted_at)
+                 VALUES (?1, x'00', 1, 'rust', 200, 2)",
+                [file_path],
+            )
+            .expect("insert file");
+
+            // Outer function span: 0..100
+            conn.execute(
+                "INSERT INTO symbols (id, file_path, name, qualified, kind, span_start, span_end, signature, parent_symbol)
+                 VALUES (1, ?1, 'outer', 'crate::outer', 'function', 0, 100, 'fn outer()', NULL)",
+                [file_path],
+            )
+            .expect("insert outer symbol");
+
+            // Nested inner function span: 20..50 (contained in outer)
+            conn.execute(
+                "INSERT INTO symbols (id, file_path, name, qualified, kind, span_start, span_end, signature, parent_symbol)
+                 VALUES (2, ?1, 'inner', 'crate::outer::inner', 'function', 20, 50, 'fn inner()', 1)",
+                [file_path],
+            )
+            .expect("insert inner symbol");
+
+            // 4 direct calls inside outer but outside inner (spans 10-15, 55-60, 70-75, 80-85)
+            let calls = [
+                (10, 15, "foo", Some("crate::foo"), "exact"),
+                (55, 60, "bar", None, "fuzzy_name"),
+                (70, 75, "baz", Some("crate::baz"), "same_module"),
+                (80, 85, "quux", Some("other::quux"), "import_resolved"),
+            ];
+            for (i, (start, end, name, qual, conf)) in calls.iter().enumerate() {
+                conn.execute(
+                    "INSERT INTO refs (id, from_file, from_span_start, from_span_end, target_name, target_qualified, target_symbol_hint, kind, confidence)
+                     VALUES (?1, ?2, ?3, ?4, ?5, ?6, NULL, 'call', ?7)",
+                    params![i as i64 + 10, file_path, *start, *end, name, qual, conf],
+                )
+                .expect("insert direct call ref");
+            }
+
+            // 1 nested call inside inner (span 30-35, contained in both)
+            conn.execute(
+                "INSERT INTO refs (id, from_file, from_span_start, from_span_end, target_name, target_qualified, target_symbol_hint, kind, confidence)
+                 VALUES (99, ?1, 30, 35, 'nested_call', 'crate::nested_call', NULL, 'call', 'exact')",
+                [file_path],
+            )
+            .expect("insert nested call ref");
+}
+
+#[test]
+fn query_callees_function_with_five_call_sites_returns_five_edges_including_nested_via_span_containment() {
+    let worktree = TestWorktree::new("callees-five");
+    let file_path = "src/example.rs";
+    worktree.write(file_path, "fn outer() { /* calls */ fn inner(){} }\n");
+
+    let graph = Graph::open(worktree.path(), SyncPolicy::Manual).expect("open graph");
+    let conn = open_test_connection(worktree.path());
+    populate_callees_fixture(&conn, file_path);
+
+    let sel = Selector::Symbol {
+        path: file_path.to_string(),
+        symbol: "outer".to_string(),
+        kind: "function".to_string(),
+    };
+    let edges: Vec<CalleeEdge> = graph.callees(&sel).expect("callees query");
+
+    assert_eq!(edges.len(), 5, "expected 5 callees (4 direct + 1 nested via containment)");
+
+    let names: Vec<_> = edges.iter().map(|e| e.target_name.as_str()).collect();
+    assert!(names.contains(&"foo"));
+    assert!(names.contains(&"nested_call")); // attributed to outer via span containment
+    let nested = edges.iter().find(|e| e.target_name == "nested_call").unwrap();
+    assert_eq!(nested.confidence, "exact");
+    assert_eq!(nested.from_span, 30);
+}
+
+#[test]
+fn query_callees_unknown_symbol_selector_returns_empty_vec_not_error() {
+    let worktree = TestWorktree::new("callees-miss");
+    worktree.write("src/lib.rs", "pub fn present() {}\n");
+    let graph = Graph::open(worktree.path(), SyncPolicy::Manual).expect("open graph");
+
+    let sel = Selector::Symbol {
+        path: "src/lib.rs".to_string(),
+        symbol: "absent".to_string(),
+        kind: "function".to_string(),
+    };
+    let edges: Vec<CalleeEdge> = graph.callees(&sel).expect("callees on missing symbol");
+    assert!(edges.is_empty());
+}
+
+#[test]
+fn query_callees_non_symbol_selector_returns_empty_vec() {
+    let worktree = TestWorktree::new("callees-non-sym");
+    worktree.write("src/lib.rs", "// empty\n");
+    let graph = Graph::open(worktree.path(), SyncPolicy::Manual).expect("open graph");
+
+    let file_sel = Selector::File { path: "src/lib.rs".to_string() };
+    let edges: Vec<CalleeEdge> = graph.callees(&file_sel).expect("callees on file sel");
+    assert!(edges.is_empty());
+
+    let dir_sel = Selector::Dir { path: "src".to_string() };
+    let edges2: Vec<CalleeEdge> = graph.callees(&dir_sel).expect("callees on dir sel");
+    assert!(edges2.is_empty());
 }


### PR DESCRIPTION
## Task

[ORB-00314](https://orbit-cli.com/tasks/ORB-00314) — Implement orbit-graph callees query (outbound calls from a symbol)

### Description

## Problem

[GRAPH_SPEC.md §9.4](docs/design/orbit-graph/specs/GRAPH_SPEC.md) defines callees: outbound calls from a symbol. The query walks the refs table filtered by from_file matching the symbol file, the from-span bounded by the symbol's span, and kind = call. Simpler than refs because it's a single-table query with a span-containment filter — no union, no two-tier routing.

## Why It Matters

callees is what powers impact (P4.4) outbound traversal and trace (P4.5). It's also useful standalone: 'what does this function call?' is a frequent agent question when reviewing a symbol's responsibilities. Landing it as a standalone task keeps the implementation focused and lets P4.4 and P4.5 consume it cleanly via Graph::callees from inside their own BFS loops.

## Constraints / Notes

- Signature per [GRAPH_SPEC.md §13](docs/design/orbit-graph/specs/GRAPH_SPEC.md): the method takes a Selector reference and returns a Vec of CalleeEdge or GraphError.
- Query: resolve selector, then look up refs filtered by from_file = symbol.file_path, from_span_start at-or-after symbol.span_start, from_span_end at-or-before symbol.span_end, kind = call. Use the indexed refs_from_file index.
- Output: Vec of CalleeEdge where each edge carries target_name, target_qualified (Option), confidence, and from_span (at least the span start, so callers can attribute to a line).
- Confidence is emitted verbatim from the refs row; this is a read query, not a re-resolution. The resolver (P3.3) is the only place that assigns confidence.
- Empty selector resolution returns an empty Vec, not Err.
- Calls self.ensure_synced at entry per [ORB-00312](.orbit/tasks/ORB-00312).
- Performance budget rolls into the §12 refs envelope (under 10ms p95).
- Errors translate at the crate boundary per [docs/design-patterns/error_translation.md](docs/design-patterns/error_translation.md). Sibling tests per [docs/design-patterns/test_layout.md](docs/design-patterns/test_layout.md).

Plan ID: P4.3. Depends on [ORB-00312](.orbit/tasks/ORB-00312). Runs in parallel with P4.1 and P4.2. Gates P4.4 (impact) and P4.5 (trace) — both BFS over Graph::callees.

### Acceptance Criteria

- Graph::callees method implemented; returns a Vec of CalleeEdge
- Query is span-containment with kind = call over the refs table: refs filtered by from_file = symbol.file_path, from_span_start at-or-after symbol.span_start, from_span_end at-or-before symbol.span_end, kind = call (uses refs_from_file index)
- CalleeEdge carries target_name, target_qualified (Option), confidence, from_span (span start at minimum)
- Confidence is emitted verbatim from the refs row (no re-resolution at read time)
- Selector resolving to no symbol returns an empty Vec, NOT Err
- Calls self.ensure_synced at entry per the P3.4 contract
- Tests: a function with 5 distinct call sites returns 5 edges; nested call inside the function attributes correctly to the outer symbol via span containment
- cargo test -p orbit-graph query::callees passes
- cargo clippy -p orbit-graph -- -D warnings passes

## Execution Summary

<details>
<summary>Click to expand</summary>

Implemented Graph::callees per GRAPH_SPEC §9.4 and ACs.

- Added ensure_synced() call, SymbolSpan resolver (handles Selector::Symbol with name/qualified + optional kind filter; non-symbol selectors and unknown return None -> empty Vec for callees).
- Implemented span-containment query on refs (from_file + from_span_start >= + from_span_end <= + kind='call') using refs_from_file index; emits target_name/qualified/confidence/from_span verbatim.
- Defined CalleeEdge with required fields.
- Added 3 unit tests under query_callees_* (5 edges incl. nested via containment; miss and non-symbol selectors return []).
- All via direct DB population + Manual policy (no disk sync).

Validation: cargo test -p orbit-graph (query_callees filter) passes; cargo clippy -p orbit-graph -- -D warnings passes.

Touched (context_files empty): lib.rs (core impl + helper), tests/lib.rs (tests). Recorded in task comment before edit.

No new deps, no cross-crate edges, no #[allow(dead_code)].

Diff (abridged):
```diff
+ pub fn callees(...) { self.ensure_synced()?; ... SELECT ... FROM refs WHERE ... kind='call' ... }
+ struct CalleeEdge { target_name, target_qualified: Option, confidence, from_span: i64 }
+ ... resolve + tests ...
```

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-00314-6a13c061`
- Behind base: 0
- Ahead of base: 1