### PR TITLE
Configure model-level crews [ORB-10133]

### DIFF
--- a/.orbit/config.toml
+++ b/.orbit/config.toml
@@ -25,18 +25,38 @@ editing = false
 [workflow]
 auto_ship = true
 base_branch = "agent-main"
-default_crew = "claude"
+default_crew = "opus"
 
 [routines]
 role = "source"
 
-[crews.claude]
-model = "claude-opus-4-8"
+[crews.opus]
+model = "opus"
 provider = "claude"
 backend = "cli"
 
-[crews.codex]
+[crews.sonnet]
+model = "sonnet"
+provider = "claude"
+backend = "cli"
+
+[crews.fable]
+model = "fable"
+provider = "claude"
+backend = "cli"
+
+[crews.sol]
+model = "gpt-5.6-sol"
+provider = "codex"
+backend = "cli"
+
+[crews.terra]
 model = "gpt-5.6-terra"
+provider = "codex"
+backend = "cli"
+
+[crews.luna]
+model = "gpt-5.6-luna"
 provider = "codex"
 backend = "cli"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 
 ### Highlights
 
+- **Constellation crew catalog uses model-level names**: the checked-in Orbit workspace now offers Claude `opus`/`sonnet`/`fable` and Codex `sol`/`terra`/`luna` crews, defaulting to `opus`. ([ORB-10133])
+
 - **Codex init default avoids nested sandboxing**: fresh Orbit configurations now seed Codex with `danger-full-access`, leaving Orbit and the host as the execution boundary. ([ORB-10131])
 - **Crews are one provider-model assignment**: `[crews.<name>]` now uses flat `model`, `provider`, and `backend` fields shared by every activity role; legacy three-role crews load through their implementer assignment. See ADR-0213. ([ORB-10130])
 - **Model defaults de-hardcoded and centralized**: a new `orbit-common::model_defaults` module is the single source of truth for production model defaults; default Claude CLI models are now the unversioned `opus`/`sonnet` aliases and default Codex is `gpt-5.6-terra`. Existing workspaces are unchanged until `orbit init --refresh-defaults`. See ADR-0211. ([ORB-10051])


### PR DESCRIPTION
## What changed

- replace the checked-in Orbit workspace's provider-level `claude`/`codex` crews with model-level Claude `opus`/`sonnet`/`fable` and Codex `sol`/`terra`/`luna` crews
- keep `gemini` and `grok` unchanged
- set the Orbit workspace default crew to `opus`
- document the rollout in the Unreleased changelog

## Why

ORB-10130 flattened every crew to one provider/model assignment. The constellation now names crews by the actual model tier so task routing is explicit and the same assignment is used for planner, implementer, and reviewer roles.

## Validation

- `make ci-fast`
- `git diff --check`
- `orbit --root <worktree>/.orbit config show --json` (default resolves to `opus`)
- all ten registered constellation workspaces pass `orbit doctor --json` after the operational config rollout