### PR TITLE
[ORB-00411] workflows: unattended ship dispatch — auto_ship opt-in, ship-sweep, POST /workflows/ship

### DIFF
--- a/crates/orbit-cli/src/audit_middleware.rs
+++ b/crates/orbit-cli/src/audit_middleware.rs
@@ -646,6 +646,7 @@ fn run_command_meta(cmd: &crate::command::run::RunCommand) -> CommandMeta {
     let (subcommand, target_type, target_id) = match &cmd.command {
         RunSubcommand::Ship(_) => ("ship", Some("workflow"), Some("ship")),
         RunSubcommand::ShipLocal(_) => ("ship-local", Some("workflow"), Some("ship-local")),
+        RunSubcommand::ShipSweep(_) => ("ship-sweep", Some("workflow"), Some("ship-sweep")),
         RunSubcommand::DuelPlan(args) => ("duel-plan", Some("task"), Some(args.task_id.as_str())),
         RunSubcommand::History(args) => ("history", Some("job_run"), args.job_id.as_deref()),
         RunSubcommand::Show(args) => ("show", Some("job_run"), args.run_id.as_deref()),

--- a/crates/orbit-cli/src/command/run/command.rs
+++ b/crates/orbit-cli/src/command/run/command.rs
@@ -10,11 +10,13 @@ use super::job::JobRunArgs;
 use super::logs::RunLogsArgs;
 use super::ship;
 use super::show::RunShowArgs;
+use super::sweep;
 use super::trace::RunTraceArgs;
 
 const RUN_AFTER_HELP: &str = "\
 Workflow entrypoints:
   orbit run ship [task_id ...]
+  orbit run ship-sweep [--dry-run] [--json]
   orbit run duel-plan <task_id>
   orbit run job <job_id> [--input key=value] [--json] [--debug]
 
@@ -40,9 +42,10 @@ Run history:
 {usage-heading} {usage}
 
 Workflows:
-  ship       Ship backlog or explicitly selected tasks through the gated task pipeline
-  duel-plan  Run a planning duel for one task
-  job        Run an arbitrary job by ID
+  ship        Ship backlog or explicitly selected tasks through the gated task pipeline
+  ship-sweep  Dispatch ship runs in every registered workspace with ready backlog tasks
+  duel-plan   Run a planning duel for one task
+  job         Run an arbitrary job by ID
 
 Audits:
   history    Show recent job runs, optionally filtered to one job
@@ -73,6 +76,9 @@ pub enum RunSubcommand {
     /// Deprecated alias for `orbit run ship --mode local`
     #[command(name = "ship-local", hide = true)]
     ShipLocal(ship::LegacyShipLocalCommand),
+    /// Dispatch ship runs in every registered workspace with ready backlog tasks
+    #[command(name = "ship-sweep")]
+    ShipSweep(sweep::ShipSweepCommand),
     /// Run a planning duel for one task
     #[command(name = "duel-plan")]
     DuelPlan(duel::DuelPlanCommand),
@@ -95,6 +101,9 @@ impl Execute for RunSubcommand {
         match self {
             RunSubcommand::Ship(command) => command.execute(runtime),
             RunSubcommand::ShipLocal(command) => command.execute(runtime),
+            // Normally dispatched before runtime init (see main.rs); the
+            // registry-driven sweep never uses the cwd-derived runtime.
+            RunSubcommand::ShipSweep(command) => command.execute_without_runtime(),
             RunSubcommand::DuelPlan(command) => command.execute(runtime),
             RunSubcommand::History(command) => command.execute(runtime),
             RunSubcommand::Show(command) => command.execute(runtime),

--- a/crates/orbit-cli/src/command/run/mod.rs
+++ b/crates/orbit-cli/src/command/run/mod.rs
@@ -10,6 +10,7 @@ pub mod ship;
 mod show;
 mod steps;
 pub(crate) mod support;
+pub mod sweep;
 mod trace;
 
 pub use command::{RunCommand, RunSubcommand};

--- a/crates/orbit-cli/src/command/run/ship.rs
+++ b/crates/orbit-cli/src/command/run/ship.rs
@@ -1,9 +1,7 @@
 //! `orbit run ship` CLI entrypoint.
 
-use std::collections::HashSet;
-
 use clap::{Args, ValueEnum};
-use orbit_core::{OrbitError, OrbitRuntime, find_workflow};
+use orbit_core::{OrbitError, OrbitRuntime, build_ship_input, find_workflow};
 use serde_json::Value;
 
 use crate::command::Execute;
@@ -19,10 +17,10 @@ pub enum ShipMode {
 }
 
 impl ShipMode {
-    fn as_input_value(self) -> &'static str {
+    pub(super) fn to_core(self) -> orbit_core::ShipMode {
         match self {
-            ShipMode::Pr => "pr",
-            ShipMode::Local => "local",
+            ShipMode::Pr => orbit_core::ShipMode::Pr,
+            ShipMode::Local => orbit_core::ShipMode::Local,
         }
     }
 }
@@ -100,40 +98,14 @@ pub(crate) fn build_ship_run_plan(
     let base = args.base.as_deref().unwrap_or(config_base_branch);
     Ok(WorkflowRunPlan {
         workflow_alias,
-        input: ship_input(args.mode, base, &args.task_ids),
+        input: build_ship_input(args.mode.to_core(), base, &args.task_ids)?,
     })
-}
-
-fn ship_input(mode: ShipMode, base: &str, task_ids: &[String]) -> Value {
-    let mut map = serde_json::Map::new();
-    map.insert(
-        "mode".to_string(),
-        Value::String(mode.as_input_value().to_string()),
-    );
-    map.insert("base_branch".to_string(), Value::String(base.to_string()));
-    if !task_ids.is_empty() {
-        map.insert(
-            "task_ids".to_string(),
-            Value::Array(task_ids.iter().cloned().map(Value::String).collect()),
-        );
-    }
-    Value::Object(map)
 }
 
 fn validate_task_selection(task_ids: &[String]) -> Result<(), OrbitError> {
     if let Some(legacy) = task_ids.first().and_then(|value| legacy_ship_form(value)) {
         return Err(OrbitError::InvalidInput(legacy.to_string()));
     }
-
-    let mut seen = HashSet::new();
-    for task_id in task_ids {
-        if !seen.insert(task_id.as_str()) {
-            return Err(OrbitError::InvalidInput(format!(
-                "duplicate task id '{task_id}' in explicit task selection"
-            )));
-        }
-    }
-
     Ok(())
 }
 

--- a/crates/orbit-cli/src/command/run/sweep.rs
+++ b/crates/orbit-cli/src/command/run/sweep.rs
@@ -1,0 +1,220 @@
+//! `orbit run ship-sweep` — dispatch ship runs across every registered
+//! workspace that opted in (`[workflow] auto_ship = true`) and has ready
+//! backlog work. Designed for unattended schedulers (systemd timer, cron):
+//! it never bootstraps a workspace from the caller's cwd, isolates
+//! per-workspace failures, and exits non-zero only when a workspace errored.
+
+use std::path::Path;
+
+use clap::Args;
+use orbit_common::types::{Workspace, WorkspaceStatus};
+use orbit_core::workspace_registry;
+use orbit_core::{
+    JobRunState, OrbitError, OrbitRuntime, TaskStatus, build_task_status_index,
+    task_dependencies_ready,
+};
+use serde_json::{Value, json};
+
+use super::ship::ShipMode;
+use super::support::TASK_AUTO_PIPELINE_JOB;
+
+#[derive(Args)]
+#[command(
+    name = "ship-sweep",
+    about = "Dispatch ship runs in every registered workspace with ready backlog tasks",
+    after_help = "Only workspaces with `[workflow] auto_ship = true` in their config.toml are\n\
+                  swept; everything else is reported as skipped. Intended to run from a\n\
+                  scheduler (systemd timer / cron), e.g.:\n  orbit run ship-sweep --json\n\n\
+                  Inspect dispatched runs per workspace with `orbit run history -j task_auto_pipeline`."
+)]
+pub struct ShipSweepCommand {
+    /// Pipeline mode for dispatched ship runs.
+    #[arg(short = 'm', long, value_enum, default_value = "pr")]
+    pub mode: ShipMode,
+    /// Report what would be dispatched without submitting any run.
+    #[arg(long)]
+    pub dry_run: bool,
+    /// Output as JSON.
+    #[arg(long)]
+    pub json: bool,
+}
+
+struct SweepReport {
+    workspace_id: String,
+    workspace_name: String,
+    action: &'static str,
+    reason: Option<String>,
+    ready_backlog: usize,
+    run_id: Option<String>,
+    run_state: Option<&'static str>,
+}
+
+impl SweepReport {
+    fn skipped(ws: &Workspace, reason: &str, ready_backlog: usize) -> Self {
+        Self {
+            workspace_id: ws.id.clone(),
+            workspace_name: ws.name.clone(),
+            action: "skipped",
+            reason: Some(reason.to_string()),
+            ready_backlog,
+            run_id: None,
+            run_state: None,
+        }
+    }
+
+    fn to_json(&self) -> Value {
+        json!({
+            "workspace_id": self.workspace_id,
+            "workspace_name": self.workspace_name,
+            "action": self.action,
+            "reason": self.reason,
+            "ready_backlog": self.ready_backlog,
+            "run_id": self.run_id,
+            "run_state": self.run_state,
+        })
+    }
+
+    fn to_line(&self) -> String {
+        let mut line = format!(
+            "{}: {} (ready backlog: {})",
+            self.workspace_name, self.action, self.ready_backlog
+        );
+        if let Some(reason) = &self.reason {
+            line.push_str(&format!(" — {reason}"));
+        }
+        if let Some(run_id) = &self.run_id {
+            line.push_str(&format!(" — run {run_id}"));
+            if let Some(state) = self.run_state {
+                line.push_str(&format!(" [{state}]"));
+            }
+        }
+        line
+    }
+}
+
+impl ShipSweepCommand {
+    /// Runs without a pre-initialized runtime: the sweep resolves every
+    /// workspace from the global registry and must never bootstrap a
+    /// `.orbit/` in the scheduler's working directory.
+    pub fn execute_without_runtime(self) -> Result<(), OrbitError> {
+        let global_root = workspace_registry::global_orbit_dir()?;
+        let registry_path = workspace_registry::registry_path_for(&global_root);
+        let mut registry = workspace_registry::load_registry_from(&registry_path)?;
+        workspace_registry::validate_workspaces(&mut registry);
+        workspace_registry::save_registry_to(&registry, &registry_path)?;
+
+        let mode = self.mode.to_core();
+        let reports: Vec<SweepReport> = registry
+            .workspaces
+            .iter()
+            .map(|ws| sweep_workspace(&global_root, ws, mode, self.dry_run))
+            .collect();
+
+        let failed = reports.iter().filter(|r| r.action == "error").count();
+        if self.json {
+            crate::output::json::print_pretty(&json!({
+                "dry_run": self.dry_run,
+                "workspaces": reports.len(),
+                "dispatched": reports.iter().filter(|r| r.action == "dispatched").count(),
+                "would_dispatch": reports.iter().filter(|r| r.action == "would_dispatch").count(),
+                "skipped": reports.iter().filter(|r| r.action == "skipped").count(),
+                "failed": failed,
+                "reports": reports.iter().map(SweepReport::to_json).collect::<Vec<_>>(),
+            }))?;
+        } else if reports.is_empty() {
+            println!("no workspaces registered");
+        } else {
+            for report in &reports {
+                println!("{}", report.to_line());
+            }
+        }
+
+        if failed > 0 {
+            return Err(OrbitError::WorkspaceError(format!(
+                "ship-sweep: {failed} of {} workspace(s) failed",
+                reports.len()
+            )));
+        }
+        Ok(())
+    }
+}
+
+fn sweep_workspace(
+    global_root: &Path,
+    ws: &Workspace,
+    mode: orbit_core::ShipMode,
+    dry_run: bool,
+) -> SweepReport {
+    if ws.status != WorkspaceStatus::Active || !ws.orbit_dir.exists() {
+        return SweepReport::skipped(ws, "workspace_inactive", 0);
+    }
+    sweep_active_workspace(global_root, ws, mode, dry_run).unwrap_or_else(|error| SweepReport {
+        workspace_id: ws.id.clone(),
+        workspace_name: ws.name.clone(),
+        action: "error",
+        reason: Some(error.to_string()),
+        ready_backlog: 0,
+        run_id: None,
+        run_state: None,
+    })
+}
+
+fn sweep_active_workspace(
+    global_root: &Path,
+    ws: &Workspace,
+    mode: orbit_core::ShipMode,
+    dry_run: bool,
+) -> Result<SweepReport, OrbitError> {
+    let runtime = OrbitRuntime::from_roots(global_root, &ws.orbit_dir)?;
+    if !runtime.workflow_auto_ship() {
+        return Ok(SweepReport::skipped(ws, "auto_ship_disabled", 0));
+    }
+
+    let tasks = runtime.list_tasks()?;
+    let status_by_id = build_task_status_index(&tasks);
+    let ready_backlog = tasks
+        .iter()
+        .filter(|task| {
+            task.status == TaskStatus::Backlog && task_dependencies_ready(task, &status_by_id)
+        })
+        .count();
+    if ready_backlog == 0 {
+        return Ok(SweepReport::skipped(ws, "no_ready_backlog", 0));
+    }
+
+    let in_flight = runtime
+        .job_history(TASK_AUTO_PIPELINE_JOB)?
+        .iter()
+        .any(|run| {
+            matches!(
+                run.state,
+                JobRunState::Pending | JobRunState::Running | JobRunState::Retrying
+            )
+        });
+    if in_flight {
+        return Ok(SweepReport::skipped(ws, "ship_in_flight", ready_backlog));
+    }
+
+    if dry_run {
+        return Ok(SweepReport {
+            workspace_id: ws.id.clone(),
+            workspace_name: ws.name.clone(),
+            action: "would_dispatch",
+            reason: None,
+            ready_backlog,
+            run_id: None,
+            run_state: None,
+        });
+    }
+
+    let invoke = runtime.submit_ship_run(mode, None, &[], Some("ship-sweep"))?;
+    Ok(SweepReport {
+        workspace_id: ws.id.clone(),
+        workspace_name: ws.name.clone(),
+        action: "dispatched",
+        reason: None,
+        ready_backlog,
+        run_id: Some(invoke.run_id),
+        run_state: Some(if invoke.queued { "queued" } else { "submitted" }),
+    })
+}

--- a/crates/orbit-cli/src/main.rs
+++ b/crates/orbit-cli/src/main.rs
@@ -44,6 +44,7 @@ use crate::command::friction::{FrictionCommand, FrictionSubcommand};
 use crate::command::hook::{HookCommand, HookSubcommand};
 use crate::command::learning::{LearningCommand, LearningSubcommand};
 use crate::command::mcp::{McpCommand, McpSubcommand};
+use crate::command::run::{RunCommand, RunSubcommand};
 use crate::command::search::SearchCommand;
 use crate::command::tool::{OutputFormat, ToolSubcommand};
 use crate::command::web::{WebCommand, WebSubcommand};
@@ -107,6 +108,18 @@ fn main() {
             command: LearningSubcommand::MigrateLayout(args),
         }) => {
             if let Err(err) = args.execute_without_runtime(root_override.as_deref()) {
+                print_error(&err, tool_run_json_output);
+                std::process::exit(1);
+            }
+            return;
+        }
+        // `orbit run ship-sweep` iterates the global workspace registry and
+        // must never bootstrap a `.orbit/` in the scheduler's cwd, so it
+        // dispatches before the eager workspace initialization below.
+        Commands::Run(RunCommand {
+            command: RunSubcommand::ShipSweep(args),
+        }) => {
+            if let Err(err) = args.execute_without_runtime() {
                 print_error(&err, tool_run_json_output);
                 std::process::exit(1);
             }

--- a/crates/orbit-core/src/command/pipeline_run.rs
+++ b/crates/orbit-core/src/command/pipeline_run.rs
@@ -49,6 +49,28 @@ pub struct PipelineWaitEntry {
 }
 
 impl OrbitRuntime {
+    /// Submit a `ship` workflow run (the `task_auto_pipeline` job).
+    ///
+    /// Shared entry point for every non-interactive submission surface
+    /// (dashboard HTTP endpoint, `orbit run ship-sweep`). `base_branch`
+    /// falls back to the workspace's `[workflow] base_branch`; an empty
+    /// `task_ids` slice selects auto (backlog-discovery) mode. One-shot:
+    /// returns as soon as the run is persisted and its worker spawned.
+    pub fn submit_ship_run(
+        &self,
+        mode: crate::command::workflow::ShipMode,
+        base_branch: Option<&str>,
+        task_ids: &[String],
+        actor: Option<&str>,
+    ) -> Result<PipelineInvokeResult, OrbitError> {
+        let workflow =
+            crate::command::workflow::find_workflow(crate::command::workflow::SHIP_WORKFLOW_ALIAS)
+                .ok_or_else(|| OrbitError::InvalidInput("unknown workflow 'ship'".to_string()))?;
+        let base = base_branch.unwrap_or_else(|| self.workflow_base_branch());
+        let input = crate::command::workflow::build_ship_input(mode, base, task_ids)?;
+        self.submit_pipeline_run(workflow.job_id, input, None, actor)
+    }
+
     pub fn submit_pipeline_run(
         &self,
         job_name: &str,

--- a/crates/orbit-core/src/command/workflow.rs
+++ b/crates/orbit-core/src/command/workflow.rs
@@ -58,6 +58,84 @@ pub fn find_workflow(name: &str) -> Option<&'static Workflow> {
     WORKFLOWS.iter().find(|w| w.alias == name)
 }
 
+/// Canonical alias of the gated ship workflow (`task_auto_pipeline`).
+pub const SHIP_WORKFLOW_ALIAS: &str = "ship";
+
+/// Pipeline mode for the `ship` workflow: open a PR or apply locally.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ShipMode {
+    Pr,
+    Local,
+}
+
+impl ShipMode {
+    /// The value the `task_auto_pipeline` job expects in its `mode` input.
+    pub fn as_input_value(self) -> &'static str {
+        match self {
+            ShipMode::Pr => "pr",
+            ShipMode::Local => "local",
+        }
+    }
+
+    /// Parse an external (CLI/HTTP) mode string.
+    pub fn parse(value: &str) -> Result<Self, OrbitError> {
+        match value {
+            "pr" => Ok(ShipMode::Pr),
+            "local" => Ok(ShipMode::Local),
+            other => Err(OrbitError::InvalidInput(format!(
+                "unknown ship mode '{other}' (expected 'pr' or 'local')"
+            ))),
+        }
+    }
+}
+
+/// Build the `task_auto_pipeline` input document for a ship run.
+///
+/// An empty `task_ids` slice selects auto mode (the pipeline discovers
+/// backlog tasks itself). Explicit ids are validated for duplicates and
+/// emptiness so every submission surface rejects the same malformed input.
+pub fn build_ship_input(
+    mode: ShipMode,
+    base_branch: &str,
+    task_ids: &[String],
+) -> Result<Value, OrbitError> {
+    if base_branch.trim().is_empty() {
+        return Err(OrbitError::InvalidInput(
+            "ship base branch must not be empty".to_string(),
+        ));
+    }
+    let mut seen = std::collections::HashSet::new();
+    for task_id in task_ids {
+        if task_id.trim().is_empty() {
+            return Err(OrbitError::InvalidInput(
+                "task id in explicit task selection must not be empty".to_string(),
+            ));
+        }
+        if !seen.insert(task_id.as_str()) {
+            return Err(OrbitError::InvalidInput(format!(
+                "duplicate task id '{task_id}' in explicit task selection"
+            )));
+        }
+    }
+
+    let mut map = serde_json::Map::new();
+    map.insert(
+        "mode".to_string(),
+        Value::String(mode.as_input_value().to_string()),
+    );
+    map.insert(
+        "base_branch".to_string(),
+        Value::String(base_branch.to_string()),
+    );
+    if !task_ids.is_empty() {
+        map.insert(
+            "task_ids".to_string(),
+            Value::Array(task_ids.iter().cloned().map(Value::String).collect()),
+        );
+    }
+    Ok(Value::Object(map))
+}
+
 pub struct WorkflowInput {
     pub tasks: Option<String>,
     pub parallelism: Option<u32>,
@@ -199,5 +277,45 @@ mod tests {
         assert!(!workflow.supports_parallelism);
         assert!(find_workflow("ship-auto").is_none());
         assert!(find_workflow("ship-local").is_none());
+    }
+}
+
+#[cfg(test)]
+mod ship_input_tests {
+    use super::*;
+
+    #[test]
+    fn build_ship_input_auto_mode_omits_task_ids() {
+        let input = build_ship_input(ShipMode::Pr, "main", &[]).expect("input builds");
+        assert_eq!(input["mode"], "pr");
+        assert_eq!(input["base_branch"], "main");
+        assert!(input.get("task_ids").is_none());
+    }
+
+    #[test]
+    fn build_ship_input_explicit_tasks_and_local_mode() {
+        let task_ids = vec!["T1".to_string(), "T2".to_string()];
+        let input = build_ship_input(ShipMode::Local, "agent-main", &task_ids).expect("builds");
+        assert_eq!(input["mode"], "local");
+        assert_eq!(input["base_branch"], "agent-main");
+        assert_eq!(input["task_ids"], serde_json::json!(["T1", "T2"]));
+    }
+
+    #[test]
+    fn build_ship_input_rejects_duplicates_blank_ids_and_empty_base() {
+        let dup = vec!["T1".to_string(), "T1".to_string()];
+        assert!(build_ship_input(ShipMode::Pr, "main", &dup).is_err());
+
+        let blank = vec!["  ".to_string()];
+        assert!(build_ship_input(ShipMode::Pr, "main", &blank).is_err());
+
+        assert!(build_ship_input(ShipMode::Pr, "  ", &[]).is_err());
+    }
+
+    #[test]
+    fn ship_mode_parses_external_strings() {
+        assert_eq!(ShipMode::parse("pr").expect("pr"), ShipMode::Pr);
+        assert_eq!(ShipMode::parse("local").expect("local"), ShipMode::Local);
+        assert!(ShipMode::parse("yolo").is_err());
     }
 }

--- a/crates/orbit-core/src/config/raw.rs
+++ b/crates/orbit-core/src/config/raw.rs
@@ -30,6 +30,10 @@ pub(super) struct RawWorkflowConfig {
     /// Repos that keep an `agent-main` buffer branch set this to
     /// `"agent-main"`.
     pub(super) base_branch: Option<String>,
+    /// `workflow.auto_ship` — opt-in for unattended ship dispatch
+    /// (`orbit run ship-sweep` and other schedulers). When absent or
+    /// `false`, sweeps skip this workspace.
+    pub(super) auto_ship: Option<bool>,
     /// Named crew used when a task does not declare `crew` and no CLI
     /// override is provided.
     pub(super) default_crew: Option<String>,

--- a/crates/orbit-core/src/config/runtime.rs
+++ b/crates/orbit-core/src/config/runtime.rs
@@ -44,6 +44,9 @@ pub(crate) struct RuntimeConfig {
     /// from `[workflow] base_branch` in `config.toml`; defaults to `"main"`
     /// when no key is set.
     pub(crate) workflow_base_branch: String,
+    /// Opt-in for unattended ship dispatch (`[workflow] auto_ship` in
+    /// `config.toml`; defaults to `false`).
+    pub(crate) workflow_auto_ship: bool,
     /// Named planner/implementer/reviewer lineups from `[crews.<name>]`.
     pub(crate) crews: BTreeMap<String, Crew>,
     pub(crate) default_crew: Option<String>,
@@ -86,6 +89,7 @@ impl RuntimeConfig {
             graph_editing: DEFAULT_GRAPH_EDITING,
             v2_backend: None,
             workflow_base_branch: DEFAULT_WORKFLOW_BASE_BRANCH.to_string(),
+            workflow_auto_ship: false,
             crews: default_crews(),
             default_crew: Some(DEFAULT_WORKFLOW_CREW.to_string()),
             duel: DuelConfig::default(),
@@ -163,6 +167,11 @@ impl RuntimeConfig {
         reject_stale_agent_role_tables(parsed.agent.as_ref())?;
 
         let workflow_base_branch = workflow_base_branch_from_raw(parsed.workflow.as_ref())?;
+        let workflow_auto_ship = parsed
+            .workflow
+            .as_ref()
+            .and_then(|workflow| workflow.auto_ship)
+            .unwrap_or(false);
         let crews = crews_from_raw(parsed.crews.as_ref())?;
         let default_crew = workflow_default_crew_from_raw(parsed.workflow.as_ref(), &crews)?;
         let duel = duel_from_raw(parsed.duel.as_ref())?;
@@ -191,6 +200,7 @@ impl RuntimeConfig {
             graph_editing,
             v2_backend,
             workflow_base_branch,
+            workflow_auto_ship,
             crews,
             default_crew,
             duel,
@@ -204,6 +214,10 @@ impl RuntimeConfig {
 
     pub(crate) fn workflow_base_branch(&self) -> &str {
         &self.workflow_base_branch
+    }
+
+    pub(crate) fn workflow_auto_ship(&self) -> bool {
+        self.workflow_auto_ship
     }
 
     pub(crate) fn pr_config(&self) -> &PrConfig {

--- a/crates/orbit-core/src/config/tests/runtime.rs
+++ b/crates/orbit-core/src/config/tests/runtime.rs
@@ -385,3 +385,25 @@ fn task_artifact_store_rejects_removed_key() {
     assert!(message.contains("no longer supported"));
     assert!(message.contains("v2"));
 }
+
+#[test]
+fn workflow_auto_ship_defaults_false_and_loads_when_set() {
+    let global = tempdir().expect("global tempdir");
+    let workspace = tempdir().expect("workspace tempdir");
+
+    write_config(workspace.path(), "");
+    let config =
+        RuntimeConfig::load_layered(global.path(), workspace.path()).expect("config loads");
+    assert!(!config.workflow_auto_ship());
+
+    write_config(
+        workspace.path(),
+        r#"
+[workflow]
+auto_ship = true
+"#,
+    );
+    let config =
+        RuntimeConfig::load_layered(global.path(), workspace.path()).expect("config loads");
+    assert!(config.workflow_auto_ship());
+}

--- a/crates/orbit-core/src/context.rs
+++ b/crates/orbit-core/src/context.rs
@@ -180,6 +180,9 @@ pub(crate) struct OrbitRuntimeSettings {
     /// Default base branch for ship/duel-plan workflows
     /// (`[workflow] base_branch` in `config.toml`, default `"main"`).
     workflow_base_branch: String,
+    /// Opt-in for unattended ship dispatch
+    /// (`[workflow] auto_ship` in `config.toml`, default `false`).
+    workflow_auto_ship: bool,
     crews: std::collections::BTreeMap<String, Crew>,
     default_crew: Option<String>,
     duel: DuelConfig,
@@ -197,6 +200,7 @@ impl OrbitRuntimeSettings {
         pr_config: PrConfig,
         v2_backend: Option<String>,
         workflow_base_branch: String,
+        workflow_auto_ship: bool,
         crews: std::collections::BTreeMap<String, Crew>,
         default_crew: Option<String>,
         duel: DuelConfig,
@@ -211,6 +215,7 @@ impl OrbitRuntimeSettings {
             pr_config,
             v2_backend,
             workflow_base_branch,
+            workflow_auto_ship,
             crews,
             default_crew,
             duel,
@@ -227,6 +232,10 @@ impl OrbitRuntimeSettings {
 
     pub(crate) fn workflow_base_branch(&self) -> &str {
         &self.workflow_base_branch
+    }
+
+    pub(crate) fn workflow_auto_ship(&self) -> bool {
+        self.workflow_auto_ship
     }
 
     pub(crate) fn crews(&self) -> &std::collections::BTreeMap<String, Crew> {
@@ -353,6 +362,12 @@ impl OrbitContext {
     /// `"main"` when the key is absent.
     pub(crate) fn workflow_base_branch(&self) -> &str {
         self.runtime.workflow_base_branch()
+    }
+
+    /// Whether this workspace opted into unattended ship dispatch
+    /// (`[workflow] auto_ship` in `config.toml`, default `false`).
+    pub(crate) fn workflow_auto_ship(&self) -> bool {
+        self.runtime.workflow_auto_ship()
     }
 
     pub(crate) fn crews(&self) -> &std::collections::BTreeMap<String, Crew> {

--- a/crates/orbit-core/src/lib.rs
+++ b/crates/orbit-core/src/lib.rs
@@ -61,8 +61,8 @@ pub use command::search::{
 };
 pub use command::task_template::TaskTemplate;
 pub use command::workflow::{
-    WORKFLOWS, Workflow, WorkflowInput, build_workflow_input, build_workflow_input_for,
-    find_workflow, validate_workflow_flags,
+    SHIP_WORKFLOW_ALIAS, ShipMode, WORKFLOWS, Workflow, WorkflowInput, build_ship_input,
+    build_workflow_input, build_workflow_input_for, find_workflow, validate_workflow_flags,
 };
 pub use context::{ActorIdentity, ActorKind, OrbitContext};
 pub use orbit_common::types::{

--- a/crates/orbit-core/src/runtime/builder.rs
+++ b/crates/orbit-core/src/runtime/builder.rs
@@ -129,6 +129,7 @@ pub(crate) fn build_context_from_roots(
     let pr_config = runtime_config.pr_config().clone();
     let v2_backend = runtime_config.v2_backend().map(ToString::to_string);
     let workflow_base_branch = runtime_config.workflow_base_branch().to_string();
+    let workflow_auto_ship = runtime_config.workflow_auto_ship();
     let crews = runtime_config.crews.clone();
     let default_crew = runtime_config.default_crew.clone();
     let duel = runtime_config.duel_config().clone();
@@ -168,6 +169,7 @@ pub(crate) fn build_context_from_roots(
             pr_config,
             v2_backend,
             workflow_base_branch,
+            workflow_auto_ship,
             crews,
             default_crew,
             duel,

--- a/crates/orbit-core/src/runtime/mod.rs
+++ b/crates/orbit-core/src/runtime/mod.rs
@@ -325,6 +325,14 @@ impl OrbitRuntime {
         self.context.workflow_base_branch()
     }
 
+    /// Whether this workspace opted into unattended ship dispatch
+    /// (`[workflow] auto_ship` in the active `config.toml`; defaults to
+    /// `false`). Consulted by `orbit run ship-sweep` and other schedulers
+    /// before dispatching ship runs nobody explicitly asked for.
+    pub fn workflow_auto_ship(&self) -> bool {
+        self.context.workflow_auto_ship()
+    }
+
     /// Returns the configured `[duel] candidates` list (e.g. ["codex", "claude", "gemini", "grok"]).
     /// Used by `orbit run duel-plan --planner-a ...` overrides to validate explicit families.
     pub fn duel_candidate_families(&self) -> Vec<String> {

--- a/crates/orbit-dashboard/src/api/mod.rs
+++ b/crates/orbit-dashboard/src/api/mod.rs
@@ -331,6 +331,7 @@ pub(super) fn router() -> Router<crate::state::DashboardState> {
         )
         .route("/jobs", get(jobs::list_jobs))
         .route("/job-runs", get(jobs::list_job_runs))
+        .route("/workflows/ship", post(runs::ship_workflow_action))
         .route("/runs/:id", get(runs::get_run))
         .route("/runs/:id/cancel", post(runs::cancel_run_action))
         .route("/runs/:id/replay", post(runs::replay_run_action))

--- a/crates/orbit-dashboard/src/api/runs.rs
+++ b/crates/orbit-dashboard/src/api/runs.rs
@@ -23,6 +23,52 @@ const RUN_LOG_PREVIEW_MAX_BYTES: usize = 8192;
 /// Maximum lines included in stdout/stderr previews returned by run-log APIs.
 const RUN_LOG_PREVIEW_MAX_LINES: usize = 120;
 
+#[derive(serde::Deserialize, Default)]
+pub(super) struct ShipBody {
+    /// Explicit task selection; empty selects auto (backlog-discovery) mode.
+    #[serde(default)]
+    task_ids: Vec<String>,
+    /// `"pr"` (default) or `"local"`.
+    #[serde(default)]
+    mode: Option<String>,
+    /// Base branch override; defaults to the workspace's `[workflow] base_branch`.
+    #[serde(default)]
+    base: Option<String>,
+}
+
+/// Submit a `ship` workflow run (`POST /workflows/ship?workspace=<id>`).
+///
+/// One-shot: responds as soon as the run is persisted, with the same
+/// `queued`/`submitted` states the CLI reports. Callers poll
+/// `GET /runs/:id` for progress.
+pub(super) async fn ship_workflow_action(
+    Ws(runtime): Ws,
+    body: Option<Json<ShipBody>>,
+) -> Response {
+    let Json(body) = body.unwrap_or_default();
+    let mode = match orbit_core::ShipMode::parse(body.mode.as_deref().unwrap_or("pr")) {
+        Ok(mode) => mode,
+        Err(e) => return bad_request(e.to_string()),
+    };
+    match runtime.submit_ship_run(
+        mode,
+        body.base.as_deref(),
+        &body.task_ids,
+        Some("dashboard"),
+    ) {
+        Ok(invoke) => Json(json!({
+            "workflow": "ship",
+            "job_id": invoke.job_name,
+            "run_id": invoke.run_id,
+            "state": if invoke.queued { "queued" } else { "submitted" },
+            "submitted_at": invoke.submitted_at,
+        }))
+        .into_response(),
+        Err(orbit_core::OrbitError::InvalidInput(msg)) => bad_request(msg),
+        Err(e) => map_runtime_error(e),
+    }
+}
+
 pub(super) async fn get_run(Ws(runtime): Ws, Path(id): Path<String>) -> Response {
     let id = match validate_id(&id) {
         Ok(id) => id,

--- a/crates/orbit-dashboard/src/api/tests/runs.rs
+++ b/crates/orbit-dashboard/src/api/tests/runs.rs
@@ -596,3 +596,77 @@ fn run_detail_uses_v2_audit_steps_when_step_bundle_is_empty() {
     assert_eq!(steps[0]["state"], "success");
     assert_eq!(steps[0]["duration_ms"], 2_000);
 }
+
+async fn request_ship(runtime: OrbitRuntime, body: Option<Value>) -> Response {
+    let mut builder = Request::builder()
+        .method(Method::POST)
+        .uri("/workflows/ship")
+        .header(header::ORIGIN, "http://localhost:3000");
+    let body = match body {
+        Some(json) => {
+            builder = builder.header(header::CONTENT_TYPE, "application/json");
+            Body::from(json.to_string())
+        }
+        None => Body::empty(),
+    };
+    router()
+        .with_state(crate::state::DashboardState::single(Arc::new(runtime)))
+        .oneshot(builder.body(body).expect("request"))
+        .await
+        .expect("response")
+}
+
+#[tokio::test]
+async fn ship_endpoint_submits_task_auto_pipeline_run() {
+    let runtime = OrbitRuntime::in_memory().expect("build runtime");
+    write_replay_job(&runtime, "task_auto_pipeline");
+
+    let response = request_ship(runtime.clone(), Some(json!({ "mode": "pr" }))).await;
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let payload = body_json(response).await;
+    assert_eq!(payload["workflow"].as_str(), Some("ship"));
+    assert_eq!(payload["job_id"].as_str(), Some("task_auto_pipeline"));
+    assert!(matches!(
+        payload["state"].as_str(),
+        Some("queued" | "submitted")
+    ));
+    let run_id = payload["run_id"].as_str().expect("run id");
+    let stored = runtime.show_job_run(run_id).expect("stored ship run");
+    assert_eq!(stored.job_id, "task_auto_pipeline");
+}
+
+#[tokio::test]
+async fn ship_endpoint_rejects_unknown_mode() {
+    let runtime = OrbitRuntime::in_memory().expect("build runtime");
+
+    let response = request_ship(runtime, Some(json!({ "mode": "yolo" }))).await;
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    let payload = body_json(response).await;
+    assert!(
+        payload["error"]
+            .as_str()
+            .is_some_and(|message| message.contains("unknown ship mode"))
+    );
+}
+
+#[tokio::test]
+async fn ship_endpoint_rejects_duplicate_task_ids() {
+    let runtime = OrbitRuntime::in_memory().expect("build runtime");
+    write_replay_job(&runtime, "task_auto_pipeline");
+
+    let response = request_ship(
+        runtime,
+        Some(json!({ "task_ids": ["T12345678-123456", "T12345678-123456"] })),
+    )
+    .await;
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    let payload = body_json(response).await;
+    assert!(
+        payload["error"]
+            .as_str()
+            .is_some_and(|message| message.contains("duplicate task id"))
+    );
+}

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,0 +1,46 @@
+# Deploy units
+
+Host-level scheduling artifacts for orbit. Nothing here is required to *use*
+orbit — these are optional units for machines that run unattended orbit work.
+
+## orbit-ship-sweep (systemd user timer)
+
+Periodically runs `orbit run ship-sweep`, which walks every workspace in
+`~/.orbit/workspaces.json` and submits a `ship` run (PR mode) where **all** of
+the following hold:
+
+1. the workspace opted in with `[workflow] auto_ship = true` in its
+   `.orbit/config.toml` (default is off — the sweep never ships a workspace
+   nobody blessed);
+2. it has at least one `backlog` task whose dependencies are satisfied;
+3. no `task_auto_pipeline` run is already pending/running there.
+
+Everything else is reported as skipped. Per-workspace failures are isolated;
+the unit exits non-zero only if a workspace errored, so failures surface in
+`systemctl --user list-units --failed`.
+
+### Install (per host, e.g. dk-server-1)
+
+```sh
+mkdir -p ~/.config/systemd/user
+cp deploy/orbit-ship-sweep.{service,timer} ~/.config/systemd/user/
+systemctl --user daemon-reload
+systemctl --user enable --now orbit-ship-sweep.timer
+```
+
+### Verify
+
+```sh
+orbit run ship-sweep --dry-run --json   # what would ship right now, no submits
+systemctl --user list-timers orbit-ship-sweep.timer
+journalctl --user -u orbit-ship-sweep -n 50
+```
+
+### Opt a workspace in
+
+```toml
+# <workspace>/.orbit/config.toml
+[workflow]
+base_branch = "agent-main"   # repo's ship base, if not "main"
+auto_ship = true
+```

--- a/deploy/orbit-ship-sweep.service
+++ b/deploy/orbit-ship-sweep.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=orbit ship-sweep (dispatch ship runs in opted-in workspaces with ready backlog)
+
+[Service]
+Type=oneshot
+# The sweep is cwd-independent (it resolves workspaces from ~/.orbit/workspaces.json
+# and never bootstraps a .orbit/ where it runs), but pin a stable directory anyway.
+WorkingDirectory=%h
+# systemd user units get a minimal PATH that omits ~/.orbit/bin (orbit) and the
+# tools the dispatched pipelines shell out to (git, gh, claude).
+Environment=PATH=%h/.local/bin:%h/.orbit/bin:/usr/local/bin:/usr/bin:/bin
+ExecStart=%h/.orbit/bin/orbit run ship-sweep --json
+SyslogIdentifier=orbit-ship-sweep

--- a/deploy/orbit-ship-sweep.timer
+++ b/deploy/orbit-ship-sweep.timer
@@ -1,0 +1,11 @@
+[Unit]
+Description=Run orbit ship-sweep every 20 minutes
+
+[Timer]
+OnBootSec=5min
+OnUnitActiveSec=20min
+# Smear start times so the sweep never lines up exactly with other timers.
+RandomizedDelaySec=60
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
## Summary

Adds two non-interactive ship submission surfaces sharing one orbit-core code path, gated by a new per-workspace opt-in:

- **`[workflow] auto_ship`** config key (default `false`) — the safety rail for unattended dispatch; threaded to `OrbitRuntime::workflow_auto_ship()`.
- **`OrbitRuntime::submit_ship_run()` + `build_ship_input()`** in orbit-core — shared submission entry point; CLI `orbit run ship` refactored onto the same builder so CLI/HTTP/sweep validate identically.
- **`orbit run ship-sweep [--dry-run] [--json]`** — walks `~/.orbit/workspaces.json` and dispatches a PR-mode ship run in each workspace that (1) opted in, (2) has dependency-ready backlog tasks, (3) has no `task_auto_pipeline` run in flight. Dispatches before eager runtime init (never bootstraps `.orbit/` in the scheduler's cwd); per-workspace failures isolated; exits non-zero only if a workspace errored.
- **`POST /workflows/ship`** on the dashboard (workspace-scoped via the existing `Ws` extractor) — one-shot submit returning `{run_id, state: queued|submitted}`; poll existing `GET /runs/:id`. Consumed by the bridge MCP gateway (companion change in the bridge repo: `workflow_ship` / `workflow_run_status` tools).
- **`deploy/`** — systemd user service + 20-min timer for host-level scheduling (dk-server-1), with install/verify/opt-in docs.

Note: ship remains deliberately absent from orbit's agent-facing MCP allowlist; the HTTP endpoint is the explicit, token-gated escalation path via bridge.

## Testing

- `cargo test -p orbit-core -p orbit-cli -p orbit-dashboard` — all 16 suites green (new: 3 dashboard endpoint tests, 4 ship-input builder tests, 1 auto_ship config test)
- `make ci-fast` passes
- Live smoke: `orbit run ship-sweep --dry-run --json` against the real local registry — correct skip reasons (`workspace_inactive`, `auto_ship_disabled`), stale-config workspaces isolated as per-workspace errors with non-zero exit

Task: ORB-00411

🤖 Generated with [Claude Code](https://claude.com/claude-code)