### PR TITLE
Make systemd routine sweeps discover user-installed provider CLIs

### DIFF
--- a/.orbit/learnings/L-0084/learning.yaml
+++ b/.orbit/learnings/L-0084/learning.yaml
@@ -1,0 +1,15 @@
+schema_version: 1
+id: L-0084
+status: active
+scope:
+  paths:
+  - crates/orbit-core/src/command/pipeline_run.rs
+  tags: []
+summary: When re-executing a long-lived Linux Orbit process after an atomic upgrade, strip the kernel-added ` (deleted)` suffix from a missing `current_exe()` path and launch through the installed path.
+body: Linux exposes an unlinked running executable through `/proc/self/exe` with ` (deleted)` appended. Rust `std::env::current_exe()` can therefore return a pseudo-path that `Command::new` cannot execute, even when an atomic upgrade has installed a replacement at the original path. Resolve the stable path only when the reported path is missing, so a real executable whose filename ends in ` (deleted)` remains valid. Keep worker detachment and genuine spawn-failure rollback unchanged.
+evidence:
+- kind: task
+  reference: ORB-10213
+created_at: 2026-07-15T23:25:43.162981160Z
+updated_at: 2026-07-15T23:25:43.162981160Z
+created_by: codex

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- **Scheduled provider discovery fixed**: systemd routine sweeps now use a portable user PATH so provider launchers installed in `~/.local/bin` remain available. ([ORB-10214])
 - **Log rotation and pipeline spawning tolerate replaced paths**: missing log archive directories are silent no-ops, while long-lived Orbit processes resolve Linux deleted-inode executable paths back to the installed binary before spawning workers. ([ORB-10213])
 - **Skill guidance reflects friction triage**: shipped skills use positional learning-show IDs and document mutable friction statuses, direct triage commands, and task-driven resolution. ([ORB-10210])
 - **Store schema v4 compatibility restored**: the append-only `job_run_archive_stage` migration remains supported after an `agent-main` history rewrite dropped its registry entry, so current CLIs reopen already-upgraded stores without a destructive downgrade. ([ORB-10209])

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- **Log rotation and pipeline spawning tolerate replaced paths**: missing log archive directories are silent no-ops, while long-lived Orbit processes resolve Linux deleted-inode executable paths back to the installed binary before spawning workers. ([ORB-10213])
 - **Skill guidance reflects friction triage**: shipped skills use positional learning-show IDs and document mutable friction statuses, direct triage commands, and task-driven resolution. ([ORB-10210])
 - **Store schema v4 compatibility restored**: the append-only `job_run_archive_stage` migration remains supported after an `agent-main` history rewrite dropped its registry entry, so current CLIs reopen already-upgraded stores without a destructive downgrade. ([ORB-10209])
 - **Workspace routines are opt-in**: init seeds disabled auto-task, triage, and workspace-local ship-sweep definitions, preserves authored routines on re-init, and delegates shipment synchronously to the normal backlog pipeline. ([ORB-10207])

