### PR TITLE
denyRead/denyModify *.env glob fails to match dotenv-variant secret files (.env.local, .env.production), allowing in-workspace secret exfiltration/modification

### DIFF
--- a/crates/orbit-common/src/utility/tests/glob.rs
+++ b/crates/orbit-common/src/utility/tests/glob.rs
@@ -42,4 +42,20 @@ mod matching {
         let path = normalize_glob_path("foo/bar/baz.rs").expect("normalize");
         assert!(!match_glob("foo/*.rs", &path).expect("match"));
     }
+
+    #[test]
+    fn dotenv_variant_patterns_match_prefix_and_suffix_forms() {
+        for (rule, path) in [
+            ("**/.env", ".env"),
+            ("**/.env.*", ".env.local"),
+            ("**/.env.*", "foo/.env.production"),
+            ("**/*.env.*", "foo/secrets.env.bak"),
+        ] {
+            let path = normalize_glob_path(path).expect("normalize");
+            assert!(
+                match_glob(rule, &path).expect("match"),
+                "rule `{rule}` should match `{path}`"
+            );
+        }
+    }
 }

--- a/crates/orbit-core/assets/policies/default.yaml
+++ b/crates/orbit-core/assets/policies/default.yaml
@@ -5,10 +5,16 @@ metadata:
 spec:
   description: Default filesystem profile policy for Orbit activity runs
   denyRead:
+    - "**/.env"
+    - "**/.env.*"
     - "**/*.env"
+    - "**/*.env.*"
   denyModify:
     - .orbit/**
+    - "**/.env"
+    - "**/.env.*"
     - "**/*.env"
+    - "**/*.env.*"
   fsProfiles:
     implementer:
       read:

--- a/crates/orbit-tools/src/builtin/fs/mod.rs
+++ b/crates/orbit-tools/src/builtin/fs/mod.rs
@@ -28,6 +28,9 @@ pub fn register(registry: &mut ToolRegistry) {
     registry.register(delete::FsDeleteTool);
 }
 
+#[cfg(test)]
+mod tests;
+
 /// Checks that `path` resolves inside the context workspace root.
 ///
 /// Symlink escapes are blocked because the path is canonicalized before the check.

--- a/crates/orbit-tools/src/builtin/fs/tests/mod.rs
+++ b/crates/orbit-tools/src/builtin/fs/tests/mod.rs
@@ -1,0 +1,1 @@
+mod read;

