### PR TITLE
Pattern redactor misses major provider/SCM/cloud key formats (Google/Gemini, GitLab, fine-grained GitHub, AWS, npm, connection-string passwords)

### DIFF
--- a/crates/orbit-common/src/utility/redaction.rs
+++ b/crates/orbit-common/src/utility/redaction.rs
@@ -244,6 +244,45 @@ impl PatternRedactor {
                 "[REDACTED_SECRET]",
             ),
             (
+                Regex::new(r"AIza[0-9A-Za-z_\-]{35}").expect("valid regex"),
+                "[REDACTED_SECRET]",
+            ),
+            (
+                Regex::new(r"glpat-[A-Za-z0-9_\-]{20,}").expect("valid regex"),
+                "[REDACTED_SECRET]",
+            ),
+            (
+                Regex::new(r"github_pat_[A-Za-z0-9_]{22,}").expect("valid regex"),
+                "[REDACTED_SECRET]",
+            ),
+            (
+                Regex::new(r"gh[opsur]_[A-Za-z0-9]{36,}").expect("valid regex"),
+                "[REDACTED_SECRET]",
+            ),
+            (
+                Regex::new(r"AKIA[0-9A-Z]{16}").expect("valid regex"),
+                "[REDACTED_SECRET]",
+            ),
+            (
+                Regex::new(r#"(?i)("aws[_-]?secret[_-]?access[_-]?key"\s*:\s*")[^"]*""#)
+                    .expect("valid regex"),
+                "${1}[REDACTED_SECRET]\"",
+            ),
+            (
+                Regex::new(r"(?i)\b(aws[_-]?secret[_-]?access[_-]?key\s*=\s*)[^&\s]+")
+                    .expect("valid regex"),
+                "${1}[REDACTED_SECRET]",
+            ),
+            (
+                Regex::new(r"npm_[A-Za-z0-9]{36}").expect("valid regex"),
+                "[REDACTED_SECRET]",
+            ),
+            (
+                Regex::new(r"([A-Za-z][A-Za-z0-9+.\-]*://[^/\s:@?#]+:)[^@\s/?#]+(@)")
+                    .expect("valid regex"),
+                "${1}[REDACTED_SECRET]${2}",
+            ),
+            (
                 Regex::new(r"ghp_[A-Za-z0-9]{36}").expect("valid regex"),
                 "[REDACTED_SECRET]",
             ),
@@ -333,6 +372,18 @@ fn high_confidence_single_token_patterns() -> &'static [Regex] {
         .get_or_init(|| {
             vec![
                 Regex::new(r"^sk-[A-Za-z0-9_\-]{20,}$").expect("valid regex"),
+                Regex::new(r"^AIza[0-9A-Za-z_\-]{35}$").expect("valid regex"),
+                Regex::new(r"^glpat-[A-Za-z0-9_\-]{20,}$").expect("valid regex"),
+                Regex::new(r"^github_pat_[A-Za-z0-9_]{22,}$").expect("valid regex"),
+                Regex::new(r"^gh[opsur]_[A-Za-z0-9]{36,}$").expect("valid regex"),
+                Regex::new(r"^AKIA[0-9A-Z]{16}$").expect("valid regex"),
+                Regex::new(r"(?i)^aws[_-]?secret[_-]?access[_-]?key=[^&\s]+$")
+                    .expect("valid regex"),
+                Regex::new(r"^npm_[A-Za-z0-9]{36}$").expect("valid regex"),
+                Regex::new(
+                    r"^[A-Za-z][A-Za-z0-9+.\-]*://[^/\s:@?#]+:[^@\s/?#]+@[^/\s?#]+(?:[/?#]\S*)?$",
+                )
+                .expect("valid regex"),
                 Regex::new(r"^ghp_[A-Za-z0-9]{36}$").expect("valid regex"),
                 Regex::new(r"^xox[baprs]-[A-Za-z0-9\-]{10,}$").expect("valid regex"),
             ]

--- a/crates/orbit-common/src/utility/tests/redaction.rs
+++ b/crates/orbit-common/src/utility/tests/redaction.rs
@@ -1,4 +1,4 @@
-use super::super::redaction::redact_all;
+use super::super::redaction::{is_high_confidence_single_token_credential, redact_all};
 
 #[test]
 fn redact_all_scrubs_key_query_params_case_insensitively() {
@@ -14,4 +14,81 @@ fn redact_all_scrubs_key_query_params_case_insensitively() {
     assert!(!redacted.contains("second-secret"));
     assert!(redacted.contains("?key=[REDACTED_AUTH]&alt=sse"));
     assert!(redacted.contains("&KEY=[REDACTED_AUTH]"));
+}
+
+#[test]
+fn redact_all_scrubs_provider_scm_cloud_tokens_and_connection_passwords() {
+    let google = format!("AIza{}", "A".repeat(35));
+    let gitlab = format!("glpat-{}", "B".repeat(20));
+    let github_fine_grained = format!("github_pat_{}", "C".repeat(22));
+    let github_oauth = format!("gho_{}", "D".repeat(36));
+    let github_classic = format!("ghp_{}", "E".repeat(36));
+    let github_server = format!("ghs_{}", "F".repeat(36));
+    let github_user_server = format!("ghu_{}", "G".repeat(36));
+    let github_refresh = format!("ghr_{}", "H".repeat(36));
+    let aws_access_key_id = format!("AKIA{}", "1".repeat(16));
+    let aws_secret_key = "aws_secret_access_key=awsSecretAccessKeyFixtureValue1234567890";
+    let npm = format!("npm_{}", "I".repeat(36));
+    let connection_string = "postgres://orbit_user:connection-pass@db.example.test/orbit";
+
+    let raw = format!(
+        "google={google}\n\
+         gitlab={gitlab}\n\
+         github_fine_grained={github_fine_grained}\n\
+         github_oauth={github_oauth}\n\
+         github_classic={github_classic}\n\
+         github_server={github_server}\n\
+         github_user_server={github_user_server}\n\
+         github_refresh={github_refresh}\n\
+         aws_access_key_id={aws_access_key_id}\n\
+         {aws_secret_key}\n\
+         npm={npm}\n\
+         dsn={connection_string}"
+    );
+
+    let redacted = redact_all(&raw);
+
+    for secret in [
+        google.as_str(),
+        gitlab.as_str(),
+        github_fine_grained.as_str(),
+        github_oauth.as_str(),
+        github_classic.as_str(),
+        github_server.as_str(),
+        github_user_server.as_str(),
+        github_refresh.as_str(),
+        aws_access_key_id.as_str(),
+        "awsSecretAccessKeyFixtureValue1234567890",
+        npm.as_str(),
+        "connection-pass",
+    ] {
+        assert!(!redacted.contains(secret), "{secret} was not redacted");
+    }
+
+    assert!(redacted.contains("postgres://orbit_user:[REDACTED_SECRET]@db.example.test/orbit"));
+}
+
+#[test]
+fn high_confidence_single_token_detection_covers_provider_scm_cloud_families() {
+    let credentials = [
+        format!("AIza{}", "A".repeat(35)),
+        format!("glpat-{}", "B".repeat(20)),
+        format!("github_pat_{}", "C".repeat(22)),
+        format!("gho_{}", "D".repeat(36)),
+        format!("ghp_{}", "E".repeat(36)),
+        format!("ghs_{}", "F".repeat(36)),
+        format!("ghu_{}", "G".repeat(36)),
+        format!("ghr_{}", "H".repeat(36)),
+        format!("AKIA{}", "1".repeat(16)),
+        "aws_secret_access_key=awsSecretAccessKeyFixtureValue1234567890".to_string(),
+        format!("npm_{}", "I".repeat(36)),
+        "postgres://orbit_user:connection-pass@db.example.test".to_string(),
+    ];
+
+    for credential in credentials {
+        assert!(
+            is_high_confidence_single_token_credential(&credential),
+            "{credential} was not classified as a high-confidence credential"
+        );
+    }
 }


### PR DESCRIPTION
## Task

[ORB-00359](https://orbit-cli.com/tasks/ORB-00359) — Pattern redactor misses major provider/SCM/cloud key formats (Google/Gemini, GitLab, fine-grained GitHub, AWS, npm, connection-string passwords)

### Description

## Problem
PatternRedactor::http_default only matches quoted authorization/x-api-key/api_key JSON, Bearer [REDACTED_AUTH], header-line forms, and three bare-token shapes (sk-..., ghp_<36>, xox[baprs]-...). is_high_confidence_single_token_credential only anchors sk-/ghp_/xox. This pattern set is the last line of defense for any secret NOT present in the orchestrator's own live environment (env-value scrubbing in redact_sensitive_env_text only replaces values seen in std::env::vars). Empirically verified that Google/Gemini keys (AIza...), GitLab PATs (glpat-...), fine-grained GitHub PATs (github_pat_...) and gh[souru]_ token families, AWS access key IDs (AKIA...) and secret keys, npm tokens (npm_...), and passwords embedded in connection strings (postgres://user:pass@host) all pass through unredacted. Gemini is a first-class Orbit provider (AgentFamily::Gemini, GEMINI_API_KEY). orbit-core artifact_redaction.rs relies entirely on this module, so the gaps propagate to persisted tool artifacts, audit events, the tracing JSONL feed, and the dashboard diagnostics view.

## Why It Matters / Exploit Scenario
An agent in the untrusted loop runs a command whose output or a file it reads contains a non-covered credential (a Gemini AIza... key from `env | grep -i key` or a teammate's .env, a glpat-/AKIA.../npm_ token in a replicated registry payload, or a postgres://user:pass@host string) that is not present in the orchestrator's own environment. The text flows through tracing (RedactingVisitor::record_str -> redact_all) into ~/.orbit/state/logs/orbit.jsonl and/or through artifact_redaction.rs into persisted task/learning/ADR artifacts and audit blobs. No pattern matches, so the credential is written and persisted in cleartext and served back through the dashboard diagnostics/runs views, leaking third-party credentials to anyone who can read those files or reach the local dashboard.

## Remediation
Add high-precision anchored patterns for the missing first-class formats to both http_default() and is_high_confidence_single_token_credential: Google (AIza[0-9A-Za-z_\-]{35}), GitLab (glpat-...), fine-grained GitHub (github_pat_...) and gh[opsur]_[A-Za-z0-9]{36,}, AWS (AKIA[0-9A-Z]{16} plus aws_secret_access_key= forms), npm_[A-Za-z0-9]{36}, and connection-string credentials (scheme://user:PASS@). Add sibling unit tests asserting each format is scrubbed.

## Affected Locations
- `crates/orbit-common/src/utility/redaction.rs:208`
- `crates/orbit-common/src/utility/redaction.rs:313`
- `crates/orbit-common/src/utility/redaction.rs:327`

## Metadata
- **Severity:** Medium
- **CWE:** CWE-312
- **Surface:** Redaction (tracing logs, run-trace JSONL, audit blobs, artifact redaction)
- **Source:** Automated multi-agent security audit (2026-06-06), double-verified (2 independent adversarial reviewers confirmed exploitability + technical correctness).

### Acceptance Criteria

- PatternRedactor::http_default and is_high_confidence_single_token_credential recognize Google/Gemini (AIza...), GitLab (glpat-...), fine-grained GitHub (github_pat_...) and gh[opsur]_ token families, AWS (AKIA... + secret-key forms), npm_ tokens, and connection-string passwords (scheme://user:PASS@host).
- New unit tests in the sibling tests/ dir assert each of the above formats is scrubbed by redact_all.
- make ci-fast passes.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Added default redaction patterns for Google/Gemini `AIza` keys, GitLab `glpat` tokens, GitHub fine-grained and `gh[opsur]` token families, AWS access key IDs, AWS secret-access-key assignment/JSON forms, npm tokens, and connection-string passwords.
- Kept whole-token credential detection aligned with those high-confidence formats so persistence guards can reject them when they appear alone.
- Added sibling redaction tests covering scrub behavior through `redact_all` and whole-token classification for the expanded families.

Assessment: Targeted security hardening is implemented in the shared redaction module and validated with focused unit tests plus the repository-required fast CI gate.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-00359-6a248170`
- Behind base: 0
- Ahead of base: 1