### PR TITLE
Make bundled public skills repository-agnostic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- **Bundled skills are repository-agnostic**: the embedded skill tree drops Orbit-source paths, private Constellation names, workspace-local artifact IDs, and fixed design-doc filenames; a portability regression test and byte-aligned plugin mirrors guard against reintroduction. ([ORB-10208])
 - **Scheduled provider discovery fixed**: systemd routine sweeps now use a portable user PATH so provider launchers installed in `~/.local/bin` remain available. ([ORB-10214])
 - **Log rotation and pipeline spawning tolerate replaced paths**: missing log archive directories are silent no-ops, while long-lived Orbit processes resolve Linux deleted-inode executable paths back to the installed binary before spawning workers. ([ORB-10213])
 - **Skill guidance reflects friction triage**: shipped skills use positional learning-show IDs and document mutable friction statuses, direct triage commands, and task-driven resolution. ([ORB-10210])

--- a/crates/orbit-core/assets/skills/orbit-knowledge/SKILL.md
+++ b/crates/orbit-core/assets/skills/orbit-knowledge/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: orbit-knowledge
-description: Create, search, update, supersede, prune, or audit Orbit's two durable-decision primitives — project learnings (recurring gotchas, incident root-causes, cross-session guardrails, push-injected by scope) and Architecture Decision Records (ADRs — decisions with a real alternative, accepted/proposed/superseded lifecycle, global ID allocation). Triggers on "learning", "gotcha", "guardrail", "ADR", "decision record", "4_decisions.md", accepting/superseding a decision, or adding a `## ADR-` heading. Covers scope-OR matching, evidence shape, update-vs-supersede (there is no comment or vote surface — corrections go through `update`/`supersede`, provenance through `evidence`), and why to never hand-edit `.orbit/learnings/` or `.orbit/adrs/`.
+description: Create, search, update, supersede, prune, or audit Orbit's two durable-decision primitives — project learnings (recurring gotchas, incident root-causes, cross-session guardrails, push-injected by scope) and Architecture Decision Records (ADRs — decisions with a real alternative, accepted/proposed/superseded lifecycle, global ID allocation). Triggers on "learning", "gotcha", "guardrail", "ADR", "decision record", editing an ADR decision-record file, accepting/superseding a decision, or adding a `## ADR-` heading. Covers scope-OR matching, evidence shape, update-vs-supersede (there is no comment or vote surface — corrections go through `update`/`supersede`, provenance through `evidence`), and why to never hand-edit `.orbit/learnings/` or `.orbit/adrs/`.
 ---
 
 # Orbit Knowledge
@@ -15,26 +15,26 @@ Both surfaces (MCP `orbit_learning_*`/`orbit_adr_*`, CLI `orbit tool run orbit.l
 - **Never invent an ID.** `add` allocates both learning and ADR IDs globally; cite the returned ID verbatim.
 - **Stage new artifact files from the current worktree** alongside the code/doc change that motivated them — sibling worktrees see remote stubs until that worktree's body files are locally readable.
 - **Update replaces, does not merge** — re-pass unchanged fields (`scope`/`evidence` for learnings; full body for ADRs) or you'll silently wipe them. **Supersede** when guidance/decision materially changes; it writes both pointers atomically and excludes the old record from default search. `update` is rejected on an already-superseded record — `supersede` again instead.
-- **Citation-at-anchor, with a hard prohibition.** When a learning/ADR encodes a convention enforced at a specific code site, drop a one-line citation (`// L-NNNN: <rationale>` or `// <adr-id>: <rationale>`) at that site. **Never** place the citation inside `crates/**/assets/**` (skill files, prompt assets, shipped plugin assets) or other consumer-facing surfaces — workspace-local artifact IDs become dangling references in other workspaces. At those surfaces, the push-injected learning (or a `## Consequences` sentence for ADRs) is the delivery mechanism instead.
+- **Citation-at-anchor, with a hard prohibition.** When a learning/ADR encodes a convention enforced at a specific code site, drop a one-line citation (`// L-NNNN: <rationale>` or `// <adr-id>: <rationale>`) at that site. **Never** place the citation inside shipped instruction or prompt assets (skill files, prompt templates, bundled plugin assets) or any other consumer-facing surface served to other workspaces — workspace-local artifact IDs become dangling references there. At those surfaces, the push-injected learning (or a `## Consequences` sentence for ADRs) is the delivery mechanism instead.
 - **Search before adding**, to avoid duplicate/contradicting records covering the same scope.
 
 ## Learnings
 
 | Tool / workflow | MCP | CLI |
 |------|-----|-----|
-| Add | `orbit_learning_add({...})` | `orbit learning add --summary "..." --path "crates/orbit-core/**/*.rs" --tag rust --body-file note.md` |
+| Add | `orbit_learning_add({...})` | `orbit learning add --summary "..." --path "src/**/*.rs" --tag rust --body-file note.md` |
 | Search | `orbit_search({...})` | `orbit search --kind learning <text>` (add `--hybrid` after `orbit semantic index --kind learnings`) |
-| Show / update / supersede | `orbit_learning_show/update/supersede({...})` | `orbit learning show L-0001` / `update --id L-0001 --priority 200` / `supersede --id L-0001 --with L-0007` |
+| Show / update / supersede | `orbit_learning_show/update/supersede({...})` | `orbit learning show L-NNNN` / `update --id L-NNNN --priority 200` / `supersede --id L-NNNN --with L-MMMM` |
 | List/audit, prune, sync | CLI-only | `orbit learning list --status active --tag rust [--path <glob>]`, `orbit learning prune --stale-only [--delete]`, `orbit learning sync` |
 
 **Workflow:** (1) search first — `orbit learning list --path/--tag` or `orbit search --kind learning` — prefer `update`/`supersede` over a duplicate. (2) Add with tight `scope: { paths?, tags? }` (OR semantics — fires on *any* path glob OR *any* tag; split concerns into separate learnings rather than over-broadening one). Include `evidence: [{kind: "task"|"commit"|"external", ref: "..."}]` whenever it came from a real incident/PR/task — a learning you can't cite a source for is a hunch. `priority` (0–255) is a secondary search-ranking key, not an importance badge. Keep `summary` ≤280 chars, written as a directive ("Always X before Y in `<crate>`"), since push-injection surfaces it first. (3) `prune --stale-only` periodically to surface learnings whose `scope.paths` no longer resolve; read before `--delete`. (4) `sync` (CLI-only) re-syncs the SQLite envelope index if YAML was touched out-of-band (merge, branch switch) — YAML is the source of truth.
 
-Legacy `L<YYYYMMDD>-N` IDs were migrated by ORB-00200 and should only appear in `legacy_ids`; canonical format is `L-NNNN`. Corrections to current wording go through `update`; material changes go through `supersede`; provenance for a new observation goes into `evidence`. (ORB-10046 removed the vote and comment surfaces — `priority` + search rank cover ranking, and `update`/`supersede`/`evidence` cover corrections/provenance.)
+Legacy `L<YYYYMMDD>-N` IDs were migrated and should only appear in `legacy_ids`; canonical format is `L-NNNN`. Corrections to current wording go through `update`; material changes go through `supersede`; provenance for a new observation goes into `evidence`. (The vote and comment surfaces were removed — `priority` + search rank cover ranking, and `update`/`supersede`/`evidence` cover corrections/provenance.)
 
 ```bash
-orbit learning add --summary "Always run \`make fmt\` before committing under crates/orbit-cli — clippy fails on stray spacing" \
-  --path "crates/orbit-cli/**/*.rs" --tag rust --tag formatting --body-file /tmp/learning.md \
-  --evidence task:T20260514-3 --priority 100 --json
+orbit learning add --summary "Always run the repo formatter before committing under src/ — the linter fails on stray spacing" \
+  --path "src/**/*.rs" --tag lang --tag formatting --body-file /tmp/learning.md \
+  --evidence task:<task-id> --priority 100 --json
 ```
 
 Common mistakes: hand-writing YAML (skips envelope+attribution — use the tools); creating a duplicate without checking first (two overlapping-scope records inject twice and contradict); `update` to "fix" a fundamental change in advice (loses the supersede chain — `supersede` instead); `scope` with no `paths` and no `tags` (never injects).
@@ -49,11 +49,11 @@ Exit: the learning exists/updates through `orbit.learning.*`, has a directive `s
 
 Listing is **not** on the agent MCP surface — use `orbit search --kind adr` for read-side discovery; CLI/admin retains `orbit tool run orbit.adr.list --input '{"feature":"<feature>"}'` (agents shouldn't call it via MCP). ADRs and docs are sibling indexes: `orbit search --kind all|doc|adr` federates ADR metadata read-only; `--hybrid` applies to `--kind adr` after `orbit semantic index --kind adrs`.
 
-**When editing `docs/design/<feature>/4_decisions.md` directly:** if you're about to add or rename a `## ADR-` heading, **stop and run `orbit.adr.add` first**, then use the allocated global ID as the local heading verbatim. Picking the next sequential local number, or a number that merely "looks global," both produce orphan decisions invisible to `orbit search --kind adr` / `orbit.adr.show` / legacy_id resolution. Backfill an existing local-numbered ADR via `orbit.adr.add` and set `legacy_ids`.
+**When your repo keeps ADR headings in a docs file and you edit one directly:** if you're about to add or rename a `## ADR-` heading, **stop and run `orbit.adr.add` first**, then use the allocated global ID as the local heading verbatim. (Where that file lives — its name and location — follows the target repo's own instructions and configured docs roots, not a fixed convention.) Picking the next sequential local number, or a number that merely "looks global," both produce orphan decisions invisible to `orbit search --kind adr` / `orbit.adr.show` / legacy_id resolution. Backfill an existing local-numbered ADR via `orbit.adr.add` and set `legacy_ids`.
 
