### PR TITLE
Detached-HEAD DB layout: ADR + implement decision

### DIFF
--- a/.orbit/adrs/accepted/ADR-0190/adr.yaml
+++ b/.orbit/adrs/accepted/ADR-0190/adr.yaml
@@ -1,0 +1,24 @@
+schema_version: 2
+id: ADR-0190
+title: Use per-commit DB files for detached HEAD
+status: accepted
+owner: codex
+created_at: 2026-05-25T17:28:27.185519Z
+accepted_at: 2026-05-25T17:28:30.633353Z
+last_updated: 2026-05-25T17:31:19.043965Z
+related_features:
+- orbit-graph
+related_tasks:
+- ORB-00331
+tags:
+- orbit-graph
+- storage
+- detached-head
+paths:
+- crates/orbit-graph/src/lib.rs
+- crates/orbit-graph/src/store/mod.rs
+- docs/design/orbit-graph/**
+supersedes: []
+legacy_ids: []
+validation_warnings: []
+legacy_validation: none

--- a/.orbit/adrs/accepted/ADR-0190/body.md
+++ b/.orbit/adrs/accepted/ADR-0190/body.md
@@ -1,0 +1,10 @@
+## Context
+ORB-00326 (78e26efa) fixed detached-HEAD meta recording, but the filename still used `HEAD.<version>.db`, so ORB-00331 had to choose between keeping one `HEAD` DB with churn warnings or giving each detached commit its own DB file. Concurrent agents on different detached commits need isolation more than they need a single reusable cache file.
+
+## Decision
+Use per-commit detached filenames: `detached-<short-sha>.<extractor_version>.db`. Branch-attached checkouts keep the existing `<branch>.<extractor_version>.db` layout, and `meta.branch` remains `HEAD` for detached checkouts.
+
+## Consequences
+- Detached checkouts on different commits no longer invalidate each other through the same `HEAD` database.
+- The stale-DB sweep must remove detached DBs whose commits are no longer reachable from any local ref, while preserving the active DB family.
+- Cost: bisecting or cherry-picking through many detached commits can create O(N) database files until the reachability sweep prunes them.

--- a/crates/orbit-graph/src/lib.rs
+++ b/crates/orbit-graph/src/lib.rs
@@ -12,8 +12,9 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
+use git2::Repository;
 pub use orbit_graph_extract::Selector;
-use rusqlite::{Connection, params};
+use rusqlite::{Connection, OpenFlags, params};
 use serde::Serialize;
 
 mod query;
@@ -406,12 +407,47 @@ impl GraphDbPath {
 /// allowlist, while the returned [`GraphDbPath`] keeps the raw branch name for
 /// future `meta.branch` storage.
 pub fn resolve_db_path(worktree_root: &Path, branch: &str, extractor_version: u32) -> GraphDbPath {
-    let sanitized_branch = sanitize_branch_for_filename(branch);
-    let filename = format!("{sanitized_branch}.{extractor_version}.db");
+    resolve_db_path_for_commit(worktree_root, branch, "", extractor_version)
+}
+
+/// Resolve the canonical graph database path, using per-commit filenames for detached HEAD.
+///
+/// Branch-attached graphs keep the branch-scoped filename. Detached HEAD graphs
+/// use `detached-<short-sha>.<version>.db` when a commit SHA is available so
+/// concurrent detached checkouts on different commits do not churn the same DB.
+// ADR-0190: detached HEAD DB filenames include a commit prefix to isolate agents.
+pub fn resolve_db_path_for_commit(
+    worktree_root: &Path,
+    branch: &str,
+    commit_sha: &str,
+    extractor_version: u32,
+) -> GraphDbPath {
+    let filename_stem = graph_db_filename_stem(branch, commit_sha);
+    let filename = format!("{filename_stem}.{extractor_version}.db");
     GraphDbPath {
         path: worktree_root.join(".orbit").join("graph").join(filename),
         branch: branch.to_string(),
         extractor_version,
+    }
+}
+
+fn graph_db_filename_stem(branch: &str, commit_sha: &str) -> String {
+    if branch == "HEAD" {
+        detached_commit_prefix(commit_sha)
+            .map(|prefix| format!("detached-{prefix}"))
+            .unwrap_or_else(|| sanitize_branch_for_filename(branch))
+    } else {
+        sanitize_branch_for_filename(branch)
+    }
+}
+
+fn detached_commit_prefix(commit_sha: &str) -> Option<&str> {
+    let commit_sha = commit_sha.trim();
+    let prefix = commit_sha.get(..12)?;
+    if prefix.chars().all(|ch| ch.is_ascii_hexdigit()) {
+        Some(prefix)
+    } else {
+        None
     }
 }
 
@@ -437,7 +473,10 @@ fn sanitize_branch_for_filename(branch: &str) -> String {
     sanitized
 }
 
-/// Delete graph database files whose filename embeds an old extractor version.
+/// Delete obsolete graph database files.
+///
+/// Removes old extractor-version files, plus detached-HEAD DBs whose commit is
+/// no longer reachable from any local ref.
 pub fn clean_old_databases(worktree_root: &Path) -> Result<CleanReport, GraphError> {
     let opened = store::open(worktree_root, SyncPolicy::Manual)?;
     clean_old_databases_excluding(worktree_root, opened.db_path.path())
@@ -459,39 +498,183 @@ fn clean_old_databases_excluding(
 
     let entries = fs::read_dir(graph_dir.as_path())
         .map_err(|source| GraphError::io("read graph database directory", &graph_dir, source))?;
+    let mut paths = Vec::new();
     for entry in entries {
         let entry = entry.map_err(|source| {
             GraphError::io("read graph database directory entry", &graph_dir, source)
         })?;
-        let path = entry.path();
-        if !path.is_file() {
+        paths.push(entry.path());
+    }
+    paths.sort();
+
+    let repo = Repository::discover(worktree_root).ok();
+    let mut delete_paths = Vec::new();
+    for path in paths {
+        if !path.is_file() || is_active_graph_db_family(path.as_path(), active_db_path) {
             continue;
         }
-        let Some(file_name) = path.file_name().and_then(|name| name.to_str()) else {
-            continue;
-        };
-        if graph_db_file_extractor_version(file_name)
-            .is_some_and(|version| version != EXTRACTOR_VERSION)
-            && path != active_db_path
-        {
-            fs::remove_file(path.as_path()).map_err(|source| {
-                GraphError::io("delete old graph database file", &path, source)
-            })?;
-            deleted.push(path);
+        if should_delete_graph_db_file(path.as_path(), repo.as_ref())? {
+            delete_paths.push(path);
         }
+    }
+
+    for path in delete_paths {
+        fs::remove_file(path.as_path())
+            .map_err(|source| GraphError::io("delete old graph database file", &path, source))?;
+        deleted.push(path);
     }
     deleted.sort();
 
     Ok(CleanReport { graph_dir, deleted })
 }
 
-fn graph_db_file_extractor_version(file_name: &str) -> Option<u32> {
+fn should_delete_graph_db_file(path: &Path, repo: Option<&Repository>) -> Result<bool, GraphError> {
+    let Some(file_name) = path.file_name().and_then(|name| name.to_str()) else {
+        return Ok(false);
+    };
+    let Some(metadata) = graph_db_file_metadata(file_name) else {
+        return Ok(false);
+    };
+
+    if metadata.extractor_version != EXTRACTOR_VERSION {
+        return Ok(true);
+    }
+
+    // ADR-0190: per-commit detached DBs are pruned by Git reachability.
+    let Some(commit_prefix) = metadata.detached_commit_prefix else {
+        return Ok(false);
+    };
+    if !detached_db_meta_matches(path, commit_prefix.as_str())? {
+        return Ok(false);
+    }
+
+    match repo {
+        Some(repo) => detached_commit_is_unreachable(repo, commit_prefix.as_str()),
+        None => Ok(false),
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct GraphDbFileMetadata {
+    extractor_version: u32,
+    detached_commit_prefix: Option<String>,
+}
+
+fn graph_db_file_metadata(file_name: &str) -> Option<GraphDbFileMetadata> {
     let db_name = file_name
         .strip_suffix(".db")
         .or_else(|| file_name.strip_suffix(".db-wal"))
         .or_else(|| file_name.strip_suffix(".db-shm"))
         .or_else(|| file_name.strip_suffix(".db.lock"))?;
-    db_name.rsplit_once('.')?.1.parse().ok()
+    let (stem, version) = db_name.rsplit_once('.')?;
+    let extractor_version = version.parse().ok()?;
+    let detached_commit_prefix = stem
+        .strip_prefix("detached-")
+        .filter(|prefix| prefix.len() == 12)
+        .filter(|prefix| prefix.chars().all(|ch| ch.is_ascii_hexdigit()))
+        .map(str::to_string);
+    Some(GraphDbFileMetadata {
+        extractor_version,
+        detached_commit_prefix,
+    })
+}
+
+fn is_active_graph_db_family(path: &Path, active_db_path: &Path) -> bool {
+    graph_db_base_path(path) == graph_db_base_path(active_db_path)
+}
+
+fn graph_db_base_path(path: &Path) -> PathBuf {
+    let Some(file_name) = path.file_name().and_then(|name| name.to_str()) else {
+        return path.to_path_buf();
+    };
+    for suffix in [".db-wal", ".db-shm", ".db.lock"] {
+        if let Some(stem) = file_name.strip_suffix(suffix) {
+            return path.with_file_name(format!("{stem}.db"));
+        }
+    }
+    path.to_path_buf()
+}
+
+fn detached_db_meta_matches(path: &Path, commit_prefix: &str) -> Result<bool, GraphError> {
+    let db_path = graph_db_base_path(path);
+    if !db_path.exists() {
+        return Ok(false);
+    }
+    let Ok(conn) = Connection::open_with_flags(db_path.as_path(), OpenFlags::SQLITE_OPEN_READ_ONLY)
+    else {
+        return Ok(false);
+    };
+    let Ok(mut stmt) =
+        conn.prepare("SELECT key, value FROM meta WHERE key IN ('branch', 'commit_sha')")
+    else {
+        return Ok(false);
+    };
+    let mut rows = stmt
+        .query([])
+        .map_err(|source| GraphError::sqlite("query detached graph metadata", source))?;
+    let mut branch = None;
+    let mut commit_sha = None;
+    while let Some(row) = rows
+        .next()
+        .map_err(|source| GraphError::sqlite("read detached graph metadata row", source))?
+    {
+        let key: String = row
+            .get(0)
+            .map_err(|source| GraphError::sqlite("read detached graph metadata key", source))?;
+        let value: String = row
+            .get(1)
+            .map_err(|source| GraphError::sqlite("read detached graph metadata value", source))?;
+        match key.as_str() {
+            "branch" => branch = Some(value),
+            "commit_sha" => commit_sha = Some(value),
+            _ => {}
+        }
+    }
+    Ok(branch.as_deref() == Some("HEAD")
+        && commit_sha
+            .as_deref()
+            .is_some_and(|sha| sha.starts_with(commit_prefix)))
+}
+
+fn detached_commit_is_unreachable(
+    repo: &Repository,
+    commit_prefix: &str,
+) -> Result<bool, GraphError> {
+    let detached_commit = match repo
+        .revparse_single(commit_prefix)
+        .and_then(|object| object.peel_to_commit())
+    {
+        Ok(commit) => commit.id(),
+        Err(_) => return Ok(true),
+    };
+
+    let refs = repo.references().map_err(|source| {
+        GraphError::invalid_data("list git refs for graph DB cleanup", source.to_string())
+    })?;
+    for reference in refs {
+        let reference = reference.map_err(|source| {
+            GraphError::invalid_data("read git ref for graph DB cleanup", source.to_string())
+        })?;
+        let Some(name) = reference.name() else {
+            continue;
+        };
+        if !name.starts_with("refs/") {
+            continue;
+        }
+        let Ok(ref_commit) = reference.peel_to_commit() else {
+            continue;
+        };
+        let reachable = repo
+            .graph_descendant_of(ref_commit.id(), detached_commit)
+            .map_err(|source| {
+                GraphError::invalid_data("check detached graph DB reachability", source.to_string())
+            })?;
+        if reachable || ref_commit.id() == detached_commit {
+            return Ok(false);
+        }
+    }
+
+    Ok(true)
 }
 
 /// Summary returned after removing stale graph database files.
@@ -499,7 +682,7 @@ fn graph_db_file_extractor_version(file_name: &str) -> Option<u32> {
 pub struct CleanReport {
     /// Directory scanned for graph database files.
     pub graph_dir: PathBuf,
-    /// Files deleted because their extractor version was not current.
+    /// Files deleted because their extractor version or detached commit was stale.
     pub deleted: Vec<PathBuf>,
 }
 

--- a/crates/orbit-graph/src/store/mod.rs
+++ b/crates/orbit-graph/src/store/mod.rs
@@ -8,7 +8,7 @@ use std::path::Path;
 use git2::Repository;
 use rusqlite::Connection;
 
-use crate::{EXTRACTOR_VERSION, GraphDbPath, GraphError, SyncPolicy, resolve_db_path};
+use crate::{EXTRACTOR_VERSION, GraphDbPath, GraphError, SyncPolicy, resolve_db_path_for_commit};
 
 pub(crate) struct OpenedGraph {
     pub(crate) db_path: GraphDbPath,
@@ -16,7 +16,12 @@ pub(crate) struct OpenedGraph {
 
 pub(crate) fn open(worktree_root: &Path, _policy: SyncPolicy) -> Result<OpenedGraph, GraphError> {
     let git = GitContext::for_worktree(worktree_root);
-    let db_path = resolve_db_path(worktree_root, git.branch.as_str(), EXTRACTOR_VERSION);
+    let db_path = resolve_db_path_for_commit(
+        worktree_root,
+        git.branch.as_str(),
+        git.commit_sha.as_str(),
+        EXTRACTOR_VERSION,
+    );
 
     if let Some(parent) = db_path.path().parent() {
         fs::create_dir_all(parent)

--- a/crates/orbit-graph/src/store/tests/schema.rs
+++ b/crates/orbit-graph/src/store/tests/schema.rs
@@ -3,11 +3,11 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use git2::{Oid, Repository, RepositoryInitOptions, Signature};
+use git2::{Oid, Repository, RepositoryInitOptions, Signature, build::CheckoutBuilder};
 use rusqlite::Connection;
 
 use crate::store::schema::SCHEMA_VERSION;
-use crate::{EXTRACTOR_VERSION, Graph, SyncPolicy, resolve_db_path};
+use crate::{EXTRACTOR_VERSION, Graph, SyncPolicy, resolve_db_path, resolve_db_path_for_commit};
 
 #[test]
 fn graph_open_creates_documented_schema_and_initial_meta() {
@@ -165,9 +165,14 @@ fn graph_open_records_commit_sha_for_detached_head() {
     let graph = Graph::open(worktree.path(), SyncPolicy::Manual).expect("open detached graph");
     drop(graph);
 
-    let db_path = resolve_db_path(worktree.path(), "HEAD", EXTRACTOR_VERSION)
-        .path()
-        .to_path_buf();
+    let db_path = resolve_db_path_for_commit(
+        worktree.path(),
+        "HEAD",
+        commit_sha.as_str(),
+        EXTRACTOR_VERSION,
+    )
+    .path()
+    .to_path_buf();
     let conn = open_test_connection(&db_path);
     let meta = read_meta(&conn);
     assert_eq!(meta.get("branch").map(String::as_str), Some("HEAD"));
@@ -176,6 +181,81 @@ fn graph_open_records_commit_sha_for_detached_head() {
         Some(commit_sha.as_str())
     );
     assert!(!commit_sha.is_empty());
+}
+
+#[test]
+fn graph_open_uses_distinct_db_files_for_detached_commits() {
+    let worktree = TestWorktree::new("detached-distinct-dbs", "main");
+    let first_commit = worktree.init_git_repo();
+    let second_commit = worktree.commit_file("second.txt", "second\n", "second");
+
+    worktree.detach_head(first_commit.as_str());
+    let first_graph =
+        Graph::open(worktree.path(), SyncPolicy::Manual).expect("open first detached graph");
+    let first_db = first_graph.db_path().path().to_path_buf();
+    drop(first_graph);
+
+    worktree.detach_head(second_commit.as_str());
+    let second_graph =
+        Graph::open(worktree.path(), SyncPolicy::Manual).expect("open second detached graph");
+    let second_db = second_graph.db_path().path().to_path_buf();
+    drop(second_graph);
+
+    assert_ne!(first_db, second_db);
+    assert!(
+        first_db.exists(),
+        "first detached DB should remain after opening another detached commit"
+    );
+    assert!(
+        second_db.exists(),
+        "second detached DB should be created separately"
+    );
+    let expected_first_file = format!("detached-{}.{}.db", &first_commit[..12], EXTRACTOR_VERSION);
+    let expected_second_file =
+        format!("detached-{}.{}.db", &second_commit[..12], EXTRACTOR_VERSION);
+    assert_eq!(
+        first_db.file_name().and_then(|name| name.to_str()),
+        Some(expected_first_file.as_str())
+    );
+    assert_eq!(
+        second_db.file_name().and_then(|name| name.to_str()),
+        Some(expected_second_file.as_str())
+    );
+}
+
+#[test]
+fn graph_open_cleans_unreachable_detached_databases() {
+    let worktree = TestWorktree::new("cleans-unreachable-detached", "main");
+    worktree.init_git_repo();
+    let reachable_commit = worktree.commit_file("reachable.txt", "reachable\n", "reachable");
+    worktree.detach_head(reachable_commit.as_str());
+    let reachable_graph =
+        Graph::open(worktree.path(), SyncPolicy::Manual).expect("open reachable detached graph");
+    let reachable_db = reachable_graph.db_path().path().to_path_buf();
+    drop(reachable_graph);
+
+    worktree.checkout_branch();
+    let unreachable_commit =
+        worktree.create_unreachable_detached_commit("unreachable.txt", "unreachable\n");
+    let unreachable_graph =
+        Graph::open(worktree.path(), SyncPolicy::Manual).expect("open unreachable detached graph");
+    let unreachable_db = unreachable_graph.db_path().path().to_path_buf();
+    drop(unreachable_graph);
+
+    worktree.checkout_branch();
+    let main_graph = Graph::open(worktree.path(), SyncPolicy::Manual).expect("open main graph");
+    let main_db = main_graph.db_path().path().to_path_buf();
+    drop(main_graph);
+
+    assert!(main_db.exists(), "active branch DB should remain");
+    assert!(
+        reachable_db.exists(),
+        "detached DB reachable from a branch ref should remain"
+    );
+    assert!(
+        !unreachable_db.exists(),
+        "detached DB for commit {unreachable_commit} should be cleaned once no local ref reaches it"
+    );
 }
 
 #[test]
@@ -429,6 +509,57 @@ impl TestWorktree {
             .commit(Some("HEAD"), &sig, &sig, "initial", &tree, &[])
             .expect("initial commit");
         oid.to_string()
+    }
+
+    fn commit_file(&self, rel: &str, content: &str, message: &str) -> String {
+        let repo = Repository::open(&self.path).expect("open git repo");
+        let path = self.path.join(rel);
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).expect("create commit file parent");
+        }
+        fs::write(path, content).expect("write commit file");
+
+        let mut index = repo.index().expect("open repo index");
+        index.add_path(Path::new(rel)).expect("add commit file");
+        index.write().expect("write index");
+        let tree_id = index.write_tree().expect("write tree");
+        let tree = repo.find_tree(tree_id).expect("find tree");
+        let parent = repo
+            .head()
+            .expect("read HEAD")
+            .peel_to_commit()
+            .expect("peel HEAD to commit");
+        let sig = Signature::now("Orbit Test", "orbit@example.test").expect("test signature");
+        let oid = repo
+            .commit(Some("HEAD"), &sig, &sig, message, &tree, &[&parent])
+            .expect("create commit");
+        oid.to_string()
+    }
+
+    fn checkout_branch(&self) {
+        let repo = Repository::open(&self.path).expect("open git repo");
+        let branch_ref = format!("refs/heads/{}", self.branch);
+        repo.set_head(branch_ref.as_str())
+            .expect("set HEAD to branch");
+        let mut checkout = CheckoutBuilder::new();
+        checkout.force();
+        repo.checkout_head(Some(&mut checkout))
+            .expect("checkout branch");
+    }
+
+    fn create_unreachable_detached_commit(&self, rel: &str, content: &str) -> String {
+        let repo = Repository::open(&self.path).expect("open git repo");
+        let branch_name = format!("refs/heads/{}", self.branch);
+        let branch_commit_id = repo
+            .find_reference(branch_name.as_str())
+            .expect("find branch ref")
+            .peel_to_commit()
+            .expect("peel branch to commit")
+            .id();
+        repo.set_head_detached(branch_commit_id)
+            .expect("detach from branch commit");
+        drop(repo);
+        self.commit_file(rel, content, "unreachable detached")
     }
 
     fn detach_head(&self, commit_sha: &str) {

--- a/crates/orbit-graph/src/tests/lib.rs
+++ b/crates/orbit-graph/src/tests/lib.rs
@@ -8,6 +8,7 @@ use rusqlite::{Connection, params};
 use crate::sync::{fail_next_sync_after_scan, sync_leader_count};
 use crate::{
     CalleeEdge, EXTRACTOR_VERSION, Graph, GraphError, Selector, SyncPolicy, resolve_db_path,
+    resolve_db_path_for_commit,
 };
 
 #[test]
@@ -59,6 +60,21 @@ fn db_path_sanitizes_filesystem_hostile_branch_names() {
         );
         assert_eq!(path.branch(), branch);
     }
+}
+
+#[test]
+fn db_path_uses_detached_commit_filename_for_head() {
+    let worktree_root = Path::new("/tmp/orbit-worktree");
+    let commit_sha = "1234567890abcdef1234567890abcdef12345678";
+
+    let detached = resolve_db_path_for_commit(worktree_root, "HEAD", commit_sha, 7);
+
+    assert_eq!(
+        detached.path(),
+        Path::new("/tmp/orbit-worktree/.orbit/graph/detached-1234567890ab.7.db")
+    );
+    assert_eq!(detached.branch(), "HEAD");
+    assert_eq!(detached.extractor_version(), 7);
 }
 
 #[test]

--- a/docs/design/orbit-graph/4_decisions.md
+++ b/docs/design/orbit-graph/4_decisions.md
@@ -3,7 +3,7 @@ summary: "Orbit Graph — Decisions"
 type: design
 title: "Orbit Graph — Decisions"
 owner: claude
-last_updated: 2026-05-24
+last_updated: 2026-05-25
 status: Draft
 feature: orbit-graph
 doc_role: decisions
@@ -97,10 +97,24 @@ Format for each entry: **Status · Date · Task(s)**, then *Context → Decision
 - Performance wins are realized by intentional baseline bumps, not silent improvements that immediately become the new floor.
 - Cost: **baseline updates are friction.** Every routine improvement requires a labeled PR. Acceptable — the friction is intentional and the alternative (no friction, no guarantee) is worse.
 
+## ADR-0190 — Use per-commit DB files for detached HEAD
+
+**Status:** Accepted · 2026-05-25 · [ORB-00331]
+
+**Context.** ORB-00326 (78e26efa) fixed detached-HEAD meta recording, but the filename still used `HEAD.<version>.db`, so detached checkouts on different commits churned the same cache. ORB-00331 compared keeping one `HEAD` DB with warnings against giving each detached commit its own DB file.
+
+**Decision.** Detached HEAD uses `detached-<short-sha>.<extractor_version>.db`. Branch-attached checkouts keep the existing `<branch>.<extractor_version>.db` layout, and detached meta still records `branch = "HEAD"` plus the full commit SHA.
+
+**Consequences.**
+- Detached checkouts on different commits no longer invalidate each other through the same `HEAD` database.
+- The stale-DB sweep removes detached DBs whose commits are no longer reachable from any local ref, while preserving the active DB family.
+- Cost: **more files during commit-hopping workflows.** Bisects and cherry-picks can create O(N) detached DBs until reachability cleanup prunes the unreachable ones.
+
 ---
 
 ## Task References
 
 - [ORB-00294] allocated the six initial orbit-graph ADR IDs (ADR-0184 through ADR-0189).
+- [ORB-00331] allocated ADR-0190 and shipped the detached-HEAD per-commit DB layout.
 
 Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.

--- a/docs/design/orbit-graph/specs/GRAPH_SPEC.md
+++ b/docs/design/orbit-graph/specs/GRAPH_SPEC.md
@@ -1,7 +1,7 @@
 # Orbit Graph — Redesign Spec
 
 **Status:** Draft proposal
-**Last updated:** 2026-05-25 (ORB-00327 impact/trace confidence floor)
+**Last updated:** 2026-05-25 (ORB-00331 detached-HEAD DB layout)
 **Relation to `orbit-knowledge`:** Coexists initially. Both crates run side-by-side under a feature flag; whether `orbit-knowledge` is eventually phased out depends on the head-to-head effectiveness measurement in §16 Step 4 — it is not a foregone conclusion of this spec.
 **Author:** working from the V2 sketch in `GRAPH_V2.md` + the existing design in [`../../knowledge-graph/`](../../knowledge-graph/)
 **Scope:** V1 — read-only graph. A writeable graph (Rename, ReplaceBody, Move, working-graph overlay, patch compiler) is V2, sketched in §17 and tracked in [`../3_vision.md`](../3_vision.md). The previous separate `GRAPH_DESIGN.md` describing the write surface has been folded into this spec on 2026-05-24 to remove the contradictory scope between the two docs.
@@ -125,13 +125,16 @@ crates/
 
 ```
 .orbit/graph/
-├── <branch>.<extractor_version>.db   # the only persistent artifact
-└── <branch>.<extractor_version>.db-wal
+├── <branch>.<extractor_version>.db
+├── detached-<short-sha>.<extractor_version>.db
+└── detached-<short-sha>.<extractor_version>.db-wal
 ```
 
-One SQLite file per `(worktree, branch, extractor_version)`. No objects, no blobs, no refs directory, no JSON index files.
+One SQLite file per `(worktree, branch-or-detached-commit, extractor_version)`. No objects, no blobs, no refs directory, no JSON index files.
 
 `<branch>` in the filename is sanitized — `/` is replaced by `_` so that `feat/foo` produces `feat_foo.42.db`, not a `feat/` subdirectory. The raw branch name is preserved in `meta.branch` for traceability.
+
+Detached HEAD uses `detached-<short-sha>.<extractor_version>.db` while preserving `meta.branch = "HEAD"` and the full commit in `meta.commit_sha`; see ADR-0190. This avoids different detached commits churning one `HEAD.<version>.db` cache. The stale-DB sweep removes detached DBs whose commits are no longer reachable from any local ref, excluding the active DB family.
 
 **Worktree-scoped, not workspace-scoped.** Each git worktree gets its own DB. Disk cost is ~10MB per worktree for orbit-sized repos — negligible. Same-branch worktree contention is solved by not sharing state.
 
@@ -552,6 +555,17 @@ pub struct TraceNode {
 
 pub enum SyncMode { Auto, Full }
 pub enum SyncPolicy { Manual, OnRead, Windowed { window: Duration } }
+
+pub struct GraphDbPath { /* opaque */ }
+
+pub fn resolve_db_path(worktree_root: &Path, branch: &str, extractor_version: u32) -> GraphDbPath;
+pub fn resolve_db_path_for_commit(
+    worktree_root: &Path,
+    branch: &str,
+    commit_sha: &str,
+    extractor_version: u32,
+) -> GraphDbPath;
+pub fn clean_old_databases(worktree_root: &Path) -> Result<CleanReport, GraphError>;
 
 pub struct SyncReport {
     pub files_indexed: usize,


### PR DESCRIPTION
## Task

[ORB-00331](https://orbit-cli.com/tasks/ORB-00331) — Detached-HEAD DB layout: ADR + implement decision

### Description

Decide between per-commit DB filename (`detached-<short-sha>.<v>.db`) and the current single-`HEAD.<v>.db` layout (commit SHA only in meta). Allocate an ADR via `orbit.adr.add`; implement the chosen path with tests.

## Why

ORB-00326 fixed `GitContext::for_worktree` to capture the actual commit `oid` in meta instead of returning `""`. But `branch` is still resolved to the literal `"HEAD"`, so the on-disk filename is `HEAD.<v>.db` regardless of which commit is checked out. Two agents bisecting, cherry-picking, or running parallel detached checkouts on different commits collide on the same DB.

This didn't surface in code review because the task description ("capture detached-HEAD commit") matched the meta-only intent shipped. The QA pass noticed the latent multi-agent footgun — worth resolving before parallel-agent workflows expand.

## Trade-off

**(A) Per-commit filename** — `detached-<short-sha>.<v>.db`
+ Isolates concurrent detached checkouts on different commits.
+ Matches the existing branch-per-DB mental model.
− Bisecting or cherry-picking on detached HEAD creates O(N) DB files. Mitigated by the stale-DB sweep landed in ORB-00326 — but the sweep currently keys on `EXTRACTOR_VERSION`, not on "unreachable from current commit".

**(B) Single `HEAD.<v>.db` + meta** (current behavior)
+ One DB; no proliferation.
+ Incremental scan handles drift cheaply on next sync.
− Concurrent agents on different commits race for the DB. The flock from ORB-00325 + in-process mutex prevents *corruption* but not *staleness churn* — each agent will keep invalidating the other's index.

## Acceptance criteria

- ADR allocated via `orbit.adr.add` and authored, proposing one path with explicit reasoning against the other. Cite ORB-00326 (78e26efa) and this task ID.
- If (A): filename logic updated in `crates/orbit-graph/src/store/mod.rs` / `lib.rs`; regression test for two concurrent detached checkouts on different commits; stale-DB sweep extended to also clean detached DBs whose commit SHA is no longer reachable from any local ref.
- If (B): the constraint documented explicitly in `crates/orbit-graph/src/lib.rs` doc comment, in `GRAPH_SPEC.md §13`, and a runtime warning emitted at sync start when the prior session's meta commit differs from the current commit.
- Either path: detached-HEAD handling test added to `crates/orbit-graph/src/store/tests/schema.rs` or equivalent.

### Acceptance Criteria



## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Allocated and accepted ADR-0190 for per-commit detached-HEAD graph DB filenames, and mirrored the decision in docs/design/orbit-graph/4_decisions.md plus GRAPH_SPEC.md.
- Added resolve_db_path_for_commit and wired store opening so detached HEAD resolves to detached-<short-sha>.<version>.db while preserving meta.branch = HEAD and full meta.commit_sha.
- Extended graph DB cleanup to prune current-version detached DB files whose commits are no longer reachable from any local ref, excluding the active DB family and retaining old extractor-version cleanup.
- Added regression tests for detached filename resolution, distinct detached commit DBs, detached meta recording, and unreachable detached DB cleanup.

Strategic decisions:
- Chose option A, per-commit detached filenames | Rationale: avoids concurrent detached checkouts invalidating a shared HEAD database; ADR-0190 records the O(N) cache-file cost and reachability cleanup mitigation.

Validation:
- cargo test -p orbit-graph
- make ci-fast
- git diff --check

Assessment: Focused change with ADR-backed storage semantics and targeted cleanup coverage.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-00331-6a14854e`
- Behind base: 0
- Ahead of base: 1