### PR TITLE
Add diagnostics stream GC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- **Diagnostics stream GC**: `orbit gc diagnostics` reclaims closed metrics/diagnostic-friction JSONL day-partitions under `state/diagnostics` past category-specific retention (`[gc.diagnostics]`, default 90d). The current-day writer target and any malformed/ambiguous file are retained and reported; canonical `.orbit/frictions`, tasks, and audit evidence are never candidates. ([ORB-10185])
 - **Age-based task archival**: `orbit gc tasks` archives terminal tasks (`done`, opt-in `rejected` via `--include-rejected`) older than retention using the persisted terminal-transition clock; keep-tagged tasks, open review threads, and active dependents are retained. Archive-only and reversible — no bundle deletion. ([ORB-10188])
 - **Unified audit retention**: `orbit gc audit` plans/applies workspace-scoped legacy/v2 envelope retention plus reference-safe blob sweeping; deprecated `orbit audit prune` routes to the same collector. An audit writer/GC guard and a durable per-blob pending-publication root span blob creation through reference publication, so concurrent writers never strand a reference, publish one to a swept blob, or lose an append. ([ORB-10186])
 - **Terminal job-run retention**: `orbit gc runs` archives then purges conclusively terminal runs with independent success/failure ages, while retaining active, resumable, live, task/reservation/scoreboard-linked runs (rowless legacy bundles included) and refusing `--global`; audit evidence stays with `orbit gc audit`. ([ORB-10183])

--- a/crates/orbit-cli/src/command/gc.rs
+++ b/crates/orbit-cli/src/command/gc.rs
@@ -7,6 +7,7 @@ use orbit_core::command::gc::{
     RunGcPolicy, SystemGcClock, WorktreeGcCollector, WorktreeGcPolicy, execute_gc,
 };
 use orbit_core::command::gc_audit::AuditGcCollector;
+use orbit_core::command::gc_diagnostics::{DiagnosticsGcCollector, DiagnosticsGcPolicy};
 use orbit_core::command::gc_logs::LogsGcCollector;
 use orbit_core::command::skill_gc::SkillsGcCollector;
 use orbit_core::command::task_gc::TaskGcCollector;
@@ -199,8 +200,10 @@ impl Execute for GcCommand {
             let report = self.run(&collector, scope, runtime)?;
             return self.finish(report);
         }
