### PR TITLE
Fix M1: audit row written after the mutation in a separate transaction, and write-failure is swallowed

### DIFF
--- a/crates/orbit-core/src/command/tool.rs
+++ b/crates/orbit-core/src/command/tool.rs
@@ -218,22 +218,65 @@ impl OrbitRuntime {
             step_index: audit_context.step_index,
         };
 
-        let audit_recorded = match self.record_audit_event(&params) {
-            Ok(()) => {
-                mark_tool_audit_recorded();
-                true
-            }
-            Err(err) => {
-                tracing::warn!("failed to persist tool audit event: {err}");
-                false
-            }
-        };
+        let audit_write = self.record_audit_event(&params);
 
+        // Claim the row for the runtime the moment it persists, so the CLI
+        // `AuditGuard` suppresses its own duplicate emission. This is
+        // independent of the tool's own success/failure: the audit row is
+        // written for both (a failed call still gets a failure-status row).
+        if audit_write.is_ok() {
+            mark_tool_audit_recorded();
+        }
+
+        // Propagate the tool's own error first. A call that already failed
+        // carries no committed mutation to strand, so its error is the
+        // authoritative result and the audit-write outcome is irrelevant.
         let value = result?;
-        Ok(ToolDispatchOutcome {
+
+        // The tool call succeeded, so any mutation it performed is now
+        // committed. Audit persistence is part of that success contract:
+        // finding M1 (SECURITY-REVIEW-2026-07-15) — the previous code only
+        // `warn!`ed on an audit-write `Err` and still returned the tool's
+        // successful value, so an unwritable audit store (disk full, locked
+        // db, bad perms) yielded a successful, un-audited mutation with no
+        // error surfaced. Fail the call instead so a committed change can
+        // never surface without its audit row.
+        finalize_successful_dispatch(name, value, audit_write)
+    }
+}
+
+/// Fold a successful tool call together with its audit-write outcome into the
+/// dispatch result.
+///
+/// On a persisted audit row it returns the value. On a failed audit write it
+/// discards the value and returns the error, so a committed mutation can never
+/// be surfaced without its audit row (finding M1). The caller is responsible
+/// for the per-thread dedup signal, which is set as soon as the row persists
+/// regardless of the tool's own outcome.
+///
+/// No read-only/mutating split exists on the tool schema, so this fails closed
+/// for *every* successful call — strictly safer than the "at least mutating
+/// tools" floor the finding sets, at the cost of also failing a read-only call
+/// when the audit store is unwritable (an already-degraded state).
+fn finalize_successful_dispatch(
+    tool_name: &str,
+    value: Value,
+    audit_write: Result<(), OrbitError>,
+) -> Result<ToolDispatchOutcome, OrbitError> {
+    match audit_write {
+        Ok(()) => Ok(ToolDispatchOutcome {
             value,
-            audit_recorded,
-        })
+            audit_recorded: true,
+        }),
+        Err(err) => {
+            tracing::error!(
+                tool = tool_name,
+                "failed to persist tool audit event: {err}"
+            );
+            Err(OrbitError::Store(format!(
+                "tool '{tool_name}' completed but its audit row could not be persisted; failing the call so no un-audited change is surfaced: {err}"
+            )))
+        }
     }
 }
 
