### PR TITLE
[ORB-10021] Routines v1: durable cron scheduler — sweep pass, routine store, CLI, clock units

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -193,6 +193,16 @@ jobs:
           fi
           cargo deny --version
 
+      # The guardrail scripts shell out to ripgrep; the ubuntu-latest runner
+      # image no longer ships it, and a missing `rg` makes
+      # check-error-translation.sh read empty search results as "translator
+      # missing" (false failures on every crate). [ORB-10021]
+      - name: Install ripgrep
+        run: |
+          set -euo pipefail
+          command -v rg >/dev/null 2>&1 || sudo apt-get install -y --no-install-recommends ripgrep
+          rg --version | head -1
+
       - name: Run CI guardrails
         run: ./scripts/ci-guardrails.sh
 

--- a/.orbit/adrs/accepted/ADR-0204/adr.yaml
+++ b/.orbit/adrs/accepted/ADR-0204/adr.yaml
@@ -1,0 +1,22 @@
+schema_version: 2
+id: ADR-0204
+title: 'The OS owns the clock: stateless orbit sweep under launchd/systemd, no resident daemon'
+status: accepted
+owner: claude
+created_at: 2026-07-04T20:45:39.976734042Z
+accepted_at: 2026-07-04T21:14:40.327750229Z
+last_updated: 2026-07-04T21:14:40.327750229Z
+related_features:
+- routines
+related_tasks:
+- ORB-10021
+tags:
+- routines
+- scheduler
+paths:
+- docs/design/routines/**
+- crates/orbit-core/src/routines/**
+supersedes: []
+legacy_ids: []
+validation_warnings: []
+legacy_validation: none

--- a/.orbit/adrs/accepted/ADR-0204/body.md
+++ b/.orbit/adrs/accepted/ADR-0204/body.md
@@ -1,0 +1,13 @@
+## Context
+
+Something must wake the scheduler. Alternatives: a resident `orbit schedulerd` owning timers in-process (sub-minute precision, event triggers, but a daemon to supervise on two platforms), or delegating wake-ups to the OS schedulers that already exist (launchd on macOS, systemd timers on Linux) invoking a stateless pass every minute.
+
+## Decision
+
+launchd (`StartInterval` 60s) and a systemd timer (`OnCalendar=*:*:00`, `Persistent=true`) invoke `orbit sweep` every minute; sweep is stateless-in, durable-out. Missed-fire semantics split between the OS layer (wake/persistence behavior) and per-routine `missed_run` policy. There is no resident Orbit daemon.
+
+## Consequences
+
+- No process supervision, crash recovery, or memory-leak surface; a wedged pass affects one minute, not the scheduler.
+- launchd wake behavior and `Persistent=true` pair with `missed_run: catch_up_once` to cover laptop sleep and host downtime.
+- Cost: minute granularity is a hard floor and event triggers are structurally impossible in v1; correct behavior depends on two platform-specific unit files that must be kept in parity and tested on both platforms.

--- a/.orbit/adrs/accepted/ADR-0205/adr.yaml
+++ b/.orbit/adrs/accepted/ADR-0205/adr.yaml
@@ -1,0 +1,22 @@
+schema_version: 2
+id: ADR-0205
+title: Routine discovery via the workspace registry and a versioned [routines] role=source config key
+status: accepted
+owner: claude
+created_at: 2026-07-04T20:45:39.980175730Z
+accepted_at: 2026-07-04T21:14:40.332406107Z
+last_updated: 2026-07-04T21:14:40.332406107Z
+related_features:
+- routines
+related_tasks:
+- ORB-10021
+tags:
+- routines
+- scheduler
+paths:
+- docs/design/routines/**
+- crates/orbit-core/src/routines/**
+supersedes: []
+legacy_ids: []
+validation_warnings: []
+legacy_validation: none

--- a/.orbit/adrs/accepted/ADR-0205/body.md
+++ b/.orbit/adrs/accepted/ADR-0205/body.md
@@ -1,0 +1,13 @@
+## Context
+
+Sweep must find routine definitions without a resident daemon and without bootstrapping from the caller's cwd. Alternatives: a host-level pointer file in `~/.orbit/host.toml` naming one designated control workspace per host (explicit two-way handshake), or reusing the global workspace registry the way `orbit run ship-sweep` / `auto_ship` already does for unattended cross-workspace dispatch.
+
+## Decision
+
+Sweep enumerates `~/.orbit/workspaces.json` and collects `.orbit/routines/*.yaml` from every registered, active workspace whose versioned `.orbit/config.toml` declares `[routines] role = "source"`. Centralizing all routines in polaris is constellation convention, not Orbit mechanism. `~/.orbit/host.toml` survives only to carry `host_id`.
+
+## Consequences
+
+- Setup is what already exists: register the workspace plus one versioned config key; both hosts converge through git with no per-host pointer files.
+- `orbit routine list` names each routine's source workspace, so provenance stays unambiguous with multiple sources.
+- Cost: any registered workspace's config can make it a routine source — the review boundary widens from one blessed repo to every registered workspace's `config.toml`, and sweep correctness now depends on registry hygiene (stale registered paths must be skipped loudly, not silently).

--- a/.orbit/adrs/accepted/ADR-0206/adr.yaml
+++ b/.orbit/adrs/accepted/ADR-0206/adr.yaml
@@ -1,0 +1,22 @@
+schema_version: 2
+id: ADR-0206
+title: Routine targets are catalog references only — no inline command payloads
+status: accepted
+owner: claude
+created_at: 2026-07-04T20:45:39.982204305Z
+accepted_at: 2026-07-04T21:14:40.329169342Z
+last_updated: 2026-07-04T21:21:16.626359502Z
+related_features:
+- routines
+related_tasks:
+- ORB-10021
+tags:
+- routines
+- scheduler
+paths:
+- docs/design/routines/**
+- crates/orbit-core/src/routines/**
+supersedes: []
+legacy_ids: []
+validation_warnings: []
+legacy_validation: none

--- a/.orbit/adrs/accepted/ADR-0206/body.md
+++ b/.orbit/adrs/accepted/ADR-0206/body.md
@@ -1,0 +1,13 @@
+## Context
+
+The original sketch allowed a `run: {type: shell, command: ...}` payload for small chores. ADR-0194 removed the `shell` activity variant and `run_shell` dispatch fail-closed; reintroducing arbitrary-command payloads through the scheduler would reopen that surface on a timer, unattended.
+
+## Decision
+
+`target:` accepts only catalog references resolved at load time; unresolvable targets are load-time errors. v1 dispatches `job:<name>` — run dispatch is job-shaped (`submit_pipeline_run` resolves jobs by name; there is no standalone activity run entrypoint), so `activity:<name>` is reserved and rejected at parse time with guidance to wrap the activity in a one-step job in the same source workspace. Shell-like chores become `deterministic` activities or jobs in the source workspace.
+
+## Consequences
+
+- Scheduled execution inherits existing activity/job policy, audit envelopes, and the fail-closed posture of ADR-0194; the scheduler adds a trigger source, not a new execution surface.
+- Load-time validation makes a broken reference visible on the next sweep instead of at fire time.
+- Cost: every new chore requires authoring a catalog asset (higher friction than a one-line command), and scheduler capability is permanently coupled to catalog capability — including the job-shaped dispatch constraint that keeps `activity:` targets out of v1.

--- a/.orbit/adrs/accepted/ADR-0207/adr.yaml
+++ b/.orbit/adrs/accepted/ADR-0207/adr.yaml
@@ -1,0 +1,22 @@
+schema_version: 2
+id: ADR-0207
+title: Routines pin hosts explicitly; no cross-host coordination in v1
+status: accepted
+owner: claude
+created_at: 2026-07-04T20:45:39.984982883Z
+accepted_at: 2026-07-04T21:14:40.332307918Z
+last_updated: 2026-07-04T21:14:40.332307918Z
+related_features:
+- routines
+related_tasks:
+- ORB-10021
+tags:
+- routines
+- scheduler
+paths:
+- docs/design/routines/**
+- crates/orbit-core/src/routines/**
+supersedes: []
+legacy_ids: []
+validation_warnings: []
+legacy_validation: none

--- a/.orbit/adrs/accepted/ADR-0207/body.md
+++ b/.orbit/adrs/accepted/ADR-0207/body.md
@@ -1,0 +1,13 @@
+## Context
+
+Some recurring work should run on exactly one machine. A "run on exactly one of N hosts" mode needs a lease protocol between hosts that only expose SSH to each other; the alternative is explicit pinning, where the definition names every host it fires on.
+
+## Decision
+
+Each routine carries a `hosts:` list matched against the host-local `host_id`; there is no "any host" value in v1. Listing two hosts means two independent fires. Failover stays out of scope until a real routine needs it.
+
+## Consequences
+
+- Due computation stays purely host-local: no lease table, no network dependency, no split-brain modes to test.
+- The semantics are trivially predictable from the YAML alone.
+- Cost: no routine survives its pinned host being down, and adding leases later introduces a second, coordinated mode whose semantics diverge from everything shipped in v1.

--- a/.orbit/adrs/accepted/ADR-0208/adr.yaml
+++ b/.orbit/adrs/accepted/ADR-0208/adr.yaml
@@ -1,0 +1,22 @@
+schema_version: 2
+id: ADR-0208
+title: Routine definitions are git-shared; scheduler state is host-local and never synced
+status: accepted
+owner: claude
+created_at: 2026-07-04T20:45:39.988226599Z
+accepted_at: 2026-07-04T21:14:40.331256298Z
+last_updated: 2026-07-04T21:14:40.331256298Z
+related_features:
+- routines
+related_tasks:
+- ORB-10021
+tags:
+- routines
+- scheduler
+paths:
+- docs/design/routines/**
+- crates/orbit-core/src/routines/**
+supersedes: []
+legacy_ids: []
+validation_warnings: []
+legacy_validation: none

--- a/.orbit/adrs/accepted/ADR-0208/body.md
+++ b/.orbit/adrs/accepted/ADR-0208/body.md
@@ -1,0 +1,13 @@
+## Context
+
+Routines run on two hosts (dk-mac, dk-server-1) with different availability profiles. Definitions must converge across hosts; scheduler runtime state (last fires, pauses, locks) could either be synced between hosts or kept local. Syncing state would let either machine answer "did the nightly fire on the other box?" but requires a scheduler network protocol between hosts that only expose 22/443 to each other.
+
+## Decision
+
+Routine YAML definitions live in routine-source workspaces and converge via git like any other versioned definition. All scheduler state — fires (with idempotency keys), host-local pauses, and the sweep advisory lock — lives in a host-local SQLite routine store, gitignored and never synced. No scheduler network protocol exists in v1.
+
+## Consequences
+
+- Two hosts converge on definitions through a normal `git pull`; no new sync mechanism to build, secure, or debug.
+- State stays consistent with the run history it references, which is also host-local.
+- Cost: cross-host observability requires asking each host — there is no single pane of glass, and a definition edit is only as fresh on the other host as its last `git pull`.

--- a/.orbit/learnings/L-0070/learning.yaml
+++ b/.orbit/learnings/L-0070/learning.yaml
@@ -1,0 +1,19 @@
+schema_version: 1
+id: L-0070
+status: active
+scope:
+  paths:
+  - crates/orbit-core/src/routines/**
+  tags:
+  - routines
+  - scheduler
+  - croner
+summary: croner occurrences carry the sub-minute component of the probe timestamp; truncate to the minute before using them as identity keys (routines::due::truncate_to_minute)
+body: 'croner''s find_next_occurrence/find_previous_occurrence return timestamps whose seconds+nanoseconds are inherited from the DateTime you probe with, not zeroed to the cron slot. Two sweeps in the same minute therefore compute ''the same'' slot with different sub-second values. Anything using an occurrence as an identity key (the routine_fires (name, slot, attempt) idempotency key) or comparing occurrences against persisted cursors must minute-align first — routines::due::truncate_to_minute does this, and due_decision applies it before any comparison. Caught live in the ORB-10021 smoke test: the first fired slot was 21:18:00.785766897+00:00 and only overlap:forbid prevented a same-minute double fire.'
+evidence:
+- kind: task
+  reference: ORB-10021
+- kind: commit
+  reference: 12c14d63
+created_at: 2026-07-04T21:23:57.780601157Z
+updated_at: 2026-07-04T21:23:57.780601157Z

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -547,6 +547,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "croner"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4aa42bcd3d846ebf66e15bd528d1087f75d1c6c1c66ebff626178a106353c576"
+dependencies = [
+ "chrono",
+ "derive_builder",
+ "strum",
+]
+
+[[package]]
 name = "crossbeam-channel"
 version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1233,6 +1244,17 @@ name = "hmac-sha256"
 version = "1.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec9d92d097f4749b64e8cc33d924d9f40a2d4eb91402b458014b781f5733d60f"
+
+[[package]]
+name = "hostname"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "617aaa3557aef3810a6369d0a99fac8a080891b68bd9f9812a1eeda0c0730cbd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "windows-link",
+]
 
 [[package]]
 name = "http"
@@ -2247,7 +2269,9 @@ name = "orbit-core"
 version = "0.9.2"
 dependencies = [
  "chrono",
+ "croner",
  "fs2",
+ "hostname",
  "libc",
  "orbit-common",
  "orbit-engine",
@@ -3410,6 +3434,27 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "strum"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "subtle"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,9 +49,11 @@ assert_cmd = "2"
 axum = { version = "0.7", default-features = false, features = ["http1", "json", "query", "tokio"] }
 chrono = { version = "0.4", features = ["serde"] }
 clap = { version = "4.5", features = ["derive"] }
+croner = "3"
 fs2 = "0.4"
 futures-core = "0.3"
 git2 = { version = "0.20", default-features = false }
+hostname = "0.4"
 ignore = "0.4.25"
 notify = "8"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "signal", "net", "sync"] }

--- a/crates/orbit-cli/src/audit_middleware.rs
+++ b/crates/orbit-cli/src/audit_middleware.rs
@@ -638,6 +638,38 @@ pub fn extract_command_meta(cmd: &Commands) -> CommandMeta {
                 job_run_id: None,
             }
         }
+        // Normally dispatched before runtime init (see main.rs); metadata
+        // kept for completeness should they ever reach the audited path.
+        Commands::Sweep(_) => CommandMeta {
+            command: "sweep".to_string(),
+            subcommand: None,
+            tool_name: None,
+            target_type: Some("workflow".to_string()),
+            target_id: Some("sweep".to_string()),
+            role: "admin".to_string(),
+            arguments_json: None,
+            job_run_id: None,
+        },
+        Commands::Routine(cmd) => {
+            use crate::command::routine::RoutineSubcommand;
+            let sub = match &cmd.command {
+                RoutineSubcommand::List(_) => "list",
+                RoutineSubcommand::Show(_) => "show",
+                RoutineSubcommand::Pause(_) => "pause",
+                RoutineSubcommand::Resume(_) => "resume",
+                RoutineSubcommand::Init(_) => "init",
+            };
+            CommandMeta {
+                command: "routine".to_string(),
+                subcommand: Some(sub.to_string()),
+                tool_name: None,
+                target_type: Some("routine".to_string()),
+                target_id: None,
+                role: "admin".to_string(),
+                arguments_json: None,
+                job_run_id: None,
+            }
+        }
         Commands::Workspace(cmd) => {
             use crate::command::workspace::WorkspaceSubcommand;
             let sub = match &cmd.command {

--- a/crates/orbit-cli/src/command/mod.rs
+++ b/crates/orbit-cli/src/command/mod.rs
@@ -15,10 +15,12 @@ pub mod log;
 pub mod mcp;
 pub mod migrate;
 pub mod policy;
+pub mod routine;
 pub mod run;
 pub mod search;
 pub mod semantic;
 pub mod skill;
+pub mod sweep;
 pub mod task;
 pub mod tool;
 pub mod web;
@@ -58,6 +60,8 @@ Environment:
 
 Operate:
   run         Run a workflow (ship, duel-plan, job)
+  sweep       Fire due routines on this host (the scheduler pass)
+  routine     Inspect and control scheduled routines on this host
   task        Create, update, and manage tasks
   docs        Search and manage the indexed docs corpus
   adr         List and inspect Architecture Decision Records
@@ -106,6 +110,8 @@ pub enum Commands {
 
     // ── Operate ──
     Run(run::RunCommand),
+    Sweep(sweep::SweepCommand),
+    Routine(routine::RoutineCommand),
     Task(Box<task::TaskCommand>),
     Search(search::SearchCommand),
     Docs(docs::DocsCommand),
@@ -149,6 +155,11 @@ impl Execute for Commands {
             Commands::Semantic(cmd) => cmd.execute(runtime),
             Commands::Migrate(cmd) => cmd.execute(runtime),
             Commands::Run(cmd) => cmd.execute(runtime),
+            // Sweep and routine resolve everything from the global registry;
+            // they normally dispatch before runtime init (see main.rs) and
+            // never use the runtime even when reached through this path.
+            Commands::Sweep(cmd) => cmd.execute_without_runtime(),
+            Commands::Routine(cmd) => cmd.execute_without_runtime(),
             Commands::Task(cmd) => (*cmd).execute(runtime),
             Commands::Search(cmd) => cmd.execute(runtime),
             Commands::Docs(cmd) => cmd.execute(runtime),

--- a/crates/orbit-cli/src/command/routine/command.rs
+++ b/crates/orbit-cli/src/command/routine/command.rs
@@ -1,0 +1,62 @@
+//! `orbit routine` — inspect and control routines on this host [ORB-10021].
+//!
+//! Every subcommand operates on the global registry and host-local scheduler
+//! state, so the whole parent command dispatches without a workspace runtime
+//! (see `main.rs`), like `orbit sweep` itself.
+
+use clap::{Args, Subcommand};
+use orbit_core::OrbitError;
+
+use super::init::RoutineInitArgs;
+use super::list::RoutineListArgs;
+use super::pause::RoutinePauseArgs;
+use super::resume::RoutineResumeArgs;
+use super::show::RoutineShowArgs;
+
+#[derive(Args)]
+#[command(
+    about = "Inspect and control scheduled routines on this host",
+    arg_required_else_help = true,
+    subcommand_required = true,
+    after_help = "Routine definitions are versioned YAML under `.orbit/routines/` in\n\
+                  workspaces with `[routines] role = \"source\"`. Pauses are host-local\n\
+                  and never synced. The scheduler pass itself is `orbit sweep`."
+)]
+pub struct RoutineCommand {
+    #[command(subcommand)]
+    pub command: RoutineSubcommand,
+}
+
+impl RoutineCommand {
+    /// All routine subcommands resolve state from the global root; none may
+    /// bootstrap a workspace from the caller's cwd.
+    pub fn execute_without_runtime(self) -> Result<(), OrbitError> {
+        self.command.execute_without_runtime()
+    }
+}
+
+#[derive(Subcommand)]
+pub enum RoutineSubcommand {
+    /// List every routine with toggles, next-due, and last fire
+    List(RoutineListArgs),
+    /// Show one routine's definition, effective state, and recent fires
+    Show(RoutineShowArgs),
+    /// Suppress a routine on this host (host-local, survives reboots)
+    Pause(RoutinePauseArgs),
+    /// Clear a host-local pause
+    Resume(RoutineResumeArgs),
+    /// Set this host's identity and optionally install the OS clock unit
+    Init(RoutineInitArgs),
+}
+
+impl RoutineSubcommand {
+    fn execute_without_runtime(self) -> Result<(), OrbitError> {
+        match self {
+            Self::List(args) => args.execute_without_runtime(),
+            Self::Show(args) => args.execute_without_runtime(),
+            Self::Pause(args) => args.execute_without_runtime(),
+            Self::Resume(args) => args.execute_without_runtime(),
+            Self::Init(args) => args.execute_without_runtime(),
+        }
+    }
+}

--- a/crates/orbit-cli/src/command/routine/init.rs
+++ b/crates/orbit-cli/src/command/routine/init.rs
@@ -1,0 +1,52 @@
+use clap::Args;
+use orbit_core::OrbitError;
+use orbit_core::routines::{install_clock, resolve_host_id, write_host_id};
+use orbit_core::workspace_registry;
+
+#[derive(Args)]
+#[command(
+    after_help = "Writes ~/.orbit/host.toml (the identity `hosts:` pinning matches\n\
+                        against) and, with --install-clock, installs the per-user OS clock\n\
+                        unit that invokes `orbit sweep` every minute (launchd on macOS, a\n\
+                        systemd user timer on Linux)."
+)]
+pub struct RoutineInitArgs {
+    /// Host identity to write (defaults to the machine hostname).
+    #[arg(long)]
+    pub host_id: Option<String>,
+    /// Also install and activate the OS clock unit driving `orbit sweep`.
+    #[arg(long)]
+    pub install_clock: bool,
+}
+
+impl RoutineInitArgs {
+    pub fn execute_without_runtime(self) -> Result<(), OrbitError> {
+        let global_root = workspace_registry::global_orbit_dir()?;
+
+        let host_id = match self.host_id {
+            Some(host_id) => host_id,
+            None => resolve_host_id(&global_root)?,
+        };
+        let path = write_host_id(&global_root, &host_id)?;
+        println!("host_id \"{host_id}\" written to {}", path.display());
+
+        if !self.install_clock {
+            println!("clock unit not installed (pass --install-clock to set up `orbit sweep`)");
+            return Ok(());
+        }
+
+        let report = install_clock(&global_root)?;
+        for file in &report.files_written {
+            println!("wrote {}", file.display());
+        }
+        if report.activated {
+            println!("clock unit active: `orbit sweep` runs every minute on this host");
+        } else {
+            println!("clock unit files written but not activated; run:");
+            for step in &report.manual_steps {
+                println!("  {step}");
+            }
+        }
+        Ok(())
+    }
+}

--- a/crates/orbit-cli/src/command/routine/list.rs
+++ b/crates/orbit-cli/src/command/routine/list.rs
@@ -1,0 +1,118 @@
+use clap::Args;
+use comfy_table::Cell;
+use orbit_core::OrbitError;
+use orbit_core::routines::routine_statuses;
+use orbit_core::workspace_registry;
+use serde_json::json;
+
+use crate::output::table::{add_single_line_row, build_table};
+
+#[derive(Args)]
+pub struct RoutineListArgs {
+    /// Output as JSON.
+    #[arg(long)]
+    pub json: bool,
+}
+
+impl RoutineListArgs {
+    pub fn execute_without_runtime(self) -> Result<(), OrbitError> {
+        let global_root = workspace_registry::global_orbit_dir()?;
+        let report = routine_statuses(&global_root)?;
+
+        if self.json {
+            let statuses: Vec<_> = report
+                .statuses
+                .iter()
+                .map(|status| {
+                    json!({
+                        "name": status.routine.definition.name,
+                        "source": status.routine.source_workspace,
+                        "target": status.routine.definition.target.as_ref_string(),
+                        "enabled": status.routine.definition.enabled,
+                        "hosts": status.routine.definition.hosts,
+                        "pinned_to_host": status.pinned_to_host,
+                        "paused_at": status.paused_at,
+                        "effective": status.effective(),
+                        "cron": status.routine.definition.trigger.cron,
+                        "next_due": status.next_due,
+                        "last_fire": status.last_fire.as_ref().map(|fire| json!({
+                            "slot": fire.slot,
+                            "attempt": fire.attempt,
+                            "state": fire.state.as_str(),
+                            "run_id": fire.run_id,
+                        })),
+                    })
+                })
+                .collect();
+            crate::output::json::print_pretty(&json!({
+                "host_id": report.host_id,
+                "routines": statuses,
+                "load_errors": report.load_errors.iter().map(|e| json!({
+                    "source_workspace": e.source_workspace,
+                    "path": e.path.as_ref().map(|p| p.display().to_string()),
+                    "message": e.message,
+                })).collect::<Vec<_>>(),
+            }))?;
+            return Ok(());
+        }
+
+        if report.statuses.is_empty() && report.load_errors.is_empty() {
+            println!(
+                "no routines found (host {}); mark a workspace with [routines] role = \"source\"",
+                report.host_id
+            );
+            return Ok(());
+        }
+
+        let mut table = build_table(&[
+            "NAME",
+            "SOURCE",
+            "ENABLED",
+            "PINNED",
+            "PAUSED",
+            "NEXT DUE",
+            "LAST FIRE",
+        ]);
+        for status in &report.statuses {
+            let last_fire = status
+                .last_fire
+                .as_ref()
+                .map(|fire| format!("{} @ {}", fire.state.as_str(), fire.slot))
+                .unwrap_or_else(|| "—".to_string());
+            add_single_line_row(
+                &mut table,
+                vec![
+                    Cell::new(&status.routine.definition.name),
+                    Cell::new(&status.routine.source_workspace),
+                    Cell::new(if status.routine.definition.enabled {
+                        "yes"
+                    } else {
+                        "no"
+                    }),
+                    Cell::new(if status.pinned_to_host { "yes" } else { "no" }),
+                    Cell::new(if status.paused_at.is_some() {
+                        "yes"
+                    } else {
+                        "no"
+                    }),
+                    Cell::new(status.next_due.as_deref().unwrap_or("—")),
+                    Cell::new(last_fire),
+                ],
+            );
+        }
+        println!("host: {}", report.host_id);
+        println!("{table}");
+        for error in &report.load_errors {
+            let path = error
+                .path
+                .as_ref()
+                .map(|path| format!(" ({})", path.display()))
+                .unwrap_or_default();
+            eprintln!(
+                "load error [{}]{}: {}",
+                error.source_workspace, path, error.message
+            );
+        }
+        Ok(())
+    }
+}

--- a/crates/orbit-cli/src/command/routine/mod.rs
+++ b/crates/orbit-cli/src/command/routine/mod.rs
@@ -1,0 +1,8 @@
+mod command;
+mod init;
+mod list;
+mod pause;
+mod resume;
+mod show;
+
+pub use command::{RoutineCommand, RoutineSubcommand};

--- a/crates/orbit-cli/src/command/routine/pause.rs
+++ b/crates/orbit-cli/src/command/routine/pause.rs
@@ -1,0 +1,25 @@
+use clap::Args;
+use orbit_core::OrbitError;
+use orbit_core::routines::pause_routine;
+use orbit_core::workspace_registry;
+
+#[derive(Args)]
+pub struct RoutinePauseArgs {
+    /// Routine name.
+    pub name: String,
+}
+
+impl RoutinePauseArgs {
+    pub fn execute_without_runtime(self) -> Result<(), OrbitError> {
+        let global_root = workspace_registry::global_orbit_dir()?;
+        if pause_routine(&global_root, &self.name, "human")? {
+            println!(
+                "paused '{}' on this host (host-local; resume with `orbit routine resume {}`)",
+                self.name, self.name
+            );
+        } else {
+            println!("'{}' is already paused on this host", self.name);
+        }
+        Ok(())
+    }
+}

--- a/crates/orbit-cli/src/command/routine/resume.rs
+++ b/crates/orbit-cli/src/command/routine/resume.rs
@@ -1,0 +1,22 @@
+use clap::Args;
+use orbit_core::OrbitError;
+use orbit_core::routines::resume_routine;
+use orbit_core::workspace_registry;
+
+#[derive(Args)]
+pub struct RoutineResumeArgs {
+    /// Routine name.
+    pub name: String,
+}
+
+impl RoutineResumeArgs {
+    pub fn execute_without_runtime(self) -> Result<(), OrbitError> {
+        let global_root = workspace_registry::global_orbit_dir()?;
+        if resume_routine(&global_root, &self.name)? {
+            println!("resumed '{}' on this host", self.name);
+        } else {
+            println!("'{}' was not paused on this host", self.name);
+        }
+        Ok(())
+    }
+}

--- a/crates/orbit-cli/src/command/routine/show.rs
+++ b/crates/orbit-cli/src/command/routine/show.rs
@@ -1,0 +1,138 @@
+use clap::Args;
+use orbit_core::OrbitError;
+use orbit_core::routines::{recent_fires, routine_statuses};
+use orbit_core::workspace_registry;
+use serde_json::json;
+
+const RECENT_FIRE_LIMIT: usize = 10;
+
+#[derive(Args)]
+pub struct RoutineShowArgs {
+    /// Routine name.
+    pub name: String,
+    /// Output as JSON.
+    #[arg(long)]
+    pub json: bool,
+}
+
+impl RoutineShowArgs {
+    pub fn execute_without_runtime(self) -> Result<(), OrbitError> {
+        let global_root = workspace_registry::global_orbit_dir()?;
+        let report = routine_statuses(&global_root)?;
+        let Some(status) = report
+            .statuses
+            .iter()
+            .find(|status| status.routine.definition.name == self.name)
+        else {
+            return Err(OrbitError::InvalidInput(format!(
+                "no routine named '{}' (see `orbit routine list`)",
+                self.name
+            )));
+        };
+        let fires = recent_fires(&global_root, &self.name, RECENT_FIRE_LIMIT)?;
+        let definition = &status.routine.definition;
+
+        if self.json {
+            crate::output::json::print_pretty(&json!({
+                "host_id": report.host_id,
+                "name": definition.name,
+                "description": definition.description,
+                "source": status.routine.source_workspace,
+                "path": status.routine.path.display().to_string(),
+                "enabled": definition.enabled,
+                "hosts": definition.hosts,
+                "pinned_to_host": status.pinned_to_host,
+                "paused_at": status.paused_at,
+                "effective": status.effective(),
+                "cron": definition.trigger.cron,
+                "missed_run": definition.trigger.missed_run,
+                "target": definition.target.as_ref_string(),
+                "policy": definition.policy,
+                "next_due": status.next_due,
+                "recent_fires": fires.iter().map(|fire| json!({
+                    "slot": fire.slot,
+                    "attempt": fire.attempt,
+                    "state": fire.state.as_str(),
+                    "run_id": fire.run_id,
+                    "detail": fire.detail,
+                    "updated_at": fire.updated_at,
+                })).collect::<Vec<_>>(),
+            }))?;
+            return Ok(());
+        }
+
+        println!("Name: {}", definition.name);
+        if !definition.description.is_empty() {
+            println!("Description: {}", definition.description);
+        }
+        println!(
+            "Source: {} ({})",
+            status.routine.source_workspace,
+            status.routine.path.display()
+        );
+        println!("Target: {}", definition.target.as_ref_string());
+        println!(
+            "Trigger: cron \"{}\" (missed_run: {})",
+            definition.trigger.cron,
+            match definition.trigger.missed_run {
+                orbit_core::MissedRunPolicy::CatchUpOnce => "catch_up_once",
+                orbit_core::MissedRunPolicy::Skip => "skip",
+            }
+        );
+        println!(
+            "Policy: timeout {}m, retries max {} (backoff {}m), overlap {}",
+            definition.policy.timeout_minutes,
+            definition.policy.retries.max,
+            definition.policy.retries.backoff_minutes,
+            match definition.policy.overlap {
+                orbit_core::OverlapPolicy::Forbid => "forbid",
+                orbit_core::OverlapPolicy::Allow => "allow",
+            }
+        );
+        println!(
+            "Enabled: {} | Pinned to {}: {} | Paused: {}",
+            definition.enabled,
+            report.host_id,
+            status.pinned_to_host,
+            status
+                .paused_at
+                .as_deref()
+                .map(|at| format!("yes (since {at})"))
+                .unwrap_or_else(|| "no".to_string())
+        );
+        println!(
+            "Effective on this host: {}",
+            if status.effective() { "yes" } else { "no" }
+        );
+        println!(
+            "Next due: {}",
+            status.next_due.as_deref().unwrap_or("unknown")
+        );
+        if fires.is_empty() {
+            println!("Recent fires: none");
+        } else {
+            println!("Recent fires:");
+            for fire in &fires {
+                let run = fire
+                    .run_id
+                    .as_deref()
+                    .map(|run_id| format!(" run {run_id}"))
+                    .unwrap_or_default();
+                let detail = fire
+                    .detail
+                    .as_deref()
+                    .map(|detail| format!(" — {detail}"))
+                    .unwrap_or_default();
+                println!(
+                    "  [{}] slot {} attempt {}{}{}",
+                    fire.state.as_str(),
+                    fire.slot,
+                    fire.attempt,
+                    run,
+                    detail
+                );
+            }
+        }
+        Ok(())
+    }
+}

--- a/crates/orbit-cli/src/command/sweep.rs
+++ b/crates/orbit-cli/src/command/sweep.rs
@@ -1,0 +1,109 @@
+//! `orbit sweep` — the stateless routine scheduler pass [ORB-10021].
+//!
+//! Invoked every minute by the OS clock (launchd / systemd; see
+//! `orbit routine init --install-clock`). Like `orbit run ship-sweep`, it
+//! resolves everything from the global registry, never bootstraps a
+//! `.orbit/` in the caller's cwd, and exits non-zero only on infrastructure
+//! errors — an unconfigured host logs one line and exits 0, because the OS
+//! clock will invoke it forever.
+
+use clap::Args;
+use orbit_core::OrbitError;
+use orbit_core::routines::{SweepOptions, SweepOutcome, run_sweep};
+use serde_json::json;
+
+#[derive(Args)]
+#[command(
+    name = "sweep",
+    about = "Fire due routines on this host (the scheduler pass the OS clock invokes)",
+    after_help = "Loads routine definitions from every registered workspace with\n\
+                  `[routines] role = \"source\"` in its config.toml, filters them for this\n\
+                  host, and dispatches due targets as normal runs. Intended for the OS\n\
+                  clock (launchd / systemd timer), e.g.:\n  orbit sweep --json\n\n\
+                  Inspect routines with `orbit routine list`; dispatched fires appear in\n\
+                  `orbit run history`."
+)]
+pub struct SweepCommand {
+    /// Report what would fire without recording or dispatching anything.
+    #[arg(long)]
+    pub dry_run: bool,
+    /// Output as JSON.
+    #[arg(long)]
+    pub json: bool,
+}
+
+impl SweepCommand {
+    /// Runs without a pre-initialized runtime: the sweep resolves every
+    /// workspace from the global registry (per-workspace runtimes are built
+    /// inside orbit-core).
+    pub fn execute_without_runtime(self) -> Result<(), OrbitError> {
+        let outcome = run_sweep(SweepOptions {
+            dry_run: self.dry_run,
+        })?;
+
+        if self.json {
+            crate::output::json::print_pretty(&outcome_json(&outcome, self.dry_run))?;
+            return Ok(());
+        }
+
+        if outcome.lock_busy {
+            println!("sweep: another pass holds the lock on this host; exiting");
+            return Ok(());
+        }
+        if outcome.reports.is_empty() && outcome.load_errors.is_empty() {
+            println!("sweep[{}]: no routines configured", outcome.host_id);
+            return Ok(());
+        }
+        for report in &outcome.reports {
+            let mut line = format!("{} ({}): {}", report.routine, report.source, report.action);
+            if let Some(reason) = &report.reason {
+                line.push_str(&format!(" — {reason}"));
+            }
+            if let Some(slot) = &report.slot {
+                line.push_str(&format!(" — slot {slot}"));
+            }
+            if let Some(run_id) = &report.run_id {
+                line.push_str(&format!(" — run {run_id}"));
+            }
+            println!("{line}");
+        }
+        for error in &outcome.load_errors {
+            let path = error
+                .path
+                .as_ref()
+                .map(|path| format!(" ({})", path.display()))
+                .unwrap_or_default();
+            eprintln!(
+                "load error [{}]{}: {}",
+                error.source_workspace, path, error.message
+            );
+        }
+        Ok(())
+    }
+}
+
+fn outcome_json(outcome: &SweepOutcome, dry_run: bool) -> serde_json::Value {
+    json!({
+        "host_id": outcome.host_id,
+        "dry_run": dry_run,
+        "lock_busy": outcome.lock_busy,
+        "fired": outcome
+            .reports
+            .iter()
+            .filter(|r| r.action == "fired" || r.action == "retry_fired")
+            .count(),
+        "reports": outcome.reports.iter().map(|r| json!({
+            "routine": r.routine,
+            "source": r.source,
+            "action": r.action,
+            "reason": r.reason,
+            "slot": r.slot,
+            "run_id": r.run_id,
+        })).collect::<Vec<_>>(),
+        "load_errors": outcome.load_errors.iter().map(|e| json!({
+            "source_workspace": e.source_workspace,
+            "path": e.path.as_ref().map(|p| p.display().to_string()),
+            "message": e.message,
+        })).collect::<Vec<_>>(),
+    })
+}

--- a/crates/orbit-cli/src/main.rs
+++ b/crates/orbit-cli/src/main.rs
@@ -135,6 +135,23 @@ fn main() {
             }
             return;
         }
+        // `orbit sweep` and `orbit routine` resolve everything from the
+        // global registry and host-local scheduler state; like ship-sweep
+        // they must never bootstrap a `.orbit/` in the scheduler's cwd.
+        Commands::Sweep(cmd) => {
+            if let Err(err) = cmd.execute_without_runtime() {
+                print_error(&err, tool_run_json_output);
+                std::process::exit(1);
+            }
+            return;
+        }
+        Commands::Routine(cmd) => {
+            if let Err(err) = cmd.execute_without_runtime() {
+                print_error(&err, tool_run_json_output);
+                std::process::exit(1);
+            }
+            return;
+        }
         // `orbit web` resolves its own workspace(s): `serve` can serve globally
         // from any directory, and `connect` is a client-side SSH tunnel whose
         // workspace lives on the remote. Both must dispatch before the eager

--- a/crates/orbit-common/src/types/mod.rs
+++ b/crates/orbit-common/src/types/mod.rs
@@ -43,6 +43,7 @@ pub mod policy_decision;
 pub mod policy_def;
 pub mod resource;
 pub mod role;
+pub mod routine;
 pub mod run_state;
 pub mod skill;
 pub mod task;
@@ -118,6 +119,10 @@ pub use resource::{
     ResourceHeader, ResourceKind, ResourceMetadata, parse_policy_resource, validate_resource_name,
 };
 pub use role::Role;
+pub use routine::{
+    MissedRunPolicy, OverlapPolicy, ROUTINE_SCHEMA_VERSION, RoutineDefinition, RoutinePolicy,
+    RoutineRetries, RoutineTarget, RoutineTrigger, parse_routine_yaml,
+};
 pub use run_state::PipelineState;
 pub use skill::Skill;
 pub use task::{

--- a/crates/orbit-common/src/types/routine.rs
+++ b/crates/orbit-common/src/types/routine.rs
@@ -1,0 +1,280 @@
+//! Routine definition schema (v1) — the durable, git-versioned unit of
+//! scheduled work. One YAML file under `.orbit/routines/` in a routine-source
+//! workspace describes a cron trigger, a catalog target, host pinning, and a
+//! retry/overlap policy. See `docs/design/routines/2_design.md` [ORB-10021].
+//!
+//! Parsing is fail-closed: an invalid file is an error, never a routine that
+//! fires with defaults. Targets are catalog references only — there is no
+//! inline command form (ADR-0194 / ADR-0206 posture).
+
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+use super::activity_job::SchemaHeader;
+use super::error::OrbitError;
+
+/// Routine YAML schema version this binary reads and writes.
+pub const ROUTINE_SCHEMA_VERSION: u32 = 1;
+
+/// Prefix for job catalog target references (`job:<name>`).
+pub const ROUTINE_JOB_TARGET_PREFIX: &str = "job:";
+/// Prefix reserved for activity references. Not dispatchable in v1: run
+/// dispatch is job-shaped (`submit_pipeline_run` resolves jobs by name),
+/// so activities are fired by wrapping them in a one-step job in the same
+/// source workspace.
+pub const ROUTINE_ACTIVITY_TARGET_PREFIX: &str = "activity:";
+
+/// A parsed, validated routine definition.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RoutineDefinition {
+    /// Schema version marker (`schemaVersion: 1`).
+    #[serde(rename = "schemaVersion")]
+    pub schema_version: u32,
+    /// Unique routine name across all routine sources on a host.
+    pub name: String,
+    /// Human description of what the routine does.
+    #[serde(default)]
+    pub description: String,
+    /// Versioned global kill-switch. Absent means enabled.
+    #[serde(default = "default_true")]
+    pub enabled: bool,
+    /// Explicit host pinning — the routine fires only on hosts whose
+    /// `host_id` appears here. There is no "any host" value in v1.
+    pub hosts: Vec<String>,
+    /// When the routine is due.
+    pub trigger: RoutineTrigger,
+    /// What fires: a catalog reference (`job:<name>`).
+    pub target: RoutineTarget,
+    /// Timeout, retry, and overlap handling applied by the dispatcher.
+    #[serde(default)]
+    pub policy: RoutinePolicy,
+}
+
+/// Cron trigger plus the policy for fires missed while the host was asleep
+/// or powered off.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RoutineTrigger {
+    /// Standard 5-field cron expression, evaluated in host-local time.
+    pub cron: String,
+    /// What to do about scheduled slots that fell in a gap. Defaults to
+    /// `skip` (wait for the next natural slot).
+    #[serde(default)]
+    pub missed_run: MissedRunPolicy,
+}
+
+/// Missed-fire policy for gaps (sleep, downtime) between sweeps.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum MissedRunPolicy {
+    /// Fire a single make-up run on the next sweep, no matter how many
+    /// slots were missed.
+    CatchUpOnce,
+    /// Ignore missed slots; wait for the next natural one.
+    #[default]
+    Skip,
+}
+
+/// What a routine fires: a reference into the existing catalog, resolved at
+/// load time. v1 dispatches `job:<name>` only — see
+/// [`ROUTINE_ACTIVITY_TARGET_PREFIX`] for why `activity:` is reserved.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RoutineTarget {
+    /// A v2 job resolved by name through the job catalog.
+    Job(String),
+}
+
+impl RoutineTarget {
+    /// The catalog job name this target dispatches.
+    pub fn job_name(&self) -> &str {
+        match self {
+            Self::Job(name) => name,
+        }
+    }
+
+    /// Canonical string form (`job:<name>`).
+    pub fn as_ref_string(&self) -> String {
+        match self {
+            Self::Job(name) => format!("{ROUTINE_JOB_TARGET_PREFIX}{name}"),
+        }
+    }
+
+    fn parse(raw: &str) -> Result<Self, String> {
+        let value = raw.trim();
+        if let Some(name) = value.strip_prefix(ROUTINE_JOB_TARGET_PREFIX) {
+            let name = name.trim();
+            if name.is_empty() {
+                return Err("target 'job:' is missing a job name".to_string());
+            }
+            return Ok(Self::Job(name.to_string()));
+        }
+        if let Some(name) = value.strip_prefix(ROUTINE_ACTIVITY_TARGET_PREFIX) {
+            return Err(format!(
+                "target 'activity:{}' is not dispatchable in routines v1; wrap the \
+                 activity in a one-step job in the same workspace and reference it \
+                 as 'job:<name>'",
+                name.trim()
+            ));
+        }
+        Err(format!(
+            "target '{value}' must be a catalog reference of the form 'job:<name>'; \
+             inline commands are not supported (ADR-0194)"
+        ))
+    }
+}
+
+impl Serialize for RoutineTarget {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_str(&self.as_ref_string())
+    }
+}
+
+impl<'de> Deserialize<'de> for RoutineTarget {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let raw = String::deserialize(deserializer)?;
+        Self::parse(&raw).map_err(serde::de::Error::custom)
+    }
+}
+
+/// Dispatcher policy applied around each fire.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RoutinePolicy {
+    /// Ceiling on how long one fire may stay in flight before it stops
+    /// blocking `overlap: forbid` (the staleness horizon) and is recorded
+    /// as timed out.
+    #[serde(default = "default_timeout_minutes")]
+    pub timeout_minutes: u64,
+    /// Bounded retries with fixed backoff for failed fires.
+    #[serde(default)]
+    pub retries: RoutineRetries,
+    /// Whether a due fire may dispatch while a previous fire of the same
+    /// routine is still in flight.
+    #[serde(default)]
+    pub overlap: OverlapPolicy,
+}
+
+impl Default for RoutinePolicy {
+    fn default() -> Self {
+        Self {
+            timeout_minutes: default_timeout_minutes(),
+            retries: RoutineRetries::default(),
+            overlap: OverlapPolicy::default(),
+        }
+    }
+}
+
+/// Retry bounds for failed fires: up to `max` re-dispatches, each waiting at
+/// least `backoff_minutes` after the previous failure.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RoutineRetries {
+    /// Maximum re-dispatches after the initial fire (0 = no retries).
+    #[serde(default)]
+    pub max: u32,
+    /// Fixed delay between a failure and its retry.
+    #[serde(default = "default_backoff_minutes")]
+    pub backoff_minutes: u64,
+}
+
+impl Default for RoutineRetries {
+    fn default() -> Self {
+        Self {
+            max: 0,
+            backoff_minutes: default_backoff_minutes(),
+        }
+    }
+}
+
+/// Overlap handling when a fire comes due while another is in flight.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum OverlapPolicy {
+    /// Skip the fire while one is in flight (the default).
+    #[default]
+    Forbid,
+    /// Dispatch anyway.
+    Allow,
+}
+
+const fn default_true() -> bool {
+    true
+}
+
+const fn default_timeout_minutes() -> u64 {
+    60
+}
+
+const fn default_backoff_minutes() -> u64 {
+    2
+}
+
+/// Parse one routine YAML document fail-closed: schema-version gate first,
+/// then a strict typed parse (unknown fields rejected), then semantic
+/// validation. Any error means the routine is treated as absent by the
+/// caller — it never degrades into "fire with defaults".
+pub fn parse_routine_yaml(yaml: &str) -> Result<RoutineDefinition, OrbitError> {
+    let header = SchemaHeader::parse_yaml(yaml)
+        .map_err(|error| OrbitError::InvalidInput(format!("routine header: {error}")))?;
+    if header.schema_version != ROUTINE_SCHEMA_VERSION {
+        return Err(OrbitError::InvalidInput(format!(
+            "unsupported routine schemaVersion {} (this binary supports {})",
+            header.schema_version, ROUTINE_SCHEMA_VERSION
+        )));
+    }
+    let definition: RoutineDefinition = serde_yaml::from_str(yaml)
+        .map_err(|error| OrbitError::InvalidInput(format!("routine: {error}")))?;
+    definition.validate()?;
+    Ok(definition)
+}
+
+impl RoutineDefinition {
+    /// Semantic checks beyond serde shape: name charset, non-empty host
+    /// pinning, non-empty cron. Full cron parsing happens in the scheduler
+    /// (orbit-core), which owns the cron dependency.
+    pub fn validate(&self) -> Result<(), OrbitError> {
+        if !is_valid_routine_name(&self.name) {
+            return Err(OrbitError::InvalidInput(format!(
+                "routine name '{}' must be non-empty, lowercase alphanumeric \
+                 with '-' or '_' separators, and start alphanumeric",
+                self.name
+            )));
+        }
+        if self.hosts.is_empty() {
+            return Err(OrbitError::InvalidInput(format!(
+                "routine '{}' must pin at least one host (there is no \"any host\" in v1)",
+                self.name
+            )));
+        }
+        if self.hosts.iter().any(|host| host.trim().is_empty()) {
+            return Err(OrbitError::InvalidInput(format!(
+                "routine '{}' hosts must not contain empty entries",
+                self.name
+            )));
+        }
+        if self.trigger.cron.trim().is_empty() {
+            return Err(OrbitError::InvalidInput(format!(
+                "routine '{}' trigger.cron must not be empty",
+                self.name
+            )));
+        }
+        if self.policy.timeout_minutes == 0 {
+            return Err(OrbitError::InvalidInput(format!(
+                "routine '{}' policy.timeout_minutes must be at least 1",
+                self.name
+            )));
+        }
+        Ok(())
+    }
+}
+
+fn is_valid_routine_name(name: &str) -> bool {
+    let mut chars = name.chars();
+    let Some(first) = chars.next() else {
+        return false;
+    };
+    if !first.is_ascii_lowercase() && !first.is_ascii_digit() {
+        return false;
+    }
+    chars.all(|ch| ch.is_ascii_lowercase() || ch.is_ascii_digit() || ch == '-' || ch == '_')
+}

--- a/crates/orbit-common/src/types/tests/mod.rs
+++ b/crates/orbit-common/src/types/tests/mod.rs
@@ -9,6 +9,7 @@ mod friction;
 mod job;
 mod learning;
 mod resource;
+mod routine;
 mod task;
 mod task_artifacts;
 mod tool_input;

--- a/crates/orbit-common/src/types/tests/routine.rs
+++ b/crates/orbit-common/src/types/tests/routine.rs
@@ -1,0 +1,163 @@
+use super::super::routine::{MissedRunPolicy, OverlapPolicy, RoutineTarget, parse_routine_yaml};
+
+const VALID_ROUTINE: &str = r#"
+schemaVersion: 1
+name: almanac-auto-commit
+description: Commit & push almanac changes nightly
+enabled: true
+hosts: [dk-mac]
+trigger:
+  cron: "0 22 * * *"
+  missed_run: catch_up_once
+target: job:almanac_commit_pipeline
+policy:
+  timeout_minutes: 10
+  retries: { max: 2, backoff_minutes: 2 }
+  overlap: forbid
+"#;
+
+#[test]
+fn parses_the_design_doc_example() {
+    let routine = parse_routine_yaml(VALID_ROUTINE).expect("valid routine");
+    assert_eq!(routine.name, "almanac-auto-commit");
+    assert!(routine.enabled);
+    assert_eq!(routine.hosts, vec!["dk-mac".to_string()]);
+    assert_eq!(routine.trigger.cron, "0 22 * * *");
+    assert_eq!(routine.trigger.missed_run, MissedRunPolicy::CatchUpOnce);
+    assert_eq!(
+        routine.target,
+        RoutineTarget::Job("almanac_commit_pipeline".to_string())
+    );
+    assert_eq!(routine.policy.timeout_minutes, 10);
+    assert_eq!(routine.policy.retries.max, 2);
+    assert_eq!(routine.policy.retries.backoff_minutes, 2);
+    assert_eq!(routine.policy.overlap, OverlapPolicy::Forbid);
+}
+
+#[test]
+fn defaults_apply_when_optional_fields_are_absent() {
+    let routine = parse_routine_yaml(
+        r#"
+schemaVersion: 1
+name: reindex
+hosts: [dk-server-1]
+trigger:
+  cron: "*/30 * * * *"
+target: job:docs_reindex
+"#,
+    )
+    .expect("valid minimal routine");
+    assert!(routine.enabled);
+    assert_eq!(routine.trigger.missed_run, MissedRunPolicy::Skip);
+    assert_eq!(routine.policy.timeout_minutes, 60);
+    assert_eq!(routine.policy.retries.max, 0);
+    assert_eq!(routine.policy.overlap, OverlapPolicy::Forbid);
+}
+
+#[test]
+fn rejects_unknown_fields_fail_closed() {
+    let error = parse_routine_yaml(
+        r#"
+schemaVersion: 1
+name: reindex
+hosts: [dk-server-1]
+trigger:
+  cron: "*/30 * * * *"
+  jitter_seconds: 5
+target: job:docs_reindex
+"#,
+    )
+    .expect_err("unknown trigger field must fail");
+    assert!(error.to_string().contains("jitter_seconds"), "{error}");
+}
+
+#[test]
+fn rejects_unsupported_schema_version() {
+    let error = parse_routine_yaml(
+        r#"
+schemaVersion: 2
+name: reindex
+hosts: [dk-server-1]
+trigger:
+  cron: "*/30 * * * *"
+target: job:docs_reindex
+"#,
+    )
+    .expect_err("schemaVersion 2 must fail");
+    assert!(error.to_string().contains("schemaVersion 2"), "{error}");
+}
+
+#[test]
+fn rejects_activity_targets_with_wrapping_guidance() {
+    let error = parse_routine_yaml(
+        r#"
+schemaVersion: 1
+name: reindex
+hosts: [dk-server-1]
+trigger:
+  cron: "*/30 * * * *"
+target: activity:semantic_reindex
+"#,
+    )
+    .expect_err("activity target must fail in v1");
+    let message = error.to_string();
+    assert!(message.contains("wrap the"), "{message}");
+    assert!(message.contains("job:<name>"), "{message}");
+}
+
+#[test]
+fn rejects_inline_command_shaped_targets() {
+    let error = parse_routine_yaml(
+        r#"
+schemaVersion: 1
+name: reindex
+hosts: [dk-server-1]
+trigger:
+  cron: "*/30 * * * *"
+target: "sh -c 'rm -rf /'"
+"#,
+    )
+    .expect_err("inline command target must fail");
+    assert!(error.to_string().contains("ADR-0194"), "{error}");
+}
+
+#[test]
+fn rejects_empty_hosts_and_bad_names() {
+    let no_hosts = parse_routine_yaml(
+        r#"
+schemaVersion: 1
+name: reindex
+hosts: []
+trigger:
+  cron: "*/30 * * * *"
+target: job:docs_reindex
+"#,
+    )
+    .expect_err("empty hosts must fail");
+    assert!(
+        no_hosts.to_string().contains("at least one host"),
+        "{no_hosts}"
+    );
+
+    let bad_name = parse_routine_yaml(
+        r#"
+schemaVersion: 1
+name: "Almanac Commit"
+hosts: [dk-mac]
+trigger:
+  cron: "0 22 * * *"
+target: job:almanac_commit_pipeline
+"#,
+    )
+    .expect_err("uppercase/space name must fail");
+    assert!(bad_name.to_string().contains("routine name"), "{bad_name}");
+}
+
+#[test]
+fn target_round_trips_through_serde() {
+    let routine = parse_routine_yaml(VALID_ROUTINE).expect("valid routine");
+    let serialized = serde_yaml::to_string(&routine).expect("serialize");
+    assert!(serialized.contains("target: job:almanac_commit_pipeline"));
+    let reparsed = parse_routine_yaml(&serialized).expect("reparse");
+    assert_eq!(reparsed, routine);
+}

