### PR TITLE
Graph impact should hint at fuzzy fallback when the precise floor is empty (parity with refs)

### DIFF
--- a/crates/orbit-graph/src/lib.rs
+++ b/crates/orbit-graph/src/lib.rs
@@ -917,6 +917,31 @@ pub struct ImpactResult {
     pub truncated: bool,
     /// Number of impacted symbols returned in `touched`.
     pub visited_nodes: usize,
+    /// Lower-confidence impact surfaced because the precise floor found no
+    /// touched nodes. Present only when a lower-confidence (`fuzzy_name`) match
+    /// exists; see [`ImpactFallback`].
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub fallback: Option<ImpactFallback>,
+}
+
+/// Lower-confidence impact surfaced when the precise floor returned no nodes.
+///
+/// `fuzzy_name` edges are name-only and may include unrelated symbols sharing
+/// the same short name. The top-level [`ImpactResult`] remains the result for
+/// the requested confidence floor; this fallback is an explicit hint that a
+/// lower-confidence blast radius exists.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct ImpactFallback {
+    /// Confidence floor used to produce the fallback impact (`fuzzy_name`).
+    pub confidence: RefConfidence,
+    /// Impacted symbols found at the fallback floor.
+    pub touched: Vec<ImpactEntry>,
+    /// Whether fallback traversal stopped because [`IMPACT_NODE_CAP`] was reached.
+    pub truncated: bool,
+    /// Number of impacted symbols returned in `touched`.
+    pub visited_nodes: usize,
+    /// Human-readable explanation of why these lower-confidence nodes are shown.
+    pub note: String,
 }
 
 /// A symbol reached by [`Graph::impact`].

--- a/crates/orbit-graph/src/query/impact.rs
+++ b/crates/orbit-graph/src/query/impact.rs
@@ -7,8 +7,8 @@ use rusqlite::{Connection, OptionalExtension, params};
 
 use crate::query::callees;
 use crate::{
-    DEFAULT_IMPACT_DEPTH, Graph, GraphError, IMPACT_NODE_CAP, ImpactEntry, ImpactResult,
-    RefConfidence, RefKind, SymbolSpan,
+    DEFAULT_IMPACT_DEPTH, Graph, GraphError, IMPACT_NODE_CAP, ImpactEntry, ImpactFallback,
+    ImpactResult, RefConfidence, RefKind, SymbolSpan,
 };
 
 pub(crate) fn run(
@@ -27,44 +27,20 @@ pub(crate) fn run(
         } else {
             depth
         });
-        let mut queue = VecDeque::from([(origin.clone(), 0usize)]);
-        let mut seen = HashSet::from([origin.qualified]);
-        let mut touched = Vec::new();
-        let mut truncated = false;
-
-        'bfs: while let Some((symbol, distance)) = queue.pop_front() {
-            if distance >= max_depth {
-                continue;
-            }
-            let next_distance = distance + 1;
-            for neighbor in neighbors(conn, &symbol, min_confidence)? {
-                if seen.contains(neighbor.qualified_name.as_str()) {
-                    continue;
-                }
-                if touched.len() >= IMPACT_NODE_CAP {
-                    truncated = true;
-                    break 'bfs;
-                }
-
-                seen.insert(neighbor.qualified_name.clone());
-                if next_distance < max_depth
-                    && let Some(next_symbol) =
-                        resolve_symbol_by_qualified(conn, neighbor.qualified_name.as_str())?
-                {
-                    queue.push_back((next_symbol, next_distance));
-                }
-                touched.push(ImpactEntry {
-                    qualified_name: neighbor.qualified_name,
-                    distance: next_distance,
-                    edge_kind: neighbor.edge_kind,
-                });
-            }
-        }
+        let traversal = traverse(conn, origin.clone(), max_depth, min_confidence)?;
+        let fallback = maybe_fuzzy_fallback(
+            conn,
+            &origin,
+            max_depth,
+            min_confidence,
+            traversal.touched.as_slice(),
+        )?;
 
         Ok(ImpactResult {
-            visited_nodes: touched.len(),
-            touched,
-            truncated,
+            visited_nodes: traversal.touched.len(),
+            touched: traversal.touched,
+            truncated: traversal.truncated,
+            fallback,
         })
     })
 }
