### PR TITLE
Accept host registry and freeze MCP bridge implementation contract

### DIFF
--- a/.orbit/adrs/accepted/ADR-0226/adr.yaml
+++ b/.orbit/adrs/accepted/ADR-0226/adr.yaml
@@ -1,0 +1,25 @@
+schema_version: 2
+id: ADR-0226
+title: Singular coordination hub, workspace owner, and per-run placement
+status: accepted
+owner: codex
+created_at: 2026-07-17T07:02:53.852664975Z
+accepted_at: 2026-07-17T07:03:25.976551336Z
+last_updated: 2026-07-17T07:03:25.976551336Z
+related_features:
+- host-registry
+- mcp-bridge
+related_tasks:
+- ORB-10245
+tags:
+- coordination
+- ownership
+- placement
+- v1
+paths:
+- docs/design/host-registry/**
+- docs/design/mcp-bridge/**
+supersedes: []
+legacy_ids: []
+validation_warnings: []
+legacy_validation: none

--- a/.orbit/adrs/accepted/ADR-0226/body.md
+++ b/.orbit/adrs/accepted/ADR-0226/body.md
@@ -1,0 +1,7 @@
+## Context
+Cross-machine work needs a coordination authority, a knowledge author, and an execution destination; treating them as the same authority would scatter task state or make ownership implicit.
+## Decision
+Use exactly one coordination hub for every workspace, declare one workspace owner, and select execution placement per run with the owner as the default.
+## Consequences
+- Coordination writes remain hub-routed while knowledge authorship remains owner-bound.
+- Cost: hub downtime stalls coordination for every workspace, and disconnected machines cannot write coordination records.

--- a/.orbit/adrs/accepted/ADR-0227/adr.yaml
+++ b/.orbit/adrs/accepted/ADR-0227/adr.yaml
@@ -1,0 +1,25 @@
+schema_version: 2
+id: ADR-0227
+title: Stable machine identity, registry, and out-of-band hub pin
+status: accepted
+owner: codex
+created_at: 2026-07-17T07:03:20.499802205Z
+accepted_at: 2026-07-17T07:03:26.175980952Z
+last_updated: 2026-07-17T07:03:26.175980952Z
+related_features:
+- host-registry
+- mcp-bridge
+related_tasks:
+- ORB-10245
+tags:
+- identity
+- registry
+- transport-trust
+- v1
+paths:
+- docs/design/host-registry/**
+- docs/design/mcp-bridge/**
+supersedes: []
+legacy_ids: []
+validation_warnings: []
+legacy_validation: none

--- a/.orbit/adrs/accepted/ADR-0227/body.md
+++ b/.orbit/adrs/accepted/ADR-0227/body.md
@@ -1,0 +1,7 @@
+## Context
+Hostname-derived strings and per-workspace transport targets can silently redirect a machine or elevate repository configuration.
+## Decision
+Assign every machine an immutable generated machine_id, keep the registry at the hub, and pin the one hub machine_id out of band in machine-local mcp.toml.
+## Consequences
+- Names resolve once at binding time and persisted records retain the stable identity.
+- Cost: bootstrap transfers the hub identity out of band and registry/trust drift requires explicit diagnosis.

--- a/.orbit/adrs/accepted/ADR-0228/adr.yaml
+++ b/.orbit/adrs/accepted/ADR-0228/adr.yaml
@@ -1,0 +1,24 @@
+schema_version: 2
+id: ADR-0228
+title: Local placement broker with capability-set filtering
+status: accepted
+owner: codex
+created_at: 2026-07-17T07:03:20.635772421Z
+accepted_at: 2026-07-17T07:03:26.373231737Z
+last_updated: 2026-07-17T07:03:26.373231737Z
+related_features:
+- mcp-bridge
+- host-registry
+related_tasks:
+- ORB-10245
+tags:
+- broker
+- placement
+- capabilities
+- v1
+paths:
+- docs/design/mcp-bridge/**
+supersedes: []
+legacy_ids: []
+validation_warnings: []
+legacy_validation: none

--- a/.orbit/adrs/accepted/ADR-0228/body.md
+++ b/.orbit/adrs/accepted/ADR-0228/body.md
@@ -1,0 +1,7 @@
+## Context
+A single remote MCP target must preserve local graph/doc behavior and must not equate tool placement with caller privilege.
+## Decision
+Make the client-facing MCP process a local placement broker whose canonical tools declare hub, owner, local-derived, or composite placement and whose effective capability set is independently filtered.
+## Consequences
+- Tool schemas have one placement and a non-empty allowed capability set.
+- Cost: the broker owns route preflight, composite auditing, and capability-by-placement conformance coverage.

--- a/.orbit/adrs/accepted/ADR-0229/adr.yaml
+++ b/.orbit/adrs/accepted/ADR-0229/adr.yaml
@@ -1,0 +1,26 @@
+schema_version: 2
+id: ADR-0229
+title: Owner-authored knowledge with hub-global IDs and explicit replicas
+status: accepted
+owner: codex
+created_at: 2026-07-17T07:03:20.765693706Z
+accepted_at: 2026-07-17T07:03:26.566162787Z
+last_updated: 2026-07-17T07:03:26.566162787Z
+related_features:
+- host-registry
+- mcp-bridge
+related_tasks:
+- ORB-10245
+tags:
+- knowledge
+- ownership
+- replicas
+- ids
+- v1
+paths:
+- docs/design/host-registry/**
+- docs/design/mcp-bridge/**
+supersedes: []
+legacy_ids: []
+validation_warnings: []
+legacy_validation: none

--- a/.orbit/adrs/accepted/ADR-0229/body.md
+++ b/.orbit/adrs/accepted/ADR-0229/body.md
@@ -1,0 +1,7 @@
+## Context
+Knowledge needs globally allocated identifiers without making a hub checkout or a stale replica a second author.
+## Decision
+The hub allocates global IDs, the declared owner authors current knowledge, and Git replicas are opt-in reads marked as replicas; the hub never proxies to a spoke owner.
+## Consequences
+- A non-owner agent files work for the owner rather than writing through a new route.
+- Cost: finalize failures consume valid-but-unused IDs and current spoke-owned knowledge is unavailable off-owner.

--- a/.orbit/adrs/accepted/ADR-0230/adr.yaml
+++ b/.orbit/adrs/accepted/ADR-0230/adr.yaml
@@ -1,0 +1,26 @@
+schema_version: 2
+id: ADR-0230
+title: Pull-based leases with immutable placement and explicit recovery
+status: accepted
+owner: codex
+created_at: 2026-07-17T07:03:20.898467960Z
+accepted_at: 2026-07-17T07:03:26.764043581Z
+last_updated: 2026-07-17T07:03:26.764043581Z
+related_features:
+- host-registry
+- mcp-bridge
+related_tasks:
+- ORB-10245
+tags:
+- leases
+- placement
+- recovery
+- runner
+- v1
+paths:
+- docs/design/host-registry/**
+- docs/design/mcp-bridge/**
+supersedes: []
+legacy_ids: []
+validation_warnings: []
+legacy_validation: none

--- a/.orbit/adrs/accepted/ADR-0230/body.md
+++ b/.orbit/adrs/accepted/ADR-0230/body.md
@@ -1,0 +1,7 @@
+## Context
+A hub-push executor model would require outbound spoke routing and makes retries obscure the placement actually selected and leased.
+## Decision
+Spokes poll the hub for placed runs; requested and actual placement are immutable, pre-start loss returns a run for redelivery, and post-start uncertainty requires explicit recovery.
+## Consequences
+- The hub is a mailbox and never opens a route to a spoke.
+- Cost: pickup latency follows poll cadence and an interrupted started run requires operator/shepherd recovery rather than silent reassignment.

--- a/.orbit/adrs/accepted/ADR-0231/adr.yaml
+++ b/.orbit/adrs/accepted/ADR-0231/adr.yaml
@@ -1,0 +1,24 @@
+schema_version: 2
+id: ADR-0231
+title: Committed-routine ownership with host-local cursors
+status: accepted
+owner: codex
+created_at: 2026-07-17T07:03:21.036752848Z
+accepted_at: 2026-07-17T07:03:26.898178732Z
+last_updated: 2026-07-17T07:03:26.898178732Z
+related_features:
+- host-registry
+related_tasks:
+- ORB-10245
+tags:
+- routines
+- ownership
+- cursor
+- v1
+paths:
+- docs/design/host-registry/**
+- docs/design/routines/**
+supersedes: []
+legacy_ids: []
+validation_warnings: []
+legacy_validation: none

--- a/.orbit/adrs/accepted/ADR-0231/body.md
+++ b/.orbit/adrs/accepted/ADR-0231/body.md
@@ -1,0 +1,7 @@
+## Context
+Git-committed routines converge to many checkouts, while scheduler cursors and pauses must remain locally meaningful.
+## Decision
+A committed routine is owned by its registry-validated host pin; unpinned committed routines fail closed, and each host retains its own cursor and pause state.
+## Consequences
+- Reassigning a routine is a reviewed pin change rather than a git-status inference.
+- Cost: handoff starts with no migrated cursor and existing committed routines need explicit pins before enforcement.

--- a/.orbit/adrs/accepted/ADR-0232/adr.yaml
+++ b/.orbit/adrs/accepted/ADR-0232/adr.yaml
@@ -1,0 +1,23 @@
+schema_version: 2
+id: ADR-0232
+title: Retire Bridge’s Orbit-shaped contract
+status: accepted
+owner: codex
+created_at: 2026-07-17T07:03:21.165568788Z
+accepted_at: 2026-07-17T07:03:27.035875019Z
+last_updated: 2026-07-17T07:03:27.035875019Z
+related_features:
+- mcp-bridge
+related_tasks:
+- ORB-10245
+tags:
+- bridge
+- contract
+- retirement
+- v1
+paths:
+- docs/design/mcp-bridge/**
+supersedes: []
+legacy_ids: []
+validation_warnings: []
+legacy_validation: none

--- a/.orbit/adrs/accepted/ADR-0232/body.md
+++ b/.orbit/adrs/accepted/ADR-0232/body.md
@@ -1,0 +1,7 @@
+## Context
+Bridge parity duplicated Orbit schemas, errors, and workflow declarations despite Orbit being the canonical domain owner.
+## Decision
+Retire Bridge’s Orbit-shaped contract after Orbit MCP reaches parity; Bridge remains only for its non-Orbit constellation domains.
+## Consequences
+- Clients register Orbit and Bridge side by side during migration.
+- Cost: cutover temporarily maintains two client registrations and requires deleting a compatibility layer rather than extending it.

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -52,6 +52,8 @@ a conservative title/status fallback.
 | [Auto-tasks](./design/auto-tasks/1_overview.md) | Dynamically-defined recurring task templates minted by one generic scheduler routine — periodic work as data, not code. | Accepted | claude |
 | [Executors](./design/executors/4_decisions.md) | ADR log for executor registration and the External Executor Protocol. | Draft | claude |
 | [Groundhog](./design/groundhog/1_overview.md) | Groundhog is Orbit's checkpoint-oriented execution mode for HTTP-backed coding agents. | Draft | codex |
+| [Host Registry](./design/host-registry/1_overview.md) | First-class, validated machine identity plus a main-host inventory, enabling pull-based orchestrator-selected execution placement and a strict per-record data-placement split. | Accepted | claude |
+| [Orbit MCP Bridge](./design/mcp-bridge/1_overview.md) | One canonical local Orbit MCP front door that routes coordination to a single hub, keeps owner-authored knowledge and derived indexes local, and removes Bridge's duplicated Orbit parity layer. | Accepted | codex |
 | [MCP Session Context](./design/mcp-session-context/1_overview.md) | MCP session context lets an MCP client announce the canonical Orbit workspace once during session initialization so workspace-taking tools can behave more like CLI commands without falling back to unsafe process cwd inference. | Draft | codex |
 | [Orbit Core](./design/orbit-core/1_overview.md) | Crate boundary and public-surface contract of orbit-core after the ORB-10016 orbit-cmd extraction. | Accepted | claude |
 | [Orbit Docs](./design/orbit-docs/1_overview.md) | Orbit Docs — what the human-authored docs corpus is, why it exists alongside learnings and ADRs, and how agents retrieve from it. | Draft | claude |

--- a/docs/design/host-registry/1_overview.md
+++ b/docs/design/host-registry/1_overview.md
@@ -1,8 +1,8 @@
 ---
 title: Host Registry — Overview
 owner: claude
-last_updated: 2026-07-16
-status: Draft
+last_updated: 2026-07-17
+status: Accepted
 feature: host-registry
 doc_role: overview
 type: design
@@ -10,7 +10,7 @@ summary: First-class, validated machine identity plus a main-host inventory, ena
 tags: [host-registry, multi-host, dispatch, routines]
 paths: ["crates/orbit-core/**", "crates/orbit-store/**", "crates/orbit-mcp/**", "crates/orbit-common/**"]
 related_features: [host-registry, mcp-bridge, routines, remote-access]
-related_artifacts: [ORB-00424, ADR-0200, ADR-0205, ADR-0208]
+related_artifacts: [ORB-00424, ADR-0200, ADR-0205, ADR-0208, ADR-0226, ADR-0227, ADR-0228, ADR-0229, ADR-0230, ADR-0231, ADR-0232]
 ---
 
 # Host Registry — Overview

--- a/docs/design/host-registry/2_design.md
+++ b/docs/design/host-registry/2_design.md
@@ -1,8 +1,8 @@
 ---
 title: Host Registry — Design
 owner: claude
-last_updated: 2026-07-16
-status: Draft
+last_updated: 2026-07-17
+status: Accepted
 feature: host-registry
 doc_role: design
 type: design
@@ -10,13 +10,13 @@ summary: Target mechanisms for host identity, the main-host registry, the coordi
 tags: [host-registry, multi-host, dispatch, routines, data-placement]
 paths: ["crates/orbit-core/**", "crates/orbit-store/**", "crates/orbit-mcp/**", "crates/orbit-common/**"]
 related_features: [host-registry, mcp-bridge, routines, remote-access, mcp-session-context]
-related_artifacts: [ORB-00424, ADR-0200, ADR-0205, ADR-0208]
+related_artifacts: [ORB-00424, ADR-0200, ADR-0205, ADR-0208, ADR-0226, ADR-0227, ADR-0228, ADR-0229, ADR-0230, ADR-0231, ADR-0232]
 ---
 
 # Host Registry — Design
 
 This doc specifies the **target** design; nothing here has landed and the folder is
-Draft. It covers host identity, the registry, the coordination-plane/workspace-
+Accepted. It covers host identity, the registry, the coordination-plane/workspace-
 ownership split, execution placement (including the hub→satellite protocol), the
 per-record data-placement split, and the revision to routine sweep ownership. It
 leaves client→hub transport to the [MCP bridge](../mcp-bridge/2_design.md)

--- a/docs/design/host-registry/3_vision.md
+++ b/docs/design/host-registry/3_vision.md
@@ -1,8 +1,8 @@
 ---
 title: Host Registry — Vision
 owner: claude
-last_updated: 2026-07-16
-status: Draft
+last_updated: 2026-07-17
+status: Accepted
 feature: host-registry
 doc_role: vision
 type: design
@@ -10,7 +10,7 @@ summary: Open questions (non-owner knowledge authoring, label taxonomy, ownershi
 tags: [host-registry, multi-host, dispatch]
 paths: ["crates/orbit-core/**", "crates/orbit-store/**", "crates/orbit-mcp/**"]
 related_features: [host-registry, mcp-bridge, routines, remote-access]
-related_artifacts: [ORB-00424]
+related_artifacts: [ORB-00424, ADR-0226, ADR-0227, ADR-0228, ADR-0229, ADR-0230, ADR-0231, ADR-0232]
 ---
 
 # Host Registry — Vision

--- a/docs/design/host-registry/4_decisions.md
+++ b/docs/design/host-registry/4_decisions.md
@@ -1,72 +1,164 @@
 ---
 title: Host Registry — Decisions
 owner: claude
-last_updated: 2026-07-16
-status: Draft
+last_updated: 2026-07-17
+status: Accepted
 feature: host-registry
 doc_role: decisions
 type: design
-summary: ADR log for the host-registry feature; no ADRs allocated yet — candidate decisions listed pending acceptance of the design.
-tags: [host-registry]
+summary: Accepted ADR log for the coupled Host Registry and MCP Bridge v1 contract.
+tags: [host-registry, mcp-bridge, multi-host, placement]
 paths: ["crates/orbit-core/**", "crates/orbit-store/**", "crates/orbit-mcp/**"]
 related_features: [host-registry, mcp-bridge]
-related_artifacts: [ADR-0200, ADR-0205, ADR-0208]
+related_artifacts: [ORB-00424, ORB-10245, ADR-0226, ADR-0227, ADR-0228, ADR-0229, ADR-0230, ADR-0231, ADR-0232]
 ---
 
 # Host Registry — Decisions
 
-ADR log for `host-registry`. Entries are append-only and ordered by ascending global
-ID. **Allocate the global `ADR-NNNN` via `orbit.adr.add` before writing the
-heading** — never hand-author a four-digit number. The store owns ID, status, owner,
-and links; this file is the long-form narrative keyed on that same ID. See
-[CONVENTIONS.md §4](../CONVENTIONS.md#4-adr-template-strict).
+ADR log for `host-registry`. Entries are append-only and ordered by global ID.
+The Orbit ADR store owns their allocation, status, and task link; this document is
+the long-form feature log. The seven entries below are the complete consolidated
+v1 decision set shared with [mcp-bridge](../mcp-bridge/4_decisions.md).
 
-**No ADRs allocated yet.** The feature is Draft ([2_design.md](./2_design.md)); when
-the design is accepted, the following candidate decisions each appear to clear the
-three-part bar (real alternative, forward constraint, non-trivial cost) and should be
-allocated:
+## ADR-0226 — Singular coordination hub, workspace owner, and per-run placement
 
-1. **The coordination plane is fixed at the main host; workspace ownership is
-   per-machine; placement is per-task.** Alternative: per-workspace coordination
-   authority (task state scattered across owners, one MCP target per machine).
-   Constraint: star topology — exactly one coordination writer, no
-   machine-to-machine routes, ownership a declared binding. Cost: a disconnected
-   machine cannot author coordination records at all, and hub downtime stalls
-   dispatch for every workspace including satellite-owned ones.
-2. **Tasks and frictions are hub-only (MCP from every other machine).**
-   Alternative: store sync (already rejected once, [ADR-0200] — this extends it to
-   writes). Cost: main-host availability becomes a hard dependency for all
-   dispatch.
-3. **Learnings/ADRs are owner-authored with hub-allocated IDs; canonical MCP reads
-   serve hub-owned workspaces; git replicas are explicit, possibly stale reads.**
-   Alternative: one-writer-on-hub (satellite prose travels over MCP into a checkout
-   the author doesn't hold) or a reservation/finalization protocol. Cost:
-   non-owner knowledge authoring is unsupported, and current-state knowledge reads
-   don't span owners.
-4. **Satellite placement is pull-based (lease poll), never hub-push.**
-   Alternative: the hub SSHes to satellites and launches runs. Constraint: the hub
-   is a mailbox — it never opens a connection to a satellite; a new `runner`
-   capability set exists. Cost: placement latency is bounded by poll cadence, and
-   every satellite holds a standing credential against the hub.
-5. **Names resolve at binding time; the system persists `machine_id`.**
-   Alternative: `host_id` strings everywhere (status quo shape). Constraint:
-   renames cannot redirect existing bindings. Cost: the registry carries an
-   append-only tombstone alias table forever, and runs/bindings need dual-field
-   (id + display name) plumbing.
-6. **Requested and actual placement are snapshotted immutably per run.**
-   Alternative: task-level `host` field only. Constraint: retries/rescues
-   re-resolve the preference; history is never rewritten. Cost: placement fields on
-   every run record even in the all-`dk1` common case.
-7. **Unpinned committed routines fail closed; scope by location, not git status.**
-   Alternative: unpinned = main host, or git-status introspection. Cost: every
-   existing committed routine must carry a pin before the lint lands.
-8. **Host identity = generated `machine_id` + renameable `host_id`, initialized by
-   `orbit init`.** Alternative: hostname-derived free string (status quo). Cost:
-   scripted init paths must pass `--host-name` or pre-seed the file.
-9. **Registry is main-host inventory in the global store, separate from client
-   `mcp.toml` trust policy.** Alternative: merge with `mcp.toml` targets. Cost: two
-   places describe hosts, and they can drift.
+**Status:** Accepted · 2026-07 · [ORB-10245] accepted the coupled v1 contract.
+
+### Context
+
+Cross-machine work needs a coordination authority, a knowledge author, and an
+execution destination; making them one authority would scatter task state or make
+ownership implicit.
+
+### Decision
+
+Use exactly one coordination hub for every workspace, declare one workspace owner,
+and select execution placement per run with the owner as the default.
+
+### Consequences
+
+- Coordination writes remain hub-routed while knowledge authorship remains owner-bound.
+- Cost: hub downtime stalls coordination for every workspace, and disconnected machines cannot write coordination records.
+
+## ADR-0227 — Stable machine identity, registry, and out-of-band hub pin
+
+**Status:** Accepted · 2026-07 · [ORB-10245] froze the host identity boundary.
+
+### Context
+
+Hostname-derived strings and per-workspace transport targets can silently redirect a
+machine or elevate repository configuration.
+
+### Decision
+
+Give each machine an immutable generated `machine_id`, keep the registry at the hub,
+and pin the one hub `machine_id` out of band in machine-local `mcp.toml`.
+
+### Consequences
+
+- Names resolve at binding time and persisted records retain stable identity.
+- Cost: bootstrap transfers hub identity out of band, and registry/trust drift needs explicit diagnosis.
+
+## ADR-0228 — Local placement broker with capability-set filtering
+
+**Status:** Accepted · 2026-07 · [ORB-10245] froze tool routing and authorization.
+
+### Context
+
+One remote MCP target must preserve local graph and documentation behavior without
+equating where a tool runs with who may invoke it.
+
+### Decision
+
+Use a local placement broker. Every exposed canonical tool has exactly one of
+`hub`, `owner`, `local-derived`, or `composite` placement and an independently
+filtered non-empty capability set.
+
+### Consequences
+
+- Conformance records placement and allowed capabilities for every exposed tool.
+- Cost: the broker owns route preflight, composite audit, and capability-by-placement coverage.
+
+## ADR-0229 — Owner-authored knowledge with hub-global IDs and explicit replicas
+
+**Status:** Accepted · 2026-07 · [ORB-10245] fixed the one-writer knowledge rule.
+
+### Context
+
+Knowledge needs global IDs without making a hub checkout or a stale replica a second
+author.
+
+### Decision
+
+The hub allocates global IDs, the declared owner authors current knowledge, and Git
+replicas are opt-in reads marked as replicas. The hub never proxies to a spoke owner.
+
+### Consequences
+
+- A non-owner agent routes actionable work as a task to the owner.
+- Cost: finalize failure consumes a valid unused ID, and current spoke-owned knowledge is unavailable off-owner.
+
+## ADR-0230 — Pull-based leases with immutable placement and explicit recovery
+
+**Status:** Accepted · 2026-07 · [ORB-10245] fixed runner delivery semantics.
+
+### Context
+
+A hub-push executor model needs outbound spoke routes and obscures the placement
+selected and leased for a run.
+
+### Decision
+
+Spokes poll the hub for placed runs. Requested and actual placement are immutable;
+pre-start loss permits redelivery, while post-start uncertainty is
+`recovery_required` and needs explicit recovery.
+
+### Consequences
+
+- The hub is a mailbox and never opens a route to a spoke.
+- Cost: pickup latency follows poll cadence and an interrupted started run is not silently reassigned.
+
+## ADR-0231 — Committed-routine ownership with host-local cursors
+
+**Status:** Accepted · 2026-07 · [ORB-10245] fixed routine execution ownership.
+
+### Context
+
+Git-committed routines converge to many checkouts, while scheduler cursor and pause
+state must remain local to the executing host.
+
+### Decision
+
+A committed routine is owned by its registry-validated host pin; unpinned committed
+routines fail closed, and each host retains its own cursor and pause state.
+
+### Consequences
+
+- Reassignment is a reviewed pin change rather than a git-status inference.
+- Cost: handoff starts with no migrated cursor and existing committed routines need explicit pins.
+
+## ADR-0232 — Retire Bridge’s Orbit-shaped contract
+
+**Status:** Accepted · 2026-07 · [ORB-10245] set the cutover boundary.
+
+### Context
+
+Bridge parity duplicates Orbit schemas, errors, and workflow declarations even
+though Orbit is the canonical domain owner.
+
+### Decision
+
+Retire Bridge’s Orbit-shaped contract after Orbit MCP reaches parity; Bridge remains
+for its non-Orbit constellation domains.
+
+### Consequences
+
+- Clients register Orbit and Bridge side by side during migration.
+- Cost: cutover temporarily maintains two registrations and requires deletion of a compatibility layer.
 
 ## Task References
+
+- [ORB-00424] — completed design proposal for canonical Orbit MCP and Bridge parity retirement.
+- [ORB-10245] — accepted the coupled contract and recorded this ADR set.
 
 > Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.

--- a/docs/design/mcp-bridge/1_overview.md
+++ b/docs/design/mcp-bridge/1_overview.md
@@ -1,7 +1,7 @@
 ---
 title: Orbit MCP Bridge — Overview
 owner: codex
-last_updated: 2026-07-16
+last_updated: 2026-07-17
 status: Accepted
 feature: mcp-bridge
 doc_role: overview
@@ -10,7 +10,7 @@ summary: One canonical local Orbit MCP front door that routes coordination to a 
 tags: [mcp, remote-access, host-registry, bridge, multi-host]
 paths: ["crates/orbit-mcp/**", "crates/orbit-cli/src/command/mcp/**", "crates/orbit-core/src/command/tool.rs", "crates/orbit-common/src/types/tool.rs"]
 related_features: [mcp-bridge, host-registry, mcp-session-context, remote-access, orbit-search, orbit-graph]
-related_artifacts: [ORB-00424, ADR-0181, ADR-0199, ADR-0200, ADR-0201]
+related_artifacts: [ORB-00424, ADR-0181, ADR-0199, ADR-0200, ADR-0201, ADR-0226, ADR-0227, ADR-0228, ADR-0229, ADR-0230, ADR-0231, ADR-0232]
 ---
 
 # Orbit MCP Bridge — Overview

--- a/docs/design/mcp-bridge/2_design.md
+++ b/docs/design/mcp-bridge/2_design.md
@@ -1,7 +1,7 @@
 ---
 title: Orbit MCP Bridge — Design
 owner: codex
-last_updated: 2026-07-16
+last_updated: 2026-07-17
 status: Accepted
 feature: mcp-bridge
 doc_role: design
@@ -10,7 +10,7 @@ summary: Target design for a local Orbit MCP broker with one SSH hub link, hub-o
 tags: [mcp, remote-access, host-registry, bridge, ssh, routing]
 paths: ["crates/orbit-mcp/**", "crates/orbit-cli/src/command/mcp/**", "crates/orbit-core/src/command/tool.rs", "crates/orbit-common/src/types/tool.rs"]
 related_features: [mcp-bridge, host-registry, mcp-session-context, remote-access, orbit-search, orbit-graph, project-learnings]
-related_artifacts: [ORB-00424, ADR-0181, ADR-0199, ADR-0200, ADR-0201]
+related_artifacts: [ORB-00424, ADR-0181, ADR-0199, ADR-0200, ADR-0201, ADR-0226, ADR-0227, ADR-0228, ADR-0229, ADR-0230, ADR-0231, ADR-0232]
 ---
 
 # Orbit MCP Bridge — Design

--- a/docs/design/mcp-bridge/3_vision.md
+++ b/docs/design/mcp-bridge/3_vision.md
@@ -1,7 +1,7 @@
 ---
 title: Orbit MCP Bridge — Vision
 owner: codex
-last_updated: 2026-07-16
+last_updated: 2026-07-17
 status: Accepted
 feature: mcp-bridge
 doc_role: vision
@@ -10,7 +10,7 @@ summary: Open questions and prior art for a singular hub MCP link, owner-bound k
 tags: [mcp, remote-access, host-registry, bridge]
 paths: ["crates/orbit-mcp/**", "crates/orbit-cli/src/command/mcp/**", "crates/orbit-core/src/command/tool.rs"]
 related_features: [mcp-bridge, host-registry, mcp-session-context, remote-access, orbit-search]
-related_artifacts: [ORB-00424, ADR-0181, ADR-0199, ADR-0200, ADR-0201]
+related_artifacts: [ORB-00424, ADR-0181, ADR-0199, ADR-0200, ADR-0201, ADR-0226, ADR-0227, ADR-0228, ADR-0229, ADR-0230, ADR-0231, ADR-0232]
 ---
 
 # Orbit MCP Bridge — Vision

--- a/docs/design/mcp-bridge/4_decisions.md
+++ b/docs/design/mcp-bridge/4_decisions.md
@@ -1,78 +1,164 @@
 ---
 title: Orbit MCP Bridge — Decisions
 owner: codex
-last_updated: 2026-07-16
+last_updated: 2026-07-17
 status: Accepted
 feature: mcp-bridge
 doc_role: decisions
 type: design
-summary: ADR log for the MCP bridge feature; no ADRs are allocated yet and candidate hub/owner decisions await coupled design acceptance.
+summary: Accepted ADR log for the coupled MCP Bridge and Host Registry v1 contract.
 tags: [mcp, remote-access, host-registry, bridge]
 paths: ["crates/orbit-mcp/**", "crates/orbit-cli/src/command/mcp/**", "crates/orbit-core/src/command/tool.rs"]
 related_features: [mcp-bridge, host-registry, mcp-session-context, remote-access]
-related_artifacts: [ORB-00424, ADR-0181, ADR-0199, ADR-0200, ADR-0201]
+related_artifacts: [ORB-00424, ORB-10245, ADR-0226, ADR-0227, ADR-0228, ADR-0229, ADR-0230, ADR-0231, ADR-0232]
 ---
 
 # Orbit MCP Bridge — Decisions
 
-ADR log for `mcp-bridge`. Entries are append-only and ordered by ascending global
-ID. **Allocate the global `ADR-NNNN` via `orbit.adr.add` before writing the
-heading** — never hand-author a four-digit number. The store owns ID, status, owner,
-and links; this file is the long-form narrative keyed on that same ID. See
-[CONVENTIONS.md §4](../CONVENTIONS.md#4-adr-template-strict).
+ADR log for `mcp-bridge`. Entries are append-only and ordered by global ID. The
+Orbit ADR store owns allocation, status, and task links; this log records the
+complete seven-decision v1 contract shared with
+[host-registry](../host-registry/4_decisions.md).
 
-**No ADRs allocated yet.** This feature design is Accepted; coupled
-[host-registry](../host-registry/4_decisions.md) remains Draft. After both designs
-are accepted, these candidates appear to clear the real-alternative, forward-
-constraint, and non-trivial-cost bar:
+## ADR-0226 — Singular coordination hub, workspace owner, and per-run placement
 
-1. **Orbit MCP has exactly one cross-machine target: the coordination hub.**
-   Alternative: per-workspace authority/owner routes. Constraint: no spoke-to-spoke
-   connections and no hub proxy to owners. Cost: current knowledge for spoke-owned
-   workspaces is unavailable off-owner except as a Git replica.
-2. **The client-facing MCP process is a local placement broker, not a whole-surface
-   SSH relay.** Alternative: run every tool on the hub. Constraint: tools declare
-   `hub`, `owner`, `local-derived`, or `composite`. Cost: Orbit owns routing,
-   composite operations, and split audit even though there is only one remote link.
-3. **Knowledge is owner-bound; the hub allocates IDs but does not finalize or proxy
-   for spoke owners.** Alternative: all knowledge on the hub or a distributed
-   reservation/finalization protocol. Constraint: an agent non-owner routes
-   authoring as a task to the owner; the explicit human ID-plus-PR path does not
-   enable replica-store writes. Cost: allocation/finalize failure may consume an
-   unused ID, and non-owner current reads do not exist.
-4. **`mcp.toml` grants transport trust to one stable hub `machine_id` only.**
-   Alternative: default/per-workspace targets or transport fields in workspace
-   bindings. Constraint: repo config cannot redirect/elevate, and ownership changes
-   never change MCP transport; the first registration pins an out-of-band-copied
-   hub ID rather than silently trusting the reached process. Cost: the operator must
-   transfer the hub ID during bootstrap, and host-registry/`mcp.toml` drift needs
-   explicit diagnostics.
-5. **Replica knowledge reads are explicit and marked.** Alternative: silently use
-   the local Git checkout whenever current owner state is unreachable. Constraint:
-   search/show never present replica data as current; `kind=all` requires current,
-   explicit replica, or explicit omission. Cost: common cross-machine searches may
-   require an extra consistency choice.
-6. **Capability and placement are orthogonal.** Alternative: assume hub tools are
-   operator-only and local tools are agent-safe. Constraint: `agent`, `operator`,
-   and `runner` filter independently of placement. Cost: conformance coverage spans
-   capability × placement combinations.
-7. **Caller-host and process-host provenance are distinct.** Alternative: retain
-   the executing process hostname only. Constraint: nested hub sessions carry
-   stable caller `machine_id`, and composite knowledge calls correlate hub/local
-   audit. Cost: v1 same-user SSH treats caller identity as trusted provenance, not
-   independently authenticated authorization.
-8. **Owners publish dispatch projections to the hub.** Alternative: the hub reads
-   owner files live or contacts owners during dispatch. Constraint: crew/workflow
-   validation uses one-way published metadata and fails when stale. Cost: another
-   projection lifecycle must be refreshed and diagnosed.
-9. **Bridge retires all Orbit-shaped parity and workflow declarations.**
-   Alternative: retain Bridge permanently as the remote compatibility layer.
-   Constraint: Orbit alone owns `orbit_*` schemas and errors. Cost: clients keep two
-   MCP registrations for Orbit and non-Orbit constellation services.
+**Status:** Accepted · 2026-07 · [ORB-10245] accepted the coupled v1 contract.
+
+### Context
+
+Cross-machine work needs a coordination authority, a knowledge author, and an
+execution destination; making them one authority would scatter task state or make
+ownership implicit.
+
+### Decision
+
+Use exactly one coordination hub for every workspace, declare one workspace owner,
+and select execution placement per run with the owner as the default.
+
+### Consequences
+
+- Coordination writes remain hub-routed while knowledge authorship remains owner-bound.
+- Cost: hub downtime stalls coordination for every workspace, and disconnected machines cannot write coordination records.
+
+## ADR-0227 — Stable machine identity, registry, and out-of-band hub pin
+
+**Status:** Accepted · 2026-07 · [ORB-10245] froze the host identity boundary.
+
+### Context
+
+Hostname-derived strings and per-workspace transport targets can silently redirect a
+machine or elevate repository configuration.
+
+### Decision
+
+Give each machine an immutable generated `machine_id`, keep the registry at the hub,
+and pin the one hub `machine_id` out of band in machine-local `mcp.toml`.
+
+### Consequences
+
+- Names resolve at binding time and persisted records retain stable identity.
+- Cost: bootstrap transfers hub identity out of band, and registry/trust drift needs explicit diagnosis.
+
+## ADR-0228 — Local placement broker with capability-set filtering
+
+**Status:** Accepted · 2026-07 · [ORB-10245] froze tool routing and authorization.
+
+### Context
+
+One remote MCP target must preserve local graph and documentation behavior without
+equating where a tool runs with who may invoke it.
+
+### Decision
+
+Use a local placement broker. Every exposed canonical tool has exactly one of
+`hub`, `owner`, `local-derived`, or `composite` placement and an independently
+filtered non-empty capability set.
+
+### Consequences
+
+- Conformance records placement and allowed capabilities for every exposed tool.
+- Cost: the broker owns route preflight, composite audit, and capability-by-placement coverage.
+
+## ADR-0229 — Owner-authored knowledge with hub-global IDs and explicit replicas
+
+**Status:** Accepted · 2026-07 · [ORB-10245] fixed the one-writer knowledge rule.
+
+### Context
+
+Knowledge needs global IDs without making a hub checkout or a stale replica a second
+author.
+
+### Decision
+
+The hub allocates global IDs, the declared owner authors current knowledge, and Git
+replicas are opt-in reads marked as replicas. The hub never proxies to a spoke owner.
+
+### Consequences
+
+- A non-owner agent routes actionable work as a task to the owner.
+- Cost: finalize failure consumes a valid unused ID, and current spoke-owned knowledge is unavailable off-owner.
+
+## ADR-0230 — Pull-based leases with immutable placement and explicit recovery
+
+**Status:** Accepted · 2026-07 · [ORB-10245] fixed runner delivery semantics.
+
+### Context
+
+A hub-push executor model needs outbound spoke routes and obscures the placement
+selected and leased for a run.
+
+### Decision
+
+Spokes poll the hub for placed runs. Requested and actual placement are immutable;
+pre-start loss permits redelivery, while post-start uncertainty is
+`recovery_required` and needs explicit recovery.
+
+### Consequences
+
+- The hub is a mailbox and never opens a route to a spoke.
+- Cost: pickup latency follows poll cadence and an interrupted started run is not silently reassigned.
+
+## ADR-0231 — Committed-routine ownership with host-local cursors
+
+**Status:** Accepted · 2026-07 · [ORB-10245] fixed routine execution ownership.
+
+### Context
+
+Git-committed routines converge to many checkouts, while scheduler cursor and pause
+state must remain local to the executing host.
+
+### Decision
+
+A committed routine is owned by its registry-validated host pin; unpinned committed
+routines fail closed, and each host retains its own cursor and pause state.
+
+### Consequences
+
+- Reassignment is a reviewed pin change rather than a git-status inference.
+- Cost: handoff starts with no migrated cursor and existing committed routines need explicit pins.
+
+## ADR-0232 — Retire Bridge’s Orbit-shaped contract
+
+**Status:** Accepted · 2026-07 · [ORB-10245] set the cutover boundary.
+
+### Context
+
+Bridge parity duplicates Orbit schemas, errors, and workflow declarations even
+though Orbit is the canonical domain owner.
+
+### Decision
+
+Retire Bridge’s Orbit-shaped contract after Orbit MCP reaches parity; Bridge remains
+for its non-Orbit constellation domains.
+
+### Consequences
+
+- Clients register Orbit and Bridge side by side during migration.
+- Cost: cutover temporarily maintains two registrations and requires deletion of a compatibility layer.
 
 ## Task References
 
-- [ORB-00424] — umbrella proposal for canonical Orbit MCP and eventual Bridge
-  parity retirement.
+- [ORB-00424] — completed design proposal for canonical Orbit MCP and Bridge parity retirement.
+- [ORB-10245] — accepted the coupled contract and recorded this ADR set.
 
 > Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.

--- a/docs/design/mcp-bridge/references/conformance-v1.yaml
+++ b/docs/design/mcp-bridge/references/conformance-v1.yaml
@@ -1,0 +1,112 @@
+schema_version: 1
+contract: orbit-mcp-bridge-v1
+source_of_truth:
+  exposed_tool_list: crates/orbit-cli/src/command/mcp/host.rs
+  canonical_schema_registry: orbit tool registry
+  placement_metadata_owner: orbit-mcp broker
+
+capabilities:
+  allowed_values: [agent, operator, runner]
+  set_rules:
+    - Every exposed tool has exactly one placement and a non-empty allowed_capabilities set.
+    - Placement and capability filtering are independent.
+    - operator does not imply runner; runner does not imply agent.
+
+tools:
+  orbit.task.add: { placement: hub, allowed_capabilities: [agent, operator] }
+  orbit.task.approve: { placement: hub, allowed_capabilities: [agent, operator] }
+  orbit.task.artifact.put: { placement: hub, allowed_capabilities: [agent, operator] }
+  orbit.task.list: { placement: hub, allowed_capabilities: [agent, operator] }
+  orbit.task.review_thread.add: { placement: hub, allowed_capabilities: [agent, operator] }
+  orbit.task.review_thread.list: { placement: hub, allowed_capabilities: [agent, operator] }
+  orbit.task.review_thread.reply: { placement: hub, allowed_capabilities: [agent, operator] }
+  orbit.task.review_thread.resolve: { placement: hub, allowed_capabilities: [agent, operator] }
+  orbit.task.show: { placement: hub, allowed_capabilities: [agent, operator] }
+  orbit.task.start: { placement: hub, allowed_capabilities: [agent, operator] }
+  orbit.task.update: { placement: hub, allowed_capabilities: [agent, operator] }
+  orbit.friction.add: { placement: hub, allowed_capabilities: [agent, operator] }
+  orbit.friction.tags: { placement: hub, allowed_capabilities: [agent, operator] }
+  orbit.friction.update: { placement: hub, allowed_capabilities: [operator] }
+  orbit.graph.sync: { placement: local-derived, allowed_capabilities: [agent, operator] }
+  orbit.graph.search: { placement: local-derived, allowed_capabilities: [agent, operator] }
+  orbit.graph.show: { placement: local-derived, allowed_capabilities: [agent, operator] }
+  orbit.graph.refs: { placement: local-derived, allowed_capabilities: [agent, operator] }
+  orbit.graph.callees: { placement: local-derived, allowed_capabilities: [agent, operator] }
+  orbit.graph.impact: { placement: local-derived, allowed_capabilities: [agent, operator] }
+  orbit.graph.trace: { placement: local-derived, allowed_capabilities: [agent, operator] }
+  orbit.graph.overview: { placement: local-derived, allowed_capabilities: [agent, operator] }
+  orbit.graph.implementors: { placement: local-derived, allowed_capabilities: [agent, operator] }
+  orbit.graph.deps: { placement: local-derived, allowed_capabilities: [agent, operator] }
+  orbit.search: { placement: composite, allowed_capabilities: [agent, operator] }
+  orbit.adr.add: { placement: composite, allowed_capabilities: [agent, operator] }
+  orbit.adr.show: { placement: owner, allowed_capabilities: [agent, operator] }
+  orbit.adr.supersede: { placement: owner, allowed_capabilities: [agent, operator] }
+  orbit.adr.update: { placement: owner, allowed_capabilities: [agent, operator] }
+  orbit.learning.add: { placement: composite, allowed_capabilities: [agent, operator] }
+  orbit.learning.show: { placement: owner, allowed_capabilities: [agent, operator] }
+  orbit.learning.update: { placement: owner, allowed_capabilities: [agent, operator] }
+  orbit.learning.supersede: { placement: owner, allowed_capabilities: [agent, operator] }
+  orbit.auto_task.add: { placement: owner, allowed_capabilities: [agent, operator] }
+  orbit.auto_task.show: { placement: owner, allowed_capabilities: [agent, operator] }
+  orbit.auto_task.update: { placement: owner, allowed_capabilities: [agent, operator] }
+  orbit.auto_task.toggle: { placement: owner, allowed_capabilities: [agent, operator] }
+
+hub_schema_digest:
+  contract_revision: 1
+  inputs:
+    - canonical schema name, description, and input schema for every hub-placed tool
+    - canonical schema name, description, and input schema for every composite tool's hub step
+    - advertised MCP name mapping for each included canonical tool
+    - canonical registry revision
+  mismatch_behavior:
+    - Reject hub routing before dispatch when revision or digest differs.
+    - Local-derived and locally eligible owner calls may continue without a hub route.
+
+run_protocol:
+  capability: runner
+  hub_endpoint_placement: hub
+  allowed_operations: [presence, lease, heartbeat, report]
+  transitions:
+    - from: placed
+      to: leased
+      event: lease_granted
+      invariant: actual placement records the leasing machine_id and never replaces requested placement.
+    - from: leased
+      to: placed
+      event: lease_expired_before_execution
+      invariant: pre-start loss is redeliverable only to the recorded placement; it is not automatic failover.
+    - from: leased
+      to: execution_started
+      event: execution_started
+      invariant: the runner records the start before execution side effects are considered recoverable.
+    - from: execution_started
+      to: recovery_required
+      event: heartbeat_expired_or_outcome_unknown
+      invariant: post-start uncertainty never redelivers automatically and requires explicit recovery.
+    - from: recovery_required
+      to: placed
+      event: explicit_recovery_and_replacement
+      invariant: a shepherd or operator records recovery before a new lease can be issued.
+
+routing_expectations:
+  topology:
+    hub_count: 1
+    coordination_writer: hub
+    workspace_coordination_target: forbidden
+    forbidden_config_forms: ["[hubs.<name>]", "workspace coordination-host"]
+    unsupported: [spoke-to-spoke route, hub-to-owner proxy, replication, failover]
+  hub:
+    route: local short-circuit or the single hub link
+    rejects: [second_hub_target, workspace_specific_coordination_target]
+  owner:
+    local_owner: execute locally in the validated owner checkout
+    hub_owner: execute through the single hub link
+    spoke_owner: reject_current_state_unavailable
+    rejects: [hub_to_owner_proxy, spoke_to_spoke_route]
+  local-derived:
+    route: caller checkout only
+    rejects: [hub_execution, missing_validated_checkout]
+  composite:
+    knowledge_add: hub_allocates_id_then_owner_finalizes
+    search: hub_tasks_plus_local_docs_plus_role_aware_knowledge
+    rejects: [owner_proxy, implicit_replica_as_current]


### PR DESCRIPTION
## Task

[ORB-10245](https://orbit-cli.com/tasks/ORB-10245) — Accept host registry and freeze MCP bridge implementation contract

### Description

## Problem

The Host Registry and Orbit MCP Bridge designs are approved, but the repository still presents Host Registry as Draft, retains overlapping candidate-decision lists, and lacks the versioned conformance fixture needed by the implementation sequence.

This is Unit A of the approved Host Registry + MCP Bridge execution plan. It closes design bookkeeping and freezes the v1 contract before runtime implementation begins.

## Required outcome

1. Mark the coupled Host Registry design Accepted and remove stale Draft/candidate language from both decision logs.
2. Consolidate the overlapping Host Registry and MCP Bridge candidates into seven load-bearing ADRs:
   - singular coordination hub, declared workspace owner, and per-run placement;
   - stable machine identity, registry, and out-of-band hub pin;
   - local placement broker with capability-set filtering;
   - owner-authored knowledge with hub-global IDs and explicit replicas;
   - pull-based leases with immutable requested/actual placement and safe recovery;
   - committed-routine ownership with host-local cursor semantics; and
   - retirement of Bridge's Orbit-shaped contract.
3. Allocate ADR IDs through `orbit.adr.add`; do not invent IDs or hand-edit ADR store metadata. Link the resulting ADRs to this task and update the feature decision logs/frontmatter with their canonical IDs.
4. Freeze one versioned conformance fixture at `docs/design/mcp-bridge/references/conformance-v1.yaml`. It must define:
   - placement and allowed capability sets for every MCP tool;
   - the hub-routed schema-digest input;
   - valid run-state transitions, including pre-start redelivery versus post-start `recovery_required`; and
   - the broker/Bridge routing expectation matrix.
5. Preserve the v1 scope guard: exactly one `[hub]`, one central coordination writer for every workspace, no per-workspace coordination target, no `[hubs.<name>]`, no spoke-to-spoke or hub-to-owner proxy, and no HA/failover scaffolding.
6. Create a separate proposed implementation-umbrella task for the remaining B1–M delivery units, related to ORB-00424 and this task. Do not create or ship the child units in this change.

## Constraints / notes

- This task freezes contracts and docs; it must not implement Host Registry, transport, broker, knowledge-routing, runner, or HA runtime behavior.
- Keep the hub distinct from workspace ownership: the hub owns coordination; the declared owner is the sole v1 knowledge author and default execution placement.
- Capabilities are sets and are orthogonal to host role and tool placement.
- ADR gaps are valid if allocation succeeds and a later write fails; never reuse an allocated ID.
- ORB-00424 remains the completed design proposal, not the implementation umbrella.
- Orbit is PR-gated: target `agent-main` and run only the repository's per-task checks.

### Acceptance Criteria

- All numbered files under docs/design/host-registry report status: Accepted, use the current last_updated date, and contain no statement that the coupled design is awaiting acceptance.
- The Host Registry and MCP Bridge decision logs contain the seven consolidated ADR entries with IDs allocated through orbit.adr.add, each ADR is linked to this task, and overlapping candidate lists are removed.
- docs/design/mcp-bridge/references/conformance-v1.yaml exists with schema_version 1 and covers every exposed MCP tool with one placement and a non-empty allowed-capabilities set drawn only from agent, operator, and runner.
- The conformance fixture records hub schema-digest inputs, valid run transitions, and routing expectations, including placed/leased/execution_started/recovery_required behavior and explicit rejection of multi-hub or owner-proxy routing.
- A repository search finds no new [hubs.<name>] form, workspace coordination-host field, spoke-to-spoke route, hub-to-owner proxy, replication/failover mechanism, or runtime implementation introduced by this task.
- A separate proposed implementation-umbrella task exists for B1-M, relates back to ORB-00424 and this task, and no B1-M child task has been created or shipped.
- make ci-fast passes from the Orbit repository root.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Marked every numbered Host Registry design document Accepted with the current date; consolidated both decision logs into seven accepted, tool-allocated ADRs (ADR-0226 through ADR-0232).
- Added conformance-v1.yaml with one placement and valid non-empty capability set for all 37 exposed MCP tools, hub schema-digest inputs, lease/recovery transitions, and topology rejection rules.
- Generated the directly coupled docs/INDEX.md metadata after frontmatter changes and created proposed implementation umbrella ORB-10246, related to ORB-00424 and ORB-10245, without creating B1–M children.
Assessment: Docs-and-contract-only change; staged diff contains no runtime implementation, transport, replication, or failover code.
Validation:
- Python YAML assertions: schema_version 1, all 37 MCP safe-surface tools covered, placements/capabilities valid, and Host Registry frontmatter Accepted/current.
- git diff --cached --check
- make ci-fast (passed)

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10245-6a59d34d`
- Behind base: 0
- Ahead of base: 1