### PR TITLE
Extract CLI command surface so `orbit graph trace` resolves real handlers

### DIFF
--- a/crates/orbit-graph-extract/src/languages/python.rs
+++ b/crates/orbit-graph-extract/src/languages/python.rs
@@ -4,7 +4,7 @@ use std::path::Path;
 
 use tree_sitter::{Node, Parser};
 
-use crate::{ExtractedFile, Extractor, RawImport, RawRef, RawRelation, RawSymbol};
+use crate::{ExtractedFile, Extractor, RawCommand, RawImport, RawRef, RawRelation, RawSymbol};
 
 /// Extracts Python source files into raw graph rows.
 pub struct PythonExtractor;
@@ -47,6 +47,7 @@ struct ExtractionState {
     refs: Vec<RawRef>,
     relations: Vec<RawRelation>,
     imports: Vec<RawImport>,
+    commands: Vec<RawCommand>,
 }
 
 impl ExtractionState {
@@ -57,6 +58,7 @@ impl ExtractionState {
             refs: Vec::new(),
             relations: Vec::new(),
             imports: Vec::new(),
+            commands: Vec::new(),
         }
     }
 
@@ -65,6 +67,7 @@ impl ExtractionState {
         dedup_refs(&mut self.refs);
         dedup_relations(&mut self.relations);
         dedup_imports(&mut self.imports);
+        dedup_commands(&mut self.commands);
         ExtractedFile {
             symbols: self.symbols,
             refs: self.refs,
@@ -72,7 +75,7 @@ impl ExtractionState {
             imports: self.imports,
             strings: Vec::new(),
             configs: Vec::new(),
-            commands: Vec::new(),
+            commands: self.commands,
         }
     }
 
@@ -112,14 +115,50 @@ impl ExtractionState {
             return;
         }
 
+        self.push_ref_span(
+            node.start_byte(),
+            node.end_byte(),
+            target_name,
+            target_qualified,
+            kind,
+            confidence,
+        );
+    }
+
+    fn push_ref_span(
+        &mut self,
+        from_span_start: usize,
+        from_span_end: usize,
+        target_name: String,
+        target_qualified: Option<String>,
+        kind: &'static str,
+        confidence: &'static str,
+    ) {
+        if target_name.is_empty() || is_ignored_name(&target_name) {
+            return;
+        }
+
         self.refs.push(RawRef {
             from_file: self.file_path.clone(),
-            from_span_start: node.start_byte(),
-            from_span_end: node.end_byte(),
+            from_span_start,
+            from_span_end,
             target_name,
             target_qualified,
             kind: kind.to_string(),
             confidence: confidence.to_string(),
+        });
+    }
+
+    fn push_command(&mut self, name: String, span_start: usize, handler_symbol: Option<String>) {
+        if name.is_empty() {
+            return;
+        }
+
+        self.commands.push(RawCommand {
+            name,
+            file_path: self.file_path.clone(),
+            span_start,
+            handler_symbol,
         });
     }
 }
