### PR TITLE
Fix remote dashboard task actions and workspace dropdown path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Highlights
 
+- **Remote dashboard task actions now reach the selected workspace**: `approve`/`reject`/`archive` used a raw `fetch()` that skipped the workspace-routing helper, so they silently no-op'd against a non-default remote workspace; the workspace selector also no longer renders its filesystem path beneath the dropdown. ([ORB-10124])
 - **Constellation crew catalog uses model-level names**: the checked-in Orbit workspace now offers Claude `opus`/`sonnet`/`fable` and Codex `sol`/`terra`/`luna` crews, defaulting to `opus`. ([ORB-10133])
 
 - **Codex init default avoids nested sandboxing**: fresh Orbit configurations now seed Codex with `danger-full-access`, leaving Orbit and the host as the execution boundary. ([ORB-10131])

--- a/crates/orbit-dashboard/assets/dashboard/app.js
+++ b/crates/orbit-dashboard/assets/dashboard/app.js
@@ -1301,34 +1301,11 @@ function buildWorkspaceSelector() {
 
   select.addEventListener("change", () => {
     setWorkspace(select.value);
-    updateWorkspacePath();
     refreshDashboard();
   });
 
-  // ORB-00037: the option labels stay short (workspace name); the selected
-  // workspace's filesystem location (home-abbreviated to ~ server-side) shows as
-  // a secondary line beneath the <select> to disambiguate same-named workspaces.
-  const pathLine = el("div", { class: "workspace-path" });
-  pathLine.id = "workspace-path";
-  const wrap = el("div", { class: "workspace-select-wrap" }, [select, pathLine]);
-
   const meta = $("meta");
-  meta.insertBefore(wrap, $("refresh-btn"));
-  updateWorkspacePath();
-}
-
-// ORB-00037: render the selected workspace's filesystem path beneath the
-// selector (and as a tooltip). Hidden for the aggregate "All workspaces" view or
-// when the path is unknown/empty.
-function updateWorkspacePath() {
-  const line = $("workspace-path");
-  if (!line) return;
-  const current = getWorkspace();
-  const ws = current && dashboardWorkspaces.find((w) => w.id === current);
-  const loc = (ws && ws.root) || "";
-  line.textContent = loc;
-  line.title = loc;
-  line.style.display = loc ? "" : "none";
+  meta.insertBefore(select, $("refresh-btn"));
 }
 
 function activeRefreshJobs() {

--- a/crates/orbit-dashboard/assets/dashboard/common.js
+++ b/crates/orbit-dashboard/assets/dashboard/common.js
@@ -47,7 +47,7 @@ export function renderPanelPlaceholder(bodyId) {
 
 // Append the selected workspace to an API path, unless one is already present
 // (aggregate endpoints like /api/tasks/all are called with no workspace set).
-function withWorkspace(path) {
+export function withWorkspace(path) {
   if (!currentWorkspace || /[?&]workspace=/.test(path)) return path;
   const sep = path.includes("?") ? "&" : "?";
   return `${path}${sep}workspace=${encodeURIComponent(currentWorkspace)}`;

--- a/crates/orbit-dashboard/assets/dashboard/dashboard.css
+++ b/crates/orbit-dashboard/assets/dashboard/dashboard.css
@@ -157,25 +157,7 @@
         vertical-align: middle;
       }
 
-      /* ORB-00037: selected-workspace filesystem path beneath the selector,
-         plus the full location in a task's Details box. */
-      .workspace-select-wrap {
-        display: inline-flex;
-        flex-direction: column;
-        align-items: flex-start;
-        gap: 1px;
-        margin: 0 2px;
-      }
-      .workspace-select-wrap .workspace-select { margin: 0; }
-      .workspace-path {
-        max-width: 190px;
-        font-family: var(--font-mono);
-        font-size: 10px;
-        color: var(--fg-dim);
-        white-space: nowrap;
-        overflow: hidden;
-        text-overflow: ellipsis;
-      }
+      /* ORB-00037: full workspace location in a task's Details box. */
       .detail-side .ws-location {
         font-size: 11px;
         color: var(--fg-dim);

--- a/crates/orbit-dashboard/assets/dashboard/tasks.js
+++ b/crates/orbit-dashboard/assets/dashboard/tasks.js
@@ -1,7 +1,7 @@
 // Orbit dashboard task-domain rendering and actions.
 // Pure vanilla JS, split into ES modules with no build step.
 
-import { el, statusPill, patchJson, syncNodes } from './common.js';
+import { el, statusPill, patchJson, syncNodes, withWorkspace } from './common.js';
 import { renderMarkdown, renderMarkdownInline } from './markdown.js';
 
 const $ = (id) => document.getElementById(id);
@@ -830,7 +830,7 @@ async function runAction(task, kind, detail, body, btnNode, context, opts = {}) 
   const prior = detail.querySelector(".action-error");
   if (prior) prior.remove();
   try {
-    const res = await fetch(opts.path || `/api/tasks/${encodeURIComponent(task.id)}/${kind}`, {
+    const res = await fetch(withWorkspace(opts.path || `/api/tasks/${encodeURIComponent(task.id)}/${kind}`), {
       method: opts.method || "POST",
       headers: body ? { "content-type": "application/json" } : undefined,
       body: body ? JSON.stringify(body) : undefined,

--- a/crates/orbit-dashboard/src/tests/dashboard_assets.rs
+++ b/crates/orbit-dashboard/src/tests/dashboard_assets.rs
@@ -65,22 +65,62 @@ fn dashboard_markdown_call_sites_use_sanitizing_wrapper() {
 
 #[test]
 fn dashboard_surfaces_workspace_location() {
-    // ORB-00037: the selector renders the selected workspace's path as a
-    // secondary line, and each aggregate task shows its workspace location in
-    // the Details box. Asserted against the embedded asset sources since the
-    // dashboard has no JS test runner (see dashboard_markdown_call_sites above).
+    // ORB-10124: the selector shows only the selected workspace's label — the
+    // secondary filesystem-path line (ORB-00037) was removed as distracting
+    // implementation detail. Each aggregate task still shows its workspace
+    // location in the Details box (a separate, unrelated feature). Asserted
+    // against the embedded asset sources since the dashboard has no JS test
+    // runner (see dashboard_markdown_call_sites above).
     let app = include_str!("../../assets/dashboard/app.js");
     let tasks = include_str!("../../assets/dashboard/tasks.js");
+    let css = include_str!("../../assets/dashboard/dashboard.css");
 
-    // Selector secondary line: a dedicated element updated from the entry `root`.
-    assert!(app.contains("workspace-path"));
-    assert!(app.contains("updateWorkspacePath"));
-    assert!(app.contains("ws.root"));
+    // Selector secondary line must be gone, along with its update helper and style.
+    assert!(
+        !app.contains("workspace-path"),
+        "the selector must no longer render a secondary filesystem-path line"
+    );
+    assert!(
+        !app.contains("updateWorkspacePath"),
+        "updateWorkspacePath must be removed along with the path line it rendered"
+    );
+    assert!(
+        !css.contains(".workspace-path"),
+        "the workspace-path CSS rule must be removed with its markup"
+    );
 
     // Task Details box: a "location" field driven by the tagged workspace_root.
     assert!(tasks.contains("workspace_root"));
     assert!(tasks.contains(r#"addField(rightCol, "location""#));
     assert!(tasks.contains("ws-location"));
+}
+
+#[test]
+fn dashboard_task_actions_route_to_selected_workspace() {
+    // ORB-10124: approve/reject/archive built their request with a raw
+    // `fetch()`, bypassing the `withWorkspace()` helper that every other
+    // dashboard request goes through (fetchJson/requestJson in common.js).
+    // Against a remote registered workspace the mutation silently applied to
+    // the default workspace (or 400'd) instead of the selected one, so the
+    // dashboard never reflected the change. Asserted against the embedded
+    // asset sources since the dashboard has no JS test runner.
+    let tasks = include_str!("../../assets/dashboard/tasks.js");
+    let common = include_str!("../../assets/dashboard/common.js");
+
+    assert!(
+        common.contains("export function withWorkspace("),
+        "withWorkspace must be exported from common.js so other modules can reuse it"
+    );
+    assert!(
+        tasks.contains("withWorkspace } from './common.js'"),
+        "tasks.js must import withWorkspace from common.js"
+    );
+    assert!(
+        tasks.contains(
+            "fetch(withWorkspace(opts.path || `/api/tasks/${encodeURIComponent(task.id)}/${kind}`)"
+        ),
+        "runAction (approve/reject/archive) must route its request through withWorkspace"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Task

[ORB-10124](https://orbit-cli.com/tasks/ORB-10124) — Fix remote dashboard task actions and workspace dropdown path

### Description

## Problem
When the Orbit dashboard is connected to a remote registered workspace, the task detail actions **Approve**, **Reject**, and **Archive** do not take effect. Clicking the buttons leaves the task unchanged.

The workspace selector also renders a second line beneath the selected workspace containing a truncated filesystem path such as `~/workspace/constellation/code...`. Remove that path line from the selector.

## Why It Matters
Remote workspace users cannot perform core task lifecycle actions from the dashboard, and the host filesystem path is distracting implementation detail in the workspace picker.

## Reproduction
1. Open the dashboard against a remote Orbit server with multiple registered workspaces.
2. Select a remote workspace and open a proposed task.
3. Click **Approve**, **Reject**, or **Archive**.
4. Observe that the requested lifecycle transition is not reflected in the task or recent history.
5. Observe the truncated workspace root path beneath the workspace dropdown.

## Constraints / Notes
- Preserve workspace routing on every mutation: the selected registered workspace must be sent to the backend action and used when refreshing task data.
- Keep the selected workspace name visible in the dropdown; remove only the auxiliary filesystem-path text beneath it.
- Cover all three actions, including success/error handling and post-mutation UI refresh.
- The screenshots attached to the originating request show the affected task-detail controls and the unwanted path line.

### Acceptance Criteria

- With a non-default remote workspace selected, approving a proposed task sends the mutation to that workspace and the dashboard refreshes to show the resulting status and history entry.
- With a non-default remote workspace selected, rejecting an eligible task sends the mutation to that workspace and the dashboard refreshes to show the rejected state and history entry.
- With a non-default remote workspace selected, archiving an eligible task sends the mutation to that workspace and removes or updates it according to the dashboard's archived-task behavior.
- Automated frontend or integration coverage verifies that each of the three task-action requests includes the selected workspace identifier and that success and failure responses produce the expected UI state.
- The workspace selector shows the selected workspace label without rendering its filesystem root/path beneath the dropdown.
- Existing default-workspace task actions and workspace switching continue to pass the dashboard's relevant test suite.

## Execution Summary

<details>
<summary>Click to expand</summary>

Root cause: `runAction` in crates/orbit-dashboard/assets/dashboard/tasks.js (handling approve/reject/archive) built its request with a raw `fetch()` instead of routing through common.js's `withWorkspace()` helper that every other dashboard request uses (fetchJson/requestJson/patchJson). Against a non-default remote registered workspace, the mutation therefore never carried `?workspace=<id>`, so it silently applied to the wrong workspace (or 400'd) and the dashboard never reflected the change.

Fix:
- Exported `withWorkspace` from common.js (was module-private).
- tasks.js now imports it and wraps the request URL in `runAction`: `fetch(withWorkspace(opts.path || ...))`. This covers all three actions (approve/reject/archive), which all funnel through `runAction`, and the existing success/error handling, spinner, and post-mutation `refreshDashboard()` call were left untouched since they already worked correctly once given the right URL.
- Removed the workspace-selector's secondary filesystem-path line (`updateWorkspacePath`, `#workspace-path`, `.workspace-select-wrap`) from app.js and dashboard.css per the second part of the task; the per-task Details-box `location` field (workspace_root, unrelated ORB-00037 feature) was left in place.
- Updated crates/orbit-dashboard/src/tests/dashboard_assets.rs: rewrote `dashboard_surfaces_workspace_location` to assert the path line is gone instead of present, and added `dashboard_task_actions_route_to_selected_workspace` asserting withWorkspace is exported, imported, and used in runAction's fetch call.
- Added a CHANGELOG Unreleased bullet under Highlights citing ORB-10124.

Validation: `cargo test -p orbit-dashboard` (145 passed) and `make ci-fast` (fmt-check + all guardrail scripts, including changelog freshness/style) both green. No live browser check was performed — this is a source-asset-only dashboard with no JS test runner in this repo, consistent with the existing test file's approach of asserting against embedded asset source strings.

Not in scope / not touched: `updateTaskStatus` and `updateTaskCrew` in tasks.js already used `patchJson` (which already routes through `withWorkspace` internally), so they were already workspace-correct and needed no change.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10124-6a52b02d`
- Behind base: 0
- Ahead of base: 1