@@ -74,6 +50,91 @@ fn empty_result() -> ImpactResult {
         touched: Vec::new(),
         truncated: false,
         visited_nodes: 0,
+        fallback: None,
+    }
+}
+
+fn traverse(
+    conn: &Connection,
+    origin: ImpactSymbol,
+    max_depth: usize,
+    min_confidence: RefConfidence,
+) -> Result<ImpactTraversal, GraphError> {
+    let mut queue = VecDeque::from([(origin.clone(), 0usize)]);
+    let mut seen = HashSet::from([origin.qualified]);
+    let mut touched = Vec::new();
+    let mut truncated = false;
+
+    'bfs: while let Some((symbol, distance)) = queue.pop_front() {
+        if distance >= max_depth {
+            continue;
+        }
+        let next_distance = distance + 1;
+        for neighbor in neighbors(conn, &symbol, min_confidence)? {
+            if seen.contains(neighbor.qualified_name.as_str()) {
+                continue;
+            }
+            if touched.len() >= IMPACT_NODE_CAP {
+                truncated = true;
+                break 'bfs;
+            }
+
+            seen.insert(neighbor.qualified_name.clone());
+            if next_distance < max_depth
+                && let Some(next_symbol) =
+                    resolve_symbol_by_qualified(conn, neighbor.qualified_name.as_str())?
+            {
+                queue.push_back((next_symbol, next_distance));
+            }
+            touched.push(ImpactEntry {
+                qualified_name: neighbor.qualified_name,
+                distance: next_distance,
+                edge_kind: neighbor.edge_kind,
+            });
+        }
+    }
+
+    Ok(ImpactTraversal { touched, truncated })
+}
+
+fn maybe_fuzzy_fallback(
+    conn: &Connection,
+    origin: &ImpactSymbol,
+    max_depth: usize,
+    min_confidence: RefConfidence,
+    touched: &[ImpactEntry],
+) -> Result<Option<ImpactFallback>, GraphError> {
+    if !touched.is_empty() || min_confidence == RefConfidence::FuzzyName {
+        return Ok(None);
+    }
+
+    let fallback = traverse(conn, origin.clone(), max_depth, RefConfidence::FuzzyName)?;
+    if fallback.touched.is_empty() {
+        return Ok(None);
+    }
+
+    let note = format!(
+        "No impacted symbols resolved at the `{}` confidence floor; showing {} match(es) found at \
+         the `fuzzy_name` fallback floor. These are name-only matches and may include unrelated \
+         symbols sharing the name; check each entry before acting.",
+        confidence_label(min_confidence),
+        fallback.touched.len(),
+    );
+    Ok(Some(ImpactFallback {
+        confidence: RefConfidence::FuzzyName,
+        visited_nodes: fallback.touched.len(),
+        touched: fallback.touched,
+        truncated: fallback.truncated,
+        note,
+    }))
+}
+
+fn confidence_label(confidence: RefConfidence) -> &'static str {
+    match confidence {
+        RefConfidence::Exact => "exact",
+        RefConfidence::ImportResolved => "import_resolved",
+        RefConfidence::SameModule => "same_module",
+        RefConfidence::FuzzyName => "fuzzy_name",
     }
 }
 
