### PR TITLE
Implement orbit-graph search + show query commands

### DIFF
--- a/.orbit/learnings/L-0052/learning.yaml
+++ b/.orbit/learnings/L-0052/learning.yaml
@@ -1,0 +1,19 @@
+schema_version: 1
+id: L-0052
+status: active
+scope:
+  paths:
+  - crates/orbit-graph/src/**/*.rs
+  tags:
+  - orbit-graph
+  - sqlite
+  - fts5
+summary: Bump orbit-graph EXTRACTOR_VERSION when changing FTS population invariants for existing SQLite graph DBs
+body: 'During ORB-00313, adding writes/deletes for the external-content FTS5 tables (`symbols_fts`, `strings_fts`, `configs_fts`) exposed a compatibility trap: existing graph DBs could contain rows in the content tables while their FTS indexes were empty because earlier sync code never populated them. A later incremental delete against that inconsistent FTS index can fail with SQLite reporting `database disk image is malformed`. When the storage invariant changes from "FTS tables may be empty" to "FTS rows mirror content rows", bump `EXTRACTOR_VERSION` so Orbit opens a fresh per-worktree graph DB instead of trying to incrementally mutate incompatible old indexes.'
+evidence:
+- kind: task
+  reference: ORB-00313
+created_at: 2026-05-25T03:39:50.772363Z
+updated_at: 2026-05-25T03:39:50.772363Z
+created_by: codex
+priority: 120

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2247,6 +2247,7 @@ dependencies = [
  "orbit-graph-extract",
  "rayon",
  "rusqlite",
+ "serde",
  "tracing",
 ]
 

--- a/crates/orbit-graph-extract/src/selector.rs
+++ b/crates/orbit-graph-extract/src/selector.rs
@@ -39,6 +39,16 @@ pub enum Selector {
         /// Symbol kind, such as `function`, `method`, or `trait`.
         kind: String,
     },
+    /// Module selector addressed by qualified module name.
+    Module {
+        /// Qualified module name.
+        qualified: String,
+    },
+    /// Command selector addressed by CLI command name.
+    Command {
+        /// Command name.
+        name: String,
+    },
 }
 
 impl Selector {
@@ -50,10 +60,17 @@ impl Selector {
             .collect()
     }
 
-    /// Return the filesystem anchor path for this selector.
+    /// Return the filesystem anchor path for this selector, or an empty string
+    /// for selector forms that are resolved through graph metadata.
     pub fn path(&self) -> &str {
+        self.anchor_path().unwrap_or("")
+    }
+
+    /// Return the filesystem anchor path for this selector when it has one.
+    pub fn anchor_path(&self) -> Option<&str> {
         match self {
-            Self::Dir { path } | Self::File { path } | Self::Symbol { path, .. } => path,
+            Self::Dir { path } | Self::File { path } | Self::Symbol { path, .. } => Some(path),
+            Self::Module { .. } | Self::Command { .. } => None,
         }
     }
 
@@ -66,6 +83,10 @@ impl Selector {
                 symbol: symbol.clone(),
                 kind: kind.clone(),
             },
+            Self::Module { qualified } => Self::Module {
+                qualified: qualified.clone(),
+            },
+            Self::Command { name } => Self::Command { name: name.clone() },
         }
     }
 
@@ -74,6 +95,8 @@ impl Selector {
             Self::Dir { .. } => ParsedScopeKind::Dir,
             Self::File { .. } => ParsedScopeKind::File,
             Self::Symbol { .. } => ParsedScopeKind::Symbol,
+            Self::Module { .. } => ParsedScopeKind::Module,
+            Self::Command { .. } => ParsedScopeKind::Command,
         }
     }
 
@@ -85,6 +108,8 @@ impl Selector {
             Self::Symbol { path, symbol, kind } => {
                 SelectorLookupKey::Symbol(format!("{path}#{symbol}"), kind.clone())
             }
+            Self::Module { qualified } => SelectorLookupKey::Module(qualified.clone()),
+            Self::Command { name } => SelectorLookupKey::Command(name.clone()),
         }
     }
 }
@@ -95,6 +120,8 @@ impl Display for Selector {
             Self::Dir { path } => write!(f, "dir:{path}"),
             Self::File { path } => write!(f, "file:{path}"),
             Self::Symbol { path, symbol, kind } => write!(f, "symbol:{path}#{symbol}:{kind}"),
+            Self::Module { qualified } => write!(f, "module:{qualified}"),
+            Self::Command { name } => write!(f, "command:{name}"),
         }
     }
 }
@@ -152,9 +179,37 @@ impl FromStr for Selector {
             });
         }
 
+        if let Some(qualified) = trimmed.strip_prefix("module:") {
+            let qualified = qualified.trim();
+            if qualified.is_empty() {
+                return Err(SelectorParseError {
+                    input: selector.to_string(),
+                    reason: "module selectors must include a qualified module".to_string(),
+                });
+            }
+            return Ok(Self::Module {
+                qualified: qualified.to_string(),
+            });
+        }
+
+        if let Some(name) = trimmed.strip_prefix("command:") {
+            let name = name.trim();
+            if name.is_empty() {
+                return Err(SelectorParseError {
+                    input: selector.to_string(),
+                    reason: "command selectors must include a command name".to_string(),
+                });
+            }
+            return Ok(Self::Command {
+                name: name.to_string(),
+            });
+        }
+
         Err(SelectorParseError {
             input: selector.to_string(),
-            reason: "selectors must start with `dir:`, `file:`, or `symbol:`".to_string(),
+            reason:
+                "selectors must start with `dir:`, `file:`, `symbol:`, `module:`, or `command:`"
+                    .to_string(),
         })
     }
 }
@@ -168,6 +223,10 @@ pub enum SelectorLookupKey {
     File(String),
     /// Symbol(location, kind) where location = "path#symbol".
     Symbol(String, String),
+    /// Module qualified-name key.
+    Module(String),
+    /// Command name key.
+    Command(String),
 }
 
 impl SelectorLookupKey {
@@ -177,6 +236,8 @@ impl SelectorLookupKey {
             Self::Dir(path) => format!("dir:{path}"),
             Self::File(path) => format!("file:{path}"),
             Self::Symbol(location, kind) => format!("symbol:{location}:{kind}"),
+            Self::Module(qualified) => format!("module:{qualified}"),
+            Self::Command(name) => format!("command:{name}"),
         }
     }
 }
