### PR TITLE
feat(qa-sweep): scheduled QA routine trailing agent-main [ORB-10039]

### DIFF
--- a/crates/orbit-cli/src/audit_middleware.rs
+++ b/crates/orbit-cli/src/audit_middleware.rs
@@ -725,6 +725,7 @@ fn run_command_meta(cmd: &crate::command::run::RunCommand) -> CommandMeta {
         RunSubcommand::Ship(_) => ("ship", Some("workflow"), Some("ship")),
         RunSubcommand::ShipLocal(_) => ("ship-local", Some("workflow"), Some("ship-local")),
         RunSubcommand::ShipSweep(_) => ("ship-sweep", Some("workflow"), Some("ship-sweep")),
+        RunSubcommand::QaSweep(_) => ("qa-sweep", Some("workflow"), Some("qa-sweep")),
         RunSubcommand::DuelPlan(args) => ("duel-plan", Some("task"), Some(args.task_id.as_str())),
         RunSubcommand::History(args) => ("history", Some("job_run"), args.job_id.as_deref()),
         RunSubcommand::Show(args) => ("show", Some("job_run"), args.run_id.as_deref()),

--- a/crates/orbit-cli/src/command/run/command.rs
+++ b/crates/orbit-cli/src/command/run/command.rs
@@ -8,6 +8,7 @@ use super::events::RunEventsArgs;
 use super::history::RunHistoryArgs;
 use super::job::JobRunArgs;
 use super::logs::RunLogsArgs;
+use super::qa_sweep;
 use super::ship;
 use super::show::RunShowArgs;
 use super::sweep;
@@ -17,6 +18,7 @@ const RUN_AFTER_HELP: &str = "\
 Workflow entrypoints:
   orbit run ship [task_id ...]
   orbit run ship-sweep [--dry-run] [--json]
+  orbit run qa-sweep [--dry-run] [--json]
   orbit run duel-plan <task_id>
   orbit run job <job_id> [--input key=value] [--json] [--debug]
 
@@ -44,6 +46,7 @@ Run history:
 Workflows:
   ship        Ship backlog or explicitly selected tasks through the gated task pipeline
   ship-sweep  Dispatch ship runs in every registered workspace with ready backlog tasks
+  qa-sweep    Validate new agent-main commits in configured direct-push workspaces
   duel-plan   Run a planning duel for one task
   job         Run an arbitrary job by ID
 
@@ -79,6 +82,9 @@ pub enum RunSubcommand {
     /// Dispatch ship runs in every registered workspace with ready backlog tasks
     #[command(name = "ship-sweep")]
     ShipSweep(sweep::ShipSweepCommand),
+    /// Validate new agent-main commits in configured direct-push workspaces
+    #[command(name = "qa-sweep")]
+    QaSweep(qa_sweep::QaSweepCommand),
     /// Run a planning duel for one task
     #[command(name = "duel-plan")]
     DuelPlan(duel::DuelPlanCommand),
@@ -104,6 +110,7 @@ impl Execute for RunSubcommand {
             // Normally dispatched before runtime init (see main.rs); the
             // registry-driven sweep never uses the cwd-derived runtime.
             RunSubcommand::ShipSweep(command) => command.execute_without_runtime(),
+            RunSubcommand::QaSweep(command) => command.execute_without_runtime(),
             RunSubcommand::DuelPlan(command) => command.execute(runtime),
             RunSubcommand::History(command) => command.execute(runtime),
             RunSubcommand::Show(command) => command.execute(runtime),

--- a/crates/orbit-cli/src/command/run/mod.rs
+++ b/crates/orbit-cli/src/command/run/mod.rs
@@ -6,6 +6,7 @@ mod history;
 pub mod job;
 pub mod legacy_logs;
 mod logs;
+pub mod qa_sweep;
 pub mod ship;
 mod show;
 mod steps;

--- a/crates/orbit-cli/src/command/run/qa_sweep.rs
+++ b/crates/orbit-cli/src/command/run/qa_sweep.rs
@@ -1,0 +1,154 @@
+//! `orbit run qa-sweep` — trailing QA validation over direct-push workspaces
+//! [ORB-10039], sibling of `orbit run ship-sweep`. Designed for unattended
+//! schedulers: it never bootstraps a workspace from the caller's cwd,
+//! isolates per-workspace failures, and exits non-zero only when a workspace
+//! errored (a red check is the sweep working — it files a task — not a sweep
+//! failure).
+
+use clap::Args;
+use orbit_core::OrbitError;
+use orbit_core::qa::{QaCheckReport, QaSweepOptions, QaWorkspaceReport, run_qa_sweep};
+use serde_json::{Value, json};
+
+#[derive(Args)]
+#[command(
+    name = "qa-sweep",
+    about = "Validate new agent-main commits in configured direct-push workspaces",
+    after_help = "Workspaces and their checks come from the [qa] section of the GLOBAL\n\
+                  ~/.orbit/config.toml (never workspace config, which task-mutation\n\
+                  commands rewrite). Per workspace: diff the live checkout's HEAD against\n\
+                  the last-validated watermark; when new commits exist, run the checks,\n\
+                  file fingerprint-deduped orbit tasks for failures, and advance the\n\
+                  watermark only on a fully green pass. Intended to run from a scheduler\n\
+                  (systemd timer / cron), e.g.:\n  orbit run qa-sweep --json\n\n\
+                  Sweeps are recorded in each workspace's run ledger under job id\n\
+                  'qa_sweep': inspect with `orbit run history -j qa_sweep` and\n\
+                  `orbit run show <run_id>` from the workspace."
+)]
+pub struct QaSweepCommand {
+    /// Report what would be validated without running checks, recording runs,
+    /// filing tasks, or advancing watermarks.
+    #[arg(long)]
+    pub dry_run: bool,
+    /// Output as JSON.
+    #[arg(long)]
+    pub json: bool,
+}
+
+impl QaSweepCommand {
+    /// Runs without a pre-initialized runtime: the sweep resolves every
+    /// workspace from the global registry and must never bootstrap a
+    /// `.orbit/` in the scheduler's working directory.
+    pub fn execute_without_runtime(self) -> Result<(), OrbitError> {
+        let outcome = run_qa_sweep(QaSweepOptions {
+            dry_run: self.dry_run,
+        })?;
+
+        let failed = outcome
+            .reports
+            .iter()
+            .filter(|report| report.action == "error")
+            .count();
+
+        if self.json {
+            crate::output::json::print_pretty(&json!({
+                "dry_run": self.dry_run,
+                "lock_busy": outcome.lock_busy,
+                "workspaces": outcome.reports.len(),
+                "validated": count_actions(&outcome.reports, "validated"),
+                "failed_checks": count_actions(&outcome.reports, "failed"),
+                "would_validate": count_actions(&outcome.reports, "would_validate"),
+                "skipped": count_actions(&outcome.reports, "skipped"),
+                "errors": failed,
+                "reports": outcome.reports.iter().map(report_json).collect::<Vec<_>>(),
+            }))?;
+        } else if outcome.lock_busy {
+            println!("qa-sweep: another pass holds the lock on this host; exiting");
+        } else if outcome.reports.is_empty() {
+            println!("qa-sweep: no [qa] workspaces configured in the global config.toml");
+        } else {
+            for report in &outcome.reports {
+                println!("{}", report_line(report));
+            }
+        }
+
+        if failed > 0 {
+            return Err(OrbitError::WorkspaceError(format!(
+                "qa-sweep: {failed} of {} workspace(s) errored",
+                outcome.reports.len()
+            )));
+        }
+        Ok(())
+    }
+}
+
+fn count_actions(reports: &[QaWorkspaceReport], action: &str) -> usize {
+    reports.iter().filter(|r| r.action == action).count()
+}
+
+pub(crate) fn report_json(report: &QaWorkspaceReport) -> Value {
+    json!({
+        "workspace": report.workspace,
+        "action": report.action,
+        "reason": report.reason,
+        "branch": report.branch,
+        "head": report.head,
+        "baseline": report.baseline,
+        "new_commits": report.new_commits.as_ref().map(Vec::len),
+        "watermark_reset": report.watermark_reset,
+        "run_id": report.run_id,
+        "checks": report.checks.iter().map(|check| json!({
+            "name": check.name,
+            "outcome": check.outcome,
+            "exit_code": check.exit_code,
+            "duration_ms": check.duration_ms,
+            "fingerprint": check.fingerprint,
+            "filed_task": check.filed_task,
+            "deduped_task": check.deduped_task,
+        })).collect::<Vec<_>>(),
+    })
+}
+
+pub(crate) fn report_line(report: &QaWorkspaceReport) -> String {
+    let mut line = format!("{}: {}", report.workspace, report.action);
+    if let Some(reason) = &report.reason {
+        line.push_str(&format!(" — {reason}"));
+    }
+    if let (Some(baseline), Some(head)) = (&report.baseline, &report.head)
+        && report.action != "skipped"
+    {
+        line.push_str(&format!(" — {}..{}", short_sha(baseline), short_sha(head)));
+    } else if let Some(head) = &report.head
+        && report.action != "skipped"
+    {
+        line.push_str(&format!(" — HEAD {}", short_sha(head)));
+    }
+    if !report.checks.is_empty() {
+        let checks = report
+            .checks
+            .iter()
+            .map(check_summary)
+            .collect::<Vec<_>>()
+            .join(", ");
+        line.push_str(&format!(" [{checks}]"));
+    }
+    if let Some(run_id) = &report.run_id {
+        line.push_str(&format!(" — run {run_id}"));
+    }
+    line
+}
+
+fn check_summary(check: &QaCheckReport) -> String {
+    let mut summary = format!("{}: {}", check.name, check.outcome);
+    if let Some(task) = &check.filed_task {
+        summary.push_str(&format!(" (filed {task})"));
+    }
+    if let Some(task) = &check.deduped_task {
+        summary.push_str(&format!(" (open {task})"));
+    }
+    summary
+}
+
+fn short_sha(sha: &str) -> &str {
+    if sha.len() > 10 { &sha[..10] } else { sha }
+}

--- a/crates/orbit-cli/src/command/run/tests/mod.rs
+++ b/crates/orbit-cli/src/command/run/tests/mod.rs
@@ -3,6 +3,7 @@
 mod duel;
 mod format;
 mod job;
+mod qa_sweep;
 mod ship;
 mod support;
 

--- a/crates/orbit-cli/src/command/run/tests/qa_sweep.rs
+++ b/crates/orbit-cli/src/command/run/tests/qa_sweep.rs
@@ -1,0 +1,105 @@
+//! Rendering tests for `orbit run qa-sweep` report rows [ORB-10039].
+
+use orbit_core::qa::{QaCheckReport, QaWorkspaceReport};
+
+use crate::command::run::RunSubcommand;
+use crate::command::run::qa_sweep::{report_json, report_line};
+
+use super::parse_run;
+
+#[test]
+fn parses_qa_sweep_flags() {
+    let command = parse_run(&["orbit", "run", "qa-sweep", "--dry-run", "--json"]);
+    match command.command {
+        RunSubcommand::QaSweep(args) => {
+            assert!(args.dry_run);
+            assert!(args.json);
+        }
+        _ => panic!("expected qa-sweep"),
+    }
+}
+
+#[test]
+fn qa_sweep_flags_default_off() {
+    let command = parse_run(&["orbit", "run", "qa-sweep"]);
+    match command.command {
+        RunSubcommand::QaSweep(args) => {
+            assert!(!args.dry_run);
+            assert!(!args.json);
+        }
+        _ => panic!("expected qa-sweep"),
+    }
+}
+
+fn report(action: &'static str) -> QaWorkspaceReport {
+    QaWorkspaceReport {
+        workspace: "polaris".to_string(),
+        action,
+        reason: None,
+        branch: Some("agent-main".to_string()),
+        head: Some("beefbeefbeefbeef".to_string()),
+        baseline: Some("cafecafecafecafe".to_string()),
+        new_commits: Some(vec!["beefbeef add thing".to_string()]),
+        watermark_reset: false,
+        run_id: Some("run-42".to_string()),
+        checks: vec![
+            QaCheckReport {
+                name: "lint".to_string(),
+                outcome: "passed",
+                exit_code: Some(0),
+                duration_ms: 120,
+                fingerprint: None,
+                filed_task: None,
+                deduped_task: None,
+            },
+            QaCheckReport {
+                name: "tests".to_string(),
+                outcome: "failed",
+                exit_code: Some(1),
+                duration_ms: 4500,
+                fingerprint: Some("abc123def456".to_string()),
+                filed_task: Some("ORB-10101".to_string()),
+                deduped_task: None,
+            },
+        ],
+    }
+}
+
+#[test]
+fn line_carries_range_checks_and_run() {
+    let line = report_line(&report("failed"));
+    assert_eq!(
+        line,
+        "polaris: failed — cafecafeca..beefbeefbe [lint: passed, tests: failed (filed ORB-10101)] — run run-42"
+    );
+}
+
+#[test]
+fn skipped_line_shows_reason_without_range() {
+    let mut skipped = report("skipped");
+    skipped.reason = Some("no_new_commits".to_string());
+    skipped.checks.clear();
+    skipped.run_id = None;
+    assert_eq!(report_line(&skipped), "polaris: skipped — no_new_commits");
+}
+
+#[test]
+fn deduped_check_names_the_open_task() {
+    let mut deduped = report("failed");
+    deduped.checks[1].filed_task = None;
+    deduped.checks[1].deduped_task = Some("ORB-10100".to_string());
+    assert!(report_line(&deduped).contains("tests: failed (open ORB-10100)"));
+}
+
+#[test]
+fn json_shape_is_stable() {
+    let value = report_json(&report("validated"));
+    assert_eq!(value["workspace"], "polaris");
+    assert_eq!(value["action"], "validated");
+    assert_eq!(value["baseline"], "cafecafecafecafe");
+    assert_eq!(value["new_commits"], 1);
+    assert_eq!(value["run_id"], "run-42");
+    assert_eq!(value["checks"][1]["fingerprint"], "abc123def456");
+    assert_eq!(value["checks"][1]["filed_task"], "ORB-10101");
+    assert_eq!(value["checks"][0]["exit_code"], 0);
+}

--- a/crates/orbit-cli/src/main.rs
+++ b/crates/orbit-cli/src/main.rs
@@ -135,6 +135,19 @@ fn main() {
             }
             return;
         }
+        // `orbit run qa-sweep` likewise resolves everything from the global
+        // registry, global config, and host-local watermark state
+        // [ORB-10039]; it must never bootstrap a `.orbit/` where the
+        // scheduler happens to run it.
+        Commands::Run(RunCommand {
+            command: RunSubcommand::QaSweep(args),
+        }) => {
+            if let Err(err) = args.execute_without_runtime() {
+                print_error(&err, tool_run_json_output);
+                std::process::exit(1);
+            }
+            return;
+        }
         // `orbit sweep` and `orbit routine` resolve everything from the
         // global registry and host-local scheduler state; like ship-sweep
         // they must never bootstrap a `.orbit/` in the scheduler's cwd.

