### PR TITLE
docs(skills): env-agnostic tool surface — bridge parity statement in orbit router skill [ORB-10037]

### DIFF
--- a/crates/orbit-core/assets/skills/orbit/SKILL.md
+++ b/crates/orbit-core/assets/skills/orbit/SKILL.md
@@ -26,6 +26,8 @@ Orbit tools are reachable via two surfaces. Both accept identical JSON arguments
 
 **Mapping rule**: `orbit.<group>.<action>` ↔ `orbit_<group>_<action>` (dots become underscores; JSON args identical). For multi-segment names like `orbit.task.review_thread.add`, every dot becomes an underscore: `orbit_task_review_thread_add`.
 
+**Environment parity**: the orbit tool surface is identical everywhere. On machines without a local orbit store, the same `orbit_*` tools are served by the bridge MCP, which mirrors the orbit MCP exactly (plus an optional `workspace` routing param on tools that lack one); bridge-only extensions (`workflow_ship`, `agent_invoke`, …) handle cross-workspace and pipeline operations.
+
 **Surface coverage:**
 
 - Task lifecycle (`orbit.task.*`), ADR artifacts (`orbit.adr.*`), learnings (`orbit.learning.*`), unified search (`orbit.search`): both surfaces.


### PR DESCRIPTION
## Summary
- P1 (ORB-10036) made the bridge MCP mirror the orbit MCP surface exactly, so the orbit tool surface is identical everywhere. This aligns the consolidated skills with that fact (design: polaris `design/multi-env/multi-env-operations.md`, D2).
- Adds one terse **Environment parity** statement to the router skill (`orbit/SKILL.md`, Tool Invocation section). No other skill changes needed: audit of all SKILL.md + references/ found no env-specific tool-surface claims (remaining `dk-mac` hits are routine host-pinning YAML examples; the Cowork note in `orbit/references/guide.md` documents a workspace-discovery misconfiguration and its fix, not a surface difference).
- `plugin/skills/*` symlinks verified unchanged-safe (skill names untouched).

## Verification
- `make ci-fast` green (fmt-check + guardrail scripts).
- `rg -n "bridge|Cowork|mac|task_create|knowledge_search" crates/orbit-core/assets/skills` — no hit implies an env-specific tool difference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)