### PR TITLE
Merge ADR creation-gate criteria in orbit-knowledge skill (single test + qualifying list)

### DIFF
--- a/crates/orbit-core/assets/skills/orbit-knowledge/SKILL.md
+++ b/crates/orbit-core/assets/skills/orbit-knowledge/SKILL.md
@@ -53,7 +53,13 @@ Listing is **not** on the agent MCP surface — use `orbit search --kind adr` fo
 
 **Workflow:** (1) inspect nearby decisions first (`orbit search "<concept>" --kind adr`, `orbit.adr.show`, `legacy_id` lookup for migrated per-feature refs). (2) new decision → `add`; body/metadata correction → `update`; reversal of an accepted ADR → create the replacement, accept it with a related task, then `supersede`. (3) body needs exactly `## Context`, `## Decision`, `## Consequences`, with ≥1 consequences bullet starting `Cost:`. (4) `related_features` = feature/area names; `tags` = free-form cross-artifact labels; `paths` = repo-relative globs the decision constrains. (5) `related_tasks` may be empty for a speculative proposed ADR — don't invent a task just to satisfy one; **acceptance requires a real related task**. (6) verify with `.show` or `orbit search --kind adr`.
 
-Creation is warranted only when all three hold: a real alternative was on the table, the choice constrains future work, and the cost is non-trivial and worth preserving. Otherwise put the detail in a design doc, a spec, or an existing ADR's instance table.
+Propose an ADR only when both hold: a real alternative was on the table, and the choice is meaningfully costly to reverse. Treat "surprising without context" as a strong signal, not a third hard requirement — lock-in can be real without being surprising (e.g. a Postgres or monorepo pick), so weigh it as a tiebreaker rather than a filter. Qualifies:
+- A deliberate deviation from the obvious path (e.g. ADR-0217's turn-knobs-out-of-specs).
+- A constraint not visible in the code itself.
+- A non-obvious rejected alternative worth recording.
+- A technology/architecture choice with real lock-in.
+
+Otherwise put the detail in a design doc, a spec, or an existing ADR's instance table.
 
 ```markdown
 ## Context

--- a/plugin/skills/orbit-knowledge/SKILL.md
+++ b/plugin/skills/orbit-knowledge/SKILL.md
@@ -53,7 +53,13 @@ Listing is **not** on the agent MCP surface — use `orbit search --kind adr` fo
 
 **Workflow:** (1) inspect nearby decisions first (`orbit search "<concept>" --kind adr`, `orbit.adr.show`, `legacy_id` lookup for migrated per-feature refs). (2) new decision → `add`; body/metadata correction → `update`; reversal of an accepted ADR → create the replacement, accept it with a related task, then `supersede`. (3) body needs exactly `## Context`, `## Decision`, `## Consequences`, with ≥1 consequences bullet starting `Cost:`. (4) `related_features` = feature/area names; `tags` = free-form cross-artifact labels; `paths` = repo-relative globs the decision constrains. (5) `related_tasks` may be empty for a speculative proposed ADR — don't invent a task just to satisfy one; **acceptance requires a real related task**. (6) verify with `.show` or `orbit search --kind adr`.
 
-Creation is warranted only when all three hold: a real alternative was on the table, the choice constrains future work, and the cost is non-trivial and worth preserving. Otherwise put the detail in a design doc, a spec, or an existing ADR's instance table.
+Propose an ADR only when both hold: a real alternative was on the table, and the choice is meaningfully costly to reverse. Treat "surprising without context" as a strong signal, not a third hard requirement — lock-in can be real without being surprising (e.g. a Postgres or monorepo pick), so weigh it as a tiebreaker rather than a filter. Qualifies:
+- A deliberate deviation from the obvious path (e.g. ADR-0217's turn-knobs-out-of-specs).
+- A constraint not visible in the code itself.
+- A non-obvious rejected alternative worth recording.
+- A technology/architecture choice with real lock-in.
+
+Otherwise put the detail in a design doc, a spec, or an existing ADR's instance table.
 
 ```markdown
 ## Context


### PR DESCRIPTION
## Task

[ORB-10198](https://orbit-cli.com/tasks/ORB-10198) — Merge ADR creation-gate criteria in orbit-knowledge skill (single test + qualifying list)

### Description

## Goal

Revise the ADR creation gate in the `orbit-knowledge` skill so there is exactly **one** three-part test, incorporating Daniel's proposed criteria — do not append a second, competing gate.

## Current state

`crates/orbit-core/assets/skills/orbit-knowledge/SKILL.md` (§ ADRs) gates creation with: "a real alternative was on the table, the choice constrains future work, and the cost is non-trivial and worth preserving."

## Proposed input (Daniel's draft, to be merged not appended)

Three AND criteria — hard to reverse; surprising without context; result of a real trade-off — plus a "what qualifies" list (architectural shape, integration patterns, lock-in tech choices, boundary/scope decisions, deliberate deviations from the obvious path, constraints not visible in code, non-obvious rejected alternatives).

## Requirements

1. **Merge into one gate.** Replace the existing one-sentence test with a short merged test: real alternative + meaningfully costly to reverse, with "surprising without context" as a strong signal/tiebreaker — not a hard AND (a Postgres/monorepo choice carries lock-in without being surprising; the draft's own qualifying list violates its criterion 2 if it stays a hard requirement).
2. **Add a compact qualifying list (~4 bullets)** drawn from the highest-value draft bullets: deliberate deviations from the obvious path, constraints not visible in the code, non-obvious rejected alternatives, technology/architecture choices with real lock-in. Keep each bullet to one line.
3. **Drop generic examples** (DDD bounded contexts, GraphQL-vs-REST). If examples are kept, use real constellation ones (e.g. ADR-0217 turn-knobs-out-of-specs as a "deliberate deviation"). This file ships as a prompt asset — token budget matters.
4. **Use "propose"** rather than "offer"/"create" phrasing, consistent with the existing lifecycle (proposed ADRs allow empty related_tasks; acceptance requires a real task).
5. **Update both copies in sync:** `crates/orbit-core/assets/skills/orbit-knowledge/SKILL.md` and `plugin/skills/orbit-knowledge/SKILL.md` (verify whether the plugin copy carries the same section; mirror the change wherever the gate appears).
6. Keep the rest of the skill (tool tables, workflow, body template, common mistakes, exit criteria) untouched except where the gate sentence lives.

## Acceptance

- Exactly one creation gate remains in the skill; no duplicated/conflicting criteria.
- "Surprising without context" present as a signal, not a hard AND.
- Qualifying list ≤5 one-line bullets; no generic DDD/GraphQL examples.
- Both skill copies identical in the changed section.

### Acceptance Criteria



## Execution Summary

<details>
<summary>Click to expand</summary>

Merged the ADR creation-gate criteria in orbit-knowledge SKILL.md into a single test. Replaced the old three-part hard-AND sentence ("a real alternative was on the table, the choice constrains future work, and the cost is non-trivial and worth preserving") with a two-part hard-AND gate (real alternative on the table + meaningfully costly to reverse), demoting "surprising without context" to a strong tiebreaker signal rather than a third hard requirement (per the task's own note that lock-in choices like Postgres/monorepo aren't always surprising). Added a compact 4-bullet qualifying list: deliberate deviation from the obvious path (cited the real ADR-0217 turn-knobs-out-of-specs example instead of generic DDD/GraphQL examples), constraint not visible in the code, non-obvious rejected alternative, and technology/architecture choice with real lock-in. Used 'propose' phrasing consistent with the existing lifecycle language. Verified crates/orbit-core/assets/skills/orbit-knowledge/SKILL.md and plugin/skills/orbit-knowledge/SKILL.md were byte-identical before the change and applied the identical edit to both, confirmed with diff afterward. Rest of the skill (tool tables, workflow steps, body template, common mistakes, exit criteria) left untouched. Validated with `make ci-fast` (fmt-check + guardrail scripts) — all passed.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10198-6a58382f`
- Behind base: 0
- Ahead of base: 1