### PR TITLE
Cleanup: migrate inline #[cfg(test)] modules to sibling tests/ layout (incremental)

### DIFF
--- a/crates/orbit-agent/src/providers/gemini_http/mod.rs
+++ b/crates/orbit-agent/src/providers/gemini_http/mod.rs
@@ -7,4 +7,7 @@
 mod transport;
 mod wire;
 
+#[cfg(test)]
+mod tests;
+
 pub use transport::GeminiHttpTransport;

--- a/crates/orbit-agent/src/providers/gemini_http/tests/mod.rs
+++ b/crates/orbit-agent/src/providers/gemini_http/tests/mod.rs
@@ -1,0 +1,1 @@
+mod transport;

--- a/crates/orbit-agent/src/providers/gemini_http/tests/transport.rs
+++ b/crates/orbit-agent/src/providers/gemini_http/tests/transport.rs
@@ -1,0 +1,119 @@
+use std::io::{Read, Write};
+use std::net::TcpListener;
+use std::thread;
+use std::time::Duration;
+
+use reqwest::blocking::Client;
+
+use super::super::transport::{GEMINI_API_KEY_HEADER, GeminiHttpTransport, network_error};
+use crate::loop_engine::transport::{
+    CacheHint, LoopTransport, Message, TransportError, TurnRequest,
+};
+
+const GEMINI_API_KEY: &str = "AIzaSyDoNotLeakThisGeminiApiKeyValue";
+
+#[test]
+fn send_turn_sends_api_key_header_without_key_query_param() {
+    let response_body = r#"{"candidates":[{"content":{"role":"model","parts":[{"text":"ok"}]},"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":1,"candidatesTokenCount":1,"cachedContentTokenCount":0}}"#;
+    let (base_url, server) = spawn_one_request_server(response_body);
+    let transport = GeminiHttpTransport::new(GEMINI_API_KEY, "gemini-test", None)
+        .expect("transport")
+        .with_base_url(base_url);
+    let messages = [Message::user_text("hello")];
+    let req = TurnRequest {
+        system: None,
+        messages: &messages,
+        tools: &[],
+        cache_hint: CacheHint::None,
+        max_response_tokens: 0,
+    };
+
+    let response = transport.send_turn(&req).expect("send turn");
+    let captured_request = server.join().expect("server thread");
+    let request_line = captured_request.lines().next().unwrap_or_default();
+
+    assert!(
+        request_line.starts_with("POST /v1beta/models/gemini-test:generateContent "),
+        "unexpected request line: {request_line}"
+    );
+    assert!(
+        !request_line.to_ascii_lowercase().contains("key="),
+        "request URL must not contain an API key query param: {request_line}"
+    );
+    assert!(
+        captured_request.contains(&format!("{GEMINI_API_KEY_HEADER}: {GEMINI_API_KEY}")),
+        "request must send the Gemini API key header"
+    );
+    assert!(!response.endpoint.to_ascii_lowercase().contains("key="));
+}
+
+#[test]
+fn endpoint_builders_do_not_include_api_key_query_params() {
+    let transport =
+        GeminiHttpTransport::new(GEMINI_API_KEY, "gemini-test", None).expect("transport");
+
+    let generate_endpoint = transport.generate_content_endpoint();
+    let cached_endpoint = transport.cached_contents_endpoint();
+
+    assert!(!generate_endpoint.to_ascii_lowercase().contains("key="));
+    assert!(!cached_endpoint.to_ascii_lowercase().contains("key="));
+    assert!(!generate_endpoint.contains(GEMINI_API_KEY));
+    assert!(!cached_endpoint.contains(GEMINI_API_KEY));
+}
+
+#[test]
+fn reqwest_transport_errors_strip_url_before_stringifying() {
+    let listener = TcpListener::bind(("127.0.0.1", 0)).expect("bind listener");
+    let addr = listener.local_addr().expect("listener address");
+    drop(listener);
+    let url = format!("http://{addr}/fail?key={GEMINI_API_KEY}");
+    let err = Client::builder()
+        .timeout(Duration::from_millis(50))
+        .build()
+        .expect("client")
+        .get(url)
+        .send()
+        .expect_err("unbound local port should fail");
+
+    let TransportError::Network(message) = network_error(err) else {
+        panic!("expected network error");
+    };
+
+    assert!(!message.contains(GEMINI_API_KEY));
+    assert!(!message.to_ascii_lowercase().contains("key="));
+}
+
+fn spawn_one_request_server(response_body: &'static str) -> (String, thread::JoinHandle<String>) {
+    let listener = TcpListener::bind(("127.0.0.1", 0)).expect("bind listener");
+    let addr = listener.local_addr().expect("listener address");
+    let handle = thread::spawn(move || {
+        let (mut stream, _) = listener.accept().expect("accept request");
+        stream
+            .set_read_timeout(Some(Duration::from_secs(2)))
+            .expect("set read timeout");
+        let mut request_bytes = Vec::new();
+        let mut buf = [0_u8; 1024];
+        loop {
+            let n = stream.read(&mut buf).expect("read request");
+            if n == 0 {
+                break;
+            }
+            request_bytes.extend_from_slice(&buf[..n]);
+            if request_bytes.windows(4).any(|window| window == b"\r\n\r\n") {
+                break;
+            }
+        }
+
+        let response = format!(
+            "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{}",
+            response_body.len(),
+            response_body
+        );
+        stream
+            .write_all(response.as_bytes())
+            .expect("write response");
+        String::from_utf8(request_bytes).expect("request utf8")
+    });
+
+    (format!("http://{addr}"), handle)
+}

