### PR TITLE
[codex] [ORB-00332] Add graph backend selector

### DIFF
--- a/crates/orbit-cli/src/audit_middleware.rs
+++ b/crates/orbit-cli/src/audit_middleware.rs
@@ -131,6 +131,7 @@ impl Drop for AuditGuard<'_> {
             step_index: std::env::var("ORBIT_STEP_INDEX")
                 .ok()
                 .and_then(|s| s.parse().ok()),
+            backend: None,
         };
 
         let write_result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {

--- a/crates/orbit-cli/src/command/audit/support.rs
+++ b/crates/orbit-cli/src/command/audit/support.rs
@@ -27,6 +27,7 @@ pub(super) fn audit_event_to_json(event: &AuditEvent) -> Value {
         "job_run_id": event.job_run_id,
         "activity_id": event.activity_id,
         "step_index": event.step_index,
+        "backend": event.backend,
     })
 }
 

--- a/crates/orbit-cli/src/command/audit/tests/support.rs
+++ b/crates/orbit-cli/src/command/audit/tests/support.rs
@@ -33,6 +33,7 @@ fn audit_list_json_projection_shape_is_stable() {
         job_run_id: Some("jrun-1".to_string()),
         activity_id: Some("implement".to_string()),
         step_index: Some(2),
+        backend: Some("legacy".to_string()),
     };
 
     assert_eq!(
@@ -62,6 +63,7 @@ fn audit_list_json_projection_shape_is_stable() {
             "job_run_id": "jrun-1",
             "activity_id": "implement",
             "step_index": 2,
+            "backend": "legacy",
         })
     );
 }

--- a/crates/orbit-cli/src/command/mcp/host.rs
+++ b/crates/orbit-cli/src/command/mcp/host.rs
@@ -13,12 +13,12 @@ use std::time::Instant;
 use orbit_common::types::{
     AuditEventStatus, LearningInjectionState, ToolSchema, ToolSessionContext, audit_execution_id,
 };
-use orbit_core::command::tool::{ToolEntryPoint, audit_role_label};
+use orbit_core::command::tool::{ToolEntryPoint, audit_role_label, graph_backend_for_audit};
 use orbit_core::{
     AuditEventInsertParams, LearningSearchParams, NotFoundKind, OrbitError, OrbitRuntime,
     redact_sensitive_env_text,
 };
-use orbit_mcp::McpHost;
+use orbit_mcp::{McpHost, McpToolAudit, McpToolAuditStatus};
 use serde_json::{Value, json};
 
 pub(crate) const ORBIT_MCP_SERVER_ID: &str = "orbit";
@@ -172,6 +172,20 @@ impl McpHost for RuntimeMcpHost {
         audited_mcp_call_with_session_context(&self.runtime, name, input, session_context)
     }
 
+    fn call_shadow_tool(
+        &self,
+        name: &str,
+        input: Value,
+        _session_context: ToolSessionContext,
+    ) -> Result<Value, OrbitError> {
+        ensure_mcp_tool_exposed(name)?;
+        self.runtime.run_tool(name, input)
+    }
+
+    fn record_tool_audit(&self, audit: McpToolAudit) -> Result<(), OrbitError> {
+        record_mcp_tool_audit(&self.runtime, audit)
+    }
+
     fn learning_candidates_for_path(
         &self,
         path: &str,
@@ -263,60 +277,95 @@ fn record_mcp_preflight_failure(
     input: &Value,
     err: &OrbitError,
 ) {
+    let audit = McpToolAudit {
+        name: name.to_string(),
+        input: input.clone(),
+        status: McpToolAuditStatus::Failure,
+        duration_ms: 1,
+        error_message: Some(err.to_string()),
+        backend: graph_backend_for_audit(name, input),
+    };
+    if let Err(write_err) = record_mcp_tool_audit(runtime, audit) {
+        eprintln!("warning: failed to persist MCP preflight audit event: {write_err}");
+    }
+}
+
+fn record_mcp_tool_audit(runtime: &OrbitRuntime, audit: McpToolAudit) -> Result<(), OrbitError> {
     let start = Instant::now();
-    let role = audit_role_label(input, None, None);
-    let duration_ms = (start.elapsed().as_millis() as i64).max(1);
+    let role = audit_role_label(&audit.input, None, None);
+    let duration_ms = audit
+        .duration_ms
+        .max((start.elapsed().as_millis() as i64).max(1));
     let working_directory = std::env::current_dir()
         .map(|path| path.to_string_lossy().into_owned())
         .unwrap_or_else(|_| ".".to_string());
+    let (status, exit_code, error_message) = match audit.status {
+        McpToolAuditStatus::Success => (AuditEventStatus::Success, 0, None),
+        McpToolAuditStatus::Failure => (
+            AuditEventStatus::Failure,
+            1,
+            audit
+                .error_message
+                .as_deref()
+                .map(redact_sensitive_env_text),
+        ),
+    };
 
     let params = AuditEventInsertParams {
         execution_id: audit_execution_id("exec"),
         command: "tool".to_string(),
         subcommand: Some(ToolEntryPoint::Mcp.audit_subcommand().to_string()),
-        tool_name: Some(name.to_string()),
+        tool_name: Some(audit.name.clone()),
         target_type: Some("tool".to_string()),
-        target_id: Some(name.to_string()),
+        target_id: Some(audit.name.clone()),
         role,
-        status: AuditEventStatus::Failure,
-        exit_code: 1,
+        status,
+        exit_code,
         duration_ms,
         working_directory,
         arguments_json: None,
         stdout_truncated: None,
         stderr_truncated: None,
-        error_message: Some(redact_sensitive_env_text(&err.to_string())),
+        error_message,
         host: std::env::var("HOSTNAME").ok(),
         pid: std::process::id(),
         session_id: None,
-        task_id: input
+        task_id: audit
+            .input
             .get("task_id")
             .and_then(Value::as_str)
             .map(ToOwned::to_owned)
             .or_else(|| std::env::var("ORBIT_TASK_ID").ok())
             .filter(|s| !s.is_empty()),
-        job_run_id: input
+        job_run_id: audit
+            .input
             .get("job_run_id")
             .and_then(Value::as_str)
             .map(ToOwned::to_owned)
             .or_else(|| std::env::var("ORBIT_RUN_ID").ok())
             .filter(|s| !s.is_empty()),
-        activity_id: input
+        activity_id: audit
+            .input
             .get("activity_id")
             .and_then(Value::as_str)
             .map(ToOwned::to_owned)
             .or_else(|| std::env::var("ORBIT_ACTIVITY_ID").ok())
             .filter(|s| !s.is_empty()),
-        step_index: input.get("step_index").and_then(Value::as_i64).or_else(|| {
-            std::env::var("ORBIT_STEP_INDEX")
-                .ok()
-                .and_then(|s| s.parse().ok())
-        }),
+        step_index: audit
+            .input
+            .get("step_index")
+            .and_then(Value::as_i64)
+            .or_else(|| {
+                std::env::var("ORBIT_STEP_INDEX")
+                    .ok()
+                    .and_then(|s| s.parse().ok())
+            }),
+        backend: audit
+            .backend
+            .or_else(|| graph_backend_for_audit(&audit.name, &audit.input)),
     };
 
-    if let Err(write_err) = runtime.record_audit_event(&params) {
-        eprintln!("warning: failed to persist MCP preflight audit event: {write_err}");
-    }
+    runtime.record_audit_event(&params)
 }
 
 /// MCP host returned when no initialized Orbit workspace is discoverable.

--- a/crates/orbit-common/src/types/audit_event.rs
+++ b/crates/orbit-common/src/types/audit_event.rs
@@ -102,6 +102,9 @@ pub struct AuditEvent {
     /// Zero-based step index within the enclosing job run, when known.
     #[serde(default)]
     pub step_index: Option<i64>,
+    /// Graph backend selected for `orbit.graph.*` calls, when applicable.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub backend: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]

--- a/crates/orbit-core/src/command/audit_event.rs
+++ b/crates/orbit-core/src/command/audit_event.rs
@@ -129,6 +129,7 @@ impl OrbitRuntime {
             step_index: std::env::var("ORBIT_STEP_INDEX")
                 .ok()
                 .and_then(|s| s.parse().ok()),
+            backend: None,
         })
     }
 

--- a/crates/orbit-core/src/command/learning_hook.rs
+++ b/crates/orbit-core/src/command/learning_hook.rs
@@ -718,6 +718,7 @@ fn emit_learning_injected_audit(
         step_index: std::env::var("ORBIT_STEP_INDEX")
             .ok()
             .and_then(|value| value.parse().ok()),
+        backend: None,
     };
 
     runtime

--- a/crates/orbit-core/src/command/pipeline_run.rs
+++ b/crates/orbit-core/src/command/pipeline_run.rs
@@ -515,6 +515,7 @@ impl OrbitRuntime {
             job_run_id: target_id.map(ToOwned::to_owned),
             activity_id: None,
             step_index: None,
+            backend: None,
         })
     }
 }

--- a/crates/orbit-core/src/command/review_thread_hook.rs
+++ b/crates/orbit-core/src/command/review_thread_hook.rs
@@ -285,6 +285,7 @@ pub(crate) fn emit_review_thread_surfaced_audit(
         step_index: std::env::var("ORBIT_STEP_INDEX")
             .ok()
             .and_then(|value| value.parse().ok()),
+        backend: None,
     };
 
     runtime

--- a/crates/orbit-core/src/command/tool.rs
+++ b/crates/orbit-core/src/command/tool.rs
@@ -17,6 +17,7 @@ use crate::redact_sensitive_env_text;
 pub use crate::runtime::pipeline::DryRunResult;
 
 const ORBIT_MANAGED_RUN_CONTEXT_ENV: &str = "ORBIT_MANAGED_RUN_CONTEXT";
