### PR TITLE
Unify Orbit provider identity and resolution with the Constellation contract

### DIFF
--- a/crates/orbit-common/src/types/activity_job/activity_v2.rs
+++ b/crates/orbit-common/src/types/activity_job/activity_v2.rs
@@ -1,3 +1,6 @@
+use std::fmt;
+use std::str::FromStr;
+
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
@@ -169,6 +172,15 @@ impl Backend {
 /// Named provider whose runtime executes an `agent_loop` activity. The enum is
 /// closed-set: adding a provider means wiring a new HTTP transport AND/OR a new
 /// CLI runtime factory, both of which are code changes.
+///
+/// This is the **single canonical provider-identity surface** for Orbit
+/// (ORB-10091): every crew/runtime path that turns a string into a provider —
+/// crew-role parsing, agent-role resolution, CLI executor selection, setup
+/// detection — routes through [`Provider::parse`] so canonical IDs, alias
+/// normalization, and capability predicates cannot drift across layers or
+/// disagree with Worker/Bridge. The set mirrors the Constellation
+/// provider-resolution contract (see `docs/CONFIG.md` and the pinned fixture
+/// under `tests/fixtures/provider_contract.json`).
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
 #[serde(rename_all = "snake_case")]
 pub enum Provider {
@@ -182,7 +194,63 @@ pub enum Provider {
     OpenaiCompat,
 }
 
+/// One accepted non-canonical spelling for a [`Provider`]. Alias normalization
+/// is table-driven so the accepted surface stays declarative and testable.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ProviderAlias {
+    /// The accepted alternate spelling (already lower-cased / trimmed form).
+    pub alias: &'static str,
+    /// The canonical provider the alias resolves to.
+    pub canonical: Provider,
+    /// Whether the alias is deprecated. Callers may warn on a deprecated alias;
+    /// resolution still succeeds so persisted identities are never broken.
+    pub deprecated: bool,
+}
+
+/// Error returned when a provider identifier cannot be resolved to a canonical
+/// [`Provider`]. Carries the offending raw string so callers can build stable,
+/// non-silent diagnostics instead of falling back to a default runtime.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProviderParseError {
+    /// The raw input (as received, before normalization) that failed to parse.
+    pub raw: String,
+}
+
+impl fmt::Display for ProviderParseError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "unknown provider '{}'; expected one of {}",
+            self.raw,
+            Provider::CANONICAL_LIST
+        )
+    }
+}
+
+impl std::error::Error for ProviderParseError {}
+
 impl Provider {
+    /// Every canonical provider, in declaration order. Adding a variant here is
+    /// a compile-time forcing function for the match arms below.
+    pub const ALL: [Provider; 6] = [
+        Provider::Claude,
+        Provider::Codex,
+        Provider::Gemini,
+        Provider::Grok,
+        Provider::Ollama,
+        Provider::OpenaiCompat,
+    ];
+
+    /// Accepted non-canonical spellings, normalized by [`Provider::parse`].
+    pub const ALIASES: &'static [ProviderAlias] = &[ProviderAlias {
+        alias: "openai-compat",
+        canonical: Provider::OpenaiCompat,
+        deprecated: false,
+    }];
+
+    /// Human-readable canonical id list used in diagnostics.
+    pub const CANONICAL_LIST: &'static str = "claude, codex, gemini, grok, ollama, openai_compat";
+
     pub fn as_str(self) -> &'static str {
         match self {
             Provider::Claude => "claude",
@@ -194,12 +262,69 @@ impl Provider {
         }
     }
 
