### PR TITLE
Implement the top-level orbit gc framework

### DIFF
--- a/.orbit/adrs/accepted/ADR-0220/adr.yaml
+++ b/.orbit/adrs/accepted/ADR-0220/adr.yaml
@@ -5,11 +5,12 @@ status: accepted
 owner: codex
 created_at: 2026-07-12T21:22:27.975299792Z
 accepted_at: 2026-07-12T21:25:28.062180793Z
-last_updated: 2026-07-12T21:25:28.062180793Z
+last_updated: 2026-07-12T21:38:23.158139268Z
 related_features:
 - gc
 related_tasks:
 - ORB-10178
+- ORB-10180
 tags:
 - gc
 - retention

--- a/.orbit/learnings/L-0077/learning.yaml
+++ b/.orbit/learnings/L-0077/learning.yaml
@@ -10,7 +10,7 @@ scope:
   - workflow-admission
   - tooling
 summary: Verify the executor Orbit binary can read the admitted worktree config and store schema before dispatch
-body: 'Workflow admission can succeed while the subsequently dispatched agent resolves an older installed `orbit` binary. The agent then cannot call required lifecycle tools if the task store schema is newer, and config validation can fail under a legacy schema before any command dispatch. Admission should validate the exact executor binary against every effective config layer and the workspace store, or pass the compatible checked-out binary explicitly. Error messages for layered config failures should include the source path. ORB-10178 reproduced the config-schema variant: the installed binary rejected the admitted worktree crew schema before `orbit.task.show`, while a workspace-built binary from the admitted revision worked.'
+body: 'Workflow admission can succeed while the subsequently dispatched agent resolves an older installed `orbit` binary. The agent then cannot call required lifecycle tools if the task store schema is newer, and config validation can fail under a legacy schema before any command dispatch. Admission should validate the exact executor binary against every effective config layer and the workspace store, or pass the compatible checked-out binary explicitly. Error messages for layered config failures should include the source path. ORB-10178 and ORB-10180 both reproduced the config-schema variant: the installed binary rejected the admitted worktree crew schema before required lifecycle/tool discovery, while the worktree-compatible MCP surface remained usable.'
 evidence:
 - kind: task
   reference: ORB-10148
@@ -20,6 +20,10 @@ evidence:
   reference: ORB-10178
 - kind: external
   reference: F2026-07-020
+- kind: task
+  reference: ORB-10180
+- kind: external
+  reference: F2026-07-022
 created_at: 2026-07-12T03:37:58.785982787Z
-updated_at: 2026-07-12T21:26:29.732641246Z
+updated_at: 2026-07-12T21:45:50.017174828Z
 created_by: codex

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- **Shared garbage-collection framework**: `orbit gc` now exposes every retention target with plan-first/apply, scope, retention, locking, immutable candidate, safety revalidation, manifest, and equivalent human/JSON report contracts for domain collectors. ([ORB-10180])
 - **Safety-first garbage collection contract**: the `orbit gc` design standardizes explicit apply, retention clocks, ownership/revalidation invariants, locking, and equivalent human/JSON reports across global and workspace collectors. ([ORB-10178])
 - **Systemd routine workers survive sweep exit**: the user sweep service now limits shutdown to its main oneshot process, allowing detached pipeline workers to claim and complete clock-dispatched runs. ([ORB-10153])
 - **Task creation surface is narrower and consistent**: task creation now exposes only legal initial statuses, list flags share repeat/comma parsing, and redundant agent/comment/instructions inputs are removed while model and managed identity attribution remain intact. ([ORB-10155])

--- a/crates/orbit-cli/src/audit_middleware.rs
+++ b/crates/orbit-cli/src/audit_middleware.rs
@@ -452,6 +452,23 @@ pub fn extract_command_meta(cmd: &Commands) -> CommandMeta {
                 job_run_id: None,
             }
         }
