### PR TITLE
Package Orbit as an installable Codex plugin

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,0 +1,20 @@
+{
+  "name": "orbit",
+  "interface": {
+    "displayName": "Orbit"
+  },
+  "plugins": [
+    {
+      "name": "orbit",
+      "source": {
+        "source": "local",
+        "path": "./plugin"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Developer Tools"
+    }
+  ]
+}

--- a/.github/workflows/smoke-plugin-install.yml
+++ b/.github/workflows/smoke-plugin-install.yml
@@ -1,8 +1,9 @@
 name: smoke-plugin-install
 
-# Exercises the /plugin install orbit chain end-to-end against the
-# published @orbit-tools/cli@latest and the latest GitHub Release tag.
-# Catches drift between npm registry, plugin manifest, and release assets.
+# Exercises the Claude and Codex plugin install chains end-to-end against the
+# published @orbit-tools/cli@latest and the latest GitHub Release tag. Catches
+# drift between npm registry, plugin manifests, Codex packaging, and release
+# assets.
 
 on:
   schedule:
@@ -35,6 +36,9 @@ jobs:
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: "20"
+
+      - name: Install Codex CLI
+        run: npm install -g @openai/codex@latest
 
       - name: Run plugin install smoke
         shell: bash

--- a/.orbit/learnings/L-0071/learning.yaml
+++ b/.orbit/learnings/L-0071/learning.yaml
@@ -1,0 +1,24 @@
+schema_version: 1
+id: L-0071
+status: active
+scope:
+  paths:
+  - plugin/skills/**
+  - plugin/.codex-plugin/**
+  - scripts/smoke-plugin-install.sh
+  - crates/orbit-core/src/command/skill.rs
+  tags:
+  - codex
+  - plugin
+summary: Materialize Codex-shipped plugin skills or compare them byte-for-byte; Codex plugin install does not follow directory symlinks under `plugin/skills/`.
+body: |-
+  While packaging Orbit for Codex in ORB-10099, a clean `codex plugin add orbit@orbit` copied `plugin/` into the Codex cache but left directory-symlink entries under `plugin/skills/` empty. The fresh Codex prompt then failed to discover `orbit:orbit-*` skills even though the repository symlinks resolved locally.
+
+  Keep Codex-shipped skill directories as real package files, or stage a package that follows symlinks before install. Preserve the source-of-truth contract by comparing packaged skill files byte-for-byte against `crates/orbit-core/assets/skills/` in the drift test instead of hand-editing packaged copies.
+evidence:
+- kind: task
+  reference: ORB-10099
+created_at: 2026-07-11T05:19:53.679729843Z
+updated_at: 2026-07-11T05:19:53.679729843Z
+created_by: codex
+priority: 160

--- a/README.md
+++ b/README.md
@@ -102,6 +102,9 @@ curl -sSf https://raw.githubusercontent.com/danieljhkim/orbit/main/install.sh | 
 # or, in Claude Code:
 #   /plugin marketplace add danieljhkim/orbit
 #   /plugin install orbit
+# or, in Codex CLI:
+#   codex plugin marketplace add danieljhkim/orbit --ref main
+#   codex plugin add orbit@orbit
 
 # initialize
 orbit init                                 # global state (~/.orbit)
@@ -168,28 +171,36 @@ After install, task writes are embedded automatically in the background; `orbit 
 
 ---
 
-## Claude Code Plugin vs CLI
+## Agent Plugins vs CLI
 
-Two install surfaces. The CLI gives you the full power of Orbit. Choose the plugin if you just want a taste. Plugin will strap orbit's MCP tools automatically.
+Orbit ships lightweight Claude Code and Codex plugins. The CLI gives you the full power of Orbit; choose a plugin when you want Orbit's MCP tools and shared skills strapped onto one agent without installing `orbit` on your `$PATH`.
 
 ```bash
+# Claude Code
 /plugin marketplace add danieljhkim/orbit
-
-# Install the plugin
 /plugin install orbit
+
+# Codex CLI
+codex plugin marketplace add danieljhkim/orbit --ref main
+codex plugin add orbit@orbit
+
+# Later, after an Orbit release:
+codex plugin marketplace upgrade orbit
+codex plugin add orbit@orbit
 ```
 
 <details>
 <summary><strong>Plugin vs. CLI</strong> — (click to expand)</summary>
 
-|   | **Claude Code plugin** | **CLI (curl / brew)** |
-|---|---|---|
-| Install | `/plugin install orbit` (after `/plugin marketplace add danieljhkim/orbit`) | `curl … \| sh` or `brew install danieljhkim/tap/orbit` |
-| Orbit binary | Lives inside the plugin sandbox (not on `$PATH`) | Installed on `$PATH` |
-| MCP registration | Automatic | Manual: `orbit workspace init --mcp` per workspace |
-| Web dashboard (`orbit web serve`) | No | Yes |
-| Works with Codex / Gemini CLI | No (Claude Code only) | Yes |
-| workflows (i.e. `orbit run ship`) | No | Yes |
+|   | **Claude Code plugin** | **Codex plugin** | **CLI (curl / brew)** |
+|---|---|---|---|
+| Install | `/plugin install orbit` after `/plugin marketplace add danieljhkim/orbit` | `codex plugin add orbit@orbit` after `codex plugin marketplace add danieljhkim/orbit --ref main` | `curl … \| sh` or `brew install danieljhkim/tap/orbit` |
+| Orbit binary | Lives inside the plugin sandbox (not on `$PATH`) | Lives inside the plugin cache (not on `$PATH`) | Installed on `$PATH` |
+| MCP registration | Automatic in Claude Code | Automatic in Codex | Manual: `orbit workspace init --mcp` per workspace |
+| Shared Orbit skills | Bundled from `plugin/skills/` | Bundled from `plugin/skills/` | Seeded by `orbit workspace init` |
+| Web dashboard (`orbit web serve`) | No | No | Yes |
+| Other agent CLIs | No, scoped to Claude Code | No, scoped to Codex | Yes |
+| Workflows (i.e. `orbit run ship`) | No | No | Yes |
 
 </details>
 

--- a/crates/orbit-core/src/command/skill.rs
+++ b/crates/orbit-core/src/command/skill.rs
@@ -187,13 +187,13 @@ impl OrbitRuntime {
 #[cfg(test)]
 mod drift_tests {
     //! Parity tests guarding against drift between the four skill catalogs:
-    //! the on-disk assets, the seeded registry, the plugin symlinks, and the
+    //! the on-disk assets, the seeded registry, the plugin package, and the
     //! router skill's enumeration. The next agent who adds a skill folder
     //! must update all four; these tests fail loudly if any catalog lags.
 
     use super::*;
     use std::collections::BTreeSet;
-    use std::path::PathBuf;
+    use std::path::{Path, PathBuf};
 
     fn assets_skills_dir() -> PathBuf {
         PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("assets/skills")
@@ -208,6 +208,76 @@ mod drift_tests {
             .parent()
             .expect("crates/ has a parent (repo root)")
             .to_path_buf()
+    }
+
+    fn collect_relative_files(root: &Path) -> Result<BTreeSet<PathBuf>, String> {
+        let mut pending = vec![root.to_path_buf()];
+        let mut files = BTreeSet::new();
+
+        while let Some(dir) = pending.pop() {
+            let entries =
+                std::fs::read_dir(&dir).map_err(|e| format!("read_dir({}): {e}", dir.display()))?;
+            for entry in entries {
+                let entry = entry.map_err(|e| format!("read_dir({}) entry: {e}", dir.display()))?;
+                let path = entry.path();
+                let file_type = entry
+                    .file_type()
+                    .map_err(|e| format!("file_type({}): {e}", path.display()))?;
+                if file_type.is_dir() {
+                    pending.push(path);
+                    continue;
+                }
+                if file_type.is_file() || file_type.is_symlink() {
+                    let relative = path
+                        .strip_prefix(root)
+                        .map_err(|e| {
+                            format!("strip_prefix({}, {}): {e}", root.display(), path.display())
+                        })?
+                        .to_path_buf();
+                    files.insert(relative);
+                }
+            }
+        }
+
+        Ok(files)
+    }
+
+    fn plugin_skill_matches_asset(plugin_skill: &Path, asset_skill: &Path) -> Result<(), String> {
+        let expected_path = asset_skill
+            .canonicalize()
+            .map_err(|e| format!("canonicalize asset path failed: {e}"))?;
+        let actual_path = plugin_skill
+            .canonicalize()
+            .map_err(|e| format!("canonicalize plugin skill failed: {e}"))?;
+        if actual_path == expected_path {
+            return Ok(());
+        }
+
+        let plugin_files = collect_relative_files(plugin_skill)?;
+        let asset_files = collect_relative_files(asset_skill)?;
+        if plugin_files != asset_files {
+            let missing_from_plugin: Vec<&PathBuf> =
+                asset_files.difference(&plugin_files).collect();
+            let extra_in_plugin: Vec<&PathBuf> = plugin_files.difference(&asset_files).collect();
+            return Err(format!(
+                "materialized files differ from asset directory (missing from plugin: {missing_from_plugin:?}; extra in plugin: {extra_in_plugin:?})"
+            ));
+        }
+
+        for relative in asset_files {
+            let plugin_bytes = std::fs::read(plugin_skill.join(&relative))
+                .map_err(|e| format!("read plugin file {}: {e}", relative.display()))?;
+            let asset_bytes = std::fs::read(asset_skill.join(&relative))
+                .map_err(|e| format!("read asset file {}: {e}", relative.display()))?;
+            if plugin_bytes != asset_bytes {
+                return Err(format!(
+                    "materialized file {} differs from asset source",
+                    relative.display()
+                ));
+            }
+        }
+
+        Ok(())
     }
 
     #[test]
@@ -243,20 +313,20 @@ mod drift_tests {
     }
 
     #[test]
-    #[cfg_attr(
-        windows,
-        ignore = "plugin/skills/ symlinks rely on POSIX symlinks; Windows checkouts with core.symlinks=false break this test"
-    )]
     fn plugin_skill_symlinks_resolve_to_assets() {
         let repo = repo_root();
         let plugin_skills = repo.join("plugin/skills");
         let assets = repo.join("crates/orbit-core/assets/skills");
+        let codex_manifest_path = repo.join("plugin/.codex-plugin/plugin.json");
+        let marketplace_path = repo.join(".agents/plugins/marketplace.json");
         let excluded: BTreeSet<&str> = PLUGIN_EXCLUDED_SKILLS.iter().copied().collect();
 
         let mut failures: Vec<String> = Vec::new();
 
-        // Forward: every non-excluded default skill must have a symlink resolving
-        // to the corresponding asset directory.
+        // Forward: every non-excluded default skill must have a package entry
+        // that either resolves to the asset directory or is a byte-for-byte
+        // materialized copy. Codex plugin installs copy the plugin package
+        // without following directory symlinks, so materialized files are valid.
         let expected_ids: BTreeSet<&str> = default_skill_ids()
             .iter()
             .copied()
@@ -266,37 +336,21 @@ mod drift_tests {
             let link = plugin_skills.join(id);
             if !link.exists() {
                 failures.push(format!(
-                    "  {id}: plugin/skills/{id} does not exist (run: ln -s ../../crates/orbit-core/assets/skills/{id} plugin/skills/{id})"
+                    "  {id}: plugin/skills/{id} does not exist (create a symlink to or materialized copy of crates/orbit-core/assets/skills/{id})"
                 ));
                 continue;
             }
-            let expected_path = match assets.join(id).canonicalize() {
-                Ok(p) => p,
-                Err(e) => {
-                    failures.push(format!("  {id}: canonicalize asset path failed: {e}"));
-                    continue;
-                }
-            };
-            let actual = match link.canonicalize() {
-                Ok(p) => p,
-                Err(e) => {
-                    failures.push(format!(
-                        "  {id}: canonicalize plugin/skills/{id} failed: {e}"
-                    ));
-                    continue;
-                }
-            };
-            if actual != expected_path {
+            if let Err(e) = plugin_skill_matches_asset(&link, &assets.join(id)) {
                 failures.push(format!(
-                    "  {id}: plugin/skills/{id} resolves to {actual:?}, expected {expected_path:?}"
+                    "  {id}: plugin/skills/{id} does not match asset: {e}"
                 ));
             }
         }
 
-        // L-0020: retired skills can leave dangling symlinks behind, so
-        // keep this reverse check strict about orphan plugin entries.
-        // Reverse: no orphan symlinks in plugin/skills/ (catches stale entries
-        // for retired skills and accidental inclusion of an excluded skill).
+        // L-0020: retired skills can leave stale package entries behind, so
+        // keep this reverse check strict about orphans. Reverse: no orphan
+        // entries in plugin/skills/ (catches stale entries for retired skills
+        // and accidental inclusion of an excluded skill).
         let on_disk: BTreeSet<String> = std::fs::read_dir(&plugin_skills)
             .unwrap_or_else(|e| panic!("read_dir({}): {e}", plugin_skills.display()))
             .filter_map(|entry| {
@@ -319,9 +373,108 @@ mod drift_tests {
             }
         }
 
+        // The Codex plugin package intentionally reuses the same shared skill
+        // directory as the Claude plugin. Keep that manifest pointed at
+        // plugin/skills/ and make sure its MCP config is Codex-specific rather
+        // than a copy of the Claude config that depends on CLAUDE_PROJECT_DIR.
+        let codex_manifest: serde_json::Value = match std::fs::read_to_string(&codex_manifest_path)
+        {
+            Ok(contents) => match serde_json::from_str(&contents) {
+                Ok(value) => value,
+                Err(e) => {
+                    failures.push(format!(
+                        "  {}: invalid JSON: {e}",
+                        codex_manifest_path.display()
+                    ));
+                    serde_json::Value::Null
+                }
+            },
+            Err(e) => {
+                failures.push(format!(
+                    "  {}: failed to read Codex plugin manifest: {e}",
+                    codex_manifest_path.display()
+                ));
+                serde_json::Value::Null
+            }
+        };
+        if !codex_manifest.is_null() {
+            if codex_manifest
+                .get("skills")
+                .and_then(|value| value.as_str())
+                != Some("./skills/")
+            {
+                failures.push(
+                    "  plugin/.codex-plugin/plugin.json: `skills` must point at ./skills/ so Codex and Claude share the canonical skill package"
+                        .to_string(),
+                );
+            }
+            if codex_manifest.get("hooks").is_some() {
+                failures.push(
+                    "  plugin/.codex-plugin/plugin.json: must not declare Claude-only hooks"
+                        .to_string(),
+                );
+            }
+            let mcp_servers = codex_manifest.get("mcpServers");
+            if !matches!(mcp_servers, Some(serde_json::Value::Object(map)) if !map.is_empty()) {
+                failures.push(
+                    "  plugin/.codex-plugin/plugin.json: `mcpServers` must be a non-empty object"
+                        .to_string(),
+                );
+            }
+            if mcp_servers
+                .map(|value| value.to_string().contains("CLAUDE_PROJECT_DIR"))
+                .unwrap_or(false)
+            {
+                failures.push(
+                    "  plugin/.codex-plugin/plugin.json: Codex MCP config must not reference CLAUDE_PROJECT_DIR"
+                        .to_string(),
+                );
+            }
+        }
+
+        let marketplace: serde_json::Value = match std::fs::read_to_string(&marketplace_path) {
+            Ok(contents) => match serde_json::from_str(&contents) {
+                Ok(value) => value,
+                Err(e) => {
+                    failures.push(format!(
+                        "  {}: invalid JSON: {e}",
+                        marketplace_path.display()
+                    ));
+                    serde_json::Value::Null
+                }
+            },
+            Err(e) => {
+                failures.push(format!(
+                    "  {}: failed to read Codex marketplace manifest: {e}",
+                    marketplace_path.display()
+                ));
+                serde_json::Value::Null
+            }
+        };
+        if let Some(plugins) = marketplace
+            .get("plugins")
+            .and_then(|value| value.as_array())
+        {
+            let source_path = plugins
+                .iter()
+                .find(|entry| entry.get("name").and_then(|value| value.as_str()) == Some("orbit"))
+                .and_then(|entry| entry.get("source"))
+                .and_then(|source| source.get("path"))
+                .and_then(|value| value.as_str());
+            if source_path != Some("./plugin") {
+                failures.push(
+                    "  .agents/plugins/marketplace.json: orbit entry must point at ./plugin"
+                        .to_string(),
+                );
+            }
+        } else if !marketplace.is_null() {
+            failures
+                .push("  .agents/plugins/marketplace.json: `plugins` must be an array".to_string());
+        }
+
         assert!(
             failures.is_empty(),
-            "plugin/skills/ symlink parity failed for {} skill(s):\n{}",
+            "plugin/skills/ package parity failed for {} skill(s):\n{}",
             failures.len(),
             failures.join("\n"),
         );

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -1,11 +1,13 @@
 # Release Procedure
 
-How to cut an Orbit release such that `/plugin install orbit` works against
-the new version. The version invariant is load-bearing: the npm package, the
-plugin manifest, and the GitHub Release tag must all agree, or the
+How to cut an Orbit release such that `/plugin install orbit` and
+`codex plugin add orbit@orbit` work against the new version. The version
+invariant is load-bearing: the npm package, the Claude and Codex plugin
+manifests, and the GitHub Release tag must all agree, or the
 `npx -y @orbit-tools/cli@latest mcp serve` indirection in
-[`plugin/.mcp.json`](../plugin/.mcp.json) downloads a binary that does not
-match the plugin manifest.
+[`plugin/.mcp.json`](../plugin/.mcp.json) and
+[`plugin/.codex-plugin/plugin.json`](../plugin/.codex-plugin/plugin.json)
+downloads a binary that does not match the installed plugin manifest.
 
 See also [../RELEASING.md](../RELEASING.md) for the higher-level release runbook and versioning policy.
 
@@ -61,9 +63,11 @@ Each step names the exact file or command. Do them in order.
    derives the binary tag as `v${PKG.version}`; this field is the source of
    truth that gets in front of users.
 
-2. **Bump the plugin manifest version** in
+2. **Bump the plugin manifest versions** in
    [`plugin/.claude-plugin/plugin.json`](../plugin/.claude-plugin/plugin.json)
-   (`.version`). Must match step 1.
+   and
+   [`plugin/.codex-plugin/plugin.json`](../plugin/.codex-plugin/plugin.json)
+   (`.version`). Both must match step 1.
 
 3. **Run `make release-check`.** Pre-tag, it will exit non-zero because
    `npm view @orbit-tools/cli version` and the latest `gh release list -L 1`
@@ -73,8 +77,8 @@ Each step names the exact file or command. Do them in order.
    in one of the files the check inspects.
 
 4. **Commit the version bumps** and merge to the release branch
-   (`agent-main`). One commit, one PR, one bump pair — do not let the two
-   files drift across commits.
+   (`agent-main`). One commit, one PR, one bump set — do not let the two
+   plugin manifests or the npm package drift across commits.
 
 5. **Push the matching tag.** From the merge commit:
 
@@ -126,7 +130,8 @@ Each step names the exact file or command. Do them in order.
 
 8. **Verify.** After npm publish completes:
 
-   - `make release-check` should now pass (all four sources agree).
+   - `make release-check` should now pass (all local manifests, npm, and the
+     release tag agree).
    - The on-tag run of
      [`.github/workflows/smoke-plugin-install.yml`](../.github/workflows/smoke-plugin-install.yml)
      should be green on macOS and Linux. (If you re-run via
@@ -138,6 +143,14 @@ Each step names the exact file or command. Do them in order.
      ./scripts/smoke-plugin-install.sh
      ```
 
+   Codex users who installed from the Git marketplace update by refreshing the
+   marketplace snapshot and reinstalling the plugin:
+
+   ```bash
+   codex plugin marketplace upgrade orbit
+   codex plugin add orbit@orbit
+   ```
+
 ## Continuous verification
 
 [`.github/workflows/smoke-plugin-install.yml`](../.github/workflows/smoke-plugin-install.yml)
@@ -145,14 +158,22 @@ runs the smoke on `macos-15` and `ubuntu-22.04` weekly (Monday 12:00 UTC)
 and on every `v*` tag. It pulls the published `@orbit-tools/cli@latest`
 from npm, exercises the postinstall download + sha256 verification, and
 drives the orbit MCP server through a JSON-RPC `initialize` + `tools/list`
-handshake. The pass criterion is that the response advertises at least one
-`orbit_*` tool. (Tool names are emitted with underscores on the wire — see
+handshake. It also installs the repository's Codex plugin into an isolated
+`CODEX_HOME`, renders a fresh Codex task prompt to confirm the shared Orbit
+skills are discovered, and calls the read-only `orbit.task.list` MCP tool
+through the installed Codex MCP transport. The pass criterion is that the
+response advertises Orbit MCP tools and the read-only call succeeds. (Tool
+names are emitted with underscores on the wire — see
 `crates/orbit-mcp/src/adapter.rs::sanitize_tool_name` — even though the
 canonical selectors used in skills and CLI args are dot-form.)
 
 The smoke runs against published artifacts, not the local working tree, so
-it catches version drift that local builds would miss. Windows is not
-covered — the npm proxy only ships `darwin` and `linux` builds.
+it catches version drift that local builds would miss. The Codex plugin
+installation uses the checked-out repository marketplace
+([`.agents/plugins/marketplace.json`](../.agents/plugins/marketplace.json))
+so manifest and skill packaging regressions are caught before publication.
+Windows is not covered — the npm proxy only ships `darwin` and `linux`
+builds.
 
 Installer environment overrides are trust-boundary changes:
 
@@ -231,17 +252,24 @@ catches a lingering broken state.
 ## What `make release-check` enforces
 
 The script at [`scripts/release-check.sh`](../scripts/release-check.sh)
-asserts equality across four sources, when each is reachable:
+asserts equality across these sources, when each is reachable:
 
 - `.version` in [`plugin/npm/package.json`](../plugin/npm/package.json)
 - `.version` in [`plugin/.claude-plugin/plugin.json`](../plugin/.claude-plugin/plugin.json)
+- `.version` in [`plugin/.codex-plugin/plugin.json`](../plugin/.codex-plugin/plugin.json)
 - `npm view @orbit-tools/cli version`
 - `gh release list -L 1` (latest tag, leading `v` stripped)
 
+It also runs
+[`scripts/validate-codex-plugin.sh`](../scripts/validate-codex-plugin.sh),
+which checks the Codex manifest, repository marketplace entry, shared skill
+paths, and the absence of user-specific absolute paths or
+`CLAUDE_PROJECT_DIR` in Codex MCP configuration.
+
 Missing `npm` or `gh` is treated as a skip with a stderr note, not a hard
-failure, so the target stays usable on a fresh checkout without
-credentials. Mismatch across any reachable sources exits non-zero — so
-the pre-tag failure described in step 3 is by design.
+failure, so the target stays usable on a fresh checkout without credentials.
+Mismatch across any reachable sources exits non-zero — so the pre-tag failure
+described in step 3 is by design.
 
 ## Out-of-band fixes
 

--- a/plugin/.codex-plugin/plugin.json
+++ b/plugin/.codex-plugin/plugin.json
@@ -1,0 +1,42 @@
+{
+  "name": "orbit",
+  "version": "0.9.2",
+  "description": "Knowledge-graph code intelligence and task/activity orchestration for AI coding agents. Adds Orbit's MCP tool surface and skills to Codex.",
+  "author": {
+    "name": "danieljhkim",
+    "url": "https://github.com/danieljhkim"
+  },
+  "homepage": "https://github.com/danieljhkim/orbit",
+  "repository": "https://github.com/danieljhkim/orbit",
+  "license": "MIT",
+  "keywords": [
+    "orbit",
+    "codex",
+    "knowledge-graph",
+    "code-intelligence",
+    "agent-orchestration",
+    "mcp"
+  ],
+  "skills": "./skills/",
+  "mcpServers": {
+    "orbit": {
+      "command": "npx",
+      "args": ["-y", "@orbit-tools/cli@latest", "mcp", "serve"]
+    }
+  },
+  "interface": {
+    "displayName": "Orbit",
+    "shortDescription": "Task, knowledge, and code-graph tools for Codex.",
+    "longDescription": "Orbit adds a local task lifecycle, project learnings, Architecture Decision Records, and code-graph MCP tools for Codex workspaces.",
+    "developerName": "danieljhkim",
+    "category": "Developer Tools",
+    "capabilities": ["MCP", "Skills", "Code Intelligence"],
+    "websiteURL": "https://github.com/danieljhkim/orbit",
+    "defaultPrompt": [
+      "Create an Orbit task for this change.",
+      "Search Orbit for related decisions.",
+      "Use Orbit graph to inspect this code."
+    ],
+    "brandColor": "#2563EB"
+  }
+}

--- a/plugin/skills/orbit
+++ b/plugin/skills/orbit
@@ -1,1 +1,0 @@
-../../crates/orbit-core/assets/skills/orbit

--- a/plugin/skills/orbit-graph
+++ b/plugin/skills/orbit-graph
@@ -1,1 +1,0 @@
-../../crates/orbit-core/assets/skills/orbit-graph

--- a/plugin/skills/orbit-graph/SKILL.md
+++ b/plugin/skills/orbit-graph/SKILL.md
@@ -1,0 +1,106 @@
+---
+name: orbit-graph
+description: Use when navigating and inspecting the codebase via the orbit-graph code index instead of raw file reads.
+---
+
+# Orbit Graph
+
+Use `orbit_graph_*` as your default way to navigate code. Start with the smallest tool that can answer the question.
+
+## Tool Invocation
+
+The graph is served **in-process over MCP** by orbit-graph (v2). Call the tools directly from your toolbox:
+
+- `orbit_graph_sync`, `orbit_graph_search`, `orbit_graph_show`, `orbit_graph_refs`, `orbit_graph_callees`, `orbit_graph_impact`, `orbit_graph_trace`, `orbit_graph_overview`, `orbit_graph_implementors`, `orbit_graph_deps`.
+
+There is **no** `orbit tool run orbit.graph.*` path — the graph is not in the CLI tool registry. For direct human/shell use, the `orbit graph` subcommand (a thin wrapper over the same library) and the standalone `orbit-graph-cli` binary expose these queries as subcommands (`orbit graph search …`, `orbit graph refs …`, or `orbit-graph-cli search …`). The agent-facing surface is still the in-process `orbit_graph_*` MCP tools above — reach for the CLI only from a shell without MCP.
+
+The graph handle auto-syncs on a file watcher, so reads are normally fresh without an explicit sync. Call `orbit_graph_sync` only to force a refresh; pass `{"full": true}` for a complete re-index (required for full `trace` coverage — incremental sync resolves far fewer command handlers).
+
+## Default Workflow
+
+1. **Search first** — `orbit_graph_search` when the prompt names a symbol, trait, function, type, string, or config key. Narrow with `kind` (`symbol`, `string`, or `config`), `lang`, and `limit`.
+2. **Inspect the exact selector** — `orbit_graph_show` to confirm the definition, source, and lines of the match you found.
+3. **Use one relationship tool only if needed**:
+   - `orbit_graph_implementors` for trait/interface implementation questions
+   - `orbit_graph_refs` for inbound usages, cross-file references, **and caller-chain questions** (refs returns the inbound call sites; there is no separate `callers` tool)
+   - `orbit_graph_callees` for outbound calls *from* a symbol
+   - `orbit_graph_impact` for a bounded blast-radius traversal before an edit
+   - `orbit_graph_trace` for a command handler's call tree (by command name)
+   - `orbit_graph_deps` for module/import edges out of a `file:` or `dir:` selector
+4. **Orient only when scope is unclear** — `orbit_graph_overview` when the subtree is unfamiliar or the task is architectural. Broad scopes default to `summary`; pass `format: "full"` only when you need per-file symbol lists.
+
+## Confidence Floors
+
+`refs`, `impact`, and `trace` accept a `confidence` floor: `exact`, `import`, `same_module` (default), or `fuzzy`. Every cross-file reference carries one of these; raise the floor to drop weakly-resolved edges, lower it to `fuzzy` to recover trait-dispatch and dynamic calls that only resolve by name.
+
+## Stop Rule
+
+If `search + show`, or `search + implementors`, or a single `search` already answers the question, stop.
+
+Do not also run `overview`, `refs`, `callees`, or `impact` unless they add information the task still requires.
+
+If you are about to call `show` on each candidate to verify which one matches, stop and reconsider — that is the verification-loop anti-pattern. Use the appropriate relation tool (`refs`, `callees`, `implementors`, `impact`) instead.
+
+## Task IDs
+
+Orbit graph task attribution was removed. When the prompt asks what a task touched, use git's local commit-message convention instead:
+
+```bash
+git log --grep '[T20260421-0528]' --oneline
+```
+
+Orbit `task_id` is local to the operator's workspace. For cross-engineer task references, prefer `external_refs`.
+
+## When `fs.read` Is Acceptable
+
+- A graph call errors or a selector does not resolve to a node
+- You need a non-code file (config, YAML, TOML, markdown) that the index does not cover, and `orbit_graph_search` with `kind: "config"` did not surface it
+- You need a few extra lines around a symbol you already found with graph tools
+
+## Minimal Commands
+
+These are MCP tool calls (JSON argument maps). The `orbit graph` subcommand and the standalone `orbit-graph-cli` accept the same fields as flags.
+
+```jsonc
+// Exact symbol lookup
+orbit_graph_search   {"query":"hello","kind":"symbol","limit":10}
+orbit_graph_show     {"selector":"symbol:src/lib.rs#hello:function"}
+orbit_graph_search   {"query":"AGENT_ENV","kind":"config"}
+
+// Trait/interface implementations
+orbit_graph_implementors {"selector":"symbol:src/lib.rs#Greeter:trait"}
+
+// Usages, caller chains, outbound calls, blast radius
+orbit_graph_refs     {"symbol":"symbol:src/lib.rs#hello:function"}
+orbit_graph_refs     {"symbol":"symbol:src/lib.rs#hello:function","confidence":"fuzzy"}
+orbit_graph_callees  {"symbol":"symbol:src/lib.rs#hello:function"}
+orbit_graph_impact   {"selector":"symbol:src/lib.rs#hello:function","depth":2}
+
+// Command handler call tree (run a full sync first for complete coverage)
+orbit_graph_sync     {"full":true}
+orbit_graph_trace    {"command_name":"orbit.task.add"}
+
+// Module/import edges and high-level shape
+orbit_graph_deps     {"selector":"dir:crates/orbit-engine/src"}
+orbit_graph_overview {"scope":"dir:src/module"}
+orbit_graph_overview {"scope":"dir:src/module","format":"full"}
+```
+
+## Selector Forms
+
+- `dir:<path>`
+- `file:<path>`
+- `symbol:<path>#<name>:<kind>`
+
+Common symbol kinds: `function`, `method`, `struct`, `trait`, `impl`, `field`, `module`.
+
+## Avoid
+
+- Skipping graph tools and going straight to `fs.read`
+- Running `orbit_graph_overview` by default for exact symbol lookups
+- Reaching for `orbit.graph.pack`, `orbit.graph.callers`, or `orbit.graph.history` — those v1 tools no longer exist. Use `show` (per selector) for context, `refs` for callers, and `git log --grep` for task attribution.
+- Using `orbit_graph_refs` for trait-implementation questions instead of `orbit_graph_implementors`
+- Using `orbit_graph_refs` for crate dependency questions instead of `orbit_graph_deps`
+- Reading full files after `show` already gave the needed context
+- Falling back to `fs.read` for a symbol the graph can resolve

--- a/plugin/skills/orbit-knowledge
+++ b/plugin/skills/orbit-knowledge
@@ -1,1 +1,0 @@
-../../crates/orbit-core/assets/skills/orbit-knowledge

--- a/plugin/skills/orbit-knowledge/SKILL.md
+++ b/plugin/skills/orbit-knowledge/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: orbit-knowledge
+description: Create, search, update, supersede, prune, or audit Orbit's two durable-decision primitives — project learnings (recurring gotchas, incident root-causes, cross-session guardrails, push-injected by scope) and Architecture Decision Records (ADRs — decisions with a real alternative, accepted/proposed/superseded lifecycle, global ID allocation). Triggers on "learning", "gotcha", "guardrail", "ADR", "decision record", "4_decisions.md", accepting/superseding a decision, or adding a `## ADR-` heading. Covers scope-OR matching, evidence shape, update-vs-supersede (there is no comment or vote surface — corrections go through `update`/`supersede`, provenance through `evidence`), and why to never hand-edit `.orbit/learnings/` or `.orbit/adrs/`.
+---
+
+# Orbit Knowledge
+
+Two sibling primitives, one shared lifecycle discipline. **Learnings** are push-injected guidance: when an agent touches a file/dir/workflow matching a learning's `scope`, it's injected into the prompt automatically — this skill is the pull/curate side (author, find, replace, archive). **ADRs** record decisions with a real alternative, a constraint on future work, and non-trivial cost — stricter lifecycle, global ID allocation.
+
+Both surfaces (MCP `orbit_learning_*`/`orbit_adr_*`, CLI `orbit tool run orbit.learning.*`/`orbit.adr.*`) accept identical JSON; always include `model` (agent family: `codex`/`claude`/`gemini`/`grok`). Prefer `--body-file`/`--input-file` over inline JSON so multi-line markdown isn't mangled by shell quoting.
+
+## Shared rules (apply to both)
+
+- **Never hand-edit `.orbit/learnings/<id>/learning.yaml` or `.orbit/adrs/<status>/<id>/{adr.yaml,body.md}`.** All writes go through the tools so envelope cache, supersede pointers, and audit events stay consistent.
+- **Never invent an ID.** `add` allocates both learning and ADR IDs globally; cite the returned ID verbatim.
+- **Stage new artifact files from the current worktree** alongside the code/doc change that motivated them — sibling worktrees see remote stubs until that worktree's body files are locally readable.
+- **Update replaces, does not merge** — re-pass unchanged fields (`scope`/`evidence` for learnings; full body for ADRs) or you'll silently wipe them. **Supersede** when guidance/decision materially changes; it writes both pointers atomically and excludes the old record from default search. `update` is rejected on an already-superseded record — `supersede` again instead.
+- **Citation-at-anchor, with a hard prohibition.** When a learning/ADR encodes a convention enforced at a specific code site, drop a one-line citation (`// L-NNNN: <rationale>` or `// <adr-id>: <rationale>`) at that site. **Never** place the citation inside `crates/**/assets/**` (skill files, prompt assets, shipped plugin assets) or other consumer-facing surfaces — workspace-local artifact IDs become dangling references in other workspaces. At those surfaces, the push-injected learning (or a `## Consequences` sentence for ADRs) is the delivery mechanism instead.
+- **Search before adding**, to avoid duplicate/contradicting records covering the same scope.
+
+## Learnings
+
+| Tool / workflow | MCP | CLI |
+|------|-----|-----|
+| Add | `orbit_learning_add({...})` | `orbit learning add --summary "..." --path "crates/orbit-core/**/*.rs" --tag rust --body-file note.md` |
+| Search | `orbit_search({...})` | `orbit search --kind learning <text>` (add `--hybrid` after `orbit semantic index --kind learnings`) |
+| Show / update / supersede | `orbit_learning_show/update/supersede({...})` | `orbit learning show --id L-0001` / `update --id L-0001 --priority 200` / `supersede --id L-0001 --with L-0007` |
+| List/audit, prune, sync | CLI-only | `orbit learning list --status active --tag rust [--path <glob>]`, `orbit learning prune --stale-only [--delete]`, `orbit learning sync` |
+
+**Workflow:** (1) search first — `orbit learning list --path/--tag` or `orbit search --kind learning` — prefer `update`/`supersede` over a duplicate. (2) Add with tight `scope: { paths?, tags? }` (OR semantics — fires on *any* path glob OR *any* tag; split concerns into separate learnings rather than over-broadening one). Include `evidence: [{kind: "task"|"commit"|"external", ref: "..."}]` whenever it came from a real incident/PR/task — a learning you can't cite a source for is a hunch. `priority` (0–255) is a secondary search-ranking key, not an importance badge. Keep `summary` ≤280 chars, written as a directive ("Always X before Y in `<crate>`"), since push-injection surfaces it first. (3) `prune --stale-only` periodically to surface learnings whose `scope.paths` no longer resolve; read before `--delete`. (4) `sync` (CLI-only) re-syncs the SQLite envelope index if YAML was touched out-of-band (merge, branch switch) — YAML is the source of truth.
+
+Legacy `L<YYYYMMDD>-N` IDs were migrated by ORB-00200 and should only appear in `legacy_ids`; canonical format is `L-NNNN`. Corrections to current wording go through `update`; material changes go through `supersede`; provenance for a new observation goes into `evidence`. (ORB-10046 removed the vote and comment surfaces — `priority` + search rank cover ranking, and `update`/`supersede`/`evidence` cover corrections/provenance.)
+
+```bash
+orbit learning add --summary "Always run \`make fmt\` before committing under crates/orbit-cli — clippy fails on stray spacing" \
+  --path "crates/orbit-cli/**/*.rs" --tag rust --tag formatting --body-file /tmp/learning.md \
+  --evidence task:T20260514-3 --priority 100 --json
+```
+
+Common mistakes: hand-writing YAML (skips envelope+attribution — use the tools); creating a duplicate without checking first (two overlapping-scope records inject twice and contradict); `update` to "fix" a fundamental change in advice (loses the supersede chain — `supersede` instead); `scope` with no `paths` and no `tags` (never injects).
+
+Exit: the learning exists/updates through `orbit.learning.*`, has a directive `summary`, ≥1 `paths`/`tags` entry, evidence when it exists, and is retrievable via `orbit learning show --id <ID>`. A code-anchored learning ships its citation in the same change.
+
+## ADRs
+
+| Tool | MCP | CLI |
+|------|-----|-----|
+| Add / show / update / supersede | `orbit_adr_add/show/update/supersede({...})` | `orbit tool run orbit.adr.add --input-file adr.json` / `.show --input '{"id":"<id>"}'` / `.update --input-file update.json` / `.supersede --input '{"old_id":"...","new_id":"..."}'` |
+
+Listing is **not** on the agent MCP surface — use `orbit search --kind adr` for read-side discovery; CLI/admin retains `orbit tool run orbit.adr.list --input '{"feature":"<feature>"}'` (agents shouldn't call it via MCP). ADRs and docs are sibling indexes: `orbit search --kind all|doc|adr` federates ADR metadata read-only; `--hybrid` applies to `--kind adr` after `orbit semantic index --kind adrs`.
+
+**When editing `docs/design/<feature>/4_decisions.md` directly:** if you're about to add or rename a `## ADR-` heading, **stop and run `orbit.adr.add` first**, then use the allocated global ID as the local heading verbatim. Picking the next sequential local number, or a number that merely "looks global," both produce orphan decisions invisible to `orbit search --kind adr` / `orbit.adr.show` / legacy_id resolution. Backfill an existing local-numbered ADR via `orbit.adr.add` and set `legacy_ids`.
+
+**Workflow:** (1) inspect nearby decisions first (`orbit search "<concept>" --kind adr`, `orbit.adr.show`, `legacy_id` lookup for migrated per-feature refs). (2) new decision → `add`; body/metadata correction → `update`; reversal of an accepted ADR → create the replacement, accept it with a related task, then `supersede`. (3) body needs exactly `## Context`, `## Decision`, `## Consequences`, with ≥1 consequences bullet starting `Cost:`. (4) `related_features` = feature-folder names; `tags` = free-form cross-artifact labels; `paths` = repo-relative globs the decision constrains. (5) `related_tasks` may be empty for a speculative proposed ADR — don't invent a task just to satisfy one; **acceptance requires a real related task**. (6) verify with `.show` or `orbit search --kind adr`.
+
+Creation is warranted only when all three hold: a real alternative was on the table, the choice constrains future work, and the cost is non-trivial and worth preserving. Otherwise put the detail in `2_design.md`, a spec, or an existing ADR's instance table.
+
+```markdown
+## Context
+<1-3 sentences: what forced a decision, what alternatives were real>
+## Decision
+<1-3 sentences: what was chosen>
+## Consequences
+- <observable/operational consequence>
+- Cost: <explicit tradeoff future readers need to know>
+```
+
+```bash
+orbit tool run orbit.adr.add --input-file /tmp/orbit-adr.json --pretty
+# {"title":"...","body":"## Context\n...\n## Decision\n...\n## Consequences\n- ...\n- Cost: ...\n",
+#  "owner":"codex","related_features":["task-artifacts"],"related_tasks":[],"tags":[...],"paths":[...],"model":"<agent-family>"}
+```
+
+Common mistakes: hand-writing `.orbit/adrs/...` (skips allocation/validation/provenance); creating a task just to propose (proposed ADRs allow empty `related_tasks`); accepting without a real task (acceptance requires one, add it in the same `update` call); omitting `Cost:` (validator rejects new ADRs without it); treating a local heading number as global (use the allocated ID, alias via `legacy_ids`).
+
+Exit: the ADR exists/updates through `orbit.adr.*`, has a valid body, names relevant features, preserves meaningful legacy aliases, and reads back via `.show`. A code-anchored ADR ships its citation in the same PR.

--- a/plugin/skills/orbit-search
+++ b/plugin/skills/orbit-search
@@ -1,1 +1,0 @@
-../../crates/orbit-core/assets/skills/orbit-search

--- a/plugin/skills/orbit-search/SKILL.md
+++ b/plugin/skills/orbit-search/SKILL.md
@@ -1,0 +1,101 @@
+---
+name: orbit-search
+description: Use when searching tasks, docs, learnings, or ADRs through the unified `orbit search` query surface; also covers the `orbit semantic` embedding-companion lifecycle, and the human-authored docs corpus — searching, listing, showing, registering, reindexing, or migrating docs (locked frontmatter schema, recommended docs layout, learning-vs-doc boundary, ADR routing).
+---
+
+# Orbit Search
+
+Use `orbit search` to find project context by topic, literal phrase, or related task ID. The query surface is `orbit search`; the lifecycle surface is `orbit semantic install|uninstall|stats|index`. `orbit graph` remains the tool for code-structure questions (callers, refs, implementors, symbol selectors) — search is corpus retrieval, graph is structural traversal.
+
+## Query Surface
+
+| Tool | MCP | CLI |
+|------|-----|-----|
+| `orbit.search` | `orbit_search({...})` | `orbit tool run orbit.search --input '{...}'` |
+
+Include `model` in JSON inputs for provenance (your agent family). See the `orbit` skill for the full surface-mapping rule.
+
+```bash
+# Lexical global search across tasks, docs, learnings, and ADRs
+orbit search "slow inference after model swap" --limit 5
+
+# Cross-artifact label and path filters (--tag is AND when repeated)
+orbit search "scheduler" --tag perf --kind all
+orbit search path crates/orbit-search/src/lib.rs --kind all
+
+# Hybrid lexical + cosine over indexed fields
+orbit search "agent loop deadlock" --hybrid --kind task --limit 5
+
+# Cosine neighbors of a known task (requires the semantic companion)
+orbit search similar "<task-id>" --limit 5   # MCP: {"semantic":"<task-id>","limit":5}
+```
+
+`orbit search path <path>` applicability lookup: task results use selector containment over `context_files`; learning/ADR results use glob-containment over stored path scopes; docs are content-indexed and don't match by applicability path. `--status` values use `kind:value` tokens (e.g. `--status task:open,doc:active,adr:proposed`) — bare tokens are rejected since statuses collide across corpora.
+
+**Index coverage:** lexical covers tasks, docs, learnings, ADRs. Vector search covers task fields plus docs/learnings/ADRs after `orbit semantic index --kind docs|learnings|adrs`. Missing vectors under `--hybrid` fall back to lexical with a note rather than failing.
+
+**When to use:** (1) pre-create dedup check — `--hybrid --kind task` before adding a task; (2) pre-execute related lookup — `semantic: "<task-id>"` after `orbit.task.show` to surface prior decisions the author may not have linked; (3) ad-hoc — "where did we decide X" starts with `orbit search "X" --kind all`.
+
+**Stop rule:** if one well-formed query returns useful hits, stop and inspect — don't chain rewrites chasing higher scores. Don't use search for "find every symbol matching X" — that's `orbit.graph.search`.
+
+## Semantic Companion Lifecycle
+
+`orbit semantic` manages the local embedding companion — it is not the query namespace.
+
+| Purpose | Form |
+|---------|------|
+| Install / remove | `orbit semantic install [--model M] [--force]` / `orbit semantic uninstall [--model M] [--all]` |
+| Status | `orbit semantic stats` |
+| Rebuild embeddings | `orbit semantic index --kind tasks\|docs\|learnings\|adrs\|all [--model M] [--force]` |
+
+Supports macOS arm64 and Linux x86_64/aarch64 with glibc ≥ 2.38; no x86_64-apple-darwin asset. Don't run `install` without operator consent; if a semantic query fails because the companion is missing, fall back to lexical `orbit search --kind <kind> <query>` and continue unless the user explicitly opted in.
+
+Result shape: `mode`, `kind`, `notes`, `results[]` — each with `kind`, `source`, and some of `id`/`path`/`title`/`summary`/`status`/`best_field`/`snippet`/`score`/`matched_by`. Treat scores as relative ordering, not confidence; read snippets/matched fields before judging relevance.
+
+## Docs Corpus
+
+Orbit docs are PR-reviewed Markdown under configured `[docs].roots` (default `docs/`) — designs, reusable patterns, domain notes, glossaries, runbooks. Registration-light: Orbit walks configured roots on demand and indexes files with valid frontmatter (tolerant fallback for legacy design/pattern docs).
+
+Frontmatter (`type` and `summary` required; `summary` non-empty single line):
+
+```yaml
+---
+type: design | pattern | context | glossary | runbook
+summary: One-line hook for agent retrieval
+tags: [hook, learning, audit]
+paths: ["crates/orbit-cli/**"]
+related_features: [hook-rewrite]
+related_artifacts: ["<task-id>", "<adr-id>", "<learning-id>"]
+---
+```
+
+Recommended (not enforced) layout: `docs/design/<feature>/`, `docs/design-patterns/`, `docs/context/`, `docs/glossary.md`, `docs/runbooks/`.
+
+**Learning vs Doc:** a learning is a load-bearing rule with a known failure mode — managed through `orbit.learning.*` (see `orbit-knowledge`), scope-glob push-injected, updatable/supersedable. A doc is explanatory context — PR-reviewed, retrieved via `orbit.search --kind doc`, no supersede flow. Link a doc to a load-bearing learning with `related_artifacts: [L-NNNN]`.
+
+**Routing:** ADRs are owned by `orbit-knowledge` and live at `.orbit/adrs/{accepted,proposed,superseded}/<adr-id>/` — docs does not walk `.orbit/`, but `orbit search --kind all|adr` federates ADR metadata alongside doc hits (`--all` includes superseded ADRs for archaeology). `orbit-design` is retired in favor of this tolerant surface.
+
+**Admin/CLI-only workflows** (agents use `orbit.search` for retrieval; these are human/admin):
+
+| Verb | Form |
+| --- | --- |
+| List | `orbit docs list --json [--type <type>] [--tag <tag>]` |
+| Show | `orbit docs show <path> --json` |
+| Add root | `orbit docs add <path>` (existing non-`.orbit/` roots only) |
+| Index | `orbit docs index --json` (after substantial edits/moves; idempotent via content hashes) |
+| Migrate | `orbit docs migrate --dry-run` then without, to backfill locked frontmatter for legacy `docs/design/<feature>/*.md` and `docs/design-patterns/*.md` — never touches `.orbit/` |
+
+## Common Mistakes
+
+| Mistake | Why it fails | Correct form |
+|---------|---------------|--------------|
+| Calling lifecycle commands to search | `orbit semantic` manages the companion | Use `orbit search` / `orbit.search` |
+| Aborting when the companion isn't installed | Embeddings are optional infra | Fall back to lexical unless the user opted in |
+| Using semantic search for exact identifiers | Lexical is cheaper/predictable for names, paths, error strings | Plain `orbit search` or `orbit.graph.search` |
+| `--semantic <id>` on a brand-new task | May not have embeddings yet | `--hybrid --kind task` on title/description |
+
+## Cross-References
+
+- `orbit-graph` — code-structure queries.
+- `orbit-task` — pre-create dedup check, pre-execute related-task lookup.
+- `orbit-knowledge` — learnings and ADRs this skill retrieves but does not author.

--- a/plugin/skills/orbit-task
+++ b/plugin/skills/orbit-task
@@ -1,1 +1,0 @@
-../../crates/orbit-core/assets/skills/orbit-task

--- a/plugin/skills/orbit-task/SKILL.md
+++ b/plugin/skills/orbit-task/SKILL.md
@@ -1,0 +1,146 @@
+---
+name: orbit-task
+description: The task-lifecycle skill — create a task, execute an existing Orbit task or human request through the lifecycle with explicit status tracking, review someone else's work and leave inline feedback as review threads, and file self-reported friction when Orbit tooling or skill instructions cause operational problems. Triggers on "create a task", "review T-id", "review this PR", "leave review feedback", tool failures, wrong CLI behavior, or misleading skill guidance. Not for task content issues like vague descriptions (fix those by re-authoring) or ordinary user-requested work/generic bugs (use friction only for self-reported Orbit tooling/workflow friction).
+---
+
+# Orbit Task
+
+Both surfaces (MCP `orbit_task_*` / CLI `orbit tool run orbit.task.*`) accept identical JSON; **always include `model`** (your agent family: `codex`, `claude`, `gemini`, or `grok` — full strings auto-normalize). See the `orbit` skill for the full surface-mapping rule. Never use direct `orbit task ...` CLI — it skips agent provenance; use `orbit tool run orbit.task.<action>` instead.
+
+## 1. Create
+
+Create a task another engineer or agent can execute without guessing: a crisp problem description plus strong acceptance criteria. The execution plan is authored later, at pickup.
+
+**Workflow:**
+1. Confirm objective, constraints, and done criteria.
+2. Optionally check for overlapping prior work with `orbit-search` (`hybrid: true`, `kind: "task"`).
+3. Write acceptance criteria that define observable success — no vague pass/fail language like "works correctly"; name a command, inspection step, or observable output for each.
+4. Enumerate files/dirs/symbols this task will modify or delete as canonical selectors (`file:`, `dir:`, `symbol:path#name:kind`) in `context_files`. Only modification targets — not read-for-context files, conventions/pattern docs (cite those in prose instead), or files that don't exist yet. Feature design docs under `docs/design/<feature>/` are the exception (co-change with implementation). Prefer `file:`/`symbol:` over `dir:` when changes can be named more precisely.
+5. Set `complexity` (`low`/`medium`/`hard`) whenever scope is clear enough to judge — batching honors this via `crates/orbit-engine/src/executor/automation/batch/dispatch.rs::task_prefers_single_batch`.
+6. Add assumptions, risks, and rollback notes to the description when they matter.
+7. Call `orbit.task.add` with description, acceptance criteria, `context_files`, workspace, complexity, and `model`. Leave `plan` blank unless pre-seeding is justified.
+8. Confirm via the tool result, or re-fetch with `orbit.task.show`.
+
+**Operating rules:** Never edit task files directly. Never invent task IDs — `orbit.task.add` allocates them. `description` should be multi-line markdown for non-trivial tasks. Required: `title`, `description`, `workspace`. Strongly prefer `acceptance_criteria` and `complexity`. Valid `type`: `feature`, `bug`, `refactor`, `chore` — use friction (below) for self-reported tooling issues, not a task type. Blank/missing companion files (`plan.md`, `execution-summary.md`) are blank fields — repair via `orbit.task.update`, never by hand.
+
+**Behavior-affecting optional fields:**
+- `dependencies: ["ORB-NNNN", ...]` — prerequisite tasks must reach a satisfying status first (`crates/orbit-common/src/types/task.rs::task_dependencies_ready`).
+- `relations: [{"type": "resolves", "target": "F<YYYY>-<MM>-<NNN>"}]` — auto-resolves the target friction when this task reaches `done` (`crates/orbit-core/src/command/task/transitions.rs::apply_resolves_side_effects`). Other `relations` types (`produces`, `blocked_by`, `child_of`, `spawned_from`, `regression_from`, `supersedes`, `related_to`) are tracked; only `produces`/`resolves` accept non-`ORB-` targets (friction/learning/ADR IDs), the rest require `ORB-NNNNN`. Dangling `resolves`/`produces` targets succeed but emit a `TaskRelationDangling` audit event.
+- `parent_id`, `source_task_id` (bug-introducing task; creation-time only — `update` silently drops it on existing tasks, see F2026-05-024/ORB-00101), `tags` (reuse existing before inventing new).
+
+**Task quality bar:** validation must not assume `.orbit/knowledge/` or uncommitted artifacts; file I/O checks use temp dirs/fakes; behavior-changing tasks touching external services/FS/time should call for deterministic mock coverage in acceptance criteria; graph/knowledge task nodes define `purpose` as role + crate/module + leaf-or-internal.
+
+```bash
+orbit tool run orbit.task.add --input '{
+  "title": "<title>", "description": "<multi-line markdown>",
+  "acceptance_criteria": ["<observable outcome 1>", "<observable outcome 2>"],
+  "context_files": ["file:src/lib.rs", "dir:src/command", "symbol:src/lib.rs#run:function"],
+  "plan": "", "workspace": "<path>", "priority": "<low|medium|high|critical>",
+  "complexity": "<low|medium|hard>", "type": "<feature|bug|refactor|chore>",
+  "model": "<agent-family>"
+}'
+```
+
+Description template:
+
+```markdown
+## Problem
+<what is broken, missing, or needs to change>
+## Why It Matters
+<user impact, operational impact, or engineering rationale>
+## Constraints / Notes
+- <important constraint>
+```
+
+Exit: task exists with strong description, clear acceptance criteria, and (when applicable) `context_files` naming only real modification targets via canonical selectors.
+
+## 2. Execute
+
+Carry a task (or human request, once created above) from intent to verified implementation with explicit lifecycle tracking.
+
+**Step 1 — Load or create.** Given an existing ID, `orbit.task.show` and extract `description`/`acceptance_criteria` (required outcome), `plan` (author one if blank/placeholder), `context_files` (resolve via `orbit_graph_show`/`orbit_graph_overview` first, `fs.read` only for unresolved selectors), `status`. Then call `orbit.search` with `semantic: "<task-id>"`, `limit: 5` (non-blocking — skip if the companion is missing or nothing's relevant) to surface prior related decisions. No ID yet → clarify intent with the human, then use Create above.
+
+**Step 2 — Plan.** `orbit.task.update` with a concrete markdown `plan` (target files, validation commands, risks) if one doesn't already exist.
+
+**Step 3 — Start.** `orbit.task.start` with a `note`. Moves `backlog`/`proposed` → `in-progress` (records approval automatically). Starting from `proposed` still requires a real plan.
+
+**Step 4 — Implement and validate.** Follow the plan; resolve `context_files` selectors via graph tools before raw reads; run the repo-approved verification commands (honor repo instructions if tests are forbidden).
+
+**Step 5 — Summarize and hand off.** Persist `execution_summary` via `orbit.task.update` first (template below). Learning checkpoint: if the task surfaced a contradicted assumption, recurring failure mode, non-obvious gotcha, or incident root cause, follow `orbit-knowledge` and call `orbit.learning.add`; skip otherwise. Then:
+- **Under an activity envelope** (e.g. `agent_implement`): persist the summary only — the pipeline owns the `review` transition after commit/merge/PR steps succeed.
+- **Direct execution** (no envelope): persist the summary and move to `review` via `orbit.task.update`.
+
+Execution summary — required content (the generated PR body supplies `## Task`/`## Execution Summary`/`## Validation`/`## Branch Freshness`; don't duplicate those headings):
+
+```markdown
+Outcome: success | failed
+Changes:
+- <what changed and why>
+Assessment: <short quality assessment>
+```
+
+Include when relevant: `Strategic decisions:`, `Design weaknesses / risks:` (with Severity/Mitigation), `Deviations from original plan:` (with Justification), `Recommended follow-ups:`.
+
+**Lifecycle rules:** one task per activity invocation — no multiplexing. Ask clarifying questions before implementing if material ambiguity remains. If `proposed`-work approval can't be obtained, stop after recording that state. Don't skip lifecycle updates. Direct execution must persist a non-empty `execution_summary` before/with the review transition.
+
+Exit: task started via `orbit.task.start`; execution summary persisted; learning checkpoint considered; direct execution advanced to `review` (envelope-driven execution leaves that to the pipeline).
+
+## 3. Review
+
+Review someone else's work and surface issues as review threads — read plus write-only-into-threads; **never** transition the reviewed task's lifecycle.
+
+**Load context.** `orbit.task.show` for `description`/`acceptance_criteria`/`plan`/`execution_summary`; inspect the diff and changed files; run `make build` and the relevant test target. Optionally `orbit.search` with `semantic: "<task-id>"` for prior similar decisions.
+
+**Two-stage review — stage 1 first:** spec compliance (does the change satisfy every acceptance criterion? anything missing or added beyond scope? interpretation gaps?). If it fails, file those threads and stop — don't spend time on stage 2. **Stage 2** (only if stage 1 passes): maintainability, patterns, performance, test-coverage gaps, risks/edge cases/security.
+
+**File threads** one per distinct issue — inline (`path` + string `line`) when location-specific, general otherwise:
+
+```text
+**[Spec compliance | Code quality | Nit] — short headline.**
+Why this matters / what's wrong.
+Suggested fix.
+```
+
+```bash
+orbit tool run orbit.task.review_thread.add --input '{"id":"<task-id>","body":"<finding>","path":"<path>","line":"<line>","model":"<agent-family>"}'
+orbit tool run orbit.task.review_thread.list --input '{"id":"<task-id>","status":"open","model":"<agent-family>"}'
+orbit tool run orbit.task.review_thread.reply --input '{"id":"<task-id>","thread_id":"<id>","body":"<reply>","model":"<agent-family>"}'
+orbit tool run orbit.task.review_thread.resolve --input '{"id":"<task-id>","thread_id":"<id>","model":"<agent-family>"}'
+```
+
+**Summarize** in chat: thread count, which are blockers, overall verdict (approve/request changes). Don't add a task `comment` — threads are the persistent surface.
+
+**Meta-review.** After filing threads, check whether they reveal a gap in an Orbit-authored instruction asset (`crates/orbit-core/assets/activities/*.yaml`, or a `SKILL.md`). Trigger: ≥2 threads map to the same instruction gap, or one thread is clearly a recurring class. When it fires, file a friction (see §4) *in addition to* the individual threads — never as a replacement. Skip for a single nit, a style preference, or a one-off mistake with no link to instruction text.
+
+**Rules:** never transition the reviewed task's status; never resolve threads you authored (exception: retracting your own thread); always include `model` on `review_thread.add`/`.reply` (rejected without it — `list`/`.resolve` don't require it); replies don't create new findings, only `.add` counts toward the scoreboard. No PR yet → threads stay local; with a PR, they mirror as PR review comments.
+
+**Not for:** implementing a task (§2); a task lifecycle approval (`orbit.task.approve`, owned by the reviewee/human).
+
+Exit: all findings filed with `model` attribution; no status transitions/resolutions on the reviewed task; chat summary names blocker count and verdict.
+
+## 4. Friction (self-reported tooling/skill issues)
+
+File **agent-discovered Orbit tooling, workflow, or seeded-instruction friction** as an append-only report instead of silently working around it — unclear command behavior, missing CLI functionality, confusing schema/config, doc gaps, unclear errors, unexpected runtime behavior, confusing seed instructions, or insufficient/vague activity-asset or `SKILL.md` prompts. **Not** for task content issues, ordinary user-requested work, or generic bugs.
+
+Stored under `.orbit/frictions/` as append-only markdown+frontmatter — no lifecycle, triage state, or scoreboard.
+
+| Tag | Use for |
+| --- | --- |
+| `build` | make/fmt/lint friction |
+| `docs` | Stale/missing CLAUDE.md or design docs |
+| `lifecycle` | Task lifecycle confusion/transition issues |
+| `naming` | Naming drift or duplicated sources of truth |
+| `policy` | fsProfile or sandboxing surprises |
+| `skill-guidance` | Misleading or incorrect skill instructions |
+| `tooling` | Orbit tool/CLI/MCP failures |
+| `other` | Fallback |
+
+```bash
+orbit tool run orbit.friction.add --input '{
+  "body": "<what happened, where, and why it caused friction>",
+  "tags": ["<tag from table>"], "during_task": "<optional task id>",
+  "model": "<agent-family>"
+}'
+```
+
+**Rules:** never silently ignore an Orbit problem — always report; never implement large design changes inline, track them first; name the concrete command/file/workflow that broke; report genuine friction only.

--- a/plugin/skills/orbit/SKILL.md
+++ b/plugin/skills/orbit/SKILL.md
@@ -1,0 +1,96 @@
+---
+name: orbit
+description: Entry point for Orbit. Once a workspace is initialized (`.orbit/` present), routes to workflow siblings (`orbit-task`, `orbit-workflow`, `orbit-search`, `orbit-knowledge`, `orbit-graph`) and covers tool invocation surfaces and task lifecycle. When `.orbit/` is absent, or for first-time setup/install ("set up orbit", "install orbit", "wire orbit into this repo", "I'm new to orbit") or feature-tour requests ("what is orbit", "give me a tour"), see references/guide.md.
+---
+
+# Orbit
+
+## Purpose
+
+This skill orients agents working with Orbit. Operations should go through the registered Orbit tool surface — not direct CLI subcommands or rebuilds from source.
+
+Lifecycle and authoring details live in the per-topic skills below; this skill stays brief on purpose.
+
+## First-Time Setup / Tour
+
+If `.orbit/` is absent in the current workspace, or the user asks "what is orbit" / "give me a tour" / hasn't committed to using it yet, read [references/guide.md](references/guide.md) and follow it end-to-end (detect state → pick setup path → run setup → verify → hand off). Once the workspace is initialized, the rest of this skill applies.
+
+## Tool Invocation
+
+Orbit tools are reachable via two surfaces. Both accept identical JSON arguments.
+
+| Surface | When to use | Form |
+|---------|-------------|------|
+| **MCP** | Claude Code with the orbit plugin (or any MCP client connected to `orbit mcp serve`); look for `orbit_*` tools in your toolbox | `orbit_task_add({"title": "...", "model": "<agent-family>"})` |
+| **CLI** | Shell access (inside an activity step, or with the `orbit` binary on `PATH`) | `orbit tool run orbit.task.add --input '{"title": "...", "model": "<agent-family>"}'` |
+
+**Mapping rule**: `orbit.<group>.<action>` ↔ `orbit_<group>_<action>` (dots become underscores; JSON args identical). For multi-segment names like `orbit.task.review_thread.add`, every dot becomes an underscore: `orbit_task_review_thread_add`.
+
+**Environment parity**: the orbit tool surface is identical everywhere. On machines without a local orbit store, the same `orbit_*` tools are served by the bridge MCP, which mirrors the orbit MCP exactly (plus an optional `workspace` routing param on tools that lack one); bridge-only extensions (`workflow_ship`, `agent_invoke`, …) handle cross-workspace and pipeline operations.
+
+**Surface coverage:**
+
+- Task lifecycle (`orbit.task.*`), ADR artifacts (`orbit.adr.*`), learnings (`orbit.learning.*`), unified search (`orbit.search`): both surfaces.
+- Graph tools (`sync`, `search`, `show`, `refs`, `callees`, `impact`, `trace`, `overview`, `implementors`, `deps`): **MCP only** — served in-process by orbit-graph (v2). There is no `orbit tool run orbit.graph.*` path and no `orbit graph` subcommand; for direct human/CLI use run the standalone `orbit-graph-cli` binary. Task-to-commit lookup is not a graph tool; use `git log --grep '[T<task-id>]'`.
+- Semantic lifecycle (`orbit semantic install|stats|index|uninstall`) and state handoff (`orbit.state.*`), routine/sweep/job commands: **CLI only** — used inside activity steps or from a shell where the agent has direct process access.
+
+**Always include `model` in the JSON** so Orbit can attribute the call to the right agent family: `codex`, `claude`, `gemini`, or `grok`. Full model strings are accepted and auto-normalized, but the family is the persisted identity.
+
+**CLI-flag → JSON mapping:** the CLI exposes some flags (e.g. `orbit tool run orbit.task.show --full ...`) that don't appear over MCP. The MCP equivalent is the default behavior when the corresponding JSON field is omitted (e.g. `orbit_task_show({"id": "<id>"})` returns the full task; pass `field` or `fields` to project).
+
+Examples below use CLI form for readability; substitute the MCP form using the mapping above when MCP tools are loaded.
+
+## Common Command Reference
+
+Intentionally common, not exhaustive. Never guess — run `orbit tool list` (CLI) or call `tools/list` (MCP) for the full registered tool surface. If an activity already injected `task` into the execution envelope, use that snapshot instead of calling `orbit.task.show` again.
+
+```bash
+orbit tool run orbit.task.show --full --input '{"id": "<id>", "model": "<agent-family>"}'                    # Load full task
+orbit tool run orbit.task.show --input '{"id": "<id>", "field": "comments", "model": "<agent-family>"}'       # Load one field
+# Valid field values: comments, plan, execution_summary, description, acceptance_criteria, history, context_files, artifacts
+orbit tool run orbit.task.list --input '{"status": "backlog", "model": "<agent-family>"}'
+orbit tool run orbit.task.list --input '{"path": "src/auth/login.rs", "model": "<agent-family>"}'             # Tasks whose context_files apply to this path
+orbit tool run orbit.search --input '{"query": "topic phrase", "kind": "task", "limit": 5, "model": "<agent-family>"}'
+orbit tool run orbit.search --input '{"query": "topic phrase", "hybrid": true, "kind": "task", "limit": 5, "model": "<agent-family>"}'
+orbit tool run orbit.task.add --input '{"title": "...", "description": "...", "acceptance_criteria": ["..."], "workspace": ".", "model": "<agent-family>"}'
+orbit tool run orbit.task.update --input '{"id": "<id>", "plan": "...", "model": "<agent-family>"}'
+orbit tool run orbit.task.start --input '{"id": "<id>", "note": "...", "model": "<agent-family>"}'            # backlog -> in-progress
+orbit tool run orbit.task.approve --input '{"id": "<id>", "note": "...", "model": "<agent-family>"}'          # proposed/friction -> backlog, review -> done
+orbit tool run orbit.task.review_thread.add --input '{"id": "<id>", "body": "...", "path": "<path>", "line": "<line>", "model": "<agent-family>"}'
+```
+
+## Common Mistakes — DO NOT
+
+| Mistake | Why it fails | Correct form |
+|---------|-------------|--------------|
+| `cargo run -- tool run ...` | Agents must use the installed `orbit` binary, not rebuild from source | `orbit tool run ...` |
+| `orbit task show <id>` | Direct CLI subcommands skip agent provenance tracking | `orbit tool run orbit.task.show --full --input '{"id":"<id>"}'` |
+
+## Lifecycle
+
+```text
+proposed → backlog → in-progress → review → done
+         ↘ rejected
+friction → backlog | in-progress | done
+         ↘ rejected
+
+someday → in-progress
+blocked → in-progress
+
+review      → rejected
+rejected    → backlog | in-progress  (reconsider)
+```
+
+Use `blocked` when execution cannot safely continue. Command surface determines provenance by default: `orbit tool run ...` is agent-driven, direct `orbit task ...` CLI usage is human-driven.
+
+## Skill Selection
+
+- `orbit-task`: Create, execute, and review tasks through the full lifecycle; also files self-reported tooling/skill-guidance friction.
+- `orbit-workflow`: Jobs, activities, routines, `orbit sweep`, and `orbit run`; diagnosing failed/stuck/cancelled job runs.
+- `orbit-search`: Find tasks, docs, learnings, and ADRs by topic; docs-corpus admin (list/show/add root/index/migrate).
+- `orbit-knowledge`: Author, update, and supersede learnings and ADRs.
+- `orbit-graph`: Navigate or inspect the codebase via the orbit-graph code index.
+
+## Voice Your Opinion
+
+If something is unclear, missing, buggy, or creates friction during agent work, track it with `orbit-task` (friction reporting).

--- a/plugin/skills/orbit/references/guide.md
+++ b/plugin/skills/orbit/references/guide.md
@@ -1,0 +1,115 @@
+# Orbit Guide (first-time setup & tour)
+
+Get a first-time user from zero to a usable Orbit workspace, then hand off to `orbit-task` for their first real task. Also handles feature-tour questions ("what is orbit", "what can it do", "give me a tour") by reading the canonical docs at invocation time rather than answering from memory.
+
+## When to use this reference vs. the rest of `orbit`
+
+- `.orbit/` missing in the current workspace → this reference.
+- User asks "what is orbit", "give me a tour", or otherwise has not committed to using it yet → this reference.
+- Workspace already initialized and the user references a task or asks to do Orbit work → the rest of the `orbit` skill and its siblings.
+
+## Canonical sources
+
+The README and config reference live in the Orbit repo. On a non-clone install path (plugin or binary-only install) there is no local copy yet — use `WebFetch` against the raw URLs below instead of answering from this snapshot.
+
+- Repo: https://github.com/danieljhkim/orbit
+- Raw README: https://raw.githubusercontent.com/danieljhkim/orbit/main/README.md
+- Raw config reference: https://raw.githubusercontent.com/danieljhkim/orbit/main/docs/CONFIG.md
+
+Always re-fetch. The README is the source of truth for install commands, destructive-action confirmation rules, and prereq versions. This reference intentionally does not duplicate any of it.
+
+## Step 1 — Detect current state
+
+Run in parallel; the answers determine which branch in Step 2 applies:
+
+```bash
+command -v orbit          # is the binary on PATH?
+test -d .orbit            # is the workspace initialized?
+test -d ~/.orbit          # is global state initialized?
+rustc --version           # only relevant for the clone-and-build branch
+```
+
+Report the four results to the user before proposing any installs.
+
+## Step 2 — Pick a setup path
+
+Ask one question (per the user-interaction guardrails) and offer three branches. The actual commands come from the README, not from this reference:
+
+1. **Clone-and-build branch (recommended).** README section "Setup via Agent Prompt" — the canonical agent-driven setup script.
+2. **Plugin branch.** README sections "Claude Code Plugin vs CLI" and "Manual Setup".
+3. **Curl-or-brew branch.** README section "Manual Setup".
+
+Do not paraphrase the commands here. Re-read the README at invocation time; it may have moved on from this snapshot.
+
+## Step 3 — Run setup
+
+Follow the destructive-action confirmation rules stated in the README's "Setup via Agent Prompt" block — that is the source of truth. If a step fails (missing toolchain, permission error, registration error), surface the failure and offer `orbit-task` friction reporting to capture it. First-time setup is exactly the signal that exists for.
+
+## Step 4 — Verify
+
+```bash
+orbit --version
+orbit task list
+orbit semantic stats   # only if the user opted into the semantic embedder
+```
+
+Report the output. If any of these fail, jump back to Step 3 — do not declare success.
+
+## Step 5 — Hand off
+
+- **First real task** — invoke `orbit-task`'s create workflow. Do not silently author the task; it enforces quality gates the user benefits from seeing.
+- **Feature tour** — read the README's `## Primary Features` section and summarize against the user's stated goal, not generically. The tour content is the README's, not this reference's.
+
+After hand-off, subsequent Orbit work routes through the rest of the `orbit` skill and its lifecycle siblings.
+
+## Routines & scheduling (`orbit sweep`)
+
+Routines make Orbit the host's scheduler: a git-versioned YAML definition (`.orbit/routines/*.yaml`) pairs a cron trigger with a catalog `job:<name>` target, host pinning, and a retry/overlap policy. A stateless `orbit sweep` pass — invoked every minute by the OS clock (launchd / systemd timer) — fires whatever is due on this host as a normal run. Definitions sync across hosts via git; **all scheduler state (last fires, pauses, locks) is host-local in `~/.orbit/orbit.db` and never synced.** Full detail (job/activity/`orbit run` usage) lives in the `orbit-workflow` skill; this section covers setup only.
+
+**Canonical sources — read at invocation time; don't answer routine field semantics from memory:** design contract at `docs/design/routines/2_design.md` §1 (field-by-field schema); command surface via `orbit routine --help` and `orbit sweep --help`.
+
+Setup sequence (skeleton is stable; re-read the design doc for full field semantics before hand-authoring a routine):
+
+1. **Set this host's identity** — `orbit routine init --host-id <id>` writes `~/.orbit/host.toml` (defaults to hostname). Add `--install-clock` to also install and start the per-user OS clock unit that runs `orbit sweep` every minute.
+2. **Make a workspace a routine source** — add `[routines]` / `role = "source"` to that workspace's `.orbit/config.toml`. The workspace must already be registered with Orbit; any other `role` value is a fail-closed config error.
+3. **Add a routine** — drop a YAML file under `<source>/.orbit/routines/`:
+
+   ```yaml
+   schemaVersion: 1
+   name: almanac-auto-commit          # unique across all sources on a host
+   enabled: true                       # versioned kill-switch
+   hosts: [dk-mac]                      # explicit pinning; no "any host" in v1
+   trigger:
+     cron: "0 22 * * *"                # 5-field, host-local time
+     missed_run: skip                   # skip | catch_up_once (default: skip)
+   target: job:almanac_commit_pipeline  # job:<name> only; activity: is rejected — wrap it in a one-step job
+   policy:
+     timeout_minutes: 10
+     retries: { max: 2, backoff_minutes: 2 }
+     overlap: forbid                    # forbid | allow
+   ```
+
+   Parsing is fail-closed: an invalid file (bad schema version, unknown field, unresolvable target, unparsable cron) makes *that routine* absent and reports a load error — it never fires with defaults.
+
+4. **Verify without firing** — `orbit routine list` shows every routine with toggle columns (enabled / pinned / paused) and computed next-due; `orbit sweep --dry-run` reports what *would* fire and records nothing. `orbit routine show <name>` adds recent fire history.
+
+Observe & control:
+
+- Fires are normal runs — they appear in `orbit run history` and carry the actor `routine/<name>`.
+- `orbit routine pause <name>` / `resume <name>` suppress a routine on *this host only* (host-local, unversioned, durable across reboots).
+- Toggle resolution order when a routine doesn't fire: `enabled: false` (versioned, everywhere) → host not in `hosts` (versioned, per host) → local pause (this host only). `orbit routine list` shows all three, so "why didn't this fire?" is one command.
+
+If setup or a sweep misbehaves, surface it and offer `orbit-task` friction reporting.
+
+## Cowork configuration
+
+If the user runs the plugin inside **Cowork** (the Claude desktop app) and only the `orbit_graph_*` tools appear — no `orbit_task_add` / ADR / learning tools — it's the known workspace-discovery gap: Cowork launches the plugin's MCP server with cwd and `CLAUDE_PROJECT_DIR` set to an internal scratchpad, not the selected repo, so `serve` finds no `.orbit/` and falls back to the graph-only surface.
+
+Fix: pass the repo explicitly via the global `--root` flag in the orbit MCP launch, in user config (`~/.claude/settings.json`) since the cached plugin copy is overwritten on reinstall. See the README "Cowork users" note for the exact `mcpServers` block — re-read it at invocation time. There is no env/cwd source for the repo path in Cowork today (see learning L-0065).
+
+## Anti-patterns (DO NOT)
+
+- Don't inline install commands, prereq versions, or destructive-action rules in this file. They rot independently from the README.
+- Don't run the README setup block from memory. Read it at invocation time.
+- Don't trigger this reference once `.orbit/` exists — use the rest of the `orbit` skill.
+- Don't author the first task silently. Route through `orbit-task`'s create workflow.

--- a/scripts/release-check.sh
+++ b/scripts/release-check.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
-# Verify the release-version invariant for the /plugin install orbit chain.
+# Verify the release-version invariant for the agent plugin install chain.
 #
-# The npm package version, the plugin manifest version, and the latest
-# GitHub Release tag must all agree. Drift here means `npx -y
-# @orbit-tools/cli@latest mcp serve` downloads a binary tagged at a
-# different release than the plugin manifest pins.
+# The npm package version, the Claude/Codex plugin manifest versions, and the
+# latest GitHub Release tag must all agree. Drift here means `npx -y
+# @orbit-tools/cli@latest mcp serve` downloads a binary tagged at a different
+# release than the installed plugin manifest advertises.
 #
 # Exits 0 when every source agrees, 1 on drift, 2 on missing prerequisites.
 # Documented entry point: `make release-check`.
@@ -14,7 +14,8 @@ repo_root="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$repo_root"
 
 NPM_PKG="@orbit-tools/cli"
-PLUGIN_MANIFEST="plugin/.claude-plugin/plugin.json"
+CLAUDE_PLUGIN_MANIFEST="plugin/.claude-plugin/plugin.json"
+CODEX_PLUGIN_MANIFEST="plugin/.codex-plugin/plugin.json"
 NPM_PACKAGE_JSON="plugin/npm/package.json"
 
 require_bin() {
@@ -27,18 +28,29 @@ require_bin() {
 
 require_bin jq
 
-for f in "$PLUGIN_MANIFEST" "$NPM_PACKAGE_JSON"; do
+for f in "$CLAUDE_PLUGIN_MANIFEST" "$CODEX_PLUGIN_MANIFEST" "$NPM_PACKAGE_JSON"; do
   if [[ ! -f "$f" ]]; then
     echo "release-check: $f not found (run from repo root)" >&2
     exit 2
   fi
 done
 
-plugin_version="$(jq -r .version "$PLUGIN_MANIFEST")"
+if [[ ! -x "scripts/validate-codex-plugin.sh" ]]; then
+  echo "release-check: scripts/validate-codex-plugin.sh is missing or not executable" >&2
+  exit 2
+fi
+"$repo_root/scripts/validate-codex-plugin.sh" "$repo_root" >/dev/null
+
+claude_plugin_version="$(jq -r .version "$CLAUDE_PLUGIN_MANIFEST")"
+codex_plugin_version="$(jq -r .version "$CODEX_PLUGIN_MANIFEST")"
 npm_package_version="$(jq -r .version "$NPM_PACKAGE_JSON")"
 
-if [[ -z "$plugin_version" || "$plugin_version" == "null" ]]; then
-  echo "release-check: $PLUGIN_MANIFEST has no .version field" >&2
+if [[ -z "$claude_plugin_version" || "$claude_plugin_version" == "null" ]]; then
+  echo "release-check: $CLAUDE_PLUGIN_MANIFEST has no .version field" >&2
+  exit 2
+fi
+if [[ -z "$codex_plugin_version" || "$codex_plugin_version" == "null" ]]; then
+  echo "release-check: $CODEX_PLUGIN_MANIFEST has no .version field" >&2
   exit 2
 fi
 if [[ -z "$npm_package_version" || "$npm_package_version" == "null" ]]; then
@@ -68,22 +80,39 @@ else
   echo "release-check: gh not on PATH; skipping GitHub Release check" >&2
 fi
 
-printf '%-32s %s\n' "$PLUGIN_MANIFEST"           "$plugin_version"
+printf '%-32s %s\n' "$CLAUDE_PLUGIN_MANIFEST"    "$claude_plugin_version"
+printf '%-32s %s\n' "$CODEX_PLUGIN_MANIFEST"     "$codex_plugin_version"
 printf '%-32s %s\n' "$NPM_PACKAGE_JSON"          "$npm_package_version"
 printf '%-32s %s\n' "npm view $NPM_PKG"          "${npm_registry_version:-<skipped>}"
 printf '%-32s %s\n' "gh release list -L 1"       "${gh_tag_version:-<skipped>}"
 
 drift=0
-if [[ "$plugin_version" != "$npm_package_version" ]]; then
-  echo "DRIFT: $PLUGIN_MANIFEST ($plugin_version) != $NPM_PACKAGE_JSON ($npm_package_version)" >&2
+if [[ "$claude_plugin_version" != "$codex_plugin_version" ]]; then
+  echo "DRIFT: $CLAUDE_PLUGIN_MANIFEST ($claude_plugin_version) != $CODEX_PLUGIN_MANIFEST ($codex_plugin_version)" >&2
   drift=1
 fi
-if [[ -n "$npm_registry_version" && "$plugin_version" != "$npm_registry_version" ]]; then
-  echo "DRIFT: $PLUGIN_MANIFEST ($plugin_version) != npm view $NPM_PKG ($npm_registry_version)" >&2
+if [[ "$claude_plugin_version" != "$npm_package_version" ]]; then
+  echo "DRIFT: $CLAUDE_PLUGIN_MANIFEST ($claude_plugin_version) != $NPM_PACKAGE_JSON ($npm_package_version)" >&2
   drift=1
 fi
-if [[ -n "$gh_tag_version" && "$plugin_version" != "$gh_tag_version" ]]; then
-  echo "DRIFT: $PLUGIN_MANIFEST ($plugin_version) != latest gh release tag ($gh_tag_version)" >&2
+if [[ "$codex_plugin_version" != "$npm_package_version" ]]; then
+  echo "DRIFT: $CODEX_PLUGIN_MANIFEST ($codex_plugin_version) != $NPM_PACKAGE_JSON ($npm_package_version)" >&2
+  drift=1
+fi
+if [[ -n "$npm_registry_version" && "$claude_plugin_version" != "$npm_registry_version" ]]; then
+  echo "DRIFT: $CLAUDE_PLUGIN_MANIFEST ($claude_plugin_version) != npm view $NPM_PKG ($npm_registry_version)" >&2
+  drift=1
+fi
+if [[ -n "$npm_registry_version" && "$codex_plugin_version" != "$npm_registry_version" ]]; then
+  echo "DRIFT: $CODEX_PLUGIN_MANIFEST ($codex_plugin_version) != npm view $NPM_PKG ($npm_registry_version)" >&2
+  drift=1
+fi
+if [[ -n "$gh_tag_version" && "$claude_plugin_version" != "$gh_tag_version" ]]; then
+  echo "DRIFT: $CLAUDE_PLUGIN_MANIFEST ($claude_plugin_version) != latest gh release tag ($gh_tag_version)" >&2
+  drift=1
+fi
+if [[ -n "$gh_tag_version" && "$codex_plugin_version" != "$gh_tag_version" ]]; then
+  echo "DRIFT: $CODEX_PLUGIN_MANIFEST ($codex_plugin_version) != latest gh release tag ($gh_tag_version)" >&2
   drift=1
 fi
 
@@ -91,14 +120,14 @@ if [[ "$drift" -ne 0 ]]; then
   cat >&2 <<EOF
 
 release-check failed. See docs/RELEASE.md for the procedure.
-The /plugin install orbit chain assumes all four sources agree.
+The agent plugin install chain assumes all manifest, npm, and release sources agree.
 EOF
   exit 1
 fi
 
 if [[ -z "$npm_registry_version" || -z "$gh_tag_version" ]]; then
-  echo "release-check: local sources agree on $plugin_version; remote checks were skipped." >&2
+  echo "release-check: local sources agree on $claude_plugin_version; remote checks were skipped." >&2
   exit 0
 fi
 
-echo "release-check: all sources agree on $plugin_version"
+echo "release-check: all sources agree on $claude_plugin_version"

--- a/scripts/smoke-plugin-install.sh
+++ b/scripts/smoke-plugin-install.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# End-to-end smoke for the /plugin install orbit chain.
+# End-to-end smoke for the agent plugin install orbit chain.
 #
 # Runs against the *published* @orbit-tools/cli@latest from npm (not the
 # local working tree) so it catches version drift between the npm proxy
@@ -11,6 +11,10 @@
 #   2. drive `orbit mcp serve` over stdio with a JSON-RPC handshake
 #      (initialize + tools/list) and assert at least one `orbit.*` tool
 #      appears in the response.
+#   3. install the repository Codex plugin into an isolated CODEX_HOME,
+#      render a fresh Codex task prompt to verify Orbit skill discovery, and
+#      call the read-only orbit.task.list MCP tool through the installed
+#      plugin transport.
 #
 # Pass: exit 0. Fail: non-zero with the relevant stderr captured.
 # Supported: macOS arm64 / x86_64, Linux x86_64 / arm64. Not Windows.
@@ -27,6 +31,8 @@ require_bin() {
 require_bin node
 require_bin npx
 require_bin npm
+require_bin python3
+require_bin codex
 
 case "$(uname -s)" in
   Darwin|Linux) ;;
@@ -37,6 +43,7 @@ case "$(uname -s)" in
 esac
 
 NPM_PKG="@orbit-tools/cli"
+repo_root="$(cd "$(dirname "$0")/.." && pwd)"
 TMPDIR_ROOT="$(mktemp -d)"
 trap 'rm -rf "$TMPDIR_ROOT"' EXIT
 
@@ -73,6 +80,39 @@ run_with_timeout() {
     gnu_g) gtimeout "$secs" "$@" ;;
     perl) perl -e '$t=shift @ARGV; alarm $t; exec @ARGV or die "exec failed: $!\n"' "$secs" "$@" ;;
   esac
+}
+
+assert_jsonrpc_tool_call_ok() {
+  local jsonrpc_output="$1"
+  local call_id="$2"
+  python3 - "$jsonrpc_output" "$call_id" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+path = Path(sys.argv[1])
+call_id = int(sys.argv[2])
+target = None
+for line in path.read_text(encoding="utf-8").splitlines():
+    line = line.strip()
+    if not line:
+        continue
+    try:
+        payload = json.loads(line)
+    except json.JSONDecodeError:
+        continue
+    if payload.get("id") == call_id:
+        target = payload
+        break
+
+if target is None:
+    print(f"FAIL: no JSON-RPC response with id={call_id}", file=sys.stderr)
+    raise SystemExit(1)
+if "error" in target:
+    print(f"FAIL: JSON-RPC response id={call_id} returned error: {target['error']}", file=sys.stderr)
+    raise SystemExit(1)
+print(f"JSON-RPC response id={call_id} succeeded")
+PY
 }
 
 echo "--- step 1: npx -y $NPM_PKG@latest --version ---"
@@ -179,4 +219,157 @@ fi
 orbit_tool_count="$(grep -o '"orbit_[a-z_]*"' "$RPC_OUT" | sort -u | wc -l | tr -d '[:space:]')"
 echo "tools/list returned $orbit_tool_count distinct orbit_* tools"
 
-echo "PASS: /plugin install orbit chain serves MCP successfully (orbit $binary_version)"
+echo "--- step 4: Codex plugin install in isolated CODEX_HOME ---"
+CODEX_HOME_DIR="$TMPDIR_ROOT/codex-home"
+mkdir -p "$CODEX_HOME_DIR"
+CODEX_ENV=(env CODEX_HOME="$CODEX_HOME_DIR")
+
+if ! "${CODEX_ENV[@]}" codex plugin marketplace add "$repo_root" --json \
+     >"$TMPDIR_ROOT/codex-marketplace-add.json" 2>"$TMPDIR_ROOT/codex-marketplace-add.err"; then
+  echo "FAIL: codex plugin marketplace add $repo_root exited non-zero" >&2
+  echo "--- stderr ---" >&2
+  cat "$TMPDIR_ROOT/codex-marketplace-add.err" >&2
+  exit 1
+fi
+python3 - "$TMPDIR_ROOT/codex-marketplace-add.json" <<'PY'
+import json
+import sys
+payload = json.load(open(sys.argv[1], encoding="utf-8"))
+if payload.get("marketplaceName") != "orbit":
+    raise SystemExit(f"FAIL: expected marketplaceName=orbit, got {payload!r}")
+print("codex marketplace => orbit")
+PY
+
+if ! "${CODEX_ENV[@]}" codex plugin add orbit@orbit --json \
+     >"$TMPDIR_ROOT/codex-plugin-add.json" 2>"$TMPDIR_ROOT/codex-plugin-add.err"; then
+  echo "FAIL: codex plugin add orbit@orbit exited non-zero" >&2
+  echo "--- stderr ---" >&2
+  cat "$TMPDIR_ROOT/codex-plugin-add.err" >&2
+  exit 1
+fi
+python3 - "$TMPDIR_ROOT/codex-plugin-add.json" <<'PY'
+import json
+import sys
+payload = json.load(open(sys.argv[1], encoding="utf-8"))
+if payload.get("name") != "orbit" or payload.get("marketplaceName") != "orbit":
+    raise SystemExit(f"FAIL: expected installed orbit@orbit, got {payload!r}")
+print(f"codex plugin installed => {payload.get('installedPath')}")
+PY
+
+if ! "${CODEX_ENV[@]}" codex mcp list --json \
+     >"$TMPDIR_ROOT/codex-mcp-list.json" 2>"$TMPDIR_ROOT/codex-mcp-list.err"; then
+  echo "FAIL: codex mcp list exited non-zero" >&2
+  echo "--- stderr ---" >&2
+  cat "$TMPDIR_ROOT/codex-mcp-list.err" >&2
+  exit 1
+fi
+CODEX_MCP_TRANSPORT="$TMPDIR_ROOT/codex-mcp-transport.json"
+python3 - "$TMPDIR_ROOT/codex-mcp-list.json" "$CODEX_MCP_TRANSPORT" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+servers = json.load(open(sys.argv[1], encoding="utf-8"))
+transport_path = Path(sys.argv[2])
+orbit = next((server for server in servers if server.get("name") == "orbit"), None)
+if orbit is None:
+    raise SystemExit("FAIL: installed Codex plugin did not register an orbit MCP server")
+transport = orbit.get("transport", {})
+serialized = json.dumps(transport)
+if "CLAUDE_PROJECT_DIR" in serialized:
+    raise SystemExit("FAIL: Codex MCP server config references CLAUDE_PROJECT_DIR")
+if transport.get("type") != "stdio":
+    raise SystemExit(f"FAIL: expected stdio Orbit MCP transport: {transport!r}")
+command = transport.get("command")
+args = transport.get("args", [])
+if not isinstance(command, str) or not command:
+    raise SystemExit(f"FAIL: Orbit MCP transport command is missing: {transport!r}")
+if not isinstance(args, list) or not all(isinstance(arg, str) and arg for arg in args):
+    raise SystemExit(f"FAIL: Orbit MCP transport args are invalid: {transport!r}")
+if command != "npx" or "mcp" not in args:
+    raise SystemExit(f"FAIL: unexpected Orbit MCP transport: {transport!r}")
+transport_path.write_text(json.dumps({"command": command, "args": args}), encoding="utf-8")
+print("codex mcp => orbit server registered")
+PY
+
+echo "--- step 5: Codex fresh task prompt discovers Orbit skills ---"
+CODEX_PROMPT_OUT="$TMPDIR_ROOT/codex-prompt.json"
+if ! "${CODEX_ENV[@]}" codex -C "$WORKSPACE_DIR" debug prompt-input "Use Orbit to list tasks." \
+     >"$CODEX_PROMPT_OUT" 2>"$TMPDIR_ROOT/codex-prompt.err"; then
+  echo "FAIL: codex debug prompt-input exited non-zero" >&2
+  echo "--- stderr ---" >&2
+  cat "$TMPDIR_ROOT/codex-prompt.err" >&2
+  exit 1
+fi
+python3 - "$CODEX_PROMPT_OUT" <<'PY'
+import json
+import sys
+text = json.dumps(json.load(open(sys.argv[1], encoding="utf-8")))
+required = [
+    "orbit:orbit",
+    "orbit:orbit-task",
+    "orbit:orbit-search",
+    "orbit:orbit-knowledge",
+    "orbit:orbit-graph",
+]
+missing = [name for name in required if name not in text]
+if missing:
+    raise SystemExit(f"FAIL: fresh Codex task prompt is missing Orbit skills: {missing}")
+print("codex prompt-input => canonical Orbit skills discovered")
+PY
+
+echo "--- step 6: Codex plugin MCP command handles read-only tool call ---"
+CODEX_RPC_IN="$TMPDIR_ROOT/codex-rpc-in.txt"
+CODEX_RPC_OUT="$TMPDIR_ROOT/codex-rpc-out.txt"
+CODEX_RPC_ERR="$TMPDIR_ROOT/codex-rpc-err.txt"
+CODEX_MCP_ARGV=()
+while IFS= read -r arg; do
+  CODEX_MCP_ARGV+=("$arg")
+done < <(python3 - "$CODEX_MCP_TRANSPORT" <<'PY'
+import json
+import sys
+
+transport = json.load(open(sys.argv[1], encoding="utf-8"))
+print(transport["command"])
+for arg in transport["args"]:
+    print(arg)
+PY
+)
+if [[ "${#CODEX_MCP_ARGV[@]}" -eq 0 ]]; then
+  echo "FAIL: Codex plugin MCP transport command was empty" >&2
+  exit 1
+fi
+
+cat >"$CODEX_RPC_IN" <<'EOF'
+{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"smoke-codex-plugin-install","version":"0.0.1"}}}
+{"jsonrpc":"2.0","method":"notifications/initialized","params":{}}
+{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}
+{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"orbit_task_list","arguments":{"status":"backlog","model":"codex"}}}
+EOF
+
+rc=0
+{
+  cat "$CODEX_RPC_IN"
+  sleep 5
+} | ( cd "$WORKSPACE_DIR" && run_with_timeout 120 "${CODEX_MCP_ARGV[@]}" ) \
+     >"$CODEX_RPC_OUT" 2>"$CODEX_RPC_ERR" || rc=$?
+
+if [[ "$rc" -ne 0 && "$rc" -ne 124 && "$rc" -ne 142 && "$rc" -ne 143 ]]; then
+  echo "FAIL: Codex plugin MCP command exited with $rc" >&2
+  echo "--- stderr ---" >&2
+  cat "$CODEX_RPC_ERR" >&2
+  echo "--- stdout ---" >&2
+  cat "$CODEX_RPC_OUT" >&2
+  exit 1
+fi
+if ! grep -q '"orbit_task_list"' "$CODEX_RPC_OUT"; then
+  echo "FAIL: Codex plugin tools/list response did not include orbit_task_list" >&2
+  echo "--- stdout ---" >&2
+  cat "$CODEX_RPC_OUT" >&2
+  echo "--- stderr ---" >&2
+  cat "$CODEX_RPC_ERR" >&2
+  exit 1
+fi
+assert_jsonrpc_tool_call_ok "$CODEX_RPC_OUT" 3
+
+echo "PASS: agent plugin install chains serve MCP successfully (orbit $binary_version)"