--- a/crates/orbit-core/src/config/mod.rs
+++ b/crates/orbit-core/src/config/mod.rs
@@ -25,6 +25,7 @@ mod store;
 pub(crate) use bootstrap::seed_default_config;
 pub(crate) use persistence::PersistenceConfig;
 pub use raw::{RawAgentRoleConfig, RawCrewEntry};
+pub(crate) use raw::{RawQaCheckConfig, RawQaConfig, RawQaWorkspaceConfig};
 pub use registry::{CONFIG_KEY_REGISTRY, ConfigKeyDescriptor, describe as describe_config_key};
 pub(crate) use runtime::{CodexExecutionPolicy, DuelConfig, ExecutionEnvPolicy, RuntimeConfig};
 pub use store::{ConfigScope, ConfigSnapshot, ConfigStore, WorkspaceInitMode};

--- a/crates/orbit-core/src/config/raw.rs
+++ b/crates/orbit-core/src/config/raw.rs
@@ -16,6 +16,7 @@ pub(super) struct RawRuntimeConfig {
     pub(super) runtime: Option<RawRuntimeSection>,
     pub(super) workflow: Option<RawWorkflowConfig>,
     pub(super) routines: Option<RawRoutinesConfig>,
+    pub(crate) qa: Option<RawQaConfig>,
     pub(super) duel: Option<RawDuelSection>,
     /// Removed in ORB-00058. Kept only so config loading can reject stale
     /// `[agent.<role>]` tables with an explicit migration error.
@@ -39,6 +40,54 @@ pub(super) struct RawWorkflowConfig {
     /// Named crew used when a task does not declare `crew` and no CLI
     /// override is provided.
     pub(super) default_crew: Option<String>,
+}
+
+/// `[qa]` — configuration for the trailing QA validation sweep
+/// (`orbit run qa-sweep`) [ORB-10039]. Host-level: the sweep reads this from
+/// the **global** `~/.orbit/config.toml` only (like the workspace registry it
+/// iterates), so a workspace-level `config.toml` — which task-mutation
+/// commands rewrite — can never strip or override it.
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct RawQaConfig {
+    /// `qa.default_priority` — priority for auto-filed QA tasks when a check
+    /// does not override it. One of `low`, `medium`, `high`, `critical`;
+    /// defaults to `medium`.
+    pub(crate) default_priority: Option<String>,
+    /// `qa.task_status` — status auto-filed QA tasks are created with. One of
+    /// `backlog` (default; lets `ship-sweep` dispatch the fix unattended, per
+    /// design D4) or `proposed` (require human approval first).
+    pub(crate) task_status: Option<String>,
+    /// `[[qa.workspace]]` — one entry per direct-push workspace to validate.
+    pub(crate) workspace: Option<Vec<RawQaWorkspaceConfig>>,
+}
+
+/// One `[[qa.workspace]]` entry.
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct RawQaWorkspaceConfig {
+    /// Workspace name as registered in the global workspace registry.
+    pub(crate) name: Option<String>,
+    /// Branch the sweep expects the checkout to be on. Defaults to the
+    /// workspace's registered `base_branch` when absent.
+    pub(crate) branch: Option<String>,
+    /// `[[qa.workspace.check]]` — the checks run against the checkout.
+    pub(crate) check: Option<Vec<RawQaCheckConfig>>,
+}
+
+/// One `[[qa.workspace.check]]` entry.
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct RawQaCheckConfig {
+    /// Stable check name; part of the failure fingerprint.
+    pub(crate) name: Option<String>,
+    /// Shell command run from the workspace root (`sh -c <command>`).
+    pub(crate) command: Option<String>,
+    /// Muted checks are skipped (not executed) without deleting their
+    /// definition — the escape hatch for flaky checks. Defaults to `false`.
+    pub(crate) mute: Option<bool>,
+    /// Per-check priority override for auto-filed QA tasks.
+    pub(crate) priority: Option<String>,
+    /// Kill the check and record a failure after this many minutes.
+    /// Defaults to 30.
+    pub(crate) timeout_minutes: Option<u64>,
 }
 
 #[derive(Debug, Clone, Deserialize)]

--- a/crates/orbit-core/src/config/runtime.rs
+++ b/crates/orbit-core/src/config/runtime.rs
@@ -52,6 +52,11 @@ pub(crate) struct RuntimeConfig {
     /// "source"` in `config.toml`; defaults to `false`). Consulted by
     /// `orbit sweep` before loading `.orbit/routines/*.yaml`.
     pub(crate) routines_source: bool,
+    /// Host-level `[qa]` section for `orbit run qa-sweep` [ORB-10039].
+    /// Meaningful only when this config is the **global** one — the sweep
+    /// loads it from `~/.orbit/config.toml`; workspace configs are never
+    /// consulted for it (they get rewritten by task-mutation commands).
+    pub(crate) qa: crate::qa::QaSweepConfig,
     /// Named planner/implementer/reviewer lineups from `[crews.<name>]`.
     pub(crate) crews: BTreeMap<String, Crew>,
     pub(crate) default_crew: Option<String>,
@@ -100,6 +105,7 @@ impl RuntimeConfig {
             workflow_base_branch: DEFAULT_WORKFLOW_BASE_BRANCH.to_string(),
             workflow_auto_ship: false,
             routines_source: false,
+            qa: crate::qa::QaSweepConfig::default(),
             crews: default_crews(),
             default_crew: Some(DEFAULT_WORKFLOW_CREW.to_string()),
             duel: DuelConfig::default(),
@@ -207,6 +213,7 @@ impl RuntimeConfig {
             .and_then(|workflow| workflow.auto_ship)
             .unwrap_or(false);
         let routines_source = routines_source_from_raw(parsed.routines.as_ref())?;
+        let qa = crate::qa::QaSweepConfig::from_raw(parsed.qa.as_ref())?;
         let crews = crews_from_raw(parsed.crews.as_ref())?;
         let default_crew = workflow_default_crew_from_raw(parsed.workflow.as_ref(), &crews)?;
         let duel = duel_from_raw(parsed.duel.as_ref())?;
@@ -238,6 +245,7 @@ impl RuntimeConfig {
             workflow_base_branch,
             workflow_auto_ship,
             routines_source,
+            qa,
             crews,
             default_crew,
             duel,
@@ -265,6 +273,11 @@ impl RuntimeConfig {
 
     pub(crate) fn routines_source(&self) -> bool {
         self.routines_source
+    }
+
+    /// The validated `[qa]` section [ORB-10039].
+    pub(crate) fn qa_sweep(&self) -> &crate::qa::QaSweepConfig {
+        &self.qa
     }
 
     pub(crate) fn pr_config(&self) -> &PrConfig {

--- a/crates/orbit-core/src/lib.rs
+++ b/crates/orbit-core/src/lib.rs
@@ -49,6 +49,7 @@ pub mod config;
 pub mod context;
 pub mod metrics;
 mod paths;
+pub mod qa;
 pub mod routines;
 pub mod runtime;
 pub mod workspace_registry;

--- a/crates/orbit-core/src/qa/config.rs
+++ b/crates/orbit-core/src/qa/config.rs
@@ -1,0 +1,205 @@
+//! Resolved, validated view of the `[qa]` config section [ORB-10039].
+//!
+//! Raw serde structs live in `config::raw`; this module turns them into a
+//! fail-closed [`QaSweepConfig`] during `RuntimeConfig` load, so a malformed
+//! `[qa]` section is a loud startup error everywhere — never a sweep that
+//! silently validates nothing.
+
+use std::collections::BTreeSet;
+use std::str::FromStr;
+use std::time::Duration;
+
+use orbit_common::types::{OrbitError, TaskPriority, TaskStatus};
+
+use crate::config::{RawQaCheckConfig, RawQaConfig, RawQaWorkspaceConfig};
+
+/// Default priority for auto-filed QA tasks.
+const DEFAULT_TASK_PRIORITY: TaskPriority = TaskPriority::Medium;
+/// Default status for auto-filed QA tasks: `backlog`, so `ship-sweep` can
+/// dispatch the fix unattended (design D4 — the loop closes without a human
+/// courier). Set `qa.task_status = "proposed"` to require approval first.
+const DEFAULT_TASK_STATUS: TaskStatus = TaskStatus::Backlog;
+/// Default per-check timeout.
+const DEFAULT_CHECK_TIMEOUT_MINUTES: u64 = 30;
+
+/// Host-level qa-sweep configuration (from the global `~/.orbit/config.toml`).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct QaSweepConfig {
+    /// Priority for auto-filed QA tasks when a check does not override it.
+    pub default_priority: TaskPriority,
+    /// Status auto-filed QA tasks are created with (`backlog` or `proposed`).
+    pub task_status: TaskStatus,
+    /// Direct-push workspaces to validate, in config order.
+    pub workspaces: Vec<QaWorkspaceConfig>,
+}
+
+/// One workspace's validation setup.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct QaWorkspaceConfig {
+    /// Workspace name as registered in the global workspace registry.
+    pub name: String,
+    /// Branch the checkout must be on for the sweep to validate it; `None`
+    /// falls back to the workspace's registered `base_branch`.
+    pub branch: Option<String>,
+    /// Checks run from the workspace root, in config order.
+    pub checks: Vec<QaCheck>,
+}
+
+/// One configured check.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct QaCheck {
+    /// Stable name; part of the failure fingerprint.
+    pub name: String,
+    /// Shell command run via `sh -c` from the workspace root.
+    pub command: String,
+    /// Muted checks are skipped without deleting their definition.
+    pub mute: bool,
+    /// Per-check priority override for auto-filed tasks.
+    pub priority: Option<TaskPriority>,
+    /// Kill the check and record a failure once this elapses.
+    pub timeout: Duration,
+}
+
+impl Default for QaSweepConfig {
+    fn default() -> Self {
+        Self {
+            default_priority: DEFAULT_TASK_PRIORITY,
+            task_status: DEFAULT_TASK_STATUS,
+            workspaces: Vec::new(),
+        }
+    }
+}
+
+impl QaSweepConfig {
+    /// Validate the raw `[qa]` section. `None` (section absent) resolves to an
+    /// empty config — the sweep then reports "no workspaces configured".
+    pub(crate) fn from_raw(raw: Option<&RawQaConfig>) -> Result<Self, OrbitError> {
+        let Some(raw) = raw else {
+            return Ok(Self::default());
+        };
+
+        let default_priority = match raw.default_priority.as_deref() {
+            Some(value) => parse_priority("qa.default_priority", value)?,
+            None => DEFAULT_TASK_PRIORITY,
+        };
+        let task_status = match raw.task_status.as_deref().map(str::trim) {
+            None => DEFAULT_TASK_STATUS,
+            Some("backlog") => TaskStatus::Backlog,
+            Some("proposed") => TaskStatus::Proposed,
+            Some(other) => {
+                return Err(OrbitError::InvalidInput(format!(
+                    "qa.task_status has invalid value '{other}'; expected one of: backlog, proposed"
+                )));
+            }
+        };
+
+        let mut workspaces = Vec::new();
+        let mut seen_workspaces = BTreeSet::new();
+        for entry in raw.workspace.as_deref().unwrap_or_default() {
+            let workspace = QaWorkspaceConfig::from_raw(entry)?;
+            if !seen_workspaces.insert(workspace.name.clone()) {
+                return Err(OrbitError::InvalidInput(format!(
+                    "[[qa.workspace]] declares workspace '{}' more than once",
+                    workspace.name
+                )));
+            }
+            workspaces.push(workspace);
+        }
+
+        Ok(Self {
+            default_priority,
+            task_status,
+            workspaces,
+        })
+    }
+
+    /// The configured entry for a workspace name, if any.
+    pub fn workspace(&self, name: &str) -> Option<&QaWorkspaceConfig> {
+        self.workspaces.iter().find(|ws| ws.name == name)
+    }
+}
+
+impl QaWorkspaceConfig {
+    fn from_raw(raw: &RawQaWorkspaceConfig) -> Result<Self, OrbitError> {
+        let name = required_trimmed("[[qa.workspace]].name", raw.name.as_deref())?;
+        let branch = match raw.branch.as_deref().map(str::trim) {
+            Some("") => {
+                return Err(OrbitError::InvalidInput(format!(
+                    "[[qa.workspace]] '{name}': branch must not be empty when set"
+                )));
+            }
+            other => other.map(ToOwned::to_owned),
+        };
+
+        let raw_checks = raw.check.as_deref().unwrap_or_default();
+        if raw_checks.is_empty() {
+            return Err(OrbitError::InvalidInput(format!(
+                "[[qa.workspace]] '{name}' must declare at least one [[qa.workspace.check]]"
+            )));
+        }
+        let mut checks = Vec::new();
+        let mut seen_checks = BTreeSet::new();
+        for raw_check in raw_checks {
+            let check = QaCheck::from_raw(&name, raw_check)?;
+            if !seen_checks.insert(check.name.clone()) {
+                return Err(OrbitError::InvalidInput(format!(
+                    "[[qa.workspace]] '{name}' declares check '{}' more than once",
+                    check.name
+                )));
+            }
+            checks.push(check);
+        }
+
+        Ok(Self {
+            name,
+            branch,
+            checks,
+        })
+    }
+}
+
+impl QaCheck {
+    fn from_raw(workspace: &str, raw: &RawQaCheckConfig) -> Result<Self, OrbitError> {
+        let context = format!("[[qa.workspace]] '{workspace}' check");
+        let name = required_trimmed(&format!("{context} name"), raw.name.as_deref())?;
+        let command = required_trimmed(
+            &format!("{context} '{name}' command"),
+            raw.command.as_deref(),
+        )?;
+        let priority = raw
+            .priority
+            .as_deref()
+            .map(|value| parse_priority(&format!("{context} '{name}' priority"), value))
+            .transpose()?;
+        let timeout_minutes = raw.timeout_minutes.unwrap_or(DEFAULT_CHECK_TIMEOUT_MINUTES);
+        if timeout_minutes == 0 {
+            return Err(OrbitError::InvalidInput(format!(
+                "{context} '{name}': timeout_minutes must be at least 1"
+            )));
+        }
+
+        Ok(Self {
+            name,
+            command,
+            mute: raw.mute.unwrap_or(false),
+            priority,
+            timeout: Duration::from_secs(timeout_minutes * 60),
+        })
+    }
+}
+
+fn required_trimmed(label: &str, value: Option<&str>) -> Result<String, OrbitError> {
+    value
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
+        .ok_or_else(|| OrbitError::InvalidInput(format!("{label} must be set and non-empty")))
+}
+
+fn parse_priority(label: &str, value: &str) -> Result<TaskPriority, OrbitError> {
+    TaskPriority::from_str(value.trim()).map_err(|_| {
+        OrbitError::InvalidInput(format!(
+            "{label} has invalid value '{value}'; expected one of: low, medium, high, critical"
+        ))
+    })
+}

--- a/crates/orbit-core/src/qa/fingerprint.rs
+++ b/crates/orbit-core/src/qa/fingerprint.rs
@@ -1,0 +1,111 @@
+//! Failure fingerprints for qa-sweep task dedupe [ORB-10039].
+//!
+//! A fingerprint identifies *one distinct way a check fails* so the sweep
+//! files one task per broken check, not one per pass (design D4). It is
+//! `sha256(workspace \n check \n normalized-output-head)` truncated to 12 hex
+//! chars and carried on the filed task as a `fp-<hash>` tag; the next sweep
+//! searches open tasks for that tag before filing again.
+//!
+//! Normalization aims for *stability across reruns of the same failure*
+//! without collapsing genuinely different failures: ANSI escapes and the
+//! absolute repo root are scrubbed (they vary per host/terminal), whitespace
+//! runs are collapsed, and only the head of the output is hashed (tails often
+//! carry timing summaries and counters that churn per run).
+
+use sha2::{Digest, Sha256};
+
+/// Lines of normalized output that participate in the fingerprint.
+const FINGERPRINT_HEAD_LINES: usize = 20;
+/// Truncated hex length of the fingerprint hash.
+const FINGERPRINT_HEX_LEN: usize = 12;
+
+/// Tag carried by every qa-sweep-filed task.
+pub const QA_SWEEP_TAG: &str = "qa-sweep";
+
+/// The `fp-<hash>` dedupe tag for a fingerprint.
+pub fn fingerprint_tag(fingerprint: &str) -> String {
+    format!("fp-{fingerprint}")
+}
+
+/// Compute the dedupe fingerprint for one failing check.
+///
+/// `output` is the check's combined stdout+stderr; `exit_summary` is a stable
+/// textual fallback (e.g. `"exit 2"` or `"timeout"`) that keeps silent
+/// failures distinguishable by exit mode.
+pub fn failure_fingerprint(
+    workspace: &str,
+    check: &str,
+    repo_root: &str,
+    output: &str,
+    exit_summary: &str,
+) -> String {
+    let head = normalized_output_head(output, repo_root);
+    let signature = if head.is_empty() {
+        exit_summary.to_string()
+    } else {
+        head
+    };
+    let digest = Sha256::digest(format!("{workspace}\n{check}\n{signature}").as_bytes());
+    let mut hex = format!("{digest:x}");
+    hex.truncate(FINGERPRINT_HEX_LEN);
+    hex
+}
+
+/// Normalize check output down to the stable head used as failure signature.
+pub(crate) fn normalized_output_head(output: &str, repo_root: &str) -> String {
+    strip_ansi(output)
+        .replace(repo_root, "<repo>")
+        .lines()
+        .map(collapse_whitespace)
+        .filter(|line| !line.is_empty())
+        .take(FINGERPRINT_HEAD_LINES)
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+/// Drop ANSI CSI/OSC escape sequences (colors, cursor moves, titles).
+fn strip_ansi(input: &str) -> String {
+    let mut out = String::with_capacity(input.len());
+    let mut chars = input.chars().peekable();
+    while let Some(ch) = chars.next() {
+        if ch != '\u{1b}' {
+            out.push(ch);
+            continue;
+        }
+        match chars.peek() {
+            // CSI: ESC [ ... final byte in 0x40..=0x7e
+            Some('[') => {
+                chars.next();
+                for next in chars.by_ref() {
+                    if ('\u{40}'..='\u{7e}').contains(&next) {
+                        break;
+                    }
+                }
+            }
+            // OSC: ESC ] ... terminated by BEL or ESC \
+            Some(']') => {
+                chars.next();
+                while let Some(next) = chars.next() {
+                    if next == '\u{07}' {
+                        break;
+                    }
+                    if next == '\u{1b}' && chars.peek() == Some(&'\\') {
+                        chars.next();
+                        break;
+                    }
+                }
+            }
+            // Bare two-char escape (ESC c etc.): drop the follower too.
+            Some(_) => {
+                chars.next();
+            }
+            None => {}
+        }
+    }
+    out
+}
+
+/// Trim the line and collapse internal whitespace runs to single spaces.
+fn collapse_whitespace(line: &str) -> String {
+    line.split_whitespace().collect::<Vec<_>>().join(" ")
+}

--- a/crates/orbit-core/src/qa/git.rs
+++ b/crates/orbit-core/src/qa/git.rs
@@ -1,0 +1,89 @@
+//! Read-only git probes for qa-sweep [ORB-10039].
+//!
+//! The sweep validates the **live checkout at its local HEAD** and never
+//! mutates the repo: no fetch, no checkout, no merge. Direct-push workspaces
+//! on this host are the working copies commits land in (local commit → push),
+//! so local HEAD is exactly the state that is live here; a `git fetch` would
+//! not move HEAD or the working tree, i.e. it cannot change what the checks
+//! observe, and background mutation of a live repo is out of scope.
+
+use std::path::Path;
+use std::process::Command;
+
+use orbit_common::types::OrbitError;
+
+/// Run a git command in `repo` and return trimmed stdout.
+fn git(repo: &Path, args: &[&str]) -> Result<String, OrbitError> {
+    let output = Command::new("git")
+        .args(args)
+        .current_dir(repo)
+        .output()
+        .map_err(|error| {
+            OrbitError::Execution(format!(
+                "run git {} in {}: {error}",
+                args[0],
+                repo.display()
+            ))
+        })?;
+    if !output.status.success() {
+        return Err(OrbitError::Execution(format!(
+            "git {} failed in {}: {}",
+            args.join(" "),
+            repo.display(),
+            String::from_utf8_lossy(&output.stderr).trim()
+        )));
+    }
+    Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
+}
+
+/// Current HEAD commit sha.
+pub(crate) fn head_sha(repo: &Path) -> Result<String, OrbitError> {
+    git(repo, &["rev-parse", "HEAD"])
+}
+
+/// Current branch name (`HEAD` when detached).
+pub(crate) fn current_branch(repo: &Path) -> Result<String, OrbitError> {
+    git(repo, &["rev-parse", "--abbrev-ref", "HEAD"])
+}
+
+/// Whether the working tree has uncommitted changes (staged, unstaged, or
+/// untracked). Informational only — the sweep still validates HEAD.
+pub(crate) fn is_dirty(repo: &Path) -> Result<bool, OrbitError> {
+    Ok(!git(repo, &["status", "--porcelain"])?.is_empty())
+}
+
+/// `--oneline` summaries for `from..to`, newest first, capped at `limit`.
+///
+/// `Ok(None)` means the range could not be resolved (e.g. the watermark
+/// commit was rewritten away by a force-push or gc) — the caller treats the
+/// range as unknown and re-validates HEAD.
+pub(crate) fn commit_range(
+    repo: &Path,
+    from: &str,
+    to: &str,
+    limit: usize,
+) -> Result<Option<Vec<String>>, OrbitError> {
+    let range = format!("{from}..{to}");
+    match git(
+        repo,
+        &[
+            "log",
+            "--oneline",
+            "--no-decorate",
+            &format!("--max-count={limit}"),
+            &range,
+        ],
+    ) {
+        Ok(log) => Ok(Some(
+            log.lines()
+                .map(str::trim)
+                .filter(|line| !line.is_empty())
+                .map(ToOwned::to_owned)
+                .collect(),
+        )),
+        // An unresolvable endpoint is expected after history rewrites; every
+        // other failure (not a repo, missing binary) surfaced above.
+        Err(_) if git(repo, &["cat-file", "-e", from]).is_err() => Ok(None),
+        Err(error) => Err(error),
+    }
+}

--- a/crates/orbit-core/src/qa/mod.rs
+++ b/crates/orbit-core/src/qa/mod.rs
@@ -1,0 +1,29 @@
+//! Trailing QA validation for direct-push workspaces [ORB-10039].
+//!
+//! `orbit run qa-sweep` — sibling of `ship-sweep` (design D4, multi-env
+//! operations): direct pushes to `agent-main` stay fast; this sweep validates
+//! them on a lag, files fingerprint-deduped orbit tasks for regressions, and
+//! advances a per-workspace last-validated watermark on green passes.
+//!
+//! - [`config`] — the `[qa]` section of the **global** `~/.orbit/config.toml`.
+//! - [`state`] — per-workspace watermarks + the single-flight pass lock,
+//!   both under the global orbit dir.
+//! - [`fingerprint`] — failure signatures for open-task dedupe.
+//! - [`sweep`] — the pass itself, including run-ledger recording.
+
+pub mod config;
+pub mod fingerprint;
+mod git;
+pub mod state;
+pub mod sweep;
+
+#[cfg(test)]
+mod tests;
+
+pub use config::{QaCheck, QaSweepConfig, QaWorkspaceConfig};
+pub use fingerprint::{QA_SWEEP_TAG, failure_fingerprint, fingerprint_tag};
+pub use state::{QaSweepState, QaWorkspaceWatermark};
+pub use sweep::{
+    QA_SWEEP_JOB, QaCheckReport, QaSweepOptions, QaSweepOutcome, QaWorkspaceReport, run_qa_sweep,
+    run_qa_sweep_at,
+};

--- a/crates/orbit-core/src/qa/state.rs
+++ b/crates/orbit-core/src/qa/state.rs
@@ -1,0 +1,167 @@
+//! qa-sweep host state [ORB-10039]: per-workspace last-validated watermarks
+//! plus the single-flight pass lock.
+//!
+//! Both live in the **global** orbit dir (`~/.orbit/state/`), never in a
+//! workspace `.orbit/` — the sweep is host-level scheduler machinery, and
+//! per-repo state files would be one `orbit init`/task-mutation rewrite away
+//! from being clobbered (see L-0041 / the hook-state watermark pattern).
+//!
+//! Watermark updates take an exclusive `fs2` lock on the state file and
+//! re-read it under the lock, so concurrent writers (a manual run racing the
+//! timer) merge instead of clobbering each other's workspaces.
+
+use std::collections::BTreeMap;
+use std::fs::{self, File, OpenOptions};
+use std::io::{Read, Seek, SeekFrom, Write};
+use std::path::{Path, PathBuf};
+
+use fs2::FileExt;
+use orbit_common::types::OrbitError;
+use serde::{Deserialize, Serialize};
+
+/// On-disk shape of `~/.orbit/state/qa-sweep.json`.
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
+pub struct QaSweepState {
+    /// Workspace name → watermark.
+    #[serde(default)]
+    pub workspaces: BTreeMap<String, QaWorkspaceWatermark>,
+}
+
+/// One workspace's last green validation.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct QaWorkspaceWatermark {
+    /// Commit sha of the last HEAD every configured (non-muted) check passed
+    /// against. Failing sweeps never advance this.
+    pub last_validated_sha: String,
+    /// RFC 3339 timestamp of the validating sweep.
+    pub validated_at: String,
+    /// Ledger run id of the validating sweep, when one was recorded.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub run_id: Option<String>,
+}
+
+/// Path of the watermark state file under a global orbit root.
+pub fn state_path(global_root: &Path) -> PathBuf {
+    global_root.join("state").join("qa-sweep.json")
+}
+
+/// Path of the single-flight pass lock under a global orbit root.
+pub(crate) fn lock_path(global_root: &Path) -> PathBuf {
+    global_root.join("state").join("qa-sweep.lock")
+}
+
+/// Read the current state (missing or unparsable file → empty state; the
+/// sweep then treats every workspace as never-validated, which only means it
+/// re-validates the current HEAD — safe in both directions).
+pub fn load_state(path: &Path) -> QaSweepState {
+    fs::read_to_string(path)
+        .ok()
+        .map(|raw| parse_state(&raw))
+        .unwrap_or_default()
+}
+
+pub(crate) fn parse_state(raw: &str) -> QaSweepState {
+    serde_json::from_str(raw.trim()).unwrap_or_default()
+}
+
+/// Advance one workspace's watermark under an exclusive file lock,
+/// read-modify-writing the file so other workspaces' entries survive.
+pub(crate) fn advance_watermark(
+    path: &Path,
+    workspace: &str,
+    watermark: QaWorkspaceWatermark,
+) -> Result<(), OrbitError> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).map_err(|error| {
+            OrbitError::Io(format!(
+                "create qa-sweep state dir {}: {error}",
+                parent.display()
+            ))
+        })?;
+    }
+
+    let mut file = OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .truncate(false)
+        .open(path)
+        .map_err(|error| {
+            OrbitError::Io(format!(
+                "open qa-sweep state file {}: {error}",
+                path.display()
+            ))
+        })?;
+    file.lock_exclusive().map_err(|error| {
+        OrbitError::Io(format!(
+            "lock qa-sweep state file {}: {error}",
+            path.display()
+        ))
+    })?;
+
+    let result = write_locked(&mut file, path, workspace, watermark);
+    let unlock = fs2::FileExt::unlock(&file).map_err(|error| {
+        OrbitError::Io(format!(
+            "unlock qa-sweep state file {}: {error}",
+            path.display()
+        ))
+    });
+    result.and(unlock)
+}
+
+fn write_locked(
+    file: &mut File,
+    path: &Path,
+    workspace: &str,
+    watermark: QaWorkspaceWatermark,
+) -> Result<(), OrbitError> {
+    let mut raw = String::new();
+    file.read_to_string(&mut raw)
+        .map_err(|error| OrbitError::Io(format!("read {}: {error}", path.display())))?;
+    let mut state = parse_state(&raw);
+    state.workspaces.insert(workspace.to_string(), watermark);
+
+    let encoded = serde_json::to_string_pretty(&state)
+        .map_err(|error| OrbitError::Io(format!("encode qa-sweep state: {error}")))?;
+    file.seek(SeekFrom::Start(0))
+        .and_then(|_| file.set_len(0))
+        .and_then(|_| file.write_all(encoded.as_bytes()))
+        .map_err(|error| OrbitError::Io(format!("write {}: {error}", path.display())))
+}
+
+/// Held for the duration of one sweep pass; the OS releases the lock on drop
+/// or process death, so a crashed sweep never wedges the next one.
+pub(crate) struct PassLock {
+    _file: File,
+}
+
+/// Try to become the single in-flight sweep on this host. `Ok(None)` means
+/// another pass holds the lock.
+pub(crate) fn try_acquire_pass_lock(global_root: &Path) -> Result<Option<PassLock>, OrbitError> {
+    let path = lock_path(global_root);
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).map_err(|error| {
+            OrbitError::Io(format!(
+                "create qa-sweep lock dir {}: {error}",
+                parent.display()
+            ))
+        })?;
+    }
+    let file = OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .truncate(false)
+        .open(&path)
+        .map_err(|error| {
+            OrbitError::Io(format!("open qa-sweep lock {}: {error}", path.display()))
+        })?;
+    match file.try_lock_exclusive() {
+        Ok(()) => Ok(Some(PassLock { _file: file })),
+        Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => Ok(None),
+        Err(error) => Err(OrbitError::Io(format!(
+            "lock qa-sweep lock {}: {error}",
+            path.display()
+        ))),
+    }
+}