-**Workflow:** (1) inspect nearby decisions first (`orbit search "<concept>" --kind adr`, `orbit.adr.show`, `legacy_id` lookup for migrated per-feature refs). (2) new decision → `add`; body/metadata correction → `update`; reversal of an accepted ADR → create the replacement, accept it with a related task, then `supersede`. (3) body needs exactly `## Context`, `## Decision`, `## Consequences`, with ≥1 consequences bullet starting `Cost:`. (4) `related_features` = feature-folder names; `tags` = free-form cross-artifact labels; `paths` = repo-relative globs the decision constrains. (5) `related_tasks` may be empty for a speculative proposed ADR — don't invent a task just to satisfy one; **acceptance requires a real related task**. (6) verify with `.show` or `orbit search --kind adr`.
+**Workflow:** (1) inspect nearby decisions first (`orbit search "<concept>" --kind adr`, `orbit.adr.show`, `legacy_id` lookup for migrated per-feature refs). (2) new decision → `add`; body/metadata correction → `update`; reversal of an accepted ADR → create the replacement, accept it with a related task, then `supersede`. (3) body needs exactly `## Context`, `## Decision`, `## Consequences`, with ≥1 consequences bullet starting `Cost:`. (4) `related_features` = feature/area names; `tags` = free-form cross-artifact labels; `paths` = repo-relative globs the decision constrains. (5) `related_tasks` may be empty for a speculative proposed ADR — don't invent a task just to satisfy one; **acceptance requires a real related task**. (6) verify with `.show` or `orbit search --kind adr`.
 
-Creation is warranted only when all three hold: a real alternative was on the table, the choice constrains future work, and the cost is non-trivial and worth preserving. Otherwise put the detail in `2_design.md`, a spec, or an existing ADR's instance table.
+Creation is warranted only when all three hold: a real alternative was on the table, the choice constrains future work, and the cost is non-trivial and worth preserving. Otherwise put the detail in a design doc, a spec, or an existing ADR's instance table.
 
 ```markdown
 ## Context

--- a/crates/orbit-core/assets/skills/orbit-search/SKILL.md
+++ b/crates/orbit-core/assets/skills/orbit-search/SKILL.md
@@ -21,7 +21,7 @@ orbit search "slow inference after model swap" --limit 5
 
 # Cross-artifact label and path filters (--tag is AND when repeated)
 orbit search "scheduler" --tag perf --kind all
-orbit search path crates/orbit-search/src/lib.rs --kind all
+orbit search path src/lib.rs --kind all
 
 # Hybrid lexical + cosine over indexed fields
 orbit search "agent loop deadlock" --hybrid --kind task --limit 5
@@ -63,7 +63,7 @@ Frontmatter (`type` and `summary` required; `summary` non-empty single line):
 type: design | pattern | context | glossary | runbook
 summary: One-line hook for agent retrieval
 tags: [hook, learning, audit]
-paths: ["crates/orbit-cli/**"]
+paths: ["src/**"]
 related_features: [hook-rewrite]
 related_artifacts: ["<task-id>", "<adr-id>", "<learning-id>"]
 ---

--- a/crates/orbit-core/assets/skills/orbit-task/SKILL.md
+++ b/crates/orbit-core/assets/skills/orbit-task/SKILL.md
@@ -15,8 +15,8 @@ Create a task another engineer or agent can execute without guessing: a crisp pr
 1. Confirm objective, constraints, and done criteria.
 2. Optionally check for overlapping prior work with `orbit-search` (`hybrid: true`, `kind: "task"`).
 3. Write acceptance criteria that define observable success — no vague pass/fail language like "works correctly"; name a command, inspection step, or observable output for each.
-4. Enumerate files/dirs/symbols this task will modify or delete as canonical selectors (`file:`, `dir:`, `symbol:path#name:kind`) in `context_files`. Only modification targets — not read-for-context files, conventions/pattern docs (cite those in prose instead), or files that don't exist yet. Feature design docs under `docs/design/<feature>/` are the exception (co-change with implementation). Prefer `file:`/`symbol:` over `dir:` when changes can be named more precisely.
-5. Set `complexity` (`low`/`medium`/`hard`) whenever scope is clear enough to judge — batching honors this via `crates/orbit-engine/src/executor/automation/batch/dispatch.rs::task_prefers_single_batch`.
+4. Enumerate files/dirs/symbols this task will modify or delete as canonical selectors (`file:`, `dir:`, `symbol:path#name:kind`) in `context_files`. Only modification targets — not read-for-context files, conventions/pattern docs (cite those in prose instead), or files that don't exist yet. Design docs your repo co-locates with the code they describe are the exception (co-change with implementation). Prefer `file:`/`symbol:` over `dir:` when changes can be named more precisely.
+5. Set `complexity` (`low`/`medium`/`hard`) whenever scope is clear enough to judge — batching honors this when dispatching work.
 6. Add assumptions, risks, and rollback notes to the description when they matter.
 7. Call `orbit.task.add` with description, acceptance criteria, `context_files`, workspace, complexity, and `model`. Leave `plan` blank unless pre-seeding is justified.
 8. Confirm via the tool result, or re-fetch with `orbit.task.show`.
@@ -24,9 +24,9 @@ Create a task another engineer or agent can execute without guessing: a crisp pr
 **Operating rules:** Never edit task files directly. Never invent task IDs — `orbit.task.add` allocates them. `description` should be multi-line markdown for non-trivial tasks. Required: `title`, `description`, `workspace`. Strongly prefer `acceptance_criteria` and `complexity`. Valid `type`: `feature`, `bug`, `refactor`, `chore` — use friction (below) for self-reported tooling issues, not a task type. Blank/missing companion files (`plan.md`, `execution-summary.md`) are blank fields — repair via `orbit.task.update`, never by hand.
 
 **Behavior-affecting optional fields:**
-- `dependencies: ["ORB-NNNN", ...]` — prerequisite tasks must reach a satisfying status first (`crates/orbit-common/src/types/task.rs::task_dependencies_ready`).
-- `relations: [{"type": "resolves", "target": "F<YYYY>-<MM>-<NNN>"}]` — auto-resolves the target friction when this task reaches `done` (`crates/orbit-core/src/command/task/transitions.rs::apply_resolves_side_effects`). Other `relations` types (`produces`, `blocked_by`, `child_of`, `spawned_from`, `regression_from`, `supersedes`, `related_to`) are tracked; only `produces`/`resolves` accept non-`ORB-` targets (friction/learning/ADR IDs), the rest require `ORB-NNNNN`. Dangling `resolves`/`produces` targets succeed but emit a `TaskRelationDangling` audit event.
-- `parent_id`, `source_task_id` (bug-introducing task; creation-time only — `update` silently drops it on existing tasks, see F2026-05-024/ORB-00101), `tags` (reuse existing before inventing new).
+- `dependencies: ["ORB-NNNN", ...]` — prerequisite tasks must reach a satisfying status first.
+- `relations: [{"type": "resolves", "target": "F<YYYY>-<MM>-<NNN>"}]` — auto-resolves the target friction when this task reaches `done`. Other `relations` types (`produces`, `blocked_by`, `child_of`, `spawned_from`, `regression_from`, `supersedes`, `related_to`) are tracked; only `produces`/`resolves` accept non-`ORB-` targets (friction/learning/ADR IDs), the rest require `ORB-NNNNN`. Dangling `resolves`/`produces` targets succeed but emit a `TaskRelationDangling` audit event.
+- `parent_id`, `source_task_id` (bug-introducing task; creation-time only — `update` silently drops it on existing tasks), `tags` (reuse existing before inventing new).
 
 **Task quality bar:** validation must not assume `.orbit/knowledge/` or uncommitted artifacts; file I/O checks use temp dirs/fakes; behavior-changing tasks touching external services/FS/time should call for deterministic mock coverage in acceptance criteria; graph/knowledge task nodes define `purpose` as role + crate/module + leaf-or-internal.
 
@@ -89,7 +89,7 @@ Exit: task started via `orbit.task.start`; execution summary persisted; learning
 
 Review someone else's work and surface issues as review threads — read plus write-only-into-threads; **never** transition the reviewed task's lifecycle.
 
-**Load context.** `orbit.task.show` for `description`/`acceptance_criteria`/`plan`/`execution_summary`; inspect the diff and changed files; run `make build` and the relevant test target. Optionally `orbit.search` with `semantic: "<task-id>"` for prior similar decisions.
+**Load context.** `orbit.task.show` for `description`/`acceptance_criteria`/`plan`/`execution_summary`; inspect the diff and changed files; run the target repo's build and the relevant test commands (from its own instructions/configuration). Optionally `orbit.search` with `semantic: "<task-id>"` for prior similar decisions.
 
 **Two-stage review — stage 1 first:** spec compliance (does the change satisfy every acceptance criterion? anything missing or added beyond scope? interpretation gaps?). If it fails, file those threads and stop — don't spend time on stage 2. **Stage 2** (only if stage 1 passes): maintainability, patterns, performance, test-coverage gaps, risks/edge cases/security.
 
