### PR TITLE
Unbounded child stdout/stderr capture enables memory-exhaustion DoS of the orchestrator

### DIFF
--- a/crates/orbit-common/src/utility/mod.rs
+++ b/crates/orbit-common/src/utility/mod.rs
@@ -4,6 +4,7 @@ pub mod git;
 pub mod glob;
 pub mod learning_session;
 pub mod logging;
+pub mod output_capture;
 pub mod path;
 pub mod process_identity;
 pub mod redaction;

--- a/crates/orbit-common/src/utility/output_capture.rs
+++ b/crates/orbit-common/src/utility/output_capture.rs
@@ -1,0 +1,59 @@
+use std::env;
+
+pub const OUTPUT_TRUNCATED_MARKER: &[u8] = b"\n[orbit: output truncated after capture limit]\n";
+
+#[derive(Debug, Clone)]
+pub struct BoundedOutputCapture {
+    bytes: Vec<u8>,
+    limit: usize,
+    truncated: bool,
+}
+
+impl BoundedOutputCapture {
+    pub fn new(limit: usize) -> Self {
+        Self {
+            bytes: Vec::new(),
+            limit,
+            truncated: false,
+        }
+    }
+
+    pub fn push(&mut self, chunk: &[u8]) -> bool {
+        if self.truncated {
+            return false;
+        }
+
+        let remaining = self.limit.saturating_sub(self.bytes.len());
+        if chunk.len() <= remaining {
+            self.bytes.extend_from_slice(chunk);
+            return false;
+        }
+
+        if remaining > 0 {
+            self.bytes.extend_from_slice(&chunk[..remaining]);
+        }
+        self.bytes.extend_from_slice(OUTPUT_TRUNCATED_MARKER);
+        self.truncated = true;
+        true
+    }
+
+    pub fn into_bytes(self) -> Vec<u8> {
+        self.bytes
+    }
+
+    pub fn as_bytes(&self) -> &[u8] {
+        &self.bytes
+    }
+
+    pub fn truncated(&self) -> bool {
+        self.truncated
+    }
+}
+
+pub fn capture_limit_from_env(name: &str, default: usize) -> usize {
+    env::var(name)
+        .ok()
+        .and_then(|value| value.parse::<usize>().ok())
+        .filter(|limit| *limit > 0)
+        .unwrap_or(default)
+}

--- a/crates/orbit-engine/src/activity_job/cli_runner/orchestrator.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/orchestrator.rs
@@ -182,6 +182,8 @@ pub fn run_cli_backend(
                 task_id: task_id_from_input(input),
                 cwd: subprocess_cwd_string.as_deref(),
             },
+            #[cfg(test)]
+            output_capture_limit: None,
         })
         .map_err(|err| DispatchError::CliInvocationFailed(err.to_string()))?;
 
