### PR TITLE
Production-readiness hardening sweep (ORB-00412–00418)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,7 @@ env:
   CARGO_TERM_COLOR: always
   NEXTEST_VERSION: 0.9.136
   NEXTEST_LINUX_SHA256: a098eed56f2dd88c7fdca1e554a6b99fa1ffbd2a7a1c41b865700112981f6f52
+  CARGO_DENY_VERSION: 0.19.9
 
 jobs:
   ci:
@@ -48,6 +49,14 @@ jobs:
           tar zxf "$archive" -C "$cargo_bin"
           rm -f "$archive"
           cargo nextest --version
+
+      - name: Install cargo-deny
+        run: |
+          set -euo pipefail
+          if ! cargo deny --version 2>/dev/null | grep -q "${CARGO_DENY_VERSION}"; then
+            cargo install cargo-deny --locked --version "${CARGO_DENY_VERSION}"
+          fi
+          cargo deny --version
 
       - name: Run CI guardrails
         run: ./scripts/ci-guardrails.sh

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,6 +33,41 @@ Rust workspace crates live under `crates/` (for example `crates/orbit-cli`).
 - Prefer removing legacy paths over carrying compatibility code when the product is still pre-adoption.
 - If you discover friction or recurring issues, fix them in scope or create a concrete follow-up task.
 