@@ -212,8 +273,12 @@ pub fn canonical_selector_in_workspace(
     let parsed = ParsedScope::parse(input)?;
     match parsed {
         ParsedScope::Selector(selector) => {
-            let path = normalize_workspace_anchor(selector.path(), workspace)?;
-            Ok(selector.with_path(path).to_string())
+            if let Some(anchor) = selector.anchor_path() {
+                let path = normalize_workspace_anchor(anchor, workspace)?;
+                Ok(selector.with_path(path).to_string())
+            } else {
+                Ok(selector.to_string())
+            }
         }
         ParsedScope::LegacyPath { path, is_dir_hint } => {
             let path = normalize_workspace_anchor(path.as_str(), workspace)?;
@@ -233,7 +298,14 @@ pub fn canonical_selector_in_workspace(
 /// backing file path. Legacy `path:line` references are reduced to their file
 /// path anchor.
 pub fn anchor_path(selector: &str) -> Result<PathBuf, SelectorParseError> {
-    Ok(PathBuf::from(ParsedScope::parse(selector)?.anchor_path()))
+    let parsed = ParsedScope::parse(selector)?;
+    parsed
+        .anchor_path()
+        .map(PathBuf::from)
+        .ok_or_else(|| SelectorParseError {
+            input: selector.to_string(),
+            reason: "selector has no filesystem anchor".to_string(),
+        })
 }
 
 /// Return whether a selector's filesystem anchor exists in the given workspace.
@@ -261,8 +333,9 @@ pub fn overlaps(a: &str, b: &str) -> bool {
         return false;
     };
 
-    let left_anchor = left.anchor_path();
-    let right_anchor = right.anchor_path();
+    let (Some(left_anchor), Some(right_anchor)) = (left.anchor_path(), right.anchor_path()) else {
+        return a.trim() == b.trim();
+    };
     if left_anchor == right_anchor {
         return true;
     }
@@ -308,6 +381,8 @@ enum ParsedScopeKind {
     Dir,
     File,
     Symbol,
+    Module,
+    Command,
     Legacy,
 }
 
@@ -330,6 +405,8 @@ impl ParsedScope {
         if trimmed.starts_with("dir:")
             || trimmed.starts_with("file:")
             || trimmed.starts_with("symbol:")
+            || trimmed.starts_with("module:")
+            || trimmed.starts_with("command:")
         {
             return Ok(Self::Selector(trimmed.parse()?));
         }
@@ -343,10 +420,10 @@ impl ParsedScope {
         Ok(Self::LegacyPath { path, is_dir_hint })
     }
 
-    fn anchor_path(&self) -> &str {
+    fn anchor_path(&self) -> Option<&str> {
         match self {
-            Self::Selector(selector) => selector.path(),
-            Self::LegacyPath { path, .. } => path,
+            Self::Selector(selector) => selector.anchor_path(),
+            Self::LegacyPath { path, .. } => Some(path),
         }
     }
 

--- a/crates/orbit-graph-extract/src/tests/selector.rs
+++ b/crates/orbit-graph-extract/src/tests/selector.rs
@@ -28,6 +28,8 @@ fn selector_audit_corpus_keeps_frozen_debug_output() {
         r#"File { path: "src/lib.rs" }"#,
         r#"Symbol { path: "src/lib.rs", symbol: "hello", kind: "function" }"#,
         r#"Symbol { path: "src/lib.rs", symbol: "Greeter", kind: "trait" }"#,
+        r#"Module { qualified: "orbit_core::scheduler" }"#,
+        r#"Command { name: "task.update" }"#,
     ];
 
     assert_eq!(actual, expected);

--- a/crates/orbit-graph/Cargo.toml
+++ b/crates/orbit-graph/Cargo.toml
@@ -18,4 +18,5 @@ ignore.workspace = true
 orbit-graph-extract = { path = "../orbit-graph-extract" }
 rayon.workspace = true
 rusqlite.workspace = true
+serde.workspace = true
 tracing.workspace = true

--- a/crates/orbit-graph/src/lib.rs
+++ b/crates/orbit-graph/src/lib.rs
@@ -12,8 +12,14 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 pub use orbit_graph_extract::Selector;
 use rusqlite::{params, Connection};
 
+mod query;
 mod store;
 mod sync;
+
+pub use query::{
+    DEFAULT_SEARCH_LIMIT, DEFAULT_SHOW_MAX_BYTES, Match, NodeMetadata, NodeView, SearchKind,
+    SearchQuery, SearchResult, SourceSpan,
+};
 
 #[cfg(test)]
 mod tests;
@@ -23,7 +29,8 @@ mod tests;
 /// Bump this when extractor output or storage expectations change
 /// incompatibly. Older graph DB files then become invisible to the active
 /// graph handle and are removed by the next sync.
-pub const EXTRACTOR_VERSION: u32 = 1;
+// L-0052: FTS population invariants require a fresh DB when old indexes may be empty.
+pub const EXTRACTOR_VERSION: u32 = 2;
 
 /// Opaque handle to a worktree-scoped graph database.
 pub struct Graph {
@@ -79,15 +86,18 @@ impl Graph {
     }
 
     /// Search indexed symbols, strings, and config keys.
-    pub fn search(&self, q: &SearchQuery) -> Result<Vec<Match>, GraphError> {
-        let _ = (self, q);
-        todo!("search graph index")
+    pub fn search(&self, q: &SearchQuery) -> Result<SearchResult, GraphError> {
+        self.ensure_synced()?;
+        query::search::run(self, q)
     }
 
     /// Show the node or source view addressed by `sel`.
-    pub fn show(&self, sel: &Selector) -> Result<Option<NodeView>, GraphError> {
-        let _ = (self, sel);
-        todo!("show graph node")
+    ///
+    /// `max_bytes` bounds the returned source slice. [`DEFAULT_SHOW_MAX_BYTES`]
+    /// is the intended CLI/MCP default.
+    pub fn show(&self, sel: &Selector, max_bytes: usize) -> Result<Option<NodeView>, GraphError> {
+        self.ensure_synced()?;
+        query::show::run(self, sel, max_bytes)
     }
 
     /// Return inbound references and relations for `sel`.
@@ -406,18 +416,6 @@ pub fn resolve_db_path(worktree_root: &Path, branch: &str, extractor_version: u3
         extractor_version,
     }
 }
-
-/// Search request for the graph query surface.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct SearchQuery;
-
-/// Search match returned by [`Graph::search`].
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct Match;
-
-/// Source and metadata view returned by [`Graph::show`].
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct NodeView;
 
 /// Reference query options for [`Graph::refs`].
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/crates/orbit-graph/src/query/mod.rs
+++ b/crates/orbit-graph/src/query/mod.rs
@@ -1,0 +1,7 @@
+//! Read-only graph query implementations.
+
+pub(crate) mod search;
+pub(crate) mod show;
+
+pub use search::{DEFAULT_SEARCH_LIMIT, Match, SearchKind, SearchQuery, SearchResult};
+pub use show::{DEFAULT_SHOW_MAX_BYTES, NodeMetadata, NodeView, SourceSpan};

--- a/crates/orbit-graph/src/query/search.rs
+++ b/crates/orbit-graph/src/query/search.rs
@@ -1,0 +1,320 @@
+//! Full-text search over indexed symbols, strings, and configs.
+
+use std::fs;
+
+use rusqlite::{Connection, params};
+use serde::Serialize;
+
+use crate::{Graph, GraphError};
+
+/// Default number of matches returned by [`Graph::search`].
+pub const DEFAULT_SEARCH_LIMIT: usize = 20;
+
+/// Search request for the graph query surface.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SearchQuery {
+    /// User query text passed through SQLite FTS5.
+    pub query: String,
+    /// Optional result-kind filter.
+    pub kind: Option<SearchKind>,
+    /// Optional language filter matched against `files.lang`.
+    pub lang: Option<String>,
+    /// Optional result limit. Defaults to [`DEFAULT_SEARCH_LIMIT`].
+    pub limit: Option<usize>,
+}
+
+impl SearchQuery {
+    /// Build a search query with default filters.
+    pub fn new(query: impl Into<String>) -> Self {
+        Self {
+            query: query.into(),
+            kind: None,
+            lang: None,
+            limit: None,
+        }
+    }
+
+    fn limit(&self) -> usize {
+        self.limit.unwrap_or(DEFAULT_SEARCH_LIMIT)
+    }
+}
+
+/// Search result kind.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum SearchKind {
+    /// Symbol definitions.
+    Symbol,
+    /// Notable string literals.
+    String,
+    /// Structured config keys.
+    Config,
+}
+
+impl SearchKind {
+    /// Parse a CLI/tool kind filter.
+    pub fn parse(value: &str) -> Option<Self> {
+        match value {
+            "symbol" => Some(Self::Symbol),
+            "string" => Some(Self::String),
+            "config" => Some(Self::Config),
+            _ => None,
+        }
+    }
+}
+
+/// Search output matching `GRAPH_SPEC.md` section 9.1.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct SearchResult {
+    /// Ranked matches.
+    pub matches: Vec<Match>,
+}
+
+/// Search match returned by [`Graph::search`].
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(tag = "kind", rename_all = "lowercase")]
+pub enum Match {
+    /// Symbol match.
+    Symbol {
+        /// Matched symbol name.
+        name: String,
+        /// Workspace-relative source path.
+        path: String,
+        /// One-based source line.
+        line: usize,
+    },
+    /// String literal match.
+    #[serde(rename = "string")]
+    StringLiteral {
+        /// Matched string value.
+        value: String,
+        /// Workspace-relative source path.
+        path: String,
+        /// One-based source line.
+        line: usize,
+    },
+    /// Config key match.
+    Config {
+        /// Matched config key.
+        value: String,
+        /// Workspace-relative source path.
+        path: String,
+        /// One-based source line.
+        line: usize,
+    },
+}
+
+pub(crate) fn run(graph: &Graph, q: &SearchQuery) -> Result<SearchResult, GraphError> {
+    let query = q.query.trim();
+    let limit = q.limit();
+    if query.is_empty() || limit == 0 {
+        return Ok(SearchResult {
+            matches: Vec::new(),
+        });
+    }
+
+    let conn = Connection::open(graph.db_path.path())
+        .map_err(|source| GraphError::sqlite("open graph database for search", source))?;
+    let raw_matches = query_matches(&conn, q, query, limit)?;
+    let matches = raw_matches
+        .into_iter()
+        .map(|raw| materialize_match(graph, raw))
+        .collect::<Result<Vec<_>, _>>()?;
+    Ok(SearchResult { matches })
+}
+
+fn query_matches(
+    conn: &Connection,
+    q: &SearchQuery,
+    query: &str,
+    limit: usize,
+) -> Result<Vec<RawMatch>, GraphError> {
+    let mut arms = Vec::new();
+    for kind in [SearchKind::Symbol, SearchKind::String, SearchKind::Config] {
+        if q.kind.is_some_and(|filter| filter != kind) {
+            continue;
+        }
+        arms.push(sql_arm(kind, q.lang.is_some()));
+    }
+
+    if arms.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let limit_index = if q.lang.is_some() { 3 } else { 2 };
+    let sql = format!(
+        "SELECT kind, label, path, span_start, line
+         FROM ({})
+         ORDER BY rank
+         LIMIT ?{limit_index}",
+        arms.join(" UNION ALL ")
+    );
+    let fts = fts_query(query);
+    let limit = usize_to_i64("convert search result limit", limit)?;
+    let mut stmt = conn
+        .prepare_cached(&sql)
+        .map_err(|source| GraphError::sqlite("prepare graph search query", source))?;
+
+    let rows = if let Some(lang) = q.lang.as_ref() {
+        stmt.query_map(params![fts, lang, limit], raw_match_from_row)
+            .map_err(|source| GraphError::sqlite("query graph search matches", source))?
+            .collect::<Result<Vec<_>, _>>()
+    } else {
+        stmt.query_map(params![fts, limit], raw_match_from_row)
+            .map_err(|source| GraphError::sqlite("query graph search matches", source))?
+            .collect::<Result<Vec<_>, _>>()
+    };
+
+    rows.map_err(|source| GraphError::sqlite("collect graph search matches", source))
+}
+
+fn sql_arm(kind: SearchKind, filter_lang: bool) -> &'static str {
+    match (kind, filter_lang) {
+        (SearchKind::Symbol, true) => {
+            "SELECT 'symbol' AS kind, s.name AS label, s.file_path AS path,
+                    s.span_start AS span_start, NULL AS line, bm25(symbols_fts) AS rank
+             FROM symbols_fts
+             JOIN symbols s ON s.id = symbols_fts.rowid
+             JOIN files f ON f.path = s.file_path
+             WHERE symbols_fts MATCH ?1 AND f.lang = ?2"
+        }
+        (SearchKind::Symbol, false) => {
+            "SELECT 'symbol' AS kind, s.name AS label, s.file_path AS path,
+                    s.span_start AS span_start, NULL AS line, bm25(symbols_fts) AS rank
+             FROM symbols_fts
+             JOIN symbols s ON s.id = symbols_fts.rowid
+             JOIN files f ON f.path = s.file_path
+             WHERE symbols_fts MATCH ?1"
+        }
+        (SearchKind::String, true) => {
+            "SELECT 'string' AS kind, st.value AS label, st.file_path AS path,
+                    NULL AS span_start, st.line AS line, bm25(strings_fts) AS rank
+             FROM strings_fts
+             JOIN strings st ON st.id = strings_fts.rowid
+             JOIN files f ON f.path = st.file_path
+             WHERE strings_fts MATCH ?1 AND f.lang = ?2"
+        }
+        (SearchKind::String, false) => {
+            "SELECT 'string' AS kind, st.value AS label, st.file_path AS path,
+                    NULL AS span_start, st.line AS line, bm25(strings_fts) AS rank
+             FROM strings_fts
+             JOIN strings st ON st.id = strings_fts.rowid
+             JOIN files f ON f.path = st.file_path
+             WHERE strings_fts MATCH ?1"
+        }
+        (SearchKind::Config, true) => {
+            "SELECT 'config' AS kind, c.key AS label, c.file_path AS path,
+                    NULL AS span_start, c.line AS line, bm25(configs_fts) AS rank
+             FROM configs_fts
+             JOIN configs c ON c.id = configs_fts.rowid
+             JOIN files f ON f.path = c.file_path
+             WHERE configs_fts MATCH ?1 AND f.lang = ?2"
+        }
+        (SearchKind::Config, false) => {
+            "SELECT 'config' AS kind, c.key AS label, c.file_path AS path,
+                    NULL AS span_start, c.line AS line, bm25(configs_fts) AS rank
+             FROM configs_fts
+             JOIN configs c ON c.id = configs_fts.rowid
+             JOIN files f ON f.path = c.file_path
+             WHERE configs_fts MATCH ?1"
+        }
+    }
+}
+
+fn fts_query(query: &str) -> String {
+    query
+        .split_whitespace()
+        .map(|term| format!("\"{}\"", term.replace('"', "\"\"")))
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct RawMatch {
+    kind: SearchKind,
+    label: String,
+    path: String,
+    span_start: Option<i64>,
+    line: Option<i64>,
+}
+
+fn raw_match_from_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<RawMatch> {
+    let kind = match row.get::<_, String>(0)?.as_str() {
+        "symbol" => SearchKind::Symbol,
+        "string" => SearchKind::String,
+        "config" => SearchKind::Config,
+        _ => unreachable!("search query only emits known kinds"),
+    };
+    Ok(RawMatch {
+        kind,
+        label: row.get(1)?,
+        path: row.get(2)?,
+        span_start: row.get(3)?,
+        line: row.get(4)?,
+    })
+}
+
+fn materialize_match(graph: &Graph, raw: RawMatch) -> Result<Match, GraphError> {
+    let line = match (raw.line, raw.span_start) {
+        (Some(line), _) => i64_to_usize("convert graph search line", line)?,
+        (None, Some(span_start)) => symbol_line(graph, raw.path.as_str(), span_start)?,
+        (None, None) => {
+            return Err(GraphError::invalid_data(
+                "materialize graph search match",
+                "match row has neither line nor span_start",
+            ));
+        }
+    };
+
+    Ok(match raw.kind {
+        SearchKind::Symbol => Match::Symbol {
+            name: raw.label,
+            path: raw.path,
+            line,
+        },
+        SearchKind::String => Match::StringLiteral {
+            value: raw.label,
+            path: raw.path,
+            line,
+        },
+        SearchKind::Config => Match::Config {
+            value: raw.label,
+            path: raw.path,
+            line,
+        },
+    })
+}
+
+fn symbol_line(graph: &Graph, path: &str, span_start: i64) -> Result<usize, GraphError> {
+    let span_start = i64_to_usize("convert graph search symbol span", span_start)?;
+    let source_path = graph.worktree_root.join(path);
+    let bytes = fs::read(source_path.as_path()).map_err(|source| {
+        GraphError::io("read source file for graph search", source_path, source)
+    })?;
+    if span_start > bytes.len() {
+        return Err(GraphError::invalid_data(
+            "read source line for graph search",
+            format!(
+                "span_start {span_start} is beyond source length {} for {path}",
+                bytes.len()
+            ),
+        ));
+    }
+    Ok(bytes[..span_start]
+        .iter()
+        .filter(|byte| **byte == b'\n')
+        .count()
+        + 1)
+}
+
+fn usize_to_i64(operation: &'static str, value: usize) -> Result<i64, GraphError> {
+    i64::try_from(value).map_err(|source| GraphError::invalid_data(operation, source.to_string()))
+}
+
+fn i64_to_usize(operation: &'static str, value: i64) -> Result<usize, GraphError> {
+    usize::try_from(value).map_err(|source| GraphError::invalid_data(operation, source.to_string()))
+}
+
+#[cfg(test)]
+#[path = "tests/search.rs"]
+mod tests;

--- a/crates/orbit-graph/src/query/show.rs
+++ b/crates/orbit-graph/src/query/show.rs
@@ -1,0 +1,227 @@
+//! Selector resolution and bounded source reads.
+
+use std::fs;
+
+use orbit_graph_extract::Selector;
+use rusqlite::{Connection, OptionalExtension, params};
+use serde::Serialize;
+
+use crate::{Graph, GraphError};
+
+/// Default maximum source bytes returned by [`Graph::show`].
+///
+/// The value keeps a single result comfortably inside agent context while
+/// still covering typical functions, files, and command handlers.
+pub const DEFAULT_SHOW_MAX_BYTES: usize = 64 * 1024;
+
+/// Source and metadata view returned by [`Graph::show`].
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct NodeView {
+    /// Source bytes from the resolved span, bounded by the caller's budget.
+    pub bytes: Vec<u8>,
+    /// Metadata for the resolved source span.
+    pub metadata: NodeMetadata,
+}
+
+/// Metadata for a [`NodeView`].
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct NodeMetadata {
+    /// Workspace-relative source path.
+    pub file: String,
+    /// Full resolved source span before byte-budget truncation.
+    pub span: SourceSpan,
+    /// Resolved node kind.
+    pub kind: String,
+    /// Display name when one exists.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    /// Qualified symbol name when one exists.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub qualified: Option<String>,
+    /// Whether `bytes` is shorter than the resolved source span.
+    pub truncated: bool,
+}
+
+/// Byte span in a source file.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+pub struct SourceSpan {
+    /// Inclusive byte start.
+    pub start: usize,
+    /// Exclusive byte end.
+    pub end: usize,
+}
+
+pub(crate) fn run(
+    graph: &Graph,
+    selector: &Selector,
+    max_bytes: usize,
+) -> Result<Option<NodeView>, GraphError> {
+    let conn = Connection::open(graph.db_path.path())
+        .map_err(|source| GraphError::sqlite("open graph database for show", source))?;
+    let Some(resolved) = resolve_selector(&conn, selector)? else {
+        return Ok(None);
+    };
+    materialize_view(graph, resolved, max_bytes).map(Some)
+}
+
+fn resolve_selector(
+    conn: &Connection,
+    selector: &Selector,
+) -> Result<Option<ResolvedView>, GraphError> {
+    match selector {
+        Selector::Symbol { path, symbol, kind } => resolve_symbol(conn, path, symbol, kind),
+        Selector::File { path } => resolve_file(conn, path),
+        Selector::Module { qualified } => resolve_module(conn, qualified),
+        Selector::Command { name } => resolve_command(conn, name),
+        Selector::Dir { .. } => Ok(None),
+    }
+}
+
+fn resolve_symbol(
+    conn: &Connection,
+    path: &str,
+    symbol: &str,
+    kind: &str,
+) -> Result<Option<ResolvedView>, GraphError> {
+    conn.query_row(
+        "SELECT file_path, span_start, span_end, kind, name, qualified
+         FROM symbols
+         WHERE file_path = ?1
+           AND kind = ?3
+           AND (name = ?2 OR qualified = ?2)
+         ORDER BY CASE WHEN qualified = ?2 THEN 0 WHEN name = ?2 THEN 1 ELSE 2 END, id
+         LIMIT 1",
+        params![path, symbol, kind],
+        resolved_symbol_from_row,
+    )
+    .optional()
+    .map_err(|source| GraphError::sqlite("resolve graph symbol selector", source))
+}
+
+fn resolve_file(conn: &Connection, path: &str) -> Result<Option<ResolvedView>, GraphError> {
+    conn.query_row(
+        "SELECT path, 0, byte_len, 'file', path, NULL
+         FROM files
+         WHERE path = ?1",
+        params![path],
+        resolved_symbol_from_row,
+    )
+    .optional()
+    .map_err(|source| GraphError::sqlite("resolve graph file selector", source))
+}
+
+fn resolve_module(conn: &Connection, qualified: &str) -> Result<Option<ResolvedView>, GraphError> {
+    conn.query_row(
+        "SELECT file_path, span_start, span_end, kind, name, qualified
+         FROM symbols
+         WHERE kind = 'module'
+           AND (qualified = ?1 OR name = ?1)
+         ORDER BY CASE WHEN qualified = ?1 THEN 0 WHEN name = ?1 THEN 1 ELSE 2 END, id
+         LIMIT 1",
+        params![qualified],
+        resolved_symbol_from_row,
+    )
+    .optional()
+    .map_err(|source| GraphError::sqlite("resolve graph module selector", source))
+}
+
+fn resolve_command(conn: &Connection, name: &str) -> Result<Option<ResolvedView>, GraphError> {
+    conn.query_row(
+        "SELECT c.file_path,
+                COALESCE(s.span_start, c.span_start) AS span_start,
+                COALESCE(s.span_end, f.byte_len) AS span_end,
+                'command' AS kind,
+                c.name AS name,
+                s.qualified AS qualified
+         FROM commands c
+         JOIN files f ON f.path = c.file_path
+         LEFT JOIN symbols s ON s.id = c.handler_symbol
+         WHERE c.name = ?1
+         ORDER BY c.name
+         LIMIT 1",
+        params![name],
+        resolved_symbol_from_row,
+    )
+    .optional()
+    .map_err(|source| GraphError::sqlite("resolve graph command selector", source))
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ResolvedView {
+    file: String,
+    span_start: i64,
+    span_end: i64,
+    kind: String,
+    name: Option<String>,
+    qualified: Option<String>,
+}
+
+fn resolved_symbol_from_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<ResolvedView> {
+    Ok(ResolvedView {
+        file: row.get(0)?,
+        span_start: row.get(1)?,
+        span_end: row.get(2)?,
+        kind: row.get(3)?,
+        name: row.get(4)?,
+        qualified: row.get(5)?,
+    })
+}
+
+fn materialize_view(
+    graph: &Graph,
+    resolved: ResolvedView,
+    max_bytes: usize,
+) -> Result<NodeView, GraphError> {
+    let source_path = graph.worktree_root.join(resolved.file.as_str());
+    let source = fs::read(source_path.as_path())
+        .map_err(|source| GraphError::io("read source file for graph show", source_path, source))?;
+    let span = validate_span(
+        "read source span for graph show",
+        resolved.span_start,
+        resolved.span_end,
+        source.len(),
+        resolved.file.as_str(),
+    )?;
+    let full = &source[span.start..span.end];
+    let byte_count = full.len().min(max_bytes);
+    let bytes = full[..byte_count].to_vec();
+    let truncated = byte_count < full.len();
+
+    Ok(NodeView {
+        bytes,
+        metadata: NodeMetadata {
+            file: resolved.file,
+            span,
+            kind: resolved.kind,
+            name: resolved.name,
+            qualified: resolved.qualified,
+            truncated,
+        },
+    })
+}
+
+fn validate_span(
+    operation: &'static str,
+    start: i64,
+    end: i64,
+    source_len: usize,
+    file: &str,
+) -> Result<SourceSpan, GraphError> {
+    let start = i64_to_usize(operation, start)?;
+    let end = i64_to_usize(operation, end)?;
+    if start > end || end > source_len {
+        return Err(GraphError::invalid_data(
+            operation,
+            format!("invalid span {start}..{end} for {file} with {source_len} bytes"),
+        ));
+    }
+    Ok(SourceSpan { start, end })
+}
+
+fn i64_to_usize(operation: &'static str, value: i64) -> Result<usize, GraphError> {
+    usize::try_from(value).map_err(|source| GraphError::invalid_data(operation, source.to_string()))
+}
+
+#[cfg(test)]
+#[path = "tests/show.rs"]
+mod tests;

--- a/crates/orbit-graph/src/query/tests/search.rs
+++ b/crates/orbit-graph/src/query/tests/search.rs
@@ -1,0 +1,248 @@
+mod support;
+
+use std::time::Instant;
+
+use rusqlite::{Connection, params};
+
+use super::{Match, SearchKind, SearchQuery};
+use crate::sync::sync_leader_count;
+use crate::{SyncMode, SyncPolicy};
+
+use support::{
+    TestWorktree, graph_db_path, insert_file, insert_symbol, open_connection, open_graph,
+};
+
+#[test]
+fn search_unions_fts_tables_and_filters_kind_and_lang() {
+    let worktree = TestWorktree::new("search-union");
+    let rust_source = "\n\npub fn scheduler() {}\n";
+    let py_source = "print('scheduler tick failed')\n";
+    worktree.write("src/lib.rs", rust_source);
+    worktree.write("scripts/tick.py", py_source);
+    let graph = open_graph(&worktree, SyncPolicy::Manual);
+    let conn = open_connection(&worktree);
+    insert_file(&conn, "src/lib.rs", "rust", rust_source);
+    insert_file(&conn, "scripts/tick.py", "python", py_source);
+    let start = rust_source.find("pub fn scheduler").expect("symbol start");
+    insert_symbol(
+        &conn,
+        "src/lib.rs",
+        "scheduler",
+        "crate::scheduler",
+        "function",
+        start,
+        start + "pub fn scheduler() {}".len(),
+    );
+    insert_string(&conn, "src/lib.rs", 4, "scheduler tick failed");
+    insert_config(&conn, "src/lib.rs", 5, "scheduler.interval");
+    insert_string(&conn, "scripts/tick.py", 1, "scheduler tick failed");
+
+    let all = graph
+        .search(&SearchQuery::new("scheduler"))
+        .expect("search all kinds");
+
+    assert!(all.matches.iter().any(|mat| {
+        matches!(
+            mat,
+            Match::Symbol { name, path, line }
+                if name == "scheduler" && path == "src/lib.rs" && *line == 3
+        )
+    }));
+    assert!(all.matches.iter().any(|mat| {
+        matches!(
+            mat,
+            Match::StringLiteral { value, path, line }
+                if value == "scheduler tick failed" && path == "src/lib.rs" && *line == 4
+        )
+    }));
+    assert!(all.matches.iter().any(|mat| {
+        matches!(
+            mat,
+            Match::Config { value, path, line }
+                if value == "scheduler.interval" && path == "src/lib.rs" && *line == 5
+        )
+    }));
+
+    let rust_strings = graph
+        .search(&SearchQuery {
+            query: "scheduler".to_string(),
+            kind: Some(SearchKind::String),
+            lang: Some("rust".to_string()),
+            limit: Some(10),
+        })
+        .expect("search rust strings");
+
+    assert_eq!(
+        rust_strings.matches,
+        vec![Match::StringLiteral {
+            value: "scheduler tick failed".to_string(),
+            path: "src/lib.rs".to_string(),
+            line: 4,
+        }]
+    );
+}
+
+#[test]
+fn search_defaults_to_twenty_matches_and_limit_overrides() {
+    let worktree = TestWorktree::new("search-limit");
+    let source = "pub fn needle_fixture() {}\n";
+    worktree.write("src/lib.rs", source);
+    let graph = open_graph(&worktree, SyncPolicy::Manual);
+    let conn = open_connection(&worktree);
+    insert_file(&conn, "src/lib.rs", "rust", source);
+    for index in 0..25 {
+        insert_symbol(
+            &conn,
+            "src/lib.rs",
+            &format!("needle_{index}"),
+            &format!("crate::needle_{index}"),
+            "function",
+            0,
+            source.len(),
+        );
+    }
+
+    let defaulted = graph
+        .search(&SearchQuery::new("needle"))
+        .expect("search default limit");
+    let overridden = graph
+        .search(&SearchQuery {
+            query: "needle".to_string(),
+            kind: Some(SearchKind::Symbol),
+            lang: None,
+            limit: Some(25),
+        })
+        .expect("search override limit");
+
+    assert_eq!(defaulted.matches.len(), 20);
+    assert_eq!(overridden.matches.len(), 25);
+}
+
+#[test]
+fn search_calls_ensure_synced_at_entry() {
+    let worktree = TestWorktree::new("search-ensure");
+    worktree.write("src/lib.rs", "pub fn auto_sync_marker() {}\n");
+    let graph = open_graph(&worktree, SyncPolicy::OnRead);
+    let db_path = graph_db_path(&worktree);
+
+    let result = graph
+        .search(&SearchQuery::new("auto_sync_marker"))
+        .expect("search with on-read sync");
+
+    assert_eq!(sync_leader_count(db_path.as_path()), 1);
+    assert_eq!(result.matches.len(), 1);
+}
+
+#[test]
+fn search_10000_symbol_performance_smoke_prints_elapsed_ms() {
+    let worktree = TestWorktree::new("search-perf");
+    let source = "pub fn needle_fixture() {}\n";
+    worktree.write("src/lib.rs", source);
+    let graph = open_graph(&worktree, SyncPolicy::Manual);
+    let mut conn = open_connection(&worktree);
+    let tx = conn.transaction().expect("begin insert transaction");
+    tx.execute(
+        "INSERT INTO files (path, content_hash, mtime_ns, lang, byte_len, extracted_at)
+         VALUES ('src/lib.rs', x'00', 1, 'rust', ?1, 2)",
+        params![i64::try_from(source.len()).expect("source length fits")],
+    )
+    .expect("insert file");
+    for index in 0..10_000 {
+        let name = format!("needle_{index}");
+        let qualified = format!("crate::{name}");
+        tx.execute(
+            "INSERT INTO symbols (
+                file_path, name, qualified, kind, span_start, span_end, signature, parent_symbol
+             ) VALUES ('src/lib.rs', ?1, ?2, 'function', 0, ?3, ?4, NULL)",
+            params![
+                name,
+                qualified,
+                i64::try_from(source.len()).expect("source length fits"),
+                format!("fn needle_{index}()")
+            ],
+        )
+        .expect("insert symbol");
+        let id = tx.last_insert_rowid();
+        tx.execute(
+            "INSERT INTO symbols_fts (rowid, name, qualified, signature)
+             VALUES (?1, ?2, ?3, ?4)",
+            params![
+                id,
+                format!("needle_{index}"),
+                format!("crate::needle_{index}"),
+                format!("fn needle_{index}()")
+            ],
+        )
+        .expect("insert symbol fts");
+    }
+    tx.commit().expect("commit insert transaction");
+
+    let started = Instant::now();
+    let result = graph
+        .search(&SearchQuery {
+            query: "needle".to_string(),
+            kind: Some(SearchKind::Symbol),
+            lang: None,
+            limit: None,
+        })
+        .expect("search synthetic fixture");
+    let elapsed = started.elapsed();
+
+    #[allow(clippy::print_stdout)]
+    {
+        println!("graph_search_10000_symbols_ms={}", elapsed.as_millis());
+    }
+    assert_eq!(result.matches.len(), 20);
+}
+
+#[test]
+fn search_sync_populates_fts_rows() {
+    let worktree = TestWorktree::new("search-sync-fts");
+    worktree.write("src/lib.rs", "pub fn synced_needle() {}\n");
+    let graph = open_graph(&worktree, SyncPolicy::Manual);
+
+    graph.sync(SyncMode::Full).expect("full sync");
+    let result = graph
+        .search(&SearchQuery::new("synced_needle"))
+        .expect("search synced fts");
+
+    assert_eq!(result.matches.len(), 1);
+}
+
+fn insert_string(conn: &Connection, file_path: &str, line: usize, value: &str) {
+    conn.execute(
+        "INSERT INTO strings (file_path, line, value, context_symbol)
+         VALUES (?1, ?2, ?3, NULL)",
+        params![
+            file_path,
+            i64::try_from(line).expect("string line fits"),
+            value
+        ],
+    )
+    .expect("insert string row");
+    let id = conn.last_insert_rowid();
+    conn.execute(
+        "INSERT INTO strings_fts (rowid, value) VALUES (?1, ?2)",
+        params![id, value],
+    )
+    .expect("insert string fts row");
+}
+
+fn insert_config(conn: &Connection, file_path: &str, line: usize, key: &str) {
+    conn.execute(
+        "INSERT INTO configs (file_path, line, key, kind)
+         VALUES (?1, ?2, ?3, 'toml')",
+        params![
+            file_path,
+            i64::try_from(line).expect("config line fits"),
+            key
+        ],
+    )
+    .expect("insert config row");
+    let id = conn.last_insert_rowid();
+    conn.execute(
+        "INSERT INTO configs_fts (rowid, key) VALUES (?1, ?2)",
+        params![id, key],
+    )
+    .expect("insert config fts row");
+}

--- a/crates/orbit-graph/src/query/tests/show.rs
+++ b/crates/orbit-graph/src/query/tests/show.rs
@@ -1,0 +1,239 @@
+mod support;
+
+use orbit_graph_extract::Selector;
+use rusqlite::{Connection, params};
+
+use super::{DEFAULT_SHOW_MAX_BYTES, SourceSpan};
+use crate::SyncPolicy;
+use crate::sync::sync_leader_count;
+
+use support::{
+    TestWorktree, graph_db_path, insert_file, insert_symbol, open_connection, open_graph,
+};
+
+#[test]
+fn show_resolves_symbol_file_module_and_command_selectors() {
+    let worktree = TestWorktree::new("show-selectors");
+    let source = "pub mod api {\n    pub fn handler() {\n        println!(\"hi\");\n    }\n}\n";
+    worktree.write("src/lib.rs", source);
+    let graph = open_graph(&worktree, SyncPolicy::Manual);
+    let conn = open_connection(&worktree);
+    insert_file(&conn, "src/lib.rs", "rust", source);
+    let module_start = source.find("pub mod api").expect("module start");
+    let module_end = source.len();
+    insert_symbol(
+        &conn,
+        "src/lib.rs",
+        "api",
+        "crate::api",
+        "module",
+        module_start,
+        module_end,
+    );
+    let handler_start = source.find("pub fn handler").expect("handler start");
+    let handler_end = source[handler_start..]
+        .find("\n    }\n")
+        .map(|offset| handler_start + offset + "\n    }".len())
+        .expect("handler end");
+    let handler_id = insert_symbol(
+        &conn,
+        "src/lib.rs",
+        "handler",
+        "crate::api::handler",
+        "function",
+        handler_start,
+        handler_end,
+    );
+    insert_command(
+        &conn,
+        "serve",
+        "src/lib.rs",
+        handler_start,
+        Some(handler_id),
+    );
+
+    let symbol = graph
+        .show(
+            &"symbol:src/lib.rs#handler:function"
+                .parse()
+                .expect("symbol selector"),
+            DEFAULT_SHOW_MAX_BYTES,
+        )
+        .expect("show symbol")
+        .expect("symbol resolves");
+    assert_eq!(symbol.metadata.file, "src/lib.rs");
+    assert_eq!(symbol.metadata.kind, "function");
+    assert_eq!(symbol.metadata.name.as_deref(), Some("handler"));
+    assert_eq!(
+        symbol.metadata.qualified.as_deref(),
+        Some("crate::api::handler")
+    );
+    assert_eq!(
+        &symbol.bytes,
+        &source.as_bytes()[handler_start..handler_end]
+    );
+
+    let file = graph
+        .show(
+            &"file:src/lib.rs".parse().expect("file selector"),
+            DEFAULT_SHOW_MAX_BYTES,
+        )
+        .expect("show file")
+        .expect("file resolves");
+    assert_eq!(file.metadata.kind, "file");
+    assert_eq!(
+        file.metadata.span,
+        SourceSpan {
+            start: 0,
+            end: source.len()
+        }
+    );
+    assert_eq!(file.bytes, source.as_bytes());
+
+    let module = graph
+        .show(
+            &Selector::Module {
+                qualified: "crate::api".to_string(),
+            },
+            DEFAULT_SHOW_MAX_BYTES,
+        )
+        .expect("show module")
+        .expect("module resolves");
+    assert_eq!(module.metadata.kind, "module");
+    assert_eq!(module.metadata.qualified.as_deref(), Some("crate::api"));
+    assert_eq!(&module.bytes, &source.as_bytes()[module_start..module_end]);
+
+    let command = graph
+        .show(
+            &Selector::Command {
+                name: "serve".to_string(),
+            },
+            DEFAULT_SHOW_MAX_BYTES,
+        )
+        .expect("show command")
+        .expect("command resolves");
+    assert_eq!(command.metadata.kind, "command");
+    assert_eq!(command.metadata.name.as_deref(), Some("serve"));
+    assert_eq!(
+        command.metadata.qualified.as_deref(),
+        Some("crate::api::handler")
+    );
+    assert_eq!(
+        &command.bytes,
+        &source.as_bytes()[handler_start..handler_end]
+    );
+}
+
+#[test]
+fn show_truncates_source_when_max_bytes_is_shorter_than_span() {
+    let worktree = TestWorktree::new("show-truncate");
+    let source = "pub fn long_body() {\n    let message = \"abcdef\";\n}\n";
+    worktree.write("src/lib.rs", source);
+    let graph = open_graph(&worktree, SyncPolicy::Manual);
+    let conn = open_connection(&worktree);
+    insert_file(&conn, "src/lib.rs", "rust", source);
+    insert_symbol(
+        &conn,
+        "src/lib.rs",
+        "long_body",
+        "crate::long_body",
+        "function",
+        0,
+        source.len(),
+    );
+
+    let view = graph
+        .show(
+            &"symbol:src/lib.rs#long_body:function"
+                .parse()
+                .expect("selector"),
+            7,
+        )
+        .expect("show symbol")
+        .expect("symbol resolves");
+
+    assert_eq!(view.bytes, b"pub fn ");
+    assert_eq!(
+        view.metadata.span,
+        SourceSpan {
+            start: 0,
+            end: source.len()
+        }
+    );
+    assert!(view.metadata.truncated);
+}
+
+#[test]
+fn show_missing_selector_returns_none() {
+    let worktree = TestWorktree::new("show-missing");
+    let source = "pub fn present() {}\n";
+    worktree.write("src/lib.rs", source);
+    let graph = open_graph(&worktree, SyncPolicy::Manual);
+    let conn = open_connection(&worktree);
+    insert_file(&conn, "src/lib.rs", "rust", source);
+
+    let missing = graph
+        .show(
+            &"symbol:src/lib.rs#missing:function"
+                .parse()
+                .expect("selector"),
+            DEFAULT_SHOW_MAX_BYTES,
+        )
+        .expect("show missing");
+
+    assert!(missing.is_none());
+}
+
+#[test]
+fn show_calls_ensure_synced_at_entry() {
+    let worktree = TestWorktree::new("show-ensure");
+    worktree.write("src/lib.rs", "pub fn auto_sync_show() {}\n");
+    let graph = open_graph(&worktree, SyncPolicy::OnRead);
+    let db_path = graph_db_path(&worktree);
+
+    let view = graph
+        .show(
+            &"file:src/lib.rs".parse().expect("file selector"),
+            DEFAULT_SHOW_MAX_BYTES,
+        )
+        .expect("show with on-read sync")
+        .expect("file resolves");
+
+    assert_eq!(sync_leader_count(db_path.as_path()), 1);
+    assert_eq!(view.metadata.file, "src/lib.rs");
+}
+
+#[test]
+fn show_unresolved_dir_selector_returns_none() {
+    let worktree = TestWorktree::new("show-dir");
+    let graph = open_graph(&worktree, SyncPolicy::Manual);
+
+    let view = graph
+        .show(
+            &"dir:src".parse().expect("dir selector"),
+            DEFAULT_SHOW_MAX_BYTES,
+        )
+        .expect("show dir");
+
+    assert!(view.is_none());
+}
+
+fn insert_command(
+    conn: &Connection,
+    name: &str,
+    file_path: &str,
+    span_start: usize,
+    handler_symbol: Option<i64>,
+) {
+    conn.execute(
+        "INSERT INTO commands (name, file_path, span_start, handler_symbol)
+         VALUES (?1, ?2, ?3, ?4)",
+        params![
+            name,
+            file_path,
+            i64::try_from(span_start).expect("command span fits"),
+            handler_symbol
+        ],
+    )
+    .expect("insert command row");
+}

--- a/crates/orbit-graph/src/query/tests/support.rs
+++ b/crates/orbit-graph/src/query/tests/support.rs
@@ -1,0 +1,109 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use rusqlite::{Connection, params};
+
+use crate::{EXTRACTOR_VERSION, Graph, SyncPolicy, resolve_db_path};
+
+pub(super) struct TestWorktree {
+    path: PathBuf,
+}
+
+impl TestWorktree {
+    pub(super) fn new(name: &str) -> Self {
+        let mut path = std::env::temp_dir();
+        let stamp = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system time after epoch")
+            .as_nanos();
+        path.push(format!(
+            "orbit-graph-query-{name}-{}-{stamp}",
+            std::process::id()
+        ));
+        fs::create_dir_all(&path).expect("create test worktree");
+        Self { path }
+    }
+
+    pub(super) fn path(&self) -> &Path {
+        self.path.as_path()
+    }
+
+    pub(super) fn write(&self, rel: &str, content: &str) {
+        let path = self.path.join(rel);
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).expect("create parent directory");
+        }
+        fs::write(path, content).expect("write source file");
+    }
+}
+
+impl Drop for TestWorktree {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.path);
+    }
+}
+
+pub(super) fn open_graph(worktree: &TestWorktree, policy: SyncPolicy) -> Graph {
+    Graph::open(worktree.path(), policy).expect("open graph")
+}
+
+pub(super) fn open_connection(worktree: &TestWorktree) -> Connection {
+    let conn = Connection::open(graph_db_path(worktree).as_path()).expect("open graph database");
+    conn.pragma_update(None, "foreign_keys", "ON")
+        .expect("enable foreign keys");
+    conn
+}
+
+pub(super) fn graph_db_path(worktree: &TestWorktree) -> PathBuf {
+    resolve_db_path(worktree.path(), "HEAD", EXTRACTOR_VERSION)
+        .path()
+        .to_path_buf()
+}
+
+pub(super) fn insert_file(conn: &Connection, path: &str, lang: &str, content: &str) {
+    conn.execute(
+        "INSERT INTO files (path, content_hash, mtime_ns, lang, byte_len, extracted_at)
+         VALUES (?1, x'00', 1, ?2, ?3, 2)",
+        params![
+            path,
+            lang,
+            i64::try_from(content.len()).expect("content length fits")
+        ],
+    )
+    .expect("insert file row");
+}
+
+pub(super) fn insert_symbol(
+    conn: &Connection,
+    file_path: &str,
+    name: &str,
+    qualified: &str,
+    kind: &str,
+    span_start: usize,
+    span_end: usize,
+) -> i64 {
+    conn.execute(
+        "INSERT INTO symbols (
+            file_path, name, qualified, kind, span_start, span_end, signature, parent_symbol
+         ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, NULL)",
+        params![
+            file_path,
+            name,
+            qualified,
+            kind,
+            i64::try_from(span_start).expect("span start fits"),
+            i64::try_from(span_end).expect("span end fits"),
+            format!("fn {name}()")
+        ],
+    )
+    .expect("insert symbol row");
+    let id = conn.last_insert_rowid();
+    conn.execute(
+        "INSERT INTO symbols_fts (rowid, name, qualified, signature)
+         VALUES (?1, ?2, ?3, ?4)",
+        params![id, name, qualified, format!("fn {name}()")],
+    )
+    .expect("insert symbol fts row");
+    id
+}

