### PR TITLE
[ORB-10131] Default Codex init to danger-full-access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Highlights
 
+- **Codex init default avoids nested sandboxing**: fresh Orbit configurations now seed Codex with `danger-full-access`, leaving Orbit and the host as the execution boundary. ([ORB-10131])
 - **Model defaults de-hardcoded and centralized**: a new `orbit-common::model_defaults` module is the single source of truth for production model defaults; default Claude CLI models are now the unversioned `opus`/`sonnet` aliases and default Codex is `gpt-5.6-terra`. Existing workspaces are unchanged until `orbit init --refresh-defaults`. See ADR-0211. ([ORB-10051])
 - **`orbit web serve` defaults to global (multi-workspace) mode**: the all-workspaces dashboard dropdown is always present; `--global` is now a deprecated no-op. ([ORB-10029])
 - **`orbit-cmd` extracted from `orbit-core`**: the CLI-facing command layer moved into a new internal `orbit-cmd` crate (depends on orbit-core, never the reverse). Import paths `orbit_core::command::{doctor,migrate,diagnostics,…}` → `orbit_cmd::…`; CLI/MCP/on-disk behavior unchanged. See ADR-0203. ([ORB-10016])

--- a/crates/orbit-core/assets/config/default-config.toml
+++ b/crates/orbit-core/assets/config/default-config.toml
@@ -14,7 +14,7 @@ pass = [
 ]
 
 [execution.codex]
-sandbox = "workspace-write"
+sandbox = "danger-full-access"
 # Optional: enable escalation requests for workflows that legitimately need approval.
 # approval_policy = "on-request"
 

--- a/crates/orbit-core/src/config/tests/bootstrap.rs
+++ b/crates/orbit-core/src/config/tests/bootstrap.rs
@@ -191,6 +191,7 @@ fn seed_with_no_role_settings_writes_generated_agent_block() {
     assert!(no_active_role_section(&contents));
     assert_all_base_crews_present(&contents);
     assert!(contents.contains("default_crew = \"codex\""));
+    assert!(contents.contains("sandbox = \"danger-full-access\""));
 }
 
 fn seed_contents(


### PR DESCRIPTION
## What changed

- Seed fresh Orbit configurations with `execution.codex.sandbox = "danger-full-access"`.
- Assert the generated config contains the new Codex default.
- Document the change in the Unreleased changelog.

## Why

Orbit and the host already provide the execution boundary. Avoiding Codex's nested Linux bubblewrap sandbox prevents double-sandbox startup failures such as `bwrap: loopback: Failed RTM_NEWADDR`.

Existing workspace configs are unchanged.

## Validation

- `cargo test -p orbit-core config::tests::bootstrap::seed_with_no_role_settings_writes_generated_agent_block --locked`
- `make ci-fast`