@@ -1123,6 +1166,36 @@ mod audit_tests {
         assert!(ctx.job_run_id.is_none());
         assert!(ctx.activity_id.is_none());
         assert!(ctx.step_index.is_none());
+    }
+
+    #[test]
+    fn successful_dispatch_returns_value_when_audit_persists() {
+        let outcome =
+            finalize_successful_dispatch("orbit.task.update", json!({"ok": true}), Ok(()))
+                .expect("audit persisted -> success");
+
+        assert!(outcome.audit_recorded);
+        assert_eq!(outcome.value, json!({"ok": true}));
+    }
+
+    #[test]
+    fn successful_mutation_fails_when_audit_row_cannot_be_persisted() {
+        // A mutating tool completed (value present), but the audit write
+        // failed. Finding M1: the call must fail rather than surface a
+        // successful, un-audited mutation.
+        let audit_write = Err(OrbitError::Store("disk full".to_string()));
+        let result = finalize_successful_dispatch(
+            "orbit.task.update",
+            json!({"mutated": true}),
+            audit_write,
+        );
+
+        let err = result.expect_err("un-audited mutation must fail the call");
+        let message = err.to_string();
+        assert!(
+            message.contains("orbit.task.update") && message.contains("audit row"),
+            "error names the tool and the missing audit row: {message}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Task

[ORB-10227](https://orbit-cli.com/tasks/ORB-10227) — Fix M1: audit row written after the mutation in a separate transaction, and write-failure is swallowed

### Description

From the pre-release security review (SECURITY-REVIEW-2026-07-15.md, finding M1).

**Bug.** `crates/orbit-core/src/command/tool.rs:178,221-232`. The tool (and its `with_mutation` commit) runs first, then a separate `INSERT` records the audit row (distinct SQLite transactions). A crash between commit and audit-insert persists the mutation while dropping its audit row. Worse, on audit-write `Err` the code only `tracing::warn!`s, sets `audit_recorded = false`, and still returns the tool's successful value — so an unwritable audit store (disk full, locked db, perms) yields a successful, un-audited mutation with no error surfaced.

**Fix.** Treat audit persistence as part of the mutation's success contract: write the audit row inside the same transaction as the mutation, or fail the call if the audit write fails (at least for mutating / non-read-only tools). At minimum, propagate the audit-write error for `status != read-only` instead of returning `Ok`.

**Acceptance.** A forced audit-write failure fails the mutating call (or the mutation is rolled back); test that a mutating tool cannot succeed without a persisted audit row.

### Acceptance Criteria



## Execution Summary

<details>
<summary>Click to expand</summary>

Fixed M1: tool audit-write failure was swallowed. In crates/orbit-core/src/command/tool.rs, execute_tool_command_dispatch_with_session_context previously matched on record_audit_event and, on Err, only tracing::warn!'d, set audit_recorded=false, and still returned the tool's successful value — so an unwritable audit store (disk full, locked db, bad perms) produced a successful, un-audited mutation with no error surfaced.

Fix: audit persistence is now part of a successful call's contract. After record_audit_event, the per-thread dedup flag (mark_tool_audit_recorded) is set whenever the row persists — independent of tool success/failure, since failed calls also write a failure-status row and the CLI AuditGuard relies on the flag to avoid double-auditing. The tool's own error still propagates first (result?). When the tool SUCCEEDED but the audit write failed, the new helper finalize_successful_dispatch returns OrbitError::Store instead of Ok, so a committed mutation can never surface without its audit row. Both the MCP host (returns the error to the client) and the CLI guard (flag stays clear on audit failure, so it still attempts its own row) handle this correctly.

Design note: no read-only/mutating classification exists on the tool schema, so the fix fails closed for EVERY successful call — strictly safer than the finding's 'at least mutating tools' floor, at the cost of failing a read-only call when the audit store is already unwritable. Documented inline.

Tests (crates/orbit-core/src/command/tests via sibling module in tool.rs): added successful_dispatch_returns_value_when_audit_persists and successful_mutation_fails_when_audit_row_cannot_be_persisted (asserts a completed mutating tool call returns Err naming the tool + missing audit row when the audit write fails). Existing dedup/audit tests unchanged and green.

Validation: cargo test -p orbit-core --lib (556 passed); cargo test -p orbit-cli --bin orbit audit (25 passed with identity env cleared); cargo clippy -p orbit-core --lib clean; cargo fmt --check clean; make ci-fast exit 0. Note: two orbit-cli/orbit-core tests that assert the default 'agent'/'human' audit role fail under this managed run because inherited ORBIT_AGENT_*/ORBIT_MANAGED_RUN_CONTEXT/ORBIT_RUN_ID env leaks the agent identity (project learning L-0068) — both pass when those vars are unset; env leakage, not a regression from this change. Added learning L-0088 documenting the audit dedup-flag coupling gotcha hit during the refactor.

Files changed: crates/orbit-core/src/command/tool.rs only (the file named in finding M1). No unlisted files required changes.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10227-6a584416`
- Behind base: 0
- Ahead of base: 1