### PR TITLE
Trim redundant flags from the `orbit task` CLI surface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- **Task creation surface is narrower and consistent**: task creation now exposes only legal initial statuses, list flags share repeat/comma parsing, and redundant agent/comment/instructions inputs are removed while model and managed identity attribution remain intact. ([ORB-10155])
+
 ### Breaking Changes
 
 - **Learning vote and comment surfaces removed**: `orbit.learning.upvote` and all `orbit.learning.comment.*` tools and CLI subcommands are gone — use `priority` + search rank for ranking, `update`/`supersede` for corrections, and `evidence` for provenance. ([ORB-10046])

--- a/crates/orbit-cli/src/command/task/add.rs
+++ b/crates/orbit-cli/src/command/task/add.rs
@@ -2,7 +2,7 @@ use clap::{ArgAction, Args};
 use orbit_cmd::TaskTemplateCommands;
 use orbit_core::command::task::TaskAddParams;
 use orbit_core::{
-    ExternalRef, OrbitError, OrbitRuntime, TaskComplexity, TaskPriority, TaskStatus, TaskType,
+    ExternalRef, OrbitError, OrbitRuntime, TaskComplexity, TaskCreateStatus, TaskPriority, TaskType,
 };
 
 use crate::command::Execute;
@@ -20,31 +20,28 @@ pub struct TaskAddArgs {
     /// Task description (overrides template if --template is also given)
     #[arg(long, default_value = "")]
     pub description: String,
-    /// Acceptance criteria. Repeat the flag for multiple criteria.
-    #[arg(long = "acceptance-criteria")]
+    /// Acceptance criteria. Repeat or comma-separate for multiple criteria.
+    #[arg(long = "acceptance-criteria", action = ArgAction::Append, value_delimiter = ',')]
     pub acceptance_criteria: Vec<String>,
-    /// Comma-separated dependency task IDs
-    #[arg(long, alias = "dependency", default_value = "")]
-    pub dependencies: String,
+    /// Dependency task IDs. Repeat or comma-separate for multiple dependencies.
+    #[arg(long, alias = "dependency", action = ArgAction::Append, value_delimiter = ',')]
+    pub dependencies: Vec<String>,
     /// Task tags. Repeat or comma-separate for multiple tags.
     #[arg(long = "tag", action = ArgAction::Append, value_delimiter = ',')]
     pub tags: Vec<String>,
     /// Optional task plan payload. Leave blank for the executing agent or planning activity to author later.
-    #[arg(long, alias = "instructions", default_value = "")]
+    #[arg(long, default_value = "")]
     pub plan: String,
     /// Pre-populate description, plan, and instructions from a named template
     #[arg(long)]
     pub template: Option<String>,
-    /// Append an initial task comment
-    #[arg(long)]
-    pub comment: Option<String>,
     /// External tracker reference in `system:id` form. Repeat for multiple refs.
     #[arg(long = "ref", action = ArgAction::Append)]
     pub external_refs: Vec<String>,
-    /// Comma-separated task context selectors. Prefer `file:`, `dir:`, or
-    /// `symbol:` forms; legacy raw paths are accepted and upgraded.
-    #[arg(long, default_value = "")]
-    pub context: String,
+    /// Task context selectors. Repeat or comma-separate for multiple selectors.
+    /// Prefer `file:`, `dir:`, or `symbol:` forms; legacy raw paths are accepted and upgraded.
+    #[arg(long, action = ArgAction::Append, value_delimiter = ',')]
+    pub context: Vec<String>,
     /// Workspace path for the task
     #[arg(long)]
     pub workspace: Option<String>,
@@ -59,16 +56,13 @@ pub struct TaskAddArgs {
     pub task_type: Option<TaskType>,
     /// Initial task status
     #[arg(long, value_enum)]
-    pub status: Option<TaskStatus>,
+    pub status: Option<TaskCreateStatus>,
     /// For bug tasks: the originating task whose implementation introduced the defect
     #[arg(long = "source-task")]
     pub source_task: Option<String>,
     /// Named crew to use when running this task
     #[arg(long)]
     pub crew: Option<String>,
-    /// Explicit agent name to persist on the task artifact
-    #[arg(long)]
-    pub agent: Option<String>,
     /// Explicit agent model to persist on the task artifact
     #[arg(long)]
     pub model: Option<String>,
@@ -79,6 +73,7 @@ pub struct TaskAddArgs {
 
 impl Execute for TaskAddArgs {
     fn execute(self, runtime: &OrbitRuntime) -> Result<(), OrbitError> {
+        let (agent, model) = super::mutation_identity(self.model);
         if let Some(parent_id) = self.parent_id.as_deref()
             && runtime.get_task(parent_id).is_err()
         {
@@ -118,17 +113,17 @@ impl Execute for TaskAddArgs {
                 title: self.title,
                 description,
                 acceptance_criteria: self.acceptance_criteria,
-                dependencies: crate::parse::csv_to_vec(&self.dependencies),
+                dependencies: self.dependencies,
                 relations: Vec::new(),
                 tags: self.tags,
                 plan,
-                comment: self.comment,
-                context_files: crate::parse::csv_to_vec(&self.context),
+                comment: None,
+                context_files: self.context,
                 workspace_path: self.workspace,
                 priority,
                 complexity: self.complexity,
                 task_type,
-                status: self.status,
+                status: self.status.map(Into::into),
                 system_created: false,
                 external_refs: self
                     .external_refs
@@ -138,8 +133,8 @@ impl Execute for TaskAddArgs {
                 source_task_id: self.source_task.clone(),
                 crew: self.crew,
             },
-            self.agent,
-            self.model,
+            agent,
+            model,
         )?;
 
         if self.json {

--- a/crates/orbit-cli/src/command/task/artifact.rs
+++ b/crates/orbit-cli/src/command/task/artifact.rs
@@ -45,9 +45,6 @@ pub struct TaskArtifactPutArgs {
     /// Artifact path relative to the task artifacts directory. Defaults to the source file name.
     #[arg(long = "path")]
     pub artifact_path: Option<String>,
-    /// Explicit agent name to persist on the task artifact update
-    #[arg(long)]
-    pub agent: Option<String>,
     /// Explicit agent model to persist on the task artifact update
     #[arg(long)]
     pub model: Option<String>,
@@ -62,10 +59,10 @@ impl Execute for TaskArtifactPutArgs {
             id,
             source_path,
             artifact_path,
-            agent,
             model,
             json,
         } = self;
+        let (agent, model) = super::mutation_identity(model);
         let artifact = TaskArtifact::from_source_file(&source_path, artifact_path.as_deref())?;
         let artifact_path = artifact.path.clone();
         let task = runtime.update_task_with_identity(

--- a/crates/orbit-cli/src/command/task/lifecycle.rs
+++ b/crates/orbit-cli/src/command/task/lifecycle.rs
@@ -18,9 +18,6 @@ pub struct TaskStartArgs {
     /// Crew override for this start
     #[arg(long)]
     pub crew: Option<String>,
-    /// Explicit agent name to persist on the task artifact
-    #[arg(long)]
-    pub agent: Option<String>,
     /// Explicit agent model to persist on the task artifact
     #[arg(long)]
     pub model: Option<String>,
@@ -31,12 +28,13 @@ pub struct TaskStartArgs {
 
 impl Execute for TaskStartArgs {
     fn execute(self, runtime: &OrbitRuntime) -> Result<(), OrbitError> {
+        let (agent, model) = super::mutation_identity(self.model);
         let task = runtime.start_task_with_identity_and_crew(
             &self.id,
             self.note,
             self.comment,
-            self.agent,
-            self.model,
+            agent,
+            model,
             self.crew,
         )?;
         if self.json {

--- a/crates/orbit-cli/src/command/task/mod.rs
+++ b/crates/orbit-cli/src/command/task/mod.rs
@@ -15,5 +15,18 @@ mod update;
 
 pub use command::{TaskCommand, TaskSubcommand};
 
+fn mutation_identity(model: Option<String>) -> (Option<String>, Option<String>) {
+    if model.is_some() {
+        return (None, model);
+    }
+    let agent = std::env::var("ORBIT_AGENT_NAME")
+        .ok()
+        .filter(|value| !value.trim().is_empty());
+    let model = std::env::var("ORBIT_AGENT_MODEL")
+        .ok()
+        .filter(|value| !value.trim().is_empty());
+    (agent, model)
+}
+
 #[cfg(test)]
 mod tests;

--- a/crates/orbit-cli/src/command/task/tests/add.rs
+++ b/crates/orbit-cli/src/command/task/tests/add.rs
@@ -1,0 +1,115 @@
+use clap::{CommandFactory, Parser};
+
+use crate::command::task::TaskSubcommand;
+use crate::command::{Cli, Commands};
+
+#[test]
+fn task_add_parses_repeat_and_comma_delimited_lists() {
+    let cli = Cli::parse_from([
+        "orbit",
+        "task",
+        "add",
+        "--title",
+        "List parsing",
+        "--acceptance-criteria",
+        "first,second",
+        "--acceptance-criteria",
+        "third",
+        "--tag",
+        "cli,surface",
+        "--tag",
+        "test",
+        "--dependencies",
+        "ORB-00001,ORB-00002",
+        "--dependency",
+        "ORB-00003",
+        "--context",
+        "file:one.rs,file:two.rs",
+        "--context",
+        "dir:three",
+    ]);
+
+    let Commands::Task(task) = cli.command else {
+        panic!("expected task command");
+    };
+    let TaskSubcommand::Add(args) = task.command else {
+        panic!("expected task add command");
+    };
+
+    assert_eq!(args.acceptance_criteria, ["first", "second", "third"]);
+    assert_eq!(args.tags, ["cli", "surface", "test"]);
+    assert_eq!(args.dependencies, ["ORB-00001", "ORB-00002", "ORB-00003"]);
+    assert_eq!(args.context, ["file:one.rs", "file:two.rs", "dir:three"]);
+}
+
+#[test]
+fn task_add_status_only_advertises_creation_legal_values() {
+    assert!(
+        Cli::try_parse_from([
+            "orbit",
+            "task",
+            "add",
+            "--title",
+            "Bad status",
+            "--status",
+            "done",
+        ])
+        .is_err()
+    );
+    let mut command = Cli::command();
+    let add = command
+        .find_subcommand_mut("task")
+        .expect("task command")
+        .find_subcommand_mut("add")
+        .expect("task add command");
+    let rendered = add.render_long_help().to_string();
+
+    for legal in ["- proposed:", "- backlog:", "- someday:"] {
+        assert!(rendered.contains(legal), "{rendered}");
+    }
+    for illegal in [
+        "archived",
+        "friction",
+        "done",
+        "review",
+        "rejected",
+        "blocked",
+        "in-progress",
+    ] {
+        assert!(
+            !rendered.contains(illegal),
+            "{illegal} leaked into help: {rendered}"
+        );
+    }
+}
+
+#[test]
+fn removed_task_flags_are_rejected() {
+    for args in [
+        vec!["task", "add", "--title", "Removed", "--agent", "codex"],
+        vec!["task", "add", "--title", "Removed", "--comment", "legacy"],
+        vec![
+            "task",
+            "add",
+            "--title",
+            "Removed",
+            "--instructions",
+            "legacy",
+        ],
+        vec!["task", "update", "ORB-00001", "--agent", "codex"],
+        vec!["task", "start", "ORB-00001", "--agent", "codex"],
+        vec![
+            "task",
+            "artifact",
+            "put",
+            "ORB-00001",
+            "summary.md",
+            "--agent",
+            "codex",
+        ],
+    ] {
+        let mut argv = vec!["orbit"];
+        argv.extend(args);
+        assert!(Cli::try_parse_from(argv).is_err());
+    }
+}

--- a/crates/orbit-cli/src/command/task/tests/artifact.rs
+++ b/crates/orbit-cli/src/command/task/tests/artifact.rs
@@ -59,7 +59,6 @@ fn artifact_put_writes_to_task_artifact_store() {
         id: task.id.clone(),
         source_path: source,
         artifact_path: Some("reports/summary.md".to_string()),
-        agent: Some("codex".to_string()),
         model: Some("gpt-5".to_string()),
         json: false,
     }

--- a/crates/orbit-cli/src/command/task/tests/mod.rs
+++ b/crates/orbit-cli/src/command/task/tests/mod.rs
@@ -1,3 +1,4 @@
+mod add;
 mod artifact;
 mod command;
 mod update;

--- a/crates/orbit-cli/src/command/task/update.rs
+++ b/crates/orbit-cli/src/command/task/update.rs
@@ -63,9 +63,6 @@ pub struct TaskUpdateArgs {
     /// Task artifact write in `path=content` form. Repeat for multiple artifacts.
     #[arg(long = "artifact")]
     pub artifacts: Vec<String>,
-    /// Explicit agent name to persist on the task artifact
-    #[arg(long)]
-    pub agent: Option<String>,
     /// Explicit agent model to persist on the task artifact
     #[arg(long)]
     pub model: Option<String>,
@@ -95,7 +92,6 @@ impl Execute for TaskUpdateArgs {
             crew,
             context_files,
             artifacts,
-            agent,
             model,
             json,
         } = self;
@@ -139,6 +135,7 @@ impl Execute for TaskUpdateArgs {
         let dependencies = dependencies.map(|value| crate::parse::csv_to_vec(&value));
         let tags = (!tags.is_empty()).then_some(tags);
         let upsert_artifacts = parse_artifact_args(&artifacts)?;
+        let (agent, model) = super::mutation_identity(model);
 
         let task = runtime.update_task_with_identity(
             &id,

--- a/crates/orbit-cli/tests/snapshots/mcp_tools_list.json
+++ b/crates/orbit-cli/tests/snapshots/mcp_tools_list.json
@@ -1224,16 +1224,12 @@
     "inputSchema": {
       "additionalProperties": true,
       "properties": {
-        "agent": {
-          "description": "Deprecated compatibility field. Prefer `model` with the agent family (`codex`, `claude`, `gemini`, or `grok`).",
-          "type": "string"
-        },
         "id": {
           "description": "task ID",
           "type": "string"
         },
         "model": {
-          "description": "Preferred provenance field. Pass the canonical agent family (`codex`, `claude`, `gemini`, or `grok`); full model strings are accepted and auto-normalized.",
+          "description": "Preferred provenance field. Pass the canonical agent family (codex, claude, gemini, or grok); full model strings are accepted and auto-normalized.",
           "enum": [
             "codex",
             "claude",
@@ -1557,10 +1553,6 @@
     "inputSchema": {
       "additionalProperties": true,
       "properties": {
-        "agent": {
-          "description": "Deprecated compatibility field. Prefer `model` with the agent family (`codex`, `claude`, `gemini`, or `grok`).",
-          "type": "string"
-        },
         "comment": {
           "description": "Optional task comment to append",
           "type": "string"
@@ -1574,7 +1566,7 @@
           "type": "string"
         },
         "model": {
-          "description": "Preferred provenance field. Pass the canonical agent family (`codex`, `claude`, `gemini`, or `grok`); full model strings are accepted and auto-normalized.",
+          "description": "Preferred provenance field. Pass the canonical agent family (codex, claude, gemini, or grok); full model strings are accepted and auto-normalized.",
           "enum": [
             "codex",
             "claude",

--- a/crates/orbit-cli/tests/task_trimmed_surface.rs
+++ b/crates/orbit-cli/tests/task_trimmed_surface.rs
@@ -137,6 +137,47 @@ fn lint_fix_sweep_drops_stale_context_entries() {
 }
 
 #[test]
+fn task_add_attributes_from_model_flag_and_managed_identity_env() {
+    let workspace = TestWorkspace::new();
+
+    let explicit = workspace.task_json(&[
+        "task",
+        "add",
+        "--title",
+        "Explicit model",
+        "--description",
+        "Model flag attribution",
+        "--model",
+        "gpt-5.6-sol",
+        "--json",
+    ]);
+    assert_eq!(explicit["created_by"], json!("gpt-5.6-sol"));
+
+    let output = run_orbit_with_identity(
+        &workspace.work,
+        &workspace.home,
+        &[
+            "task",
+            "add",
+            "--title",
+            "Managed identity",
+            "--description",
+            "Environment attribution",
+            "--json",
+        ],
+        "codex",
+        "gpt-5.6-terra",
+    );
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let managed: Value = serde_json::from_slice(&output.stdout).expect("managed task JSON");
+    assert_eq!(managed["created_by"], json!("gpt-5.6-terra"));
+}
+
+#[test]
 fn locks_release_reaches_admin_tool_bypassing_agent_gate() {
     let workspace = TestWorkspace::new();
 
@@ -261,6 +302,29 @@ fn run_orbit(cwd: &Path, home: &Path, args: &[&str]) -> Output {
         .env("HOME", home)
         .env("USERPROFILE", home)
         .env_remove("ORBIT_ROOT")
+        .env_remove("ORBIT_AGENT_NAME")
+        .env_remove("ORBIT_AGENT_MODEL")
+        .env_remove("ORBIT_MANAGED_RUN_CONTEXT")
         .args(args);
     command.output().expect("run orbit")
+}
+
+fn run_orbit_with_identity(
+    cwd: &Path,
+    home: &Path,
+    args: &[&str],
+    agent: &str,
+    model: &str,
+) -> Output {
+    let mut command = cargo_bin_cmd!("orbit");
+    command
+        .current_dir(cwd)
+        .env("HOME", home)
+        .env("USERPROFILE", home)
+        .env_remove("ORBIT_ROOT")
+        .env("ORBIT_AGENT_NAME", agent)
+        .env("ORBIT_AGENT_MODEL", model)
+        .env("ORBIT_MANAGED_RUN_CONTEXT", "1")
+        .args(args);
+    command.output().expect("run orbit with managed identity")
 }

--- a/crates/orbit-common/src/types/mod.rs
+++ b/crates/orbit-common/src/types/mod.rs
@@ -131,8 +131,8 @@ pub use skill::Skill;
 pub use task::{
     ExternalRef, GITHUB_PR_EXTERNAL_REF_SYSTEM, NO_DIFF_EXPECTED_TAG, ResolvedTaskDependency,
     ReviewMessage, ReviewThread, ReviewThreadAnchor, ReviewThreadStatus, Task, TaskArtifact,
-    TaskComment, TaskComplexity, TaskHistoryEntry, TaskPriority, TaskStatus, TaskType,
-    build_task_status_index, media_type_for_artifact_path, normalize_task_dependencies,
+    TaskComment, TaskComplexity, TaskCreateStatus, TaskHistoryEntry, TaskPriority, TaskStatus,
+    TaskType, build_task_status_index, media_type_for_artifact_path, normalize_task_dependencies,
     normalize_task_tags, prune_missing_context_files, push_external_ref_if_missing,
     resolve_task_dependencies, task_dependencies_ready, task_matches_tags, unmet_task_dependencies,
     validate_task_dependencies,

--- a/crates/orbit-common/src/types/task.rs
+++ b/crates/orbit-common/src/types/task.rs
@@ -85,6 +85,29 @@ pub enum TaskStatus {
     Someday,
 }
 
+/// Lifecycle states that may be selected when a task is first created.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[cfg_attr(feature = "clap", derive(clap::ValueEnum))]
+#[serde(rename_all = "snake_case")]
+pub enum TaskCreateStatus {
+    /// Awaiting human approval before entering the backlog.
+    Proposed,
+    /// Approved and queued for work; not yet started.
+    Backlog,
+    /// Future-scoped — wanted but not yet actionable.
+    Someday,
+}
+
+impl From<TaskCreateStatus> for TaskStatus {
+    fn from(value: TaskCreateStatus) -> Self {
+        match value {
+            TaskCreateStatus::Proposed => Self::Proposed,
+            TaskCreateStatus::Backlog => Self::Backlog,
+            TaskCreateStatus::Someday => Self::Someday,
+        }
+    }
+}
+
 impl Display for TaskStatus {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.cli_name())

--- a/crates/orbit-core/src/lib.rs
+++ b/crates/orbit-core/src/lib.rs
@@ -77,7 +77,7 @@ pub use orbit_common::types::{
     AuditEvent, AuditEventStatus, AuditStats, AutoTaskDefinition, AutoTaskSchedule,
     AutoTaskTemplate, DedupePolicy, EvidenceKind, ExecutorDef, ExternalRef, JobRun, JobRunState,
     JobRunStep, JobTargetType, Learning, LearningEvidence, LearningScope, LearningStatus,
-    ReviewThreadStatus, Task, TaskComplexity, TaskPriority, TaskStatus, TaskType,
+    ReviewThreadStatus, Task, TaskComplexity, TaskCreateStatus, TaskPriority, TaskStatus, TaskType,
     build_task_status_index, resolve_task_dependencies, task_dependencies_ready,
 };
 pub use orbit_common::types::{MissedRunPolicy, NotFoundKind, OrbitError, OverlapPolicy};

--- a/crates/orbit-dashboard/src/api/tasks.rs
+++ b/crates/orbit-dashboard/src/api/tasks.rs
@@ -8,7 +8,8 @@ use axum::response::{IntoResponse, Json, Response};
 use orbit_common::types::validate_relative_artifact_path;
 use orbit_core::command::task::{TaskAddParams, TaskUpdateParams};
 use orbit_core::{
-    ExternalRef, OrbitRuntime, Task, TaskComplexity, TaskPriority, TaskStatus, TaskType,
+    ExternalRef, OrbitRuntime, Task, TaskComplexity, TaskCreateStatus, TaskPriority, TaskStatus,
+    TaskType,
 };
 use serde::{Deserialize, Deserializer};
 use serde_json::{Value, json};
@@ -60,8 +61,6 @@ pub(super) struct CreateTaskBody {
     #[serde(default)]
     plan: String,
     #[serde(default)]
-    comment: Option<String>,
-    #[serde(default)]
     context_files: Vec<String>,
     #[serde(default)]
     external_refs: Vec<ExternalRef>,
@@ -85,7 +84,7 @@ pub(super) struct CreateTaskBody {
     #[serde(default)]
     task_type: Option<TaskType>,
     #[serde(default)]
-    status: Option<TaskStatus>,
+    status: Option<TaskCreateStatus>,
     #[serde(default)]
     parent_id: Option<String>,
     #[serde(default)]
@@ -306,13 +305,13 @@ pub(super) async fn create_task_action(
         relations: Vec::new(),
         tags: body.tags,
         plan: body.plan,
-        comment: body.comment,
+        comment: None,
         context_files: body.context_files,
         workspace_path: body.workspace_path,
         priority: body.priority,
         complexity: body.complexity,
         task_type: body.task_type,
-        status: body.status,
+        status: body.status.map(Into::into),
         system_created: false,
         external_refs: body.external_refs,
         source_task_id: body.source_task_id,

--- a/crates/orbit-dashboard/src/api/tests/tasks.rs
+++ b/crates/orbit-dashboard/src/api/tests/tasks.rs
@@ -15,6 +15,16 @@ use tower::ServiceExt;
 use super::super::router;
 use super::test_support::body_json;
 
+fn post_json(uri: &str, body: Value) -> Request<Body> {
+    Request::builder()
+        .method(Method::POST)
+        .uri(uri)
+        .header(header::ORIGIN, "http://localhost:7878")
+        .header(header::CONTENT_TYPE, "application/json")
+        .body(Body::from(body.to_string()))
+        .expect("request")
+}
+
 fn seed_task_with_artifact(runtime: &OrbitRuntime) -> orbit_core::Task {
     seed_task_with_artifact_payload(
         runtime,
@@ -746,4 +756,41 @@ async fn create_task_rejects_stray_workspace_body_key() {
     let message = body["error"].as_str().expect("error message");
     assert!(message.contains("workspace"), "names the offending key");
     assert!(message.contains("?workspace="), "points at the query param");
+}
+
+#[tokio::test]
+async fn create_task_only_accepts_creation_legal_statuses_and_ignores_comment() {
+    let runtime = OrbitRuntime::in_memory().expect("build runtime");
+    let app = router().with_state(crate::state::DashboardState::single(Arc::new(runtime)));
+
+    let rejected = app
+        .clone()
+        .oneshot(post_json(
+            "/tasks",
+            json!({
+                "title": "illegal status",
+                "description": "must not start done",
+                "status": "done",
+            }),
+        ))
+        .await
+        .expect("response");
+    assert!(rejected.status().is_client_error());
+
+    let created = app
+        .oneshot(post_json(
+            "/tasks",
+            json!({
+                "title": "legal status",
+                "description": "starts in backlog",
+                "status": "backlog",
+                "comment": "retired create input",
+            }),
+        ))
+        .await
+        .expect("response");
+    assert_eq!(created.status(), StatusCode::OK);
+    let body = body_json(created).await;
+    assert_eq!(body["status"], json!("backlog"));
+    assert_eq!(body["comments"], json!([]));
 }

--- a/crates/orbit-tools/src/builtin/orbit/task/artifact_put.rs
+++ b/crates/orbit-tools/src/builtin/orbit/task/artifact_put.rs
@@ -26,7 +26,7 @@ impl Tool for OrbitTaskArtifactPutTool {
                 required: false,
             },
         ]);
-        parameters.extend(super::super::identity_params());
+        parameters.extend(super::super::model_identity_params());
 
         ToolSchema {
             name: "orbit.task.artifact.put".to_string(),
@@ -37,6 +37,7 @@ impl Tool for OrbitTaskArtifactPutTool {
     }
 
     fn execute(&self, ctx: &ToolContext, input: Value) -> Result<Value, OrbitError> {
+        super::super::reject_agent_field(&input, "orbit.task.artifact.put")?;
         let id = super::super::required_string(&input, &["id"], "id")?;
         let source_path = super::super::required_string(
             &input,

--- a/crates/orbit-tools/src/builtin/orbit/task/start.rs
+++ b/crates/orbit-tools/src/builtin/orbit/task/start.rs
@@ -28,7 +28,7 @@ impl Tool for OrbitTaskStartTool {
                 required: false,
             },
         ]);
-        parameters.extend(super::super::identity_params());
+        parameters.extend(super::super::model_identity_params());
 
         ToolSchema {
             name: "orbit.task.start".to_string(),
@@ -39,6 +39,7 @@ impl Tool for OrbitTaskStartTool {
     }
 
     fn execute(&self, ctx: &ToolContext, input: Value) -> Result<Value, OrbitError> {
+        super::super::reject_agent_field(&input, "orbit.task.start")?;
         super::super::execute_host_action(ctx, input, OrbitBuiltinAction::TaskStart)
     }
 }

--- a/crates/orbit-tools/src/builtin/orbit/task/tests/artifact_put.rs
+++ b/crates/orbit-tools/src/builtin/orbit/task/tests/artifact_put.rs
@@ -68,7 +68,6 @@ fn artifact_put_reads_relative_source_and_delegates_to_task_update() {
                 "id": "ORB-00001",
                 "source_path": "summary.md",
                 "path": "reports/summary.md",
-                "agent": "codex",
                 "model": "gpt-5"
             }),
         )
@@ -86,4 +85,21 @@ fn artifact_put_reads_relative_source_and_delegates_to_task_update() {
         json!([100, 111, 110, 101, 10])
     );
     assert!(call.input.get("source_path").is_none());
+}
+
+#[test]
+fn artifact_put_rejects_agent_identity_field() {
+    let ctx = ToolContext::default();
+    let error = OrbitTaskArtifactPutTool
+        .execute(
+            &ctx,
+            json!({
+                "id": "ORB-00001",
+                "source_path": "summary.md",
+                "agent": "codex",
+            }),
+        )
+        .expect_err("agent must be rejected before reading the source file");
+
+    assert!(error.to_string().contains("use `model`"));
 }

--- a/crates/orbit-tools/tests/public_tool_surface.rs
+++ b/crates/orbit-tools/tests/public_tool_surface.rs
@@ -287,11 +287,16 @@ fn task_update_dependency_params_remain_in_agent_tool_schema() {
 }
 
 #[test]
-fn task_add_update_schemas_use_model_only_identity() {
+fn task_mutation_schemas_use_model_only_identity() {
     let mut registry = ToolRegistry::new();
     registry.register_builtins();
 
-    for tool_name in ["orbit.task.add", "orbit.task.update"] {
+    for tool_name in [
+        "orbit.task.add",
+        "orbit.task.update",
+        "orbit.task.start",
+        "orbit.task.artifact.put",
+    ] {
         let schema = registry
             .get_schema(tool_name)
             .unwrap_or_else(|| panic!("{tool_name} schema"));


### PR DESCRIPTION
## Task

[ORB-10155](https://orbit-cli.com/tasks/ORB-10155) — Trim redundant flags from the `orbit task` CLI surface

### Description

Cleanup of redundant/misleading flags on `orbit task add` (and siblings `update`, `start`, `artifact put`), from a review of `crates/orbit-cli/src/command/task/*.rs`:

1. **Drop `--agent`; keep `--model`.** At creation `--agent` only feeds the attribution label as a fallback — `effective_actor_label` (`orbit-core/src/command/task/helpers.rs:50`) prefers model, the agent family is inferable from the model string (`infer_agent_family_from_model`), routing is owned by `--crew` (ORB-10130), and agent runs already carry identity via the `ORBIT_AGENT_NAME`/`ORBIT_AGENT_MODEL` envelope. Remove `--agent` from `task add`, `task update`, `task start`, and `task artifact put`; keep the env-envelope and `--model` paths intact. Do NOT touch `tool run` — tool-call dispatch still needs the explicit family across its trust boundary (`resolve_agent_identity`, `orbit-core/src/command/tool.rs`).

2. **Introduce a creation-legal status enum for `task add --status`.** The help advertises all 10 `TaskStatus` variants, but `infer_task_create_type_and_status` (`orbit-core/src/command/task/add.rs:131`) rejects `archived` and `friction` at runtime. Add a `TaskCreateStatus` (or equivalent) value-enum limited to `proposed`, `backlog`, `someday` so the help is truthful and `done`/`review`/`rejected`-at-birth footguns disappear. Keep the runtime guard as defense in depth.

3. **Drop `--comment` from `task add`.** An initial comment authored by the same actor at the same instant is redundant with `--description`. Keep `--comment` on `update`/`start`/lifecycle commands where it records something new.

4. **Unify list-flag conventions on `task add`:** `--acceptance-criteria` is repeat-only, `--tag` is repeat+comma-delimited, `--dependencies`/`--context` are comma-strings with `default_value = ""` parsed via `csv_to_vec`. Convert all to repeat + `value_delimiter(',')` `Vec<String>` args and remove the empty-string defaults.

5. **Remove the hidden `--instructions` alias on `--plan`** (`orbit-cli/src/command/task/add.rs:33`) — legacy from the pre-`plan` field name; invisible in help.

Mirror the surface changes in the MCP task tools (`orbit_tool_host/task_tools.rs`) and the dashboard POST path where they share params, and update any activity prompts/templates that still reference removed flags.

### Acceptance Criteria

- `--agent` removed from `task add`, `task update`, `task start`, and `task artifact put`; `--model` and the ORBIT_AGENT_* env envelope still produce correct attribution (existing identity tests pass or are updated)
- `task add --status` only accepts and advertises creation-legal statuses (proposed, backlog, someday); help output no longer lists archived/friction/done/review/rejected/blocked/in-progress for creation
- `--comment` removed from `task add`; still present on update/start
- `--acceptance-criteria`, `--tag`, `--dependencies`, `--context` all accept repeat and comma-delimited forms uniformly; empty-string defaults and `csv_to_vec` usage in task add are gone
- hidden `--instructions` alias removed
- MCP task tools and dashboard task-create paths reflect the same surface; no test or activity prompt still uses a removed flag
- cargo test green

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Removed --agent from task add/update/start/artifact put while retaining --model and managed ORBIT_AGENT_* attribution through a shared task-mutation identity helper.
- Added TaskCreateStatus with proposed/backlog/someday only; wired it into CLI help/parsing and dashboard task creation while retaining the core runtime guards.
- Removed task-add --comment and --instructions alias; normalized acceptance criteria, tags, dependencies, and context to repeated/comma-delimited Vec arguments without csv_to_vec or empty list defaults.
- Mirrored model-only identity in MCP start/artifact-put schemas and rejection behavior, updated the production tools/list snapshot, and removed dashboard initial comments.
- Added CLI, dashboard, MCP/tool, list parsing, legal-status help, removed-flag, and model/env attribution coverage; added the Unreleased changelog entry.
- Required unlisted files were recorded in task comments before edits.

Assessment: The scoped task surfaces now agree and the full Cargo test suite passes. No new dependency edge or ADR was required.

Validation:
- cargo test: passed (with identity env unset per L-0068 and umask 077 for secure companion fixtures)
- cargo check -p orbit-cli -p orbit-dashboard -p orbit-tools: passed
- targeted CLI/dashboard/orbit-tools/MCP snapshot tests: passed
- cargo fmt --all -- --check and all ci-fast guardrails except installer security: passed
- make ci-fast could not complete because node is absent from the runner PATH; scripts/test-installer-security.sh was the only skipped check. Friction F2026-07-018 records this environment limitation.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10155-6a532183`
- Behind base: 0
- Ahead of base: 1