### PR TITLE
Normalize CLI agent envelopes before workflow templating

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - **Bundled skills are repository-agnostic**: the embedded skill tree drops Orbit-source paths, private Constellation names, workspace-local artifact IDs, and fixed design-doc filenames; a portability regression test and byte-aligned plugin mirrors guard against reintroduction. ([ORB-10208])
+- **CLI agent envelopes reach workflows**: provider-wrapped, prose-prefixed successful responses now validate and project their result object before workflow templating; malformed or failed envelopes fail closed. ([ORB-10216])
 - **Scheduled provider discovery fixed**: systemd routine sweeps now use a portable user PATH so provider launchers installed in `~/.local/bin` remain available. ([ORB-10214])
 - **Log rotation and pipeline spawning tolerate replaced paths**: missing log archive directories are silent no-ops, while long-lived Orbit processes resolve Linux deleted-inode executable paths back to the installed binary before spawning workers. ([ORB-10213])
 - **Skill guidance reflects friction triage**: shipped skills use positional learning-show IDs and document mutable friction statuses, direct triage commands, and task-driven resolution. ([ORB-10210])

--- a/crates/orbit-core/src/command/job/exec.rs
+++ b/crates/orbit-core/src/command/job/exec.rs
@@ -412,7 +412,8 @@ mod tests {
 
     use chrono::Utc;
     use orbit_common::types::{
-        AuditEventStatus, ExecutorDef, ExecutorType, TaskPriority, TaskStatus, TaskType,
+        AuditEventStatus, ExecutorDef, ExecutorType, JobRunState, TaskPriority, TaskStatus,
+        TaskType,
     };
     use orbit_engine::{DispatchError, ResolvedCliExecutor, V2RuntimeHost};
     use orbit_store::{InvocationQuery, V2AuditEventFilter};
@@ -895,25 +896,71 @@ spec:
 
     #[cfg(unix)]
     fn write_fake_codex(path: &Path) {
+        write_fake_cli_response(
+            path,
+            r#"{"type":"thread.started","thread_id":"fake"}
+{"type":"item.started","item":{"id":"item_1","type":"command_execution","command":"orbit graph","aggregated_output":"","exit_code":null,"status":"in_progress"}}
+{"type":"item.completed","item":{"id":"item_1","type":"command_execution","command":"orbit graph","aggregated_output":"ok","exit_code":0,"status":"completed"}}
+{"schemaVersion":1,"status":"success","result":{"ok":true},"error":null}
+{"type":"turn.completed","usage":{"input_tokens":100,"cached_input_tokens":25,"output_tokens":12}}
+"#,
+        );
+    }
+
+    #[cfg(unix)]
+    fn write_fake_cli_response(path: &Path, stdout: &str) {
         use std::os::unix::fs::PermissionsExt;
 
-        std::fs::write(
-            path,
-            r#"#!/bin/sh
-cat >/dev/null
-printf '%s\n' '{"type":"thread.started","thread_id":"fake"}'
-printf '%s\n' '{"type":"item.started","item":{"id":"item_1","type":"command_execution","command":"orbit graph","aggregated_output":"","exit_code":null,"status":"in_progress"}}'
-printf '%s\n' '{"type":"item.completed","item":{"id":"item_1","type":"command_execution","command":"orbit graph","aggregated_output":"ok","exit_code":0,"status":"completed"}}'
-printf '%s\n' '{"schemaVersion":1,"status":"success","result":{"ok":true},"error":null}'
-printf '%s\n' '{"type":"turn.completed","usage":{"input_tokens":100,"cached_input_tokens":25,"output_tokens":12}}'
-"#,
-        )
-        .expect("write fake codex");
+        let output_path = path.with_extension("stdout");
+        std::fs::write(&output_path, stdout).expect("write fake cli stdout");
+        std::fs::write(path, "#!/bin/sh\ncat >/dev/null\ncat \"$0.stdout\"\n")
+            .expect("write fake cli");
         let mut permissions = std::fs::metadata(path)
-            .expect("fake codex metadata")
+            .expect("fake cli metadata")
             .permissions();
         permissions.set_mode(0o755);
-        std::fs::set_permissions(path, permissions).expect("chmod fake codex");
+        std::fs::set_permissions(path, permissions).expect("chmod fake cli");
+    }
+
+    fn seed_failed_triage_candidate(runtime: &OrbitRuntime, title: &str) -> String {
+        let task = runtime
+            .add_task(TaskAddParams {
+                title: title.to_string(),
+                description: "Fixture task blocked by a failed pipeline.".to_string(),
+                status: Some(TaskStatus::Backlog),
+                ..Default::default()
+            })
+            .expect("seed triage task");
+        let run = runtime
+            .stores()
+            .jobs()
+            .insert_run("task_pr_pipeline", 1, Utc::now(), None, None)
+            .expect("insert failed pipeline run");
+        runtime
+            .stores()
+            .jobs()
+            .mark_run_running(&run.run_id, Utc::now(), std::process::id())
+            .expect("mark failed pipeline run running");
+        runtime
+            .finalize_job_run_with_reservation_cleanup(
+                &run.run_id,
+                JobRunState::Failed,
+                Utc::now(),
+                Some(1),
+                TaskReservationReleaseReason::RunTerminal,
+            )
+            .expect("finalize failed pipeline run");
+        runtime
+            .update_task(
+                &task.id,
+                TaskUpdateParams {
+                    status: Some(TaskStatus::Blocked),
+                    job_run_id: Some(Some(run.run_id)),
+                    ..Default::default()
+                },
+            )
+            .expect("couple blocked task to failed run");
+        task.id
     }
 
     #[test]
@@ -1124,6 +1171,112 @@ printf '%s\n' '{"type":"turn.completed","usage":{"input_tokens":100,"cached_inpu
                 && row.tool_name == "command_execution"
                 && row.call_count == 1
         }));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn task_triage_pipeline_applies_multiple_cli_envelope_dispositions() {
+        let (_root, runtime, repo_root, global_root) = test_runtime();
+        seed_default_catalogs(&global_root);
+        let environmental = seed_failed_triage_candidate(&runtime, "Environmental triage fixture");
+        let code_defect = seed_failed_triage_candidate(&runtime, "Code-defect triage fixture");
+
+        let agent_envelope = json!({
+            "schemaVersion": 1,
+            "status": "success",
+            "result": {
+                "dispositions": [
+                    {
+                        "task_id": environmental.clone(),
+                        "classification": "environmental",
+                        "disposition": "rebacklog",
+                        "diagnosis": "the runner lost its workspace lease",
+                        "mitigation": "stale lease cleared"
+                    },
+                    {
+                        "task_id": code_defect.clone(),
+                        "classification": "code_defect",
+                        "disposition": "stay_blocked",
+                        "diagnosis": "the task still has failing tests"
+                    }
+                ],
+                "summary": "one task can retry and one needs a code fix"
+            },
+            "error": null
+        });
+        let provider_stdout = json!({
+            "type": "result",
+            "subtype": "success",
+            "result": format!("Triage complete.\n{agent_envelope}"),
+            "usage": {
+                "input_tokens": 12,
+                "output_tokens": 8
+            }
+        })
+        .to_string();
+        let fake_bin = repo_root.join("claude");
+        write_fake_cli_response(&fake_bin, &provider_stdout);
+
+        let now = Utc::now();
+        runtime
+            .upsert_executor_def(&ExecutorDef {
+                name: "claude".to_string(),
+                executor_type: ExecutorType::DirectAgent,
+                command: Some(fake_bin.display().to_string()),
+                args: Vec::new(),
+                stdout_format: None,
+                model_pair_override: None,
+                model_flag: None,
+                timeout_seconds: None,
+                env: HashMap::new(),
+                sandbox: None,
+                allow_fallback: false,
+                created_at: now,
+                updated_at: now,
+            })
+            .expect("seed fake claude executor");
+
+        let result = runtime
+            .run_job_v2_from_yaml(
+                &global_root.join("resources/jobs/task_triage_pipeline.yaml"),
+                json!({
+                    "task_ids": [environmental.clone(), code_defect.clone()],
+                    "max_tasks": 20,
+                    "max_rebacklogs": 2,
+                }),
+                Some(Backend::Cli),
+            )
+            .expect("task triage pipeline succeeds");
+
+        assert!(result.success);
+        assert_eq!(
+            result.pipeline["triage"]["dispositions"]
+                .as_array()
+                .map(Vec::len),
+            Some(2)
+        );
+        assert_eq!(
+            result.pipeline["apply_dispositions"]["rebacklogged_count"],
+            json!(1)
+        );
+        assert_eq!(
+            result.pipeline["apply_dispositions"]["diagnosed_count"],
+            json!(1)
+        );
+        assert_eq!(
+            runtime
+                .get_task(&environmental)
+                .expect("environmental task")
+                .status,
+            TaskStatus::Backlog
+        );
+        assert_eq!(
+            runtime
+                .get_task(&code_defect)
+                .expect("code defect task")
+                .status,
+            TaskStatus::Blocked
+        );
     }
 
     fn write_three_step_job(path: &Path, name: &str) {

--- a/crates/orbit-engine/src/activity_job/cli_runner/envelope.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/envelope.rs
@@ -1,4 +1,4 @@
-use orbit_agent::parse_and_validate_response;
+use orbit_agent::{AgentResponseStatus, parse_and_validate_response};
 use orbit_common::types::activity_job::AgentLoopSpec;
 use orbit_common::types::{ExecutionResult, InvocationTrace};
 use serde_json::Value;
@@ -65,6 +65,48 @@ pub(super) fn parse_cli_invocation_trace(
     parse_and_validate_response(&exec_result)
         .map(|(_, _, trace)| trace)
         .ok()
+}
+
+/// Parse the provider's stdout as an Orbit response envelope and return the
+/// object that workflow templates may consume as an activity output.
+///
+/// Provider CLIs commonly wrap the response in a JSON object and, in
+/// Claude's case, may prefix the embedded response with explanatory prose.
+/// `parse_and_validate_response` owns that wrapper traversal and envelope
+/// validation, so the CLI backend must use the same boundary before exposing
+/// output to later workflow steps.
+pub(super) fn parse_cli_response_result(
+    stdout: &[u8],
+    stderr: &[u8],
+    exit_code: Option<i32>,
+    duration_ms: u64,
+    success: bool,
+) -> Result<serde_json::Map<String, Value>, String> {
+    let exec_result = ExecutionResult {
+        success,
+        stdout: String::from_utf8_lossy(stdout).into_owned(),
+        stderr: String::from_utf8_lossy(stderr).into_owned(),
+        exit_code,
+        duration_ms,
+        output: None,
+    };
+    let (envelope, status, _) =
+        parse_and_validate_response(&exec_result).map_err(|error| error.to_string())?;
+
+    match status {
+        AgentResponseStatus::Success => {
+            if let Some(Value::Object(result)) = envelope.result {
+                Ok(result)
+            } else {
+                Err(
+                    "Orbit response envelope status=success requires an object `result`"
+                        .to_string(),
+                )
+            }
+        }
+        AgentResponseStatus::Failed => Err("Orbit response envelope status=failed".to_string()),
+        AgentResponseStatus::Timeout => Err("Orbit response envelope status=timeout".to_string()),
+    }
 }
 
 pub(super) fn user_prompt_from_input(input: &Value) -> Result<String, DispatchError> {

--- a/crates/orbit-engine/src/activity_job/cli_runner/orchestrator.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/orchestrator.rs
@@ -18,13 +18,17 @@ use super::super::workspace::resolve_subprocess_cwd;
 use super::argv::{
     apply_provider_static_arg_fixups, audit_argv_for_dispatch, neutralize_inner_sandbox,
 };
-use super::envelope::{cli_agent_envelope_json, parse_cli_invocation_trace, task_id_from_input};
+use super::envelope::{
+    cli_agent_envelope_json, parse_cli_invocation_trace, parse_cli_response_result,
+    task_id_from_input,
+};
 use super::supervisor::{
     DEFAULT_WALL_CLOCK_TIMEOUT_SECONDS, SpawnTraceContext, SpawnWithTimeoutRequest,
     spawn_with_timeout,
 };
 
 const STDOUT_TEXT_PREVIEW_LIMIT_BYTES: usize = 64 * 1024;
+const RESPONSE_DIAGNOSTIC_LIMIT_CHARS: usize = 1024;
 
 pub fn run_cli_backend(
     host: &dyn V2RuntimeHost,
@@ -215,19 +219,24 @@ pub fn run_cli_backend(
         timed_out,
     });
 
-    // Provisional success based on exit code; the embedded envelope status
-    // (read below) can demote this to false. Some provider CLIs (notably
-    // claude) can exit 0 with an outer `result.subtype = "success"` envelope
-    // even when their inner Orbit response payload reports `status = "failed"`,
-    // and pre-T20260508-17 the dispatcher recorded that as success. The
-    // structured envelope is now authoritative when present.
+    // A clean subprocess exit is only provisional. Provider CLIs commonly
+    // wrap the agent response (and Claude may prefix that response with
+    // explanatory prose), so validate and unwrap the embedded Orbit envelope
+    // before exposing anything to downstream workflow templates.
     let exit_success = !timed_out && matches!(exit_code, Some(0));
     let stdout_text = String::from_utf8_lossy(&stdout);
     let envelope_status = peek_response_status(stdout_text.as_ref());
     let stdout_preview = stdout_text_preview(stdout_text.as_ref(), &redaction);
-    let envelope_indicates_failure =
-        matches!(envelope_status.as_deref(), Some("failed") | Some("timeout"));
-    let success = exit_success && !envelope_indicates_failure;
+    let parsed_result = exit_success.then(|| {
+        parse_cli_response_result(
+            &stdout,
+            &stderr,
+            exit_code,
+            duration.as_millis() as u64,
+            true,
+        )
+    });
+    let success = exit_success && matches!(parsed_result.as_ref(), Some(Ok(_)));
     let trace = parse_cli_invocation_trace(
         &stdout,
         &stderr,
@@ -240,34 +249,59 @@ pub fn run_cli_backend(
             "cli subprocess exceeded {}s wall-clock timeout",
             timeout_seconds
         ))
-    } else if exit_success && envelope_indicates_failure {
+    } else if exit_success && matches!(envelope_status.as_deref(), Some("failed") | Some("timeout"))
+    {
         Some(format!(
             "cli subprocess reported envelope status={:?} despite exit 0",
             envelope_status.as_deref().unwrap_or("unknown")
         ))
+    } else if let Some(Err(error)) = parsed_result.as_ref() {
+        Some(response_diagnostic(error, &redaction))
     } else if !success {
         Some(format!("cli subprocess exited with code {:?}", exit_code))
     } else {
         None
     };
 
+    let StdoutTextPreview {
+        text: stdout_text,
+        truncated: stdout_text_truncated,
+        preview_bytes: stdout_text_preview_bytes,
+    } = stdout_preview;
+    let mut output = parsed_result.and_then(Result::ok).unwrap_or_default();
+    for (key, value) in [
+        ("provider", Value::String(provider.clone())),
+        ("argv_redacted", serde_json::json!(argv_redacted)),
+        ("stdin_blob_ref", Value::String(stdin_blob_ref.clone())),
+        ("stdout_blob_ref", Value::String(stdout_blob_ref.clone())),
+        ("stderr_blob_ref", Value::String(stderr_blob_ref.clone())),
+        ("exit_code", serde_json::json!(exit_code)),
+        (
+            "duration_ms",
+            serde_json::json!(duration.as_millis() as u64),
+        ),
+        ("timed_out", Value::Bool(timed_out)),
+        ("stdout_text", Value::String(stdout_text)),
+        ("stdout_text_truncated", Value::Bool(stdout_text_truncated)),
+        (
+            "stdout_text_original_bytes",
+            serde_json::json!(stdout.len()),
+        ),
+        (
+            "stdout_text_preview_bytes",
+            serde_json::json!(stdout_text_preview_bytes),
+        ),
+        (
+            "stdout_text_preview_limit_bytes",
+            serde_json::json!(STDOUT_TEXT_PREVIEW_LIMIT_BYTES),
+        ),
+    ] {
+        output.entry(key.to_string()).or_insert(value);
+    }
+
     Ok(DispatchOutcome {
         success,
-        output: serde_json::json!({
-            "provider": provider,
-            "argv_redacted": argv_redacted,
-            "stdin_blob_ref": stdin_blob_ref,
-            "stdout_blob_ref": stdout_blob_ref,
-            "stderr_blob_ref": stderr_blob_ref,
-            "exit_code": exit_code,
-            "duration_ms": duration.as_millis() as u64,
-            "timed_out": timed_out,
-            "stdout_text": stdout_preview.text,
-            "stdout_text_truncated": stdout_preview.truncated,
-            "stdout_text_original_bytes": stdout.len(),
-            "stdout_text_preview_bytes": stdout_preview.preview_bytes,
-            "stdout_text_preview_limit_bytes": STDOUT_TEXT_PREVIEW_LIMIT_BYTES,
-        }),
+        output: Value::Object(output),
         message,
         invocation: trace.map(|trace| DispatchInvocationTrace {
             provider,
@@ -275,6 +309,20 @@ pub fn run_cli_backend(
             trace,
         }),
     })
+}
+
+fn response_diagnostic(error: &str, redactor: &PatternRedactor) -> String {
+    let redacted = redactor.apply_str(&redact_sensitive_env_text(error));
+    let bounded: String = redacted
+        .chars()
+        .take(RESPONSE_DIAGNOSTIC_LIMIT_CHARS)
+        .collect();
+    let suffix = if bounded.len() < redacted.len() {
+        "…"
+    } else {
+        ""
+    };
+    format!("cli response envelope invalid: {bounded}{suffix}")
 }
 
 struct CliLearningContext {

--- a/crates/orbit-engine/src/activity_job/cli_runner/tests/orchestrator.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/tests/orchestrator.rs
@@ -26,7 +26,7 @@ fn run_cli_backend_finished_audit_event_keeps_stdout_stderr_blob_refs() {
     let script = temp.path().join("codex");
     write_executable(
         &script,
-        "#!/bin/sh\nprintf '%s\\n' 'plain stdout'\nprintf '%s\\n' 'plain stderr' >&2\n",
+        "#!/bin/sh\nprintf '%s\\n' '{\"schemaVersion\":1,\"status\":\"success\",\"result\":{},\"error\":null}'\nprintf '%s\\n' 'plain stderr' >&2\n",
     );
 
     let sink = Arc::new(RecordingSink::default());
@@ -47,9 +47,10 @@ fn run_cli_backend_finished_audit_event_keeps_stdout_stderr_blob_refs() {
         .expect("run succeeds");
 
     assert!(outcome.success);
-    assert_eq!(outcome.output["stdout_text"], "plain stdout\n");
+    let stdout = "{\"schemaVersion\":1,\"status\":\"success\",\"result\":{},\"error\":null}\n";
+    assert_eq!(outcome.output["stdout_text"], stdout);
     assert_eq!(outcome.output["stdout_text_truncated"], false);
-    assert_eq!(outcome.output["stdout_text_original_bytes"], 13);
+    assert_eq!(outcome.output["stdout_text_original_bytes"], stdout.len());
     let events = audit.events_snapshot().expect("events snapshot");
     let finished = events
         .iter()
@@ -77,8 +78,132 @@ fn run_cli_backend_finished_audit_event_keeps_stdout_stderr_blob_refs() {
     assert_eq!(finished.2, Some("blob-2"));
     assert_eq!(finished.3, Some("blob-3"));
     assert!(!finished.4);
-    assert_eq!(sink.blob("blob-2"), Some(b"plain stdout\n".to_vec()));
+    assert_eq!(sink.blob("blob-2"), Some(stdout.as_bytes().to_vec()));
     assert_eq!(sink.blob("blob-3"), Some(b"plain stderr\n".to_vec()));
+}
+
+#[test]
+fn run_cli_backend_projects_prose_prefixed_claude_envelope_result() {
+    let temp = tempdir().expect("tempdir");
+    let script = temp.path().join("claude");
+    let response = serde_json::json!({
+        "type": "result",
+        "subtype": "success",
+        "result": format!(
+            "I classified both failed runs.\n{}",
+            serde_json::json!({
+                "schemaVersion": 1,
+                "status": "success",
+                "result": {
+                    "dispositions": [
+                        {
+                            "task_id": "ORB-A",
+                            "classification": "environmental",
+                            "disposition": "rebacklog",
+                            "diagnosis": "stale worktree removed"
+                        },
+                        {
+                            "task_id": "ORB-B",
+                            "classification": "code_defect",
+                            "disposition": "stay_blocked",
+                            "diagnosis": "tests remain red"
+                        }
+                    ],
+                    "summary": "one recovery and one human follow-up"
+                },
+                "error": null
+            })
+        ),
+        "usage": {
+            "input_tokens": 11,
+            "output_tokens": 7
+        }
+    })
+    .to_string();
+    write_executable(
+        &script,
+        &format!("#!/bin/sh\ncat > /dev/null\nprintf '%s\\n' '{response}'\n"),
+    );
+
+    let sink = Arc::new(RecordingSink::default());
+    let sink_for_writer: Arc<dyn AuditSink> = sink;
+    let audit = Arc::new(V2AuditWriter::new(
+        "job-claude-envelope-result",
+        "claude:sonnet",
+        sink_for_writer,
+    ));
+    let host = TestHost::with_command(script.display().to_string());
+    let spec = test_agent_loop_spec_for("claude", Duration::from_secs(5));
+
+    let outcome = run_cli_backend(
+        &host,
+        &spec,
+        "job-claude-envelope-result",
+        audit,
+        &serde_json::json!({"prompt": "triage failed runs"}),
+        None,
+    )
+    .expect("run cli backend");
+
+    assert!(outcome.success);
+    assert_eq!(
+        outcome.output["dispositions"].as_array().map(Vec::len),
+        Some(2)
+    );
+    assert_eq!(
+        outcome.output["dispositions"][0]["disposition"],
+        serde_json::json!("rebacklog")
+    );
+    assert_eq!(
+        outcome.output["dispositions"][1]["disposition"],
+        serde_json::json!("stay_blocked")
+    );
+    assert_eq!(
+        outcome.output["summary"],
+        serde_json::json!("one recovery and one human follow-up")
+    );
+    assert_eq!(outcome.output["provider"], serde_json::json!("claude"));
+}
+
+#[test]
+fn run_cli_backend_rejects_schema_invalid_success_envelope() {
+    let temp = tempdir().expect("tempdir");
+    let script = temp.path().join("codex");
+    write_executable(
+        &script,
+        "#!/bin/sh\ncat > /dev/null\nprintf '%s\\n' '{\"schemaVersion\":2,\"status\":\"success\",\"result\":{},\"error\":null}'\n",
+    );
+
+    let sink = Arc::new(RecordingSink::default());
+    let sink_for_writer: Arc<dyn AuditSink> = sink;
+    let audit = Arc::new(V2AuditWriter::new(
+        "job-invalid-envelope",
+        "codex:gpt-5.5",
+        sink_for_writer,
+    ));
+    let host = TestHost::with_command(script.display().to_string());
+    let spec = test_agent_loop_spec(Duration::from_secs(5));
+
+    let outcome = run_cli_backend(
+        &host,
+        &spec,
+        "job-invalid-envelope",
+        audit,
+        &serde_json::json!({"prompt": "hi"}),
+        None,
+    )
+    .expect("run cli backend");
+
+    assert!(!outcome.success);
+    let message = outcome.message.expect("invalid envelope message");
+    assert!(
+        message.contains("cli response envelope invalid"),
+        "{message}"
+    );
+    assert!(
+        message.contains("unsupported schemaVersion: 2"),
+        "{message}"
+    );
 }
 
 #[test]
@@ -154,10 +279,11 @@ fn run_cli_backend_redacts_secret_like_stdout_text_preview() {
         &script,
         r#"#!/bin/sh
 cat > /dev/null
-printf '%s\n' 'Authorization: Bearer stdout-secret-token'
-printf '%s\n' 'x-api-key: stdout-header-key'
-printf '%s\n' 'sk-stdoutsecret123'
+printf '%s\n' '{"log":"Authorization: Bearer stdout-secret-token"}'
+printf '%s\n' '{"x-api-key":"stdout-header-key"}'
+printf '%s\n' '{"log":"sk-stdoutsecret123"}'
 printf '%s\n' '{"api_key":"stdout-json-key"}'
+printf '%s\n' '{"schemaVersion":1,"status":"success","result":{},"error":null}'
 "#,
     );
 
@@ -208,7 +334,7 @@ fn run_cli_backend_redacts_live_env_values_in_stored_blobs() {
     write_executable(
         &script,
         &format!(
-            "#!/bin/sh\ncat > /dev/null\nprintf '%s\\n' 'stdout leak {secret}'\nprintf '%s\\n' 'stderr leak {secret}' >&2\n"
+            "#!/bin/sh\ncat > /dev/null\nprintf '%s\\n' '{{\"log\":\"stdout leak {secret}\"}}'\nprintf '%s\\n' '{{\"schemaVersion\":1,\"status\":\"success\",\"result\":{{}},\"error\":null}}'\nprintf '%s\\n' 'stderr leak {secret}' >&2\n"
         ),
     );
 
@@ -266,7 +392,7 @@ fn run_cli_backend_returns_error_when_declared_workspace_path_missing() {
     let script = temp.path().join("codex");
     write_executable(
         &script,
-        "#!/bin/sh\ncat > /dev/null\nprintf '%s\\n' '{\"status\":\"ok\"}'\n",
+        "#!/bin/sh\ncat > /dev/null\nprintf '%s\\n' '{\"schemaVersion\":1,\"status\":\"success\",\"result\":{},\"error\":null}'\n",
     );
     let missing = temp.path().join("missing-worktree");
 
@@ -319,7 +445,7 @@ fn run_cli_backend_records_resolved_cwd_in_started_event() {
     let script = temp.path().join("codex");
     write_executable(
         &script,
-        "#!/bin/sh\ncat > /dev/null\nprintf '%s\\n' '{\"status\":\"ok\"}'\n",
+        "#!/bin/sh\ncat > /dev/null\nprintf '%s\\n' '{\"schemaVersion\":1,\"status\":\"success\",\"result\":{},\"error\":null}'\n",
     );
     let workspace_dir = tempdir().expect("workspace tempdir");
     let workspace = workspace_dir
@@ -374,7 +500,7 @@ fn run_cli_backend_passes_provider_config_to_codex_runtime_args() {
     let script = temp.path().join("codex");
     write_executable(
         &script,
-        "#!/bin/sh\ncat > /dev/null\nprintf '%s\\n' '{\"status\":\"ok\"}'\n",
+        "#!/bin/sh\ncat > /dev/null\nprintf '%s\\n' '{\"schemaVersion\":1,\"status\":\"success\",\"result\":{},\"error\":null}'\n",
     );
 
     let sink = Arc::new(RecordingSink::default());
@@ -703,11 +829,11 @@ fn mixed_crew_drives_exact_models_to_planner_and_implementer() {
     let codex_script = temp.path().join("codex");
     write_executable(
         &claude_script,
-        "#!/bin/sh\nprintf '{\"schemaVersion\":1,\"status\":\"success\"}\\n'\n",
+        "#!/bin/sh\nprintf '{\"schemaVersion\":1,\"status\":\"success\",\"result\":{},\"error\":null}\\n'\n",
     );
     write_executable(
         &codex_script,
-        "#!/bin/sh\nprintf '{\"schemaVersion\":1,\"status\":\"success\"}\\n'\n",
+        "#!/bin/sh\nprintf '{\"schemaVersion\":1,\"status\":\"success\",\"result\":{},\"error\":null}\\n'\n",
     );
 
     // planner leg via mixed fixture crew
@@ -831,7 +957,10 @@ fn run_cli_backend_redacts_token_shaped_argv_in_audit() {
     // the persisted run record / audit event, not recorded verbatim.
     let temp = tempdir().expect("tempdir");
     let script = temp.path().join("codex");
-    write_executable(&script, "#!/bin/sh\ncat > /dev/null\nprintf 'ok\\n'\n");
+    write_executable(
+        &script,
+        "#!/bin/sh\ncat > /dev/null\nprintf '{\"schemaVersion\":1,\"status\":\"success\",\"result\":{},\"error\":null}\\n'\n",
+    );
 
     let sink = Arc::new(RecordingSink::default());
     let sink_for_writer: Arc<dyn AuditSink> = sink;

--- a/crates/orbit-engine/src/activity_job/cli_runner/tests/orchestrator_macos.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/tests/orchestrator_macos.rs
@@ -28,7 +28,7 @@ fn run_cli_backend_audit_argv_starts_with_sandbox_exec_for_each_provider() {
         let script = temp.path().join(provider_name);
         write_executable(
             &script,
-            "#!/bin/sh\ncat > /dev/null\nprintf '%s\\n' '{\"status\":\"ok\"}'\n",
+            "#!/bin/sh\ncat > /dev/null\nprintf '%s\\n' '{\"schemaVersion\":1,\"status\":\"success\",\"result\":{},\"error\":null}'\n",
         );
 
         let sink = Arc::new(RecordingSink::default());
@@ -99,7 +99,7 @@ fn run_cli_backend_pins_codex_sandbox_under_outer_wrapper() {
     let script = temp.path().join("codex");
     write_executable(
         &script,
-        "#!/bin/sh\ncat > /dev/null\nprintf '%s\\n' '{\"status\":\"ok\"}'\n",
+        "#!/bin/sh\ncat > /dev/null\nprintf '%s\\n' '{\"schemaVersion\":1,\"status\":\"success\",\"result\":{},\"error\":null}'\n",
     );
 
     let sink = Arc::new(RecordingSink::default());
@@ -167,7 +167,7 @@ fn run_cli_backend_drops_gemini_sandbox_flag_under_outer_wrapper() {
     let script = temp.path().join("gemini");
     write_executable(
         &script,
-        "#!/bin/sh\ncat > /dev/null\nprintf '%s\\n' '{\"status\":\"ok\"}'\n",
+        "#!/bin/sh\ncat > /dev/null\nprintf '%s\\n' '{\"schemaVersion\":1,\"status\":\"success\",\"result\":{},\"error\":null}'\n",
     );
 
     let sink = Arc::new(RecordingSink::default());
@@ -233,7 +233,7 @@ fn run_cli_backend_drops_grok_sandbox_flag_under_outer_wrapper() {
     let script = temp.path().join("grok");
     write_executable(
         &script,
-        "#!/bin/sh\ncat > /dev/null\nprintf '%s\\n' '{\"status\":\"ok\"}'\n",
+        "#!/bin/sh\ncat > /dev/null\nprintf '%s\\n' '{\"schemaVersion\":1,\"status\":\"success\",\"result\":{},\"error\":null}'\n",
     );
 
     let sink = Arc::new(RecordingSink::default());
@@ -296,7 +296,7 @@ fn run_cli_backend_leaves_claude_argv_suffix_unchanged_under_sandbox() {
     let script = temp.path().join("claude");
     write_executable(
         &script,
-        "#!/bin/sh\ncat > /dev/null\nprintf '%s\\n' '{\"status\":\"ok\"}'\n",
+        "#!/bin/sh\ncat > /dev/null\nprintf '%s\\n' '{\"schemaVersion\":1,\"status\":\"success\",\"result\":{},\"error\":null}'\n",
     );
 
     let sink = Arc::new(RecordingSink::default());


### PR DESCRIPTION
## Task

ORB-10216

## Execution Summary

- Validates and unwraps provider-wrapped CLI response envelopes before exposing result fields to workflow templates.
- Preserves bounded/redacted runtime metadata and fails closed on malformed or failed envelopes.
- Adds a prose-prefixed Claude regression plus an end-to-end multi-disposition triage regression.

## Validation

- `cargo test -p orbit-engine activity_job::cli_runner --lib` (44 passed)
- `cargo test -p orbit-core task_triage_pipeline_applies_multiple_cli_envelope_dispositions --lib` (1 passed)
- `make ci-fast`

## Branch Freshness

Based on current `origin/agent-main` at `cc204723b7f1ab4f36eb3b8412b0316fe2c5d088`.