### PR TITLE
Propagate re-executed step outputs during job resume

### DIFF
--- a/.orbit/learnings/L-0091/learning.yaml
+++ b/.orbit/learnings/L-0091/learning.yaml
@@ -1,0 +1,19 @@
+schema_version: 1
+id: L-0091
+status: active
+scope:
+  paths:
+  - crates/orbit-engine/src/activity_job/job_executor/**/*.rs
+  tags:
+  - workflow
+  - resume
+  - templating
+summary: Preserve the source JSON type when an exact job template forwards `steps.*` output; numeric-looking strings such as PR numbers must not be reparsed as numbers.
+body: Exact step-output templates are typed data forwarding, not string interpolation. ORB-10241 showed that rendering `"618"` to text and parsing it back produced numeric `618`; the downstream string validator then reported `pr_number` as missing even though the resumed checkpoint contained it. Keep interpolated strings on the text-render path, but return the underlying JSON value for an exact `steps.<id>.output...` reference.
+evidence:
+- kind: task
+  reference: ORB-10241
+created_at: 2026-07-16T06:49:23.704086543Z
+updated_at: 2026-07-16T06:49:23.704086543Z
+created_by: codex
+priority: 100

--- a/crates/orbit-core/src/command/job/exec.rs
+++ b/crates/orbit-core/src/command/job/exec.rs
@@ -1476,6 +1476,18 @@ spec:
             resumed.retry_source_run_id.as_deref(),
             Some(run.run_id.as_str())
         );
+        let resumed_state = runtime
+            .read_run_state(&result.run_id)
+            .expect("read resumed checkpoint")
+            .expect("resumed checkpoint exists");
+        assert_eq!(resumed_state.step_states.len(), 3);
+        assert_eq!(resumed_state.step_outputs.len(), 3);
+        assert_eq!(
+            resumed_state.pipeline.get("nap0"),
+            Some(&json!({"checkpointed": true}))
+        );
+        assert!(resumed_state.pipeline.get("nap1").is_some());
+        assert!(resumed_state.pipeline.get("nap2").is_some());
 
         // Step 0 was NOT re-executed: it is audited as skipped-for-resume and
         // never started; steps 1 and 2 started for real.
@@ -1503,6 +1515,13 @@ spec:
         // Source run stays interrupted; resume never mutates its history.
         let source_after = runtime.show_job_run(&run.run_id).expect("show source");
         assert_eq!(source_after.state, JobRunState::Interrupted);
+        let source_state_after = runtime
+            .read_run_state(&run.run_id)
+            .expect("read source checkpoint")
+            .expect("source checkpoint exists");
+        assert_eq!(source_state_after.step_states.len(), 1);
+        assert!(source_state_after.pipeline.get("nap1").is_none());
+        assert!(source_state_after.pipeline.get("nap2").is_none());
     }
 
     /// [ORB-10002] Resume refuses runs that are not interrupted / failed /

--- a/crates/orbit-engine/src/activity_job/job_executor/mod.rs
+++ b/crates/orbit-engine/src/activity_job/job_executor/mod.rs
@@ -155,7 +155,7 @@ pub fn execute_job_with_resume(
         audit: audit.clone(),
         host,
         input: base_input.clone(),
-        pipeline: Arc::new(Mutex::new(seed_pipeline_from_resume(resume))),
+        pipeline: Arc::new(Mutex::new(seed_pipeline_from_resume(job, resume))),
         sessions: Arc::new(Mutex::new(HashMap::new())),
         recovery_activity,
         item: None,
@@ -210,17 +210,31 @@ pub fn execute_job_with_resume(
     })
 }
 
