### PR TITLE
Implement orbit-graph-cli crate with seven subcommands

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -30,6 +30,8 @@ flowchart LR
   Search --> Common
   SearchCompanion["orbit-search-companion"] --> Search
   SearchCompanion --> Common
+  GraphCli["orbit-graph-cli"] --> Graph
+  GraphCli --> GraphExtract
   MCP --> Common
   Dashboard["orbit-dashboard"] --> Core
   Dashboard --> Knowledge
@@ -50,7 +52,8 @@ flowchart LR
 - **orbit-search-companion**: separately installed search companion binary. Depends on `orbit-search` and fastembed-rs; not linked into the default `orbit` CLI binary.
 - **orbit-registry**: generic replicated registry substrate for publication flows. Opaque-bytes payloads + caller-chosen merge classes; optional `transport-git2` feature for git-backed replicas. Depends only on `orbit-common`.
 - **orbit-graph-extract**: pure graph extraction contracts and language-specific tree-sitter extractors for the orbit-graph migration. Owns `Extractor`, `ExtractedFile`, raw row shapes, and the stable `Selector` parser; no internal crate dependencies, storage, async, or filesystem traversal.
-- **orbit-graph**: SQLite graph store, sync policy, and query API skeleton for the orbit-graph migration. Depends on `orbit-graph-extract` for selector/extraction contracts; storage and query implementations land in later phase tasks.
+- **orbit-graph**: SQLite graph store, sync policy, and query API for the orbit-graph migration. Depends on `orbit-graph-extract` for selector/extraction contracts.
+- **orbit-graph-cli**: clap-based JSON command surface for the orbit-graph migration. Depends on `orbit-graph` for sync/query dispatch and `orbit-graph-extract` for selector parsing, without depending on `orbit-knowledge`.
 - **orbit-knowledge**: knowledge/graph parsing and storage helpers. Multi-language source parsing (Rust, Go, Java, JavaScript/TypeScript, Python). Depends on `orbit-common` and temporarily on `orbit-graph-extract` for the selector parser during the orbit-graph dual-run migration; consumed by `orbit-tools`, which exposes graph tool and CLI-use-case facades upstream.
 - **orbit-store**: layered store pattern (YAML + SQLite). Match existing modules when adding new ones. Depends only on `orbit-common`; the semantic vector schema is owned by `orbit-search::vector` (not `orbit-store`).
 - **orbit-tools**: tool registry plus built-in graph, fs, and policy-aware exec tools. Depends on `orbit-common`, `orbit-exec`, `orbit-knowledge`, `orbit-policy`.
