### PR TITLE
Seed opt-in workspace ship-sweep routines [ORB-10207]

### DIFF
--- a/.orbit/adrs/accepted/ADR-0215/adr.yaml
+++ b/.orbit/adrs/accepted/ADR-0215/adr.yaml
@@ -5,15 +5,17 @@ status: accepted
 owner: claude
 created_at: 2026-07-11T21:51:13.196368558Z
 accepted_at: 2026-07-11T21:51:20.761360481Z
-last_updated: 2026-07-11T21:51:20.761360481Z
+last_updated: 2026-07-15T22:19:13.397683324Z
 related_features:
 - routines
 related_tasks:
 - ORB-10129
+- ORB-10207
 tags:
 - routines
 - default-assets
 - triage
+- ship-sweep
 paths:
 - crates/orbit-core/assets/routines/**
 - crates/orbit-core/src/command/routine.rs

--- a/.orbit/adrs/accepted/ADR-0215/body.md
+++ b/.orbit/adrs/accepted/ADR-0215/body.md
@@ -1,11 +1,11 @@
 ## Context
-ORB-10129 ships the triage pipeline as a default, but routines have no global directory: discovery reads `.orbit/routines/*.yaml` from `[routines] role = "source"` workspaces, v1 requires explicit host pinning (no "any host"), and routine names must be unique across all sources on a host — so a static shipped YAML cannot work. The real alternatives were leaving the triage routine workspace-authored (no out-of-the-box self-healing) or adding a global routines directory (a discovery-model change ADR-0205 deliberately avoided).
+ORB-10129 ships the triage pipeline as a default, but routines have no global directory: discovery reads `.orbit/routines/*.yaml` from `[routines] role = "source"` workspaces, v1 requires explicit host pinning (no "any host"), and routine names must be unique across all sources on a host — so a static shipped YAML cannot work. The real alternatives were leaving defaults workspace-authored from scratch or adding a global routines directory (a discovery-model change ADR-0205 deliberately avoided).
 
 ## Decision
-`orbit init` (workspace branch) seeds `DEFAULT_ROUTINE_FILES` templates into `.orbit/routines/`, resolving `__ORBIT_HOST_ID__` via `resolve_host_id` and `__ORBIT_ROUTINE_NAME__` from a workspace-directory slug (`task-triage-<workspace>`), validating each rendered document fail-closed before writing. Plain re-init preserves user edits; `--refresh-defaults`/`--force` re-render. Seeded routines are inert until the workspace opts into `[routines] role = "source"`.
+`orbit init` (workspace branch) seeds `DEFAULT_ROUTINE_FILES` templates into `.orbit/routines/`, resolving `__ORBIT_HOST_ID__` via `resolve_host_id` and `__ORBIT_ROUTINE_NAME__` from a workspace-directory slug, validating each rendered document fail-closed before writing. Every default is disabled. Plain re-init creates missing defaults while preserving existing definitions byte-for-byte; destructive `--force` recreates templates. A routine fires only after the workspace is a routine source and its versioned `enabled` field is set true.
 
 ## Consequences
-- A fresh workspace gets working periodic triage (hourly, `overlap: forbid`, sparser than the ~20-minute ship sweep) the moment it becomes a routine source — no bespoke per-box scripting.
+- Fresh workspaces get reviewable routine definitions without silently granting scheduled execution.
 - Per-workspace names let multiple seeded source workspaces coexist on one host despite the global name-uniqueness rule.
-- The seeded file pins the initializing host; sharing the repo to another host needs a re-init with `--refresh-defaults` or a hand edit of `hosts:`.
-- Cost: `orbit init` output now depends on the machine it runs on (host id, directory name) — two clones of the same repo can carry differently-rendered routine files, and identical workspace directory names on one host still collide fail-closed.
+- The seeded file pins the initializing host; sharing the repo to another host needs a hand edit of `hosts:` or recreation during destructive initialization.
+- Cost: `orbit init` output depends on the machine it runs on (host id, directory name), and routine template improvements do not overwrite existing workspace-authored files.

--- a/.orbit/adrs/accepted/ADR-0223/adr.yaml
+++ b/.orbit/adrs/accepted/ADR-0223/adr.yaml
@@ -1,0 +1,24 @@
+schema_version: 2
+id: ADR-0223
+title: Delegate workspace ship routines through a synchronous wrapper job
+status: accepted
+owner: codex
+created_at: 2026-07-15T22:14:11.893535040Z
+accepted_at: 2026-07-15T22:19:13.834542981Z
+last_updated: 2026-07-15T22:19:13.834542981Z
+related_features:
+- routines
+- activity-job
+related_tasks:
+- ORB-10207
+tags:
+- routines
+- ship-sweep
+paths:
+- crates/orbit-core/assets/routines/**
+- crates/orbit-core/assets/jobs/**
+- crates/orbit-core/src/runtime/v2_host/**
+supersedes: []
+legacy_ids: []
+validation_warnings: []
+legacy_validation: none

--- a/.orbit/adrs/accepted/ADR-0223/body.md
+++ b/.orbit/adrs/accepted/ADR-0223/body.md
@@ -1,0 +1,11 @@
+## Context
+A scheduled ship routine must dispatch only its source workspace, resolve that workspace ship mode and base branch, and keep the parent run active until normal backlog shipment finishes. The alternatives were special-casing routine dispatch, spawning the legacy multi-workspace CLI sweep, or composing the existing job catalog.
+
+## Decision
+Seed a workspace-local ship-sweep routine targeting a shipped wrapper job. The wrapper deterministically resolves ship input for its active runtime, invokes `task_auto_pipeline` with no explicit task IDs, waits for it, and guards child success; it does not consult `workflow.auto_ship` or the cross-workspace sweep path.
+
+## Consequences
+- Backlog discovery, readiness, locking, bundling, crew selection, and gates remain owned by `task_auto_pipeline`.
+- `overlap: forbid` covers the child shipment because the wrapper does not finish before the child.
+- The legacy global ship-sweep remains compatible during burn-in but is not used by routines.
+- Cost: the catalog gains a small wrapper job and deterministic resolver activity whose input contract must stay aligned with the canonical ship workflow.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - **Store schema v4 compatibility restored**: the append-only `job_run_archive_stage` migration remains supported after an `agent-main` history rewrite dropped its registry entry, so current CLIs reopen already-upgraded stores without a destructive downgrade. ([ORB-10209])
+- **Workspace routines are opt-in**: init seeds disabled auto-task, triage, and workspace-local ship-sweep definitions, preserves authored routines on re-init, and delegates shipment synchronously to the normal backlog pipeline. ([ORB-10207])
 - **Legacy task friction status removed**: tasks no longer deserialize, list, update, admit, or render `status: friction`; standalone friction artifacts are the only supported surface. Task attribution and record-parameter construction now share implementations without changing admission or triage behavior. ([ORB-10202])
 - **Activity and job catalogs share layered loading**: typed adapters now share recursive discovery, directory deduplication, first-wins layering, and duplicate detection while preserving their distinct precedence and validation policies. ([ORB-10201])
 - **Configuration admission is table-driven**: fixed settings now declare parsing, defaults, validation metadata, and CLI projection once, with generated registry/snapshot lookup completeness checks. ([ORB-10199])

--- a/crates/orbit-cli/src/command/workspace/tests/init.rs
+++ b/crates/orbit-cli/src/command/workspace/tests/init.rs
@@ -2,12 +2,112 @@ use std::sync::Mutex;
 
 use tempfile::tempdir;
 
+use orbit_common::types::{OverlapPolicy, RoutineTarget, parse_routine_yaml};
 use orbit_core::command::init::default_orbitignore_template;
 use orbit_core::workspace_registry;
 
 use super::super::init::WorkspaceInitArgs;
 
 static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+#[test]
+fn workspace_init_seeds_disabled_routines_and_reinit_preserves_authored_files() {
+    let _guard = ENV_LOCK.lock().expect("lock env");
+    let workspace = tempdir().expect("workspace tempdir");
+    let home = tempdir().expect("home tempdir");
+    let global = home.path().join(".orbit");
+    std::fs::create_dir_all(&global).expect("create global orbit");
+    std::fs::write(global.join("host.toml"), "host_id = \"init-host\"\n").expect("write host pin");
+
+    let previous_home = std::env::var_os("HOME");
+    let previous_cwd = std::env::current_dir().expect("capture cwd");
+    unsafe {
+        std::env::set_var("HOME", home.path());
+    }
+    std::env::set_current_dir(workspace.path()).expect("enter workspace");
+
+    let init = || WorkspaceInitArgs {
+        name: Some("routine-seed-test".to_string()),
+        base_branch: "agent-main".to_string(),
+        ship_mode: Some("pr".to_string()),
+        task_id_start: None,
+        mcp: false,
+        hooks: false,
+        inject_agent_rules: false,
+        refresh_defaults: false,
+    };
+    init()
+        .execute_without_runtime(None)
+        .expect("first workspace init");
+
+    let routines_dir = workspace.path().join(".orbit/routines");
+    let workspace_slug = workspace
+        .path()
+        .file_name()
+        .expect("workspace directory name")
+        .to_string_lossy()
+        .trim_start_matches('.')
+        .to_ascii_lowercase();
+    for (stem, target) in [
+        ("auto_task_scheduler", "auto_task_scheduler_pipeline"),
+        ("task_triage", "task_triage_pipeline"),
+        ("ship_sweep", "workspace_ship_pipeline"),
+    ] {
+        let yaml = std::fs::read_to_string(routines_dir.join(format!("{stem}.yaml")))
+            .expect("read seeded routine");
+        let definition = parse_routine_yaml(&yaml).expect("parse seeded routine");
+        assert_eq!(
+            definition.name,
+            format!("{}-{workspace_slug}", stem.replace('_', "-"))
+        );
+        assert_eq!(definition.hosts, ["init-host"]);
+        assert_eq!(definition.target, RoutineTarget::Job(target.to_string()));
+        assert_eq!(definition.policy.overlap, OverlapPolicy::Forbid);
+        assert!(!definition.enabled);
+    }
+
+    let authored_ship = r#"schemaVersion: 1
+name: custom-ship-sweep
+description: authored values must survive re-init
+enabled: true
+hosts: [custom-host]
+trigger:
+  cron: "7 3 * * *"
+  missed_run: catch_up_once
+target: job:workspace_ship_pipeline
+policy:
+  timeout_minutes: 77
+  overlap: allow
+"#;
+    std::fs::write(routines_dir.join("ship_sweep.yaml"), authored_ship)
+        .expect("author ship routine");
+    std::fs::remove_file(routines_dir.join("task_triage.yaml"))
+        .expect("remove one default routine");
+
+    init()
+        .execute_without_runtime(None)
+        .expect("second workspace init");
+
+    assert_eq!(
+        std::fs::read_to_string(routines_dir.join("ship_sweep.yaml"))
+            .expect("read authored ship routine"),
+        authored_ship,
+        "plain re-init must preserve workspace-authored routine bytes"
+    );
+    let recreated = std::fs::read_to_string(routines_dir.join("task_triage.yaml"))
+        .expect("missing default recreated");
+    assert!(
+        !parse_routine_yaml(&recreated)
+            .expect("parse recreated routine")
+            .enabled
+    );
+
+    std::env::set_current_dir(previous_cwd).expect("restore cwd");
+    match previous_home {
+        Some(value) => unsafe { std::env::set_var("HOME", value) },
+        None => unsafe { std::env::remove_var("HOME") },
+    }
+}
 
 #[test]
 fn workspace_init_seeds_auto_detected_mcp_configs() {

--- a/crates/orbit-core/assets/activities/resolve_workspace_ship_input.yaml
+++ b/crates/orbit-core/assets/activities/resolve_workspace_ship_input.yaml
@@ -1,0 +1,26 @@
+schemaVersion: 2
+kind: Activity
+metadata:
+  name: resolve_workspace_ship_input
+spec:
+  type: deterministic
+  description: >
+    Resolve the active workspace's canonical ship input without consulting
+    workflow.auto_ship or dispatching any other registered workspace. Returns
+    only mode and base_branch; omitted task_ids keeps task_auto_pipeline in
+    normal backlog-discovery mode.
+  input_schema_json:
+    type: object
+    additionalProperties: false
+  output_schema_json:
+    type: object
+    required: [mode, base_branch]
+    additionalProperties: false
+    properties:
+      mode:
+        type: string
+        enum: [pr, local]
+      base_branch:
+        type: string
+  action: resolve_workspace_ship_input
+  config: {}

--- a/crates/orbit-core/assets/jobs/workspace_ship_pipeline.yaml
+++ b/crates/orbit-core/assets/jobs/workspace_ship_pipeline.yaml
@@ -1,0 +1,32 @@
+# Workspace-local ship wrapper.
+#
+# The routine supplies no input. The first deterministic step resolves the
+# active runtime's ship mode and configured base branch; the second invokes
+# and waits for the existing task_auto_pipeline with no explicit task IDs.
+# Waiting keeps this wrapper active for the full shipment, so the routine's
+# `overlap: forbid` covers the child run. Empty backlog is the child's existing
+# clean no-op path.
+schemaVersion: 2
+kind: Job
+metadata:
+  name: workspace_ship_pipeline
+spec:
+  state: enabled
+  kind: workflow
+  max_active_runs: 1
+  steps:
+    - id: resolve_ship_input
+      target: activity:resolve_workspace_ship_input
+      default_input: {}
+
+    - id: ship
+      target: activity:invoke_and_wait
+      default_input:
+        job_name: task_auto_pipeline
+        run_input: "{{ steps.resolve_ship_input.output }}"
+
+    - id: require_ship_success
+      target: activity:pipeline_success_guard
+      default_input:
+        context: workspace ship pipeline
+        result: "{{ steps.ship.output }}"

--- a/crates/orbit-core/assets/routines/auto_task_scheduler.yaml
+++ b/crates/orbit-core/assets/routines/auto_task_scheduler.yaml
@@ -2,8 +2,9 @@
 # `.orbit/routines/` on `orbit init` with the routine name and host pin
 # resolved at seed time (see `seed_default_routines` in
 # `crates/orbit-core/src/command/routine.rs`). It only fires from workspaces
-# whose config declares `[routines] role = "source"` — in every other
-# workspace the file is inert until that role is enabled.
+# whose config declares `[routines] role = "source"`. The versioned
+# `enabled` switch is deliberately false when seeded; opt in by reviewing
+# this definition and changing it to true.
 #
 # This is THE scheduler surface for auto-tasks: one generic routine that fires
 # `auto_task_scheduler_pipeline`, which reads every `.orbit/auto_tasks/*.yaml`
@@ -22,7 +23,7 @@ description: >
   `.orbit/auto_tasks` definition. Catch-up collapses and `skip_if_open`
   dedupe are enforced by the scheduler; each definition's own schedule
   governs its cadence.
-enabled: true
+enabled: false
 hosts:
   - __ORBIT_HOST_ID__
 trigger:

--- a/crates/orbit-core/assets/routines/ship_sweep.yaml
+++ b/crates/orbit-core/assets/routines/ship_sweep.yaml
@@ -1,0 +1,25 @@
+# Default workspace ship-sweep routine. Seeded into
+# `.orbit/routines/` with a workspace-unique name and the initializing host
+# pin resolved at seed time. It is intentionally disabled: enabling scheduled
+# shipment is an explicit, versioned workspace decision.
+#
+# The target is workspace-local. `workspace_ship_pipeline` resolves the source
+# workspace's ship mode and configured base branch, then invokes and waits for
+# `task_auto_pipeline` without explicit task IDs. The child pipeline remains
+# the only owner of backlog discovery, readiness, locks, bundles, and gates.
+schemaVersion: 1
+name: __ORBIT_ROUTINE_NAME__
+description: >
+  Ship this workspace's ready backlog through the normal gated task pipeline.
+  Disabled by default; set enabled to true in this versioned definition to
+  opt this workspace into scheduled shipment.
+enabled: false
+hosts:
+  - __ORBIT_HOST_ID__
+trigger:
+  cron: "*/20 * * * *"
+  missed_run: skip
+target: job:workspace_ship_pipeline
+policy:
+  timeout_minutes: 120
+  overlap: forbid

