### PR TITLE
Graph trace resolves a handler for only ~34% of commands; command: selector silently returns empty

### DIFF
--- a/crates/orbit-graph-cli/src/commands/trace.rs
+++ b/crates/orbit-graph-cli/src/commands/trace.rs
@@ -21,11 +21,19 @@ impl TraceCommand {
     pub(crate) fn run(&self, context: &CommandContext) -> Result<serde_json::Value, CliError> {
         let graph = context.open_graph()?;
         json_value(graph.trace(
-            self.command_name.as_str(),
+            normalize_command_selector(self.command_name.as_str()),
             self.depth,
             self.confidence.into_graph(),
         )?)
     }
+}
+
+fn normalize_command_selector(command: &str) -> &str {
+    command
+        .trim()
+        .strip_prefix("command:")
+        .map(str::trim)
+        .unwrap_or_else(|| command.trim())
 }
 
 #[derive(Debug, Clone, Copy, ValueEnum)]

--- a/crates/orbit-graph-cli/tests/subcommands.rs
+++ b/crates/orbit-graph-cli/tests/subcommands.rs
@@ -97,6 +97,25 @@ fn query_and_admin_subcommands_emit_json() -> TestResult {
     assert!(trace["root"].is_null());
     assert_eq!(trace["visited_nodes"], 0);
 
+    let trace_selector = run_json(
+        worktree.path(),
+        [
+            "trace",
+            "command:ship",
+            "--depth",
+            "2",
+            "--confidence",
+            "same_module",
+        ],
+    )?;
+    assert!(trace_selector["root"].is_object());
+    assert!(
+        trace_selector["visited_nodes"]
+            .as_u64()
+            .is_some_and(|visited_nodes| visited_nodes > 0),
+        "command selector should trace a non-empty tree in {trace_selector}"
+    );
+
     let version = run_json(worktree.path(), ["version"])?;
     assert_eq!(version["crate_version"], env!("CARGO_PKG_VERSION"));
     assert!(
@@ -196,6 +215,19 @@ pub fn entry() -> i32 {
 pub fn caller() -> i32 {
     entry()
 }
+"#,
+    )?;
+    fs::write(
+        tempdir.path().join("src/cli.py"),
+        r#"
+import click
+
+@click.command()
+def ship():
+    helper()
+
+def helper():
+    return "ok"
 "#,
     )?;
     fs::write(

--- a/crates/orbit-graph-extract/src/languages/rust/commands.rs
+++ b/crates/orbit-graph-extract/src/languages/rust/commands.rs
@@ -7,6 +7,10 @@ use tree_sitter::Node;
 use super::{ExtractionState, ModuleScope, get_name, node_text, normalize_qualified_name};
 
 pub(super) fn extract_commands(root: Node, source: &str, state: &mut ExtractionState) {
+    if !is_orbit_cli_command_surface(&state.file_path) {
+        return;
+    }
+
     let mut extraction = CommandExtraction::default();
     collect_command_items(root, source, &ModuleScope::root(), &mut extraction);
 
@@ -532,6 +536,10 @@ fn crate_name_from_path(path: &str) -> Option<String> {
         }
     }
     None
+}
+
+fn is_orbit_cli_command_surface(path: &str) -> bool {
+    crate_name_from_path(path).is_none_or(|crate_name| crate_name == "orbit-cli")
 }
 
 fn enum_variant_payload_type(node: Node, source: &str) -> Option<String> {

--- a/crates/orbit-graph-extract/src/languages/tests/rust.rs
+++ b/crates/orbit-graph-extract/src/languages/tests/rust.rs
@@ -9,6 +9,10 @@ fn extract(source: &str) -> crate::ExtractedFile {
     RustExtractor.extract(Path::new("src/sample.rs"), source.as_bytes())
 }
 
+fn extract_at(path: &str, source: &str) -> crate::ExtractedFile {
+    RustExtractor.extract(Path::new(path), source.as_bytes())
+}
+
 fn symbol_kinds(file: &crate::ExtractedFile) -> Vec<&str> {
     file.symbols
         .iter()
@@ -300,4 +304,33 @@ fn run(_args: RunArgs) {}
         .find(|command| command.name == "job run")
         .map(|command| command.handler_symbol.as_deref());
     assert_eq!(command, Some(None));
+}
+
+#[test]
+fn skips_command_extraction_for_non_orbit_workspace_crates() {
+    let file = extract_at(
+        "crates/orbit-graph-cli/src/commands/mod.rs",
+        r#"
+use clap::Subcommand;
+
+#[derive(Subcommand)]
+enum Command {
+    Trace(TraceCommand),
+}
+
+struct TraceCommand;
+
+fn dispatch(command: Command) {
+    match command {
+        Command::Trace(args) => args.run(),
+    }
+}
+
+impl TraceCommand {
+    fn run(self) {}
+}
+"#,
+    );
+
+    assert!(file.commands.is_empty());
 }

--- a/crates/orbit-graph/src/query/tests/trace.rs
+++ b/crates/orbit-graph/src/query/tests/trace.rs
@@ -67,6 +67,24 @@ fn synthetic_command_with_three_level_call_tree_returns_full_tree() {
 }
 
 #[test]
+fn command_selector_prefix_resolves_like_bare_command_name() {
+    let worktree = TestWorktree::new("trace-command-selector");
+    let graph = open_graph(&worktree, SyncPolicy::Manual);
+    let conn = open_connection(&worktree);
+
+    let root_id = seed_symbol(&conn, "src/root.rs", "handler", "crate::handler");
+    insert_command(&conn, "job-run", "src/root.rs", root_id);
+
+    let result = graph
+        .trace("command:job-run", 5, RefConfidence::SameModule)
+        .expect("trace command selector");
+
+    assert_eq!(result.visited_nodes, 1);
+    let root = result.root.expect("trace root");
+    assert_eq!(root.qualified_name.as_deref(), Some("crate::handler"));
+}
+
+#[test]
 fn branching_factor_five_depth_five_caps_at_200_nodes() {
     let worktree = TestWorktree::new("trace-cap");
     let graph = open_graph(&worktree, SyncPolicy::Manual);
@@ -172,6 +190,62 @@ fn helper() {}
     let root = result.root.expect("trace root");
     assert_eq!(root.name, "add");
     assert_eq!(root.qualified_name.as_deref(), Some("add"));
+    assert_eq!(child_names(&root), vec!["helper"]);
+}
+
+#[test]
+fn trace_resolves_rust_clap_handler_from_later_file_after_full_sync() {
+    let worktree = TestWorktree::new("trace-rust-cross-file-clap-handler");
+    worktree.write(
+        "src/command.rs",
+        r#"
+use clap::Subcommand;
+
+#[derive(Subcommand)]
+enum AuditSubcommand {
+    List(AuditListArgs),
+}
+
+struct AuditListArgs;
+
+fn dispatch(command: AuditSubcommand) {
+    match command {
+        AuditSubcommand::List(args) => args.execute(),
+    }
+}
+"#,
+    );
+    worktree.write(
+        "src/handler.rs",
+        r#"
+struct AuditListArgs;
+trait Execute {
+    fn execute(self);
+}
+
+impl Execute for AuditListArgs {
+    fn execute(self) {
+        helper();
+    }
+}
+
+fn helper() {}
+"#,
+    );
+    let graph = open_graph(&worktree, SyncPolicy::Manual);
+    graph.sync(SyncMode::Full).expect("sync rust clap fixture");
+
+    let result = graph
+        .trace("audit list", 3, RefConfidence::SameModule)
+        .expect("trace rust cross-file clap command");
+
+    assert!(result.visited_nodes > 0);
+    let root = result.root.expect("trace root");
+    assert_eq!(root.name, "execute");
+    assert_eq!(
+        root.qualified_name.as_deref(),
+        Some("<AuditListArgs as Execute>::execute")
+    );
     assert_eq!(child_names(&root), vec!["helper"]);
 }
 

--- a/crates/orbit-graph/src/query/trace.rs
+++ b/crates/orbit-graph/src/query/trace.rs
@@ -16,6 +16,7 @@ pub(crate) fn run(
     depth: u8,
     min_confidence: RefConfidence,
 ) -> Result<TraceResult, GraphError> {
+    let command = normalize_command_selector(command);
     graph.with_read_connection(|conn| {
         let Some(origin) = resolve_command_handler(conn, command)? else {
             return Ok(TraceResult::empty());
@@ -72,6 +73,14 @@ pub(crate) fn run(
             visited_nodes: arena.len(),
         })
     })
+}
+
+fn normalize_command_selector(command: &str) -> &str {
+    command
+        .trim()
+        .strip_prefix("command:")
+        .map(str::trim)
+        .unwrap_or_else(|| command.trim())
 }
 
 fn confidence_visible_at_floor(

--- a/crates/orbit-graph/src/sync/pass1.rs
+++ b/crates/orbit-graph/src/sync/pass1.rs
@@ -72,16 +72,20 @@ fn run_with_backend(
     }
 
     let mut refs = Vec::new();
+    let mut commands = Vec::new();
     let mut files_written = 0;
     for mut file in extracted {
         let file_refs = std::mem::take(&mut file.rows.refs);
+        let file_commands = std::mem::take(&mut file.rows.commands);
         write_file_transaction(&mut conn, &file)?;
         refs.push(ExtractedFileRefs {
             file_path: file.file_path.clone(),
             refs: file_refs,
         });
+        commands.extend(file_commands);
         files_written += 1;
     }
+    insert_commands_transaction(&mut conn, &commands)?;
 
     let files_indexed = count_files(&conn)?;
 
@@ -321,10 +325,26 @@ fn write_file_transaction(
     insert_relations(&tx, &file.rows.relations)?;
     insert_strings(&tx, &file.rows.strings, &symbol_ids)?;
     insert_configs(&tx, &file.rows.configs)?;
-    insert_commands(&tx, &file.rows.commands, &symbol_ids)?;
 
     tx.commit()
         .map_err(|source| GraphError::sqlite("commit pass1 file transaction", source))?;
+    Ok(())
+}
+
+fn insert_commands_transaction(
+    conn: &mut Connection,
+    commands: &[RawCommand],
+) -> Result<(), GraphError> {
+    if commands.is_empty() {
+        return Ok(());
+    }
+
+    let tx = conn
+        .transaction_with_behavior(TransactionBehavior::Immediate)
+        .map_err(|source| GraphError::sqlite("begin pass1 command transaction", source))?;
+    insert_commands(&tx, commands)?;
+    tx.commit()
+        .map_err(|source| GraphError::sqlite("commit pass1 command transaction", source))?;
     Ok(())
 }
 
@@ -503,17 +523,10 @@ fn delete_fts_for_file(tx: &Transaction<'_>, file_path: &str) -> Result<(), Grap
     Ok(())
 }
 
-fn insert_commands(
-    tx: &Transaction<'_>,
-    commands: &[RawCommand],
-    symbol_ids: &BTreeMap<String, i64>,
-) -> Result<(), GraphError> {
+fn insert_commands(tx: &Transaction<'_>, commands: &[RawCommand]) -> Result<(), GraphError> {
     for command in commands {
         let handler_symbol = match command.handler_symbol.as_ref() {
-            Some(qualified) => match symbol_ids.get(qualified) {
-                Some(symbol_id) => Some(*symbol_id),
-                None => unique_symbol_id_for_qualified(tx, qualified)?,
-            },
+            Some(qualified) => unique_symbol_id_for_qualified(tx, qualified)?,
             None => None,
         };
         tx.execute(


### PR DESCRIPTION
## Task

[ORB-00387](https://orbit-cli.com/tasks/ORB-00387) — Graph trace resolves a handler for only ~34% of commands; command: selector silently returns empty

### Description

## Problem
Two issues in v2 `trace`:
1. The `commands` table populates `handler_symbol` for only 51 of 148 commands (~34%) in the agent-main DB. `resolve_command_handler` (crates/orbit-graph/src/query/trace.rs:84) does an INNER JOIN on `handler_symbol`, so trace silently returns `{"root":null,"visited_nodes":0}` for the other ~66% (e.g. `audit list`, `audit show`, `audit prune`). The extractor also mis-indexes foreign clap apps as Orbit commands (e.g. `orbit-graph-cli refs/search/show/sync` appear as command rows).
2. `orbit-graph-cli trace` takes a bare command name and passes it straight to `graph.trace()` without the Selector parser (crates/orbit-graph-cli/src/commands/trace.rs); passing the documented `command:<name>` selector form silently yields an empty result instead of an error.

The trace engine itself works for resolved handlers (verified: `trace 'adr list'` returns execute -> print_pretty -> print_with_format).

## Why It Matters
ADR-0192 named "trace returned empty for real enum-dispatch commands" as a cutover blocker. Silent empties for two-thirds of commands plus a footgun selector make trace unreliable as the v2 replacement. trace is a v2-only capability (no v1 equivalent), so its correctness gate stands on its own.

## Constraints / Notes
- Improve command-to-handler extraction so real Orbit subcommands resolve a handler (investigate the enum-dispatch Execute impls for subcommands like `audit list`).
- Stop indexing non-Orbit clap binaries (orbit-graph-cli's own subcommands) as Orbit commands, or scope command extraction to the orbit-cli command tree.
- Make trace either accept the `command:<name>` selector form (consistent with refs/impact/show) or return a clear error when handed a selector, rather than a silent empty.
- Consider distinguishing "command found but no handler resolved" from "command not found".

### Acceptance Criteria

- target/release/orbit-graph-cli trace 'audit list' returns a non-empty call tree (root resolved), not {"root":null,"visited_nodes":0}
- Share of commands rows with a non-null handler_symbol increases materially over the current 51/148 baseline (state the new figure in the execution summary); verify via sqlite3 .orbit/graph/agent-main.4.db "SELECT count(*),count(handler_symbol) FROM commands"
- No rows for non-Orbit binaries (e.g. orbit-graph-cli %) remain in the commands table after a fresh sync
- orbit-graph-cli trace 'command:audit list' either resolves or returns a clear selector error (no silent empty)
- make ci-fast passes

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Deferred `commands` inserts in graph sync until after all changed files' symbols have been written, so cross-file enum-dispatch handlers such as `<AuditListArgs as Execute>::execute` resolve on a fresh full sync.
- Scoped Rust clap command extraction for workspace crates to `orbit-cli`, removing `orbit-graph-cli ...` command rows while preserving generic fixture extraction outside `crates/`.
- Normalized `command:<name>` inputs in both `orbit-graph-cli trace` and `Graph::trace`, so CLI and API callers resolve the selector form instead of getting a silent empty result.
- Added regression coverage for non-Orbit command filtering, deferred cross-file handler resolution, command-selector trace inputs, and the graph CLI selector path.

Validation:
- `cargo fmt --check`
- `cargo test -p orbit-graph-extract languages::tests::rust -- --nocapture`
- `cargo test -p orbit-graph query::trace -- --nocapture`
- `cargo test -p orbit-graph-cli --test subcommands -- --nocapture`
- `cargo build --release -p orbit-graph-cli`
- `target/release/orbit-graph-cli sync --full`
- `target/release/orbit-graph-cli trace 'audit list' --depth 2 --confidence same_module` -> root `<AuditListArgs as Execute>::execute`, visited_nodes=4
- `target/release/orbit-graph-cli trace 'command:audit list' --depth 2 --confidence same_module` -> root `<AuditListArgs as Execute>::execute`, visited_nodes=4
- `sqlite3 $(target/release/orbit-graph-cli db-path | jq -r .path) "SELECT count(*), count(handler_symbol) FROM commands"` -> `138|132` (up from 51/148 baseline)
- `sqlite3 $(target/release/orbit-graph-cli db-path | jq -r .path) "SELECT count(*) FROM commands WHERE name LIKE 'orbit-graph-cli %'"` -> `0`
- `make ci-fast`

Note: this worktree's graph DB is branch-scoped as `.orbit/graph/orbit_ORB-00387-6a2efa6f.4.db`; extractor version remains 4.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-00387-6a2efa6f`
- Behind base: 0
- Ahead of base: 1