@@ -153,11 +192,254 @@ fn extract_decorated(
 ) {
     if let Some(definition) = node.child_by_field_name("definition") {
         match definition.kind() {
-            "function_definition" => extract_function(definition, source, parent_symbol, state),
+            "function_definition" => {
+                extract_function(definition, source, parent_symbol, state);
+                extract_click_commands(node, definition, source, parent_symbol, state);
+            }
             "class_definition" => extract_class(definition, source, parent_symbol, state),
             _ => {}
         }
     }
+}
+
+fn extract_click_commands(
+    decorated: Node,
+    function: Node,
+    source: &str,
+    parent_symbol: Option<&str>,
+    state: &mut ExtractionState,
+) {
+    let Some(function_name) = get_name(function, source) else {
+        return;
+    };
+    let handler_symbol = qualify_name(parent_symbol, &function_name);
+
+    let mut cursor = decorated.walk();
+    for child in decorated.named_children(&mut cursor) {
+        if child.start_byte() >= function.start_byte() {
+            break;
+        }
+        if child.kind() != "decorator" {
+            continue;
+        }
+
+        match click_command_from_decorator(child, source, &function_name) {
+            Some(CommandName::Resolved(name)) => {
+                state.push_command(name, child.start_byte(), Some(handler_symbol.clone()));
+            }
+            Some(CommandName::Unresolved {
+                span_start,
+                span_end,
+                target_name,
+            }) => state.push_ref_span(
+                span_start,
+                span_end,
+                target_name,
+                None,
+                "command",
+                "fuzzy_name",
+            ),
+            None => {}
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum CommandName {
+    Resolved(String),
+    Unresolved {
+        span_start: usize,
+        span_end: usize,
+        target_name: String,
+    },
+}
+
+fn click_command_from_decorator(
+    node: Node,
+    source: &str,
+    fallback_function_name: &str,
+) -> Option<CommandName> {
+    let text = node_text(node, source);
+    let at_index = text.find('@')?;
+    let body_start = at_index + 1;
+    let body = text.get(body_start..)?.trim_start();
+    let body_leading_ws = text.get(body_start..)?.len() - body.len();
+    let body_start = body_start + body_leading_ws;
+
+    let Some(open_index_in_body) = body.find('(') else {
+        return is_click_command_target(body)
+            .then(|| CommandName::Resolved(click_default_command_name(fallback_function_name)));
+    };
+
+    let target = body.get(..open_index_in_body)?.trim();
+    if !is_click_command_target(target) {
+        return None;
+    }
+
+    let args_start = body_start + open_index_in_body + 1;
+    let close_index = text.rfind(')').unwrap_or(text.len());
+    let args = text.get(args_start..close_index).unwrap_or_default();
+    command_name_from_click_args(args, node.start_byte() + args_start, fallback_function_name)
+}
+
+fn is_click_command_target(target: &str) -> bool {
+    matches!(
+        target.rsplit('.').next().map(str::trim),
+        Some("command" | "group")
+    )
+}
+
+fn command_name_from_click_args(
+    args: &str,
+    args_start: usize,
+    fallback_function_name: &str,
+) -> Option<CommandName> {
+    for arg in split_top_level_args(args, args_start) {
+        let trimmed = arg.text.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+
+        let trimmed_start = arg.start + leading_whitespace_len(arg.text);
+        if let Some((key, value, value_start)) = split_keyword_arg(trimmed, trimmed_start) {
+            if key == "name" {
+                return command_name_from_value(value, value_start);
+            }
+            continue;
+        }
+
+        return command_name_from_value(trimmed, trimmed_start);
+    }
+
+    Some(CommandName::Resolved(click_default_command_name(
+        fallback_function_name,
+    )))
+}
+
+fn command_name_from_value(value: &str, value_start: usize) -> Option<CommandName> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    let span_start = value_start + leading_whitespace_len(value);
+
+    if let Some(literal) = python_string_literal_value(trimmed) {
+        return Some(CommandName::Resolved(literal));
+    }
+
+    let target_name = unresolved_command_target_name(trimmed)?;
+    Some(CommandName::Unresolved {
+        span_start,
+        span_end: span_start + trimmed.len(),
+        target_name,
+    })
+}
+
+#[derive(Debug, Clone, Copy)]
+struct ArgSpan<'a> {
+    text: &'a str,
+    start: usize,
+}
+
+fn split_top_level_args(args: &str, args_start: usize) -> Vec<ArgSpan<'_>> {
+    let mut spans = Vec::new();
+    let mut start = 0usize;
+    let mut depth = 0usize;
+    let mut quote = None;
+    let mut escaped = false;
+
+    for (index, ch) in args.char_indices() {
+        if let Some(quote_char) = quote {
+            if escaped {
+                escaped = false;
+            } else if ch == '\\' {
+                escaped = true;
+            } else if ch == quote_char {
+                quote = None;
+            }
+            continue;
+        }
+
+        match ch {
+            '\'' | '"' => quote = Some(ch),
+            '(' | '[' | '{' => depth += 1,
+            ')' | ']' | '}' => depth = depth.saturating_sub(1),
+            ',' if depth == 0 => {
+                spans.push(ArgSpan {
+                    text: &args[start..index],
+                    start: args_start + start,
+                });
+                start = index + ch.len_utf8();
+            }
+            _ => {}
+        }
+    }
+
+    spans.push(ArgSpan {
+        text: &args[start..],
+        start: args_start + start,
+    });
+    spans
+}
+
+fn split_keyword_arg<'a>(arg: &'a str, arg_start: usize) -> Option<(&'a str, &'a str, usize)> {
+    let equals_index = arg.find('=')?;
+    let key = arg.get(..equals_index)?.trim();
+    if key.is_empty()
+        || !key
+            .chars()
+            .all(|ch| ch == '_' || ch.is_ascii_alphanumeric())
+    {
+        return None;
+    }
+    let value_start = arg_start + equals_index + 1;
+    let value = arg.get(equals_index + 1..)?;
+    Some((key, value, value_start))
+}
+
+fn python_string_literal_value(value: &str) -> Option<String> {
+    let mut literal = value.trim();
+    loop {
+        let Some(first) = literal.chars().next() else {
+            return None;
+        };
+        if matches!(first, 'r' | 'R' | 'u' | 'U' | 'b' | 'B') {
+            literal = literal.get(first.len_utf8()..)?;
+            continue;
+        }
+        if matches!(first, 'f' | 'F') {
+            return None;
+        }
+        break;
+    }
+
+    let quote = literal.chars().next()?;
+    if !matches!(quote, '\'' | '"') {
+        return None;
+    }
+    let rest = literal.get(quote.len_utf8()..)?;
+    let end = rest.rfind(quote)?;
+    Some(rest.get(..end)?.to_string())
+}
+
+fn unresolved_command_target_name(value: &str) -> Option<String> {
+    let token_end = value
+        .find(|ch: char| !(ch == '_' || ch == '.' || ch.is_ascii_alphanumeric()))
+        .unwrap_or(value.len());
+    value
+        .get(..token_end)?
+        .rsplit('.')
+        .next()
+        .map(str::to_string)
+        .filter(|name| !name.is_empty())
+}
+
+fn click_default_command_name(function_name: &str) -> String {
+    function_name.replace('_', "-")
+}
+
+fn leading_whitespace_len(value: &str) -> usize {
+    value.len() - value.trim_start().len()
 }
 
 fn extract_function(
@@ -686,6 +968,21 @@ fn dedup_imports(imports: &mut Vec<RawImport>) {
         left.from_file == right.from_file
             && left.target_path == right.target_path
             && left.target_symbol == right.target_symbol
+    });
+}
+
+fn dedup_commands(commands: &mut Vec<RawCommand>) {
+    commands.sort_by(|left, right| {
+        left.span_start
+            .cmp(&right.span_start)
+            .then_with(|| left.name.cmp(&right.name))
+            .then_with(|| left.handler_symbol.cmp(&right.handler_symbol))
+    });
+    commands.dedup_by(|left, right| {
+        left.file_path == right.file_path
+            && left.name == right.name
+            && left.span_start == right.span_start
+            && left.handler_symbol == right.handler_symbol
     });
 }
 