--- a/crates/orbit-core/assets/routines/task_triage.yaml
+++ b/crates/orbit-core/assets/routines/task_triage.yaml
@@ -2,8 +2,9 @@
 # `.orbit/routines/` on `orbit init` with the routine name and host pin
 # resolved at seed time (see `seed_default_routines` in
 # `crates/orbit-core/src/command/routine.rs`). It only fires from workspaces
-# whose config declares `[routines] role = "source"` — in every other
-# workspace the file is inert until that role is enabled.
+# whose config declares `[routines] role = "source"`. The versioned
+# `enabled` switch is deliberately false when seeded; opt in by reviewing
+# this definition and changing it to true.
 #
 # Cadence is deliberately sparser than the ~20-minute ship sweep: triage is
 # cleanup, not a hot path. `overlap: forbid` plus the job's
@@ -14,7 +15,7 @@ description: >
   Hourly triage of tasks blocked by failed job runs: diagnose the failure,
   re-backlog environmental casualties, and leave everything else blocked
   with a diagnosis attached.
-enabled: true
+enabled: false
 hosts:
   - __ORBIT_HOST_ID__
 trigger:

--- a/crates/orbit-core/src/command/activity.rs
+++ b/crates/orbit-core/src/command/activity.rs
@@ -85,6 +85,10 @@ pub(crate) const DEFAULT_ACTIVITY_FILES: &[(&str, &str)] = &[
         include_str!("../../assets/activities/release_locks.yaml"),
     ),
     (
+        "resolve_workspace_ship_input",
+        include_str!("../../assets/activities/resolve_workspace_ship_input.yaml"),
+    ),
+    (
         "run_auto_task_scheduler",
         include_str!("../../assets/activities/run_auto_task_scheduler.yaml"),
     ),

