### PR TITLE
[ORB-10026] docs: ADR-0209 north-star operation-registry architecture bearing

### DIFF
--- a/.orbit/adrs/proposed/ADR-0209/adr.yaml
+++ b/.orbit/adrs/proposed/ADR-0209/adr.yaml
@@ -1,0 +1,22 @@
+schema_version: 2
+id: ADR-0209
+title: 'North-star architecture bearing: operations as data behind an operation registry'
+status: proposed
+owner: claude
+created_at: 2026-07-04T23:09:14.562930629Z
+last_updated: 2026-07-04T23:09:14.562930629Z
+related_features:
+- orbit-core
+- orbit-search
+- activity-job
+related_tasks:
+- ORB-10026
+tags:
+- north-star
+- architecture
+- operation-registry
+paths: []
+supersedes: []
+legacy_ids: []
+validation_warnings: []
+legacy_validation: none

--- a/.orbit/adrs/proposed/ADR-0209/body.md
+++ b/.orbit/adrs/proposed/ADR-0209/body.md
@@ -1,0 +1,23 @@
+## Context
+Orbit's four consumer surfaces — the CLI (`orbit-cli`), MCP (`orbit-mcp`), the web dashboard (`orbit-dashboard`), and the in-runtime agent tool hosts — are four hand-wired adapter layers over the same underlying operations, so every new operation is plumbed by hand up to four times. The same shape keeps constraining refactors: inherent `impl OrbitRuntime` methods plus the orphan rule forced the ORB-10016 / ADR-0203 orbit-cmd extraction to leave the runtime-entangled command groups behind in orbit-core as documented residuals, and the same wall shelved the docs+search pluginization (docs/design/orbit-docs-plugin/1_scope.md — pending commit). Repeated point refactors treat symptoms; the missing piece is a recorded long-term bearing that future refactors steer by. Real alternatives existed: keep the status quo and continue paying per-surface wiring, or mandate a big-bang plugin/microkernel rewrite.
+
+## Decision
+Record five bearings as orbit's north star. This is an **incremental bearing, not a rewrite mandate**: no code changes are required by this ADR, and existing code is not wrong for predating it.
+
+1. **Operations as data, not inherent methods.** Every orbit operation is eventually defined as a serializable request/response pair with a handler registered in an operation table. The four consumer surfaces become derived adapters over that registry instead of four hand-wired layers, and the recurring inherent-impl/orphan-rule constraint (ADR-0203 residuals; the shelved docs+search pluginization) dissolves because handlers are registry entries, not inherent methods on `OrbitRuntime`.
+2. **Knowledge/execution split.** Orbit is two products — a knowledge store (tasks, learnings, ADRs, docs) and an execution engine (activities, jobs, agent providers) — glued by one runtime. Bearing: two systems sharing only a kernel (IDs, errors, audit), mirroring the constellation split (polaris = knowledge, worker = execution).
+3. **Events over side-effects.** The task-mutation → semantic-index coupling becomes a transactional SQLite outbox consumed by the indexer, replacing the lossy in-process `EmbedWorker` enqueue (best-effort batches, drops on queue-full, debug-level failure logging).
+4. **One retrieval trait, two backends.** orbit-search (workspace-local) and sextant (constellation-wide) become deployment choices behind one retrieval interface, dissolving the two-stack question.
+5. **Crates follow build boundaries, not taxonomy.** Crate splits are justified by compile-graph and dependency-direction needs, not by conceptual category. Explicitly kept as-is under this bearing: the ADR-005 companion-subprocess packaging pattern (docs/design/orbit-search/4_decisions.md ADR-005, global ADR-0117), the YAML+SQLite layered store in orbit-store, and the stability-tier markers (ARCHITECTURE.md §Stability tiers).
+
+**Adoption model.** Incremental and opportunistic: when a new surface is added or an existing command group is touched for other reasons, move that slice to request/response + registry then. Future ADRs should cite this bearing when steering by it, or supersede it if the bearing itself changes.
+
+**Alternatives rejected.** (a) *Status quo as the implicit bearing*: keeps charging up to 4× adapter wiring per operation and guarantees the next boundary refactor hits the same inherent-impl/orphan-rule wall with no recorded direction — the cost that motivated this ADR. (b) *Big-bang registry rewrite*: months of churn across every surface with no incremental payoff and high regression risk in a codebase that ships continuously; rejected in favor of the touch-it-move-it model.
+
+## Consequences
+- Future architecture ADRs have a fixed point to cite or supersede; "which direction were we going?" is answerable from the store.
+- Slices touched after this ADR should trend toward request/response + registry; reviewers can ask "why not the registry shape?" when a new hand-wired adapter appears.
+- The knowledge/execution split (bearing 2) gives crate and module moves a destination: kernel-shared code is IDs/errors/audit only.
+- The transition is unbounded by design, so registry-shaped and inherent-method slices will coexist indefinitely; the registry idiom is the tie-breaker, not a deadline.
+- No single code anchor; convention enforced via review.
+- Cost: two coexisting idioms during the (unbounded) incremental transition — readers must recognize both the registry shape and the legacy inherent-method shape — and request/response indirection adds per-operation boilerplate (a request type, a response type, a registration) compared to calling an inherent method directly.