--- a/crates/orbit-core/src/qa/sweep.rs
+++ b/crates/orbit-core/src/qa/sweep.rs
@@ -1,0 +1,743 @@
+//! `orbit run qa-sweep` — the trailing QA pass over direct-push workspaces
+//! [ORB-10039], sibling of `orbit run ship-sweep` (design D4).
+//!
+//! Direct pushes to `agent-main` stay fast at write time; this sweep enforces
+//! correctness on a lag. Per configured workspace it diffs the live checkout's
+//! HEAD against a per-workspace last-validated watermark, runs the configured
+//! checks when new commits exist, files fingerprint-deduped orbit tasks for
+//! failures, and advances the watermark only on a fully green pass.
+//!
+//! **Ledger integration.** Every validating pass records a first-class v2 job
+//! run (job id [`QA_SWEEP_JOB`]) in the swept workspace's jobs store — one run
+//! per workspace per pass, one run step per executed check — via the same
+//! store the pipeline worker uses (`insert_run` → `mark_run_running` → per-
+//! check `complete_run_step` → `finalize_run`, plus the `JobRunStarted` /
+//! `JobRunCompleted` events). Checks execute inline in the sweep process
+//! (they are host-trusted shell commands, not agent activities), so no
+//! worker is spawned and no v2 job YAML asset exists; `orbit run history`
+//! intentionally serves run history for asset-less job ids, so
+//! `orbit run history -j qa_sweep` and `orbit run show <run_id>` surface the
+//! sweeps and their per-check steps honestly — the run record is written by
+//! the code that did the work, not a decorative side channel.
+//!
+//! Like ship-sweep, this never bootstraps a `.orbit/` in the scheduler's cwd:
+//! everything resolves from the global registry and global config, and
+//! per-workspace failures are isolated into report rows.
+
+use std::path::Path;
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
+
+use chrono::Utc;
+use orbit_common::types::{
+    JobRunState, JobTargetType, OrbitError, OrbitEvent, Task, TaskStatus, TaskType, Workspace,
+    WorkspaceStatus,
+};
+use orbit_store::JobRunStepParams;
+use serde_json::{Value, json};
+
+use crate::OrbitRuntime;
+use crate::command::task::TaskAddParams;
+use crate::config::RuntimeConfig;
+use crate::workspace_registry;
+
+use super::config::{QaCheck, QaSweepConfig, QaWorkspaceConfig};
+use super::fingerprint::{QA_SWEEP_TAG, failure_fingerprint, fingerprint_tag};
+use super::git;
+use super::state::{QaWorkspaceWatermark, advance_watermark, load_state, state_path};
+
+/// Job id qa-sweep runs are recorded under in each workspace's run ledger.
+pub const QA_SWEEP_JOB: &str = "qa_sweep";
+
+/// Commits listed as evidence per finding (range summaries are capped; the
+/// range endpoints are always recorded in full).
+const EVIDENCE_COMMIT_LIMIT: usize = 20;
+/// Head of the combined check output quoted as evidence in filed tasks.
+const EVIDENCE_OUTPUT_LINES: usize = 40;
+const EVIDENCE_OUTPUT_BYTES: usize = 4000;
+/// Poll interval while waiting on a running check.
+const CHECK_POLL_INTERVAL: Duration = Duration::from_millis(50);
+
+/// Options for one qa-sweep pass.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct QaSweepOptions {
+    /// Report what would be validated without running checks, recording runs,
+    /// filing tasks, or advancing watermarks.
+    pub dry_run: bool,
+}
+
+/// Result of one qa-sweep pass.
+#[derive(Debug, Default)]
+pub struct QaSweepOutcome {
+    /// True when another pass held the host lock and this one exited early.
+    pub lock_busy: bool,
+    /// Per-configured-workspace outcomes, in config order.
+    pub reports: Vec<QaWorkspaceReport>,
+}
+
+/// Per-workspace outcome of one pass.
+#[derive(Debug)]
+pub struct QaWorkspaceReport {
+    /// Configured workspace name.
+    pub workspace: String,
+    /// One of: `validated`, `failed`, `would_validate`, `skipped`, `error`.
+    pub action: &'static str,
+    /// Why, for `skipped` / `error` rows.
+    pub reason: Option<String>,
+    /// Branch the checkout was validated on.
+    pub branch: Option<String>,
+    /// HEAD sha the checks ran against.
+    pub head: Option<String>,
+    /// Watermark sha the diff was computed from (`None` = first validation).
+    pub baseline: Option<String>,
+    /// Commits in `baseline..head`, capped at [`EVIDENCE_COMMIT_LIMIT`].
+    /// `None` when the baseline no longer resolves (history rewrite).
+    pub new_commits: Option<Vec<String>>,
+    /// True when the watermark existed but no longer resolves in the repo.
+    pub watermark_reset: bool,
+    /// Ledger run id, when a run was recorded.
+    pub run_id: Option<String>,
+    /// Per-check outcomes for validating passes.
+    pub checks: Vec<QaCheckReport>,
+}
+
+impl QaWorkspaceReport {
+    fn skipped(workspace: &str, reason: &str) -> Self {
+        Self {
+            reason: Some(reason.to_string()),
+            ..Self::bare(workspace, "skipped")
+        }
+    }
+
+    fn bare(workspace: &str, action: &'static str) -> Self {
+        Self {
+            workspace: workspace.to_string(),
+            action,
+            reason: None,
+            branch: None,
+            head: None,
+            baseline: None,
+            new_commits: None,
+            watermark_reset: false,
+            run_id: None,
+            checks: Vec::new(),
+        }
+    }
+}
+
+/// One check's outcome within a validating pass.
+#[derive(Debug)]
+pub struct QaCheckReport {
+    /// Configured check name.
+    pub name: String,
+    /// One of: `passed`, `failed`, `timeout`, `muted`, `would_run`.
+    pub outcome: &'static str,
+    /// Exit code, when the check ran to completion.
+    pub exit_code: Option<i32>,
+    /// Wall-clock duration of the check.
+    pub duration_ms: u64,
+    /// Failure fingerprint, for failing checks.
+    pub fingerprint: Option<String>,
+    /// Task id filed for this failure, when one was created this pass.
+    pub filed_task: Option<String>,
+    /// Open task id the failure deduped against, when one already existed.
+    pub deduped_task: Option<String>,
+}
+
+/// Run one qa-sweep pass against the default global root (`~/.orbit`).
+pub fn run_qa_sweep(options: QaSweepOptions) -> Result<QaSweepOutcome, OrbitError> {
+    let global_root = workspace_registry::global_orbit_dir()?;
+    run_qa_sweep_at(&global_root, options)
+}
+
+/// Run one qa-sweep pass against an explicit global root (test seam).
+pub fn run_qa_sweep_at(
+    global_root: &Path,
+    options: QaSweepOptions,
+) -> Result<QaSweepOutcome, OrbitError> {
+    // Host-level config only: workspace config.toml files are rewritten by
+    // task-mutation commands and must never own scheduler enablement.
+    let config = RuntimeConfig::load_layered(global_root, global_root)?;
+    let qa = config.qa_sweep().clone();
+
+    // One pass per host at a time; flock releases on process death.
+    let Some(_lock) = super::state::try_acquire_pass_lock(global_root)? else {
+        return Ok(QaSweepOutcome {
+            lock_busy: true,
+            ..QaSweepOutcome::default()
+        });
+    };
+
+    let registry_path = workspace_registry::registry_path_for(global_root);
+    let mut registry = workspace_registry::load_registry_from(&registry_path)?;
+    workspace_registry::validate_workspaces(&mut registry);
+
+    let state = load_state(&state_path(global_root));
+
+    let reports = qa
+        .workspaces
+        .iter()
+        .map(|ws_config| {
+            let Some(workspace) = registry
+                .workspaces
+                .iter()
+                .find(|candidate| candidate.name == ws_config.name)
+            else {
+                // Loud: a configured-but-unregistered workspace is a
+                // misconfiguration, not a benign skip.
+                return QaWorkspaceReport {
+                    reason: Some("workspace not found in the global registry".to_string()),
+                    ..QaWorkspaceReport::bare(&ws_config.name, "error")
+                };
+            };
+            let baseline = state
+                .workspaces
+                .get(&ws_config.name)
+                .map(|watermark| watermark.last_validated_sha.clone());
+            sweep_workspace(global_root, &qa, ws_config, workspace, baseline, options)
+                .unwrap_or_else(|error| QaWorkspaceReport {
+                    reason: Some(error.to_string()),
+                    ..QaWorkspaceReport::bare(&ws_config.name, "error")
+                })
+        })
+        .collect();
+
+    Ok(QaSweepOutcome {
+        lock_busy: false,
+        reports,
+    })
+}
+
+fn sweep_workspace(
+    global_root: &Path,
+    qa: &QaSweepConfig,
+    ws_config: &QaWorkspaceConfig,
+    workspace: &Workspace,
+    baseline: Option<String>,
+    options: QaSweepOptions,
+) -> Result<QaWorkspaceReport, OrbitError> {
+    if workspace.status != WorkspaceStatus::Active || !workspace.orbit_dir.exists() {
+        return Ok(QaWorkspaceReport::skipped(
+            &ws_config.name,
+            "workspace_inactive",
+        ));
+    }
+
+    let repo_root = &workspace.root;
+    let branch = ws_config
+        .branch
+        .clone()
+        .unwrap_or_else(|| workspace.base_branch.clone());
+
+    // The sweep validates the live checkout at local HEAD (see `qa::git`); a
+    // checkout parked on another branch would validate the wrong content and
+    // poison the watermark, so it is skipped until it returns.
+    let current_branch = git::current_branch(repo_root)?;
+    if current_branch != branch {
+        return Ok(QaWorkspaceReport {
+            branch: Some(branch),
+            ..QaWorkspaceReport::skipped(
+                &ws_config.name,
+                &format!("not_on_branch (checkout is on '{current_branch}')"),
+            )
+        });
+    }
+
+    let head = git::head_sha(repo_root)?;
+    if baseline.as_deref() == Some(head.as_str()) {
+        return Ok(QaWorkspaceReport {
+            branch: Some(branch),
+            head: Some(head.clone()),
+            baseline: Some(head),
+            ..QaWorkspaceReport::skipped(&ws_config.name, "no_new_commits")
+        });
+    }
+
+    // `Some(None)` = the watermark commit no longer resolves (history
+    // rewrite): treat the range as unknown and re-validate HEAD.
+    let ranged = baseline
+        .as_deref()
+        .map(|from| git::commit_range(repo_root, from, &head, EVIDENCE_COMMIT_LIMIT))
+        .transpose()?;
+    let watermark_reset = matches!(ranged, Some(None));
+    let new_commits = ranged.flatten();
+
+    let mut report = QaWorkspaceReport {
+        branch: Some(branch.clone()),
+        head: Some(head.clone()),
+        baseline: baseline.clone(),
+        new_commits,
+        watermark_reset,
+        ..QaWorkspaceReport::bare(&ws_config.name, "validated")
+    };
+
+    if options.dry_run {
+        report.action = "would_validate";
+        report.checks = ws_config
+            .checks
+            .iter()
+            .map(|check| check_report(check, if check.mute { "muted" } else { "would_run" }, 0))
+            .collect();
+        return Ok(report);
+    }
+
+    let runtime = OrbitRuntime::from_roots(global_root, &workspace.orbit_dir)?;
+    let dirty = git::is_dirty(repo_root)?;
+    let started_at = Utc::now();
+    let started = Instant::now();
+
+    let input = json!({
+        "trigger": "qa-sweep",
+        "workspace": ws_config.name,
+        "branch": branch,
+        "baseline": baseline,
+        "head": head,
+        "new_commits": report.new_commits.as_ref().map(Vec::len),
+        "watermark_reset": watermark_reset,
+        "dirty_working_tree": dirty,
+        "checks": ws_config.checks.iter().map(|check| json!({
+            "name": check.name,
+            "muted": check.mute,
+        })).collect::<Vec<_>>(),
+    });
+
+    let run = runtime
+        .stores()
+        .jobs()
+        .insert_run(QA_SWEEP_JOB, 1, started_at, Some(input), None)?;
+    runtime
+        .stores()
+        .jobs()
+        .mark_run_running(&run.run_id, started_at, std::process::id())?;
+    runtime.record_event(OrbitEvent::JobRunStarted {
+        job_id: QA_SWEEP_JOB.to_string(),
+        run_id: run.run_id.clone(),
+        attempt: 1,
+    })?;
+    report.run_id = Some(run.run_id.clone());
+
+    let all_green = match run_workspace_checks(&runtime, qa, ws_config, &run.run_id, &mut report) {
+        Ok(all_green) => all_green,
+        Err(error) => {
+            // Don't leave the run record dangling in `running` when the pass
+            // itself broke (spawn failure, store error): finalize it as
+            // failed, best-effort, then surface the error as this
+            // workspace's report row.
+            let _ = runtime.stores().jobs().finalize_run(
+                &run.run_id,
+                JobRunState::Failed,
+                Utc::now(),
+                Some(elapsed_ms(started)),
+            );
+            let _ = runtime.record_event(OrbitEvent::JobRunCompleted {
+                job_id: QA_SWEEP_JOB.to_string(),
+                run_id: run.run_id.clone(),
+                state: JobRunState::Failed.to_string(),
+            });
+            return Err(error);
+        }
+    };
+
+    let final_state = if all_green {
+        JobRunState::Success
+    } else {
+        JobRunState::Failed
+    };
+    let finished_at = Utc::now();
+    runtime.stores().jobs().finalize_run(
+        &run.run_id,
+        final_state,
+        finished_at,
+        Some(elapsed_ms(started)),
+    )?;
+    runtime.record_event(OrbitEvent::JobRunCompleted {
+        job_id: QA_SWEEP_JOB.to_string(),
+        run_id: run.run_id.clone(),
+        state: final_state.to_string(),
+    })?;
+
+    if all_green {
+        // Advance to the sha the checks actually ran against; commits landing
+        // mid-pass are picked up by the next sweep.
+        advance_watermark(
+            &state_path(global_root),
+            &ws_config.name,
+            QaWorkspaceWatermark {
+                last_validated_sha: head,
+                validated_at: finished_at.to_rfc3339(),
+                run_id: Some(run.run_id),
+            },
+        )?;
+    } else {
+        report.action = "failed";
+    }
+
+    Ok(report)
+}
+
+/// Execute the workspace's checks against the checkout, recording one ledger
+/// step per executed check and filing/deduping tasks for failures. Returns
+/// whether every executed (non-muted) check passed.
+fn run_workspace_checks(
+    runtime: &OrbitRuntime,
+    qa: &QaSweepConfig,
+    ws_config: &QaWorkspaceConfig,
+    run_id: &str,
+    report: &mut QaWorkspaceReport,
+) -> Result<bool, OrbitError> {
+    let repo_root = runtime.paths().repo_root.clone();
+    let mut all_green = true;
+    let mut step_index = 0usize;
+    for check in &ws_config.checks {
+        if check.mute {
+            report.checks.push(check_report(check, "muted", 0));
+            continue;
+        }
+
+        let step_started_at = Utc::now();
+        let execution = execute_check(&repo_root, &check.command, check.timeout)?;
+        let step_finished_at = Utc::now();
+
+        let mut entry = check_report(
+            check,
+            match (execution.timed_out, execution.exit_code) {
+                (true, _) => "timeout",
+                (false, Some(0)) => "passed",
+                (false, _) => "failed",
+            },
+            execution.duration_ms,
+        );
+        entry.exit_code = execution.exit_code;
+        let passed = entry.outcome == "passed";
+        all_green &= passed;
+
+        if !passed {
+            let finding = handle_failure(runtime, qa, ws_config, check, report, &execution)?;
+            entry.fingerprint = Some(finding.fingerprint);
+            entry.filed_task = finding.filed_task;
+            entry.deduped_task = finding.deduped_task;
+        }
+
+        runtime.stores().jobs().complete_run_step(
+            run_id,
+            &JobRunStepParams {
+                step_index,
+                target_type: JobTargetType::Job,
+                target_id: format!("{QA_SWEEP_JOB}:{}", check.name),
+                started_at: step_started_at,
+                finished_at: step_finished_at,
+                duration_ms: Some(execution.duration_ms),
+                exit_code: execution.exit_code,
+                agent_response_json: Some(step_summary_json(&entry)),
+                state: if passed {
+                    JobRunState::Success
+                } else {
+                    JobRunState::Failed
+                },
+                error_code: None,
+                error_message: (!passed).then(|| {
+                    format!(
+                        "check '{}' {}: {}",
+                        check.name,
+                        entry.outcome,
+                        evidence_excerpt(&execution.output)
+                    )
+                }),
+            },
+        )?;
+        step_index += 1;
+        report.checks.push(entry);
+    }
+    Ok(all_green)
+}
+
+fn elapsed_ms(started: Instant) -> u64 {
+    started.elapsed().as_millis().min(u64::MAX as u128) as u64
+}
+
+fn check_report(check: &QaCheck, outcome: &'static str, duration_ms: u64) -> QaCheckReport {
+    QaCheckReport {
+        name: check.name.clone(),
+        outcome,
+        exit_code: None,
+        duration_ms,
+        fingerprint: None,
+        filed_task: None,
+        deduped_task: None,
+    }
+}
+
+fn step_summary_json(entry: &QaCheckReport) -> Value {
+    json!({
+        "check": entry.name,
+        "outcome": entry.outcome,
+        "fingerprint": entry.fingerprint,
+        "filed_task": entry.filed_task,
+        "deduped_task": entry.deduped_task,
+    })
+}
+
+struct FailureFinding {
+    fingerprint: String,
+    filed_task: Option<String>,
+    deduped_task: Option<String>,
+}
+
+/// Fingerprint a failing check, dedupe against open qa-sweep tasks carrying
+/// the same fingerprint tag, and file a task when none exists.
+fn handle_failure(
+    runtime: &OrbitRuntime,
+    qa: &QaSweepConfig,
+    ws_config: &QaWorkspaceConfig,
+    check: &QaCheck,
+    report: &QaWorkspaceReport,
+    execution: &CheckExecution,
+) -> Result<FailureFinding, OrbitError> {
+    let exit_summary = if execution.timed_out {
+        format!("timeout after {}s", check.timeout.as_secs())
+    } else {
+        match execution.exit_code {
+            Some(code) => format!("exit {code}"),
+            None => "killed by signal".to_string(),
+        }
+    };
+    let repo_root = runtime.paths().repo_root.display().to_string();
+    let fingerprint = failure_fingerprint(
+        &ws_config.name,
+        &check.name,
+        &repo_root,
+        &execution.output,
+        &exit_summary,
+    );
+    let tags = vec![QA_SWEEP_TAG.to_string(), fingerprint_tag(&fingerprint)];
+
+    let open_task = runtime
+        .list_tasks_by_tags(&tags)?
+        .into_iter()
+        .find(task_is_open);
+    if let Some(task) = open_task {
+        return Ok(FailureFinding {
+            fingerprint,
+            filed_task: None,
+            deduped_task: Some(task.id),
+        });
+    }
+
+    let task = runtime.add_task(TaskAddParams {
+        title: format!(
+            "qa-sweep: check '{}' failing in {}",
+            check.name, ws_config.name
+        ),
+        description: failure_description(ws_config, check, report, execution, &exit_summary),
+        acceptance_criteria: vec![format!(
+            "`{}` exits 0 from the {} workspace root on `{}`",
+            check.command,
+            ws_config.name,
+            report.branch.as_deref().unwrap_or("agent-main"),
+        )],
+        tags,
+        priority: check.priority.unwrap_or(qa.default_priority),
+        task_type: Some(TaskType::Bug),
+        status: Some(qa.task_status),
+        system_created: true,
+        ..TaskAddParams::default()
+    })?;
+
+    Ok(FailureFinding {
+        fingerprint,
+        filed_task: Some(task.id),
+        deduped_task: None,
+    })
+}
+
+fn task_is_open(task: &Task) -> bool {
+    !matches!(
+        task.status,
+        TaskStatus::Done | TaskStatus::Archived | TaskStatus::Rejected
+    )
+}
+
+fn failure_description(
+    ws_config: &QaWorkspaceConfig,
+    check: &QaCheck,
+    report: &QaWorkspaceReport,
+    execution: &CheckExecution,
+    exit_summary: &str,
+) -> String {
+    let range = match (&report.baseline, report.watermark_reset) {
+        (Some(baseline), false) => format!(
+            "{}..{} ({} new commit(s) shown below)",
+            baseline,
+            report.head.as_deref().unwrap_or("HEAD"),
+            report.new_commits.as_ref().map(Vec::len).unwrap_or(0),
+        ),
+        (Some(baseline), true) => format!(
+            "unknown — last-validated commit {baseline} no longer resolves (history rewrite); validated HEAD {}",
+            report.head.as_deref().unwrap_or("HEAD"),
+        ),
+        (None, _) => format!(
+            "first validation of this workspace; validated HEAD {}",
+            report.head.as_deref().unwrap_or("HEAD"),
+        ),
+    };
+    let commits = report
+        .new_commits
+        .as_ref()
+        .filter(|commits| !commits.is_empty())
+        .map(|commits| format!("\nCommits since last green:\n{}\n", commits.join("\n")))
+        .unwrap_or_default();
+
+    format!(
+        "Automated qa-sweep finding.\n\n\
+         - workspace: {workspace}\n\
+         - check: {check_name} (`sh -c {command}`)\n\
+         - branch: {branch}\n\
+         - result: {exit_summary}\n\
+         - commit range since last green: {range}\n\
+         - ledger run: {run} (`orbit run show <run_id>` in the workspace)\n\
+         {commits}\n\
+         Output (head):\n```text\n{output}\n```\n",
+        workspace = ws_config.name,
+        check_name = check.name,
+        command = check.command,
+        branch = report.branch.as_deref().unwrap_or("agent-main"),
+        run = report.run_id.as_deref().unwrap_or("not recorded"),
+        output = evidence_excerpt(&execution.output),
+    )
+}
+
+/// Head of the combined output, bounded in lines and bytes.
+fn evidence_excerpt(output: &str) -> String {
+    let mut excerpt = output
+        .lines()
+        .take(EVIDENCE_OUTPUT_LINES)
+        .collect::<Vec<_>>()
+        .join("\n");
+    if excerpt.len() > EVIDENCE_OUTPUT_BYTES {
+        let mut cut = EVIDENCE_OUTPUT_BYTES;
+        while !excerpt.is_char_boundary(cut) {
+            cut -= 1;
+        }
+        excerpt.truncate(cut);
+    }
+    if excerpt.trim().is_empty() {
+        "(no output)".to_string()
+    } else {
+        excerpt
+    }
+}
+
+pub(super) struct CheckExecution {
+    pub(super) exit_code: Option<i32>,
+    pub(super) timed_out: bool,
+    pub(super) output: String,
+    pub(super) duration_ms: u64,
+}
+
+/// Run one check via `sh -c` from the workspace root, killing it once the
+/// configured timeout elapses. stdout and stderr are captured off-thread (so
+/// a chatty check cannot deadlock on a full pipe) and concatenated
+/// stdout-then-stderr for evidence and fingerprinting.
+///
+/// On Unix the check runs in its own session/process group and a timeout
+/// kills the whole group — otherwise grandchildren (a `make` fanning out to
+/// compilers, a shell forking `sleep`) would survive the kill and keep the
+/// output pipes open, wedging the sweep until they exit on their own.
+pub(super) fn execute_check(
+    repo_root: &Path,
+    command: &str,
+    timeout: Duration,
+) -> Result<CheckExecution, OrbitError> {
+    let started = Instant::now();
+    let mut builder = Command::new("sh");
+    builder
+        .arg("-c")
+        .arg(command)
+        .current_dir(repo_root)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    #[cfg(unix)]
+    unsafe {
+        use std::os::unix::process::CommandExt;
+        builder.pre_exec(|| {
+            if libc::setsid() == -1 {
+                return Err(std::io::Error::last_os_error());
+            }
+            Ok(())
+        });
+    }
+    let mut child = builder.spawn().map_err(|error| {
+        OrbitError::Execution(format!("spawn check `sh -c {command}`: {error}"))
+    })?;
+
+    let stdout = drain_off_thread(child.stdout.take());
+    let stderr = drain_off_thread(child.stderr.take());
+
+    let mut timed_out = false;
+    let status = loop {
+        match child.try_wait() {
+            Ok(Some(status)) => break Some(status),
+            Ok(None) => {
+                if started.elapsed() >= timeout {
+                    timed_out = true;
+                    kill_check_group(&mut child);
+                    break child.wait().ok();
+                }
+                std::thread::sleep(CHECK_POLL_INTERVAL);
+            }
+            Err(error) => {
+                return Err(OrbitError::Execution(format!(
+                    "wait on check `{command}`: {error}"
+                )));
+            }
+        }
+    };
+
+    let mut output = stdout.join().unwrap_or_default();
+    let err_output = stderr.join().unwrap_or_default();
+    if !err_output.is_empty() {
+        if !output.is_empty() && !output.ends_with('\n') {
+            output.push('\n');
+        }
+        output.push_str(&err_output);
+    }
+
+    Ok(CheckExecution {
+        exit_code: if timed_out {
+            None
+        } else {
+            status.and_then(|status| status.code())
+        },
+        timed_out,
+        output,
+        duration_ms: started.elapsed().as_millis().min(u64::MAX as u128) as u64,
+    })
+}
+
+/// Kill a timed-out check together with its process group (Unix) so orphaned
+/// grandchildren cannot hold the captured pipes open.
+fn kill_check_group(child: &mut std::process::Child) {
+    #[cfg(unix)]
+    {
+        let pid = child.id() as libc::pid_t;
+        // The check was made its own session leader in `pre_exec`, so its pid
+        // is the process-group id; negative pid targets the whole group.
+        unsafe {
+            libc::kill(-pid, libc::SIGKILL);
+        }
+    }
+    let _ = child.kill();
+}
+
+fn drain_off_thread<R: std::io::Read + Send + 'static>(
+    source: Option<R>,
+) -> std::thread::JoinHandle<String> {
+    std::thread::spawn(move || {
+        let mut buffer = Vec::new();
+        if let Some(mut source) = source {
+            let _ = std::io::Read::read_to_end(&mut source, &mut buffer);
+        }
+        String::from_utf8_lossy(&buffer).into_owned()
+    })
+}

