### PR TITLE
fix: remove dangling orbit.learning.comment.add refs left by ORB-10046 [ORB-10087]

### DIFF
--- a/crates/orbit-cli/CLAUDE.md
+++ b/crates/orbit-cli/CLAUDE.md
@@ -20,8 +20,8 @@ forces a directory.
 
 - [`hook/`](src/command/hook) — three subcommands, one `.rs` per body, shared
   enum types in `render.rs`.
-- [`learning/`](src/command/learning) — ten subcommands, a `comment` parent
-  with its own nested subcommands, shared formatting in `output.rs`.
+- [`learning/`](src/command/learning) — eight subcommands, one `.rs` per body,
+  shared formatting in `output.rs`.
 - [`task/`](src/command/task) — large surface with `artifact` nested parent
   and a `tests/` subdir mirroring source files.
 

--- a/crates/orbit-cli/tests/snapshots/mcp_tools_list.json
+++ b/crates/orbit-cli/tests/snapshots/mcp_tools_list.json
@@ -753,38 +753,6 @@
     "name": "orbit_learning_add"
   },
   {
-    "description": "Append a footnote-style comment to an active learning. Returns `{ id, learning_id, created_at }`.",
-    "inputSchema": {
-      "additionalProperties": true,
-      "properties": {
-        "body": {
-          "description": "Comment body (trimmed, non-empty, ≤ 500 chars).",
-          "type": "string"
-        },
-        "learning_id": {
-          "description": "ID of the parent learning.",
-          "type": "string"
-        },
-        "model": {
-          "description": "Preferred provenance field. Pass the canonical agent family (codex, claude, gemini, or grok); full model strings are accepted and auto-normalized.",
-          "enum": [
-            "codex",
-            "claude",
-            "gemini",
-            "grok"
-          ],
-          "type": "string"
-        }
-      },
-      "required": [
-        "learning_id",
-        "body"
-      ],
-      "type": "object"
-    },
-    "name": "orbit_learning_comment_add"
-  },
-  {
     "description": "Fetch a single learning by ID as JSON. Returns the full record including body and evidence.",
     "inputSchema": {
       "additionalProperties": true,

--- a/crates/orbit-core/assets/activities/agent_implement.yaml
+++ b/crates/orbit-core/assets/activities/agent_implement.yaml
@@ -141,8 +141,6 @@ spec:
     - orbit.search
     - orbit.learning.show
     - orbit.learning.add
-    - orbit.learning.comment.add
-    # ORB-00289: orbit.learning.comment.delete is admin/CLI-only; not exposed on the agent surface.
     - orbit.learning.update
     - orbit.learning.supersede
     - fs.read

--- a/crates/orbit-core/assets/activities/agent_review.yaml
+++ b/crates/orbit-core/assets/activities/agent_review.yaml
@@ -81,8 +81,6 @@ spec:
     - orbit.search
     - orbit.learning.show
     - orbit.learning.add
-    - orbit.learning.comment.add
-    # ORB-00289: orbit.learning.comment.delete is admin/CLI-only; not exposed on the agent surface.
     - orbit.learning.update
     - orbit.learning.supersede
     - fs.read

--- a/docs/design/auditability/specs/artifact-redaction.md
+++ b/docs/design/auditability/specs/artifact-redaction.md
@@ -8,9 +8,8 @@ Orbit artifact tools persist repo-backed YAML, markdown, and JSON. Their write b
 |------|----------------------------------------------|-------------------------------|------|
 | `orbit.adr.add` / `orbit.adr.update` | `title`, `body` | - | status, owner, related ids/features/tasks, legacy ids |
 | `orbit.adr.supersede` | - | - | `old_id`, `new_id` |
-| `orbit.learning.add` / `orbit.learning.update` | `summary`, `body`, `scope.tags[]`, `evidence[].ref` | `scope.paths[]` | status, ids, priority, votes, model fields |
+| `orbit.learning.add` / `orbit.learning.update` | `summary`, `body`, `scope.tags[]`, `evidence[].ref` | `scope.paths[]` | status, ids, priority, model fields |
 | `orbit.learning.supersede` | - | - | `old_id`, `new_id` |
-| `orbit.learning.comment.add` | `body` | - | `learning_id`, `model` |
 | `orbit.task.add` | `title`, `description`, `plan`, `acceptance_criteria[]`, `comment` | `context_files[]`, `context`, `external_refs[].url` | workspace, ids, enums, dependency/relation targets, crew, tags |
 | `orbit.task.update` | `title`, `description`, `plan`, `execution_summary`, `acceptance_criteria[]`, `comment` | `context_files[]`, `context` | provenance/status/identity fields, tags, raw artifacts |
 | `orbit.task.reject` | `note`, `comment` | - | `id` |


### PR DESCRIPTION
## Why

ORB-10046 (PR #541) removed the `orbit.learning.comment.add` tool from the registry but left references behind. Two of them are **test-breaking**, so `agent-main` CI has been red and the **deployed pipeline on dk-server-1 is down**:

- Dispatching any task via `workflow_ship` into `ws_orbit` fails in ~9ms with:
  ```
  build activity catalog: activity `agent_implement` tool allowlist invalid:
  unknown tool name in allowlist entry `orbit.learning.comment.add`
  ```
  This takes down **both** the ship-sweep and the qa-sweep (both rely on `agent_implement` / `agent_review`).

## What

Removes the last dangling references to the deleted tool:

| File | Fix | Impact |
|---|---|---|
| `crates/orbit-core/assets/activities/agent_implement.yaml` | drop `- orbit.learning.comment.add` (+ orphaned `# ORB-00289` comment) | restores activity-catalog build → pipeline |
| `crates/orbit-core/assets/activities/agent_review.yaml` | same | same |
| `crates/orbit-cli/tests/snapshots/mcp_tools_list.json` | regenerated via `ORBIT_MCP_UPDATE_SNAPSHOT=1` (only the `comment_add` object drops) | fixes `mcp_serve_tools_list_matches_production_snapshot` |
| `docs/design/auditability/specs/artifact-redaction.md` | remove the `comment.add` row + stale `votes` passthrough field | doc cleanup |
| `crates/orbit-cli/CLAUDE.md` | learning is now 8 flat subcommands, no `comment` parent | doc cleanup |

Corrections to learnings already route through `orbit.learning.update` / `orbit.learning.supersede`, which remain in the allowlists.

## Verification (local)

- `cargo test -p orbit-core --lib default_activity_catalog_allowlists_resolve_registered_tools` → **pass** (was failing pre-fix)
- `cargo test -p orbit-cli --test mcp_roundtrip mcp_serve_tools_list_matches_production_snapshot` → **fails pre-fix**, **passes** after snapshot regen
- `make ci-fast` → **pass** (exit 0)

## Follow-up (not in this PR)

⚠️ **dk-server-1 needs a rebuild+redeploy after merge** — merging alone does not restore the running server's pipeline.

Tracked as **ORB-10087** (bug, source: ORB-10046). Unblocks **ORB-10085** (daily qa-sweep routine, carved from ORB-10049 P5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)