### PR TITLE
Resolve CI failures on orbit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Highlights
 
+- **CI green again — MCP `tools/list` snapshot synced**: ORB-10149's four `orbit_auto_task_*` tools reached the MCP surface without a snapshot refresh, failing `mcp_serve_tools_list_matches_production_snapshot` on every push; the round-trip snapshot now includes them (additive — no tools removed). ([ORB-10152])
 - **QA sweep is an auto-task**: the checked-in six-hour definition routes hands-on validation to `crews.qa`, dedupes open runs, and files findings through Orbit; `no-diff-expected` exempts side-effect-only tasks from workflow diff gates. Legacy QA code, config, CLI, routines, and deployment units are removed. ([ORB-10148])
 - **Auto-task primitive**: recurring chores are data, not code. `orbit auto-task add/list/show/update/toggle` (+ `orbit.auto_task.*` tools) define `.orbit/auto_tasks/*.yaml` templates with a cron/interval schedule and dedupe policy; one seeded scheduler routine mints tasks from the due ones with catch-up collapse and `skip_if_open` dedupe. Provider-neutral (ADR-0217). ([ORB-10149])
 - **Ship `--mode pr` fails loudly on an empty diff**: an implement step that writes nothing no longer reports success — an empty commit and a `0 commits ahead` branch now hard-fail (no empty branch pushed, no PR, no promote-to-review), the premature pre-commit `push` is removed, and the agent envelope gets `repo_root` plus a fail-closed `workspace_path`. ([ORB-10134])

