### PR TITLE
Add stable host identity and migrate initialization ownership

### DIFF
--- a/.orbit/learnings/L-0092/learning.yaml
+++ b/.orbit/learnings/L-0092/learning.yaml
@@ -1,0 +1,27 @@
+schema_version: 1
+id: L-0092
+status: active
+scope:
+  paths:
+  - crates/orbit-core/src/routines/host.rs
+  - crates/orbit-core/src/routines/**
+  - crates/orbit-core/src/command/init.rs
+  tags:
+  - host-registry
+  - routines
+  - migration
+summary: Flipping a lenient resolver to strict fail-closed needs a migration pass and a side-effect audit of its callers
+body: |-
+  Host identity loading (ORB-10247) replaced host.rs resolve_host_id (OS-hostname fallback for absent/blank host.toml) with a strict load_host_identity that fails closed. Two non-obvious consequences bit during implementation:
+
+  1. Callers can depend on the lenient path's SIDE EFFECTS, not just its return value. A workspace-init regression test relied on routine seeding (which called resolve_host_id) implicitly creating .orbit/routines/ via the hostname fallback; once seeding skipped on a missing identity, that directory was never created and an unrelated file-write in the test failed with NotFound. Audit every caller of a resolver you tighten for behavior that assumed the fallback always succeeded.
+
+  2. Strict loading requires a one-time migration before dependent commands work on existing installs. A live host whose ~/.orbit/host.toml is still the legacy host_id-only form has `orbit sweep` and `routine status` fail closed until `orbit init` migrates the file (idempotent: preserves host_id, generates machine_id once). Sequence the migration into deploy; complements L-0077 on executor/config-schema readiness before dispatch.
+
+  Design guardrail: put first-time identity creation + migration in a single owning command (orbit init), keep the loader read-only and strict, and make migration atomic + idempotent so repeated init is a no-op write.
+evidence:
+- kind: task
+  reference: ORB-10247
+created_at: 2026-07-18T01:16:26.461640115Z
+updated_at: 2026-07-18T01:16:26.461640115Z
+created_by: claude

--- a/crates/orbit-cli/src/command/init.rs
+++ b/crates/orbit-cli/src/command/init.rs
@@ -5,9 +5,13 @@ use orbit_core::config::agent_detect::{DetectedAgents, RealAgentEnvProbe, detect
 use orbit_core::config::agent_prompt::{
     StdinPrompter, collect_qa_crew_setting, collect_role_settings,
 };
+use orbit_core::routines::{
+    HostIdentityOutcome, HostMode, NewHostIdentity, ensure_host_identity, os_hostname,
+};
 use orbit_core::workspace_registry::global_orbit_dir;
 use orbit_core::{OrbitError, OrbitRuntime};
 use std::collections::BTreeMap;
+use std::io::{self, Write};
 use std::path::{Path, PathBuf};
 
 use crate::command::Execute;
@@ -24,41 +28,31 @@ pub struct InitCommand {
     /// hang.
     #[arg(long)]
     pub non_interactive: bool,
+
+    /// Operator-chosen host name for this machine's identity. Used only when
+    /// no identity exists yet (first init). Required with --non-interactive on
+    /// a fresh host; interactively, the OS hostname is the default.
+    #[arg(long)]
+    pub host_name: Option<String>,
+
+    /// Host operating mode for this machine's identity: standalone | hub |
+    /// spoke. Defaults to standalone. Used only on first init.
+    #[arg(long, value_name = "MODE")]
+    pub host_mode: Option<String>,
 }
 
 impl Execute for InitCommand {
     fn execute(self, _runtime: &OrbitRuntime) -> Result<(), OrbitError> {
-        let detected = detect(&RealAgentEnvProbe);
-        let role_settings =
-            collect_role_settings_for_init(None, self.force, self.non_interactive, &detected)?;
-        let result = init_global(
-            None,
-            InitOptions {
-                force: self.force,
-                refresh_defaults: true,
-                role_settings,
-                detected: Some(detected),
-                ..Default::default()
-            },
-        )?;
-        let paths = reported_init_paths(None);
-        print_init_result(InitOutput {
-            skills_root: paths.skills_root,
-            refreshed_skill_files: result.refreshed_skill_files,
-            created_skills_symlink: result.created_skills_symlink,
-            config_path: paths.config_path,
-            created_config: result.created_config,
-            refreshed_default_activities: result.refreshed_default_activities,
-            refreshed_default_jobs: result.refreshed_default_jobs,
-            refreshed_default_executors: result.refreshed_default_executors,
-            refreshed_default_policies: result.refreshed_default_policies,
-        });
-        Ok(())
+        self.run(None)
     }
 }
 
 impl InitCommand {
     pub fn execute_without_runtime(self, root_override: Option<&Path>) -> Result<(), OrbitError> {
+        self.run(root_override)
+    }
+
+    fn run(self, root_override: Option<&Path>) -> Result<(), OrbitError> {
         let detected = detect(&RealAgentEnvProbe);
         let role_settings = collect_role_settings_for_init(
             root_override,
@@ -76,6 +70,15 @@ impl InitCommand {
                 ..Default::default()
             },
         )?;
+        // Host identity is created/migrated here — `orbit init` is its sole
+        // owner (ADR-0227). This runs after the root exists so the file has a
+        // parent directory.
+        ensure_host_identity_for_init(
+            root_override,
+            self.non_interactive,
+            self.host_name,
+            self.host_mode,
+        )?;
         let paths = reported_init_paths(root_override);
         print_init_result(InitOutput {
             skills_root: paths.skills_root,
@@ -90,6 +93,109 @@ impl InitCommand {
         });
         Ok(())
     }
+}
+
+/// Create or migrate this machine's host identity. Host name and mode are only
+/// consulted when the identity is absent (a fresh create); a present identity
+/// is preserved unchanged and a legacy file is migrated without prompting.
+fn ensure_host_identity_for_init(
+    root_override: Option<&Path>,
+    non_interactive: bool,
+    host_name: Option<String>,
+    host_mode: Option<String>,
+) -> Result<(), OrbitError> {
+    let global_root = match root_override {
+        Some(root) => root.to_path_buf(),
+        None => global_orbit_dir()?,
+    };
+    // Validate an explicit mode up front so an invalid value fails closed even
+    // when the identity already exists.
+    let requested_mode = match host_mode.as_deref() {
+        Some(mode) => Some(HostMode::parse(mode)?),
+        None => None,
+    };
+
+    let outcome = ensure_host_identity(&global_root, move || {
+        let host_id = match host_name {
+            Some(name) => name,
+            None if non_interactive => {
+                return Err(OrbitError::InvalidInput(
+                    "host identity is absent; pass --host-name (and optionally --host-mode) \
+                     to initialize a fresh host non-interactively"
+                        .to_string(),
+                ));
+            }
+            None => prompt_host_name()?,
+        };
+        let mode = match requested_mode {
+            Some(mode) => mode,
+            None if non_interactive => HostMode::Standalone,
+            None => prompt_host_mode()?,
+        };
+        Ok(NewHostIdentity { host_id, mode })
+    })?;
+
+    report_host_identity(&outcome);
+    Ok(())
+}
+
+fn report_host_identity(outcome: &HostIdentityOutcome) {
+    let identity = outcome.identity();
+    let verb = match outcome {
+        HostIdentityOutcome::Created(_) => "created",
+        HostIdentityOutcome::Migrated(_) => "migrated",
+        HostIdentityOutcome::Unchanged(_) => "unchanged",
+    };
+    println!(
+        "host identity ({verb}): host_id=\"{}\", machine_id={}, mode={}",
+        identity.host_id, identity.machine_id, identity.mode
+    );
+}
+
+fn prompt_host_name() -> Result<String, OrbitError> {
+    let default = os_hostname();
+    let prompt = match default.as_deref() {
+        Some(name) => format!("Host name [{name}]: "),
+        None => "Host name: ".to_string(),
+    };
+    let answer = read_line(&prompt)?;
+    if answer.is_empty() {
+        default.ok_or_else(|| {
+            OrbitError::InvalidInput(
+                "no host name entered and the OS hostname is unavailable; \
+                 re-run with --host-name"
+                    .to_string(),
+            )
+        })
+    } else {
+        Ok(answer)
+    }
+}
+
+fn prompt_host_mode() -> Result<HostMode, OrbitError> {
+    loop {
+        let answer = read_line("Host mode (standalone/hub/spoke) [standalone]: ")?;
+        if answer.is_empty() {
+            return Ok(HostMode::Standalone);
+        }
+        match HostMode::parse(&answer) {
+            Ok(mode) => return Ok(mode),
+            Err(error) => println!("{error}"),
+        }
+    }
+}
+
+fn read_line(prompt: &str) -> Result<String, OrbitError> {
+    let mut stdout = io::stdout();
+    write!(stdout, "{prompt}").map_err(|error| OrbitError::Io(error.to_string()))?;
+    stdout
+        .flush()
+        .map_err(|error| OrbitError::Io(error.to_string()))?;
+    let mut line = String::new();
+    io::stdin()
+        .read_line(&mut line)
+        .map_err(|error| OrbitError::Io(error.to_string()))?;
+    Ok(line.trim().to_string())
 }
 
 /// Decide whether to prompt for `[agent.<role>]` settings and collect them.

--- a/crates/orbit-cli/src/command/routine/command.rs
+++ b/crates/orbit-cli/src/command/routine/command.rs
@@ -45,7 +45,7 @@ pub enum RoutineSubcommand {
     Pause(RoutinePauseArgs),
     /// Clear a host-local pause
     Resume(RoutineResumeArgs),
-    /// Set this host's identity and optionally install the OS clock unit
+    /// Read this host's identity and optionally install the OS clock unit
     Init(RoutineInitArgs),
 }
 

--- a/crates/orbit-cli/src/command/routine/init.rs
+++ b/crates/orbit-cli/src/command/routine/init.rs
@@ -1,19 +1,17 @@
 use clap::Args;
 use orbit_core::OrbitError;
-use orbit_core::routines::{install_clock, resolve_host_id, write_host_id};
+use orbit_core::routines::{install_clock, load_host_identity};
 use orbit_core::workspace_registry;
 
 #[derive(Args)]
 #[command(
-    after_help = "Writes ~/.orbit/host.toml (the identity `hosts:` pinning matches\n\
-                        against) and, with --install-clock, installs the per-user OS clock\n\
-                        unit that invokes `orbit sweep` every minute (launchd on macOS, a\n\
-                        systemd user timer on Linux)."
+    after_help = "Reads the machine identity from ~/.orbit/host.toml (created by\n\
+                        `orbit init`) and, with --install-clock, installs the per-user OS\n\
+                        clock unit that invokes `orbit sweep` every minute (launchd on\n\
+                        macOS, a systemd user timer on Linux). It never creates or rewrites\n\
+                        host identity — run `orbit init` for that."
 )]
 pub struct RoutineInitArgs {
-    /// Host identity to write (defaults to the machine hostname).
-    #[arg(long)]
-    pub host_id: Option<String>,
     /// Also install and activate the OS clock unit driving `orbit sweep`.
     #[arg(long)]
     pub install_clock: bool,
@@ -23,12 +21,13 @@ impl RoutineInitArgs {
     pub fn execute_without_runtime(self) -> Result<(), OrbitError> {
         let global_root = workspace_registry::global_orbit_dir()?;
 
-        let host_id = match self.host_id {
-            Some(host_id) => host_id,
-            None => resolve_host_id(&global_root)?,
-        };
-        let path = write_host_id(&global_root, &host_id)?;
-        println!("host_id \"{host_id}\" written to {}", path.display());
+        // Read-only: host identity is owned by `orbit init`. Fail closed with
+        // an actionable error when it is absent or unmigrated.
+        let identity = load_host_identity(&global_root)?;
+        println!(
+            "host identity: host_id=\"{}\", machine_id={}, mode={}",
+            identity.host_id, identity.machine_id, identity.mode
+        );
 
         if !self.install_clock {
             println!("clock unit not installed (pass --install-clock to set up `orbit sweep`)");

--- a/crates/orbit-cli/src/command/tests/init.rs
+++ b/crates/orbit-cli/src/command/tests/init.rs
@@ -108,11 +108,29 @@ fn non_interactive_init_isolates_temporary_root_skill_discovery() {
         InitCommand {
             force: false,
             non_interactive: true,
+            host_name: Some("validation-host".to_string()),
+            host_mode: None,
         }
         .execute_without_runtime(Some(&validation_root.path().join(".orbit")))
     };
 
     outcome.expect("init succeeded");
+
+    // Non-interactive init created the machine identity in the isolated root.
+    let host_toml = validation_root.path().join(".orbit").join("host.toml");
+    let host_contents = fs::read_to_string(&host_toml).expect("read host.toml");
+    assert!(
+        host_contents.contains("schema_version = 1"),
+        "{host_contents}"
+    );
+    assert!(
+        host_contents.contains("host_id = \"validation-host\""),
+        "{host_contents}"
+    );
+    assert!(
+        host_contents.contains("mode = \"standalone\""),
+        "{host_contents}"
+    );
 
     assert_discovery_sentinel(&agents_link, &agents_target);
     assert_discovery_sentinel(&claude_link, &claude_target);
@@ -161,4 +179,94 @@ fn non_interactive_init_isolates_temporary_root_skill_discovery() {
     drop(validation_home);
     assert_discovery_sentinel(&agents_link, &agents_target);
     assert_discovery_sentinel(&claude_link, &claude_target);
+}
+
+fn init_host(
+    root: &Path,
+    host_name: Option<&str>,
+    host_mode: Option<&str>,
+) -> Result<(), orbit_core::OrbitError> {
+    InitCommand {
+        force: false,
+        non_interactive: true,
+        host_name: host_name.map(str::to_string),
+        host_mode: host_mode.map(str::to_string),
+    }
+    .execute_without_runtime(Some(root))
+}
+
+/// Non-interactive `--host-name` + `--host-mode` create the identity exactly
+/// once, and a repeat init preserves the generated machine_id unchanged.
+#[test]
+fn non_interactive_host_name_and_mode_create_then_repeat_is_stable() {
+    let _guard = ENV_LOCK.lock().expect("lock env");
+    let home = tempdir().expect("home tempdir");
+    let _home = ScopedHome::set(home.path());
+    let root = home.path().join(".orbit");
+
+    init_host(&root, Some("dk-mac"), Some("hub")).expect("first init");
+    let host_toml = root.join("host.toml");
+    let first = fs::read_to_string(&host_toml).expect("read host.toml");
+    assert!(first.contains("host_id = \"dk-mac\""), "{first}");
+    assert!(first.contains("mode = \"hub\""), "{first}");
+    let machine_line = first
+        .lines()
+        .find(|line| line.starts_with("machine_id = "))
+        .expect("machine_id line")
+        .to_string();
+    assert!(machine_line.contains("hm_"), "{machine_line}");
+
+    // Repeated init: no prompt, no rewrite, identical machine_id.
+    init_host(&root, Some("ignored-on-repeat"), Some("spoke")).expect("repeat init");
+    let second = fs::read_to_string(&host_toml).expect("re-read host.toml");
+    assert_eq!(first, second, "repeat init must not rewrite host.toml");
+}
+
+/// A legacy `host_id`-only file migrates in place on init.
+#[test]
+fn init_migrates_legacy_host_toml() {
+    let _guard = ENV_LOCK.lock().expect("lock env");
+    let home = tempdir().expect("home tempdir");
+    let _home = ScopedHome::set(home.path());
+    let root = home.path().join(".orbit");
+    fs::create_dir_all(&root).expect("mkdir .orbit");
+    fs::write(root.join("host.toml"), "host_id = \"legacy-host\"\n").expect("seed legacy");
+
+    // No --host-name needed: migration preserves the legacy name.
+    init_host(&root, None, None).expect("migrating init");
+    let migrated = fs::read_to_string(root.join("host.toml")).expect("read migrated");
+    assert!(migrated.contains("schema_version = 1"), "{migrated}");
+    assert!(migrated.contains("host_id = \"legacy-host\""), "{migrated}");
+    assert!(migrated.contains("mode = \"standalone\""), "{migrated}");
+    assert!(migrated.contains("machine_id = \"hm_"), "{migrated}");
+}
+
+/// A fresh host initialized non-interactively without --host-name fails closed.
+#[test]
+fn non_interactive_missing_host_name_fails_closed() {
+    let _guard = ENV_LOCK.lock().expect("lock env");
+    let home = tempdir().expect("home tempdir");
+    let _home = ScopedHome::set(home.path());
+    let root = home.path().join(".orbit");
+
+    let error = init_host(&root, None, None).expect_err("missing host name must fail closed");
+    assert!(error.to_string().contains("--host-name"), "{error}");
+    assert!(
+        !root.join("host.toml").exists(),
+        "no identity should be written on the failure path"
+    );
+}
+
+/// An invalid `--host-mode` fails closed before any identity is written.
+#[test]
+fn invalid_host_mode_fails_closed() {
+    let _guard = ENV_LOCK.lock().expect("lock env");
+    let home = tempdir().expect("home tempdir");
+    let _home = ScopedHome::set(home.path());
+    let root = home.path().join(".orbit");
+
+    let error =
+        init_host(&root, Some("dk-mac"), Some("bogus")).expect_err("invalid mode must fail");
+    assert!(error.to_string().contains("unknown host mode"), "{error}");
+    assert!(!root.join("host.toml").exists());
 }

--- a/crates/orbit-cli/src/command/workspace/tests/init.rs
+++ b/crates/orbit-cli/src/command/workspace/tests/init.rs
@@ -22,6 +22,13 @@ fn workspace_reinit_merges_explicit_registration_updates_without_resetting_autho
     let home = tempdir().expect("home tempdir");
     let global = home.path().join(".orbit");
     std::fs::create_dir_all(&global).expect("create global orbit");
+    // A host identity must exist for workspace init to seed default routines
+    // (which creates `.orbit/routines/`); `orbit init` owns its creation.
+    std::fs::write(
+        global.join("host.toml"),
+        "schema_version = 1\nmachine_id = \"hm_reinit\"\nhost_id = \"reinit-host\"\nmode = \"standalone\"\n",
+    )
+    .expect("write host identity");
 
     let previous_home = std::env::var_os("HOME");
     let previous_cwd = std::env::current_dir().expect("capture cwd");
@@ -176,7 +183,11 @@ fn workspace_init_seeds_disabled_routines_and_reinit_preserves_authored_files() 
     let home = tempdir().expect("home tempdir");
     let global = home.path().join(".orbit");
     std::fs::create_dir_all(&global).expect("create global orbit");
-    std::fs::write(global.join("host.toml"), "host_id = \"init-host\"\n").expect("write host pin");
+    std::fs::write(
+        global.join("host.toml"),
+        "schema_version = 1\nmachine_id = \"hm_inithost\"\nhost_id = \"init-host\"\nmode = \"standalone\"\n",
+    )
+    .expect("write host identity");
 
     let previous_home = std::env::var_os("HOME");
     let previous_cwd = std::env::current_dir().expect("capture cwd");

--- a/crates/orbit-core/src/command/init.rs
+++ b/crates/orbit-core/src/command/init.rs
@@ -221,13 +221,14 @@ pub fn init_workspace_at_root(
         created_skills_symlink = global_result.created_skills_symlink;
         // Routines are workspace-authored (`.orbit/routines/`, no global
         // directory), so defaults seed here rather than in the global
-        // branch. Host resolution is best-effort: an unresolvable host id
-        // skips routine seeding instead of failing the whole init.
-        match crate::routines::resolve_host_id(&global_root) {
-            Ok(host_id) => {
+        // branch. Host resolution is best-effort: an absent or unmigrated
+        // host identity (created by `orbit init`) skips routine seeding
+        // instead of failing the whole init — no OS-hostname fallback.
+        match crate::routines::load_host_identity(&global_root) {
+            Ok(identity) => {
                 refreshed_default_routines = seed_default_routines(
                     &orbit_root.join("routines"),
-                    &host_id,
+                    &identity.host_id,
                     workspace_slug_from_orbit_root(&orbit_root).as_deref(),
                     // Routine definitions become workspace-authored after
                     // seeding. Refresh global defaults without overwriting

--- a/crates/orbit-core/src/command/routine.rs
+++ b/crates/orbit-core/src/command/routine.rs
@@ -6,7 +6,7 @@
 //! at seed time:
 //!
 //! - `__ORBIT_HOST_ID__` — routines v1 has no "any host", so the seeded
-//!   definition pins the initializing host (`resolve_host_id`).
+//!   definition pins the initializing host (`load_host_identity().host_id`).
 //! - `__ORBIT_ROUTINE_NAME__` — routine names must be unique across all
 //!   routine sources on a host, so the seeded name carries a
 //!   workspace-derived suffix (`task-triage-<workspace>`) to keep two

--- a/crates/orbit-core/src/routines/host.rs
+++ b/crates/orbit-core/src/routines/host.rs
@@ -1,87 +1,364 @@
-//! Host identity for routine scheduling [ORB-10021].
+//! Host identity for this Orbit machine [ORB-10247].
 //!
-//! `hosts:` pinning in routine definitions matches against a `host_id` that
-//! lives in `~/.orbit/host.toml` — the one genuinely host-local datum in the
-//! routines design (ADR-0205 keeps discovery in the workspace registry;
-//! `host.toml` survives only to carry identity). When the file is absent the
-//! machine hostname is used, so pinning works out of the box on hosts whose
-//! hostnames are already stable names like `dk-server-1`.
+//! `~/.orbit/host.toml` carries the one genuinely host-local datum: a versioned
+//! [`HostIdentity`] with a stable, generated `machine_id`, an operator-chosen
+//! `host_id` display name, and an operating `mode`. First-time creation lives in
+//! global `orbit init` (see `crate::command::init`); a legacy file that carried
+//! only `host_id` (the routines-v1 scheduling pin) is migrated in place, once,
+//! preserving its `host_id` and generating a `machine_id`.
+//!
+//! Loading is strict: after migration an absent, malformed, incomplete, blank,
+//! or future-schema file is a hard error with an actionable message — there is
+//! no silent fallback to the OS hostname (ADR-0227). Routine `hosts:` pinning,
+//! the sweep, and status all resolve through [`HostIdentity::host_id`].
 
-use std::fs;
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use orbit_common::types::OrbitError;
+use orbit_common::utility::fs::atomic_write_text;
 use serde::Deserialize;
 
 /// File under the global Orbit root carrying the host identity.
 pub const HOST_TOML_FILE: &str = "host.toml";
 
-#[derive(Debug, Deserialize)]
-struct HostToml {
-    host_id: Option<String>,
+/// Current on-disk schema version for [`HostIdentity`]. A file whose
+/// `schema_version` exceeds this fails closed (see [`inspect_host_identity`]).
+pub const HOST_IDENTITY_SCHEMA_VERSION: u32 = 1;
+
+const MACHINE_ID_PREFIX: &str = "hm_";
+
+/// Operating mode of this Orbit host.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HostMode {
+    /// Self-contained host (the standalone default; no registry/hub role).
+    Standalone,
+    /// Coordination hub for a multi-host constellation.
+    Hub,
+    /// Satellite that polls a hub for placed runs.
+    Spoke,
 }
 
-/// Resolve this machine's routine-scheduling identity: `host_id` from
-/// `<global_root>/host.toml` when present and non-empty, otherwise the
-/// machine hostname.
-pub fn resolve_host_id(global_root: &Path) -> Result<String, OrbitError> {
-    let path = host_toml_path(global_root);
-    if path.exists() {
-        let raw = fs::read_to_string(&path).map_err(|error| {
-            OrbitError::Io(format!("failed to read '{}': {error}", path.display()))
-        })?;
-        let parsed: HostToml = toml::from_str(&raw).map_err(|error| {
-            OrbitError::InvalidInput(format!("invalid host config '{}': {error}", path.display()))
-        })?;
-        if let Some(host_id) = parsed
-            .host_id
-            .as_deref()
-            .map(str::trim)
-            .filter(|value| !value.is_empty())
-        {
-            return Ok(host_id.to_string());
+impl HostMode {
+    /// The persisted string form (matches the `mode` values in `host.toml`).
+    pub fn as_str(self) -> &'static str {
+        match self {
+            HostMode::Standalone => "standalone",
+            HostMode::Hub => "hub",
+            HostMode::Spoke => "spoke",
         }
     }
-    hostname_fallback()
+
+    /// Parse an external (CLI / file) mode string, failing closed on anything
+    /// outside the fixed vocabulary.
+    pub fn parse(value: &str) -> Result<Self, OrbitError> {
+        match value.trim() {
+            "standalone" => Ok(HostMode::Standalone),
+            "hub" => Ok(HostMode::Hub),
+            "spoke" => Ok(HostMode::Spoke),
+            other => Err(OrbitError::InvalidInput(format!(
+                "unknown host mode '{other}' (expected 'standalone', 'hub', or 'spoke')"
+            ))),
+        }
+    }
 }
 
-/// Write (or overwrite) the host identity. Returns the file path written.
-pub fn write_host_id(global_root: &Path, host_id: &str) -> Result<PathBuf, OrbitError> {
-    let trimmed = host_id.trim();
-    if trimmed.is_empty() {
-        return Err(OrbitError::InvalidInput(
-            "host_id must not be empty".to_string(),
-        ));
+impl std::fmt::Display for HostMode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
     }
-    let path = host_toml_path(global_root);
-    if let Some(parent) = path.parent() {
-        fs::create_dir_all(parent).map_err(|error| OrbitError::Io(error.to_string()))?;
+}
+
+/// Versioned machine identity persisted in `~/.orbit/host.toml`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HostIdentity {
+    /// On-disk schema version; always [`HOST_IDENTITY_SCHEMA_VERSION`] for a
+    /// value produced by this build.
+    pub schema_version: u32,
+    /// Opaque, generated-once, never-reused stable identity (`hm_<hex>`).
+    pub machine_id: String,
+    /// Operator-chosen, renameable display name; matched against routine
+    /// `hosts:` pins.
+    pub host_id: String,
+    /// Host operating mode.
+    pub mode: HostMode,
+}
+
+impl HostIdentity {
+    /// Deterministic `host.toml` rendering — same identity always serializes to
+    /// the same bytes, so a re-migration or repeated init is a no-op write.
+    fn to_toml(&self) -> String {
+        format!(
+            "# Machine identity for this Orbit host [ORB-10247]. Created by\n\
+             # `orbit init`; `machine_id` is generated once and never edited.\n\
+             # `host_id` is the operator-chosen display name matched against\n\
+             # routine `hosts:` pins.\n\
+             schema_version = {}\n\
+             machine_id = \"{}\"\n\
+             host_id = \"{}\"\n\
+             mode = \"{}\"\n",
+            self.schema_version,
+            self.machine_id,
+            self.host_id,
+            self.mode.as_str(),
+        )
     }
-    let body = format!(
-        "# Host identity for routine scheduling (matched against `hosts:` in\n\
-         # routine definitions). Written by `orbit routine init` [ORB-10021].\n\
-         host_id = \"{trimmed}\"\n"
-    );
-    fs::write(&path, body).map_err(|error| {
-        OrbitError::Io(format!("failed to write '{}': {error}", path.display()))
-    })?;
-    Ok(path)
+}
+
+/// The three actionable states of `host.toml`. Malformed, incomplete, blank,
+/// and future-schema files are returned as `Err` by [`inspect_host_identity`],
+/// never as a variant here.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum HostIdentityState {
+    /// A complete, current-schema identity.
+    Present(HostIdentity),
+    /// A legacy pre-migration file carrying only `host_id`.
+    Legacy {
+        /// The preserved, non-blank legacy `host_id`.
+        host_id: String,
+    },
+    /// No `host.toml` exists yet.
+    Absent,
+}
+
+impl HostIdentityState {
+    /// The host name this state resolves to for routine pinning, if any.
+    pub fn host_id(&self) -> Option<&str> {
+        match self {
+            HostIdentityState::Present(identity) => Some(&identity.host_id),
+            HostIdentityState::Legacy { host_id } => Some(host_id),
+            HostIdentityState::Absent => None,
+        }
+    }
+}
+
+/// Outcome of [`ensure_host_identity`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum HostIdentityOutcome {
+    /// A fresh identity was created from operator input.
+    Created(HostIdentity),
+    /// A legacy `host_id`-only file was migrated to the current schema.
+    Migrated(HostIdentity),
+    /// A complete current-schema identity already existed; nothing was written.
+    Unchanged(HostIdentity),
+}
+
+impl HostIdentityOutcome {
+    /// The resulting identity, regardless of how it was reached.
+    pub fn identity(&self) -> &HostIdentity {
+        match self {
+            HostIdentityOutcome::Created(identity)
+            | HostIdentityOutcome::Migrated(identity)
+            | HostIdentityOutcome::Unchanged(identity) => identity,
+        }
+    }
+}
+
+/// Operator-supplied fields for a first-time identity creation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NewHostIdentity {
+    /// Operator-chosen display name.
+    pub host_id: String,
+    /// Operating mode.
+    pub mode: HostMode,
+}
+
+#[derive(Debug, Deserialize)]
+struct RawHostToml {
+    schema_version: Option<u32>,
+    machine_id: Option<String>,
+    host_id: Option<String>,
+    mode: Option<String>,
 }
 
 fn host_toml_path(global_root: &Path) -> PathBuf {
     global_root.join(HOST_TOML_FILE)
 }
 
-fn hostname_fallback() -> Result<String, OrbitError> {
-    let name = hostname::get()
-        .map_err(|error| OrbitError::Io(format!("failed to resolve hostname: {error}")))?;
-    let name = name.to_string_lossy().trim().to_string();
-    if name.is_empty() {
-        return Err(OrbitError::InvalidInput(
-            "machine hostname is empty; set host_id in ~/.orbit/host.toml \
-             via `orbit routine init --host-id <id>`"
-                .to_string(),
-        ));
+fn non_blank(value: &Option<String>) -> Option<String> {
+    value
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
+}
+
+/// Classify `host.toml` without mutating it. Returns the actionable
+/// [`HostIdentityState`] for absent / legacy / present files, and a hard error
+/// for malformed, incomplete, blank, or future-schema files (fail closed —
+/// never rewrites the file).
+pub fn inspect_host_identity(global_root: &Path) -> Result<HostIdentityState, OrbitError> {
+    let path = host_toml_path(global_root);
+    if !path.exists() {
+        return Ok(HostIdentityState::Absent);
     }
-    Ok(name)
+    let raw_text = std::fs::read_to_string(&path)
+        .map_err(|error| OrbitError::Io(format!("failed to read '{}': {error}", path.display())))?;
+    let parsed: RawHostToml = toml::from_str(&raw_text).map_err(|error| {
+        OrbitError::InvalidInput(format!(
+            "invalid host identity '{}': {error}",
+            path.display()
+        ))
+    })?;
+
+    match parsed.schema_version {
+        None => {
+            // Legacy files carried only `host_id`. A present, non-blank
+            // `host_id` migrates; anything else is unusable.
+            match non_blank(&parsed.host_id) {
+                Some(host_id) => Ok(HostIdentityState::Legacy { host_id }),
+                None => Err(OrbitError::InvalidInput(format!(
+                    "host identity '{}' is incomplete: no schema_version and no host_id; \
+                     run `orbit init` to create one",
+                    path.display()
+                ))),
+            }
+        }
+        Some(version) if version == HOST_IDENTITY_SCHEMA_VERSION => {
+            let machine_id = non_blank(&parsed.machine_id).ok_or_else(|| {
+                OrbitError::InvalidInput(format!(
+                    "host identity '{}' is incomplete: missing or blank machine_id",
+                    path.display()
+                ))
+            })?;
+            let host_id = non_blank(&parsed.host_id).ok_or_else(|| {
+                OrbitError::InvalidInput(format!(
+                    "host identity '{}' is incomplete: missing or blank host_id",
+                    path.display()
+                ))
+            })?;
+            let mode = non_blank(&parsed.mode).ok_or_else(|| {
+                OrbitError::InvalidInput(format!(
+                    "host identity '{}' is incomplete: missing or blank mode",
+                    path.display()
+                ))
+            })?;
+            let mode = HostMode::parse(&mode)?;
+            Ok(HostIdentityState::Present(HostIdentity {
+                schema_version: version,
+                machine_id,
+                host_id,
+                mode,
+            }))
+        }
+        Some(version) if version > HOST_IDENTITY_SCHEMA_VERSION => {
+            Err(OrbitError::InvalidInput(format!(
+                "host identity '{}' has unsupported schema_version {version}; this build \
+                 supports up to {HOST_IDENTITY_SCHEMA_VERSION}. Upgrade Orbit; the file is \
+                 left unchanged",
+                path.display()
+            )))
+        }
+        Some(version) => Err(OrbitError::InvalidInput(format!(
+            "host identity '{}' has invalid schema_version {version}",
+            path.display()
+        ))),
+    }
+}
+
+/// Strictly load a complete, current-schema identity. Absent and legacy files
+/// are errors here (they resolve through `orbit init`); malformed / future
+/// files propagate from [`inspect_host_identity`]. Never falls back to the OS
+/// hostname.
+pub fn load_host_identity(global_root: &Path) -> Result<HostIdentity, OrbitError> {
+    match inspect_host_identity(global_root)? {
+        HostIdentityState::Present(identity) => Ok(identity),
+        HostIdentityState::Legacy { .. } => Err(OrbitError::InvalidInput(format!(
+            "host identity '{}' is a legacy pre-migration file; run `orbit init` to migrate it",
+            host_toml_path(global_root).display()
+        ))),
+        HostIdentityState::Absent => Err(OrbitError::InvalidInput(format!(
+            "no host identity at '{}'; run `orbit init` to create one",
+            host_toml_path(global_root).display()
+        ))),
+    }
+}
+
+/// Ensure a complete, current-schema identity exists, creating or migrating as
+/// needed and returning what happened. `new` supplies the operator's host name
+/// and mode and is invoked **only** when the identity is absent, so callers can
+/// defer prompting until a fresh create is actually required.
+///
+/// Idempotent: a present identity is returned `Unchanged` with no write. A
+/// malformed or future-schema file is never overwritten — the error propagates.
+pub fn ensure_host_identity(
+    global_root: &Path,
+    new: impl FnOnce() -> Result<NewHostIdentity, OrbitError>,
+) -> Result<HostIdentityOutcome, OrbitError> {
+    match inspect_host_identity(global_root)? {
+        HostIdentityState::Present(identity) => Ok(HostIdentityOutcome::Unchanged(identity)),
+        HostIdentityState::Legacy { host_id } => {
+            // Migrate atomically: preserve host_id, generate machine_id, default
+            // to standalone. Rollback leaves the last valid file readable.
+            let identity = HostIdentity {
+                schema_version: HOST_IDENTITY_SCHEMA_VERSION,
+                machine_id: generate_machine_id(),
+                host_id,
+                mode: HostMode::Standalone,
+            };
+            write_host_identity(global_root, &identity)?;
+            Ok(HostIdentityOutcome::Migrated(identity))
+        }
+        HostIdentityState::Absent => {
+            let NewHostIdentity { host_id, mode } = new()?;
+            let host_id = host_id.trim().to_string();
+            if host_id.is_empty() {
+                return Err(OrbitError::InvalidInput(
+                    "host name must not be empty".to_string(),
+                ));
+            }
+            let identity = HostIdentity {
+                schema_version: HOST_IDENTITY_SCHEMA_VERSION,
+                machine_id: generate_machine_id(),
+                host_id,
+                mode,
+            };
+            write_host_identity(global_root, &identity)?;
+            Ok(HostIdentityOutcome::Created(identity))
+        }
+    }
+}
+
+/// Atomically (re)write `host.toml`. The staged-rename write never leaves a
+/// partially overwritten file, so a crash preserves the last valid identity.
+fn write_host_identity(global_root: &Path, identity: &HostIdentity) -> Result<PathBuf, OrbitError> {
+    let path = host_toml_path(global_root);
+    atomic_write_text(&path, &identity.to_toml()).map_err(|error| {
+        OrbitError::Io(format!("failed to write '{}': {error}", path.display()))
+    })?;
+    Ok(path)
+}
+
+/// Best-effort OS hostname, used as the interactive default host name at init.
+/// `None` when the hostname is unavailable or empty.
+pub fn os_hostname() -> Option<String> {
+    hostname::get()
+        .ok()
+        .map(|name| name.to_string_lossy().trim().to_string())
+        .filter(|name| !name.is_empty())
+}
+
+static MACHINE_ID_SEQUENCE: AtomicU64 = AtomicU64::new(0);
+
+/// Generate an opaque, stable `hm_<hex>` machine id. Called exactly once per
+/// machine (at create / migrate); the persisted value is never regenerated.
+fn generate_machine_id() -> String {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_nanos() as u64)
+        .unwrap_or(0);
+    let pid = u64::from(std::process::id());
+    let seq = MACHINE_ID_SEQUENCE.fetch_add(1, Ordering::Relaxed);
+    let seed =
+        nanos ^ pid.wrapping_mul(0x9E37_79B9_7F4A_7C15) ^ seq.wrapping_mul(0xD1B5_4A32_D192_ED03);
+    format!("{MACHINE_ID_PREFIX}{:016x}", splitmix64(seed))
+}
+
+/// SplitMix64 finalizer — folds a seed into a well-distributed 64-bit value.
+fn splitmix64(seed: u64) -> u64 {
+    let mut z = seed.wrapping_add(0x9E37_79B9_7F4A_7C15);
+    z = (z ^ (z >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
+    z = (z ^ (z >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
+    z ^ (z >> 31)
 }

--- a/crates/orbit-core/src/routines/mod.rs
+++ b/crates/orbit-core/src/routines/mod.rs
@@ -18,7 +18,10 @@ pub mod sweep;
 
 pub use clock::{ClockInstallReport, install_clock};
 pub use due::{DueDecision, due_decision, parse_cron};
-pub use host::{resolve_host_id, write_host_id};
+pub use host::{
+    HOST_IDENTITY_SCHEMA_VERSION, HostIdentity, HostIdentityOutcome, HostIdentityState, HostMode,
+    NewHostIdentity, ensure_host_identity, inspect_host_identity, load_host_identity, os_hostname,
+};
 pub use loader::{LoadedRoutine, RoutineCollection, RoutineLoadError, collect_routines};
 pub use status::{
     RoutineStatus, RoutineStatusReport, pause_routine, recent_fires, resume_routine,

--- a/crates/orbit-core/src/routines/status.rs
+++ b/crates/orbit-core/src/routines/status.rs
@@ -10,7 +10,7 @@ use orbit_common::types::OrbitError;
 use orbit_store::{RoutineFireRecord, Store};
 
 use super::due::{parse_cron, truncate_to_minute};
-use super::host::resolve_host_id;
+use super::host::load_host_identity;
 use super::loader::{LoadedRoutine, RoutineLoadError, collect_routines, discover_workspaces};
 
 /// Full effective state of one routine on this host.
@@ -49,7 +49,7 @@ pub struct RoutineStatusReport {
 
 /// Collect the status of every routine visible from the global registry.
 pub fn routine_statuses(global_root: &Path) -> Result<RoutineStatusReport, OrbitError> {
-    let host_id = resolve_host_id(global_root)?;
+    let host_id = load_host_identity(global_root)?.host_id;
     let store = Store::open(&global_root.join("orbit.db"))?;
 
     let discovered = discover_workspaces(global_root)?;

--- a/crates/orbit-core/src/routines/sweep.rs
+++ b/crates/orbit-core/src/routines/sweep.rs
@@ -18,7 +18,7 @@ use crate::OrbitRuntime;
 use crate::workspace_registry;
 
 use super::due::{DueDecision, due_decision, parse_cron};
-use super::host::resolve_host_id;
+use super::host::load_host_identity;
 use super::loader::{
     LoadedRoutine, RoutineCollection, RoutineLoadError, collect_routines, discover_workspaces,
 };
@@ -129,7 +129,7 @@ pub fn run_sweep(options: SweepOptions) -> Result<SweepOutcome, OrbitError> {
 
 /// Run one sweep pass against an explicit global root (test seam).
 pub fn run_sweep_at(global_root: &Path, options: SweepOptions) -> Result<SweepOutcome, OrbitError> {
-    let host_id = resolve_host_id(global_root)?;
+    let host_id = load_host_identity(global_root)?.host_id;
 
     // One pass per host at a time: overlapping invocations from a slow prior
     // pass must not double-fire. flock releases on process death, so a

--- a/crates/orbit-core/src/routines/tests/host.rs
+++ b/crates/orbit-core/src/routines/tests/host.rs
@@ -1,37 +1,158 @@
-use super::super::host::{resolve_host_id, write_host_id};
+use super::super::host::{
+    HOST_IDENTITY_SCHEMA_VERSION, HostIdentityOutcome, HostIdentityState, HostMode,
+    NewHostIdentity, ensure_host_identity, inspect_host_identity, load_host_identity,
+};
 
-#[test]
-fn write_and_resolve_round_trip() {
-    let dir = tempfile::tempdir().expect("tempdir");
-    let path = write_host_id(dir.path(), "dk-server-1").expect("write");
-    assert!(path.ends_with("host.toml"));
-    assert_eq!(resolve_host_id(dir.path()).expect("resolve"), "dk-server-1");
+fn requested(
+    name: &str,
+    mode: HostMode,
+) -> impl FnOnce() -> Result<NewHostIdentity, orbit_common::types::OrbitError> {
+    let name = name.to_string();
+    move || {
+        Ok(NewHostIdentity {
+            host_id: name,
+            mode,
+        })
+    }
 }
 
 #[test]
-fn missing_host_toml_falls_back_to_hostname() {
+fn create_persists_current_schema_identity() {
     let dir = tempfile::tempdir().expect("tempdir");
-    let resolved = resolve_host_id(dir.path()).expect("resolve");
-    assert!(!resolved.is_empty());
+    let outcome = ensure_host_identity(dir.path(), requested("dk-server-1", HostMode::Standalone))
+        .expect("create");
+    assert!(matches!(outcome, HostIdentityOutcome::Created(_)));
+    let identity = outcome.identity();
+    assert_eq!(identity.schema_version, HOST_IDENTITY_SCHEMA_VERSION);
+    assert_eq!(identity.host_id, "dk-server-1");
+    assert_eq!(identity.mode, HostMode::Standalone);
+    assert!(identity.machine_id.starts_with("hm_"));
+
+    let loaded = load_host_identity(dir.path()).expect("load");
+    assert_eq!(&loaded, identity);
 }
 
 #[test]
-fn empty_host_id_is_rejected_on_write() {
+fn repeated_init_is_unchanged_and_stable() {
     let dir = tempfile::tempdir().expect("tempdir");
-    write_host_id(dir.path(), "  ").expect_err("empty host_id must fail");
+    let created =
+        ensure_host_identity(dir.path(), requested("dk-server-1", HostMode::Hub)).expect("create");
+    let first_machine_id = created.identity().machine_id.clone();
+    let before = std::fs::read_to_string(dir.path().join("host.toml")).expect("read");
+
+    // A second init must not prompt (the closure would panic) and must not
+    // change the file.
+    let again = ensure_host_identity(dir.path(), || panic!("must not create on repeat"))
+        .expect("repeat init");
+    assert!(matches!(again, HostIdentityOutcome::Unchanged(_)));
+    assert_eq!(again.identity().machine_id, first_machine_id);
+    assert_eq!(again.identity().mode, HostMode::Hub);
+    let after = std::fs::read_to_string(dir.path().join("host.toml")).expect("read");
+    assert_eq!(before, after, "repeat init must not rewrite host.toml");
 }
 
 #[test]
-fn invalid_host_toml_is_an_error_not_a_fallback() {
+fn legacy_host_id_only_file_migrates_idempotently() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    std::fs::write(dir.path().join("host.toml"), "host_id = \"dk-server-1\"\n").expect("write");
+
+    assert!(matches!(
+        inspect_host_identity(dir.path()).expect("inspect"),
+        HostIdentityState::Legacy { .. }
+    ));
+
+    let migrated =
+        ensure_host_identity(dir.path(), || panic!("migration must not prompt")).expect("migrate");
+    assert!(matches!(migrated, HostIdentityOutcome::Migrated(_)));
+    let identity = migrated.identity();
+    assert_eq!(identity.schema_version, HOST_IDENTITY_SCHEMA_VERSION);
+    assert_eq!(identity.host_id, "dk-server-1");
+    assert_eq!(identity.mode, HostMode::Standalone);
+    let machine_id = identity.machine_id.clone();
+
+    // Second initialization preserves the generated machine_id and rewrites
+    // nothing (identical file).
+    let before = std::fs::read_to_string(dir.path().join("host.toml")).expect("read");
+    let again = ensure_host_identity(dir.path(), || panic!("no create on repeat")).expect("repeat");
+    assert!(matches!(again, HostIdentityOutcome::Unchanged(_)));
+    assert_eq!(again.identity().machine_id, machine_id);
+    let after = std::fs::read_to_string(dir.path().join("host.toml")).expect("read");
+    assert_eq!(before, after);
+}
+
+#[test]
+fn absent_file_loads_as_actionable_error_not_hostname() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    assert!(matches!(
+        inspect_host_identity(dir.path()).expect("inspect"),
+        HostIdentityState::Absent
+    ));
+    let error = load_host_identity(dir.path()).expect_err("absent must fail closed");
+    assert!(error.to_string().contains("orbit init"), "{error}");
+}
+
+#[test]
+fn legacy_file_loads_as_error_until_migrated() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    std::fs::write(dir.path().join("host.toml"), "host_id = \"dk-server-1\"\n").expect("write");
+    let error = load_host_identity(dir.path()).expect_err("legacy must not load strictly");
+    assert!(error.to_string().contains("migrate"), "{error}");
+}
+
+#[test]
+fn malformed_toml_is_an_error_not_a_fallback() {
     let dir = tempfile::tempdir().expect("tempdir");
     std::fs::write(dir.path().join("host.toml"), "host_id = [not toml").expect("write");
-    resolve_host_id(dir.path()).expect_err("invalid toml must fail closed");
+    inspect_host_identity(dir.path()).expect_err("invalid toml must fail closed");
 }
 
 #[test]
-fn blank_host_id_key_falls_back_to_hostname() {
+fn incomplete_current_schema_file_is_rejected() {
     let dir = tempfile::tempdir().expect("tempdir");
-    std::fs::write(dir.path().join("host.toml"), "host_id = \"  \"\n").expect("write");
-    let resolved = resolve_host_id(dir.path()).expect("resolve");
-    assert!(!resolved.is_empty());
+    std::fs::write(
+        dir.path().join("host.toml"),
+        "schema_version = 1\nhost_id = \"dk-server-1\"\nmode = \"standalone\"\n",
+    )
+    .expect("write");
+    let error = inspect_host_identity(dir.path()).expect_err("missing machine_id must fail");
+    assert!(error.to_string().contains("machine_id"), "{error}");
+}
+
+#[test]
+fn blank_field_is_rejected() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    std::fs::write(
+        dir.path().join("host.toml"),
+        "schema_version = 1\nmachine_id = \"hm_1\"\nhost_id = \"  \"\nmode = \"standalone\"\n",
+    )
+    .expect("write");
+    inspect_host_identity(dir.path()).expect_err("blank host_id must fail closed");
+}
+
+#[test]
+fn future_schema_version_fails_closed_without_rewrite() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let body = "schema_version = 2\nmachine_id = \"hm_future\"\nhost_id = \"dk-server-1\"\nmode = \"standalone\"\n";
+    std::fs::write(dir.path().join("host.toml"), body).expect("write");
+    inspect_host_identity(dir.path()).expect_err("future schema must fail closed");
+    // The file is left untouched (never rewritten by a read).
+    assert_eq!(
+        std::fs::read_to_string(dir.path().join("host.toml")).expect("read"),
+        body
+    );
+    // ensure must also refuse to overwrite it.
+    ensure_host_identity(dir.path(), || panic!("must not create over a future file"))
+        .expect_err("ensure must not overwrite future schema");
+    assert_eq!(
+        std::fs::read_to_string(dir.path().join("host.toml")).expect("read"),
+        body
+    );
+}
+
+#[test]
+fn invalid_mode_is_rejected() {
+    assert!(HostMode::parse("standalone").is_ok());
+    assert!(HostMode::parse("hub").is_ok());
+    assert!(HostMode::parse("spoke").is_ok());
+    HostMode::parse("bogus").expect_err("invalid mode must fail");
 }

--- a/crates/orbit-core/src/routines/tests/sweep.rs
+++ b/crates/orbit-core/src/routines/tests/sweep.rs
@@ -497,7 +497,13 @@ fn run_sweep_at_dry_run_discovers_loads_and_fails_closed() {
     fs::create_dir_all(ws_orbit.join("routines")).unwrap();
     fs::create_dir_all(ws_orbit.join("resources/jobs")).unwrap();
 
-    fs::write(global.join("host.toml"), format!("host_id = \"{HOST}\"\n")).unwrap();
+    fs::write(
+        global.join("host.toml"),
+        format!(
+            "schema_version = 1\nmachine_id = \"hm_testhost\"\nhost_id = \"{HOST}\"\nmode = \"standalone\"\n"
+        ),
+    )
+    .unwrap();
     fs::write(
         ws_orbit.join("config.toml"),
         "[routines]\nrole = \"source\"\n",

--- a/docs/design/host-registry/2_design.md
+++ b/docs/design/host-registry/2_design.md
@@ -1,7 +1,7 @@
 ---
 title: Host Registry — Design
 owner: claude
-last_updated: 2026-07-17
+last_updated: 2026-07-18
 status: Accepted
 feature: host-registry
 doc_role: design
@@ -10,7 +10,7 @@ summary: Target mechanisms for host identity, the main-host registry, the coordi
 tags: [host-registry, multi-host, dispatch, routines, data-placement]
 paths: ["crates/orbit-core/**", "crates/orbit-store/**", "crates/orbit-mcp/**", "crates/orbit-common/**"]
 related_features: [host-registry, mcp-bridge, routines, remote-access, mcp-session-context]
-related_artifacts: [ORB-00424, ADR-0200, ADR-0205, ADR-0208, ADR-0226, ADR-0227, ADR-0228, ADR-0229, ADR-0230, ADR-0231, ADR-0232]
+related_artifacts: [ORB-00424, ORB-10247, ADR-0200, ADR-0205, ADR-0208, ADR-0226, ADR-0227, ADR-0228, ADR-0229, ADR-0230, ADR-0231, ADR-0232]
 ---
 
 # Host Registry — Design
@@ -25,19 +25,36 @@ leaves client→hub transport to the [MCP bridge](../mcp-bridge/2_design.md)
 ## 1. Host Identity (`host.toml`)
 
 `~/.orbit/host.toml` remains the one genuinely host-local datum ([ADR-0205]), widened
-from a scheduling pin to general machine identity:
+from a scheduling pin to a versioned machine identity ([ORB-10247]):
 
 ```toml
 # ~/.orbit/host.toml
-host_id    = "dk-mac"        # human name; unique across the registry
-machine_id = "hm_9f2c81d4"   # generated once at init; never edited or reused
+schema_version = 1           # on-disk version; a higher value fails closed
+machine_id     = "hm_9f2c81d4"   # generated once at init; never edited or reused
+host_id        = "dk-mac"        # human name; unique across the registry
+mode           = "standalone"    # standalone | hub | spoke
 ```
 
 **Initialization moves to `orbit init`.** Global seeding prompts for a host name
-(default: OS hostname; refuses to prompt when stdin is not a TTY) and generates
-`machine_id` if absent. Non-interactive callers pass `--host-name <name>`. `orbit
-routine init` continues to work but no longer owns the file — it reads the existing
-identity and errors if none exists, replacing today's silent hostname fallback.
+(default: OS hostname; refuses to prompt when stdin is not a TTY), asks for the
+operating `mode` (default `standalone`), and generates `machine_id` if absent.
+Non-interactive callers pass `--host-name <name>` (and optionally `--host-mode`); a
+fresh host initialized non-interactively without `--host-name` fails closed rather
+than defaulting silently. `orbit routine init` continues to work but no longer owns
+the file — it reads the existing identity (limiting its own mutation to clock
+installation) and errors if none exists, replacing today's silent hostname fallback.
+
+**Migration is once and idempotent.** A legacy `host.toml` carrying only `host_id`
+(the routines-v1 scheduling pin) is upgraded in place on `orbit init`: `host_id` is
+preserved, `mode` defaults to `standalone`, and `machine_id` is generated once and
+never regenerated. A repeated init preserves the `machine_id` and writes nothing.
+The write is atomic (staged rename), so rollback always leaves the last valid
+identity readable and a partially overwritten file is impossible.
+
+**Loading is strict.** After migration, identity resolution (routine `hosts:`
+matching, the sweep, `routine status`) fails closed with an actionable error on an
+absent, malformed, incomplete, blank, or future-schema file — it never falls back to
+the OS hostname, and a newer `schema_version` fails without rewriting the file.
 
 **Resolution rule: names are for humans, `machine_id` is what the system stores.**
 Human-authored text — routine `hosts:` pins, the task `host` selector, CLI arguments
@@ -328,5 +345,8 @@ of that routine.** Consequences:
 - [ORB-00424] — proposed the local/remote Orbit MCP unification (SSH-carried stdio,
   capability sets) that carries client→hub traffic; this design adds the
   hub→satellite half as a pull-based runner protocol.
+- [ORB-10247] — implemented the versioned `HostIdentity` (§1): `schema_version` /
+  `machine_id` / `host_id` / `mode`, `orbit init` ownership, legacy migration, and
+  strict fail-closed loading (Phase 1 / Unit B1 under ORB-10246).
 
 > Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.


### PR DESCRIPTION
## Task

[ORB-10247](https://orbit-cli.com/tasks/ORB-10247) — Add stable host identity and migrate initialization ownership

### Description

## Problem

Orbit's machine identity is currently a routine-only `host_id` stored in `~/.orbit/host.toml`, initialized by `orbit routine init`, and allowed to fall back to the hostname. Host Registry requires one stable machine identity created by global initialization and shared by routines, registry, MCP, and future runner work.

This is Phase 1 / Unit B1 under implementation umbrella ORB-10246. It depends on the accepted contract freeze in ORB-10245.

## Required outcome

Introduce a versioned `HostIdentity` persisted in `~/.orbit/host.toml`:

```toml
schema_version = 1
machine_id = "hm_<generated>"
host_id = "operator-chosen-name"
mode = "standalone" # standalone | hub | spoke
```

Move first-time identity creation to global `orbit init`. Interactive initialization asks for host name and mode only when identity is absent; non-interactive initialization accepts explicit `--host-name` and `--host-mode`. Generate `machine_id` once, preserve it across ordinary and repeated initialization, and preserve an existing legacy `host_id` during migration.

After migration, identity reads fail with an actionable error when the file is absent, invalid, unsupported, or incomplete; do not fall back to the OS hostname. `orbit routine init` must read the existing identity and manage only routine clock installation, never create or rewrite machine identity.

## Compatibility and boundaries

- Legacy `host.toml` containing only `host_id` migrates atomically and idempotently.
- Existing standalone behavior remains the default; this task introduces no registry database, MCP transport, remote routing, or HA behavior.
- `machine_id` is opaque and stable; `host_id` remains renameable display identity.
- Newer unsupported schema versions fail closed without rewriting the file.
- Update the Host Registry design docs in the same PR if implementation details refine the accepted contract.
- Rollback must leave the last valid identity readable; do not partially overwrite `host.toml`.

### Acceptance Criteria

- A legacy host.toml containing only host_id migrates to schema_version 1 with the same host_id, mode standalone, and one generated machine_id; running initialization a second time produces the identical machine_id and no semantic file change.
- Fresh interactive and non-interactive initialization paths create HostIdentity exactly once, and CLI tests cover --host-name, --host-mode, invalid mode, missing non-interactive values, and repeated init.
- Identity loading rejects absent, malformed, incomplete, blank, and future-schema files with actionable errors and never falls back to the machine hostname after migration.
- orbit routine init no longer accepts ownership of host naming or writes host.toml; it reads HostIdentity and limits mutation to clock installation.
- Existing routine status/sweep host filtering uses HostIdentity.host_id, while standalone task, knowledge, graph, docs, routine, and workflow behavior remains unchanged in focused regression tests.
- cargo test -p orbit-core and cargo test -p orbit-cli pass.
- make ci-fast passes from the Orbit repository root.

## Execution Summary

<details>
<summary>Click to expand</summary>

Introduced a versioned HostIdentity in ~/.orbit/host.toml and moved first-time identity creation to global `orbit init`.

Core (orbit-core/src/routines/host.rs, full rewrite): new HostIdentity { schema_version=1, machine_id 'hm_<hex>', host_id, mode } + HostMode enum (standalone|hub|spoke, parse/Display). API: inspect_host_identity (Absent|Legacy|Present, Err for malformed/incomplete/blank/future-schema, never rewrites), load_host_identity (strict; no OS-hostname fallback; actionable errors for absent/legacy), ensure_host_identity(closure) (Created/Migrated/Unchanged; closure resolves name+mode only when Absent so prompts are deferred), os_hostname helper, and a self-contained splitmix64-based machine_id generator (no new deps). Writes are atomic (atomic_write_text staged rename) so rollback leaves the last valid file readable; deterministic serialization makes repeated init a no-op write. Legacy host_id-only files migrate once, preserving host_id, defaulting mode=standalone, generating machine_id.

Wiring: routines/status.rs and routines/sweep.rs host filtering now use load_host_identity().host_id (AC #5). core command/init.rs routine seeding uses load_host_identity (best-effort; skips on absent/legacy instead of hostname fallback). routines/mod.rs re-exports the new surface (resolve_host_id/write_host_id removed).

CLI: `orbit init` gained --host-name / --host-mode; execute + execute_without_runtime share a run() that calls ensure_host_identity after init_global. Interactive prompts for name (default OS hostname) and mode (default standalone) only when identity is absent; --non-interactive requires --host-name on a fresh host (fails closed) and defaults mode to standalone; invalid --host-mode fails closed before any write. `orbit routine init` is now read-only for identity: it reads load_host_identity (errors if absent) and limits mutation to clock installation; the --host-id flag was removed.

Tests: rewrote routines/tests/host.rs (create/migrate/idempotent/strict-load/malformed/blank/incomplete/future-schema/invalid-mode); added CLI tests for --host-name+--host-mode create, repeat-stable, legacy migration, missing non-interactive value, invalid mode; updated fixtures in routines/tests/sweep.rs and workspace/tests/init.rs to current-schema host.toml. Docs: host-registry/2_design.md §1 updated (schema_version+mode fields, migration, strict loading), last_updated bumped, ORB-10247 added to related_artifacts + Task References.

Validation: `cargo test -p orbit-core` and `cargo test -p orbit-cli` — all routines + init suites green; the only failures are PRE-EXISTING on the pristine branch and unrelated to this change (verified via git stash): orbit-core command::activity::tests::triage_agent_allowlist_makes_write_surfaces_structurally_impossible; orbit-cli tests::audit_middleware::tool_run_audit_meta_uses_agent_role_without_identity; and the docs.rs/semantic_companion.rs integration tests that require the orbit-search-companion binary (absent in this sandbox). `make ci-fast` passes (exit 0); `cargo fmt --check` clean; `cargo clippy -p orbit-core -p orbit-cli --all-targets` clean.

Deploy note: host identity loading is now strict, so on a machine whose ~/.orbit/host.toml is still the legacy host_id-only form, `orbit sweep`/`routine status` fail closed until a one-time `orbit init` migrates the file (idempotent). Run `orbit init` once post-deploy on each host.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10247-6a5ace7f`
- Behind base: 0
- Ahead of base: 1