--- a/crates/orbit-core/Cargo.toml
+++ b/crates/orbit-core/Cargo.toml
@@ -16,6 +16,8 @@ clap = ["orbit-common/clap"]
 
 [dependencies]
 chrono.workspace = true
+croner.workspace = true
+hostname.workspace = true
 fs2.workspace = true
 orbit-common = { path = "../orbit-common" }
 orbit-search = { path = "../orbit-search" }

--- a/crates/orbit-core/assets/clock/com.orbit.sweep.plist
+++ b/crates/orbit-core/assets/clock/com.orbit.sweep.plist
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!-- launchd agent driving `orbit sweep` every minute [ORB-10021] / ADR-0204.
+     launchd also fires on wake, which pairs with `missed_run: catch_up_once`
+     for laptop sleep gaps. Installed by `orbit routine init` with the
+     install-clock flag. -->
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.orbit.sweep</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>{{ORBIT_BIN}}</string>
+        <string>sweep</string>
+    </array>
+    <key>StartInterval</key>
+    <integer>60</integer>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>StandardOutPath</key>
+    <string>{{LOG_PATH}}</string>
+    <key>StandardErrorPath</key>
+    <string>{{LOG_PATH}}</string>
+</dict>
+</plist>

--- a/crates/orbit-core/assets/clock/orbit-sweep.service
+++ b/crates/orbit-core/assets/clock/orbit-sweep.service
@@ -1,0 +1,8 @@
+# Oneshot service driving `orbit sweep` [ORB-10021] / ADR-0204.
+# Installed as a systemd *user* unit by `orbit routine init --install-clock`.
+[Unit]
+Description=Orbit routine sweep (fires due routines on this host)
+
+[Service]
+Type=oneshot
+ExecStart={{ORBIT_BIN}} sweep