--- a/docs/design/orbit-core/4_decisions.md
+++ b/docs/design/orbit-core/4_decisions.md
@@ -7,10 +7,10 @@ feature: orbit-core
 doc_role: decisions
 type: design
 summary: ADR log for orbit-core crate-boundary decisions, starting with the ORB-10016 orbit-cmd extraction.
-tags: [orbit-core, orbit-cmd, architecture]
+tags: [orbit-core, orbit-cmd, architecture, north-star]
 paths: ["crates/orbit-core/**", "crates/orbit-cmd/**"]
 related_features: [orbit-core]
-related_artifacts: [ADR-0203]
+related_artifacts: [ADR-0203, ADR-0209, ORB-10026]
 ---
 
 # Orbit Core — Decisions
@@ -97,8 +97,82 @@ owning module or crate.
   the kernel's nominal public API is wider even though the crate is smaller,
   and those items cannot be narrowed again without touching orbit-cmd.
 
+## ADR-0209 — North-star architecture bearing: operations as data behind an operation registry
+
+**Status:** Proposed · 2026-07 · [ORB-10026]
+
+**Context.** Orbit's four consumer surfaces — the CLI (`orbit-cli`), MCP
+(`orbit-mcp`), the web dashboard (`orbit-dashboard`), and the in-runtime agent
+tool hosts — are four hand-wired adapter layers over the same underlying
+operations, so a new operation is plumbed by hand up to four times. The same
+structural shape keeps constraining refactors: inherent `impl OrbitRuntime`
+methods plus the orphan rule forced the [ORB-10016] / ADR-0203 orbit-cmd
+extraction to leave the runtime-entangled command groups behind in orbit-core
+as documented residuals, and the same wall shelved the docs+search
+pluginization (`docs/design/orbit-docs-plugin/1_scope.md` — pending commit).
+Point refactors treat symptoms; what was missing is a recorded long-term
+bearing that future refactors steer by.
+
+**Decision.** Record five bearings as orbit's north star. This is an
+**incremental bearing, not a rewrite mandate** — no code change is required by
+this ADR, and existing code is not wrong for predating it.
+
+1. **Operations as data, not inherent methods.** Every orbit operation is
+   eventually a serializable request/response pair with a handler registered
+   in an operation table; the four surfaces become derived adapters over that
+   registry, and the inherent-impl/orphan-rule constraint dissolves because
+   handlers are registry entries, not inherent methods on `OrbitRuntime`.
+2. **Knowledge/execution split.** Orbit is two products — a knowledge store
+   (tasks, learnings, ADRs, docs) and an execution engine (activities, jobs,
+   agent providers) — glued by one runtime. Bearing: two systems sharing only
+   a kernel (IDs, errors, audit), mirroring the constellation split
+   (polaris = knowledge, worker = execution).
+3. **Events over side-effects.** The task-mutation → semantic-index coupling
+   becomes a transactional SQLite outbox consumed by the indexer, replacing
+   the lossy in-process `EmbedWorker` enqueue (best-effort batches, drops on
+   queue-full, debug-level failure logging).
+4. **One retrieval trait, two backends.** orbit-search (workspace-local) and
+   sextant (constellation-wide) become deployment choices behind one retrieval
+   interface, dissolving the two-stack question.
+5. **Crates follow build boundaries, not taxonomy.** Crate splits are
+   justified by compile-graph and dependency-direction needs, not conceptual
+   category. Explicitly kept: the ADR-005 companion-subprocess packaging
+   pattern ([orbit-search 4_decisions.md ADR-005](../orbit-search/4_decisions.md),
+   global ADR-0117), the YAML+SQLite layered store in orbit-store, and the
+   stability-tier markers (ARCHITECTURE.md §Stability tiers).
+
+Adoption is opportunistic: when a surface is added or a command group is
+touched for other reasons, move that slice to request/response + registry
+then. Future ADRs cite this bearing when steering by it, or supersede it if
+the bearing itself changes.
+
+**Rejected alternatives.**
+
+- *Status quo as the implicit bearing.* Keeps charging up to 4× adapter wiring
+  per operation and guarantees the next boundary refactor hits the same
+  inherent-impl/orphan-rule wall with no recorded direction.
+- *Big-bang registry rewrite.* Months of churn across every surface with no
+  incremental payoff and high regression risk in a codebase that ships
+  continuously; rejected in favor of the touch-it-move-it model.
+
+**Consequences.**
+
+- Future architecture ADRs have a fixed point to cite or supersede.
+- Slices touched after this ADR should trend toward request/response +
+  registry; reviewers can ask "why not the registry shape?" when a new
+  hand-wired adapter appears.
+- The knowledge/execution split gives crate and module moves a destination:
+  kernel-shared code is IDs/errors/audit only.
+- No single code anchor; convention enforced via review.
+- Cost: two coexisting idioms during the (unbounded) incremental transition —
+  readers must recognize both the registry shape and the legacy
+  inherent-method shape — and request/response indirection adds per-operation
+  boilerplate (request type, response type, registration) compared to calling
+  an inherent method directly.
+
 ## Task References
 
 - [ORB-10016] — extracted `orbit-cmd` from orbit-core, converted moved command groups to extension traits, and trimmed root re-exports.