@@ -110,7 +110,7 @@ orbit tool run orbit.task.review_thread.resolve --input '{"id":"<task-id>","thre
 
 **Summarize** in chat: thread count, which are blockers, overall verdict (approve/request changes). Don't add a task `comment` — threads are the persistent surface.
 
-**Meta-review.** After filing threads, check whether they reveal a gap in an Orbit-authored instruction asset (`crates/orbit-core/assets/activities/*.yaml`, or a `SKILL.md`). Trigger: ≥2 threads map to the same instruction gap, or one thread is clearly a recurring class. When it fires, file a friction (see §4) *in addition to* the individual threads — never as a replacement. Skip for a single nit, a style preference, or a one-off mistake with no link to instruction text.
+**Meta-review.** After filing threads, check whether they reveal a gap in an Orbit-authored instruction asset (an activity definition or a `SKILL.md`). Trigger: ≥2 threads map to the same instruction gap, or one thread is clearly a recurring class. When it fires, file a friction (see §4) *in addition to* the individual threads — never as a replacement. Skip for a single nit, a style preference, or a one-off mistake with no link to instruction text.
 
 **Rules:** never transition the reviewed task's status; never resolve threads you authored (exception: retracting your own thread); always include `model` on `review_thread.add`/`.reply` (rejected without it — `list`/`.resolve` don't require it); replies don't create new findings, only `.add` counts toward the scoreboard. No PR yet → threads stay local; with a PR, they mirror as PR review comments.
 

--- a/crates/orbit-core/assets/skills/orbit-workflow/SKILL.md
+++ b/crates/orbit-core/assets/skills/orbit-workflow/SKILL.md
@@ -7,8 +7,8 @@ description: How to use Orbit's execution layer — jobs, activities, routines, 
 
 ## Concepts
 
-- **Job** — a deterministic, multi-step pipeline (schemaVersion 2 YAML) under `crates/orbit-core/assets/jobs/` (e.g. `task_pr_pipeline`, `task_auto_pipeline`, `task_gate_pipeline`, `task_epic_pipeline`, `job_duel_plan_pipeline`). Jobs compose **activities**.
-- **Activity** — one named step definition under `crates/orbit-core/assets/activities/*.yaml` (`agent_implement`, `agent_review`, `git_commit`, `git_push`, `pr_open`, `worktree_setup`, `reserve_locks`, ...). Activities aren't invoked directly by CLI; a job's step list references them.
+- **Job** — a deterministic, multi-step pipeline (schemaVersion 2 YAML) from the installed job catalog; discover it with `orbit job list` / `orbit job show <id>` (e.g. `task_pr_pipeline`, `task_auto_pipeline`, `task_gate_pipeline`, `task_epic_pipeline`, `job_duel_plan_pipeline`). Jobs compose **activities**.
+- **Activity** — one named step definition referenced by a job's step list (`agent_implement`, `agent_review`, `git_commit`, `git_push`, `pr_open`, `worktree_setup`, `reserve_locks`, ...). Activities aren't invoked directly by CLI; a job's step list references them.
 - **Routine** — a git-versioned cron trigger (`.orbit/routines/*.yaml`) pointing at a `job:<name>` target, with host pinning and a retry/overlap policy.
 - **Sweep** — the stateless per-minute clock tick (`orbit sweep`, fired by an OS timer) that fires whatever routine is due on this host. All scheduler state (last fires, pauses, locks) is host-local in `~/.orbit/orbit.db`, never synced; routine *definitions* sync via git.
 - **`orbit run`** — the execution frontend: `orbit run ship` / `ship-local` / `ship-sweep` (dispatch across every registered workspace) / `duel-plan` / `job <id>` / `history` / `show <run_id>` / `logs <run_id>` / `events <run_id>` / `trace <run_id>`. Equivalent job-catalog commands exist as `orbit job list|show|run|replay|resume`.
@@ -31,11 +31,11 @@ orbit run show <run_id> --json
 3. **Add a routine** — YAML under `<source>/.orbit/routines/`:
    ```yaml
    schemaVersion: 1
-   name: almanac-auto-commit
+   name: <routine-name>
    enabled: true
-   hosts: [dk-mac]                      # explicit pinning; no "any host" in v1
+   hosts: [<host-id>]                   # explicit pinning; no "any host" in v1
    trigger: { cron: "0 22 * * *", missed_run: skip }   # skip | catch_up_once
-   target: job:almanac_commit_pipeline  # job:<name> only — activity: is rejected
+   target: job:<job-name>               # job:<name> only — activity: is rejected
    policy: { timeout_minutes: 10, retries: { max: 2, backoff_minutes: 2 }, overlap: forbid }
    ```
    Parsing is fail-closed: an invalid file makes *that routine* absent and reports a load error — it never fires with defaults.
@@ -43,7 +43,7 @@ orbit run show <run_id> --json
 
 Fires appear in `orbit run history` under actor `routine/<name>`. `orbit routine pause|resume <name>` is host-local and durable across reboots. Toggle resolution order when something doesn't fire: `enabled: false` (versioned) → host not in `hosts` (versioned) → local pause (this host). `orbit routine list` shows all three.
 
-Read the full schema at `docs/design/routines/2_design.md` §1 before hand-authoring a routine — don't answer field semantics from memory.
+Consult `orbit routine --help` for the full field schema before hand-authoring a routine — don't answer field semantics from memory.
 
 ## Checking Operational Logs
 

--- a/crates/orbit-core/assets/skills/orbit-workflow/references/common_failures.md
+++ b/crates/orbit-core/assets/skills/orbit-workflow/references/common_failures.md
@@ -54,8 +54,9 @@ Confirm:
 
 ```bash
 orbit run show <run_id> --json
+orbit job show <job> --json
 rg -n '<missing_field>|<activity_name>|<job_name>' .orbit/state/audit/v2_loop/<run_id>.jsonl
-diff -u crates/orbit-core/assets/jobs/<job>.yaml ~/.orbit/resources/jobs/job_<job>.yaml
+diff -u .orbit/resources/jobs/job_<job>.yaml ~/.orbit/resources/jobs/job_<job>.yaml
 find .orbit/resources/jobs ~/.orbit/resources/jobs -name '*<job>*' -print
 ```
 

--- a/crates/orbit-core/assets/skills/orbit-workflow/references/common_failures.md
+++ b/crates/orbit-core/assets/skills/orbit-workflow/references/common_failures.md
@@ -17,7 +17,7 @@ Confirm:
 
 ```bash
 orbit locks list --json
-orbit tool run orbit.task.show --full --input '{"id":"<blocking_task_id>","model":"codex"}'
+orbit tool run orbit.task.show --full --input '{"id":"<blocking_task_id>","model":"<agent-family>"}'
 rg -n '<reservation_id>|task.locks.reserve.denied|<blocked_task_id>' .orbit/state/audit/v2_loop
 ```
 
@@ -80,7 +80,7 @@ Confirm:
 orbit run show <run_id> --json
 git -C <workspace_path> status --short --branch
 git -C <workspace_path> rev-list --left-right --count <base_ref>...HEAD