@@ -205,9 +207,9 @@ pub fn run_cli_backend(
     // and pre-T20260508-17 the dispatcher recorded that as success. The
     // structured envelope is now authoritative when present.
     let exit_success = !timed_out && matches!(exit_code, Some(0));
-    let stdout_text = String::from_utf8_lossy(&stdout).into_owned();
-    let envelope_status = peek_response_status(&stdout_text);
-    let stdout_preview = stdout_text_preview(&stdout_text, &redaction);
+    let stdout_text = String::from_utf8_lossy(&stdout);
+    let envelope_status = peek_response_status(stdout_text.as_ref());
+    let stdout_preview = stdout_text_preview(stdout_text.as_ref(), &redaction);
     let envelope_indicates_failure =
         matches!(envelope_status.as_deref(), Some("failed") | Some("timeout"));
     let success = exit_success && !envelope_indicates_failure;

--- a/crates/orbit-engine/src/activity_job/cli_runner/supervisor.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/supervisor.rs
@@ -1,7 +1,7 @@
 // ORB-00013: Existing expect calls in this module document local invariants; keep the allow scoped while the workspace lint is ratcheted.
 #![allow(clippy::expect_used)]
 
-use std::io::{BufRead, BufReader, Read, Write};
+use std::io::{Read, Write};
 use std::path::Path;
 use std::process::Child;
 use std::sync::{Arc, Mutex, mpsc};
@@ -10,6 +10,7 @@ use std::time::{Duration, Instant};
 
 use super::super::dispatcher::ResolvedSandbox;
 use super::spawn::{SpawnedChild, spawn_child_with_optional_sandbox};
+use orbit_common::utility::output_capture::{BoundedOutputCapture, capture_limit_from_env};
 
 /// Default wall-clock timeout when `AgentLoopSpec::wall_clock_timeout_seconds`
 /// is zero. Matches §7.6 guidance: CLI subprocesses must have a mandatory
@@ -19,6 +20,11 @@ pub(super) const DEFAULT_WALL_CLOCK_TIMEOUT_SECONDS: u64 = 300;
 pub(super) type SpawnOutput = (Vec<u8>, Vec<u8>, Option<i32>, Duration, bool);
 
 const OUTPUT_READER_JOIN_TIMEOUT: Duration = Duration::from_millis(500);
+const CLI_RUNNER_OUTPUT_CAPTURE_LIMIT_ENV: &str = "ORBIT_CLI_RUNNER_OUTPUT_CAPTURE_LIMIT_BYTES";
+const DEFAULT_CLI_RUNNER_OUTPUT_CAPTURE_LIMIT_BYTES: usize = 1024 * 1024;
+const OUTPUT_LINE_EVENT_LIMIT_BYTES: usize = 64 * 1024;
+
+type SharedOutputCapture = Arc<Mutex<BoundedOutputCapture>>;
 
 pub(super) struct SpawnTraceContext<'a> {
     pub(super) provider: &'a str,
@@ -36,6 +42,8 @@ pub(super) struct SpawnWithTimeoutRequest<'a> {
     pub(super) timeout: Duration,
     pub(super) sandbox: Option<&'a ResolvedSandbox>,
     pub(super) trace: SpawnTraceContext<'a>,
+    #[cfg(test)]
+    pub(super) output_capture_limit: Option<usize>,
 }
 
 struct OutputReaderContext {
@@ -45,6 +53,7 @@ struct OutputReaderContext {
     task_id: Option<String>,
     cwd: Option<String>,
     dispatch: tracing::Dispatch,
+    limit_tx: mpsc::Sender<&'static str>,
 }
 
 struct OutputReaderHandle {
@@ -64,6 +73,8 @@ pub(super) fn spawn_with_timeout(
         timeout,
         sandbox,
         trace,
+        #[cfg(test)]
+        output_capture_limit,
     } = request;
 
     let started = Instant::now();
@@ -81,8 +92,13 @@ pub(super) fn spawn_with_timeout(
         });
     }
 
-    let stdout_buf = Arc::new(Mutex::new(Vec::new()));
-    let stderr_buf = Arc::new(Mutex::new(Vec::new()));
+    #[cfg(test)]
+    let output_limit = output_capture_limit.unwrap_or_else(default_output_capture_limit);
+    #[cfg(not(test))]
+    let output_limit = default_output_capture_limit();
+    let stdout_buf = Arc::new(Mutex::new(BoundedOutputCapture::new(output_limit)));
+    let stderr_buf = Arc::new(Mutex::new(BoundedOutputCapture::new(output_limit)));
+    let (output_limit_tx, output_limit_rx) = mpsc::channel();
     let dispatch = tracing::dispatcher::get_default(Clone::clone);
 
     let stdout_reader = child.stdout.take().map(|handle| {
@@ -96,6 +112,7 @@ pub(super) fn spawn_with_timeout(
                 task_id: trace.task_id.map(ToString::to_string),
                 cwd: trace.cwd.map(ToString::to_string),
                 dispatch: dispatch.clone(),
+                limit_tx: output_limit_tx.clone(),
             },
         )
     });
