### PR TITLE
Add ADR create route to orbit HTTP API (orchestrator-authored ADRs)

### DIFF
--- a/.orbit/learnings/L-0075/learning.yaml
+++ b/.orbit/learnings/L-0075/learning.yaml
@@ -1,0 +1,23 @@
+schema_version: 1
+id: L-0075
+status: active
+scope:
+  paths:
+  - crates/orbit-store/src/file/adr_store/**
+  - crates/orbit-core/src/runtime/orbit_tool_host/adr_tools.rs
+  - crates/orbit-dashboard/src/api/adrs.rs
+  tags:
+  - adr
+  - validation
+summary: orbit.adr.add does NOT enforce the Context/Decision/Consequences+Cost body template its schema advertises
+body: |-
+  The `orbit.adr.add` tool schema (crates/orbit-tools/src/builtin/orbit/adr/add.rs) documents the `body` param as: "Must include Context / Decision / Consequences sections per the ADR template; at least one consequences bullet must be a labeled `Cost:` line." That constraint is **not enforced anywhere in code**. The create path is `adr_tools::add` -> `AdrRecords::add` -> `AdrFileStore::add_adr`, and the only validation there (`validate_bundle` in crates/orbit-store/src/file/adr_store/bundle/mod.rs) checks solely the ADR id via `validate_adr_id`. `add_adr` additionally rejects only empty title/owner. A body of arbitrary non-empty text (e.g. "no template shape here") creates a Proposed ADR successfully.
+
+  **Why it matters:** when adding tests or callers for ADR creation, do not assume a malformed/template-violating body yields an InvalidInput/400 — it won't. Only genuinely empty title/body (guarded at the HTTP layer) or an id/allocation failure produces an error. The template is convention enforced by the authoring skill/prompt, not by the store.
+evidence:
+- kind: task
+  reference: ORB-10141
+created_at: 2026-07-11T23:06:40.993267467Z
+updated_at: 2026-07-11T23:06:40.993267467Z
+created_by: claude
+priority: 2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Highlights
 
+- **ADR create over HTTP**: `POST /api/adrs` records a Proposed ADR (mirroring `orbit.adr.add`), so remote orchestrators can author decisions without an on-box run; malformed payloads get a structured 400. Friction/learning create routes stay absent. ([ORB-10141])
 - **Default failed-run triage**: a seeded `task_triage_pipeline` (+ hourly routine, `orbit run triage`) diagnoses tasks blocked by failed runs, re-backlogs environmental failures with a bounded retry budget, and leaves the rest blocked with a diagnosis attached. See ADR-0215/ADR-0216. ([ORB-10129])
 - **Orphaned pending job runs now reconcile to `interrupted`**: workers claim their queued run's pid, the open-time orphan scan and `orbit doctor` cover pending runs, `orbit run cancel <run_id>` terminalizes stuck runs, and orbit-web-upgrade's deferral gate checks worker liveness. ([ORB-10070])
 - **Remote dashboard task actions now reach the selected workspace**: `approve`/`reject`/`archive` used a raw `fetch()` that skipped the workspace-routing helper, so they silently no-op'd against a non-default remote workspace; the workspace selector also no longer renders its filesystem path beneath the dropdown. ([ORB-10124])

--- a/crates/orbit-dashboard/src/api/adrs.rs
+++ b/crates/orbit-dashboard/src/api/adrs.rs
@@ -4,6 +4,7 @@ use std::fs;
 use std::io::ErrorKind;
 
 use crate::state::Ws;
+use axum::extract::rejection::JsonRejection;
 use axum::extract::{Path, Query};
 use axum::response::{IntoResponse, Json, Response};
 use orbit_core::{OrbitError, OrbitRuntime};
@@ -27,6 +28,28 @@ pub(super) struct AdrsQuery {
     limit: Option<usize>,
     #[serde(default)]
     offset: Option<usize>,
+}
+
+/// Create body for `POST /adrs`. Mirrors the `orbit.adr.add` tool schema:
+/// `title` and `body` are required (validated in the handler for a structured
+/// 400 rather than serde's default rejection); the remaining fields default to
+/// empty. Status is not a field — the tool always creates a Proposed ADR.
+#[derive(Deserialize, Default)]
+pub(super) struct CreateAdrBody {
+    #[serde(default)]
+    title: Option<String>,
+    #[serde(default)]
+    body: Option<String>,
+    #[serde(default)]
+    owner: Option<String>,
+    #[serde(default)]
+    related_features: Vec<String>,
+    #[serde(default)]
+    related_tasks: Vec<String>,
+    #[serde(default)]
+    tags: Vec<String>,
+    #[serde(default)]
+    paths: Vec<String>,
 }
 
 #[derive(Deserialize, Default)]
@@ -88,6 +111,53 @@ pub(super) async fn list_adrs(Ws(runtime): Ws, Query(query): Query<AdrsQuery>) -
 pub(super) async fn get_adr(Ws(runtime): Ws, Path(id): Path<String>) -> Response {
     match adr_show(&runtime, &id) {
         Ok(adr) => Json(adr).into_response(),
+        Err(e) => map_runtime_error(e),
+    }
+}
+
+/// `POST /adrs` — record a new Proposed ADR, mirroring `orbit adr` creation
+/// semantics (`orbit.adr.add`). The freshly created ADR is returned with its
+/// body attached so callers see the same shape `GET /adrs/:id` produces, and it
+/// is immediately visible via the existing read surfaces. Malformed payloads
+/// (unparseable JSON, or a missing/empty `title` or `body`) are rejected with a
+/// structured 400; deeper validation errors from the tool surface through
+/// [`map_runtime_error`].
+pub(super) async fn create_adr_action(
+    Ws(runtime): Ws,
+    body: Result<Json<CreateAdrBody>, JsonRejection>,
+) -> Response {
+    let Json(body) = match body {
+        Ok(body) => body,
+        Err(rejection) => {
+            return bad_request(format!("malformed ADR create payload: {rejection}"));
+        }
+    };
+    let Some(title) = body.title.as_deref().and_then(non_empty_string) else {
+        return bad_request("request body must include non-empty `title`".to_string());
+    };
+    let Some(adr_body) = body.body.as_deref().and_then(non_empty_string) else {
+        return bad_request("request body must include non-empty `body`".to_string());
+    };
+
+    let mut input = json!({
+        "title": title,
+        "body": adr_body,
+        "related_features": body.related_features,
+        "related_tasks": body.related_tasks,
+        "tags": body.tags,
+        "paths": body.paths,
+    });
+    if let Some(owner) = body.owner.as_deref().and_then(non_empty_string)
+        && let Some(object) = input.as_object_mut()
+    {
+        object.insert("owner".to_string(), Value::String(owner));
+    }
+
+    match run_adr_tool(&runtime, "orbit.adr.add", input) {
+        Ok(mut adr) => match attach_body(&runtime, &mut adr) {
+            Ok(()) => Json(adr).into_response(),
+            Err(e) => map_runtime_error(e),
+        },
         Err(e) => map_runtime_error(e),
     }
 }

--- a/crates/orbit-dashboard/src/api/mod.rs
+++ b/crates/orbit-dashboard/src/api/mod.rs
@@ -315,7 +315,7 @@ pub(super) fn router() -> Router<crate::state::DashboardState> {
             "/learnings/:id/supersede",
             post(learnings::supersede_learning_action),
         )
-        .route("/adrs", get(adrs::list_adrs))
+        .route("/adrs", get(adrs::list_adrs).post(adrs::create_adr_action))
         .route("/adrs/:id", get(adrs::get_adr))
         .route("/adrs/:id/accept", post(adrs::accept_adr_action))
         .route("/adrs/:id/supersede", post(adrs::supersede_adr_action))

--- a/crates/orbit-dashboard/src/api/tests/adrs.rs
+++ b/crates/orbit-dashboard/src/api/tests/adrs.rs
@@ -50,6 +50,31 @@ fn adr_id(adr: &Value) -> &str {
     adr["id"].as_str().expect("ADR id")
 }
 
+async fn request_create(
+    runtime: OrbitRuntime,
+    origin: Option<&str>,
+    body: Option<Value>,
+) -> axum::response::Response {
+    let mut builder = Request::builder().method(Method::POST).uri("/adrs");
+    if let Some(origin) = origin {
+        builder = builder.header(header::ORIGIN, origin);
+    }
+    let request = if let Some(body) = body {
+        builder
+            .header(header::CONTENT_TYPE, "application/json")
+            .body(Body::from(body.to_string()))
+            .expect("request")
+    } else {
+        builder.body(Body::empty()).expect("request")
+    };
+
+    router()
+        .with_state(crate::state::DashboardState::single(Arc::new(runtime)))
+        .oneshot(request)
+        .await
+        .expect("response")
+}
+
 async fn request_accept(
     runtime: OrbitRuntime,
     id: &str,
@@ -95,6 +120,113 @@ async fn request_supersede(
         .oneshot(request)
         .await
         .expect("response")
+}
+
+#[tokio::test]
+async fn create_persists_proposed_adr_and_reads_back() {
+    let runtime = OrbitRuntime::in_memory().expect("build runtime");
+
+    let response = request_create(
+        runtime.clone(),
+        Some("http://localhost:7878"),
+        Some(json!({
+            "title": "Created over HTTP",
+            "body": ADR_BODY,
+            "owner": TEST_CODEX_MODEL,
+            "related_features": ["dashboard"],
+            "related_tasks": ["ORB-00063"],
+        })),
+    )
+    .await;
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let created = body_json(response).await;
+    let id = created["id"].as_str().expect("created ADR id").to_string();
+    assert_eq!(created["status"], "proposed");
+    assert_eq!(created["title"], "Created over HTTP");
+    assert!(
+        created["body"]
+            .as_str()
+            .is_some_and(|b| b.contains("Fixture decision")),
+        "response carries the ADR body"
+    );
+
+    // On-disk shape matches the CLI/tool: proposed/<ID>/{adr.yaml,body.md}.
+    let adr_dir = runtime.data_root().join("adrs").join("proposed").join(&id);
+    assert!(adr_dir.join("adr.yaml").is_file(), "{}", adr_dir.display());
+    assert!(adr_dir.join("body.md").is_file(), "{}", adr_dir.display());
+
+    // Immediately visible via the existing read surface.
+    let stored = runtime
+        .execute_tool_command(
+            "orbit.adr.show",
+            json!({ "id": id }),
+            None,
+            Some(TEST_CODEX_MODEL.to_string()),
+        )
+        .expect("show created");
+    assert_eq!(stored["id"], id);
+    assert_eq!(stored["status"], "proposed");
+    assert_eq!(stored["title"], "Created over HTTP");
+}
+
+#[tokio::test]
+async fn create_requires_localhost_origin() {
+    let runtime = OrbitRuntime::in_memory().expect("build runtime");
+
+    let response = request_create(
+        runtime.clone(),
+        None,
+        Some(json!({ "title": "No origin", "body": ADR_BODY })),
+    )
+    .await;
+
+    assert_eq!(response.status(), StatusCode::FORBIDDEN);
+}
+
+#[tokio::test]
+async fn create_rejects_missing_title() {
+    let runtime = OrbitRuntime::in_memory().expect("build runtime");
+
+    let response = request_create(
+        runtime,
+        Some("http://localhost:7878"),
+        Some(json!({ "body": ADR_BODY })),
+    )
+    .await;
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    let payload = body_json(response).await;
+    let error = payload["error"].as_str().expect("error");
+    assert!(error.contains("title"), "{error}");
+}
+
+#[tokio::test]
+async fn create_rejects_malformed_json() {
+    let runtime = OrbitRuntime::in_memory().expect("build runtime");
+
+    let response = router()
+        .with_state(crate::state::DashboardState::single(Arc::new(runtime)))
+        .oneshot(
+            Request::builder()
+                .method(Method::POST)
+                .uri("/adrs")
+                .header(header::ORIGIN, "http://localhost:7878")
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from("{not valid json"))
+                .expect("request"),
+        )
+        .await
+        .expect("response");
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    let payload = body_json(response).await;
+    assert!(
+        payload["error"]
+            .as_str()
+            .is_some_and(|e| e.contains("malformed")),
+        "structured error names the malformed payload"
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Task

[ORB-10141](https://orbit-cli.com/tasks/ORB-10141) — Add ADR create route to orbit HTTP API (orchestrator-authored ADRs)

### Description

Policy (Daniel, 2026-07-11): the authorship boundary on knowledge artifacts follows role — orchestrators author *decisions and work* (tasks, ADRs); executing agents author *experience* (frictions, learnings); orchestrators read everything. Tasks already have full create support over HTTP, ADRs do not: orbit's HTTP API has no ADR create route (per ORB-10128, which is why bridge's `orbit_adr_add` ships as a raising stub).

Add an ADR create route to orbit's HTTP API (POST, mirroring the CLI's `orbit adr` creation semantics: title/body/status proposed, workspace-scoped), so remote orchestrators can record architectural decisions without an on-box run. Companion task unstubs the bridge passthrough. Friction/learning create routes remain intentionally absent — this is ADR only.

### Acceptance Criteria

- POST route creates an ADR in the workspace's .orbit/adrs with the same on-disk shape the CLI produces
- Created ADR is immediately visible via existing ADR read surfaces (orbit_adr_show / orbit_search kind adr)
- Route rejects malformed payloads with a structured error; no friction or learning create routes are added
- API tests cover create + read-back round trip

## Execution Summary

<details>
<summary>Click to expand</summary>

Added `POST /adrs` to orbit's dashboard HTTP API (mounted at `/api/adrs`), mirroring `orbit.adr.add` / CLI ADR creation semantics: title+body required, status forced to Proposed, workspace-scoped via the existing `?workspace=<id>` selector.

Implementation (crates/orbit-dashboard/src/api/):
- adrs.rs: new `CreateAdrBody` deserialize struct (title, body, owner, related_features, related_tasks, tags, paths) and `create_adr_action` handler. It validates title/body are non-empty (structured 400), routes through the existing `run_adr_tool("orbit.adr.add", ...)` helper (same audit/model-identity path as accept/supersede), attaches the on-disk body, and returns the created record. Malformed JSON is caught via `Result<Json<_>, JsonRejection>` → structured 400.
- mod.rs: chained `.post(adrs::create_adr_action)` onto the existing `.route("/adrs", get(...))`. POST inherits the localhost-origin CSRF middleware automatically.

Acceptance criteria met: creates ADR under .orbit/adrs/proposed/<ID>/{adr.yaml,body.md} (same shape as CLI/tool); immediately visible via orbit.adr.show; malformed payloads rejected with structured error; no friction/learning create routes added.

Tests (api/tests/adrs.rs, 4 new, all green): create+read-back round trip (asserts proposed status, on-disk files, orbit.adr.show visibility), localhost-origin requirement, missing-title 400, malformed-JSON 400. Full api::tests::adrs suite = 9 passed.

Validation: `cargo test -p orbit-dashboard` (adrs module) green; `cargo clippy -p orbit-dashboard` clean; `cargo fmt --all --check` clean. `make ci-fast` fmt/changelog/guardrail checks pass; its `test-installer-security.sh` step could not run in this sandbox (requires `node`, not on PATH) — unrelated to this change, deferred to CI. CHANGELOG Unreleased entry added.

Note: the `orbit.adr.add` schema documents a Context/Decision/Consequences+Cost body template, but that shape is NOT enforced in code (validate_bundle only checks the ADR id) — so no template-validation test was added; body only needs to be non-empty.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10141-6a52c992`
- Behind base: 0
- Ahead of base: 1