### PR TITLE
Add cargo-deny supply-chain + license gate

### DIFF
--- a/.github/workflows/cargo-deny.yml
+++ b/.github/workflows/cargo-deny.yml
@@ -1,0 +1,12 @@
+name: cargo-deny
+on:
+  push: { branches: [main] }
+  pull_request:
+jobs:
+  cargo-deny:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: EmbarkStudios/cargo-deny-action@v2
+        with:
+          command: check advisories bans licenses sources

--- a/.orbit/learnings/L-0059/learning.yaml
+++ b/.orbit/learnings/L-0059/learning.yaml
@@ -1,0 +1,21 @@
+schema_version: 1
+id: L-0059
+status: active
+scope:
+  paths:
+  - deny.toml
+  - Cargo.toml
+  - crates/*/Cargo.toml
+  - tools/*/Cargo.toml
+  tags:
+  - supply-chain
+  - cargo-deny
+summary: Keep workspace packages private when cargo-deny denies wildcard dependencies
+body: |
+  When enabling `cargo deny` with `[bans] wildcards = "deny"`, versionless workspace path dependencies are treated as wildcard dependencies unless cargo-deny can see the owning package is private. Keep root `[workspace.package] publish = false`, have workspace packages inherit it with `publish.workspace = true`, and use `allow-wildcard-paths = true` so local path deps pass while registry wildcard requirements still fail.
+evidence:
+- kind: task
+  reference: ORB-00353
+created_at: 2026-06-06T19:09:23.989315Z
+updated_at: 2026-06-06T19:09:23.989315Z
+priority: 120

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,8 @@ resolver = "2"
 version = "0.8.2"
 edition = "2024"
 license = "MIT"
+# L-0059: cargo-deny needs workspace crates marked private before allowing local path wildcards.
+publish = false
 
 # Workspace-wide lint config. Each crate opts in via `[lints] workspace = true`.
 # Keep this list short — only rules that are mechanically true everywhere.

--- a/crates/orbit-agent/Cargo.toml
+++ b/crates/orbit-agent/Cargo.toml
@@ -3,6 +3,7 @@ name = "orbit-agent"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+publish.workspace = true
 
 [package.metadata.orbit]
 stability = "internal"

--- a/crates/orbit-cli/Cargo.toml
+++ b/crates/orbit-cli/Cargo.toml
@@ -3,6 +3,7 @@ name = "orbit-cli"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+publish.workspace = true
 
 [package.metadata.orbit]
 stability = "internal"

--- a/crates/orbit-common/Cargo.toml
+++ b/crates/orbit-common/Cargo.toml
@@ -3,6 +3,7 @@ name = "orbit-common"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+publish.workspace = true
 
 [package.metadata.orbit]
 stability = "stable"

--- a/crates/orbit-core/Cargo.toml
+++ b/crates/orbit-core/Cargo.toml
@@ -3,6 +3,7 @@ name = "orbit-core"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+publish.workspace = true
 
 [package.metadata.orbit]
 stability = "internal"

--- a/crates/orbit-dashboard/Cargo.toml
+++ b/crates/orbit-dashboard/Cargo.toml
@@ -3,6 +3,7 @@ name = "orbit-dashboard"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+publish.workspace = true
 
 [package.metadata.orbit]
 stability = "internal"

--- a/crates/orbit-engine/Cargo.toml
+++ b/crates/orbit-engine/Cargo.toml
@@ -3,6 +3,7 @@ name = "orbit-engine"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+publish.workspace = true
 
 [package.metadata.orbit]
 stability = "internal"

--- a/crates/orbit-exec/Cargo.toml
+++ b/crates/orbit-exec/Cargo.toml
@@ -3,6 +3,7 @@ name = "orbit-exec"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+publish.workspace = true
 
 [package.metadata.orbit]
 stability = "internal"

--- a/crates/orbit-graph-cli/Cargo.toml
+++ b/crates/orbit-graph-cli/Cargo.toml
@@ -3,6 +3,7 @@ name = "orbit-graph-cli"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+publish.workspace = true
 
 [package.metadata.orbit]
 stability = "internal"

--- a/crates/orbit-graph-extract/Cargo.toml
+++ b/crates/orbit-graph-extract/Cargo.toml
@@ -3,6 +3,7 @@ name = "orbit-graph-extract"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+publish.workspace = true
 
 [package.metadata.orbit]
 stability = "internal"

--- a/crates/orbit-graph/Cargo.toml
+++ b/crates/orbit-graph/Cargo.toml
@@ -3,6 +3,7 @@ name = "orbit-graph"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+publish.workspace = true
 
 [package.metadata.orbit]
 stability = "internal"

