### PR TITLE
Add learning + ADR update routes to orbit HTTP API (orchestrator-curated lifecycle)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Highlights
 
+- **Learning + ADR update routes on the HTTP API**: `PATCH /learnings/:id` (summary/scope/tags/body/evidence/priority) and `PATCH /adrs/:id` (status/tags and mutable metadata) delegate to the CLI tools, preserving supersede-don't-delete and invalid-transition rejection; no create routes added. ([ORB-10143])
 - **Default failed-run triage**: a seeded `task_triage_pipeline` (+ hourly routine, `orbit run triage`) diagnoses tasks blocked by failed runs, re-backlogs environmental failures with a bounded retry budget, and leaves the rest blocked with a diagnosis attached. See ADR-0215/ADR-0216. ([ORB-10129])
 - **Orphaned pending job runs now reconcile to `interrupted`**: workers claim their queued run's pid, the open-time orphan scan and `orbit doctor` cover pending runs, `orbit run cancel <run_id>` terminalizes stuck runs, and orbit-web-upgrade's deferral gate checks worker liveness. ([ORB-10070])
 - **Remote dashboard task actions now reach the selected workspace**: `approve`/`reject`/`archive` used a raw `fetch()` that skipped the workspace-routing helper, so they silently no-op'd against a non-default remote workspace; the workspace selector also no longer renders its filesystem path beneath the dropdown. ([ORB-10124])

--- a/crates/orbit-dashboard/src/api/adrs.rs
+++ b/crates/orbit-dashboard/src/api/adrs.rs
@@ -37,6 +37,35 @@ pub(super) struct SupersedeAdrBody {
     reason: Option<String>,
 }
 
+/// Partial-update payload for `PATCH /adrs/:id`, mirroring the mutable fields
+/// of the `orbit.adr.update` tool. Status transitions follow the ADR
+/// lifecycle rules (e.g. `accepted -> proposed` and direct writes to
+/// `superseded` are rejected — supersede has its own route). List fields
+/// replace wholesale; an empty list clears, absence leaves unchanged.
+#[derive(Deserialize, Default)]
+pub(super) struct AdrPatchBody {
+    #[serde(default)]
+    title: Option<String>,
+    #[serde(default)]
+    owner: Option<String>,
+    #[serde(default)]
+    body: Option<String>,
+    #[serde(default)]
+    status: Option<String>,
+    #[serde(default)]
+    related_features: Option<Vec<String>>,
+    #[serde(default)]
+    related_tasks: Option<Vec<String>>,
+    #[serde(default)]
+    tags: Option<Vec<String>>,
+    #[serde(default)]
+    paths: Option<Vec<String>>,
+    #[serde(default)]
+    supersedes: Option<Vec<String>>,
+    #[serde(default)]
+    legacy_ids: Option<Vec<String>>,
+}
+
 pub(super) async fn list_adrs(Ws(runtime): Ws, Query(query): Query<AdrsQuery>) -> Response {
     let all = match adr_list(&runtime, Map::new()) {
         Ok(adrs) => adrs,
@@ -110,6 +139,52 @@ pub(super) async fn accept_adr_action(Ws(runtime): Ws, Path(id): Path<String>) -
     }
 }
 