-orbit tool run orbit.task.show --full --input '{"id":"<task_id>","model":"codex"}'
+orbit tool run orbit.task.show --full --input '{"id":"<task_id>","model":"<agent-family>"}'
 ```
 
 Solution:

--- a/crates/orbit-core/assets/skills/orbit-workflow/references/debug-job-failure.md
+++ b/crates/orbit-core/assets/skills/orbit-workflow/references/debug-job-failure.md
@@ -63,7 +63,7 @@ Do not paste huge transcripts back to the human — summarize the decisive lines
 ## Distinguish Failure Classes
 
 - **Implementation failure:** the agent loop exited nonzero or reported a failed envelope during `implement_one`.
-- **Validation failure:** implementation completed but `make build`, `make fmt`, `cargo test`, or a task-specific command failed.
+- **Validation failure:** implementation completed but the repo's build, format, test, or a task-specific validation command failed.
 - **Git/branch failure:** `git_push`, `pr_open`, `git_merge`, freshness checks, rebase, or conflicts failed after implementation.
 - **Provider/tooling failure:** provider command failed before useful work, model unavailable, timeout, sandbox denial, tool surface mismatch.
 - **Recovery failure:** the original step failed and `step_failure_recovery` also failed — report both, keep the original step as primary unless recovery caused additional damage.

--- a/crates/orbit-core/assets/skills/orbit/SKILL.md
+++ b/crates/orbit-core/assets/skills/orbit/SKILL.md
@@ -26,7 +26,7 @@ Orbit tools are reachable via two surfaces. Both accept identical JSON arguments
 
 **Mapping rule**: `orbit.<group>.<action>` ↔ `orbit_<group>_<action>` (dots become underscores; JSON args identical). For multi-segment names like `orbit.task.review_thread.add`, every dot becomes an underscore: `orbit_task_review_thread_add`.
 
-**Environment parity**: the orbit tool surface is identical everywhere. On machines without a local orbit store, the same `orbit_*` tools are served by the bridge MCP, which mirrors the orbit MCP exactly (plus an optional `workspace` routing param on tools that lack one); bridge-only extensions (`workflow_ship`, `agent_invoke`, …) handle cross-workspace and pipeline operations.
+**Environment parity**: the orbit tool surface is identical across MCP and CLI. Some deployments front the orbit MCP behind a gateway that mirrors the surface exactly and may add an optional `workspace` routing param on tools that lack one. Any non-standard tools a gateway adds beyond the orbit surface are documented by that gateway, not here — consult its own reference before relying on them.
 
 **Surface coverage:**
 

--- a/crates/orbit-core/assets/skills/orbit/references/guide.md
+++ b/crates/orbit-core/assets/skills/orbit/references/guide.md
@@ -66,7 +66,7 @@ After hand-off, subsequent Orbit work routes through the rest of the `orbit` ski
 
 Routines make Orbit the host's scheduler: a git-versioned YAML definition (`.orbit/routines/*.yaml`) pairs a cron trigger with a catalog `job:<name>` target, host pinning, and a retry/overlap policy. A stateless `orbit sweep` pass — invoked every minute by the OS clock (launchd / systemd timer) — fires whatever is due on this host as a normal run. Definitions sync across hosts via git; **all scheduler state (last fires, pauses, locks) is host-local in `~/.orbit/orbit.db` and never synced.** Full detail (job/activity/`orbit run` usage) lives in the `orbit-workflow` skill; this section covers setup only.
 
-**Canonical sources — read at invocation time; don't answer routine field semantics from memory:** design contract at `docs/design/routines/2_design.md` §1 (field-by-field schema); command surface via `orbit routine --help` and `orbit sweep --help`.
+**Canonical sources — read at invocation time; don't answer routine field semantics from memory:** command surface via `orbit routine --help` and `orbit sweep --help` (field-by-field schema).
 
 Setup sequence (skeleton is stable; re-read the design doc for full field semantics before hand-authoring a routine):
 
@@ -76,13 +76,13 @@ Setup sequence (skeleton is stable; re-read the design doc for full field semant
 
    ```yaml
    schemaVersion: 1
-   name: almanac-auto-commit          # unique across all sources on a host
+   name: <routine-name>               # unique across all sources on a host
    enabled: true                       # versioned kill-switch
-   hosts: [dk-mac]                      # explicit pinning; no "any host" in v1
+   hosts: [<host-id>]                   # explicit pinning; no "any host" in v1
    trigger:
      cron: "0 22 * * *"                # 5-field, host-local time
      missed_run: skip                   # skip | catch_up_once (default: skip)
-   target: job:almanac_commit_pipeline  # job:<name> only; activity: is rejected — wrap it in a one-step job
+   target: job:<job-name>               # job:<name> only; activity: is rejected — wrap it in a one-step job
    policy:
      timeout_minutes: 10
      retries: { max: 2, backoff_minutes: 2 }
@@ -105,7 +105,7 @@ If setup or a sweep misbehaves, surface it and offer `orbit-task` friction repor
 
 If the user runs the plugin inside **Cowork** (the Claude desktop app) and only the `orbit_graph_*` tools appear — no `orbit_task_add` / ADR / learning tools — it's the known workspace-discovery gap: Cowork launches the plugin's MCP server with cwd and `CLAUDE_PROJECT_DIR` set to an internal scratchpad, not the selected repo, so `serve` finds no `.orbit/` and falls back to the graph-only surface.
 
-Fix: pass the repo explicitly via the global `--root` flag in the orbit MCP launch, in user config (`~/.claude/settings.json`) since the cached plugin copy is overwritten on reinstall. See the README "Cowork users" note for the exact `mcpServers` block — re-read it at invocation time. There is no env/cwd source for the repo path in Cowork today (see learning L-0065).
+Fix: pass the repo explicitly via the global `--root` flag in the orbit MCP launch, in user config (`~/.claude/settings.json`) since the cached plugin copy is overwritten on reinstall. See the README "Cowork users" note for the exact `mcpServers` block — re-read it at invocation time. There is no env/cwd source for the repo path in Cowork today.
 
 ## Anti-patterns (DO NOT)
 

--- a/crates/orbit-core/src/command/skill.rs
+++ b/crates/orbit-core/src/command/skill.rs
@@ -186,11 +186,16 @@ impl OrbitRuntime {
 }
 
 #[cfg(test)]
-mod drift_tests {
+mod tests {
     //! Parity tests guarding against drift between the four skill catalogs:
     //! the on-disk assets, the seeded registry, the plugin package, and the
     //! router skill's enumeration. The next agent who adds a skill folder
     //! must update all four; these tests fail loudly if any catalog lags.
+    //!
+    //! Plus a portability regression (`embedded_skills_are_repository_agnostic`)
+    //! guarding the shipped skill tree against leaking Orbit-source paths,
+    //! private Constellation names, workspace-local artifact IDs, and fixed
+    //! consumer design-doc filenames into public consumer workspaces.
 
     use super::*;
     use std::collections::BTreeSet;
@@ -502,6 +507,195 @@ mod drift_tests {
             missing.is_empty(),
             "router skill at {} does not name these default skills as inline-code identifiers (expected occurrences of `<id>`): {missing:?}\nfix by adding a bullet to the ## Skill Selection block.",
             router_path.display(),
+        );
+    }
+
+    // --- Portability regression -------------------------------------------
+    //
+    // The shipped skill tree is embedded into the binary, seeded into arbitrary
+    // consumer workspaces, and mirrored into the public plugin package. It must
+    // not encode assumptions that only hold in an Orbit source checkout or in
+    // Daniel's private Constellation environment. `portability_violations`
+    // classifies the leak families the ORB-10208 audit found; the test asserts
+    // no shipped file trips them, while allowing genuine public Orbit runtime
+    // paths (`.orbit/...`, `~/.orbit/...`) and placeholder IDs (`ORB-NNNN`,
+    // `L-NNNN`, `<task-id>`).
+
+    /// Concrete workspace-local artifact IDs (task/friction/learning) that would
+    /// become dangling references in a consumer workspace. Placeholder forms
+    /// (`ORB-NNNN`, `L-NNNN`, `<task-id>`) use non-digit stand-ins and are
+    /// intentionally *not* matched.
+    fn find_artifact_ids(content: &str) -> Vec<String> {
+        let b = content.as_bytes();
+        let n = b.len();
+        let boundary = |i: usize| i == 0 || !b[i - 1].is_ascii_alphanumeric();
+        let digit_run = |start: usize| {
+            let mut k = 0;
+            while start + k < n && b[start + k].is_ascii_digit() {
+                k += 1;
+            }
+            k
+        };
+        let starts = |i: usize, pat: &[u8]| i + pat.len() <= n && &b[i..i + pat.len()] == pat;
+        let is_digit = |j: usize| j < n && b[j].is_ascii_digit();
+
+        let mut out = Vec::new();
+        let mut i = 0;
+        while i < n {
+            if boundary(i) {
+                // ORB-<digit...> (task ids). ORB-NNNN / ORB-NNNNN placeholders
+                // have a non-digit after the dash and are skipped.
+                if starts(i, b"ORB-") && is_digit(i + 4) {
+                    let d = digit_run(i + 4);
+                    out.push(String::from_utf8_lossy(&b[i..i + 4 + d]).into_owned());
+                }
+                // L-<3+ digits> (learning ids). L-NNNN placeholder is skipped.
+                if starts(i, b"L-") {
+                    let d = digit_run(i + 2);
+                    if d >= 3 {
+                        out.push(String::from_utf8_lossy(&b[i..i + 2 + d]).into_owned());
+                    }
+                }
+                // F<yyyy>-<mm>-<nnn> (friction ids). F<YYYY>-<MM>-<NNN> is skipped.
+                if b[i] == b'F'
+                    && i + 12 <= n
+                    && (1..=4).all(|k| is_digit(i + k))
+                    && b[i + 5] == b'-'
+                    && is_digit(i + 6)
+                    && is_digit(i + 7)
+                    && b[i + 8] == b'-'
+                    && (9..=11).all(|k| is_digit(i + k))
+                {
+                    out.push(String::from_utf8_lossy(&b[i..i + 12]).into_owned());
+                }
+                // T<6+ digits> (legacy task ids like T20260514-3).
+                if b[i] == b'T' {
+                    let d = digit_run(i + 1);
+                    if d >= 6 {
+                        out.push(String::from_utf8_lossy(&b[i..i + 1 + d]).into_owned());
+                    }
+                }
+            }
+            i += 1;
+        }
+        out
+    }
+
+    /// Fixed numbered consumer design-doc filenames such as `4_decisions.md` or
+    /// `2_design.md` — an Orbit-source layout convention that does not hold in an
+    /// arbitrary consumer repo.
+    fn find_numbered_design_doc(content: &str) -> Option<String> {
+        let b = content.as_bytes();
+        let n = b.len();
+        let boundary = |i: usize| i == 0 || !b[i - 1].is_ascii_alphanumeric();
+        let mut i = 0;
+        while i < n {
+            if b[i].is_ascii_digit() && boundary(i) && i + 1 < n && b[i + 1] == b'_' {
+                let mut j = i + 2;
+                while j < n && (b[j].is_ascii_lowercase() || b[j] == b'_') {
+                    j += 1;
+                }
+                if j > i + 2 && j + 3 <= n && &b[j..j + 3] == b".md" {
+                    return Some(String::from_utf8_lossy(&b[i..j + 3]).into_owned());
+                }
+            }
+            i += 1;
+        }
+        None
+    }
+
+    /// Every reason `content` is not repository-agnostic. Empty == portable.
+    fn portability_violations(content: &str) -> Vec<String> {
+        let mut hits = Vec::new();
+
+        // Unguarded Orbit source paths (crate tree only exists in a source clone).
+        if content.contains("crates/") {
+            hits.push("Orbit source path `crates/...`".to_string());
+        }
+
+        // Private / Constellation-specific names.
+        for needle in ["almanac", "dk-mac", "dk-server", "Constellation"] {
+            if content.contains(needle) {
+                hits.push(format!("private name `{needle}`"));
+            }
+        }
+
+        // Fixed consumer design-doc filenames.
+        if let Some(name) = find_numbered_design_doc(content) {
+            hits.push(format!("fixed design-doc filename `{name}`"));
+        }
+
+        // Workspace-local artifact IDs.
+        for id in find_artifact_ids(content) {
+            hits.push(format!("workspace-local artifact id `{id}`"));
+        }
+
+        hits
+    }
+
+    #[test]
+    fn portability_checker_flags_and_allows_representative_inputs() {
+        // Fails on representative leaks from each family.
+        for bad in [
+            "see crates/orbit-core/src/lib.rs",
+            "the almanac workspace",
+            "hosts: [dk-mac]",
+            "part of the Constellation",
+            "migrated by ORB-00200",
+            "see learning L-0065",
+            "silently drops it (F2026-05-024)",
+            "--evidence task:T20260514-3",
+            "docs/design/<feature>/4_decisions.md",
+            "put it in 2_design.md",
+        ] {
+            assert!(
+                !portability_violations(bad).is_empty(),
+                "portability checker failed to flag a leak: {bad:?}",
+            );
+        }
+
+        // Allows genuine public Orbit runtime paths and placeholder IDs.
+        for good in [
+            "artifacts live under `.orbit/adrs/{accepted,proposed}/`",
+            "scheduler state in `~/.orbit/orbit.db` is host-local",
+            "evidence under `.orbit/state/job-runs/`",
+            "dependencies: [\"ORB-NNNN\", ...] require ORB-NNNNN targets",
+            "drop a `// L-NNNN: <rationale>` citation",
+            "recommended layout: `docs/design/<feature>/`",
+            "resolve `context_files` selectors, then `fs.read` a `<task-id>`",
+            "run `orbit search --kind adr`",
+        ] {
+            assert!(
+                portability_violations(good).is_empty(),
+                "portability checker false-positive on portable text {good:?}: {:?}",
+                portability_violations(good),
+            );
+        }
+    }
+
+    #[test]
+    fn embedded_skills_are_repository_agnostic() {
+        let root = assets_skills_dir();
+        let files = collect_relative_files(&root)
+            .unwrap_or_else(|e| panic!("collect_relative_files({}): {e}", root.display()));
+
+        let mut failures: Vec<String> = Vec::new();
+        for relative in files {
+            let path = root.join(&relative);
+            let content = std::fs::read_to_string(&path)
+                .unwrap_or_else(|e| panic!("read {}: {e}", path.display()));
+            for violation in portability_violations(&content) {
+                failures.push(format!("  {}: {violation}", relative.display()));
+            }
+        }
+
+        assert!(
+            failures.is_empty(),
+            "embedded skill assets under crates/orbit-core/assets/skills/ are not repository-agnostic \
+             ({} leak(s)) — generalize, remove, or guard as explicitly source-only/client-specific \
+             guidance (ORB-10208):\n{}",
+            failures.len(),
+            failures.join("\n"),
         );
     }
 }

--- a/crates/orbit-core/src/command/skill.rs
+++ b/crates/orbit-core/src/command/skill.rs
@@ -620,6 +620,16 @@ mod tests {
             }
         }
 
+        // A shipped example must not silently select one provider family.
+        // Ignore formatting whitespace so both compact and pretty JSON are caught.
+        let compact: String = content
+            .chars()
+            .filter(|ch| !ch.is_ascii_whitespace())
+            .collect();
+        if compact.contains("\"model\":\"codex\"") {
+            hits.push("hard-coded agent model `codex`".to_string());
+        }
+
         // Fixed consumer design-doc filenames.
         if let Some(name) = find_numbered_design_doc(content) {
             hits.push(format!("fixed design-doc filename `{name}`"));
@@ -641,6 +651,7 @@ mod tests {
             "the almanac workspace",
             "hosts: [dk-mac]",
             "part of the Constellation",
+            r#"{"model": "codex"}"#,
             "migrated by ORB-00200",
             "see learning L-0065",
             "silently drops it (F2026-05-024)",

--- a/plugin/skills/orbit-knowledge/SKILL.md
+++ b/plugin/skills/orbit-knowledge/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: orbit-knowledge
-description: Create, search, update, supersede, prune, or audit Orbit's two durable-decision primitives — project learnings (recurring gotchas, incident root-causes, cross-session guardrails, push-injected by scope) and Architecture Decision Records (ADRs — decisions with a real alternative, accepted/proposed/superseded lifecycle, global ID allocation). Triggers on "learning", "gotcha", "guardrail", "ADR", "decision record", "4_decisions.md", accepting/superseding a decision, or adding a `## ADR-` heading. Covers scope-OR matching, evidence shape, update-vs-supersede (there is no comment or vote surface — corrections go through `update`/`supersede`, provenance through `evidence`), and why to never hand-edit `.orbit/learnings/` or `.orbit/adrs/`.
+description: Create, search, update, supersede, prune, or audit Orbit's two durable-decision primitives — project learnings (recurring gotchas, incident root-causes, cross-session guardrails, push-injected by scope) and Architecture Decision Records (ADRs — decisions with a real alternative, accepted/proposed/superseded lifecycle, global ID allocation). Triggers on "learning", "gotcha", "guardrail", "ADR", "decision record", editing an ADR decision-record file, accepting/superseding a decision, or adding a `## ADR-` heading. Covers scope-OR matching, evidence shape, update-vs-supersede (there is no comment or vote surface — corrections go through `update`/`supersede`, provenance through `evidence`), and why to never hand-edit `.orbit/learnings/` or `.orbit/adrs/`.
 ---
 
 # Orbit Knowledge
@@ -15,26 +15,26 @@ Both surfaces (MCP `orbit_learning_*`/`orbit_adr_*`, CLI `orbit tool run orbit.l
 - **Never invent an ID.** `add` allocates both learning and ADR IDs globally; cite the returned ID verbatim.
 - **Stage new artifact files from the current worktree** alongside the code/doc change that motivated them — sibling worktrees see remote stubs until that worktree's body files are locally readable.
 - **Update replaces, does not merge** — re-pass unchanged fields (`scope`/`evidence` for learnings; full body for ADRs) or you'll silently wipe them. **Supersede** when guidance/decision materially changes; it writes both pointers atomically and excludes the old record from default search. `update` is rejected on an already-superseded record — `supersede` again instead.
-- **Citation-at-anchor, with a hard prohibition.** When a learning/ADR encodes a convention enforced at a specific code site, drop a one-line citation (`// L-NNNN: <rationale>` or `// <adr-id>: <rationale>`) at that site. **Never** place the citation inside `crates/**/assets/**` (skill files, prompt assets, shipped plugin assets) or other consumer-facing surfaces — workspace-local artifact IDs become dangling references in other workspaces. At those surfaces, the push-injected learning (or a `## Consequences` sentence for ADRs) is the delivery mechanism instead.
+- **Citation-at-anchor, with a hard prohibition.** When a learning/ADR encodes a convention enforced at a specific code site, drop a one-line citation (`// L-NNNN: <rationale>` or `// <adr-id>: <rationale>`) at that site. **Never** place the citation inside shipped instruction or prompt assets (skill files, prompt templates, bundled plugin assets) or any other consumer-facing surface served to other workspaces — workspace-local artifact IDs become dangling references there. At those surfaces, the push-injected learning (or a `## Consequences` sentence for ADRs) is the delivery mechanism instead.
 - **Search before adding**, to avoid duplicate/contradicting records covering the same scope.
 
 ## Learnings
 
 | Tool / workflow | MCP | CLI |
 |------|-----|-----|
-| Add | `orbit_learning_add({...})` | `orbit learning add --summary "..." --path "crates/orbit-core/**/*.rs" --tag rust --body-file note.md` |
+| Add | `orbit_learning_add({...})` | `orbit learning add --summary "..." --path "src/**/*.rs" --tag rust --body-file note.md` |
 | Search | `orbit_search({...})` | `orbit search --kind learning <text>` (add `--hybrid` after `orbit semantic index --kind learnings`) |