--- a/crates/orbit-core/src/qa/tests/config.rs
+++ b/crates/orbit-core/src/qa/tests/config.rs
@@ -1,0 +1,151 @@
+//! `[qa]` config validation tests [ORB-10039]: the section is fail-closed —
+//! a typo'd priority/status or an empty check list must be a config error,
+//! never a sweep that silently validates nothing.
+
+use std::time::Duration;
+
+use orbit_common::types::{OrbitError, TaskPriority, TaskStatus};
+
+use crate::config::RuntimeConfig;
+use crate::qa::QaSweepConfig;
+
+/// Parse a config.toml document through the exact production pipeline and
+/// return its resolved `[qa]` section.
+fn qa_from_toml(raw: &str) -> Result<QaSweepConfig, OrbitError> {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("config.toml");
+    std::fs::write(&path, raw).expect("write config");
+    let config = RuntimeConfig::load_layered(dir.path(), dir.path())?;
+    Ok(config.qa_sweep().clone())
+}
+
+const FULL: &str = r#"
+[qa]
+default_priority = "high"
+task_status = "proposed"
+
+[[qa.workspace]]
+name = "polaris"
+branch = "agent-main"
+
+[[qa.workspace.check]]
+name = "frontmatter"
+command = "python3 scripts/check_frontmatter.py"
+
+[[qa.workspace.check]]
+name = "lint"
+command = "make lint"
+mute = true
+priority = "critical"
+timeout_minutes = 5
+
+[[qa.workspace]]
+name = "bridge"
+
+[[qa.workspace.check]]
+name = "tests"
+command = "pytest -q"
+"#;
+
+#[test]
+fn full_section_parses_with_overrides_and_defaults() {
+    let qa = qa_from_toml(FULL).expect("valid config");
+    assert_eq!(qa.default_priority, TaskPriority::High);
+    assert_eq!(qa.task_status, TaskStatus::Proposed);
+    assert_eq!(qa.workspaces.len(), 2);
+
+    let polaris = qa.workspace("polaris").expect("polaris entry");
+    assert_eq!(polaris.branch.as_deref(), Some("agent-main"));
+    assert_eq!(polaris.checks.len(), 2);
+    let frontmatter = &polaris.checks[0];
+    assert!(!frontmatter.mute);
+    assert_eq!(frontmatter.priority, None);
+    assert_eq!(frontmatter.timeout, Duration::from_secs(30 * 60));
+    let lint = &polaris.checks[1];
+    assert!(lint.mute);
+    assert_eq!(lint.priority, Some(TaskPriority::Critical));
+    assert_eq!(lint.timeout, Duration::from_secs(5 * 60));
+
+    // Branch defaults to None (resolved from the registry at sweep time).
+    assert_eq!(qa.workspace("bridge").expect("bridge entry").branch, None);
+}
+
+#[test]
+fn absent_section_resolves_to_empty_defaults() {
+    let qa = qa_from_toml("[workflow]\nbase_branch = \"agent-main\"\n").expect("valid config");
+    assert_eq!(qa, QaSweepConfig::default());
+    assert!(qa.workspaces.is_empty());
+    assert_eq!(qa.default_priority, TaskPriority::Medium);
+    // Backlog by default: design D4 wants the loop to close without a human
+    // courier (ship-sweep can dispatch the fix).
+    assert_eq!(qa.task_status, TaskStatus::Backlog);
+}
+
+fn assert_invalid(raw: &str, needle: &str) {
+    match qa_from_toml(raw) {
+        Err(OrbitError::InvalidInput(message)) => assert!(
+            message.contains(needle),
+            "expected error containing '{needle}', got: {message}"
+        ),
+        other => panic!("expected InvalidInput containing '{needle}', got {other:?}"),
+    }
+}
+
+#[test]
+fn invalid_priority_is_rejected() {
+    assert_invalid(
+        "[qa]\ndefault_priority = \"urgent\"\n",
+        "qa.default_priority",
+    );
+}
+
+#[test]
+fn invalid_task_status_is_rejected() {
+    assert_invalid("[qa]\ntask_status = \"done\"\n", "qa.task_status");
+}
+
+#[test]
+fn workspace_without_checks_is_rejected() {
+    assert_invalid(
+        "[[qa.workspace]]\nname = \"polaris\"\n",
+        "at least one [[qa.workspace.check]]",
+    );
+}
+
+#[test]
+fn check_without_command_is_rejected() {
+    assert_invalid(
+        "[[qa.workspace]]\nname = \"polaris\"\n[[qa.workspace.check]]\nname = \"lint\"\n",
+        "command must be set",
+    );
+}
+
+#[test]
+fn duplicate_check_names_are_rejected() {
+    assert_invalid(
+        "[[qa.workspace]]\nname = \"polaris\"\n\
+         [[qa.workspace.check]]\nname = \"lint\"\ncommand = \"a\"\n\
+         [[qa.workspace.check]]\nname = \"lint\"\ncommand = \"b\"\n",
+        "more than once",
+    );
+}
+
+#[test]
+fn duplicate_workspaces_are_rejected() {
+    assert_invalid(
+        "[[qa.workspace]]\nname = \"polaris\"\n\
+         [[qa.workspace.check]]\nname = \"lint\"\ncommand = \"a\"\n\
+         [[qa.workspace]]\nname = \"polaris\"\n\
+         [[qa.workspace.check]]\nname = \"lint\"\ncommand = \"a\"\n",
+        "more than once",
+    );
+}
+
+#[test]
+fn zero_timeout_is_rejected() {
+    assert_invalid(
+        "[[qa.workspace]]\nname = \"polaris\"\n\
+         [[qa.workspace.check]]\nname = \"lint\"\ncommand = \"a\"\ntimeout_minutes = 0\n",
+        "timeout_minutes",
+    );
+}