--- a/crates/orbit-cli/tests/snapshots/mcp_tools_list.json
+++ b/crates/orbit-cli/tests/snapshots/mcp_tools_list.json
@@ -287,6 +287,153 @@
     "name": "orbit_adr_update"
   },
   {
+    "description": "Create a recurring auto-task definition. The generic scheduler mints a task from its template on each due slot.",
+    "inputSchema": {
+      "additionalProperties": true,
+      "properties": {
+        "dedupe": {
+          "description": "Dedupe policy: `skip_if_open` (default) or `always`.",
+          "type": "string"
+        },
+        "description": {
+          "description": "Human description of the recurring chore.",
+          "type": "string"
+        },
+        "name": {
+          "description": "Unique definition name (lowercase alphanumeric, `-`/`_`, starts alphanumeric). Required.",
+          "type": "string"
+        },
+        "schedule": {
+          "anyOf": [
+            {
+              "type": "object"
+            },
+            {
+              "items": {
+                "type": "object"
+              },
+              "type": "array"
+            }
+          ],
+          "description": "Schedule object: exactly one of `{ cron: string }` (5-field cron) or `{ every_minutes: number }`. Required."
+        },
+        "template": {
+          "anyOf": [
+            {
+              "type": "object"
+            },
+            {
+              "items": {
+                "type": "object"
+              },
+              "type": "array"
+            }
+          ],
+          "description": "Task template: `{ title, description?, acceptance_criteria?, task_type?, tags?, priority?, crew?, status? }`. Provider-neutral — no turn knobs. Required."
+        }
+      },
+      "required": [
+        "name",
+        "schedule",
+        "template"
+      ],
+      "type": "object"
+    },
+    "name": "orbit_auto_task_add"
+  },
+  {
+    "description": "Show a single auto-task definition by name.",
+    "inputSchema": {
+      "additionalProperties": true,
+      "properties": {
+        "name": {
+          "description": "Definition name. Required.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "type": "object"
+    },
+    "name": "orbit_auto_task_show"
+  },
+  {
+    "description": "Enable or disable an auto-task definition without deleting it.",
+    "inputSchema": {
+      "additionalProperties": true,
+      "properties": {
+        "enabled": {
+          "description": "Whether to enable (`true`) or disable (`false`) the definition. Disabling is the kill-switch, not a delete. Required.",
+          "type": "boolean"
+        },
+        "name": {
+          "description": "Definition name. Required.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "enabled"
+      ],
+      "type": "object"
+    },
+    "name": "orbit_auto_task_toggle"
+  },
+  {
+    "description": "Update an existing auto-task definition (present fields only).",
+    "inputSchema": {
+      "additionalProperties": true,
+      "properties": {
+        "dedupe": {
+          "description": "New dedupe policy: `skip_if_open` or `always`.",
+          "type": "string"
+        },
+        "description": {
+          "description": "New description.",
+          "type": "string"
+        },
+        "name": {
+          "description": "Definition name. Required.",
+          "type": "string"
+        },
+        "schedule": {
+          "anyOf": [
+            {
+              "type": "object"
+            },
+            {
+              "items": {
+                "type": "object"
+              },
+              "type": "array"
+            }
+          ],
+          "description": "New schedule object: `{ cron: string }` or `{ every_minutes: number }`."
+        },
+        "template": {
+          "anyOf": [
+            {
+              "type": "object"
+            },
+            {
+              "items": {
+                "type": "object"
+              },
+              "type": "array"
+            }
+          ],
+          "description": "Replacement task template object."
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "type": "object"
+    },
+    "name": "orbit_auto_task_update"
+  },
+  {
     "description": "Append an Orbit friction report under .orbit/frictions/",
     "inputSchema": {
       "additionalProperties": true,


### PR DESCRIPTION
## Task

[ORB-10152](https://orbit-cli.com/tasks/ORB-10152) — Resolve CI failures on orbit

### Description

**Problem.** Orbit's CI is failing (GitHub Actions on `danieljhkim/orbit`). Diagnose the current failures on `agent-main` and recent PR runs (e.g. around PR #573) and fix them.

**Scope.**
1. Pull the latest failing workflow runs (`gh run list` / `gh run view --log-failed`) and classify each failure: test regression, build/toolchain, lint/fmt, flaky, or infra.
2. Fix root causes — not by skipping/ignoring tests. Flaky tests may be quarantined only with a comment and a follow-up note in the execution summary.
3. Done when CI is green on `agent-main` and on this task's own PR.

**Verification.** All workflows pass on the task PR; a re-run of the previously failing workflows on `agent-main` (post-merge) is green.

### Acceptance Criteria

- Each failing CI workflow root-caused and fixed (no blanket test-skips)
- CI green on the task PR
- Previously failing workflows green on agent-main after merge

## Execution Summary

<details>
<summary>Click to expand</summary>

Root-caused and fixed the CI failure on agent-main.

DIAGNOSIS: CI (Check / Clippy / Test job) has been red since PR #571 merged. Classified each job: fmt ✓, clippy ✓, MSRV ✓, coverage=informational (not a gate). The gating 'Run CI guardrails' step failed at the nextest phase on a single test: crates/orbit-cli/tests/mcp_roundtrip.rs::mcp_serve_tools_list_matches_production_snapshot (exit 100). The MCP tools/list payload drifted from tests/snapshots/mcp_tools_list.json.

ROOT CAUSE (not flaky, not infra): ORB-10149 (#571, auto-task primitive) added four MCP tools — orbit_auto_task_add/show/toggle/update — to the served surface but never regenerated the round-trip snapshot. The snapshot test is a deliberate breaking-change tripwire; the additive tools tripped it on every subsequent push (#571, #572, and the ADR docs push). CHANGELOG already documents the tools (ORB-10149 entry), so this is snapshot-sync, not a new feature.

FIX (no test-skips, no quarantine): regenerated the snapshot via ORBIT_MCP_UPDATE_SNAPSHOT=1 cargo test -p orbit-cli --test mcp_roundtrip. Diff is purely additive: +147 lines, the four orbit_auto_task_* tool schemas, zero removals. Added one terse CHANGELOG Unreleased bullet under [ORB-10152].

FILES: crates/orbit-cli/tests/snapshots/mcp_tools_list.json (regenerated), CHANGELOG.md (one bullet).

VALIDATION (local, cargo 1.96): cargo fmt --check ✓; cargo clippy --workspace --all-targets -D warnings ✓; mcp_roundtrip 3/3 ✓; cargo test --workspace --doc ✓; check-changelog-freshness/style ✓. cargo-nextest not installed locally so used cargo test fallback (same coverage).

ENV-ONLY NON-FAILURES (documented per envelope rule 10, NOT code issues, pass in CI): (1) tests::audit_middleware::tool_run_audit_meta_uses_agent_role_without_identity fails locally because the executor sets ORBIT_AGENT_MODEL=opus/ORBIT_AGENT_NAME=claude which the test's fallback reads; passes with those unset. (2) Seven orbit-cli::docs tests fail locally with 'search companion override parent must not be group/world writable: /tmp/...' because this box's /tmp is drwxrwxrwt; all seven are PASS in the CI log. Neither reflects my change.

Process note: agent-main accumulated this drift because #571/#572 merged while their own CI was red. Out of scope here; flagged for orchestrator triage.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10152-6a5313c2`
- Behind base: 0
- Ahead of base: 1