--- a/crates/orbit-graph-extract/src/languages/tests/python.rs
+++ b/crates/orbit-graph-extract/src/languages/tests/python.rs
@@ -73,3 +73,47 @@ def helper():
             && reference.confidence == "fuzzy_name"
     }));
 }
+
+#[test]
+fn extracts_click_commands_and_marks_dynamic_names_fuzzy() {
+    let source = r#"
+import click
+
+@click.command()
+def status():
+    pass
+
+@click.group(name="ops")
+def cli():
+    pass
+
+@cli.command("serve")
+def serve():
+    status()
+
+@cli.command(name=COMMAND_NAME)
+def dynamic():
+    pass
+"#;
+
+    let file = extract(source);
+
+    assert!(file.commands.iter().any(|command| {
+        command.name == "status" && command.handler_symbol.as_deref() == Some("status")
+    }));
+    assert!(file.commands.iter().any(|command| {
+        command.name == "ops" && command.handler_symbol.as_deref() == Some("cli")
+    }));
+    assert!(file.commands.iter().any(|command| {
+        command.name == "serve" && command.handler_symbol.as_deref() == Some("serve")
+    }));
+    assert!(file.commands.iter().all(|command| {
+        command.span_start < source.len() && command.file_path == "src/sample.py"
+    }));
+    assert!(file.refs.iter().any(|reference| {
+        reference.kind == "command"
+            && reference.target_name == "COMMAND_NAME"
+            && reference.target_qualified.is_none()
+            && reference.confidence == "fuzzy_name"
+    }));
+}

--- a/crates/orbit-graph/src/lib.rs
+++ b/crates/orbit-graph/src/lib.rs
@@ -34,7 +34,7 @@ mod tests;
 /// incompatibly. Older graph DB files then become invisible to the active
 /// graph handle and are removed by the next sync.
 // L-0052: FTS population invariants require a fresh DB when old indexes may be empty.
-pub const EXTRACTOR_VERSION: u32 = 2;
+pub const EXTRACTOR_VERSION: u32 = 3;
 
 /// Default graph distance used by callers that do not supply `--depth`.
 pub const DEFAULT_IMPACT_DEPTH: u8 = 3;

