### PR TITLE
Apply no-nested-sandbox setting to existing Orbit workspace

### DIFF
--- a/.orbit/config.toml
+++ b/.orbit/config.toml
@@ -10,7 +10,7 @@ pass = [
 ]
 
 [execution.codex]
-sandbox = "workspace-write"
+sandbox = "danger-full-access"
 
 [task.approval]
 delegate_approval = true


### PR DESCRIPTION
## Task

[ORB-10136](https://orbit-cli.com/tasks/ORB-10136) — Apply no-nested-sandbox setting to existing Orbit workspace

### Description

## Problem
ORB-10131 changed the fresh-init template to danger-full-access, but this existing tracked workspace still sets execution.codex.sandbox = workspace-write in .orbit/config.toml. Because workspace config replaces global config, Codex workflow runs continue to start bubblewrap and fail with RTM_NEWADDR.

## Why It Matters
All Codex-backed Orbit tasks on dk-server-1 remain unable to execute despite the global config and new-init default being corrected.

## Constraints / Notes
- Change only the existing workspace Codex sandbox value; preserve all crew and workflow configuration.
- Use the normal PR-gated Orbit workflow.
- Route implementation through Claude/Opus because Codex is the broken execution path.
- This is the operational follow-up to ORB-10131 and resolves F2026-07-011.

### Acceptance Criteria

- The tracked .orbit/config.toml sets execution.codex.sandbox = danger-full-access.
- From the Orbit repository root, orbit config get execution.codex.sandbox prints danger-full-access after the change is landed.
- No unrelated workspace configuration changes are introduced.
- make ci-fast passes and the PR is green.

## Execution Summary

<details>
<summary>Click to expand</summary>

Changed execution.codex.sandbox from "workspace-write" to "danger-full-access" in the tracked .orbit/config.toml (line 13). This is the only change. Rationale: workspace config replaces global config, so despite ORB-10131 fixing the fresh-init template and global default, this existing tracked workspace still forced Codex runs into nested bubblewrap (RTM_NEWADDR failures). Resolves F2026-07-011.

Verification: git diff shows a single-line change with no unrelated config edits (all crew/workflow/duel/docs blocks untouched). orbit config get execution.codex.sandbox --root <worktree> prints danger-full-access. Note: plain orbit config get from the worktree returns the OLD value because the worktree lives inside the main repo's .orbit/state/, so orbit walks up and resolves the main checkout's config; the acceptance-criterion command (run from the Orbit repo root) will print danger-full-access once this lands to agent-main and the main checkout is updated. make ci-fast passed (EXIT 0).

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10136-6a52b6df`
- Behind base: 0
- Ahead of base: 1