### PR TITLE
Classify provider auth/credential failures distinctly and roll back tasks stranded by pre-work run failures

### DIFF
--- a/crates/orbit-agent/src/lib.rs
+++ b/crates/orbit-agent/src/lib.rs
@@ -58,4 +58,7 @@ pub use agent::{Agent, AgentConfig, ProviderOptions};
 pub use orbit_common::types::{InvocationTrace, TokenUsage, ToolCallTrace};
 pub use runtime::AgentRuntime;
 pub use types::{AgentInvocationSpec, AgentOperation, AgentRequest, AgentResponseStatus};
-pub use types::{is_timeout, parse_and_validate_response, peek_response_status};
+pub use types::{
+    ProviderAuthFailure, is_timeout, parse_and_validate_response, peek_provider_auth_failure,
+    peek_response_status,
+};

--- a/crates/orbit-agent/src/types/mod.rs
+++ b/crates/orbit-agent/src/types/mod.rs
@@ -3,7 +3,10 @@ mod response;
 
 pub use request::{AgentOperation, AgentRequest};
 pub use response::{AgentInvocationSpec, AgentResponseStatus};
-pub use response::{is_timeout, parse_and_validate_response, peek_response_status};
+pub use response::{
+    ProviderAuthFailure, is_timeout, parse_and_validate_response, peek_provider_auth_failure,
+    peek_response_status,
+};
 
 #[cfg(test)]
 mod tests;

--- a/crates/orbit-agent/src/types/response.rs
+++ b/crates/orbit-agent/src/types/response.rs
@@ -14,7 +14,10 @@ pub(in crate::types) mod usage;
 use orbit_common::types::{OrbitError, ToolCallTrace};
 use serde_json::Value;
 
