### PR TITLE
Complete Codex plugin documentation parity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Highlights
 
+- **Codex plugin documentation parity**: Website install/MCP guides now cover Codex plugin installation, upgrades, fresh-task discovery, and read-only MCP smoke checks alongside Claude; the npm proxy README clarifies how both supported plugins consume the binary without manual asset copying. ([ORB-10117])
 - **Routine scheduler health over HTTP**: `GET /api/routines` on the dashboard exposes each routine's last fire (timestamp, ok/error outcome, duration) and next-due slot, so a stopped `ship-sweep`/`qa-sweep` is visible remotely as a stale `last_fire` without box ssh. ([ORB-10138])
 - **ADR create over HTTP**: `POST /api/adrs` records a Proposed ADR (mirroring `orbit.adr.add`), so remote orchestrators can author decisions without an on-box run; malformed payloads get a structured 400. Friction/learning create routes stay absent. ([ORB-10141])
 - **Learning + ADR update routes on the HTTP API**: `PATCH /learnings/:id` (summary/scope/tags/body/evidence/priority) and `PATCH /adrs/:id` (status/tags and mutable metadata) delegate to the CLI tools, preserving supersede-don't-delete and invalid-transition rejection; no create routes added. ([ORB-10143])

--- a/plugin/npm/README.md
+++ b/plugin/npm/README.md
@@ -1,11 +1,19 @@
 # @orbit-tools/cli
 
