### PR TITLE
Audit blob and JSONL log files written world-readable (default umask), no permission hardening

### DIFF
--- a/crates/orbit-common/src/utility/blob_store.rs
+++ b/crates/orbit-common/src/utility/blob_store.rs
@@ -16,6 +16,7 @@ use std::path::{Path, PathBuf};
 
 use sha2::{Digest, Sha256};
 
+use super::fs::{create_new_private_file, create_private_dir_all};
 use super::redaction::{PatternRedactor, redact_all};
 
 pub struct BlobStore {
@@ -47,20 +48,16 @@ impl BlobStore {
         let redacted = self.redact_for_storage(content);
         let hash = sha256_hex(&redacted);
         let dir = self.root.join(&hash[..2]);
-        fs::create_dir_all(&dir)?;
+        create_private_dir_all(&dir)?;
         let path = dir.join(&hash);
         if !path.exists() {
-            let mut f = fs::OpenOptions::new()
-                .write(true)
-                .create_new(true)
-                .open(&path)
-                .or_else(|err| {
-                    if err.kind() == io::ErrorKind::AlreadyExists {
-                        fs::OpenOptions::new().write(true).open(&path)
-                    } else {
-                        Err(err)
-                    }
-                })?;
+            let mut f = create_new_private_file(&path).or_else(|err| {
+                if err.kind() == io::ErrorKind::AlreadyExists {
+                    fs::OpenOptions::new().write(true).open(&path)
+                } else {
+                    Err(err)
+                }
+            })?;
             f.write_all(&redacted)?;
             f.flush()?;
         }

--- a/crates/orbit-common/src/utility/fs.rs
+++ b/crates/orbit-common/src/utility/fs.rs
@@ -24,6 +24,48 @@ use fs2::FileExt;
 
 static TEMP_FILE_COUNTER: AtomicU64 = AtomicU64::new(0);
 
+#[cfg(unix)]
+const PRIVATE_FILE_MODE: u32 = 0o600;
+
+#[cfg(unix)]
+const PRIVATE_DIR_MODE: u32 = 0o700;
+
+/// Creates a directory tree for secret-bearing Orbit state.
+///
+/// On Unix, every directory this call creates is immediately restricted to the
+/// current user (`0o700`) instead of relying on the process umask. Existing
+/// directories are left unchanged so callers do not unexpectedly chmod a
+/// workspace root or home directory.
+pub(crate) fn create_private_dir_all(path: &Path) -> io::Result<()> {
+    #[cfg(unix)]
+    {
+        create_private_dir_all_unix(path)
+    }
+    #[cfg(not(unix))]
+    {
+        fs::create_dir_all(path)
+    }
+}
+
+/// Create a new secret-bearing file for writing.
+///
+/// On Unix, the file is opened with and then set to `0o600` so group/other bits
+/// cannot leak in through the process umask.
+pub(crate) fn create_new_private_file(path: &Path) -> io::Result<File> {
+    let mut options = OpenOptions::new();
+    options.create_new(true).truncate(true).write(true);
+    open_private_file(path, &mut options)
+}
+
+/// Open a secret-bearing append-only file, creating it if needed.
+///
+/// On Unix, newly created and pre-existing files are set to `0o600`.
+pub(crate) fn append_private_file(path: &Path) -> io::Result<File> {
+    let mut options = OpenOptions::new();
+    options.create(true).append(true);
+    open_private_file(path, &mut options)
+}
+
 /// Atomically write `content` to `path`, then fsync the parent directory so
 /// the rename survives a crash. Creates parent directories as needed.
 pub fn atomic_write_text(path: &Path, content: &str) -> io::Result<()> {
@@ -40,14 +82,10 @@ pub fn atomic_write_bytes(path: &Path, content: &[u8]) -> io::Result<()> {
             format!("no parent dir for {}", path.display()),
         )
     })?;
-    fs::create_dir_all(parent)?;
+    create_private_dir_all(parent)?;
 
     let temp_path = temp_path_for(path);
-    let mut file = OpenOptions::new()
-        .create_new(true)
-        .truncate(true)
-        .write(true)
-        .open(&temp_path)?;
+    let mut file = create_new_private_file(&temp_path)?;
 
     if let Ok(metadata) = fs::metadata(path) {
         fs::set_permissions(&temp_path, metadata.permissions())?;
@@ -96,14 +134,10 @@ impl StagedTextFile {
                 format!("no parent dir for {}", target_path.display()),
             )
         })?;
