### PR TITLE
[ORB-00030] dashboard: global multi-workspace serve

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Highlights
 
 - **`orbit web connect <ssh-host>`**: a client-side convenience command that views a workspace's dashboard running on another machine over an SSH tunnel — automating the manual `ssh -L 7878:localhost:7878 <host> "orbit web serve --no-open"` dance. It picks a free local port (preferring 7878, else ephemeral), starts `orbit web serve --no-open` on the remote, forwards the port, waits for `/healthz`, opens the browser, and tears the tunnel (and remote serve process) down cleanly on Ctrl-C. The loopback-only bind guard (ORB-00360) is untouched and auth is delegated entirely to SSH — no new network attack surface. Flags: `--port`, `--remote-port`, `--root`, `--no-open`. ([ORB-00029])
+- **Global, multi-workspace dashboard**: `orbit web serve` is no longer confined to a single workspace. Run it outside any workspace — or pass the new `--global` flag from inside one — and the dashboard serves every workspace registered in `~/.orbit/workspaces.json`, lazily building a runtime per workspace and skipping stale-path entries rather than failing to start. A header workspace selector plus an aggregate "All workspaces" task view (`GET /api/workspaces`, `GET /api/tasks/all`) let one loopback server cover the whole machine; inside a workspace without `--global`, behavior is unchanged. The dashboard's axum state moves from a single `Arc<OrbitRuntime>` to a workspace-keyed runtime map behind a `Ws` extractor, and the loopback-only bind guard (ORB-00360) is untouched. ([ORB-00030])
 
 ## 0.9.2
 

--- a/README.md
+++ b/README.md
@@ -122,8 +122,12 @@ orbit task approve "$TASK_ID"
 # conflict-aware, parallel flush of the backlog tasks to PRs
 orbit run ship
 
-# launch interactive dashboard
+# launch interactive dashboard (this workspace)
 orbit web serve
+
+# one dashboard over every registered workspace (also the default when run
+# outside a workspace)
+orbit web serve --global
 
 # ...or view a workspace running on another machine over an SSH tunnel
 # (the dashboard stays loopback-only; auth is delegated to SSH)

--- a/crates/orbit-cli/src/main.rs
+++ b/crates/orbit-cli/src/main.rs
@@ -46,6 +46,7 @@ use crate::command::learning::{LearningCommand, LearningSubcommand};
 use crate::command::mcp::{McpCommand, McpSubcommand};
 use crate::command::search::SearchCommand;
 use crate::command::tool::{OutputFormat, ToolSubcommand};
+use crate::command::web::{WebCommand, WebSubcommand};
 use crate::command::workspace::{WorkspaceCommand, WorkspaceSubcommand};
 use crate::command::{Commands, Execute, init::InitCommand};
 
