### PR TITLE
Make CLI response envelopes opt-in for artifact-backed activities [ORB-10231]

### DIFF
--- a/.orbit/adrs/accepted/ADR-0224/adr.yaml
+++ b/.orbit/adrs/accepted/ADR-0224/adr.yaml
@@ -1,0 +1,24 @@
+schema_version: 2
+id: ADR-0224
+title: CLI response envelopes are optional for artifact-backed activities
+status: accepted
+owner: codex
+created_at: 2026-07-16T02:08:23.713248330Z
+accepted_at: 2026-07-16T02:08:38.533091253Z
+last_updated: 2026-07-16T02:08:38.533091253Z
+related_features:
+- activity-job
+related_tasks:
+- ORB-10231
+tags:
+- workflow
+- cli
+- artifact-contract
+paths:
+- crates/orbit-common/src/types/activity_job/**
+- crates/orbit-engine/src/activity_job/cli_runner/**
+- crates/orbit-core/assets/activities/**
+supersedes: []
+legacy_ids: []
+validation_warnings: []
+legacy_validation: none

--- a/.orbit/adrs/accepted/ADR-0224/body.md
+++ b/.orbit/adrs/accepted/ADR-0224/body.md
@@ -1,0 +1,8 @@
+## Context
+CLI providers can exit successfully after persisting authoritative task, review, and git artifacts while emitting prose or provider wrapper JSON that lacks an Orbit response envelope. Treating every missing or malformed envelope as fatal strands completed work; treating every response as advisory would break activities whose downstream templates consume structured fields.
+## Decision
+CLI agent-loop activities treat response envelopes as best-effort by default. Exit status and timeout determine transport success, valid envelopes still project result fields, and parse failures become bounded redacted diagnostics. An activity sets `require_response_envelope: true` only when downstream workflow steps consume its structured response.
+## Consequences
+- Artifact-backed implementation and review runs no longer fail solely because final agent prose is malformed or missing an envelope.
+- Structured-output activities remain fail-closed through an explicit per-activity contract.
+- Cost: Activity authors must classify the handoff correctly, and response-consuming activities need a regression that pins strict mode.

--- a/.orbit/learnings/L-0087/learning.yaml
+++ b/.orbit/learnings/L-0087/learning.yaml
@@ -1,0 +1,20 @@
+schema_version: 1
+id: L-0087
+status: active
+scope:
+  paths:
+  - crates/orbit-common/src/types/activity_job/**
+  - crates/orbit-engine/src/activity_job/cli_runner/**
+  - crates/orbit-core/assets/activities/**
+  tags: []
+summary: Treat CLI final responses as advisory in artifact-backed activities; gate on durable task/review/git artifacts and reserve strict envelope validation for declared structured-output consumers.
+body: Incident jrun-20260716-0136-3 completed implementation, validation, commit, and task execution-summary persistence, but the task pipeline failed only because Claude final prose lacked an embedded Orbit envelope. For artifact-backed activities, final response parsing must remain best-effort diagnostic/projection logic; subprocess exit/timeout and deterministic artifact gates own success. Activities that feed response fields into templates must opt into strict validation explicitly.
+evidence:
+- kind: task
+  reference: ORB-10231
+- kind: external
+  reference: jrun-20260716-0136-3
+created_at: 2026-07-16T02:11:11.681249761Z
+updated_at: 2026-07-16T02:11:11.681249761Z
+created_by: codex
+priority: 180

--- a/crates/orbit-common/src/types/activity_job/activity_v2.rs
+++ b/crates/orbit-common/src/types/activity_job/activity_v2.rs
@@ -72,6 +72,12 @@ pub struct AgentLoopSpec {
     /// where the loop engine applies its own timeout.
     #[serde(default = "default_cli_wall_clock_timeout_seconds")]
     pub wall_clock_timeout_seconds: u64,
+    /// Require a valid Orbit response envelope before a CLI invocation may
+    /// report success. Defaults to `false` for artifact-backed activities,
+    /// whose durable task/review/git state is authoritative. Activities that
+    /// feed response fields into downstream templates opt in explicitly.
+    #[serde(default)]
+    pub require_response_envelope: bool,
     /// Optional role tag (ADR-029). When set, the engine consults
     /// `[agent.<role>]` in `config.toml` and overrides `provider`/`model`/
     /// `backend` field-by-field at dispatch time. The step-level role on
@@ -133,6 +139,7 @@ impl GroundhogSpec {
             backend: Backend::Http,
             provider: self.provider,
             wall_clock_timeout_seconds: self.wall_clock_timeout_seconds,
+            require_response_envelope: false,
             role: self.role,
             proc_allowed_programs: self.proc_allowed_programs.clone(),
         }

--- a/crates/orbit-common/src/types/activity_job/tests/activity_v2.rs
+++ b/crates/orbit-common/src/types/activity_job/tests/activity_v2.rs
@@ -294,6 +294,23 @@ fn agent_loop_spec_defaults_to_cli_backend() {
 }
 
 #[test]
+fn agent_loop_spec_response_envelope_defaults_to_best_effort() {
+    let yaml = "instruction: hi\n";
+    let parsed: AgentLoopSpec = serde_yaml::from_str(yaml).expect("parse spec");
+    assert!(!parsed.require_response_envelope);
+}
+
+#[test]
+fn agent_loop_spec_required_response_envelope_round_trips() {
+    let yaml = "instruction: hi\nrequire_response_envelope: true\n";
+    let parsed: AgentLoopSpec = serde_yaml::from_str(yaml).expect("parse spec");
+    assert!(parsed.require_response_envelope);
+    let reserialized = serde_yaml::to_string(&parsed).expect("serialize spec");
+    let reparsed: AgentLoopSpec = serde_yaml::from_str(&reserialized).expect("re-parse spec");
+    assert!(reparsed.require_response_envelope);
+}
+
+#[test]
 fn agent_loop_spec_proc_allowed_programs_defaults_to_none() {
     let yaml = "instruction: hi\n";
     let parsed: AgentLoopSpec = serde_yaml::from_str(yaml).expect("parse spec");

--- a/crates/orbit-core/assets/activities/epic_orchestrator.yaml
+++ b/crates/orbit-core/assets/activities/epic_orchestrator.yaml
@@ -4,6 +4,7 @@ metadata:
   name: epic_orchestrator
 spec:
   type: agent_loop
+  require_response_envelope: true
   description: >
     Judgment-grade orchestrator for epic-sized tasks. One invocation = one
     cycle: read state, decide READY subtasks, decide SEQUENTIAL vs PARALLEL,

--- a/crates/orbit-core/assets/activities/triage_failed_runs.yaml
+++ b/crates/orbit-core/assets/activities/triage_failed_runs.yaml
@@ -4,6 +4,7 @@ metadata:
   name: triage_failed_runs
 spec:
   type: agent_loop
+  require_response_envelope: true
   description: >
     Diagnose tasks blocked by terminally-failed job runs. For each candidate
     the agent reads the failure evidence, classifies the cause

--- a/crates/orbit-core/src/command/activity.rs
+++ b/crates/orbit-core/src/command/activity.rs
@@ -206,6 +206,30 @@ mod tests {
         }
     }
 
+    #[test]
+    fn agent_response_contract_matches_durable_handoff_shape() {
+        for (name, required) in [
+            ("agent_implement", false),
+            ("agent_review", false),
+            ("triage_failed_runs", true),
+            ("epic_orchestrator", true),
+        ] {
+            let (_, yaml) = DEFAULT_ACTIVITY_FILES
+                .iter()
+                .find(|(candidate, _)| *candidate == name)
+                .unwrap_or_else(|| panic!("{name} activity is seeded"));
+            let asset = load_activity_asset(yaml)
+                .unwrap_or_else(|error| panic!("parse {name} activity: {error}"));
+            match asset.spec.spec {
+                ActivityV2Spec::AgentLoop(spec) => assert_eq!(
+                    spec.require_response_envelope, required,
+                    "{name} response contract drifted"
+                ),
+                other => panic!("expected agent_loop {name} activity, got {other:?}"),
+            }
+        }
+    }
+
     /// [ORB-10129] The triage agent's hard bounds are structural: its tool
     /// allowlist must exclude every write/dispatch surface (code edits,
     /// commits/pushes/merges, PR approval, pipeline invocation, task

--- a/crates/orbit-core/src/runtime/v2_host/mod.rs
+++ b/crates/orbit-core/src/runtime/v2_host/mod.rs
@@ -546,6 +546,7 @@ mod tests {
             backend: Backend::Http,
             provider: Provider::Claude,
             wall_clock_timeout_seconds: 30,
+            require_response_envelope: false,
             role: None,
             proc_allowed_programs: None,
         };

--- a/crates/orbit-core/tests/grok_cli_backend_smoke.rs
+++ b/crates/orbit-core/tests/grok_cli_backend_smoke.rs
@@ -73,6 +73,7 @@ fn installed_grok_cli_backend_smoke_captures_stdout_artifact() {
         backend: Backend::Cli,
         provider: Provider::Grok,
         wall_clock_timeout_seconds: 120,
+        require_response_envelope: true,
         role: None,
         proc_allowed_programs: None,
     };

--- a/crates/orbit-engine/examples/v2_cli_backend_smoke.rs
+++ b/crates/orbit-engine/examples/v2_cli_backend_smoke.rs
@@ -434,6 +434,7 @@ fn cli_agent_loop_spec(provider: Option<Provider>) -> AgentLoopSpec {
         backend: Backend::Cli,
         provider: provider.unwrap_or(Provider::Claude),
         wall_clock_timeout_seconds: 30,
+        require_response_envelope: false,
         role: None,
         proc_allowed_programs: None,
     }
@@ -512,6 +513,7 @@ fn synthetic_loop_session_cli_job() -> JobV2 {
                 backend: Backend::Cli,
                 provider: Provider::Claude,
                 wall_clock_timeout_seconds: 30,
+                require_response_envelope: false,
                 role: None,
                 proc_allowed_programs: None,
             }),

--- a/crates/orbit-engine/src/activity_job/cli_runner/orchestrator.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/orchestrator.rs
@@ -219,10 +219,11 @@ pub fn run_cli_backend(
         timed_out,
     });
 
-    // A clean subprocess exit is only provisional. Provider CLIs commonly
-    // wrap the agent response (and Claude may prefix that response with
-    // explanatory prose), so validate and unwrap the embedded Orbit envelope
-    // before exposing anything to downstream workflow templates.
+    // Provider output is not the system of record for artifact-backed
+    // activities: task state, review threads, git state, and deterministic
+    // downstream gates are. Parse response envelopes to project useful fields
+    // and diagnostics, but only make them authoritative when the activity
+    // explicitly declares that downstream templates require them.
     let exit_success = !timed_out && matches!(exit_code, Some(0));
     // A truncated capture retains the final complete JSONL events separately
     // from its diagnostic prefix. Protocol parsing must use that tail so a
@@ -239,7 +240,13 @@ pub fn run_cli_backend(
             true,
         )
     });
-    let success = exit_success && matches!(parsed_result.as_ref(), Some(Ok(_)));
+    let response_envelope_valid = matches!(parsed_result.as_ref(), Some(Ok(_)));
+    let response_envelope_error = parsed_result
+        .as_ref()
+        .and_then(|result| result.as_ref().err())
+        .map(|error| response_diagnostic(error, &redaction));
+    // ADR-0224 / L-0087: parsing is advisory unless the activity opts into strict mode.
+    let success = exit_success && (!spec.require_response_envelope || response_envelope_valid);
     let trace = parse_cli_invocation_trace(
         stdout.protocol_bytes(),
         stderr.protocol_bytes(),
@@ -252,16 +259,17 @@ pub fn run_cli_backend(
             "cli subprocess exceeded {}s wall-clock timeout",
             timeout_seconds
         ))
-    } else if exit_success && matches!(envelope_status.as_deref(), Some("failed") | Some("timeout"))
+    } else if !exit_success {
+        Some(format!("cli subprocess exited with code {:?}", exit_code))
+    } else if spec.require_response_envelope
+        && matches!(envelope_status.as_deref(), Some("failed") | Some("timeout"))
     {
         Some(format!(
             "cli subprocess reported envelope status={:?} despite exit 0",
             envelope_status.as_deref().unwrap_or("unknown")
         ))
-    } else if let Some(Err(error)) = parsed_result.as_ref() {
-        Some(response_diagnostic(error, &redaction))
-    } else if !success {
-        Some(format!("cli subprocess exited with code {:?}", exit_code))
+    } else if spec.require_response_envelope {
+        response_envelope_error.clone()
     } else {
         None
     };
@@ -284,6 +292,22 @@ pub fn run_cli_backend(
             serde_json::json!(duration.as_millis() as u64),
         ),
         ("timed_out", Value::Bool(timed_out)),
+        (
+            "response_envelope_required",
+            Value::Bool(spec.require_response_envelope),
+        ),
+        (
+            "response_envelope_valid",
+            Value::Bool(response_envelope_valid),
+        ),
+        (
+            "response_envelope_status",
+            envelope_status.map_or(Value::Null, Value::String),
+        ),
+        (
+            "response_envelope_error",
+            response_envelope_error.map_or(Value::Null, Value::String),
+        ),
         ("stdout_text", Value::String(stdout_text)),
         (
             "stdout_text_truncated",

--- a/crates/orbit-engine/src/activity_job/cli_runner/tests/orchestrator.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/tests/orchestrator.rs
@@ -183,7 +183,8 @@ fn run_cli_backend_rejects_schema_invalid_success_envelope() {
         sink_for_writer,
     ));
     let host = TestHost::with_command(script.display().to_string());
-    let spec = test_agent_loop_spec(Duration::from_secs(5));
+    let mut spec = test_agent_loop_spec(Duration::from_secs(5));
+    spec.require_response_envelope = true;
 
     let outcome = run_cli_backend(
         &host,
@@ -204,6 +205,96 @@ fn run_cli_backend_rejects_schema_invalid_success_envelope() {
     assert!(
         message.contains("unsupported schemaVersion: 2"),
         "{message}"
+    );
+}
+
+#[test]
+fn run_cli_backend_accepts_claude_success_prose_without_envelope_for_artifact_activity() {
+    let temp = tempdir().expect("tempdir");
+    let script = temp.path().join("claude");
+    let stdout = serde_json::json!({
+        "type": "result",
+        "subtype": "success",
+        "is_error": false,
+        "result": "All changes are complete and validated. Execution summary persisted to the task.",
+        "stop_reason": "end_turn"
+    })
+    .to_string();
+    write_executable(
+        &script,
+        &format!("#!/bin/sh\ncat > /dev/null\nprintf '%s\\n' '{stdout}'\n"),
+    );
+
+    let sink = Arc::new(RecordingSink::default());
+    let sink_for_writer: Arc<dyn AuditSink> = sink;
+    let audit = Arc::new(V2AuditWriter::new(
+        "job-artifact-response",
+        "claude:sonnet",
+        sink_for_writer,
+    ));
+    let host = TestHost::with_command(script.display().to_string());
+    let spec = test_agent_loop_spec_for("claude", Duration::from_secs(5));
+
+    let outcome = run_cli_backend(
+        &host,
+        &spec,
+        "job-artifact-response",
+        audit,
+        &serde_json::json!({"task_id": "ORB-10230"}),
+        None,
+    )
+    .expect("run cli backend");
+
+    assert!(outcome.success);
+    assert!(outcome.message.is_none());
+    assert_eq!(outcome.output["exit_code"], 0);
+    assert_eq!(outcome.output["response_envelope_required"], false);
+    assert_eq!(outcome.output["response_envelope_valid"], false);
+    assert!(
+        outcome.output["response_envelope_error"]
+            .as_str()
+            .is_some_and(|message| message.contains("does not contain an Orbit response envelope"))
+    );
+}
+
+#[test]
+fn run_cli_backend_requires_envelope_when_activity_opts_in() {
+    let temp = tempdir().expect("tempdir");
+    let script = temp.path().join("claude");
+    write_executable(
+        &script,
+        "#!/bin/sh\ncat > /dev/null\nprintf '%s\\n' '{\"type\":\"result\",\"subtype\":\"success\",\"result\":\"completed\"}'\n",
+    );
+
+    let sink = Arc::new(RecordingSink::default());
+    let sink_for_writer: Arc<dyn AuditSink> = sink;
+    let audit = Arc::new(V2AuditWriter::new(
+        "job-required-response",
+        "claude:sonnet",
+        sink_for_writer,
+    ));
+    let host = TestHost::with_command(script.display().to_string());
+    let mut spec = test_agent_loop_spec_for("claude", Duration::from_secs(5));
+    spec.require_response_envelope = true;
+
+    let outcome = run_cli_backend(
+        &host,
+        &spec,
+        "job-required-response",
+        audit,
+        &serde_json::json!({"prompt": "return structured data"}),
+        None,
+    )
+    .expect("run cli backend");
+
+    assert!(!outcome.success);
+    assert_eq!(outcome.output["response_envelope_required"], true);
+    assert_eq!(outcome.output["response_envelope_valid"], false);
+    assert!(
+        outcome
+            .message
+            .as_deref()
+            .is_some_and(|message| message.contains("does not contain an Orbit response envelope"))
     );
 }
 
@@ -319,7 +410,8 @@ fn run_cli_backend_bounds_stdout_text_preview_and_keeps_envelope_status_from_ful
         sink_for_writer,
     ));
     let host = TestHost::with_command(script.display().to_string());
-    let spec = test_agent_loop_spec(Duration::from_secs(5));
+    let mut spec = test_agent_loop_spec(Duration::from_secs(5));
+    spec.require_response_envelope = true;
 
     let outcome = run_cli_backend(
         &host,
@@ -801,11 +893,9 @@ impl Drop for EnvVarGuard {
     }
 }
 
-/// Regression for T20260508-17: a CLI subprocess that exits 0 but emits an
-/// embedded Orbit response envelope reporting `status: "failed"` must NOT
-/// be classified as success. Pre-fix, dispatch returned `success: true`
-/// because the dispatcher only consulted exit code, leaving the planning
-/// pipeline to push an empty branch and open an empty PR.
+/// Regression for T20260508-17: a structured-output activity that opts into
+/// strict response validation must demote an exit-0 subprocess whose embedded
+/// Orbit response reports `status: "failed"`.
 #[test]
 fn run_cli_backend_demotes_success_when_envelope_reports_failed_despite_exit_zero() {
     let temp = tempdir().expect("tempdir");
@@ -842,7 +932,8 @@ fn run_cli_backend_demotes_success_when_envelope_reports_failed_despite_exit_zer
         sink_for_writer,
     ));
     let host = TestHost::with_command(script.display().to_string());
-    let spec = test_agent_loop_spec(Duration::from_secs(5));
+    let mut spec = test_agent_loop_spec(Duration::from_secs(5));
+    spec.require_response_envelope = true;
 
     let outcome = run_cli_backend(
         &host,

--- a/crates/orbit-engine/src/activity_job/cli_runner/tests/test_support.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/tests/test_support.rs
@@ -340,6 +340,7 @@ pub(in crate::activity_job::cli_runner) fn test_agent_loop_spec(
         backend: Backend::Cli,
         provider: Provider::Codex,
         wall_clock_timeout_seconds: timeout.as_secs(),
+        require_response_envelope: false,
         role: None,
         proc_allowed_programs: None,
     }
@@ -365,6 +366,7 @@ pub(in crate::activity_job::cli_runner) fn test_agent_loop_spec_for(
         backend: Backend::Cli,
         provider,
         wall_clock_timeout_seconds: timeout.as_secs(),
+        require_response_envelope: false,
         role: None,
         proc_allowed_programs: None,
     }

--- a/crates/orbit-engine/src/activity_job/job_executor/tests/recovery.rs
+++ b/crates/orbit-engine/src/activity_job/job_executor/tests/recovery.rs
@@ -459,6 +459,7 @@ fn recovery_agent_loop_spec(
         backend,
         provider,
         wall_clock_timeout_seconds: 30,
+        require_response_envelope: false,
         role,
         proc_allowed_programs: None,
     }

--- a/crates/orbit-engine/src/activity_job/job_executor/tests/target.rs
+++ b/crates/orbit-engine/src/activity_job/job_executor/tests/target.rs
@@ -88,6 +88,7 @@ fn inline_agent_loop_spec() -> AgentLoopSpec {
         backend: Backend::Cli,
         provider: Provider::Claude,
         wall_clock_timeout_seconds: 30,
+        require_response_envelope: false,
         role: None,
         proc_allowed_programs: None,
     }

--- a/crates/orbit-engine/src/activity_job/tests/agent_loop_driver.rs
+++ b/crates/orbit-engine/src/activity_job/tests/agent_loop_driver.rs
@@ -152,6 +152,7 @@ fn replay_spec(on_denial: OnDenial) -> AgentLoopSpec {
         backend: Backend::Http,
         provider: Provider::Claude,
         wall_clock_timeout_seconds: 30,
+        require_response_envelope: false,
         role: None,
         proc_allowed_programs: None,
     }

--- a/crates/orbit-engine/src/activity_job/tests/agent_role.rs
+++ b/crates/orbit-engine/src/activity_job/tests/agent_role.rs
@@ -19,6 +19,7 @@ fn inline_spec() -> AgentLoopSpec {
         backend: Backend::Cli,
         provider: Provider::Claude,
         wall_clock_timeout_seconds: 30,
+        require_response_envelope: false,
         role: Some(AgentRole::Implementer),
         proc_allowed_programs: None,
     }

--- a/docs/design/activity-job/2_design.md
+++ b/docs/design/activity-job/2_design.md
@@ -3,7 +3,7 @@ summary: "Activity / Job — Design"
 type: design
 title: "Activity / Job — Design"
 owner: codex
-last_updated: 2026-07-14
+last_updated: 2026-07-16
 status: Draft
 feature: activity-job
 doc_role: design
@@ -53,6 +53,8 @@ The common `agent_loop` fields are:
 - `backend`
 - `provider`
 - `wall_clock_timeout_seconds`
+- `require_response_envelope` (default `false`; opt in only when downstream
+  templates consume structured response fields)
 
 Groundhog has its own `GroundhogSpec`, but `as_agent_loop_spec()` projects it into an HTTP-backed agent loop when the runner needs the shared transport path. That sibling kind landed in [T20260420-0510-2].
 
@@ -218,7 +220,7 @@ The CLI path is driven by `cli_runner.rs`, added in [T20260419-0104]. The flow i
 6. Emit `CliInvocationStarted` with redacted argv, stdin blob ref, and resolved cwd.
 7. Spawn the subprocess in that cwd with a wall-clock timeout.
 8. Emit `CliInvocationFinished` with stdout/stderr blob refs and timeout state.
-9. Parse the captured provider output with the existing Orbit response parser and persist its `InvocationTrace` through the host.
+9. Parse the captured provider output with the existing Orbit response parser and persist its `InvocationTrace` through the host. After [ORB-10231] / [ADR-0224], envelope parsing is best-effort by default: provider exit status and timeout determine transport success while durable task/review/git artifacts remain authoritative. A valid envelope still projects its result fields, and an invalid or absent envelope is retained as bounded/redacted diagnostic metadata. Activities whose downstream templates require response fields set `require_response_envelope: true`, preserving fail-closed validation for that explicit contract.
 
 After [T20260426-2313], stdout/stderr readers emit line-level `tracing::info!` events while the child runs, carrying `provider`, `stream`, `job_run_id`, `task_id`, and `line`. After [T20260508-8], those events also carry `cwd` when the CLI subprocess has a resolved cwd. After [T20260426-2349], the default tracing subscriber redacts formatted output. The readers still retain original bytes for the existing audit/blob path, so run logs follow blob refs rather than the live feed.
 

--- a/docs/design/activity-job/4_decisions.md
+++ b/docs/design/activity-job/4_decisions.md
@@ -3,7 +3,7 @@ summary: "Activity / Job — Decisions"
 type: design
 title: "Activity / Job — Decisions"
 owner: codex
-last_updated: 2026-07-11
+last_updated: 2026-07-16
 status: Draft
 feature: activity-job
 doc_role: decisions
@@ -590,6 +590,21 @@ Rejected alternatives: reconciling by parent linkage (no parent run id is persis
 - The agent's output is advisory data: it cannot move a task anywhere but `backlog`, cannot touch a task outside the candidate list, and cannot exceed the budget — misclassification degrades to a wasted bounded retry, never a corrupted lifecycle.
 - Loop-guard state lives in task history events rather than a new task field, so exhaustion survives restarts and is human-auditable.
 - Cost: a second bespoke deterministic action (and its activity asset) to maintain instead of reusing `update_task`, and the disposition vocabulary must be extended in Rust when triage learns new outcomes.
+
+---
+
+## ADR-0224 — CLI response envelopes are optional for artifact-backed activities
+
+**Status:** Accepted · 2026-07 · [ORB-10231]
+
+**Context.** CLI providers can exit successfully after persisting authoritative task, review, and git artifacts while emitting prose or provider wrapper JSON that lacks an Orbit response envelope. Treating every missing or malformed envelope as fatal strands completed work; treating every response as advisory would break activities whose downstream templates consume structured fields.
+
+**Decision.** CLI agent-loop activities treat response envelopes as best-effort by default. Exit status and timeout determine transport success, valid envelopes still project result fields, and parse failures become bounded redacted diagnostics. An activity sets `require_response_envelope: true` only when downstream workflow steps consume its structured response.
+
+**Consequences.**
+- Artifact-backed implementation and review runs no longer fail solely because final agent prose is malformed or missing an envelope.
+- Structured-output activities remain fail-closed through an explicit per-activity contract.
+- Cost: activity authors must classify the handoff correctly, and response-consuming activities need a regression that pins strict mode.
 
 ---
 


### PR DESCRIPTION
## What changed

- Make CLI response-envelope validation best-effort by default for artifact-backed agent activities.
- Keep valid result projection and record bounded/redacted envelope policy, validity, status, and parse-error diagnostics.
- Add an explicit `require_response_envelope: true` contract for response-driven activities; triage and epic orchestration remain fail-closed.
- Add regression coverage for the exact Claude outer-success/prose shape from `jrun-20260716-0136-3`.
- Record accepted ADR-0224 and incident learning L-0087; update the activity-job design docs.

## Root cause

ORB-10216 / `7ac187e9` changed CLI success from transport success plus explicit failure demotion to requiring a fully valid Orbit response envelope. That stranded ORB-10230 even though Claude exited 0, validation passed, the implementation was committed, and the task execution summary was persisted. `ae2c7b78` added bounded capture metadata/tail handling but was not causal here; the failed run was not truncated.

## Impact

Artifact-backed task/review workflows now use durable task, review-thread, git, and deterministic downstream state as the source of truth. Timeouts and nonzero exits remain hard failures. Workflows that genuinely consume response fields still opt into strict validation.

## Validation

- `cargo test -p orbit-common activity_job::tests::activity_v2` — 16 passed
- `cargo test -p orbit-engine activity_job::cli_runner::tests --lib` — 47 passed
- `cargo test -p orbit-core command::activity::tests::agent_response_contract_matches_durable_handoff_shape --lib` — 1 passed
- `cargo check -p orbit-engine --examples` — passed
- `cargo check -p orbit-core --tests` — passed
- `make ci-fast` — passed after final changes
- `git diff --check` — passed

## Task

ORB-10231
