### PR TITLE
C extractor: emit fuzzy_name refs for function calls instead of dropping them

### DIFF
--- a/crates/orbit-graph-extract/src/languages/c.rs
+++ b/crates/orbit-graph-extract/src/languages/c.rs
@@ -8,8 +8,8 @@ use std::path::Path;
 
 use tree_sitter::{Node, Parser};
 
-use super::common::{dedup_imports, dedup_symbols, normalize_path};
-use crate::{ExtractedFile, Extractor, RawImport, RawSymbol};
+use super::common::{dedup_imports, dedup_refs, dedup_symbols, normalize_path};
+use crate::{ExtractedFile, Extractor, RawImport, RawRef, RawSymbol};
 
 /// C tree-sitter extractor (functions, structs, includes).
 pub struct CExtractor;
@@ -45,6 +45,7 @@ impl Extractor for CExtractor {
 
         let mut state = ExtractionState::new(path);
         extract_top_level(tree.root_node(), source, &mut state);
+        collect_call_refs(tree.root_node(), source, &mut state);
         state.finish()
     }
 }
@@ -52,6 +53,7 @@ impl Extractor for CExtractor {
 struct ExtractionState {
     file_path: String,
     symbols: Vec<RawSymbol>,
+    refs: Vec<RawRef>,
     imports: Vec<RawImport>,
 }
 
@@ -60,15 +62,18 @@ impl ExtractionState {
         Self {
             file_path: normalize_path(path),
             symbols: Vec::new(),
+            refs: Vec::new(),
             imports: Vec::new(),
         }
     }
 
     fn finish(mut self) -> ExtractedFile {
         dedup_symbols(&mut self.symbols);
+        dedup_refs(&mut self.refs);
         dedup_imports(&mut self.imports);
         ExtractedFile {
             symbols: self.symbols,
+            refs: self.refs,
             imports: self.imports,
             ..Default::default()
         }
@@ -92,6 +97,30 @@ impl ExtractionState {
             from_file: self.file_path.clone(),
             target_path,
             target_symbol: None,
+        });
+    }
+
+    fn push_ref(
+        &mut self,
+        node: Node,
+        source: &str,
+        target_qualified: Option<String>,
+        kind: &'static str,
+        confidence: &'static str,
+    ) {
+        let target_name = node_text(node, source);
+        if target_name.is_empty() {
+            return;
+        }
+
+        self.refs.push(RawRef {
+            from_file: self.file_path.clone(),
+            from_span_start: node.start_byte(),
+            from_span_end: node.end_byte(),
+            target_name,
+            target_qualified,
+            kind: kind.to_string(),
+            confidence: confidence.to_string(),
         });
     }
 }
@@ -188,6 +217,31 @@ fn extract_tag_specifier(node: Node, source: &str, state: &mut ExtractionState) 
         return;
     };
     state.push_symbol(node, name, kind);
+}
+
+fn collect_call_refs(node: Node, source: &str, state: &mut ExtractionState) {
+    if node.kind() == "call_expression" {
+        collect_call_ref(node, source, state);
+    }
+
+    let mut cursor = node.walk();
+    for child in node.named_children(&mut cursor) {
+        collect_call_refs(child, source, state);
+    }
+}
+
+fn collect_call_ref(node: Node, source: &str, state: &mut ExtractionState) {
+    let Some(function) = node.child_by_field_name("function") else {
+        return;
+    };
+
+    if function.kind() == "identifier" {
+        state.push_ref(function, source, None, "call", "fuzzy_name");
+        return;
+    }
+
+    // Complex callees like (*callback)(x) do not expose an honest target_name
+    // without type/preprocessor context, so GRAPH_SPEC.md §11 requires eliding.
 }
 
 fn get_name(node: Node, source: &str) -> Option<String> {

--- a/crates/orbit-graph-extract/src/languages/tests/c.rs
+++ b/crates/orbit-graph-extract/src/languages/tests/c.rs
@@ -6,7 +6,11 @@ use crate::Extractor;
 use crate::languages::CExtractor;
 
 fn extract(source: &str) -> crate::ExtractedFile {
-    CExtractor.extract(Path::new("example.c"), source.as_bytes())
+    extract_at("example.c", source)
+}
+
+fn extract_at(path: &str, source: &str) -> crate::ExtractedFile {
+    CExtractor.extract(Path::new(path), source.as_bytes())
 }
 
 #[test]
@@ -54,8 +58,49 @@ void proto(int x);
 }
 
 #[test]
