### PR TITLE
Fix H3: `orbit.graph.*` MCP tools bypass the safe-surface allowlist and the audit trail

### DIFF
--- a/crates/orbit-cli/src/command/mcp/host.rs
+++ b/crates/orbit-cli/src/command/mcp/host.rs
@@ -1,12 +1,12 @@
 //! MCP host implementations and audit bracketing.
 //!
-//! Listing is sourced from [`OrbitRuntime::list_tools`], which already filters
-//! disabled tools and merges external (non-builtin) entries. Execution is
-//! routed through [`OrbitRuntime::execute_tool_command_dispatch`] tagged with
-//! [`ToolEntryPoint::Mcp`], so the runtime persists an audit row for every
-//! dispatch with the same identity-resolution rules as the CLI path. The
-//! `tools/call` preflight wraps the dispatch so rejected names also produce a
-//! failure-status audit row.
+//! Registry-backed listing is sourced from [`OrbitRuntime::list_tools`], which
+//! already filters disabled tools and merges external (non-builtin) entries.
+//! Registry-backed and adapter-owned execution both use the runtime audit
+//! boundary tagged with [`ToolEntryPoint::Mcp`], so every dispatch has the same
+//! identity-resolution rules as the CLI path. Adapter preflight lives inside
+//! that boundary; registry preflight failures are recorded explicitly before
+//! runtime dispatch. Either rejection path produces a failure-status row.
 
 use std::time::Instant;
 
@@ -49,15 +49,21 @@ pub(crate) const FRICTION_TOOL_NAMES: &[&str] = &[
     "orbit.friction.update",
 ];
 
-// ORB-00391: the agent `orbit.graph.*` surface is now served by the in-process
-// orbit-graph (v2) adapter in `orbit-mcp` (`adapter::graph::GraphToolRegistry`),
-// not by orbit-knowledge (v1) builtins. The adapter is gated off whenever the
-// host exposes ANY `orbit.graph.*` schema (`host_exposes_graph_tools`), so this
-// allowlist is intentionally empty — the host must expose no graph tool for the
-// v2 adapter to activate. The constant is kept (empty) so the aggregation in
-// `safe_mcp_tool_names` and the `mcp/tests/mod.rs` chain stay structurally
-// symmetric. See ADR-0192 and GRAPH_SPEC §16.
-pub(crate) const GRAPH_READ_TOOL_NAMES: &[&str] = &[];
+// The implementation lives in orbit-mcp's in-process graph adapter, but the
+// safe-surface decision remains explicit here alongside every registry-backed
+// MCP tool. This set includes sync because it mutates the local graph index.
+pub(crate) const GRAPH_TOOL_NAMES: &[&str] = &[
+    "orbit.graph.sync",
+    "orbit.graph.search",
+    "orbit.graph.show",
+    "orbit.graph.refs",
+    "orbit.graph.callees",
+    "orbit.graph.impact",
+    "orbit.graph.trace",
+    "orbit.graph.overview",
+    "orbit.graph.implementors",
+    "orbit.graph.deps",
+];
 
 pub(crate) const SEARCH_TOOL_NAMES: &[&str] = &["orbit.search"];
 
@@ -106,7 +112,7 @@ pub(crate) fn safe_mcp_tool_names() -> Vec<&'static str> {
     let mut names = Vec::with_capacity(
         TASK_TOOL_NAMES.len()
             + FRICTION_TOOL_NAMES.len()
-            + GRAPH_READ_TOOL_NAMES.len()
+            + GRAPH_TOOL_NAMES.len()
             + SEARCH_TOOL_NAMES.len()
             + SEMANTIC_TOOL_NAMES.len()
             + ADR_TOOL_NAMES.len()
@@ -116,7 +122,7 @@ pub(crate) fn safe_mcp_tool_names() -> Vec<&'static str> {
     );
     names.extend_from_slice(TASK_TOOL_NAMES);
     names.extend_from_slice(FRICTION_TOOL_NAMES);
-    names.extend_from_slice(GRAPH_READ_TOOL_NAMES);
+    names.extend_from_slice(GRAPH_TOOL_NAMES);
     names.extend_from_slice(SEARCH_TOOL_NAMES);
     names.extend_from_slice(SEMANTIC_TOOL_NAMES);
     names.extend_from_slice(ADR_TOOL_NAMES);