--- a/crates/orbit-knowledge/Cargo.toml
+++ b/crates/orbit-knowledge/Cargo.toml
@@ -3,6 +3,7 @@ name = "orbit-knowledge"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+publish.workspace = true
 
 [package.metadata.orbit]
 stability = "internal"

--- a/crates/orbit-mcp/Cargo.toml
+++ b/crates/orbit-mcp/Cargo.toml
@@ -3,6 +3,7 @@ name = "orbit-mcp"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+publish.workspace = true
 
 [package.metadata.orbit]
 stability = "internal"

--- a/crates/orbit-policy/Cargo.toml
+++ b/crates/orbit-policy/Cargo.toml
@@ -3,6 +3,7 @@ name = "orbit-policy"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+publish.workspace = true
 
 [package.metadata.orbit]
 stability = "internal"

--- a/crates/orbit-registry/Cargo.toml
+++ b/crates/orbit-registry/Cargo.toml
@@ -3,6 +3,7 @@ name = "orbit-registry"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+publish.workspace = true
 
 [package.metadata.orbit]
 stability = "experimental"

--- a/crates/orbit-search-companion/Cargo.toml
+++ b/crates/orbit-search-companion/Cargo.toml
@@ -3,6 +3,7 @@ name = "orbit-search-companion"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+publish.workspace = true
 
 [package.metadata.orbit]
 stability = "experimental"

--- a/crates/orbit-search/Cargo.toml
+++ b/crates/orbit-search/Cargo.toml
@@ -3,6 +3,7 @@ name = "orbit-search"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+publish.workspace = true
 
 [package.metadata.orbit]
 stability = "internal"

--- a/crates/orbit-store/Cargo.toml
+++ b/crates/orbit-store/Cargo.toml
@@ -3,6 +3,7 @@ name = "orbit-store"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+publish.workspace = true
 
 [package.metadata.orbit]
 stability = "stable"

--- a/crates/orbit-tools/Cargo.toml
+++ b/crates/orbit-tools/Cargo.toml
@@ -3,6 +3,7 @@ name = "orbit-tools"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+publish.workspace = true
 
 [package.metadata.orbit]
 stability = "internal"

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,35 @@
+# Supply-chain + license gate. Run locally with: cargo deny check
+[graph]
+all-features = true
+
+[advisories]
+version = 2
+ignore = [
+    # RUSTSEC-2024-0436: pre-existing transitive paste use via tokenizers/fastembed; no safe upgrade is available.
+    "RUSTSEC-2024-0436",
+    # RUSTSEC-2023-0071: pre-existing rsa advisory; Orbit uses rsa only for public-key signature verification of the search companion.
+    "RUSTSEC-2023-0071",
+]
+# v2 defaults: vulnerabilities/unsound/yanked = deny, unmaintained = workspace.
+
+[licenses]
+version = 2
+confidence-threshold = 0.9
+allow = [
+    "MIT", "Apache-2.0", "Apache-2.0 WITH LLVM-exception",
+    "BSD-2-Clause", "BSD-3-Clause", "ISC", "Zlib", "MPL-2.0",
+    "Unicode-3.0", "Unicode-DFS-2016", "CC0-1.0", "Unlicense", "OpenSSL",
+    "CDLA-Permissive-2.0",
+]
+# rusqlite bundles SQLite (public-domain "blessing"); add a [[licenses.clarify]]
+# entry if it gets flagged after the first run.
+
+[bans]
+multiple-versions = "warn"   # duplicate transitive versions are common; warn, don't block
+wildcards = "deny"
+# L-0059: publish=false keeps local path deps allowed while registry wildcards stay denied.
+allow-wildcard-paths = true  # workspace path deps omit version requirements; registry wildcards remain denied
+
+[sources]
+unknown-registry = "deny"
+unknown-git = "deny"

--- a/tools/graph-equiv/Cargo.toml
+++ b/tools/graph-equiv/Cargo.toml
@@ -3,6 +3,7 @@ name = "graph-equiv"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+publish.workspace = true
 
 [package.metadata.orbit]
 stability = "internal"


### PR DESCRIPTION
## Task

