### PR TITLE
macOS sandbox profile grants unrestricted file-read* plus network*, allowing a sandboxed agent to read and exfiltrate any on-disk secret

### DIFF
--- a/crates/orbit-exec/src/macos_sandbox/compile.rs
+++ b/crates/orbit-exec/src/macos_sandbox/compile.rs
@@ -7,9 +7,9 @@ use orbit_common::types::{OrbitError, ResolvedFsProfile};
 ///
 /// The emitted profile:
 /// - denies everything by default;
-/// - allows broad reads (`file-read*`) — agent CLIs read from `/usr`,
-///   `/System`, `/Library`, dyld caches, fonts, and similar locations that
-///   are not realistic to enumerate;
+/// - allows broad reads (`file-read*`) for agent CLI compatibility, then
+///   appends default read denies for well-known credential locations so those
+///   paths still lose under SBPL's last-match-wins evaluation;
 /// - allows the syscall classes agent CLIs rely on (process, signal, mach,
 ///   ipc, sysctl, iokit) and unrestricted network — agents call out to
 ///   provider APIs;
@@ -144,6 +144,36 @@ pub(super) fn compile_macos_sandbox_profile_with_env(
             ));
         }
     }
+    emit_default_credential_read_denies(home, &mut out);
 
     Ok(out)
+}
+
+fn emit_default_credential_read_denies(home: Option<&OsStr>, out: &mut String) {
+    if let Some(home) = super::provider_dirs::non_empty_env_path(home) {
+        let home = home.display().to_string();
+        for suffix in [
+            ".ssh",
+            ".aws",
+            ".config/gh",
+            "Library/Keychains",
+            "Library/Application Support/Google/Chrome",
+            "Library/Application Support/Chromium",
+            "Library/Application Support/BraveSoftware/Brave-Browser",
+            "Library/Application Support/Firefox",
+        ] {
+            emit_read_deny_subpath(&format!("{home}/{suffix}"), out);
+        }
+    }
+
+    for path in ["/Library/Keychains", "/System/Library/Keychains"] {
+        emit_read_deny_subpath(path, out);
+    }
+}
+
+fn emit_read_deny_subpath(path: &str, out: &mut String) {
+    out.push_str(&format!(
+        "(deny file-read* (subpath \"{}\"))\n",
+        super::sbpl_filter::sbpl_escape(path)
+    ));
 }

--- a/crates/orbit-exec/src/macos_sandbox/tests/compile.rs
+++ b/crates/orbit-exec/src/macos_sandbox/tests/compile.rs
@@ -13,6 +13,43 @@ fn compile_emits_deny_default_and_broad_read_with_modify_subpath() {
 }
 
 #[test]
