### PR TITLE
Fix stale codex-crew role prompts: graph tools are MCP-only, not reachable via `orbit tool run`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Highlights
 
+- **Planning-duel role prompts stop instructing CLI-only agents to reach `orbit.graph.*` via `orbit tool run`**: the graph surface is MCP-only per ADR-0198; agents without an MCP handle are now pointed at the `orbit graph`/`orbit-graph-cli` shell fallback instead of retrying a nonexistent CLI tool path. ([ORB-10150])
 - **Auto-task primitive**: recurring chores are data, not code. `orbit auto-task add/list/show/update/toggle` (+ `orbit.auto_task.*` tools) define `.orbit/auto_tasks/*.yaml` templates with a cron/interval schedule and dedupe policy; one seeded scheduler routine mints tasks from the due ones with catch-up collapse and `skip_if_open` dedupe. Provider-neutral (ADR-0217). ([ORB-10149])
 - **Ship `--mode pr` fails loudly on an empty diff**: an implement step that writes nothing no longer reports success — an empty commit and a `0 commits ahead` branch now hard-fail (no empty branch pushed, no PR, no promote-to-review), the premature pre-commit `push` is removed, and the agent envelope gets `repo_root` plus a fail-closed `workspace_path`. ([ORB-10134])
 - **Codex plugin documentation parity**: Website install/MCP guides now cover Codex plugin installation, upgrades, fresh-task discovery, and read-only MCP smoke checks alongside Claude; the npm proxy README clarifies how both supported plugins consume the binary without manual asset copying. ([ORB-10117])

--- a/crates/orbit-engine/src/executor/automation/duel/planning_duel/roles.rs
+++ b/crates/orbit-engine/src/executor/automation/duel/planning_duel/roles.rs
@@ -37,7 +37,16 @@ Steps:
 
 3. Gather context with the graph surface BEFORE drafting. No single tool is
    sufficient — show returns bodies; refs, callees, and search return the call
-   and import graph that bodies alone miss. You must:
+   and import graph that bodies alone miss.
+   - `orbit.graph.*` is served in-process over MCP only (ADR-0198) — there is
+     no `orbit tool run orbit.graph.*` path. If `orbit.graph.*` is in your
+     tool surface, use it as described below. If it is not (a CLI-only agent
+     with no MCP handle), do not attempt `orbit tool run orbit.graph.*` — it
+     will fail with "tool not found". Instead run the same queries from the
+     shell via `orbit graph <subcommand>` (e.g. `orbit graph overview <dir>`,
+     `orbit graph show <selector>`, `orbit graph refs <selector>`) or the
+     standalone `orbit-graph-cli` binary if `orbit graph` is unavailable; see
+     the `orbit-graph` skill for the full subcommand list.
    - Start with orbit.graph.overview over the task's directories and
      orbit.graph.show on each task.context_files selector for breadth.
    - For every symbol the task proposes to move, rename, remove, or add: call
@@ -49,9 +58,9 @@ Steps:
      import direction.
    - Use orbit.graph.show for full symbol bodies you need to read.
    - Use orbit.graph.overview to map an unfamiliar area first.
-   - fs.read is a fallback only for selectors the graph cannot resolve (raw
-     YAML, Markdown, assets the graph does not index, or unresolved selectors
-     the graph reports).
+   - fs.read is a fallback only for selectors the graph (MCP or CLI) cannot
+     resolve (raw YAML, Markdown, assets the graph does not index, or
+     unresolved selectors the graph reports).
    - If you discover pub(crate) imports, helper coupling, call sites, or
      dependency edges not reflected in the task description, treat them as
      hidden coupling — they belong in step 1 of your plan body.
@@ -116,9 +125,16 @@ Steps:
    - The artifact signature is the canonical planner identity source.
 
 4. Use the graph surface to verify claims:
-   - Prefer orbit.graph.overview, orbit.graph.search, orbit.graph.refs, orbit.graph.show,
-     and orbit.graph.impact for spot checks against the codebase.
-   - Fall back to fs.read only when the graph does not have enough knowledge.
+   - `orbit.graph.*` is served in-process over MCP only (ADR-0198) — there is
+     no `orbit tool run orbit.graph.*` path. If `orbit.graph.*` is in your
+     tool surface, prefer orbit.graph.overview, orbit.graph.search,
+     orbit.graph.refs, orbit.graph.show, and orbit.graph.impact for spot
+     checks against the codebase. If it is not (a CLI-only agent with no MCP
+     handle), do not attempt `orbit tool run orbit.graph.*`; instead run the
+     same queries from the shell via `orbit graph <subcommand>` or the
+     standalone `orbit-graph-cli` binary — see the `orbit-graph` skill.
+   - Fall back to fs.read only when the graph (MCP or CLI) does not have
+     enough knowledge.
 
 5. Decide the winner:
    - Choose the artifact proposal that is more feasible, complete, scoped, and aligned


### PR DESCRIPTION
## Task

