### PR TITLE
Routines QA follow-ups: sweep tests, dispatch-error retry, bounded sweep.log [ORB-00421/422/423]

### DIFF
--- a/crates/orbit-cli/src/command/sweep.rs
+++ b/crates/orbit-cli/src/command/sweep.rs
@@ -9,7 +9,7 @@
 
 use clap::Args;
 use orbit_core::OrbitError;
-use orbit_core::routines::{SweepOptions, SweepOutcome, run_sweep};
+use orbit_core::routines::{RoutineSweepReport, SweepOptions, SweepOutcome, run_sweep};
 use serde_json::json;
 
 #[derive(Args)]
@@ -20,6 +20,9 @@ use serde_json::json;
                   `[routines] role = \"source\"` in its config.toml, filters them for this\n\
                   host, and dispatches due targets as normal runs. Intended for the OS\n\
                   clock (launchd / systemd timer), e.g.:\n  orbit sweep --json\n\n\
+                  By default only noteworthy rows (fires, retries, baselines, errors)\n\
+                  print — the per-minute clock must not grow its log with `not_due`\n\
+                  churn. Use --verbose for every routine's row.\n\n\
                   Inspect routines with `orbit routine list`; dispatched fires appear in\n\
                   `orbit run history`."
 )]
@@ -27,9 +30,35 @@ pub struct SweepCommand {
     /// Report what would fire without recording or dispatching anything.
     #[arg(long)]
     pub dry_run: bool,
+    /// Print a row for every routine, including skipped/not-due ones.
+    #[arg(long)]
+    pub verbose: bool,
     /// Output as JSON.
     #[arg(long)]
     pub json: bool,
+}
+
+/// Actions worth a line on the once-a-minute clock path. The high-churn
+/// `skipped` / `not_due` / `would_*` rows are suppressed unless `--verbose`
+/// (or a dry-run, which is an interactive diagnostic) asks for everything —
+/// otherwise a healthy host writes one line per routine per minute forever.
+pub(crate) fn report_is_noteworthy(action: &str) -> bool {
+    matches!(action, "fired" | "retry_fired" | "baselined" | "error")
+}
+
+/// Render one report row (used for both quiet and verbose output).
+pub(crate) fn format_report_line(report: &RoutineSweepReport) -> String {
+    let mut line = format!("{} ({}): {}", report.routine, report.source, report.action);
+    if let Some(reason) = &report.reason {
+        line.push_str(&format!(" — {reason}"));
+    }
+    if let Some(slot) = &report.slot {
+        line.push_str(&format!(" — slot {slot}"));
+    }
+    if let Some(run_id) = &report.run_id {
+        line.push_str(&format!(" — run {run_id}"));
+    }
+    line
 }
 
 impl SweepCommand {
@@ -54,18 +83,15 @@ impl SweepCommand {
             println!("sweep[{}]: no routines configured", outcome.host_id);
             return Ok(());
         }
+
+        // Quiet by default; a dry-run is interactive so it shows everything.
+        let show_all = self.verbose || self.dry_run;
+        let mut shown = 0usize;
         for report in &outcome.reports {
-            let mut line = format!("{} ({}): {}", report.routine, report.source, report.action);
-            if let Some(reason) = &report.reason {
-                line.push_str(&format!(" — {reason}"));
+            if show_all || report_is_noteworthy(report.action) {
+                println!("{}", format_report_line(report));
+                shown += 1;
             }
-            if let Some(slot) = &report.slot {
-                line.push_str(&format!(" — slot {slot}"));
-            }
-            if let Some(run_id) = &report.run_id {
-                line.push_str(&format!(" — run {run_id}"));
-            }
-            println!("{line}");
         }
         for error in &outcome.load_errors {
             let path = error
@@ -78,11 +104,21 @@ impl SweepCommand {
                 error.source_workspace, path, error.message
             );
         }
+        // A one-line heartbeat when a healthy pass had nothing to report, so the
+        // log still shows the sweep ran (bounded by the log rotation in
+        // `run_sweep`) without a row per routine.
+        if shown == 0 && outcome.load_errors.is_empty() {
+            println!(
+                "sweep[{}]: {} routine(s), nothing due",
+                outcome.host_id,
+                outcome.reports.len()
+            );
+        }
         Ok(())
     }
 }
 
