### PR TITLE
Error and bytes fields recorded via tracing bypass redaction (record_error/record_bytes)

### DIFF
--- a/crates/orbit-common/src/utility/logging.rs
+++ b/crates/orbit-common/src/utility/logging.rs
@@ -25,9 +25,10 @@
 //!
 //! Redaction integration: both the stderr formatter and global JSONL formatter
 //! use [`RedactingFields`], which applies [`super::redaction::redact_all`] to
-//! string field values, `Debug`-formatted values, and unstructured `message`
-//! text before output is written. [`redact_event_text`] remains available for
-//! non-tracing surfaces that must scrub text before writing it elsewhere.
+//! string field values, `Error` chains, byte slices, `Debug`-formatted values,
+//! and unstructured `message` text before output is written.
+//! [`redact_event_text`] remains available for non-tracing surfaces that must
+//! scrub text before writing it elsewhere.
 
 use std::{
     collections::BTreeMap,
@@ -237,17 +238,31 @@ where
     }
 
     fn record_bytes(&mut self, field: &Field, value: &[u8]) {
-        self.inner.record_bytes(field, value);
+        let decoded = String::from_utf8_lossy(value);
+        let redacted = redaction::redact_all(decoded.as_ref());
+        self.inner.record_str(field, &redacted);
     }
 
     fn record_error(&mut self, field: &Field, value: &(dyn std::error::Error + 'static)) {
-        self.inner.record_error(field, value);
+        let redacted = redaction::redact_all(&format_error_chain(value));
+        self.inner.record_str(field, &redacted);
     }
 
     fn record_debug(&mut self, field: &Field, value: &dyn std_fmt::Debug) {
         let redacted = redaction::redact_all(&format!("{value:?}"));
         self.inner.record_debug(field, &RedactedDebug(redacted));
     }
+}
+
+fn format_error_chain(value: &(dyn std::error::Error + 'static)) -> String {
+    let mut formatted = value.to_string();
+    let mut source = value.source();
+    while let Some(error) = source {
+        formatted.push_str(": ");
+        formatted.push_str(&error.to_string());
+        source = error.source();
+    }
+    formatted
 }
 
 impl<V> VisitOutput<std_fmt::Result> for RedactingVisitor<V>

--- a/crates/orbit-common/src/utility/tests/logging.rs
+++ b/crates/orbit-common/src/utility/tests/logging.rs
@@ -170,12 +170,25 @@ impl Drop for EnvVarGuard {
 }
 
 mod redaction {
-    use std::{ffi::OsString, io};
+    use std::{ffi::OsString, fmt, io};
 
     use tempfile::tempdir;
 
     use super::super::super::logging::*;
-    use super::{ENV_LOCK, EnvVarGuard, read_jsonl_values, with_test_subscriber_at_path};
+    use super::{
+        BufferMakeWriter, ENV_LOCK, EnvVarGuard, read_jsonl_values, with_test_subscriber_at_path,
+    };
+
+    #[derive(Debug)]
+    struct SecretDisplayError;
+
+    impl fmt::Display for SecretDisplayError {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            f.write_str("request failed with Authorization: Bearer error-secret")
+        }
+    }
+
+    impl std::error::Error for SecretDisplayError {}
 
     #[test]
     fn jsonl_redacting_fields_preserves_typed_values_and_redacts_strings() {
@@ -274,6 +287,60 @@ mod redaction {
             .expect("payload is string");
         assert!(payload.contains("[REDACTED_AUTH]"));
         assert!(!payload.contains("abc456"));
+    }
+
+    #[test]
+    fn redacting_fields_redacts_bare_error_values() {
+        let _env = ENV_LOCK.lock().expect("lock env");
+        let _rust_log = EnvVarGuard::remove("RUST_LOG");
+        let dir = tempdir().expect("tempdir");
+        let log_path = dir.path().join("orbit.jsonl");
+        let stderr = BufferMakeWriter::default();
+        let stderr_buffer = stderr.buffer();
+
+        with_test_subscriber_at_path("info", &log_path, stderr, || {
+            let error = SecretDisplayError;
+            tracing::error!(
+                error = &error as &(dyn std::error::Error + 'static),
+                "operation failed"
+            );
+        })
+        .expect("subscriber should run");
+
+        let stderr_text = String::from_utf8(stderr_buffer.lock().expect("stderr lock").clone())
+            .expect("stderr utf8");
+        assert!(stderr_text.contains("[REDACTED_AUTH]"));
+        assert!(!stderr_text.contains("error-secret"));
+
+        let values = read_jsonl_values(&log_path);
+        assert_eq!(values.len(), 1);
+        let error = values[0]["fields"]["error"]
+            .as_str()
+            .expect("error is string");
+        assert!(error.contains("[REDACTED_AUTH]"));
+        assert!(!error.contains("error-secret"));
+    }
+
+    #[test]
+    fn jsonl_redacting_fields_redacts_byte_values() {
+        let _env = ENV_LOCK.lock().expect("lock env");
+        let _rust_log = EnvVarGuard::remove("RUST_LOG");
+        let dir = tempdir().expect("tempdir");
+        let log_path = dir.path().join("orbit.jsonl");
+
+        with_test_subscriber_at_path("info", &log_path, io::sink, || {
+            let payload = b"Authorization: Bearer byte-secret".as_slice();
+            tracing::info!(payload = payload);
+        })
+        .expect("subscriber should run");
+
+        let values = read_jsonl_values(&log_path);
+        assert_eq!(values.len(), 1);
+        let payload = values[0]["fields"]["payload"]
+            .as_str()
+            .expect("payload is string");
+        assert!(payload.contains("[REDACTED_AUTH]"));
+        assert!(!payload.contains("byte-secret"));
     }
 
     #[test]


### PR DESCRIPTION
## Task

[ORB-00367](https://orbit-cli.com/tasks/ORB-00367) — Error and bytes fields recorded via tracing bypass redaction (record_error/record_bytes)

### Description

## Problem
RedactingVisitor redacts string fields (record_str) and Debug fields (record_debug) via redact_all, but record_error forwards the &dyn std::error::Error straight to the inner visitor with no redaction, and record_bytes is likewise forwarded unredacted. Worse, by explicitly overriding record_error to delegate to self.inner.record_error, the code defeats its own redaction: had it not overridden it, tracing-core's default record_error would have routed through RedactingVisitor's own redacting record_debug. Instead it reaches the inner formatter's non-redacting record_debug (DefaultVisitor for text, JsonFieldVisitor for JSON, which does not override record_error). Any tracing call recording an error via the bare `error = <ident>` value form writes the error's Display/Debug verbatim to both stderr and the JSONL feed.

## Why It Matters / Exploit Scenario
A developer adds (or a future refactor introduces) `tracing::error!(error = some_err, "...")` where some_err implements std::error::Error and its Display/Debug embeds a secret (an HTTP error echoing an Authorization header, or an OrbitError wrapping subprocess output containing a token). The secret is written to ~/.orbit/state/logs/orbit.jsonl in cleartext, silently bypassing the redaction layer. Latent today: all current error-logging call sites use the %/? sigil forms (which are redacted), so there is no reachable trigger in the present code.

## Remediation
Implement record_error in RedactingVisitor to redact: format the error chain to a String, apply redact_all, and forward via record_str. Apply the same treatment to record_bytes (lossy-decode + redact, or drop). This closes the bypass so redaction holds for every field shape.

## Affected Locations
- `crates/orbit-common/src/utility/logging.rs:242`
- `crates/orbit-common/src/utility/logging.rs:238`

## Metadata
- **Severity:** Low
- **CWE:** CWE-532
- **Surface:** Logging / tracing redaction layer
- **Source:** Automated multi-agent security audit (2026-06-06), double-verified (2 independent adversarial reviewers confirmed exploitability + technical correctness).

### Acceptance Criteria

- RedactingVisitor implements record_error (format the error chain to a String, apply redact_all, forward via record_str) and redacts record_bytes (lossy-decode + redact, or drop) in crates/orbit-common/src/utility/logging.rs.
- A unit test in the sibling tests/ dir records an error whose Display embeds a secret pattern and asserts the emitted log line is redacted.
- make ci-fast passes.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Updated `RedactingVisitor` so `record_error` formats the error source chain, redacts it, and forwards through `record_str`.
- Updated `record_bytes` to lossily decode bytes, redact the decoded text, and forward through `record_str`.
- Added sibling logging tests covering bare error-field redaction in stderr and JSONL, plus byte-field redaction in JSONL.

Assessment: Focused security fix; targeted tests and `make ci-fast` pass.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-00367-6a248170`
- Behind base: 0
- Ahead of base: 1