+- [ORB-10026] — authored the ADR-0209 north-star operation-registry architecture bearing.
 
 > Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.


### PR DESCRIPTION
## Task

**ORB-10026 — Author north-star ADR: operation-registry architecture bearing for orbit** (polaris task store)

Allocate and author a **proposed** ADR via orbit.adr.add recording the long-term architecture bearing for orbit — a north-star note future refactors steer by, NOT a rewrite mandate. Bearings: (1) operations as data behind an operation registry; (2) knowledge/execution split; (3) events over side-effects (transactional SQLite outbox replacing the in-process EmbedWorker enqueue); (4) one retrieval trait, two backends (orbit-search / sextant); (5) crates follow build boundaries, not taxonomy — explicitly keeping the ADR-005 companion pattern, the YAML+SQLite layered store, and stability tiers. Incremental adoption model; at least one alternative and a cost per 4_decisions convention.

Acceptance criteria:
- A new ADR allocated via orbit.adr.add exists in proposed status whose title identifies the operation-registry / north-star architecture bearing
- The ADR body covers all five bearings from the task description and names what is explicitly kept (ADR-005 companion pattern, layered store, stability tiers), plus at least one alternative and its cost
- The ADR explicitly states it is an incremental bearing, not a rewrite mandate, and cites ORB-10016/ADR-0203 and docs/design/orbit-docs-plugin/1_scope.md as motivating context

## Execution Summary

- Allocated **ADR-0209** via `orbit.adr.add` (status `proposed`, owner `claude`, `related_tasks: [ORB-10026]`, no validation warnings) from this branch's worktree; body covers all five bearings, the incremental adoption framing, the explicit keeps, and two rejected alternatives with costs.
- Appended the long-form ADR-0209 narrative to `docs/design/orbit-core/4_decisions.md` (after ADR-0203, ascending-ID order), updated its Task References and frontmatter `related_artifacts`.
- `docs/design/orbit-docs-plugin/1_scope.md` is absent from this clone (host-side, not yet committed) — cited as "(pending commit)" per the task notes.

## Validation

- `make ci-fast` green locally (fmt-check + guardrail scripts).
- `orbit tool run orbit.adr.show --input '{"id":"ADR-0209"}'` reads back the record cleanly.
- Docs/ADR-only change — no code touched.