@@ -82,6 +85,7 @@ Each workspace crate declares a stability tier in its `Cargo.toml` under `[packa
 | orbit-cli             | internal     |
 | orbit-core            | internal     |
 | orbit-graph           | internal     |
+| orbit-graph-cli       | internal     |
 | orbit-search           | internal     |
 | orbit-engine          | internal     |
 | orbit-exec            | internal     |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2252,6 +2252,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "orbit-graph-cli"
+version = "0.7.1"
+dependencies = [
+ "assert_cmd",
+ "clap",
+ "git2",
+ "orbit-graph",
+ "orbit-graph-extract",
+ "predicates",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "thiserror",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "orbit-graph-extract"
 version = "0.7.1"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ members = [
   "crates/orbit-core",
   "crates/orbit-engine",
   "crates/orbit-graph",
+  "crates/orbit-graph-cli",
   "crates/orbit-graph-extract",
   "crates/orbit-knowledge",
   "crates/orbit-store",
@@ -40,6 +41,7 @@ unwrap_used = "warn"
 missing_docs = "warn"
 
 [workspace.dependencies]
+assert_cmd = "2"
 axum = { version = "0.7", default-features = false, features = ["http1", "json", "query", "tokio"] }
 chrono = { version = "0.4", features = ["serde"] }
 clap = { version = "4.5", features = ["derive"] }
@@ -70,6 +72,8 @@ unicode-normalization = "0.1"
 url = "2"
 wait-timeout = "0.2"
 proptest = "1"
+predicates = "3"
+tempfile = "3"
 tree-sitter = "0.26"
 tree-sitter-c = "0.24.2"
 tree-sitter-c-sharp = "0.23.5"

--- a/crates/orbit-cli/Cargo.toml
+++ b/crates/orbit-cli/Cargo.toml
@@ -34,12 +34,12 @@ tracing.workspace = true
 url.workspace = true
 
 [dev-dependencies]
-assert_cmd = "2"
-predicates = "3"
+assert_cmd.workspace = true
+predicates.workspace = true
 rusqlite.workspace = true
 serde_json.workspace = true
 serde_yaml.workspace = true
-tempfile = "3"
+tempfile.workspace = true
 toml.workspace = true
 tower = { version = "0.5", features = ["util"] }
 

--- a/crates/orbit-graph-cli/Cargo.toml
+++ b/crates/orbit-graph-cli/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "orbit-graph-cli"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[package.metadata.orbit]
+stability = "internal"
+
+[lints]
+workspace = true
+
+[dependencies]
+clap.workspace = true
+git2.workspace = true
+orbit-graph = { path = "../orbit-graph" }
+orbit-graph-extract = { path = "../orbit-graph-extract" }
+serde.workspace = true
+serde_json.workspace = true
+thiserror.workspace = true
+tracing.workspace = true
+tracing-subscriber.workspace = true
+
+[dev-dependencies]
+assert_cmd.workspace = true
+predicates.workspace = true
+serde_json.workspace = true
+tempfile.workspace = true

--- a/crates/orbit-graph-cli/src/commands/callees.rs
+++ b/crates/orbit-graph-cli/src/commands/callees.rs
@@ -1,0 +1,19 @@
+use clap::Args;
+use orbit_graph_extract::Selector;
+
+use super::{CliError, CommandContext, json_value};
+
+#[derive(Debug, Args)]
+pub(crate) struct CalleesCommand {
+    symbol: String,
+}
+
+impl CalleesCommand {
+    pub(crate) fn run(&self, context: &CommandContext) -> Result<serde_json::Value, CliError> {
+        let graph = context.open_graph()?;
+        let selector = self.symbol.parse::<Selector>()?;
+        json_value(serde_json::json!({
+            "callees": graph.callees(&selector)?,
+        }))
+    }
+}

--- a/crates/orbit-graph-cli/src/commands/clean.rs
+++ b/crates/orbit-graph-cli/src/commands/clean.rs
@@ -1,0 +1,28 @@
+use clap::Args;
+use orbit_graph::clean_old_databases;
+use serde::Serialize;
+
+use super::{CliError, CommandContext, json_value};
+
+#[derive(Debug, Args)]
+pub(crate) struct CleanCommand;
+
+impl CleanCommand {
+    pub(crate) fn run(&self, context: &CommandContext) -> Result<serde_json::Value, CliError> {
+        let report = clean_old_databases(context.worktree_root.as_path())?;
+        json_value(CleanOutput {
+            graph_dir: report.graph_dir.display().to_string(),
+            deleted: report
+                .deleted
+                .iter()
+                .map(|path| path.display().to_string())
+                .collect(),
+        })
+    }
+}
+
+#[derive(Debug, Serialize)]
+struct CleanOutput {
+    graph_dir: String,
+    deleted: Vec<String>,
+}

--- a/crates/orbit-graph-cli/src/commands/db_path.rs
+++ b/crates/orbit-graph-cli/src/commands/db_path.rs
@@ -1,0 +1,26 @@
+use clap::Args;
+use serde::Serialize;
+
+use super::{CliError, CommandContext, json_value};
+
+#[derive(Debug, Args)]
+pub(crate) struct DbPathCommand;
+
+impl DbPathCommand {
+    pub(crate) fn run(&self, context: &CommandContext) -> Result<serde_json::Value, CliError> {
+        let graph = context.open_graph()?;
+        let db_path = graph.db_path();
+        json_value(DbPathOutput {
+            path: db_path.path().display().to_string(),
+            branch: db_path.branch().to_string(),
+            extractor_version: db_path.extractor_version(),
+        })
+    }
+}
+
+#[derive(Debug, Serialize)]
+struct DbPathOutput {
+    path: String,
+    branch: String,
+    extractor_version: u32,
+}

--- a/crates/orbit-graph-cli/src/commands/impact.rs
+++ b/crates/orbit-graph-cli/src/commands/impact.rs
@@ -1,0 +1,20 @@
+use clap::Args;
+use orbit_graph::DEFAULT_IMPACT_DEPTH;
+use orbit_graph_extract::Selector;
+
+use super::{CliError, CommandContext, json_value};
+
+#[derive(Debug, Args)]
+pub(crate) struct ImpactCommand {
+    selector: String,
+    #[arg(long, default_value_t = DEFAULT_IMPACT_DEPTH)]
+    depth: u8,
+}
+
+impl ImpactCommand {
+    pub(crate) fn run(&self, context: &CommandContext) -> Result<serde_json::Value, CliError> {
+        let graph = context.open_graph()?;
+        let selector = self.selector.parse::<Selector>()?;
+        json_value(graph.impact(&selector, self.depth)?)
+    }
+}

--- a/crates/orbit-graph-cli/src/commands/mod.rs
+++ b/crates/orbit-graph-cli/src/commands/mod.rs
@@ -1,0 +1,121 @@
+use std::env;
+use std::path::PathBuf;
+
+use clap::{Parser, Subcommand};
+use orbit_graph::{Graph, GraphError, SyncPolicy};
+use orbit_graph_extract::SelectorParseError;
+use serde::Serialize;
+use serde_json::Value;
+use thiserror::Error;
+
+mod callees;
+mod clean;
+mod db_path;
+mod impact;
+mod refs;
+mod search;
+mod show;
+mod sync;
+mod trace;
+mod version;
+
+#[derive(Debug, Parser)]
+#[command(name = "orbit-graph-cli", about = "Query the Orbit graph index")]
+pub struct Cli {
+    #[command(subcommand)]
+    command: Command,
+}
+
+impl Cli {
+    pub fn run(&self) -> Result<Value, CliError> {
+        let context = CommandContext::from_current_dir()?;
+        match &self.command {
+            Command::Sync(command) => command.run(&context),
+            Command::Search(command) => command.run(&context),
+            Command::Show(command) => command.run(&context),
+            Command::Refs(command) => command.run(&context),
+            Command::Callees(command) => command.run(&context),
+            Command::Impact(command) => command.run(&context),
+            Command::Trace(command) => command.run(&context),
+            Command::Version(command) => command.run(),
+            Command::DbPath(command) => command.run(&context),
+            Command::Clean(command) => command.run(&context),
+        }
+    }
+}
+
+#[derive(Debug, Subcommand)]
+enum Command {
+    Sync(sync::SyncCommand),
+    Search(search::SearchCommand),
+    Show(show::ShowCommand),
+    Refs(refs::RefsCommand),
+    Callees(callees::CalleesCommand),
+    Impact(impact::ImpactCommand),
+    Trace(trace::TraceCommand),
+    Version(version::VersionCommand),
+    DbPath(db_path::DbPathCommand),
+    Clean(clean::CleanCommand),
+}
+
+pub(crate) struct CommandContext {
+    worktree_root: PathBuf,
+}
+
+impl CommandContext {
+    fn from_current_dir() -> Result<Self, CliError> {
+        let current_dir = env::current_dir().map_err(CliError::CurrentDir)?;
+        let worktree_root = git2::Repository::discover(current_dir.as_path())
+            .ok()
+            .and_then(|repo| repo.workdir().map(PathBuf::from))
+            .unwrap_or(current_dir);
+        Ok(Self { worktree_root })
+    }
+
+    pub(crate) fn open_graph(&self) -> Result<Graph, CliError> {
+        Graph::open(self.worktree_root.as_path(), SyncPolicy::Manual).map_err(CliError::Graph)
+    }
+}
+
+pub(crate) fn json_value<T: Serialize>(value: T) -> Result<Value, CliError> {
+    serde_json::to_value(value).map_err(CliError::Json)
+}
+
+#[derive(Debug, Error)]
+pub enum CliError {
+    #[error(transparent)]
+    Clap(clap::Error),
+    #[error("failed to determine current directory: {0}")]
+    CurrentDir(std::io::Error),
+    #[error(transparent)]
+    Graph(#[from] GraphError),
+    #[error(transparent)]
+    Selector(#[from] SelectorParseError),
+    #[error("failed to serialize JSON: {0}")]
+    Json(serde_json::Error),
+    #[error("failed to write JSON to stdout: {0}")]
+    Stdout(std::io::Error),
+}
+
+impl CliError {
+    pub fn code(&self) -> &'static str {
+        match self {
+            Self::Clap(_) => "argument_error",
+            Self::CurrentDir(_) => "current_dir_error",
+            Self::Graph(_) => "graph_error",
+            Self::Selector(_) => "selector_parse_error",
+            Self::Json(_) => "json_error",
+            Self::Stdout(_) => "stdout_error",
+        }
+    }
+
+    pub fn details(&self) -> Option<&str> {
+        match self {
+            Self::Graph(GraphError::InvalidData { reason, .. }) => Some(reason.as_str()),
+            Self::Graph(GraphError::Io { reason, .. }) => Some(reason.as_str()),
+            Self::Graph(GraphError::Sqlite { reason, .. }) => Some(reason.as_str()),
+            Self::Graph(GraphError::Unimplemented) => None,
+            _ => None,
+        }
+    }
+}

--- a/crates/orbit-graph-cli/src/commands/refs.rs
+++ b/crates/orbit-graph-cli/src/commands/refs.rs
@@ -1,0 +1,74 @@
+use clap::{Args, ValueEnum};
+use orbit_graph::{RefConfidence, RefKind, RefOpts};
+use orbit_graph_extract::Selector;
+
+use super::{CliError, CommandContext, json_value};
+
+#[derive(Debug, Args)]
+pub(crate) struct RefsCommand {
+    symbol: String,
+    #[arg(long, value_enum, default_value_t = ConfidenceArg::SameModule)]
+    confidence: ConfidenceArg,
+    #[arg(long, value_enum)]
+    kind: Option<RefKindArg>,
+}
+
+impl RefsCommand {
+    pub(crate) fn run(&self, context: &CommandContext) -> Result<serde_json::Value, CliError> {
+        let graph = context.open_graph()?;
+        let selector = self.symbol.parse::<Selector>()?;
+        let opts = RefOpts {
+            confidence: self.confidence.into_graph(),
+            kind: self.kind.map(RefKindArg::into_graph),
+        };
+        json_value(graph.refs(&selector, &opts)?)
+    }
+}
+
+#[derive(Debug, Clone, Copy, ValueEnum)]
+#[clap(rename_all = "snake_case")]
+enum ConfidenceArg {
+    Exact,
+    #[value(alias = "import_resolved")]
+    Import,
+    SameModule,
+    #[value(alias = "fuzzy_name")]
+    Fuzzy,
+}
+
+impl ConfidenceArg {
+    fn into_graph(self) -> RefConfidence {
+        match self {
+            Self::Exact => RefConfidence::Exact,
+            Self::Import => RefConfidence::ImportResolved,
+            Self::SameModule => RefConfidence::SameModule,
+            Self::Fuzzy => RefConfidence::FuzzyName,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, ValueEnum)]
+#[clap(rename_all = "snake_case")]
+enum RefKindArg {
+    Call,
+    Type,
+    Use,
+    TraitBound,
+    Impl,
+    Extends,
+    Implements,
+}
+
+impl RefKindArg {
+    fn into_graph(self) -> RefKind {
+        match self {
+            Self::Call => RefKind::Call,
+            Self::Type => RefKind::Type,
+            Self::Use => RefKind::Use,
+            Self::TraitBound => RefKind::TraitBound,
+            Self::Impl => RefKind::Impl,
+            Self::Extends => RefKind::Extends,
+            Self::Implements => RefKind::Implements,
+        }
+    }
+}

--- a/crates/orbit-graph-cli/src/commands/search.rs
+++ b/crates/orbit-graph-cli/src/commands/search.rs
@@ -1,0 +1,45 @@
+use clap::{Args, ValueEnum};
+use orbit_graph::{SearchKind, SearchQuery};
+
+use super::{CliError, CommandContext, json_value};
+
+#[derive(Debug, Args)]
+pub(crate) struct SearchCommand {
+    query: String,
+    #[arg(long, value_enum)]
+    kind: Option<SearchKindArg>,
+    #[arg(long)]
+    lang: Option<String>,
+    #[arg(long)]
+    limit: Option<usize>,
+}
+
+impl SearchCommand {
+    pub(crate) fn run(&self, context: &CommandContext) -> Result<serde_json::Value, CliError> {
+        let graph = context.open_graph()?;
+        let query = SearchQuery {
+            query: self.query.clone(),
+            kind: self.kind.map(SearchKindArg::into_graph),
+            lang: self.lang.clone(),
+            limit: self.limit,
+        };
+        json_value(graph.search(&query)?)
+    }
+}
+
+#[derive(Debug, Clone, Copy, ValueEnum)]
+enum SearchKindArg {
+    Symbol,
+    String,
+    Config,
+}
+
+impl SearchKindArg {
+    fn into_graph(self) -> SearchKind {
+        match self {
+            Self::Symbol => SearchKind::Symbol,
+            Self::String => SearchKind::String,
+            Self::Config => SearchKind::Config,
+        }
+    }
+}

--- a/crates/orbit-graph-cli/src/commands/show.rs
+++ b/crates/orbit-graph-cli/src/commands/show.rs
@@ -1,0 +1,20 @@
+use clap::Args;
+use orbit_graph::DEFAULT_SHOW_MAX_BYTES;
+use orbit_graph_extract::Selector;
+
+use super::{CliError, CommandContext, json_value};
+
+#[derive(Debug, Args)]
+pub(crate) struct ShowCommand {
+    selector: String,
+    #[arg(long, default_value_t = DEFAULT_SHOW_MAX_BYTES)]
+    max_bytes: usize,
+}
+
+impl ShowCommand {
+    pub(crate) fn run(&self, context: &CommandContext) -> Result<serde_json::Value, CliError> {
+        let graph = context.open_graph()?;
+        let selector = self.selector.parse::<Selector>()?;
+        json_value(graph.show(&selector, self.max_bytes)?)
+    }
+}

--- a/crates/orbit-graph-cli/src/commands/sync.rs
+++ b/crates/orbit-graph-cli/src/commands/sync.rs
@@ -1,0 +1,42 @@
+use std::time::Duration;
+
+use clap::Args;
+use orbit_graph::SyncMode;
+use serde::Serialize;
+
+use super::{CliError, CommandContext, json_value};
+
+#[derive(Debug, Args)]
+pub(crate) struct SyncCommand {
+    #[arg(long)]
+    full: bool,
+}
+
+impl SyncCommand {
+    pub(crate) fn run(&self, context: &CommandContext) -> Result<serde_json::Value, CliError> {
+        let graph = context.open_graph()?;
+        let report = graph.sync(if self.full {
+            SyncMode::Full
+        } else {
+            SyncMode::Auto
+        })?;
+        json_value(SyncOutput {
+            files_indexed: report.files_indexed,
+            files_changed: report.files_changed,
+            files_removed: report.files_removed,
+            duration_ms: duration_millis(report.duration),
+        })
+    }
+}
+
+#[derive(Debug, Serialize)]
+struct SyncOutput {
+    files_indexed: usize,
+    files_changed: usize,
+    files_removed: usize,
+    duration_ms: u128,
+}
+
+fn duration_millis(duration: Duration) -> u128 {
+    duration.as_millis()
+}

--- a/crates/orbit-graph-cli/src/commands/trace.rs
+++ b/crates/orbit-graph-cli/src/commands/trace.rs
@@ -1,0 +1,18 @@
+use clap::Args;
+use orbit_graph::DEFAULT_TRACE_DEPTH;
+
+use super::{CliError, CommandContext, json_value};
+
+#[derive(Debug, Args)]
+pub(crate) struct TraceCommand {
+    command_name: String,
+    #[arg(long, default_value_t = DEFAULT_TRACE_DEPTH)]
+    depth: u8,
+}
+
+impl TraceCommand {
+    pub(crate) fn run(&self, context: &CommandContext) -> Result<serde_json::Value, CliError> {
+        let graph = context.open_graph()?;
+        json_value(graph.trace(self.command_name.as_str(), self.depth)?)
+    }
+}

--- a/crates/orbit-graph-cli/src/commands/version.rs
+++ b/crates/orbit-graph-cli/src/commands/version.rs
@@ -1,0 +1,23 @@
+use clap::Args;
+use orbit_graph::EXTRACTOR_VERSION;
+use serde::Serialize;
+
+use super::{CliError, json_value};
+
+#[derive(Debug, Args)]
+pub(crate) struct VersionCommand;
+
+impl VersionCommand {
+    pub(crate) fn run(&self) -> Result<serde_json::Value, CliError> {
+        json_value(VersionOutput {
+            crate_version: env!("CARGO_PKG_VERSION"),
+            extractor_version: EXTRACTOR_VERSION,
+        })
+    }
+}
+
+#[derive(Debug, Serialize)]
+struct VersionOutput {
+    crate_version: &'static str,
+    extractor_version: u32,
+}

--- a/crates/orbit-graph-cli/src/main.rs
+++ b/crates/orbit-graph-cli/src/main.rs
@@ -1,0 +1,76 @@
+#![allow(missing_docs)]
+
+//! JSON CLI for the SQLite-backed Orbit graph.
+
+mod commands;
+
+use std::io::{self, Write};
+use std::process::ExitCode;
+
+use clap::Parser;
+use serde::Serialize;
+use serde_json::json;
+use tracing_subscriber::EnvFilter;
+
+use crate::commands::{Cli, CliError};
+
+fn main() -> ExitCode {
+    init_tracing();
+
+    match run() {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(error) => {
+            let _ = write_json_to_stderr(&ErrorPayload::from(&error));
+            ExitCode::from(1)
+        }
+    }
+}
+
+fn run() -> Result<(), CliError> {
+    let cli = Cli::try_parse().map_err(CliError::Clap)?;
+    let output = cli.run()?;
+    write_json_to_stdout(&output)
+}
+
+fn init_tracing() {
+    let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("off"));
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter(filter)
+        .with_writer(io::stderr)
+        .with_target(false)
+        .without_time()
+        .try_init();
+}
+
+fn write_json_to_stdout<T: Serialize>(value: &T) -> Result<(), CliError> {
+    let mut stdout = io::stdout().lock();
+    serde_json::to_writer(&mut stdout, value).map_err(CliError::Json)?;
+    stdout.write_all(b"\n").map_err(CliError::Stdout)?;
+    stdout.flush().map_err(CliError::Stdout)
+}
+
+fn write_json_to_stderr<T: Serialize>(value: &T) -> io::Result<()> {
+    let mut stderr = io::stderr().lock();
+    serde_json::to_writer(&mut stderr, value)?;
+    stderr.write_all(b"\n")?;
+    stderr.flush()
+}
+
+#[derive(Debug, Serialize)]
+struct ErrorPayload<'a> {
+    error: serde_json::Value,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    details: Option<&'a str>,
+}
+
+impl<'a> From<&'a CliError> for ErrorPayload<'a> {
+    fn from(error: &'a CliError) -> Self {
+        Self {
+            error: json!({
+                "code": error.code(),
+                "message": error.to_string(),
+            }),
+            details: error.details(),
+        }
+    }
+}

--- a/crates/orbit-graph-cli/tests/subcommands.rs
+++ b/crates/orbit-graph-cli/tests/subcommands.rs
@@ -1,0 +1,192 @@
+#![allow(missing_docs)]
+
+use std::fs;
+use std::path::Path;
+use std::process::Command as StdCommand;
+
+use assert_cmd::Command;
+use predicates::prelude::*;
+use serde_json::Value;
+use tempfile::TempDir;
+
+#[test]
+fn query_and_admin_subcommands_emit_json() {
+    let worktree = fixture_worktree();
+
+    let sync = run_json(worktree.path(), ["sync", "--full"]);
+    assert_eq!(sync["files_removed"], 0);
+    assert!(sync["files_indexed"].as_u64().expect("files_indexed") >= 1);
+
+    let search = run_json(
+        worktree.path(),
+        ["search", "helper", "--kind", "symbol", "--limit", "5"],
+    );
+    assert_array_field(&search, "matches");
+
+    let show = run_json(
+        worktree.path(),
+        [
+            "show",
+            "symbol:src/lib.rs#entry:function",
+            "--max-bytes",
+            "256",
+        ],
+    );
+    assert_eq!(show["metadata"]["file"], "src/lib.rs");
+    assert_array_field(&show, "bytes");
+
+    let refs = run_json(
+        worktree.path(),
+        [
+            "refs",
+            "symbol:src/lib.rs#helper:function",
+            "--confidence",
+            "fuzzy",
+            "--kind",
+            "call",
+        ],
+    );
+    assert!(refs.get("target").is_some());
+    assert_array_field(&refs, "refs");
+    assert_array_field(&refs, "relations");
+
+    let callees = run_json(
+        worktree.path(),
+        ["callees", "symbol:src/lib.rs#entry:function"],
+    );
+    assert_array_field(&callees, "callees");
+
+    let impact = run_json(
+        worktree.path(),
+        ["impact", "symbol:src/lib.rs#entry:function", "--depth", "2"],
+    );
+    assert_array_field(&impact, "touched");
+    assert!(impact.get("visited_nodes").is_some());
+
+    let trace = run_json(
+        worktree.path(),
+        ["trace", "missing-command", "--depth", "2"],
+    );
+    assert!(trace["root"].is_null());
+    assert_eq!(trace["visited_nodes"], 0);
+
+    let version = run_json(worktree.path(), ["version"]);
+    assert_eq!(version["crate_version"], env!("CARGO_PKG_VERSION"));
+    assert!(
+        version["extractor_version"]
+            .as_u64()
+            .expect("extractor_version")
+            > 0
+    );
+
+    let db_path = run_json(worktree.path(), ["db-path"]);
+    assert!(
+        db_path["path"]
+            .as_str()
+            .expect("db path string")
+            .ends_with(".db")
+    );
+    assert!(db_path.get("branch").is_some());
+
+    let graph_dir = worktree.path().join(".orbit").join("graph");
+    fs::create_dir_all(&graph_dir).expect("create graph dir");
+    let old_db = graph_dir.join("main.1.db");
+    fs::write(&old_db, b"stale").expect("write stale db");
+    let clean = run_json(worktree.path(), ["clean"]);
+    let deleted = clean["deleted"].as_array().expect("deleted array");
+    assert!(deleted.iter().any(|path| {
+        path.as_str()
+            .is_some_and(|path| path.ends_with("main.1.db"))
+    }));
+    assert!(!old_db.exists());
+}
+
+#[test]
+fn invalid_selector_errors_are_json_on_stderr() {
+    let worktree = fixture_worktree();
+    let mut command = graph_cli_command();
+    command
+        .current_dir(worktree.path())
+        .args(["show", "not-a-selector"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "\"code\":\"selector_parse_error\"",
+        ));
+}
+
+fn run_json<const N: usize>(worktree: &Path, args: [&str; N]) -> Value {
+    let mut command = graph_cli_command();
+    let output = command
+        .current_dir(worktree)
+        .args(args)
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    serde_json::from_slice(&output).expect("stdout is JSON")
+}
+
+fn graph_cli_command() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_orbit-graph-cli"))
+}
+
+fn assert_array_field(value: &Value, field: &str) {
+    assert!(
+        value.get(field).and_then(Value::as_array).is_some(),
+        "{field} should be an array in {value}"
+    );
+}
+
+fn fixture_worktree() -> TempDir {
+    let tempdir = TempDir::new().expect("temp worktree");
+    run_git(tempdir.path(), ["init", "-b", "main"]);
+    run_git(
+        tempdir.path(),
+        ["config", "user.email", "orbit@example.invalid"],
+    );
+    run_git(tempdir.path(), ["config", "user.name", "Orbit Test"]);
+
+    fs::create_dir_all(tempdir.path().join("src")).expect("create src");
+    fs::write(
+        tempdir.path().join("src/lib.rs"),
+        r#"
+pub fn helper() -> i32 {
+    1
+}
+
+pub fn entry() -> i32 {
+    helper()
+}
+
+pub fn caller() -> i32 {
+    entry()
+}
+"#,
+    )
+    .expect("write fixture");
+    fs::write(
+        tempdir.path().join("Cargo.toml"),
+        "[package]\nname = \"graph_cli_fixture\"\nversion = \"0.0.0\"\nedition = \"2024\"\n",
+    )
+    .expect("write manifest");
+
+    run_git(tempdir.path(), ["add", "."]);
+    run_git(tempdir.path(), ["commit", "-m", "fixture"]);
+    tempdir
+}
+
+fn run_git<const N: usize>(worktree: &Path, args: [&str; N]) {
+    let output = StdCommand::new("git")
+        .current_dir(worktree)
+        .args(args)
+        .output()
+        .expect("run git");
+    assert!(
+        output.status.success(),
+        "git failed: stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}

--- a/crates/orbit-graph/src/lib.rs
+++ b/crates/orbit-graph/src/lib.rs
@@ -8,6 +8,7 @@
 //! the stable schema.
 
 use std::fmt::{Display, Formatter};
+use std::fs;
 use std::path::{Path, PathBuf};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
@@ -70,6 +71,11 @@ impl Graph {
     /// Synchronize indexed rows with files on disk.
     pub fn sync(&self, mode: SyncMode) -> Result<SyncReport, GraphError> {
         sync::run(self.db_path.path(), self.worktree_root.as_path(), mode)
+    }
+
+    /// Return the resolved database path backing this graph handle.
+    pub fn db_path(&self) -> &GraphDbPath {
+        &self.db_path
     }
 
     pub(crate) fn ensure_synced(&self) -> Result<(), GraphError> {
@@ -398,6 +404,66 @@ pub fn resolve_db_path(worktree_root: &Path, branch: &str, extractor_version: u3
     }
 }
 
+/// Delete graph database files whose filename embeds an old extractor version.
+pub fn clean_old_databases(worktree_root: &Path) -> Result<CleanReport, GraphError> {
+    let graph = Graph::open(worktree_root, SyncPolicy::Manual)?;
+    let graph_dir = graph
+        .db_path
+        .path()
+        .parent()
+        .map(Path::to_path_buf)
+        .unwrap_or_else(|| worktree_root.join(".orbit").join("graph"));
+    let mut deleted = Vec::new();
+
+    if !graph_dir.exists() {
+        return Ok(CleanReport { graph_dir, deleted });
+    }
+
+    let entries = fs::read_dir(graph_dir.as_path())
+        .map_err(|source| GraphError::io("read graph database directory", &graph_dir, source))?;
+    for entry in entries {
+        let entry = entry.map_err(|source| {
+            GraphError::io("read graph database directory entry", &graph_dir, source)
+        })?;
+        let path = entry.path();
+        if !path.is_file() {
+            continue;
+        }
+        let Some(file_name) = path.file_name().and_then(|name| name.to_str()) else {
+            continue;
+        };
+        if graph_db_file_extractor_version(file_name)
+            .is_some_and(|version| version != EXTRACTOR_VERSION)
+        {
+            fs::remove_file(path.as_path()).map_err(|source| {
+                GraphError::io("delete old graph database file", &path, source)
+            })?;
+            deleted.push(path);
+        }
+    }
+    deleted.sort();
+
+    Ok(CleanReport { graph_dir, deleted })
+}
+
+fn graph_db_file_extractor_version(file_name: &str) -> Option<u32> {
+    let db_name = file_name
+        .strip_suffix(".db")
+        .or_else(|| file_name.strip_suffix(".db-wal"))
+        .or_else(|| file_name.strip_suffix(".db-shm"))
+        .or_else(|| file_name.strip_suffix(".db.lock"))?;
+    db_name.rsplit_once('.')?.1.parse().ok()
+}
+
+/// Summary returned after removing stale graph database files.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct CleanReport {
+    /// Directory scanned for graph database files.
+    pub graph_dir: PathBuf,
+    /// Files deleted because their extractor version was not current.
+    pub deleted: Vec<PathBuf>,
+}
+
 /// Reference query options for [`Graph::refs`].
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RefOpts {
@@ -501,7 +567,7 @@ pub struct RelationEntry {
 }
 
 /// Outbound call edge returned by [`Graph::callees`].
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct CalleeEdge {
     /// Short target name as written in the call site.
     pub target_name: String,

--- a/scripts/check-dependency-direction.sh
+++ b/scripts/check-dependency-direction.sh
@@ -28,6 +28,9 @@ allowed_internal_deps() {
     orbit-graph)
       echo "orbit-graph-extract"
       ;;
+    orbit-graph-cli)
+      echo "orbit-graph orbit-graph-extract"
+      ;;
     orbit-tools)
       echo "orbit-common orbit-exec orbit-knowledge orbit-policy"
       ;;


### PR DESCRIPTION
## Task

[ORB-00318](https://orbit-cli.com/tasks/ORB-00318) — Implement orbit-graph-cli crate with seven subcommands

### Description

## Problem

[GRAPH_SPEC.md §9](docs/design/orbit-graph/specs/GRAPH_SPEC.md) defines seven user-facing commands: sync, search, show, refs, callees, impact, trace. After Phase 4 lands the Graph API methods, this task wraps them in a CLI binary `orbit-graph-cli` exposing `orbit graph <cmd>` subcommands per [2_design.md §1](docs/design/orbit-graph/2_design.md). The CLI does no semantic work — only argument parsing, Graph::open, method dispatch, JSON serialization, and error mapping.

## Why It Matters

This is the first reachable surface for orbit-graph. Without it, the Graph API only runs from Rust callers. Landing the CLI enables manual smoke testing on real worktrees, lets the equivalence harness ([ORB-00297](.orbit/tasks/ORB-00297)) drive v2 outputs side-by-side with v1, and unlocks broader integration with the orbit ecosystem (orbit binary subcommand wiring, skills that shell out, etc.).

## Constraints / Notes

- Crate path: `crates/orbit-graph-cli/` per [GRAPH_SPEC.md §5](docs/design/orbit-graph/specs/GRAPH_SPEC.md). Add to workspace [Cargo.toml](Cargo.toml) members.
- Use the workspace clap dep with the derive feature (matches other CLI crates in the workspace).
- CLI surface: each subcommand maps 1:1 to a Graph method. Subcommand list per GRAPH_SPEC.md §9 (seven query commands) plus three admin commands from §3 (version, db-path, clean) — these admin commands are not counted against the seven-command query surface but they belong in the same binary.
- Default SyncPolicy for the CLI: Manual per [GRAPH_SPEC.md §8.3](docs/design/orbit-graph/specs/GRAPH_SPEC.md). CLI users are explicit — sync is its own subcommand.
- Output: JSON to stdout via serde-json. No human-readable formatting in this task — the orbit binary handles pretty-printing one layer up if needed.
- Errors: typed at the crate boundary per [docs/design-patterns/error_translation.md](docs/design-patterns/error_translation.md); mapped to non-zero exit codes at main(); JSON error payloads to stderr for machine consumers.
- Diagnostic logging via tracing per CLAUDE.md — no eprint! / println! calls. The workspace tracing-subscriber init pattern from other CLI crates applies.
- The CLI must NOT depend on orbit-knowledge. Only orbit-graph + orbit-graph-extract + workspace deps.
- No MCP code in this task — that is P5.2.
- Sibling test layout per [docs/design-patterns/test_layout.md](docs/design-patterns/test_layout.md). Subprocess-driven integration tests via assert_cmd over a temp-dir worktree are appropriate.

Plan ID: P5.1. Depends on all five Phase 4 tasks: ORB-00313 (search + show), ORB-00315 (refs), ORB-00314 (callees), ORB-00316 (impact), ORB-00317 (trace). Gates P5.2 (MCP wrappers) and Phase 6 harness wiring.

### Acceptance Criteria

- crates/orbit-graph-cli/Cargo.toml exists with [lints] workspace = true, declares dependencies on orbit-graph and orbit-graph-extract, declares clap with the derive feature
- Workspace root Cargo.toml [workspace] members lists crates/orbit-graph-cli
- src/main.rs entry point; src/commands/ subdirectory contains one file per subcommand
- Seven query subcommands implemented per GRAPH_SPEC.md §9: sync (with --full flag), search (with --kind, --lang, --limit flags), show (with --max-bytes flag), refs (with --confidence and --kind flags), callees, impact (with --depth flag), trace (with --depth flag)
- Three admin subcommands implemented per GRAPH_SPEC.md §3: version (prints crate version + EXTRACTOR_VERSION), db-path (prints the resolved DB path for the current worktree + branch), clean (deletes old extractor-version DB files in .orbit/graph/)
- CLI passes SyncPolicy::Manual to Graph::open — CLI users are explicit per GRAPH_SPEC.md §8.3
- All command output is JSON written to stdout via serde-json; output field shapes match the JSON contracts in GRAPH_SPEC.md §9
- Errors map to non-zero exit codes; error payloads written to stderr as JSON; diagnostic logging uses tracing per CLAUDE.md (no eprint! / println! calls)
- No dependency on crates/orbit-knowledge — verified with cargo tree -p orbit-graph-cli not showing orbit-knowledge
- Integration tests under crates/orbit-graph-cli/tests/ create a temp worktree with a small rust fixture, run each subcommand via assert_cmd or equivalent, and assert the output JSON shape
- cargo build -p orbit-graph-cli succeeds
- cargo test -p orbit-graph-cli passes
- cargo clippy -p orbit-graph-cli -- -D warnings passes under workspace lint config

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Added the `orbit-graph-cli` workspace crate with JSON stdout/stderr handling, tracing initialization, and one command module per sync/search/show/refs/callees/impact/trace/version/db-path/clean subcommand.
- Wired all graph commands through `Graph::open(..., SyncPolicy::Manual)` and serialized API results to the GRAPH_SPEC-shaped JSON surfaces.
- Added graph support for exposing the resolved DB path, serializing callee edges, and cleaning old extractor-version DB files.
- Updated workspace membership, dependency-direction/stability architecture metadata, and moved shared test dependencies to workspace-managed declarations.
- Added assert_cmd integration tests that build a temp git worktree, sync a Rust fixture, exercise every subcommand, and assert JSON output/error shape.

Assessment: The crate builds, tests, and passes clippy under workspace lints; `cargo tree -p orbit-graph-cli --edges all` has no `orbit-knowledge` dependency.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-00318-6a13d535`
- Behind base: 0
- Ahead of base: 1