### PR TITLE
orbit-graph polish batch: golden tests, callees coverage, MCP schema parity, UX warts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2251,6 +2251,7 @@ dependencies = [
  "rayon",
  "rusqlite",
  "serde",
+ "serde_json",
  "tracing",
 ]
 

--- a/crates/orbit-graph-extract/src/languages/go.rs
+++ b/crates/orbit-graph-extract/src/languages/go.rs
@@ -307,7 +307,7 @@ fn collect_call_ref(node: Node, source: &str, state: &mut ExtractionState) {
             source,
             Some(node_text(function, source)),
             "call",
-            "same_module",
+            "fuzzy_name",
         ),
         "selector_expression" => collect_selector_call_ref(function, source, state),
         "type_instantiation_expression" | "generic_type" => {
@@ -344,7 +344,7 @@ fn collect_type_refs(node: Node, source: &str, state: &mut ExtractionState) {
     match node.kind() {
         "type_identifier" => {
             let target = node_text(node, source);
-            state.push_ref(node, source, Some(target), "type", "same_module");
+            state.push_ref(node, source, Some(target), "type", "fuzzy_name");
             return;
         }
         "qualified_type" => {
@@ -387,7 +387,7 @@ fn collect_qualified_type_ref(node: Node, source: &str, state: &mut ExtractionSt
     let confidence = if state.import_aliases.contains_key(&package) {
         "import_resolved"
     } else {
-        "same_module"
+        "fuzzy_name"
     };
     state.push_ref(
         name_node,

--- a/crates/orbit-graph-extract/src/languages/js_ts.rs
+++ b/crates/orbit-graph-extract/src/languages/js_ts.rs
@@ -475,7 +475,7 @@ fn collect_type_refs(node: Node, source: &str, state: &mut ExtractionState) {
                     symbol.name.clone(),
                     Some(symbol.name),
                     "type",
-                    "same_module",
+                    "fuzzy_name",
                 );
             }
         }
@@ -586,7 +586,7 @@ fn collect_callable_ref(
     match function.kind() {
         "identifier" => {
             let name = node_text(function, source);
-            state.push_ref(function, source, Some(name), "call", "same_module");
+            state.push_ref(function, source, Some(name), "call", "fuzzy_name");
         }
         "member_expression" | "optional_chain" | "subscript_expression" => {
             if let Some(property) = member_property_node(function) {
@@ -765,7 +765,7 @@ fn confidence_for_reference(name: &str) -> &'static str {
     if name.contains('.') || name.contains('/') {
         "import_resolved"
     } else {
-        "same_module"
+        "fuzzy_name"
     }
 }
 

--- a/crates/orbit-graph-extract/src/languages/python.rs
+++ b/crates/orbit-graph-extract/src/languages/python.rs
@@ -626,7 +626,7 @@ fn collect_call_ref(
                 source,
                 Some(qualify_name(parent_symbol, &name)),
                 "call",
-                "same_module",
+                "fuzzy_name",
             );
         }
         "attribute" => {
@@ -880,7 +880,7 @@ fn confidence_for_name(name: &str) -> &'static str {
     if name.contains('.') {
         "import_resolved"
     } else {
-        "same_module"
+        "fuzzy_name"
     }
 }
 

--- a/crates/orbit-graph-extract/src/languages/ruby.rs
+++ b/crates/orbit-graph-extract/src/languages/ruby.rs
@@ -368,7 +368,7 @@ fn collect_call_ref(
             source,
             Some(qualify_name(parent_symbol, &method_name)),
             "call",
-            "same_module",
+            "fuzzy_name",
         );
     }
 }
@@ -545,7 +545,7 @@ fn confidence_for_name(name: &str) -> &'static str {
     if name.contains("::") {
         "import_resolved"
     } else {
-        "same_module"
+        "fuzzy_name"
     }
 }
 

--- a/crates/orbit-graph-extract/src/languages/rust.rs
+++ b/crates/orbit-graph-extract/src/languages/rust.rs
@@ -608,7 +608,7 @@ fn collect_call_ref(node: Node, source: &str, module: &ModuleScope, state: &mut 
             source,
             Some(module.qualify(&node_text(function, source))),
             "call",
-            "same_module",
+            "fuzzy_name",
         ),
         "scoped_identifier" => state.push_ref(
             function,
@@ -900,7 +900,7 @@ fn confidence_for_type(node: Node, source: &str) -> &'static str {
     if text.contains("::") {
         "import_resolved"
     } else {
-        "same_module"
+        "fuzzy_name"
     }
 }
 

--- a/crates/orbit-graph/Cargo.toml
+++ b/crates/orbit-graph/Cargo.toml
@@ -20,3 +20,6 @@ rayon.workspace = true
 rusqlite.workspace = true
 serde.workspace = true
 tracing.workspace = true
+
+[dev-dependencies]
+serde_json.workspace = true

--- a/crates/orbit-graph/src/lib.rs
+++ b/crates/orbit-graph/src/lib.rs
@@ -583,6 +583,7 @@ pub struct RefTarget {
     /// Short symbol name requested or resolved.
     pub name: String,
     /// Fully-qualified symbol name used as the graph query key.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub qualified: Option<String>,
 }
 
@@ -623,8 +624,8 @@ pub struct CalleeEdge {
     pub target_qualified: Option<String>,
     /// Confidence label emitted verbatim by the resolver (P3.3) at write time.
     pub confidence: String,
-    /// Start byte offset of the call site span inside its source file (minimum for attribution).
-    pub from_span: i64,
+    /// One-based source line containing the call site.
+    pub line: usize,
 }
 
 /// Bounded impact result returned by [`Graph::impact`].

--- a/crates/orbit-graph/src/query/callees.rs
+++ b/crates/orbit-graph/src/query/callees.rs
@@ -1,5 +1,8 @@
 //! Outbound call-edge query.
 
+use std::fs;
+use std::path::{Path, PathBuf};
+
 use orbit_graph_extract::Selector;
 use rusqlite::{Connection, params};
 
@@ -13,13 +16,18 @@ pub(crate) fn run(graph: &Graph, sel: &Selector) -> Result<Vec<CalleeEdge>, Grap
 
     let conn = Connection::open(graph.db_path.path())
         .map_err(|source| GraphError::sqlite("open graph database for callees", source))?;
-    edges_for_symbol(&conn, &symbol)
+    let edges = edges_for_symbol(&conn, &symbol)?;
+    materialize_edges(
+        graph.worktree_root.as_path(),
+        symbol.file_path.as_str(),
+        edges,
+    )
 }
 
 pub(crate) fn edges_for_symbol(
     conn: &Connection,
     symbol: &SymbolSpan,
-) -> Result<Vec<CalleeEdge>, GraphError> {
+) -> Result<Vec<StoredCalleeEdge>, GraphError> {
     let mut stmt = conn
         .prepare_cached(
             "SELECT target_name, target_qualified, confidence, from_span_start
@@ -35,7 +43,7 @@ pub(crate) fn edges_for_symbol(
     stmt.query_map(
         params![symbol.file_path, symbol.span_start, symbol.span_end],
         |row| {
-            Ok(CalleeEdge {
+            Ok(StoredCalleeEdge {
                 target_name: row.get(0)?,
                 target_qualified: row.get(1)?,
                 confidence: row.get(2)?,
@@ -46,4 +54,81 @@ pub(crate) fn edges_for_symbol(
     .map_err(|source| GraphError::sqlite("execute callees query", source))?
     .collect::<Result<Vec<_>, _>>()
     .map_err(|source| GraphError::sqlite("collect callees edges", source))
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct StoredCalleeEdge {
+    pub(crate) target_name: String,
+    pub(crate) target_qualified: Option<String>,
+    pub(crate) confidence: String,
+    pub(crate) from_span: i64,
+}
+
+fn materialize_edges(
+    worktree_root: &Path,
+    file_path: &str,
+    edges: Vec<StoredCalleeEdge>,
+) -> Result<Vec<CalleeEdge>, GraphError> {
+    if edges.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let source_path = source_path(worktree_root, file_path);
+    let bytes = fs::read(source_path.as_path()).map_err(|source| {
+        GraphError::io(
+            "read source file for graph callee line",
+            source_path,
+            source,
+        )
+    })?;
+    let lines = LineIndex::new(bytes);
+    edges
+        .into_iter()
+        .map(|edge| {
+            let from_span = usize::try_from(edge.from_span).map_err(|source| {
+                GraphError::invalid_data("compute graph callee line", source.to_string())
+            })?;
+            Ok(CalleeEdge {
+                target_name: edge.target_name,
+                target_qualified: edge.target_qualified,
+                confidence: edge.confidence,
+                line: lines.line_for(from_span),
+            })
+        })
+        .collect()
+}
+
+fn source_path(worktree_root: &Path, file: &str) -> PathBuf {
+    let path = Path::new(file);
+    if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        worktree_root.join(path)
+    }
+}
+
+struct LineIndex {
+    byte_len: usize,
+    line_starts: Vec<usize>,
+}
+
+impl LineIndex {
+    fn new(bytes: Vec<u8>) -> Self {
+        let mut line_starts = vec![0];
+        for (index, byte) in bytes.iter().enumerate() {
+            if *byte == b'\n' {
+                line_starts.push(index + 1);
+            }
+        }
+        Self {
+            byte_len: bytes.len(),
+            line_starts,
+        }
+    }
+
+    fn line_for(&self, byte_offset: usize) -> usize {
+        let capped = byte_offset.min(self.byte_len);
+        self.line_starts
+            .partition_point(|line_start| *line_start <= capped)
+    }
 }

--- a/crates/orbit-graph/src/query/tests/callees.golden.json
+++ b/crates/orbit-graph/src/query/tests/callees.golden.json
@@ -1,0 +1,14 @@
+[
+  {
+    "target_name": "foo",
+    "target_qualified": "crate::foo",
+    "confidence": "exact",
+    "line": 2
+  },
+  {
+    "target_name": "dynamic",
+    "target_qualified": null,
+    "confidence": "fuzzy_name",
+    "line": 4
+  }
+]

--- a/crates/orbit-graph/src/query/tests/callees.rs
+++ b/crates/orbit-graph/src/query/tests/callees.rs
@@ -1,0 +1,181 @@
+use rusqlite::{Connection, params};
+
+use crate::query::tests::support::{
+    TestWorktree, assert_json_matches_fixture, insert_file, insert_symbol, open_connection,
+    open_graph,
+};
+use crate::{CalleeEdge, Selector, SyncPolicy};
+
+#[test]
+fn callees_result_shape_matches_golden_fixture() {
+    let result = vec![
+        CalleeEdge {
+            target_name: "foo".to_string(),
+            target_qualified: Some("crate::foo".to_string()),
+            confidence: "exact".to_string(),
+            line: 2,
+        },
+        CalleeEdge {
+            target_name: "dynamic".to_string(),
+            target_qualified: None,
+            confidence: "fuzzy_name".to_string(),
+            line: 4,
+        },
+    ];
+
+    assert_json_matches_fixture(&result, include_str!("callees.golden.json"));
+}
+
+#[test]
+fn mixed_confidence_edges_return_source_lines() {
+    let worktree = TestWorktree::new("callees-mixed");
+    let source = "fn caller() {\n    exact_call();\n    fuzzy_call();\n    imported_call();\n}\n";
+    worktree.write("src/lib.rs", source);
+    let graph = open_graph(&worktree, SyncPolicy::Manual);
+    let conn = open_connection(&worktree);
+    seed_caller(&conn, source);
+
+    insert_call_ref(
+        &conn,
+        source.find("exact_call").expect("exact call span"),
+        "exact_call",
+        Some("crate::exact_call"),
+        "exact",
+    );
+    insert_call_ref(
+        &conn,
+        source.find("fuzzy_call").expect("fuzzy call span"),
+        "fuzzy_call",
+        None,
+        "fuzzy_name",
+    );
+    insert_call_ref(
+        &conn,
+        source.find("imported_call").expect("imported call span"),
+        "imported_call",
+        Some("other::imported_call"),
+        "import_resolved",
+    );
+
+    let edges = graph
+        .callees(&caller_selector())
+        .expect("query mixed callees");
+
+    assert_eq!(
+        edges,
+        vec![
+            CalleeEdge {
+                target_name: "exact_call".to_string(),
+                target_qualified: Some("crate::exact_call".to_string()),
+                confidence: "exact".to_string(),
+                line: 2,
+            },
+            CalleeEdge {
+                target_name: "fuzzy_call".to_string(),
+                target_qualified: None,
+                confidence: "fuzzy_name".to_string(),
+                line: 3,
+            },
+            CalleeEdge {
+                target_name: "imported_call".to_string(),
+                target_qualified: Some("other::imported_call".to_string()),
+                confidence: "import_resolved".to_string(),
+                line: 4,
+            },
+        ]
+    );
+}
+
+#[test]
+fn leaf_symbol_with_no_call_refs_returns_empty_edges() {
+    let worktree = TestWorktree::new("callees-leaf");
+    let source = "fn caller() {\n}\n";
+    worktree.write("src/lib.rs", source);
+    let graph = open_graph(&worktree, SyncPolicy::Manual);
+    let conn = open_connection(&worktree);
+    seed_caller(&conn, source);
+
+    let edges = graph
+        .callees(&caller_selector())
+        .expect("query leaf callees");
+
+    assert!(edges.is_empty());
+}
+
+#[test]
+fn null_qualified_edges_are_preserved_and_ordered_by_span() {
+    let worktree = TestWorktree::new("callees-null-qualified");
+    let source = "fn caller() {\n    first();\n    second();\n}\n";
+    worktree.write("src/lib.rs", source);
+    let graph = open_graph(&worktree, SyncPolicy::Manual);
+    let conn = open_connection(&worktree);
+    seed_caller(&conn, source);
+    insert_call_ref(
+        &conn,
+        source.find("second").expect("second span"),
+        "second",
+        None,
+        "fuzzy_name",
+    );
+    insert_call_ref(
+        &conn,
+        source.find("first").expect("first span"),
+        "first",
+        None,
+        "fuzzy_name",
+    );
+
+    let edges = graph
+        .callees(&caller_selector())
+        .expect("query null-qualified callees");
+
+    let names = edges
+        .iter()
+        .map(|edge| (edge.target_name.as_str(), edge.target_qualified.as_deref()))
+        .collect::<Vec<_>>();
+    assert_eq!(names, vec![("first", None), ("second", None)]);
+}
+
+fn seed_caller(conn: &Connection, source: &str) {
+    insert_file(conn, "src/lib.rs", "rust", source);
+    insert_symbol(
+        conn,
+        "src/lib.rs",
+        "caller",
+        "crate::caller",
+        "function",
+        0,
+        source.len(),
+    );
+}
+
+fn caller_selector() -> Selector {
+    Selector::Symbol {
+        path: "src/lib.rs".to_string(),
+        symbol: "caller".to_string(),
+        kind: "function".to_string(),
+    }
+}
+
+fn insert_call_ref(
+    conn: &Connection,
+    span_start: usize,
+    target_name: &str,
+    target_qualified: Option<&str>,
+    confidence: &str,
+) {
+    conn.execute(
+        "INSERT INTO refs (
+            from_file, from_span_start, from_span_end, target_name, target_qualified,
+            target_symbol_hint, kind, confidence
+         ) VALUES ('src/lib.rs', ?1, ?2, ?3, ?4, NULL, 'call', ?5)",
+        params![
+            i64::try_from(span_start).expect("span start fits"),
+            i64::try_from(span_start + target_name.len()).expect("span end fits"),
+            target_name,
+            target_qualified,
+            confidence
+        ],
+    )
+    .expect("insert call ref");
+}

--- a/crates/orbit-graph/src/query/tests/impact.golden.json
+++ b/crates/orbit-graph/src/query/tests/impact.golden.json
@@ -1,0 +1,16 @@
+{
+  "touched": [
+    {
+      "qualified_name": "crate::a",
+      "distance": 1,
+      "edge_kind": "call"
+    },
+    {
+      "qualified_name": "crate::Impl",
+      "distance": 2,
+      "edge_kind": "impl"
+    }
+  ],
+  "truncated": false,
+  "visited_nodes": 2
+}

--- a/crates/orbit-graph/src/query/tests/impact.rs
+++ b/crates/orbit-graph/src/query/tests/impact.rs
@@ -8,7 +8,34 @@ use crate::query::tests::support::{
     TestWorktree, graph_db_path, insert_file, insert_symbol, open_connection, open_graph,
 };
 use crate::sync::sync_leader_count;
-use crate::{IMPACT_NODE_CAP, ImpactEntry, RefConfidence, RefKind, Selector, SyncPolicy};
+use crate::{
+    IMPACT_NODE_CAP, ImpactEntry, ImpactResult, RefConfidence, RefKind, Selector, SyncPolicy,
+};
+
+#[test]
+fn impact_result_shape_matches_golden_fixture() {
+    let result = ImpactResult {
+        touched: vec![
+            ImpactEntry {
+                qualified_name: "crate::a".to_string(),
+                distance: 1,
+                edge_kind: RefKind::Call,
+            },
+            ImpactEntry {
+                qualified_name: "crate::Impl".to_string(),
+                distance: 2,
+                edge_kind: RefKind::Impl,
+            },
+        ],
+        truncated: false,
+        visited_nodes: 2,
+    };
+
+    crate::query::tests::support::assert_json_matches_fixture(
+        &result,
+        include_str!("impact.golden.json"),
+    );
+}
 
 #[test]
 fn five_node_tree_at_depth_two_returns_all_five_touched_symbols() {

--- a/crates/orbit-graph/src/query/tests/mod.rs
+++ b/crates/orbit-graph/src/query/tests/mod.rs
@@ -1,2 +1,3 @@
+mod callees;
 mod refs;
 pub(in crate::query) mod support;

--- a/crates/orbit-graph/src/query/tests/refs.golden.json
+++ b/crates/orbit-graph/src/query/tests/refs.golden.json
@@ -1,0 +1,8 @@
+{
+  "target": {
+    "name": "Missing"
+  },
+  "refs": [],
+  "relations": [],
+  "skipped_low_confidence": 0
+}

--- a/crates/orbit-graph/src/query/tests/refs.rs
+++ b/crates/orbit-graph/src/query/tests/refs.rs
@@ -7,9 +7,27 @@ use rusqlite::{Connection, params};
 
 use crate::sync::sync_leader_count;
 use crate::{
-    EXTRACTOR_VERSION, Graph, RefConfidence, RefKind, RefOpts, Selector, SyncPolicy,
-    resolve_db_path,
+    EXTRACTOR_VERSION, Graph, RefConfidence, RefKind, RefOpts, RefResult, RefTarget, Selector,
+    SyncPolicy, resolve_db_path,
 };
+
+#[test]
+fn refs_result_shape_matches_golden_fixture_and_skips_unresolved_qualified() {
+    let result = RefResult {
+        target: RefTarget {
+            name: "Missing".to_string(),
+            qualified: None,
+        },
+        refs: Vec::new(),
+        relations: Vec::new(),
+        skipped_low_confidence: 0,
+    };
+
+    crate::query::tests::support::assert_json_matches_fixture(
+        &result,
+        include_str!("refs.golden.json"),
+    );
+}
 
 #[test]
 fn default_floor_skips_fuzzy_refs_and_reports_count() {

--- a/crates/orbit-graph/src/query/tests/search.golden.json
+++ b/crates/orbit-graph/src/query/tests/search.golden.json
@@ -1,0 +1,22 @@
+{
+  "matches": [
+    {
+      "kind": "symbol",
+      "name": "run_due_schedulers",
+      "path": "crates/orbit-core/src/scheduler/scheduler.rs",
+      "line": 142
+    },
+    {
+      "kind": "string",
+      "value": "scheduler tick failed",
+      "path": "crates/orbit-core/src/scheduler/runner.rs",
+      "line": 88
+    },
+    {
+      "kind": "config",
+      "value": "scheduler.interval",
+      "path": "crates/orbit-core/Cargo.toml",
+      "line": 12
+    }
+  ]
+}

--- a/crates/orbit-graph/src/query/tests/search.rs
+++ b/crates/orbit-graph/src/query/tests/search.rs
@@ -4,10 +4,36 @@ use rusqlite::{Connection, params};
 
 use super::{Match, SearchKind, SearchQuery};
 use crate::query::tests::support::{
-    TestWorktree, graph_db_path, insert_file, insert_symbol, open_connection, open_graph,
+    TestWorktree, assert_json_matches_fixture, graph_db_path, insert_file, insert_symbol,
+    open_connection, open_graph,
 };
 use crate::sync::sync_leader_count;
 use crate::{SyncMode, SyncPolicy};
+
+#[test]
+fn search_result_shape_matches_golden_fixture() {
+    let result = super::SearchResult {
+        matches: vec![
+            Match::Symbol {
+                name: "run_due_schedulers".to_string(),
+                path: "crates/orbit-core/src/scheduler/scheduler.rs".to_string(),
+                line: 142,
+            },
+            Match::StringLiteral {
+                value: "scheduler tick failed".to_string(),
+                path: "crates/orbit-core/src/scheduler/runner.rs".to_string(),
+                line: 88,
+            },
+            Match::Config {
+                value: "scheduler.interval".to_string(),
+                path: "crates/orbit-core/Cargo.toml".to_string(),
+                line: 12,
+            },
+        ],
+    };
+
+    assert_json_matches_fixture(&result, include_str!("search.golden.json"));
+}
 
 #[test]
 fn search_unions_fts_tables_and_filters_kind_and_lang() {

--- a/crates/orbit-graph/src/query/tests/show.golden.json
+++ b/crates/orbit-graph/src/query/tests/show.golden.json
@@ -1,0 +1,35 @@
+{
+  "bytes": [
+    112,
+    117,
+    98,
+    32,
+    102,
+    110,
+    32,
+    104,
+    97,
+    110,
+    100,
+    108,
+    101,
+    114,
+    40,
+    41,
+    32,
+    123,
+    125,
+    10
+  ],
+  "metadata": {
+    "file": "src/lib.rs",
+    "span": {
+      "start": 0,
+      "end": 20
+    },
+    "kind": "function",
+    "name": "handler",
+    "qualified": "crate::handler",
+    "truncated": false
+  }
+}

--- a/crates/orbit-graph/src/query/tests/show.rs
+++ b/crates/orbit-graph/src/query/tests/show.rs
@@ -1,12 +1,30 @@
 use orbit_graph_extract::Selector;
 use rusqlite::{Connection, params};
 
-use super::{DEFAULT_SHOW_MAX_BYTES, SourceSpan};
+use super::{DEFAULT_SHOW_MAX_BYTES, NodeMetadata, NodeView, SourceSpan};
 use crate::SyncPolicy;
 use crate::query::tests::support::{
-    TestWorktree, graph_db_path, insert_file, insert_symbol, open_connection, open_graph,
+    TestWorktree, assert_json_matches_fixture, graph_db_path, insert_file, insert_symbol,
+    open_connection, open_graph,
 };
 use crate::sync::sync_leader_count;
+
+#[test]
+fn show_result_shape_matches_golden_fixture() {
+    let result = NodeView {
+        bytes: b"pub fn handler() {}\n".to_vec(),
+        metadata: NodeMetadata {
+            file: "src/lib.rs".to_string(),
+            span: SourceSpan { start: 0, end: 20 },
+            kind: "function".to_string(),
+            name: Some("handler".to_string()),
+            qualified: Some("crate::handler".to_string()),
+            truncated: false,
+        },
+    };
+
+    assert_json_matches_fixture(&result, include_str!("show.golden.json"));
+}
 
 #[test]
 fn show_resolves_symbol_file_module_and_command_selectors() {

--- a/crates/orbit-graph/src/query/tests/support.rs
+++ b/crates/orbit-graph/src/query/tests/support.rs
@@ -3,6 +3,8 @@ use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use rusqlite::{Connection, params};
+use serde::Serialize;
+use serde_json::Value;
 
 use crate::{EXTRACTOR_VERSION, Graph, SyncPolicy, resolve_db_path};
 
@@ -106,4 +108,13 @@ pub(in crate::query) fn insert_symbol(
     )
     .expect("insert symbol fts row");
     id
+}
+
+pub(in crate::query) fn assert_json_matches_fixture<T>(actual: &T, fixture: &str)
+where
+    T: Serialize,
+{
+    let actual = serde_json::to_value(actual).expect("serialize query result to JSON");
+    let expected: Value = serde_json::from_str(fixture).expect("parse golden JSON fixture");
+    assert_eq!(actual, expected);
 }

--- a/crates/orbit-graph/src/query/tests/trace.golden.json
+++ b/crates/orbit-graph/src/query/tests/trace.golden.json
@@ -1,0 +1,17 @@
+{
+  "root": {
+    "name": "handler",
+    "qualified_name": "crate::handler",
+    "confidence": null,
+    "children": [
+      {
+        "name": "helper",
+        "qualified_name": "crate::helper",
+        "confidence": "exact",
+        "children": []
+      }
+    ]
+  },
+  "truncated": false,
+  "visited_nodes": 2
+}

--- a/crates/orbit-graph/src/query/tests/trace.rs
+++ b/crates/orbit-graph/src/query/tests/trace.rs
@@ -4,7 +4,31 @@ use crate::query::tests::support::{
     TestWorktree, graph_db_path, insert_file, insert_symbol, open_connection, open_graph,
 };
 use crate::sync::sync_leader_count;
-use crate::{RefConfidence, SyncMode, SyncPolicy, TRACE_NODE_CAP, TraceNode};
+use crate::{RefConfidence, SyncMode, SyncPolicy, TRACE_NODE_CAP, TraceNode, TraceResult};
+
+#[test]
+fn trace_result_shape_matches_golden_fixture() {
+    let result = TraceResult {
+        root: Some(TraceNode {
+            name: "handler".to_string(),
+            qualified_name: Some("crate::handler".to_string()),
+            confidence: None,
+            children: vec![TraceNode {
+                name: "helper".to_string(),
+                qualified_name: Some("crate::helper".to_string()),
+                confidence: Some("exact".to_string()),
+                children: Vec::new(),
+            }],
+        }),
+        truncated: false,
+        visited_nodes: 2,
+    };
+
+    crate::query::tests::support::assert_json_matches_fixture(
+        &result,
+        include_str!("trace.golden.json"),
+    );
+}
 
 #[test]
 fn synthetic_command_with_three_level_call_tree_returns_full_tree() {

--- a/crates/orbit-graph/src/tests/lib.rs
+++ b/crates/orbit-graph/src/tests/lib.rs
@@ -256,10 +256,14 @@ impl Drop for TestWorktree {
 }
 
 fn populate_callees_fixture(conn: &Connection, file_path: &str) {
+    let content = "0123456789\n".repeat(10);
     conn.execute(
         "INSERT INTO files (path, content_hash, mtime_ns, lang, byte_len, extracted_at)
-                 VALUES (?1, x'00', 1, 'rust', 200, 2)",
-        [file_path],
+                 VALUES (?1, x'00', 1, 'rust', ?2, 2)",
+        params![
+            file_path,
+            i64::try_from(content.len()).expect("content length fits")
+        ],
     )
     .expect("insert file");
 
@@ -309,7 +313,7 @@ fn query_callees_function_with_five_call_sites_returns_five_edges_including_nest
  {
     let worktree = TestWorktree::new("callees-five");
     let file_path = "src/example.rs";
-    worktree.write(file_path, "fn outer() { /* calls */ fn inner(){} }\n");
+    worktree.write(file_path, &"0123456789\n".repeat(10));
 
     let graph = Graph::open(worktree.path(), SyncPolicy::Manual).expect("open graph");
     let conn = open_test_connection(worktree.path());
@@ -336,7 +340,7 @@ fn query_callees_function_with_five_call_sites_returns_five_edges_including_nest
         .find(|e| e.target_name == "nested_call")
         .unwrap();
     assert_eq!(nested.confidence, "exact");
-    assert_eq!(nested.from_span, 30);
+    assert_eq!(nested.line, 3);
 }
 
 #[test]

--- a/crates/orbit-mcp/src/adapter/graph.rs
+++ b/crates/orbit-mcp/src/adapter/graph.rs
@@ -203,7 +203,19 @@ pub(super) fn graph_tool_schemas() -> Vec<ToolSchema> {
     ]
 }
 
-fn schema(name: &str, description: &str, parameters: Vec<ToolParam>) -> ToolSchema {
+fn schema(name: &str, description: &str, mut parameters: Vec<ToolParam>) -> ToolSchema {
+    parameters.push(param(
+        "workspace_path",
+        "Optional worktree path for this graph request.",
+        "string",
+        false,
+    ));
+    parameters.push(param(
+        "workspace",
+        "Optional worktree path alias for this graph request.",
+        "string",
+        false,
+    ));
     ToolSchema {
         name: name.to_string(),
         description: description.to_string(),

--- a/crates/orbit-mcp/src/adapter/tests/graph.rs
+++ b/crates/orbit-mcp/src/adapter/tests/graph.rs
@@ -28,13 +28,29 @@ fn graph_tool_schemas_cover_cli_parameters() {
         ]
     );
 
-    assert_param_names(&schemas[0], &["full"]);
-    assert_param_names(&schemas[1], &["query", "kind", "lang", "limit"]);
-    assert_param_names(&schemas[2], &["selector", "max_bytes"]);
-    assert_param_names(&schemas[3], &["symbol", "confidence", "kind"]);
-    assert_param_names(&schemas[4], &["symbol"]);
-    assert_param_names(&schemas[5], &["selector", "depth", "confidence"]);
-    assert_param_names(&schemas[6], &["command_name", "depth", "confidence"]);
+    assert_param_names(&schemas[0], &with_workspace_params(&["full"]));
+    assert_param_names(
+        &schemas[1],
+        &with_workspace_params(&["query", "kind", "lang", "limit"]),
+    );
+    assert_param_names(
+        &schemas[2],
+        &with_workspace_params(&["selector", "max_bytes"]),
+    );
+    assert_param_names(
+        &schemas[3],
+        &with_workspace_params(&["symbol", "confidence", "kind"]),
+    );
+    assert_param_names(&schemas[4], &with_workspace_params(&["symbol"]));
+    assert_param_names(
+        &schemas[5],
+        &with_workspace_params(&["selector", "depth", "confidence"]),
+    );
+    assert_param_names(
+        &schemas[6],
+        &with_workspace_params(&["command_name", "depth", "confidence"]),
+    );
+    assert_workspace_params_optional_strings(&schemas);
 }
 
 #[test]
@@ -59,7 +75,10 @@ fn combined_schemas_override_legacy_host_graph_tools() {
         .iter()
         .find(|schema| schema.name == "orbit.graph.search")
         .expect("graph search schema");
-    assert_param_names(search, &["query", "kind", "lang", "limit"]);
+    assert_param_names(
+        search,
+        &with_workspace_params(&["query", "kind", "lang", "limit"]),
+    );
     assert!(
         schemas
             .iter()
@@ -224,6 +243,27 @@ fn assert_param_names(schema: &orbit_common::types::ToolSchema, expected: &[&str
         .map(|param| param.name.as_str())
         .collect();
     assert_eq!(names, expected);
+}
+
+fn with_workspace_params(base: &[&'static str]) -> Vec<&'static str> {
+    base.iter()
+        .copied()
+        .chain(["workspace_path", "workspace"])
+        .collect()
+}
+
+fn assert_workspace_params_optional_strings(schemas: &[orbit_common::types::ToolSchema]) {
+    for schema in schemas {
+        for param_name in ["workspace_path", "workspace"] {
+            let param = schema
+                .parameters
+                .iter()
+                .find(|param| param.name == param_name)
+                .expect("workspace parameter exists");
+            assert_eq!(param.param_type, "string");
+            assert!(!param.required);
+        }
+    }
 }
 
 fn fixture_worktree() -> TempDir {


### PR DESCRIPTION
## Task

[ORB-00329](https://orbit-cli.com/tasks/ORB-00329) — orbit-graph polish batch: golden tests, callees coverage, MCP schema parity, UX warts

### Description

## Problem

Several smaller items from the QA review that are individually too small for their own tasks but collectively make the public surface fragile:

1. **No §9 golden-shape tests anywhere.** `crates/orbit-graph/src/query/tests/*.rs` has zero serde_json::to_value round-trips against GRAPH_SPEC.md §9 sample JSONs. Future serde renames will silently break agent consumers.

2. **callees.rs has no test file at all.** Not wired via `#[path]` (cf. search.rs:319, show.rs:226, impact.rs:345, trace.rs:171) and not in query/tests/mod.rs:1-2. Covered only transitively through impact/trace.

3. **RefTarget.qualified serializes null when unresolved** (`crates/orbit-graph/src/lib.rs:521-567`). GRAPH_SPEC.md §9.3 sample always shows a string. Add `#[serde(skip_serializing_if = "Option::is_none")]`.

4. **MCP workspace_path / workspace input fields not in schema.** `crates/orbit-mcp/src/adapter/graph.rs:345-348` accepts them but graph_tool_schemas does not declare them. Agents discovering via tools/list cannot see them.

5. **callees returns from_span (byte offset)** where every other query returns line (`crates/orbit-graph/src/lib.rs:571-580`). UX wart for human readers and JSON consumers.

6. **Pass-1 confidence labels include same_module.** Per GRAPH_SPEC.md §7.1, pass-1 should emit at most import_resolved or fuzzy_name; same_module is pass-2 territory. Violations at rust.rs:611, js_ts.rs:478,589, ruby.rs:371, python.rs:347, go.rs:310,347. Pass-2 recomputes anyway, so this is cosmetic — but the labels mislead readers of the intermediate state.

## Why It Matters

Individually small; collectively, the orbit-graph public surface is less self-consistent than it should be on first ship. Goldens in particular are cheap insurance against future serde-rename regressions.

## Constraints / Notes

- Goldens: one JSON fixture per shipping query (six total). Run serde_json::to_value on a representative QueryResult and compare against a checked-in fixture. Update fixtures intentionally when shape changes — the goldens are the contract record.
- Callees tests: mirror the structure of query/tests/impact.rs. Cover at least three scenarios (mixed confidence, leaf with empty result, dedup or null-qualified handling).
- For (5): convert at query-time by looking up file line breaks or storing line in `relations`. Pick the cheaper option and document the call.
- For (6): change emit sites to import_resolved or fuzzy_name only. Pass-2 already overwrites in resolution, so behavior is unchanged.

### Acceptance Criteria

- Golden-shape tests exist for all six shipping queries (search, show, refs, callees, impact, trace) under crates/orbit-graph/src/query/tests/; each fixture lives next to its test file
- query/tests/mod.rs lists a callees test module; the module covers at least three scenarios
- RefTarget.qualified uses skip_serializing_if Option::is_none; verified by a golden fixture that does not include the field for unresolved targets
- MCP graph_tool_schemas declares workspace_path and workspace as optional string inputs on all seven graph tools
- callees query returns line of type usize instead of or alongside from_span of type i64; pick one and document in the execution summary
- Pass-1 extractors emit only import_resolved or fuzzy_name labels; same_module is removed from pass-1 emit sites
- cargo test -p orbit-graph -p orbit-mcp -p orbit-graph-extract passes
- make ci-fast passes

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Added serde JSON golden-shape fixtures/tests for search, show, refs, callees, impact, and trace under crates/orbit-graph/src/query/tests/.
- Added a dedicated callees test module covering mixed confidence/line output, leaf empty results, and null-qualified ordering.
- Updated RefTarget.qualified to skip absent values and changed public CalleeEdge output to use one-based line: usize instead of from_span byte offsets.
- Added workspace_path/workspace optional string schema params to all seven MCP graph tools and verified them in adapter tests.
- Replaced pass-1 same_module extractor labels with fuzzy_name/import_resolved-only labels across Rust, JS/TS, Python, Ruby, and Go emit sites.

Strategic decisions:
- Callees now returns line only, not from_span | Rationale: line matches the rest of the query surface and avoids exposing byte offsets to human/API consumers.

Validation:
- cargo test -p orbit-graph -p orbit-mcp -p orbit-graph-extract
- make ci-fast

Assessment: Acceptance criteria satisfied; no task learning checkpoint item was durable enough to add.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-00329-6a13ff8a`
- Behind base: 0
- Ahead of base: 1