--- a/crates/orbit-core/src/command/init.rs
+++ b/crates/orbit-core/src/command/init.rs
@@ -229,7 +229,11 @@ pub fn init_workspace_at_root(
                     &orbit_root.join("routines"),
                     &host_id,
                     workspace_slug_from_orbit_root(&orbit_root).as_deref(),
-                    overwrite,
+                    // Routine definitions become workspace-authored after
+                    // seeding. Refresh global defaults without overwriting
+                    // cadence, host pins, policy, or enabled choices here;
+                    // destructive `force` already recreated the root.
+                    options.force,
                 )?;
             }
             Err(error) => {

--- a/crates/orbit-core/src/command/job/catalog.rs
+++ b/crates/orbit-core/src/command/job/catalog.rs
@@ -51,6 +51,10 @@ const DEFAULT_JOB_FILES: &[(&str, &str)] = &[
         "task_triage_pipeline",
         include_str!("../../../assets/jobs/task_triage_pipeline.yaml"),
     ),
+    (
+        "workspace_ship_pipeline",
+        include_str!("../../../assets/jobs/workspace_ship_pipeline.yaml"),
+    ),
 ];
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -673,6 +677,49 @@ spec:
     }
 
     #[test]
+    fn workspace_ship_pipeline_resolves_then_waits_for_normal_auto_ship() {
+        let yaml = DEFAULT_JOB_FILES
+            .iter()
+            .find_map(|(name, yaml)| (*name == "workspace_ship_pipeline").then_some(*yaml))
+            .expect("workspace ship pipeline default exists");
+        let asset = load_job_asset(yaml).expect("parse workspace ship pipeline");
+        assert_eq!(asset.spec.max_active_runs, 1);
+        assert_eq!(asset.spec.steps.len(), 3);
+        assert_eq!(asset.spec.steps[0].id, "resolve_ship_input");
+        assert_eq!(asset.spec.steps[1].id, "ship");
+        assert_eq!(asset.spec.steps[2].id, "require_ship_success");
+
+        match &asset.spec.steps[0].body {
+            JobV2StepBody::TargetRef(target) => {
+                assert_eq!(target.target, "activity:resolve_workspace_ship_input");
+            }
+            other => panic!("expected resolver target ref, got {other:?}"),
+        }
+        match &asset.spec.steps[1].body {
+            JobV2StepBody::TargetRef(target) => {
+                assert_eq!(target.target, "activity:invoke_and_wait");
+                let input = target.default_input.as_ref().expect("ship input");
+                assert_eq!(input["job_name"], "task_auto_pipeline");
+                assert_eq!(
+                    input["run_input"],
+                    Value::String("{{ steps.resolve_ship_input.output }}".to_string())
+                );
+                assert!(input.get("task_ids").is_none());
+            }
+            other => panic!("expected invoke-and-wait target ref, got {other:?}"),
+        }
+        match &asset.spec.steps[2].body {
+            JobV2StepBody::TargetRef(target) => {
+                assert_eq!(target.target, "activity:pipeline_success_guard");
+            }
+            other => panic!("expected success guard target ref, got {other:?}"),
+        }
+        assert!(!yaml.contains("auto_ship"));
+        assert!(!yaml.contains("ship-sweep"));
+        assert!(!yaml.contains("type: shell"));
+    }
+
+    #[test]
     fn default_jobs_template_only_declared_agent_loop_handoffs() {
         let agent_activity_names = DEFAULT_ACTIVITY_FILES
             .iter()
@@ -789,6 +836,7 @@ spec:
             "task_epic_pipeline",
             "task_gate_pipeline",
             "task_triage_pipeline",
+            "workspace_ship_pipeline",
         ] {
             let yaml = DEFAULT_JOB_FILES
                 .iter()

--- a/crates/orbit-core/src/command/routine.rs
+++ b/crates/orbit-core/src/command/routine.rs
@@ -14,7 +14,7 @@
 //!
 //! Seeded routines are inert until the workspace opts into
 //! `[routines] role = "source"`; they exist so a fresh workspace gets
-//! working periodic triage the moment it becomes a routine source.
+//! reviewable, opt-in schedules without silently enabling unattended work.
 
 use std::path::Path;
 
@@ -35,6 +35,10 @@ pub(crate) const DEFAULT_ROUTINE_FILES: &[(&str, &str)] = &[
         "task_triage",
         include_str!("../../assets/routines/task_triage.yaml"),
     ),
+    (
+        "ship_sweep",
+        include_str!("../../assets/routines/ship_sweep.yaml"),
+    ),
 ];
 
 const HOST_ID_PLACEHOLDER: &str = "__ORBIT_HOST_ID__";
