### PR TITLE
feat(deploy): daily orbit-web upgrade timer on agent-main hosts [ORB-10034]

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -70,7 +70,7 @@ Safety properties, in order:
 3. **Deferral** instead of restart when any registered workspace has a
    pending/running job run (`orbit run history`).
 4. **Rollback**: if `/healthz` + `/api/workspaces` don't come back healthy
-   within 30s of the restart, the script reinstalls `orbit.bak`, restarts
+   within the post-restart retry window (30 attempts), the script reinstalls `orbit.bak`, restarts
    again, records a friction in polaris, and exits nonzero so the failure
    shows in `systemctl --user list-units --failed`.
 

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -51,6 +51,56 @@ base_branch = "agent-main"   # repo's ship base, if not "main"
 auto_ship = true
 ```
 
+## orbit-web-upgrade (systemd user timer)
+
+Daily `orbit-web-upgrade.sh` run: rebuild `agent-main` in the orbit checkout,
+atomically swap `~/.orbit/bin/orbit` (previous binary kept as `orbit.bak`),
+restart `orbit-web`, and health-check `/healthz` + `/api/workspaces`. This
+automates the manual upgrade runbook in `docs/OPERATIONS.md` so the dashboard
+never drifts behind `agent-main`.
+
+Safety properties, in order:
+
+1. **No-op** when the freshly built binary is byte-identical to the installed
+   one — no swap, no restart, no daily service blip.
+2. **Pre-swap aborts leave everything untouched**: wrong branch, dirty tree,
+   failed `git pull --ff-only`, failed `cargo build --release`, or an
+   `orbit migrate --dry-run` that errors under the new binary (merely *pending*
+   migrations don't block — orbit auto-applies them on workspace open).
+3. **Deferral** instead of restart when any registered workspace has a
+   pending/running job run (`orbit run history`).
+4. **Rollback**: if `/healthz` + `/api/workspaces` don't come back healthy
+   within 30s of the restart, the script reinstalls `orbit.bak`, restarts
+   again, records a friction in polaris, and exits nonzero so the failure
+   shows in `systemctl --user list-units --failed`.
+
+It's a systemd user timer (not an orbit routine) deliberately: the job
+replaces and restarts the very binary the orbit scheduler runs on, so it
+lives outside orbit — like its siblings above, it still works when orbit is
+the thing that's broken.
+
+### Install (per host, e.g. dk-server-1)
+
+```sh
+cp deploy/orbit-web-upgrade.{service,timer} ~/.config/systemd/user/
+systemctl --user daemon-reload
+systemctl --user enable --now orbit-web-upgrade.timer
+```
+
+The service `ExecStart` points at this script inside the checkout
+(`~/workspace/constellation/codebases/orbit/deploy/orbit-web-upgrade.sh`), so
+script fixes land with a normal `git pull` — only `.service`/`.timer` edits
+need a re-copy + `daemon-reload`.
+
+### Inspect / disable
+
+```sh
+systemctl --user list-timers orbit-web-upgrade.timer     # next/last fire
+journalctl --user -t orbit-web-upgrade -n 50             # last run's output
+systemctl --user start orbit-web-upgrade.service         # run once now
+systemctl --user disable --now orbit-web-upgrade.timer   # stop the schedule
+```
+
 ## orbit-web (systemd user service)
 
 Runs `orbit web serve --global --no-open`: the always-on dashboard over every

--- a/deploy/orbit-web-upgrade.service
+++ b/deploy/orbit-web-upgrade.service
@@ -1,0 +1,20 @@
+[Unit]
+Description=orbit-web upgrade (rebuild agent-main, swap ~/.orbit/bin/orbit, restart, verify)
+# Never race the dashboard's own startup ordering: this unit restarts
+# orbit-web itself, so it must not be pulled in as one of its dependencies.
+
+[Service]
+Type=oneshot
+# The script cds into the orbit checkout itself; pin a stable directory anyway.
+WorkingDirectory=%h
+# systemd user units get a minimal PATH that omits cargo (~/.cargo/bin), orbit
+# (~/.orbit/bin), and the git/gh credential tooling in ~/.local/bin.
+Environment=PATH=%h/.cargo/bin:%h/.local/bin:%h/.orbit/bin:/usr/local/bin:/usr/bin:/bin
+ExecStart=%h/workspace/constellation/codebases/orbit/deploy/orbit-web-upgrade.sh
+# A full release rebuild can take several minutes; don't let the default
+# oneshot start timeout kill the build mid-way.
+TimeoutStartSec=30min
+# No Restart=on-failure: a failed pull/build would just fail again seconds
+# later. The daily timer is the retry; failures stay visible in
+# `systemctl --user list-units --failed` until then.
+SyslogIdentifier=orbit-web-upgrade

--- a/deploy/orbit-web-upgrade.service
+++ b/deploy/orbit-web-upgrade.service
@@ -11,8 +11,9 @@ WorkingDirectory=%h
 # (~/.orbit/bin), and the git/gh credential tooling in ~/.local/bin.
 Environment=PATH=%h/.cargo/bin:%h/.local/bin:%h/.orbit/bin:/usr/local/bin:/usr/bin:/bin
 ExecStart=%h/workspace/constellation/codebases/orbit/deploy/orbit-web-upgrade.sh
-# A full release rebuild can take several minutes; don't let the default
-# oneshot start timeout kill the build mid-way.
+# Type=oneshot has no start timeout by default; this is a deliberate ceiling
+# so a wedged pull/build can't hang forever. A killed run is a safe pre-swap
+# abort — the daily timer retries. Raise it if a cold rebuild ever needs more.
 TimeoutStartSec=30min
 # No Restart=on-failure: a failed pull/build would just fail again seconds
 # later. The daily timer is the retry; failures stay visible in

--- a/deploy/orbit-web-upgrade.sh
+++ b/deploy/orbit-web-upgrade.sh
@@ -32,7 +32,7 @@ health_ok() {
   local i
   for i in $(seq 1 30); do
     if [[ "$(curl -fsS --max-time 2 "$WEB_URL/healthz" 2>/dev/null)" == "ok" ]] &&
-      curl -fsS --max-time 2 "$WEB_URL/api/workspaces" 2>/dev/null | grep -q '"id":"ws_'; then
+      grep -Eq '"id" *: *"ws_' <<<"$(curl -fsS --max-time 2 "$WEB_URL/api/workspaces" 2>/dev/null)"; then
       return 0
     fi
     sleep 1
@@ -62,6 +62,11 @@ install_binary() {
 
 main() {
   cd "$REPO"
+
+  # Fail-soft gates below iterate the registered workspaces; make an
+  # unreadable registry observable instead of silently checking nothing.
+  [[ -r "$WORKSPACES_JSON" ]] ||
+    log "warning: $WORKSPACES_JSON unreadable — migrate + deferral gates have nothing to check"
 
   # ---- guards: pre-swap failures leave the installed binary untouched ------
   local head
@@ -96,11 +101,21 @@ main() {
       [[ -d "$ws_root/.orbit" ]] || continue
       if out=$("$new" migrate --dry-run --json --root "$ws_root/.orbit" 2>/dev/null); then
         :
-      elif echo "$out" | python3 -c 'import json,sys; json.load(sys.stdin)' 2>/dev/null; then
-        # Nonzero exit but valid JSON = migrations pending, inspection worked.
+      elif echo "$out" | python3 -c '
+import json, sys
+d = json.load(sys.stdin)
+for comp in ("layout", "schema"):
+    c = d.get(comp, {})
+    if c.get("current", 0) > c.get("supported", 0):
+        sys.exit(2)  # workspace newer than this binary = downgrade
+' 2>/dev/null; then
+        # Nonzero exit, valid JSON, current <= supported everywhere: migrations
+        # merely pending — orbit auto-applies them on workspace open.
         log "pending migrations in $ws_root (auto-apply on open): $(echo "$out" | tr -d '\n' | head -c 300)"
       else
-        die "migrate --dry-run failed in $ws_root with $new_ver: $("$new" migrate --dry-run --root "$ws_root/.orbit" 2>&1 | tail -5 | tr '\n' ' ')"
+        # Hard error or a workspace newer than the new binary (downgrade):
+        # never swap in a binary that can't open every active workspace.
+        die "migrate --dry-run failed in $ws_root with $new_ver (downgrade or hard error): $("$new" migrate --dry-run --root "$ws_root/.orbit" 2>&1 | tail -5 | tr '\n' ' ')"
       fi
     done < <(active_workspace_roots)
   fi
@@ -112,7 +127,7 @@ main() {
   while IFS= read -r ws_root; do
     [[ -d "$ws_root/.orbit" ]] || continue
     if "$BIN" run history --json --limit 20 --root "$ws_root/.orbit" 2>/dev/null |
-      grep -Eq '"status" *: *"(running|pending)"'; then
+      grep -Eq '"state" *: *"(running|pending)"'; then
       log "active job run in $ws_root — deferring upgrade to the next timer tick"
       exit 0
     fi

--- a/deploy/orbit-web-upgrade.sh
+++ b/deploy/orbit-web-upgrade.sh
@@ -1,0 +1,154 @@
+#!/usr/bin/env bash
+# orbit-web-upgrade — daily orbit binary upgrade on a box running orbit-web.
+#
+# Rebuilds agent-main, atomically swaps ~/.orbit/bin/orbit, restarts orbit-web,
+# and health-checks the dashboard — rolling back to orbit.bak when the new
+# binary does not come up healthy. No-ops when the freshly built binary is
+# byte-identical to the installed one, so the daily timer never restarts the
+# service pointlessly.
+#
+# Scheduled by deploy/orbit-web-upgrade.{service,timer}; see deploy/README.md.
+# Runs unattended: every failure path either leaves the installed binary
+# untouched (pre-swap aborts) or restores it from orbit.bak (post-swap).
+
+set -euo pipefail
+
+REPO="${ORBIT_REPO:-$HOME/workspace/constellation/codebases/orbit}"
+BRANCH="${ORBIT_BRANCH:-agent-main}"
+# ORBIT_BIN is overridable so the swap/rollback machinery can be drilled
+# against a sandbox path without touching the real install.
+BIN="${ORBIT_BIN:-$HOME/.orbit/bin/orbit}"
+BAK="$BIN.bak"
+WEB_URL="${ORBIT_WEB_URL:-http://127.0.0.1:7878}"
+UNIT="orbit-web"
+WORKSPACES_JSON="$HOME/.orbit/workspaces.json"
+
+log() { echo "orbit-web-upgrade: $*"; }
+die() { echo "orbit-web-upgrade: ABORT: $*" >&2; exit 1; }
+
+# /healthz must answer "ok" and /api/workspaces must list registered ws_* ids.
+# Retries for up to 30s so a just-restarted server gets time to bind.
+health_ok() {
+  local i
+  for i in $(seq 1 30); do
+    if [[ "$(curl -fsS --max-time 2 "$WEB_URL/healthz" 2>/dev/null)" == "ok" ]] &&
+      curl -fsS --max-time 2 "$WEB_URL/api/workspaces" 2>/dev/null | grep -q '"id":"ws_'; then
+      return 0
+    fi
+    sleep 1
+  done
+  return 1
+}
+
+active_workspace_roots() {
+  python3 -c '
+import json, sys
+with open(sys.argv[1]) as f:
+    data = json.load(f)
+for ws in data["workspaces"]:
+    if ws.get("status") == "active":
+        print(ws["root"])
+' "$WORKSPACES_JSON" 2>/dev/null
+}
+
+# Atomic install: never write into the live inode (the running orbit-web holds
+# it executing — a plain `cp` over it fails with ETXTBSY). Rename replaces the
+# directory entry instead.
+install_binary() {
+  local src="$1"
+  install -m 0755 "$src" "$BIN.next"
+  mv -f "$BIN.next" "$BIN"
+}
+
+main() {
+  cd "$REPO"
+
+  # ---- guards: pre-swap failures leave the installed binary untouched ------
+  local head
+  head=$(git symbolic-ref --short -q HEAD) || die "detached HEAD in $REPO"
+  [[ "$head" == "$BRANCH" ]] || die "checkout is on '$head', not '$BRANCH' — refusing to build"
+  [[ -z "$(git status --porcelain --untracked-files=no)" ]] ||
+    die "working tree in $REPO is dirty — refusing to pull/build"
+  git pull --ff-only --quiet || die "git pull --ff-only failed"
+  cargo build --release --quiet || die "cargo build --release failed"
+
+  local new="$REPO/target/release/orbit"
+  [[ -x "$new" ]] || die "build produced no binary at $new"
+
+  # ---- no-op path: installed binary already matches the agent-main build ---
+  if cmp -s "$new" "$BIN"; then
+    log "installed binary already matches agent-main build ($("$BIN" --version)) — no-op"
+    exit 0
+  fi
+
+  local cur_ver new_ver
+  cur_ver=$("$BIN" --version 2>/dev/null || echo "unknown")
+  new_ver=$("$new" --version)
+
+  # ---- migration gate -------------------------------------------------------
+  # Orbit auto-applies pending migrations on workspace open by design (see
+  # `orbit migrate --help`), so *pending* migrations do not block the swap —
+  # they are logged. A `migrate --dry-run` that errors outright means the new
+  # binary cannot even inspect a workspace: abort before touching anything.
+  if [[ "$cur_ver" != "$new_ver" ]]; then
+    local ws_root out
+    while IFS= read -r ws_root; do
+      [[ -d "$ws_root/.orbit" ]] || continue
+      if out=$("$new" migrate --dry-run --json --root "$ws_root/.orbit" 2>/dev/null); then
+        :
+      elif echo "$out" | python3 -c 'import json,sys; json.load(sys.stdin)' 2>/dev/null; then
+        # Nonzero exit but valid JSON = migrations pending, inspection worked.
+        log "pending migrations in $ws_root (auto-apply on open): $(echo "$out" | tr -d '\n' | head -c 300)"
+      else
+        die "migrate --dry-run failed in $ws_root with $new_ver: $("$new" migrate --dry-run --root "$ws_root/.orbit" 2>&1 | tail -5 | tr '\n' ' ')"
+      fi
+    done < <(active_workspace_roots)
+  fi
+
+  # ---- mid-flight check (cheap, fail-soft) ----------------------------------
+  # Don't restart under an active pipeline/ship run; defer to tomorrow's tick.
+  # Worker CLI runs don't go through orbit-web, so only job runs matter here.
+  local ws_root
+  while IFS= read -r ws_root; do
+    [[ -d "$ws_root/.orbit" ]] || continue
+    if "$BIN" run history --json --limit 20 --root "$ws_root/.orbit" 2>/dev/null |
+      grep -Eq '"status" *: *"(running|pending)"'; then
+      log "active job run in $ws_root — deferring upgrade to the next timer tick"
+      exit 0
+    fi
+  done < <(active_workspace_roots)
+
+  # ---- swap -----------------------------------------------------------------
+  cp -p "$BIN" "$BAK" || die "could not back up $BIN to $BAK"
+  install_binary "$new"
+  systemctl --user restart "$UNIT" || log "systemctl restart $UNIT reported failure — verifying health anyway"
+
+  if health_ok; then
+    log "upgraded: '$cur_ver' -> '$new_ver'; $UNIT healthy"
+    exit 0
+  fi
+
+  # ---- rollback --------------------------------------------------------------
+  log "health check FAILED after swap to '$new_ver' — rolling back to orbit.bak"
+  install_binary "$BAK"
+  systemctl --user restart "$UNIT" || true
+  if health_ok; then
+    log "rollback succeeded: $UNIT healthy again on '$cur_ver'"
+  else
+    log "rollback did NOT restore health — $UNIT unhealthy, manual intervention required"
+  fi
+  # Surface loudly: friction record in polaris (fail-soft — the rolled-back
+  # binary is doing the writing) plus nonzero exit so the unit lands in
+  # `systemctl --user list-units --failed`.
+  "$BIN" friction add --model claude --tag tooling \
+    --body "orbit-web-upgrade: swap to '$new_ver' failed the post-restart health check on $(hostname); rolled back to '$cur_ver' (orbit.bak). See: journalctl --user -t orbit-web-upgrade" \
+    --root "$HOME/workspace/constellation/knowledgebase/polaris/.orbit" 2>/dev/null ||
+    log "could not record friction (non-fatal)"
+  die "upgrade to '$new_ver' failed health check; rolled back to '$cur_ver'"
+}
+
+# Everything above only defines functions/variables; the single call below is
+# the last line the shell needs from this file. That keeps the run safe even
+# though `git pull` may rewrite this very script mid-execution (bash reads
+# scripts incrementally).
+main "$@"

--- a/deploy/orbit-web-upgrade.timer
+++ b/deploy/orbit-web-upgrade.timer
@@ -1,0 +1,14 @@
+[Unit]
+Description=Run the orbit-web upgrade daily
+
+[Timer]
+# Daily cadence. OnCalendar (not OnUnitActiveSec) because Persistent= only
+# takes effect on calendar timers — a box that was down at midnight catches
+# up on boot instead of skipping a day.
+OnCalendar=daily
+Persistent=true
+# Smear start times so the rebuild never lines up exactly with other timers.
+RandomizedDelaySec=600
+
+[Install]
+WantedBy=timers.target

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -473,3 +473,8 @@ sqlite3 ~/.orbit/orbit.db "VACUUM INTO '/backups/orbit.db'"   # global store (§
 Then upgrade the binary, run `orbit migrate --dry-run` to review, `orbit migrate` to
 apply, and `orbit doctor` to verify. After swapping the binary on a host running the
 dashboard: `systemctl --user restart orbit-web`.
+
+On hosts that track `agent-main` continuously, this whole sequence is automated by the
+daily `orbit-web-upgrade` timer (`deploy/orbit-web-upgrade.{sh,service,timer}` — see
+`deploy/README.md`): rebuild, no-op when unchanged, migrate gate, atomic swap with
+`orbit.bak`, restart, health-check, rollback on failure.


### PR DESCRIPTION
Automates the manual orbit-web upgrade runbook (docs/OPERATIONS.md) as a daily systemd **user** timer, sibling to `orbit-ship-sweep` and `orbit-web` in `deploy/`.

## What
- `deploy/orbit-web-upgrade.sh` — rebuild `agent-main`, atomic-swap `~/.orbit/bin/orbit` (previous kept as `orbit.bak`), restart `orbit-web`, health-check `/healthz` + `/api/workspaces`, roll back on failure.
- `deploy/orbit-web-upgrade.{service,timer}` — `Type=oneshot`, `OnCalendar=daily`, `Persistent=true`, journal `SyslogIdentifier=orbit-web-upgrade`, `TimeoutStartSec=30min` for cold rebuilds.
- README section (install / inspect / disable) + OPERATIONS.md pointer.

## Safety (verified on dk-server-1 before this PR)
| Path | Result |
|---|---|
| wrong branch / dirty tree / build failure | abort pre-swap, installed binary untouched (hash-verified) |
| built == installed | no-op: no swap, no restart (orbit-web PID unchanged) |
| swap + healthy | upgraded, `orbit.bak` kept |
| swap + failed health check | rolled back to `orbit.bak` byte-identically, friction recorded in polaris, exit 1 |
| pending migrations | logged, non-blocking (orbit auto-applies on open); `migrate --dry-run` *errors* abort |
| active job run in any workspace | defer to next tick |

Mechanism choice: systemd user timer over an orbit routine because this job replaces/restarts the binary the orbit scheduler itself runs on — it must keep working when orbit is what's broken.

Task: ORB-10034

🤖 Generated with [Claude Code](https://claude.com/claude-code)