-fn outcome_json(outcome: &SweepOutcome, dry_run: bool) -> serde_json::Value {
+pub(crate) fn outcome_json(outcome: &SweepOutcome, dry_run: bool) -> serde_json::Value {
     json!({
         "host_id": outcome.host_id,
         "dry_run": dry_run,

--- a/crates/orbit-cli/src/command/tests/mod.rs
+++ b/crates/orbit-cli/src/command/tests/mod.rs
@@ -2,6 +2,7 @@
 // tests/mod.rs can directly contain tests for the declaring parent module (exempt from orphan rules).
 
 mod init;
+mod sweep;
 
 use clap::{Parser, error::ErrorKind};
 

--- a/crates/orbit-cli/src/command/tests/sweep.rs
+++ b/crates/orbit-cli/src/command/tests/sweep.rs
@@ -1,0 +1,84 @@
+//! `orbit sweep` output/reporting tests [ORB-00423]: the quiet-by-default
+//! filtering that keeps the once-a-minute clock from growing its log, and the
+//! stable `--json` shape machine consumers depend on.
+
+use orbit_core::routines::{RoutineSweepReport, SweepOutcome};
+
+use crate::command::sweep::{format_report_line, outcome_json, report_is_noteworthy};
+
+fn report(action: &'static str) -> RoutineSweepReport {
+    RoutineSweepReport {
+        routine: "nightly".to_string(),
+        source: "polaris".to_string(),
+        action,
+        reason: None,
+        slot: None,
+        run_id: None,
+    }
+}
+
+#[test]
+fn noteworthy_actions_print_by_default_churn_does_not() {
+    for action in ["fired", "retry_fired", "baselined", "error"] {
+        assert!(
+            report_is_noteworthy(action),
+            "{action} should print by default"
+        );
+    }
+    // The high-churn rows a healthy per-minute pass produces are suppressed.
+    for action in ["skipped", "would_fire", "would_baseline"] {
+        assert!(
+            !report_is_noteworthy(action),
+            "{action} should be quiet by default"
+        );
+    }
+}
+
+#[test]
+fn format_report_line_includes_slot_and_run() {
+    let mut r = report("fired");
+    r.slot = Some("2026-01-01T00:01:00+00:00".to_string());
+    r.run_id = Some("run-1".to_string());
+    let line = format_report_line(&r);
+    assert!(line.contains("nightly (polaris): fired"));
+    assert!(line.contains("slot 2026-01-01T00:01:00+00:00"));
+    assert!(line.contains("run run-1"));
+}
+
+#[test]
+fn json_shape_is_stable() {
+    let outcome = SweepOutcome {
+        host_id: "dk-mac".to_string(),
+        lock_busy: false,
+        reports: vec![RoutineSweepReport {
+            routine: "nightly".to_string(),
+            source: "polaris".to_string(),
+            action: "fired",
+            reason: None,
+            slot: Some("2026-01-01T00:01:00+00:00".to_string()),
+            run_id: Some("run-1".to_string()),
+        }],
+        load_errors: Vec::new(),
+    };
+
+    let value = outcome_json(&outcome, false);
+    let object = value.as_object().expect("json object");
+    for key in [
+        "host_id",
+        "dry_run",
+        "lock_busy",
+        "fired",
+        "reports",
+        "load_errors",
+    ] {
+        assert!(object.contains_key(key), "missing top-level key {key}");
+    }
+    assert_eq!(object["fired"], 1);
+
+    let first = &value["reports"][0];
+    let report_obj = first.as_object().expect("report object");
+    for key in ["routine", "source", "action", "reason", "slot", "run_id"] {
+        assert!(report_obj.contains_key(key), "missing report key {key}");
+    }
+    assert_eq!(first["action"], "fired");
+}

--- a/crates/orbit-core/assets/skills/orbit-guide/SKILL.md
+++ b/crates/orbit-core/assets/skills/orbit-guide/SKILL.md
@@ -75,6 +75,48 @@ Two handoff branches, depending on user intent:
 
 After hand-off, this skill's job is done. Subsequent Orbit work routes through the `orbit` skill and its lifecycle siblings.
 
+## Routines & scheduling (`orbit sweep`)
+
+Routines make Orbit the host's scheduler: a git-versioned YAML definition (`.orbit/routines/*.yaml`) pairs a cron trigger with a catalog `job:<name>` target, host pinning, and a retry/overlap policy. A stateless `orbit sweep` pass — invoked every minute by the OS clock (launchd / systemd timer) — fires whatever is due on this host as a normal run. Definitions sync across hosts via git; **all scheduler state (last fires, pauses, locks) is host-local in `~/.orbit/orbit.db` and never synced.**
+
+**Canonical sources — read these at invocation time; don't answer routine field semantics from memory:**
+
+- Design contract (schema, discovery, sweep, host-local state, clock): `docs/design/routines/` — start at `2_design.md` (§1 is the field-by-field schema, the source of truth).
+- Command surface: `orbit routine --help` and `orbit sweep --help`.
+
+Setup sequence (the *skeleton* is stable; re-read the design doc for full field semantics before hand-authoring a routine):
+
+1. **Set this host's identity** — `orbit routine init --host-id <id>` writes `~/.orbit/host.toml`. The `<id>` is what a routine's `hosts:` list is matched against. Absent an explicit id it defaults to the machine hostname. Add `--install-clock` to also install and start the per-user OS clock unit that runs `orbit sweep` every minute (launchd agent on macOS, systemd user timer on Linux).
+2. **Make a workspace a routine source** — add `[routines]` / `role = "source"` to that workspace's `.orbit/config.toml` (versioned; both hosts converge via `git pull`). The workspace must already be registered with Orbit. Only `role = "source"` is valid — any other value is a fail-closed config error.
+3. **Add a routine** — drop a YAML file under `<source>/.orbit/routines/`. Minimal illustrative shape (see `2_design.md` §1 for every field and default):
+
+   ```yaml
+   schemaVersion: 1
+   name: almanac-auto-commit          # unique across all sources on a host
+   enabled: true                       # versioned kill-switch
+   hosts: [dk-mac]                      # explicit pinning; no "any host" in v1
+   trigger:
+     cron: "0 22 * * *"                # 5-field, host-local time
+     missed_run: skip                   # skip | catch_up_once (default: skip)
+   target: job:almanac_commit_pipeline  # job:<name> only; activity: is rejected — wrap it in a one-step job
+   policy:
+     timeout_minutes: 10
+     retries: { max: 2, backoff_minutes: 2 }
+     overlap: forbid                    # forbid | allow
+   ```
+
+   Parsing is fail-closed: an invalid file (bad schema version, unknown field, unresolvable target, unparsable cron) makes *that routine* absent and reports a load error — it never fires with defaults.
+
+4. **Verify without firing** — `orbit routine list` shows every routine with its toggle columns (enabled / pinned / paused) and computed next-due; `orbit sweep --dry-run` reports what *would* fire and records nothing. `orbit routine show <name>` adds recent fire history.
+
+Observe & control:
+
+- Fires are normal runs — they appear in `orbit run history` and carry the actor `routine/<name>`.
+- `orbit routine pause <name>` / `resume <name>` suppress a routine on *this host only* (host-local, unversioned, durable across reboots).
+- Toggle resolution order when a routine doesn't fire: `enabled: false` (versioned, everywhere) → host not in `hosts` (versioned, per host) → local pause (this host only). `orbit routine list` shows all three, so "why didn't this fire?" is one command.
+
+If setup or a sweep misbehaves, surface it and offer `orbit-track-issues` to capture the friction.
+
 ## Cowork configuration
 
 If the user runs the plugin inside **Cowork** (the Claude desktop app) and only the `orbit_graph_*` tools appear — no `orbit_task_add` / ADR / learning tools — it's the known workspace-discovery gap: Cowork launches the plugin's MCP server with cwd and `CLAUDE_PROJECT_DIR` set to an internal scratchpad, not the selected repo, so `serve` finds no `.orbit/` and falls back to the graph-only surface.

--- a/crates/orbit-core/src/routines/clock.rs
+++ b/crates/orbit-core/src/routines/clock.rs
@@ -19,6 +19,15 @@ pub const LAUNCHD_LABEL: &str = "com.orbit.sweep";
 /// systemd unit base name (Linux).
 pub const SYSTEMD_UNIT: &str = "orbit-sweep";
 
+/// Path launchd redirects `orbit sweep` stdout/stderr to on macOS, and the
+/// file `run_sweep` rotates so it stays bounded on an always-on host
+/// ([ORB-00423]). Single source of truth shared by the installer and the sweep
+/// pass so the writer and the rotator never disagree. (Linux logs to the
+/// journal, which rotates on its own, so only macOS needs this file.)
+pub fn sweep_log_path(global_root: &Path) -> PathBuf {
+    global_root.join("logs").join("sweep.log")
+}
+
 /// What an installation attempt did: files written, plus either a successful
 /// activation or the commands the user must run themselves.
 #[derive(Debug)]
@@ -50,7 +59,7 @@ pub fn install_clock(global_root: &Path) -> Result<ClockInstallReport, OrbitErro
 
 fn install_launchd(global_root: &Path, orbit_bin: &str) -> Result<ClockInstallReport, OrbitError> {
     let home = home_dir()?;
-    let log_path = global_root.join("logs").join("sweep.log");
+    let log_path = sweep_log_path(global_root);
     if let Some(parent) = log_path.parent() {
         fs::create_dir_all(parent).map_err(|error| OrbitError::Io(error.to_string()))?;
     }

--- a/crates/orbit-core/src/routines/sweep.rs
+++ b/crates/orbit-core/src/routines/sweep.rs
@@ -436,16 +436,16 @@ fn sync_unresolved_fires(
             now_utc.signed_duration_since(created_at) > Duration::minutes(timeout_minutes as i64);
 
         match fire.state {
-            RoutineFireState::Intent => {
-                if expired {
-                    store.routine_mark_fire_outcome(
-                        &fire.routine_name,
-                        &fire.slot,
-                        fire.attempt,
-                        RoutineFireState::Error,
-                        Some("stale fire intent reclaimed (sweep died before dispatch)"),
-                    )?;
-                }
+            // A recorded intent whose sweep died before dispatch: reclaim it
+            // once past the timeout horizon, otherwise leave it for a later pass.
+            RoutineFireState::Intent if expired => {
+                store.routine_mark_fire_outcome(
+                    &fire.routine_name,
+                    &fire.slot,
+                    fire.attempt,
+                    RoutineFireState::Error,
+                    Some("stale fire intent reclaimed (sweep died before dispatch)"),
+                )?;
             }
             RoutineFireState::Dispatched => {
                 let run_state = fire.run_id.as_deref().and_then(|run_id| {

--- a/crates/orbit-core/src/routines/sweep.rs
+++ b/crates/orbit-core/src/routines/sweep.rs
@@ -18,7 +18,59 @@ use crate::workspace_registry;
 
 use super::due::{DueDecision, due_decision, parse_cron};
 use super::host::resolve_host_id;
-use super::loader::{LoadedRoutine, RoutineLoadError, collect_routines, discover_workspaces};
+use super::loader::{
+    LoadedRoutine, RoutineCollection, RoutineLoadError, collect_routines, discover_workspaces,
+};
+
+/// Dispatch seam for the sweep [ORB-00421]. The production impl
+/// ([`RuntimeDispatch`]) wraps one `OrbitRuntime` per source workspace and
+/// dispatches through `submit_pipeline_run` / `show_job_run`; tests supply a
+/// fake so the sweep's fire / retry / overlap / outcome-sync orchestration is
+/// exercised deterministically without spawning pipeline workers.
+pub(crate) trait RoutineDispatch {
+    /// Submit `job_name` in the source workspace rooted at `source_orbit_dir`
+    /// under `actor`, returning the dispatched run id.
+    fn submit(
+        &self,
+        source_orbit_dir: &Path,
+        job_name: &str,
+        actor: &str,
+    ) -> Result<String, OrbitError>;
+
+    /// Current run state for a dispatched fire, when the run is queryable.
+    fn run_state(&self, source_orbit_dir: &Path, run_id: &str) -> Option<JobRunState>;
+}
+
+/// Production dispatch over the per-workspace runtimes discovered this pass.
+pub(crate) struct RuntimeDispatch<'a> {
+    runtimes: BTreeMap<PathBuf, &'a OrbitRuntime>,
+}
+
+impl RoutineDispatch for RuntimeDispatch<'_> {
+    fn submit(
+        &self,
+        source_orbit_dir: &Path,
+        job_name: &str,
+        actor: &str,
+    ) -> Result<String, OrbitError> {
+        let runtime = self.runtimes.get(source_orbit_dir).ok_or_else(|| {
+            OrbitError::WorkspaceError(format!(
+                "no runtime for source workspace '{}'",
+                source_orbit_dir.display()
+            ))
+        })?;
+        runtime
+            .submit_pipeline_run(job_name, json!({}), None, Some(actor))
+            .map(|invoke| invoke.run_id)
+    }
+
+    fn run_state(&self, source_orbit_dir: &Path, run_id: &str) -> Option<JobRunState> {
+        self.runtimes
+            .get(source_orbit_dir)
+            .and_then(|runtime| runtime.show_job_run(run_id).ok())
+            .map(|run| run.state)
+    }
+}
 
 /// Options for one sweep pass.
 #[derive(Debug, Clone, Copy, Default)]
@@ -89,44 +141,22 @@ pub fn run_sweep_at(global_root: &Path, options: SweepOptions) -> Result<SweepOu
     let mut collection = collect_routines(&discovered.entries);
     load_errors.append(&mut collection.errors);
 
-    let routines_by_name: BTreeMap<String, &LoadedRoutine> = collection
-        .routines
-        .iter()
-        .map(|routine| (routine.definition.name.clone(), routine))
-        .collect();
-    let runtime_by_orbit_dir: BTreeMap<PathBuf, &OrbitRuntime> = discovered
-        .entries
-        .iter()
-        .map(|(workspace, runtime)| (workspace.orbit_dir.clone(), runtime))
-        .collect();
+    let dispatch = RuntimeDispatch {
+        runtimes: discovered
+            .entries
+            .iter()
+            .map(|(workspace, runtime)| (workspace.orbit_dir.clone(), runtime))
+            .collect(),
+    };
 
-    let now_utc = Utc::now();
-    if !options.dry_run {
-        sync_unresolved_fires(&store, &routines_by_name, &runtime_by_orbit_dir, now_utc)?;
-    }
-
-    let pauses = store.routine_pauses()?;
-
-    let mut reports = Vec::new();
-    for routine in &collection.routines {
-        let report = sweep_routine(
-            &store,
-            routine,
-            &runtime_by_orbit_dir,
-            &host_id,
-            &pauses,
-            options,
-        )
-        .unwrap_or_else(|error| RoutineSweepReport {
-            routine: routine.definition.name.clone(),
-            source: routine.source_workspace.clone(),
-            action: "error",
-            reason: Some(error.to_string()),
-            slot: None,
-            run_id: None,
-        });
-        reports.push(report);
-    }
+    let reports = run_sweep_core(
+        &store,
+        &host_id,
+        &collection,
+        &dispatch,
+        options,
+        Utc::now(),
+    )?;
 
     Ok(SweepOutcome {
         host_id,
@@ -136,13 +166,56 @@ pub fn run_sweep_at(global_root: &Path, options: SweepOptions) -> Result<SweepOu
     })
 }
 
+/// The dispatch-agnostic core of one sweep pass [ORB-00421]: outcome-sync
+/// (unless dry-run), then per-routine due evaluation and fire/skip. Split out
+/// from [`run_sweep_at`] — which owns the lock, store, and workspace discovery
+/// — so the orchestration can be driven against a temp store, a hand-built
+/// [`RoutineCollection`], a fake [`RoutineDispatch`], and an explicit `now`.
+pub(crate) fn run_sweep_core(
+    store: &Store,
+    host_id: &str,
+    collection: &RoutineCollection,
+    dispatch: &dyn RoutineDispatch,
+    options: SweepOptions,
+    now_utc: DateTime<Utc>,
+) -> Result<Vec<RoutineSweepReport>, OrbitError> {
+    let routines_by_name: BTreeMap<String, &LoadedRoutine> = collection
+        .routines
+        .iter()
+        .map(|routine| (routine.definition.name.clone(), routine))
+        .collect();
+
+    if !options.dry_run {
+        sync_unresolved_fires(store, &routines_by_name, dispatch, now_utc)?;
+    }
+
+    let pauses = store.routine_pauses()?;
+
+    let mut reports = Vec::new();
+    for routine in &collection.routines {
+        let report = sweep_routine(store, routine, dispatch, host_id, &pauses, options, now_utc)
+            .unwrap_or_else(|error| RoutineSweepReport {
+                routine: routine.definition.name.clone(),
+                source: routine.source_workspace.clone(),
+                action: "error",
+                reason: Some(error.to_string()),
+                slot: None,
+                run_id: None,
+            });
+        reports.push(report);
+    }
+
+    Ok(reports)
+}
+
 fn sweep_routine(
     store: &Store,
     routine: &LoadedRoutine,
-    runtimes: &BTreeMap<PathBuf, &OrbitRuntime>,
+    dispatch: &dyn RoutineDispatch,
     host_id: &str,
     pauses: &BTreeMap<String, orbit_store::RoutinePauseRecord>,
     options: SweepOptions,
+    now_utc: DateTime<Utc>,
 ) -> Result<RoutineSweepReport, OrbitError> {
     let definition = &routine.definition;
     let name = &definition.name;
@@ -160,7 +233,7 @@ fn sweep_routine(
     }
 
     let cron = parse_cron(&definition.trigger.cron)?;
-    let now_local = Local::now();
+    let now_local = now_utc.with_timezone(&Local);
 
     let Some(cursor) = store.routine_cursor(name)? else {
         // First observation on this host: record the baseline and fire
@@ -169,7 +242,7 @@ fn sweep_routine(
         if options.dry_run {
             return Ok(action(routine, "would_baseline"));
         }
-        store.routine_record_baseline(name, &Utc::now().to_rfc3339())?;
+        store.routine_record_baseline(name, &now_utc.to_rfc3339())?;
         return Ok(action(routine, "baselined"));
     };
 
@@ -184,16 +257,16 @@ fn sweep_routine(
     )? {
         DueDecision::Fire { slot, .. } => {
             let slot_utc = slot.with_timezone(&Utc).to_rfc3339();
-            fire(store, routine, runtimes, &slot_utc, 1, "fired", options)
+            fire(store, routine, dispatch, &slot_utc, 1, "fired", options)
         }
         DueDecision::NotDue => {
             // No new slot: a failed most-recent fire may still have retry
             // budget under the same slot.
-            if let Some(retry) = retry_candidate(store, routine, Utc::now())? {
+            if let Some(retry) = retry_candidate(store, routine, now_utc)? {
                 return fire(
                     store,
                     routine,
-                    runtimes,
+                    dispatch,
                     &retry.slot,
                     retry.attempt + 1,
                     "retry_fired",
@@ -237,7 +310,7 @@ fn retry_candidate(
 fn fire(
     store: &Store,
     routine: &LoadedRoutine,
-    runtimes: &BTreeMap<PathBuf, &OrbitRuntime>,
+    dispatch: &dyn RoutineDispatch,
     slot: &str,
     attempt: u32,
     fired_action: &'static str,
@@ -279,24 +352,21 @@ fn fire(
         });
     }
 
-    let runtime = runtimes.get(&routine.source_orbit_dir).ok_or_else(|| {
-        OrbitError::WorkspaceError(format!(
-            "no runtime for source workspace '{}'",
-            routine.source_workspace
-        ))
-    })?;
-
     let actor = format!("routine/{name}");
-    match runtime.submit_pipeline_run(definition.target.job_name(), json!({}), None, Some(&actor)) {
-        Ok(invoke) => {
-            store.routine_mark_fire_dispatched(name, slot, attempt, &invoke.run_id)?;
+    match dispatch.submit(
+        &routine.source_orbit_dir,
+        definition.target.job_name(),
+        &actor,
+    ) {
+        Ok(run_id) => {
+            store.routine_mark_fire_dispatched(name, slot, attempt, &run_id)?;
             Ok(RoutineSweepReport {
                 routine: name.clone(),
                 source: routine.source_workspace.clone(),
                 action: fired_action,
                 reason: None,
                 slot: Some(slot.to_string()),
-                run_id: Some(invoke.run_id),
+                run_id: Some(run_id),
             })
         }
         Err(error) => {
@@ -326,7 +396,7 @@ fn fire(
 fn sync_unresolved_fires(
     store: &Store,
     routines_by_name: &BTreeMap<String, &LoadedRoutine>,
-    runtimes: &BTreeMap<PathBuf, &OrbitRuntime>,
+    dispatch: &dyn RoutineDispatch,
     now_utc: DateTime<Utc>,
 ) -> Result<(), OrbitError> {
     for fire in store.routine_unresolved_fires()? {
@@ -354,16 +424,11 @@ fn sync_unresolved_fires(
                 }
             }
             RoutineFireState::Dispatched => {
-                let run_state = fire
-                    .run_id
-                    .as_deref()
-                    .and_then(|run_id| {
-                        routines_by_name
-                            .get(&fire.routine_name)
-                            .and_then(|routine| runtimes.get(&routine.source_orbit_dir))
-                            .and_then(|runtime| runtime.show_job_run(run_id).ok())
-                    })
-                    .map(|run| run.state);
+                let run_state = fire.run_id.as_deref().and_then(|run_id| {
+                    routines_by_name
+                        .get(&fire.routine_name)
+                        .and_then(|routine| dispatch.run_state(&routine.source_orbit_dir, run_id))
+                });
                 let outcome = match run_state {
                     Some(JobRunState::Success) => Some((RoutineFireState::Succeeded, None)),
                     Some(JobRunState::Failed) => Some((RoutineFireState::Failed, None)),

--- a/crates/orbit-core/src/routines/sweep.rs
+++ b/crates/orbit-core/src/routines/sweep.rs
@@ -260,8 +260,9 @@ fn sweep_routine(
             fire(store, routine, dispatch, &slot_utc, 1, "fired", options)
         }
         DueDecision::NotDue => {
-            // No new slot: a failed most-recent fire may still have retry
-            // budget under the same slot.
+            // No new slot: a most-recent fire that failed (run-level) or
+            // errored at dispatch may still have retry budget under the same
+            // slot.
             if let Some(retry) = retry_candidate(store, routine, now_utc)? {
                 return fire(
                     store,
@@ -278,8 +279,16 @@ fn sweep_routine(
     }
 }
 
-/// The most recent fire, when it failed with retry budget left and the
-/// fixed backoff has elapsed.
+/// The most recent fire, when it failed with retry budget left and the fixed
+/// backoff has elapsed.
+///
+/// Retryable means `Failed` — a run-level failure *or* a synchronous dispatch
+/// failure ([ORB-00422]): `fire` records a `submit_pipeline_run` that returns
+/// `Err` as `Failed` (not `Error`) precisely because nothing dispatched, so it
+/// is unambiguously safe to re-dispatch under the same slot. `Error` is
+/// reserved for the *ambiguous* case — a crashed sweep's stale intent reclaimed
+/// by the outcome sync, where a worker may have partially started — and stays
+/// terminal so a make-up fire never races an orphaned run.
 fn retry_candidate(
     store: &Store,
     routine: &LoadedRoutine,
@@ -370,12 +379,16 @@ fn fire(
             })
         }
         Err(error) => {
+            // A synchronous dispatch failure means nothing was dispatched, so
+            // record it as `Failed` — retryable under the same slot within
+            // `policy.retries` ([ORB-00422]) — rather than the terminal `Error`
+            // the outcome sync reserves for an ambiguous crash-orphaned intent.
             store.routine_mark_fire_outcome(
                 name,
                 slot,
                 attempt,
-                RoutineFireState::Error,
-                Some(&error.to_string()),
+                RoutineFireState::Failed,
+                Some(&format!("dispatch failed: {error}")),
             )?;
             Ok(RoutineSweepReport {
                 routine: name.clone(),

--- a/crates/orbit-core/src/routines/sweep.rs
+++ b/crates/orbit-core/src/routines/sweep.rs
@@ -10,6 +10,7 @@ use std::path::{Path, PathBuf};
 
 use chrono::{DateTime, Duration, Local, Utc};
 use orbit_common::types::{JobRunState, OrbitError, OverlapPolicy};
+use orbit_common::utility::log_rotation::{self, LogRotationConfig};
 use orbit_store::{RoutineFireIntentParams, RoutineFireRecord, RoutineFireState, Store};
 use serde_json::json;
 
@@ -113,6 +114,16 @@ pub struct SweepOutcome {
 /// Run one sweep pass against the default global root (`~/.orbit`).
 pub fn run_sweep(options: SweepOptions) -> Result<SweepOutcome, OrbitError> {
     let global_root = workspace_registry::global_orbit_dir()?;
+    // The OS clock invokes this every minute forever; on macOS launchd
+    // redirects stdout/stderr into `logs/sweep.log`. Opportunistically roll +
+    // prune it here (rename-based, best-effort) so an always-on host cannot
+    // grow it without bound [ORB-00423]. No-op until the file exceeds the
+    // configured per-file budget. `run_sweep_at` (the test seam) is left
+    // untouched so tests never rotate real logs.
+    log_rotation::rotate_and_prune(
+        &super::clock::sweep_log_path(&global_root),
+        &LogRotationConfig::load_global_best_effort(),
+    );
     run_sweep_at(&global_root, options)
 }
 

--- a/crates/orbit-core/src/routines/tests/mod.rs
+++ b/crates/orbit-core/src/routines/tests/mod.rs
@@ -1,2 +1,3 @@
 mod due;
 mod host;
+mod sweep;

--- a/crates/orbit-core/src/routines/tests/sweep.rs
+++ b/crates/orbit-core/src/routines/tests/sweep.rs
@@ -84,7 +84,7 @@ fn ts(y: i32, mo: u32, d: u32, h: u32, mi: u32, s: u32) -> DateTime<Utc> {
 /// run ids, and answers `run_state` from a table the test primes.
 #[derive(Default)]
 struct FakeDispatch {
-    fail_submit: bool,
+    fail_submit: Cell<bool>,
     counter: Cell<u32>,
     submits: RefCell<Vec<(PathBuf, String)>>,
     states: RefCell<HashMap<String, JobRunState>>,
@@ -97,11 +97,15 @@ impl FakeDispatch {
     fn set_state(&self, run_id: &str, state: JobRunState) {
         self.states.borrow_mut().insert(run_id.to_string(), state);
     }
+    /// Make the next `submit` calls fail (dispatch-time error) until cleared.
+    fn set_fail(&self, fail: bool) {
+        self.fail_submit.set(fail);
+    }
 }
 
 impl RoutineDispatch for FakeDispatch {
     fn submit(&self, dir: &Path, job: &str, _actor: &str) -> Result<String, OrbitError> {
-        if self.fail_submit {
+        if self.fail_submit.get() {
             return Err(OrbitError::Execution("dispatch boom".to_string()));
         }
         let n = self.counter.get() + 1;
@@ -378,6 +382,65 @@ fn sync_reclaims_stale_intent_and_dispatched_past_timeout() {
         Some(&RoutineFireState::TimedOut),
         "stale dispatched reclaimed as timed_out"
     );
+}
+
+// ---- dispatch-error retry [ORB-00422] -------------------------------------
+
+#[test]
+fn dispatch_error_is_retry_eligible_under_the_same_slot() {
+    let store = store();
+    let dispatch = FakeDispatch::default();
+    // Daily catch-up routine so exactly one slot is due across both sweeps
+    // (a frequent cron would surface a *new* slot before any retry). backoff 0
+    // keeps the retry immediately eligible without wall-clock waiting.
+    let yaml = format!(
+        "schemaVersion: 1\nname: job\nenabled: true\nhosts: [{HOST}]\n\
+         trigger:\n  cron: \"0 0 * * *\"\n  missed_run: catch_up_once\n\
+         target: job:noop\n\
+         policy:\n  timeout_minutes: 10\n  overlap: forbid\n  \
+         retries: {{ max: 2, backoff_minutes: 0 }}\n"
+    );
+    let coll = collection(vec![loaded(parse_routine_yaml(&yaml).unwrap())]);
+    // `now` sits just ahead of wall-clock so the errored fire's stored
+    // updated_at is strictly in the past (backoff 0 is then satisfied).
+    let now = Utc::now() + Duration::minutes(1);
+    store
+        .routine_record_baseline("job", &(now - Duration::days(2)).to_rfc3339())
+        .unwrap();
+
+    // Sweep 1: the slot is due; the synchronous dispatch fails.
+    dispatch.set_fail(true);
+    let r1 = run_sweep_core(&store, HOST, &coll, &dispatch, SweepOptions::default(), now).unwrap();
+    assert_eq!(
+        r1[0].action, "error",
+        "dispatch failure is reported as error"
+    );
+    let errored = store.routine_latest_fire("job").unwrap().unwrap();
+    // Recorded as retryable Failed (nothing dispatched), not terminal Error.
+    assert_eq!(errored.state, RoutineFireState::Failed);
+    assert_eq!(errored.attempt, 1);
+    assert_eq!(
+        dispatch.submit_count(),
+        0,
+        "a failed submit dispatches nothing"
+    );
+    let slot = errored.slot.clone();
+
+    // Sweep 2: no new slot is due, but the dispatch error is now retryable.
+    // With submit healthy it re-dispatches attempt 2 under the SAME slot.
+    dispatch.set_fail(false);
+    let r2 = run_sweep_core(&store, HOST, &coll, &dispatch, SweepOptions::default(), now).unwrap();
+    assert_eq!(r2[0].action, "retry_fired");
+    let retried = store.routine_latest_fire("job").unwrap().unwrap();
+    assert_eq!(retried.state, RoutineFireState::Dispatched);
+    assert_eq!(retried.attempt, 2);
+    assert_eq!(retried.slot, slot, "retry re-uses the same scheduled slot");
+    assert_eq!(dispatch.submit_count(), 1);
+
+    // Idempotency: exactly two fires for the one slot (no double-dispatch).
+    let rows = fires(&store, "job");
+    assert_eq!(rows.len(), 2);
+    assert!(rows.iter().all(|f| f.slot == slot));
 }
 
 // ---- dry-run --------------------------------------------------------------

--- a/crates/orbit-core/src/routines/tests/sweep.rs
+++ b/crates/orbit-core/src/routines/tests/sweep.rs
@@ -1,0 +1,521 @@
+//! Sweep-orchestration tests [ORB-00421]: exercise the fire / idempotency /
+//! overlap / retry / outcome-sync logic in `routines/sweep.rs` that shipped
+//! untested in [ORB-10021].
+//!
+//! Two layers:
+//! - `run_sweep_core` against an in-memory store, a hand-built
+//!   [`RoutineCollection`], a fake [`RoutineDispatch`], and an explicit `now`
+//!   — deterministic, no pipeline workers spawned.
+//! - one `run_sweep_at` integration pass over a seeded global root, covering
+//!   discovery + fail-closed loading end-to-end via `--dry-run` (which records
+//!   and dispatches nothing).
+
+use std::cell::{Cell, RefCell};
+use std::collections::HashMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use chrono::{DateTime, Duration, TimeZone, Utc};
+use orbit_common::types::{
+    JobRunState, OrbitError, RoutineDefinition, Workspace, WorkspaceRegistry, WorkspaceStatus,
+    parse_routine_yaml,
+};
+use orbit_store::{RoutineFireIntentParams, RoutineFireState, Store};
+use tempfile::tempdir;
+
+use crate::routines::loader::{LoadedRoutine, RoutineCollection};
+use crate::routines::sweep::{RoutineDispatch, SweepOptions, run_sweep_at, run_sweep_core};
+use crate::workspace_registry;
+
+const HOST: &str = "test-host";
+const SOURCE_DIR: &str = "/ws/.orbit";
+
+// ---- fixtures -------------------------------------------------------------
+
+/// Build a validated routine with the common knobs the tests vary.
+fn routine(
+    name: &str,
+    cron: &str,
+    enabled: bool,
+    overlap: &str,
+    retries_max: u32,
+) -> LoadedRoutine {
+    let yaml = format!(
+        "schemaVersion: 1\n\
+         name: {name}\n\
+         enabled: {enabled}\n\
+         hosts: [{HOST}]\n\
+         trigger:\n  cron: \"{cron}\"\n\
+         target: job:noop\n\
+         policy:\n  timeout_minutes: 10\n  overlap: {overlap}\n  \
+         retries: {{ max: {retries_max}, backoff_minutes: 1 }}\n"
+    );
+    loaded(parse_routine_yaml(&yaml).expect("valid routine yaml"))
+}
+
+fn loaded(definition: RoutineDefinition) -> LoadedRoutine {
+    let name = definition.name.clone();
+    LoadedRoutine {
+        definition,
+        source_workspace: "polaris".to_string(),
+        source_orbit_dir: PathBuf::from(SOURCE_DIR),
+        path: PathBuf::from(format!("{SOURCE_DIR}/routines/{name}.yaml")),
+    }
+}
+
+fn collection(routines: Vec<LoadedRoutine>) -> RoutineCollection {
+    RoutineCollection {
+        routines,
+        errors: Vec::new(),
+    }
+}
+
+fn store() -> Store {
+    Store::open_in_memory().expect("in-memory store")
+}
+
+fn ts(y: i32, mo: u32, d: u32, h: u32, mi: u32, s: u32) -> DateTime<Utc> {
+    Utc.with_ymd_and_hms(y, mo, d, h, mi, s)
+        .single()
+        .expect("valid ts")
+}
+
+/// A scriptable dispatch double: records submissions, hands back deterministic
+/// run ids, and answers `run_state` from a table the test primes.
+#[derive(Default)]
+struct FakeDispatch {
+    fail_submit: bool,
+    counter: Cell<u32>,
+    submits: RefCell<Vec<(PathBuf, String)>>,
+    states: RefCell<HashMap<String, JobRunState>>,
+}
+
+impl FakeDispatch {
+    fn submit_count(&self) -> usize {
+        self.submits.borrow().len()
+    }
+    fn set_state(&self, run_id: &str, state: JobRunState) {
+        self.states.borrow_mut().insert(run_id.to_string(), state);
+    }
+}
+
+impl RoutineDispatch for FakeDispatch {
+    fn submit(&self, dir: &Path, job: &str, _actor: &str) -> Result<String, OrbitError> {
+        if self.fail_submit {
+            return Err(OrbitError::Execution("dispatch boom".to_string()));
+        }
+        let n = self.counter.get() + 1;
+        self.counter.set(n);
+        self.submits
+            .borrow_mut()
+            .push((dir.to_path_buf(), job.to_string()));
+        Ok(format!("run-{n}"))
+    }
+
+    fn run_state(&self, _dir: &Path, run_id: &str) -> Option<JobRunState> {
+        self.states.borrow().get(run_id).cloned()
+    }
+}
+
+fn fires(store: &Store, name: &str) -> Vec<orbit_store::RoutineFireRecord> {
+    store.routine_recent_fires(name, 32).expect("recent fires")
+}
+
+// ---- baseline & fire ------------------------------------------------------
+
+#[test]
+fn first_sweep_baselines_and_fires_nothing_then_next_slot_fires() {
+    let store = store();
+    let dispatch = FakeDispatch::default();
+    let coll = collection(vec![routine("nightly", "* * * * *", true, "allow", 0)]);
+
+    // First observation: baseline is recorded, nothing fires.
+    let reports = run_sweep_core(
+        &store,
+        HOST,
+        &coll,
+        &dispatch,
+        SweepOptions::default(),
+        ts(2026, 1, 1, 0, 0, 30),
+    )
+    .expect("sweep 1");
+    assert_eq!(reports[0].action, "baselined");
+    assert!(store.routine_cursor("nightly").unwrap().is_some());
+    assert!(fires(&store, "nightly").is_empty());
+    assert_eq!(dispatch.submit_count(), 0);
+
+    // A later natural slot fires exactly once.
+    let reports = run_sweep_core(
+        &store,
+        HOST,
+        &coll,
+        &dispatch,
+        SweepOptions::default(),
+        ts(2026, 1, 1, 0, 1, 20),
+    )
+    .expect("sweep 2");
+    assert_eq!(reports[0].action, "fired");
+    let rows = fires(&store, "nightly");
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].state, RoutineFireState::Dispatched);
+    assert_eq!(dispatch.submit_count(), 1);
+}
+
+#[test]
+fn same_slot_second_sweep_does_not_double_fire() {
+    let store = store();
+    let dispatch = FakeDispatch::default();
+    let coll = collection(vec![routine("nightly", "* * * * *", true, "allow", 0)]);
+    // Baseline in the past so the target minute is already fireable.
+    store
+        .routine_record_baseline("nightly", &ts(2026, 1, 1, 0, 0, 0).to_rfc3339())
+        .unwrap();
+
+    let opts = SweepOptions::default();
+    let first = run_sweep_core(
+        &store,
+        HOST,
+        &coll,
+        &dispatch,
+        opts,
+        ts(2026, 1, 1, 0, 1, 10),
+    )
+    .unwrap();
+    assert_eq!(first[0].action, "fired");
+
+    // Second sweep in the SAME minute: the consumed slot is not re-fired.
+    let second = run_sweep_core(
+        &store,
+        HOST,
+        &coll,
+        &dispatch,
+        opts,
+        ts(2026, 1, 1, 0, 1, 50),
+    )
+    .unwrap();
+    assert_eq!(second[0].action, "skipped");
+    assert_eq!(second[0].reason.as_deref(), Some("not_due"));
+
+    assert_eq!(
+        fires(&store, "nightly").len(),
+        1,
+        "exactly one fire for the slot"
+    );
+    assert_eq!(dispatch.submit_count(), 1);
+}
+
+// ---- toggles --------------------------------------------------------------
+
+#[test]
+fn toggles_suppress_the_fire_with_the_right_reason() {
+    let store = store();
+    let dispatch = FakeDispatch::default();
+    store
+        .routine_record_baseline("disabled", &ts(2026, 1, 1, 0, 0, 0).to_rfc3339())
+        .unwrap();
+    store
+        .routine_record_baseline("paused", &ts(2026, 1, 1, 0, 0, 0).to_rfc3339())
+        .unwrap();
+    store
+        .routine_record_baseline("elsewhere", &ts(2026, 1, 1, 0, 0, 0).to_rfc3339())
+        .unwrap();
+    store.routine_pause("paused", "test").unwrap();
+
+    let mut off = routine("elsewhere", "* * * * *", true, "allow", 0);
+    off.definition.hosts = vec!["other-host".to_string()];
+    let coll = collection(vec![
+        routine("disabled", "* * * * *", false, "allow", 0),
+        routine("paused", "* * * * *", true, "allow", 0),
+        off,
+    ]);
+
+    let reports = run_sweep_core(
+        &store,
+        HOST,
+        &coll,
+        &dispatch,
+        SweepOptions::default(),
+        ts(2026, 1, 1, 0, 5, 10),
+    )
+    .unwrap();
+
+    let reason = |name: &str| {
+        reports
+            .iter()
+            .find(|r| r.routine == name)
+            .and_then(|r| r.reason.clone())
+    };
+    assert_eq!(
+        reason("disabled").as_deref(),
+        Some("disabled_in_definition")
+    );
+    assert_eq!(reason("paused").as_deref(), Some("paused_locally"));
+    assert_eq!(reason("elsewhere").as_deref(), Some("host_not_pinned"));
+    assert_eq!(dispatch.submit_count(), 0);
+}
+
+// ---- overlap: forbid ------------------------------------------------------
+
+#[test]
+fn overlap_forbid_skips_while_in_flight_then_fires_once_terminal() {
+    let store = store();
+    let dispatch = FakeDispatch::default();
+    let coll = collection(vec![routine("job", "* * * * *", true, "forbid", 0)]);
+
+    // Seed a dispatched, still-in-flight fire at 00:05 and point the cursor at it.
+    store
+        .routine_record_baseline("job", &ts(2026, 1, 1, 0, 0, 0).to_rfc3339())
+        .unwrap();
+    let slot_in_flight = ts(2026, 1, 1, 0, 5, 0).to_rfc3339();
+    store
+        .routine_record_fire_intent(&RoutineFireIntentParams {
+            routine_name: "job".to_string(),
+            slot: slot_in_flight.clone(),
+            attempt: 1,
+            source_workspace: "polaris".to_string(),
+        })
+        .unwrap();
+    store
+        .routine_mark_fire_dispatched("job", &slot_in_flight, 1, "inflight")
+        .unwrap();
+
+    // A new slot comes due while the prior fire is non-terminal -> skipped.
+    // `now` sits before the seeded fire's real-clock created_at, so the outcome
+    // sync cannot reclaim it as stale — it is genuinely in flight.
+    let reports = run_sweep_core(
+        &store,
+        HOST,
+        &coll,
+        &dispatch,
+        SweepOptions::default(),
+        ts(2026, 1, 1, 0, 6, 20),
+    )
+    .unwrap();
+    assert_eq!(reports[0].action, "skipped");
+    assert_eq!(reports[0].reason.as_deref(), Some("overlap_in_flight"));
+    assert_eq!(dispatch.submit_count(), 0);
+
+    // Once the in-flight run reaches a terminal state, the next slot fires.
+    dispatch.set_state("inflight", JobRunState::Success);
+    let reports = run_sweep_core(
+        &store,
+        HOST,
+        &coll,
+        &dispatch,
+        SweepOptions::default(),
+        ts(2026, 1, 1, 0, 7, 20),
+    )
+    .unwrap();
+    assert_eq!(reports[0].action, "fired");
+    assert_eq!(dispatch.submit_count(), 1);
+    // The reclaimed fire is now terminal.
+    let seeded = fires(&store, "job")
+        .into_iter()
+        .find(|f| f.slot == slot_in_flight)
+        .unwrap();
+    assert_eq!(seeded.state, RoutineFireState::Succeeded);
+}
+
+// ---- outcome sync / staleness horizon -------------------------------------
+
+#[test]
+fn sync_reclaims_stale_intent_and_dispatched_past_timeout() {
+    let store = store();
+    let dispatch = FakeDispatch::default();
+    // enabled:false so the per-routine pass is a no-op and only the outcome
+    // sync at the top of the pass touches these fires.
+    let coll = collection(vec![routine("job", "* * * * *", false, "forbid", 0)]);
+
+    let now = Utc::now();
+    store
+        .routine_record_baseline("job", &now.to_rfc3339())
+        .unwrap();
+    // Stale intent (sweep died before dispatch).
+    store
+        .routine_record_fire_intent(&RoutineFireIntentParams {
+            routine_name: "job".to_string(),
+            slot: "2026-01-01T00:01:00+00:00".to_string(),
+            attempt: 1,
+            source_workspace: "polaris".to_string(),
+        })
+        .unwrap();
+    // Dispatched but the run is unqueryable (fake returns no state).
+    store
+        .routine_record_fire_intent(&RoutineFireIntentParams {
+            routine_name: "job".to_string(),
+            slot: "2026-01-01T00:02:00+00:00".to_string(),
+            attempt: 1,
+            source_workspace: "polaris".to_string(),
+        })
+        .unwrap();
+    store
+        .routine_mark_fire_dispatched("job", "2026-01-01T00:02:00+00:00", 1, "lost-run")
+        .unwrap();
+
+    // Advance `now` past the 10-minute policy timeout so both are reclaimable.
+    let reclaim_at = now + Duration::hours(2);
+    run_sweep_core(
+        &store,
+        HOST,
+        &coll,
+        &dispatch,
+        SweepOptions::default(),
+        reclaim_at,
+    )
+    .unwrap();
+
+    let by_slot: HashMap<String, RoutineFireState> = fires(&store, "job")
+        .into_iter()
+        .map(|f| (f.slot, f.state))
+        .collect();
+    assert_eq!(
+        by_slot.get("2026-01-01T00:01:00+00:00"),
+        Some(&RoutineFireState::Error),
+        "stale intent reclaimed as error"
+    );
+    assert_eq!(
+        by_slot.get("2026-01-01T00:02:00+00:00"),
+        Some(&RoutineFireState::TimedOut),
+        "stale dispatched reclaimed as timed_out"
+    );
+}
+
+// ---- dry-run --------------------------------------------------------------
+
+#[test]
+fn dry_run_records_no_state() {
+    let store = store();
+    let dispatch = FakeDispatch::default();
+    let coll = collection(vec![routine("nightly", "* * * * *", true, "allow", 0)]);
+    store
+        .routine_record_baseline("seen", &ts(2026, 1, 1, 0, 0, 0).to_rfc3339())
+        .unwrap();
+
+    let reports = run_sweep_core(
+        &store,
+        HOST,
+        &coll,
+        &dispatch,
+        SweepOptions { dry_run: true },
+        ts(2026, 1, 1, 0, 5, 10),
+    )
+    .unwrap();
+
+    // First-observation routine reports would_baseline but records no cursor.
+    assert_eq!(reports[0].action, "would_baseline");
+    assert!(store.routine_cursor("nightly").unwrap().is_none());
+    assert!(fires(&store, "nightly").is_empty());
+    assert_eq!(dispatch.submit_count(), 0);
+}
+
+// ---- run_sweep_at end-to-end (discovery + fail-closed loading) ------------
+
+const NOOP_JOB: &str = "schemaVersion: 2\n\
+kind: Job\n\
+metadata:\n  name: noop\n\
+spec:\n  state: enabled\n  kind: workflow\n  max_active_runs: 1\n  \
+steps:\n    - id: noop\n      target: activity:worktree_setup\n      \
+default_input:\n        task_id: \"qa\"\n";
+
+fn source_routine_yaml(name: &str, target: &str, hosts: &str) -> String {
+    format!(
+        "schemaVersion: 1\nname: {name}\nenabled: true\nhosts: {hosts}\n\
+         trigger: {{ cron: \"* * * * *\" }}\ntarget: {target}\n"
+    )
+}
+
+#[test]
+fn run_sweep_at_dry_run_discovers_loads_and_fails_closed() {
+    let tmp = tempdir().unwrap();
+    let global = tmp.path().join("global");
+    let ws_root = tmp.path().join("polaris");
+    let ws_orbit = ws_root.join(".orbit");
+    fs::create_dir_all(global.join("state")).unwrap();
+    fs::create_dir_all(ws_orbit.join("routines")).unwrap();
+    fs::create_dir_all(ws_orbit.join("resources/jobs")).unwrap();
+
+    fs::write(global.join("host.toml"), format!("host_id = \"{HOST}\"\n")).unwrap();
+    fs::write(
+        ws_orbit.join("config.toml"),
+        "[routines]\nrole = \"source\"\n",
+    )
+    .unwrap();
+    fs::write(ws_orbit.join("resources/jobs/noop.yaml"), NOOP_JOB).unwrap();
+
+    let ph = format!("[{HOST}]");
+    fs::write(
+        ws_orbit.join("routines/minutely.yaml"),
+        source_routine_yaml("qa-minutely", "job:noop", &ph),
+    )
+    .unwrap();
+    fs::write(
+        ws_orbit.join("routines/otherhost.yaml"),
+        source_routine_yaml("qa-otherhost", "job:noop", "[dk-server-1]"),
+    )
+    .unwrap();
+    fs::write(
+        ws_orbit.join("routines/badtarget.yaml"),
+        source_routine_yaml("qa-bad", "job:does_not_exist", &ph),
+    )
+    .unwrap();
+    fs::write(
+        ws_orbit.join("routines/activity.yaml"),
+        source_routine_yaml("qa-activity", "activity:worktree_setup", &ph),
+    )
+    .unwrap();
+
+    let mut registry = WorkspaceRegistry::default();
+    registry.workspaces.push(Workspace {
+        id: "ws-1".to_string(),
+        name: "polaris".to_string(),
+        root: ws_root.clone(),
+        orbit_dir: ws_orbit.clone(),
+        git_remote: None,
+        base_branch: "agent-main".to_string(),
+        status: WorkspaceStatus::Active,
+        created_at: Utc::now(),
+        updated_at: Utc::now(),
+    });
+    workspace_registry::save_registry_to(
+        &registry,
+        &workspace_registry::registry_path_for(&global),
+    )
+    .unwrap();
+
+    let outcome = run_sweep_at(&global, SweepOptions { dry_run: true }).expect("sweep ok");
+
+    assert_eq!(outcome.host_id, HOST);
+    assert!(!outcome.lock_busy);
+
+    let report = |name: &str| outcome.reports.iter().find(|r| r.routine == name);
+    // Valid, pinned routine: first observation -> would_baseline (dry-run).
+    assert_eq!(
+        report("qa-minutely").map(|r| r.action),
+        Some("would_baseline")
+    );
+    // Pinned elsewhere -> skipped.
+    assert_eq!(
+        report("qa-otherhost")
+            .and_then(|r| r.reason.clone())
+            .as_deref(),
+        Some("host_not_pinned")
+    );
+    // Fail-closed load errors, not fires: unresolvable target + reserved activity.
+    assert!(
+        outcome
+            .load_errors
+            .iter()
+            .any(|e| e.message.contains("does not resolve")),
+        "unresolvable target is a load error"
+    );
+    assert!(
+        outcome
+            .load_errors
+            .iter()
+            .any(|e| e.message.contains("not dispatchable")),
+        "activity target rejected at parse"
+    );
+    // dry-run recorded nothing.
+    let store = Store::open(&global.join("orbit.db")).unwrap();
+    assert!(store.routine_cursor("qa-minutely").unwrap().is_none());
+}

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -283,6 +283,22 @@ jq -r 'select(.level=="ERROR")
 `RUST_LOG` controls the tracing filter for any orbit process
 (e.g. `RUST_LOG=debug orbit task list` — standard `EnvFilter` syntax).
 
+**Routine sweep log (macOS).** The launchd agent (`com.orbit.sweep`, installed by
+`orbit routine init --install-clock`) redirects `orbit sweep` stdout/stderr to a separate
+file, since it is not the JSONL tracing sink:
+
+```
+~/.orbit/logs/sweep.log
+```
+
+Two things keep it bounded on an always-on host ([ORB-00423]): `orbit sweep` prints only
+noteworthy rows by default — fires, retries, baselines, and errors, plus a one-line
+heartbeat when a pass had nothing due (`--verbose` restores a row per routine) — and each
+pass opportunistically rolls + prunes `sweep.log` through the same
+`log_rotation` machinery and `[runtime]` caps as the JSONL sink above (rename-based archives
+`sweep.log.<UTC-timestamp>`). On Linux the sweep unit logs to the journal instead, which
+rotates on its own.
+
 ---
 
 ## 6. Audit trail

--- a/docs/design/routines/2_design.md
+++ b/docs/design/routines/2_design.md
@@ -1,7 +1,7 @@
 ---
 title: Routines — Design
 owner: claude
-last_updated: 2026-07-04
+last_updated: 2026-07-05
 status: Accepted
 feature: routines
 doc_role: design
@@ -65,7 +65,12 @@ Field semantics:
   fixed backoff, and overlap handling. `overlap: forbid` is the default; `timeout_minutes`
   defaults to 60 and doubles as the staleness horizon (§4), `retries` defaults to
   `{max: 0, backoff_minutes: 2}`. Retries re-dispatch a *failed* fire under the same slot
-  (attempt 2..max+1) once the backoff has elapsed, evaluated on later sweep passes.
+  (attempt 2..max+1) once the backoff has elapsed, evaluated on later sweep passes. A fire
+  that *errored at dispatch* (`submit_pipeline_run` failed synchronously — lock contention, a
+  momentary catalog/store hiccup) is retried under the same policy as a run-level failure
+  ([ORB-00422]): a transient dispatch failure is the class retries exist to absorb, so it must
+  not burn the slot when retry budget remains. With `max: 0` (the default) a dispatch error,
+  like any failure, consumes the slot and waits for the next natural one.
 
 Parsing is fail-closed: an invalid routine file is reported and *that routine* is treated
 as absent; it never degrades into "fire with defaults".
@@ -205,7 +210,13 @@ out of v1 scope for this reason.
   accurate in-flight bookkeeping; a crashed sweep that recorded a fire intent but died
   before dispatch leaves a stale in-flight entry. The outcome-sync step reclaims intents
   and dispatches older than `policy.timeout_minutes` (marking them `error` / `timed_out`);
-  the consumed slot is not re-fired — the idempotency key holds.
+  the consumed slot is not re-fired — the idempotency key holds. The two failure paths are
+  deliberately given different states so retry can tell them apart ([ORB-00422]): a
+  *synchronous* `submit_pipeline_run` error is unambiguous (nothing dispatched), so `fire`
+  records it as `failed` — retryable under `policy.retries` like a run-level failure; a crashed
+  sweep's reclaimed stale intent is *ambiguous* (a worker may have partially started), so the
+  outcome sync records it as `error` — terminal, never re-fired, so a make-up fire cannot race
+  an orphaned run.
 - **Routines carry no input payload.** v1 dispatches every target with an empty input
   object; jobs meant for routines must run with defaults. Parameterized fires would be a
   schema addition.


### PR DESCRIPTION
Follow-ups from QA validation of the routines/sweep feature ([ORB-10021], #529). One commit per task.

## Commits

1. **docs(orbit-guide)** — add a "Routines & scheduling" usage section to the onboarding skill (what routines are, host-local state, the setup sequence, observe/control commands), deferring field semantics to `docs/design/routines/2_design.md` and `--help`.

2. **test(routines): cover the sweep orchestration — [ORB-00421]**
   The ~426-line `sweep.rs` orchestration shipped untested (only the pure sub-pieces had coverage). Adds a minimal dispatch seam (`RoutineDispatch` trait + production `RuntimeDispatch`) and extracts `run_sweep_core(..., now)` so the fire / idempotency / overlap / retry / outcome-sync logic is testable deterministically without spawning pipeline workers. `run_sweep_at` is behaviourally unchanged. New tests: baseline-then-fire, same-slot idempotency, toggle suppression, overlap:forbid skip-then-fire, stale-intent/dispatched reclamation, dry-run, plus one `run_sweep_at` end-to-end pass over a seeded global root (discovery + fail-closed loading).

3. **fix(routines): retry synchronous dispatch failures — [ORB-00422]**
   A `submit_pipeline_run` that returned `Err` was recorded as terminal `Error` and never retried, so a transient dispatch failure permanently burned the slot even with `retries.max > 0`. Now recorded as `Failed` (retryable — nothing dispatched), while `Error` stays reserved for the *ambiguous* crash-orphaned intent (terminal, so a make-up fire never races an orphaned run). `retry_candidate` is unchanged (`Failed`-only), preserving crash-safety. Design doc §1/§6 updated; covered by a fail-then-heal test.

4. **fix(routines): bound the macOS sweep.log; quiet the clock output — [ORB-00423]**
   launchd redirected `orbit sweep` to an un-rotated `~/.orbit/logs/sweep.log`, and every pass printed a row per routine → unbounded growth on an always-on Mac. Now: quiet by default (only fires/retries/baselines/errors + a heartbeat; `--verbose` restores all; `--json` unchanged), and `run_sweep` rolls+prunes `sweep.log` via the existing `log_rotation` utility/caps. `docs/OPERATIONS.md` §5 documents it.

## Validation
- `make ci-fast` passes (fmt-check + guardrails).
- `cargo test -p orbit-core -p orbit-cli`: 729 passed, 0 failed.

## Notes
- Tasks were filed in the orbit workspace: [ORB-00421], [ORB-00422], [ORB-00423].
- [ORB-00422] documents the contract change in the design doc; a formal ADR amendment (ADR-0207, retry policy) via `orbit.adr` tooling is a reasonable follow-up but was not done here to avoid touching shared global ADR state from an isolated worktree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)