### PR TITLE
test: isolate temporary init skill links [ORB-10220]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - **Bundled skills are repository-agnostic**: the embedded skill tree drops Orbit-source paths, private Constellation names, workspace-local artifact IDs, and fixed design-doc filenames; a portability regression test and byte-aligned plugin mirrors guard against reintroduction. ([ORB-10208])
 - **CLI agent envelopes reach workflows**: provider-wrapped, prose-prefixed successful responses now validate and project their result object before workflow templating; malformed or failed envelopes fail closed. ([ORB-10216])
+- **Temporary init validation isolates skill discovery**: test fixtures now sandbox HOME before seeding skills, preserving existing agent discovery links after temporary-root cleanup. ([ORB-10220])
 - **Scheduled provider discovery fixed**: systemd routine sweeps now use a portable user PATH so provider launchers installed in `~/.local/bin` remain available. ([ORB-10214])
 - **Log rotation and pipeline spawning tolerate replaced paths**: missing log archive directories are silent no-ops, while long-lived Orbit processes resolve Linux deleted-inode executable paths back to the installed binary before spawning workers. ([ORB-10213])
 - **Skill guidance reflects friction triage**: shipped skills use positional learning-show IDs and document mutable friction statuses, direct triage commands, and task-driven resolution. ([ORB-10210])

--- a/crates/orbit-cli/src/command/tests/init.rs
+++ b/crates/orbit-cli/src/command/tests/init.rs
@@ -1,12 +1,66 @@
 use std::fs;
+use std::path::{Path, PathBuf};
 use std::sync::Mutex;
+
 use tempfile::tempdir;
 
 use crate::InitCommand;
 use crate::command::init::collect_role_settings_for_init;
+use orbit_common::utility::fs::create_dir_symlink;
 use orbit_core::config::agent_detect::DetectedAgents;
 
 static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+struct ScopedHome {
+    previous_home: Option<std::ffi::OsString>,
+    previous_userprofile: Option<std::ffi::OsString>,
+}
+
+impl ScopedHome {
+    fn set(path: &Path) -> Self {
+        let guard = Self {
+            previous_home: std::env::var_os("HOME"),
+            previous_userprofile: std::env::var_os("USERPROFILE"),
+        };
+        unsafe {
+            std::env::set_var("HOME", path);
+            std::env::set_var("USERPROFILE", path);
+        }
+        guard
+    }
+}
+
+impl Drop for ScopedHome {
+    fn drop(&mut self) {
+        restore_env("HOME", self.previous_home.take());
+        restore_env("USERPROFILE", self.previous_userprofile.take());
+    }
+}
+
+fn restore_env(name: &str, value: Option<std::ffi::OsString>) {
+    match value {
+        Some(value) => unsafe { std::env::set_var(name, value) },
+        None => unsafe { std::env::remove_var(name) },
+    }
+}
+
+fn seed_discovery_sentinel(home: &Path, agent_dir: &str) -> (PathBuf, PathBuf) {
+    let target = home.join("live-sentinels").join(agent_dir).join("orbit");
+    fs::create_dir_all(&target).expect("create sentinel target");
+    let link = home.join(agent_dir).join("skills").join("orbit");
+    fs::create_dir_all(link.parent().expect("sentinel link parent"))
+        .expect("create sentinel link parent");
+    create_dir_symlink(&target, &link).expect("create sentinel discovery link");
+    (link, target)
+}
+
+fn assert_discovery_sentinel(link: &Path, target: &Path) {
+    assert_eq!(
+        fs::read_link(link).expect("read sentinel discovery link"),
+        target,
+        "temporary-root validation must not rewrite live skill discovery links",
+    );
+}
 
 /// `collect_role_settings_for_init` short-circuits when --non-interactive
 /// is set, regardless of whether config.toml exists. No prompts are
@@ -35,23 +89,53 @@ fn existing_config_short_circuits_before_prompts() {
     assert!(matches!(result, Ok(None)));
 }
 
-/// End-to-end: `InitCommand { non_interactive: true }` produces a fresh
-/// config.toml with generated crew tables and no uncommented `[agent.*]`
-/// sections. The exact default crew/duel set depends on the runner PATH.
+/// End-to-end: temporary-root validation runs with an isolated discovery
+/// home, preserving the invoking account's existing skill links while it
+/// produces a fresh config.toml with generated crew tables.
 #[test]
-fn non_interactive_init_writes_generated_crew_config() {
+fn non_interactive_init_isolates_temporary_root_skill_discovery() {
     let _guard = ENV_LOCK.lock().expect("lock env");
-    let home = tempdir().expect("home tempdir");
+    let live_home = tempdir().expect("live home tempdir");
+    let validation_home = tempdir().expect("validation home tempdir");
+    let validation_root = tempdir().expect("validation root tempdir");
 
-    let cmd = InitCommand {
-        force: false,
-        non_interactive: true,
+    let _live_home = ScopedHome::set(live_home.path());
+    let (agents_link, agents_target) = seed_discovery_sentinel(live_home.path(), ".agents");
+    let (claude_link, claude_target) = seed_discovery_sentinel(live_home.path(), ".claude");
+
+    let outcome = {
+        let _validation_home = ScopedHome::set(validation_home.path());
+        InitCommand {
+            force: false,
+            non_interactive: true,
+        }
+        .execute_without_runtime(Some(&validation_root.path().join(".orbit")))
     };
-    let outcome = cmd.execute_without_runtime(Some(&home.path().join(".orbit")));
 
     outcome.expect("init succeeded");
 
-    let config_path = home.path().join(".orbit").join("config.toml");
+    assert_discovery_sentinel(&agents_link, &agents_target);
+    assert_discovery_sentinel(&claude_link, &claude_target);
+    assert!(
+        validation_home
+            .path()
+            .join(".agents")
+            .join("skills")
+            .join("orbit")
+            .is_symlink(),
+        "validation links belong under the isolated HOME"
+    );
+    assert!(
+        validation_home
+            .path()
+            .join(".claude")
+            .join("skills")
+            .join("orbit")
+            .is_symlink(),
+        "validation links belong under the isolated HOME"
+    );
+
+    let config_path = validation_root.path().join(".orbit").join("config.toml");
     let contents = fs::read_to_string(&config_path).expect("read config");
     for line in contents.lines() {
         assert!(
@@ -73,4 +157,8 @@ fn non_interactive_init_writes_generated_crew_config() {
         codex.get("model").and_then(toml::Value::as_str),
         Some("gpt-5.6-terra"),
     );
+    drop(validation_root);
+    drop(validation_home);
+    assert_discovery_sentinel(&agents_link, &agents_target);
+    assert_discovery_sentinel(&claude_link, &claude_target);
 }


### PR DESCRIPTION
## Summary
- isolate temporary-root init validation from the operator HOME and USERPROFILE
- preserve live skill discovery links across fixture cleanup
- add a regression with sentinel live links and record the fix in the changelog

## Validation
- cargo test -p orbit-cli non_interactive_init_isolates_temporary_root_skill_discovery
- make ci-fast

Resolves ORB-10220 and F2026-07-065.