### PR TITLE
Honor --root consistently for workspace registry list and show

### DIFF
--- a/crates/orbit-core/src/runtime/mod.rs
+++ b/crates/orbit-core/src/runtime/mod.rs
@@ -123,7 +123,13 @@ impl OrbitRuntime {
         root_override: Option<&Path>,
     ) -> Result<OrbitRuntimeRoots, OrbitError> {
         let resolved = resolve_initialize_roots(cwd, root_override)?;
-        Ok(OrbitRuntimeRoots::new(resolve_global_root()?, resolved))
+        // Only the explicit `--root` flag pins the global registry root to the
+        // isolated root here, so `workspace list` / `show --root <r>` read
+        // `<r>/workspaces.json` — the same file `workspace init --root <r>`
+        // writes — instead of `$HOME/.orbit/workspaces.json` [ORB-10218].
+        // `ORBIT_ROOT` stays a workspace selector that leaves the global root at
+        // `$HOME/.orbit` (see `orbit_root_env_selects_workspace_but_not_global_root`).
+        Self::roots_from_resolved(resolved, root_override.is_some())
     }
 
     pub fn resolve_bootstrap_roots_for_cwd(
@@ -131,14 +137,18 @@ impl OrbitRuntime {
         root_override: Option<&Path>,
     ) -> Result<OrbitRuntimeRoots, OrbitError> {
         let resolved = resolve_bootstrap_roots(cwd, root_override)?;
-        Self::bootstrap_roots_from_resolved_roots(resolved, root_override)
+        Self::roots_from_resolved(resolved, has_explicit_root_override(root_override))
     }
 
-    fn bootstrap_roots_from_resolved_roots(
+    /// Selects the global root for a resolved workspace: when
+    /// `pin_global_to_shared` is set the global root is the isolated shared
+    /// root (registry lookups target the custom root), otherwise it falls back
+    /// to `$HOME/.orbit`.
+    fn roots_from_resolved(
         resolved: ResolvedOrbitRoots,
-        root_override: Option<&Path>,
+        pin_global_to_shared: bool,
     ) -> Result<OrbitRuntimeRoots, OrbitError> {
-        let global_root = if has_explicit_root_override(root_override) {
+        let global_root = if pin_global_to_shared {
             resolved.shared_root.clone()
         } else {
             resolve_global_root()?

--- a/crates/orbit-core/src/runtime/tests/runtime.rs
+++ b/crates/orbit-core/src/runtime/tests/runtime.rs
@@ -104,6 +104,28 @@ fn orbit_root_env_selects_workspace_but_not_global_root() {
     assert_eq!(resolved_roots.local_root, workspace_root);
 }
 
+#[test]
+fn explicit_root_flag_pins_global_registry_root() {
+    let _guard = ENV_LOCK.lock().expect("lock env");
+    let home = tempdir().expect("home tempdir");
+    let repo = tempdir().expect("repo tempdir");
+    let custom_root_parent = tempdir().expect("custom root parent");
+    let custom_root = custom_root_parent.path().join("custom-orbit");
+    seed_initialized_workspace_root(&custom_root);
+    let _home = EnvVarGuard::set("HOME", home.path().as_os_str().to_os_string());
+
+    let resolved_roots =
+        OrbitRuntime::resolve_roots_for_cwd(repo.path(), Some(custom_root.as_path()))
+            .expect("resolve roots with explicit --root");
+
+    // The `--root` flag pins both the shared and global roots to the isolated
+    // custom root, so `workspace list`/`show --root <custom>` read
+    // `<custom>/workspaces.json` rather than `$HOME/.orbit` [ORB-10218].
+    assert_eq!(resolved_roots.global_root, custom_root);
+    assert_eq!(resolved_roots.shared_root, custom_root);
+    assert_ne!(resolved_roots.global_root, home.path().join(".orbit"));
+}
+
 fn seed_initialized_workspace_root(path: &Path) {
     std::fs::create_dir_all(path.join("resources")).expect("create resources dir");
     std::fs::create_dir_all(path.join("tasks")).expect("create tasks dir");


### PR DESCRIPTION
## Task

[ORB-10218](https://orbit-cli.com/tasks/ORB-10218) — Honor --root consistently for workspace registry list and show

### Description

## Problem
`orbit workspace init --root <custom-root>` persists the registration in `<custom-root>/workspaces.json`, but subsequent `orbit workspace list --root <custom-root>` and `orbit workspace show --root <custom-root>` resolve their global registry from `$HOME/.orbit` instead. The list therefore omits the just-initialized workspace and show reports `(not registered as a workspace)`, so an operator cannot inspect the effective ship mode for an isolated/custom Orbit root.

## Evidence
QA sweep against `cc204723b7f1ab4f36eb3b8412b0316fe2c5d088` built the current CLI and exercised re-init with `--ship-mode pr`. With a fresh temporary git repository and custom root, both init commands succeeded and wrote `<custom-root>/workspaces.json`; `workspace show --root <custom-root>` printed `current orbit root: <custom-root>` followed by `(not registered as a workspace)`, while `workspace list --root <custom-root>` rendered the operator home registry. A default-HOME flow does show the expected `ship_mode: pr`, isolating the failure to explicit-root registry resolution.

## Reproduction
1. Create a temporary git repository and choose an empty custom root.
2. From the repository, run `orbit workspace init --root <custom-root> --name qa-e2e --base-branch agent-main --ship-mode pr`.
3. Re-run `orbit workspace init --root <custom-root> --name qa-e2e` to exercise preservation.
4. Run `orbit workspace show --root <custom-root>` and `orbit workspace list --root <custom-root>`.
5. Observe show says the root is unregistered and list reads `$HOME/.orbit/workspaces.json` instead of displaying `qa-e2e` with `pr`.

## Why It Matters
The CLI advertises `--root` as its highest-precedence root override, and init already treats it as the registry root. The mismatch makes root-isolated setup and routing verification misleading.

### Acceptance Criteria

- After `workspace init --root <custom-root> --ship-mode pr`, `workspace show --root <custom-root>` displays the same registration including `ship_mode:   pr`.
- `workspace list --root <custom-root>` reads `<custom-root>/workspaces.json` and lists the newly registered workspace with effective `pr` mode, not entries from `$HOME/.orbit`.
- The default HOME-backed workspace init/list/show flow remains unchanged, and focused regression coverage plus `make ci-fast` pass.

## Execution Summary

<details>
<summary>Click to expand</summary>

Fixed `workspace list`/`show --root <r>` resolving their global registry from `$HOME/.orbit` instead of the custom root, so registrations written by `workspace init --root <r>` were invisible (show printed `(not registered as a workspace)`; list read the home registry).

Root cause: `OrbitRuntime::resolve_roots_for_cwd` (the non-bootstrap path powering `initialize_with_root_override`, used by list/show) hard-coded `global_root = resolve_global_root()?` (= `$HOME/.orbit`), ignoring the explicit `--root`. The bootstrap path (`workspace init`) already honored the override via `bootstrap_roots_from_resolved_roots`.

Fix (crates/orbit-core/src/runtime/mod.rs): renamed `bootstrap_roots_from_resolved_roots` -> shared `roots_from_resolved(resolved, pin_global_to_shared: bool)`. `resolve_roots_for_cwd` now pins the global root to the resolved shared root when the explicit `--root` flag is present (`root_override.is_some()`); the bootstrap wrapper keeps its existing `has_explicit_root_override(...)` predicate. Scoped to the `--root` flag only: `ORBIT_ROOT` intentionally remains a workspace selector that leaves the global root at `$HOME/.orbit`, preserving the existing `orbit_root_env_selects_workspace_but_not_global_root` regression contract.

Test: added `explicit_root_flag_pins_global_registry_root` in crates/orbit-core/src/runtime/tests/runtime.rs asserting `resolve_roots_for_cwd(cwd, Some(custom_root))` yields `global_root == shared_root == custom_root` and not `$HOME/.orbit` — exactly what list/show feed into `registry_path_for`.

Validation: `make ci-fast` passes; new test + `orbit_root_env_selects_workspace_but_not_global_root` + full `runtime::tests::runtime` suite pass; `orbit-cli` builds clean. NOTE: two pre-existing attribution tests (`direct_update_task_keeps_default_human_attribution`, `automation_update_without_agent_runtime_falls_back_to_system_attribution`) fail ONLY because the executor sets `ORBIT_AGENT_MODEL=opus`; both pass with that env var unset and are unrelated to this change.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10218-6a58382f`
- Behind base: 0
- Ahead of base: 1