-fn c_extractor_emits_no_relations_or_refs() {
-    let file = extract("struct S { int f; }; int f(void) {}");
+fn c_extractor_emits_fuzzy_call_refs() {
+    let source = r#"
+#define LOG_EVENT(value) helper(value)
+
+typedef void (*callback_t)(int);
+int helper(int value);
+
+void caller(callback_t callback, callback_t indirect) {
+    helper(1);
+    callback(2);
+    LOG_EVENT(3);
+    (*indirect)(4);
+}
+"#;
+
+    let file = extract(source);
     assert!(file.relations.is_empty());
-    assert!(file.refs.is_empty());
+    assert!(file.refs.iter().all(|reference| {
+        reference.confidence == "fuzzy_name" && !reference.target_name.is_empty()
+    }));
+    assert_fuzzy_call_ref(&file, "helper");
+    assert_fuzzy_call_ref(&file, "callback");
+    assert_fuzzy_call_ref(&file, "LOG_EVENT");
+    assert!(
+        !file
+            .refs
+            .iter()
+            .any(|reference| reference.target_name == "indirect")
+    );
+
+    let header = extract_at(
+        "example.h",
+        "static inline int header_call(void) { return helper(1); }",
+    );
+    assert_fuzzy_call_ref(&header, "helper");
+}
+
+fn assert_fuzzy_call_ref(file: &crate::ExtractedFile, target_name: &str) {
+    assert!(file.refs.iter().any(|reference| {
+        reference.kind == "call"
+            && reference.target_name == target_name
+            && reference.target_qualified.is_none()
+            && reference.confidence == "fuzzy_name"
+            && reference.from_span_start < reference.from_span_end
+    }));
 }


### PR DESCRIPTION
## Task

[ORB-00328](https://orbit-cli.com/tasks/ORB-00328) — C extractor: emit fuzzy_name refs for function calls instead of dropping them

### Description

## Problem

`crates/orbit-graph-extract/src/languages/c.rs:67-74` returns `ExtractedFile { symbols, imports, ..Default::default() }` — refs are silently empty. The test at `crates/orbit-graph-extract/src/languages/tests/c.rs:53-58` codifies this by asserting `file.refs.is_empty()`.

This violates `docs/design/orbit-graph/specs/GRAPH_SPEC.md` §11's honesty rule: when an extractor cannot fully resolve, it must degrade to fuzzy_name, not drop. C calls don't resolve cleanly through tree-sitter (no header inclusion model, no preprocessor expansion), but call sites are visible as `identifier(...)` patterns.

## Why It Matters

A C codebase under orbit-graph today returns zero call references. Any agent asking `orbit graph refs <c-symbol>` against a C-heavy crate gets a structurally-empty answer for the most useful surface (callers). The spec calls this dishonest; the test enshrines the dishonesty.

## Constraints / Notes

- Walk the C tree-sitter parse for call-expression patterns; emit a RawRef with confidence equal to fuzzy_name, target_qualified equal to None, target_name equal to the callee identifier.
- The B3 refs-at-fuzzy-floor fix is a prerequisite for these refs to be reachable to the query layer. Coordinate landing order if both are in flight (see the refs-fuzzy task created in the same QA batch).
- Update the C fixture test to cover at least: a simple function call, a call through a function pointer, a macro invocation. The first should emit a fuzzy_name ref; the latter two can be elided with a comment if structurally infeasible.
- The existing `refs.is_empty()` assertion at tests/c.rs:53-58 must be flipped or replaced.

### Acceptance Criteria

- C extractor emits RawRef entries with confidence equal to fuzzy_name for function call patterns in .c and .h files
- A new test exercises at least one call site and asserts the resulting ref has confidence equal to fuzzy_name with a non-empty target_name
- The existing refs.is_empty assertion at crates/orbit-graph-extract/src/languages/tests/c.rs:53-58 is replaced with positive coverage
- Calls through function pointers and macro invocations are either covered with their own fuzzy refs or explicitly elided in code with a comment citing GRAPH_SPEC.md §11
- cargo test -p orbit-graph-extract passes
- make ci-fast passes

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Added C RawRef collection for tree-sitter call_expression nodes whose callee is an identifier, emitting kind=call refs at confidence=fuzzy_name with no pre-guessed qualified target.
- Deduplicated and returned C refs alongside existing symbols/imports, preserving empty relations.
- Replaced the empty-ref C regression with positive coverage for simple calls, function-pointer-style identifier calls, macro invocations, complex pointer-call elision, and .h extraction.

Assessment: cargo test -p orbit-graph-extract and make ci-fast both pass.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-00328-6a13f96f`
- Behind base: 0
- Ahead of base: 1