### PR TITLE
ship pr pipeline reports success on an empty diff: pushes empty branch, opens no PR, still promotes task to review

### DIFF
--- a/.orbit/learnings/L-0076/learning.yaml
+++ b/.orbit/learnings/L-0076/learning.yaml
@@ -1,0 +1,21 @@
+schema_version: 1
+id: L-0076
+status: active
+scope:
+  paths: []
+  tags: []
+summary: 'Orbit PR pipeline: implement step leaves changes UNCOMMITTED (pr_open commits them), and task-context workspace_path serializes as JSON null when undeclared'
+body: |-
+  Two non-obvious invariants when touching the ship `--mode pr` pipeline commit/cwd paths:
+
+  1. **The implement step does not commit.** `task_pr_pipeline.yaml` has no explicit commit step; `pr_open` (vcs/pr/open.rs) calls `commit_batch_changes` (vcs/commit/mod.rs), which stages `git add --all` and creates the commit from the agent's *uncommitted* worktree changes. So an empty stage there means 'the implement step wrote nothing' — now a hard error (ORB-10134). Corollary: tests that pre-commit the branch for a pr_open path must instead leave changes uncommitted (see `pr_workspace_uncommitted()`).
+
+  2. **workspace_path is present-as-null, not absent.** The agent envelope and task context (runtime/engine/envelope.rs, runtime/v2_host/task_context.rs) always serialize `"workspace_path": null` when the run has no declared workspace. `resolve_subprocess_cwd` must treat JSON `null` as 'not declared' (fall back to repo root for direct runs) and only fail closed on a non-null non-string or empty value. Failing closed on null breaks every direct (non-worktree) v2 job run.
+
+  3. There is no persisted per-task `workspace_path` in the v2 store (Task, TaskRecordUpdateParams, TaskDocumentUpdateParams all lack it); the worktree path reaches the agent purely via the pipeline step input.
+evidence:
+- kind: task
+  reference: ORB-10134
+created_at: 2026-07-12T00:39:40.086091981Z
+updated_at: 2026-07-12T00:39:40.086091981Z
+created_by: claude

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Highlights
 
+- **Ship `--mode pr` fails loudly on an empty diff**: an implement step that writes nothing no longer reports success — an empty commit and a `0 commits ahead` branch now hard-fail (no empty branch pushed, no PR, no promote-to-review), the premature pre-commit `push` is removed, and the agent envelope gets `repo_root` plus a fail-closed `workspace_path`. ([ORB-10134])
 - **Routine scheduler health over HTTP**: `GET /api/routines` on the dashboard exposes each routine's last fire (timestamp, ok/error outcome, duration) and next-due slot, so a stopped `ship-sweep`/`qa-sweep` is visible remotely as a stale `last_fire` without box ssh. ([ORB-10138])
 - **ADR create over HTTP**: `POST /api/adrs` records a Proposed ADR (mirroring `orbit.adr.add`), so remote orchestrators can author decisions without an on-box run; malformed payloads get a structured 400. Friction/learning create routes stay absent. ([ORB-10141])
 - **Learning + ADR update routes on the HTTP API**: `PATCH /learnings/:id` (summary/scope/tags/body/evidence/priority) and `PATCH /adrs/:id` (status/tags and mutable metadata) delegate to the CLI tools, preserving supersede-don't-delete and invalid-transition rejection; no create routes added. ([ORB-10143])

--- a/crates/orbit-core/assets/jobs/task_pr_pipeline.yaml
+++ b/crates/orbit-core/assets/jobs/task_pr_pipeline.yaml
@@ -60,6 +60,7 @@ spec:
             default_input:
               task_id: "{{ item }}"
               workspace_path: "{{ steps.worktree.output.workspace_path }}"
+              repo_root: "{{ steps.worktree.output.workspace_path }}"
 
     - id: review_bundle
       when: "{{ input.review }} == true"
@@ -69,12 +70,6 @@ spec:
         task_ids: "{{ input.task_ids }}"
         workspace_path: "{{ steps.worktree.output.workspace_path }}"
         base_branch: "{{ input.base_branch }}"
-
-    - id: push
-      recovery_activity: step_failure_recovery
-      target: activity:git_push
-      default_input:
-        workspace_path: "{{ steps.worktree.output.workspace_path }}"
 
     - id: pr_open
       recovery_activity: step_failure_recovery

