### PR TITLE
Executor defs: platform-aware sandbox default (macos-sandbox-exec fails closed on Linux)

### DIFF
--- a/crates/orbit-common/src/types/executor_def.rs
+++ b/crates/orbit-common/src/types/executor_def.rs
@@ -56,6 +56,26 @@ impl ExecutorSandboxKind {
             Self::MacosSandboxExec => "macos-sandbox-exec",
         }
     }
+
+    /// OS this sandbox primitive can be applied on, named to match
+    /// `std::env::consts::OS` (e.g. `"macos"`, `"linux"`).
+    ///
+    /// Every kind is single-OS today. When a Linux variant (`linux-bwrap`
+    /// or similar) lands, add its arm here; the seed-time platform scrub in
+    /// `orbit-core` reads this to decide whether to keep a declaration.
+    pub fn target_os(self) -> &'static str {
+        match self {
+            Self::MacosSandboxExec => "macos",
+        }
+    }
+
+    /// Whether this sandbox primitive applies to the running host. Used to
+    /// scrub platform-mismatched sandbox declarations at seed time so a
+    /// shipped executor asset doesn't fail-closed at dispatch on an
+    /// unsupported OS (see [ORB-10047]).
+    pub fn is_available_on_current_platform(self) -> bool {
+        self.target_os() == std::env::consts::OS
+    }
 }
 
 impl fmt::Display for ExecutorSandboxKind {

--- a/crates/orbit-common/src/types/tests/executor_def.rs
+++ b/crates/orbit-common/src/types/tests/executor_def.rs
@@ -1,3 +1,24 @@
+mod sandbox_kind_platform {
+    use super::super::super::executor_def::ExecutorSandboxKind;
+
+    #[test]
+    fn target_os_matches_std_env_consts_naming() {
+        assert_eq!(ExecutorSandboxKind::MacosSandboxExec.target_os(), "macos");
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn is_available_on_current_platform_is_true_on_macos() {
+        assert!(ExecutorSandboxKind::MacosSandboxExec.is_available_on_current_platform());
+    }
+
+    #[cfg(not(target_os = "macos"))]
+    #[test]
+    fn is_available_on_current_platform_is_false_off_macos() {
+        assert!(!ExecutorSandboxKind::MacosSandboxExec.is_available_on_current_platform());
+    }
+}
+
 mod external_variant {
     use super::super::super::executor_def::*;
     use crate::types::ExecutorResource;

--- a/crates/orbit-core/src/command/executor.rs
+++ b/crates/orbit-core/src/command/executor.rs
@@ -43,23 +43,46 @@ pub(crate) fn seed_default_executors(
     Ok(created)
 }
 
-fn migrated_default_executor(existing: &ExecutorDef, seeded: &ExecutorDef) -> Option<ExecutorDef> {
+pub(super) fn migrated_default_executor(
+    existing: &ExecutorDef,
+    seeded: &ExecutorDef,
+) -> Option<ExecutorDef> {
     if existing.name != seeded.name {
         return None;
     }
 
-    if existing.executor_type != ExecutorType::AgentCli
-        || seeded.executor_type != ExecutorType::DirectAgent
+    let mut migrated = existing.clone();
+    let mut changed = false;
+
+    if existing.executor_type == ExecutorType::AgentCli
+        && seeded.executor_type == ExecutorType::DirectAgent
     {
-        return None;
+        migrated.executor_type = ExecutorType::DirectAgent;
+        changed = true;
     }
 
-    let mut migrated = existing.clone();
-    migrated.executor_type = ExecutorType::DirectAgent;
-    Some(migrated)
+    // Scrub a platform-mismatched sandbox left over from a prior install so
+    // re-seeding on a host that can't apply it (e.g. `macos-sandbox-exec` on
+    // Linux) drops the declaration instead of leaving dispatch fail-closed.
+    // See [ORB-10047].
+    if let Some(kind) = existing.sandbox {
+        if !kind.is_available_on_current_platform() {
+            tracing::warn!(
+                executor = %existing.name,
+                sandbox = %kind,
+                current_platform = std::env::consts::OS,
+                target_platform = kind.target_os(),
+                "scrubbing platform-mismatched sandbox from installed executor def on re-seed",
+            );
+            migrated.sandbox = None;
+            changed = true;
+        }
+    }
+
+    if changed { Some(migrated) } else { None }
 }
 
-fn parse_default_executor(name: &str, yaml: &str) -> Result<ExecutorDef, OrbitError> {
+pub(super) fn parse_default_executor(name: &str, yaml: &str) -> Result<ExecutorDef, OrbitError> {
     let resource: ExecutorResource = serde_yaml::from_str(yaml).map_err(|e| {
         OrbitError::InvalidInput(format!("invalid embedded executor def '{name}': {e}"))
     })?;
@@ -82,10 +105,30 @@ fn parse_default_executor(name: &str, yaml: &str) -> Result<ExecutorDef, OrbitEr
         )));
     }
 
-    Ok(ExecutorDef::from_resource_spec(
+    let mut def = ExecutorDef::from_resource_spec(
         resource.metadata.name,
         resource.spec.clone(),
         resource.spec.created_at,
         resource.spec.updated_at,
-    ))
+    );
+
+    // Shipped executor assets today declare a single-OS sandbox primitive
+    // (`macos-sandbox-exec`); dispatch fails closed if the runner platform
+    // can't apply it. Drop the declaration at parse time on hosts where it
+    // doesn't apply so first-install and re-install (overwrite mode) don't
+    // persist a platform-mismatched sandbox. See [ORB-10047].
+    if let Some(kind) = def.sandbox {
+        if !kind.is_available_on_current_platform() {
+            tracing::warn!(
+                executor = %def.name,
+                sandbox = %kind,
+                current_platform = std::env::consts::OS,
+                target_platform = kind.target_os(),
+                "shipped executor asset declares sandbox for another platform; installing without sandbox on this host",
+            );
+            def.sandbox = None;
+        }
+    }
+
+    Ok(def)
 }

--- a/crates/orbit-core/src/command/tests/executor.rs
+++ b/crates/orbit-core/src/command/tests/executor.rs
@@ -1,0 +1,99 @@
+use chrono::Utc;
+use orbit_common::types::{ExecutorDef, ExecutorSandboxKind, ExecutorType};
+
+use crate::command::executor::{migrated_default_executor, parse_default_executor};
+
+fn base_def(name: &str, executor_type: ExecutorType) -> ExecutorDef {
+    let now = Utc::now();
+    ExecutorDef {
+        name: name.to_string(),
+        executor_type,
+        command: Some("noop".to_string()),
+        args: Vec::new(),
+        stdout_format: None,
+        model_pair_override: None,
+        model_flag: None,
+        timeout_seconds: None,
+        env: Default::default(),
+        sandbox: None,
+        allow_fallback: false,
+        created_at: now,
+        updated_at: now,
+    }
+}
+
+const CLAUDE_YAML: &str = r#"schemaVersion: 2
+kind: Executor
+metadata:
+  name: claude
+spec:
+  executor_type: direct_agent
+  command: claude
+  sandbox: macos-sandbox-exec
+"#;
+
+/// On macOS the sandbox declaration matches the host and must survive parsing —
+/// otherwise ORB-10047's fix would silently disarm the sandbox everywhere.
+#[cfg(target_os = "macos")]
+#[test]
+fn parse_default_executor_preserves_sandbox_on_matching_platform() {
+    let def = parse_default_executor("claude", CLAUDE_YAML).expect("parse");
+    assert_eq!(def.sandbox, Some(ExecutorSandboxKind::MacosSandboxExec));
+}
+
+/// On Linux the shipped `macos-sandbox-exec` declaration cannot be enforced;
+/// keeping it would make every crew dispatch fail closed at dispatch time.
+/// See ORB-10047.
+#[cfg(not(target_os = "macos"))]
+#[test]
+fn parse_default_executor_scrubs_sandbox_on_mismatched_platform() {
+    let def = parse_default_executor("claude", CLAUDE_YAML).expect("parse");
+    assert_eq!(def.sandbox, None);
+}
+
+/// Re-seeding must scrub a platform-mismatched sandbox left over from a
+/// prior install, so an upgrade on Linux clears a persisted
+/// `macos-sandbox-exec` even though the executor type is unchanged.
+#[cfg(not(target_os = "macos"))]
+#[test]
+fn migrated_default_executor_scrubs_platform_mismatched_sandbox_on_non_matching_host() {
+    let mut existing = base_def("claude", ExecutorType::DirectAgent);
+    existing.sandbox = Some(ExecutorSandboxKind::MacosSandboxExec);
+    let seeded = base_def("claude", ExecutorType::DirectAgent);
+
+    let migrated =
+        migrated_default_executor(&existing, &seeded).expect("scrub should produce a migrated def");
+    assert_eq!(migrated.sandbox, None);
+    assert_eq!(migrated.executor_type, ExecutorType::DirectAgent);
+}
+
+/// On macOS the persisted sandbox is host-compatible; re-seeding must not
+/// touch it and must not force a rewrite.
+#[cfg(target_os = "macos")]
+#[test]
+fn migrated_default_executor_preserves_sandbox_on_matching_host() {
+    let mut existing = base_def("claude", ExecutorType::DirectAgent);
+    existing.sandbox = Some(ExecutorSandboxKind::MacosSandboxExec);
+    let seeded = base_def("claude", ExecutorType::DirectAgent);
+
+    assert!(migrated_default_executor(&existing, &seeded).is_none());
+}
+
+/// The pre-ORB-10047 `AgentCli → DirectAgent` migration path must still fire
+/// so upgrades from older on-disk executor defs continue to move forward.
+#[test]
+fn migrated_default_executor_still_migrates_agent_cli_to_direct_agent() {
+    let existing = base_def("claude", ExecutorType::AgentCli);
+    let seeded = base_def("claude", ExecutorType::DirectAgent);
+
+    let migrated = migrated_default_executor(&existing, &seeded).expect("type migration");
+    assert_eq!(migrated.executor_type, ExecutorType::DirectAgent);
+    assert_eq!(migrated.sandbox, None);
+}
+
+#[test]
+fn migrated_default_executor_returns_none_when_nothing_needs_migrating() {
+    let existing = base_def("claude", ExecutorType::DirectAgent);
+    let seeded = base_def("claude", ExecutorType::DirectAgent);
+    assert!(migrated_default_executor(&existing, &seeded).is_none());
+}

--- a/crates/orbit-core/src/command/tests/mod.rs
+++ b/crates/orbit-core/src/command/tests/mod.rs
@@ -1,1 +1,2 @@
+mod executor;
 mod review_thread_hook;


### PR DESCRIPTION
## Task

[ORB-10047](https://orbit-cli.com/tasks/ORB-10047) — Executor defs: platform-aware sandbox default (macos-sandbox-exec fails closed on Linux)

### Description

All shipped executor assets (crates/orbit-core/assets/executors/{claude,codex,gemini,grok}.yaml) declare 'sandbox: macos-sandbox-exec'. On dk-server-1 (Linux) every crew dispatch fails closed at dispatch time: 'executor claude declares sandbox macos-sandbox-exec but current platform is linux' — first observed on the first-ever real ship-sweep dispatch (jrun-20260706-0141, ws_sextant, during ORB-10038 verification). executor_def.rs:44 notes only macos-sandbox-exec is wired and a Linux variant is future work. Workaround applied on the box (2026-07-06): removed the sandbox line from the four installed defs under ~/.orbit/resources/executors/ (box already runs claude crews with --permission-mode bypassPermissions, so unsandboxed matches the existing trust model). Durable fix: make the sandbox declaration platform-conditional (e.g. per-platform map or omit-on-mismatch-with-warning policy knob), or ship a Linux sandbox (bwrap/landlock) — and ensure resource re-installation on runtime upgrade doesn't silently reinstate a platform-mismatched declaration.

### Acceptance Criteria

- a crew dispatch on Linux does not fail closed due to a macos-only sandbox declaration in the shipped executor defs
- behavior on macOS unchanged (sandbox still applied)
- runtime resource (re)installation cannot reintroduce a platform-mismatched sandbox silently

## Execution Summary

<details>
<summary>Click to expand</summary>

Made the shipped executor sandbox declaration platform-conditional so a Linux runner no longer fails closed on dispatch with "executor claude declares sandbox macos-sandbox-exec but current platform is linux" (see [ORB-10047]).

Changes:
- `crates/orbit-common/src/types/executor_def.rs`: added `ExecutorSandboxKind::target_os()` and `is_available_on_current_platform()`. `target_os()` names match `std::env::consts::OS` ("macos"), giving the seed-time platform check a single source of truth. New Linux variants (`linux-bwrap`, etc.) just add an arm.
- `crates/orbit-core/src/command/executor.rs`:
  - `parse_default_executor` now drops `spec.sandbox` at parse time when the declared kind can't be applied on the current host and logs a warning; this covers both first install and re-install (overwrite mode).
  - `migrated_default_executor` no longer early-returns on non-`AgentCli -> DirectAgent` — it accumulates changes and additionally scrubs a platform-mismatched sandbox left on an already-installed def. Runtime upgrade can't silently reinstate a platform-mismatched declaration.
  - Both were promoted from `fn` to `pub(super) fn` so the sibling `command::tests::executor` module can exercise them.
- Tests:
  - `crates/orbit-common/src/types/tests/executor_def.rs`: `target_os()` naming; `is_available_on_current_platform()` gated per host.
  - `crates/orbit-core/src/command/tests/executor.rs` (new): `parse_default_executor` strips `macos-sandbox-exec` off macOS via `#[cfg]`; `migrated_default_executor` scrubs a mismatched sandbox off an installed def and preserves the executor-type migration.

Acceptance criteria:
- Linux dispatch no longer fails closed on macOS-only sandbox declaration: parse-time scrub drops the field on install; migration path scrubs on re-seed.
- macOS behavior unchanged: `is_available_on_current_platform()` returns true; no scrub runs; existing tests remain green under `#[cfg(target_os = "macos")]`.
- Re-installation on a platform-mismatched runner cannot silently reinstate the sandbox — `migrated_default_executor` now emits a warning and returns a migrated def with `sandbox = None`.

Follow-up (out of scope): shipping an actual Linux sandbox primitive (bwrap/landlock) and adding it as a new `ExecutorSandboxKind` variant with `target_os() = "linux"`. Recorded in the durable-fix comment in `executor_def.rs`.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10047-6a4b119e`
- Behind base: 0
- Ahead of base: 1