--- a/crates/orbit-core/assets/clock/orbit-sweep.timer
+++ b/crates/orbit-core/assets/clock/orbit-sweep.timer
@@ -1,0 +1,13 @@
+# Minutely timer for `orbit sweep` [ORB-10021] / ADR-0204.
+# Persistent=true covers host downtime at the OS layer; per-routine
+# `missed_run` policy decides whether a covered gap produces a make-up fire.
+[Unit]
+Description=Run orbit sweep every minute
+
+[Timer]
+OnCalendar=*:*:00
+Persistent=true
+AccuracySec=5s
+
+[Install]
+WantedBy=timers.target

--- a/crates/orbit-core/src/config/raw.rs
+++ b/crates/orbit-core/src/config/raw.rs
@@ -15,6 +15,7 @@ pub(super) struct RawRuntimeConfig {
     pub(super) watch: Option<toml::Value>,
     pub(super) runtime: Option<RawRuntimeSection>,
     pub(super) workflow: Option<RawWorkflowConfig>,
+    pub(super) routines: Option<RawRoutinesConfig>,
     pub(super) duel: Option<RawDuelSection>,
     /// Removed in ORB-00058. Kept only so config loading can reject stale
     /// `[agent.<role>]` tables with an explicit migration error.
@@ -38,6 +39,16 @@ pub(super) struct RawWorkflowConfig {
     /// Named crew used when a task does not declare `crew` and no CLI
     /// override is provided.
     pub(super) default_crew: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub(super) struct RawRoutinesConfig {
+    /// `routines.role` — opt-in for the routine scheduler. `"source"` marks
+    /// this workspace as a routine source: `orbit sweep` loads
+    /// `.orbit/routines/*.yaml` from it. Any other value is a config error
+    /// (fail-closed; scheduled execution must never be enabled by a typo'd
+    /// key that silently parses).
+    pub(super) role: Option<String>,
 }
 
 #[derive(Debug, Clone, Deserialize)]

--- a/crates/orbit-core/src/config/runtime.rs
+++ b/crates/orbit-core/src/config/runtime.rs
@@ -14,8 +14,8 @@ use crate::paths;
 use super::persistence::PersistenceConfig;
 use super::raw::{
     RawAgentRoleConfig, RawCodexExecutionConfig, RawCrewEntry, RawDuelSection,
-    RawExecutionEnvConfig, RawPrSection, RawRuntimeConfig, RawRuntimeSection, RawTaskSection,
-    RawWorkflowConfig,
+    RawExecutionEnvConfig, RawPrSection, RawRoutinesConfig, RawRuntimeConfig, RawRuntimeSection,
+    RawTaskSection, RawWorkflowConfig,
 };
 
 const DEFAULT_ENV_INHERIT: bool = false;
@@ -48,6 +48,10 @@ pub(crate) struct RuntimeConfig {
     /// Opt-in for unattended ship dispatch (`[workflow] auto_ship` in
     /// `config.toml`; defaults to `false`).
     pub(crate) workflow_auto_ship: bool,
+    /// Whether this workspace is a routine source (`[routines] role =
+    /// "source"` in `config.toml`; defaults to `false`). Consulted by
+    /// `orbit sweep` before loading `.orbit/routines/*.yaml`.
+    pub(crate) routines_source: bool,
     /// Named planner/implementer/reviewer lineups from `[crews.<name>]`.
     pub(crate) crews: BTreeMap<String, Crew>,
     pub(crate) default_crew: Option<String>,
@@ -95,6 +99,7 @@ impl RuntimeConfig {
             v2_backend: None,
             workflow_base_branch: DEFAULT_WORKFLOW_BASE_BRANCH.to_string(),
             workflow_auto_ship: false,
+            routines_source: false,
             crews: default_crews(),
             default_crew: Some(DEFAULT_WORKFLOW_CREW.to_string()),
             duel: DuelConfig::default(),
@@ -183,6 +188,7 @@ impl RuntimeConfig {
             .as_ref()
             .and_then(|workflow| workflow.auto_ship)
             .unwrap_or(false);
+        let routines_source = routines_source_from_raw(parsed.routines.as_ref())?;
         let crews = crews_from_raw(parsed.crews.as_ref())?;
         let default_crew = workflow_default_crew_from_raw(parsed.workflow.as_ref(), &crews)?;
         let duel = duel_from_raw(parsed.duel.as_ref())?;
@@ -213,6 +219,7 @@ impl RuntimeConfig {
             v2_backend,
             workflow_base_branch,
             workflow_auto_ship,
+            routines_source,
             crews,
             default_crew,
             duel,
@@ -236,6 +243,10 @@ impl RuntimeConfig {
 
     pub(crate) fn workflow_auto_ship(&self) -> bool {
         self.workflow_auto_ship
+    }
+
+    pub(crate) fn routines_source(&self) -> bool {
+        self.routines_source
     }
 
     pub(crate) fn pr_config(&self) -> &PrConfig {
@@ -544,6 +555,18 @@ fn validate_task_artifact_store_from_raw(raw: Option<&RawTaskSection>) -> Result
     Err(OrbitError::InvalidInput(format!(
         "[task] artifact_store is no longer supported; remove the key because v2 task artifacts are always enabled (found '{trimmed}')"
     )))
+}
+
+fn routines_source_from_raw(raw: Option<&RawRoutinesConfig>) -> Result<bool, OrbitError> {
+    let Some(value) = raw.and_then(|section| section.role.as_deref()) else {
+        return Ok(false);
+    };
+    match value.trim() {
+        "source" => Ok(true),
+        other => Err(OrbitError::InvalidInput(format!(
+            "[routines] role has invalid value '{other}'; the only supported value is 'source'"
+        ))),
+    }
 }
 
 fn workflow_base_branch_from_raw(raw: Option<&RawWorkflowConfig>) -> Result<String, OrbitError> {

--- a/crates/orbit-core/src/context.rs
+++ b/crates/orbit-core/src/context.rs
@@ -183,6 +183,9 @@ pub(crate) struct OrbitRuntimeSettings {
     /// Opt-in for unattended ship dispatch
     /// (`[workflow] auto_ship` in `config.toml`, default `false`).
     workflow_auto_ship: bool,
+    /// Whether this workspace is a routine source
+    /// (`[routines] role = "source"` in `config.toml`, default `false`).
+    routines_source: bool,
     crews: std::collections::BTreeMap<String, Crew>,
     default_crew: Option<String>,
     duel: DuelConfig,
@@ -201,6 +204,7 @@ impl OrbitRuntimeSettings {
         v2_backend: Option<String>,
         workflow_base_branch: String,
         workflow_auto_ship: bool,
+        routines_source: bool,
         crews: std::collections::BTreeMap<String, Crew>,
         default_crew: Option<String>,
         duel: DuelConfig,
@@ -216,6 +220,7 @@ impl OrbitRuntimeSettings {
             v2_backend,
             workflow_base_branch,
             workflow_auto_ship,
+            routines_source,
             crews,
             default_crew,
             duel,
@@ -236,6 +241,10 @@ impl OrbitRuntimeSettings {
 
     pub(crate) fn workflow_auto_ship(&self) -> bool {
         self.workflow_auto_ship
+    }
+
+    pub(crate) fn routines_source(&self) -> bool {
+        self.routines_source
     }
 
     pub(crate) fn crews(&self) -> &std::collections::BTreeMap<String, Crew> {
@@ -368,6 +377,12 @@ impl OrbitContext {
     /// (`[workflow] auto_ship` in `config.toml`, default `false`).
     pub(crate) fn workflow_auto_ship(&self) -> bool {
         self.runtime.workflow_auto_ship()
+    }
+
+    /// Whether this workspace is a routine source
+    /// (`[routines] role = "source"` in `config.toml`, default `false`).
+    pub(crate) fn routines_source(&self) -> bool {
+        self.runtime.routines_source()
     }
 
     pub(crate) fn crews(&self) -> &std::collections::BTreeMap<String, Crew> {

--- a/crates/orbit-core/src/lib.rs
+++ b/crates/orbit-core/src/lib.rs
@@ -49,6 +49,7 @@ pub mod config;
 pub mod context;
 pub mod metrics;
 mod paths;
+pub mod routines;
 pub mod runtime;
 pub mod workspace_registry;
 
@@ -77,7 +78,9 @@ pub use orbit_common::types::{
     TaskStatus, TaskType, build_task_status_index, resolve_task_dependencies,
     task_dependencies_ready,
 };
-pub use orbit_common::types::{LearningComment, NotFoundKind, OrbitError};
+pub use orbit_common::types::{
+    LearningComment, MissedRunPolicy, NotFoundKind, OrbitError, OverlapPolicy,
+};
 pub use orbit_common::utility::redaction::redact_sensitive_env_text;
 pub use orbit_store::learning_layout::LearningLayoutMigrationReport;
 pub use orbit_store::{

--- a/crates/orbit-core/src/routines/clock.rs
+++ b/crates/orbit-core/src/routines/clock.rs
@@ -1,0 +1,156 @@
+//! OS clock integration [ORB-10021] / ADR-0204: the OS owns the wake-up,
+//! Orbit owns everything else. `orbit routine init --install-clock` renders
+//! the platform unit from the templates in `assets/clock/` and installs it
+//! as a per-user unit (launchd agent on macOS, systemd user timer on Linux).
+//! There is no resident Orbit daemon.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use orbit_common::types::OrbitError;
+
+const LAUNCHD_PLIST_TEMPLATE: &str = include_str!("../../assets/clock/com.orbit.sweep.plist");
+const SYSTEMD_SERVICE_TEMPLATE: &str = include_str!("../../assets/clock/orbit-sweep.service");
+const SYSTEMD_TIMER_TEMPLATE: &str = include_str!("../../assets/clock/orbit-sweep.timer");
+
+/// launchd agent label (macOS).
+pub const LAUNCHD_LABEL: &str = "com.orbit.sweep";
+/// systemd unit base name (Linux).
+pub const SYSTEMD_UNIT: &str = "orbit-sweep";
+
+/// What an installation attempt did: files written, plus either a successful
+/// activation or the commands the user must run themselves.
+#[derive(Debug)]
+pub struct ClockInstallReport {
+    /// Unit files written.
+    pub files_written: Vec<PathBuf>,
+    /// True when the unit was activated (loaded/enabled) successfully.
+    pub activated: bool,
+    /// Follow-up commands to run manually when activation failed or was
+    /// unavailable (e.g. no user systemd session).
+    pub manual_steps: Vec<String>,
+}
+
+/// Render and install the platform clock unit for the current user, then try
+/// to activate it. File writes are mandatory (errors propagate); activation
+/// is best-effort with explicit manual steps on failure, because unit
+/// managers behave differently across sessions (SSH, headless, containers).
+pub fn install_clock(global_root: &Path) -> Result<ClockInstallReport, OrbitError> {
+    let orbit_bin = std::env::current_exe()
+        .map_err(|error| OrbitError::Io(format!("resolve current orbit executable: {error}")))?;
+    let orbit_bin = orbit_bin.to_string_lossy().to_string();
+
+    if cfg!(target_os = "macos") {
+        install_launchd(global_root, &orbit_bin)
+    } else {
+        install_systemd(&orbit_bin)
+    }
+}
+
+fn install_launchd(global_root: &Path, orbit_bin: &str) -> Result<ClockInstallReport, OrbitError> {
+    let home = home_dir()?;
+    let log_path = global_root.join("logs").join("sweep.log");
+    if let Some(parent) = log_path.parent() {
+        fs::create_dir_all(parent).map_err(|error| OrbitError::Io(error.to_string()))?;
+    }
+    let plist = LAUNCHD_PLIST_TEMPLATE
+        .replace("{{ORBIT_BIN}}", orbit_bin)
+        .replace("{{LOG_PATH}}", &log_path.to_string_lossy());
+
+    let agents_dir = home.join("Library/LaunchAgents");
+    fs::create_dir_all(&agents_dir).map_err(|error| OrbitError::Io(error.to_string()))?;
+    let plist_path = agents_dir.join(format!("{LAUNCHD_LABEL}.plist"));
+    fs::write(&plist_path, plist).map_err(|error| {
+        OrbitError::Io(format!(
+            "failed to write '{}': {error}",
+            plist_path.display()
+        ))
+    })?;
+
+    // `launchctl load` is deprecated but still the most portable activation;
+    // a stale agent is unloaded first so re-installs pick up the new binary
+    // path.
+    let _ = Command::new("launchctl")
+        .args(["unload", &plist_path.to_string_lossy()])
+        .output();
+    let activated = Command::new("launchctl")
+        .args(["load", &plist_path.to_string_lossy()])
+        .output()
+        .map(|output| output.status.success())
+        .unwrap_or(false);
+
+    let manual_steps = if activated {
+        Vec::new()
+    } else {
+        vec![format!("launchctl load {}", plist_path.display())]
+    };
+    Ok(ClockInstallReport {
+        files_written: vec![plist_path],
+        activated,
+        manual_steps,
+    })
+}
+
+fn install_systemd(orbit_bin: &str) -> Result<ClockInstallReport, OrbitError> {
+    let home = home_dir()?;
+    let unit_dir = home.join(".config/systemd/user");
+    fs::create_dir_all(&unit_dir).map_err(|error| OrbitError::Io(error.to_string()))?;
+
+    let service_path = unit_dir.join(format!("{SYSTEMD_UNIT}.service"));
+    let timer_path = unit_dir.join(format!("{SYSTEMD_UNIT}.timer"));
+    fs::write(
+        &service_path,
+        SYSTEMD_SERVICE_TEMPLATE.replace("{{ORBIT_BIN}}", orbit_bin),
+    )
+    .map_err(|error| {
+        OrbitError::Io(format!(
+            "failed to write '{}': {error}",
+            service_path.display()
+        ))
+    })?;
+    fs::write(&timer_path, SYSTEMD_TIMER_TEMPLATE).map_err(|error| {
+        OrbitError::Io(format!(
+            "failed to write '{}': {error}",
+            timer_path.display()
+        ))
+    })?;
+
+    let reloaded = Command::new("systemctl")
+        .args(["--user", "daemon-reload"])
+        .output()
+        .map(|output| output.status.success())
+        .unwrap_or(false);
+    let activated = reloaded
+        && Command::new("systemctl")
+            .args([
+                "--user",
+                "enable",
+                "--now",
+                &format!("{SYSTEMD_UNIT}.timer"),
+            ])
+            .output()
+            .map(|output| output.status.success())
+            .unwrap_or(false);
+
+    let manual_steps = if activated {
+        Vec::new()
+    } else {
+        vec![
+            "systemctl --user daemon-reload".to_string(),
+            format!("systemctl --user enable --now {SYSTEMD_UNIT}.timer"),
+        ]
+    };
+    Ok(ClockInstallReport {
+        files_written: vec![service_path, timer_path],
+        activated,
+        manual_steps,
+    })
+}
+
+fn home_dir() -> Result<PathBuf, OrbitError> {
+    std::env::var_os("HOME")
+        .map(PathBuf::from)
+        .filter(|path| !path.as_os_str().is_empty())
+        .ok_or_else(|| OrbitError::InvalidInput("HOME is not set".to_string()))
+}

--- a/crates/orbit-core/src/routines/due.rs
+++ b/crates/orbit-core/src/routines/due.rs
@@ -1,0 +1,99 @@
+//! Due computation for routines [ORB-10021]: given a cron trigger, the
+//! host-local cursor, and "now", decide whether a routine fires this sweep
+//! and for which scheduled slot.
+//!
+//! The computation is O(1) per routine — `find_previous_occurrence` from
+//! `now`, compared against the cursor — never an iteration over every slot
+//! in a gap, so a week of downtime against a minutely cron costs the same
+//! as one minute.
+
+use chrono::{DateTime, Duration, TimeZone, Timelike};
+use croner::Cron;
+use orbit_common::types::{MissedRunPolicy, OrbitError};
+
+/// How far past its scheduled slot a fire still counts as "natural" for
+/// `missed_run: skip`. Two sweep intervals: tolerates one slow or skipped
+/// sweep without reclassifying the slot as missed.
+pub const NATURAL_SLOT_GRACE_SECONDS: i64 = 120;
+
+/// Outcome of the due check for one routine on one sweep pass.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DueDecision<Tz: TimeZone> {
+    /// Nothing to do this pass.
+    NotDue,
+    /// Fire for `slot`. `is_catch_up` marks a make-up fire for a slot that
+    /// fell in a gap (only produced under `missed_run: catch_up_once`).
+    Fire {
+        /// The scheduled slot this fire consumes (the idempotency key).
+        slot: DateTime<Tz>,
+        /// Whether this is a make-up fire rather than a natural one.
+        is_catch_up: bool,
+    },
+}
+
+/// Pin a scheduled occurrence to its minute (seconds and sub-seconds
+/// zeroed). Slot identity must be stable across sweeps for the idempotency
+/// key to hold.
+pub fn truncate_to_minute<Tz: TimeZone>(value: DateTime<Tz>) -> Result<DateTime<Tz>, OrbitError> {
+    value
+        .with_second(0)
+        .and_then(|value| value.with_nanosecond(0))
+        .ok_or_else(|| OrbitError::InvalidInput("timestamp cannot be minute-aligned".to_string()))
+}
+
+/// Parse and validate a routine cron expression (standard 5-field form,
+/// evaluated in host-local time by the caller's choice of `Tz`).
+pub fn parse_cron(expression: &str) -> Result<Cron, OrbitError> {
+    expression.parse::<Cron>().map_err(|error| {
+        OrbitError::InvalidInput(format!("invalid cron expression '{expression}': {error}"))
+    })
+}
+
+/// Decide whether a routine is due.
+///
+/// `lower_bound` is the exclusive floor slots must be after: the cursor's
+/// `last_slot` when one exists, otherwise the baseline (first observation) —
+/// a routine never fires for slots that predate its registration on this
+/// host.
+pub fn due_decision<Tz: TimeZone>(
+    cron: &Cron,
+    missed_run: MissedRunPolicy,
+    lower_bound: &DateTime<Tz>,
+    now: &DateTime<Tz>,
+) -> Result<DueDecision<Tz>, OrbitError> {
+    // Latest scheduled slot at or before now.
+    let previous = cron
+        .find_previous_occurrence(now, true)
+        .map_err(|error| OrbitError::InvalidInput(format!("cron evaluation failed: {error}")))?;
+    // croner carries `now`'s sub-minute component into the occurrence it
+    // returns, which would make the slot different on every sweep within the
+    // same minute — breaking the (name, slot) idempotency key. 5-field cron
+    // is minute-granular by definition, so pin slots to the minute.
+    let previous = truncate_to_minute(previous)?;
+
+    if previous <= *lower_bound {
+        return Ok(DueDecision::NotDue);
+    }
+
+    let age = now.clone().signed_duration_since(previous.clone());
+    let natural = age <= Duration::seconds(NATURAL_SLOT_GRACE_SECONDS);
+    if natural {
+        return Ok(DueDecision::Fire {
+            slot: previous,
+            is_catch_up: false,
+        });
+    }
+
+    match missed_run {
+        // One make-up fire for the latest missed slot, no matter how many
+        // slots the gap swallowed ("collapses history" — see 2_design.md §6).
+        MissedRunPolicy::CatchUpOnce => Ok(DueDecision::Fire {
+            slot: previous,
+            is_catch_up: true,
+        }),
+        // Wait for the next natural slot. The cursor is left untouched:
+        // correctness only needs slots to be after `lower_bound`, so an
+        // unconsumed missed slot simply never fires.
+        MissedRunPolicy::Skip => Ok(DueDecision::NotDue),
+    }
+}

--- a/crates/orbit-core/src/routines/host.rs
+++ b/crates/orbit-core/src/routines/host.rs
@@ -1,0 +1,87 @@
+//! Host identity for routine scheduling [ORB-10021].
+//!
+//! `hosts:` pinning in routine definitions matches against a `host_id` that
+//! lives in `~/.orbit/host.toml` — the one genuinely host-local datum in the
+//! routines design (ADR-0205 keeps discovery in the workspace registry;
+//! `host.toml` survives only to carry identity). When the file is absent the
+//! machine hostname is used, so pinning works out of the box on hosts whose
+//! hostnames are already stable names like `dk-server-1`.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use orbit_common::types::OrbitError;
+use serde::Deserialize;
+
+/// File under the global Orbit root carrying the host identity.
+pub const HOST_TOML_FILE: &str = "host.toml";
+
+#[derive(Debug, Deserialize)]
+struct HostToml {
+    host_id: Option<String>,
+}
+
+/// Resolve this machine's routine-scheduling identity: `host_id` from
+/// `<global_root>/host.toml` when present and non-empty, otherwise the
+/// machine hostname.
+pub fn resolve_host_id(global_root: &Path) -> Result<String, OrbitError> {
+    let path = host_toml_path(global_root);
+    if path.exists() {
+        let raw = fs::read_to_string(&path).map_err(|error| {
+            OrbitError::Io(format!("failed to read '{}': {error}", path.display()))
+        })?;
+        let parsed: HostToml = toml::from_str(&raw).map_err(|error| {
+            OrbitError::InvalidInput(format!("invalid host config '{}': {error}", path.display()))
+        })?;
+        if let Some(host_id) = parsed
+            .host_id
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+        {
+            return Ok(host_id.to_string());
+        }
+    }
+    hostname_fallback()
+}
+
+/// Write (or overwrite) the host identity. Returns the file path written.
+pub fn write_host_id(global_root: &Path, host_id: &str) -> Result<PathBuf, OrbitError> {
+    let trimmed = host_id.trim();
+    if trimmed.is_empty() {
+        return Err(OrbitError::InvalidInput(
+            "host_id must not be empty".to_string(),
+        ));
+    }
+    let path = host_toml_path(global_root);
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).map_err(|error| OrbitError::Io(error.to_string()))?;
+    }
+    let body = format!(
+        "# Host identity for routine scheduling (matched against `hosts:` in\n\
+         # routine definitions). Written by `orbit routine init` [ORB-10021].\n\
+         host_id = \"{trimmed}\"\n"
+    );
+    fs::write(&path, body).map_err(|error| {
+        OrbitError::Io(format!("failed to write '{}': {error}", path.display()))
+    })?;
+    Ok(path)
+}
+
+fn host_toml_path(global_root: &Path) -> PathBuf {
+    global_root.join(HOST_TOML_FILE)
+}
+
+fn hostname_fallback() -> Result<String, OrbitError> {
+    let name = hostname::get()
+        .map_err(|error| OrbitError::Io(format!("failed to resolve hostname: {error}")))?;
+    let name = name.to_string_lossy().trim().to_string();
+    if name.is_empty() {
+        return Err(OrbitError::InvalidInput(
+            "machine hostname is empty; set host_id in ~/.orbit/host.toml \
+             via `orbit routine init --host-id <id>`"
+                .to_string(),
+        ));
+    }
+    Ok(name)
+}

--- a/crates/orbit-core/src/routines/loader.rs
+++ b/crates/orbit-core/src/routines/loader.rs
@@ -1,0 +1,220 @@
+//! Routine discovery [ORB-10021]: enumerate the global workspace registry,
+//! visit every registered, active workspace whose versioned config declares
+//! `[routines] role = "source"` (ADR-0205), and load `.orbit/routines/*.yaml`
+//! from each — fail-closed per file. An invalid definition becomes a load
+//! error and that routine is treated as absent; it never fires with defaults.
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+use orbit_common::types::{
+    OrbitError, RoutineDefinition, Workspace, WorkspaceStatus, parse_routine_yaml,
+};
+
+use crate::OrbitRuntime;
+use crate::workspace_registry;
+
+use super::due::parse_cron;
+
+/// Directory under a source workspace's `.orbit/` holding routine YAML files.
+pub const ROUTINES_DIR: &str = "routines";
+
+/// One successfully loaded, fully validated routine.
+#[derive(Debug, Clone)]
+pub struct LoadedRoutine {
+    /// The parsed definition.
+    pub definition: RoutineDefinition,
+    /// Registry name of the source workspace.
+    pub source_workspace: String,
+    /// The source workspace's `.orbit` directory (dispatch root).
+    pub source_orbit_dir: PathBuf,
+    /// Path of the YAML file the definition came from.
+    pub path: PathBuf,
+}
+
+/// One fail-closed load failure, kept for reporting: the routine (or source)
+/// it names is treated as absent this pass.
+#[derive(Debug, Clone)]
+pub struct RoutineLoadError {
+    /// Registry name of the source workspace involved.
+    pub source_workspace: String,
+    /// File that failed, when the failure is file-scoped.
+    pub path: Option<PathBuf>,
+    /// Human-readable reason.
+    pub message: String,
+}
+
+/// Result of one discovery pass across all routine sources.
+#[derive(Debug, Default)]
+pub struct RoutineCollection {
+    /// Valid routines, in stable (workspace, filename) order.
+    pub routines: Vec<LoadedRoutine>,
+    /// Everything that failed fail-closed.
+    pub errors: Vec<RoutineLoadError>,
+}
+
+/// Registered workspaces with their runtimes, ready for routine discovery
+/// and dispatch, plus the workspaces that failed to open (reported loudly —
+/// registry hygiene must not silently shrink the source set).
+#[derive(Default)]
+pub struct DiscoveredWorkspaces {
+    /// Active, openable workspaces (source or not) with their runtimes.
+    pub entries: Vec<(Workspace, OrbitRuntime)>,
+    /// Registered workspaces that could not be opened.
+    pub errors: Vec<RoutineLoadError>,
+}
+
+/// Enumerate the global registry (validating and persisting hygiene fixes,
+/// like `ship-sweep` does) and build one runtime per active workspace.
+pub fn discover_workspaces(global_root: &Path) -> Result<DiscoveredWorkspaces, OrbitError> {
+    let registry_path = workspace_registry::registry_path_for(global_root);
+    let mut registry = workspace_registry::load_registry_from(&registry_path)?;
+    workspace_registry::validate_workspaces(&mut registry);
+    workspace_registry::save_registry_to(&registry, &registry_path)?;
+
+    let mut discovered = DiscoveredWorkspaces::default();
+    for workspace in registry.workspaces {
+        if workspace.status != WorkspaceStatus::Active || !workspace.orbit_dir.exists() {
+            continue;
+        }
+        match OrbitRuntime::from_roots(global_root, &workspace.orbit_dir) {
+            Ok(runtime) => discovered.entries.push((workspace, runtime)),
+            Err(error) => discovered.errors.push(RoutineLoadError {
+                source_workspace: workspace.name.clone(),
+                path: Some(workspace.orbit_dir.clone()),
+                message: format!("failed to open workspace runtime: {error}"),
+            }),
+        }
+    }
+    Ok(discovered)
+}
+
+/// Load routines from every source workspace among `workspaces` (the same
+/// runtimes are later used for dispatch). Cross-source name collisions are
+/// load-time errors: every colliding definition is dropped.
+pub fn collect_routines(workspaces: &[(Workspace, OrbitRuntime)]) -> RoutineCollection {
+    let mut collection = RoutineCollection::default();
+
+    for (workspace, runtime) in workspaces {
+        if !runtime.routines_source() {
+            continue;
+        }
+        load_source_workspace(workspace, runtime, &mut collection);
+    }
+
+    drop_name_collisions(&mut collection);
+    collection
+}
+
+fn load_source_workspace(
+    workspace: &Workspace,
+    runtime: &OrbitRuntime,
+    collection: &mut RoutineCollection,
+) {
+    let routines_dir = workspace.orbit_dir.join(ROUTINES_DIR);
+    if !routines_dir.is_dir() {
+        // A source with no routines directory is simply an empty source.
+        return;
+    }
+
+    let mut paths: Vec<PathBuf> = match std::fs::read_dir(&routines_dir) {
+        Ok(entries) => entries
+            .filter_map(|entry| entry.ok().map(|e| e.path()))
+            .filter(|path| {
+                path.extension()
+                    .and_then(|ext| ext.to_str())
+                    .is_some_and(|ext| {
+                        ext.eq_ignore_ascii_case("yaml") || ext.eq_ignore_ascii_case("yml")
+                    })
+            })
+            .collect(),
+        Err(error) => {
+            collection.errors.push(RoutineLoadError {
+                source_workspace: workspace.name.clone(),
+                path: Some(routines_dir),
+                message: format!("failed to list routines directory: {error}"),
+            });
+            return;
+        }
+    };
+    paths.sort();
+
+    for path in paths {
+        match load_routine_file(&path, workspace, runtime) {
+            Ok(routine) => collection.routines.push(routine),
+            Err(message) => collection.errors.push(RoutineLoadError {
+                source_workspace: workspace.name.clone(),
+                path: Some(path),
+                message,
+            }),
+        }
+    }
+}
+
+fn load_routine_file(
+    path: &Path,
+    workspace: &Workspace,
+    runtime: &OrbitRuntime,
+) -> Result<LoadedRoutine, String> {
+    let raw = std::fs::read_to_string(path).map_err(|error| format!("read failed: {error}"))?;
+    let definition = parse_routine_yaml(&raw).map_err(|error| error.to_string())?;
+
+    // Load-time cron validation: a routine with an unparsable trigger never
+    // reaches the due computation.
+    parse_cron(&definition.trigger.cron).map_err(|error| error.to_string())?;
+
+    // Load-time target resolution through the source workspace's catalog,
+    // like `target:` steps in JobV2: an unresolvable target is a load error,
+    // not a fire-time surprise (ADR-0206).
+    let job_name = definition.target.job_name();
+    runtime.load_v2_job_asset_by_name(job_name).map_err(|_| {
+        format!(
+            "target 'job:{job_name}' does not resolve in workspace '{}': \
+             no such job in its catalog",
+            workspace.name
+        )
+    })?;
+
+    Ok(LoadedRoutine {
+        definition,
+        source_workspace: workspace.name.clone(),
+        source_orbit_dir: workspace.orbit_dir.clone(),
+        path: path.to_path_buf(),
+    })
+}
+
+/// Names must be unique across all routine sources on a host; a collision is
+/// a load-time error and every colliding definition is treated as absent
+/// (fail-closed — firing an arbitrary winner would make behavior depend on
+/// registry iteration order).
+fn drop_name_collisions(collection: &mut RoutineCollection) {
+    let mut counts: BTreeMap<String, usize> = BTreeMap::new();
+    for routine in &collection.routines {
+        *counts.entry(routine.definition.name.clone()).or_default() += 1;
+    }
+    let colliding: Vec<String> = counts
+        .into_iter()
+        .filter(|(_, count)| *count > 1)
+        .map(|(name, _)| name)
+        .collect();
+    if colliding.is_empty() {
+        return;
+    }
+    let mut kept = Vec::with_capacity(collection.routines.len());
+    for routine in collection.routines.drain(..) {
+        if colliding.contains(&routine.definition.name) {
+            collection.errors.push(RoutineLoadError {
+                source_workspace: routine.source_workspace.clone(),
+                path: Some(routine.path.clone()),
+                message: format!(
+                    "routine name '{}' is defined by more than one source; \
+                     names must be unique across all routine sources",
+                    routine.definition.name
+                ),
+            });
+        } else {
+            kept.push(routine);
+        }
+    }
+    collection.routines = kept;
+}

--- a/crates/orbit-core/src/routines/mod.rs
+++ b/crates/orbit-core/src/routines/mod.rs
@@ -1,0 +1,30 @@
+//! Routines [ORB-10021]: Orbit as the constellation's single scheduler.
+//!
+//! A routine is a durable, git-versioned YAML definition of recurring work —
+//! a cron trigger, a catalog target, host pinning, and a retry/overlap
+//! policy — living under `.orbit/routines/` in a routine-source workspace
+//! (`[routines] role = "source"`). The stateless [`run_sweep`] pass, invoked
+//! every minute by the OS clock (see [`clock`]), fires whatever is due on
+//! the current host through the existing v2 run machinery. Definitions are
+//! shared across hosts via git; all scheduler state is host-local and never
+//! synced (ADR-0204..ADR-0208; design in `docs/design/routines/`).
+
+pub mod clock;
+pub mod due;
+pub mod host;
+pub mod loader;
+pub mod status;
+pub mod sweep;
+
+pub use clock::{ClockInstallReport, install_clock};
+pub use due::{DueDecision, due_decision, parse_cron};
+pub use host::{resolve_host_id, write_host_id};
+pub use loader::{LoadedRoutine, RoutineCollection, RoutineLoadError, collect_routines};
+pub use status::{
+    RoutineStatus, RoutineStatusReport, pause_routine, recent_fires, resume_routine,
+    routine_statuses,
+};
+pub use sweep::{RoutineSweepReport, SweepOptions, SweepOutcome, run_sweep, run_sweep_at};
+
+#[cfg(test)]
+mod tests;

--- a/crates/orbit-core/src/routines/status.rs
+++ b/crates/orbit-core/src/routines/status.rs
@@ -1,0 +1,112 @@
+//! Read-only status projection for `orbit routine list` / `show` [ORB-10021]:
+//! every routine with all three toggle layers (versioned `enabled`, versioned
+//! host pinning, host-local pause), the computed next-due slot, and the last
+//! recorded fire — so "why didn't this fire?" is one command.
+
+use std::path::Path;
+
+use chrono::Local;
+use orbit_common::types::OrbitError;
+use orbit_store::{RoutineFireRecord, Store};
+
+use super::due::{parse_cron, truncate_to_minute};
+use super::host::resolve_host_id;
+use super::loader::{LoadedRoutine, RoutineLoadError, collect_routines, discover_workspaces};
+
+/// Full effective state of one routine on this host.
+#[derive(Debug, Clone)]
+pub struct RoutineStatus {
+    /// The loaded definition plus its provenance.
+    pub routine: LoadedRoutine,
+    /// Whether this host's `host_id` appears in the routine's `hosts`.
+    pub pinned_to_host: bool,
+    /// Host-local pause, when one is set (RFC 3339 pause timestamp).
+    pub paused_at: Option<String>,
+    /// Next scheduled slot (RFC 3339, host-local), when computable.
+    pub next_due: Option<String>,
+    /// Most recent fire attempt recorded on this host.
+    pub last_fire: Option<RoutineFireRecord>,
+}
+
+impl RoutineStatus {
+    /// Whether the routine would currently fire on this host when due:
+    /// enabled, pinned, and not paused.
+    pub fn effective(&self) -> bool {
+        self.routine.definition.enabled && self.pinned_to_host && self.paused_at.is_none()
+    }
+}
+
+/// Everything `orbit routine list` renders.
+#[derive(Debug)]
+pub struct RoutineStatusReport {
+    /// This host's identity.
+    pub host_id: String,
+    /// Per-routine status rows, in discovery order.
+    pub statuses: Vec<RoutineStatus>,
+    /// Fail-closed load failures (these routines are absent).
+    pub load_errors: Vec<RoutineLoadError>,
+}
+
+/// Collect the status of every routine visible from the global registry.
+pub fn routine_statuses(global_root: &Path) -> Result<RoutineStatusReport, OrbitError> {
+    let host_id = resolve_host_id(global_root)?;
+    let store = Store::open(&global_root.join("orbit.db"))?;
+
+    let discovered = discover_workspaces(global_root)?;
+    let mut load_errors = discovered.errors.clone();
+    let mut collection = collect_routines(&discovered.entries);
+    load_errors.append(&mut collection.errors);
+
+    let pauses = store.routine_pauses()?;
+    let now = Local::now();
+
+    let mut statuses = Vec::with_capacity(collection.routines.len());
+    for routine in collection.routines {
+        let next_due = parse_cron(&routine.definition.trigger.cron)
+            .ok()
+            .and_then(|cron| cron.find_next_occurrence(&now, false).ok())
+            .and_then(|slot| truncate_to_minute(slot).ok())
+            .map(|slot| slot.to_rfc3339());
+        let last_fire = store.routine_latest_fire(&routine.definition.name)?;
+        let paused_at = pauses
+            .get(&routine.definition.name)
+            .map(|pause| pause.paused_at.clone());
+        let pinned_to_host = routine.definition.hosts.iter().any(|host| host == &host_id);
+        statuses.push(RoutineStatus {
+            routine,
+            pinned_to_host,
+            paused_at,
+            next_due,
+            last_fire,
+        });
+    }
+
+    Ok(RoutineStatusReport {
+        host_id,
+        statuses,
+        load_errors,
+    })
+}
+
+/// Pause a routine on this host (host-local, never synced). Returns `false`
+/// when it was already paused.
+pub fn pause_routine(global_root: &Path, name: &str, actor: &str) -> Result<bool, OrbitError> {
+    let store = Store::open(&global_root.join("orbit.db"))?;
+    store.routine_pause(name, actor)
+}
+
+/// Clear a host-local pause. Returns `false` when it was not paused.
+pub fn resume_routine(global_root: &Path, name: &str) -> Result<bool, OrbitError> {
+    let store = Store::open(&global_root.join("orbit.db"))?;
+    store.routine_resume(name)
+}
+
+/// Recent fire attempts for one routine, newest first (for `routine show`).
+pub fn recent_fires(
+    global_root: &Path,
+    name: &str,
+    limit: usize,
+) -> Result<Vec<RoutineFireRecord>, OrbitError> {
+    let store = Store::open(&global_root.join("orbit.db"))?;
+    store.routine_recent_fires(name, limit)
+}

--- a/crates/orbit-core/src/routines/sweep.rs
+++ b/crates/orbit-core/src/routines/sweep.rs
@@ -1,0 +1,426 @@
+//! The stateless sweep pass [ORB-10021]: what runs when the OS clock invokes
+//! `orbit sweep` (ADR-0204). Modeled on `orbit run ship-sweep`: never
+//! bootstraps a workspace from the caller's cwd, isolates per-routine
+//! failures into report rows, and returns `Err` only for infrastructure
+//! failures (registry unreadable, store unopenable) — an unconfigured host
+//! is a clean no-op, because launchd/systemd will invoke this forever.
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+use chrono::{DateTime, Duration, Local, Utc};
+use orbit_common::types::{JobRunState, OrbitError, OverlapPolicy};
+use orbit_store::{RoutineFireIntentParams, RoutineFireRecord, RoutineFireState, Store};
+use serde_json::json;
+
+use crate::OrbitRuntime;
+use crate::workspace_registry;
+
+use super::due::{DueDecision, due_decision, parse_cron};
+use super::host::resolve_host_id;
+use super::loader::{LoadedRoutine, RoutineLoadError, collect_routines, discover_workspaces};
+
+/// Options for one sweep pass.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct SweepOptions {
+    /// Report what would fire without recording or dispatching anything.
+    pub dry_run: bool,
+}
+
+/// Per-routine outcome of one sweep pass.
+#[derive(Debug, Clone)]
+pub struct RoutineSweepReport {
+    /// Routine name.
+    pub routine: String,
+    /// Source workspace name.
+    pub source: String,
+    /// One of: `fired`, `retry_fired`, `would_fire`, `baselined`,
+    /// `would_baseline`, `skipped`, `error`.
+    pub action: &'static str,
+    /// Why, for `skipped`/`error` rows.
+    pub reason: Option<String>,
+    /// Scheduled slot consumed (RFC 3339, UTC), when a fire was involved.
+    pub slot: Option<String>,
+    /// Run id returned by dispatch, when one was submitted.
+    pub run_id: Option<String>,
+}
+
+/// Result of one sweep pass.
+#[derive(Debug, Default)]
+pub struct SweepOutcome {
+    /// Host identity the pass filtered against.
+    pub host_id: String,
+    /// True when another sweep held the lock and this pass exited early.
+    pub lock_busy: bool,
+    /// Per-routine outcomes.
+    pub reports: Vec<RoutineSweepReport>,
+    /// Fail-closed definition/load failures (those routines were absent).
+    pub load_errors: Vec<RoutineLoadError>,
+}
+
+/// Run one sweep pass against the default global root (`~/.orbit`).
+pub fn run_sweep(options: SweepOptions) -> Result<SweepOutcome, OrbitError> {
+    let global_root = workspace_registry::global_orbit_dir()?;
+    run_sweep_at(&global_root, options)
+}
+
+/// Run one sweep pass against an explicit global root (test seam).
+pub fn run_sweep_at(global_root: &Path, options: SweepOptions) -> Result<SweepOutcome, OrbitError> {
+    let host_id = resolve_host_id(global_root)?;
+
+    // One pass per host at a time: overlapping invocations from a slow prior
+    // pass must not double-fire. flock releases on process death, so a
+    // crashed sweep never wedges the next one.
+    let lock = orbit_store::try_acquire_routine_sweep_lock(&global_root.join("state"))?;
+    let Some(_lock) = lock else {
+        return Ok(SweepOutcome {
+            host_id,
+            lock_busy: true,
+            ..SweepOutcome::default()
+        });
+    };
+
+    let store = Store::open(&global_root.join("orbit.db"))?;
+
+    // One runtime per active workspace; discovery and dispatch share them.
+    let discovered = discover_workspaces(global_root)?;
+    let mut load_errors: Vec<RoutineLoadError> = discovered.errors.clone();
+
+    let mut collection = collect_routines(&discovered.entries);
+    load_errors.append(&mut collection.errors);
+
+    let routines_by_name: BTreeMap<String, &LoadedRoutine> = collection
+        .routines
+        .iter()
+        .map(|routine| (routine.definition.name.clone(), routine))
+        .collect();
+    let runtime_by_orbit_dir: BTreeMap<PathBuf, &OrbitRuntime> = discovered
+        .entries
+        .iter()
+        .map(|(workspace, runtime)| (workspace.orbit_dir.clone(), runtime))
+        .collect();
+
+    let now_utc = Utc::now();
+    if !options.dry_run {
+        sync_unresolved_fires(&store, &routines_by_name, &runtime_by_orbit_dir, now_utc)?;
+    }
+
+    let pauses = store.routine_pauses()?;
+
+    let mut reports = Vec::new();
+    for routine in &collection.routines {
+        let report = sweep_routine(
+            &store,
+            routine,
+            &runtime_by_orbit_dir,
+            &host_id,
+            &pauses,
+            options,
+        )
+        .unwrap_or_else(|error| RoutineSweepReport {
+            routine: routine.definition.name.clone(),
+            source: routine.source_workspace.clone(),
+            action: "error",
+            reason: Some(error.to_string()),
+            slot: None,
+            run_id: None,
+        });
+        reports.push(report);
+    }
+
+    Ok(SweepOutcome {
+        host_id,
+        lock_busy: false,
+        reports,
+        load_errors,
+    })
+}
+
+fn sweep_routine(
+    store: &Store,
+    routine: &LoadedRoutine,
+    runtimes: &BTreeMap<PathBuf, &OrbitRuntime>,
+    host_id: &str,
+    pauses: &BTreeMap<String, orbit_store::RoutinePauseRecord>,
+    options: SweepOptions,
+) -> Result<RoutineSweepReport, OrbitError> {
+    let definition = &routine.definition;
+    let name = &definition.name;
+
+    // Toggle resolution order (2_design.md §4): versioned kill-switch →
+    // versioned host pinning → host-local pause.
+    if !definition.enabled {
+        return Ok(skipped(routine, "disabled_in_definition"));
+    }
+    if !definition.hosts.iter().any(|host| host == host_id) {
+        return Ok(skipped(routine, "host_not_pinned"));
+    }
+    if pauses.contains_key(name) {
+        return Ok(skipped(routine, "paused_locally"));
+    }
+
+    let cron = parse_cron(&definition.trigger.cron)?;
+    let now_local = Local::now();
+
+    let Some(cursor) = store.routine_cursor(name)? else {
+        // First observation on this host: record the baseline and fire
+        // nothing — a routine never fires for slots that predate its
+        // registration here.
+        if options.dry_run {
+            return Ok(action(routine, "would_baseline"));
+        }
+        store.routine_record_baseline(name, &Utc::now().to_rfc3339())?;
+        return Ok(action(routine, "baselined"));
+    };
+
+    let lower_bound_raw = cursor.last_slot.as_deref().unwrap_or(&cursor.baseline_at);
+    let lower_bound = parse_rfc3339(lower_bound_raw)?.with_timezone(&Local);
+
+    match due_decision(
+        &cron,
+        definition.trigger.missed_run,
+        &lower_bound,
+        &now_local,
+    )? {
+        DueDecision::Fire { slot, .. } => {
+            let slot_utc = slot.with_timezone(&Utc).to_rfc3339();
+            fire(store, routine, runtimes, &slot_utc, 1, "fired", options)
+        }
+        DueDecision::NotDue => {
+            // No new slot: a failed most-recent fire may still have retry
+            // budget under the same slot.
+            if let Some(retry) = retry_candidate(store, routine, Utc::now())? {
+                return fire(
+                    store,
+                    routine,
+                    runtimes,
+                    &retry.slot,
+                    retry.attempt + 1,
+                    "retry_fired",
+                    options,
+                );
+            }
+            Ok(skipped(routine, "not_due"))
+        }
+    }
+}
+
+/// The most recent fire, when it failed with retry budget left and the
+/// fixed backoff has elapsed.
+fn retry_candidate(
+    store: &Store,
+    routine: &LoadedRoutine,
+    now_utc: DateTime<Utc>,
+) -> Result<Option<RoutineFireRecord>, OrbitError> {
+    let retries = routine.definition.policy.retries;
+    if retries.max == 0 {
+        return Ok(None);
+    }
+    let Some(latest) = store.routine_latest_fire(&routine.definition.name)? else {
+        return Ok(None);
+    };
+    if latest.state != RoutineFireState::Failed {
+        return Ok(None);
+    }
+    // attempt is 1-based: max=2 allows attempts 2 and 3.
+    if latest.attempt > retries.max {
+        return Ok(None);
+    }
+    let failed_at = parse_rfc3339(&latest.updated_at)?;
+    if now_utc.signed_duration_since(failed_at) < Duration::minutes(retries.backoff_minutes as i64)
+    {
+        return Ok(None);
+    }
+    Ok(Some(latest))
+}
+
+fn fire(
+    store: &Store,
+    routine: &LoadedRoutine,
+    runtimes: &BTreeMap<PathBuf, &OrbitRuntime>,
+    slot: &str,
+    attempt: u32,
+    fired_action: &'static str,
+    options: SweepOptions,
+) -> Result<RoutineSweepReport, OrbitError> {
+    let definition = &routine.definition;
+    let name = &definition.name;
+
+    if definition.policy.overlap == OverlapPolicy::Forbid
+        && let Some(latest) = store.routine_latest_fire(name)?
+        && !latest.state.is_terminal()
+    {
+        // Stale in-flight entries past the policy timeout were already
+        // reclaimed by the outcome sync at the top of the pass, so anything
+        // still non-terminal here is genuinely (believed) in flight.
+        return Ok(RoutineSweepReport {
+            slot: Some(slot.to_string()),
+            ..skipped(routine, "overlap_in_flight")
+        });
+    }
+
+    if options.dry_run {
+        return Ok(RoutineSweepReport {
+            slot: Some(slot.to_string()),
+            ..action(routine, "would_fire")
+        });
+    }
+
+    let claimed = store.routine_record_fire_intent(&RoutineFireIntentParams {
+        routine_name: name.clone(),
+        slot: slot.to_string(),
+        attempt,
+        source_workspace: routine.source_workspace.clone(),
+    })?;
+    if !claimed {
+        return Ok(RoutineSweepReport {
+            slot: Some(slot.to_string()),
+            ..skipped(routine, "slot_already_claimed")
+        });
+    }
+
+    let runtime = runtimes.get(&routine.source_orbit_dir).ok_or_else(|| {
+        OrbitError::WorkspaceError(format!(
+            "no runtime for source workspace '{}'",
+            routine.source_workspace
+        ))
+    })?;
+
+    let actor = format!("routine/{name}");
+    match runtime.submit_pipeline_run(definition.target.job_name(), json!({}), None, Some(&actor)) {
+        Ok(invoke) => {
+            store.routine_mark_fire_dispatched(name, slot, attempt, &invoke.run_id)?;
+            Ok(RoutineSweepReport {
+                routine: name.clone(),
+                source: routine.source_workspace.clone(),
+                action: fired_action,
+                reason: None,
+                slot: Some(slot.to_string()),
+                run_id: Some(invoke.run_id),
+            })
+        }
+        Err(error) => {
+            store.routine_mark_fire_outcome(
+                name,
+                slot,
+                attempt,
+                RoutineFireState::Error,
+                Some(&error.to_string()),
+            )?;
+            Ok(RoutineSweepReport {
+                routine: name.clone(),
+                source: routine.source_workspace.clone(),
+                action: "error",
+                reason: Some(format!("dispatch failed: {error}")),
+                slot: Some(slot.to_string()),
+                run_id: None,
+            })
+        }
+    }
+}
+
+/// Bring unresolved fires up to date against actual run state, and reclaim
+/// entries older than the routine's policy timeout (the staleness horizon —
+/// without it, a sweep that crashed between intent and dispatch would block
+/// `overlap: forbid` forever).
+fn sync_unresolved_fires(
+    store: &Store,
+    routines_by_name: &BTreeMap<String, &LoadedRoutine>,
+    runtimes: &BTreeMap<PathBuf, &OrbitRuntime>,
+    now_utc: DateTime<Utc>,
+) -> Result<(), OrbitError> {
+    for fire in store.routine_unresolved_fires()? {
+        let timeout_minutes = routines_by_name
+            .get(&fire.routine_name)
+            .map(|routine| routine.definition.policy.timeout_minutes)
+            .unwrap_or(60);
+        let created_at = match parse_rfc3339(&fire.created_at) {
+            Ok(value) => value,
+            Err(_) => continue,
+        };
+        let expired =
+            now_utc.signed_duration_since(created_at) > Duration::minutes(timeout_minutes as i64);
+
+        match fire.state {
+            RoutineFireState::Intent => {
+                if expired {
+                    store.routine_mark_fire_outcome(
+                        &fire.routine_name,
+                        &fire.slot,
+                        fire.attempt,
+                        RoutineFireState::Error,
+                        Some("stale fire intent reclaimed (sweep died before dispatch)"),
+                    )?;
+                }
+            }
+            RoutineFireState::Dispatched => {
+                let run_state = fire
+                    .run_id
+                    .as_deref()
+                    .and_then(|run_id| {
+                        routines_by_name
+                            .get(&fire.routine_name)
+                            .and_then(|routine| runtimes.get(&routine.source_orbit_dir))
+                            .and_then(|runtime| runtime.show_job_run(run_id).ok())
+                    })
+                    .map(|run| run.state);
+                let outcome = match run_state {
+                    Some(JobRunState::Success) => Some((RoutineFireState::Succeeded, None)),
+                    Some(JobRunState::Failed) => Some((RoutineFireState::Failed, None)),
+                    Some(JobRunState::Timeout) => Some((RoutineFireState::TimedOut, None)),
+                    Some(JobRunState::Cancelled) => {
+                        Some((RoutineFireState::Failed, Some("run cancelled")))
+                    }
+                    Some(JobRunState::Interrupted) => {
+                        Some((RoutineFireState::Failed, Some("run interrupted")))
+                    }
+                    // Still in flight (or unqueryable): reclaim once past the
+                    // policy timeout, otherwise leave for a later pass.
+                    _ => expired.then_some((
+                        RoutineFireState::TimedOut,
+                        Some("exceeded policy timeout without a terminal run state"),
+                    )),
+                };
+                if let Some((state, detail)) = outcome {
+                    store.routine_mark_fire_outcome(
+                        &fire.routine_name,
+                        &fire.slot,
+                        fire.attempt,
+                        state,
+                        detail,
+                    )?;
+                }
+            }
+            _ => {}
+        }
+    }
+    Ok(())
+}
+
+fn skipped(routine: &LoadedRoutine, reason: &str) -> RoutineSweepReport {
+    RoutineSweepReport {
+        routine: routine.definition.name.clone(),
+        source: routine.source_workspace.clone(),
+        action: "skipped",
+        reason: Some(reason.to_string()),
+        slot: None,
+        run_id: None,
+    }
+}
+
+fn action(routine: &LoadedRoutine, action: &'static str) -> RoutineSweepReport {
+    RoutineSweepReport {
+        routine: routine.definition.name.clone(),
+        source: routine.source_workspace.clone(),
+        action,
+        reason: None,
+        slot: None,
+        run_id: None,
+    }
+}
+
+fn parse_rfc3339(raw: &str) -> Result<DateTime<Utc>, OrbitError> {
+    DateTime::parse_from_rfc3339(raw)
+        .map(|value| value.with_timezone(&Utc))
+        .map_err(|error| OrbitError::Store(format!("invalid stored timestamp '{raw}': {error}")))
+}

--- a/crates/orbit-core/src/routines/tests/due.rs
+++ b/crates/orbit-core/src/routines/tests/due.rs
@@ -1,0 +1,113 @@
+use chrono::{DateTime, TimeZone, Utc};
+
+use super::super::due::{DueDecision, due_decision, parse_cron};
+use orbit_common::types::MissedRunPolicy;
+
+fn at(y: i32, mo: u32, d: u32, h: u32, mi: u32, s: u32) -> DateTime<Utc> {
+    Utc.with_ymd_and_hms(y, mo, d, h, mi, s)
+        .single()
+        .expect("valid ts")
+}
+
+#[test]
+fn parse_cron_accepts_standard_five_field_and_rejects_garbage() {
+    parse_cron("0 22 * * *").expect("nightly");
+    parse_cron("*/30 * * * *").expect("half-hourly");
+    parse_cron("not a cron").expect_err("garbage must fail");
+    parse_cron("").expect_err("empty must fail");
+}
+
+#[test]
+fn not_due_when_no_slot_after_lower_bound() {
+    let cron = parse_cron("0 22 * * *").expect("cron");
+    // Last fired at yesterday's 22:00 slot; now is 10:00 — nothing new.
+    let lower = at(2026, 7, 1, 22, 0, 0);
+    let now = at(2026, 7, 2, 10, 0, 0);
+    let decision = due_decision(&cron, MissedRunPolicy::Skip, &lower, &now).expect("decision");
+    assert_eq!(decision, DueDecision::NotDue);
+}
+
+#[test]
+fn natural_slot_fires_within_grace() {
+    let cron = parse_cron("0 22 * * *").expect("cron");
+    let lower = at(2026, 7, 1, 22, 0, 0);
+    // Sweep runs 40 seconds after the slot — natural fire.
+    let now = at(2026, 7, 2, 22, 0, 40);
+    let decision = due_decision(&cron, MissedRunPolicy::Skip, &lower, &now).expect("decision");
+    assert_eq!(
+        decision,
+        DueDecision::Fire {
+            slot: at(2026, 7, 2, 22, 0, 0),
+            is_catch_up: false,
+        }
+    );
+}
+
+#[test]
+fn catch_up_once_collapses_a_week_of_missed_slots_into_one_fire() {
+    let cron = parse_cron("0 22 * * *").expect("cron");
+    // Laptop slept for a week after the July 1 fire.
+    let lower = at(2026, 7, 1, 22, 0, 0);
+    let now = at(2026, 7, 8, 9, 30, 0);
+    let decision =
+        due_decision(&cron, MissedRunPolicy::CatchUpOnce, &lower, &now).expect("decision");
+    // One make-up fire for the *latest* missed slot, not seven fires.
+    assert_eq!(
+        decision,
+        DueDecision::Fire {
+            slot: at(2026, 7, 7, 22, 0, 0),
+            is_catch_up: true,
+        }
+    );
+}
+
+#[test]
+fn skip_waits_for_the_next_natural_slot() {
+    let cron = parse_cron("0 22 * * *").expect("cron");
+    let lower = at(2026, 7, 1, 22, 0, 0);
+    let now = at(2026, 7, 8, 9, 30, 0);
+    let decision = due_decision(&cron, MissedRunPolicy::Skip, &lower, &now).expect("decision");
+    assert_eq!(decision, DueDecision::NotDue);
+}
+
+#[test]
+fn slots_are_minute_aligned_regardless_of_sub_minute_now() {
+    let cron = parse_cron("* * * * *").expect("cron");
+    let lower = at(2026, 7, 2, 21, 59, 0);
+    // "now" carries seconds + nanos, as real sweeps do; the slot must not.
+    let now = Utc
+        .with_ymd_and_hms(2026, 7, 2, 22, 0, 42)
+        .single()
+        .expect("valid ts")
+        + chrono::Duration::nanoseconds(785_766_897);
+    let decision = due_decision(&cron, MissedRunPolicy::Skip, &lower, &now).expect("decision");
+    assert_eq!(
+        decision,
+        DueDecision::Fire {
+            slot: at(2026, 7, 2, 22, 0, 0),
+            is_catch_up: false,
+        }
+    );
+}
+
+#[test]
+fn slot_exactly_at_lower_bound_does_not_refire() {
+    let cron = parse_cron("0 22 * * *").expect("cron");
+    let slot = at(2026, 7, 2, 22, 0, 0);
+    // Sweep re-runs 30 seconds later with the cursor already at this slot.
+    let now = at(2026, 7, 2, 22, 0, 30);
+    let decision =
+        due_decision(&cron, MissedRunPolicy::CatchUpOnce, &slot, &now).expect("decision");
+    assert_eq!(decision, DueDecision::NotDue);
+}
+
+#[test]
+fn baseline_in_the_future_of_all_slots_suppresses_firing() {
+    let cron = parse_cron("0 22 * * *").expect("cron");
+    // Routine first observed at 23:00 — the 22:00 slot predates registration.
+    let baseline = at(2026, 7, 2, 23, 0, 0);
+    let now = at(2026, 7, 2, 23, 30, 0);
+    let decision =
+        due_decision(&cron, MissedRunPolicy::CatchUpOnce, &baseline, &now).expect("decision");
+    assert_eq!(decision, DueDecision::NotDue);
+}

--- a/crates/orbit-core/src/routines/tests/host.rs
+++ b/crates/orbit-core/src/routines/tests/host.rs
@@ -1,0 +1,37 @@
+use super::super::host::{resolve_host_id, write_host_id};
+
+#[test]
+fn write_and_resolve_round_trip() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = write_host_id(dir.path(), "dk-server-1").expect("write");
+    assert!(path.ends_with("host.toml"));
+    assert_eq!(resolve_host_id(dir.path()).expect("resolve"), "dk-server-1");
+}
+
+#[test]
+fn missing_host_toml_falls_back_to_hostname() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let resolved = resolve_host_id(dir.path()).expect("resolve");
+    assert!(!resolved.is_empty());
+}
+
+#[test]
+fn empty_host_id_is_rejected_on_write() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    write_host_id(dir.path(), "  ").expect_err("empty host_id must fail");
+}
+
+#[test]
+fn invalid_host_toml_is_an_error_not_a_fallback() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    std::fs::write(dir.path().join("host.toml"), "host_id = [not toml").expect("write");
+    resolve_host_id(dir.path()).expect_err("invalid toml must fail closed");
+}
+
+#[test]
+fn blank_host_id_key_falls_back_to_hostname() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    std::fs::write(dir.path().join("host.toml"), "host_id = \"  \"\n").expect("write");
+    let resolved = resolve_host_id(dir.path()).expect("resolve");
+    assert!(!resolved.is_empty());
+}

--- a/crates/orbit-core/src/routines/tests/mod.rs
+++ b/crates/orbit-core/src/routines/tests/mod.rs
@@ -1,0 +1,2 @@
+mod due;
+mod host;

--- a/crates/orbit-core/src/runtime/builder.rs
+++ b/crates/orbit-core/src/runtime/builder.rs
@@ -135,6 +135,7 @@ pub(crate) fn build_context_from_roots(
     let v2_backend = runtime_config.v2_backend().map(ToString::to_string);
     let workflow_base_branch = runtime_config.workflow_base_branch().to_string();
     let workflow_auto_ship = runtime_config.workflow_auto_ship();
+    let routines_source = runtime_config.routines_source();
     let crews = runtime_config.crews.clone();
     let default_crew = runtime_config.default_crew.clone();
     let duel = runtime_config.duel_config().clone();
@@ -175,6 +176,7 @@ pub(crate) fn build_context_from_roots(
             v2_backend,
             workflow_base_branch,
             workflow_auto_ship,
+            routines_source,
             crews,
             default_crew,
             duel,

--- a/crates/orbit-core/src/runtime/mod.rs
+++ b/crates/orbit-core/src/runtime/mod.rs
@@ -363,6 +363,14 @@ impl OrbitRuntime {
         self.context.workflow_auto_ship()
     }
 
+    /// Whether this workspace declared itself a routine source
+    /// (`[routines] role = "source"` in the active `config.toml`; defaults
+    /// to `false`). Consulted by `orbit sweep` before loading routine
+    /// definitions nobody registered explicitly.
+    pub fn routines_source(&self) -> bool {
+        self.context.routines_source()
+    }
+
     /// Returns the configured `[duel] candidates` list (e.g. ["codex", "claude", "gemini", "grok"]).
     /// Used by `orbit run duel-plan --planner-a ...` overrides to validate explicit families.
     pub fn duel_candidate_families(&self) -> Vec<String> {

--- a/crates/orbit-store/src/file_lock/mod.rs
+++ b/crates/orbit-store/src/file_lock/mod.rs
@@ -116,6 +116,45 @@ pub(crate) fn acquire_exclusive(path: &Path, label: &str) -> Result<FileLockGuar
     acquire_exclusive_with(path, label, LockOptions::default())
 }
 
+/// Single-shot exclusive acquisition: returns `Ok(None)` immediately when
+/// another process holds the lock instead of waiting. For callers whose
+/// correct response to contention is "someone else is already doing this
+/// pass, exit" (e.g. the routine sweep) rather than queueing behind the
+/// holder. The OS releases the lock on process death, so a crashed holder
+/// never wedges future acquisitions.
+pub(crate) fn try_acquire_exclusive(
+    path: &Path,
+    label: &str,
+) -> Result<Option<FileLockGuard>, OrbitError> {
+    let parent = path.parent().ok_or_else(|| {
+        OrbitError::Store(format!(
+            "cannot determine lock parent for '{}'",
+            path.display()
+        ))
+    })?;
+    fs::create_dir_all(parent).map_err(|error| OrbitError::Io(error.to_string()))?;
+
+    let file = OpenOptions::new()
+        .create(true)
+        .truncate(false)
+        .read(true)
+        .write(true)
+        .open(path)
+        .map_err(|error| OrbitError::Io(error.to_string()))?;
+
+    match file.try_lock_exclusive() {
+        Ok(()) => {
+            write_holder(&file, label);
+            Ok(Some(FileLockGuard { _file: file }))
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => Ok(None),
+        Err(error) => Err(OrbitError::Store(format!(
+            "failed to acquire {label} lock '{}': {error}",
+            path.display()
+        ))),
+    }
+}
+
 /// Acquire an exclusive advisory lock with explicit [`LockOptions`]. On timeout
 /// returns [`OrbitError::Store`] whose message names the lock path and any
 /// holder metadata, so a stalled waiter is observable rather than silent.

--- a/crates/orbit-store/src/lib.rs
+++ b/crates/orbit-store/src/lib.rs
@@ -151,6 +151,10 @@ pub use sqlite::invocation_store::{
     ActivityInvocationMetrics, AgentInvocationMetrics, InvocationInsertParams, InvocationQuery,
     InvocationRecord, InvocationToolCallRecord, TaskInvocationMetrics, ToolInvocationMetrics,
 };
+pub use sqlite::routine_store::{
+    RoutineCursor, RoutineFireIntentParams, RoutineFireRecord, RoutineFireState,
+    RoutinePauseRecord, RoutineSweepLock, try_acquire_routine_sweep_lock,
+};
 pub use sqlite::task_registry::workspace_id_for_orbit_dir;
 pub use sqlite::v2_audit_store::{V2AuditEventFilter, V2AuditEventInsertParams, V2AuditEventRow};
 

--- a/crates/orbit-store/src/sqlite/migration/mod.rs
+++ b/crates/orbit-store/src/sqlite/migration/mod.rs
@@ -230,8 +230,61 @@ fn apply_baseline_schema(conn: &Connection) -> Result<(), OrbitError> {
     ensure_learning_index_schema(conn)?;
     ensure_invocation_schema(conn)?;
     ensure_v2_state_consolidation_schema(conn)?;
+    ensure_routine_schema(conn)?;
 
     Ok(())
+}
+
+fn ensure_routine_schema(conn: &Connection) -> Result<(), OrbitError> {
+    conn.execute_batch(
+        r#"
+            -- Host-local routine scheduler state [ORB-10021]. Lives only in
+            -- the host-global store database and is never synced between
+            -- hosts (ADR-0208); routine *definitions* are git-versioned YAML
+            -- in routine-source workspaces.
+
+            -- Per-routine cursor: first observation baseline + last slot
+            -- consumed. A routine never fires for slots before its baseline.
+            CREATE TABLE IF NOT EXISTS routine_cursors (
+                routine_name TEXT PRIMARY KEY,
+                baseline_at TEXT NOT NULL,
+                last_slot TEXT,
+                updated_at TEXT NOT NULL
+            );
+
+            -- One row per fire attempt. The (name, slot, attempt) uniqueness
+            -- is the idempotency key that prevents double fires for the same
+            -- scheduled slot across overlapping or crashed sweeps.
+            CREATE TABLE IF NOT EXISTS routine_fires (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                routine_name TEXT NOT NULL,
+                slot TEXT NOT NULL,
+                attempt INTEGER NOT NULL DEFAULT 1,
+                state TEXT NOT NULL,
+                run_id TEXT,
+                source_workspace TEXT NOT NULL,
+                detail TEXT,
+                created_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL,
+                UNIQUE(routine_name, slot, attempt)
+            );
+
+            CREATE INDEX IF NOT EXISTS idx_routine_fires_name_slot
+            ON routine_fires(routine_name, slot DESC, attempt DESC);
+
+            CREATE INDEX IF NOT EXISTS idx_routine_fires_state
+            ON routine_fires(state);
+
+            -- Host-local suppressions written by `orbit routine pause`;
+            -- durable across reboots, invisible to git.
+            CREATE TABLE IF NOT EXISTS routine_pauses (
+                routine_name TEXT PRIMARY KEY,
+                paused_at TEXT NOT NULL,
+                actor TEXT
+            );
+        "#,
+    )
+    .map_err(|e| OrbitError::Store(e.to_string()))
 }
 
 fn ensure_adr_index_schema(conn: &Connection) -> Result<(), OrbitError> {

--- a/crates/orbit-store/src/sqlite/mod.rs
+++ b/crates/orbit-store/src/sqlite/mod.rs
@@ -6,6 +6,7 @@ pub mod job_run_store;
 pub mod learning_index;
 pub mod migration;
 pub(crate) mod read_pool;
+pub mod routine_store;
 pub mod session_learning_state_store;
 pub mod task_registry;
 pub mod task_reservation_store;

--- a/crates/orbit-store/src/sqlite/routine_store/mod.rs
+++ b/crates/orbit-store/src/sqlite/routine_store/mod.rs
@@ -1,0 +1,390 @@
+//! Host-local scheduler state for the routines feature [ORB-10021].
+//!
+//! All rows live in the host-global store database (`~/.orbit/orbit.db`) and
+//! are never synced between hosts (ADR-0208): routine *definitions* converge
+//! via git; fires, pauses, and the sweep lock stay local. Three tables:
+//!
+//! - `routine_cursors` — per routine: when this host first observed it
+//!   (the baseline; a routine never fires for slots that predate its first
+//!   observation) and the last scheduled slot consumed.
+//! - `routine_fires` — one row per fire attempt, keyed on the idempotency
+//!   triple (routine name, scheduled slot, attempt). Recording the intent
+//!   and advancing the cursor happen in one transaction, so a slot can
+//!   never double-fire even across crashed sweeps.
+//! - `routine_pauses` — host-local suppressions written by
+//!   `orbit routine pause`, invisible to git.
+//!
+//! The sweep advisory lock is a `flock(2)` file lock, not a table: the OS
+//! releases it on process death, so a crashed sweep never wedges the next
+//! one (see `try_acquire_routine_sweep_lock`).
+
+use std::collections::BTreeMap;
+use std::path::Path;
+
+use orbit_common::types::OrbitError;
+use rusqlite::{OptionalExtension, TransactionBehavior, params};
+
+use crate::Store;
+use crate::file_lock::{self, FileLockGuard};
+
+pub mod types;
+
+pub use types::{
+    RoutineCursor, RoutineFireIntentParams, RoutineFireRecord, RoutineFireState, RoutinePauseRecord,
+};
+
+/// Lock file name under the global state dir guarding one sweep pass per host.
+const SWEEP_LOCK_FILE: &str = "routine-sweep.lock";
+
+/// RAII guard over the host-global sweep advisory lock
+/// (`docs/design-patterns/raii_guard.md`): dropping it releases the lock.
+#[derive(Debug)]
+#[must_use = "the sweep lock is released as soon as the guard is dropped"]
+pub struct RoutineSweepLock {
+    _guard: FileLockGuard,
+}
+
+/// Try to take this host's sweep lock without waiting. `Ok(None)` means
+/// another sweep pass is in flight and the caller should exit cleanly —
+/// overlapping invocations from a slow prior pass must not double-fire.
+pub fn try_acquire_routine_sweep_lock(
+    global_state_dir: &Path,
+) -> Result<Option<RoutineSweepLock>, OrbitError> {
+    let path = global_state_dir.join(SWEEP_LOCK_FILE);
+    Ok(file_lock::try_acquire_exclusive(&path, "routine sweep")?
+        .map(|guard| RoutineSweepLock { _guard: guard }))
+}
+
+impl Store {
+    /// Cursor for one routine, if this host has observed it before.
+    pub fn routine_cursor(&self, routine_name: &str) -> Result<Option<RoutineCursor>, OrbitError> {
+        let conn = self.read()?;
+        conn.query_row(
+            "SELECT routine_name, baseline_at, last_slot FROM routine_cursors
+             WHERE routine_name = ?1",
+            params![routine_name],
+            |row| {
+                Ok(RoutineCursor {
+                    routine_name: row.get(0)?,
+                    baseline_at: row.get(1)?,
+                    last_slot: row.get(2)?,
+                })
+            },
+        )
+        .optional()
+        .map_err(|error| OrbitError::Store(error.to_string()))
+    }
+
+    /// Record the first observation of a routine on this host. Idempotent:
+    /// an existing cursor is left untouched, so the baseline never moves
+    /// backwards or forwards once set. Returns whether a row was created.
+    pub fn routine_record_baseline(
+        &self,
+        routine_name: &str,
+        baseline_at: &str,
+    ) -> Result<bool, OrbitError> {
+        self.with_transaction_behavior(TransactionBehavior::Immediate, |tx| {
+            let now = crate::now_string();
+            let inserted = tx
+                .tx
+                .execute(
+                    "INSERT OR IGNORE INTO routine_cursors
+                     (routine_name, baseline_at, last_slot, updated_at)
+                     VALUES (?1, ?2, NULL, ?3)",
+                    params![routine_name, baseline_at, now],
+                )
+                .map_err(|error| OrbitError::Store(error.to_string()))?;
+            Ok(inserted > 0)
+        })
+    }
+
+    /// Record the intent to fire one (routine, slot, attempt) and advance the
+    /// cursor's `last_slot` in the same transaction. Returns `false` when the
+    /// idempotency key already exists — the slot was already claimed by an
+    /// earlier sweep (possibly one that crashed mid-dispatch), and the caller
+    /// must not dispatch again.
+    pub fn routine_record_fire_intent(
+        &self,
+        intent: &RoutineFireIntentParams,
+    ) -> Result<bool, OrbitError> {
+        self.with_transaction_behavior(TransactionBehavior::Immediate, |tx| {
+            let now = crate::now_string();
+            let inserted = tx
+                .tx
+                .execute(
+                    "INSERT OR IGNORE INTO routine_fires
+                     (routine_name, slot, attempt, state, run_id, source_workspace,
+                      detail, created_at, updated_at)
+                     VALUES (?1, ?2, ?3, ?4, NULL, ?5, NULL, ?6, ?6)",
+                    params![
+                        intent.routine_name,
+                        intent.slot,
+                        intent.attempt,
+                        RoutineFireState::Intent.as_str(),
+                        intent.source_workspace,
+                        now,
+                    ],
+                )
+                .map_err(|error| OrbitError::Store(error.to_string()))?;
+            if inserted == 0 {
+                return Ok(false);
+            }
+            tx.tx
+                .execute(
+                    "UPDATE routine_cursors SET last_slot = ?2, updated_at = ?3
+                     WHERE routine_name = ?1",
+                    params![intent.routine_name, intent.slot, now],
+                )
+                .map_err(|error| OrbitError::Store(error.to_string()))?;
+            Ok(true)
+        })
+    }
+
+    /// Mark a recorded fire intent as dispatched, attaching the run id the
+    /// pipeline submission returned.
+    pub fn routine_mark_fire_dispatched(
+        &self,
+        routine_name: &str,
+        slot: &str,
+        attempt: u32,
+        run_id: &str,
+    ) -> Result<(), OrbitError> {
+        self.routine_update_fire(
+            routine_name,
+            slot,
+            attempt,
+            RoutineFireState::Dispatched,
+            Some(run_id),
+            None,
+        )
+    }
+
+    /// Record the terminal outcome of a fire (succeeded / failed / timed out
+    /// / error), with an optional human-readable detail message.
+    pub fn routine_mark_fire_outcome(
+        &self,
+        routine_name: &str,
+        slot: &str,
+        attempt: u32,
+        state: RoutineFireState,
+        detail: Option<&str>,
+    ) -> Result<(), OrbitError> {
+        self.routine_update_fire(routine_name, slot, attempt, state, None, detail)
+    }
+
+    fn routine_update_fire(
+        &self,
+        routine_name: &str,
+        slot: &str,
+        attempt: u32,
+        state: RoutineFireState,
+        run_id: Option<&str>,
+        detail: Option<&str>,
+    ) -> Result<(), OrbitError> {
+        self.with_transaction_behavior(TransactionBehavior::Immediate, |tx| {
+            let now = crate::now_string();
+            tx.tx
+                .execute(
+                    "UPDATE routine_fires
+                     SET state = ?4,
+                         run_id = COALESCE(?5, run_id),
+                         detail = COALESCE(?6, detail),
+                         updated_at = ?7
+                     WHERE routine_name = ?1 AND slot = ?2 AND attempt = ?3",
+                    params![
+                        routine_name,
+                        slot,
+                        attempt,
+                        state.as_str(),
+                        run_id,
+                        detail,
+                        now
+                    ],
+                )
+                .map_err(|error| OrbitError::Store(error.to_string()))?;
+            Ok(())
+        })
+    }
+
+    /// Most recent fire attempt for one routine, if any.
+    pub fn routine_latest_fire(
+        &self,
+        routine_name: &str,
+    ) -> Result<Option<RoutineFireRecord>, OrbitError> {
+        let conn = self.read()?;
+        conn.query_row(
+            &format!(
+                "SELECT {FIRE_COLUMNS} FROM routine_fires
+                 WHERE routine_name = ?1
+                 ORDER BY slot DESC, attempt DESC LIMIT 1"
+            ),
+            params![routine_name],
+            fire_row,
+        )
+        .optional()
+        .map_err(|error| OrbitError::Store(error.to_string()))?
+        .map(RoutineFireRecord::try_from_row)
+        .transpose()
+    }
+
+    /// All fires that have not reached a terminal state (intent recorded but
+    /// never dispatched, or dispatched with the run outcome not yet synced).
+    pub fn routine_unresolved_fires(&self) -> Result<Vec<RoutineFireRecord>, OrbitError> {
+        let conn = self.read()?;
+        let mut stmt = conn
+            .prepare(&format!(
+                "SELECT {FIRE_COLUMNS} FROM routine_fires
+                 WHERE state IN (?1, ?2)
+                 ORDER BY routine_name ASC, slot ASC, attempt ASC"
+            ))
+            .map_err(|error| OrbitError::Store(error.to_string()))?;
+        let rows = stmt
+            .query_map(
+                params![
+                    RoutineFireState::Intent.as_str(),
+                    RoutineFireState::Dispatched.as_str()
+                ],
+                fire_row,
+            )
+            .map_err(|error| OrbitError::Store(error.to_string()))?;
+        collect_fires(rows)
+    }
+
+    /// Recent fire attempts for one routine, newest first.
+    pub fn routine_recent_fires(
+        &self,
+        routine_name: &str,
+        limit: usize,
+    ) -> Result<Vec<RoutineFireRecord>, OrbitError> {
+        let conn = self.read()?;
+        let mut stmt = conn
+            .prepare(&format!(
+                "SELECT {FIRE_COLUMNS} FROM routine_fires
+                 WHERE routine_name = ?1
+                 ORDER BY slot DESC, attempt DESC LIMIT ?2"
+            ))
+            .map_err(|error| OrbitError::Store(error.to_string()))?;
+        let rows = stmt
+            .query_map(params![routine_name, limit as i64], fire_row)
+            .map_err(|error| OrbitError::Store(error.to_string()))?;
+        collect_fires(rows)
+    }
+
+    /// Suppress a routine on this host. Returns `false` when already paused.
+    pub fn routine_pause(&self, routine_name: &str, actor: &str) -> Result<bool, OrbitError> {
+        self.with_transaction_behavior(TransactionBehavior::Immediate, |tx| {
+            let now = crate::now_string();
+            let inserted = tx
+                .tx
+                .execute(
+                    "INSERT OR IGNORE INTO routine_pauses (routine_name, paused_at, actor)
+                     VALUES (?1, ?2, ?3)",
+                    params![routine_name, now, actor],
+                )
+                .map_err(|error| OrbitError::Store(error.to_string()))?;
+            Ok(inserted > 0)
+        })
+    }
+
+    /// Clear a host-local pause. Returns `false` when it was not paused.
+    pub fn routine_resume(&self, routine_name: &str) -> Result<bool, OrbitError> {
+        self.with_transaction_behavior(TransactionBehavior::Immediate, |tx| {
+            let deleted = tx
+                .tx
+                .execute(
+                    "DELETE FROM routine_pauses WHERE routine_name = ?1",
+                    params![routine_name],
+                )
+                .map_err(|error| OrbitError::Store(error.to_string()))?;
+            Ok(deleted > 0)
+        })
+    }
+
+    /// All host-local pauses, keyed by routine name.
+    pub fn routine_pauses(&self) -> Result<BTreeMap<String, RoutinePauseRecord>, OrbitError> {
+        let conn = self.read()?;
+        let mut stmt = conn
+            .prepare("SELECT routine_name, paused_at, actor FROM routine_pauses")
+            .map_err(|error| OrbitError::Store(error.to_string()))?;
+        let rows = stmt
+            .query_map([], |row| {
+                Ok(RoutinePauseRecord {
+                    routine_name: row.get(0)?,
+                    paused_at: row.get(1)?,
+                    actor: row.get(2)?,
+                })
+            })
+            .map_err(|error| OrbitError::Store(error.to_string()))?;
+        let mut pauses = BTreeMap::new();
+        for row in rows {
+            let pause = row.map_err(|error| OrbitError::Store(error.to_string()))?;
+            pauses.insert(pause.routine_name.clone(), pause);
+        }
+        Ok(pauses)
+    }
+}
+
+const FIRE_COLUMNS: &str =
+    "routine_name, slot, attempt, state, run_id, source_workspace, detail, created_at, updated_at";
+
+struct FireRow {
+    routine_name: String,
+    slot: String,
+    attempt: u32,
+    state: String,
+    run_id: Option<String>,
+    source_workspace: String,
+    detail: Option<String>,
+    created_at: String,
+    updated_at: String,
+}
+
+fn fire_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<FireRow> {
+    Ok(FireRow {
+        routine_name: row.get(0)?,
+        slot: row.get(1)?,
+        attempt: row.get(2)?,
+        state: row.get(3)?,
+        run_id: row.get(4)?,
+        source_workspace: row.get(5)?,
+        detail: row.get(6)?,
+        created_at: row.get(7)?,
+        updated_at: row.get(8)?,
+    })
+}
+
+fn collect_fires(
+    rows: impl Iterator<Item = rusqlite::Result<FireRow>>,
+) -> Result<Vec<RoutineFireRecord>, OrbitError> {
+    let mut fires = Vec::new();
+    for row in rows {
+        fires.push(RoutineFireRecord::try_from_row(
+            row.map_err(|error| OrbitError::Store(error.to_string()))?,
+        )?);
+    }
+    Ok(fires)
+}
+
+impl RoutineFireRecord {
+    fn try_from_row(row: FireRow) -> Result<Self, OrbitError> {
+        Ok(Self {
+            state: RoutineFireState::parse(&row.state).ok_or_else(|| {
+                OrbitError::Store(format!(
+                    "routine fire ({}, {}, {}) has unknown state '{}'",
+                    row.routine_name, row.slot, row.attempt, row.state
+                ))
+            })?,
+            routine_name: row.routine_name,
+            slot: row.slot,
+            attempt: row.attempt,
+            run_id: row.run_id,
+            source_workspace: row.source_workspace,
+            detail: row.detail,
+            created_at: row.created_at,
+            updated_at: row.updated_at,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/orbit-store/src/sqlite/routine_store/tests/mod.rs
+++ b/crates/orbit-store/src/sqlite/routine_store/tests/mod.rs
@@ -1,0 +1,1 @@
+mod routine_store;

--- a/crates/orbit-store/src/sqlite/routine_store/tests/routine_store.rs
+++ b/crates/orbit-store/src/sqlite/routine_store/tests/routine_store.rs
@@ -1,0 +1,197 @@
+use crate::sqlite::routine_store::try_acquire_routine_sweep_lock;
+use crate::{RoutineFireIntentParams, RoutineFireState, Store};
+
+fn store() -> Store {
+    Store::open_in_memory().expect("in-memory store")
+}
+
+fn intent(name: &str, slot: &str, attempt: u32) -> RoutineFireIntentParams {
+    RoutineFireIntentParams {
+        routine_name: name.to_string(),
+        slot: slot.to_string(),
+        attempt,
+        source_workspace: "polaris".to_string(),
+    }
+}
+
+#[test]
+fn baseline_is_idempotent_and_never_moves() {
+    let store = store();
+    assert!(
+        store
+            .routine_record_baseline("nightly", "2026-07-01T00:00:00+00:00")
+            .expect("first baseline")
+    );
+    assert!(
+        !store
+            .routine_record_baseline("nightly", "2026-07-02T00:00:00+00:00")
+            .expect("second baseline")
+    );
+    let cursor = store
+        .routine_cursor("nightly")
+        .expect("cursor")
+        .expect("cursor exists");
+    assert_eq!(cursor.baseline_at, "2026-07-01T00:00:00+00:00");
+    assert_eq!(cursor.last_slot, None);
+}
+
+#[test]
+fn fire_intent_is_idempotent_per_slot_and_advances_cursor() {
+    let store = store();
+    store
+        .routine_record_baseline("nightly", "2026-07-01T00:00:00+00:00")
+        .expect("baseline");
+
+    let slot = "2026-07-02T22:00:00+00:00";
+    assert!(
+        store
+            .routine_record_fire_intent(&intent("nightly", slot, 1))
+            .expect("first claim")
+    );
+    // A second sweep racing on the same slot must not claim it again.
+    assert!(
+        !store
+            .routine_record_fire_intent(&intent("nightly", slot, 1))
+            .expect("second claim")
+    );
+
+    let cursor = store
+        .routine_cursor("nightly")
+        .expect("cursor")
+        .expect("cursor exists");
+    assert_eq!(cursor.last_slot.as_deref(), Some(slot));
+
+    // A retry of the same slot is a distinct attempt, not a duplicate.
+    assert!(
+        store
+            .routine_record_fire_intent(&intent("nightly", slot, 2))
+            .expect("retry claim")
+    );
+}
+
+#[test]
+fn fire_lifecycle_updates_state_run_id_and_detail() {
+    let store = store();
+    let slot = "2026-07-02T22:00:00+00:00";
+    store
+        .routine_record_fire_intent(&intent("nightly", slot, 1))
+        .expect("claim");
+
+    store
+        .routine_mark_fire_dispatched("nightly", slot, 1, "run-123")
+        .expect("dispatched");
+    let fire = store
+        .routine_latest_fire("nightly")
+        .expect("latest")
+        .expect("fire exists");
+    assert_eq!(fire.state, RoutineFireState::Dispatched);
+    assert_eq!(fire.run_id.as_deref(), Some("run-123"));
+    assert!(!fire.state.is_terminal());
+
+    store
+        .routine_mark_fire_outcome("nightly", slot, 1, RoutineFireState::Failed, Some("exit 1"))
+        .expect("outcome");
+    let fire = store
+        .routine_latest_fire("nightly")
+        .expect("latest")
+        .expect("fire exists");
+    assert_eq!(fire.state, RoutineFireState::Failed);
+    // run_id survives the outcome update (COALESCE keeps the old value).
+    assert_eq!(fire.run_id.as_deref(), Some("run-123"));
+    assert_eq!(fire.detail.as_deref(), Some("exit 1"));
+    assert!(fire.state.is_terminal());
+}
+
+#[test]
+fn unresolved_fires_lists_only_non_terminal_states() {
+    let store = store();
+    store
+        .routine_record_fire_intent(&intent("a", "2026-07-02T01:00:00+00:00", 1))
+        .expect("claim a");
+    store
+        .routine_record_fire_intent(&intent("b", "2026-07-02T02:00:00+00:00", 1))
+        .expect("claim b");
+    store
+        .routine_mark_fire_dispatched("b", "2026-07-02T02:00:00+00:00", 1, "run-b")
+        .expect("dispatch b");
+    store
+        .routine_record_fire_intent(&intent("c", "2026-07-02T03:00:00+00:00", 1))
+        .expect("claim c");
+    store
+        .routine_mark_fire_outcome(
+            "c",
+            "2026-07-02T03:00:00+00:00",
+            1,
+            RoutineFireState::Succeeded,
+            None,
+        )
+        .expect("resolve c");
+
+    let unresolved = store.routine_unresolved_fires().expect("unresolved");
+    let names: Vec<&str> = unresolved
+        .iter()
+        .map(|fire| fire.routine_name.as_str())
+        .collect();
+    assert_eq!(names, vec!["a", "b"]);
+}
+
+#[test]
+fn latest_fire_orders_by_slot_then_attempt() {
+    let store = store();
+    for (slot, attempt) in [
+        ("2026-07-01T22:00:00+00:00", 1),
+        ("2026-07-02T22:00:00+00:00", 1),
+        ("2026-07-02T22:00:00+00:00", 2),
+    ] {
+        store
+            .routine_record_fire_intent(&intent("nightly", slot, attempt))
+            .expect("claim");
+    }
+    let latest = store
+        .routine_latest_fire("nightly")
+        .expect("latest")
+        .expect("fire exists");
+    assert_eq!(latest.slot, "2026-07-02T22:00:00+00:00");
+    assert_eq!(latest.attempt, 2);
+
+    let recent = store.routine_recent_fires("nightly", 2).expect("recent");
+    assert_eq!(recent.len(), 2);
+    assert_eq!(recent[0].attempt, 2);
+    assert_eq!(recent[1].attempt, 1);
+}
+
+#[test]
+fn pause_and_resume_round_trip() {
+    let store = store();
+    assert!(store.routine_pause("nightly", "human").expect("pause"));
+    assert!(!store.routine_pause("nightly", "human").expect("re-pause"));
+
+    let pauses = store.routine_pauses().expect("pauses");
+    assert!(pauses.contains_key("nightly"));
+    assert_eq!(pauses["nightly"].actor.as_deref(), Some("human"));
+
+    assert!(store.routine_resume("nightly").expect("resume"));
+    assert!(!store.routine_resume("nightly").expect("re-resume"));
+    assert!(store.routine_pauses().expect("pauses").is_empty());
+}
+
+#[test]
+fn sweep_lock_is_exclusive_per_path_and_released_on_drop() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let first = try_acquire_routine_sweep_lock(dir.path())
+        .expect("acquire")
+        .expect("lock free");
+    assert!(
+        try_acquire_routine_sweep_lock(dir.path())
+            .expect("second acquire")
+            .is_none(),
+        "held lock must not be re-acquirable"
+    );
+    drop(first);
+    assert!(
+        try_acquire_routine_sweep_lock(dir.path())
+            .expect("third acquire")
+            .is_some(),
+        "dropped lock must be re-acquirable"
+    );
+}

--- a/crates/orbit-store/src/sqlite/routine_store/types.rs
+++ b/crates/orbit-store/src/sqlite/routine_store/types.rs
@@ -1,0 +1,117 @@
+//! Row and parameter types for the host-local routine scheduler state.
+
+use serde::{Deserialize, Serialize};
+
+/// Lifecycle of one fire attempt. `Intent` and `Dispatched` are the
+/// non-terminal states [`crate::Store::routine_unresolved_fires`] returns;
+/// everything else is terminal.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RoutineFireState {
+    /// Claimed (idempotency key written) but not yet handed to the run
+    /// machinery. A crashed sweep can leave a fire here.
+    Intent,
+    /// Submitted to the run machinery; `run_id` is set.
+    Dispatched,
+    /// The dispatched run finished successfully.
+    Succeeded,
+    /// The dispatched run finished in failure.
+    Failed,
+    /// The fire exceeded the routine's `policy.timeout_minutes` without a
+    /// terminal run outcome and no longer blocks `overlap: forbid`.
+    TimedOut,
+    /// Dispatch itself errored (e.g. target no longer resolvable).
+    Error,
+}
+
+impl RoutineFireState {
+    /// Stable string form persisted in the `routine_fires.state` column.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Intent => "intent",
+            Self::Dispatched => "dispatched",
+            Self::Succeeded => "succeeded",
+            Self::Failed => "failed",
+            Self::TimedOut => "timed_out",
+            Self::Error => "error",
+        }
+    }
+
+    /// Inverse of [`Self::as_str`]; `None` for unknown values.
+    pub fn parse(value: &str) -> Option<Self> {
+        match value {
+            "intent" => Some(Self::Intent),
+            "dispatched" => Some(Self::Dispatched),
+            "succeeded" => Some(Self::Succeeded),
+            "failed" => Some(Self::Failed),
+            "timed_out" => Some(Self::TimedOut),
+            "error" => Some(Self::Error),
+            _ => None,
+        }
+    }
+
+    /// Whether this state ends the fire's lifecycle.
+    pub fn is_terminal(self) -> bool {
+        !matches!(self, Self::Intent | Self::Dispatched)
+    }
+}
+
+/// Per-routine scheduling cursor on this host.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RoutineCursor {
+    /// Routine this cursor belongs to.
+    pub routine_name: String,
+    /// RFC 3339 timestamp of this host's first observation of the routine.
+    /// Slots scheduled before it never fire.
+    pub baseline_at: String,
+    /// RFC 3339 timestamp of the last scheduled slot consumed (fired or
+    /// claimed), if any.
+    pub last_slot: Option<String>,
+}
+
+/// Parameters for recording a fire intent (the idempotency claim).
+#[derive(Debug, Clone)]
+pub struct RoutineFireIntentParams {
+    /// Routine being fired.
+    pub routine_name: String,
+    /// RFC 3339 timestamp of the scheduled slot being consumed.
+    pub slot: String,
+    /// 1-based attempt number (retries increment it under the same slot).
+    pub attempt: u32,
+    /// Name of the source workspace the definition was loaded from.
+    pub source_workspace: String,
+}
+
+/// One recorded fire attempt.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RoutineFireRecord {
+    /// Routine that fired.
+    pub routine_name: String,
+    /// RFC 3339 timestamp of the scheduled slot this fire consumed.
+    pub slot: String,
+    /// 1-based attempt number under this slot.
+    pub attempt: u32,
+    /// Current lifecycle state.
+    pub state: RoutineFireState,
+    /// Run id returned by the run machinery once dispatched.
+    pub run_id: Option<String>,
+    /// Source workspace name the definition was loaded from.
+    pub source_workspace: String,
+    /// Optional detail (dispatch error, outcome message).
+    pub detail: Option<String>,
+    /// RFC 3339 creation (intent) timestamp.
+    pub created_at: String,
+    /// RFC 3339 timestamp of the last state change.
+    pub updated_at: String,
+}
+
+/// One host-local pause row.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RoutinePauseRecord {
+    /// Paused routine.
+    pub routine_name: String,
+    /// RFC 3339 timestamp the pause was written.
+    pub paused_at: String,
+    /// Who paused it (actor label), when recorded.
+    pub actor: Option<String>,
+}

--- a/docs/design/routines/1_overview.md
+++ b/docs/design/routines/1_overview.md
@@ -1,8 +1,8 @@
 ---
 title: Routines — Overview
 owner: claude
-last_updated: 2026-07-03
-status: Draft
+last_updated: 2026-07-04
+status: Accepted
 feature: routines
 doc_role: overview
 type: design
@@ -10,7 +10,7 @@ summary: Durable, git-versioned scheduler primitive that fires catalog jobs/acti
 tags: [routines, scheduler]
 paths: ["crates/orbit-cli/src/command/routine/**", "crates/orbit-core/src/routines/**"]
 related_features: [routines, activity-job]
-related_artifacts: [ORB-10001]
+related_artifacts: [ORB-10001, ORB-10021]
 ---
 
 # Routines — Overview
@@ -21,11 +21,12 @@ activity/job catalog, host pinning, and a retry/overlap policy. A stateless **`o
 pass, invoked every minute by the OS scheduler (launchd on macOS, a systemd timer on Linux),
 fires whatever is due on the current host through the existing v2 run machinery. Definitions
 are shared across hosts via git; all scheduler state (last fires, pauses, locks, run history)
-is host-local and never synced. [2_design.md](./2_design.md) is the proposed contract;
+is host-local and never synced. [2_design.md](./2_design.md) is the v1 contract;
 [3_vision.md](./3_vision.md) holds what is deliberately out of scope for v1.
 
-> **Status.** This feature is a design proposal. Nothing described here is implemented yet;
-> the At a Glance table lists *proposed* homes for each concern.
+> **Status.** v1 shipped in [ORB-10021]; the At a Glance table lists the actual home of
+> each concern. Targets are `job:<name>` in v1 — see [ADR-0206] for why `activity:` is
+> reserved.
 
 ---
 
@@ -58,8 +59,9 @@ fragmentation this feature exists to end.
 
 - **Routine** — a versioned YAML definition in a routine-source workspace: name, trigger,
   target, `hosts`, `enabled`, and policy. The durable unit of scheduling.
-- **Target** — what fires: a reference into the existing catalog (`job:<name>` or
-  `activity:<name>`). Routines carry no inline commands; the `shell` activity variant was
+- **Target** — what fires: a reference into the existing catalog. v1 dispatches
+  `job:<name>`; `activity:<name>` is reserved (wrap the activity in a one-step job — see
+  [ADR-0206]). Routines carry no inline commands; the `shell` activity variant was
   removed fail-closed in [ORB-00374] (see [ADR-0194]), and routines inherit that posture.
 - **Sweep** — `orbit sweep`, the stateless due-check pass the OS clock invokes every minute.
   Loads definitions, filters for this host, fires due routines, records state, exits.
@@ -77,22 +79,23 @@ fragmentation this feature exists to end.
 
 ## 3. At a Glance
 
-All rows are proposed, not shipped; the task column fills in as work is created.
-
-| Concern | File (proposed) | Task |
-|---------|-----------------|------|
-| Routine definition type + YAML loader | `crates/orbit-common/src/types/routine.rs` | — |
-| Due computation, host filter, dispatch | `crates/orbit-core/src/routines/` | — |
-| Host-local scheduler state (fires, pauses, locks) | `crates/orbit-store/src/sqlite/routine_store/` | — |
-| `orbit sweep` CLI entrypoint | `crates/orbit-cli/src/command/sweep.rs` | — |
-| `orbit routine` CLI (`list/show/pause/resume/init`) | `crates/orbit-cli/src/command/routine/` | — |
-| launchd/systemd unit templates + installer | `crates/orbit-core/assets/clock/` | — |
+| Concern | File | Task |
+|---------|------|------|
+| Routine definition type + fail-closed YAML parse | `crates/orbit-common/src/types/routine.rs` | [ORB-10021] |
+| Discovery, due computation, dispatch, status | `crates/orbit-core/src/routines/` | [ORB-10021] |
+| Host-local scheduler state (fires, pauses) | `crates/orbit-store/src/sqlite/routine_store/` | [ORB-10021] |
+| Sweep advisory lock (flock, host-global) | `crates/orbit-store/src/sqlite/routine_store/mod.rs` | [ORB-10021] |
+| `orbit sweep` CLI entrypoint | `crates/orbit-cli/src/command/sweep.rs` | [ORB-10021] |
+| `orbit routine` CLI (`list/show/pause/resume/init`) | `crates/orbit-cli/src/command/routine/` | [ORB-10021] |
+| launchd/systemd unit templates + installer | `crates/orbit-core/assets/clock/` + `src/routines/clock.rs` | [ORB-10021] |
+| `[routines] role = "source"` config key | `crates/orbit-core/src/config/{raw,runtime}.rs` | [ORB-10021] |
 
 ---
 
 ## Task References
 
 - [ORB-10001] — authored this design-doc folder (proposal; no implementation).
+- [ORB-10021] — implemented routines v1 (types, store, sweep, CLI, clock units).
 - [ORB-00374] — removed the `shell` activity variant and `run_shell` dispatch (fail-closed);
   routines inherit this constraint.
 

--- a/docs/design/routines/2_design.md
+++ b/docs/design/routines/2_design.md
@@ -1,8 +1,8 @@
 ---
 title: Routines — Design
 owner: claude
-last_updated: 2026-07-03
-status: Draft
+last_updated: 2026-07-04
+status: Accepted
 feature: routines
 doc_role: design
 type: design
@@ -10,14 +10,14 @@ summary: Proposed contract for routine definitions, sweep dispatch, host-local s
 tags: [routines, scheduler]
 paths: ["crates/orbit-cli/src/command/routine/**", "crates/orbit-core/src/routines/**"]
 related_features: [routines, activity-job]
-related_artifacts: [ORB-10001]
+related_artifacts: [ORB-10001, ORB-10021]
 ---
 
 # Routines — Design
 
-This doc is the proposed v1 contract: the routine definition schema, how definitions are
-discovered, what `orbit sweep` does on each invocation, where state lives, and how the OS
-clock drives it. Cross-host coordination, event triggers, and everything else deferred is
+This doc is the v1 contract as shipped in [ORB-10021]: the routine definition schema,
+how definitions are discovered, what `orbit sweep` does on each invocation, where state
+lives, and how the OS clock drives it. Cross-host coordination, event triggers, and everything else deferred is
 in [3_vision.md](./3_vision.md). Decision rationale lives in [4_decisions.md](./4_decisions.md).
 
 ---
@@ -36,8 +36,8 @@ enabled: true                  # global kill-switch, versioned
 hosts: [dk-mac]                # explicit host pinning; no "any host" in v1
 trigger:
   cron: "0 22 * * *"           # standard 5-field cron, evaluated in host-local time
-  missed_run: catch_up_once    # catch_up_once | skip
-target: job:almanac_commit_pipeline   # job:<name> | activity:<name>, resolved via the catalog
+  missed_run: catch_up_once    # catch_up_once | skip (default: skip)
+target: job:almanac_commit_pipeline   # job:<name>, resolved via the catalog
 policy:
   timeout_minutes: 10
   retries: { max: 2, backoff_minutes: 2 }
@@ -53,13 +53,19 @@ Field semantics:
 - **`trigger.cron`** — when the routine is due. `missed_run` governs fires that fall in a
   window when the host was asleep or powered off: `catch_up_once` fires a single make-up run
   on the next sweep (never one per missed slot); `skip` waits for the next natural slot.
-- **`target`** — a `job:` or `activity:` reference resolved through the existing catalog at
-  load time, exactly like `target:` steps in `JobV2`. Unresolvable targets are load-time
-  errors. There is deliberately no inline command form: the `shell` activity variant was
-  removed fail-closed in [ORB-00374] / [ADR-0194], and reintroducing arbitrary-command
+- **`target`** — a `job:<name>` reference resolved through the source workspace's job
+  catalog at load time. Unresolvable targets are load-time errors. `activity:<name>` is
+  reserved and rejected at parse time with wrapping guidance: run dispatch is job-shaped
+  (`submit_pipeline_run` resolves jobs by name; nothing dispatches a bare activity), and a
+  one-step wrapper job in the same source workspace is the existing composition grammar
+  ([ADR-0206]). There is deliberately no inline command form: the `shell` activity variant
+  was removed fail-closed in [ORB-00374] / [ADR-0194], and reintroducing arbitrary-command
   payloads through the scheduler would reopen that surface on a timer.
 - **`policy`** — applied by the dispatcher around the run: timeout, bounded retries with
-  fixed backoff, and overlap handling. `overlap: forbid` is the default.
+  fixed backoff, and overlap handling. `overlap: forbid` is the default; `timeout_minutes`
+  defaults to 60 and doubles as the staleness horizon (§4), `retries` defaults to
+  `{max: 0, backoff_minutes: 2}`. Retries re-dispatch a *failed* fire under the same slot
+  (attempt 2..max+1) once the backoff has elapsed, evaluated on later sweep passes.
 
 Parsing is fail-closed: an invalid routine file is reported and *that routine* is treated
 as absent; it never degrades into "fire with defaults".
@@ -93,7 +99,9 @@ properties fall out:
 
 Host identity is the one genuinely host-local datum: `~/.orbit/host.toml` carries
 `host_id = "dk-mac"`, defaulting to the machine hostname when absent. `orbit routine init`
-writes it and (with `--install-clock`) installs the OS clock unit (§5).
+writes it and (with `--install-clock`) installs the OS clock unit (§5). A malformed
+`host.toml` is an error, not a fallback; a `[routines] role` value other than `"source"`
+is a config error (fail-closed on both).
 
 ---
 
@@ -111,13 +119,20 @@ Per pass:
    exit immediately — overlapping invocations from a slow prior pass must not double-fire.
 2. Load the registry; collect routines from all source workspaces (fail-closed per file).
 3. Filter to routines where `enabled`, `hosts` contains this `host_id`, and no local pause.
-4. For each, compute due-ness from the cron expression and the persisted last-fire
-   timestamp; apply `missed_run` policy for gaps.
-5. For each due routine: check `overlap` against in-flight fires, record the fire intent
-   (idempotency key: routine name + scheduled slot), then dispatch the target through the
-   existing v2 run entrypoints in the routine's source workspace, tagging provenance
-   `origin: routine/<name>` in the audit envelope.
-6. Record outcomes and exit.
+4. Sync unresolved fires against actual run state, reclaiming entries older than the
+   routine's `timeout_minutes` (the staleness horizon — a sweep that crashed between
+   intent and dispatch must not block `overlap: forbid` forever).
+5. For each, compute due-ness from the cron expression and the persisted cursor
+   (last slot, else the first-observation baseline — a routine never fires for slots that
+   predate its registration on this host; the first sweep records the baseline and fires
+   nothing). Due-ness is O(1) via previous-occurrence lookup, never a walk over every
+   missed slot; `missed_run` policy decides gaps. A slot is "natural" within a 120s grace
+   of its scheduled time.
+6. For each due routine: check `overlap` against in-flight fires, record the fire intent
+   (idempotency key: routine name + scheduled slot + attempt, transactionally with the
+   cursor advance), then dispatch the target via `submit_pipeline_run` in the routine's
+   source workspace with actor `routine/<name>` as run provenance.
+7. Record outcomes and exit.
 
 Fires are normal runs: they appear in run history, carry v2 audit envelopes, and are
 debuggable with the existing run tooling — there is no separate "scheduled run" ledger.
@@ -130,14 +145,18 @@ vision item ([3_vision.md](./3_vision.md) §1), not a v1 goal.
 
 ## 4. Host-Local State and Toggles
 
-All scheduler state lives in a host-local SQLite store (`routine_store`, following the
-existing store patterns), gitignored and never synced:
+All scheduler state lives host-locally (the `routine_*` tables in the host-global store
+database `~/.orbit/orbit.db`, module `orbit-store/src/sqlite/routine_store/`), gitignored
+and never synced:
 
-- **fires** — per routine: last scheduled slot fired, fire intents (idempotency keys),
-  outcome, dispatched run id.
-- **pauses** — host-local suppressions written by `orbit routine pause <name>` / cleared by
-  `resume`. Durable across reboots; invisible to git.
-- **sweep lock** — the advisory lock from §3.
+- **routine_cursors** — per routine: first-observation baseline + last slot consumed.
+- **routine_fires** — one row per fire attempt: `(name, slot, attempt)` idempotency key,
+  state (`intent → dispatched → succeeded/failed/timed_out/error`), dispatched run id.
+- **routine_pauses** — host-local suppressions written by `orbit routine pause <name>` /
+  cleared by `resume`. Durable across reboots; invisible to git.
+- **sweep lock** — a `flock(2)` file lock (`~/.orbit/state/routine-sweep.lock`) rather
+  than a table: the OS releases it on process death, so a crashed sweep never wedges the
+  next pass and no lock-staleness logic is needed.
 
 Toggle resolution, in order: `enabled: false` (versioned, everywhere) → not in `hosts`
 (versioned, per host) → local pause (unversioned, this host only). `orbit routine list`
@@ -184,14 +203,19 @@ out of v1 scope for this reason.
   be a new `missed_run` variant.
 - **First minute of overlap risk is on the dispatcher.** `overlap: forbid` depends on
   accurate in-flight bookkeeping; a crashed sweep that recorded a fire intent but died
-  before dispatch leaves a stale in-flight entry. The store needs a staleness horizon
-  (intent older than policy timeout → reclaimable) — easy to get subtly wrong; needs tests.
+  before dispatch leaves a stale in-flight entry. The outcome-sync step reclaims intents
+  and dispatches older than `policy.timeout_minutes` (marking them `error` / `timed_out`);
+  the consumed slot is not re-fired — the idempotency key holds.
+- **Routines carry no input payload.** v1 dispatches every target with an empty input
+  object; jobs meant for routines must run with defaults. Parameterized fires would be a
+  schema addition.
 
 ---
 
 ## Task References
 
 - [ORB-10001] — authored this design-doc folder (proposal; no implementation).
+- [ORB-10021] — implemented routines v1 (types, store, sweep, CLI, clock units).
 - [ORB-00374] — removed the `shell` activity variant and `run_shell` dispatch (fail-closed);
   routines inherit this constraint.
 

--- a/docs/design/routines/3_vision.md
+++ b/docs/design/routines/3_vision.md
@@ -1,7 +1,7 @@
 ---
 title: Routines — Vision
 owner: claude
-last_updated: 2026-07-03
+last_updated: 2026-07-04
 status: Draft
 feature: routines
 doc_role: vision
@@ -10,7 +10,7 @@ summary: Open questions and prior art for the routines scheduler — leases, eve
 tags: [routines, scheduler]
 paths: ["crates/orbit-core/src/routines/**"]
 related_features: [routines, activity-job]
-related_artifacts: [ORB-10001]
+related_artifacts: [ORB-10001, ORB-10021]
 ---
 
 # Routines — Vision
@@ -23,6 +23,10 @@ and an ADR, not by drifting in.
 
 ## 1. Open Questions
 
+0. **First-class `activity:` targets.** v1 rejects `activity:<name>` at parse time because
+   run dispatch is job-shaped ([ADR-0206]); the wrapper-job idiom covers current needs. A
+   standalone activity run entrypoint (or auto-wrapping) would let routines fire
+   activities directly — worth doing only if the wrapper friction proves real.
 1. **Single-fire across hosts.** v1 pins routines to explicit hosts. A "exactly one of N"
    mode needs a lease: the natural v2 shape is a lease table in one designated host's store,
    reached over SSH (port 22 is the only always-open channel between the current hosts).
@@ -110,5 +114,6 @@ External:
 ## Task References
 
 - [ORB-10001] — authored this design-doc folder (proposal; no implementation).
+- [ORB-10021] — implemented routines v1.
 
 > Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.

--- a/docs/design/routines/4_decisions.md
+++ b/docs/design/routines/4_decisions.md
@@ -1,16 +1,16 @@
 ---
 title: Routines — Decisions
 owner: claude
-last_updated: 2026-07-03
-status: Draft
+last_updated: 2026-07-04
+status: Accepted
 feature: routines
 doc_role: decisions
 type: design
-summary: ADR log for the routines scheduler; candidate decisions pending global ID allocation.
+summary: ADR log for the routines scheduler — five decisions allocated and accepted with the v1 implementation.
 tags: [routines, scheduler]
 paths: ["crates/orbit-core/src/routines/**"]
 related_features: [routines, activity-job]
-related_artifacts: [ORB-10001]
+related_artifacts: [ORB-10001, ORB-10021]
 ---
 
 # Routines — Decisions
@@ -19,71 +19,170 @@ This is the append-only ADR log for the `routines` feature. Entries are ordered 
 ascending global ADR number, each keyed on an ID allocated through `orbit.adr.add`; the
 ADR store is the source of truth for status, owner, `related_features`, and `related_tasks`.
 
-> **No ADRs allocated yet.** The feature is a proposal; per convention, global IDs are
-> allocated via `orbit.adr.add` before any `## ADR-` heading is written, so this log starts
-> with the candidate decisions below. Each candidate meets the three-part ADR bar (real
-> alternative, forward constraint, non-trivial cost) and should be allocated as `Proposed`
-> when the feature's first task is cut, then written up here under its allocated heading.
+The five candidate decisions recorded by [ORB-10001] were allocated as ADR-0204..ADR-0208
+when the v1 implementation task ([ORB-10021]) was cut, and accepted when it shipped.
 
 ---
 
-## Candidate decisions (pending allocation)
+## ADR-0204 — The OS owns the clock: stateless `orbit sweep` under launchd/systemd, no resident daemon
 
-### Candidate: definitions are git-shared; scheduler state is host-local and never synced
+**Status:** Accepted · 2026-07 · [ORB-10021]
 
-- **Alternative considered:** syncing scheduler state (last fires, pauses) between hosts so
-  either machine can answer for both.
-- **Decision sketch:** routine YAML is versioned and converges via git; fires, pauses, and
-  locks live in a host-local SQLite `routine_store`. No scheduler network protocol exists.
-- **Cost:** cross-host observability requires asking each host (no single pane of glass),
-  and a definition edit is only as fresh on the other host as its last `git pull`.
+### Context
 
-### Candidate: discovery via the workspace registry + `[routines] role = "source"`, not a host-level pointer file
+Something must wake the scheduler. The alternatives were a resident `orbit schedulerd`
+owning timers in-process (sub-minute precision, event triggers, but a daemon to supervise
+on two platforms), or delegating wake-ups to the OS schedulers that already exist —
+launchd on macOS, systemd timers on Linux — invoking a stateless pass every minute.
 
-- **Alternative considered:** a `~/.orbit/host.toml` entry pointing at one designated
-  control-workspace path per host (explicit two-way handshake).
-- **Decision sketch:** sweep enumerates `~/.orbit/workspaces.json` and collects routines
-  from registered workspaces whose versioned config opts in — the `ship-sweep` /
-  `auto_ship` precedent. Centralizing all routines in polaris is constellation convention,
-  not Orbit mechanism. `host.toml` survives only to carry `host_id`.
-- **Cost:** any registered workspace's config can make it a routine source — the review
-  boundary widens from one blessed repo to every registered workspace's `config.toml`, and
-  sweep behavior now depends on registry hygiene (stale registered paths must be skipped
-  loudly, not silently).
+### Decision
 
-### Candidate: hosts are pinned explicitly; no cross-host coordination in v1
+launchd (`StartInterval` 60s) and a systemd user timer (`OnCalendar=*:*:00`,
+`Persistent=true`) invoke `orbit sweep` every minute; sweep is stateless-in, durable-out.
+Missed-fire semantics split between the OS layer (wake/persistence behavior) and
+per-routine `missed_run` policy. There is no resident Orbit daemon. Unit templates live
+in `crates/orbit-core/assets/clock/` and are installed by
+`orbit routine init --install-clock`.
 
-- **Alternative considered:** a "run on exactly one host" mode backed by leases.
-- **Decision sketch:** `hosts:` lists every host a routine fires on; listing two hosts
-  means two independent fires. Failover is out of scope until a real routine needs it.
-- **Cost:** no routine survives its pinned host being down; adding leases later introduces
-  a second, coordinated mode whose semantics diverge from everything shipped in v1.
+### Consequences
 
-### Candidate: targets are catalog references only — no inline command payloads
+- No process supervision, crash recovery, or memory-leak surface; a wedged pass affects
+  one minute, not the scheduler.
+- launchd wake behavior and `Persistent=true` pair with `missed_run: catch_up_once` to
+  cover laptop sleep and host downtime.
+- Cost: minute granularity is a hard floor and event triggers are structurally impossible
+  in v1; correct behavior depends on two platform-specific unit files that must be kept in
+  parity and tested on both platforms.
 
-- **Alternative considered:** a `run: {type: shell, command: ...}` payload for small
-  chores, which was the original design sketch before [ADR-0194] surfaced.
-- **Decision sketch:** `target:` accepts `job:<name>` / `activity:<name>` resolved through
-  the existing catalog, load-time-validated, executing under existing activity/job policy.
-  Shell-like chores become `deterministic` activities or jobs in the source workspace.
-- **Cost:** every new chore requires authoring a catalog asset (higher friction than a
-  one-line command), and scheduler capability is permanently coupled to catalog capability.
+---
 
-### Candidate: the OS owns the clock — stateless `orbit sweep` under launchd/systemd, no daemon
+## ADR-0205 — Routine discovery via the workspace registry and a versioned `[routines] role = "source"` config key
 
-- **Alternative considered:** a resident `orbit schedulerd` owning timers in-process.
-- **Decision sketch:** launchd (`StartInterval`) and a systemd timer (`Persistent=true`)
-  invoke `orbit sweep` every minute; sweep is stateless-in, durable-out. Missed-fire
-  semantics are split between the OS layer (wake/persistence) and per-routine
-  `missed_run` policy.
-- **Cost:** minute granularity is a hard floor, event triggers are structurally impossible
-  in v1, and correct behavior depends on two platform-specific unit files that must be
-  kept in parity and tested on both platforms.
+**Status:** Accepted · 2026-07 · [ORB-10021]
+
+### Context
+
+Sweep must find routine definitions without a resident daemon and without bootstrapping
+from the caller's cwd. The alternative was a host-level pointer file in `~/.orbit/host.toml`
+naming one designated control workspace per host (an explicit two-way handshake), versus
+reusing the global workspace registry the way `orbit run ship-sweep` / `auto_ship` already
+does for unattended cross-workspace dispatch.
+
+### Decision
+
+Sweep enumerates `~/.orbit/workspaces.json` and collects `.orbit/routines/*.yaml` from
+every registered, active workspace whose versioned `.orbit/config.toml` declares
+`[routines] role = "source"`. Centralizing all routines in polaris is constellation
+convention, not Orbit mechanism. `~/.orbit/host.toml` survives only to carry `host_id`.
+
+### Consequences
+
+- Setup is what already exists: register the workspace plus one versioned config key;
+  both hosts converge through git with no per-host pointer files.
+- `orbit routine list` names each routine's source workspace, so provenance stays
+  unambiguous with multiple sources.
+- Cost: any registered workspace's config can make it a routine source — the review
+  boundary widens from one blessed repo to every registered workspace's `config.toml`,
+  and sweep correctness now depends on registry hygiene (stale registered paths must be
+  skipped loudly, not silently).
+
+---
+
+## ADR-0206 — Routine targets are catalog references only — no inline command payloads
+
+**Status:** Accepted · 2026-07 · [ORB-10021]
+
+### Context
+
+The original sketch allowed a `run: {type: shell, command: ...}` payload for small
+chores. [ADR-0194] removed the `shell` activity variant and `run_shell` dispatch
+fail-closed; reintroducing arbitrary-command payloads through the scheduler would reopen
+that surface on a timer, unattended.
+
+### Decision
+
+`target:` accepts only catalog references resolved at load time; unresolvable targets are
+load-time errors. v1 dispatches `job:<name>` — run dispatch is job-shaped
+(`submit_pipeline_run` resolves jobs by name; there is no standalone activity run
+entrypoint), so `activity:<name>` is reserved and rejected at parse time with guidance to
+wrap the activity in a one-step job in the same source workspace. Shell-like chores become
+`deterministic` activities or jobs in the source workspace.
+
+### Consequences
+
+- Scheduled execution inherits existing activity/job policy, audit envelopes, and the
+  fail-closed posture of [ADR-0194]; the scheduler adds a trigger source, not a new
+  execution surface.
+- Load-time validation makes a broken reference visible on the next sweep instead of at
+  fire time.
+- Cost: every new chore requires authoring a catalog asset (higher friction than a
+  one-line command), and scheduler capability is permanently coupled to catalog
+  capability — including the job-shaped dispatch constraint that keeps `activity:`
+  targets out of v1.
+
+---
+
+## ADR-0207 — Routines pin hosts explicitly; no cross-host coordination in v1
+
+**Status:** Accepted · 2026-07 · [ORB-10021]
+
+### Context
+
+Some recurring work should run on exactly one machine. A "run on exactly one of N hosts"
+mode needs a lease protocol between hosts that only expose SSH to each other; the
+alternative is explicit pinning, where the definition names every host it fires on.
+
+### Decision
+
+Each routine carries a `hosts:` list matched against the host-local `host_id`; there is
+no "any host" value in v1. Listing two hosts means two independent fires. Failover stays
+out of scope until a real routine needs it.
+
+### Consequences
+
+- Due computation stays purely host-local: no lease table, no network dependency, no
+  split-brain modes to test.
+- The semantics are trivially predictable from the YAML alone.
+- Cost: no routine survives its pinned host being down, and adding leases later
+  introduces a second, coordinated mode whose semantics diverge from everything shipped
+  in v1.
+
+---
+
+## ADR-0208 — Routine definitions are git-shared; scheduler state is host-local and never synced
+
+**Status:** Accepted · 2026-07 · [ORB-10021]
+
+### Context
+
+Routines run on two hosts (dk-mac, dk-server-1) with different availability profiles.
+Definitions must converge across hosts; scheduler runtime state (last fires, pauses,
+locks) could either be synced between hosts or kept local. Syncing state would let either
+machine answer "did the nightly fire on the other box?" but requires a scheduler network
+protocol between hosts that only expose 22/443 to each other.
+
+### Decision
+
+Routine YAML definitions live in routine-source workspaces and converge via git like any
+other versioned definition. All scheduler state — fires (with `name + slot + attempt`
+idempotency keys), host-local pauses, and the sweep lock — lives in host-local storage
+(the `routine_*` tables in `~/.orbit/orbit.db`, plus a `flock(2)` sweep lock that the OS
+releases on process death), gitignored and never synced. No scheduler network protocol
+exists in v1.
+
+### Consequences
+
+- Two hosts converge on definitions through a normal `git pull`; no new sync mechanism to
+  build, secure, or debug.
+- State stays consistent with the run history it references, which is also host-local.
+- Cost: cross-host observability requires asking each host — there is no single pane of
+  glass, and a definition edit is only as fresh on the other host as its last `git pull`.
 
 ---
 
 ## Task References
 
-- [ORB-10001] — authored this design-doc folder (proposal; no implementation).
+- [ORB-10001] — authored this design-doc folder (proposal).
+- [ORB-10021] — implemented routines v1; allocated and accepted ADR-0204..ADR-0208.
 
 > Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.

--- a/scripts/ci-guardrails.sh
+++ b/scripts/ci-guardrails.sh
@@ -4,6 +4,14 @@ set -euo pipefail
 repo_root="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$repo_root"
 
+# Several guardrail scripts shell out to ripgrep; a missing `rg` degrades
+# them silently (empty search results read as "clean" or, worse, as false
+# violations). Fail fast instead. [ORB-10021]
+if ! command -v rg >/dev/null 2>&1; then
+  echo "ci-guardrails: ripgrep (rg) is required; install it before running" >&2
+  exit 1
+fi
+
 cargo fmt --all -- --check
 cargo clippy --workspace --all-targets -- -D warnings
 # Keep examples covered by clippy's all-targets pass, but avoid re-running


### PR DESCRIPTION
Implements the routines feature — Orbit as the constellation's single scheduler — per `docs/design/routines/` (proposal authored under ORB-10001; implementation task ORB-10021).

## What ships

- **Definition schema** (`orbit-common/src/types/routine.rs`): `schemaVersion: 1` YAML under `.orbit/routines/` in a source workspace — cron trigger with `missed_run: catch_up_once|skip`, catalog-only `job:<name>` target, explicit `hosts:` pinning, `timeout/retries/overlap` policy. Fail-closed parse: unknown fields, bad schema versions, inline-command-shaped targets, and `activity:` targets are load errors (`activity:` gets wrapping guidance — run dispatch is job-shaped, see ADR-0206).
- **Host-local scheduler state** (`orbit-store/src/sqlite/routine_store/`): cursors (first-observation baseline + last slot), fires keyed on `(name, slot, attempt)` recorded transactionally with the cursor advance, host-local pauses — all in the host-global `orbit.db`, never synced (ADR-0208). The sweep lock is `flock(2)`-based, so a crashed sweep never wedges the next pass.
- **Scheduler core** (`orbit-core/src/routines/`): registry discovery gated on `[routines] role = "source"` (ADR-0205), host identity from `~/.orbit/host.toml` with hostname fallback, O(1) minute-aligned due computation (croner), overlap `forbid` with a policy-timeout staleness horizon, bounded retry-with-backoff under the same slot, dispatch via `submit_pipeline_run` with actor `routine/<name>`, outcome sync against run state each pass.
- **CLI**: `orbit sweep` (stateless, lock-guarded, exit 0 on unconfigured hosts) and `orbit routine list/show/pause/resume/init [--install-clock]`; both dispatch before workspace runtime init, like ship-sweep.
- **Clock units** (`orbit-core/assets/clock/`): launchd agent (`StartInterval` 60) and systemd user timer (`OnCalendar=*:*:00`, `Persistent=true`) rendered and installed by `orbit routine init --install-clock` (ADR-0204).
- **ADRs & docs**: ADR-0204..ADR-0208 allocated via `orbit.adr.add` and accepted; `docs/design/routines/` flipped to Accepted with the shipped contract (job-only targets, staleness horizon, empty input payloads, At a Glance filled).

## Verification

- 28 new unit tests (sibling layout): fail-closed parsing, cron due-ness incl. catch-up collapse / skip / baseline suppression / minute alignment, store idempotency + pause/resume + lock exclusivity, host identity.
- End-to-end on an isolated global root: baseline-first sweep, minute-boundary fire dispatching a real `job:` run (visible in `orbit run history`, succeeded), same-slot idempotency, `overlap_in_flight` skip, pause/resume, outcome sync, dry-run, clock unit rendering with fail-soft activation.
- `make ci-fast` green; `orbit docs index` run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)