### PR TITLE
Non-UTF-8 audit blobs bypass all mandatory secret redaction

### DIFF
--- a/crates/orbit-common/src/utility/blob_store.rs
+++ b/crates/orbit-common/src/utility/blob_store.rs
@@ -72,7 +72,12 @@ impl BlobStore {
                 .extra_redactor
                 .apply_str(&redact_all(text))
                 .into_bytes(),
-            Err(_) => self.extra_redactor.apply_bytes(content),
+            Err(_) => {
+                let lossy_text = String::from_utf8_lossy(content);
+                self.extra_redactor
+                    .apply_str(&redact_all(&lossy_text))
+                    .into_bytes()
+            }
         }
     }
 

--- a/crates/orbit-common/src/utility/tests/blob_store.rs
+++ b/crates/orbit-common/src/utility/tests/blob_store.rs
@@ -76,6 +76,27 @@ fn caller_redaction_cannot_weaken_default_redaction() {
 }
 
 #[test]
+fn write_redacts_secret_patterns_in_non_utf8_blob() {
+    let temp = tempdir().expect("tempdir");
+    let store = BlobStore::new(temp.path());
+    let secret = b"nonutf-secret-token";
+    let mut raw = b"stdout prefix\nAuthorization: Bearer ".to_vec();
+    raw.extend_from_slice(secret);
+    raw.extend_from_slice(b"\ninvalid byte follows: ");
+    raw.push(0xff);
+
+    let hash = store.write(&raw).expect("write blob");
+    let stored = store.read(&hash).expect("read blob");
+    let stored_text = String::from_utf8(stored.clone()).expect("stored lossy utf8");
+    let expected = redact_all(&String::from_utf8_lossy(&raw));
+
+    assert!(!stored.windows(secret.len()).any(|window| window == secret));
+    assert!(!stored_text.contains("nonutf-secret-token"));
+    assert!(stored_text.contains("Authorization: [REDACTED_AUTH]"));
+    assert_eq!(hash, sha256_hex(expected.as_bytes()));
+}
+
+#[test]
 fn caller_redaction_can_add_stronger_patterns() {
     let temp = tempdir().expect("tempdir");
     let store = BlobStore::new(temp.path()).with_redaction(PatternRedactor::with_argv_secrets());


### PR DESCRIPTION
## Task

[ORB-00358](https://orbit-cli.com/tasks/ORB-00358) — Non-UTF-8 audit blobs bypass all mandatory secret redaction

### Description

## Problem
BlobStore::redact_for_storage only applies the mandatory env+HTTP pattern scrub (redact_all) on the UTF-8 branch. For content that is not valid UTF-8 it calls only self.extra_redactor.apply_bytes(content) and skips redact_all entirely. PatternRedactor::apply_bytes returns the bytes unchanged on non-UTF-8 input, and the default extra_redactor created by BlobStore::new is PatternRedactor::empty(). Both production sinks (orbit-agent InMemorySink and orbit-engine sqlite_sink) construct BlobStore via new() with no .with_redaction(), so the non-UTF-8 branch is a complete no-op: a blob containing even a single invalid UTF-8 byte is written verbatim with zero redaction. Validation is per-whole-blob (from_utf8 over the entire slice), so a single 0xFF byte anywhere defeats redaction for the entire payload. This is the sole redaction boundary for audit payloads; the read side (read_blob_text_best_effort via from_utf8_lossy) deliberately does not re-redact.

## Why It Matters / Exploit Scenario
A spawned provider/tool CLI emits stdout/stderr containing a secret (echoed API key, Authorization header, env dump) together with any non-UTF-8 byte (binary fragment, truncated multibyte under a non-UTF-8 locale, or a deliberately injected 0xFF byte). The cli_runner orchestrator captures the raw Vec<u8> (orchestrator.rs:170-189) and calls audit.write_blob, routing to BlobStore::write -> redact_for_storage. from_utf8 returns Err, so only the empty extra_redactor runs and the full secret is persisted verbatim under ~/.orbit/state/audit/blobs/. It is later served back through the dashboard diagnostics API and orbit run-audit/log tooling in cleartext (minus the single U+FFFD-replaced byte).

## Remediation
On the non-UTF-8 branch, still scrub: run redact_all over String::from_utf8_lossy(content) (plus the extra redactor) so env-value and HTTP/argv patterns apply regardless of encoding, or reject the blob when UTF-8 validation fails. Do not store raw bytes unredacted.

## Affected Locations
- `crates/orbit-common/src/utility/blob_store.rs:78`
- `crates/orbit-common/src/utility/blob_store.rs:30`
- `crates/orbit-common/src/utility/redaction.rs:283`

## Metadata
- **Severity:** Medium
- **CWE:** CWE-312
- **Surface:** Blob storage / audit payload persistence
- **Source:** Automated multi-agent security audit (2026-06-06), double-verified (2 independent adversarial reviewers confirmed exploitability + technical correctness).

### Acceptance Criteria

- BlobStore::redact_for_storage applies the mandatory redact_all scrub on the non-UTF-8 branch (e.g. over String::from_utf8_lossy), or rejects storing the blob when UTF-8 validation fails — raw unredacted bytes are never persisted.
- A unit test in the sibling tests/ dir writes a blob containing a known secret pattern plus an invalid UTF-8 byte (0xFF) and asserts the persisted bytes are redacted.
- make ci-fast passes.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Updated BlobStore::redact_for_storage so invalid UTF-8 blobs are lossy-decoded and still pass through mandatory redact_all() plus caller extra redaction before hashing/storage.
- Added a sibling blob_store unit test that writes an Authorization/Bearer [REDACTED_AUTH] with a 0xFF byte and verifies the persisted blob no longer contains the secret.

Assessment: Scoped security fix with focused regression coverage.

Validation:
- cargo test -p orbit-common utility::tests::blob_store --lib
- make ci-fast

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-00358-6a2cafba`
- Behind base: 0
- Ahead of base: 1