### PR TITLE
Graph sync: prune build/ignored dirs in .orbitignore discovery walk (no-op sync ~10s → sub-second)

### DIFF
--- a/crates/orbit-graph/src/sync/scanner.rs
+++ b/crates/orbit-graph/src/sync/scanner.rs
@@ -226,17 +226,20 @@ struct OrbitIgnoreMatcher {
 impl OrbitIgnoreMatcher {
     fn load(repo_path: &Path) -> Result<Self, GraphError> {
         let mut builder = GitignoreBuilder::new(repo_path);
-        for pattern in DEFAULT_ORBITIGNORE_PATTERNS {
-            builder.add_line(None, pattern).map_err(|error| {
-                GraphError::invalid_data(
-                    "load default .orbitignore patterns",
-                    format!("invalid default .orbitignore pattern `{pattern}`: {error}"),
-                )
-            })?;
-        }
+        add_default_orbitignore_patterns(&mut builder)?;
+        let default_orbitignore = Self {
+            gitignore: builder.build().map_err(|error| {
+                GraphError::invalid_data("build default .orbitignore matcher", error.to_string())
+            })?,
+        };
 
         let mut orbitignore_files = Vec::new();
-        collect_orbitignore_files(repo_path, repo_path, &mut orbitignore_files)?;
+        collect_orbitignore_files(
+            repo_path,
+            repo_path,
+            &default_orbitignore,
+            &mut orbitignore_files,
+        )?;
         orbitignore_files.sort_by(|left, right| {
             let left_rel = left.strip_prefix(repo_path).unwrap_or(left.as_path());
             let right_rel = right.strip_prefix(repo_path).unwrap_or(right.as_path());
@@ -267,6 +270,18 @@ impl OrbitIgnoreMatcher {
             .matched_path_or_any_parents(rel_path, is_dir)
             .is_ignore()
     }
+}
+
+fn add_default_orbitignore_patterns(builder: &mut GitignoreBuilder) -> Result<(), GraphError> {
+    for pattern in DEFAULT_ORBITIGNORE_PATTERNS {
+        builder.add_line(None, pattern).map_err(|error| {
+            GraphError::invalid_data(
+                "load default .orbitignore patterns",
+                format!("invalid default .orbitignore pattern `{pattern}`: {error}"),
+            )
+        })?;
+    }
+    Ok(())
 }
 
 fn load_file_rows(conn: &Connection) -> Result<BTreeMap<PathBuf, FileRow>, GraphError> {
@@ -357,6 +372,7 @@ fn walk_dir(
 fn collect_orbitignore_files(
     root: &Path,
     dir: &Path,
+    default_orbitignore: &OrbitIgnoreMatcher,
     out: &mut Vec<PathBuf>,
 ) -> Result<(), GraphError> {
     let entries =
@@ -372,10 +388,15 @@ fn collect_orbitignore_files(
             .map_err(|source| GraphError::io("read file type", path.as_path(), source))?;
 
         if file_type.is_dir() {
+            if let Ok(rel) = path.strip_prefix(root)
+                && default_orbitignore.is_ignored(rel, true)
+            {
+                continue;
+            }
             if name.starts_with('.') {
                 continue;
             }
-            collect_orbitignore_files(root, path.as_path(), out)?;
+            collect_orbitignore_files(root, path.as_path(), default_orbitignore, out)?;
         } else if file_type.is_file() && name.as_ref() == ORBITIGNORE_FILE_NAME {
             let relative = path.strip_prefix(root).map_err(|error| {
                 GraphError::invalid_data("strip .orbitignore prefix", error.to_string())

--- a/crates/orbit-graph/src/sync/tests/scanner.rs
+++ b/crates/orbit-graph/src/sync/tests/scanner.rs
@@ -5,10 +5,12 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use std::thread;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
+use ignore::gitignore::GitignoreBuilder;
 use rusqlite::{Connection, params};
 
 use super::{
-    ContentHasher, DbLockGuard, OrbitIgnoreMatcher, Scanner, mtime_ns, scan_count, scan_diff,
+    ContentHasher, DbLockGuard, OrbitIgnoreMatcher, Scanner, add_default_orbitignore_patterns,
+    collect_orbitignore_files, mtime_ns, scan_count, scan_diff,
 };
 use crate::sync::{SyncLeaderGate, set_sync_leader_gate, sync_leader_count};
 use crate::{EXTRACTOR_VERSION, Graph, SyncMode, SyncPolicy, resolve_db_path};
@@ -179,6 +181,67 @@ fn orbitignore_semantics_match_orbit_knowledge_fixture_corpus() {
 }
 
 #[test]
+fn orbitignore_discovery_prunes_default_ignored_directories() {
+    let worktree = TestWorktree::new("orbitignore-discovery-prunes-defaults");
+    worktree.write(".orbitignore", "# root rules\n");
+    worktree.write("src/.orbitignore", "generated.rs\n");
+
+    for ignored_dir in [
+        "target",
+        "node_modules",
+        "dist",
+        "build",
+        ".venv",
+        "venv",
+        "__pycache__",
+        "crate.egg-info",
+        ".orbit",
+    ] {
+        worktree.write(&format!("{ignored_dir}/.orbitignore"), "*.rs\n");
+        worktree.write(&format!("{ignored_dir}/nested/.orbitignore"), "*.rs\n");
+    }
+
+    let default_orbitignore = default_orbitignore_matcher(worktree.path());
+    let mut orbitignore_files = Vec::new();
+    collect_orbitignore_files(
+        worktree.path(),
+        worktree.path(),
+        &default_orbitignore,
+        &mut orbitignore_files,
+    )
+    .expect("collect .orbitignore files");
+
+    let mut relative_files = orbitignore_files
+        .into_iter()
+        .map(|path| {
+            path.strip_prefix(worktree.path())
+                .expect("strip worktree prefix")
+                .to_path_buf()
+        })
+        .collect::<Vec<_>>();
+    relative_files.sort();
+
+    assert_eq!(
+        relative_files,
+        vec![
+            PathBuf::from(".orbitignore"),
+            PathBuf::from("src/.orbitignore")
+        ]
+    );
+}
+
+#[test]
+fn nested_orbitignore_in_non_ignored_directory_is_discovered() {
+    let worktree = TestWorktree::new("nested-orbitignore-discovered");
+    worktree.write("subdir/.orbitignore", "ignored.rs\n");
+
+    let matcher = OrbitIgnoreMatcher::load(worktree.path()).expect("load matcher");
+
+    assert!(matcher.is_ignored(Path::new("subdir/ignored.rs"), false));
+    assert!(!matcher.is_ignored(Path::new("subdir/kept.rs"), false));
+}
+
+#[test]
 fn dropping_scanner_releases_flock() {
     let worktree = TestWorktree::new("flock-release");
     let graph = Graph::open(worktree.path(), SyncPolicy::Manual).expect("open graph");
@@ -300,6 +363,14 @@ fn graph_db_path(worktree: &Path) -> PathBuf {
     resolve_db_path(worktree, "HEAD", EXTRACTOR_VERSION)
         .path()
         .to_path_buf()
+}
+
+fn default_orbitignore_matcher(worktree: &Path) -> OrbitIgnoreMatcher {
+    let mut builder = GitignoreBuilder::new(worktree);
+    add_default_orbitignore_patterns(&mut builder).expect("add default .orbitignore patterns");
+    OrbitIgnoreMatcher {
+        gitignore: builder.build().expect("build default .orbitignore matcher"),
+    }
 }
 
 struct TestWorktree {


### PR DESCRIPTION
## Task

[ORB-00376](https://orbit-cli.com/tasks/ORB-00376) — Graph sync: prune build/ignored dirs in .orbitignore discovery walk (no-op sync ~10s → sub-second)

### Description

## Problem
Every `orbit.graph.*` MCP call runs `ensure_synced()` first (`crates/orbit-graph/src/lib.rs:112`), and the MCP adapter opens each worktree with `SyncPolicy::Windowed { window: 500ms }` (`crates/orbit-mcp/src/adapter/graph.rs:91`). Agent tool calls are almost always >500ms apart, so the window has effectively always elapsed and nearly every graph call triggers a full sync before the query runs.

A *no-op* sync (nothing changed) is the bottleneck. The scanner does **two** tree walks:
- `walk_dir` correctly prunes ignored dirs via `orbitignore.is_ignored(rel, true)`, skipping `target/`, `node_modules/`, etc. (`scanner.rs:320`).
- But it is preceded by `collect_orbitignore_files`, which walks the tree first just to locate `.orbitignore` files and **only skips dot-directories — it never consults any ignore rules** (`scanner.rs:357`). So it recurses into the entire `target/` build-output tree on every sync.

### Measured (this repo, 1684 indexed files, `files_changed: 0`)
- Steady-state no-op `orbit-graph-cli sync`: **~10.1 s** wall, 26% CPU (I/O-bound).
- Unfiltered full-tree walk (`find . -type f`): **9.1 s** — matches the sync cost.
- Pruned walk skipping `target/ .git/ node_modules/`: **0.24 s** (~38× faster).
- `target/` alone holds **1.7M** files; whole tree 1.92M.

The unfiltered `.orbitignore`-discovery walk *is* the ~9 s. This is I/O-bound directory traversal, so a release build does not help — the fix is algorithmic (prune).

## Why It Matters
This makes graph tools feel broken on any active dev workspace with a populated `target/`: the agent eats a ~10s stall on (effectively) every graph call, and concurrent calls coalesce onto the same blocking sync (`sync/mod.rs` `coalesced`). The cost scales with *build-output* size rather than *source* size — exactly backwards. The query itself is fast; the inline rescan dominates.

## Constraints / Notes
- Scope this task to the surgical P0 fix: make `.orbitignore` discovery honor the same `DEFAULT_ORBITIGNORE_PATTERNS` pruning the main walk uses (`scanner.rs:20`). Those patterns are static and do not require `.orbitignore` files to be loaded first, so pruning during discovery is safe. `target/`, `node_modules/`, etc. never contain meaningful `.orbitignore` files.
- A clean alternative is to collapse the two walks (`collect_orbitignore_files` + `walk_dir`) plus the per-sync `git check-ignore --stdin` subprocess (`scanner.rs:402`) into a single `ignore::WalkBuilder` pass — the crate already depends on `ignore` (`scanner.rs:11`), and `WalkBuilder` is gitignore-aware natively and supports a custom ignore filename. Either approach is acceptable for this task as long as discovery no longer descends into ignored dirs and `.orbitignore` semantics are preserved.
- Do NOT change the 500ms sync window or the read-path sync model here — that is a separate follow-up (lengthen window vs. watcher/background sync, needs an ADR per ARCHITECTURE.md). File separately.
- Preserve nested `.orbitignore` behavior: a `.orbitignore` in a non-ignored subdirectory must still be discovered and applied.

### Acceptance Criteria

- `.orbitignore` discovery (collect_orbitignore_files or its replacement) does not descend into directories matched by DEFAULT_ORBITIGNORE_PATTERNS (target/, node_modules/, dist/, build/, .venv/, venv/, __pycache__/, *.egg-info/, .orbit/) — verifiable by code inspection of crates/orbit-graph/src/sync/scanner.rs.
- On the orbit repo with a populated target/ (1.7M+ files), a steady-state no-op sync completes in under 1000ms: `time ./target/release/orbit-graph-cli sync` (run twice; second run reports files_changed:0 and duration_ms < 1000), down from the ~10000ms baseline.
- Nested .orbitignore still works: a .orbitignore in a non-ignored subdirectory is discovered and applied — `cargo test -p orbit-knowledge --test orbitignore` passes (includes orbitignore_root_file_excludes_symbols_from_graph_search).
- Scanner unit tests pass: `cargo test -p orbit-graph` is green (includes sync/scanner tests).
- `make ci-fast` passes.

## Execution Summary

<details>
<summary>Click to expand</summary>

Implemented the scanner-side P0 fix for `.orbitignore` discovery.

Changes:
- `crates/orbit-graph/src/sync/scanner.rs`: build the default `.orbitignore` matcher before discovery and pass it into `collect_orbitignore_files`, so discovery prunes directories matched by `DEFAULT_ORBITIGNORE_PATTERNS` before recursing. Nested `.orbitignore` files under non-ignored directories are still collected and then loaded into the final matcher.
- `crates/orbit-graph/src/sync/tests/scanner.rs`: added direct coverage that discovery skips `target`, `node_modules`, `dist`, `build`, `.venv`, `venv`, `__pycache__`, `*.egg-info`, and `.orbit`, while preserving root and nested non-ignored `.orbitignore` files.

Validation:
- `cargo test -p orbit-graph` passed: 87 passed.
- `cargo test -p orbit-knowledge --test orbitignore` passed: 6 passed.
- `make ci-fast` passed.
- Built release CLI with `cargo build --release -p orbit-graph-cli`.
- `./target/release/orbit-graph-cli sync` first run refreshed 1684 files in 38712 ms; second steady-state run reported `files_changed:0`, `files_indexed:1684`, `duration_ms:80` (`real 0.08`).

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-00376-6a2d9a05`
- Behind base: 0
- Ahead of base: 1