-| Show / update / supersede | `orbit_learning_show/update/supersede({...})` | `orbit learning show L-0001` / `update --id L-0001 --priority 200` / `supersede --id L-0001 --with L-0007` |
+| Show / update / supersede | `orbit_learning_show/update/supersede({...})` | `orbit learning show L-NNNN` / `update --id L-NNNN --priority 200` / `supersede --id L-NNNN --with L-MMMM` |
 | List/audit, prune, sync | CLI-only | `orbit learning list --status active --tag rust [--path <glob>]`, `orbit learning prune --stale-only [--delete]`, `orbit learning sync` |
 
 **Workflow:** (1) search first — `orbit learning list --path/--tag` or `orbit search --kind learning` — prefer `update`/`supersede` over a duplicate. (2) Add with tight `scope: { paths?, tags? }` (OR semantics — fires on *any* path glob OR *any* tag; split concerns into separate learnings rather than over-broadening one). Include `evidence: [{kind: "task"|"commit"|"external", ref: "..."}]` whenever it came from a real incident/PR/task — a learning you can't cite a source for is a hunch. `priority` (0–255) is a secondary search-ranking key, not an importance badge. Keep `summary` ≤280 chars, written as a directive ("Always X before Y in `<crate>`"), since push-injection surfaces it first. (3) `prune --stale-only` periodically to surface learnings whose `scope.paths` no longer resolve; read before `--delete`. (4) `sync` (CLI-only) re-syncs the SQLite envelope index if YAML was touched out-of-band (merge, branch switch) — YAML is the source of truth.
 
