### PR TITLE
Document and test pr_status clear semantics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- **PR review status clearing is documented**: `orbit.task.update` now describes its empty-string clear convention, with tool-host coverage for the persisted null result. ([ORB-10229])
 - **Task PR status updates persist in v2 storage**: local tool and dashboard PATCH updates now retain `pr_status` alongside status and execution-summary changes. ([ORB-10223])
 - **Bundled skills are repository-agnostic**: the embedded skill tree drops Orbit-source paths, private Constellation names, workspace-local artifact IDs, and fixed design-doc filenames; a portability regression test and byte-aligned plugin mirrors guard against reintroduction. ([ORB-10208])
 - **CLI agent envelopes reach workflows**: provider-wrapped, prose-prefixed successful responses now validate and project their result object before workflow templating; malformed or failed envelopes fail closed. ([ORB-10216])

--- a/crates/orbit-cli/tests/snapshots/mcp_tools_list.json
+++ b/crates/orbit-cli/tests/snapshots/mcp_tools_list.json
@@ -1699,7 +1699,7 @@
           "type": "string"
         },
         "pr_status": {
-          "description": "PR review status (e.g. approve, request-changes)",
+          "description": "PR review status (e.g. approve, request-changes; empty string clears)",
           "type": "string"
         },
         "relations": {

--- a/crates/orbit-core/src/runtime/orbit_tool_host/tests/task_tools.rs
+++ b/crates/orbit-core/src/runtime/orbit_tool_host/tests/task_tools.rs
@@ -783,7 +783,7 @@ fn task_update_tool_infers_agent_from_model_only_input() {
 }
 
 #[test]
-fn task_update_tool_persists_pr_status_with_status_and_execution_summary() {
+fn task_update_tool_persists_and_clears_pr_status() {
     let (_root, runtime, repo_root) = test_runtime();
     let task = create_task(
         &runtime,
@@ -822,6 +822,29 @@ fn task_update_tool_persists_pr_status_with_status_and_execution_summary() {
     assert_eq!(persisted.pr_status.as_deref(), Some("approved"));
     assert_eq!(persisted.execution_summary, "Implemented and verified.");
     assert_eq!(persisted.status, TaskStatus::Review);
+
+    let cleared = runtime
+        .execute_tool_command(
+            "orbit.task.update",
+            json!({
+                "id": task.id,
+                "pr_status": "",
+            }),
+            Some("codex".to_string()),
+            Some(orbit_common::test_fixtures::TEST_CODEX_MODEL.to_string()),
+        )
+        .expect("empty pr status clears the field");
+    assert_eq!(cleared.get("pr_status"), Some(&Value::Null));
+
+    let persisted = runtime
+        .execute_tool_command(
+            "orbit.task.show",
+            json!({ "id": task.id }),
+            Some("codex".to_string()),
+            Some(orbit_common::test_fixtures::TEST_CODEX_MODEL.to_string()),
+        )
+        .expect("task show tool succeeds after clearing pr status");
+    assert_eq!(persisted.get("pr_status"), Some(&Value::Null));
 }
 
 #[test]

--- a/crates/orbit-tools/src/builtin/orbit/task/update.rs
+++ b/crates/orbit-tools/src/builtin/orbit/task/update.rs
@@ -101,7 +101,8 @@ impl Tool for OrbitTaskUpdateTool {
             },
             ToolParam {
                 name: "pr_status".to_string(),
-                description: "PR review status (e.g. approve, request-changes)".to_string(),
+                description: "PR review status (e.g. approve, request-changes; empty string clears)"
+                    .to_string(),
                 param_type: "string".to_string(),
                 required: false,
             },


### PR DESCRIPTION
## Task

[ORB-10229](https://orbit-cli.com/tasks/ORB-10229) — Document and test pr_status clear semantics

### Description

The v2 pr_status mutation now works, but the tool surface does not disclose that an empty string clears the field; explicit JSON null is treated as field absence. Align the registered parameter description with the existing adapter convention and add a regression that sets and then clears pr_status through orbit.task.update so callers cannot mistake a successful no-op for a clear.

### Acceptance Criteria

- The orbit.task.update pr_status parameter description explicitly states that an empty string clears the field, consistent with job_run_id and crew.
- A tool-host regression sets pr_status and then clears it with the documented representation, proving the persisted task returns pr_status null.
- Relevant focused tests and make ci-fast pass.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Documented that an empty `pr_status` string clears the field.
- Extended the tool-host regression to set, clear, and read back `pr_status` as JSON null.
- Synced the MCP tools/list snapshot and added the required Unreleased changelog entry.

Assessment: The clear convention is now visible in the schema and protected across update and persisted readback.

Validation:
- `cargo test -p orbit-core task_update_tool_persists_and_clears_pr_status --lib`
- `cargo test -p orbit-cli --test mcp_roundtrip mcp_serve_tools_list_matches_production_snapshot`
- `make ci-fast`

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10229-6a583558`
- Behind base: 0
- Ahead of base: 1