+## Supply-chain (cargo-deny)
+
+Dependencies are gated by [`cargo-deny`](https://embarkstudios.github.io/cargo-deny/)
+on every PR (via `scripts/ci-guardrails.sh`) and locally with `make audit`. The
+policy lives in [`deny.toml`](deny.toml): it denies crates with an open RUSTSEC
+advisory or a yanked version, and restricts licenses to a reviewed allow-list.
+
+Run it before landing a dependency change:
+
+```bash
+cargo install cargo-deny --locked   # one-time
+make audit                          # == cargo deny check
+```
+
+**Adding a license.** If a new dependency introduces a license not in the
+`[licenses].allow` list, `cargo deny check` fails. Add the SPDX identifier to
+the list in `deny.toml` **only** if it is a permissive/public-domain-equivalent
+license, with a one-line comment naming the crate(s) and (for weak-copyleft
+licenses such as MPL-2.0) a short justification. Copyleft licenses that would
+impose obligations on Orbit's own sources must not be added — replace the
+dependency instead.
+
+**Advisory exceptions.** Only when there is no safe upgrade available may an
+advisory be time-boxed in `[advisories].ignore`. Each entry must be an object
+carrying:
+
+- `id` — the `RUSTSEC-YYYY-NNNN` identifier, and
+- `reason` — why it is safe in Orbit's usage (why the vulnerable path is
+  unreachable or the impact is bounded) **and** a `Re-review YYYY-MM-DD` date
+  (default: ~6 months out).
+
+Re-review ignored advisories on or before their date and drop the entry once an
+upstream fix lands. Never ignore an advisory that has an available patched
+release — bump the dependency instead.
+
 ## Orbit State
 
 Orbit keeps operational state under `.orbit/`. Review those changes carefully before committing.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2212,6 +2212,7 @@ dependencies = [
  "sha2",
  "tempfile",
  "thiserror",
+ "toml",
  "tracing",
  "tracing-appender",
  "tracing-subscriber",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2379,6 +2379,7 @@ dependencies = [
  "chrono",
  "orbit-common",
  "serde",
+ "tempfile",
 ]
 
 [[package]]

--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ help:
 	@echo "  make fmt-check    Check formatting"
 	@echo "  make clippy       Lint with clippy (deny warnings)"
 	@echo "  make bench        Run graph build benchmark (ARGS=... optional)"
-	@echo "  make audit        Cargo audit (security)"
+	@echo "  make audit        Supply-chain audit (cargo-deny: advisories + licenses)"
 	@echo "  make tree         Print dependency tree"
 	@echo "  make ci           Full CI pass (clippy + tests + doc + guardrails; also runs on PRs)"
 	@echo "  make ci-fast      Pre-handoff gate for agents (fmt-check + guardrail scripts; no compile)"
@@ -98,9 +98,11 @@ clippy:
 bench:
 	$(CARGO) run -p orbit-knowledge --example graph_build --release -- $(ARGS)
 
-# Security audit (requires cargo-audit)
+# Supply-chain audit: advisories + license allow-list via cargo-deny (deny.toml).
+# Canonical command; CI runs the same check via scripts/ci-guardrails.sh.
 audit:
-	$(CARGO) audit || echo "Install cargo-audit via: cargo install cargo-audit"
+	@command -v cargo-deny >/dev/null 2>&1 || { echo "Install cargo-deny via: cargo install cargo-deny --locked"; exit 1; }
+	$(CARGO) deny check
 
 # Dependency tree inspection
 tree:

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -62,11 +62,15 @@ plus global `denyRead` / `denyModify` rules, evaluated by `orbit-policy`.
 filesystem location, not the requested path. Before matching, the requested
 path is resolved with `Path::canonicalize` (following symlinks); for a
 not-yet-existing target (a write/create) the nearest existing ancestor is
-canonicalized and the remaining components are rejoined. A symlink inside an
-allowed subtree that points into a denied subtree is therefore **denied**, and
-a resolved path that escapes the workspace root is denied outright. This
-resolution lives in `orbit-policy` (`PolicyEngine::check_resolved`) so the
-guarantee holds regardless of the caller.
+canonicalized and the remaining components are rejoined. **Dangling** symlinks
+are followed too (with an `ELOOP`-style traversal cap): an `O_CREAT` open
+through a dangling link creates the link's *target*, so evaluation happens at
+that target, not at the link path. A symlink inside an allowed subtree that
+points into a denied subtree is therefore **denied**, and a resolved path that
+escapes the workspace root is denied outright. This resolution lives in
+`orbit-policy` (`PolicyEngine::check_resolved` / `resolve_symlinks`) and is
+shared by the tools-layer workspace-boundary check, so the guarantee holds
+regardless of the caller.
 
 **Known limitation (TOCTOU).** There is an inherent time-of-check to
 time-of-use gap between the policy decision and the actual filesystem

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -45,3 +45,32 @@ Out of scope:
 - Issues that require an attacker who already has local code execution as the user running Orbit, or write access to the workspace, unless they cross a documented trust boundary.
 - Social-engineering or phishing of project maintainers.
 - Findings against forks or third-party redistributions of Orbit.
+
+## Filesystem Policy Enforcement
+
+Agent filesystem access is scoped by an `fsProfile` (`read` / `modify` globs)
+plus global `denyRead` / `denyModify` rules, evaluated by `orbit-policy`.
+
+**Enforcement layers differ by platform:**
+
+| Platform | Layers |
+| --- | --- |
+| **macOS** | Policy evaluation **and** the `orbit-exec` seatbelt (`sandbox-exec`) profile — two independent layers. |
+| **Linux** | Policy evaluation **only** — there is no OS-level sandbox. The policy check is the sole line of defense, so it must be correct on its own. |
+
+**Symlink resolution.** Policy rules are matched against the *real*
+filesystem location, not the requested path. Before matching, the requested
+path is resolved with `Path::canonicalize` (following symlinks); for a
+not-yet-existing target (a write/create) the nearest existing ancestor is
+canonicalized and the remaining components are rejoined. A symlink inside an
+allowed subtree that points into a denied subtree is therefore **denied**, and
+a resolved path that escapes the workspace root is denied outright. This
+resolution lives in `orbit-policy` (`PolicyEngine::check_resolved`) so the
+guarantee holds regardless of the caller.
+
+**Known limitation (TOCTOU).** There is an inherent time-of-check to
+time-of-use gap between the policy decision and the actual filesystem
+operation: an attacker who can race the filesystem (swap a resolved path for a
+symlink between check and use) is an OS-level concern outside what the policy
+layer can close. On macOS the seatbelt provides a second enforcement point; on
+Linux, treat a workspace an attacker can concurrently mutate as untrusted.

--- a/crates/orbit-common/Cargo.toml
+++ b/crates/orbit-common/Cargo.toml
@@ -23,6 +23,7 @@ serde_json.workspace = true
 serde_yaml.workspace = true
 sha2.workspace = true
 thiserror.workspace = true
+toml.workspace = true
 tracing.workspace = true
 tracing-appender.workspace = true
 tracing-subscriber.workspace = true

--- a/crates/orbit-common/src/utility/log_rotation.rs
+++ b/crates/orbit-common/src/utility/log_rotation.rs
@@ -211,10 +211,11 @@ pub(crate) fn prune_archives(
         archives.push((entry.path(), mtime, meta.len()));
     }
 
-    // Age-based pruning.
-    if let Some(cutoff) =
-        SystemTime::now().checked_sub(Duration::from_secs(config.retention_days * SECONDS_PER_DAY))
-    {
+    // Age-based pruning. Saturate the multiply so an absurd (but validated
+    // nonzero) retention_days cannot overflow into a tiny cutoff.
+    if let Some(cutoff) = SystemTime::now().checked_sub(Duration::from_secs(
+        config.retention_days.saturating_mul(SECONDS_PER_DAY),
+    )) {
         archives.retain(|(path, mtime, _size)| {
             if *mtime < cutoff {
                 let _ = std::fs::remove_file(path);

--- a/crates/orbit-common/src/utility/log_rotation.rs
+++ b/crates/orbit-common/src/utility/log_rotation.rs
@@ -1,0 +1,243 @@
+//! Rotation + retention for the global JSONL tracing feed
+//! (`~/.orbit/state/logs/orbit.jsonl`). [ORB-00415]
+//!
+//! On an always-on host the JSONL feed would otherwise grow unbounded until the
+//! disk fills — which then cascades into SQLite write failures across every
+//! store. This module bounds it with an opportunistic, rename-based roll plus a
+//! retention sweep, both run once at subscriber init (cheap, no daemon).
+//!
+//! The active file stays at the fixed path `orbit.jsonl` — readers
+//! (`orbit log tail`, the dashboard) open that exact path, so we do NOT adopt
+//! `tracing-appender`'s dated active filenames. Instead, when the active file
+//! exceeds the per-file budget it is renamed to a dated archive
+//! (`orbit.jsonl.<UTC-timestamp>`) and the subscriber reopens a fresh active
+//! file. Retention then prunes archives older than the age budget or beyond the
+//! total-size budget (delete-only; no compression, to avoid pulling a
+//! compression codec into `orbit-common`).
+//!
+//! Concurrency: rolls are rare (size-triggered) and rename is atomic. A
+//! long-running process that keeps its fd open after another process rolls the
+//! file continues writing valid JSONL into the renamed inode (Unix) — no
+//! corruption, though those lines land in the archive rather than the new
+//! active file. That trade-off is acceptable given the criterion is
+//! corruption-freedom, not real-time reader completeness.
+
+use std::path::{Path, PathBuf};
+use std::time::{Duration, SystemTime};
+
+use chrono::Utc;
+
+use crate::types::OrbitError;
+
+const DEFAULT_RETENTION_DAYS: u64 = 7;
+const DEFAULT_MAX_TOTAL_MB: u64 = 500;
+const DEFAULT_MAX_FILE_MB: u64 = 100;
+const BYTES_PER_MB: u64 = 1024 * 1024;
+const SECONDS_PER_DAY: u64 = 86_400;
+
+/// Resolved rotation/retention budgets for the global JSONL feed. Overridable
+/// via the `[runtime]` section of `~/.orbit/config.toml`
+/// (`log_retention_days`, `log_max_total_mb`, `log_max_file_mb`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct LogRotationConfig {
+    /// Delete archives whose mtime is older than this many days.
+    pub retention_days: u64,
+    /// Total byte budget across archive files; oldest are deleted first when
+    /// exceeded.
+    pub max_total_bytes: u64,
+    /// Roll the active file once it grows beyond this many bytes.
+    pub max_file_bytes: u64,
+}
+
+impl Default for LogRotationConfig {
+    fn default() -> Self {
+        Self {
+            retention_days: DEFAULT_RETENTION_DAYS,
+            max_total_bytes: DEFAULT_MAX_TOTAL_MB * BYTES_PER_MB,
+            max_file_bytes: DEFAULT_MAX_FILE_MB * BYTES_PER_MB,
+        }
+    }
+}
+
+impl LogRotationConfig {
+    /// Build from raw `[runtime]` values (megabytes / days), validating each.
+    /// A `None` field falls back to the conservative default. Returns a clear
+    /// [`OrbitError::InvalidInput`] for out-of-range values so the config
+    /// loader can reject a malformed config at load time.
+    pub fn from_parts(
+        retention_days: Option<u64>,
+        max_total_mb: Option<u64>,
+        max_file_mb: Option<u64>,
+    ) -> Result<Self, OrbitError> {
+        let retention_days = retention_days.unwrap_or(DEFAULT_RETENTION_DAYS);
+        let max_total_mb = max_total_mb.unwrap_or(DEFAULT_MAX_TOTAL_MB);
+        let max_file_mb = max_file_mb.unwrap_or(DEFAULT_MAX_FILE_MB);
+
+        if retention_days == 0 {
+            return Err(OrbitError::InvalidInput(
+                "[runtime] log_retention_days must be >= 1".to_string(),
+            ));
+        }
+        if max_total_mb == 0 {
+            return Err(OrbitError::InvalidInput(
+                "[runtime] log_max_total_mb must be >= 1".to_string(),
+            ));
+        }
+        if max_file_mb == 0 {
+            return Err(OrbitError::InvalidInput(
+                "[runtime] log_max_file_mb must be >= 1".to_string(),
+            ));
+        }
+        if max_file_mb > max_total_mb {
+            return Err(OrbitError::InvalidInput(format!(
+                "[runtime] log_max_file_mb ({max_file_mb}) must be <= log_max_total_mb ({max_total_mb})"
+            )));
+        }
+
+        Ok(Self {
+            retention_days,
+            max_total_bytes: max_total_mb * BYTES_PER_MB,
+            max_file_bytes: max_file_mb * BYTES_PER_MB,
+        })
+    }
+
+    /// Read rotation config from the global `~/.orbit/config.toml` `[runtime]`
+    /// section, falling back to [`LogRotationConfig::default`] on any error
+    /// (missing file, parse error, or invalid values). Lenient by design: the
+    /// subscriber initializes before argument parsing and config load, so it
+    /// must never fail here. `orbit-core`'s config loader validates the same
+    /// keys strictly and surfaces a clear load-time error.
+    pub fn load_global_best_effort() -> Self {
+        load_global().unwrap_or_default()
+    }
+}
+
+fn load_global() -> Option<LogRotationConfig> {
+    let home = std::env::var_os("HOME")
+        .or_else(|| std::env::var_os("USERPROFILE"))
+        .filter(|value| !value.is_empty())?;
+    let path = Path::new(&home).join(".orbit").join("config.toml");
+    let raw = std::fs::read_to_string(&path).ok()?;
+    let value: toml::Value = toml::from_str(&raw).ok()?;
+    let runtime = value.get("runtime")?;
+    let read_u64 = |key: &str| {
+        runtime
+            .get(key)
+            .and_then(toml::Value::as_integer)
+            .and_then(|integer| u64::try_from(integer).ok())
+    };
+    LogRotationConfig::from_parts(
+        read_u64("log_retention_days"),
+        read_u64("log_max_total_mb"),
+        read_u64("log_max_file_mb"),
+    )
+    .ok()
+}
+
+/// Opportunistically roll the active log if oversized, then prune archives by
+/// age and total-size budget. Best-effort: logs a warning on failure but never
+/// panics or fails the caller. Intended to run once at subscriber init.
+pub fn rotate_and_prune(active_path: &Path, config: &LogRotationConfig) {
+    if let Err(error) = maybe_roll(active_path, config) {
+        tracing::warn!(
+            target: "orbit.logging.rotation",
+            path = %active_path.display(),
+            error = %error,
+            "failed to roll oversized JSONL log",
+        );
+    }
+    if let Err(error) = prune_archives(active_path, config) {
+        tracing::warn!(
+            target: "orbit.logging.rotation",
+            error = %error,
+            "failed to prune JSONL log archives",
+        );
+    }
+}
+
+/// Rename the active file to a dated archive when it exceeds the per-file
+/// budget. Returns `Ok(())` (no-op) when the file is absent or within budget.
+pub(crate) fn maybe_roll(active_path: &Path, config: &LogRotationConfig) -> std::io::Result<()> {
+    let size = match std::fs::metadata(active_path) {
+        Ok(meta) => meta.len(),
+        Err(_) => return Ok(()), // no active file yet
+    };
+    if size <= config.max_file_bytes {
+        return Ok(());
+    }
+    std::fs::rename(active_path, archive_path(active_path))
+}
+
+fn archive_path(active_path: &Path) -> PathBuf {
+    let stamp = Utc::now().format("%Y%m%dT%H%M%S%3fZ");
+    let name = active_path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("orbit.jsonl");
+    active_path.with_file_name(format!("{name}.{stamp}"))
+}
+
+/// Delete archives older than the age budget, then, if the surviving archive
+/// set still exceeds the total-size budget, delete oldest-first until it fits.
+pub(crate) fn prune_archives(
+    active_path: &Path,
+    config: &LogRotationConfig,
+) -> std::io::Result<()> {
+    let Some(dir) = active_path.parent() else {
+        return Ok(());
+    };
+    let active_name = active_path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("orbit.jsonl");
+    // Archives are `<active_name>.<stamp>`; never touch the active file itself.
+    let prefix = format!("{active_name}.");
+
+    let mut archives: Vec<(PathBuf, SystemTime, u64)> = Vec::new();
+    for entry in std::fs::read_dir(dir)? {
+        let entry = entry?;
+        let file_name = entry.file_name();
+        let Some(name) = file_name.to_str() else {
+            continue;
+        };
+        if !name.starts_with(&prefix) {
+            continue;
+        }
+        let meta = entry.metadata()?;
+        if !meta.is_file() {
+            continue;
+        }
+        let mtime = meta.modified().unwrap_or(SystemTime::UNIX_EPOCH);
+        archives.push((entry.path(), mtime, meta.len()));
+    }
+
+    // Age-based pruning.
+    if let Some(cutoff) =
+        SystemTime::now().checked_sub(Duration::from_secs(config.retention_days * SECONDS_PER_DAY))
+    {
+        archives.retain(|(path, mtime, _size)| {
+            if *mtime < cutoff {
+                let _ = std::fs::remove_file(path);
+                false
+            } else {
+                true
+            }
+        });
+    }
+
+    // Size-based pruning: delete oldest archives until under the total budget.
+    let mut total: u64 = archives.iter().map(|(_, _, size)| *size).sum();
+    if total > config.max_total_bytes {
+        archives.sort_by_key(|(_, mtime, _)| *mtime); // oldest first
+        for (path, _, size) in &archives {
+            if total <= config.max_total_bytes {
+                break;
+            }
+            if std::fs::remove_file(path).is_ok() {
+                total = total.saturating_sub(*size);
+            }
+        }
+    }
+
+    Ok(())
+}

--- a/crates/orbit-common/src/utility/logging.rs
+++ b/crates/orbit-common/src/utility/logging.rs
@@ -359,7 +359,18 @@ pub fn init_default_subscriber(default_filter: &str) {
         .fmt_fields(RedactingFields::default());
     let log_layer = global_jsonl_log_path()
         .map_err(|err| err.to_string())
-        .and_then(|path| jsonl_layer_at_path(&path).map_err(|err| err.to_string()));
+        .and_then(|path| {
+            // [ORB-00415] Opportunistically roll the active feed if it has grown
+            // past the per-file budget and prune old archives, before reopening
+            // the (fixed-path) active file for appending. Config is read
+            // leniently from the global config here; orbit-core validates the
+            // same keys strictly at config load.
+            super::log_rotation::rotate_and_prune(
+                &path,
+                &super::log_rotation::LogRotationConfig::load_global_best_effort(),
+            );
+            jsonl_layer_at_path(&path).map_err(|err| err.to_string())
+        });
 
     match log_layer {
         Ok((file_layer, guard)) => {

--- a/crates/orbit-common/src/utility/mod.rs
+++ b/crates/orbit-common/src/utility/mod.rs
@@ -3,6 +3,7 @@ pub mod fs;
 pub mod git;
 pub mod glob;
 pub mod learning_session;
+pub mod log_rotation;
 pub mod logging;
 pub mod output_capture;
 pub mod path;

--- a/crates/orbit-common/src/utility/redaction.rs
+++ b/crates/orbit-common/src/utility/redaction.rs
@@ -140,6 +140,54 @@ pub fn redact_sensitive_env_error(error: OrbitError) -> OrbitError {
     }
 }
 
+/// Scrub an [`OrbitError`]'s string payloads with the full [`redact_all`]
+/// pipeline (live env values **plus** the HTTP header / bearer / provider-key
+/// patterns), not just env values like [`redact_sensitive_env_error`].
+/// [ORB-00417] Apply at the error persistence/log boundary so an error message
+/// embedding a `Bearer <token>` or `sk-*` key in a URL is never written out
+/// un-redacted. Idempotent: `redact_all` placeholders never re-match the secret
+/// patterns.
+pub fn redact_all_error(error: OrbitError) -> OrbitError {
+    match error {
+        OrbitError::PolicyDenied(m) => OrbitError::PolicyDenied(redact_all(&m)),
+        OrbitError::NotFound { kind, id } => OrbitError::NotFound {
+            kind,
+            id: redact_all(&id),
+        },
+        OrbitError::TaskApprovalRequired(m) => OrbitError::TaskApprovalRequired(redact_all(&m)),
+        OrbitError::AdrInvalidTransition(m) => OrbitError::AdrInvalidTransition(redact_all(&m)),
+        OrbitError::CompanionNotInstalled(m) => OrbitError::CompanionNotInstalled(redact_all(&m)),
+        OrbitError::InvalidInput(m) => OrbitError::InvalidInput(redact_all(&m)),
+        OrbitError::SensitiveInput { field, reason } => OrbitError::SensitiveInput {
+            field: redact_all(&field),
+            reason: redact_all(&reason),
+        },
+        OrbitError::InvalidInputDiagnostic {
+            message,
+            did_you_mean,
+        } => OrbitError::InvalidInputDiagnostic {
+            message: redact_all(&message),
+            did_you_mean: did_you_mean
+                .into_iter()
+                .map(|suggestion| redact_all(&suggestion))
+                .collect(),
+        },
+        OrbitError::SkillValidation(m) => OrbitError::SkillValidation(redact_all(&m)),
+        OrbitError::JobValidation(m) => OrbitError::JobValidation(redact_all(&m)),
+        OrbitError::AgentProtocolViolation(m) => OrbitError::AgentProtocolViolation(redact_all(&m)),
+        OrbitError::UnsupportedAgentProvider(m) => {
+            OrbitError::UnsupportedAgentProvider(redact_all(&m))
+        }
+        OrbitError::Execution(m) => OrbitError::Execution(redact_all(&m)),
+        OrbitError::Store(m) => OrbitError::Store(redact_all(&m)),
+        OrbitError::TaskStatusTransition(m) => OrbitError::TaskStatusTransition(redact_all(&m)),
+        OrbitError::JobRunStateTransition(m) => OrbitError::JobRunStateTransition(redact_all(&m)),
+        OrbitError::Io(m) => OrbitError::Io(redact_all(&m)),
+        OrbitError::WorkspaceError(m) => OrbitError::WorkspaceError(redact_all(&m)),
+        OrbitError::Migration(m) => OrbitError::Migration(redact_all(&m)),
+    }
+}
+
 fn home_dir_string() -> Option<String> {
     std::env::var("HOME")
         .ok()

--- a/crates/orbit-common/src/utility/tests/log_rotation.rs
+++ b/crates/orbit-common/src/utility/tests/log_rotation.rs
@@ -160,11 +160,16 @@ fn concurrent_writers_do_not_corrupt_jsonl_lines() {
                     // Re-open per line (O_APPEND) to mirror separate processes
                     // appending concurrently; short lines stay under PIPE_BUF.
                     let mut file = append_private_file(&path).expect("append open");
-                    let line = serde_json::to_string(
+                    let mut line = serde_json::to_string(
                         &serde_json::json!({"writer": writer_id, "seq": seq}),
                     )
                     .expect("serialize");
-                    writeln!(file, "{line}").expect("write line");
+                    // One write() per line, newline included — mirrors the fmt
+                    // layer, which write_all()s the whole formatted event.
+                    // (`writeln!` issues a second syscall for the `\n`, which
+                    // can interleave between concurrent appenders.)
+                    line.push('\n');
+                    file.write_all(line.as_bytes()).expect("write line");
                 }
             })
         })

--- a/crates/orbit-common/src/utility/tests/log_rotation.rs
+++ b/crates/orbit-common/src/utility/tests/log_rotation.rs
@@ -1,0 +1,212 @@
+//! [ORB-00415] Rotation + retention tests for the global JSONL tracing feed.
+
+use std::io::Write;
+use std::time::{Duration, SystemTime};
+
+use tempfile::TempDir;
+
+use crate::utility::fs::append_private_file;
+use crate::utility::log_rotation::{
+    LogRotationConfig, maybe_roll, prune_archives, rotate_and_prune,
+};
+
+fn archive_names(dir: &std::path::Path) -> Vec<String> {
+    std::fs::read_dir(dir)
+        .expect("read_dir")
+        .filter_map(Result::ok)
+        .map(|entry| entry.file_name().to_string_lossy().into_owned())
+        .filter(|name| name.starts_with("orbit.jsonl."))
+        .collect()
+}
+
+fn backdate(path: &std::path::Path, ago: Duration) {
+    let when = SystemTime::now().checked_sub(ago).expect("valid time");
+    std::fs::File::options()
+        .write(true)
+        .open(path)
+        .expect("open for mtime")
+        .set_modified(when)
+        .expect("set mtime");
+}
+
+#[test]
+fn oversized_active_file_rolls_to_dated_archive_preserving_old_content() {
+    let dir = TempDir::new().expect("tempdir");
+    let active = dir.path().join("orbit.jsonl");
+    let old_content = "OLD-LINE\n".repeat(20); // ~180 bytes
+    std::fs::write(&active, &old_content).expect("write active");
+
+    let config = LogRotationConfig {
+        retention_days: 7,
+        max_total_bytes: 10_000_000,
+        max_file_bytes: 50,
+    };
+    maybe_roll(&active, &config).expect("roll");
+
+    assert!(!active.exists(), "active file should have been rolled away");
+    let archives = archive_names(dir.path());
+    assert_eq!(
+        archives.len(),
+        1,
+        "expected one dated archive, got {archives:?}"
+    );
+    let archived = std::fs::read_to_string(dir.path().join(&archives[0])).expect("read archive");
+    assert_eq!(
+        archived, old_content,
+        "old content must be preserved in the archive"
+    );
+
+    // The subscriber reopening the fixed active path creates a fresh file at
+    // the boundary.
+    std::fs::write(&active, "NEW-LINE\n").expect("reopen active");
+    assert!(active.exists());
+    assert_eq!(
+        std::fs::read_to_string(&active).expect("read active"),
+        "NEW-LINE\n"
+    );
+}
+
+#[test]
+fn within_budget_active_file_is_not_rolled() {
+    let dir = TempDir::new().expect("tempdir");
+    let active = dir.path().join("orbit.jsonl");
+    std::fs::write(&active, "small\n").expect("write active");
+
+    let config = LogRotationConfig {
+        retention_days: 7,
+        max_total_bytes: 10_000_000,
+        max_file_bytes: 1_000,
+    };
+    maybe_roll(&active, &config).expect("roll");
+
+    assert!(active.exists(), "within-budget file must not be rolled");
+    assert!(
+        archive_names(dir.path()).is_empty(),
+        "no archive should be created"
+    );
+}
+
+#[test]
+fn retention_deletes_archives_older_than_age_budget() {
+    let dir = TempDir::new().expect("tempdir");
+    let active = dir.path().join("orbit.jsonl");
+    let old = dir.path().join("orbit.jsonl.OLD");
+    let recent = dir.path().join("orbit.jsonl.RECENT");
+    std::fs::write(&old, "old").expect("write old");
+    std::fs::write(&recent, "recent").expect("write recent");
+    backdate(&old, Duration::from_secs(10 * 86_400)); // 10 days old
+
+    let config = LogRotationConfig {
+        retention_days: 7,
+        max_total_bytes: 10_000_000,
+        max_file_bytes: 10_000_000,
+    };
+    prune_archives(&active, &config).expect("prune");
+
+    assert!(
+        !old.exists(),
+        "archive older than the age budget must be deleted"
+    );
+    assert!(recent.exists(), "recent archive must be kept");
+}
+
+#[test]
+fn retention_deletes_oldest_archives_beyond_total_size_budget() {
+    let dir = TempDir::new().expect("tempdir");
+    let active = dir.path().join("orbit.jsonl");
+    let a = dir.path().join("orbit.jsonl.A");
+    let b = dir.path().join("orbit.jsonl.B");
+    let c = dir.path().join("orbit.jsonl.C");
+    for (path, secs_ago) in [(&a, 30u64), (&b, 20), (&c, 10)] {
+        std::fs::write(path, "x".repeat(100)).expect("write archive");
+        backdate(path, Duration::from_secs(secs_ago));
+    }
+
+    // 300 bytes total, budget 150: delete oldest (A) -> 200, then B -> 100.
+    let config = LogRotationConfig {
+        retention_days: 3_650,
+        max_total_bytes: 150,
+        max_file_bytes: 10_000_000,
+    };
+    prune_archives(&active, &config).expect("prune");
+
+    assert!(!a.exists(), "oldest archive should be deleted first");
+    assert!(!b.exists(), "second-oldest deleted to fit the budget");
+    assert!(c.exists(), "newest archive kept within budget");
+}
+
+#[test]
+fn rotate_and_prune_is_a_noop_when_nothing_to_do() {
+    let dir = TempDir::new().expect("tempdir");
+    let active = dir.path().join("orbit.jsonl");
+    std::fs::write(&active, "line\n").expect("write");
+    // Generous budgets -> no roll, no prune, no panic even with no archives.
+    rotate_and_prune(&active, &LogRotationConfig::default());
+    assert!(active.exists());
+    assert!(archive_names(dir.path()).is_empty());
+}
+
+#[test]
+fn concurrent_writers_do_not_corrupt_jsonl_lines() {
+    let dir = TempDir::new().expect("tempdir");
+    let path = dir.path().join("orbit.jsonl");
+    const PER_WRITER: usize = 300;
+
+    let handles: Vec<_> = (0..2)
+        .map(|writer_id| {
+            let path = path.clone();
+            std::thread::spawn(move || {
+                for seq in 0..PER_WRITER {
+                    // Re-open per line (O_APPEND) to mirror separate processes
+                    // appending concurrently; short lines stay under PIPE_BUF.
+                    let mut file = append_private_file(&path).expect("append open");
+                    let line = serde_json::to_string(
+                        &serde_json::json!({"writer": writer_id, "seq": seq}),
+                    )
+                    .expect("serialize");
+                    writeln!(file, "{line}").expect("write line");
+                }
+            })
+        })
+        .collect();
+    for handle in handles {
+        handle.join().expect("join writer");
+    }
+
+    let content = std::fs::read_to_string(&path).expect("read log");
+    let mut count = 0;
+    for line in content.lines() {
+        if line.trim().is_empty() {
+            continue;
+        }
+        serde_json::from_str::<serde_json::Value>(line)
+            .unwrap_or_else(|error| panic!("corrupt interleaved line `{line}`: {error}"));
+        count += 1;
+    }
+    assert_eq!(
+        count,
+        2 * PER_WRITER,
+        "every line from both writers must parse"
+    );
+}
+
+#[test]
+fn from_parts_validates_and_converts_units() {
+    assert_eq!(
+        LogRotationConfig::from_parts(None, None, None).expect("defaults"),
+        LogRotationConfig::default()
+    );
+
+    let config = LogRotationConfig::from_parts(Some(3), Some(200), Some(50)).expect("valid");
+    assert_eq!(config.retention_days, 3);
+    assert_eq!(config.max_total_bytes, 200 * 1024 * 1024);
+    assert_eq!(config.max_file_bytes, 50 * 1024 * 1024);
+
+    assert!(LogRotationConfig::from_parts(Some(0), None, None).is_err());
+    assert!(LogRotationConfig::from_parts(None, Some(0), None).is_err());
+    assert!(LogRotationConfig::from_parts(None, None, Some(0)).is_err());
+    assert!(
+        LogRotationConfig::from_parts(None, Some(10), Some(50)).is_err(),
+        "a per-file budget larger than the total budget must be rejected"
+    );
+}

--- a/crates/orbit-common/src/utility/tests/mod.rs
+++ b/crates/orbit-common/src/utility/tests/mod.rs
@@ -1,5 +1,6 @@
 mod blob_store;
 mod glob;
+mod log_rotation;
 mod logging;
 #[cfg(unix)]
 mod process_identity;

--- a/crates/orbit-common/src/utility/tests/redaction.rs
+++ b/crates/orbit-common/src/utility/tests/redaction.rs
@@ -181,3 +181,51 @@ fn identity_backfill_does_not_weaken_credential_scrubbing() {
         );
     }
 }
+
+// [ORB-00417] redact_all_error: pattern + env redaction over OrbitError payloads.
+
+#[test]
+fn redact_all_error_scrubs_bearer_token_in_message() {
+    use super::super::redaction::redact_all_error;
+    use crate::types::OrbitError;
+
+    let raw = OrbitError::Execution(
+        "request to https://api.example.test failed \
+         (Authorization: Bearer abc123def456ghi789SECRETTOKEN)"
+            .to_string(),
+    );
+    let redacted = redact_all_error(raw);
+    let message = redacted.to_string();
+
+    assert!(
+        !message.contains("abc123def456ghi789SECRETTOKEN"),
+        "bearer token must be redacted from the error message: {message}"
+    );
+    assert!(
+        message.contains("[REDACTED_AUTH]"),
+        "a redaction placeholder should replace the token: {message}"
+    );
+    assert!(
+        matches!(redacted, OrbitError::Execution(_)),
+        "the error variant must be preserved"
+    );
+}
+
+#[test]
+fn redact_all_error_is_idempotent() {
+    use super::super::redaction::redact_all_error;
+    use crate::types::OrbitError;
+
+    let OrbitError::Store(once) = redact_all_error(OrbitError::Store(
+        "token=Bearer abc123def456ghi789SECRETTOKEN".to_string(),
+    )) else {
+        panic!("variant must be preserved");
+    };
+    let OrbitError::Store(twice) = redact_all_error(OrbitError::Store(once.clone())) else {
+        panic!("variant must be preserved");
+    };
+    assert_eq!(
+        once, twice,
+        "redaction must be idempotent so read-time re-application is safe"
+    );
+}

--- a/crates/orbit-core/assets/config/default-config.toml
+++ b/crates/orbit-core/assets/config/default-config.toml
@@ -35,3 +35,15 @@ editing = false
 # `agent-main` is the dev integration branch where task PRs land — set
 # `base_branch = "agent-main"` for the same layout in your own repo.
 base_branch = "main"
+
+[runtime]
+# `backend` selects the v2 `agent_loop` execution backend: "cli" | "http" | "auto".
+# backend = "cli"
+#
+# Rotation + retention for the global JSONL log (~/.orbit/state/logs/orbit.jsonl).
+# [ORB-00415] Applied opportunistically at process start. All optional; the
+# conservative defaults below are used when a key is omitted. Invalid values
+# (0, or log_max_file_mb > log_max_total_mb) are rejected at config load.
+# log_retention_days = 7    # delete archives older than N days (>= 1)
+# log_max_total_mb   = 500  # total MiB budget across archives; oldest pruned first (>= 1)
+# log_max_file_mb    = 100  # roll the active log once it exceeds N MiB (>= 1, <= log_max_total_mb)

--- a/crates/orbit-core/src/command/task/add.rs
+++ b/crates/orbit-core/src/command/task/add.rs
@@ -2,6 +2,7 @@ use orbit_common::types::{
     OrbitError, OrbitEvent, Task, TaskStatus, TaskType, normalize_task_dependencies,
     normalize_task_tags, prune_missing_context_files, validate_task_dependencies,
 };
+use orbit_common::utility::redaction::redact_all;
 use orbit_store::TaskCreateParams as StoreTaskCreateParams;
 
 use crate::OrbitRuntime;
@@ -22,10 +23,21 @@ impl OrbitRuntime {
 
     pub fn add_task_with_identity(
         &self,
-        params: TaskAddParams,
+        mut params: TaskAddParams,
         agent: Option<String>,
         model: Option<String>,
     ) -> Result<Task, OrbitError> {
+        // [ORB-00417] Redact secrets at the single task-creation choke point
+        // (shared by the dashboard POST, CLI `task add`, and the MCP task tool)
+        // so a pasted key never lands in the task registry or the audit trail.
+        // `redact_all` is idempotent, so read-time redaction still composes.
+        params.title = redact_all(&params.title);
+        params.description = redact_all(&params.description);
+        params.plan = redact_all(&params.plan);
+        for criterion in params.acceptance_criteria.iter_mut() {
+            *criterion = redact_all(criterion);
+        }
+
         let (canonical_agent, canonical_model) =
             self.try_canonical_agent_model_identity(agent.as_deref(), model.as_deref())?;
         let actor = self.actor().clone();

--- a/crates/orbit-core/src/command/task/add.rs
+++ b/crates/orbit-core/src/command/task/add.rs
@@ -37,6 +37,7 @@ impl OrbitRuntime {
         for criterion in params.acceptance_criteria.iter_mut() {
             *criterion = redact_all(criterion);
         }
+        params.comment = params.comment.map(|comment| redact_all(&comment));
 
         let (canonical_agent, canonical_model) =
             self.try_canonical_agent_model_identity(agent.as_deref(), model.as_deref())?;

--- a/crates/orbit-core/src/command/task/tests/add.rs
+++ b/crates/orbit-core/src/command/task/tests/add.rs
@@ -148,8 +148,9 @@ fn add_task_warnings_mixed_valid_and_claude_over_only() {
 
 #[test]
 fn task_add_redacts_secrets_in_stored_fields() {
-    // [ORB-00417] A pasted key in title/description/plan/acceptance_criteria
-    // must be redacted at write time so it never lands in the task registry.
+    // [ORB-00417] A pasted key in title/description/plan/acceptance_criteria/
+    // comment must be redacted at write time so it never lands in the task
+    // registry.
     let (_root, runtime) = test_runtime();
 
     let sk_key = "sk-ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789abcd";
@@ -160,6 +161,7 @@ fn task_add_redacts_secrets_in_stored_fields() {
             description: format!("Header pasted: Authorization: Bearer {bearer_token}"),
             acceptance_criteria: vec![format!("no leak of {sk_key}")],
             plan: format!("call the API with {sk_key}"),
+            comment: Some(format!("context: reproduce with {sk_key}")),
             workspace_path: Some(".".to_string()),
             ..Default::default()
         })
@@ -198,4 +200,15 @@ fn task_add_redacts_secrets_in_stored_fields() {
     // ...and so is the persisted record read back from the store.
     let reloaded = runtime.get_task(&task.id).expect("get task");
     check(&reloaded, "reloaded");
+
+    // The creation comment is persisted separately — it must be redacted too.
+    let comments = runtime.get_task_comments(&task.id).expect("get comments");
+    assert!(
+        !comments.iter().any(|c| c.message.contains(sk_key)),
+        "creation comment leaked key: {comments:?}"
+    );
+    assert!(
+        comments.iter().any(|c| c.message.contains("[REDACTED")),
+        "creation comment should carry a redaction placeholder: {comments:?}"
+    );
 }

--- a/crates/orbit-core/src/command/task/tests/add.rs
+++ b/crates/orbit-core/src/command/task/tests/add.rs
@@ -145,3 +145,57 @@ fn add_task_warnings_mixed_valid_and_claude_over_only() {
     assert!(!w[0].contains("without context_files"));
     assert!(!w[0].contains("src/foo.rs"));
 }
+
+#[test]
+fn task_add_redacts_secrets_in_stored_fields() {
+    // [ORB-00417] A pasted key in title/description/plan/acceptance_criteria
+    // must be redacted at write time so it never lands in the task registry.
+    let (_root, runtime) = test_runtime();
+
+    let sk_key = "sk-ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789abcd";
+    let bearer_token = "abc123def456ghi789SECRETTOKEN";
+    let task = runtime
+        .add_task(TaskAddParams {
+            title: format!("Fix auth using {sk_key}"),
+            description: format!("Header pasted: Authorization: Bearer {bearer_token}"),
+            acceptance_criteria: vec![format!("no leak of {sk_key}")],
+            plan: format!("call the API with {sk_key}"),
+            workspace_path: Some(".".to_string()),
+            ..Default::default()
+        })
+        .expect("task add succeeds");
+
+    let check = |task: &orbit_common::types::Task, label: &str| {
+        assert!(
+            !task.title.contains(sk_key),
+            "{label}: title leaked key: {}",
+            task.title
+        );
+        assert!(
+            !task.description.contains(bearer_token),
+            "{label}: description leaked bearer token: {}",
+            task.description
+        );
+        assert!(
+            !task.plan.contains(sk_key),
+            "{label}: plan leaked key: {}",
+            task.plan
+        );
+        assert!(
+            !task.acceptance_criteria.iter().any(|c| c.contains(sk_key)),
+            "{label}: acceptance criteria leaked key: {:?}",
+            task.acceptance_criteria
+        );
+        assert!(
+            task.title.contains("[REDACTED"),
+            "{label}: title should carry a redaction placeholder: {}",
+            task.title
+        );
+    };
+
+    // The returned (just-created) record is redacted...
+    check(&task, "returned");
+    // ...and so is the persisted record read back from the store.
+    let reloaded = runtime.get_task(&task.id).expect("get task");
+    check(&reloaded, "reloaded");
+}

--- a/crates/orbit-core/src/config/raw.rs
+++ b/crates/orbit-core/src/config/raw.rs
@@ -94,6 +94,15 @@ pub(super) struct RawRuntimeSection {
     /// backend (§3.1). One of `http`, `cli`, `auto`; validated by
     /// `RuntimeConfig::load_layered`.
     pub(super) backend: Option<String>,
+    /// `runtime.log_retention_days` — delete JSONL log archives older than this
+    /// many days. [ORB-00415] Validated by `RuntimeConfig::load_layered`.
+    pub(super) log_retention_days: Option<u64>,
+    /// `runtime.log_max_total_mb` — total size budget (MiB) across JSONL log
+    /// archives; oldest are pruned first when exceeded.
+    pub(super) log_max_total_mb: Option<u64>,
+    /// `runtime.log_max_file_mb` — roll the active JSONL log once it grows past
+    /// this many MiB.
+    pub(super) log_max_file_mb: Option<u64>,
 }
 
 #[derive(Debug, Clone, Deserialize)]

--- a/crates/orbit-core/src/config/runtime.rs
+++ b/crates/orbit-core/src/config/runtime.rs
@@ -5,6 +5,7 @@ use std::path::Path;
 use orbit_common::types::{
     Crew, CrewRoleAssignment, OrbitError, activity_job::Backend, all_agent_families, resolve_crew,
 };
+use orbit_common::utility::log_rotation::LogRotationConfig;
 use orbit_common::utility::redaction::redact_home_dir;
 use orbit_engine::PrConfig;
 
@@ -168,6 +169,11 @@ impl RuntimeConfig {
 
         validate_task_artifact_store_from_raw(parsed.task.as_ref())?;
         let v2_backend = runtime_backend_from_raw(parsed.runtime.as_ref())?;
+        // [ORB-00415] Strict gate for the JSONL log rotation/retention knobs so
+        // a malformed `[runtime]` value fails `orbit` startup with a clear
+        // error. The subscriber itself reads these keys leniently at init
+        // (before config load); this validates the same values.
+        validate_log_rotation_from_raw(parsed.runtime.as_ref())?;
 
         reject_stale_agent_role_tables(parsed.agent.as_ref())?;
 
@@ -515,6 +521,19 @@ fn runtime_backend_from_raw(raw: Option<&RawRuntimeSection>) -> Result<Option<St
         )));
     };
     Ok(Some(backend.as_str().to_string()))
+}
+
+fn validate_log_rotation_from_raw(raw: Option<&RawRuntimeSection>) -> Result<(), OrbitError> {
+    let (retention_days, max_total_mb, max_file_mb) = match raw {
+        Some(section) => (
+            section.log_retention_days,
+            section.log_max_total_mb,
+            section.log_max_file_mb,
+        ),
+        None => (None, None, None),
+    };
+    LogRotationConfig::from_parts(retention_days, max_total_mb, max_file_mb)?;
+    Ok(())
 }
 
 fn validate_task_artifact_store_from_raw(raw: Option<&RawTaskSection>) -> Result<(), OrbitError> {

--- a/crates/orbit-core/src/config/tests/runtime.rs
+++ b/crates/orbit-core/src/config/tests/runtime.rs
@@ -407,3 +407,42 @@ auto_ship = true
         RuntimeConfig::load_layered(global.path(), workspace.path()).expect("config loads");
     assert!(config.workflow_auto_ship());
 }
+
+#[test]
+fn runtime_log_rotation_rejects_invalid_values() {
+    // [ORB-00415] Malformed rotation knobs must fail at config load with a
+    // clear, key-naming error.
+    let global = tempdir().expect("global tempdir");
+    let workspace = tempdir().expect("workspace tempdir");
+
+    write_config(workspace.path(), "[runtime]\nlog_retention_days = 0\n");
+    let error = RuntimeConfig::load_layered(global.path(), workspace.path())
+        .expect_err("zero retention must fail config load");
+    assert!(
+        error.to_string().contains("log_retention_days"),
+        "message: {error}"
+    );
+
+    write_config(
+        workspace.path(),
+        "[runtime]\nlog_max_total_mb = 10\nlog_max_file_mb = 50\n",
+    );
+    let error = RuntimeConfig::load_layered(global.path(), workspace.path())
+        .expect_err("per-file budget above total must fail config load");
+    assert!(
+        error.to_string().contains("log_max_file_mb"),
+        "message: {error}"
+    );
+}
+
+#[test]
+fn runtime_log_rotation_accepts_valid_values() {
+    let global = tempdir().expect("global tempdir");
+    let workspace = tempdir().expect("workspace tempdir");
+    write_config(
+        workspace.path(),
+        "[runtime]\nlog_retention_days = 14\nlog_max_total_mb = 200\nlog_max_file_mb = 20\n",
+    );
+    RuntimeConfig::load_layered(global.path(), workspace.path())
+        .expect("valid log rotation config should load");
+}

--- a/crates/orbit-core/src/lib.rs
+++ b/crates/orbit-core/src/lib.rs
@@ -77,8 +77,8 @@ pub use orbit_common::types::{
 };
 pub use orbit_common::types::{LearningComment, NotFoundKind, OrbitError};
 pub use orbit_common::utility::redaction::{
-    redact_sensitive_env_error, redact_sensitive_env_json, redact_sensitive_env_option,
-    redact_sensitive_env_text,
+    redact_all_error, redact_sensitive_env_error, redact_sensitive_env_json,
+    redact_sensitive_env_option, redact_sensitive_env_text,
 };
 pub use orbit_store::learning_layout::LearningLayoutMigrationReport;
 pub use orbit_store::{

--- a/crates/orbit-core/src/runtime/pipeline.rs
+++ b/crates/orbit-core/src/runtime/pipeline.rs
@@ -3,7 +3,7 @@ use std::process::Command;
 use std::sync::Arc;
 
 use orbit_common::types::{OrbitEvent, Role, activity_job::tool_allowed};
-use orbit_common::utility::redaction::{redact_sensitive_env_error, redact_sensitive_env_json};
+use orbit_common::utility::redaction::{redact_all_error, redact_sensitive_env_json};
 use orbit_tools::ToolContext;
 use serde_json::Value;
 
@@ -85,7 +85,7 @@ impl OrbitRuntime {
         let output = match self
             .tool_registry()
             .execute(name, &tool_context, input)
-            .map_err(redact_sensitive_env_error)
+            .map_err(redact_all_error)
         {
             Ok(output) => output,
             Err(OrbitError::PolicyDenied(reason)) => {

--- a/crates/orbit-engine/src/activity_job/audit_writer.rs
+++ b/crates/orbit-engine/src/activity_job/audit_writer.rs
@@ -1,10 +1,12 @@
 use std::collections::HashMap;
 use std::path::Path;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 use std::thread::ThreadId;
 
 use chrono::Utc;
 use orbit_agent::loop_engine::audit::{AuditSink, LoopAuditEvent};
+use orbit_common::types::OrbitError;
 use orbit_common::types::activity_job::{
     AUDIT_ENVELOPE_SCHEMA_VERSION, V2AuditEnvelope, V2AuditEvent, V2AuditEventKind,
 };
@@ -13,6 +15,21 @@ use thiserror::Error;
 use orbit_store::Store;
 
 use super::sqlite_sink::V2SqliteSink;
+
+/// Persistence sink for §7 audit envelopes. Abstracted behind a trait
+/// ([ORB-00414]) so the writer can be exercised with an injected failing sink
+/// and so envelope persistence failures can be surfaced rather than swallowed.
+pub trait EnvelopeSink: Send + Sync {
+    /// Persist one envelope event. An `Err` is recorded by the writer as a
+    /// non-fatal audit failure rather than crashing the run.
+    fn write_envelope(&self, event: &V2AuditEvent) -> Result<(), OrbitError>;
+}
+
+impl EnvelopeSink for V2SqliteSink {
+    fn write_envelope(&self, event: &V2AuditEvent) -> Result<(), OrbitError> {
+        V2SqliteSink::write_envelope(self, event)
+    }
+}
 
 /// Writes §7 v2 audit envelope events. Nests the existing loop-engine events
 /// underneath an Activity event via `parent_event_id` so the whole tree
@@ -27,10 +44,13 @@ pub struct V2AuditWriter {
     agent_identity: String,
     workspace_path: Option<String>,
     inner: Arc<dyn AuditSink>,
-    envelope_sink: Option<Arc<V2SqliteSink>>,
+    envelope_sink: Option<Arc<dyn EnvelopeSink>>,
     events: Mutex<Vec<V2AuditEvent>>,
     event_counter: Mutex<u64>,
     parent_stacks: Mutex<HashMap<ThreadId, Vec<String>>>,
+    /// [ORB-00414] Count of audit-write failures observed this run. Non-fatal
+    /// to the run, but recorded so consumers know the trail is incomplete.
+    audit_failures: AtomicU64,
 }
 
 /// Restores the calling thread's previous parent stack on drop.
@@ -61,12 +81,13 @@ impl V2AuditWriter {
             events: Mutex::new(Vec::new()),
             event_counter: Mutex::new(0),
             parent_stacks: Mutex::new(HashMap::new()),
+            audit_failures: AtomicU64::new(0),
         }
     }
 
     /// Attach a SQLite sink for §7 envelope events. When set, every emitted
     /// envelope event is persisted alongside the in-memory snapshot.
-    pub fn with_envelope_sink(mut self, sink: Arc<V2SqliteSink>) -> Self {
+    pub fn with_envelope_sink(mut self, sink: Arc<dyn EnvelopeSink>) -> Self {
         self.envelope_sink = Some(sink);
         self
     }
@@ -144,17 +165,75 @@ impl V2AuditWriter {
             workspace_path: self.workspace_path.clone(),
         };
         let event = V2AuditEvent { envelope, kind };
-        if let Some(sink) = &self.envelope_sink {
-            // SQLite persistence failures should not crash the run. Emitting
-            // the event to the in-memory snapshot is the load-bearing path;
-            // the run-level result owns the user-visible failure state.
-            let _ = sink.write_envelope(&event);
+        if let Some(sink) = &self.envelope_sink
+            && let Err(error) = sink.write_envelope(&event)
+        {
+            // [ORB-00414] SQLite persistence failures should not crash the run,
+            // but must be observable: record the failure (counter + tracing
+            // error) instead of swallowing it. Emitting the event to the
+            // in-memory snapshot below is still the load-bearing path.
+            self.note_audit_failure(event.envelope.event_type.as_str(), &error);
         }
         self.events
             .lock()
             .map_err(|_| WriteError::Poisoned)?
             .push(event);
         Ok(event_id)
+    }
+
+    /// [ORB-00414] Record a non-fatal audit-write failure: bump the per-run
+    /// failure counter and emit a `tracing::error!` naming the run and event
+    /// kind so a degraded audit trail is observable to log/JSONL consumers.
+    pub(crate) fn note_audit_failure(&self, event_kind: &str, error: &dyn std::fmt::Display) {
+        self.audit_failures.fetch_add(1, Ordering::Relaxed);
+        tracing::error!(
+            target: "orbit.engine.audit",
+            run_id = %self.run_id,
+            event_kind,
+            error = %error,
+            "audit write failed; run continuing with degraded audit trail",
+        );
+    }
+
+    /// Number of audit-write failures observed this run.
+    pub fn audit_failure_count(&self) -> u64 {
+        self.audit_failures.load(Ordering::Relaxed)
+    }
+
+    /// True when at least one audit write failed — the trail is incomplete.
+    pub fn degraded_audit(&self) -> bool {
+        self.audit_failure_count() > 0
+    }
+
+    /// [ORB-00414] Emit an envelope event, recording (not discarding) a write
+    /// failure. Non-fatal: returns the event_id on success, `None` on failure.
+    /// Used at emission sites whose event id is not load-bearing for parent
+    /// nesting.
+    pub(crate) fn emit_lossy(&self, kind: V2AuditEventKind) -> Option<String> {
+        let event_kind = kind.event_type();
+        match self.emit(kind) {
+            Ok(event_id) => Some(event_id),
+            Err(error) => {
+                self.note_audit_failure(event_kind, &error);
+                None
+            }
+        }
+    }
+
+    /// [ORB-00414] Push a parent context, recording a failure instead of
+    /// discarding it. Non-fatal.
+    pub(crate) fn push_parent_lossy(&self, event_id: String) {
+        if let Err(error) = self.push_parent(event_id) {
+            self.note_audit_failure("push_parent", &error);
+        }
+    }
+
+    /// [ORB-00414] Pop the most recent parent context, recording a failure
+    /// instead of discarding it. Non-fatal.
+    pub(crate) fn pop_parent_lossy(&self) {
+        if let Err(error) = self.pop_parent() {
+            self.note_audit_failure("pop_parent", &error);
+        }
     }
 
     /// Push a parent context so subsequent events nest beneath it.

--- a/crates/orbit-engine/src/activity_job/cli_runner/orchestrator.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/orchestrator.rs
@@ -45,7 +45,7 @@ pub fn run_cli_backend(
 
     // §6 allowlist-advisory event — emitted once per invocation before the
     // subprocess starts so a reviewer can see the enforcement gap at a glance.
-    let _ = audit.emit(V2AuditEventKind::ToolAllowlistHarnessDelegated {
+    audit.emit_lossy(V2AuditEventKind::ToolAllowlistHarnessDelegated {
         provider: provider.clone(),
         tools: spec.tools.clone(),
     });
@@ -139,7 +139,7 @@ pub fn run_cli_backend(
     let stdin_blob_ref = audit.write_blob(&invocation.stdin);
 
     let model_redacted = agent.model_name().map(|m| redaction.apply_str(m));
-    let _ = audit.emit(V2AuditEventKind::CliInvocationStarted {
+    audit.emit_lossy(V2AuditEventKind::CliInvocationStarted {
         provider: provider.clone(),
         argv_redacted: argv_redacted.clone(),
         stdin_blob_ref: Some(stdin_blob_ref.clone()),
@@ -190,7 +190,7 @@ pub fn run_cli_backend(
     let stdout_blob_ref = audit.write_blob(&stdout);
     let stderr_blob_ref = audit.write_blob(&stderr);
 
-    let _ = audit.emit(V2AuditEventKind::CliInvocationFinished {
+    audit.emit_lossy(V2AuditEventKind::CliInvocationFinished {
         provider: provider.clone(),
         exit_code,
         duration_ms: duration.as_millis() as u64,

--- a/crates/orbit-engine/src/activity_job/cli_runner/tests/orchestrator.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/tests/orchestrator.rs
@@ -823,3 +823,59 @@ fn mixed_crew_drives_exact_models_to_planner_and_implementer() {
         "implementer --model must be exact gpt-5.5, not family"
     );
 }
+
+#[test]
+fn run_cli_backend_redacts_token_shaped_argv_in_audit() {
+    // [ORB-00417] A token-shaped provider-CLI flag value must be redacted in
+    // the persisted run record / audit event, not recorded verbatim.
+    let temp = tempdir().expect("tempdir");
+    let script = temp.path().join("codex");
+    write_executable(&script, "#!/bin/sh\ncat > /dev/null\nprintf 'ok\\n'\n");
+
+    let sink = Arc::new(RecordingSink::default());
+    let sink_for_writer: Arc<dyn AuditSink> = sink;
+    let audit = Arc::new(V2AuditWriter::new(
+        "job-argv-redaction",
+        "codex:gpt-5.5",
+        sink_for_writer,
+    ));
+    let audit_for_assert = Arc::clone(&audit);
+
+    let mut host = TestHost::with_command(script.display().to_string());
+    host.executor_args = vec![
+        "--api-key".to_string(),
+        "sk-secretargvtoken1234567890abcdef".to_string(),
+    ];
+    let spec = test_agent_loop_spec(Duration::from_secs(5));
+
+    let outcome = run_cli_backend(
+        &host,
+        &spec,
+        "job-argv-redaction",
+        audit,
+        &serde_json::json!({"prompt": "hi"}),
+        None,
+    )
+    .expect("run succeeds");
+    assert!(outcome.success);
+
+    let events = audit_for_assert.events_snapshot().expect("audit snapshot");
+    let argv = events
+        .iter()
+        .find_map(|event| match &event.kind {
+            V2AuditEventKind::CliInvocationStarted { argv_redacted, .. } => {
+                Some(argv_redacted.clone())
+            }
+            _ => None,
+        })
+        .expect("a CliInvocationStarted audit event should be present");
+    let joined = argv.join(" ");
+    assert!(
+        !joined.contains("sk-secretargvtoken1234567890abcdef"),
+        "argv leaked the token: {joined}"
+    );
+    assert!(
+        joined.contains("[REDACTED"),
+        "argv should carry a redaction placeholder: {joined}"
+    );
+}

--- a/crates/orbit-engine/src/activity_job/dispatcher.rs
+++ b/crates/orbit-engine/src/activity_job/dispatcher.rs
@@ -317,7 +317,7 @@ fn dispatch_v2_activity_inner(
             },
         )
         .map_err(|err| DispatchError::AuditFailed(format!("{err:?}")))?;
-    let _ = input.audit.push_parent(activity_event_id);
+    input.audit.push_parent_lossy(activity_event_id);
 
     let result = match input.spec {
         ActivityV2Spec::AgentLoop(spec) => match input.host {
@@ -364,13 +364,13 @@ fn dispatch_v2_activity_inner(
         },
     };
 
-    let _ = input.audit.pop_parent();
+    input.audit.pop_parent_lossy();
     let outcome_str = match &result {
         Ok(o) if o.success => "success",
         Ok(_) => "failed",
         Err(_) => "error",
     };
-    let _ = input.audit.emit(
+    input.audit.emit_lossy(
         orbit_common::types::activity_job::V2AuditEventKind::ActivityFinished {
             activity_name: input.activity_name.to_string(),
             outcome: outcome_str.to_string(),

--- a/crates/orbit-engine/src/activity_job/job_executor/audit.rs
+++ b/crates/orbit-engine/src/activity_job/job_executor/audit.rs
@@ -28,6 +28,23 @@ pub(super) fn emit_job_event(
     audit.emit(kind)
 }
 
+/// [ORB-00414] Non-fatal variant of [`emit_job_event`]: on an audit-write
+/// failure it records the failure through the writer's per-run counter +
+/// `tracing::error!` rather than discarding it with `let _ =`. Used at the
+/// job-lifecycle emission sites whose returned event id is not load-bearing;
+/// `StepStarted` (whose id parents nested events) keeps using the fatal
+/// [`emit_job_event`] directly.
+pub(super) fn emit_job_event_lossy(
+    audit: &V2AuditWriter,
+    task_id: Option<&str>,
+    kind: V2AuditEventKind,
+) {
+    let event_kind = kind.event_type();
+    if let Err(error) = emit_job_event(audit, task_id, kind) {
+        audit.note_audit_failure(event_kind, &error);
+    }
+}
+
 /// Project a job-lifecycle `V2AuditEventKind` onto the unified tracing feed
 /// using the per-variant target/level rules documented in T20260427-27.
 ///

--- a/crates/orbit-engine/src/activity_job/job_executor/fan_out.rs
+++ b/crates/orbit-engine/src/activity_job/job_executor/fan_out.rs
@@ -13,7 +13,7 @@ pub(super) fn run_fan_out(
     let items = render_items_expression(&block.items, &tctx, "fan_out.items")?;
     let worker_count = items.len() as u32;
 
-    let _ = emit_job_event(
+    emit_job_event_lossy(
         &ctx.audit,
         ctx.task_id(),
         V2AuditEventKind::FanoutDispatched {
@@ -23,7 +23,7 @@ pub(super) fn run_fan_out(
     );
 
     if items.is_empty() {
-        let _ = emit_job_event(
+        emit_job_event_lossy(
             &ctx.audit,
             ctx.task_id(),
             V2AuditEventKind::FaninJoined {
@@ -80,7 +80,7 @@ pub(super) fn run_fan_out(
                 // below and is no longer accessible afterwards.
                 let worker_task_id =
                     super::super::cli_runner::task_id_from_input(&base_input).map(str::to_string);
-                let _ = emit_job_event(
+                emit_job_event_lossy(
                     &audit,
                     worker_task_id.as_deref(),
                     V2AuditEventKind::WorkerState {
@@ -106,7 +106,7 @@ pub(super) fn run_fan_out(
                     Ok(_) => "failed",
                     Err(_) => "failed",
                 };
-                let _ = emit_job_event(
+                emit_job_event_lossy(
                     &audit,
                     worker_task_id.as_deref(),
                     V2AuditEventKind::WorkerState {
@@ -152,7 +152,7 @@ pub(super) fn run_fan_out(
         }
     }
 
-    let _ = emit_job_event(
+    emit_job_event_lossy(
         &ctx.audit,
         ctx.task_id(),
         V2AuditEventKind::FaninJoined {

--- a/crates/orbit-engine/src/activity_job/job_executor/loop_block.rs
+++ b/crates/orbit-engine/src/activity_job/job_executor/loop_block.rs
@@ -32,7 +32,7 @@ pub(super) fn run_loop(
     for iter in 1..=planned_iterations {
         let iteration_index = iter - 1;
         last_iter = iter;
-        let _ = emit_job_event(
+        emit_job_event_lossy(
             &ctx.audit,
             ctx.task_id(),
             V2AuditEventKind::LoopIterationStart {
@@ -76,7 +76,7 @@ pub(super) fn run_loop(
             false
         };
 
-        let _ = emit_job_event(
+        emit_job_event_lossy(
             &ctx.audit,
             ctx.task_id(),
             V2AuditEventKind::LoopIterationEnd {
@@ -93,7 +93,7 @@ pub(super) fn run_loop(
     }
 
     if !broke && block.break_when.is_some() {
-        let _ = emit_job_event(
+        emit_job_event_lossy(
             &ctx.audit,
             ctx.task_id(),
             V2AuditEventKind::LoopDidNotConverge {

--- a/crates/orbit-engine/src/activity_job/job_executor/mod.rs
+++ b/crates/orbit-engine/src/activity_job/job_executor/mod.rs
@@ -83,6 +83,12 @@ pub struct JobOutcome {
     pub success: bool,
     pub pipeline: Value,
     pub message: Option<String>,
+    /// [ORB-00414] Number of audit-write failures observed during the run.
+    /// Non-zero means the audit trail is incomplete (see `degraded_audit`).
+    pub audit_failures: u64,
+    /// [ORB-00414] True when any audit write failed — retry/recovery/debugging
+    /// consumers should treat the trail as incomplete.
+    pub degraded_audit: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -160,5 +166,7 @@ pub fn execute_job(
         success: overall_ok,
         pipeline,
         message: (!overall_ok).then_some(overall_message).flatten(),
+        audit_failures: audit.audit_failure_count(),
+        degraded_audit: audit.degraded_audit(),
     })
 }

--- a/crates/orbit-engine/src/activity_job/job_executor/parallel.rs
+++ b/crates/orbit-engine/src/activity_job/job_executor/parallel.rs
@@ -81,7 +81,7 @@ pub(super) fn run_parallel(
         JoinMode::Any => "any",
         JoinMode::Quorum { .. } => "quorum",
     };
-    let _ = emit_job_event(
+    emit_job_event_lossy(
         &ctx.audit,
         ctx.task_id(),
         V2AuditEventKind::StepJoin {

--- a/crates/orbit-engine/src/activity_job/job_executor/recovery.rs
+++ b/crates/orbit-engine/src/activity_job/job_executor/recovery.rs
@@ -67,17 +67,22 @@ pub(super) fn attempt_recovery_activity(
 
     let recovery_succeeded = match dispatch {
         Ok(dispatch) if dispatch.success => {
+            // [ORB-00414] Best-effort dispatch-invocation persistence (a DB
+            // record, not an audit-envelope write); a failure here is
+            // intentionally non-fatal and does not affect recovery outcome. The
+            // audit trail of the recovery attempt is emitted separately below.
             let _ = persist_dispatch_invocation(ctx, &recovery.name, &input, &dispatch);
             true
         }
         Ok(dispatch) => {
+            // [ORB-00414] See above: non-audit DB persistence, non-fatal.
             let _ = persist_dispatch_invocation(ctx, &recovery.name, &input, &dispatch);
             false
         }
         Err(_) => false,
     };
 
-    let _ = emit_job_event(
+    emit_job_event_lossy(
         &ctx.audit,
         ctx.task_id(),
         V2AuditEventKind::StepRecoveryAttempted {

--- a/crates/orbit-engine/src/activity_job/job_executor/step.rs
+++ b/crates/orbit-engine/src/activity_job/job_executor/step.rs
@@ -7,7 +7,7 @@ pub(super) fn run_step(step: &JobV2Step, ctx: &ExecCtx<'_>) -> Result<StepOutcom
         let matched = evaluate_bool_expr(expr, &tctx)
             .map_err(|err| DispatchError::JobExecution(format!("when expr: {err}")))?;
         if !matched {
-            let _ = emit_job_event(
+            emit_job_event_lossy(
                 &ctx.audit,
                 ctx.task_id(),
                 V2AuditEventKind::StepSkipped {
@@ -32,17 +32,17 @@ pub(super) fn run_step(step: &JobV2Step, ctx: &ExecCtx<'_>) -> Result<StepOutcom
         },
     )
     .map_err(|e| DispatchError::AuditFailed(format!("{e:?}")))?;
-    let _ = ctx.audit.push_parent(step_event_id);
+    ctx.audit.push_parent_lossy(step_event_id);
 
     let result = run_step_with_retry(step, ctx);
 
-    let _ = ctx.audit.pop_parent();
+    ctx.audit.pop_parent_lossy();
     let (outcome_str, error_message) = match &result {
         Ok(StepOutcome { success: true, .. }) => ("success", None),
         Ok(StepOutcome { message, .. }) => ("failed", message.clone()),
         Err(err) => ("error", Some(err.to_string())),
     };
-    let _ = emit_job_event(
+    emit_job_event_lossy(
         &ctx.audit,
         ctx.task_id(),
         V2AuditEventKind::StepFinished {
@@ -97,7 +97,7 @@ pub(super) fn run_step_with_retry(
             break;
         }
         let backoff_ms = compute_backoff_ms(retry, attempt);
-        let _ = emit_job_event(
+        emit_job_event_lossy(
             &ctx.audit,
             ctx.task_id(),
             V2AuditEventKind::StepRetry {
@@ -170,7 +170,7 @@ pub(super) fn emit_denied_if_applicable(
     task_id: Option<&str>,
 ) {
     if matches!(err, DispatchError::ToolDenied { .. }) {
-        let _ = emit_job_event(
+        emit_job_event_lossy(
             audit,
             task_id,
             V2AuditEventKind::StepDenied {

--- a/crates/orbit-engine/src/activity_job/job_executor/tests/audit.rs
+++ b/crates/orbit-engine/src/activity_job/job_executor/tests/audit.rs
@@ -2,6 +2,49 @@
 
 use super::*;
 
+/// [ORB-00414] A failing envelope sink must not crash the run, but the loss
+/// must be observable: the run completes, a `tracing::error!` naming the run is
+/// emitted, and the outcome carries a nonzero audit-failure count + degraded
+/// flag.
+#[test]
+fn failing_envelope_sink_is_nonfatal_and_recorded() {
+    let host = ScriptedHost::new([("act", vec![Action::Ok(json!({"ok": true}))])]);
+    let job = job_with_steps(vec![target_step("s1", "act")]);
+    let run_id = "run-audit-degraded";
+    let writer = std::sync::Arc::new(failing_sink_writer(run_id));
+
+    let assert_writer = writer.clone();
+    let trace = capture(|| {
+        let outcome = execute_job(&job, Value::Null, run_id, writer.clone(), &host)
+            .expect("job completes despite audit sink failures");
+        assert!(outcome.success, "job should still succeed");
+        assert!(outcome.degraded_audit, "degraded_audit must be set");
+        assert!(
+            outcome.audit_failures > 0,
+            "audit_failures must be nonzero, got {}",
+            outcome.audit_failures
+        );
+    });
+
+    // The shared writer sees the same recorded failures.
+    assert!(assert_writer.degraded_audit());
+    assert!(assert_writer.audit_failure_count() > 0);
+
+    // A tracing error naming the run was emitted on the audit target.
+    let has_error = trace.events.iter().any(|event| {
+        event.target == "orbit.engine.audit"
+            && event.level == Level::ERROR
+            && event
+                .field("run_id")
+                .is_some_and(|value| value.contains(run_id))
+    });
+    assert!(
+        has_error,
+        "expected an audit-failure tracing error naming the run; captured targets={:?}",
+        trace.targets()
+    );
+}
+
 #[test]
 fn merges_object_defaults_with_explicit_object_input() {
     let defaults = json!({

--- a/crates/orbit-engine/src/activity_job/job_executor/tests/mod.rs
+++ b/crates/orbit-engine/src/activity_job/job_executor/tests/mod.rs
@@ -34,6 +34,24 @@ fn test_writer(run_id: &str) -> V2AuditWriter {
     V2AuditWriter::new(run_id, "test-agent", inner)
 }
 
+/// [ORB-00414] Envelope sink that always fails, used to exercise the non-fatal
+/// audit-failure recording path (counter + tracing error + degraded flag).
+struct FailingEnvelopeSink;
+
+impl crate::activity_job::audit_writer::EnvelopeSink for FailingEnvelopeSink {
+    fn write_envelope(&self, _event: &V2AuditEvent) -> Result<(), orbit_common::types::OrbitError> {
+        Err(orbit_common::types::OrbitError::Store(
+            "injected audit sink failure".to_string(),
+        ))
+    }
+}
+
+fn failing_sink_writer(run_id: &str) -> V2AuditWriter {
+    let inner: std::sync::Arc<dyn AuditSink> = std::sync::Arc::new(NullSink);
+    V2AuditWriter::new(run_id, "test-agent", inner)
+        .with_envelope_sink(std::sync::Arc::new(FailingEnvelopeSink))
+}
+
 fn capture<F>(f: F) -> CapturedTrace
 where
     F: FnOnce(),

--- a/crates/orbit-engine/src/activity_job/job_executor/tests/recovery.rs
+++ b/crates/orbit-engine/src/activity_job/job_executor/tests/recovery.rs
@@ -8,6 +8,39 @@ use crate::AgentRoleConfig;
 
 use super::role_overridden_recovery_spec;
 
+/// [ORB-00414] Audit-write failures on the recovery path are recorded (counter
+/// + degraded flag) but never fatal: recovery still runs and the job succeeds.
+#[test]
+fn recovery_path_audit_failures_are_recorded_not_fatal() {
+    let original_error = retryable_error("flaky", "dirty checkout");
+    let host = RecoveryHost::new([
+        (
+            "flaky",
+            vec![
+                Err(original_error.clone()),
+                Err(original_error.clone()),
+                Ok(json!({"fixed": true})),
+            ],
+        ),
+        ("recover", vec![Ok(json!({"recovered": true}))]),
+    ]);
+    let job = recovery_job(Some("recover"), Some("wide"), "flaky", Some("narrow"), 2);
+    let run_id = "run-recovery-degraded-audit";
+    let writer = std::sync::Arc::new(failing_sink_writer(run_id));
+
+    let outcome = execute_job(&job, Value::Null, run_id, writer.clone(), &host)
+        .expect("job should recover despite audit sink failures");
+
+    assert!(outcome.success, "recovery should still succeed");
+    assert_eq!(host.action_count("recover"), 1, "recovery must have run");
+    assert!(
+        outcome.degraded_audit,
+        "audit trail must be marked degraded after recovery-path sink failures"
+    );
+    assert!(outcome.audit_failures > 0);
+    assert!(writer.degraded_audit());
+}
+
 #[test]
 fn recovery_success_runs_one_post_recovery_attempt_with_exact_input_and_fs_profile() {
     let original_error = retryable_error("flaky", "dirty checkout");

--- a/crates/orbit-engine/src/activity_job/tool_enforcement.rs
+++ b/crates/orbit-engine/src/activity_job/tool_enforcement.rs
@@ -73,7 +73,7 @@ impl AuditSink for EnforcedAuditSink {
             LoopAuditEvent::PolicyDenial {
                 tool_name, reason, ..
             } => {
-                let _ = self.writer.emit(V2AuditEventKind::ToolDenied {
+                self.writer.emit_lossy(V2AuditEventKind::ToolDenied {
                     tool_name: tool_name.clone(),
                     reason: reason.clone(),
                 });
@@ -87,7 +87,7 @@ impl AuditSink for EnforcedAuditSink {
                 if !tool_allowed(tool_name, &self.allowlist) =>
             {
                 let reason = format!("tool `{tool_name}` not in allowlist");
-                let _ = self.writer.emit(V2AuditEventKind::ToolDenied {
+                self.writer.emit_lossy(V2AuditEventKind::ToolDenied {
                     tool_name: tool_name.clone(),
                     reason: reason.clone(),
                 });

--- a/crates/orbit-policy/Cargo.toml
+++ b/crates/orbit-policy/Cargo.toml
@@ -16,3 +16,4 @@ serde.workspace = true
 
 [dev-dependencies]
 chrono.workspace = true
+tempfile.workspace = true

--- a/crates/orbit-policy/src/engine.rs
+++ b/crates/orbit-policy/src/engine.rs
@@ -105,10 +105,35 @@ impl PolicyEngine {
     }
 }
 
+/// Cap on symlink traversals while resolving a not-yet-existing tail. Mirrors
+/// the kernel's `ELOOP` limit; a cycle of dangling links fails closed here
+/// instead of looping.
+const MAX_SYMLINK_FOLLOWS: usize = 40;
+
 /// Resolve symlinks in `path`, tolerating a not-yet-existing tail (writes /
 /// creates): canonicalize the nearest existing ancestor and rejoin the missing
 /// components. [ORB-00418]
-fn resolve_symlinks(path: &Path) -> Result<PathBuf, OrbitError> {
+///
+/// A *dangling* symlink reports `exists() == false` (`exists()` follows the
+/// link), but an `O_CREAT` open through it creates the link's **target** — so a
+/// dangling component is resolved via `read_link` rather than treated as a
+/// missing tail. Without this, a dangling link inside an allowed subtree
+/// pointing into a denied subtree would pass rule matching while the actual
+/// write landed at the denied target.
+///
+/// Shared with `orbit-tools`' workspace-boundary check so the two enforcement
+/// layers cannot drift.
+pub fn resolve_symlinks(path: &Path) -> Result<PathBuf, OrbitError> {
+    resolve_symlinks_bounded(path.to_path_buf(), 0)
+}
+
+fn resolve_symlinks_bounded(path: PathBuf, follows: usize) -> Result<PathBuf, OrbitError> {
+    if follows > MAX_SYMLINK_FOLLOWS {
+        return Err(OrbitError::InvalidInput(format!(
+            "too many levels of symbolic links resolving {}",
+            path.display()
+        )));
+    }
     if path.exists() {
         return path
             .canonicalize()
@@ -116,8 +141,33 @@ fn resolve_symlinks(path: &Path) -> Result<PathBuf, OrbitError> {
     }
 
     let mut missing = Vec::new();
-    let mut ancestor = path;
+    let mut ancestor = path.as_path();
     while !ancestor.exists() {
+        // Dangling symlink: follow it (fail closed if the link is unreadable)
+        // and restart resolution at the rejoined target.
+        let is_symlink = ancestor
+            .symlink_metadata()
+            .map(|meta| meta.file_type().is_symlink())
+            .unwrap_or(false);
+        if is_symlink {
+            let target = ancestor.read_link().map_err(|error| {
+                OrbitError::Io(format!("read_link {}: {error}", ancestor.display()))
+            })?;
+            let mut rejoined = if target.is_absolute() {
+                target
+            } else {
+                ancestor
+                    .parent()
+                    .map(Path::to_path_buf)
+                    .unwrap_or_default()
+                    .join(target)
+            };
+            for name in missing.iter().rev() {
+                rejoined.push(name);
+            }
+            return resolve_symlinks_bounded(rejoined, follows + 1);
+        }
+
         let name = ancestor.file_name().ok_or_else(|| {
             OrbitError::InvalidInput(format!("path has no file name: {}", path.display()))
         })?;

--- a/crates/orbit-policy/src/engine.rs
+++ b/crates/orbit-policy/src/engine.rs
@@ -1,6 +1,11 @@
+use std::path::{Path, PathBuf};
+
 use orbit_common::types::{FsOperation, OrbitError, PolicyDef};
 
 use crate::evaluator;
+
+/// `matched_rule` recorded when a resolved path escapes the workspace root.
+const OUTSIDE_WORKSPACE: &str = "<outside workspace>";
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct FsPolicyEvaluation {
@@ -40,7 +45,104 @@ impl PolicyEngine {
         })
     }
 
+    /// Symlink-safe policy evaluation. [ORB-00418]
+    ///
+    /// Resolves `requested_path` — following symlinks — against
+    /// `workspace_root` before matching rules, so a symlink inside an allowed
+    /// subtree that points into a denied subtree is DENIED: rules match the
+    /// *real* filesystem location, not the link path. Existing paths are
+    /// canonicalized directly; for a not-yet-existing target (a write/create)
+    /// the nearest existing ancestor is canonicalized (resolving symlinks in
+    /// the ancestor) and the remaining components are rejoined.
+    ///
+    /// A resolved path that escapes the workspace root is denied outright.
+    ///
+    /// Unlike [`Self::check`] (which matches the caller-supplied path string as
+    /// given), this method owns symlink resolution so the guarantee does not
+    /// depend on every caller canonicalizing first. On non-sandboxed platforms
+    /// (Linux) the policy check is the only enforcement layer, so resolving
+    /// here is load-bearing. TOCTOU between this check and the actual
+    /// filesystem access is an OS-level concern and out of scope.
+    pub fn check_resolved(
+        &self,
+        workspace_root: &Path,
+        profile: impl Into<String>,
+        operation: FsOperation,
+        requested_path: &Path,
+    ) -> Result<FsPolicyEvaluation, OrbitError> {
+        let profile = profile.into();
+        let resolved = resolve_symlinks(requested_path)?;
+        let canonical_root = workspace_root
+            .canonicalize()
+            .unwrap_or_else(|_| workspace_root.to_path_buf());
+
+        let Ok(relative) = resolved.strip_prefix(&canonical_root) else {
+            // The resolved path (e.g. a symlink target) landed outside the
+            // workspace root entirely — deny, don't fall through to rules that
+            // only govern in-workspace paths.
+            return Ok(FsPolicyEvaluation {
+                profile,
+                operation,
+                path: resolved.to_string_lossy().replace('\\', "/"),
+                allowed: false,
+                matched_rule: OUTSIDE_WORKSPACE.to_string(),
+            });
+        };
+
+        let relative = workspace_relative_string(relative);
+        let result = evaluator::evaluate(&self.def, &profile, operation, &relative)?;
+        Ok(FsPolicyEvaluation {
+            profile,
+            operation,
+            path: relative,
+            allowed: result.allowed,
+            matched_rule: result.matched_rule,
+        })
+    }
+
     pub fn def(&self) -> &PolicyDef {
         &self.def
+    }
+}
+
+/// Resolve symlinks in `path`, tolerating a not-yet-existing tail (writes /
+/// creates): canonicalize the nearest existing ancestor and rejoin the missing
+/// components. [ORB-00418]
+fn resolve_symlinks(path: &Path) -> Result<PathBuf, OrbitError> {
+    if path.exists() {
+        return path
+            .canonicalize()
+            .map_err(|error| OrbitError::Io(format!("canonicalize {}: {error}", path.display())));
+    }
+
+    let mut missing = Vec::new();
+    let mut ancestor = path;
+    while !ancestor.exists() {
+        let name = ancestor.file_name().ok_or_else(|| {
+            OrbitError::InvalidInput(format!("path has no file name: {}", path.display()))
+        })?;
+        missing.push(name.to_os_string());
+        ancestor = ancestor.parent().ok_or_else(|| {
+            OrbitError::InvalidInput(format!("path has no existing parent: {}", path.display()))
+        })?;
+    }
+
+    let mut resolved = ancestor
+        .canonicalize()
+        .map_err(|error| OrbitError::Io(format!("canonicalize {}: {error}", ancestor.display())))?;
+    for name in missing.iter().rev() {
+        resolved.push(name);
+    }
+    Ok(resolved)
+}
+
+/// Render a workspace-relative path as the `./…` form the rule matcher expects
+/// (mirrors the projection used by callers that pre-relativize).
+fn workspace_relative_string(relative: &Path) -> String {
+    let rendered = relative.to_string_lossy().replace('\\', "/");
+    if rendered.is_empty() {
+        ".".to_string()
+    } else {
+        format!("./{rendered}")
     }
 }

--- a/crates/orbit-policy/src/lib.rs
+++ b/crates/orbit-policy/src/lib.rs
@@ -17,6 +17,8 @@
 //! # Key exports
 //! - [`PolicyEngine`] — wraps a validated [`orbit_common::types::PolicyDef`]
 //! - [`FsPolicyEvaluation`] — structured allow/deny outcome with matched rule
+//! - [`resolve_symlinks`] — symlink-safe path resolution (dangling links
+//!   included) shared by policy evaluation and the tools-layer boundary check
 //!
 //! # Dependency direction
 //! `orbit-types` → `orbit-policy` → orbit-core
@@ -29,4 +31,4 @@ mod evaluator;
 mod tests;
 
 pub use decision::PolicyDecision;
-pub use engine::{FsPolicyEvaluation, PolicyEngine};
+pub use engine::{FsPolicyEvaluation, PolicyEngine, resolve_symlinks};

--- a/crates/orbit-policy/src/tests/engine.rs
+++ b/crates/orbit-policy/src/tests/engine.rs
@@ -228,3 +228,118 @@ fn check_global_deny_read_overrides_profile_read_allow() {
         "global denyRead must override profile-level read allow"
     );
 }
+
+// --- [ORB-00418] Symlink-safe evaluation (check_resolved) ---
+
+#[cfg(unix)]
+#[test]
+fn resolved_read_through_symlink_into_denied_subtree_is_denied() {
+    use std::os::unix::fs::symlink;
+
+    let root = tempfile::TempDir::new().expect("tempdir");
+    let root_path = root.path();
+    std::fs::create_dir(root_path.join("allowed_dir")).expect("allowed_dir");
+    std::fs::create_dir(root_path.join("denied_dir")).expect("denied_dir");
+    std::fs::write(root_path.join("denied_dir/secret.txt"), b"topsecret").expect("secret");
+    // A symlink inside the allowed subtree pointing into the denied subtree.
+    symlink(
+        root_path.join("denied_dir"),
+        root_path.join("allowed_dir/link"),
+    )
+    .expect("symlink");
+
+    let def = make_def(
+        vec!["denied_dir/**"],
+        vec!["denied_dir/**"],
+        &[("default", &["./**"], &["./**"])],
+    );
+    let engine = PolicyEngine::from_def(&def).expect("engine");
+
+    // Reading through the link resolves to denied_dir/secret.txt -> DENIED,
+    // even though the link path itself is under an allowed subtree.
+    let through_link = root_path.join("allowed_dir/link/secret.txt");
+    let eval = engine
+        .check_resolved(root_path, "default", FsOperation::Read, &through_link)
+        .expect("check");
+    assert!(
+        !eval.allowed,
+        "read through symlink into denied subtree must be denied: {eval:?}"
+    );
+
+    // A genuine (non-symlink) allowed path is still permitted — resolution must
+    // not over-block ordinary paths.
+    std::fs::write(root_path.join("allowed_dir/ok.txt"), b"ok").expect("ok file");
+    let ok = engine
+        .check_resolved(
+            root_path,
+            "default",
+            FsOperation::Read,
+            &root_path.join("allowed_dir/ok.txt"),
+        )
+        .expect("check");
+    assert!(ok.allowed, "non-symlink allowed path should pass: {ok:?}");
+}
+
+#[cfg(unix)]
+#[test]
+fn resolved_write_to_missing_path_under_symlinked_ancestor_uses_real_location() {
+    use std::os::unix::fs::symlink;
+
+    let root = tempfile::TempDir::new().expect("tempdir");
+    let root_path = root.path();
+    std::fs::create_dir(root_path.join("allowed_dir")).expect("allowed_dir");
+    std::fs::create_dir(root_path.join("denied_dir")).expect("denied_dir");
+    symlink(
+        root_path.join("denied_dir"),
+        root_path.join("allowed_dir/link"),
+    )
+    .expect("symlink");
+
+    let def = make_def(
+        vec![],
+        vec!["denied_dir/**"],
+        &[("default", &["./**"], &["./**"])],
+    );
+    let engine = PolicyEngine::from_def(&def).expect("engine");
+
+    // The target does not exist yet (a write/create); it must resolve against
+    // the symlinked ancestor's real location for rule matching.
+    let target = root_path.join("allowed_dir/link/newfile.txt");
+    let eval = engine
+        .check_resolved(root_path, "default", FsOperation::Modify, &target)
+        .expect("check");
+    assert!(
+        !eval.allowed,
+        "write under a symlinked ancestor must resolve to the real (denied) location: {eval:?}"
+    );
+    assert!(
+        eval.path.contains("denied_dir/newfile.txt"),
+        "resolved path should point at the real location, got `{}`",
+        eval.path
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn resolved_symlink_escaping_workspace_is_denied() {
+    use std::os::unix::fs::symlink;
+
+    let outside = tempfile::TempDir::new().expect("outside");
+    std::fs::write(outside.path().join("passwd"), b"root:x:0:0").expect("outside file");
+    let root = tempfile::TempDir::new().expect("workspace");
+    let root_path = root.path();
+    symlink(outside.path(), root_path.join("escape")).expect("symlink");
+
+    let def = make_def(vec![], vec![], &[("default", &["./**"], &["./**"])]);
+    let engine = PolicyEngine::from_def(&def).expect("engine");
+
+    let through = root_path.join("escape/passwd");
+    let eval = engine
+        .check_resolved(root_path, "default", FsOperation::Read, &through)
+        .expect("check");
+    assert!(
+        !eval.allowed,
+        "a symlink escaping the workspace root must be denied: {eval:?}"
+    );
+    assert_eq!(eval.matched_rule, "<outside workspace>");
+}

--- a/crates/orbit-policy/src/tests/engine.rs
+++ b/crates/orbit-policy/src/tests/engine.rs
@@ -343,3 +343,101 @@ fn resolved_symlink_escaping_workspace_is_denied() {
     );
     assert_eq!(eval.matched_rule, "<outside workspace>");
 }
+
+#[cfg(unix)]
+#[test]
+fn resolved_dangling_symlink_into_denied_subtree_is_denied() {
+    use std::os::unix::fs::symlink;
+
+    let root = tempfile::TempDir::new().expect("tempdir");
+    let root_path = root.path();
+    std::fs::create_dir(root_path.join("allowed_dir")).expect("allowed_dir");
+    std::fs::create_dir(root_path.join("denied_dir")).expect("denied_dir");
+    // Dangling link: the target does NOT exist. `exists()` on the link path is
+    // false, but an O_CREAT open through the link creates the *target*, so the
+    // policy must evaluate the target location, not the link path.
+    symlink(
+        root_path.join("denied_dir/planted.txt"),
+        root_path.join("allowed_dir/link"),
+    )
+    .expect("symlink");
+
+    let def = make_def(
+        vec![],
+        vec!["denied_dir/**"],
+        &[("default", &["./**"], &["./**"])],
+    );
+    let engine = PolicyEngine::from_def(&def).expect("engine");
+
+    let eval = engine
+        .check_resolved(
+            root_path,
+            "default",
+            FsOperation::Modify,
+            &root_path.join("allowed_dir/link"),
+        )
+        .expect("check");
+    assert!(
+        !eval.allowed,
+        "a write through a dangling symlink must be evaluated at the link target: {eval:?}"
+    );
+    assert!(
+        eval.path.contains("denied_dir/planted.txt"),
+        "resolved path should be the dangling link's target, got `{}`",
+        eval.path
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn resolved_dangling_symlink_escaping_workspace_is_denied() {
+    use std::os::unix::fs::symlink;
+
+    let outside = tempfile::TempDir::new().expect("outside");
+    let root = tempfile::TempDir::new().expect("workspace");
+    let root_path = root.path();
+    // Dangling link whose (nonexistent) target lives outside the workspace.
+    symlink(outside.path().join("planted.txt"), root_path.join("escape")).expect("symlink");
+
+    let def = make_def(vec![], vec![], &[("default", &["./**"], &["./**"])]);
+    let engine = PolicyEngine::from_def(&def).expect("engine");
+
+    let eval = engine
+        .check_resolved(
+            root_path,
+            "default",
+            FsOperation::Modify,
+            &root_path.join("escape"),
+        )
+        .expect("check");
+    assert!(
+        !eval.allowed,
+        "a dangling symlink escaping the workspace must be denied: {eval:?}"
+    );
+    assert_eq!(eval.matched_rule, "<outside workspace>");
+}
+
+#[cfg(unix)]
+#[test]
+fn resolved_symlink_cycle_fails_closed() {
+    use std::os::unix::fs::symlink;
+
+    let root = tempfile::TempDir::new().expect("tempdir");
+    let root_path = root.path();
+    symlink(root_path.join("b"), root_path.join("a")).expect("symlink a");
+    symlink(root_path.join("a"), root_path.join("b")).expect("symlink b");
+
+    let def = make_def(vec![], vec![], &[("default", &["./**"], &["./**"])]);
+    let engine = PolicyEngine::from_def(&def).expect("engine");
+
+    let result = engine.check_resolved(
+        root_path,
+        "default",
+        FsOperation::Modify,
+        &root_path.join("a"),
+    );
+    assert!(
+        result.is_err(),
+        "a symlink cycle must fail closed (error), got {result:?}"
+    );
+}

--- a/crates/orbit-store/src/file/adr_store/api/mod.rs
+++ b/crates/orbit-store/src/file/adr_store/api/mod.rs
@@ -58,12 +58,14 @@ impl AdrFileStore {
 
     /// Creates a new ADR.
     ///
-    /// Filesystem write happens first (atomic via `write_bundle_at`); if it
-    /// succeeds and an index is attached, the envelope is upserted. A failed
-    /// index write is logged but does **not** roll back the filesystem: the
-    /// filesystem is the source of truth and `rebuild_index` can recover.
-    /// The inverse direction (FS failure → index rollback) is implicit since
-    /// the index INSERT is gated on FS success.
+    /// The SQLite ID reservation from `allocate_adr` is the source of truth for
+    /// the ID; the bundle is then written to disk and the body path recorded.
+    /// [ORB-00413] If the bundle write or the body-path record fails, the
+    /// reservation is rolled back (bundle removed + allocation abandoned) so a
+    /// partial create leaves either a complete ADR or nothing — never a
+    /// half-visible ID. A failed index upsert is logged but does **not** roll
+    /// back the filesystem: the filesystem is the source of truth and the index
+    /// can be rebuilt from it.
     pub(crate) fn add_adr(&self, params: AdrCreateParams) -> Result<Adr, OrbitError> {
         if params.title.trim().is_empty() {
             return Err(OrbitError::InvalidInput(
@@ -106,13 +108,39 @@ impl AdrFileStore {
         validate_bundle(&bundle)?;
 
         let target_dir = adr_dir(&self.root, AdrStateDir::Proposed, &id);
-        write_bundle_at(&target_dir, &bundle)?;
-        self.id_allocator
-            .record_adr_body_path(&id, &super::layout::body_path(&target_dir))?;
+        if let Err(error) = write_bundle_at(&target_dir, &bundle) {
+            self.rollback_partial_adr(&id, &target_dir);
+            return Err(error);
+        }
+        if let Err(error) = self
+            .id_allocator
+            .record_adr_body_path(&id, &super::layout::body_path(&target_dir))
+        {
+            self.rollback_partial_adr(&id, &target_dir);
+            return Err(error);
+        }
 
         let adr = bundle_to_adr(bundle);
         self.upsert_index_row(&adr);
         Ok(adr)
+    }
+
+    /// [ORB-00413] Best-effort rollback of a partially-created ADR: remove the
+    /// staged bundle directory and abandon the reservation so the ID is never
+    /// left half-visible. Never fails the caller; logs only if the abandon
+    /// itself fails. Safe because the last fallible step before finalization is
+    /// `record_adr_body_path`, so the reservation's `body_path` is still unset
+    /// (and thus abandonable) whenever this runs.
+    fn rollback_partial_adr(&self, id: &str, target_dir: &std::path::Path) {
+        let _ = std::fs::remove_dir_all(target_dir);
+        if let Err(error) = self.id_allocator.abandon_adr(id) {
+            orbit_common::tracing::warn!(
+                target: "orbit.store.adr",
+                id,
+                error = %error,
+                "rollback: failed to abandon reserved ADR after a partial create",
+            );
+        }
     }
 
     pub(crate) fn get_adr(&self, id: &str) -> Result<Option<Adr>, OrbitError> {

--- a/crates/orbit-store/src/file/adr_store/lock.rs
+++ b/crates/orbit-store/src/file/adr_store/lock.rs
@@ -1,39 +1,15 @@
-use std::fs::{self, File, OpenOptions};
 use std::path::{Path, PathBuf};
 
-use fs2::FileExt;
 use orbit_common::types::OrbitError;
+
+use crate::file_lock::{FileLockGuard, acquire_exclusive};
 
 const LOCKS_DIR_NAME: &str = ".locks";
 
-pub(super) fn acquire_adr_lock(root: &Path, id: &str) -> Result<File, OrbitError> {
+pub(super) fn acquire_adr_lock(root: &Path, id: &str) -> Result<FileLockGuard, OrbitError> {
     let path = adr_lock_path(root, id);
-    acquire_lock(path, &format!("adr '{id}'"))
-}
-
-fn acquire_lock(path: PathBuf, label: &str) -> Result<File, OrbitError> {
-    let parent = path.parent().ok_or_else(|| {
-        OrbitError::Store(format!(
-            "cannot determine lock parent for '{}'",
-            path.display()
-        ))
-    })?;
-    fs::create_dir_all(parent).map_err(|err| OrbitError::Io(err.to_string()))?;
-
-    let file = OpenOptions::new()
-        .create(true)
-        .truncate(false)
-        .read(true)
-        .write(true)
-        .open(&path)
-        .map_err(|err| OrbitError::Io(err.to_string()))?;
-    file.lock_exclusive().map_err(|err| {
-        OrbitError::Store(format!(
-            "failed to acquire {label} lock '{}': {err}",
-            path.display()
-        ))
-    })?;
-    Ok(file)
+    // [ORB-00412] Bounded acquisition with holder diagnostics.
+    acquire_exclusive(&path, &format!("adr '{id}'"))
 }
 
 fn adr_lock_path(root: &Path, id: &str) -> PathBuf {

--- a/crates/orbit-store/src/file/learning_store/api/crud.rs
+++ b/crates/orbit-store/src/file/learning_store/api/crud.rs
@@ -67,18 +67,82 @@ impl LearningFileStore {
             };
 
             let path = learning_doc_path(&self.root, &id);
-            if !create_learning_file_exclusive(&path, &learning, LearningStatus::Active)? {
-                self.adopt_or_reject_existing_learning_path(&id, &path)?;
-                continue;
-            }
 
-            ensure_empty_sidecar(&votes_jsonl_path(&self.root, &id))?;
-            ensure_empty_sidecar(&comments_jsonl_path(&self.root, &id))?;
-            self.id_allocator.record_learning_body_path(&id, &path)?;
-            self.upsert_index_row(&learning);
-            self.invalidate_envelope_cache();
-            return Ok(learning);
+            // [ORB-00413] The SQLite reservation from `allocate_learning` is the
+            // source of truth for the ID; guard the body/sidecar/record steps so
+            // a partial create rolls the reservation back rather than leaving a
+            // half-visible ID (reserved-without-body) or an orphaned body file.
+            // A learning after this point either fully exists (allocated + body
+            // present + indexed) or not at all.
+            match create_learning_file_exclusive(&path, &learning, LearningStatus::Active) {
+                Ok(true) => match self.finalize_created_learning(&id, &path, &learning) {
+                    Ok(()) => return Ok(learning),
+                    Err(error) => {
+                        self.rollback_partial_learning(&id, &path);
+                        return Err(error);
+                    }
+                },
+                Ok(false) => {
+                    // The allocated id's path already exists: adopt it (same id)
+                    // or reject (different id). `adopt_or_reject_existing_learning_path`
+                    // owns cleanup of the reservation in the reject case, so no
+                    // body of ours is left behind.
+                    self.adopt_or_reject_existing_learning_path(&id, &path)?;
+                    continue;
+                }
+                Err(error) => {
+                    // The exclusive create failed with an IO error — a
+                    // pre-existing file surfaces as `Ok(false)`, not `Err`, so
+                    // any partial file here is ours to clean up.
+                    self.rollback_partial_learning(&id, &path);
+                    return Err(error);
+                }
+            }
         }
+    }
+
+    /// Finalize a freshly-created learning body: write its empty sidecars,
+    /// record the allocation's body path, and refresh the index. The last
+    /// fallible step is `record_learning_body_path`; everything after it is
+    /// infallible, so a returned `Err` always leaves the reservation's
+    /// `body_path` unset and thus abandonable by [`Self::rollback_partial_learning`].
+    fn finalize_created_learning(
+        &self,
+        id: &str,
+        path: &std::path::Path,
+        learning: &Learning,
+    ) -> Result<(), OrbitError> {
+        ensure_empty_sidecar(&votes_jsonl_path(&self.root, id))?;
+        ensure_empty_sidecar(&comments_jsonl_path(&self.root, id))?;
+        self.id_allocator.record_learning_body_path(id, path)?;
+        self.upsert_index_row(learning);
+        self.invalidate_envelope_cache();
+        Ok(())
+    }
+
+    /// [ORB-00413] Best-effort rollback of a partially-created learning: remove
+    /// the staged body + sidecars we wrote, drop the now-empty id directory, and
+    /// abandon the reservation so the ID is never left half-visible. Never fails
+    /// the caller — the original error is what propagates — and only logs if the
+    /// abandon itself fails.
+    fn rollback_partial_learning(&self, id: &str, path: &std::path::Path) {
+        let _ = std::fs::remove_file(path);
+        let _ = std::fs::remove_file(votes_jsonl_path(&self.root, id));
+        let _ = std::fs::remove_file(comments_jsonl_path(&self.root, id));
+        if let Some(dir) = path.parent() {
+            // Only succeeds if the directory is now empty — leaves any
+            // pre-existing/foreign content in place.
+            let _ = std::fs::remove_dir(dir);
+        }
+        if let Err(error) = self.id_allocator.abandon_learning(id) {
+            orbit_common::tracing::warn!(
+                target: "orbit.store.learning",
+                id,
+                error = %error,
+                "rollback: failed to abandon reserved learning after a partial create",
+            );
+        }
+        self.invalidate_envelope_cache();
     }
 
     pub(crate) fn get_learning(&self, id: &str) -> Result<Option<Learning>, OrbitError> {

--- a/crates/orbit-store/src/file/learning_store/api/search_index.rs
+++ b/crates/orbit-store/src/file/learning_store/api/search_index.rs
@@ -13,6 +13,18 @@ use super::super::votes::{deduped_vote_times, read_vote_rows};
 use super::store::LearningFileStore;
 use crate::backend::{LearningSearchParams, LearningSearchResult};
 
+/// [ORB-00413] An on-disk learning body whose ID the allocator has no active
+/// record of — the fingerprint of a legacy partial create (body written, the
+/// allocation never recorded). Returned by
+/// [`LearningFileStore::reconcile_learning_orphans`] and surfaced as warnings by
+/// [`LearningFileStore::sync_learnings`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct LearningOrphan {
+    pub(crate) id: String,
+    pub(crate) body_path: std::path::PathBuf,
+    pub(crate) remedy: String,
+}
+
 pub(crate) struct EnvelopeSnapshot {
     pub(super) id: String,
     pub(super) paths: Vec<String>,
@@ -34,6 +46,27 @@ impl LearningFileStore {
     pub(crate) fn sync_learnings(&self) -> Result<(), OrbitError> {
         validate_vote_files(&self.root)?;
         super::validation::validate_comment_files(&self.root)?;
+        // [ORB-00413] Surface orphaned body files (the fingerprint of a legacy
+        // partial create: body on disk, allocation never recorded) so the
+        // resync command reports them with a remedy. Non-fatal to the sync.
+        match self.reconcile_learning_orphans() {
+            Ok(orphans) => {
+                for orphan in &orphans {
+                    orbit_common::tracing::warn!(
+                        target: "orbit.store.learning",
+                        id = %orphan.id,
+                        body_path = %orphan.body_path.display(),
+                        "orphaned learning body detected: {}",
+                        orphan.remedy,
+                    );
+                }
+            }
+            Err(error) => orbit_common::tracing::warn!(
+                target: "orbit.store.learning",
+                error = %error,
+                "learning orphan reconcile failed during sync",
+            ),
+        }
         let Some(index) = &self.index else {
             self.invalidate_envelope_cache();
             return Ok(());
@@ -45,6 +78,49 @@ impl LearningFileStore {
         }
         self.invalidate_envelope_cache();
         Ok(())
+    }
+
+    /// [ORB-00413] Detect learning body files on disk whose ID the allocator has
+    /// no active record of. Such an orphan is the residue of a legacy partial
+    /// create (body written before the allocation was recorded) that predates
+    /// the write-time rollback in `crud`. Read-only: reports, never mutates.
+    pub(crate) fn reconcile_learning_orphans(&self) -> Result<Vec<LearningOrphan>, OrbitError> {
+        let mut orphans = Vec::new();
+        if !self.root.exists() {
+            return Ok(orphans);
+        }
+        for entry in std::fs::read_dir(&self.root).map_err(|e| OrbitError::Io(e.to_string()))? {
+            let entry = entry.map_err(|e| OrbitError::Io(e.to_string()))?;
+            if !entry
+                .file_type()
+                .map_err(|e| OrbitError::Io(e.to_string()))?
+                .is_dir()
+            {
+                continue;
+            }
+            let Some(id) = entry.file_name().to_str().map(str::to_string) else {
+                continue;
+            };
+            if super::super::layout::validate_learning_id(&id).is_err() {
+                continue;
+            }
+            let body_path = super::super::layout::learning_doc_path(&self.root, &id);
+            if !body_path.is_file() {
+                continue;
+            }
+            if self.id_allocator.learning_allocation(&id)?.is_none() {
+                orphans.push(LearningOrphan {
+                    id: id.clone(),
+                    body_path,
+                    remedy: format!(
+                        "learning body exists on disk but the allocator has no record of '{id}'; \
+                         reopen the workspace to backfill the allocation, or remove the orphaned body"
+                    ),
+                });
+            }
+        }
+        orphans.sort_by(|left, right| left.id.cmp(&right.id));
+        Ok(orphans)
     }
 
     /// Run the phase-1 scope-OR search.

--- a/crates/orbit-store/src/file/learning_store/api/tests/crud.rs
+++ b/crates/orbit-store/src/file/learning_store/api/tests/crud.rs
@@ -640,3 +640,131 @@ fn layout_places_files_at_expected_paths_and_gitignore_is_respected() {
         ".gitignore must ignore .orbit/state/ (or the wider .orbit/) so the rebuildable index is not checked in",
     );
 }
+
+// [ORB-00413] Atomic learning creation: rollback on partial write + reconcile.
+
+#[test]
+fn partial_create_rolls_back_reservation_and_body() {
+    let (dir, store) = store_with_index();
+    let root = dir.path().to_path_buf();
+
+    // Inject a failure *between* the YAML body write and the allocation
+    // recording: pre-create the votes sidecar path (for the id the fresh
+    // allocator will hand out first) as a *directory*, so `ensure_empty_sidecar`
+    // fails when it opens it as a file. The first id in a fresh store is L-0001.
+    let expected_id = "L-0001";
+    std::fs::create_dir_all(root.join(expected_id).join("votes.jsonl"))
+        .expect("seed sidecar collision");
+
+    let result = store.create_learning(create_params("rolled back", vec!["a/**"], vec!["t"]));
+    assert!(
+        result.is_err(),
+        "create must fail on the seeded sidecar collision"
+    );
+
+    // No orphaned state: not indexed, body removed, reservation abandoned —
+    // the learning either fully exists or not at all.
+    assert!(
+        store.get_learning(expected_id).expect("get").is_none(),
+        "no learning should be visible after rollback"
+    );
+    assert!(
+        store
+            .id_allocator
+            .learning_allocation(expected_id)
+            .expect("alloc lookup")
+            .is_none(),
+        "reserved id must be abandoned (not left half-visible) after rollback"
+    );
+    assert!(
+        !root.join(expected_id).join("learning.yaml").exists(),
+        "staged body file must be removed on rollback"
+    );
+
+    // The workspace is still usable: a subsequent create succeeds (the burned
+    // id is not reissued, per abandon semantics).
+    let next = store
+        .create_learning(create_params("after rollback", vec!["a/**"], vec!["t"]))
+        .expect("create after rollback succeeds");
+    assert_ne!(next.id, expected_id);
+}
+
+#[test]
+fn reconcile_detects_body_with_no_allocator_row() {
+    let (dir, store) = store_with_index();
+    let root = dir.path().to_path_buf();
+
+    let learning = store
+        .create_learning(create_params("keep", vec!["a/**"], vec!["t"]))
+        .expect("create");
+    assert_eq!(learning.id, "L-0001");
+
+    // Simulate the legacy partial-create residue: a body dir the allocator has
+    // no record of. Renaming to a fresh id the allocator never allocated yields
+    // exactly that shape (body present on disk, allocation absent).
+    let orphan_id = "L-0009";
+    std::fs::rename(root.join("L-0001"), root.join(orphan_id)).expect("rename to orphan id");
+
+    let orphans = store.reconcile_learning_orphans().expect("reconcile");
+    assert_eq!(
+        orphans.len(),
+        1,
+        "expected exactly one orphan; got {orphans:?}"
+    );
+    let orphan = &orphans[0];
+    assert_eq!(orphan.id, orphan_id);
+    assert_eq!(orphan.body_path, root.join(orphan_id).join("learning.yaml"));
+    assert!(
+        orphan.body_path.is_file(),
+        "orphan body path should point at the real file"
+    );
+    assert!(
+        orphan.remedy.contains("allocator"),
+        "remedy should name the allocator and a fix: {}",
+        orphan.remedy
+    );
+}
+
+#[test]
+fn concurrent_creation_yields_two_distinct_records() {
+    let dir = tempdir().expect("tempdir");
+    let root = dir.path().to_path_buf();
+
+    // Two stores over the same workspace (shared allocator db + lock file),
+    // mirroring concurrent multi-process creation. The file lock + Immediate
+    // transaction serialize id allocation.
+    let store_a = LearningFileStore::new(root.clone());
+    let store_b = LearningFileStore::new(root.clone());
+    let barrier = Arc::new(Barrier::new(2));
+
+    let barrier_a = Arc::clone(&barrier);
+    let handle_a = std::thread::spawn(move || {
+        barrier_a.wait();
+        store_a
+            .create_learning(create_params("thread a", vec!["a/**"], vec!["t"]))
+            .expect("thread a create")
+            .id
+    });
+    let barrier_b = barrier;
+    let handle_b = std::thread::spawn(move || {
+        barrier_b.wait();
+        store_b
+            .create_learning(create_params("thread b", vec!["b/**"], vec!["t"]))
+            .expect("thread b create")
+            .id
+    });
+
+    let id_a = handle_a.join().expect("join a");
+    let id_b = handle_b.join().expect("join b");
+    assert_ne!(id_a, id_b, "concurrent creates must yield distinct ids");
+
+    // Both records are well-formed and readable from a fresh store.
+    let reader = LearningFileStore::new(root.clone());
+    for id in [&id_a, &id_b] {
+        let learning = reader.get_learning(id).expect("get").expect("present");
+        assert_eq!(&learning.id, id);
+        assert!(root.join(id).join("learning.yaml").is_file());
+    }
+    let ids: BTreeSet<String> = [id_a, id_b].into_iter().collect();
+    assert_eq!(ids.len(), 2);
+}

--- a/crates/orbit-store/src/file/learning_store/lock.rs
+++ b/crates/orbit-store/src/file/learning_store/lock.rs
@@ -1,46 +1,21 @@
-use std::fs::{self, File, OpenOptions};
 use std::path::{Path, PathBuf};
 
-use fs2::FileExt;
 use orbit_common::types::OrbitError;
 
 use super::constants::{LEARNING_ALLOCATION_LOCK_FILE_NAME, LOCKS_DIR_NAME};
+use crate::file_lock::{FileLockGuard, acquire_exclusive};
 
-pub(super) fn acquire_learning_allocation_lock(root: &Path) -> Result<File, OrbitError> {
+pub(super) fn acquire_learning_allocation_lock(root: &Path) -> Result<FileLockGuard, OrbitError> {
     let path = root
         .join(LOCKS_DIR_NAME)
         .join(LEARNING_ALLOCATION_LOCK_FILE_NAME);
-    acquire_lock(path, "learning allocation")
+    // [ORB-00412] Bounded acquisition with holder diagnostics.
+    acquire_exclusive(&path, "learning allocation")
 }
 
-pub(super) fn acquire_learning_lock(root: &Path, id: &str) -> Result<File, OrbitError> {
+pub(super) fn acquire_learning_lock(root: &Path, id: &str) -> Result<FileLockGuard, OrbitError> {
     let path = learning_lock_path(root, id);
-    acquire_lock(path, &format!("learning '{id}'"))
-}
-
-fn acquire_lock(path: PathBuf, label: &str) -> Result<File, OrbitError> {
-    let parent = path.parent().ok_or_else(|| {
-        OrbitError::Store(format!(
-            "cannot determine lock parent for '{}'",
-            path.display()
-        ))
-    })?;
-    fs::create_dir_all(parent).map_err(|err| OrbitError::Io(err.to_string()))?;
-
-    let file = OpenOptions::new()
-        .create(true)
-        .truncate(false)
-        .read(true)
-        .write(true)
-        .open(&path)
-        .map_err(|err| OrbitError::Io(err.to_string()))?;
-    file.lock_exclusive().map_err(|err| {
-        OrbitError::Store(format!(
-            "failed to acquire {label} lock '{}': {err}",
-            path.display()
-        ))
-    })?;
-    Ok(file)
+    acquire_exclusive(&path, &format!("learning '{id}'"))
 }
 
 fn learning_lock_path(root: &Path, id: &str) -> PathBuf {

--- a/crates/orbit-store/src/file_lock/mod.rs
+++ b/crates/orbit-store/src/file_lock/mod.rs
@@ -1,0 +1,211 @@
+//! Bounded, diagnostic advisory file locking shared by the SQLite ID allocator
+//! and the file-backed learning/ADR stores. [ORB-00412]
+//!
+//! ID allocation and learning/ADR record mutation serialize through `fs2`
+//! advisory (`flock(2)`) locks. A bare [`fs2::FileExt::lock_exclusive`] blocks
+//! *indefinitely*: if a holder hangs — as opposed to crashing, since the OS
+//! releases advisory locks on process death — every other agent stalls forever
+//! with no signal about who holds the lock or why. Under concurrent
+//! multi-agent use (planning duels, parallel worktrees, unattended
+//! ship-sweep) that silent stall is a whole-workspace availability risk.
+//!
+//! This module bounds the wait with a configurable deadline, records holder
+//! metadata (PID + acquisition timestamp) into the lock file for diagnostics,
+//! and emits a `tracing::warn!` once a waiter has been blocked past a
+//! threshold. Holder metadata is advisory only — the OS `flock` is the source
+//! of truth; the metadata is read solely to enrich the error/warning a blocked
+//! waiter reports.
+//!
+//! The returned [`FileLockGuard`] follows the RAII-guard pattern
+//! (`docs/design-patterns/raii_guard.md`): the OS lock is released when the
+//! guard is dropped, including on `?`-return and unwind.
+
+use std::fs::{self, File, OpenOptions};
+use std::io::{Read, Seek, SeekFrom, Write};
+use std::path::Path;
+use std::time::{Duration, Instant};
+
+use fs2::FileExt;
+use orbit_common::types::OrbitError;
+use serde::{Deserialize, Serialize};
+
+/// Default upper bound on how long an exclusive acquisition blocks before
+/// failing with a typed error. Deliberately generous: contention is normal
+/// under concurrent multi-agent use, but a hung holder should not stall the
+/// workspace forever.
+pub(crate) const DEFAULT_LOCK_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Emit a diagnostic warning once a waiter has been blocked at least this long.
+const DEFAULT_WARN_AFTER: Duration = Duration::from_secs(3);
+
+/// Poll interval for the try-lock retry loop.
+const RETRY_INTERVAL: Duration = Duration::from_millis(50);
+
+/// Tunables for a single lock acquisition. Use [`LockOptions::default`] for
+/// production defaults; tests override the durations to stay fast and
+/// deterministic.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct LockOptions {
+    /// Fail the acquisition once the waiter has blocked this long.
+    pub(crate) timeout: Duration,
+    /// Warn (once) once the waiter has blocked this long.
+    pub(crate) warn_after: Duration,
+}
+
+impl Default for LockOptions {
+    fn default() -> Self {
+        Self {
+            timeout: DEFAULT_LOCK_TIMEOUT,
+            warn_after: DEFAULT_WARN_AFTER,
+        }
+    }
+}
+
+/// RAII guard over an exclusive advisory file lock. The lock is released when
+/// the wrapped [`File`] is dropped (`fs2` unlocks on close), so callers hold
+/// the guard for the critical section and rely on scope exit to release it.
+#[derive(Debug)]
+#[must_use = "the advisory lock is released as soon as the guard is dropped"]
+pub(crate) struct FileLockGuard {
+    // Held purely for its Drop side effect: closing the file releases the
+    // `flock`. Named with a leading underscore so dead-code analysis does not
+    // flag the never-read field (mirrors `SignalHandlerGuard::_lock`).
+    _file: File,
+}
+
+/// Metadata written into a lock file by its current holder. Advisory and
+/// diagnostic only — never load-bearing for correctness.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct LockHolder {
+    pid: u32,
+    /// RFC 3339 acquisition timestamp.
+    acquired_at: String,
+    /// Human label of the operation holding the lock.
+    label: String,
+}
+
+/// Acquire an exclusive advisory lock on `path` using production defaults,
+/// creating the file (and parent directories) if needed. `label` names the
+/// operation for diagnostics (e.g. `"id allocation"`).
+pub(crate) fn acquire_exclusive(path: &Path, label: &str) -> Result<FileLockGuard, OrbitError> {
+    acquire_exclusive_with(path, label, LockOptions::default())
+}
+
+/// Acquire an exclusive advisory lock with explicit [`LockOptions`]. On timeout
+/// returns [`OrbitError::Store`] whose message names the lock path and any
+/// holder metadata, so a stalled waiter is observable rather than silent.
+pub(crate) fn acquire_exclusive_with(
+    path: &Path,
+    label: &str,
+    options: LockOptions,
+) -> Result<FileLockGuard, OrbitError> {
+    let parent = path.parent().ok_or_else(|| {
+        OrbitError::Store(format!(
+            "cannot determine lock parent for '{}'",
+            path.display()
+        ))
+    })?;
+    fs::create_dir_all(parent).map_err(|error| OrbitError::Io(error.to_string()))?;
+
+    let file = OpenOptions::new()
+        .create(true)
+        .truncate(false)
+        .read(true)
+        .write(true)
+        .open(path)
+        .map_err(|error| OrbitError::Io(error.to_string()))?;
+
+    let started = Instant::now();
+    let mut warned = false;
+    loop {
+        match file.try_lock_exclusive() {
+            Ok(()) => {
+                // Best-effort holder metadata; advisory/diagnostic only.
+                write_holder(&file, label);
+                return Ok(FileLockGuard { _file: file });
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                let elapsed = started.elapsed();
+                if elapsed >= options.timeout {
+                    return Err(OrbitError::Store(format!(
+                        "timed out after {:?} acquiring {label} lock '{}'{}",
+                        options.timeout,
+                        path.display(),
+                        holder_suffix(path),
+                    )));
+                }
+                if !warned && elapsed >= options.warn_after {
+                    warned = true;
+                    orbit_common::tracing::warn!(
+                        target: "orbit.store.file_lock",
+                        lock_path = %path.display(),
+                        label,
+                        waited_ms = elapsed.as_millis() as u64,
+                        holder = %holder_description(path),
+                        "still waiting for advisory file lock; a holder may be hung",
+                    );
+                }
+                std::thread::sleep(RETRY_INTERVAL);
+            }
+            Err(error) => {
+                return Err(OrbitError::Store(format!(
+                    "failed to acquire {label} lock '{}': {error}",
+                    path.display()
+                )));
+            }
+        }
+    }
+}
+
+/// Overwrite the lock file with the current holder's metadata. Best-effort: a
+/// failure here never fails the acquisition, and a concurrent reader tolerating
+/// a torn write is expected (see [`read_holder`]).
+fn write_holder(file: &File, label: &str) {
+    let holder = LockHolder {
+        pid: std::process::id(),
+        acquired_at: chrono::Utc::now().to_rfc3339(),
+        label: label.to_string(),
+    };
+    let _ = write_holder_inner(file, &holder);
+}
+
+fn write_holder_inner(mut file: &File, holder: &LockHolder) -> std::io::Result<()> {
+    let json = serde_json::to_string(holder).unwrap_or_default();
+    file.seek(SeekFrom::Start(0))?;
+    file.set_len(0)?;
+    file.write_all(json.as_bytes())?;
+    file.flush()?;
+    Ok(())
+}
+
+/// Read the holder metadata a blocked waiter can report. Lenient: any read or
+/// parse failure (missing file, torn write, legacy empty lock file) yields
+/// `None` rather than an error, because this is diagnostic-only.
+fn read_holder(path: &Path) -> Option<LockHolder> {
+    let mut raw = String::new();
+    File::open(path).ok()?.read_to_string(&mut raw).ok()?;
+    serde_json::from_str(&raw).ok()
+}
+
+fn holder_suffix(path: &Path) -> String {
+    match read_holder(path) {
+        Some(holder) => format!(
+            " (held by pid {} since {}, op: {})",
+            holder.pid, holder.acquired_at, holder.label
+        ),
+        None => String::new(),
+    }
+}
+
+fn holder_description(path: &Path) -> String {
+    match read_holder(path) {
+        Some(holder) => format!(
+            "pid {} since {} ({})",
+            holder.pid, holder.acquired_at, holder.label
+        ),
+        None => "unknown".to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/orbit-store/src/file_lock/tests/file_lock.rs
+++ b/crates/orbit-store/src/file_lock/tests/file_lock.rs
@@ -1,0 +1,228 @@
+use std::collections::BTreeMap;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use tempfile::TempDir;
+use tracing::field::{Field, Visit};
+use tracing::span;
+use tracing::{Event, Metadata, Subscriber};
+
+use super::super::{FileLockGuard, LockOptions, acquire_exclusive, acquire_exclusive_with};
+
+/// Exact libtest name of the ignored helper below, re-exec'd as a child process
+/// by [`sigkilled_holder_releases_lock`]. Keep in sync with the module path.
+#[cfg(unix)]
+const CRASH_CHILD_TEST: &str = "file_lock::tests::file_lock::crash_holder_child";
+
+fn short_options(timeout_ms: u64) -> LockOptions {
+    LockOptions {
+        timeout: Duration::from_millis(timeout_ms),
+        // Push the warn threshold out of the way unless a test wants it.
+        warn_after: Duration::from_secs(3600),
+    }
+}
+
+#[test]
+fn acquire_release_then_reacquire() {
+    let dir = TempDir::new().expect("tempdir");
+    let path = dir.path().join("state").join("x.lock");
+
+    {
+        let _guard: FileLockGuard = acquire_exclusive(&path, "first").expect("first acquire");
+    } // guard dropped here -> flock released
+
+    // Parent dirs were created by the first acquisition; a second one succeeds.
+    let _guard = acquire_exclusive(&path, "second").expect("second acquire after release");
+}
+
+#[test]
+fn times_out_naming_lock_path_and_holder() {
+    let dir = TempDir::new().expect("tempdir");
+    let path = dir.path().join("a.lock");
+
+    let _held = acquire_exclusive(&path, "holder").expect("hold lock");
+
+    // A second independent descriptor conflicts even within one process
+    // (flock(2) treats separate opens independently), so this must time out.
+    let error = acquire_exclusive_with(&path, "waiter", short_options(150))
+        .expect_err("acquisition should time out while the lock is held");
+    let message = error.to_string();
+
+    assert!(
+        message.contains("a.lock"),
+        "timeout error must name the lock path: {message}"
+    );
+    assert!(
+        message.contains(&format!("pid {}", std::process::id())),
+        "timeout error must name the holder pid: {message}"
+    );
+    assert!(
+        message.contains("op: holder"),
+        "timeout error must carry the holder's operation label: {message}"
+    );
+}
+
+#[test]
+fn blocked_waiter_emits_warning_with_holder_metadata() {
+    let dir = TempDir::new().expect("tempdir");
+    let path = dir.path().join("b.lock");
+
+    let _held = acquire_exclusive(&path, "holder").expect("hold lock");
+
+    let events = Arc::new(Mutex::new(Vec::new()));
+    let subscriber = CaptureSubscriber {
+        events: Arc::clone(&events),
+    };
+    let dispatch = tracing::Dispatch::new(subscriber);
+
+    let options = LockOptions {
+        timeout: Duration::from_millis(400),
+        warn_after: Duration::from_millis(20),
+    };
+    let result = tracing::dispatcher::with_default(&dispatch, || {
+        acquire_exclusive_with(&path, "waiter", options)
+    });
+    assert!(result.is_err(), "held lock should still time out");
+
+    let events = events.lock().expect("events lock");
+    let warned = events.iter().any(|fields| {
+        fields.get("label").map(String::as_str) == Some("waiter")
+            && fields
+                .get("holder")
+                .is_some_and(|holder| holder.contains(&format!("pid {}", std::process::id())))
+            && fields.contains_key("waited_ms")
+    });
+    assert!(
+        warned,
+        "expected a warn event naming the waiter and holder metadata; captured={events:?}"
+    );
+}
+
+/// Crash semantics: the OS releases advisory (`flock`) locks when a holder
+/// process dies, so a hung/crashed holder never wedges the workspace forever.
+/// A child process takes the lock, we SIGKILL it, and a subsequent acquisition
+/// by the parent must succeed. Documents the assumption the timeout targets the
+/// *hung* (not crashed) holder.
+#[cfg(unix)]
+#[test]
+fn sigkilled_holder_releases_lock() {
+    let dir = TempDir::new().expect("tempdir");
+    let lock_path = dir.path().join("crash.lock");
+    let ready_path = dir.path().join("ready");
+
+    let exe = std::env::current_exe().expect("current test exe");
+    let mut child = std::process::Command::new(exe)
+        .args(["--exact", CRASH_CHILD_TEST, "--ignored"])
+        .env("ORBIT_FILE_LOCK_CRASH_LOCK", &lock_path)
+        .env("ORBIT_FILE_LOCK_CRASH_READY", &ready_path)
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .spawn()
+        .expect("spawn lock-holder child");
+
+    // Wait for the child to signal it holds the lock.
+    let start = std::time::Instant::now();
+    while !ready_path.exists() {
+        if start.elapsed() > Duration::from_secs(20) {
+            let _ = child.kill();
+            let _ = child.wait();
+            panic!("child never acquired the lock");
+        }
+        std::thread::sleep(Duration::from_millis(20));
+    }
+
+    // While the child holds it, the parent cannot acquire within a short budget.
+    let held = acquire_exclusive_with(&lock_path, "parent-probe", short_options(200));
+    assert!(held.is_err(), "lock should be held by the live child");
+
+    // Crash the holder: Child::kill() sends SIGKILL on Unix.
+    child.kill().expect("SIGKILL child");
+    child.wait().expect("reap child");
+
+    // The advisory lock is released on process death: acquisition now succeeds.
+    let guard = acquire_exclusive_with(
+        &lock_path,
+        "parent-after-crash",
+        LockOptions {
+            timeout: Duration::from_secs(10),
+            warn_after: Duration::from_secs(3600),
+        },
+    );
+    assert!(
+        guard.is_ok(),
+        "lock not released after holder was SIGKILLed: {:?}",
+        guard.err()
+    );
+}
+
+/// Re-exec'd as a child process by [`sigkilled_holder_releases_lock`]. Ignored
+/// so it never runs on its own; when invoked with the crash env vars it takes
+/// the lock, signals readiness via a sentinel file, and blocks until killed.
+#[cfg(unix)]
+#[test]
+#[ignore = "helper process for sigkilled_holder_releases_lock; re-exec'd, not run directly"]
+fn crash_holder_child() {
+    let (Ok(lock_path), Ok(ready_path)) = (
+        std::env::var("ORBIT_FILE_LOCK_CRASH_LOCK"),
+        std::env::var("ORBIT_FILE_LOCK_CRASH_READY"),
+    ) else {
+        return;
+    };
+
+    let _guard =
+        acquire_exclusive(std::path::Path::new(&lock_path), "crash-holder").expect("child acquire");
+    std::fs::write(&ready_path, b"ready").expect("write ready sentinel");
+    // Hold the lock until the parent SIGKILLs us.
+    std::thread::sleep(Duration::from_secs(60));
+}
+
+/// Minimal tracing subscriber that records each event's fields into a shared
+/// vector, so a test can assert on emitted warnings. Mirrors the capture
+/// pattern in `orbit-engine`'s cli_runner tests.
+struct CaptureSubscriber {
+    events: Arc<Mutex<Vec<BTreeMap<String, String>>>>,
+}
+
+impl Subscriber for CaptureSubscriber {
+    fn enabled(&self, _metadata: &Metadata<'_>) -> bool {
+        true
+    }
+
+    fn new_span(&self, _span: &span::Attributes<'_>) -> span::Id {
+        span::Id::from_u64(1)
+    }
+
+    fn record(&self, _span: &span::Id, _values: &span::Record<'_>) {}
+
+    fn record_follows_from(&self, _span: &span::Id, _follows: &span::Id) {}
+
+    fn event(&self, event: &Event<'_>) {
+        let mut visitor = FieldCapture::default();
+        event.record(&mut visitor);
+        self.events
+            .lock()
+            .expect("events lock")
+            .push(visitor.fields);
+    }
+
+    fn enter(&self, _span: &span::Id) {}
+
+    fn exit(&self, _span: &span::Id) {}
+}
+
+#[derive(Default)]
+struct FieldCapture {
+    fields: BTreeMap<String, String>,
+}
+
+impl Visit for FieldCapture {
+    fn record_str(&mut self, field: &Field, value: &str) {
+        self.fields
+            .insert(field.name().to_string(), value.to_string());
+    }
+
+    fn record_debug(&mut self, field: &Field, value: &dyn std::fmt::Debug) {
+        self.fields
+            .insert(field.name().to_string(), format!("{value:?}"));
+    }
+}

--- a/crates/orbit-store/src/file_lock/tests/mod.rs
+++ b/crates/orbit-store/src/file_lock/tests/mod.rs
@@ -1,0 +1,1 @@
+mod file_lock;

--- a/crates/orbit-store/src/lib.rs
+++ b/crates/orbit-store/src/lib.rs
@@ -35,6 +35,7 @@
 
 pub(crate) mod backend;
 mod file;
+pub(crate) mod file_lock;
 pub(crate) mod json_schema;
 pub(crate) mod scope;
 pub mod sqlite;

--- a/crates/orbit-store/src/sqlite/id_allocator/mod.rs
+++ b/crates/orbit-store/src/sqlite/id_allocator/mod.rs
@@ -1,10 +1,9 @@
 use std::collections::BTreeMap;
-use std::fs::{self, File, OpenOptions};
+use std::fs;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 
 use chrono::{DateTime, Utc};
-use fs2::FileExt;
 use orbit_common::types::OrbitError;
 use orbit_common::utility::fs::atomic_write_text;
 use orbit_common::utility::git::{CurrentBranchStatus, current_branch};
@@ -551,28 +550,11 @@ impl IdAllocator {
         Ok(records)
     }
 
-    fn acquire_lock(&self) -> Result<File, OrbitError> {
-        let parent = self.inner.lock_path.parent().ok_or_else(|| {
-            OrbitError::Store(format!(
-                "cannot determine id allocation lock parent for '{}'",
-                self.inner.lock_path.display()
-            ))
-        })?;
-        fs::create_dir_all(parent).map_err(|error| OrbitError::Io(error.to_string()))?;
-        let file = OpenOptions::new()
-            .create(true)
-            .truncate(false)
-            .read(true)
-            .write(true)
-            .open(&self.inner.lock_path)
-            .map_err(|error| OrbitError::Io(error.to_string()))?;
-        file.lock_exclusive().map_err(|error| {
-            OrbitError::Store(format!(
-                "failed to acquire id allocation lock '{}': {error}",
-                self.inner.lock_path.display()
-            ))
-        })?;
-        Ok(file)
+    /// Acquire the process-wide ID-allocation lock. [ORB-00412] Bounded by a
+    /// deadline with holder diagnostics via [`crate::file_lock`] — a hung
+    /// holder no longer stalls every other allocator forever.
+    fn acquire_lock(&self) -> Result<crate::file_lock::FileLockGuard, OrbitError> {
+        crate::file_lock::acquire_exclusive(&self.inner.lock_path, "id allocation")
     }
 
     fn lock_conn(&self) -> Result<std::sync::MutexGuard<'_, Connection>, OrbitError> {

--- a/crates/orbit-store/src/sqlite/id_allocator/mod.rs
+++ b/crates/orbit-store/src/sqlite/id_allocator/mod.rs
@@ -198,6 +198,12 @@ impl IdAllocator {
         self.abandon(IdAllocationKind::Learning, id)
     }
 
+    /// [ORB-00413] Abandon a reserved-but-unfinalized ADR allocation so a
+    /// partial ADR create does not leak a half-visible ID.
+    pub fn abandon_adr(&self, id: &str) -> Result<(), OrbitError> {
+        self.abandon(IdAllocationKind::Adr, id)
+    }
+
     pub fn adr_allocation(&self, id: &str) -> Result<Option<IdAllocationRecord>, OrbitError> {
         self.allocation(IdAllocationKind::Adr, id)
     }

--- a/crates/orbit-tools/src/builtin/fs/mod.rs
+++ b/crates/orbit-tools/src/builtin/fs/mod.rs
@@ -144,13 +144,20 @@ fn enforce_fs_policy(
     let Some(policy_engine) = ctx.policy_engine.as_ref() else {
         return Ok(None);
     };
+    let workspace_root = ctx.workspace_root.as_ref().ok_or_else(|| {
+        OrbitError::PolicyDenied("workspace_root is not set; filesystem access denied".to_string())
+    })?;
 
-    let path = workspace_relative_path(ctx, canonical_path)?;
-    let evaluation = policy_engine.check(profile.to_string(), op, path.clone())?;
+    // [ORB-00418] Route through the policy engine's symlink-safe evaluation so
+    // resolution is enforced by the security-critical layer itself, not just by
+    // this caller's earlier canonicalization. `canonical_path` is already
+    // resolved, so re-resolution here is idempotent.
+    let evaluation =
+        policy_engine.check_resolved(workspace_root, profile.to_string(), op, canonical_path)?;
     let allowance = FsPolicyAllowance {
         profile: evaluation.profile,
         op: evaluation.operation,
-        path,
+        path: evaluation.path,
         matched_rule: evaluation.matched_rule,
     };
 
@@ -195,26 +202,4 @@ fn emit_fs_event(
         allowed,
         matched_rule: allowance.matched_rule.clone(),
     })
-}
-
-fn workspace_relative_path(ctx: &ToolContext, canonical_path: &Path) -> Result<String, OrbitError> {
-    let workspace_root = ctx.workspace_root.as_ref().ok_or_else(|| {
-        OrbitError::PolicyDenied("workspace_root is not set; filesystem access denied".to_string())
-    })?;
-    let canonical_root = workspace_root
-        .canonicalize()
-        .unwrap_or_else(|_| workspace_root.clone());
-    let relative = canonical_path.strip_prefix(&canonical_root).map_err(|_| {
-        OrbitError::PolicyDenied(format!(
-            "path is outside workspace: {}",
-            canonical_path.display()
-        ))
-    })?;
-
-    let rendered = relative.to_string_lossy().replace('\\', "/");
-    if rendered.is_empty() {
-        Ok(".".to_string())
-    } else {
-        Ok(format!("./{rendered}"))
-    }
 }

--- a/crates/orbit-tools/src/builtin/fs/mod.rs
+++ b/crates/orbit-tools/src/builtin/fs/mod.rs
@@ -33,10 +33,13 @@ mod tests;
 
 /// Checks that `path` resolves inside the context workspace root.
 ///
-/// Symlink escapes are blocked because the path is canonicalized before the check.
-/// For paths that do not yet exist (e.g. `fs.write` creating a new file), the
-/// nearest existing ancestor is canonicalized and the remaining components are
-/// appended before the check.
+/// Symlink escapes are blocked because the path is resolved via
+/// [`orbit_policy::resolve_symlinks`] before the check — the same resolver the
+/// policy engine uses ([ORB-00418]), so the two layers cannot drift. It follows
+/// dangling links (an `O_CREAT` open through one creates the link's *target*)
+/// and, for paths that do not yet exist (e.g. `fs.write` creating a new file),
+/// canonicalizes the nearest existing ancestor and appends the remaining
+/// components before the check.
 ///
 /// Returns `Err(PolicyDenied)` when no workspace root is set (fail-closed) or
 /// when the canonical path is outside the root. Returns `Ok` only when the
@@ -54,7 +57,7 @@ pub(crate) fn check_workspace_boundary(
         }
     };
 
-    let canonical = canonicalize_with_missing_tail(path)?;
+    let canonical = orbit_policy::resolve_symlinks(path)?;
 
     // Canonicalize the workspace root so symlinks (e.g. /var -> /private/var on
     // macOS) don't cause false negatives when comparing against the canonical path.
@@ -69,34 +72,6 @@ pub(crate) fn check_workspace_boundary(
         )));
     }
 
-    Ok(canonical)
-}
-
-fn canonicalize_with_missing_tail(path: &Path) -> Result<PathBuf, OrbitError> {
-    if path.exists() {
-        return path
-            .canonicalize()
-            .map_err(|e| OrbitError::Io(format!("failed to canonicalize path: {e}")));
-    }
-
-    let mut missing_components = Vec::new();
-    let mut existing_ancestor = path;
-    while !existing_ancestor.exists() {
-        let name = existing_ancestor
-            .file_name()
-            .ok_or_else(|| OrbitError::InvalidInput("path has no file name".to_string()))?;
-        missing_components.push(name.to_os_string());
-        existing_ancestor = existing_ancestor.parent().ok_or_else(|| {
-            OrbitError::InvalidInput("path has no existing parent directory".to_string())
-        })?;
-    }
-
-    let mut canonical = existing_ancestor
-        .canonicalize()
-        .map_err(|e| OrbitError::Io(format!("failed to canonicalize parent directory: {e}")))?;
-    for component in missing_components.iter().rev() {
-        canonical.push(component);
-    }
     Ok(canonical)
 }
 

--- a/crates/orbit-tools/src/builtin/fs/tests/boundary.rs
+++ b/crates/orbit-tools/src/builtin/fs/tests/boundary.rs
@@ -1,0 +1,73 @@
+//! Tests for `check_workspace_boundary` (defined in `fs/mod.rs`): the
+//! resolve-then-compare workspace containment gate every fs tool runs before
+//! policy evaluation. [ORB-00418]
+
+use orbit_common::types::OrbitError;
+
+use crate::ToolContext;
+
+use super::super::check_workspace_boundary;
+
+fn ctx_with_root(root: &std::path::Path) -> ToolContext {
+    ToolContext {
+        workspace_root: Some(root.to_path_buf()),
+        ..ToolContext::default()
+    }
+}
+
+#[cfg(unix)]
+#[test]
+fn boundary_denies_symlink_escaping_workspace() {
+    use std::os::unix::fs::symlink;
+
+    let outside = tempfile::tempdir().expect("outside");
+    std::fs::write(outside.path().join("target.txt"), b"x").expect("outside file");
+    let workspace = tempfile::tempdir().expect("workspace");
+    symlink(
+        outside.path().join("target.txt"),
+        workspace.path().join("link"),
+    )
+    .expect("symlink");
+
+    let error = check_workspace_boundary(
+        &ctx_with_root(workspace.path()),
+        &workspace.path().join("link"),
+    )
+    .expect_err("symlink pointing outside the workspace must be denied");
+    assert!(matches!(error, OrbitError::PolicyDenied(_)), "{error:?}");
+}
+
+#[cfg(unix)]
+#[test]
+fn boundary_denies_dangling_symlink_escaping_workspace() {
+    use std::os::unix::fs::symlink;
+
+    let outside = tempfile::tempdir().expect("outside");
+    let workspace = tempfile::tempdir().expect("workspace");
+    // Dangling link: target does not exist, but an O_CREAT open through the
+    // link (fs::write / File::create) would create it *outside* the workspace.
+    symlink(
+        outside.path().join("planted.txt"),
+        workspace.path().join("link"),
+    )
+    .expect("symlink");
+
+    let error = check_workspace_boundary(
+        &ctx_with_root(workspace.path()),
+        &workspace.path().join("link"),
+    )
+    .expect_err("dangling symlink pointing outside the workspace must be denied");
+    assert!(matches!(error, OrbitError::PolicyDenied(_)), "{error:?}");
+}
+
+#[test]
+fn boundary_allows_missing_tail_inside_workspace() {
+    let workspace = tempfile::tempdir().expect("workspace");
+
+    let canonical = check_workspace_boundary(
+        &ctx_with_root(workspace.path()),
+        &workspace.path().join("new_dir/new_file.txt"),
+    )
+    .expect("a not-yet-existing in-workspace target must pass");
+    assert!(canonical.ends_with("new_dir/new_file.txt"));
+}

--- a/crates/orbit-tools/src/builtin/fs/tests/mod.rs
+++ b/crates/orbit-tools/src/builtin/fs/tests/mod.rs
@@ -1,1 +1,2 @@
+mod boundary;
 mod read;

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,68 @@
+# cargo-deny configuration — supply-chain CI gate (advisories + licenses).
+# [ORB-00416]
+#
+# Run locally with `make audit` (or `cargo deny check`). CI runs it on every PR
+# via scripts/ci-guardrails.sh with a pinned cargo-deny version. This file is
+# NOT consulted by `make ci-fast` (which stays no-compile).
+#
+# Adding an advisory exception or a new license requires review — see the
+# "Supply-chain" section of CONTRIBUTING.md for the process (justification +
+# expiry).
+
+[advisories]
+# Deny crates with an open RUSTSEC advisory (the default) and yanked crates.
+# Time-boxed exceptions live in `ignore` with a rationale; see CONTRIBUTING.md.
+# Each entry below has no available safe upgrade at time of writing and is
+# tagged with a re-review date — drop it once an upstream fix lands.
+yanked = "deny"
+ignore = [
+    # git2 / libgit2 unsoundness in `Remote::list()` and blame `Signature`.
+    # No fixed release yet; orbit invokes git2 only against local, trusted
+    # repositories (branch/status/worktree ops), not attacker-controlled remotes
+    # via these APIs. Re-review by 2027-01-04.
+    { id = "RUSTSEC-2026-0183", reason = "libgit2 Remote::list UB; no fix released; local trusted repos only. Re-review 2027-01-04." },
+    { id = "RUSTSEC-2026-0184", reason = "git2 BlameHunk Signature UB; no fix released; local trusted repos only. Re-review 2027-01-04." },
+    # `paste` is unmaintained (not a vulnerability), pulled transitively via
+    # tokenizers -> fastembed (embeddings). No maintained drop-in; low risk.
+    # Re-review by 2027-01-04.
+    { id = "RUSTSEC-2024-0436", reason = "paste unmaintained; transitive via fastembed/tokenizers; no vuln. Re-review 2027-01-04." },
+    # rsa Marvin timing sidechannel. No constant-time release yet. Reachable
+    # only via local embedding/search paths where request timing is not
+    # network-observable. Re-review by 2027-01-04.
+    { id = "RUSTSEC-2023-0071", reason = "rsa Marvin timing sidechannel; no fixed release; local non-network-observable use. Re-review 2027-01-04." },
+]
+
+[licenses]
+# Allow-list of licenses observed in the current dependency tree. Every entry
+# is an OSI-approved permissive or public-domain-equivalent license. New
+# entries require review.
+allow = [
+    "MIT",
+    "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "ISC",
+    "Zlib",              # foldhash
+    "Unicode-3.0",       # icu_* / unicode-ident
+    "CC0-1.0",           # notify (public-domain dedication)
+    # Weak/file-level copyleft — acceptable because we consume these crates
+    # unmodified and do not redistribute modified sources. Deliberate policy
+    # decisions; flag in review if the set grows.
+    "MPL-2.0",           # colored, option-ext
+    "CDLA-Permissive-2.0", # webpki-roots, webpki-root-certs
+]
+# Crates offering "<copyleft> OR <permissive>" (ryu, r-efi, the BurntSushi
+# Unlicense-OR-MIT crates) resolve to an allowed branch and need no entry.
+confidence-threshold = 0.9
+
+[bans]
+# Start permissive: duplicate versions and wildcard deps are not gated here.
+multiple-versions = "allow"
+wildcards = "allow"
+
+[sources]
+# Only crates.io (and any explicitly-allowed registries/git sources) are
+# permitted; an unknown source fails closed.
+unknown-registry = "deny"
+unknown-git = "deny"

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -128,7 +128,7 @@ Use `[duel]` to constrain which CLIs Orbit will spawn — e.g. drop `grok` from 
 | `[scoring]` | `enabled = true` records per-agent scoreboard counters under `.orbit/state/scoreboard/`. |
 | `[graph]` | `editing = false` (default) makes the knowledge graph read-only from agent tools; flip to `true` to allow `orbit.graph.*` mutations. |
 | `[pr]` | PR creation defaults (template, labels, draft mode) for `orbit run ship --mode pr`. |
-| `[runtime]` | `backend = "cli" \| "http" \| "auto"` selects the activity-job dispatcher backend for v2 `agent_loop` activities. |
+| `[runtime]` | `backend = "cli" \| "http" \| "auto"` selects the activity-job dispatcher backend for v2 `agent_loop` activities. **JSONL log rotation/retention** (`~/.orbit/state/logs/orbit.jsonl`): `log_retention_days` (default `7`) deletes archives older than N days; `log_max_total_mb` (default `500`) caps total archive size, pruning oldest first; `log_max_file_mb` (default `100`) rolls the active file to a dated archive once it exceeds N MiB. Rotation runs opportunistically at process start. Invalid values (`0`, or `log_max_file_mb > log_max_total_mb`) are rejected at config load. |
 
 ---
 

--- a/scripts/check-artifact-redaction-guardrail.sh
+++ b/scripts/check-artifact-redaction-guardrail.sh
@@ -15,6 +15,14 @@ targets=(
   "crates/orbit-tools/src/builtin/orbit/task"
   "crates/orbit-tools/src/builtin/orbit/review_thread"
   "crates/orbit-tools/src/builtin/orbit/friction"
+  # [ORB-00417] Write-time redaction paths: task creation (dashboard + core
+  # choke point) and provider CLI argv. Redaction must flow through
+  # orbit_common::utility::redaction (redact_all / with_argv_secrets), never a
+  # surface-local helper here.
+  "crates/orbit-core/src/command/task/add.rs"
+  "crates/orbit-dashboard/src/api/tasks.rs"
+  "crates/orbit-engine/src/activity_job/cli_runner/orchestrator.rs"
+  "crates/orbit-engine/src/activity_job/cli_runner/argv.rs"
 )
 
 if rg -n 'fn\s+redact_' "${targets[@]}"; then

--- a/scripts/ci-guardrails.sh
+++ b/scripts/ci-guardrails.sh
@@ -16,6 +16,14 @@ else
 fi
 cargo test --workspace --doc
 RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --workspace
+# Supply-chain gate: dependency advisories + license allow-list (deny.toml).
+# [ORB-00416] Soft-presence like nextest above — CI installs a pinned version;
+# local runs without the tool warn instead of hard-failing.
+if command -v cargo-deny >/dev/null 2>&1; then
+  cargo deny check
+else
+  echo "cargo-deny not found; skipping supply-chain gate (install: cargo install cargo-deny --locked)" >&2
+fi
 "$repo_root/scripts/check-installer-pubkey.sh"
 "$repo_root/scripts/test-installer-security.sh"
 "$repo_root/scripts/check-dependency-direction.sh"


### PR DESCRIPTION
Seven high/critical production-readiness hardening tasks, one commit each. Each commit is self-contained with tests; the whole branch `cargo check --workspace --all-targets` and `make ci-fast` clean.

| Task | Area | What |
|---|---|---|
| **ORB-00412** | store | Bounded file-lock acquisition (timeout + holder PID/timestamp diagnostics + warn) replacing three bare `fs2::lock_exclusive()` sites; RAII guard; SIGKILL crash-release test. |
| **ORB-00413** | store | Atomic learning/ADR creation — rollback the SQLite reservation + remove staged body on any partial-write failure; `reconcile_learning_orphans` surfaced via `orbit learning sync`. |
| **ORB-00414** | engine | Propagate audit-write failures instead of `let _ =` (~20 sites): per-run failure counter + `tracing::error!`, `degraded_audit` on `JobOutcome`, `EnvelopeSink` trait for injectable failing sink. Non-fatal to runs. |
| **ORB-00415** | logging | Rotation + retention for `~/.orbit/state/logs/orbit.jsonl` — size-triggered roll to dated archives (fixed active path preserved for readers), age + total-size prune, configurable via `[runtime]`, strict validation at config load. |
| **ORB-00416** | ci | `cargo-deny` (advisories + licenses) as a CI gate: `deny.toml`, wired into `ci-guardrails.sh` + pinned install in `ci.yml`, Makefile `audit` retargeted, exception process in CONTRIBUTING.md. Four no-safe-upgrade advisories carry dated ignores. |
| **ORB-00417** | security | Write-time secret redaction: task title/description/plan/acceptance at the `add_task_with_identity` choke point; `redact_all_error` at the error persistence boundary; argv regression test; guardrail extended. |
| **ORB-00418** | policy (**critical**) | Symlink canonicalization in `PolicyEngine::check_resolved` — rules match the resolved real path (Linux has no sandbox); orbit-tools routed through it; SECURITY.md documents per-platform enforcement + TOCTOU. |

## Verification
- Per-crate tests pass: `orbit-store`, `orbit-engine`, `orbit-policy`, `orbit-tools`, `orbit-core`, `orbit-dashboard`, plus new `orbit-common` rotation/redaction tests.
- `cargo deny check` passes locally against the committed `deny.toml`.
- `cargo check --workspace --all-targets` and `make ci-fast` are clean.

> Note: the pre-existing `orbit-common` test `redact_all_scrubs_provider_scm_cloud_tokens_and_connection_passwords` fails only on hosts where a sensitive-named env var value collides with the fixture (env-value redaction over-matches); it is green in CI's clean env and is unrelated to this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)