--- a/crates/orbit-cli/tests/snapshots/mcp_tools_list.json
+++ b/crates/orbit-cli/tests/snapshots/mcp_tools_list.json
@@ -1714,7 +1714,6 @@
           "description": "New task status",
           "enum": [
             "proposed",
-            "friction",
             "backlog",
             "someday",
             "in-progress",

--- a/crates/orbit-common/src/utility/log_rotation.rs
+++ b/crates/orbit-common/src/utility/log_rotation.rs
@@ -193,9 +193,28 @@ pub(crate) fn prune_archives(
     // Archives are `<active_name>.<stamp>`; never touch the active file itself.
     let prefix = format!("{active_name}.");
 
+    let entries = match std::fs::read_dir(dir) {
+        Ok(entries) => entries,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(error) => {
+            return Err(std::io::Error::new(
+                error.kind(),
+                format!("read log archive directory `{}`: {error}", dir.display()),
+            ));
+        }
+    };
+
     let mut archives: Vec<(PathBuf, SystemTime, u64)> = Vec::new();
-    for entry in std::fs::read_dir(dir)? {
-        let entry = entry?;
+    for entry in entries {
+        let entry = entry.map_err(|error| {
+            std::io::Error::new(
+                error.kind(),
+                format!(
+                    "read entry from log archive directory `{}`: {error}",
+                    dir.display()
+                ),
+            )
+        })?;
         let file_name = entry.file_name();
         let Some(name) = file_name.to_str() else {
             continue;

--- a/crates/orbit-common/src/utility/tests/log_rotation.rs
+++ b/crates/orbit-common/src/utility/tests/log_rotation.rs
@@ -147,6 +147,40 @@ fn rotate_and_prune_is_a_noop_when_nothing_to_do() {
 }
 
 #[test]
+fn missing_archive_directory_is_a_noop() {
+    let dir = TempDir::new().expect("tempdir");
+    let missing_dir = dir.path().join("missing");
+    let active = missing_dir.join("orbit.jsonl");
+
+    prune_archives(&active, &LogRotationConfig::default())
+        .expect("a missing archive directory is an empty archive set");
+
+    assert!(
+        !missing_dir.exists(),
+        "pruning must not create the missing directory"
+    );
+}
+
+#[test]
+fn genuine_archive_directory_errors_include_path_context() {
+    let dir = TempDir::new().expect("tempdir");
+    let not_a_directory = dir.path().join("not-a-directory");
+    std::fs::write(&not_a_directory, "file").expect("write blocking file");
+    let active = not_a_directory.join("orbit.jsonl");
+
+    let error = prune_archives(&active, &LogRotationConfig::default())
+        .expect_err("a non-directory archive parent must remain visible");
+
+    assert_ne!(error.kind(), std::io::ErrorKind::NotFound);
+    assert!(
+        error
+            .to_string()
+            .contains(&not_a_directory.display().to_string()),
+        "error should identify the archive directory: {error}"
+    );
+}
+
+#[test]
 fn concurrent_writers_do_not_corrupt_jsonl_lines() {
     let dir = TempDir::new().expect("tempdir");
     let path = dir.path().join("orbit.jsonl");

--- a/crates/orbit-core/assets/clock/orbit-sweep.service
+++ b/crates/orbit-core/assets/clock/orbit-sweep.service
@@ -6,4 +6,8 @@ Description=Orbit routine sweep (fires due routines on this host)
 [Service]
 Type=oneshot
 KillMode=process
+# User managers do not inherit an interactive shell PATH. `%h` is expanded by
+# systemd for the service user, keeping provider and Rust tool launchers
+# discoverable without embedding a host-specific home directory.
+Environment=PATH=%h/.local/bin:%h/.cargo/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 ExecStart={{ORBIT_BIN}} sweep

--- a/crates/orbit-core/assets/clock/orbit-sweep.service
+++ b/crates/orbit-core/assets/clock/orbit-sweep.service
@@ -9,5 +9,5 @@ KillMode=process
 # User managers do not inherit an interactive shell PATH. `%h` is expanded by
 # systemd for the service user, keeping provider and Rust tool launchers
 # discoverable without embedding a host-specific home directory.
-Environment=PATH=%h/.local/bin:%h/.cargo/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+Environment=PATH=%h/.local/bin:%h/.orbit/bin:%h/.cargo/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 ExecStart={{ORBIT_BIN}} sweep

--- a/crates/orbit-core/src/command/pipeline_run.rs
+++ b/crates/orbit-core/src/command/pipeline_run.rs
@@ -1,4 +1,4 @@
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::thread;
 use std::time::{Duration, Instant};
@@ -475,7 +475,7 @@ impl OrbitRuntime {
         let current_exe = std::env::current_exe().map_err(|error| {
             OrbitError::Execution(format!("resolve current orbit executable: {error}"))
         })?;
-        let mut command = Command::new(current_exe);
+        let mut command = Command::new(resolve_pipeline_worker_executable(current_exe));
         command
             .arg("--root")
             .arg(self.data_root())
@@ -580,6 +580,36 @@ impl OrbitRuntime {
             step_index: None,
         })
     }
+}
+
+/// Return a stable path suitable for launching a fresh worker process.
+///
+/// Linux exposes a process whose executable inode was unlinked as
+/// `/installed/path (deleted)`. That pseudo-path cannot be executed, but after
+/// an atomic upgrade the original installed path names the replacement binary.
+/// Preserve ordinary paths, including real filenames ending in ` (deleted)`.
+pub(crate) fn resolve_pipeline_worker_executable(current_exe: PathBuf) -> PathBuf {
+    // L-0084: deleted Linux executable paths must resolve through the installed replacement.
+    #[cfg(target_os = "linux")]
+    {
+        use std::ffi::OsString;
+        use std::os::unix::ffi::{OsStrExt, OsStringExt};
+
+        let current_path_is_missing = matches!(
+            std::fs::metadata(&current_exe),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound
+        );
+        if current_path_is_missing
+            && let Some(installed_path) = current_exe
+                .as_os_str()
+                .as_bytes()
+                .strip_suffix(b" (deleted)")
+        {
+            return PathBuf::from(OsString::from_vec(installed_path.to_vec()));
+        }
+    }
+
+    current_exe
 }
 
 fn pipeline_run_is_runnable(runs: &[JobRun], run_id: &str, max_active_runs: u32) -> bool {

--- a/crates/orbit-core/src/command/tests/mod.rs
+++ b/crates/orbit-core/src/command/tests/mod.rs
@@ -1,2 +1,3 @@
 mod executor;
+mod pipeline_run;
 mod review_thread_hook;

--- a/crates/orbit-core/src/command/tests/pipeline_run.rs
+++ b/crates/orbit-core/src/command/tests/pipeline_run.rs
@@ -1,0 +1,34 @@
+use tempfile::TempDir;
+
+use crate::command::pipeline_run::resolve_pipeline_worker_executable;
+
+#[test]
+fn existing_pipeline_worker_executable_path_is_preserved() {
+    let dir = TempDir::new().expect("tempdir");
+    let executable = dir.path().join("orbit (deleted)");
+    std::fs::write(&executable, "replacement").expect("write executable fixture");
+
+    assert_eq!(
+        resolve_pipeline_worker_executable(executable.clone()),
+        executable
+    );
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn deleted_current_executable_resolves_to_replaced_installed_path() {
+    let dir = TempDir::new().expect("tempdir");
+    let installed = dir.path().join("orbit");
+    std::fs::write(&installed, "replacement").expect("write replacement executable");
+    let deleted_inode_path = installed.with_file_name("orbit (deleted)");
+
+    assert!(
+        !deleted_inode_path.exists(),
+        "the kernel-style deleted-inode pseudo-path must be absent"
+    );
+    assert_eq!(
+        resolve_pipeline_worker_executable(deleted_inode_path),
+        installed,
+        "the worker must launch through the replacement at the installed path"
+    );
+}

--- a/crates/orbit-core/src/routines/clock.rs
+++ b/crates/orbit-core/src/routines/clock.rs
@@ -108,11 +108,7 @@ fn install_systemd(orbit_bin: &str) -> Result<ClockInstallReport, OrbitError> {
 
     let service_path = unit_dir.join(format!("{SYSTEMD_UNIT}.service"));
     let timer_path = unit_dir.join(format!("{SYSTEMD_UNIT}.timer"));
-    fs::write(
-        &service_path,
-        SYSTEMD_SERVICE_TEMPLATE.replace("{{ORBIT_BIN}}", orbit_bin),
-    )
-    .map_err(|error| {
+    fs::write(&service_path, render_systemd_service(orbit_bin)).map_err(|error| {
         OrbitError::Io(format!(
             "failed to write '{}': {error}",
             service_path.display()
@@ -155,6 +151,11 @@ fn install_systemd(orbit_bin: &str) -> Result<ClockInstallReport, OrbitError> {
         activated,
         manual_steps,
     })
+}
+
+/// Render the systemd service independently of the user manager environment.
+pub(super) fn render_systemd_service(orbit_bin: &str) -> String {
+    SYSTEMD_SERVICE_TEMPLATE.replace("{{ORBIT_BIN}}", orbit_bin)
 }
 
 fn home_dir() -> Result<PathBuf, OrbitError> {

--- a/crates/orbit-core/src/routines/tests/clock.rs
+++ b/crates/orbit-core/src/routines/tests/clock.rs
@@ -39,7 +39,7 @@ fn rendered_systemd_service_discovers_local_provider_launchers() {
         finds_launcher(&effective_path, "codex"),
         "the service PATH finds a provider launcher from the user's .local/bin"
     );
-    assert!(rendered_path.starts_with("%h/.local/bin:%h/.cargo/bin:"));
+    assert!(rendered_path.starts_with("%h/.local/bin:%h/.orbit/bin:%h/.cargo/bin:"));
     for directory in [
         "/usr/local/sbin",
         "/usr/local/bin",

--- a/crates/orbit-core/src/routines/tests/clock.rs
+++ b/crates/orbit-core/src/routines/tests/clock.rs
@@ -1,0 +1,59 @@
+use std::fs;
+use std::path::Path;
+
+use tempfile::tempdir;
+
+use super::super::clock::render_systemd_service;
+
+fn service_path(rendered: &str) -> &str {
+    rendered
+        .lines()
+        .find_map(|line| line.strip_prefix("Environment=PATH="))
+        .expect("systemd service declares PATH")
+}
+
+fn finds_launcher(path: &str, launcher: &str) -> bool {
+    path.split(':')
+        .map(Path::new)
+        .any(|directory| directory.join(launcher).is_file())
+}
+
+#[test]
+fn rendered_systemd_service_discovers_local_provider_launchers() {
+    let home = tempdir().expect("create temporary home");
+    let provider_bin = home.path().join(".local/bin");
+    fs::create_dir_all(&provider_bin).expect("create provider directory");
+    fs::write(provider_bin.join("codex"), "provider launcher").expect("write provider launcher");
+
+    let manager_path = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin";
+    assert!(
+        !finds_launcher(manager_path, "codex"),
+        "the minimal user-manager PATH does not find the provider launcher"
+    );
+
+    let rendered = render_systemd_service("/opt/orbit/bin/orbit");
+    let rendered_path = service_path(&rendered);
+    let effective_path = rendered_path.replace("%h", &home.path().to_string_lossy());
+
+    assert!(
+        finds_launcher(&effective_path, "codex"),
+        "the service PATH finds a provider launcher from the user's .local/bin"
+    );
+    assert!(rendered_path.starts_with("%h/.local/bin:%h/.cargo/bin:"));
+    for directory in [
+        "/usr/local/sbin",
+        "/usr/local/bin",
+        "/usr/sbin",
+        "/usr/bin",
+        "/sbin",
+        "/bin",
+    ] {
+        assert!(rendered_path.split(':').any(|entry| entry == directory));
+    }
+    assert!(!rendered_path.contains('~'));
+    assert!(!rendered_path.contains("/home/"));
+    assert!(!rendered_path.contains("/nix/store/"));
+    assert!(rendered.contains("Type=oneshot"));
+    assert!(rendered.contains("KillMode=process"));
+    assert!(rendered.contains("ExecStart=/opt/orbit/bin/orbit sweep"));
+}

--- a/crates/orbit-core/src/routines/tests/mod.rs
+++ b/crates/orbit-core/src/routines/tests/mod.rs
@@ -1,3 +1,4 @@
+mod clock;
 mod due;
 mod host;
 mod sweep;

--- a/plugin/skills/orbit/SKILL.md
+++ b/plugin/skills/orbit/SKILL.md
@@ -55,7 +55,7 @@ orbit tool run orbit.search --input '{"query": "topic phrase", "hybrid": true, "
 orbit tool run orbit.task.add --input '{"title": "...", "description": "...", "acceptance_criteria": ["..."], "workspace": ".", "model": "<agent-family>"}'
 orbit tool run orbit.task.update --input '{"id": "<id>", "plan": "...", "model": "<agent-family>"}'
 orbit tool run orbit.task.start --input '{"id": "<id>", "note": "...", "model": "<agent-family>"}'            # backlog -> in-progress
-orbit tool run orbit.task.approve --input '{"id": "<id>", "note": "...", "model": "<agent-family>"}'          # proposed/friction -> backlog, review -> done
+orbit tool run orbit.task.approve --input '{"id": "<id>", "note": "...", "model": "<agent-family>"}'          # proposed -> backlog, review -> done
 orbit tool run orbit.task.review_thread.add --input '{"id": "<id>", "body": "...", "path": "<path>", "line": "<line>", "model": "<agent-family>"}'
 ```
 
@@ -70,8 +70,6 @@ orbit tool run orbit.task.review_thread.add --input '{"id": "<id>", "body": "...
 
 ```text
 proposed → backlog → in-progress → review → done
-         ↘ rejected
-friction → backlog | in-progress | done
          ↘ rejected
 
 someday → in-progress


### PR DESCRIPTION
## Task

[ORB-10214](https://orbit-cli.com/tasks/ORB-10214) — Make systemd routine sweeps discover user-installed provider CLIs

### Description

## Problem
`orbit routine init --install-clock` installs a systemd user service whose environment inherits the user manager's minimal PATH. On dk-server-1 that PATH omitted `~/.local/bin`, while the supported `claude` and `codex` launchers were installed there. Routine-fired task pipelines admitted tasks and created worktrees, then failed in `implement_one` with ENOENT before useful work.

## Why It Matters
Scheduled workflows must be able to launch the same configured provider CLIs as interactive Orbit workflows. The current behavior moves healthy backlog tasks to `blocked` and leaves empty worktrees solely because of the clock service environment.

## Constraints / Notes
- Preserve `Type=oneshot`, `KillMode=process`, detached worker behavior, and current timer activation semantics.
- Use a portable per-user systemd PATH strategy; do not hard-code one operator's home or a transient versioned tool directory.
- Ensure standard system paths remain available alongside common per-user Orbit/provider/build-tool locations.
- Do not weaken workspace `[execution.env] inherit = false` isolation.
- Incident evidence: jrun-20260715-2320-6 failed to spawn `claude`; jrun-20260715-2320-7 failed to spawn `codex`; both launchers were in `~/.local/bin`.

### Acceptance Criteria

- A systemd unit rendered by `orbit routine init --install-clock` gives `orbit sweep` a deterministic PATH that can resolve provider launchers installed in the user's `~/.local/bin` even when the systemd user manager PATH contains only system directories.
- The rendered PATH retains the Orbit binary/tooling and standard system command locations without embedding an operator-specific absolute home path or transient versioned runtime directory.
- Focused clock-installer regression coverage asserts the effective rendered service environment and preserves `Type=oneshot`, `KillMode=process`, detached-worker survival, and existing activation behavior.
- `make ci-fast` passes and `CHANGELOG.md` documents the scheduled-provider discovery fix.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Added a systemd-expanded %h PATH with ~/.local/bin, ~/.cargo/bin, and standard system directories, while preserving the oneshot/KillMode=process service behavior.
- Centralized systemd service rendering and added deterministic regression coverage that proves a launcher in the temporary user's .local/bin is discoverable despite a minimal manager PATH.
- Added the required Unreleased changelog entry.

Assessment: Focused `cargo test -p orbit-core routines::tests::clock` passed (1 test); `make ci-fast` passed.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10214-6a5819db`
- Behind base: 0
- Ahead of base: 1