+pub(super) async fn update_adr_action(
+    Ws(runtime): Ws,
+    Path(id): Path<String>,
+    body: Option<Json<AdrPatchBody>>,
+) -> Response {
+    let Some(Json(body)) = body else {
+        return bad_request("request body must include at least one updatable field".to_string());
+    };
+    let AdrPatchBody {
+        title,
+        owner,
+        body,
+        status,
+        related_features,
+        related_tasks,
+        tags,
+        paths,
+        supersedes,
+        legacy_ids,
+    } = body;
+
+    let mut input = Map::new();
+    insert_optional_string(&mut input, "title", title);
+    insert_optional_string(&mut input, "owner", owner);
+    insert_optional_string(&mut input, "body", body);
+    insert_optional_string(&mut input, "status", status);
+    insert_optional_list(&mut input, "related_features", related_features);
+    insert_optional_list(&mut input, "related_tasks", related_tasks);
+    insert_optional_list(&mut input, "tags", tags);
+    insert_optional_list(&mut input, "paths", paths);
+    insert_optional_list(&mut input, "supersedes", supersedes);
+    insert_optional_list(&mut input, "legacy_ids", legacy_ids);
+    if input.is_empty() {
+        return bad_request("request body must include at least one updatable field".to_string());
+    }
+    input.insert("id".to_string(), Value::String(id));
+
+    match run_adr_tool(&runtime, "orbit.adr.update", Value::Object(input)) {
+        Ok(mut adr) => match attach_body(&runtime, &mut adr) {
+            Ok(()) => Json(adr).into_response(),
+            Err(e) => map_runtime_error(e),
+        },
+        Err(e) => map_runtime_error(e),
+    }
+}
+
 pub(super) async fn supersede_adr_action(
     Ws(runtime): Ws,
     Path(id): Path<String>,
@@ -152,6 +227,18 @@ pub(super) async fn supersede_adr_action(
             .into_response()
         }
         Err(e) => map_runtime_error(e),
+    }
+}
+
+fn insert_optional_string(input: &mut Map<String, Value>, key: &str, value: Option<String>) {
+    if let Some(value) = value.as_deref().and_then(non_empty_string) {
+        input.insert(key.to_string(), Value::String(value));
+    }
+}
+
+fn insert_optional_list(input: &mut Map<String, Value>, key: &str, value: Option<Vec<String>>) {
+    if let Some(value) = value {
+        input.insert(key.to_string(), json!(value));
     }
 }
 

--- a/crates/orbit-dashboard/src/api/learnings.rs
+++ b/crates/orbit-dashboard/src/api/learnings.rs
@@ -5,7 +5,7 @@ use axum::extract::{Path, Query};
 use axum::response::{IntoResponse, Json, Response};
 use orbit_core::{Learning, LearningSearchParams};
 use serde::Deserialize;
-use serde_json::{Value, json};
+use serde_json::{Map, Value, json};
 
 use super::{bad_request, bounded_limit, map_runtime_error, non_empty_string, server_error};
 use crate::projections::learning_to_json;
