### PR TITLE
Document actual enforcement boundary in SECURITY.md (H2/M6/M7/M9 — macOS read-scope, provider-dir writes, env forwarding, Linux CLI confinement)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -51,12 +51,44 @@ Out of scope:
 Agent filesystem access is scoped by an `fsProfile` (`read` / `modify` globs)
 plus global `denyRead` / `denyModify` rules, evaluated by `orbit-policy`.
 
-**Enforcement layers differ by platform:**
+**Enforcement layers differ by platform, and by backend:**
 
-| Platform | Layers |
+For built-in Orbit tools (the `fs.*`/`proc.*` tool surface), `orbit-policy`
+evaluation applies on every platform and is the sole enforcement point for
+those tools' filesystem access.
+
+For `backend: cli` agents (an agent CLI such as Codex/Claude/Gemini/Grok
+spawned as a subprocess, making its own syscalls outside Orbit's tool
+surface), enforcement differs sharply by platform:
+
+| Platform | What actually constrains a `backend: cli` agent's own syscalls |
 | --- | --- |
-| **macOS** | Policy evaluation **and** the `orbit-exec` seatbelt (`sandbox-exec`) profile — two independent layers. |
-| **Linux** | Policy evaluation **only** — there is no OS-level sandbox. The policy check is the sole line of defense, so it must be correct on its own. |
+| **macOS** | The `orbit-exec` seatbelt (`sandbox-exec`) profile is a **write** boundary, not a meaningful **read** boundary. The compiled profile emits a blanket `(allow file-read*)` for the whole filesystem, minus a small fixed credential denylist (`~/.ssh`, `~/.aws`, `~/.config/gh`, browser keychains/profile stores, system Keychains) — the `fsProfile`'s positive `read` globs are never emitted into the seatbelt at all (only `read` *deny* entries are). Combined with the unrestricted `(allow network*)` the profile also grants (agents need to reach provider APIs), a `backend: cli` agent's read scope is effectively "everything except the denylist," with an open network egress path — an exfiltration exposure. The credential denylist is also known-incomplete: it does not cover `~/.netrc`, `~/.git-credentials`, `~/.gnupg`, `~/.docker/config.json`, `~/.kube/config`, `~/.npmrc`, or cloud-CLI credential caches (e.g. `~/.aws/sso/cache`, `~/.config/gcloud`, `~/.azure`). Treat the macOS seatbelt's read scoping as **advisory, not a security boundary**, for `backend: cli` agents. Tracked in `ORB-10233`. |
+| **Linux** | **No OS-level sandbox exists for `backend: cli` agents at all.** Orbit's policy governs only the built-in tool surface; a CLI agent's own syscalls (arbitrary file reads/writes, network egress, process spawn) are constrained by nothing Orbit provides. On Linux, a `backend: cli` agent has the full filesystem and network access of the user running Orbit. Tracked in `ORB-10236`. |
+
+Additionally, on macOS the seatbelt profile allows writes to each supported
+provider's state directory (`~/.claude`, `~/.codex`, `~/.gemini`, `~/.grok`)
+unconditionally, regardless of which provider is actually active for the
+run — a config or hook file dropped in another provider's state directory is
+a cross-session persistence vector, not scoped to the current agent's own
+provider. Tracked in `ORB-10234`.
+
+**Environment forwarding to sandboxed/subprocess agents is name-based, not
+value-shaped.** Orbit filters ambient environment variables passed to
+provider subprocesses by matching variable *names* against a fixed list of
+substrings (`SECRET`, `TOKEN`, `PASSWORD`, `API_KEY`, `_KEY`, `PRIVATE`,
+`CREDENTIAL`, `COOKIE`, `SESSION`, `BEARER`, `AUTH`). A secret held in a
+benignly-named variable — `DATABASE_URL`, a bare connection string, an
+internal service URL with embedded credentials — is forwarded unredacted to
+any spawned agent, including `backend: cli` agents with open network access.
+Tracked in `ORB-10235`.
+
+**Follow-up remediation** (filed from the pre-release security review,
+`SECURITY-REVIEW-2026-07-15.md`, findings H2/M6/M7/M9): `ORB-10233` (macOS
+seatbelt positive read allowlist), `ORB-10234` (scope provider state-dir
+writes to the active provider), `ORB-10235` (env forwarding allowlist instead
+of denylist), `ORB-10236` (Linux provider-native sandbox for `backend: cli`
+agents).
 
 **Symlink resolution.** Policy rules are matched against the *real*
 filesystem location, not the requested path. Before matching, the requested


### PR DESCRIPTION
## Task

