### PR TITLE
Gemini HTTP transport places API key in URL query string, leaking it via reqwest error Display and to on-path proxies

### DIFF
--- a/crates/orbit-agent/src/providers/gemini_http/transport.rs
+++ b/crates/orbit-agent/src/providers/gemini_http/transport.rs
@@ -12,7 +12,7 @@ use crate::loop_engine::transport::{
     ContentBlock, LoopTransport, Message, MessageRole, StopReason, ToolSpec, TransportError,
     TurnRequest, TurnResponse, TurnUsage,
 };
-use reqwest::blocking::Client;
+use reqwest::blocking::{Client, RequestBuilder};
 use reqwest::header::{CONTENT_TYPE, HeaderName, HeaderValue};
 
 use super::wire::{
@@ -22,6 +22,7 @@ use super::wire::{
 };
 
 const DEFAULT_BASE_URL: &str = "https://generativelanguage.googleapis.com";
+const GEMINI_API_KEY_HEADER: &str = "x-goog-api-key";
 
 pub struct GeminiHttpTransport {
     client: Client,
@@ -69,16 +70,32 @@ impl GeminiHttpTransport {
 
     fn generate_content_endpoint(&self) -> String {
         format!(
-            "{}/v1beta/models/{}:generateContent?key={}",
-            self.base_url, self.model, self.api_key
+            "{}/v1beta/models/{}:generateContent",
+            self.base_url, self.model
         )
     }
 
     fn cached_contents_endpoint(&self) -> String {
-        format!(
-            "{}/v1beta/cachedContents?key={}",
-            self.base_url, self.api_key
-        )
+        format!("{}/v1beta/cachedContents", self.base_url)
+    }
+
+    fn post_json_request(&self, endpoint: &str) -> Result<RequestBuilder, TransportError> {
+        let mut request = self
+            .client
+            .post(endpoint)
+            .header(CONTENT_TYPE, "application/json")
+            .header(GEMINI_API_KEY_HEADER, self.api_key_header_value()?);
+
+        for (name, value) in &self.custom_headers {
+            request = request.header(name.clone(), value.clone());
+        }
+
+        Ok(request)
+    }
+
+    fn api_key_header_value(&self) -> Result<HeaderValue, TransportError> {
+        HeaderValue::from_str(&self.api_key)
+            .map_err(|e| TransportError::Other(format!("invalid Gemini API key header value: {e}")))
     }
 
     fn try_create_cached_content(
@@ -98,24 +115,15 @@ impl GeminiHttpTransport {
         let body_bytes = serde_json::to_vec(&req)
             .map_err(|e| TransportError::Decode(format!("serialize cache request: {e}")))?;
 
-        let mut request = self
-            .client
-            .post(self.cached_contents_endpoint())
-            .header(CONTENT_TYPE, "application/json");
+        let endpoint = self.cached_contents_endpoint();
+        let request = self.post_json_request(&endpoint)?;
 
-        for (name, value) in &self.custom_headers {
-            request = request.header(name.clone(), value.clone());
-        }
-
-        let response = request
-            .body(body_bytes)
-            .send()
-            .map_err(|e| TransportError::Network(e.to_string()))?;
+        let response = request.body(body_bytes).send().map_err(network_error)?;
 
         let http_status = response.status().as_u16();
         let response_bytes = response
             .bytes()
-            .map_err(|e| TransportError::Network(format!("read body: {e}")))?
+            .map_err(|e| network_error_with_context("read body", e))?
             .to_vec();
 
         if !(200..300).contains(&http_status) {
@@ -208,24 +216,17 @@ impl LoopTransport for GeminiHttpTransport {
             .map_err(|e| TransportError::Decode(format!("serialize request: {e}")))?;
 
         let endpoint = self.generate_content_endpoint();
-        let mut request = self
-            .client
-            .post(&endpoint)
-            .header(CONTENT_TYPE, "application/json");
-
-        for (name, value) in &self.custom_headers {
-            request = request.header(name.clone(), value.clone());
-        }
+        let request = self.post_json_request(&endpoint)?;
 
         let response = request
             .body(body_bytes.clone())
             .send()
-            .map_err(|e| TransportError::Network(e.to_string()))?;
+            .map_err(network_error)?;
 
         let http_status = response.status().as_u16();
         let response_bytes = response
             .bytes()
-            .map_err(|e| TransportError::Network(format!("read body: {e}")))?
+            .map_err(|e| network_error_with_context("read body", e))?
             .to_vec();
 
         if !(200..300).contains(&http_status) {
@@ -373,6 +374,18 @@ fn build_client(timeout: Duration) -> Result<Client, TransportError> {
         .map_err(|e| TransportError::Other(format!("reqwest build: {e}")))
 }
 
+fn network_error(error: reqwest::Error) -> TransportError {
+    TransportError::Network(reqwest_error_message(error))
+}
+
+fn network_error_with_context(context: &str, error: reqwest::Error) -> TransportError {
+    TransportError::Network(format!("{context}: {}", reqwest_error_message(error)))
+}
+
+fn reqwest_error_message(error: reqwest::Error) -> String {
+    error.without_url().to_string()
+}
+
 fn normalize_base_url(base_url: String) -> String {
     let trimmed = base_url.trim();
     let normalized = if trimmed.is_empty() {
@@ -397,4 +410,125 @@ fn validate_headers(
             Ok((header_name, header_value))
         })
         .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::{Read, Write};
+    use std::net::TcpListener;
+    use std::thread;
+    use std::time::Duration;
+
+    use super::*;
+    use crate::loop_engine::transport::{CacheHint, Message};
+
+    const GEMINI_API_KEY: &str = "AIzaSyDoNotLeakThisGeminiApiKeyValue";
+
+    #[test]
+    fn send_turn_sends_api_key_header_without_key_query_param() {
+        let response_body = r#"{"candidates":[{"content":{"role":"model","parts":[{"text":"ok"}]},"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":1,"candidatesTokenCount":1,"cachedContentTokenCount":0}}"#;
+        let (base_url, server) = spawn_one_request_server(response_body);
+        let transport = GeminiHttpTransport::new(GEMINI_API_KEY, "gemini-test", None)
+            .expect("transport")
+            .with_base_url(base_url);
+        let messages = [Message::user_text("hello")];
+        let req = TurnRequest {
+            system: None,
+            messages: &messages,
+            tools: &[],
+            cache_hint: CacheHint::None,
+            max_response_tokens: 0,
+        };
+
+        let response = transport.send_turn(&req).expect("send turn");
+        let captured_request = server.join().expect("server thread");
+        let request_line = captured_request.lines().next().unwrap_or_default();
+
+        assert!(
+            request_line.starts_with("POST /v1beta/models/gemini-test:generateContent "),
+            "unexpected request line: {request_line}"
+        );
+        assert!(
+            !request_line.to_ascii_lowercase().contains("key="),
+            "request URL must not contain an API key query param: {request_line}"
+        );
+        assert!(
+            captured_request.contains(&format!("{GEMINI_API_KEY_HEADER}: {GEMINI_API_KEY}")),
+            "request must send the Gemini API key header"
+        );
+        assert!(!response.endpoint.to_ascii_lowercase().contains("key="));
+    }
+
+    #[test]
+    fn endpoint_builders_do_not_include_api_key_query_params() {
+        let transport =
+            GeminiHttpTransport::new(GEMINI_API_KEY, "gemini-test", None).expect("transport");
+
+        let generate_endpoint = transport.generate_content_endpoint();
+        let cached_endpoint = transport.cached_contents_endpoint();
+
+        assert!(!generate_endpoint.to_ascii_lowercase().contains("key="));
+        assert!(!cached_endpoint.to_ascii_lowercase().contains("key="));
+        assert!(!generate_endpoint.contains(GEMINI_API_KEY));
+        assert!(!cached_endpoint.contains(GEMINI_API_KEY));
+    }
+
+    #[test]
+    fn reqwest_transport_errors_strip_url_before_stringifying() {
+        let listener = TcpListener::bind(("127.0.0.1", 0)).expect("bind listener");
+        let addr = listener.local_addr().expect("listener address");
+        drop(listener);
+        let url = format!("http://{addr}/fail?key={GEMINI_API_KEY}");
+        let err = Client::builder()
+            .timeout(Duration::from_millis(50))
+            .build()
+            .expect("client")
+            .get(url)
+            .send()
+            .expect_err("unbound local port should fail");
+
+        let TransportError::Network(message) = network_error(err) else {
+            panic!("expected network error");
+        };
+
+        assert!(!message.contains(GEMINI_API_KEY));
+        assert!(!message.to_ascii_lowercase().contains("key="));
+    }
+
+    fn spawn_one_request_server(
+        response_body: &'static str,
+    ) -> (String, thread::JoinHandle<String>) {
+        let listener = TcpListener::bind(("127.0.0.1", 0)).expect("bind listener");
+        let addr = listener.local_addr().expect("listener address");
+        let handle = thread::spawn(move || {
+            let (mut stream, _) = listener.accept().expect("accept request");
+            stream
+                .set_read_timeout(Some(Duration::from_secs(2)))
+                .expect("set read timeout");
+            let mut request_bytes = Vec::new();
+            let mut buf = [0_u8; 1024];
+            loop {
+                let n = stream.read(&mut buf).expect("read request");
+                if n == 0 {
+                    break;
+                }
+                request_bytes.extend_from_slice(&buf[..n]);
+                if request_bytes.windows(4).any(|window| window == b"\r\n\r\n") {
+                    break;
+                }
+            }
+
+            let response = format!(
+                "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{}",
+                response_body.len(),
+                response_body
+            );
+            stream
+                .write_all(response.as_bytes())
+                .expect("write response");
+            String::from_utf8(request_bytes).expect("request utf8")
+        });
+
+        (format!("http://{addr}"), handle)
+    }
 }

--- a/crates/orbit-common/src/utility/redaction.rs
+++ b/crates/orbit-common/src/utility/redaction.rs
@@ -194,17 +194,17 @@ pub fn is_sensitive_env_name(name: &str) -> bool {
 /// Regex-driven scrubber for HTTP-shape and argv-shape secrets.
 ///
 /// Builds to `default()` give you the same coverage as the former
-/// `RedactionMiddleware` (Authorization / x-api-key / Bearer / raw header
-/// lines). Use [`PatternRedactor::with_argv_secrets`] to also catch bare
-/// `sk-…` tokens — needed when scrubbing subprocess argv where a provider
-/// key sometimes ends up mis-configured.
+/// `RedactionMiddleware` (Authorization / x-api-key / URL key params /
+/// Bearer / raw header lines). Use [`PatternRedactor::with_argv_secrets`] to
+/// also catch bare `sk-…` tokens — needed when scrubbing subprocess argv where
+/// a provider key sometimes ends up mis-configured.
 pub struct PatternRedactor {
     patterns: Vec<(Regex, &'static str)>,
 }
 
 impl PatternRedactor {
-    /// HTTP-only default: Authorization / x-api-key / api_key / Bearer in
-    /// both JSON and raw-header form.
+    /// HTTP-only default: Authorization / x-api-key / api_key / URL key
+    /// params / Bearer in both JSON and raw-header form.
     pub fn http_default() -> Self {
         let patterns = vec![
             (
@@ -233,6 +233,10 @@ impl PatternRedactor {
             ),
             (
                 Regex::new(r"(?im)^(\s*api[_-]?key\s*:\s*).+$").expect("valid regex"),
+                "${1}[REDACTED_AUTH]",
+            ),
+            (
+                Regex::new(r"(?i)([?&]key=)[^&\s]+").expect("valid regex"),
                 "${1}[REDACTED_AUTH]",
             ),
             (

--- a/crates/orbit-common/src/utility/tests/mod.rs
+++ b/crates/orbit-common/src/utility/tests/mod.rs
@@ -3,4 +3,5 @@ mod glob;
 mod logging;
 #[cfg(unix)]
 mod process_identity;
+mod redaction;
 mod selector;

--- a/crates/orbit-common/src/utility/tests/redaction.rs
+++ b/crates/orbit-common/src/utility/tests/redaction.rs
@@ -1,0 +1,17 @@
+use super::super::redaction::redact_all;
+
+#[test]
+fn redact_all_scrubs_key_query_params_case_insensitively() {
+    let raw = concat!(
+        "failed for url (https://example.test/v1beta/models/m:generateContent",
+        "?key=AIzaSyQuerySecret&alt=sse) and ",
+        "https://example.test/v1beta/cachedContents?foo=1&KEY=second-secret"
+    );
+
+    let redacted = redact_all(raw);
+
+    assert!(!redacted.contains("AIzaSyQuerySecret"));
+    assert!(!redacted.contains("second-secret"));
+    assert!(redacted.contains("?key=[REDACTED_AUTH]&alt=sse"));
+    assert!(redacted.contains("&KEY=[REDACTED_AUTH]"));
+}


### PR DESCRIPTION
## Task

[ORB-00371](https://orbit-cli.com/tasks/ORB-00371) — Gemini HTTP transport places API key in URL query string, leaking it via reqwest error Display and to on-path proxies

### Description

## Problem
GeminiHttpTransport embeds the raw provider API key in the request URL query string rather than an HTTP header. generate_content_endpoint() builds "{base}/v1beta/models/{model}:generateContent?key={api_key}" and cached_contents_endpoint() builds "{base}/v1beta/cachedContents?key={api_key}". Both URLs are passed to reqwest. On any transport-level failure the code maps the reqwest error with TransportError::Network(e.to_string()), and reqwest 0.12.28's Error Display appends the full failing URL (including the query string) to the message; url::Url Display does not redact query params. The resulting error string contains cleartext key=<API_KEY>. The default PatternRedactor does not match a Google AIza key in a key= URL param. Independently, putting the secret in the URL exposes it to any forward/observability proxy, TLS-terminating gateway, or server access log on the egress path — which the sibling header-based transports (Anthropic x-api-key, OpenAI Authorization: Bearer) do not. Currently the transport is reachable mainly via the shipped example; the engine driver hardcodes the Anthropic transport, and env-sourced keys are partially mitigated by redact_sensitive_env_text on paths that run redact_all.

## Why It Matters / Exploit Scenario
A consumer uses GeminiHttpTransport with a real GEMINI_API_KEY. The endpoint times out or the host is offline, so send_turn returns TransportError::Network("... for url (https://generativelanguage.googleapis.com/v1beta/models/...:generateContent?key=AIzaSy...REAL_KEY...)"). If that error string is surfaced or persisted via a path that does not run redact_all (e.g. the example's stderr, or format!("{err:?}")), the cleartext key is exposed; the pattern redactor would not mask the key= param. The key is also visible to any HTTP proxy, gateway, or server access log on the request path regardless of local redaction.

## Remediation
Do not put the API key in the URL. Send it via the documented header (x-goog-api-key: <key>) and build the endpoint without the ?key= param, matching the header-based pattern used by the Anthropic and OpenAI transports. As defense in depth, strip the URL from transport errors before stringifying (reqwest::Error::without_url()), and extend the redactor with a (?i)([?&]key=)[^&\s]+ pattern.

## Affected Locations
- `crates/orbit-agent/src/providers/gemini_http/transport.rs:73`
- `crates/orbit-agent/src/providers/gemini_http/transport.rs:80`
- `crates/orbit-agent/src/providers/gemini_http/transport.rs:223`
- `crates/orbit-agent/src/providers/gemini_http/transport.rs:113`

## Metadata
- **Severity:** Low
- **CWE:** CWE-598
- **Surface:** HTTP LoopTransport (GeminiHttpTransport)
- **Source:** Automated multi-agent security audit (2026-06-06), double-verified (2 independent adversarial reviewers confirmed exploitability + technical correctness).

### Acceptance Criteria

- GeminiHttpTransport sends the API key via the `x-goog-api-key` header instead of the `?key=` URL query param (crates/orbit-agent/src/providers/gemini_http/transport.rs).
- Transport errors strip the URL before stringifying (reqwest without_url()) so a failing request cannot leak the key, and a `(?i)[?&]key=` redaction pattern is added as defense-in-depth.
- A test asserts the request URL contains no `key=` param and that a simulated transport error string contains no API key.
- make ci-fast passes.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Gemini HTTP generateContent and cachedContents endpoints no longer include key= query params; requests now attach x-goog-api-key through a shared request builder.
- Reqwest network errors in Gemini transport call without_url() before stringifying, including body-read errors.
- Default PatternRedactor now scrubs ?key=/&key= params; tests cover request URL/header behavior, endpoint builders, transport-error sanitization, and query-param redaction.

Assessment: Targeted tests and make ci-fast pass.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-00371-6a247329`
- Behind base: 0
- Ahead of base: 1