### PR TITLE
Retry the failed pipeline step after successful recovery

### DIFF
--- a/.orbit/learnings/L-0086/learning.yaml
+++ b/.orbit/learnings/L-0086/learning.yaml
@@ -1,0 +1,19 @@
+schema_version: 1
+id: L-0086
+status: active
+scope:
+  paths:
+  - crates/orbit-engine/src/activity_job/job_executor/recovery.rs
+  - crates/orbit-engine/src/executor/automation/vcs/pr/open.rs
+  tags: []
+summary: Make every recoverable composite workflow step restartable from its first incomplete side effect before enabling post-recovery retry.
+body: 'A recovery agent can legitimately complete a prefix of the failed step while repairing state. The executor then re-enters the whole step, so leading operations must recognize durable valid state: reuse the task commit, inspect remote branch divergence before choosing or skipping a push, and persist/reuse PR identity before later metadata or lifecycle work. Emit a separate resumed-attempt audit event and return the resumed error if that one bounded attempt fails; otherwise operators see the stale pre-recovery failure and cannot diagnose the real terminal cause.'
+evidence:
+- kind: task
+  reference: ORB-10222
+- kind: external
+  reference: jrun-20260716-0031-4
+created_at: 2026-07-16T02:02:59.773115176Z
+updated_at: 2026-07-16T02:02:59.773115176Z
+created_by: codex
+priority: 180

