### PR TITLE
Complete the Constellation provider resolution contract [ORB-10091]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -578,9 +578,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/crates/orbit-agent/examples/redaction_smoke.rs
+++ b/crates/orbit-agent/examples/redaction_smoke.rs
@@ -49,14 +49,14 @@ content-type: application/json
     if stored_str.contains(secret) {
         eprintln!(
             "FAIL: stored blob contains raw secret. first 200 chars: {}",
-            &stored_str.chars().take(200).collect::<String>()
+            stored_str.chars().take(200).collect::<String>()
         );
         return ExitCode::FAILURE;
     }
     if !stored_str.contains("[REDACTED_AUTH]") {
         eprintln!(
             "FAIL: stored blob missing redaction marker. first 200 chars: {}",
-            &stored_str.chars().take(200).collect::<String>()
+            stored_str.chars().take(200).collect::<String>()
         );
         return ExitCode::FAILURE;
     }

--- a/crates/orbit-common/src/types/activity_job/activity_v2.rs
+++ b/crates/orbit-common/src/types/activity_job/activity_v2.rs
@@ -241,12 +241,46 @@ impl Provider {
         Provider::OpenaiCompat,
     ];
 
-    /// Accepted non-canonical spellings, normalized by [`Provider::parse`].
-    pub const ALIASES: &'static [ProviderAlias] = &[ProviderAlias {
-        alias: "openai-compat",
-        canonical: Provider::OpenaiCompat,
-        deprecated: false,
-    }];
+    /// Accepted non-canonical spellings, normalized by [`Provider::parse`] /
+    /// [`Provider::resolve_name`]. The five legacy **vendor** names are the
+    /// deprecated aliases from the Constellation provider-resolution contract
+    /// (§2): they resolve successfully but carry an observable deprecation
+    /// signal. `openai-compat` is a non-deprecated spelling variant of the
+    /// canonical `openai_compat` id (it is also a serde alias on the enum).
+    /// This table is **closed** — an unlisted string is `provider.unknown`,
+    /// never guessed. New aliases require a contract bump.
+    pub const ALIASES: &'static [ProviderAlias] = &[
+        ProviderAlias {
+            alias: "anthropic",
+            canonical: Provider::Claude,
+            deprecated: true,
+        },
+        ProviderAlias {
+            alias: "openai",
+            canonical: Provider::Codex,
+            deprecated: true,
+        },
+        ProviderAlias {
+            alias: "chatgpt",
+            canonical: Provider::Codex,
+            deprecated: true,
+        },
+        ProviderAlias {
+            alias: "google",
+            canonical: Provider::Gemini,
+            deprecated: true,
+        },
+        ProviderAlias {
+            alias: "xai",
+            canonical: Provider::Grok,
+            deprecated: true,
+        },
+        ProviderAlias {
+            alias: "openai-compat",
+            canonical: Provider::OpenaiCompat,
+            deprecated: false,
+        },
+    ];
 
     /// Human-readable canonical id list used in diagnostics.
     pub const CANONICAL_LIST: &'static str = "claude, codex, gemini, grok, ollama, openai_compat";
@@ -262,28 +296,52 @@ impl Provider {
         }
     }
 
-    /// Canonical parse with alias normalization. Trims surrounding whitespace
+    /// Canonical parse with alias normalization, **preserving** the observable
+    /// alias/deprecation metadata (contract §2). Trims surrounding whitespace
     /// and lower-cases before matching, so config/env casing variants resolve
-    /// to the same identity. Unknown strings return [`ProviderParseError`] —
-    /// this is the *only* string→provider entry point; callers must not invent
-    /// their own match and must not silently fall back on error.
-    pub fn parse(raw: &str) -> Result<Provider, ProviderParseError> {
+    /// to the same identity (`"  OpenAI "` → `codex` + deprecation signal).
+    /// Unknown strings return [`ProviderParseError`] — this is the *only*
+    /// string→provider entry point; callers must not invent their own match and
+    /// must not silently fall back on error.
+    ///
+    /// Prefer this over [`Provider::parse`] wherever the caller can surface the
+    /// deprecation (e.g. a config warn-log): `parse` discards the signal.
+    pub fn resolve_name(raw: &str) -> Result<ProviderIdentity, ProviderParseError> {
         let normalized = raw.trim().to_ascii_lowercase();
         if let Some(provider) = Provider::ALL
             .into_iter()
             .find(|provider| provider.as_str() == normalized)
         {
-            return Ok(provider);
+            return Ok(ProviderIdentity {
+                provider,
+                deprecation: None,
+            });
         }
         if let Some(alias) = Provider::ALIASES
             .iter()
             .find(|alias| alias.alias == normalized)
         {
-            return Ok(alias.canonical);
+            let deprecation = alias.deprecated.then(|| ProviderDeprecation {
+                // The signal carries the normalized alias spelling, not the raw
+                // casing, so `"OpenAI"` and `"openai"` produce the same signal.
+                alias: normalized.clone(),
+                canonical: alias.canonical,
+            });
+            return Ok(ProviderIdentity {
+                provider: alias.canonical,
+                deprecation,
+            });
         }
         Err(ProviderParseError {
             raw: raw.to_string(),
         })
+    }
+
+    /// Canonical parse that discards alias/deprecation metadata. Thin wrapper
+    /// over [`Provider::resolve_name`] for the many call sites that only need
+    /// the canonical identity. Same normalization and same no-fallback error.
+    pub fn parse(raw: &str) -> Result<Provider, ProviderParseError> {
+        Provider::resolve_name(raw).map(|identity| identity.provider)
     }
 
     /// Whether Phase 2c wires an HTTP transport for this provider. Used by the
@@ -326,6 +384,271 @@ impl FromStr for Provider {
     fn from_str(value: &str) -> Result<Self, Self::Err> {
         Provider::parse(value)
     }
+}
+
+/// A resolved provider identity plus any observable deprecation signal emitted
+/// while normalizing a legacy alias (contract §2). Returned by
+/// [`Provider::resolve_name`] so callers can warn on a deprecated alias without
+/// losing the fact that normalization occurred.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProviderIdentity {
+    /// The canonical provider the input normalized to.
+    pub provider: Provider,
+    /// `Some` when the input was a **deprecated** alias; `None` for a canonical
+    /// id or a non-deprecated spelling variant.
+    pub deprecation: Option<ProviderDeprecation>,
+}
+
+/// Observable deprecation signal: a legacy alias was normalized to a canonical
+/// provider. Resolution still succeeds (contract §2); callers surface this as a
+/// warning carrying `{alias, canonical}`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProviderDeprecation {
+    /// The normalized (trimmed, lower-cased) alias spelling that was accepted.
+    pub alias: String,
+    /// The canonical provider it resolved to.
+    pub canonical: Provider,
+}
+
+/// Which entry point's capability set applies during full resolution
+/// (contract §5). The canonical four providers are executable at every entry
+/// point; `ollama` / `openai_compat` are known Orbit identities that no CLI
+/// entry point can execute.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ProviderEntryPoint {
+    Orbit,
+    Worker,
+    Bridge,
+}
+
+/// The precedence tier that supplied the resolved value (contract §3).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ProviderSource {
+    Explicit,
+    TaskConfig,
+    WorkspaceDefault,
+    EnvironmentDefault,
+    SystemDefault,
+    PersistedReconciliation,
+}
+
+impl ProviderSource {
+    /// Stable contract spelling used in diagnostics / conformance assertions.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            ProviderSource::Explicit => "explicit",
+            ProviderSource::TaskConfig => "task_config",
+            ProviderSource::WorkspaceDefault => "workspace_default",
+            ProviderSource::EnvironmentDefault => "environment_default",
+            ProviderSource::SystemDefault => "system_default",
+            ProviderSource::PersistedReconciliation => "persisted_reconciliation",
+        }
+    }
+}
+
+/// Stable diagnostic code for a resolution outcome (contract §6). Each repo
+/// maps its native error/log to the shared code; conformance asserts the code,
+/// not the wording.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ProviderDiagnostic {
+    Ok,
+    Defaulted,
+    AliasDeprecated,
+    Unknown,
+    Unsupported,
+    Unavailable,
+}
+
+impl ProviderDiagnostic {
+    /// Stable contract code string (e.g. `"provider.alias_deprecated"`).
+    pub fn as_str(self) -> &'static str {
+        match self {
+            ProviderDiagnostic::Ok => "provider.ok",
+            ProviderDiagnostic::Defaulted => "provider.defaulted",
+            ProviderDiagnostic::AliasDeprecated => "provider.alias_deprecated",
+            ProviderDiagnostic::Unknown => "provider.unknown",
+            ProviderDiagnostic::Unsupported => "provider.unsupported",
+            ProviderDiagnostic::Unavailable => "provider.unavailable",
+        }
+    }
+
+    /// Whether the diagnostic represents a successful resolution (§6).
+    pub fn is_success(self) -> bool {
+        matches!(
+            self,
+            ProviderDiagnostic::Ok
+                | ProviderDiagnostic::Defaulted
+                | ProviderDiagnostic::AliasDeprecated
+        )
+    }
+}
+
+/// Inputs to a single provider resolution (contract §8). Every tier is an
+/// optional raw string (empty / whitespace-only counts as "not selected" and
+/// falls through, not an error). `host_available` is `None` when availability
+/// is not exercised.
+#[derive(Debug, Clone)]
+pub struct ProviderResolveRequest<'a> {
+    pub entry_point: ProviderEntryPoint,
+    pub requested: Option<&'a str>,
+    pub task_provider: Option<&'a str>,
+    pub workspace_default: Option<&'a str>,
+    pub env_default: Option<&'a str>,
+    pub system_default: Option<&'a str>,
+    pub persisted_resolution: Option<&'a str>,
+    pub host_available: Option<bool>,
+}
+
+impl ProviderResolveRequest<'_> {
+    /// A request with only the entry point set; fill tiers with struct-update
+    /// syntax (`ProviderResolveRequest { requested: Some(x), ..base }`).
+    pub fn new(entry_point: ProviderEntryPoint) -> Self {
+        Self {
+            entry_point,
+            requested: None,
+            task_provider: None,
+            workspace_default: None,
+            env_default: None,
+            system_default: None,
+            persisted_resolution: None,
+            host_available: None,
+        }
+    }
+}
+
+/// Outcome of a provider resolution (contract §8): the normalized identity (or
+/// `None` on `provider.unknown`), the tier it came from, the stable diagnostic,
+/// and any deprecation signal.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProviderResolution {
+    pub normalized_provider: Option<Provider>,
+    pub source: ProviderSource,
+    pub diagnostic: ProviderDiagnostic,
+    pub deprecation: Option<ProviderDeprecation>,
+}
+
+impl ProviderResolution {
+    /// Whether resolution succeeded (identity usable for dispatch).
+    pub fn is_success(&self) -> bool {
+        self.diagnostic.is_success()
+    }
+}
+
+impl Provider {
+    /// Providers this entry point can execute (contract §5 capability set). The
+    /// canonical four are executable everywhere; `ollama` / `openai_compat` are
+    /// known but unsupported at every CLI entry point — the identity resolves,
+    /// only execution capability is missing.
+    pub fn capabilities(_entry_point: ProviderEntryPoint) -> &'static [Provider] {
+        const CANONICAL: [Provider; 4] = [
+            Provider::Claude,
+            Provider::Codex,
+            Provider::Gemini,
+            Provider::Grok,
+        ];
+        &CANONICAL
+    }
+
+    /// Full contract resolution (§8): reconciliation short-circuit, then
+    /// precedence (§3), alias normalization (§2), and identity → capability →
+    /// availability checks (§5) — never falling back to another provider. This
+    /// is the surface the vendored conformance cases assert against, so Orbit
+    /// stays in parity with Worker and Bridge.
+    pub fn resolve(request: &ProviderResolveRequest<'_>) -> ProviderResolution {
+        // Reconciliation short-circuit: a frozen resolution is reused verbatim
+        // and precedence is not re-run (§7).
+        if let Some(persisted) = non_empty(request.persisted_resolution) {
+            // A persisted identity is already canonical; if it somehow fails to
+            // parse we surface `unknown` rather than inventing a fallback.
+            return match Provider::parse(persisted) {
+                Ok(provider) => ProviderResolution {
+                    normalized_provider: Some(provider),
+                    source: ProviderSource::PersistedReconciliation,
+                    diagnostic: ProviderDiagnostic::Ok,
+                    deprecation: None,
+                },
+                Err(_) => ProviderResolution {
+                    normalized_provider: None,
+                    source: ProviderSource::PersistedReconciliation,
+                    diagnostic: ProviderDiagnostic::Unknown,
+                    deprecation: None,
+                },
+            };
+        }
+
+        // Precedence: first non-empty tier wins (§3).
+        let tiers = [
+            (request.requested, ProviderSource::Explicit),
+            (request.task_provider, ProviderSource::TaskConfig),
+            (request.workspace_default, ProviderSource::WorkspaceDefault),
+            (request.env_default, ProviderSource::EnvironmentDefault),
+            (request.system_default, ProviderSource::SystemDefault),
+        ];
+        let Some((raw, source)) = tiers
+            .into_iter()
+            .find_map(|(value, source)| non_empty(value).map(|raw| (raw, source)))
+        else {
+            // No tier supplied a value. The contract always provides a system
+            // default (canonical `claude`); treat an absent one as that so
+            // resolution is total.
+            return ProviderResolution {
+                normalized_provider: Some(Provider::default()),
+                source: ProviderSource::SystemDefault,
+                diagnostic: ProviderDiagnostic::Defaulted,
+                deprecation: None,
+            };
+        };
+
+        // Normalize (§2), then identity → capability → availability (§5).
+        let identity = match Provider::resolve_name(raw) {
+            Ok(identity) => identity,
+            Err(_) => {
+                return ProviderResolution {
+                    normalized_provider: None,
+                    source,
+                    diagnostic: ProviderDiagnostic::Unknown,
+                    deprecation: None,
+                };
+            }
+        };
+
+        if !Provider::capabilities(request.entry_point).contains(&identity.provider) {
+            return ProviderResolution {
+                normalized_provider: Some(identity.provider),
+                source,
+                diagnostic: ProviderDiagnostic::Unsupported,
+                deprecation: None,
+            };
+        }
+
+        if request.host_available == Some(false) {
+            return ProviderResolution {
+                normalized_provider: Some(identity.provider),
+                source,
+                diagnostic: ProviderDiagnostic::Unavailable,
+                deprecation: None,
+            };
+        }
+
+        let diagnostic = if identity.deprecation.is_some() {
+            ProviderDiagnostic::AliasDeprecated
+        } else if source == ProviderSource::Explicit {
+            ProviderDiagnostic::Ok
+        } else {
+            ProviderDiagnostic::Defaulted
+        };
+        ProviderResolution {
+            normalized_provider: Some(identity.provider),
+            source,
+            diagnostic,
+            deprecation: identity.deprecation,
+        }
+    }
+}
+
+/// Trim a tier value and treat empty / whitespace-only as "not selected" (§3).
+fn non_empty(value: Option<&str>) -> Option<&str> {
+    value.map(str::trim).filter(|value| !value.is_empty())
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]