-/// [ORB-10002] Seed the executor pipeline map from a resume snapshot so
-/// skipped steps' outputs stay visible to later steps.
-fn seed_pipeline_from_resume(resume: Option<&PipelineState>) -> HashMap<String, Value> {
-    resume
-        .and_then(|state| state.pipeline.as_object())
-        .map(|map| {
-            map.iter()
-                .map(|(key, value)| (key.clone(), value.clone()))
-                .collect()
+/// [ORB-10002] Seed the executor pipeline map from successful checkpoints so
+/// skipped steps' outputs stay visible without exposing failed/timed-out data.
+fn seed_pipeline_from_resume(
+    job: &JobV2,
+    resume: Option<&PipelineState>,
+) -> HashMap<String, Value> {
+    let Some(state) = resume else {
+        return HashMap::new();
+    };
+
+    job.steps
+        .iter()
+        .enumerate()
+        .filter_map(|(index, step)| {
+            let step_index = index as u32;
+            if state.step_states.get(&step_index) != Some(&JobRunState::Success) {
+                return None;
+            }
+            state
+                .step_outputs
+                .get(&step_index)
+                .cloned()
+                .map(|output| (step.id.clone(), output))
         })
-        .unwrap_or_default()
+        .collect()
 }
 
 /// [ORB-10002] True when the resume snapshot records this top-level step as

--- a/crates/orbit-engine/src/activity_job/job_executor/templating.rs
+++ b/crates/orbit-engine/src/activity_job/job_executor/templating.rs
@@ -44,6 +44,14 @@ pub(super) fn render_items_expression(
 pub(super) fn render_value(v: &Value, tctx: &TemplateContext) -> Result<Value, DispatchError> {
     match v {
         Value::String(s) if s.contains("{{") => {
+            // L-0091: Exact step-output templates forward typed JSON values.
+            // ORB-10241: Preserve the source JSON type for an exact step-output
+            // reference. Rendering through text and parsing it again turns a
+            // string such as PR number "618" into the number 618, which then
+            // fails downstream string validation despite being present.
+            if let Some(value) = exact_step_template_value(s, tctx) {
+                return Ok(value);
+            }
             let rendered = template::render(s, tctx)
                 .map_err(|err| DispatchError::JobExecution(format!("template render: {err}")))?;
             // Try to parse back to a JSON value (numbers, bools, arrays);
@@ -63,4 +71,27 @@ pub(super) fn render_value(v: &Value, tctx: &TemplateContext) -> Result<Value, D
         }
         _ => Ok(v.clone()),
     }
+}
+
+fn exact_step_template_value(template: &str, tctx: &TemplateContext) -> Option<Value> {
+    let token = template.strip_prefix("{{")?.strip_suffix("}}")?.trim();
+    if token.contains("{{") || token.contains("}}") {
+        return None;
+    }
+
+    let mut path = token.split('.');
+    if path.next()? != "steps" {
+        return None;
+    }
+    let step_id = path.next()?;
+    let namespace = path.next()?;
+    if namespace != "output" && namespace != "state" {
+        return None;
+    }
+
+    let mut value = tctx.steps.get(step_id)?.get(namespace)?;
+    for segment in path {
+        value = value.get(segment)?;
+    }
+    Some(value.clone())
 }

--- a/crates/orbit-engine/src/activity_job/job_executor/tests/resume.rs
+++ b/crates/orbit-engine/src/activity_job/job_executor/tests/resume.rs
@@ -16,6 +16,7 @@ use super::*;
 struct CheckpointHost {
     inner: ScriptedHost,
     checkpoints: StdMutex<Vec<(u32, String, Value, Value)>>,
+    inputs: StdMutex<Vec<(String, Value)>>,
     fail_checkpoints: bool,
 }
 
@@ -24,6 +25,7 @@ impl CheckpointHost {
         Self {
             inner,
             checkpoints: StdMutex::new(Vec::new()),
+            inputs: StdMutex::new(Vec::new()),
             fail_checkpoints: false,
         }
     }
@@ -38,6 +40,17 @@ impl CheckpointHost {
     fn checkpoints(&self) -> Vec<(u32, String, Value, Value)> {
         self.checkpoints.lock().expect("checkpoints").clone()
     }
+
+    fn inputs_for(&self, action: &str) -> Vec<Value> {
+        self.inputs
+            .lock()
+            .expect("inputs")
+            .iter()
+            .filter_map(|(recorded_action, input)| {
+                (recorded_action == action).then_some(input.clone())
+            })
+            .collect()
+    }
 }
 
 impl V2RuntimeHost for CheckpointHost {
@@ -48,6 +61,10 @@ impl V2RuntimeHost for CheckpointHost {
         input: &Value,
         tool_context: orbit_tools::ToolContext,
     ) -> Result<Value, DispatchError> {
+        self.inputs
+            .lock()
+            .expect("inputs")
+            .push((action.to_string(), input.clone()));
         self.inner
             .run_deterministic(action, config, input, tool_context)
     }
@@ -225,6 +242,109 @@ fn resume_skips_checkpointed_steps_and_feeds_their_outputs() {
     assert_eq!(
         checkpoints[0].3.get("s0"),
         Some(&json!({"v": "checkpointed-0"}))
+    );
+}
+
+#[test]
+fn resume_reexecuted_pr_output_reaches_promotion_and_checkpoint() {
+    // ORB-10241 / ORB-10240 incident shape: push completed in the source
+    // attempt, pr_open failed, then resume skips push, re-executes pr_open,
+    // and renders its numeric-looking string output into pr_promote.
+    let host = CheckpointHost::new(ScriptedHost::new([
+        ("git_push", vec![Action::Ok(json!({"pushed": "again"}))]),
+        (
+            "pr_open",
+            vec![Action::Ok(json!({
+                "pr_number": "618",
+                "pr_url": "https://github.example/pull/618",
+            }))],
+        ),
+        ("pr_promote", vec![Action::Ok(json!({"promoted": true}))]),
+    ]));
+    let mut promote = target_step("promote_tasks", "pr_promote");
+    promote.when = Some("{{ steps.pr_open.output.pr_number }} == 618".to_string());
+    let JobV2StepBody::Target(target) = &mut promote.body else {
+        panic!("target step");
+    };
+    target.default_input = Some(json!({
+        "pr_number": "{{ steps.pr_open.output.pr_number }}",
+        "pr_url": "{{ steps.pr_open.output.pr_url }}",
+    }));
+    let job = job_with_steps(vec![
+        target_step("push", "git_push"),
+        target_step("pr_open", "pr_open"),
+        promote,
+    ]);
+    let mut resume = resume_state_with_completed_steps(&[(0, "push", json!({"pushed": true}))]);
+    resume.record_step(
+        1,
+        JobRunState::Failed,
+        Some(json!({"pr_number": "stale"})),
+        None,
+    );
+    resume.sync_pipeline(json!({
+        "push": {"pushed": true},
+        "pr_open": {"pr_number": "stale"},
+    }));
+    let writer = std::sync::Arc::new(test_writer("run-resume-pr-open"));
+
+    let outcome = execute_job_with_resume(
+        &job,
+        Value::Null,
+        "run-resume-pr-open",
+        writer,
+        &host,
+        Some(&resume),
+    )
+    .expect("resume succeeds through promotion");
+
+    assert!(outcome.success);
+    assert_eq!(host.inner.call_count("git_push"), 0);
+    assert_eq!(host.inner.call_count("pr_open"), 1);
+    assert_eq!(host.inner.call_count("pr_promote"), 1);
+    assert_eq!(
+        host.inputs_for("pr_promote"),
+        vec![json!({
+            "pr_number": "618",
+            "pr_url": "https://github.example/pull/618",
+            "run_id": "run-resume-pr-open",
+        })],
+        "fresh pr_open output retains its string type for downstream input",
+    );
+
+    let checkpoints = host.checkpoints();
+    assert_eq!(checkpoints.len(), 2);
+    assert_eq!(checkpoints[0].0, 1);
+    assert_eq!(checkpoints[0].1, "pr_open");
+    assert_eq!(checkpoints[0].2["pr_number"], json!("618"));
+    assert_eq!(checkpoints[0].3["pr_open"]["pr_number"], json!("618"));
+    assert_eq!(resume.step_states.get(&1), Some(&JobRunState::Failed));
+}
+
+#[test]
+fn resume_seed_uses_only_successful_checkpoint_outputs() {
+    let job = job_with_steps(vec![
+        target_step("success", "a0"),
+        target_step("failed", "a1"),
+        target_step("timed_out", "a2"),
+    ]);
+    let mut resume = PipelineState::new(
+        "jrun-source".to_string(),
+        "qa_resume".to_string(),
+        Value::Object(Default::default()),
+    );
+    resume.record_step(0, JobRunState::Success, Some(json!({"v": 0})), None);
+    resume.record_step(1, JobRunState::Failed, Some(json!({"v": 1})), None);
+    resume.record_step(2, JobRunState::Timeout, Some(json!({"v": 2})), None);
+    resume.sync_pipeline(json!({
+        "success": {"v": 0},
+        "failed": {"v": 1},
+        "timed_out": {"v": 2},
+    }));
+
+    assert_eq!(
+        seed_pipeline_from_resume(&job, Some(&resume)),
+        HashMap::from([("success".to_string(), json!({"v": 0}))]),
     );
 }
 


### PR DESCRIPTION
## Task

[ORB-10241](https://orbit-cli.com/tasks/ORB-10241) — Propagate re-executed step outputs during job resume

### Description

## Problem
A resumed v2 job can successfully re-execute the source run's failed step but fail the immediately following step because the new output is unavailable to downstream template resolution.

## Observed Evidence
- ORB-10240 source run `jrun-20260716-0544-3` failed at `pr_open` after all earlier implementation, validation, commit, sync, and push checkpoints had succeeded.
- Resuming that exact checkpoint with the branch-built fixed binary created resume run `jrun-20260716-0555-2`.
- The resumed run skipped the previously successful checkpoints and successfully completed `pr_open`, creating GitHub PR #618 and returning its PR metadata.
- The next `pr_promote` step failed with `missing required input.pr_number`, even though its input is derived from `steps.pr_open.output.pr_number`.
- No duplicate PR was created and no implementation/validation step failed; manual lifecycle repair was required.

## Why It Matters
Durable resume promises that completed checkpoints are skipped while the failed step and its downstream dependents continue normally. Losing the just-re-executed step output makes recovery fail after the original blocker is repaired and can strand otherwise-landable PR-mode tasks.

## Constraints / Notes
- Preserve source-run immutability and retry provenance.
- Continue to pre-seed outputs only for checkpointed successful steps; do not expose stale outputs from failed/timed-out steps.
- A re-executed step's output must be visible to later steps in the same resumed run and persisted in the resumed run's checkpoint state.
- Preserve idempotency: resuming after an externally successful PR creation must not create duplicate PRs.

### Acceptance Criteria

- A regression reproduces the ORB-10240 shape: a source run has earlier successful checkpoints and a failed `pr_open`; on resume, `pr_open` re-executes successfully and the following `pr_promote` input resolves `steps.pr_open.output.pr_number` without manual injection.
- Outputs from steps re-executed successfully during a resumed run are available to all downstream template and condition evaluation in that same run and are persisted in the resumed run's pipeline checkpoint.
- Checkpointed successful steps remain skipped with their recorded outputs pre-seeded, while failed/timed-out step outputs are not reused as stale input.
- Resume preserves source-run history, retry provenance, and idempotency, including no duplicate PR creation in the post-create recovery case.
- Focused orbit-engine resume tests, the task-pr-pipeline regression, formatting/diff checks, and `make ci-fast` pass.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Resume seeding now rebuilds the live pipeline only from top-level checkpoints recorded as successful, keyed by the current job step IDs; failed and timed-out raw outputs are excluded.
- Exact `steps.*` output templates now forward the underlying typed JSON value. This preserves numeric-looking strings such as `pr_open.pr_number = "618"` instead of coercing them to a JSON number that `pr_promote` rejects as missing.
- Added the ORB-10240-shaped regression: prior push is skipped, failed `pr_open` executes exactly once, its fresh output drives both a downstream condition and `pr_promote` input, cumulative checkpoints contain the fresh PR metadata, and the source snapshot remains unchanged.
- Strengthened the persisted-run resume regression to verify retry provenance, full resumed checkpoint persistence, and source-run immutability. Recorded the reusable typed-template guardrail as L-0091.

Validation:
- `cargo test -p orbit-engine activity_job::job_executor::tests::resume --lib` (8 passed)
- `cargo test -p orbit-engine activity_job::job_executor::tests::templating --lib` (1 passed)
- `cargo test -p orbit-core command::job::exec::tests::interrupted_run_resumes_skipping_checkpointed_steps --lib` (1 passed)
- `cargo test -p orbit-core command::job::catalog::tests::pr_pipeline_models_handoff_phases_as_ordered_activity_checkpoints --lib` (1 passed)
- `cargo clippy -p orbit-engine -p orbit-core --lib --tests -- -D warnings`
- `cargo fmt --all --check`
- `git diff --check`
- `make ci-fast`

Deviations from original plan:
- `crates/orbit-engine/src/activity_job/job_executor/templating.rs` was added to scope after the live run checkpoint proved the output was present but its numeric-looking string type was lost during exact-template rendering; this extension was recorded in a task comment before editing.

Assessment: resumed execution now exposes only valid prior checkpoints, preserves newly produced output types for downstream evaluation, persists cumulative resumed state, and retains retry/source provenance without replaying completed PR phases.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10241-6a587cc3`
- Behind base: 0
- Ahead of base: 1