--- a/crates/orbit-core/src/qa/tests/fingerprint.rs
+++ b/crates/orbit-core/src/qa/tests/fingerprint.rs
@@ -1,0 +1,98 @@
+//! Fingerprint stability tests [ORB-10039]: the same failure must hash the
+//! same across reruns (ANSI, whitespace, host paths, tail churn scrubbed),
+//! while distinct failures stay distinct.
+
+use crate::qa::fingerprint::{failure_fingerprint, fingerprint_tag, normalized_output_head};
+
+const WS: &str = "polaris";
+const CHECK: &str = "lint";
+const ROOT: &str = "/home/user/workspace/polaris";
+
+#[test]
+fn identical_failures_share_a_fingerprint() {
+    let output = "error: broken frontmatter in docs/a.md\nexpected key 'title'";
+    let first = failure_fingerprint(WS, CHECK, ROOT, output, "exit 1");
+    let second = failure_fingerprint(WS, CHECK, ROOT, output, "exit 1");
+    assert_eq!(first, second);
+    assert_eq!(first.len(), 12);
+    assert!(first.chars().all(|ch| ch.is_ascii_hexdigit()));
+}
+
+#[test]
+fn workspace_check_and_output_all_discriminate() {
+    let output = "error: broken";
+    let base = failure_fingerprint(WS, CHECK, ROOT, output, "exit 1");
+    assert_ne!(
+        base,
+        failure_fingerprint("bridge", CHECK, ROOT, output, "exit 1")
+    );
+    assert_ne!(
+        base,
+        failure_fingerprint(WS, "tests", ROOT, output, "exit 1")
+    );
+    assert_ne!(
+        base,
+        failure_fingerprint(WS, CHECK, ROOT, "error: different", "exit 1")
+    );
+}
+
+#[test]
+fn ansi_whitespace_and_repo_root_are_normalized_away() {
+    let plain = format!("error in {ROOT}/docs/a.md\nline two");
+    let noisy = format!("\u{1b}[31merror   in\t{ROOT}/docs/a.md\u{1b}[0m\r\n\n   line   two   \n");
+    assert_eq!(
+        failure_fingerprint(WS, CHECK, ROOT, &plain, "exit 1"),
+        failure_fingerprint(WS, CHECK, ROOT, &noisy, "exit 1"),
+    );
+    // The other direction: a different repo root must not change the hash.
+    assert_eq!(
+        failure_fingerprint(WS, CHECK, ROOT, &plain, "exit 1"),
+        failure_fingerprint(
+            WS,
+            CHECK,
+            "/srv/polaris",
+            &plain.replace(ROOT, "/srv/polaris"),
+            "exit 1"
+        ),
+    );
+}
+
+#[test]
+fn tail_churn_beyond_the_head_window_is_ignored() {
+    let head: String = (0..25).map(|i| format!("error line {i}\n")).collect();
+    let with_timing = format!("{head}finished in 12.3s\n");
+    let with_other_timing = format!("{head}finished in 45.6s\n");
+    assert_eq!(
+        failure_fingerprint(WS, CHECK, ROOT, &with_timing, "exit 1"),
+        failure_fingerprint(WS, CHECK, ROOT, &with_other_timing, "exit 1"),
+    );
+}
+
+#[test]
+fn silent_failures_fall_back_to_the_exit_summary() {
+    let exit_1 = failure_fingerprint(WS, CHECK, ROOT, "", "exit 1");
+    let exit_2 = failure_fingerprint(WS, CHECK, ROOT, "", "exit 2");
+    let timeout = failure_fingerprint(WS, CHECK, ROOT, "", "timeout after 1800s");
+    assert_ne!(exit_1, exit_2);
+    assert_ne!(exit_1, timeout);
+    // Deterministic: same silent failure, same hash.
+    assert_eq!(
+        exit_1,
+        failure_fingerprint(WS, CHECK, ROOT, "\n  \n", "exit 1")
+    );
+}
+
+#[test]
+fn normalized_head_drops_blank_lines_and_caps_at_twenty() {
+    let output = "  a  \n\n\nb\tc\n".to_string() + &"x\n".repeat(40);
+    let head = normalized_output_head(&output, ROOT);
+    let lines: Vec<&str> = head.lines().collect();
+    assert_eq!(lines[0], "a");
+    assert_eq!(lines[1], "b c");
+    assert_eq!(lines.len(), 20);
+}
+
+#[test]
+fn tag_shape_is_stable() {
+    assert_eq!(fingerprint_tag("abc123def456"), "fp-abc123def456");
+}

