### PR TITLE
Fix H1: glob `/**`-suffix rule with wildcard prefix silently matches nothing (policy bypass)

### DIFF
--- a/crates/orbit-common/src/utility/glob.rs
+++ b/crates/orbit-common/src/utility/glob.rs
@@ -124,13 +124,26 @@ pub fn compile_glob_regex(rule: &str) -> Result<Regex, regex::Error> {
         if prefix.is_empty() {
             return compile_filesystem_regex(r"^.*$");
         }
-        let escaped = regex::escape(prefix);
-        return compile_filesystem_regex(&format!("^{escaped}(?:/.*)?$"));
+        // Route the prefix through the same segment-aware translation as the
+        // general path below. Escaping the whole prefix would turn any `*`/`?`
+        // in it into a literal, so `**/secrets/**` would compile to
+        // `^\*\*/secrets(?:/.*)?$` and match nothing — silently voiding a deny
+        // rule (H1). Translating instead yields `^(?:.*/)?secrets(?:/.*)?$`.
+        let body = translate_glob_body(prefix);
+        return compile_filesystem_regex(&format!("^{body}(?:/.*)?$"));
     }
 
+    let body = translate_glob_body(rule);
+    compile_filesystem_regex(&format!("^{body}$"))
+}
+
+/// Translate a glob pattern into an *unanchored* regex body, honoring the
+/// segment-aware operators (`**/`, `**`, `*`, `?`) and escaping every other
+/// character. Callers wrap the result in anchors (`^`…`$`) and any suffix.
+fn translate_glob_body(rule: &str) -> String {
     let chars: Vec<char> = rule.chars().collect();
     let mut index = 0usize;
-    let mut pattern = String::from("^");
+    let mut pattern = String::new();
     while index < chars.len() {
         if chars[index] == '*' {
             if index + 2 < chars.len() && chars[index + 1] == '*' && chars[index + 2] == '/' {
@@ -157,8 +170,7 @@ pub fn compile_glob_regex(rule: &str) -> Result<Regex, regex::Error> {
         pattern.push_str(&regex::escape(&chars[index].to_string()));
         index += 1;
     }
-    pattern.push('$');
-    compile_filesystem_regex(&pattern)
+    pattern
 }
 
 fn compile_filesystem_regex(pattern: &str) -> Result<Regex, regex::Error> {

--- a/crates/orbit-common/src/utility/tests/glob.rs
+++ b/crates/orbit-common/src/utility/tests/glob.rs
@@ -90,6 +90,74 @@ mod matching {
         }
     }
 
+    /// [ORB-10224] H1 regression: a `/**`-suffix rule whose prefix contains
+    /// glob metacharacters (`**`, `*`) must route through the same
+    /// segment-aware translation as the general path. Previously the prefix
+    /// was passed through `regex::escape()`, so `**/secrets/**` compiled to
+    /// `^\*\*/secrets(?:/.*)?$` and matched nothing — silently voiding the
+    /// deny rule.
+    #[test]
+    fn wildcard_prefix_subtree_rules_match_intended_paths() {
+        for (rule, path) in [
+            // Subtree-at-any-depth denies — the most natural spelling.
+            ("**/secrets/**", "secrets/key.txt"),
+            ("**/secrets/**", "app/config/secrets/key.txt"),
+            ("**/.git/**", ".git/config"),
+            ("**/.git/**", "vendor/dep/.git/HEAD"),
+            ("**/node_modules/**", "node_modules/left-pad/index.js"),
+            (
+                "**/node_modules/**",
+                "packages/ui/node_modules/react/index.js",
+            ),
+            // Single-star prefix crosses exactly one segment.
+            ("*/dir/**", "top/dir/file.rs"),
+            ("*/dir/**", "top/dir/nested/file.rs"),
+            // The subtree rule also anchors the directory itself.
+            ("**/secrets/**", "secrets"),
+            ("**/.git/**", "vendor/dep/.git"),
+        ] {
+            let normalized = normalize_glob_path(path).expect("normalize");
+            assert!(
+                match_glob(rule, &normalized).expect("match glob"),
+                "rule `{rule}` should match `{normalized}`"
+            );
+        }
+    }
+
+    /// [ORB-10224] The wildcard-prefix subtree rule must still respect
+    /// segment boundaries: a single-star prefix does not cross a separator,
+    /// and a subtree deny does not leak onto a sibling that merely shares a
+    /// name prefix.
+    #[test]
+    fn wildcard_prefix_subtree_rules_reject_non_matching_paths() {
+        for (rule, path) in [
+            // `*` spans one segment, so a two-segment prefix does not match.
+            ("*/dir/**", "a/b/dir/file.rs"),
+            // `secrets` as a path fragment, not a full segment, must not match.
+            ("**/secrets/**", "my-secrets-backup/key.txt"),
+            ("**/.git/**", "not-a.git/file"),
+        ] {
+            let normalized = normalize_glob_path(path).expect("normalize");
+            assert!(
+                !match_glob(rule, &normalized).expect("match glob"),
+                "rule `{rule}` must not match `{normalized}`"
+            );
+        }
+    }
+
+    /// [ORB-10224] `validate()` behavior for metachar-in-prefix: such a rule
+    /// is a *valid* glob (it compiles) and actively blocks its target, rather
+    /// than being an inert, silently-passing deny.
+    #[test]
+    fn wildcard_prefix_subtree_rule_compiles_and_blocks() {
+        let regex = compile_glob_regex("**/secrets/**").expect("compile valid glob");
+        let path = normalize_glob_path("app/secrets/private.key").expect("normalize");
+        assert!(
+            regex.is_match(&path),
+            "a `**/dir/**` deny rule must actually block its target path"
+        );
+    }
+
     #[cfg(any(target_os = "macos", windows))]
     #[test]
     fn deny_globs_match_case_variants_on_case_insensitive_platforms() {


### PR DESCRIPTION
## Task

[ORB-10224](https://orbit-cli.com/tasks/ORB-10224) — Fix H1: glob `/**`-suffix rule with wildcard prefix silently matches nothing (policy bypass)

### Description

From the pre-release security review (SECURITY-REVIEW-2026-07-15.md, finding H1).

**Bug.** `crates/orbit-common/src/utility/glob.rs:123-129` — the `/**`-suffix fast path runs `regex::escape()` over the entire prefix, so any `*`/`?` in the prefix becomes a literal. A rule like `**/secrets/**` compiles to `^\*\*/secrets(?:/.*)?$`, which cannot match any real path — the deny is inert, and `validate()` raises no error.

**Impact.** Subtree-at-any-depth denies — the most natural way to write `denyRead`/`denyModify` (`**/.git/**`, `**/node_modules/**`, `**/secrets/**`) — provide zero protection with no feedback. On Linux the policy check is the sole enforcement layer, so this is a real bypass. Reproduced: those three rules MISS their target paths; non-wildcard controls (`secrets/**`, `**/node_modules`) match correctly.

**Fix.** Route the `/**` prefix through the same segment-aware translation as the general char-loop, e.g. `**/secrets/**` -> `^(?:.*/)?secrets(?:/.*)?$`. Alternatively fail-closed in `validate()` on any `/**` prefix containing glob metacharacters (the design doc already lists this pattern as one the translator should reject).

**Acceptance.** Regression tests covering `**/dir/**`, `*/dir/**`, `**/.git/**` matching the intended paths; a deny rule of this shape actually blocks; `validate()` behavior defined for metachar-in-prefix. Small, self-contained change in glob.rs.

### Acceptance Criteria



## Execution Summary

<details>
<summary>Click to expand</summary>

Fixed H1 policy bypass in crates/orbit-common/src/utility/glob.rs. Root cause: the `/**`-suffix fast path in `compile_glob_regex` ran `regex::escape()` over the entire prefix, turning any `*`/`?` in the prefix into a literal. So a natural subtree deny like `**/secrets/**` compiled to `^\*\*/secrets(?:/.*)?$`, which matches no real path — an inert deny with no validate() error.

Fix: extracted the general segment-aware char-loop translation into a shared helper `translate_glob_body(rule)` (unanchored regex body honoring `**/`, `**`, `*`, `?`), and routed BOTH the `/**`-prefix path and the general path through it. Now `**/secrets/**` -> `^(?:.*/)?secrets(?:/.*)?$`, actively blocking its target. Behavior for non-`/**` rules is unchanged (same translation logic, just refactored). This also defines validate() behavior for metachar-in-prefix: such rules now compile to valid, correctly-matching regexes rather than silently-passing inert denies.

Self-contained change in glob.rs (no new deps, no cross-crate edges). Added ORB-10224 regression tests in crates/orbit-common/src/utility/tests/glob.rs: wildcard_prefix_subtree_rules_match_intended_paths (covers **/dir/**, */dir/**, **/.git/**, **/node_modules/**, and directory-anchor cases), wildcard_prefix_subtree_rules_reject_non_matching_paths (segment-boundary + name-fragment safety), and wildcard_prefix_subtree_rule_compiles_and_blocks (compile-and-block / validate behavior).

Validation: `cargo test -p orbit-common --lib` -> 222 passed / 0 failed (incl. 3 new tests). `cargo fmt --check`, `cargo clippy -p orbit-common --lib` clean. `make ci-fast` passes.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10224-6a584413`
- Behind base: 0
- Ahead of base: 1