--- a/crates/orbit-graph/src/sync/pass1.rs
+++ b/crates/orbit-graph/src/sync/pass1.rs
@@ -282,6 +282,7 @@ fn delete_file_transaction(conn: &mut Connection, rel_path: &Path) -> Result<(),
     let tx = conn
         .transaction_with_behavior(TransactionBehavior::Immediate)
         .map_err(|source| GraphError::sqlite("begin pass1 delete transaction", source))?;
+    delete_fts_for_file(&tx, &normalize_path(rel_path))?;
     tx.execute(
         "DELETE FROM files WHERE path = ?1",
         params![normalize_path(rel_path)],
@@ -299,6 +300,7 @@ fn write_file_transaction(
     let tx = conn
         .transaction_with_behavior(TransactionBehavior::Immediate)
         .map_err(|source| GraphError::sqlite("begin pass1 file transaction", source))?;
+    delete_fts_for_file(&tx, &file.file_path)?;
     tx.execute("DELETE FROM files WHERE path = ?1", params![file.file_path])
         .map_err(|source| GraphError::sqlite("delete prior graph file rows", source))?;
     tx.execute(
@@ -348,7 +350,14 @@ fn insert_symbols(
             ],
         )
         .map_err(|source| GraphError::sqlite("insert graph symbol row", source))?;
-        symbol_ids.insert(symbol.qualified.clone(), tx.last_insert_rowid());
+        let symbol_id = tx.last_insert_rowid();
+        tx.execute(
+            "INSERT INTO symbols_fts (rowid, name, qualified, signature)
+             VALUES (?1, ?2, ?3, ?4)",
+            params![symbol_id, symbol.name, symbol.qualified, symbol.signature],
+        )
+        .map_err(|source| GraphError::sqlite("insert graph symbol fts row", source))?;
+        symbol_ids.insert(symbol.qualified.clone(), symbol_id);
     }
 
     for symbol in symbols {
@@ -427,6 +436,12 @@ fn insert_strings(
             ],
         )
         .map_err(|source| GraphError::sqlite("insert graph string row", source))?;
+        let string_id = tx.last_insert_rowid();
+        tx.execute(
+            "INSERT INTO strings_fts (rowid, value) VALUES (?1, ?2)",
+            params![string_id, string.value],
+        )
+        .map_err(|source| GraphError::sqlite("insert graph string fts row", source))?;
     }
     Ok(())
 }