@@ -32,6 +32,26 @@ pub(super) struct SupersedeLearningBody {
     by: Option<String>,
     #[serde(default)]
     reason: Option<String>,
+}
+
+/// Partial-update payload for `PATCH /learnings/:id`, mirroring the
+/// `orbit.learning.update` tool's mutable fields. Every field replaces the
+/// corresponding record field wholesale (matching CLI semantics); `scope`
+/// carries the learning's `paths`/`tags`. Lifecycle transitions
+/// (supersede) stay on the dedicated `/learnings/:id/supersede` route so a
+/// superseded record is never mutated or deleted through this path.
+#[derive(Deserialize, Default)]
+pub(super) struct LearningPatchBody {
+    #[serde(default)]
+    summary: Option<String>,
+    #[serde(default)]
+    scope: Option<Value>,
+    #[serde(default)]
+    body: Option<String>,
+    #[serde(default)]
+    evidence: Option<Value>,
+    #[serde(default)]
+    priority: Option<i64>,
 }
 
 pub(super) async fn list_learnings(
@@ -90,6 +110,59 @@ pub(super) async fn list_learnings(
 pub(super) async fn get_learning(Ws(runtime): Ws, Path(id): Path<String>) -> Response {
     match runtime.get_learning(&id) {
         Ok(learning) => Json(learning_to_json(&learning)).into_response(),
+        Err(e) => map_runtime_error(e),
+    }
+}
+
+pub(super) async fn update_learning_action(
+    Ws(runtime): Ws,
+    Path(id): Path<String>,
+    body: Option<Json<LearningPatchBody>>,
+) -> Response {
+    let Some(Json(body)) = body else {
+        return bad_request(
+            "request body must include one of `summary`, `scope`, `body`, `evidence`, `priority`"
+                .to_string(),
+        );
+    };
+    let LearningPatchBody {
+        summary,
+        scope,
+        body,
+        evidence,
+        priority,
+    } = body;
+    let summary = summary.as_deref().and_then(non_empty_string);
+
+    let mut input = Map::new();
+    if let Some(summary) = summary {
+        input.insert("summary".to_string(), Value::String(summary));
+    }
+    if let Some(scope) = scope {
+        input.insert("scope".to_string(), scope);
+    }
+    if let Some(body) = body {
+        input.insert("body".to_string(), Value::String(body));
+    }
+    if let Some(evidence) = evidence {
+        input.insert("evidence".to_string(), evidence);
+    }
+    if let Some(priority) = priority {
+        input.insert("priority".to_string(), Value::from(priority));
+    }
+    if input.is_empty() {
+        return bad_request(
+            "request body must include one of `summary`, `scope`, `body`, `evidence`, `priority`"
+                .to_string(),
+        );
+    }
+    input.insert("id".to_string(), Value::String(id));
+
+    // Delegate to the `orbit.learning.update` tool so the HTTP route inherits
+    // the CLI lifecycle rules verbatim — notably the rejection of updates on a
+    // superseded record (supersede, don't mutate/delete).
+    match runtime.run_tool("orbit.learning.update", Value::Object(input)) {
+        Ok(learning) => Json(learning).into_response(),
         Err(e) => map_runtime_error(e),
     }
 }

--- a/crates/orbit-dashboard/src/api/mod.rs
+++ b/crates/orbit-dashboard/src/api/mod.rs
@@ -310,13 +310,19 @@ pub(super) fn router() -> Router<crate::state::DashboardState> {
         .route("/tasks/:id/reject", post(tasks::reject_task_action))
         .route("/tasks/:id/archive", post(tasks::archive_task_action))
         .route("/learnings", get(learnings::list_learnings))
-        .route("/learnings/:id", get(learnings::get_learning))
+        .route(
+            "/learnings/:id",
+            get(learnings::get_learning).patch(learnings::update_learning_action),
+        )
         .route(
             "/learnings/:id/supersede",
             post(learnings::supersede_learning_action),
         )
         .route("/adrs", get(adrs::list_adrs))
-        .route("/adrs/:id", get(adrs::get_adr))
+        .route(
+            "/adrs/:id",
+            get(adrs::get_adr).patch(adrs::update_adr_action),
+        )
         .route("/adrs/:id/accept", post(adrs::accept_adr_action))
         .route("/adrs/:id/supersede", post(adrs::supersede_adr_action))
         .route("/frictions", get(frictions::list_frictions))

--- a/crates/orbit-dashboard/src/api/tests/adrs.rs
+++ b/crates/orbit-dashboard/src/api/tests/adrs.rs
@@ -239,3 +239,150 @@ async fn supersede_moves_source_to_superseded_and_populates_edge() {
         .join(adr_id(&old));
     assert!(!accepted_dir.exists(), "{}", accepted_dir.display());
 }
+
+async fn request_update(
+    runtime: OrbitRuntime,
+    id: &str,
+    origin: Option<&str>,
+    body: Option<Value>,
+) -> axum::response::Response {
+    let mut builder = Request::builder()
+        .method(Method::PATCH)
+        .uri(format!("/adrs/{id}"));
+    if let Some(origin) = origin {
+        builder = builder.header(header::ORIGIN, origin);
+    }
+    let request = if let Some(body) = body {
+        builder
+            .header(header::CONTENT_TYPE, "application/json")
+            .body(Body::from(body.to_string()))
+            .expect("request")
+    } else {
+        builder.body(Body::empty()).expect("request")
+    };
+
+    router()
+        .with_state(crate::state::DashboardState::single(Arc::new(runtime)))
+        .oneshot(request)
+        .await
+        .expect("response")
+}
+
+#[tokio::test]
+async fn update_requires_localhost_origin() {
+    let runtime = OrbitRuntime::in_memory().expect("build runtime");
+    let adr = seed_adr(&runtime, "Cross-origin ADR", vec!["ORB-00063"]);
+
+    let response = request_update(
+        runtime.clone(),
+        adr_id(&adr),
+        None,
+        Some(json!({ "tags": ["blocked"] })),
+    )
+    .await;
+
+    assert_eq!(response.status(), StatusCode::FORBIDDEN);
+}
+
+#[tokio::test]
+async fn update_rejects_empty_body() {
+    let runtime = OrbitRuntime::in_memory().expect("build runtime");
+    let adr = seed_adr(&runtime, "Empty patch ADR", vec!["ORB-00063"]);
+
+    let response = request_update(
+        runtime,
+        adr_id(&adr),
+        Some("http://localhost:7878"),
+        Some(json!({})),
+    )
+    .await;
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn update_sets_status_and_tags() {
+    let runtime = OrbitRuntime::in_memory().expect("build runtime");
+    let adr = seed_adr(&runtime, "Curated ADR", vec!["ORB-00063"]);
+
+    let response = request_update(
+        runtime.clone(),
+        adr_id(&adr),
+        Some("http://localhost:7878"),
+        Some(json!({ "status": "accepted", "tags": ["curated", "api"] })),
+    )
+    .await;
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let payload = body_json(response).await;
+    assert_eq!(payload["status"], "accepted");
+    assert_eq!(payload["tags"][0], "curated");
+    assert_eq!(payload["tags"][1], "api");
+    // Body is re-attached from disk on the update response.
+    assert!(payload["body"].as_str().is_some());
+
+    let stored = runtime
+        .execute_tool_command(
+            "orbit.adr.show",
+            json!({ "id": adr_id(&adr) }),
+            None,
+            Some(TEST_CODEX_MODEL.to_string()),
+        )
+        .expect("show adr");
+    assert_eq!(stored["status"], "accepted");
+}
+
+#[tokio::test]
+async fn update_rejects_invalid_status_transition() {
+    let runtime = OrbitRuntime::in_memory().expect("build runtime");
+    let adr = seed_adr(&runtime, "Accepted ADR", vec!["ORB-00063"]);
+    accept_adr(&runtime, adr_id(&adr));
+
+    // accepted -> proposed is a rejected lifecycle transition.
+    let response = request_update(
+        runtime.clone(),
+        adr_id(&adr),
+        Some("http://localhost:7878"),
+        Some(json!({ "status": "proposed" })),
+    )
+    .await;
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    let payload = body_json(response).await;
+    assert!(
+        payload["error"]
+            .as_str()
+            .expect("error")
+            .contains("Invalid ADR status transition"),
+        "{}",
+        payload["error"]
+    );
+
+    let stored = runtime
+        .execute_tool_command(
+            "orbit.adr.show",
+            json!({ "id": adr_id(&adr) }),
+            None,
+            Some(TEST_CODEX_MODEL.to_string()),
+        )
+        .expect("show adr");
+    assert_eq!(stored["status"], "accepted");
+}
+
+#[tokio::test]
+async fn update_rejects_direct_write_to_superseded() {
+    let runtime = OrbitRuntime::in_memory().expect("build runtime");
+    let adr = seed_adr(&runtime, "Guarded ADR", vec!["ORB-00063"]);
+    accept_adr(&runtime, adr_id(&adr));
+
+    // Direct writes to `superseded` must go through the supersede route.
+    let response = request_update(
+        runtime,
+        adr_id(&adr),
+        Some("http://localhost:7878"),
+        Some(json!({ "status": "superseded" })),
+    )
+    .await;
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+}

--- a/crates/orbit-dashboard/src/api/tests/learnings.rs
+++ b/crates/orbit-dashboard/src/api/tests/learnings.rs
@@ -180,3 +180,119 @@ async fn list_learnings_returns_stats_and_rows() {
     assert!(payload["stats"]["last_indexed"].as_str().is_some());
     assert_eq!(payload["items"].as_array().expect("items").len(), 2);
 }
+
+async fn request_update(
+    runtime: OrbitRuntime,
+    id: &str,
+    origin: Option<&str>,
+    body: Option<Value>,
+) -> axum::response::Response {
+    let mut builder = Request::builder()
+        .method(Method::PATCH)
+        .uri(format!("/learnings/{id}"));
+    if let Some(origin) = origin {
+        builder = builder.header(header::ORIGIN, origin);
+    }
+    let request = if let Some(body) = body {
+        builder
+            .header(header::CONTENT_TYPE, "application/json")
+            .body(Body::from(body.to_string()))
+            .expect("request")
+    } else {
+        builder.body(Body::empty()).expect("request")
+    };
+
+    router()
+        .with_state(crate::state::DashboardState::single(Arc::new(runtime)))
+        .oneshot(request)
+        .await
+        .expect("response")
+}
+
+#[tokio::test]
+async fn update_requires_localhost_origin() {
+    let runtime = OrbitRuntime::in_memory().expect("build runtime");
+    let learning = seed_learning(&runtime, "Cross-origin learning");
+
+    let response = request_update(
+        runtime.clone(),
+        &learning.id,
+        None,
+        Some(json!({ "summary": "Updated" })),
+    )
+    .await;
+
+    assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    let stored = runtime.get_learning(&learning.id).expect("read learning");
+    assert_eq!(stored.summary, "Cross-origin learning");
+}
+
+#[tokio::test]
+async fn update_rejects_empty_body() {
+    let runtime = OrbitRuntime::in_memory().expect("build runtime");
+    let learning = seed_learning(&runtime, "Empty patch learning");
+
+    let response = request_update(
+        runtime,
+        &learning.id,
+        Some("http://localhost:7878"),
+        Some(json!({})),
+    )
+    .await;
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn update_replaces_summary_and_scope_tags() {
+    let runtime = OrbitRuntime::in_memory().expect("build runtime");
+    let learning = seed_learning(&runtime, "Original learning");
+
+    let response = request_update(
+        runtime.clone(),
+        &learning.id,
+        Some("http://localhost:7878"),
+        Some(json!({
+            "summary": "Curated learning",
+            "scope": { "paths": ["crates/orbit-dashboard/**"], "tags": ["api", "http"] },
+        })),
+    )
+    .await;
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let payload = body_json(response).await;
+    assert_eq!(payload["summary"], "Curated learning");
+
+    let stored = runtime.get_learning(&learning.id).expect("read learning");
+    assert_eq!(stored.summary, "Curated learning");
+    assert_eq!(
+        stored.scope.tags,
+        vec!["api".to_string(), "http".to_string()]
+    );
+    assert_eq!(stored.status, LearningStatus::Active);
+}
+
+#[tokio::test]
+async fn update_rejects_superseded_record() {
+    let runtime = OrbitRuntime::in_memory().expect("build runtime");
+    let old = seed_learning(&runtime, "Old learning");
+    let new = seed_learning(&runtime, "New learning");
+    runtime
+        .supersede_learning(&old.id, &new.id)
+        .expect("supersede fixture");
+
+    // A superseded learning must never be mutated in place — the lifecycle is
+    // supersede-don't-delete, and updates to it are rejected.
+    let response = request_update(
+        runtime.clone(),
+        &old.id,
+        Some("http://localhost:7878"),
+        Some(json!({ "summary": "Should not apply" })),
+    )
+    .await;
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    let stored = runtime.get_learning(&old.id).expect("read superseded");
+    assert_eq!(stored.status, LearningStatus::Superseded);
+    assert_eq!(stored.summary, "Old learning");
+}


### PR DESCRIPTION
## Task

[ORB-10143](https://orbit-cli.com/tasks/ORB-10143) — Add learning + ADR update routes to orbit HTTP API (orchestrator-curated lifecycle)

### Description

Policy (Daniel, 2026-07-11): knowledge-artifact lifecycle follows role — executing agents *create* frictions and learnings (their experience); the orchestrator *updates and resolves* them (close frictions, supersede/update learnings) and authors/updates ADRs. Friction update already has a working remote path (bridge `orbit_friction_update`); learning update and ADR update do not — orbit's HTTP API lacks the routes, which is why bridge's `orbit_learning_update` and `orbit_adr_update` ship as raising stubs (ORB-10128).

Add HTTP update routes for learnings (status/supersede lifecycle, tags — mirroring the CLI's learning lifecycle semantics; supersede-don't-delete preserved) and ADRs (status transitions, tags), workspace-scoped. Create routes for frictions/learnings remain intentionally absent — creation stays executor-side. Companion: ORB-10142 unstubs the bridge passthroughs (ADR create per ORB-10141, plus these update routes).

### Acceptance Criteria

- HTTP route updates a learning's lifecycle (supersede/status) and tags, matching CLI semantics; superseded entries are preserved, never deleted
- HTTP route updates an ADR's status and tags
- No friction or learning create routes are added
- API tests cover both update routes including invalid-transition rejection

## Execution Summary

<details>
<summary>Click to expand</summary>

Added workspace-scoped HTTP update routes for learnings and ADRs to orbit-dashboard, closing the gap that forced bridge's orbit_learning_update / orbit_adr_update to ship as raising stubs (ORB-10128). No create routes added — creation stays executor-side.

Changes:
- crates/orbit-dashboard/src/api/learnings.rs: new LearningPatchBody DTO + update_learning_action handler. PATCH /learnings/:id forwards summary/scope(paths+tags)/body/evidence/priority to the orbit.learning.update tool via runtime.run_tool, so the route inherits CLI lifecycle semantics verbatim — notably rejection of updates on a superseded record (supersede-don't-delete; superseded entries are never mutated or deleted here). Lifecycle transitions stay on the existing /learnings/:id/supersede route. Empty body -> 400.
- crates/orbit-dashboard/src/api/adrs.rs: new AdrPatchBody DTO + update_adr_action handler + insert_optional_string/insert_optional_list helpers. PATCH /adrs/:id forwards status + tags + mutable metadata (title/owner/body/related_features/related_tasks/paths/supersedes/legacy_ids) to orbit.adr.update via run_adr_tool, re-attaches body from disk, and enforces ADR lifecycle rules (accepted->proposed and direct writes to superseded are rejected as 400 AdrInvalidTransition; supersede has its own route). Empty body -> 400.
- crates/orbit-dashboard/src/api/mod.rs: chained .patch(update_learning_action) onto GET /learnings/:id and .patch(update_adr_action) onto GET /adrs/:id (guarded by existing require_localhost_origin middleware).
- Tests (sibling api/tests/learnings.rs + api/tests/adrs.rs): both update routes covered — happy-path status/tags/summary/scope updates, empty-body 400, cross-origin 403, and invalid-transition rejection (ADR accepted->proposed and ->superseded both 400; learning update on a superseded record 400 with the record left unchanged). 19 dashboard API tests pass.
- CHANGELOG.md: terse Unreleased Highlights bullet.

Design note: routes delegate through the existing tool layer (run_tool / run_adr_tool) rather than duplicating store/param-parsing logic, matching the friction update route pattern and giving exact CLI parity for free. Companion ORB-10142 unstubs the bridge passthroughs.

Validation: cargo test -p orbit-dashboard (learnings+adrs api tests) all green; cargo clippy -p orbit-dashboard --all-targets clean; cargo fmt --all --check clean. make ci-fast's fmt-check + guardrails pass except test-installer-security, which aborts because 'node' is not on PATH in this sandbox (unrelated to this change, no installer files touched) — the CI merge gate runs it unrestricted.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10143-6a52c992`
- Behind base: 0
- Ahead of base: 1