@@ -106,6 +107,18 @@ fn main() {
             command: LearningSubcommand::MigrateLayout(args),
         }) => {
             if let Err(err) = args.execute_without_runtime(root_override.as_deref()) {
+                print_error(&err, tool_run_json_output);
+                std::process::exit(1);
+            }
+            return;
+        }
+        // The dashboard resolves its own workspace(s) and can serve globally
+        // from any directory, so it must dispatch before the eager workspace
+        // initialization below (which fails outside a workspace).
+        Commands::Web(WebCommand {
+            command: WebSubcommand::Serve(args),
+        }) => {
+            if let Err(err) = orbit_dashboard::serve_from_env(args, root_override.as_deref()) {
                 print_error(&err, tool_run_json_output);
                 std::process::exit(1);
             }

--- a/crates/orbit-dashboard/assets/dashboard/app.js
+++ b/crates/orbit-dashboard/assets/dashboard/app.js
@@ -1,7 +1,7 @@
 // Orbit dashboard — terminal-dark, manually refreshed SPA.
 // Pure vanilla JS, split into ES modules with no build step.
 
-import { el, statusPill, stateCell, fetchJson, requestJson, postJson, patchJson, syncNodes, positiveIntParam } from './common.js';
+import { el, statusPill, stateCell, fetchJson, requestJson, postJson, patchJson, syncNodes, positiveIntParam, getWorkspace, setWorkspace } from './common.js';
 import { buildChips, cacheCrewPayload, copyTaskIdWithNotice, hasCrewOptions, openVisibleTask, renderTasks, setPinnedExternalTask, wireSearch } from './tasks.js';
 import { applyAuditHashQuery, buildAuditChips, buildAuditHash, fetchAndRenderAudit, fetchAndRenderPolicy, getActiveAuditSubtab, navigateToAuditExecution, renderAuditSummary, setActiveAuditSubtabFromButton, setAuditSubtab, syncAuditControls, wireAuditSearch, } from './audit.js';
 import { renderScoreboard } from './scoreboard.js';
@@ -83,6 +83,10 @@ let frictionSearchQuery = "";
 
 // Health strip state
 let lastSummary = null;
+
+// ORB-00030: workspaces the dashboard is serving. Empty/one entry => single
+// mode (no selector). More than one => global mode (selector shown).
+let dashboardWorkspaces = [];
 
 function taskContext() {
   return {
@@ -1158,13 +1162,73 @@ function fetchAndCacheCrews() {
 }
 
 function fetchAndRenderTasks() {
+  // In global mode with the aggregate ("All workspaces") view selected, pull
+  // every workspace's tasks; otherwise the single/selected workspace's tasks
+  // (the workspace query param is applied by fetchJson).
+  const aggregate = dashboardWorkspaces.length > 1 && !getWorkspace();
+  const path = aggregate ? "/api/tasks/all" : "/api/tasks";
   return Promise.all([
-    fetchJson("/api/tasks"),
+    fetchJson(path),
     fetchAndCacheCrews(),
   ]).then(([tasks]) => {
     lastTasks = tasks;
     renderTasks(tasks, taskContext());
   });
+}
+
+// ORB-00030: discover servable workspaces and, in global mode, install a
+// header selector. Runs before the first refresh so the initial fetches target
+// the right workspace. Failures are non-fatal (single-workspace fallback).
+async function initWorkspaceSelector() {
+  let entries;
+  try {
+    entries = await fetchJson("/api/workspaces");
+  } catch (e) {
+    console.error(e);
+    return;
+  }
+  dashboardWorkspaces = Array.isArray(entries) ? entries : [];
+  if (dashboardWorkspaces.length <= 1) return; // single mode: no selector
+
+  // Default to the workspace flagged by the server (the cwd workspace, if the
+  // server was launched inside one) so every tab works out of the box; else the
+  // first active workspace. "All workspaces" (aggregate) is an explicit choice.
+  if (!getWorkspace()) {
+    const def = dashboardWorkspaces.find((w) => w.is_default);
+    const firstActive = dashboardWorkspaces.find((w) => w.status === "active");
+    const initial = (def || firstActive || dashboardWorkspaces[0]).id;
+    setWorkspace(initial);
+  }
+  buildWorkspaceSelector();
+}
+
+function buildWorkspaceSelector() {
+  const select = el("select", { class: "workspace-select", title: "Workspace" });
+  select.id = "workspace-select";
+
+  const allOption = el("option", { text: "All workspaces" });
+  allOption.value = "";
+  select.appendChild(allOption);
+
+  const current = getWorkspace() || "";
+  for (const ws of dashboardWorkspaces) {
+    const active = ws.status === "active";
+    const label = active ? ws.name : `${ws.name} (unavailable)`;
+    const option = el("option", { text: label });
+    option.value = ws.id;
+    option.disabled = !active;
+    if (ws.id === current) option.selected = true;
+    select.appendChild(option);
+  }
+  if (!current) allOption.selected = true;
+
+  select.addEventListener("change", () => {
+    setWorkspace(select.value);
+    refreshDashboard();
+  });
+
+  const meta = $("meta");
+  meta.insertBefore(select, $("refresh-btn"));
 }
 
 function activeRefreshJobs() {
@@ -1465,6 +1529,9 @@ initRunDetail(runDetailContext());
 initReviewThreads();
 const rctx = routerContext();
 initRouter(rctx);
+// Resolve workspaces before the router fires its first refresh so the initial
+// fetches carry the right workspace (top-level await; app.js is an ES module).
+await initWorkspaceSelector();
 iT();
 
 initLogTail();

--- a/crates/orbit-dashboard/assets/dashboard/common.js
+++ b/crates/orbit-dashboard/assets/dashboard/common.js
@@ -1,5 +1,27 @@
 const params = new URLSearchParams(window.location.search);
 
+// ORB-00030: the dashboard can serve multiple workspaces. `currentWorkspace`
+// (a workspace id, or null for the aggregate "all" view) is transparently
+// appended as `?workspace=<id>` to every API request below, so individual view
+// modules stay workspace-agnostic. Initialized from the URL for shareable links.
+let currentWorkspace = params.get("workspace") || null;
+
+export function getWorkspace() {
+  return currentWorkspace;
+}
+
+export function setWorkspace(id) {
+  currentWorkspace = id || null;
+}
+
+// Append the selected workspace to an API path, unless one is already present
+// (aggregate endpoints like /api/tasks/all are called with no workspace set).
+function withWorkspace(path) {
+  if (!currentWorkspace || /[?&]workspace=/.test(path)) return path;
+  const sep = path.includes("?") ? "&" : "?";
+  return `${path}${sep}workspace=${encodeURIComponent(currentWorkspace)}`;
+}
+
 export function positiveIntParam(name, fallback) {
   const parsed = parseInt(params.get(name) || String(fallback), 10);
   return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
@@ -39,7 +61,7 @@ export function stateCell(state) {
 }
 
 export function fetchJson(path) {
-  return fetch(path, { headers: { accept: "application/json" } })
+  return fetch(withWorkspace(path), { headers: { accept: "application/json" } })
     .then(res => {
       if (!res.ok) throw new Error(`${path}: HTTP ${res.status}`);
       return res.json();
@@ -56,7 +78,7 @@ export function requestJson(path, method, body) {
     headers["content-type"] = "application/json";
     opts.body = JSON.stringify(body);
   }
-  return fetch(path, opts).then(async (res) => {
+  return fetch(withWorkspace(path), opts).then(async (res) => {
     const text = await res.text();
     const body = text ? JSON.parse(text) : {};
     if (!res.ok) {

--- a/crates/orbit-dashboard/assets/dashboard/dashboard.css
+++ b/crates/orbit-dashboard/assets/dashboard/dashboard.css
@@ -128,6 +128,34 @@
         opacity: 0.55;
       }
 
+      /* ORB-00030 multi-workspace: header selector + per-task workspace badge */
+      .workspace-select {
+        height: 30px;
+        max-width: 190px;
+        margin: 0 2px;
+        border: 1px solid var(--border);
+        border-radius: 2px;
+        background: var(--bg-elev);
+        color: var(--fg);
+        font-family: var(--font-sans);
+        font-size: 12px;
+        font-weight: 500;
+        padding: 0 6px;
+        cursor: pointer;
+      }
+      .workspace-select:hover { border-color: var(--accent); }
+      .workspace-select:focus { border-color: var(--accent); outline: none; }
+      .ws-badge {
+        display: inline-block;
+        margin-right: 6px;
+        padding: 0 4px;
+        font-size: 10px;
+        color: var(--fg-dim);
+        border: 1px solid var(--border);
+        border-radius: 2px;
+        vertical-align: middle;
+      }
+
       /* ORB-00211 global resolver (added after task comment; minimal to make input usable in header + error visible + pinned distinguishable) */
       header .global-id-wrap { position: relative; display: inline-block; margin: 0 2px; }
       #global-task-id { width: 142px; height: 26px; font: 12px/1.2 var(--font-mono); background: var(--bg); color: var(--fg); border: 1px solid var(--border); border-radius: 2px; padding: 3px 6px; vertical-align: middle; }

--- a/crates/orbit-dashboard/assets/dashboard/tasks.js
+++ b/crates/orbit-dashboard/assets/dashboard/tasks.js
@@ -869,6 +869,11 @@ export function renderTasks(tasks, context) {
   const body = $("tasks-body");
   if (!body) return;
 
+  // ORB-00030: in the aggregate ("All workspaces") view each task carries its
+  // owning workspace; show it as a badge in the Title cell. Detected from the
+  // data so no extra plumbing is needed (single-workspace lists lack the field).
+  const aggregate = Array.isArray(tasks) && tasks.some((t) => t && t.workspace_name);
+
   // Auto-clear pinned external (global resolver) if its status+search now makes it
   // visible in the normal filtered list (user enabled the chip or cleared search).
   if (pinnedExternalTask && pinnedExternalTask.task) {
@@ -980,15 +985,21 @@ export function renderTasks(tasks, context) {
           idSpan.style.color = "";
         }, 1000);
       });
+      const titleCell = aggregate && t.workspace_name
+        ? el("span", { class: "title" }, [
+            el("span", { class: "ws-badge mono", text: t.workspace_name, title: `Workspace: ${t.workspace_name}` }),
+            t.title,
+          ])
+        : el("span", { class: "title", text: t.title });
       const row = el("div", { class: "row", title: t.title }, [
         idSpan,
-        el("span", { class: "title", text: t.title }),
+        titleCell,
         buildStatusUpdateControl(t, context),
         buildCrewUpdateControl(t, context),
       ]);
       row.dataset.key = `task-${t.id}`;
       // Basic hash based on row presentation parameters + expanded state
-      row.dataset.hash = `${t.id}-${t.title}-${t.status}-${t.crew || ""}-${t.resolved_crew || ""}-${crewOptionsSignature()}-${crewUpdateErrors.get(t.id) || ""}-${expandedTaskIds.has(t.id)}`;
+      row.dataset.hash = `${t.id}-${t.title}-${t.status}-${t.crew || ""}-${t.resolved_crew || ""}-${t.workspace_id || ""}-${crewOptionsSignature()}-${crewUpdateErrors.get(t.id) || ""}-${expandedTaskIds.has(t.id)}`;
       row.addEventListener("click", () => {
         const toggle = () => {
           if (expandedTaskIds.has(t.id)) expandedTaskIds.delete(t.id);

--- a/crates/orbit-dashboard/src/api/adrs.rs
+++ b/crates/orbit-dashboard/src/api/adrs.rs
@@ -2,9 +2,9 @@
 
 use std::fs;
 use std::io::ErrorKind;
-use std::sync::Arc;
 
-use axum::extract::{Path, Query, State};
+use crate::state::Ws;
+use axum::extract::{Path, Query};
 use axum::response::{IntoResponse, Json, Response};
 use orbit_core::{OrbitError, OrbitRuntime};
 use serde::Deserialize;
@@ -37,10 +37,7 @@ pub(super) struct SupersedeAdrBody {
     reason: Option<String>,
 }
 
-pub(super) async fn list_adrs(
-    State(runtime): State<Arc<OrbitRuntime>>,
-    Query(query): Query<AdrsQuery>,
-) -> Response {
+pub(super) async fn list_adrs(Ws(runtime): Ws, Query(query): Query<AdrsQuery>) -> Response {
     let all = match adr_list(&runtime, Map::new()) {
         Ok(adrs) => adrs,
         Err(e) => return map_runtime_error(e),
@@ -88,20 +85,14 @@ pub(super) async fn list_adrs(
     .into_response()
 }
 
-pub(super) async fn get_adr(
-    State(runtime): State<Arc<OrbitRuntime>>,
-    Path(id): Path<String>,
-) -> Response {
+pub(super) async fn get_adr(Ws(runtime): Ws, Path(id): Path<String>) -> Response {
     match adr_show(&runtime, &id) {
         Ok(adr) => Json(adr).into_response(),
         Err(e) => map_runtime_error(e),
     }
 }
 
-pub(super) async fn accept_adr_action(
-    State(runtime): State<Arc<OrbitRuntime>>,
-    Path(id): Path<String>,
-) -> Response {
+pub(super) async fn accept_adr_action(Ws(runtime): Ws, Path(id): Path<String>) -> Response {
     let result = run_adr_tool(
         &runtime,
         "orbit.adr.update",
@@ -120,7 +111,7 @@ pub(super) async fn accept_adr_action(
 }
 
 pub(super) async fn supersede_adr_action(
-    State(runtime): State<Arc<OrbitRuntime>>,
+    Ws(runtime): Ws,
     Path(id): Path<String>,
     body: Option<Json<SupersedeAdrBody>>,
 ) -> Response {

--- a/crates/orbit-dashboard/src/api/audit.rs
+++ b/crates/orbit-dashboard/src/api/audit.rs
@@ -2,9 +2,9 @@
 
 use std::collections::BTreeMap;
 use std::str::FromStr;
-use std::sync::Arc;
 
-use axum::extract::{Query, State};
+use crate::state::Ws;
+use axum::extract::Query;
 use axum::response::{IntoResponse, Json, Response};
 use chrono::{DateTime, Duration, Utc};
 use orbit_core::command::job::JobRunListParams;
@@ -27,10 +27,7 @@ use crate::projections::audit_event_to_json;
 /// switch the tile to alert state without a second round-trip.
 const DEFAULT_DENIAL_THRESHOLD: i64 = 10;
 
-pub(super) async fn list_audit(
-    State(runtime): State<Arc<OrbitRuntime>>,
-    Query(q): Query<AuditQuery>,
-) -> Response {
+pub(super) async fn list_audit(Ws(runtime): Ws, Query(q): Query<AuditQuery>) -> Response {
     let since = match q.since.as_deref() {
         Some(raw) => match parse_since(raw) {
             Ok(ts) => Some(ts),
@@ -146,10 +143,7 @@ fn arguments_json_matches_profile(raw: Option<&str>, expected: &str) -> bool {
     false
 }
 
-pub(super) async fn audit_summary(
-    State(runtime): State<Arc<OrbitRuntime>>,
-    Query(q): Query<AuditSummaryQuery>,
-) -> Response {
+pub(super) async fn audit_summary(Ws(runtime): Ws, Query(q): Query<AuditSummaryQuery>) -> Response {
     let raw_since = q.since.as_deref().unwrap_or(DEFAULT_SUMMARY_WINDOW);
     let since = match parse_since(raw_since) {
         Ok(ts) => ts,

--- a/crates/orbit-dashboard/src/api/crews.rs
+++ b/crates/orbit-dashboard/src/api/crews.rs
@@ -1,11 +1,8 @@
 //! Crew registry handlers.
 
-use std::sync::Arc;
-
-use axum::extract::State;
+use crate::state::Ws;
 use axum::response::{IntoResponse, Json, Response};
-use orbit_core::OrbitRuntime;
 
-pub(super) async fn list_crews(State(runtime): State<Arc<OrbitRuntime>>) -> Response {
+pub(super) async fn list_crews(Ws(runtime): Ws) -> Response {
     Json(runtime.configured_crew_registry_projection()).into_response()
 }

--- a/crates/orbit-dashboard/src/api/denials.rs
+++ b/crates/orbit-dashboard/src/api/denials.rs
@@ -2,9 +2,9 @@
 //! SQLite audit-events table.
 
 use std::collections::BTreeMap;
-use std::sync::Arc;
 
-use axum::extract::{Query, State};
+use crate::state::Ws;
+use axum::extract::Query;
 use axum::response::{IntoResponse, Json, Response};
 use chrono::{DateTime, Utc};
 use orbit_common::types::activity_job::{
@@ -496,10 +496,7 @@ pub(super) fn denials_by_reason_summary(rows: &[DenialRow], limit: usize) -> Val
     )
 }
 
-pub(super) async fn list_denials(
-    State(runtime): State<Arc<OrbitRuntime>>,
-    Query(q): Query<DenialsQuery>,
-) -> Response {
+pub(super) async fn list_denials(Ws(runtime): Ws, Query(q): Query<DenialsQuery>) -> Response {
     let raw_since = q.since.as_deref().unwrap_or(DEFAULT_SUMMARY_WINDOW);
     let since = match parse_since(raw_since) {
         Ok(ts) => Some(ts),

--- a/crates/orbit-dashboard/src/api/diagnostics.rs
+++ b/crates/orbit-dashboard/src/api/diagnostics.rs
@@ -1,9 +1,9 @@
 //! `/diagnostics/{metrics,errors,friction}` aggregation endpoints.
 
 use std::collections::{HashMap, HashSet};
-use std::sync::Arc;
 
-use axum::extract::{Query, State};
+use crate::state::Ws;
+use axum::extract::Query;
 use axum::response::{IntoResponse, Json, Response};
 use chrono::DateTime;
 use orbit_common::utility::blob_store::BlobStore;
@@ -18,7 +18,7 @@ use super::{
 use crate::log_format::{Filters as LogFilters, read_recent_rendered_events, resolve_log_path};
 
 pub(super) async fn list_diagnostics_metrics(
-    State(runtime): State<Arc<OrbitRuntime>>,
+    Ws(runtime): Ws,
     Query(q): Query<DiagnosticsQuery>,
 ) -> Response {
     let month = q.month.unwrap_or_else(current_year_month_utc);
@@ -298,7 +298,7 @@ fn read_blob_text_best_effort(blob_store: &BlobStore, blob_ref: &str) -> String 
 }
 
 pub(super) async fn list_diagnostics_errors(
-    State(runtime): State<Arc<OrbitRuntime>>,
+    Ws(runtime): Ws,
     Query(q): Query<DiagnosticsQuery>,
 ) -> Response {
     let limit = bounded_limit(q.limit, HISTORY_DEFAULT_LIMIT);
@@ -483,7 +483,7 @@ fn strip_htmlish(raw: &str) -> String {
 }
 
 pub(super) async fn list_diagnostics_friction(
-    State(runtime): State<Arc<OrbitRuntime>>,
+    Ws(runtime): Ws,
     Query(q): Query<DiagnosticsQuery>,
 ) -> Response {
     let month = q.month.unwrap_or_else(current_year_month_utc);
@@ -512,9 +512,7 @@ pub(super) async fn list_diagnostics_friction(
     }
 }
 
-pub(super) async fn diagnostics_implement_one(
-    State(runtime): State<Arc<OrbitRuntime>>,
-) -> Response {
+pub(super) async fn diagnostics_implement_one(Ws(runtime): Ws) -> Response {
     let runtime_clone = runtime.clone();
     let actor_vec =
         match tokio::task::spawn_blocking(move || compute_implement_one_by_actor(&runtime_clone))

--- a/crates/orbit-dashboard/src/api/frictions.rs
+++ b/crates/orbit-dashboard/src/api/frictions.rs
@@ -1,8 +1,7 @@
 //! Friction artifact scan and triage handlers.
 
-use std::sync::Arc;
-
-use axum::extract::{Path, Query, State};
+use crate::state::Ws;
+use axum::extract::{Path, Query};
 use axum::response::{IntoResponse, Json, Response};
 use orbit_core::{OrbitError, OrbitRuntime};
 use serde::Deserialize;
@@ -38,7 +37,7 @@ pub(super) struct FrictionPatchBody {
 }
 
 pub(super) async fn list_frictions(
-    State(runtime): State<Arc<OrbitRuntime>>,
+    Ws(runtime): Ws,
     Query(query): Query<FrictionsQuery>,
 ) -> Response {
     let mut input = Map::new();
@@ -78,10 +77,7 @@ pub(super) async fn list_frictions(
     .into_response()
 }
 
-pub(super) async fn get_friction(
-    State(runtime): State<Arc<OrbitRuntime>>,
-    Path(id): Path<String>,
-) -> Response {
+pub(super) async fn get_friction(Ws(runtime): Ws, Path(id): Path<String>) -> Response {
     let mut friction = match run_friction_tool(
         &runtime,
         "orbit.friction.show",
@@ -102,7 +98,7 @@ pub(super) async fn get_friction(
     Json(friction).into_response()
 }
 
-pub(super) async fn friction_stats(State(runtime): State<Arc<OrbitRuntime>>) -> Response {
+pub(super) async fn friction_stats(Ws(runtime): Ws) -> Response {
     match run_friction_tool(&runtime, "orbit.friction.stats", json!({})) {
         Ok(stats) => Json(stats).into_response(),
         Err(e) => map_runtime_error(e),
@@ -110,7 +106,7 @@ pub(super) async fn friction_stats(State(runtime): State<Arc<OrbitRuntime>>) -> 
 }
 
 pub(super) async fn update_friction_action(
-    State(runtime): State<Arc<OrbitRuntime>>,
+    Ws(runtime): Ws,
     Path(id): Path<String>,
     body: Option<Json<FrictionPatchBody>>,
 ) -> Response {
@@ -136,10 +132,7 @@ pub(super) async fn update_friction_action(
     }
 }
 
-pub(super) async fn resolve_friction_action(
-    State(runtime): State<Arc<OrbitRuntime>>,
-    Path(id): Path<String>,
-) -> Response {
+pub(super) async fn resolve_friction_action(Ws(runtime): Ws, Path(id): Path<String>) -> Response {
     match run_friction_tool(
         &runtime,
         "orbit.friction.resolve",

--- a/crates/orbit-dashboard/src/api/jobs.rs
+++ b/crates/orbit-dashboard/src/api/jobs.rs
@@ -1,10 +1,8 @@
 //! Job catalog and job-run listing handlers.
 
-use std::sync::Arc;
-
-use axum::extract::{Query, State};
+use crate::state::Ws;
+use axum::extract::Query;
 use axum::response::{IntoResponse, Json, Response};
-use orbit_core::OrbitRuntime;
 use orbit_core::command::job::JobRunListParams;
 use serde_json::Value;
 
@@ -13,7 +11,7 @@ use crate::projections::{job_catalog_to_json_with_last_run, job_run_to_json};
 
 const JOB_RUN_DEFAULT_LIMIT: usize = 25;
 
-pub(super) async fn list_jobs(State(runtime): State<Arc<OrbitRuntime>>) -> Response {
+pub(super) async fn list_jobs(Ws(runtime): Ws) -> Response {
     use orbit_core::command::job::JobCatalogFilter;
     match runtime.list_job_catalog_with_last_run(true, JobCatalogFilter::All) {
         Ok(rows) => {
@@ -29,10 +27,7 @@ pub(super) async fn list_jobs(State(runtime): State<Arc<OrbitRuntime>>) -> Respo
     }
 }
 
-pub(super) async fn list_job_runs(
-    State(runtime): State<Arc<OrbitRuntime>>,
-    Query(q): Query<LimitQuery>,
-) -> Response {
+pub(super) async fn list_job_runs(Ws(runtime): Ws, Query(q): Query<LimitQuery>) -> Response {
     let limit = bounded_limit(q.limit, JOB_RUN_DEFAULT_LIMIT);
     let params = JobRunListParams {
         job_id: None,

--- a/crates/orbit-dashboard/src/api/learnings.rs
+++ b/crates/orbit-dashboard/src/api/learnings.rs
@@ -1,10 +1,9 @@
 //! Learning scan and curation handlers.
 
-use std::sync::Arc;
-
-use axum::extract::{Path, Query, State};
+use crate::state::Ws;
+use axum::extract::{Path, Query};
 use axum::response::{IntoResponse, Json, Response};
-use orbit_core::{Learning, LearningSearchParams, OrbitRuntime};
+use orbit_core::{Learning, LearningSearchParams};
 use serde::Deserialize;
 use serde_json::{Value, json};
 
@@ -36,7 +35,7 @@ pub(super) struct SupersedeLearningBody {
 }
 
 pub(super) async fn list_learnings(
-    State(runtime): State<Arc<OrbitRuntime>>,
+    Ws(runtime): Ws,
     Query(query): Query<LearningsQuery>,
 ) -> Response {
     let all = match runtime.list_learnings(None) {
@@ -88,10 +87,7 @@ pub(super) async fn list_learnings(
     .into_response()
 }
 
-pub(super) async fn get_learning(
-    State(runtime): State<Arc<OrbitRuntime>>,
-    Path(id): Path<String>,
-) -> Response {
+pub(super) async fn get_learning(Ws(runtime): Ws, Path(id): Path<String>) -> Response {
     match runtime.get_learning(&id) {
         Ok(learning) => Json(learning_to_json(&learning)).into_response(),
         Err(e) => map_runtime_error(e),
@@ -99,7 +95,7 @@ pub(super) async fn get_learning(
 }
 
 pub(super) async fn supersede_learning_action(
-    State(runtime): State<Arc<OrbitRuntime>>,
+    Ws(runtime): Ws,
     Path(id): Path<String>,
     body: Option<Json<SupersedeLearningBody>>,
 ) -> Response {

--- a/crates/orbit-dashboard/src/api/metrics.rs
+++ b/crates/orbit-dashboard/src/api/metrics.rs
@@ -1,13 +1,12 @@
 //! `/metrics/*` parity endpoints for the retired CLI metrics views.
 
-use std::sync::Arc;
-
-use axum::extract::{Path, Query, State};
+use crate::state::Ws;
+use axum::extract::{Path, Query};
 use axum::response::{IntoResponse, Json, Response};
 use chrono::{DateTime, Utc};
+use orbit_core::InvocationQuery;
 use orbit_core::command::job::JobRunListParams;
 use orbit_core::metrics::aggregate as aggregate_knowledge_stats;
-use orbit_core::{InvocationQuery, OrbitRuntime};
 use serde::Deserialize;
 
 use super::{LimitQuery, map_runtime_error, non_empty_string};
@@ -36,10 +35,7 @@ pub(super) struct MetricsInvocationsQuery {
     limit: Option<usize>,
 }
 
-pub(super) async fn knowledge_metrics(
-    State(runtime): State<Arc<OrbitRuntime>>,
-    Query(q): Query<LimitQuery>,
-) -> Response {
+pub(super) async fn knowledge_metrics(Ws(runtime): Ws, Query(q): Query<LimitQuery>) -> Response {
     match runtime.list_job_runs(JobRunListParams {
         limit: q.limit,
         ..Default::default()
@@ -49,24 +45,21 @@ pub(super) async fn knowledge_metrics(
     }
 }
 
-pub(super) async fn activity_metrics(State(runtime): State<Arc<OrbitRuntime>>) -> Response {
+pub(super) async fn activity_metrics(Ws(runtime): Ws) -> Response {
     match runtime.activity_invocation_metrics() {
         Ok(rows) => Json(rows).into_response(),
         Err(e) => map_runtime_error(e),
     }
 }
 
-pub(super) async fn tool_metrics(State(runtime): State<Arc<OrbitRuntime>>) -> Response {
+pub(super) async fn tool_metrics(Ws(runtime): Ws) -> Response {
     match runtime.tool_invocation_metrics() {
         Ok(rows) => Json(rows).into_response(),
         Err(e) => map_runtime_error(e),
     }
 }
 
-pub(super) async fn task_metrics(
-    State(runtime): State<Arc<OrbitRuntime>>,
-    Path(id): Path<String>,
-) -> Response {
+pub(super) async fn task_metrics(Ws(runtime): Ws, Path(id): Path<String>) -> Response {
     match runtime.task_invocation_metrics(&id) {
         Ok(row) => Json(row).into_response(),
         Err(e) => map_runtime_error(e),
@@ -74,7 +67,7 @@ pub(super) async fn task_metrics(
 }
 
 pub(super) async fn invocation_metrics(
-    State(runtime): State<Arc<OrbitRuntime>>,
+    Ws(runtime): Ws,
     Query(q): Query<MetricsInvocationsQuery>,
 ) -> Response {
     let query = match q.into_invocation_query() {

--- a/crates/orbit-dashboard/src/api/mod.rs
+++ b/crates/orbit-dashboard/src/api/mod.rs
@@ -8,8 +8,6 @@
 // `*_tests` modules are the documented exception for test harness code.
 #![cfg_attr(test, allow(clippy::expect_used, clippy::unwrap_used))]
 
-use std::sync::Arc;
-
 use axum::Router;
 use axum::body::Body;
 use axum::http::{Method, Request, StatusCode, header};
@@ -17,7 +15,6 @@ use axum::middleware::{self, Next};
 use axum::response::{IntoResponse, Json, Response};
 use axum::routing::{get, post};
 use chrono::{DateTime, Duration, TimeZone, Timelike, Utc};
-use orbit_core::OrbitRuntime;
 use serde::Deserialize;
 use serde_json::json;
 use url::Url;
@@ -36,6 +33,7 @@ mod review_threads;
 mod runs;
 mod scoreboard;
 mod tasks;
+mod workspaces;
 
 pub(super) const HISTORY_DEFAULT_LIMIT: usize = 50;
 pub(super) const HISTORY_MAX_LIMIT: usize = 200;
@@ -293,13 +291,15 @@ async fn require_localhost_origin(request: Request<Body>, next: Next) -> Respons
     next.run(request).await
 }
 
-pub(super) fn router() -> Router<Arc<OrbitRuntime>> {
+pub(super) fn router() -> Router<crate::state::DashboardState> {
     Router::new()
         .route(
             "/tasks",
             get(tasks::list_tasks).post(tasks::create_task_action),
         )
         .route("/tasks/locks", get(tasks::list_task_locks))
+        .route("/tasks/all", get(workspaces::list_all_tasks))
+        .route("/workspaces", get(workspaces::list_workspaces))
         .route(
             "/tasks/:id",
             get(tasks::get_task).patch(tasks::update_task_action),

--- a/crates/orbit-dashboard/src/api/review_threads.rs
+++ b/crates/orbit-dashboard/src/api/review_threads.rs
@@ -5,13 +5,12 @@
 //! does not have to fan out across the per-task endpoints. Write paths
 //! delegate to the same `OrbitRuntime` methods the MCP tools use.
 
-use std::sync::Arc;
-
-use axum::extract::{Path, Query, State};
+use crate::state::Ws;
+use axum::extract::{Path, Query};
 use axum::response::{IntoResponse, Json, Response};
 use chrono::{DateTime, Utc};
 use orbit_common::types::{ReviewMessage, ReviewThread, ReviewThreadStatus, all_agent_families};
-use orbit_core::{OrbitRuntime, TaskStatus};
+use orbit_core::TaskStatus;
 use serde::Deserialize;
 use serde_json::{Value, json};
 
@@ -33,10 +32,7 @@ pub(super) struct ReplyBody {
     pub(super) body: String,
 }
 
-pub(super) async fn list_review_threads(
-    State(runtime): State<Arc<OrbitRuntime>>,
-    Query(q): Query<ListQuery>,
-) -> Response {
+pub(super) async fn list_review_threads(Ws(runtime): Ws, Query(q): Query<ListQuery>) -> Response {
     let status_filter = match parse_status_filter(q.status.as_deref()) {
         Ok(value) => value,
         Err(message) => return bad_request(message),
@@ -121,7 +117,7 @@ pub(super) async fn list_review_threads(
 }
 
 pub(super) async fn reply_review_thread_action(
-    State(runtime): State<Arc<OrbitRuntime>>,
+    Ws(runtime): Ws,
     Path((task_id, thread_id)): Path<(String, String)>,
     Json(body): Json<ReplyBody>,
 ) -> Response {
@@ -149,7 +145,7 @@ pub(super) async fn reply_review_thread_action(
 }
 
 pub(super) async fn resolve_review_thread_action(
-    State(runtime): State<Arc<OrbitRuntime>>,
+    Ws(runtime): Ws,
     Path((task_id, thread_id)): Path<(String, String)>,
 ) -> Response {
     let validated_id = match validate_id(&task_id) {
@@ -172,7 +168,7 @@ pub(super) async fn resolve_review_thread_action(
 }
 
 pub(super) async fn reopen_review_thread_action(
-    State(runtime): State<Arc<OrbitRuntime>>,
+    Ws(runtime): Ws,
     Path((task_id, thread_id)): Path<(String, String)>,
 ) -> Response {
     let validated_id = match validate_id(&task_id) {

--- a/crates/orbit-dashboard/src/api/runs.rs
+++ b/crates/orbit-dashboard/src/api/runs.rs
@@ -1,8 +1,7 @@
 //! Run lifecycle: detail, cancel, replay, events, logs.
 
-use std::sync::Arc;
-
-use axum::extract::{Path, Query, State};
+use crate::state::Ws;
+use axum::extract::{Path, Query};
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Json, Response};
 use orbit_common::utility::redaction::redact_all;
@@ -24,10 +23,7 @@ const RUN_LOG_PREVIEW_MAX_BYTES: usize = 8192;
 /// Maximum lines included in stdout/stderr previews returned by run-log APIs.
 const RUN_LOG_PREVIEW_MAX_LINES: usize = 120;
 
-pub(super) async fn get_run(
-    State(runtime): State<Arc<OrbitRuntime>>,
-    Path(id): Path<String>,
-) -> Response {
+pub(super) async fn get_run(Ws(runtime): Ws, Path(id): Path<String>) -> Response {
     let id = match validate_id(&id) {
         Ok(id) => id,
         Err(message) => return bad_request(message),
@@ -38,10 +34,7 @@ pub(super) async fn get_run(
     }
 }
 
-pub(super) async fn cancel_run_action(
-    State(runtime): State<Arc<OrbitRuntime>>,
-    Path(id): Path<String>,
-) -> Response {
+pub(super) async fn cancel_run_action(Ws(runtime): Ws, Path(id): Path<String>) -> Response {
     let id = match validate_id(&id) {
         Ok(id) => id,
         Err(message) => return bad_request(message),
@@ -65,10 +58,7 @@ pub(super) async fn cancel_run_action(
     }
 }
 
-pub(super) async fn replay_run_action(
-    State(runtime): State<Arc<OrbitRuntime>>,
-    Path(id): Path<String>,
-) -> Response {
+pub(super) async fn replay_run_action(Ws(runtime): Ws, Path(id): Path<String>) -> Response {
     let id = match validate_id(&id) {
         Ok(id) => id,
         Err(message) => return bad_request(message),
@@ -128,7 +118,7 @@ fn audit_step_to_json(step: &RunAuditStep) -> Value {
 }
 
 pub(super) async fn list_run_events(
-    State(runtime): State<Arc<OrbitRuntime>>,
+    Ws(runtime): Ws,
     Path(id): Path<String>,
     Query(q): Query<RunEventsQuery>,
 ) -> Response {
@@ -201,7 +191,7 @@ pub(super) async fn list_run_events(
 }
 
 pub(super) async fn list_run_logs(
-    State(runtime): State<Arc<OrbitRuntime>>,
+    Ws(runtime): Ws,
     Path(id): Path<String>,
     Query(q): Query<LimitQuery>,
 ) -> Response {

--- a/crates/orbit-dashboard/src/api/scoreboard.rs
+++ b/crates/orbit-dashboard/src/api/scoreboard.rs
@@ -1,9 +1,9 @@
 //! Scoreboard endpoint: per-agent stats joined with metrics extras and denials.
 
 use std::collections::BTreeMap;
-use std::sync::Arc;
 
-use axum::extract::{Query, State};
+use crate::state::Ws;
+use axum::extract::Query;
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Json, Response};
 use chrono::{Duration, Utc};
@@ -24,10 +24,7 @@ pub(super) struct ScoreboardQuery {
     pub(super) window: Option<String>,
 }
 
-pub(super) async fn scoreboard(
-    State(runtime): State<Arc<OrbitRuntime>>,
-    Query(query): Query<ScoreboardQuery>,
-) -> Response {
+pub(super) async fn scoreboard(Ws(runtime): Ws, Query(query): Query<ScoreboardQuery>) -> Response {
     let window = match query.window.as_deref() {
         None => ScoreboardWindow::All,
         Some(raw) => match raw.parse::<ScoreboardWindow>() {

--- a/crates/orbit-dashboard/src/api/tasks.rs
+++ b/crates/orbit-dashboard/src/api/tasks.rs
@@ -1,9 +1,8 @@
 //! Task CRUD and lifecycle handlers.
 
-use std::sync::Arc;
-
+use crate::state::Ws;
 use axum::body::Body;
-use axum::extract::{Path, State};
+use axum::extract::Path;
 use axum::http::{HeaderName, HeaderValue, header};
 use axum::response::{IntoResponse, Json, Response};
 use orbit_common::types::validate_relative_artifact_path;
@@ -132,27 +131,27 @@ where
     Option::<String>::deserialize(deserializer).map(Some)
 }
 
-pub(super) async fn list_tasks(State(runtime): State<Arc<OrbitRuntime>>) -> Response {
-    match list_dashboard_tasks(&runtime) {
-        Ok(tasks) => match dashboard_status_index(&runtime) {
-            Ok(status_by_id) => {
-                let values = match tasks
-                    .iter()
-                    .map(|task| task_to_json_with_sidecars(&runtime, task, &status_by_id))
-                    .collect::<Result<Vec<_>, _>>()
-                {
-                    Ok(values) => values,
-                    Err(error) => return server_error(error),
-                };
-                Json(Value::Array(values)).into_response()
-            }
-            Err(e) => server_error(e),
-        },
+pub(super) async fn list_tasks(Ws(runtime): Ws) -> Response {
+    match list_tasks_json(&runtime) {
+        Ok(values) => Json(Value::Array(values)).into_response(),
         Err(e) => server_error(e),
     }
 }
 
-pub(super) async fn list_task_locks(State(runtime): State<Arc<OrbitRuntime>>) -> Response {
+/// Build the dashboard task list as JSON values (shared by `list_tasks` and the
+/// cross-workspace `/api/tasks/all` aggregate).
+pub(super) fn list_tasks_json(
+    runtime: &OrbitRuntime,
+) -> Result<Vec<Value>, orbit_core::OrbitError> {
+    let tasks = list_dashboard_tasks(runtime)?;
+    let status_by_id = dashboard_status_index(runtime)?;
+    tasks
+        .iter()
+        .map(|task| task_to_json_with_sidecars(runtime, task, &status_by_id))
+        .collect()
+}
+
+pub(super) async fn list_task_locks(Ws(runtime): Ws) -> Response {
     match task_locks_json(&runtime) {
         Ok(value) => Json(value).into_response(),
         Err(e) => server_error(e),
@@ -173,10 +172,7 @@ fn dashboard_status_index(
     Ok(orbit_core::build_task_status_index(&runtime.list_tasks()?))
 }
 
-pub(super) async fn get_task(
-    State(runtime): State<Arc<OrbitRuntime>>,
-    Path(id): Path<String>,
-) -> Response {
+pub(super) async fn get_task(Ws(runtime): Ws, Path(id): Path<String>) -> Response {
     let id = match validate_id(&id) {
         Ok(id) => id,
         Err(message) => return bad_request(message),
@@ -194,7 +190,7 @@ pub(super) async fn get_task(
 }
 
 pub(super) async fn get_task_artifact(
-    State(runtime): State<Arc<OrbitRuntime>>,
+    Ws(runtime): Ws,
     Path((id, path)): Path<(String, String)>,
 ) -> Response {
     let id = match validate_id(&id) {
@@ -270,7 +266,7 @@ fn validate_artifact_request_path(path: &str) -> Result<String, String> {
 }
 
 pub(super) async fn create_task_action(
-    State(runtime): State<Arc<OrbitRuntime>>,
+    Ws(runtime): Ws,
     Json(body): Json<CreateTaskBody>,
 ) -> Response {
     let params = TaskAddParams {
@@ -307,7 +303,7 @@ pub(super) async fn create_task_action(
 }
 
 pub(super) async fn update_task_action(
-    State(runtime): State<Arc<OrbitRuntime>>,
+    Ws(runtime): Ws,
     Path(id): Path<String>,
     Json(body): Json<UpdateTaskBody>,
 ) -> Response {
@@ -350,7 +346,7 @@ pub(super) async fn update_task_action(
 }
 
 pub(super) async fn approve_task_action(
-    State(runtime): State<Arc<OrbitRuntime>>,
+    Ws(runtime): Ws,
     Path(id): Path<String>,
     body: Option<Json<ApproveBody>>,
 ) -> Response {
@@ -372,7 +368,7 @@ pub(super) async fn approve_task_action(
 }
 
 pub(super) async fn reject_task_action(
-    State(runtime): State<Arc<OrbitRuntime>>,
+    Ws(runtime): Ws,
     Path(id): Path<String>,
     Json(body): Json<RejectBody>,
 ) -> Response {
@@ -392,10 +388,7 @@ pub(super) async fn reject_task_action(
     }
 }
 
-pub(super) async fn archive_task_action(
-    State(runtime): State<Arc<OrbitRuntime>>,
-    Path(id): Path<String>,
-) -> Response {
+pub(super) async fn archive_task_action(Ws(runtime): Ws, Path(id): Path<String>) -> Response {
     let id = match validate_id(&id) {
         Ok(id) => id,
         Err(message) => return bad_request(message),

--- a/crates/orbit-dashboard/src/api/tests/adrs.rs
+++ b/crates/orbit-dashboard/src/api/tests/adrs.rs
@@ -62,7 +62,7 @@ async fn request_accept(
     }
 
     router()
-        .with_state(Arc::new(runtime))
+        .with_state(crate::state::DashboardState::single(Arc::new(runtime)))
         .oneshot(builder.body(Body::empty()).expect("request"))
         .await
         .expect("response")
@@ -90,7 +90,7 @@ async fn request_supersede(
     };
 
     router()
-        .with_state(Arc::new(runtime))
+        .with_state(crate::state::DashboardState::single(Arc::new(runtime)))
         .oneshot(request)
         .await
         .expect("response")

--- a/crates/orbit-dashboard/src/api/tests/diagnostics.rs
+++ b/crates/orbit-dashboard/src/api/tests/diagnostics.rs
@@ -25,7 +25,7 @@ use orbit_common::utility::blob_store::BlobStore;
 async fn request_dashboard_errors(runtime: OrbitRuntime) -> Response {
     Router::new()
         .nest("/api", router())
-        .with_state(Arc::new(runtime))
+        .with_state(crate::state::DashboardState::single(Arc::new(runtime)))
         .oneshot(
             Request::builder()
                 .uri("/api/diagnostics/errors?limit=10")

--- a/crates/orbit-dashboard/src/api/tests/frictions.rs
+++ b/crates/orbit-dashboard/src/api/tests/frictions.rs
@@ -46,7 +46,7 @@ async fn request(
     };
 
     router()
-        .with_state(Arc::new(runtime))
+        .with_state(crate::state::DashboardState::single(Arc::new(runtime)))
         .oneshot(request)
         .await
         .expect("response")

--- a/crates/orbit-dashboard/src/api/tests/handlers.rs
+++ b/crates/orbit-dashboard/src/api/tests/handlers.rs
@@ -18,7 +18,7 @@ async fn request_cancel(runtime: OrbitRuntime, run_id: &str, origin: Option<&str
         builder = builder.header(header::ORIGIN, origin);
     }
     router()
-        .with_state(Arc::new(runtime))
+        .with_state(crate::state::DashboardState::single(Arc::new(runtime)))
         .oneshot(builder.body(Body::empty()).expect("request"))
         .await
         .expect("response")
@@ -26,7 +26,7 @@ async fn request_cancel(runtime: OrbitRuntime, run_id: &str, origin: Option<&str
 
 async fn request_tasks(runtime: OrbitRuntime) -> Response {
     router()
-        .with_state(Arc::new(runtime))
+        .with_state(crate::state::DashboardState::single(Arc::new(runtime)))
         .oneshot(
             Request::builder()
                 .method(Method::GET)
@@ -44,7 +44,7 @@ async fn patch_task_crew(runtime: OrbitRuntime, task_id: &str, crew: &str) -> Re
 
 async fn patch_task_body(runtime: OrbitRuntime, task_id: &str, body: String) -> Response {
     router()
-        .with_state(Arc::new(runtime))
+        .with_state(crate::state::DashboardState::single(Arc::new(runtime)))
         .oneshot(
             Request::builder()
                 .method(Method::PATCH)
@@ -60,7 +60,7 @@ async fn patch_task_body(runtime: OrbitRuntime, task_id: &str, body: String) -> 
 
 async fn request_crews(runtime: OrbitRuntime) -> Response {
     router()
-        .with_state(Arc::new(runtime))
+        .with_state(crate::state::DashboardState::single(Arc::new(runtime)))
         .oneshot(
             Request::builder()
                 .method(Method::GET)
@@ -380,7 +380,7 @@ async fn require_localhost_origin_blocks_cross_origin_get_with_attacker_origin()
     let runtime = OrbitRuntime::in_memory().expect("build runtime");
 
     let response = router()
-        .with_state(Arc::new(runtime))
+        .with_state(crate::state::DashboardState::single(Arc::new(runtime)))
         .oneshot(
             Request::builder()
                 .method(Method::GET)

--- a/crates/orbit-dashboard/src/api/tests/learnings.rs
+++ b/crates/orbit-dashboard/src/api/tests/learnings.rs
@@ -57,7 +57,7 @@ async fn request_supersede(
     };
 
     router()
-        .with_state(Arc::new(runtime))
+        .with_state(crate::state::DashboardState::single(Arc::new(runtime)))
         .oneshot(request)
         .await
         .expect("response")
@@ -161,7 +161,7 @@ async fn list_learnings_returns_stats_and_rows() {
         .expect("supersede fixture");
 
     let response = router()
-        .with_state(Arc::new(runtime))
+        .with_state(crate::state::DashboardState::single(Arc::new(runtime)))
         .oneshot(
             Request::builder()
                 .method(Method::GET)

--- a/crates/orbit-dashboard/src/api/tests/metrics.rs
+++ b/crates/orbit-dashboard/src/api/tests/metrics.rs
@@ -28,7 +28,7 @@ const TASK_ID: &str = "ORB-METRICS-1";
 async fn request_metrics(runtime: OrbitRuntime, uri: &str) -> Response {
     Router::new()
         .nest("/api", router())
-        .with_state(Arc::new(runtime))
+        .with_state(crate::state::DashboardState::single(Arc::new(runtime)))
         .oneshot(
             Request::builder()
                 .uri(format!("/api{uri}"))

--- a/crates/orbit-dashboard/src/api/tests/mod.rs
+++ b/crates/orbit-dashboard/src/api/tests/mod.rs
@@ -16,3 +16,4 @@ mod review_threads;
 mod runs;
 mod scoreboard;
 mod tasks;
+mod workspaces;

--- a/crates/orbit-dashboard/src/api/tests/review_threads.rs
+++ b/crates/orbit-dashboard/src/api/tests/review_threads.rs
@@ -43,7 +43,7 @@ fn seed_task(runtime: &OrbitRuntime) -> String {
 
 async fn get(runtime: Arc<OrbitRuntime>, uri: &str) -> axum::response::Response {
     router()
-        .with_state(runtime)
+        .with_state(crate::state::DashboardState::single(runtime))
         .oneshot(
             Request::builder()
                 .method(Method::GET)
@@ -71,7 +71,7 @@ async fn post(
         Body::empty()
     };
     router()
-        .with_state(runtime)
+        .with_state(crate::state::DashboardState::single(runtime))
         .oneshot(builder.body(body).expect("request"))
         .await
         .expect("response")
@@ -250,7 +250,7 @@ async fn cross_origin_post_is_forbidden() {
     let runtime = Arc::new(runtime);
 
     let response = router()
-        .with_state(runtime)
+        .with_state(crate::state::DashboardState::single(runtime))
         .oneshot(
             Request::builder()
                 .method(Method::POST)

--- a/crates/orbit-dashboard/src/api/tests/runs.rs
+++ b/crates/orbit-dashboard/src/api/tests/runs.rs
@@ -25,7 +25,7 @@ async fn request_cancel(runtime: OrbitRuntime, run_id: &str, origin: Option<&str
         builder = builder.header(header::ORIGIN, origin);
     }
     router()
-        .with_state(Arc::new(runtime))
+        .with_state(crate::state::DashboardState::single(Arc::new(runtime)))
         .oneshot(builder.body(Body::empty()).expect("request"))
         .await
         .expect("response")
@@ -39,7 +39,7 @@ async fn request_replay(runtime: OrbitRuntime, run_id: &str, origin: Option<&str
         builder = builder.header(header::ORIGIN, origin);
     }
     router()
-        .with_state(Arc::new(runtime))
+        .with_state(crate::state::DashboardState::single(Arc::new(runtime)))
         .oneshot(builder.body(Body::empty()).expect("request"))
         .await
         .expect("response")
@@ -56,7 +56,7 @@ async fn request_dashboard_run_events_query(
 ) -> Response {
     Router::new()
         .nest("/api", router())
-        .with_state(Arc::new(runtime))
+        .with_state(crate::state::DashboardState::single(Arc::new(runtime)))
         .oneshot(
             Request::builder()
                 .uri(format!("/api/runs/{encoded_run_id}/events{query}"))
@@ -70,7 +70,7 @@ async fn request_dashboard_run_events_query(
 async fn request_dashboard_run_logs(runtime: OrbitRuntime, encoded_run_id: &str) -> Response {
     Router::new()
         .nest("/api", router())
-        .with_state(Arc::new(runtime))
+        .with_state(crate::state::DashboardState::single(Arc::new(runtime)))
         .oneshot(
             Request::builder()
                 .uri(format!("/api/runs/{encoded_run_id}/logs"))
@@ -477,7 +477,9 @@ async fn replay_run_endpoint_returns_new_run_id_and_lineage() {
         Some(source.run_id.as_str())
     );
     let list_response = router()
-        .with_state(Arc::new(runtime.clone()))
+        .with_state(crate::state::DashboardState::single(Arc::new(
+            runtime.clone(),
+        )))
         .oneshot(
             Request::builder()
                 .uri("/job-runs?limit=10")

--- a/crates/orbit-dashboard/src/api/tests/scoreboard.rs
+++ b/crates/orbit-dashboard/src/api/tests/scoreboard.rs
@@ -24,7 +24,7 @@ async fn get_scoreboard(runtime: OrbitRuntime, query: Option<&str>) -> axum::res
         None => "/scoreboard".to_string(),
     };
     router()
-        .with_state(Arc::new(runtime))
+        .with_state(crate::state::DashboardState::single(Arc::new(runtime)))
         .oneshot(
             Request::builder()
                 .method(Method::GET)

--- a/crates/orbit-dashboard/src/api/tests/tasks.rs
+++ b/crates/orbit-dashboard/src/api/tests/tasks.rs
@@ -105,7 +105,7 @@ fn seed_lock_task(
 
 async fn request(runtime: OrbitRuntime, uri: &str) -> axum::response::Response {
     router()
-        .with_state(Arc::new(runtime))
+        .with_state(crate::state::DashboardState::single(Arc::new(runtime)))
         .oneshot(
             Request::builder()
                 .method(Method::GET)
@@ -441,7 +441,7 @@ async fn patch_api_accepts_in_progress_hyphen_from_dashboard_and_returns_in_prog
     // Wrap to exercise the literal /api/tasks path per acceptance criteria
     let app = Router::new()
         .nest("/api", router())
-        .with_state(Arc::new(runtime));
+        .with_state(crate::state::DashboardState::single(Arc::new(runtime)));
 
     let response = app
         .oneshot(

--- a/crates/orbit-dashboard/src/api/tests/workspaces.rs
+++ b/crates/orbit-dashboard/src/api/tests/workspaces.rs
@@ -1,0 +1,164 @@
+//! Tests for the global (cross-workspace) endpoints (ORB-00030).
+
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use axum::body::Body;
+use axum::http::{Method, Request};
+use orbit_core::command::task::TaskAddParams;
+use orbit_core::{ActorIdentity, OrbitRuntime, TaskStatus};
+use serde_json::json;
+use tower::ServiceExt;
+
+use super::super::*;
+use super::test_support::body_json;
+use crate::state::{DashboardState, WsEntry};
+
+fn get(uri: &str) -> Request<Body> {
+    Request::builder()
+        .method(Method::GET)
+        .uri(uri)
+        .body(Body::empty())
+        .expect("request")
+}
+
+/// Create an on-disk workspace under `base/<name>`, seed one in-progress task,
+/// and return `(orbit_dir, repo_root)`. The workspace persists after the
+/// runtime is dropped, so global mode can reopen it via `from_roots`.
+fn seed_workspace(global_root: &Path, base: &Path, name: &str) -> (PathBuf, PathBuf) {
+    let repo_root = base.join(name);
+    let orbit_dir = repo_root.join(".orbit");
+    std::fs::create_dir_all(&orbit_dir).expect("create .orbit");
+    std::fs::write(orbit_dir.join("config.toml"), "").expect("write config");
+    let runtime = OrbitRuntime::from_roots(global_root, &orbit_dir)
+        .expect("build runtime")
+        .with_actor(ActorIdentity::human("human"));
+    runtime
+        .add_task(TaskAddParams {
+            title: format!("{name} task"),
+            description: "seed".to_string(),
+            workspace_path: Some(".".to_string()),
+            status: Some(TaskStatus::InProgress),
+            ..Default::default()
+        })
+        .expect("add task");
+    (orbit_dir, repo_root)
+}
+
+#[tokio::test]
+async fn workspaces_endpoint_reports_single_default() {
+    let runtime = OrbitRuntime::in_memory().expect("build runtime");
+    let state = DashboardState::single(Arc::new(runtime));
+    let response = router()
+        .with_state(state)
+        .oneshot(get("/workspaces"))
+        .await
+        .expect("response");
+    let body = body_json(response).await;
+    let entries = body.as_array().expect("array");
+    assert_eq!(entries.len(), 1);
+    assert_eq!(entries[0]["id"], json!("default"));
+    assert_eq!(entries[0]["is_default"], json!(true));
+    assert_eq!(entries[0]["status"], json!("active"));
+}
+
+#[tokio::test]
+async fn tasks_all_in_single_mode_tags_default_workspace() {
+    let runtime = OrbitRuntime::in_memory()
+        .expect("build runtime")
+        .with_actor(ActorIdentity::human("human"));
+    runtime
+        .add_task(TaskAddParams {
+            title: "solo".to_string(),
+            description: "seed".to_string(),
+            workspace_path: Some(".".to_string()),
+            status: Some(TaskStatus::InProgress),
+            ..Default::default()
+        })
+        .expect("add task");
+    let state = DashboardState::single(Arc::new(runtime));
+    let response = router()
+        .with_state(state)
+        .oneshot(get("/tasks/all"))
+        .await
+        .expect("response");
+    let body = body_json(response).await;
+    let tasks = body.as_array().expect("array");
+    assert_eq!(tasks.len(), 1);
+    assert_eq!(tasks[0]["workspace_id"], json!("default"));
+    assert_eq!(tasks[0]["workspace_name"], json!("default"));
+}
+
+#[tokio::test]
+async fn tasks_all_aggregates_active_workspaces_and_skips_inactive() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let global_root = tmp.path().join("global");
+    std::fs::create_dir_all(&global_root).expect("create global root");
+
+    let (alpha_orbit, alpha_repo) = seed_workspace(&global_root, tmp.path(), "alpha");
+    let (beta_orbit, beta_repo) = seed_workspace(&global_root, tmp.path(), "beta");
+
+    let entries = vec![
+        WsEntry {
+            id: "alpha".to_string(),
+            name: "alpha".to_string(),
+            repo_root: alpha_repo,
+            orbit_dir: alpha_orbit,
+            active: true,
+        },
+        WsEntry {
+            id: "beta".to_string(),
+            name: "beta".to_string(),
+            repo_root: beta_repo,
+            orbit_dir: beta_orbit,
+            active: true,
+        },
+        WsEntry {
+            id: "gone".to_string(),
+            name: "gone".to_string(),
+            repo_root: tmp.path().join("missing"),
+            orbit_dir: tmp.path().join("missing/.orbit"),
+            active: false,
+        },
+    ];
+    let state = DashboardState::global(global_root, entries, Some("alpha".to_string()));
+
+    // Aggregate task list: one task per active workspace, tagged; none from the
+    // inactive workspace.
+    let response = router()
+        .with_state(state.clone())
+        .oneshot(get("/tasks/all"))
+        .await
+        .expect("response");
+    let body = body_json(response).await;
+    let tasks = body.as_array().expect("array");
+    assert_eq!(tasks.len(), 2);
+    let ws_ids: HashSet<&str> = tasks
+        .iter()
+        .map(|t| t["workspace_id"].as_str().expect("workspace_id"))
+        .collect();
+    assert_eq!(ws_ids, HashSet::from(["alpha", "beta"]));
+    assert!(tasks.iter().all(|t| t["workspace_name"].is_string()));
+
+    // Workspace listing: all three, with status + default flag.
+    let response = router()
+        .with_state(state)
+        .oneshot(get("/workspaces"))
+        .await
+        .expect("response");
+    let body = body_json(response).await;
+    let listed = body.as_array().expect("array");
+    assert_eq!(listed.len(), 3);
+    let gone = listed
+        .iter()
+        .find(|w| w["id"] == json!("gone"))
+        .expect("gone entry");
+    assert_eq!(gone["status"], json!("invalid"));
+    let alpha = listed
+        .iter()
+        .find(|w| w["id"] == json!("alpha"))
+        .expect("alpha entry");
+    assert_eq!(alpha["is_default"], json!(true));
+    assert_eq!(alpha["status"], json!("active"));
+}

--- a/crates/orbit-dashboard/src/api/workspaces.rs
+++ b/crates/orbit-dashboard/src/api/workspaces.rs
@@ -1,0 +1,62 @@
+//! Global (cross-workspace) endpoints (ORB-00030).
+//!
+//! These handlers take the whole [`DashboardState`] rather than a single
+//! workspace runtime (via the [`Ws`](crate::state::Ws) extractor), because they
+//! describe or aggregate across every servable workspace. In single mode they
+//! degrade gracefully: `/api/workspaces` reports the one synthetic entry and
+//! `/api/tasks/all` returns that workspace's tasks.
+
+use axum::extract::State;
+use axum::response::{IntoResponse, Json, Response};
+use serde_json::{Value, json};
+
+use super::server_error;
+use super::tasks::list_tasks_json;
+use crate::state::DashboardState;
+
+/// `GET /api/workspaces` — list every workspace the dashboard can serve, with
+/// the currently-selected default flagged.
+pub(super) async fn list_workspaces(State(state): State<DashboardState>) -> Response {
+    let default = state.default_workspace();
+    let values: Vec<Value> = state
+        .entries()
+        .iter()
+        .map(|entry| {
+            json!({
+                "id": entry.id,
+                "name": entry.name,
+                "root": entry.repo_root,
+                "status": if entry.active { "active" } else { "invalid" },
+                "is_default": Some(entry.id.as_str()) == default,
+            })
+        })
+        .collect();
+    Json(Value::Array(values)).into_response()
+}
+
+/// `GET /api/tasks/all` — dashboard tasks aggregated across active workspaces.
+///
+/// Each task object is tagged with its owning workspace (`workspace_id` /
+/// `workspace_name`) so the frontend can render a workspace column. Inactive
+/// (stale-path) workspaces are skipped, as are any that fail to open — the
+/// aggregate view stays available even when one workspace is broken.
+pub(super) async fn list_all_tasks(State(state): State<DashboardState>) -> Response {
+    let mut all = Vec::new();
+    for entry in state.entries().iter().filter(|entry| entry.active) {
+        let Ok(runtime) = state.runtime_for(&entry.id) else {
+            continue;
+        };
+        let values = match list_tasks_json(&runtime) {
+            Ok(values) => values,
+            Err(e) => return server_error(e),
+        };
+        for mut value in values {
+            if let Value::Object(map) = &mut value {
+                map.insert("workspace_id".to_string(), json!(entry.id));
+                map.insert("workspace_name".to_string(), json!(entry.name));
+            }
+            all.push(value);
+        }
+    }
+    Json(Value::Array(all)).into_response()
+}

--- a/crates/orbit-dashboard/src/lib.rs
+++ b/crates/orbit-dashboard/src/lib.rs
@@ -5,15 +5,18 @@
 //! large dependency subtree (axum, etc). Behavior is identical to the prior
 //! in-tree implementation.
 //!
-//! Public surface is deliberately tiny: `ServeArgs` (clap) + `serve()` entry
-//! point. All routes, content types, defaults, and graceful shutdown are
-//! preserved.
+//! Public surface is deliberately tiny: `ServeArgs` (clap) plus two entry
+//! points — `serve()` for a caller-supplied runtime and `serve_from_env()`,
+//! which resolves the workspace(s) to serve from the environment (single
+//! workspace, or every registered workspace in global mode). All routes,
+//! content types, defaults, and graceful shutdown are preserved.
 
 mod api;
 mod connect;
 mod log_format;
 mod parse;
 mod projections;
+mod state;
 
 #[cfg(test)]
 mod tests;
@@ -21,6 +24,7 @@ mod tests;
 pub use connect::{ConnectArgs, connect};
 
 use std::net::{IpAddr, SocketAddr};
+use std::path::Path;
 use std::sync::Arc;
 
 use axum::Router;
@@ -28,7 +32,8 @@ use axum::http::{HeaderValue, StatusCode, header};
 use axum::response::{IntoResponse, Response};
 use axum::routing::get;
 use clap::Args;
-use orbit_core::{OrbitError, OrbitRuntime};
+use orbit_common::types::{WorkspaceRegistry, WorkspaceStatus};
+use orbit_core::{ActorIdentity, OrbitError, OrbitRuntime, workspace_registry};
 
 const INDEX_HTML: &str = include_str!("../assets/dashboard/index.html");
 const DASHBOARD_CSS: &str = include_str!("../assets/dashboard/dashboard.css");
@@ -79,20 +84,99 @@ pub struct ServeArgs {
     /// Do not attempt to open the dashboard URL in a browser on startup.
     #[arg(long)]
     pub no_open: bool,
+
+    /// Serve every registered workspace (machine-wide view) instead of only
+    /// the current one. Implied automatically when run outside any workspace.
+    #[arg(long)]
+    pub global: bool,
 }
 
-/// Boot the dashboard server and block until shutdown (ctrl-c or SIGTERM).
-///
-/// This is the single public entry point. The caller (typically orbit-cli's
-/// thin `web` subcommand) supplies the shared `OrbitRuntime` and the clap
-/// args. All routes, response shapes, and side-effects (browser open, banner)
-/// are unchanged from the prior CLI-embedded version.
+/// Boot the dashboard for a single, already-built runtime and block until
+/// shutdown (ctrl-c or SIGTERM). Retained for callers that already hold an
+/// `OrbitRuntime`; `orbit web serve` uses [`serve_from_env`] instead.
 pub fn serve(runtime: &OrbitRuntime, args: ServeArgs) -> Result<(), OrbitError> {
+    let state = state::DashboardState::single(Arc::new(runtime.clone()));
+    run_server(&args, state)
+}
+
+/// Boot the dashboard, resolving which workspace(s) to serve from the current
+/// environment, and block until shutdown.
+///
+/// Unlike [`serve`], this needs no pre-built runtime, so it works from any
+/// directory — the entry point for `orbit web serve` (dispatched before the
+/// CLI's eager workspace initialization, which would otherwise fail outside a
+/// workspace). Inside a workspace without `--global` it preserves the original
+/// single-workspace behavior; otherwise it serves every registered workspace.
+pub fn serve_from_env(args: ServeArgs, root_override: Option<&Path>) -> Result<(), OrbitError> {
+    let state = build_state(&args, root_override)?;
+    run_server(&args, state)
+}
+
+/// Resolve dashboard state from the environment.
+///
+/// - Inside a workspace, no `--global`: single mode over that workspace.
+/// - `--global`, or outside any workspace: global mode over every registered
+///   workspace (stale-path entries are listed but marked inactive and never
+///   built).
+fn build_state(
+    args: &ServeArgs,
+    root_override: Option<&Path>,
+) -> Result<state::DashboardState, OrbitError> {
+    let cwd_runtime = OrbitRuntime::try_initialize_existing(root_override)?;
+
+    if !args.global
+        && let Some(runtime) = cwd_runtime
+    {
+        let runtime = runtime.with_actor(ActorIdentity::human("human"));
+        return Ok(state::DashboardState::single(Arc::new(runtime)));
+    }
+
+    let global_root = workspace_registry::global_orbit_dir()?;
+    let mut registry = workspace_registry::load_registry()?;
+    workspace_registry::validate_workspaces(&mut registry);
+
+    let default_workspace = std::env::current_dir()
+        .ok()
+        .and_then(|cwd| default_workspace_for_cwd(&registry, &cwd));
+
+    let entries = registry
+        .workspaces
+        .iter()
+        .map(|ws| state::WsEntry {
+            id: ws.id.clone(),
+            name: ws.name.clone(),
+            repo_root: ws.root.clone(),
+            orbit_dir: ws.orbit_dir.clone(),
+            active: ws.status == WorkspaceStatus::Active,
+        })
+        .collect();
+
+    Ok(state::DashboardState::global(
+        global_root,
+        entries,
+        default_workspace,
+    ))
+}
+
+/// Best-effort default when serving globally: the registered workspace whose
+/// repo root is the longest prefix of `cwd`, if the server was launched inside
+/// one. `None` means the frontend opens on the aggregate "all workspaces" view.
+fn default_workspace_for_cwd(registry: &WorkspaceRegistry, cwd: &Path) -> Option<String> {
+    registry
+        .workspaces
+        .iter()
+        .filter(|ws| ws.status == WorkspaceStatus::Active && cwd.starts_with(&ws.root))
+        .max_by_key(|ws| ws.root.as_os_str().len())
+        .map(|ws| ws.id.clone())
+}
+
+/// Build the axum app and block on the tokio runtime until graceful shutdown.
+fn run_server(args: &ServeArgs, state: state::DashboardState) -> Result<(), OrbitError> {
     check_bindable_host(args.host, args.port)?;
 
     let addr = SocketAddr::new(args.host, args.port);
     let url = format!("http://{addr}");
-    let runtime = Arc::new(runtime.clone());
+    let no_open = args.no_open;
 
     let app = Router::new()
         .route("/", get(serve_index))
@@ -113,7 +197,7 @@ pub fn serve(runtime: &OrbitRuntime, args: ServeArgs) -> Result<(), OrbitError> 
         .route("/static/review-threads.js", get(serve_review_threads_js))
         .route("/healthz", get(healthz))
         .nest("/api", api::router())
-        .with_state(runtime);
+        .with_state(state);
 
     let tokio_runtime = tokio::runtime::Builder::new_multi_thread()
         .enable_all()
@@ -130,7 +214,7 @@ pub fn serve(runtime: &OrbitRuntime, args: ServeArgs) -> Result<(), OrbitError> 
             println!("Dashboard listening on {url}");
         }
 
-        if !args.no_open {
+        if !no_open {
             open_browser(&url);
         }
 

--- a/crates/orbit-dashboard/src/state.rs
+++ b/crates/orbit-dashboard/src/state.rs
@@ -1,0 +1,231 @@
+//! Multi-workspace dashboard state (ORB-00030).
+//!
+//! The dashboard was originally coupled to a single `Arc<OrbitRuntime>` used
+//! directly as axum state. To let one server serve every registered workspace
+//! on the machine, state is generalized to a workspace-keyed, lazily-built
+//! runtime map ([`DashboardState`]) and handlers receive their runtime through
+//! the [`Ws`] extractor (which selects a workspace from the `?workspace=<id>`
+//! query parameter, falling back to the configured default).
+//!
+//! [`DashboardState::single`] preserves the original single-workspace behavior
+//! so `serve()` inside a workspace and every existing handler test keep working
+//! unchanged: one pre-built runtime, always selected, no lazy construction.
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
+
+use axum::extract::FromRequestParts;
+use axum::http::StatusCode;
+use axum::http::request::Parts;
+use axum::response::{IntoResponse, Json, Response};
+use orbit_core::{ActorIdentity, OrbitError, OrbitRuntime};
+use serde_json::json;
+
+/// Synthetic workspace id used by [`DashboardState::single`].
+pub(crate) const SINGLE_WORKSPACE_ID: &str = "default";
+
+/// One registered workspace the dashboard can serve.
+///
+/// `orbit_dir` is the workspace's `.orbit` directory — the value passed to
+/// [`OrbitRuntime::from_roots`] as the workspace root. `active` mirrors the
+/// registry status: inactive (stale-path) entries are listed but never built.
+#[derive(Clone, Debug)]
+pub(crate) struct WsEntry {
+    pub(crate) id: String,
+    pub(crate) name: String,
+    pub(crate) repo_root: PathBuf,
+    pub(crate) orbit_dir: PathBuf,
+    pub(crate) active: bool,
+}
+
+struct StateInner {
+    /// Global orbit root (`~/.orbit`); passed as `global_root` when building
+    /// per-workspace runtimes. Unused in single mode.
+    global_root: PathBuf,
+    entries: Vec<WsEntry>,
+    default_workspace: Option<String>,
+    /// Lazily-built, cached runtimes keyed by workspace id.
+    runtimes: Mutex<HashMap<String, Arc<OrbitRuntime>>>,
+}
+
+/// Axum application state: the set of servable workspaces plus a lazy runtime
+/// cache. Cheap to clone (single `Arc`).
+#[derive(Clone)]
+pub(crate) struct DashboardState {
+    inner: Arc<StateInner>,
+}
+
+impl DashboardState {
+    /// Single-workspace mode: serve exactly one pre-built runtime, always
+    /// selected. Preserves the pre-ORB-00030 behavior and keeps every handler
+    /// test (which builds an in-memory runtime) working unchanged.
+    pub(crate) fn single(runtime: Arc<OrbitRuntime>) -> Self {
+        let entry = WsEntry {
+            id: SINGLE_WORKSPACE_ID.to_string(),
+            name: SINGLE_WORKSPACE_ID.to_string(),
+            repo_root: PathBuf::new(),
+            orbit_dir: PathBuf::new(),
+            active: true,
+        };
+        let mut runtimes = HashMap::new();
+        runtimes.insert(SINGLE_WORKSPACE_ID.to_string(), runtime);
+        Self {
+            inner: Arc::new(StateInner {
+                global_root: PathBuf::new(),
+                entries: vec![entry],
+                default_workspace: Some(SINGLE_WORKSPACE_ID.to_string()),
+                runtimes: Mutex::new(runtimes),
+            }),
+        }
+    }
+
+    /// Global mode: serve every registered workspace, building runtimes on
+    /// first access. `default_workspace` (if any) is the workspace selected
+    /// when a request omits `?workspace=`.
+    pub(crate) fn global(
+        global_root: PathBuf,
+        entries: Vec<WsEntry>,
+        default_workspace: Option<String>,
+    ) -> Self {
+        Self {
+            inner: Arc::new(StateInner {
+                global_root,
+                entries,
+                default_workspace,
+                runtimes: Mutex::new(HashMap::new()),
+            }),
+        }
+    }
+
+    pub(crate) fn entries(&self) -> &[WsEntry] {
+        &self.inner.entries
+    }
+
+    pub(crate) fn default_workspace(&self) -> Option<&str> {
+        self.inner.default_workspace.as_deref()
+    }
+
+    /// Resolve (and lazily build + cache) the runtime for workspace `id`.
+    ///
+    /// Building happens outside the cache lock; a concurrent build for the same
+    /// id is harmless (idempotent) and the first cached value wins.
+    pub(crate) fn runtime_for(&self, id: &str) -> Result<Arc<OrbitRuntime>, WsRejection> {
+        let entry = self
+            .inner
+            .entries
+            .iter()
+            .find(|e| e.id == id)
+            .ok_or_else(|| WsRejection::unknown(id))?;
+        if !entry.active {
+            return Err(WsRejection::inactive(id));
+        }
+
+        // Fast path: already cached.
+        if let Some(rt) = self.lock_runtimes().get(id).cloned() {
+            return Ok(rt);
+        }
+
+        // Build outside the lock (no lock held across construction).
+        let runtime = OrbitRuntime::from_roots(&self.inner.global_root, &entry.orbit_dir)
+            .map_err(|e| WsRejection::build_failed(id, &e))?
+            .with_actor(ActorIdentity::human("human"));
+        let runtime = Arc::new(runtime);
+
+        let mut cache = self.lock_runtimes();
+        let cached = cache
+            .entry(id.to_string())
+            .or_insert_with(|| runtime.clone());
+        Ok(cached.clone())
+    }
+
+    fn lock_runtimes(&self) -> std::sync::MutexGuard<'_, HashMap<String, Arc<OrbitRuntime>>> {
+        // Recover from poisoning: the cache is an idempotent build cache, so a
+        // panic in another thread cannot leave it logically inconsistent.
+        self.inner
+            .runtimes
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+    }
+}
+
+/// Rejection returned by the [`Ws`] extractor when a workspace cannot be
+/// selected or built. Renders as a JSON `{ "error": ... }` body.
+pub(crate) struct WsRejection {
+    status: StatusCode,
+    message: String,
+}
+
+impl WsRejection {
+    fn unknown(id: &str) -> Self {
+        Self {
+            status: StatusCode::NOT_FOUND,
+            message: format!("unknown workspace: {id}"),
+        }
+    }
+
+    fn inactive(id: &str) -> Self {
+        Self {
+            status: StatusCode::BAD_REQUEST,
+            message: format!("workspace '{id}' is inactive (its path no longer exists)"),
+        }
+    }
+
+    fn build_failed(id: &str, err: &OrbitError) -> Self {
+        Self {
+            status: StatusCode::INTERNAL_SERVER_ERROR,
+            message: format!("failed to open workspace '{id}': {err}"),
+        }
+    }
+
+    fn no_default() -> Self {
+        Self {
+            status: StatusCode::BAD_REQUEST,
+            message: "no workspace selected and no default is configured; \
+                      pass ?workspace=<id>"
+                .to_string(),
+        }
+    }
+}
+
+impl IntoResponse for WsRejection {
+    fn into_response(self) -> Response {
+        (self.status, Json(json!({ "error": self.message }))).into_response()
+    }
+}
+
+/// Extractor yielding the `Arc<OrbitRuntime>` for the request's workspace.
+///
+/// Selection order: the `?workspace=<id>` query parameter, else the state's
+/// configured default. Handlers destructure it as `Ws(runtime)` — a drop-in
+/// replacement for the former `State(runtime): State<Arc<OrbitRuntime>>`.
+pub(crate) struct Ws(pub(crate) Arc<OrbitRuntime>);
+
+#[axum::async_trait]
+impl FromRequestParts<DashboardState> for Ws {
+    type Rejection = WsRejection;
+
+    async fn from_request_parts(
+        parts: &mut Parts,
+        state: &DashboardState,
+    ) -> Result<Self, Self::Rejection> {
+        let requested = parts.uri.query().and_then(workspace_from_query);
+        let id = match requested {
+            Some(id) => id,
+            None => state
+                .default_workspace()
+                .map(str::to_string)
+                .ok_or_else(WsRejection::no_default)?,
+        };
+        Ok(Ws(state.runtime_for(&id)?))
+    }
+}
+
+/// Extract the `workspace` value from a raw query string (percent-decoded),
+/// ignoring empty values so `?workspace=` behaves like an omitted parameter.
+fn workspace_from_query(query: &str) -> Option<String> {
+    url::form_urlencoded::parse(query.as_bytes())
+        .find(|(k, _)| k == "workspace")
+        .map(|(_, v)| v.into_owned())
+        .filter(|v| !v.is_empty())
+}

--- a/crates/orbit-dashboard/src/tests/mod.rs
+++ b/crates/orbit-dashboard/src/tests/mod.rs
@@ -5,3 +5,4 @@ mod dashboard_assets;
 mod log_format;
 mod parse;
 mod serve;
+mod state;

--- a/crates/orbit-dashboard/src/tests/state.rs
+++ b/crates/orbit-dashboard/src/tests/state.rs
@@ -1,0 +1,80 @@
+//! Unit tests for multi-workspace state and default-workspace resolution
+//! (ORB-00030).
+
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use chrono::Utc;
+use orbit_common::types::{Workspace, WorkspaceRegistry, WorkspaceStatus};
+use orbit_core::OrbitRuntime;
+
+use crate::default_workspace_for_cwd;
+use crate::state::{DashboardState, WsEntry};
+
+fn workspace(id: &str, root: &str, status: WorkspaceStatus) -> Workspace {
+    let now = Utc::now();
+    Workspace {
+        id: id.to_string(),
+        name: id.to_string(),
+        root: PathBuf::from(root),
+        orbit_dir: PathBuf::from(root).join(".orbit"),
+        git_remote: None,
+        base_branch: "main".to_string(),
+        status,
+        created_at: now,
+        updated_at: now,
+    }
+}
+
+#[test]
+fn single_mode_exposes_one_default_workspace() {
+    let runtime = OrbitRuntime::in_memory().expect("build runtime");
+    let state = DashboardState::single(Arc::new(runtime));
+
+    assert_eq!(state.entries().len(), 1);
+    assert_eq!(state.default_workspace(), Some("default"));
+    assert!(state.runtime_for("default").is_ok());
+    assert!(state.runtime_for("unknown").is_err());
+}
+
+#[test]
+fn global_mode_rejects_inactive_and_unknown_workspaces() {
+    let entries = vec![WsEntry {
+        id: "stale".to_string(),
+        name: "stale".to_string(),
+        repo_root: PathBuf::from("/nonexistent"),
+        orbit_dir: PathBuf::from("/nonexistent/.orbit"),
+        active: false,
+    }];
+    let state = DashboardState::global(PathBuf::from("/nonexistent"), entries, None);
+
+    // Inactive entries are listed but never built.
+    assert_eq!(state.entries().len(), 1);
+    assert!(state.runtime_for("stale").is_err());
+    // Unknown ids are rejected outright.
+    assert!(state.runtime_for("ghost").is_err());
+    assert_eq!(state.default_workspace(), None);
+}
+
+#[test]
+fn default_workspace_for_cwd_picks_longest_active_prefix() {
+    let registry = WorkspaceRegistry {
+        workspaces: vec![
+            workspace("outer", "/repos", WorkspaceStatus::Active),
+            workspace("inner", "/repos/inner", WorkspaceStatus::Active),
+            workspace("stale", "/repos/inner/sub", WorkspaceStatus::Invalid),
+        ],
+        path_overrides: Default::default(),
+    };
+
+    // Deepest active workspace wins; the still-deeper inactive one is ignored.
+    assert_eq!(
+        default_workspace_for_cwd(&registry, Path::new("/repos/inner/sub/pkg")),
+        Some("inner".to_string())
+    );
+    // Outside any registered root -> no default (frontend opens the aggregate).
+    assert_eq!(
+        default_workspace_for_cwd(&registry, Path::new("/elsewhere")),
+        None
+    );
+}

--- a/docs/design/user-interface/4_decisions.md
+++ b/docs/design/user-interface/4_decisions.md
@@ -3,7 +3,7 @@ summary: "User Interface — Decisions"
 type: design
 title: "User Interface — Decisions"
 owner: gemini
-last_updated: 2026-05-18
+last_updated: 2026-07-02
 status: Draft
 feature: user-interface
 doc_role: decisions
@@ -115,6 +115,22 @@ Rejected alternative: pure heatmap matrix. Rejected because color alone hides pr
 - No single Rust code anchor; this is enforced by dashboard rendering and design review, and workspace-local ADR comments should not be embedded in shipped dashboard assets.
 - Cost: The denser matrix needs careful row-height discipline when new metrics are added.
 
+## ADR-00030 — Global, Multi-Workspace Dashboard
+
+**Status:** Accepted · 2026-07 · [ORB-00030]
+
+**Context.** `orbit web serve` was coupled to a single workspace: the CLI eagerly initialized one `OrbitRuntime` (failing outside a workspace) and handed it to the dashboard as `Arc<OrbitRuntime>` axum state, so 46 of 48 handlers took `State(runtime): State<Arc<OrbitRuntime>>`. Operators wanted one dashboard over every workspace on the machine, launchable from any directory. `~/.orbit/workspaces.json` already enumerates workspaces and the SQLite stores already scope by workspace, so the missing piece was serving many runtimes from one process without rewriting every handler.
+
+**Decision.** Introduce `DashboardState` — a workspace-keyed, lazily-built runtime map — as the axum state, and a `Ws` extractor that selects the request's runtime from a `?workspace=<id>` query parameter (falling back to a configured default). Handlers change only their signature line (`State(runtime): State<Arc<OrbitRuntime>>` → `Ws(runtime): Ws`); bodies are untouched. `DashboardState::single` preserves the pre-existing single-workspace behavior (and every handler test). `orbit web serve` dispatches through a new `serve_from_env` before the CLI's eager runtime init, so it works from anywhere: inside a workspace without `--global` it stays single-mode; with `--global` or outside any workspace it enumerates the registry, skipping stale-path entries rather than failing. Two aggregate endpoints (`GET /api/workspaces`, `GET /api/tasks/all`) plus a header workspace selector and an "All workspaces" task view expose the machine-wide surface.
+
+Rejected alternative: workspace-prefixed route paths (`/api/:workspace/tasks`). Rejected because it would rewrite all 48 route registrations and every frontend fetch path, versus a single query-param choke point in `common.js` and one-line handler signature swaps.
+
+**Consequences.**
+- One loopback dashboard can cover every workspace; per-workspace views drill down via the selector while Tasks offers a cross-workspace aggregate.
+- The loopback-only bind guard (ORB-00360) is unchanged — global mode broadens data exposure only on the same machine, still with no network binding and no auth added.
+- Runtimes are built on first access and cached, so an unopenable or stale workspace degrades to being skipped instead of failing startup.
+- Cost: handlers that need a concrete workspace now depend on the `Ws` extractor's selection rules; the aggregate task endpoint reopens each workspace's store per request (no cross-workspace caching of task lists yet).
+
 ## Task References
 
 - [T20260427-29] introduced the Canon Refined UI direction.
@@ -125,5 +141,6 @@ Rejected alternative: pure heatmap matrix. Rejected because color alone hides pr
 - [ORB-00144] grouped scoreboard metrics and added knowledge counters plus duel matrix data.
 - [ORB-00146] extracted the dashboard and JSON API into the new `orbit-dashboard` internal crate (this document).
 - [ORB-00154] unified the Scoreboard tab into a metric-major leaderboard matrix.
+- [ORB-00030] made the dashboard global/multi-workspace (workspace-keyed state, `Ws` extractor, serve-from-anywhere, aggregate endpoints).
 
 > Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.


### PR DESCRIPTION
## Task
ORB-00030 — Make the dashboard global-scoped: `orbit web serve` from anywhere, over all workspaces.

## Summary
Generalizes the dashboard from a single `Arc<OrbitRuntime>` axum state to a workspace-keyed, lazily-built runtime map (`DashboardState` + `Ws` extractor). `orbit web serve` now runs from any directory:
- **Inside a workspace, no `--global`** → single mode over that workspace (unchanged behavior).
- **`--global`, or outside any workspace** → global mode over every workspace in `~/.orbit/workspaces.json`, building runtimes on first access and skipping stale-path entries instead of failing startup.

### Backend
- `src/state.rs`: `DashboardState::{single,global}` + `Ws` extractor. The 46 stateful handlers change **only their signature line** (`State(runtime): State<Arc<OrbitRuntime>>` → `Ws(runtime): Ws`); bodies untouched. `single` preserves the pre-existing behavior and every handler test.
- `serve_from_env(args, root_override)` dispatched from an early `main.rs` arm (before the CLI's eager runtime init, which fails outside a workspace). Added `ServeArgs --global`.
- New endpoints: `GET /api/workspaces` (list + `is_default`) and `GET /api/tasks/all` (aggregate, each task tagged `workspace_id`/`workspace_name`; inactive/unopenable workspaces skipped).
- Loopback-only bind guard (ORB-00360) **untouched**.

### Frontend
- Workspace-aware fetch choke point in `common.js` (transparent `?workspace=`), header workspace selector populated from `/api/workspaces` (global mode only) with an **All workspaces** aggregate option, and a per-task workspace badge in the aggregate Tasks view.

## Validation
- `cargo test -p orbit-dashboard`: **94 passed** (88 existing + 6 new — endpoint tests incl. on-disk multi-workspace aggregation & stale-path skip, plus state/lib unit tests).
- `cargo clippy -p orbit-dashboard -p orbit-cli --all-targets`: clean · `cargo fmt --check`: clean · `make ci-fast`: pass.
- End-to-end from a non-workspace dir: `orbit web serve --global` listed all 4 registered workspaces; `/api/tasks/all` returned tasks tagged by workspace; `/api/tasks?workspace=<id>` scoped correctly; unknown workspace → 404.

## Docs
CHANGELOG (Unreleased), README quick-start `--global`, ADR-00030 in `docs/design/user-interface/4_decisions.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)