@@ -444,7 +459,38 @@ fn insert_configs(tx: &Transaction<'_>, configs: &[RawConfig]) -> Result<(), Gra
             ],
         )
         .map_err(|source| GraphError::sqlite("insert graph config row", source))?;
+        let config_id = tx.last_insert_rowid();
+        tx.execute(
+            "INSERT INTO configs_fts (rowid, key) VALUES (?1, ?2)",
+            params![config_id, config.key],
+        )
+        .map_err(|source| GraphError::sqlite("insert graph config fts row", source))?;
     }
+    Ok(())
+}
+
+fn delete_fts_for_file(tx: &Transaction<'_>, file_path: &str) -> Result<(), GraphError> {
+    tx.execute(
+        "DELETE FROM symbols_fts WHERE rowid IN (
+            SELECT id FROM symbols WHERE file_path = ?1
+         )",
+        params![file_path],
+    )
+    .map_err(|source| GraphError::sqlite("delete prior symbol fts rows", source))?;
+    tx.execute(
+        "DELETE FROM strings_fts WHERE rowid IN (
+            SELECT id FROM strings WHERE file_path = ?1
+         )",
+        params![file_path],
+    )
+    .map_err(|source| GraphError::sqlite("delete prior string fts rows", source))?;
+    tx.execute(
+        "DELETE FROM configs_fts WHERE rowid IN (
+            SELECT id FROM configs WHERE file_path = ?1
+         )",
+        params![file_path],
+    )
+    .map_err(|source| GraphError::sqlite("delete prior config fts rows", source))?;
     Ok(())
 }
 

