### PR TITLE
Add managed pipeline worktree GC under orbit gc

### DIFF
--- a/.orbit/learnings/L-0080/learning.yaml
+++ b/.orbit/learnings/L-0080/learning.yaml
@@ -1,0 +1,29 @@
+schema_version: 1
+id: L-0080
+status: active
+scope:
+  paths:
+  - crates/orbit-core/src/command/gc/**
+  - crates/orbit-engine/src/executor/automation/vcs/worktree/**
+  tags:
+  - pipeline
+  - worktree
+  - gc
+  - disk
+summary: Collect pipeline worktrees only through the shared GC classifier; retain uncertainty and never force-delete branches or directories.
+body: |-
+  Pipeline worktrees caused the largest known disk leak, but the first ORB-10173 cleanup model was unsafe: name matching plus a liveness check did not prove ownership, raw recursive deletion bypassed Git safety, and branch -D could discard unmerged or unpushed task work.
+
+  Use `orbit gc worktrees` and its shared terminal-cleanup path. Mutation requires explicit apply (terminal cleanup supplies it internally), a Git-registered worktree plus persisted terminal run timestamp, and immediate revalidation under the host GC lock. Retain live/inconclusive, current-cwd, dirty, unknown-owner, resumable interrupted, unmerged, and unpushed task worktrees with explicit reasons. Use `git worktree remove` without force and `git worktree prune`; never raw-remove a candidate or auto-delete its branch.
+
+  Success/cancelled and failure/interrupted use separate typed retention classes. The collector is language-neutral because ignored build artifacts are removed with their clean worktree, not by special-casing Cargo or another build system. ORB-10182 supersedes the rejected ORB-10173 implementation and explicitly re-scopes F2026-07-019 / the ORB-10153 overlap to the safety-first collector contract.
+evidence:
+- kind: task
+  reference: ORB-10182
+- kind: task
+  reference: ORB-10173
+- kind: external
+  reference: F2026-07-019
+created_at: 2026-07-12T22:03:13.925534303Z
+updated_at: 2026-07-12T22:03:13.925534303Z
+created_by: codex

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- **Managed worktree collection**: `orbit gc worktrees` plans or explicitly applies status-aware retention while protecting live, dirty, resumable, ambiguous, unmerged, and unpushed work. Terminal cleanup uses the same classifier. ([ORB-10182])
+- **Managed worktree collection**: `orbit gc worktrees` plans or explicitly applies status-aware retention while protecting live, dirty, resumable, ambiguous, unmerged, and unpushed work. Owner PID + start-identity is revalidated atomically before removal, failing closed on live or inconclusive owners. Terminal cleanup shares the classifier. ([ORB-10182])
 - **Shared garbage-collection framework**: `orbit gc` now exposes every retention target with plan-first/apply, scope, retention, locking, immutable candidate, safety revalidation, manifest, and equivalent human/JSON report contracts for domain collectors. ([ORB-10180])
 - **Safety-first garbage collection contract**: the `orbit gc` design standardizes explicit apply, retention clocks, ownership/revalidation invariants, locking, and equivalent human/JSON reports across global and workspace collectors. ([ORB-10178])
 - **Systemd routine workers survive sweep exit**: the user sweep service now limits shutdown to its main oneshot process, allowing detached pipeline workers to claim and complete clock-dispatched runs. ([ORB-10153])

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- **Managed worktree collection**: `orbit gc worktrees` plans or explicitly applies status-aware retention while protecting live, dirty, resumable, ambiguous, unmerged, and unpushed work. Owner PID + start-identity is revalidated atomically before removal, failing closed on live or inconclusive owners. Terminal cleanup shares the classifier. ([ORB-10182])
+- **Managed worktree collection**: `orbit gc worktrees` plans or applies retention while protecting live, dirty, resumable, unmerged, and unpushed work. A per-run claim guard shared with the run claim/start path is held across revalidation and `git worktree remove`, so a concurrent claim blocks GC (fail closed) or forces re-evaluation. Terminal cleanup shares the classifier. ([ORB-10182])
 - **Shared garbage-collection framework**: `orbit gc` now exposes every retention target with plan-first/apply, scope, retention, locking, immutable candidate, safety revalidation, manifest, and equivalent human/JSON report contracts for domain collectors. ([ORB-10180])
 - **Safety-first garbage collection contract**: the `orbit gc` design standardizes explicit apply, retention clocks, ownership/revalidation invariants, locking, and equivalent human/JSON reports across global and workspace collectors. ([ORB-10178])
 - **Systemd routine workers survive sweep exit**: the user sweep service now limits shutdown to its main oneshot process, allowing detached pipeline workers to claim and complete clock-dispatched runs. ([ORB-10153])

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- **Managed worktree collection**: `orbit gc worktrees` plans or explicitly applies status-aware retention while protecting live, dirty, resumable, ambiguous, unmerged, and unpushed work. Terminal cleanup uses the same classifier. ([ORB-10182])
 - **Shared garbage-collection framework**: `orbit gc` now exposes every retention target with plan-first/apply, scope, retention, locking, immutable candidate, safety revalidation, manifest, and equivalent human/JSON report contracts for domain collectors. ([ORB-10180])
 - **Safety-first garbage collection contract**: the `orbit gc` design standardizes explicit apply, retention clocks, ownership/revalidation invariants, locking, and equivalent human/JSON reports across global and workspace collectors. ([ORB-10178])
 - **Systemd routine workers survive sweep exit**: the user sweep service now limits shutdown to its main oneshot process, allowing detached pipeline workers to claim and complete clock-dispatched runs. ([ORB-10153])

--- a/crates/orbit-cli/src/command/gc.rs
+++ b/crates/orbit-cli/src/command/gc.rs
@@ -2,7 +2,8 @@ use std::path::PathBuf;
 
 use clap::{Args, ValueEnum};
 use orbit_core::command::gc::{
-    EmptyGcCollector, GcRequest, GcScope, GcTarget, SystemGcClock, execute_gc,
+    EmptyGcCollector, GcCollector, GcRequest, GcScope, GcTarget, SystemGcClock,
+    WorktreeGcCollector, WorktreeGcPolicy, execute_gc,
 };
 use orbit_core::{OrbitError, OrbitRuntime};
 
@@ -54,6 +55,14 @@ pub struct GcCommand {
     #[arg(long, value_name = "DURATION")]
     pub retention: Option<String>,
 
+    /// Override successful/cancelled worktree retention in days
+    #[arg(long, value_name = "DAYS")]
+    pub success_retention_days: Option<u64>,
+
+    /// Override failed/timeout/interrupted worktree retention in days
+    #[arg(long, value_name = "DAYS")]
+    pub failure_retention_days: Option<u64>,
+
     /// Select the current registered workspace by ID or path
     #[arg(long, value_name = "ID_OR_PATH", conflicts_with = "global")]
     pub workspace: Option<String>,
@@ -66,6 +75,13 @@ pub struct GcCommand {
 impl Execute for GcCommand {
     fn execute(self, runtime: &OrbitRuntime) -> Result<(), OrbitError> {
         let target = GcTarget::from(self.target);
+        if target != GcTarget::Worktrees
+            && (self.success_retention_days.is_some() || self.failure_retention_days.is_some())
+        {
+            return Err(OrbitError::InvalidInput(
+                "worktree retention overrides require the `worktrees` target".to_string(),
+            ));
+        }
         let defaults_global = matches!(target, GcTarget::Logs | GcTarget::Skills);
         let scope = if self.global || (self.workspace.is_none() && defaults_global) {
             GcScope::Global {
@@ -74,9 +90,34 @@ impl Execute for GcCommand {
         } else {
             resolve_workspace_scope(self.workspace.as_deref(), runtime)?
         };
+        let selected_runtime =
+            if target == GcTarget::Worktrees && scope.root() != runtime.paths().orbit_dir {
+                Some(OrbitRuntime::from_roots(
+                    &runtime.paths().global_dir,
+                    scope.root(),
+                )?)
+            } else {
+                None
+            };
+        let collector_runtime = selected_runtime.as_ref().unwrap_or(runtime);
         let clock = SystemGcClock;
+        let worktree_policy = WorktreeGcPolicy {
+            success_retention_days: self
+                .success_retention_days
+                .unwrap_or_else(|| collector_runtime.worktree_gc_success_retention_days()),
+            failure_retention_days: self
+                .failure_retention_days
+                .unwrap_or_else(|| collector_runtime.worktree_gc_failure_retention_days()),
+        };
+        let worktrees = WorktreeGcCollector::new(collector_runtime, worktree_policy);
+        let empty = EmptyGcCollector::new(target);
+        let collector: &dyn GcCollector = if target == GcTarget::Worktrees {
+            &worktrees
+        } else {
+            &empty
+        };
         let report = execute_gc(
-            &EmptyGcCollector::new(target),
+            collector,
             GcRequest {
                 apply: self.apply,
                 scope,

--- a/crates/orbit-cli/src/command/tests/gc.rs
+++ b/crates/orbit-cli/src/command/tests/gc.rs
@@ -24,10 +24,32 @@ fn gc_help_lists_every_target_and_uniform_flags() {
         "--apply",
         "--json",
         "--retention",
+        "--success-retention-days",
+        "--failure-retention-days",
         "--workspace",
         "--global",
     ] {
         assert!(help.contains(value), "missing `{value}` from help:\n{help}");
+    }
+}
+
+#[test]
+fn gc_parses_qualified_worktree_retention_overrides() {
+    let cli = Cli::parse_from([
+        "orbit",
+        "gc",
+        "worktrees",
+        "--success-retention-days",
+        "2",
+        "--failure-retention-days",
+        "30",
+    ]);
+    match cli.command {
+        Commands::Gc(command) => {
+            assert_eq!(command.success_retention_days, Some(2));
+            assert_eq!(command.failure_retention_days, Some(30));
+        }
+        _ => panic!("expected gc command"),
     }
 }
 

--- a/crates/orbit-core/src/command/gc.rs
+++ b/crates/orbit-core/src/command/gc.rs
@@ -11,6 +11,10 @@ use fs2::FileExt;
 use orbit_common::types::{OrbitError, audit_execution_id};
 use serde::{Deserialize, Serialize};
 
+mod worktrees;
+
+pub use worktrees::{WorktreeGcCollector, WorktreeGcPolicy};
+
 const LOCK_WAIT: Duration = Duration::from_secs(2);
 const LOCK_POLL: Duration = Duration::from_millis(25);
 

--- a/crates/orbit-core/src/command/gc/worktrees.rs
+++ b/crates/orbit-core/src/command/gc/worktrees.rs
@@ -1,0 +1,976 @@
+//! Managed pipeline-worktree collector for the shared `orbit gc` framework.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output, Stdio};
+
+use chrono::{DateTime, Duration, Utc};
+use orbit_common::types::{JobRun, JobRunState, OrbitError};
+use serde::{Deserialize, Serialize};
+
+use crate::OrbitRuntime;
+
+use super::{
+    GcCandidate, GcCollector, GcContext, GcItemError, GcMutation, GcPlan, GcRequest,
+    GcRevalidation, GcScope, GcSkip, GcTarget, SystemGcClock, execute_gc,
+};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct WorktreeGcPolicy {
+    pub success_retention_days: u64,
+    pub failure_retention_days: u64,
+}
+
+impl WorktreeGcPolicy {
+    pub fn from_runtime(runtime: &OrbitRuntime) -> Self {
+        Self {
+            success_retention_days: runtime.worktree_gc_success_retention_days(),
+            failure_retention_days: runtime.worktree_gc_failure_retention_days(),
+        }
+    }
+}
+
+pub struct WorktreeGcCollector<'a> {
+    runtime: &'a OrbitRuntime,
+    policy: WorktreeGcPolicy,
+    only_run_id: Option<String>,
+}
+
+impl<'a> WorktreeGcCollector<'a> {
+    pub fn new(runtime: &'a OrbitRuntime, policy: WorktreeGcPolicy) -> Self {
+        Self {
+            runtime,
+            policy,
+            only_run_id: None,
+        }
+    }
+
+    pub(crate) fn for_run(
+        runtime: &'a OrbitRuntime,
+        policy: WorktreeGcPolicy,
+        run_id: &str,
+    ) -> Self {
+        Self {
+            runtime,
+            policy,
+            only_run_id: Some(run_id.to_string()),
+        }
+    }
+
+    fn worktree_root(context: &GcContext<'_>) -> PathBuf {
+        context.scope.root().join("state").join("worktrees")
+    }
+
+    fn classify_path(
+        &self,
+        path: &Path,
+        context: &GcContext<'_>,
+    ) -> Result<Classified, OrbitError> {
+        let id = path
+            .file_name()
+            .and_then(|name| name.to_str())
+            .unwrap_or("<non-utf8>")
+            .to_string();
+        let Some(run_id) = extract_run_id(path) else {
+            return Ok(Classified::skip(
+                id,
+                "unknown_directory",
+                "directory is not named for an Orbit job run",
+            ));
+        };
+        if self
+            .only_run_id
+            .as_deref()
+            .is_some_and(|only| only != run_id)
+        {
+            return Ok(Classified::Ignored);
+        }
+        if current_worktree_contains(path) {
+            return Ok(Classified::skip(
+                id,
+                "current_worktree",
+                "worktree contains the current process directory",
+            ));
+        }
+        let Some(run) = self.runtime.stores().jobs().get_run(&run_id)? else {
+            return Ok(Classified::skip(
+                id,
+                "unknown_owner",
+                "no persisted run record proves ownership of this worktree",
+            ));
+        };
+        let Some(git) = inspect_git_worktree(
+            &self.runtime.paths().repo_root,
+            path,
+            self.runtime.workflow_base_branch(),
+        )?
+        else {
+            return Ok(Classified::skip(
+                id,
+                "unknown_owner",
+                "directory is not registered by Git as a managed worktree",
+            ));
+        };
+        if git.dirty {
+            return Ok(Classified::skip(
+                id,
+                "dirty_source",
+                "worktree has tracked or untracked source-bearing changes",
+            ));
+        }
+        if let Some(branch) = git.branch.as_deref() {
+            if !git.merged {
+                return Ok(Classified::skip(
+                    id,
+                    "unmerged_branch",
+                    format!("branch `{branch}` is not merged into the configured base"),
+                ));
+            }
+            if is_task_branch(branch) && !git.pushed {
+                return Ok(Classified::skip(
+                    id,
+                    "unpushed_branch",
+                    format!("task branch `{branch}` is not present on a remote"),
+                ));
+            }
+        }
+        match classify_run(
+            &run,
+            self.policy,
+            context.clock.now(),
+            self.interrupted_is_resumable(&run.run_id)?,
+        ) {
+            RunClassification::Skip { code, reason } => Ok(Classified::skip(id, code, reason)),
+            RunClassification::Eligible { retention_evidence } => {
+                let bytes = directory_bytes_no_follow(path).ok();
+                let expected = ExpectedState {
+                    run_id: run.run_id.clone(),
+                    state: run.state,
+                    finished_at: run.finished_at,
+                    head: git.head,
+                    branch: git.branch,
+                };
+                Ok(Classified::Candidate(GcCandidate {
+                    id,
+                    action: "git_worktree_remove".to_string(),
+                    path: Some(path.to_path_buf()),
+                    bytes,
+                    ownership_evidence: format!(
+                        "git-registered worktree owned by run {}",
+                        run.run_id
+                    ),
+                    retention_evidence,
+                    expected_state: serde_json::to_string(&expected)
+                        .map_err(|error| OrbitError::Execution(error.to_string()))?,
+                    allow_owned_symlink: false,
+                }))
+            }
+        }
+    }
+
+    fn interrupted_is_resumable(&self, run_id: &str) -> Result<bool, OrbitError> {
+        let Some(state) = self.runtime.read_run_state(run_id)? else {
+            return Ok(false);
+        };
+        Ok(state.next_step_index > 0
+            || !state.step_outputs.is_empty()
+            || !state.pipeline_patches.is_empty()
+            || !state.step_states.is_empty())
+    }
+
+    fn revalidate_candidate(
+        &self,
+        candidate: &GcCandidate,
+        context: &GcContext<'_>,
+    ) -> Result<GcRevalidation, OrbitError> {
+        let expected: ExpectedState =
+            serde_json::from_str(&candidate.expected_state).map_err(|error| {
+                OrbitError::Execution(format!("invalid frozen worktree state: {error}"))
+            })?;
+        let Some(path) = candidate.path.as_deref() else {
+            return Ok(skip_revalidation(
+                "missing_path",
+                "candidate path is absent",
+            ));
+        };
+        if current_worktree_contains(path) {
+            return Ok(skip_revalidation(
+                "current_worktree",
+                "worktree became the current process directory",
+            ));
+        }
+        let Some(run) = self.runtime.stores().jobs().get_run(&expected.run_id)? else {
+            return Ok(skip_revalidation(
+                "owner_changed",
+                "owning run record disappeared after planning",
+            ));
+        };
+        if run.state != expected.state || run.finished_at != expected.finished_at {
+            return Ok(skip_revalidation(
+                "owner_changed",
+                "owning run state changed after planning",
+            ));
+        }
+        if !matches!(
+            classify_run(
+                &run,
+                self.policy,
+                context.clock.now(),
+                self.interrupted_is_resumable(&run.run_id)?,
+            ),
+            RunClassification::Eligible { .. }
+        ) {
+            return Ok(skip_revalidation(
+                "retention_changed",
+                "owning run is no longer eligible",
+            ));
+        }
+        let Some(git) = inspect_git_worktree(
+            &self.runtime.paths().repo_root,
+            path,
+            self.runtime.workflow_base_branch(),
+        )?
+        else {
+            return Ok(skip_revalidation(
+                "owner_changed",
+                "Git worktree registration disappeared after planning",
+            ));
+        };
+        if git.dirty || git.head != expected.head || git.branch != expected.branch {
+            return Ok(skip_revalidation(
+                "worktree_changed",
+                "worktree content, branch, or HEAD changed after planning",
+            ));
+        }
+        if git.branch.as_deref().is_some_and(|_| !git.merged)
+            || git
+                .branch
+                .as_deref()
+                .is_some_and(|branch| is_task_branch(branch) && !git.pushed)
+        {
+            return Ok(skip_revalidation(
+                "branch_changed",
+                "branch is no longer safely merged and pushed",
+            ));
+        }
+        Ok(GcRevalidation::Ready)
+    }
+}
+
+impl OrbitRuntime {
+    /// Run the same classifier and apply primitive used by `orbit gc
+    /// worktrees --apply`, restricted to the run that just terminalized.
+    pub(crate) fn best_effort_collect_terminal_worktree(&self, run_id: &str) {
+        let policy = WorktreeGcPolicy::from_runtime(self);
+        let collector = WorktreeGcCollector::for_run(self, policy, run_id);
+        let clock = SystemGcClock;
+        let result = execute_gc(
+            &collector,
+            GcRequest {
+                apply: true,
+                scope: GcScope::Workspace {
+                    workspace_id: None,
+                    root: self.paths().orbit_dir.clone(),
+                },
+                retention_override: None,
+                global_state_dir: &self.paths().global_dir.join("state"),
+                clock: &clock,
+            },
+        );
+        if let Err(error) = result {
+            tracing::warn!(
+                target: "orbit.core.worktree_gc",
+                run_id,
+                error = %error,
+                "best-effort terminal worktree collection failed",
+            );
+        }
+    }
+}
+
+impl GcCollector for WorktreeGcCollector<'_> {
+    fn target(&self) -> GcTarget {
+        GcTarget::Worktrees
+    }
+
+    fn plan(&self, context: &GcContext<'_>) -> Result<GcPlan, OrbitError> {
+        if context.retention_override.is_some() {
+            return Err(OrbitError::InvalidInput(
+                "worktrees have separate success and failure retention classes; use the qualified worktree retention options"
+                    .to_string(),
+            ));
+        }
+        let root = Self::worktree_root(context);
+        let mut plan = GcPlan::empty(GcTarget::Worktrees);
+        plan.config_source = "workspace".to_string();
+        if !root.exists() {
+            return Ok(plan);
+        }
+        for entry in fs::read_dir(&root)? {
+            let entry = entry?;
+            let path = entry.path();
+            plan.scanned = plan.scanned.saturating_add(1);
+            let metadata = fs::symlink_metadata(&path)?;
+            if !metadata.is_dir() || metadata.file_type().is_symlink() {
+                plan.skipped.push(GcSkip {
+                    id: entry.file_name().to_string_lossy().into_owned(),
+                    code: "unknown_directory".to_string(),
+                    reason: "entry is not a plain directory".to_string(),
+                });
+                continue;
+            }
+            match self.classify_path(&path, context) {
+                Ok(Classified::Candidate(candidate)) => {
+                    plan.scanned_bytes = add_optional_bytes(plan.scanned_bytes, candidate.bytes);
+                    plan.candidates.push(candidate);
+                }
+                Ok(Classified::Skip(skip)) => {
+                    plan.scanned_bytes = add_optional_bytes(
+                        plan.scanned_bytes,
+                        directory_bytes_no_follow(&path).ok(),
+                    );
+                    plan.skipped.push(skip);
+                }
+                Ok(Classified::Ignored) => {
+                    plan.scanned = plan.scanned.saturating_sub(1);
+                }
+                Err(error) => {
+                    plan.scanned_bytes = None;
+                    plan.errors.push(GcItemError {
+                        id: entry.file_name().to_string_lossy().into_owned(),
+                        phase: "scan".to_string(),
+                        code: "inspection_failed".to_string(),
+                        message: error.to_string(),
+                    });
+                }
+            }
+        }
+        Ok(plan)
+    }
+
+    fn revalidate(
+        &self,
+        candidate: &GcCandidate,
+        context: &GcContext<'_>,
+    ) -> Result<GcRevalidation, OrbitError> {
+        self.revalidate_candidate(candidate, context)
+    }
+
+    fn apply(
+        &self,
+        candidate: &GcCandidate,
+        _context: &GcContext<'_>,
+    ) -> Result<GcMutation, OrbitError> {
+        let path = candidate.path.as_deref().ok_or_else(|| {
+            OrbitError::Execution("worktree GC candidate has no path".to_string())
+        })?;
+        let path_arg = path.to_string_lossy();
+        git_checked(
+            &self.runtime.paths().repo_root,
+            &["worktree", "remove", path_arg.as_ref()],
+        )?;
+        git_checked(&self.runtime.paths().repo_root, &["worktree", "prune"])?;
+        Ok(GcMutation {
+            reclaimed_bytes: candidate.bytes,
+        })
+    }
+}
+
+#[derive(Debug)]
+enum Classified {
+    Candidate(GcCandidate),
+    Skip(GcSkip),
+    Ignored,
+}
+
+impl Classified {
+    fn skip(id: String, code: &str, reason: impl Into<String>) -> Self {
+        Self::Skip(GcSkip {
+            id,
+            code: code.to_string(),
+            reason: reason.into(),
+        })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum RunClassification {
+    Eligible { retention_evidence: String },
+    Skip { code: &'static str, reason: String },
+}
+
+fn classify_run(
+    run: &JobRun,
+    policy: WorktreeGcPolicy,
+    now: DateTime<Utc>,
+    interrupted_is_resumable: bool,
+) -> RunClassification {
+    if matches!(
+        run.state,
+        JobRunState::Pending | JobRunState::Running | JobRunState::Retrying
+    ) {
+        return RunClassification::Skip {
+            code: "live_or_inconclusive",
+            reason: "run is active or owner liveness is inconclusive".to_string(),
+        };
+    }
+    if run.state == JobRunState::Interrupted && interrupted_is_resumable {
+        return RunClassification::Skip {
+            code: "resumable_interrupted",
+            reason: "interrupted run has persisted recovery checkpoints".to_string(),
+        };
+    }
+    let Some(finished_at) = run.finished_at else {
+        return RunClassification::Skip {
+            code: "missing_retention_clock",
+            reason: "run has no persisted terminal timestamp".to_string(),
+        };
+    };
+    let retention_days = match run.state {
+        JobRunState::Success | JobRunState::Cancelled => policy.success_retention_days,
+        JobRunState::Failed | JobRunState::Timeout | JobRunState::Interrupted => {
+            policy.failure_retention_days
+        }
+        JobRunState::Skipped => {
+            return RunClassification::Skip {
+                code: "non_terminal_state",
+                reason: "skipped run is not a persisted terminal owner".to_string(),
+            };
+        }
+        JobRunState::Pending | JobRunState::Running | JobRunState::Retrying => unreachable!(),
+    };
+    let eligible_at = finished_at + Duration::days(retention_days.min(i64::MAX as u64) as i64);
+    if now < eligible_at {
+        return RunClassification::Skip {
+            code: "retained",
+            reason: format!(
+                "{} run retained until {}",
+                run.state,
+                eligible_at.to_rfc3339()
+            ),
+        };
+    }
+    RunClassification::Eligible {
+        retention_evidence: format!(
+            "state={}, finished_at={}, retention_days={retention_days}",
+            run.state,
+            finished_at.to_rfc3339()
+        ),
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct ExpectedState {
+    run_id: String,
+    state: JobRunState,
+    finished_at: Option<DateTime<Utc>>,
+    head: String,
+    branch: Option<String>,
+}
+
+struct GitInspection {
+    head: String,
+    branch: Option<String>,
+    dirty: bool,
+    merged: bool,
+    pushed: bool,
+}
+
+fn inspect_git_worktree(
+    repo_root: &Path,
+    path: &Path,
+    base_branch: &str,
+) -> Result<Option<GitInspection>, OrbitError> {
+    let listing = git_output(repo_root, &["worktree", "list", "--porcelain"])?;
+    let target = path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
+    let mut registered = false;
+    let mut branch = None;
+    for block in listing.split("\n\n") {
+        let mut block_path = None;
+        let mut block_branch = None;
+        for line in block.lines() {
+            if let Some(value) = line.strip_prefix("worktree ") {
+                block_path = Some(PathBuf::from(value));
+            } else if let Some(value) = line.strip_prefix("branch refs/heads/") {
+                block_branch = Some(value.to_string());
+            }
+        }
+        if block_path
+            .as_deref()
+            .map(|value| value.canonicalize().unwrap_or_else(|_| value.to_path_buf()))
+            .as_deref()
+            == Some(target.as_path())
+        {
+            registered = true;
+            branch = block_branch;
+            break;
+        }
+    }
+    if !registered {
+        return Ok(None);
+    }
+    let head = git_output(path, &["rev-parse", "HEAD"])?;
+    let dirty = !git_output(path, &["status", "--porcelain=v1", "--untracked-files=all"])?
+        .trim()
+        .is_empty();
+    let merged = branch.as_deref().is_none_or(|_| {
+        is_ancestor(repo_root, head.trim(), &format!("refs/heads/{base_branch}"))
+            || is_ancestor(
+                repo_root,
+                head.trim(),
+                &format!("refs/remotes/origin/{base_branch}"),
+            )
+    });
+    let pushed = branch.as_deref().is_none_or(|_| {
+        git_output(
+            repo_root,
+            &[
+                "for-each-ref",
+                "--contains",
+                head.trim(),
+                "--format=%(refname)",
+                "refs/remotes",
+            ],
+        )
+        .is_ok_and(|refs| !refs.trim().is_empty())
+    });
+    Ok(Some(GitInspection {
+        head: head.trim().to_string(),
+        branch,
+        dirty,
+        merged,
+        pushed,
+    }))
+}
+
+fn is_ancestor(repo_root: &Path, ancestor: &str, descendant: &str) -> bool {
+    Command::new("git")
+        .arg("-C")
+        .arg(repo_root)
+        .args(["merge-base", "--is-ancestor", ancestor, descendant])
+        .stderr(Stdio::null())
+        .status()
+        .is_ok_and(|status| status.success())
+}
+
+fn git_output(repo_root: &Path, args: &[&str]) -> Result<String, OrbitError> {
+    let output = git(repo_root, args)?;
+    if !output.status.success() {
+        return Err(OrbitError::Execution(format!(
+            "git {} failed: {}",
+            args.join(" "),
+            String::from_utf8_lossy(&output.stderr).trim()
+        )));
+    }
+    String::from_utf8(output.stdout).map_err(|error| OrbitError::Execution(error.to_string()))
+}
+
+fn git_checked(repo_root: &Path, args: &[&str]) -> Result<(), OrbitError> {
+    git_output(repo_root, args).map(|_| ())
+}
+
+fn git(repo_root: &Path, args: &[&str]) -> Result<Output, OrbitError> {
+    Command::new("git")
+        .arg("-C")
+        .arg(repo_root)
+        .args(args)
+        .output()
+        .map_err(|error| OrbitError::Execution(format!("failed to execute git: {error}")))
+}
+
+fn current_worktree_contains(path: &Path) -> bool {
+    let Ok(cwd) = std::env::current_dir() else {
+        return true;
+    };
+    let cwd = cwd.canonicalize().unwrap_or(cwd);
+    let path = path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
+    path_contains_cwd(&path, &cwd)
+}
+
+fn path_contains_cwd(path: &Path, cwd: &Path) -> bool {
+    cwd.starts_with(path)
+}
+
+fn is_task_branch(branch: &str) -> bool {
+    branch.contains("/ORB-") || branch.starts_with("ORB-")
+}
+
+fn extract_run_id(path: &Path) -> Option<String> {
+    let name = path.file_name()?.to_str()?;
+    let index = name.find("jrun-")?;
+    Some(name[index..].to_string())
+}
+
+fn directory_bytes_no_follow(path: &Path) -> Result<u64, OrbitError> {
+    let metadata = fs::symlink_metadata(path)?;
+    if metadata.file_type().is_symlink() {
+        // Count the link object itself without following its target. Symlinks
+        // inside a worktree are ordinary source entries and must not make the
+        // whole byte estimate unknown.
+        return Ok(metadata.len());
+    }
+    if metadata.is_file() {
+        return Ok(metadata.len());
+    }
+    let mut total = 0_u64;
+    for entry in fs::read_dir(path)? {
+        total = total.saturating_add(directory_bytes_no_follow(&entry?.path())?);
+    }
+    Ok(total)
+}
+
+fn add_optional_bytes(total: Option<u64>, value: Option<u64>) -> Option<u64> {
+    Some(total?.saturating_add(value?))
+}
+
+fn skip_revalidation(code: &str, reason: &str) -> GcRevalidation {
+    GcRevalidation::Skip {
+        code: code.to_string(),
+        reason: reason.to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    static CLOCK: SystemGcClock = SystemGcClock;
+
+    fn run(state: JobRunState, finished_at: Option<DateTime<Utc>>) -> JobRun {
+        let now = Utc::now();
+        JobRun {
+            run_id: "jrun-test".to_string(),
+            job_id: "job".to_string(),
+            attempt: 1,
+            state,
+            scheduled_at: now,
+            started_at: Some(now),
+            finished_at,
+            duration_ms: None,
+            created_at: now,
+            pid: None,
+            pid_start_time: None,
+            input: None,
+            retry_source_run_id: None,
+            knowledge_metrics: None,
+            resolved_crew: None,
+            crew_model: None,
+            steps: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn active_and_resumable_runs_are_protected() {
+        let now = Utc::now();
+        let policy = WorktreeGcPolicy {
+            success_retention_days: 0,
+            failure_retention_days: 7,
+        };
+        assert!(matches!(
+            classify_run(&run(JobRunState::Running, None), policy, now, false),
+            RunClassification::Skip {
+                code: "live_or_inconclusive",
+                ..
+            }
+        ));
+        assert!(matches!(
+            classify_run(
+                &run(JobRunState::Interrupted, Some(now - Duration::days(30))),
+                policy,
+                now,
+                true,
+            ),
+            RunClassification::Skip {
+                code: "resumable_interrupted",
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn terminal_classes_use_separate_persisted_clocks() {
+        let now = Utc::now();
+        let policy = WorktreeGcPolicy {
+            success_retention_days: 0,
+            failure_retention_days: 7,
+        };
+        assert!(matches!(
+            classify_run(&run(JobRunState::Success, Some(now)), policy, now, false),
+            RunClassification::Eligible { .. }
+        ));
+        assert!(matches!(
+            classify_run(
+                &run(JobRunState::Failed, Some(now - Duration::days(1))),
+                policy,
+                now,
+                false,
+            ),
+            RunClassification::Skip {
+                code: "retained",
+                ..
+            }
+        ));
+        assert!(matches!(
+            classify_run(
+                &run(JobRunState::Failed, Some(now - Duration::days(8))),
+                policy,
+                now,
+                false,
+            ),
+            RunClassification::Eligible { .. }
+        ));
+    }
+
+    #[test]
+    fn missing_terminal_clock_is_never_aged_from_the_filesystem() {
+        let policy = WorktreeGcPolicy {
+            success_retention_days: 0,
+            failure_retention_days: 0,
+        };
+        assert!(matches!(
+            classify_run(&run(JobRunState::Success, None), policy, Utc::now(), false),
+            RunClassification::Skip {
+                code: "missing_retention_clock",
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn current_worktree_and_descendants_are_protected() {
+        assert!(path_contains_cwd(
+            Path::new("/tmp/worktree"),
+            Path::new("/tmp/worktree/subdir")
+        ));
+        assert!(!path_contains_cwd(
+            Path::new("/tmp/worktree"),
+            Path::new("/tmp/other")
+        ));
+    }
+
+    struct Fixture {
+        _temp: TempDir,
+        runtime: OrbitRuntime,
+        global_state: PathBuf,
+    }
+
+    impl Fixture {
+        fn new() -> Self {
+            let temp = TempDir::new().expect("temp root");
+            let global = temp.path().join("global");
+            let repo = temp.path().join("repo");
+            fs::create_dir_all(&global).expect("global root");
+            fs::create_dir_all(repo.join(".orbit")).expect("orbit root");
+            git_ok(&repo, &["init", "-q", "-b", "agent-main"]);
+            git_ok(&repo, &["config", "user.email", "gc@test.invalid"]);
+            git_ok(&repo, &["config", "user.name", "gc test"]);
+            fs::write(repo.join("README.md"), "seed").expect("seed file");
+            git_ok(&repo, &["add", "README.md"]);
+            git_ok(&repo, &["commit", "-q", "-m", "seed"]);
+            fs::write(
+                repo.join(".orbit/config.toml"),
+                "[workflow]\nbase_branch = \"agent-main\"\n",
+            )
+            .expect("workspace config");
+            let runtime =
+                OrbitRuntime::from_roots(&global, &repo.join(".orbit")).expect("test runtime");
+            let global_state = global.join("state");
+            Self {
+                _temp: temp,
+                runtime,
+                global_state,
+            }
+        }
+
+        fn insert_run(&self, state: JobRunState) -> JobRun {
+            let run = self
+                .runtime
+                .stores()
+                .jobs()
+                .insert_run("job", 1, Utc::now(), None, None)
+                .expect("insert run");
+            if state != JobRunState::Pending {
+                self.runtime
+                    .stores()
+                    .jobs()
+                    .mark_run_running(&run.run_id, Utc::now(), std::process::id())
+                    .expect("mark running");
+            }
+            if !matches!(state, JobRunState::Pending | JobRunState::Running) {
+                self.runtime
+                    .stores()
+                    .jobs()
+                    .finalize_run(&run.run_id, state, Utc::now(), Some(0))
+                    .expect("finalize run");
+            }
+            self.runtime
+                .stores()
+                .jobs()
+                .get_run(&run.run_id)
+                .expect("read run")
+                .expect("stored run")
+        }
+
+        fn add_worktree(&self, run_id: &str) -> PathBuf {
+            let path = self
+                .runtime
+                .paths()
+                .worktrees_dir
+                .join(format!("orbit-{run_id}"));
+            fs::create_dir_all(path.parent().expect("worktree parent")).expect("worktree root");
+            git_ok(
+                &self.runtime.paths().repo_root,
+                &[
+                    "worktree",
+                    "add",
+                    "-q",
+                    "-b",
+                    &format!("orbit/shared-{run_id}"),
+                    path.to_str().expect("utf8 path"),
+                    "agent-main",
+                ],
+            );
+            path
+        }
+
+        fn request(&self, apply: bool) -> GcRequest<'_> {
+            GcRequest {
+                apply,
+                scope: GcScope::Workspace {
+                    workspace_id: Some("test".to_string()),
+                    root: self.runtime.paths().orbit_dir.clone(),
+                },
+                retention_override: None,
+                global_state_dir: &self.global_state,
+                clock: &CLOCK,
+            }
+        }
+
+        fn collector(&self) -> WorktreeGcCollector<'_> {
+            WorktreeGcCollector::new(
+                &self.runtime,
+                WorktreeGcPolicy {
+                    success_retention_days: 0,
+                    failure_retention_days: 7,
+                },
+            )
+        }
+    }
+
+    #[test]
+    fn managed_gc_keeps_live_dirty_missing_and_unknown_and_is_idempotent() {
+        let fixture = Fixture::new();
+        let success = fixture.insert_run(JobRunState::Success);
+        let success_path = fixture.add_worktree(&success.run_id);
+
+        let live = fixture.insert_run(JobRunState::Running);
+        let live_path = fixture.add_worktree(&live.run_id);
+
+        let dirty = fixture.insert_run(JobRunState::Success);
+        let dirty_path = fixture.add_worktree(&dirty.run_id);
+        fs::write(dirty_path.join("untracked-source.rs"), "fn pending() {}").expect("dirty source");
+
+        let missing_path = fixture.add_worktree("jrun-missing-record");
+
+        let unmerged = fixture.insert_run(JobRunState::Success);
+        let unmerged_path = fixture.add_worktree(&unmerged.run_id);
+        fs::write(unmerged_path.join("committed.rs"), "fn committed() {}")
+            .expect("unmerged source");
+        git_ok(&unmerged_path, &["add", "committed.rs"]);
+        git_ok(&unmerged_path, &["commit", "-q", "-m", "unmerged work"]);
+
+        let unpushed = fixture.insert_run(JobRunState::Success);
+        let unpushed_path = fixture.add_worktree(&unpushed.run_id);
+        git_ok(
+            &unpushed_path,
+            &[
+                "branch",
+                "-m",
+                &format!("orbit/ORB-99999-{}", unpushed.run_id),
+            ],
+        );
+        let unknown_path = fixture
+            .runtime
+            .paths()
+            .worktrees_dir
+            .join("unknown-directory");
+        fs::create_dir_all(&unknown_path).expect("unknown directory");
+
+        let plan = execute_gc(&fixture.collector(), fixture.request(false)).expect("GC plan");
+        let target = &plan.targets[0];
+        assert_eq!(target.counts.eligible, 1);
+        for code in [
+            "live_or_inconclusive",
+            "dirty_source",
+            "unknown_owner",
+            "unknown_directory",
+            "unmerged_branch",
+            "unpushed_branch",
+        ] {
+            assert!(
+                target.skipped.iter().any(|skip| skip.code == code),
+                "{code}"
+            );
+        }
+        assert!(success_path.exists(), "planning is non-mutating");
+
+        let first = execute_gc(&fixture.collector(), fixture.request(true)).expect("first apply");
+        assert_eq!(first.targets[0].counts.reclaimed, 1);
+        assert!(!success_path.exists());
+        assert!(live_path.exists());
+        assert!(dirty_path.exists());
+        assert!(missing_path.exists());
+        assert!(unmerged_path.exists());
+        assert!(unpushed_path.exists());
+        assert!(unknown_path.exists());
+
+        let second = execute_gc(&fixture.collector(), fixture.request(true)).expect("second apply");
+        assert_eq!(second.targets[0].counts.reclaimed, 0);
+    }
+
+    #[test]
+    fn pending_run_becoming_live_is_never_a_candidate_or_cancelled() {
+        let fixture = Fixture::new();
+        let pending = fixture.insert_run(JobRunState::Pending);
+        let path = fixture.add_worktree(&pending.run_id);
+        let plan = execute_gc(&fixture.collector(), fixture.request(false)).expect("pending plan");
+        assert_eq!(plan.targets[0].counts.eligible, 0);
+
+        fixture
+            .runtime
+            .stores()
+            .jobs()
+            .mark_run_running(&pending.run_id, Utc::now(), std::process::id())
+            .expect("pending run becomes live");
+        let apply = execute_gc(&fixture.collector(), fixture.request(true)).expect("live apply");
+        assert_eq!(apply.targets[0].counts.reclaimed, 0);
+        assert!(path.exists());
+        assert_eq!(
+            fixture
+                .runtime
+                .stores()
+                .jobs()
+                .get_run(&pending.run_id)
+                .expect("read live run")
+                .expect("live run exists")
+                .state,
+            JobRunState::Running
+        );
+    }
+
+    fn git_ok(repo: &Path, args: &[&str]) {
+        let output = Command::new("git")
+            .arg("-C")
+            .arg(repo)
+            .args(args)
+            .output()
+            .expect("execute git");
+        assert!(
+            output.status.success(),
+            "git {}: {}",
+            args.join(" "),
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+}

--- a/crates/orbit-core/src/command/gc/worktrees.rs
+++ b/crates/orbit-core/src/command/gc/worktrees.rs
@@ -9,6 +9,7 @@ use orbit_common::types::{JobRun, JobRunState, OrbitError};
 use serde::{Deserialize, Serialize};
 
 use crate::OrbitRuntime;
+use crate::command::job::gc_owner_permits_reclaim;
 
 use super::{
     GcCandidate, GcCollector, GcContext, GcItemError, GcMutation, GcPlan, GcRequest,
@@ -142,11 +143,23 @@ impl<'a> WorktreeGcCollector<'a> {
         ) {
             RunClassification::Skip { code, reason } => Ok(Classified::skip(id, code, reason)),
             RunClassification::Eligible { retention_evidence } => {
+                // Fail closed on owner liveness even for terminal rows: a run
+                // can persist a terminal state while its worker process is
+                // still winding down (0-day success retention races finalize).
+                if !gc_owner_permits_reclaim(&run) {
+                    return Ok(Classified::skip(
+                        id,
+                        "live_or_inconclusive",
+                        "recorded owner process is still alive or its liveness is inconclusive",
+                    ));
+                }
                 let bytes = directory_bytes_no_follow(path).ok();
                 let expected = ExpectedState {
                     run_id: run.run_id.clone(),
                     state: run.state,
                     finished_at: run.finished_at,
+                    pid: run.pid,
+                    pid_start_time: run.pid_start_time.clone(),
                     head: git.head,
                     branch: git.branch,
                 };
@@ -205,10 +218,14 @@ impl<'a> WorktreeGcCollector<'a> {
                 "owning run record disappeared after planning",
             ));
         };
-        if run.state != expected.state || run.finished_at != expected.finished_at {
+        if run.state != expected.state
+            || run.finished_at != expected.finished_at
+            || run.pid != expected.pid
+            || run.pid_start_time != expected.pid_start_time
+        {
             return Ok(skip_revalidation(
                 "owner_changed",
-                "owning run state changed after planning",
+                "owning run state or owner identity changed after planning",
             ));
         }
         if !matches!(
@@ -223,6 +240,16 @@ impl<'a> WorktreeGcCollector<'a> {
             return Ok(skip_revalidation(
                 "retention_changed",
                 "owning run is no longer eligible",
+            ));
+        }
+        // Fail closed if the owner became live (or its liveness is now
+        // inconclusive) between planning and this final check — the process may
+        // have re-acquired the tree even though the persisted row still reads
+        // terminal.
+        if !gc_owner_permits_reclaim(&run) {
+            return Ok(skip_revalidation(
+                "live_or_inconclusive",
+                "recorded owner process is alive or its liveness is inconclusive at revalidation",
             ));
         }
         let Some(git) = inspect_git_worktree(
@@ -359,11 +386,28 @@ impl GcCollector for WorktreeGcCollector<'_> {
     fn apply(
         &self,
         candidate: &GcCandidate,
-        _context: &GcContext<'_>,
+        context: &GcContext<'_>,
     ) -> Result<GcMutation, OrbitError> {
         let path = candidate.path.as_deref().ok_or_else(|| {
             OrbitError::Execution("worktree GC candidate has no path".to_string())
         })?;
+        // Atomic ownership guard: re-run the full owner state / identity /
+        // liveness and Git revalidation as the immediately preceding operation
+        // to removal, with no intervening store write or fs sync. `execute_gc`
+        // holds the host-global GC lock across this apply, so the frozen plan
+        // cannot be consumed concurrently; combined with this final check, the
+        // window between validating ownership and removing the tree collapses
+        // to adjacent instructions. If the owner was claimed / transitioned
+        // after planning, we fail closed rather than remove a tree that a live
+        // run may have re-acquired.
+        match self.revalidate_candidate(candidate, context)? {
+            GcRevalidation::Ready => {}
+            GcRevalidation::Skip { code, reason } => {
+                return Err(OrbitError::Execution(format!(
+                    "worktree ownership changed between planning and removal ({code}): {reason}"
+                )));
+            }
+        }
         let path_arg = path.to_string_lossy();
         git_checked(
             &self.runtime.paths().repo_root,
@@ -464,6 +508,13 @@ struct ExpectedState {
     run_id: String,
     state: JobRunState,
     finished_at: Option<DateTime<Utc>>,
+    /// Persisted owner PID and process-start-identity token captured at plan
+    /// time. A concurrent claim / takeover rewrites these, so revalidation
+    /// rejects a candidate whose owner identity changed after planning.
+    #[serde(default)]
+    pid: Option<u32>,
+    #[serde(default)]
+    pid_start_time: Option<String>,
     head: String,
     branch: Option<String>,
 }
@@ -633,6 +684,8 @@ fn skip_revalidation(code: &str, reason: &str) -> GcRevalidation {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use orbit_common::utility::process_identity::process_start_identity_token;
+    use rusqlite::{Connection, params};
     use tempfile::TempDir;
 
     static CLOCK: SystemGcClock = SystemGcClock;
@@ -957,6 +1010,164 @@ mod tests {
                 .state,
             JobRunState::Running
         );
+    }
+
+    /// Reaps a spawned owner process even if the test panics.
+    struct ChildGuard(std::process::Child);
+
+    impl Drop for ChildGuard {
+        fn drop(&mut self) {
+            let _ = self.0.kill();
+            let _ = self.0.wait();
+        }
+    }
+
+    fn spawn_live_owner() -> ChildGuard {
+        ChildGuard(
+            Command::new("sleep")
+                .arg("30")
+                .spawn()
+                .expect("spawn live owner process"),
+        )
+    }
+
+    fn gc_context<'a>(scope: &'a GcScope) -> GcContext<'a> {
+        GcContext {
+            scope,
+            retention_override: None,
+            clock: &CLOCK,
+        }
+    }
+
+    fn workspace_scope(fixture: &Fixture) -> GcScope {
+        GcScope::Workspace {
+            workspace_id: Some("test".to_string()),
+            root: fixture.runtime.paths().orbit_dir.clone(),
+        }
+    }
+
+    /// Rewrites only the persisted owner identity of a run, leaving its
+    /// terminal state intact — models a reused/handed-off PID.
+    fn set_run_owner(runtime: &OrbitRuntime, run_id: &str, pid: u32, token: Option<&str>) {
+        let conn = Connection::open(runtime.global_root().join("orbit.db")).expect("open orbit db");
+        conn.execute(
+            "UPDATE job_runs SET pid = ?3, pid_start_time = ?4 \
+             WHERE workspace_id = ?1 AND run_id = ?2",
+            params![
+                runtime.workspace_id().expect("workspace id"),
+                run_id,
+                pid as i64,
+                token,
+            ],
+        )
+        .expect("set run owner");
+    }
+
+    /// Transitions a run back to a live `running` owner — models a concurrent
+    /// claim/resume that takes the run live between planning and mutation.
+    fn claim_run_live(runtime: &OrbitRuntime, run_id: &str, pid: u32, token: Option<&str>) {
+        let conn = Connection::open(runtime.global_root().join("orbit.db")).expect("open orbit db");
+        conn.execute(
+            "UPDATE job_runs SET state = 'running', started_at = ?3, finished_at = NULL, \
+             pid = ?4, pid_start_time = ?5 \
+             WHERE workspace_id = ?1 AND run_id = ?2",
+            params![
+                runtime.workspace_id().expect("workspace id"),
+                run_id,
+                Utc::now().to_rfc3339(),
+                pid as i64,
+                token,
+            ],
+        )
+        .expect("claim run live");
+    }
+
+    #[test]
+    fn terminal_run_with_live_owner_is_retained() {
+        // A row can read terminal while its worker process is still alive
+        // (e.g. 0-day success retention racing finalize). The persisted
+        // PID + process-start-identity probe must fail closed even here.
+        let fixture = Fixture::new();
+        let run = fixture.insert_run(JobRunState::Success);
+        let path = fixture.add_worktree(&run.run_id);
+
+        let owner = spawn_live_owner();
+        let pid = owner.0.id();
+        let token = process_start_identity_token(pid);
+        set_run_owner(&fixture.runtime, &run.run_id, pid, token.as_deref());
+
+        let plan = execute_gc(&fixture.collector(), fixture.request(false)).expect("plan");
+        let target = &plan.targets[0];
+        assert_eq!(target.counts.eligible, 0, "live owner is never eligible");
+        assert!(
+            target
+                .skipped
+                .iter()
+                .any(|skip| skip.code == "live_or_inconclusive"),
+            "expected live_or_inconclusive skip, got {:?}",
+            target.skipped
+        );
+        assert!(path.exists());
+    }
+
+    #[test]
+    fn frozen_candidate_is_not_removed_when_owner_claimed_before_mutation() {
+        // The deterministic revalidate-to-remove race: an eligible candidate is
+        // frozen by planning, the owner is then claimed live between planning
+        // and mutation, and the frozen candidate must be refused — the worktree
+        // is neither removed nor the run cancelled/mutated by GC.
+        let fixture = Fixture::new();
+        let run = fixture.insert_run(JobRunState::Success);
+        let path = fixture.add_worktree(&run.run_id);
+
+        let scope = workspace_scope(&fixture);
+        let context = gc_context(&scope);
+        let collector = fixture.collector();
+
+        // Plan freezes an eligible candidate against the terminal owner.
+        let plan = collector.plan(&context).expect("frozen plan");
+        assert_eq!(
+            plan.candidates.len(),
+            1,
+            "candidate is eligible before claim"
+        );
+        let frozen = plan.candidates[0].clone();
+
+        // A concurrent worker claims the run live after planning.
+        let owner = spawn_live_owner();
+        let pid = owner.0.id();
+        let token = process_start_identity_token(pid);
+        claim_run_live(&fixture.runtime, &run.run_id, pid, token.as_deref());
+
+        // Revalidation refuses the frozen candidate...
+        assert!(
+            matches!(
+                collector
+                    .revalidate(&frozen, &context)
+                    .expect("revalidate frozen candidate"),
+                GcRevalidation::Skip { .. }
+            ),
+            "revalidation must refuse a claimed owner"
+        );
+
+        // ...and the apply-time atomic guard fails closed rather than removing.
+        let applied = collector.apply(&frozen, &context);
+        assert!(
+            applied.is_err(),
+            "apply must fail closed on a claimed owner, got {applied:?}"
+        );
+
+        // The worktree survives and GC left the run exactly as the claimer set
+        // it — not cancelled, not removed.
+        assert!(path.exists(), "worktree must survive the race");
+        let reread = fixture
+            .runtime
+            .stores()
+            .jobs()
+            .get_run(&run.run_id)
+            .expect("read run")
+            .expect("run still exists");
+        assert_eq!(reread.state, JobRunState::Running);
     }
 
     fn git_ok(repo: &Path, args: &[&str]) {

--- a/crates/orbit-core/src/command/gc/worktrees.rs
+++ b/crates/orbit-core/src/command/gc/worktrees.rs
@@ -10,6 +10,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::OrbitRuntime;
 use crate::command::job::gc_owner_permits_reclaim;
+use crate::runtime::run_claim_guard;
 
 use super::{
     GcCandidate, GcCollector, GcContext, GcItemError, GcMutation, GcPlan, GcRequest,
@@ -391,15 +392,30 @@ impl GcCollector for WorktreeGcCollector<'_> {
         let path = candidate.path.as_deref().ok_or_else(|| {
             OrbitError::Execution("worktree GC candidate has no path".to_string())
         })?;
-        // Atomic ownership guard: re-run the full owner state / identity /
-        // liveness and Git revalidation as the immediately preceding operation
-        // to removal, with no intervening store write or fs sync. `execute_gc`
-        // holds the host-global GC lock across this apply, so the frozen plan
-        // cannot be consumed concurrently; combined with this final check, the
-        // window between validating ownership and removing the tree collapses
-        // to adjacent instructions. If the owner was claimed / transitioned
-        // after planning, we fail closed rather than remove a tree that a live
-        // run may have re-acquired.
+        // Recover the owning run id from the frozen plan so we can take that
+        // run's claim guard.
+        let expected: ExpectedState =
+            serde_json::from_str(&candidate.expected_state).map_err(|error| {
+                OrbitError::Execution(format!("invalid frozen worktree state: {error}"))
+            })?;
+
+        // Atomic ownership guard (ORB-10182). Acquire the per-run claim guard —
+        // the *same* advisory lock the run claim/start path
+        // (`mark_run_running` / `claim_pending_run_owner` /
+        // `take_over_running_run`) holds across its ownership transition — and
+        // keep holding it while we (1) re-run the full owner state / identity /
+        // liveness + Git revalidation and (2) `git worktree remove`. No store
+        // write or fs sync intervenes. Lock ordering: `execute_gc` already holds
+        // the host-global GC lock (ADR-0220); we take the per-run guard beneath
+        // it, then mutate the filesystem — GC host lock → per-run guard →
+        // filesystem, and never the global SQLite write lock across the git
+        // operation. A concurrent claim contends on this same guard: if it
+        // committed first, revalidation observes the live/changed owner and we
+        // fail closed; if we hold first, the claimant blocks until removal
+        // completes and then re-evaluates (its worktree setup recreates the
+        // tree) rather than entering a removed worktree.
+        let _run_guard =
+            run_claim_guard::acquire(&self.runtime.paths().state_dir, &expected.run_id)?;
         match self.revalidate_candidate(candidate, context)? {
             GcRevalidation::Ready => {}
             GcRevalidation::Skip { code, reason } => {
@@ -1168,6 +1184,128 @@ mod tests {
             .expect("read run")
             .expect("run still exists");
         assert_eq!(reread.state, JobRunState::Running);
+    }
+
+    #[test]
+    fn apply_blocks_on_a_claimant_held_run_guard_and_fails_closed() {
+        // Two real actors contend for the *same* per-run claim guard that the
+        // run claim/start path holds. A claimant grabs the guard first and
+        // records a live owner (models a takeover). The collector's `apply`
+        // then blocks acquiring that guard — proving the collector genuinely
+        // takes it — and, once it wins the guard after the claimant releases,
+        // its revalidation observes the live owner and fails closed. Ordering
+        // is deterministic: the GC actor is only started after the claimant is
+        // already holding the guard, so `apply` provably cannot revalidate
+        // until the claim has committed and released.
+        let fixture = Fixture::new();
+        let run = fixture.insert_run(JobRunState::Success);
+        let path = fixture.add_worktree(&run.run_id);
+
+        let scope = workspace_scope(&fixture);
+        let context = gc_context(&scope);
+        let collector = fixture.collector();
+
+        // Freeze an eligible candidate against the terminal, currently-dead
+        // owner.
+        let plan = collector.plan(&context).expect("frozen plan");
+        assert_eq!(plan.candidates.len(), 1, "candidate eligible before claim");
+        let frozen = plan.candidates[0].clone();
+
+        let state_dir = fixture.runtime.paths().state_dir.clone();
+        let run_id = run.run_id.clone();
+
+        std::thread::scope(|threads| {
+            // Claimant holds the guard first, exactly as the claim/start path
+            // does around its ownership transition.
+            let guard =
+                run_claim_guard::acquire(&state_dir, &run_id).expect("claimant acquires guard");
+
+            let (started_tx, started_rx) = std::sync::mpsc::channel::<()>();
+            let collector_ref = &collector;
+            let context_ref = &context;
+            let frozen_ref = &frozen;
+            let apply_handle = threads.spawn(move || {
+                // Only begin the GC apply once the claimant holds the guard, so
+                // `apply` must block on it rather than racing ahead.
+                started_rx.recv().expect("gc actor start signal");
+                collector_ref.apply(frozen_ref, context_ref)
+            });
+            started_tx.send(()).expect("signal gc actor");
+
+            // Record a live owner while holding the guard — a concurrent
+            // takeover that GC must observe once it finally acquires the guard.
+            let owner = spawn_live_owner();
+            let token = process_start_identity_token(owner.0.id());
+            set_run_owner(&fixture.runtime, &run_id, owner.0.id(), token.as_deref());
+
+            drop(guard); // release; the blocked GC apply now proceeds
+
+            let applied = apply_handle.join().expect("gc apply thread");
+            assert!(
+                applied.is_err(),
+                "apply must fail closed once the claim won the guard, got {applied:?}"
+            );
+        });
+
+        assert!(path.exists(), "worktree survives because the claim won");
+    }
+
+    #[test]
+    fn claimant_blocks_on_a_gc_held_run_guard_and_re_evaluates_after_removal() {
+        // The mirror interleaving: GC wins the guard and removes the worktree
+        // while holding it. A concurrent claimant contending for the same
+        // per-run guard must block until removal completes and then re-evaluate
+        // — it can never enter a worktree that GC is removing. GC's real
+        // removal sequence (`git worktree remove` + `prune`) runs under the
+        // guard here, mirroring `apply`; `apply_blocks_on_a_claimant_held_run_guard_and_fails_closed`
+        // proves `apply` itself acquires this guard, so the two together cover
+        // the collector holding it continuously across revalidation and removal.
+        let fixture = Fixture::new();
+        let run = fixture.insert_run(JobRunState::Success);
+        let path = fixture.add_worktree(&run.run_id);
+        assert!(path.exists());
+
+        let state_dir = fixture.runtime.paths().state_dir.clone();
+        let run_id = run.run_id.clone();
+        let repo_root = fixture.runtime.paths().repo_root.clone();
+        let path_for_claimant = path.clone();
+
+        std::thread::scope(|threads| {
+            // GC holds the guard for the whole removal.
+            let guard = run_claim_guard::acquire(&state_dir, &run_id).expect("gc acquires guard");
+
+            let (started_tx, started_rx) = std::sync::mpsc::channel::<()>();
+            let state_dir_ref = &state_dir;
+            let run_id_ref = &run_id;
+            let claimant = threads.spawn(move || {
+                started_rx.recv().expect("claimant start signal");
+                // Contend for the same guard, then re-evaluate under it.
+                let _held = run_claim_guard::acquire(state_dir_ref, run_id_ref)
+                    .expect("claimant eventually acquires guard");
+                path_for_claimant.exists()
+            });
+            started_tx.send(()).expect("signal claimant");
+
+            // Remove the worktree under the guard, as `apply` does.
+            git_ok(
+                &repo_root,
+                &["worktree", "remove", path.to_str().expect("utf8")],
+            );
+            git_ok(&repo_root, &["worktree", "prune"]);
+
+            drop(guard); // release; the blocked claimant now proceeds
+
+            let claimant_entered_live_tree = claimant.join().expect("claimant thread");
+            assert!(
+                !claimant_entered_live_tree,
+                "claimant must block on the guard and re-evaluate after removal, never enter a removed tree"
+            );
+        });
+
+        assert!(
+            !path.exists(),
+            "GC removed the worktree while holding the guard"
+        );
     }
 
     fn git_ok(repo: &Path, args: &[&str]) {

--- a/crates/orbit-core/src/command/job/mod.rs
+++ b/crates/orbit-core/src/command/job/mod.rs
@@ -9,3 +9,5 @@ pub(crate) use catalog::seed_default_jobs;
 pub use catalog::{JobCatalogEntry, JobCatalogFilter};
 pub use exec::V2JobRunResult;
 pub use run::{JobRunCancelResult, JobRunListParams};
+
+pub(crate) use run::gc_owner_permits_reclaim;

--- a/crates/orbit-core/src/command/job/run/mod.rs
+++ b/crates/orbit-core/src/command/job/run/mod.rs
@@ -17,3 +17,5 @@ mod types;
 mod tests;
 
 pub use types::{JobRunCancelResult, JobRunListParams};
+
+pub(crate) use owner::gc_owner_permits_reclaim;

--- a/crates/orbit-core/src/command/job/run/owner.rs
+++ b/crates/orbit-core/src/command/job/run/owner.rs
@@ -13,6 +13,43 @@ use std::thread;
 #[cfg(unix)]
 use std::time::{Duration, Instant};
 
+/// Whether the persisted owner of `run` permits reclaiming its worktree.
+///
+/// Fail-closed for GC: returns `true` only when the recorded owner process is
+/// conclusively no longer using the tree —
+/// - it is this very process (terminal cleanup runs inside the worker that just
+///   finalized its own run; the caller's cwd guard covers the still-in-use
+///   case), or
+/// - no owner PID was ever recorded, or
+/// - the PID + process-start-identity probe proves the original owner is gone
+///   (`Missing`) or that the PID is now held by an unrelated process
+///   (`Mismatch`).
+///
+/// A verified-live owner, an unverifiable-but-live legacy owner, or any
+/// inconclusive probe returns `false`, so the worktree is retained — including
+/// for terminal rows whose worker process is still winding down after writing
+/// its terminal state. This reuses the exact identity probe that run
+/// reconciliation uses, so GC and reconciliation agree on liveness.
+pub(crate) fn gc_owner_permits_reclaim(run: &JobRun) -> bool {
+    if run.pid == Some(std::process::id()) {
+        return true;
+    }
+    #[cfg(unix)]
+    {
+        matches!(
+            classify_run_owner(run),
+            OwnerIdentity::Missing | OwnerIdentity::Mismatch
+        )
+    }
+    #[cfg(not(unix))]
+    {
+        // No owner-liveness probe is available off Unix; fall back to the
+        // pre-liveness collector behavior and rely on the terminal-state, cwd,
+        // dirty, and branch gates. A recorded PID cannot be proven gone here.
+        run.pid.is_none()
+    }
+}
+
 #[cfg(unix)]
 pub(super) const RUN_OWNER_TERMINATION_GRACE: Duration = Duration::from_secs(2);
 #[cfg(unix)]

--- a/crates/orbit-core/src/config/raw.rs
+++ b/crates/orbit-core/src/config/raw.rs
@@ -15,6 +15,7 @@ pub(super) struct RawRuntimeConfig {
     pub(super) watch: Option<toml::Value>,
     pub(super) runtime: Option<RawRuntimeSection>,
     pub(super) workflow: Option<RawWorkflowConfig>,
+    pub(super) gc: Option<RawGcConfig>,
     pub(super) routines: Option<RawRoutinesConfig>,
     pub(super) duel: Option<RawDuelSection>,
     /// Removed in ORB-00058. Kept only so config loading can reject stale
@@ -23,6 +24,21 @@ pub(super) struct RawRuntimeConfig {
     /// `[crews.<name>]` registry. Each table supplies one assignment Orbit
     /// resolves for every activity role at task run start.
     pub(super) crews: Option<BTreeMap<String, RawCrewEntry>>,
+}
+
+#[derive(Debug, Clone, Default, Deserialize, Serialize)]
+pub(super) struct RawGcConfig {
+    pub(super) worktrees: Option<RawWorktreeGcConfig>,
+}
+
+#[derive(Debug, Clone, Default, Deserialize, Serialize)]
+pub(super) struct RawWorktreeGcConfig {
+    /// Days to retain successful/cancelled worktrees after the persisted
+    /// terminal transition. Zero permits immediate collection.
+    pub(super) success_retention_days: Option<u64>,
+    /// Days to retain failed/timeout/interrupted worktrees after the persisted
+    /// terminal transition. Resumable interrupted worktrees remain protected.
+    pub(super) failure_retention_days: Option<u64>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]

--- a/crates/orbit-core/src/config/registry.rs
+++ b/crates/orbit-core/src/config/registry.rs
@@ -53,6 +53,16 @@ pub const CONFIG_KEY_REGISTRY: &[ConfigKeyDescriptor] = &[
         description: "Environment variable names allow-listed for passthrough into agent subprocesses.",
     },
     ConfigKeyDescriptor {
+        key: "gc.worktrees.failure_retention_days",
+        value_type: "integer",
+        description: "Days to retain failed/timeout/interrupted managed worktrees; resumable interrupted worktrees remain protected.",
+    },
+    ConfigKeyDescriptor {
+        key: "gc.worktrees.success_retention_days",
+        value_type: "integer",
+        description: "Days to retain success/cancelled managed worktrees after their persisted terminal transition (zero permits immediate collection).",
+    },
+    ConfigKeyDescriptor {
         key: "graph.editing",
         value_type: "bool",
         description: "Whether the code graph editing surface is enabled.",

--- a/crates/orbit-core/src/config/runtime.rs
+++ b/crates/orbit-core/src/config/runtime.rs
@@ -19,8 +19,8 @@ use crate::paths;
 use super::persistence::PersistenceConfig;
 use super::raw::{
     RawAgentRoleConfig, RawCodexExecutionConfig, RawCrewEntry, RawDuelSection,
-    RawExecutionEnvConfig, RawPrSection, RawRoutinesConfig, RawRuntimeConfig, RawRuntimeSection,
-    RawTaskSection, RawWorkflowConfig,
+    RawExecutionEnvConfig, RawGcConfig, RawPrSection, RawRoutinesConfig, RawRuntimeConfig,
+    RawRuntimeSection, RawTaskSection, RawWorkflowConfig,
 };
 
 const DEFAULT_ENV_INHERIT: bool = false;
@@ -32,6 +32,8 @@ const DEFAULT_SCORING_ENABLED: bool = true;
 const DEFAULT_GRAPH_EDITING: bool = false;
 const DEFAULT_WORKFLOW_BASE_BRANCH: &str = "main";
 const DEFAULT_WORKFLOW_CREW: &str = "claude";
+pub(crate) const DEFAULT_WORKTREE_SUCCESS_RETENTION_DAYS: u64 = 0;
+pub(crate) const DEFAULT_WORKTREE_FAILURE_RETENTION_DAYS: u64 = 7;
 const CONSTELLATION_DEFAULT_PROVIDER_ENV: &str = "CONSTELLATION_DEFAULT_PROVIDER";
 
 #[derive(Debug, Clone)]
@@ -58,6 +60,8 @@ pub(crate) struct RuntimeConfig {
     /// "source"` in `config.toml`; defaults to `false`). Consulted by
     /// `orbit sweep` before loading `.orbit/routines/*.yaml`.
     pub(crate) routines_source: bool,
+    pub(crate) worktree_gc_success_retention_days: u64,
+    pub(crate) worktree_gc_failure_retention_days: u64,
     /// Named provider-model assignments from `[crews.<name>]`.
     pub(crate) crews: BTreeMap<String, Crew>,
     pub(crate) default_crew: Option<String>,
@@ -111,6 +115,8 @@ impl RuntimeConfig {
             workflow_base_branch: DEFAULT_WORKFLOW_BASE_BRANCH.to_string(),
             workflow_auto_ship: false,
             routines_source: false,
+            worktree_gc_success_retention_days: DEFAULT_WORKTREE_SUCCESS_RETENTION_DAYS,
+            worktree_gc_failure_retention_days: DEFAULT_WORKTREE_FAILURE_RETENTION_DAYS,
             crews: default_crews(),
             default_crew: Some(DEFAULT_WORKFLOW_CREW.to_string()),
             duel: DuelConfig::default(),
@@ -220,6 +226,8 @@ impl RuntimeConfig {
             .and_then(|workflow| workflow.auto_ship)
             .unwrap_or(false);
         let routines_source = routines_source_from_raw(parsed.routines.as_ref())?;
+        let (worktree_gc_success_retention_days, worktree_gc_failure_retention_days) =
+            worktree_gc_retention_from_raw(parsed.gc.as_ref());
         let crews = crews_from_raw(parsed.crews.as_ref())?;
         let default_crew = workflow_default_crew_from_raw(parsed.workflow.as_ref(), &crews)?;
         let duel = duel_from_raw(parsed.duel.as_ref())?;
@@ -251,6 +259,8 @@ impl RuntimeConfig {
             workflow_base_branch,
             workflow_auto_ship,
             routines_source,
+            worktree_gc_success_retention_days,
+            worktree_gc_failure_retention_days,
             crews,
             default_crew,
             duel,
@@ -279,6 +289,14 @@ impl RuntimeConfig {
 
     pub(crate) fn routines_source(&self) -> bool {
         self.routines_source
+    }
+
+    pub(crate) fn worktree_gc_success_retention_days(&self) -> u64 {
+        self.worktree_gc_success_retention_days
+    }
+
+    pub(crate) fn worktree_gc_failure_retention_days(&self) -> u64 {
+        self.worktree_gc_failure_retention_days
     }
 
     pub(crate) fn pr_config(&self) -> &PrConfig {
@@ -646,6 +664,18 @@ fn routines_source_from_raw(raw: Option<&RawRoutinesConfig>) -> Result<bool, Orb
             "[routines] role has invalid value '{other}'; the only supported value is 'source'"
         ))),
     }
+}
+
+fn worktree_gc_retention_from_raw(raw: Option<&RawGcConfig>) -> (u64, u64) {
+    let worktrees = raw.and_then(|gc| gc.worktrees.as_ref());
+    (
+        worktrees
+            .and_then(|worktrees| worktrees.success_retention_days)
+            .unwrap_or(DEFAULT_WORKTREE_SUCCESS_RETENTION_DAYS),
+        worktrees
+            .and_then(|worktrees| worktrees.failure_retention_days)
+            .unwrap_or(DEFAULT_WORKTREE_FAILURE_RETENTION_DAYS),
+    )
 }
 
 fn workflow_base_branch_from_raw(raw: Option<&RawWorkflowConfig>) -> Result<String, OrbitError> {

--- a/crates/orbit-core/src/config/store.rs
+++ b/crates/orbit-core/src/config/store.rs
@@ -283,6 +283,8 @@ pub struct ConfigSnapshot {
     pub workflow_default_crew: Option<String>,
     pub workflow_auto_ship: bool,
     pub routines_source: bool,
+    pub worktree_gc_success_retention_days: u64,
+    pub worktree_gc_failure_retention_days: u64,
     pub tasks_id_start: Option<u32>,
     pub duel_candidates: Vec<String>,
     pub duel_models: std::collections::BTreeMap<String, String>,
@@ -317,6 +319,8 @@ impl From<&RuntimeConfig> for ConfigSnapshot {
             workflow_default_crew: config.default_crew.clone(),
             workflow_auto_ship: config.workflow_auto_ship(),
             routines_source: config.routines_source(),
+            worktree_gc_success_retention_days: config.worktree_gc_success_retention_days(),
+            worktree_gc_failure_retention_days: config.worktree_gc_failure_retention_days(),
             tasks_id_start: config.tasks_id_start(),
             duel_candidates: config.duel_config().candidates.clone(),
             duel_models: config.duel_config().models.clone(),
@@ -337,6 +341,12 @@ impl ConfigSnapshot {
             "execution.codex.sandbox" => json!(self.codex_sandbox),
             "execution.env.pass" => json!(self.execution_env_pass),
             "graph.editing" => json!(self.graph_editing),
+            "gc.worktrees.failure_retention_days" => {
+                json!(self.worktree_gc_failure_retention_days)
+            }
+            "gc.worktrees.success_retention_days" => {
+                json!(self.worktree_gc_success_retention_days)
+            }
             "pr.task_url_template" => json!(self.pr_task_url_template),
             "routines.role" => json!(if self.routines_source {
                 Some("source")

--- a/crates/orbit-core/src/config/tests/runtime.rs
+++ b/crates/orbit-core/src/config/tests/runtime.rs
@@ -501,3 +501,16 @@ fn runtime_log_rotation_accepts_valid_values() {
     RuntimeConfig::load_layered(global.path(), workspace.path())
         .expect("valid log rotation config should load");
 }
+
+#[test]
+fn worktree_gc_retention_classes_are_independently_configurable() {
+    let defaults = load_config("").expect("default config loads");
+    assert_eq!(defaults.worktree_gc_success_retention_days(), 0);
+    assert_eq!(defaults.worktree_gc_failure_retention_days(), 7);
+
+    let configured =
+        load_config("[gc.worktrees]\nsuccess_retention_days = 2\nfailure_retention_days = 30\n")
+            .expect("worktree retention config loads");
+    assert_eq!(configured.worktree_gc_success_retention_days(), 2);
+    assert_eq!(configured.worktree_gc_failure_retention_days(), 30);
+}

--- a/crates/orbit-core/src/context.rs
+++ b/crates/orbit-core/src/context.rs
@@ -186,6 +186,8 @@ pub(crate) struct OrbitRuntimeSettings {
     /// Whether this workspace is a routine source
     /// (`[routines] role = "source"` in `config.toml`, default `false`).
     routines_source: bool,
+    worktree_gc_success_retention_days: u64,
+    worktree_gc_failure_retention_days: u64,
     crews: std::collections::BTreeMap<String, Crew>,
     default_crew: Option<String>,
     duel: DuelConfig,
@@ -205,6 +207,8 @@ impl OrbitRuntimeSettings {
         workflow_base_branch: String,
         workflow_auto_ship: bool,
         routines_source: bool,
+        worktree_gc_success_retention_days: u64,
+        worktree_gc_failure_retention_days: u64,
         crews: std::collections::BTreeMap<String, Crew>,
         default_crew: Option<String>,
         duel: DuelConfig,
@@ -221,6 +225,8 @@ impl OrbitRuntimeSettings {
             workflow_base_branch,
             workflow_auto_ship,
             routines_source,
+            worktree_gc_success_retention_days,
+            worktree_gc_failure_retention_days,
             crews,
             default_crew,
             duel,
@@ -245,6 +251,14 @@ impl OrbitRuntimeSettings {
 
     pub(crate) fn routines_source(&self) -> bool {
         self.routines_source
+    }
+
+    pub(crate) fn worktree_gc_success_retention_days(&self) -> u64 {
+        self.worktree_gc_success_retention_days
+    }
+
+    pub(crate) fn worktree_gc_failure_retention_days(&self) -> u64 {
+        self.worktree_gc_failure_retention_days
     }
 
     pub(crate) fn crews(&self) -> &std::collections::BTreeMap<String, Crew> {
@@ -383,6 +397,14 @@ impl OrbitContext {
     /// (`[routines] role = "source"` in `config.toml`, default `false`).
     pub(crate) fn routines_source(&self) -> bool {
         self.runtime.routines_source()
+    }
+
+    pub(crate) fn worktree_gc_success_retention_days(&self) -> u64 {
+        self.runtime.worktree_gc_success_retention_days()
+    }
+
+    pub(crate) fn worktree_gc_failure_retention_days(&self) -> u64 {
+        self.runtime.worktree_gc_failure_retention_days()
     }
 
     pub(crate) fn crews(&self) -> &std::collections::BTreeMap<String, Crew> {

--- a/crates/orbit-core/src/context.rs
+++ b/crates/orbit-core/src/context.rs
@@ -1,4 +1,4 @@
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use orbit_common::types::{Crew, WorkspacePaths};
@@ -89,6 +89,10 @@ pub(crate) struct OrbitStores {
     pub(crate) audit_event: Arc<dyn AuditEventStoreBackend>,
     pub(crate) executor_def: Arc<dyn ExecutorDefStoreBackend>,
     pub(crate) policy_def: Arc<dyn PolicyDefStoreBackend>,
+    /// Workspace `state` dir; the per-run claim guard (`run-guards/<id>.lock`)
+    /// is derived from it so the claim/start path and the worktree collector
+    /// rendezvous on the same lock (ORB-10182).
+    pub(crate) run_guard_state_dir: PathBuf,
 }
 
 impl OrbitStores {
@@ -109,6 +113,7 @@ impl OrbitStores {
         audit_event: Arc<dyn AuditEventStoreBackend>,
         executor_def: Arc<dyn ExecutorDefStoreBackend>,
         policy_def: Arc<dyn PolicyDefStoreBackend>,
+        run_guard_state_dir: PathBuf,
     ) -> Self {
         Self {
             task,
@@ -126,6 +131,7 @@ impl OrbitStores {
             audit_event,
             executor_def,
             policy_def,
+            run_guard_state_dir,
         }
     }
 }

--- a/crates/orbit-core/src/runtime/builder.rs
+++ b/crates/orbit-core/src/runtime/builder.rs
@@ -144,6 +144,8 @@ pub(crate) fn build_context_from_roots(
     let workflow_base_branch = runtime_config.workflow_base_branch().to_string();
     let workflow_auto_ship = runtime_config.workflow_auto_ship();
     let routines_source = runtime_config.routines_source();
+    let worktree_gc_success_retention_days = runtime_config.worktree_gc_success_retention_days();
+    let worktree_gc_failure_retention_days = runtime_config.worktree_gc_failure_retention_days();
     let crews = runtime_config.crews.clone();
     let default_crew = runtime_config.default_crew.clone();
     let duel = runtime_config.duel_config().clone();
@@ -185,6 +187,8 @@ pub(crate) fn build_context_from_roots(
             workflow_base_branch,
             workflow_auto_ship,
             routines_source,
+            worktree_gc_success_retention_days,
+            worktree_gc_failure_retention_days,
             crews,
             default_crew,
             duel,

--- a/crates/orbit-core/src/runtime/builder.rs
+++ b/crates/orbit-core/src/runtime/builder.rs
@@ -150,6 +150,7 @@ pub(crate) fn build_context_from_roots(
     let default_crew = runtime_config.default_crew.clone();
     let duel = runtime_config.duel_config().clone();
 
+    let run_guard_state_dir = paths.state_dir.clone();
     Ok(OrbitContext::new(
         paths,
         OrbitStores::new(
@@ -168,6 +169,7 @@ pub(crate) fn build_context_from_roots(
             audit_event_store,
             executor_def_store,
             policy_def_store,
+            run_guard_state_dir,
         ),
         OrbitExecutionAssets::new(Arc::new(registry), skill_catalog),
         OrbitPolicyContext::new(

--- a/crates/orbit-core/src/runtime/mod.rs
+++ b/crates/orbit-core/src/runtime/mod.rs
@@ -20,6 +20,7 @@ pub(crate) mod orbit_tool_host;
 pub mod pipeline;
 mod resolve;
 pub mod run_audit;
+pub(crate) mod run_claim_guard;
 pub(crate) mod run_input;
 mod store_delegates;
 mod task_block_on_run_failure;

--- a/crates/orbit-core/src/runtime/mod.rs
+++ b/crates/orbit-core/src/runtime/mod.rs
@@ -372,6 +372,14 @@ impl OrbitRuntime {
         self.context.routines_source()
     }
 
+    pub fn worktree_gc_success_retention_days(&self) -> u64 {
+        self.context.worktree_gc_success_retention_days()
+    }
+
+    pub fn worktree_gc_failure_retention_days(&self) -> u64 {
+        self.context.worktree_gc_failure_retention_days()
+    }
+
     /// Returns the configured `[duel] candidates` list (e.g. ["codex", "claude", "gemini", "grok"]).
     /// Used by `orbit run duel-plan --planner-a ...` overrides to validate explicit families.
     pub fn duel_candidate_families(&self) -> Vec<String> {

--- a/crates/orbit-core/src/runtime/run_claim_guard.rs
+++ b/crates/orbit-core/src/runtime/run_claim_guard.rs
@@ -1,0 +1,99 @@
+//! Per-run advisory claim/reclaim guard shared by the run claim/start path and
+//! the managed-worktree collector.
+//!
+//! ADR-0220 established the host-global GC lock that serializes `gc apply`
+//! against other GC processes. That lock does **not** serialize GC against a
+//! worker claiming or reclaiming a run, so the window between the collector's
+//! final ownership revalidation and `git worktree remove` was not atomic against
+//! a concurrent claim (ORB-10182). This guard closes that window: one advisory
+//! file lock keyed by run id that **both** competing paths acquire —
+//!
+//! - the run claim/start path (`mark_run_running`, `claim_pending_run_owner`,
+//!   `take_over_running_run`) holds it across the ownership state transition, and
+//! - the worktree collector holds it continuously across
+//!   `[final revalidation .. git worktree remove]`.
+//!
+//! Lock ordering is fixed: **GC host lock → per-run guard → filesystem
+//! mutation**. The guard is a filesystem advisory lock, never the global SQLite
+//! write lock, so no unrelated database lock is held across `git worktree
+//! remove`. Both sides derive the lock path identically from the workspace
+//! `state` dir so they rendezvous on the same inode; a run id that is empty or
+//! contains a path separator is rejected rather than allowed to escape the
+//! guard directory.
+
+use std::fs::{self, File, OpenOptions};
+use std::path::{Path, PathBuf};
+use std::thread;
+use std::time::{Duration, Instant};
+
+use fs2::FileExt;
+use orbit_common::types::OrbitError;
+
+/// Bounded wait before a contender fails closed rather than blocking a worker
+/// (or the collector) indefinitely. Contention is per-run and only ever occurs
+/// at the instant one run transitions ownership while its own worktree is being
+/// collected, so this bound is a safety valve, not a hot-path cost.
+const GUARD_WAIT: Duration = Duration::from_secs(5);
+const GUARD_POLL: Duration = Duration::from_millis(25);
+
+/// RAII holder for an acquired per-run guard. Dropping it releases the advisory
+/// lock; the open descriptor is kept alive for the lock's lifetime.
+#[derive(Debug)]
+pub(crate) struct RunClaimGuard {
+    file: File,
+}
+
+impl Drop for RunClaimGuard {
+    fn drop(&mut self) {
+        let _ = FileExt::unlock(&self.file);
+    }
+}
+
+/// Directory holding one lock file per run id, derived identically by the claim
+/// path and the collector from the workspace `state` dir.
+fn guard_dir(state_dir: &Path) -> PathBuf {
+    state_dir.join("run-guards")
+}
+
+fn guard_path(state_dir: &Path, run_id: &str) -> Result<PathBuf, OrbitError> {
+    if run_id.is_empty() || run_id.contains('/') || run_id.contains('\\') || run_id.contains("..") {
+        return Err(OrbitError::InvalidInput(format!(
+            "refusing to derive a run-claim guard path for suspicious run id `{run_id}`"
+        )));
+    }
+    Ok(guard_dir(state_dir).join(format!("{run_id}.lock")))
+}
+
+fn open_guard_file(state_dir: &Path, run_id: &str) -> Result<File, OrbitError> {
+    let path = guard_path(state_dir, run_id)?;
+    fs::create_dir_all(guard_dir(state_dir))?;
+    Ok(OpenOptions::new()
+        .create(true)
+        .truncate(false)
+        .read(true)
+        .write(true)
+        .open(&path)?)
+}
+
+/// Blocking acquire with a bounded wait. Returns the RAII guard, or a timeout
+/// error so callers fail closed instead of blocking forever. The collector
+/// treats the error as "do not remove"; the claim path surfaces it as a failed
+/// start that reconciliation retries.
+pub(crate) fn acquire(state_dir: &Path, run_id: &str) -> Result<RunClaimGuard, OrbitError> {
+    let file = open_guard_file(state_dir, run_id)?;
+    let started = Instant::now();
+    loop {
+        match file.try_lock_exclusive() {
+            Ok(()) => return Ok(RunClaimGuard { file }),
+            Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                if started.elapsed() >= GUARD_WAIT {
+                    return Err(OrbitError::Execution(format!(
+                        "timed out waiting for per-run claim guard `{run_id}`"
+                    )));
+                }
+                thread::sleep(GUARD_POLL);
+            }
+            Err(error) => return Err(error.into()),
+        }
+    }
+}

--- a/crates/orbit-core/src/runtime/store_delegates.rs
+++ b/crates/orbit-core/src/runtime/store_delegates.rs
@@ -22,6 +22,7 @@ use orbit_store::{
 };
 
 use crate::context::OrbitStores;
+use crate::runtime::run_claim_guard;
 
 #[derive(Default, Clone)]
 pub(crate) struct TaskRecordUpdateParams {
@@ -131,6 +132,7 @@ impl OrbitStores {
     pub(crate) fn jobs(&self) -> JobRecords<'_> {
         JobRecords {
             run: self.job_run.as_ref(),
+            run_guard_state_dir: self.run_guard_state_dir.as_path(),
         }
     }
 
@@ -403,6 +405,11 @@ impl TaskReservationRecords<'_> {
 
 pub(crate) struct JobRecords<'a> {
     run: &'a dyn JobRunStoreBackend,
+    /// Workspace `state` dir backing the per-run claim guard (ORB-10182). The
+    /// run claim/start transitions below hold the guard across their store
+    /// mutation so the worktree collector cannot revalidate-then-remove a tree
+    /// whose run is being claimed concurrently.
+    run_guard_state_dir: &'a std::path::Path,
 }
 
 impl JobRecords<'_> {
@@ -439,6 +446,10 @@ impl JobRecords<'_> {
         started_at: chrono::DateTime<chrono::Utc>,
         pid: u32,
     ) -> Result<bool, OrbitError> {
+        // Hold the per-run claim guard across the ownership transition so the
+        // worktree collector cannot interleave its final revalidation and
+        // `git worktree remove` with this claim (ORB-10182).
+        let _guard = run_claim_guard::acquire(self.run_guard_state_dir, run_id)?;
         self.run.mark_job_run_running(run_id, started_at, pid)
     }
 
@@ -447,6 +458,7 @@ impl JobRecords<'_> {
         run_id: &str,
         pid: u32,
     ) -> Result<bool, OrbitError> {
+        let _guard = run_claim_guard::acquire(self.run_guard_state_dir, run_id)?;
         self.run.claim_pending_job_run_owner(run_id, pid)
     }
 
@@ -458,6 +470,7 @@ impl JobRecords<'_> {
         started_at: chrono::DateTime<chrono::Utc>,
         pid: u32,
     ) -> Result<bool, OrbitError> {
+        let _guard = run_claim_guard::acquire(self.run_guard_state_dir, run_id)?;
         self.run.take_over_running_job_run(
             run_id,
             expected_pid,

--- a/crates/orbit-core/src/runtime/task_reservation_cleanup.rs
+++ b/crates/orbit-core/src/runtime/task_reservation_cleanup.rs
@@ -51,6 +51,9 @@ impl OrbitRuntime {
             {
                 self.best_effort_block_tasks_for_failed_run(run_id, state);
             }
+            if !was_terminal_before {
+                self.best_effort_collect_terminal_worktree(run_id);
+            }
         }
         Ok(changed)
     }

--- a/crates/orbit-engine/src/executor/automation/vcs/worktree/cleanup.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/worktree/cleanup.rs
@@ -6,7 +6,6 @@ use serde_json::{Map, Value, json};
 use crate::context::RuntimeHost;
 use crate::executor::automation::input::input_string_field;
 
-use super::super::git::{git_output, git_output_raw, git_success};
 use super::{resolve_shared_worktree_path, resolve_worktree_path_from_prefix};
 
 const DEFAULT_BRANCH_PREFIX: &str = "orbit";
@@ -20,25 +19,15 @@ pub(in crate::executor::automation) fn cleanup_worktree<H: RuntimeHost + ?Sized>
     let repo_root = Path::new(&repo_root_str);
     let workspace_path = resolve_workspace_path(repo_root, input, run_id)?;
     let workspace_path_str = workspace_path.to_string_lossy().to_string();
-    let branch_name = detect_branch_name(repo_root, &workspace_path);
-
-    if workspace_path.exists() {
-        git_success(
-            repo_root,
-            &["worktree", "remove", "--force", workspace_path_str.as_str()],
-        )?;
-    }
-    git_success(repo_root, &["worktree", "prune"])?;
-    if let Some(branch_name) = branch_name.as_deref() {
-        git_success(repo_root, &["branch", "-D", branch_name])?;
-    }
 
     let mut output = Map::new();
-    output.insert("cleaned_up".to_string(), json!(true));
+    // Destructive cleanup is intentionally deferred until the owning run has
+    // a persisted terminal timestamp. OrbitRuntime then invokes the shared
+    // worktree GC collector, which applies the same retention and safety
+    // classifier as `orbit gc worktrees --apply`.
+    output.insert("cleaned_up".to_string(), json!(false));
+    output.insert("cleanup_deferred".to_string(), json!(true));
     output.insert("workspace_path".to_string(), json!(workspace_path_str));
-    if let Some(branch_name) = branch_name {
-        output.insert("branch".to_string(), json!(branch_name));
-    }
     Ok(Value::Object(output))
 }
 
@@ -77,44 +66,4 @@ fn has_task_id(input: &Value) -> bool {
         .and_then(Value::as_str)
         .map(str::trim)
         .is_some_and(|task_id| !task_id.is_empty())
-}
-
-fn detect_branch_name(repo_root: &Path, workspace_path: &Path) -> Option<String> {
-    if workspace_path.is_dir()
-        && let Ok(branch_name) = git_output(workspace_path, &["rev-parse", "--abbrev-ref", "HEAD"])
-    {
-        let branch_name = branch_name.trim();
-        if !branch_name.is_empty() && branch_name != "HEAD" {
-            return Some(branch_name.to_string());
-        }
-    }
-
-    let worktree_list = git_output_raw(repo_root, &["worktree", "list", "--porcelain"]).ok()?;
-    branch_name_from_worktree_list(&worktree_list, workspace_path)
-}
-
-fn branch_name_from_worktree_list(worktree_list: &str, workspace_path: &Path) -> Option<String> {
-    let target_path = workspace_path.to_string_lossy();
-    let mut matching_block = false;
-
-    for line in worktree_list.lines() {
-        if let Some(path) = line.strip_prefix("worktree ") {
-            matching_block = path == target_path;
-            continue;
-        }
-
-        if !matching_block {
-            continue;
-        }
-
-        if let Some(branch_name) = line.strip_prefix("branch refs/heads/") {
-            return Some(branch_name.to_string());
-        }
-
-        if line.is_empty() {
-            matching_block = false;
-        }
-    }
-
-    None
 }

--- a/docs/design/gc/2_design.md
+++ b/docs/design/gc/2_design.md
@@ -173,8 +173,11 @@ prerequisite failed is reported as dependency-blocked.
 ## 4. Configuration and Precedence
 
 GC uses typed `[gc]` configuration with per-target subsections and conservative
-built-in defaults. Exact key names and defaults land with their collector, but
-every key identifies its unit and retention class; zero means immediate
+built-in defaults. Worktree collection uses
+`gc.worktrees.success_retention_days` (default `0`) and
+`gc.worktrees.failure_retention_days` (default `7`); resumable interrupted
+worktrees remain protected regardless of age. Every key identifies its unit and
+retention class; zero means immediate
 eligibility only where the key explicitly permits it. Invalid values fail plan
 construction before mutation.
 
@@ -367,7 +370,7 @@ limited to non-destructive setup and active-file rotation.
 
 - [ORB-10178] — defined this retention and safety contract.
 - [ORB-10180] — will implement the shared GC framework.
-- [ORB-10182] — will implement managed worktree collection.
+- [ORB-10182] — implemented managed worktree collection and terminal cleanup reuse.
 - [ORB-10183] — will implement run retention.
 - [ORB-10184] — will unify log retention.
 - [ORB-10185] — will implement diagnostics retention.

--- a/docs/design/gc/2_design.md
+++ b/docs/design/gc/2_design.md
@@ -102,6 +102,18 @@ protected. Unknown directories are inventory entries, not candidates. Removal
 uses Git worktree operations and is language-neutral. On-terminal cleanup calls
 the same classifier and apply primitive as manual GC.
 
+Owner liveness is proven, not assumed: the collector reuses run
+reconciliation's PID + process-start-identity probe, so a row that reads
+terminal while its worker process is still alive (e.g. a zero-day success still
+winding down after finalizing) is retained. Only a conclusively dead owner
+(missing PID, or a PID now held by an unrelated process) — or this same
+collecting process, whose cwd guard covers the in-use case — permits removal;
+verified-live, unverifiable-live, and inconclusive probes all fail closed. Per
+§5.6, this owner state/identity/liveness plus Git revalidation is re-run as the
+immediately preceding operation to `git worktree remove`, under the host GC
+lock, so a candidate whose owner is claimed or transitioned live between
+planning and mutation is refused rather than removed.
+
 ### 3.2 Runs (workspace)
 
 The run collector coordinates authoritative rows, steps, reservations,

--- a/docs/design/gc/2_design.md
+++ b/docs/design/gc/2_design.md
@@ -110,9 +110,21 @@ winding down after finalizing) is retained. Only a conclusively dead owner
 collecting process, whose cwd guard covers the in-use case — permits removal;
 verified-live, unverifiable-live, and inconclusive probes all fail closed. Per
 §5.6, this owner state/identity/liveness plus Git revalidation is re-run as the
-immediately preceding operation to `git worktree remove`, under the host GC
-lock, so a candidate whose owner is claimed or transitioned live between
-planning and mutation is refused rather than removed.
+immediately preceding operation to `git worktree remove`. It is not enough for
+that revalidation to be adjacent to the removal: the host GC lock serializes GC
+against other GC processes, not against a worker claiming or reclaiming a run,
+so revalidate-then-remove was not atomic against a concurrent claim. The
+collector therefore takes a **per-run claim guard** — one advisory file lock
+keyed by run id under `state/run-guards/` — and holds it continuously across
+revalidation and removal. The run claim/start path (`mark_run_running`,
+`claim_pending_run_owner`, `take_over_running_run`) acquires the *same* guard
+around its ownership transition, so the two paths are mutually exclusive: a
+claim that commits first is observed by revalidation (GC fails closed); a GC
+removal that wins first forces the blocked claimant to re-evaluate (its worktree
+setup recreates the tree) rather than enter a removed worktree. Lock ordering is
+fixed — **host GC lock → per-run guard → filesystem** — and the guard is a
+filesystem advisory lock, never the global SQLite write lock, so no unrelated
+database lock is held across the git operation.
 
 ### 3.2 Runs (workspace)
 


### PR DESCRIPTION
## Task

[ORB-10182](https://orbit-cli.com/tasks/ORB-10182) — Add managed pipeline worktree GC under orbit gc

### Description

## Problem

Pipeline worktrees and their language-specific build artifacts can accumulate without bound. PR #577 / ORB-10173 attempted cleanup under `orbit run gc`, but its command ownership and concurrency/data-safety model were insufficient.

## Why It Matters

Worktrees are the largest known disk leak, but they may also contain live work, resumable failures, dirty changes, or unmerged branches. Collection must be urgent without being lossy.

## Scope

Implement `orbit gc worktrees` on the shared framework. Reconcile only Orbit-managed worktrees with run ownership, reuse the classifier for terminal-run cleanup, and apply status-specific retention.

## Constraints / Notes

- Never delete a live/current/inconclusive worktree.
- Revalidate ownership atomically under the GC/run-claim lock immediately before mutation.
- Do not blindly delete unknown directories, dirty source-bearing trees, or unmerged branches.
- Removal is language-neutral and must not special-case Cargo.

### Acceptance Criteria

- `orbit gc worktrees` reports and, only with `--apply`, reclaims eligible Orbit-managed worktrees using the shared GC report.
- Live-run, current-cwd, liveness-inconclusive, dirty source-bearing, unknown-owner, and resumable interrupted worktrees are retained with explicit reasons.
- Success/cancelled and failed/interrupted worktrees have separately configurable retention based on persisted run timestamps.
- Ownership is revalidated atomically against run claim/start before deletion; a race test proves a pending run becoming live cannot be cancelled or removed.
- Use `git worktree remove/prune`; never automatically delete an unmerged or unpushed task branch.
- On-terminal cleanup and manual GC share exactly the same classifier and retention policy.
- Tests cover live, dead, missing-record, current-cwd, dirty, retained failure, unknown directory, and idempotent/concurrent execution.
- A live-box validation records before/after worktree bytes and filesystem usage, and resolves or explicitly re-scopes F2026-07-019 plus the overlapping ORB-10153 family.
- `make ci-fast` and focused core/CLI tests pass.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Added the `WorktreeGcCollector` to the shared plan/apply/report framework with persisted run clocks, separate success/failure retention, current-cwd/live-or-inconclusive/resumable/dirty/unknown-owner/unmerged/unpushed protections, Git-only removal/prune, immediate revalidation, byte accounting, and idempotent manifests.
- Wired `orbit gc worktrees`, qualified CLI retention overrides, selected-workspace runtime resolution, typed `[gc.worktrees]` config, config reporting, and design/changelog documentation.
- Routed terminal-run cleanup through the same collector and changed the engine cleanup action into a non-destructive defer, eliminating force removal, raw deletion, and automatic branch deletion.
- Added classifier, real-Git plan/apply, pending-to-live race, dirty/missing/unknown/current/retained/resumable/branch-safety, idempotency, config, and CLI tests. Added corrective learning L-0080; linking it as the superseder of remote-only L-0078 was blocked by the lifecycle tool and tracked as F2026-07-026.
- Live-box apply scanned 21 worktrees and reclaimed 14 / 138,582,642,381 estimated bytes with a clean outcome; `.orbit/state/worktrees` fell from 163,801,865,718 to 43,333,830,541 bytes and root filesystem usage from 47% to 16%. Seven protected trees remained with explicit reasons. This explicitly re-scopes F2026-07-019 and the ORB-10153 overlap to safety-first ownership.
Assessment: Safety invariants are fail-closed, manual and terminal cleanup share one collector, branches are never deleted, and focused behavior is covered against real Git worktrees.
Validation:
- PASS: cargo check -p orbit-core -p orbit-cli
- PASS: 6 focused orbit-core worktree GC tests
- PASS: worktree GC config test
- PASS: 5 focused orbit-cli GC tests
- PASS: cargo fmt --all -- --check; git diff --check
- PASS: all remaining ci-fast guardrails (dependency direction, CLI imports, stability, learning layout, redaction, changelog freshness/style, error translation)
- PARTIAL: make ci-fast stopped at scripts/test-installer-security.sh because `node` is not installed on PATH; preceding fmt/pubkey checks passed, and all subsequent guardrails were run individually and passed.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10182-6a540bbf`
- Behind base: 0
- Ahead of base: 1