@@ -398,6 +459,11 @@ struct ImpactSymbol {
 struct ImpactNeighbor {
     qualified_name: String,
     edge_kind: RefKind,
+}
+
+struct ImpactTraversal {
+    touched: Vec<ImpactEntry>,
+    truncated: bool,
 }
 
 struct RawNeighborRow {

--- a/crates/orbit-graph/src/query/tests/impact.rs
+++ b/crates/orbit-graph/src/query/tests/impact.rs
@@ -29,6 +29,7 @@ fn impact_result_shape_matches_golden_fixture() {
         ],
         truncated: false,
         visited_nodes: 2,
+        fallback: None,
     };
 
     crate::query::tests::support::assert_json_matches_fixture(
@@ -328,7 +329,9 @@ fn fuzzy_name_inbound_ref_with_null_qualified_is_visible_at_fuzzy_floor() {
     seed_symbol(&conn, "src/caller.rs", "caller", "crate::caller", 0, 200);
     insert_fuzzy_call_ref(&conn, "src/caller.rs", 10, 11, "did_you_mean");
 
-    // Below the fuzzy floor the edge stays excluded, matching `refs` semantics.
+    // Below the fuzzy floor the precise result stays empty, but the result now
+    // carries the same labeled fallback hint that `refs` emits for name-only
+    // fuzzy matches.
     let same_module = graph
         .impact(
             &symbol_selector("src/target.rs", "did_you_mean"),
@@ -337,6 +340,18 @@ fn fuzzy_name_inbound_ref_with_null_qualified_is_visible_at_fuzzy_floor() {
         )
         .expect("query impact below fuzzy floor");
     assert!(same_module.touched.is_empty());
+    assert_eq!(same_module.visited_nodes, 0);
+    let fallback = same_module.fallback.expect("fallback populated");
+    assert_eq!(fallback.confidence, RefConfidence::FuzzyName);
+    assert_eq!(fallback.visited_nodes, 1);
+    assert_eq!(fallback.touched.len(), 1);
+    assert_eq!(fallback.touched[0].qualified_name, "crate::caller");
+    assert_eq!(fallback.touched[0].edge_kind, RefKind::Call);
+    assert!(
+        fallback.note.contains("same_module") && fallback.note.contains("fuzzy_name"),
+        "note names both the precise floor and the fallback floor: {}",
+        fallback.note
+    );
 
     // At the fuzzy floor the caller is surfaced.
     let fuzzy = graph
@@ -354,6 +369,7 @@ fn fuzzy_name_inbound_ref_with_null_qualified_is_visible_at_fuzzy_floor() {
         .collect();
     assert_eq!(names, vec!["crate::caller"]);
     assert_eq!(fuzzy.touched[0].edge_kind, RefKind::Call);
+    assert!(fuzzy.fallback.is_none());
 }
 
 fn seed_symbol(


### PR DESCRIPTION
## Task

[ORB-00390](https://orbit-cli.com/tasks/ORB-00390) — Graph impact should hint at fuzzy fallback when the precise floor is empty (parity with refs)

### Description

## Problem
`refs` (ORB-00383) auto-falls-back to fuzzy_name matches and returns an explanatory `fallback` note when nothing resolves at the same_module floor. `impact` does not: for a symbol whose edges only resolve at fuzzy_name (e.g. did_you_mean), impact returns `{"touched":[],"visited_nodes":0}` at the default floor with no hint, while passing --confidence fuzzy surfaces a real 6-node blast radius. The two verbs behave inconsistently on identical underlying data.

## Why It Matters
The silent empty is misleading - a caller reasonably concludes "no blast radius" when lowering the confidence floor would reveal one. Matching the refs fallback-and-note behavior makes impact trustworthy and consistent, which supports the impact correctness gate (ADR-0192).

## Constraints / Notes
- Mirror the refs fallback shape (crates/orbit-graph/src/query/refs.rs, ORB-00383): when the precise floor yields zero touched nodes but fuzzy edges exist, either include them under a labeled fallback or emit a count/note that fuzzy results are available.
- Do not change the default floor; keep precise-only as the default result, with the fallback clearly labeled as name-only / may-include-unrelated.
- impact logic: crates/orbit-graph/src/query/impact.rs.

### Acceptance Criteria

- orbit-graph-cli impact 'symbol:crates/orbit-common/src/types/error.rs#did_you_mean:method' at the default floor returns either the labeled fuzzy fallback or an explicit note/count that fuzzy matches exist - not a bare empty result
- The note/shape matches the refs fallback convention
- Behavior at the fuzzy confidence floor is unchanged (still returns the 6-node radius)
- make ci-fast passes

## Execution Summary

<details>
<summary>Click to expand</summary>

Implemented impact fuzzy fallback parity with refs. `ImpactResult` now serializes an optional `fallback` when the requested confidence floor returns zero touched nodes but a `fuzzy_name` traversal would return nodes. The top-level result remains precise/default-floor only; explicit `--confidence fuzzy` output is unchanged. Added unit coverage for name-only fuzzy refs and verified the stated `did_you_mean` CLI case returns a 6-node fallback at the default floor and a 6-node top-level result at the fuzzy floor.

Validation:
- `cargo test -p orbit-graph impact`
- `cargo run -q -p orbit-graph-cli -- sync`
- `cargo run -q -p orbit-graph-cli -- impact 'symbol:crates/orbit-common/src/types/error.rs#did_you_mean:method'`
- `cargo run -q -p orbit-graph-cli -- impact 'symbol:crates/orbit-common/src/types/error.rs#did_you_mean:method' --confidence fuzzy`
- `cargo fmt --check && make ci-fast`

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-00390-6a2f06fb`
- Behind base: 0
- Ahead of base: 1