-pub use envelope::{is_timeout, parse_and_validate_response, peek_response_status};
+pub use envelope::{
+    ProviderAuthFailure, is_timeout, parse_and_validate_response, peek_provider_auth_failure,
+    peek_response_status,
+};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AgentInvocationSpec {

--- a/crates/orbit-agent/src/types/response/envelope.rs
+++ b/crates/orbit-agent/src/types/response/envelope.rs
@@ -2,7 +2,7 @@ use orbit_common::types::{
     AgentResponseEnvelope, AgentRunError, ExecutionResult, InvocationTrace, OrbitError,
 };
 use serde::Deserialize;
-use serde_json::{Deserializer, Value};
+use serde_json::{Deserializer, Map, Value};
 
 use super::{AgentResponseStatus, ResponseParseResult, trace::extract_invocation_trace};
 
@@ -36,6 +36,30 @@ pub fn peek_response_status(stdout: &str) -> Option<String> {
         .rev()
         .find_map(find_agent_response_envelope)?;
     Some(envelope.status)
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProviderAuthFailure {
+    pub status: Option<u16>,
+    pub message: String,
+}
+
+impl ProviderAuthFailure {
+    pub fn error_code(&self) -> &'static str {
+        "provider_auth"
+    }
+}
+
+/// Best-effort lookup of provider authentication failures in raw CLI stdout.
+///
+/// Claude's CLI can return a wrapper such as `{ "is_error": true,
+/// "api_error_status": 401, "result": "Failed to authenticate..." }` without
+/// an Orbit response envelope. This helper recognizes that provider-shaped
+/// failure without treating ordinary Orbit success/failed envelopes as auth
+/// failures.
+pub fn peek_provider_auth_failure(stdout: &str) -> Option<ProviderAuthFailure> {
+    let documents = parse_json_documents(stdout).ok()?;
+    documents.iter().rev().find_map(find_provider_auth_failure)
 }
 
 fn parse_json_documents(stdout: &str) -> Result<Vec<Value>, OrbitError> {
@@ -255,4 +279,66 @@ fn deserialize_envelope(value: &Value) -> Option<AgentResponseEnvelope> {
         return None;
     }
     serde_json::from_value(value.clone()).ok()
+}
+
+fn find_provider_auth_failure(value: &Value) -> Option<ProviderAuthFailure> {
+    match value {
+        Value::String(raw) => find_provider_auth_failure_in_string(raw),
+        Value::Array(items) => items.iter().rev().find_map(find_provider_auth_failure),
+        Value::Object(map) => provider_auth_failure_from_object(map)
+            .or_else(|| map.values().find_map(find_provider_auth_failure)),
+        _ => None,
+    }
+}
+
+fn find_provider_auth_failure_in_string(raw: &str) -> Option<ProviderAuthFailure> {
+    if let Ok(nested) = serde_json::from_str::<Value>(raw) {
+        return find_provider_auth_failure(&nested);
+    }
+    None
+}
+
+fn provider_auth_failure_from_object(map: &Map<String, Value>) -> Option<ProviderAuthFailure> {
+    if map.get("is_error").and_then(Value::as_bool) != Some(true) {
+        return None;
+    }
+
+    let status = map
+        .get("api_error_status")
+        .and_then(Value::as_u64)
+        .and_then(|status| u16::try_from(status).ok());
+    let result_text = ["result", "message", "error"]
+        .iter()
+        .find_map(|key| map.get(*key).and_then(Value::as_str));
+    let auth_status = matches!(status, Some(401 | 403));
+    let auth_text = result_text.is_some_and(text_indicates_provider_auth_failure);
+    if !auth_status && !auth_text {
+        return None;
+    }
+
+    Some(ProviderAuthFailure {
+        status,
+        message: provider_auth_failure_message(status, result_text),
+    })
+}
+
+fn text_indicates_provider_auth_failure(text: &str) -> bool {
+    let lower = text.to_ascii_lowercase();
+    lower.contains("authenticat") || lower.contains("credential")
+}
+
+fn provider_auth_failure_message(status: Option<u16>, result_text: Option<&str>) -> String {
+    let detail = result_text.map(str::trim).filter(|value| !value.is_empty());
+    match (status, detail) {
+        (Some(status), Some(detail)) => {
+            format!("provider authentication failed with API status {status}: {detail}")
+        }
+        (Some(status), None) => {
+            format!("provider authentication failed with API status {status}")
+        }
+        (None, Some(detail)) => {
+            format!("provider authentication failed: {detail}")
+        }
+        (None, None) => "provider authentication failed".to_string(),
+    }
 }

--- a/crates/orbit-agent/src/types/tests/response.rs
+++ b/crates/orbit-agent/src/types/tests/response.rs
@@ -128,6 +128,36 @@ mod parse {
     }
 
     #[test]
+    fn peek_provider_auth_failure_classifies_claude_auth_stdout() {
+        let stdout = r#"{"type":"result","subtype":"error","is_error":true,"api_error_status":401,"result":"Failed to authenticate. API Error: 401 Invalid authentication credentials","usage":{"input_tokens":0,"output_tokens":0}}"#;
+
+        let classification =
+            peek_provider_auth_failure(stdout).expect("provider auth classification");
+
+        assert_eq!(classification.error_code(), "provider_auth");
+        assert_eq!(classification.status, Some(401));
+        assert!(
+            classification.message.contains("authentication"),
+            "{:?}",
+            classification
+        );
+        assert!(
+            classification.message.contains("credentials"),
+            "{:?}",
+            classification
+        );
+    }
+
+    #[test]
+    fn peek_provider_auth_failure_ignores_normal_envelopes() {
+        let success = r#"{"schemaVersion":1,"status":"success","result":{}}"#;
+        let failed = r#"{"schemaVersion":1,"status":"failed","error":{"code":"agent_failed","message":"ordinary failure","details":null}}"#;
+
+        assert_eq!(peek_provider_auth_failure(success), None);
+        assert_eq!(peek_provider_auth_failure(failed), None);
+    }
+
+    #[test]
     fn synthesize_response_failed_path_carries_usage() {
         // Empty stdout + non-zero exit triggers the synthesize "failed" path.
         // The trace returned alongside the synthesized envelope must preserve

--- a/crates/orbit-core/src/command/job/exec.rs
+++ b/crates/orbit-core/src/command/job/exec.rs
@@ -29,6 +29,7 @@ pub struct V2JobRunResult {
     pub job_name: String,
     pub success: bool,
     pub pipeline: Value,
+    pub error_code: Option<String>,
     pub message: Option<String>,
     pub events_emitted: usize,
     /// Resolved backend applied at load time to every `agent_loop` step in
@@ -128,8 +129,13 @@ impl OrbitRuntime {
                 } else {
                     let fallback = "job completed with success=false but emitted no failure detail";
                     let message = result.message.as_deref().unwrap_or(fallback);
-                    let _ =
-                        self.record_pipeline_failure_step(&run, started_at, finished_at, message);
+                    let _ = self.record_pipeline_failure_step(
+                        &run,
+                        started_at,
+                        finished_at,
+                        result.error_code.as_deref(),
+                        message,
+                    );
                 }
                 self.finalize_job_run_with_reservation_cleanup(
                     &run.run_id,
@@ -138,6 +144,16 @@ impl OrbitRuntime {
                     duration_ms,
                     TaskReservationReleaseReason::RunTerminal,
                 )?;
+                if final_state == JobRunState::Failed {
+                    let fallback = "job completed with success=false but emitted no failure detail";
+                    self.rollback_workflow_admissions_after_failed_run(
+                        &run.run_id,
+                        &run.job_id,
+                        &input,
+                        Some(&result.pipeline),
+                        Some(result.message.as_deref().unwrap_or(fallback)),
+                    );
+                }
                 self.record_event(OrbitEvent::JobRunCompleted {
                     job_id: run.job_id.clone(),
                     run_id: run.run_id.clone(),
@@ -150,6 +166,7 @@ impl OrbitRuntime {
                     &run,
                     started_at,
                     finished_at,
+                    None,
                     &error.to_string(),
                 );
                 self.finalize_job_run_with_reservation_cleanup(
@@ -159,6 +176,13 @@ impl OrbitRuntime {
                     duration_ms,
                     TaskReservationReleaseReason::RunTerminal,
                 )?;
+                self.rollback_workflow_admissions_after_failed_run(
+                    &run.run_id,
+                    &run.job_id,
+                    &input,
+                    None,
+                    Some(&error.to_string()),
+                );
                 self.record_event(OrbitEvent::JobRunCompleted {
                     job_id: run.job_id.clone(),
                     run_id: run.run_id.clone(),
@@ -277,6 +301,7 @@ impl OrbitRuntime {
                 job_name: asset.name,
                 success: o.success,
                 pipeline: o.pipeline,
+                error_code: o.error_code,
                 message: o.message,
                 events_emitted: events_count,
                 resolved_backend: resolution.backend,

--- a/crates/orbit-core/src/command/job/run/reconcile.rs
+++ b/crates/orbit-core/src/command/job/run/reconcile.rs
@@ -69,6 +69,7 @@ impl OrbitRuntime {
             run,
             step_started_at,
             finished_at,
+            None,
             &stale_job_run_message(run, stale_reason),
         );
         self.record_event(OrbitEvent::JobRunCompleted {

--- a/crates/orbit-core/src/command/job/tests/exec.rs
+++ b/crates/orbit-core/src/command/job/tests/exec.rs
@@ -1,0 +1,230 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use chrono::Utc;
+use orbit_common::types::{ExecutorDef, ExecutorType, JobRunState, TaskStatus};
+use serde_json::json;
+use tempfile::tempdir;
+
+use crate::OrbitRuntime;
+use crate::command::activity::seed_default_activities;
+use crate::command::task::TaskAddParams;
+
+fn test_runtime() -> (tempfile::TempDir, OrbitRuntime, PathBuf) {
+    let root = tempdir().expect("create tempdir");
+    let global_root = root.path().join("global");
+    let repo_root = root.path().join("repo");
+    let workspace_root = repo_root.join(".orbit");
+    fs::create_dir_all(&global_root).expect("create global root");
+    fs::create_dir_all(&workspace_root).expect("create workspace root");
+    seed_default_activities(&global_root.join("resources/activities"), true)
+        .expect("seed default activities");
+    let runtime =
+        OrbitRuntime::from_roots(&global_root, &workspace_root).expect("build test runtime");
+    (root, runtime, repo_root)
+}
+
+fn init_git_repo(repo: &Path) {
+    git(repo, &["init"]);
+    git(repo, &["checkout", "-b", "main"]);
+    git(repo, &["config", "user.name", "Orbit Test"]);
+    git(repo, &["config", "user.email", "orbit-test@example.com"]);
+    fs::write(repo.join("README.md"), "test repo\n").expect("write README");
+    git(repo, &["add", "README.md"]);
+    git(repo, &["commit", "-m", "initial commit"]);
+}
+
+fn git(current_dir: &Path, args: &[&str]) {
+    let output = Command::new("git")
+        .args(args)
+        .current_dir(current_dir)
+        .output()
+        .expect("run git");
+    assert!(
+        output.status.success(),
+        "git {} failed in {}:\nstdout: {}\nstderr: {}",
+        args.join(" "),
+        current_dir.display(),
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[cfg(unix)]
+fn write_executable(path: &Path, contents: &str) {
+    use std::os::unix::fs::PermissionsExt;
+
+    fs::write(path, contents).expect("write script");
+    let mut permissions = fs::metadata(path).expect("script metadata").permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(path, permissions).expect("script permissions");
+}
+
+fn add_backlog_task(runtime: &OrbitRuntime) -> String {
+    let task = runtime
+        .add_task(TaskAddParams {
+            title: "Provider auth rollback fixture".to_string(),
+            description: "Exercise failed run rollback behavior.".to_string(),
+            workspace_path: Some(".".to_string()),
+            ..TaskAddParams::default()
+        })
+        .expect("add task");
+    runtime
+        .approve_task(&task.id, Some("approve for workflow".to_string()), None)
+        .expect("approve task");
+    task.id
+}
+
+fn upsert_claude_executor(runtime: &OrbitRuntime, command: &Path) {
+    let now = Utc::now();
+    runtime
+        .upsert_executor_def(&ExecutorDef {
+            name: "claude".to_string(),
+            executor_type: ExecutorType::DirectAgent,
+            command: Some(command.display().to_string()),
+            args: Vec::new(),
+            stdout_format: None,
+            model_pair_override: None,
+            model_flag: None,
+            timeout_seconds: None,
+            env: Default::default(),
+            sandbox: None,
+            allow_fallback: false,
+            created_at: now,
+            updated_at: now,
+        })
+        .expect("seed claude executor");
+}
+
+fn write_auth_failure_job(path: &Path) {
+    let yaml = r#"schemaVersion: 2
+kind: Job
+metadata:
+  name: qa_provider_auth_pipeline
+spec:
+  state: enabled
+  kind: workflow
+  steps:
+    - id: worktree
+      target: activity:worktree_setup
+      default_input:
+        task_ids: "{{ input.task_ids }}"
+        base: main
+        base_sync: local
+        branch_prefix: orbit-test
+    - id: implement_one
+      spec:
+        type: agent_loop
+        instruction: "exercise provider auth classification"
+        tools: []
+        on_denial: terminate
+        max_iterations: 1
+        model: claude-opus-4-7
+        backend: cli
+        provider: claude
+        wall_clock_timeout_seconds: 30
+      default_input:
+        task_id: "{{ input.task_id }}"
+        workspace_path: "{{ steps.worktree.output.workspace_path }}"
+"#;
+    fs::write(path, yaml).expect("write job");
+}
+
+fn auth_failure_stdout() -> &'static str {
+    r#"{"type":"result","subtype":"error","is_error":true,"api_error_status":401,"result":"Failed to authenticate. API Error: 401 Invalid authentication credentials","usage":{"input_tokens":0,"output_tokens":0}}"#
+}
+
+#[cfg(unix)]
+#[test]
+fn provider_auth_failure_persists_error_code_and_rolls_back_pre_work_admission() {
+    let (_root, runtime, repo_root) = test_runtime();
+    init_git_repo(&repo_root);
+    let task_id = add_backlog_task(&runtime);
+    let claude = repo_root.join("claude");
+    write_executable(
+        &claude,
+        &format!(
+            "#!/bin/sh\ncat > /dev/null\nprintf '%s\\n' '{}'\nexit 1\n",
+            auth_failure_stdout()
+        ),
+    );
+    upsert_claude_executor(&runtime, &claude);
+    let yaml_path = repo_root.join("qa_provider_auth_pipeline.yaml");
+    write_auth_failure_job(&yaml_path);
+
+    let result = runtime
+        .run_job_v2_from_yaml(
+            &yaml_path,
+            json!({"task_id": task_id.clone(), "task_ids": [task_id.clone()]}),
+            None,
+        )
+        .expect("job records a failed result");
+
+    assert!(!result.success);
+    assert_eq!(result.error_code.as_deref(), Some("provider_auth"));
+    let run = runtime.show_job_run(&result.run_id).expect("show run");
+    assert_eq!(run.state, JobRunState::Failed);
+    assert!(run.steps.iter().any(|step| {
+        step.error_code.as_deref() == Some("provider_auth")
+            && step
+                .error_message
+                .as_deref()
+                .is_some_and(|message| message.contains("credentials"))
+    }));
+
+    let task = runtime.get_task(&task_id).expect("reload task");
+    assert_eq!(task.status, TaskStatus::Backlog);
+    assert_eq!(task.job_run_id, None);
+    let history = runtime.get_task_history(&task_id).expect("task history");
+    assert!(history.iter().any(|entry| {
+        entry.event == "workflow_admission_rolled_back"
+            && entry.from_status == Some(TaskStatus::InProgress)
+            && entry.to_status == Some(TaskStatus::Backlog)
+    }));
+}
+
+#[cfg(unix)]
+#[test]
+fn provider_auth_failure_after_committed_work_does_not_roll_back_task() {
+    let (_root, runtime, repo_root) = test_runtime();
+    init_git_repo(&repo_root);
+    let task_id = add_backlog_task(&runtime);
+    let claude = repo_root.join("claude");
+    write_executable(
+        &claude,
+        &format!(
+            r#"#!/bin/sh
+cat > /dev/null
+printf '%s\n' 'post-work fixture' > post-work.txt
+git add post-work.txt
+git commit -m 'post-work fixture' >/dev/null
+printf '%s\n' '{}'
+exit 1
+"#,
+            auth_failure_stdout()
+        ),
+    );
+    upsert_claude_executor(&runtime, &claude);
+    let yaml_path = repo_root.join("qa_provider_auth_pipeline.yaml");
+    write_auth_failure_job(&yaml_path);
+
+    let result = runtime
+        .run_job_v2_from_yaml(
+            &yaml_path,
+            json!({"task_id": task_id.clone(), "task_ids": [task_id.clone()]}),
+            None,
+        )
+        .expect("job records a failed result");
+
+    assert!(!result.success);
+    let task = runtime.get_task(&task_id).expect("reload task");
+    assert_eq!(task.status, TaskStatus::InProgress);
+    assert_eq!(task.job_run_id.as_deref(), Some(result.run_id.as_str()));
+    let history = runtime.get_task_history(&task_id).expect("task history");
+    assert!(
+        !history
+            .iter()
+            .any(|entry| entry.event == "workflow_admission_rolled_back")
+    );
+}

--- a/crates/orbit-core/src/command/job/tests/mod.rs
+++ b/crates/orbit-core/src/command/job/tests/mod.rs
@@ -1,1 +1,2 @@
 mod catalog;
+mod exec;

--- a/crates/orbit-core/src/command/pipeline_run.rs
+++ b/crates/orbit-core/src/command/pipeline_run.rs
@@ -8,6 +8,7 @@ use orbit_common::types::{
     AuditEventStatus, JobRun, JobRunState, JobScheduleState, JobTargetType, NotFoundKind,
     OrbitError, OrbitEvent, PipelineState, audit_execution_id,
 };
+use orbit_common::utility::git::run_git;
 use orbit_store::{AuditEventInsertParams, JobRunStepParams, TaskReservationReleaseReason};
 use serde::Serialize;
 use serde_json::{Value, json};
@@ -255,7 +256,7 @@ impl OrbitRuntime {
         match outcome {
             Ok(result) => {
                 let mut state = self.read_run_state(&run.run_id)?.unwrap_or_else(|| {
-                    PipelineState::new(run.run_id.clone(), run.job_id.clone(), input)
+                    PipelineState::new(run.run_id.clone(), run.job_id.clone(), input.clone())
                 });
                 state.sync_pipeline(result.pipeline.clone());
                 self.stores().jobs().write_run_state(&run.run_id, &state)?;
@@ -265,8 +266,13 @@ impl OrbitRuntime {
                 } else {
                     let fallback = "job completed with success=false but emitted no failure detail";
                     let message = result.message.as_deref().unwrap_or(fallback);
-                    let _ =
-                        self.record_pipeline_failure_step(run, started_at, finished_at, message);
+                    let _ = self.record_pipeline_failure_step(
+                        run,
+                        started_at,
+                        finished_at,
+                        result.error_code.as_deref(),
+                        message,
+                    );
                     JobRunState::Failed
                 };
                 self.finalize_job_run_with_reservation_cleanup(
@@ -276,6 +282,16 @@ impl OrbitRuntime {
                     duration_ms,
                     TaskReservationReleaseReason::RunTerminal,
                 )?;
+                if final_state == JobRunState::Failed {
+                    let fallback = "job completed with success=false but emitted no failure detail";
+                    self.rollback_workflow_admissions_after_failed_run(
+                        &run.run_id,
+                        &run.job_id,
+                        &input,
+                        Some(&result.pipeline),
+                        Some(result.message.as_deref().unwrap_or(fallback)),
+                    );
+                }
                 self.record_event(OrbitEvent::JobRunCompleted {
                     job_id: run.job_id.clone(),
                     run_id: run.run_id.clone(),
@@ -288,6 +304,7 @@ impl OrbitRuntime {
                     run,
                     started_at,
                     finished_at,
+                    None,
                     &error.to_string(),
                 );
                 self.finalize_job_run_with_reservation_cleanup(
@@ -297,6 +314,13 @@ impl OrbitRuntime {
                     duration_ms,
                     TaskReservationReleaseReason::RunTerminal,
                 )?;
+                self.rollback_workflow_admissions_after_failed_run(
+                    &run.run_id,
+                    &run.job_id,
+                    &input,
+                    None,
+                    Some(&error.to_string()),
+                );
                 self.record_event(OrbitEvent::JobRunCompleted {
                     job_id: run.job_id.clone(),
                     run_id: run.run_id.clone(),
@@ -312,6 +336,7 @@ impl OrbitRuntime {
         run: &JobRun,
         started_at: chrono::DateTime<Utc>,
         finished_at: chrono::DateTime<Utc>,
+        error_code: Option<&str>,
         message: &str,
     ) -> Result<(), OrbitError> {
         let current = self.show_job_run(&run.run_id)?;
@@ -346,7 +371,7 @@ impl OrbitRuntime {
             exit_code: None,
             agent_response_json: None,
             state: JobRunState::Failed,
-            error_code: None,
+            error_code: error_code.map(str::to_string),
             error_message: Some(message.to_string()),
         };
         let _ = self
@@ -354,6 +379,36 @@ impl OrbitRuntime {
             .jobs()
             .complete_run_step(&run.run_id, &params)?;
         Ok(())
+    }
+
+    pub(crate) fn rollback_workflow_admissions_after_failed_run(
+        &self,
+        run_id: &str,
+        job_id: &str,
+        input: &Value,
+        pipeline: Option<&Value>,
+        error_message: Option<&str>,
+    ) {
+        let has_material_work = pipeline
+            .map(workflow_pipeline_has_material_work)
+            .unwrap_or(true);
+        for task_id in task_ids_from_pipeline_input(input) {
+            if let Err(error) = self.rollback_workflow_admission_after_pre_work_failure_as_system(
+                &task_id,
+                run_id,
+                "worktree_setup",
+                job_id,
+                error_message,
+                has_material_work,
+            ) {
+                tracing::warn!(
+                    task_id = task_id.as_str(),
+                    run_id,
+                    error = %error,
+                    "failed to roll back workflow admission after failed run",
+                );
+            }
+        }
     }
 
     fn collect_pipeline_wait_entries(
@@ -517,6 +572,74 @@ impl OrbitRuntime {
             step_index: None,
         })
     }
+}
+
+fn task_ids_from_pipeline_input(input: &Value) -> Vec<String> {
+    let mut ids = Vec::new();
+    if let Some(task_id) = input
+        .get("task_id")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    {
+        ids.push(task_id.to_string());
+    }
+    if let Some(task_ids) = input.get("task_ids").and_then(Value::as_array) {
+        for task_id in task_ids
+            .iter()
+            .filter_map(Value::as_str)
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+        {
+            if !ids.iter().any(|existing| existing == task_id) {
+                ids.push(task_id.to_string());
+            }
+        }
+    }
+    ids
+}
+
+fn workflow_pipeline_has_material_work(pipeline: &Value) -> bool {
+    let Some(worktree) = pipeline.get("worktree") else {
+        return true;
+    };
+    let Some(workspace_path) = worktree.get("workspace_path").and_then(Value::as_str) else {
+        return true;
+    };
+    let Some(base_ref) = worktree.get("base_ref").and_then(Value::as_str) else {
+        return true;
+    };
+    worktree_has_commits_since_base(Path::new(workspace_path), base_ref)
+        || worktree_has_dirty_changes(Path::new(workspace_path))
+}
+
+fn worktree_has_commits_since_base(workspace_path: &Path, base_ref: &str) -> bool {
+    let range = format!("{base_ref}..HEAD");
+    let Ok(output) = run_git(workspace_path, &["rev-list", "--count", &range]) else {
+        return true;
+    };
+    if !output.success {
+        return true;
+    }
+    output
+        .stdout
+        .trim()
+        .parse::<u64>()
+        .map(|count| count > 0)
+        .unwrap_or(true)
+}
+
+fn worktree_has_dirty_changes(workspace_path: &Path) -> bool {
+    let Ok(output) = run_git(
+        workspace_path,
+        &["status", "--porcelain", "--untracked-files=all"],
+    ) else {
+        return true;
+    };
+    if !output.success {
+        return true;
+    }
+    !output.stdout.trim().is_empty()
 }
 
 fn pipeline_run_is_runnable(runs: &[JobRun], run_id: &str, max_active_runs: u32) -> bool {

--- a/crates/orbit-core/src/command/task/transitions.rs
+++ b/crates/orbit-core/src/command/task/transitions.rs
@@ -449,6 +449,52 @@ impl OrbitRuntime {
         Ok(updated)
     }
 
+    pub(crate) fn rollback_workflow_admission_after_pre_work_failure_as_system(
+        &self,
+        id: &str,
+        run_id: &str,
+        workflow: &str,
+        job_id: &str,
+        error_message: Option<&str>,
+        has_material_work: bool,
+    ) -> Result<bool, OrbitError> {
+        if has_material_work {
+            return Ok(false);
+        }
+
+        let task = self.get_task(id)?;
+        if task.status != TaskStatus::InProgress
+            || task.job_run_id.as_deref() != Some(run_id)
+            || !latest_history_is_workflow_admission_from_backlog(
+                &self.get_task_history(id)?,
+                workflow,
+            )
+        {
+            return Ok(false);
+        }
+
+        let note = workflow_admission_rollback_note(job_id, run_id, error_message);
+        self.with_mutation(|| {
+            let task = self.stores().tasks().update(
+                id,
+                StoreTaskUpdateParams {
+                    actor: SYSTEM_ACTOR_LABEL.to_string(),
+                    status: Some(TaskStatus::Backlog),
+                    status_event: Some("workflow_admission_rolled_back".to_string()),
+                    status_note: Some(note),
+                    job_run_id: Some(None),
+                    ..Default::default()
+                },
+            )?;
+            Ok((
+                true,
+                OrbitEvent::TaskUpdated {
+                    id: task.id.clone(),
+                },
+            ))
+        })
+    }
+
     pub fn reject_task(
         &self,
         id: &str,
@@ -669,4 +715,36 @@ pub(crate) fn ensure_task_has_execution_plan(id: &str, plan: &str) -> Result<(),
 
 pub(crate) fn in_progress_transition_requires_plan(from_status: TaskStatus) -> bool {
     !matches!(from_status, TaskStatus::Backlog | TaskStatus::InProgress)
+}
+
+fn latest_history_is_workflow_admission_from_backlog(
+    history: &[TaskHistoryEntry],
+    workflow: &str,
+) -> bool {
+    let expected_note = format!("workflow admission: {workflow}");
+    history
+        .iter()
+        .rev()
+        .find(|entry| entry.from_status.is_some() || entry.to_status.is_some())
+        .is_some_and(|entry| {
+            entry.event == "started"
+                && entry.by == SYSTEM_ACTOR_LABEL
+                && entry.note.as_deref() == Some(expected_note.as_str())
+                && entry.from_status == Some(TaskStatus::Backlog)
+                && entry.to_status == Some(TaskStatus::InProgress)
+        })
+}
+
+fn workflow_admission_rollback_note(
+    job_id: &str,
+    run_id: &str,
+    error_message: Option<&str>,
+) -> String {
+    let message = error_message
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .unwrap_or("run failed before implementation work was committed");
+    format!(
+        "rolled back workflow admission after pre-work failure: job={job_id}, run_id={run_id}, error={message}"
+    )
 }

--- a/crates/orbit-engine/src/activity_job/cli_runner/orchestrator.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/orchestrator.rs
@@ -4,7 +4,10 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use chrono::Utc;
-use orbit_agent::{Agent, AgentConfig, AgentOperation, AgentRequest, peek_response_status};
+use orbit_agent::{
+    Agent, AgentConfig, AgentOperation, AgentRequest, peek_provider_auth_failure,
+    peek_response_status,
+};
 use orbit_common::types::activity_job::{AgentLoopSpec, V2AuditEventKind};
 use orbit_common::types::{LearningInjectionCaps, LearningInjectionState, prepend_reminder_block};
 use orbit_common::utility::redaction::{PatternRedactor, redact_sensitive_env_text};
@@ -209,10 +212,11 @@ pub fn run_cli_backend(
     let exit_success = !timed_out && matches!(exit_code, Some(0));
     let stdout_text = String::from_utf8_lossy(&stdout);
     let envelope_status = peek_response_status(stdout_text.as_ref());
+    let provider_auth_failure = peek_provider_auth_failure(stdout_text.as_ref());
     let stdout_preview = stdout_text_preview(stdout_text.as_ref(), &redaction);
     let envelope_indicates_failure =
         matches!(envelope_status.as_deref(), Some("failed") | Some("timeout"));
-    let success = exit_success && !envelope_indicates_failure;
+    let success = exit_success && !envelope_indicates_failure && provider_auth_failure.is_none();
     let trace = parse_cli_invocation_trace(
         &stdout,
         &stderr,
@@ -220,11 +224,16 @@ pub fn run_cli_backend(
         duration.as_millis() as u64,
         success,
     );
+    let error_code = provider_auth_failure
+        .as_ref()
+        .map(|failure| failure.error_code().to_string());
     let message = if timed_out {
         Some(format!(
             "cli subprocess exceeded {}s wall-clock timeout",
             timeout_seconds
         ))
+    } else if let Some(failure) = provider_auth_failure {
+        Some(failure.message)
     } else if exit_success && envelope_indicates_failure {
         Some(format!(
             "cli subprocess reported envelope status={:?} despite exit 0",
@@ -253,6 +262,7 @@ pub fn run_cli_backend(
             "stdout_text_preview_bytes": stdout_preview.preview_bytes,
             "stdout_text_preview_limit_bytes": STDOUT_TEXT_PREVIEW_LIMIT_BYTES,
         }),
+        error_code,
         message,
         invocation: trace.map(|trace| DispatchInvocationTrace {
             provider,

--- a/crates/orbit-engine/src/activity_job/cli_runner/tests/orchestrator.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/tests/orchestrator.rs
@@ -653,6 +653,47 @@ fn run_cli_backend_demotes_success_when_envelope_reports_failed_despite_exit_zer
     );
 }
 
+#[test]
+fn run_cli_backend_classifies_provider_auth_failure() {
+    let temp = tempdir().expect("tempdir");
+    let script = temp.path().join("claude");
+    let stdout = r#"{"type":"result","subtype":"error","is_error":true,"api_error_status":401,"result":"Failed to authenticate. API Error: 401 Invalid authentication credentials","usage":{"input_tokens":0,"output_tokens":0}}"#;
+    write_executable(
+        &script,
+        &format!("#!/bin/sh\ncat > /dev/null\nprintf '%s\\n' '{stdout}'\nexit 1\n"),
+    );
+
+    let sink_for_writer: Arc<dyn AuditSink> = Arc::new(RecordingSink::default());
+    let audit = Arc::new(V2AuditWriter::new(
+        "job-provider-auth",
+        "claude:claude-opus-4-7",
+        sink_for_writer,
+    ));
+    let host = TestHost::with_command(script.display().to_string());
+    let mut spec = test_agent_loop_spec_for("claude", Duration::from_secs(5));
+    spec.model = Some("claude-opus-4-7".to_string());
+
+    let outcome = run_cli_backend(
+        &host,
+        &spec,
+        "job-provider-auth",
+        audit,
+        &serde_json::json!({"prompt": "hi", "task_id": "TAUTH"}),
+        None,
+    )
+    .expect("run cli backend");
+
+    assert!(!outcome.success);
+    assert_eq!(outcome.error_code.as_deref(), Some("provider_auth"));
+    let message = outcome.message.expect("classified message");
+    assert!(message.contains("authentication"), "{message}");
+    assert!(message.contains("credentials"), "{message}");
+    assert!(
+        !message.contains("cli subprocess exited with code"),
+        "{message}"
+    );
+}
+
 /// Sanity check that the demotion does not regress the happy path: an exit-0
 /// run with a `status: "success"` envelope must still be classified as
 /// success. Without this, the demotion logic could silently flip every

--- a/crates/orbit-engine/src/activity_job/dispatcher.rs
+++ b/crates/orbit-engine/src/activity_job/dispatcher.rs
@@ -197,6 +197,7 @@ pub struct V2DispatchInput<'a> {
 pub struct DispatchOutcome {
     pub success: bool,
     pub output: Value,
+    pub error_code: Option<String>,
     pub message: Option<String>,
     pub invocation: Option<DispatchInvocationTrace>,
 }
@@ -411,6 +412,7 @@ fn run_deterministic(
     Ok(DispatchOutcome {
         success: true,
         output,
+        error_code: None,
         message: None,
         invocation: None,
     })
@@ -486,6 +488,7 @@ fn run_agent_loop_via_driver(
     Ok(DispatchOutcome {
         success: true,
         output: agent_loop_output_from_final_message(&outcome.final_message, metadata),
+        error_code: None,
         message: None,
         invocation: Some(DispatchInvocationTrace {
             provider: spec.provider.as_str().to_string(),

--- a/crates/orbit-engine/src/activity_job/groundhog/mod.rs
+++ b/crates/orbit-engine/src/activity_job/groundhog/mod.rs
@@ -66,6 +66,7 @@ pub fn run_groundhog_activity(
                     "completed_checkpoints": chronicle.days.len(),
                     "chronicle_days": chronicle.days.len(),
                 }),
+                error_code: None,
                 message: Some("groundhog run completed all checkpoints".to_string()),
                 invocation: None,
             });
@@ -166,6 +167,7 @@ pub fn run_groundhog_activity(
                                 "checkpoint_id": checkpoint.id,
                                 "reason": "attempt budget exhausted",
                             }),
+                            error_code: None,
                             message: Some(format!(
                                 "checkpoint `{}` exhausted its attempt budget",
                                 checkpoint.id
@@ -247,6 +249,7 @@ pub fn run_groundhog_activity(
                             "checkpoint_id": checkpoint.id,
                             "reason": "attempt budget exhausted",
                         }),
+                        error_code: None,
                         message: Some(format!(
                             "checkpoint `{}` exhausted its attempt budget",
                             checkpoint.id

--- a/crates/orbit-engine/src/activity_job/job_executor/exec_ctx.rs
+++ b/crates/orbit-engine/src/activity_job/job_executor/exec_ctx.rs
@@ -68,6 +68,7 @@ pub(super) fn wrap_step_output(raw: &Value) -> Value {
 pub(super) struct StepOutcome {
     pub(super) success: bool,
     pub(super) output: Value,
+    pub(super) error_code: Option<String>,
     pub(super) message: Option<String>,
     /// `true` when `when:` returned false and the step did not run. Kept for
     /// future callers that need to distinguish a skipped-but-successful step

--- a/crates/orbit-engine/src/activity_job/job_executor/fan_out.rs
+++ b/crates/orbit-engine/src/activity_job/job_executor/fan_out.rs
@@ -35,6 +35,7 @@ pub(super) fn run_fan_out(
         return Ok(StepOutcome {
             success: true,
             output: Value::Array(Vec::new()),
+            error_code: None,
             message: None,
             skipped: false,
         });
@@ -181,6 +182,7 @@ pub(super) fn run_fan_out(
     Ok(StepOutcome {
         success: block_ok,
         output: collected_value,
+        error_code: None,
         message: None,
         skipped: false,
     })

--- a/crates/orbit-engine/src/activity_job/job_executor/loop_block.rs
+++ b/crates/orbit-engine/src/activity_job/job_executor/loop_block.rs
@@ -60,6 +60,7 @@ pub(super) fn run_loop(
                 return Ok(StepOutcome {
                     success: false,
                     output: outcome.output,
+                    error_code: outcome.error_code,
                     message: outcome.message,
                     skipped: false,
                 });
@@ -112,6 +113,7 @@ pub(super) fn run_loop(
     Ok(StepOutcome {
         success: true,
         output: out,
+        error_code: None,
         message: None,
         skipped: false,
     })

--- a/crates/orbit-engine/src/activity_job/job_executor/mod.rs
+++ b/crates/orbit-engine/src/activity_job/job_executor/mod.rs
@@ -82,6 +82,7 @@ pub use self::validate::validate_job;
 pub struct JobOutcome {
     pub success: bool,
     pub pipeline: Value,
+    pub error_code: Option<String>,
     pub message: Option<String>,
 }
 
@@ -133,11 +134,13 @@ pub fn execute_job(
     };
 
     let mut overall_ok = true;
+    let mut overall_error_code = None;
     let mut overall_message = None;
     for step in &job.steps {
         let outcome = run_step(step, &ctx)?;
         if !outcome.success {
             overall_ok = false;
+            overall_error_code = outcome.error_code;
             overall_message = Some(
                 outcome
                     .message
@@ -159,6 +162,7 @@ pub fn execute_job(
     Ok(JobOutcome {
         success: overall_ok,
         pipeline,
+        error_code: (!overall_ok).then_some(overall_error_code).flatten(),
         message: (!overall_ok).then_some(overall_message).flatten(),
     })
 }

--- a/crates/orbit-engine/src/activity_job/job_executor/parallel.rs
+++ b/crates/orbit-engine/src/activity_job/job_executor/parallel.rs
@@ -13,6 +13,7 @@ pub(super) fn run_parallel(
         return Ok(StepOutcome {
             success: true,
             output: Value::Array(Vec::new()),
+            error_code: None,
             message: None,
             skipped: false,
         });
@@ -113,6 +114,7 @@ pub(super) fn run_parallel(
     Ok(StepOutcome {
         success: block_ok,
         output: out,
+        error_code: None,
         message: None,
         skipped: false,
     })

--- a/crates/orbit-engine/src/activity_job/job_executor/step.rs
+++ b/crates/orbit-engine/src/activity_job/job_executor/step.rs
@@ -18,6 +18,7 @@ pub(super) fn run_step(step: &JobV2Step, ctx: &ExecCtx<'_>) -> Result<StepOutcom
             return Ok(StepOutcome {
                 success: true,
                 output: Value::Null,
+                error_code: None,
                 message: None,
                 skipped: true,
             });
@@ -114,6 +115,7 @@ pub(super) fn run_step_with_retry(
         None => Ok(StepOutcome {
             success: false,
             output: Value::Null,
+            error_code: None,
             message: None,
             skipped: false,
         }),

--- a/crates/orbit-engine/src/activity_job/job_executor/target.rs
+++ b/crates/orbit-engine/src/activity_job/job_executor/target.rs
@@ -84,6 +84,7 @@ pub(super) fn run_target(
             Ok(StepOutcome {
                 success: dispatch.success,
                 output: out,
+                error_code: dispatch.error_code,
                 message: dispatch.message,
                 skipped: false,
             })
@@ -105,6 +106,7 @@ pub(super) fn run_target(
             Ok(StepOutcome {
                 success: dispatch.success,
                 output: out,
+                error_code: dispatch.error_code,
                 message: dispatch.message,
                 skipped: false,
             })
@@ -181,6 +183,7 @@ pub(super) fn run_agent_loop_outcome(
     Ok(StepOutcome {
         success: true,
         output: out_json,
+        error_code: None,
         message: None,
         skipped: false,
     })


### PR DESCRIPTION
## Task

[ORB-00407](https://orbit-cli.com/tasks/ORB-00407) — Classify provider auth/credential failures distinctly and roll back tasks stranded by pre-work run failures

### Description

## Problem
Run `jrun-20260621-2010-3` (job `task_pr_pipeline`, task `ORB-00406`) died when the sandboxed `claude` CLI returned `401 Invalid authentication credentials` on its first API call (`implement_one`, model `claude-opus-4-7`, 1 turn, 0 tokens, $0, ~2.5s). See friction `F2026-06-004`. Two distinct defects surfaced:

**1. Provider auth failures are flattened into a generic exit-code message.** The 401 is only visible by digging into `implement_one.stdout_text` (`is_error:true`, `api_error_status:401`, `result:"Failed to authenticate. API Error: 401 Invalid authentication credentials"`). At the run/step level it was recorded as `error_code: null` and `error_message: "cli subprocess exited with code Some(1)"`. The message-building site is [orchestrator.rs:223-237](crates/orbit-engine/src/activity_job/cli_runner/orchestrator.rs:223), which already special-cases timeout and envelope-failure via `peek_response_status` ([envelope.rs:32](crates/orbit-agent/src/types/response/envelope.rs:32)). Auth/credential failures are environmental and retryable and deserve a distinct, surfaced classification.

**2. Tasks are stranded `in-progress` after a pre-work failure.** `worktree_setup` admission flips the task `backlog -> in_progress` ([transitions.rs:389-444](crates/orbit-core/src/command/task/transitions.rs:389)) at 20:10:32; the run then failed at 20:10:36 before any work landed (empty worktree, no recovery). The task is left in `in-progress` and must be manually reset to `backlog` before it can run again, which also pollutes batching/admission state.

## Why It Matters
Auth failures are common and environmental (expired token/key). Today they read as opaque code-1 failures and silently park the task mid-lifecycle, costing operator time to diagnose (digging into stdout blobs) and to recover (manual status reset). A distinct error class + automatic rollback on pre-work failure makes these self-evident and self-healing.

## Scope
- Add detection of the provider auth-error shape (claude wrapper `is_error:true` with `api_error_status` in {401,403}, or `result` text indicating an authentication/credentials failure) as a small typed helper alongside `peek_response_status` in `crates/orbit-agent/src/types/response/envelope.rs`.
- Surface a distinct classification on the run record (e.g. `error_code = provider_auth`) and a human-readable `error_message` naming authentication, wired through the dispatch outcome in `crates/orbit-engine/src/activity_job/cli_runner/orchestrator.rs`.
- Roll a task back to its pre-admission status (`backlog`) when a run fails before any implementation work has been committed, in/near `crates/orbit-core/src/command/task/transitions.rs`. The rollback MUST be guarded so it never clobbers a task whose run already produced committed changes.

## Constraints / Notes
- Follow the error-translation pattern in [docs/design-patterns/error_translation.md](docs/design-patterns/error_translation.md) and prefer a typed `thiserror`/`OrbitError` variant over an ad-hoc string; consider the existing `AgentRunError` taxonomy.
- Tests go in sibling `tests/` dirs per [docs/design-patterns/test_layout.md](docs/design-patterns/test_layout.md) (e.g. `crates/orbit-agent/src/types/tests/response.rs`). Keep them deterministic with static stdout fixtures / in-memory task stores.
- Do not edit run-bundle or audit files; this changes code paths only.
- If the planner prefers, parts (1) and (2) may be split into sibling tasks, but they share one trigger and one report.

### Acceptance Criteria

- Given the claude auth-failure stdout fixture (containing `"api_error_status":401` and `"Failed to authenticate. API Error: 401 Invalid authentication credentials"`), a new helper in crates/orbit-agent/src/types/response/envelope.rs returns a provider-auth classification; a unit test in crates/orbit-agent/src/types/tests/response.rs asserts this, and a negative test asserts a normal success/failed envelope returns no auth classification.
- When implement_one fails due to provider auth, `orbit run show <run_id> --json` reports a distinct `error_code` (e.g. `provider_auth`) and an `error_message` that names authentication/credentials rather than the generic `cli subprocess exited with code Some(1)`. Covered by a deterministic dispatcher-level test feeding the auth-failure stdout fixture and asserting the classified outcome message/code.
- When a run fails before any implementation work is committed, a task transitioned `backlog -> in_progress` solely by `worktree_setup` admission is rolled back to `backlog`, and a rollback event is appended to the task history. Verified by a deterministic test (in-memory/temp store) that drives admission then a pre-work failure and asserts final status == backlog with the rollback history entry.
- The rollback is guarded: a failure that occurs AFTER implementation has produced committed work leaves the task in `in-progress`. A test asserts a post-work failure does NOT roll the task back.
- `make ci-fast` passes; all new/changed unit tests live in sibling `tests/` directories per the test-layout convention; no new clippy or unwrap-at-boundary violations are introduced.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Added `peek_provider_auth_failure` and `ProviderAuthFailure` in `orbit-agent`, exported through the public agent type surface, and covered the Claude 401 stdout fixture plus normal envelope negatives.
- Classified provider-auth CLI failures in the v2 CLI orchestrator as `error_code=provider_auth` with an authentication/credentials message, then threaded dispatch error codes through step/job outcomes so `orbit run show` persists the distinct code.
- Added guarded workflow-admission rollback: failed runs inspect the admitted worktree for commits or dirty changes, roll back only clean backlog -> in-progress `worktree_setup` admissions, clear `job_run_id`, and append `workflow_admission_rolled_back` history.
- Added deterministic dispatcher and end-to-end job tests for auth classification, pre-work rollback, persisted run error_code, and the post-commit guard.

Assessment: Targeted implementation with conservative rollback behavior; unknown worktree state or material work prevents rollback.

Validation:
- `cargo test -p orbit-agent peek_provider_auth_failure`
- `cargo test -p orbit-engine activity_job::cli_runner::tests::orchestrator::run_cli_backend_classifies_provider_auth_failure`
- `cargo test -p orbit-core provider_auth_failure_`
- `cargo check --workspace`
- `make ci-fast`

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-00407-6a385fe8`
- Behind base: 0
- Ahead of base: 1