+    /// Canonical parse with alias normalization. Trims surrounding whitespace
+    /// and lower-cases before matching, so config/env casing variants resolve
+    /// to the same identity. Unknown strings return [`ProviderParseError`] —
+    /// this is the *only* string→provider entry point; callers must not invent
+    /// their own match and must not silently fall back on error.
+    pub fn parse(raw: &str) -> Result<Provider, ProviderParseError> {
+        let normalized = raw.trim().to_ascii_lowercase();
+        if let Some(provider) = Provider::ALL
+            .into_iter()
+            .find(|provider| provider.as_str() == normalized)
+        {
+            return Ok(provider);
+        }
+        if let Some(alias) = Provider::ALIASES
+            .iter()
+            .find(|alias| alias.alias == normalized)
+        {
+            return Ok(alias.canonical);
+        }
+        Err(ProviderParseError {
+            raw: raw.to_string(),
+        })
+    }
+
     /// Whether Phase 2c wires an HTTP transport for this provider. Used by the
     /// dispatcher's §3.1 no-silent-fallback check: `backend: http` against a
     /// provider whose HTTP transport is not wired must fail structurally, not
     /// silently fall back to CLI.
     pub fn has_http_transport(self) -> bool {
         matches!(self, Provider::Claude)
+    }
+
+    /// Whether Orbit ships a CLI runtime for this provider. `openai_compat` is
+    /// HTTP-only, so `backend: cli` selecting it must fail structurally rather
+    /// than fall back. All other canonical providers have a CLI runtime.
+    pub fn has_cli_runtime(self) -> bool {
+        !matches!(self, Provider::OpenaiCompat)
+    }
+
+    /// Whether the model-neutral Worker leaf executor can execute this
+    /// provider. Worker only wires the CLI agent families; `ollama` and
+    /// `openai_compat` are Orbit-canonical capabilities Worker does not run.
+    /// Preserving this distinction is an explicit ORB-10091 constraint — Orbit
+    /// keeps the wider set even though Worker cannot execute all of it.
+    pub fn is_worker_executable(self) -> bool {
+        matches!(
+            self,
+            Provider::Claude | Provider::Codex | Provider::Gemini | Provider::Grok
+        )
+    }
+}
+
+impl fmt::Display for Provider {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl FromStr for Provider {
+    type Err = ProviderParseError;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        Provider::parse(value)
     }
 }
 