--- a/crates/orbit-core/src/qa/tests/mod.rs
+++ b/crates/orbit-core/src/qa/tests/mod.rs
@@ -1,0 +1,4 @@
+mod config;
+mod fingerprint;
+mod state;
+mod sweep;

--- a/crates/orbit-core/src/qa/tests/state.rs
+++ b/crates/orbit-core/src/qa/tests/state.rs
@@ -1,0 +1,111 @@
+//! Watermark state tests [ORB-10039]: locked read-modify-write updates that
+//! preserve other workspaces' entries, plus lenient loading (missing or
+//! corrupt state only means "re-validate current HEAD").
+
+use crate::qa::state::{
+    QaWorkspaceWatermark, advance_watermark, load_state, parse_state, state_path,
+    try_acquire_pass_lock,
+};
+
+fn watermark(sha: &str) -> QaWorkspaceWatermark {
+    QaWorkspaceWatermark {
+        last_validated_sha: sha.to_string(),
+        validated_at: "2026-07-06T00:00:00Z".to_string(),
+        run_id: Some("run-1".to_string()),
+    }
+}
+
+#[test]
+fn missing_state_file_loads_empty() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let state = load_state(&state_path(dir.path()));
+    assert!(state.workspaces.is_empty());
+}
+
+#[test]
+fn corrupt_state_file_loads_empty() {
+    assert!(parse_state("{not json").workspaces.is_empty());
+    assert!(parse_state("").workspaces.is_empty());
+}
+
+#[test]
+fn advance_creates_file_and_roundtrips() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = state_path(dir.path());
+
+    advance_watermark(&path, "polaris", watermark("aaa111")).expect("advance");
+    let state = load_state(&path);
+    assert_eq!(
+        state
+            .workspaces
+            .get("polaris")
+            .map(|w| w.last_validated_sha.as_str()),
+        Some("aaa111")
+    );
+    assert_eq!(
+        state
+            .workspaces
+            .get("polaris")
+            .and_then(|w| w.run_id.as_deref()),
+        Some("run-1")
+    );
+}
+
+#[test]
+fn advance_preserves_other_workspaces_and_overwrites_own_entry() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = state_path(dir.path());
+
+    advance_watermark(&path, "polaris", watermark("aaa111")).expect("advance polaris");
+    advance_watermark(&path, "bridge", watermark("bbb222")).expect("advance bridge");
+    advance_watermark(&path, "polaris", watermark("ccc333")).expect("re-advance polaris");
+
+    let state = load_state(&path);
+    assert_eq!(state.workspaces.len(), 2);
+    assert_eq!(
+        state
+            .workspaces
+            .get("polaris")
+            .map(|w| w.last_validated_sha.as_str()),
+        Some("ccc333")
+    );
+    assert_eq!(
+        state
+            .workspaces
+            .get("bridge")
+            .map(|w| w.last_validated_sha.as_str()),
+        Some("bbb222")
+    );
+}
+
+#[test]
+fn shorter_rewrites_do_not_leave_trailing_garbage() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = state_path(dir.path());
+
+    advance_watermark(&path, "polaris", watermark(&"long".repeat(50))).expect("long entry");
+    advance_watermark(&path, "polaris", watermark("s")).expect("short entry");
+
+    // A truncation bug would leave trailing JSON that fails to parse.
+    let raw = std::fs::read_to_string(&path).expect("read state");
+    let state: crate::qa::QaSweepState = serde_json::from_str(&raw).expect("clean json");
+    assert_eq!(
+        state
+            .workspaces
+            .get("polaris")
+            .map(|w| w.last_validated_sha.as_str()),
+        Some("s")
+    );
+}
+
+#[test]
+fn pass_lock_is_exclusive_per_host() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let first = try_acquire_pass_lock(dir.path()).expect("acquire");
+    assert!(first.is_some());
+    // Same-process re-acquisition behavior varies by platform for flock, so
+    // only assert release-on-drop: after dropping the guard the lock is free.
+    drop(first);
+    let second = try_acquire_pass_lock(dir.path()).expect("re-acquire");
+    assert!(second.is_some());
+}

