### PR TITLE
fix: learning list/show prefer canonical self.root over stale worktree body_path [ORB-00373]

### DIFF
--- a/crates/orbit-store/src/file/learning_store/api/crud.rs
+++ b/crates/orbit-store/src/file/learning_store/api/crud.rs
@@ -234,8 +234,21 @@ impl LearningFileStore {
         &self,
         record: &IdAllocationRecord,
     ) -> Result<Option<Learning>, OrbitError> {
+        // ORB-00373: the canonical copy under `self.root` is the source of
+        // truth (docs/design/project-learnings/2_design.md). Resolve it FIRST,
+        // ahead of the allocator's recorded `body_path`. A learning first
+        // allocated inside a job-run worktree records that worktree's path; a
+        // later supersede/update/sync rewrites only the canonical `self.root`
+        // copy (+ the SQLite index), leaving stale worktree copies behind. If
+        // we read the recorded `body_path` first, `list`/`show` report
+        // superseded learnings as active (F2026-06-001). The `body_path` is a
+        // fallback only for learnings genuinely absent from `self.root`
+        // (sibling-worktree / remote stubs).
+        if let Some(local) = self.get_learning(&record.id)? {
+            return Ok(Some(local));
+        }
         let Some(path) = record.resolved_body_path() else {
-            return self.get_learning(&record.id);
+            return Ok(None);
         };
         if !path.is_file() {
             return Ok(None);

--- a/crates/orbit-store/src/file/learning_store/api/tests/crud.rs
+++ b/crates/orbit-store/src/file/learning_store/api/tests/crud.rs
@@ -238,6 +238,83 @@ fn shared_allocator_assigns_distinct_learning_ids_across_divergent_worktrees() {
 }
 
 #[test]
+fn canonical_self_root_copy_wins_over_stale_worktree_body_path() {
+    // F2026-06-001 / ORB-00373. A learning first allocated inside a job-run
+    // worktree records that worktree's `body_path` in the shared allocator. A
+    // later supersede/update rewrites only the canonical `self.root` copy,
+    // leaving the worktree copy active. `list`/`show` must report the canonical
+    // (superseded) status — the YAML under `self.root` is the source of truth —
+    // not the stale worktree copy the allocator points at.
+    let dir = tempdir().expect("tempdir");
+    let shared_orbit = dir.path().join("shared/.orbit");
+    let worktree_a = dir.path().join("worktree-a"); // canonical store we operate from
+    let worktree_b = dir.path().join("worktree-b"); // stale allocator-recorded copy
+    std::fs::create_dir_all(shared_orbit.join("learnings")).expect("shared learnings");
+    std::fs::create_dir_all(worktree_a.join(".orbit/learnings")).expect("worktree a");
+    std::fs::create_dir_all(worktree_b.join(".orbit/learnings")).expect("worktree b");
+
+    // Allocate from worktree-b so the shared allocator records the body_path
+    // against worktree-b's copy (which stays active).
+    let store_b = learning_store_for_worktree(&shared_orbit, &worktree_b);
+    let learning = store_b
+        .create_learning(create_params(
+            "case identity rule",
+            vec!["crates/**"],
+            vec!["macos"],
+        ))
+        .expect("create in worktree-b");
+
+    // Canonical copy under worktree-a (the store we operate) is superseded,
+    // while worktree-b's allocator-recorded copy remains active — the exact
+    // on-disk divergence observed in the field.
+    let canonical = worktree_a
+        .join(".orbit/learnings")
+        .join(&learning.id)
+        .join("learning.yaml");
+    std::fs::create_dir_all(canonical.parent().expect("canonical parent")).expect("canonical dir");
+    std::fs::write(
+        &canonical,
+        super::test_support::legacy_learning_yaml(
+            &learning.id,
+            "superseded",
+            "case identity rule",
+            1,
+        ),
+    )
+    .expect("write superseded canonical copy");
+
+    let store_a = learning_store_for_worktree(&shared_orbit, &worktree_a);
+
+    // `show` (federated) must reflect the canonical superseded status.
+    let shown = store_a
+        .get_learning_federated(&learning.id)
+        .expect("federated get")
+        .expect("present");
+    assert_eq!(
+        shown.status,
+        LearningStatus::Superseded,
+        "federated get must prefer the canonical self.root copy, not the stale worktree body_path",
+    );
+
+    // `list --status active` must exclude it; `list --status superseded` must
+    // include it as a Local entry.
+    let active = store_a
+        .list_learning_entries(Some(LearningStatus::Active), false)
+        .expect("active entries");
+    assert!(
+        !entry_has_id(&active, &learning.id),
+        "superseded learning must not appear under --status active",
+    );
+    let superseded = store_a
+        .list_learning_entries(Some(LearningStatus::Superseded), false)
+        .expect("superseded entries");
+    assert!(
+        entry_is_local(&superseded, &learning.id),
+        "superseded learning must appear (Local) under --status superseded",
+    );
+}
+
+#[test]
 fn learnings_index_partial_index_present_after_apply_schema() {
     let store = Store::open_in_memory().expect("open in-memory store");
     let conn_arc = store.connection();


### PR DESCRIPTION
## Task
[ORB-00373] — `orbit learning list`/`show` report superseded learnings as active (`type: bug`). Resolves friction **F2026-06-001**.

## Problem
After `orbit learning supersede L-0061 --with L-0062`, the canonical `.orbit/learnings/L-0061/learning.yaml` is correctly `superseded`, yet `orbit learning show L-0061` and `orbit learning list --status active` still report it **active** (and `--status superseded` omits it).

## Root cause (verified)
The learning read surface resolves bodies through the **ID-allocator's recorded `body_path`** (`worktree_root.join(body_path)`) *before* the canonical `self.root` copy:
- `list_learning_entries` iterates allocator records → `read_learning_allocation`, which read the recorded `body_path` first.
- `get_learning_federated` (used by `show`) delegates to the same.

A learning first allocated **inside a job-run worktree** records that worktree's path. `supersede`/`update`/`sync` rewrite only the canonical `self.root` copy (+ the SQLite index). The repo had **six** on-disk copies of `L-0061/learning.yaml`: the canonical one (`superseded`) and five stale copies in leftover failed-run worktrees under `.orbit/state/worktrees/orbit-jrun-*` (all `active`). Reads surfaced a stale worktree copy — contradicting the documented invariant (`docs/design/project-learnings/2_design.md`: *"The YAML files are the source of truth"*).

> The leftover worktrees are themselves fallout of the `(?i)` SBPL bug (ORB-00372 / #495), whose failed runs never cleaned up.

## Fix
`read_learning_allocation` resolves the canonical `self.root` copy **first** (`get_learning`), using the allocator-recorded `body_path` only when the learning is absent locally (genuinely remote / sibling-worktree stubs). The remote-federation model is unchanged.

## Scope correction to F2026-06-001
The friction claimed the superseded learning "keeps push-injecting" and that `orbit learning sync` fails to reconcile. **That was over-stated.** Verified the index/injection path is correct: `supersede` upserts the index, `orbit search --kind learning` (the injection read path) excludes the superseded learning, and `sync` rebuilds the index from `self.root`. The defect was confined to the **allocator-based CLI read surface**; push-injection to agents was unaffected.

## Validation
- `cargo test -p orbit-store`: **207 passed / 0 failed**, including:
  - new `canonical_self_root_copy_wins_over_stale_worktree_body_path` (reproduces the divergence; fails without the fix);
  - unchanged `shared_allocator_assigns_distinct_learning_ids_across_divergent_worktrees` (remote federation still works).
- `make fmt` clean; `make ci-fast` passes.

## Notes / follow-ups
- Runtime hygiene: leftover `.orbit/state/worktrees/orbit-jrun-*` from failed runs aren't GC'd — separate task; the fix is robust to them regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
