### PR TITLE
[codex] Fix CI failures on agent-main

### DIFF
--- a/crates/orbit-cli/src/command/mcp/setup/workspace.rs
+++ b/crates/orbit-cli/src/command/mcp/setup/workspace.rs
@@ -36,6 +36,7 @@ pub(super) fn resolve_workspace_layout_for_cwd(cwd: &Path) -> Result<WorkspaceLa
     // Skip the user's global $HOME/.orbit during ancestor walk-up. It is the
     // global Orbit root, not a workspace, so adopting it would silently write
     // workspace-scope MCP configs to home-scope paths.
+    let home = env_home_dir();
     for ancestor in cwd.ancestors() {
         let orbit_root = ancestor.join(".orbit");
         if orbit_root.is_dir() && !is_global_orbit_dir(&orbit_root) {
@@ -43,6 +44,12 @@ pub(super) fn resolve_workspace_layout_for_cwd(cwd: &Path) -> Result<WorkspaceLa
                 repo_root: ancestor.to_path_buf(),
                 orbit_root,
             });
+        }
+        if home
+            .as_deref()
+            .is_some_and(|home| paths_equivalent(ancestor, home))
+        {
+            break;
         }
     }
 

--- a/crates/orbit-core/src/command/job/run/tests/actions.rs
+++ b/crates/orbit-core/src/command/job/run/tests/actions.rs
@@ -129,20 +129,12 @@ where
 }
 
 #[cfg(unix)]
-fn read_pid_pair(path: &Path) -> (u32, u32) {
-    let raw = std::fs::read_to_string(path).expect("read pid file");
+fn read_pid_pair(path: &Path) -> Option<(u32, u32)> {
+    let raw = std::fs::read_to_string(path).ok()?;
     let mut parts = raw.split_whitespace();
-    let owner = parts
-        .next()
-        .expect("owner pid")
-        .parse()
-        .expect("parse owner pid");
-    let child = parts
-        .next()
-        .expect("child pid")
-        .parse()
-        .expect("parse child pid");
-    (owner, child)
+    let owner = parts.next()?.parse().ok()?;
+    let child = parts.next()?.parse().ok()?;
+    Some((owner, child))
 }
 
 #[cfg(unix)]
@@ -218,11 +210,17 @@ fn cancel_job_run_terminates_owner_process_group_and_child() {
         });
     }
     let mut owner = owner.spawn().expect("spawn owner");
+    let mut pid_pair = None;
     assert!(
-        wait_until(StdDuration::from_secs(2), || pid_file.exists()),
+        wait_until(StdDuration::from_secs(2), || {
+            pid_pair = read_pid_pair(&pid_file);
+            pid_pair.is_some()
+        }),
         "owner did not write pid file"
     );
-    let (owner_pid, child_pid) = read_pid_pair(&pid_file);
+    let Some((owner_pid, child_pid)) = pid_pair else {
+        panic!("owner did not write pid file");
+    };
     assert_eq!(owner.id(), owner_pid);
     runtime
         .stores()

--- a/crates/orbit-core/src/runtime/resolve.rs
+++ b/crates/orbit-core/src/runtime/resolve.rs
@@ -124,8 +124,11 @@ fn resolve_roots(
         ));
     }
 
