### PR TITLE
orbit-sweep.service must set KillMode=process — systemd cgroup kills detached pipeline worker, routine auto-tasks never mint

### DIFF
--- a/.orbit/learnings/L-0079/learning.yaml
+++ b/.orbit/learnings/L-0079/learning.yaml
@@ -1,0 +1,18 @@
+schema_version: 1
+id: L-0079
+status: active
+scope:
+  paths:
+  - crates/orbit-core/assets/clock/*.service
+  - crates/orbit-core/src/command/pipeline_run.rs
+  tags:
+  - systemd
+  - workers
+summary: When a systemd oneshot launches detached workers, set KillMode=process or move workers to an independent scope; setsid does not escape the unit cgroup.
+body: A worker created with setsid starts a new session but remains in the launching systemd unit cgroup. With the default KillMode=control-group, systemd kills that worker when the oneshot main process exits, often before the worker can claim durable work. Services that intentionally outlive their launcher must either use KillMode=process or explicitly create an independent systemd scope.
+evidence:
+- kind: task
+  reference: ORB-10153
+created_at: 2026-07-12T21:22:25.948439524Z
+updated_at: 2026-07-12T21:22:25.948439524Z
+created_by: codex

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- **Systemd routine workers survive sweep exit**: the user sweep service now limits shutdown to its main oneshot process, allowing detached pipeline workers to claim and complete clock-dispatched runs. ([ORB-10153])
 - **Task creation surface is narrower and consistent**: task creation now exposes only legal initial statuses, list flags share repeat/comma parsing, and redundant agent/comment/instructions inputs are removed while model and managed identity attribution remain intact. ([ORB-10155])
 
 ### Breaking Changes

--- a/crates/orbit-core/assets/clock/orbit-sweep.service
+++ b/crates/orbit-core/assets/clock/orbit-sweep.service
@@ -5,4 +5,5 @@ Description=Orbit routine sweep (fires due routines on this host)
 
 [Service]
 Type=oneshot
+KillMode=process
 ExecStart={{ORBIT_BIN}} sweep


### PR DESCRIPTION
## Task

[ORB-10153](https://orbit-cli.com/tasks/ORB-10153) — orbit-sweep.service must set KillMode=process — systemd cgroup kills detached pipeline worker, routine auto-tasks never mint

### Description

## Problem

On systemd hosts, routine-dispatched pipeline runs (`auto_task_scheduler_pipeline`, `task_triage_pipeline`) die without ever executing — reconciled as `interrupted` with `reason=never_claimed, no live worker process owns it`. Consequently **no auto-task ever mints** and failed-run triage never runs. Found live on dk-server-1 while enabling the ORB-10148 qa-sweep auto-task for an end-to-end test (2026-07-12).

## Root cause

`OrbitRuntime::spawn_pipeline_worker` (`crates/orbit-core/src/command/pipeline_run.rs:474`) spawns the pipeline worker as a child: `orbit --root … job run-pipeline-worker <run_id>` with `libc::setsid()`. `setsid()` starts a new session but does **not** move the child out of the systemd unit's cgroup.

The OS clock unit `crates/orbit-core/assets/clock/orbit-sweep.service` is `Type=oneshot` with **no `KillMode`**, so it defaults to `KillMode=control-group`. When `orbit sweep` (ExecStart) exits, systemd tears down the unit's cgroup and SIGKILLs the just-spawned worker before it can claim the run → `never_claimed`.

This affects every systemd host installed via `orbit routine init --install-clock`; the whole routines/auto-task execution path is dead on Linux.

## Evidence (dk-server-1)

- `jrun-20260712-0404` / `-0434` / `-0459`: `interrupted (never_claimed)` / stuck `pending`, 0 steps, no owner pid.
- After adding a local systemd drop-in `KillMode=process` (`~/.config/systemd/user/orbit-sweep.service.d/override.conf`) + `daemon-reload`, the very next clock-driven sweep produced `jrun-20260712-0504` = **success** (worker survived, ran to completion). Same binary, same definitions — only the KillMode changed.

## Fix

Add `KillMode=process` to the `[Service]` section of `crates/orbit-core/assets/clock/orbit-sweep.service` (leave only the main sweep process managed; the detached worker survives). Optionally, more robustly, launch the worker into an independent transient scope (e.g. `systemd-run --user --scope`) so it is never tied to the sweep unit's lifetime.

Existing installs need `orbit routine init --install-clock` re-run (or the drop-in) to pick up the new unit. Consider having `routine init` detect/upgrade a KillMode-less unit.

## Note

A **local drop-in workaround is already applied on dk-server-1** to unblock the live test; this task is the durable source fix. macOS/launchd is unaffected (no cgroup teardown of the setsid'd child).

### Acceptance Criteria

- crates/orbit-core/assets/clock/orbit-sweep.service sets KillMode=process (or the worker is spawned into a systemd scope independent of the sweep unit's lifetime)
- A routine pipeline run dispatched by the OS clock sweep reaches state=success on a systemd host (worker survives the oneshot's exit), demonstrated by orbit run history
- orbit routine init --install-clock on a systemd host writes/updates the unit so routine-dispatched pipeline workers are not killed when orbit sweep exits

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Added `KillMode=process` to the shipped systemd user service, so `orbit routine init --install-clock` overwrites existing service files with a unit that leaves detached pipeline workers alive after the oneshot sweep exits.
- Added the required Unreleased changelog entry.
- Recorded the incident root-cause guardrail as learning L-0079.

Validation:
- Confirmed the directive is in the `[Service]` section and `git diff --check` passes.
- Verified `jrun-20260712-0504` in live `orbit run history` has `job_id=auto_task_scheduler_pipeline` and `state=success`, matching the systemd drop-in evidence.
- `make ci-fast` passed formatting and installer pubkey checks, then could not run `test-installer-security.sh` because Node is absent from the runner; every remaining ci-fast guardrail was run individually and passed.

Assessment: The minimal service-template change fixes the systemd cgroup lifetime bug without changing worker spawning or macOS behavior.

Design weaknesses / risks:
- Existing systemd installs retain their old unit until `orbit routine init --install-clock` is re-run. | Severity: Medium | Mitigation: The installer unconditionally rewrites the service and runs `systemctl --user daemon-reload`.

Deviations from original plan:
- Full `make ci-fast` completion was unavailable because the runner lacks Node. | Justification: This is an environment limitation; the remaining checks passed independently.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10153-6a5404d2`
- Behind base: 0
- Ahead of base: 1