-Legacy `L<YYYYMMDD>-N` IDs were migrated by ORB-00200 and should only appear in `legacy_ids`; canonical format is `L-NNNN`. Corrections to current wording go through `update`; material changes go through `supersede`; provenance for a new observation goes into `evidence`. (ORB-10046 removed the vote and comment surfaces — `priority` + search rank cover ranking, and `update`/`supersede`/`evidence` cover corrections/provenance.)
+Legacy `L<YYYYMMDD>-N` IDs were migrated and should only appear in `legacy_ids`; canonical format is `L-NNNN`. Corrections to current wording go through `update`; material changes go through `supersede`; provenance for a new observation goes into `evidence`. (The vote and comment surfaces were removed — `priority` + search rank cover ranking, and `update`/`supersede`/`evidence` cover corrections/provenance.)
 
 ```bash
-orbit learning add --summary "Always run \`make fmt\` before committing under crates/orbit-cli — clippy fails on stray spacing" \
-  --path "crates/orbit-cli/**/*.rs" --tag rust --tag formatting --body-file /tmp/learning.md \
-  --evidence task:T20260514-3 --priority 100 --json
+orbit learning add --summary "Always run the repo formatter before committing under src/ — the linter fails on stray spacing" \
+  --path "src/**/*.rs" --tag lang --tag formatting --body-file /tmp/learning.md \
+  --evidence task:<task-id> --priority 100 --json
 ```
 
 Common mistakes: hand-writing YAML (skips envelope+attribution — use the tools); creating a duplicate without checking first (two overlapping-scope records inject twice and contradict); `update` to "fix" a fundamental change in advice (loses the supersede chain — `supersede` instead); `scope` with no `paths` and no `tags` (never injects).
@@ -49,11 +49,11 @@ Exit: the learning exists/updates through `orbit.learning.*`, has a directive `s
 
 Listing is **not** on the agent MCP surface — use `orbit search --kind adr` for read-side discovery; CLI/admin retains `orbit tool run orbit.adr.list --input '{"feature":"<feature>"}'` (agents shouldn't call it via MCP). ADRs and docs are sibling indexes: `orbit search --kind all|doc|adr` federates ADR metadata read-only; `--hybrid` applies to `--kind adr` after `orbit semantic index --kind adrs`.
 
-**When editing `docs/design/<feature>/4_decisions.md` directly:** if you're about to add or rename a `## ADR-` heading, **stop and run `orbit.adr.add` first**, then use the allocated global ID as the local heading verbatim. Picking the next sequential local number, or a number that merely "looks global," both produce orphan decisions invisible to `orbit search --kind adr` / `orbit.adr.show` / legacy_id resolution. Backfill an existing local-numbered ADR via `orbit.adr.add` and set `legacy_ids`.
+**When your repo keeps ADR headings in a docs file and you edit one directly:** if you're about to add or rename a `## ADR-` heading, **stop and run `orbit.adr.add` first**, then use the allocated global ID as the local heading verbatim. (Where that file lives — its name and location — follows the target repo's own instructions and configured docs roots, not a fixed convention.) Picking the next sequential local number, or a number that merely "looks global," both produce orphan decisions invisible to `orbit search --kind adr` / `orbit.adr.show` / legacy_id resolution. Backfill an existing local-numbered ADR via `orbit.adr.add` and set `legacy_ids`.
 
-**Workflow:** (1) inspect nearby decisions first (`orbit search "<concept>" --kind adr`, `orbit.adr.show`, `legacy_id` lookup for migrated per-feature refs). (2) new decision → `add`; body/metadata correction → `update`; reversal of an accepted ADR → create the replacement, accept it with a related task, then `supersede`. (3) body needs exactly `## Context`, `## Decision`, `## Consequences`, with ≥1 consequences bullet starting `Cost:`. (4) `related_features` = feature-folder names; `tags` = free-form cross-artifact labels; `paths` = repo-relative globs the decision constrains. (5) `related_tasks` may be empty for a speculative proposed ADR — don't invent a task just to satisfy one; **acceptance requires a real related task**. (6) verify with `.show` or `orbit search --kind adr`.
+**Workflow:** (1) inspect nearby decisions first (`orbit search "<concept>" --kind adr`, `orbit.adr.show`, `legacy_id` lookup for migrated per-feature refs). (2) new decision → `add`; body/metadata correction → `update`; reversal of an accepted ADR → create the replacement, accept it with a related task, then `supersede`. (3) body needs exactly `## Context`, `## Decision`, `## Consequences`, with ≥1 consequences bullet starting `Cost:`. (4) `related_features` = feature/area names; `tags` = free-form cross-artifact labels; `paths` = repo-relative globs the decision constrains. (5) `related_tasks` may be empty for a speculative proposed ADR — don't invent a task just to satisfy one; **acceptance requires a real related task**. (6) verify with `.show` or `orbit search --kind adr`.
 
-Creation is warranted only when all three hold: a real alternative was on the table, the choice constrains future work, and the cost is non-trivial and worth preserving. Otherwise put the detail in `2_design.md`, a spec, or an existing ADR's instance table.
+Creation is warranted only when all three hold: a real alternative was on the table, the choice constrains future work, and the cost is non-trivial and worth preserving. Otherwise put the detail in a design doc, a spec, or an existing ADR's instance table.
 
 ```markdown
 ## Context

--- a/plugin/skills/orbit-search/SKILL.md
+++ b/plugin/skills/orbit-search/SKILL.md
@@ -21,7 +21,7 @@ orbit search "slow inference after model swap" --limit 5
 
 # Cross-artifact label and path filters (--tag is AND when repeated)
 orbit search "scheduler" --tag perf --kind all
-orbit search path crates/orbit-search/src/lib.rs --kind all
+orbit search path src/lib.rs --kind all
 
 # Hybrid lexical + cosine over indexed fields
 orbit search "agent loop deadlock" --hybrid --kind task --limit 5
@@ -63,7 +63,7 @@ Frontmatter (`type` and `summary` required; `summary` non-empty single line):
 type: design | pattern | context | glossary | runbook
 summary: One-line hook for agent retrieval
 tags: [hook, learning, audit]
-paths: ["crates/orbit-cli/**"]
+paths: ["src/**"]
 related_features: [hook-rewrite]
 related_artifacts: ["<task-id>", "<adr-id>", "<learning-id>"]
 ---

--- a/plugin/skills/orbit-task/SKILL.md
+++ b/plugin/skills/orbit-task/SKILL.md
@@ -15,8 +15,8 @@ Create a task another engineer or agent can execute without guessing: a crisp pr
 1. Confirm objective, constraints, and done criteria.
 2. Optionally check for overlapping prior work with `orbit-search` (`hybrid: true`, `kind: "task"`).
 3. Write acceptance criteria that define observable success — no vague pass/fail language like "works correctly"; name a command, inspection step, or observable output for each.
-4. Enumerate files/dirs/symbols this task will modify or delete as canonical selectors (`file:`, `dir:`, `symbol:path#name:kind`) in `context_files`. Only modification targets — not read-for-context files, conventions/pattern docs (cite those in prose instead), or files that don't exist yet. Feature design docs under `docs/design/<feature>/` are the exception (co-change with implementation). Prefer `file:`/`symbol:` over `dir:` when changes can be named more precisely.
-5. Set `complexity` (`low`/`medium`/`hard`) whenever scope is clear enough to judge — batching honors this via `crates/orbit-engine/src/executor/automation/batch/dispatch.rs::task_prefers_single_batch`.
+4. Enumerate files/dirs/symbols this task will modify or delete as canonical selectors (`file:`, `dir:`, `symbol:path#name:kind`) in `context_files`. Only modification targets — not read-for-context files, conventions/pattern docs (cite those in prose instead), or files that don't exist yet. Design docs your repo co-locates with the code they describe are the exception (co-change with implementation). Prefer `file:`/`symbol:` over `dir:` when changes can be named more precisely.
+5. Set `complexity` (`low`/`medium`/`hard`) whenever scope is clear enough to judge — batching honors this when dispatching work.
 6. Add assumptions, risks, and rollback notes to the description when they matter.
 7. Call `orbit.task.add` with description, acceptance criteria, `context_files`, workspace, complexity, and `model`. Leave `plan` blank unless pre-seeding is justified.
 8. Confirm via the tool result, or re-fetch with `orbit.task.show`.