-        fs::create_dir_all(parent)?;
+        create_private_dir_all(parent)?;
 
         let temp_path = temp_path_for(target_path);
-        let mut file = OpenOptions::new()
-            .create_new(true)
-            .truncate(true)
-            .write(true)
-            .open(&temp_path)?;
+        let mut file = create_new_private_file(&temp_path)?;
 
         if let Ok(metadata) = fs::metadata(target_path) {
             fs::set_permissions(&temp_path, metadata.permissions())?;
@@ -227,18 +261,18 @@ where
             format!("cannot determine parent for '{}'", target_path.display()),
         )
     })?;
-    fs::create_dir_all(parent)?;
+    create_private_dir_all(parent)?;
 
     let lock_path = lock_path_for(target_path)?;
-    let lock_file = OpenOptions::new()
-        .create(true)
-        .read(true)
-        .write(true)
-        .truncate(false)
-        .open(&lock_path)
-        .map_err(|e| {
-            io::Error::other(format!("open {label} lock '{}': {e}", lock_path.display()))
-        })?;
+    let mut options = OpenOptions::new();
+    options.create(true).read(true).write(true).truncate(false);
+    apply_private_file_mode(&mut options);
+    let lock_file = options.open(&lock_path).map_err(|e| {
+        io::Error::other(format!("open {label} lock '{}': {e}", lock_path.display()))
+    })?;
+    set_private_file_permissions(&lock_path).map_err(|e| {
+        io::Error::other(format!("chmod {label} lock '{}': {e}", lock_path.display()))
+    })?;
     lock_file
         .lock_exclusive()
         .map_err(|e| io::Error::other(format!("lock {label} '{}': {e}", lock_path.display())))?;
@@ -254,4 +288,80 @@ fn lock_path_for(path: &Path) -> io::Result<PathBuf> {
         )
     })?;
     Ok(path.with_file_name(format!(".{file_name}.lock")))
