### PR TITLE
qa-sweep v2: replace inline shell checks with a worker-invoked QA agent pass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Breaking Changes
 
+- **qa-sweep runs a QA agent, not inline shell checks**: `[[qa.workspace.check]]` tables are removed and now fail config load with a migration error. Configure per-workspace `crew`/`timeout_minutes`/`max_commits` and `qa.base_url` instead; the sweep submits a worker QA-agent run and files tasks from its findings. ([ORB-10146])
+
 - **Learning vote and comment surfaces removed**: `orbit.learning.upvote` and all `orbit.learning.comment.*` tools and CLI subcommands are gone — use `priority` + search rank for ranking, `update`/`supersede` for corrections, and `evidence` for provenance. ([ORB-10046])
 - **`orbit task` trimmed from 19 to 12 subcommands**: seven state-transition and read-projection verbs removed. `approve`/`reject`/`unarchive`/`delete` → `orbit task update --status …`; `locks` → `orbit locks`; `prune-context` → `orbit task lint --fix`; `templates` dropped. MCP tool surface unchanged. ([ORB-10000])
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2279,6 +2279,7 @@ dependencies = [
  "orbit-search",
  "orbit-store",
  "orbit-tools",
+ "reqwest",
  "rusqlite",
  "serde",
  "serde_json",

--- a/crates/orbit-cli/src/command/run/qa_sweep.rs
+++ b/crates/orbit-cli/src/command/run/qa_sweep.rs
@@ -1,33 +1,34 @@
 //! `orbit run qa-sweep` — trailing QA validation over direct-push workspaces
-//! [ORB-10039], sibling of `orbit run ship-sweep`. Designed for unattended
-//! schedulers: it never bootstraps a workspace from the caller's cwd,
-//! isolates per-workspace failures, and exits non-zero only when a workspace
-//! errored (a red check is the sweep working — it files a task — not a sweep
-//! failure).
+//! [ORB-10039], reworked to a worker-invoked QA agent pass [ORB-10146].
+//! Sibling of `orbit run ship-sweep`. Designed for unattended schedulers: it
+//! never bootstraps a workspace from the caller's cwd, isolates per-workspace
+//! failures, and exits non-zero only when a workspace errored (findings filed
+//! from a completed agent run are the sweep working, not a sweep failure).
 
 use clap::Args;
 use orbit_core::OrbitError;
-use orbit_core::qa::{QaCheckReport, QaSweepOptions, QaWorkspaceReport, run_qa_sweep};
+use orbit_core::qa::{QaFindingReport, QaSweepOptions, QaWorkspaceReport, run_qa_sweep};
 use serde_json::{Value, json};
 
 #[derive(Args)]
 #[command(
     name = "qa-sweep",
     about = "Validate new agent-main commits in configured direct-push workspaces",
-    after_help = "Workspaces and their checks come from the [qa] section of the GLOBAL\n\
-                  ~/.orbit/config.toml (never workspace config, which task-mutation\n\
-                  commands rewrite). Per workspace: diff the live checkout's HEAD against\n\
-                  the last-validated watermark; when new commits exist, run the checks,\n\
-                  file fingerprint-deduped orbit tasks for failures, and advance the\n\
-                  watermark only on a fully green pass. Intended to run from a scheduler\n\
+    after_help = "Workspaces come from the [qa] section of the GLOBAL ~/.orbit/config.toml\n\
+                  (never workspace config, which task-mutation commands rewrite). Per\n\
+                  workspace: diff the live checkout's HEAD against the last-validated\n\
+                  watermark; when new commits exist, submit a QA agent run to the worker\n\
+                  invoke daemon, poll it to a terminal state, file fingerprint-deduped\n\
+                  orbit tasks for its findings, and advance the watermark when the run\n\
+                  completed and its report parsed. Intended to run from a scheduler\n\
                   (systemd timer / cron), e.g.:\n  orbit run qa-sweep --json\n\n\
                   Sweeps are recorded in each workspace's run ledger under job id\n\
                   'qa_sweep': inspect with `orbit run history -j qa_sweep` and\n\
                   `orbit run show <run_id>` from the workspace."
 )]
 pub struct QaSweepCommand {
-    /// Report what would be validated without running checks, recording runs,
-    /// filing tasks, or advancing watermarks.
+    /// Report what would be validated without invoking the agent, recording
+    /// runs, filing tasks, or advancing watermarks.
     #[arg(long)]
     pub dry_run: bool,
     /// Output as JSON.
@@ -57,10 +58,15 @@ impl QaSweepCommand {
                 "lock_busy": outcome.lock_busy,
                 "workspaces": outcome.reports.len(),
                 "validated": count_actions(&outcome.reports, "validated"),
-                "failed_checks": count_actions(&outcome.reports, "failed"),
                 "would_validate": count_actions(&outcome.reports, "would_validate"),
                 "skipped": count_actions(&outcome.reports, "skipped"),
                 "errors": failed,
+                "findings_filed": outcome
+                    .reports
+                    .iter()
+                    .flat_map(|report| report.findings.iter())
+                    .filter(|finding| finding.filed_task.is_some())
+                    .count(),
                 "reports": outcome.reports.iter().map(report_json).collect::<Vec<_>>(),
             }))?;
         } else if outcome.lock_busy {
@@ -93,19 +99,19 @@ pub(crate) fn report_json(report: &QaWorkspaceReport) -> Value {
         "action": report.action,
         "reason": report.reason,
         "branch": report.branch,
+        "crew": report.crew,
         "head": report.head,
         "baseline": report.baseline,
         "new_commits": report.new_commits.as_ref().map(Vec::len),
         "watermark_reset": report.watermark_reset,
         "run_id": report.run_id,
-        "checks": report.checks.iter().map(|check| json!({
-            "name": check.name,
-            "outcome": check.outcome,
-            "exit_code": check.exit_code,
-            "duration_ms": check.duration_ms,
-            "fingerprint": check.fingerprint,
-            "filed_task": check.filed_task,
-            "deduped_task": check.deduped_task,
+        "agent_run_id": report.agent_run_id,
+        "findings": report.findings.iter().map(|finding| json!({
+            "name": finding.name,
+            "severity": finding.severity,
+            "fingerprint": finding.fingerprint,
+            "filed_task": finding.filed_task,
+            "deduped_task": finding.deduped_task,
         })).collect::<Vec<_>>(),
     })
 }
@@ -124,14 +130,21 @@ pub(crate) fn report_line(report: &QaWorkspaceReport) -> String {
     {
         line.push_str(&format!(" — HEAD {}", short_sha(head)));
     }
-    if !report.checks.is_empty() {
-        let checks = report
-            .checks
+    if let Some(crew) = &report.crew
+        && report.action != "skipped"
+    {
+        line.push_str(&format!(" — crew {crew}"));
+    }
+    if !report.findings.is_empty() {
+        let findings = report
+            .findings
             .iter()
-            .map(check_summary)
+            .map(finding_summary)
             .collect::<Vec<_>>()
             .join(", ");
-        line.push_str(&format!(" [{checks}]"));
+        line.push_str(&format!(" [{findings}]"));
+    } else if report.action == "validated" {
+        line.push_str(" [clean]");
     }
     if let Some(run_id) = &report.run_id {
         line.push_str(&format!(" — run {run_id}"));
@@ -139,12 +152,12 @@ pub(crate) fn report_line(report: &QaWorkspaceReport) -> String {
     line
 }
 
-fn check_summary(check: &QaCheckReport) -> String {
-    let mut summary = format!("{}: {}", check.name, check.outcome);
-    if let Some(task) = &check.filed_task {
+fn finding_summary(finding: &QaFindingReport) -> String {
+    let mut summary = format!("{}: {}", finding.name, finding.severity);
+    if let Some(task) = &finding.filed_task {
         summary.push_str(&format!(" (filed {task})"));
     }
-    if let Some(task) = &check.deduped_task {
+    if let Some(task) = &finding.deduped_task {
         summary.push_str(&format!(" (open {task})"));
     }
     summary

--- a/crates/orbit-cli/src/command/run/tests/qa_sweep.rs
+++ b/crates/orbit-cli/src/command/run/tests/qa_sweep.rs
@@ -1,6 +1,7 @@
-//! Rendering tests for `orbit run qa-sweep` report rows [ORB-10039].
+//! Rendering tests for `orbit run qa-sweep` report rows [ORB-10039,
+//! reworked ORB-10146].
 
-use orbit_core::qa::{QaCheckReport, QaWorkspaceReport};
+use orbit_core::qa::{QaFindingReport, QaWorkspaceReport};
 
 use crate::command::run::RunSubcommand;
 use crate::command::run::qa_sweep::{report_json, report_line};
@@ -37,58 +38,56 @@ fn report(action: &'static str) -> QaWorkspaceReport {
         action,
         reason: None,
         branch: Some("agent-main".to_string()),
+        crew: Some("opus".to_string()),
         head: Some("beefbeefbeefbeef".to_string()),
         baseline: Some("cafecafecafecafe".to_string()),
         new_commits: Some(vec!["beefbeef add thing".to_string()]),
         watermark_reset: false,
         run_id: Some("run-42".to_string()),
-        checks: vec![
-            QaCheckReport {
-                name: "lint".to_string(),
-                outcome: "passed",
-                exit_code: Some(0),
-                duration_ms: 120,
-                fingerprint: None,
-                filed_task: None,
-                deduped_task: None,
-            },
-            QaCheckReport {
-                name: "tests".to_string(),
-                outcome: "failed",
-                exit_code: Some(1),
-                duration_ms: 4500,
-                fingerprint: Some("abc123def456".to_string()),
-                filed_task: Some("ORB-10101".to_string()),
-                deduped_task: None,
-            },
-        ],
+        agent_run_id: Some("wrk-7".to_string()),
+        findings: vec![QaFindingReport {
+            name: "login-redirect-loops".to_string(),
+            severity: "high".to_string(),
+            fingerprint: "abc123def456".to_string(),
+            filed_task: Some("ORB-10101".to_string()),
+            deduped_task: None,
+        }],
     }
 }
 
 #[test]
-fn line_carries_range_checks_and_run() {
-    let line = report_line(&report("failed"));
+fn line_carries_range_findings_and_run() {
+    let line = report_line(&report("validated"));
     assert_eq!(
         line,
-        "polaris: failed — cafecafeca..beefbeefbe [lint: passed, tests: failed (filed ORB-10101)] — run run-42"
+        "polaris: validated — cafecafeca..beefbeefbe — crew opus \
+         [login-redirect-loops: high (filed ORB-10101)] — run run-42"
     );
+}
+
+#[test]
+fn clean_validated_line_marks_clean() {
+    let mut clean = report("validated");
+    clean.findings.clear();
+    assert!(report_line(&clean).contains("[clean]"));
 }
 
 #[test]
 fn skipped_line_shows_reason_without_range() {
     let mut skipped = report("skipped");
     skipped.reason = Some("no_new_commits".to_string());
-    skipped.checks.clear();
+    skipped.crew = None;
+    skipped.findings.clear();
     skipped.run_id = None;
     assert_eq!(report_line(&skipped), "polaris: skipped — no_new_commits");
 }
 
 #[test]
-fn deduped_check_names_the_open_task() {
-    let mut deduped = report("failed");
-    deduped.checks[1].filed_task = None;
-    deduped.checks[1].deduped_task = Some("ORB-10100".to_string());
-    assert!(report_line(&deduped).contains("tests: failed (open ORB-10100)"));
+fn deduped_finding_names_the_open_task() {
+    let mut deduped = report("validated");
+    deduped.findings[0].filed_task = None;
+    deduped.findings[0].deduped_task = Some("ORB-10100".to_string());
+    assert!(report_line(&deduped).contains("login-redirect-loops: high (open ORB-10100)"));
 }
 
 #[test]
@@ -99,7 +98,9 @@ fn json_shape_is_stable() {
     assert_eq!(value["baseline"], "cafecafecafecafe");
     assert_eq!(value["new_commits"], 1);
     assert_eq!(value["run_id"], "run-42");
-    assert_eq!(value["checks"][1]["fingerprint"], "abc123def456");
-    assert_eq!(value["checks"][1]["filed_task"], "ORB-10101");
-    assert_eq!(value["checks"][0]["exit_code"], 0);
+    assert_eq!(value["agent_run_id"], "wrk-7");
+    assert_eq!(value["crew"], "opus");
+    assert_eq!(value["findings"][0]["fingerprint"], "abc123def456");
+    assert_eq!(value["findings"][0]["filed_task"], "ORB-10101");
+    assert_eq!(value["findings"][0]["severity"], "high");
 }

--- a/crates/orbit-core/Cargo.toml
+++ b/crates/orbit-core/Cargo.toml
@@ -25,6 +25,7 @@ orbit-engine = { path = "../orbit-engine" }
 orbit-policy = { path = "../orbit-policy" }
 orbit-store = { path = "../orbit-store" }
 orbit-tools = { path = "../orbit-tools" }
+reqwest.workspace = true
 rusqlite.workspace = true
 serde_json.workspace = true
 serde.workspace = true

--- a/crates/orbit-core/src/config/mod.rs
+++ b/crates/orbit-core/src/config/mod.rs
@@ -25,7 +25,7 @@ mod store;
 pub(crate) use bootstrap::seed_default_config;
 pub(crate) use persistence::PersistenceConfig;
 pub use raw::{RawAgentRoleConfig, RawCrewEntry};
-pub(crate) use raw::{RawQaCheckConfig, RawQaConfig, RawQaWorkspaceConfig};
+pub(crate) use raw::{RawQaConfig, RawQaWorkspaceConfig};
 pub use registry::{CONFIG_KEY_REGISTRY, ConfigKeyDescriptor, describe as describe_config_key};
 pub(crate) use runtime::{CodexExecutionPolicy, DuelConfig, ExecutionEnvPolicy, RuntimeConfig};
 pub use store::{ConfigScope, ConfigSnapshot, ConfigStore, WorkspaceInitMode};

--- a/crates/orbit-core/src/config/raw.rs
+++ b/crates/orbit-core/src/config/raw.rs
@@ -43,20 +43,23 @@ pub(super) struct RawWorkflowConfig {
 }
 
 /// `[qa]` — configuration for the trailing QA validation sweep
-/// (`orbit run qa-sweep`) [ORB-10039]. Host-level: the sweep reads this from
-/// the **global** `~/.orbit/config.toml` only (like the workspace registry it
-/// iterates), so a workspace-level `config.toml` — which task-mutation
-/// commands rewrite — can never strip or override it.
+/// (`orbit run qa-sweep`) [ORB-10039, reworked ORB-10146]. Host-level: the
+/// sweep reads this from the **global** `~/.orbit/config.toml` only (like the
+/// workspace registry it iterates), so a workspace-level `config.toml` — which
+/// task-mutation commands rewrite — can never strip or override it.
 #[derive(Debug, Clone, Deserialize)]
 pub(crate) struct RawQaConfig {
-    /// `qa.default_priority` — priority for auto-filed QA tasks when a check
-    /// does not override it. One of `low`, `medium`, `high`, `critical`;
-    /// defaults to `medium`.
+    /// `qa.default_priority` — ceiling priority for auto-filed QA tasks; a
+    /// finding's severity-mapped priority is clamped to at most this. One of
+    /// `low`, `medium`, `high`, `critical`; defaults to `medium`.
     pub(crate) default_priority: Option<String>,
     /// `qa.task_status` — status auto-filed QA tasks are created with. One of
     /// `backlog` (default; lets `ship-sweep` dispatch the fix unattended, per
     /// design D4) or `proposed` (require human approval first).
     pub(crate) task_status: Option<String>,
+    /// `qa.base_url` — base URL of the loopback worker invoke daemon the sweep
+    /// submits QA agent runs to. Defaults to `http://127.0.0.1:7879`.
+    pub(crate) base_url: Option<String>,
     /// `[[qa.workspace]]` — one entry per direct-push workspace to validate.
     pub(crate) workspace: Option<Vec<RawQaWorkspaceConfig>>,
 }
@@ -69,25 +72,20 @@ pub(crate) struct RawQaWorkspaceConfig {
     /// Branch the sweep expects the checkout to be on. Defaults to the
     /// workspace's registered `base_branch` when absent.
     pub(crate) branch: Option<String>,
-    /// `[[qa.workspace.check]]` — the checks run against the checkout.
-    pub(crate) check: Option<Vec<RawQaCheckConfig>>,
-}
-
-/// One `[[qa.workspace.check]]` entry.
-#[derive(Debug, Clone, Deserialize)]
-pub(crate) struct RawQaCheckConfig {
-    /// Stable check name; part of the failure fingerprint.
-    pub(crate) name: Option<String>,
-    /// Shell command run from the workspace root (`sh -c <command>`).
-    pub(crate) command: Option<String>,
-    /// Muted checks are skipped (not executed) without deleting their
-    /// definition — the escape hatch for flaky checks. Defaults to `false`.
-    pub(crate) mute: Option<bool>,
-    /// Per-check priority override for auto-filed QA tasks.
-    pub(crate) priority: Option<String>,
-    /// Kill the check and record a failure after this many minutes.
-    /// Defaults to 30.
+    /// Named crew for the QA agent run. Falls back to the workspace's default
+    /// crew resolution [ORB-10133] when absent.
+    pub(crate) crew: Option<String>,
+    /// Agent-run wall-clock timeout in minutes (default 120). Maps to the
+    /// worker's `limits.wall_clock_secs`.
     pub(crate) timeout_minutes: Option<u64>,
+    /// Cap on the number of commits listed in the QA prompt. Absent = the
+    /// built-in evidence cap.
+    pub(crate) max_commits: Option<usize>,
+    /// Removed in ORB-10146 (qa-sweep v2 invokes a QA agent instead of running
+    /// inline shell checks). Retained only so a leftover `[[qa.workspace.check]]`
+    /// table is rejected at config load with a migration error instead of being
+    /// silently ignored.
+    pub(crate) check: Option<toml::Value>,
 }
 
 #[derive(Debug, Clone, Deserialize)]

--- a/crates/orbit-core/src/qa/config.rs
+++ b/crates/orbit-core/src/qa/config.rs
@@ -1,9 +1,14 @@
-//! Resolved, validated view of the `[qa]` config section [ORB-10039].
+//! Resolved, validated view of the `[qa]` config section [ORB-10039,
+//! reworked ORB-10146].
 //!
 //! Raw serde structs live in `config::raw`; this module turns them into a
 //! fail-closed [`QaSweepConfig`] during `RuntimeConfig` load, so a malformed
 //! `[qa]` section is a loud startup error everywhere — never a sweep that
 //! silently validates nothing.
+//!
+//! qa-sweep v2 invokes a QA agent per workspace instead of running inline
+//! shell checks. Legacy `[[qa.workspace.check]]` tables are rejected here with
+//! a migration error rather than silently ignored.
 
 use std::collections::BTreeSet;
 use std::str::FromStr;
@@ -11,53 +16,50 @@ use std::time::Duration;
 
 use orbit_common::types::{OrbitError, TaskPriority, TaskStatus};
 
-use crate::config::{RawQaCheckConfig, RawQaConfig, RawQaWorkspaceConfig};
+use crate::config::{RawQaConfig, RawQaWorkspaceConfig};
 
-/// Default priority for auto-filed QA tasks.
+/// Default ceiling priority for auto-filed QA tasks.
 const DEFAULT_TASK_PRIORITY: TaskPriority = TaskPriority::Medium;
 /// Default status for auto-filed QA tasks: `backlog`, so `ship-sweep` can
 /// dispatch the fix unattended (design D4 — the loop closes without a human
 /// courier). Set `qa.task_status = "proposed"` to require approval first.
 const DEFAULT_TASK_STATUS: TaskStatus = TaskStatus::Backlog;
-/// Default per-check timeout.
-const DEFAULT_CHECK_TIMEOUT_MINUTES: u64 = 30;
+/// Default per-workspace agent-run wall-clock timeout, in minutes. Generous by
+/// design: a QA agent builds, runs, and exercises new features hands-on.
+const DEFAULT_AGENT_TIMEOUT_MINUTES: u64 = 120;
+/// Default base URL of the loopback worker invoke daemon.
+pub const DEFAULT_WORKER_BASE_URL: &str = "http://127.0.0.1:7879";
 
 /// Host-level qa-sweep configuration (from the global `~/.orbit/config.toml`).
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct QaSweepConfig {
-    /// Priority for auto-filed QA tasks when a check does not override it.
+    /// Ceiling priority for auto-filed QA tasks; a finding's severity-mapped
+    /// priority is clamped to at most this.
     pub default_priority: TaskPriority,
     /// Status auto-filed QA tasks are created with (`backlog` or `proposed`).
     pub task_status: TaskStatus,
+    /// Base URL of the loopback worker invoke daemon.
+    pub worker_base_url: String,
     /// Direct-push workspaces to validate, in config order.
     pub workspaces: Vec<QaWorkspaceConfig>,
 }
 
-/// One workspace's validation setup.
+/// One workspace's QA-agent validation setup.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct QaWorkspaceConfig {
     /// Workspace name as registered in the global workspace registry.
     pub name: String,
-    /// Branch the checkout must be on for the sweep to validate it; `None`
+    /// Branch the sweep expects the checkout to be on for validation; `None`
     /// falls back to the workspace's registered `base_branch`.
     pub branch: Option<String>,
-    /// Checks run from the workspace root, in config order.
-    pub checks: Vec<QaCheck>,
-}
-
-/// One configured check.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct QaCheck {
-    /// Stable name; part of the failure fingerprint.
-    pub name: String,
-    /// Shell command run via `sh -c` from the workspace root.
-    pub command: String,
-    /// Muted checks are skipped without deleting their definition.
-    pub mute: bool,
-    /// Per-check priority override for auto-filed tasks.
-    pub priority: Option<TaskPriority>,
-    /// Kill the check and record a failure once this elapses.
+    /// Named crew for the QA agent run; `None` falls back to the workspace's
+    /// default crew resolution [ORB-10133].
+    pub crew: Option<String>,
+    /// Agent-run wall-clock timeout; the worker kills the run once it elapses.
     pub timeout: Duration,
+    /// Cap on the number of commits listed in the QA prompt; `None` uses the
+    /// built-in evidence cap.
+    pub max_commits: Option<usize>,
 }
 
 impl Default for QaSweepConfig {
@@ -65,6 +67,7 @@ impl Default for QaSweepConfig {
         Self {
             default_priority: DEFAULT_TASK_PRIORITY,
             task_status: DEFAULT_TASK_STATUS,
+            worker_base_url: DEFAULT_WORKER_BASE_URL.to_string(),
             workspaces: Vec::new(),
         }
     }
@@ -92,6 +95,18 @@ impl QaSweepConfig {
                 )));
             }
         };
+        let worker_base_url = match raw.base_url.as_deref() {
+            None => DEFAULT_WORKER_BASE_URL.to_string(),
+            Some(value) => {
+                let trimmed = value.trim();
+                if trimmed.is_empty() {
+                    return Err(OrbitError::InvalidInput(
+                        "qa.base_url must not be empty when set".to_string(),
+                    ));
+                }
+                trimmed.trim_end_matches('/').to_string()
+            }
+        };
 
         let mut workspaces = Vec::new();
         let mut seen_workspaces = BTreeSet::new();
@@ -109,6 +124,7 @@ impl QaSweepConfig {
         Ok(Self {
             default_priority,
             task_status,
+            worker_base_url,
             workspaces,
         })
     }
@@ -122,6 +138,19 @@ impl QaSweepConfig {
 impl QaWorkspaceConfig {
     fn from_raw(raw: &RawQaWorkspaceConfig) -> Result<Self, OrbitError> {
         let name = required_trimmed("[[qa.workspace]].name", raw.name.as_deref())?;
+
+        // Fail-closed migration guard: qa-sweep v2 replaced inline shell checks
+        // with a QA agent run, so a leftover `[[qa.workspace.check]]` table is a
+        // stale config the operator must remove — never a silent no-op.
+        if raw.check.is_some() {
+            return Err(OrbitError::InvalidInput(format!(
+                "[[qa.workspace]] '{name}' still declares [[qa.workspace.check]]; \
+                 qa-sweep v2 (ORB-10146) removed inline shell checks — remove the \
+                 check tables and configure a QA agent run via `crew` / `timeout_minutes` \
+                 / `max_commits` instead"
+            )));
+        }
+
         let branch = match raw.branch.as_deref().map(str::trim) {
             Some("") => {
                 return Err(OrbitError::InvalidInput(format!(
@@ -130,60 +159,35 @@ impl QaWorkspaceConfig {
             }
             other => other.map(ToOwned::to_owned),
         };
-
-        let raw_checks = raw.check.as_deref().unwrap_or_default();
-        if raw_checks.is_empty() {
-            return Err(OrbitError::InvalidInput(format!(
-                "[[qa.workspace]] '{name}' must declare at least one [[qa.workspace.check]]"
-            )));
-        }
-        let mut checks = Vec::new();
-        let mut seen_checks = BTreeSet::new();
-        for raw_check in raw_checks {
-            let check = QaCheck::from_raw(&name, raw_check)?;
-            if !seen_checks.insert(check.name.clone()) {
+        let crew = match raw.crew.as_deref().map(str::trim) {
+            Some("") => {
                 return Err(OrbitError::InvalidInput(format!(
-                    "[[qa.workspace]] '{name}' declares check '{}' more than once",
-                    check.name
+                    "[[qa.workspace]] '{name}': crew must not be empty when set"
                 )));
             }
-            checks.push(check);
+            other => other.map(ToOwned::to_owned),
+        };
+        let timeout_minutes = raw.timeout_minutes.unwrap_or(DEFAULT_AGENT_TIMEOUT_MINUTES);
+        if timeout_minutes == 0 {
+            return Err(OrbitError::InvalidInput(format!(
+                "[[qa.workspace]] '{name}': timeout_minutes must be at least 1"
+            )));
         }
+        let max_commits = match raw.max_commits {
+            Some(0) => {
+                return Err(OrbitError::InvalidInput(format!(
+                    "[[qa.workspace]] '{name}': max_commits must be at least 1 when set"
+                )));
+            }
+            other => other,
+        };
 
         Ok(Self {
             name,
             branch,
-            checks,
-        })
-    }
-}
-
-impl QaCheck {
-    fn from_raw(workspace: &str, raw: &RawQaCheckConfig) -> Result<Self, OrbitError> {
-        let context = format!("[[qa.workspace]] '{workspace}' check");
-        let name = required_trimmed(&format!("{context} name"), raw.name.as_deref())?;
-        let command = required_trimmed(
-            &format!("{context} '{name}' command"),
-            raw.command.as_deref(),
-        )?;
-        let priority = raw
-            .priority
-            .as_deref()
-            .map(|value| parse_priority(&format!("{context} '{name}' priority"), value))
-            .transpose()?;
-        let timeout_minutes = raw.timeout_minutes.unwrap_or(DEFAULT_CHECK_TIMEOUT_MINUTES);
-        if timeout_minutes == 0 {
-            return Err(OrbitError::InvalidInput(format!(
-                "{context} '{name}': timeout_minutes must be at least 1"
-            )));
-        }
-
-        Ok(Self {
-            name,
-            command,
-            mute: raw.mute.unwrap_or(false),
-            priority,
+            crew,
             timeout: Duration::from_secs(timeout_minutes * 60),
+            max_commits,
         })
     }
 }

--- a/crates/orbit-core/src/qa/fingerprint.rs
+++ b/crates/orbit-core/src/qa/fingerprint.rs
@@ -1,21 +1,19 @@
-//! Failure fingerprints for qa-sweep task dedupe [ORB-10039].
+//! Failure fingerprints for qa-sweep task dedupe [ORB-10039, reworked
+//! ORB-10146].
 //!
-//! A fingerprint identifies *one distinct way a check fails* so the sweep
-//! files one task per broken check, not one per pass (design D4). It is
-//! `sha256(workspace \n check \n normalized-output-head)` truncated to 12 hex
-//! chars and carried on the filed task as a `fp-<hash>` tag; the next sweep
-//! searches open tasks for that tag before filing again.
+//! A fingerprint identifies *one distinct finding* so the sweep files one task
+//! per open issue, not one per pass (design D4). It is
+//! `sha256(workspace \n normalized-finding-name)` truncated to 12 hex chars and
+//! carried on the filed task as a `fp-<hash>` tag; the next sweep searches open
+//! tasks for that tag before filing again.
 //!
-//! Normalization aims for *stability across reruns of the same failure*
-//! without collapsing genuinely different failures: ANSI escapes and the
-//! absolute repo root are scrubbed (they vary per host/terminal), whitespace
-//! runs are collapsed, and only the head of the output is hashed (tails often
-//! carry timing summaries and counters that churn per run).
+//! qa-sweep v2 fingerprints over the *finding name* the QA agent reports (a
+//! stable signature for the issue) rather than a shell check's output head, so
+//! the same feature regression surfaced across reruns dedupes to one task even
+//! as the agent's prose evidence varies.
 
 use sha2::{Digest, Sha256};
 
-/// Lines of normalized output that participate in the fingerprint.
-const FINGERPRINT_HEAD_LINES: usize = 20;
 /// Truncated hex length of the fingerprint hash.
 const FINGERPRINT_HEX_LEN: usize = 12;
 
@@ -27,40 +25,30 @@ pub fn fingerprint_tag(fingerprint: &str) -> String {
     format!("fp-{fingerprint}")
 }
 
-/// Compute the dedupe fingerprint for one failing check.
+/// Compute the dedupe fingerprint for one reported finding.
 ///
-/// `output` is the check's combined stdout+stderr; `exit_summary` is a stable
-/// textual fallback (e.g. `"exit 2"` or `"timeout"`) that keeps silent
-/// failures distinguishable by exit mode.
-pub fn failure_fingerprint(
-    workspace: &str,
-    check: &str,
-    repo_root: &str,
-    output: &str,
-    exit_summary: &str,
-) -> String {
-    let head = normalized_output_head(output, repo_root);
-    let signature = if head.is_empty() {
-        exit_summary.to_string()
+/// The signature is the workspace plus the finding's normalized name, so the
+/// same issue reported on later sweeps (possibly with different evidence prose)
+/// dedupes to the same open task. A blank name falls back to a stable literal
+/// so nameless findings still fingerprint deterministically per workspace.
+pub fn finding_fingerprint(workspace: &str, finding_name: &str) -> String {
+    let signature = normalize_signature(finding_name);
+    let signature = if signature.is_empty() {
+        "<unnamed-finding>"
     } else {
-        head
+        signature.as_str()
     };
-    let digest = Sha256::digest(format!("{workspace}\n{check}\n{signature}").as_bytes());
+    let digest = Sha256::digest(format!("{workspace}\n{signature}").as_bytes());
     let mut hex = format!("{digest:x}");
     hex.truncate(FINGERPRINT_HEX_LEN);
     hex
 }
 
-/// Normalize check output down to the stable head used as failure signature.
-pub(crate) fn normalized_output_head(output: &str, repo_root: &str) -> String {
-    strip_ansi(output)
-        .replace(repo_root, "<repo>")
-        .lines()
-        .map(collapse_whitespace)
-        .filter(|line| !line.is_empty())
-        .take(FINGERPRINT_HEAD_LINES)
-        .collect::<Vec<_>>()
-        .join("\n")
+/// Normalize a finding name to a stable signature: ANSI escapes stripped,
+/// lowercased, and internal whitespace collapsed so trivial formatting
+/// differences do not split one finding into two fingerprints.
+pub(crate) fn normalize_signature(name: &str) -> String {
+    collapse_whitespace(&strip_ansi(name)).to_ascii_lowercase()
 }
 
 /// Drop ANSI CSI/OSC escape sequences (colors, cursor moves, titles).
@@ -105,7 +93,7 @@ fn strip_ansi(input: &str) -> String {
     out
 }
 
-/// Trim the line and collapse internal whitespace runs to single spaces.
+/// Trim and collapse internal whitespace runs to single spaces.
 fn collapse_whitespace(line: &str) -> String {
     line.split_whitespace().collect::<Vec<_>>().join(" ")
 }

--- a/crates/orbit-core/src/qa/git.rs
+++ b/crates/orbit-core/src/qa/git.rs
@@ -46,12 +46,6 @@ pub(crate) fn current_branch(repo: &Path) -> Result<String, OrbitError> {
     git(repo, &["rev-parse", "--abbrev-ref", "HEAD"])
 }
 
-/// Whether the working tree has uncommitted changes (staged, unstaged, or
-/// untracked). Informational only — the sweep still validates HEAD.
-pub(crate) fn is_dirty(repo: &Path) -> Result<bool, OrbitError> {
-    Ok(!git(repo, &["status", "--porcelain"])?.is_empty())
-}
-
 /// `--oneline` summaries for `from..to`, newest first, capped at `limit`.
 ///
 /// `Ok(None)` means the range could not be resolved (e.g. the watermark

--- a/crates/orbit-core/src/qa/mod.rs
+++ b/crates/orbit-core/src/qa/mod.rs
@@ -8,22 +8,29 @@
 //! - [`config`] — the `[qa]` section of the **global** `~/.orbit/config.toml`.
 //! - [`state`] — per-workspace watermarks + the single-flight pass lock,
 //!   both under the global orbit dir.
-//! - [`fingerprint`] — failure signatures for open-task dedupe.
+//! - [`fingerprint`] — finding signatures for open-task dedupe.
+//! - [`prompt`] — composition of the QA agent prompt.
+//! - [`report`] — parsing the agent's structured findings report.
+//! - [`worker`] — the loopback client for the worker invoke daemon.
 //! - [`sweep`] — the pass itself, including run-ledger recording.
 
 pub mod config;
 pub mod fingerprint;
 mod git;
+pub mod prompt;
+pub mod report;
 pub mod state;
 pub mod sweep;
+pub mod worker;
 
 #[cfg(test)]
 mod tests;
 
-pub use config::{QaCheck, QaSweepConfig, QaWorkspaceConfig};
-pub use fingerprint::{QA_SWEEP_TAG, failure_fingerprint, fingerprint_tag};
+pub use config::{DEFAULT_WORKER_BASE_URL, QaSweepConfig, QaWorkspaceConfig};
+pub use fingerprint::{QA_SWEEP_TAG, finding_fingerprint, fingerprint_tag};
+pub use report::{Finding, QaReport, Severity, parse_report};
 pub use state::{QaSweepState, QaWorkspaceWatermark};
 pub use sweep::{
-    QA_SWEEP_JOB, QaCheckReport, QaSweepOptions, QaSweepOutcome, QaWorkspaceReport, run_qa_sweep,
+    QA_SWEEP_JOB, QaFindingReport, QaSweepOptions, QaSweepOutcome, QaWorkspaceReport, run_qa_sweep,
     run_qa_sweep_at,
 };

--- a/crates/orbit-core/src/qa/prompt.rs
+++ b/crates/orbit-core/src/qa/prompt.rs
@@ -1,0 +1,94 @@
+//! Composition of the QA agent prompt [ORB-10146].
+//!
+//! The prompt is the contract between the sweep and the QA agent: it carries
+//! the workspace, branch, and `baseline..head` commit range, and instructs the
+//! agent to identify new features / behaviour changes, exercise them hands-on
+//! (not just re-run the test suite), and emit a structured findings report as
+//! its final output. Task filing stays in the sweep — the agent only reports.
+
+/// Inputs to the QA prompt for one workspace pass.
+pub(crate) struct PromptInputs<'a> {
+    pub workspace: &'a str,
+    pub repo_root: &'a str,
+    pub branch: &'a str,
+    pub baseline: Option<&'a str>,
+    pub head: &'a str,
+    pub watermark_reset: bool,
+    /// Commit summaries in `baseline..head`, newest first (already capped).
+    pub commits: &'a [String],
+}
+
+/// Build the QA agent prompt from the pass inputs.
+pub(crate) fn compose_prompt(inputs: &PromptInputs<'_>) -> String {
+    let range = match (inputs.baseline, inputs.watermark_reset) {
+        (Some(baseline), false) => format!("{baseline}..{}", inputs.head),
+        (Some(baseline), true) => format!(
+            "history was rewritten since last validation (last-validated commit {baseline} no \
+             longer resolves); treat HEAD {} as newly landed",
+            inputs.head
+        ),
+        (None, _) => format!(
+            "first validation of this workspace; treat HEAD {} as newly landed",
+            inputs.head
+        ),
+    };
+
+    let commits = if inputs.commits.is_empty() {
+        "(commit list unavailable — inspect the range with git directly)".to_string()
+    } else {
+        inputs
+            .commits
+            .iter()
+            .map(|commit| format!("- {commit}"))
+            .collect::<Vec<_>>()
+            .join("\n")
+    };
+
+    format!(
+        "You are a QA engineer validating newly-landed work on a direct-push branch. \
+         Your job is to confirm that the NEW features and behaviour changes in this range \
+         actually work — not merely that the build is green.\n\n\
+         ## Target\n\
+         - workspace: {workspace}\n\
+         - repository root: {repo_root}\n\
+         - branch: {branch}\n\
+         - commit range: {range}\n\n\
+         ## Commits since last validation (newest first)\n\
+         {commits}\n\n\
+         ## What to do\n\
+         1. Read the diff for this range (`git diff {baseline_arg}`, `git log -p`, etc.) and \
+         identify the new features and behaviour changes it introduces.\n\
+         2. Validate each one HANDS-ON from {repo_root}: build it, run it, invoke the relevant \
+         CLI/API, drive the changed code path, and add targeted checks. Do not stop at re-running \
+         the existing test suite — exercise the new behaviour the way a user would.\n\
+         3. Record concrete issues you find: regressions, features that do not work as intended, \
+         broken behaviour changes, missing wiring. Ignore pre-existing issues unrelated to this \
+         range.\n\n\
+         ## Required final output\n\
+         End your run with a single JSON document — and nothing after it — of exactly this shape:\n\n\
+         ```json\n\
+         {{\"findings\": [\n\
+         \x20 {{\n\
+         \x20   \"name\": \"short stable slug for the issue\",\n\
+         \x20   \"severity\": \"critical|high|medium|low\",\n\
+         \x20   \"summary\": \"one-line description\",\n\
+         \x20   \"evidence\": \"how you reproduced it: commands, output, reasoning\",\n\
+         \x20   \"commits\": [\"<sha> subject\"]\n\
+         \x20 }}\n\
+         ]}}\n\
+         ```\n\n\
+         Use an EMPTY array (`{{\"findings\": []}}`) when the new work validates cleanly. \
+         Keep each `name` stable and specific so the same issue re-reported on a later sweep is \
+         recognizable. Do NOT file tasks yourself — reporting the JSON is your only deliverable.",
+        workspace = inputs.workspace,
+        repo_root = inputs.repo_root,
+        branch = inputs.branch,
+        range = range,
+        commits = commits,
+        baseline_arg = inputs
+            .baseline
+            .filter(|_| !inputs.watermark_reset)
+            .map(|baseline| format!("{baseline}..{}", inputs.head))
+            .unwrap_or_else(|| inputs.head.to_string()),
+    )
+}

--- a/crates/orbit-core/src/qa/report.rs
+++ b/crates/orbit-core/src/qa/report.rs
@@ -1,0 +1,230 @@
+//! The structured findings report a QA agent emits as its final output
+//! [ORB-10146].
+//!
+//! The QA prompt (see [`super::prompt`]) instructs the agent to end with a JSON
+//! document `{"findings": [{name, severity, summary, evidence, commits}]}` — an
+//! empty array for a clean pass. Agents wrap that JSON in prose or a ```json
+//! fence more often than not, so parsing is deliberately lenient about the
+//! surrounding text but strict about the contract: a terminal run whose output
+//! carries no parseable `findings` object is a *bad report*, and the sweep
+//! holds the watermark on it rather than recording a silent green.
+
+use orbit_common::types::TaskPriority;
+use serde::Deserialize;
+use serde_json::Value;
+
+/// A parsed QA agent report.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct QaReport {
+    /// Findings the agent reported; empty for a clean pass.
+    pub findings: Vec<Finding>,
+}
+
+/// One issue the QA agent surfaced.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Finding {
+    /// Stable signature for the issue; the dedupe fingerprint hashes it.
+    pub name: String,
+    /// Reported severity, mapped to a task priority (clamped by policy later).
+    pub severity: Severity,
+    /// One-line description of the issue.
+    pub summary: String,
+    /// Evidence the agent gathered (repro steps, output, reasoning).
+    pub evidence: String,
+    /// Commits the agent attributes the issue to.
+    pub commits: Vec<String>,
+}
+
+/// A finding's reported severity.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Severity {
+    Critical,
+    High,
+    Medium,
+    Low,
+    /// Missing or unrecognized severity; the sweep falls back to the configured
+    /// default priority.
+    Unknown,
+}
+
+impl Severity {
+    /// Lenient parse: case-insensitive, trims, maps a few common synonyms.
+    pub fn parse(raw: &str) -> Self {
+        match raw.trim().to_ascii_lowercase().as_str() {
+            "critical" | "crit" | "blocker" => Self::Critical,
+            "high" | "major" => Self::High,
+            "medium" | "moderate" | "normal" => Self::Medium,
+            "low" | "minor" | "trivial" => Self::Low,
+            _ => Self::Unknown,
+        }
+    }
+
+    /// The task priority this severity maps to, before policy clamping.
+    /// `Unknown` yields `None` so the caller substitutes the default priority.
+    pub fn mapped_priority(self) -> Option<TaskPriority> {
+        match self {
+            Self::Critical => Some(TaskPriority::Critical),
+            Self::High => Some(TaskPriority::High),
+            Self::Medium => Some(TaskPriority::Medium),
+            Self::Low => Some(TaskPriority::Low),
+            Self::Unknown => None,
+        }
+    }
+
+    /// Lowercase label for reports.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Critical => "critical",
+            Self::High => "high",
+            Self::Medium => "medium",
+            Self::Low => "low",
+            Self::Unknown => "unknown",
+        }
+    }
+}
+
+/// Rank a priority for clamping (higher = more severe).
+fn priority_rank(priority: TaskPriority) -> u8 {
+    match priority {
+        TaskPriority::Low => 0,
+        TaskPriority::Medium => 1,
+        TaskPriority::High => 2,
+        TaskPriority::Critical => 3,
+    }
+}
+
+/// Resolve a finding's task priority: map its severity (default priority when
+/// unknown), then clamp so it never exceeds the configured ceiling.
+pub(crate) fn resolve_priority(severity: Severity, ceiling: TaskPriority) -> TaskPriority {
+    let mapped = severity.mapped_priority().unwrap_or(ceiling);
+    if priority_rank(mapped) > priority_rank(ceiling) {
+        ceiling
+    } else {
+        mapped
+    }
+}
+
+/// Why a report failed to parse.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ReportParseError {
+    pub reason: String,
+}
+
+impl std::fmt::Display for ReportParseError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.reason)
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct RawReport {
+    findings: Option<Vec<RawFinding>>,
+}
+
+#[derive(Debug, Deserialize)]
+struct RawFinding {
+    name: Option<String>,
+    severity: Option<String>,
+    summary: Option<String>,
+    evidence: Option<String>,
+    commits: Option<Vec<Value>>,
+}
+
+/// Parse a QA agent's final output into a [`QaReport`].
+///
+/// Accepts the JSON document bare, inside a ```json / ``` fence, or embedded in
+/// surrounding prose (the first balanced `{...}` object that deserializes and
+/// carries a `findings` array wins). Returns an error when no such object is
+/// present — the contract requires an explicit `findings` array even for a
+/// clean pass.
+pub fn parse_report(raw: &str) -> Result<QaReport, ReportParseError> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return Err(ReportParseError {
+            reason: "empty agent output; no findings report".to_string(),
+        });
+    }
+
+    for candidate in json_candidates(trimmed) {
+        if let Ok(report) = serde_json::from_str::<RawReport>(&candidate)
+            && let Some(raw_findings) = report.findings
+        {
+            return Ok(QaReport {
+                findings: raw_findings.into_iter().map(Finding::from_raw).collect(),
+            });
+        }
+    }
+
+    Err(ReportParseError {
+        reason: "no parseable {\"findings\": [...]} object in agent output".to_string(),
+    })
+}
+
+impl Finding {
+    fn from_raw(raw: RawFinding) -> Self {
+        Self {
+            name: raw.name.unwrap_or_default().trim().to_string(),
+            severity: raw
+                .severity
+                .as_deref()
+                .map(Severity::parse)
+                .unwrap_or(Severity::Unknown),
+            summary: raw.summary.unwrap_or_default().trim().to_string(),
+            evidence: raw.evidence.unwrap_or_default().trim().to_string(),
+            commits: raw
+                .commits
+                .unwrap_or_default()
+                .into_iter()
+                .map(|value| match value {
+                    Value::String(string) => string,
+                    other => other.to_string(),
+                })
+                .filter(|commit| !commit.trim().is_empty())
+                .collect(),
+        }
+    }
+}
+
+/// Ordered JSON candidates to try: fenced blocks first, then the whole string,
+/// then the outermost balanced object embedded in prose.
+fn json_candidates(text: &str) -> Vec<String> {
+    let mut candidates = Vec::new();
+    candidates.extend(fenced_blocks(text));
+    candidates.push(text.to_string());
+    if let Some(object) = outermost_object(text) {
+        candidates.push(object);
+    }
+    candidates
+}
+
+/// Extract the contents of ``` fenced code blocks (```json or bare ```).
+fn fenced_blocks(text: &str) -> Vec<String> {
+    let mut blocks = Vec::new();
+    let mut rest = text;
+    while let Some(open) = rest.find("```") {
+        let after_open = &rest[open + 3..];
+        // Skip an optional language tag up to the newline.
+        let body_start = match after_open.find('\n') {
+            Some(newline) => newline + 1,
+            None => break,
+        };
+        let body = &after_open[body_start..];
+        let Some(close) = body.find("```") else {
+            break;
+        };
+        blocks.push(body[..close].trim().to_string());
+        rest = &body[close + 3..];
+    }
+    blocks
+}
+
+/// The substring from the first `{` to the last `}` inclusive, if both exist.
+fn outermost_object(text: &str) -> Option<String> {
+    let start = text.find('{')?;
+    let end = text.rfind('}')?;
+    if end > start {
+        Some(text[start..=end].to_string())
+    } else {
+        None
+    }
+}

--- a/crates/orbit-core/src/qa/sweep.rs
+++ b/crates/orbit-core/src/qa/sweep.rs
@@ -1,68 +1,69 @@
 //! `orbit run qa-sweep` — the trailing QA pass over direct-push workspaces
-//! [ORB-10039], sibling of `orbit run ship-sweep` (design D4).
+//! [ORB-10039], reworked to a worker-invoked QA agent pass [ORB-10146].
 //!
-//! Direct pushes to `agent-main` stay fast at write time; this sweep enforces
-//! correctness on a lag. Per configured workspace it diffs the live checkout's
-//! HEAD against a per-workspace last-validated watermark, runs the configured
-//! checks when new commits exist, files fingerprint-deduped orbit tasks for
-//! failures, and advances the watermark only on a fully green pass.
+//! Direct pushes to `agent-main` stay fast at write time; this sweep validates
+//! them on a lag. Per configured workspace it diffs the live checkout's HEAD
+//! against a per-workspace last-validated watermark and, when new commits
+//! exist, submits a **QA agent run** to the worker invoke daemon: the agent
+//! reads the new commits, exercises the new features/behaviour changes
+//! hands-on, and emits a structured findings report. The sweep parses that
+//! report, files fingerprint-deduped orbit tasks for the findings, and advances
+//! the watermark whenever the run completed and the report parsed (findings are
+//! captured as tasks, so re-validating the same range adds nothing). A failed,
+//! timed-out, or unparseable run leaves the watermark and is reported as an
+//! `error` row — never a silent green.
 //!
 //! **Ledger integration.** Every validating pass records a first-class v2 job
 //! run (job id [`QA_SWEEP_JOB`]) in the swept workspace's jobs store — one run
-//! per workspace per pass, one run step per executed check — via the same
-//! store the pipeline worker uses (`insert_run` → `mark_run_running` → per-
-//! check `complete_run_step` → `finalize_run`, plus the `JobRunStarted` /
-//! `JobRunCompleted` events). Checks execute inline in the sweep process
-//! (they are host-trusted shell commands, not agent activities), so no
-//! worker is spawned and no v2 job YAML asset exists; `orbit run history`
-//! intentionally serves run history for asset-less job ids, so
-//! `orbit run history -j qa_sweep` and `orbit run show <run_id>` surface the
-//! sweeps and their per-check steps honestly — the run record is written by
-//! the code that did the work, not a decorative side channel.
+//! per workspace per pass, with a single run step whose payload links the
+//! worker `run_id` for the agent run — so `orbit run history -j qa_sweep` and
+//! `orbit run show <run_id>` surface the sweeps honestly.
 //!
 //! Like ship-sweep, this never bootstraps a `.orbit/` in the scheduler's cwd:
 //! everything resolves from the global registry and global config, and
 //! per-workspace failures are isolated into report rows.
 
-use std::path::Path;
-use std::process::{Command, Stdio};
+use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};
 
 use chrono::Utc;
 use orbit_common::types::{
-    JobRunState, JobTargetType, OrbitError, OrbitEvent, Task, TaskStatus, TaskType, Workspace,
-    WorkspaceStatus,
+    Crew, JobRunState, JobTargetType, OrbitError, OrbitEvent, Task, TaskStatus, TaskType,
+    Workspace, WorkspaceStatus,
 };
 use orbit_store::JobRunStepParams;
-use serde_json::{Value, json};
+use serde_json::json;
 
 use crate::OrbitRuntime;
 use crate::command::task::TaskAddParams;
 use crate::config::RuntimeConfig;
 use crate::workspace_registry;
 
-use super::config::{QaCheck, QaSweepConfig, QaWorkspaceConfig};
-use super::fingerprint::{QA_SWEEP_TAG, failure_fingerprint, fingerprint_tag};
+use super::config::{QaSweepConfig, QaWorkspaceConfig};
+use super::fingerprint::{QA_SWEEP_TAG, finding_fingerprint, fingerprint_tag};
 use super::git;
+use super::prompt::{PromptInputs, compose_prompt};
+use super::report::{QaReport, parse_report, resolve_priority};
 use super::state::{QaWorkspaceWatermark, advance_watermark, load_state, state_path};
+use super::worker::{STATUS_OK, WorkerClient, WorkerError, WorkerRunRequest};
 
 /// Job id qa-sweep runs are recorded under in each workspace's run ledger.
 pub const QA_SWEEP_JOB: &str = "qa_sweep";
 
-/// Commits listed as evidence per finding (range summaries are capped; the
-/// range endpoints are always recorded in full).
-const EVIDENCE_COMMIT_LIMIT: usize = 20;
-/// Head of the combined check output quoted as evidence in filed tasks.
-const EVIDENCE_OUTPUT_LINES: usize = 40;
-const EVIDENCE_OUTPUT_BYTES: usize = 4000;
-/// Poll interval while waiting on a running check.
-const CHECK_POLL_INTERVAL: Duration = Duration::from_millis(50);
+/// Commits listed in the QA prompt / as evidence, when a per-workspace
+/// `max_commits` cap is not set.
+const EVIDENCE_COMMIT_LIMIT: usize = 30;
+/// Evidence text quoted per filed task.
+const EVIDENCE_TEXT_LINES: usize = 60;
+const EVIDENCE_TEXT_BYTES: usize = 6000;
+/// Turn budget for a QA agent run (providers that support the control).
+const QA_MAX_TURNS: u32 = 150;
 
 /// Options for one qa-sweep pass.
 #[derive(Debug, Clone, Default)]
 pub struct QaSweepOptions {
-    /// Report what would be validated without running checks, recording runs,
-    /// filing tasks, or advancing watermarks.
+    /// Report what would be validated without invoking the agent, recording
+    /// runs, filing tasks, or advancing watermarks.
     pub dry_run: bool,
     /// Restrict the pass to one configured workspace. `None` preserves the
     /// host-wide behavior used by the transitional systemd entry point.
@@ -83,25 +84,29 @@ pub struct QaSweepOutcome {
 pub struct QaWorkspaceReport {
     /// Configured workspace name.
     pub workspace: String,
-    /// One of: `validated`, `failed`, `would_validate`, `skipped`, `error`.
+    /// One of: `validated`, `error`, `would_validate`, `skipped`.
     pub action: &'static str,
     /// Why, for `skipped` / `error` rows.
     pub reason: Option<String>,
     /// Branch the checkout was validated on.
     pub branch: Option<String>,
-    /// HEAD sha the checks ran against.
+    /// Resolved crew name for the QA agent run.
+    pub crew: Option<String>,
+    /// HEAD sha the agent validated against.
     pub head: Option<String>,
     /// Watermark sha the diff was computed from (`None` = first validation).
     pub baseline: Option<String>,
-    /// Commits in `baseline..head`, capped at [`EVIDENCE_COMMIT_LIMIT`].
-    /// `None` when the baseline no longer resolves (history rewrite).
+    /// Commits in `baseline..head`, capped. `None` when the baseline no longer
+    /// resolves (history rewrite).
     pub new_commits: Option<Vec<String>>,
     /// True when the watermark existed but no longer resolves in the repo.
     pub watermark_reset: bool,
     /// Ledger run id, when a run was recorded.
     pub run_id: Option<String>,
-    /// Per-check outcomes for validating passes.
-    pub checks: Vec<QaCheckReport>,
+    /// Worker agent run id, when one was created.
+    pub agent_run_id: Option<String>,
+    /// Findings filed/deduped for a validating pass.
+    pub findings: Vec<QaFindingReport>,
 }
 
 impl QaWorkspaceReport {
@@ -118,33 +123,120 @@ impl QaWorkspaceReport {
             action,
             reason: None,
             branch: None,
+            crew: None,
             head: None,
             baseline: None,
             new_commits: None,
             watermark_reset: false,
             run_id: None,
-            checks: Vec::new(),
+            agent_run_id: None,
+            findings: Vec::new(),
         }
     }
 }
 
-/// One check's outcome within a validating pass.
+/// One finding's disposition within a validating pass.
 #[derive(Debug)]
-pub struct QaCheckReport {
-    /// Configured check name.
+pub struct QaFindingReport {
+    /// Finding name as reported by the agent.
     pub name: String,
-    /// One of: `passed`, `failed`, `timeout`, `muted`, `would_run`.
-    pub outcome: &'static str,
-    /// Exit code, when the check ran to completion.
-    pub exit_code: Option<i32>,
-    /// Wall-clock duration of the check.
-    pub duration_ms: u64,
-    /// Failure fingerprint, for failing checks.
-    pub fingerprint: Option<String>,
-    /// Task id filed for this failure, when one was created this pass.
+    /// Reported severity (lowercase).
+    pub severity: String,
+    /// Dedupe fingerprint.
+    pub fingerprint: String,
+    /// Task id filed for this finding, when one was created this pass.
     pub filed_task: Option<String>,
-    /// Open task id the failure deduped against, when one already existed.
+    /// Open task id the finding deduped against, when one already existed.
     pub deduped_task: Option<String>,
+}
+
+/// The QA agent invocation seam. Production submits to the worker daemon; tests
+/// inject a fake to exercise report parsing, dedupe, watermark rules, and
+/// worker-client failure paths without a live daemon.
+pub(crate) trait QaAgent {
+    fn run(&self, request: QaAgentRequest) -> Result<QaAgentRun, QaAgentError>;
+}
+
+/// A QA agent run request, resolved from a workspace's config + checkout.
+#[derive(Debug, Clone)]
+pub(crate) struct QaAgentRequest {
+    pub workspace: String,
+    pub repo_root: PathBuf,
+    pub provider: String,
+    pub model: String,
+    pub prompt: String,
+    pub timeout: Duration,
+}
+
+/// A QA agent run that reached a terminal state.
+#[derive(Debug, Clone)]
+pub(crate) struct QaAgentRun {
+    /// Worker run id.
+    pub agent_run_id: String,
+    /// Terminal status string.
+    pub status: String,
+    /// Final agent output text.
+    pub report_text: Option<String>,
+}
+
+/// A QA agent run that could not be completed. Carries the worker run id when
+/// one was created (e.g. a timeout) so the ledger step can still link it.
+#[derive(Debug, Clone)]
+pub(crate) struct QaAgentError {
+    pub agent_run_id: Option<String>,
+    pub message: String,
+}
+
+/// Production [`QaAgent`] backed by the loopback worker invoke daemon.
+pub(crate) struct WorkerQaAgent {
+    base_url: String,
+}
+
+impl WorkerQaAgent {
+    pub(crate) fn new(base_url: &str) -> Self {
+        Self {
+            base_url: base_url.to_string(),
+        }
+    }
+}
+
+impl QaAgent for WorkerQaAgent {
+    fn run(&self, request: QaAgentRequest) -> Result<QaAgentRun, QaAgentError> {
+        let client = WorkerClient::new(&self.base_url).map_err(|error| QaAgentError {
+            agent_run_id: None,
+            message: error.to_string(),
+        })?;
+        // Only providers with a turn control get `max_turns`; others (Codex
+        // rejects the control outright) rely on the wall-clock budget.
+        let max_turns = (request.provider == "claude").then_some(QA_MAX_TURNS);
+        let worker_request = WorkerRunRequest {
+            prompt: request.prompt,
+            provider: request.provider,
+            model: request.model,
+            cwd: request.repo_root.display().to_string(),
+            wall_clock_secs: request.timeout.as_secs().max(1),
+            max_turns,
+            serialization_key: Some(format!("qa-sweep:{}", request.workspace)),
+        };
+        match client.run_to_terminal(&worker_request, request.timeout) {
+            Ok((run_id, terminal)) => Ok(QaAgentRun {
+                agent_run_id: run_id,
+                status: terminal.status,
+                report_text: terminal.report_text,
+            }),
+            Err(WorkerError::Timeout {
+                run_id,
+                waited_secs,
+            }) => Err(QaAgentError {
+                agent_run_id: Some(run_id),
+                message: format!("agent run timed out after {waited_secs}s"),
+            }),
+            Err(other) => Err(QaAgentError {
+                agent_run_id: None,
+                message: other.to_string(),
+            }),
+        }
+    }
 }
 
 /// Run one qa-sweep pass against the default global root (`~/.orbit`).
@@ -153,10 +245,25 @@ pub fn run_qa_sweep(options: QaSweepOptions) -> Result<QaSweepOutcome, OrbitErro
     run_qa_sweep_at(&global_root, options)
 }
 
-/// Run one qa-sweep pass against an explicit global root (test seam).
+/// Run one qa-sweep pass against an explicit global root, invoking the real
+/// worker daemon.
 pub fn run_qa_sweep_at(
     global_root: &Path,
     options: QaSweepOptions,
+) -> Result<QaSweepOutcome, OrbitError> {
+    // The worker base URL is read from the same host-level `[qa]` config the
+    // rest of the pass uses; build the agent up front so a bad URL fails once.
+    let config = RuntimeConfig::load_layered(global_root, global_root)?;
+    let base_url = config.qa_sweep().worker_base_url.clone();
+    let agent = WorkerQaAgent::new(&base_url);
+    run_qa_sweep_with(global_root, options, &agent)
+}
+
+/// Run one qa-sweep pass with an injected [`QaAgent`] (test seam).
+pub(crate) fn run_qa_sweep_with(
+    global_root: &Path,
+    options: QaSweepOptions,
+    agent: &dyn QaAgent,
 ) -> Result<QaSweepOutcome, OrbitError> {
     // Host-level config only: workspace config.toml files are rewritten by
     // task-mutation commands and must never own scheduler enablement.
@@ -210,6 +317,7 @@ pub fn run_qa_sweep_at(
                 workspace,
                 baseline,
                 options.dry_run,
+                agent,
             )
             .unwrap_or_else(|error| QaWorkspaceReport {
                 reason: Some(error.to_string()),
@@ -224,6 +332,7 @@ pub fn run_qa_sweep_at(
     })
 }
 
+#[allow(clippy::too_many_arguments)]
 fn sweep_workspace(
     global_root: &Path,
     qa: &QaSweepConfig,
@@ -231,6 +340,7 @@ fn sweep_workspace(
     workspace: &Workspace,
     baseline: Option<String>,
     dry_run: bool,
+    agent: &dyn QaAgent,
 ) -> Result<QaWorkspaceReport, OrbitError> {
     if workspace.status != WorkspaceStatus::Active || !workspace.orbit_dir.exists() {
         return Ok(QaWorkspaceReport::skipped(
@@ -271,9 +381,10 @@ fn sweep_workspace(
 
     // `Some(None)` = the watermark commit no longer resolves (history
     // rewrite): treat the range as unknown and re-validate HEAD.
+    let commit_limit = ws_config.max_commits.unwrap_or(EVIDENCE_COMMIT_LIMIT);
     let ranged = baseline
         .as_deref()
-        .map(|from| git::commit_range(repo_root, from, &head, EVIDENCE_COMMIT_LIMIT))
+        .map(|from| git::commit_range(repo_root, from, &head, commit_limit))
         .transpose()?;
     let watermark_reset = matches!(ranged, Some(None));
     let new_commits = ranged.flatten();
@@ -287,21 +398,30 @@ fn sweep_workspace(
         ..QaWorkspaceReport::bare(&ws_config.name, "validated")
     };
 
+    // Resolve the crew for the QA run: the per-workspace `crew` override, else
+    // the workspace's default crew resolution [ORB-10133]. Done against the
+    // workspace's own runtime so its crew registry / default apply.
+    let runtime = OrbitRuntime::from_roots(global_root, &workspace.orbit_dir)?;
+    let crew = runtime.resolve_crew_for_task(ws_config.crew.as_deref(), None)?;
+    report.crew = Some(crew.name.clone());
+
     if dry_run {
         report.action = "would_validate";
-        report.checks = ws_config
-            .checks
-            .iter()
-            .map(|check| check_report(check, if check.mute { "muted" } else { "would_run" }, 0))
-            .collect();
         return Ok(report);
     }
 
-    let runtime = OrbitRuntime::from_roots(global_root, &workspace.orbit_dir)?;
-    let dirty = git::is_dirty(repo_root)?;
+    let prompt = compose_prompt(&PromptInputs {
+        workspace: &ws_config.name,
+        repo_root: &repo_root.display().to_string(),
+        branch: &branch,
+        baseline: baseline.as_deref(),
+        head: &head,
+        watermark_reset,
+        commits: report.new_commits.as_deref().unwrap_or_default(),
+    });
+
     let started_at = Utc::now();
     let started = Instant::now();
-
     let input = json!({
         "trigger": "qa-sweep",
         "workspace": ws_config.name,
@@ -310,11 +430,9 @@ fn sweep_workspace(
         "head": head,
         "new_commits": report.new_commits.as_ref().map(Vec::len),
         "watermark_reset": watermark_reset,
-        "dirty_working_tree": dirty,
-        "checks": ws_config.checks.iter().map(|check| json!({
-            "name": check.name,
-            "muted": check.mute,
-        })).collect::<Vec<_>>(),
+        "crew": crew.name,
+        "provider": crew.assignment.provider,
+        "model": crew.assignment.model,
     });
 
     let run = runtime
@@ -332,29 +450,66 @@ fn sweep_workspace(
     })?;
     report.run_id = Some(run.run_id.clone());
 
-    let all_green = match run_workspace_checks(&runtime, qa, ws_config, &run.run_id, &mut report) {
-        Ok(all_green) => all_green,
-        Err(error) => {
-            // Don't leave the run record dangling in `running` when the pass
-            // itself broke (spawn failure, store error): finalize it as
-            // failed, best-effort, then surface the error as this
-            // workspace's report row.
-            let _ = runtime.stores().jobs().finalize_run(
-                &run.run_id,
-                JobRunState::Failed,
-                Utc::now(),
-                Some(elapsed_ms(started)),
-            );
-            let _ = runtime.record_event(OrbitEvent::JobRunCompleted {
-                job_id: QA_SWEEP_JOB.to_string(),
-                run_id: run.run_id.clone(),
-                state: JobRunState::Failed.to_string(),
-            });
-            return Err(error);
-        }
+    // Invoke the QA agent. Errors here are pass outcomes, not sweep aborts: the
+    // ledger run is always finalized so no run dangles in `running`.
+    let outcome = agent.run(QaAgentRequest {
+        workspace: ws_config.name.clone(),
+        repo_root: repo_root.clone(),
+        provider: crew.assignment.provider.clone(),
+        model: crew.assignment.model.clone(),
+        prompt,
+        timeout: ws_config.timeout,
+    });
+    report.agent_run_id = match &outcome {
+        Ok(run) => Some(run.agent_run_id.clone()),
+        Err(error) => error.agent_run_id.clone(),
+    };
+    let terminal_status = match &outcome {
+        Ok(run) => run.status.clone(),
+        Err(_) => "no_run".to_string(),
     };
 
-    let final_state = if all_green {
+    let finalize_failed = |error: OrbitError| -> OrbitError {
+        let _ = runtime.stores().jobs().finalize_run(
+            &run.run_id,
+            JobRunState::Failed,
+            Utc::now(),
+            Some(elapsed_ms(started)),
+        );
+        let _ = runtime.record_event(OrbitEvent::JobRunCompleted {
+            job_id: QA_SWEEP_JOB.to_string(),
+            run_id: run.run_id.clone(),
+            state: JobRunState::Failed.to_string(),
+        });
+        error
+    };
+
+    let classified = classify_outcome(&outcome);
+    let (success, reason) = match &classified {
+        Ok(qa_report) => {
+            // A store error while filing is a genuine sweep failure: finalize the
+            // run failed and surface it as this workspace's error row.
+            let findings = file_findings(&runtime, qa, ws_config, &report, qa_report)
+                .map_err(finalize_failed)?;
+            report.findings = findings;
+            (true, None)
+        }
+        Err(reason) => (false, Some(reason.clone())),
+    };
+
+    record_agent_step(
+        &runtime,
+        &run.run_id,
+        started_at,
+        started,
+        &crew,
+        &report,
+        &terminal_status,
+        success,
+        reason.as_deref(),
+    )?;
+
+    let final_state = if success {
         JobRunState::Success
     } else {
         JobRunState::Failed
@@ -372,8 +527,9 @@ fn sweep_workspace(
         state: final_state.to_string(),
     })?;
 
-    if all_green {
-        // Advance to the sha the checks actually ran against; commits landing
+    if success {
+        // Findings are captured as tasks, so re-validating this range adds
+        // nothing: advance to the sha the agent ran against. Commits landing
         // mid-pass are picked up by the next sweep.
         advance_watermark(
             &state_path(global_root),
@@ -384,186 +540,144 @@ fn sweep_workspace(
                 run_id: Some(run.run_id),
             },
         )?;
+        report.action = "validated";
     } else {
-        report.action = "failed";
+        report.action = "error";
+        report.reason = reason;
     }
 
     Ok(report)
 }
 
-/// Execute the workspace's checks against the checkout, recording one ledger
-/// step per executed check and filing/deduping tasks for failures. Returns
-/// whether every executed (non-muted) check passed.
-fn run_workspace_checks(
+/// Classify the agent outcome into a parsed report (advance the watermark) or a
+/// failure reason (hold it). Only an `ok` terminal run whose output carries a
+/// parseable `findings` report counts as a completed validation.
+fn classify_outcome(outcome: &Result<QaAgentRun, QaAgentError>) -> Result<QaReport, String> {
+    match outcome {
+        Ok(run) if run.status == STATUS_OK => {
+            let text = run.report_text.as_deref().unwrap_or("");
+            parse_report(text).map_err(|error| format!("unparseable findings report: {error}"))
+        }
+        Ok(run) => Err(format!(
+            "agent run ended in non-success state '{}'",
+            run.status
+        )),
+        Err(error) => Err(error.message.clone()),
+    }
+}
+
+/// File a fingerprint-deduped task per finding, returning the per-finding
+/// disposition (filed vs deduped against an existing open task).
+fn file_findings(
     runtime: &OrbitRuntime,
     qa: &QaSweepConfig,
     ws_config: &QaWorkspaceConfig,
-    run_id: &str,
-    report: &mut QaWorkspaceReport,
-) -> Result<bool, OrbitError> {
-    let repo_root = runtime.paths().repo_root.clone();
-    let mut all_green = true;
-    let mut step_index = 0usize;
-    for check in &ws_config.checks {
-        if check.mute {
-            report.checks.push(check_report(check, "muted", 0));
+    report: &QaWorkspaceReport,
+    qa_report: &QaReport,
+) -> Result<Vec<QaFindingReport>, OrbitError> {
+    let mut filed = Vec::new();
+    for finding in &qa_report.findings {
+        let fingerprint = finding_fingerprint(&ws_config.name, &finding.name);
+        let tags = vec![QA_SWEEP_TAG.to_string(), fingerprint_tag(&fingerprint)];
+
+        let open_task = runtime
+            .list_tasks_by_tags(&tags)?
+            .into_iter()
+            .find(task_is_open);
+        if let Some(task) = open_task {
+            filed.push(QaFindingReport {
+                name: finding.name.clone(),
+                severity: finding.severity.as_str().to_string(),
+                fingerprint,
+                filed_task: None,
+                deduped_task: Some(task.id),
+            });
             continue;
         }
 
-        let step_started_at = Utc::now();
-        let execution = execute_check(&repo_root, &check.command, check.timeout)?;
-        let step_finished_at = Utc::now();
+        let priority = resolve_priority(finding.severity, qa.default_priority);
+        let task = runtime.add_task(TaskAddParams {
+            title: finding_title(ws_config, &finding.name),
+            description: finding_description(ws_config, report, finding),
+            acceptance_criteria: vec![format!(
+                "The qa-sweep finding '{}' in {} on `{}` is resolved — the new behaviour works as \
+                 intended (verified hands-on, not just a green test suite).",
+                finding.name,
+                ws_config.name,
+                report.branch.as_deref().unwrap_or("agent-main"),
+            )],
+            tags,
+            priority,
+            task_type: Some(TaskType::Bug),
+            status: Some(qa.task_status),
+            system_created: true,
+            ..TaskAddParams::default()
+        })?;
 
-        let mut entry = check_report(
-            check,
-            match (execution.timed_out, execution.exit_code) {
-                (true, _) => "timeout",
-                (false, Some(0)) => "passed",
-                (false, _) => "failed",
-            },
-            execution.duration_ms,
-        );
-        entry.exit_code = execution.exit_code;
-        let passed = entry.outcome == "passed";
-        all_green &= passed;
-
-        if !passed {
-            let finding = handle_failure(runtime, qa, ws_config, check, report, &execution)?;
-            entry.fingerprint = Some(finding.fingerprint);
-            entry.filed_task = finding.filed_task;
-            entry.deduped_task = finding.deduped_task;
-        }
-
-        runtime.stores().jobs().complete_run_step(
-            run_id,
-            &JobRunStepParams {
-                step_index,
-                target_type: JobTargetType::Job,
-                target_id: format!("{QA_SWEEP_JOB}:{}", check.name),
-                started_at: step_started_at,
-                finished_at: step_finished_at,
-                duration_ms: Some(execution.duration_ms),
-                exit_code: execution.exit_code,
-                agent_response_json: Some(step_summary_json(&entry)),
-                state: if passed {
-                    JobRunState::Success
-                } else {
-                    JobRunState::Failed
-                },
-                error_code: None,
-                error_message: (!passed).then(|| {
-                    format!(
-                        "check '{}' {}: {}",
-                        check.name,
-                        entry.outcome,
-                        evidence_excerpt(&execution.output)
-                    )
-                }),
-            },
-        )?;
-        step_index += 1;
-        report.checks.push(entry);
+        filed.push(QaFindingReport {
+            name: finding.name.clone(),
+            severity: finding.severity.as_str().to_string(),
+            fingerprint,
+            filed_task: Some(task.id),
+            deduped_task: None,
+        });
     }
-    Ok(all_green)
+    Ok(filed)
+}
+
+/// Record the single agent run step in the ledger, linking the worker run id.
+#[allow(clippy::too_many_arguments)]
+fn record_agent_step(
+    runtime: &OrbitRuntime,
+    run_id: &str,
+    started_at: chrono::DateTime<Utc>,
+    started: Instant,
+    crew: &Crew,
+    report: &QaWorkspaceReport,
+    terminal_status: &str,
+    success: bool,
+    reason: Option<&str>,
+) -> Result<(), OrbitError> {
+    let payload = json!({
+        "agent_run_id": report.agent_run_id,
+        "worker_status": terminal_status,
+        "crew": crew.name,
+        "provider": crew.assignment.provider,
+        "model": crew.assignment.model,
+        "findings": report.findings.len(),
+        "filed": report.findings.iter().filter(|f| f.filed_task.is_some()).count(),
+        "deduped": report.findings.iter().filter(|f| f.deduped_task.is_some()).count(),
+    });
+    runtime.stores().jobs().complete_run_step(
+        run_id,
+        &JobRunStepParams {
+            step_index: 0,
+            target_type: JobTargetType::Job,
+            target_id: format!("{QA_SWEEP_JOB}:agent"),
+            started_at,
+            finished_at: Utc::now(),
+            duration_ms: Some(elapsed_ms(started)),
+            exit_code: None,
+            agent_response_json: Some(payload),
+            state: if success {
+                JobRunState::Success
+            } else {
+                JobRunState::Failed
+            },
+            error_code: None,
+            error_message: reason.map(|reason| {
+                format!(
+                    "qa agent run for {} did not validate: {reason}",
+                    report.workspace
+                )
+            }),
+        },
+    )?;
+    Ok(())
 }
 
 fn elapsed_ms(started: Instant) -> u64 {
     started.elapsed().as_millis().min(u64::MAX as u128) as u64
-}
-
-fn check_report(check: &QaCheck, outcome: &'static str, duration_ms: u64) -> QaCheckReport {
-    QaCheckReport {
-        name: check.name.clone(),
-        outcome,
-        exit_code: None,
-        duration_ms,
-        fingerprint: None,
-        filed_task: None,
-        deduped_task: None,
-    }
-}
-
-fn step_summary_json(entry: &QaCheckReport) -> Value {
-    json!({
-        "check": entry.name,
-        "outcome": entry.outcome,
-        "fingerprint": entry.fingerprint,
-        "filed_task": entry.filed_task,
-        "deduped_task": entry.deduped_task,
-    })
-}
-
-struct FailureFinding {
-    fingerprint: String,
-    filed_task: Option<String>,
-    deduped_task: Option<String>,
-}
-
-/// Fingerprint a failing check, dedupe against open qa-sweep tasks carrying
-/// the same fingerprint tag, and file a task when none exists.
-fn handle_failure(
-    runtime: &OrbitRuntime,
-    qa: &QaSweepConfig,
-    ws_config: &QaWorkspaceConfig,
-    check: &QaCheck,
-    report: &QaWorkspaceReport,
-    execution: &CheckExecution,
-) -> Result<FailureFinding, OrbitError> {
-    let exit_summary = if execution.timed_out {
-        format!("timeout after {}s", check.timeout.as_secs())
-    } else {
-        match execution.exit_code {
-            Some(code) => format!("exit {code}"),
-            None => "killed by signal".to_string(),
-        }
-    };
-    let repo_root = runtime.paths().repo_root.display().to_string();
-    let fingerprint = failure_fingerprint(
-        &ws_config.name,
-        &check.name,
-        &repo_root,
-        &execution.output,
-        &exit_summary,
-    );
-    let tags = vec![QA_SWEEP_TAG.to_string(), fingerprint_tag(&fingerprint)];
-
-    let open_task = runtime
-        .list_tasks_by_tags(&tags)?
-        .into_iter()
-        .find(task_is_open);
-    if let Some(task) = open_task {
-        return Ok(FailureFinding {
-            fingerprint,
-            filed_task: None,
-            deduped_task: Some(task.id),
-        });
-    }
-
-    let task = runtime.add_task(TaskAddParams {
-        title: format!(
-            "qa-sweep: check '{}' failing in {}",
-            check.name, ws_config.name
-        ),
-        description: failure_description(ws_config, check, report, execution, &exit_summary),
-        acceptance_criteria: vec![format!(
-            "`{}` exits 0 from the {} workspace root on `{}`",
-            check.command,
-            ws_config.name,
-            report.branch.as_deref().unwrap_or("agent-main"),
-        )],
-        tags,
-        priority: check.priority.unwrap_or(qa.default_priority),
-        task_type: Some(TaskType::Bug),
-        status: Some(qa.task_status),
-        system_created: true,
-        ..TaskAddParams::default()
-    })?;
-
-    Ok(FailureFinding {
-        fingerprint,
-        filed_task: Some(task.id),
-        deduped_task: None,
-    })
 }
 
 fn task_is_open(task: &Task) -> bool {
@@ -573,12 +687,30 @@ fn task_is_open(task: &Task) -> bool {
     )
 }
 
-fn failure_description(
+/// A concise task title from a finding name (bounded, single line).
+fn finding_title(ws_config: &QaWorkspaceConfig, name: &str) -> String {
+    let clean = name.split_whitespace().collect::<Vec<_>>().join(" ");
+    let clean = if clean.is_empty() {
+        "unnamed QA finding".to_string()
+    } else {
+        clean
+    };
+    let mut title = format!("qa-sweep: {clean} ({})", ws_config.name);
+    if title.len() > 120 {
+        let mut cut = 117;
+        while !title.is_char_boundary(cut) {
+            cut -= 1;
+        }
+        title.truncate(cut);
+        title.push_str("...");
+    }
+    title
+}
+
+fn finding_description(
     ws_config: &QaWorkspaceConfig,
-    check: &QaCheck,
     report: &QaWorkspaceReport,
-    execution: &CheckExecution,
-    exit_summary: &str,
+    finding: &super::report::Finding,
 ) -> String {
     let range = match (&report.baseline, report.watermark_reset) {
         (Some(baseline), false) => format!(
@@ -602,158 +734,64 @@ fn failure_description(
         .filter(|commits| !commits.is_empty())
         .map(|commits| format!("\nCommits since last green:\n{}\n", commits.join("\n")))
         .unwrap_or_default();
+    let finding_commits = if finding.commits.is_empty() {
+        String::new()
+    } else {
+        format!(
+            "\nAttributed commits:\n{}\n",
+            finding
+                .commits
+                .iter()
+                .map(|commit| format!("- {commit}"))
+                .collect::<Vec<_>>()
+                .join("\n")
+        )
+    };
 
     format!(
-        "Automated qa-sweep finding.\n\n\
+        "Automated qa-sweep finding (QA agent pass).\n\n\
+         - finding: {name}\n\
          - workspace: {workspace}\n\
-         - check: {check_name} (`sh -c {command}`)\n\
          - branch: {branch}\n\
-         - result: {exit_summary}\n\
+         - severity: {severity}\n\
          - commit range since last green: {range}\n\
          - ledger run: {run} (`orbit run show <run_id>` in the workspace)\n\
-         {commits}\n\
-         Output (head):\n```text\n{output}\n```\n",
+         - worker agent run: {agent_run}\n\
+         {commits}{finding_commits}\n\
+         Summary: {summary}\n\n\
+         Evidence:\n```text\n{evidence}\n```\n",
+        name = finding.name,
         workspace = ws_config.name,
-        check_name = check.name,
-        command = check.command,
         branch = report.branch.as_deref().unwrap_or("agent-main"),
+        severity = finding.severity.as_str(),
         run = report.run_id.as_deref().unwrap_or("not recorded"),
-        output = evidence_excerpt(&execution.output),
+        agent_run = report.agent_run_id.as_deref().unwrap_or("not recorded"),
+        summary = if finding.summary.is_empty() {
+            "(none provided)"
+        } else {
+            finding.summary.as_str()
+        },
+        evidence = evidence_excerpt(&finding.evidence),
     )
 }
 
-/// Head of the combined output, bounded in lines and bytes.
-fn evidence_excerpt(output: &str) -> String {
-    let mut excerpt = output
+/// Head of the evidence text, bounded in lines and bytes.
+fn evidence_excerpt(evidence: &str) -> String {
+    let mut excerpt = evidence
         .lines()
-        .take(EVIDENCE_OUTPUT_LINES)
+        .take(EVIDENCE_TEXT_LINES)
         .collect::<Vec<_>>()
         .join("\n");
-    if excerpt.len() > EVIDENCE_OUTPUT_BYTES {
-        let mut cut = EVIDENCE_OUTPUT_BYTES;
+    if excerpt.len() > EVIDENCE_TEXT_BYTES {
+        let mut cut = EVIDENCE_TEXT_BYTES;
         while !excerpt.is_char_boundary(cut) {
             cut -= 1;
         }
         excerpt.truncate(cut);
     }
     if excerpt.trim().is_empty() {
-        "(no output)".to_string()
+        "(no evidence provided)".to_string()
     } else {
         excerpt
     }
-}
-
-pub(super) struct CheckExecution {
-    pub(super) exit_code: Option<i32>,
-    pub(super) timed_out: bool,
-    pub(super) output: String,
-    pub(super) duration_ms: u64,
-}
-
-/// Run one check via `sh -c` from the workspace root, killing it once the
-/// configured timeout elapses. stdout and stderr are captured off-thread (so
-/// a chatty check cannot deadlock on a full pipe) and concatenated
-/// stdout-then-stderr for evidence and fingerprinting.
-///
-/// On Unix the check runs in its own session/process group and a timeout
-/// kills the whole group — otherwise grandchildren (a `make` fanning out to
-/// compilers, a shell forking `sleep`) would survive the kill and keep the
-/// output pipes open, wedging the sweep until they exit on their own.
-pub(super) fn execute_check(
-    repo_root: &Path,
-    command: &str,
-    timeout: Duration,
-) -> Result<CheckExecution, OrbitError> {
-    let started = Instant::now();
-    let mut builder = Command::new("sh");
-    builder
-        .arg("-c")
-        .arg(command)
-        .current_dir(repo_root)
-        .stdin(Stdio::null())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped());
-    #[cfg(unix)]
-    unsafe {
-        use std::os::unix::process::CommandExt;
-        builder.pre_exec(|| {
-            if libc::setsid() == -1 {
-                return Err(std::io::Error::last_os_error());
-            }
-            Ok(())
-        });
-    }
-    let mut child = builder.spawn().map_err(|error| {
-        OrbitError::Execution(format!("spawn check `sh -c {command}`: {error}"))
-    })?;
-
-    let stdout = drain_off_thread(child.stdout.take());
-    let stderr = drain_off_thread(child.stderr.take());
-
-    let mut timed_out = false;
-    let status = loop {
-        match child.try_wait() {
-            Ok(Some(status)) => break Some(status),
-            Ok(None) => {
-                if started.elapsed() >= timeout {
-                    timed_out = true;
-                    kill_check_group(&mut child);
-                    break child.wait().ok();
-                }
-                std::thread::sleep(CHECK_POLL_INTERVAL);
-            }
-            Err(error) => {
-                return Err(OrbitError::Execution(format!(
-                    "wait on check `{command}`: {error}"
-                )));
-            }
-        }
-    };
-
-    let mut output = stdout.join().unwrap_or_default();
-    let err_output = stderr.join().unwrap_or_default();
-    if !err_output.is_empty() {
-        if !output.is_empty() && !output.ends_with('\n') {
-            output.push('\n');
-        }
-        output.push_str(&err_output);
-    }
-
-    Ok(CheckExecution {
-        exit_code: if timed_out {
-            None
-        } else {
-            status.and_then(|status| status.code())
-        },
-        timed_out,
-        output,
-        duration_ms: started.elapsed().as_millis().min(u64::MAX as u128) as u64,
-    })
-}
-
-/// Kill a timed-out check together with its process group (Unix) so orphaned
-/// grandchildren cannot hold the captured pipes open.
-fn kill_check_group(child: &mut std::process::Child) {
-    #[cfg(unix)]
-    {
-        let pid = child.id() as libc::pid_t;
-        // The check was made its own session leader in `pre_exec`, so its pid
-        // is the process-group id; negative pid targets the whole group.
-        unsafe {
-            libc::kill(-pid, libc::SIGKILL);
-        }
-    }
-    let _ = child.kill();
-}
-
-fn drain_off_thread<R: std::io::Read + Send + 'static>(
-    source: Option<R>,
-) -> std::thread::JoinHandle<String> {
-    std::thread::spawn(move || {
-        let mut buffer = Vec::new();
-        if let Some(mut source) = source {
-            let _ = std::io::Read::read_to_end(&mut source, &mut buffer);
-        }
-        String::from_utf8_lossy(&buffer).into_owned()
-    })
 }

--- a/crates/orbit-core/src/qa/tests/config.rs
+++ b/crates/orbit-core/src/qa/tests/config.rs
@@ -1,6 +1,7 @@
-//! `[qa]` config validation tests [ORB-10039]: the section is fail-closed —
-//! a typo'd priority/status or an empty check list must be a config error,
-//! never a sweep that silently validates nothing.
+//! `[qa]` config validation tests [ORB-10039, reworked ORB-10146]: the section
+//! is fail-closed — a typo'd priority/status, a bad worker URL, or a leftover
+//! legacy `[[qa.workspace.check]]` table must be a config error, never a sweep
+//! that silently validates nothing.
 
 use std::time::Duration;
 
@@ -8,6 +9,7 @@ use orbit_common::types::{OrbitError, TaskPriority, TaskStatus};
 
 use crate::config::RuntimeConfig;
 use crate::qa::QaSweepConfig;
+use crate::qa::config::DEFAULT_WORKER_BASE_URL;
 
 /// Parse a config.toml document through the exact production pipeline and
 /// return its resolved `[qa]` section.
@@ -23,28 +25,17 @@ const FULL: &str = r#"
 [qa]
 default_priority = "high"
 task_status = "proposed"
+base_url = "http://127.0.0.1:9099/"
 
 [[qa.workspace]]
 name = "polaris"
 branch = "agent-main"
-
-[[qa.workspace.check]]
-name = "frontmatter"
-command = "python3 scripts/check_frontmatter.py"
-
-[[qa.workspace.check]]
-name = "lint"
-command = "make lint"
-mute = true
-priority = "critical"
-timeout_minutes = 5
+crew = "opus"
+timeout_minutes = 90
+max_commits = 10
 
 [[qa.workspace]]
 name = "bridge"
-
-[[qa.workspace.check]]
-name = "tests"
-command = "pytest -q"
 "#;
 
 #[test]
@@ -52,22 +43,22 @@ fn full_section_parses_with_overrides_and_defaults() {
     let qa = qa_from_toml(FULL).expect("valid config");
     assert_eq!(qa.default_priority, TaskPriority::High);
     assert_eq!(qa.task_status, TaskStatus::Proposed);
+    // Trailing slash is trimmed.
+    assert_eq!(qa.worker_base_url, "http://127.0.0.1:9099");
     assert_eq!(qa.workspaces.len(), 2);
 
     let polaris = qa.workspace("polaris").expect("polaris entry");
     assert_eq!(polaris.branch.as_deref(), Some("agent-main"));
-    assert_eq!(polaris.checks.len(), 2);
-    let frontmatter = &polaris.checks[0];
-    assert!(!frontmatter.mute);
-    assert_eq!(frontmatter.priority, None);
-    assert_eq!(frontmatter.timeout, Duration::from_secs(30 * 60));
-    let lint = &polaris.checks[1];
-    assert!(lint.mute);
-    assert_eq!(lint.priority, Some(TaskPriority::Critical));
-    assert_eq!(lint.timeout, Duration::from_secs(5 * 60));
+    assert_eq!(polaris.crew.as_deref(), Some("opus"));
+    assert_eq!(polaris.timeout, Duration::from_secs(90 * 60));
+    assert_eq!(polaris.max_commits, Some(10));
 
-    // Branch defaults to None (resolved from the registry at sweep time).
-    assert_eq!(qa.workspace("bridge").expect("bridge entry").branch, None);
+    // Bridge: branch/crew default to None, timeout to the 120-minute default.
+    let bridge = qa.workspace("bridge").expect("bridge entry");
+    assert_eq!(bridge.branch, None);
+    assert_eq!(bridge.crew, None);
+    assert_eq!(bridge.timeout, Duration::from_secs(120 * 60));
+    assert_eq!(bridge.max_commits, None);
 }
 
 #[test]
@@ -76,6 +67,7 @@ fn absent_section_resolves_to_empty_defaults() {
     assert_eq!(qa, QaSweepConfig::default());
     assert!(qa.workspaces.is_empty());
     assert_eq!(qa.default_priority, TaskPriority::Medium);
+    assert_eq!(qa.worker_base_url, DEFAULT_WORKER_BASE_URL);
     // Backlog by default: design D4 wants the loop to close without a human
     // courier (ship-sweep can dispatch the fix).
     assert_eq!(qa.task_status, TaskStatus::Backlog);
@@ -105,38 +97,31 @@ fn invalid_task_status_is_rejected() {
 }
 
 #[test]
-fn workspace_without_checks_is_rejected() {
-    assert_invalid(
-        "[[qa.workspace]]\nname = \"polaris\"\n",
-        "at least one [[qa.workspace.check]]",
-    );
+fn empty_base_url_is_rejected() {
+    assert_invalid("[qa]\nbase_url = \"  \"\n", "qa.base_url");
 }
 
 #[test]
-fn check_without_command_is_rejected() {
-    assert_invalid(
-        "[[qa.workspace]]\nname = \"polaris\"\n[[qa.workspace.check]]\nname = \"lint\"\n",
-        "command must be set",
-    );
-}
-
-#[test]
-fn duplicate_check_names_are_rejected() {
+fn legacy_check_config_fails_with_a_migration_error() {
     assert_invalid(
         "[[qa.workspace]]\nname = \"polaris\"\n\
-         [[qa.workspace.check]]\nname = \"lint\"\ncommand = \"a\"\n\
-         [[qa.workspace.check]]\nname = \"lint\"\ncommand = \"b\"\n",
-        "more than once",
+         [[qa.workspace.check]]\nname = \"lint\"\ncommand = \"make lint\"\n",
+        "removed inline shell checks",
+    );
+}
+
+#[test]
+fn empty_crew_is_rejected() {
+    assert_invalid(
+        "[[qa.workspace]]\nname = \"polaris\"\ncrew = \"  \"\n",
+        "crew must not be empty",
     );
 }
 
 #[test]
 fn duplicate_workspaces_are_rejected() {
     assert_invalid(
-        "[[qa.workspace]]\nname = \"polaris\"\n\
-         [[qa.workspace.check]]\nname = \"lint\"\ncommand = \"a\"\n\
-         [[qa.workspace]]\nname = \"polaris\"\n\
-         [[qa.workspace.check]]\nname = \"lint\"\ncommand = \"a\"\n",
+        "[[qa.workspace]]\nname = \"polaris\"\n[[qa.workspace]]\nname = \"polaris\"\n",
         "more than once",
     );
 }
@@ -144,8 +129,20 @@ fn duplicate_workspaces_are_rejected() {
 #[test]
 fn zero_timeout_is_rejected() {
     assert_invalid(
-        "[[qa.workspace]]\nname = \"polaris\"\n\
-         [[qa.workspace.check]]\nname = \"lint\"\ncommand = \"a\"\ntimeout_minutes = 0\n",
+        "[[qa.workspace]]\nname = \"polaris\"\ntimeout_minutes = 0\n",
         "timeout_minutes",
     );
+}
+
+#[test]
+fn zero_max_commits_is_rejected() {
+    assert_invalid(
+        "[[qa.workspace]]\nname = \"polaris\"\nmax_commits = 0\n",
+        "max_commits",
+    );
+}
+
+#[test]
+fn workspace_without_name_is_rejected() {
+    assert_invalid("[[qa.workspace]]\nbranch = \"agent-main\"\n", "name");
 }

--- a/crates/orbit-core/src/qa/tests/fingerprint.rs
+++ b/crates/orbit-core/src/qa/tests/fingerprint.rs
@@ -1,98 +1,58 @@
-//! Fingerprint stability tests [ORB-10039]: the same failure must hash the
-//! same across reruns (ANSI, whitespace, host paths, tail churn scrubbed),
-//! while distinct failures stay distinct.
+//! Finding-fingerprint tests [ORB-10039, reworked ORB-10146]: the fingerprint
+//! must be stable across reruns of the same finding (so one open task per
+//! issue) while staying distinct across workspaces and finding names.
 
-use crate::qa::fingerprint::{failure_fingerprint, fingerprint_tag, normalized_output_head};
+use crate::qa::fingerprint::{finding_fingerprint, fingerprint_tag, normalize_signature};
 
 const WS: &str = "polaris";
-const CHECK: &str = "lint";
-const ROOT: &str = "/home/user/workspace/polaris";
+const NAME: &str = "login redirect loops on expired session";
 
 #[test]
-fn identical_failures_share_a_fingerprint() {
-    let output = "error: broken frontmatter in docs/a.md\nexpected key 'title'";
-    let first = failure_fingerprint(WS, CHECK, ROOT, output, "exit 1");
-    let second = failure_fingerprint(WS, CHECK, ROOT, output, "exit 1");
+fn same_finding_hashes_stably() {
+    let first = finding_fingerprint(WS, NAME);
+    let second = finding_fingerprint(WS, NAME);
     assert_eq!(first, second);
-    assert_eq!(first.len(), 12);
-    assert!(first.chars().all(|ch| ch.is_ascii_hexdigit()));
+    assert_eq!(first.len(), 12, "12 hex chars");
 }
 
 #[test]
-fn workspace_check_and_output_all_discriminate() {
-    let output = "error: broken";
-    let base = failure_fingerprint(WS, CHECK, ROOT, output, "exit 1");
+fn workspace_and_name_change_the_fingerprint() {
+    let base = finding_fingerprint(WS, NAME);
+    assert_ne!(base, finding_fingerprint("bridge", NAME));
     assert_ne!(
         base,
-        failure_fingerprint("bridge", CHECK, ROOT, output, "exit 1")
-    );
-    assert_ne!(
-        base,
-        failure_fingerprint(WS, "tests", ROOT, output, "exit 1")
-    );
-    assert_ne!(
-        base,
-        failure_fingerprint(WS, CHECK, ROOT, "error: different", "exit 1")
+        finding_fingerprint(WS, "a completely different issue")
     );
 }
 
 #[test]
-fn ansi_whitespace_and_repo_root_are_normalized_away() {
-    let plain = format!("error in {ROOT}/docs/a.md\nline two");
-    let noisy = format!("\u{1b}[31merror   in\t{ROOT}/docs/a.md\u{1b}[0m\r\n\n   line   two   \n");
-    assert_eq!(
-        failure_fingerprint(WS, CHECK, ROOT, &plain, "exit 1"),
-        failure_fingerprint(WS, CHECK, ROOT, &noisy, "exit 1"),
+fn formatting_and_case_differences_collapse() {
+    let plain = finding_fingerprint(WS, NAME);
+    let noisy = finding_fingerprint(WS, "  Login   Redirect Loops On Expired Session  ");
+    assert_eq!(plain, noisy, "whitespace + case normalized");
+
+    let with_ansi = finding_fingerprint(
+        WS,
+        "\u{1b}[31mlogin redirect loops on expired session\u{1b}[0m",
     );
-    // The other direction: a different repo root must not change the hash.
-    assert_eq!(
-        failure_fingerprint(WS, CHECK, ROOT, &plain, "exit 1"),
-        failure_fingerprint(
-            WS,
-            CHECK,
-            "/srv/polaris",
-            &plain.replace(ROOT, "/srv/polaris"),
-            "exit 1"
-        ),
-    );
+    assert_eq!(plain, with_ansi, "ANSI escapes stripped");
 }
 
 #[test]
-fn tail_churn_beyond_the_head_window_is_ignored() {
-    let head: String = (0..25).map(|i| format!("error line {i}\n")).collect();
-    let with_timing = format!("{head}finished in 12.3s\n");
-    let with_other_timing = format!("{head}finished in 45.6s\n");
-    assert_eq!(
-        failure_fingerprint(WS, CHECK, ROOT, &with_timing, "exit 1"),
-        failure_fingerprint(WS, CHECK, ROOT, &with_other_timing, "exit 1"),
-    );
+fn blank_name_falls_back_to_a_stable_signature() {
+    let empty = finding_fingerprint(WS, "");
+    let whitespace = finding_fingerprint(WS, "   \n  ");
+    assert_eq!(empty, whitespace);
+    // Still distinct per workspace.
+    assert_ne!(empty, finding_fingerprint("bridge", ""));
 }
 
 #[test]
-fn silent_failures_fall_back_to_the_exit_summary() {
-    let exit_1 = failure_fingerprint(WS, CHECK, ROOT, "", "exit 1");
-    let exit_2 = failure_fingerprint(WS, CHECK, ROOT, "", "exit 2");
-    let timeout = failure_fingerprint(WS, CHECK, ROOT, "", "timeout after 1800s");
-    assert_ne!(exit_1, exit_2);
-    assert_ne!(exit_1, timeout);
-    // Deterministic: same silent failure, same hash.
-    assert_eq!(
-        exit_1,
-        failure_fingerprint(WS, CHECK, ROOT, "\n  \n", "exit 1")
-    );
+fn fingerprint_tag_prefixes_fp() {
+    assert_eq!(fingerprint_tag("abc123"), "fp-abc123");
 }
 
 #[test]
-fn normalized_head_drops_blank_lines_and_caps_at_twenty() {
-    let output = "  a  \n\n\nb\tc\n".to_string() + &"x\n".repeat(40);
-    let head = normalized_output_head(&output, ROOT);
-    let lines: Vec<&str> = head.lines().collect();
-    assert_eq!(lines[0], "a");
-    assert_eq!(lines[1], "b c");
-    assert_eq!(lines.len(), 20);
-}
-
-#[test]
-fn tag_shape_is_stable() {
-    assert_eq!(fingerprint_tag("abc123def456"), "fp-abc123def456");
+fn normalize_signature_lowercases_and_collapses() {
+    assert_eq!(normalize_signature("  Foo   BAR  "), "foo bar");
 }

--- a/crates/orbit-core/src/qa/tests/mod.rs
+++ b/crates/orbit-core/src/qa/tests/mod.rs
@@ -1,4 +1,6 @@
 mod config;
 mod fingerprint;
+mod report;
 mod state;
 mod sweep;
+mod worker;

--- a/crates/orbit-core/src/qa/tests/report.rs
+++ b/crates/orbit-core/src/qa/tests/report.rs
@@ -1,0 +1,112 @@
+//! QA findings-report parsing tests [ORB-10146]: agents wrap their JSON in
+//! prose or fences, so parsing is lenient about the surroundings but strict
+//! about the contract — a terminal run with no parseable `findings` object is a
+//! bad report the sweep must not treat as a clean pass.
+
+use orbit_common::types::TaskPriority;
+
+use crate::qa::report::{Severity, parse_report, resolve_priority};
+
+#[test]
+fn parses_bare_json_object() {
+    let report = parse_report(
+        r#"{"findings":[{"name":"broken login","severity":"high","summary":"loops","evidence":"repro","commits":["abc feat"]}]}"#,
+    )
+    .expect("parse");
+    assert_eq!(report.findings.len(), 1);
+    let finding = &report.findings[0];
+    assert_eq!(finding.name, "broken login");
+    assert_eq!(finding.severity, Severity::High);
+    assert_eq!(finding.summary, "loops");
+    assert_eq!(finding.evidence, "repro");
+    assert_eq!(finding.commits, vec!["abc feat".to_string()]);
+}
+
+#[test]
+fn empty_findings_is_a_clean_pass() {
+    let report = parse_report(r#"{"findings": []}"#).expect("parse");
+    assert!(report.findings.is_empty());
+}
+
+#[test]
+fn extracts_json_from_a_fenced_block_amid_prose() {
+    let raw = "I validated the changes hands-on. Here is my report:\n\n\
+               ```json\n\
+               {\"findings\": [{\"name\": \"cli flag ignored\", \"severity\": \"medium\"}]}\n\
+               ```\n\n\
+               Let me know if you need more detail.";
+    let report = parse_report(raw).expect("parse");
+    assert_eq!(report.findings.len(), 1);
+    assert_eq!(report.findings[0].name, "cli flag ignored");
+    assert_eq!(report.findings[0].severity, Severity::Medium);
+}
+
+#[test]
+fn extracts_embedded_object_without_a_fence() {
+    let raw = "Final report: {\"findings\": [{\"name\": \"x\", \"severity\": \"low\"}]} done.";
+    let report = parse_report(raw).expect("parse");
+    assert_eq!(report.findings.len(), 1);
+    assert_eq!(report.findings[0].severity, Severity::Low);
+}
+
+#[test]
+fn missing_findings_key_is_an_error() {
+    // Valid JSON, but not the contract: must not be treated as a clean pass.
+    assert!(parse_report(r#"{"result": "all good"}"#).is_err());
+}
+
+#[test]
+fn non_json_output_is_an_error() {
+    assert!(parse_report("The build passed and everything looks fine.").is_err());
+}
+
+#[test]
+fn empty_output_is_an_error() {
+    assert!(parse_report("   \n  ").is_err());
+}
+
+#[test]
+fn unknown_severity_falls_back_to_unknown() {
+    let report = parse_report(r#"{"findings":[{"name":"n","severity":"spicy"}]}"#).expect("parse");
+    assert_eq!(report.findings[0].severity, Severity::Unknown);
+}
+
+#[test]
+fn commits_accepts_non_string_values() {
+    let report =
+        parse_report(r#"{"findings":[{"name":"n","commits":["a subj", 42, ""]}]}"#).expect("parse");
+    // Blank entries dropped, non-strings stringified.
+    assert_eq!(
+        report.findings[0].commits,
+        vec!["a subj".to_string(), "42".to_string()]
+    );
+}
+
+// ---- severity -> priority mapping + clamping -------------------------------
+
+#[test]
+fn severity_maps_and_clamps_to_ceiling() {
+    // High severity clamps down to a medium ceiling.
+    assert_eq!(
+        resolve_priority(Severity::High, TaskPriority::Medium),
+        TaskPriority::Medium
+    );
+    // Low severity stays low even under a high ceiling.
+    assert_eq!(
+        resolve_priority(Severity::Low, TaskPriority::High),
+        TaskPriority::Low
+    );
+    // Critical under a critical ceiling stays critical.
+    assert_eq!(
+        resolve_priority(Severity::Critical, TaskPriority::Critical),
+        TaskPriority::Critical
+    );
+}
+
+#[test]
+fn unknown_severity_uses_the_ceiling_as_default() {
+    assert_eq!(
+        resolve_priority(Severity::Unknown, TaskPriority::High),
+        TaskPriority::High
+    );
+}

--- a/crates/orbit-core/src/qa/tests/sweep.rs
+++ b/crates/orbit-core/src/qa/tests/sweep.rs
@@ -1,10 +1,13 @@
-//! qa-sweep pass tests [ORB-10039]: end-to-end over a seeded global root and
-//! a real temp git repo — watermark advance/hold, ledger run recording,
-//! fingerprint dedupe, mute handling, branch guard, dry-run inertness.
+//! qa-sweep pass tests [ORB-10039, reworked ORB-10146]: end-to-end over a
+//! seeded global root and a real temp git repo, with an injected fake QA agent
+//! standing in for the worker daemon. Covers watermark advance/hold rules,
+//! ledger run recording, finding-task filing + fingerprint dedupe, severity
+//! clamping, the prompt contract, dry-run inertness, the branch guard, and the
+//! worker-client failure paths (daemon down, timeout, bad JSON, non-success).
 
 use std::path::{Path, PathBuf};
 use std::process::Command;
-use std::time::Duration;
+use std::sync::Mutex;
 
 use chrono::Utc;
 use orbit_common::types::{
@@ -14,11 +17,68 @@ use tempfile::TempDir;
 
 use crate::OrbitRuntime;
 use crate::qa::state::{load_state, state_path};
-use crate::qa::sweep::execute_check;
-use crate::qa::{QA_SWEEP_JOB, QA_SWEEP_TAG, QaSweepOptions, run_qa_sweep_at};
+use crate::qa::sweep::{
+    QaAgent, QaAgentError, QaAgentRequest, QaAgentRun, QaWorkspaceReport, run_qa_sweep_with,
+};
+use crate::qa::{QA_SWEEP_JOB, QA_SWEEP_TAG, QaSweepOptions};
 use crate::workspace_registry;
 
 const WS_NAME: &str = "polaris";
+
+// ---- fake QA agent ---------------------------------------------------------
+
+/// A [`QaAgent`] that returns a canned outcome and records the last prompt it
+/// was handed, so tests can exercise every pass branch without a live daemon.
+struct FakeAgent {
+    result: Result<QaAgentRun, QaAgentError>,
+    last_prompt: Mutex<Option<String>>,
+    calls: Mutex<usize>,
+}
+
+impl FakeAgent {
+    fn new(result: Result<QaAgentRun, QaAgentError>) -> Self {
+        Self {
+            result,
+            last_prompt: Mutex::new(None),
+            calls: Mutex::new(0),
+        }
+    }
+
+    /// Agent that completes `ok` with the given findings-report text.
+    fn reporting(report: &str) -> Self {
+        Self::new(Ok(QaAgentRun {
+            agent_run_id: "wrk-1".to_string(),
+            status: "ok".to_string(),
+            report_text: Some(report.to_string()),
+        }))
+    }
+
+    fn called(&self) -> usize {
+        *self.calls.lock().unwrap()
+    }
+
+    fn last_prompt(&self) -> Option<String> {
+        self.last_prompt.lock().unwrap().clone()
+    }
+}
+
+impl QaAgent for FakeAgent {
+    fn run(&self, request: QaAgentRequest) -> Result<QaAgentRun, QaAgentError> {
+        *self.calls.lock().unwrap() += 1;
+        *self.last_prompt.lock().unwrap() = Some(request.prompt);
+        self.result.clone()
+    }
+}
+
+const CLEAN: &str = r#"{"findings": []}"#;
+
+fn one_finding(name: &str, severity: &str) -> String {
+    format!(
+        r#"{{"findings":[{{"name":"{name}","severity":"{severity}","summary":"broken","evidence":"repro steps","commits":["abc feat"]}}]}}"#
+    )
+}
+
+// ---- fixture ---------------------------------------------------------------
 
 struct Fixture {
     _tmp: TempDir,
@@ -28,13 +88,13 @@ struct Fixture {
 }
 
 impl Fixture {
-    /// Sweep once (non-dry) and return the single workspace report.
-    fn sweep(&self) -> crate::qa::QaWorkspaceReport {
-        self.sweep_with(QaSweepOptions::default())
+    /// Sweep once (non-dry) with `agent` and return the single workspace report.
+    fn sweep(&self, agent: &dyn QaAgent) -> QaWorkspaceReport {
+        self.sweep_with(QaSweepOptions::default(), agent)
     }
 
-    fn sweep_with(&self, options: QaSweepOptions) -> crate::qa::QaWorkspaceReport {
-        let mut outcome = run_qa_sweep_at(&self.global, options).expect("sweep pass");
+    fn sweep_with(&self, options: QaSweepOptions, agent: &dyn QaAgent) -> QaWorkspaceReport {
+        let mut outcome = run_qa_sweep_with(&self.global, options, agent).expect("sweep pass");
         assert!(!outcome.lock_busy, "pass lock unexpectedly busy");
         assert_eq!(outcome.reports.len(), 1, "one configured workspace");
         outcome.reports.remove(0)
@@ -57,17 +117,17 @@ impl Fixture {
 
     fn commit(&self, name: &str) {
         std::fs::write(self.repo.join(name), name).expect("write file");
-        git(&self.repo, &["add", "."]);
+        // Stage only the named file: `git add .` races with the live SQLite WAL
+        // files the sweep's runtime writes under `.orbit/`.
+        git(&self.repo, &["add", name]);
         git(&self.repo, &["commit", "-m", &format!("add {name}")]);
     }
 }
 
-/// Seed a global root + registered git workspace whose `[qa]` section carries
-/// the given `[[qa.workspace.check]]` entries (TOML snippet).
-fn fixture(checks_toml: &str) -> Fixture {
-    fixture_with_qa(&format!(
-        "[qa]\n\n[[qa.workspace]]\nname = \"{WS_NAME}\"\n{checks_toml}"
-    ))
+/// Seed a global root + registered git workspace with the default `[qa]`
+/// section (one workspace, no crew override → default crew resolution).
+fn fixture() -> Fixture {
+    fixture_with_qa(&format!("[qa]\n\n[[qa.workspace]]\nname = \"{WS_NAME}\"\n"))
 }
 
 fn fixture_with_qa(qa_toml: &str) -> Fixture {
@@ -83,7 +143,7 @@ fn fixture_with_qa(qa_toml: &str) -> Fixture {
     git(&repo, &["init", "--quiet"]);
     git(&repo, &["checkout", "-q", "-b", "agent-main"]);
     std::fs::write(repo.join("README.md"), "seed").expect("seed file");
-    git(&repo, &["add", "."]);
+    git(&repo, &["add", "README.md"]);
     git(&repo, &["commit", "-q", "-m", "seed"]);
 
     let mut registry = WorkspaceRegistry::default();
@@ -139,29 +199,30 @@ fn git_command(repo: &Path, args: &[&str]) -> Command {
     command
 }
 
-const PASSING_CHECK: &str = "[[qa.workspace.check]]\nname = \"ok\"\ncommand = \"echo fine\"\n";
-const FAILING_CHECK: &str =
-    "[[qa.workspace.check]]\nname = \"broken\"\ncommand = \"echo boom >&2; exit 3\"\n";
-
-// ---- green / skip / watermark ---------------------------------------------
+// ---- clean pass / watermark advance ----------------------------------------
 
 #[test]
-fn green_pass_records_ledger_run_and_advances_watermark() {
-    let fixture = fixture(PASSING_CHECK);
+fn clean_pass_records_ledger_run_and_advances_watermark() {
+    let fixture = fixture();
     let head = fixture.head();
+    let agent = FakeAgent::reporting(CLEAN);
 
-    let report = fixture.sweep();
+    let report = fixture.sweep(&agent);
     assert_eq!(report.action, "validated", "reason: {:?}", report.reason);
     assert_eq!(report.baseline, None, "first validation has no baseline");
     assert_eq!(report.head.as_deref(), Some(head.as_str()));
-    assert_eq!(report.checks.len(), 1);
-    assert_eq!(report.checks[0].outcome, "passed");
-    assert_eq!(report.checks[0].exit_code, Some(0));
+    assert!(report.findings.is_empty());
+    assert_eq!(
+        report.crew.as_deref(),
+        Some("claude"),
+        "default crew resolved"
+    );
+    assert_eq!(report.agent_run_id.as_deref(), Some("wrk-1"));
 
     // Watermark advanced to the validated HEAD.
     assert_eq!(fixture.watermark().as_deref(), Some(head.as_str()));
 
-    // The pass is a first-class ledger run with one step per executed check.
+    // The pass is a first-class ledger run with one agent step linking the run.
     let runtime = fixture.runtime();
     let runs = runtime.job_history(QA_SWEEP_JOB).expect("qa_sweep history");
     assert_eq!(runs.len(), 1);
@@ -172,14 +233,79 @@ fn green_pass_records_ledger_run_and_advances_watermark() {
 }
 
 #[test]
-fn unchanged_head_is_skipped_without_a_run() {
-    let fixture = fixture(PASSING_CHECK);
-    assert_eq!(fixture.sweep().action, "validated");
+fn findings_are_filed_as_deduped_tasks_and_watermark_advances() {
+    // default_priority critical so a high-severity finding maps straight to High.
+    let fixture = fixture_with_qa(&format!(
+        "[qa]\ndefault_priority = \"critical\"\n\n[[qa.workspace]]\nname = \"{WS_NAME}\"\n"
+    ));
+    let head = fixture.head();
+    let agent = FakeAgent::reporting(&one_finding("login-loops", "high"));
 
-    let report = fixture.sweep();
+    let report = fixture.sweep(&agent);
+    assert_eq!(report.action, "validated");
+    assert_eq!(report.findings.len(), 1);
+    let finding = &report.findings[0];
+    assert_eq!(finding.severity, "high");
+    let task_id = finding.filed_task.clone().expect("task filed");
+    assert!(finding.deduped_task.is_none());
+
+    // Findings captured as tasks → watermark advances (re-validating adds nothing).
+    assert_eq!(fixture.watermark().as_deref(), Some(head.as_str()));
+
+    let runtime = fixture.runtime();
+    let tasks = runtime.list_tasks().expect("list tasks");
+    assert_eq!(tasks.len(), 1);
+    let task = &tasks[0];
+    assert_eq!(task.id, task_id);
+    assert_eq!(task.status, TaskStatus::Backlog, "default files as backlog");
+    assert_eq!(
+        task.priority,
+        TaskPriority::High,
+        "severity high under critical ceiling"
+    );
+    assert!(task.tags.contains(&QA_SWEEP_TAG.to_string()));
+    assert!(task.tags.contains(&format!("fp-{}", finding.fingerprint)));
+    assert!(
+        task.description.contains("repro steps"),
+        "evidence attached"
+    );
+    assert!(task.description.contains("login-loops"));
+
+    let runs = runtime.job_history(QA_SWEEP_JOB).expect("history");
+    assert_eq!(
+        runs[0].state,
+        JobRunState::Success,
+        "findings still validate the pass"
+    );
+}
+
+#[test]
+fn severity_is_clamped_to_the_default_priority_ceiling() {
+    // default ceiling medium: a critical finding is clamped down.
+    let fixture = fixture();
+    let agent = FakeAgent::reporting(&one_finding("data-loss", "critical"));
+    let report = fixture.sweep(&agent);
+    let task_id = report.findings[0].filed_task.clone().expect("filed");
+
+    let runtime = fixture.runtime();
+    let task = runtime.get_task(&task_id).expect("task");
+    assert_eq!(task.priority, TaskPriority::Medium, "clamped to ceiling");
+}
+
+#[test]
+fn unchanged_head_is_skipped_without_a_run() {
+    let fixture = fixture();
+    assert_eq!(
+        fixture.sweep(&FakeAgent::reporting(CLEAN)).action,
+        "validated"
+    );
+
+    let agent = FakeAgent::reporting(CLEAN);
+    let report = fixture.sweep(&agent);
     assert_eq!(report.action, "skipped");
     assert_eq!(report.reason.as_deref(), Some("no_new_commits"));
     assert!(report.run_id.is_none());
+    assert_eq!(agent.called(), 0, "no agent invoked on a skip");
 
     let runtime = fixture.runtime();
     assert_eq!(
@@ -191,98 +317,159 @@ fn unchanged_head_is_skipped_without_a_run() {
 
 #[test]
 fn new_commits_are_revalidated_with_the_range_reported() {
-    let fixture = fixture(PASSING_CHECK);
-    assert_eq!(fixture.sweep().action, "validated");
+    let fixture = fixture();
+    assert_eq!(
+        fixture.sweep(&FakeAgent::reporting(CLEAN)).action,
+        "validated"
+    );
     let baseline = fixture.watermark().expect("baseline");
 
     fixture.commit("one.txt");
     fixture.commit("two.txt");
     let head = fixture.head();
 
-    let report = fixture.sweep();
+    let report = fixture.sweep(&FakeAgent::reporting(CLEAN));
     assert_eq!(report.action, "validated");
     assert_eq!(report.baseline.as_deref(), Some(baseline.as_str()));
     assert_eq!(report.new_commits.as_ref().map(Vec::len), Some(2));
     assert_eq!(fixture.watermark().as_deref(), Some(head.as_str()));
 }
 
-// ---- failures: task filing, dedupe, watermark hold -------------------------
+// ---- worker-client failure paths (watermark held, error row) ---------------
 
 #[test]
-fn failing_check_files_a_tagged_task_and_holds_the_watermark() {
-    let fixture = fixture(FAILING_CHECK);
-    let report = fixture.sweep();
+fn non_success_run_holds_watermark_and_files_no_task() {
+    let fixture = fixture();
+    let agent = FakeAgent::new(Ok(QaAgentRun {
+        agent_run_id: "wrk-9".to_string(),
+        status: "error".to_string(),
+        report_text: Some("crashed".to_string()),
+    }));
 
-    assert_eq!(report.action, "failed");
-    assert_eq!(report.checks[0].outcome, "failed");
-    assert_eq!(report.checks[0].exit_code, Some(3));
-    let fingerprint = report.checks[0].fingerprint.clone().expect("fingerprint");
-    let task_id = report.checks[0].filed_task.clone().expect("task filed");
-    assert!(report.checks[0].deduped_task.is_none());
-
-    // Failure never advances the watermark.
-    assert_eq!(fixture.watermark(), None);
-
-    // The task carries evidence and the dedupe tags.
-    let runtime = fixture.runtime();
-    let tasks = runtime.list_tasks().expect("list tasks");
-    assert_eq!(tasks.len(), 1);
-    let task = &tasks[0];
-    assert_eq!(task.id, task_id);
-    assert_eq!(task.status, TaskStatus::Backlog, "default files as backlog");
-    assert_eq!(task.priority, TaskPriority::Medium);
-    assert!(task.tags.contains(&QA_SWEEP_TAG.to_string()));
-    assert!(task.tags.contains(&format!("fp-{fingerprint}")));
-    assert!(task.description.contains("boom"), "output excerpt attached");
+    let report = fixture.sweep(&agent);
+    assert_eq!(report.action, "error");
     assert!(
-        task.description
-            .contains(&report.run_id.clone().expect("run id")),
-        "ledger run referenced"
+        report
+            .reason
+            .as_deref()
+            .is_some_and(|r| r.contains("non-success")),
+        "reason: {:?}",
+        report.reason
+    );
+    assert_eq!(report.agent_run_id.as_deref(), Some("wrk-9"));
+    assert_eq!(
+        fixture.watermark(),
+        None,
+        "failure never advances the watermark"
     );
 
-    // The ledger run is failed, with the failing step carrying the evidence.
+    let runtime = fixture.runtime();
+    assert!(runtime.list_tasks().expect("tasks").is_empty());
     let runs = runtime.job_history(QA_SWEEP_JOB).expect("history");
-    assert_eq!(runs.len(), 1);
     assert_eq!(runs[0].state, JobRunState::Failed);
     assert_eq!(runs[0].steps.len(), 1);
     assert_eq!(runs[0].steps[0].state, JobRunState::Failed);
+}
+
+#[test]
+fn unparseable_report_holds_watermark() {
+    let fixture = fixture();
+    let agent = FakeAgent::reporting("the build looked fine to me, no JSON here");
+
+    let report = fixture.sweep(&agent);
+    assert_eq!(report.action, "error");
     assert!(
-        runs[0].steps[0]
-            .error_message
+        report
+            .reason
             .as_deref()
-            .is_some_and(|message| message.contains("boom"))
+            .is_some_and(|r| r.contains("unparseable")),
+        "reason: {:?}",
+        report.reason
+    );
+    assert_eq!(fixture.watermark(), None);
+
+    let runtime = fixture.runtime();
+    assert_eq!(
+        runtime.job_history(QA_SWEEP_JOB).expect("history")[0].state,
+        JobRunState::Failed
     );
 }
 
 #[test]
-fn repeated_failure_dedupes_against_the_open_task() {
-    let fixture = fixture(FAILING_CHECK);
-    let first = fixture.sweep();
-    let filed = first.checks[0].filed_task.clone().expect("task filed");
+fn daemon_down_holds_watermark_but_records_a_failed_ledger_run() {
+    let fixture = fixture();
+    let agent = FakeAgent::new(Err(QaAgentError {
+        agent_run_id: None,
+        message: "worker daemon unreachable: connection refused".to_string(),
+    }));
 
-    // New commit, same breakage: no second task.
+    let report = fixture.sweep(&agent);
+    assert_eq!(report.action, "error");
+    assert!(
+        report
+            .reason
+            .as_deref()
+            .is_some_and(|r| r.contains("unreachable"))
+    );
+    assert!(report.agent_run_id.is_none());
+    assert_eq!(fixture.watermark(), None);
+
+    // A ledger run is still recorded for the swept workspace (finalized failed).
+    let runtime = fixture.runtime();
+    let runs = runtime.job_history(QA_SWEEP_JOB).expect("history");
+    assert_eq!(runs.len(), 1);
+    assert_eq!(runs[0].state, JobRunState::Failed);
+    assert_eq!(runs[0].steps.len(), 1);
+}
+
+#[test]
+fn timeout_preserves_the_worker_run_id_on_the_report() {
+    let fixture = fixture();
+    let agent = FakeAgent::new(Err(QaAgentError {
+        agent_run_id: Some("wrk-timeout".to_string()),
+        message: "agent run timed out after 7200s".to_string(),
+    }));
+
+    let report = fixture.sweep(&agent);
+    assert_eq!(report.action, "error");
+    assert_eq!(report.agent_run_id.as_deref(), Some("wrk-timeout"));
+    assert_eq!(fixture.watermark(), None);
+}
+
+// ---- dedupe / refile -------------------------------------------------------
+
+#[test]
+fn repeated_finding_dedupes_against_the_open_task() {
+    let fixture = fixture();
+    let first = fixture.sweep(&FakeAgent::reporting(&one_finding("flaky-x", "medium")));
+    let filed = first.findings[0].filed_task.clone().expect("task filed");
+
+    // New commit, same finding name: no second task.
     fixture.commit("more.txt");
-    let second = fixture.sweep();
-    assert_eq!(second.action, "failed");
-    assert_eq!(second.checks[0].filed_task, None);
+    let second = fixture.sweep(&FakeAgent::reporting(&one_finding("flaky-x", "medium")));
+    assert_eq!(second.action, "validated");
+    assert_eq!(second.findings[0].filed_task, None);
     assert_eq!(
-        second.checks[0].deduped_task.as_deref(),
+        second.findings[0].deduped_task.as_deref(),
         Some(filed.as_str())
     );
-    assert_eq!(second.checks[0].fingerprint, first.checks[0].fingerprint);
+    assert_eq!(
+        second.findings[0].fingerprint,
+        first.findings[0].fingerprint
+    );
 
     let runtime = fixture.runtime();
     let qa_tasks = runtime
         .list_tasks_by_tags(&[QA_SWEEP_TAG.to_string()])
         .expect("tag query");
-    assert_eq!(qa_tasks.len(), 1, "one open task per distinct failure");
+    assert_eq!(qa_tasks.len(), 1, "one open task per distinct finding");
 }
 
 #[test]
-fn closed_task_with_same_fingerprint_is_refiled() {
-    let fixture = fixture(FAILING_CHECK);
-    let first = fixture.sweep();
-    let filed = first.checks[0].filed_task.clone().expect("task filed");
+fn closed_task_with_same_finding_is_refiled() {
+    let fixture = fixture();
+    let first = fixture.sweep(&FakeAgent::reporting(&one_finding("regression-y", "high")));
+    let filed = first.findings[0].filed_task.clone().expect("task filed");
 
     // Close the finding without fixing it; a recurrence must file anew.
     let runtime = fixture.runtime();
@@ -301,82 +488,59 @@ fn closed_task_with_same_fingerprint_is_refiled() {
     drop(runtime);
 
     fixture.commit("again.txt");
-    let second = fixture.sweep();
-    let refiled = second.checks[0].filed_task.clone().expect("refiled task");
+    let second = fixture.sweep(&FakeAgent::reporting(&one_finding("regression-y", "high")));
+    let refiled = second.findings[0].filed_task.clone().expect("refiled task");
     assert_ne!(refiled, filed);
-    assert_eq!(second.checks[0].deduped_task, None);
+    assert_eq!(second.findings[0].deduped_task, None);
 }
 
+// ---- prompt contract -------------------------------------------------------
+
 #[test]
-fn per_check_priority_override_applies_to_the_filed_task() {
-    let fixture = fixture(
-        "[[qa.workspace.check]]\nname = \"broken\"\ncommand = \"exit 1\"\npriority = \"critical\"\n",
+fn prompt_carries_the_range_and_commit_list() {
+    let fixture = fixture();
+    assert_eq!(
+        fixture.sweep(&FakeAgent::reporting(CLEAN)).action,
+        "validated"
     );
-    let report = fixture.sweep();
-    let task_id = report.checks[0].filed_task.clone().expect("task filed");
-
-    let runtime = fixture.runtime();
-    let tasks = runtime.list_tasks().expect("list tasks");
-    let task = tasks.iter().find(|task| task.id == task_id).expect("task");
-    assert_eq!(task.priority, TaskPriority::Critical);
-}
-
-// ---- mutes, branch guard, dry-run, misconfig -------------------------------
-
-#[test]
-fn muted_failing_check_does_not_block_a_green_pass() {
-    let fixture = fixture(&format!(
-        "{PASSING_CHECK}\
-         [[qa.workspace.check]]\nname = \"flaky\"\ncommand = \"exit 1\"\nmute = true\n"
-    ));
+    let baseline = fixture.watermark().expect("baseline");
+    fixture.commit("feature.txt");
     let head = fixture.head();
 
-    let report = fixture.sweep();
-    assert_eq!(report.action, "validated");
-    let flaky = report
-        .checks
-        .iter()
-        .find(|check| check.name == "flaky")
-        .expect("flaky check reported");
-    assert_eq!(flaky.outcome, "muted");
-    assert!(flaky.filed_task.is_none(), "muted checks never file tasks");
-    assert_eq!(fixture.watermark().as_deref(), Some(head.as_str()));
-
-    // Muted checks are not executed, so no ledger step exists for them.
-    let runtime = fixture.runtime();
-    let runs = runtime.job_history(QA_SWEEP_JOB).expect("history");
-    assert_eq!(runs[0].steps.len(), 1);
-}
-
-#[test]
-fn checkout_on_another_branch_is_skipped() {
-    let fixture = fixture(PASSING_CHECK);
-    git(&fixture.repo, &["checkout", "-q", "-b", "task/side-branch"]);
-
-    let report = fixture.sweep();
-    assert_eq!(report.action, "skipped");
+    let agent = FakeAgent::reporting(CLEAN);
+    fixture.sweep(&agent);
+    let prompt = agent.last_prompt().expect("prompt captured");
     assert!(
-        report
-            .reason
-            .as_deref()
-            .is_some_and(|reason| reason.contains("not_on_branch")),
-        "reason: {:?}",
-        report.reason
+        prompt.contains(&format!("{baseline}..{head}")),
+        "range in prompt"
     );
-    assert_eq!(fixture.watermark(), None);
+    assert!(
+        prompt.contains("add feature.txt"),
+        "commit subject in prompt"
+    );
+    assert!(prompt.contains("findings"), "JSON contract in prompt");
+    assert!(prompt.contains(WS_NAME), "workspace named");
 }
 
+// ---- dry-run, branch guard, misconfig --------------------------------------
+
 #[test]
-fn dry_run_reports_but_records_nothing() {
-    let fixture = fixture(FAILING_CHECK);
-    let report = fixture.sweep_with(QaSweepOptions {
-        dry_run: true,
-        ..QaSweepOptions::default()
-    });
+fn dry_run_reports_but_records_nothing_and_never_invokes_the_agent() {
+    let fixture = fixture();
+    let agent = FakeAgent::reporting(&one_finding("x", "high"));
+    let report = fixture.sweep_with(
+        QaSweepOptions {
+            dry_run: true,
+            ..QaSweepOptions::default()
+        },
+        &agent,
+    );
 
     assert_eq!(report.action, "would_validate");
-    assert_eq!(report.checks[0].outcome, "would_run");
+    assert_eq!(report.crew.as_deref(), Some("claude"));
+    assert!(report.findings.is_empty());
     assert!(report.run_id.is_none());
+    assert_eq!(agent.called(), 0, "dry run never invokes the agent");
     assert_eq!(fixture.watermark(), None);
 
     let runtime = fixture.runtime();
@@ -392,18 +556,37 @@ fn dry_run_reports_but_records_nothing() {
 }
 
 #[test]
+fn checkout_on_another_branch_is_skipped() {
+    let fixture = fixture();
+    git(&fixture.repo, &["checkout", "-q", "-b", "task/side-branch"]);
+
+    let agent = FakeAgent::reporting(CLEAN);
+    let report = fixture.sweep(&agent);
+    assert_eq!(report.action, "skipped");
+    assert!(
+        report
+            .reason
+            .as_deref()
+            .is_some_and(|reason| reason.contains("not_on_branch")),
+        "reason: {:?}",
+        report.reason
+    );
+    assert_eq!(agent.called(), 0);
+    assert_eq!(fixture.watermark(), None);
+}
+
+#[test]
 fn workspace_filter_excludes_other_configured_workspaces() {
     let fixture = fixture_with_qa(&format!(
-        "[qa]\n\n[[qa.workspace]]\nname = \"{WS_NAME}\"\n{PASSING_CHECK}\n\
-         [[qa.workspace]]\nname = \"ghost\"\n\
-         [[qa.workspace.check]]\nname = \"ok\"\ncommand = \"true\"\n"
+        "[qa]\n\n[[qa.workspace]]\nname = \"{WS_NAME}\"\n\n[[qa.workspace]]\nname = \"ghost\"\n"
     ));
-    let outcome = run_qa_sweep_at(
+    let outcome = run_qa_sweep_with(
         &fixture.global,
         QaSweepOptions {
             dry_run: true,
             workspace: Some(WS_NAME.to_string()),
         },
+        &FakeAgent::reporting(CLEAN),
     )
     .expect("filtered sweep");
 
@@ -414,11 +597,13 @@ fn workspace_filter_excludes_other_configured_workspaces() {
 
 #[test]
 fn unregistered_configured_workspace_is_an_error_row() {
-    let fixture = fixture_with_qa(
-        "[qa]\n\n[[qa.workspace]]\nname = \"ghost\"\n\
-         [[qa.workspace.check]]\nname = \"ok\"\ncommand = \"true\"\n",
-    );
-    let outcome = run_qa_sweep_at(&fixture.global, QaSweepOptions::default()).expect("sweep");
+    let fixture = fixture_with_qa("[qa]\n\n[[qa.workspace]]\nname = \"ghost\"\n");
+    let outcome = run_qa_sweep_with(
+        &fixture.global,
+        QaSweepOptions::default(),
+        &FakeAgent::reporting(CLEAN),
+    )
+    .expect("sweep");
     assert_eq!(outcome.reports.len(), 1);
     assert_eq!(outcome.reports[0].action, "error");
     assert!(
@@ -432,33 +617,11 @@ fn unregistered_configured_workspace_is_an_error_row() {
 #[test]
 fn no_configured_workspaces_is_a_clean_noop() {
     let fixture = fixture_with_qa("[workflow]\nbase_branch = \"agent-main\"\n");
-    let outcome = run_qa_sweep_at(&fixture.global, QaSweepOptions::default()).expect("sweep");
-    assert!(outcome.reports.is_empty());
-}
-
-// ---- check execution --------------------------------------------------------
-
-#[test]
-fn execute_check_captures_both_streams_and_exit_code() {
-    let dir = tempfile::tempdir().expect("tempdir");
-    let execution = execute_check(
-        dir.path(),
-        "echo out; echo err >&2; exit 3",
-        Duration::from_secs(10),
+    let outcome = run_qa_sweep_with(
+        &fixture.global,
+        QaSweepOptions::default(),
+        &FakeAgent::reporting(CLEAN),
     )
-    .expect("run check");
-    assert_eq!(execution.exit_code, Some(3));
-    assert!(!execution.timed_out);
-    assert!(execution.output.contains("out"));
-    assert!(execution.output.contains("err"));
-}
-
-#[test]
-fn execute_check_kills_and_flags_a_hung_command() {
-    let dir = tempfile::tempdir().expect("tempdir");
-    let execution =
-        execute_check(dir.path(), "sleep 30", Duration::from_millis(200)).expect("run check");
-    assert!(execution.timed_out);
-    assert_eq!(execution.exit_code, None);
-    assert!(execution.duration_ms < 10_000, "killed promptly");
+    .expect("sweep");
+    assert!(outcome.reports.is_empty());
 }

--- a/crates/orbit-core/src/qa/tests/worker.rs
+++ b/crates/orbit-core/src/qa/tests/worker.rs
@@ -1,0 +1,175 @@
+//! Loopback worker-client tests [ORB-10146]: request-body shaping, response
+//! parsing, terminal classification, the poll-until-terminal timeout, and the
+//! daemon-down failure path — all without a live daemon.
+
+use std::cell::Cell;
+use std::time::Duration;
+
+use crate::qa::worker::{
+    WorkerClient, WorkerError, WorkerRunRequest, WorkerRunStatus, await_terminal,
+    build_invoke_body, is_terminal, parse_run_status, parse_submit_response,
+};
+
+fn request(provider: &str, max_turns: Option<u32>) -> WorkerRunRequest {
+    WorkerRunRequest {
+        prompt: "validate the new feature".to_string(),
+        provider: provider.to_string(),
+        model: "opus".to_string(),
+        cwd: "/repo".to_string(),
+        wall_clock_secs: 7200,
+        max_turns,
+        serialization_key: Some("qa-sweep:polaris".to_string()),
+    }
+}
+
+#[test]
+fn invoke_body_carries_prompt_provider_cwd_and_limits() {
+    let body = build_invoke_body(&request("claude", Some(150)));
+    assert_eq!(body["prompt"], "validate the new feature");
+    assert_eq!(body["provider"], "claude");
+    assert_eq!(body["model"], "opus");
+    assert_eq!(body["cwd"], "/repo");
+    assert_eq!(body["limits"]["wall_clock_secs"], 7200);
+    assert_eq!(body["limits"]["max_turns"], 150);
+    assert_eq!(body["serialization_key"], "qa-sweep:polaris");
+}
+
+#[test]
+fn invoke_body_omits_max_turns_when_unset() {
+    // Codex rejects `max_turns`; the caller passes None there.
+    let body = build_invoke_body(&request("codex", None));
+    assert!(body["limits"].get("max_turns").is_none());
+    assert_eq!(body["limits"]["wall_clock_secs"], 7200);
+}
+
+#[test]
+fn parses_run_id_from_submit_response() {
+    let run_id =
+        parse_submit_response(r#"{"run_id":"abc-123","status":"queued"}"#).expect("run id");
+    assert_eq!(run_id, "abc-123");
+}
+
+#[test]
+fn submit_response_without_run_id_is_a_bad_response() {
+    match parse_submit_response(r#"{"status":"queued"}"#) {
+        Err(WorkerError::BadResponse(_)) => {}
+        other => panic!("expected BadResponse, got {other:?}"),
+    }
+}
+
+#[test]
+fn submit_response_that_is_not_json_is_a_bad_response() {
+    assert!(matches!(
+        parse_submit_response("<html>502</html>"),
+        Err(WorkerError::BadResponse(_))
+    ));
+}
+
+#[test]
+fn parses_status_and_result_text_from_run_record() {
+    let status = parse_run_status(r#"{"status":"ok","result":{"result":"done","completed":true}}"#)
+        .expect("status");
+    assert_eq!(status.status, "ok");
+    assert_eq!(status.report_text.as_deref(), Some("done"));
+}
+
+#[test]
+fn parses_bare_string_result_on_dispatch_failure() {
+    let status =
+        parse_run_status(r#"{"status":"error","result":"claude not found"}"#).expect("status");
+    assert_eq!(status.status, "error");
+    assert_eq!(status.report_text.as_deref(), Some("claude not found"));
+}
+
+#[test]
+fn run_status_missing_status_is_a_bad_response() {
+    assert!(matches!(
+        parse_run_status(r#"{"result":{"result":"x"}}"#),
+        Err(WorkerError::BadResponse(_))
+    ));
+}
+
+#[test]
+fn terminal_statuses_are_recognized() {
+    for status in [
+        "ok",
+        "error",
+        "timeout",
+        "max_turns",
+        "cost_exceeded",
+        "cancelled",
+        "interrupted",
+    ] {
+        assert!(is_terminal(status), "{status} should be terminal");
+    }
+    for status in ["queued", "running", "unknown"] {
+        assert!(!is_terminal(status), "{status} should not be terminal");
+    }
+}
+
+#[test]
+fn await_terminal_returns_immediately_on_a_terminal_status() {
+    let terminal = await_terminal(
+        Duration::from_secs(5),
+        Duration::from_millis(1),
+        "r",
+        || {
+            Ok(WorkerRunStatus {
+                status: "ok".to_string(),
+                report_text: Some("report".to_string()),
+            })
+        },
+    )
+    .expect("terminal");
+    assert_eq!(terminal.status, "ok");
+    assert_eq!(terminal.report_text.as_deref(), Some("report"));
+}
+
+#[test]
+fn await_terminal_times_out_on_a_run_that_never_finishes() {
+    let polls = Cell::new(0u32);
+    let result = await_terminal(
+        Duration::from_millis(40),
+        Duration::from_millis(2),
+        "run-x",
+        || {
+            polls.set(polls.get() + 1);
+            Ok(WorkerRunStatus {
+                status: "running".to_string(),
+                report_text: None,
+            })
+        },
+    );
+    match result {
+        Err(WorkerError::Timeout { run_id, .. }) => assert_eq!(run_id, "run-x"),
+        other => panic!("expected Timeout, got {other:?}"),
+    }
+    assert!(polls.get() >= 1, "polled at least once");
+}
+
+#[test]
+fn await_terminal_propagates_a_poll_error() {
+    let result = await_terminal(
+        Duration::from_secs(5),
+        Duration::from_millis(1),
+        "r",
+        || Err(WorkerError::Poll("boom".to_string())),
+    );
+    assert!(matches!(result, Err(WorkerError::Poll(_))));
+}
+
+#[test]
+fn submit_to_a_dead_daemon_reports_unreachable() {
+    // Port 9 (discard) is not served on loopback; the connection is refused.
+    let client = WorkerClient::new("http://127.0.0.1:9").expect("client");
+    let result = client.submit(&request("claude", Some(150)));
+    // A connection refusal classifies as an unreachable daemon; any sandbox
+    // that blocks the connect still surfaces a typed error, never a hang.
+    assert!(result.is_err(), "dead daemon must be an error");
+    if let Err(error) = &result {
+        assert!(
+            matches!(error, WorkerError::Unreachable(_)),
+            "expected Unreachable, got {error:?}"
+        );
+    }
+}

--- a/crates/orbit-core/src/qa/worker.rs
+++ b/crates/orbit-core/src/qa/worker.rs
@@ -1,0 +1,319 @@
+//! Loopback client for the worker invoke daemon [ORB-10146].
+//!
+//! qa-sweep v2 submits a QA agent run per workspace to the worker daemon (the
+//! same loopback service bridge's `agent_invoke` uses): `POST /invoke` enqueues
+//! a run and returns a `run_id` (202, async), `GET /runs/{run_id}` polls it to a
+//! terminal state, and `DELETE /runs/{run_id}` cancels it. The final agent
+//! output text lives in `result.result` on a terminal run record.
+//!
+//! The HTTP surface is a thin wrapper; the request-body construction, response
+//! parsing, terminal-state classification, and poll-until-terminal loop are all
+//! pure/injectable so the sweep's worker-client failure paths (daemon down,
+//! timeout, bad JSON) are unit-testable without a live daemon.
+
+use std::time::{Duration, Instant};
+
+use reqwest::blocking::Client;
+use serde_json::Value;
+
+/// Per-request HTTP timeout for submit/poll/cancel calls. The daemon answers
+/// these promptly (`/invoke` is async); the *run's* budget is enforced by the
+/// worker via `limits.wall_clock_secs`, not this timeout.
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
+/// Interval between run-status polls.
+pub(crate) const POLL_INTERVAL: Duration = Duration::from_secs(5);
+
+/// Terminal worker run statuses (from the daemon's `RunStatus` enum). Any other
+/// status (`queued`, `running`, `unknown`) means keep polling.
+const TERMINAL_STATUSES: &[&str] = &[
+    "ok",
+    "error",
+    "timeout",
+    "max_turns",
+    "cost_exceeded",
+    "cancelled",
+    "interrupted",
+];
+
+/// The status a successfully-completed run reports.
+pub(crate) const STATUS_OK: &str = "ok";
+
+/// One QA agent run request to the worker daemon.
+#[derive(Debug, Clone)]
+pub(crate) struct WorkerRunRequest {
+    /// The composed QA prompt.
+    pub prompt: String,
+    /// Worker provider family (`claude`, `codex`, `gemini`, `grok`).
+    pub provider: String,
+    /// Provider model string.
+    pub model: String,
+    /// Working directory for the run (the workspace repo root).
+    pub cwd: String,
+    /// Wall-clock budget in seconds (`limits.wall_clock_secs`).
+    pub wall_clock_secs: u64,
+    /// Turn budget (`limits.max_turns`); omitted for providers that reject it
+    /// (notably Codex), so the caller passes `None` there.
+    pub max_turns: Option<u32>,
+    /// Explicit serialization lease key so concurrent sweeps do not run two
+    /// agents against the same checkout at once.
+    pub serialization_key: Option<String>,
+}
+
+/// A run's status as seen by one poll.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct WorkerRunStatus {
+    /// Raw status string.
+    pub status: String,
+    /// Final agent output text, present once the run has executed.
+    pub report_text: Option<String>,
+}
+
+/// A run that reached a terminal state.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct WorkerTerminal {
+    /// Terminal status string (`ok`, `error`, `timeout`, ...).
+    pub status: String,
+    /// Final agent output text, when present.
+    pub report_text: Option<String>,
+}
+
+/// Failure of a worker interaction.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum WorkerError {
+    /// Could not connect to the daemon (down / wrong URL).
+    Unreachable(String),
+    /// Submit was rejected or otherwise failed.
+    Submit(String),
+    /// A poll request failed.
+    Poll(String),
+    /// A response was not the expected JSON shape.
+    BadResponse(String),
+    /// The run did not reach a terminal state within the budget.
+    Timeout { run_id: String, waited_secs: u64 },
+}
+
+impl std::fmt::Display for WorkerError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Unreachable(message) => write!(f, "worker daemon unreachable: {message}"),
+            Self::Submit(message) => write!(f, "worker run submission failed: {message}"),
+            Self::Poll(message) => write!(f, "worker run poll failed: {message}"),
+            Self::BadResponse(message) => write!(f, "worker returned a bad response: {message}"),
+            Self::Timeout {
+                run_id,
+                waited_secs,
+            } => write!(
+                f,
+                "worker run {run_id} did not finish within {waited_secs}s"
+            ),
+        }
+    }
+}
+
+/// Blocking loopback client for the worker invoke daemon.
+pub(crate) struct WorkerClient {
+    base_url: String,
+    http: Client,
+}
+
+impl WorkerClient {
+    /// Build a client against `base_url` (no trailing slash).
+    pub(crate) fn new(base_url: &str) -> Result<Self, WorkerError> {
+        let http = Client::builder()
+            .timeout(REQUEST_TIMEOUT)
+            .build()
+            .map_err(|error| WorkerError::Submit(format!("build http client: {error}")))?;
+        Ok(Self {
+            base_url: base_url.trim_end_matches('/').to_string(),
+            http,
+        })
+    }
+
+    /// Submit a run and return its `run_id` (does not wait for completion).
+    pub(crate) fn submit(&self, request: &WorkerRunRequest) -> Result<String, WorkerError> {
+        let body = build_invoke_body(request);
+        let response = self
+            .http
+            .post(format!("{}/invoke", self.base_url))
+            .json(&body)
+            .send()
+            .map_err(|error| send_error("submit run", error))?;
+        let status = response.status();
+        let text = response
+            .text()
+            .map_err(|error| WorkerError::BadResponse(format!("read /invoke body: {error}")))?;
+        if !status.is_success() {
+            return Err(WorkerError::Submit(format!(
+                "worker /invoke returned HTTP {}: {}",
+                status.as_u16(),
+                text.trim()
+            )));
+        }
+        parse_submit_response(&text)
+    }
+
+    /// Fetch one run's current status.
+    pub(crate) fn get_run(&self, run_id: &str) -> Result<WorkerRunStatus, WorkerError> {
+        let response = self
+            .http
+            .get(format!("{}/runs/{run_id}", self.base_url))
+            .send()
+            .map_err(|error| send_error("poll run", error))?;
+        let status = response.status();
+        let text = response
+            .text()
+            .map_err(|error| WorkerError::BadResponse(format!("read /runs body: {error}")))?;
+        if !status.is_success() {
+            return Err(WorkerError::Poll(format!(
+                "worker /runs/{run_id} returned HTTP {}: {}",
+                status.as_u16(),
+                text.trim()
+            )));
+        }
+        parse_run_status(&text)
+    }
+
+    /// Best-effort cancel of a run (used when the sweep gives up on a timeout).
+    pub(crate) fn cancel(&self, run_id: &str) {
+        let _ = self
+            .http
+            .delete(format!("{}/runs/{run_id}", self.base_url))
+            .send();
+    }
+
+    /// Submit a run and poll it to a terminal state, cancelling on timeout.
+    pub(crate) fn run_to_terminal(
+        &self,
+        request: &WorkerRunRequest,
+        timeout: Duration,
+    ) -> Result<(String, WorkerTerminal), WorkerError> {
+        let run_id = self.submit(request)?;
+        match await_terminal(timeout, POLL_INTERVAL, &run_id, || self.get_run(&run_id)) {
+            Ok(terminal) => Ok((run_id, terminal)),
+            Err(error) => {
+                if matches!(error, WorkerError::Timeout { .. }) {
+                    self.cancel(&run_id);
+                }
+                Err(error)
+            }
+        }
+    }
+}
+
+/// Map a reqwest transport error to a typed worker error, treating connection
+/// failures as an unreachable daemon.
+fn send_error(context: &str, error: reqwest::Error) -> WorkerError {
+    if error.is_connect() {
+        WorkerError::Unreachable(format!("{context}: {error}"))
+    } else if error.is_timeout() {
+        WorkerError::Poll(format!("{context}: request timed out: {error}"))
+    } else {
+        WorkerError::BadResponse(format!("{context}: {error}"))
+    }
+}
+
+/// Build the `POST /invoke` request body. `max_turns` is included only when set
+/// (Codex rejects the control), and `max_cost_usd` is left to the daemon.
+pub(crate) fn build_invoke_body(request: &WorkerRunRequest) -> Value {
+    let mut limits = serde_json::Map::new();
+    limits.insert(
+        "wall_clock_secs".to_string(),
+        Value::from(request.wall_clock_secs),
+    );
+    if let Some(max_turns) = request.max_turns {
+        limits.insert("max_turns".to_string(), Value::from(max_turns));
+    }
+
+    let mut body = serde_json::Map::new();
+    body.insert("prompt".to_string(), Value::from(request.prompt.clone()));
+    body.insert(
+        "provider".to_string(),
+        Value::from(request.provider.clone()),
+    );
+    body.insert("model".to_string(), Value::from(request.model.clone()));
+    body.insert("cwd".to_string(), Value::from(request.cwd.clone()));
+    body.insert("limits".to_string(), Value::Object(limits));
+    if let Some(key) = &request.serialization_key {
+        body.insert("serialization_key".to_string(), Value::from(key.clone()));
+    }
+    Value::Object(body)
+}
+
+/// Extract the `run_id` from a `POST /invoke` 202 body.
+pub(crate) fn parse_submit_response(text: &str) -> Result<String, WorkerError> {
+    let value: Value = serde_json::from_str(text)
+        .map_err(|error| WorkerError::BadResponse(format!("parse /invoke body: {error}")))?;
+    value
+        .get("run_id")
+        .and_then(Value::as_str)
+        .filter(|run_id| !run_id.trim().is_empty())
+        .map(str::to_string)
+        .ok_or_else(|| WorkerError::BadResponse("/invoke response missing 'run_id'".to_string()))
+}
+
+/// Parse a `GET /runs/{id}` body into a status + optional final text.
+pub(crate) fn parse_run_status(text: &str) -> Result<WorkerRunStatus, WorkerError> {
+    let value: Value = serde_json::from_str(text)
+        .map_err(|error| WorkerError::BadResponse(format!("parse /runs body: {error}")))?;
+    let status = value
+        .get("status")
+        .and_then(Value::as_str)
+        .filter(|status| !status.trim().is_empty())
+        .ok_or_else(|| WorkerError::BadResponse("/runs response missing 'status'".to_string()))?
+        .to_string();
+    Ok(WorkerRunStatus {
+        status,
+        report_text: extract_result_text(&value),
+    })
+}
+
+/// The agent's final text from a run record: `result.result` when `result` is
+/// an object, or the bare string on a dispatch-failure record.
+fn extract_result_text(value: &Value) -> Option<String> {
+    match value.get("result") {
+        Some(Value::Object(map)) => map
+            .get("result")
+            .and_then(Value::as_str)
+            .map(str::to_string),
+        Some(Value::String(text)) => Some(text.clone()),
+        _ => None,
+    }
+}
+
+/// Whether a status string is terminal.
+pub(crate) fn is_terminal(status: &str) -> bool {
+    TERMINAL_STATUSES.contains(&status)
+}
+
+/// Poll `fetch` until it reports a terminal status or `timeout` elapses.
+///
+/// Always polls at least once before checking the deadline, so a run that is
+/// already terminal returns immediately. Injectable `fetch` (and thus testable
+/// without a live daemon).
+pub(crate) fn await_terminal<F>(
+    timeout: Duration,
+    interval: Duration,
+    run_id: &str,
+    mut fetch: F,
+) -> Result<WorkerTerminal, WorkerError>
+where
+    F: FnMut() -> Result<WorkerRunStatus, WorkerError>,
+{
+    let start = Instant::now();
+    loop {
+        let current = fetch()?;
+        if is_terminal(&current.status) {
+            return Ok(WorkerTerminal {
+                status: current.status,
+                report_text: current.report_text,
+            });
+        }
+        if start.elapsed() >= timeout {
+            return Err(WorkerError::Timeout {
+                run_id: run_id.to_string(),
+                waited_secs: start.elapsed().as_secs(),
+            });
+        }
+        std::thread::sleep(interval);
+    }
+}

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -31,9 +31,14 @@ default `KillMode=control-group` kills the whole cgroup when the oneshot
 deactivates — reaping the just-spawned workers (observed as
 `task_auto_pipeline` runs flipping to `interrupted` with
 `process_not_found` seconds after "Finished orbit-ship-sweep.service").
-`orbit-qa-sweep.service` deliberately keeps the default: qa-sweep runs its
-checks inline and finishes its ledger run before exiting, so cgroup cleanup
-is correct there.
+`orbit-qa-sweep.service` also keeps the default `KillMode=control-group`, but
+the reasoning changed with qa-sweep v2 [ORB-10146]: the QA work now runs as a
+**remote** worker-daemon run, not an inline child, so cgroup kill on unit exit
+no longer reaps it — the sweep process only submits, polls, and finalizes its
+ledger run before exiting. On a timeout the sweep best-effort cancels the
+worker run (`DELETE /runs/<id>`); a sweep killed mid-poll leaves the worker run
+to finish on its own budget and be picked up by the next pass's watermark
+check. Nothing survives in the sweep's own cgroup that needs reaping.
 
 ### Install (per host, e.g. dk-server-1)
 
@@ -63,49 +68,69 @@ auto_ship = true
 
 ## orbit-qa-sweep (systemd user timer)
 
-Periodically runs `orbit run qa-sweep` [ORB-10039]: the trailing QA pass over
-direct-push workspaces (design D4 — writes to `agent-main` stay fast;
-validation happens on a lag). Per workspace listed in the `[qa]` section of
-the **global** `~/.orbit/config.toml`:
+Periodically runs `orbit run qa-sweep` [ORB-10039, reworked ORB-10146]: the
+trailing QA pass over direct-push workspaces (design D4 — writes to `agent-main`
+stay fast; validation happens on a lag). Per workspace listed in the `[qa]`
+section of the **global** `~/.orbit/config.toml`:
 
 1. skip unless the live checkout is on the expected branch and its HEAD moved
    past the per-workspace last-validated watermark
    (`~/.orbit/state/qa-sweep.json`);
-2. run the configured checks (`sh -c`, from the workspace root; per-check
-   timeout, muted checks skipped);
-3. file a fingerprint-deduped orbit task per distinct failure (tags
-   `qa-sweep` + `fp-<hash>`; an open task with the same fingerprint suppresses
-   refiling);
-4. advance the watermark only when every non-muted check passed.
+2. resolve the QA crew (per-workspace `crew`, else the workspace's default crew),
+   compose a QA prompt carrying the `baseline..head` range + commit list, and
+   submit a **QA agent run** to the loopback worker invoke daemon (`qa.base_url`,
+   default `http://127.0.0.1:7879`); poll it to a terminal state (per-workspace
+   `timeout_minutes`);
+3. parse the agent's structured findings JSON and file a fingerprint-deduped
+   orbit task per finding (tags `qa-sweep` + `fp-<hash>`; an open task with the
+   same fingerprint suppresses refiling; priority from finding severity clamped
+   by `qa.default_priority`);
+4. advance the watermark whenever the run completed and its report parsed —
+   findings are captured as tasks, so re-validating adds nothing. A failed,
+   timed-out, or unparseable run holds the watermark and is an `error` row.
 
 Each validating pass is recorded in the workspace's run ledger under job id
-`qa_sweep` (`orbit run history -j qa_sweep`, `orbit run show <run_id>`). The
-unit exits non-zero only on workspace *errors* (misconfig, git/probe
-failures) — a red check files a task and exits 0, so `--failed` means the
-sweep itself is broken, not the code it checks.
+`qa_sweep`, with one step linking the worker `run_id` (`orbit run history -j
+qa_sweep`, `orbit run show <run_id>`). The unit exits non-zero only on workspace
+*errors* (misconfig, unreachable/failed/timed-out agent run) — findings filed
+from a completed run exit 0, so `--failed` means the sweep itself is broken, not
+the code it validated.
 
 Config lives in the **global** config.toml only (workspace `config.toml`
-files are rewritten by task-mutation commands and are replace-not-merge):
+files are rewritten by task-mutation commands and are replace-not-merge).
+Legacy `[[qa.workspace.check]]` shell-check tables are removed — a leftover one
+now fails config load with a migration error:
 
 ```toml
 # ~/.orbit/config.toml
 [qa]
-default_priority = "medium"    # priority of auto-filed QA tasks
+default_priority = "medium"    # ceiling priority for auto-filed QA tasks
 task_status = "backlog"        # or "proposed" to require human approval
+base_url = "http://127.0.0.1:7879"  # worker invoke daemon (default shown)
 
 [[qa.workspace]]
 name = "polaris"               # registry name (orbit workspace list)
 branch = "agent-main"          # defaults to the registered base_branch
+crew = "opus"                  # optional; defaults to the workspace's crew
+timeout_minutes = 120          # agent-run wall-clock budget (default 120)
+max_commits = 40               # optional cap on commits listed in the prompt
+```
 
-[[qa.workspace.check]]
-name = "frontmatter"
-command = "python3 scripts/check_frontmatter.py"
+### Install (per host, e.g. dk-server-1)
 
-[[qa.workspace.check]]
-name = "lint"
-command = "make lint"
-mute = true                    # flaky: keep the definition, skip the check
-timeout_minutes = 10           # default 30
+```sh
+mkdir -p ~/.config/systemd/user
+cp deploy/orbit-qa-sweep.{service,timer} ~/.config/systemd/user/
+systemctl --user daemon-reload
+systemctl --user enable --now orbit-qa-sweep.timer
+```
+
+### Verify
+
+```sh
+orbit run qa-sweep --dry-run --json     # what would be validated, runs nothing
+systemctl --user list-timers orbit-qa-sweep.timer
+journalctl --user -u orbit-qa-sweep -n 50
 ```
 
 ## orbit-web-upgrade (systemd user timer)
@@ -142,7 +167,6 @@ the thing that's broken.
 ### Install (per host, e.g. dk-server-1)
 
 ```sh
-<<<<<<< HEAD
 cp deploy/orbit-web-upgrade.{service,timer} ~/.config/systemd/user/
 systemctl --user daemon-reload
 systemctl --user enable --now orbit-web-upgrade.timer
@@ -160,20 +184,6 @@ systemctl --user list-timers orbit-web-upgrade.timer     # next/last fire
 journalctl --user -t orbit-web-upgrade -n 50             # last run's output
 systemctl --user start orbit-web-upgrade.service         # run once now
 systemctl --user disable --now orbit-web-upgrade.timer   # stop the schedule
-=======
-mkdir -p ~/.config/systemd/user
-cp deploy/orbit-qa-sweep.{service,timer} ~/.config/systemd/user/
-systemctl --user daemon-reload
-systemctl --user enable --now orbit-qa-sweep.timer
-```
-
-### Verify
-
-```sh
-orbit run qa-sweep --dry-run --json     # what would be validated, runs nothing
-systemctl --user list-timers orbit-qa-sweep.timer
-journalctl --user -u orbit-qa-sweep -n 50
->>>>>>> 1ec6d2d3 (feat(qa-sweep): scheduled QA routine trailing agent-main)
 ```
 
 ## orbit-web (systemd user service)

--- a/deploy/orbit-qa-sweep.service
+++ b/deploy/orbit-qa-sweep.service
@@ -15,11 +15,15 @@ WorkingDirectory=%h
 # tools the configured checks shell out to (git, make, python3, ...).
 Environment=PATH=%h/.local/bin:%h/.orbit/bin:/usr/local/bin:/usr/bin:/bin
 ExecStart=%h/.orbit/bin/orbit run qa-sweep --json
-# Unlike ship-sweep (which spawns detached pipeline workers and needs
-# KillMode=process [ORB-10038]), qa-sweep runs its checks *inline* and only
-# exits after finalizing the ledger run, so the default KillMode=control-group
-# is correct here — anything still alive at exit is a leaked check process
-# that should be reaped.
+# KillMode is left at the default control-group. qa-sweep v2 [ORB-10146] runs
+# the QA work as a *remote* worker-daemon run, not an inline child: the sweep
+# process only submits, polls, and finalizes its ledger run before exiting, so
+# nothing in its own cgroup needs reaping. Control-group kill therefore does
+# NOT reap the QA agent run — on timeout the sweep best-effort cancels it
+# (DELETE /runs/<id>); a sweep killed mid-poll leaves the worker run to finish
+# on its own budget, and the next pass's watermark check picks up where it left
+# off. (Unlike ship-sweep, which spawns detached pipeline workers and needs
+# KillMode=process [ORB-10038] to avoid reaping them.)
 # Retry a failed sweep after a pause instead of waiting a full timer interval.
 # Restart= on a Type=oneshot unit requires systemd >= 254; on older systemd
 # drop these two lines (the timer's OnUnitActiveSec still retries every 6h).

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -414,17 +414,22 @@ User units, installed to `~/.config/systemd/user/` (see
 - **`orbit-ship-sweep.service` + `.timer`** — every 20 min, dispatch ship runs in
   workspaces opted in via `[workflow] auto_ship = true`.
 - **`orbit-qa-sweep.service` + `.timer`** — every 6 h, run `orbit run qa-sweep`
-  [ORB-10039]: the trailing QA pass over direct-push workspaces (design D4). Per
-  workspace listed under `[qa]` in the **global** `~/.orbit/config.toml`, it diffs the
-  live checkout's HEAD against the last-validated watermark
-  (`~/.orbit/state/qa-sweep.json`), runs the configured `sh -c` checks when new commits
-  exist (per-check timeout; `mute = true` skips a flaky check without deleting it), files
-  one fingerprint-deduped orbit task per distinct failure (tags `qa-sweep` +
-  `fp-<hash>`; an open task with the same fingerprint suppresses refiling), and advances
-  the watermark only on a fully green pass. Every validating pass is a ledger run under
-  job id `qa_sweep` (`orbit run history -j qa_sweep` in the workspace). The unit fails
-  only on sweep *errors* — a red check files a task and exits 0. Config schema and
-  install steps: [deploy/README.md](../deploy/README.md).
+  [ORB-10039, reworked ORB-10146]: the trailing QA pass over direct-push workspaces
+  (design D4). Per workspace listed under `[qa]` in the **global** `~/.orbit/config.toml`,
+  it diffs the live checkout's HEAD against the last-validated watermark
+  (`~/.orbit/state/qa-sweep.json`) and, when new commits exist, submits a **QA agent run**
+  to the loopback worker invoke daemon (`qa.base_url`, default `http://127.0.0.1:7879`):
+  the agent reads the new commits, exercises the new features/behaviour changes hands-on,
+  and reports a structured findings JSON. The sweep files one fingerprint-deduped orbit
+  task per finding (tags `qa-sweep` + `fp-<hash>`; an open task with the same fingerprint
+  suppresses refiling; priority from finding severity clamped by `qa.default_priority`)
+  and advances the watermark whenever the run completed and its report parsed. A failed,
+  timed-out, or unparseable run holds the watermark and is an `error` row. Every validating
+  pass is a ledger run under job id `qa_sweep`, with one step linking the worker `run_id`
+  (`orbit run history -j qa_sweep` in the workspace). The unit fails only on sweep
+  *errors*. Per-workspace `crew` / `timeout_minutes` / `max_commits` tune the agent run;
+  legacy `[[qa.workspace.check]]` tables now fail config load. Config schema and install
+  steps: [deploy/README.md](../deploy/README.md).
 
 ```sh
 systemctl --user status orbit-web


### PR DESCRIPTION
## Task

[ORB-10146](https://orbit-cli.com/tasks/ORB-10146) — qa-sweep v2: replace inline shell checks with a worker-invoked QA agent pass

### Description

## Motivation

The current qa-sweep (ORB-10039) runs configured shell checks (builds/tests) inline per direct-push workspace. That only catches mechanical regressions and has proven useless for its actual purpose: nobody validates that *new features work*. Revise the sweep so it invokes a QA agent that reads the new commits, manually exercises the new features/behaviour changes, and reports real issues — the sweep then files them as tasks.

## Design (decided)

**1. Invocation — worker one-shot run.** For each configured workspace with new commits in `baseline..head`, the sweep composes a QA prompt and submits it to the worker invoke daemon (`POST /invoke` on the loopback service in `agentbase/worker/server` — the same surface bridge `agent_invoke` uses). Worker is async (202 + run store); the sweep polls run status until terminal or a configured timeout. Add a small loopback HTTP client in orbit-core for this; endpoint/base URL configurable under `[qa]`. Use generous run budgets (default ~150 turns / 7200s), overridable per workspace.

**2. QA prompt contract.** The prompt carries: workspace root, branch, `baseline..head` range plus commit list (subjects + shas, capped), and instructions to (a) read the diff and identify new features / behaviour changes, (b) validate them hands-on — build, run, targeted tests, CLI/API invocation as appropriate — not just re-run the test suite, (c) emit as final output a structured findings report: JSON `{findings: [{name, severity, summary, evidence, commits}]}` with an empty array for a clean pass. The agent does NOT file tasks itself.

**3. Task filing stays in the sweep.** Parse the structured report; per finding, file a fingerprint-deduped orbit task (reuse `qa::fingerprint` — fingerprint over workspace + finding name/signature instead of check name + output), tagged `QA_SWEEP_TAG`, priority mapped from finding severity clamped by `qa.default_priority`, status from `qa.task_status` (unchanged semantics). Evidence caps analogous to today's.

**4. Watermark semantics.** Advance the watermark whenever the agent run completes and the report parses — findings are captured as tasks, so re-validating the same range adds nothing. A failed/timed-out/unparseable run leaves the watermark and is reported as `error` (no silent green).

**5. Config.** Rework `[qa]`: per-workspace `crew` key selecting the named crew for the QA run (falls back to the workspace's default crew resolution [ORB-10133]); per-workspace agent-run `timeout` and optional `max_commits` cap. Remove `[[qa.workspace.check]]` (shell checks) — fail-closed on leftover check config with a clear migration error; note removal in CHANGELOG.

**6. Ledger.** Keep the first-class v2 job run record (`QA_SWEEP_JOB`): one run per workspace per pass, now with a single step for the agent run whose payload links the worker `run_id` (instead of per-check steps). `orbit run history -j qa_sweep` stays honest.

**7. Deployment.** `deploy/orbit-qa-sweep.{service,timer}` cadence unchanged. Revisit the KillMode comment: the sweep now waits on a remote worker run rather than inline child processes, so control-group kill no longer reaps the actual QA work — cancellation of the worker run on sweep termination should be handled or explicitly documented as best-effort.

## Acceptance criteria in brief

Sweep with new commits submits one worker run per workspace, polls to terminal, files deduped tasks from findings, advances watermark per §4; dry-run reports would-validate without invoking; malformed `[qa]` (including legacy check config) is a loud startup error; unit tests cover report parsing, fingerprint dedupe, watermark rules, and worker-client failure paths (daemon down, timeout, bad JSON).

### Acceptance Criteria

- qa-sweep invokes one worker one-shot QA agent run per configured workspace with new baseline..head commits, and polls it to a terminal state
- Findings from the agent's structured JSON report are filed as fingerprint-deduped orbit tasks with QA_SWEEP tag, severity-mapped priority, and configured status
- Watermark advances only on a completed run with a parseable report; run failure/timeout/bad JSON leaves the watermark and surfaces as an error row
- [qa] config supports per-workspace crew, timeout, and max_commits; legacy [[qa.workspace.check]] entries fail config load with a migration error
- QA_SWEEP_JOB ledger run recorded per swept workspace with one step linking the worker run_id
- Tests cover report parsing, dedupe, watermark rules, and worker-client failure paths

## Execution Summary

<details>
<summary>Click to expand</summary>

qa-sweep v2: replaced the inline shell-check sweep with a worker-invoked QA agent pass.

Config (crates/orbit-core/src/config/raw.rs, qa/config.rs): [qa] reworked. RawQaConfig gains base_url; RawQaWorkspaceConfig gains crew/timeout_minutes/max_commits and keeps a raw `check` field ONLY to detect+reject legacy [[qa.workspace.check]] with a fail-closed migration error. QaSweepConfig{default_priority(now a ceiling), task_status, worker_base_url(default http://127.0.0.1:7879), workspaces}; QaWorkspaceConfig{name, branch, crew, timeout, max_commits}. QaCheck/RawQaCheckConfig removed.

Worker client (qa/worker.rs, new; reqwest.workspace=true added to orbit-core): blocking loopback client for the worker invoke daemon — POST /invoke (async 202 -> run_id), GET /runs/{id} polled to a terminal status, DELETE /runs/{id} best-effort cancel on timeout. max_turns sent only for claude (Codex rejects the control). Pure helpers (build_invoke_body, parse_submit_response, parse_run_status, is_terminal, await_terminal) are unit-tested without a daemon.

Report (qa/report.rs, new): lenient parse of the agent's {findings:[{name,severity,summary,evidence,commits}]} from bare/fenced/prose-wrapped output; a terminal run with no parseable findings object is a bad report. Severity->TaskPriority mapping clamped to the qa.default_priority ceiling (resolve_priority).

Prompt (qa/prompt.rs, new): composes the QA prompt (root, branch, baseline..head, capped commit list, hands-on validation instructions, JSON output contract).

Fingerprint (qa/fingerprint.rs): finding_fingerprint(workspace, finding-name) replaces failure_fingerprint; QA_SWEEP_TAG + fp-<hash> dedupe unchanged.

Sweep (qa/sweep.rs): per workspace resolve crew (ws `crew` override else workspace default via resolve_crew_for_task), compose prompt, submit through an injected QaAgent trait (production WorkerQaAgent), poll to terminal. Watermark advances only when status==ok AND the report parses; failure/timeout/bad-JSON -> action=error, watermark held. QA_SWEEP_JOB ledger run recorded per swept workspace (even on daemon-down) with ONE step whose payload links the worker run_id. Findings filed as fingerprint-deduped, system-created Bug tasks with severity-mapped+clamped priority and qa.task_status. QaWorkspaceReport now carries crew/agent_run_id/findings; actions are validated|error|would_validate|skipped.

CLI (crates/orbit-cli/src/command/run/qa_sweep.rs): report_json/report_line render findings+crew+agent_run_id; JSON summary swaps failed_checks for findings_filed.

Deploy/docs: orbit-qa-sweep.service KillMode comment revised (remote worker run, best-effort cancel on timeout); deploy/README.md + docs/OPERATIONS.md rewritten for the agent design and new [qa] schema. NOTE: deploy/README.md also carried a PRE-EXISTING unresolved git merge conflict (commit 1ec6d2d3) that garbled the qa-sweep install docs — resolved it (kept HEAD web-upgrade install/inspect; qa-sweep Install/Verify now lives in its own section). CHANGELOG breaking-change bullet added.

Validation: full orbit-core lib suite 578 passed (0 failed); new qa tests cover report parsing, dedupe, watermark advance/hold, ledger recording, prompt contract, severity clamping, dry-run inertness, and worker-client failure paths (daemon down, timeout, non-success, bad JSON). orbit-cli qa_sweep tests pass. Fixed a flaky test (git add . raced live SQLite WAL under .orbit/ -> now stages only the named file). cargo fmt --all applied; clippy clean; ci-fast guardrails pass except test-installer-security.sh (requires `node`, absent in sandbox — unrelated to this change; CI covers it).

ADR: not allocated inline — orbit.adr.add/task.add require loading runtime config, and in this worktree the stale installed binary rejects the flat [crews.*] config while the freshly-built binary correctly rejects this repo's live .orbit/config.toml legacy [[qa.workspace.check]] the operator must still migrate. Recommend the feature-lead allocate an ADR + docs/design/qa-sweep/4_decisions.md as a follow-up (see task comments).

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10146-6a52e3e3`
- Behind base: 0
- Ahead of base: 1