+const ORBIT_GRAPH_BACKEND_ENV: &str = "ORBIT_GRAPH_BACKEND";
 
 #[derive(Debug, Clone)]
 pub struct ToolInfo {
@@ -149,6 +150,7 @@ impl OrbitRuntime {
             .map(|path| path.to_string_lossy().into_owned())
             .unwrap_or_else(|_| ".".to_string());
         let audit_context = resolve_audit_context(&input);
+        let graph_backend = graph_backend_for_audit(name, &input);
 
         // Closure boundary so any setup failure (e.g. an inconsistent
         // `agent`/`model` rejected by `resolve_agent_identity`) becomes a
@@ -216,6 +218,7 @@ impl OrbitRuntime {
             job_run_id: audit_context.job_run_id,
             activity_id: audit_context.activity_id,
             step_index: audit_context.step_index,
+            backend: graph_backend,
         };
 
         let audit_recorded = match self.record_audit_event(&params) {
@@ -282,6 +285,25 @@ fn resolve_audit_context(input: &Value) -> AuditContext {
             .and_then(Value::as_i64)
             .or_else(|| env_str("ORBIT_STEP_INDEX").and_then(|s| s.parse().ok())),
     }
+}
+
+pub fn graph_backend_for_audit(name: &str, input: &Value) -> Option<String> {
+    if !name.starts_with("orbit.graph.") {
+        return None;
+    }
+    input
+        .get("backend")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| matches!(*value, "legacy" | "new" | "both"))
+        .map(ToOwned::to_owned)
+        .or_else(|| {
+            std::env::var(ORBIT_GRAPH_BACKEND_ENV)
+                .ok()
+                .map(|value| value.trim().to_string())
+                .filter(|value| matches!(value.as_str(), "legacy" | "new" | "both"))
+        })
+        .or_else(|| Some("legacy".to_string()))
 }
 
 fn reservation_owner_from_env() -> Option<ReservationOwnerContext> {
@@ -807,6 +829,26 @@ mod audit_tests {
         assert_eq!(row.exit_code, 1);
         assert!(row.error_message.is_some());
         assert_eq!(row.subcommand.as_deref(), Some("run-mcp"));
+    }
+
+    #[test]
+    fn dispatch_records_graph_backend_in_audit_row() {
+        let _g = env_guard();
+        let runtime = fresh_runtime();
+
+        let _ = runtime.execute_tool_command_dispatch(
+            "orbit.graph.search",
+            json!({ "query": "anything", "backend": "both", "model": "gpt-5.5" }),
+            None,
+            None,
+            ToolEntryPoint::Mcp,
+        );
+
+        let events = runtime
+            .list_audit_events(None, Some("orbit.graph.search".to_string()), None, None, 16)
+            .expect("list audit events");
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].backend.as_deref(), Some("both"));
     }
 
     #[test]

--- a/crates/orbit-core/src/runtime/builder.rs
+++ b/crates/orbit-core/src/runtime/builder.rs
@@ -233,6 +233,7 @@ fn record_learning_id_migration_audit(
         step_index: std::env::var("ORBIT_STEP_INDEX")
             .ok()
             .and_then(|s| s.parse().ok()),
+        backend: None,
     })
 }
 

--- a/crates/orbit-core/src/runtime/orbit_tool_host/adr_tools.rs
+++ b/crates/orbit-core/src/runtime/orbit_tool_host/adr_tools.rs
@@ -391,6 +391,7 @@ fn record_transition_audit(
         step_index: std::env::var("ORBIT_STEP_INDEX")
             .ok()
             .and_then(|s| s.parse().ok()),
+        backend: None,
     })
 }
 

--- a/crates/orbit-core/src/runtime/orbit_tool_host/artifact_redaction.rs
+++ b/crates/orbit-core/src/runtime/orbit_tool_host/artifact_redaction.rs
@@ -477,6 +477,7 @@ fn emit_audit_events(
             step_index: std::env::var("ORBIT_STEP_INDEX")
                 .ok()
                 .and_then(|s| s.parse().ok()),
+            backend: None,
         })?;
     }
     Ok(())

--- a/crates/orbit-core/src/runtime/orbit_tool_host/task_locks.rs
+++ b/crates/orbit-core/src/runtime/orbit_tool_host/task_locks.rs
@@ -570,6 +570,7 @@ fn record_task_lock_audit_event(
         step_index: std::env::var("ORBIT_STEP_INDEX")
             .ok()
             .and_then(|s| s.parse().ok()),
+        backend: None,
     })
 }
 

--- a/crates/orbit-core/src/runtime/v2_host/pipeline_actions.rs
+++ b/crates/orbit-core/src/runtime/v2_host/pipeline_actions.rs
@@ -315,6 +315,7 @@ fn record_gate_stale_noop(
             job_run_id: parent_run_id,
             activity_id: None,
             step_index: None,
+            backend: None,
         })
         .map_err(|err| action_failed(action, format!("record gate.stale_noop audit: {err}")))
 }
@@ -511,6 +512,7 @@ pub(super) fn gate_starvation_fail(
             job_run_id: None,
             activity_id: None,
             step_index: None,
+            backend: None,
         })
         .map_err(|err| DispatchError::DeterministicActionFailed {
             action: action.to_string(),

--- a/crates/orbit-dashboard/src/api/tests/denials.rs
+++ b/crates/orbit-dashboard/src/api/tests/denials.rs
@@ -113,6 +113,7 @@ fn denials_payload_combines_v2_and_sqlite_denials() {
             job_run_id: None,
             activity_id: None,
             step_index: None,
+            backend: None,
         })
         .expect("record sqlite denial");
 
@@ -200,6 +201,7 @@ fn denials_payload_distinguishes_job_runs_from_audit_executions() {
             job_run_id: Some("jrun-real-policy".to_string()),
             activity_id: Some("agent_implement".to_string()),
             step_index: Some(0),
+            backend: None,
         })
         .expect("record linked denial");
     runtime
@@ -238,6 +240,7 @@ fn denials_payload_distinguishes_job_runs_from_audit_executions() {
             job_run_id: None,
             activity_id: None,
             step_index: None,
+            backend: None,
         })
         .expect("record task-lock denial");
 

--- a/crates/orbit-graph-cli/src/commands/callees.rs
+++ b/crates/orbit-graph-cli/src/commands/callees.rs
@@ -1,19 +1,32 @@
 use clap::Args;
+use orbit_graph::GraphQueryKind;
 use orbit_graph_extract::Selector;
 
-use super::{CliError, CommandContext, json_value};
+use super::{BackendArg, CliError, CommandContext, json_value};
 
 #[derive(Debug, Args)]
 pub(crate) struct CalleesCommand {
     symbol: String,
+    #[arg(long, value_enum)]
+    backend: Option<BackendArg>,
 }
 
 impl CalleesCommand {
     pub(crate) fn run(&self, context: &CommandContext) -> Result<serde_json::Value, CliError> {
-        let graph = context.open_graph()?;
         let selector = self.symbol.parse::<Selector>()?;
-        json_value(serde_json::json!({
-            "callees": graph.callees(&selector)?,
-        }))
+        let worktree = context.worktree_root.clone();
+        context.route_query(
+            self.backend,
+            GraphQueryKind::Callees,
+            move || {
+                let graph =
+                    orbit_graph::Graph::open(worktree.as_path(), orbit_graph::SyncPolicy::Manual)
+                        .map_err(CliError::Graph)?;
+                json_value(serde_json::json!({
+                    "callees": graph.callees(&selector)?,
+                }))
+            },
+            || context.legacy_unavailable("callees"),
+        )
     }
 }

--- a/crates/orbit-graph-cli/src/commands/impact.rs
+++ b/crates/orbit-graph-cli/src/commands/impact.rs
@@ -1,8 +1,8 @@
 use clap::{Args, ValueEnum};
-use orbit_graph::{DEFAULT_IMPACT_DEPTH, RefConfidence};
+use orbit_graph::{DEFAULT_IMPACT_DEPTH, GraphQueryKind, RefConfidence};
 use orbit_graph_extract::Selector;
 