+fn compile_default_profile_denies_well_known_credential_reads() {
+    let resolved = profile("default", &["/Users/test/repo"], &["/Users/test/repo/src"]);
+    let text = compile_with_env(
+        &resolved,
+        EnvOverrides {
+            home: Some("/Users/test"),
+            ..Default::default()
+        },
+    );
+
+    for credential_root in [
+        "/Users/test/.ssh",
+        "/Users/test/.aws",
+        "/Users/test/.config/gh",
+        "/Users/test/Library/Keychains",
+        "/Library/Keychains",
+        "/System/Library/Keychains",
+    ] {
+        let clause = format!("(deny file-read* (subpath \"{credential_root}\"))");
+        assert!(
+            text.contains(&clause),
+            "missing default credential read deny for {credential_root}: {text}"
+        );
+    }
+
+    let allow_pos = text.find("(allow file-read*)").expect("broad read allow");
+    let ssh_deny = "(deny file-read* (subpath \"/Users/test/.ssh\"))";
+    let ssh_deny_pos = text
+        .find(ssh_deny)
+        .expect("default ~/.ssh read deny for private keys such as ~/.ssh/id_rsa");
+    assert!(
+        allow_pos < ssh_deny_pos,
+        "credential read denies must follow broad read allow for last-match-wins: {text}"
+    );
+}
+
+#[test]
 fn compile_grants_write_access_to_global_orbit_log_dir() {
     // The agent CLI inherits the sandbox into `orbit mcp serve` and any
     // other `orbit ...` calls. The JSONL tracing layer resolves its


### PR DESCRIPTION
## Task

[ORB-00370](https://orbit-cli.com/tasks/ORB-00370) — macOS sandbox profile grants unrestricted file-read* plus network*, allowing a sandboxed agent to read and exfiltrate any on-disk secret

### Description

## Problem
compile_macos_sandbox_profile_with_env emits (deny default) followed by an unconditional (allow file-read*) and (allow network*). Read access is therefore allow-by-default for the entire filesystem; the only read restrictions are explicit denyRead entries the profile author must remember to add (the read-deny loop only emits clauses for !-prefixed rules). The sandbox is effectively a write-only boundary scoped to the FsProfile's modify rules, while unrestricted reads of arbitrary files combined with unrestricted outbound network give a sandboxed backend: cli agent everything needed to read and exfiltrate secrets outside the workspace. This is a documented, consciously accepted trade-off (broad reads are required for agent CLIs and system libraries), making it defense-in-depth hardening rather than an accidental misconfiguration.

## Why It Matters / Exploit Scenario
A prompt-injected or malicious agent CLI running under the macOS sandbox (the OS-level enforcement seam for backend: cli activities) reads ~/.ssh/id_rsa, ~/.aws/credentials, ~/.config/gh/hosts.yml, or other on-disk secrets and POSTs them to an attacker-controlled endpoint over the allowed network. None are blocked because reads are globally allowed and network is unrestricted, unless an operator pre-listed every secret path under denyRead.

## Remediation
Treat reads symmetrically with writes: derive a read allowlist from the FsProfile (workspace root, provider state dirs, system library/dyld paths) rather than (allow file-read*), or at minimum emit hardcoded (deny file-read* (subpath ...)) clauses for well-known credential locations (~/.ssh, ~/.aws, ~/.config/gh, browser/keychain stores) by default. Consider constraining network* for activities that do not require provider API egress.

## Affected Locations
- `crates/orbit-exec/src/macos_sandbox/compile.rs:68`
- `crates/orbit-exec/src/macos_sandbox/compile.rs:83`
- `crates/orbit-exec/src/macos_sandbox/compile.rs:139`

## Metadata
- **Severity:** Low
- **CWE:** CWE-732
- **Surface:** macOS sandbox SBPL compilation
- **Source:** Automated multi-agent security audit (2026-06-06), double-verified (2 independent adversarial reviewers confirmed exploitability + technical correctness).

### Acceptance Criteria

- The macOS sandbox profile no longer emits a blanket `(allow file-read*)`; reads are constrained to an allowlist derived from the FsProfile (workspace + required system/provider paths), OR well-known credential locations (~/.ssh, ~/.aws, ~/.config/gh, keychains) are explicitly denied by default.
- A test asserts the compiled SBPL for a default profile denies reading a path like ~/.ssh/id_rsa.
- make ci-fast passes.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Appended default SBPL read-deny clauses for HOME-scoped credential stores (`~/.ssh`, `~/.aws`, `~/.config/gh`, user keychains, and common browser credential stores) plus machine keychain locations, after the broad read allow so they win under last-match-wins.
- Added a focused macOS sandbox compiler test proving a default profile emits read denies for credential roots including `~/.ssh`, which covers private keys such as `~/.ssh/id_rsa`, and that the deny follows `(allow file-read*)`.

Assessment: The hardening keeps the existing broad read compatibility model while blocking the audited secret paths by default. Validation passed with targeted orbit-exec tests and `make ci-fast`.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-00370-6a247329`
- Behind base: 0
- Ahead of base: 1