--- a/crates/orbit-core/src/qa/tests/sweep.rs
+++ b/crates/orbit-core/src/qa/tests/sweep.rs
@@ -1,0 +1,439 @@
+//! qa-sweep pass tests [ORB-10039]: end-to-end over a seeded global root and
+//! a real temp git repo — watermark advance/hold, ledger run recording,
+//! fingerprint dedupe, mute handling, branch guard, dry-run inertness.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::time::Duration;
+
+use chrono::Utc;
+use orbit_common::types::{
+    JobRunState, TaskPriority, TaskStatus, Workspace, WorkspaceRegistry, WorkspaceStatus,
+};
+use tempfile::TempDir;
+
+use crate::OrbitRuntime;
+use crate::qa::state::{load_state, state_path};
+use crate::qa::sweep::execute_check;
+use crate::qa::{QA_SWEEP_JOB, QA_SWEEP_TAG, QaSweepOptions, run_qa_sweep_at};
+use crate::workspace_registry;
+
+const WS_NAME: &str = "polaris";
+
+struct Fixture {
+    _tmp: TempDir,
+    global: PathBuf,
+    repo: PathBuf,
+    orbit_dir: PathBuf,
+}
+
+impl Fixture {
+    /// Sweep once (non-dry) and return the single workspace report.
+    fn sweep(&self) -> crate::qa::QaWorkspaceReport {
+        self.sweep_with(QaSweepOptions::default())
+    }
+
+    fn sweep_with(&self, options: QaSweepOptions) -> crate::qa::QaWorkspaceReport {
+        let mut outcome = run_qa_sweep_at(&self.global, options).expect("sweep pass");
+        assert!(!outcome.lock_busy, "pass lock unexpectedly busy");
+        assert_eq!(outcome.reports.len(), 1, "one configured workspace");
+        outcome.reports.remove(0)
+    }
+
+    fn runtime(&self) -> OrbitRuntime {
+        OrbitRuntime::from_roots(&self.global, &self.orbit_dir).expect("open workspace runtime")
+    }
+
+    fn watermark(&self) -> Option<String> {
+        load_state(&state_path(&self.global))
+            .workspaces
+            .get(WS_NAME)
+            .map(|watermark| watermark.last_validated_sha.clone())
+    }
+
+    fn head(&self) -> String {
+        git_stdout(&self.repo, &["rev-parse", "HEAD"])
+    }
+
+    fn commit(&self, name: &str) {
+        std::fs::write(self.repo.join(name), name).expect("write file");
+        git(&self.repo, &["add", "."]);
+        git(&self.repo, &["commit", "-m", &format!("add {name}")]);
+    }
+}
+
+/// Seed a global root + registered git workspace whose `[qa]` section carries
+/// the given `[[qa.workspace.check]]` entries (TOML snippet).
+fn fixture(checks_toml: &str) -> Fixture {
+    fixture_with_qa(&format!(
+        "[qa]\n\n[[qa.workspace]]\nname = \"{WS_NAME}\"\n{checks_toml}"
+    ))
+}
+
+fn fixture_with_qa(qa_toml: &str) -> Fixture {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let global = tmp.path().join("global");
+    let repo = tmp.path().join(WS_NAME);
+    let orbit_dir = repo.join(".orbit");
+    std::fs::create_dir_all(&global).expect("global root");
+    std::fs::create_dir_all(&orbit_dir).expect("workspace orbit dir");
+
+    std::fs::write(global.join("config.toml"), qa_toml).expect("write global config");
+
+    git(&repo, &["init", "--quiet"]);
+    git(&repo, &["checkout", "-q", "-b", "agent-main"]);
+    std::fs::write(repo.join("README.md"), "seed").expect("seed file");
+    git(&repo, &["add", "."]);
+    git(&repo, &["commit", "-q", "-m", "seed"]);
+
+    let mut registry = WorkspaceRegistry::default();
+    registry.workspaces.push(Workspace {
+        id: "ws-qa-test".to_string(),
+        name: WS_NAME.to_string(),
+        root: repo.clone(),
+        orbit_dir: orbit_dir.clone(),
+        git_remote: None,
+        base_branch: "agent-main".to_string(),
+        status: WorkspaceStatus::Active,
+        created_at: Utc::now(),
+        updated_at: Utc::now(),
+    });
+    workspace_registry::save_registry_to(
+        &registry,
+        &workspace_registry::registry_path_for(&global),
+    )
+    .expect("save registry");
+
+    Fixture {
+        _tmp: tmp,
+        global,
+        repo,
+        orbit_dir,
+    }
+}
+
+fn git(repo: &Path, args: &[&str]) {
+    let status = git_command(repo, args).status().expect("run git");
+    assert!(status.success(), "git {args:?} failed");
+}
+
+fn git_stdout(repo: &Path, args: &[&str]) -> String {
+    let output = git_command(repo, args).output().expect("run git");
+    assert!(output.status.success(), "git {args:?} failed");
+    String::from_utf8_lossy(&output.stdout).trim().to_string()
+}
+
+fn git_command(repo: &Path, args: &[&str]) -> Command {
+    std::fs::create_dir_all(repo).expect("repo dir");
+    let mut command = Command::new("git");
+    command
+        .args(args)
+        .current_dir(repo)
+        .env("GIT_AUTHOR_NAME", "qa")
+        .env("GIT_AUTHOR_EMAIL", "qa@test")
+        .env("GIT_COMMITTER_NAME", "qa")
+        .env("GIT_COMMITTER_EMAIL", "qa@test")
+        .env("GIT_CONFIG_GLOBAL", "/dev/null")
+        .env("GIT_CONFIG_SYSTEM", "/dev/null");
+    command
+}
+
+const PASSING_CHECK: &str = "[[qa.workspace.check]]\nname = \"ok\"\ncommand = \"echo fine\"\n";
+const FAILING_CHECK: &str =
+    "[[qa.workspace.check]]\nname = \"broken\"\ncommand = \"echo boom >&2; exit 3\"\n";
+
+// ---- green / skip / watermark ---------------------------------------------
+
+#[test]
+fn green_pass_records_ledger_run_and_advances_watermark() {
+    let fixture = fixture(PASSING_CHECK);
+    let head = fixture.head();
+
+    let report = fixture.sweep();
+    assert_eq!(report.action, "validated", "reason: {:?}", report.reason);
+    assert_eq!(report.baseline, None, "first validation has no baseline");
+    assert_eq!(report.head.as_deref(), Some(head.as_str()));
+    assert_eq!(report.checks.len(), 1);
+    assert_eq!(report.checks[0].outcome, "passed");
+    assert_eq!(report.checks[0].exit_code, Some(0));
+
+    // Watermark advanced to the validated HEAD.
+    assert_eq!(fixture.watermark().as_deref(), Some(head.as_str()));
+
+    // The pass is a first-class ledger run with one step per executed check.
+    let runtime = fixture.runtime();
+    let runs = runtime.job_history(QA_SWEEP_JOB).expect("qa_sweep history");
+    assert_eq!(runs.len(), 1);
+    assert_eq!(runs[0].state, JobRunState::Success);
+    assert_eq!(runs[0].run_id, report.run_id.expect("run id reported"));
+    assert_eq!(runs[0].steps.len(), 1);
+    assert_eq!(runs[0].steps[0].state, JobRunState::Success);
+}
+
+#[test]
+fn unchanged_head_is_skipped_without_a_run() {
+    let fixture = fixture(PASSING_CHECK);
+    assert_eq!(fixture.sweep().action, "validated");
+
+    let report = fixture.sweep();
+    assert_eq!(report.action, "skipped");
+    assert_eq!(report.reason.as_deref(), Some("no_new_commits"));
+    assert!(report.run_id.is_none());
+
+    let runtime = fixture.runtime();
+    assert_eq!(
+        runtime.job_history(QA_SWEEP_JOB).expect("history").len(),
+        1,
+        "skip records no second run"
+    );
+}
+
+#[test]
+fn new_commits_are_revalidated_with_the_range_reported() {
+    let fixture = fixture(PASSING_CHECK);
+    assert_eq!(fixture.sweep().action, "validated");
+    let baseline = fixture.watermark().expect("baseline");
+
+    fixture.commit("one.txt");
+    fixture.commit("two.txt");
+    let head = fixture.head();
+
+    let report = fixture.sweep();
+    assert_eq!(report.action, "validated");
+    assert_eq!(report.baseline.as_deref(), Some(baseline.as_str()));
+    assert_eq!(report.new_commits.as_ref().map(Vec::len), Some(2));
+    assert_eq!(fixture.watermark().as_deref(), Some(head.as_str()));
+}
+
+// ---- failures: task filing, dedupe, watermark hold -------------------------
+
+#[test]
+fn failing_check_files_a_tagged_task_and_holds_the_watermark() {
+    let fixture = fixture(FAILING_CHECK);
+    let report = fixture.sweep();
+
+    assert_eq!(report.action, "failed");
+    assert_eq!(report.checks[0].outcome, "failed");
+    assert_eq!(report.checks[0].exit_code, Some(3));
+    let fingerprint = report.checks[0].fingerprint.clone().expect("fingerprint");
+    let task_id = report.checks[0].filed_task.clone().expect("task filed");
+    assert!(report.checks[0].deduped_task.is_none());
+
+    // Failure never advances the watermark.
+    assert_eq!(fixture.watermark(), None);
+
+    // The task carries evidence and the dedupe tags.
+    let runtime = fixture.runtime();
+    let tasks = runtime.list_tasks().expect("list tasks");
+    assert_eq!(tasks.len(), 1);
+    let task = &tasks[0];
+    assert_eq!(task.id, task_id);
+    assert_eq!(task.status, TaskStatus::Backlog, "default files as backlog");
+    assert_eq!(task.priority, TaskPriority::Medium);
+    assert!(task.tags.contains(&QA_SWEEP_TAG.to_string()));
+    assert!(task.tags.contains(&format!("fp-{fingerprint}")));
+    assert!(task.description.contains("boom"), "output excerpt attached");
+    assert!(
+        task.description
+            .contains(&report.run_id.clone().expect("run id")),
+        "ledger run referenced"
+    );
+
+    // The ledger run is failed, with the failing step carrying the evidence.
+    let runs = runtime.job_history(QA_SWEEP_JOB).expect("history");
+    assert_eq!(runs.len(), 1);
+    assert_eq!(runs[0].state, JobRunState::Failed);
+    assert_eq!(runs[0].steps.len(), 1);
+    assert_eq!(runs[0].steps[0].state, JobRunState::Failed);
+    assert!(
+        runs[0].steps[0]
+            .error_message
+            .as_deref()
+            .is_some_and(|message| message.contains("boom"))
+    );
+}
+
+#[test]
+fn repeated_failure_dedupes_against_the_open_task() {
+    let fixture = fixture(FAILING_CHECK);
+    let first = fixture.sweep();
+    let filed = first.checks[0].filed_task.clone().expect("task filed");
+
+    // New commit, same breakage: no second task.
+    fixture.commit("more.txt");
+    let second = fixture.sweep();
+    assert_eq!(second.action, "failed");
+    assert_eq!(second.checks[0].filed_task, None);
+    assert_eq!(
+        second.checks[0].deduped_task.as_deref(),
+        Some(filed.as_str())
+    );
+    assert_eq!(second.checks[0].fingerprint, first.checks[0].fingerprint);
+
+    let runtime = fixture.runtime();
+    let qa_tasks = runtime
+        .list_tasks_by_tags(&[QA_SWEEP_TAG.to_string()])
+        .expect("tag query");
+    assert_eq!(qa_tasks.len(), 1, "one open task per distinct failure");
+}
+
+#[test]
+fn closed_task_with_same_fingerprint_is_refiled() {
+    let fixture = fixture(FAILING_CHECK);
+    let first = fixture.sweep();
+    let filed = first.checks[0].filed_task.clone().expect("task filed");
+
+    // Close the finding without fixing it; a recurrence must file anew.
+    let runtime = fixture.runtime();
+    runtime
+        .stores()
+        .tasks()
+        .update(
+            &filed,
+            crate::runtime::TaskRecordUpdateParams {
+                actor: "test".to_string(),
+                status: Some(TaskStatus::Done),
+                ..Default::default()
+            },
+        )
+        .expect("close task");
+    drop(runtime);
+
+    fixture.commit("again.txt");
+    let second = fixture.sweep();
+    let refiled = second.checks[0].filed_task.clone().expect("refiled task");
+    assert_ne!(refiled, filed);
+    assert_eq!(second.checks[0].deduped_task, None);
+}
+
+#[test]
+fn per_check_priority_override_applies_to_the_filed_task() {
+    let fixture = fixture(
+        "[[qa.workspace.check]]\nname = \"broken\"\ncommand = \"exit 1\"\npriority = \"critical\"\n",
+    );
+    let report = fixture.sweep();
+    let task_id = report.checks[0].filed_task.clone().expect("task filed");
+
+    let runtime = fixture.runtime();
+    let tasks = runtime.list_tasks().expect("list tasks");
+    let task = tasks.iter().find(|task| task.id == task_id).expect("task");
+    assert_eq!(task.priority, TaskPriority::Critical);
+}
+
+// ---- mutes, branch guard, dry-run, misconfig -------------------------------
+
+#[test]
+fn muted_failing_check_does_not_block_a_green_pass() {
+    let fixture = fixture(&format!(
+        "{PASSING_CHECK}\
+         [[qa.workspace.check]]\nname = \"flaky\"\ncommand = \"exit 1\"\nmute = true\n"
+    ));
+    let head = fixture.head();
+
+    let report = fixture.sweep();
+    assert_eq!(report.action, "validated");
+    let flaky = report
+        .checks
+        .iter()
+        .find(|check| check.name == "flaky")
+        .expect("flaky check reported");
+    assert_eq!(flaky.outcome, "muted");
+    assert!(flaky.filed_task.is_none(), "muted checks never file tasks");
+    assert_eq!(fixture.watermark().as_deref(), Some(head.as_str()));
+
+    // Muted checks are not executed, so no ledger step exists for them.
+    let runtime = fixture.runtime();
+    let runs = runtime.job_history(QA_SWEEP_JOB).expect("history");
+    assert_eq!(runs[0].steps.len(), 1);
+}
+
+#[test]
+fn checkout_on_another_branch_is_skipped() {
+    let fixture = fixture(PASSING_CHECK);
+    git(&fixture.repo, &["checkout", "-q", "-b", "task/side-branch"]);
+
+    let report = fixture.sweep();
+    assert_eq!(report.action, "skipped");
+    assert!(
+        report
+            .reason
+            .as_deref()
+            .is_some_and(|reason| reason.contains("not_on_branch")),
+        "reason: {:?}",
+        report.reason
+    );
+    assert_eq!(fixture.watermark(), None);
+}
+
+#[test]
+fn dry_run_reports_but_records_nothing() {
+    let fixture = fixture(FAILING_CHECK);
+    let report = fixture.sweep_with(QaSweepOptions { dry_run: true });
+
+    assert_eq!(report.action, "would_validate");
+    assert_eq!(report.checks[0].outcome, "would_run");
+    assert!(report.run_id.is_none());
+    assert_eq!(fixture.watermark(), None);
+
+    let runtime = fixture.runtime();
+    assert!(runtime.list_tasks().expect("tasks").is_empty());
+    assert!(
+        runtime.job_history(QA_SWEEP_JOB).is_err()
+            || runtime
+                .job_history(QA_SWEEP_JOB)
+                .expect("history")
+                .is_empty(),
+        "dry run must not create ledger runs"
+    );
+}
+
+#[test]
+fn unregistered_configured_workspace_is_an_error_row() {
+    let fixture = fixture_with_qa(
+        "[qa]\n\n[[qa.workspace]]\nname = \"ghost\"\n\
+         [[qa.workspace.check]]\nname = \"ok\"\ncommand = \"true\"\n",
+    );
+    let outcome = run_qa_sweep_at(&fixture.global, QaSweepOptions::default()).expect("sweep");
+    assert_eq!(outcome.reports.len(), 1);
+    assert_eq!(outcome.reports[0].action, "error");
+    assert!(
+        outcome.reports[0]
+            .reason
+            .as_deref()
+            .is_some_and(|reason| reason.contains("not found in the global registry"))
+    );
+}
+
+#[test]
+fn no_configured_workspaces_is_a_clean_noop() {
+    let fixture = fixture_with_qa("[workflow]\nbase_branch = \"agent-main\"\n");
+    let outcome = run_qa_sweep_at(&fixture.global, QaSweepOptions::default()).expect("sweep");
+    assert!(outcome.reports.is_empty());
+}
+
+// ---- check execution --------------------------------------------------------
+
+#[test]
+fn execute_check_captures_both_streams_and_exit_code() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let execution = execute_check(
+        dir.path(),
+        "echo out; echo err >&2; exit 3",
+        Duration::from_secs(10),
+    )
+    .expect("run check");
+    assert_eq!(execution.exit_code, Some(3));
+    assert!(!execution.timed_out);
+    assert!(execution.output.contains("out"));
+    assert!(execution.output.contains("err"));
+}
+
+#[test]
+fn execute_check_kills_and_flags_a_hung_command() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let execution =
+        execute_check(dir.path(), "sleep 30", Duration::from_millis(200)).expect("run check");
+    assert!(execution.timed_out);
+    assert_eq!(execution.exit_code, None);
+    assert!(execution.duration_ms < 10_000, "killed promptly");
+}

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -51,6 +51,53 @@ base_branch = "agent-main"   # repo's ship base, if not "main"
 auto_ship = true
 ```
 
+## orbit-qa-sweep (systemd user timer)
+
+Periodically runs `orbit run qa-sweep` [ORB-10039]: the trailing QA pass over
+direct-push workspaces (design D4 — writes to `agent-main` stay fast;
+validation happens on a lag). Per workspace listed in the `[qa]` section of
+the **global** `~/.orbit/config.toml`:
+
+1. skip unless the live checkout is on the expected branch and its HEAD moved
+   past the per-workspace last-validated watermark
+   (`~/.orbit/state/qa-sweep.json`);
+2. run the configured checks (`sh -c`, from the workspace root; per-check
+   timeout, muted checks skipped);
+3. file a fingerprint-deduped orbit task per distinct failure (tags
+   `qa-sweep` + `fp-<hash>`; an open task with the same fingerprint suppresses
+   refiling);
+4. advance the watermark only when every non-muted check passed.
+
+Each validating pass is recorded in the workspace's run ledger under job id
+`qa_sweep` (`orbit run history -j qa_sweep`, `orbit run show <run_id>`). The
+unit exits non-zero only on workspace *errors* (misconfig, git/probe
+failures) — a red check files a task and exits 0, so `--failed` means the
+sweep itself is broken, not the code it checks.
+
+Config lives in the **global** config.toml only (workspace `config.toml`
+files are rewritten by task-mutation commands and are replace-not-merge):
+
+```toml
+# ~/.orbit/config.toml
+[qa]
+default_priority = "medium"    # priority of auto-filed QA tasks
+task_status = "backlog"        # or "proposed" to require human approval
+
+[[qa.workspace]]
+name = "polaris"               # registry name (orbit workspace list)
+branch = "agent-main"          # defaults to the registered base_branch
+
+[[qa.workspace.check]]
+name = "frontmatter"
+command = "python3 scripts/check_frontmatter.py"
+
+[[qa.workspace.check]]
+name = "lint"
+command = "make lint"
+mute = true                    # flaky: keep the definition, skip the check
+timeout_minutes = 10           # default 30
+```
+
 ## orbit-web-upgrade (systemd user timer)
 
 Daily `orbit-web-upgrade.sh` run: rebuild `agent-main` in the orbit checkout,
@@ -82,6 +129,7 @@ the thing that's broken.
 ### Install (per host, e.g. dk-server-1)
 
 ```sh