--- a/crates/orbit-tools/src/builtin/fs/tests/read.rs
+++ b/crates/orbit-tools/src/builtin/fs/tests/read.rs
@@ -1,0 +1,88 @@
+use std::sync::Arc;
+
+use chrono::Utc;
+use orbit_common::types::{
+    FsOperation, OrbitError, PolicyDef, ResourceKind, parse_policy_resource,
+};
+use orbit_policy::PolicyEngine;
+use serde_json::json;
+
+use super::super::read::FsReadTool;
+use crate::{Tool, ToolContext};
+
+const DEFAULT_POLICY: &str = include_str!("../../../../../orbit-core/assets/policies/default.yaml");
+
+fn default_policy_engine() -> Arc<PolicyEngine> {
+    let resource =
+        parse_policy_resource(DEFAULT_POLICY, "seeded default policy").expect("parse policy");
+    assert_eq!(resource.kind, ResourceKind::Policy);
+
+    let now = Utc::now();
+    let def = PolicyDef {
+        name: resource.metadata.name,
+        description: resource.spec.description,
+        deny_read: resource.spec.deny_read,
+        deny_modify: resource.spec.deny_modify,
+        fs_profiles: resource.spec.fs_profiles,
+        created_at: now,
+        updated_at: now,
+    };
+
+    Arc::new(PolicyEngine::from_def(&def).expect("policy engine"))
+}
+
+#[test]
+fn fs_read_denies_dotenv_local_with_default_policy() {
+    let workspace = tempfile::tempdir().expect("tempdir");
+    let dotenv_path = workspace.path().join(".env.local");
+    std::fs::write(&dotenv_path, "API_KEY=secret\n").expect("write dotenv");
+
+    let ctx = ToolContext {
+        workspace_root: Some(workspace.path().to_path_buf()),
+        policy_engine: Some(default_policy_engine()),
+        fs_profile: Some("implementer".to_string()),
+        ..ToolContext::default()
+    };
+
+    let error = FsReadTool
+        .execute(
+            &ctx,
+            json!({
+                "path": dotenv_path.display().to_string(),
+            }),
+        )
+        .expect_err("default policy should deny .env.local reads");
+
+    let OrbitError::PolicyDenied(message) = error else {
+        panic!("expected PolicyDenied error");
+    };
+    assert!(message.contains(".env.local"));
+}
+
+#[test]
+fn default_policy_denies_dotenv_variants_for_read_and_modify() {
+    let engine = default_policy_engine();
+
+    for path in [
+        ".env",
+        ".env.local",
+        ".env.production",
+        "foo/secrets.env.bak",
+    ] {
+        for operation in [FsOperation::Read, FsOperation::Modify] {
+            let result = engine
+                .check("implementer", operation, path)
+                .expect("policy check");
+
+            assert!(
+                !result.allowed,
+                "{operation:?} should deny `{path}` under the default policy"
+            );
+            assert!(
+                result.matched_rule.contains(".env"),
+                "matched rule should identify a dotenv deny rule, got `{}`",
+                result.matched_rule
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Task

[ORB-00357](https://orbit-cli.com/tasks/ORB-00357) — denyRead/denyModify *.env glob fails to match dotenv-variant secret files (.env.local, .env.production), allowing in-workspace secret exfiltration/modification

### Description

## Problem
The seeded default policy declares the secret-file boundary as denyRead **/*.env and denyModify [.orbit/**, **/*.env]. compile_glob_regex translates * to [^/]* and end-anchors the pattern (...\.env$), so **/*.env compiles to ^(?:.*/)?[^/]*\.env$ and matches only paths whose final component ends exactly in .env. The de-facto-standard dotenv secret files .env.local, .env.production, .env.development, secrets.env.bak, etc. are NOT matched, so neither denyRead nor denyModify covers them. These files routinely hold real API keys/DB credentials and live inside the workspace where the fsProfile read rule ./** allows access. The deny list is the only barrier (fs.read returns raw, unredacted file content). Policy evaluation is last-match-wins: ./** matches and the negated !**/*.env never fires for .env.local, so access is allowed.

## Why It Matters / Exploit Scenario
An agent (driven by untrusted task/activity text or content it reads during a run) invokes the builtin fs.read tool with path .env.local. check_workspace_boundary canonicalizes it inside the workspace (allowed); PolicyEngine evaluates effective read rules [./**, !**/*.env] and the negation does not match .env.local, so access is allowed. fs::read_to_string returns the file's full plaintext (API keys, DB URLs) in the content field, fed back into the agent loop and exfiltratable. The same gap lets the implementer profile (modify ./**) overwrite .env.production, since denyModify **/*.env likewise misses it.

## Remediation
Treat dotenv files as a prefix/substring class, not a suffix: ship default deny rules like **/.env, **/.env.*, **/*.env, **/*.env.* (or special-case .env in the matcher). Document that *.env-style suffix rules do not cover .env.<suffix> and add the variants to the seeded default policy denyRead/denyModify.

## Affected Locations
- `crates/orbit-common/src/utility/glob.rs:106`
- `crates/orbit-core/assets/policies/default.yaml:8`
- `crates/orbit-core/assets/policies/default.yaml:11`
- `crates/orbit-tools/src/builtin/fs/read.rs:34`

## Metadata
- **Severity:** High
- **CWE:** CWE-22
- **Surface:** orbit-policy fs-scoping engine (glob matcher) + default policy
- **Source:** Automated multi-agent security audit (2026-06-06), double-verified (2 independent adversarial reviewers confirmed exploitability + technical correctness).

### Acceptance Criteria

- The seeded default policy (crates/orbit-core/assets/policies/default.yaml) denyRead/denyModify rules match `.env`, `.env.local`, `.env.production`, and `foo/secrets.env.bak`-style files.
- Glob unit tests in the sibling tests/ dir assert that the dotenv-variant patterns match `.env.local` / `foo/.env.production` and that fs.read of `.env.local` inside a workspace is denied by the default policy.
- make ci-fast passes.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Expanded the seeded default policy denyRead and denyModify dotenv rules to cover `**/.env`, `**/.env.*`, `**/*.env`, and `**/*.env.*`.
- Added glob coverage for `.env.local`, `foo/.env.production`, and `foo/secrets.env.bak` style paths.
- Added fs.read tests that parse the seeded default policy, verify read/modify denies for dotenv variants, and prove reading `.env.local` inside a workspace is denied.

Assessment: Focused security fix with targeted regression coverage and repo guardrails passing.

Validation:
- `cargo test -p orbit-common dotenv_variant_patterns_match_prefix_and_suffix_forms --quiet`
- `cargo test -p orbit-tools default_policy_denies_dotenv_variants_for_read_and_modify --quiet`
- `cargo test -p orbit-tools fs_read_denies_dotenv_local_with_default_policy --quiet`
- `make ci-fast`

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-00357-6a246e8b`
- Behind base: 0
- Ahead of base: 1