### PR TITLE
Wire graph_bench.rs to CI with regression gate against bench/baselines.json

### DIFF
--- a/.github/workflows/ci-bench.yml
+++ b/.github/workflows/ci-bench.yml
@@ -1,0 +1,90 @@
+name: Graph Bench
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled, edited]
+    paths:
+      - "crates/**/*.rs"
+      - "tools/**/*.rs"
+      - "Cargo.toml"
+      - "crates/**/Cargo.toml"
+      - "tools/**/Cargo.toml"
+      - "Cargo.lock"
+      - "bench/baselines.json"
+      - "bench/check_baseline.sh"
+      - "bench/run_graph_bench_ci.sh"
+      - ".github/workflows/ci-bench.yml"
+
+permissions:
+  contents: read
+
+env:
+  CARGO_TERM_COLOR: always
+  GRAPH_BENCH_RUNS: 3
+  GRAPH_BENCH_RUNNER_IMAGE: ubuntu-24.04
+
+jobs:
+  ci-bench:
+    name: Graph Bench
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          ref: ${{ github.head_ref }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable (2026-05-07)
+
+      - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-graph-bench-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-graph-bench-cargo-
+            ${{ runner.os }}-cargo-
+
+      - name: Verify runner profile
+        run: |
+          set -euo pipefail
+          cores="$(getconf _NPROCESSORS_ONLN)"
+          memory_mib="$(awk '/MemTotal/ { print int($2 / 1024) }' /proc/meminfo)"
+          if [[ "$cores" -ne 4 || "$memory_mib" -lt 15000 || "$memory_mib" -gt 17000 ]]; then
+            echo "::error::Graph benchmark requires ubuntu-24.04 with 4 vCPU and approximately 16GB RAM; saw ${cores} cores and ${memory_mib} MiB."
+            exit 1
+          fi
+
+      - name: Run graph benchmark
+        run: ./bench/run_graph_bench_ci.sh
+
+      - name: Upload graph benchmark results
+        if: always() && hashFiles('target/bench/results.json') != ''
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: graph-bench-results
+          path: target/bench/results.json
+          if-no-files-found: error
+
+      - name: Validate baseline bump justification
+        id: baseline_bump
+        run: |
+          set -euo pipefail
+          has_bump_label="$(jq -r 'any(.pull_request.labels[]?; .name == "bench-baseline-bump")' "$GITHUB_EVENT_PATH")"
+          echo "has_bump_label=${has_bump_label}" >> "$GITHUB_OUTPUT"
+
+          if [[ "$has_bump_label" == "true" ]]; then
+            if ! jq -e '(.pull_request.body // "") | test("^\\s*bench-baseline-bump\\s*:\\s*\\S"; "im")' "$GITHUB_EVENT_PATH" >/dev/null; then
+              echo "::error::PRs labeled bench-baseline-bump must include a one-line PR body justification like 'bench-baseline-bump: <reason>'."
+              exit 1
+            fi
+          fi
+
+      - name: Check graph benchmark baseline
+        if: steps.baseline_bump.outputs.has_bump_label != 'true'
+        run: ./bench/check_baseline.sh --results target/bench/results.json --baseline bench/baselines.json
+
+      - name: Note baseline bump bypass
+        if: steps.baseline_bump.outputs.has_bump_label == 'true'
+        run: echo "bench-baseline-bump label present; baseline regression check bypassed after PR-body justification validation."

--- a/bench/README.md
+++ b/bench/README.md
@@ -36,9 +36,42 @@ P6.2 owns wiring the permanent `graph_bench.rs` CI gate. Once that lands, use
 the gate artifact under `target/bench/` as the capture source instead of an
 ad-hoc capture script.
 
+## CI Regression Gate
+
+The `Graph Bench / Graph Bench` PR job runs on the pinned
+`ubuntu-24.04` runner profile from the spec. The workflow is path-filtered to
+Rust source, Cargo, graph-bench, and workflow files so docs-only PRs do not
+spend a benchmark runner.
+
+The job builds the release benchmark binaries, runs the graph benchmark three
+times, and writes `target/bench/results.json`. Each reported row stores the raw
+samples and the median value used for the gate. The artifact is uploaded as
+`graph-bench-results` on the PR's Actions page.
+
+Gate decision for ORB-00321: v2 `orbit-graph` rows are gated against
+`bench/baselines.json`; v1 `orbit-knowledge` rows from `graph_bench.rs` remain
+informational in the artifact. GRAPH_SPEC section 12 sets budgets for the v2
+implementation, while the v1 rows are retained during the transition so
+reviewers can compare old and new behavior.
+
+`bench/check_baseline.sh` compares every gated row in
+`target/bench/results.json` against the committed baseline row with the same
+ID. A row fails when its median value is more than 20 percent slower than the
+baseline value.
+
 ## Updating Baselines
 
 A PR that changes `bench/baselines.json` must have the
 `bench-baseline-bump` label and a one-line justification in the PR body.
+Use a line in this exact form so CI can verify it:
+
+```text
+bench-baseline-bump: <why this baseline change is intentional>
+```
+
+When the label and justification are present, CI still runs the benchmark and
+uploads `target/bench/results.json`, but skips the regression check. Without
+the label, or with the label but no justification line, the gate runs normally
+or fails the PR-body validation.
 Routine performance wins should bump the baseline down. Routine performance
 drift should not bump the baseline; fix the regression instead.

--- a/bench/check_baseline.sh
+++ b/bench/check_baseline.sh
@@ -1,0 +1,144 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$repo_root"
+
+baseline_path="bench/baselines.json"
+results_path="target/bench/results.json"
+threshold_percent="20"
+
+usage() {
+  cat <<'EOF'
+Usage: bench/check_baseline.sh [--baseline PATH] [--results PATH] [--threshold-percent N]
+
+Compares gated rows in target/bench/results.json against bench/baselines.json.
+Rows fail when their median value is more than N percent slower than baseline.
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --baseline)
+      baseline_path="$2"
+      shift 2
+      ;;
+    --results)
+      results_path="$2"
+      shift 2
+      ;;
+    --threshold-percent)
+      threshold_percent="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ ! -f "$baseline_path" ]]; then
+  echo "baseline file not found: $baseline_path" >&2
+  exit 2
+fi
+
+if [[ ! -f "$results_path" ]]; then
+  echo "results file not found: $results_path" >&2
+  exit 2
+fi
+
+report="$(
+  jq -n \
+    --slurpfile baseline "$baseline_path" \
+    --slurpfile results "$results_path" \
+    --argjson threshold_percent "$threshold_percent" '
+      ($baseline[0].rows // []) as $baseline_rows
+      | ($results[0].rows // []) as $result_rows
+      | (($threshold_percent + 100) / 100) as $multiplier
+      | def baseline_row($id):
+          first($baseline_rows[] | select(.id == $id));
+        [ $result_rows[] | select(.gate != false) ] as $gated
+      | {
+          checked: [
+            $gated[] as $row
+            | ($row.baseline_id // $row.id) as $baseline_id
+            | (baseline_row($baseline_id)) as $baseline
+            | select($baseline != null and (($baseline.baseline.value // null) != null))
+            | {
+                id: $row.id,
+                baseline_id: $baseline_id,
+                implementation: ($row.implementation // "unknown"),
+                value: $row.value,
+                baseline_value: $baseline.baseline.value,
+                unit: ($row.unit // ""),
+                baseline_unit: ($baseline.baseline.unit // ""),
+                limit: ($baseline.baseline.value * $multiplier),
+                slower_percent: (
+                  if ($baseline.baseline.value | tonumber) > 0 then
+                    (($row.value - $baseline.baseline.value) / $baseline.baseline.value * 100)
+                  else
+                    null
+                  end
+                )
+              }
+          ],
+          missing: [
+            $gated[] as $row
+            | ($row.baseline_id // $row.id) as $baseline_id
+            | select((baseline_row($baseline_id)) == null)
+            | { id: $row.id, baseline_id: $baseline_id }
+          ],
+          invalid_baselines: [
+            $gated[] as $row
+            | ($row.baseline_id // $row.id) as $baseline_id
+            | (baseline_row($baseline_id)) as $baseline
+            | select($baseline != null and (($baseline.baseline.value // null) == null or ($baseline.baseline.value | tonumber) <= 0))
+            | { id: $row.id, baseline_id: $baseline_id }
+          ]
+        }
+      | . + {
+          unit_mismatches: [
+            .checked[]
+            | select(.unit != .baseline_unit)
+            | { id, unit, baseline_unit }
+          ],
+          regressions: [
+            .checked[]
+            | select(.value > .limit)
+          ]
+        }
+    '
+)"
+
+echo "$report" | jq -r '
+  .checked[]
+  | "\(.id) [\(.implementation)]: \(.value)\(.unit) vs baseline \(.baseline_value)\(.baseline_unit) (limit \(.limit | floor)\(.baseline_unit))"
+'
+
+if [[ "$(echo "$report" | jq '.checked | length')" -eq 0 ]]; then
+  echo "no gated result rows found in $results_path" >&2
+  exit 1
+fi
+
+if ! echo "$report" | jq -e '
+  (.missing | length) == 0
+  and (.invalid_baselines | length) == 0
+  and (.unit_mismatches | length) == 0
+  and (.regressions | length) == 0
+' >/dev/null; then
+  echo "$report" | jq -r '
+    (.missing[]? | "missing baseline for result row \(.id) (baseline_id=\(.baseline_id))"),
+    (.invalid_baselines[]? | "invalid baseline for result row \(.id) (baseline_id=\(.baseline_id))"),
+    (.unit_mismatches[]? | "unit mismatch for \(.id): result \(.unit), baseline \(.baseline_unit)"),
+    (.regressions[]? | "regression: \(.id) [\(.implementation)] \(.value)\(.unit) is \(.slower_percent | floor)% slower than baseline \(.baseline_value)\(.baseline_unit)")
+  ' >&2
+  exit 1
+fi
+
+echo "graph benchmark baseline check passed"

--- a/bench/run_graph_bench_ci.sh
+++ b/bench/run_graph_bench_ci.sh
@@ -1,0 +1,241 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$repo_root"
+
+run_count="${GRAPH_BENCH_RUNS:-3}"
+if ! [[ "$run_count" =~ ^[0-9]+$ ]] || (( run_count < 1 )); then
+  echo "GRAPH_BENCH_RUNS must be a positive integer" >&2
+  exit 2
+fi
+
+target_dir="${GRAPH_BENCH_TARGET_DIR:-target/bench}"
+samples_path="$target_dir/samples.ndjson"
+results_path="$target_dir/results.json"
+touch_path="crates/orbit-graph-cli/src/__graph_bench_touch.rs"
+
+cleanup() {
+  rm -f "$touch_path"
+}
+trap cleanup EXIT
+
+rm -rf "$target_dir"
+mkdir -p "$target_dir"
+: > "$samples_path"
+cleanup
+
+cargo build -p orbit-knowledge --example graph_build --release
+cargo build -p orbit-graph-cli --release
+
+graph_build_bin="$repo_root/target/release/examples/graph_build"
+graph_cli_bin="$repo_root/target/release/orbit-graph-cli"
+
+now_ms() {
+  perl -MTime::HiRes=time -e 'printf "%.0f\n", time() * 1000'
+}
+
+file_size_bytes() {
+  local path="$1"
+  if stat -c %s "$path" >/dev/null 2>&1; then
+    stat -c %s "$path"
+  else
+    stat -f %z "$path"
+  fi
+}
+
+memory_mib() {
+  if [[ -r /proc/meminfo ]]; then
+    awk '/MemTotal/ { print int($2 / 1024) }' /proc/meminfo
+  else
+    echo 0
+  fi
+}
+
+measure_ms() {
+  local output_path="$1"
+  shift
+  local start_ms end_ms
+  start_ms="$(now_ms)"
+  "$@" > "$output_path"
+  end_ms="$(now_ms)"
+  echo $((end_ms - start_ms))
+}
+
+measure_peak_rss_kib() {
+  local output_path="$1"
+  shift
+  local rss_path="${output_path}.rss"
+  if /usr/bin/time -f "%M" -o "$rss_path" true >/dev/null 2>&1; then
+    /usr/bin/time -f "%M" -o "$rss_path" "$@" > "$output_path"
+    cat "$rss_path"
+  else
+    "$@" > "$output_path"
+    echo 0
+  fi
+}
+
+add_sample() {
+  local run="$1"
+  local id="$2"
+  local baseline_id="$3"
+  local implementation="$4"
+  local gate="$5"
+  local unit="$6"
+  local value="$7"
+
+  jq -nc \
+    --argjson run "$run" \
+    --arg id "$id" \
+    --arg baseline_id "$baseline_id" \
+    --arg implementation "$implementation" \
+    --argjson gate "$gate" \
+    --arg unit "$unit" \
+    --argjson value "$value" \
+    '{
+      run: $run,
+      id: $id,
+      baseline_id: $baseline_id,
+      implementation: $implementation,
+      gate: $gate,
+      unit: $unit,
+      value: $value
+    }' >> "$samples_path"
+}
+
+for run_index in $(seq 1 "$run_count"); do
+  run_dir="$target_dir/run-$run_index"
+  mkdir -p "$run_dir"
+
+  rm -rf .orbit/graph
+  cleanup
+
+  "$graph_build_bin" \
+    --workspace "$repo_root" \
+    --knowledge-dir "$run_dir/v1-knowledge" \
+    --scoreboard "$run_dir/v1-scoreboard.json" \
+    > "$run_dir/v1-summary.txt"
+
+  jq -c --argjson run "$run_index" '
+    .[-1] as $record
+    | [
+        {
+          id: "v1_cold_build",
+          baseline_id: "cold_full_build",
+          implementation: "v1",
+          gate: false,
+          unit: "ms",
+          value: $record.scenarios.cold_build.wall_time_ms
+        },
+        {
+          id: "v1_incremental_no_changes",
+          baseline_id: "incremental_no_changes",
+          implementation: "v1",
+          gate: false,
+          unit: "ms",
+          value: $record.scenarios.warm_incremental_noop.wall_time_ms
+        },
+        {
+          id: "v1_resident_memory",
+          baseline_id: "resident_memory",
+          implementation: "v1",
+          gate: false,
+          unit: "KiB",
+          value: ($record.scenarios.warm_incremental_noop.peak_rss_kib // 0)
+        }
+      ]
+    | .[] + { run: $run }
+  ' "$run_dir/v1-scoreboard.json" >> "$samples_path"
+
+  v2_full_sync_json="$run_dir/v2-full-sync.json"
+  v2_rss_kib="$(measure_peak_rss_kib "$v2_full_sync_json" "$graph_cli_bin" sync --full)"
+  add_sample "$run_index" "cold_full_build" "cold_full_build" "v2" "true" "ms" "$(jq -r '.duration_ms' "$v2_full_sync_json")"
+  add_sample "$run_index" "resident_memory" "resident_memory" "v2" "true" "KiB" "$v2_rss_kib"
+
+  v2_noop_sync_json="$run_dir/v2-noop-sync.json"
+  "$graph_cli_bin" sync > "$v2_noop_sync_json"
+  add_sample "$run_index" "incremental_no_changes" "incremental_no_changes" "v2" "true" "ms" "$(jq -r '.duration_ms' "$v2_noop_sync_json")"
+
+  cat > "$touch_path" <<'RS'
+pub fn graph_bench_touch() -> u8 {
+    1
+}
+RS
+  v2_one_file_json="$run_dir/v2-one-file-sync.json"
+  "$graph_cli_bin" sync > "$v2_one_file_json"
+  add_sample "$run_index" "incremental_one_file_changed" "incremental_one_file_changed" "v2" "true" "ms" "$(jq -r '.duration_ms' "$v2_one_file_json")"
+
+  search_ms="$(measure_ms "$run_dir/v2-search.json" "$graph_cli_bin" search GraphBenchOptions --kind symbol --limit 20)"
+  add_sample "$run_index" "search" "search" "v2" "true" "ms" "$search_ms"
+
+  refs_selector="symbol:crates/orbit-knowledge/src/graph_bench.rs#run_benchmark_with_child_process:function"
+  refs_ms="$(measure_ms "$run_dir/v2-refs.json" "$graph_cli_bin" refs "$refs_selector" --confidence same_module)"
+  add_sample "$run_index" "refs" "refs" "v2" "true" "ms" "$refs_ms"
+
+  impact_selector="symbol:crates/orbit-knowledge/src/graph_bench.rs#append_scoreboard:function"
+  impact_ms="$(measure_ms "$run_dir/v2-impact.json" "$graph_cli_bin" impact "$impact_selector" --depth 3)"
+  add_sample "$run_index" "impact_depth_3" "impact_depth_3" "v2" "true" "ms" "$impact_ms"
+
+  v2_db_path_json="$run_dir/v2-db-path.json"
+  "$graph_cli_bin" db-path > "$v2_db_path_json"
+  db_path="$(jq -r '.path' "$v2_db_path_json")"
+  add_sample "$run_index" "db_size" "db_size" "v2" "true" "bytes" "$(file_size_bytes "$db_path")"
+done
+
+generated_at="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+git_sha="$(git rev-parse HEAD 2>/dev/null || echo unknown)"
+logical_core_count="$(getconf _NPROCESSORS_ONLN 2>/dev/null || echo 0)"
+runner_image="${GRAPH_BENCH_RUNNER_IMAGE:-ubuntu-24.04}"
+runner_os_release="$(if [[ -r /etc/os-release ]]; then . /etc/os-release && echo "${PRETTY_NAME:-unknown}"; else echo unknown; fi)"
+
+jq -s \
+  --arg generated_at "$generated_at" \
+  --arg git_sha "$git_sha" \
+  --argjson run_count "$run_count" \
+  --arg runner_image "$runner_image" \
+  --arg runner_os_release "$runner_os_release" \
+  --argjson logical_core_count "$logical_core_count" \
+  --argjson memory_mib "$(memory_mib)" '
+    def median:
+      sort
+      | .[((length - 1) / 2 | floor)];
+
+    sort_by(.id)
+    | group_by(.id)
+    | map(
+        sort_by(.run) as $items
+        | $items[0] as $first
+        | ($items | map(.value) | median) as $median
+        | {
+            id: $first.id,
+            baseline_id: $first.baseline_id,
+            implementation: $first.implementation,
+            gate: $first.gate,
+            unit: $first.unit,
+            statistic: ("median_of_" + ($items | length | tostring)),
+            value: $median,
+            samples: ($items | map({ run, value }))
+          }
+      )
+    | sort_by((.gate == false), .id)
+    | {
+        schema_version: 1,
+        generated_at: $generated_at,
+        git_sha: $git_sha,
+        run_count: $run_count,
+        gate: {
+          implementation: "v2",
+          regression_threshold_percent: 20,
+          statistic: "median"
+        },
+        runner: {
+          image: $runner_image,
+          os_release: $runner_os_release,
+          logical_core_count: $logical_core_count,
+          memory_mib: $memory_mib
+        },
+        rows: .
+      }
+  ' "$samples_path" > "$results_path"
+
+echo "Wrote $results_path"


### PR DESCRIPTION
## Task

[ORB-00321](https://orbit-cli.com/tasks/ORB-00321) — Wire graph_bench.rs to CI with regression gate against bench/baselines.json

### Description

## Problem

[GRAPH_SPEC.md §12](docs/design/orbit-graph/specs/GRAPH_SPEC.md) prescribes a CI-enforced perf gate: each run compares against the committed bench/baselines.json. Regression fires when any row is more than 20 percent slower than baseline. The baseline was captured in [ORB-00296](.orbit/tasks/ORB-00296) (P0.3) and the bump workflow documented (label bench-baseline-bump). This task wires the existing graph_bench.rs harness to CI, emits results as an artifact, diffs against bench/baselines.json, and gates merges on more-than-20-percent regressions.

## Why It Matters

Without this gate, the baseline file is decorative. The spec design choice (candidate ADR-6 in [4_decisions.md](docs/design/orbit-graph/4_decisions.md)) was specifically to avoid 'ratchet up to whatever the last commit happened to measure'; that only works if the gate runs on every PR. This is the last piece of the perf contract — capture done in P0.3, gate landed here.

## Constraints / Notes

- graph_bench.rs already exists at [crates/orbit-knowledge/src/graph_bench.rs](crates/orbit-knowledge/src/graph_bench.rs). After Phase 1's lift ([ORB-00306](.orbit/tasks/ORB-00306) / P1.4), it should still run against the consumer surface. After Phases 3-4 land, it should also exercise orbit-graph directly for the v2 numbers.
- Decision point: does the gate compare v1 numbers, v2 numbers, or both? Spec §12 budgets target the v2 implementation specifically. Recommendation is to gate on v2 numbers against the baseline; v1 numbers are informational. Document the choice in the task notes; deviation requires explicit rationale.
- CI integration: a new GitHub Actions job runs the bench harness, writes results to target/bench/results.json, then runs a diff script against bench/baselines.json. Gate fires on any row more than 20 percent slower than baseline.
- Bump workflow: PRs with the bench-baseline-bump label bypass the regression check but require a one-line justification in the PR body. The workflow verifies the justification. Implement label detection via the GitHub Actions event payload.
- Runner profile: spec §12 says ubuntu-24.04, 4 vCPU, 16GB RAM. Pin to this runner. Do not run on macOS or other variants — timings will not be comparable.
- Stability: run the bench 3 times and take the median to dampen noise. Document the choice.
- Path filter: docs-only changes do not trigger the perf job. Use the GitHub Actions paths filter on Rust source roots.
- This task lands the gate. It does NOT pre-flight v2 against the baseline (Phase 3 + 4 must land first for v2 to exist). After v2 lands, expect the first few runs to need baseline bumps as numbers settle — that is what the label workflow is for.

Plan ID: P6.2. Depends on [ORB-00296](.orbit/tasks/ORB-00296) (P0.3 — baseline captured) and [ORB-00318](.orbit/tasks/ORB-00318) (P5.1 — CLI surface to invoke v2 numbers). Runs in parallel with P6.1.

### Acceptance Criteria

- A new GitHub Actions job (e.g. ci-bench) runs graph_bench.rs on every PR with Rust source changes
- The job runs the bench 3 times and takes the median per row to dampen noise
- The job emits target/bench/results.json as an Actions artifact (uploaded for download on PR pages)
- A diff script (bench/check_baseline.sh or a Rust binary) compares results.json against bench/baselines.json and exits non-zero if any row is more than 20 percent slower than the baseline
- PRs with the bench-baseline-bump label bypass the regression check but require a one-line justification in the PR body; the workflow verifies the justification is present
- Runner profile pinned to ubuntu-24.04 with 4 vCPU and 16GB RAM per GRAPH_SPEC.md §12
- Path filter ensures docs-only changes do not trigger the perf job (no rust source touched = no bench run)
- bench/README.md is updated with the new gate behavior and the label-bypass workflow (ORB-00296 added the bump workflow doc; this task adds the gate behavior section)
- make ci passes on the current main branch with no false positives against the committed baseline (proves the runner profile + median strategy is stable enough for the gate)
- Gate decision (v1 vs v2 numbers) documented in task notes — spec §12 budgets target v2 specifically, so the recommendation is to gate on v2 numbers with v1 numbers informational

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Added `.github/workflows/ci-bench.yml` with a `ci-bench` PR job on `ubuntu-24.04`, native PR path filters, runner core/memory verification, pinned actions, artifact upload, and `bench-baseline-bump` PR-body justification validation.
- Added `bench/run_graph_bench_ci.sh` to build release bench binaries, run `graph_bench.rs` three times via the `graph_build` example, measure v2 `orbit-graph-cli` rows three times, and write median rows to `target/bench/results.json`.
- Added `bench/check_baseline.sh` to compare gated result rows against `bench/baselines.json` and fail rows more than 20 percent slower than baseline.
- Updated `bench/README.md` with the CI gate behavior, artifact location, v1/v2 gate decision, and exact baseline-bump justification line.

Strategic decisions:
- Gate v2 `orbit-graph` rows (`gate: true`) against the committed baseline and keep v1 `orbit-knowledge` rows (`gate: false`) informational. | Rationale: GRAPH_SPEC §12 budgets target v2; v1 values remain useful transition context but should not decide the gate.

Assessment: The implementation is scoped to CI/bench wiring and avoids new crate dependencies. Full `make ci` was not run locally because repo instructions reserve it for the PR merge gate; `make ci-fast` passed.

Validation:
- `bash -n bench/run_graph_bench_ci.sh bench/check_baseline.sh` passed.
- Ruby YAML parse for `.github/workflows/ci-bench.yml` passed.
- Synthetic `bench/check_baseline.sh` pass/fail cases passed, including skipping `gate: false` v1 rows.
- `GRAPH_BENCH_RUNS=1 ./bench/run_graph_bench_ci.sh` wrote `target/bench/results.json`; local macOS baseline comparison flagged v2 `cold_full_build`, so the real gate remains pinned to the verified Ubuntu runner profile.
- `make ci-fast` passed.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-00321-6a13de74`
- Behind base: 0
- Ahead of base: 1