+<<<<<<< HEAD
 cp deploy/orbit-web-upgrade.{service,timer} ~/.config/systemd/user/
 systemctl --user daemon-reload
 systemctl --user enable --now orbit-web-upgrade.timer
@@ -99,6 +147,20 @@ systemctl --user list-timers orbit-web-upgrade.timer     # next/last fire
 journalctl --user -t orbit-web-upgrade -n 50             # last run's output
 systemctl --user start orbit-web-upgrade.service         # run once now
 systemctl --user disable --now orbit-web-upgrade.timer   # stop the schedule
+=======
+mkdir -p ~/.config/systemd/user
+cp deploy/orbit-qa-sweep.{service,timer} ~/.config/systemd/user/
+systemctl --user daemon-reload
+systemctl --user enable --now orbit-qa-sweep.timer
+```
+
+### Verify
+
+```sh
+orbit run qa-sweep --dry-run --json     # what would be validated, runs nothing
+systemctl --user list-timers orbit-qa-sweep.timer
+journalctl --user -u orbit-qa-sweep -n 50
+>>>>>>> 1ec6d2d3 (feat(qa-sweep): scheduled QA routine trailing agent-main)
 ```
 
 ## orbit-web (systemd user service)

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -25,6 +25,16 @@ persistent failure trips the start limit instead of thrashing. `Restart=` on a
 `Type=oneshot` unit requires systemd >= 254 — on older hosts drop the
 `Restart=`/`RestartSec=` lines; the timer still retries every 20 minutes.
 
+The unit sets `KillMode=process` [ORB-10038]: the sweep dispatches pipeline
+runs by spawning **detached** worker processes and exits immediately, and the
+default `KillMode=control-group` kills the whole cgroup when the oneshot
+deactivates — reaping the just-spawned workers (observed as
+`task_auto_pipeline` runs flipping to `interrupted` with
+`process_not_found` seconds after "Finished orbit-ship-sweep.service").
+`orbit-qa-sweep.service` deliberately keeps the default: qa-sweep runs its
+checks inline and finishes its ledger run before exiting, so cgroup cleanup
+is correct there.
+
 ### Install (per host, e.g. dk-server-1)
 
 ```sh

--- a/deploy/orbit-qa-sweep.service
+++ b/deploy/orbit-qa-sweep.service
@@ -1,0 +1,28 @@
+[Unit]
+Description=orbit qa-sweep (validate new agent-main commits in configured direct-push workspaces)
+# Circuit-breaker for the Restart= retries below: at most 3 starts in 30 min,
+# then stay failed until the next timer tick (or `systemctl --user reset-failed`).
+StartLimitIntervalSec=1800
+StartLimitBurst=3
+
+[Service]
+Type=oneshot
+# The sweep is cwd-independent (workspaces come from ~/.orbit/workspaces.json,
+# config and watermarks from ~/.orbit/; it never bootstraps a .orbit/ where it
+# runs), but pin a stable directory anyway.
+WorkingDirectory=%h
+# systemd user units get a minimal PATH that omits ~/.orbit/bin (orbit) and the
+# tools the configured checks shell out to (git, make, python3, ...).
+Environment=PATH=%h/.local/bin:%h/.orbit/bin:/usr/local/bin:/usr/bin:/bin
+ExecStart=%h/.orbit/bin/orbit run qa-sweep --json
+# Unlike ship-sweep (which spawns detached pipeline workers and needs
+# KillMode=process [ORB-10038]), qa-sweep runs its checks *inline* and only
+# exits after finalizing the ledger run, so the default KillMode=control-group
+# is correct here — anything still alive at exit is a leaked check process
+# that should be reaped.
+# Retry a failed sweep after a pause instead of waiting a full timer interval.
+# Restart= on a Type=oneshot unit requires systemd >= 254; on older systemd
+# drop these two lines (the timer's OnUnitActiveSec still retries every 6h).
+Restart=on-failure
+RestartSec=300
+SyslogIdentifier=orbit-qa-sweep

--- a/deploy/orbit-qa-sweep.timer
+++ b/deploy/orbit-qa-sweep.timer
@@ -1,0 +1,14 @@
+[Unit]
+Description=Run orbit qa-sweep every 6 hours
+
+[Timer]
+OnBootSec=15min
+# QA trails agent-main on a lag by design (D4): checks can be heavy
+# (builds/tests) and findings are deduped, so a slow cadence loses nothing.
+OnUnitActiveSec=6h
+# Smear start times so the sweep never lines up exactly with other timers
+# (notably orbit-ship-sweep, which dispatches into the same workspaces).
+RandomizedDelaySec=10min
+
+[Install]
+WantedBy=timers.target

--- a/deploy/orbit-ship-sweep.service
+++ b/deploy/orbit-ship-sweep.service
@@ -14,6 +14,12 @@ WorkingDirectory=%h
 # tools the dispatched pipelines shell out to (git, gh, claude).
 Environment=PATH=%h/.local/bin:%h/.orbit/bin:/usr/local/bin:/usr/bin:/bin
 ExecStart=%h/.orbit/bin/orbit run ship-sweep --json
+# The sweep spawns *detached* pipeline workers (setsid) and exits immediately;
+# the default KillMode=control-group would reap those workers the moment this
+# oneshot unit deactivates (observed live: a just-dispatched task_auto_pipeline
+# run marked interrupted seconds after "Finished orbit-ship-sweep.service").
+# KillMode=process signals only the sweep CLI itself. [ORB-10038]
+KillMode=process
 # Retry a failed sweep after a short pause instead of waiting a full timer
 # interval. Restart= on a Type=oneshot unit requires systemd >= 254; on older
 # systemd drop these two lines (the timer's OnUnitActiveSec still retries

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -52,6 +52,7 @@ Two roots. **Workspace state** lives in `<repo>/.orbit/`; **user/machine state**
 | `tasks/workspaces/<ws-id>/<task-id>/` | canonical task bundles (survive repo moves) | **authoritative** |
 | `resources/`, `skills/` | default activity/job/executor/policy defs, skills | regenerable (`orbit init` reseeds) |
 | `state/logs/orbit.jsonl` (+ rotated archives) | unified JSONL log sink for all orbit processes | disposable |
+| `state/qa-sweep.json` (+ `.lock`) | per-workspace last-validated watermarks for `orbit run qa-sweep` [ORB-10039] | regenerable (deleting it only re-validates current HEADs) |
 | `embed/` | semantic-search companion binary + models | regenerable (`orbit semantic install`) |
 | `bin/` | installed orbit binary (when installed via `install.sh`) | reinstallable |
 
@@ -408,12 +409,26 @@ User units, installed to `~/.config/systemd/user/` (see
   circuit breaker.
 - **`orbit-ship-sweep.service` + `.timer`** — every 20 min, dispatch ship runs in
   workspaces opted in via `[workflow] auto_ship = true`.
+- **`orbit-qa-sweep.service` + `.timer`** — every 6 h, run `orbit run qa-sweep`
+  [ORB-10039]: the trailing QA pass over direct-push workspaces (design D4). Per
+  workspace listed under `[qa]` in the **global** `~/.orbit/config.toml`, it diffs the
+  live checkout's HEAD against the last-validated watermark
+  (`~/.orbit/state/qa-sweep.json`), runs the configured `sh -c` checks when new commits
+  exist (per-check timeout; `mute = true` skips a flaky check without deleting it), files
+  one fingerprint-deduped orbit task per distinct failure (tags `qa-sweep` +
+  `fp-<hash>`; an open task with the same fingerprint suppresses refiling), and advances
+  the watermark only on a fully green pass. Every validating pass is a ledger run under
+  job id `qa_sweep` (`orbit run history -j qa_sweep` in the workspace). The unit fails
+  only on sweep *errors* — a red check files a task and exits 0. Config schema and
+  install steps: [deploy/README.md](../deploy/README.md).
 
 ```sh
 systemctl --user status orbit-web
-systemctl --user list-timers orbit-ship-sweep.timer
+systemctl --user list-timers orbit-ship-sweep.timer orbit-qa-sweep.timer
 systemctl --user list-units --failed
 journalctl --user -u orbit-ship-sweep -n 50
+journalctl --user -u orbit-qa-sweep -n 50
+orbit run qa-sweep --dry-run --json       # what QA would validate, runs nothing
 systemctl --user restart orbit-web        # after swapping the binary
 systemctl --user reset-failed orbit-web   # if the circuit breaker tripped
 ```


### PR DESCRIPTION
Implements P4 of the multi-env operations design (D4): direct pushes to `agent-main` stay fast; correctness is enforced on a lag by `orbit run qa-sweep`, a scheduler-run sibling of `ship-sweep`.

## Design

- **Sweep loop** — per workspace listed under `[qa]` in the **global** `~/.orbit/config.toml`: skip unless the live checkout is on the expected branch and its HEAD moved past the per-workspace last-validated watermark; run the configured checks; file fingerprint-deduped orbit tasks for failures; advance the watermark only on a fully green pass. The sweep validates the local HEAD of the live checkout and never mutates the repo (no fetch/checkout — fetch cannot change what the checks observe, and background mutation of a live repo is out of scope; documented in `qa::git`).
- **Config home** — global config.toml only, because workspace configs are replace-not-merge and get silently rewritten by task-mutation commands:

  ```toml
  # ~/.orbit/config.toml
  [qa]
  default_priority = "medium"    # priority of auto-filed QA tasks
  task_status = "backlog"        # or "proposed" to require human approval first

  [[qa.workspace]]
  name = "polaris"               # registry name (orbit workspace list)
  branch = "agent-main"          # defaults to the registered base_branch

  [[qa.workspace.check]]
  name = "frontmatter"
  command = "python3 scripts/check_frontmatter.py"

  [[qa.workspace.check]]
  name = "lint"
  command = "make lint"
  mute = true                    # flaky: keep the definition, skip the check
  timeout_minutes = 10           # default 30
  ```

  Fail-closed validation runs inside `RuntimeConfig` load, so a typo'd priority/status is a loud startup error, never a sweep that validates nothing.
- **Watermark** — `~/.orbit/state/qa-sweep.json` (global orbit dir, per L-0041: never per-repo cwd), fs2-locked read-modify-write so concurrent writers merge instead of clobbering. Failures never advance it; a watermark orphaned by a history rewrite is treated as unknown range and HEAD is re-validated. A host-wide flock makes passes single-flight.
- **Fingerprint** — `sha256(workspace \n check \n normalized-output-head)[..12]`, where the head is the first 20 non-blank lines with ANSI escapes, the absolute repo root, and whitespace runs scrubbed; empty output falls back to the exit summary (`exit N` / `timeout`). Carried as tags `qa-sweep` + `fp-<hash>`; a sweep finding an OPEN task with the same fingerprint reports it instead of refiling (closed tasks refile on recurrence).
- **Ledger integration (honest minimal)** — each validating pass records a first-class v2 job run under job id `qa_sweep` in the swept workspace's jobs store — `insert_run → mark_run_running → complete_run_step` (one step per executed check, evidence in `error_message`) `→ finalize_run`, plus `JobRunStarted/Completed` events — written inline by the code doing the work. No worker spawn and no YAML job asset: checks are host-trusted shell commands, and `orbit run history` intentionally serves asset-less job ids, so `orbit run history -j qa_sweep` and `orbit run show <run_id>` show sweeps and their per-check steps. A pass that errors mid-flight finalizes its run as failed rather than leaving it `running`.
- **Checks** — `sh -c` from the workspace root in their own process group; timeout kills the whole group (otherwise grandchildren keep the captured pipes open and wedge the sweep). Red checks are the sweep *working* (task filed, exit 0); only workspace errors exit non-zero, so a failed unit means the sweep is broken, not the code it checks.
- **Scheduling** — `deploy/orbit-qa-sweep.{service,timer}`: 6h cadence, 10min randomized delay, runtime-free early dispatch in `main.rs` so the scheduler cwd never grows a `.orbit/`.

Also includes the live-verified **ship-sweep unit fix [ORB-10038]** as a separate commit: `KillMode=process` so the oneshot's cgroup cleanup stops reaping the detached pipeline workers the sweep just spawned. qa-sweep deliberately keeps the default control-group kill (checks run inline; nothing legitimate survives exit) — documented in both unit files and deploy/README.md.

## Evidence

- `make fmt-check` clean; `make clippy` (workspace, `-D warnings`) clean.
- Tests: `cargo test -p orbit-core` → **500 passed** (incl. 36 new qa tests: config fail-closed validation, fingerprint stability/discrimination, locked watermark round-trips, and end-to-end sweeps over real temp git repos covering green-advance, no-new-commits skip, failure filing + watermark hold, dedupe, closed-task refiling, mute, branch guard, dry-run inertness, unregistered-workspace error, timeout group-kill). `cargo test -p orbit-cli` new qa-sweep parse/render tests pass (6/6).
- ci-guardrails: fmt/clippy plus all 9 guardrail scripts pass individually; the workspace test phase hits 7 **pre-existing** `cli_semantic_*`/docs-index failures on this box (world-writable `/tmp` companion-override check) that reproduce identically on pristine `origin/agent-main` — unrelated to this change, expected green on CI runners.
- Manual end-to-end smoke with an isolated `$HOME` (debug binary): dry-run → failing sweep files exactly one `backlog/high/bug` task with `qa-sweep` + `fp-…` tags and output evidence → repeat failure dedupes against it → fix commit turns the sweep green and advances the watermark → next sweep skips on `no_new_commits`; `orbit run history -j qa_sweep` shows all three runs, `orbit run show` shows the per-check step; no `.orbit/` created in the scheduler cwd.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