-npm proxy for the [Orbit](https://github.com/danieljhkim/orbit) CLI.
+npm binary proxy for the [Orbit](https://github.com/danieljhkim/orbit) CLI and
+the supported Orbit plugins for Claude Code and Codex.
 
 On install, downloads the matching prebuilt `orbit` binary from
 [GitHub Releases](https://github.com/danieljhkim/orbit/releases), authenticates
 the signed `orbit-checksums.txt` with the package-pinned release trust set,
 verifies the archive SHA-256, and exposes it as the `orbit` command.
+
+The Claude Code and Codex plugin manifests both launch this package as
+`npx -y @orbit-tools/cli@latest mcp serve`. Their plugin managers install the
+appropriate manifests, shared skills, and client-specific integration assets;
+users do not need to copy files from this package or the Orbit repository.
+Installing `@orbit-tools/cli` by itself provides the native CLI proxy, not the
+agent plugin assets.
 
 ## Usage
 
@@ -14,7 +22,7 @@ verifies the archive SHA-256, and exposes it as the `orbit` command.
 npm install -g @orbit-tools/cli
 orbit --version
 
-# One-shot via npx (used by the orbit Claude plugin)
+# One-shot via npx (used by the Orbit Claude Code and Codex plugins)
 npx -y @orbit-tools/cli mcp serve
 ```
 
@@ -41,3 +49,5 @@ Windows is not currently published. Use WSL or build from source.
 ## License
 
 MIT.
+
+<!-- ORB-10117 -->

--- a/website/src/content/docs/getting-started/install.md
+++ b/website/src/content/docs/getting-started/install.md
@@ -36,7 +36,41 @@ Claude Code plugin (skips the install script, downloads the binary on first MCP 
 /plugin install orbit
 ```
 
-The plugin registers Orbit's MCP server, skills, and orchestration subagents in Claude Code, and pulls the matching native `orbit` binary through the [`@orbit-tools/cli`](https://www.npmjs.com/package/@orbit-tools/cli) npm proxy on first invocation. Requires Node 18+ on `PATH`. To get the `orbit` CLI on your shell as well: `npm install -g @orbit-tools/cli`.
+Codex plugin (also skips the install script):
+
+```bash
+codex plugin marketplace add danieljhkim/orbit --ref main
+codex plugin add orbit@orbit
+```
+
+Both plugins register Orbit's MCP server and shared skills automatically. The
+Claude package also includes its Claude-specific hooks and subagents. On the
+first MCP call, either package pulls the matching native `orbit` binary through
+the [`@orbit-tools/cli`](https://www.npmjs.com/package/@orbit-tools/cli) npm
+proxy. Node 18+ must be on `PATH`. To get the `orbit` CLI on your shell as well,
+run `npm install -g @orbit-tools/cli`.
+
+Refresh an existing plugin installation after an Orbit release:
+
+```text
+# Claude Code
+/plugin update orbit
+
+# Codex CLI
+codex plugin marketplace upgrade orbit
+codex plugin add orbit@orbit
+```
+
+Start a fresh agent task from your repository and make a read-only MCP call to
+confirm the installed package is active:
+
+```bash
+# Claude Code
+claude -p 'Use the read-only orbit.task.list MCP tool to list up to three tasks, then report how many were returned.'
+
+# Codex CLI
+codex -C <repo> 'Use the read-only orbit.task.list MCP tool to list up to three tasks, then report how many were returned.'
+```
 
 From source (requires Rust toolchain):
 
@@ -101,3 +135,5 @@ For a complete re-index — needed for full `trace` coverage, since incremental 
 ```bash
 orbit graph sync --full
 ```
+
+<!-- ORB-10117 -->

--- a/website/src/content/docs/how-to/mcp-integration.md
+++ b/website/src/content/docs/how-to/mcp-integration.md
@@ -5,16 +5,56 @@ sidebar:
   order: 5
 ---
 
-## Claude Code (plugin path)
+## Agent plugins
 
-For Claude Code, the simplest setup is the official plugin — it registers the MCP server, skills, and subagents in one step and pulls the native binary via the `@orbit-tools/cli` npm proxy:
+The official Claude Code and Codex plugins register the MCP server and shared
+Orbit skills automatically. They pull the native binary through the
+`@orbit-tools/cli` npm proxy on the first MCP call, so the `orbit` CLI does not
+need to be installed separately.
+
+### Claude Code
 
 ```text
 /plugin marketplace add danieljhkim/orbit
 /plugin install orbit
 ```
 
-Requires Node 18+ on `PATH`. Skip the rest of this page if you go this route; the plugin handles registration. Use the manual flow below for Codex, Gemini, Grok Build, or a Claude Code install you want to wire by hand.
+To update later, run `/plugin update orbit` and restart Claude Code.
+
+### Codex
+
+```bash
+codex plugin marketplace add danieljhkim/orbit --ref main
+codex plugin add orbit@orbit
+```
+
+To update later, refresh the Git marketplace snapshot and reinstall the plugin:
+
+```bash
+codex plugin marketplace upgrade orbit
+codex plugin add orbit@orbit
+```
+
+Both plugin paths require Node 18+ on `PATH`. Skip the manual registration flow
+below when you use a plugin.
+
+### Verify a plugin installation
+
+Start a fresh task from an initialized Orbit workspace. These prompts ask the
+agent to discover the bundled Orbit skill and invoke the read-only
+`orbit.task.list` MCP tool:
+
+```bash
+# Claude Code
+claude -p 'Use the read-only orbit.task.list MCP tool to list up to three tasks, then report how many were returned.'
+
+# Codex CLI
+codex -C <repo> 'Use the read-only orbit.task.list MCP tool to list up to three tasks, then report how many were returned.'
+```
+
+For Codex, `codex mcp list` should also show an `orbit` server whose command is
+the canonical `npx -y @orbit-tools/cli@latest mcp serve` transport declared by
+the plugin manifest.
 
 ## Initialize (manual)
 
@@ -50,3 +90,5 @@ The surface includes task tools and graph read tools. Graph write tools are not 
 ```bash
 orbit mcp remove --all
 ```
+
+<!-- ORB-10117 -->


### PR DESCRIPTION
## Task

[ORB-10117](https://orbit-cli.com/tasks/ORB-10117) — Complete Codex plugin documentation parity

### Description

## Problem
Orbit's website and npm proxy documentation do not fully cover the newly installable Codex plugin alongside Claude.
## Scope
Document install, upgrade, new-task discovery, and MCP smoke for the Codex package while preserving Claude packaging. Repository-local child of ORB-10062.

### Acceptance Criteria

- Website install and MCP pages include current Codex plugin install/upgrade/new-task/read-only MCP smoke commands alongside Claude.
- The npm plugin README accurately explains that the proxy package serves supported Claude and Codex integration assets without implying manual file copying.
- Commands match the current Codex CLI/plugin manifest and canonical Orbit MCP command.
- `bash scripts/validate-codex-plugin.sh`, `bash scripts/smoke-plugin-install.sh`, and `make ci-fast` pass; full CI is green on the PR.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Added Codex plugin installation and upgrade commands to the website install and MCP integration guides alongside the existing Claude path.
- Added fresh-task smoke prompts for Claude and Codex that exercise the read-only `orbit.task.list` MCP tool, plus the canonical Codex MCP transport command from the plugin manifest.
- Clarified that `@orbit-tools/cli` is the binary proxy consumed by both supported agent plugins; each plugin manager installs its own manifests, skills, and client-specific assets without manual copying.
- Added the required Unreleased changelog entry for ORB-10117.

Assessment: Documentation now matches the validated Codex plugin manifest and current local Codex/Claude CLI command surfaces while preserving the Claude packaging guidance.

Validation:
- `bash scripts/validate-codex-plugin.sh` passed.
- `bash scripts/smoke-plugin-install.sh` passed, including isolated Codex install, fresh-task skill discovery, and read-only MCP call.
- `make ci-fast` passed.
- `git diff --check` passed.

Deviations from original plan:
- Added `CHANGELOG.md` outside the original context list | Justification: repository instructions require every PR to add a terse Unreleased bullet; the scope expansion was recorded in a task comment.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10117-6a52dd80`
- Behind base: 0
- Ahead of base: 1