+}
+
+fn open_private_file(path: &Path, options: &mut OpenOptions) -> io::Result<File> {
+    apply_private_file_mode(options);
+    let file = options.open(path)?;
+    set_private_file_permissions(path)?;
+    Ok(file)
+}
+
+#[cfg(unix)]
+fn create_private_dir_all_unix(path: &Path) -> io::Result<()> {
+    use std::os::unix::fs::{DirBuilderExt, PermissionsExt};
+
+    let mut current = PathBuf::new();
+    for component in path.components() {
+        current.push(component.as_os_str());
+        if current.as_os_str().is_empty() {
+            continue;
+        }
+
+        match fs::metadata(&current) {
+            Ok(metadata) if metadata.is_dir() => continue,
+            Ok(_) => {
+                return Err(io::Error::new(
+                    io::ErrorKind::AlreadyExists,
+                    format!("{} exists and is not a directory", current.display()),
+                ));
+            }
+            Err(error) if error.kind() == io::ErrorKind::NotFound => {
+                let mut builder = fs::DirBuilder::new();
+                builder.mode(PRIVATE_DIR_MODE);
+                match builder.create(&current) {
+                    Ok(()) => {
+                        fs::set_permissions(
+                            &current,
+                            fs::Permissions::from_mode(PRIVATE_DIR_MODE),
+                        )?;
+                    }
+                    Err(error) if error.kind() == io::ErrorKind::AlreadyExists => {
+                        if !current.is_dir() {
+                            return Err(io::Error::new(
+                                io::ErrorKind::AlreadyExists,
+                                format!("{} exists and is not a directory", current.display()),
+                            ));
+                        }
+                    }
+                    Err(error) => return Err(error),
+                }
+            }
+            Err(error) => return Err(error),
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(unix)]
+fn apply_private_file_mode(options: &mut OpenOptions) {
+    use std::os::unix::fs::OpenOptionsExt;
+
+    options.mode(PRIVATE_FILE_MODE);
+}
+
+#[cfg(not(unix))]
+fn apply_private_file_mode(_options: &mut OpenOptions) {}
+
+#[cfg(unix)]
+fn set_private_file_permissions(path: &Path) -> io::Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+
+    fs::set_permissions(path, fs::Permissions::from_mode(PRIVATE_FILE_MODE))
+}
+
+#[cfg(not(unix))]
+fn set_private_file_permissions(_path: &Path) -> io::Result<()> {
+    Ok(())
 }

--- a/crates/orbit-common/src/utility/logging.rs
+++ b/crates/orbit-common/src/utility/logging.rs
@@ -31,9 +31,7 @@
 
 use std::{
     collections::BTreeMap,
-    fmt as std_fmt,
-    fs::{self, OpenOptions},
-    io,
+    fmt as std_fmt, io,
     path::{Path, PathBuf},
     sync::OnceLock,
 };
@@ -58,7 +56,10 @@ use tracing_subscriber::{
     util::SubscriberInitExt,
 };
 
-use super::redaction;
+use super::{
+    fs::{append_private_file, create_private_dir_all},
+    redaction,
+};
 
 static FILE_GUARD: OnceLock<WorkerGuard> = OnceLock::new();
 
@@ -423,7 +424,7 @@ where
     S: tracing::Subscriber + for<'lookup> LookupSpan<'lookup>,
 {
     if let Some(parent) = path.parent() {
-        fs::create_dir_all(parent).map_err(|err| {
+        create_private_dir_all(parent).map_err(|err| {
             io::Error::new(
                 err.kind(),
                 format!(
@@ -434,16 +435,12 @@ where
         })?;
     }
 
-    let file = OpenOptions::new()
-        .create(true)
-        .append(true)
-        .open(path)
-        .map_err(|err| {
-            io::Error::new(
-                err.kind(),
-                format!("cannot open JSONL tracing log {}: {err}", path.display()),
-            )
-        })?;
+    let file = append_private_file(path).map_err(|err| {
+        io::Error::new(
+            err.kind(),
+            format!("cannot open JSONL tracing log {}: {err}", path.display()),
+        )
+    })?;
     let (writer, guard) = tracing_appender::non_blocking(file);
     let layer = fmt::layer()
         .event_format(RedactingJsonEventFormat)

--- a/crates/orbit-common/src/utility/tests/blob_store.rs
+++ b/crates/orbit-common/src/utility/tests/blob_store.rs
@@ -91,6 +91,22 @@ fn caller_redaction_can_add_stronger_patterns() {
     assert_eq!(hash, sha256_hex(expected.as_bytes()));
 }
 
+#[cfg(unix)]
+#[test]
+fn write_creates_private_blob_file_and_dirs() {
+    let temp = tempdir().expect("tempdir");
+    let root = temp.path().join("audit").join("blobs");
+    let store = BlobStore::new(&root);
+
+    let hash = store.write(b"audit payload").expect("write blob");
+    let shard_dir = root.join(&hash[..2]);
+    let blob_path = shard_dir.join(&hash);
+
+    assert_eq!(mode(&blob_path), 0o600);
+    assert_eq!(mode(&root), 0o700);
+    assert_eq!(mode(&shard_dir), 0o700);
+}
+
 fn sha256_hex(bytes: &[u8]) -> String {
     let mut hasher = Sha256::new();
     hasher.update(bytes);
@@ -100,4 +116,15 @@ fn sha256_hex(bytes: &[u8]) -> String {
         out.push_str(&format!("{:02x}", byte));
     }
     out
+}
+
+#[cfg(unix)]
+fn mode(path: &std::path::Path) -> u32 {
+    use std::os::unix::fs::PermissionsExt;
+
+    std::fs::metadata(path)
+        .expect("metadata")
+        .permissions()
+        .mode()
+        & 0o777
 }

--- a/crates/orbit-common/src/utility/tests/logging.rs
+++ b/crates/orbit-common/src/utility/tests/logging.rs
@@ -406,6 +406,28 @@ mod subscriber {
         assert_eq!(appended["fields"]["line"], "after-sentinel");
     }
 
+    #[cfg(unix)]
+    #[test]
+    fn jsonl_file_and_created_state_dirs_are_private() {
+        let _env = ENV_LOCK.lock().expect("lock env");
+        let _rust_log = EnvVarGuard::remove("RUST_LOG");
+        let dir = tempdir().expect("tempdir");
+        let orbit_dir = dir.path().join(".orbit");
+        let state_dir = orbit_dir.join("state");
+        let log_dir = state_dir.join("logs");
+        let log_path = log_dir.join("orbit.jsonl");
+
+        with_test_subscriber_at_path("info", &log_path, io::sink, || {
+            tracing::info!(line = "private-log");
+        })
+        .expect("subscriber should run");
+
+        assert_eq!(mode(&log_path), 0o600);
+        assert_eq!(mode(&orbit_dir), 0o700);
+        assert_eq!(mode(&state_dir), 0o700);
+        assert_eq!(mode(&log_dir), 0o700);
+    }
+
     #[test]
     fn file_layer_failure_falls_back_to_stderr_layer() {
         let _env = ENV_LOCK.lock().expect("lock env");
@@ -427,5 +449,12 @@ mod subscriber {
             .expect("stderr utf8");
         assert!(stderr_text.contains("failed to initialize JSONL tracing log"));
         assert!(stderr_text.contains("stderr-still-works"));
+    }
+
+    #[cfg(unix)]
+    fn mode(path: &std::path::Path) -> u32 {
+        use std::os::unix::fs::PermissionsExt;
+
+        fs::metadata(path).expect("metadata").permissions().mode() & 0o777
     }
 }


### PR DESCRIPTION
## Task

[ORB-00368](https://orbit-cli.com/tasks/ORB-00368) — Audit blob and JSONL log files written world-readable (default umask), no permission hardening

### Description

## Problem
Blob files are created with OpenOptions::new().write(true).create_new(true) (no mode set) and the JSONL tracing feed at $HOME/.orbit/state/logs/orbit.jsonl is created with OpenOptions::new().create(true).append(true) (no mode set); on Unix both inherit the process umask (typically 0644, world-readable). The atomic_write helpers in fs.rs only copy permissions from a pre-existing target and otherwise leave new files at umask defaults. No PermissionsExt/0o600 hardening exists anywhere in orbit-common. These files hold audit payloads and run-trace events that always contain operational/PII context (home paths are never scrubbed by redact_all) and, given the redaction gaps above, frequently contain residual secrets.

## Why It Matters / Exploit Scenario
On a shared/multi-user host (CI runner, build server, multi-user dev box) with default umask, Orbit runs as user A and writes ~A/.orbit/state/audit/blobs/** and ~A/.orbit/state/logs/orbit.jsonl mode 0644. If the home tree is traversable (common on multi-user setups, or files placed in a shared CI workspace), local user B reads them directly, harvesting full command/run context, home paths, and any secret that slipped past redaction. Combined with the redaction gaps this turns incomplete redaction into actual cross-user credential disclosure.

## Remediation
Create the .orbit state dirs with 0o700 and these files with 0o600 on Unix (OpenOptionsExt::mode(0o600) for files; set dir perms on creation). Treat audit blobs and the JSONL feed as secret-bearing by default rather than relying on umask.

## Affected Locations
- `crates/orbit-common/src/utility/blob_store.rs:55`
- `crates/orbit-common/src/utility/logging.rs:437`
- `crates/orbit-common/src/utility/fs.rs:52`

## Metadata
- **Severity:** Low
- **CWE:** CWE-276
- **Surface:** Blob storage + global JSONL tracing log on disk
- **Source:** Automated multi-agent security audit (2026-06-06), double-verified (2 independent adversarial reviewers confirmed exploitability + technical correctness).

### Acceptance Criteria

- Audit blob files, the JSONL tracing feed, and the .orbit state dirs are created with restrictive permissions on Unix (0o600 files / 0o700 dirs) rather than inheriting the umask.
- A unix-gated test asserts a newly written blob and the JSONL log file have mode 0o600 (no group/other read).
- make ci-fast passes.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Added Unix-only private file/directory helpers in `orbit-common::utility::fs`: new sensitive files are opened/chmodded to `0o600`, newly created private directory components are chmodded to `0o700`, and atomic write/lock helpers use those defaults while preserving permissions for existing atomic-write targets.
- Switched audit blob writes and JSONL tracing log creation to the private helpers so blob shards/log state dirs no longer inherit permissive umask defaults.
- Added Unix-gated tests asserting newly written blob and JSONL log files are `0o600`, with created blob/log state directories at `0o700`.

Assessment: The scoped security hardening is implemented in `orbit-common`, keeps Windows behavior unchanged, and is covered by focused Unix permission tests plus the repo fast gate.

Validation:
- `cargo test -p orbit-common utility::tests::blob_store::write_creates_private_blob_file_and_dirs`
- `cargo test -p orbit-common utility::tests::logging::subscriber::jsonl_file_and_created_state_dirs_are_private`
- `cargo test -p orbit-common utility::tests`
- `cargo test -p orbit-common`
- `make ci-fast`

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-00368-6a247329`
- Behind base: 0
- Ahead of base: 1