-        let selected_runtime = if matches!(target, GcTarget::Worktrees | GcTarget::Runs)
-            && scope.root() != runtime.paths().orbit_dir
+        let selected_runtime = if matches!(
+            target,
+            GcTarget::Worktrees | GcTarget::Runs | GcTarget::Diagnostics
+        ) && scope.root() != runtime.paths().orbit_dir
         {
             Some(OrbitRuntime::from_roots(
                 &runtime.paths().global_dir,
@@ -242,6 +245,18 @@ impl Execute for GcCommand {
             .map(Duration::from_secs);
         let logs = matches!(target, GcTarget::Logs)
             .then(|| LogsGcCollector::from_scope(&scope, retention_window));
+        let diagnostics = matches!(target, GcTarget::Diagnostics).then(|| {
+            let (metrics_retention_days, friction_retention_days) =
+                collector_runtime.diagnostics_gc_retention_days();
+            DiagnosticsGcCollector::from_scope(
+                &scope,
+                DiagnosticsGcPolicy {
+                    metrics_retention_days,
+                    friction_retention_days,
+                },
+                retention_window,
+            )
+        });
         let empty = EmptyGcCollector::new(target);
         let collector: &dyn GcCollector = if target == GcTarget::Worktrees {
             &worktrees
@@ -249,6 +264,8 @@ impl Execute for GcCommand {
             &runs
         } else if let Some(logs) = logs.as_ref() {
             logs
+        } else if let Some(diagnostics) = diagnostics.as_ref() {
+            diagnostics
         } else {
             &empty
         };

--- a/crates/orbit-core/src/command/gc_diagnostics.rs
+++ b/crates/orbit-core/src/command/gc_diagnostics.rs
@@ -1,0 +1,422 @@
+//! GC collector for Orbit-owned diagnostics telemetry streams [ORB-10185].
+//!
+//! `orbit gc diagnostics` bounds the append-only JSONL partitions written under
+//! `<root>/state/diagnostics/{metrics,friction}`. Both streams are day
+//! partitioned (`<category>/YYYY-MM/DD.jsonl`); the writer only ever appends to
+//! the partition for the current UTC day. This collector therefore treats each
+//! `DD.jsonl` file as a partition and reclaims only *closed* partitions — those
+//! whose calendar day is strictly in the past — once they age past the
+//! category-specific retention window. The current-day partition (and any file
+//! whose date is today or in the future) is never a candidate, so a live writer
+//! holding it open is unaffected without any cross-process locking.
+//!
+//! Explicitly out of scope, so this stream GC can never be confused with
+//! durable knowledge:
+//! - Canonical friction records under `<root>/frictions` (a sibling of, not
+//!   under, `state/diagnostics/friction`).
+//! - Tasks, ADRs, learnings, and audit evidence — none live under
+//!   `state/diagnostics`, so scoping the scan to the two telemetry directories
+//!   excludes them by construction.
+//!
+//! Malformed or ambiguously named entries (a month directory that is not
+//! `YYYY-MM`, a partition file that is not `DD.jsonl`, a stray file or nested
+//! directory) are diagnostic evidence in their own right: they are reported as
+//! skips and always retained.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use chrono::{Datelike, NaiveDate};
+use orbit_common::types::OrbitError;
+use serde::{Deserialize, Serialize};
+
+use super::gc::{
+    GcCandidate, GcCollector, GcContext, GcMutation, GcPlan, GcRevalidation, GcScope, GcSkip,
+    GcTarget,
+};
+
+const SECONDS_PER_DAY: u64 = 86_400;
+
+/// A diagnostics telemetry stream. Each maps to one directory under
+/// `state/diagnostics` and carries its own retention window.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum DiagnosticsCategory {
+    Metrics,
+    Friction,
+}
+
+impl DiagnosticsCategory {
+    const ALL: [DiagnosticsCategory; 2] = [Self::Metrics, Self::Friction];
+
+    fn dir(self) -> &'static str {
+        match self {
+            Self::Metrics => "metrics",
+            Self::Friction => "friction",
+        }
+    }
+}
+
+/// Per-category retention windows (in days) for closed diagnostics partitions.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct DiagnosticsGcPolicy {
+    pub metrics_retention_days: u64,
+    pub friction_retention_days: u64,
+}
+
+impl DiagnosticsGcPolicy {
+    fn retention_days(&self, category: DiagnosticsCategory) -> u64 {
+        match category {
+            DiagnosticsCategory::Metrics => self.metrics_retention_days,
+            DiagnosticsCategory::Friction => self.friction_retention_days,
+        }
+    }
+}
+
+/// Collector for the append-only metrics/friction diagnostics streams.
+pub struct DiagnosticsGcCollector {
+    /// `<scope root>/state/diagnostics`.
+    diagnostics_root: PathBuf,
+    policy: DiagnosticsGcPolicy,
+    /// Uniform `--retention` override (pre-parsed by the CLI). When set it
+    /// replaces the configured per-category window for *both* streams, floored
+    /// to whole days.
+    retention_override: Option<Duration>,
+}
+
+impl DiagnosticsGcCollector {
+    /// Manage the diagnostics streams under `scope_root/state/diagnostics`.
+    pub fn from_scope(
+        scope: &GcScope,
+        policy: DiagnosticsGcPolicy,
+        retention_override: Option<Duration>,
+    ) -> Self {
+        Self::new(scope.root(), policy, retention_override)
+    }
+
+    /// Explicit constructor (test seam): manage the streams under
+    /// `scope_root/state/diagnostics`.
+    pub fn new(
+        scope_root: &Path,
+        policy: DiagnosticsGcPolicy,
+        retention_override: Option<Duration>,
+    ) -> Self {
+        Self {
+            diagnostics_root: scope_root.join("state").join("diagnostics"),
+            policy,
+            retention_override,
+        }
+    }
+
+    fn retention_days(&self, category: DiagnosticsCategory) -> u64 {
+        match self.retention_override {
+            Some(window) => window.as_secs() / SECONDS_PER_DAY,
+            None => self.policy.retention_days(category),
+        }
+    }
+
+    /// Classify one candidate day-partition against `today`. Returns a candidate
+    /// when the partition is closed and aged past retention; otherwise a skip
+    /// describing why it is retained (open/current-day or within retention).
+    fn classify_partition(
+        &self,
+        category: DiagnosticsCategory,
+        partition_date: NaiveDate,
+        path: &Path,
+        today: NaiveDate,
+    ) -> Result<Classified, OrbitError> {
+        let id = self.partition_id(path);
+        // Partition-closure rule: only strictly-past calendar days are closed.
+        // The current-day writer (and any future-dated file) is protected here
+        // without file locking.
+        if partition_date >= today {
+            return Ok(Classified::Skip(GcSkip {
+                id,
+                code: "open_partition".to_string(),
+                reason: format!(
+                    "partition {partition_date} is the current-day (or future) writer target"
+                ),
+            }));
+        }
+        let age_days = (today - partition_date).num_days().max(0) as u64;
+        let retention_days = self.retention_days(category);
+        if age_days <= retention_days {
+            return Ok(Classified::Skip(GcSkip {
+                id,
+                code: "retained".to_string(),
+                reason: format!(
+                    "closed {} partition {partition_date} is {age_days}d old; within {retention_days}d retention",
+                    category.dir()
+                ),
+            }));
+        }
+        let bytes = fs::symlink_metadata(path).map(|meta| meta.len()).ok();
+        let expected = ExpectedPartition {
+            category: category.dir().to_string(),
+            partition_date,
+            bytes,
+        };
+        Ok(Classified::Candidate(GcCandidate {
+            id,
+            action: "delete".to_string(),
+            path: Some(path.to_path_buf()),
+            bytes,
+            ownership_evidence: format!(
+                "append-only diagnostics {} day-partition under state/diagnostics/{}; canonical .orbit/frictions, tasks, and audit evidence excluded",
+                category.dir(),
+                category.dir()
+            ),
+            retention_evidence: format!(
+                "closed {} partition dated {partition_date}; age {age_days}d exceeds {retention_days}d retention",
+                category.dir()
+            ),
+            expected_state: serde_json::to_string(&expected)
+                .map_err(|error| OrbitError::Execution(error.to_string()))?,
+            allow_owned_symlink: false,
+        }))
+    }
+
+    /// Stable `<category>/<month>/<DD>.jsonl` identifier for a partition path
+    /// (the path relative to the diagnostics root already leads with the
+    /// category directory).
+    fn partition_id(&self, path: &Path) -> String {
+        path.strip_prefix(&self.diagnostics_root)
+            .map(|relative| relative.display().to_string())
+            .unwrap_or_else(|_| path.display().to_string())
+    }
+
+    fn scan_category(
+        &self,
+        category: DiagnosticsCategory,
+        today: NaiveDate,
+        plan: &mut GcPlan,
+    ) -> Result<(), OrbitError> {
+        let category_root = self.diagnostics_root.join(category.dir());
+        if !category_root.exists() {
+            return Ok(());
+        }
+        let mut month_dirs = Vec::new();
+        for entry in fs::read_dir(&category_root)? {
+            let path = entry?.path();
+            let name = file_name(&path);
+            if path.is_dir() {
+                if parse_year_month(&name).is_some() {
+                    month_dirs.push((name, path));
+                } else {
+                    plan.scanned = plan.scanned.saturating_add(1);
+                    plan.skipped.push(GcSkip {
+                        id: format!("{}/{name}", category.dir()),
+                        code: "malformed_partition".to_string(),
+                        reason: "month directory name is not YYYY-MM; retained as evidence"
+                            .to_string(),
+                    });
+                }
+            } else {
+                // A stray file directly under the category root is ambiguous:
+                // partitions always live inside a month directory.
+                plan.scanned = plan.scanned.saturating_add(1);
+                plan.skipped.push(GcSkip {
+                    id: format!("{}/{name}", category.dir()),
+                    code: "malformed_partition".to_string(),
+                    reason:
+                        "unexpected file outside a YYYY-MM month directory; retained as evidence"
+                            .to_string(),
+                });
+            }
+        }
+        // Deterministic order so plan/report output is stable across runs.
+        month_dirs.sort_by(|left, right| left.0.cmp(&right.0));
+        for (month_name, month_dir) in month_dirs {
+            self.scan_month(category, &month_name, &month_dir, today, plan)?;
+        }
+        Ok(())
+    }
+
+    fn scan_month(
+        &self,
+        category: DiagnosticsCategory,
+        month_name: &str,
+        month_dir: &Path,
+        today: NaiveDate,
+        plan: &mut GcPlan,
+    ) -> Result<(), OrbitError> {
+        let mut files = Vec::new();
+        for entry in fs::read_dir(month_dir)? {
+            files.push(entry?.path());
+        }
+        files.sort();
+        for path in files {
+            let name = file_name(&path);
+            plan.scanned = plan.scanned.saturating_add(1);
+            if path.is_dir() {
+                plan.skipped.push(GcSkip {
+                    id: format!("{}/{month_name}/{name}", category.dir()),
+                    code: "malformed_partition".to_string(),
+                    reason: "nested directory where a DD.jsonl partition was expected; retained as evidence"
+                        .to_string(),
+                });
+                continue;
+            }
+            let Some(partition_date) = parse_partition_date(month_name, &name) else {
+                plan.skipped.push(GcSkip {
+                    id: format!("{}/{month_name}/{name}", category.dir()),
+                    code: "malformed_partition".to_string(),
+                    reason: "file name is not a valid DD.jsonl day partition; retained as evidence"
+                        .to_string(),
+                });
+                continue;
+            };
+            if let Ok(meta) = fs::symlink_metadata(&path) {
+                plan.scanned_bytes = plan.scanned_bytes.map(|sum| sum.saturating_add(meta.len()));
+            }
+            match self.classify_partition(category, partition_date, &path, today)? {
+                Classified::Candidate(candidate) => plan.candidates.push(candidate),
+                Classified::Skip(skip) => plan.skipped.push(skip),
+            }
+        }
+        Ok(())
+    }
+
+    fn revalidate_partition(
+        &self,
+        candidate: &GcCandidate,
+        context: &GcContext<'_>,
+    ) -> Result<GcRevalidation, OrbitError> {
+        let expected: ExpectedPartition =
+            serde_json::from_str(&candidate.expected_state).map_err(|error| {
+                OrbitError::Execution(format!("invalid frozen diagnostics partition: {error}"))
+            })?;
+        let Some(path) = candidate.path.as_deref() else {
+            return Ok(GcRevalidation::Skip {
+                code: "missing_path".to_string(),
+                reason: "diagnostics GC candidate has no path".to_string(),
+            });
+        };
+        let meta = match fs::symlink_metadata(path) {
+            Ok(meta) => meta,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                return Ok(GcRevalidation::Skip {
+                    code: "state_changed".to_string(),
+                    reason: "partition disappeared before apply".to_string(),
+                });
+            }
+            Err(error) => return Err(OrbitError::from(error)),
+        };
+        if !meta.file_type().is_file() {
+            return Ok(GcRevalidation::Skip {
+                code: "not_a_file".to_string(),
+                reason: "candidate is no longer a regular file".to_string(),
+            });
+        }
+        // A size change means a writer touched the partition after planning —
+        // fail closed rather than deleting freshly appended telemetry.
+        if expected.bytes.is_some_and(|frozen| frozen != meta.len()) {
+            return Ok(GcRevalidation::Skip {
+                code: "state_changed".to_string(),
+                reason: "partition size changed after planning".to_string(),
+            });
+        }
+        let today = context.clock.now().date_naive();
+        if expected.partition_date >= today {
+            return Ok(GcRevalidation::Skip {
+                code: "open_partition".to_string(),
+                reason: "partition is no longer closed relative to the current day".to_string(),
+            });
+        }
+        Ok(GcRevalidation::Ready)
+    }
+}
+
+impl GcCollector for DiagnosticsGcCollector {
+    fn target(&self) -> GcTarget {
+        GcTarget::Diagnostics
+    }
+
+    fn plan(&self, context: &GcContext<'_>) -> Result<GcPlan, OrbitError> {
+        let today = context.clock.now().date_naive();
+        let mut plan = GcPlan::empty(GcTarget::Diagnostics);
+        plan.config_source = "gc.diagnostics".to_string();
+        for category in DiagnosticsCategory::ALL {
+            self.scan_category(category, today, &mut plan)?;
+        }
+        Ok(plan)
+    }
+
+    fn revalidate(
+        &self,
+        candidate: &GcCandidate,
+        context: &GcContext<'_>,
+    ) -> Result<GcRevalidation, OrbitError> {
+        self.revalidate_partition(candidate, context)
+    }
+
+    fn apply(
+        &self,
+        candidate: &GcCandidate,
+        _context: &GcContext<'_>,
+    ) -> Result<GcMutation, OrbitError> {
+        let path = candidate.path.as_ref().ok_or_else(|| {
+            OrbitError::Execution("diagnostics GC candidate has no path".to_string())
+        })?;
+        let bytes = fs::symlink_metadata(path)
+            .map(|meta| meta.len())
+            .ok()
+            .or(candidate.bytes);
+        fs::remove_file(path)?;
+        Ok(GcMutation {
+            reclaimed_bytes: bytes,
+        })
+    }
+}
+
+#[derive(Debug)]
+enum Classified {
+    Candidate(GcCandidate),
+    Skip(GcSkip),
+}
+
+/// Frozen partition identity carried from plan to apply so revalidation can
+/// detect drift (a writer touching the file, or the day rolling over).
+#[derive(Debug, Serialize, Deserialize)]
+struct ExpectedPartition {
+    category: String,
+    partition_date: NaiveDate,
+    bytes: Option<u64>,
+}
+
+fn file_name(path: &Path) -> String {
+    path.file_name()
+        .and_then(|name| name.to_str())
+        .map_or_else(|| path.display().to_string(), ToString::to_string)
+}
+
+/// Strict `YYYY-MM` validator. Returns the first-of-month date only when the
+/// name is exactly a zero-padded year-month, so ambiguously named directories
+/// are reported rather than swept.
+fn parse_year_month(name: &str) -> Option<NaiveDate> {
+    let bytes = name.as_bytes();
+    let well_formed = bytes.len() == 7
+        && bytes[4] == b'-'
+        && bytes[..4].iter().all(u8::is_ascii_digit)
+        && bytes[5..].iter().all(u8::is_ascii_digit);
+    if !well_formed {
+        return None;
+    }
+    NaiveDate::parse_from_str(&format!("{name}-01"), "%Y-%m-%d").ok()
+}
+
+/// Strict `DD.jsonl` validator composed against its month directory. Returns the
+/// full partition date only for a zero-padded two-digit day that forms a real
+/// calendar date (so `32.jsonl` or `30.jsonl` in February are rejected).
+fn parse_partition_date(month_name: &str, file_name: &str) -> Option<NaiveDate> {
+    let stem = file_name.strip_suffix(".jsonl")?;
+    if stem.len() != 2 || !stem.bytes().all(|byte| byte.is_ascii_digit()) {
+        return None;
+    }
+    let month = parse_year_month(month_name)?;
+    NaiveDate::parse_from_str(
+        &format!("{:04}-{:02}-{stem}", month.year(), month.month()),
+        "%Y-%m-%d",
+    )
+    .ok()
+}

--- a/crates/orbit-core/src/command/mod.rs
+++ b/crates/orbit-core/src/command/mod.rs
@@ -22,6 +22,7 @@ pub mod docs;
 pub mod executor;
 pub mod gc;
 pub mod gc_audit;
+pub mod gc_diagnostics;
 pub mod gc_logs;
 pub mod init;
 pub mod job;

--- a/crates/orbit-core/src/command/tests/gc_diagnostics.rs
+++ b/crates/orbit-core/src/command/tests/gc_diagnostics.rs
@@ -1,0 +1,295 @@
+//! [ORB-10185] Tests for the diagnostics telemetry stream GC collector.
+
+use std::collections::BTreeSet;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use chrono::{DateTime, TimeZone, Utc};
+use tempfile::TempDir;
+
+use crate::command::gc::{
+    GcClock, GcItemStatus, GcMode, GcOutcome, GcReport, GcRequest, GcScope, execute_gc,
+};
+use crate::command::gc_diagnostics::{DiagnosticsGcCollector, DiagnosticsGcPolicy};
+
+struct FakeClock(DateTime<Utc>);
+
+impl GcClock for FakeClock {
+    fn now(&self) -> DateTime<Utc> {
+        self.0
+    }
+}
+
+/// `today` for every fixture below is 2026-07-12 (UTC). Partition ages are
+/// derived from the file's calendar name, not its mtime, so tests never touch
+/// filesystem timestamps.
+fn fixed_now() -> DateTime<Utc> {
+    Utc.with_ymd_and_hms(2026, 7, 12, 12, 0, 0)
+        .single()
+        .expect("fixed time")
+}
+
+struct Fixture {
+    _temp: TempDir,
+    root: PathBuf,
+    state: PathBuf,
+    clock: FakeClock,
+}
+
+impl Fixture {
+    fn new() -> Self {
+        let temp = TempDir::new().expect("temp");
+        // Canonicalize so candidate containment (which canonicalizes the owned
+        // root) holds even when TMPDIR is a symlink (macOS /var -> /private/var).
+        let base = temp.path().canonicalize().expect("canonical temp");
+        let root = base.join("workspace");
+        let state = root.join("state");
+        fs::create_dir_all(&state).expect("state dir");
+        Self {
+            _temp: temp,
+            root,
+            state,
+            clock: FakeClock(fixed_now()),
+        }
+    }
+
+    fn write_partition(&self, category: &str, month: &str, day: &str, contents: &str) -> PathBuf {
+        write_partition_in(&self.root, category, month, day, contents)
+    }
+
+    fn collector(&self, policy: DiagnosticsGcPolicy) -> DiagnosticsGcCollector {
+        DiagnosticsGcCollector::new(&self.root, policy, None)
+    }
+
+    fn request(&self, apply: bool) -> GcRequest<'_> {
+        GcRequest {
+            apply,
+            scope: GcScope::Workspace {
+                workspace_id: None,
+                root: self.root.clone(),
+            },
+            retention_override: None,
+            global_state_dir: &self.state,
+            clock: &self.clock,
+        }
+    }
+}
+
+fn write_partition_in(
+    root: &Path,
+    category: &str,
+    month: &str,
+    day: &str,
+    contents: &str,
+) -> PathBuf {
+    let dir = root
+        .join("state")
+        .join("diagnostics")
+        .join(category)
+        .join(month);
+    fs::create_dir_all(&dir).expect("partition dir");
+    let path = dir.join(format!("{day}.jsonl"));
+    fs::write(&path, contents).expect("partition file");
+    path
+}
+
+fn policy(metrics: u64, friction: u64) -> DiagnosticsGcPolicy {
+    DiagnosticsGcPolicy {
+        metrics_retention_days: metrics,
+        friction_retention_days: friction,
+    }
+}
+
+fn eligible_ids(report: &GcReport) -> BTreeSet<String> {
+    report.targets[0]
+        .items
+        .iter()
+        .filter(|item| item.status == GcItemStatus::Eligible)
+        .map(|item| item.id.clone())
+        .collect()
+}
+
+fn reclaimed_ids(report: &GcReport) -> BTreeSet<String> {
+    report.targets[0]
+        .items
+        .iter()
+        .filter(|item| item.status == GcItemStatus::Reclaimed)
+        .map(|item| item.id.clone())
+        .collect()
+}
+
+fn skip_codes(report: &GcReport) -> BTreeSet<String> {
+    report.targets[0]
+        .skipped
+        .iter()
+        .map(|skip| skip.code.clone())
+        .collect()
+}
+
+#[test]
+fn plan_lists_closed_old_partitions_without_deleting_and_apply_reclaims_them() {
+    let fixture = Fixture::new();
+    // 2026-04-01 is 102 days before 2026-07-12 → past the 90-day window.
+    let old = fixture.write_partition("metrics", "2026-04", "01", "{\"ts\":\"x\"}\n");
+    // 2026-06-20 is only 22 days old → retained.
+    let recent = fixture.write_partition("metrics", "2026-06", "20", "{\"ts\":\"y\"}\n");
+    let collector = fixture.collector(policy(90, 90));
+
+    let plan = execute_gc(&collector, fixture.request(false)).expect("plan");
+    assert_eq!(plan.mode, GcMode::Plan);
+    assert_eq!(
+        eligible_ids(&plan),
+        BTreeSet::from(["metrics/2026-04/01.jsonl".to_string()])
+    );
+    assert_eq!(plan.targets[0].counts.reclaimed, 0);
+    assert!(old.exists(), "dry-run must not delete anything");
+    assert_eq!(plan.targets[0].items[0].action, "delete");
+
+    let apply = execute_gc(&collector, fixture.request(true)).expect("apply");
+    assert_eq!(apply.mode, GcMode::Apply);
+    assert_eq!(apply.outcome, GcOutcome::Clean);
+    assert_eq!(
+        reclaimed_ids(&apply),
+        BTreeSet::from(["metrics/2026-04/01.jsonl".to_string()])
+    );
+    assert!(!old.exists(), "closed partition past retention is deleted");
+    assert!(recent.exists(), "within-retention partition is kept");
+}
+
+#[test]
+fn current_day_partition_is_protected_from_the_active_writer() {
+    let fixture = Fixture::new();
+    // The writer appends to today's partition; even with a zero-day window it
+    // must never be eligible.
+    let today = fixture.write_partition("metrics", "2026-07", "12", "{\"ts\":\"live\"}\n");
+    let collector = fixture.collector(policy(0, 0));
+
+    let apply = execute_gc(&collector, fixture.request(true)).expect("apply");
+    assert_eq!(apply.outcome, GcOutcome::Clean);
+    assert!(eligible_ids(&apply).is_empty());
+    assert!(reclaimed_ids(&apply).is_empty());
+    assert!(today.exists(), "current-day partition survives");
+    assert!(
+        skip_codes(&apply).contains("open_partition"),
+        "current-day partition is reported as an open partition skip"
+    );
+}
+
+#[test]
+fn category_retention_overrides_are_independent() {
+    let fixture = Fixture::new();
+    // 2026-05-01 is 72 days before today: past friction's 30-day window but
+    // within metrics' 90-day window.
+    let metrics = fixture.write_partition("metrics", "2026-05", "01", "{\"ts\":\"m\"}\n");
+    let friction = fixture.write_partition("friction", "2026-05", "01", "{\"ts\":\"f\"}\n");
+    let collector = fixture.collector(policy(90, 30));
+
+    let apply = execute_gc(&collector, fixture.request(true)).expect("apply");
+    assert_eq!(apply.outcome, GcOutcome::Clean);
+    assert_eq!(
+        reclaimed_ids(&apply),
+        BTreeSet::from(["friction/2026-05/01.jsonl".to_string()]),
+        "only the diagnostic-friction partition ages out under its shorter window"
+    );
+    assert!(metrics.exists(), "metrics partition retained under 90d");
+    assert!(!friction.exists(), "friction partition reclaimed under 30d");
+}
+
+#[test]
+fn malformed_and_ambiguous_entries_are_reported_and_retained() {
+    let fixture = Fixture::new();
+    let diagnostics = fixture.root.join("state").join("diagnostics");
+    // Ambiguous month directory name.
+    let bad_month = diagnostics.join("metrics").join("2026-13");
+    fs::create_dir_all(&bad_month).expect("bad month");
+    let bad_month_file = bad_month.join("01.jsonl");
+    fs::write(&bad_month_file, "x").expect("bad month file");
+    // Stray file directly under the category root.
+    let stray = diagnostics.join("metrics").join("orphan.jsonl");
+    fs::create_dir_all(diagnostics.join("metrics")).expect("metrics dir");
+    fs::write(&stray, "x").expect("stray file");
+    // Non day-partition file name inside a valid month.
+    let bad_day = fixture.write_partition("metrics", "2026-04", "99", "x");
+    // A genuinely eligible partition still gets collected alongside the noise.
+    let good = fixture.write_partition("metrics", "2026-04", "01", "x");
+    let collector = fixture.collector(policy(90, 90));
+
+    let apply = execute_gc(&collector, fixture.request(true)).expect("apply");
+    // Malformed entries do not fail the run (they are evidence, not errors).
+    assert!(apply.targets[0].errors.is_empty());
+    assert!(
+        skip_codes(&apply).contains("malformed_partition"),
+        "malformed entries are reported as skips"
+    );
+    assert!(bad_month_file.exists(), "malformed month dir file retained");
+    assert!(stray.exists(), "stray file retained");
+    assert!(bad_day.exists(), "non-DD.jsonl file retained");
+    assert!(
+        !good.exists(),
+        "the valid eligible partition is still reclaimed"
+    );
+}
+
+#[test]
+fn apply_is_idempotent() {
+    let fixture = Fixture::new();
+    fixture.write_partition("metrics", "2026-04", "01", "x");
+    let collector = fixture.collector(policy(90, 90));
+
+    let first = execute_gc(&collector, fixture.request(true)).expect("first apply");
+    assert_eq!(first.targets[0].counts.reclaimed, 1);
+
+    let second = execute_gc(&collector, fixture.request(true)).expect("second apply");
+    assert_eq!(second.outcome, GcOutcome::Clean);
+    assert_eq!(second.targets[0].counts.reclaimed, 0);
+    assert!(eligible_ids(&second).is_empty());
+}
+
+#[test]
+fn collection_is_isolated_to_its_own_scope_root() {
+    let fixture = Fixture::new();
+    fixture.write_partition("metrics", "2026-04", "01", "x");
+    // A second, independent workspace root with an equally-aged partition.
+    let other_root = fixture.root.parent().expect("base").join("other-workspace");
+    fs::create_dir_all(other_root.join("state")).expect("other state");
+    let other = write_partition_in(&other_root, "metrics", "2026-04", "01", "x");
+    let collector = fixture.collector(policy(90, 90));
+
+    let apply = execute_gc(&collector, fixture.request(true)).expect("apply");
+    assert_eq!(apply.targets[0].counts.reclaimed, 1);
+    assert!(
+        other.exists(),
+        "a partition under a different scope root is never touched"
+    );
+}
+
+#[test]
+fn reader_stays_correct_after_older_partitions_are_removed() {
+    let fixture = Fixture::new();
+    fixture.write_partition("metrics", "2026-04", "01", "{\"ts\":\"old\"}\n");
+    let kept = fixture.write_partition("metrics", "2026-06", "20", "{\"ts\":\"kept\"}\n");
+    let collector = fixture.collector(policy(90, 90));
+
+    execute_gc(&collector, fixture.request(true)).expect("apply");
+
+    // The retained partition is untouched and its month directory still reads
+    // back cleanly; the reclaimed month simply has no files left.
+    assert!(kept.exists());
+    assert_eq!(
+        fs::read_to_string(&kept).expect("kept readable"),
+        "{\"ts\":\"kept\"}\n"
+    );
+    let removed_month = fixture
+        .root
+        .join("state")
+        .join("diagnostics")
+        .join("metrics")
+        .join("2026-04");
+    let remaining: Vec<_> = fs::read_dir(&removed_month)
+        .map(|dir| dir.filter_map(Result::ok).map(|e| e.path()).collect())
+        .unwrap_or_default();
+    assert!(
+        remaining.is_empty(),
+        "reclaimed month directory has no partition files left"
+    );
+}