@@ -110,6 +127,7 @@ pub(super) fn spawn_with_timeout(
                 task_id: trace.task_id.map(ToString::to_string),
                 cwd: trace.cwd.map(ToString::to_string),
                 dispatch,
+                limit_tx: output_limit_tx,
             },
         )
     });
@@ -118,6 +136,12 @@ pub(super) fn spawn_with_timeout(
     let deadline = started + timeout;
     let exit_status;
     loop {
+        if output_limit_rx.try_recv().is_ok() {
+            kill_child_process_tree(&mut child);
+            exit_status = None;
+            break;
+        }
+
         match child.try_wait() {
             Ok(Some(status)) => {
                 cleanup_child_process_group(child.id());
@@ -145,16 +169,29 @@ pub(super) fn spawn_with_timeout(
         join_output_reader(h, reader_join_deadline);
     }
 
-    let stdout = stdout_buf.lock().map(|buf| buf.clone()).unwrap_or_default();
-    let stderr = stderr_buf.lock().map(|buf| buf.clone()).unwrap_or_default();
+    let stdout = stdout_buf
+        .lock()
+        .map(|buf| buf.as_bytes().to_vec())
+        .unwrap_or_default();
+    let stderr = stderr_buf
+        .lock()
+        .map(|buf| buf.as_bytes().to_vec())
+        .unwrap_or_default();
     let exit_code = exit_status.as_ref().and_then(|s| s.code());
     let duration = started.elapsed();
     Ok((stdout, stderr, exit_code, duration, timed_out))
 }
 
+fn default_output_capture_limit() -> usize {
+    capture_limit_from_env(
+        CLI_RUNNER_OUTPUT_CAPTURE_LIMIT_ENV,
+        DEFAULT_CLI_RUNNER_OUTPUT_CAPTURE_LIMIT_BYTES,
+    )
+}
+
 fn spawn_output_reader<R>(
     handle: R,
-    buf: Arc<Mutex<Vec<u8>>>,
+    buf: SharedOutputCapture,
     context: OutputReaderContext,
 ) -> OutputReaderHandle
 where
@@ -167,32 +204,50 @@ where
         task_id,
         cwd,
         dispatch,
+        limit_tx,
     } = context;
 
     let (finished_tx, finished) = mpsc::channel();
     let join = thread::spawn(move || {
         tracing::dispatcher::with_default(&dispatch, || {
-            let mut reader = BufReader::new(handle);
-            let mut raw_line = Vec::new();
+            let mut reader = handle;
+            let mut chunk = [0u8; 4096];
+            let mut line_buf = Vec::new();
             loop {
-                raw_line.clear();
-                match reader.read_until(b'\n', &mut raw_line) {
+                match reader.read(&mut chunk) {
                     Ok(0) => break,
-                    Ok(_) => {
-                        buf.lock()
+                    Ok(n) => {
+                        let raw = &chunk[..n];
+                        let exceeded = buf
+                            .lock()
                             .expect("subprocess output buf poisoned")
-                            .extend_from_slice(&raw_line);
-                        emit_output_line(
+                            .push(raw);
+                        emit_output_chunk(
                             &provider,
                             stream,
                             &job_run_id,
                             task_id.as_deref(),
                             cwd.as_deref(),
-                            &raw_line,
+                            raw,
+                            &mut line_buf,
                         );
+                        if exceeded {
+                            let _ = limit_tx.send(stream);
+                            break;
+                        }
                     }
                     Err(_) => break,
                 }
+            }
+            if !line_buf.is_empty() {
+                emit_output_line(
+                    &provider,
+                    stream,
+                    &job_run_id,
+                    task_id.as_deref(),
+                    cwd.as_deref(),
+                    &line_buf,
+                );
             }
         });
         let _ = finished_tx.send(());
@@ -249,6 +304,24 @@ fn signal_child_process_group(child_id: u32, signal: libc::c_int) -> std::io::Re
         Ok(())
     } else {
         Err(error)
+    }
+}
+
+fn emit_output_chunk(
+    provider: &str,
+    stream: &str,
+    job_run_id: &str,
+    task_id: Option<&str>,
+    cwd: Option<&str>,
+    raw: &[u8],
+    line_buf: &mut Vec<u8>,
+) {
+    for segment in raw.split_inclusive(|byte| *byte == b'\n') {
+        line_buf.extend_from_slice(segment);
+        if segment.ends_with(b"\n") || line_buf.len() >= OUTPUT_LINE_EVENT_LIMIT_BYTES {
+            emit_output_line(provider, stream, job_run_id, task_id, cwd, line_buf);
+            line_buf.clear();
+        }
     }
 }
 

--- a/crates/orbit-engine/src/activity_job/cli_runner/tests/supervisor.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/tests/supervisor.rs
@@ -3,6 +3,7 @@
 use std::path::Path;
 use std::time::Duration;
 
+use orbit_common::utility::output_capture::OUTPUT_TRUNCATED_MARKER;
 use tempfile::tempdir;
 
 use super::super::supervisor::{SpawnTraceContext, SpawnWithTimeoutRequest, spawn_with_timeout};
@@ -24,6 +25,7 @@ fn spawn_test_request<'a>(
         timeout,
         sandbox: None,
         trace,
+        output_capture_limit: None,
     }
 }
 
@@ -149,6 +151,38 @@ fn spawn_with_timeout_kills_timed_out_process_and_keeps_partial_output() {
     assert_eq!(events.len(), 1);
     assert_eq!(events[0].field("stream"), Some("stdout"));
     assert_eq!(events[0].field("line"), Some("before timeout"));
+}
+
+#[test]
+fn spawn_with_timeout_kills_when_output_capture_limit_is_exceeded() {
+    let args = sh_args("yes capped-output");
+    let mut request = spawn_test_request(
+        "/bin/sh",
+        &args,
+        None,
+        Duration::from_secs(5),
+        SpawnTraceContext {
+            provider: "codex",
+            job_run_id: "job-output-cap",
+            task_id: Some("TCAP"),
+            cwd: None,
+        },
+    );
+    request.output_capture_limit = Some(64);
+
+    let started = std::time::Instant::now();
+    let (stdout, stderr, exit_code, _duration, timed_out) =
+        spawn_with_timeout(request).expect("spawn succeeds");
+
+    assert!(!timed_out);
+    assert_eq!(exit_code, None);
+    assert!(stderr.is_empty());
+    assert!(stdout.ends_with(OUTPUT_TRUNCATED_MARKER));
+    assert!(stdout.len() <= 64 + OUTPUT_TRUNCATED_MARKER.len());
+    assert!(
+        started.elapsed() < Duration::from_secs(2),
+        "output cap should kill the subprocess promptly"
+    );
 }
 
 #[cfg(unix)]

--- a/crates/orbit-exec/src/supervision/mod.rs
+++ b/crates/orbit-exec/src/supervision/mod.rs
@@ -5,3 +5,6 @@ mod tee;
 mod wait;
 
 pub(crate) use wait::wait_with_optional_timeout;
+
+#[cfg(test)]
+mod tests;

--- a/crates/orbit-exec/src/supervision/tee.rs
+++ b/crates/orbit-exec/src/supervision/tee.rs
@@ -2,16 +2,33 @@ use std::io::{Read, Write};
 use std::sync::mpsc::Sender;
 use std::thread::{self, JoinHandle};
 
+use orbit_common::utility::output_capture::{BoundedOutputCapture, capture_limit_from_env};
 use orbit_common::utility::redaction::redact_sensitive_env_text;
 
-pub(super) fn spawn_stdout_drain<R>(mut out: R, debug: bool) -> JoinHandle<Vec<u8>>
+pub(super) const ORBIT_EXEC_OUTPUT_CAPTURE_LIMIT_ENV: &str =
+    "ORBIT_EXEC_OUTPUT_CAPTURE_LIMIT_BYTES";
+pub(super) const DEFAULT_OUTPUT_CAPTURE_LIMIT_BYTES: usize = 1024 * 1024;
+
+pub(super) fn output_capture_limit() -> usize {
+    capture_limit_from_env(
+        ORBIT_EXEC_OUTPUT_CAPTURE_LIMIT_ENV,
+        DEFAULT_OUTPUT_CAPTURE_LIMIT_BYTES,
+    )
+}
+
+pub(super) fn spawn_stdout_drain<R>(
+    mut out: R,
+    debug: bool,
+    limit: usize,
+    limit_tx: Sender<&'static str>,
+) -> JoinHandle<Vec<u8>>
 where
     R: Read + Send + 'static,
 {
     thread::spawn(move || {
+        let mut capture = BoundedOutputCapture::new(limit);
+        let mut chunk = [0u8; 4096];
         if debug {
-            let mut buf = Vec::new();
-            let mut chunk = [0u8; 4096];
             loop {
                 match out.read(&mut chunk) {
                     Ok(0) | Err(_) => break,
@@ -21,43 +38,70 @@ where
                         let raw = String::from_utf8_lossy(&chunk[..n]);
                         let redacted = redact_sensitive_env_text(&raw);
                         let _ = std::io::stderr().write_all(redacted.as_bytes());
-                        buf.extend_from_slice(&chunk[..n]);
+                        if capture.push(&chunk[..n]) {
+                            let _ = limit_tx.send("stdout");
+                            break;
+                        }
                     }
                 }
             }
-            buf
         } else {
-            let mut buf = Vec::new();
-            let _ = out.read_to_end(&mut buf);
-            buf
+            loop {
+                match out.read(&mut chunk) {
+                    Ok(0) | Err(_) => break,
+                    Ok(n) => {
+                        if capture.push(&chunk[..n]) {
+                            let _ = limit_tx.send("stdout");
+                            break;
+                        }
+                    }
+                }
+            }
         }
+        capture.into_bytes()
     })
 }
 
-pub(super) fn spawn_stderr_drain<R>(mut err: R, debug: bool) -> JoinHandle<Vec<u8>>
+pub(super) fn spawn_stderr_drain<R>(
+    mut err: R,
+    debug: bool,
+    limit: usize,
+    limit_tx: Sender<&'static str>,
+) -> JoinHandle<Vec<u8>>
 where
     R: Read + Send + 'static,
 {
     thread::spawn(move || {
+        let mut capture = BoundedOutputCapture::new(limit);
+        let mut chunk = [0u8; 4096];
         if debug {
-            let mut buf = Vec::new();
-            let mut chunk = [0u8; 4096];
             loop {
                 match err.read(&mut chunk) {
                     Ok(0) | Err(_) => break,
                     Ok(n) => {
                         let redacted = redact_chunk(&chunk[..n]);
                         let _ = std::io::stderr().write_all(&redacted);
-                        buf.extend_from_slice(&redacted);
+                        if capture.push(&redacted) {
+                            let _ = limit_tx.send("stderr");
+                            break;
+                        }
                     }
                 }
             }
-            buf
         } else {
-            let mut buf = Vec::new();
-            let _ = err.read_to_end(&mut buf);
-            buf
+            loop {
+                match err.read(&mut chunk) {
+                    Ok(0) | Err(_) => break,
+                    Ok(n) => {
+                        if capture.push(&chunk[..n]) {
+                            let _ = limit_tx.send("stderr");
+                            break;
+                        }
+                    }
+                }
+            }
         }
+        capture.into_bytes()
     })
 }
 

--- a/crates/orbit-exec/src/supervision/tests/mod.rs
+++ b/crates/orbit-exec/src/supervision/tests/mod.rs
@@ -1,0 +1,1 @@
+mod wait;

--- a/crates/orbit-exec/src/supervision/tests/wait.rs
+++ b/crates/orbit-exec/src/supervision/tests/wait.rs
@@ -1,0 +1,35 @@
+use std::time::{Duration, Instant};
+
+use orbit_common::utility::output_capture::OUTPUT_TRUNCATED_MARKER;
+
+use super::super::wait::wait_with_timeout_and_output_limit;
+use crate::runner::{EnvironmentMode, ExecRequest, StdinMode};
+
+#[cfg(unix)]
+#[test]
+fn wait_kills_process_when_stdout_capture_limit_is_exceeded() {
+    let req = ExecRequest {
+        program: "/bin/sh".to_string(),
+        args: vec!["-c".to_string(), "yes orbit-cap".to_string()],
+        current_dir: None,
+        timeout_ms: Some(5_000),
+        stdin_mode: StdinMode::Null,
+        environment_mode: EnvironmentMode::Inherit,
+        debug: false,
+    };
+    let child = crate::process::spawn(&req).expect("spawn child");
+
+    let started = Instant::now();
+    let result =
+        wait_with_timeout_and_output_limit(child, Some(5_000), false, None, 64).expect("wait");
+
+    assert!(!result.exit_success);
+    assert_eq!(result.exit_code, None);
+    assert!(result.stderr.is_empty());
+    assert!(result.stdout.ends_with(OUTPUT_TRUNCATED_MARKER));
+    assert!(result.stdout.len() <= 64 + OUTPUT_TRUNCATED_MARKER.len());
+    assert!(
+        started.elapsed() < Duration::from_secs(2),
+        "output cap should kill the subprocess promptly"
+    );
+}

--- a/crates/orbit-exec/src/supervision/wait.rs
+++ b/crates/orbit-exec/src/supervision/wait.rs
@@ -11,7 +11,7 @@ use super::cleanup::terminate_orphaned_process_group;
 use super::cleanup::{kill_process_group, terminate_process_group, termination_signal};
 #[cfg(unix)]
 use super::signal::{SignalHandlerGuard, signal_message};
-use super::tee::{spawn_stderr_drain, spawn_stdin_write, spawn_stdout_drain};
+use super::tee::{output_capture_limit, spawn_stderr_drain, spawn_stdin_write, spawn_stdout_drain};
 
 pub(crate) const WAIT_POLL_INTERVAL: Duration = Duration::from_millis(100);
 
@@ -28,10 +28,26 @@ pub(crate) struct WaitResult {
 }
 
 pub(crate) fn wait_with_optional_timeout(
+    child: Child,
+    timeout_ms: Option<u64>,
+    debug: bool,
+    stdin_payload: Option<Vec<u8>>,
+) -> Result<WaitResult, OrbitError> {
+    wait_with_timeout_and_output_limit(
+        child,
+        timeout_ms,
+        debug,
+        stdin_payload,
+        output_capture_limit(),
+    )
+}
+
+pub(super) fn wait_with_timeout_and_output_limit(
     mut child: Child,
     timeout_ms: Option<u64>,
     debug: bool,
     stdin_payload: Option<Vec<u8>>,
+    output_limit: usize,
 ) -> Result<WaitResult, OrbitError> {
     // Drain stdout/stderr in background threads so the child never blocks on a
     // full pipe buffer (which would prevent it from exiting).
@@ -39,14 +55,15 @@ pub(crate) fn wait_with_optional_timeout(
     // In debug mode, both stdout and stderr are tee'd through redaction-aware
     // drains so the user sees live output without bypassing capture/redaction.
     let (stdin_result_rx, stdin_thread) = spawn_stdin_thread(&mut child, stdin_payload)?;
+    let (output_limit_tx, output_limit_rx) = mpsc::channel();
     let stdout_thread = child
         .stdout
         .take()
-        .map(|out| spawn_stdout_drain(out, debug));
+        .map(|out| spawn_stdout_drain(out, debug, output_limit, output_limit_tx.clone()));
     let stderr_thread = child
         .stderr
         .take()
-        .map(|err| spawn_stderr_drain(err, debug));
+        .map(|err| spawn_stderr_drain(err, debug, output_limit, output_limit_tx));
 
     #[cfg(unix)]
     let signal_guard = SignalHandlerGuard::install()?;
@@ -54,6 +71,11 @@ pub(crate) fn wait_with_optional_timeout(
     let deadline = timeout_ms.map(|ms| Instant::now() + Duration::from_millis(ms));
     let mut stdin_write_error = None;
     let (timed_out, interrupted_signal, exit_success, exit_code) = loop {
+        if output_limit_rx.try_recv().is_ok() {
+            terminate_process_group(&mut child, termination_signal(), WAIT_POLL_INTERVAL)?;
+            break (false, None, false, None);
+        }
+
         if let Some(rx) = stdin_result_rx.as_ref() {
             match rx.try_recv() {
                 Ok(Ok(())) => {}

--- a/crates/orbit-tools/src/builtin/proc/spawn.rs
+++ b/crates/orbit-tools/src/builtin/proc/spawn.rs
@@ -3,7 +3,7 @@ use orbit_common::types::{OrbitError, ToolParam, ToolSchema};
 use orbit_exec::{EnvironmentMode, ExecRequest, NoSandbox, StdinMode, run_process};
 use serde_json::Value;
 
-use crate::{Tool, ToolContext};
+use crate::{TIMEOUT_DEFAULT_MS, Tool, ToolContext};
 
 pub struct ProcSpawnTool;
 
@@ -78,7 +78,7 @@ impl Tool for ProcSpawnTool {
             })
             .unwrap_or_default();
 
-        let timeout_ms = input.get("timeout_ms").and_then(Value::as_u64);
+        let timeout_ms = proc_spawn_timeout_ms(&input);
 
         // Filter sensitive env vars instead of inheriting the full environment.
         let env_pairs: Vec<(String, String)> = std::env::vars()
@@ -95,7 +95,7 @@ impl Tool for ProcSpawnTool {
                 program,
                 args,
                 current_dir,
-                timeout_ms,
+                timeout_ms: Some(timeout_ms),
                 stdin_mode: StdinMode::Inherit,
                 environment_mode: EnvironmentMode::ClearAndSet(env_pairs),
                 debug: false,
@@ -114,3 +114,14 @@ fn is_sensitive_env_name(name: &str) -> bool {
     let patterns = ["KEY", "TOKEN", "SECRET", "PASSWORD", "CREDENTIAL"];
     patterns.iter().any(|p| upper.contains(p))
 }
+
+fn proc_spawn_timeout_ms(input: &Value) -> u64 {
+    input
+        .get("timeout_ms")
+        .and_then(Value::as_u64)
+        .unwrap_or(TIMEOUT_DEFAULT_MS)
+}
+
+#[cfg(test)]
+#[path = "tests/spawn.rs"]
+mod tests;

--- a/crates/orbit-tools/src/builtin/proc/tests/spawn.rs
+++ b/crates/orbit-tools/src/builtin/proc/tests/spawn.rs
@@ -1,0 +1,14 @@
+use serde_json::json;
+
+use super::proc_spawn_timeout_ms;
+use crate::TIMEOUT_DEFAULT_MS;
+
+#[test]
+fn missing_proc_spawn_timeout_uses_default_timeout() {
+    assert_eq!(proc_spawn_timeout_ms(&json!({})), TIMEOUT_DEFAULT_MS);
+}
+
+#[test]
+fn explicit_proc_spawn_timeout_is_preserved() {
+    assert_eq!(proc_spawn_timeout_ms(&json!({ "timeout_ms": 42 })), 42);
+}


### PR DESCRIPTION
## Task

[ORB-00362](https://orbit-cli.com/tasks/ORB-00362) — Unbounded child stdout/stderr capture enables memory-exhaustion DoS of the orchestrator

### Description

## Problem
Both subprocess supervisors capture child stdout/stderr into unbounded in-memory Vec<u8> buffers with no size cap. In orbit-exec, tee.rs drains via out.read_to_end/err.read_to_end (and extend_from_slice on the debug path); the full output is held until the child exits and converted to String in runner.rs. Compounding this, wait_with_optional_timeout accepts timeout_ms: Option<u64> and, when None, the poll loop never forces termination — a child writing forever both hangs the supervisor and grows memory without bound. proc.spawn passes the agent-supplied timeout_ms straight through with no default, so an omitted timeout yields the unbounded/never-killed case. In orbit-engine, the cli_runner supervisor appends every line to a shared Vec<u8> with no cap (bounded only by a 300s wall-clock timeout), then orchestrator.rs copies the full buffers into audit blobs and builds another full-size lossy String (~3x peak memory) before truncating only the preview.

## Why It Matters / Exploit Scenario
An agent (untrusted loop driver) invokes an allowlisted program via proc.spawn (e.g. `sh -c 'cat /dev/zero'` or `yes`, where the allowlist gates only the program name) with timeout_ms omitted. orbit-exec buffers every byte in RAM with no ceiling and, absent a timeout, never kills the child, driving the host process to OOM and taking down the orchestrator and concurrent jobs. Even with a timeout (or via the run_command engine path which always sets 120s), a flood-output child still buffers all bytes produced before the deadline, enabling a large memory spike.

## Remediation
Cap captured output at a configurable maximum (truncate with a marker once the cap is exceeded, as the cli_runner preview path already does) and stop reading / kill the process group when the cap is hit. Stream the blob to disk rather than holding full output in memory. Enforce a non-optional default timeout (or reject None) so a child can never hang the supervisor indefinitely; have proc.spawn supply a default timeout_ms rather than passing None.

## Affected Locations
- `crates/orbit-exec/src/supervision/tee.rs:31`
- `crates/orbit-exec/src/supervision/tee.rs:57`
- `crates/orbit-exec/src/supervision/wait.rs:54`
- `crates/orbit-tools/src/builtin/proc/spawn.rs:81`
- `crates/orbit-engine/src/activity_job/cli_runner/supervisor.rs:182`
- `crates/orbit-engine/src/activity_job/cli_runner/orchestrator.rs:188`

## Metadata
- **Severity:** Medium
- **CWE:** CWE-400
- **Surface:** process supervision / subprocess output capture (orbit-exec + orbit-engine cli_runner)
- **Source:** Automated multi-agent security audit (2026-06-06), double-verified (2 independent adversarial reviewers confirmed exploitability + technical correctness).

### Acceptance Criteria

- Captured child stdout/stderr is bounded by a configurable maximum (truncate-with-marker past the cap) in orbit-exec supervision (tee.rs) and the orbit-engine cli_runner supervisor; reading stops / the process group is killed once the cap is exceeded.
- proc.spawn supplies a default timeout rather than passing None, so a child can never hang the supervisor indefinitely.
- A test in the sibling tests/ dir asserts output beyond the cap is truncated and flagged, and that a missing timeout falls back to a default.
- make ci-fast passes.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Added shared bounded-output capture support in `orbit-common`, with a truncation marker and env-configurable capture limit.
- Updated `orbit-exec` stdout/stderr drain threads to stop reading at the cap, mark captured output as truncated, and notify the waiter to terminate the process group.
- Updated the `orbit-engine` cli_runner supervisor to capture bounded output, avoid unbounded `read_until` line buffers, and kill the subprocess tree when the cap is exceeded.
- Changed `proc.spawn` to use `TIMEOUT_DEFAULT_MS` when callers omit `timeout_ms`, so it no longer forwards `None` to the supervisor.
- Added sibling tests for orbit-exec output-cap termination, orbit-engine output-cap termination, and proc.spawn default timeout fallback.

Validation:
- `cargo test -p orbit-exec supervision`
- `cargo test -p orbit-tools proc_spawn_timeout`
- `cargo test -p orbit-engine activity_job::cli_runner::tests::supervisor`
- `git diff --check`
- `make ci-fast`

Assessment: scoped security hardening is implemented and validated with focused tests plus the repository fast gate.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-00362-6a2cafba`
- Behind base: 0
- Ahead of base: 1