--- a/crates/orbit-common/src/types/activity_job/mod.rs
+++ b/crates/orbit-common/src/types/activity_job/mod.rs
@@ -11,7 +11,7 @@ pub mod tool_allowlist;
 
 pub use activity_v2::{
     ActivityV2, ActivityV2Spec, AgentLoopSpec, AgentRole, Backend, DeterministicSpec,
-    GroundhogSpec, OnDenial, Provider,
+    GroundhogSpec, OnDenial, Provider, ProviderAlias, ProviderParseError,
 };
 pub use asset_loader::{
     ActivityAsset, AssetLoadError, JobAsset, load_activity_asset, load_job_asset,

--- a/crates/orbit-common/src/types/activity_job/tests/activity_v2.rs
+++ b/crates/orbit-common/src/types/activity_job/tests/activity_v2.rs
@@ -1,4 +1,129 @@
 use super::super::activity_v2::*;
+use serde::Deserialize;
+
+/// Pinned local copy of the Constellation provider-resolution contract
+/// (ORB-10091). The table-driven tests below assert the orbit-common `Provider`
+/// surface against every row so canonical ids, aliases, and capability
+/// predicates cannot drift from the shared contract.
+const CONTRACT_JSON: &str = include_str!("fixtures/provider_contract.json");
+
+#[derive(Debug, Deserialize)]
+struct ProviderContract {
+    contract_version: String,
+    providers: Vec<ProviderRow>,
+    unknown_provider_examples: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ProviderRow {
+    canonical: String,
+    aliases: Vec<String>,
+    has_cli_runtime: bool,
+    has_http_transport: bool,
+    worker_executable: bool,
+}
+
+fn load_contract() -> ProviderContract {
+    serde_json::from_str(CONTRACT_JSON).expect("parse pinned provider contract fixture")
+}
+
+#[test]
+fn provider_contract_fixture_is_pinned() {
+    let contract = load_contract();
+    // Pin the version so an upstream contract change forces a conscious bump.
+    assert_eq!(contract.contract_version, "1.0.0");
+    // Every canonical variant must appear exactly once; adding a `Provider`
+    // variant without a fixture row (or vice-versa) fails here.
+    assert_eq!(contract.providers.len(), Provider::ALL.len());
+}
+
+#[test]
+fn provider_surface_matches_contract_rows() {
+    let contract = load_contract();
+    for row in &contract.providers {
+        let provider = Provider::parse(&row.canonical)
+            .unwrap_or_else(|_| panic!("canonical id '{}' must parse", row.canonical));
+        assert_eq!(provider.as_str(), row.canonical, "as_str round-trip");
+        assert_eq!(provider.to_string(), row.canonical, "Display round-trip");
+        assert_eq!(
+            provider.has_cli_runtime(),
+            row.has_cli_runtime,
+            "has_cli_runtime for {}",
+            row.canonical
+        );
+        assert_eq!(
+            provider.has_http_transport(),
+            row.has_http_transport,
+            "has_http_transport for {}",
+            row.canonical
+        );
+        assert_eq!(
+            provider.is_worker_executable(),
+            row.worker_executable,
+            "is_worker_executable for {}",
+            row.canonical
+        );
+        for alias in &row.aliases {
+            assert_eq!(
+                Provider::parse(alias).expect("alias must parse"),
+                provider,
+                "alias '{alias}' resolves to {}",
+                row.canonical
+            );
+        }
+    }
+}
+
+#[test]
+fn provider_parse_normalizes_case_and_whitespace() {
+    for (raw, expected) in [
+        ("  claude ", Provider::Claude),
+        ("CLAUDE", Provider::Claude),
+        ("Codex", Provider::Codex),
+        ("OPENAI_COMPAT", Provider::OpenaiCompat),
+        ("openai-compat", Provider::OpenaiCompat),
+        (" OpenAI-Compat ", Provider::OpenaiCompat),
+    ] {
+        assert_eq!(Provider::parse(raw).expect("parse"), expected, "raw={raw}");
+    }
+}
+
+#[test]
+fn provider_parse_rejects_unknown_without_fallback() {
+    let contract = load_contract();
+    for raw in &contract.unknown_provider_examples {
+        let err = Provider::parse(raw)
+            .expect_err("unknown provider must not resolve to a default runtime");
+        assert_eq!(&err.raw, raw, "error preserves the offending raw input");
+        // Diagnostic lists the canonical set and never coerces to a default.
+        assert!(
+            err.to_string().contains(Provider::CANONICAL_LIST),
+            "diagnostic for {raw:?} lists canonical providers"
+        );
+    }
+}
+
+#[test]
+fn provider_from_str_matches_parse() {
+    assert_eq!("grok".parse::<Provider>().expect("FromStr"), Provider::Grok);
+    assert!("nope".parse::<Provider>().is_err());
+}
+
+#[test]
+fn provider_alias_table_resolves_and_flags_deprecation() {
+    for alias in Provider::ALIASES {
+        assert_eq!(
+            Provider::parse(alias.alias).expect("alias must parse"),
+            alias.canonical
+        );
+        // The only shipped alias is a spelling variant, not a deprecated name.
+        assert!(
+            !alias.deprecated,
+            "alias '{}' unexpectedly deprecated",
+            alias.alias
+        );
+    }
+}
 
 #[test]
 fn agent_role_serde_roundtrips_lowercase() {

--- a/crates/orbit-common/src/types/activity_job/tests/fixtures/provider_contract.json
+++ b/crates/orbit-common/src/types/activity_job/tests/fixtures/provider_contract.json
@@ -1,0 +1,51 @@
+{
+  "contract": "constellation-provider-resolution",
+  "contract_version": "1.0.0",
+  "source": "Polaris ORB-10089 (contract from ORB-10058); Orbit consumer ORB-10091",
+  "note": "Pinned local copy of the shared Constellation provider-identity contract. Cross-workspace dependencies are intentionally NOT encoded, so this file is the Orbit-side source of truth. Bump contract_version and update the rows whenever the upstream Polaris contract changes; the table-driven tests in tests/activity_v2.rs assert the orbit-common Provider surface against every row.",
+  "providers": [
+    {
+      "canonical": "claude",
+      "aliases": [],
+      "has_cli_runtime": true,
+      "has_http_transport": true,
+      "worker_executable": true
+    },
+    {
+      "canonical": "codex",
+      "aliases": [],
+      "has_cli_runtime": true,
+      "has_http_transport": false,
+      "worker_executable": true
+    },
+    {
+      "canonical": "gemini",
+      "aliases": [],
+      "has_cli_runtime": true,
+      "has_http_transport": false,
+      "worker_executable": true
+    },
+    {
+      "canonical": "grok",
+      "aliases": [],
+      "has_cli_runtime": true,
+      "has_http_transport": false,
+      "worker_executable": true
+    },
+    {
+      "canonical": "ollama",
+      "aliases": [],
+      "has_cli_runtime": true,
+      "has_http_transport": false,
+      "worker_executable": false
+    },
+    {
+      "canonical": "openai_compat",
+      "aliases": ["openai-compat"],
+      "has_cli_runtime": false,
+      "has_http_transport": false,
+      "worker_executable": false
+    }
+  ],
+  "unknown_provider_examples": ["", "   ", "anthropic", "openai", "gpt", "claude-3", "grokk"]
+}

--- a/crates/orbit-core/src/runtime/engine/environment_host.rs
+++ b/crates/orbit-core/src/runtime/engine/environment_host.rs
@@ -72,7 +72,10 @@ pub(crate) fn typed_role_config_from_assignment(
     raw: &CrewRoleAssignment,
 ) -> AgentRoleConfig {
     let provider = Some(raw.provider.as_str()).and_then(|raw_value| {
-        let parsed = parse_provider(raw_value);
+        // Canonical string→provider parsing lives on the orbit-common `Provider`
+        // surface (ORB-10091); the crew path routes through it so casing/alias
+        // handling cannot drift from the other layers.
+        let parsed = Provider::parse(raw_value).ok();
         if parsed.is_none() {
             tracing::warn!(
                 target: "orbit.config.crew",
@@ -104,18 +107,6 @@ pub(crate) fn typed_role_config_from_assignment(
         provider,
         model,
         backend,
-    }
-}
-
-fn parse_provider(raw: &str) -> Option<Provider> {
-    match raw.trim() {
-        "claude" => Some(Provider::Claude),
-        "codex" => Some(Provider::Codex),
-        "gemini" => Some(Provider::Gemini),
-        "grok" => Some(Provider::Grok),
-        "ollama" => Some(Provider::Ollama),
-        "openai_compat" | "openai-compat" => Some(Provider::OpenaiCompat),
-        _ => None,
     }
 }
 

--- a/crates/orbit-core/src/runtime/v2_host/cli_executor.rs
+++ b/crates/orbit-core/src/runtime/v2_host/cli_executor.rs
@@ -1,4 +1,5 @@
 use orbit_common::types::ExecutorType;
+use orbit_common::types::activity_job::Provider;
 use orbit_engine::{DispatchError, ResolvedCliExecutor};
 
 use crate::OrbitRuntime;
@@ -57,16 +58,21 @@ pub(super) fn resolve_cli_executor(
         });
     }
 
-    match provider {
-        "claude" | "codex" | "gemini" | "grok" | "ollama" => Ok(ResolvedCliExecutor {
-            command: provider.to_string(),
+    // Canonical provider identity + capability live on the orbit-common
+    // `Provider` surface (ORB-10091). Selecting a provider that parses but has
+    // no CLI runtime (`openai_compat`, HTTP-only) or does not parse at all
+    // fails with a stable diagnostic and never silently falls back to a
+    // different runtime.
+    match Provider::parse(provider) {
+        Ok(parsed) if parsed.has_cli_runtime() => Ok(ResolvedCliExecutor {
+            command: parsed.as_str().to_string(),
             args: Vec::new(),
         }),
-        "openai_compat" => Err(DispatchError::CliInvocationFailed(
-            "provider openai_compat has no CLI runtime (HTTP-only)".to_string(),
-        )),
-        other => Err(DispatchError::CliInvocationFailed(format!(
-            "unknown provider `{other}` — no CLI runtime registered"
+        Ok(parsed) => Err(DispatchError::CliInvocationFailed(format!(
+            "provider {parsed} has no CLI runtime (HTTP-only)"
+        ))),
+        Err(err) => Err(DispatchError::CliInvocationFailed(format!(
+            "{err} — no CLI runtime registered"
         ))),
     }
 }
@@ -89,5 +95,44 @@ mod tests {
 
         assert_eq!(resolved.command, "codex");
         assert_eq!(resolved.args, ["exec", "--json"]);
+    }
+
+    /// Table-driven coverage of executor selection through the centralized
+    /// `Provider` surface (ORB-10091): every provider that ships a CLI runtime
+    /// resolves to a command named after its canonical id; a provider that
+    /// parses but is HTTP-only (`openai_compat`) and a provider that does not
+    /// parse both fail with a stable diagnostic and never fall back.
+    #[test]
+    fn cli_executor_selection_diagnostics_table() {
+        let runtime = OrbitRuntime::in_memory().expect("build runtime");
+
+        for provider in ["claude", "codex", "gemini", "grok", "ollama"] {
+            let resolved = runtime
+                .resolve_cli_executor(provider)
+                .unwrap_or_else(|err| panic!("{provider} should resolve: {err:?}"));
+            assert_eq!(resolved.command, provider, "command for {provider}");
+            assert!(resolved.args.is_empty(), "fallback args for {provider}");
+        }
+
+        let http_only = runtime
+            .resolve_cli_executor("openai_compat")
+            .expect_err("openai_compat is HTTP-only and must not fall back to CLI");
+        assert!(
+            format!("{http_only:?}").contains("no CLI runtime (HTTP-only)"),
+            "http-only diagnostic: {http_only:?}"
+        );
+
+        let unknown = runtime
+            .resolve_cli_executor("bogus_provider")
+            .expect_err("unknown provider must not resolve to a default runtime");
+        let msg = format!("{unknown:?}");
+        assert!(
+            msg.contains("unknown provider"),
+            "unknown diagnostic: {msg}"
+        );
+        assert!(
+            msg.contains("no CLI runtime registered"),
+            "unknown diagnostic: {msg}"
+        );
     }
 }

--- a/crates/orbit-engine/src/activity_job/tests/agent_role.rs
+++ b/crates/orbit-engine/src/activity_job/tests/agent_role.rs
@@ -61,6 +61,97 @@ fn full_override_replaces_every_field() {
     assert_eq!(resolved.backend, Backend::Http);
 }
 
+/// Table-driven coverage of the field-by-field crew-override precedence
+/// (ORB-10091). Each row states the crew-config override and the expected
+/// resolved triple against a fixed `Provider::Claude` inline spec. The rows
+/// where `config.provider` is `None` assert the persisted/inline provider
+/// identity is preserved and never re-defaulted to `Provider::default()`.
+#[test]
+fn resolve_from_config_precedence_table() {
+    struct Row {
+        name: &'static str,
+        config: Option<AgentRoleConfig>,
+        expect_provider: Provider,
+        expect_model: Option<&'static str>,
+        expect_backend: Backend,
+    }
+
+    let rows = [
+        Row {
+            name: "no crew config -> inline preserved",
+            config: None,
+            expect_provider: Provider::Claude,
+            expect_model: Some(TEST_CLAUDE_MODEL),
+            expect_backend: Backend::Cli,
+        },
+        Row {
+            name: "provider-only override keeps inline model + backend",
+            config: Some(AgentRoleConfig {
+                provider: Some(Provider::Codex),
+                model: None,
+                backend: None,
+            }),
+            expect_provider: Provider::Codex,
+            expect_model: Some(TEST_CLAUDE_MODEL),
+            expect_backend: Backend::Cli,
+        },
+        Row {
+            name: "full override replaces every field",
+            config: Some(AgentRoleConfig {
+                provider: Some(Provider::Codex),
+                model: Some(TEST_CODEX_MODEL.to_string()),
+                backend: Some(Backend::Http),
+            }),
+            expect_provider: Provider::Codex,
+            expect_model: Some(TEST_CODEX_MODEL),
+            expect_backend: Backend::Http,
+        },
+        Row {
+            name: "model-only override preserves persisted provider",
+            config: Some(AgentRoleConfig {
+                provider: None,
+                model: Some(TEST_CODEX_MODEL.to_string()),
+                backend: None,
+            }),
+            expect_provider: Provider::Claude,
+            expect_model: Some(TEST_CODEX_MODEL),
+            expect_backend: Backend::Cli,
+        },
+        Row {
+            name: "backend-only override preserves persisted provider + model",
+            config: Some(AgentRoleConfig {
+                provider: None,
+                model: None,
+                backend: Some(Backend::Http),
+            }),
+            expect_provider: Provider::Claude,
+            expect_model: Some(TEST_CLAUDE_MODEL),
+            expect_backend: Backend::Http,
+        },
+    ];
+
+    let inline = inline_spec();
+    for row in rows {
+        let resolved = resolve_from_config(row.config.as_ref(), &inline);
+        assert_eq!(
+            resolved.provider, row.expect_provider,
+            "provider: {}",
+            row.name
+        );
+        assert_eq!(
+            resolved.model.as_deref(),
+            row.expect_model,
+            "model: {}",
+            row.name
+        );
+        assert_eq!(
+            resolved.backend, row.expect_backend,
+            "backend: {}",
+            row.name
+        );
+    }
+}
+
 #[test]
 fn apply_mutates_spec_in_place() {
     let mut spec = inline_spec();

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -39,7 +39,7 @@ A **crew** assigns models to the three roles in the ship pipeline: `planner`, `i
 | Field | Purpose | Values |
 |---|---|---|
 | `model` | Model identifier passed to the provider CLI | Provider-specific (e.g. `opus`, `sonnet`, `gpt-5.5`, `pro`, `grok-build`) |
-| `provider` | Agent family | `claude`, `codex`, `gemini`, `grok` |
+| `provider` | Agent family | `claude`, `codex`, `gemini`, `grok` (the CLI-executable families; see [Provider identity and resolution](#provider-identity-and-resolution) for the full canonical set) |
 | `backend` | How Orbit dispatches the agent | `cli` (today the only supported value for these roles) |
 
 Example — a single-family Codex crew:
@@ -59,6 +59,47 @@ You can define any number of crews. Set the workspace-wide fallback with `workfl
 Crews are validated at load time: each role must have non-empty `model`, `provider`, and `backend`; `workflow.default_crew` must name a defined crew.
 
 > **Note.** Earlier Orbit versions used `[agent.<role>]` tables. That schema was removed in [ORB-00058](../.orbit/) — config load now hard-errors if `[agent.*]` is present. Migrate to `[crews.<name>]` + `workflow.default_crew`.
+
+---
+
+## Provider identity and resolution
+
+Every `provider` string Orbit reads — in `[crews.<name>]` roles, in an activity's inline `provider`, and in setup detection — is parsed through **one canonical surface** (`orbit_common::types::activity_job::Provider`, ORB-10091). Centralizing parsing means the crew layer, the agent-role resolver, the CLI executor, and reconciliation cannot disagree with each other or with Worker/Bridge about what a provider name means.
+
+### Canonical providers
+
+| Canonical id | Aliases | CLI runtime | HTTP transport | Worker-executable |
+|---|---|---|---|---|
+| `claude` | — | yes | yes | yes |
+| `codex` | — | yes | no | yes |
+| `gemini` | — | yes | no | yes |
+| `grok` | — | yes | no | yes |
+| `ollama` | — | yes | no | **no** |
+| `openai_compat` | `openai-compat` | **no** (HTTP-only) | no | **no** |
+
+- **Parsing is case- and whitespace-insensitive.** `Claude`, `  claude `, and `CLAUDE` all resolve to `claude`. Aliases (e.g. `openai-compat`) normalize to their canonical id.
+- **Canonical ≠ Worker-executable.** Orbit's canonical set is deliberately wider than what the model-neutral Worker leaf executor can run: `ollama` and `openai_compat` are first-class Orbit providers but Worker does not execute them. This distinction is preserved on purpose — do not narrow the canonical set to Worker's subset.
+- **`openai_compat` is HTTP-only.** It has no CLI runtime, so selecting it with `backend = "cli"` fails structurally (see below) rather than falling back.
+
+### Resolution precedence
+
+For a role's effective `(provider, model, backend)` the resolver applies, per field:
+
+1. **Explicit** value on the activity/step (inline spec).
+2. **Task crew** — `task.crew` on the task artifact.
+3. **Workspace default crew** — `[workflow].default_crew`.
+4. **Environment / system default** — what `orbit init`'s detection seeds when nothing above is set.
+
+A field is only overridden by a lower-precedence layer when that layer supplies a value; an override that omits a field (e.g. a crew role that sets `model` but leaves `provider` unparseable) leaves the higher-precedence value in place. This is why **persisted provider identity is never re-defaulted** during reconciliation: a resolved provider already recorded on a run is preserved, not silently reset to the enum default.
+
+### No silent fallback
+
+Explicit selections that are unsupported or unavailable **fail with a stable diagnostic and never fall back** to a different runtime:
+
+- `provider openai_compat has no CLI runtime (HTTP-only)` — a CLI-executable dispatch selected an HTTP-only provider.
+- `unknown provider '<x>'; expected one of claude, codex, gemini, grok, ollama, openai_compat — no CLI runtime registered` — the provider string did not resolve to a canonical id.
+
+An **unrecognized `[crews.<name>].provider` value** is the one non-fatal case: it is logged (`orbit.config.crew` warn) and that field falls back to the activity's inline `provider`, because a config typo should not coerce dispatch onto a wrong runtime — the inline value is the known-good identity, not a default guess.
 
 ---
 


### PR DESCRIPTION
## Task

[ORB-10091](https://orbit-cli.com/tasks/ORB-10091) — Unify Orbit provider identity and resolution with the Constellation contract

### Description

## Problem
Orbit parses and defaults providers in multiple layers: the Provider enum, environment/crew parsing, role resolution, CLI-executor lookup, setup detection, and reconciliation/display paths. These branches can disagree with Worker and Bridge.

## Scope
Implement Orbit's consumer of the Polaris provider-resolution contract created from ORB-10058. Centralize canonical parsing and alias normalization on the provider identity surface, apply the documented precedence to task/crew/workspace/default paths, preserve persisted provider identity during reconciliation, and expose stable diagnostics without silent fallback.

## Constraints / Notes
- Orbit's canonical provider set includes capabilities not executable by Worker, including ollama and openai_compat; preserve that distinction.
- Avoid a new cross-crate dependency unless ARCHITECTURE.md permits it; prefer the existing orbit-common provider type as the shared Rust surface.
- Maintain existing crew semantics except where they conflict with the canonical precedence.
- Tests must consume or pin the shared contract fixture.
- Coordinate against Polaris contract task ORB-10089; cross-workspace dependencies are intentionally not encoded.

### Acceptance Criteria

- Provider parsing, canonical IDs, and aliases are centralized on one Orbit surface and all affected crew/runtime paths use it.
- Task crew, workspace default crew, environment/system default, explicit provider, and persisted reconciliation follow the documented precedence.
- Explicit unsupported or unavailable selections fail with stable diagnostics and never fall back.
- Table-driven Rust tests cover the shared contract rows across Provider parsing, agent-role resolution, CLI executor selection, and reconciliation-relevant paths.
- `make ci-fast` passes locally and the full CI workflow passes on the PR; docs/CONFIG.md describes the effective behavior.

## Execution Summary

<details>
<summary>Click to expand</summary>

Centralized Orbit's provider identity/resolution on the single orbit-common `Provider` surface (ORB-10091) and routed the affected crew/runtime paths through it.

What changed:
- crates/orbit-common/src/types/activity_job/activity_v2.rs: added the canonical parse/normalize surface to `Provider` — `Provider::parse` (trim + ascii-lowercase, alias-aware, returns typed `ProviderParseError` with the offending raw string, never falls back), `FromStr`, `Display`, `Provider::ALL`, `Provider::ALIASES` (table-driven `ProviderAlias { alias, canonical, deprecated }`; ships `openai-compat`), `CANONICAL_LIST`, and capability predicates `has_cli_runtime()` (false only for openai_compat) and `is_worker_executable()` (claude/codex/gemini/grok only — preserves the Orbit>Worker distinction for ollama/openai_compat). Kept existing `as_str`/`has_http_transport`.
- crates/orbit-common/src/types/activity_job/mod.rs: re-export `ProviderParseError` and `ProviderAlias`.
- crates/orbit-core/src/runtime/engine/environment_host.rs: crew-role provider parsing now calls `Provider::parse(...).ok()`; removed the duplicate local `parse_provider` match (unrecognized crew provider still warns on `orbit.config.crew` and falls back to the inline activity provider, the known-good identity).
- crates/orbit-core/src/runtime/v2_host/cli_executor.rs: CLI-executor fallback selection routes through `Provider::parse` + `has_cli_runtime()`; HTTP-only (openai_compat) and unparseable providers fail with stable diagnostics and never fall back. Registered-executor-def and env-override paths preserved.
- docs/CONFIG.md: new 'Provider identity and resolution' section — canonical set table (CLI/HTTP/Worker-executable columns), case/alias normalization, the explicit>task-crew>workspace-default>env-default precedence, persisted-identity-never-re-defaulted, and the no-silent-fallback diagnostics; crews table `provider` cell links to it.

Contract fixture + tests (table-driven):
- New pinned fixture crates/orbit-common/src/types/activity_job/tests/fixtures/provider_contract.json (contract_version 1.0.0). Cross-workspace deps to Polaris (ORB-10089/ORB-10058) are intentionally NOT encoded, so this is the Orbit-side pinned copy; a version-pin test forces a conscious bump when the upstream contract changes.
- orbit-common tests/activity_v2.rs: 6 new tests asserting the Provider surface against every fixture row (as_str/Display round-trip, capability predicates, alias resolution), case/whitespace normalization, FromStr parity, and unknown-input rejection with stable diagnostics.
- orbit-engine tests/agent_role.rs: `resolve_from_config_precedence_table` — 5 rows covering field-by-field crew override precedence, incl. provider-None rows that assert persisted/inline provider identity is preserved (reconciliation-relevant, never re-defaulted).
- orbit-core cli_executor.rs: `cli_executor_selection_diagnostics_table` — CLI-capable providers resolve to canonical command; openai_compat and unknown fail with stable diagnostics, no fallback.

Scope note (beyond context_files): touched mod.rs (re-export) and cli_executor.rs (executor-selection diagnostics) — both tightly coupled to the centralization intent; no new crate edges (surface lives in orbit-common, already depended on by orbit-core/orbit-engine per ARCHITECTURE.md). Left agent_detect.rs `default_model_for` as-is (already delegates to the centralized orbit-common model_defaults).

Validation: `cargo check -p orbit-common -p orbit-core -p orbit-engine` clean; new + existing targeted tests pass (orbit-common provider ×6, orbit-engine agent_role ×5, orbit-core cli_executor ×2, orbit-core crew ×4). `cargo fmt --all --check` clean. `cargo clippy -p orbit-common -p orbit-core -p orbit-engine --all-targets` clean for changed files (the only 2 warnings are pre-existing collapsible-if in the untouched command/executor.rs). `make ci-fast`: fmt-check + check-installer-pubkey passed; the installer-security guardrail could not run because `node` is not on PATH in this sandbox (environmental, unrelated to this change) — CI runs it unrestricted.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10091-6a519841`
- Behind base: 0
- Ahead of base: 1