### PR TITLE
Define the orbit gc retention and safety contract

### DIFF
--- a/.orbit/adrs/accepted/ADR-0220/adr.yaml
+++ b/.orbit/adrs/accepted/ADR-0220/adr.yaml
@@ -1,0 +1,25 @@
+schema_version: 2
+id: ADR-0220
+title: One safety contract for explicit Orbit garbage collection
+status: accepted
+owner: codex
+created_at: 2026-07-12T21:22:27.975299792Z
+accepted_at: 2026-07-12T21:25:28.062180793Z
+last_updated: 2026-07-12T21:25:28.062180793Z
+related_features:
+- gc
+related_tasks:
+- ORB-10178
+tags:
+- gc
+- retention
+- safety
+paths:
+- docs/design/gc/**
+- crates/orbit-cli/src/command/gc/**
+- crates/orbit-core/src/command/gc/**
+- crates/orbit-core/src/config/**
+supersedes: []
+legacy_ids: []
+validation_warnings: []
+legacy_validation: none

--- a/.orbit/adrs/accepted/ADR-0220/body.md
+++ b/.orbit/adrs/accepted/ADR-0220/body.md
@@ -1,0 +1,12 @@
+## Context
+Orbit cleanup is split between domain commands and startup hooks, while a proposed top-level collector must coordinate global and workspace state without racing live owners. Real alternatives were to keep domain-specific mutation surfaces, place worktree cleanup under `orbit run`, or let each collector define its own locks, reports, and force behavior.
+
+## Decision
+Adopt one top-level `orbit gc [TARGET]` family whose default is a non-mutating plan and whose only mutation gate is explicit `--apply`. Every target uses a shared immutable plan/report contract, one host-wide apply lock plus domain-specific atomic revalidation, source-of-truth retention clocks, and non-bypassable containment, symlink, current-owner, and ambiguity protections; `all` composes the same collectors.
+
+## Consequences
+- Existing cleanup entry points delegate to the shared collectors or become non-mutating compatibility shims; `orbit run gc` is rejected because retention is storage lifecycle, not workflow execution.
+- Global targets take policy only from global config; workspace targets use the existing complete-document workspace-replaces-global rule, with CLI overrides highest.
+- Partial failure preserves successful mutations, reports every skip/error, and returns non-zero; reruns are idempotent.
+- No single code anchor yet; the convention will be enforced by the shared GC framework and collector review.
+- Cost: All apply passes serialize behind one host-wide lock and pay per-candidate revalidation, and workspace owners must repeat any global GC settings they want in a complete workspace policy instead of inheriting a merged fragment.

--- a/.orbit/learnings/L-0077/learning.yaml
+++ b/.orbit/learnings/L-0077/learning.yaml
@@ -9,13 +9,17 @@ scope:
   tags:
   - workflow-admission
   - tooling
-summary: Verify the executor Orbit binary can read the admitted worktree's config and store schema before dispatch
-body: Workflow admission can succeed while the subsequently dispatched agent resolves an older installed `orbit` binary. The agent then cannot call required lifecycle tools if the task store schema is newer, and config validation can fail under a legacy schema before any command dispatch. Admission should validate the exact executor binary against every effective config layer and the workspace store, or pass the compatible checked-out binary explicitly. Error messages for layered config failures should include the source path.
+summary: Verify the executor Orbit binary can read the admitted worktree config and store schema before dispatch
+body: 'Workflow admission can succeed while the subsequently dispatched agent resolves an older installed `orbit` binary. The agent then cannot call required lifecycle tools if the task store schema is newer, and config validation can fail under a legacy schema before any command dispatch. Admission should validate the exact executor binary against every effective config layer and the workspace store, or pass the compatible checked-out binary explicitly. Error messages for layered config failures should include the source path. ORB-10178 reproduced the config-schema variant: the installed binary rejected the admitted worktree crew schema before `orbit.task.show`, while a workspace-built binary from the admitted revision worked.'
 evidence:
 - kind: task
   reference: ORB-10148
 - kind: external
   reference: F2026-07-015
+- kind: task
+  reference: ORB-10178
+- kind: external
+  reference: F2026-07-020
 created_at: 2026-07-12T03:37:58.785982787Z
-updated_at: 2026-07-12T03:37:58.785982787Z
+updated_at: 2026-07-12T21:26:29.732641246Z
 created_by: codex

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- **Safety-first garbage collection contract**: the `orbit gc` design standardizes explicit apply, retention clocks, ownership/revalidation invariants, locking, and equivalent human/JSON reports across global and workspace collectors. ([ORB-10178])
 - **Task creation surface is narrower and consistent**: task creation now exposes only legal initial statuses, list flags share repeat/comma parsing, and redundant agent/comment/instructions inputs are removed while model and managed identity attribution remain intact. ([ORB-10155])
 
 ### Breaking Changes

--- a/docs/design/CONVENTIONS.md
+++ b/docs/design/CONVENTIONS.md
@@ -1,7 +1,7 @@
 ---
 title: Design Doc Conventions
 owner: daniel
-last_updated: 2026-06-20
+last_updated: 2026-07-12
 status: Accepted
 ---
 
@@ -191,6 +191,7 @@ Retired features stay listed with their `_archive/` path as a historical record.
 | Agent Families | [docs/design/agent-families/](./agent-families/) | grok |
 | Auditability | [docs/design/auditability/](./auditability/) | codex |
 | Executors | [docs/design/executors/](./executors/) | claude |
+| Garbage Collection | [docs/design/gc/](./gc/) | codex |
 | Global Store Consolidation | [docs/design/_archive/global-store-consolidation/](./_archive/global-store-consolidation/) | codex |
 | Groundhog | [docs/design/groundhog/](./groundhog/) | codex |
 | Knowledge graph | [docs/design/_archive/knowledge-graph/](./_archive/knowledge-graph/) | claude |

--- a/docs/design/gc/1_overview.md
+++ b/docs/design/gc/1_overview.md
@@ -1,0 +1,77 @@
+---
+title: Garbage Collection — Overview
+owner: codex
+last_updated: 2026-07-12
+status: Draft
+feature: gc
+doc_role: overview
+type: design
+summary: Defines Orbit's explainable, explicitly applied retention family across global and workspace state.
+tags: [gc, retention, safety]
+paths: ["crates/orbit-cli/src/command/gc/**", "crates/orbit-core/src/command/gc/**", "crates/orbit-core/src/config/**"]
+related_features: [gc, activity-job, auditability, task-artifacts, worktree-artifacts]
+related_artifacts: [ORB-10178, ADR-0220]
+---
+
+# Garbage Collection — Overview
+
+`orbit gc [TARGET]` is the single inspection and retention family for
+Orbit-owned state. It makes every candidate and exclusion explainable before
+mutation, requires an explicit `--apply`, and gives every collector the same
+locking, path-safety, revalidation, and reporting contract.
+
+## 1. Motivation
+
+Orbit currently bounds some state at startup, exposes destructive operations in
+individual domains, and leaves other stores unbounded. Those entry points do not
+share ownership proofs, retention clocks, concurrency rules, or output. A
+top-level family is needed before more collectors are added because an incorrect
+cleanup contract can destroy active work, provenance, or audit evidence.
+
+This feature covers only Orbit-owned roots and lifecycle records. Language build
+caches are collected only when they reside inside a managed worktree; arbitrary
+Cargo, Gradle, Python, or Node caches outside one are not GC candidates.
+
+## 2. Core Concepts
+
+- **Target** — one collector: `worktrees`, `runs`, `logs`, `diagnostics`,
+  `audit`, `skills`, `tasks`, or the aggregate `all` target.
+- **Plan** — the immutable candidate snapshot built for one invocation. Apply
+  consumes that plan but revalidates each item immediately before mutation.
+- **Ownership proof** — domain metadata tying a candidate to an Orbit-owned
+  root and record. A familiar name or old filesystem mtime is not proof.
+- **Retention clock** — the persisted domain event from which age is computed,
+  such as a run's terminal transition or a task's terminal history entry.
+- **Protection invariant** — a rule that turns uncertainty into a reported skip.
+  Protection invariants cannot be disabled by force or retention overrides.
+- **Reclaimed** — a completed deletion or lifecycle mutation. In v1, task GC
+  archives tasks and does not physically delete task bundles.
+
+## 3. At a Glance
+
+| Concern | File | Task |
+|---------|------|------|
+| Shared grammar, plan/apply/report, and lock | [2_design.md](./2_design.md) | [ORB-10180] |
+| Managed worktrees | [2_design.md §3.1](./2_design.md#31-worktrees-workspace) | [ORB-10182] |
+| Job-run bundles and records | [2_design.md §3.2](./2_design.md#32-runs-workspace) | [ORB-10183] |
+| Operational logs | [2_design.md §3.3](./2_design.md#33-logs-global) | [ORB-10184] |
+| Diagnostics partitions | [2_design.md §3.4](./2_design.md#34-diagnostics-workspace) | [ORB-10185] |
+| Audit envelopes and blobs | [2_design.md §3.5](./2_design.md#35-audit-workspace-and-global) | [ORB-10186] |
+| Generated skills and links | [2_design.md §3.6](./2_design.md#36-skills-global) | [ORB-10187] |
+| Terminal task archival | [2_design.md §3.7](./2_design.md#37-tasks-workspace) | [ORB-10188] |
+| Aggregate and automatic collection | [2_design.md §9](./2_design.md#9-aggregate-and-automation-policy) | [ORB-10189] |
+
+## Task References
+
+- [ORB-10178] — defined the GC retention and safety contract.
+- [ORB-10180] — will implement the shared top-level GC framework.
+- [ORB-10182] — will implement managed worktree collection.
+- [ORB-10183] — will implement terminal run collection.
+- [ORB-10184] — will implement operational log collection.
+- [ORB-10185] — will implement diagnostics collection.
+- [ORB-10186] — will implement audit retention and blob reachability.
+- [ORB-10187] — will implement generated-skill collection.
+- [ORB-10188] — will implement terminal task archival.
+- [ORB-10189] — will implement aggregate and opt-in automatic collection.
+
+> Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.

--- a/docs/design/gc/2_design.md
+++ b/docs/design/gc/2_design.md
@@ -1,0 +1,374 @@
+---
+title: Garbage Collection — Design
+owner: codex
+last_updated: 2026-07-12
+status: Draft
+feature: gc
+doc_role: design
+type: design
+summary: Specifies GC grammar, collector ownership, retention clocks, safety invariants, locking, and reports.
+tags: [gc, retention, safety]
+paths: ["crates/orbit-cli/src/command/gc/**", "crates/orbit-core/src/command/gc/**", "crates/orbit-core/src/config/**"]
+related_features: [gc, activity-job, auditability, task-artifacts, worktree-artifacts]
+related_artifacts: [ORB-10178, ADR-0220]
+---
+
+# Garbage Collection — Design
+
+This document is the normative v1 contract for planning and applying retention
+to Orbit-owned global and workspace state. Collector implementation details may
+vary, but they may not weaken the mutation gate, ownership rules, protection
+invariants, revalidation, lock, or report semantics defined here.
+
+## 1. Command Grammar and Mutation Gate
+
+The family is:
+
+```text
+orbit gc [TARGET] [--workspace <id-or-path> | --global] [--retention <duration>]
+         [--json] [--apply]
+
+TARGET := worktrees | runs | logs | diagnostics | audit | skills | tasks | all
+```
+
+The omitted target means an overview of all targets available in the resolved
+scope. `orbit gc`, `orbit gc all`, and every individual target are plan-only by
+default. They scan and report but perform no deletion, archival, cancellation,
+rotation, link repair, or other lifecycle mutation. `--apply` is required for
+every mutation, including when the command is called by compatibility shims or
+automation. There is no interactive confirmation that silently substitutes for
+`--apply`.
+
+`--retention` is a target-appropriate one-invocation override. It affects
+eligibility only; it cannot waive a protection invariant. Collectors with more
+than one retention class expose explicit qualified overrides rather than giving
+one ambiguous duration multiple meanings. Unsupported scope/target combinations
+are reported as `not_applicable`; they never fall through to another root.
+
+`--workspace` selects one registered workspace without changing process cwd.
+When neither scope flag is present, Orbit uses the discovered current workspace
+for workspace targets and the global root for global targets. Outside a
+workspace, workspace targets report that selection is required. `--global`
+selects only global targets; it is not shorthand for every registered workspace.
+Cross-workspace collection is reserved for a separately explicit aggregate
+operator surface.
+
+## 2. Shared Plan and Apply Protocol
+
+Every collector implements the same phases:
+
+1. **Resolve** the target, owned roots, effective configuration, clock, and
+   read-only domain stores.
+2. **Scan** entries without following symlinks. Record every recognized item,
+   unknown item, and scan error.
+3. **Classify** from persisted domain state into eligible or a stable skip code.
+4. **Freeze** an immutable plan containing candidate identity, ownership proof,
+   retention evidence, expected state/version, path identity, and byte estimate.
+5. **Apply**, only when explicitly requested, by revalidating and mutating each
+   frozen candidate under the locks in §6.
+6. **Report** the same plan and outcomes in human or JSON form.
+
+An apply invocation acquires the GC lock before scanning and holds it while it
+builds and consumes its one immutable plan. A plan-only invocation does not
+persist authority for a later apply: a later `--apply` invocation builds a new
+plan because clocks and owners may have changed. Given the same roots, config,
+clock, and store snapshot, plan-only and apply select the same candidates;
+apply may only reduce mutations by turning a candidate into a revalidation skip
+or error. It may never add an item that was absent from the frozen plan.
+
+Planning has no side effects, including no opportunistic store migration,
+rotation, stale-owner cancellation, index rewrite, or lock cleanup. Opening a
+store for planning must use a read-only/no-migration path.
+
+## 3. Targets, Ownership, and Retention Clocks
+
+Age is computed from the named persisted domain timestamp. Filesystem mtime is
+never the sole eligibility clock. If the authoritative timestamp or ownership
+proof is absent, malformed, or contradictory, the item is skipped as ambiguous.
+
+### 3.1 Worktrees (workspace)
+
+The collector owns only worktrees registered by Orbit beneath the resolved
+workspace worktree root. Eligibility uses the owning run's persisted terminal
+transition: success/cancelled and failed/interrupted classes have separate
+retention. Pending, running, resumable, live-owned, current, dirty source-bearing,
+unknown-owner, unmerged, unpushed, or liveness-inconclusive worktrees are
+protected. Unknown directories are inventory entries, not candidates. Removal
+uses Git worktree operations and is language-neutral. On-terminal cleanup calls
+the same classifier and apply primitive as manual GC.
+
+### 3.2 Runs (workspace)
+
+The run collector coordinates authoritative rows, steps, reservations,
+checkpoints/scoreboards, task references, and legacy/regenerable bundles. Its
+clock is the persisted terminal transition. Archive and purge are distinct
+stages with distinct ages, and failed/interrupted evidence may have a longer
+retention. Active, resumable, task-held, or liveness-inconclusive runs are
+protected. Audit envelopes and blobs are not run-owned deletion side effects;
+they remain the audit collector's responsibility.
+
+### 3.3 Logs (global)
+
+The log collector owns Orbit-created operational JSONL archives in configured
+global log roots. The active inode and any file held by a known writer are
+protected. Age uses the managed archive timestamp written at rotation; malformed
+names are retained rather than aged by mtime. The existing age and total-byte
+budgets share one planner with startup pruning. Journald, system logs, and
+third-party logs are out of scope.
+
+### 3.4 Diagnostics (workspace)
+
+This collector owns closed metrics and diagnostic-friction JSONL partitions
+under the workspace diagnostics root. Its clock is the partition boundary plus
+persisted record/closure timestamps. The current partition, writer-owned files,
+malformed partitions, canonical friction records, tasks, learnings, and audit
+evidence are protected.
+
+### 3.5 Audit (workspace and global)
+
+Audit collection covers the legacy event store in its owning scope and
+workspace v2 events, loop envelopes, and content-addressed blobs. Event age uses
+the persisted event timestamp. Blob deletion is never age-based: a mark phase
+walks all retained envelopes, holds, exports, and retained-run references, and
+only unreachable blobs enter the sweep plan. Ordering must ensure a retained
+envelope never points at a deleted blob. The GC operation writes a deletion
+manifest or out-of-band audit event that the active plan cannot recursively
+collect.
+
+### 3.6 Skills (global)
+
+Skill collection covers generated directories and supported agent-root links
+whose Orbit ownership is proven by manifest/hash and retirement metadata. Age,
+when relevant, uses a persisted retirement timestamp. Name matching, a broken
+link, or mtime is insufficient. Modified generated content, same-named user
+content, links targeting elsewhere, plugin caches, and third-party content are
+protected. Only the link itself may be unlinked; a symlink target is never
+traversed for deletion.
+
+### 3.7 Tasks (workspace)
+
+V1 task collection is reversible archival, not physical bundle deletion. It
+uses the persisted transition into an eligible terminal status. Active states,
+open review threads, keep/exemption metadata, unresolved relations, and other
+lifecycle holds are protected. Apply delegates to the ordinary task lifecycle
+mutation so history, audit, projections, relations, and search indexes remain
+consistent. A future purge requires a separate export/restore, tombstone, and
+referential-integrity decision.
+
+### 3.8 All
+
+`all` contains each target available in the explicitly resolved scope and uses
+the exact individual collectors. It freezes one aggregate plan. Apply order is
+stable and dependency-aware: `worktrees`, `runs`, `diagnostics`, `skills`,
+`tasks`, `audit`, then `logs`. This preserves worktree ownership evidence before
+run cleanup and lets audit reachability observe the post-run/task retained set.
+Independent later collectors may continue after an error; a collector whose
+prerequisite failed is reported as dependency-blocked.
+
+## 4. Configuration and Precedence
+
+GC uses typed `[gc]` configuration with per-target subsections and conservative
+built-in defaults. Exact key names and defaults land with their collector, but
+every key identifies its unit and retention class; zero means immediate
+eligibility only where the key explicitly permits it. Invalid values fail plan
+construction before mutation.
+
+Precedence is:
+
+1. explicit CLI override for this invocation;
+2. the one effective config document for the target scope;
+3. built-in target defaults.
+
+Global targets read only the global config. A workspace target reads the
+workspace config when it exists; that document replaces, rather than merges,
+global config. Therefore a workspace config is a complete policy document:
+missing GC keys fall back to built-in defaults, not values from global config.
+If no workspace config exists, the global document is the workspace target's
+effective document. Reports identify `config_source` and resolved values.
+
+For `all`, each subplan resolves independently: global subtargets use the global
+document, while workspace subtargets use the complete workspace policy above.
+A workspace cannot use its config to broaden global roots or weaken global
+protection rules.
+
+## 5. Non-bypassable Safety Invariants
+
+The following are eligibility requirements, not warnings. No `--force`, short
+retention, environment variable, compatibility command, or automation setting
+may bypass them.
+
+1. **Root containment.** Each path is derived from an allowlisted `WorkspacePaths`
+   or global-root field. Lexical normalization must reject parent traversal, and
+   resolved identity must remain beneath the already validated owned root.
+   Arbitrary user-supplied deletion roots are unsupported.
+2. **Symlink safety.** Scan with `symlink_metadata`; do not follow symlinks while
+   measuring or deleting. A proven Orbit-owned symlink may be unlinked as an
+   object, but its target is never recursively removed. A symlink/reparse point
+   in any unexpected path component makes the candidate ambiguous.
+3. **Current-process protection.** Never mutate the current working worktree,
+   the running executable or its containing installation, the active log inode,
+   this process's run/reservation, or state locked by this process. Ancestor and
+   identity comparisons use resolved paths/file identity, not string spelling.
+4. **Live-owner protection.** A live PID/lease/run claim/writer or a resumable
+   owner prevents mutation. PID reuse must be ruled out with a persisted owner
+   token/start identity. Permission errors and inconclusive liveness are skips,
+   never evidence that an owner is dead.
+5. **Ownership and ambiguity.** Every mutation needs positive domain ownership
+   and a source-of-truth retention clock. Unknown, malformed, dirty, conflicting,
+   or partially readable items remain in place with a reason.
+6. **Atomic revalidation.** Immediately before mutation, re-read ownership,
+   state/version, retention evidence, liveness, path identity, and holds under
+   the GC lock plus the domain writer lock or store transaction. Use
+   descriptor-relative/no-follow mutation where available. If the platform
+   cannot close a path race safely, skip rather than falling back to an unsafe
+   recursive delete.
+7. **Branch and evidence preservation.** Collection never deletes an unmerged
+   or unpushed task branch, reachable audit blob, held export, or evidence still
+   required by a retained run/task.
+
+## 6. Mutual Exclusion and Writer Coordination
+
+Every apply entry point, individual or aggregate, acquires one host-wide
+exclusive lock beneath the global Orbit state root. This serializes global and
+workspace GC so two workspaces cannot concurrently touch shared logs, skills,
+or stores. Lock metadata contains process identity, start identity, command,
+scope, and acquisition time. Acquisition has a bounded wait and returns a clear
+non-mutating error for a live holder; stale-lock recovery itself requires a
+conclusive dead-owner check.
+
+The GC lock coordinates collectors, not ordinary writers. Before each mutation,
+the collector also participates in the domain's writer protocol: a database
+transaction/CAS, run-claim or task lock, log rotation lock, or equivalent.
+Lock order is always GC lock, then domain lock, then filesystem operation.
+Collectors never wait for a domain lock while holding locks in the reverse
+order. Plan-only scans may run concurrently and must tolerate changes as
+reported uncertainty.
+
+## 7. Standard Report Contract
+
+Human and JSON modes are projections of one in-memory `GcReport`; they contain
+the same targets, scopes, counts, byte estimates, skips, errors, and final
+outcome. Human mode may abbreviate item detail on screen but must state where
+the complete deletion manifest was written. JSON field meanings are versioned:
+
+```json
+{
+  "schema_version": 1,
+  "mode": "plan|apply",
+  "plan_id": "stable invocation identifier",
+  "scope": {"kind": "global|workspace", "workspace_id": null, "root": "..."},
+  "config_source": "builtin|global|workspace",
+  "started_at": "RFC3339",
+  "finished_at": "RFC3339",
+  "outcome": "clean|partial|failed",
+  "targets": [{
+    "target": "worktrees",
+    "counts": {"scanned": 0, "eligible": 0, "reclaimed": 0},
+    "bytes": {"scanned": 0, "eligible": 0, "reclaimed": 0, "estimate_complete": true},
+    "items": [{"id": "...", "action": "delete|archive|unlink|rotate", "status": "eligible|reclaimed|skipped|error", "bytes": 0}],
+    "skipped": [{"id": "...", "code": "live_owner", "reason": "..."}],
+    "errors": [{"id": "...", "phase": "scan|revalidate|apply", "code": "...", "message": "..."}]
+  }]
+}
+```
+
+Counts are item counts, never inferred from array truncation. `scanned` includes
+recognized, unknown, skipped, and errored entries encountered in the owned
+scope. `eligible` is the frozen plan count. `reclaimed` counts only completed
+mutations; in plan mode it is zero. Bytes use saturating `u64` estimates;
+unknown sizes do not become zero silently and set `estimate_complete=false`.
+Reclaimed bytes are measured or best-effort verified after mutation and may be
+lower than eligible bytes. Skip and error codes are stable machine values;
+reasons/messages are redacted human explanations.
+
+A clean plan or apply exits zero. Any scan/apply error or dependency-blocked
+target makes the outcome partial/failed and the process non-zero, while ordinary
+policy skips such as `retained`, `live_owner`, or `not_applicable` remain a
+successful report. Lock contention is a non-mutating error. JSON is written as
+one valid document to stdout; diagnostics do not corrupt it.
+
+## 8. Partial Failure, Audit, and Recovery
+
+Candidates are independent unless a collector declares a transaction group.
+An item failure is recorded and later independent items continue. Completed
+mutations are not rolled back by recreating deleted state. A transactional
+collector must order mutations so interruption leaves either the old state or a
+restart-safe intermediate state; re-running plans what remains and is
+idempotent. Aggregate collection continues independent targets but reports
+targets blocked by a failed prerequisite.
+
+Every completed mutation is represented in an append-only deletion manifest
+containing the plan ID, target, candidate identity, ownership/clock evidence,
+action, bytes, and result. Where safe, Orbit also emits a normal audit event.
+The manifest/event for the active pass is excluded from its own candidate
+snapshot, preventing recursive audit/log growth or self-deletion.
+
+## 9. Aggregate and Automation Policy
+
+`orbit gc all` uses one host-wide lock and aggregate snapshot, the stable order
+in §3.8, and configurable time/item/reclaimed-byte budgets. A budget is checked
+before starting the next item; reaching it is a reported bounded stop, not an
+error and never interrupts an item mid-transaction.
+
+Automatic collection is disabled by default. Opt-in automation must name its
+scope and targets, set the collector's explicit apply argument, and use the same
+budgets, lock, collectors, protections, and reports as an operator invocation.
+It may be a scheduled routine, but it cannot discover, create, or dispatch
+tasks. Startup hooks do not delete or perform lifecycle mutations; they are
+limited to non-destructive setup and active-file rotation.
+
+## 10. Compatibility and Surface Ownership
+
+- **`orbit audit prune`.** Keep a deprecation shim for one documented migration
+  window. The old bare destructive form becomes plan-only; mutation requires a
+  new explicit `--apply`. `--older-than` maps to the legacy-event retention
+  override, and both paths call the audit collector. There is no legacy bypass
+  around blob reachability, holds, locking, reporting, or revalidation.
+- **Log startup pruning.** Extract the existing rotation/pruning classifier.
+  Startup may continue active-file rotation but stops deleting archives;
+  archive eligibility is visible in `orbit gc logs`, and deletion occurs only
+  through `orbit gc logs --apply` (whether invoked by an operator or explicitly
+  configured automation). There is no config-only substitute for the apply
+  argument.
+- **Skill unlink/init cleanup.** Explicit `orbit skill unlink` remains an
+  operator-owned uninstall action, but generated-content retirement and init
+  cleanup delegate to the skill ownership classifier. Existing `force` flags
+  may replace an installation during init but cannot weaken GC ownership,
+  symlink, or containment invariants.
+- **Rejected `orbit run gc`.** No compatibility alias is added. `run` owns
+  workflow/job execution; retention spans stores unrelated to a run. Any
+  unreleased or experimental `orbit run gc` implementation is removed or emits
+  a non-mutating diagnostic pointing to `orbit gc worktrees`; it must never
+  preserve old destructive semantics.
+
+## 11. Concerns & Honest Limitations
+
+- Portable descriptor-relative deletion and reliable open-file ownership differ
+  by platform. Unsupported proofs reduce reclamation by producing skips; they do
+  not justify weaker deletion.
+- Byte totals are estimates for sparse files, reflinks, compressed stores, and
+  concurrently changing trees. Reports expose incompleteness instead of
+  claiming exact disk blocks.
+- A host-wide lock intentionally limits GC throughput. This is preferable to
+  cross-workspace races while collectors share global roots; finer locking
+  requires a future proof that preserves the same safety.
+- V1 does not physically purge tasks, collect arbitrary build caches, repair
+  ambiguous ownership, or promise that every skip can be resolved automatically.
+- This document defines the contract before collectors exist. Each implementing
+  task must add fake-clock, temp-root, race, symlink, partial-failure, and
+  idempotency tests appropriate to its domain.
+
+## Task References
+
+- [ORB-10178] — defined this retention and safety contract.
+- [ORB-10180] — will implement the shared GC framework.
+- [ORB-10182] — will implement managed worktree collection.
+- [ORB-10183] — will implement run retention.
+- [ORB-10184] — will unify log retention.
+- [ORB-10185] — will implement diagnostics retention.
+- [ORB-10186] — will implement audit and blob collection.
+- [ORB-10187] — will implement generated-skill collection.
+- [ORB-10188] — will implement task archival.
+- [ORB-10189] — will implement aggregate and automatic collection.
+
+> Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.

--- a/docs/design/gc/3_vision.md
+++ b/docs/design/gc/3_vision.md
@@ -1,0 +1,81 @@
+---
+title: Garbage Collection — Vision
+owner: codex
+last_updated: 2026-07-12
+status: Draft
+feature: gc
+doc_role: vision
+type: design
+summary: Tracks future GC questions beyond the v1 explicit, safety-first retention contract.
+tags: [gc, retention, safety]
+paths: ["crates/orbit-cli/src/command/gc/**", "crates/orbit-core/src/command/gc/**"]
+related_features: [gc, activity-job, auditability, task-artifacts, worktree-artifacts]
+related_artifacts: [ORB-10178, ADR-0220]
+---
+
+# Garbage Collection — Vision
+
+The v1 direction is deliberately conservative: explain first, apply explicitly,
+and retain anything whose ownership or liveness is uncertain. This document
+tracks possible extensions; none weakens the normative invariants in
+[2_design.md](./2_design.md).
+
+## 1. Open Questions
+
+1. Can the host-wide apply lock eventually become a hierarchy without allowing
+   cross-workspace races over global logs, skills, audit data, or registries?
+2. Which platforms can provide a common descriptor-relative, no-follow deletion
+   primitive with equally strong revalidation guarantees?
+3. Should a signed plan be exportable for separate human approval and later
+   apply, and what maximum age/version checks would prevent stale authority?
+4. What export, tombstone, restore, and relation model would make physical task
+   purge safe enough to propose?
+5. Can allocated disk blocks be measured portably enough to supplement logical
+   byte estimates without making collection depend on platform utilities?
+
+## 2. Prior Work
+
+### Orbit cleanup surfaces
+
+`orbit audit prune`, JSONL startup pruning, skill unlink/init cleanup, and the
+archived worktree-GC attempt [ORB-10173] provide useful domain primitives. They
+also demonstrate why command ownership, mutation gating, live-owner checks, and
+one report contract must be established before reuse.
+
+### Storage lifecycle systems
+
+Database vacuuming, object-store lifecycle policies, Git worktree management,
+and tracing-log rotation all separate eligibility from physical reclamation in
+different ways. Orbit borrows their source-of-truth clocks and restart-safe
+thinking but cannot delegate cross-domain ownership or referential integrity to
+any one of them.
+
+## 3. What May Be Distinctive
+
+The individual mechanisms are conventional. The potentially distinctive part
+is treating heterogeneous cleanup as one explainable plan whose safety
+invariants are stronger than its retention settings: automation and operators
+can shorten age thresholds, but neither can convert uncertainty into permission.
+
+## 4. References
+
+**Orbit-internal**
+
+- [Garbage Collection design](./2_design.md)
+- [Activity / Job design](../activity-job/2_design.md)
+- [Auditability design](../auditability/2_design.md)
+- [Task Artifacts design](../task-artifacts/2_design.md)
+- [Worktree Artifacts design](../worktree-artifacts/2_design.md)
+
+**External**
+
+- Git documentation for `git worktree remove` and `git worktree prune`.
+- SQLite documentation for transactions and write-ahead logging.
+
+## Task References
+
+- [ORB-10173] — demonstrated the worktree leak and an earlier domain-specific GC attempt.
+- [ORB-10178] — defined the GC retention and safety contract.
+- [ORB-10189] — will validate aggregate and opt-in automatic collection.
+
+> Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.

--- a/docs/design/gc/4_decisions.md
+++ b/docs/design/gc/4_decisions.md
@@ -1,0 +1,61 @@
+---
+title: Garbage Collection — Decisions
+owner: codex
+last_updated: 2026-07-12
+status: Draft
+feature: gc
+doc_role: decisions
+type: design
+summary: Records the durable choice of one explicit, safety-first Orbit garbage-collection family.
+tags: [gc, retention, safety]
+paths: ["docs/design/gc/**", "crates/orbit-cli/src/command/gc/**", "crates/orbit-core/src/command/gc/**"]
+related_features: [gc]
+related_artifacts: [ADR-0220, ORB-10178]
+---
+
+# Garbage Collection — Decisions
+
+ADR log for garbage collection. Entries are append-only and ordered by ascending
+global ID. The store owns ID, status, owner, and links; this file is the
+long-form narrative keyed on the same allocated ID. See
+[CONVENTIONS.md §4](../CONVENTIONS.md#4-adr-template-strict) for the full rules.
+
+## ADR-0220 — One safety contract for explicit Orbit garbage collection
+
+**Status:** Accepted · 2026-07 · [ORB-10178]
+
+**Context.** Orbit cleanup is split between domain commands and startup hooks,
+while a top-level collector must coordinate global and workspace state without
+racing live owners. Real alternatives were to keep domain-specific mutation
+surfaces, put worktree cleanup under `orbit run`, let each collector define its
+own lock/report/force rules, or make bare invocation destructive.
+
+**Decision.** Adopt one top-level `orbit gc [TARGET]` family whose default is a
+non-mutating plan and whose only mutation gate is explicit `--apply`. Every
+target uses a shared immutable plan/report contract, one host-wide apply lock
+plus domain-specific atomic revalidation, source-of-truth retention clocks, and
+non-bypassable containment, symlink, current-owner, and ambiguity protections;
+`all` composes the same collectors.
+
+**Consequences.**
+
+- Existing cleanup entry points delegate to shared collectors or become
+  non-mutating compatibility shims; `orbit run gc` is rejected because
+  retention is storage lifecycle, not workflow execution.
+- Global targets take policy only from global config. Workspace targets use the
+  existing complete-document workspace-replaces-global rule, with CLI
+  overrides highest.
+- Partial failure preserves successful mutations, reports every skip/error, and
+  returns non-zero; reruns are idempotent.
+- No single code anchor yet; the convention will be enforced by the shared GC
+  framework and collector review.
+- Cost: All apply passes serialize behind one host-wide lock and pay
+  per-candidate revalidation, and workspace owners must repeat any global GC
+  settings they want in a complete workspace policy instead of inheriting a
+  merged fragment.
+
+## Task References
+
+- [ORB-10178] — selected and specified the shared GC contract.
+
+> Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.


### PR DESCRIPTION
## Task

[ORB-10178](https://orbit-cli.com/tasks/ORB-10178) — Define the orbit gc retention and safety contract

### Description

## Problem

Orbit cleanup is fragmented across domain commands and startup hooks, with no shared ownership, retention, concurrency, or reporting contract. A new top-level `orbit gc` family will perform destructive work across both global and workspace-local state, so implementing collectors before defining the safety model risks data loss and inconsistent behavior.

## Why It Matters

Worktrees, run evidence, logs, diagnostics, audit records, generated skills, and tasks have different sources of truth and retention clocks. The command family needs one reviewed design that makes deletion eligibility explainable and ensures no collector can escape Orbit-owned roots or race live writers.

## Scope

Author the design document and ADR for `orbit gc`, covering command grammar, collector boundaries, global versus workspace scope, retention/config precedence, candidate planning, locking/revalidation, reporting, compatibility aliases, partial failures, and automation policy.

## Constraints / Notes

- Bare `orbit gc` and every collector default to a non-mutating overview; mutation requires explicit `--apply`.
- Age must come from persisted domain timestamps when available, never filesystem mtime alone.
- Root containment, symlink handling, live-owner protection, and ambiguity rules are non-bypassable invariants.
- Workspace config replaces rather than merges global config, so the design must state complete-config behavior.
- Arbitrary language build caches outside Orbit-managed worktrees are out of scope.

### Acceptance Criteria

- A reviewed design doc and ADR define `orbit gc [TARGET]`, including `worktrees`, `runs`, `logs`, `diagnostics`, `audit`, `skills`, `tasks`, and `all`.
- The design makes bare/default invocation non-mutating and requires explicit `--apply` for every deletion or lifecycle mutation.
- A standard report schema is defined with target, scope, scanned/eligible/reclaimed counts and bytes, skipped items with reasons, errors, and equivalent human/JSON semantics.
- The design defines global versus workspace targets, retention clocks, config precedence, partial-failure behavior, and a GC-wide mutual-exclusion model.
- Root-containment, symlink, current-process/current-worktree, live-owner, and atomic revalidation invariants are explicit and cannot be bypassed by force flags.
- Compatibility policy is specified for existing `orbit audit prune`, log startup pruning, skill unlink/init cleanup, and the rejected `orbit run gc` surface.
- The ADR records the chosen alternatives and costs, and `make ci-fast` passes.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Added the complete `docs/design/gc/` design set. The normative design specifies `orbit gc [TARGET]` for worktrees, runs, logs, diagnostics, audit, skills, tasks, and all; bare/default invocations are plan-only and every mutation requires explicit `--apply`.
- Defined target ownership and retention clocks, global versus workspace scope, complete-document workspace config precedence, immutable plan/apply semantics, a host-wide GC lock plus domain revalidation, partial-failure/recovery behavior, stable aggregate ordering, bounded opt-in automation, and compatibility policy for audit prune, log startup pruning, skill cleanup, and the rejected `orbit run gc` surface.
- Defined schema-versioned equivalent human/JSON reporting with target/scope/config provenance, scanned/eligible/reclaimed counts and bytes, stable skip codes, item errors, and outcome semantics.
- Made containment, no-follow symlink handling, current-process/current-worktree protection, positive ownership, conclusive live-owner checks, branch/evidence preservation, and atomic pre-mutation revalidation non-bypassable by force or retention overrides.
- Allocated and accepted ADR-0220 through `orbit.adr.add`/`update`, recording the rejected alternatives and serialization/revalidation/complete-config costs; mirrored it in the decision log. Registered the feature owner in `docs/design/CONVENTIONS.md` and added the required Unreleased changelog bullet.
- Filed F2026-07-020 for the incompatible installed executor binary and updated existing learning L-0077 through `orbit.learning.update` with this recurrence as evidence.

Strategic decisions:
- One top-level, plan-first GC family with a single host-wide apply lock | Rationale: retention spans shared global and workspace stores, so domain-local force/lock/report rules cannot prove cross-target safety.
- Global policy comes only from global config; workspace policy uses the existing workspace-replaces-global complete-document rule | Rationale: a workspace must not broaden global deletion authority, and silent partial merging would make effective retention hard to explain.
- Task GC is archive-only in v1 and audit blobs are reachability-collected | Rationale: age alone cannot preserve task relations or audit referential integrity.

Validation:
- `git diff --check`, `cargo fmt --all -- --check`, ADR read-back, and strict `orbit docs show` parsing for all four new docs passed.
- Every `make ci-fast` guardrail except `test-installer-security.sh` passed, including changelog freshness/style, dependency direction, CLI imports, stability, learning layout, artifact redaction, and error translation. The canonical `make ci-fast` stopped only because the runner has no `node` binary; the script reported `required binary node not on PATH`.

Assessment: The design covers every acceptance criterion with explicit fail-closed semantics and leaves implementation-specific defaults/key names to the dependent collector tasks without weakening the shared contract.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10178-6a5404d2`
- Behind base: 0
- Ahead of base: 1