--- a/scripts/validate-codex-plugin.sh
+++ b/scripts/validate-codex-plugin.sh
@@ -1,0 +1,273 @@
+#!/usr/bin/env bash
+# Validate the repository-owned Codex plugin package.
+#
+# This intentionally lives in-repo instead of depending on a developer's
+# ~/.codex skill checkout. It mirrors the supported Codex manifest contract
+# used by the plugin-creator validator for the fields Orbit ships.
+set -euo pipefail
+
+repo_root="${1:-${ORBIT_REPO_ROOT:-$(cd "$(dirname "$0")/.." && pwd)}}"
+
+if ! command -v python3 >/dev/null 2>&1; then
+  echo "validate-codex-plugin: required binary 'python3' not on PATH" >&2
+  exit 2
+fi
+
+python3 - "$repo_root" <<'PY'
+import json
+import re
+import sys
+from pathlib import Path, PurePosixPath
+from typing import Any
+from urllib.parse import urlparse
+
+repo = Path(sys.argv[1]).resolve()
+plugin_root = repo / "plugin"
+manifest_path = plugin_root / ".codex-plugin" / "plugin.json"
+marketplace_path = repo / ".agents" / "plugins" / "marketplace.json"
+
+SEMVER_RE = re.compile(
+    r"^(0|[1-9]\d*)\."
+    r"(0|[1-9]\d*)\."
+    r"(0|[1-9]\d*)"
+    r"(?:-(?:0|[1-9]\d*|\d*[A-Za-z-][0-9A-Za-z-]*)(?:\."
+    r"(?:0|[1-9]\d*|\d*[A-Za-z-][0-9A-Za-z-]*))*)?"
+    r"(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$"
+)
+HEX_COLOR_RE = re.compile(r"^#[0-9A-F]{6}$", re.IGNORECASE)
+
+errors: list[str] = []
+
+
+def load_json(path: Path, label: str) -> dict[str, Any] | None:
+    if not path.is_file():
+        errors.append(f"{label} is missing")
+        return None
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        errors.append(f"{label} is not valid JSON: {exc}")
+        return None
+    if not isinstance(payload, dict):
+        errors.append(f"{label} must contain a JSON object")
+        return None
+    return payload
+
+
+def reject_todos(value: Any, path: str) -> None:
+    if isinstance(value, str):
+        if "[TODO:" in value:
+            errors.append(f"{path} still contains a [TODO: ...] placeholder")
+    elif isinstance(value, list):
+        for index, item in enumerate(value):
+            reject_todos(item, f"{path}[{index}]")
+    elif isinstance(value, dict):
+        for key, item in value.items():
+            reject_todos(item, f"{path}.{key}")
+
+
+def require_string(payload: dict[str, Any], key: str, label: str) -> str | None:
+    value = payload.get(key)
+    if not isinstance(value, str) or not value.strip():
+        errors.append(f"{label}.{key} must be a non-empty string")
+        return None
+    return value
+
+
+def optional_https(payload: dict[str, Any], key: str, label: str) -> None:
+    value = payload.get(key)
+    if value is None:
+        return
+    parsed = urlparse(value) if isinstance(value, str) else None
+    if parsed is None or parsed.scheme != "https" or not parsed.netloc:
+        errors.append(f"{label}.{key} must be an absolute https:// URL")
+
+
+def normalize_contract_path(raw_path: Any) -> str | None:
+    if not isinstance(raw_path, str):
+        return None
+    path = PurePosixPath(raw_path.replace("\\", "/"))
+    if path.is_absolute() or any(part in {"", ".."} for part in path.parts):
+        return None
+    normalized = path.as_posix().rstrip("/")
+    if normalized.startswith("./"):
+        normalized = normalized[2:]
+    return normalized or None
+
+
+def reject_user_specific_paths(value: Any, path: str) -> None:
+    if isinstance(value, str):
+        if "CLAUDE_PROJECT_DIR" in value:
+            errors.append(f"{path} must not reference CLAUDE_PROJECT_DIR")
+        if str(Path.home()) in value:
+            errors.append(f"{path} must not embed a user-specific absolute home path")
+        return
+    if isinstance(value, list):
+        for index, item in enumerate(value):
+            reject_user_specific_paths(item, f"{path}[{index}]")
+        return
+    if isinstance(value, dict):
+        for key, item in value.items():
+            reject_user_specific_paths(item, f"{path}.{key}")
+
+
+def validate_skill_frontmatter(skill_dir: Path) -> None:
+    skill_path = skill_dir / "SKILL.md"
+    if not skill_path.is_file():
+        errors.append(f"skill {skill_dir.name} is missing SKILL.md")
+        return
+    text = skill_path.read_text(encoding="utf-8")
+    if not text.startswith("---\n"):
+        errors.append(f"skill {skill_dir.name} must start with YAML frontmatter")
+        return
+    end = text.find("\n---", 4)
+    if end == -1:
+        errors.append(f"skill {skill_dir.name} frontmatter is not closed")
+        return
+    frontmatter = text[4:end]
+    fields: dict[str, str] = {}
+    for line in frontmatter.splitlines():
+        if ":" not in line:
+            continue
+        key, value = line.split(":", 1)
+        fields[key.strip()] = value.strip().strip('"').strip("'")
+    for key in ("name", "description"):
+        if not fields.get(key):
+            errors.append(f"skill {skill_dir.name} frontmatter field {key} must be non-empty")
+
+
+manifest = load_json(manifest_path, "plugin/.codex-plugin/plugin.json")
+if manifest is not None:
+    reject_todos(manifest, "plugin.json")
+    allowed_keys = {
+        "id",
+        "name",
+        "version",
+        "description",
+        "skills",
+        "apps",
+        "mcpServers",
+        "interface",
+        "author",
+        "homepage",
+        "repository",
+        "license",
+        "keywords",
+    }
+    for key in sorted(set(manifest) - allowed_keys):
+        errors.append(f"plugin.json field {key} is not supported")
+
+    name = require_string(manifest, "name", "plugin.json")
+    version = require_string(manifest, "version", "plugin.json")
+    require_string(manifest, "description", "plugin.json")
+    if version is not None and SEMVER_RE.fullmatch(version) is None:
+        errors.append("plugin.json.version must use strict semver")
+
+    author = manifest.get("author")
+    if not isinstance(author, dict):
+        errors.append("plugin.json.author must be an object")
+    else:
+        require_string(author, "name", "plugin.json.author")
+        optional_https(author, "url", "plugin.json.author")
+
+    if normalize_contract_path(manifest.get("skills")) != "skills":
+        errors.append("plugin.json.skills must resolve to ./skills/")
+
+    mcp_servers = manifest.get("mcpServers")
+    if not isinstance(mcp_servers, dict) or not mcp_servers:
+        errors.append("plugin.json.mcpServers must be a non-empty object for Orbit")
+    else:
+        reject_user_specific_paths(mcp_servers, "plugin.json.mcpServers")
+        for server_name, server in mcp_servers.items():
+            if not isinstance(server_name, str) or not server_name.strip():
+                errors.append("plugin.json.mcpServers keys must be non-empty strings")
+            if not isinstance(server, dict):
+                errors.append(f"plugin.json.mcpServers.{server_name} must be an object")
+                continue
+            command = server.get("command")
+            if not isinstance(command, str) or not command.strip():
+                errors.append(f"plugin.json.mcpServers.{server_name}.command must be non-empty")
+            args = server.get("args")
+            if args is not None and (
+                not isinstance(args, list)
+                or not all(isinstance(arg, str) and arg.strip() for arg in args)
+            ):
+                errors.append(f"plugin.json.mcpServers.{server_name}.args must be an array of strings")
+
+    interface = manifest.get("interface")
+    if not isinstance(interface, dict):
+        errors.append("plugin.json.interface must be an object")
+    else:
+        for field in (
+            "displayName",
+            "shortDescription",
+            "longDescription",
+            "developerName",
+            "category",
+        ):
+            require_string(interface, field, "plugin.json.interface")
+        capabilities = interface.get("capabilities")
+        if not isinstance(capabilities, list) or not all(
+            isinstance(item, str) and item.strip() for item in capabilities
+        ):
+            errors.append("plugin.json.interface.capabilities must be an array of strings")
+        prompts = interface.get("defaultPrompt")
+        if not isinstance(prompts, list) or not 1 <= len(prompts) <= 3 or not all(
+            isinstance(item, str) and item.strip() and len(item) <= 128 for item in prompts
+        ):
+            errors.append("plugin.json.interface.defaultPrompt must contain 1-3 short strings")
+        color = interface.get("brandColor")
+        if color is not None and (not isinstance(color, str) or HEX_COLOR_RE.fullmatch(color) is None):
+            errors.append("plugin.json.interface.brandColor must use #RRGGBB")
+        for field in ("websiteURL", "privacyPolicyURL", "termsOfServiceURL"):
+            optional_https(interface, field, "plugin.json.interface")
+
+    skills_root = plugin_root / "skills"
+    if not skills_root.is_dir():
+        errors.append("plugin/skills is missing")
+    else:
+        for skill_dir in sorted(path for path in skills_root.iterdir() if path.is_dir()):
+            validate_skill_frontmatter(skill_dir)
+
+    marketplace = load_json(marketplace_path, ".agents/plugins/marketplace.json")
+    if marketplace is not None and name is not None:
+        if not isinstance(marketplace.get("name"), str) or not marketplace["name"].strip():
+            errors.append("marketplace.name must be a non-empty string")
+        plugins = marketplace.get("plugins")
+        if not isinstance(plugins, list):
+            errors.append("marketplace.plugins must be an array")
+        else:
+            entries = [entry for entry in plugins if isinstance(entry, dict) and entry.get("name") == name]
+            if len(entries) != 1:
+                errors.append(f"marketplace must contain exactly one plugin entry named {name!r}")
+            else:
+                entry = entries[0]
+                source = entry.get("source")
+                if not isinstance(source, dict) or source.get("source") != "local":
+                    errors.append("marketplace orbit entry must use a local source")
+                else:
+                    raw_path = source.get("path")
+                    normalized = normalize_contract_path(raw_path)
+                    if normalized is None:
+                        errors.append("marketplace orbit source.path must be a relative path")
+                    elif (repo / normalized).resolve() != plugin_root:
+                        errors.append("marketplace orbit source.path must resolve to ./plugin")
+                policy = entry.get("policy")
+                if not isinstance(policy, dict):
+                    errors.append("marketplace orbit policy must be an object")
+                else:
+                    if policy.get("installation") not in {"AVAILABLE", "NOT_AVAILABLE", "INSTALLED_BY_DEFAULT"}:
+                        errors.append("marketplace orbit policy.installation is invalid")
+                    if policy.get("authentication") not in {"ON_INSTALL", "ON_USE"}:
+                        errors.append("marketplace orbit policy.authentication is invalid")
+                if not isinstance(entry.get("category"), str) or not entry["category"].strip():
+                    errors.append("marketplace orbit category must be a non-empty string")
+
+if errors:
+    print("validate-codex-plugin: failed", file=sys.stderr)
+    for error in errors:
+        print(f"- {error}", file=sys.stderr)
+    raise SystemExit(1)
+
+print(f"validate-codex-plugin: plugin manifest is valid ({manifest_path.relative_to(repo)})")
+PY


