### PR TITLE
Graph scan: prune build/ignored dirs in orbit-knowledge .orbitignore discovery walk

### DIFF
--- a/crates/orbit-knowledge/src/pipeline/scan.rs
+++ b/crates/orbit-knowledge/src/pipeline/scan.rs
@@ -25,16 +25,18 @@ pub(crate) struct OrbitIgnoreMatcher {
 impl OrbitIgnoreMatcher {
     pub(crate) fn load(repo_path: &Path) -> Result<Self, KnowledgeError> {
         let mut builder = GitignoreBuilder::new(repo_path);
-        for pattern in DEFAULT_ORBITIGNORE_PATTERNS {
-            builder.add_line(None, pattern).map_err(|error| {
-                KnowledgeError::invalid_data(format!(
-                    "invalid default .orbitignore pattern `{pattern}`: {error}"
-                ))
-            })?;
-        }
+        add_default_orbitignore_patterns(&mut builder)?;
 
+        let discovery_matcher = OrbitIgnoreMatcher {
+            gitignore: build_default_orbitignore(repo_path)?,
+        };
         let mut orbitignore_files = Vec::new();
-        collect_orbitignore_files(repo_path, repo_path, &mut orbitignore_files)?;
+        collect_orbitignore_files(
+            repo_path,
+            repo_path,
+            &discovery_matcher,
+            &mut orbitignore_files,
+        )?;
         orbitignore_files.sort_by(|left, right| {
             let left_rel = left.strip_prefix(repo_path).unwrap_or(left.as_path());
             let right_rel = right.strip_prefix(repo_path).unwrap_or(right.as_path());
@@ -65,6 +67,26 @@ impl OrbitIgnoreMatcher {
             .matched_path_or_any_parents(rel_path, is_dir)
             .is_ignore()
     }
+}
+
+fn build_default_orbitignore(repo_path: &Path) -> Result<Gitignore, KnowledgeError> {
+    let mut builder = GitignoreBuilder::new(repo_path);
+    add_default_orbitignore_patterns(&mut builder)?;
+    builder.build().map_err(|error| {
+        KnowledgeError::invalid_data(format!("build default .orbitignore matcher: {error}"))
+    })
+}
+
+fn add_default_orbitignore_patterns(builder: &mut GitignoreBuilder) -> Result<(), KnowledgeError> {
+    for pattern in DEFAULT_ORBITIGNORE_PATTERNS {
+        builder.add_line(None, pattern).map_err(|error| {
+            KnowledgeError::invalid_data(format!(
+                "invalid default .orbitignore pattern `{pattern}`: {error}"
+            ))
+        })?;
+    }
+
+    Ok(())
 }
 
 /// Scan the repo, populating `ctx.file_paths` with relative paths.
@@ -143,6 +165,7 @@ fn walk_dir(
 fn collect_orbitignore_files(
     root: &Path,
     dir: &Path,
+    discovery_matcher: &OrbitIgnoreMatcher,
     out: &mut Vec<PathBuf>,
 ) -> Result<(), KnowledgeError> {
     let entries = std::fs::read_dir(dir)
@@ -162,7 +185,12 @@ fn collect_orbitignore_files(
             if name.starts_with('.') {
                 continue;
             }
-            collect_orbitignore_files(root, &path, out)?;
+            if let Ok(rel) = path.strip_prefix(root)
+                && discovery_matcher.is_ignored(rel, true)
+            {
+                continue;
+            }
+            collect_orbitignore_files(root, &path, discovery_matcher, out)?;
         } else if file_type.is_file() && name.as_ref() == ORBITIGNORE_FILE_NAME {
             let relative = path
                 .strip_prefix(root)

--- a/crates/orbit-knowledge/src/pipeline/tests/scan.rs
+++ b/crates/orbit-knowledge/src/pipeline/tests/scan.rs
@@ -26,6 +26,52 @@ fn orbitignore_matches_recursive_glob() {
 }
 
 #[test]
+fn orbitignore_discovery_prunes_default_ignored_dirs() {
+    let repo = tempdir().unwrap();
+    let target_dir = repo.path().join("target").join("deep");
+    fs::create_dir_all(&target_dir).unwrap();
+    for index in 0..8 {
+        fs::write(target_dir.join(format!("artifact-{index}.rs")), "generated").unwrap();
+    }
+    // The invalid pattern is the sentinel: load succeeds only if discovery prunes target/.
+    fs::write(
+        repo.path().join("target").join(".orbitignore"),
+        "bad[z-a]\n",
+    )
+    .unwrap();
+
+    let matcher = OrbitIgnoreMatcher::load(repo.path())
+        .expect("target/.orbitignore sentinel should not be parsed");
+    assert!(matcher.is_ignored(Path::new("target"), true));
+
+    let control_repo = tempdir().unwrap();
+    fs::create_dir_all(control_repo.path().join("src")).unwrap();
+    fs::write(
+        control_repo.path().join("src").join(".orbitignore"),
+        "bad[z-a]\n",
+    )
+    .unwrap();
+    assert!(OrbitIgnoreMatcher::load(control_repo.path()).is_err());
+}
+
+#[test]
+fn orbitignore_discovers_nested_files_in_source_dirs() {
+    let repo = tempdir().unwrap();
+    fs::create_dir_all(repo.path().join("src")).unwrap();
+    fs::write(repo.path().join(".orbitignore"), "*.tmp\n").unwrap();
+    fs::write(
+        repo.path().join("src").join(".orbitignore"),
+        "!keep.tmp\nlocal-only.rs\n",
+    )
+    .unwrap();
+
+    let matcher = OrbitIgnoreMatcher::load(repo.path()).unwrap();
+    assert!(matcher.is_ignored(Path::new("src/drop.tmp"), false));
+    assert!(!matcher.is_ignored(Path::new("src/keep.tmp"), false));
+    assert!(matcher.is_ignored(Path::new("src/local-only.rs"), false));
+}
+
+#[test]
 fn orbitignore_negation_reincludes_prior_exclusion() {
     let repo = tempdir().unwrap();
     fs::write(


### PR DESCRIPTION
## Task

[ORB-00378](https://orbit-cli.com/tasks/ORB-00378) — Graph scan: prune build/ignored dirs in orbit-knowledge .orbitignore discovery walk

### Description

## Problem
`collect_orbitignore_files` in `crates/orbit-knowledge/src/pipeline/scan.rs:143` recurses the entire worktree to discover nested `.orbitignore` files, skipping **only** dot-directories (`name.starts_with('.')`). It never consults the ignore rules, so it descends into `target/`, `node_modules/`, etc. On this repo `target/` holds **1,701,177 files**. Measured discovery walk: **~90s cold / ~9s warm**, versus **0.80s / 0.24s** when `target`/`node_modules`/`.git` are pruned (~38–113×).

This runs inside `OrbitIgnoreMatcher::load` → `scan_repo` → on every knowledge-graph rebuild. The actual file scan in `walk_dir` (scan.rs:113) already prunes correctly via `orbitignore.is_ignored(rel, true)`; only the *pre-pass* discovery walk is unfiltered.

This is the orbit-knowledge analogue of the orbit-graph bug tracked in ORB-00376 (which targets `crates/orbit-graph/src/sync/scanner.rs`). orbit-knowledge is the engine actually behind the live `orbit.graph.*` tool surface (`orbit.graph.search` → `OrbitKnowledgeSearchTool`), so the fix matters here regardless of ORB-00376.

## Why It Matters
Every rebuild — and rebuilds fire frequently during active editing (see the companion sync task) — pays this multi-second-to-90s directory traversal. It is the single largest acute stall in graph tool latency on large repos and is pure waste: the directories walked are exactly the ones the matcher would exclude.

## Constraints / Notes
- Chicken-and-egg: the walk discovers `.orbitignore` files in order to *build* the matcher. Resolve by building a baseline matcher from `DEFAULT_ORBITIGNORE_PATTERNS` (orbit-knowledge `lib.rs:20`) first, then prune the discovery walk with that baseline — so `target/`/`node_modules/` are skipped while nested `.orbitignore` files in source dirs are still found and applied.
- Alternatively reuse `ignore::WalkBuilder` (already a dependency) with the default patterns seeded.
- Must preserve existing behavior: nested `.orbitignore` files in non-ignored subdirectories are still discovered, and ordering (shallow-before-deep, per scan.rs:38) is retained.
- Output-equivalence: the resulting `OrbitIgnoreMatcher` must classify the same set of paths as before for a non-pathological tree (no files newly included/excluded except those under already-ignored dirs that were never meant to be scanned).
- Docs/scripts-only? No — this is a Rust change in orbit-knowledge; run the crate tests.

### Acceptance Criteria

- A unit test in crates/orbit-knowledge/src/pipeline/tests/scan.rs constructs a fixture with a populated `target/` (or `node_modules/`) subtree containing a sentinel `.orbitignore`, and asserts the discovery walk does NOT traverse into it (e.g. via a traversal counter or by asserting the sentinel's patterns are not loaded).
- A unit test asserts a `.orbitignore` placed in a NON-ignored source subdirectory IS still discovered and its patterns applied (no regression in matcher behavior or shallow-before-deep ordering).
- On a repo with a populated target/, the `.orbitignore` discovery phase (OrbitIgnoreMatcher::load) completes in < 1s; record before/after wall-clock in the task execution summary.
- `cargo test -p orbit-knowledge` passes.
- `make ci-fast` passes.

## Execution Summary

<details>
<summary>Click to expand</summary>

Implemented ORB-00378 in orbit-knowledge. OrbitIgnoreMatcher::load now builds a default-only discovery matcher from DEFAULT_ORBITIGNORE_PATTERNS and passes it into collect_orbitignore_files so the pre-pass skips default-ignored directories such as target/ and node_modules/ while preserving shallow-before-deep loading for discovered .orbitignore files. Added unit coverage for pruning a populated target/ containing a sentinel invalid .orbitignore, and for discovering/applying a nested .orbitignore in a non-ignored source directory with negation ordering intact.

Timing on ~/workspace/repos/orbit with target/ containing 1,701,418 files: before 27,689 ms warm (old load path), after 33 ms warm (new load path), comfortably under 1s.

Validation: cargo test -p orbit-knowledge; make ci-fast.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-00378-6a2da3ca`
- Behind base: 0
- Ahead of base: 1