@@ -24,9 +24,9 @@ Create a task another engineer or agent can execute without guessing: a crisp pr
 **Operating rules:** Never edit task files directly. Never invent task IDs — `orbit.task.add` allocates them. `description` should be multi-line markdown for non-trivial tasks. Required: `title`, `description`, `workspace`. Strongly prefer `acceptance_criteria` and `complexity`. Valid `type`: `feature`, `bug`, `refactor`, `chore` — use friction (below) for self-reported tooling issues, not a task type. Blank/missing companion files (`plan.md`, `execution-summary.md`) are blank fields — repair via `orbit.task.update`, never by hand.
 
 **Behavior-affecting optional fields:**
-- `dependencies: ["ORB-NNNN", ...]` — prerequisite tasks must reach a satisfying status first (`crates/orbit-common/src/types/task.rs::task_dependencies_ready`).
-- `relations: [{"type": "resolves", "target": "F<YYYY>-<MM>-<NNN>"}]` — auto-resolves the target friction when this task reaches `done` (`crates/orbit-core/src/command/task/transitions.rs::apply_resolves_side_effects`). Other `relations` types (`produces`, `blocked_by`, `child_of`, `spawned_from`, `regression_from`, `supersedes`, `related_to`) are tracked; only `produces`/`resolves` accept non-`ORB-` targets (friction/learning/ADR IDs), the rest require `ORB-NNNNN`. Dangling `resolves`/`produces` targets succeed but emit a `TaskRelationDangling` audit event.
-- `parent_id`, `source_task_id` (bug-introducing task; creation-time only — `update` silently drops it on existing tasks, see F2026-05-024/ORB-00101), `tags` (reuse existing before inventing new).
+- `dependencies: ["ORB-NNNN", ...]` — prerequisite tasks must reach a satisfying status first.
+- `relations: [{"type": "resolves", "target": "F<YYYY>-<MM>-<NNN>"}]` — auto-resolves the target friction when this task reaches `done`. Other `relations` types (`produces`, `blocked_by`, `child_of`, `spawned_from`, `regression_from`, `supersedes`, `related_to`) are tracked; only `produces`/`resolves` accept non-`ORB-` targets (friction/learning/ADR IDs), the rest require `ORB-NNNNN`. Dangling `resolves`/`produces` targets succeed but emit a `TaskRelationDangling` audit event.
+- `parent_id`, `source_task_id` (bug-introducing task; creation-time only — `update` silently drops it on existing tasks), `tags` (reuse existing before inventing new).
 
 **Task quality bar:** validation must not assume `.orbit/knowledge/` or uncommitted artifacts; file I/O checks use temp dirs/fakes; behavior-changing tasks touching external services/FS/time should call for deterministic mock coverage in acceptance criteria; graph/knowledge task nodes define `purpose` as role + crate/module + leaf-or-internal.
 
@@ -89,7 +89,7 @@ Exit: task started via `orbit.task.start`; execution summary persisted; learning
 
 Review someone else's work and surface issues as review threads — read plus write-only-into-threads; **never** transition the reviewed task's lifecycle.
 
-**Load context.** `orbit.task.show` for `description`/`acceptance_criteria`/`plan`/`execution_summary`; inspect the diff and changed files; run `make build` and the relevant test target. Optionally `orbit.search` with `semantic: "<task-id>"` for prior similar decisions.
+**Load context.** `orbit.task.show` for `description`/`acceptance_criteria`/`plan`/`execution_summary`; inspect the diff and changed files; run the target repo's build and the relevant test commands (from its own instructions/configuration). Optionally `orbit.search` with `semantic: "<task-id>"` for prior similar decisions.
 
 **Two-stage review — stage 1 first:** spec compliance (does the change satisfy every acceptance criterion? anything missing or added beyond scope? interpretation gaps?). If it fails, file those threads and stop — don't spend time on stage 2. **Stage 2** (only if stage 1 passes): maintainability, patterns, performance, test-coverage gaps, risks/edge cases/security.
 
@@ -110,7 +110,7 @@ orbit tool run orbit.task.review_thread.resolve --input '{"id":"<task-id>","thre
 
 **Summarize** in chat: thread count, which are blockers, overall verdict (approve/request changes). Don't add a task `comment` — threads are the persistent surface.
 
-**Meta-review.** After filing threads, check whether they reveal a gap in an Orbit-authored instruction asset (`crates/orbit-core/assets/activities/*.yaml`, or a `SKILL.md`). Trigger: ≥2 threads map to the same instruction gap, or one thread is clearly a recurring class. When it fires, file a friction (see §4) *in addition to* the individual threads — never as a replacement. Skip for a single nit, a style preference, or a one-off mistake with no link to instruction text.
+**Meta-review.** After filing threads, check whether they reveal a gap in an Orbit-authored instruction asset (an activity definition or a `SKILL.md`). Trigger: ≥2 threads map to the same instruction gap, or one thread is clearly a recurring class. When it fires, file a friction (see §4) *in addition to* the individual threads — never as a replacement. Skip for a single nit, a style preference, or a one-off mistake with no link to instruction text.
 
 **Rules:** never transition the reviewed task's status; never resolve threads you authored (exception: retracting your own thread); always include `model` on `review_thread.add`/`.reply` (rejected without it — `list`/`.resolve` don't require it); replies don't create new findings, only `.add` counts toward the scoreboard. No PR yet → threads stay local; with a PR, they mirror as PR review comments.
 

--- a/plugin/skills/orbit/SKILL.md
+++ b/plugin/skills/orbit/SKILL.md
@@ -26,7 +26,7 @@ Orbit tools are reachable via two surfaces. Both accept identical JSON arguments
 
 **Mapping rule**: `orbit.<group>.<action>` ↔ `orbit_<group>_<action>` (dots become underscores; JSON args identical). For multi-segment names like `orbit.task.review_thread.add`, every dot becomes an underscore: `orbit_task_review_thread_add`.
 
-**Environment parity**: the orbit tool surface is identical everywhere. On machines without a local orbit store, the same `orbit_*` tools are served by the bridge MCP, which mirrors the orbit MCP exactly (plus an optional `workspace` routing param on tools that lack one); bridge-only extensions (`workflow_ship`, `agent_invoke`, …) handle cross-workspace and pipeline operations.
+**Environment parity**: the orbit tool surface is identical across MCP and CLI. Some deployments front the orbit MCP behind a gateway that mirrors the surface exactly and may add an optional `workspace` routing param on tools that lack one. Any non-standard tools a gateway adds beyond the orbit surface are documented by that gateway, not here — consult its own reference before relying on them.
 
 **Surface coverage:**
 

--- a/plugin/skills/orbit/references/guide.md
+++ b/plugin/skills/orbit/references/guide.md
@@ -66,7 +66,7 @@ After hand-off, subsequent Orbit work routes through the rest of the `orbit` ski
 
 Routines make Orbit the host's scheduler: a git-versioned YAML definition (`.orbit/routines/*.yaml`) pairs a cron trigger with a catalog `job:<name>` target, host pinning, and a retry/overlap policy. A stateless `orbit sweep` pass — invoked every minute by the OS clock (launchd / systemd timer) — fires whatever is due on this host as a normal run. Definitions sync across hosts via git; **all scheduler state (last fires, pauses, locks) is host-local in `~/.orbit/orbit.db` and never synced.** Full detail (job/activity/`orbit run` usage) lives in the `orbit-workflow` skill; this section covers setup only.
 
-**Canonical sources — read at invocation time; don't answer routine field semantics from memory:** design contract at `docs/design/routines/2_design.md` §1 (field-by-field schema); command surface via `orbit routine --help` and `orbit sweep --help`.
+**Canonical sources — read at invocation time; don't answer routine field semantics from memory:** command surface via `orbit routine --help` and `orbit sweep --help` (field-by-field schema).
 
 Setup sequence (skeleton is stable; re-read the design doc for full field semantics before hand-authoring a routine):
 