@@ -43,8 +47,8 @@ const ROUTINE_NAME_PLACEHOLDER: &str = "__ORBIT_ROUTINE_NAME__";
 /// Seed every entry in [`DEFAULT_ROUTINE_FILES`] under `routines_dir`,
 /// resolving the host and routine-name placeholders. Mirrors the activity /
 /// job seeding convention: when `overwrite` is false (plain re-init),
-/// existing files are preserved; `--refresh-defaults` / `--force` set
-/// `overwrite` and re-render them.
+/// existing files are preserved. Destructive initialization may set
+/// `overwrite`, though `--force` normally recreates the whole root first.
 // ADR-0215: default routines are seeded per workspace with host and name
 // resolved at seed time — routines have no global directory and v1 requires
 // explicit host pinning and host-unique names.
@@ -118,29 +122,48 @@ mod tests {
     use super::*;
 
     #[test]
-    fn seeded_triage_routine_is_valid_pinned_and_overlap_forbidden() {
+    fn seeded_routines_are_valid_disabled_pinned_and_workspace_unique() {
         let root = tempdir().expect("create tempdir");
         let routines_dir = root.path().join(".orbit/routines");
         let seeded = seed_default_routines(&routines_dir, "test-host", Some("My Repo!"), true)
             .expect("seed default routines");
         assert_eq!(seeded, DEFAULT_ROUTINE_FILES.len());
 
-        let yaml = std::fs::read_to_string(routines_dir.join("task_triage.yaml"))
-            .expect("read seeded triage routine");
-        let definition = parse_routine_yaml(&yaml).expect("seeded routine parses fail-closed");
-        assert_eq!(definition.name, "task-triage-my-repo");
-        assert_eq!(definition.hosts, vec!["test-host".to_string()]);
-        assert_eq!(
-            definition.target,
-            RoutineTarget::Job("task_triage_pipeline".to_string())
-        );
-        assert_eq!(definition.policy.overlap, OverlapPolicy::Forbid);
-        assert!(definition.enabled);
+        for (stem, target) in [
+            ("auto_task_scheduler", "auto_task_scheduler_pipeline"),
+            ("task_triage", "task_triage_pipeline"),
+            ("ship_sweep", "workspace_ship_pipeline"),
+        ] {
+            let yaml = std::fs::read_to_string(routines_dir.join(format!("{stem}.yaml")))
+                .expect("read seeded routine");
+            let definition = parse_routine_yaml(&yaml).expect("seeded routine parses fail-closed");
+            assert_eq!(
+                definition.name,
+                format!("{}-my-repo", stem.replace('_', "-"))
+            );
+            assert_eq!(definition.hosts, vec!["test-host".to_string()]);
+            assert_eq!(definition.target, RoutineTarget::Job(target.to_string()));
+            assert_eq!(definition.policy.overlap, OverlapPolicy::Forbid);
+            assert!(!definition.enabled);
+        }
 
         // Cadence: hourly — deliberately sparser than the ~20-minute ship
         // sweep, and parseable by the scheduler.
-        assert_eq!(definition.trigger.cron, "15 * * * *");
-        parse_cron(&definition.trigger.cron).expect("seeded cron parses");
+        let triage = std::fs::read_to_string(routines_dir.join("task_triage.yaml"))
+            .expect("read triage routine");
+        let triage = parse_routine_yaml(&triage).expect("triage routine parses");
+        assert_eq!(triage.trigger.cron, "15 * * * *");
+        parse_cron(&triage.trigger.cron).expect("seeded cron parses");
+
+        let ship = std::fs::read_to_string(routines_dir.join("ship_sweep.yaml"))
+            .expect("read ship routine");
+        let ship = parse_routine_yaml(&ship).expect("ship routine parses");
+        assert_eq!(
+            ship.trigger.missed_run,
+            orbit_common::types::MissedRunPolicy::Skip
+        );
+        assert_eq!(ship.trigger.cron, "*/20 * * * *");
+        parse_cron(&ship.trigger.cron).expect("ship cron parses");
     }
 
     #[test]

--- a/crates/orbit-core/src/runtime/v2_host/backlog_exclusion_tests.rs
+++ b/crates/orbit-core/src/runtime/v2_host/backlog_exclusion_tests.rs
@@ -54,6 +54,18 @@ fn output_task_ids(output: &Value) -> Vec<String> {
         .collect()
 }
 
+#[test]
+fn list_backlog_tasks_empty_workspace_is_a_clean_noop() {
+    let (_root, runtime, _repo_root) = runtime_with_workspace_layout();
+
+    let output = list_backlog_tasks(&runtime, json!({}));
+
+    assert_eq!(output["task_count"], json!(0));
+    assert_eq!(output["task_ids"], json!([]));
+    assert_eq!(output["bundles"], json!([]));
+    assert_eq!(output["excluded"], json!([]));
+}
+
 fn seed_task_with_dependencies(
     runtime: &OrbitRuntime,
     title: &str,
@@ -232,6 +244,41 @@ fn list_backlog_tasks_preserves_existing_fields_without_conflicts() {
         ])
     );
     assert_eq!(output["excluded"], json!([]));
+}
+
+#[test]
+fn list_backlog_tasks_does_not_filter_auto_task_provenance_tags() {
+    let (_root, runtime, _repo_root) = runtime_with_workspace_layout();
+    let ordinary = runtime
+        .add_task(crate::command::task::TaskAddParams {
+            title: "Ordinary backlog".to_string(),
+            description: "ordinary".to_string(),
+            acceptance_criteria: vec!["selected".to_string()],
+            plan: "ship".to_string(),
+            status: Some(TaskStatus::Backlog),
+            task_type: Some(TaskType::Chore),
+            ..Default::default()
+        })
+        .expect("seed ordinary backlog");
+    let auto_task = runtime
+        .add_task(crate::command::task::TaskAddParams {
+            title: "Auto-task backlog".to_string(),
+            description: "minted by scheduler".to_string(),
+            acceptance_criteria: vec!["selected".to_string()],
+            tags: vec!["auto-task:nightly-maintenance".to_string()],
+            plan: "ship".to_string(),
+            status: Some(TaskStatus::Backlog),
+            task_type: Some(TaskType::Chore),
+            ..Default::default()
+        })
+        .expect("seed auto-task backlog");
+
+    let output = list_backlog_tasks(&runtime, json!({}));
+    let selected = output_task_ids(&output);
+
+    assert_eq!(selected.len(), 2);
+    assert!(selected.contains(&ordinary.id));
+    assert!(selected.contains(&auto_task.id));
 }
 
 #[test]

