### PR TITLE
[ORB-10085] Add daily Orbit QA routine

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,6 +59,7 @@ benchmarks/**/tasks/**
 # Project learnings travel with the repo (ADR-003 in docs/design/project-learnings/4_decisions.md).
 !.orbit/learnings/
 !.orbit/resources/
+!.orbit/routines/
 !.orbit/config.toml
 .monodev/
 

--- a/.orbit/config.toml
+++ b/.orbit/config.toml
@@ -27,6 +27,9 @@ auto_ship = true
 base_branch = "agent-main"
 default_crew = "claude"
 
+[routines]
+role = "source"
+
 [crews.claude]
 planner = { model = "claude-opus-4-8", provider = "claude", backend = "cli" }
 implementer = { model = "claude-opus-4-8", provider = "claude", backend = "cli" }

--- a/.orbit/resources/activities/qa_sweep.yaml
+++ b/.orbit/resources/activities/qa_sweep.yaml
@@ -1,0 +1,32 @@
+schemaVersion: 2
+kind: Activity
+metadata:
+  name: qa_sweep
+spec:
+  type: deterministic
+  description: >
+    Run the mechanism-agnostic QA sweep core for one explicitly named
+    workspace. The workspace input is required so scheduled callers cannot
+    accidentally broaden a single-workspace routine into a host-wide pass.
+  input_schema_json:
+    type: object
+    additionalProperties: false
+    required: [workspace]
+    properties:
+      workspace:
+        type: string
+        minLength: 1
+  output_schema_json:
+    type: object
+    required: [lock_busy, workspaces, reports]
+    properties:
+      lock_busy:
+        type: boolean
+      workspaces:
+        type: number
+      reports:
+        type: array
+        items:
+          type: object
+  action: qa_sweep
+  config: {}

--- a/.orbit/resources/jobs/qa_sweep_routine.yaml
+++ b/.orbit/resources/jobs/qa_sweep_routine.yaml
@@ -1,0 +1,15 @@
+schemaVersion: 2
+kind: Job
+metadata:
+  name: qa_sweep_routine
+spec:
+  state: enabled
+  kind: workflow
+  max_active_runs: 1
+  default_input:
+    workspace: orbit
+  steps:
+    - id: qa_sweep
+      target: activity:qa_sweep
+      default_input:
+        workspace: "{{ input.workspace }}"

--- a/.orbit/routines/orbit-qa-sweep.yaml
+++ b/.orbit/routines/orbit-qa-sweep.yaml
@@ -1,0 +1,13 @@
+schemaVersion: 1
+name: orbit-qa-sweep
+description: Validate new agent-main commits in the orbit workspace once per day
+enabled: true
+hosts: [dk-server-1]
+trigger:
+  cron: "0 3 * * *"
+  missed_run: skip
+target: job:qa_sweep_routine
+policy:
+  timeout_minutes: 120
+  retries: { max: 1, backoff_minutes: 15 }
+  overlap: forbid

--- a/crates/orbit-cli/src/command/run/qa_sweep.rs
+++ b/crates/orbit-cli/src/command/run/qa_sweep.rs
@@ -42,6 +42,7 @@ impl QaSweepCommand {
     pub fn execute_without_runtime(self) -> Result<(), OrbitError> {
         let outcome = run_qa_sweep(QaSweepOptions {
             dry_run: self.dry_run,
+            workspace: None,
         })?;
 
         let failed = outcome

--- a/crates/orbit-core/src/qa/sweep.rs
+++ b/crates/orbit-core/src/qa/sweep.rs
@@ -59,11 +59,14 @@ const EVIDENCE_OUTPUT_BYTES: usize = 4000;
 const CHECK_POLL_INTERVAL: Duration = Duration::from_millis(50);
 
 /// Options for one qa-sweep pass.
-#[derive(Debug, Clone, Copy, Default)]
+#[derive(Debug, Clone, Default)]
 pub struct QaSweepOptions {
     /// Report what would be validated without running checks, recording runs,
     /// filing tasks, or advancing watermarks.
     pub dry_run: bool,
+    /// Restrict the pass to one configured workspace. `None` preserves the
+    /// host-wide behavior used by the transitional systemd entry point.
+    pub workspace: Option<String>,
 }
 
 /// Result of one qa-sweep pass.
@@ -177,6 +180,12 @@ pub fn run_qa_sweep_at(
     let reports = qa
         .workspaces
         .iter()
+        .filter(|ws_config| {
+            options
+                .workspace
+                .as_deref()
+                .is_none_or(|workspace| ws_config.name == workspace)
+        })
         .map(|ws_config| {
             let Some(workspace) = registry
                 .workspaces
@@ -194,11 +203,18 @@ pub fn run_qa_sweep_at(
                 .workspaces
                 .get(&ws_config.name)
                 .map(|watermark| watermark.last_validated_sha.clone());
-            sweep_workspace(global_root, &qa, ws_config, workspace, baseline, options)
-                .unwrap_or_else(|error| QaWorkspaceReport {
-                    reason: Some(error.to_string()),
-                    ..QaWorkspaceReport::bare(&ws_config.name, "error")
-                })
+            sweep_workspace(
+                global_root,
+                &qa,
+                ws_config,
+                workspace,
+                baseline,
+                options.dry_run,
+            )
+            .unwrap_or_else(|error| QaWorkspaceReport {
+                reason: Some(error.to_string()),
+                ..QaWorkspaceReport::bare(&ws_config.name, "error")
+            })
         })
         .collect();
 
@@ -214,7 +230,7 @@ fn sweep_workspace(
     ws_config: &QaWorkspaceConfig,
     workspace: &Workspace,
     baseline: Option<String>,
-    options: QaSweepOptions,
+    dry_run: bool,
 ) -> Result<QaWorkspaceReport, OrbitError> {
     if workspace.status != WorkspaceStatus::Active || !workspace.orbit_dir.exists() {
         return Ok(QaWorkspaceReport::skipped(
@@ -271,7 +287,7 @@ fn sweep_workspace(
         ..QaWorkspaceReport::bare(&ws_config.name, "validated")
     };
 
-    if options.dry_run {
+    if dry_run {
         report.action = "would_validate";
         report.checks = ws_config
             .checks

--- a/crates/orbit-core/src/qa/tests/sweep.rs
+++ b/crates/orbit-core/src/qa/tests/sweep.rs
@@ -369,7 +369,10 @@ fn checkout_on_another_branch_is_skipped() {
 #[test]
 fn dry_run_reports_but_records_nothing() {
     let fixture = fixture(FAILING_CHECK);
-    let report = fixture.sweep_with(QaSweepOptions { dry_run: true });
+    let report = fixture.sweep_with(QaSweepOptions {
+        dry_run: true,
+        ..QaSweepOptions::default()
+    });
 
     assert_eq!(report.action, "would_validate");
     assert_eq!(report.checks[0].outcome, "would_run");
@@ -386,6 +389,27 @@ fn dry_run_reports_but_records_nothing() {
                 .is_empty(),
         "dry run must not create ledger runs"
     );
+}
+
+#[test]
+fn workspace_filter_excludes_other_configured_workspaces() {
+    let fixture = fixture_with_qa(&format!(
+        "[qa]\n\n[[qa.workspace]]\nname = \"{WS_NAME}\"\n{PASSING_CHECK}\n\
+         [[qa.workspace]]\nname = \"ghost\"\n\
+         [[qa.workspace.check]]\nname = \"ok\"\ncommand = \"true\"\n"
+    ));
+    let outcome = run_qa_sweep_at(
+        &fixture.global,
+        QaSweepOptions {
+            dry_run: true,
+            workspace: Some(WS_NAME.to_string()),
+        },
+    )
+    .expect("filtered sweep");
+
+    assert_eq!(outcome.reports.len(), 1);
+    assert_eq!(outcome.reports[0].workspace, WS_NAME);
+    assert_eq!(outcome.reports[0].action, "would_validate");
 }
 
 #[test]

--- a/crates/orbit-core/src/runtime/v2_host/dispatch.rs
+++ b/crates/orbit-core/src/runtime/v2_host/dispatch.rs
@@ -1,6 +1,7 @@
 use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::time::{Duration, Instant};
 
+use crate::qa::{QaSweepOptions, run_qa_sweep};
 use orbit_common::types::{
     OrbitError, Role, build_task_status_index, optional_string_list_alias, unmet_task_dependencies,
 };
@@ -177,6 +178,57 @@ pub(super) fn run_deterministic(
             std::thread::sleep(Duration::from_secs_f64(seconds));
             Ok(serde_json::json!({
                 "slept_seconds": started_at.elapsed().as_secs_f64(),
+            }))
+        }
+        "qa_sweep" => {
+            let workspace = input
+                .get("workspace")
+                .and_then(Value::as_str)
+                .map(str::trim)
+                .filter(|workspace| !workspace.is_empty())
+                .ok_or_else(|| DispatchError::DeterministicActionFailed {
+                    action: action.to_string(),
+                    message: "missing non-empty `workspace`".to_string(),
+                })?;
+            let outcome = run_qa_sweep(QaSweepOptions {
+                dry_run: false,
+                workspace: Some(workspace.to_string()),
+            })
+            .map_err(|error| DispatchError::DeterministicActionFailed {
+                action: action.to_string(),
+                message: error.to_string(),
+            })?;
+            let errors = outcome
+                .reports
+                .iter()
+                .filter(|report| report.action == "error")
+                .count();
+            if errors > 0 {
+                return Err(DispatchError::DeterministicActionFailed {
+                    action: action.to_string(),
+                    message: format!("qa-sweep: {errors} workspace(s) errored"),
+                });
+            }
+            let reports = outcome
+                .reports
+                .iter()
+                .map(|report| {
+                    serde_json::json!({
+                        "workspace": report.workspace,
+                        "action": report.action,
+                        "reason": report.reason,
+                        "branch": report.branch,
+                        "head": report.head,
+                        "baseline": report.baseline,
+                        "watermark_reset": report.watermark_reset,
+                        "run_id": report.run_id,
+                    })
+                })
+                .collect::<Vec<_>>();
+            Ok(serde_json::json!({
+                "lock_busy": outcome.lock_busy,
+                "workspaces": reports.len(),
+                "reports": reports,
             }))
         }
         // Materialize the workspace backlog for auto-dispatch.


### PR DESCRIPTION
## Task

[ORB-10085](https://orbit-cli.com/tasks/ORB-10085)

## What changed

- Added a daily `orbit-qa-sweep` routine pinned to `dk-server-1`.
- Added workspace-local job and deterministic activity assets that call the existing Rust QA sweep core.
- Added an explicit workspace filter so the routine validates only `orbit`; the existing CLI remains host-wide.
- Added regression coverage for workspace filtering.
- Left the transitional systemd QA service and timer unchanged.

## Validation

- `cargo test -p orbit-core qa::tests::sweep`
- `cargo test -p orbit-cli command::run::tests::qa_sweep`
- `cargo test -p orbit-core routines::tests`
- `make ci-fast`
- `orbit job show qa_sweep_routine --json`
- `orbit routine list --json`
- `orbit sweep --dry-run`

All local checks passed.