-use super::{CliError, CommandContext, json_value};
+use super::{BackendArg, CliError, CommandContext, json_value};
 
 #[derive(Debug, Args)]
 pub(crate) struct ImpactCommand {
@@ -11,13 +11,27 @@ pub(crate) struct ImpactCommand {
     depth: u8,
     #[arg(long, value_enum, default_value_t = ConfidenceArg::SameModule)]
     confidence: ConfidenceArg,
+    #[arg(long, value_enum)]
+    backend: Option<BackendArg>,
 }
 
 impl ImpactCommand {
     pub(crate) fn run(&self, context: &CommandContext) -> Result<serde_json::Value, CliError> {
-        let graph = context.open_graph()?;
         let selector = self.selector.parse::<Selector>()?;
-        json_value(graph.impact(&selector, self.depth, self.confidence.into_graph())?)
+        let depth = self.depth;
+        let confidence = self.confidence.into_graph();
+        let worktree = context.worktree_root.clone();
+        context.route_query(
+            self.backend,
+            GraphQueryKind::Impact,
+            move || {
+                let graph =
+                    orbit_graph::Graph::open(worktree.as_path(), orbit_graph::SyncPolicy::Manual)
+                        .map_err(CliError::Graph)?;
+                json_value(graph.impact(&selector, depth, confidence)?)
+            },
+            || context.legacy_unavailable("impact"),
+        )
     }
 }
 

--- a/crates/orbit-graph-cli/src/commands/mod.rs
+++ b/crates/orbit-graph-cli/src/commands/mod.rs
@@ -1,11 +1,15 @@
 use std::env;
 use std::path::PathBuf;
+use std::process::Command as ProcessCommand;
 
-use clap::{Parser, Subcommand};
-use orbit_graph::{Graph, GraphError, SyncPolicy};
+use clap::{Parser, Subcommand, ValueEnum};
+use orbit_graph::{
+    Graph, GraphBackend, GraphBackendParseError, GraphError, GraphQueryKind, SyncPolicy,
+    route_query,
+};
 use orbit_graph_extract::SelectorParseError;
 use serde::Serialize;
-use serde_json::Value;
+use serde_json::{Value, json};
 use thiserror::Error;
 
 mod callees;
@@ -75,10 +79,95 @@ impl CommandContext {
     pub(crate) fn open_graph(&self) -> Result<Graph, CliError> {
         Graph::open(self.worktree_root.as_path(), SyncPolicy::Manual).map_err(CliError::Graph)
     }
+
+    pub(crate) fn route_query<N, L>(
+        &self,
+        backend: Option<BackendArg>,
+        query: GraphQueryKind,
+        run_new: N,
+        run_legacy: L,
+    ) -> Result<Value, CliError>
+    where
+        N: FnOnce() -> Result<Value, CliError> + Send,
+        L: FnOnce() -> Result<Value, CliError> + Send,
+    {
+        let backend = GraphBackend::resolve(backend.map(BackendArg::into_graph))?;
+        route_query(backend, query, run_new, run_legacy)
+    }
+
+    pub(crate) fn run_legacy_tool(&self, tool_name: &str, input: Value) -> Result<Value, CliError> {
+        let orbit = env::var_os("ORBIT_LEGACY_CLI")
+            .map(PathBuf::from)
+            .unwrap_or_else(|| PathBuf::from("orbit"));
+        let output = ProcessCommand::new(&orbit)
+            .current_dir(self.worktree_root.as_path())
+            .args(["tool", "run", tool_name, "--full", "--input"])
+            .arg(input.to_string())
+            .output()
+            .map_err(|source| CliError::LegacyProcess {
+                command: orbit.display().to_string(),
+                source,
+            })?;
+        if !output.status.success() {
+            return Err(CliError::LegacyTool {
+                command: format!("{} tool run {tool_name}", orbit.display()),
+                status: output.status.code(),
+                stderr: String::from_utf8_lossy(&output.stderr).trim().to_string(),
+            });
+        }
+        serde_json::from_slice(&output.stdout).map_err(CliError::Json)
+    }
+
+    pub(crate) fn run_legacy_sync(&self, full: bool) -> Result<Value, CliError> {
+        let orbit = env::var_os("ORBIT_LEGACY_CLI")
+            .map(PathBuf::from)
+            .unwrap_or_else(|| PathBuf::from("orbit"));
+        let subcommand = if full { "build" } else { "update" };
+        let output = ProcessCommand::new(&orbit)
+            .current_dir(self.worktree_root.as_path())
+            .args(["graph", subcommand])
+            .output()
+            .map_err(|source| CliError::LegacyProcess {
+                command: orbit.display().to_string(),
+                source,
+            })?;
+        if !output.status.success() {
+            return Err(CliError::LegacyTool {
+                command: format!("{} graph {subcommand}", orbit.display()),
+                status: output.status.code(),
+                stderr: String::from_utf8_lossy(&output.stderr).trim().to_string(),
+            });
+        }
+        Ok(json!({
+            "backend": "legacy",
+            "command": format!("graph {subcommand}"),
+        }))
+    }
+
+    pub(crate) fn legacy_unavailable(&self, query: &'static str) -> Result<Value, CliError> {
+        Err(CliError::LegacyUnavailable(query))
+    }
 }
 
 pub(crate) fn json_value<T: Serialize>(value: T) -> Result<Value, CliError> {
     serde_json::to_value(value).map_err(CliError::Json)
+}
+
+#[derive(Debug, Clone, Copy, ValueEnum)]
+pub(crate) enum BackendArg {
+    Legacy,
+    New,
+    Both,
+}
+
+impl BackendArg {
+    fn into_graph(self) -> GraphBackend {
+        match self {
+            Self::Legacy => GraphBackend::Legacy,
+            Self::New => GraphBackend::New,
+            Self::Both => GraphBackend::Both,
+        }
+    }
 }
 
 #[derive(Debug, Error)]
@@ -90,11 +179,26 @@ pub enum CliError {
     #[error(transparent)]
     Graph(#[from] GraphError),
     #[error(transparent)]
+    Backend(#[from] GraphBackendParseError),
+    #[error(transparent)]
     Selector(#[from] SelectorParseError),
     #[error("failed to serialize JSON: {0}")]
     Json(serde_json::Error),
     #[error("failed to write JSON to stdout: {0}")]
     Stdout(std::io::Error),
+    #[error("failed to run legacy graph command `{command}`: {source}")]
+    LegacyProcess {
+        command: String,
+        source: std::io::Error,
+    },
+    #[error("legacy graph command `{command}` failed")]
+    LegacyTool {
+        command: String,
+        status: Option<i32>,
+        stderr: String,
+    },
+    #[error("legacy graph backend does not support `{0}`")]
+    LegacyUnavailable(&'static str),
 }
 
 impl CliError {
@@ -103,9 +207,13 @@ impl CliError {
             Self::Clap(_) => "argument_error",
             Self::CurrentDir(_) => "current_dir_error",
             Self::Graph(_) => "graph_error",
+            Self::Backend(_) => "backend_error",
             Self::Selector(_) => "selector_parse_error",
             Self::Json(_) => "json_error",
             Self::Stdout(_) => "stdout_error",
+            Self::LegacyProcess { .. } => "legacy_process_error",
+            Self::LegacyTool { .. } => "legacy_tool_error",
+            Self::LegacyUnavailable(_) => "legacy_unavailable",
         }
     }
 
@@ -115,6 +223,7 @@ impl CliError {
             Self::Graph(GraphError::Io { reason, .. }) => Some(reason.as_str()),
             Self::Graph(GraphError::Sqlite { reason, .. }) => Some(reason.as_str()),
             Self::Graph(GraphError::Unimplemented) => None,
+            Self::LegacyTool { stderr, .. } => Some(stderr.as_str()),
             _ => None,
         }
     }

--- a/crates/orbit-graph-cli/src/commands/refs.rs
+++ b/crates/orbit-graph-cli/src/commands/refs.rs
@@ -1,8 +1,9 @@
 use clap::{Args, ValueEnum};
-use orbit_graph::{RefConfidence, RefKind, RefOpts};
+use orbit_graph::{GraphQueryKind, RefConfidence, RefKind, RefOpts};
 use orbit_graph_extract::Selector;
+use serde_json::json;
 
-use super::{CliError, CommandContext, json_value};
+use super::{BackendArg, CliError, CommandContext, json_value};
 
 #[derive(Debug, Args)]
 pub(crate) struct RefsCommand {
@@ -11,17 +12,37 @@ pub(crate) struct RefsCommand {
     confidence: ConfidenceArg,
     #[arg(long, value_enum)]
     kind: Option<RefKindArg>,
+    #[arg(long, value_enum)]
+    backend: Option<BackendArg>,
 }
 
 impl RefsCommand {
     pub(crate) fn run(&self, context: &CommandContext) -> Result<serde_json::Value, CliError> {
-        let graph = context.open_graph()?;
         let selector = self.symbol.parse::<Selector>()?;
         let opts = RefOpts {
             confidence: self.confidence.into_graph(),
             kind: self.kind.map(RefKindArg::into_graph),
         };
-        json_value(graph.refs(&selector, &opts)?)
+        let raw_selector = self.symbol.clone();
+        let worktree = context.worktree_root.clone();
+        context.route_query(
+            self.backend,
+            GraphQueryKind::Refs,
+            move || {
+                let graph =
+                    orbit_graph::Graph::open(worktree.as_path(), orbit_graph::SyncPolicy::Manual)
+                        .map_err(CliError::Graph)?;
+                json_value(graph.refs(&selector, &opts)?)
+            },
+            || {
+                context.run_legacy_tool(
+                    "orbit.graph.refs",
+                    json!({
+                        "selector": raw_selector,
+                    }),
+                )
+            },
+        )
     }
 }
 

--- a/crates/orbit-graph-cli/src/commands/search.rs
+++ b/crates/orbit-graph-cli/src/commands/search.rs
@@ -1,7 +1,8 @@
 use clap::{Args, ValueEnum};
-use orbit_graph::{SearchKind, SearchQuery};
+use orbit_graph::{GraphQueryKind, SearchKind, SearchQuery};
+use serde_json::json;
 
-use super::{CliError, CommandContext, json_value};
+use super::{BackendArg, CliError, CommandContext, json_value};
 
 #[derive(Debug, Args)]
 pub(crate) struct SearchCommand {
@@ -12,19 +13,43 @@ pub(crate) struct SearchCommand {
     lang: Option<String>,
     #[arg(long)]
     limit: Option<usize>,
+    #[arg(long, value_enum)]
+    backend: Option<BackendArg>,
 }
 
 impl SearchCommand {
     pub(crate) fn run(&self, context: &CommandContext) -> Result<serde_json::Value, CliError> {
-        let graph = context.open_graph()?;
+        let worktree = context.worktree_root.clone();
         let query = SearchQuery {
             query: self.query.clone(),
             kind: self.kind.map(SearchKindArg::into_graph),
             lang: self.lang.clone(),
             limit: self.limit,
         };
-        json_value(graph.search(&query)?)
+        let legacy_input = legacy_search_input(&query);
+        context.route_query(
+            self.backend,
+            GraphQueryKind::Search,
+            move || {
+                let graph =
+                    orbit_graph::Graph::open(worktree.as_path(), orbit_graph::SyncPolicy::Manual)
+                        .map_err(CliError::Graph)?;
+                json_value(graph.search(&query)?)
+            },
+            || context.run_legacy_tool("orbit.graph.search", legacy_input),
+        )
     }
+}
+
+fn legacy_search_input(query: &SearchQuery) -> serde_json::Value {
+    let mut input = json!({
+        "query": query.query,
+        "limit": query.limit,
+    });
+    if matches!(query.kind, Some(SearchKind::Symbol)) {
+        input["type"] = json!("symbol");
+    }
+    input
 }
 
 #[derive(Debug, Clone, Copy, ValueEnum)]

--- a/crates/orbit-graph-cli/src/commands/show.rs
+++ b/crates/orbit-graph-cli/src/commands/show.rs
@@ -1,20 +1,42 @@
 use clap::Args;
-use orbit_graph::DEFAULT_SHOW_MAX_BYTES;
+use orbit_graph::{DEFAULT_SHOW_MAX_BYTES, GraphQueryKind};
 use orbit_graph_extract::Selector;
+use serde_json::json;
 
-use super::{CliError, CommandContext, json_value};
+use super::{BackendArg, CliError, CommandContext, json_value};
 
 #[derive(Debug, Args)]
 pub(crate) struct ShowCommand {
     selector: String,
     #[arg(long, default_value_t = DEFAULT_SHOW_MAX_BYTES)]
     max_bytes: usize,
+    #[arg(long, value_enum)]
+    backend: Option<BackendArg>,
 }
 
 impl ShowCommand {
     pub(crate) fn run(&self, context: &CommandContext) -> Result<serde_json::Value, CliError> {
-        let graph = context.open_graph()?;
         let selector = self.selector.parse::<Selector>()?;
-        json_value(graph.show(&selector, self.max_bytes)?)
+        let raw_selector = self.selector.clone();
+        let max_bytes = self.max_bytes;
+        let worktree = context.worktree_root.clone();
+        context.route_query(
+            self.backend,
+            GraphQueryKind::Show,
+            move || {
+                let graph =
+                    orbit_graph::Graph::open(worktree.as_path(), orbit_graph::SyncPolicy::Manual)
+                        .map_err(CliError::Graph)?;
+                json_value(graph.show(&selector, max_bytes)?)
+            },
+            || {
+                context.run_legacy_tool(
+                    "orbit.graph.show",
+                    json!({
+                        "selector": raw_selector,
+                    }),
+                )
+            },
+        )
     }
 }

--- a/crates/orbit-graph-cli/src/commands/sync.rs
+++ b/crates/orbit-graph-cli/src/commands/sync.rs
@@ -1,31 +1,40 @@
 use std::time::Duration;
 
 use clap::Args;
-use orbit_graph::SyncMode;
+use orbit_graph::{GraphQueryKind, SyncMode};
 use serde::Serialize;
 
-use super::{CliError, CommandContext, json_value};
+use super::{BackendArg, CliError, CommandContext, json_value};
 
 #[derive(Debug, Args)]
 pub(crate) struct SyncCommand {
     #[arg(long)]
     full: bool,
+    #[arg(long, value_enum)]
+    backend: Option<BackendArg>,
 }
 
 impl SyncCommand {
     pub(crate) fn run(&self, context: &CommandContext) -> Result<serde_json::Value, CliError> {
-        let graph = context.open_graph()?;
-        let report = graph.sync(if self.full {
-            SyncMode::Full
-        } else {
-            SyncMode::Auto
-        })?;
-        json_value(SyncOutput {
-            files_indexed: report.files_indexed,
-            files_changed: report.files_changed,
-            files_removed: report.files_removed,
-            duration_ms: duration_millis(report.duration),
-        })
+        let full = self.full;
+        let worktree = context.worktree_root.clone();
+        context.route_query(
+            self.backend,
+            GraphQueryKind::Sync,
+            move || {
+                let graph =
+                    orbit_graph::Graph::open(worktree.as_path(), orbit_graph::SyncPolicy::Manual)
+                        .map_err(CliError::Graph)?;
+                let report = graph.sync(if full { SyncMode::Full } else { SyncMode::Auto })?;
+                json_value(SyncOutput {
+                    files_indexed: report.files_indexed,
+                    files_changed: report.files_changed,
+                    files_removed: report.files_removed,
+                    duration_ms: duration_millis(report.duration),
+                })
+            },
+            || context.run_legacy_sync(full),
+        )
     }
 }
 

--- a/crates/orbit-graph-cli/src/commands/trace.rs
+++ b/crates/orbit-graph-cli/src/commands/trace.rs
@@ -1,7 +1,7 @@
 use clap::{Args, ValueEnum};
-use orbit_graph::{DEFAULT_TRACE_DEPTH, RefConfidence};
+use orbit_graph::{DEFAULT_TRACE_DEPTH, GraphQueryKind, RefConfidence};
 
-use super::{CliError, CommandContext, json_value};
+use super::{BackendArg, CliError, CommandContext, json_value};
 
 #[derive(Debug, Args)]
 pub(crate) struct TraceCommand {
@@ -10,16 +10,27 @@ pub(crate) struct TraceCommand {
     depth: u8,
     #[arg(long, value_enum, default_value_t = ConfidenceArg::SameModule)]
     confidence: ConfidenceArg,
+    #[arg(long, value_enum)]
+    backend: Option<BackendArg>,
 }
 
 impl TraceCommand {
     pub(crate) fn run(&self, context: &CommandContext) -> Result<serde_json::Value, CliError> {
-        let graph = context.open_graph()?;
-        json_value(graph.trace(
-            self.command_name.as_str(),
-            self.depth,
-            self.confidence.into_graph(),
-        )?)
+        let command_name = self.command_name.clone();
+        let depth = self.depth;
+        let confidence = self.confidence.into_graph();
+        let worktree = context.worktree_root.clone();
+        context.route_query(
+            self.backend,
+            GraphQueryKind::Trace,
+            move || {
+                let graph =
+                    orbit_graph::Graph::open(worktree.as_path(), orbit_graph::SyncPolicy::Manual)
+                        .map_err(CliError::Graph)?;
+                json_value(graph.trace(command_name.as_str(), depth, confidence)?)
+            },
+            || context.legacy_unavailable("trace"),
+        )
     }
 }
 

--- a/crates/orbit-graph-cli/tests/subcommands.rs
+++ b/crates/orbit-graph-cli/tests/subcommands.rs
@@ -13,13 +13,22 @@ use tempfile::TempDir;
 fn query_and_admin_subcommands_emit_json() {
     let worktree = fixture_worktree();
 
-    let sync = run_json(worktree.path(), ["sync", "--full"]);
+    let sync = run_json(worktree.path(), ["sync", "--full", "--backend", "new"]);
     assert_eq!(sync["files_removed"], 0);
     assert!(sync["files_indexed"].as_u64().expect("files_indexed") >= 1);
 
     let search = run_json(
         worktree.path(),
-        ["search", "helper", "--kind", "symbol", "--limit", "5"],
+        [
+            "search",
+            "helper",
+            "--kind",
+            "symbol",
+            "--limit",
+            "5",
+            "--backend",
+            "new",
+        ],
     );
     assert_array_field(&search, "matches");
 
@@ -30,6 +39,8 @@ fn query_and_admin_subcommands_emit_json() {
             "symbol:src/lib.rs#entry:function",
             "--max-bytes",
             "256",
+            "--backend",
+            "new",
         ],
     );
     assert_eq!(show["metadata"]["file"], "src/lib.rs");
@@ -44,6 +55,8 @@ fn query_and_admin_subcommands_emit_json() {
             "fuzzy",
             "--kind",
             "call",
+            "--backend",
+            "new",
         ],
     );
     assert!(refs.get("target").is_some());
@@ -52,7 +65,12 @@ fn query_and_admin_subcommands_emit_json() {
 
     let callees = run_json(
         worktree.path(),
-        ["callees", "symbol:src/lib.rs#entry:function"],
+        [
+            "callees",
+            "symbol:src/lib.rs#entry:function",
+            "--backend",
+            "new",
+        ],
     );
     assert_array_field(&callees, "callees");
 
@@ -65,6 +83,8 @@ fn query_and_admin_subcommands_emit_json() {
             "2",
             "--confidence",
             "same_module",
+            "--backend",
+            "new",
         ],
     );
     assert_array_field(&impact, "touched");
@@ -79,6 +99,8 @@ fn query_and_admin_subcommands_emit_json() {
             "2",
             "--confidence",
             "same_module",
+            "--backend",
+            "new",
         ],
     );
     assert!(trace["root"].is_null());
@@ -127,6 +149,31 @@ fn invalid_selector_errors_are_json_on_stderr() {
         .stderr(predicate::str::contains(
             "\"code\":\"selector_parse_error\"",
         ));
+}
+
+#[test]
+fn backend_cli_override_takes_precedence_over_env() {
+    let worktree = fixture_worktree();
+    let mut command = graph_cli_command();
+    command
+        .current_dir(worktree.path())
+        .env("ORBIT_GRAPH_BACKEND", "legacy")
+        .args(["sync", "--full", "--backend", "new"])
+        .assert()
+        .success();
+}
+
+#[test]
+fn backend_env_selects_legacy_by_default() {
+    let worktree = fixture_worktree();
+    let mut command = graph_cli_command();
+    command
+        .current_dir(worktree.path())
+        .env("ORBIT_GRAPH_BACKEND", "legacy")
+        .args(["callees", "symbol:src/lib.rs#entry:function"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("\"code\":\"legacy_unavailable\""));
 }
 
 fn run_json<const N: usize>(worktree: &Path, args: [&str; N]) -> Value {

--- a/crates/orbit-graph/Cargo.toml
+++ b/crates/orbit-graph/Cargo.toml
@@ -19,7 +19,7 @@ orbit-graph-extract = { path = "../orbit-graph-extract" }
 rayon.workspace = true
 rusqlite.workspace = true
 serde.workspace = true
+serde_json.workspace = true
 tracing.workspace = true
 
 [dev-dependencies]
-serde_json.workspace = true

--- a/crates/orbit-graph/src/backend.rs
+++ b/crates/orbit-graph/src/backend.rs
@@ -1,0 +1,220 @@
+use std::fmt::{Display, Formatter};
+use std::str::FromStr;
+use std::thread;
+
+use serde::Serialize;
+use serde_json::Value;
+
+/// Environment variable used to select the graph query backend.
+pub const ORBIT_GRAPH_BACKEND_ENV: &str = "ORBIT_GRAPH_BACKEND";
+
+/// Runtime backend selector for graph query surfaces.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum GraphBackend {
+    /// Route queries through the legacy `orbit-knowledge` surface.
+    Legacy,
+    /// Route queries through the new SQLite-backed `orbit-graph` surface.
+    New,
+    /// Return new-backend results while shadowing the same query against legacy.
+    Both,
+}
+
+impl GraphBackend {
+    /// Stable lowercase label used in CLI args, JSON payloads, and audit rows.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Legacy => "legacy",
+            Self::New => "new",
+            Self::Both => "both",
+        }
+    }
+
+    /// Resolve the effective backend with CLI/tool input taking precedence
+    /// over the environment, and `legacy` as the final default.
+    pub fn resolve(override_backend: Option<Self>) -> Result<Self, GraphBackendParseError> {
+        Self::resolve_from(
+            override_backend,
+            std::env::var(ORBIT_GRAPH_BACKEND_ENV).ok(),
+        )
+    }
+
+    /// Testable resolver variant with an injected environment value.
+    pub fn resolve_from(
+        override_backend: Option<Self>,
+        env_backend: Option<String>,
+    ) -> Result<Self, GraphBackendParseError> {
+        if let Some(backend) = override_backend {
+            return Ok(backend);
+        }
+        let Some(raw) = env_backend else {
+            return Ok(Self::Legacy);
+        };
+        let raw = raw.trim();
+        if raw.is_empty() {
+            return Ok(Self::Legacy);
+        }
+        raw.parse()
+    }
+}
+
+impl Display for GraphBackend {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl FromStr for GraphBackend {
+    type Err = GraphBackendParseError;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value.trim() {
+            "legacy" => Ok(Self::Legacy),
+            "new" => Ok(Self::New),
+            "both" => Ok(Self::Both),
+            other => Err(GraphBackendParseError {
+                value: other.to_string(),
+            }),
+        }
+    }
+}
+
+/// Parse error for [`GraphBackend`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GraphBackendParseError {
+    value: String,
+}
+
+impl Display for GraphBackendParseError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "invalid graph backend `{}`; expected legacy, new, or both",
+            self.value
+        )
+    }
+}
+
+impl std::error::Error for GraphBackendParseError {}
+
+/// Graph query name used for structured backend routing logs.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GraphQueryKind {
+    /// Synchronize the selected graph backend.
+    Sync,
+    /// Search symbols, strings, or configs.
+    Search,
+    /// Show one selector.
+    Show,
+    /// Find inbound references for a selector.
+    Refs,
+    /// Find outbound calls from a selector.
+    Callees,
+    /// Traverse the bounded blast radius around a selector.
+    Impact,
+    /// Trace command-handler calls.
+    Trace,
+}
+
+impl GraphQueryKind {
+    /// Stable query label used in structured logs.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Sync => "sync",
+            Self::Search => "search",
+            Self::Show => "show",
+            Self::Refs => "refs",
+            Self::Callees => "callees",
+            Self::Impact => "impact",
+            Self::Trace => "trace",
+        }
+    }
+}
+
+/// Route a graph query to the selected backend.
+///
+/// `both` returns the new backend result as primary, runs legacy as a shadow
+/// query, and logs shadow failures or JSON differences without failing the
+/// primary query.
+pub fn route_query<E, N, L>(
+    backend: GraphBackend,
+    query: GraphQueryKind,
+    run_new: N,
+    run_legacy: L,
+) -> Result<Value, E>
+where
+    E: Display + Send,
+    N: FnOnce() -> Result<Value, E> + Send,
+    L: FnOnce() -> Result<Value, E> + Send,
+{
+    match backend {
+        GraphBackend::Legacy => run_legacy(),
+        GraphBackend::New => run_new(),
+        GraphBackend::Both => route_both(query, run_new, run_legacy),
+    }
+}
+
+fn route_both<E, N, L>(query: GraphQueryKind, run_new: N, run_legacy: L) -> Result<Value, E>
+where
+    E: Display + Send,
+    N: FnOnce() -> Result<Value, E> + Send,
+    L: FnOnce() -> Result<Value, E> + Send,
+{
+    let (primary, shadow) = thread::scope(|scope| {
+        let shadow = scope.spawn(run_legacy);
+        let primary = run_new();
+        let shadow = shadow.join();
+        (primary, shadow)
+    });
+
+    match shadow {
+        Ok(Ok(shadow_value)) => {
+            if let Ok(primary_value) = primary.as_ref() {
+                log_diff_if_needed(query, primary_value, &shadow_value);
+            }
+        }
+        Ok(Err(error)) => {
+            tracing::warn!(
+                target: "orbit.graph.backend",
+                query = query.as_str(),
+                primary_backend = GraphBackend::New.as_str(),
+                shadow_backend = GraphBackend::Legacy.as_str(),
+                error = %error,
+                "graph backend shadow query failed"
+            );
+        }
+        Err(_) => {
+            tracing::warn!(
+                target: "orbit.graph.backend",
+                query = query.as_str(),
+                primary_backend = GraphBackend::New.as_str(),
+                shadow_backend = GraphBackend::Legacy.as_str(),
+                "graph backend shadow query panicked"
+            );
+        }
+    }
+
+    primary
+}
+
+fn log_diff_if_needed(query: GraphQueryKind, primary: &Value, shadow: &Value) {
+    if primary == shadow {
+        return;
+    }
+
+    let primary_json = serde_json::to_vec(primary).unwrap_or_default();
+    let shadow_json = serde_json::to_vec(shadow).unwrap_or_default();
+    let primary_hash = blake3::hash(primary_json.as_slice()).to_hex().to_string();
+    let shadow_hash = blake3::hash(shadow_json.as_slice()).to_hex().to_string();
+    tracing::warn!(
+        target: "orbit.graph.backend",
+        query = query.as_str(),
+        primary_backend = GraphBackend::New.as_str(),
+        shadow_backend = GraphBackend::Legacy.as_str(),
+        primary_len = primary_json.len(),
+        shadow_len = shadow_json.len(),
+        primary_hash,
+        shadow_hash,
+        "graph backend shadow diff"
+    );
+}