--- a/crates/orbit-core/src/runtime/v2_host/dispatch.rs
+++ b/crates/orbit-core/src/runtime/v2_host/dispatch.rs
@@ -188,6 +188,10 @@ pub(super) fn run_deterministic(
                 action: action.to_string(),
                 message: error.to_string(),
             }),
+        // ADR-0223: scheduled shipment resolves only the active runtime's
+        // canonical ship input; cross-workspace enumeration stays in the
+        // legacy CLI sweep and `workflow.auto_ship` is deliberately ignored.
+        "resolve_workspace_ship_input" => resolve_workspace_ship_input(runtime, action),
         // Materialize the workspace backlog for auto-dispatch.
         // Filters by `status: backlog`. In automatic mode, drops any backlog
         // task group whose context overlaps files
@@ -301,6 +305,34 @@ pub(super) fn run_deterministic(
     }
 }
 
+fn resolve_workspace_ship_input(
+    runtime: &OrbitRuntime,
+    action: &str,
+) -> Result<Value, DispatchError> {
+    let registry_path = crate::workspace_registry::registry_path_for(&runtime.global_root());
+    let registry =
+        crate::workspace_registry::load_registry_from(&registry_path).map_err(|error| {
+            DispatchError::DeterministicActionFailed {
+                action: action.to_string(),
+                message: format!("load workspace registry: {error}"),
+            }
+        })?;
+    let source_orbit_dir = runtime.shared_root();
+    let mode = registry
+        .workspaces
+        .iter()
+        .find(|workspace| workspace.orbit_dir == source_orbit_dir)
+        .map(crate::command::workflow::resolved_ship_mode)
+        .unwrap_or(crate::command::workflow::ShipMode::Local);
+
+    crate::command::workflow::build_ship_input(mode, runtime.workflow_base_branch(), &[]).map_err(
+        |error| DispatchError::DeterministicActionFailed {
+            action: action.to_string(),
+            message: format!("resolve workspace ship input: {error}"),
+        },
+    )
+}
+
 fn unmet_dependency_ids_for_input(
     runtime: &OrbitRuntime,
     input: &Value,
@@ -388,6 +420,9 @@ mod tests {
     use orbit_engine::V2RuntimeHost;
     use orbit_tools::ToolContext;
     use serde_json::json;
+    use tempfile::tempdir;
+
+    use orbit_common::types::{Workspace, WorkspaceRegistry, WorkspaceStatus};
 
     fn seed_task(
         runtime: &OrbitRuntime,
@@ -458,6 +493,68 @@ mod tests {
             }
             other => panic!("expected registered action failure, got {other}"),
         }
+    }
+
+    #[test]
+    fn workspace_ship_input_is_source_local_and_ignores_auto_ship() {
+        let root = tempdir().expect("tempdir");
+        let global = root.path().join("global");
+        let source_root = root.path().join("source");
+        let source_orbit = source_root.join(".orbit");
+        let other_root = root.path().join("other");
+        let other_orbit = other_root.join(".orbit");
+        std::fs::create_dir_all(&source_orbit).expect("source orbit");
+        std::fs::create_dir_all(&other_orbit).expect("other orbit");
+        std::fs::create_dir_all(&global).expect("global orbit");
+        std::fs::write(
+            source_orbit.join("config.toml"),
+            "[workflow]\nbase_branch = \"agent-main\"\nauto_ship = false\n",
+        )
+        .expect("source config");
+
+        let now = Utc::now();
+        let registry = WorkspaceRegistry {
+            workspaces: vec![
+                Workspace {
+                    id: "ws-other".to_string(),
+                    name: "other".to_string(),
+                    root: other_root,
+                    orbit_dir: other_orbit,
+                    git_remote: None,
+                    ship_mode: Some("local".to_string()),
+                    base_branch: "wrong-branch".to_string(),
+                    status: WorkspaceStatus::Active,
+                    created_at: now,
+                    updated_at: now,
+                },
+                Workspace {
+                    id: "ws-source".to_string(),
+                    name: "source".to_string(),
+                    root: source_root,
+                    orbit_dir: source_orbit.clone(),
+                    git_remote: None,
+                    ship_mode: Some("pr".to_string()),
+                    base_branch: "registry-branch".to_string(),
+                    status: WorkspaceStatus::Active,
+                    created_at: now,
+                    updated_at: now,
+                },
+            ],
+            ..WorkspaceRegistry::default()
+        };
+        crate::workspace_registry::save_registry_to(
+            &registry,
+            &crate::workspace_registry::registry_path_for(&global),
+        )
+        .expect("save registry");
+
+        let runtime = OrbitRuntime::from_roots(&global, &source_orbit).expect("source runtime");
+        assert!(!runtime.workflow_auto_ship());
+        let input = resolve_workspace_ship_input(&runtime, "resolve_workspace_ship_input")
+            .expect("resolve source ship input");
+
+        assert_eq!(input, json!({"mode": "pr", "base_branch": "agent-main"}));
+        assert!(input.get("task_ids").is_none());
     }
 
     #[test]

--- a/docs/design/routines/1_overview.md
+++ b/docs/design/routines/1_overview.md
@@ -1,7 +1,7 @@
 ---
 title: Routines — Overview
 owner: claude
-last_updated: 2026-07-04
+last_updated: 2026-07-15
 status: Accepted
 feature: routines
 doc_role: overview
@@ -10,7 +10,7 @@ summary: Durable, git-versioned scheduler primitive that fires catalog jobs/acti
 tags: [routines, scheduler]
 paths: ["crates/orbit-cli/src/command/routine/**", "crates/orbit-core/src/routines/**"]
 related_features: [routines, activity-job]
-related_artifacts: [ORB-10001, ORB-10021]
+related_artifacts: [ORB-10001, ORB-10021, ORB-10207, ADR-0223]
 ---
 
 # Routines — Overview
@@ -27,6 +27,13 @@ is host-local and never synced. [2_design.md](./2_design.md) is the v1 contract;
 > **Status.** v1 shipped in [ORB-10021]; the At a Glance table lists the actual home of
 > each concern. Targets are `job:<name>` in v1 — see [ADR-0206] for why `activity:` is
 > reserved.
+
+`orbit workspace init` creates the complete default set (`auto_task_scheduler`,
+`task_triage`, and `ship_sweep`) under `.orbit/routines/`. Every default is
+`enabled: false`: scheduled execution is an explicit, versioned opt-in made by changing
+the reviewed definition to `enabled: true`. Re-init creates newly introduced missing
+defaults but never rewrites existing routine files; those files belong to the workspace
+after seeding. A destructive force initialization recreates templates from defaults.
 
 ---
 
@@ -89,6 +96,7 @@ fragmentation this feature exists to end.
 | `orbit routine` CLI (`list/show/pause/resume/init`) | `crates/orbit-cli/src/command/routine/` | [ORB-10021] |
 | launchd/systemd unit templates + installer | `crates/orbit-core/assets/clock/` + `src/routines/clock.rs` | [ORB-10021] |
 | `[routines] role = "source"` config key | `crates/orbit-core/src/config/{raw,runtime}.rs` | [ORB-10021] |
+| Disabled default routine seeding + workspace ship wrapper | `crates/orbit-core/assets/{routines,jobs}/` | [ORB-10207] / [ADR-0223] |
 
 ---
 
@@ -96,6 +104,7 @@ fragmentation this feature exists to end.
 
 - [ORB-10001] — authored this design-doc folder (proposal; no implementation).
 - [ORB-10021] — implemented routines v1 (types, store, sweep, CLI, clock units).
+- [ORB-10207] — seeded opt-in defaults and the workspace-local ship-sweep wrapper.
 - [ORB-00374] — removed the `shell` activity variant and `run_shell` dispatch (fail-closed);
   routines inherit this constraint.
 

--- a/docs/design/routines/2_design.md
+++ b/docs/design/routines/2_design.md
@@ -1,7 +1,7 @@
 ---
 title: Routines — Design
 owner: claude
-last_updated: 2026-07-05
+last_updated: 2026-07-15
 status: Accepted
 feature: routines
 doc_role: design
@@ -10,7 +10,7 @@ summary: Proposed contract for routine definitions, sweep dispatch, host-local s
 tags: [routines, scheduler]
 paths: ["crates/orbit-cli/src/command/routine/**", "crates/orbit-core/src/routines/**"]
 related_features: [routines, activity-job]
-related_artifacts: [ORB-10001, ORB-10021]
+related_artifacts: [ORB-10001, ORB-10021, ORB-10207, ADR-0223]
 ---
 
 # Routines — Design
@@ -74,6 +74,26 @@ Field semantics:
 
 Parsing is fail-closed: an invalid routine file is reported and *that routine* is treated
 as absent; it never degrades into "fire with defaults".
+
+### Seeded defaults and ownership
+
+`orbit workspace init` seeds `auto_task_scheduler.yaml`, `task_triage.yaml`, and
+`ship_sweep.yaml` with a workspace-unique name, the resolved host pin, and
+`enabled: false`. The definition's versioned `enabled` field is the opt-in: changing it
+to `true` deliberately grants that scheduled capability in the workspace.
+
+Seeded files become workspace-authored immediately. Plain re-init is create-if-missing:
+it adds a newly shipped default or recreates a deleted default, but byte-for-byte preserves
+existing definitions, including `enabled`, `hosts`, cron, and policy edits. Only destructive
+force initialization recreates the workspace and therefore restores template defaults.
+
+The seeded `ship_sweep` targets `job:workspace_ship_pipeline` with `missed_run: skip` and
+`overlap: forbid`. The wrapper resolves the source runtime's ship mode and configured base
+branch, invokes and waits for `task_auto_pipeline` without explicit task IDs, and guards
+its result. It never calls the legacy cross-workspace CLI sweep or consults
+`[workflow] auto_ship`; the child's existing empty-backlog path is a successful no-op.
+Waiting keeps the wrapper run active for the whole shipment, so routine overlap protection
+covers the child rather than only submission ([ADR-0223]).
 
 ---
 
@@ -142,9 +162,9 @@ Per pass:
 Fires are normal runs: they appear in run history, carry v2 audit envelopes, and are
 debuggable with the existing run tooling — there is no separate "scheduled run" ledger.
 
-Naming note: `orbit sweep` is the general scheduler pass; `orbit run ship-sweep` remains
-the shipped, single-purpose backlog sweep. Folding ship-sweep into a seeded routine is a
-vision item ([3_vision.md](./3_vision.md) §1), not a v1 goal.
+Naming note: `orbit sweep` is the general scheduler pass. The seeded `ship_sweep` routine
+is workspace-local; the legacy `orbit run ship-sweep` cross-workspace entrypoint remains
+compatible during routine burn-in and is a separate eventual-removal concern.
 
 ---
 
@@ -227,6 +247,7 @@ out of v1 scope for this reason.
 
 - [ORB-10001] — authored this design-doc folder (proposal; no implementation).
 - [ORB-10021] — implemented routines v1 (types, store, sweep, CLI, clock units).
+- [ORB-10207] — added disabled-by-default seeding and workspace-local ship sweep.
 - [ORB-00374] — removed the `shell` activity variant and `run_shell` dispatch (fail-closed);
   routines inherit this constraint.
 

--- a/docs/design/routines/3_vision.md
+++ b/docs/design/routines/3_vision.md
@@ -1,7 +1,7 @@
 ---
 title: Routines — Vision
 owner: claude
-last_updated: 2026-07-04
+last_updated: 2026-07-15
 status: Draft
 feature: routines
 doc_role: vision
@@ -10,7 +10,7 @@ summary: Open questions and prior art for the routines scheduler — leases, eve
 tags: [routines, scheduler]
 paths: ["crates/orbit-core/src/routines/**"]
 related_features: [routines, activity-job]
-related_artifacts: [ORB-10001, ORB-10021]
+related_artifacts: [ORB-10001, ORB-10021, ORB-10207, ADR-0223]
 ---
 
 # Routines — Vision
@@ -31,30 +31,33 @@ and an ADR, not by drifting in.
    mode needs a lease: the natural v2 shape is a lease table in one designated host's store,
    reached over SSH (port 22 is the only always-open channel between the current hosts).
    Worth doing only when a real routine needs failover, not before.
-2. **Folding `ship-sweep` into a routine.** `orbit run ship-sweep` predates routines and
-   hard-codes its own opt-in (`[workflow] auto_ship`). Once routines ship, ship-sweep is
-   expressible as a seeded routine targeting the backlog-dispatch job. Convergence would
-   retire one bespoke scheduler entrypoint — but only after routines have run unattended
-   long enough to be trusted with it.
-3. **Event triggers.** File-watch, webhook, or run-completion triggers ("reindex after any
+2. **Event triggers.** File-watch, webhook, or run-completion triggers ("reindex after any
    docs change") require a resident process — the thing v1 deliberately avoids. If bridge
    ever grows a long-lived daemon on the always-on box, it may be the natural event source,
    with routines subscribing rather than Orbit growing its own daemon.
-4. **Routine-emitted tasks.** A routine whose job files an Orbit task on findings (nightly
+3. **Routine-emitted tasks.** A routine whose job files an Orbit task on findings (nightly
    drift check → task per drift) works today via job semantics; what's open is whether
    routines should get first-class dedup support ("don't file a duplicate of an open task
    from a previous fire") or leave that to job logic.
-5. **Sub-minute and jitter.** Minute granularity is a v1 floor. Per-routine jitter matters
+4. **Sub-minute and jitter.** Minute granularity is a v1 floor. Per-routine jitter matters
    only if many routines land on the same slot and contend; revisit when there are enough
    routines for it to be observable.
-6. **Missed-run variants.** `catch_up_once | skip` covers current needs; a count-preserving
+5. **Missed-run variants.** `catch_up_once | skip` covers current needs; a count-preserving
    `catch_up_all` (anacron-style) is additive if a routine ever needs per-slot semantics.
-7. **Cross-host visibility.** Each host's state is local, so "did the nightly commit fire
+6. **Cross-host visibility.** Each host's state is local, so "did the nightly commit fire
    on the other box?" requires asking that box. The single-host half of this is now built:
    `GET /api/routines` projects this host's routine health (last fire, outcome, duration,
    next due) over the dashboard HTTP API [ORB-10138], so a stopped sweep is visible remotely
    without box ssh. True cross-host *aggregation* (one surface querying every box's store)
    remains open; state *sync* is still explicitly not the answer.
+
+### Graduated
+
+- **Workspace-local ship-sweep convergence ([ORB-10207], [ADR-0223]).** The default
+  `ship_sweep` routine delegates synchronously to the normal shipment pipeline for only
+  its source workspace. It is seeded disabled and enabled through the versioned
+  definition. The legacy global CLI entrypoint remains during burn-in; removing it is a
+  separate compatibility task.
 
 ---
 
@@ -117,5 +120,6 @@ External:
 
 - [ORB-10001] — authored this design-doc folder (proposal; no implementation).
 - [ORB-10021] — implemented routines v1.
+- [ORB-10207] — graduated workspace-local ship-sweep scheduling from this vision.
 
 > Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.

--- a/docs/design/routines/4_decisions.md
+++ b/docs/design/routines/4_decisions.md
@@ -1,16 +1,16 @@
 ---
 title: Routines — Decisions
 owner: claude
-last_updated: 2026-07-11
+last_updated: 2026-07-15
 status: Accepted
 feature: routines
 doc_role: decisions
 type: design
-summary: ADR log for the routines scheduler — five decisions allocated and accepted with the v1 implementation.
+summary: ADR log for the routines scheduler, including default seeding and workspace-local shipment.
 tags: [routines, scheduler]
 paths: ["crates/orbit-core/src/routines/**"]
 related_features: [routines, activity-job]
-related_artifacts: [ORB-10001, ORB-10021]
+related_artifacts: [ORB-10001, ORB-10021, ORB-10207, ADR-0223]
 ---
 
 # Routines — Decisions
@@ -200,13 +200,14 @@ directory (a discovery-model change ADR-0205 deliberately avoided).
 `.orbit/routines/`, resolving `__ORBIT_HOST_ID__` via `resolve_host_id` and
 `__ORBIT_ROUTINE_NAME__` from a workspace-directory slug (`task-triage-<workspace>`),
 validating each rendered document fail-closed before writing. Plain re-init preserves
-user edits; `--refresh-defaults` / `--force` re-render. Seeded routines stay inert until
-the workspace opts into `[routines] role = "source"`.
+user edits while creating newly introduced missing defaults; destructive `--force`
+recreates templates. Every default is seeded with `enabled: false`, so a routine fires
+only after the workspace is a routine source and its versioned enable switch is set true.
 
 ### Consequences
 
-- A fresh workspace gets working periodic triage (hourly, `overlap: forbid`, deliberately
-  sparser than the ~20-minute ship sweep) the moment it becomes a routine source.
+- A fresh workspace gets reviewable definitions without silently granting scheduled
+  execution; each routine is enabled explicitly in version control.
 - Per-workspace names let multiple seeded source workspaces coexist on one host despite
   the global name-uniqueness rule.
 - The seeded file pins the initializing host; sharing the repo to another host needs a
@@ -217,11 +218,41 @@ the workspace opts into `[routines] role = "source"`.
 
 ---
 
+## ADR-0223 — Delegate workspace ship routines through a synchronous wrapper job
+
+**Status:** Accepted · 2026-07 · [ORB-10207]
+
+### Context
+
+A scheduled ship routine must dispatch only its source workspace, resolve that workspace's
+ship mode and base branch, and keep the parent run active until normal backlog shipment
+finishes. The alternatives were special-casing routine dispatch, spawning the legacy
+multi-workspace CLI sweep, or composing the existing job catalog.
+
+### Decision
+
+Seed a workspace-local `ship_sweep` routine targeting `workspace_ship_pipeline`. The
+wrapper deterministically resolves ship input for its active runtime, invokes and waits
+for `task_auto_pipeline` with no explicit task IDs, and guards child success. It does not
+consult `workflow.auto_ship` or the cross-workspace sweep path.
+
+### Consequences
+
+- Backlog discovery, readiness, locking, bundling, crew selection, and gates remain owned
+  by `task_auto_pipeline`; an empty backlog remains a clean no-op.
+- `overlap: forbid` covers child shipment because the wrapper remains active while waiting.
+- The legacy global ship-sweep remains compatible during burn-in but is not used by routines.
+- Cost: the catalog gains a wrapper job and deterministic resolver activity whose input
+  contract must stay aligned with the canonical ship workflow.
+
+---
+
 ## Task References
 
 - [ORB-10001] — authored this design-doc folder (proposal).
 - [ORB-10021] — implemented routines v1; allocated and accepted ADR-0204..ADR-0208.
 - [ORB-10129] — shipped the default triage routine; allocated and accepted ADR-0215.
+- [ORB-10207] — seeded disabled defaults and allocated/accepted ADR-0223 for workspace ship.
 - [ORB-10138] — exposed per-routine scheduler health over the dashboard HTTP API
   (`GET /api/routines`), realizing the single-host half of the §7 cross-host-visibility
   vision. Read-only projection of `routine_statuses`; no new ADR (no new architectural


### PR DESCRIPTION
## Task

ORB-10207 — seed an opt-in workspace ship-sweep routine and make all default routines disabled.

## Execution Summary

- Seeds `auto_task_scheduler`, `task_triage`, and `ship_sweep` as disabled, workspace-owned routine definitions.
- Preserves existing routine files byte-for-byte on re-init while recreating missing defaults.
- Adds a synchronous workspace-local ship wrapper that resolves the source workspace ship mode/base branch and delegates to the existing `task_auto_pipeline` without explicit task IDs.
- Adds deterministic coverage for seeding, re-init preservation, workspace-local resolution, empty-backlog behavior, and unchanged auto-task-tag selection.
- Updates the routines design corpus, ADR-0215, new ADR-0223, and the changelog.

## Validation

- `make ci-fast` — passed on the rebased branch.
- Focused routine seeding, workspace-init, job catalog, workflow, workspace ship resolution, auto-task provenance, and empty-backlog tests — passed during the implementation run.

## Branch Freshness

Rebased onto `agent-main` at `f9872c68` before push; the branch is one commit ahead with a clean worktree.

## Recovery Note

The original PR pipeline stopped after implementation because its invocation store was at schema v4 while the executing Orbit binary only supported schema v3. The completed work was recovered from the dedicated task worktree, committed, rebased, validated, and pushed directly.
