### PR TITLE
Make default_crew and [duel].candidates dynamic from detected agents at orbit init

### DIFF
--- a/.orbit/adrs/accepted/ADR-0193/adr.yaml
+++ b/.orbit/adrs/accepted/ADR-0193/adr.yaml
@@ -1,0 +1,25 @@
+schema_version: 2
+id: ADR-0193
+title: Freeze Agent Detection at Init Seeding
+status: accepted
+owner: codex
+created_at: 2026-05-30T20:17:27.417750Z
+accepted_at: 2026-05-30T20:17:29.805438Z
+last_updated: 2026-05-30T20:17:29.805438Z
+related_features:
+- agent-families
+related_tasks:
+- ORB-00347
+tags:
+- config
+- agent-detection
+- init
+paths:
+- crates/orbit-core/src/config/**
+- crates/orbit-core/src/command/init.rs
+- crates/orbit-cli/src/command/init.rs
+- crates/orbit-core/assets/config/default-config.toml
+supersedes: []
+legacy_ids: []
+validation_warnings: []
+legacy_validation: none

--- a/.orbit/adrs/accepted/ADR-0193/body.md
+++ b/.orbit/adrs/accepted/ADR-0193/body.md
@@ -1,0 +1,10 @@
+## Context
+`orbit init` needs a config that reflects installed agent surfaces, but live detection reads ambient PATH and API-key environment. Re-running detection during `RuntimeConfig::load_layered` would make crew and duel resolution vary between invocations without a config diff.
+
+## Decision
+Agent availability is detected once during init using `DetectedAgents`, rendered into `config.toml`, and then treated as static configuration. Runtime config loading continues to use file contents and built-in fallbacks only; it never probes PATH or environment.
+
+## Consequences
+- Fresh configs pick a sensible `default_crew` and duel candidate set for the host that created them.
+- Runtime behavior is deterministic for a given config file, including hot config loads.
+- Cost: A user who installs or removes agent CLIs after init must edit or regenerate config instead of getting automatic runtime drift.

--- a/crates/orbit-cli/src/command/init.rs
+++ b/crates/orbit-cli/src/command/init.rs
@@ -1,7 +1,7 @@
 use clap::Args;
 use orbit_core::command::init::{InitOptions, init_global};
 use orbit_core::config::RawAgentRoleConfig;
-use orbit_core::config::agent_detect::{RealAgentEnvProbe, detect};
+use orbit_core::config::agent_detect::{DetectedAgents, RealAgentEnvProbe, detect};
 use orbit_core::config::agent_prompt::{StdinPrompter, collect_role_settings};
 use orbit_core::workspace_registry::global_orbit_dir;
 use orbit_core::{OrbitError, OrbitRuntime};
@@ -17,21 +17,25 @@ pub struct InitCommand {
     #[arg(long)]
     pub force: bool,
 
-    /// Skip interactive prompts. config.toml is seeded without `[agent.*]`
-    /// blocks so a CI runner that pipes nothing into stdin will not hang.
+    /// Skip interactive prompts. config.toml is still seeded from detected
+    /// agent surfaces, but a CI runner that pipes nothing into stdin will not
+    /// hang.
     #[arg(long)]
     pub non_interactive: bool,
 }
 
 impl Execute for InitCommand {
     fn execute(self, _runtime: &OrbitRuntime) -> Result<(), OrbitError> {
-        let role_settings = collect_role_settings_for_init(None, self.force, self.non_interactive)?;
+        let detected = detect(&RealAgentEnvProbe);
+        let role_settings =
+            collect_role_settings_for_init(None, self.force, self.non_interactive, &detected)?;
         let result = init_global(
             None,
             InitOptions {
                 force: self.force,
                 refresh_defaults: true,
                 role_settings,
+                detected: Some(detected),
                 ..Default::default()
             },
         )?;
@@ -53,14 +57,20 @@ impl Execute for InitCommand {
 
 impl InitCommand {
     pub fn execute_without_runtime(self, root_override: Option<&Path>) -> Result<(), OrbitError> {
-        let role_settings =
-            collect_role_settings_for_init(root_override, self.force, self.non_interactive)?;
+        let detected = detect(&RealAgentEnvProbe);
+        let role_settings = collect_role_settings_for_init(
+            root_override,
+            self.force,
+            self.non_interactive,
+            &detected,
+        )?;
         let result = init_global(
             root_override,
             InitOptions {
                 force: self.force,
                 refresh_defaults: true,
                 role_settings,
+                detected: Some(detected),
                 ..Default::default()
             },
         )?;
@@ -90,6 +100,7 @@ pub(crate) fn collect_role_settings_for_init(
     root_override: Option<&Path>,
     force: bool,
     non_interactive: bool,
+    detected: &DetectedAgents,
 ) -> Result<Option<BTreeMap<String, RawAgentRoleConfig>>, OrbitError> {
     if non_interactive {
         return Ok(None);
@@ -100,10 +111,8 @@ pub(crate) fn collect_role_settings_for_init(
         return Ok(None);
     }
 
-    let probe = RealAgentEnvProbe;
-    let detected = detect(&probe);
     let mut prompter = StdinPrompter;
-    let collected = collect_role_settings(&detected, &mut prompter)
+    let collected = collect_role_settings(detected, &mut prompter)
         .map_err(|err| OrbitError::Io(format!("agent prompts failed: {err}")))?;
     Ok(Some(collected))
 }

--- a/crates/orbit-cli/src/command/tests/init.rs
+++ b/crates/orbit-cli/src/command/tests/init.rs
@@ -4,19 +4,9 @@ use tempfile::tempdir;
 
 use crate::InitCommand;
 use crate::command::init::collect_role_settings_for_init;
+use orbit_core::config::agent_detect::DetectedAgents;
 
 static ENV_LOCK: Mutex<()> = Mutex::new(());
-
-fn restore_home(previous_home: Option<std::ffi::OsString>) {
-    match previous_home {
-        Some(value) => unsafe {
-            std::env::set_var("HOME", value);
-        },
-        None => unsafe {
-            std::env::remove_var("HOME");
-        },
-    }
-}
 
 /// `collect_role_settings_for_init` short-circuits when --non-interactive
 /// is set, regardless of whether config.toml exists. No prompts are
@@ -26,7 +16,8 @@ fn restore_home(previous_home: Option<std::ffi::OsString>) {
 fn non_interactive_short_circuits_before_prompts() {
     let _guard = ENV_LOCK.lock().expect("lock env");
     let home = tempdir().expect("home tempdir");
-    let result = collect_role_settings_for_init(Some(home.path()), false, true);
+    let detected = DetectedAgents::default();
+    let result = collect_role_settings_for_init(Some(home.path()), false, true, &detected);
     assert!(matches!(result, Ok(None)));
 }
 
@@ -39,27 +30,24 @@ fn existing_config_short_circuits_before_prompts() {
     let config_path = root.path().join("config.toml");
     fs::write(&config_path, "# pre-existing\n").expect("preseed");
 
-    let result = collect_role_settings_for_init(Some(root.path()), false, false);
+    let detected = DetectedAgents::default();
+    let result = collect_role_settings_for_init(Some(root.path()), false, false, &detected);
     assert!(matches!(result, Ok(None)));
 }
 
 /// End-to-end: `InitCommand { non_interactive: true }` produces a fresh
-/// config.toml that contains no uncommented `[agent.*]` sections.
+/// config.toml with generated crew tables and no uncommented `[agent.*]`
+/// sections. The exact default crew/duel set depends on the runner PATH.
 #[test]
-fn non_interactive_init_writes_no_active_agent_sections() {
+fn non_interactive_init_writes_generated_crew_config() {
     let _guard = ENV_LOCK.lock().expect("lock env");
     let home = tempdir().expect("home tempdir");
-    let previous_home = std::env::var_os("HOME");
-    unsafe {
-        std::env::set_var("HOME", home.path());
-    }
 
     let cmd = InitCommand {
         force: false,
         non_interactive: true,
     };
     let outcome = cmd.execute_without_runtime(Some(&home.path().join(".orbit")));
-    restore_home(previous_home);
 
     outcome.expect("init succeeded");
 
@@ -71,4 +59,9 @@ fn non_interactive_init_writes_no_active_agent_sections() {
             "unexpected uncommented agent section: {line}",
         );
     }
+    assert!(contents.contains("[crews.claude]"));
+    assert!(contents.contains("[crews.codex]"));
+    assert!(contents.contains("[crews.gemini]"));
+    assert!(contents.contains("[crews.grok]"));
+    toml::from_str::<toml::Value>(&contents).expect("seeded config parses");
 }

--- a/crates/orbit-core/assets/config/default-config.toml
+++ b/crates/orbit-core/assets/config/default-config.toml
@@ -33,33 +33,3 @@ editing = false
 # `agent-main` is the dev integration branch where task PRs land — set
 # `base_branch = "agent-main"` for the same layout in your own repo.
 base_branch = "main"
-default_crew = "codex"
-
-[crews.claude]
-planner = { model = "claude-opus-4-7", provider = "claude", backend = "cli" }
-implementer = { model = "claude-opus-4-7", provider = "claude", backend = "cli" }
-reviewer = { model = "claude-opus-4-7", provider = "claude", backend = "cli" }
-
-[crews.codex]
-planner = { model = "gpt-5.5", provider = "codex", backend = "cli" }
-implementer = { model = "gpt-5.5", provider = "codex", backend = "cli" }
-reviewer = { model = "gpt-5.5", provider = "codex", backend = "cli" }
-
-[crews.gemini]
-planner = { model = "pro", provider = "gemini", backend = "cli" }
-implementer = { model = "pro", provider = "gemini", backend = "cli" }
-reviewer = { model = "pro", provider = "gemini", backend = "cli" }
-
-[crews.grok]
-planner = { model = "grok-build", provider = "grok", backend = "cli" }
-implementer = { model = "grok-build", provider = "grok", backend = "cli" }
-reviewer = { model = "grok-build", provider = "grok", backend = "cli" }
-
-[duel]
-candidates = ["codex", "claude", "gemini", "grok"]
-
-[duel.models]                             
-codex  = "gpt-5.5"
-claude = "claude-opus-4-7"
-gemini = "pro"
-grok = "grok-build"

--- a/crates/orbit-core/src/command/init.rs
+++ b/crates/orbit-core/src/command/init.rs
@@ -15,7 +15,11 @@ use crate::command::skill::{
 };
 use orbit_common::utility::fs::{atomic_write_text, create_dir_symlink, remove_path_if_exists};
 
-use crate::config::{RawAgentRoleConfig, RuntimeConfig, seed_default_config};
+use crate::config::{
+    RawAgentRoleConfig, RuntimeConfig,
+    agent_detect::{DetectedAgents, RealAgentEnvProbe, detect},
+    seed_default_config,
+};
 use crate::runtime::resolve_global_root;
 
 const LEGACY_WORKSPACE_SEEDED_SKILL_IDS: [&str; 2] = ["orbit-approve-task", "orbit-pr"];
@@ -51,6 +55,9 @@ pub struct InitOptions {
     /// the default crew template". Ignored when config.toml already exists
     /// — init remains idempotent.
     pub role_settings: Option<BTreeMap<String, RawAgentRoleConfig>>,
+    /// Agent availability snapshot used to freeze agent-dependent config at
+    /// init time. When omitted, init probes the real host environment.
+    pub detected: Option<DetectedAgents>,
 }
 
 impl OrbitRuntime {
@@ -151,7 +158,11 @@ pub fn init_workspace_at_root(
     };
     let created_config = if options.global_only {
         let config_path = orbit_root.join("config.toml");
-        seed_default_config(&config_path, options.role_settings.as_ref())?
+        let detected = options
+            .detected
+            .clone()
+            .unwrap_or_else(|| detect(&RealAgentEnvProbe));
+        seed_default_config(&config_path, &detected, options.role_settings.as_ref())?
     } else {
         false
     };
@@ -199,6 +210,7 @@ pub fn init_workspace_at_root(
                 global_only: true,
                 link_global_skills: options.link_global_skills || options.refresh_defaults,
                 role_settings: options.role_settings.clone(),
+                detected: options.detected.clone(),
                 ..Default::default()
             },
         )?;
@@ -614,6 +626,7 @@ mod tests {
             None,
             InitOptions {
                 refresh_defaults: true,
+                detected: Some(DetectedAgents::default()),
                 ..Default::default()
             },
         );
@@ -693,6 +706,7 @@ mod tests {
             InitOptions {
                 refresh_defaults: true,
                 global_root_override: Some(home.path().join(".orbit")),
+                detected: Some(DetectedAgents::default()),
                 ..Default::default()
             },
         );
@@ -765,6 +779,7 @@ mod tests {
             InitOptions {
                 refresh_defaults: true,
                 role_settings: Some(roles),
+                detected: Some(DetectedAgents::default()),
                 ..Default::default()
             },
         );
@@ -839,6 +854,7 @@ mod tests {
             InitOptions {
                 refresh_defaults: true,
                 role_settings: Some(roles),
+                detected: Some(DetectedAgents::default()),
                 ..Default::default()
             },
         );
@@ -865,6 +881,7 @@ mod tests {
             InitOptions {
                 refresh_defaults: true,
                 role_settings: None,
+                detected: Some(DetectedAgents::default()),
                 ..Default::default()
             },
         );

--- a/crates/orbit-core/src/config/agent_detect.rs
+++ b/crates/orbit-core/src/config/agent_detect.rs
@@ -106,6 +106,39 @@ pub fn detect(probe: &dyn AgentEnvProbe) -> DetectedAgents {
     }
 }
 
+/// Agent families available for crew-backed config seeding.
+///
+/// The order intentionally mirrors [`default_provider`] for the overlapping
+/// families, excluding `ollama` because Orbit does not ship an `ollama` crew.
+pub fn available_crew_families(detected: &DetectedAgents) -> Vec<&'static str> {
+    let mut families = Vec::new();
+    if detected.claude_cli || detected.anthropic_api_key {
+        families.push("claude");
+    }
+    if detected.codex_cli || detected.openai_api_key {
+        families.push("codex");
+    }
+    if detected.gemini_cli || detected.gemini_api_key {
+        families.push("gemini");
+    }
+    if detected.grok_cli {
+        families.push("grok");
+    }
+    families
+}
+
+/// Default crew name frozen into newly seeded config.
+///
+/// Falling back to `codex` preserves the historical no-detection template
+/// behavior even though [`default_provider`] still falls back to `claude` for
+/// role prompt defaults.
+pub fn default_crew_name(detected: &DetectedAgents) -> &'static str {
+    available_crew_families(detected)
+        .first()
+        .copied()
+        .unwrap_or("codex")
+}
+
 /// Hardcoded "latest known good" model per provider. Returned to seed prompt
 /// defaults; users can override at the prompt. Update this map when new
 /// flagship models ship.

--- a/crates/orbit-core/src/config/bootstrap.rs
+++ b/crates/orbit-core/src/config/bootstrap.rs
@@ -6,55 +6,160 @@ use serde::Serialize;
 
 use orbit_common::utility::fs::write_text_with_parent;
 
-use super::raw::{RawAgentRoleConfig, RawCrewEntry};
+use super::agent_detect::{
+    DetectedAgents, available_crew_families, default_crew_name, default_model_for,
+};
+use super::raw::{RawAgentRoleConfig, RawCrewEntry, RawDuelSection};
+use super::runtime::default_crews;
 
 pub(crate) const DEFAULT_CONFIG_TEMPLATE: &str =
     include_str!("../../assets/config/default-config.toml"); // pub(crate) for sibling tests/bootstrap.rs per ORB-00223; no prod behavior change.
 
 pub(crate) fn seed_default_config(
     config_path: &Path,
+    detected: &DetectedAgents,
     role_settings: Option<&BTreeMap<String, RawAgentRoleConfig>>,
 ) -> Result<bool, OrbitError> {
     if config_path.exists() {
         return Ok(false);
     }
-    let body = match role_settings.filter(|m| !m.is_empty()) {
-        Some(roles) => render_with_role_settings(DEFAULT_CONFIG_TEMPLATE, roles)?,
-        None => DEFAULT_CONFIG_TEMPLATE.to_string(),
-    };
+    let body = render_seeded_config(DEFAULT_CONFIG_TEMPLATE, detected, role_settings)?;
     write_text_with_parent(config_path, &body)?;
     Ok(true)
 }
 
-fn render_with_role_settings(
+fn render_seeded_config(
     template: &str,
-    roles: &BTreeMap<String, RawAgentRoleConfig>,
+    detected: &DetectedAgents,
+    role_settings: Option<&BTreeMap<String, RawAgentRoleConfig>>,
 ) -> Result<String, OrbitError> {
-    validate_complete_role_settings(roles)?;
-
-    #[derive(Serialize)]
-    struct CrewConfig<'a> {
-        crews: BTreeMap<&'a str, RawCrewEntry>,
+    let role_settings = role_settings.filter(|roles| !roles.is_empty());
+    if let Some(roles) = role_settings {
+        validate_complete_role_settings(roles)?;
     }
 
-    let mut crews = BTreeMap::new();
-    crews.insert(
-        "custom",
-        RawCrewEntry {
-            planner: roles.get("planner").cloned(),
-            implementer: roles.get("implementer").cloned(),
-            reviewer: roles.get("reviewer").cloned(),
-        },
-    );
-    let custom_crew = toml::to_string(&CrewConfig { crews })
-        .map_err(|err| OrbitError::Io(format!("serialize [crews.<name>] sections: {err}")))?;
-    let mut body = template.replace("default_crew = \"codex\"", "default_crew = \"custom\"");
+    let mut body = template.to_string();
     if !body.ends_with('\n') {
         body.push('\n');
     }
+
+    // ADR-0193: freeze agent detection at init; runtime config loading never probes PATH/env.
+    body.push_str(&render_workflow_default_crew(detected, role_settings));
     body.push('\n');
-    body.push_str(&custom_crew);
+    body.push_str(&render_crews(role_settings)?);
+    body.push_str(&render_duel(detected)?);
     Ok(body)
+}
+
+fn render_workflow_default_crew(
+    detected: &DetectedAgents,
+    role_settings: Option<&BTreeMap<String, RawAgentRoleConfig>>,
+) -> String {
+    let default_crew = if role_settings.is_some() {
+        "custom"
+    } else {
+        default_crew_name(detected)
+    };
+    format!("default_crew = \"{default_crew}\"\n")
+}
+
+fn render_crews(
+    role_settings: Option<&BTreeMap<String, RawAgentRoleConfig>>,
+) -> Result<String, OrbitError> {
+    let mut crews: BTreeMap<String, RawCrewEntry> = default_crews()
+        .into_iter()
+        .map(|(name, crew)| {
+            (
+                name,
+                RawCrewEntry {
+                    planner: Some(raw_role_from_assignment(&crew.planner)),
+                    implementer: Some(raw_role_from_assignment(&crew.implementer)),
+                    reviewer: Some(raw_role_from_assignment(&crew.reviewer)),
+                },
+            )
+        })
+        .collect();
+
+    if let Some(roles) = role_settings {
+        crews.insert(
+            "custom".to_string(),
+            RawCrewEntry {
+                planner: roles.get("planner").cloned(),
+                implementer: roles.get("implementer").cloned(),
+                reviewer: roles.get("reviewer").cloned(),
+            },
+        );
+    }
+
+    let mut rendered = String::new();
+    for (name, entry) in crews {
+        rendered.push_str(&render_crew_table(&name, &entry)?);
+    }
+    Ok(rendered)
+}
+
+fn render_crew_table(name: &str, entry: &RawCrewEntry) -> Result<String, OrbitError> {
+    let mut rendered = format!("[crews.{name}]\n");
+    for (role, config) in [
+        ("planner", entry.planner.as_ref()),
+        ("implementer", entry.implementer.as_ref()),
+        ("reviewer", entry.reviewer.as_ref()),
+    ] {
+        let config = config.ok_or_else(|| {
+            OrbitError::InvalidInput(format!("crew `{name}` is missing `{role}` role settings"))
+        })?;
+        let value = toml::Value::try_from(config).map_err(|err| {
+            OrbitError::Io(format!("serialize [crews.{name}].{role} assignment: {err}"))
+        })?;
+        rendered.push_str(&format!("{role} = {value}\n"));
+    }
+    rendered.push('\n');
+    Ok(rendered)
+}
+
+fn raw_role_from_assignment(
+    assignment: &orbit_common::types::CrewRoleAssignment,
+) -> RawAgentRoleConfig {
+    RawAgentRoleConfig {
+        provider: Some(assignment.provider.clone()),
+        model: Some(assignment.model.clone()),
+        backend: Some(assignment.backend.clone()),
+    }
+}
+
+fn render_duel(detected: &DetectedAgents) -> Result<String, OrbitError> {
+    let candidates = available_crew_families(detected);
+    if candidates.len() < 3 {
+        return Ok(String::new());
+    }
+
+    #[derive(Serialize)]
+    struct DuelConfig {
+        duel: RawDuelSection,
+    }
+
+    let mut models = BTreeMap::new();
+    for family in &candidates {
+        let model = default_model_for(family).ok_or_else(|| {
+            OrbitError::InvalidInput(format!("no default model configured for `{family}`"))
+        })?;
+        models.insert((*family).to_string(), model.to_string());
+    }
+
+    let mut rendered = toml::to_string(&DuelConfig {
+        duel: RawDuelSection {
+            candidates: Some(candidates.into_iter().map(str::to_string).collect()),
+            models: Some(models),
+        },
+    })
+    .map_err(|err| OrbitError::Io(format!("serialize [duel] sections: {err}")))?;
+    if !rendered.starts_with('\n') {
+        rendered.insert(0, '\n');
+    }
+    if !rendered.ends_with('\n') {
+        rendered.push('\n');
+    }
+    Ok(rendered)
 }
 
 fn validate_complete_role_settings(

--- a/crates/orbit-core/src/config/raw.rs
+++ b/crates/orbit-core/src/config/raw.rs
@@ -23,7 +23,7 @@ pub(super) struct RawRuntimeConfig {
     pub(super) crews: Option<BTreeMap<String, RawCrewEntry>>,
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub(super) struct RawWorkflowConfig {
     /// `workflow.base_branch` — repo-level default base branch for ship and
     /// duel-plan workflows. When absent, defaults to `main`.
@@ -35,7 +35,7 @@ pub(super) struct RawWorkflowConfig {
     pub(super) default_crew: Option<String>,
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub(super) struct RawDuelSection {
     pub(super) candidates: Option<Vec<String>>,
     pub(super) models: Option<BTreeMap<String, String>>,

--- a/crates/orbit-core/src/config/tests/bootstrap.rs
+++ b/crates/orbit-core/src/config/tests/bootstrap.rs
@@ -1,5 +1,9 @@
+use super::super::agent_detect::{DetectedAgents, detect, testing::MockAgentEnvProbe};
 use super::super::bootstrap::*;
 use super::super::raw::RawAgentRoleConfig;
+use super::super::raw::RawRuntimeConfig;
+use super::super::runtime::RuntimeConfig;
+use orbit_common::types::all_agent_families;
 use std::collections::BTreeMap;
 use tempfile::tempdir;
 
@@ -33,19 +37,184 @@ fn sample_roles() -> BTreeMap<String, RawAgentRoleConfig> {
 }
 
 #[test]
-fn seed_with_no_role_settings_matches_template() {
+fn default_template_keeps_agent_dependent_sections_out() {
+    assert!(!DEFAULT_CONFIG_TEMPLATE.contains("default_crew"));
+    assert!(!DEFAULT_CONFIG_TEMPLATE.contains("[crews."));
+    assert!(!DEFAULT_CONFIG_TEMPLATE.contains("[duel"));
+    assert!(DEFAULT_CONFIG_TEMPLATE.contains("[execution.env]"));
+    assert!(DEFAULT_CONFIG_TEMPLATE.contains("[execution.codex]"));
+    assert!(DEFAULT_CONFIG_TEMPLATE.contains("[task.approval]"));
+    assert!(DEFAULT_CONFIG_TEMPLATE.contains("[scoring]"));
+    assert!(DEFAULT_CONFIG_TEMPLATE.contains("[graph]"));
+    assert!(DEFAULT_CONFIG_TEMPLATE.contains("[workflow]"));
+    assert!(DEFAULT_CONFIG_TEMPLATE.contains("base_branch = \"main\""));
+}
+
+#[test]
+fn seed_with_claude_detection_writes_all_crews_and_claude_default() {
+    let detected = detect(&MockAgentEnvProbe::new().with_binary("claude"));
+    let contents = seed_contents(&detected, None);
+
+    assert_all_base_crews_present(&contents);
+    assert!(contents.contains("default_crew = \"claude\""));
+    assert!(!contents.contains("[duel"));
+}
+
+#[test]
+fn seed_with_empty_detection_defaults_codex_and_omits_duel() {
+    let detected = DetectedAgents::default();
+    let contents = seed_contents(&detected, None);
+
+    assert_all_base_crews_present(&contents);
+    assert!(contents.contains("default_crew = \"codex\""));
+    assert!(!contents.contains("[duel"));
+}
+
+#[test]
+fn seed_with_three_available_families_writes_duel_candidates_and_models() {
+    let detected = detect(
+        &MockAgentEnvProbe::new()
+            .with_binary("claude")
+            .with_binary("codex")
+            .with_binary("gemini"),
+    );
+    let contents = seed_contents(&detected, None);
+    let parsed: toml::Value = toml::from_str(&contents).expect("parse seeded config");
+
+    let candidates = parsed
+        .get("duel")
+        .and_then(|duel| duel.get("candidates"))
+        .and_then(|candidates| candidates.as_array())
+        .expect("duel candidates");
+    let candidates: Vec<&str> = candidates
+        .iter()
+        .map(|candidate| candidate.as_str().expect("candidate string"))
+        .collect();
+    assert_eq!(candidates, vec!["claude", "codex", "gemini"]);
+
+    let models = parsed
+        .get("duel")
+        .and_then(|duel| duel.get("models"))
+        .and_then(|models| models.as_table())
+        .expect("duel models");
+    assert_eq!(models.len(), 3);
+    assert_eq!(
+        models.get("claude").and_then(|v| v.as_str()),
+        Some("claude-opus-4-7")
+    );
+    assert_eq!(
+        models.get("codex").and_then(|v| v.as_str()),
+        Some("gpt-5.5")
+    );
+    assert_eq!(
+        models.get("gemini").and_then(|v| v.as_str()),
+        Some("gemini-3-pro")
+    );
+}
+
+#[test]
+fn seed_with_fewer_than_three_families_omits_duel_and_runtime_falls_back() {
+    let detected = detect(&MockAgentEnvProbe::new().with_binary("claude"));
+    let contents = seed_contents(&detected, None);
+
+    assert!(!contents.contains("[duel"));
+    let config = load_seeded_config(&contents);
+    let expected: Vec<String> = all_agent_families()
+        .into_iter()
+        .map(str::to_string)
+        .collect();
+    assert_eq!(config.duel.candidates, expected);
+}
+
+#[test]
+fn seeded_configs_round_trip_for_detection_permutations() {
+    let cases = [
+        ("none", DetectedAgents::default()),
+        (
+            "one cli",
+            detect(&MockAgentEnvProbe::new().with_binary("claude")),
+        ),
+        (
+            "two clis",
+            detect(
+                &MockAgentEnvProbe::new()
+                    .with_binary("claude")
+                    .with_binary("codex"),
+            ),
+        ),
+        (
+            "three clis",
+            detect(
+                &MockAgentEnvProbe::new()
+                    .with_binary("claude")
+                    .with_binary("codex")
+                    .with_binary("gemini"),
+            ),
+        ),
+        (
+            "four clis",
+            detect(
+                &MockAgentEnvProbe::new()
+                    .with_binary("claude")
+                    .with_binary("codex")
+                    .with_binary("gemini")
+                    .with_binary("grok"),
+            ),
+        ),
+        (
+            "api keys only",
+            detect(
+                &MockAgentEnvProbe::new()
+                    .with_env("ANTHROPIC_API_KEY", "anthropic")
+                    .with_env("OPENAI_API_KEY", "openai")
+                    .with_env("GEMINI_API_KEY", "gemini"),
+            ),
+        ),
+    ];
+
+    for (name, detected) in cases {
+        let contents = seed_contents(&detected, None);
+        toml::from_str::<RawRuntimeConfig>(&contents)
+            .unwrap_or_else(|err| panic!("{name} raw parse failed: {err}"));
+        load_seeded_config(&contents);
+    }
+}
+
+#[test]
+fn seed_with_no_role_settings_writes_generated_agent_block() {
     let dir = tempdir().expect("tempdir");
     let path = dir.path().join("config.toml");
-    let created = seed_default_config(&path, None).expect("seed");
+    let detected = DetectedAgents::default();
+    let created = seed_default_config(&path, &detected, None).expect("seed");
     assert!(created);
     let contents = std::fs::read_to_string(&path).expect("read");
-    assert_eq!(contents, DEFAULT_CONFIG_TEMPLATE);
     assert!(no_active_role_section(&contents));
+    assert_all_base_crews_present(&contents);
+    assert!(contents.contains("default_crew = \"codex\""));
+}
+
+fn seed_contents(
+    detected: &DetectedAgents,
+    role_settings: Option<&BTreeMap<String, RawAgentRoleConfig>>,
+) -> String {
+    let dir = tempdir().expect("tempdir");
+    let path = dir.path().join("config.toml");
+    let created = seed_default_config(&path, detected, role_settings).expect("seed");
+    assert!(created);
+    std::fs::read_to_string(&path).expect("read")
+}
+
+fn load_seeded_config(contents: &str) -> RuntimeConfig {
+    let dir = tempdir().expect("tempdir");
+    std::fs::write(dir.path().join("config.toml"), contents).expect("write config");
+    RuntimeConfig::load_layered(dir.path(), dir.path()).expect("runtime config loads")
+}
+
+fn assert_all_base_crews_present(contents: &str) {
     assert!(contents.contains("[crews.claude]"));
     assert!(contents.contains("[crews.codex]"));
     assert!(contents.contains("[crews.gemini]"));
     assert!(contents.contains("[crews.grok]"));
-    assert!(contents.contains("default_crew = \"codex\""));
 }
 
 fn no_active_role_section(contents: &str) -> bool {
@@ -59,12 +228,15 @@ fn seed_with_role_settings_writes_custom_crew() {
     let dir = tempdir().expect("tempdir");
     let path = dir.path().join("config.toml");
     let roles = sample_roles();
-    let created = seed_default_config(&path, Some(&roles)).expect("seed");
+    let detected = DetectedAgents::default();
+    let created = seed_default_config(&path, &detected, Some(&roles)).expect("seed");
     assert!(created);
     let contents = std::fs::read_to_string(&path).expect("read");
 
     assert!(no_active_role_section(&contents));
     assert!(contents.contains("default_crew = \"custom\""));
+    assert_all_base_crews_present(&contents);
+    assert!(contents.contains("[crews.custom]"));
     assert!(contents.contains("provider = \"claude\""));
     assert!(contents.contains("provider = \"codex\""));
     assert!(contents.contains("model = \"claude-opus-4-7\""));
@@ -93,7 +265,8 @@ fn seed_with_existing_file_is_noop() {
     std::fs::write(&path, "# pre-existing user content\n").expect("preseed");
 
     let roles = sample_roles();
-    let created = seed_default_config(&path, Some(&roles)).expect("seed");
+    let detected = DetectedAgents::default();
+    let created = seed_default_config(&path, &detected, Some(&roles)).expect("seed");
     assert!(!created);
 
     let contents = std::fs::read_to_string(&path).expect("read");
@@ -101,14 +274,16 @@ fn seed_with_existing_file_is_noop() {
 }
 
 #[test]
-fn seed_with_empty_role_map_matches_template() {
+fn seed_with_empty_role_map_uses_detected_default() {
     let dir = tempdir().expect("tempdir");
     let path = dir.path().join("config.toml");
     let roles: BTreeMap<String, RawAgentRoleConfig> = BTreeMap::new();
-    let created = seed_default_config(&path, Some(&roles)).expect("seed");
+    let detected = DetectedAgents::default();
+    let created = seed_default_config(&path, &detected, Some(&roles)).expect("seed");
     assert!(created);
     let contents = std::fs::read_to_string(&path).expect("read");
-    assert_eq!(contents, DEFAULT_CONFIG_TEMPLATE);
+    assert!(contents.contains("default_crew = \"codex\""));
+    assert_all_base_crews_present(&contents);
 }
 
 #[test]
@@ -117,7 +292,9 @@ fn seed_with_incomplete_role_settings_fails() {
     let path = dir.path().join("config.toml");
     let mut roles = sample_roles();
     roles.get_mut("planner").expect("planner").model.take();
-    let error = seed_default_config(&path, Some(&roles)).expect_err("missing model fails");
+    let detected = DetectedAgents::default();
+    let error =
+        seed_default_config(&path, &detected, Some(&roles)).expect_err("missing model fails");
     assert!(
         error
             .to_string()


### PR DESCRIPTION
## Task

[ORB-00347](https://orbit-cli.com/tasks/ORB-00347) — Make default_crew and [duel].candidates dynamic from detected agents at orbit init

### Description

## Problem

The agent-dependent sections of the seeded Orbit config are hardcoded in the static template [`crates/orbit-core/assets/config/default-config.toml`](crates/orbit-core/assets/config/default-config.toml): `[workflow].default_crew = "codex"` (line 36) and `[duel].candidates = ["codex","claude","gemini","grok"]` (line 59), plus the four `[crews.*]` tables and `[duel.models]`. A user who only has, say, `claude` installed still gets `default_crew = "codex"` and a duel pointed at four families they don't have.

Detection machinery already exists and is half-wired: [`crates/orbit-core/src/config/agent_detect.rs`](crates/orbit-core/src/config/agent_detect.rs) probes `PATH` for `claude`/`codex`/`gemini`/`grok`/`ollama` and checks `*_API_KEY` env vars behind an injectable `AgentEnvProbe`, and exposes `default_provider()`, `default_backend()`, `default_model_for()`. But detection flows through **only the interactive CLI prompt** ([`collect_role_settings_for_init`](crates/orbit-cli/src/command/init.rs)), and even there it only emits `[crews.custom]` via a brittle string replace (`body.replace("default_crew = \"codex\"", …)` in [`bootstrap.rs`](crates/orbit-core/src/config/bootstrap.rs)). The `--non-interactive` path and the implicit bootstrap (`ensure_orbit_root_initialized` → `init_global`) write the fully static template verbatim, and **nothing ever touches `[duel].candidates`**.

## Why It Matters

`orbit init` should produce a config that matches the user's actual environment, not a fixed assumption. Today the very first thing a fresh user sees can point them at an agent they haven't installed.

## Solution (design approved)

Make detection the single source for the agent-dependent sections, computed once and **frozen into `config.toml` at `orbit init`**. Route every init path through it. Runtime config loading stays static-fallback — **no live re-detection at load time** (detection reads ambient `PATH`/env and load is hot; crew resolution must not silently change run-to-run).

1. **Split the template.** [`default-config.toml`](crates/orbit-core/assets/config/default-config.toml) keeps only agent-independent sections (`[execution.*]`, `[task.approval]`, `[scoring]`, `[graph]`, `[workflow].base_branch`). `default_crew`, `[crews.*]`, `[duel]`, `[duel.models]` move out and become generated.

2. **Generate the agent block from a `DetectedAgents` snapshot** in the config layer, building typed `Serialize` structs and `toml::to_string`-ing them (kills the string-replace hack). `RawCrewEntry`/`RawAgentRoleConfig` already derive `Serialize`; add serializable workflow/duel structs in [`raw.rs`](crates/orbit-core/src/config/raw.rs) as needed.

3. **Wire all init paths.** `seed_default_config` takes `&DetectedAgents`; the `--non-interactive` and implicit-bootstrap paths compute it via `detect(&RealAgentEnvProbe)`. Interactive `role_settings` continue to layer on top as an override.

### Locked decisions

- **Crews → keep all four always.** Emit `[crews.claude/codex/gemini/grok]` regardless of detection (cheap switchable templates). Only `default_crew` is dynamic.
- **`default_crew` → first available family** (CLI-on-PATH or matching API key) in `default_provider`'s preference order; **fall back to `codex`** when nothing is detected (preserves today's behavior; do not flip to claude). When the interactive prompt supplied `role_settings`, that still wins (`[crews.custom]` + `default_crew = "custom"`).
- **Duel → ≥3 guard.** If ≥3 families available: write `[duel].candidates = [available…]` + `[duel.models]` from `default_model_for`. If **<3 available: omit `[duel]` entirely** so the loader falls back to the canonical 4-family `DuelConfig::default()`. Duel stays discoverable and only errors if actually run. Rationale: the duel structurally needs 3 distinct families ([`select_roles.rs`](crates/orbit-engine/src/executor/automation/duel/select_roles.rs)) and the loader rejects <3 ([`duel_candidates_from_raw`](crates/orbit-core/src/config/runtime.rs)).

## Constraints / Notes

- Seeding stays idempotent — no-op when `config.toml` already exists.
- A repo with **no** `config.toml` still resolves to all-four/`codex` via the static `RuntimeConfig` defaults; this intentional divergence ("no config = assume everything") should be left as-is, not treated as a bug. No runtime code changes — the loader/validators ([`workflow_default_crew_from_raw`](crates/orbit-core/src/config/runtime.rs), [`duel_candidates_from_raw`](crates/orbit-core/src/config/runtime.rs)) already accept everything the generator emits.
- The "detect at seed time, static at runtime" choice is a non-obvious architectural decision — consider recording an ADR per CLAUDE.md (use the `orbit-adr` skill) during planning/execution.
- Existing seeded-content assertions in the init tests (e.g. `global_init_without_role_settings_writes_clean_template`) will need updating.

### Acceptance Criteria

- `default-config.toml` no longer contains `default_crew`, `[crews.`, `[duel]`, or `[duel.models]` (`rg -n 'default_crew|\[crews|\[duel' crates/orbit-core/assets/config/default-config.toml` returns no matches) while still containing `[execution.env]`, `[execution.codex]`, `[task.approval]`, `[scoring]`, `[graph]`, and `[workflow]` with `base_branch`.
- `seed_default_config` accepts a `&DetectedAgents` argument, and all three init paths — interactive CLI, `--non-interactive`, and implicit bootstrap via `ensure_orbit_root_initialized` — pass a real detection snapshot (computed with `RealAgentEnvProbe` for the non-interactive/implicit paths).
- A seeded config always emits all four `[crews.claude]`, `[crews.codex]`, `[crews.gemini]`, `[crews.grok]` tables regardless of which agents are detected; a unit test using `MockAgentEnvProbe` with only `claude` on PATH asserts all four crew tables are present.
- `default_crew` equals the first available family (CLI-on-PATH or matching API key) in `default_provider`'s preference order; a `MockAgentEnvProbe` seeded with only `claude` yields `default_crew = "claude"`, and an empty probe yields `default_crew = "codex"` (asserted by unit tests).
- When 3+ families are available, the generated config writes `[duel].candidates` equal to exactly the available families (normalized, deduped, preference order) plus a `[duel.models]` entry per candidate sourced from `default_model_for`; a test with claude+codex+gemini CLIs asserts the candidate list and that the models map has exactly those three keys.
- When fewer than 3 families are available, the generated config omits `[duel]` and `[duel.models]` entirely (no `[duel]` substring in the seeded file), and the resulting file loads via `RuntimeConfig::load_layered` with `DuelConfig.candidates == all_agent_families()` (asserted by a test).
- The interactive `role_settings` path still produces a `[crews.custom]` table with `default_crew = "custom"`, now via typed TOML rendering; the `body.replace("default_crew = \"codex\"", …)` string replacement in `bootstrap.rs` is removed, and existing init tests are updated to match.
- Across a representative set of `DetectedAgents` permutations (none, one CLI, two CLIs, three CLIs, four, API-key-only), every seeded config round-trips: `toml::from_str::<RawRuntimeConfig>` and `RuntimeConfig::load_layered` both succeed with no error (covered by a parameterized test).
- `seed_default_config` remains idempotent — it returns `Ok(false)` and leaves the file untouched when `config.toml` already exists (existing test still passes).
- `make ci-fast` passes and `cargo test -p orbit-core config` (config-module unit tests) passes; no runtime/load-time detection is introduced (no call to `detect`/`RealAgentEnvProbe` from `RuntimeConfig::load_layered`).

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Split agent-dependent seed config out of `default-config.toml`; the static template now keeps only execution/task/scoring/graph/workflow base-branch settings.
- Added detected-agent helpers and a seeded-config generator that freezes `DetectedAgents` into `default_crew`, canonical crew tables, and guarded duel candidates/models at init time.
- Threaded the detection snapshot through core init and CLI init paths, with deterministic test injection and real `RealAgentEnvProbe` snapshots for CLI/non-interactive and implicit bootstrap paths.
- Updated bootstrap/init tests for all required detection permutations, custom role settings, idempotency, and runtime round-trips.
- Added accepted ADR-0193 documenting seed-time detection and static runtime loading.

Assessment: Scoped implementation is complete; validation passes.

Validation:
- PASS: `rg -n 'default_crew|\[crews|\[duel' crates/orbit-core/assets/config/default-config.toml` returned no matches.
- PASS: `cargo build -p orbit-core -p orbit-cli`.
- PASS: `cargo test -p orbit-core config`.
- PASS: `cargo test -p orbit-core init`.
- PASS: `cargo test -p orbit-cli init`.
- PASS: `make ci-fast`.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-00347-6a1b4542`
- Behind base: 0
- Ahead of base: 1