--- a/crates/orbit-graph/src/lib.rs
+++ b/crates/orbit-graph/src/lib.rs
@@ -17,10 +17,14 @@ pub use orbit_graph_extract::Selector;
 use rusqlite::{Connection, OpenFlags, params};
 use serde::Serialize;
 
+mod backend;
 mod query;
 mod store;
 mod sync;
 
+pub use backend::{
+    GraphBackend, GraphBackendParseError, GraphQueryKind, ORBIT_GRAPH_BACKEND_ENV, route_query,
+};
 pub use query::{
     DEFAULT_SEARCH_LIMIT, DEFAULT_SHOW_MAX_BYTES, Match, NodeMetadata, NodeView, SearchKind,
     SearchQuery, SearchResult, SourceSpan,

--- a/crates/orbit-graph/src/tests/backend.rs
+++ b/crates/orbit-graph/src/tests/backend.rs
@@ -1,0 +1,52 @@
+use serde_json::json;
+
+use crate::{GraphBackend, GraphQueryKind, route_query};
+
+#[test]
+fn backend_resolver_uses_override_then_env_then_legacy_default() {
+    assert_eq!(
+        GraphBackend::resolve_from(None, None).unwrap(),
+        GraphBackend::Legacy
+    );
+    assert_eq!(
+        GraphBackend::resolve_from(None, Some("new".to_string())).unwrap(),
+        GraphBackend::New
+    );
+    assert_eq!(
+        GraphBackend::resolve_from(Some(GraphBackend::Both), Some("new".to_string())).unwrap(),
+        GraphBackend::Both
+    );
+}
+
+#[test]
+fn backend_resolver_rejects_unknown_env_value() {
+    let error = GraphBackend::resolve_from(None, Some("sideways".to_string()))
+        .expect_err("invalid backend rejected");
+    assert!(error.to_string().contains("expected legacy, new, or both"));
+}
+
+#[test]
+fn route_query_uses_new_backend_when_requested() {
+    let value = route_query::<String, _, _>(
+        GraphBackend::New,
+        GraphQueryKind::Search,
+        || Ok(json!({ "backend": "new" })),
+        || Ok(json!({ "backend": "legacy" })),
+    )
+    .unwrap();
+
+    assert_eq!(value["backend"], "new");
+}
+
+#[test]
+fn route_query_both_returns_new_when_shadow_fails() {
+    let value = route_query(
+        GraphBackend::Both,
+        GraphQueryKind::Refs,
+        || Ok(json!({ "backend": "new" })),
+        || Err("shadow unavailable".to_string()),
+    )
+    .unwrap();
+
+    assert_eq!(value["backend"], "new");
+}

--- a/crates/orbit-graph/src/tests/mod.rs
+++ b/crates/orbit-graph/src/tests/mod.rs
@@ -1,1 +1,2 @@
+mod backend;
 mod lib;

--- a/crates/orbit-mcp/src/adapter/dispatch.rs
+++ b/crates/orbit-mcp/src/adapter/dispatch.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 use std::sync::Arc;
+use std::time::Instant;
 
 use orbit_common::types::{OrbitError, ToolSchema, ToolSessionContext};
 use rmcp::ErrorData as McpError;
@@ -16,6 +17,7 @@ use super::name_map::{ToolNameCollision, build_name_map};
 use super::schema::schema_to_tool;
 use super::structured::mcp_structured_content;
 use crate::error::tool_error_result;
+use crate::{McpToolAudit, McpToolAuditStatus};
 
 impl OrbitToolServer {
     pub(super) fn combined_tool_schemas(&self) -> Vec<ToolSchema> {
@@ -103,9 +105,42 @@ impl OrbitToolServer {
         let session_context = self.session_context();
         let input_for_learning = input.clone();
         let graph_tool = self.graph_tools.is_graph_tool(&canonical);
+        let graph_backend = if graph_tool {
+            match self.graph_tools.resolve_backend(&input) {
+                Ok(backend) => Some(backend),
+                Err(err) => {
+                    record_direct_graph_audit(
+                        host.as_ref(),
+                        &canonical,
+                        input.clone(),
+                        None,
+                        McpToolAuditStatus::Failure,
+                        Some(err.to_string()),
+                        1,
+                    );
+                    return Ok(tool_error_result(&err));
+                }
+            }
+        } else {
+            None
+        };
+        let direct_audit_backend = graph_backend
+            .filter(|backend| !self.graph_tools.host_audits_call(&canonical, *backend))
+            .map(|backend| backend.as_str().to_string());
+        let start = Instant::now();
+        let input_for_audit = input.clone();
         let join = tokio::task::spawn_blocking(move || {
             if graph_tool {
-                graph_tools.call_tool(&exec_name, input, session_context)
+                let legacy_host = Arc::clone(&host);
+                let shadow_host = Arc::clone(&host);
+                graph_tools.call_tool(
+                    &exec_name,
+                    input,
+                    session_context,
+                    graph_backend.expect("graph backend resolved before graph dispatch"),
+                    |name, input, context| legacy_host.call_tool(name, input, context),
+                    |name, input, context| shadow_host.call_shadow_tool(name, input, context),
+                )
             } else {
                 host.call_tool(&exec_name, input, session_context)
             }
@@ -114,12 +149,34 @@ impl OrbitToolServer {
 
         match join {
             Ok(Ok(value)) => {
+                if let Some(backend) = direct_audit_backend.as_deref() {
+                    record_direct_graph_audit(
+                        self.host.as_ref(),
+                        &canonical,
+                        input_for_audit.clone(),
+                        Some(backend.to_string()),
+                        McpToolAuditStatus::Success,
+                        None,
+                        elapsed_ms(start),
+                    );
+                }
                 let value = self
                     .maybe_attach_learning_sidecar(&canonical, input_for_learning, value)
                     .await?;
                 Ok(CallToolResult::structured(mcp_structured_content(value)))
             }
             Ok(Err(orbit_err)) => {
+                if let Some(backend) = direct_audit_backend.as_deref() {
+                    record_direct_graph_audit(
+                        self.host.as_ref(),
+                        &canonical,
+                        input_for_audit.clone(),
+                        Some(backend.to_string()),
+                        McpToolAuditStatus::Failure,
+                        Some(orbit_err.to_string()),
+                        elapsed_ms(start),
+                    );
+                }
                 if graph_tool {
                     tracing::warn!(
                         target: "orbit.mcp.graph",
@@ -134,9 +191,50 @@ impl OrbitToolServer {
                 let err = OrbitError::Execution(format!(
                     "tool '{canonical}' worker panicked or was cancelled: {join_err}"
                 ));
+                if let Some(backend) = direct_audit_backend.as_deref() {
+                    record_direct_graph_audit(
+                        self.host.as_ref(),
+                        &canonical,
+                        input_for_audit,
+                        Some(backend.to_string()),
+                        McpToolAuditStatus::Failure,
+                        Some(err.to_string()),
+                        elapsed_ms(start),
+                    );
+                }
                 Ok(tool_error_result(&err))
             }
         }
+    }
+}
+
+fn elapsed_ms(start: Instant) -> i64 {
+    (start.elapsed().as_millis() as i64).max(1)
+}
+
+fn record_direct_graph_audit(
+    host: &dyn crate::McpHost,
+    name: &str,
+    input: Value,
+    backend: Option<String>,
+    status: McpToolAuditStatus,
+    error_message: Option<String>,
+    duration_ms: i64,
+) {
+    if let Err(err) = host.record_tool_audit(McpToolAudit {
+        name: name.to_string(),
+        input,
+        status,
+        duration_ms,
+        error_message,
+        backend,
+    }) {
+        tracing::warn!(
+            target: "orbit.mcp.audit",
+            tool = %name,
+            error = %err,
+            "failed to persist direct MCP graph audit event"
+        );
     }
 }
 

--- a/crates/orbit-mcp/src/adapter/graph.rs
+++ b/crates/orbit-mcp/src/adapter/graph.rs
@@ -9,8 +9,9 @@ use orbit_common::types::{
     required_string,
 };
 use orbit_graph::{
-    DEFAULT_IMPACT_DEPTH, DEFAULT_SHOW_MAX_BYTES, DEFAULT_TRACE_DEPTH, Graph, GraphError,
-    RefConfidence, RefKind, RefOpts, SearchKind, SearchQuery, SyncMode, SyncPolicy,
+    DEFAULT_IMPACT_DEPTH, DEFAULT_SHOW_MAX_BYTES, DEFAULT_TRACE_DEPTH, Graph, GraphBackend,
+    GraphBackendParseError, GraphError, GraphQueryKind, RefConfidence, RefKind, RefOpts,
+    SearchKind, SearchQuery, SyncMode, SyncPolicy, route_query,
 };
 use orbit_graph_extract::{Selector, SelectorParseError};
 use serde_json::{Value, json};
@@ -59,22 +60,52 @@ impl GraphToolRegistry {
         name: &str,
         input: Value,
         session_context: ToolSessionContext,
+        backend: GraphBackend,
+        run_legacy_primary: impl FnOnce(&str, Value, ToolSessionContext) -> Result<Value, OrbitError>
+        + Send,
+        run_legacy_shadow: impl FnOnce(&str, Value, ToolSessionContext) -> Result<Value, OrbitError>
+        + Send,
     ) -> Result<Value, OrbitError> {
+        let query = graph_query_kind(name)?;
         let worktree = resolve_worktree(&input, &session_context)?;
-        let graph = self.graph_for_worktree(worktree.as_path())?;
+        let new_input = input.clone();
+        let legacy_input = legacy_input_for_graph_tool(name, input);
+        let legacy_context = session_context.clone();
         match name {
-            GRAPH_SYNC_TOOL => graph_sync(graph.as_ref(), &input),
-            GRAPH_SEARCH_TOOL => graph_search(graph.as_ref(), &input),
-            GRAPH_SHOW_TOOL => graph_show(graph.as_ref(), &input),
-            GRAPH_REFS_TOOL => graph_refs(graph.as_ref(), &input),
-            GRAPH_CALLEES_TOOL => graph_callees(graph.as_ref(), &input),
-            GRAPH_IMPACT_TOOL => graph_impact(graph.as_ref(), &input),
-            GRAPH_TRACE_TOOL => graph_trace(graph.as_ref(), &input),
+            GRAPH_SYNC_TOOL | GRAPH_SEARCH_TOOL | GRAPH_SHOW_TOOL | GRAPH_REFS_TOOL
+            | GRAPH_CALLEES_TOOL | GRAPH_IMPACT_TOOL | GRAPH_TRACE_TOOL => route_query(
+                backend,
+                query,
+                || {
+                    let graph = self.graph_for_worktree(worktree.as_path())?;
+                    graph_new_query(name, graph.as_ref(), &new_input)
+                },
+                move || {
+                    let legacy_name = legacy_tool_name(name)?;
+                    match backend {
+                        GraphBackend::Legacy => {
+                            run_legacy_primary(legacy_name, legacy_input, legacy_context)
+                        }
+                        GraphBackend::Both => {
+                            run_legacy_shadow(legacy_name, legacy_input, legacy_context)
+                        }
+                        GraphBackend::New => unreachable!("new backend does not call legacy"),
+                    }
+                },
+            ),
             _ => Err(OrbitError::not_found(
                 orbit_common::types::NotFoundKind::Tool,
                 name.to_string(),
             )),
         }
+    }
+
+    pub(super) fn resolve_backend(&self, input: &Value) -> Result<GraphBackend, OrbitError> {
+        GraphBackend::resolve(parse_backend_override(input)?).map_err(backend_error_to_orbit)
+    }
+
+    pub(super) fn host_audits_call(&self, name: &str, backend: GraphBackend) -> bool {
+        matches!(backend, GraphBackend::Legacy) && legacy_tool_name(name).is_ok()
     }
 
     fn graph_for_worktree(&self, worktree: &Path) -> Result<Arc<Graph>, OrbitError> {
@@ -205,6 +236,12 @@ pub(super) fn graph_tool_schemas() -> Vec<ToolSchema> {
 
 fn schema(name: &str, description: &str, mut parameters: Vec<ToolParam>) -> ToolSchema {
     parameters.push(param(
+        "backend",
+        "Optional graph backend override: legacy, new, or both. Takes precedence over ORBIT_GRAPH_BACKEND.",
+        "string",
+        false,
+    ));
+    parameters.push(param(
         "workspace_path",
         "Optional worktree path for this graph request.",
         "string",
@@ -222,6 +259,78 @@ fn schema(name: &str, description: &str, mut parameters: Vec<ToolParam>) -> Tool
         parameters,
         builtin: true,
     }
+}
+
+fn graph_new_query(name: &str, graph: &Graph, input: &Value) -> Result<Value, OrbitError> {
+    match name {
+        GRAPH_SYNC_TOOL => graph_sync(graph, input),
+        GRAPH_SEARCH_TOOL => graph_search(graph, input),
+        GRAPH_SHOW_TOOL => graph_show(graph, input),
+        GRAPH_REFS_TOOL => graph_refs(graph, input),
+        GRAPH_CALLEES_TOOL => graph_callees(graph, input),
+        GRAPH_IMPACT_TOOL => graph_impact(graph, input),
+        GRAPH_TRACE_TOOL => graph_trace(graph, input),
+        _ => Err(OrbitError::not_found(
+            orbit_common::types::NotFoundKind::Tool,
+            name.to_string(),
+        )),
+    }
+}
+
+fn graph_query_kind(name: &str) -> Result<GraphQueryKind, OrbitError> {
+    match name {
+        GRAPH_SYNC_TOOL => Ok(GraphQueryKind::Sync),
+        GRAPH_SEARCH_TOOL => Ok(GraphQueryKind::Search),
+        GRAPH_SHOW_TOOL => Ok(GraphQueryKind::Show),
+        GRAPH_REFS_TOOL => Ok(GraphQueryKind::Refs),
+        GRAPH_CALLEES_TOOL => Ok(GraphQueryKind::Callees),
+        GRAPH_IMPACT_TOOL => Ok(GraphQueryKind::Impact),
+        GRAPH_TRACE_TOOL => Ok(GraphQueryKind::Trace),
+        _ => Err(OrbitError::not_found(
+            orbit_common::types::NotFoundKind::Tool,
+            name.to_string(),
+        )),
+    }
+}
+
+fn legacy_tool_name(name: &str) -> Result<&'static str, OrbitError> {
+    match name {
+        GRAPH_SEARCH_TOOL => Ok(GRAPH_SEARCH_TOOL),
+        GRAPH_SHOW_TOOL => Ok(GRAPH_SHOW_TOOL),
+        GRAPH_REFS_TOOL => Ok(GRAPH_REFS_TOOL),
+        GRAPH_SYNC_TOOL => Err(OrbitError::Execution(
+            "legacy graph backend does not expose orbit.graph.sync over MCP".to_string(),
+        )),
+        GRAPH_CALLEES_TOOL => Err(OrbitError::Execution(
+            "legacy graph backend does not expose orbit.graph.callees".to_string(),
+        )),
+        GRAPH_IMPACT_TOOL => Err(OrbitError::Execution(
+            "legacy graph backend does not expose orbit.graph.impact".to_string(),
+        )),
+        GRAPH_TRACE_TOOL => Err(OrbitError::Execution(
+            "legacy graph backend does not expose orbit.graph.trace".to_string(),
+        )),
+        _ => Err(OrbitError::not_found(
+            orbit_common::types::NotFoundKind::Tool,
+            name.to_string(),
+        )),
+    }
+}
+
+fn legacy_input_for_graph_tool(name: &str, mut input: Value) -> Value {
+    if name == GRAPH_REFS_TOOL
+        && input.get("selector").is_none()
+        && let Some(symbol) = input.get("symbol").cloned()
+    {
+        input["selector"] = symbol;
+    }
+    if name == GRAPH_SEARCH_TOOL
+        && input.get("type").is_none()
+        && input.get("kind").and_then(Value::as_str) == Some("symbol")
+    {
+        input["type"] = json!("symbol");
+    }
+    input
 }
 
 fn param(name: &str, description: &str, param_type: &str, required: bool) -> ToolParam {
@@ -317,6 +426,16 @@ fn optional_confidence(input: &Value) -> Result<RefConfidence, OrbitError> {
         .map(|value| parse_confidence(value.as_str()))
         .transpose()
         .map(|confidence| confidence.unwrap_or_default())
+}
+
+fn parse_backend_override(input: &Value) -> Result<Option<GraphBackend>, OrbitError> {
+    optional_string(input, "backend")?
+        .map(|value| {
+            value
+                .parse::<GraphBackend>()
+                .map_err(backend_error_to_orbit)
+        })
+        .transpose()
 }
 
 fn parse_selector(raw: String) -> Result<Selector, OrbitError> {
@@ -440,6 +559,10 @@ fn graph_error_to_orbit(error: GraphError) -> OrbitError {
         }
         _ => OrbitError::Execution(error.to_string()),
     }
+}
+
+fn backend_error_to_orbit(error: GraphBackendParseError) -> OrbitError {
+    OrbitError::InvalidInput(error.to_string())
 }
 
 fn selector_error_to_orbit(error: SelectorParseError) -> OrbitError {

--- a/crates/orbit-mcp/src/adapter/tests/graph.rs
+++ b/crates/orbit-mcp/src/adapter/tests/graph.rs
@@ -1,11 +1,14 @@
 use std::fs;
 use std::path::Path;
 use std::process::Command;
-use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
 
-use orbit_common::types::ToolSessionContext;
+use orbit_common::types::{OrbitError, ToolSchema, ToolSessionContext};
 use serde_json::{Value, json};
 use tempfile::TempDir;
+
+use crate::{McpHost, McpToolAudit, McpToolAuditStatus};
 
 use super::super::OrbitToolServer;
 use super::super::graph::graph_tool_schemas;
@@ -28,27 +31,27 @@ fn graph_tool_schemas_cover_cli_parameters() {
         ]
     );
 
-    assert_param_names(&schemas[0], &with_workspace_params(&["full"]));
+    assert_param_names(&schemas[0], &with_workspace_params(&["full", "backend"]));
     assert_param_names(
         &schemas[1],
-        &with_workspace_params(&["query", "kind", "lang", "limit"]),
+        &with_workspace_params(&["query", "kind", "lang", "limit", "backend"]),
     );
     assert_param_names(
         &schemas[2],
-        &with_workspace_params(&["selector", "max_bytes"]),
+        &with_workspace_params(&["selector", "max_bytes", "backend"]),
     );
     assert_param_names(
         &schemas[3],
-        &with_workspace_params(&["symbol", "confidence", "kind"]),
+        &with_workspace_params(&["symbol", "confidence", "kind", "backend"]),
     );
-    assert_param_names(&schemas[4], &with_workspace_params(&["symbol"]));
+    assert_param_names(&schemas[4], &with_workspace_params(&["symbol", "backend"]));
     assert_param_names(
         &schemas[5],
-        &with_workspace_params(&["selector", "depth", "confidence"]),
+        &with_workspace_params(&["selector", "depth", "confidence", "backend"]),
     );
     assert_param_names(
         &schemas[6],
-        &with_workspace_params(&["command_name", "depth", "confidence"]),
+        &with_workspace_params(&["command_name", "depth", "confidence", "backend"]),
     );
     assert_workspace_params_optional_strings(&schemas);
 }
@@ -77,7 +80,7 @@ fn combined_schemas_override_legacy_host_graph_tools() {
         .expect("graph search schema");
     assert_param_names(
         search,
-        &with_workspace_params(&["query", "kind", "lang", "limit"]),
+        &with_workspace_params(&["query", "kind", "lang", "limit", "backend"]),
     );
     assert!(
         schemas
@@ -102,7 +105,8 @@ async fn graph_tools_invoke_in_process_fixture() {
         &server,
         "orbit.graph.sync",
         json!({
-            "full": true
+            "full": true,
+            "backend": "new"
         }),
     )
     .await;
@@ -115,7 +119,8 @@ async fn graph_tools_invoke_in_process_fixture() {
         json!({
             "query": "helper",
             "kind": "symbol",
-            "limit": 5
+            "limit": 5,
+            "backend": "new"
         }),
     )
     .await;
@@ -126,7 +131,8 @@ async fn graph_tools_invoke_in_process_fixture() {
         "orbit.graph.show",
         json!({
             "selector": "symbol:src/lib.rs#entry:function",
-            "max_bytes": 256
+            "max_bytes": 256,
+            "backend": "new"
         }),
     )
     .await;
@@ -139,7 +145,8 @@ async fn graph_tools_invoke_in_process_fixture() {
         json!({
             "symbol": "symbol:src/lib.rs#helper:function",
             "confidence": "fuzzy",
-            "kind": "call"
+            "kind": "call",
+            "backend": "new"
         }),
     )
     .await;
@@ -151,7 +158,8 @@ async fn graph_tools_invoke_in_process_fixture() {
         &server,
         "orbit.graph.callees",
         json!({
-            "symbol": "symbol:src/lib.rs#entry:function"
+            "symbol": "symbol:src/lib.rs#entry:function",
+            "backend": "new"
         }),
     )
     .await;
@@ -163,7 +171,8 @@ async fn graph_tools_invoke_in_process_fixture() {
         json!({
             "selector": "symbol:src/lib.rs#entry:function",
             "depth": 2,
-            "confidence": "same_module"
+            "confidence": "same_module",
+            "backend": "new"
         }),
     )
     .await;
@@ -176,7 +185,8 @@ async fn graph_tools_invoke_in_process_fixture() {
         json!({
             "command_name": "missing-command",
             "depth": 2,
-            "confidence": "same_module"
+            "confidence": "same_module",
+            "backend": "new"
         }),
     )
     .await;
@@ -201,7 +211,7 @@ async fn graph_tool_errors_are_structured_mcp_tool_errors() {
     let result = server
         .call_tool_request(request_with_args(
             "orbit.graph.show",
-            json!({ "selector": "not-a-selector" }),
+            json!({ "selector": "not-a-selector", "backend": "new" }),
         ))
         .await
         .expect("MCP request succeeds with tool error payload");
@@ -217,6 +227,38 @@ async fn graph_tool_errors_are_structured_mcp_tool_errors() {
     );
 }
 
+#[tokio::test]
+async fn graph_both_backend_records_one_direct_audit_and_uses_unaudited_shadow() {
+    let worktree = fixture_worktree();
+    let host = Arc::new(RecordingHost::default());
+    let server = OrbitToolServer::new(host.clone());
+    server.replace_session_context(ToolSessionContext::with_workspace(
+        worktree.path().display().to_string(),
+    ));
+
+    let search = call_json(
+        &server,
+        "orbit.graph.search",
+        json!({
+            "query": "helper",
+            "kind": "symbol",
+            "limit": 5,
+            "backend": "both"
+        }),
+    )
+    .await;
+    assert_array_field(&search, "matches");
+
+    assert_eq!(host.primary_calls.load(Ordering::SeqCst), 0);
+    assert_eq!(host.shadow_calls.load(Ordering::SeqCst), 1);
+
+    let audits = host.audits.lock().expect("audit lock");
+    assert_eq!(audits.len(), 1);
+    assert_eq!(audits[0].name, "orbit.graph.search");
+    assert_eq!(audits[0].status, McpToolAuditStatus::Success);
+    assert_eq!(audits[0].backend.as_deref(), Some("both"));
+}
+
 async fn call_json(server: &OrbitToolServer, name: &str, args: Value) -> Value {
     let result = server
         .call_tool_request(request_with_args(name, args))
@@ -227,6 +269,46 @@ async fn call_json(server: &OrbitToolServer, name: &str, args: Value) -> Value {
         "{name} should not return a tool error: {result:?}"
     );
     result.structured_content.expect("structured content")
+}
+
+#[derive(Default)]
+struct RecordingHost {
+    audits: Mutex<Vec<McpToolAudit>>,
+    primary_calls: AtomicUsize,
+    shadow_calls: AtomicUsize,
+}
+
+impl McpHost for RecordingHost {
+    fn list_tool_schemas(&self) -> Vec<ToolSchema> {
+        Vec::new()
+    }
+
+    fn call_tool(
+        &self,
+        _name: &str,
+        _input: Value,
+        _session_context: ToolSessionContext,
+    ) -> Result<Value, OrbitError> {
+        self.primary_calls.fetch_add(1, Ordering::SeqCst);
+        Err(OrbitError::Execution(
+            "primary legacy host should not run for backend=both".to_string(),
+        ))
+    }
+
+    fn call_shadow_tool(
+        &self,
+        _name: &str,
+        _input: Value,
+        _session_context: ToolSessionContext,
+    ) -> Result<Value, OrbitError> {
+        self.shadow_calls.fetch_add(1, Ordering::SeqCst);
+        Ok(json!({ "matches": [] }))
+    }
+
+    fn record_tool_audit(&self, audit: McpToolAudit) -> Result<(), OrbitError> {
+        self.audits.lock().expect("audit lock").push(audit);
+        Ok(())
+    }
 }
 
 fn assert_array_field(value: &Value, field: &str) {

--- a/crates/orbit-mcp/src/lib.rs
+++ b/crates/orbit-mcp/src/lib.rs
@@ -48,6 +48,22 @@ use serde_json::Value;
 
 pub use adapter::OrbitToolServer;
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum McpToolAuditStatus {
+    Success,
+    Failure,
+}
+
+#[derive(Debug, Clone)]
+pub struct McpToolAudit {
+    pub name: String,
+    pub input: Value,
+    pub status: McpToolAuditStatus,
+    pub duration_ms: i64,
+    pub error_message: Option<String>,
+    pub backend: Option<String>,
+}
+
 /// A pluggable back-end that satisfies MCP `tools/list` and `tools/call`
 /// requests.
 ///
@@ -63,6 +79,19 @@ pub trait McpHost: Send + Sync + 'static {
         input: Value,
         session_context: ToolSessionContext,
     ) -> Result<Value, OrbitError>;
+
+    fn call_shadow_tool(
+        &self,
+        name: &str,
+        input: Value,
+        session_context: ToolSessionContext,
+    ) -> Result<Value, OrbitError> {
+        self.call_tool(name, input, session_context)
+    }
+
+    fn record_tool_audit(&self, _audit: McpToolAudit) -> Result<(), OrbitError> {
+        Ok(())
+    }
 
     /// L-0043: sidecar internals use host extensions so runtime-backed MCP
     /// hosts can keep the client safe surface narrow.

--- a/crates/orbit-store/src/sqlite/audit_event_store/mod.rs
+++ b/crates/orbit-store/src/sqlite/audit_event_store/mod.rs
@@ -35,6 +35,7 @@ pub struct AuditEventInsertParams {
     pub job_run_id: Option<String>,
     pub activity_id: Option<String>,
     pub step_index: Option<i64>,
+    pub backend: Option<String>,
 }
 
 #[derive(Debug, Clone, Default)]
@@ -119,8 +120,8 @@ impl Store {
                 duration_ms, working_directory, arguments_json,
                 stdout_truncated, stderr_truncated, error_message,
                 host, pid, session_id, task_id, job_run_id, activity_id,
-                step_index
-            ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19, ?20, ?21, ?22, ?23)"#,
+                step_index, backend
+            ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19, ?20, ?21, ?22, ?23, ?24)"#,
             rusqlite::params![
                 params.execution_id,
                 now_string(),
@@ -145,6 +146,7 @@ impl Store {
                 params.job_run_id,
                 params.activity_id,
                 params.step_index,
+                params.backend,
             ],
         )
         .map_err(|e| OrbitError::Store(e.to_string()))?;
@@ -202,7 +204,7 @@ impl Store {
              target_type, target_id, role, status, exit_code, duration_ms, \
              working_directory, arguments_json, stdout_truncated, stderr_truncated, \
              error_message, host, pid, session_id, task_id, job_run_id, activity_id, \
-             step_index \
+             step_index, backend \
              FROM audit_events {where_clause} ORDER BY id DESC LIMIT ?{}",
             param_values.len() + 1
         );
@@ -255,6 +257,7 @@ impl Store {
                     job_run_id: row.get(21)?,
                     activity_id: row.get(22)?,
                     step_index: row.get(23)?,
+                    backend: row.get(24)?,
                 })
             })
             .map_err(|e| OrbitError::Store(e.to_string()))?;
@@ -275,7 +278,7 @@ impl Store {
                  target_type, target_id, role, status, exit_code, duration_ms, \
                  working_directory, arguments_json, stdout_truncated, stderr_truncated, \
                  error_message, host, pid, session_id, task_id, job_run_id, activity_id, \
-                 step_index \
+                 step_index, backend \
                  FROM audit_events WHERE id = ?1",
             )
             .map_err(|e| OrbitError::Store(e.to_string()))?;
@@ -319,6 +322,7 @@ impl Store {
                     job_run_id: row.get(21)?,
                     activity_id: row.get(22)?,
                     step_index: row.get(23)?,
+                    backend: row.get(24)?,
                 })
             })
             .optional()

--- a/crates/orbit-store/src/sqlite/audit_event_store/tests/audit_event_store.rs
+++ b/crates/orbit-store/src/sqlite/audit_event_store/tests/audit_event_store.rs
@@ -26,6 +26,7 @@ fn sample_params() -> AuditEventInsertParams {
         job_run_id: Some("jrun-xyz".to_string()),
         activity_id: Some("agent_implement".to_string()),
         step_index: Some(2),
+        backend: Some("legacy".to_string()),
     }
 }
 
@@ -59,6 +60,7 @@ fn insert_then_read_round_trips_correlation_fields() {
     assert_eq!(event.job_run_id.as_deref(), Some("jrun-xyz"));
     assert_eq!(event.activity_id.as_deref(), Some("agent_implement"));
     assert_eq!(event.step_index, Some(2));
+    assert_eq!(event.backend.as_deref(), Some("legacy"));
 
     let by_id = store
         .get_audit_event(event.id)
@@ -68,6 +70,7 @@ fn insert_then_read_round_trips_correlation_fields() {
     assert_eq!(by_id.job_run_id.as_deref(), Some("jrun-xyz"));
     assert_eq!(by_id.activity_id.as_deref(), Some("agent_implement"));
     assert_eq!(by_id.step_index, Some(2));
+    assert_eq!(by_id.backend.as_deref(), Some("legacy"));
 }
 
 #[test]

--- a/crates/orbit-store/src/sqlite/migration/mod.rs
+++ b/crates/orbit-store/src/sqlite/migration/mod.rs
@@ -56,7 +56,8 @@ pub(crate) fn apply_schema(conn: &Connection) -> Result<(), OrbitError> {
                 task_id TEXT,
                 job_run_id TEXT,
                 activity_id TEXT,
-                step_index INTEGER
+                step_index INTEGER,
+                backend TEXT
             );
 
             CREATE TABLE IF NOT EXISTS task_reservations (
@@ -393,6 +394,7 @@ fn ensure_audit_events_schema(conn: &Connection) -> Result<(), OrbitError> {
         conn,
         "ALTER TABLE audit_events ADD COLUMN step_index INTEGER",
     )?;
+    add_column_if_missing(conn, "ALTER TABLE audit_events ADD COLUMN backend TEXT")?;
 
     conn.execute_batch(
         r#"

--- a/docs/design/orbit-graph/specs/GRAPH_SPEC.md
+++ b/docs/design/orbit-graph/specs/GRAPH_SPEC.md
@@ -4,7 +4,7 @@
 **Last updated:** 2026-05-25 (ORB-00330 Rust command extraction; ORB-00331 detached-HEAD DB layout)
 **Relation to `orbit-knowledge`:** Coexists initially. Both crates run side-by-side under a feature flag; whether `orbit-knowledge` is eventually phased out depends on the head-to-head effectiveness measurement in §16 Step 4 — it is not a foregone conclusion of this spec.
 **Author:** working from the V2 sketch in `GRAPH_V2.md` + the existing design in [`../../knowledge-graph/`](../../knowledge-graph/)
-**Scope:** V1 — read-only graph. A writeable graph (Rename, ReplaceBody, Move, working-graph overlay, patch compiler) is V2, sketched in §17 and tracked in [`../3_vision.md`](../3_vision.md). The previous separate `GRAPH_DESIGN.md` describing the write surface has been folded into this spec on 2026-05-24 to remove the contradictory scope between the two docs.
+**Scope:** V1 — read-only graph. A writeable graph (Rename, ReplaceBody, Move, working-graph overlay, patch compiler) is V2, sketched in §18 and tracked in [`../3_vision.md`](../3_vision.md). The previous separate `GRAPH_DESIGN.md` describing the write surface has been folded into this spec on 2026-05-24 to remove the contradictory scope between the two docs.
 
 ---
 
@@ -639,7 +639,33 @@ The output is a **decision artifact**, not a deletion: keep both crates, depreca
 
 Estimated calendar time: 6–8 weeks for Steps 1–3 driven by a single agent. Step 4's calendar is the length of the evaluation window plus the decision turnaround. The bulk of *technical* risk lives in Step 2; the bulk of *organizational* commitment lives in Step 4.
 
-## 17. Open questions
+## 17. Backend selection and cutover flag
+
+During Phase 7, every graph query surface accepts a runtime backend selector:
+
+- Environment variable: `ORBIT_GRAPH_BACKEND=legacy|new|both`.
+- Per-call override: `--backend legacy|new|both` on the `orbit-graph-cli` query commands, and `backend: "legacy" | "new" | "both"` on MCP/tool calls.
+- Precedence: per-call override > `ORBIT_GRAPH_BACKEND` > default.
+- Default: `legacy` until the Phase 7.4 effectiveness data supports the P7.2 default flip.
+
+Backend meanings:
+
+| Backend | Behavior |
+|---|---|
+| `legacy` | Route to the existing `orbit-knowledge` graph surface. This is the conservative default during the measurement window. |
+| `new` | Route to the SQLite-backed `orbit-graph` implementation. |
+| `both` | Return `orbit-graph` as the primary result and run `orbit-knowledge` as a shadow query. Shadow failures are logged but do not fail the primary query. Shadow result differences are logged at `WARN` with structured fields including query name, primary/shadow backend labels, serialized lengths, and content hashes. |
+
+Command audit entries for `orbit.graph.*` calls carry `backend: legacy|new|both` so the Phase 7.4 analysis can correlate latency, coverage, failures, and downstream task outcomes with the backend that served each query. Invalid environment values fail the graph call rather than silently changing the query path.
+
+Cutover plan:
+
+1. P7.1 ships the selector with `legacy` as default and `both` for shadow comparison.
+2. P7.3/P7.4 run real agent workflows through `both` and `new`, using audit rows plus shadow diffs to quantify coverage and effectiveness.
+3. P7.2 flips the default to `new` only after the documented measurement window is green.
+4. `legacy` remains available after the flip until a separate decision artifact chooses deprecation or removal.
+
+## 18. Open questions
 
 These are deliberately deferred — not blockers for shipping the spec, but listed so they don't get lost.
 
@@ -649,7 +675,7 @@ These are deliberately deferred — not blockers for shipping the spec, but list
 4. **Watcher reliability.** `notify` has known issues on Linux with mass-rename operations. `SyncPolicy::Windowed` is the safety net; we should still measure.
 5. **V2 write surface.** Rename, ReplaceBody, Delete, InsertAfter, Move — with an in-memory working-graph overlay, optimistic per-file hash verification on commit, and a patch compiler that turns graph edits into source diffs. Sketch lives in [`../3_vision.md`](../3_vision.md) §1.1. Out of scope for V1, but the V1 read model (per-worktree DB, qualified-name resolution, ephemeral symbol IDs) is deliberately compatible with adding writes later without a schema break.
 
-## 18. What this spec deliberately does *not* include
+## 19. What this spec deliberately does *not* include
 
 - A philosophy section. The principles ("structural not semantic," "deterministic," etc.) are inherited from `GRAPH_V2.md` and the existing knowledge-graph ADRs. They don't need restating.
 - A long list of "why not LSP." Not actually a live option in this codebase.


### PR DESCRIPTION
## Summary

- Add a shared `GraphBackend` selector and `route_query` helper for `legacy`, `new`, and `both` graph routing.
- Wire `ORBIT_GRAPH_BACKEND` and per-call backend overrides through the graph CLI and MCP graph tools.
- Record selected graph backend values in audit rows and document the Phase 7.1 cutover behavior in `GRAPH_SPEC.md`.

## Why

ORB-00332 needs an opt-in runtime switch so Phase 7 can compare the legacy `orbit-knowledge` graph surface with the new SQLite-backed `orbit-graph` implementation without recompilation. The default remains `legacy`, while `both` returns the new backend as primary and logs legacy shadow failures or diffs without failing the primary call.

## Validation

- `cargo check -p orbit-graph -p orbit-graph-cli -p orbit-mcp -p orbit-store -p orbit-core -p orbit-cli --tests`
- `cargo test -p orbit-graph`
- `cargo test -p orbit-graph-cli`
- `cargo test -p orbit-mcp`
- `cargo test -p orbit-store audit_event_store`
- `cargo test -p orbit-core dispatch_records_graph_backend_in_audit_row`
- `cargo test -p orbit-cli audit`
- `git diff --check`
- `make ci-fast`