### PR TITLE
Add min_confidence parameter to orbit-graph impact and trace queries

### DIFF
--- a/crates/orbit-graph-cli/src/commands/impact.rs
+++ b/crates/orbit-graph-cli/src/commands/impact.rs
@@ -1,5 +1,5 @@
-use clap::Args;
-use orbit_graph::DEFAULT_IMPACT_DEPTH;
+use clap::{Args, ValueEnum};
+use orbit_graph::{DEFAULT_IMPACT_DEPTH, RefConfidence};
 use orbit_graph_extract::Selector;
 
 use super::{CliError, CommandContext, json_value};
@@ -9,12 +9,36 @@ pub(crate) struct ImpactCommand {
     selector: String,
     #[arg(long, default_value_t = DEFAULT_IMPACT_DEPTH)]
     depth: u8,
+    #[arg(long, value_enum, default_value_t = ConfidenceArg::SameModule)]
+    confidence: ConfidenceArg,
 }
 
 impl ImpactCommand {
     pub(crate) fn run(&self, context: &CommandContext) -> Result<serde_json::Value, CliError> {
         let graph = context.open_graph()?;
         let selector = self.selector.parse::<Selector>()?;
-        json_value(graph.impact(&selector, self.depth)?)
+        json_value(graph.impact(&selector, self.depth, self.confidence.into_graph())?)
+    }
+}
+
+#[derive(Debug, Clone, Copy, ValueEnum)]
+#[clap(rename_all = "snake_case")]
+enum ConfidenceArg {
+    Exact,
+    #[value(alias = "import_resolved")]
+    Import,
+    SameModule,
+    #[value(alias = "fuzzy_name")]
+    Fuzzy,
+}
+
+impl ConfidenceArg {
+    fn into_graph(self) -> RefConfidence {
+        match self {
+            Self::Exact => RefConfidence::Exact,
+            Self::Import => RefConfidence::ImportResolved,
+            Self::SameModule => RefConfidence::SameModule,
+            Self::Fuzzy => RefConfidence::FuzzyName,
+        }
     }
 }

--- a/crates/orbit-graph-cli/src/commands/trace.rs
+++ b/crates/orbit-graph-cli/src/commands/trace.rs
@@ -1,5 +1,5 @@
-use clap::Args;
-use orbit_graph::DEFAULT_TRACE_DEPTH;
+use clap::{Args, ValueEnum};
+use orbit_graph::{DEFAULT_TRACE_DEPTH, RefConfidence};
 
 use super::{CliError, CommandContext, json_value};
 
@@ -8,11 +8,39 @@ pub(crate) struct TraceCommand {
     command_name: String,
     #[arg(long, default_value_t = DEFAULT_TRACE_DEPTH)]
     depth: u8,
+    #[arg(long, value_enum, default_value_t = ConfidenceArg::SameModule)]
+    confidence: ConfidenceArg,
 }
 
 impl TraceCommand {
     pub(crate) fn run(&self, context: &CommandContext) -> Result<serde_json::Value, CliError> {
         let graph = context.open_graph()?;
-        json_value(graph.trace(self.command_name.as_str(), self.depth)?)
+        json_value(graph.trace(
+            self.command_name.as_str(),
+            self.depth,
+            self.confidence.into_graph(),
+        )?)
+    }
+}
+
+#[derive(Debug, Clone, Copy, ValueEnum)]
+#[clap(rename_all = "snake_case")]
+enum ConfidenceArg {
+    Exact,
+    #[value(alias = "import_resolved")]
+    Import,
+    SameModule,
+    #[value(alias = "fuzzy_name")]
+    Fuzzy,
+}
+
+impl ConfidenceArg {
+    fn into_graph(self) -> RefConfidence {
+        match self {
+            Self::Exact => RefConfidence::Exact,
+            Self::Import => RefConfidence::ImportResolved,
+            Self::SameModule => RefConfidence::SameModule,
+            Self::Fuzzy => RefConfidence::FuzzyName,
+        }
     }
 }