--- a/crates/orbit-graph/src/sync/tests/pass1.rs
+++ b/crates/orbit-graph/src/sync/tests/pass1.rs
@@ -246,6 +246,13 @@ fn insert_file_with_three_symbols(conn: &Connection, rel: &str) {
             ],
         )
         .expect("insert old symbol");
+        let id = conn.last_insert_rowid();
+        conn.execute(
+            "INSERT INTO symbols_fts (rowid, name, qualified, signature)
+             VALUES (?1, ?2, ?3, NULL)",
+            params![id, format!("old_{index}"), format!("crate::old_{index}")],
+        )
+        .expect("insert old symbol fts");
     }
 }
 
@@ -263,6 +270,12 @@ fn insert_file_anchored_rows(conn: &Connection, rel: &str) {
         params![rel],
     )
     .expect("insert symbol");
+    conn.execute(
+        "INSERT INTO symbols_fts (rowid, name, qualified, signature)
+         VALUES (1, 'run', 'crate::run', 'fn run()')",
+        [],
+    )
+    .expect("insert symbol fts");
     conn.execute(
         "INSERT INTO refs (
             from_file, from_span_start, from_span_end, target_name, target_qualified,
@@ -296,12 +309,24 @@ fn insert_file_anchored_rows(conn: &Connection, rel: &str) {
         params![rel],
     )
     .expect("insert string");
+    let string_id = conn.last_insert_rowid();
+    conn.execute(
+        "INSERT INTO strings_fts (rowid, value) VALUES (?1, 'hello world')",
+        params![string_id],
+    )
+    .expect("insert string fts");
     conn.execute(
         "INSERT INTO configs (file_path, line, key, kind)
          VALUES (?1, 1, 'app.name', 'toml')",
         params![rel],
     )
     .expect("insert config");
+    let config_id = conn.last_insert_rowid();
+    conn.execute(
+        "INSERT INTO configs_fts (rowid, key) VALUES (?1, 'app.name')",
+        params![config_id],
+    )
+    .expect("insert config fts");
 }
 
 fn open_test_connection(worktree: &Path) -> Connection {

--- a/crates/orbit-knowledge/src/commands/write.rs
+++ b/crates/orbit-knowledge/src/commands/write.rs
@@ -102,9 +102,9 @@ fn write(
         ));
     }
     let selector = parse_selector(&selector_str)?;