--- a/crates/orbit-cli/src/command/log/format.rs
+++ b/crates/orbit-cli/src/command/log/format.rs
@@ -183,6 +183,10 @@ pub(crate) fn format_code(target: &str, level: &str, fields: &Value) -> String {
         "orbit.policy.deny" => "DENY".to_string(),
         "orbit.friction.reported" => "FRC".to_string(),
         "orbit.job.step_retry" => "RTRY".to_string(),
+        "orbit.job.step_recovery_resumed" => match fields.get("outcome").and_then(Value::as_str) {
+            Some("success") => "RCVR".to_string(),
+            _ => "ERR".to_string(),
+        },
         "orbit.job.step_finished" => match fields.get("success").and_then(Value::as_bool) {
             Some(true) => "OK".to_string(),
             Some(false) => "ERR".to_string(),
@@ -278,6 +282,19 @@ pub(crate) fn format_message(target: &str, fields: &Value) -> String {
             getn("attempt"),
             getn("next_backoff_ms"),
         ),
+        "orbit.job.step_recovery_resumed" => {
+            let mut message = format!(
+                "step {} resumed after recovery attempt={} outcome={}",
+                getf("step_id"),
+                getn("attempt"),
+                getf("outcome"),
+            );
+            let error = getf("error_message");
+            if !error.is_empty() {
+                message.push_str(&format!(": {error}"));
+            }
+            message
+        }
         "orbit.job.step_skipped" => {
             format!("step {} skipped: {}", getf("step_id"), getf("reason"))
         }

--- a/crates/orbit-common/src/types/activity_job/audit_envelope.rs
+++ b/crates/orbit-common/src/types/activity_job/audit_envelope.rs
@@ -85,6 +85,13 @@ pub enum V2AuditEventKind {
         recovery_activity: String,
         recovery_succeeded: bool,
     },
+    StepRecoveryResumed {
+        step_id: String,
+        attempt: u32,
+        outcome: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        error_message: Option<String>,
+    },
     StepDenied {
         step_id: String,
         reason: String,
@@ -196,6 +203,7 @@ impl V2AuditEventKind {
             V2AuditEventKind::StepSkipped { .. } => "step.skipped",
             V2AuditEventKind::StepRetry { .. } => "step.retry",
             V2AuditEventKind::StepRecoveryAttempted { .. } => "step.recovery_attempted",
+            V2AuditEventKind::StepRecoveryResumed { .. } => "step.recovery_resumed",
             V2AuditEventKind::StepDenied { .. } => V2_EVENT_TYPE_STEP_DENIED,
             V2AuditEventKind::StepJoin { .. } => "step.join",
             V2AuditEventKind::FanoutDispatched { .. } => "fanout.dispatched",

--- a/crates/orbit-common/src/types/activity_job/tests/audit_envelope.rs
+++ b/crates/orbit-common/src/types/activity_job/tests/audit_envelope.rs
@@ -77,3 +77,29 @@ fn run_finished_error_message_round_trips_and_absence_defaults_to_none() {
         }
     ));
 }
+
+#[test]
+fn step_recovery_resumed_error_round_trips() {
+    let encoded = serde_json::to_value(V2AuditEventKind::StepRecoveryResumed {
+        step_id: "pr_open".to_string(),
+        attempt: 2,
+        outcome: "error".to_string(),
+        error_message: Some("push failed after recovery".to_string()),
+    })
+    .expect("serialize resumed recovery step");
+
+    assert_eq!(encoded["body_kind"], "step_recovery_resumed");
+    assert_eq!(encoded["attempt"], 2);
+    assert_eq!(encoded["error_message"], "push failed after recovery");
+    let decoded: V2AuditEventKind =
+        serde_json::from_value(encoded).expect("deserialize resumed recovery step");
+    assert!(matches!(
+        decoded,
+        V2AuditEventKind::StepRecoveryResumed {
+            step_id,
+            attempt: 2,
+            outcome,
+            error_message: Some(message),
+        } if step_id == "pr_open" && outcome == "error" && message == "push failed after recovery"
+    ));
+}

--- a/crates/orbit-dashboard/src/log_format.rs
+++ b/crates/orbit-dashboard/src/log_format.rs
@@ -230,6 +230,10 @@ pub(crate) fn format_code(target: &str, level: &str, fields: &Value) -> String {
         "orbit.policy.deny" => "DENY".to_string(),
         "orbit.friction.reported" => "FRC".to_string(),
         "orbit.job.step_retry" => "RTRY".to_string(),
+        "orbit.job.step_recovery_resumed" => match fields.get("outcome").and_then(Value::as_str) {
+            Some("success") => "RCVR".to_string(),
+            _ => "ERR".to_string(),
+        },
         "orbit.job.step_finished" => match fields.get("success").and_then(Value::as_bool) {
             Some(true) => "OK".to_string(),
             Some(false) => "ERR".to_string(),
@@ -302,6 +306,20 @@ pub(crate) fn format_message_html(target: &str, fields: &Value) -> String {
             code_value(getn("attempt")),
             code_value(getn("next_backoff_ms")),
         ),
+        "orbit.job.step_recovery_resumed" => {
+            let mut message = format!(
+                "step {} resumed after recovery attempt={} outcome={}",
+                code_value(getf("step_id").to_string()),
+                code_value(getn("attempt")),
+                code_value(getf("outcome").to_string()),
+            );
+            let error = getf("error_message");
+            if !error.is_empty() {
+                message.push_str(": ");
+                message.push_str(&escape_html(error));
+            }
+            message
+        }
         "orbit.job.step_skipped" => {
             format!(
                 "step {} skipped: {}",

--- a/crates/orbit-engine/src/activity_job/job_executor/audit.rs
+++ b/crates/orbit-engine/src/activity_job/job_executor/audit.rs
@@ -148,6 +148,35 @@ pub(super) fn emit_job_tracing(job_run_id: &str, task_id: Option<&str>, kind: &V
                 );
             }
         }
+        V2AuditEventKind::StepRecoveryResumed {
+            step_id,
+            attempt,
+            outcome,
+            error_message,
+        } => {
+            if outcome == "success" {
+                tracing::info!(
+                    target: "orbit.job.step_recovery_resumed",
+                    job_run_id = job_run_id,
+                    task_id = task_id,
+                    step_id = step_id.as_str(),
+                    attempt = *attempt,
+                    outcome = outcome.as_str(),
+                    "post-recovery step resumed",
+                );
+            } else {
+                tracing::error!(
+                    target: "orbit.job.step_recovery_resumed",
+                    job_run_id = job_run_id,
+                    task_id = task_id,
+                    step_id = step_id.as_str(),
+                    attempt = *attempt,
+                    outcome = outcome.as_str(),
+                    error_message = error_message.as_deref().unwrap_or(""),
+                    "post-recovery step resumed",
+                );
+            }
+        }
         V2AuditEventKind::StepDenied { step_id, reason } => {
             tracing::error!(
                 target: "orbit.job.step_denied",

--- a/crates/orbit-engine/src/activity_job/job_executor/recovery.rs
+++ b/crates/orbit-engine/src/activity_job/job_executor/recovery.rs
@@ -11,14 +11,51 @@ pub(super) fn recover_or_return_original(
         return Err(original_err);
     };
 
+    // L-0086: post-recovery re-entry is bounded and reports the resumed outcome.
     if attempt_recovery_activity(step, ctx, &recovery, &original_err, attempt, max_attempts) {
-        match run_step_body(step, ctx) {
-            Ok(outcome) if outcome.success => return Ok(outcome),
-            Ok(_) | Err(_) => {}
-        }
+        let resumed_attempt = attempt.saturating_add(1);
+        return match run_step_body(step, ctx) {
+            Ok(outcome) if outcome.success => {
+                emit_recovery_resumed(step, ctx, resumed_attempt, "success", None);
+                Ok(outcome)
+            }
+            Ok(outcome) => {
+                let message = outcome.message.unwrap_or_else(|| {
+                    format!(
+                        "post-recovery attempt {resumed_attempt} of step `{}` returned an unsuccessful outcome",
+                        step.id
+                    )
+                });
+                emit_recovery_resumed(step, ctx, resumed_attempt, "failed", Some(message.clone()));
+                Err(DispatchError::JobExecution(message))
+            }
+            Err(err) => {
+                emit_recovery_resumed(step, ctx, resumed_attempt, "error", Some(err.to_string()));
+                Err(err)
+            }
+        };
     }
 
     Err(original_err)
+}
+
+fn emit_recovery_resumed(
+    step: &JobV2Step,
+    ctx: &ExecCtx<'_>,
+    attempt: u32,
+    outcome: &str,
+    error_message: Option<String>,
+) {
+    emit_job_event_lossy(
+        &ctx.audit,
+        ctx.task_id(),
+        V2AuditEventKind::StepRecoveryResumed {
+            step_id: step.id.clone(),
+            attempt,
+            outcome: outcome.to_string(),
+            error_message,
+        },
+    );
 }
 
 pub(super) fn recovery_activity_for_step(

--- a/crates/orbit-engine/src/activity_job/job_executor/tests/recovery.rs
+++ b/crates/orbit-engine/src/activity_job/job_executor/tests/recovery.rs
@@ -97,10 +97,19 @@ fn recovery_success_runs_one_post_recovery_attempt_with_exact_input_and_fs_profi
             recovery_succeeded: true,
         } if step_id == "build" && recovery_activity == "recover"
     ));
+    assert!(matches!(
+        resumed_events(&events)[0].kind,
+        V2AuditEventKind::StepRecoveryResumed {
+            ref step_id,
+            attempt: 3,
+            ref outcome,
+            error_message: None,
+        } if step_id == "build" && outcome == "success"
+    ));
 }
 
 #[test]
-fn recovery_success_with_post_recovery_failure_returns_original_error_text() {
+fn recovery_success_with_post_recovery_failure_surfaces_resumed_error_and_stops() {
     let original_error = retryable_error("flaky", "first failure");
     let post_recovery_error = retryable_error("flaky", "post recovery still failing");
     let host = RecoveryHost::new([
@@ -109,7 +118,7 @@ fn recovery_success_with_post_recovery_failure_returns_original_error_text() {
             vec![
                 Err(original_error.clone()),
                 Err(original_error.clone()),
-                Err(post_recovery_error),
+                Err(post_recovery_error.clone()),
             ],
         ),
         ("recover", vec![Ok(json!({"recovered": true}))]),
@@ -124,11 +133,22 @@ fn recovery_success_with_post_recovery_failure_returns_original_error_text() {
         writer.clone(),
         &host,
     )
-    .expect_err("post-recovery failure should surface original error");
+    .expect_err("post-recovery failure should surface resumed error");
 
-    assert_eq!(err.to_string(), original_error.to_string());
+    assert_eq!(err.to_string(), post_recovery_error.to_string());
+    assert_eq!(host.action_count("flaky"), 3, "only one resumed attempt");
     assert_eq!(host.action_count("recover"), 1);
-    assert_eq!(recovery_events(&writer.events_snapshot().unwrap()).len(), 1);
+    let events = writer.events_snapshot().expect("audit snapshot");
+    assert_eq!(recovery_events(&events).len(), 1);
+    assert!(matches!(
+        resumed_events(&events)[0].kind,
+        V2AuditEventKind::StepRecoveryResumed {
+            attempt: 3,
+            ref outcome,
+            error_message: Some(ref message),
+            ..
+        } if outcome == "error" && message == &post_recovery_error.to_string()
+    ));
 }
 
 #[test]
@@ -489,6 +509,13 @@ fn recovery_events(events: &[V2AuditEvent]) -> Vec<&V2AuditEvent> {
     events
         .iter()
         .filter(|event| matches!(event.kind, V2AuditEventKind::StepRecoveryAttempted { .. }))
+        .collect()
+}
+
+fn resumed_events(events: &[V2AuditEvent]) -> Vec<&V2AuditEvent> {
+    events
+        .iter()
+        .filter(|event| matches!(event.kind, V2AuditEventKind::StepRecoveryResumed { .. }))
         .collect()
 }
 

--- a/crates/orbit-engine/src/executor/automation/vcs/commit/mod.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/commit/mod.rs
@@ -12,7 +12,7 @@ use serde_json::{Value, json};
 use crate::context::{RuntimeHost, TaskHost};
 
 use super::super::input::{canonicalize_existing_dir, input_string_field, required_job_run_id};
-use super::git::git_success;
+use super::git::{git_output, git_success};
 use author::{append_co_author_trailers, commit_author_for_tasks, git_author_for_task};
 use git_ops::{
     ensure_named_branch, ensure_no_unmerged_changes, git_commit_with_identity, stage_paths,
@@ -168,6 +168,21 @@ pub(super) fn commit_batch_changes<H: TaskHost + RuntimeHost + ?Sized>(
     host: &H,
     input: &Value,
 ) -> Result<Value, OrbitError> {
+    commit_batch_changes_with_reuse(host, input, false)
+}
+
+pub(super) fn commit_batch_changes_for_handoff<H: TaskHost + RuntimeHost + ?Sized>(
+    host: &H,
+    input: &Value,
+) -> Result<Value, OrbitError> {
+    commit_batch_changes_with_reuse(host, input, true)
+}
+
+fn commit_batch_changes_with_reuse<H: TaskHost + RuntimeHost + ?Sized>(
+    host: &H,
+    input: &Value,
+    reuse_existing_task_commit: bool,
+) -> Result<Value, OrbitError> {
     let batch_id = required_job_run_id(input, "commit_batch_changes")?;
     let batch_tasks = host.list_tasks_filtered(None, None, None, Some(batch_id), None, None)?;
     let [task] = batch_tasks.as_slice() else {
@@ -194,6 +209,22 @@ pub(super) fn commit_batch_changes<H: TaskHost + RuntimeHost + ?Sized>(
                 "task_id": task.id,
             }));
         }
+        if reuse_existing_task_commit {
+            let subject = git_output(&workspace_path, &["log", "-1", "--format=%s", "HEAD"])?;
+            let task_marker = format!("[{}]", task.id);
+            if subject
+                .split_ascii_whitespace()
+                .any(|part| part == task_marker)
+            {
+                let commit_sha = git_output(&workspace_path, &["rev-parse", "HEAD"])?;
+                return Ok(json!({
+                    "committed": false,
+                    "commit_reused": true,
+                    "commit_sha": commit_sha,
+                    "task_id": task.id,
+                }));
+            }
+        }
         return Err(OrbitError::Execution(format!(
             "commit_batch_changes: no staged changes to commit for task '{}' in worktree '{}'; \
              the implement step produced an empty diff",
@@ -206,7 +237,13 @@ pub(super) fn commit_batch_changes<H: TaskHost + RuntimeHost + ?Sized>(
     let author = git_author_for_task(task);
 
     git_commit_with_identity(&workspace_path, &message, author.as_ref())?;
-    Ok(json!({}))
+    let commit_sha = git_output(&workspace_path, &["rev-parse", "HEAD"])?;
+    Ok(json!({
+        "committed": true,
+        "commit_reused": false,
+        "commit_sha": commit_sha,
+        "task_id": task.id,
+    }))
 }
 
 fn resolve_workspace_path<H: RuntimeHost + ?Sized>(

--- a/crates/orbit-engine/src/executor/automation/vcs/pr/open.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/pr/open.rs
@@ -1,8 +1,10 @@
+use std::collections::BTreeSet;
 use std::path::Path;
 
 use chrono::Utc;
 use orbit_common::types::{
-    ExternalRef, NO_DIFF_EXPECTED_TAG, OrbitError, Role, Task, TaskComment, TaskStatus,
+    ExternalRef, GITHUB_PR_EXTERNAL_REF_SYSTEM, NO_DIFF_EXPECTED_TAG, OrbitError, Role, Task,
+    TaskComment, TaskStatus,
 };
 use orbit_tools::ToolContext;
 use serde_json::{Value, json};
@@ -14,7 +16,7 @@ use super::super::super::input::{
     required_job_run_id,
 };
 use super::super::freshness::ensure_branch_rebased_onto_base;
-use super::super::git::git_output;
+use super::super::git::{git_command_success, git_output, git_success};
 use super::attribution::pr_review_attribution;
 use super::body::{build_batch_pr_body, default_pr_title, meaningful_execution_summary};
 
@@ -24,8 +26,13 @@ pub(in crate::executor::automation) fn pr_open<H: RuntimeHost + TaskHost + Sync 
     host: &H,
     input: &Value,
 ) -> Result<Value, OrbitError> {
-    super::super::commit::commit_batch_changes(host, input)?;
-    open_batch_pr(host, input)
+    // L-0086: each handoff phase must reuse valid state after recovery re-entry.
+    let mut commit_result = super::super::commit::commit_batch_changes_for_handoff(host, input)?;
+    let pr_result = open_batch_pr(host, input)?;
+    if let (Some(base), Some(overlay)) = (commit_result.as_object_mut(), pr_result.as_object()) {
+        base.extend(overlay.clone());
+    }
+    Ok(commit_result)
 }
 
 pub(crate) fn open_batch_pr<H: RuntimeHost + TaskHost + ?Sized>(
@@ -191,16 +198,39 @@ pub(crate) fn open_batch_pr<H: RuntimeHost + TaskHost + ?Sized>(
         ..Default::default()
     };
 
-    if let Err(error) = host.run_tool_with_context_and_role(
-        "git.push",
-        json!({
-            "repo_root": workspace_path.to_string_lossy().to_string(),
-            "branch": head,
-            "force_with_lease": branch_was_rebased,
-        }),
-        Role::Admin,
-        tool_context.clone(),
-    ) {
+    let push_decision = match remote_push_decision(&workspace_path, &head) {
+        Ok(decision) => decision,
+        Err(error) => {
+            record_failed_handoff(
+                host,
+                &completed_tasks,
+                FailedHandoff {
+                    batch_id,
+                    workspace_path: &workspace_path,
+                    head: &head,
+                    base: &base,
+                    base_ref: Some(&freshness.base_ref),
+                    op: FailedHandoffOp::Push,
+                    error: &error,
+                },
+            )?;
+            return Err(error);
+        }
+    };
+    let force_with_lease = branch_was_rebased || push_decision.requires_force();
+    let push_performed = !push_decision.is_current();
+    if push_performed
+        && let Err(error) = host.run_tool_with_context_and_role(
+            "git.push",
+            json!({
+                "repo_root": workspace_path.to_string_lossy().to_string(),
+                "branch": head,
+                "force_with_lease": force_with_lease,
+            }),
+            Role::Admin,
+            tool_context.clone(),
+        )
+    {
         record_failed_handoff(
             host,
             &completed_tasks,
@@ -217,63 +247,89 @@ pub(crate) fn open_batch_pr<H: RuntimeHost + TaskHost + ?Sized>(
         return Err(error);
     }
 
-    let pr_create = match host.run_tool_with_context_and_role(
-        "github.pr.create",
-        json!({
-            "title": title,
-            "body": body,
-            "base": base,
-            "head": head,
-        }),
-        Role::Admin,
-        tool_context.clone(),
-    ) {
-        Ok(value) => value,
-        Err(error) => {
-            record_failed_handoff(
-                host,
-                &completed_tasks,
-                FailedHandoff {
-                    batch_id,
-                    workspace_path: &workspace_path,
-                    head: &head,
-                    base: &base,
-                    base_ref: Some(&freshness.base_ref),
-                    op: FailedHandoffOp::PrCreate,
-                    error: &error,
-                },
-            )?;
-            return Err(error);
-        }
-    };
-    let pr_url = match pr_create
-        .get("url")
-        .and_then(Value::as_str)
-        .filter(|value| !value.trim().is_empty())
-    {
-        Some(url) => url.to_string(),
-        None => {
-            let error =
-                OrbitError::Execution("github.pr.create did not return a PR url".to_string());
-            record_failed_handoff(
-                host,
-                &completed_tasks,
-                FailedHandoff {
-                    batch_id,
-                    workspace_path: &workspace_path,
-                    head: &head,
-                    base: &base,
-                    base_ref: Some(&freshness.base_ref),
-                    op: FailedHandoffOp::PrCreate,
-                    error: &error,
-                },
-            )?;
-            return Err(error);
+    let existing_pr = completed_tasks_pr_identity(&completed_tasks)?;
+    let mut pr_reused = existing_pr.is_some();
+    let mut pr_url = existing_pr
+        .as_ref()
+        .and_then(|identity| identity.url.clone());
+    let mut expected_pr_number = existing_pr.map(|identity| identity.number);
+    let pr_selector = if let Some(number) = expected_pr_number.as_ref() {
+        number.clone()
+    } else {
+        let pr_create = match host.run_tool_with_context_and_role(
+            "github.pr.create",
+            json!({
+                "title": title,
+                "body": body,
+                "base": base,
+                "head": head,
+            }),
+            Role::Admin,
+            tool_context.clone(),
+        ) {
+            Ok(value) => value,
+            Err(error) if pull_request_already_exists(&error) => {
+                pr_reused = true;
+                Value::Null
+            }
+            Err(error) => {
+                record_failed_handoff(
+                    host,
+                    &completed_tasks,
+                    FailedHandoff {
+                        batch_id,
+                        workspace_path: &workspace_path,
+                        head: &head,
+                        base: &base,
+                        base_ref: Some(&freshness.base_ref),
+                        op: FailedHandoffOp::PrCreate,
+                        error: &error,
+                    },
+                )?;
+                return Err(error);
+            }
+        };
+
+        if pr_reused {
+            head.clone()
+        } else {
+            let url = match pr_create
+                .get("url")
+                .and_then(Value::as_str)
+                .filter(|value| !value.trim().is_empty())
+            {
+                Some(url) => url.to_string(),
+                None => {
+                    let error = OrbitError::Execution(
+                        "github.pr.create did not return a PR url".to_string(),
+                    );
+                    record_failed_handoff(
+                        host,
+                        &completed_tasks,
+                        FailedHandoff {
+                            batch_id,
+                            workspace_path: &workspace_path,
+                            head: &head,
+                            base: &base,
+                            base_ref: Some(&freshness.base_ref),
+                            op: FailedHandoffOp::PrCreate,
+                            error: &error,
+                        },
+                    )?;
+                    return Err(error);
+                }
+            };
+            if let Some(number) = pr_number_from_url(&url) {
+                persist_pr_identity(host, &completed_tasks, &number, Some(&url))?;
+                expected_pr_number = Some(number);
+            }
+            pr_url = Some(url.clone());
+            url
         }
     };
     let pr_view = match host.run_tool_with_context_and_role(
         "github.pr.view",
-        json!({ "pr": pr_url }),
+        json!({ "pr": pr_selector }),
         orbit_common::types::Role::Admin,
         tool_context,
     ) {
@@ -320,6 +376,14 @@ pub(crate) fn open_batch_pr<H: RuntimeHost + TaskHost + ?Sized>(
             return Err(error);
         }
     };
+    if let Some(expected) = expected_pr_number.as_deref()
+        && expected != pr_number
+    {
+        return Err(OrbitError::Execution(format!(
+            "github.pr.view returned PR {pr_number}, but task state records PR {expected}"
+        )));
+    }
+    persist_pr_identity(host, &completed_tasks, &pr_number, pr_url.as_deref())?;
 
     for task in &completed_tasks {
         let model = pr_review_attribution(host, task, batch_id)?;
@@ -336,8 +400,13 @@ pub(crate) fn open_batch_pr<H: RuntimeHost + TaskHost + ?Sized>(
 
     Ok(json!({
         "pr_created": true,
+        "pr_create_performed": !pr_reused,
+        "pr_reused": pr_reused,
         "pr_number": pr_number,
         "pr_url": pr_url,
+        "push_performed": push_performed,
+        "push_reused": !push_performed,
+        "push_force_with_lease": push_performed && force_with_lease,
         "base": base,
         "head": head,
         "base_ref": freshness.base_ref,
@@ -345,6 +414,143 @@ pub(crate) fn open_batch_pr<H: RuntimeHost + TaskHost + ?Sized>(
         "commits_behind": freshness.commits_behind,
         "commits_ahead": freshness.commits_ahead,
     }))
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+enum RemotePushDecision {
+    Missing,
+    Current,
+    FastForward,
+    Diverged,
+}
+
+impl RemotePushDecision {
+    fn is_current(self) -> bool {
+        self == Self::Current
+    }
+
+    fn requires_force(self) -> bool {
+        self == Self::Diverged
+    }
+}
+
+fn remote_push_decision(
+    workspace_path: &Path,
+    head: &str,
+) -> Result<RemotePushDecision, OrbitError> {
+    if !git_command_success(workspace_path, &["remote", "get-url", "origin"])? {
+        return Ok(RemotePushDecision::Missing);
+    }
+
+    let remote_ref = format!("refs/heads/{head}");
+    let remote = git_output(
+        workspace_path,
+        &["ls-remote", "--heads", "origin", &remote_ref],
+    )?;
+    let Some(observed_remote_sha) = remote.split_whitespace().next() else {
+        return Ok(RemotePushDecision::Missing);
+    };
+    let local_sha = git_output(workspace_path, &["rev-parse", head])?;
+    if observed_remote_sha == local_sha {
+        return Ok(RemotePushDecision::Current);
+    }
+
+    // Refresh the tracking ref even when the object is already local. Besides
+    // closing the ls-remote race for the ancestry checks, this supplies the
+    // exact expected remote value used by a later --force-with-lease push.
+    let remote_tracking_ref = format!("refs/remotes/origin/{head}");
+    let fetch_refspec = format!("+{remote_ref}:{remote_tracking_ref}");
+    git_success(workspace_path, &["fetch", "origin", &fetch_refspec])?;
+    let remote_sha = git_output(workspace_path, &["rev-parse", &remote_tracking_ref])?;
+    if remote_sha == local_sha {
+        return Ok(RemotePushDecision::Current);
+    }
+    if git_command_success(
+        workspace_path,
+        &["merge-base", "--is-ancestor", &remote_sha, head],
+    )? {
+        return Ok(RemotePushDecision::FastForward);
+    }
+    if git_command_success(
+        workspace_path,
+        &["merge-base", "--is-ancestor", head, &remote_sha],
+    )? {
+        return Err(OrbitError::Execution(format!(
+            "remote task branch 'origin/{head}' is ahead of local '{head}'; refusing to overwrite remote commits during PR handoff retry"
+        )));
+    }
+    Ok(RemotePushDecision::Diverged)
+}
+
+#[derive(Debug)]
+struct ExistingPrIdentity {
+    number: String,
+    url: Option<String>,
+}
+
+fn completed_tasks_pr_identity(tasks: &[Task]) -> Result<Option<ExistingPrIdentity>, OrbitError> {
+    let mut numbers = BTreeSet::new();
+    let mut url = None;
+    for task in tasks {
+        for external_ref in &task.external_refs {
+            if external_ref.system != GITHUB_PR_EXTERNAL_REF_SYSTEM {
+                continue;
+            }
+            numbers.insert(external_ref.id.clone());
+            if url.is_none() {
+                url = external_ref.url.clone();
+            }
+        }
+    }
+    if numbers.len() > 1 {
+        return Err(OrbitError::Execution(format!(
+            "completed tasks record conflicting GitHub PRs: {}",
+            numbers.into_iter().collect::<Vec<_>>().join(", ")
+        )));
+    }
+    Ok(numbers
+        .into_iter()
+        .next()
+        .map(|number| ExistingPrIdentity { number, url }))
+}
+
+fn persist_pr_identity<H: TaskHost + ?Sized>(
+    host: &H,
+    tasks: &[Task],
+    pr_number: &str,
+    pr_url: Option<&str>,
+) -> Result<(), OrbitError> {
+    let external_ref = ExternalRef::try_new(
+        GITHUB_PR_EXTERNAL_REF_SYSTEM.to_string(),
+        pr_number.to_string(),
+        pr_url.map(str::to_string),
+    )?;
+    for task in tasks {
+        if task.github_pr_number() == Some(pr_number) {
+            continue;
+        }
+        host.apply_task_automation_update(
+            &task.id,
+            TaskAutomationUpdate {
+                external_refs: vec![external_ref.clone()],
+                ..TaskAutomationUpdate::default()
+            },
+        )?;
+    }
+    Ok(())
+}
+
+fn pr_number_from_url(url: &str) -> Option<String> {
+    url.trim_end_matches('/')
+        .rsplit('/')
+        .next()
+        .filter(|value| !value.is_empty() && value.chars().all(|ch| ch.is_ascii_digit()))
+        .map(str::to_string)
+}
+
+fn pull_request_already_exists(error: &OrbitError) -> bool {
+    let message = error.to_string().to_ascii_lowercase();
+    message.contains("pull request") && message.contains("already exists")
 }
 
 fn completed_task_ids_from_input(input: &Value) -> Option<Vec<String>> {

--- a/crates/orbit-engine/src/executor/automation/vcs/pr/tests/open.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/pr/tests/open.rs
@@ -4,6 +4,7 @@ use super::test_support::*;
 use crate::context::TaskReadHost;
 use orbit_common::types::TaskStatus;
 use serde_json::json;
+use std::process::Command;
 
 #[test]
 fn pr_open_rejects_missing_execution_summary_before_create() {
@@ -250,6 +251,125 @@ fn pr_open_records_failed_handoff_comment_when_rebase_fails() {
         host.comments_for("T20260521-1A").len(),
         1,
         "repeated failures from the same run/op must not spam duplicate comments"
+    );
+}
+
+#[test]
+fn pr_open_reuses_recovered_commit_then_continues_push_and_pr_idempotently() {
+    let workspace = rebase_conflict_pr_workspace();
+    git(
+        &workspace.repo,
+        &[
+            "commit",
+            "--amend",
+            "-m",
+            "chore: Rebase recovery task [T20260521-1A]",
+        ],
+    );
+
+    let remote = workspace
+        .repo
+        .parent()
+        .expect("repo parent")
+        .join("remote.git");
+    std::fs::create_dir_all(&remote).expect("create bare remote dir");
+    git(&remote, &["init", "--bare"]);
+    let remote_path = remote.to_string_lossy().to_string();
+    git(&workspace.repo, &["remote", "add", "origin", &remote_path]);
+    git(&workspace.repo, &["push", "origin", "agent-main"]);
+    git(&workspace.repo, &["push", "origin", "orbit/test-batch"]);
+
+    let rebase = Command::new("git")
+        .args(["rebase", "agent-main"])
+        .current_dir(&workspace.repo)
+        .output()
+        .expect("start conflicting recovery rebase");
+    assert!(!rebase.status.success(), "fixture must require recovery");
+    std::fs::write(
+        workspace.repo.join("src/lib.rs"),
+        "pub fn diverged() {}\npub fn recovered() {}\n",
+    )
+    .expect("resolve rebase conflict");
+    git(&workspace.repo, &["add", "src/lib.rs"]);
+    git(
+        &workspace.repo,
+        &["-c", "core.editor=true", "rebase", "--continue"],
+    );
+    assert!(
+        git(&workspace.repo, &["status", "--porcelain"]).is_empty(),
+        "recovery must leave a clean worktree"
+    );
+    assert_eq!(
+        git(
+            &workspace.repo,
+            &["rev-list", "--left-right", "--count", "agent-main...HEAD"]
+        ),
+        "0\t1"
+    );
+
+    let host = PrOpenTestHost::new(
+        vec![batch_task(
+            "T20260521-1A",
+            "Rebase recovery task",
+            "Outcome: success\n\nChanges:\n- Implemented.",
+        )],
+        workspace.repo.clone(),
+    );
+    let input = pr_open_input(&workspace.repo, vec!["T20260521-1A"]);
+    let recovered_head = git(&workspace.repo, &["rev-parse", "HEAD"]);
+    host.fail_tool("github.pr.view", "temporary PR metadata failure");
+
+    let first_error = pr_open(&host, &input)
+        .expect_err("a failure after PR creation should leave resumable state");
+    assert!(
+        first_error
+            .to_string()
+            .contains("temporary PR metadata failure")
+    );
+    assert_eq!(git(&workspace.repo, &["rev-parse", "HEAD"]), recovered_head);
+    assert_eq!(
+        host.get_task("T20260521-1A")
+            .expect("task after partial handoff")
+            .github_pr_number(),
+        Some("42"),
+        "PR identity must be durable before the later view/promotion step"
+    );
+    let first_push = host
+        .tool_calls()
+        .into_iter()
+        .find(|call| call.name == "git.push")
+        .expect("recovered branch push");
+    assert_eq!(first_push.input["force_with_lease"], json!(true));
+
+    // The test host records the push but does not mutate the bare remote. Bring
+    // it to the state a successful real git.push call would have established.
+    git(
+        &workspace.repo,
+        &["push", "--force", "origin", "orbit/test-batch"],
+    );
+    host.clear_tool_failure("github.pr.view");
+
+    let second = pr_open(&host, &input).expect("handoff retry should reuse valid state");
+    assert_eq!(second["commit_reused"], json!(true));
+    assert_eq!(second["push_performed"], json!(false));
+    assert_eq!(second["push_reused"], json!(true));
+    assert_eq!(second["pr_reused"], json!(true));
+    assert_eq!(second["pr_create_performed"], json!(false));
+    assert_eq!(git(&workspace.repo, &["rev-parse", "HEAD"]), recovered_head);
+
+    let calls = host.tool_calls();
+    assert_eq!(
+        calls.iter().filter(|call| call.name == "git.push").count(),
+        1,
+        "a current remote branch must not be pushed twice"
+    );
+    assert_eq!(
+        calls
+            .iter()
+            .filter(|call| call.name == "github.pr.create")
+            .count(),
+        1,
+        "the persisted PR identity must prevent duplicate creation"
     );
 }
 

--- a/crates/orbit-engine/src/executor/automation/vcs/pr/tests/test_support.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/pr/tests/test_support.rs
@@ -71,6 +71,13 @@ impl PrOpenTestHost {
             .insert(name.to_string(), message.to_string());
     }
 
+    pub fn clear_tool_failure(&self, name: &str) {
+        self.tool_errors
+            .lock()
+            .expect("tool errors lock")
+            .remove(name);
+    }
+
     pub fn comments_for(&self, task_id: &str) -> Vec<TaskComment> {
         self.comments
             .lock()

--- a/docs/design/activity-job/2_design.md
+++ b/docs/design/activity-job/2_design.md
@@ -3,7 +3,7 @@ summary: "Activity / Job — Design"
 type: design
 title: "Activity / Job — Design"
 owner: codex
-last_updated: 2026-07-14
+last_updated: 2026-07-16
 status: Draft
 feature: activity-job
 doc_role: design
@@ -134,7 +134,7 @@ The public CLI now executes activity assets through jobs rather than exposing a 
 
 Some module comments still describe older phase ordering; the authoritative behavior is the orbit-core call path in `crates/orbit-core/src/command/job/exec.rs`.
 
-Seeded direct shipment workflows (`task_local_pipeline` and `task_pr_pipeline`) opt into `recovery_activity: step_failure_recovery` on specific steps after [T20260430-14]. After [T20260509-14], the recovery activity is tagged `role: reviewer`, so its effective provider/model/backend comes from `[agent.reviewer]` like other reviewer work. The recovery agent receives only the executor-provided recovery keys, inspects the failed step, makes bounded repairs when safe, and returns before the executor's single post-recovery attempt. Higher-level orchestration workflows do not enable the hook because replaying child-run dispatch or planning orchestration is not a safe default recovery action.
+Seeded direct shipment workflows (`task_local_pipeline` and `task_pr_pipeline`) opt into `recovery_activity: step_failure_recovery` on specific steps after [T20260430-14]. After [T20260509-14], the recovery activity is tagged `role: reviewer`, so its effective provider/model/backend comes from `[agent.reviewer]` like other reviewer work. The recovery agent receives only the executor-provided recovery keys, inspects the failed step, makes bounded repairs when safe, and returns before the executor's single post-recovery attempt. The executor emits `step.recovery_resumed` with that attempt's outcome; success continues the pipeline and failure terminalizes with the resumed error rather than the stale pre-recovery error. Higher-level orchestration workflows do not enable the hook because replaying child-run dispatch or planning orchestration is not a safe default recovery action. [ORB-10222] made this resumed attempt explicit and auditable.
 
 The seeded `list_backlog_tasks` deterministic activity starts `task_auto_pipeline`. Automatic mode admits tasks by `status: backlog`. It emits `task_count`, `task_ids`, `tasks`, singleton `bundles`, and an `excluded` array for admitted backlog tasks filtered because their context files overlap `in-progress` or `review` locks. `excluded` covers only lock overlap; status-based admission and `max_tasks` truncation stay silent, and explicit `task_ids` mode omits it. This attribution contract was added in [T20260421-0542-2].
 
@@ -363,7 +363,7 @@ After [T20260509-9], `writeback_planning_duel_task` also extracts a "Context Fil
 
 After [T20260508-3], generated one-task PR bodies render the task contract first: `## Task`, optional collapsed `## Execution Summary`, `## Validation`, then `## Branch Freshness`. The task section includes the task link, description, and plain-bullet acceptance criteria so reviewers can see the requested work beside the implementation summary. Multi-task callers keep the legacy `## Tasks` plus files-changed layout until those paths are retired.
 
-After [ORB-00016], `pr_open` treats a branch with zero commits ahead of the selected base as a successful no-repository-diff handoff after the same durable task guards pass. This path advances completed `in-progress` tasks to `review`, returns `pr_created: false` with base/head freshness fields, and does not call GitHub PR creation or stamp `github-pr` external refs. The normal branch-with-commits path still pushes, opens the PR, returns `pr_created: true`, and records the PR ref on participating tasks.
+The `pr_open` action is a restartable commit → freshness/rebase → push → PR handoff. A retry with a clean worktree reuses `HEAD` only when its subject carries the exact current task marker; an unrelated clean branch still fails the empty-diff gate established by [ORB-10134], while an explicit `no-diff-expected` task remains the side-effect-only exception. Remote branch inspection skips a push that is already current, uses a normal push for a missing or fast-forward remote, selects `--force-with-lease` only for a recovered divergent task branch, and refuses to overwrite a remote branch that is ahead of local state. PR identity is persisted as soon as creation yields a usable number, so a retry reuses the existing PR and continues with view/task promotion rather than creating another one. The step output records `commit_reused`, `push_performed`/`push_reused`, `push_force_with_lease`, and `pr_create_performed`/`pr_reused`; these fields make the resumed sub-step decision durable in pipeline state. [ORB-10222]
 
 ### 8.12 Test surfaces guarding executor invariants
 
@@ -551,6 +551,8 @@ Read-only history does not need the same dependencies as live execution. [T20260
 - **[T20260509-38]** — Run legacy parallel-batch workers through cancellable pipeline runs so timeout failure paths return promptly.
 - **[T20260509-40]** — Run CLI subprocesses in killable process groups and bound timeout-path output reader joins.
 - **[ORB-00016]** — Treat no-repository-diff `task_pr_pipeline` handoffs as successful no-PR completions.
+- **[ORB-10134]** — Fail task PR handoff when an ordinary implementation branch has no commits ahead of base.
+- **[ORB-10222]** — Resume once after successful step recovery and make commit/push/PR handoff retries idempotent and auditable.
 - **[ORB-00374]** — Remove the `shell` activity variant and `run_shell` dispatch (fail-closed resolution of security bug [ORB-00363]).
 
 > Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.

--- a/docs/design/activity-job/4_decisions.md
+++ b/docs/design/activity-job/4_decisions.md
@@ -3,7 +3,7 @@ summary: "Activity / Job — Decisions"
 type: design
 title: "Activity / Job — Decisions"
 owner: codex
-last_updated: 2026-07-11
+last_updated: 2026-07-16
 status: Draft
 feature: activity-job
 doc_role: decisions
@@ -249,11 +249,11 @@ Folded into ADR-007's rollup for durable run state and operator inspection.
 
 ## ADR-023 — Seeded task-shipment workflows are deterministic, recoverable, and lock-aware
 
-**Status:** Accepted · 2026-05 · [T20260427-33], [T20260425-2010], [T20260427-45], [T20260430-9], [T20260430-12], [T20260430-14], [T20260421-0542-2], [T20260430-27], [T20260430-30], [T20260430-26], [T20260427-34], [T20260427-36], [T20260505-2], [T20260505-10], [T20260506-18], [T20260509-14]
+**Status:** Accepted · 2026-05 · [T20260427-33], [T20260425-2010], [T20260427-45], [T20260430-9], [T20260430-12], [T20260430-14], [T20260421-0542-2], [T20260430-27], [T20260430-30], [T20260430-26], [T20260427-34], [T20260427-36], [T20260505-2], [T20260505-10], [T20260506-18], [T20260509-14], [ORB-10222]
 
 **Context.** The seeded task workflows added many small ADRs as shipment behavior grew: run aliases, deterministic auto-dispatch, remote base selection, recovery hooks, backlog exclusions, operator status, and lock cleanup. They are one decision family: task shipment is an explicit durable workflow, not an advisory agent step or hidden side effect.
 
-**Decision.** Keep `orbit run` workflow aliases focused on execution, make automatic task shipment deterministic from backlog listing through gate fan-out, default shipping worktrees to fetched remote base refs, admit tasks through status-aware workflow gates, and protect overlapping work with durable task-lock reservations whose seeded TTL covers the child wait budget. Recovery is bounded, step-scoped on direct shipment workflows, and assigned through the configured reviewer role; child pipeline joins are followed by deterministic success guards after required cleanup, operator status is derived from persisted pipeline state, and run-owned reservations clean up when their owner run reaches a terminal state.
+**Decision.** Keep `orbit run` workflow aliases focused on execution, make automatic task shipment deterministic from backlog listing through gate fan-out, default shipping worktrees to fetched remote base refs, admit tasks through status-aware workflow gates, and protect overlapping work with durable task-lock reservations whose seeded TTL covers the child wait budget. Recovery is bounded, step-scoped on direct shipment workflows, assigned through the configured reviewer role, and followed by exactly one audited resumed attempt. Composite shipment actions must reuse verified commit, remote-branch, and PR state so that resumed execution continues at its first incomplete side effect. Child pipeline joins are followed by deterministic success guards after required cleanup, operator status is derived from persisted pipeline state, and run-owned reservations clean up when their owner run reaches a terminal state.
 
 Folded instances:
 
@@ -275,6 +275,7 @@ Folded instances:
 - Auto-dispatch no longer depends on provider credentials before it has deterministic backlog bundles.
 - Gate-owned reservations serialize overlapping bundles while their owner run is alive and are released by both seeded early-release steps and engine-owned terminal cleanup.
 - Seeded gate defaults require `ttl_seconds >= dispatch_timeout_seconds` so a legal child shipment wait cannot outlive its admission reservation.
+- Successful recovery re-enters the failed direct-shipment step once; audit events and step output distinguish reused handoff state from newly performed commit, push, and PR operations.
 - Costs retained from folded entries:
 - Cost: the auto-dispatch audit trail no longer contains a model-authored advisory grouping note.
 - Cost: users of `orbit run ship local`, `orbit run ship list/show`, and `orbit run duel list/show` must update their command muscle memory and scripts.
@@ -282,6 +283,7 @@ Folded instances:
 - Cost: job authors must make the recovery activity generic enough for every retryable step in that job.
 - Cost: this is intentionally conservative; it does not perform semantic git cleanup, task mutation, or child-run reconciliation until a more specific recovery policy is justified.
 - Cost: default recovery now depends on the configured reviewer agent being available, and authors must decide which steps deserve recovery rather than flipping one workflow-level switch.
+- Cost: deterministic shipment actions must carry explicit idempotency probes for their external side effects, and remote divergence checks add network and Git inspection before a push.
 - Cost: the Rust serializer and seeded activity YAML schema now duplicate the exclusion shape and must be kept in sync.
 - Cost: the CLI formatter now knows selected fields from `task_auto_pipeline` state, so future pipeline key renames must either preserve compatibility or update the operator summary parser.
 - Cost: `task_gate_pipeline` now relies on the dynamic `task_{{ input.mode }}_pipeline` job-name convention, so future gate modes must either follow that naming convention or refactor the dispatch selector.
@@ -662,5 +664,6 @@ Rejected alternatives: reconciling by parent linkage (no parent run id is persis
 - **[ORB-00363]** — Security bug: `run_shell` spawned unsandboxed subprocesses behind a tautological allowlist.
 - **[ORB-00374]** — Remove the `shell` activity variant and `run_shell` dispatch (fail-closed resolution of [ORB-00363]).
 - **[ORB-10202]** — Remove the retired friction task status while preserving workflow admission and triage behavior.
+- **[ORB-10222]** — Resume direct shipment once after successful recovery and reuse verified commit, push, and PR state.
 
 > Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.


### PR DESCRIPTION
## Task

[ORB-10222](https://orbit-cli.com/tasks/ORB-10222) — Retry the failed pipeline step after successful recovery

### Description

A step-failure recovery can repair repository state successfully (for example, refresh origin/agent-main, rebase the task branch, resolve conflicts, and leave the worktree clean and ahead) but then stop without retrying the failed executor step. This happened for jrun-20260716-0031-4: recovery completed, yet push and PR-open were intentionally left undone, requiring manual continuation. Add a post-recovery retry/resume phase that re-enters the original pipeline at the first incomplete step after recovery has established a valid checkpoint.

### Acceptance Criteria

- After recovery reports a clean valid task branch, the workflow automatically resumes at the first incomplete pipeline step instead of terminalizing with work still pending.
- Retry is idempotent across commits, pushes, and PR creation: existing valid state is reused and duplicate commits, force pushes, or pull requests are not created.
- The recovery and resumed-step decisions are visible in job audit/state, with bounded retry behavior and a clear terminal error if the resumed step fails again.
- Regression coverage reproduces a successful rebase recovery followed by push/PR continuation, and focused tests plus make ci-fast pass.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Made successful step recovery re-enter the failed step exactly once, emit a durable step.recovery_resumed audit event, and surface the resumed attempt error if it fails.
- Made pr_open restartable across its commit, remote-branch push, PR creation/view, and task-promotion phases: verified task commits are reused, current pushes are skipped, divergent recovered branches use force-with-lease, remote-ahead branches fail closed, and persisted PR identity prevents duplicate creation. Successful step output records which commit/push/PR operations were performed or reused.
- Added regression coverage that resolves a conflicting rebase, resumes from the clean recovered commit, force-pushes once, persists PR identity before a simulated later failure, then retries without another commit, push, or PR creation.
- Updated activity/job design and operator audit formatting, and recorded the incident-derived recovery guardrail as L-0086.

Validation:
- cargo test -p orbit-common types::activity_job::tests::audit_envelope --lib (3 passed)
- cargo test -p orbit-engine activity_job::job_executor::tests::recovery --lib (11 passed)
- cargo test -p orbit-engine executor::automation::vcs::pr::tests::open --lib (9 passed)
- cargo clippy -p orbit-common -p orbit-engine -p orbit-cli -p orbit-dashboard --lib --tests -- -D warnings
- make ci-fast

Strategic decisions:
- Treat recovery as whole-step re-entry and make composite deterministic actions checkpoint themselves from durable repository/task/external state, preserving the existing bounded one-attempt executor contract.

Design weaknesses / risks:
- Remote push reuse adds an ls-remote probe and fetches a divergent task ref before choosing force-with-lease. | Severity: Low | Mitigation: network/Git errors fail closed as push handoff failures, and remote-ahead state is never overwritten.

Assessment: The incident path is now bounded, auditable, and idempotent at each externally visible handoff boundary while retaining the ordinary empty-diff safety gate.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10222-6a58382f`
- Behind base: 0
- Ahead of base: 1