@@ -76,13 +76,13 @@ Setup sequence (skeleton is stable; re-read the design doc for full field semant
 
    ```yaml
    schemaVersion: 1
-   name: almanac-auto-commit          # unique across all sources on a host
+   name: <routine-name>               # unique across all sources on a host
    enabled: true                       # versioned kill-switch
-   hosts: [dk-mac]                      # explicit pinning; no "any host" in v1
+   hosts: [<host-id>]                   # explicit pinning; no "any host" in v1
    trigger:
      cron: "0 22 * * *"                # 5-field, host-local time
      missed_run: skip                   # skip | catch_up_once (default: skip)
-   target: job:almanac_commit_pipeline  # job:<name> only; activity: is rejected — wrap it in a one-step job
+   target: job:<job-name>               # job:<name> only; activity: is rejected — wrap it in a one-step job
    policy:
      timeout_minutes: 10
      retries: { max: 2, backoff_minutes: 2 }
@@ -105,7 +105,7 @@ If setup or a sweep misbehaves, surface it and offer `orbit-task` friction repor
 
 If the user runs the plugin inside **Cowork** (the Claude desktop app) and only the `orbit_graph_*` tools appear — no `orbit_task_add` / ADR / learning tools — it's the known workspace-discovery gap: Cowork launches the plugin's MCP server with cwd and `CLAUDE_PROJECT_DIR` set to an internal scratchpad, not the selected repo, so `serve` finds no `.orbit/` and falls back to the graph-only surface.
 
-Fix: pass the repo explicitly via the global `--root` flag in the orbit MCP launch, in user config (`~/.claude/settings.json`) since the cached plugin copy is overwritten on reinstall. See the README "Cowork users" note for the exact `mcpServers` block — re-read it at invocation time. There is no env/cwd source for the repo path in Cowork today (see learning L-0065).
+Fix: pass the repo explicitly via the global `--root` flag in the orbit MCP launch, in user config (`~/.claude/settings.json`) since the cached plugin copy is overwritten on reinstall. See the README "Cowork users" note for the exact `mcpServers` block — re-read it at invocation time. There is no env/cwd source for the repo path in Cowork today.
 
 ## Anti-patterns (DO NOT)
 


### PR DESCRIPTION
## Task

[ORB-10208](https://orbit-cli.com/tasks/ORB-10208) — Make bundled public skills repository-agnostic

### Description

## Problem
The five skills and four reference files under `crates/orbit-core/assets/skills/` are embedded into the Orbit binary, seeded into downstream workspaces, and partly mirrored into the public plugin package. They currently mix portable Orbit product guidance with assumptions that only hold in the Orbit source checkout or Daniel's Constellation environment.

The audit found these recurring leak classes:
- fixed Orbit-repo design paths and filenames such as `docs/design/<feature>/4_decisions.md`, `docs/design/routines/2_design.md`, and `2_design.md`;
- internal source paths and symbols such as `crates/orbit-engine/...`, `crates/orbit-core/assets/{jobs,activities}/...`, and `crates/orbit-cli/**`;
- workspace-local provenance IDs such as `ORB-00200`, `ORB-10046`, `F2026-05-024`, `ORB-00101`, and `L-0065`;
- private examples and infrastructure names such as `almanac`, `dk-mac`, the Constellation Bridge MCP, and its bridge-only extensions;
- repo/toolchain assumptions such as unconditional `make build` / `make fmt` / `cargo test`, hard-coded `model: "codex"`, and source-checkout comparisons that cannot work from a consumer workspace;
- a current materialized-plugin drift in `plugin/skills/orbit/SKILL.md` versus the canonical embedded asset.

These references can send public consumers to nonexistent files, encode private operating conventions as product rules, and create dangling task/learning references. This also conflicts with `orbit-knowledge`'s own rule that workspace-local artifact IDs must not be shipped in consumer-facing assets.

## Why It Matters
These skills are a public execution contract. They must work from arbitrary initialized repositories and across supported clients, whether Orbit was installed from a binary, plugin, or source clone. Repository-local policy should come from the consumer workspace's instruction chain, configured docs roots, and runtime tool/catalog surfaces—not from Orbit's own development layout.

## Constraints / Notes
- Audit all nine shipped files, including the four nested references; do not limit the fix to the reported ADR filename.
- Preserve commands, paths, and terminology that are genuine public Orbit runtime contracts (for example `.orbit/adrs/`, `.orbit/state/`, and official CLI/MCP names).
- Keep source-checkout or client-specific instructions only when they are explicitly conditional, publicly supported, and anchored to public documentation or runtime discovery.
- Replace private/internal examples with neutral placeholders.
- Route repository-specific build, validation, design-doc, and instruction behavior through the target repo's own instructions/configuration.
- Keep `orbit-workflow` CLI-only in the plugin package as currently intended.
- Maintain byte-for-byte parity between canonical assets and every materialized plugin skill that is supposed to mirror them.

### Acceptance Criteria

- Every `SKILL.md` and nested reference under `crates/orbit-core/assets/skills/` is audited; fixed host/source-checkout assumptions are removed, generalized, or explicitly guarded as source-only/client-specific guidance.
- `orbit-knowledge` no longer assumes `docs/design/<feature>/4_decisions.md`, `2_design.md`, or feature-folder naming as a universal consumer-repo convention; ADR authoring is routed through `orbit.adr.*`, configured docs roots, and the target repository's instructions.
- `orbit-task`, `orbit-search`, and `orbit-workflow` use neutral repo paths, examples, model placeholders, and repo-defined validation commands rather than Orbit-crate paths, local task/friction/learning IDs, private Constellation names, or unconditional Make/Cargo conventions.
- Public skill guidance does not depend on the Constellation Bridge MCP or bridge-only extensions; any retained client-specific setup guidance is clearly conditional and points to a public, current source of truth.
- A focused automated portability regression test covers the embedded skill tree and fails on representative private names, workspace-local artifact IDs, unguarded Orbit source paths, or fixed consumer design-doc filenames while allowing documented public Orbit runtime paths.
- The canonical embedded assets and all non-excluded materialized `plugin/skills/` copies are byte-for-byte aligned; the existing `plugin/skills/orbit/SKILL.md` drift is resolved.
- `cargo test -p orbit-core command::skill::tests`, `bash scripts/validate-codex-plugin.sh`, and `make ci-fast` pass.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Audited all nine shipped skill files under `crates/orbit-core/assets/skills/` (5 SKILL.md + 4 references) and removed every host/source-checkout and Constellation-private assumption:
  - orbit/SKILL.md: rewrote the bridge-MCP paragraph into a client-neutral "gateway may proxy the orbit surface" note; dropped `workflow_ship`/`agent_invoke` bridge-only names.
  - orbit-task/SKILL.md: dropped internal source symbols/paths (`crates/orbit-engine/...`, `crates/orbit-common/...`, `crates/orbit-core/.../transitions.rs`, `crates/orbit-core/assets/activities/*.yaml`), removed provenance IDs `F2026-05-024`/`ORB-00101`, generalized `make build` → target-repo build/test, and softened the `docs/design/<feature>/` design-doc exception.
  - orbit-knowledge/SKILL.md: routed ADR authoring through `orbit.adr.*` + target-repo docs roots instead of assuming `4_decisions.md`/`2_design.md`/feature-folder naming; neutralized the citation-prohibition (was `crates/**/assets/**`), example paths (`crates/orbit-*` → `src/**`), example IDs (`L-0001`/`L-0007`/`T20260514-3` → placeholders), and removed `ORB-00200`/`ORB-10046` provenance IDs and the `make fmt` example.
  - orbit-search/SKILL.md: example paths `crates/orbit-*` → `src/**` (kept the non-enforced `docs/design/<feature>/` docs-corpus layout as a genuine product recommendation).
  - orbit-workflow/SKILL.md + references: replaced `crates/orbit-core/assets/{jobs,activities}/` descriptions with runtime discovery (`orbit job list/show`), private routine example (`almanac`/`dk-mac`) with `<routine-name>`/`<host-id>`/`<job-name>`, `docs/design/routines/2_design.md` with `orbit routine --help`, the source-checkout `diff` against `crates/...` with installed-resource comparison, and `make/cargo` validation examples with neutral repo commands.
  - orbit/references/guide.md: neutralized the routine example, dropped the source design-doc path, and removed the `L-0065` learning reference.
- Preserved genuine public runtime contracts (`.orbit/adrs/`, `.orbit/state/`, `~/.orbit/`, official CLI/MCP names, the public GitHub README URLs).
- Kept the 4 mirrored plugin skills (`plugin/skills/{orbit,orbit-knowledge,orbit-search,orbit-task}` + orbit/references/guide.md) byte-for-byte aligned with the canonical assets; orbit-workflow stays plugin-excluded.
- Added a portability regression test in `crates/orbit-core/src/command/skill.rs` (renamed the inline `drift_tests` module → `tests` so the AC's `command::skill::tests` filter matches it). `portability_violations()` flags Orbit source `crates/` paths, private names (almanac/dk-mac/dk-server/Constellation), concrete artifact IDs (ORB-<digits>, L-<3+ digits>, F####-##-###, T<6+ digits>), and numbered design-doc filenames, while allowing public `.orbit/`/`~/.orbit/` paths and placeholder IDs. Two tests: a self-check that the classifier flags/allows representative inputs, and a scan asserting the shipped tree is clean.
- Added one terse CHANGELOG `## Unreleased` bullet (required by the freshness/style guardrail).

Assessment: Focused, low-risk documentation/guidance change plus a guardrail test; no runtime code behavior changed. The audit was exhaustive (re-grepped the tree to zero for every leak class).

Validation:
- `cargo test -p orbit-core command::skill::tests` — 5 passed (portability self-check, embedded-tree scan, plugin byte-parity, asset/registry parity, router enumeration).
- `bash scripts/validate-codex-plugin.sh` — valid (exit 0).
- `make ci-fast` — passed (fmt-check + all guardrail scripts, including changelog freshness/style).

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10208-6a58211f`
- Behind base: 0
- Ahead of base: 1