--- a/crates/orbit-agent/src/providers/gemini_http/transport.rs
+++ b/crates/orbit-agent/src/providers/gemini_http/transport.rs
@@ -22,7 +22,8 @@ use super::wire::{
 };
 
 const DEFAULT_BASE_URL: &str = "https://generativelanguage.googleapis.com";
-const GEMINI_API_KEY_HEADER: &str = "x-goog-api-key";
+// `pub(super)` widened for sibling test access; otherwise file-private.
+pub(super) const GEMINI_API_KEY_HEADER: &str = "x-goog-api-key";
 
 pub struct GeminiHttpTransport {
     client: Client,
@@ -68,14 +69,16 @@ impl GeminiHttpTransport {
         Ok(self)
     }
 
-    fn generate_content_endpoint(&self) -> String {
+    // `pub(super)` widened for sibling test access.
+    pub(super) fn generate_content_endpoint(&self) -> String {
         format!(
             "{}/v1beta/models/{}:generateContent",
             self.base_url, self.model
         )
     }
 
-    fn cached_contents_endpoint(&self) -> String {
+    // `pub(super)` widened for sibling test access.
+    pub(super) fn cached_contents_endpoint(&self) -> String {
         format!("{}/v1beta/cachedContents", self.base_url)
     }
 
@@ -374,7 +377,8 @@ fn build_client(timeout: Duration) -> Result<Client, TransportError> {
         .map_err(|e| TransportError::Other(format!("reqwest build: {e}")))
 }
 
-fn network_error(error: reqwest::Error) -> TransportError {
+// `pub(super)` widened for sibling test access.
+pub(super) fn network_error(error: reqwest::Error) -> TransportError {
     TransportError::Network(reqwest_error_message(error))
 }
 
@@ -410,125 +414,4 @@ fn validate_headers(
             Ok((header_name, header_value))
         })
         .collect()
-}
-
-#[cfg(test)]
-mod tests {
-    use std::io::{Read, Write};
-    use std::net::TcpListener;
-    use std::thread;
-    use std::time::Duration;
-
-    use super::*;
-    use crate::loop_engine::transport::{CacheHint, Message};
-
-    const GEMINI_API_KEY: &str = "AIzaSyDoNotLeakThisGeminiApiKeyValue";
-
-    #[test]
-    fn send_turn_sends_api_key_header_without_key_query_param() {
-        let response_body = r#"{"candidates":[{"content":{"role":"model","parts":[{"text":"ok"}]},"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":1,"candidatesTokenCount":1,"cachedContentTokenCount":0}}"#;
-        let (base_url, server) = spawn_one_request_server(response_body);
-        let transport = GeminiHttpTransport::new(GEMINI_API_KEY, "gemini-test", None)
-            .expect("transport")
-            .with_base_url(base_url);
-        let messages = [Message::user_text("hello")];
-        let req = TurnRequest {
-            system: None,
-            messages: &messages,
-            tools: &[],
-            cache_hint: CacheHint::None,
-            max_response_tokens: 0,
-        };
-
-        let response = transport.send_turn(&req).expect("send turn");
-        let captured_request = server.join().expect("server thread");
-        let request_line = captured_request.lines().next().unwrap_or_default();
-
-        assert!(
-            request_line.starts_with("POST /v1beta/models/gemini-test:generateContent "),
-            "unexpected request line: {request_line}"
-        );
-        assert!(
-            !request_line.to_ascii_lowercase().contains("key="),
-            "request URL must not contain an API key query param: {request_line}"
-        );
-        assert!(
-            captured_request.contains(&format!("{GEMINI_API_KEY_HEADER}: {GEMINI_API_KEY}")),
-            "request must send the Gemini API key header"
-        );
-        assert!(!response.endpoint.to_ascii_lowercase().contains("key="));
-    }
-
-    #[test]
-    fn endpoint_builders_do_not_include_api_key_query_params() {
-        let transport =
-            GeminiHttpTransport::new(GEMINI_API_KEY, "gemini-test", None).expect("transport");
-
-        let generate_endpoint = transport.generate_content_endpoint();
-        let cached_endpoint = transport.cached_contents_endpoint();
-
-        assert!(!generate_endpoint.to_ascii_lowercase().contains("key="));
-        assert!(!cached_endpoint.to_ascii_lowercase().contains("key="));
-        assert!(!generate_endpoint.contains(GEMINI_API_KEY));
-        assert!(!cached_endpoint.contains(GEMINI_API_KEY));
-    }
-
-    #[test]
-    fn reqwest_transport_errors_strip_url_before_stringifying() {
-        let listener = TcpListener::bind(("127.0.0.1", 0)).expect("bind listener");
-        let addr = listener.local_addr().expect("listener address");
-        drop(listener);
-        let url = format!("http://{addr}/fail?key={GEMINI_API_KEY}");
-        let err = Client::builder()
-            .timeout(Duration::from_millis(50))
-            .build()
-            .expect("client")
-            .get(url)
-            .send()
-            .expect_err("unbound local port should fail");
-
-        let TransportError::Network(message) = network_error(err) else {
-            panic!("expected network error");
-        };
-
-        assert!(!message.contains(GEMINI_API_KEY));
-        assert!(!message.to_ascii_lowercase().contains("key="));
-    }
-
-    fn spawn_one_request_server(
-        response_body: &'static str,
-    ) -> (String, thread::JoinHandle<String>) {
-        let listener = TcpListener::bind(("127.0.0.1", 0)).expect("bind listener");
-        let addr = listener.local_addr().expect("listener address");
-        let handle = thread::spawn(move || {
-            let (mut stream, _) = listener.accept().expect("accept request");
-            stream
-                .set_read_timeout(Some(Duration::from_secs(2)))
-                .expect("set read timeout");
-            let mut request_bytes = Vec::new();
-            let mut buf = [0_u8; 1024];
-            loop {
-                let n = stream.read(&mut buf).expect("read request");
-                if n == 0 {
-                    break;
-                }
-                request_bytes.extend_from_slice(&buf[..n]);
-                if request_bytes.windows(4).any(|window| window == b"\r\n\r\n") {
-                    break;
-                }
-            }
-
-            let response = format!(
-                "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{}",
-                response_body.len(),
-                response_body
-            );
-            stream
-                .write_all(response.as_bytes())
-                .expect("write response");
-            String::from_utf8(request_bytes).expect("request utf8")
-        });
-
-        (format!("http://{addr}"), handle)
-    }
 }

--- a/crates/orbit-dashboard/src/api/review_threads.rs
+++ b/crates/orbit-dashboard/src/api/review_threads.rs
@@ -201,7 +201,10 @@ enum AuthorKindFilter {
     Agent,
 }
 
-fn parse_status_filter(raw: Option<&str>) -> Result<Option<ReviewThreadStatus>, String> {
+// `pub(super)` widened so the sibling test module
+// (`src/api/tests/review_threads.rs`) can exercise the helper. Used only
+// by handlers in this file plus tests.
+pub(super) fn parse_status_filter(raw: Option<&str>) -> Result<Option<ReviewThreadStatus>, String> {
     let Some(raw) = raw.map(str::trim).filter(|value| !value.is_empty()) else {
         return Ok(None);
     };
@@ -322,7 +325,8 @@ fn project_thread(
     }
 }
 
-fn preview_body(body: &str) -> String {
+// `pub(super)` widened for sibling test access.
+pub(super) fn preview_body(body: &str) -> String {
     const PREVIEW_LIMIT: usize = 160;
     let collapsed: String = body
         .lines()
@@ -338,8 +342,9 @@ fn preview_body(body: &str) -> String {
     }
 }
 
+// `pub(super)` widened for sibling test access.
 #[derive(Debug, Clone)]
-enum AuthorKind {
+pub(super) enum AuthorKind {
     Human,
     Agent { family: Option<String> },
 }
@@ -360,7 +365,8 @@ impl AuthorKind {
     }
 }
 
-fn classify_author(label: &str) -> AuthorKind {
+// `pub(super)` widened for sibling test access.
+pub(super) fn classify_author(label: &str) -> AuthorKind {
     let trimmed = label.trim();
     if trimmed.is_empty() {
         return AuthorKind::Human;
@@ -379,51 +385,4 @@ fn classify_author(label: &str) -> AuthorKind {
         };
     }
     AuthorKind::Human
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn classify_author_recognizes_known_families_and_models() {
-        assert!(matches!(
-            classify_author("claude"),
-            AuthorKind::Agent { .. }
-        ));
-        assert!(matches!(
-            classify_author("claude-opus-4-7"),
-            AuthorKind::Agent { .. }
-        ));
-        assert!(matches!(
-            classify_author("gpt-5.5"),
-            AuthorKind::Agent { .. }
-        ));
-        assert!(matches!(classify_author("daniel"), AuthorKind::Human));
-        assert!(matches!(classify_author(""), AuthorKind::Human));
-    }
-
-    #[test]
-    fn parse_status_filter_accepts_open_resolved_all() {
-        assert!(matches!(
-            parse_status_filter(Some("open")),
-            Ok(Some(ReviewThreadStatus::Open))
-        ));
-        assert!(matches!(
-            parse_status_filter(Some("resolved")),
-            Ok(Some(ReviewThreadStatus::Resolved))
-        ));
-        assert!(matches!(parse_status_filter(Some("all")), Ok(None)));
-        assert!(matches!(parse_status_filter(None), Ok(None)));
-        assert!(parse_status_filter(Some("bogus")).is_err());
-    }
-
-    #[test]
-    fn preview_body_collapses_and_truncates() {
-        assert_eq!(preview_body("hello\n\nworld"), "hello world");
-        let long: String = "a".repeat(500);
-        let preview = preview_body(&long);
-        assert!(preview.chars().count() <= 161);
-        assert!(preview.ends_with('\u{2026}'));
-    }
 }

--- a/crates/orbit-dashboard/src/api/tests/review_threads.rs
+++ b/crates/orbit-dashboard/src/api/tests/review_threads.rs
@@ -5,6 +5,7 @@ use std::sync::Arc;
 
 use axum::body::Body;
 use axum::http::{Method, Request, StatusCode, header};
+use orbit_common::types::ReviewThreadStatus;
 use orbit_core::ActorIdentity;
 use orbit_core::OrbitRuntime;
 use orbit_core::TaskStatus;
@@ -12,6 +13,9 @@ use orbit_core::command::task::{TaskAddParams, TaskUpdateParams};
 use serde_json::Value;
 use tower::ServiceExt;
 
+use super::super::review_threads::{
+    AuthorKind, classify_author, parse_status_filter, preview_body,
+};
 use super::super::router;
 use super::test_support::body_json;
 
@@ -383,4 +387,46 @@ async fn list_review_threads_excludes_threads_on_closed_tasks() {
     let stats = &body["stats"];
     assert_eq!(stats["open"].as_u64(), Some(3));
     assert_eq!(stats["total"].as_u64(), Some(3));
+}
+
+#[test]
+fn classify_author_recognizes_known_families_and_models() {
+    assert!(matches!(
+        classify_author("claude"),
+        AuthorKind::Agent { .. }
+    ));
+    assert!(matches!(
+        classify_author("claude-opus-4-7"),
+        AuthorKind::Agent { .. }
+    ));
+    assert!(matches!(
+        classify_author("gpt-5.5"),
+        AuthorKind::Agent { .. }
+    ));
+    assert!(matches!(classify_author("daniel"), AuthorKind::Human));
+    assert!(matches!(classify_author(""), AuthorKind::Human));
+}
+
+#[test]
+fn parse_status_filter_accepts_open_resolved_all() {
+    assert!(matches!(
+        parse_status_filter(Some("open")),
+        Ok(Some(ReviewThreadStatus::Open))
+    ));
+    assert!(matches!(
+        parse_status_filter(Some("resolved")),
+        Ok(Some(ReviewThreadStatus::Resolved))
+    ));
+    assert!(matches!(parse_status_filter(Some("all")), Ok(None)));
+    assert!(matches!(parse_status_filter(None), Ok(None)));
+    assert!(parse_status_filter(Some("bogus")).is_err());
+}
+
+#[test]
+fn preview_body_collapses_and_truncates() {
+    assert_eq!(preview_body("hello\n\nworld"), "hello world");
+    let long: String = "a".repeat(500);
+    let preview = preview_body(&long);
+    assert!(preview.chars().count() <= 161);
+    assert!(preview.ends_with('\u{2026}'));
 }


### PR DESCRIPTION
## Task

[ORB-00402](https://orbit-cli.com/tasks/ORB-00402) — Cleanup: migrate inline #[cfg(test)] modules to sibling tests/ layout (incremental)

### Description

Bring the test layout into line with the CLAUDE.md / `docs/design-patterns/test_layout.md` convention: unit tests live in a **sibling** `tests/` directory mirroring source filenames (`src/command/skill.rs` → `src/command/tests/skill.rs`), not inline `#[cfg(test)] mod tests` blocks.

**Scope:** a scan found ~178 source files still using the inline pattern. Per-crate counts: orbit-core 43, orbit-store 35, orbit-engine 22, orbit-cli 19, orbit-graph 14, orbit-graph-extract 10, orbit-tools 7, orbit-search 7, orbit-agent 6, orbit-dashboard 5, orbit-common 5, orbit-mcp 2, orbit-exec 2, orbit-policy 1.

**This is deliberately an umbrella / incremental task — NOT a single big-bang PR.** A 178-file mechanical move is high-churn and review-hostile if done at once. Recommended approach:
- One PR per crate (or per subtree for the large crates), smallest crates first to validate the mechanical recipe (orbit-policy → orbit-exec → orbit-mcp …).
- Mechanical recipe: extract each file's `#[cfg(test)] mod tests { ... }` into `<dir>/tests/<filename>.rs`, wire it via the sibling `tests/mod.rs`, fix `use super::*;` paths, run that crate's `cargo test`.
- Track progress against the per-crate counts above; do not silently stop partway without recording how many remain.
- Optional finisher: add a guardrail (e.g. a `scripts/check-*.sh`) that flags new inline test modules once a crate is fully migrated, so the convention doesn't regress.

Deferred from cleanup day by human decision (2026-06-20): worth doing, but as tracked incremental work rather than today.

### Acceptance Criteria

- A documented per-crate migration order exists and the mechanical recipe is validated on at least one small crate end-to-end (cargo test green for that crate)
- Each migrated crate has zero inline #[cfg(test)] mod tests blocks remaining (rg -c verifies), with tests moved to sibling tests/ files
- cargo test passes for every crate touched by each increment
- Remaining un-migrated crates and their counts are recorded in the task as progress is made
- (Optional) a guardrail script flags new inline test modules in fully-migrated crates

## Execution Summary

<details>
<summary>Click to expand</summary>

Increment 1 of incremental test-layout migration: validated the recipe end-to-end on 2 small crates and corrected the scoreboard.

Changes:
- orbit-dashboard: moved inline tests from `src/api/review_threads.rs` to sibling `src/api/tests/review_threads.rs`; widened `classify_author`, `parse_status_filter`, `preview_body`, `AuthorKind` to `pub(super)`. `cargo test -p orbit-dashboard --lib`: 88 passed.
- orbit-agent: moved inline tests from `src/providers/gemini_http/transport.rs` to new `src/providers/gemini_http/tests/transport.rs` (+ `tests/mod.rs`); widened `GEMINI_API_KEY_HEADER`, `generate_content_endpoint`, `cached_contents_endpoint`, `network_error` to `pub(super)`. `cargo test -p orbit-agent --lib`: 26 passed.
- `make ci-fast` passes.

Scoreboard correction: the original "~178 files" count over-counted by matching any `#[cfg(test)]` occurrence. Actual inline `#[cfg(test)] mod tests { ... }` body count is 29 remaining after this PR (orbit-store: 4, orbit-core: 25 + 1 sibling `_tests.rs` to fold). All other crates were already migrated.

Open item flagged for next PR: the 3 remaining orbit-store cases live in non-trivial `mod.rs` files; `docs/design-patterns/test_layout.md` does not address this shape. Proposed naming `<dir>/tests/<dir_name>.rs` documented in the task comment.

Next increments (suggested): one PR for orbit-store (4 files, resolves mod.rs naming convention); 2-3 PRs for orbit-core (25 files + 1 sibling `_tests.rs`); optional guardrail script once both are clean.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-00402-6a36f3f1`
- Behind base: 0
- Ahead of base: 1