--- a/crates/orbit-core/src/command/tests/mod.rs
+++ b/crates/orbit-core/src/command/tests/mod.rs
@@ -1,6 +1,7 @@
 mod executor;
 mod gc;
 mod gc_audit;
+mod gc_diagnostics;
 mod gc_logs;
 mod review_thread_hook;
 mod skill_gc;

--- a/crates/orbit-core/src/config/raw.rs
+++ b/crates/orbit-core/src/config/raw.rs
@@ -30,6 +30,18 @@ pub(super) struct RawRuntimeConfig {
 pub(super) struct RawGcConfig {
     pub(super) worktrees: Option<RawWorktreeGcConfig>,
     pub(super) runs: Option<RawRunGcConfig>,
+    pub(super) diagnostics: Option<RawDiagnosticsGcConfig>,
+}
+
+#[derive(Debug, Clone, Default, Deserialize, Serialize)]
+pub(super) struct RawDiagnosticsGcConfig {
+    /// Days to retain closed metrics day-partitions before they are eligible
+    /// for collection. Zero collects every closed (non-current-day) partition.
+    pub(super) metrics_retention_days: Option<u64>,
+    /// Days to retain closed diagnostic-friction day-partitions. Canonical
+    /// `.orbit/frictions` records are never affected by this — only the
+    /// append-only telemetry under `state/diagnostics/friction`.
+    pub(super) friction_retention_days: Option<u64>,
 }
 
 #[derive(Debug, Clone, Default, Deserialize, Serialize)]

--- a/crates/orbit-core/src/config/registry.rs
+++ b/crates/orbit-core/src/config/registry.rs
@@ -53,6 +53,16 @@ pub const CONFIG_KEY_REGISTRY: &[ConfigKeyDescriptor] = &[
         description: "Environment variable names allow-listed for passthrough into agent subprocesses.",
     },
     ConfigKeyDescriptor {
+        key: "gc.diagnostics.friction_retention_days",
+        value_type: "integer",
+        description: "Days to retain closed diagnostic-friction telemetry day-partitions under state/diagnostics/friction (canonical .orbit/frictions records are never affected).",
+    },
+    ConfigKeyDescriptor {
+        key: "gc.diagnostics.metrics_retention_days",
+        value_type: "integer",
+        description: "Days to retain closed metrics telemetry day-partitions under state/diagnostics/metrics.",
+    },
+    ConfigKeyDescriptor {
         key: "gc.runs.archive_after_days",
         value_type: "integer",
         description: "Days after a successful/cancelled terminal transition before a job run is archived.",

--- a/crates/orbit-core/src/config/runtime.rs
+++ b/crates/orbit-core/src/config/runtime.rs
@@ -34,6 +34,11 @@ const DEFAULT_WORKFLOW_BASE_BRANCH: &str = "main";
 const DEFAULT_WORKFLOW_CREW: &str = "claude";
 pub(crate) const DEFAULT_WORKTREE_SUCCESS_RETENTION_DAYS: u64 = 0;
 pub(crate) const DEFAULT_WORKTREE_FAILURE_RETENTION_DAYS: u64 = 7;
+/// Default retention (in days) for closed diagnostics telemetry day-partitions.
+/// Diagnostic streams are unbounded append-only JSONL; ninety days keeps the
+/// dashboard's rolling history intact while bounding disk growth.
+pub(crate) const DEFAULT_DIAGNOSTICS_METRICS_RETENTION_DAYS: u64 = 90;
+pub(crate) const DEFAULT_DIAGNOSTICS_FRICTION_RETENTION_DAYS: u64 = 90;
 const CONSTELLATION_DEFAULT_PROVIDER_ENV: &str = "CONSTELLATION_DEFAULT_PROVIDER";
 
 #[derive(Debug, Clone)]
@@ -66,6 +71,10 @@ pub(crate) struct RuntimeConfig {
     pub(crate) run_gc_purge_after_days: u64,
     pub(crate) run_gc_failure_archive_after_days: u64,
     pub(crate) run_gc_failure_purge_after_days: u64,
+    /// Days to retain closed diagnostics metrics/friction day-partitions
+    /// (`[gc.diagnostics]`). See `orbit gc diagnostics`.
+    pub(crate) diagnostics_gc_metrics_retention_days: u64,
+    pub(crate) diagnostics_gc_friction_retention_days: u64,
     /// Named provider-model assignments from `[crews.<name>]`.
     pub(crate) crews: BTreeMap<String, Crew>,
     pub(crate) default_crew: Option<String>,
@@ -125,6 +134,8 @@ impl RuntimeConfig {
             run_gc_purge_after_days: 30,
             run_gc_failure_archive_after_days: 30,
             run_gc_failure_purge_after_days: 90,
+            diagnostics_gc_metrics_retention_days: DEFAULT_DIAGNOSTICS_METRICS_RETENTION_DAYS,
+            diagnostics_gc_friction_retention_days: DEFAULT_DIAGNOSTICS_FRICTION_RETENTION_DAYS,
             crews: default_crews(),
             default_crew: Some(DEFAULT_WORKFLOW_CREW.to_string()),
             duel: DuelConfig::default(),
@@ -242,6 +253,8 @@ impl RuntimeConfig {
             run_gc_failure_archive_after_days,
             run_gc_failure_purge_after_days,
         ) = run_gc_retention_from_raw(parsed.gc.as_ref())?;
+        let (diagnostics_gc_metrics_retention_days, diagnostics_gc_friction_retention_days) =
+            diagnostics_gc_retention_from_raw(parsed.gc.as_ref());
         let crews = crews_from_raw(parsed.crews.as_ref())?;
         let default_crew = workflow_default_crew_from_raw(parsed.workflow.as_ref(), &crews)?;
         let duel = duel_from_raw(parsed.duel.as_ref())?;
@@ -279,6 +292,8 @@ impl RuntimeConfig {
             run_gc_purge_after_days,
             run_gc_failure_archive_after_days,
             run_gc_failure_purge_after_days,
+            diagnostics_gc_metrics_retention_days,
+            diagnostics_gc_friction_retention_days,
             crews,
             default_crew,
             duel,
@@ -323,6 +338,15 @@ impl RuntimeConfig {
             self.run_gc_purge_after_days,
             self.run_gc_failure_archive_after_days,
             self.run_gc_failure_purge_after_days,
+        )
+    }
+
+    /// Closed diagnostics day-partition retention in days, as
+    /// `(metrics, friction)`.
+    pub(crate) fn diagnostics_gc_retention_days(&self) -> (u64, u64) {
+        (
+            self.diagnostics_gc_metrics_retention_days,
+            self.diagnostics_gc_friction_retention_days,
         )
     }
 
@@ -728,6 +752,18 @@ fn run_gc_retention_from_raw(
         ));
     }
     Ok((archive, purge, failure_archive, failure_purge))
+}
+
+fn diagnostics_gc_retention_from_raw(raw: Option<&RawGcConfig>) -> (u64, u64) {
+    let diagnostics = raw.and_then(|gc| gc.diagnostics.as_ref());
+    (
+        diagnostics
+            .and_then(|diagnostics| diagnostics.metrics_retention_days)
+            .unwrap_or(DEFAULT_DIAGNOSTICS_METRICS_RETENTION_DAYS),
+        diagnostics
+            .and_then(|diagnostics| diagnostics.friction_retention_days)
+            .unwrap_or(DEFAULT_DIAGNOSTICS_FRICTION_RETENTION_DAYS),
+    )
 }
 
 fn workflow_base_branch_from_raw(raw: Option<&RawWorkflowConfig>) -> Result<String, OrbitError> {

--- a/crates/orbit-core/src/config/store.rs
+++ b/crates/orbit-core/src/config/store.rs
@@ -289,6 +289,8 @@ pub struct ConfigSnapshot {
     pub run_gc_purge_after_days: u64,
     pub run_gc_failure_archive_after_days: u64,
     pub run_gc_failure_purge_after_days: u64,
+    pub diagnostics_gc_metrics_retention_days: u64,
+    pub diagnostics_gc_friction_retention_days: u64,
     pub tasks_id_start: Option<u32>,
     pub duel_candidates: Vec<String>,
     pub duel_models: std::collections::BTreeMap<String, String>,
@@ -305,6 +307,7 @@ impl From<&RuntimeConfig> for ConfigSnapshot {
         let log_rotation = config.log_rotation();
         let (run_archive, run_purge, run_failure_archive, run_failure_purge) =
             config.run_gc_retention_days();
+        let (diagnostics_metrics, diagnostics_friction) = config.diagnostics_gc_retention_days();
         Self {
             execution_env_inherit: config.execution_env.inherit(),
             execution_env_pass: config.execution_env.pass().to_vec(),
@@ -331,6 +334,8 @@ impl From<&RuntimeConfig> for ConfigSnapshot {
             run_gc_purge_after_days: run_purge,
             run_gc_failure_archive_after_days: run_failure_archive,
             run_gc_failure_purge_after_days: run_failure_purge,
+            diagnostics_gc_metrics_retention_days: diagnostics_metrics,
+            diagnostics_gc_friction_retention_days: diagnostics_friction,
             tasks_id_start: config.tasks_id_start(),
             duel_candidates: config.duel_config().candidates.clone(),
             duel_models: config.duel_config().models.clone(),
@@ -351,6 +356,12 @@ impl ConfigSnapshot {
             "execution.codex.sandbox" => json!(self.codex_sandbox),
             "execution.env.pass" => json!(self.execution_env_pass),
             "graph.editing" => json!(self.graph_editing),
+            "gc.diagnostics.friction_retention_days" => {
+                json!(self.diagnostics_gc_friction_retention_days)
+            }
+            "gc.diagnostics.metrics_retention_days" => {
+                json!(self.diagnostics_gc_metrics_retention_days)
+            }
             "gc.runs.archive_after_days" => json!(self.run_gc_archive_after_days),
             "gc.runs.purge_after_days" => json!(self.run_gc_purge_after_days),
             "gc.runs.failure_archive_after_days" => {

--- a/crates/orbit-core/src/config/tests/runtime.rs
+++ b/crates/orbit-core/src/config/tests/runtime.rs
@@ -530,3 +530,15 @@ fn run_gc_archive_and_purge_ages_are_independently_configurable_and_ordered() {
         .expect_err("purge before archive must fail");
     assert!(error.to_string().contains("purge ages"), "{error}");
 }
+
+#[test]
+fn diagnostics_gc_retention_classes_are_independently_configurable() {
+    let defaults = load_config("").expect("default config loads");
+    assert_eq!(defaults.diagnostics_gc_retention_days(), (90, 90));
+
+    let configured = load_config(
+        "[gc.diagnostics]\nmetrics_retention_days = 30\nfriction_retention_days = 180\n",
+    )
+    .expect("diagnostics retention config loads");
+    assert_eq!(configured.diagnostics_gc_retention_days(), (30, 180));
+}

--- a/crates/orbit-core/src/context.rs
+++ b/crates/orbit-core/src/context.rs
@@ -195,6 +195,7 @@ pub(crate) struct OrbitRuntimeSettings {
     worktree_gc_success_retention_days: u64,
     worktree_gc_failure_retention_days: u64,
     run_gc_retention_days: (u64, u64, u64, u64),
+    diagnostics_gc_retention_days: (u64, u64),
     crews: std::collections::BTreeMap<String, Crew>,
     default_crew: Option<String>,
     duel: DuelConfig,
@@ -217,6 +218,7 @@ impl OrbitRuntimeSettings {
         worktree_gc_success_retention_days: u64,
         worktree_gc_failure_retention_days: u64,
         run_gc_retention_days: (u64, u64, u64, u64),
+        diagnostics_gc_retention_days: (u64, u64),
         crews: std::collections::BTreeMap<String, Crew>,
         default_crew: Option<String>,
         duel: DuelConfig,
@@ -236,6 +238,7 @@ impl OrbitRuntimeSettings {
             worktree_gc_success_retention_days,
             worktree_gc_failure_retention_days,
             run_gc_retention_days,
+            diagnostics_gc_retention_days,
             crews,
             default_crew,
             duel,
@@ -272,6 +275,10 @@ impl OrbitRuntimeSettings {
 
     pub(crate) fn run_gc_retention_days(&self) -> (u64, u64, u64, u64) {
         self.run_gc_retention_days
+    }
+
+    pub(crate) fn diagnostics_gc_retention_days(&self) -> (u64, u64) {
+        self.diagnostics_gc_retention_days
     }
 
     pub(crate) fn crews(&self) -> &std::collections::BTreeMap<String, Crew> {
@@ -422,6 +429,10 @@ impl OrbitContext {
 
     pub(crate) fn run_gc_retention_days(&self) -> (u64, u64, u64, u64) {
         self.runtime.run_gc_retention_days()
+    }
+
+    pub(crate) fn diagnostics_gc_retention_days(&self) -> (u64, u64) {
+        self.runtime.diagnostics_gc_retention_days()
     }
 
     pub(crate) fn crews(&self) -> &std::collections::BTreeMap<String, Crew> {

--- a/crates/orbit-core/src/runtime/builder.rs
+++ b/crates/orbit-core/src/runtime/builder.rs
@@ -147,6 +147,7 @@ pub(crate) fn build_context_from_roots(
     let worktree_gc_success_retention_days = runtime_config.worktree_gc_success_retention_days();
     let worktree_gc_failure_retention_days = runtime_config.worktree_gc_failure_retention_days();
     let run_gc_retention_days = runtime_config.run_gc_retention_days();
+    let diagnostics_gc_retention_days = runtime_config.diagnostics_gc_retention_days();
     let crews = runtime_config.crews.clone();
     let default_crew = runtime_config.default_crew.clone();
     let duel = runtime_config.duel_config().clone();
@@ -193,6 +194,7 @@ pub(crate) fn build_context_from_roots(
             worktree_gc_success_retention_days,
             worktree_gc_failure_retention_days,
             run_gc_retention_days,
+            diagnostics_gc_retention_days,
             crews,
             default_crew,
             duel,

--- a/crates/orbit-core/src/runtime/mod.rs
+++ b/crates/orbit-core/src/runtime/mod.rs
@@ -385,6 +385,12 @@ impl OrbitRuntime {
         self.context.run_gc_retention_days()
     }
 
+    /// Closed diagnostics day-partition retention in days, as
+    /// `(metrics, friction)`. Consulted by `orbit gc diagnostics`.
+    pub fn diagnostics_gc_retention_days(&self) -> (u64, u64) {
+        self.context.diagnostics_gc_retention_days()
+    }
+
     /// Returns the configured `[duel] candidates` list (e.g. ["codex", "claude", "gemini", "grok"]).
     /// Used by `orbit run duel-plan --planner-a ...` overrides to validate explicit families.
     pub fn duel_candidate_families(&self) -> Vec<String> {

--- a/docs/design/gc/1_overview.md
+++ b/docs/design/gc/1_overview.md
@@ -68,7 +68,7 @@ Cargo, Gradle, Python, or Node caches outside one are not GC candidates.
 - [ORB-10182] — will implement managed worktree collection.
 - [ORB-10183] — implemented staged terminal run archival and purge.
 - [ORB-10184] — will implement operational log collection.
-- [ORB-10185] — will implement diagnostics collection.
+- [ORB-10185] — implemented diagnostics stream collection.
 - [ORB-10186] — will implement audit retention and blob reachability.
 - [ORB-10187] — will implement generated-skill collection.
 - [ORB-10188] — will implement terminal task archival.

--- a/docs/design/gc/2_design.md
+++ b/docs/design/gc/2_design.md
@@ -169,10 +169,18 @@ not skipped. Journald, system logs, and third-party logs are out of scope.
 ### 3.4 Diagnostics (workspace)
 
 This collector owns closed metrics and diagnostic-friction JSONL partitions
-under the workspace diagnostics root. Its clock is the partition boundary plus
-persisted record/closure timestamps. The current partition, writer-owned files,
-malformed partitions, canonical friction records, tasks, learnings, and audit
-evidence are protected.
+under the workspace diagnostics root (`state/diagnostics/{metrics,friction}`).
+Each stream is day-partitioned (`<category>/YYYY-MM/DD.jsonl`) and the writer
+only ever appends to the current-day partition, so the clock is the partition's
+calendar day: a partition is *closed* once its day is strictly in the past. A
+closed partition is eligible only when its age exceeds the category-specific
+retention window — `[gc.diagnostics] metrics_retention_days` /
+`friction_retention_days`, default 90 days each, uniformly overridable by
+`--retention`. The current-day (and any future-dated) partition, malformed or
+ambiguously named files, canonical `.orbit/frictions` records, tasks, learnings,
+and audit evidence are never candidates; malformed files are reported as skips
+and retained. The partition-closure rule protects the live writer without any
+cross-process file lock. [ORB-10185]
 
 ### 3.5 Audit (workspace and global)
 
@@ -502,7 +510,7 @@ that same gate on a schedule.
 - [ORB-10182] — implemented managed worktree collection and terminal cleanup reuse.
 - [ORB-10183] — implemented staged terminal run archival and purge (rowless legacy bundles share the persisted-row protections; `runs` refuses `--global`).
 - [ORB-10184] — unified log retention: `orbit gc logs` + shared `plan_prune` (ADR-0221).
-- [ORB-10185] — will implement diagnostics retention.
+- [ORB-10185] — implemented diagnostics retention (`gc_diagnostics::DiagnosticsGcCollector`, `orbit gc diagnostics`; category-specific `[gc.diagnostics]` windows).
 - [ORB-10186] — will implement audit and blob collection.
 - [ORB-10187] — implemented generated-skill collection (`skill_gc::SkillsGcCollector`).
 - [ORB-10188] — implemented task archival (`TaskGcCollector`, `orbit gc tasks`).


### PR DESCRIPTION
## Task

[ORB-10185](https://orbit-cli.com/tasks/ORB-10185) — Add diagnostics stream GC

### Description

## Problem

Workspace diagnostics are append-only JSONL partitions under `.orbit/state/diagnostics/{metrics,friction}` with no retention/prune path.

## Why It Matters

Diagnostic telemetry should remain useful and bounded, but it must not be confused with canonical friction records or pruned while the current partition is being written.

## Scope

Implement `orbit gc diagnostics` with category-specific retention for closed metrics and diagnostic-friction partitions.

## Constraints / Notes

- Canonical `.orbit/frictions` records and durable knowledge are never candidates.
- Current/open partitions require writer coordination and are retained.
- Malformed files are diagnostic evidence: report and retain them.

### Acceptance Criteria

- `orbit gc diagnostics` covers metrics and diagnostic-friction JSONL partitions under the workspace diagnostics root.
- Canonical friction records, tasks, audit evidence, and other durable knowledge are explicitly excluded.
- Only closed partitions older than category-specific configured retention are eligible; current-day/month writers are protected by locking or partition closure rules.
- Malformed or ambiguously named files are reported and retained.
- Dashboard and diagnostic readers remain correct when older partitions are absent.
- Reports include category, partition, age, bytes, and skip/error reason.
- Tests cover active writer, closed old partition, category overrides, malformed files, dry-run parity, cross-workspace isolation, and idempotency.
- `make ci-fast` and focused diagnostics/dashboard tests pass.

## Execution Summary

<details>
<summary>Click to expand</summary>

Implemented `orbit gc diagnostics`: a DiagnosticsGcCollector (crates/orbit-core/src/command/gc_diagnostics.rs) that reclaims closed metrics/diagnostic-friction JSONL day-partitions under <scope>/state/diagnostics/{metrics,friction}.

Model: each stream is day-partitioned as <category>/YYYY-MM/DD.jsonl; the writer only appends to the current-day partition. Partition-closure rule = a partition is closed once its calendar day is strictly in the past, so the current-day (and any future-dated) partition is protected with no cross-process lock. A closed partition is eligible only when age (today - partition_date, in days) exceeds the category-specific retention window.

Retention config: new [gc.diagnostics] metrics_retention_days / friction_retention_days (default 90d each), threaded through RawGcConfig -> RuntimeConfig -> OrbitRuntimeSettings/OrbitContext -> OrbitRuntime::diagnostics_gc_retention_days(); uniform --retention override applies to both streams. Also registered both keys in the config registry + ConfigSnapshot so `orbit config get/set` works.

Safety: canonical .orbit/frictions, tasks, learnings, and audit evidence are never candidates (scan is scoped to the two telemetry dirs). Malformed/ambiguous entries (non-YYYY-MM month dirs, non-DD.jsonl files, stray files, nested dirs) are reported as `malformed_partition` skips and always retained. Deletion goes through the shared GC framework's plan-first/apply gate, revalidation (size-change + day-rollover detection), containment/no-follow checks, and manifest (ADR-0220). Dashboard/diagnostic readers remain correct: absent partitions already read back empty.

CLI: crates/orbit-cli/src/command/gc.rs dispatches the Diagnostics target to the new collector (was EmptyGcCollector); included in the selected_runtime set so cross-workspace scope loads the right config.

Tests: crates/orbit-core/src/command/tests/gc_diagnostics.rs (7 tests: dry-run parity + closed-old reclaim, active-writer protection, category overrides, malformed reported+retained, idempotency, cross-workspace isolation, reader-after-removal) + config parse test in config/tests/runtime.rs. Docs: updated GC design docs (1_overview §Task References, 2_design §3.4 + references) to reflect the shipped collector.

Validation: cargo fmt --check OK; clippy clean on orbit-core+orbit-cli; new + existing gc/config/CLI-gc tests pass (25 focused + 14 CLI gc + 111 core gc/config). `make ci-fast` guardrails all pass EXCEPT ./scripts/test-installer-security.sh, which cannot run here because `node` is not on PATH (environment limitation, unrelated to this change); the CI merge gate runs it unrestricted.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10185-6a545100`
- Behind base: 0
- Ahead of base: 1