-    if matches!(selector, Selector::Dir { .. }) {
+    if !matches!(selector, Selector::File { .. } | Selector::Symbol { .. }) {
         return Err(KnowledgeError::invalid_data(
-            "graph.write does not accept dir selectors".to_string(),
+            "graph.write requires a file or symbol selector".to_string(),
         ));
     }
     let position_selector = parse_position_selector(position.as_deref())?;
@@ -157,7 +157,9 @@ fn write(
                             .map_err(write_err_to_orbit)
                     }
                 }
-                Selector::Dir { .. } => unreachable!(),
+                Selector::Dir { .. } | Selector::Module { .. } | Selector::Command { .. } => {
+                    unreachable!()
+                }
             },
         )
         .map_err(knowledge_error_from_orbit)?;

--- a/crates/orbit-knowledge/src/service/selectors.rs
+++ b/crates/orbit-knowledge/src/service/selectors.rs
@@ -43,6 +43,8 @@ impl<'a> GraphContextService<'a> {
             Selector::Dir { path } => path.trim_end_matches('/').to_string(),
             Selector::File { path } => path.clone(),
             Selector::Symbol { path, symbol, kind } => format!("{path}#{symbol}:{kind}"),
+            Selector::Module { qualified } => format!("module:{qualified}"),
+            Selector::Command { name } => format!("command:{name}"),
         };
 
         let node_id = self.location_index.get(key.as_str()).ok_or_else(|| {

--- a/crates/orbit-knowledge/src/service/task_graph.rs
+++ b/crates/orbit-knowledge/src/service/task_graph.rs
@@ -299,7 +299,7 @@ fn lock_targets_for_mutation(selector: &Selector, extra_files: &[&str]) -> Vec<S
             targets.push(selector.to_string());
             targets.push(format!("file:{path}"));
         }
-        Selector::Dir { .. } => {}
+        Selector::Dir { .. } | Selector::Module { .. } | Selector::Command { .. } => {}
     }
 
     for file in extra_files {

--- a/docs/design/orbit-graph/2_design.md
+++ b/docs/design/orbit-graph/2_design.md
@@ -206,8 +206,8 @@ impl Graph {
     pub fn open(worktree_root: &Path, policy: SyncPolicy) -> Result<Self, GraphError>;
     pub fn sync(&self, mode: SyncMode) -> Result<SyncReport, GraphError>;
 
-    pub fn search(&self, q: &SearchQuery)            -> Result<Vec<Match>, GraphError>;
-    pub fn show(&self, sel: &Selector)                -> Result<Option<NodeView>, GraphError>;
+    pub fn search(&self, q: &SearchQuery)            -> Result<SearchResult, GraphError>;
+    pub fn show(&self, sel: &Selector, max_bytes: usize) -> Result<Option<NodeView>, GraphError>;
     pub fn refs(&self, sel: &Selector, opts: &RefOpts)-> Result<RefResult, GraphError>;
     pub fn callees(&self, sel: &Selector)             -> Result<Vec<CalleeEdge>, GraphError>;
     pub fn impact(&self, sel: &Selector, depth: u8)   -> Result<ImpactResult, GraphError>;

--- a/docs/design/orbit-graph/specs/GRAPH_SPEC.md
+++ b/docs/design/orbit-graph/specs/GRAPH_SPEC.md
@@ -517,8 +517,8 @@ impl Graph {
     pub fn open(worktree_root: &Path, policy: SyncPolicy) -> Result<Self, GraphError>;
     pub fn sync(&self, mode: SyncMode) -> Result<SyncReport, GraphError>;
 
-    pub fn search(&self, q: &SearchQuery) -> Result<Vec<Match>, GraphError>;
-    pub fn show(&self, sel: &Selector) -> Result<Option<NodeView>, GraphError>;
+    pub fn search(&self, q: &SearchQuery) -> Result<SearchResult, GraphError>;
+    pub fn show(&self, sel: &Selector, max_bytes: usize) -> Result<Option<NodeView>, GraphError>;
     pub fn refs(&self, sel: &Selector, opts: &RefOpts) -> Result<RefResult, GraphError>;
     pub fn callees(&self, sel: &Selector) -> Result<Vec<CalleeEdge>, GraphError>;
     pub fn impact(&self, sel: &Selector, depth: u8) -> Result<ImpactResult, GraphError>;
@@ -616,4 +616,3 @@ These are deliberately deferred — not blockers for shipping the spec, but list
 - A long list of "why not LSP." Not actually a live option in this codebase.
 - Embedding / semantic search plans. Separate spec if and when needed.
 - A rollback story beyond Step 3's env var. If we get to Step 4 and need to roll back, that's a crisis, not a planned mode.
-

--- a/docs/design/orbit-graph/specs/selector_corpus.txt
+++ b/docs/design/orbit-graph/specs/selector_corpus.txt
@@ -2,3 +2,5 @@ dir:src/command
 file:src/lib.rs
 symbol:src/lib.rs#hello:function
 symbol:src/lib.rs#Greeter:trait
+module:orbit_core::scheduler
+command:task.update


### PR DESCRIPTION
## Task

[ORB-00313](https://orbit-cli.com/tasks/ORB-00313) — Implement orbit-graph search + show query commands

### Description

## Problem

GRAPH_SPEC.md §9.1 and §9.2 define two read-only query commands: search (FTS5 across symbols, strings, and configs tables) and show (selector to source bytes plus metadata). Both are the simplest read paths in the query surface — single-table or single-symbol lookups with no graph traversal — making them the natural first query tasks once Phase 3 lands.

## Why It Matters

search is the entry point agents use most often: 'find the symbol named X' or 'where does rate-limit appear in code'. show is the second-most-used: 'I have a selector, give me the source'. Landing them first means the rest of Phase 4 (refs, callees, impact, trace) can be integration-tested against working read paths, and the CLI scaffolding in Phase 5 has real commands to wire up.

## Constraints / Notes

- search queries the three FTS5 tables (symbols_fts, strings_fts, configs_fts) per GRAPH_SPEC.md §9.1. Default returns top 20 by relevance. CLI flags: --kind symbol|string|config (filter), --lang X (filter by files.lang).
- Output shape is the contract; downstream MCP tool wrappers (P5.2) serialize as-is. Do not rename fields.
- show parses a Selector (from orbit-graph-extract, already lifted in ORB-00300), resolves to a symbol or file or module or command, returns source bytes plus metadata. Bounded by a max_bytes parameter in the function signature (suggested default 64 KiB; pick a value and document the choice).
- Selector forms covered per GRAPH_SPEC.md §9.2: symbol form, file form, module form, command form. The parser is already done; this task consumes it.
- Both methods call self.ensure_synced at entry per ORB-00312 (P3.4) — single line at the top of each.
- No async on the public surface. Return JSON-serializable structs; the CLI and MCP serialize them.
- Performance budgets per GRAPH_SPEC.md §12: search under 5ms p95 over about 100k symbols; show is a single-row lookup plus a file byte read (sub-ms typically).
- Errors translate at the crate boundary per docs/design-patterns/error_translation.md. Sibling tests per docs/design-patterns/test_layout.md.

Plan ID: P4.1 (repurposed from a duplicated P4.3 — see comment thread). Depends on ORB-00312. Runs in parallel with ORB-00315 (P4.2 refs) and ORB-00314 (P4.3 callees). Gates Phase 5 (CLI/MCP wrappers consume these methods).

### Acceptance Criteria

- Graph search method implemented; queries symbols_fts unioned with strings_fts unioned with configs_fts and returns top 20 by FTS5 relevance unless --limit overrides
- --kind filter restricts results to one of symbol, string, or config; --lang filter restricts to rows whose backing file row has files.lang = ?
- Search output shape matches the JSON in GRAPH_SPEC.md §9.1: matches array of (kind, name-or-value, path, line)
- Graph show method implemented; resolves all four selector forms from spec §9.2 (symbol, file, module, command); returns source bytes (bounded by max_bytes) plus metadata (file, span, kind, qualified name when applicable)
- show with max_bytes shorter than the resolved span returns truncated bytes plus a truncated=true indicator in metadata
- show for a selector that does not resolve returns Ok(None), not an error
- Both Graph search and Graph show call self.ensure_synced at entry per the P3.4 contract — verifiable via tracing assertion or behavior test
- Performance smoke: search over a synthetic 10k-symbol fixture prints actual ms (no hard gate; P6.2 owns gating)
- cargo test -p orbit-graph query::search and query::show passes
- cargo clippy -p orbit-graph -- -D warnings passes

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Implemented `Graph::search` as a synchronous, JSON-serializable FTS5 query result over symbols, strings, and configs with kind/lang filters, default limit 20, line materialization for symbol spans, and `ensure_synced` at entry.
- Implemented `Graph::show` with bounded source bytes, metadata/truncation reporting, and resolution for symbol/file/module/command selectors; added `DEFAULT_SHOW_MAX_BYTES = 64 KiB`.
- Extended `orbit_graph_extract::Selector` to parse/display `module:` and `command:` selectors, updated selector corpus/docs, and adjusted orbit-knowledge exhaustive matches to preserve existing write/pack behavior.
- Populated and deleted FTS5 rows during pass1 sync, bumped `EXTRACTOR_VERSION` to avoid incompatible old empty-FTS graph DBs, and added learning L-0052 for that storage invariant.
- Added focused query search/show tests, a 10k-symbol search performance smoke, and pass1 fixture updates for the FTS invariant.

Assessment: The scoped query paths are implemented and validated. Search/show call `ensure_synced`, return serializable structs matching the spec shape, and existing graph sync tests still pass.

Strategic decisions:
- Return `SearchResult { matches }` instead of a bare `Vec<Match>` | Rationale: GRAPH_SPEC §9.1 and downstream tool serialization require a top-level `matches` array.
- Bump `EXTRACTOR_VERSION` | Rationale: existing DBs may have content rows without FTS index rows, and incremental FTS deletes against that state can fail as malformed.

Validation:
- `cargo test -p orbit-graph query::search` passed
- `cargo test -p orbit-graph query::show` passed
- `cargo test -p orbit-graph sync::pass1` passed
- `cargo test -p orbit-graph` passed
- `cargo test -p orbit-graph-extract selector` passed
- `cargo check -p orbit-knowledge` passed
- `cargo check -p orbit-knowledge -p orbit-core` passed earlier after selector compatibility changes
- `cargo clippy -p orbit-graph -- -D warnings` passed
- `make ci-fast` passed
- `git diff --check` passed

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-00313-6a13c061`
- Behind base: 0
- Ahead of base: 1