### PR TITLE
orbit.task.add: un-retire `crew` param (restore create-time crew) [ORB-10123]

### DIFF
--- a/crates/orbit-cli/tests/snapshots/mcp_tools_list.json
+++ b/crates/orbit-cli/tests/snapshots/mcp_tools_list.json
@@ -966,6 +966,10 @@
           ],
           "description": "Optional task context selectors as a comma-separated string or array of strings. Add entries ONLY for existing files, directories, or symbols expected to be modified or deleted by the task. Do not add background-reading entries or files referenced only for context. Prefer canonical selectors: `file:`, `dir:`, or `symbol:path#name:kind`. Legacy raw paths are accepted and upgraded automatically."
         },
+        "crew": {
+          "description": "Optional named crew to use when running this task",
+          "type": "string"
+        },
         "description": {
           "description": "Task description markdown",
           "type": "string"

--- a/crates/orbit-common/src/types/tool_input.rs
+++ b/crates/orbit-common/src/types/tool_input.rs
@@ -5,7 +5,6 @@ use crate::types::OrbitError;
 pub const RETIRED_TASK_ADD_INPUT_FIELDS: &[&str] = &[
     "plan",
     "status",
-    "crew",
     "parent_id",
     "source_task_id",
     "external_refs",

--- a/crates/orbit-core/src/runtime/orbit_tool_host/task_tools.rs
+++ b/crates/orbit-core/src/runtime/orbit_tool_host/task_tools.rs
@@ -71,7 +71,7 @@ pub(super) fn add(
             system_created: false,
             external_refs: Vec::new(),
             source_task_id: None,
-            crew: None,
+            crew: optional_string(&input, "crew")?,
         },
         agent,
         model,

--- a/crates/orbit-core/src/runtime/orbit_tool_host/tests/task_tools.rs
+++ b/crates/orbit-core/src/runtime/orbit_tool_host/tests/task_tools.rs
@@ -523,6 +523,68 @@ fn task_add_and_show_tools_roundtrip_tags() {
 }
 
 #[test]
+fn task_add_and_show_tools_roundtrip_crew() {
+    // ORB-10123: `crew` is no longer a retired/stripped field on orbit.task.add.
+    // The tool reads it from input, validates it, and persists it onto the
+    // created task (pre-un-retire it was silently dropped before host execution).
+    let (_root, runtime, _repo_root) = test_runtime();
+
+    let added = runtime
+        .execute_tool_command(
+            "orbit.task.add",
+            json!({
+                "title": "Crew task",
+                "description": "Exercise crew input on the agent-facing create path.",
+                "workspace": ".",
+                "crew": "codex",
+            }),
+            Some("codex".to_string()),
+            Some(orbit_common::test_fixtures::TEST_CODEX_MODEL.to_string()),
+        )
+        .expect("task add tool succeeds with a valid crew");
+    let task_id = added["id"].as_str().expect("task id");
+    assert_eq!(added.get("crew"), Some(&json!("codex")));
+
+    let shown = runtime
+        .execute_tool_command(
+            "orbit.task.show",
+            json!({ "id": task_id }),
+            Some("codex".to_string()),
+            Some(orbit_common::test_fixtures::TEST_CODEX_MODEL.to_string()),
+        )
+        .expect("task show tool succeeds");
+    assert_eq!(shown.get("crew"), Some(&json!("codex")));
+}
+
+#[test]
+fn task_add_tool_rejects_unknown_crew() {
+    // Un-retiring crew also means it is validated: an unknown crew is now
+    // rejected rather than silently ignored.
+    let (_root, runtime, _repo_root) = test_runtime();
+
+    let result = runtime.execute_tool_command(
+        "orbit.task.add",
+        json!({
+            "title": "Bad crew task",
+            "description": "Unknown crew must be rejected on the create path.",
+            "workspace": ".",
+            "crew": "does-not-exist",
+        }),
+        Some("codex".to_string()),
+        Some(orbit_common::test_fixtures::TEST_CODEX_MODEL.to_string()),
+    );
+
+    let message = match result {
+        Err(error) => format!("{error:?}"),
+        Ok(value) => panic!("expected unknown crew to be rejected, got {value}"),
+    };
+    assert!(
+        message.contains("crew 'does-not-exist' is not defined"),
+        "error should explain the crew is undefined: {message}"
+    );
+}
+
+#[test]
 fn task_show_tool_includes_empty_tags_array() {
     let (_root, runtime, repo_root) = test_runtime();
     let task = create_task(

--- a/crates/orbit-mcp/src/adapter/tests/schema.rs
+++ b/crates/orbit-mcp/src/adapter/tests/schema.rs
@@ -468,6 +468,7 @@ fn task_add_mcp_schema_exposes_trimmed_fields_with_complexity_and_model_enums() 
         param_with_type("complexity", "string"),
         param_with_type("type", "string"),
         param_with_type("relations", "array"),
+        param_with_type("crew", "string"),
         param_with_type("model", "string"),
     ];
     let schema = build_input_schema("orbit.task.add", &params);
@@ -483,6 +484,7 @@ fn task_add_mcp_schema_exposes_trimmed_fields_with_complexity_and_model_enums() 
             "acceptance_criteria",
             "complexity",
             "context_files",
+            "crew",
             "description",
             "model",
             "priority",
@@ -521,7 +523,6 @@ fn task_add_mcp_schema_exposes_trimmed_fields_with_complexity_and_model_enums() 
     for removed in [
         "plan",
         "status",
-        "crew",
         "parent_id",
         "source_task_id",
         "external_refs",
@@ -534,4 +535,10 @@ fn task_add_mcp_schema_exposes_trimmed_fields_with_complexity_and_model_enums() 
             "{removed} must not appear in MCP schema properties for orbit.task.add"
         );
     }
+
+    // crew was un-retired (ORB-10123): it is now an authoring param again.
+    assert!(
+        properties.contains_key("crew"),
+        "crew must appear in MCP schema properties for orbit.task.add"
+    );
 }

--- a/crates/orbit-tools/src/builtin/orbit/task/add.rs
+++ b/crates/orbit-tools/src/builtin/orbit/task/add.rs
@@ -78,6 +78,12 @@ impl Tool for OrbitTaskAddTool {
                 param_type: "array".to_string(),
                 required: false,
             },
+            ToolParam {
+                name: "crew".to_string(),
+                description: "Optional named crew to use when running this task".to_string(),
+                param_type: "string".to_string(),
+                required: false,
+            },
         ];
         parameters.extend(super::super::model_identity_params());
 