-    // 5. Walk up from cwd to find first workspace .orbit/ directory
-    if let Some(orbit_dir) = find_orbit_dir_walk_up(cwd) {
+    // 5. Walk up from cwd to find first workspace .orbit/ directory. Bootstrap
+    // flows stop at the current git root, or cwd when there is no git root, so
+    // unrelated parent directories with `.orbit/` cannot capture new workspaces.
+    let walk_up_boundaries = walk_up_boundaries(cwd, explicit_root_mode);
+    if let Some(orbit_dir) = find_orbit_dir_walk_up(cwd, &walk_up_boundaries) {
         let root = resolve_orbit_dir_candidate(&orbit_dir)?;
         return Ok(log_resolved_roots(
             cwd,
@@ -194,15 +197,42 @@ fn local_worktree_orbit_dir(cwd: &Path) -> PathBuf {
 /// `orbit workspace init` in a repo under `$HOME` with no local `.orbit/` would
 /// discover the global root before the git-repo bootstrap fallback and then
 /// write workspace state into `$HOME/.orbit`.
-fn find_orbit_dir_walk_up(start: &Path) -> Option<PathBuf> {
+fn find_orbit_dir_walk_up(start: &Path, boundaries: &[PathBuf]) -> Option<PathBuf> {
     let mut current = start;
     loop {
         let candidate = current.join(".orbit");
         if candidate.is_dir() && !is_global_orbit_dir(&candidate) {
             return Some(candidate);
         }
+        if boundaries
+            .iter()
+            .any(|boundary| paths_equivalent(current, boundary))
+        {
+            return None;
+        }
         current = current.parent()?;
     }
+}
+
+fn walk_up_boundaries(cwd: &Path, explicit_root_mode: ExplicitRootMode) -> Vec<PathBuf> {
+    let mut boundaries = Vec::new();
+    if explicit_root_mode == ExplicitRootMode::AllowUninitialized {
+        boundaries.push(paths::find_git_worktree_root(cwd).unwrap_or_else(|| cwd.to_path_buf()));
+    }
+    if let Some(home) = home_dir_boundary()
+        && !boundaries
+            .iter()
+            .any(|boundary| paths_equivalent(boundary, &home))
+    {
+        boundaries.push(home);
+    }
+    boundaries
+}
+
+fn home_dir_boundary() -> Option<PathBuf> {
+    workspace_registry::global_orbit_dir()
+        .ok()
+        .and_then(|global| global.parent().map(Path::to_path_buf))
 }
 
 fn is_global_orbit_dir(candidate: &Path) -> bool {
@@ -389,7 +419,8 @@ pub(crate) fn try_resolve_initialized_roots(
         )));
     }
 
-    if let Some(orbit_dir) = find_orbit_dir_walk_up(cwd)
+    let walk_up_boundaries = walk_up_boundaries(cwd, ExplicitRootMode::RequireInitialized);
+    if let Some(orbit_dir) = find_orbit_dir_walk_up(cwd, &walk_up_boundaries)
         && is_initialized_orbit_root(&orbit_dir)
     {
         let root = resolve_orbit_dir_candidate(&orbit_dir)?;

--- a/crates/orbit-core/src/runtime/tests/pipeline.rs
+++ b/crates/orbit-core/src/runtime/tests/pipeline.rs
@@ -9,6 +9,7 @@ use orbit_tools::ToolContext;
 
 use orbit_common::types::{TaskPriority, TaskStatus, TaskType};
 use orbit_store::TaskCreateParams;
+use rusqlite::Connection;
 use serde_json::json;
 use tempfile::tempdir;
 
@@ -67,17 +68,17 @@ fn run_tool_context_allowlist_honors_task_wildcard() {
 }
 
 #[test]
-fn graph_tool_refresh_from_linked_worktree_attributes_to_worktree_branch() {
+fn graph_tool_sync_from_linked_worktree_attributes_to_worktree_branch() {
     let fixture = GitWorktreeFixture::new();
     let runtime =
         OrbitRuntime::from_roots(&fixture.global_root, &fixture.main_orbit).expect("build runtime");
 
     runtime
         .run_tool_with_context_and_role(
-            "orbit.graph.pack",
+            "orbit.graph.sync",
             json!({
-                "selectors": ["file:Cargo.toml"],
-                "refresh": true,
+                "full": true,
+                "workspace_path": fixture.worktree.to_string_lossy(),
             }),
             Role::Admin,
             ToolContext {
@@ -85,17 +86,12 @@ fn graph_tool_refresh_from_linked_worktree_attributes_to_worktree_branch() {
                 ..Default::default()
             },
         )
-        .expect("pack from worktree");
+        .expect("sync from worktree");
 
-    assert!(
-        fixture
-            .main_orbit
-            .join("knowledge/graph/refs/heads/orbit/ORB-00099-test.json")
-            .is_file(),
-        "worktree branch ref should be written under shared knowledge dir"
-    );
+    let graph_db = worktree_branch_graph_db(&fixture.worktree);
+    assert_eq!(graph_meta(&graph_db, "branch"), "orbit/ORB-00099-test");
     assert_eq!(
-        manifest_head_oid(&fixture.main_orbit.join("knowledge/manifest.json")),
+        graph_meta(&graph_db, "commit_sha"),
         git_output(&fixture.worktree, &["rev-parse", "HEAD"])
     );
 }
@@ -191,11 +187,28 @@ fn git_output(cwd: &Path, args: &[&str]) -> String {
         .to_string()
 }
 
-fn manifest_head_oid(path: &Path) -> String {
-    let raw = std::fs::read_to_string(path).expect("read manifest");
-    let manifest: serde_json::Value = serde_json::from_str(&raw).expect("parse manifest");
-    manifest["git_head_oid"]
-        .as_str()
-        .expect("manifest git_head_oid")
-        .to_string()
+fn worktree_branch_graph_db(worktree: &Path) -> PathBuf {
+    let graph_dir = worktree.join(".orbit").join("graph");
+    let mut matches = std::fs::read_dir(&graph_dir)
+        .expect("read graph dir")
+        .map(|entry| entry.expect("graph entry").path())
+        .filter(|path| {
+            path.file_name()
+                .and_then(|name| name.to_str())
+                .is_some_and(|name| {
+                    name.starts_with("orbit_ORB-00099-test.") && name.ends_with(".db")
+                })
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(matches.len(), 1, "expected one worktree branch graph DB");
+    matches.remove(0)
+}
+
+fn graph_meta(path: &Path, key: &str) -> String {
+    Connection::open(path)
+        .expect("open graph db")
+        .query_row("SELECT value FROM meta WHERE key = ?1", [key], |row| {
+            row.get(0)
+        })
+        .expect("read graph meta")
 }

--- a/crates/orbit-core/src/runtime/tests/resolve.rs
+++ b/crates/orbit-core/src/runtime/tests/resolve.rs
@@ -5,7 +5,7 @@ use std::fs;
 use std::path::Path;
 use std::sync::Mutex;
 
-use tempfile::tempdir;
+use tempfile::{tempdir, tempdir_in};
 
 use orbit_common::types::OrbitError;
 
@@ -224,12 +224,14 @@ fn bootstrap_ignores_home_global_orbit_when_repo_has_no_workspace_orbit() {
 fn try_resolve_returns_none_outside_orbit_workspace() {
     let _guard = ENV_LOCK.lock().expect("lock env");
     let _env = EnvVarGuard::remove("ORBIT_ROOT");
-    let nowhere = tempdir().expect("nowhere tempdir");
+    let home = tempdir().expect("home tempdir");
+    let _home = EnvVarGuard::set("HOME", home.path().as_os_str().to_os_string());
+    let nowhere = tempdir_in(home.path()).expect("nowhere tempdir");
 
     let resolved = try_resolve_initialized_roots(nowhere.path(), None)
         .expect("try_resolve completes without error");
 
-    assert!(resolved.is_none());
+    assert!(resolved.is_none(), "unexpected roots: {resolved:?}");
     assert!(!nowhere.path().join(".orbit").exists());
 }
 
@@ -253,8 +255,10 @@ fn try_resolve_finds_initialized_workspace_via_walk_up() {
 fn try_resolve_finds_main_worktree_orbit_for_linked_worktree() {
     let _guard = ENV_LOCK.lock().expect("lock env");
     let _env = EnvVarGuard::remove("ORBIT_ROOT");
-    let main_repo = tempdir().expect("main repo tempdir");
-    let worktree = tempdir().expect("worktree tempdir");
+    let home = tempdir().expect("home tempdir");
+    let _home = EnvVarGuard::set("HOME", home.path().as_os_str().to_os_string());
+    let main_repo = tempdir_in(home.path()).expect("main repo tempdir");
+    let worktree = tempdir_in(home.path()).expect("worktree tempdir");
     seed_fake_git_worktree(main_repo.path(), worktree.path());
     let main_orbit = main_repo.path().join(".orbit");
     seed_initialized_workspace_root(&main_orbit);
@@ -269,8 +273,10 @@ fn try_resolve_finds_main_worktree_orbit_for_linked_worktree() {
 fn try_resolve_returns_none_when_main_worktree_orbit_is_uninitialized() {
     let _guard = ENV_LOCK.lock().expect("lock env");
     let _env = EnvVarGuard::remove("ORBIT_ROOT");
-    let main_repo = tempdir().expect("main repo tempdir");
-    let worktree = tempdir().expect("worktree tempdir");
+    let home = tempdir().expect("home tempdir");
+    let _home = EnvVarGuard::set("HOME", home.path().as_os_str().to_os_string());
+    let main_repo = tempdir_in(home.path()).expect("main repo tempdir");
+    let worktree = tempdir_in(home.path()).expect("worktree tempdir");
     seed_fake_git_worktree(main_repo.path(), worktree.path());
     // No `.orbit/` exists at all — main worktree resolution finds the
     // path but it's uninitialized, so try_resolve falls through.
@@ -278,7 +284,7 @@ fn try_resolve_returns_none_when_main_worktree_orbit_is_uninitialized() {
     let resolved = try_resolve_initialized_roots(worktree.path(), None)
         .expect("try_resolve completes without error");
 
-    assert!(resolved.is_none());
+    assert!(resolved.is_none(), "unexpected roots: {resolved:?}");
     assert!(!main_repo.path().join(".orbit").exists());
     assert!(!worktree.path().join(".orbit").exists());
 }

--- a/crates/orbit-dashboard/src/api/scoreboard.rs
+++ b/crates/orbit-dashboard/src/api/scoreboard.rs
@@ -30,7 +30,7 @@ pub(super) async fn scoreboard(
 ) -> Response {
     let window = match query.window.as_deref() {
         None => ScoreboardWindow::All,
-        Some(raw) => match ScoreboardWindow::from_str(raw) {
+        Some(raw) => match raw.parse::<ScoreboardWindow>() {
             Ok(w) => w,
             Err(e) => {
                 return (

--- a/crates/orbit-graph-cli/tests/subcommands.rs
+++ b/crates/orbit-graph-cli/tests/subcommands.rs
@@ -9,18 +9,25 @@ use predicates::prelude::*;
 use serde_json::Value;
 use tempfile::TempDir;
 
-#[test]
-fn query_and_admin_subcommands_emit_json() {
-    let worktree = fixture_worktree();
+type TestResult<T = ()> = Result<T, Box<dyn std::error::Error>>;
 
-    let sync = run_json(worktree.path(), ["sync", "--full"]);
+#[test]
+fn query_and_admin_subcommands_emit_json() -> TestResult {
+    let worktree = fixture_worktree()?;
+
+    let sync = run_json(worktree.path(), ["sync", "--full"])?;
     assert_eq!(sync["files_removed"], 0);
-    assert!(sync["files_indexed"].as_u64().expect("files_indexed") >= 1);
+    assert!(
+        sync["files_indexed"]
+            .as_u64()
+            .is_some_and(|files_indexed| files_indexed >= 1),
+        "files_indexed should be at least 1 in {sync}"
+    );
 
     let search = run_json(
         worktree.path(),
         ["search", "helper", "--kind", "symbol", "--limit", "5"],
-    );
+    )?;
     assert_array_field(&search, "matches");
 
     let show = run_json(
@@ -31,12 +38,9 @@ fn query_and_admin_subcommands_emit_json() {
             "--max-bytes",
             "256",
         ],
-    );
+    )?;
     assert_eq!(show["metadata"]["file"], "src/lib.rs");
-    assert_eq!(
-        show["text"].as_str().expect("show text"),
-        expected_entry_source()
-    );
+    assert_eq!(show["text"].as_str(), Some(expected_entry_source()));
     assert!(show.get("bytes").is_none());
 
     let refs = run_json(
@@ -49,7 +53,7 @@ fn query_and_admin_subcommands_emit_json() {
             "--kind",
             "call",
         ],
-    );
+    )?;
     assert!(refs.get("target").is_some());
     assert_array_field(&refs, "refs");
     assert_array_field(&refs, "relations");
@@ -57,7 +61,7 @@ fn query_and_admin_subcommands_emit_json() {
     let callees = run_json(
         worktree.path(),
         ["callees", "symbol:src/lib.rs#entry:function"],
-    );
+    )?;
     assert_array_field(&callees, "callees");
 
     let impact = run_json(
@@ -70,7 +74,7 @@ fn query_and_admin_subcommands_emit_json() {
             "--confidence",
             "same_module",
         ],
-    );
+    )?;
     assert_array_field(&impact, "touched");
     assert!(impact.get("visited_nodes").is_some());
 
@@ -84,44 +88,49 @@ fn query_and_admin_subcommands_emit_json() {
             "--confidence",
             "same_module",
         ],
-    );
+    )?;
     assert!(trace["root"].is_null());
     assert_eq!(trace["visited_nodes"], 0);
 
-    let version = run_json(worktree.path(), ["version"]);
+    let version = run_json(worktree.path(), ["version"])?;
     assert_eq!(version["crate_version"], env!("CARGO_PKG_VERSION"));
     assert!(
         version["extractor_version"]
             .as_u64()
-            .expect("extractor_version")
-            > 0
+            .is_some_and(|extractor_version| extractor_version > 0),
+        "extractor_version should be positive in {version}"
     );
 
-    let db_path = run_json(worktree.path(), ["db-path"]);
+    let db_path = run_json(worktree.path(), ["db-path"])?;
     assert!(
         db_path["path"]
             .as_str()
-            .expect("db path string")
-            .ends_with(".db")
+            .is_some_and(|path| path.ends_with(".db")),
+        "db path should end with .db in {db_path}"
     );
     assert!(db_path.get("branch").is_some());
 
     let graph_dir = worktree.path().join(".orbit").join("graph");
-    fs::create_dir_all(&graph_dir).expect("create graph dir");
+    fs::create_dir_all(&graph_dir)?;
     let old_db = graph_dir.join("main.1.db");
-    fs::write(&old_db, b"stale").expect("write stale db");
-    let clean = run_json(worktree.path(), ["clean"]);
-    let deleted = clean["deleted"].as_array().expect("deleted array");
-    assert!(deleted.iter().any(|path| {
-        path.as_str()
-            .is_some_and(|path| path.ends_with("main.1.db"))
-    }));
+    fs::write(&old_db, b"stale")?;
+    let clean = run_json(worktree.path(), ["clean"])?;
+    assert!(
+        clean["deleted"].as_array().is_some_and(|deleted| {
+            deleted.iter().any(|path| {
+                path.as_str()
+                    .is_some_and(|path| path.ends_with("main.1.db"))
+            })
+        }),
+        "deleted should include main.1.db in {clean}"
+    );
     assert!(!old_db.exists());
+    Ok(())
 }
 
 #[test]
-fn invalid_selector_errors_are_json_on_stderr() {
-    let worktree = fixture_worktree();
+fn invalid_selector_errors_are_json_on_stderr() -> TestResult {
+    let worktree = fixture_worktree()?;
     let mut command = graph_cli_command();
     command
         .current_dir(worktree.path())
@@ -131,9 +140,10 @@ fn invalid_selector_errors_are_json_on_stderr() {
         .stderr(predicate::str::contains(
             "\"code\":\"selector_parse_error\"",
         ));
+    Ok(())
 }
 
-fn run_json<const N: usize>(worktree: &Path, args: [&str; N]) -> Value {
+fn run_json<const N: usize>(worktree: &Path, args: [&str; N]) -> TestResult<Value> {
     let mut command = graph_cli_command();
     let output = command
         .current_dir(worktree)
@@ -143,7 +153,7 @@ fn run_json<const N: usize>(worktree: &Path, args: [&str; N]) -> Value {
         .get_output()
         .stdout
         .clone();
-    serde_json::from_slice(&output).expect("stdout is JSON")
+    Ok(serde_json::from_slice(&output)?)
 }
 
 fn graph_cli_command() -> Command {
@@ -161,16 +171,16 @@ fn expected_entry_source() -> &'static str {
     "pub fn entry() -> i32 {\n    helper()\n}"
 }
 
-fn fixture_worktree() -> TempDir {
-    let tempdir = TempDir::new().expect("temp worktree");
-    run_git(tempdir.path(), ["init", "-b", "main"]);
+fn fixture_worktree() -> TestResult<TempDir> {
+    let tempdir = TempDir::new()?;
+    run_git(tempdir.path(), ["init", "-b", "main"])?;
     run_git(
         tempdir.path(),
         ["config", "user.email", "orbit@example.invalid"],
-    );
-    run_git(tempdir.path(), ["config", "user.name", "Orbit Test"]);
+    )?;
+    run_git(tempdir.path(), ["config", "user.name", "Orbit Test"])?;
 
-    fs::create_dir_all(tempdir.path().join("src")).expect("create src");
+    fs::create_dir_all(tempdir.path().join("src"))?;
     fs::write(
         tempdir.path().join("src/lib.rs"),
         r#"
@@ -186,29 +196,27 @@ pub fn caller() -> i32 {
     entry()
 }
 "#,
-    )
-    .expect("write fixture");
+    )?;
     fs::write(
         tempdir.path().join("Cargo.toml"),
         "[package]\nname = \"graph_cli_fixture\"\nversion = \"0.0.0\"\nedition = \"2024\"\n",
-    )
-    .expect("write manifest");
+    )?;
 
-    run_git(tempdir.path(), ["add", "."]);
-    run_git(tempdir.path(), ["commit", "-m", "fixture"]);
-    tempdir
+    run_git(tempdir.path(), ["add", "."])?;
+    run_git(tempdir.path(), ["commit", "-m", "fixture"])?;
+    Ok(tempdir)
 }
 
-fn run_git<const N: usize>(worktree: &Path, args: [&str; N]) {
+fn run_git<const N: usize>(worktree: &Path, args: [&str; N]) -> TestResult {
     let output = StdCommand::new("git")
         .current_dir(worktree)
         .args(args)
-        .output()
-        .expect("run git");
+        .output()?;
     assert!(
         output.status.success(),
         "git failed: stdout={} stderr={}",
         String::from_utf8_lossy(&output.stdout),
         String::from_utf8_lossy(&output.stderr)
     );
+    Ok(())
 }

--- a/crates/orbit-graph-extract/src/languages/c.rs
+++ b/crates/orbit-graph-extract/src/languages/c.rs
@@ -237,7 +237,6 @@ fn collect_call_ref(node: Node, source: &str, state: &mut ExtractionState) {
 
     if function.kind() == "identifier" {
         state.push_ref(function, source, None, "call", "fuzzy_name");
-        return;
     }
 
     // Complex callees like (*callback)(x) do not expose an honest target_name

--- a/crates/orbit-graph-extract/src/languages/python.rs
+++ b/crates/orbit-graph-extract/src/languages/python.rs
@@ -382,7 +382,7 @@ fn split_top_level_args(args: &str, args_start: usize) -> Vec<ArgSpan<'_>> {
     spans
 }
 
-fn split_keyword_arg<'a>(arg: &'a str, arg_start: usize) -> Option<(&'a str, &'a str, usize)> {
+fn split_keyword_arg(arg: &str, arg_start: usize) -> Option<(&str, &str, usize)> {
     let equals_index = arg.find('=')?;
     let key = arg.get(..equals_index)?.trim();
     if key.is_empty()
@@ -400,9 +400,7 @@ fn split_keyword_arg<'a>(arg: &'a str, arg_start: usize) -> Option<(&'a str, &'a
 fn python_string_literal_value(value: &str) -> Option<String> {
     let mut literal = value.trim();
     loop {
-        let Some(first) = literal.chars().next() else {
-            return None;
-        };
+        let first = literal.chars().next()?;
         if matches!(first, 'r' | 'R' | 'u' | 'U' | 'b' | 'B') {
             literal = literal.get(first.len_utf8()..)?;
             continue;

--- a/crates/orbit-graph-extract/src/languages/rust/commands.rs
+++ b/crates/orbit-graph-extract/src/languages/rust/commands.rs
@@ -356,10 +356,10 @@ fn collect_call_handlers(
     state: &ExtractionState,
     handlers: &mut BTreeSet<String>,
 ) {
-    if node.kind() == "call_expression" {
-        if let Some(handler) = call_handler(node, source, module, variant, state) {
-            handlers.insert(handler);
-        }
+    if node.kind() == "call_expression"
+        && let Some(handler) = call_handler(node, source, module, variant, state)
+    {
+        handlers.insert(handler);
     }
 
     let mut cursor = node.walk();
@@ -588,8 +588,7 @@ fn collect_command_type_names(
 fn choose_payload_type(types: Vec<String>) -> Option<String> {
     types
         .into_iter()
-        .filter(|name| !matches!(name.as_str(), "Box" | "Option" | "Vec"))
-        .next_back()
+        .rfind(|name| !matches!(name.as_str(), "Box" | "Option" | "Vec"))
 }
 
 fn kebab_case(name: &str) -> String {

--- a/crates/orbit-graph-extract/src/languages/tests/rust.rs
+++ b/crates/orbit-graph-extract/src/languages/tests/rust.rs
@@ -221,8 +221,8 @@ fn add(_args: AddArgs) {}
         .commands
         .iter()
         .find(|command| command.name == "task add")
-        .expect("task add command");
-    assert_eq!(command.handler_symbol.as_deref(), Some("add"));
+        .map(|command| command.handler_symbol.as_deref());
+    assert_eq!(command, Some(Some("add")));
 }
 
 #[test]
@@ -298,6 +298,6 @@ fn run(_args: RunArgs) {}
         .commands
         .iter()
         .find(|command| command.name == "job run")
-        .expect("job run command");
-    assert_eq!(command.handler_symbol, None);
+        .map(|command| command.handler_symbol.as_deref());
+    assert_eq!(command, Some(None));
 }

--- a/crates/orbit-graph/src/lib.rs
+++ b/crates/orbit-graph/src/lib.rs
@@ -687,7 +687,7 @@ pub struct CleanReport {
 }
 
 /// Reference query options for [`Graph::refs`].
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct RefOpts {
     /// Minimum confidence included in returned results.
     pub confidence: RefConfidence,
@@ -695,17 +695,8 @@ pub struct RefOpts {
     pub kind: Option<RefKind>,
 }
 
-impl Default for RefOpts {
-    fn default() -> Self {
-        Self {
-            confidence: RefConfidence::default(),
-            kind: None,
-        }
-    }
-}
-
 /// Confidence floor and output value for graph references.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum RefConfidence {
     /// Same file, unambiguous match on name and qualified path.
@@ -713,6 +704,7 @@ pub enum RefConfidence {
     /// Cross-file reference resolved through an explicit import.
     ImportResolved,
     /// Cross-file reference resolved within the same module namespace.
+    #[default]
     SameModule,
     /// Name-only match with ambiguous or weak resolution.
     FuzzyName,
@@ -720,12 +712,6 @@ pub enum RefConfidence {
 
 /// Confidence floor used by reference and traversal queries.
 pub use RefConfidence as Confidence;
-
-impl Default for RefConfidence {
-    fn default() -> Self {
-        Self::SameModule
-    }
-}
 
 /// Filterable reference and relation kinds.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]

--- a/crates/orbit-graph/src/sync/mod.rs
+++ b/crates/orbit-graph/src/sync/mod.rs
@@ -282,9 +282,11 @@ fn sync_after_scan_gate(db_path: &Path) -> Option<Arc<SyncLeaderGate>> {
 }
 
 #[cfg(test)]
-fn sync_after_scan_gate_slot() -> &'static Mutex<Option<(PathBuf, Arc<SyncLeaderGate>)>> {
-    static SYNC_AFTER_SCAN_GATE: OnceLock<Mutex<Option<(PathBuf, Arc<SyncLeaderGate>)>>> =
-        OnceLock::new();
+type SyncAfterScanGateSlot = Mutex<Option<(PathBuf, Arc<SyncLeaderGate>)>>;
+
+#[cfg(test)]
+fn sync_after_scan_gate_slot() -> &'static SyncAfterScanGateSlot {
+    static SYNC_AFTER_SCAN_GATE: OnceLock<SyncAfterScanGateSlot> = OnceLock::new();
     SYNC_AFTER_SCAN_GATE.get_or_init(|| Mutex::new(None))
 }
 

--- a/crates/orbit-store/src/file/scoreboard/scoreboard_summary/mod.rs
+++ b/crates/orbit-store/src/file/scoreboard/scoreboard_summary/mod.rs
@@ -78,11 +78,15 @@ impl ScoreboardWindow {
             ScoreboardWindow::All => "all",
         }
     }
+}
+
+impl std::str::FromStr for ScoreboardWindow {
+    type Err = OrbitError;
 
     /// Parse a canonical window string. Accepts exactly `"1h"`, `"24h"`,
     /// `"7d"`, `"30d"`, or `"all"`. Any other input returns
     /// [`OrbitError::InvalidInput`] so HTTP callers can render an exact 400.
-    pub fn from_str(value: &str) -> Result<Self, OrbitError> {
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
         match value {
             "1h" => Ok(ScoreboardWindow::Hour),
             "24h" => Ok(ScoreboardWindow::Day),
@@ -100,7 +104,7 @@ impl TryFrom<&str> for ScoreboardWindow {
     type Error = OrbitError;
 
     fn try_from(value: &str) -> Result<Self, Self::Error> {
-        ScoreboardWindow::from_str(value)
+        value.parse()
     }
 }
 

--- a/crates/orbit-store/src/file/scoreboard/scoreboard_summary/tests/scoreboard_summary.rs
+++ b/crates/orbit-store/src/file/scoreboard/scoreboard_summary/tests/scoreboard_summary.rs
@@ -878,9 +878,10 @@ fn window_string_round_trips_for_all_variants() {
         ScoreboardWindow::Month,
         ScoreboardWindow::All,
     ] {
-        let parsed = ScoreboardWindow::from_str(w.as_str()).expect("round trip");
-        assert_eq!(parsed, w);
+        assert_eq!(w.as_str().parse::<ScoreboardWindow>().ok(), Some(w));
     }
-    let err = ScoreboardWindow::from_str("bogus").expect_err("rejects unknown");
-    assert!(matches!(err, OrbitError::InvalidInput(_)));
+    assert!(matches!(
+        "bogus".parse::<ScoreboardWindow>(),
+        Err(OrbitError::InvalidInput(_))
+    ));
 }

--- a/crates/orbit-tools/src/builtin/orbit/graph.rs
+++ b/crates/orbit-tools/src/builtin/orbit/graph.rs
@@ -26,7 +26,7 @@ impl Tool for OrbitGraphSyncTool {
     fn schema(&self) -> ToolSchema {
         schema(
             "orbit.graph.sync",
-            "Synchronize the orbit-graph index for the current worktree.",
+            "Use when the orbit-graph index may be stale and graph reads need current results. Prefer over grep when follow-up graph queries should reflect recent file changes.",
             vec![param(
                 "full",
                 "Run a full sync instead of an incremental auto sync.",
@@ -46,7 +46,7 @@ impl Tool for OrbitGraphSearchTool {
     fn schema(&self) -> ToolSchema {
         schema(
             "orbit.graph.search",
-            "Search orbit-graph symbols, notable strings, and config keys.",
+            "Use when finding symbols, notable strings, or config keys by text. Prefer over grep when structured symbol metadata or language filters matter.",
             vec![
                 param("query", "Search query text.", "string", true),
                 param(
@@ -71,7 +71,7 @@ impl Tool for OrbitGraphShowTool {
     fn schema(&self) -> ToolSchema {
         schema(
             "orbit.graph.show",
-            "Show source and metadata for an orbit-graph selector. UTF-8 source is returned as `text`; non-UTF-8 source omits `text` and returns fallback `bytes`.",
+            "Use when inspecting one known orbit-graph selector's source and metadata, including UTF-8 `text` or fallback `bytes`. Prefer over grep when the selector is already known.",
             vec![
                 param("selector", "Selector to show.", "string", true),
                 param(
@@ -94,7 +94,7 @@ impl Tool for OrbitGraphRefsTool {
     fn schema(&self) -> ToolSchema {
         schema(
             "orbit.graph.refs",
-            "Find inbound references and relations for an orbit-graph symbol selector.",
+            "Use when finding inbound references and relations for a symbol selector. Prefer over grep when cross-file graph resolution is needed.",
             vec![
                 param("symbol", "Symbol selector to query.", "string", true),
                 param("confidence", "Minimum confidence floor.", "string", false),
@@ -118,7 +118,7 @@ impl Tool for OrbitGraphCalleesTool {
     fn schema(&self) -> ToolSchema {
         schema(
             "orbit.graph.callees",
-            "Find outbound calls from an orbit-graph symbol selector.",
+            "Use when finding outbound calls from a symbol selector. Prefer over grep when call edges are needed instead of textual matches.",
             vec![param("symbol", "Symbol selector to query.", "string", true)],
         )
     }
@@ -133,7 +133,7 @@ impl Tool for OrbitGraphImpactTool {
     fn schema(&self) -> ToolSchema {
         schema(
             "orbit.graph.impact",
-            "Return a bounded orbit-graph blast-radius traversal.",
+            "Use when estimating the blast radius from a symbol selector. Prefer over grep when transitive graph impact matters.",
             vec![
                 param("selector", "Origin selector.", "string", true),
                 param("depth", "Maximum traversal depth.", "number", false),
@@ -157,7 +157,7 @@ impl Tool for OrbitGraphTraceTool {
     fn schema(&self) -> ToolSchema {
         schema(
             "orbit.graph.trace",
-            "Trace a command handler call tree from orbit-graph command metadata.",
+            "Use when tracing a command handler call tree from graph command metadata. Prefer over grep when call-tree structure matters.",
             vec![
                 param("command_name", "Command name to trace.", "string", true),
                 param("depth", "Maximum call-tree depth.", "number", false),


### PR DESCRIPTION
## Summary

Fixes the current `agent-main` CI failures exposed by the Rust 1.95 toolchain and the latest graph/scoreboard changes.

- Updates graph extraction code and tests for new Clippy lints.
- Hardens workspace/orbit-root resolution so tests do not accidentally discover unrelated parent or global `.orbit` directories.
- Refreshes graph tool tests and descriptions for the current `orbit.graph.*` surface.
- Converts scoreboard window parsing to `FromStr` and removes new `expect` usage from tests.
- Fixes a process-group cancellation test race by waiting for a parseable PID file, not just file existence.

## Validation

- `cargo test -p orbit-core command::job::run::tests::actions::cancel_job_run_terminates_owner_process_group_and_child --lib -- --exact --nocapture`
- `cargo test -p orbit-tools --test graph_tool_surface`
- `./scripts/ci-guardrails.sh`

Note: local guardrails used the script's `cargo test` fallback because `cargo-nextest` is not installed locally.
