### PR TITLE
CI: fix runner ENOSPC — trim debuginfo, reclaim runner disk, drop incremental, rethink coverage cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,13 @@ permissions:
 
 env:
   CARGO_TERM_COLOR: always
+  # [ORB-10126] ENOSPC controls on ubuntu-latest (~14 GB free). Incremental
+  # artifacts roughly double target/ and are useless on ephemeral runners;
+  # full test debuginfo is the single biggest target-size lever. Coverage
+  # only needs line tables, so trim the whole workspace test profile to
+  # line-tables-only (deps included) — 50–70% smaller target/.
+  CARGO_INCREMENTAL: "0"
+  CARGO_PROFILE_TEST_DEBUG: line-tables-only
   NEXTEST_VERSION: 0.9.136
   NEXTEST_LINUX_SHA256: a098eed56f2dd88c7fdca1e554a6b99fa1ffbd2a7a1c41b865700112981f6f52
   CARGO_DENY_VERSION: 0.19.9
@@ -100,6 +107,25 @@ jobs:
     name: Coverage (informational)
     runs-on: ubuntu-latest
     steps:
+      # [ORB-10126] Reclaim ~25-30 GB of preinstalled runner bloat before the
+      # instrumented build. No maintained free-disk action is pinned in this
+      # repo, so an explicit rm list keeps the repo's pinned-action convention
+      # intact (nothing new to pin/audit). df -h brackets it for diagnosis.
+      - name: Free up runner disk space
+        run: |
+          set -euo pipefail
+          echo "Disk before cleanup:"
+          df -h /
+          sudo rm -rf /usr/local/lib/android
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /opt/ghc /usr/local/.ghcup
+          sudo rm -rf /opt/hostedtoolcache/CodeQL
+          sudo rm -rf /usr/local/share/boost
+          sudo rm -rf /usr/local/share/powershell
+          sudo rm -rf /usr/share/swift
+          echo "Disk after cleanup:"
+          df -h /
+
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           ref: ${{ github.event_name == 'pull_request' && github.head_ref || github.ref_name }}
@@ -109,15 +135,18 @@ jobs:
         with:
           components: llvm-tools-preview
 
+      # [ORB-10126] Deps-only cache: the instrumented target/ is dropped from
+      # the cache path (it churns near actions/cache's ~10 GB cap and its
+      # restore competes with fresh instrumented artifacts + profraw for disk).
+      # Only the immutable registry/git deps are cached here.
       - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-coverage-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-coverage-deps-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
-            ${{ runner.os }}-cargo-coverage-
+            ${{ runner.os }}-cargo-coverage-deps-
 
       # Same pinned-tarball convention as the nextest install in the ci job.
       - name: Install cargo-llvm-cov
@@ -150,10 +179,34 @@ jobs:
           path: lcov.info
           if-no-files-found: error
 
+      # [ORB-10126] Confirm headroom survived the instrumented build (runs even
+      # if a prior step failed, so an ENOSPC crash still surfaces disk state).
+      - name: Report disk usage
+        if: always()
+        run: df -h /
+
   ci:
     name: Check / Clippy / Test
     runs-on: ubuntu-latest
     steps:
+      # [ORB-10126] Same runner-bloat reclaim as the coverage job; the ci job
+      # compiles the whole workspace from the same target/ and sits close to
+      # the ubuntu-latest disk limit. Runs ahead of the build.
+      - name: Free up runner disk space
+        run: |
+          set -euo pipefail
+          echo "Disk before cleanup:"
+          df -h /
+          sudo rm -rf /usr/local/lib/android
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /opt/ghc /usr/local/.ghcup
+          sudo rm -rf /opt/hostedtoolcache/CodeQL
+          sudo rm -rf /usr/local/share/boost
+          sudo rm -rf /usr/local/share/powershell
+          sudo rm -rf /usr/share/swift
+          echo "Disk after cleanup:"
+          df -h /
+
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           ref: ${{ github.event_name == 'pull_request' && github.head_ref || github.ref_name }}
@@ -205,6 +258,11 @@ jobs:
 
       - name: Run CI guardrails
         run: ./scripts/ci-guardrails.sh
+
+      # [ORB-10126] Confirm disk headroom survived the workspace build/test.
+      - name: Report disk usage
+        if: always()
+        run: df -h /
 
       - name: Create orbit task on CI failure
         if: failure() && github.event_name == 'pull_request'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 
 ### Highlights
 
+- **CI runner ENOSPC fixes**: the coverage and `ci` jobs reclaim ~25-30 GB of preinstalled runner bloat before building, set `CARGO_INCREMENTAL=0` and `CARGO_PROFILE_TEST_DEBUG=line-tables-only` to shrink `target/`, and the coverage cache is now deps-only (no instrumented `target/`). ([ORB-10126])
+
 - **Constellation crew catalog uses model-level names**: the checked-in Orbit workspace now offers Claude `opus`/`sonnet`/`fable` and Codex `sol`/`terra`/`luna` crews, defaulting to `opus`. ([ORB-10133])
 
 - **Codex init default avoids nested sandboxing**: fresh Orbit configurations now seed Codex with `danger-full-access`, leaving Orbit and the host as the execution boundary. ([ORB-10131])