--- a/crates/orbit-tools/src/builtin/orbit/task/tests/add.rs
+++ b/crates/orbit-tools/src/builtin/orbit/task/tests/add.rs
@@ -164,6 +164,7 @@ fn schema_exposes_only_trimmed_create_task_fields() {
             "complexity",
             "type",
             "relations",
+            "crew",
             "model",
         ]
     );
@@ -233,7 +234,7 @@ fn add_call_with_retired_fields_warns_once_and_ignores_them() {
         "model": "grok",
         "plan": "ignored plan",
         "status": "done",
-        "crew": "ignored-crew",
+        "crew": "release-crew",
         "parent_id": "ORB-00003",
         "source_task_id": "ORB-00004",
         "external_refs": [{"system": "ENG", "id": "123"}],
@@ -285,6 +286,7 @@ fn add_call_with_retired_fields_warns_once_and_ignores_them() {
         "complexity",
         "type",
         "relations",
+        "crew",
         "model",
     ] {
         assert!(
@@ -293,6 +295,10 @@ fn add_call_with_retired_fields_warns_once_and_ignores_them() {
         );
     }
     assert_eq!(rec_input["complexity"], "medium");
+    assert_eq!(
+        rec_input["crew"], "release-crew",
+        "crew must survive host execution and reach the create path"
+    );
     assert_eq!(
         rec_input["context_files"][0],
         "file:crates/orbit-tools/src/builtin/orbit/task/add.rs"

--- a/crates/orbit-tools/tests/public_tool_surface.rs
+++ b/crates/orbit-tools/tests/public_tool_surface.rs
@@ -252,6 +252,7 @@ fn task_add_schema_uses_trimmed_authoring_surface() {
             "complexity",
             "type",
             "relations",
+            "crew",
             "model",
         ]
     );


### PR DESCRIPTION
## Summary
`crew` is accepted by the CLI (`orbit task add --crew`) and the HTTP create endpoint, but **ORB-00255** deliberately stripped it from the agent-facing MCP tool (`orbit.task.add`). This re-exposes it so all three create surfaces agree — and unblocks bridge's mirrored `orbit_task_add`, which must match orbit's MCP schema per the ORB-10036/D2 parity contract.

Reverses only the crew-specific part of ORB-00255; the other 8 trimmed fields stay retired.

## Changes
- `tool_input.rs`: drop `crew` from `RETIRED_TASK_ADD_INPUT_FIELDS`
- `orbit_tool_host/task_tools.rs`: `add()` reads `crew` from input instead of hardcoding `None`
- `orbit-tools/.../task/add.rs`: add the optional `crew` string schema param
- Regenerated MCP tools snapshot (`crates/orbit-cli/tests/snapshots/mcp_tools_list.json`)
- Tests: updated schema-surface `names` vecs + mcp adapter schema test; moved `crew` from the retired-fields warn test to a kept-field assertion; added two orbit-core host tests — `task_add_and_show_tools_roundtrip_crew` and `task_add_tool_rejects_unknown_crew`

## Verification
- orbit-tools / mcp / common: pass
- orbit-cli `mcp_roundtrip` (snapshot regen + stable): pass
- orbit-core `task_tools` (35 passed, incl. 2 new): pass
- `make ci-fast`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)