### PR TITLE
Harden Graph::open: auto-clean stale DBs, broaden branch sanitization, capture detached-HEAD commit

### DIFF
--- a/crates/orbit-graph/src/lib.rs
+++ b/crates/orbit-graph/src/lib.rs
@@ -61,6 +61,7 @@ impl Graph {
         // Phase 4 query methods will call this; keep the dispatcher live under dead-code lints.
         let _ensure_synced: fn(&Self) -> Result<(), GraphError> = Self::ensure_synced;
         let opened = store::open(worktree_root, policy)?;
+        clean_old_databases_excluding(worktree_root, opened.db_path.path())?;
         Ok(Self {
             db_path: opened.db_path,
             worktree_root: worktree_root.to_path_buf(),
@@ -391,11 +392,11 @@ impl GraphDbPath {
 
 /// Resolve the canonical graph database path for a worktree and branch.
 ///
-/// The filename sanitizes the branch by replacing `/` with `_`, while the
-/// returned [`GraphDbPath`] keeps the raw branch name for future `meta.branch`
-/// storage.
+/// The filename sanitizes the branch with a conservative filesystem-safe
+/// allowlist, while the returned [`GraphDbPath`] keeps the raw branch name for
+/// future `meta.branch` storage.
 pub fn resolve_db_path(worktree_root: &Path, branch: &str, extractor_version: u32) -> GraphDbPath {
-    let sanitized_branch = branch.replace('/', "_");
+    let sanitized_branch = sanitize_branch_for_filename(branch);
     let filename = format!("{sanitized_branch}.{extractor_version}.db");
     GraphDbPath {
         path: worktree_root.join(".orbit").join("graph").join(filename),
@@ -404,12 +405,39 @@ pub fn resolve_db_path(worktree_root: &Path, branch: &str, extractor_version: u3
     }
 }
 
+fn sanitize_branch_for_filename(branch: &str) -> String {
+    if branch.is_empty() {
+        return "_".to_string();
+    }
+
+    let chars = branch.chars().collect::<Vec<_>>();
+    let mut sanitized = String::with_capacity(branch.len());
+    for (index, ch) in chars.iter().copied().enumerate() {
+        let is_dot = ch == '.';
+        let is_double_dot = is_dot
+            && ((index > 0 && chars[index - 1] == '.')
+                || (index + 1 < chars.len() && chars[index + 1] == '.'));
+        let allowed = ch.is_ascii_alphanumeric()
+            || ch == '_'
+            || ch == '-'
+            || (index > 0 && is_dot && !is_double_dot);
+
+        sanitized.push(if allowed { ch } else { '_' });
+    }
+    sanitized
+}
+
 /// Delete graph database files whose filename embeds an old extractor version.
 pub fn clean_old_databases(worktree_root: &Path) -> Result<CleanReport, GraphError> {
-    let graph = Graph::open(worktree_root, SyncPolicy::Manual)?;
-    let graph_dir = graph
-        .db_path
-        .path()
+    let opened = store::open(worktree_root, SyncPolicy::Manual)?;
+    clean_old_databases_excluding(worktree_root, opened.db_path.path())
+}
+
+fn clean_old_databases_excluding(
+    worktree_root: &Path,
+    active_db_path: &Path,
+) -> Result<CleanReport, GraphError> {
+    let graph_dir = active_db_path
         .parent()
         .map(Path::to_path_buf)
         .unwrap_or_else(|| worktree_root.join(".orbit").join("graph"));
@@ -434,6 +462,7 @@ pub fn clean_old_databases(worktree_root: &Path) -> Result<CleanReport, GraphErr
         };
         if graph_db_file_extractor_version(file_name)
             .is_some_and(|version| version != EXTRACTOR_VERSION)
+            && path != active_db_path
         {
             fs::remove_file(path.as_path()).map_err(|source| {
                 GraphError::io("delete old graph database file", &path, source)

--- a/crates/orbit-graph/src/store/mod.rs
+++ b/crates/orbit-graph/src/store/mod.rs
@@ -81,11 +81,7 @@ impl GitContext {
         } else {
             "HEAD".to_string()
         };
-        let commit_sha = if head.is_branch() {
-            head.target().map(|oid| oid.to_string()).unwrap_or_default()
-        } else {
-            String::new()
-        };
+        let commit_sha = head.target().map(|oid| oid.to_string()).unwrap_or_default();
 
         Self { branch, commit_sha }
     }

--- a/crates/orbit-graph/src/store/tests/schema.rs
+++ b/crates/orbit-graph/src/store/tests/schema.rs
@@ -3,7 +3,7 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use git2::{Repository, RepositoryInitOptions, Signature};
+use git2::{Oid, Repository, RepositoryInitOptions, Signature};
 use rusqlite::Connection;
 
 use crate::store::schema::SCHEMA_VERSION;
@@ -120,6 +120,62 @@ fn graph_open_creates_documented_schema_and_initial_meta() {
         meta.get("last_incremental_at").map(String::as_str),
         Some("0")
     );
+}
+
+#[test]
+fn graph_open_cleans_stale_version_databases_without_deleting_active_db() {
+    let worktree = TestWorktree::new("cleans-stale-dbs", "main");
+    worktree.init_git_repo();
+
+    let [stale_version_a, stale_version_b] = stale_versions();
+    let stale_main = resolve_db_path(worktree.path(), "main", stale_version_a)
+        .path()
+        .to_path_buf();
+    let stale_feature = resolve_db_path(worktree.path(), "feat/old", stale_version_b)
+        .path()
+        .to_path_buf();
+    fs::create_dir_all(stale_main.parent().expect("stale db parent")).expect("create graph dir");
+    fs::write(&stale_main, "stale main").expect("write stale main db");
+    fs::write(&stale_feature, "stale feature").expect("write stale feature db");
+
+    let graph = Graph::open(worktree.path(), SyncPolicy::Manual).expect("open graph");
+    let active_db = graph.db_path().path().to_path_buf();
+    drop(graph);
+
+    assert!(
+        active_db.exists(),
+        "active DB should remain after auto-clean"
+    );
+    assert!(
+        !stale_main.exists(),
+        "same-branch stale DB should be removed"
+    );
+    assert!(
+        !stale_feature.exists(),
+        "other-branch stale DB should be removed"
+    );
+}
+
+#[test]
+fn graph_open_records_commit_sha_for_detached_head() {
+    let worktree = TestWorktree::new("detached-head-meta", "main");
+    let commit_sha = worktree.init_git_repo();
+    worktree.detach_head(commit_sha.as_str());
+
+    let graph = Graph::open(worktree.path(), SyncPolicy::Manual).expect("open detached graph");
+    drop(graph);
+
+    let db_path = resolve_db_path(worktree.path(), "HEAD", EXTRACTOR_VERSION)
+        .path()
+        .to_path_buf();
+    let conn = open_test_connection(&db_path);
+    let meta = read_meta(&conn);
+    assert_eq!(meta.get("branch").map(String::as_str), Some("HEAD"));
+    assert_eq!(
+        meta.get("commit_sha").map(String::as_str),
+        Some(commit_sha.as_str())
+    );
+    assert!(!commit_sha.is_empty());
 }
 
 #[test]
@@ -316,6 +372,21 @@ fn row_count(conn: &Connection, table: &str) -> i64 {
         .expect("count table rows")
 }
 
+fn stale_versions() -> [u32; 2] {
+    [
+        if EXTRACTOR_VERSION > 0 {
+            EXTRACTOR_VERSION - 1
+        } else {
+            EXTRACTOR_VERSION + 1
+        },
+        if EXTRACTOR_VERSION > 1 {
+            EXTRACTOR_VERSION - 2
+        } else {
+            EXTRACTOR_VERSION + 2
+        },
+    ]
+}
+
 struct TestWorktree {
     path: PathBuf,
     branch: String,
@@ -358,6 +429,12 @@ impl TestWorktree {
             .commit(Some("HEAD"), &sig, &sig, "initial", &tree, &[])
             .expect("initial commit");
         oid.to_string()
+    }
+
+    fn detach_head(&self, commit_sha: &str) {
+        let repo = Repository::open(&self.path).expect("open git repo");
+        let oid = Oid::from_str(commit_sha).expect("parse commit oid");
+        repo.set_head_detached(oid).expect("detach HEAD");
     }
 }
 

--- a/crates/orbit-graph/src/tests/lib.rs
+++ b/crates/orbit-graph/src/tests/lib.rs
@@ -40,6 +40,28 @@ fn db_path_sanitizes_branch_slashes_and_preserves_raw_branch() {
 }
 
 #[test]
+fn db_path_sanitizes_filesystem_hostile_branch_names() {
+    let worktree_root = Path::new("/tmp/orbit-worktree");
+
+    for (branch, expected_file_name) in [
+        ("feat:foo", "feat_foo.1.db"),
+        ("feat\\foo", "feat_foo.1.db"),
+        ("feat..foo", "feat__foo.1.db"),
+        (".hidden", "_hidden.1.db"),
+        ("", "_.1.db"),
+        ("feat\0foo", "feat_foo.1.db"),
+    ] {
+        let path = resolve_db_path(worktree_root, branch, 1);
+        assert_eq!(
+            path.path().file_name().and_then(|name| name.to_str()),
+            Some(expected_file_name),
+            "sanitized filename for branch {branch:?}"
+        );
+        assert_eq!(path.branch(), branch);
+    }
+}
+
+#[test]
 fn manual_policy_ensure_synced_is_noop() {
     let worktree = TestWorktree::new("manual-noop");
     worktree.write("src/lib.rs", "pub fn manual() {}\n");


### PR DESCRIPTION
## Task

[ORB-00326](https://orbit-cli.com/tasks/ORB-00326) — Harden Graph::open: auto-clean stale DBs, broaden branch sanitization, capture detached-HEAD commit

### Description

## Problem

Three small store-layer gaps surfaced by the QA review, all in the same file pair:

1. **Stale-version DBs not auto-cleaned.** `crates/orbit-graph/src/lib.rs:33` doc comment says "[old DBs] are removed by the next sync." `Graph::open` (`crates/orbit-graph/src/store/mod.rs:17-42`) never calls `clean_old_databases`. Cleanup only happens via the explicit `orbit graph clean` subcommand. Disk usage grows monotonically across EXTRACTOR_VERSION bumps. GRAPH_SPEC.md §6.1 expects auto-clean.

2. **Branch sanitization too narrow.** `resolve_db_path` (`crates/orbit-graph/src/lib.rs:393-403`) only replaces `/`. Other filesystem-hostile chars (`:`, `\`, `..`, leading `.`, null) pass through. Real git allows `:` on Linux/macOS and Windows-hostile chars in cross-platform worktrees.

3. **Detached-HEAD commit_sha silently empty.** `GitContext::for_worktree` (`crates/orbit-graph/src/store/mod.rs:84-88`) returns empty string for detached HEAD even though `head.target()` would yield a valid commit. The `head.is_branch()` guard short-circuits. Detached HEAD is normal during rebases, bisects, and PR checkouts — those worktrees silently lose commit traceability.

## Why It Matters

None is catastrophic individually, but all three violate stated contracts and all three live in the same surgical area. Bundling keeps touch-cost down.

## Constraints / Notes

- For (1): call `clean_old_databases` from `Graph::open` after the active DB is opened. Verify the active DB is excluded from the candidate-delete list (self-delete guard).
- For (2): conservative allowlist — ASCII alphanumeric plus `_`, `-`, `.` after the first char. Replace everything else (including `/`) with `_`. Keep the existing `/` test cases green.
- For (3): when `head.is_branch()` is false but `head.target()` is `Some`, capture the commit sha. Only set empty for unborn-branch worktrees.
- Sibling tests already exist; extend `crates/orbit-graph/src/store/tests/schema.rs` and `crates/orbit-graph/src/tests/lib.rs`.

### Acceptance Criteria

- Graph::open invokes clean_old_databases for the worktree and skips the active DB; a new test writes two stale-version DBs, opens with the current version, and asserts the stale files are gone
- Branch sanitization handles colon, backslash, double-dot, leading dot, and empty strings; new tests under crates/orbit-graph/src/tests/lib.rs cover each case with expected sanitized output
- Detached-HEAD commit capture: when head.is_branch is false but head.target is Some, commit_sha is populated; new test exercises a detached-HEAD fixture and asserts non-empty commit_sha
- All three changes preserve back-compat with existing slash-only sanitization, branch-named worktrees, and the manual orbit graph clean subcommand
- cargo test -p orbit-graph passes
- make ci-fast passes

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- `Graph::open` now opens the active DB and then scans the worktree graph directory for extractor-version-mismatched DB files, with an active-path guard and no recursion through the public clean API.
- Branch DB filenames now use a conservative sanitizer: ASCII alphanumeric, `_`, `-`, and non-leading single `.` are preserved; slash, colon, backslash, double-dot, leading dot, NUL, empty names, and other unsafe chars are mapped to safe filenames while preserving the raw branch in metadata.
- Detached HEAD worktrees now persist `head.target()` as `commit_sha` when available, while unborn/non-git contexts still record an empty SHA.
- Added store/lib tests for stale DB auto-clean, active DB preservation, detached-HEAD commit metadata, and hostile branch sanitization.

Validation:
- `cargo test -p orbit-graph` passed.
- `make ci-fast` passed.

Assessment: Focused store-layer fix with regression tests covering all stated acceptance criteria.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-00326-6a13f96f`
- Behind base: 0
- Ahead of base: 1