### PR TITLE
fix(activity): implement agent must persist execution_summary via MCP-or-CLI

### DIFF
--- a/crates/orbit-core/assets/activities/agent_implement.yaml
+++ b/crates/orbit-core/assets/activities/agent_implement.yaml
@@ -30,6 +30,16 @@ spec:
   instruction: |
     You are implementing an Orbit task from plan to validated code.
 
+    Tool access: whenever an instruction below says to call an `orbit.*` tool
+    (e.g. `orbit.task.update`, `orbit.task.show`, `orbit.search`), use that tool
+    when it is present in your tool surface. When it is NOT — some executors run
+    without the Orbit MCP tools wired in — run the equivalent Orbit CLI in the
+    terminal instead: `orbit tool run <tool.name> --input '<json>'` (use
+    `--input-file <path>` for large or multi-line values). State you persist
+    through Orbit (via the MCP tool OR the CLI) is durable; the structured
+    result object you return at the end is NOT persisted, so never treat it as
+    the system of record.
+
     1. Start with the injected `task` object when present. Treat it as the
        authoritative task context for title, description, acceptance criteria,
        plan, and context files.
@@ -109,7 +119,15 @@ spec:
         call `orbit.task.start` — this envelope rule overrides the direct-execution
         start step described in the `orbit-task` skill's Execute Step 3. Proceed
         directly to implementation.
-    14. Persist an execution summary when useful, but do not move the task to
+    14. Persist your execution summary to the task before handoff — this is
+        REQUIRED, not "when useful". The downstream PR step reads the task's
+        persisted `execution_summary` and refuses to open a PR without a
+        meaningful one; the structured result object you return is NOT persisted,
+        so a summary that lives only there is lost and strands your work. Persist
+        it with `orbit.task.update` when that tool is available, otherwise via
+        the terminal:
+        `orbit tool run orbit.task.update --input '{"id":"<task_id>","execution_summary":"<summary>"}'`
+        (prefer `--input-file` for multi-line summaries). Do NOT move the task to
         `review`; the pipeline does that only after commit/merge or PR steps
         succeed. This envelope rule overrides the direct-execution review
         transition described in the `orbit-task` skill's Execute Step 5 and Exit
@@ -135,6 +153,7 @@ spec:
     - make
     - cargo
     - rg
+    - orbit
   on_denial: terminate
   max_iterations: 25
   role: implementer


### PR DESCRIPTION
## Problem
Every **claude-executed** task fails the `open_batch_pr` guard:
`task '<id>' requires a meaningful persisted execution_summary before opening the PR`.

Root cause (traced on ORB-10042 / `jrun-20260706-0305-5`):
1. The `agent_implement` seed prompt tells the agent to persist status + `execution_summary` via `orbit.task.update`, **not** via the result object.
2. But the claude executor launches `claude -p --tools default` with **no Orbit MCP server wired in** (`assets/executors/claude.yaml`), so `orbit_task_update` et al. are absent from the agent's tool surface. (The agent even ran `ToolSearch` 3× hunting for it — all misses.)
3. The agent did the work correctly (274 orbit-store tests pass) and put its summary in the returned **result object** — the only place available.
4. The deterministic `update_task` automation hardcodes `execution_summary: None` (`orbit-engine/.../automation/task_update/mod.rs`) and never harvests the result object, so `task.execution_summary` stays empty.
5. `open_batch_pr`'s guard (`.../vcs/pr/open.rs`, `ensure_completed_tasks_have_meaningful_execution_summaries`) reads the empty field and hard-fails.

So it's a tooling/instruction gap, not an agent omission.

## Fix (instruction-only, no wiring change)
- Add a general **tool-access rule**: use an `orbit.*` tool when present in the tool surface; otherwise run the equivalent Orbit CLI in the terminal — `orbit tool run <tool.name> --input '<json>'`.
- Make persisting the execution summary **REQUIRED** (was "when useful"), explain that the returned result object is not persisted, and spell out the CLI form: `orbit tool run orbit.task.update --input '{"id":"<task_id>","execution_summary":"<summary>"}'`.
- Add `orbit` to `proc_allowed_programs` so the CLI fallback is permitted.

## Not in this PR
- Executor `sandbox:` fields are unchanged (Mac installs need `macos-sandbox-exec`; the Linux box strips it on install).
- Suggested follow-up: have `update_task`/`open_batch_pr` harvest `result.summary` as a fallback so a good envelope is never silently lost.

Friction: `F2026-07-003`. `make ci-fast` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)