### PR TITLE
[ORB-00029] web: add `orbit web connect <ssh-host>` SSH-tunnel command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Highlights
+
+- **`orbit web connect <ssh-host>`**: a client-side convenience command that views a workspace's dashboard running on another machine over an SSH tunnel — automating the manual `ssh -L 7878:localhost:7878 <host> "orbit web serve --no-open"` dance. It picks a free local port (preferring 7878, else ephemeral), starts `orbit web serve --no-open` on the remote, forwards the port, waits for `/healthz`, opens the browser, and tears the tunnel (and remote serve process) down cleanly on Ctrl-C. The loopback-only bind guard (ORB-00360) is untouched and auth is delegated entirely to SSH — no new network attack surface. Flags: `--port`, `--remote-port`, `--root`, `--no-open`. ([ORB-00029])
+
 ## 0.9.2
 
 ### Highlights

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2242,6 +2242,7 @@ dependencies = [
  "chrono",
  "clap",
  "futures-core",
+ "libc",
  "orbit-common",
  "orbit-core",
  "rusqlite",

--- a/README.md
+++ b/README.md
@@ -124,6 +124,10 @@ orbit run ship
 
 # launch interactive dashboard
 orbit web serve
+
+# ...or view a workspace running on another machine over an SSH tunnel
+# (the dashboard stays loopback-only; auth is delegated to SSH)
+orbit web connect my-server
 ```
 
 </details>

--- a/crates/orbit-cli/src/audit_middleware.rs
+++ b/crates/orbit-cli/src/audit_middleware.rs
@@ -565,6 +565,7 @@ pub fn extract_command_meta(cmd: &Commands) -> CommandMeta {
             use crate::command::web::WebSubcommand;
             let sub = match &cmd.command {
                 WebSubcommand::Serve(_) => "serve",
+                WebSubcommand::Connect(_) => "connect",
             };
             CommandMeta {
                 command: "web".to_string(),

--- a/crates/orbit-cli/src/command/tests/mod.rs
+++ b/crates/orbit-cli/src/command/tests/mod.rs
@@ -89,6 +89,22 @@ fn cli_parses_web_serve() {
     match cli.command {
         Commands::Web(command) => match command.command {
             WebSubcommand::Serve(_) => {}
+            WebSubcommand::Connect(_) => panic!("expected serve"),
+        },
+        _ => panic!("expected top-level web command"),
+    }
+}
+
+#[test]
+fn cli_parses_web_connect() {
+    let cli = Cli::parse_from(["orbit", "web", "connect", "my-host", "--no-open"]);
+    match cli.command {
+        Commands::Web(command) => match command.command {
+            WebSubcommand::Connect(args) => {
+                assert_eq!(args.ssh_host, "my-host");
+                assert!(args.no_open);
+            }
+            WebSubcommand::Serve(_) => panic!("expected connect"),
         },
         _ => panic!("expected top-level web command"),
     }

--- a/crates/orbit-cli/src/command/web.rs
+++ b/crates/orbit-cli/src/command/web.rs
@@ -31,12 +31,17 @@ impl Execute for WebCommand {
 pub enum WebSubcommand {
     /// Run the Orbit dashboard
     Serve(orbit_dashboard::ServeArgs),
+    /// Open a remote workspace's dashboard over an SSH tunnel
+    Connect(orbit_dashboard::ConnectArgs),
 }
 
 impl Execute for WebSubcommand {
     fn execute(self, runtime: &OrbitRuntime) -> Result<(), OrbitError> {
         match self {
             WebSubcommand::Serve(args) => orbit_dashboard::serve(runtime, args),
+            // `connect` is a client-side tunnel helper; the workspace lives on
+            // the remote, so it needs no local runtime.
+            WebSubcommand::Connect(args) => orbit_dashboard::connect(args),
         }
     }
 }

--- a/crates/orbit-dashboard/Cargo.toml
+++ b/crates/orbit-dashboard/Cargo.toml
@@ -15,6 +15,7 @@ axum.workspace = true
 chrono.workspace = true
 clap.workspace = true
 futures-core.workspace = true
+libc.workspace = true
 orbit-common = { path = "../orbit-common" }
 orbit-core = { path = "../orbit-core" }
 serde.workspace = true

--- a/crates/orbit-dashboard/src/connect.rs
+++ b/crates/orbit-dashboard/src/connect.rs
@@ -1,0 +1,384 @@
+//! `orbit web connect <ssh-host>` — client-side SSH-tunnel convenience.
+//!
+//! The dashboard binds loopback-only by design (see [`crate::check_bindable_host`],
+//! ORB-00360): it has no authentication, so it must never be exposed to a
+//! network directly. To view a workspace's dashboard from another machine the
+//! supported path is an authenticated SSH tunnel — historically the manual
+//! `ssh -L 7878:localhost:7878 <host> "orbit web serve --no-open"`.
+//!
+//! `connect` automates exactly that workflow and nothing more: it delegates
+//! authentication to SSH, keeps the loopback bind guard intact, and adds no new
+//! attack surface. It runs `orbit web serve` on the remote over a single `ssh`
+//! invocation that also forwards a local port, waits for the remote server to
+//! answer `/healthz`, opens a browser, and — on Ctrl-C — tears the tunnel down
+//! so no orphaned remote `orbit web serve` process is left behind.
+//!
+//! Unlike [`crate::serve`], this command reads no local `.orbit/` state: the
+//! workspace lives on the remote, so it needs no [`orbit_core::OrbitRuntime`].
+
+use std::io::{BufRead, BufReader, Write};
+use std::net::{Ipv4Addr, SocketAddr, TcpListener, TcpStream};
+use std::process::{Child, Command, ExitStatus, Stdio};
+use std::time::{Duration, Instant};
+
+use clap::Args;
+use orbit_core::OrbitError;
+
+use crate::{DEFAULT_DASHBOARD_PORT, open_browser};
+
+/// How long to wait for the remote dashboard to answer `/healthz` before
+/// giving up. Generous because it covers SSH connect + remote process spawn.
+const READINESS_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Delay between readiness probes.
+const POLL_INTERVAL: Duration = Duration::from_millis(250);
+
+/// Per-probe TCP connect/read/write timeout for the `/healthz` check.
+const PROBE_TIMEOUT: Duration = Duration::from_millis(500);
+
+/// Grace period between SIGTERM and SIGKILL when tearing the tunnel down.
+#[cfg(unix)]
+const TEARDOWN_GRACE: Duration = Duration::from_secs(2);
+
+/// Arguments for `orbit web connect`.
+#[derive(Args, Clone)]
+#[command(about = "Open a remote workspace's dashboard over an SSH tunnel")]
+pub struct ConnectArgs {
+    /// SSH destination — anything `ssh` accepts (`host`, `user@host`, or a
+    /// `~/.ssh/config` alias).
+    pub ssh_host: String,
+
+    /// Local port for the tunnel. Defaults to 7878, falling back to an
+    /// ephemeral port if 7878 is already in use.
+    #[arg(long)]
+    pub port: Option<u16>,
+
+    /// Port the remote `orbit web serve` listens on (remote loopback).
+    #[arg(long, default_value_t = DEFAULT_DASHBOARD_PORT)]
+    pub remote_port: u16,
+
+    /// Remote workspace path, passed through to `orbit web serve --root` on
+    /// the remote host. Omit to use the remote's default workspace resolution.
+    #[arg(long)]
+    pub root: Option<String>,
+
+    /// Do not open the dashboard URL in a browser once the tunnel is ready.
+    #[arg(long)]
+    pub no_open: bool,
+}
+
+/// Establish the tunnel, wait for readiness, open the browser, and block until
+/// Ctrl-C / SIGTERM — then tear everything down cleanly.
+pub fn connect(args: ConnectArgs) -> Result<(), OrbitError> {
+    let local_port = select_local_port(args.port)?;
+    let ssh_args = build_ssh_args(&args, local_port);
+
+    // Force a pty (`-tt`) so that when we kill the local `ssh`, the remote
+    // `orbit web serve` receives SIGHUP and exits — no orphan. `stdin` is null
+    // so Ctrl-C is delivered to *us* (the foreground process) rather than being
+    // forwarded down the pty to the remote.
+    let child = Command::new("ssh")
+        .args(&ssh_args)
+        .stdin(Stdio::null())
+        .spawn()
+        .map_err(|e| OrbitError::Io(format!("failed to launch ssh: {e}")))?;
+
+    // From here on, every exit path (error, panic, normal) tears the tunnel
+    // down via `SshTunnel`'s `Drop`.
+    let mut tunnel = SshTunnel::new(child);
+
+    let url = format!("http://localhost:{local_port}");
+    wait_until_ready(&mut tunnel, local_port)?;
+
+    #[allow(clippy::print_stdout)]
+    {
+        println!("Dashboard tunnel ready: {url}  (Ctrl-C to disconnect)");
+    }
+
+    if !args.no_open {
+        open_browser(&url);
+    }
+
+    wait_for_shutdown(&mut tunnel);
+    Ok(())
+}
+
+// Visibility note: the pure helpers below are `pub(crate)` so the sibling
+// `tests/connect.rs` module can exercise them directly (the crate's test-layout
+// convention). None are part of the crate's public API.
+
+/// Choose the local port to bind the tunnel to.
+///
+/// - An explicit `--port` is honored or fails with a clear error if busy.
+/// - Otherwise prefer the conventional [`DEFAULT_DASHBOARD_PORT`], falling back
+///   to an OS-assigned ephemeral port when it is taken.
+///
+/// Note: this is inherently racy (TOCTOU) — the probed port can be claimed by
+/// another process before `ssh` binds it. That is acceptable for a developer
+/// convenience command; if it happens, `ssh -L` fails loudly on startup.
+pub(crate) fn select_local_port(preferred: Option<u16>) -> Result<u16, OrbitError> {
+    match preferred {
+        Some(port) => {
+            probe_bindable(port).map_err(|e| {
+                OrbitError::InvalidInput(format!(
+                    "requested local port {port} is not available: {e}"
+                ))
+            })?;
+            Ok(port)
+        }
+        None => {
+            if probe_bindable(DEFAULT_DASHBOARD_PORT).is_ok() {
+                Ok(DEFAULT_DASHBOARD_PORT)
+            } else {
+                ephemeral_port()
+            }
+        }
+    }
+}
+
+/// Return `Ok` if a loopback TCP listener can bind `port` (immediately released).
+pub(crate) fn probe_bindable(port: u16) -> std::io::Result<()> {
+    TcpListener::bind((Ipv4Addr::LOCALHOST, port)).map(|_| ())
+}
+
+/// Ask the OS for a free ephemeral loopback port.
+pub(crate) fn ephemeral_port() -> Result<u16, OrbitError> {
+    let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0))
+        .map_err(|e| OrbitError::Io(format!("could not reserve a local port: {e}")))?;
+    listener
+        .local_addr()
+        .map(|addr| addr.port())
+        .map_err(|e| OrbitError::Io(format!("could not read reserved local port: {e}")))
+}
+
+/// Build the argument vector passed to `ssh` (everything after the program).
+///
+/// Pure and deterministic so it can be unit-tested without spawning anything.
+pub(crate) fn build_ssh_args(cfg: &ConnectArgs, local_port: u16) -> Vec<String> {
+    vec![
+        // Force pty allocation even though our stdin is null, so the remote
+        // command dies (SIGHUP) when the tunnel drops.
+        "-tt".to_string(),
+        // Fail fast if the local port cannot be forwarded rather than silently
+        // running the remote command with no working tunnel.
+        "-o".to_string(),
+        "ExitOnForwardFailure=yes".to_string(),
+        "-L".to_string(),
+        format!("{local_port}:localhost:{}", cfg.remote_port),
+        cfg.ssh_host.clone(),
+        remote_serve_command(cfg),
+    ]
+}
+
+/// The remote shell command line: `orbit web serve --no-open --port N [--root P]`.
+///
+/// `ssh` concatenates trailing args with spaces and re-parses them via the
+/// remote shell, so any value that could contain spaces (`--root`) is
+/// shell-quoted.
+pub(crate) fn remote_serve_command(cfg: &ConnectArgs) -> String {
+    let mut cmd = format!("orbit web serve --no-open --port {}", cfg.remote_port);
+    if let Some(root) = &cfg.root {
+        cmd.push_str(" --root ");
+        cmd.push_str(&shell_quote(root));
+    }
+    cmd
+}
+
+/// POSIX single-quote a value for safe interpolation into the remote command.
+pub(crate) fn shell_quote(value: &str) -> String {
+    // Wrap in single quotes; a literal `'` becomes `'\''`.
+    format!("'{}'", value.replace('\'', "'\\''"))
+}
+
+/// Poll `/healthz` until the remote dashboard answers, or fail if `ssh` exits
+/// first (misconfigured host, `orbit` not on PATH, …) or the timeout elapses.
+fn wait_until_ready(tunnel: &mut SshTunnel, local_port: u16) -> Result<(), OrbitError> {
+    let deadline = Instant::now() + READINESS_TIMEOUT;
+    loop {
+        if let Some(status) = tunnel.try_wait()? {
+            return Err(classify_ssh_exit(status));
+        }
+        if healthz_ok(local_port) {
+            return Ok(());
+        }
+        if Instant::now() >= deadline {
+            return Err(OrbitError::Execution(format!(
+                "timed out after {}s waiting for the remote dashboard at \
+                 http://localhost:{local_port}/healthz to become ready",
+                READINESS_TIMEOUT.as_secs()
+            )));
+        }
+        std::thread::sleep(POLL_INTERVAL);
+    }
+}
+
+/// Best-effort `GET /healthz` over the forwarded local port. Returns `true`
+/// only on a `200` status line. Any connect/IO error (including `ssh` refusing
+/// the forwarded connection because the remote server is not up yet) is `false`.
+fn healthz_ok(local_port: u16) -> bool {
+    let addr = SocketAddr::from((Ipv4Addr::LOCALHOST, local_port));
+    let Ok(mut stream) = TcpStream::connect_timeout(&addr, PROBE_TIMEOUT) else {
+        return false;
+    };
+    let _ = stream.set_read_timeout(Some(PROBE_TIMEOUT));
+    let _ = stream.set_write_timeout(Some(PROBE_TIMEOUT));
+    if stream
+        .write_all(b"GET /healthz HTTP/1.0\r\nHost: localhost\r\nConnection: close\r\n\r\n")
+        .is_err()
+    {
+        return false;
+    }
+    let mut status_line = String::new();
+    if BufReader::new(stream).read_line(&mut status_line).is_err() {
+        return false;
+    }
+    status_line.starts_with("HTTP/1.") && status_line.contains(" 200 ")
+}
+
+/// Map an early `ssh` exit to an actionable error.
+pub(crate) fn classify_ssh_exit(status: ExitStatus) -> OrbitError {
+    match status.code() {
+        // The remote shell returns 127 when it cannot find the command.
+        Some(127) => OrbitError::Execution(
+            "`orbit` was not found on the remote host's PATH (ssh exited 127). \
+             Ensure orbit is installed and on PATH for non-interactive SSH \
+             sessions (e.g. add it to ~/.profile / ~/.bashrc on the remote)."
+                .to_string(),
+        ),
+        // ssh's own failure code (bad host, auth, network).
+        Some(255) => OrbitError::Execution(
+            "ssh could not connect (exit 255). Check the host, your SSH \
+             config/keys, and network reachability."
+                .to_string(),
+        ),
+        Some(code) => OrbitError::Execution(format!(
+            "remote `orbit web serve` exited with status {code} before the \
+             dashboard became ready"
+        )),
+        None => OrbitError::Execution(
+            "ssh was terminated by a signal before the dashboard became ready".to_string(),
+        ),
+    }
+}
+
+/// Block until Ctrl-C / SIGTERM, or until the `ssh` child exits on its own
+/// (e.g. the remote server dies). Teardown then happens via `SshTunnel::Drop`.
+///
+/// Uses a small current-thread tokio runtime and the same signal primitives as
+/// [`crate::serve`] so behavior is consistent across the two `web` surfaces. If
+/// the runtime cannot be built we fall back to a plain poll loop that at least
+/// returns when the child exits (teardown still runs on drop; a Ctrl-C in that
+/// degraded mode terminates the process, and the OS reaps the tunnel).
+fn wait_for_shutdown(tunnel: &mut SshTunnel) {
+    let Ok(rt) = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+    else {
+        while !matches!(tunnel.try_wait(), Ok(Some(_))) {
+            std::thread::sleep(POLL_INTERVAL);
+        }
+        return;
+    };
+
+    rt.block_on(async {
+        let ctrl_c = async {
+            let _ = tokio::signal::ctrl_c().await;
+        };
+
+        #[cfg(unix)]
+        let terminate = async {
+            if let Ok(mut sig) =
+                tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())
+            {
+                sig.recv().await;
+            }
+        };
+        #[cfg(not(unix))]
+        let terminate = std::future::pending::<()>();
+
+        // Also return if `ssh` dies on its own (remote server crashed, network
+        // dropped, …) so we do not hang forever.
+        let child_exit = async {
+            while !matches!(tunnel.try_wait(), Ok(Some(_))) {
+                tokio::time::sleep(POLL_INTERVAL).await;
+            }
+        };
+
+        tokio::select! {
+            _ = ctrl_c => {}
+            _ = terminate => {}
+            _ = child_exit => {}
+        }
+    });
+}
+
+/// RAII owner of the `ssh` child that guarantees teardown of the tunnel (and,
+/// via the remote pty's SIGHUP, the remote `orbit web serve`) on drop.
+pub(crate) struct SshTunnel {
+    child: Option<Child>,
+}
+
+impl SshTunnel {
+    pub(crate) fn new(child: Child) -> Self {
+        Self { child: Some(child) }
+    }
+
+    /// Non-blocking check for the child's exit status.
+    pub(crate) fn try_wait(&mut self) -> Result<Option<ExitStatus>, OrbitError> {
+        match &mut self.child {
+            Some(child) => child
+                .try_wait()
+                .map_err(|e| OrbitError::Io(format!("waiting on ssh: {e}"))),
+            None => Ok(None),
+        }
+    }
+
+    /// Terminate the `ssh` child if it is still running. Idempotent.
+    pub(crate) fn shutdown(&mut self) {
+        let Some(mut child) = self.child.take() else {
+            return;
+        };
+        if let Ok(Some(_)) = child.try_wait() {
+            return; // already gone
+        }
+        terminate_child(&mut child);
+    }
+}
+
+impl Drop for SshTunnel {
+    fn drop(&mut self) {
+        self.shutdown();
+    }
+}
+
+/// Ask the child to exit gracefully (SIGTERM), then force it (SIGKILL) if it
+/// does not within [`TEARDOWN_GRACE`]. Closing `ssh` drops the connection,
+/// which delivers SIGHUP to the remote pty session and stops the remote serve.
+#[cfg(unix)]
+pub(crate) fn terminate_child(child: &mut Child) {
+    let pid = child.id() as libc::pid_t;
+    // SAFETY: `pid` is our own direct child; signalling it is well-defined.
+    unsafe {
+        libc::kill(pid, libc::SIGTERM);
+    }
+    let deadline = Instant::now() + TEARDOWN_GRACE;
+    loop {
+        match child.try_wait() {
+            Ok(Some(_)) => return,
+            Ok(None) => {}
+            Err(_) => break,
+        }
+        if Instant::now() >= deadline {
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+    let _ = child.kill();
+    let _ = child.wait();
+}
+
+#[cfg(not(unix))]
+pub(crate) fn terminate_child(child: &mut Child) {
+    let _ = child.kill();
+    let _ = child.wait();
+}

--- a/crates/orbit-dashboard/src/lib.rs
+++ b/crates/orbit-dashboard/src/lib.rs
@@ -10,12 +10,15 @@
 //! preserved.
 
 mod api;
+mod connect;
 mod log_format;
 mod parse;
 mod projections;
 
 #[cfg(test)]
 mod tests;
+
+pub use connect::{ConnectArgs, connect};
 
 use std::net::{IpAddr, SocketAddr};
 use std::sync::Arc;
@@ -56,6 +59,11 @@ const DASHBOARD_CSP: &str = concat!(
     "frame-ancestors 'none'"
 );
 
+/// Conventional loopback port for the dashboard. Shared by `web serve`'s
+/// `--port` default and `web connect`'s local/remote port preference so the
+/// two surfaces agree on one number.
+pub(crate) const DEFAULT_DASHBOARD_PORT: u16 = 7878;
+
 /// Arguments for `orbit web serve` (and the library entry point).
 #[derive(Args, Clone)]
 #[command(about = "Run the Orbit dashboard")]
@@ -65,7 +73,7 @@ pub struct ServeArgs {
     pub host: IpAddr,
 
     /// Port to bind to.
-    #[arg(long, default_value_t = 7878)]
+    #[arg(long, default_value_t = DEFAULT_DASHBOARD_PORT)]
     pub port: u16,
 
     /// Do not attempt to open the dashboard URL in a browser on startup.
@@ -269,7 +277,7 @@ async fn shutdown_signal() {
     }
 }
 
-fn open_browser(url: &str) {
+pub(crate) fn open_browser(url: &str) {
     #[cfg(target_os = "macos")]
     let cmd = "open";
     #[cfg(all(unix, not(target_os = "macos")))]

--- a/crates/orbit-dashboard/src/tests/connect.rs
+++ b/crates/orbit-dashboard/src/tests/connect.rs
@@ -1,0 +1,203 @@
+//! Unit tests for `orbit web connect` helpers (port selection, ssh arg
+//! construction, and tunnel teardown). No real `ssh` process is spawned.
+
+use std::net::{Ipv4Addr, TcpListener};
+use std::process::Command;
+
+use orbit_core::OrbitError;
+
+use super::super::DEFAULT_DASHBOARD_PORT;
+use super::super::connect::{
+    ConnectArgs, build_ssh_args, ephemeral_port, probe_bindable, remote_serve_command,
+    select_local_port, shell_quote,
+};
+
+/// Minimal args builder so each test states only what it cares about.
+fn args(host: &str, remote_port: u16, root: Option<&str>) -> ConnectArgs {
+    ConnectArgs {
+        ssh_host: host.to_string(),
+        port: None,
+        remote_port,
+        root: root.map(str::to_string),
+        no_open: false,
+    }
+}
+
+// ── port selection ────────────────────────────────────────────────────────
+
+#[test]
+fn ephemeral_port_is_nonzero_and_bindable() {
+    let port = ephemeral_port().expect("ephemeral port");
+    assert_ne!(port, 0);
+    assert!(probe_bindable(port).is_ok());
+}
+
+#[test]
+fn probe_bindable_detects_busy_port() {
+    // Hold a listener open so the port is genuinely in use.
+    let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).expect("bind");
+    let busy = listener.local_addr().expect("addr").port();
+    assert!(probe_bindable(busy).is_err());
+}
+
+#[test]
+fn explicit_free_port_is_honored() {
+    let free = ephemeral_port().expect("ephemeral port");
+    assert_eq!(select_local_port(Some(free)).expect("select"), free);
+}
+
+#[test]
+fn explicit_busy_port_errors() {
+    let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).expect("bind");
+    let busy = listener.local_addr().expect("addr").port();
+    let err = select_local_port(Some(busy)).expect_err("busy port must error");
+    assert!(matches!(err, OrbitError::InvalidInput(_)));
+}
+
+#[test]
+fn auto_selection_falls_back_when_default_is_busy() {
+    // Occupy the preferred default port; auto-selection must pick something
+    // else that is itself bindable. If 7878 is already taken by another
+    // process in this environment, the same fallback path runs but we cannot
+    // assert deterministically, so we skip in that case.
+    if let Ok(listener) = TcpListener::bind((Ipv4Addr::LOCALHOST, DEFAULT_DASHBOARD_PORT)) {
+        let chosen = select_local_port(None).expect("auto select");
+        assert_ne!(chosen, DEFAULT_DASHBOARD_PORT);
+        assert!(probe_bindable(chosen).is_ok());
+        drop(listener);
+    }
+}
+
+// ── ssh argument construction ─────────────────────────────────────────────
+
+#[test]
+fn build_ssh_args_basic() {
+    let got = build_ssh_args(&args("box", 7878, None), 9999);
+    assert_eq!(
+        got,
+        vec![
+            "-tt".to_string(),
+            "-o".to_string(),
+            "ExitOnForwardFailure=yes".to_string(),
+            "-L".to_string(),
+            "9999:localhost:7878".to_string(),
+            "box".to_string(),
+            "orbit web serve --no-open --port 7878".to_string(),
+        ]
+    );
+}
+
+#[test]
+fn build_ssh_args_forwards_distinct_local_and_remote_ports() {
+    let got = build_ssh_args(&args("user@host", 9000, None), 7000);
+    assert!(got.contains(&"7000:localhost:9000".to_string()));
+    assert!(got.contains(&"orbit web serve --no-open --port 9000".to_string()));
+}
+
+#[test]
+fn remote_command_always_passes_no_open() {
+    // The remote must never open a browser on the box regardless of the local
+    // `--no-open` flag (which only controls *our* browser).
+    let mut cfg = args("box", 7878, None);
+    cfg.no_open = true;
+    assert!(remote_serve_command(&cfg).contains("--no-open"));
+    cfg.no_open = false;
+    assert!(remote_serve_command(&cfg).contains("--no-open"));
+}
+
+#[test]
+fn remote_command_shell_quotes_root() {
+    let cmd = remote_serve_command(&args("box", 7878, Some("/srv/my ws")));
+    assert!(
+        cmd.contains("--root '/srv/my ws'"),
+        "root with a space must be single-quoted: {cmd}"
+    );
+}
+
+#[test]
+fn remote_command_without_root_has_no_root_flag() {
+    let cmd = remote_serve_command(&args("box", 7878, None));
+    assert!(!cmd.contains("--root"));
+}
+
+#[test]
+fn shell_quote_escapes_embedded_single_quotes() {
+    assert_eq!(shell_quote("plain"), "'plain'");
+    assert_eq!(shell_quote("a'b"), "'a'\\''b'");
+}
+
+// ── ssh exit classification ───────────────────────────────────────────────
+
+#[cfg(unix)]
+#[test]
+fn classify_exit_127_points_at_remote_path() {
+    use super::super::connect::classify_ssh_exit;
+    use std::os::unix::process::ExitStatusExt;
+
+    // waitpid encodes a normal exit code in the high byte.
+    let err = classify_ssh_exit(std::process::ExitStatus::from_raw(127 << 8));
+    match err {
+        OrbitError::Execution(msg) => assert!(msg.contains("PATH"), "got: {msg}"),
+        other => panic!("expected Execution, got {other:?}"),
+    }
+}
+
+#[cfg(unix)]
+#[test]
+fn classify_exit_255_points_at_ssh_connect() {
+    use super::super::connect::classify_ssh_exit;
+    use std::os::unix::process::ExitStatusExt;
+
+    let err = classify_ssh_exit(std::process::ExitStatus::from_raw(255 << 8));
+    match err {
+        OrbitError::Execution(msg) => assert!(msg.contains("connect"), "got: {msg}"),
+        other => panic!("expected Execution, got {other:?}"),
+    }
+}
+
+// ── teardown ──────────────────────────────────────────────────────────────
+
+#[cfg(unix)]
+#[test]
+fn terminate_child_stops_a_running_process() {
+    use super::super::connect::terminate_child;
+
+    let mut child = Command::new("sleep")
+        .arg("30")
+        .spawn()
+        .expect("spawn sleep");
+    assert!(
+        child.try_wait().expect("try_wait").is_none(),
+        "sleep should still be running before teardown"
+    );
+
+    terminate_child(&mut child);
+
+    // terminate_child waits internally, so the exit status is now available.
+    assert!(
+        child.try_wait().expect("try_wait").is_some(),
+        "sleep should be terminated after teardown"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn tunnel_drop_reaps_child() {
+    use super::super::connect::SshTunnel;
+
+    let child = Command::new("sleep")
+        .arg("30")
+        .spawn()
+        .expect("spawn sleep");
+    let pid = child.id() as libc::pid_t;
+
+    {
+        let _tunnel = SshTunnel::new(child);
+    } // Drop tears the tunnel down here.
+
+    // The child is signalled and reaped, so it no longer exists. `kill(pid, 0)`
+    // returns -1/ESRCH for an absent process. (A pid-reuse race in this window
+    // is vanishingly unlikely for a just-spawned `sleep`.)
+    let alive = unsafe { libc::kill(pid, 0) } == 0;
+    assert!(!alive, "ssh child must be gone after the tunnel drops");
+}

--- a/crates/orbit-dashboard/src/tests/mod.rs
+++ b/crates/orbit-dashboard/src/tests/mod.rs
@@ -1,5 +1,6 @@
 #![allow(clippy::expect_used, clippy::unwrap_used)]
 
+mod connect;
 mod dashboard_assets;
 mod log_format;
 mod parse;


### PR DESCRIPTION
## Task
ORB-00029 — Add `orbit web connect <ssh-host>` for cross-environment dashboard access.

## Summary
Adds a client-side convenience subcommand that automates the manual `ssh -L 7878:localhost:7878 <host> "orbit web serve --no-open"` workflow for viewing a workspace's dashboard from another machine, while keeping the dashboard's **loopback-only bind guard (ORB-00360) fully intact** — auth is delegated to SSH, no new network attack surface.

- Lives in `orbit-dashboard` alongside `serve`/`ServeArgs` (keeps `orbit-cli` a thin clap entry point); needs no `OrbitRuntime` since the workspace is on the remote.
- Picks a free local port (prefers 7878, falls back to an ephemeral port).
- Starts the remote server over a single `ssh -tt -o ExitOnForwardFailure=yes -L <local>:localhost:<remote> <host> "orbit web serve --no-open --port <remote> [--root <quoted>]"`. `-tt` forces a remote pty so the remote serve receives SIGHUP and is **not orphaned** when the tunnel drops.
- Waits for readiness via a hand-rolled `GET /healthz` over `TcpStream` (no new heavy dep), then opens the browser (respecting `--no-open`).
- Tears the tunnel + remote process down cleanly on Ctrl-C / SIGTERM via a `SshTunnel` RAII guard (graceful SIGTERM → SIGKILL-after-grace).
- Clear errors for the common failure modes (`orbit` not on remote PATH → exit 127; ssh connect failure → exit 255).

Flags: `<ssh-host>` positional, `--port` (local), `--remote-port`, `--root` (remote workspace path), `--no-open`.

## Design notes
- **connect in orbit-dashboard, not orbit-cli** — mirrors the existing `serve`/`ServeArgs` precedent that keeps the axum-tax'd web surface out of orbit-cli.
- **Hand-rolled `/healthz` GET instead of pulling in reqwest** — the dashboard crate is deliberately dependency-isolated; a one-line localhost GET doesn't warrant it. Only new dep is `libc` (already a workspace dep) for the unix SIGTERM.
- Shared `DEFAULT_DASHBOARD_PORT` const now backs both `ServeArgs`' default and connect.

## Validation
- `cargo test -p orbit-dashboard` — 103 passed (incl. 15 new `tests::connect::*`: port selection, ssh-arg construction incl. `--root` shell-quoting, exit classification, teardown).
- `cargo test -p orbit-cli cli_parses_web*` — pass (new `cli_parses_web_connect`).
- `cargo clippy -p orbit-dashboard -p orbit-cli --all-targets` — clean; `cargo fmt --all --check` — clean.
- `orbit web connect --help` renders as expected.

Non-goals (unchanged): no token auth, no relaxing of the non-loopback bind guard, no remote data backend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)