### PR TITLE
Select shipped executor sandbox settings by host platform

### DIFF
--- a/crates/orbit-common/src/types/executor_def.rs
+++ b/crates/orbit-common/src/types/executor_def.rs
@@ -69,12 +69,20 @@ impl ExecutorSandboxKind {
         }
     }
 
+    /// Whether this sandbox primitive applies to a given host OS, named to
+    /// match `std::env::consts::OS`. Injecting the platform lets shipped-executor
+    /// seed-time selection (see `orbit-core`) be tested deterministically on
+    /// either OS without a `#[cfg]` split (see [ORB-10112]).
+    pub fn is_available_on(self, target_os: &str) -> bool {
+        self.target_os() == target_os
+    }
+
     /// Whether this sandbox primitive applies to the running host. Used to
     /// scrub platform-mismatched sandbox declarations at seed time so a
     /// shipped executor asset doesn't fail-closed at dispatch on an
     /// unsupported OS (see [ORB-10047]).
     pub fn is_available_on_current_platform(self) -> bool {
-        self.target_os() == std::env::consts::OS
+        self.is_available_on(std::env::consts::OS)
     }
 }
 

--- a/crates/orbit-common/src/types/tests/executor_def.rs
+++ b/crates/orbit-common/src/types/tests/executor_def.rs
@@ -6,6 +6,13 @@ mod sandbox_kind_platform {
         assert_eq!(ExecutorSandboxKind::MacosSandboxExec.target_os(), "macos");
     }
 