--- a/crates/orbit-graph-cli/tests/subcommands.rs
+++ b/crates/orbit-graph-cli/tests/subcommands.rs
@@ -58,14 +58,28 @@ fn query_and_admin_subcommands_emit_json() {
 
     let impact = run_json(
         worktree.path(),
-        ["impact", "symbol:src/lib.rs#entry:function", "--depth", "2"],
+        [
+            "impact",
+            "symbol:src/lib.rs#entry:function",
+            "--depth",
+            "2",
+            "--confidence",
+            "same_module",
+        ],
     );
     assert_array_field(&impact, "touched");
     assert!(impact.get("visited_nodes").is_some());
 
     let trace = run_json(
         worktree.path(),
-        ["trace", "missing-command", "--depth", "2"],
+        [
+            "trace",
+            "missing-command",
+            "--depth",
+            "2",
+            "--confidence",
+            "same_module",
+        ],
     );
     assert!(trace["root"].is_null());
     assert_eq!(trace["visited_nodes"], 0);

--- a/crates/orbit-graph/src/lib.rs
+++ b/crates/orbit-graph/src/lib.rs
@@ -135,15 +135,25 @@ impl Graph {
     }
 
     /// Return the bounded impact set around `sel`.
-    pub fn impact(&self, sel: &Selector, depth: u8) -> Result<ImpactResult, GraphError> {
+    pub fn impact(
+        &self,
+        sel: &Selector,
+        depth: u8,
+        min_confidence: Confidence,
+    ) -> Result<ImpactResult, GraphError> {
         self.ensure_synced()?;
-        query::impact::run(self, sel, depth)
+        query::impact::run(self, sel, depth, min_confidence)
     }
 
     /// Trace the call tree rooted at a command handler.
-    pub fn trace(&self, command: &str, depth: u8) -> Result<TraceResult, GraphError> {
+    pub fn trace(
+        &self,
+        command: &str,
+        depth: u8,
+        min_confidence: Confidence,
+    ) -> Result<TraceResult, GraphError> {
         self.ensure_synced()?;
-        query::trace::run(self, command, depth)
+        query::trace::run(self, command, depth, min_confidence)
     }
 }
 
@@ -505,7 +515,7 @@ pub struct RefOpts {
 impl Default for RefOpts {
     fn default() -> Self {
         Self {
-            confidence: RefConfidence::SameModule,
+            confidence: RefConfidence::default(),
             kind: None,
         }
     }
@@ -523,6 +533,15 @@ pub enum RefConfidence {
     SameModule,
     /// Name-only match with ambiguous or weak resolution.
     FuzzyName,
+}
+
+/// Confidence floor used by reference and traversal queries.
+pub use RefConfidence as Confidence;
+
+impl Default for RefConfidence {
+    fn default() -> Self {
+        Self::SameModule
+    }
 }
 
 /// Filterable reference and relation kinds.

--- a/crates/orbit-graph/src/query/impact.rs
+++ b/crates/orbit-graph/src/query/impact.rs
@@ -8,10 +8,15 @@ use rusqlite::{Connection, OptionalExtension, params};
 use crate::query::callees;
 use crate::{
     DEFAULT_IMPACT_DEPTH, Graph, GraphError, IMPACT_NODE_CAP, ImpactEntry, ImpactResult,
-    RefConfidence, RefKind, RefOpts, SymbolSpan,
+    RefConfidence, RefKind, SymbolSpan,
 };
 
-pub(crate) fn run(graph: &Graph, sel: &Selector, depth: u8) -> Result<ImpactResult, GraphError> {
+pub(crate) fn run(
+    graph: &Graph,
+    sel: &Selector,
+    depth: u8,
+    min_confidence: RefConfidence,
+) -> Result<ImpactResult, GraphError> {
     let conn = Connection::open(graph.db_path.path())
         .map_err(|source| GraphError::sqlite("open graph database for impact", source))?;
     let Some(origin) = resolve_selector(&conn, sel)? else {
@@ -33,7 +38,7 @@ pub(crate) fn run(graph: &Graph, sel: &Selector, depth: u8) -> Result<ImpactResu
             continue;
         }
         let next_distance = distance + 1;
-        for neighbor in neighbors(&conn, &symbol)? {
+        for neighbor in neighbors(&conn, &symbol, min_confidence)? {
             if seen.contains(neighbor.qualified_name.as_str()) {
                 continue;
             }
@@ -72,16 +77,25 @@ fn empty_result() -> ImpactResult {
     }
 }
 
-fn neighbors(conn: &Connection, symbol: &ImpactSymbol) -> Result<Vec<ImpactNeighbor>, GraphError> {
-    let mut neighbors = inbound_ref_neighbors(conn, symbol.qualified.as_str())?;
-    neighbors.extend(outbound_call_neighbors(conn, symbol)?);
-    neighbors.extend(relation_neighbors(conn, symbol.qualified.as_str())?);
+fn neighbors(
+    conn: &Connection,
+    symbol: &ImpactSymbol,
+    min_confidence: RefConfidence,
+) -> Result<Vec<ImpactNeighbor>, GraphError> {
+    let mut neighbors = inbound_ref_neighbors(conn, symbol.qualified.as_str(), min_confidence)?;
+    neighbors.extend(outbound_call_neighbors(conn, symbol, min_confidence)?);
+    neighbors.extend(relation_neighbors(
+        conn,
+        symbol.qualified.as_str(),
+        min_confidence,
+    )?);
     Ok(neighbors)
 }
 
 fn inbound_ref_neighbors(
     conn: &Connection,
     qualified: &str,
+    min_confidence: RefConfidence,
 ) -> Result<Vec<ImpactNeighbor>, GraphError> {
     let mut stmt = conn
         .prepare_cached(
@@ -113,12 +127,13 @@ fn inbound_ref_neighbors(
         .collect::<Result<Vec<_>, _>>()
         .map_err(|source| GraphError::sqlite("collect impact inbound refs rows", source))?;
 
-    rows_to_neighbors(rows)
+    rows_to_neighbors(rows, min_confidence)
 }
 
 fn outbound_call_neighbors(
     conn: &Connection,
     symbol: &ImpactSymbol,
+    min_confidence: RefConfidence,
 ) -> Result<Vec<ImpactNeighbor>, GraphError> {
     let span = SymbolSpan {
         file_path: symbol.file_path.clone(),
@@ -127,7 +142,7 @@ fn outbound_call_neighbors(
     };
     let mut neighbors = Vec::new();
     for edge in callees::edges_for_symbol(conn, &span)? {
-        if !confidence_visible_at_default_floor(edge.confidence.as_str())? {
+        if !confidence_visible_at_floor(edge.confidence.as_str(), min_confidence)? {
             continue;
         }
         let Some(qualified_name) = edge.target_qualified else {
@@ -144,6 +159,7 @@ fn outbound_call_neighbors(
 fn relation_neighbors(
     conn: &Connection,
     qualified: &str,
+    min_confidence: RefConfidence,
 ) -> Result<Vec<ImpactNeighbor>, GraphError> {
     let mut neighbors = relation_rows(
         conn,
@@ -153,6 +169,7 @@ fn relation_neighbors(
          ORDER BY def_file, def_span_start, id",
         qualified,
         "impact inbound relations",
+        min_confidence,
     )?;
     neighbors.extend(relation_rows(
         conn,
@@ -162,6 +179,7 @@ fn relation_neighbors(
          ORDER BY def_file, def_span_start, id",
         qualified,
         "impact outbound relations",
+        min_confidence,
     )?);
     Ok(neighbors)
 }
@@ -171,6 +189,7 @@ fn relation_rows(
     sql: &str,
     qualified: &str,
     operation: &'static str,
+    min_confidence: RefConfidence,
 ) -> Result<Vec<ImpactNeighbor>, GraphError> {
     let mut stmt = conn
         .prepare_cached(sql)
@@ -187,13 +206,16 @@ fn relation_rows(
         .collect::<Result<Vec<_>, _>>()
         .map_err(|source| GraphError::sqlite("collect relation rows for impact", source))?;
 
-    rows_to_neighbors(rows)
+    rows_to_neighbors(rows, min_confidence)
 }
 
-fn rows_to_neighbors(rows: Vec<RawNeighborRow>) -> Result<Vec<ImpactNeighbor>, GraphError> {
+fn rows_to_neighbors(
+    rows: Vec<RawNeighborRow>,
+    min_confidence: RefConfidence,
+) -> Result<Vec<ImpactNeighbor>, GraphError> {
     let mut neighbors = Vec::with_capacity(rows.len());
     for row in rows {
-        if !confidence_visible_at_default_floor(row.confidence.as_str())? {
+        if !confidence_visible_at_floor(row.confidence.as_str(), min_confidence)? {
             continue;
         }
         let Some(qualified_name) = row.qualified_name else {
@@ -207,8 +229,11 @@ fn rows_to_neighbors(rows: Vec<RawNeighborRow>) -> Result<Vec<ImpactNeighbor>, G
     Ok(neighbors)
 }
 
-fn confidence_visible_at_default_floor(confidence: &str) -> Result<bool, GraphError> {
-    Ok(RefConfidence::from_db(confidence)?.visible_at_floor(RefOpts::default().confidence))
+fn confidence_visible_at_floor(
+    confidence: &str,
+    min_confidence: RefConfidence,
+) -> Result<bool, GraphError> {
+    Ok(RefConfidence::from_db(confidence)?.visible_at_floor(min_confidence))
 }
 
 fn resolve_selector(

--- a/crates/orbit-graph/src/query/tests/impact.rs
+++ b/crates/orbit-graph/src/query/tests/impact.rs
@@ -8,7 +8,7 @@ use crate::query::tests::support::{
     TestWorktree, graph_db_path, insert_file, insert_symbol, open_connection, open_graph,
 };
 use crate::sync::sync_leader_count;
-use crate::{IMPACT_NODE_CAP, ImpactEntry, RefKind, Selector, SyncPolicy};
+use crate::{IMPACT_NODE_CAP, ImpactEntry, RefConfidence, RefKind, Selector, SyncPolicy};
 
 #[test]
 fn five_node_tree_at_depth_two_returns_all_five_touched_symbols() {
@@ -47,7 +47,11 @@ fn five_node_tree_at_depth_two_returns_all_five_touched_symbols() {
     );
 
     let result = graph
-        .impact(&symbol_selector("src/root.rs", "root"), 2)
+        .impact(
+            &symbol_selector("src/root.rs", "root"),
+            2,
+            RefConfidence::SameModule,
+        )
         .expect("query impact tree");
 
     assert_eq!(result.visited_nodes, 5);
@@ -85,7 +89,11 @@ fn circular_reference_does_not_loop_forever() {
     insert_call_ref(&conn, "src/a.rs", 10, 11, "root", "crate::root", "exact");
 
     let result = graph
-        .impact(&symbol_selector("src/root.rs", "root"), 10)
+        .impact(
+            &symbol_selector("src/root.rs", "root"),
+            10,
+            RefConfidence::SameModule,
+        )
         .expect("query impact cycle");
 
     assert_eq!(result.visited_nodes, 1);
@@ -102,7 +110,11 @@ fn synthetic_300_node_graph_caps_at_200_and_reports_truncation() {
     seed_wide_callee_graph(&conn, 300);
 
     let result = graph
-        .impact(&symbol_selector("src/root.rs", "root"), 10)
+        .impact(
+            &symbol_selector("src/root.rs", "root"),
+            10,
+            RefConfidence::SameModule,
+        )
         .expect("query impact cap");
 
     assert_eq!(result.visited_nodes, IMPACT_NODE_CAP);
@@ -120,7 +132,9 @@ fn impact_calls_ensure_synced_at_entry() {
     let selector =
         Selector::from_str("symbol:src/lib.rs#synced_root:function").expect("parse selector");
 
-    let result = graph.impact(&selector, 1).expect("impact triggers sync");
+    let result = graph
+        .impact(&selector, 1, RefConfidence::SameModule)
+        .expect("impact triggers sync");
 
     assert_eq!(sync_leader_count(db_path.as_path()), 1);
     assert!(result.touched.is_empty());
@@ -135,7 +149,11 @@ fn impact_200_node_cap_performance_smoke_prints_elapsed_ms() {
 
     let started = Instant::now();
     let result = graph
-        .impact(&symbol_selector("src/root.rs", "root"), 10)
+        .impact(
+            &symbol_selector("src/root.rs", "root"),
+            10,
+            RefConfidence::SameModule,
+        )
         .expect("query impact perf cap");
     let elapsed = started.elapsed();
 
@@ -145,6 +163,79 @@ fn impact_200_node_cap_performance_smoke_prints_elapsed_ms() {
     }
     assert_eq!(result.visited_nodes, IMPACT_NODE_CAP);
     assert!(result.truncated);
+}
+
+#[test]
+fn confidence_floor_filters_and_prevents_below_floor_expansion() {
+    let worktree = TestWorktree::new("impact-confidence-floor");
+    let graph = open_graph(&worktree, SyncPolicy::Manual);
+    let conn = open_connection(&worktree);
+
+    seed_symbol(&conn, "src/root.rs", "root", "crate::root", 0, 100);
+    seed_symbol(&conn, "src/exact.rs", "exact", "crate::exact", 0, 50);
+    seed_symbol(&conn, "src/same.rs", "same", "crate::same_module", 0, 50);
+    seed_symbol(&conn, "src/leaf.rs", "leaf", "crate::leaf", 0, 50);
+    seed_symbol(&conn, "src/fuzzy.rs", "fuzzy", "crate::fuzzy", 0, 50);
+
+    insert_call_ref(
+        &conn,
+        "src/root.rs",
+        10,
+        11,
+        "exact",
+        "crate::exact",
+        "exact",
+    );
+    insert_call_ref(
+        &conn,
+        "src/root.rs",
+        12,
+        13,
+        "same",
+        "crate::same_module",
+        "same_module",
+    );
+    insert_call_ref(
+        &conn,
+        "src/root.rs",
+        14,
+        15,
+        "fuzzy",
+        "crate::fuzzy",
+        "fuzzy_name",
+    );
+    insert_call_ref(&conn, "src/same.rs", 10, 11, "leaf", "crate::leaf", "exact");
+
+    let default_floor = graph
+        .impact(
+            &symbol_selector("src/root.rs", "root"),
+            2,
+            RefConfidence::SameModule,
+        )
+        .expect("query impact default confidence floor");
+    let default_names: Vec<_> = default_floor
+        .touched
+        .iter()
+        .map(|entry| entry.qualified_name.as_str())
+        .collect();
+    assert_eq!(
+        default_names,
+        vec!["crate::exact", "crate::same_module", "crate::leaf"]
+    );
+
+    let exact_floor = graph
+        .impact(
+            &symbol_selector("src/root.rs", "root"),
+            2,
+            RefConfidence::Exact,
+        )
+        .expect("query impact exact confidence floor");
+    let exact_names: Vec<_> = exact_floor
+        .touched
+        .iter()
+        .map(|entry| entry.qualified_name.as_str())
+        .collect();
+    assert_eq!(exact_names, vec!["crate::exact"]);
 }
 
 fn seed_symbol(

--- a/crates/orbit-graph/src/query/tests/trace.rs
+++ b/crates/orbit-graph/src/query/tests/trace.rs
@@ -4,7 +4,7 @@ use crate::query::tests::support::{
     TestWorktree, graph_db_path, insert_file, insert_symbol, open_connection, open_graph,
 };
 use crate::sync::sync_leader_count;
-use crate::{SyncMode, SyncPolicy, TRACE_NODE_CAP, TraceNode};
+use crate::{RefConfidence, SyncMode, SyncPolicy, TRACE_NODE_CAP, TraceNode};
 
 #[test]
 fn synthetic_command_with_three_level_call_tree_returns_full_tree() {
@@ -24,7 +24,7 @@ fn synthetic_command_with_three_level_call_tree_returns_full_tree() {
     insert_call_ref(&conn, "src/c.rs", 10, 11, "d", "crate::d");
 
     let result = graph
-        .trace("job-run", 0)
+        .trace("job-run", 0, RefConfidence::SameModule)
         .expect("trace defaults to depth five");
 
     assert_eq!(result.visited_nodes, 5);
@@ -50,7 +50,7 @@ fn branching_factor_five_depth_five_caps_at_200_nodes() {
     seed_branching_command(&conn, 5, 5);
 
     let result = graph
-        .trace("wide-command", 5)
+        .trace("wide-command", 5, RefConfidence::SameModule)
         .expect("trace branching graph");
 
     assert_eq!(result.visited_nodes, TRACE_NODE_CAP);
@@ -64,7 +64,7 @@ fn unknown_command_returns_empty_trace_result() {
     let graph = open_graph(&worktree, SyncPolicy::Manual);
 
     let result = graph
-        .trace("missing-command", 5)
+        .trace("missing-command", 5, RefConfidence::SameModule)
         .expect("trace missing command");
 
     assert_eq!(result.visited_nodes, 0);
@@ -94,7 +94,9 @@ def leaf():
     let graph = open_graph(&worktree, SyncPolicy::Manual);
     graph.sync(SyncMode::Full).expect("sync click fixture");
 
-    let result = graph.trace("ship", 3).expect("trace click command");
+    let result = graph
+        .trace("ship", 3, RefConfidence::SameModule)
+        .expect("trace click command");
 
     assert!(result.visited_nodes > 0);
     let root = result.root.expect("trace root");
@@ -115,11 +117,66 @@ fn trace_calls_ensure_synced_at_entry() {
     let db_path = graph_db_path(&worktree);
 
     let result = graph
-        .trace("missing-after-sync", 5)
+        .trace("missing-after-sync", 5, RefConfidence::SameModule)
         .expect("trace triggers sync");
 
     assert_eq!(sync_leader_count(db_path.as_path()), 1);
     assert!(result.root.is_none());
+}
+
+#[test]
+fn confidence_floor_filters_and_prevents_below_floor_expansion() {
+    let worktree = TestWorktree::new("trace-confidence-floor");
+    let graph = open_graph(&worktree, SyncPolicy::Manual);
+    let conn = open_connection(&worktree);
+
+    let root_id = seed_symbol(&conn, "src/root.rs", "handler", "crate::handler");
+    seed_symbol(&conn, "src/exact.rs", "exact", "crate::exact");
+    seed_symbol(&conn, "src/same.rs", "same", "crate::same_module");
+    seed_symbol(&conn, "src/leaf.rs", "leaf", "crate::leaf");
+    seed_symbol(&conn, "src/fuzzy.rs", "fuzzy", "crate::fuzzy");
+    insert_command(&conn, "job-run", "src/root.rs", root_id);
+    insert_call_ref_with_confidence(
+        &conn,
+        "src/root.rs",
+        10,
+        11,
+        "exact",
+        "crate::exact",
+        "exact",
+    );
+    insert_call_ref_with_confidence(
+        &conn,
+        "src/root.rs",
+        20,
+        21,
+        "same",
+        "crate::same_module",
+        "same_module",
+    );
+    insert_call_ref_with_confidence(
+        &conn,
+        "src/root.rs",
+        30,
+        31,
+        "fuzzy",
+        "crate::fuzzy",
+        "fuzzy_name",
+    );
+    insert_call_ref_with_confidence(&conn, "src/same.rs", 10, 11, "leaf", "crate::leaf", "exact");
+
+    let default_floor = graph
+        .trace("job-run", 2, RefConfidence::SameModule)
+        .expect("trace default confidence floor");
+    let default_root = default_floor.root.expect("default trace root");
+    assert_eq!(child_names(&default_root), vec!["exact", "same"]);
+    assert_eq!(child_names(child(&default_root, "same")), vec!["leaf"]);
+
+    let exact_floor = graph
+        .trace("job-run", 2, RefConfidence::Exact)
+        .expect("trace exact confidence floor");
+    let exact_root = exact_floor.root.expect("exact trace root");
+    assert_eq!(child_names(&exact_root), vec!["exact"]);
 }
 
 fn seed_symbol(conn: &Connection, file_path: &str, name: &str, qualified: &str) -> i64 {
@@ -145,17 +202,38 @@ fn insert_call_ref(
     target_name: &str,
     target_qualified: &str,
 ) {
+    insert_call_ref_with_confidence(
+        conn,
+        from_file,
+        span_start,
+        span_end,
+        target_name,
+        target_qualified,
+        "exact",
+    );
+}
+
+fn insert_call_ref_with_confidence(
+    conn: &Connection,
+    from_file: &str,
+    span_start: usize,
+    span_end: usize,
+    target_name: &str,
+    target_qualified: &str,
+    confidence: &str,
+) {
     conn.execute(
         "INSERT INTO refs (
             from_file, from_span_start, from_span_end, target_name, target_qualified,
             target_symbol_hint, kind, confidence
-         ) VALUES (?1, ?2, ?3, ?4, ?5, NULL, 'call', 'exact')",
+         ) VALUES (?1, ?2, ?3, ?4, ?5, NULL, 'call', ?6)",
         params![
             from_file,
             i64::try_from(span_start).expect("span start fits"),
             i64::try_from(span_end).expect("span end fits"),
             target_name,
             target_qualified,
+            confidence,
         ],
     )
     .expect("insert call ref");

--- a/crates/orbit-graph/src/query/trace.rs
+++ b/crates/orbit-graph/src/query/trace.rs
@@ -6,10 +6,16 @@ use rusqlite::{Connection, OptionalExtension, params};
 
 use crate::query::callees;
 use crate::{
-    DEFAULT_TRACE_DEPTH, Graph, GraphError, SymbolSpan, TRACE_NODE_CAP, TraceNode, TraceResult,
+    DEFAULT_TRACE_DEPTH, Graph, GraphError, RefConfidence, SymbolSpan, TRACE_NODE_CAP, TraceNode,
+    TraceResult,
 };
 
-pub(crate) fn run(graph: &Graph, command: &str, depth: u8) -> Result<TraceResult, GraphError> {
+pub(crate) fn run(
+    graph: &Graph,
+    command: &str,
+    depth: u8,
+    min_confidence: RefConfidence,
+) -> Result<TraceResult, GraphError> {
     let conn = Connection::open(graph.db_path.path())
         .map_err(|source| GraphError::sqlite("open graph database for trace", source))?;
     let Some(origin) = resolve_command_handler(&conn, command)? else {
@@ -32,6 +38,9 @@ pub(crate) fn run(graph: &Graph, command: &str, depth: u8) -> Result<TraceResult
 
         let next_distance = distance + 1;
         for edge in callees::edges_for_symbol(&conn, &symbol.span())? {
+            if !confidence_visible_at_floor(edge.confidence.as_str(), min_confidence)? {
+                continue;
+            }
             if arena.len() >= TRACE_NODE_CAP {
                 truncated = true;
                 break 'bfs;
@@ -60,6 +69,13 @@ pub(crate) fn run(graph: &Graph, command: &str, depth: u8) -> Result<TraceResult
         truncated,
         visited_nodes: arena.len(),
     })
+}
+
+fn confidence_visible_at_floor(
+    confidence: &str,
+    min_confidence: RefConfidence,
+) -> Result<bool, GraphError> {
+    Ok(RefConfidence::from_db(confidence)?.visible_at_floor(min_confidence))
 }
 
 fn resolve_command_handler(

--- a/crates/orbit-mcp/src/adapter/graph.rs
+++ b/crates/orbit-mcp/src/adapter/graph.rs
@@ -178,6 +178,12 @@ pub(super) fn graph_tool_schemas() -> Vec<ToolSchema> {
             vec![
                 param("selector", "Origin selector.", "string", true),
                 param("depth", "Maximum traversal depth.", "number", false),
+                param(
+                    "confidence",
+                    "Minimum confidence floor. Defaults to same_module.",
+                    "string",
+                    false,
+                ),
             ],
         ),
         schema(
@@ -186,6 +192,12 @@ pub(super) fn graph_tool_schemas() -> Vec<ToolSchema> {
             vec![
                 param("command_name", "Command name to trace.", "string", true),
                 param("depth", "Maximum call-tree depth.", "number", false),
+                param(
+                    "confidence",
+                    "Minimum confidence floor. Defaults to same_module.",
+                    "string",
+                    false,
+                ),
             ],
         ),
     ]
@@ -269,9 +281,10 @@ fn graph_callees(graph: &Graph, input: &Value) -> Result<Value, OrbitError> {
 fn graph_impact(graph: &Graph, input: &Value) -> Result<Value, OrbitError> {
     let selector = parse_selector(required_string(input, &["selector"], "selector")?)?;
     let depth = optional_u8(input, "depth")?.unwrap_or(DEFAULT_IMPACT_DEPTH);
+    let min_confidence = optional_confidence(input)?;
     to_json(
         graph
-            .impact(&selector, depth)
+            .impact(&selector, depth, min_confidence)
             .map_err(graph_error_to_orbit)?,
     )
 }
@@ -279,11 +292,19 @@ fn graph_impact(graph: &Graph, input: &Value) -> Result<Value, OrbitError> {
 fn graph_trace(graph: &Graph, input: &Value) -> Result<Value, OrbitError> {
     let command_name = required_string(input, &["command_name", "command"], "command_name")?;
     let depth = optional_u8(input, "depth")?.unwrap_or(DEFAULT_TRACE_DEPTH);
+    let min_confidence = optional_confidence(input)?;
     to_json(
         graph
-            .trace(command_name.as_str(), depth)
+            .trace(command_name.as_str(), depth, min_confidence)
             .map_err(graph_error_to_orbit)?,
     )
+}
+
+fn optional_confidence(input: &Value) -> Result<RefConfidence, OrbitError> {
+    optional_string(input, "confidence")?
+        .map(|value| parse_confidence(value.as_str()))
+        .transpose()
+        .map(|confidence| confidence.unwrap_or_default())
 }
 
 fn parse_selector(raw: String) -> Result<Selector, OrbitError> {

--- a/crates/orbit-mcp/src/adapter/tests/graph.rs
+++ b/crates/orbit-mcp/src/adapter/tests/graph.rs
@@ -33,8 +33,8 @@ fn graph_tool_schemas_cover_cli_parameters() {
     assert_param_names(&schemas[2], &["selector", "max_bytes"]);
     assert_param_names(&schemas[3], &["symbol", "confidence", "kind"]);
     assert_param_names(&schemas[4], &["symbol"]);
-    assert_param_names(&schemas[5], &["selector", "depth"]);
-    assert_param_names(&schemas[6], &["command_name", "depth"]);
+    assert_param_names(&schemas[5], &["selector", "depth", "confidence"]);
+    assert_param_names(&schemas[6], &["command_name", "depth", "confidence"]);
 }
 
 #[test]
@@ -143,7 +143,8 @@ async fn graph_tools_invoke_in_process_fixture() {
         "orbit.graph.impact",
         json!({
             "selector": "symbol:src/lib.rs#entry:function",
-            "depth": 2
+            "depth": 2,
+            "confidence": "same_module"
         }),
     )
     .await;
@@ -155,7 +156,8 @@ async fn graph_tools_invoke_in_process_fixture() {
         "orbit.graph.trace",
         json!({
             "command_name": "missing-command",
-            "depth": 2
+            "depth": 2,
+            "confidence": "same_module"
         }),
     )
     .await;

--- a/docs/design/orbit-graph/2_design.md
+++ b/docs/design/orbit-graph/2_design.md
@@ -3,7 +3,7 @@ summary: "Orbit Graph — Design"
 type: design
 title: "Orbit Graph — Design"
 owner: claude
-last_updated: 2026-05-24
+last_updated: 2026-05-25
 status: Draft
 feature: orbit-graph
 doc_role: design
@@ -181,8 +181,8 @@ orbit graph search   <query>   [--kind symbol|string|config] [--lang X]
 orbit graph show     <selector>
 orbit graph refs     <symbol>  [--confidence ...] [--kind ...]
 orbit graph callees  <symbol>
-orbit graph impact   <selector> [--depth N=3]
-orbit graph trace    <command> [--depth N=5]
+orbit graph impact   <selector> [--depth N=3] [--confidence exact|import|same_module|fuzzy]
+orbit graph trace    <command> [--depth N=5] [--confidence exact|import|same_module|fuzzy]
 ```
 
 Bounded outputs: `impact` and `trace` both cap at 200 visited nodes regardless of `--depth`. When the cap fires, the response carries `truncated: true` so callers can split into narrower queries.
@@ -210,8 +210,8 @@ impl Graph {
     pub fn show(&self, sel: &Selector, max_bytes: usize) -> Result<Option<NodeView>, GraphError>;
     pub fn refs(&self, sel: &Selector, opts: &RefOpts)-> Result<RefResult, GraphError>;
     pub fn callees(&self, sel: &Selector)             -> Result<Vec<CalleeEdge>, GraphError>;
-    pub fn impact(&self, sel: &Selector, depth: u8)   -> Result<ImpactResult, GraphError>;
-    pub fn trace(&self, command: &str, depth: u8)     -> Result<TraceResult, GraphError>;
+    pub fn impact(&self, sel: &Selector, depth: u8, min_confidence: Confidence) -> Result<ImpactResult, GraphError>;
+    pub fn trace(&self, command: &str, depth: u8, min_confidence: Confidence)   -> Result<TraceResult, GraphError>;
 }
 ```
 

--- a/docs/design/orbit-graph/specs/GRAPH_SPEC.md
+++ b/docs/design/orbit-graph/specs/GRAPH_SPEC.md
@@ -1,7 +1,7 @@
 # Orbit Graph — Redesign Spec
 
 **Status:** Draft proposal
-**Last updated:** 2026-05-25 (ORB-00323 command extraction coverage)
+**Last updated:** 2026-05-25 (ORB-00327 impact/trace confidence floor)
 **Relation to `orbit-knowledge`:** Coexists initially. Both crates run side-by-side under a feature flag; whether `orbit-knowledge` is eventually phased out depends on the head-to-head effectiveness measurement in §16 Step 4 — it is not a foregone conclusion of this spec.
 **Author:** working from the V2 sketch in `GRAPH_V2.md` + the existing design in [`../../knowledge-graph/`](../../knowledge-graph/)
 **Scope:** V1 — read-only graph. A writeable graph (Rename, ReplaceBody, Move, working-graph overlay, patch compiler) is V2, sketched in §17 and tracked in [`../3_vision.md`](../3_vision.md). The previous separate `GRAPH_DESIGN.md` describing the write surface has been folded into this spec on 2026-05-24 to remove the contradictory scope between the two docs.
@@ -382,8 +382,8 @@ orbit graph show <selector>
 orbit graph refs <symbol> [--confidence exact|import|same_module|fuzzy]
                           [--kind call|type|use|trait_bound|impl|extends|implements]
 orbit graph callees <symbol>
-orbit graph impact <selector> [--depth N=3]
-orbit graph trace <command-name> [--depth N=5]
+orbit graph impact <selector> [--depth N=3] [--confidence exact|import|same_module|fuzzy]
+orbit graph trace <command-name> [--depth N=5] [--confidence exact|import|same_module|fuzzy]
 ```
 
 ### 9.1 `search`
@@ -446,15 +446,15 @@ Outbound calls from a symbol. Walks `refs WHERE from_file = ? AND from_span_star
 
 ### 9.5 `impact`
 
-BFS over the union of `refs` (inbound) and `callees` (outbound), plus `relations` for impl-driven edges. Default depth 3. Default confidence floor: `same_module` (matches `refs`' default — excludes only `fuzzy_name`). Returns a flat list of touched symbols ordered by graph distance, capped at 200.
+BFS over the union of `refs` (inbound) and `callees` (outbound), plus `relations` for impl-driven edges. Default depth 3. Accepts the same confidence floor as `refs` (`--confidence exact|import|same_module|fuzzy`; Rust API parameter `min_confidence`). Default confidence floor: `same_module` (matches `refs`' default -- excludes only `fuzzy_name`). Edges below the floor are not included or enqueued for later BFS levels. Returns a flat list of touched symbols ordered by graph distance, capped at 200.
 
 ### 9.6 `trace`
 
 ```bash
-orbit graph trace job-run
+orbit graph trace job-run [--confidence exact|import|same_module|fuzzy]
 ```
 
-Resolves command name to its handler symbol via `commands.handler_symbol`, then BFS over `callees` with depth 5. Returns the call tree as nested JSON.
+Resolves command name to its handler symbol via `commands.handler_symbol`, then BFS over `callees` with depth 5. The Rust API accepts `min_confidence`; the CLI/MCP default is `same_module`, matching `refs` and `impact`. Call edges below the floor are not included or enqueued for later BFS levels. Returns the call tree as nested JSON.
 
 Unknown command names return an empty result (`root: null`, `visited_nodes: 0`). Resolved commands return a single root node for the handler; each nested `children` list contains outbound call targets reached from that symbol. `confidence` is `null` on the root and carries the resolver confidence string on call edges.
 
@@ -533,8 +533,8 @@ impl Graph {
     pub fn show(&self, sel: &Selector, max_bytes: usize) -> Result<Option<NodeView>, GraphError>;
     pub fn refs(&self, sel: &Selector, opts: &RefOpts) -> Result<RefResult, GraphError>;
     pub fn callees(&self, sel: &Selector) -> Result<Vec<CalleeEdge>, GraphError>;
-    pub fn impact(&self, sel: &Selector, depth: u8) -> Result<ImpactResult, GraphError>;
-    pub fn trace(&self, command: &str, depth: u8) -> Result<TraceResult, GraphError>;
+    pub fn impact(&self, sel: &Selector, depth: u8, min_confidence: Confidence) -> Result<ImpactResult, GraphError>;
+    pub fn trace(&self, command: &str, depth: u8, min_confidence: Confidence) -> Result<TraceResult, GraphError>;
 }
 
 pub struct TraceResult {


### PR DESCRIPTION
## Task

[ORB-00327](https://orbit-cli.com/tasks/ORB-00327) — Add min_confidence parameter to orbit-graph impact and trace queries

### Description

## Problem

The `impact` and `trace` queries lock to the default confidence floor (`SameModule`) with no caller-controllable parameter:

- `crates/orbit-graph/src/lib.rs:584-602` — `Graph::impact(sel, depth)` does not accept confidence
- `crates/orbit-graph/src/query/trace.rs:34` — consumes `callees::edges_for_symbol` raw, with no confidence filter at all

`refs` accepts a confidence floor (CLI flag plus RefOpts.confidence in the Rust API). impact and trace traverse the same `relations` table but cannot be widened to surface fuzzy edges for blast-radius audits, nor narrowed to exact-only for high-precision sweeps. In trace, fuzzy edges become real BFS nodes — and the 200-node cap fires regardless of edge quality, so noisy fuzzy edges can crowd out real callees in large fan-outs.

## Why It Matters

The confidence ladder is the read-time precision dial agents rely on (`docs/design/orbit-graph/specs/GRAPH_SPEC.md` §15). Two of the three traversal queries don't expose it. This caps the value of the ladder design and means agents reading the spec see a knob that isn't actually there for those queries.

## Constraints / Notes

- Add a min_confidence (of type Confidence) parameter to the Rust API on Graph::impact and Graph::trace. Default to Confidence::SameModule to preserve current behavior.
- Add corresponding CLI flags on the impact and trace subcommands; mirror the parsing pattern used by refs.
- Add corresponding MCP schema fields in `crates/orbit-mcp/src/adapter/graph.rs` for both tools with the same default.
- BFS in trace must filter edges below the floor before enqueueing — apply at the SQL or post-fetch step in callees::edges_for_symbol or its callsite.
- Tests in `crates/orbit-graph/src/query/tests/{impact,trace}.rs`: floor at default surfaces all current rows; floor at exact filters out fuzzy and same_module; trace BFS does not enqueue below-floor edges.
- Schema unchanged.
- GRAPH_SPEC.md §9.5 and §9.6 updated to document the new parameter.

### Acceptance Criteria

- Graph::impact and Graph::trace accept a min_confidence parameter of type Confidence; default is Confidence::SameModule
- The impact and trace CLI subcommands accept a corresponding flag matching the refs subcommand naming convention
- MCP tool schemas for orbit.graph.impact and orbit.graph.trace declare the new field with the same default
- Trace BFS does not enqueue edges below the floor; new test asserts this
- Impact BFS does not enqueue edges below the floor; new test asserts this
- Default-floor behavior is unchanged; existing tests pass without modification
- GRAPH_SPEC.md §9.5 and §9.6 document the new parameter
- cargo test -p orbit-graph -p orbit-graph-cli -p orbit-mcp passes
- make ci-fast passes

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Added a public `Confidence` alias/default for the existing confidence ladder and threaded `min_confidence` through `Graph::impact`, `Graph::trace`, and the impact/trace BFS implementations.
- Added `--confidence` to the impact and trace CLI subcommands, plus matching MCP `confidence` schema/input handling with `same_module` default.
- Added focused impact/trace tests proving default floor behavior and exact-floor filtering prevents below-floor expansion; updated CLI/MCP coverage for the new parameter.
- Updated GRAPH_SPEC.md §9.5/§9.6 and the orbit-graph design summary to document the new confidence floor.

Assessment: The change is scoped to graph traversal query surfaces and preserves existing default behavior while enabling narrower or wider confidence floors.

Validation:
- `cargo test -p orbit-graph -p orbit-graph-cli -p orbit-mcp`
- `make ci-fast`
- `git diff --check`

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-00327-6a13fc65`
- Behind base: 0
- Ahead of base: 1