### PR DESCRIPTION
## Task

[ORB-10099](https://orbit-cli.com/tasks/ORB-10099) — Package Orbit as an installable Codex plugin

### Description

## Problem
Orbit has a mature Claude plugin package but no installable Codex plugin. Codex users currently need project-local/manual configuration.

## Scope
Create a supported Codex plugin package in the Orbit repository using `.codex-plugin/plugin.json`, canonical shared Orbit skills, a Codex-appropriate MCP configuration, release validation, and an isolated clean-home smoke harness.

Keep Claude-only hooks and agents Claude-only. Do not reuse `plugin/.mcp.json` unchanged because it embeds `${CLAUDE_PROJECT_DIR}`. Follow the repository's plugin-creator skill and its manifest validator.

This is the Orbit-owned implementation half of ORB-10065. Session auditing is handled separately in the constellation umbrella repository.

## New files expected
- `plugin/.codex-plugin/plugin.json`
- Codex-specific MCP/marketplace/install-smoke assets as required by the validated packaging design

## Risks / rollback
Preserve existing Claude installation and npm/MCP behavior. The change is removable by deleting only Codex-specific packaging and reverting shared release/test updates.

### Acceptance Criteria

- A repository-owned validation command (using the supported Codex plugin schema validator or an equivalent checked-in schema test) accepts plugin/.codex-plugin/plugin.json without relying on a user-specific absolute path.
- An isolated clean Codex home installs Orbit from the repository/package, starts a fresh task, discovers the canonical Orbit skills, and successfully invokes a read-only Orbit MCP tool in an automated smoke test or documented reproducible harness.
- cargo test -p orbit-core plugin_skill_symlinks_resolve_to_assets passes and validates capability parity/drift for skills intended to be shared between Claude and Codex packages.
- ./scripts/release-check.sh validates the Codex manifest/version/package invariants alongside the existing Claude/npm checks.
- Existing Claude plugin installation behavior remains intact; ./scripts/smoke-plugin-install.sh and make ci-fast pass.
- README.md and docs/RELEASE.md document supported Codex installation/update usage without claiming Claude-only support.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Added a Codex plugin manifest at `plugin/.codex-plugin/plugin.json` with shared Orbit skills and a Codex-specific MCP server config that does not reference `CLAUDE_PROJECT_DIR`.
- Added `.agents/plugins/marketplace.json` so `codex plugin marketplace add <repo>` exposes `orbit@orbit` from the repository plugin package.
- Materialized the shared Orbit skills under `plugin/skills/` because Codex plugin installs do not follow directory symlinks into the cache; extended `plugin_skill_symlinks_resolve_to_assets` to accept symlinks or byte-for-byte materialized copies and to validate Codex manifest/marketplace parity.
- Added `scripts/validate-codex-plugin.sh` and wired `scripts/release-check.sh` to validate the Codex manifest plus Claude/Codex/npm/release version lockstep.
- Extended `scripts/smoke-plugin-install.sh` and `.github/workflows/smoke-plugin-install.yml` to install Codex CLI, install Orbit into an isolated `CODEX_HOME`, verify fresh Codex task skill discovery, and call read-only `orbit.task.list` through the installed Codex MCP transport.
- Updated README and release docs with supported Codex install/update usage. Preserved learning `L-0071` for the Codex symlink-copy gotcha surfaced by this task.

Assessment: The scoped Codex packaging path is implemented. Claude-specific hooks/agents remain Claude-only, and the existing Claude manifest/MCP config were left intact.

Validation:
- `./scripts/validate-codex-plugin.sh` passed.
- `python3 ~/.codex/skills/.system/plugin-creator/scripts/validate_plugin.py plugin` passed.
- `cargo test -p orbit-core plugin_skill_symlinks_resolve_to_assets` passed.
- `./scripts/release-check.sh` passed; npm registry check was skipped because `npm` is not installed, while local manifest/package versions and latest GitHub release tag agreed on `0.9.2`.
- Isolated `CODEX_HOME` install/prompt discovery passed manually with `codex plugin marketplace add`, `codex plugin add orbit@orbit`, `codex mcp list`, and `codex debug prompt-input`; the installed MCP transport registered `npx -y @orbit-tools/cli@latest mcp serve` with no `CLAUDE_PROJECT_DIR`.
- Local `orbit mcp serve` JSON-RPC `tools/list` + read-only `orbit_task_list` call passed.
- `bash -n scripts/release-check.sh scripts/smoke-plugin-install.sh scripts/validate-codex-plugin.sh` and `git diff --check` passed.
- `make ci-fast` could not complete in this runner because `node` is not on PATH; it passed `cargo fmt --check` and `check-installer-pubkey` before stopping at the pre-existing Node prerequisite in `test-installer-security.sh`. The remaining non-Node ci-fast guardrails were run individually and passed.
- `./scripts/smoke-plugin-install.sh` could not run in this runner because `node` is not on PATH; the workflow now sets up Node and installs Codex CLI before running it.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10099-6a51cd2d`
- Behind base: 0
- Ahead of base: 1