+    #[test]
+    fn is_available_on_matches_only_its_target_os() {
+        assert!(ExecutorSandboxKind::MacosSandboxExec.is_available_on("macos"));
+        assert!(!ExecutorSandboxKind::MacosSandboxExec.is_available_on("linux"));
+        assert!(!ExecutorSandboxKind::MacosSandboxExec.is_available_on("windows"));
+    }
+
     #[cfg(target_os = "macos")]
     #[test]
     fn is_available_on_current_platform_is_true_on_macos() {

--- a/crates/orbit-core/src/command/executor.rs
+++ b/crates/orbit-core/src/command/executor.rs
@@ -1,6 +1,6 @@
 use orbit_common::types::{
-    EXECUTOR_RESOURCE_SCHEMA_VERSION, ExecutorDef, ExecutorResource, ExecutorType, OrbitError,
-    ResourceKind,
+    EXECUTOR_RESOURCE_SCHEMA_VERSION, ExecutorDef, ExecutorResource, ExecutorSandboxKind,
+    ExecutorType, OrbitError, ResourceKind,
 };
 use orbit_store::ExecutorDefStoreBackend;
 
@@ -19,9 +19,21 @@ pub(crate) fn seed_default_executors(
     store: &dyn ExecutorDefStoreBackend,
     overwrite: bool,
 ) -> Result<usize, OrbitError> {
+    seed_default_executors_for_platform(store, overwrite, std::env::consts::OS)
+}
+
+/// Platform-injected core of [`seed_default_executors`]. The host OS is passed
+/// explicitly (rather than read from `std::env::consts::OS`) so both the macOS
+/// and Linux seeding paths can be exercised deterministically in tests on a
+/// single CI host. See [ORB-10112].
+pub(super) fn seed_default_executors_for_platform(
+    store: &dyn ExecutorDefStoreBackend,
+    overwrite: bool,
+    target_os: &str,
+) -> Result<usize, OrbitError> {
     let mut created = 0usize;
     for (name, yaml) in DEFAULT_EXECUTOR_FILES {
-        let def = parse_default_executor(name, yaml)?;
+        let def = parse_default_executor_for_platform(name, yaml, target_os)?;
         let existing = store.get_executor_def(&def.name)?;
         match existing {
             None => {
@@ -33,7 +45,9 @@ pub(crate) fn seed_default_executors(
                 created += 1;
             }
             Some(existing) => {
-                if let Some(migrated) = migrated_default_executor(&existing, &def) {
+                if let Some(migrated) =
+                    migrated_default_executor_for_platform(&existing, &def, target_os)
+                {
                     store.upsert_executor_def(&migrated)?;
                     created += 1;
                 }
@@ -43,9 +57,38 @@ pub(crate) fn seed_default_executors(
     Ok(created)
 }
 
+/// Select the sandbox setting a *shipped* executor should be installed with on
+/// `target_os`. Shipped assets declare their macOS sandbox intent; keep it on
+/// hosts where the primitive applies and install without an OS sandbox
+/// elsewhere until a native backend for that host exists.
+///
+/// This is deliberate platform selection for Orbit's own defaults, so it is
+/// silent. It does NOT relax validation of user-authored executor defs: a
+/// custom def that explicitly requests an incompatible sandbox backend is left
+/// untouched here and still fails closed at dispatch in
+/// `runtime::v2_host::sandbox`. See [ORB-10112] / [ORB-10047].
+fn select_shipped_sandbox(
+    declared: Option<ExecutorSandboxKind>,
+    target_os: &str,
+) -> Option<ExecutorSandboxKind> {
+    match declared {
+        Some(kind) if kind.is_available_on(target_os) => Some(kind),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
 pub(super) fn migrated_default_executor(
     existing: &ExecutorDef,
     seeded: &ExecutorDef,
+) -> Option<ExecutorDef> {
+    migrated_default_executor_for_platform(existing, seeded, std::env::consts::OS)
+}
+
+pub(super) fn migrated_default_executor_for_platform(
+    existing: &ExecutorDef,
+    seeded: &ExecutorDef,
+    target_os: &str,
 ) -> Option<ExecutorDef> {
     if existing.name != seeded.name {
         return None;
@@ -61,28 +104,38 @@ pub(super) fn migrated_default_executor(
         changed = true;
     }
 
-    // Scrub a platform-mismatched sandbox left over from a prior install so
-    // re-seeding on a host that can't apply it (e.g. `macos-sandbox-exec` on
-    // Linux) drops the declaration instead of leaving dispatch fail-closed.
-    // See [ORB-10047].
+    // Re-align a leftover platform-mismatched sandbox on an installed default
+    // to the platform-appropriate value chosen at seed time. Upgrading a host
+    // that can't apply the persisted primitive (e.g. `macos-sandbox-exec`
+    // installed on Linux before [ORB-10112]) drops it to the seeded value so
+    // dispatch doesn't fail closed. See [ORB-10047].
     if let Some(kind) = existing.sandbox
-        && !kind.is_available_on_current_platform()
+        && !kind.is_available_on(target_os)
+        && existing.sandbox != seeded.sandbox
     {
-        tracing::warn!(
+        tracing::debug!(
             executor = %existing.name,
             sandbox = %kind,
-            current_platform = std::env::consts::OS,
-            target_platform = kind.target_os(),
-            "scrubbing platform-mismatched sandbox from installed executor def on re-seed",
+            target_os,
+            "re-aligning platform-mismatched sandbox on installed default executor to seeded value",
         );
-        migrated.sandbox = None;
+        migrated.sandbox = seeded.sandbox;
         changed = true;
     }
 
     if changed { Some(migrated) } else { None }
 }
 
+#[cfg(test)]
 pub(super) fn parse_default_executor(name: &str, yaml: &str) -> Result<ExecutorDef, OrbitError> {
+    parse_default_executor_for_platform(name, yaml, std::env::consts::OS)
+}
+
+pub(super) fn parse_default_executor_for_platform(
+    name: &str,
+    yaml: &str,
+    target_os: &str,
+) -> Result<ExecutorDef, OrbitError> {
     let resource: ExecutorResource = serde_yaml::from_str(yaml).map_err(|e| {
         OrbitError::InvalidInput(format!("invalid embedded executor def '{name}': {e}"))
     })?;
@@ -112,23 +165,15 @@ pub(super) fn parse_default_executor(name: &str, yaml: &str) -> Result<ExecutorD
         resource.spec.updated_at,
     );
 
-    // Shipped executor assets today declare a single-OS sandbox primitive
-    // (`macos-sandbox-exec`); dispatch fails closed if the runner platform
-    // can't apply it. Drop the declaration at parse time on hosts where it
-    // doesn't apply so first-install and re-install (overwrite mode) don't
-    // persist a platform-mismatched sandbox. See [ORB-10047].
-    if let Some(kind) = def.sandbox
-        && !kind.is_available_on_current_platform()
-    {
-        tracing::warn!(
-            executor = %def.name,
-            sandbox = %kind,
-            current_platform = std::env::consts::OS,
-            target_platform = kind.target_os(),
-            "shipped executor asset declares sandbox for another platform; installing without sandbox on this host",
-        );
-        def.sandbox = None;
-    }
+    // Shipped executor assets declare their macOS sandbox intent
+    // (`macos-sandbox-exec`), which dispatch fails closed on if the runner
+    // platform can't apply it. Select the platform-appropriate sandbox at seed
+    // time so first-install and re-install (overwrite mode) persist the value
+    // that matches the host: kept where the primitive applies, dropped
+    // elsewhere until a native backend for that host lands. This is deliberate
+    // selection for our own defaults, so — unlike the earlier mismatch
+    // handling — it is silent. See [ORB-10112] / [ORB-10047].
+    def.sandbox = select_shipped_sandbox(def.sandbox, target_os);
 
     Ok(def)
 }

--- a/crates/orbit-core/src/command/tests/executor.rs
+++ b/crates/orbit-core/src/command/tests/executor.rs
@@ -1,9 +1,21 @@
+use std::sync::Mutex;
+
 use chrono::Utc;
-use orbit_common::types::{ExecutorDef, ExecutorSandboxKind, ExecutorType};
+use orbit_common::types::{ExecutorDef, ExecutorSandboxKind, ExecutorType, OrbitError};
+use orbit_store::ExecutorDefStoreBackend;
 
 use crate::command::executor::{
-    DEFAULT_EXECUTOR_FILES, migrated_default_executor, parse_default_executor,
+    DEFAULT_EXECUTOR_FILES, migrated_default_executor, migrated_default_executor_for_platform,
+    parse_default_executor, parse_default_executor_for_platform,
+    seed_default_executors_for_platform,
 };
+
+const MACOS: &str = "macos";
+const LINUX: &str = "linux";
+
+/// Shipped executors that opt into Orbit's sandbox wrapper. `local-shell` is
+/// deliberately excluded — it stays unsandboxed on every platform.
+const SANDBOXED_SHIPPED: &[&str] = &["claude", "codex", "gemini", "grok"];
 
 fn base_def(name: &str, executor_type: ExecutorType) -> ExecutorDef {
     let now = Utc::now();
@@ -24,6 +36,47 @@ fn base_def(name: &str, executor_type: ExecutorType) -> ExecutorDef {
     }
 }
 
+fn yaml_for(name: &str) -> &'static str {
+    DEFAULT_EXECUTOR_FILES
+        .iter()
+        .find(|(key, _)| *key == name)
+        .map(|(_, yaml)| *yaml)
+        .unwrap_or_else(|| panic!("shipped executor asset `{name}` present"))
+}
+
+/// Minimal in-memory store so the seed path can be exercised without touching
+/// the filesystem or the host platform.
+#[derive(Default)]
+struct InMemoryExecutorStore {
+    defs: Mutex<Vec<ExecutorDef>>,
+}
+
+impl ExecutorDefStoreBackend for InMemoryExecutorStore {
+    fn list_executor_defs(&self) -> Result<Vec<ExecutorDef>, OrbitError> {
+        Ok(self.defs.lock().expect("lock").clone())
+    }
+
+    fn get_executor_def(&self, name: &str) -> Result<Option<ExecutorDef>, OrbitError> {
+        Ok(self
+            .defs
+            .lock()
+            .expect("lock")
+            .iter()
+            .find(|def| def.name == name)
+            .cloned())
+    }
+
+    fn upsert_executor_def(&self, def: &ExecutorDef) -> Result<(), OrbitError> {
+        let mut defs = self.defs.lock().expect("lock");
+        if let Some(existing) = defs.iter_mut().find(|d| d.name == def.name) {
+            *existing = def.clone();
+        } else {
+            defs.push(def.clone());
+        }
+        Ok(())
+    }
+}
+
 const CLAUDE_YAML: &str = r#"schemaVersion: 2
 kind: Executor
 metadata:
@@ -34,55 +87,87 @@ spec:
   sandbox: macos-sandbox-exec
 "#;
 
-/// On macOS the sandbox declaration matches the host and must survive parsing —
-/// otherwise ORB-10047's fix would silently disarm the sandbox everywhere.
-#[cfg(target_os = "macos")]
+/// On the macOS seed path every sandbox-supporting shipped executor keeps the
+/// `macos-sandbox-exec` declaration; `local-shell` stays unsandboxed. Driven
+/// by an injected platform string so it runs deterministically on any CI host.
 #[test]
-fn parse_default_executor_preserves_sandbox_on_matching_platform() {
-    let def = parse_default_executor("claude", CLAUDE_YAML).expect("parse");
-    assert_eq!(def.sandbox, Some(ExecutorSandboxKind::MacosSandboxExec));
+fn parse_default_executor_installs_macos_sandbox_on_macos_path() {
+    for name in SANDBOXED_SHIPPED {
+        let def = parse_default_executor_for_platform(name, yaml_for(name), MACOS)
+            .unwrap_or_else(|err| panic!("parse {name}: {err}"));
+        assert_eq!(
+            def.sandbox,
+            Some(ExecutorSandboxKind::MacosSandboxExec),
+            "{name} should keep macos-sandbox-exec on the macOS path"
+        );
+    }
+
+    let local_shell =
+        parse_default_executor_for_platform("local-shell", yaml_for("local-shell"), MACOS)
+            .expect("parse local-shell");
+    assert_eq!(
+        local_shell.sandbox, None,
+        "local-shell must stay unsandboxed on macOS"
+    );
 }
 
-/// On Linux the shipped `macos-sandbox-exec` declaration cannot be enforced;
-/// keeping it would make every crew dispatch fail closed at dispatch time.
-/// See ORB-10047.
-#[cfg(not(target_os = "macos"))]
+/// On the Linux seed path no shipped executor carries an OS sandbox — there is
+/// no Linux backend yet — and none of them emit the platform-mismatch warning,
+/// because the selection is deliberate rather than a mismatch to flag.
 #[test]
-fn parse_default_executor_scrubs_sandbox_on_mismatched_platform() {
-    let def = parse_default_executor("claude", CLAUDE_YAML).expect("parse");
-    assert_eq!(def.sandbox, None);
+fn parse_default_executor_installs_without_sandbox_on_linux_path() {
+    for (name, yaml) in DEFAULT_EXECUTOR_FILES {
+        let def = parse_default_executor_for_platform(name, yaml, LINUX)
+            .unwrap_or_else(|err| panic!("parse {name}: {err}"));
+        assert_eq!(
+            def.sandbox, None,
+            "{name} must install without an OS sandbox on the Linux path"
+        );
+    }
 }
 
-/// Re-seeding must scrub a platform-mismatched sandbox left over from a
-/// prior install, so an upgrade on Linux clears a persisted
-/// `macos-sandbox-exec` even though the executor type is unchanged.
-#[cfg(not(target_os = "macos"))]
+/// The host-platform default entry point defers to the injected core: on the
+/// running host, a shipped sandbox declaration survives iff the primitive
+/// applies to this OS.
 #[test]
-fn migrated_default_executor_scrubs_platform_mismatched_sandbox_on_non_matching_host() {
+fn parse_default_executor_selects_by_host_platform() {
+    let def = parse_default_executor("claude", CLAUDE_YAML).expect("parse");
+    if ExecutorSandboxKind::MacosSandboxExec.is_available_on_current_platform() {
+        assert_eq!(def.sandbox, Some(ExecutorSandboxKind::MacosSandboxExec));
+    } else {
+        assert_eq!(def.sandbox, None);
+    }
+}
+
+/// Re-seeding must re-align a platform-mismatched sandbox left over from a
+/// prior install: an upgrade on Linux clears a persisted `macos-sandbox-exec`
+/// even though the executor type is unchanged.
+#[test]
+fn migrated_default_executor_realigns_platform_mismatched_sandbox_on_linux() {
     let mut existing = base_def("claude", ExecutorType::DirectAgent);
     existing.sandbox = Some(ExecutorSandboxKind::MacosSandboxExec);
-    let seeded = base_def("claude", ExecutorType::DirectAgent);
+    let seeded = parse_default_executor_for_platform("claude", CLAUDE_YAML, LINUX).expect("seed");
 
-    let migrated =
-        migrated_default_executor(&existing, &seeded).expect("scrub should produce a migrated def");
+    let migrated = migrated_default_executor_for_platform(&existing, &seeded, LINUX)
+        .expect("re-align should produce a migrated def");
     assert_eq!(migrated.sandbox, None);
     assert_eq!(migrated.executor_type, ExecutorType::DirectAgent);
 }
 
-/// On macOS the persisted sandbox is host-compatible; re-seeding must not
-/// touch it and must not force a rewrite.
-#[cfg(target_os = "macos")]
+/// On macOS the persisted sandbox is host-compatible; re-seeding must not touch
+/// it and must not force a rewrite.
 #[test]
-fn migrated_default_executor_preserves_sandbox_on_matching_host() {
+fn migrated_default_executor_preserves_sandbox_on_macos() {
     let mut existing = base_def("claude", ExecutorType::DirectAgent);
     existing.sandbox = Some(ExecutorSandboxKind::MacosSandboxExec);
-    let seeded = base_def("claude", ExecutorType::DirectAgent);
+    let seeded = parse_default_executor_for_platform("claude", CLAUDE_YAML, MACOS).expect("seed");
 
-    assert!(migrated_default_executor(&existing, &seeded).is_none());
+    assert!(migrated_default_executor_for_platform(&existing, &seeded, MACOS).is_none());
 }
 
-/// The pre-ORB-10047 `AgentCli → DirectAgent` migration path must still fire
-/// so upgrades from older on-disk executor defs continue to move forward.
+/// The pre-ORB-10047 `AgentCli → DirectAgent` migration path must still fire so
+/// upgrades from older on-disk executor defs continue to move forward,
+/// regardless of platform.
 #[test]
 fn migrated_default_executor_still_migrates_agent_cli_to_direct_agent() {
     let existing = base_def("claude", ExecutorType::AgentCli);
@@ -98,6 +183,77 @@ fn migrated_default_executor_returns_none_when_nothing_needs_migrating() {
     let existing = base_def("claude", ExecutorType::DirectAgent);
     let seeded = base_def("claude", ExecutorType::DirectAgent);
     assert!(migrated_default_executor(&existing, &seeded).is_none());
+}
+
+/// Seeding twice on the macOS path is idempotent and preserves the
+/// `macos-sandbox-exec` value: the second pass creates nothing new and leaves
+/// every sandbox-supporting default sandboxed.
+#[test]
+fn seed_default_executors_is_idempotent_on_macos_path() {
+    let store = InMemoryExecutorStore::default();
+
+    let first = seed_default_executors_for_platform(&store, false, MACOS).expect("first seed");
+    assert_eq!(first, DEFAULT_EXECUTOR_FILES.len());
+
+    let second = seed_default_executors_for_platform(&store, false, MACOS).expect("second seed");
+    assert_eq!(second, 0, "re-seed must be a no-op on the macOS path");
+
+    for name in SANDBOXED_SHIPPED {
+        let def = store
+            .get_executor_def(name)
+            .expect("get")
+            .unwrap_or_else(|| panic!("{name} seeded"));
+        assert_eq!(
+            def.sandbox,
+            Some(ExecutorSandboxKind::MacosSandboxExec),
+            "{name} sandbox must survive idempotent re-seed on macOS"
+        );
+    }
+}
+
+/// Seeding twice on the Linux path is idempotent and preserves the unsandboxed
+/// value: no default acquires a sandbox and the second pass creates nothing.
+#[test]
+fn seed_default_executors_is_idempotent_on_linux_path() {
+    let store = InMemoryExecutorStore::default();
+
+    let first = seed_default_executors_for_platform(&store, false, LINUX).expect("first seed");
+    assert_eq!(first, DEFAULT_EXECUTOR_FILES.len());
+
+    let second = seed_default_executors_for_platform(&store, false, LINUX).expect("second seed");
+    assert_eq!(second, 0, "re-seed must be a no-op on the Linux path");
+
+    for (name, _) in DEFAULT_EXECUTOR_FILES {
+        let def = store
+            .get_executor_def(name)
+            .expect("get")
+            .unwrap_or_else(|| panic!("{name} seeded"));
+        assert_eq!(
+            def.sandbox, None,
+            "{name} must stay unsandboxed across idempotent re-seed on Linux"
+        );
+    }
+}
+
+/// A pre-ORB-10112 Linux install that persisted `macos-sandbox-exec` is healed
+/// on the next seed: the leftover mismatch is re-aligned to unsandboxed.
+#[test]
+fn seed_default_executors_heals_leftover_macos_sandbox_on_linux() {
+    let store = InMemoryExecutorStore::default();
+    let mut stale = base_def("claude", ExecutorType::DirectAgent);
+    stale.sandbox = Some(ExecutorSandboxKind::MacosSandboxExec);
+    store.upsert_executor_def(&stale).expect("seed stale def");
+
+    seed_default_executors_for_platform(&store, false, LINUX).expect("seed");
+
+    let healed = store
+        .get_executor_def("claude")
+        .expect("get")
+        .expect("claude present");
+    assert_eq!(
+        healed.sandbox, None,
+        "leftover macos-sandbox-exec must be cleared on the Linux seed path"
+    );
 }
 
 /// ADR-0211 asset↔const seam: the shipped `claude.yaml` cannot reference the


### PR DESCRIPTION
## Task

[ORB-10112](https://orbit-cli.com/tasks/ORB-10112) — Select shipped executor sandbox settings by host platform

### Description

## Problem
Orbit’s shipped executor assets statically declare `sandbox: macos-sandbox-exec`. On Linux, every executor registry initialization or listing emits a platform-mismatch warning and strips the declaration before installation. The resulting Linux configuration is usable, but the repeated warnings are noisy and the shipped defaults do not directly represent the host platform.

## Desired behavior
Determine the sandbox setting when shipped executors are installed or seeded:

- On macOS, executors that support Orbit’s sandbox wrapper use `macos-sandbox-exec`.
- On Linux, those executors are installed without an OS-level sandbox until a Linux backend exists.
- `local-shell` remains unsandboxed on both platforms.

## Constraints / Notes
- Apply the behavior consistently to Claude, Codex, Gemini, and Grok.
- Preserve fail-closed validation for user-authored/custom executor definitions that explicitly request a sandbox backend incompatible with the current host.
- Avoid platform-dependent test execution by exposing or injecting the platform decision so both macOS and Linux behavior can be tested deterministically on CI.
- This should replace the temporary host-local binary patch applied on `dk1`; rollback is to restore the current static asset declarations and mismatch handling.

### Acceptance Criteria

- A deterministic test of the macOS path shows shipped Claude, Codex, Gemini, and Grok definitions installed with `spec.sandbox: macos-sandbox-exec`, while `local-shell` has no sandbox.
- A deterministic test of the Linux path shows all shipped executor definitions installed without `spec.sandbox` and emits no `shipped executor asset declares sandbox for another platform` warnings during executor seeding/listing.
- An explicitly configured custom executor whose sandbox backend targets a different platform is still rejected or otherwise handled fail-closed by runtime sandbox resolution; the change does not silently weaken custom-definition validation.
- Repeated shipped-executor seeding is idempotent on both platform paths and preserves the platform-appropriate sandbox value.
- The Orbit repository’s formatting, lint, and relevant executor/runtime test commands pass on Linux CI, with macOS behavior covered deterministically or by the macOS CI job.

## Execution Summary

<details>
<summary>Click to expand</summary>

Select shipped executor sandbox settings by host platform, replacing the static
`macos-sandbox-exec` declaration + Linux warn-and-scrub with silent seed-time
platform selection.

Approach: shipped executor YAML assets keep declaring `sandbox: macos-sandbox-exec`
as the *macOS sandbox intent*. Sandbox is now chosen at seed/install time from the
host OS, injected explicitly so both platform paths test deterministically on one CI host.

Changes:
- orbit-common/src/types/executor_def.rs: added `ExecutorSandboxKind::is_available_on(target_os: &str)`;
  `is_available_on_current_platform` delegates to it (platform-injection seam).
- orbit-core/src/command/executor.rs:
  * `seed_default_executors` -> delegates to new `seed_default_executors_for_platform(store, overwrite, target_os)`
    (host default = std::env::consts::OS).
  * new `select_shipped_sandbox(declared, target_os)`: keeps the declared sandbox where the
    primitive applies to the host, drops it otherwise — SILENTLY (removed the noisy
    "shipped executor asset declares sandbox for another platform" warning; it was deliberate
    platform selection for our own defaults, not a mismatch).
  * `parse_default_executor_for_platform` uses `select_shipped_sandbox`.
  * `migrated_default_executor_for_platform` re-aligns a leftover platform-mismatched sandbox
    on an installed default to the seeded (platform-appropriate) value on re-seed, at debug level.
  * test-only thin wrappers (`parse_default_executor`, `migrated_default_executor`) kept under #[cfg(test)].

Fail-closed preserved (AC #3): custom/user-authored defs are untouched by seeding; runtime
`runtime::v2_host::sandbox::resolve_executor_sandbox` still errors when a def declares
`macos-sandbox-exec` off macOS. Guarded by the existing (unmodified) test
`resolve_executor_sandbox_errors_on_non_macos_platform` (passes on Linux).

Tests (deterministic, no #[cfg] platform split):
- orbit-core command::tests::executor — macOS path installs macos-sandbox-exec for
  claude/codex/gemini/grok and none for local-shell; Linux path installs all shipped defs
  unsandboxed; re-seed idempotent on both paths preserving the platform-appropriate value;
  leftover macos-sandbox-exec on Linux healed on re-seed; AgentCli->DirectAgent migration intact.
  Uses an in-memory ExecutorDefStoreBackend.
- orbit-common executor_def tests — is_available_on matches only its target OS.

Validation on Linux: cargo test -p orbit-common (executor_def) and -p orbit-core
(command::tests::executor, runtime::v2_host::sandbox) all pass; cargo fmt --all --check clean;
cargo clippy -p orbit-common -p orbit-core clean.
NOT RUN here (environment limitation, not a change defect): `make ci-fast`'s
`test-installer-security.sh` step requires `node`, which is absent on this runner
(`required binary 'node' not on PATH`). fmt-check and check-installer-pubkey within ci-fast
passed. CI runs the full gate unrestricted.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10112-6a52901a`
- Behind base: 0
- Ahead of base: 1