[ORB-10226](https://orbit-cli.com/tasks/ORB-10226) — Document actual enforcement boundary in SECURITY.md (H2/M6/M7/M9 — macOS read-scope, provider-dir writes, env forwarding, Linux CLI confinement)

### Description

From the pre-release security review (SECURITY-REVIEW-2026-07-15.md, findings H2, M6, M7, M9). Decision: document honestly in SECURITY.md now; resolve the underlying gaps later (track separately).

SECURITY.md's "two independent layers" framing overstates what the macOS seatbelt enforces. Update SECURITY.md so the stated boundary matches the code, covering:

- **H2 — macOS read-scope not enforced.** `crates/orbit-exec/src/macos_sandbox/compile.rs:68,83,152-172`: the seatbelt emits `(allow file-read*)` for the whole FS minus a small fixed credential denylist, plus `(allow network*)`; the fsProfile's positive `read` globs are never emitted. So on macOS the seatbelt is a *write* boundary, not a meaningful *read* boundary — for a `backend: cli` agent, read scope is all-minus-blocklist. Note the exfiltration exposure (broad read x open network) and that the credential denylist misses `~/.netrc`, `~/.git-credentials`, `~/.gnupg`, `~/.docker/config.json`, `~/.kube/config`, `~/.npmrc`, cloud-CLI caches.
- **M6 — provider state dirs write-allowed** (`~/.claude`, `~/.codex`, `~/.gemini`, `~/.grok`) regardless of active provider; hook-bearing config there is a cross-session persistence vector.
- **M7 — env forwarding to sandboxed children is a name-based denylist**; value-shaped secrets in benignly-named vars (`DATABASE_URL`, etc.) leak to networked children.
- **M9 — Linux `backend: cli` agents' own syscalls are constrained by nothing from Orbit** (policy governs builtin tools only; no OS sandbox on Linux).

**Scope of this task:** documentation only — make SECURITY.md accurate (state macOS read-scoping is advisory for CLI agents; describe the Linux confinement gap; note the env-forwarding and provider-dir caveats). File follow-up tasks for the actual fixes (positive read allowlist, narrowed provider-dir writes, allowlist-based env forwarding, Linux provider-native sandbox) referencing the review.

**Acceptance.** SECURITY.md no longer claims protection the code doesn't provide; follow-up remediation tasks created and linked.

### Acceptance Criteria



## Execution Summary

<details>
<summary>Click to expand</summary>

Rewrote SECURITY.md's Filesystem Policy Enforcement section to match actual code behavior for the four pre-release-review findings (SECURITY-REVIEW-2026-07-15.md):

- H2: Documented that the macOS seatbelt (crates/orbit-exec/src/macos_sandbox/compile.rs) emits a blanket `(allow file-read*)` plus a fixed credential denylist; the fsProfile's positive `read` globs are never compiled in, so for `backend: cli` agents the seatbelt is a write boundary, not a read boundary. Called out the open `(allow network*)` exfiltration exposure and the denylist's known gaps (~/.netrc, ~/.git-credentials, ~/.gnupg, ~/.docker/config.json, ~/.kube/config, ~/.npmrc, cloud-CLI caches).
- M6: Documented that seatbelt writes to all provider state dirs (~/.claude, ~/.codex, ~/.gemini, ~/.grok) are allowed unconditionally regardless of the active provider.
- M7: Documented that env forwarding to spawned provider subprocesses (orbit-common redaction::is_sensitive_env_name / non_sensitive_env_vars, used by orbit-engine cli_runner/spawn.rs) is a name-based substring denylist, not value-shaped -- secrets in benignly-named vars (e.g. DATABASE_URL) forward unredacted.
- M9: Documented that on Linux there is no OS-level sandbox at all for `backend: cli` agents' own syscalls; orbit-policy governs only Orbit's builtin fs.*/proc.* tool surface.

Also split the enforcement framing from 'two independent layers on macOS' (overstated) to per-backend: orbit-policy is the sole and correct enforcement point for builtin tools on every platform; the macOS seatbelt for `backend: cli` agents is write-only/advisory-on-read; Linux has nothing for `backend: cli` agents.

Filed four follow-up remediation tasks (all workspace ws_orbit, tag security) and linked their IDs inline in SECURITY.md:
- ORB-10233 (H2 -- compile fsProfile positive read globs into the seatbelt instead of blanket allow; expand credential denylist)
- ORB-10234 (M6 -- thread active provider through SBPL compilation, scope state-dir write allows to only that provider)
- ORB-10235 (M7 -- replace name-based env denylist with an explicit forwarding allowlist)
- ORB-10236 (M9 -- investigate a Linux confinement mechanism, e.g. bubblewrap/Landlock/seccomp+namespaces, analogous to macos_sandbox)

Scope: documentation only, no source changes. Validation: no Rust code was touched, so no compile/test surface to exercise; `make ci-fast` could not run in this sandbox (cargo not installed in the environment) -- unrelated to the correctness of this docs-only change, CI is authoritative. Verified the SECURITY.md claims directly against crates/orbit-exec/src/macos_sandbox/compile.rs and crates/orbit-common/src/utility/redaction.rs before writing them.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10226-6a584415`
- Behind base: 0
- Ahead of base: 1