[ORB-00353](https://orbit-cli.com/tasks/ORB-00353) — Add cargo-deny supply-chain + license gate

### Description

## Problem

Orbit has no automated supply-chain or license gate. Nothing fails CI when a transitive dependency picks up a security advisory, an unexpected license, an unknown source registry, or a wildcard version requirement. The dependency tree is large (tree-sitter family, `rsa`, `blake3`, `axum`, `reqwest`) and keeps growing through transitive deps.

## Why It Matters

A vulnerable or non-permissive-licensed transitive dep can land silently on a routine dependency bump. A dedicated `cargo deny` job catches advisory / license / source / ban violations on every PR. Keeping it a **separate** job from the main `make ci` gate ([.github/workflows/ci.yml](.github/workflows/ci.yml)) means an advisory in a transitive dep fails the build without blocking the fast clippy/test loop.

## Proposed Change

Add two new files (neither exists today).

**`deny.toml`** at repo root:

```toml
# Supply-chain + license gate. Run locally with: cargo deny check
[graph]
all-features = true

[advisories]
version = 2
ignore = []
# v2 defaults: vulnerabilities/unsound/yanked = deny, unmaintained = workspace.

[licenses]
version = 2
confidence-threshold = 0.9
allow = [
    "MIT", "Apache-2.0", "Apache-2.0 WITH LLVM-exception",
    "BSD-2-Clause", "BSD-3-Clause", "ISC", "Zlib", "MPL-2.0",
    "Unicode-3.0", "Unicode-DFS-2016", "CC0-1.0", "Unlicense", "OpenSSL",
]
# rusqlite bundles SQLite (public-domain "blessing"); add a [[licenses.clarify]]
# entry if it gets flagged after the first run.

[bans]
multiple-versions = "warn"   # duplicate transitive versions are common; warn, don't block
wildcards = "deny"

[sources]
unknown-registry = "deny"
unknown-git = "deny"
```

**`.github/workflows/cargo-deny.yml`**:

```yaml
name: cargo-deny
on:
  push: { branches: [main] }
  pull_request:
jobs:
  cargo-deny:
    runs-on: ubuntu-latest
    steps:
      - uses: actions/checkout@v4
      - uses: EmbarkStudios/cargo-deny-action@v2
        with:
          command: check advisories bans licenses sources
```

## Constraints / Notes

- Standalone CI job — do **not** fold it into `ci.yml`.
- Pin the action at `EmbarkStudios/cargo-deny-action@v2`.
- `multiple-versions = "warn"` (duplicate transitive versions are common in this tree); `wildcards = "deny"`.
- The current tree is permissive (tree-sitter family, `rsa`, `blake3`, `axum`, `reqwest`). Run `cargo deny check licenses` once locally and add any straggler license to the `allow` list rather than lowering `confidence-threshold` below 0.9.
- If `rusqlite`/SQLite is flagged, add a `[[licenses.clarify]]` entry — do not loosen the threshold.
- Any pre-existing advisory must be handled explicitly via `[advisories].ignore` with a comment, not by weakening the gate.

### Acceptance Criteria

- `deny.toml` exists at repo root with `[advisories] version = 2`, `[licenses] version = 2` (allow-list as specified, `confidence-threshold = 0.9`), `[bans] wildcards = "deny"` and `multiple-versions = "warn"`, and `[sources]` with `unknown-registry = "deny"` and `unknown-git = "deny"`.
- Running `cargo deny check licenses` locally exits 0 against the current tree; any straggler license is added to `allow` (not handled by lowering `confidence-threshold`).
- Running `cargo deny check advisories bans licenses sources` locally exits 0, OR any pre-existing advisory is explicitly listed in `[advisories].ignore` with a justifying comment.
- `.github/workflows/cargo-deny.yml` exists, triggers on `pull_request` and on `push` to `main`, runs `EmbarkStudios/cargo-deny-action@v2` with `command: check advisories bans licenses sources`, and is its own job (not merged into ci.yml).
- `.github/workflows/cargo-deny.yml` is valid YAML and appears as a standalone status check on a PR (verify with `actionlint .github/workflows/cargo-deny.yml` or by opening a draft PR).

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Added deny.toml with cargo-deny advisory, license, bans, and sources checks, including CDLA-Permissive-2.0 after local license validation.
- Added a standalone cargo-deny GitHub Actions workflow using EmbarkStudios/cargo-deny-action@v2 for pull_request and pushes to main.
- Marked workspace packages as private via publish=false inheritance so cargo-deny can allow local path dependencies while keeping registry wildcard requirements denied.
- Ignored pre-existing RUSTSEC-2024-0436 and RUSTSEC-2023-0071 advisories with config comments, and captured the cargo-deny path-wildcard gotcha as learning L-0059.

Validation:
- PATH=/tmp/orbit-tools/bin:$PATH CARGO_HOME=/tmp/orbit-cargo-home cargo deny check licenses
- PATH=/tmp/orbit-tools/bin:$PATH CARGO_HOME=/tmp/orbit-cargo-home cargo deny check advisories bans licenses sources
- PATH=/tmp/orbit-tools/bin:$PATH actionlint .github/workflows/cargo-deny.yml
- make ci-fast

Assessment: Supply-chain gate is in place and validated locally; cargo-deny still emits non-failing warnings for allow-listed licenses not currently encountered and duplicate transitive versions per the requested warn policy.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-00353-6a246e8b`
- Behind base: 0
- Ahead of base: 1