### PR TITLE
Fix orbit graph refs returning nothing at the fuzzy_name confidence floor

### DIFF
--- a/crates/orbit-graph/src/query/refs.rs
+++ b/crates/orbit-graph/src/query/refs.rs
@@ -31,6 +31,7 @@ pub(crate) fn run(graph: &Graph, sel: &Selector, opts: &RefOpts) -> Result<RefRe
         query_refs(
             &conn,
             qualified,
+            target.name.as_str(),
             opts,
             &mut line_cache,
             &mut skipped_low_confidence,
@@ -113,18 +114,37 @@ fn should_query_relations(kind: Option<RefKind>) -> bool {
 fn query_refs(
     conn: &Connection,
     qualified: &str,
+    target_name: &str,
     opts: &RefOpts,
     line_cache: &mut LineCache,
     skipped_low_confidence: &mut usize,
 ) -> Result<Vec<RefEntry>, GraphError> {
-    let sql = match opts.kind {
-        Some(_) => {
+    let include_fuzzy_name = opts.confidence == RefConfidence::FuzzyName;
+    let sql = match (opts.kind, include_fuzzy_name) {
+        (Some(_), true) => {
+            "SELECT from_file, from_span_start, kind, confidence
+             FROM refs
+             WHERE kind = ?2
+               AND (
+                   target_qualified = ?1
+                   OR (confidence = 'fuzzy_name' AND target_name = ?3)
+               )
+             ORDER BY from_file, from_span_start, id"
+        }
+        (Some(_), false) => {
             "SELECT from_file, from_span_start, kind, confidence
              FROM refs
              WHERE target_qualified = ?1 AND kind = ?2
              ORDER BY from_file, from_span_start, id"
         }
-        None => {
+        (None, true) => {
+            "SELECT from_file, from_span_start, kind, confidence
+             FROM refs
+             WHERE target_qualified = ?1
+                OR (confidence = 'fuzzy_name' AND target_name = ?2)
+             ORDER BY from_file, from_span_start, id"
+        }
+        (None, false) => {
             "SELECT from_file, from_span_start, kind, confidence
              FROM refs
              WHERE target_qualified = ?1
@@ -134,12 +154,23 @@ fn query_refs(
     let mut stmt = conn
         .prepare_cached(sql)
         .map_err(|source| GraphError::sqlite("prepare refs lookup", source))?;
-    let rows = match opts.kind {
-        Some(kind) => stmt
+    let rows = match (opts.kind, include_fuzzy_name) {
+        (Some(kind), true) => stmt
+            .query_map(
+                params![qualified, kind.as_str(), target_name],
+                row_to_ref_row,
+            )
+            .map_err(|source| GraphError::sqlite("query refs by target", source))?
+            .collect::<Result<Vec<_>, _>>(),
+        (Some(kind), false) => stmt
             .query_map(params![qualified, kind.as_str()], row_to_ref_row)
             .map_err(|source| GraphError::sqlite("query refs by target", source))?
             .collect::<Result<Vec<_>, _>>(),
-        None => stmt
+        (None, true) => stmt
+            .query_map(params![qualified, target_name], row_to_ref_row)
+            .map_err(|source| GraphError::sqlite("query refs by target", source))?
+            .collect::<Result<Vec<_>, _>>(),
+        (None, false) => stmt
             .query_map(params![qualified], row_to_ref_row)
             .map_err(|source| GraphError::sqlite("query refs by target", source))?
             .collect::<Result<Vec<_>, _>>(),

--- a/crates/orbit-graph/src/query/tests/refs.rs
+++ b/crates/orbit-graph/src/query/tests/refs.rs
@@ -34,7 +34,7 @@ fn default_floor_skips_fuzzy_refs_and_reports_count() {
             &conn,
             "src/caller.rs",
             "Target",
-            "crate::Target",
+            Some("crate::Target"),
             "call",
             "exact",
             index,
@@ -45,7 +45,7 @@ fn default_floor_skips_fuzzy_refs_and_reports_count() {
             &conn,
             "src/caller.rs",
             "Target",
-            "crate::Target",
+            Some("crate::Target"),
             "call",
             "fuzzy_name",
             index,
@@ -83,7 +83,7 @@ fn fuzzy_floor_includes_fuzzy_name_refs() {
         &conn,
         "src/caller.rs",
         "Target",
-        "crate::Target",
+        Some("crate::Target"),
         "call",
         "fuzzy_name",
         0,
@@ -105,6 +105,50 @@ fn fuzzy_floor_includes_fuzzy_name_refs() {
 }
 
 #[test]
+fn fuzzy_floor_includes_name_only_fuzzy_refs() {
+    let worktree = TestWorktree::new("include-name-only-fuzzy");
+    let graph = Graph::open(worktree.path(), SyncPolicy::Manual).expect("open graph");
+    let conn = open_test_connection(worktree.path());
+    seed_target(
+        &conn,
+        worktree.path(),
+        "src/target.rs",
+        "Target",
+        "crate::Target",
+    );
+    seed_file(
+        &conn,
+        worktree.path(),
+        "src/caller.rs",
+        "Target::fuzzy();\n",
+    );
+    insert_ref(
+        &conn,
+        "src/caller.rs",
+        "Target",
+        None,
+        "call",
+        "fuzzy_name",
+        0,
+    );
+
+    let result = graph
+        .refs(
+            &target_selector(),
+            &RefOpts {
+                confidence: RefConfidence::FuzzyName,
+                kind: None,
+            },
+        )
+        .expect("query name-only fuzzy refs");
+
+    assert_eq!(result.refs.len(), 1);
+    assert_eq!(result.refs[0].kind, RefKind::Call);
+    assert_eq!(result.refs[0].confidence, RefConfidence::FuzzyName);
+    assert_eq!(result.skipped_low_confidence, 0);
+}
+
+#[test]
 fn kind_filter_routes_to_textual_refs_or_structural_relations() {
     let worktree = TestWorktree::new("kind-routing");
     let graph = Graph::open(worktree.path(), SyncPolicy::Manual).expect("open graph");
@@ -121,7 +165,7 @@ fn kind_filter_routes_to_textual_refs_or_structural_relations() {
         &conn,
         "src/caller.rs",
         "Target",
-        "crate::Target",
+        Some("crate::Target"),
         "call",
         "exact",
         0,
@@ -283,7 +327,7 @@ fn insert_ref(
     conn: &Connection,
     from_file: &str,
     target_name: &str,
-    target_qualified: &str,
+    target_qualified: Option<&str>,
     kind: &str,
     confidence: &str,
     index: i64,


### PR DESCRIPTION
## Task

[ORB-00324](https://orbit-cli.com/tasks/ORB-00324) — Fix orbit graph refs returning nothing at the fuzzy_name confidence floor

### Description

## Problem

Pass-2 resolver writes `target_qualified = NULL` for fuzzy-name matches (`crates/orbit-graph/src/sync/pass2.rs:118`). The refs query filters `WHERE target_qualified = ?1` (`crates/orbit-graph/src/query/refs.rs:122-132`). Net effect: lowering the confidence floor to fuzzy_name returns the same rows as same_module — the lowest tier is unreachable.

## Why It Matters

The whole point of the confidence ladder (`docs/design/orbit-graph/specs/GRAPH_SPEC.md` §15) is read-time precision/recall control. Right now fuzzy_name is opt-in per the spec, but the gateway is plumbed wrong: choosing it returns nothing. Agents reading the spec and asking for fuzzy refs are silently lied to.

## Constraints / Notes

- Two viable fixes:
  1. Pass-2 resolver fills target_qualified with a best-guess (e.g., the bare target_name treated as qualified), marked fuzzy_name; refs query SQL unchanged.
  2. Refs query SQL splits into two branches: resolved tiers filter on target_qualified; fuzzy_name branch filters on target_name with no target_qualified predicate.
  Option 2 is cleaner — fuzzy matches don't have a real qualified name by definition. Document the choice.
- New regression test must insert at least one fuzzy-only ref via the fixture builder, query refs at the fuzzy floor, and assert non-empty result with confidence equal to fuzzy_name.
- Schema unchanged (per `crates/orbit-graph/src/store/schema.rs`).
- Touch points: `crates/orbit-graph/src/{sync/pass2.rs, query/refs.rs}` plus sibling tests.
- This fix is a prerequisite for the C-extractor honesty fix (refs cannot land usefully without the fuzzy-tier surfacing).

### Acceptance Criteria

- Lowering the refs confidence floor to fuzzy_name returns refs that are otherwise filtered out, verified by a regression test in crates/orbit-graph/src/query/tests/refs.rs
- The test inserts at least one fuzzy-only ref via the fixture builder, queries refs at the fuzzy floor, and asserts the returned row has confidence equal to fuzzy_name
- An existing test exercising higher tiers still passes unchanged
- The chosen fix path (resolver-fills vs SQL-branches) is documented in the execution summary
- cargo test -p orbit-graph passes
- make ci-fast passes

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Updated `crates/orbit-graph/src/query/refs.rs` so `Graph::refs` passes the resolved target's short name into the refs lookup and, when the confidence floor is `fuzzy_name`, unions the normal `target_qualified` lookup with a fuzzy branch filtered by `target_name` and `confidence = 'fuzzy_name'`.
- Added `query::tests::refs::fuzzy_floor_includes_name_only_fuzzy_refs`, inserting a fixture ref with `target_qualified = NULL` and asserting it is returned at the fuzzy floor with `RefConfidence::FuzzyName`.
- Adjusted the refs test fixture helper to accept `Option<&str>` for `target_qualified`; existing higher-tier refs tests still pass.

Strategic decisions:
- Chose the SQL-branches fix path over resolver-fills. Rationale: fuzzy refs do not have a real qualified target, so reads opt into a name-based fuzzy branch while resolved tiers continue using `target_qualified`.

Assessment: The change is scoped to the refs query and its sibling regression test, preserves the pass-2 fuzzy NULL invariant, and leaves default higher-confidence behavior intact.

Validation:
- `cargo test -p orbit-graph query::tests::refs` passed.
- `cargo test -p orbit-graph` passed.
- `make ci-fast` passed.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-00324-6a13f124`
- Behind base: 0
- Ahead of base: 1