### PR TITLE
fix(dashboard): drop intra-doc link to private build_state (rustdoc -D warnings) [ORB-10045]

### DIFF
--- a/crates/orbit-dashboard/src/lib.rs
+++ b/crates/orbit-dashboard/src/lib.rs
@@ -116,7 +116,7 @@ pub fn serve(runtime: &OrbitRuntime, args: ServeArgs) -> Result<(), OrbitError> 
 ///
 /// `root_override` is the top-level `--root <path>` flag, if given; it picks
 /// the dropdown's default-preselected workspace ahead of the process cwd (see
-/// [`build_state`]). This matters for `orbit web connect`: the remote `orbit
+/// `build_state`). This matters for `orbit web connect`: the remote `orbit
 /// web serve` it launches over `ssh` runs non-interactively with cwd set to
 /// the remote user's home directory, so `--root` is the only signal available
 /// to hint which workspace should be preselected there.


### PR DESCRIPTION
agent-main's `Check / Clippy / Test` guardrail is red: the public doc comment on `serve_from_env` (crates/orbit-dashboard/src/lib.rs:119, from ORB-10029) intra-doc-links `build_state`, which is private — `rustdoc -D warnings` rejects it. Surfaced by the PR #536 CI run; reproduced locally.

One-line doc-comment fix: plain code span instead of the link. Verified `RUSTDOCFLAGS='-D warnings' cargo doc -p orbit-dashboard --no-deps` exits 0 on this branch.

Task: ORB-10045

🤖 Generated with [Claude Code](https://claude.com/claude-code)