### PR DESCRIPTION
## Task

[ORB-10126](https://orbit-cli.com/tasks/ORB-10126) — CI: fix runner ENOSPC — trim debuginfo, reclaim runner disk, drop incremental, rethink coverage cache

### Description

## Problem
GitHub-hosted runners are crashing with `No space left on device`. `ubuntu-latest` has ~14 GB free; the workspace `target/` is ~21 GB for a plain build, and the coverage job (ORB-10010) is worse: `cargo llvm-cov --workspace` builds the whole workspace instrumented with full debuginfo, on top of a restored `~cargo-coverage-` cached `target/`, plus per-test-binary profraw files. Restored cache + instrumented artifacts + profdata exceeds the disk and the runner dies. The main `ci` job builds from the same workspace and is close to the same limit.

## Scope (`.github/workflows/ci.yml` — coverage job and `ci` job)

1. **Cut debuginfo in CI** (biggest lever): set `CARGO_PROFILE_TEST_DEBUG=line-tables-only` (coverage needs line tables only; deps can go to `debug=0`). Expected 50–70% target-size reduction.
2. **Reclaim runner disk up front**: a first step deleting GitHub's preinstalled bloat (`/usr/local/lib/android`, `/usr/share/dotnet`, `/opt/ghc`, ...) — frees ~25–30 GB. Either a maintained action or an explicit `rm -rf` list consistent with the repo's pinned-action convention.
3. **`CARGO_INCREMENTAL=0`** across CI jobs — incremental artifacts roughly double target size and are useless on ephemeral runners.
4. **Coverage cache**: stop caching the full instrumented `target/` under raw `actions/cache` (churns near the 10 GB cap and inflates restores). Prefer `Swatinem/rust-cache` (deps-only, prunes artifacts) or drop `target` from the cache path for the coverage job.

Keep the coverage job informational/non-gating (ORB-10010) and respect the existing pinned-action-SHA convention. Optionally add `df -h` before/after the cleanup step for future diagnosis.

## Acceptance signal
A full CI run (including coverage) completes on `ubuntu-latest` with comfortable headroom (`df -h` shows several GB free at the end of the largest job).

### Acceptance Criteria

- Coverage job and ci job complete on ubuntu-latest without ENOSPC; df -h output shows multi-GB headroom at job end
- Test-profile debuginfo reduced (line-tables-only or equivalent) and CARGO_INCREMENTAL=0 set in CI env
- Runner disk-reclaim step added ahead of the build in disk-heavy jobs, following the repo's pinned-action convention
- Coverage job no longer caches a full instrumented target/ via raw actions/cache (rust-cache or deps-only caching), and lcov artifact upload still works
- Coverage job remains informational (non-gating)

## Execution Summary

<details>
<summary>Click to expand</summary>

Fixed ubuntu-latest ENOSPC crashes in .github/workflows/ci.yml (coverage + ci jobs).

Changes:
1. Top-level env: CARGO_INCREMENTAL="0" (kills incremental artifacts that ~2x target/) and CARGO_PROFILE_TEST_DEBUG=line-tables-only (biggest lever; coverage needs only line tables, whole test profile incl. deps trimmed, 50-70% smaller target/). Applies to all jobs.
2. Disk-reclaim step added as the FIRST step (ahead of build) in both disk-heavy jobs (coverage, ci): explicit sudo rm -rf of preinstalled runner bloat (android, dotnet, ghc/ghcup, CodeQL toolcache, boost, powershell, swift) ~25-30 GB freed, bracketed by df -h. Explicit rm chosen over a maintained action because no free-disk action is pinned in this repo, keeping the pinned-action-SHA convention intact (nothing new to pin/audit).
3. Coverage cache: dropped target/ from the actions/cache path (now deps-only: ~/.cargo/registry + ~/.cargo/git), renamed key to *-coverage-deps-. Stops churning the instrumented target/ near actions/cache's ~10 GB cap. lcov render + upload-artifact untouched.
4. Added an if: always() df -h / step at the end of coverage and ci jobs so headroom is visible at job end (and disk state surfaces even on an ENOSPC crash).

Coverage job remains informational/non-gating (no change to required-status wiring). ci job keeps its full target/ cache (only coverage was over-caching).

Also updated CHANGELOG.md (## Unreleased > Highlights) with a terse ORB-10126 bullet — required by check-changelog-freshness.sh, which this same CI runs.

Validation: YAML parses (python yaml.safe_load, all 4 jobs intact); check-changelog-style.sh and check-changelog-freshness.sh both exit 0. No Rust changed, so fmt-check/compile guardrails are unaffected. The full ci-guardrails.sh run was not completed locally - its error-translation/rg scans over the whole workspace exceed the 2-min sandbox timeout - but none of those guardrails touch the changed files; CI runs them unrestricted.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10126-6a52b02d`
- Behind base: 0
- Ahead of base: 1