@@ -129,7 +135,7 @@ pub(crate) fn safe_mcp_tool_names() -> Vec<&'static str> {
 pub(crate) fn is_mcp_tool_exposed(name: &str) -> bool {
     TASK_TOOL_NAMES.contains(&name)
         || FRICTION_TOOL_NAMES.contains(&name)
-        || GRAPH_READ_TOOL_NAMES.contains(&name)
+        || GRAPH_TOOL_NAMES.contains(&name)
         || SEARCH_TOOL_NAMES.contains(&name)
         || SEMANTIC_TOOL_NAMES.contains(&name)
         || ADR_TOOL_NAMES.contains(&name)
@@ -154,6 +160,13 @@ pub(super) struct RuntimeMcpHost {
 
 impl RuntimeMcpHost {
     pub(super) fn new(runtime: OrbitRuntime) -> Self {
+        let safe_names = safe_mcp_tool_names();
+        assert!(
+            orbit_mcp::graph_tool_names()
+                .iter()
+                .all(|name| safe_names.contains(name)),
+            "in-process graph tool names must be a subset of the MCP safe surface"
+        );
         Self { runtime }
     }
 }
@@ -180,6 +193,21 @@ impl McpHost for RuntimeMcpHost {
         session_context: ToolSessionContext,
     ) -> Result<Value, OrbitError> {
         audited_mcp_call_with_session_context(&self.runtime, name, input, session_context)
+    }
+
+    fn call_in_process_tool(
+        &self,
+        name: &str,
+        input: Value,
+        session_context: ToolSessionContext,
+        dispatch: &mut dyn FnMut(Value, ToolSessionContext) -> Result<Value, OrbitError>,
+    ) -> Result<Value, OrbitError> {
+        self.runtime
+            .execute_in_process_tool_dispatch(name, input, ToolEntryPoint::Mcp, |input| {
+                ensure_mcp_tool_exposed(name)?;
+                dispatch(input, session_context)
+            })
+            .map(|outcome| outcome.value)
     }
 
     fn learning_candidates_for_path(

--- a/crates/orbit-cli/src/command/mcp/tests/mod.rs
+++ b/crates/orbit-cli/src/command/mcp/tests/mod.rs
@@ -8,9 +8,9 @@ use orbit_core::OrbitRuntime;
 use orbit_mcp::McpHost;
 
 use super::host::{
-    ADR_TOOL_NAMES, DOCS_TOOL_NAMES, FRICTION_TOOL_NAMES, GRAPH_READ_TOOL_NAMES,
-    LEARNING_TOOL_NAMES, RuntimeMcpHost, SEARCH_TOOL_NAMES, SEMANTIC_TOOL_NAMES, TASK_TOOL_NAMES,
-    is_mcp_tool_exposed, safe_mcp_tool_names,
+    ADR_TOOL_NAMES, DOCS_TOOL_NAMES, FRICTION_TOOL_NAMES, GRAPH_TOOL_NAMES, LEARNING_TOOL_NAMES,
+    RuntimeMcpHost, SEARCH_TOOL_NAMES, SEMANTIC_TOOL_NAMES, TASK_TOOL_NAMES, is_mcp_tool_exposed,
+    safe_mcp_tool_names,
 };
 
 const EXPECTED_INACTIVE_TOOL_NAMES: &[&str] = &[
@@ -124,7 +124,6 @@ fn safe_surface_matches_runtime_graph_and_task_tools() {
     for name in TASK_TOOL_NAMES
         .iter()
         .chain(FRICTION_TOOL_NAMES)
-        .chain(GRAPH_READ_TOOL_NAMES)
         .chain(SEARCH_TOOL_NAMES)
         .chain(SEMANTIC_TOOL_NAMES)
         .chain(ADR_TOOL_NAMES)
@@ -200,6 +199,19 @@ fn safe_surface_matches_runtime_graph_and_task_tools() {
 }
 
 #[test]
+fn graph_adapter_names_are_explicitly_allowlisted() {
+    let safe_names: BTreeSet<&str> = safe_mcp_tool_names().into_iter().collect();
+    let adapter_names: BTreeSet<&str> = orbit_mcp::graph_tool_names().iter().copied().collect();
+    let configured_names: BTreeSet<&str> = GRAPH_TOOL_NAMES.iter().copied().collect();
+
+    assert_eq!(adapter_names, configured_names);
+    assert!(adapter_names.is_subset(&safe_names));
+    for name in adapter_names {
+        assert!(is_mcp_tool_exposed(name));
+    }
+}
+
+#[test]
 fn runtime_mcp_host_lists_safe_tools_and_no_graph_surface_after_v2_cutover() {
     let runtime = OrbitRuntime::in_memory().expect("build test runtime");
     let host = RuntimeMcpHost { runtime };
@@ -209,7 +221,10 @@ fn runtime_mcp_host_lists_safe_tools_and_no_graph_surface_after_v2_cutover() {
         .map(|schema| schema.name)
         .collect();
 
-    for name in safe_mcp_tool_names() {
+    for name in safe_mcp_tool_names()
+        .into_iter()
+        .filter(|name| !GRAPH_TOOL_NAMES.contains(name))
+    {
         assert!(
             listed.contains(name),
             "client-visible MCP tool list missing safe tool: {name}"
@@ -230,10 +245,10 @@ fn runtime_mcp_host_lists_safe_tools_and_no_graph_surface_after_v2_cutover() {
         );
     }
 
-    // ORB-00391: the orbit-tools runtime host must expose NO `orbit.graph.*`
-    // tool. The orbit-mcp adapter gates its in-process orbit-graph (v2) tools on
-    // exactly this condition (`host_exposes_graph_tools` → false), so any graph
-    // tool leaking back into the host surface would silently disable v2.
+    // ORB-00391: the orbit-tools runtime host still owns no `orbit.graph.*`
+    // implementation. The orbit-mcp adapter now replaces any accidentally
+    // re-exposed known graph schema, but this assertion preserves the intended
+    // crate ownership boundary.
     assert!(
         !listed.iter().any(|name| name.starts_with("orbit.graph.")),
         "host must expose no orbit.graph.* tool after the v2 cutover, found: {:?}",
@@ -254,7 +269,7 @@ mod audited_mcp_call_tests {
     };
     use orbit_common::types::{
         AuditEventStatus, LearningInjectionCaps, LearningInjectionState, LearningReminder,
-        LearningScope,
+        LearningScope, ToolSessionContext,
     };
     use orbit_core::LearningEvidence;
     use orbit_core::{LearningCreateParams, OrbitError, OrbitRuntime};
@@ -328,6 +343,92 @@ mod audited_mcp_call_tests {
         assert_eq!(events.len(), 1, "exactly one audit row for happy path");
         assert_eq!(events[0].subcommand.as_deref(), Some("run-mcp"));
         assert_eq!(events[0].status, AuditEventStatus::Success);
+    }
+
+    #[test]
+    fn in_process_graph_dispatch_records_success_and_failure_audit_rows() {
+        let _guard = EnvGuard::set(&[
+            ("ORBIT_AGENT_NAME", None),
+            ("ORBIT_AGENT_MODEL", None),
+            ("ORBIT_MANAGED_RUN_CONTEXT", None),
+            ("ORBIT_RUN_ID", None),
+        ]);
+        let runtime = OrbitRuntime::in_memory().expect("build test runtime");
+        let host = RuntimeMcpHost {
+            runtime: runtime.clone(),
+        };
+
+        let mut success_dispatch =
+            |input: serde_json::Value, _session_context: ToolSessionContext| {
+                assert_eq!(input["query"], "dispatch");
+                Ok(json!({ "matches": [] }))
+            };
+        host.call_in_process_tool(
+            "orbit.graph.search",
+            json!({ "query": "dispatch", "model": "codex" }),
+            Default::default(),
+            &mut success_dispatch,
+        )
+        .expect("allowlisted graph call succeeds");
+
+        let mut failure_dispatch =
+            |_input: serde_json::Value, _session_context: ToolSessionContext| {
+                Err(OrbitError::InvalidInput("invalid selector".to_string()))
+            };
+        host.call_in_process_tool(
+            "orbit.graph.show",
+            json!({ "selector": "invalid", "model": "codex" }),
+            Default::default(),
+            &mut failure_dispatch,
+        )
+        .expect_err("graph implementation failure propagates");
+
+        for (name, expected_status) in [
+            ("orbit.graph.search", AuditEventStatus::Success),
+            ("orbit.graph.show", AuditEventStatus::Failure),
+        ] {
+            let events = runtime
+                .list_audit_events(None, Some(name.to_string()), None, None, 16)
+                .expect("list graph audit events");
+            assert_eq!(events.len(), 1, "exactly one audit row for {name}");
+            let row = &events[0];
+            assert_eq!(row.subcommand.as_deref(), Some("run-mcp"));
+            assert_eq!(row.tool_name.as_deref(), Some(name));
+            assert_eq!(row.role, "codex");
+            assert_eq!(row.status, expected_status);
+            assert!(row.duration_ms >= 1);
+        }
+    }
+
+    #[test]
+    fn unallowlisted_graph_tool_is_rejected_before_in_process_dispatch() {
+        let runtime = OrbitRuntime::in_memory().expect("build test runtime");
+        let host = RuntimeMcpHost {
+            runtime: runtime.clone(),
+        };
+        let mut called = false;
+        let mut dispatch = |_input: serde_json::Value, _session_context: ToolSessionContext| {
+            called = true;
+            Ok(json!({}))
+        };
+
+        let error = host
+            .call_in_process_tool(
+                "orbit.graph.pack",
+                json!({ "model": "codex" }),
+                Default::default(),
+                &mut dispatch,
+            )
+            .expect_err("unallowlisted graph tool is rejected");
+        assert!(matches!(error, OrbitError::NotFound { .. }));
+        assert!(!called, "rejected graph implementation must not run");
+
+        let events = runtime
+            .list_audit_events(None, Some("orbit.graph.pack".to_string()), None, None, 16)
+            .expect("list graph preflight audit event");
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].subcommand.as_deref(), Some("run-mcp"));
+        assert_eq!(events[0].status, AuditEventStatus::Failure);
     }
 
     #[test]

--- a/crates/orbit-cli/tests/mcp_roundtrip.rs
+++ b/crates/orbit-cli/tests/mcp_roundtrip.rs
@@ -73,7 +73,11 @@ impl McpWorkspace {
             .env_remove("ORBIT_TASK_ID")
             .env_remove("ORBIT_RUN_ID")
             .env_remove("ORBIT_ACTIVITY_ID")
-            .env_remove("ORBIT_STEP_INDEX");
+            .env_remove("ORBIT_STEP_INDEX")
+            .env_remove("ORBIT_AGENT_NAME")
+            .env_remove("ORBIT_AGENT_MODEL")
+            .env_remove("ORBIT_MANAGED_RUN_CONTEXT")
+            .env_remove("ORBIT_TASK_ACTOR_KIND");
         command
     }
 
@@ -402,4 +406,51 @@ fn mcp_serve_error_paths_return_tool_errors_and_keep_serving() {
     // The server must still answer after every error path above.
     let listed = client.call_tool_ok("orbit_task_list", json!({}));
     assert!(listed["items"].is_array(), "server wedged: {listed}");
+}
+
+#[test]
+fn mcp_graph_calls_persist_success_and_failure_audit_rows() {
+    let workspace = McpWorkspace::init();
+    let mut client = workspace.serve();
+
+    client.call_tool_ok(
+        "orbit_graph_search",
+        json!({ "query": "mcp-audit-marker", "model": "codex" }),
+    );
+    let error = client.call_tool_err(
+        "orbit_graph_show",
+        json!({ "selector": "not-a-selector", "model": "codex" }),
+    );
+    assert_eq!(error["code"], "invalid_input");
+    let unallowlisted = client.call_tool_err(
+        "orbit.graph.pack",
+        json!({ "selectors": ["file:src/lib.rs"], "model": "codex" }),
+    );
+    assert_eq!(unallowlisted["code"], "tool_not_found");
+    drop(client);
+
+    for (tool_name, status) in [
+        ("orbit.graph.search", "success"),
+        ("orbit.graph.show", "failure"),
+        ("orbit.graph.pack", "failure"),
+    ] {
+        let output = McpWorkspace::orbit_command(&workspace.work, &workspace.home)
+            .args(["audit", "list", "--tool", tool_name, "--json"])
+            .output()
+            .expect("query graph audit rows");
+        assert!(
+            output.status.success(),
+            "audit list failed for {tool_name}: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        let rows: Value = serde_json::from_slice(&output.stdout).expect("parse audit rows");
+        let rows = rows.as_array().expect("audit row array");
+        assert_eq!(rows.len(), 1, "exactly one audit row for {tool_name}");
+        let row = &rows[0];
+        assert_eq!(row["tool_name"], tool_name);
+        assert_eq!(row["subcommand"], "run-mcp");
+        assert_eq!(row["status"], status);
+        assert_eq!(row["role"], "codex");
+        assert!(row["duration_ms"].as_i64().is_some_and(|value| value >= 1));
+    }
 }

--- a/crates/orbit-core/src/command/tool.rs
+++ b/crates/orbit-core/src/command/tool.rs
@@ -142,6 +142,68 @@ impl OrbitRuntime {
         entry_point: ToolEntryPoint,
         session_context: ToolSessionContext,
     ) -> Result<ToolDispatchOutcome, OrbitError> {
+        self.execute_tool_dispatch_with(
+            name,
+            input,
+            agent_override.clone(),
+            model_override.clone(),
+            entry_point,
+            |input| {
+                self.ensure_tool_agent_facing(name)?;
+                let allowed_tools = read_activity_tools_from_env();
+                let (agent_name, model_name) =
+                    resolve_agent_identity(agent_override, model_override)?;
+                let proc_allowed_programs = read_proc_allowed_programs_from_env();
+                let cwd = std::env::current_dir()
+                    .ok()
+                    .map(|path| path.to_string_lossy().into_owned());
+                let tool_context = ToolContext {
+                    cwd,
+                    session_context,
+                    allowed_tools,
+                    agent_name,
+                    model_name,
+                    workspace_root: None,
+                    proc_allowed_programs,
+                    reservation_owner: reservation_owner_from_env(),
+                    ..Default::default()
+                };
+                self.run_tool_with_context_and_role(name, input, Role::Admin, tool_context)
+            },
+        )
+    }
+
+    /// Run an in-process tool implementation inside the same audit boundary
+    /// used by registry-backed tool dispatch.
+    ///
+    /// Transport adapters use this for tools whose implementation deliberately
+    /// lives outside the runtime registry. Policy checks belong inside
+    /// `dispatch` so a rejection is captured by the resulting audit row.
+    pub fn execute_in_process_tool_dispatch<F>(
+        &self,
+        name: &str,
+        input: Value,
+        entry_point: ToolEntryPoint,
+        dispatch: F,
+    ) -> Result<ToolDispatchOutcome, OrbitError>
+    where
+        F: FnOnce(Value) -> Result<Value, OrbitError>,
+    {
+        self.execute_tool_dispatch_with(name, input, None, None, entry_point, dispatch)
+    }
+
+    fn execute_tool_dispatch_with<F>(
+        &self,
+        name: &str,
+        input: Value,
+        agent_override: Option<String>,
+        model_override: Option<String>,
+        entry_point: ToolEntryPoint,
+        dispatch: F,
+    ) -> Result<ToolDispatchOutcome, OrbitError>
+    where
+        F: FnOnce(Value) -> Result<Value, OrbitError>,
+    {
         let start = Instant::now();
         let role_label =
             audit_role_label(&input, agent_override.as_deref(), model_override.as_deref());
@@ -150,33 +212,9 @@ impl OrbitRuntime {
             .unwrap_or_else(|_| ".".to_string());
         let audit_context = resolve_audit_context(&input);
 
-        // Closure boundary so any setup failure (e.g. an inconsistent
-        // `agent`/`model` rejected by `resolve_agent_identity`) becomes a
-        // recorded failure-status audit row rather than a silent early `?`
-        // return. Without this, MCP-originated calls — which have no
-        // surrounding `AuditGuard` to fall back on — would fail without any
-        // audit row at all when identity setup is the cause.
-        let result: Result<Value, OrbitError> = (|| {
-            self.ensure_tool_agent_facing(name)?;
-            let allowed_tools = read_activity_tools_from_env();
-            let (agent_name, model_name) = resolve_agent_identity(agent_override, model_override)?;
-            let proc_allowed_programs = read_proc_allowed_programs_from_env();
-            let cwd = std::env::current_dir()
-                .ok()
-                .map(|path| path.to_string_lossy().into_owned());
-            let tool_context = ToolContext {
-                cwd,
-                session_context,
-                allowed_tools,
-                agent_name,
-                model_name,
-                workspace_root: None,
-                proc_allowed_programs,
-                reservation_owner: reservation_owner_from_env(),
-                ..Default::default()
-            };
-            self.run_tool_with_context_and_role(name, input, Role::Admin, tool_context)
-        })();
+        // Keep the callback inside the audit boundary so setup, policy, and
+        // implementation failures all produce a failure-status row.
+        let result = dispatch(input);
         let duration_ms = (start.elapsed().as_millis() as i64).max(1);
 
         let (status, exit_code, error_message) = match &result {

--- a/crates/orbit-mcp/src/adapter/dispatch.rs
+++ b/crates/orbit-mcp/src/adapter/dispatch.rs
@@ -21,13 +21,13 @@ impl OrbitToolServer {
     pub(super) fn combined_tool_schemas(&self) -> Vec<ToolSchema> {
         let mut schemas = self.host.list_tool_schemas();
         // ORB-00391: the v1 orbit-knowledge graph builtins were decommissioned,
-        // so the host exposes no `orbit.graph.*` schema and the in-process
-        // orbit-graph (v2) adapter is the sole graph surface. The gate stays as a
-        // safety net: if any host ever re-exposes a graph tool, the adapter backs
-        // off rather than colliding on names.
-        if !host_exposes_graph_tools(&schemas) {
-            schemas.extend(self.graph_tools.schemas());
-        }
+        // so the in-process orbit-graph (v2) adapter owns its known graph
+        // names. Replace any re-exposed host schema for those names instead of
+        // letting schema presence disable the adapter's policy/audit path.
+        // Unknown host graph names remain visible and take the normal host
+        // dispatch path, including its allowlist preflight.
+        schemas.retain(|schema| !self.graph_tools.is_graph_tool(&schema.name));
+        schemas.extend(self.graph_tools.schemas());
         schemas
     }
 
@@ -104,11 +104,17 @@ impl OrbitToolServer {
         let exec_name = canonical.clone();
         let session_context = self.session_context();
         let input_for_learning = input.clone();
-        let graph_tool =
-            self.adapter_graph_tools_enabled() && self.graph_tools.is_graph_tool(&canonical);
+        // Dispatch recognition is deliberately independent of host schemas.
+        // Re-exposing a host graph schema must not make
+        // adapter-owned graph calls bypass the host's policy/audit seam.
+        let graph_tool = self.graph_tools.is_graph_tool(&canonical);
         let join = tokio::task::spawn_blocking(move || {
             if graph_tool {
-                graph_tools.call_tool(&exec_name, input, session_context)
+                let graph_name = exec_name.clone();
+                let mut dispatch = move |input, session_context| {
+                    graph_tools.call_tool(&graph_name, input, session_context)
+                };
+                host.call_in_process_tool(&exec_name, input, session_context, &mut dispatch)
             } else {
                 host.call_tool(&exec_name, input, session_context)
             }
@@ -141,16 +147,6 @@ impl OrbitToolServer {
             }
         }
     }
-
-    fn adapter_graph_tools_enabled(&self) -> bool {
-        !host_exposes_graph_tools(&self.host.list_tool_schemas())
-    }
-}
-
-fn host_exposes_graph_tools(schemas: &[ToolSchema]) -> bool {
-    schemas
-        .iter()
-        .any(|schema| schema.name.starts_with("orbit.graph."))
 }
 
 impl ServerHandler for OrbitToolServer {

--- a/crates/orbit-mcp/src/adapter/graph.rs
+++ b/crates/orbit-mcp/src/adapter/graph.rs
@@ -27,7 +27,7 @@ const GRAPH_OVERVIEW_TOOL: &str = "orbit.graph.overview";
 const GRAPH_IMPLEMENTORS_TOOL: &str = "orbit.graph.implementors";
 const GRAPH_DEPS_TOOL: &str = "orbit.graph.deps";
 
-const GRAPH_TOOL_NAMES: &[&str] = &[
+pub(super) const GRAPH_TOOL_NAMES: &[&str] = &[
     GRAPH_SYNC_TOOL,
     GRAPH_SEARCH_TOOL,
     GRAPH_SHOW_TOOL,

--- a/crates/orbit-mcp/src/adapter/mod.rs
+++ b/crates/orbit-mcp/src/adapter/mod.rs
@@ -100,3 +100,7 @@ impl OrbitToolServer {
 }
 
 pub(super) const PROCESS_LEARNING_SESSION_KEY: &str = "__process__";
+
+pub(crate) fn graph_tool_names() -> &'static [&'static str] {
+    graph::GRAPH_TOOL_NAMES
+}

--- a/crates/orbit-mcp/src/adapter/test_support.rs
+++ b/crates/orbit-mcp/src/adapter/test_support.rs
@@ -58,6 +58,16 @@ impl crate::McpHost for StubHost {
     ) -> Result<Value, OrbitError> {
         Ok(Value::Null)
     }
+
+    fn call_in_process_tool(
+        &self,
+        _name: &str,
+        input: Value,
+        session_context: ToolSessionContext,
+        dispatch: &mut dyn FnMut(Value, ToolSessionContext) -> Result<Value, OrbitError>,
+    ) -> Result<Value, OrbitError> {
+        dispatch(input, session_context)
+    }
 }
 
 pub(super) struct EchoArrayHost {

--- a/crates/orbit-mcp/src/adapter/tests/graph.rs
+++ b/crates/orbit-mcp/src/adapter/tests/graph.rs
@@ -2,8 +2,9 @@ use std::fs;
 use std::path::Path;
 use std::process::Command;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
 
-use orbit_common::types::ToolSessionContext;
+use orbit_common::types::{NotFoundKind, OrbitError, ToolSessionContext};
 use serde_json::{Value, json};
 use tempfile::TempDir;
 
@@ -60,7 +61,7 @@ fn graph_tool_schemas_cover_cli_parameters() {
 }
 
 #[test]
-fn combined_schemas_preserve_legacy_host_graph_tools() {
+fn combined_schemas_replace_known_host_graph_tools_and_preserve_unknown_ones() {
     let host = Arc::new(StubHost {
         schemas: vec![
             tool_schema("orbit.graph.search"),
@@ -83,13 +84,69 @@ fn combined_schemas_preserve_legacy_host_graph_tools() {
         .iter()
         .find(|schema| schema.name == "orbit.graph.search")
         .expect("graph search schema");
-    assert_param_names(search, &[]);
+    assert_param_names(
+        search,
+        &with_workspace_params(&["query", "kind", "lang", "limit"]),
+    );
     assert!(names.contains(&"orbit.graph.pack"));
     assert!(names.contains(&"orbit.task.show"));
-    assert!(!names.contains(&"orbit.graph.sync"));
-    assert!(!names.contains(&"orbit.graph.callees"));
-    assert!(!names.contains(&"orbit.graph.impact"));
-    assert!(!names.contains(&"orbit.graph.trace"));
+    assert!(names.contains(&"orbit.graph.sync"));
+    assert!(names.contains(&"orbit.graph.callees"));
+    assert!(names.contains(&"orbit.graph.impact"));
+    assert!(names.contains(&"orbit.graph.trace"));
+}
+
+#[tokio::test]
+async fn reexposed_graph_schema_still_crosses_in_process_policy_seam() {
+    struct ReexposedGraphHost {
+        host_calls: AtomicUsize,
+        in_process_calls: AtomicUsize,
+    }
+
+    impl crate::McpHost for ReexposedGraphHost {
+        fn list_tool_schemas(&self) -> Vec<orbit_common::types::ToolSchema> {
+            vec![tool_schema("orbit.graph.search")]
+        }
+
+        fn call_tool(
+            &self,
+            _name: &str,
+            _input: Value,
+            _session_context: ToolSessionContext,
+        ) -> Result<Value, OrbitError> {
+            self.host_calls.fetch_add(1, Ordering::SeqCst);
+            Ok(json!({ "bypassed": true }))
+        }
+
+        fn call_in_process_tool(
+            &self,
+            name: &str,
+            _input: Value,
+            _session_context: ToolSessionContext,
+            _dispatch: &mut dyn FnMut(Value, ToolSessionContext) -> Result<Value, OrbitError>,
+        ) -> Result<Value, OrbitError> {
+            self.in_process_calls.fetch_add(1, Ordering::SeqCst);
+            Err(OrbitError::not_found(NotFoundKind::Tool, name.to_string()))
+        }
+    }
+
+    let host = Arc::new(ReexposedGraphHost {
+        host_calls: AtomicUsize::new(0),
+        in_process_calls: AtomicUsize::new(0),
+    });
+    let server = OrbitToolServer::new(host.clone());
+
+    let result = server
+        .call_tool_request(request_with_args(
+            "orbit.graph.search",
+            json!({ "query": "dispatch" }),
+        ))
+        .await
+        .expect("MCP request returns a structured policy error");
+
+    assert!(result.is_error.unwrap_or(false));
+    assert_eq!(host.in_process_calls.load(Ordering::SeqCst), 1);
+    assert_eq!(host.host_calls.load(Ordering::SeqCst), 0);
 }
 
 #[test]

--- a/crates/orbit-mcp/src/lib.rs
+++ b/crates/orbit-mcp/src/lib.rs
@@ -13,19 +13,17 @@
 //!
 //! The crate is primarily a thin transport adapter between rmcp's server
 //! runtime and an Orbit-supplied [`McpHost`]. Most tool dispatch, policy
-//! evaluation, and audit logging is delegated to the host. The exception is
-//! the read-only `orbit.graph.*` surface backed by `orbit-graph`; those
-//! wrappers live in-process so a long-running MCP server can reuse one graph
-//! handle per worktree and apply the MCP watcher-backed sync policy. In the
-//! default `orbit-cli` wiring the host is
-//! `RuntimeMcpHost`, which brackets every call with an audit boundary
-//! (`audited_mcp_call`): the wrapper records a failure-status audit row when
-//! preflight rejects an unknown / unexposed tool name, and otherwise dispatches
-//! through `OrbitRuntime::execute_tool_command_dispatch` tagged with
-//! `ToolEntryPoint::Mcp`, where the runtime persists a success-or-failure
-//! audit row with the same identity-resolution rules and policy chain as the
-//! CLI path. Audit rows from MCP calls carry `subcommand = "run-mcp"` so they
-//! can be filtered apart from CLI tool runs (which carry `"run"`).
+//! evaluation, and audit logging is delegated to the host. The implementation
+//! of the `orbit.graph.*` surface is backed by `orbit-graph` in-process so a
+//! long-running MCP server can reuse one graph handle per worktree and apply
+//! the MCP watcher-backed sync policy. Its policy and audit boundary still
+//! belong to the host. In the default `orbit-cli` wiring the host is
+//! `RuntimeMcpHost`, which applies the safe-surface preflight and brackets both
+//! registry-backed and in-process calls with OrbitRuntime's audit boundary,
+//! tagged with `ToolEntryPoint::Mcp`. The runtime persists a success-or-failure
+//! audit row with the same identity-resolution rules as the CLI path. Audit
+//! rows from MCP calls carry `subcommand = "run-mcp"` so they can be filtered
+//! apart from CLI tool runs (which carry `"run"`).
 //!
 //! # Role
 //! Depends on `orbit-common`, `orbit-graph`, and `orbit-graph-extract`. The
@@ -41,20 +39,28 @@ mod error;
 
 use std::sync::Arc;
 
-use orbit_common::types::{LearningInjectionState, OrbitError, ToolSchema, ToolSessionContext};
+use orbit_common::types::{
+    LearningInjectionState, NotFoundKind, OrbitError, ToolSchema, ToolSessionContext,
+};
 use rmcp::ServiceExt;
 use rmcp::transport::io::stdio;
 use serde_json::Value;
 
 pub use adapter::OrbitToolServer;
 
+/// Canonical names implemented by the in-process graph adapter.
+pub fn graph_tool_names() -> &'static [&'static str] {
+    adapter::graph_tool_names()
+}
+
 /// A pluggable back-end that satisfies MCP `tools/list` and `tools/call`
 /// requests.
 ///
 /// `list_tool_schemas` is expected to return only the tools the host wants
 /// exposed — disabled tools should be filtered out here, not in the adapter.
-/// `call_tool` must itself run whatever policy, audit, and sandboxing the host
-/// wants applied; the adapter will never bypass it.
+/// `call_tool` and `call_in_process_tool` must run whatever policy, audit, and
+/// sandboxing the host wants applied; the adapter never invokes an in-process
+/// implementation without first crossing the latter host seam.
 pub trait McpHost: Send + Sync + 'static {
     fn list_tool_schemas(&self) -> Vec<ToolSchema>;
     fn call_tool(
@@ -63,6 +69,19 @@ pub trait McpHost: Send + Sync + 'static {
         input: Value,
         session_context: ToolSessionContext,
     ) -> Result<Value, OrbitError>;
+
+    /// Apply host policy and auditing around a tool implemented inside this
+    /// adapter. The secure default rejects the call; hosts must explicitly
+    /// admit adapter-owned tools and invoke `dispatch` inside their boundary.
+    fn call_in_process_tool(
+        &self,
+        name: &str,
+        _input: Value,
+        _session_context: ToolSessionContext,
+        _dispatch: &mut dyn FnMut(Value, ToolSessionContext) -> Result<Value, OrbitError>,
+    ) -> Result<Value, OrbitError> {
+        Err(OrbitError::not_found(NotFoundKind::Tool, name.to_string()))
+    }
 
     /// L-0043: sidecar internals use host extensions so runtime-backed MCP
     /// hosts can keep the client safe surface narrow.

--- a/crates/orbit-mcp/tests/mcp_wire_roundtrip.rs
+++ b/crates/orbit-mcp/tests/mcp_wire_roundtrip.rs
@@ -176,6 +176,16 @@ impl McpHost for FileStoreHost {
             other => Err(OrbitError::not_found(NotFoundKind::Tool, other.to_string())),
         }
     }
+
+    fn call_in_process_tool(
+        &self,
+        _name: &str,
+        input: Value,
+        session_context: ToolSessionContext,
+        dispatch: &mut dyn FnMut(Value, ToolSessionContext) -> Result<Value, OrbitError>,
+    ) -> Result<Value, OrbitError> {
+        dispatch(input, session_context)
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/docs/design/auditability/2_design.md
+++ b/docs/design/auditability/2_design.md
@@ -3,7 +3,7 @@ summary: "Auditability — Design"
 type: design
 title: "Auditability — Design"
 owner: codex
-last_updated: 2026-07-15
+last_updated: 2026-07-16
 status: Draft
 feature: auditability
 doc_role: design
@@ -42,7 +42,7 @@ The CLI RAII guard in `crates/orbit-cli/src/audit_middleware.rs` defaults to fai
 
 For `orbit tool run`, [T20260427-52] first collapsed duplicate `agent` + `model` inputs. [ORB-00080] later made the family the durable identity: agent-facing `model` inputs should be `codex`, `claude`, `gemini`, or `grok`, while full model strings remain accepted for compatibility and normalize to the family before persistence. Missing identity falls back to `agent` for tool dispatch, while direct non-tool CLI commands use `admin`.
 
-After [T20260428-4], tool-invocation audit is written in `OrbitRuntime::execute_tool_command_dispatch` for CLI, MCP, and future entry points. A `ToolEntryPoint` discriminator surfaces as `subcommand: "run"` or `"run-mcp"`, setup failures inside dispatch are audited, and `duration_ms` is clamped to at least `1`. The legacy CLI guard skips its own emission when the runtime sets a per-thread `mark_tool_audit_recorded` signal; pre-runtime CLI failures such as invalid JSON still produce the existing guard-side row.
+After [T20260428-4], tool-invocation audit is written at the OrbitRuntime dispatch boundary for CLI, MCP, and future entry points. A `ToolEntryPoint` discriminator surfaces as `subcommand: "run"` or `"run-mcp"`, setup failures inside dispatch are audited, and `duration_ms` is clamped to at least `1`. [ORB-10225] extracted the shared boundary behind registry-backed dispatch and added `execute_in_process_tool_dispatch` for adapter-owned implementations: the in-process `orbit.graph.*` tools now cross the same MCP allowlist and success/failure audit bracket instead of calling their handler directly. The legacy CLI guard skips its own emission when the runtime sets a per-thread `mark_tool_audit_recorded` signal; pre-runtime CLI failures such as invalid JSON still produce the existing guard-side row.
 
 ---
 
@@ -50,8 +50,8 @@ After [T20260428-4], tool-invocation audit is written in `OrbitRuntime::execute_
 
 Some runtime paths write targeted command-audit rows directly:
 
-- `crates/orbit-core/src/command/tool.rs` records CLI and MCP tool invocations as `command: tool` with `subcommand: "run"` or `"run-mcp"`.
-- `crates/orbit-cli/src/command/mcp/mod.rs` records MCP preflight failures for unknown or unexposed tools before runtime dispatch.
+- `crates/orbit-core/src/command/tool.rs` records registry-backed and in-process CLI/MCP tool invocations as `command: tool` with `subcommand: "run"` or `"run-mcp"`.
+- `crates/orbit-cli/src/command/mcp/host.rs` owns MCP safe-surface preflight. Adapter-owned preflight runs inside the shared runtime boundary; registry preflight failures are recorded explicitly before runtime dispatch. Unknown or unexposed names therefore produce failure rows without invoking either implementation.
 - `crates/orbit-core/src/runtime/orbit_tool_host/mod.rs` records task lock reservation checks, reservations, releases, and denials.
 - `crates/orbit-core/src/runtime/v2_host/pipeline_actions.rs` records gate-starvation failures for task bundles.
 
@@ -176,5 +176,6 @@ Each record contains timestamp, level, target, and structured fields. After [T20
 - **[ORB-00090]** — Aligned agent-facing provenance wording with the family-as-identity convention.
 - **[ORB-00106]** — Preserve per-task implementer attribution when `orbit run ship` moves batch PR tasks from Review to Done.
 - **[ORB-10200]** — Derive CLI audit metadata and the other cross-cutting command policies from one exhaustive command-operation registry.
+- **[ORB-10225]** — Route in-process graph MCP calls through the safe-surface allowlist and shared runtime audit boundary.
 
 > Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.

--- a/docs/design/orbit-graph/2_design.md
+++ b/docs/design/orbit-graph/2_design.md
@@ -3,7 +3,7 @@ summary: "Orbit Graph — Design"
 type: design
 title: "Orbit Graph — Design"
 owner: claude
-last_updated: 2026-06-13
+last_updated: 2026-07-16
 status: Draft
 feature: orbit-graph
 doc_role: design
@@ -176,7 +176,7 @@ The previous hardcoded "10ms stat budget, 500ms cache window" heuristic was an i
 
 ## 6. Query Surface
 
-Seven commands, each mapped 1:1 to an MCP tool. Specified in detail in [`GRAPH_SPEC.md`](./specs/GRAPH_SPEC.md) §9.
+Ten commands, each mapped 1:1 to an MCP tool. Specified in detail in [`GRAPH_SPEC.md`](./specs/GRAPH_SPEC.md) §9.
 
 ```
 orbit graph sync     [--full]
@@ -186,11 +186,16 @@ orbit graph refs     <symbol>  [--confidence ...] [--kind ...]
 orbit graph callees  <symbol>
 orbit graph impact   <selector> [--depth N=3] [--confidence exact|import|same_module|fuzzy]
 orbit graph trace    <command> [--depth N=5] [--confidence exact|import|same_module|fuzzy]
+orbit graph overview [dir:… | file:…] [--format summary|full]
+orbit graph implementors <trait-selector>
+orbit graph deps     <file:… | dir:…>
 ```
 
 Bounded outputs: `impact` and `trace` both cap at 200 visited nodes regardless of `--depth`. When the cap fires, the response carries `truncated: true` so callers can split into narrower queries.
 
-`refs` unions queries against the `refs` table (calls/type/use/trait_bound) and the `relations` table (impl/extends/implements). CLI `--kind impl` is a routing alias to `relations`. This means the seven-command surface absorbs what `orbit-knowledge` exposed as separate `callers`, `implementors`, `deps`, and `lineage` queries.
+`refs` unions queries against the `refs` table (calls/type/use/trait_bound) and the `relations` table (impl/extends/implements). CLI `--kind impl` is a routing alias to `relations`. The ten-command surface absorbs `orbit-knowledge`'s navigation use cases while keeping `overview`, `implementors`, and outbound module-level `deps` explicit.
+
+For the agent-facing MCP entry point, the ten canonical names are an explicit safe-surface set in `orbit-cli`. `orbit-mcp` owns the in-process implementations but calls them only through the host's policy/audit seam; `RuntimeMcpHost` applies the allowlist and records success or failure through the shared `ToolEntryPoint::Mcp` runtime boundary. Known graph schemas accidentally re-exposed by a host are replaced by the adapter schemas, so schema presence cannot disable that seam. [ORB-10225] added the startup subset assertion and end-to-end audit coverage.
 
 The `Selector` grammar is preserved verbatim from `orbit-knowledge` — every form used in existing skills (`symbol:<file>#<name>:<kind>`, `file:<path>`, `module:<qualified>`, `command:<name>`) must continue to parse identically. A pre-Step-1 audit of `.claude/skills/` captures the full grammar surface as the canonical reference.
 
@@ -235,5 +240,6 @@ No async on the public surface. SQLite and tree-sitter are both sync. If the MCP
 ## Task References
 
 - [ORB-00377] moved long-lived MCP graph reads to watcher-backed background sync and documented the freshness contract in ADR-0195.
+- [ORB-10225] routed the in-process graph MCP surface through the explicit allowlist and shared runtime audit boundary.
 
 Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.

--- a/docs/design/orbit-graph/specs/GRAPH_SPEC.md
+++ b/docs/design/orbit-graph/specs/GRAPH_SPEC.md
@@ -1,7 +1,7 @@
 # Orbit Graph — Redesign Spec
 
 **Status:** Draft proposal
-**Last updated:** 2026-07-04 (ORB-10011 consolidated the `Selector` parser into `orbit-common::utility::selector`; previously ORB-00391 completed the v2 cutover and removed `orbit-knowledge`)
+**Last updated:** 2026-07-16 (ORB-10225 routed the MCP graph surface through the explicit allowlist and shared runtime audit boundary; previously ORB-10011 consolidated the `Selector` parser)
 **Relation to `orbit-knowledge`:** Decommissioned. `orbit-knowledge` (v1) was removed in ORB-00391; orbit-graph is the sole graph backend. The two no longer coexist. See §16 for the migration outcome.
 **Author:** working from the V2 sketch in `GRAPH_V2.md` + the existing design in [`../../knowledge-graph/`](../../_archive/knowledge-graph/)
 **Scope:** V1 — read-only graph. A writeable graph (Rename, ReplaceBody, Move, working-graph overlay, patch compiler) is V2, sketched in §17 and tracked in [`../3_vision.md`](../3_vision.md). The previous separate `GRAPH_DESIGN.md` describing the write surface has been folded into this spec on 2026-05-24 to remove the contradictory scope between the two docs.
@@ -381,7 +381,7 @@ The graph reflects what's on disk, not what's in git. Uncommitted changes are in
 
 ## 9. Query surface
 
-Seven commands. Each maps 1:1 to an MCP tool.
+Ten commands. Each maps 1:1 to an MCP tool.
 
 ```
 orbit graph sync [--full]
@@ -392,7 +392,12 @@ orbit graph refs <symbol> [--confidence exact|import|same_module|fuzzy]
 orbit graph callees <symbol>
 orbit graph impact <selector> [--depth N=3] [--confidence exact|import|same_module|fuzzy]
 orbit graph trace <command-name> [--depth N=5] [--confidence exact|import|same_module|fuzzy]
+orbit graph overview [dir:… | file:…] [--format summary|full]
+orbit graph implementors <trait-selector>
+orbit graph deps <file:… | dir:…>
 ```
+
+The agent-facing MCP surface uses these same ten canonical names as an explicit `orbit-cli` safe-surface allowlist. Although `orbit-mcp` executes the graph implementations in-process to retain watcher-backed handles, every call first crosses the host-owned policy/audit seam. The production host performs allowlist preflight inside OrbitRuntime's shared `ToolEntryPoint::Mcp` audit bracket, recording tool name, role, duration, and success/failure; a rejected name never invokes the graph handler. The MCP host asserts at startup that the adapter name set is a subset of the intended safe surface. If a host re-exposes a known graph schema, the adapter schema and policy/audit route remain authoritative rather than falling back based on schema presence. [ORB-10225]
 
 ### 9.1 `search`
 


### PR DESCRIPTION
## Task

[ORB-10225](https://orbit-cli.com/tasks/ORB-10225) — Fix H3: `orbit.graph.*` MCP tools bypass the safe-surface allowlist and the audit trail

### Description

From the pre-release security review (SECURITY-REVIEW-2026-07-15.md, finding H3; combines audit A1 + B1).

**Bug.** `crates/orbit-mcp/src/adapter/dispatch.rs:107-115`, `graph.rs:64-88`, `crates/orbit-cli/src/command/mcp/host.rs:60`. The `orbit.graph.*` tools (including the mutating `orbit.graph.sync` and source-disclosing `orbit.graph.show`) are served by an in-process adapter that activates precisely because the host exposes no graph schema. Dispatch goes straight to `graph_tools.call_tool` and never reaches `is_mcp_tool_exposed` (the allowlist) or `execute_tool_command_dispatch` (the sole audit-writing seam).

**Impact.** (1) A whole tool category sits outside the documented safe-surface allowlist. (2) Graph MCP calls produce NO audit record — an omission path, squarely in SECURITY.md scope. The gate is a fragile double-negative that fails open toward the host path if a graph schema is ever re-exposed.

**Fix.** Route graph dispatch through the same allowlist + audit bracket as the host path: add an explicit `GRAPH_*_TOOL_NAMES` set that `is_mcp_tool_exposed` checks, and wrap `graph_tools.call_tool` in the audit bracket (record success/failure with `ToolEntryPoint::Mcp`, tool name, duration, role). At minimum assert at startup that the graph-tool name set is a subset of the intended safe surface.

**Acceptance.** Graph MCP calls appear in the audit trail (success + failure); a graph tool not on the allowlist is rejected at the MCP seam; test that re-exposing a graph schema does not silently disable the allowlist check.

### Acceptance Criteria



## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Added all ten in-process graph MCP names to the explicit CLI safe surface, with a production-startup subset assertion against the adapter-owned name set.
- Added a secure-by-default McpHost in-process dispatch seam and routed graph calls through RuntimeMcpHost allowlist preflight plus the shared ToolEntryPoint::Mcp runtime audit bracket.
- Extracted OrbitRuntime's common audit bracket so registry-backed and adapter-owned tool implementations record the same tool name, role, duration, status, and correlation fields without cross-crate audit-code duplication.
- Removed schema-presence dispatch gating for known graph tools: adapter schemas replace re-exposed known host schemas, while unknown host graph names remain on the allowlisted/audited host path.
- Added adapter, host, and production stdio coverage for schema re-exposure, allowlist rejection, and persisted graph success/failure audit rows; custom test hosts now opt into in-process graph execution explicitly.
- Updated the auditability and orbit-graph design contracts to document the ten-tool surface and the host-owned policy/audit seam.
Validation:
- make ci-fast
- cargo clippy -p orbit-core -p orbit-mcp -p orbit-cli --tests -- -D warnings
- cargo test -p orbit-mcp (37 unit + 6 wire integration tests)
- cargo test -p orbit-core command::tool::audit_tests (19 tests; managed identity env cleared)
- cargo test -p orbit-cli command::mcp::tests (12 tests; managed identity env cleared)
- cargo test -p orbit-cli --test mcp_roundtrip (4 production stdio tests; managed identity env cleared)
Assessment: Acceptance criteria are covered end to end. Known graph calls cannot bypass the host seam when schemas are re-exposed, unallowlisted graph names are rejected and audited, and both successful and failed graph implementations persist one MCP audit row. The McpHost default now rejects adapter-owned tools until a custom host explicitly supplies policy, which is the intended secure default.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10225-6a584414`
- Behind base: 0
- Ahead of base: 1

*authored by: codex*