--- a/crates/orbit-graph/src/query/tests/trace.rs
+++ b/crates/orbit-graph/src/query/tests/trace.rs
@@ -4,7 +4,7 @@ use crate::query::tests::support::{
     TestWorktree, graph_db_path, insert_file, insert_symbol, open_connection, open_graph,
 };
 use crate::sync::sync_leader_count;
-use crate::{SyncPolicy, TRACE_NODE_CAP, TraceNode};
+use crate::{SyncMode, SyncPolicy, TRACE_NODE_CAP, TraceNode};
 
 #[test]
 fn synthetic_command_with_three_level_call_tree_returns_full_tree() {
@@ -70,6 +70,41 @@ fn unknown_command_returns_empty_trace_result() {
     assert_eq!(result.visited_nodes, 0);
     assert!(!result.truncated);
     assert!(result.root.is_none());
+}
+
+#[test]
+fn trace_resolves_python_click_command_from_synced_fixture() {
+    let worktree = TestWorktree::new("trace-click-command");
+    worktree.write(
+        "src/cli.py",
+        r#"
+import click
+
+@click.command()
+def ship():
+    helper()
+
+def helper():
+    leaf()
+
+def leaf():
+    return "done"
+"#,
+    );
+    let graph = open_graph(&worktree, SyncPolicy::Manual);
+    graph.sync(SyncMode::Full).expect("sync click fixture");
+
+    let result = graph.trace("ship", 3).expect("trace click command");
+
+    assert!(result.visited_nodes > 0);
+    let root = result.root.expect("trace root");
+    assert_eq!(root.name, "ship");
+    assert_eq!(root.qualified_name.as_deref(), Some("ship"));
+    assert_eq!(child_names(&root), vec!["helper"]);
+
+    let helper = child(&root, "helper");
+    assert_eq!(helper.qualified_name.as_deref(), Some("helper"));
+    assert_eq!(child_names(helper), vec!["leaf"]);
 }
 
 #[test]

--- a/docs/design/orbit-graph/specs/GRAPH_SPEC.md
+++ b/docs/design/orbit-graph/specs/GRAPH_SPEC.md
@@ -1,6 +1,7 @@
 # Orbit Graph — Redesign Spec
 
 **Status:** Draft proposal
+**Last updated:** 2026-05-25 (ORB-00323 command extraction coverage)
 **Relation to `orbit-knowledge`:** Coexists initially. Both crates run side-by-side under a feature flag; whether `orbit-knowledge` is eventually phased out depends on the head-to-head effectiveness measurement in §16 Step 4 — it is not a foregone conclusion of this spec.
 **Author:** working from the V2 sketch in `GRAPH_V2.md` + the existing design in [`../../knowledge-graph/`](../../knowledge-graph/)
 **Scope:** V1 — read-only graph. A writeable graph (Rename, ReplaceBody, Move, working-graph overlay, patch compiler) is V2, sketched in §17 and tracked in [`../3_vision.md`](../3_vision.md). The previous separate `GRAPH_DESIGN.md` describing the write surface has been folded into this spec on 2026-05-24 to remove the contradictory scope between the two docs.
@@ -479,6 +480,15 @@ This is the "structural feature expansion" capability — concrete, bounded, no 
 | 4 | `fuzzy_name` | Name matches but multiple candidates exist, or no import path can be established. | no (opt-in via `--confidence fuzzy`) |
 
 Ordering is strict high→low. `import_resolved` outranks `same_module` deliberately: an explicit `use` is stronger evidence than module-namespace uniqueness, because wildcard re-exports can produce the same `same_module` candidate for unrelated symbols.
+
+**Command surface coverage.** `RawCommand` rows follow the same honesty rule as refs: extractors populate a command only when the CLI declaration exposes a literal or defaulted command name and a concrete handler symbol in the same file; dynamic command names are surfaced as `fuzzy_name` refs instead of being guessed.
+
+| Language | CLI patterns populating `RawCommand` | Dynamic / unresolved behavior |
+|---|---|---|
+| Python | Click decorators on functions: `@click.command()`, `@click.group(...)`, and group-bound `@cli.command(...)` / `@cli.group(...)`. Literal `name=` or first positional names are exact; no-arg decorators use Click's default function-name command. | Non-literal command names emit `kind=command, confidence=fuzzy_name` refs and do not create a command row. |
+| Rust | Not yet populated. `clap` derive macros remain opaque without macro expansion. | No command rows. |
+| JavaScript / TypeScript | Not yet populated. `commander` / `yargs` chains are still refs only. | No command rows. |
+| C, C#, Go, Java, Kotlin, Ruby, Markdown, Config | No CLI command extraction in V1. | No command rows. |
 
 What we explicitly **don't** promise:
 


### PR DESCRIPTION
## Task

[ORB-00323](https://orbit-cli.com/tasks/ORB-00323) — Extract CLI command surface so `orbit graph trace` resolves real handlers

### Description

## Problem

Every language extractor hardcodes `commands: Vec::new()` — `crates/orbit-graph-extract/src/languages/rust.rs:77`, `java.rs:75`, `csharp.rs:75`, and nine others. The `RawCommand` collection on `ExtractedFile` (`crates/orbit-graph-extract/src/lib.rs`) is dead. The sync pipeline calls `insert_commands` at `crates/orbit-graph/src/sync/pass1.rs:325` against an empty vec every run.

Consequence: `orbit graph trace <command-name>` (shipped via ORB-00317) returns shape but cannot resolve any handler — the `commands` table is uniformly empty. Query-path tests passed because their fixtures use direct symbol lookups, not command-name resolution.

## Why It Matters

`trace` is one of seven shipping queries (`docs/design/orbit-graph/specs/GRAPH_SPEC.md` §9.6). Without command extraction it is shipped-but-broken — agents calling `orbit.graph.trace` for any real CLI handler get an empty walk and assume the codebase has no caller. False-negative answers are worse than no answer.

## Constraints / Notes

- **Scope decision required at execution time:** which extractor(s) own command-surface extraction? Tree-sitter does not expand Rust derive macros, so `#[derive(clap::Parser)]` is opaque structurally. Options:
  1. Pattern-match on `clap::Subcommand`, `clap::Command::new(...)`, or `Parser` impl bodies in Rust.
  2. Handle JS/Python CLI shapes (`commander`, `yargs`, `click`, `argparse`) which are more amenable to tree-sitter.
  3. Defer Rust; ship JS/Python first.
  Pick one and document in the task notes. §11's honesty rule: if the extractor cannot resolve, emit `fuzzy_name`; do not drop silently.
- `RawCommand` shape lives in `crates/orbit-graph-extract/src/lib.rs`. At minimum: `name`, `handler_qualified_name`, `file`, `span`.
- Pass 1 inserts via `insert_commands` (`crates/orbit-graph/src/sync/pass1.rs:325`). No schema change needed — `commands` table already exists from ORB-00308.
- The trace BFS at `crates/orbit-graph/src/query/trace.rs:34` consumes the resolved handler symbol and walks callees. Chain: `command_name → handler_qualified → relations`. Verify end-to-end against at least one real command.
- End-to-end smoke test: extract `orbit-cli` itself, trace one of its own subcommands, walk three levels deep, assert the BFS surfaces real handler symbols.

### Acceptance Criteria

- At least one language extractor populates RawCommand from that language's CLI declaration pattern (Rust clap and/or JS commander/yargs and/or Python argparse/click)
- The selected pattern is documented in the execution summary with rationale tied to GRAPH_SPEC.md §11
- orbit graph trace against a fixture repo returns a non-empty TraceResult with visited_nodes greater than zero and at least one real handler symbol in the tree
- New extractor tests cover at least three commands in the chosen language: a no-args command, a subcommand, and an unresolvable case that emits a fuzzy_name ref or is elided with a comment
- cargo test -p orbit-graph-extract -p orbit-graph passes
- GRAPH_SPEC.md §11 language coverage matrix updated to reflect which languages now populate RawCommand
- make ci-fast passes

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Implemented Python Click command extraction for @click.command/@click.group and group-bound @cli.command/@cli.group. Literal names and default no-arg command names populate RawCommand with handler symbols; non-literal command names emit command refs with fuzzy_name confidence.
- Added extractor tests covering a no-args command, group/subcommand decorators, and a dynamic-name fuzzy case.
- Added a synced trace fixture proving command trace visits ship -> helper -> leaf from the commands table, bumped EXTRACTOR_VERSION to rebuild graph DBs, and updated GRAPH_SPEC.md §11 with the command coverage matrix.

Strategic decisions:
- Chose Python Click because decorator nodes expose concrete function handlers and literal/default command names through tree-sitter, matching GRAPH_SPEC.md §11 honesty better than guessing through Rust clap derive macros.

Assessment: cargo test -p orbit-graph-extract -p orbit-graph, a direct orbit-graph-cli trace fixture smoke, and make ci-fast all pass.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-00323-6a13f276`
- Behind base: 0
- Ahead of base: 1