### PR TITLE
Cleanup: refresh design-doc CONVENTIONS ownership table; resolve incomplete executors/ folder

### DIFF
--- a/docs/design/CONVENTIONS.md
+++ b/docs/design/CONVENTIONS.md
@@ -1,7 +1,7 @@
 ---
 title: Design Doc Conventions
 owner: daniel
-last_updated: 2026-05-20
+last_updated: 2026-06-20
 status: Accepted
 ---
 
@@ -227,12 +227,22 @@ Until those exist: cross-review and author judgment are the quality mechanism. W
 
 ## 12. Ownership
 
+The `Lead` value mirrors each live feature folder's frontmatter `owner:` field
+and uses the canonical agent family (`codex`, `claude`, `gemini`, or `grok`).
+
 | Feature | Folder | Lead |
 |---------|--------|------|
 | Activity / Job | [docs/design/activity-job/](./activity-job/) | codex |
+| Agent Families | [docs/design/agent-families/](./agent-families/) | grok |
 | Auditability | [docs/design/auditability/](./auditability/) | codex |
+| Executors | [docs/design/executors/](./executors/) | claude |
+| Global Store Consolidation | [docs/design/global-store-consolidation/](./global-store-consolidation/) | codex |
 | Groundhog | [docs/design/groundhog/](./groundhog/) | codex |
 | Knowledge graph | [docs/design/knowledge-graph/](./knowledge-graph/) | claude |
+| MCP Session Context | [docs/design/mcp-session-context/](./mcp-session-context/) | codex |
+| Orbit Docs | [docs/design/orbit-docs/](./orbit-docs/) | claude |
+| Orbit Graph | [docs/design/orbit-graph/](./orbit-graph/) | claude |
+| Orbit Search | [docs/design/orbit-search/](./orbit-search/) | claude |
 | Policy & Sandboxing | [docs/design/policy-sandbox/](./policy-sandbox/) | claude |
 | Project Learnings | [docs/design/project-learnings/](./project-learnings/) | claude |
 | Task Artifacts | [docs/design/task-artifacts/](./task-artifacts/) | codex |

--- a/docs/design/executors/4_decisions.md
+++ b/docs/design/executors/4_decisions.md
@@ -1,7 +1,7 @@
 ---
 title: Executors — Decisions
 owner: claude
-last_updated: 2026-06-13
+last_updated: 2026-06-20
 status: Draft
 feature: executors
 doc_role: decisions
@@ -10,7 +10,7 @@ summary: ADR log for executor registration and the External Executor Protocol.
 tags: [executors]
 paths: ["crates/orbit-engine/src/executor/**", "crates/orbit-common/src/types/executor_def.rs"]
 related_features: [executors]
-related_artifacts: [ORB-00384, ADR-0196]
+related_artifacts: [ORB-00384, ORB-00400, ADR-0196]
 ---
 
 # Executors — Decisions
@@ -20,6 +20,14 @@ by ascending global ADR number. Each entry is the long-form narrative keyed on a
 global ID allocated through `orbit.adr.add`; the ADR store is the source of truth
 for status, owner, `related_features`, and `related_tasks`. Resolve any global ID
 with `orbit tool run orbit.adr.show --input '{"id":"ADR-0196"}'`.
+
+Layout note: as of [ORB-00400], this folder is intentionally decisions+specs-only.
+[ADR-0196] and [specs/external-executor-protocol.md](./specs/external-executor-protocol.md)
+are the load-bearing docs for the shipped External Executor Protocol; placeholder
+`1_overview.md`, `2_design.md`, and `3_vision.md` docs would imply a broader
+executor feature narrative that this work has not established. Add numbered docs
+only when a future executor-architecture task owns that narrative, and retire
+this exception in the same PR.
 
 ---
 
@@ -43,5 +51,6 @@ with `orbit tool run orbit.adr.show --input '{"id":"ADR-0196"}'`.
 ## Task References
 
 - **[ORB-00384]** — External Executor Protocol v1: define the contract, add `ExecutorType::External`, register a generic external-process executor, document the spec, ship a conformance test.
+- **[ORB-00400]** — recorded the `executors` folder as a decisions+specs-only layout exception while refreshing design-doc ownership conventions.
 
 > Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.


### PR DESCRIPTION
## Task

[ORB-00400](https://orbit-cli.com/tasks/ORB-00400) — Cleanup: refresh design-doc CONVENTIONS ownership table; resolve incomplete executors/ folder

### Description

Structure/staleness fixes for `docs/design/` conventions. Run **after ORB-00399** (design-doc deletions) so the ownership table reflects the post-deletion folder set.

**1. CONVENTIONS.md §12 ownership table is stale.** It lists 11 of the live feature folders; the table is missing rows for folders that exist and ship. After ORB-00399 removes `design-docs/` and `adr-artifact/`, the table should list every remaining live folder with its accountable owner family. Folders currently absent from the table: `agent-families` (owner grok), `global-store-consolidation` (codex), `mcp-session-context` (codex), `orbit-docs` (claude), `orbit-graph` (claude), `orbit-search` (claude). Verify each owner against the folder's frontmatter `owner:` field rather than trusting this list. Note: the §12 table header currently implies owners are only codex/claude/gemini — `agent-families` is grok-owned, so either widen the convention or confirm the correct owner.

**2. `docs/design/executors/` is structurally incomplete** — only `4_decisions.md` + `specs/external-executor-protocol.md`; missing `1_overview.md`, `2_design.md`, `3_vision.md`. The external-executor feature shipped (ORB-00384, ADR-0196). Resolve by either (a) authoring the three missing numbered docs, or (b) making an explicit, documented decision that this folder is decisions+specs-only and recording that exception. Pick the lower-effort option that leaves the folder honest; do not leave it silently half-formed.

Docs-only — `make ci-fast` is the gate.

### Acceptance Criteria

- CONVENTIONS.md §12 ownership table lists every live docs/design/<feature> folder (post-ORB-00399) with an owner verified against each folder's frontmatter owner: field
- adr-artifact and design-docs do NOT appear in the table (removed by ORB-00399)
- docs/design/executors/ is either completed with 1_/2_/3_ numbered docs OR carries an explicit recorded note that it is decisions+specs-only
- make ci-fast passes

## Execution Summary

<details>
<summary>Click to expand</summary>

Refreshed `docs/design/CONVENTIONS.md` §12 ownership table for the post-ORB-00399 live design-doc folder set, adding the missing feature folders and clarifying that `Lead` mirrors each folder's frontmatter `owner:` agent family, including `grok`. Recorded `docs/design/executors/` as an intentional decisions+specs-only layout exception in `docs/design/executors/4_decisions.md`, with ORB-00400 frontmatter/task-reference updates. Verified the table against frontmatter owners while excluding the ORB-00399-removed `adr-artifact` and `design-docs` folders; `make ci-fast` passed.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-00400-6a36d4b1`
- Behind base: 0
- Ahead of base: 1

*authored by: codex*