### PR TITLE
Correct friction lifecycle and learning-show skill guidance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- **Skill guidance reflects friction triage**: shipped skills use positional learning-show IDs and document mutable friction statuses, direct triage commands, and task-driven resolution. ([ORB-10210])
 - **Store schema v4 compatibility restored**: the append-only `job_run_archive_stage` migration remains supported after an `agent-main` history rewrite dropped its registry entry, so current CLIs reopen already-upgraded stores without a destructive downgrade. ([ORB-10209])
 - **Legacy task friction status removed**: tasks no longer deserialize, list, update, admit, or render `status: friction`; standalone friction artifacts are the only supported surface. Task attribution and record-parameter construction now share implementations without changing admission or triage behavior. ([ORB-10202])
 - **Activity and job catalogs share layered loading**: typed adapters now share recursive discovery, directory deduplication, first-wins layering, and duplicate detection while preserving their distinct precedence and validation policies. ([ORB-10201])

--- a/crates/orbit-core/assets/skills/orbit-knowledge/SKILL.md
+++ b/crates/orbit-core/assets/skills/orbit-knowledge/SKILL.md
@@ -24,7 +24,7 @@ Both surfaces (MCP `orbit_learning_*`/`orbit_adr_*`, CLI `orbit tool run orbit.l
 |------|-----|-----|
 | Add | `orbit_learning_add({...})` | `orbit learning add --summary "..." --path "crates/orbit-core/**/*.rs" --tag rust --body-file note.md` |
 | Search | `orbit_search({...})` | `orbit search --kind learning <text>` (add `--hybrid` after `orbit semantic index --kind learnings`) |
-| Show / update / supersede | `orbit_learning_show/update/supersede({...})` | `orbit learning show --id L-0001` / `update --id L-0001 --priority 200` / `supersede --id L-0001 --with L-0007` |
+| Show / update / supersede | `orbit_learning_show/update/supersede({...})` | `orbit learning show L-0001` / `update --id L-0001 --priority 200` / `supersede --id L-0001 --with L-0007` |
 | List/audit, prune, sync | CLI-only | `orbit learning list --status active --tag rust [--path <glob>]`, `orbit learning prune --stale-only [--delete]`, `orbit learning sync` |
 
 **Workflow:** (1) search first — `orbit learning list --path/--tag` or `orbit search --kind learning` — prefer `update`/`supersede` over a duplicate. (2) Add with tight `scope: { paths?, tags? }` (OR semantics — fires on *any* path glob OR *any* tag; split concerns into separate learnings rather than over-broadening one). Include `evidence: [{kind: "task"|"commit"|"external", ref: "..."}]` whenever it came from a real incident/PR/task — a learning you can't cite a source for is a hunch. `priority` (0–255) is a secondary search-ranking key, not an importance badge. Keep `summary` ≤280 chars, written as a directive ("Always X before Y in `<crate>`"), since push-injection surfaces it first. (3) `prune --stale-only` periodically to surface learnings whose `scope.paths` no longer resolve; read before `--delete`. (4) `sync` (CLI-only) re-syncs the SQLite envelope index if YAML was touched out-of-band (merge, branch switch) — YAML is the source of truth.
@@ -39,7 +39,7 @@ orbit learning add --summary "Always run \`make fmt\` before committing under cr
 
 Common mistakes: hand-writing YAML (skips envelope+attribution — use the tools); creating a duplicate without checking first (two overlapping-scope records inject twice and contradict); `update` to "fix" a fundamental change in advice (loses the supersede chain — `supersede` instead); `scope` with no `paths` and no `tags` (never injects).
 
-Exit: the learning exists/updates through `orbit.learning.*`, has a directive `summary`, ≥1 `paths`/`tags` entry, evidence when it exists, and is retrievable via `orbit learning show --id <ID>`. A code-anchored learning ships its citation in the same change.
+Exit: the learning exists/updates through `orbit.learning.*`, has a directive `summary`, ≥1 `paths`/`tags` entry, evidence when it exists, and is retrievable via `orbit learning show <ID>`. A code-anchored learning ships its citation in the same change.
 
 ## ADRs
 

--- a/crates/orbit-core/assets/skills/orbit-task/SKILL.md
+++ b/crates/orbit-core/assets/skills/orbit-task/SKILL.md
@@ -122,7 +122,7 @@ Exit: all findings filed with `model` attribution; no status transitions/resolut
 
 File **agent-discovered Orbit tooling, workflow, or seeded-instruction friction** as an append-only report instead of silently working around it — unclear command behavior, missing CLI functionality, confusing schema/config, doc gaps, unclear errors, unexpected runtime behavior, confusing seed instructions, or insufficient/vague activity-asset or `SKILL.md` prompts. **Not** for task content issues, ordinary user-requested work, or generic bugs.
 
-Stored under `.orbit/frictions/` as append-only markdown+frontmatter — no lifecycle, triage state, or scoreboard.
+Friction bodies are append-only markdown reports under `.orbit/frictions/`; their triage metadata is mutable. New records start `open` and may be `triaged` or `resolved`. Human/orchestrator triage uses `orbit friction update <ID> --status triaged` (and optional replacement tags), while `orbit friction resolve <ID>` closes a report. When a task fixes the underlying cause, add `relations: [{"type":"resolves","target":"F<YYYY>-<MM>-<NNN>"}]`: that task auto-resolves an existing friction and records `resolved_by_task` when it reaches `done`; a dangling target is audit-visible but does not block task completion.
 
 | Tag | Use for |
 | --- | --- |

--- a/plugin/skills/orbit-knowledge/SKILL.md
+++ b/plugin/skills/orbit-knowledge/SKILL.md
@@ -24,7 +24,7 @@ Both surfaces (MCP `orbit_learning_*`/`orbit_adr_*`, CLI `orbit tool run orbit.l
 |------|-----|-----|
 | Add | `orbit_learning_add({...})` | `orbit learning add --summary "..." --path "crates/orbit-core/**/*.rs" --tag rust --body-file note.md` |
 | Search | `orbit_search({...})` | `orbit search --kind learning <text>` (add `--hybrid` after `orbit semantic index --kind learnings`) |
-| Show / update / supersede | `orbit_learning_show/update/supersede({...})` | `orbit learning show --id L-0001` / `update --id L-0001 --priority 200` / `supersede --id L-0001 --with L-0007` |
+| Show / update / supersede | `orbit_learning_show/update/supersede({...})` | `orbit learning show L-0001` / `update --id L-0001 --priority 200` / `supersede --id L-0001 --with L-0007` |
 | List/audit, prune, sync | CLI-only | `orbit learning list --status active --tag rust [--path <glob>]`, `orbit learning prune --stale-only [--delete]`, `orbit learning sync` |
 
 **Workflow:** (1) search first — `orbit learning list --path/--tag` or `orbit search --kind learning` — prefer `update`/`supersede` over a duplicate. (2) Add with tight `scope: { paths?, tags? }` (OR semantics — fires on *any* path glob OR *any* tag; split concerns into separate learnings rather than over-broadening one). Include `evidence: [{kind: "task"|"commit"|"external", ref: "..."}]` whenever it came from a real incident/PR/task — a learning you can't cite a source for is a hunch. `priority` (0–255) is a secondary search-ranking key, not an importance badge. Keep `summary` ≤280 chars, written as a directive ("Always X before Y in `<crate>`"), since push-injection surfaces it first. (3) `prune --stale-only` periodically to surface learnings whose `scope.paths` no longer resolve; read before `--delete`. (4) `sync` (CLI-only) re-syncs the SQLite envelope index if YAML was touched out-of-band (merge, branch switch) — YAML is the source of truth.
@@ -39,7 +39,7 @@ orbit learning add --summary "Always run \`make fmt\` before committing under cr
 
 Common mistakes: hand-writing YAML (skips envelope+attribution — use the tools); creating a duplicate without checking first (two overlapping-scope records inject twice and contradict); `update` to "fix" a fundamental change in advice (loses the supersede chain — `supersede` instead); `scope` with no `paths` and no `tags` (never injects).
 
-Exit: the learning exists/updates through `orbit.learning.*`, has a directive `summary`, ≥1 `paths`/`tags` entry, evidence when it exists, and is retrievable via `orbit learning show --id <ID>`. A code-anchored learning ships its citation in the same change.
+Exit: the learning exists/updates through `orbit.learning.*`, has a directive `summary`, ≥1 `paths`/`tags` entry, evidence when it exists, and is retrievable via `orbit learning show <ID>`. A code-anchored learning ships its citation in the same change.
 
 ## ADRs
 

--- a/plugin/skills/orbit-task/SKILL.md
+++ b/plugin/skills/orbit-task/SKILL.md
@@ -122,7 +122,7 @@ Exit: all findings filed with `model` attribution; no status transitions/resolut
 
 File **agent-discovered Orbit tooling, workflow, or seeded-instruction friction** as an append-only report instead of silently working around it — unclear command behavior, missing CLI functionality, confusing schema/config, doc gaps, unclear errors, unexpected runtime behavior, confusing seed instructions, or insufficient/vague activity-asset or `SKILL.md` prompts. **Not** for task content issues, ordinary user-requested work, or generic bugs.
 
-Stored under `.orbit/frictions/` as append-only markdown+frontmatter — no lifecycle, triage state, or scoreboard.
+Friction bodies are append-only markdown reports under `.orbit/frictions/`; their triage metadata is mutable. New records start `open` and may be `triaged` or `resolved`. Human/orchestrator triage uses `orbit friction update <ID> --status triaged` (and optional replacement tags), while `orbit friction resolve <ID>` closes a report. When a task fixes the underlying cause, add `relations: [{"type":"resolves","target":"F<YYYY>-<MM>-<NNN>"}]`: that task auto-resolves an existing friction and records `resolved_by_task` when it reaches `done`; a dangling target is audit-visible but does not block task completion.
 
 | Tag | Use for |
 | --- | --- |


### PR DESCRIPTION
## Task

[ORB-10210](https://orbit-cli.com/tasks/ORB-10210) — Correct friction lifecycle and learning-show skill guidance

### Description

## Problem
Orbit skill guidance currently documents `orbit learning show --id L-…`, although the CLI requires a positional ID. The task/friction guidance also says friction records have no lifecycle or triage state even though Orbit persists `open`/`triaged`/`resolved` metadata and exposes update/resolve commands.

## Why It Matters
Agents following the shipped skills hit avoidable command failures and cannot tell whether a request to resolve friction means fixing the cause, updating triage metadata, or both.

## Constraints / Notes
- Keep the canonical asset and plugin skill copies identical.
- Describe friction bodies as append-only while accurately documenting mutable triage metadata and task-relation auto-resolution.
- Current canonical knowledge guidance is consolidated under `orbit-knowledge`; legacy standalone installed copies are environment cleanup, not new canonical skill assets.
- Preserve unrelated primary-checkout edits by working in a dedicated worktree.

### Acceptance Criteria

- Every shipped/plugin learning-show example uses the positional `orbit learning show <ID>` syntax, while commands that genuinely require `--id` retain it.
- Shipped task/friction guidance accurately documents open/triaged/resolved metadata, `orbit friction update|resolve`, and task `resolves` side effects without claiming that no friction lifecycle exists.
- Canonical `crates/orbit-core/assets/skills` and `plugin/skills` copies remain in parity and the relevant skill-validation/guardrail tests pass.
- `make ci-fast` passes and CHANGELOG.md contains a concise ORB task entry.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Corrected every shipped `orbit learning show` example to use the required positional ID while retaining `--id` on update and supersede commands.
- Rewrote friction guidance to distinguish append-only report bodies from mutable open/triaged/resolved triage metadata, document `orbit friction update|resolve` as human/orchestrator actions, and explain task `resolves` auto-resolution plus `resolved_by_task`.
- Kept canonical asset and plugin skill copies byte-identical, and added the required Unreleased changelog entry.

Validation:
- `./scripts/validate-codex-plugin.sh .`, copy-parity checks, positional-command checks, and `git diff --check` passed.
- `make ci-fast` began successfully but stopped at `scripts/test-installer-security.sh` because `node` is not installed in this runner.
- `cargo test -p orbit-core plugin_skill_symlinks_resolve_to_assets` was attempted but fails on the pre-existing, out-of-scope mismatch between `plugin/skills/orbit` and its canonical asset; the two skill pairs changed by this task pass byte-for-byte parity checks.

Assessment: Scoped documentation correction is complete; remaining validation failures are unrelated runner/baseline conditions.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10210-6a580f00`
- Behind base: 0
- Ahead of base: 1