--- a/crates/orbit-common/src/types/activity_job/mod.rs
+++ b/crates/orbit-common/src/types/activity_job/mod.rs
@@ -11,7 +11,9 @@ pub mod tool_allowlist;
 
 pub use activity_v2::{
     ActivityV2, ActivityV2Spec, AgentLoopSpec, AgentRole, Backend, DeterministicSpec,
-    GroundhogSpec, OnDenial, Provider, ProviderAlias, ProviderParseError,
+    GroundhogSpec, OnDenial, Provider, ProviderAlias, ProviderDeprecation, ProviderDiagnostic,
+    ProviderEntryPoint, ProviderIdentity, ProviderParseError, ProviderResolution,
+    ProviderResolveRequest, ProviderSource,
 };
 pub use asset_loader::{
     ActivityAsset, AssetLoadError, JobAsset, load_activity_asset, load_job_asset,

--- a/crates/orbit-common/src/types/activity_job/tests/activity_v2.rs
+++ b/crates/orbit-common/src/types/activity_job/tests/activity_v2.rs
@@ -1,104 +1,168 @@
 use super::super::activity_v2::*;
-use serde::Deserialize;
+use serde_json::Value;
+use sha2::{Digest, Sha256};
 
-/// Pinned local copy of the Constellation provider-resolution contract
-/// (ORB-10091). The table-driven tests below assert the orbit-common `Provider`
-/// surface against every row so canonical ids, aliases, and capability
-/// predicates cannot drift from the shared contract.
+/// Exact vendored copy of the Constellation provider-resolution contract cases
+/// (Polaris `rules/provider-resolution-cases.json`, ORB-10091) — byte-for-byte,
+/// so the embedded `cases_sha256` stays valid and the Orbit resolver can be
+/// asserted against the same rows as Worker and Bridge.
 const CONTRACT_JSON: &str = include_str!("fixtures/provider_contract.json");
 
-#[derive(Debug, Deserialize)]
-struct ProviderContract {
-    contract_version: String,
-    providers: Vec<ProviderRow>,
-    unknown_provider_examples: Vec<String>,
+/// Pinned contract identity. Drift in the upstream contract changes the hash and
+/// fails `provider_contract_hash_is_pinned` loudly, forcing a reviewed pin bump.
+const PINNED_CONTRACT_VERSION: &str = "1.0.0";
+const PINNED_CASES_SHA256: &str =
+    "191058b435063a905943c9ef6779683e2b273ae0a0a338464419c74708d67cfe";
+
+fn contract() -> Value {
+    serde_json::from_str(CONTRACT_JSON).expect("parse vendored provider contract fixture")
 }
 
-#[derive(Debug, Deserialize)]
-struct ProviderRow {
-    canonical: String,
-    aliases: Vec<String>,
-    has_cli_runtime: bool,
-    has_http_transport: bool,
-    worker_executable: bool,
+fn sha256_hex(bytes: &[u8]) -> String {
+    use std::fmt::Write;
+    let digest = Sha256::digest(bytes);
+    let mut hex = String::with_capacity(digest.len() * 2);
+    for byte in digest {
+        let _ = write!(hex, "{byte:02x}");
+    }
+    hex
 }
 
-fn load_contract() -> ProviderContract {
-    serde_json::from_str(CONTRACT_JSON).expect("parse pinned provider contract fixture")
+fn string_vec(value: &Value) -> Vec<String> {
+    value
+        .as_array()
+        .expect("array")
+        .iter()
+        .map(|entry| entry.as_str().expect("string entry").to_string())
+        .collect()
 }
 
 #[test]
-fn provider_contract_fixture_is_pinned() {
-    let contract = load_contract();
-    // Pin the version so an upstream contract change forces a conscious bump.
-    assert_eq!(contract.contract_version, "1.0.0");
-    // Every canonical variant must appear exactly once; adding a `Provider`
-    // variant without a fixture row (or vice-versa) fails here.
-    assert_eq!(contract.providers.len(), Provider::ALL.len());
+fn provider_contract_hash_is_pinned() {
+    let contract = contract();
+    assert_eq!(
+        contract["contract_version"].as_str(),
+        Some(PINNED_CONTRACT_VERSION),
+        "contract_version drifted; review and bump the pin",
+    );
+    // Recompute the hash the contract's way: sha256 over the canonical JSON of
+    // the `cases` array (sorted keys, compact separators). serde_json::Value
+    // serializes object keys sorted (no preserve_order feature) with `,`/`:`
+    // compact separators — byte-equal to Python's
+    // json.dumps(cases, sort_keys=True, separators=(",",":")).
+    let canonical = serde_json::to_string(&contract["cases"]).expect("serialize cases");
+    let recomputed = sha256_hex(canonical.as_bytes());
+    assert_eq!(
+        Some(recomputed.as_str()),
+        contract["cases_sha256"].as_str(),
+        "recomputed cases hash disagrees with the fixture's embedded value",
+    );
+    assert_eq!(
+        recomputed, PINNED_CASES_SHA256,
+        "cases hash drifted from the pinned contract revision",
+    );
 }
 
 #[test]
-fn provider_surface_matches_contract_rows() {
-    let contract = load_contract();
-    for row in &contract.providers {
-        let provider = Provider::parse(&row.canonical)
-            .unwrap_or_else(|_| panic!("canonical id '{}' must parse", row.canonical));
-        assert_eq!(provider.as_str(), row.canonical, "as_str round-trip");
-        assert_eq!(provider.to_string(), row.canonical, "Display round-trip");
+fn provider_capability_predicates_match_contract() {
+    let contract = contract();
+    let canonical = string_vec(&contract["canonical_providers"]);
+    let known = string_vec(&contract["known_providers"]);
+
+    // Every canonical variant maps to exactly one known-provider row; adding a
+    // `Provider` variant without a contract row (or vice-versa) fails here.
+    assert_eq!(canonical.len(), 4, "canonical set is exactly four");
+    assert_eq!(
+        Provider::ALL.len(),
+        known.len(),
+        "Provider::ALL must mirror the contract's known_providers",
+    );
+
+    for name in &known {
+        let provider =
+            Provider::parse(name).unwrap_or_else(|_| panic!("known provider '{name}' must parse"));
+        assert_eq!(provider.as_str(), name, "as_str round-trip for {name}");
+        assert_eq!(provider.to_string(), *name, "Display round-trip for {name}");
+        // Canonical == worker-executable; ollama/openai_compat are known Orbit
+        // identities Worker cannot execute (the wider-set distinction).
+        assert_eq!(
+            provider.is_worker_executable(),
+            canonical.contains(name),
+            "is_worker_executable for {name}",
+        );
+        // openai_compat is the only HTTP-only id (no CLI runtime); claude is the
+        // only id with an HTTP transport wired in Orbit today.
         assert_eq!(
             provider.has_cli_runtime(),
-            row.has_cli_runtime,
-            "has_cli_runtime for {}",
-            row.canonical
+            name != "openai_compat",
+            "has_cli_runtime for {name}",
         );
         assert_eq!(
             provider.has_http_transport(),
-            row.has_http_transport,
-            "has_http_transport for {}",
-            row.canonical
+            name == "claude",
+            "has_http_transport for {name}",
         );
-        assert_eq!(
-            provider.is_worker_executable(),
-            row.worker_executable,
-            "is_worker_executable for {}",
-            row.canonical
-        );
-        for alias in &row.aliases {
-            assert_eq!(
-                Provider::parse(alias).expect("alias must parse"),
-                provider,
-                "alias '{alias}' resolves to {}",
-                row.canonical
-            );
-        }
     }
 }
 
 #[test]
-fn provider_parse_normalizes_case_and_whitespace() {
-    for (raw, expected) in [
-        ("  claude ", Provider::Claude),
-        ("CLAUDE", Provider::Claude),
-        ("Codex", Provider::Codex),
-        ("OPENAI_COMPAT", Provider::OpenaiCompat),
-        ("openai-compat", Provider::OpenaiCompat),
-        (" OpenAI-Compat ", Provider::OpenaiCompat),
-    ] {
-        assert_eq!(Provider::parse(raw).expect("parse"), expected, "raw={raw}");
+fn provider_alias_table_matches_contract_and_signals_deprecation() {
+    let contract = contract();
+    let aliases = contract["aliases"].as_object().expect("aliases object");
+    // Every deprecated alias in the contract resolves to its canonical id AND
+    // carries an observable deprecation signal (normalized alias + canonical).
+    for (alias, canonical) in aliases {
+        let canonical = canonical.as_str().expect("canonical string");
+        let identity = Provider::resolve_name(alias)
+            .unwrap_or_else(|_| panic!("alias '{alias}' must resolve"));
+        assert_eq!(
+            identity.provider.as_str(),
+            canonical,
+            "alias {alias} -> {canonical}",
+        );
+        let deprecation = identity
+            .deprecation
+            .unwrap_or_else(|| panic!("alias '{alias}' must carry a deprecation signal"));
+        assert_eq!(&deprecation.alias, alias, "signal alias for {alias}");
+        assert_eq!(
+            deprecation.canonical.as_str(),
+            canonical,
+            "signal canonical for {alias}",
+        );
     }
+
+    // Case-insensitive + whitespace: "  OpenAI " -> codex, signal alias "openai".
+    let identity = Provider::resolve_name("  OpenAI ").expect("resolve mixed-case alias");
+    assert_eq!(identity.provider, Provider::Codex);
+    assert_eq!(
+        identity.deprecation.expect("deprecation present").alias,
+        "openai",
+    );
+
+    // Canonical ids and the non-deprecated spelling variant carry no signal.
+    assert!(
+        Provider::resolve_name("CODEX")
+            .expect("canonical")
+            .deprecation
+            .is_none(),
+    );
+    assert!(
+        Provider::resolve_name("openai-compat")
+            .expect("spelling variant")
+            .deprecation
+            .is_none(),
+    );
 }
 
 #[test]
 fn provider_parse_rejects_unknown_without_fallback() {
-    let contract = load_contract();
-    for raw in &contract.unknown_provider_examples {
+    for raw in ["", "   ", "gpt", "claude-3", "grokk", "bogus"] {
         let err = Provider::parse(raw)
             .expect_err("unknown provider must not resolve to a default runtime");
-        assert_eq!(&err.raw, raw, "error preserves the offending raw input");
-        // Diagnostic lists the canonical set and never coerces to a default.
+        assert_eq!(err.raw, raw, "error preserves the offending raw input");
         assert!(
             err.to_string().contains(Provider::CANONICAL_LIST),
-            "diagnostic for {raw:?} lists canonical providers"
+            "diagnostic for {raw:?} lists canonical providers",
         );
     }
 }
@@ -109,20 +173,89 @@ fn provider_from_str_matches_parse() {
     assert!("nope".parse::<Provider>().is_err());
 }
 
+/// The Orbit resolver must produce the same `(normalized_provider, source,
+/// diagnostic, deprecation)` as every contract row whose `entry_point` is `any`
+/// or `orbit` — the machine-checkable cross-repo parity assertion.
 #[test]
-fn provider_alias_table_resolves_and_flags_deprecation() {
-    for alias in Provider::ALIASES {
+fn resolver_matches_contract_cases_for_orbit_entry_points() {
+    let contract = contract();
+    let cases = contract["cases"].as_array().expect("cases array");
+    let mut asserted = 0usize;
+
+    for case in cases {
+        let input = &case["input"];
+        let id = case["id"].as_str().unwrap_or("<unknown>");
+
+        // A repo runs the cases whose entry_point is `any` or its own (orbit);
+        // worker/bridge-only rows are asserted by those repos.
+        let entry_point = match input["entry_point"].as_str().expect("entry_point") {
+            "any" | "orbit" => ProviderEntryPoint::Orbit,
+            "worker" | "bridge" => continue,
+            other => panic!("unexpected entry_point '{other}' in case {id}"),
+        };
+
+        let request = ProviderResolveRequest {
+            entry_point,
+            requested: input["requested"].as_str(),
+            task_provider: input["task_provider"].as_str(),
+            workspace_default: input["workspace_default"].as_str(),
+            env_default: input["env_default"].as_str(),
+            system_default: input["system_default"].as_str(),
+            persisted_resolution: input["persisted_resolution"].as_str(),
+            host_available: input["host_available"].as_bool(),
+        };
+        let got = Provider::resolve(&request);
+        let expected = &case["expected"];
+
         assert_eq!(
-            Provider::parse(alias.alias).expect("alias must parse"),
-            alias.canonical
+            got.is_success(),
+            expected["status"].as_str() == Some("success"),
+            "status: {id}",
         );
-        // The only shipped alias is a spelling variant, not a deprecated name.
-        assert!(
-            !alias.deprecated,
-            "alias '{}' unexpectedly deprecated",
-            alias.alias
+        assert_eq!(
+            got.normalized_provider.map(Provider::as_str),
+            expected["normalized_provider"].as_str(),
+            "normalized_provider: {id}",
         );
+        assert_eq!(
+            Some(got.source.as_str()),
+            expected["source"].as_str(),
+            "source: {id}",
+        );
+        assert_eq!(
+            Some(got.diagnostic.as_str()),
+            expected["diagnostic"].as_str(),
+            "diagnostic: {id}",
+        );
+        match expected["deprecation"].as_object() {
+            Some(obj) => {
+                let deprecation = got
+                    .deprecation
+                    .as_ref()
+                    .unwrap_or_else(|| panic!("expected deprecation signal: {id}"));
+                assert_eq!(
+                    Some(deprecation.alias.as_str()),
+                    obj["alias"].as_str(),
+                    "deprecation.alias: {id}",
+                );
+                assert_eq!(
+                    Some(deprecation.canonical.as_str()),
+                    obj["canonical"].as_str(),
+                    "deprecation.canonical: {id}",
+                );
+            }
+            None => assert!(got.deprecation.is_none(), "unexpected deprecation: {id}"),
+        }
+        asserted += 1;
     }
+
+    // Guardrail: every any+orbit row ran (all but the three worker-only
+    // unsupported/unavailable cases). Catches an accidental silent skip.
+    assert_eq!(
+        asserted,
+        cases.len() - 3,
+        "expected to run all any+orbit contract cases",
+    );
 }
 
 #[test]

--- a/crates/orbit-common/src/types/activity_job/tests/fixtures/provider_contract.json
+++ b/crates/orbit-common/src/types/activity_job/tests/fixtures/provider_contract.json
@@ -1,51 +1,228 @@
 {
   "contract": "constellation-provider-resolution",
   "contract_version": "1.0.0",
-  "source": "Polaris ORB-10089 (contract from ORB-10058); Orbit consumer ORB-10091",
-  "note": "Pinned local copy of the shared Constellation provider-identity contract. Cross-workspace dependencies are intentionally NOT encoded, so this file is the Orbit-side source of truth. Bump contract_version and update the rows whenever the upstream Polaris contract changes; the table-driven tests in tests/activity_v2.rs assert the orbit-common Provider surface against every row.",
-  "providers": [
+  "spec": "rules/provider-resolution.md",
+  "generated_for": "ORB-10089",
+  "description": "Language-neutral, table-driven conformance cases for the Constellation provider-resolution contract. Worker, Bridge, and Orbit each vendor a copy of this file (or its pinned contract_version + cases_sha256) and run these cases through their own resolver, asserting the same normalized_provider, source, diagnostic, and deprecation for identical inputs. See rules/provider-resolution.md for the normative prose and the resolution algorithm these cases encode.",
+  "canonical_providers": ["claude", "codex", "gemini", "grok"],
+  "known_providers": ["claude", "codex", "gemini", "grok", "ollama", "openai_compat"],
+  "aliases": {
+    "anthropic": "claude",
+    "openai": "codex",
+    "chatgpt": "codex",
+    "google": "gemini",
+    "xai": "grok"
+  },
+  "default_provider": "claude",
+  "default_override_setting": {
+    "environment_variable": "CONSTELLATION_DEFAULT_PROVIDER",
+    "precedence_tier": "environment_default",
+    "persisted_config": {
+      "orbit": "[workflow].default_crew (crew name maps to same-named provider)",
+      "worker": "baseline constant (worker/providers/registry.py DEFAULT_PROVIDER)",
+      "bridge": "baseline constant (bridge.services.worker.DEFAULT_PROVIDER)"
+    },
+    "note": "Setting CONSTELLATION_DEFAULT_PROVIDER to a canonical id changes every otherwise-defaulted execution path at once, without editing any repo. It sits above the persisted per-repo system default and below any explicit/task/workspace selection."
+  },
+  "capabilities": {
+    "orbit": ["claude", "codex", "gemini", "grok"],
+    "worker": ["claude", "codex", "gemini", "grok"],
+    "bridge": ["claude", "codex", "gemini", "grok"]
+  },
+  "environment_availability": {
+    "_note": "NON-NORMATIVE host snapshot, not part of contract_version behavior. Availability is a runtime property of each host; conformance cases pass host_available explicitly so they stay host-independent.",
+    "host": "dk-server-1",
+    "installed": ["claude", "codex"],
+    "absent": ["gemini", "grok"]
+  },
+  "precedence": ["explicit", "task_config", "workspace_default", "environment_default", "system_default"],
+  "diagnostics": {
+    "provider.ok": "Explicitly selected canonical provider resolved with no normalization needed.",
+    "provider.defaulted": "No explicit selection; resolved from a default tier (task_config, workspace_default, environment_default, or system_default).",
+    "provider.alias_deprecated": "A recognized legacy alias was normalized to its canonical id. Non-fatal; resolution succeeds. Emit an observable deprecation signal (log/warning) carrying alias and canonical.",
+    "provider.unknown": "Input is neither a canonical id, a known provider, nor a recognized alias. Hard error. No fallback.",
+    "provider.unsupported": "Input normalizes to a known provider that THIS entry point lacks the capability to execute (capability gap). Hard error. No fallback.",
+    "provider.unavailable": "Input normalizes to a provider this entry point supports, but its CLI/binary is not installed or runnable on the host (availability gap). Hard error. No silent substitution."
+  },
+  "case_input_schema": {
+    "entry_point": "any | orbit | worker | bridge — which entry point's capability set to apply.",
+    "requested": "raw provider string from the explicit request, or null if omitted.",
+    "task_provider": "provider/crew pinned on the task record, or null.",
+    "workspace_default": "per-workspace/project config default (e.g. orbit [workflow].default_crew), or null.",
+    "env_default": "value of CONSTELLATION_DEFAULT_PROVIDER, or null.",
+    "system_default": "the persisted baseline system default for this deployment (canonical: claude).",
+    "persisted_resolution": "a provider already frozen on the run record; when non-null, reconciliation reuses it and skips precedence.",
+    "host_available": "whether the resolved provider's binary is installed/runnable; null = assume available / not exercised."
+  },
+  "cases_sha256": "191058b435063a905943c9ef6779683e2b273ae0a0a338464419c74708d67cfe",
+  "cases": [
     {
-      "canonical": "claude",
-      "aliases": [],
-      "has_cli_runtime": true,
-      "has_http_transport": true,
-      "worker_executable": true
+      "id": "omitted-resolves-to-system-default",
+      "category": "omitted",
+      "input": {"entry_point": "any", "requested": null, "task_provider": null, "workspace_default": null, "env_default": null, "system_default": "claude", "persisted_resolution": null, "host_available": null},
+      "expected": {"status": "success", "normalized_provider": "claude", "source": "system_default", "diagnostic": "provider.defaulted", "deprecation": null}
     },
     {
-      "canonical": "codex",
-      "aliases": [],
-      "has_cli_runtime": true,
-      "has_http_transport": false,
-      "worker_executable": true
+      "id": "omitted-parameterized-system-default-codex",
+      "category": "omitted",
+      "input": {"entry_point": "orbit", "requested": null, "task_provider": null, "workspace_default": null, "env_default": null, "system_default": "codex", "persisted_resolution": null, "host_available": null},
+      "expected": {"status": "success", "normalized_provider": "codex", "source": "system_default", "diagnostic": "provider.defaulted", "deprecation": null}
     },
     {
-      "canonical": "gemini",
-      "aliases": [],
-      "has_cli_runtime": true,
-      "has_http_transport": false,
-      "worker_executable": true
+      "id": "canonical-explicit-codex",
+      "category": "canonical",
+      "input": {"entry_point": "any", "requested": "codex", "task_provider": null, "workspace_default": null, "env_default": null, "system_default": "claude", "persisted_resolution": null, "host_available": null},
+      "expected": {"status": "success", "normalized_provider": "codex", "source": "explicit", "diagnostic": "provider.ok", "deprecation": null}
     },
     {
-      "canonical": "grok",
-      "aliases": [],
-      "has_cli_runtime": true,
-      "has_http_transport": false,
-      "worker_executable": true
+      "id": "canonical-explicit-claude",
+      "category": "canonical",
+      "input": {"entry_point": "any", "requested": "claude", "task_provider": null, "workspace_default": null, "env_default": null, "system_default": "claude", "persisted_resolution": null, "host_available": null},
+      "expected": {"status": "success", "normalized_provider": "claude", "source": "explicit", "diagnostic": "provider.ok", "deprecation": null}
     },
     {
-      "canonical": "ollama",
-      "aliases": [],
-      "has_cli_runtime": true,
-      "has_http_transport": false,
-      "worker_executable": false
+      "id": "canonical-case-insensitive",
+      "category": "canonical",
+      "input": {"entry_point": "any", "requested": "CODEX", "task_provider": null, "workspace_default": null, "env_default": null, "system_default": "claude", "persisted_resolution": null, "host_available": null},
+      "expected": {"status": "success", "normalized_provider": "codex", "source": "explicit", "diagnostic": "provider.ok", "deprecation": null}
     },
     {
-      "canonical": "openai_compat",
-      "aliases": ["openai-compat"],
-      "has_cli_runtime": false,
-      "has_http_transport": false,
-      "worker_executable": false
+      "id": "canonical-whitespace-trimmed",
+      "category": "canonical",
+      "input": {"entry_point": "any", "requested": "  claude  ", "task_provider": null, "workspace_default": null, "env_default": null, "system_default": "claude", "persisted_resolution": null, "host_available": null},
+      "expected": {"status": "success", "normalized_provider": "claude", "source": "explicit", "diagnostic": "provider.ok", "deprecation": null}
+    },
+    {
+      "id": "alias-anthropic-to-claude",
+      "category": "alias",
+      "input": {"entry_point": "any", "requested": "anthropic", "task_provider": null, "workspace_default": null, "env_default": null, "system_default": "claude", "persisted_resolution": null, "host_available": null},
+      "expected": {"status": "success", "normalized_provider": "claude", "source": "explicit", "diagnostic": "provider.alias_deprecated", "deprecation": {"alias": "anthropic", "canonical": "claude"}}
+    },
+    {
+      "id": "alias-openai-to-codex",
+      "category": "alias",
+      "input": {"entry_point": "any", "requested": "openai", "task_provider": null, "workspace_default": null, "env_default": null, "system_default": "claude", "persisted_resolution": null, "host_available": null},
+      "expected": {"status": "success", "normalized_provider": "codex", "source": "explicit", "diagnostic": "provider.alias_deprecated", "deprecation": {"alias": "openai", "canonical": "codex"}}
+    },
+    {
+      "id": "alias-chatgpt-to-codex",
+      "category": "alias",
+      "input": {"entry_point": "any", "requested": "chatgpt", "task_provider": null, "workspace_default": null, "env_default": null, "system_default": "claude", "persisted_resolution": null, "host_available": null},
+      "expected": {"status": "success", "normalized_provider": "codex", "source": "explicit", "diagnostic": "provider.alias_deprecated", "deprecation": {"alias": "chatgpt", "canonical": "codex"}}
+    },
+    {
+      "id": "alias-google-to-gemini",
+      "category": "alias",
+      "input": {"entry_point": "any", "requested": "google", "task_provider": null, "workspace_default": null, "env_default": null, "system_default": "claude", "persisted_resolution": null, "host_available": null},
+      "expected": {"status": "success", "normalized_provider": "gemini", "source": "explicit", "diagnostic": "provider.alias_deprecated", "deprecation": {"alias": "google", "canonical": "gemini"}}
+    },
+    {
+      "id": "alias-xai-to-grok",
+      "category": "alias",
+      "input": {"entry_point": "any", "requested": "xai", "task_provider": null, "workspace_default": null, "env_default": null, "system_default": "claude", "persisted_resolution": null, "host_available": null},
+      "expected": {"status": "success", "normalized_provider": "grok", "source": "explicit", "diagnostic": "provider.alias_deprecated", "deprecation": {"alias": "xai", "canonical": "grok"}}
+    },
+    {
+      "id": "alias-case-insensitive-openai",
+      "category": "alias",
+      "input": {"entry_point": "any", "requested": "OpenAI", "task_provider": null, "workspace_default": null, "env_default": null, "system_default": "claude", "persisted_resolution": null, "host_available": null},
+      "expected": {"status": "success", "normalized_provider": "codex", "source": "explicit", "diagnostic": "provider.alias_deprecated", "deprecation": {"alias": "openai", "canonical": "codex"}}
+    },
+    {
+      "id": "alias-in-workspace-default-tier",
+      "category": "alias",
+      "input": {"entry_point": "any", "requested": null, "task_provider": null, "workspace_default": "anthropic", "env_default": null, "system_default": "claude", "persisted_resolution": null, "host_available": null},
+      "expected": {"status": "success", "normalized_provider": "claude", "source": "workspace_default", "diagnostic": "provider.alias_deprecated", "deprecation": {"alias": "anthropic", "canonical": "claude"}}
+    },
+    {
+      "id": "unknown-garbage-no-fallback",
+      "category": "unknown",
+      "input": {"entry_point": "any", "requested": "bogus", "task_provider": null, "workspace_default": null, "env_default": null, "system_default": "claude", "persisted_resolution": null, "host_available": null},
+      "expected": {"status": "error", "normalized_provider": null, "source": "explicit", "diagnostic": "provider.unknown", "deprecation": null}
+    },
+    {
+      "id": "omitted-whitespace-is-not-a-selection",
+      "category": "omitted",
+      "input": {"entry_point": "any", "requested": "   ", "task_provider": null, "workspace_default": null, "env_default": null, "system_default": "claude", "persisted_resolution": null, "host_available": null},
+      "expected": {"status": "success", "normalized_provider": "claude", "source": "system_default", "diagnostic": "provider.defaulted", "deprecation": null}
+    },
+    {
+      "id": "unsupported-worker-cannot-run-openai-compat",
+      "category": "unsupported",
+      "input": {"entry_point": "worker", "requested": "openai_compat", "task_provider": null, "workspace_default": null, "env_default": null, "system_default": "claude", "persisted_resolution": null, "host_available": null},
+      "expected": {"status": "error", "normalized_provider": "openai_compat", "source": "explicit", "diagnostic": "provider.unsupported", "deprecation": null}
+    },
+    {
+      "id": "unsupported-orbit-cli-backend-cannot-run-ollama",
+      "category": "unsupported",
+      "input": {"entry_point": "orbit", "requested": "ollama", "task_provider": null, "workspace_default": null, "env_default": null, "system_default": "claude", "persisted_resolution": null, "host_available": null},
+      "expected": {"status": "error", "normalized_provider": "ollama", "source": "explicit", "diagnostic": "provider.unsupported", "deprecation": null}
+    },
+    {
+      "id": "unavailable-gemini-binary-absent-no-substitute",
+      "category": "unavailable",
+      "input": {"entry_point": "worker", "requested": "gemini", "task_provider": null, "workspace_default": null, "env_default": null, "system_default": "claude", "persisted_resolution": null, "host_available": false},
+      "expected": {"status": "error", "normalized_provider": "gemini", "source": "explicit", "diagnostic": "provider.unavailable", "deprecation": null}
+    },
+    {
+      "id": "unavailable-grok-binary-absent-no-substitute",
+      "category": "unavailable",
+      "input": {"entry_point": "worker", "requested": "grok", "task_provider": null, "workspace_default": null, "env_default": null, "system_default": "claude", "persisted_resolution": null, "host_available": false},
+      "expected": {"status": "error", "normalized_provider": "grok", "source": "explicit", "diagnostic": "provider.unavailable", "deprecation": null}
+    },
+    {
+      "id": "task-crew-override-when-request-omitted",
+      "category": "task_override",
+      "input": {"entry_point": "any", "requested": null, "task_provider": "grok", "workspace_default": null, "env_default": null, "system_default": "claude", "persisted_resolution": null, "host_available": null},
+      "expected": {"status": "success", "normalized_provider": "grok", "source": "task_config", "diagnostic": "provider.defaulted", "deprecation": null}
+    },
+    {
+      "id": "workspace-default-when-task-and-request-omitted",
+      "category": "workspace_default",
+      "input": {"entry_point": "orbit", "requested": null, "task_provider": null, "workspace_default": "codex", "env_default": null, "system_default": "claude", "persisted_resolution": null, "host_available": null},
+      "expected": {"status": "success", "normalized_provider": "codex", "source": "workspace_default", "diagnostic": "provider.defaulted", "deprecation": null}
+    },
+    {
+      "id": "environment-default-changes-otherwise-defaulted-path",
+      "category": "environment_default",
+      "input": {"entry_point": "any", "requested": null, "task_provider": null, "workspace_default": null, "env_default": "gemini", "system_default": "claude", "persisted_resolution": null, "host_available": null},
+      "expected": {"status": "success", "normalized_provider": "gemini", "source": "environment_default", "diagnostic": "provider.defaulted", "deprecation": null}
+    },
+    {
+      "id": "explicit-beats-every-lower-tier-no-fallback",
+      "category": "precedence",
+      "input": {"entry_point": "any", "requested": "claude", "task_provider": "codex", "workspace_default": "gemini", "env_default": "grok", "system_default": "claude", "persisted_resolution": null, "host_available": null},
+      "expected": {"status": "success", "normalized_provider": "claude", "source": "explicit", "diagnostic": "provider.ok", "deprecation": null}
+    },
+    {
+      "id": "workspace-default-beats-environment-and-system",
+      "category": "precedence",
+      "input": {"entry_point": "orbit", "requested": null, "task_provider": null, "workspace_default": "codex", "env_default": "gemini", "system_default": "claude", "persisted_resolution": null, "host_available": null},
+      "expected": {"status": "success", "normalized_provider": "codex", "source": "workspace_default", "diagnostic": "provider.defaulted", "deprecation": null}
+    },
+    {
+      "id": "task-config-beats-workspace-and-environment",
+      "category": "precedence",
+      "input": {"entry_point": "orbit", "requested": null, "task_provider": "grok", "workspace_default": "codex", "env_default": "gemini", "system_default": "claude", "persisted_resolution": null, "host_available": null},
+      "expected": {"status": "success", "normalized_provider": "grok", "source": "task_config", "diagnostic": "provider.defaulted", "deprecation": null}
+    },
+    {
+      "id": "environment-default-beats-system-default",
+      "category": "precedence",
+      "input": {"entry_point": "any", "requested": null, "task_provider": null, "workspace_default": null, "env_default": "grok", "system_default": "claude", "persisted_resolution": null, "host_available": null},
+      "expected": {"status": "success", "normalized_provider": "grok", "source": "environment_default", "diagnostic": "provider.defaulted", "deprecation": null}
+    },
+    {
+      "id": "persisted-reconciliation-reuses-frozen-resolution",
+      "category": "persisted_reconciliation",
+      "input": {"entry_point": "orbit", "requested": "claude", "task_provider": null, "workspace_default": "codex", "env_default": null, "system_default": "claude", "persisted_resolution": "codex", "host_available": null},
+      "expected": {"status": "success", "normalized_provider": "codex", "source": "persisted_reconciliation", "diagnostic": "provider.ok", "deprecation": null}
+    },
+    {
+      "id": "persisted-reconciliation-does-not-re-resolve-after-default-change",
+      "category": "persisted_reconciliation",
+      "input": {"entry_point": "orbit", "requested": null, "task_provider": null, "workspace_default": null, "env_default": "gemini", "system_default": "claude", "persisted_resolution": "codex", "host_available": null},
+      "expected": {"status": "success", "normalized_provider": "codex", "source": "persisted_reconciliation", "diagnostic": "provider.ok", "deprecation": null}
     }
-  ],
-  "unknown_provider_examples": ["", "   ", "anthropic", "openai", "gpt", "claude-3", "grokk"]
+  ]
 }

--- a/crates/orbit-core/src/command/executor.rs
+++ b/crates/orbit-core/src/command/executor.rs
@@ -65,18 +65,18 @@ pub(super) fn migrated_default_executor(
     // re-seeding on a host that can't apply it (e.g. `macos-sandbox-exec` on
     // Linux) drops the declaration instead of leaving dispatch fail-closed.
     // See [ORB-10047].
-    if let Some(kind) = existing.sandbox {
-        if !kind.is_available_on_current_platform() {
-            tracing::warn!(
-                executor = %existing.name,
-                sandbox = %kind,
-                current_platform = std::env::consts::OS,
-                target_platform = kind.target_os(),
-                "scrubbing platform-mismatched sandbox from installed executor def on re-seed",
-            );
-            migrated.sandbox = None;
-            changed = true;
-        }
+    if let Some(kind) = existing.sandbox
+        && !kind.is_available_on_current_platform()
+    {
+        tracing::warn!(
+            executor = %existing.name,
+            sandbox = %kind,
+            current_platform = std::env::consts::OS,
+            target_platform = kind.target_os(),
+            "scrubbing platform-mismatched sandbox from installed executor def on re-seed",
+        );
+        migrated.sandbox = None;
+        changed = true;
     }
 
     if changed { Some(migrated) } else { None }
@@ -117,17 +117,17 @@ pub(super) fn parse_default_executor(name: &str, yaml: &str) -> Result<ExecutorD
     // can't apply it. Drop the declaration at parse time on hosts where it
     // doesn't apply so first-install and re-install (overwrite mode) don't
     // persist a platform-mismatched sandbox. See [ORB-10047].
-    if let Some(kind) = def.sandbox {
-        if !kind.is_available_on_current_platform() {
-            tracing::warn!(
-                executor = %def.name,
-                sandbox = %kind,
-                current_platform = std::env::consts::OS,
-                target_platform = kind.target_os(),
-                "shipped executor asset declares sandbox for another platform; installing without sandbox on this host",
-            );
-            def.sandbox = None;
-        }
+    if let Some(kind) = def.sandbox
+        && !kind.is_available_on_current_platform()
+    {
+        tracing::warn!(
+            executor = %def.name,
+            sandbox = %kind,
+            current_platform = std::env::consts::OS,
+            target_platform = kind.target_os(),
+            "shipped executor asset declares sandbox for another platform; installing without sandbox on this host",
+        );
+        def.sandbox = None;
     }
 
     Ok(def)

--- a/crates/orbit-core/src/command/task/review.rs
+++ b/crates/orbit-core/src/command/task/review.rs
@@ -315,9 +315,24 @@ mod tests {
         serde_json::from_str(&raw).expect("parse task review scoreboard")
     }
 
+    fn test_runtime_with_codex_reviewer() -> (tempfile::TempDir, OrbitRuntime) {
+        test_runtime_with_workspace_config(&format!(
+            r#"
+[crews.codex-review]
+planner = {{ model = "{model}", provider = "codex", backend = "cli" }}
+implementer = {{ model = "{model}", provider = "codex", backend = "cli" }}
+reviewer = {{ model = "{model}", provider = "codex", backend = "cli" }}
+
+[workflow]
+default_crew = "codex-review"
+"#,
+            model = orbit_common::test_fixtures::TEST_CODEX_MODEL,
+        ))
+    }
+
     #[test]
     fn add_and_reply_review_threads_score_local_review_threads_once() {
-        let (_root, runtime) = test_runtime();
+        let (_root, runtime) = test_runtime_with_codex_reviewer();
         let scoreboard_dir = runtime.data_root().join("state").join("scoreboard");
         fs::create_dir_all(&scoreboard_dir).expect("create scoreboard dir");
         let task = runtime
@@ -377,7 +392,7 @@ mod tests {
 
     #[test]
     fn typo_prefixed_models_do_not_score_local_review_threads() {
-        let (_root, runtime) = test_runtime();
+        let (_root, runtime) = test_runtime_with_codex_reviewer();
         let scoreboard_dir = runtime.data_root().join("state").join("scoreboard");
         fs::create_dir_all(&scoreboard_dir).expect("create scoreboard dir");
         let task = runtime

--- a/crates/orbit-core/src/config/runtime.rs
+++ b/crates/orbit-core/src/config/runtime.rs
@@ -7,7 +7,9 @@ use orbit_common::model_defaults::{
     GROK_DEFAULT_MODEL,
 };
 use orbit_common::types::{
-    Crew, CrewRoleAssignment, OrbitError, activity_job::Backend, all_agent_families, resolve_crew,
+    Crew, CrewRoleAssignment, OrbitError,
+    activity_job::{Backend, Provider},
+    all_agent_families, resolve_crew,
 };
 use orbit_common::utility::log_rotation::LogRotationConfig;
 use orbit_common::utility::redaction::redact_home_dir;
@@ -25,12 +27,13 @@ use super::raw::{
 const DEFAULT_ENV_INHERIT: bool = false;
 const DEFAULT_TASK_APPROVAL_REQUIRED_FOR_AGENT: bool = false;
 const DEFAULT_TASK_APPROVAL_DELEGATE_APPROVAL: bool = false;
-// Keep the runtime fallback aligned with the seeded default config so repos
-// without an explicit Orbit config still record scoreboard metrics.
+// Canonical system fallback from the Constellation provider contract. A seeded
+// or explicit workspace default remains a higher-precedence configured choice.
 const DEFAULT_SCORING_ENABLED: bool = true;
 const DEFAULT_GRAPH_EDITING: bool = false;
 const DEFAULT_WORKFLOW_BASE_BRANCH: &str = "main";
-const DEFAULT_WORKFLOW_CREW: &str = "codex";
+const DEFAULT_WORKFLOW_CREW: &str = "claude";
+const CONSTELLATION_DEFAULT_PROVIDER_ENV: &str = "CONSTELLATION_DEFAULT_PROVIDER";
 
 #[derive(Debug, Clone)]
 pub(crate) struct RuntimeConfig {
@@ -539,12 +542,31 @@ pub(super) fn workflow_default_crew_from_raw(
     raw: Option<&RawWorkflowConfig>,
     crews: &BTreeMap<String, Crew>,
 ) -> Result<Option<String>, OrbitError> {
+    let env_default = std::env::var(CONSTELLATION_DEFAULT_PROVIDER_ENV).ok();
+    workflow_default_crew_from_raw_with_env(raw, crews, env_default.as_deref())
+}
+
+pub(super) fn workflow_default_crew_from_raw_with_env(
+    raw: Option<&RawWorkflowConfig>,
+    crews: &BTreeMap<String, Crew>,
+    env_default: Option<&str>,
+) -> Result<Option<String>, OrbitError> {
     let value = raw.and_then(|workflow| workflow.default_crew.as_deref());
     let Some(value) = value else {
-        // No explicit [workflow].default_crew. Fall back to the seeded default
-        // when its crew is still present; otherwise demand the user pick one
-        // explicitly so downstream `start`/`show` calls don't surprise them
-        // with a generic "no crew selected" error.
+        // No explicit workspace default. Apply the environment tier before the
+        // canonical system default. A selected invalid value is a loud error,
+        // never a silent fall-through to a lower tier.
+        if let Some(raw_env) = env_default.filter(|value| !value.trim().is_empty()) {
+            let provider = Provider::parse(raw_env).map_err(|err| {
+                OrbitError::InvalidInput(format!(
+                    "{CONSTELLATION_DEFAULT_PROVIDER_ENV} has invalid value: {err}"
+                ))
+            })?;
+            let crew = provider.as_str();
+            resolve_crew(crew, crews)?;
+            return Ok(Some(crew.to_string()));
+        }
+
         if crews.contains_key(DEFAULT_WORKFLOW_CREW) {
             return Ok(Some(DEFAULT_WORKFLOW_CREW.to_string()));
         }

--- a/crates/orbit-core/src/config/tests/runtime.rs
+++ b/crates/orbit-core/src/config/tests/runtime.rs
@@ -1,11 +1,25 @@
 use super::super::runtime::*;
-use orbit_common::types::{OrbitError, all_agent_families};
+use orbit_common::types::{Crew, CrewRoleAssignment, OrbitError, all_agent_families};
 use std::collections::BTreeMap;
 use std::path::Path;
 use tempfile::tempdir;
 
 fn write_config(dir: &Path, body: &str) {
     std::fs::write(dir.join("config.toml"), body).expect("write config");
+}
+
+fn single_family_crew(name: &str) -> Crew {
+    let role = CrewRoleAssignment {
+        model: format!("{name}-model"),
+        provider: name.to_string(),
+        backend: "cli".to_string(),
+    };
+    Crew {
+        name: name.to_string(),
+        planner: role.clone(),
+        implementer: role.clone(),
+        reviewer: role,
+    }
 }
 
 fn load_config(body: &str) -> Result<RuntimeConfig, OrbitError> {
@@ -327,20 +341,20 @@ reviewer = { model = "gpt-5.5", provider = "codex", backend = "cli" }
 fn default_crew_unset_with_seeded_crew_still_loads() {
     let global = tempdir().expect("global tempdir");
     let workspace = tempdir().expect("workspace tempdir");
-    // The seeded codex crew is present, so the default-crew fallback applies.
+    // The canonical claude system crew is present, so the fallback applies.
     write_config(
         workspace.path(),
         r#"
-[crews.codex]
-planner = { model = "gpt-5.5", provider = "codex", backend = "cli" }
-implementer = { model = "gpt-5.5", provider = "codex", backend = "cli" }
-reviewer = { model = "gpt-5.5", provider = "codex", backend = "cli" }
+[crews.claude]
+planner = { model = "opus", provider = "claude", backend = "cli" }
+implementer = { model = "opus", provider = "claude", backend = "cli" }
+reviewer = { model = "opus", provider = "claude", backend = "cli" }
 "#,
     );
 
     let config =
         RuntimeConfig::load_layered(global.path(), workspace.path()).expect("config loads");
-    assert_eq!(config.default_crew.as_deref(), Some("codex"));
+    assert_eq!(config.default_crew.as_deref(), Some("claude"));
 }
 
 #[test]
@@ -351,6 +365,26 @@ fn workflow_default_crew_no_crews_defined_is_noop() {
         workflow_default_crew_from_raw(None, &crews).expect("empty registry is allowed");
 
     assert_eq!(default_crew, None);
+}
+
+#[test]
+fn workflow_default_crew_uses_environment_then_claude_system_default() {
+    let crews = BTreeMap::from([
+        ("claude".to_string(), single_family_crew("claude")),
+        ("gemini".to_string(), single_family_crew("gemini")),
+    ]);
+
+    let env = workflow_default_crew_from_raw_with_env(None, &crews, Some("google"))
+        .expect("deprecated environment alias resolves");
+    assert_eq!(env.as_deref(), Some("gemini"));
+
+    let system = workflow_default_crew_from_raw_with_env(None, &crews, None)
+        .expect("canonical system default resolves");
+    assert_eq!(system.as_deref(), Some("claude"));
+
+    let error = workflow_default_crew_from_raw_with_env(None, &crews, Some("bogus"))
+        .expect_err("selected invalid environment value must not fall back");
+    assert!(error.to_string().contains("CONSTELLATION_DEFAULT_PROVIDER"));
 }
 
 #[test]

--- a/crates/orbit-core/src/runtime/engine/crew.rs
+++ b/crates/orbit-core/src/runtime/engine/crew.rs
@@ -1,3 +1,4 @@
+use orbit_common::types::activity_job::ProviderSource;
 use orbit_common::types::{
     Crew, CrewRoleAssignment, OrbitError, Task, all_agent_families, infer_agent_family_from_model,
     resolve_crew,
@@ -7,6 +8,36 @@ use serde_json::Value;
 
 use crate::OrbitRuntime;
 use crate::runtime::run_input::{non_empty, singular_task_id_from_input};
+
+/// Select the crew *name* to dispatch by the Constellation provider-resolution
+/// precedence (ORB-10091, contract §3): explicit > task_config >
+/// workspace_default > environment_default > system_default. Empty /
+/// whitespace-only values are skipped (not a selection). Returns the chosen
+/// name and the tier it came from; `None` only when no tier supplies a value.
+/// Pure and table-tested so the precedence cannot drift from the shared
+/// contract or from the `Provider::resolve` surface it mirrors.
+pub(crate) fn select_crew_name<'a>(
+    explicit: Option<&'a str>,
+    task_config: Option<&'a str>,
+    workspace_default: Option<&'a str>,
+    environment_default: Option<&'a str>,
+    system_default: Option<&'a str>,
+) -> Option<(&'a str, ProviderSource)> {
+    [
+        (explicit, ProviderSource::Explicit),
+        (task_config, ProviderSource::TaskConfig),
+        (workspace_default, ProviderSource::WorkspaceDefault),
+        (environment_default, ProviderSource::EnvironmentDefault),
+        (system_default, ProviderSource::SystemDefault),
+    ]
+    .into_iter()
+    .find_map(|(value, source)| {
+        value
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(|value| (value, source))
+    })
+}
 
 /// Runtime crew registry projection for dashboard/API consumers.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
@@ -94,12 +125,19 @@ impl OrbitRuntime {
         cli_override: Option<&str>,
         task_crew: Option<&str>,
     ) -> Result<Crew, OrbitError> {
-        let selected = cli_override
-            .map(str::trim)
-            .filter(|value| !value.is_empty())
-            .or_else(|| task_crew.map(str::trim).filter(|value| !value.is_empty()))
-            .or_else(|| self.context.default_crew());
-        let Some(selected) = selected else {
+        // Runtime precedence is explicit > task_config > the default projected
+        // by RuntimeConfig. That projection has already resolved workspace >
+        // environment > system-default precedence, so lower tiers are not
+        // re-read here and cannot drift during a run.
+        let selection = select_crew_name(
+            cli_override,
+            task_crew,
+            self.context.default_crew(),
+            None,
+            None,
+        );
+
+        let Some((selected, _source)) = selection else {
             return Err(OrbitError::InvalidInput(
                 "no crew selected; set [workflow].default_crew, task.crew, or pass crew"
                     .to_string(),

--- a/crates/orbit-core/src/runtime/engine/environment_host.rs
+++ b/crates/orbit-core/src/runtime/engine/environment_host.rs
@@ -74,17 +74,31 @@ pub(crate) fn typed_role_config_from_assignment(
     let provider = Some(raw.provider.as_str()).and_then(|raw_value| {
         // Canonical string→provider parsing lives on the orbit-common `Provider`
         // surface (ORB-10091); the crew path routes through it so casing/alias
-        // handling cannot drift from the other layers.
-        let parsed = Provider::parse(raw_value).ok();
-        if parsed.is_none() {
-            tracing::warn!(
-                target: "orbit.config.crew",
-                role = role.as_str(),
-                raw = raw_value,
-                "[crews.<name>].provider has an unrecognized value; falling back to inline activity provider",
-            );
+        // handling cannot drift from the other layers. `resolve_name` preserves
+        // the deprecation signal so a legacy alias resolves *and* warns.
+        match Provider::resolve_name(raw_value) {
+            Ok(identity) => {
+                if let Some(deprecation) = identity.deprecation {
+                    tracing::warn!(
+                        target: "orbit.config.crew",
+                        role = role.as_str(),
+                        alias = %deprecation.alias,
+                        canonical = %deprecation.canonical,
+                        "[crews.<name>].provider uses a deprecated alias; resolving to the canonical id — update the config",
+                    );
+                }
+                Some(identity.provider)
+            }
+            Err(_) => {
+                tracing::warn!(
+                    target: "orbit.config.crew",
+                    role = role.as_str(),
+                    raw = raw_value,
+                    "[crews.<name>].provider has an unrecognized value; falling back to inline activity provider",
+                );
+                None
+            }
         }
-        parsed
     });
 
     let backend = Some(raw.backend.as_str()).and_then(|raw_value| {

--- a/crates/orbit-core/src/runtime/engine/tests/crew.rs
+++ b/crates/orbit-core/src/runtime/engine/tests/crew.rs
@@ -1,11 +1,26 @@
 //! Sibling tests for `crew.rs` (migrated per ORB-00246 / docs/design-patterns/test_layout.md).
 
+use std::sync::{Mutex, MutexGuard, OnceLock};
+
 use chrono::Utc;
+use orbit_common::types::activity_job::ProviderSource;
 use serde_json::json;
 use tempfile::{TempDir, tempdir};
 
+use super::super::crew::select_crew_name;
 use crate::OrbitRuntime;
 use crate::command::task::TaskAddParams;
+
+const CONSTELLATION_DEFAULT_PROVIDER_ENV: &str = "CONSTELLATION_DEFAULT_PROVIDER";
+
+/// Serialize the process-wide `CONSTELLATION_DEFAULT_PROVIDER` mutations so the
+/// env-default test cannot race concurrent tests.
+fn env_lock() -> MutexGuard<'static, ()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(()))
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+}
 
 fn runtime_with_named_crews() -> (TempDir, OrbitRuntime) {
     let root = tempdir().expect("create temp root");
@@ -124,4 +139,138 @@ fn multi_task_ids_without_override_falls_back_to_default_crew() {
 
     assert_eq!(crew.name, "primary");
     assert_eq!(crew.implementer.model, "default-implementer");
+}
+
+/// Table-driven proof of the crew-selection precedence (ORB-10091, contract §3)
+/// and of the environment-default tier. Each row fixes the higher tiers and
+/// varies the `env` column (`CONSTELLATION_DEFAULT_PROVIDER`): a row that has an
+/// explicit / task / workspace choice keeps its result regardless of `env`,
+/// while the otherwise-defaulted rows flip when the single env setting changes.
+#[test]
+fn select_crew_name_precedence_and_environment_default() {
+    struct Row {
+        name: &'static str,
+        explicit: Option<&'static str>,
+        task: Option<&'static str>,
+        workspace: Option<&'static str>,
+        env: Option<&'static str>,
+        system: Option<&'static str>,
+        expect: Option<(&'static str, ProviderSource)>,
+    }
+
+    let rows = [
+        // Explicit wins over every lower tier, including a set env.
+        Row {
+            name: "explicit beats all (env ignored)",
+            explicit: Some("gamma"),
+            task: Some("beta"),
+            workspace: Some("primary"),
+            env: Some("gemini"),
+            system: Some("claude"),
+            expect: Some(("gamma", ProviderSource::Explicit)),
+        },
+        // Task config wins over workspace + env when there is no explicit choice.
+        Row {
+            name: "task beats workspace+env",
+            explicit: None,
+            task: Some("beta"),
+            workspace: Some("primary"),
+            env: Some("gemini"),
+            system: Some("claude"),
+            expect: Some(("beta", ProviderSource::TaskConfig)),
+        },
+        // A configured workspace default is never overridden by the env lever.
+        Row {
+            name: "workspace beats env (unchanged by env)",
+            explicit: None,
+            task: None,
+            workspace: Some("primary"),
+            env: Some("gemini"),
+            system: Some("claude"),
+            expect: Some(("primary", ProviderSource::WorkspaceDefault)),
+        },
+        // Otherwise-defaulted: the env setting is the selection...
+        Row {
+            name: "env applies when otherwise-defaulted (claude)",
+            explicit: None,
+            task: None,
+            workspace: None,
+            env: Some("claude"),
+            system: Some("claude"),
+            expect: Some(("claude", ProviderSource::EnvironmentDefault)),
+        },
+        // ...and changing that one setting changes the resolved crew.
+        Row {
+            name: "env applies when otherwise-defaulted (gemini)",
+            explicit: None,
+            task: None,
+            workspace: None,
+            env: Some("gemini"),
+            system: Some("claude"),
+            expect: Some(("gemini", ProviderSource::EnvironmentDefault)),
+        },
+        // No env set: fall through to the system default.
+        Row {
+            name: "system default when nothing else",
+            explicit: None,
+            task: None,
+            workspace: None,
+            env: None,
+            system: Some("claude"),
+            expect: Some(("claude", ProviderSource::SystemDefault)),
+        },
+        // Whitespace at a tier is not a selection; fall through.
+        Row {
+            name: "whitespace at a tier is skipped",
+            explicit: Some("   "),
+            task: None,
+            workspace: None,
+            env: Some("codex"),
+            system: Some("claude"),
+            expect: Some(("codex", ProviderSource::EnvironmentDefault)),
+        },
+        // Nothing at any tier -> no selection (caller surfaces the error).
+        Row {
+            name: "nothing selected",
+            explicit: None,
+            task: None,
+            workspace: None,
+            env: None,
+            system: None,
+            expect: None,
+        },
+    ];
+
+    for row in rows {
+        let got = select_crew_name(row.explicit, row.task, row.workspace, row.env, row.system);
+        assert_eq!(got, row.expect, "{}", row.name);
+    }
+}
+
+/// End-to-end wiring: `resolve_crew_for_task` actually reads
+/// `CONSTELLATION_DEFAULT_PROVIDER`, and the environment tier stays subordinate
+/// to a configured `[workflow].default_crew`. Because a workspace default beats
+/// the env tier, a leaked value cannot affect concurrent tests.
+#[test]
+fn resolve_crew_for_task_reads_env_default_but_workspace_crew_wins() {
+    let _lock = env_lock();
+    let saved = std::env::var(CONSTELLATION_DEFAULT_PROVIDER_ENV).ok();
+    // SAFETY: serialized by env_lock(); restored before we assert or return.
+    unsafe { std::env::set_var(CONSTELLATION_DEFAULT_PROVIDER_ENV, "claude") };
+
+    let (_root, runtime) = runtime_with_named_crews();
+    let resolved = runtime.resolve_crew_for_task(None, None);
+
+    // Restore the prior environment before asserting so a failure never leaks.
+    // SAFETY: same serialization lock still held.
+    unsafe {
+        match saved {
+            Some(value) => std::env::set_var(CONSTELLATION_DEFAULT_PROVIDER_ENV, value),
+            None => std::env::remove_var(CONSTELLATION_DEFAULT_PROVIDER_ENV),
+        }
+    }
+
+    let crew = resolved.expect("resolve crew");
+    // `[workflow].default_crew = "primary"` (workspace tier) beats the env tier.
+    assert_eq!(crew.name, "primary");
 }

--- a/crates/orbit-core/src/runtime/v2_host/cli_executor.rs
+++ b/crates/orbit-core/src/runtime/v2_host/cli_executor.rs
@@ -1,5 +1,5 @@
 use orbit_common::types::ExecutorType;
-use orbit_common::types::activity_job::Provider;
+use orbit_common::types::activity_job::{Provider, ProviderEntryPoint};
 use orbit_engine::{DispatchError, ResolvedCliExecutor};
 
 use crate::OrbitRuntime;
@@ -64,12 +64,21 @@ pub(super) fn resolve_cli_executor(
     // fails with a stable diagnostic and never silently falls back to a
     // different runtime.
     match Provider::parse(provider) {
-        Ok(parsed) if parsed.has_cli_runtime() => Ok(ResolvedCliExecutor {
-            command: parsed.as_str().to_string(),
-            args: Vec::new(),
-        }),
+        Ok(parsed)
+            if Provider::capabilities(ProviderEntryPoint::Orbit).contains(&parsed)
+                && parsed.has_cli_runtime() =>
+        {
+            Ok(ResolvedCliExecutor {
+                command: parsed.as_str().to_string(),
+                args: Vec::new(),
+            })
+        }
+        Ok(Provider::OpenaiCompat) => Err(DispatchError::CliInvocationFailed(
+            "provider openai_compat is unsupported by the Orbit CLI entry point (HTTP-only)"
+                .to_string(),
+        )),
         Ok(parsed) => Err(DispatchError::CliInvocationFailed(format!(
-            "provider {parsed} has no CLI runtime (HTTP-only)"
+            "provider {parsed} is unsupported by the Orbit CLI entry point"
         ))),
         Err(err) => Err(DispatchError::CliInvocationFailed(format!(
             "{err} — no CLI runtime registered"
@@ -106,7 +115,7 @@ mod tests {
     fn cli_executor_selection_diagnostics_table() {
         let runtime = OrbitRuntime::in_memory().expect("build runtime");
 
-        for provider in ["claude", "codex", "gemini", "grok", "ollama"] {
+        for provider in ["claude", "codex", "gemini", "grok"] {
             let resolved = runtime
                 .resolve_cli_executor(provider)
                 .unwrap_or_else(|err| panic!("{provider} should resolve: {err:?}"));
@@ -114,13 +123,15 @@ mod tests {
             assert!(resolved.args.is_empty(), "fallback args for {provider}");
         }
 
-        let http_only = runtime
-            .resolve_cli_executor("openai_compat")
-            .expect_err("openai_compat is HTTP-only and must not fall back to CLI");
-        assert!(
-            format!("{http_only:?}").contains("no CLI runtime (HTTP-only)"),
-            "http-only diagnostic: {http_only:?}"
-        );
+        for unsupported in ["ollama", "openai_compat"] {
+            let error = runtime
+                .resolve_cli_executor(unsupported)
+                .expect_err("unsupported provider must not fall back to CLI");
+            assert!(
+                format!("{error:?}").contains("unsupported by the Orbit CLI entry point"),
+                "unsupported diagnostic for {unsupported}: {error:?}"
+            );
+        }
 
         let unknown = runtime
             .resolve_cli_executor("bogus_provider")

--- a/crates/orbit-engine/src/activity_job/tests/agent_role.rs
+++ b/crates/orbit-engine/src/activity_job/tests/agent_role.rs
@@ -61,11 +61,17 @@ fn full_override_replaces_every_field() {
     assert_eq!(resolved.backend, Backend::Http);
 }
 
-/// Table-driven coverage of the field-by-field crew-override precedence
-/// (ORB-10091). Each row states the crew-config override and the expected
-/// resolved triple against a fixed `Provider::Claude` inline spec. The rows
-/// where `config.provider` is `None` assert the persisted/inline provider
-/// identity is preserved and never re-defaulted to `Provider::default()`.
+/// Table-driven coverage of **step 2** of provider resolution (ORB-10091): the
+/// selected crew role's `(provider, model, backend)` values override the
+/// activity's inline `agent_loop` baseline, field by field. This is *not* the
+/// crew-*selection* precedence (explicit > task_config > workspace_default >
+/// environment_default > system_default) — that runs earlier, in orbit-core's
+/// `select_crew_name` / `resolve_crew_for_task`, and is table-tested there.
+///
+/// Each row states the crew-config override and the expected resolved triple
+/// against a fixed `Provider::Claude` inline spec. The rows where
+/// `config.provider` is `None` assert the inline provider identity is preserved
+/// and never re-defaulted to `Provider::default()`.
 #[test]
 fn resolve_from_config_precedence_table() {
     struct Row {

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -74,29 +74,49 @@ Every `provider` string Orbit reads — in `[crews.<name>]` roles, in an activit
 | `codex` | — | yes | no | yes |
 | `gemini` | — | yes | no | yes |
 | `grok` | — | yes | no | yes |
-| `ollama` | — | yes | no | **no** |
+| `ollama` | — | **unsupported at the Orbit CLI entry point** | no | **no** |
 | `openai_compat` | `openai-compat` | **no** (HTTP-only) | no | **no** |
 
-- **Parsing is case- and whitespace-insensitive.** `Claude`, `  claude `, and `CLAUDE` all resolve to `claude`. Aliases (e.g. `openai-compat`) normalize to their canonical id.
+- **Parsing is case- and whitespace-insensitive.** `Claude`, `  claude `, and `CLAUDE` all resolve to `claude`. `openai-compat` normalizes to `openai_compat`.
+- **Deprecated aliases resolve *and* warn.** The legacy vendor names normalize to their canonical id and log an `orbit.config.crew` deprecation warning (`{alias, canonical}`) — they never fail, but update the config:
+
+  | Deprecated alias | Canonical |
+  |---|---|
+  | `anthropic` | `claude` |
+  | `openai`, `chatgpt` | `codex` |
+  | `google` | `gemini` |
+  | `xai` | `grok` |
+
 - **Canonical ≠ Worker-executable.** Orbit's canonical set is deliberately wider than what the model-neutral Worker leaf executor can run: `ollama` and `openai_compat` are first-class Orbit providers but Worker does not execute them. This distinction is preserved on purpose — do not narrow the canonical set to Worker's subset.
+- **Known ≠ executable at this entry point.** The shared contract recognizes `ollama`, but the Orbit CLI capability set is the canonical cross-repo four; explicitly selecting `ollama` fails as `provider.unsupported` rather than falling back.
 - **`openai_compat` is HTTP-only.** It has no CLI runtime, so selecting it with `backend = "cli"` fails structurally (see below) rather than falling back.
 
 ### Resolution precedence
 
-For a role's effective `(provider, model, backend)` the resolver applies, per field:
+Provider selection is **two composed steps**, not one. Describe them precisely — the inline `provider` on an activity is the *template baseline*, **not** an explicit override that outranks the crew.
 
-1. **Explicit** value on the activity/step (inline spec).
-2. **Task crew** — `task.crew` on the task artifact.
-3. **Workspace default crew** — `[workflow].default_crew`.
-4. **Environment / system default** — what `orbit init`'s detection seeds when nothing above is set.
+**1 — Which crew is dispatched** (`resolve_crew_for_task`). The crew *name* is chosen by the Constellation provider-resolution precedence (contract §3), first non-empty tier wins:
 
-A field is only overridden by a lower-precedence layer when that layer supplies a value; an override that omits a field (e.g. a crew role that sets `model` but leaves `provider` unparseable) leaves the higher-precedence value in place. This is why **persisted provider identity is never re-defaulted** during reconciliation: a resolved provider already recorded on a run is preserved, not silently reset to the enum default.
+1. **explicit** — `--crew` flag / run-input `crew`.
+2. **task_config** — `task.crew` on the task artifact.
+3. **workspace_default** — `[workflow].default_crew` in `config.toml`.
+4. **environment_default** — the `CONSTELLATION_DEFAULT_PROVIDER` environment variable (a canonical provider id, which names the same-named single-family crew).
+5. **system_default** — the canonical baseline (see below).
+
+**2 — The selected crew's role values override the activity's inline baseline** (`resolve_from_config`). For each `(provider, model, backend)` field independently: the selected crew role's value wins **when present**; otherwise the activity's inline `agent_loop` value stands. A crew override that omits a field (or whose `provider` string is unparseable) leaves the inline baseline in place — so a config typo never coerces dispatch onto a wrong runtime. This is also why **persisted provider identity is never re-defaulted** during reconciliation: a provider already frozen on a run record is reused verbatim, not reset to the enum default.
+
+### The one setting that changes the default — `CONSTELLATION_DEFAULT_PROVIDER`
+
+`CONSTELLATION_DEFAULT_PROVIDER` occupies the **environment_default** tier (4) — below any explicit / task / workspace choice, above the persisted baseline. Setting it to a canonical id (or a deprecated alias, which normalizes) re-defaults **every otherwise-defaulted resolution path at once**, without editing any repo or per-workspace config; a path that already made a higher-precedence choice is deliberately unaffected. Because Orbit seeds `[workflow].default_crew` on `orbit init`, a normally-configured workspace resolves at the workspace tier, so the env lever governs paths that reach resolution without a configured crew and **never overrides a configured `[workflow].default_crew`**.
+
+> **System default.** The canonical Constellation system default is `claude`. When no higher tier selects a crew, Orbit dispatches the same-named `claude` crew. Existing workspaces whose `[workflow].default_crew` is `codex` retain that higher-precedence configured choice; the system fallback does not rewrite workspace configuration.
 
 ### No silent fallback
 
 Explicit selections that are unsupported or unavailable **fail with a stable diagnostic and never fall back** to a different runtime:
 
-- `provider openai_compat has no CLI runtime (HTTP-only)` — a CLI-executable dispatch selected an HTTP-only provider.
+- `provider openai_compat is unsupported by the Orbit CLI entry point (HTTP-only)` — a CLI-executable dispatch selected an HTTP-only provider.
+- `provider ollama is unsupported by the Orbit CLI entry point` — a known provider is outside this entry point's capability set.
 - `unknown provider '<x>'; expected one of claude, codex, gemini, grok, ollama, openai_compat — no CLI runtime registered` — the provider string did not resolve to a canonical id.
 
 An **unrecognized `[crews.<name>].provider` value** is the one non-fatal case: it is logged (`orbit.config.crew` warn) and that field falls back to the activity's inline `provider`, because a config typo should not coerce dispatch onto a wrong runtime — the inline value is the known-good identity, not a default guess.
@@ -105,11 +125,13 @@ An **unrecognized `[crews.<name>].provider` value** is the one non-fatal case: i
 
 ## Per-task crew override
 
-`[workflow].default_crew` is the workspace fallback, not a global verdict. **Every task carries an optional `crew` field**, and `orbit run ship` resolves which crew to dispatch per task in this order:
+`[workflow].default_crew` is the workspace fallback, not a global verdict. **Every task carries an optional `crew` field**, and `orbit run ship` resolves which crew to dispatch per task by the [resolution precedence](#resolution-precedence) above:
 
-1. `task.crew` if set on the task artifact, otherwise
-2. `[workflow].default_crew` from `config.toml`, otherwise
-3. error: `no crew selected; set [workflow].default_crew, task.crew, or pass crew`.
+1. explicit `--crew` / run-input `crew`, otherwise
+2. `task.crew` if set on the task artifact, otherwise
+3. `[workflow].default_crew` from `config.toml`, otherwise
+4. `CONSTELLATION_DEFAULT_PROVIDER` if set (environment tier), otherwise
+5. the canonical `claude` system-default crew.
 
 This means you can mix-and-match in a single ship run: route a tricky refactor to `claude` while routing routine cleanups to `codex` — both go through the same `orbit run ship` invocation, each picking its own crew at dispatch time.
 


### PR DESCRIPTION
## What changed

- makes Orbit consume the accepted Constellation provider contract and exact pinned fixture
- implements canonical identities, deprecated aliases, deterministic precedence, and stable diagnostics
- applies crew-role overrides consistently across runtime paths
- rejects known-but-unsupported Orbit CLI providers without fallback
- documents the provider/crew resolution model
- updates review-scoreboard tests to select Codex explicitly now that the contract's system fallback is Claude

## Why

PR #549 merged the first ORB-10091 implementation before the three contract review findings were addressed. This follow-up completes those requirements so Orbit agrees with the already-landed Polaris contract, Bridge consumer, and Worker consumer.

## Validation

- `cargo test -p orbit-common -p orbit-core -p orbit-engine`
  - orbit-common: 214 passed
  - orbit-core: 521 passed, 1 ignored
  - orbit-core integration: 6 passed
  - orbit-engine: 240 passed
- `make ci-fast`
- `cargo check -p orbit-common -p orbit-core -p orbit-engine`
- `cargo +1.97.0 clippy --workspace --all-targets -- -D warnings`
- `cargo +1.97.0 fmt --all -- --check`
- `cargo fmt --all`
- `git diff --check`

The two small follow-up commits also clear four pre-existing Rust 1.97 lints in
`orbit-core` executor setup and the `orbit-agent` redaction example; CI's stable
toolchain made these newly fatal even though they are outside the provider path.

Task: ORB-10091