[ORB-10150](https://orbit-cli.com/tasks/ORB-10150) — Fix stale codex-crew role prompts: graph tools are MCP-only, not reachable via `orbit tool run`

### Description

**Problem.** The 24h failure dashboard shows `orbit.graph.show` at 100% failure (9/9). All failures are `role=codex`, CLI surface (`orbit tool run`), erroring instantly with `tool not found: orbit.graph.show`. Root cause: per ADR-0198, graph tools are served in-process by `GraphToolRegistry` in `orbit-mcp` — there is no `orbit tool run orbit.graph.*` path (the v1 `orbit graph` CLI command was decommissioned with orbit-knowledge). But the codex-crew role prompts in `crates/orbit-engine/**/planning_duel/roles.rs` (~lines 41-51, 256-258) still instruct agents to call `orbit.graph.overview` / `orbit.graph.show`, which codex crews can only reach via the CLI surface → guaranteed failure.

**Fix.** Update the stale instructions to route graph queries through the MCP surface:
- In `planning_duel/roles.rs`, rewrite the graph-tool guidance so agents on the CLI-only surface are not told to invoke `orbit.graph.*` via `orbit tool run`. Either direct them to the MCP surface where available, or (where the run has no MCP handle) drop the graph-tool instructions and point at the documented alternatives (e.g. `orbit-graph-cli` or non-graph tools).
- Sweep the orbit repo for any other prompt/skill/doc text that instructs calling `orbit.graph.*` through `orbit tool run` and fix those the same way.
- Keep behavior aligned with ADR-0198 (graph is MCP-only; `orbit-graph-cli` is the manual escape hatch). Do NOT build a CLI shim — that would need a new ADR and is out of scope.

**Verification.** After the change, no role prompt or in-repo instruction directs a CLI-surface agent to `orbit tool run orbit.graph.*`.

### Acceptance Criteria

- No prompt/doc in the repo instructs CLI-surface agents to call orbit.graph.* via `orbit tool run`
- Codex-crew role prompts route graph queries via the MCP surface or omit graph tools with a documented alternative
- Change is consistent with ADR-0198 (no CLI shim added)

## Execution Summary

<details>
<summary>Click to expand</summary>

Root cause confirmed via ADR-0198: orbit.graph.* is served in-process by orbit-mcp's GraphToolRegistry only — there is no `orbit tool run orbit.graph.*` CLI path. Traced how planning-duel agent_invoke activities dispatch (crates/orbit-core/src/runtime/engine/runtime_host.rs -> ActivityExecutorRegistry keyed by agent_cli -> DirectAgentExecutor spawning `codex exec --json` / `claude -p ...` with no MCP flags) and confirmed the executor never guarantees an MCP handle for the spawned process; MCP availability is a separate, host-level `orbit mcp setup <provider>` concern. So when a CLI-only agent (codex crews, or any family lacking that host-level MCP wiring) hits the PLANNER/ARBITER instructions in crates/orbit-engine/src/executor/automation/duel/planning_duel/roles.rs and orbit.graph.* isn't in its tool surface, the generic 'fall back to orbit tool run <tool>' convention leads it to a nonexistent path and a guaranteed failure, matching the 9/9 orbit.graph.show failures on the 24h dashboard.

Fix: rewrote step 3 of PLANNING_DUEL_INSTRUCTION and step 4 of ARBITER_INSTRUCTION in roles.rs to state explicitly that orbit.graph.* is MCP-only per ADR-0198, forbid `orbit tool run orbit.graph.*`, and redirect CLI-only agents to the real, already-wired fallback: the `orbit graph <subcommand>` command on the main `orbit` binary (added by ADR-0199; confirmed live-wired in crates/orbit-cli/src/command/mod.rs and command/graph.rs) or the standalone `orbit-graph-cli` binary, per the orbit-graph skill already in these activities' skill_refs. No CLI shim was added — both fallback paths already existed; only the prompt text changed.

Swept the rest of the repo for the same anti-pattern: grepped every file containing both 'orbit tool run' and 'orbit.graph.' (README.md, CHANGELOG.md, all orbit/orbit-graph/orbit-search/orbit-task SKILL.md copies under crates/orbit-core/assets/skills and plugin/skills, plugin/agents/orbit-code-reader.md, docs/LESSONS.md, and benchmarks/**). All skill docs and orbit-code-reader.md already correctly document 'no orbit tool run orbit.graph.* path'; README/CHANGELOG only list tool names or record historical changelog entries; the benchmarks/** docs are retrospective research reports analyzing past experiment configurations (pre/post ADR-0198), not live agent instructions. roles.rs was the only offender with prompt text that omitted the MCP-only caveat. Also grepped all non-test .rs files for embedded orbit.graph.* tool-name literals to rule out other role-prompt constants elsewhere in the engine; only roles.rs and non-instructional files (tool_allowlist.rs, mcp adapter) matched.

Added a terse CHANGELOG Unreleased bullet citing ORB-10150 per the freshness guardrail. Validation: `cargo check -p orbit-engine --lib` compiles clean; `cargo fmt --all -- --check` passes; `scripts/check-installer-pubkey.sh` passes; `scripts/check-changelog-freshness.sh` and `scripts/check-changelog-style.sh` both pass. `make ci-fast`'s only failure is `scripts/test-installer-security.sh` erroring on a missing `node` binary in this sandbox — unrelated to this change (no JS/installer files touched); the CI merge gate runs in an unrestricted environment and is the authoritative arbiter for that check. No tests reference the instruction string constants, so none needed updating.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10150-6a530d0a`
- Behind base: 0
- Ahead of base: 1