### PR TITLE
release: v0.9.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,11 @@
 # Changelog
 
-## Unreleased
+## 0.9.2
 
 ### Highlights
 
 - **`orbit graph` is back as a thin CLI wrapper**: the v2 graph is now reachable from the single `orbit` binary via `orbit graph {sync, search, show, refs, callees, impact, trace, overview, implementors, deps, version, db-path, clean}`, not only the standalone `orbit-graph-cli` binary or the in-process MCP adapter. `orbit-graph-cli` is lib-ified (lib + bin) so both front ends share one command layer with no duplication; the agent-facing graph surface is unchanged (still MCP-only). This amends the ADR-0198 consequence that dropped the subcommand. ([ORB-00396], ADR-0199)
+- **Task store crash durability hardened**: the task registry SQLite connection now runs with `synchronous=FULL`, and task-bundle creation fsyncs the bundle directory's parent before returning — so a power loss or OS crash mid-write can no longer leave the task store or a freshly-created bundle in a torn, unrecoverable state. ([ORB-00395], [ORB-00394])
 
 ## 0.9.1
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2143,7 +2143,7 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "orbit-agent"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "chrono",
  "orbit-common",
@@ -2158,7 +2158,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-cli"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "assert_cmd",
  "chrono",
@@ -2188,7 +2188,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-common"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "chrono",
  "clap",
@@ -2210,7 +2210,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-core"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "chrono",
  "fs2",
@@ -2235,7 +2235,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-dashboard"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "axum",
  "chrono",
@@ -2255,7 +2255,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-engine"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "chrono",
  "jsonschema",
@@ -2278,7 +2278,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-exec"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "libc",
  "orbit-common",
@@ -2289,7 +2289,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-graph"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "blake3",
  "fs2",
@@ -2306,7 +2306,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-graph-cli"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -2324,7 +2324,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-graph-extract"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "serde",
  "serde_json",
@@ -2346,7 +2346,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-mcp"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "orbit-common",
  "orbit-graph",
@@ -2362,7 +2362,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-policy"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "chrono",
  "orbit-common",
@@ -2371,7 +2371,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-registry"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "git2",
  "orbit-common",
@@ -2380,7 +2380,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-search"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "blake3",
  "chrono",
@@ -2398,7 +2398,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-search-companion"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "clap",
  "fastembed",
@@ -2409,7 +2409,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-store"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "blake3",
  "chrono",
@@ -2429,7 +2429,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-tools"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "chrono",
  "orbit-common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.9.1"
+version = "0.9.2"
 edition = "2024"
 license = "MIT"
 

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "orbit",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "Knowledge-graph code intelligence and task/activity orchestration for AI coding agents. Adds Orbit's MCP tool surface, skills, and orchestration subagents to Claude Code.",
   "hooks": "./hooks/hooks.json",
   "author": {

--- a/plugin/npm/package.json
+++ b/plugin/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@orbit-tools/cli",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "npm proxy for the Orbit CLI. Downloads the matching native binary from GitHub Releases on install and forwards all invocations.",
   "bin": {
     "orbit": "bin/orbit.js"


### PR DESCRIPTION
Promotes **v0.9.2** to `main`. See [CHANGELOG.md](CHANGELOG.md).

Patch release on top of v0.9.1 (already on `main` via #509). No breaking changes.

### Highlights
- **`orbit graph` is back as a thin CLI wrapper**: the v2 graph is reachable from the single `orbit` binary via `orbit graph {sync, search, show, refs, callees, impact, trace, overview, implementors, deps, version, db-path, clean}` — not only the standalone `orbit-graph-cli` binary or the in-process MCP adapter. The agent-facing graph surface is unchanged (still MCP-only). ([ORB-00396], ADR-0199)
- **Task store crash durability hardened**: the task registry SQLite connection runs with `synchronous=FULL`, and bundle creation fsyncs the bundle directory's parent — a crash mid-write can no longer leave the store or a fresh bundle torn. ([ORB-00395], [ORB-00394])

### Merge notes
- Merge with a **merge commit** (`gh pr merge --merge --admin`), not squash/rebase, so tag `v0.9.2` stays reachable from `main` (RELEASING.md §10b).
- Hold the merge until release CI for `v0.9.2` is green.
- Follow with the `main → agent-main` back-merge (RELEASING.md §10c).

🤖 Generated with [Claude Code](https://claude.com/claude-code)