### PR TITLE
Fix activity catalog precedence doc/code mismatch in activity-job design doc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- **Activity/job precedence docs match execution trust rules**: the design now distinguishes workspace-preferred job listings from default-authoritative named job and activity execution. ([ORB-10203])
 - **Systemd routine workers survive sweep exit**: the user sweep service now limits shutdown to its main oneshot process, allowing detached pipeline workers to claim and complete clock-dispatched runs. ([ORB-10153])
 - **Task creation surface is narrower and consistent**: task creation now exposes only legal initial statuses, list flags share repeat/comma parsing, and redundant agent/comment/instructions inputs are removed while model and managed identity attribution remain intact. ([ORB-10155])
 

--- a/docs/design/activity-job/2_design.md
+++ b/docs/design/activity-job/2_design.md
@@ -3,7 +3,7 @@ summary: "Activity / Job — Design"
 type: design
 title: "Activity / Job — Design"
 owner: codex
-last_updated: 2026-07-11
+last_updated: 2026-07-14
 status: Draft
 feature: activity-job
 doc_role: design
@@ -101,9 +101,13 @@ Step-level `default_input` is still recursively template-rendered before dispatc
 
 orbit-core normalizes raw YAML before dispatch.
 
-Catalog-discovered v2 jobs use `MergeByKey` precedence after [T20260425-0204]: `ORBIT_JOB_DIR` / `ORBIT_V2_JOB_DIR` entries first, then workspace jobs, then global seeded jobs. The first valid `metadata.name` wins, so a workspace `task_auto_pipeline` overrides the global default without making `orbit run ship` fail. Duplicate names inside one directory tree remain invalid because that single layer would otherwise be ambiguous.
+Job catalog listing uses `MergeByKey` precedence after [T20260425-0204]: `ORBIT_JOB_DIR` / `ORBIT_V2_JOB_DIR` entries first, then workspace jobs, then global seeded jobs. The first valid `metadata.name` wins, so listing can show a workspace `task_auto_pipeline` in place of the global default without making the catalog ambiguous. Duplicate names inside one directory tree remain invalid because that single layer would otherwise be ambiguous.
 
-Activity catalogs follow the same first-wins rule after [T20260426-0047]: `ORBIT_ACTIVITY_DIR` / `ORBIT_V2_CATALOG_DIR` entries first, then workspace activities, then global seeded activities. This lets a workspace carry an override such as `pr_open` without `orbit activity list --ops` failing on the duplicate global default. Duplicate names inside one activity directory tree remain invalid.
+Job execution deliberately has a different order: explicit `ORBIT_JOB_DIR` / `ORBIT_V2_JOB_DIR` entries, then global seeded jobs, then workspace jobs only for names that are not shipped defaults. Thus an explicit environment catalog can opt in to a replacement for testing or smoke runs, but a workspace-local file cannot shadow a shipped job when Orbit resolves that job by name for execution.
+
+Activity resolution is likewise execution-oriented, but its directory order is explicit `ORBIT_ACTIVITY_DIR` / `ORBIT_V2_CATALOG_DIR`, then global seeded activities, then workspace activities. Explicit and global directories use first-wins loading. Workspace activities may add names that are absent from the catalog, but any workspace name matching a shipped default is skipped even if the global file is missing; a workspace activity also cannot replace an earlier explicit or global entry. Duplicate names inside one activity directory tree remain invalid.
+
+This is an intentional default-shadowing asymmetry: job *listing* is workspace-preferred, while named job execution and activity resolution keep shipped defaults authoritative over workspace resources. The split follows [L-0060] and its originating security fix [ORB-00356]: display/catalog override semantics must not make checked-in workspace YAML executable in place of a trusted shipped default. That learning is the rationale; the runtime and job catalog code are authoritative for the exact loading behavior.
 
 Direct single-activity runtime helpers:
 


### PR DESCRIPTION
## Task

[ORB-10203](https://orbit-cli.com/tasks/ORB-10203) — Fix activity catalog precedence doc/code mismatch in activity-job design doc

### Description

Found during verification of the 2026-07-14 architecture review. `docs/design/activity-job/2_design.md:104–106` states activities load env→workspace→global ("the same first-wins rule" as jobs), but the code (`runtime/mod.rs:494–505`) loads env→global→workspace and relies on the default-name skip (`:437–439`) to get intended precedence — activities can add but never shadow defaults, which is NOT symmetric with job listing behavior. Update the doc to describe the actual asymmetry (job listing vs job execution vs activity orders), citing L-0060 for why execution resolution keeps shipped defaults authoritative. Doc-only change; no code.

### Acceptance Criteria

- 2_design.md accurately describes job listing, job execution, and activity dir orders as implemented
- The default-shadowing asymmetry between jobs and activities is stated explicitly
- L-0060 / ORB-00356 referenced as rationale

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Corrected the Activity / Job design’s precedence model: job catalog listing remains env → workspace → global, while named job execution is env → global → non-default workspace.
- Documented activity resolution as env → global → workspace additions, including the rule that workspace assets cannot shadow shipped defaults even if the global file is absent.
- Stated the intentional listing-versus-execution default-shadowing asymmetry and cited L-0060 / ORB-00356.
- Updated the document timestamp and added the required terse Unreleased entry.

Assessment: Documentation now matches the authoritative runtime and catalog behavior; no production code changed.

Validation:
- Passed `cargo fmt --all -- --check` (run by `make ci-fast`).
- Passed dependency-direction, CLI-import, stability, learning-layout, artifact-redaction, changelog freshness/style guardrails, and `git diff --check`.
- `make ci-fast` could not complete because `scripts/test-installer-security.sh` requires `node`, which is not installed in this runner; this is unrelated to the documentation-only change.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10203-6a56a465`
- Behind base: 0
- Ahead of base: 1