--- a/crates/orbit-engine/src/activity_job/tests/workspace.rs
+++ b/crates/orbit-engine/src/activity_job/tests/workspace.rs
@@ -37,8 +37,74 @@ fn resolve_subprocess_cwd_prefers_input_over_task_over_tool_ctx() {
         Some(task_dir.path().canonicalize().expect("canonical task dir"))
     );
 
+    // Absent key (direct, non-worktree run): fall back to the tool context's
+    // workspace_root — the repo root is the correct cwd there.
     let resolved =
         resolve_subprocess_cwd(&input, None, Some(tool_dir.path())).expect("tool cwd resolves");
+    assert_eq!(
+        resolved,
+        Some(tool_dir.path().canonicalize().expect("canonical tool dir"))
+    );
+}
+
+#[test]
+fn resolve_subprocess_cwd_fails_closed_on_declared_non_string_workspace_path() {
+    // Regression (ORB-10134): a worktree pipeline step whose workspace_path
+    // template rendered to a non-string, non-null value must fail closed, not
+    // silently fall back to the tool context's workspace_root (the primary
+    // checkout).
+    let tool_dir = tempdir().expect("tool tempdir");
+
+    for value in [
+        serde_json::json!(42),
+        serde_json::json!(true),
+        serde_json::json!({ "nested": "object" }),
+    ] {
+        let input = serde_json::json!({ "workspace_path": value });
+        let err = resolve_subprocess_cwd(&input, None, Some(tool_dir.path()))
+            .expect_err("non-string workspace_path must fail closed");
+        match err {
+            DispatchError::CliInvocationFailed(message) => {
+                assert!(
+                    message.contains("non-string workspace_path"),
+                    "message should flag the non-string value: {message}"
+                );
+            }
+            other => panic!("expected CliInvocationFailed, got {other:?}"),
+        }
+    }
+
+    // An empty-string render is likewise refused (fail closed, not fall back).
+    let input = serde_json::json!({ "workspace_path": "   " });
+    let err = resolve_subprocess_cwd(&input, None, Some(tool_dir.path()))
+        .expect_err("empty workspace_path must fail closed");
+    assert!(matches!(err, DispatchError::CliInvocationFailed(_)));
+}
+
+#[test]
+fn resolve_subprocess_cwd_treats_null_workspace_path_as_absent() {
+    // The agent envelope / task context serialize an undeclared workspace_path
+    // as JSON null; that must be treated as "not declared" so direct
+    // (non-worktree) runs fall back to the tool context's workspace_root.
+    let tool_dir = tempdir().expect("tool tempdir");
+
+    let input = serde_json::json!({ "workspace_path": null });
+    let resolved = resolve_subprocess_cwd(&input, None, Some(tool_dir.path()))
+        .expect("null input workspace_path falls back to tool cwd");
+    assert_eq!(
+        resolved,
+        Some(tool_dir.path().canonicalize().expect("canonical tool dir"))
+    );
+
+    // Same for a null workspace_path on the task context (its always-present
+    // key), which is how a task with no declared workspace serializes.
+    let task_ctx = serde_json::json!({ "workspace_path": null });
+    let resolved = resolve_subprocess_cwd(
+        &serde_json::json!({}),
+        Some(&task_ctx),
+        Some(tool_dir.path()),
+    )
+    .expect("null task-context workspace_path falls back to tool cwd");
     assert_eq!(
         resolved,
         Some(tool_dir.path().canonicalize().expect("canonical tool dir"))

--- a/crates/orbit-engine/src/activity_job/workspace.rs
+++ b/crates/orbit-engine/src/activity_job/workspace.rs
@@ -9,15 +9,18 @@ pub fn resolve_subprocess_cwd(
     task_ctx: Option<&Value>,
     tool_ctx_workspace_root: Option<&Path>,
 ) -> Result<Option<PathBuf>, DispatchError> {
-    if let Some(path) = input.get("workspace_path").and_then(Value::as_str) {
-        return validate_declared_workspace_path(path);
+    // A *declared* workspace_path must be usable. Fail closed if the key is
+    // present but renders to a non-string, null, or empty value — a
+    // worktree-based pipeline step whose `{{ ... workspace_path }}` failed to
+    // render would otherwise fall through and silently run the agent in the
+    // primary checkout, which is the ORB-10134 data-loss hazard. A genuinely
+    // absent key (direct, non-worktree runs) still falls back to the tool
+    // context's workspace_root below.
+    if let Some(resolved) = resolve_declared_workspace_path(Some(input), "activity input")? {
+        return Ok(Some(resolved));
     }
-
-    if let Some(path) = task_ctx
-        .and_then(|task| task.get("workspace_path"))
-        .and_then(Value::as_str)
-    {
-        return validate_declared_workspace_path(path);
+    if let Some(resolved) = resolve_declared_workspace_path(task_ctx, "task context")? {
+        return Ok(Some(resolved));
     }
 
     let Some(path) = tool_ctx_workspace_root else {
@@ -36,7 +39,34 @@ pub fn resolve_subprocess_cwd(
     Ok(None)
 }
 
-fn validate_declared_workspace_path(path: &str) -> Result<Option<PathBuf>, DispatchError> {
+/// Resolve a `workspace_path` declared on `container`. Returns:
+/// - `Ok(None)` when the key is absent or JSON `null` (caller falls back — the
+///   agent envelope / task context always serialize an undeclared
+///   workspace_path as `null`, so `null` means "not declared");
+/// - `Ok(Some(dir))` when it is a valid, existing directory;
+/// - `Err(..)` when it is present but a non-string/non-null value or empty, or
+///   names a path that is not a writable directory (fail closed — never fall
+///   back to the primary checkout).
+fn resolve_declared_workspace_path(
+    container: Option<&Value>,
+    source: &str,
+) -> Result<Option<PathBuf>, DispatchError> {
+    let Some(value) = container.and_then(|container| container.get("workspace_path")) else {
+        return Ok(None);
+    };
+    if value.is_null() {
+        return Ok(None);
+    }
+    let Some(path) = value.as_str() else {
+        return Err(DispatchError::CliInvocationFailed(format!(
+            "{source} declared a non-string workspace_path ({value}); \
+             refusing to fall back to the repository root"
+        )));
+    };
+    validate_declared_workspace_path(path).map(Some)
+}
+
+fn validate_declared_workspace_path(path: &str) -> Result<PathBuf, DispatchError> {
     let path_buf = PathBuf::from(path);
     if path.trim().is_empty() || !path_buf.is_dir() {
         return Err(DispatchError::CliInvocationFailed(format!(
@@ -44,7 +74,7 @@ fn validate_declared_workspace_path(path: &str) -> Result<Option<PathBuf>, Dispa
             path_buf.display()
         )));
     }
-    Ok(Some(canonicalize_dir(&path_buf)))
+    Ok(canonicalize_dir(&path_buf))
 }
 
 // pub(crate) widened for tests/ layout under ORB-00225; test reaches via exposed surface.

--- a/crates/orbit-engine/src/executor/automation/vcs/commit/mod.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/commit/mod.rs
@@ -186,7 +186,12 @@ pub(super) fn commit_batch_changes<H: TaskHost + RuntimeHost + ?Sized>(
     let changed_files = staged_changed_files(&workspace_path)?;
     if changed_files.is_empty() {
         git_success(&workspace_path, &["reset", "HEAD"])?;
-        return Ok(json!({}));
+        return Err(OrbitError::Execution(format!(
+            "commit_batch_changes: no staged changes to commit for task '{}' in worktree '{}'; \
+             the implement step produced an empty diff",
+            task.id,
+            workspace_path.display()
+        )));
     }
 
     let message = batch_commit_message(task);

--- a/crates/orbit-engine/src/executor/automation/vcs/commit/tests/author.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/commit/tests/author.rs
@@ -169,6 +169,38 @@ fn git_commit_batch_uses_templated_single_task_message() {
 }
 
 #[test]
+fn git_commit_batch_errors_on_empty_stage() {
+    // Regression (ORB-10134): a clean worktree (implement step wrote nothing)
+    // must make `commit_batch_changes` error, not return a silent `Ok`.
+    let temp = initialized_git_repo();
+    let workspace = temp.path();
+
+    let tasks = vec![task_with_file(
+        "T1",
+        "Empty task",
+        "src/missing.txt",
+        "claude-opus-4-7",
+    )];
+    let host = CommitTestHost::new(tasks, workspace.to_path_buf());
+    let input = json!({
+        "scope": "all",
+        "job_run_id": "batch-1",
+        "workspace_path": workspace.to_string_lossy().to_string(),
+    });
+
+    let error = git_commit(&host, &input).expect_err("empty stage must error");
+    assert!(
+        error.to_string().contains("no staged changes to commit"),
+        "expected empty-diff error, got: {error}"
+    );
+
+    // The index is left clean (the staging reset ran before erroring), so no
+    // commit was created beyond the repo's initial commit.
+    let log = git_output(workspace, &["rev-list", "--count", "HEAD"]).expect("count commits");
+    assert_eq!(log.trim(), "1", "no commit should have been created");
+}
+
+#[test]
 fn git_commit_batch_rejects_multiple_tasks() {
     let temp = initialized_git_repo();
     let workspace = temp.path();

--- a/crates/orbit-engine/src/executor/automation/vcs/pr/open.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/pr/open.rs
@@ -113,32 +113,30 @@ pub(crate) fn open_batch_pr<H: RuntimeHost + TaskHost + ?Sized>(
         .collect();
 
     if freshness.commits_ahead == 0 {
-        for task in &completed_tasks {
-            let model = pr_review_attribution(host, task, batch_id)?;
-            host.apply_task_automation_update(
-                &task.id,
-                TaskAutomationUpdate {
-                    status: if task.status == TaskStatus::InProgress {
-                        Some(TaskStatus::Review)
-                    } else {
-                        None
-                    },
-                    model,
-                    ..TaskAutomationUpdate::default()
-                },
-            )?;
-        }
-
-        return Ok(json!({
-            "pr_created": false,
-            "reason": "no repository commits between base and head; completed tasks moved to review without a GitHub PR",
-            "base": base,
-            "head": head,
-            "base_ref": freshness.base_ref,
-            "head_ref": freshness.head_ref,
-            "commits_behind": freshness.commits_behind,
-            "commits_ahead": freshness.commits_ahead,
-        }));
+        // An empty head branch after the implement step is a bug, not an
+        // outcome: promoting the tasks to review and skipping the PR would
+        // strand the work (branch pushed at base HEAD, no PR, no signal). Fail
+        // loudly so the run terminalizes and the coupled tasks are blocked for
+        // a human/orchestrator to inspect. See ORB-10134.
+        let error = OrbitError::Execution(format!(
+            "open_batch_pr: head '{head}' has 0 commits ahead of base '{base}' (base_ref '{}'); \
+             the implement step produced an empty branch — refusing to open a PR or promote tasks to review",
+            freshness.base_ref
+        ));
+        record_failed_handoff(
+            host,
+            &completed_tasks,
+            FailedHandoff {
+                batch_id,
+                workspace_path: &workspace_path,
+                head: &head,
+                base: &base,
+                base_ref: Some(&freshness.base_ref),
+                op: FailedHandoffOp::EmptyBranch,
+                error: &error,
+            },
+        )?;
+        return Err(error);
     }
 
     let title = input_string_field(input, "title")
@@ -366,6 +364,7 @@ pub(super) enum FailedHandoffOp {
     Push,
     PrCreate,
     PrView,
+    EmptyBranch,
 }
 
 impl FailedHandoffOp {
@@ -375,6 +374,7 @@ impl FailedHandoffOp {
             Self::Push => "push",
             Self::PrCreate => "github.pr.create",
             Self::PrView => "github.pr.view",
+            Self::EmptyBranch => "empty-branch",
         }
     }
 }
@@ -415,6 +415,9 @@ fn failed_handoff_recovery(
         ),
         FailedHandoffOp::PrCreate => format!("{cd}\n  gh pr create --base {base} --head {head}"),
         FailedHandoffOp::PrView => format!("{cd}\n  gh pr view {head} --json url,number"),
+        FailedHandoffOp::EmptyBranch => format!(
+            "{cd}\n  # {head} carries no commits ahead of {base}; re-run the task so the implement step writes changes into the worktree before shipping"
+        ),
     }
 }
 

--- a/crates/orbit-engine/src/executor/automation/vcs/pr/tests/open.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/pr/tests/open.rs
@@ -38,7 +38,10 @@ fn pr_open_rejects_missing_execution_summary_before_create() {
 }
 
 #[test]
-fn pr_open_completes_no_diff_branch_without_github_pr() {
+fn pr_open_fails_loudly_on_empty_worktree_diff() {
+    // Regression (ORB-10134): when the implement step writes nothing into the
+    // worktree, `pr_open` must fail at the commit step — never push an empty
+    // branch, open a PR, or promote the task to review.
     let workspace = no_diff_pr_workspace();
     let host = PrOpenTestHost::new(
         vec![batch_task(
@@ -50,27 +53,73 @@ fn pr_open_completes_no_diff_branch_without_github_pr() {
     )
     .with_activity_implementer("codex", "codex");
 
-    let result = pr_open(&host, &pr_open_input(&workspace.repo, vec!["T20260513-16"]))
-        .expect("pr_open should complete no-diff handoff without a GitHub PR");
-
-    assert_eq!(result["pr_created"], json!(false));
-    assert_eq!(result["base"], json!("agent-main"));
-    assert_eq!(result["head"], json!("orbit/test-batch"));
-    assert_eq!(result["commits_behind"], json!(0));
-    assert_eq!(result["commits_ahead"], json!(0));
+    let error = pr_open(&host, &pr_open_input(&workspace.repo, vec!["T20260513-16"]))
+        .expect_err("empty worktree diff must fail loudly, not promote to review");
+    let message = error.to_string();
     assert!(
-        result["reason"]
-            .as_str()
-            .expect("no-diff reason")
-            .contains("no repository commits")
+        message.contains("no staged changes to commit"),
+        "expected empty-diff commit error, got: {message}"
     );
-    assert!(host.tool_calls().is_empty());
 
-    let task = host.get_task("T20260513-16").expect("updated task");
-    assert_eq!(task.status, TaskStatus::Review);
-    assert_eq!(task.implemented_by.as_deref(), Some("codex"));
+    // No branch push and no PR creation ever run.
+    assert!(
+        host.tool_calls().is_empty(),
+        "no git.push or github.pr.create should run on an empty diff, got: {:?}",
+        host.tool_calls()
+    );
+
+    // The task is NOT promoted to review — it stays in-progress so the run can
+    // terminalize and block it for inspection.
+    let task = host.get_task("T20260513-16").expect("task still exists");
+    assert_eq!(task.status, TaskStatus::InProgress);
     assert!(task.external_refs.is_empty());
     assert_eq!(task.github_pr_number(), None);
+}
+
+#[test]
+fn open_batch_pr_rejects_zero_commits_ahead_branch() {
+    // Even if a commit somehow exists but the head branch carries 0 commits
+    // ahead of base, `open_batch_pr` must fail rather than pushing the empty
+    // branch and promoting tasks to review (ORB-10134).
+    let workspace = no_diff_pr_workspace();
+    let host = PrOpenTestHost::new(
+        vec![batch_task(
+            "T20260513-16",
+            "Create a user-global skill",
+            "Outcome: success\n\nChanges:\n- Nothing landed on the branch.",
+        )],
+        workspace.repo.clone(),
+    );
+
+    let error = open_batch_pr(&host, &pr_open_input(&workspace.repo, vec!["T20260513-16"]))
+        .expect_err("a branch with 0 commits ahead of base must fail, not promote to review");
+    let message = error.to_string();
+    assert!(
+        message.contains("0 commits ahead"),
+        "expected empty-branch error, got: {message}"
+    );
+
+    assert!(
+        host.tool_calls()
+            .iter()
+            .all(|call| call.name != "github.pr.create"),
+        "github.pr.create must not run for an empty branch"
+    );
+
+    // The task stays in-progress and a failed-handoff comment is recorded.
+    let task = host.get_task("T20260513-16").expect("task still exists");
+    assert_eq!(task.status, TaskStatus::InProgress);
+    assert!(task.external_refs.is_empty());
+    assert_eq!(task.github_pr_number(), None);
+
+    let comments = host.comments_for("T20260513-16");
+    assert_eq!(comments.len(), 1, "exactly one failed-handoff comment");
+    let body = &comments[0].message;
+    assert!(
+        body.contains("[op=empty-branch]"),
+        "handoff op should be empty-branch: {body}"
+    );
+    assert!(body.contains("0 commits ahead"), "handoff body: {body}");
 }
 
 #[test]
@@ -253,7 +302,10 @@ fn pr_open_records_failed_handoff_comment_when_pr_create_fails() {
 
 #[test]
 fn pr_open_preserves_non_empty_explicit_body() {
-    let workspace = pr_workspace();
+    // Exercises the full pr_open path (commit uncommitted worktree changes,
+    // then open the PR) against a worktree whose implement-step changes are not
+    // yet committed — the real PR pipeline shape.
+    let workspace = pr_workspace_uncommitted();
     let host = PrOpenTestHost::new(
         vec![batch_task(
             "T20260430-31A",

--- a/crates/orbit-engine/src/executor/automation/vcs/pr/tests/test_support.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/pr/tests/test_support.rs
@@ -479,6 +479,29 @@ pub fn pr_workspace() -> PrWorkspace {
     PrWorkspace { _temp: temp, repo }
 }
 
+/// Like `pr_workspace`, but the branch's change is left UNCOMMITTED in the
+/// working tree — mirroring the real PR pipeline, where the implement step
+/// writes changes into the worktree and `pr_open`'s commit step creates the
+/// commit. Used to exercise `pr_open` end-to-end (commit + open).
+pub fn pr_workspace_uncommitted() -> PrWorkspace {
+    let temp = tempdir().expect("tempdir");
+    let repo = temp.path().join("repo");
+    fs::create_dir_all(&repo).expect("create repo dir");
+    git(&repo, &["init"]);
+    git(&repo, &["checkout", "-b", "agent-main"]);
+    git(&repo, &["config", "user.name", "Orbit Test"]);
+    git(&repo, &["config", "user.email", "orbit-test@example.com"]);
+    fs::write(repo.join("README.md"), "base\n").expect("write readme");
+    git(&repo, &["add", "README.md"]);
+    git(&repo, &["commit", "-m", "base"]);
+    git(&repo, &["checkout", "-b", "orbit/test-batch"]);
+    fs::create_dir_all(repo.join("src")).expect("create src dir");
+    // Intentionally left uncommitted: pr_open's commit step must create it.
+    fs::write(repo.join("src/lib.rs"), "pub fn changed() {}\n").expect("write lib");
+
+    PrWorkspace { _temp: temp, repo }
+}
+
 pub fn no_diff_pr_workspace() -> PrWorkspace {
     let temp = tempdir().expect("tempdir");
     let repo = temp.path().join("repo");


### PR DESCRIPTION
## Task

[ORB-10134](https://orbit-cli.com/tasks/ORB-10134) — ship pr pipeline reports success on an empty diff: pushes empty branch, opens no PR, still promotes task to review

### Description

## Symptom (real run)

`orbit run ship --mode pr` on `ws_bridge` (run `jrun-20260711-1932`, task ORB-10128) reported `state: success` and advanced the task to `review`, but:

- branch `orbit/ORB-10128-6a529a44` was pushed to origin **at base HEAD, 0 commits ahead** — it contained none of the work;
- **no PR was ever opened** (task left with `pr_status: null`, `external_refs: []`);
- the entire implementation (7 files) survived only as an **uncommitted dirty working tree in the primary checkout** of `~/workspace/constellation/codebases/bridge` on `agent-main` — one auto-commit hook away from landing on `agent-main` un-reviewed, bypassing bridge's PR gate.

The work was recoverable only because it was noticed by hand. The pipeline gave no signal that anything was wrong.

## Root cause — three compounding lenient paths (verified in code @ `eea3aab4`)

Whatever leaves the worktree empty (see "Secondary" below), the pipeline **converts that into a silent success**:

1. **`push` runs before any commit exists.** `crates/orbit-core/assets/jobs/task_pr_pipeline.yaml`: `push` (line 73) is ordered *before* `pr_open` (line 79). It pushes the branch exactly as `git worktree add -B <branch> <path> <target>` created it (`vcs/worktree/setup.rs:147-157`) — i.e. at base HEAD, zero commits ahead. On a normal run `pr_open` later commits and re-pushes with `--force-with-lease` (`vcs/pr/open.rs:167-176`), which masks the ordering. When the commit is a no-op, nothing ever corrects the pushed-empty branch. Note `task_local_pipeline.yaml:66-72` has an explicit `commit` step; the PR pipeline has none — its commit is buried inside `pr_open` (`vcs/pr/open.rs:21-27`).

2. **The commit silently no-ops on an empty diff.** `vcs/commit/mod.rs:167-197` stages `--all`, finds nothing staged, runs `git reset HEAD`, and returns `Ok(json!({}))` — success, not an error.

3. **`commits_ahead == 0` is treated as success *and* promotes the task.** `vcs/pr/open.rs:115-142` early-returns `{"pr_created": false, "reason": "no repository commits between base and head; completed tasks moved to review without a GitHub PR"}` and applies `in-progress -> review` to every completed task. `github.pr.create` (open.rs:193) sits *below* that early return, so it never fires. `require_child_success` / `require_gate_success` then both pass, so the run is `success`.

No guard anywhere asserts the head branch actually carries commits. The one guard that could have caught it — `ensure_completed_tasks_have_meaningful_execution_summaries` (open.rs:71, 349-361) — passed, because the agent had dutifully written a summary for work that was never committed.

This is **not a recent regression**: the push-before-`pr_open` ordering dates to `08026a15` (ORB-00059) and the `commits_ahead == 0` path is long-standing. It is latent until a worktree comes out empty.

## Secondary (separate, likely contributing — split out if you prefer)

Why was the worktree empty and the diff in the primary checkout? The implementing agent appears to have written through **absolute paths into the primary checkout** rather than its worktree. Nothing prevents or detects this:

- **`resolve_subprocess_cwd` fails open.** `crates/orbit-engine/src/activity_job/workspace.rs:7-37`: if `input.workspace_path` is absent or non-string, it silently falls through to the task's `workspace_path` and then to `tool_ctx.workspace_root` — **the primary checkout**. No error. (For *this* run the worktree path did render — the `push` would otherwise have failed — so rung 1 was taken; the fallback remains a live hazard.)
- **The agent is told `repo_root: null`.** `runtime/v2_host/task_context.rs:60-86` populates `repo_root` only from `input.repo_root`, and `task_pr_pipeline.yaml` never passes it — while `agent_implement.yaml` instruction #4 tells the agent to "use `input.workspace_path` and `input.repo_root` when provided."
- **The task's `workspace_path` is never re-stamped to the worktree.** `vcs/worktree/setup.rs:57-66` stamps only `job_run_id`, despite `worktree_setup.yaml:7-9` claiming it stamps workspace metadata. Any stale absolute path on the task record still points at the primary checkout.
- **The sandbox permits it.** `runtime/v2_host/sandbox.rs:78-97` absolutizes the fs policy against `repo_root`, so `<repo_root>/**` is writable (only `<repo_root>/.orbit/**` is denied, then the active worktree re-allowed). On non-macOS there is no sandbox at all (sandbox.rs:33-41).

## Fixes

Primary (the pipeline must fail loudly):
- Make `commits_ahead == 0` in `vcs/pr/open.rs:115` a **hard failure** — never `pr_created: false` + promote-to-review. An empty head branch after an implement step is a bug, not an outcome.
- Remove the premature `push` step from `task_pr_pipeline.yaml` (or move it after `pr_open`'s commit) — `pr_open` already pushes.
- Make `commit_batch_changes` **error** on an empty stage instead of returning `Ok(json!({}))`.
- Add a post-implement assertion that the worktree is dirty / the branch is ahead, before push/PR.

Secondary (don't let the agent escape the worktree):
- Fail closed in `resolve_subprocess_cwd` rather than falling back to `repo_root`.
- Pass `repo_root` through `task_pr_pipeline.yaml` into the agent envelope, and re-stamp the task's `workspace_path` to the worktree in `worktree_setup`.

## Verification aid

The `CliInvocationStarted` audit event (`cli_runner/orchestrator.rs:152`) records the agent's actual `cwd` for `jrun-20260711-1932-3` — pull it to confirm the agent was launched in the worktree and wrote outside it.

### Acceptance Criteria

- A ship --mode pr run whose head branch has 0 commits ahead of base FAILS the run; the task is never promoted to review and no branch is left pushed-but-empty on origin
- commit_batch_changes errors on an empty stage instead of returning Ok(json!({}))
- task_pr_pipeline.yaml no longer pushes the branch before the commit exists (premature push removed or reordered after pr_open's commit)
- resolve_subprocess_cwd fails closed instead of falling back to tool_ctx.workspace_root (the primary checkout) when workspace_path is absent/non-string
- task_pr_pipeline.yaml passes repo_root into the agent envelope, and worktree_setup re-stamps the task's workspace_path to the worktree path
- Regression test: a pipeline run where the implement step writes nothing into the worktree fails loudly (no PR, no review promotion, no empty branch pushed)

## Execution Summary

<details>
<summary>Click to expand</summary>

## Status
success

## Summary of Changes
Made the ship `--mode pr` pipeline fail loudly instead of reporting success on an empty diff (which pushed an empty branch, opened no PR, yet still promoted tasks to review).

### Primary (pipeline fails loudly)
- `crates/orbit-engine/src/executor/automation/vcs/commit/mod.rs`: `commit_batch_changes` now returns `Err` (was `Ok(json!({}))`) when the stage is empty after `git add --all`. This is the effective post-implement assertion — `pr_open` calls it first, so an empty worktree fails at the commit step.
- `crates/orbit-engine/src/executor/automation/vcs/pr/open.rs`: `commits_ahead == 0` is now a hard failure (was `pr_created:false` + promote every task to review). Records a `[op=empty-branch]` failed-handoff comment and returns `Err`, leaving tasks in-progress so the run terminalizes and blocks them. Added `FailedHandoffOp::EmptyBranch` (label + recovery text).
- `crates/orbit-core/assets/jobs/task_pr_pipeline.yaml`: removed the premature `push` step (it pushed the branch at base HEAD before any commit existed); `pr_open` already commits + pushes.

### Secondary (don't let the agent escape the worktree)
- `crates/orbit-core/assets/jobs/task_pr_pipeline.yaml`: `implement_one` now passes `repo_root: {{ steps.worktree.output.workspace_path }}` into the agent envelope (agent_implement instruction #4 references it; it was previously null).
- `crates/orbit-engine/src/activity_job/workspace.rs`: `resolve_subprocess_cwd` fails closed on a *declared* but malformed `workspace_path` (non-string/non-null or empty) instead of silently falling back to `tool_ctx.workspace_root` (the primary checkout). A genuinely absent key and JSON `null` (how the envelope/task-context serialize an undeclared workspace) still fall back — required so direct, non-worktree job runs keep running in the repo root.

### Scope note on AC#5 re-stamp
The 'worktree_setup re-stamps the task workspace_path' half was left unimplemented and documented in a task comment: the v2 task record has no persisted per-task workspace_path field, and the worktree path already reaches the agent envelope via the pipeline step input. Adding a persisted field would be a new orbit-store/orbit-common artifact (out of scope).

## Tests
- `pr/tests/open.rs`: rewrote `pr_open_completes_no_diff_branch_without_github_pr` into `pr_open_fails_loudly_on_empty_worktree_diff` (regression AC#6) and added `open_batch_pr_rejects_zero_commits_ahead_branch`; repointed `pr_open_preserves_non_empty_explicit_body` at a new `pr_workspace_uncommitted()` fixture that mirrors the real flow (uncommitted worktree changes that pr_open commits).
- `commit/tests/author.rs`: added `git_commit_batch_errors_on_empty_stage`.
- `activity_job/tests/workspace.rs`: added fail-closed (non-string) and null-is-absent cases; restored the absent-key fallback case.

## Validation
- `cargo check -p orbit-engine -p orbit-core`: clean.
- `cargo test -p orbit-engine --lib`: 239 passed.
- `cargo test -p orbit-core --lib`: 551 passed, 1 ignored.
- `make ci-fast`: all guardrails + changelog style/freshness pass.
- CHANGELOG `## Unreleased` bullet added.

Full `make ci` (the merge gate) not run locally per repo policy.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10134-6a52dd80`
- Behind base: 0
- Ahead of base: 2