+        Commands::Gc(cmd) => CommandMeta {
+            command: "gc".to_string(),
+            subcommand: Some(format!("{:?}", cmd.target).to_lowercase()),
+            tool_name: None,
+            target_type: Some("gc_target".to_string()),
+            target_id: Some(format!("{:?}", cmd.target).to_lowercase()),
+            role: "admin".to_string(),
+            arguments_json: serde_json::to_string(&serde_json::json!({
+                "apply": cmd.apply,
+                "global": cmd.global,
+                "json": cmd.json,
+                "retention": cmd.retention,
+                "workspace": cmd.workspace,
+            }))
+            .ok(),
+            job_run_id: None,
+        },
         Commands::AutoTask(cmd) => {
             use crate::command::auto_task::AutoTaskSubcommand;
             let (sub, target_id): (&str, Option<&str>) = match &cmd.command {

--- a/crates/orbit-cli/src/command/gc.rs
+++ b/crates/orbit-cli/src/command/gc.rs
@@ -1,0 +1,191 @@
+use std::path::PathBuf;
+
+use clap::{Args, ValueEnum};
+use orbit_core::command::gc::{
+    EmptyGcCollector, GcRequest, GcScope, GcTarget, SystemGcClock, execute_gc,
+};
+use orbit_core::{OrbitError, OrbitRuntime};
+
+use super::Execute;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub enum GcTargetArg {
+    Worktrees,
+    Runs,
+    Logs,
+    Diagnostics,
+    Audit,
+    Skills,
+    Tasks,
+    All,
+}
+
+impl From<GcTargetArg> for GcTarget {
+    fn from(value: GcTargetArg) -> Self {
+        match value {
+            GcTargetArg::Worktrees => Self::Worktrees,
+            GcTargetArg::Runs => Self::Runs,
+            GcTargetArg::Logs => Self::Logs,
+            GcTargetArg::Diagnostics => Self::Diagnostics,
+            GcTargetArg::Audit => Self::Audit,
+            GcTargetArg::Skills => Self::Skills,
+            GcTargetArg::Tasks => Self::Tasks,
+            GcTargetArg::All => Self::All,
+        }
+    }
+}
+
+#[derive(Debug, Args)]
+#[command(about = "Plan or apply garbage collection for Orbit-owned state")]
+pub struct GcCommand {
+    /// Storage family to inspect (omitted means all available targets)
+    #[arg(value_enum, default_value_t = GcTargetArg::All)]
+    pub target: GcTargetArg,
+
+    /// Perform the mutations in the frozen plan
+    #[arg(long)]
+    pub apply: bool,
+
+    /// Emit the complete versioned report as JSON
+    #[arg(long)]
+    pub json: bool,
+
+    /// Override the target's retention for this invocation
+    #[arg(long, value_name = "DURATION")]
+    pub retention: Option<String>,
+
+    /// Select the current registered workspace by ID or path
+    #[arg(long, value_name = "ID_OR_PATH", conflicts_with = "global")]
+    pub workspace: Option<String>,
+
+    /// Select global Orbit-owned state only
+    #[arg(long, conflicts_with = "workspace")]
+    pub global: bool,
+}
+
+impl Execute for GcCommand {
+    fn execute(self, runtime: &OrbitRuntime) -> Result<(), OrbitError> {
+        let target = GcTarget::from(self.target);
+        let defaults_global = matches!(target, GcTarget::Logs | GcTarget::Skills);
+        let scope = if self.global || (self.workspace.is_none() && defaults_global) {
+            GcScope::Global {
+                root: runtime.paths().global_dir.clone(),
+            }
+        } else {
+            resolve_workspace_scope(self.workspace.as_deref(), runtime)?
+        };
+        let clock = SystemGcClock;
+        let report = execute_gc(
+            &EmptyGcCollector::new(target),
+            GcRequest {
+                apply: self.apply,
+                scope,
+                retention_override: self.retention.as_deref(),
+                global_state_dir: &runtime.paths().global_dir.join("state"),
+                clock: &clock,
+            },
+        )?;
+        if self.json {
+            println!(
+                "{}",
+                serde_json::to_string_pretty(&report)
+                    .map_err(|error| OrbitError::Execution(error.to_string()))?
+            );
+        } else {
+            print_human_report(&report);
+        }
+        if report.has_errors() {
+            return Err(OrbitError::Execution(format!(
+                "garbage collection completed with {:?} outcome",
+                report.outcome
+            )));
+        }
+        Ok(())
+    }
+}
+
+fn resolve_workspace_scope(
+    selector: Option<&str>,
+    runtime: &OrbitRuntime,
+) -> Result<GcScope, OrbitError> {
+    let Some(selector) = selector else {
+        return Ok(GcScope::Workspace {
+            workspace_id: None,
+            root: runtime.paths().orbit_dir.clone(),
+        });
+    };
+    let registry_path =
+        orbit_core::workspace_registry::registry_path_for(&runtime.paths().global_dir);
+    let registry = orbit_core::workspace_registry::load_registry_from(&registry_path)?;
+    let selector_path = PathBuf::from(selector);
+    if selector_path.is_absolute() {
+        let selected = selector_path.canonicalize().map_err(|error| {
+            OrbitError::InvalidInput(format!("cannot resolve workspace `{selector}`: {error}"))
+        })?;
+        let workspace = registry
+            .workspaces
+            .iter()
+            .find(|workspace| {
+                workspace
+                    .root
+                    .canonicalize()
+                    .is_ok_and(|root| root == selected)
+            })
+            .ok_or_else(|| {
+                OrbitError::InvalidInput(format!("workspace path `{selector}` is not registered"))
+            })?;
+        return Ok(GcScope::Workspace {
+            workspace_id: Some(workspace.id.clone()),
+            root: workspace.orbit_dir.clone(),
+        });
+    }
+    let workspace = orbit_core::workspace_registry::find_workspace(&registry, selector)
+        .ok_or_else(|| {
+            OrbitError::InvalidInput(format!("workspace `{selector}` is not registered"))
+        })?;
+    Ok(GcScope::Workspace {
+        workspace_id: Some(workspace.id.clone()),
+        root: workspace.orbit_dir.clone(),
+    })
+}
+
+fn print_human_report(report: &orbit_core::command::gc::GcReport) {
+    println!(
+        "GC {:?} {} ({:?})",
+        report.mode, report.plan_id, report.outcome
+    );
+    for target in &report.targets {
+        println!(
+            "{}: scanned {}, eligible {}, reclaimed {}; bytes scanned {}, eligible {}, reclaimed {}",
+            target.target,
+            target.counts.scanned,
+            target.counts.eligible,
+            target.counts.reclaimed,
+            target.bytes.scanned,
+            target.bytes.eligible,
+            target.bytes.reclaimed,
+        );
+        for item in &target.items {
+            println!(
+                "  item {} [{:?}]: {} ({} bytes)",
+                item.id,
+                item.status,
+                item.action,
+                item.bytes
+                    .map_or_else(|| "unknown".to_string(), |bytes| bytes.to_string())
+            );
+        }
+        for skip in &target.skipped {
+            println!("  skipped {} [{}]: {}", skip.id, skip.code, skip.reason);
+        }
+        for error in &target.errors {
+            println!(
+                "  error {} [{}:{}]: {}",
+                error.id, error.phase, error.code, error.message
+            );
+        }
+    }
+    if let Some(path) = &report.manifest_path {
+        println!("deletion manifest: {}", path.display());
+    }
+}

--- a/crates/orbit-cli/src/command/mod.rs
+++ b/crates/orbit-cli/src/command/mod.rs
@@ -7,6 +7,7 @@ pub mod docs;
 pub mod doctor;
 pub mod executor;
 pub mod friction;
+pub mod gc;
 pub mod graph;
 pub mod hook;
 pub mod init;
@@ -70,6 +71,7 @@ Operate:
   adr         List and inspect Architecture Decision Records
   friction    Report, list, and triage friction records
   learning    Create, search, and curate project learnings
+  gc          Plan or apply garbage collection for Orbit-owned state
 
 Observe:
   search      Search tasks, docs, learnings, and ADRs
@@ -123,6 +125,7 @@ pub enum Commands {
     Adr(adr::AdrCommand),
     Friction(friction::FrictionCommand),
     Learning(learning::LearningCommand),
+    Gc(gc::GcCommand),
 
     // ── Observe ──
     Graph(graph::GraphCommand),
@@ -174,6 +177,7 @@ impl Execute for Commands {
             Commands::Adr(cmd) => cmd.execute(runtime),
             Commands::Friction(cmd) => cmd.execute(runtime),
             Commands::Learning(cmd) => cmd.execute(runtime),
+            Commands::Gc(cmd) => cmd.execute(runtime),
             Commands::Graph(cmd) => cmd.execute(runtime),
             Commands::Audit(cmd) => cmd.execute(runtime),
             Commands::Log(cmd) => cmd.execute(runtime),

--- a/crates/orbit-cli/src/command/tests/gc.rs
+++ b/crates/orbit-cli/src/command/tests/gc.rs
@@ -1,0 +1,71 @@
+use clap::{CommandFactory, Parser};
+
+use super::super::{Cli, Commands, gc::GcTargetArg};
+
+#[test]
+fn gc_help_lists_every_target_and_uniform_flags() {
+    let mut root = Cli::command();
+    let root_help = root.render_long_help().to_string();
+    assert!(root_help.contains("gc          Plan or apply garbage collection"));
+    let help = root
+        .find_subcommand_mut("gc")
+        .expect("gc command")
+        .render_long_help()
+        .to_string();
+    for value in [
+        "worktrees",
+        "runs",
+        "logs",
+        "diagnostics",
+        "audit",
+        "skills",
+        "tasks",
+        "all",
+        "--apply",
+        "--json",
+        "--retention",
+        "--workspace",
+        "--global",
+    ] {
+        assert!(help.contains(value), "missing `{value}` from help:\n{help}");
+    }
+}
+
+#[test]
+fn gc_audit_metadata_tracks_target_and_mutation_gate() {
+    let cli = Cli::parse_from(["orbit", "gc", "worktrees", "--apply"]);
+    let meta = crate::audit_middleware::extract_command_meta(&cli.command);
+    assert_eq!(meta.command, "gc");
+    assert_eq!(meta.subcommand.as_deref(), Some("worktrees"));
+    assert_eq!(meta.target_type.as_deref(), Some("gc_target"));
+    assert_eq!(meta.target_id.as_deref(), Some("worktrees"));
+    assert!(
+        meta.arguments_json
+            .as_deref()
+            .is_some_and(|arguments| arguments.contains("\"apply\":true"))
+    );
+}
+
+#[test]
+fn gc_is_plan_only_by_default_and_parses_target() {
+    let cli = Cli::parse_from(["orbit", "gc", "runs", "--retention", "30d", "--json"]);
+    match cli.command {
+        Commands::Gc(command) => {
+            assert_eq!(command.target, GcTargetArg::Runs);
+            assert!(!command.apply);
+            assert!(command.json);
+            assert_eq!(command.retention.as_deref(), Some("30d"));
+        }
+        _ => panic!("expected gc command"),
+    }
+}
+
+#[test]
+fn gc_scope_flags_conflict() {
+    let error =
+        match Cli::try_parse_from(["orbit", "gc", "tasks", "--workspace", "here", "--global"]) {
+            Ok(_) => panic!("scope flags must conflict"),
+            Err(error) => error,
+        };
+    assert!(error.to_string().contains("cannot be used with"));
+}

--- a/crates/orbit-cli/src/command/tests/mod.rs
+++ b/crates/orbit-cli/src/command/tests/mod.rs
@@ -1,6 +1,7 @@
 // Content moved from inline #[cfg(test)] mod tests in command/mod.rs per ORB-00221.
 // tests/mod.rs can directly contain tests for the declaring parent module (exempt from orphan rules).
 
+mod gc;
 mod init;
 mod sweep;
 

--- a/crates/orbit-core/src/command/gc.rs
+++ b/crates/orbit-core/src/command/gc.rs
@@ -1,0 +1,684 @@
+//! Shared, domain-neutral garbage-collection planning and apply framework.
+
+use std::fs::{self, File, OpenOptions};
+use std::io::Write;
+use std::path::{Component, Path, PathBuf};
+use std::thread;
+use std::time::{Duration, Instant};
+
+use chrono::{DateTime, Utc};
+use fs2::FileExt;
+use orbit_common::types::{OrbitError, audit_execution_id};
+use serde::{Deserialize, Serialize};
+
+const LOCK_WAIT: Duration = Duration::from_secs(2);
+const LOCK_POLL: Duration = Duration::from_millis(25);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum GcTarget {
+    Worktrees,
+    Runs,
+    Logs,
+    Diagnostics,
+    Audit,
+    Skills,
+    Tasks,
+    All,
+}
+
+impl std::fmt::Display for GcTarget {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let value = serde_json::to_value(self).map_err(|_| std::fmt::Error)?;
+        formatter.write_str(value.as_str().ok_or(std::fmt::Error)?)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum GcScope {
+    Global {
+        root: PathBuf,
+    },
+    Workspace {
+        workspace_id: Option<String>,
+        root: PathBuf,
+    },
+}
+
+impl GcScope {
+    pub fn root(&self) -> &Path {
+        match self {
+            Self::Global { root } | Self::Workspace { root, .. } => root,
+        }
+    }
+
+    fn label(&self) -> String {
+        match self {
+            Self::Global { .. } => "global".to_string(),
+            Self::Workspace { workspace_id, .. } => workspace_id
+                .as_deref()
+                .map_or_else(|| "workspace".to_string(), |id| format!("workspace:{id}")),
+        }
+    }
+}
+
+pub trait GcClock: Send + Sync {
+    fn now(&self) -> DateTime<Utc>;
+}
+
+#[derive(Debug, Default)]
+pub struct SystemGcClock;
+
+impl GcClock for SystemGcClock {
+    fn now(&self) -> DateTime<Utc> {
+        Utc::now()
+    }
+}
+
+pub struct GcContext<'a> {
+    pub scope: &'a GcScope,
+    pub retention_override: Option<&'a str>,
+    pub clock: &'a dyn GcClock,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct GcCandidate {
+    pub id: String,
+    pub action: String,
+    pub path: Option<PathBuf>,
+    pub bytes: Option<u64>,
+    pub ownership_evidence: String,
+    pub retention_evidence: String,
+    pub expected_state: String,
+    #[serde(default)]
+    pub allow_owned_symlink: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct GcSkip {
+    pub id: String,
+    pub code: String,
+    pub reason: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct GcItemError {
+    pub id: String,
+    pub phase: String,
+    pub code: String,
+    pub message: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GcPlan {
+    pub target: GcTarget,
+    pub config_source: String,
+    pub scanned: u64,
+    pub scanned_bytes: Option<u64>,
+    pub candidates: Vec<GcCandidate>,
+    pub skipped: Vec<GcSkip>,
+    pub errors: Vec<GcItemError>,
+}
+
+impl GcPlan {
+    pub fn empty(target: GcTarget) -> Self {
+        Self {
+            target,
+            config_source: "builtin".to_string(),
+            scanned: 0,
+            scanned_bytes: Some(0),
+            candidates: Vec::new(),
+            skipped: Vec::new(),
+            errors: Vec::new(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum GcRevalidation {
+    Ready,
+    Skip { code: String, reason: String },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GcMutation {
+    pub reclaimed_bytes: Option<u64>,
+}
+
+pub trait GcCollector {
+    fn target(&self) -> GcTarget;
+    fn plan(&self, context: &GcContext<'_>) -> Result<GcPlan, OrbitError>;
+    fn revalidate(
+        &self,
+        candidate: &GcCandidate,
+        context: &GcContext<'_>,
+    ) -> Result<GcRevalidation, OrbitError>;
+    fn apply(
+        &self,
+        candidate: &GcCandidate,
+        context: &GcContext<'_>,
+    ) -> Result<GcMutation, OrbitError>;
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum GcMode {
+    Plan,
+    Apply,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum GcOutcome {
+    Clean,
+    Partial,
+    Failed,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct GcCounts {
+    pub scanned: u64,
+    pub eligible: u64,
+    pub reclaimed: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct GcBytes {
+    pub scanned: u64,
+    pub eligible: u64,
+    pub reclaimed: u64,
+    pub estimate_complete: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum GcItemStatus {
+    Eligible,
+    Reclaimed,
+    Skipped,
+    Error,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct GcItemReport {
+    pub id: String,
+    pub action: String,
+    pub status: GcItemStatus,
+    pub bytes: Option<u64>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct GcTargetReport {
+    pub target: GcTarget,
+    pub counts: GcCounts,
+    pub bytes: GcBytes,
+    pub items: Vec<GcItemReport>,
+    pub skipped: Vec<GcSkip>,
+    pub errors: Vec<GcItemError>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct GcReport {
+    pub schema_version: u32,
+    pub mode: GcMode,
+    pub plan_id: String,
+    pub scope: GcScope,
+    pub config_source: String,
+    pub started_at: DateTime<Utc>,
+    pub finished_at: DateTime<Utc>,
+    pub outcome: GcOutcome,
+    pub manifest_path: Option<PathBuf>,
+    pub targets: Vec<GcTargetReport>,
+}
+
+impl GcReport {
+    pub fn has_errors(&self) -> bool {
+        self.targets.iter().any(|target| !target.errors.is_empty())
+    }
+}
+
+pub struct GcRequest<'a> {
+    pub apply: bool,
+    pub scope: GcScope,
+    pub retention_override: Option<&'a str>,
+    pub global_state_dir: &'a Path,
+    pub clock: &'a dyn GcClock,
+}
+
+pub fn execute_gc(
+    collector: &dyn GcCollector,
+    request: GcRequest<'_>,
+) -> Result<GcReport, OrbitError> {
+    let started_at = request.clock.now();
+    let plan_id = audit_execution_id("gc");
+    let context = GcContext {
+        scope: &request.scope,
+        retention_override: request.retention_override,
+        clock: request.clock,
+    };
+
+    // ADR-0220: apply holds the host lock while creating and consuming one frozen plan.
+    let _lock = if request.apply {
+        Some(acquire_gc_lock(
+            request.global_state_dir,
+            &plan_id,
+            collector.target(),
+            &request.scope,
+            started_at,
+        )?)
+    } else {
+        None
+    };
+    let plan = collector.plan(&context)?;
+    if plan.target != collector.target() {
+        return Err(OrbitError::Execution(format!(
+            "GC collector reported target `{}` while registered as `{}`",
+            plan.target,
+            collector.target()
+        )));
+    }
+
+    let eligible_bytes = plan
+        .candidates
+        .iter()
+        .filter_map(|candidate| candidate.bytes)
+        .fold(0_u64, u64::saturating_add);
+    let estimate_complete = plan.scanned_bytes.is_some()
+        && plan
+            .candidates
+            .iter()
+            .all(|candidate| candidate.bytes.is_some());
+    let mut report = GcTargetReport {
+        target: plan.target,
+        counts: GcCounts {
+            scanned: plan.scanned,
+            eligible: plan.candidates.len() as u64,
+            reclaimed: 0,
+        },
+        bytes: GcBytes {
+            scanned: plan.scanned_bytes.unwrap_or_default(),
+            eligible: eligible_bytes,
+            reclaimed: 0,
+            estimate_complete,
+        },
+        items: plan
+            .candidates
+            .iter()
+            .map(|candidate| GcItemReport {
+                id: candidate.id.clone(),
+                action: candidate.action.clone(),
+                status: GcItemStatus::Eligible,
+                bytes: candidate.bytes,
+            })
+            .collect(),
+        skipped: plan.skipped,
+        errors: plan.errors,
+    };
+
+    let manifest_path = request.apply.then(|| {
+        request
+            .global_state_dir
+            .join("gc")
+            .join("manifests")
+            .join(format!("{plan_id}.jsonl"))
+    });
+    if request.apply {
+        for (candidate, item) in plan.candidates.iter().zip(report.items.iter_mut()) {
+            let result = apply_candidate(
+                collector,
+                &context,
+                candidate,
+                manifest_path.as_deref().ok_or_else(|| {
+                    OrbitError::Execution("GC apply manifest path was not created".to_string())
+                })?,
+                &plan_id,
+            );
+            match result {
+                Ok(ApplyResult::Reclaimed {
+                    bytes,
+                    manifest_error,
+                }) => {
+                    item.status = GcItemStatus::Reclaimed;
+                    item.bytes = bytes.or(item.bytes);
+                    report.counts.reclaimed = report.counts.reclaimed.saturating_add(1);
+                    report.bytes.reclaimed = report
+                        .bytes
+                        .reclaimed
+                        .saturating_add(bytes.or(candidate.bytes).unwrap_or_default());
+                    if bytes.is_none() && candidate.bytes.is_none() {
+                        report.bytes.estimate_complete = false;
+                    }
+                    if let Some(error) = manifest_error {
+                        report.errors.push(error);
+                    }
+                }
+                Ok(ApplyResult::Skipped(skip)) => {
+                    item.status = GcItemStatus::Skipped;
+                    report.skipped.push(skip);
+                }
+                Err(error) => {
+                    item.status = GcItemStatus::Error;
+                    report.errors.push(error);
+                }
+            }
+        }
+    }
+
+    let outcome = if report.errors.is_empty() {
+        GcOutcome::Clean
+    } else if report.counts.reclaimed > 0 {
+        GcOutcome::Partial
+    } else {
+        GcOutcome::Failed
+    };
+    Ok(GcReport {
+        schema_version: 1,
+        mode: if request.apply {
+            GcMode::Apply
+        } else {
+            GcMode::Plan
+        },
+        plan_id,
+        scope: request.scope,
+        config_source: plan.config_source,
+        started_at,
+        finished_at: request.clock.now(),
+        outcome,
+        manifest_path: manifest_path.filter(|path| path.exists()),
+        targets: vec![report],
+    })
+}
+
+enum ApplyResult {
+    Reclaimed {
+        bytes: Option<u64>,
+        manifest_error: Option<GcItemError>,
+    },
+    Skipped(GcSkip),
+}
+
+fn apply_candidate(
+    collector: &dyn GcCollector,
+    context: &GcContext<'_>,
+    candidate: &GcCandidate,
+    manifest_path: &Path,
+    plan_id: &str,
+) -> Result<ApplyResult, GcItemError> {
+    match collector.revalidate(candidate, context) {
+        Ok(GcRevalidation::Ready) => {}
+        Ok(GcRevalidation::Skip { code, reason }) => {
+            return Ok(ApplyResult::Skipped(GcSkip {
+                id: candidate.id.clone(),
+                code,
+                reason,
+            }));
+        }
+        Err(error) => return Err(item_error(candidate, "revalidate", error)),
+    }
+    if let Some(path) = &candidate.path
+        && let Err(error) =
+            validate_candidate_path(context.scope.root(), path, candidate.allow_owned_symlink)
+    {
+        return Err(item_error(candidate, "revalidate", error));
+    }
+    // Persist intent before mutation so even interruption between mutation and
+    // result recording cannot leave an unaudited destructive attempt.
+    append_manifest(
+        manifest_path,
+        plan_id,
+        collector.target(),
+        candidate,
+        None,
+        "attempting",
+    )
+    .map_err(|error| item_error(candidate, "manifest", error))?;
+    let mutation = collector
+        .apply(candidate, context)
+        .map_err(|error| item_error(candidate, "apply", error))?;
+    let manifest_error = append_manifest(
+        manifest_path,
+        plan_id,
+        collector.target(),
+        candidate,
+        mutation.reclaimed_bytes,
+        "reclaimed",
+    )
+    .err()
+    .map(|error| item_error(candidate, "manifest", error));
+    Ok(ApplyResult::Reclaimed {
+        bytes: mutation.reclaimed_bytes,
+        manifest_error,
+    })
+}
+
+fn item_error(candidate: &GcCandidate, phase: &str, error: OrbitError) -> GcItemError {
+    GcItemError {
+        id: candidate.id.clone(),
+        phase: phase.to_string(),
+        code: "operation_failed".to_string(),
+        message: error.to_string(),
+    }
+}
+
+#[derive(Serialize)]
+struct ManifestEntry<'a> {
+    schema_version: u32,
+    plan_id: &'a str,
+    target: GcTarget,
+    candidate_id: &'a str,
+    ownership_evidence: &'a str,
+    retention_evidence: &'a str,
+    action: &'a str,
+    reclaimed_bytes: Option<u64>,
+    result: &'static str,
+}
+
+fn append_manifest(
+    path: &Path,
+    plan_id: &str,
+    target: GcTarget,
+    candidate: &GcCandidate,
+    reclaimed_bytes: Option<u64>,
+    result: &'static str,
+) -> Result<(), OrbitError> {
+    let parent = path.parent().ok_or_else(|| {
+        OrbitError::Execution("GC manifest path has no parent directory".to_string())
+    })?;
+    fs::create_dir_all(parent)?;
+    let mut file = OpenOptions::new().create(true).append(true).open(path)?;
+    serde_json::to_writer(
+        &mut file,
+        &ManifestEntry {
+            schema_version: 1,
+            plan_id,
+            target,
+            candidate_id: &candidate.id,
+            ownership_evidence: &candidate.ownership_evidence,
+            retention_evidence: &candidate.retention_evidence,
+            action: &candidate.action,
+            reclaimed_bytes,
+            result,
+        },
+    )
+    .map_err(|error| OrbitError::Io(error.to_string()))?;
+    file.write_all(b"\n")?;
+    file.sync_data()?;
+    Ok(())
+}
+
+struct GcLockGuard {
+    file: File,
+}
+
+impl Drop for GcLockGuard {
+    fn drop(&mut self) {
+        let _ = FileExt::unlock(&self.file);
+    }
+}
+
+fn acquire_gc_lock(
+    global_state_dir: &Path,
+    plan_id: &str,
+    target: GcTarget,
+    scope: &GcScope,
+    acquired_at: DateTime<Utc>,
+) -> Result<GcLockGuard, OrbitError> {
+    fs::create_dir_all(global_state_dir)?;
+    let path = global_state_dir.join("gc.lock");
+    let mut file = OpenOptions::new()
+        .create(true)
+        .truncate(false)
+        .read(true)
+        .write(true)
+        .open(&path)?;
+    let started = Instant::now();
+    loop {
+        match file.try_lock_exclusive() {
+            Ok(()) => break,
+            Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                if started.elapsed() >= LOCK_WAIT {
+                    return Err(OrbitError::Execution(format!(
+                        "timed out waiting for host-global GC lock `{}`",
+                        path.display()
+                    )));
+                }
+                thread::sleep(LOCK_POLL);
+            }
+            Err(error) => return Err(error.into()),
+        }
+    }
+    file.set_len(0)?;
+    let metadata = serde_json::json!({
+        "pid": std::process::id(),
+        "process_start_identity": process_start_identity(),
+        "plan_id": plan_id,
+        "command": format!("gc {target}"),
+        "scope": scope.label(),
+        "acquired_at": acquired_at,
+    });
+    serde_json::to_writer(&mut file, &metadata)
+        .map_err(|error| OrbitError::Io(error.to_string()))?;
+    file.sync_data()?;
+    Ok(GcLockGuard { file })
+}
+
+#[cfg(target_os = "linux")]
+fn process_start_identity() -> Option<String> {
+    let stat = fs::read_to_string("/proc/self/stat").ok()?;
+    let (_, fields) = stat.rsplit_once(") ")?;
+    // `/proc/<pid>/stat` field 22 is the process start time in clock ticks.
+    fields.split_whitespace().nth(19).map(ToString::to_string)
+}
+
+#[cfg(not(target_os = "linux"))]
+fn process_start_identity() -> Option<String> {
+    None
+}
+
+pub fn validate_candidate_path(
+    owned_root: &Path,
+    candidate: &Path,
+    allow_final_symlink: bool,
+) -> Result<(), OrbitError> {
+    // ADR-0220: containment and no-follow symlink checks are non-bypassable mutation gates.
+    if candidate
+        .components()
+        .any(|component| component == Component::ParentDir)
+    {
+        return Err(OrbitError::InvalidInput(format!(
+            "GC candidate contains parent traversal: {}",
+            candidate.display()
+        )));
+    }
+    let root = owned_root.canonicalize().map_err(|error| {
+        OrbitError::Io(format!(
+            "cannot resolve GC owned root `{}`: {error}",
+            owned_root.display()
+        ))
+    })?;
+    let absolute = if candidate.is_absolute() {
+        candidate.to_path_buf()
+    } else {
+        root.join(candidate)
+    };
+    if !absolute.starts_with(&root) || absolute == root {
+        return Err(OrbitError::PolicyDenied(format!(
+            "GC candidate escapes or equals owned root: {}",
+            candidate.display()
+        )));
+    }
+    let relative = absolute.strip_prefix(&root).map_err(|_| {
+        OrbitError::PolicyDenied(format!(
+            "GC candidate escapes owned root: {}",
+            candidate.display()
+        ))
+    })?;
+    let mut current = root;
+    let component_count = relative.components().count();
+    for (index, component) in relative.components().enumerate() {
+        if !matches!(component, Component::Normal(_)) {
+            return Err(OrbitError::InvalidInput(format!(
+                "GC candidate has an unsupported path component: {}",
+                candidate.display()
+            )));
+        }
+        current.push(component.as_os_str());
+        let metadata = fs::symlink_metadata(&current)?;
+        if metadata.file_type().is_symlink()
+            && !(allow_final_symlink && index + 1 == component_count)
+        {
+            return Err(OrbitError::PolicyDenied(format!(
+                "GC candidate crosses a symlink: {}",
+                current.display()
+            )));
+        }
+    }
+    Ok(())
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct EmptyGcCollector {
+    target: GcTarget,
+}
+
+impl EmptyGcCollector {
+    pub fn new(target: GcTarget) -> Self {
+        Self { target }
+    }
+}
+
+impl GcCollector for EmptyGcCollector {
+    fn target(&self) -> GcTarget {
+        self.target
+    }
+
+    fn plan(&self, _context: &GcContext<'_>) -> Result<GcPlan, OrbitError> {
+        let mut plan = GcPlan::empty(self.target);
+        plan.skipped.push(GcSkip {
+            id: self.target.to_string(),
+            code: "collector_not_implemented".to_string(),
+            reason: "target grammar is registered; domain collection lands in a dependent task"
+                .to_string(),
+        });
+        Ok(plan)
+    }
+
+    fn revalidate(
+        &self,
+        _candidate: &GcCandidate,
+        _context: &GcContext<'_>,
+    ) -> Result<GcRevalidation, OrbitError> {
+        Ok(GcRevalidation::Ready)
+    }
+
+    fn apply(
+        &self,
+        _candidate: &GcCandidate,
+        _context: &GcContext<'_>,
+    ) -> Result<GcMutation, OrbitError> {
+        Err(OrbitError::Execution(
+            "empty GC collector cannot mutate candidates".to_string(),
+        ))
+    }
+}

--- a/crates/orbit-core/src/command/mod.rs
+++ b/crates/orbit-core/src/command/mod.rs
@@ -20,6 +20,7 @@ pub mod audit_event;
 pub mod backend_resolver;
 pub mod docs;
 pub mod executor;
+pub mod gc;
 pub mod init;
 pub mod job;
 pub mod learning;

--- a/crates/orbit-core/src/command/tests/gc.rs
+++ b/crates/orbit-core/src/command/tests/gc.rs
@@ -1,0 +1,276 @@
+use std::collections::BTreeSet;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::sync::Mutex;
+
+use chrono::{DateTime, TimeZone, Utc};
+use fs2::FileExt;
+use orbit_common::types::OrbitError;
+use tempfile::TempDir;
+
+use crate::command::gc::{
+    EmptyGcCollector, GcCandidate, GcClock, GcCollector, GcContext, GcMode, GcMutation, GcOutcome,
+    GcPlan, GcRequest, GcRevalidation, GcScope, GcTarget, execute_gc, validate_candidate_path,
+};
+
+struct FakeClock(DateTime<Utc>);
+
+impl GcClock for FakeClock {
+    fn now(&self) -> DateTime<Utc> {
+        self.0
+    }
+}
+
+struct FileCollector {
+    root: PathBuf,
+    names: Vec<String>,
+    fail: BTreeSet<String>,
+    planned: Mutex<Vec<String>>,
+    applied: Mutex<Vec<String>>,
+}
+
+impl FileCollector {
+    fn new(root: &Path, names: &[&str]) -> Self {
+        Self {
+            root: root.to_path_buf(),
+            names: names.iter().map(|name| (*name).to_string()).collect(),
+            fail: BTreeSet::new(),
+            planned: Mutex::new(Vec::new()),
+            applied: Mutex::new(Vec::new()),
+        }
+    }
+
+    fn failing(mut self, name: &str) -> Self {
+        self.fail.insert(name.to_string());
+        self
+    }
+}
+
+impl GcCollector for FileCollector {
+    fn target(&self) -> GcTarget {
+        GcTarget::Logs
+    }
+
+    fn plan(&self, _context: &GcContext<'_>) -> Result<GcPlan, OrbitError> {
+        let mut candidates = Vec::new();
+        for name in &self.names {
+            let path = self.root.join(name);
+            if path.exists() {
+                candidates.push(GcCandidate {
+                    id: name.clone(),
+                    action: "delete".to_string(),
+                    path: Some(path),
+                    bytes: Some(fs::metadata(self.root.join(name))?.len()),
+                    ownership_evidence: "fake-owner".to_string(),
+                    retention_evidence: "fake-clock".to_string(),
+                    expected_state: "present".to_string(),
+                    allow_owned_symlink: false,
+                });
+            }
+        }
+        *self.planned.lock().expect("planned lock") = candidates
+            .iter()
+            .map(|candidate| candidate.id.clone())
+            .collect();
+        Ok(GcPlan {
+            target: GcTarget::Logs,
+            config_source: "test".to_string(),
+            scanned: self.names.len() as u64,
+            scanned_bytes: Some(
+                candidates
+                    .iter()
+                    .filter_map(|candidate| candidate.bytes)
+                    .sum(),
+            ),
+            candidates,
+            skipped: Vec::new(),
+            errors: Vec::new(),
+        })
+    }
+
+    fn revalidate(
+        &self,
+        candidate: &GcCandidate,
+        _context: &GcContext<'_>,
+    ) -> Result<GcRevalidation, OrbitError> {
+        if candidate.path.as_ref().is_some_and(|path| path.exists()) {
+            Ok(GcRevalidation::Ready)
+        } else {
+            Ok(GcRevalidation::Skip {
+                code: "state_changed".to_string(),
+                reason: "candidate disappeared".to_string(),
+            })
+        }
+    }
+
+    fn apply(
+        &self,
+        candidate: &GcCandidate,
+        _context: &GcContext<'_>,
+    ) -> Result<GcMutation, OrbitError> {
+        self.applied
+            .lock()
+            .expect("applied lock")
+            .push(candidate.id.clone());
+        if self.fail.contains(&candidate.id) {
+            return Err(OrbitError::Execution("injected failure".to_string()));
+        }
+        fs::remove_file(candidate.path.as_ref().expect("candidate path"))?;
+        Ok(GcMutation {
+            reclaimed_bytes: candidate.bytes,
+        })
+    }
+}
+
+struct Fixture {
+    temp: TempDir,
+    root: PathBuf,
+    state: PathBuf,
+    clock: FakeClock,
+}
+
+impl Fixture {
+    fn new() -> Self {
+        let temp = TempDir::new().expect("temp root");
+        let root = temp.path().join("owned");
+        let state = temp.path().join("global-state");
+        fs::create_dir_all(&root).expect("owned root");
+        Self {
+            temp,
+            root,
+            state,
+            clock: FakeClock(
+                Utc.with_ymd_and_hms(2026, 7, 12, 12, 0, 0)
+                    .single()
+                    .expect("fixed time"),
+            ),
+        }
+    }
+
+    fn write(&self, name: &str, contents: &str) {
+        fs::write(self.root.join(name), contents).expect("fixture file");
+    }
+
+    fn request(&self, apply: bool) -> GcRequest<'_> {
+        GcRequest {
+            apply,
+            scope: GcScope::Workspace {
+                workspace_id: Some("test".to_string()),
+                root: self.root.clone(),
+            },
+            retention_override: Some("1d"),
+            global_state_dir: &self.state,
+            clock: &self.clock,
+        }
+    }
+}
+
+#[test]
+fn plan_is_a_noop_and_apply_consumes_only_the_frozen_candidates() {
+    let fixture = Fixture::new();
+    fixture.write("one", "1");
+    fixture.write("two", "22");
+    let collector = FileCollector::new(&fixture.root, &["one", "two"]);
+
+    let plan = execute_gc(&collector, fixture.request(false)).expect("plan report");
+    assert_eq!(plan.mode, GcMode::Plan);
+    assert_eq!(plan.targets[0].counts.eligible, 2);
+    assert_eq!(plan.targets[0].counts.reclaimed, 0);
+    assert!(fixture.root.join("one").exists());
+    assert!(collector.applied.lock().expect("applied lock").is_empty());
+
+    let apply = execute_gc(&collector, fixture.request(true)).expect("apply report");
+    assert_eq!(apply.targets[0].counts.eligible, 2);
+    assert_eq!(apply.targets[0].counts.reclaimed, 2);
+    assert_eq!(apply.outcome, GcOutcome::Clean);
+    assert_eq!(
+        *collector.planned.lock().expect("planned lock"),
+        *collector.applied.lock().expect("applied lock")
+    );
+    let manifest =
+        fs::read_to_string(apply.manifest_path.expect("manifest path")).expect("manifest contents");
+    assert_eq!(manifest.lines().count(), 4);
+    assert_eq!(manifest.matches("\"result\":\"attempting\"").count(), 2);
+    assert_eq!(manifest.matches("\"result\":\"reclaimed\"").count(), 2);
+}
+
+#[test]
+fn partial_failure_preserves_success_and_reports_the_item_error() {
+    let fixture = Fixture::new();
+    fixture.write("good", "ok");
+    fixture.write("bad", "no");
+    fixture.write("later", "ok");
+    let collector = FileCollector::new(&fixture.root, &["good", "bad", "later"]).failing("bad");
+
+    let report = execute_gc(&collector, fixture.request(true)).expect("partial report");
+    assert_eq!(report.outcome, GcOutcome::Partial);
+    assert!(report.has_errors());
+    assert_eq!(report.targets[0].counts.reclaimed, 2);
+    assert!(!fixture.root.join("good").exists());
+    assert!(fixture.root.join("bad").exists());
+    assert!(!fixture.root.join("later").exists());
+    assert_eq!(report.targets[0].errors[0].id, "bad");
+}
+
+#[test]
+fn second_apply_is_idempotent() {
+    let fixture = Fixture::new();
+    fixture.write("old", "data");
+    let collector = FileCollector::new(&fixture.root, &["old"]);
+
+    let first = execute_gc(&collector, fixture.request(true)).expect("first apply");
+    let second = execute_gc(&collector, fixture.request(true)).expect("second apply");
+    assert_eq!(first.targets[0].counts.reclaimed, 1);
+    assert_eq!(second.targets[0].counts.eligible, 0);
+    assert_eq!(second.targets[0].counts.reclaimed, 0);
+    assert_eq!(second.outcome, GcOutcome::Clean);
+}
+
+#[test]
+fn containment_rejects_escape_root_and_parent_traversal() {
+    let fixture = Fixture::new();
+    fixture.write("safe", "data");
+    assert!(validate_candidate_path(&fixture.root, &fixture.root.join("safe"), false).is_ok());
+    assert!(validate_candidate_path(&fixture.root, fixture.temp.path(), false).is_err());
+    assert!(validate_candidate_path(&fixture.root, Path::new("../outside"), false).is_err());
+}
+
+#[test]
+fn apply_fails_without_planning_when_host_gc_lock_is_contended() {
+    let fixture = Fixture::new();
+    fs::create_dir_all(&fixture.state).expect("global state");
+    let lock = fs::OpenOptions::new()
+        .create(true)
+        .truncate(false)
+        .read(true)
+        .write(true)
+        .open(fixture.state.join("gc.lock"))
+        .expect("GC lock file");
+    lock.lock_exclusive().expect("hold GC lock");
+
+    let error = execute_gc(
+        &EmptyGcCollector::new(GcTarget::Logs),
+        fixture.request(true),
+    )
+    .expect_err("contended apply must fail closed");
+    assert!(error.to_string().contains("timed out waiting"), "{error}");
+    FileExt::unlock(&lock).expect("release GC lock");
+}
+
+#[cfg(unix)]
+#[test]
+fn containment_rejects_symlink_escape_and_can_unlink_owned_final_symlink() {
+    use std::os::unix::fs::symlink;
+
+    let fixture = Fixture::new();
+    let outside = fixture.temp.path().join("outside");
+    fs::create_dir_all(&outside).expect("outside root");
+    fs::write(outside.join("secret"), "secret").expect("outside file");
+    symlink(&outside, fixture.root.join("escape")).expect("escape symlink");
+
+    assert!(
+        validate_candidate_path(&fixture.root, &fixture.root.join("escape/secret"), false).is_err()
+    );
+    assert!(validate_candidate_path(&fixture.root, &fixture.root.join("escape"), false).is_err());
+    assert!(validate_candidate_path(&fixture.root, &fixture.root.join("escape"), true).is_ok());
+}

--- a/crates/orbit-core/src/command/tests/mod.rs
+++ b/crates/orbit-core/src/command/tests/mod.rs
@@ -1,2 +1,3 @@
 mod executor;
+mod gc;
 mod review_thread_hook;

--- a/docs/design/gc/2_design.md
+++ b/docs/design/gc/2_design.md
@@ -10,7 +10,7 @@ summary: Specifies GC grammar, collector ownership, retention clocks, safety inv
 tags: [gc, retention, safety]
 paths: ["crates/orbit-cli/src/command/gc/**", "crates/orbit-core/src/command/gc/**", "crates/orbit-core/src/config/**"]
 related_features: [gc, activity-job, auditability, task-artifacts, worktree-artifacts]
-related_artifacts: [ORB-10178, ADR-0220]
+related_artifacts: [ORB-10178, ORB-10180, ADR-0220]
 ---
 
 # Garbage Collection — Design
@@ -19,6 +19,11 @@ This document is the normative v1 contract for planning and applying retention
 to Orbit-owned global and workspace state. Collector implementation details may
 vary, but they may not weaken the mutation gate, ownership rules, protection
 invariants, revalidation, lock, or report semantics defined here.
+
+The shared protocol is implemented in
+`crates/orbit-core/src/command/gc.rs`; the command grammar and report rendering
+live in `crates/orbit-cli/src/command/gc.rs`. Domain collectors plug into that
+protocol in the dependent tasks listed below.
 
 ## 1. Command Grammar and Mutation Gate
 

--- a/docs/design/gc/4_decisions.md
+++ b/docs/design/gc/4_decisions.md
@@ -10,7 +10,7 @@ summary: Records the durable choice of one explicit, safety-first Orbit garbage-
 tags: [gc, retention, safety]
 paths: ["docs/design/gc/**", "crates/orbit-cli/src/command/gc/**", "crates/orbit-core/src/command/gc/**"]
 related_features: [gc]
-related_artifacts: [ADR-0220, ORB-10178]
+related_artifacts: [ADR-0220, ORB-10178, ORB-10180]
 ---
 
 # Garbage Collection — Decisions
@@ -47,8 +47,10 @@ non-bypassable containment, symlink, current-owner, and ambiguity protections;
   overrides highest.
 - Partial failure preserves successful mutations, reports every skip/error, and
   returns non-zero; reruns are idempotent.
-- No single code anchor yet; the convention will be enforced by the shared GC
-  framework and collector review.
+- Code anchors: `execute_gc` freezes and consumes plans under the host lock;
+  `validate_candidate_path` enforces containment and no-follow path checks.
+  Both cite ADR-0220 at the enforcement point; collector review covers the
+  remaining domain-specific invariants.
 - Cost: All apply passes serialize behind one host-wide lock and pay
   per-candidate revalidation, and workspace owners must repeat any global GC
   settings they want in a complete workspace policy instead of inheriting a
@@ -57,5 +59,6 @@ non-bypassable containment, symlink, current-owner, and ambiguity protections;
 ## Task References
 
 - [ORB-10178] — selected and specified the shared GC contract.
+- [ORB-10180] — implemented the shared framework and top-level command grammar.
 
 > Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.


### PR DESCRIPTION
## Task

[ORB-10180](https://orbit-cli.com/tasks/ORB-10180) — Implement the top-level orbit gc framework

### Description

## Problem

Orbit has no top-level garbage-collection command or shared collector abstraction. Domain-specific cleanup currently produces inconsistent flags, reports, locking, and failure behavior.

## Why It Matters

Every collector must plan and apply the same candidate set, produce auditable explanations, and obey the safety contract from ORB-10178. Building this once prevents each storage domain from inventing deletion semantics.

## Scope

Add the top-level `orbit gc` command family and shared collector/plan/apply/report infrastructure. Register the target grammar for `worktrees`, `runs`, `logs`, `diagnostics`, `audit`, `skills`, `tasks`, and `all`; domain deletion logic lands in dependent tasks.

## Constraints / Notes

- Bare commands are non-mutating; `--apply` is required.
- Dry-run and apply must share the same eligibility planner.
- Each mutation is audited without recursively triggering collection.
- Use deterministic clocks and temp roots in tests.

### Acceptance Criteria

- `orbit gc --help` exposes the target family under a top-level `gc` command, and the hand-written root help plus audit middleware stay in sync.
- A shared collector interface supports plan/apply/report with uniform `--apply`, `--json`, retention override, and global/workspace scope handling.
- Dry-run and apply use the same immutable eligibility snapshot and select the same candidates.
- The report includes counts, byte estimates, skip reasons, and per-item errors; partial failure preserves successful results but returns non-zero.
- A workspace/global GC lock and immediate pre-mutation revalidation hooks are available to every collector.
- Every mutation emits an audit record or deletion manifest without recursive logging.
- Deterministic fake-clock/temp-root tests cover no-op dry-run, partial failure, path containment, symlink escape, and idempotent second execution.
- `make ci-fast` and focused CLI/core tests pass.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Added the top-level `orbit gc [TARGET]` command grammar for worktrees, runs, logs, diagnostics, audit, skills, tasks, and all, with uniform `--apply`, `--json`, `--retention`, `--workspace`, and `--global` handling. Root help, dispatch, human/JSON rendering, and audit middleware metadata are synchronized.
- Added the shared `orbit-core` GC protocol: target/scope/clock abstractions, immutable candidate plans, one plan/apply path, versioned reports with counts/byte completeness/skips/item errors, partial-failure continuation, and non-zero signaling through the CLI.
- Added a bounded host-global apply lock with PID/start identity metadata. Apply planning occurs under that lock, every frozen candidate receives an immediate collector revalidation hook plus fail-closed containment/no-follow path validation, and no candidate can be added during apply.
- Added append-only two-phase deletion manifests: intent is synced before mutation and completion is synced afterward, keeping destructive attempts auditable without feeding the active frozen plan recursively.
- Registered transparent placeholder collectors that report `collector_not_implemented` until the dependent domain tasks attach deletion logic.
- Added deterministic fake-clock/temp-root tests covering plan-only no-op, frozen candidate identity, partial failure with later success, idempotent second apply, traversal/root containment, symlink escape/final-link handling, manifest records, and bounded lock contention; added CLI help/parse/scope-conflict/audit tests.
- Updated the GC design/code anchors, linked ORB-10180 to accepted ADR-0220 through `orbit.adr.update`, added the Unreleased changelog entry, filed F2026-07-022, and updated recurring learning L-0077 through `orbit.learning.update`.

Strategic decisions:
- The framework owns lock, frozen-plan execution, generic path revalidation, reporting, and manifests; collectors own domain eligibility, writer coordination, and mutation | Rationale: dependent collectors get one safety envelope without pulling domain stores into a generic abstraction.
- Manifest intent is durable before mutation and completion is a second record | Rationale: interruption cannot create an entirely unaudited destructive attempt, while manifest-write failure prevents mutation.

Design weaknesses / risks:
- Domain targets currently report `collector_not_implemented`; storage-specific scanning and deletion intentionally land in ORB-10182 through ORB-10188, and aggregate ordering/budgets in ORB-10189 | Severity: Low | Mitigation: the CLI is plan-first and placeholders never mutate.
- Non-Linux lock metadata cannot provide the Linux `/proc` process-start token, though the OS advisory lock remains the source of truth | Severity: Low | Mitigation: lock contention fails closed and no stale-lock deletion is needed.

Validation:
- `cargo test -p orbit-core command::tests::gc`: 6 passed.
- `cargo test -p orbit-cli command::tests::gc`: 4 passed.
- `cargo clippy -p orbit-core -p orbit-cli --all-targets -- -D warnings`, `cargo fmt --all -- --check`, `git diff --check`, and `cargo run -q -p orbit-cli -- gc --help` passed.
- All runnable `make ci-fast` guardrails passed individually: dependency direction, CLI imports, stability, learning layout, artifact redaction, changelog freshness/style, and error translation. Canonical `make ci-fast` stopped only because this runner has no `node` binary; `test-installer-security.sh` reported `required binary 'node' not on PATH`.

Assessment: The shared framework and CLI surface satisfy the scoped safety/reporting contract and leave domain-specific ownership logic explicit for the already-planned dependent tasks.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10180-6a5407b7`
- Behind base: 0
- Ahead of base: 1

*authored by: codex*