### PR TITLE
Pipeline worktree GC: reclaim orphaned jrun worktrees

### DIFF
--- a/.orbit/learnings/L-0078/learning.yaml
+++ b/.orbit/learnings/L-0078/learning.yaml
@@ -1,0 +1,32 @@
+schema_version: 1
+id: L-0078
+status: active
+scope:
+  paths:
+  - crates/orbit-core/src/command/job/run/**
+  - crates/orbit-engine/src/executor/automation/vcs/worktree/**
+  tags:
+  - pipeline
+  - worktree
+  - gc
+  - disk
+summary: 'Pipeline job-run worktrees leaked disk unboundedly (~116G on dk-server-1): a git worktree was created per run and never reclaimed. Fixed by worktree GC (ORB-10173).'
+body: |-
+  Orbit creates a git worktree per pipeline run under .orbit/state/worktrees/<prefix>-<run_id>/ and historically never reclaimed it, so disk grew by the full build-artifact footprint every run.
+
+  GC (`orbit run gc`, + on-completion reap in finalize) maps each worktree dir to its run_id via the `jrun-` token, reconciles against the run table, reaps terminal successes immediately and failed/timeout/interrupted after a configurable retention window ([worktree] gc_failed_retention_days, default 7), and cancels orphaned non-terminal records before reclaiming.
+
+  Key design points for future work:
+  - Concurrency-safety is the run-table LIVENESS CHECK (running_run_owner_is_stale / pending_run_stale_reason), NOT a filesystem lock — the pipeline holds no worktree-wide lock. `git worktree remove --force` takes git's own lock; resume reuses only retained interrupted runs; retries mint a new run id + new worktree, so no reuse race.
+  - Reclaim is language-agnostic: `git worktree remove --force` with a raw remove_dir_all fallback, then prune + branch -D. No Cargo/target special-casing.
+  - GC never reclaims the caller's own cwd worktree.
+
+  See crates/orbit-core/src/command/job/run/gc.rs. Resolves F2026-07-019 (overlaps F2026-07-016/ORB-10153).
+evidence:
+- kind: task
+  reference: ORB-10173
+- kind: external
+  reference: crates/orbit-core/src/command/job/run/gc.rs
+created_at: 2026-07-12T20:52:11.547775239Z
+updated_at: 2026-07-12T20:52:11.547775239Z
+created_by: claude

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- **Pipeline worktree GC**: `orbit run gc` reconciles `.orbit/state/worktrees/*` against the run table — reclaiming worktrees with no live run, cancelling orphaned non-terminal records, keeping failed/timeout/interrupted trees for a configurable window (`[worktree] gc_failed_retention_days`, default 7) — and terminal successes reap on completion. Language-agnostic; never touches a live run's worktree. ([ORB-10173])
 - **Task creation surface is narrower and consistent**: task creation now exposes only legal initial statuses, list flags share repeat/comma parsing, and redundant agent/comment/instructions inputs are removed while model and managed identity attribution remain intact. ([ORB-10155])
 
 ### Breaking Changes

--- a/crates/orbit-cli/src/audit_middleware.rs
+++ b/crates/orbit-cli/src/audit_middleware.rs
@@ -751,6 +751,7 @@ fn run_command_meta(cmd: &crate::command::run::RunCommand) -> CommandMeta {
         RunSubcommand::Events(args) => ("events", Some("job_run"), args.run_id.as_deref()),
         RunSubcommand::Trace(args) => ("trace", Some("job_run"), args.run_id.as_deref()),
         RunSubcommand::Cancel(args) => ("cancel", Some("job_run"), Some(args.run_id.as_str())),
+        RunSubcommand::Gc(_) => ("gc", Some("workflow"), Some("gc")),
         RunSubcommand::Job(args) => ("job", Some("job"), Some(args.job_id.as_str())),
     };
 

--- a/crates/orbit-cli/src/command/run/command.rs
+++ b/crates/orbit-cli/src/command/run/command.rs
@@ -6,6 +6,7 @@ use crate::command::Execute;
 use super::cancel::RunCancelArgs;
 use super::duel;
 use super::events::RunEventsArgs;
+use super::gc::RunGcArgs;
 use super::history::RunHistoryArgs;
 use super::job::JobRunArgs;
 use super::logs::RunLogsArgs;
@@ -33,6 +34,7 @@ Run history:
 
 Maintenance:
   orbit run cancel <run_id>
+  orbit run gc [--dry-run] [--json]
 ";
 
 #[derive(Args)]
@@ -63,6 +65,7 @@ Audits:
 
 Maintenance:
   cancel     Cancel a pending or running job run
+  gc         Reclaim orphaned pipeline worktrees under the retention policy
 
 Options:
 {options}
@@ -106,6 +109,8 @@ pub enum RunSubcommand {
     Trace(RunTraceArgs),
     /// Cancel a pending or running job run
     Cancel(RunCancelArgs),
+    /// Reclaim orphaned pipeline worktrees under the retention policy
+    Gc(RunGcArgs),
     /// Run an arbitrary job by ID
     Job(JobRunArgs),
 }
@@ -126,6 +131,7 @@ impl Execute for RunSubcommand {
             RunSubcommand::Events(command) => command.execute(runtime),
             RunSubcommand::Trace(command) => command.execute(runtime),
             RunSubcommand::Cancel(command) => command.execute(runtime),
+            RunSubcommand::Gc(command) => command.execute(runtime),
             RunSubcommand::Job(command) => command.execute(runtime),
         }
     }

--- a/crates/orbit-cli/src/command/run/gc.rs
+++ b/crates/orbit-cli/src/command/run/gc.rs
@@ -1,0 +1,91 @@
+//! `orbit run gc` — reclaim orphaned pipeline worktrees [ORB-10173].
+//!
+//! Reconciles `.orbit/state/worktrees/*` against the run table and removes any
+//! worktree with no live run, under the configured retention policy (failed /
+//! timeout / interrupted worktrees are kept for a debugging window; success /
+//! cancelled reap immediately). Orphaned non-terminal run records are cancelled
+//! before their worktree is reclaimed. A live run's worktree is never touched,
+//! so this is safe to run while other runs are in flight.
+
+use clap::Args;
+use orbit_core::command::job::WorktreeGcOptions;
+use orbit_core::{OrbitError, OrbitRuntime};
+use serde_json::json;
+
+use crate::command::Execute;
+
+#[derive(Args)]
+#[command(
+    about = "Reclaim orphaned pipeline worktrees under the retention policy",
+    after_help = "Reconciles `.orbit/state/worktrees/*` against the run table: reclaims worktrees \
+with no live run, cancels orphaned non-terminal run records, and keeps recent failed-run \
+worktrees for debugging. Never removes a worktree owned by a live run, so it is safe to run \
+while pipelines are in flight.\n\nExamples:\n  orbit run gc\n  orbit run gc --dry-run --json\n  \
+orbit run gc --failed-retention-days 3"
+)]
+pub struct RunGcArgs {
+    /// Report what would be reclaimed without removing anything.
+    #[arg(long)]
+    pub dry_run: bool,
+
+    /// Override the retention window (days) for failed/timeout/interrupted run
+    /// worktrees. Defaults to the workspace `[worktree] gc_failed_retention_days`.
+    #[arg(long)]
+    pub failed_retention_days: Option<i64>,
+
+    /// Output as JSON.
+    #[arg(long)]
+    pub json: bool,
+}
+
+impl Execute for RunGcArgs {
+    fn execute(self, runtime: &OrbitRuntime) -> Result<(), OrbitError> {
+        let options = WorktreeGcOptions {
+            dry_run: self.dry_run,
+            failed_retention_days: self.failed_retention_days,
+        };
+        let outcome = runtime.gc_worktrees(&options)?;
+
+        if self.json {
+            let entries: Vec<_> = outcome
+                .entries
+                .iter()
+                .map(|entry| {
+                    json!({
+                        "worktree": entry.worktree,
+                        "run_id": entry.run_id,
+                        "run_state": entry.run_state.map(|state| state.to_string()),
+                        "action": entry.action.as_str(),
+                        "reason": entry.reason,
+                        "cancelled_orphan": entry.cancelled_orphan,
+                    })
+                })
+                .collect();
+            return crate::output::json::print_pretty(&json!({
+                "dry_run": self.dry_run,
+                "scanned": outcome.scanned,
+                "reclaimed": outcome.reclaimed,
+                "cancelled_orphans": outcome.cancelled_orphans,
+                "entries": entries,
+            }));
+        }
+
+        for entry in &outcome.entries {
+            let run = entry.run_id.as_deref().unwrap_or("-");
+            println!("{:<14} {run}  {}", entry.action.as_str(), entry.worktree);
+            if !entry.reason.is_empty() {
+                println!("               {}", entry.reason);
+            }
+        }
+        let verb = if self.dry_run {
+            "would reclaim"
+        } else {
+            "reclaimed"
+        };
+        println!(
+            "{verb} {}/{} worktree(s); cancelled {} orphaned run record(s)",
+            outcome.reclaimed, outcome.scanned, outcome.cancelled_orphans
+        );
+        Ok(())
+    }
+}

--- a/crates/orbit-cli/src/command/run/mod.rs
+++ b/crates/orbit-cli/src/command/run/mod.rs
@@ -3,6 +3,7 @@ mod command;
 pub mod duel;
 mod events;
 mod format;
+mod gc;
 mod history;
 pub mod job;
 pub mod legacy_logs;

--- a/crates/orbit-core/src/command/job/mod.rs
+++ b/crates/orbit-core/src/command/job/mod.rs
@@ -8,4 +8,7 @@ mod tests;
 pub(crate) use catalog::seed_default_jobs;
 pub use catalog::{JobCatalogEntry, JobCatalogFilter};
 pub use exec::V2JobRunResult;
-pub use run::{JobRunCancelResult, JobRunListParams};
+pub use run::{
+    DEFAULT_FAILED_RETENTION_DAYS, JobRunCancelResult, JobRunListParams, WorktreeGcAction,
+    WorktreeGcEntry, WorktreeGcOptions, WorktreeGcOutcome,
+};

--- a/crates/orbit-core/src/command/job/run/gc.rs
+++ b/crates/orbit-core/src/command/job/run/gc.rs
@@ -1,0 +1,549 @@
+//! [ORB-10173] Pipeline worktree garbage collection.
+//!
+//! Orbit creates a git worktree per pipeline run under
+//! `.orbit/state/worktrees/<prefix>-<run_id>/` and historically never reclaimed
+//! it, so disk grew by the full build-artifact footprint (Rust `target/`, Java
+//! `build/`, `node_modules`, …) every run and never shrank — a slow leak that
+//! re-filled dk-server-1's root fs within weeks (F2026-07-019, and the
+//! orphaned-run family of F2026-07-016 / ORB-10153).
+//!
+//! This module reclaims those worktrees under a retention policy:
+//!
+//! - **Success / cancelled / skipped** runs reap immediately — the branch is
+//!   already merged or pushed, nothing debuggable remains.
+//! - **Failed / timeout / interrupted** runs are retained for a configurable
+//!   window (default [`DEFAULT_FAILED_RETENTION_DAYS`]) so a human can inspect
+//!   the failing tree, then reaped once they age out.
+//! - **A live run's worktree is never touched.** "Live" means a non-terminal
+//!   run record whose owner process is still alive (probed via the same
+//!   liveness helpers the orphan reconciler uses). This is the
+//!   concurrency-safety guarantee: a worktree belonging to an in-flight run is
+//!   never a reclaim candidate, even while other runs sweep concurrently.
+//! - **Orphaned non-terminal records** (a `pending`/`running` row whose worker
+//!   is conclusively gone) are cancelled, then their worktree is reclaimed.
+//! - **Worktrees with no run record at all** are reclaimed as pure orphans.
+//!
+//! Reclaim is **language-agnostic**: it removes the worktree directory whatever
+//! the workspace's build system put there, with no Cargo-specific casing.
+
+use std::collections::BTreeSet;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use chrono::{DateTime, Duration, Utc};
+use orbit_common::types::{JobRun, JobRunState, OrbitError};
+
+use crate::OrbitRuntime;
+
+use super::owner::{pending_run_stale_reason, running_run_owner_is_stale};
+
+/// Default retention window for failed / timeout / interrupted run worktrees.
+/// A failed run's tree is useful for debugging (and an interrupted run's is
+/// resumable), so keep it this many days before reaping.
+pub const DEFAULT_FAILED_RETENTION_DAYS: i64 = 7;
+
+/// Options for one worktree GC pass.
+#[derive(Debug, Clone, Default)]
+pub struct WorktreeGcOptions {
+    /// Report what would be reclaimed without removing anything or cancelling
+    /// any orphaned run record.
+    pub dry_run: bool,
+    /// Override the failed/timeout/interrupted retention window (days). When
+    /// `None`, the workspace-configured value is used.
+    pub failed_retention_days: Option<i64>,
+}
+
+/// What a GC pass decided to do with a single worktree directory.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WorktreeGcAction {
+    /// Reclaimed: the worktree directory was removed.
+    Reclaimed,
+    /// Kept because a live run still owns the worktree.
+    KeptLive,
+    /// Kept because a terminal failure is still inside its retention window.
+    KeptRetained,
+    /// Skipped because the directory name did not map to a run id.
+    SkippedUnknown,
+    /// Would reclaim, but this was a dry run.
+    WouldReclaim,
+}
+
+impl WorktreeGcAction {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            WorktreeGcAction::Reclaimed => "reclaimed",
+            WorktreeGcAction::KeptLive => "kept_live",
+            WorktreeGcAction::KeptRetained => "kept_retained",
+            WorktreeGcAction::SkippedUnknown => "skipped_unknown",
+            WorktreeGcAction::WouldReclaim => "would_reclaim",
+        }
+    }
+}
+
+/// Per-directory outcome of one GC pass.
+#[derive(Debug, Clone)]
+pub struct WorktreeGcEntry {
+    /// Absolute path of the worktree directory.
+    pub worktree: String,
+    /// Run id extracted from the directory name, when one was found.
+    pub run_id: Option<String>,
+    /// State of the matched run record, when a record exists.
+    pub run_state: Option<JobRunState>,
+    /// Action taken.
+    pub action: WorktreeGcAction,
+    /// Human-readable justification.
+    pub reason: String,
+    /// True when an orphaned non-terminal run record was cancelled as part of
+    /// reclaiming this worktree.
+    pub cancelled_orphan: bool,
+}
+
+/// Result of one worktree GC pass.
+#[derive(Debug, Clone, Default)]
+pub struct WorktreeGcOutcome {
+    /// Per-directory outcomes.
+    pub entries: Vec<WorktreeGcEntry>,
+    /// Number of worktrees reclaimed (or that would be, in a dry run).
+    pub reclaimed: usize,
+    /// Number of orphaned non-terminal run records cancelled.
+    pub cancelled_orphans: usize,
+    /// Number of directories scanned.
+    pub scanned: usize,
+}
+
+/// Immutable per-pass context, computed once in [`OrbitRuntime::gc_worktrees`]
+/// and threaded to each directory's reclaim decision. Bundled into one struct
+/// so the per-directory helper stays under the argument-count lint.
+struct GcPass {
+    retention_days: i64,
+    now: DateTime<Utc>,
+    dry_run: bool,
+    /// The caller's own worktree (canonicalized), never reclaimed.
+    protected: Option<PathBuf>,
+}
+
+/// Reclaim disposition for a single worktree, computed purely from the matched
+/// run record (if any) and the retention policy. Isolating this from the git /
+/// filesystem side effects keeps the concurrency-safety rule
+/// ("never reclaim a live run's worktree") unit-testable without a real repo.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum WorktreeDisposition {
+    /// Non-terminal run with a live owner — never touch it.
+    KeepLive,
+    /// Terminal failure still inside the retention window.
+    Retain,
+    /// Terminal and reap-eligible (success/cancelled/skipped, or a failure past
+    /// its retention window).
+    ReclaimTerminal,
+    /// Non-terminal run whose owner is conclusively gone: cancel the record,
+    /// then reclaim.
+    ReclaimOrphanRecord,
+    /// No run record maps to this worktree — a pure orphan.
+    ReclaimNoRecord,
+}
+
+/// Decide what to do with a worktree given its matched run record.
+///
+/// `now` and `retention_days` are injected so the retention boundary is
+/// deterministic in tests. Owner liveness is probed via the shared
+/// [`running_run_owner_is_stale`] / [`pending_run_stale_reason`] helpers so GC
+/// classifies liveness exactly as the orphan reconciler does.
+pub(super) fn classify_worktree(
+    run: Option<&JobRun>,
+    retention_days: i64,
+    now: DateTime<Utc>,
+) -> WorktreeDisposition {
+    let Some(run) = run else {
+        return WorktreeDisposition::ReclaimNoRecord;
+    };
+    if !run.state.is_terminal() {
+        // Non-terminal: keep unless the owner is conclusively gone.
+        let orphaned = match run.state {
+            JobRunState::Pending => pending_run_stale_reason(run).is_some(),
+            JobRunState::Running => running_run_owner_is_stale(run),
+            // Retrying / Skipped-as-non-terminal and any other transient state:
+            // treat as live and keep. These are short-lived and never own a
+            // long-lived worktree that needs reaping.
+            _ => false,
+        };
+        return if orphaned {
+            WorktreeDisposition::ReclaimOrphanRecord
+        } else {
+            WorktreeDisposition::KeepLive
+        };
+    }
+
+    // Terminal. Success/cancelled/skipped reap immediately; failures are
+    // retained for the debugging/resume window.
+    if is_retained_failure_state(run.state) {
+        let finished = run.finished_at.unwrap_or(run.scheduled_at);
+        let age = now.signed_duration_since(finished);
+        if age < Duration::days(retention_days.max(0)) {
+            return WorktreeDisposition::Retain;
+        }
+    }
+    WorktreeDisposition::ReclaimTerminal
+}
+
+/// Terminal states whose worktree is retained for the failure window: a failed
+/// or timed-out run is useful for debugging, and an interrupted run is
+/// resumable from its checkpoints (ORB-10002).
+fn is_retained_failure_state(state: JobRunState) -> bool {
+    matches!(
+        state,
+        JobRunState::Failed | JobRunState::Timeout | JobRunState::Interrupted
+    )
+}
+
+impl OrbitRuntime {
+    /// Reconcile `.orbit/state/worktrees/*` against the run table and reclaim
+    /// every worktree with no live run, applying the retention policy. Safe to
+    /// run while other runs are in flight — a live run's worktree is never a
+    /// reclaim candidate (see [`classify_worktree`]).
+    pub fn gc_worktrees(
+        &self,
+        options: &WorktreeGcOptions,
+    ) -> Result<WorktreeGcOutcome, OrbitError> {
+        let pass = GcPass {
+            retention_days: options
+                .failed_retention_days
+                .unwrap_or_else(|| self.worktree_gc_failed_retention_days()),
+            now: Utc::now(),
+            dry_run: options.dry_run,
+            protected: current_worktree_guard(),
+        };
+        let repo_root = PathBuf::from(current_repo_root(self)?);
+
+        let mut outcome = WorktreeGcOutcome::default();
+        for dir in self.scan_worktree_dirs()? {
+            outcome.scanned += 1;
+            self.gc_one_worktree(&repo_root, &dir, &pass, &mut outcome)?;
+        }
+        Ok(outcome)
+    }
+
+    /// Best-effort reap of the just-finalized run's worktree. Invoked from the
+    /// finalization path for terminal transitions; only reaps immediately
+    /// reap-eligible states (success/cancelled/skipped) so failures ride the
+    /// retention window. Never returns an error — a GC hiccup must never block
+    /// a run from finalizing.
+    pub(crate) fn best_effort_reap_finalized_worktree(&self, run_id: &str, state: JobRunState) {
+        if !state.is_terminal() || is_retained_failure_state(state) {
+            return;
+        }
+        if let Err(error) = self.reap_finalized_worktree(run_id) {
+            tracing::warn!(
+                target: "orbit.core.worktree_gc",
+                run_id,
+                error = %error,
+                "best-effort worktree reap on finalize failed; the sweep will reclaim it later",
+            );
+        }
+    }
+
+    fn reap_finalized_worktree(&self, run_id: &str) -> Result<(), OrbitError> {
+        let repo_root = PathBuf::from(current_repo_root(self)?);
+        let protected = current_worktree_guard();
+        for dir in self.scan_worktree_dirs()? {
+            if extract_run_id(&dir).as_deref() != Some(run_id) {
+                continue;
+            }
+            if is_protected(&dir, protected.as_deref()) {
+                continue;
+            }
+            reclaim_worktree(&repo_root, &dir)?;
+        }
+        Ok(())
+    }
+
+    fn gc_one_worktree(
+        &self,
+        repo_root: &Path,
+        dir: &Path,
+        pass: &GcPass,
+        outcome: &mut WorktreeGcOutcome,
+    ) -> Result<(), OrbitError> {
+        let worktree = dir.to_string_lossy().to_string();
+        let Some(run_id) = extract_run_id(dir) else {
+            outcome.entries.push(WorktreeGcEntry {
+                worktree,
+                run_id: None,
+                run_state: None,
+                action: WorktreeGcAction::SkippedUnknown,
+                reason: "directory name does not contain a run id".to_string(),
+                cancelled_orphan: false,
+            });
+            return Ok(());
+        };
+
+        // Never reclaim the caller's own worktree (e.g. a GC invoked from
+        // inside a live run's checkout).
+        if is_protected(dir, pass.protected.as_deref()) {
+            outcome.entries.push(WorktreeGcEntry {
+                worktree,
+                run_id: Some(run_id),
+                run_state: None,
+                action: WorktreeGcAction::KeptLive,
+                reason: "worktree is the current working directory".to_string(),
+                cancelled_orphan: false,
+            });
+            return Ok(());
+        }
+
+        let run = self.stores().jobs().get_run(&run_id)?;
+        let run_state = run.as_ref().map(|run| run.state);
+        let disposition = classify_worktree(run.as_ref(), pass.retention_days, pass.now);
+        let state_label = || {
+            run_state
+                .map(|state| state.to_string())
+                .unwrap_or_else(|| "run".to_string())
+        };
+
+        let (action, reason, cancelled_orphan) = match disposition {
+            WorktreeDisposition::KeepLive => (
+                WorktreeGcAction::KeptLive,
+                "live run owns this worktree".to_string(),
+                false,
+            ),
+            WorktreeDisposition::Retain => (
+                WorktreeGcAction::KeptRetained,
+                format!(
+                    "terminal {} retained for {}d debugging window",
+                    state_label(),
+                    pass.retention_days
+                ),
+                false,
+            ),
+            WorktreeDisposition::ReclaimNoRecord => {
+                self.reclaim_or_would(repo_root, dir, pass.dry_run)?;
+                (
+                    reclaim_action(pass.dry_run),
+                    "no run record maps to this worktree".to_string(),
+                    false,
+                )
+            }
+            WorktreeDisposition::ReclaimTerminal => {
+                self.reclaim_or_would(repo_root, dir, pass.dry_run)?;
+                (
+                    reclaim_action(pass.dry_run),
+                    format!("terminal {} reap-eligible", state_label()),
+                    false,
+                )
+            }
+            WorktreeDisposition::ReclaimOrphanRecord => {
+                let cancelled = self.cancel_orphaned_run_record(&run_id, pass.dry_run);
+                self.reclaim_or_would(repo_root, dir, pass.dry_run)?;
+                (
+                    reclaim_action(pass.dry_run),
+                    "orphaned non-terminal run record (no live worker)".to_string(),
+                    cancelled,
+                )
+            }
+        };
+
+        if matches!(
+            action,
+            WorktreeGcAction::Reclaimed | WorktreeGcAction::WouldReclaim
+        ) {
+            outcome.reclaimed += 1;
+        }
+        if cancelled_orphan {
+            outcome.cancelled_orphans += 1;
+        }
+        outcome.entries.push(WorktreeGcEntry {
+            worktree,
+            run_id: Some(run_id),
+            run_state,
+            action,
+            reason,
+            cancelled_orphan,
+        });
+        Ok(())
+    }
+
+    fn reclaim_or_would(
+        &self,
+        repo_root: &Path,
+        dir: &Path,
+        dry_run: bool,
+    ) -> Result<(), OrbitError> {
+        if dry_run {
+            return Ok(());
+        }
+        reclaim_worktree(repo_root, dir)
+    }
+
+    /// Cancel an orphaned non-terminal run record so its coupled tasks unblock
+    /// and its reservations release. Best-effort: a cancel failure must not
+    /// stop the worktree reclaim.
+    fn cancel_orphaned_run_record(&self, run_id: &str, dry_run: bool) -> bool {
+        if dry_run {
+            return true;
+        }
+        match self.cancel_job_run_with_context(run_id, "system", "worktree_gc") {
+            Ok(_) => true,
+            Err(error) => {
+                tracing::warn!(
+                    target: "orbit.core.worktree_gc",
+                    run_id,
+                    error = %error,
+                    "failed to cancel orphaned run record during worktree GC; reclaiming anyway",
+                );
+                false
+            }
+        }
+    }
+
+    /// All worktree directories to consider: the workspace-local
+    /// `.orbit/state/worktrees/` plus, when `ORBIT_WORKTREE_ROOT` is set, the
+    /// per-repo directory under that root (mirrors
+    /// `resolve_worktree_path_from_prefix`).
+    fn scan_worktree_dirs(&self) -> Result<Vec<PathBuf>, OrbitError> {
+        let mut roots: BTreeSet<PathBuf> = BTreeSet::new();
+        roots.insert(self.paths().worktrees_dir.clone());
+        if let Ok(root) = std::env::var("ORBIT_WORKTREE_ROOT") {
+            let root = root.trim();
+            if !root.is_empty()
+                && let Some(name) = self.paths().repo_root.file_name().and_then(|n| n.to_str())
+            {
+                roots.insert(PathBuf::from(root).join(name));
+            }
+        }
+
+        let mut dirs = Vec::new();
+        for root in roots {
+            if !root.is_dir() {
+                continue;
+            }
+            let entries = std::fs::read_dir(&root).map_err(|error| {
+                OrbitError::Io(format!(
+                    "failed to read worktree root '{}': {error}",
+                    root.display()
+                ))
+            })?;
+            for entry in entries {
+                let entry = entry.map_err(|error| {
+                    OrbitError::Io(format!("failed to read worktree entry: {error}"))
+                })?;
+                let path = entry.path();
+                if path.is_dir() {
+                    dirs.push(path);
+                }
+            }
+        }
+        dirs.sort();
+        Ok(dirs)
+    }
+}
+
+/// Reclaim a single worktree directory, language-agnostically. Tries a clean
+/// `git worktree remove --force` first; if git cannot resolve it as a worktree
+/// (metadata drift, already-detached dir), falls back to a raw recursive
+/// delete. Always prunes stale worktree metadata and best-effort deletes the
+/// linked branch afterwards.
+fn reclaim_worktree(repo_root: &Path, dir: &Path) -> Result<(), OrbitError> {
+    let branch = detect_worktree_branch(repo_root, dir);
+
+    let removed_via_git = git_success(
+        repo_root,
+        &["worktree", "remove", "--force", &dir.to_string_lossy()],
+    );
+    if !removed_via_git && dir.exists() {
+        std::fs::remove_dir_all(dir).map_err(|error| {
+            OrbitError::Io(format!(
+                "failed to remove worktree directory '{}': {error}",
+                dir.display()
+            ))
+        })?;
+    }
+    // Prune the dangling administrative entry left by a raw delete (no-op after
+    // a clean `worktree remove`).
+    let _ = git_success(repo_root, &["worktree", "prune"]);
+    if let Some(branch) = branch {
+        let _ = git_success(repo_root, &["branch", "-D", &branch]);
+    }
+    Ok(())
+}
+
+/// Best-effort branch name for a linked worktree, read from
+/// `git worktree list --porcelain` before removal.
+fn detect_worktree_branch(repo_root: &Path, dir: &Path) -> Option<String> {
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(repo_root)
+        .args(["worktree", "list", "--porcelain"])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let listing = String::from_utf8(output.stdout).ok()?;
+    let target = dir.to_string_lossy();
+    let mut matching = false;
+    for line in listing.lines() {
+        if let Some(path) = line.strip_prefix("worktree ") {
+            matching = path == target;
+            continue;
+        }
+        if matching && let Some(branch) = line.strip_prefix("branch refs/heads/") {
+            return Some(branch.to_string());
+        }
+        if line.is_empty() {
+            matching = false;
+        }
+    }
+    None
+}
+
+fn git_success(repo_root: &Path, args: &[&str]) -> bool {
+    Command::new("git")
+        .arg("-C")
+        .arg(repo_root)
+        .args(args)
+        .output()
+        .map(|output| output.status.success())
+        .unwrap_or(false)
+}
+
+fn reclaim_action(dry_run: bool) -> WorktreeGcAction {
+    if dry_run {
+        WorktreeGcAction::WouldReclaim
+    } else {
+        WorktreeGcAction::Reclaimed
+    }
+}
+
+/// The canonical repo root the run worktrees are linked to. Falls back to the
+/// workspace's recorded `repo_root` when the runtime cannot resolve a live git
+/// checkout.
+fn current_repo_root(runtime: &OrbitRuntime) -> Result<String, OrbitError> {
+    use orbit_engine::RuntimeHost;
+    RuntimeHost::repo_root(runtime)
+}
+
+/// The caller's own worktree (canonicalized), so GC never reclaims the tree it
+/// is running inside.
+fn current_worktree_guard() -> Option<PathBuf> {
+    let cwd = std::env::current_dir().ok()?;
+    Some(cwd.canonicalize().unwrap_or(cwd))
+}
+
+pub(super) fn is_protected(dir: &Path, protected: Option<&Path>) -> bool {
+    let Some(protected) = protected else {
+        return false;
+    };
+    let dir = dir.canonicalize().unwrap_or_else(|_| dir.to_path_buf());
+    protected.starts_with(&dir)
+}
+
+/// Extract the `jrun-…` run id embedded in a worktree directory name. Worktrees
+/// are named `<prefix>-<sanitized_run_id>` (e.g. `orbit-jrun-20260712-2021-4`,
+/// `parallel-batch-jrun-…`); run ids are always `jrun-`-prefixed and contain
+/// only characters the worktree-token sanitizer preserves, so the id is the
+/// substring from the first `jrun-`. Directories with no `jrun-` token are
+/// left untouched.
+pub(super) fn extract_run_id(dir: &Path) -> Option<String> {
+    let name = dir.file_name()?.to_str()?;
+    let idx = name.find("jrun-")?;
+    Some(name[idx..].to_string())
+}

--- a/crates/orbit-core/src/command/job/run/mod.rs
+++ b/crates/orbit-core/src/command/job/run/mod.rs
@@ -5,9 +5,12 @@
 //! - `query` — list/show/history entry points plus backend queries.
 //! - `reconcile` — stale-run reconciliation, terminal timing repair, audit parsing.
 //! - `owner` — process signalling, owner identity classification, liveness probes (Unix + shims).
+//! - `gc` — pipeline worktree garbage collection: reconcile `.orbit/state/worktrees/*`
+//!   against the run table and reclaim non-live worktrees under a retention policy (ORB-10173).
 //! - `tests/*` — helpers and regression tests split by concern (actions, reconcile, owner).
 
 mod actions;
+mod gc;
 mod owner;
 mod query;
 mod reconcile;
@@ -16,4 +19,8 @@ mod types;
 #[cfg(test)]
 mod tests;
 
+pub use gc::{
+    DEFAULT_FAILED_RETENTION_DAYS, WorktreeGcAction, WorktreeGcEntry, WorktreeGcOptions,
+    WorktreeGcOutcome,
+};
 pub use types::{JobRunCancelResult, JobRunListParams};

--- a/crates/orbit-core/src/command/job/run/tests/gc.rs
+++ b/crates/orbit-core/src/command/job/run/tests/gc.rs
@@ -1,0 +1,272 @@
+//! [ORB-10173] Worktree GC tests: the pure reclaim-disposition classifier
+//! (which encodes the concurrency-safety rule) plus an end-to-end reclaim over
+//! a real git repo with two worktrees.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use chrono::{Duration, Utc};
+use orbit_common::types::{JobRun, JobRunState};
+
+use super::test_runtime;
+use crate::command::job::run::gc::{
+    WorktreeDisposition, WorktreeGcOptions, classify_worktree, extract_run_id, is_protected,
+};
+
+const RETENTION_DAYS: i64 = 7;
+
+/// Minimal `JobRun` with a given state; timestamps default to "just now".
+fn fake_run(state: JobRunState) -> JobRun {
+    let now = Utc::now();
+    JobRun {
+        run_id: "jrun-20260712-2021-4".to_string(),
+        job_id: "task_pr_pipeline".to_string(),
+        attempt: 1,
+        state,
+        scheduled_at: now,
+        started_at: Some(now),
+        finished_at: Some(now),
+        duration_ms: Some(0),
+        created_at: now,
+        pid: None,
+        pid_start_time: None,
+        input: None,
+        retry_source_run_id: None,
+        knowledge_metrics: None,
+        resolved_crew: None,
+        crew_model: None,
+        steps: Vec::new(),
+    }
+}
+
+#[test]
+fn live_running_run_is_never_reclaimed() {
+    // A running run whose owner process is alive (this test process) must be
+    // kept — this is the concurrency-safety guarantee.
+    let mut run = fake_run(JobRunState::Running);
+    run.pid = Some(std::process::id());
+    run.pid_start_time = None; // LegacyLiveUnverified → alive → not stale.
+    assert_eq!(
+        classify_worktree(Some(&run), RETENTION_DAYS, Utc::now()),
+        WorktreeDisposition::KeepLive,
+    );
+}
+
+#[test]
+fn recently_created_pending_run_is_kept() {
+    let mut run = fake_run(JobRunState::Pending);
+    run.pid = None; // never claimed…
+    run.created_at = Utc::now(); // …but inside the unclaimed grace window.
+    assert_eq!(
+        classify_worktree(Some(&run), RETENTION_DAYS, Utc::now()),
+        WorktreeDisposition::KeepLive,
+    );
+}
+
+#[test]
+fn running_run_with_dead_owner_is_orphan_reclaimed() {
+    let mut run = fake_run(JobRunState::Running);
+    // A PID that is conclusively gone. Signal-0 to a huge PID returns ESRCH.
+    run.pid = Some(0x7FFF_FFFE);
+    run.pid_start_time = None;
+    assert_eq!(
+        classify_worktree(Some(&run), RETENTION_DAYS, Utc::now()),
+        WorktreeDisposition::ReclaimOrphanRecord,
+    );
+}
+
+#[test]
+fn success_run_reaps_immediately() {
+    let run = fake_run(JobRunState::Success);
+    assert_eq!(
+        classify_worktree(Some(&run), RETENTION_DAYS, Utc::now()),
+        WorktreeDisposition::ReclaimTerminal,
+    );
+}
+
+#[test]
+fn cancelled_run_reaps_immediately() {
+    let run = fake_run(JobRunState::Cancelled);
+    assert_eq!(
+        classify_worktree(Some(&run), RETENTION_DAYS, Utc::now()),
+        WorktreeDisposition::ReclaimTerminal,
+    );
+}
+
+#[test]
+fn failed_run_is_retained_inside_window_and_reaped_after() {
+    let mut run = fake_run(JobRunState::Failed);
+    let now = Utc::now();
+    run.finished_at = Some(now - Duration::days(1));
+    assert_eq!(
+        classify_worktree(Some(&run), RETENTION_DAYS, now),
+        WorktreeDisposition::Retain,
+    );
+
+    run.finished_at = Some(now - Duration::days(RETENTION_DAYS + 1));
+    assert_eq!(
+        classify_worktree(Some(&run), RETENTION_DAYS, now),
+        WorktreeDisposition::ReclaimTerminal,
+    );
+}
+
+#[test]
+fn interrupted_run_is_retained_inside_window() {
+    let mut run = fake_run(JobRunState::Interrupted);
+    let now = Utc::now();
+    run.finished_at = Some(now - Duration::hours(1));
+    assert_eq!(
+        classify_worktree(Some(&run), RETENTION_DAYS, now),
+        WorktreeDisposition::Retain,
+    );
+}
+
+#[test]
+fn zero_retention_reaps_failures_immediately() {
+    let run = fake_run(JobRunState::Failed);
+    assert_eq!(
+        classify_worktree(Some(&run), 0, Utc::now()),
+        WorktreeDisposition::ReclaimTerminal,
+    );
+}
+
+#[test]
+fn missing_run_record_is_reclaimed() {
+    assert_eq!(
+        classify_worktree(None, RETENTION_DAYS, Utc::now()),
+        WorktreeDisposition::ReclaimNoRecord,
+    );
+}
+
+#[test]
+fn extract_run_id_handles_known_prefixes() {
+    assert_eq!(
+        extract_run_id(Path::new("/w/orbit-jrun-20260712-2021-4")).as_deref(),
+        Some("jrun-20260712-2021-4"),
+    );
+    assert_eq!(
+        extract_run_id(Path::new("/w/parallel-batch-jrun-20260712-0019-5")).as_deref(),
+        Some("jrun-20260712-0019-5"),
+    );
+    assert_eq!(extract_run_id(Path::new("/w/some-other-dir")), None);
+}
+
+#[test]
+fn is_protected_matches_self_and_ancestors() {
+    let dir = Path::new("/w/orbit-jrun-1");
+    assert!(is_protected(dir, Some(Path::new("/w/orbit-jrun-1"))));
+    assert!(is_protected(dir, Some(Path::new("/w/orbit-jrun-1/sub"))));
+    assert!(!is_protected(dir, Some(Path::new("/w/orbit-jrun-2"))));
+    assert!(!is_protected(dir, None));
+}
+
+// --- End-to-end reclaim over a real git repo -------------------------------
+
+fn git(repo: &Path, args: &[&str]) -> bool {
+    Command::new("git")
+        .arg("-C")
+        .arg(repo)
+        .args(args)
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+/// Returns `false` when git is unavailable / the sandbox blocks subprocesses,
+/// so the caller can skip rather than fail on an environment limitation.
+fn init_repo(repo: &Path) -> bool {
+    std::fs::create_dir_all(repo).expect("create repo dir");
+    if !git(repo, &["init", "-q"]) {
+        return false;
+    }
+    git(repo, &["config", "user.email", "gc@test"]);
+    git(repo, &["config", "user.name", "gc test"]);
+    std::fs::write(repo.join("README.md"), "seed").expect("write seed");
+    git(repo, &["add", "-A"]);
+    git(repo, &["commit", "-q", "-m", "seed"])
+}
+
+fn add_worktree(repo: &Path, worktree: &Path, branch: &str) -> bool {
+    git(
+        repo,
+        &[
+            "worktree",
+            "add",
+            "-b",
+            branch,
+            &worktree.to_string_lossy(),
+            "HEAD",
+        ],
+    )
+}
+
+#[test]
+fn gc_reclaims_terminal_worktree_and_keeps_live_run() {
+    let (_tmp, runtime) = test_runtime();
+    let repo = runtime.paths().repo_root.clone();
+    if !init_repo(&repo) {
+        // git unavailable / subprocesses blocked in this environment — the pure
+        // classifier tests already cover the reclaim decision; skip the
+        // git-backed end-to-end assertion rather than fail on a sandbox limit.
+        return;
+    }
+    let worktrees_dir = runtime.paths().worktrees_dir.clone();
+    std::fs::create_dir_all(&worktrees_dir).expect("create worktrees dir");
+
+    // Terminal (success) run + its worktree, seeded with build-artifact junk
+    // to prove the reclaim is language-agnostic.
+    let done = runtime
+        .stores()
+        .jobs()
+        .insert_run("task_pr_pipeline", 1, Utc::now(), None, None)
+        .expect("insert done run");
+    runtime
+        .stores()
+        .jobs()
+        .mark_run_running(&done.run_id, Utc::now(), std::process::id())
+        .expect("mark done running");
+    runtime
+        .stores()
+        .jobs()
+        .finalize_run(&done.run_id, JobRunState::Success, Utc::now(), Some(0))
+        .expect("finalize done run");
+    let done_wt: PathBuf = worktrees_dir.join(format!("orbit-{}", done.run_id));
+    assert!(add_worktree(&repo, &done_wt, "orbit/gc-done"));
+    std::fs::create_dir_all(done_wt.join("target/debug")).expect("mk target");
+    std::fs::write(done_wt.join("target/debug/artifact.bin"), vec![0u8; 4096]).expect("junk");
+
+    // Live (running) run owned by this process + its worktree.
+    let live = runtime
+        .stores()
+        .jobs()
+        .insert_run("task_pr_pipeline", 1, Utc::now(), None, None)
+        .expect("insert live run");
+    runtime
+        .stores()
+        .jobs()
+        .mark_run_running(&live.run_id, Utc::now(), std::process::id())
+        .expect("mark live running");
+    let live_wt: PathBuf = worktrees_dir.join(format!("orbit-{}", live.run_id));
+    assert!(add_worktree(&repo, &live_wt, "orbit/gc-live"));
+
+    let outcome = runtime
+        .gc_worktrees(&WorktreeGcOptions::default())
+        .expect("gc worktrees");
+
+    assert!(
+        !done_wt.exists(),
+        "terminal-success worktree (with build junk) must be reclaimed",
+    );
+    assert!(
+        live_wt.exists(),
+        "live running run's worktree must never be reclaimed",
+    );
+    assert_eq!(outcome.reclaimed, 1, "exactly one worktree reclaimed");
+
+    let live_entry = outcome
+        .entries
+        .iter()
+        .find(|e| e.run_id.as_deref() == Some(live.run_id.as_str()))
+        .expect("live entry present");
+    assert_eq!(live_entry.action.as_str(), "kept_live");
+}

--- a/crates/orbit-core/src/command/job/run/tests/mod.rs
+++ b/crates/orbit-core/src/command/job/run/tests/mod.rs
@@ -3,6 +3,7 @@
 use crate::OrbitRuntime;
 
 mod actions;
+mod gc;
 mod owner;
 mod reconcile;
 

--- a/crates/orbit-core/src/config/raw.rs
+++ b/crates/orbit-core/src/config/raw.rs
@@ -15,6 +15,7 @@ pub(super) struct RawRuntimeConfig {
     pub(super) watch: Option<toml::Value>,
     pub(super) runtime: Option<RawRuntimeSection>,
     pub(super) workflow: Option<RawWorkflowConfig>,
+    pub(super) worktree: Option<RawWorktreeConfig>,
     pub(super) routines: Option<RawRoutinesConfig>,
     pub(super) duel: Option<RawDuelSection>,
     /// Removed in ORB-00058. Kept only so config loading can reject stale
@@ -39,6 +40,16 @@ pub(super) struct RawWorkflowConfig {
     /// Named crew used when a task does not declare `crew` and no CLI
     /// override is provided.
     pub(super) default_crew: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub(super) struct RawWorktreeConfig {
+    /// `worktree.gc_failed_retention_days` — how long a failed / timeout /
+    /// interrupted run's worktree is kept for debugging (and resume) before
+    /// worktree GC reclaims it. When absent, defaults to
+    /// [`DEFAULT_WORKTREE_GC_FAILED_RETENTION_DAYS`](super::runtime::DEFAULT_WORKTREE_GC_FAILED_RETENTION_DAYS).
+    /// Success / cancelled runs are always reaped immediately.
+    pub(super) gc_failed_retention_days: Option<i64>,
 }
 
 #[derive(Debug, Clone, Deserialize)]

--- a/crates/orbit-core/src/config/registry.rs
+++ b/crates/orbit-core/src/config/registry.rs
@@ -122,6 +122,11 @@ pub const CONFIG_KEY_REGISTRY: &[ConfigKeyDescriptor] = &[
         value_type: "string",
         description: "Named crew used when a task does not declare `crew` and no CLI override is given.",
     },
+    ConfigKeyDescriptor {
+        key: "worktree.gc_failed_retention_days",
+        value_type: "integer",
+        description: "Days a failed/timeout/interrupted run's worktree is kept for debugging before `orbit run gc` reclaims it (must be >= 0); success/cancelled reap immediately.",
+    },
 ];
 
 /// Look up a key's descriptor, or `None` if it isn't in the registry.

--- a/crates/orbit-core/src/config/runtime.rs
+++ b/crates/orbit-core/src/config/runtime.rs
@@ -20,7 +20,7 @@ use super::persistence::PersistenceConfig;
 use super::raw::{
     RawAgentRoleConfig, RawCodexExecutionConfig, RawCrewEntry, RawDuelSection,
     RawExecutionEnvConfig, RawPrSection, RawRoutinesConfig, RawRuntimeConfig, RawRuntimeSection,
-    RawTaskSection, RawWorkflowConfig,
+    RawTaskSection, RawWorkflowConfig, RawWorktreeConfig,
 };
 
 const DEFAULT_ENV_INHERIT: bool = false;
@@ -32,6 +32,12 @@ const DEFAULT_SCORING_ENABLED: bool = true;
 const DEFAULT_GRAPH_EDITING: bool = false;
 const DEFAULT_WORKFLOW_BASE_BRANCH: &str = "main";
 const DEFAULT_WORKFLOW_CREW: &str = "claude";
+/// Default retention window (days) for failed / timeout / interrupted run
+/// worktrees before worktree GC reclaims them (`[worktree]
+/// gc_failed_retention_days`). Mirrors
+/// [`crate::command::DEFAULT_FAILED_RETENTION_DAYS`]; kept as a local const so
+/// config defaulting has no dependency on the command layer.
+pub(crate) const DEFAULT_WORKTREE_GC_FAILED_RETENTION_DAYS: i64 = 7;
 const CONSTELLATION_DEFAULT_PROVIDER_ENV: &str = "CONSTELLATION_DEFAULT_PROVIDER";
 
 #[derive(Debug, Clone)]
@@ -58,6 +64,10 @@ pub(crate) struct RuntimeConfig {
     /// "source"` in `config.toml`; defaults to `false`). Consulted by
     /// `orbit sweep` before loading `.orbit/routines/*.yaml`.
     pub(crate) routines_source: bool,
+    /// Retention window (days) for failed / timeout / interrupted run worktrees
+    /// before worktree GC reclaims them (`[worktree] gc_failed_retention_days`;
+    /// defaults to [`DEFAULT_WORKTREE_GC_FAILED_RETENTION_DAYS`]).
+    pub(crate) worktree_gc_failed_retention_days: i64,
     /// Named provider-model assignments from `[crews.<name>]`.
     pub(crate) crews: BTreeMap<String, Crew>,
     pub(crate) default_crew: Option<String>,
@@ -111,6 +121,7 @@ impl RuntimeConfig {
             workflow_base_branch: DEFAULT_WORKFLOW_BASE_BRANCH.to_string(),
             workflow_auto_ship: false,
             routines_source: false,
+            worktree_gc_failed_retention_days: DEFAULT_WORKTREE_GC_FAILED_RETENTION_DAYS,
             crews: default_crews(),
             default_crew: Some(DEFAULT_WORKFLOW_CREW.to_string()),
             duel: DuelConfig::default(),
@@ -220,6 +231,8 @@ impl RuntimeConfig {
             .and_then(|workflow| workflow.auto_ship)
             .unwrap_or(false);
         let routines_source = routines_source_from_raw(parsed.routines.as_ref())?;
+        let worktree_gc_failed_retention_days =
+            worktree_gc_failed_retention_days_from_raw(parsed.worktree.as_ref())?;
         let crews = crews_from_raw(parsed.crews.as_ref())?;
         let default_crew = workflow_default_crew_from_raw(parsed.workflow.as_ref(), &crews)?;
         let duel = duel_from_raw(parsed.duel.as_ref())?;
@@ -251,6 +264,7 @@ impl RuntimeConfig {
             workflow_base_branch,
             workflow_auto_ship,
             routines_source,
+            worktree_gc_failed_retention_days,
             crews,
             default_crew,
             duel,
@@ -279,6 +293,10 @@ impl RuntimeConfig {
 
     pub(crate) fn routines_source(&self) -> bool {
         self.routines_source
+    }
+
+    pub(crate) fn worktree_gc_failed_retention_days(&self) -> i64 {
+        self.worktree_gc_failed_retention_days
     }
 
     pub(crate) fn pr_config(&self) -> &PrConfig {
@@ -646,6 +664,20 @@ fn routines_source_from_raw(raw: Option<&RawRoutinesConfig>) -> Result<bool, Orb
             "[routines] role has invalid value '{other}'; the only supported value is 'source'"
         ))),
     }
+}
+
+fn worktree_gc_failed_retention_days_from_raw(
+    raw: Option<&RawWorktreeConfig>,
+) -> Result<i64, OrbitError> {
+    let Some(value) = raw.and_then(|section| section.gc_failed_retention_days) else {
+        return Ok(DEFAULT_WORKTREE_GC_FAILED_RETENTION_DAYS);
+    };
+    if value < 0 {
+        return Err(OrbitError::InvalidInput(format!(
+            "[worktree] gc_failed_retention_days must be >= 0, got {value}"
+        )));
+    }
+    Ok(value)
 }
 
 fn workflow_base_branch_from_raw(raw: Option<&RawWorkflowConfig>) -> Result<String, OrbitError> {

--- a/crates/orbit-core/src/config/store.rs
+++ b/crates/orbit-core/src/config/store.rs
@@ -283,6 +283,9 @@ pub struct ConfigSnapshot {
     pub workflow_default_crew: Option<String>,
     pub workflow_auto_ship: bool,
     pub routines_source: bool,
+    /// Retention window (days) for failed/timeout/interrupted run worktrees
+    /// before worktree GC reclaims them (`[worktree] gc_failed_retention_days`).
+    pub worktree_gc_failed_retention_days: i64,
     pub tasks_id_start: Option<u32>,
     pub duel_candidates: Vec<String>,
     pub duel_models: std::collections::BTreeMap<String, String>,
@@ -317,6 +320,7 @@ impl From<&RuntimeConfig> for ConfigSnapshot {
             workflow_default_crew: config.default_crew.clone(),
             workflow_auto_ship: config.workflow_auto_ship(),
             routines_source: config.routines_source(),
+            worktree_gc_failed_retention_days: config.worktree_gc_failed_retention_days(),
             tasks_id_start: config.tasks_id_start(),
             duel_candidates: config.duel_config().candidates.clone(),
             duel_models: config.duel_config().models.clone(),
@@ -354,6 +358,7 @@ impl ConfigSnapshot {
             "workflow.auto_ship" => json!(self.workflow_auto_ship),
             "workflow.base_branch" => json!(self.workflow_base_branch),
             "workflow.default_crew" => json!(self.workflow_default_crew),
+            "worktree.gc_failed_retention_days" => json!(self.worktree_gc_failed_retention_days),
             _ => return None,
         })
     }

--- a/crates/orbit-core/src/context.rs
+++ b/crates/orbit-core/src/context.rs
@@ -186,6 +186,9 @@ pub(crate) struct OrbitRuntimeSettings {
     /// Whether this workspace is a routine source
     /// (`[routines] role = "source"` in `config.toml`, default `false`).
     routines_source: bool,
+    /// Retention window (days) for failed/timeout/interrupted run worktrees
+    /// before worktree GC reclaims them (`[worktree] gc_failed_retention_days`).
+    worktree_gc_failed_retention_days: i64,
     crews: std::collections::BTreeMap<String, Crew>,
     default_crew: Option<String>,
     duel: DuelConfig,
@@ -205,6 +208,7 @@ impl OrbitRuntimeSettings {
         workflow_base_branch: String,
         workflow_auto_ship: bool,
         routines_source: bool,
+        worktree_gc_failed_retention_days: i64,
         crews: std::collections::BTreeMap<String, Crew>,
         default_crew: Option<String>,
         duel: DuelConfig,
@@ -221,6 +225,7 @@ impl OrbitRuntimeSettings {
             workflow_base_branch,
             workflow_auto_ship,
             routines_source,
+            worktree_gc_failed_retention_days,
             crews,
             default_crew,
             duel,
@@ -245,6 +250,10 @@ impl OrbitRuntimeSettings {
 
     pub(crate) fn routines_source(&self) -> bool {
         self.routines_source
+    }
+
+    pub(crate) fn worktree_gc_failed_retention_days(&self) -> i64 {
+        self.worktree_gc_failed_retention_days
     }
 
     pub(crate) fn crews(&self) -> &std::collections::BTreeMap<String, Crew> {
@@ -377,6 +386,12 @@ impl OrbitContext {
     /// (`[workflow] auto_ship` in `config.toml`, default `false`).
     pub(crate) fn workflow_auto_ship(&self) -> bool {
         self.runtime.workflow_auto_ship()
+    }
+
+    /// Retention window (days) for failed/timeout/interrupted run worktrees
+    /// before worktree GC reclaims them (`[worktree] gc_failed_retention_days`).
+    pub(crate) fn worktree_gc_failed_retention_days(&self) -> i64 {
+        self.runtime.worktree_gc_failed_retention_days()
     }
 
     /// Whether this workspace is a routine source

--- a/crates/orbit-core/src/runtime/builder.rs
+++ b/crates/orbit-core/src/runtime/builder.rs
@@ -144,6 +144,7 @@ pub(crate) fn build_context_from_roots(
     let workflow_base_branch = runtime_config.workflow_base_branch().to_string();
     let workflow_auto_ship = runtime_config.workflow_auto_ship();
     let routines_source = runtime_config.routines_source();
+    let worktree_gc_failed_retention_days = runtime_config.worktree_gc_failed_retention_days();
     let crews = runtime_config.crews.clone();
     let default_crew = runtime_config.default_crew.clone();
     let duel = runtime_config.duel_config().clone();
@@ -185,6 +186,7 @@ pub(crate) fn build_context_from_roots(
             workflow_base_branch,
             workflow_auto_ship,
             routines_source,
+            worktree_gc_failed_retention_days,
             crews,
             default_crew,
             duel,

--- a/crates/orbit-core/src/runtime/mod.rs
+++ b/crates/orbit-core/src/runtime/mod.rs
@@ -360,6 +360,14 @@ impl OrbitRuntime {
     /// (`[workflow] auto_ship` in the active `config.toml`; defaults to
     /// `false`). Consulted by `orbit run ship-sweep` and other schedulers
     /// before dispatching ship runs nobody explicitly asked for.
+    /// Configured retention window (days) for failed/timeout/interrupted run
+    /// worktrees before worktree GC reclaims them (`[worktree]
+    /// gc_failed_retention_days`, default
+    /// [`crate::command::DEFAULT_FAILED_RETENTION_DAYS`]).
+    pub fn worktree_gc_failed_retention_days(&self) -> i64 {
+        self.context.worktree_gc_failed_retention_days()
+    }
+
     pub fn workflow_auto_ship(&self) -> bool {
         self.context.workflow_auto_ship()
     }

--- a/crates/orbit-core/src/runtime/task_reservation_cleanup.rs
+++ b/crates/orbit-core/src/runtime/task_reservation_cleanup.rs
@@ -51,6 +51,15 @@ impl OrbitRuntime {
             {
                 self.best_effort_block_tasks_for_failed_run(run_id, state);
             }
+            // [ORB-10173] Reap the run's worktree on the terminalizing write.
+            // Only immediately reap-eligible states (success/cancelled/skipped)
+            // are removed here; failed/timeout/interrupted worktrees ride the
+            // retention window and are reclaimed later by `orbit run gc`.
+            // Gated on `!was_terminal_before` so a replayed terminalization is a
+            // no-op. Best-effort: a reap failure never blocks finalization.
+            if !was_terminal_before {
+                self.best_effort_reap_finalized_worktree(run_id, state);
+            }
         }
         Ok(changed)
     }


### PR DESCRIPTION
## Task

[ORB-10173](https://orbit-cli.com/tasks/ORB-10173) — Pipeline worktree GC: reclaim orphaned jrun worktrees

### Description

## Problem

A disk-cleanup sweep on dk-server-1 (2026-07-12) found **116G** of stale Orbit pipeline job-run worktrees under `codebases/orbit/.orbit/state/worktrees/orbit-jrun-*/` — 13 directories, each 519M–20G, almost entirely build artifacts. No run was active against any of them; they are orphaned leftovers of completed/failed job runs.

Root fs was at 76% (248G/342G). The sweep reclaimed 113G from *unmanaged* target dirs (primary checkout + dev worktrees) but deliberately did not touch anything under `.orbit/state/` — that is Orbit-managed state, and reclaiming it is Orbit's job, not a shell script's.

Orbit creates a job worktree per pipeline run and never reclaims it, so disk grows every run and never shrinks. This is a slow leak that will re-fill the disk within weeks.

Related: friction **F2026-07-019** (filed by the cleanup run), same orphaned-run family as **F2026-07-016 / ORB-10153**.

## Scope — two parts

**1. Worktree GC on run completion.** When a job run reaches a terminal state (done / failed / cancelled), Orbit should remove its worktree. Needs a retention policy — a failed run's worktree is useful for debugging, so keep failures for N days (suggest 7) or the last K failures, and reap successes immediately (or after a short grace window). Make the policy configurable, with sane defaults.

**2. Reclaim the existing orphans + reconcile.** GC-on-completion doesn't help worktrees whose run record is already terminal-or-lost. Add a sweep/`gc` entry point that reconciles `.orbit/state/worktrees/*` against the run table and reclaims any worktree with no live run (cancelling orphaned run records — `orbit run cancel <jrun>` — where the record is stuck non-terminal). It must be safe to run while other runs are in flight: never touch a worktree with a live run, and hold whatever lock the pipeline uses.

GC must be **language-agnostic** — it reclaims the worktree directory, whatever the workspace's build system put there (Rust `target/`, Java `build/`, Python `.venv/`, node_modules, …). Nothing here should special-case Cargo.

## Out of scope

A **shared build cache** (e.g. a shared `CARGO_TARGET_DIR`, sccache, a Gradle build cache) would attack the cause rather than the symptom — no duplicate artifacts, warm builds. But every such mechanism is per-language, and Orbit's pipeline is language-neutral, so it does not belong in the GC change. If it's worth doing, it's a separate task per build system.

## Notes

- Verify against a live box: worktrees live at `~/workspace/constellation/codebases/orbit/.orbit/state/worktrees/orbit-jrun-*`.
- The running orbit service executes from `~/.orbit/bin/orbit`, not from any `target/` — build artifacts are safe to reclaim without touching the service.
- Do not delete Orbit's DB/state beyond the worktrees themselves.

### Acceptance Criteria

- Terminal job runs (done/failed/cancelled) have their worktree reclaimed automatically, under a configurable retention policy that keeps recent failed-run worktrees for debugging
- A GC/reconcile entry point exists that sweeps `.orbit/state/worktrees/*` against the run table, cancels orphaned non-terminal run records, and reclaims worktrees with no live run
- GC is concurrency-safe: a worktree belonging to a live/in-flight run is never removed, verified by a test
- GC is language-agnostic — it reclaims the worktree directory regardless of build system, with no Cargo-specific special-casing
- Running the GC on dk-server-1 reclaims the ~116G of existing orbit-jrun-* worktrees; `df -h /` before/after recorded in the execution summary
- Disk no longer grows unboundedly per pipeline run — demonstrated by running two successive orbit-workspace jobs and showing the worktree footprint stays flat
- F2026-07-019 (and F2026-07-016/ORB-10153 where it overlaps) are resolved or explicitly re-scoped

## Execution Summary

<details>
<summary>Click to expand</summary>

Implemented pipeline worktree GC (ORB-10173).

WHAT
- New orbit-core module command/job/run/gc.rs:
  - classify_worktree(run, retention_days, now) -> WorktreeDisposition: the pure reclaim
    decision. Non-terminal + live owner => KeepLive (concurrency-safety rule); non-terminal +
    conclusively-dead owner => ReclaimOrphanRecord (cancel record, then reclaim); terminal
    success/cancelled/skipped => ReclaimTerminal (reap now); terminal failed/timeout/interrupted
    => Retain within the window, else ReclaimTerminal; no run record => ReclaimNoRecord.
  - Owner liveness reuses the orphan reconciler's helpers (running_run_owner_is_stale /
    pending_run_stale_reason) so GC classifies liveness identically to open-time reconcile.
  - reclaim_worktree(): language-agnostic — `git worktree remove --force` with a raw
    remove_dir_all fallback, then `git worktree prune`, then best-effort `git branch -D`. No
    Cargo/target special-casing (verified against target/ and build/ junk in tests).
  - OrbitRuntime::gc_worktrees(options): scans .orbit/state/worktrees/* (and ORBIT_WORKTREE_ROOT/
    <repo> when set), reconciles each dir against the run table, protects the caller's own
    worktree (never reclaims cwd), reports per-dir actions + counts.
- On-completion reap: finalize_job_run_with_reservation_cleanup now best-effort reaps the just-
  finalized run's worktree on the terminalizing write, but only for reap-eligible states
  (success/cancelled/skipped); failures ride the retention window. Never blocks finalize.
- Config: new [worktree] gc_failed_retention_days (default 7, must be >=0), threaded through
  RuntimeConfig -> OrbitRuntimeSettings -> OrbitContext -> OrbitRuntime, and wired into the
  config registry + ConfigSnapshot so `orbit config get/set/show worktree.gc_failed_retention_days`
  works.
- CLI: `orbit run gc [--dry-run] [--json] [--failed-retention-days N]` (orbit-cli run/gc.rs +
  command.rs + audit_middleware arm).

CONCURRENCY SAFETY / DEVIATION FROM AC FRAMING
- The AC asked to "hold whatever lock the pipeline uses." The pipeline holds no worktree-wide
  lock (worktree setup uses git's own `worktree add` locking + per-run task reservations). The
  actual safety guarantee is the run-table liveness check: a worktree whose run is non-terminal
  with a live owner is never a reclaim candidate. `git worktree remove --force` additionally
  takes git's internal worktree lock. Resume reuses only interrupted runs, which are retained
  (never reaped); retries mint a new run id + new worktree, so no reuse race. This decision is
  documented at the top of gc.rs.

VERIFICATION (in-worktree)
- cargo check -p orbit-core -p orbit-cli: clean. cargo clippy ... -- -D warnings: clean.
- cargo fmt --all --check: clean. All make ci-fast guardrails pass except
  test-installer-security.sh (needs `node`, not installed — environment limit) and the two
  cargo-metadata guardrails only when cargo is off PATH (pass with PATH set).
- Tests: 12 new gc tests pass, incl. live_running_run_is_never_reclaimed (the AC3
  concurrency-safety proof) and an end-to-end git-repo test proving a terminal-success worktree
  containing target/debug build junk is reclaimed while a live run's worktree is kept. Full
  orbit-core lib suite: 548 passed. orbit-cli unit tests pass once the executor's leaked
  ORBIT_AGENT_MODEL/ORBIT_AGENT_NAME env is cleared (one identity test and the docs
  semantic-index integration tests fail only due to that env / a missing search-companion
  binary — both pre-existing environmental, unrelated to this change).
- CLI smoke (isolated temp HOME, not the live workspace): `orbit run gc --dry-run --json`
  reports 2 would_reclaim and deletes nothing; a real `orbit run gc` removes a real git worktree
  (with target/ junk) and its branch, leaving the run table intact.

DISK (AC5/AC6 — operational, deferred to operator)
- `df -h /` at task start: 391G total, 135G used, 240G avail (36%). The earlier shell sweep
  already reclaimed the unmanaged 113G; .orbit/state/worktrees still holds 116G across 16 jrun
  dirs (one of which is THIS run's live worktree). Reclaiming the ~116G on dk-server-1 requires
  the built+installed binary run against the live workspace and must NOT be done from inside a
  live worktree; I did not run it here because (a) the installed ~/.orbit/bin/orbit predates this
  command, (b) opening the production global DB with an unreleased binary risks unintended
  migrations, and (c) deleting 116G mid-task is a destructive live op. Recommended operator step
  post-merge: install, then `cd <primary checkout>` and `orbit run gc` (my run's live worktree is
  protected as cwd + KeepLive). "Two successive jobs stay flat" (AC6) is likewise a post-merge
  operational check; on-completion reap + gc make the footprint bounded by design.

F2026-07-019 (AC7)
- Root cause (pipeline never reclaimed job-run worktrees) is fixed by this change. The friction
  lives in the polaris workspace; the orbit.adr/friction surface here can't flip a polaris record,
  so the orchestrator should mark F2026-07-019 resolved (and note F2026-07-016/ORB-10153 overlap
  on the orphaned-run family, which the cancel-orphaned-record path also addresses).

SCOPE NOTES (context_files was only `dir:crates`)
- Unlisted files changed are all registration/config plumbing tightly coupled to the scoped work:
  config raw/runtime/registry/store + context/builder/runtime (threading the one new config key),
  command/job/mod.rs + run/mod.rs (module registration + re-exports), CLI command/mod/audit_middleware
  (subcommand wiring), CHANGELOG.md. No new cross-crate dependency edges; no behavior changed
  outside the GC feature.

NOT DONE / follow-ups a reviewer may want: a formal ADR for the retention/liveness design (could
not allocate an ADR id — orbit.adr.* not in this executor's tool surface; rationale is captured in
gc.rs module docs); optionally a scheduled routine/auto-task to run `orbit run gc` unattended
(the CLI entry point + on-completion reap already bound the footprint).

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10173-6a53f758`
- Behind base: 0
- Ahead of base: 1