### PR TITLE
Split logical workspace catalog from local checkout bindings

### DIFF
--- a/crates/orbit-cli/src/command/run/ship.rs
+++ b/crates/orbit-cli/src/command/run/ship.rs
@@ -75,9 +75,12 @@ fn resolve_ship_mode(
     let registry = orbit_core::workspace_registry::load_registry()?;
     let orbit_dir = runtime.shared_root();
     let mode = registry
-        .workspaces
+        .checkouts
         .iter()
-        .find(|ws| ws.orbit_dir == orbit_dir)
+        .find(|checkout| checkout.orbit_dir == orbit_dir)
+        .and_then(|checkout| {
+            orbit_core::workspace_registry::find_workspace(&registry, &checkout.workspace_id)
+        })
         .map(orbit_core::resolved_ship_mode)
         .unwrap_or(orbit_core::ShipMode::Local);
     Ok(mode)

--- a/crates/orbit-cli/src/command/run/sweep.rs
+++ b/crates/orbit-cli/src/command/run/sweep.rs
@@ -7,7 +7,7 @@
 use std::path::Path;
 
 use clap::Args;
-use orbit_common::types::{Workspace, WorkspaceStatus};
+use orbit_common::types::{Workspace, WorkspaceCheckout, WorkspaceStatus};
 use orbit_core::workspace_registry;
 use orbit_core::{
     JobRunState, OrbitError, OrbitRuntime, TaskStatus, build_task_status_index,
@@ -115,10 +115,16 @@ impl ShipSweepCommand {
         workspace_registry::save_registry_to(&registry, &registry_path)?;
 
         let mode_override = self.mode.map(ShipMode::to_core);
-        let reports: Vec<SweepReport> = registry
-            .workspaces
-            .iter()
-            .map(|ws| sweep_workspace(&global_root, ws, mode_override, self.dry_run))
+        let reports: Vec<SweepReport> = workspace_registry::local_workspaces(&registry)
+            .map(|(workspace, checkout)| {
+                sweep_workspace(
+                    &global_root,
+                    workspace,
+                    checkout,
+                    mode_override,
+                    self.dry_run,
+                )
+            })
             .collect();
 
         let failed = reports.iter().filter(|r| r.action == "error").count();
@@ -153,10 +159,11 @@ impl ShipSweepCommand {
 fn sweep_workspace(
     global_root: &Path,
     ws: &Workspace,
+    checkout: &WorkspaceCheckout,
     mode_override: Option<orbit_core::ShipMode>,
     dry_run: bool,
 ) -> SweepReport {
-    if ws.status != WorkspaceStatus::Active || !ws.orbit_dir.exists() {
+    if ws.status != WorkspaceStatus::Active || !checkout.orbit_dir.exists() {
         return SweepReport::skipped(ws, "workspace_inactive", 0);
     }
     // An explicit `--mode` override wins for every workspace; otherwise resolve
@@ -165,25 +172,28 @@ fn sweep_workspace(
     // pipeline instead of failing `pr_open` — only workspaces that carry an
     // explicit `ship_mode = "pr"` ship via PR.
     let mode = mode_override.unwrap_or_else(|| orbit_core::resolved_ship_mode(ws));
-    sweep_active_workspace(global_root, ws, mode, dry_run).unwrap_or_else(|error| SweepReport {
-        workspace_id: ws.id.clone(),
-        workspace_name: ws.name.clone(),
-        action: "error",
-        reason: Some(error.to_string()),
-        ready_backlog: 0,
-        mode: None,
-        run_id: None,
-        run_state: None,
+    sweep_active_workspace(global_root, ws, checkout, mode, dry_run).unwrap_or_else(|error| {
+        SweepReport {
+            workspace_id: ws.id.clone(),
+            workspace_name: ws.name.clone(),
+            action: "error",
+            reason: Some(error.to_string()),
+            ready_backlog: 0,
+            mode: None,
+            run_id: None,
+            run_state: None,
+        }
     })
 }
 
 fn sweep_active_workspace(
     global_root: &Path,
     ws: &Workspace,
+    checkout: &WorkspaceCheckout,
     mode: orbit_core::ShipMode,
     dry_run: bool,
 ) -> Result<SweepReport, OrbitError> {
-    let runtime = OrbitRuntime::from_roots(global_root, &ws.orbit_dir)?;
+    let runtime = OrbitRuntime::from_roots(global_root, &checkout.orbit_dir)?;
     if !runtime.workflow_auto_ship() {
         return Ok(SweepReport::skipped(ws, "auto_ship_disabled", 0));
     }

--- a/crates/orbit-cli/src/command/workspace/init.rs
+++ b/crates/orbit-cli/src/command/workspace/init.rs
@@ -3,7 +3,7 @@ use std::path::{Path, PathBuf};
 use chrono::Utc;
 use clap::Args;
 use orbit_cmd::agent_rules::{InjectionAction, inject_agent_rules};
-use orbit_common::types::{Workspace, WorkspaceStatus};
+use orbit_common::types::{Workspace, WorkspaceCheckout, WorkspaceStatus};
 use orbit_core::command::init::{InitOptions, init_workspace_at_root, seed_default_orbitignore};
 use orbit_core::workspace_registry;
 use orbit_core::{OrbitError, OrbitRuntime};
@@ -162,13 +162,29 @@ impl WorkspaceInitArgs {
                 existing.base_branch = base_branch;
             }
             existing.updated_at = Utc::now();
+            if let Some(checkout) = registry
+                .checkouts
+                .iter_mut()
+                .find(|checkout| checkout.workspace_id == id)
+            {
+                checkout.repo_root = cwd.to_path_buf();
+                checkout.orbit_dir = orbit_dir.to_path_buf();
+            } else {
+                workspace_registry::register_checkout(
+                    &mut registry,
+                    WorkspaceCheckout::owner(
+                        id.clone(),
+                        cwd.to_path_buf(),
+                        orbit_dir.to_path_buf(),
+                    ),
+                )?;
+            }
         } else {
             let now = Utc::now();
             let ws = Workspace {
                 id: id.clone(),
                 name: name.clone(),
-                root: cwd.to_path_buf(),
-                orbit_dir: orbit_dir.to_path_buf(),
+                owner_machine_id: None,
                 git_remote,
                 ship_mode: self.ship_mode,
                 base_branch: self.base_branch.unwrap_or_else(|| "main".to_string()),
@@ -177,6 +193,10 @@ impl WorkspaceInitArgs {
                 updated_at: now,
             };
             workspace_registry::register_workspace(&mut registry, ws)?;
+            workspace_registry::register_checkout(
+                &mut registry,
+                WorkspaceCheckout::owner(id.clone(), cwd.to_path_buf(), orbit_dir.to_path_buf()),
+            )?;
         }
         workspace_registry::save_registry_to(&registry, registry_path)?;
 

--- a/crates/orbit-cli/src/command/workspace/list.rs
+++ b/crates/orbit-cli/src/command/workspace/list.rs
@@ -37,13 +37,16 @@ pub(super) fn format_workspace_list(registry: &WorkspaceRegistry) -> String {
         "NAME", "ID", "STATUS", "SHIP MODE"
     );
     for workspace in &registry.workspaces {
+        let root = workspace_registry::find_checkout(registry, &workspace.id)
+            .map(|checkout| checkout.repo_root.display().to_string())
+            .unwrap_or_else(|| "-".to_string());
         output.push_str(&format!(
             "{:<20} {:<12} {:<8} {:<10} {}\n",
             workspace.name,
             workspace.id,
             workspace.status,
             orbit_core::resolved_ship_mode(workspace).as_input_value(),
-            workspace.root.display()
+            root
         ));
     }
     output

--- a/crates/orbit-cli/src/command/workspace/show.rs
+++ b/crates/orbit-cli/src/command/workspace/show.rs
@@ -1,5 +1,5 @@
 use clap::Args;
-use orbit_common::types::Workspace;
+use orbit_common::types::{Workspace, WorkspaceCheckout};
 use orbit_core::workspace_registry;
 use orbit_core::{OrbitError, OrbitRuntime};
 
@@ -17,15 +17,18 @@ impl Execute for WorkspaceShowArgs {
         let registry = workspace_registry::load_registry_from(&registry_path)?;
 
         // Find workspace whose orbit_dir matches the current runtime's data root
-        let ws = registry.workspaces.iter().find(|w| {
-            let ws_canonical =
-                std::fs::canonicalize(&w.orbit_dir).unwrap_or_else(|_| w.orbit_dir.clone());
+        let checkout = registry.checkouts.iter().find(|checkout| {
+            let ws_canonical = std::fs::canonicalize(&checkout.orbit_dir)
+                .unwrap_or_else(|_| checkout.orbit_dir.clone());
             ws_canonical == data_root_canonical
         });
 
-        match ws {
-            Some(ws) => {
-                print!("{}", format_workspace_show(ws));
+        match checkout.and_then(|checkout| {
+            workspace_registry::find_workspace(&registry, &checkout.workspace_id)
+                .map(|workspace| (workspace, checkout))
+        }) {
+            Some((workspace, checkout)) => {
+                print!("{}", format_workspace_show(workspace, checkout));
             }
             None => {
                 println!("current orbit root: {}", data_root.display());
@@ -36,13 +39,13 @@ impl Execute for WorkspaceShowArgs {
     }
 }
 
-pub(super) fn format_workspace_show(workspace: &Workspace) -> String {
+pub(super) fn format_workspace_show(workspace: &Workspace, checkout: &WorkspaceCheckout) -> String {
     let mut output = format!(
         "name:        {}\nid:          {}\nroot:        {}\norbit_dir:   {}\nbase_branch: {}\nship_mode:   {}\nstatus:      {}\n",
         workspace.name,
         workspace.id,
-        workspace.root.display(),
-        workspace.orbit_dir.display(),
+        checkout.repo_root.display(),
+        checkout.orbit_dir.display(),
         workspace.base_branch,
         orbit_core::resolved_ship_mode(workspace).as_input_value(),
         workspace.status,

--- a/crates/orbit-cli/src/command/workspace/teardown.rs
+++ b/crates/orbit-cli/src/command/workspace/teardown.rs
@@ -54,12 +54,12 @@ impl Execute for WorkspaceTeardownArgs {
         let registry_path = workspace_registry::registry_path_for(&global_root);
         if registry_path.exists() {
             let mut registry = workspace_registry::load_registry_from(&registry_path)?;
-            let ws = registry.workspaces.iter().find(|w| {
-                let ws_canonical =
-                    std::fs::canonicalize(&w.orbit_dir).unwrap_or_else(|_| w.orbit_dir.clone());
+            let checkout = registry.checkouts.iter().find(|checkout| {
+                let ws_canonical = std::fs::canonicalize(&checkout.orbit_dir)
+                    .unwrap_or_else(|_| checkout.orbit_dir.clone());
                 ws_canonical == orbit_canonical
             });
-            if let Some(ws_id) = ws.map(|w| w.id.clone()) {
+            if let Some(ws_id) = checkout.map(|checkout| checkout.workspace_id.clone()) {
                 let ws = workspace_registry::remove_workspace(&mut registry, &ws_id)?;
                 workspace_registry::save_registry_to(&registry, &registry_path)?;
                 removed.push(format!(

--- a/crates/orbit-cli/src/command/workspace/tests/init.rs
+++ b/crates/orbit-cli/src/command/workspace/tests/init.rs
@@ -4,7 +4,8 @@ use tempfile::tempdir;
 
 use chrono::Utc;
 use orbit_common::types::{
-    OverlapPolicy, RoutineTarget, Workspace, WorkspaceRegistry, WorkspaceStatus, parse_routine_yaml,
+    OverlapPolicy, RoutineTarget, Workspace, WorkspaceCheckout, WorkspaceRegistry, WorkspaceStatus,
+    parse_routine_yaml,
 };
 use orbit_core::command::init::default_orbitignore_template;
 use orbit_core::workspace_registry;
@@ -154,8 +155,7 @@ fn workspace_list_and_show_report_effective_ship_mode() {
     let workspace = Workspace {
         id: "ws_pr_gated".to_string(),
         name: "pr-gated".to_string(),
-        root: "/work/pr-gated".into(),
-        orbit_dir: "/work/pr-gated/.orbit".into(),
+        owner_machine_id: None,
         git_remote: None,
         ship_mode: Some("pr".to_string()),
         base_branch: "agent-main".to_string(),
@@ -165,6 +165,11 @@ fn workspace_list_and_show_report_effective_ship_mode() {
     };
     let registry = WorkspaceRegistry {
         workspaces: vec![workspace.clone()],
+        checkouts: vec![WorkspaceCheckout::owner(
+            workspace.id.clone(),
+            "/work/pr-gated".into(),
+            "/work/pr-gated/.orbit".into(),
+        )],
         ..Default::default()
     };
 
@@ -172,7 +177,7 @@ fn workspace_list_and_show_report_effective_ship_mode() {
     assert!(list.contains("SHIP MODE"), "{list}");
     assert!(list.contains("pr"), "{list}");
 
-    let show = format_workspace_show(&workspace);
+    let show = format_workspace_show(&workspace, &registry.checkouts[0]);
     assert!(show.contains("ship_mode:   pr"), "{show}");
 }
 
@@ -648,12 +653,14 @@ fn workspace_init_with_root_override_uses_custom_registry() {
         .iter()
         .find(|workspace| workspace.name == "custom-root")
         .expect("registered workspace");
+    let checkout = workspace_registry::find_checkout(&registry, &workspace_record.id)
+        .expect("registered checkout");
     assert_eq!(
-        std::fs::canonicalize(&workspace_record.root).expect("canonical registered root"),
+        std::fs::canonicalize(&checkout.repo_root).expect("canonical registered root"),
         std::fs::canonicalize(workspace.path()).expect("canonical workspace")
     );
     assert_eq!(
-        std::fs::canonicalize(&workspace_record.orbit_dir).expect("canonical registered root"),
+        std::fs::canonicalize(&checkout.orbit_dir).expect("canonical registered root"),
         std::fs::canonicalize(&custom_root).expect("canonical custom root")
     );
     assert_eq!(workspace_record.base_branch, "main");

--- a/crates/orbit-common/src/types/mod.rs
+++ b/crates/orbit-common/src/types/mod.rs
@@ -155,7 +155,10 @@ pub use tool_input::{
     optional_string, optional_string_alias, optional_string_list_alias, optional_u32_alias,
     required_string, split_csv, strip_retired_task_add_input_fields,
 };
-pub use workspace::{Workspace, WorkspacePaths, WorkspaceRegistry, WorkspaceStatus};
+pub use workspace::{
+    WORKSPACE_REGISTRY_SCHEMA_VERSION, Workspace, WorkspaceCheckout, WorkspaceCheckoutRole,
+    WorkspacePaths, WorkspaceRegistry, WorkspaceStatus,
+};
 
 #[cfg(test)]
 mod tests;

--- a/crates/orbit-common/src/types/tests/mod.rs
+++ b/crates/orbit-common/src/types/tests/mod.rs
@@ -13,3 +13,4 @@ mod routine;
 mod task;
 mod task_artifacts;
 mod tool_input;
+mod workspace;

--- a/crates/orbit-common/src/types/tests/workspace.rs
+++ b/crates/orbit-common/src/types/tests/workspace.rs
@@ -1,0 +1,43 @@
+use chrono::{TimeZone, Utc};
+
+use crate::types::{
+    WORKSPACE_REGISTRY_SCHEMA_VERSION, Workspace, WorkspaceCheckout, WorkspaceCheckoutRole,
+    WorkspaceRegistry, WorkspaceStatus,
+};
+
+#[test]
+fn registry_serialization_keeps_paths_out_of_logical_workspaces() {
+    let now = Utc
+        .with_ymd_and_hms(2026, 7, 18, 1, 2, 3)
+        .single()
+        .expect("fixed timestamp");
+    let registry = WorkspaceRegistry {
+        workspaces: vec![Workspace {
+            id: "ws_orbit".to_string(),
+            name: "orbit".to_string(),
+            owner_machine_id: Some("hm_owner".to_string()),
+            git_remote: None,
+            ship_mode: Some("pr".to_string()),
+            base_branch: "agent-main".to_string(),
+            status: WorkspaceStatus::Active,
+            created_at: now,
+            updated_at: now,
+        }],
+        checkouts: vec![WorkspaceCheckout {
+            workspace_id: "ws_orbit".to_string(),
+            repo_root: "/repos/orbit".into(),
+            orbit_dir: "/repos/orbit/.orbit".into(),
+            role: Some(WorkspaceCheckoutRole::Replica),
+            owner_machine_id: Some("hm_owner".to_string()),
+            path_overrides: vec!["/worktrees/orbit-feature".into()],
+        }],
+        ..Default::default()
+    };
+
+    let value = serde_json::to_value(&registry).expect("serialize registry");
+    assert_eq!(value["schema_version"], WORKSPACE_REGISTRY_SCHEMA_VERSION);
+    assert!(value["workspaces"][0].get("repo_root").is_none());
+    assert!(value["workspaces"][0].get("orbit_dir").is_none());
+    assert_eq!(value["checkouts"][0]["role"], "replica");
+    assert_eq!(value["checkouts"][0]["owner_machine_id"], "hm_owner");
+}

--- a/crates/orbit-common/src/types/workspace.rs
+++ b/crates/orbit-common/src/types/workspace.rs
@@ -1,10 +1,12 @@
-use std::collections::HashMap;
 use std::fmt;
 use std::path::PathBuf;
 use std::str::FromStr;
 
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
+
+/// Current on-disk schema version for `~/.orbit/workspaces.json`.
+pub const WORKSPACE_REGISTRY_SCHEMA_VERSION: u32 = 1;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -34,11 +36,14 @@ impl FromStr for WorkspaceStatus {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct Workspace {
     pub id: String,
     pub name: String,
-    pub root: PathBuf,
-    pub orbit_dir: PathBuf,
+    /// Stable owner identity. Standalone registries created before host
+    /// identity existed may omit this; hub and spoke registries may not.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub owner_machine_id: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub git_remote: Option<String>,
     /// Explicit ship-pipeline mode for this workspace: `"pr"` or `"local"`.
@@ -64,12 +69,67 @@ fn default_status() -> WorkspaceStatus {
     WorkspaceStatus::Active
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+/// This machine's role for a local checkout of a logical workspace.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum WorkspaceCheckoutRole {
+    /// This machine owns the canonical checkout.
+    Owner,
+    /// This checkout is a replica of a workspace owned by another machine.
+    Replica,
+}
+
+/// Machine-local filesystem binding for a logical [`Workspace`].
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct WorkspaceCheckout {
+    pub workspace_id: String,
+    pub repo_root: PathBuf,
+    pub orbit_dir: PathBuf,
+    /// Missing only while loading a legacy/partially migrated standalone
+    /// registry; registry validation canonicalizes it to `owner`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub role: Option<WorkspaceCheckoutRole>,
+    /// Required only for replicas and always names the stable owner machine.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub owner_machine_id: Option<String>,
+    /// Additional roots (for example linked worktrees) that resolve to this
+    /// local checkout. These never appear on the logical workspace record.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub path_overrides: Vec<PathBuf>,
+}
+
+impl WorkspaceCheckout {
+    pub fn owner(workspace_id: String, repo_root: PathBuf, orbit_dir: PathBuf) -> Self {
+        Self {
+            workspace_id,
+            repo_root,
+            orbit_dir,
+            role: Some(WorkspaceCheckoutRole::Owner),
+            owner_machine_id: None,
+            path_overrides: Vec::new(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct WorkspaceRegistry {
+    pub schema_version: u32,
     #[serde(default)]
     pub workspaces: Vec<Workspace>,
     #[serde(default)]
-    pub path_overrides: HashMap<PathBuf, String>,
+    pub checkouts: Vec<WorkspaceCheckout>,
+}
+
+impl Default for WorkspaceRegistry {
+    fn default() -> Self {
+        Self {
+            schema_version: WORKSPACE_REGISTRY_SCHEMA_VERSION,
+            workspaces: Vec::new(),
+            checkouts: Vec::new(),
+        }
+    }
 }
 
 /// Derived directory layout for a workspace.

--- a/crates/orbit-core/src/command/workflow.rs
+++ b/crates/orbit-core/src/command/workflow.rs
@@ -365,14 +365,12 @@ mod ship_mode_resolution_tests {
     use super::*;
     use chrono::Utc;
     use orbit_common::types::{Workspace, WorkspaceStatus};
-    use std::path::PathBuf;
 
     fn workspace(git_remote: Option<&str>, ship_mode: Option<&str>) -> Workspace {
         Workspace {
             id: "ws_test".to_string(),
             name: "test".to_string(),
-            root: PathBuf::from("/tmp/test"),
-            orbit_dir: PathBuf::from("/tmp/test/.orbit"),
+            owner_machine_id: None,
             git_remote: git_remote.map(str::to_string),
             ship_mode: ship_mode.map(str::to_string),
             base_branch: "agent-main".to_string(),

--- a/crates/orbit-core/src/routines/loader.rs
+++ b/crates/orbit-core/src/routines/loader.rs
@@ -73,15 +73,15 @@ pub fn discover_workspaces(global_root: &Path) -> Result<DiscoveredWorkspaces, O
     workspace_registry::save_registry_to(&registry, &registry_path)?;
 
     let mut discovered = DiscoveredWorkspaces::default();
-    for workspace in registry.workspaces {
-        if workspace.status != WorkspaceStatus::Active || !workspace.orbit_dir.exists() {
+    for (workspace, checkout) in workspace_registry::local_workspaces(&registry) {
+        if workspace.status != WorkspaceStatus::Active || !checkout.orbit_dir.exists() {
             continue;
         }
-        match OrbitRuntime::from_roots(global_root, &workspace.orbit_dir) {
-            Ok(runtime) => discovered.entries.push((workspace, runtime)),
+        match OrbitRuntime::from_roots(global_root, &checkout.orbit_dir) {
+            Ok(runtime) => discovered.entries.push((workspace.clone(), runtime)),
             Err(error) => discovered.errors.push(RoutineLoadError {
                 source_workspace: workspace.name.clone(),
-                path: Some(workspace.orbit_dir.clone()),
+                path: Some(checkout.orbit_dir.clone()),
                 message: format!("failed to open workspace runtime: {error}"),
             }),
         }
@@ -111,7 +111,7 @@ fn load_source_workspace(
     runtime: &OrbitRuntime,
     collection: &mut RoutineCollection,
 ) {
-    let routines_dir = workspace.orbit_dir.join(ROUTINES_DIR);
+    let routines_dir = runtime.shared_root().join(ROUTINES_DIR);
     if !routines_dir.is_dir() {
         // A source with no routines directory is simply an empty source.
         return;
@@ -178,7 +178,7 @@ fn load_routine_file(
     Ok(LoadedRoutine {
         definition,
         source_workspace: workspace.name.clone(),
-        source_orbit_dir: workspace.orbit_dir.clone(),
+        source_orbit_dir: runtime.shared_root(),
         path: path.to_path_buf(),
     })
 }

--- a/crates/orbit-core/src/routines/sweep.rs
+++ b/crates/orbit-core/src/routines/sweep.rs
@@ -156,7 +156,7 @@ pub fn run_sweep_at(global_root: &Path, options: SweepOptions) -> Result<SweepOu
         runtimes: discovered
             .entries
             .iter()
-            .map(|(workspace, runtime)| (workspace.orbit_dir.clone(), runtime))
+            .map(|(_, runtime)| (runtime.shared_root(), runtime))
             .collect(),
     };
 

--- a/crates/orbit-core/src/routines/tests/sweep.rs
+++ b/crates/orbit-core/src/routines/tests/sweep.rs
@@ -17,8 +17,8 @@ use std::path::{Path, PathBuf};
 
 use chrono::{DateTime, Duration, TimeZone, Utc};
 use orbit_common::types::{
-    JobRunState, OrbitError, RoutineDefinition, Workspace, WorkspaceRegistry, WorkspaceStatus,
-    parse_routine_yaml,
+    JobRunState, OrbitError, RoutineDefinition, Workspace, WorkspaceCheckout, WorkspaceRegistry,
+    WorkspaceStatus, parse_routine_yaml,
 };
 use orbit_store::{RoutineFireIntentParams, RoutineFireState, Store};
 use tempfile::tempdir;
@@ -537,8 +537,7 @@ fn run_sweep_at_dry_run_discovers_loads_and_fails_closed() {
     registry.workspaces.push(Workspace {
         id: "ws-1".to_string(),
         name: "polaris".to_string(),
-        root: ws_root.clone(),
-        orbit_dir: ws_orbit.clone(),
+        owner_machine_id: None,
         git_remote: None,
         ship_mode: None,
         base_branch: "agent-main".to_string(),
@@ -546,6 +545,11 @@ fn run_sweep_at_dry_run_discovers_loads_and_fails_closed() {
         created_at: Utc::now(),
         updated_at: Utc::now(),
     });
+    registry.checkouts.push(WorkspaceCheckout::owner(
+        "ws-1".to_string(),
+        ws_root,
+        ws_orbit,
+    ));
     workspace_registry::save_registry_to(
         &registry,
         &workspace_registry::registry_path_for(&global),

--- a/crates/orbit-core/src/runtime/builder.rs
+++ b/crates/orbit-core/src/runtime/builder.rs
@@ -197,10 +197,10 @@ fn registered_repo_root(global_root: &Path, workspace_root: &Path) -> Option<Pat
     let registry = workspace_registry::load_registry_from(&registry_path).ok()?;
     let workspace_root_canonical =
         std::fs::canonicalize(workspace_root).unwrap_or_else(|_| workspace_root.to_path_buf());
-    registry.workspaces.iter().find_map(|workspace| {
-        let orbit_dir_canonical = std::fs::canonicalize(&workspace.orbit_dir)
-            .unwrap_or_else(|_| workspace.orbit_dir.clone());
-        (orbit_dir_canonical == workspace_root_canonical).then(|| workspace.root.clone())
+    registry.checkouts.iter().find_map(|checkout| {
+        let orbit_dir_canonical = std::fs::canonicalize(&checkout.orbit_dir)
+            .unwrap_or_else(|_| checkout.orbit_dir.clone());
+        (orbit_dir_canonical == workspace_root_canonical).then(|| checkout.repo_root.clone())
     })
 }
 

--- a/crates/orbit-core/src/runtime/resolve.rs
+++ b/crates/orbit-core/src/runtime/resolve.rs
@@ -180,8 +180,8 @@ enum ExplicitRootMode {
 /// Checks path_overrides in the global registry for a matching workspace.
 fn resolve_from_path_override(cwd: &Path) -> Option<PathBuf> {
     let registry = workspace_registry::load_registry().ok()?;
-    let ws = workspace_registry::find_workspace_by_path(&registry, cwd)?;
-    Some(ws.orbit_dir.clone())
+    let checkout = workspace_registry::find_checkout_by_path(&registry, cwd)?;
+    Some(checkout.orbit_dir.clone())
 }
 
 fn find_main_worktree_orbit_dir(cwd: &Path) -> Option<PathBuf> {

--- a/crates/orbit-core/src/runtime/v2_host/dispatch.rs
+++ b/crates/orbit-core/src/runtime/v2_host/dispatch.rs
@@ -319,9 +319,12 @@ fn resolve_workspace_ship_input(
         })?;
     let source_orbit_dir = runtime.shared_root();
     let mode = registry
-        .workspaces
+        .checkouts
         .iter()
-        .find(|workspace| workspace.orbit_dir == source_orbit_dir)
+        .find(|checkout| checkout.orbit_dir == source_orbit_dir)
+        .and_then(|checkout| {
+            crate::workspace_registry::find_workspace(&registry, &checkout.workspace_id)
+        })
         .map(crate::command::workflow::resolved_ship_mode)
         .unwrap_or(crate::command::workflow::ShipMode::Local);
 
@@ -424,7 +427,7 @@ mod tests {
     use serde_json::json;
     use tempfile::tempdir;
 
-    use orbit_common::types::{Workspace, WorkspaceRegistry, WorkspaceStatus};
+    use orbit_common::types::{Workspace, WorkspaceCheckout, WorkspaceRegistry, WorkspaceStatus};
 
     fn seed_task(
         runtime: &OrbitRuntime,
@@ -618,8 +621,7 @@ mod tests {
                 Workspace {
                     id: "ws-other".to_string(),
                     name: "other".to_string(),
-                    root: other_root,
-                    orbit_dir: other_orbit,
+                    owner_machine_id: None,
                     git_remote: None,
                     ship_mode: Some("local".to_string()),
                     base_branch: "wrong-branch".to_string(),
@@ -630,8 +632,7 @@ mod tests {
                 Workspace {
                     id: "ws-source".to_string(),
                     name: "source".to_string(),
-                    root: source_root,
-                    orbit_dir: source_orbit.clone(),
+                    owner_machine_id: None,
                     git_remote: None,
                     ship_mode: Some("pr".to_string()),
                     base_branch: "registry-branch".to_string(),
@@ -639,6 +640,14 @@ mod tests {
                     created_at: now,
                     updated_at: now,
                 },
+            ],
+            checkouts: vec![
+                WorkspaceCheckout::owner("ws-other".to_string(), other_root, other_orbit),
+                WorkspaceCheckout::owner(
+                    "ws-source".to_string(),
+                    source_root,
+                    source_orbit.clone(),
+                ),
             ],
             ..WorkspaceRegistry::default()
         };

--- a/crates/orbit-core/src/tests/workspace_registry.rs
+++ b/crates/orbit-core/src/tests/workspace_registry.rs
@@ -1,0 +1,385 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use chrono::{TimeZone, Utc};
+use orbit_common::types::{
+    OrbitError, WORKSPACE_REGISTRY_SCHEMA_VERSION, Workspace, WorkspaceCheckout,
+    WorkspaceCheckoutRole, WorkspaceRegistry, WorkspaceStatus,
+};
+use serde_json::{Value, json};
+use tempfile::tempdir;
+
+use super::{
+    find_checkout_by_path, find_workspace, find_workspace_by_path, load_registry_from,
+    load_registry_from_with_writer,
+};
+
+fn timestamp() -> chrono::DateTime<Utc> {
+    Utc.with_ymd_and_hms(2026, 7, 18, 1, 2, 3)
+        .single()
+        .expect("fixed timestamp")
+}
+
+fn logical_workspace(id: &str, owner_machine_id: Option<&str>) -> Workspace {
+    Workspace {
+        id: id.to_string(),
+        name: id.trim_start_matches("ws_").to_string(),
+        owner_machine_id: owner_machine_id.map(str::to_string),
+        git_remote: Some("git@example.test:orbit/repo.git".to_string()),
+        ship_mode: Some("pr".to_string()),
+        base_branch: "agent-main".to_string(),
+        status: WorkspaceStatus::Active,
+        created_at: timestamp(),
+        updated_at: timestamp(),
+    }
+}
+
+fn write_host_identity(root: &Path, mode: &str, machine_id: &str) {
+    fs::write(
+        root.join("host.toml"),
+        format!(
+            "schema_version = 1\nmachine_id = \"{machine_id}\"\nhost_id = \"test-host\"\nmode = \"{mode}\"\n"
+        ),
+    )
+    .expect("write host identity");
+}
+
+fn write_json(path: &Path, value: &Value) -> Vec<u8> {
+    let bytes = serde_json::to_vec_pretty(value).expect("serialize fixture");
+    fs::write(path, &bytes).expect("write fixture");
+    bytes
+}
+
+#[test]
+fn legacy_registry_migrates_to_path_free_catalog_and_is_byte_stable() {
+    let root = tempdir().expect("tempdir");
+    let path = root.path().join("workspaces.json");
+    let repo_root = root.path().join("repo");
+    let orbit_dir = repo_root.join(".orbit");
+    let override_path = root.path().join("linked-worktree");
+    write_json(
+        &path,
+        &json!({
+            "workspaces": [{
+                "id": "ws_orbit",
+                "name": "orbit",
+                "root": repo_root,
+                "orbit_dir": orbit_dir,
+                "git_remote": "git@example.test:orbit/orbit.git",
+                "ship_mode": "pr",
+                "base_branch": "agent-main",
+                "status": "active",
+                "created_at": "2026-07-18T01:02:03Z",
+                "updated_at": "2026-07-18T01:02:03Z"
+            }],
+            "path_overrides": {
+                (override_path.to_string_lossy().to_string()): "ws_orbit",
+                (root.path().join("dangling").to_string_lossy().to_string()): "ws_missing"
+            }
+        }),
+    );
+
+    let migrated = load_registry_from(&path).expect("migrate registry");
+    assert_eq!(migrated.schema_version, WORKSPACE_REGISTRY_SCHEMA_VERSION);
+    assert_eq!(migrated.workspaces.len(), 1);
+    assert_eq!(migrated.checkouts.len(), 1);
+    let workspace = &migrated.workspaces[0];
+    assert_eq!(workspace.id, "ws_orbit");
+    assert_eq!(workspace.name, "orbit");
+    assert_eq!(
+        workspace.git_remote.as_deref(),
+        Some("git@example.test:orbit/orbit.git")
+    );
+    assert_eq!(workspace.ship_mode.as_deref(), Some("pr"));
+    assert_eq!(workspace.base_branch, "agent-main");
+    assert_eq!(workspace.created_at, timestamp());
+    assert_eq!(workspace.updated_at, timestamp());
+    let checkout = &migrated.checkouts[0];
+    assert_eq!(checkout.workspace_id, "ws_orbit");
+    assert_eq!(checkout.role, Some(WorkspaceCheckoutRole::Owner));
+    assert_eq!(checkout.path_overrides, vec![override_path]);
+
+    let persisted: Value =
+        serde_json::from_slice(&fs::read(&path).expect("read migrated registry"))
+            .expect("parse migrated registry");
+    assert!(persisted["workspaces"][0].get("root").is_none());
+    assert!(persisted["workspaces"][0].get("orbit_dir").is_none());
+    assert!(persisted.get("path_overrides").is_none());
+    assert_eq!(persisted["checkouts"][0]["role"], "owner");
+
+    let first_bytes = fs::read(&path).expect("read first migration");
+    let second = load_registry_from(&path).expect("load migrated registry again");
+    assert_eq!(second, migrated);
+    assert_eq!(fs::read(&path).expect("read second migration"), first_bytes);
+}
+
+#[test]
+fn standalone_missing_role_canonicalizes_to_local_owner() {
+    let root = tempdir().expect("tempdir");
+    let path = root.path().join("workspaces.json");
+    write_json(
+        &path,
+        &json!({
+            "schema_version": 1,
+            "workspaces": [logical_workspace("ws_orbit", None)],
+            "checkouts": [{
+                "workspace_id": "ws_orbit",
+                "repo_root": "/repos/orbit",
+                "orbit_dir": "/repos/orbit/.orbit"
+            }]
+        }),
+    );
+
+    let registry = load_registry_from(&path).expect("load standalone registry");
+    assert_eq!(
+        registry.checkouts[0].role,
+        Some(WorkspaceCheckoutRole::Owner)
+    );
+    let persisted: Value =
+        serde_json::from_slice(&fs::read(&path).expect("read registry")).expect("parse registry");
+    assert_eq!(persisted["checkouts"][0]["role"], "owner");
+}
+
+#[test]
+fn multi_host_legacy_registry_rejects_missing_role_without_rewriting() {
+    for mode in ["hub", "spoke"] {
+        let root = tempdir().expect("tempdir");
+        write_host_identity(root.path(), mode, "hm_local");
+        let path = root.path().join("workspaces.json");
+        let original = write_json(
+            &path,
+            &json!({
+                "workspaces": [{
+                    "id": "ws_legacy",
+                    "name": "legacy",
+                    "root": "/repos/legacy",
+                    "orbit_dir": "/repos/legacy/.orbit",
+                    "git_remote": null,
+                    "base_branch": "main",
+                    "status": "active",
+                    "created_at": "2026-07-18T01:02:03Z",
+                    "updated_at": "2026-07-18T01:02:03Z"
+                }],
+                "path_overrides": {}
+            }),
+        );
+
+        let error = load_registry_from(&path).expect_err("legacy role must not be inferred");
+        let message = error.to_string();
+        assert!(message.contains("ws_legacy"), "{message}");
+        assert!(
+            message.contains("missing a local checkout role"),
+            "{message}"
+        );
+        assert_eq!(fs::read(&path).expect("read unchanged registry"), original);
+    }
+}
+
+#[test]
+fn multi_host_modes_reject_missing_unknown_and_contradictory_roles_by_workspace_id() {
+    let cases = [
+        (
+            "hub",
+            json!({
+                "workspace_id": "ws_missing_role",
+                "repo_root": "/repos/missing",
+                "orbit_dir": "/repos/missing/.orbit"
+            }),
+            "missing a local checkout role",
+        ),
+        (
+            "spoke",
+            json!({
+                "workspace_id": "ws_unknown_role",
+                "repo_root": "/repos/unknown",
+                "orbit_dir": "/repos/unknown/.orbit",
+                "role": "secondary"
+            }),
+            "unknown checkout role 'secondary'",
+        ),
+        (
+            "hub",
+            json!({
+                "workspace_id": "ws_contradictory",
+                "repo_root": "/repos/contradictory",
+                "orbit_dir": "/repos/contradictory/.orbit",
+                "role": "owner"
+            }),
+            "logical owner is machine 'hm_remote'",
+        ),
+        (
+            "spoke",
+            json!({
+                "workspace_id": "ws_replica_without_owner",
+                "repo_root": "/repos/replica",
+                "orbit_dir": "/repos/replica/.orbit",
+                "role": "replica"
+            }),
+            "replica role without owner_machine_id",
+        ),
+    ];
+
+    for (mode, checkout, expected) in cases {
+        let root = tempdir().expect("tempdir");
+        write_host_identity(root.path(), mode, "hm_local");
+        let path = root.path().join("workspaces.json");
+        let workspace_id = checkout["workspace_id"].as_str().expect("workspace id");
+        let owner = match workspace_id {
+            "ws_contradictory" | "ws_replica_without_owner" => Some("hm_remote"),
+            _ => Some("hm_local"),
+        };
+        let original = write_json(
+            &path,
+            &json!({
+                "schema_version": 1,
+                "workspaces": [logical_workspace(workspace_id, owner)],
+                "checkouts": [checkout]
+            }),
+        );
+
+        let error = load_registry_from(&path).expect_err("invalid role must fail closed");
+        let message = error.to_string();
+        assert!(message.contains(workspace_id), "{message}");
+        assert!(message.contains(expected), "{message}");
+        assert_eq!(fs::read(&path).expect("read unchanged registry"), original);
+    }
+}
+
+#[test]
+fn valid_spoke_replica_requires_and_preserves_owner_machine() {
+    let root = tempdir().expect("tempdir");
+    write_host_identity(root.path(), "spoke", "hm_local");
+    let path = root.path().join("workspaces.json");
+    write_json(
+        &path,
+        &json!({
+            "schema_version": 1,
+            "workspaces": [logical_workspace("ws_orbit", Some("hm_owner"))],
+            "checkouts": [{
+                "workspace_id": "ws_orbit",
+                "repo_root": "/repos/orbit",
+                "orbit_dir": "/repos/orbit/.orbit",
+                "role": "replica",
+                "owner_machine_id": "hm_owner"
+            }]
+        }),
+    );
+
+    let registry = load_registry_from(&path).expect("valid replica registry");
+    assert_eq!(
+        registry.checkouts[0].role,
+        Some(WorkspaceCheckoutRole::Replica)
+    );
+    assert_eq!(
+        registry.checkouts[0].owner_machine_id.as_deref(),
+        Some("hm_owner")
+    );
+}
+
+#[test]
+fn identity_lookup_is_path_independent_and_path_lookup_is_checkout_only() {
+    let mut registry = WorkspaceRegistry {
+        workspaces: vec![
+            logical_workspace("ws_outer", None),
+            logical_workspace("ws_inner", None),
+            logical_workspace("ws_remote", Some("hm_remote")),
+        ],
+        checkouts: vec![
+            WorkspaceCheckout::owner(
+                "ws_outer".to_string(),
+                PathBuf::from("/repos"),
+                PathBuf::from("/repos/.orbit"),
+            ),
+            WorkspaceCheckout::owner(
+                "ws_inner".to_string(),
+                PathBuf::from("/different/inner"),
+                PathBuf::from("/different/inner/.orbit"),
+            ),
+        ],
+        ..Default::default()
+    };
+    registry.checkouts[1]
+        .path_overrides
+        .push(PathBuf::from("/repos/inner"));
+
+    assert_eq!(
+        find_workspace(&registry, "ws_remote").map(|workspace| workspace.id.as_str()),
+        Some("ws_remote")
+    );
+    assert_eq!(
+        find_workspace(&registry, "remote").map(|workspace| workspace.id.as_str()),
+        Some("ws_remote")
+    );
+    assert_eq!(
+        find_workspace_by_path(&registry, Path::new("/repos/inner/src"))
+            .map(|workspace| workspace.id.as_str()),
+        Some("ws_inner")
+    );
+    assert_eq!(
+        find_checkout_by_path(&registry, Path::new("/repos/inner/src"))
+            .map(|checkout| checkout.workspace_id.as_str()),
+        Some("ws_inner")
+    );
+    assert!(find_workspace_by_path(&registry, Path::new("/remote/ws_remote")).is_none());
+}
+
+#[test]
+fn malformed_and_future_registries_fail_without_rewriting() {
+    let root = tempdir().expect("tempdir");
+    for (name, bytes, expected) in [
+        ("malformed", b"{ not json".to_vec(), "malformed JSON"),
+        (
+            "future",
+            serde_json::to_vec_pretty(&json!({
+                "schema_version": WORKSPACE_REGISTRY_SCHEMA_VERSION + 1,
+                "workspaces": [],
+                "checkouts": []
+            }))
+            .expect("serialize future fixture"),
+            "unsupported schema_version",
+        ),
+    ] {
+        let path = root.path().join(format!("{name}.json"));
+        fs::write(&path, &bytes).expect("write invalid fixture");
+        let error = load_registry_from(&path).expect_err("invalid registry must fail");
+        assert!(error.to_string().contains(expected), "{error}");
+        assert_eq!(fs::read(&path).expect("read unchanged fixture"), bytes);
+    }
+}
+
+#[test]
+fn injected_migration_write_failure_preserves_readable_legacy_registry() {
+    let root = tempdir().expect("tempdir");
+    let path = root.path().join("workspaces.json");
+    let original = write_json(
+        &path,
+        &json!({
+            "workspaces": [{
+                "id": "ws_orbit",
+                "name": "orbit",
+                "root": "/repos/orbit",
+                "orbit_dir": "/repos/orbit/.orbit",
+                "git_remote": null,
+                "base_branch": "main",
+                "status": "active",
+                "created_at": "2026-07-18T01:02:03Z",
+                "updated_at": "2026-07-18T01:02:03Z"
+            }],
+            "path_overrides": {}
+        }),
+    );
+
+    let error = load_registry_from_with_writer(&path, |_, _| {
+        Err(OrbitError::Io("injected write failure".to_string()))
+    })
+    .expect_err("write failure must surface");
+    assert!(error.to_string().contains("injected write failure"));
+    assert_eq!(
+        fs::read(&path).expect("read preserved legacy file"),
+        original
+    );
+
+    let recovered = load_registry_from(&path).expect("legacy source remains migratable");
+    assert_eq!(recovered.workspaces[0].id, "ws_orbit");
+    assert_eq!(recovered.checkouts[0].workspace_id, "ws_orbit");
+}

--- a/crates/orbit-core/src/workspace_registry.rs
+++ b/crates/orbit-core/src/workspace_registry.rs
@@ -1,11 +1,16 @@
+use std::collections::{BTreeMap, HashSet};
 use std::path::{Path, PathBuf};
 
-use chrono::Utc;
+use chrono::{DateTime, Utc};
 use orbit_common::types::{
-    NotFoundKind, OrbitError, Workspace, WorkspaceRegistry, WorkspaceStatus,
+    NotFoundKind, OrbitError, WORKSPACE_REGISTRY_SCHEMA_VERSION, Workspace, WorkspaceCheckout,
+    WorkspaceCheckoutRole, WorkspaceRegistry, WorkspaceStatus,
 };
-
 use orbit_common::utility::fs::atomic_write_text;
+use serde::Deserialize;
+use serde_json::Value;
+
+use crate::routines::{HostIdentityState, HostMode, inspect_host_identity};
 
 /// Returns the global Orbit directory: `~/.orbit/`.
 pub fn global_orbit_dir() -> Result<PathBuf, OrbitError> {
@@ -31,12 +36,25 @@ pub fn load_registry() -> Result<WorkspaceRegistry, OrbitError> {
 
 /// Loads the workspace registry from a specific path (for testing).
 pub fn load_registry_from(path: &Path) -> Result<WorkspaceRegistry, OrbitError> {
+    load_registry_from_with_writer(path, |registry, destination| {
+        write_registry(registry, destination)
+    })
+}
+
+fn load_registry_from_with_writer(
+    path: &Path,
+    writer: impl FnOnce(&WorkspaceRegistry, &Path) -> Result<(), OrbitError>,
+) -> Result<WorkspaceRegistry, OrbitError> {
     if !path.exists() {
         return Ok(WorkspaceRegistry::default());
     }
     let content = std::fs::read_to_string(path).map_err(|e| OrbitError::Io(e.to_string()))?;
-    serde_json::from_str(&content)
-        .map_err(|e| OrbitError::WorkspaceError(format!("invalid registry: {e}")))
+    let context = registry_host_context(path)?;
+    let (registry, migrated) = parse_registry(&content, &context)?;
+    if migrated {
+        writer(&registry, path)?;
+    }
+    Ok(registry)
 }
 
 /// Saves the workspace registry atomically.
@@ -46,9 +64,10 @@ pub fn save_registry(registry: &WorkspaceRegistry) -> Result<(), OrbitError> {
 
 /// Saves the workspace registry to a specific path (for testing).
 pub fn save_registry_to(registry: &WorkspaceRegistry, path: &Path) -> Result<(), OrbitError> {
-    let content = serde_json::to_string_pretty(registry)
-        .map_err(|e| OrbitError::WorkspaceError(format!("failed to serialize registry: {e}")))?;
-    atomic_write_text(path, &content).map_err(Into::into)
+    let context = registry_host_context(path)?;
+    let mut canonical = registry.clone();
+    validate_registry(&mut canonical, &context)?;
+    write_registry(&canonical, path)
 }
 
 /// Registers a new workspace. Errors if a workspace with the same id or name already exists.
@@ -72,6 +91,35 @@ pub fn register_workspace(
     Ok(())
 }
 
+/// Registers a machine-local checkout for an existing logical workspace.
+pub fn register_checkout(
+    registry: &mut WorkspaceRegistry,
+    checkout: WorkspaceCheckout,
+) -> Result<(), OrbitError> {
+    if !registry
+        .workspaces
+        .iter()
+        .any(|workspace| workspace.id == checkout.workspace_id)
+    {
+        return Err(OrbitError::not_found(
+            NotFoundKind::Workspace,
+            checkout.workspace_id,
+        ));
+    }
+    if registry
+        .checkouts
+        .iter()
+        .any(|existing| existing.workspace_id == checkout.workspace_id)
+    {
+        return Err(OrbitError::WorkspaceError(format!(
+            "local checkout for workspace '{}' already exists",
+            checkout.workspace_id
+        )));
+    }
+    registry.checkouts.push(checkout);
+    Ok(())
+}
+
 /// Removes a workspace by id or name. Returns the removed workspace.
 pub fn remove_workspace(
     registry: &mut WorkspaceRegistry,
@@ -83,10 +131,9 @@ pub fn remove_workspace(
         .position(|w| w.id == id_or_name || w.name == id_or_name)
         .ok_or_else(|| OrbitError::not_found(NotFoundKind::Workspace, id_or_name.to_string()))?;
     let removed = registry.workspaces.remove(idx);
-    // Also remove any path overrides pointing to this workspace
     registry
-        .path_overrides
-        .retain(|_, ws_id| ws_id != &removed.id);
+        .checkouts
+        .retain(|checkout| checkout.workspace_id != removed.id);
     Ok(removed)
 }
 
@@ -101,31 +148,65 @@ pub fn find_workspace<'a>(
         .find(|w| w.id == id_or_name || w.name == id_or_name)
 }
 
-/// Finds the workspace for a given path using longest prefix match on `path_overrides`.
-pub fn find_workspace_by_path<'a>(
+/// Finds the local checkout for a workspace ID or name.
+pub fn find_checkout<'a>(
+    registry: &'a WorkspaceRegistry,
+    id_or_name: &str,
+) -> Option<&'a WorkspaceCheckout> {
+    let workspace = find_workspace(registry, id_or_name)?;
+    registry
+        .checkouts
+        .iter()
+        .find(|checkout| checkout.workspace_id == workspace.id)
+}
+
+/// Iterates logical workspaces that have a machine-local checkout binding.
+pub fn local_workspaces(
+    registry: &WorkspaceRegistry,
+) -> impl Iterator<Item = (&Workspace, &WorkspaceCheckout)> {
+    registry.checkouts.iter().filter_map(|checkout| {
+        registry
+            .workspaces
+            .iter()
+            .find(|workspace| workspace.id == checkout.workspace_id)
+            .map(|workspace| (workspace, checkout))
+    })
+}
+
+/// Finds the local checkout for a path using longest-prefix matching across
+/// its repository root and explicit path overrides.
+pub fn find_checkout_by_path<'a>(
     registry: &'a WorkspaceRegistry,
     cwd: &Path,
-) -> Option<&'a Workspace> {
-    let mut best_match: Option<(&PathBuf, &String)> = None;
+) -> Option<&'a WorkspaceCheckout> {
+    let mut best_match: Option<(&WorkspaceCheckout, usize)> = None;
 
-    for (override_path, ws_id) in &registry.path_overrides {
-        if cwd.starts_with(override_path) {
-            match best_match {
-                Some((current_best, _))
-                    if override_path.as_os_str().len() > current_best.as_os_str().len() =>
-                {
-                    best_match = Some((override_path, ws_id));
-                }
-                None => {
-                    best_match = Some((override_path, ws_id));
-                }
-                _ => {}
+    for checkout in &registry.checkouts {
+        for candidate in std::iter::once(&checkout.repo_root).chain(&checkout.path_overrides) {
+            if !cwd.starts_with(candidate) {
+                continue;
+            }
+            let candidate_len = candidate.as_os_str().len();
+            if best_match.is_none_or(|(_, current_len)| candidate_len > current_len) {
+                best_match = Some((checkout, candidate_len));
             }
         }
     }
 
-    let (_, ws_id) = best_match?;
-    registry.workspaces.iter().find(|w| &w.id == ws_id)
+    best_match.map(|(checkout, _)| checkout)
+}
+
+/// Finds the logical workspace for a path, but only through a machine-local
+/// checkout binding. Checkoutless catalog entries can never match a path.
+pub fn find_workspace_by_path<'a>(
+    registry: &'a WorkspaceRegistry,
+    cwd: &Path,
+) -> Option<&'a Workspace> {
+    let checkout = find_checkout_by_path(registry, cwd)?;
+    registry
+        .workspaces
+        .iter()
+        .find(|workspace| workspace.id == checkout.workspace_id)
 }
 
 /// Sets a path override binding a directory to a workspace.
@@ -134,24 +215,36 @@ pub fn set_path_override(
     path: PathBuf,
     workspace_id: &str,
 ) -> Result<(), OrbitError> {
-    // Verify the workspace exists
-    if !registry.workspaces.iter().any(|w| w.id == workspace_id) {
-        return Err(OrbitError::not_found(
-            NotFoundKind::Workspace,
-            workspace_id.to_string(),
-        ));
+    let checkout = registry
+        .checkouts
+        .iter_mut()
+        .find(|checkout| checkout.workspace_id == workspace_id)
+        .ok_or_else(|| {
+            OrbitError::WorkspaceError(format!(
+                "workspace '{workspace_id}' has no local checkout binding"
+            ))
+        })?;
+    if !checkout.path_overrides.contains(&path) {
+        checkout.path_overrides.push(path);
+        checkout.path_overrides.sort();
     }
-    registry
-        .path_overrides
-        .insert(path, workspace_id.to_string());
     Ok(())
 }
 
-/// Validates all workspaces in the registry, marking those whose root no longer exists as invalid.
+/// Validates local checkout paths, marking their logical workspace invalid
+/// when the local repository root no longer exists. Checkoutless logical
+/// workspaces retain their catalog status.
 pub fn validate_workspaces(registry: &mut WorkspaceRegistry) {
     let now = Utc::now();
     for ws in &mut registry.workspaces {
-        if ws.root.exists() {
+        let Some(checkout) = registry
+            .checkouts
+            .iter()
+            .find(|checkout| checkout.workspace_id == ws.id)
+        else {
+            continue;
+        };
+        if checkout.repo_root.exists() {
             if ws.status == WorkspaceStatus::Invalid {
                 ws.status = WorkspaceStatus::Active;
                 ws.updated_at = now;
@@ -162,6 +255,337 @@ pub fn validate_workspaces(registry: &mut WorkspaceRegistry) {
         }
     }
 }
+
+#[derive(Debug, Clone)]
+struct RegistryHostContext {
+    mode: HostMode,
+    machine_id: Option<String>,
+}
+
+fn registry_host_context(path: &Path) -> Result<RegistryHostContext, OrbitError> {
+    let global_root = path.parent().ok_or_else(|| {
+        OrbitError::WorkspaceError(format!(
+            "registry path '{}' has no parent directory",
+            path.display()
+        ))
+    })?;
+    match inspect_host_identity(global_root)? {
+        HostIdentityState::Present(identity) => Ok(RegistryHostContext {
+            mode: identity.mode,
+            machine_id: Some(identity.machine_id),
+        }),
+        // Pre-host-identity installations are the legacy standalone case.
+        HostIdentityState::Legacy { .. } | HostIdentityState::Absent => Ok(RegistryHostContext {
+            mode: HostMode::Standalone,
+            machine_id: None,
+        }),
+    }
+}
+
+fn parse_registry(
+    content: &str,
+    context: &RegistryHostContext,
+) -> Result<(WorkspaceRegistry, bool), OrbitError> {
+    let value: Value = serde_json::from_str(content)
+        .map_err(|error| invalid_registry(format!("malformed JSON: {error}")))?;
+    let Some(version_value) = value.get("schema_version") else {
+        let mut migrated = migrate_legacy_registry(value, context)?;
+        validate_registry(&mut migrated, context)?;
+        return Ok((migrated, true));
+    };
+    let version = version_value.as_u64().ok_or_else(|| {
+        invalid_registry("schema_version must be a non-negative integer".to_string())
+    })?;
+    if version > u64::from(WORKSPACE_REGISTRY_SCHEMA_VERSION) {
+        return Err(invalid_registry(format!(
+            "unsupported schema_version {version}; this build supports up to {WORKSPACE_REGISTRY_SCHEMA_VERSION}. Upgrade Orbit; the file is left unchanged"
+        )));
+    }
+    if version != u64::from(WORKSPACE_REGISTRY_SCHEMA_VERSION) {
+        return Err(invalid_registry(format!(
+            "invalid schema_version {version}; expected {WORKSPACE_REGISTRY_SCHEMA_VERSION}"
+        )));
+    }
+
+    validate_role_tokens(&value)?;
+    let mut registry: WorkspaceRegistry =
+        serde_json::from_value(value).map_err(|error| invalid_registry(error.to_string()))?;
+    let changed = validate_registry(&mut registry, context)?;
+    Ok((registry, changed))
+}
+
+fn validate_role_tokens(value: &Value) -> Result<(), OrbitError> {
+    let Some(checkouts) = value.get("checkouts").and_then(Value::as_array) else {
+        return Ok(());
+    };
+    for checkout in checkouts {
+        let workspace_id = checkout
+            .get("workspace_id")
+            .and_then(Value::as_str)
+            .unwrap_or("<unknown>");
+        let Some(role) = checkout.get("role") else {
+            continue;
+        };
+        match role.as_str() {
+            Some("owner" | "replica") => {}
+            Some(other) => {
+                return Err(invalid_registry(format!(
+                    "workspace '{workspace_id}' has unknown checkout role '{other}'"
+                )));
+            }
+            None => {
+                return Err(invalid_registry(format!(
+                    "workspace '{workspace_id}' has a non-string checkout role"
+                )));
+            }
+        }
+    }
+    Ok(())
+}
+
+fn validate_registry(
+    registry: &mut WorkspaceRegistry,
+    context: &RegistryHostContext,
+) -> Result<bool, OrbitError> {
+    if registry.schema_version != WORKSPACE_REGISTRY_SCHEMA_VERSION {
+        return Err(invalid_registry(format!(
+            "schema_version {} is not supported by this build",
+            registry.schema_version
+        )));
+    }
+
+    let mut changed = false;
+    let mut workspace_ids = HashSet::new();
+    let mut workspace_names = HashSet::new();
+    for workspace in &registry.workspaces {
+        if !workspace_ids.insert(workspace.id.clone()) {
+            return Err(invalid_registry(format!(
+                "duplicate workspace id '{}'",
+                workspace.id
+            )));
+        }
+        if !workspace_names.insert(workspace.name.clone()) {
+            return Err(invalid_registry(format!(
+                "duplicate workspace name '{}'",
+                workspace.name
+            )));
+        }
+    }
+
+    let mut checkout_ids = HashSet::new();
+    for checkout in &mut registry.checkouts {
+        let workspace = registry
+            .workspaces
+            .iter_mut()
+            .find(|workspace| workspace.id == checkout.workspace_id)
+            .ok_or_else(|| {
+                invalid_registry(format!(
+                    "checkout references unknown workspace '{}'",
+                    checkout.workspace_id
+                ))
+            })?;
+        if !checkout_ids.insert(checkout.workspace_id.clone()) {
+            return Err(invalid_registry(format!(
+                "workspace '{}' has more than one local checkout binding",
+                checkout.workspace_id
+            )));
+        }
+
+        if checkout.role.is_none() {
+            if context.mode == HostMode::Standalone {
+                checkout.role = Some(WorkspaceCheckoutRole::Owner);
+                changed = true;
+            } else {
+                return Err(invalid_registry(format!(
+                    "workspace '{}' is missing a local checkout role in {} mode",
+                    checkout.workspace_id, context.mode
+                )));
+            }
+        }
+
+        match checkout.role {
+            Some(WorkspaceCheckoutRole::Owner) => {
+                if checkout.owner_machine_id.is_some() {
+                    return Err(invalid_registry(format!(
+                        "workspace '{}' has contradictory owner role and replica owner_machine_id",
+                        checkout.workspace_id
+                    )));
+                }
+                if let Some(machine_id) = context.machine_id.as_deref() {
+                    match workspace.owner_machine_id.as_deref() {
+                        Some(owner) if owner != machine_id => {
+                            return Err(invalid_registry(format!(
+                                "workspace '{}' declares local owner role, but logical owner is machine '{owner}' instead of local machine '{machine_id}'",
+                                checkout.workspace_id
+                            )));
+                        }
+                        None => {
+                            workspace.owner_machine_id = Some(machine_id.to_string());
+                            changed = true;
+                        }
+                        Some(_) => {}
+                    }
+                } else if context.mode != HostMode::Standalone {
+                    return Err(invalid_registry(format!(
+                        "workspace '{}' cannot validate owner role without a local machine_id",
+                        checkout.workspace_id
+                    )));
+                }
+            }
+            Some(WorkspaceCheckoutRole::Replica) => {
+                if context.mode == HostMode::Standalone {
+                    return Err(invalid_registry(format!(
+                        "workspace '{}' cannot use replica role in standalone mode",
+                        checkout.workspace_id
+                    )));
+                }
+                let binding_owner = checkout.owner_machine_id.as_deref().ok_or_else(|| {
+                    invalid_registry(format!(
+                        "workspace '{}' has replica role without owner_machine_id",
+                        checkout.workspace_id
+                    ))
+                })?;
+                let logical_owner = workspace.owner_machine_id.as_deref().ok_or_else(|| {
+                    invalid_registry(format!(
+                        "workspace '{}' has replica role but its logical record has no owner_machine_id",
+                        checkout.workspace_id
+                    ))
+                })?;
+                if binding_owner != logical_owner {
+                    return Err(invalid_registry(format!(
+                        "workspace '{}' replica owner '{binding_owner}' contradicts logical owner '{logical_owner}'",
+                        checkout.workspace_id
+                    )));
+                }
+                if context.machine_id.as_deref() == Some(binding_owner) {
+                    return Err(invalid_registry(format!(
+                        "workspace '{}' declares replica role of the local machine '{binding_owner}'",
+                        checkout.workspace_id
+                    )));
+                }
+            }
+            None => unreachable!("missing checkout role handled above"),
+        }
+
+        let before = checkout.path_overrides.len();
+        checkout.path_overrides.sort();
+        checkout.path_overrides.dedup();
+        changed |= checkout.path_overrides.len() != before;
+    }
+    if context.mode != HostMode::Standalone {
+        for workspace in &registry.workspaces {
+            if workspace.owner_machine_id.is_none() {
+                return Err(invalid_registry(format!(
+                    "workspace '{}' is missing owner_machine_id in {} mode",
+                    workspace.id, context.mode
+                )));
+            }
+        }
+    }
+    Ok(changed)
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct LegacyWorkspaceRegistry {
+    #[serde(default)]
+    workspaces: Vec<LegacyWorkspace>,
+    #[serde(default)]
+    path_overrides: BTreeMap<PathBuf, String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct LegacyWorkspace {
+    id: String,
+    name: String,
+    root: PathBuf,
+    orbit_dir: PathBuf,
+    #[serde(default)]
+    git_remote: Option<String>,
+    #[serde(default)]
+    ship_mode: Option<String>,
+    #[serde(default = "legacy_default_base_branch")]
+    base_branch: String,
+    #[serde(default = "legacy_default_status")]
+    status: WorkspaceStatus,
+    created_at: DateTime<Utc>,
+    updated_at: DateTime<Utc>,
+}
+
+fn migrate_legacy_registry(
+    value: Value,
+    context: &RegistryHostContext,
+) -> Result<WorkspaceRegistry, OrbitError> {
+    let legacy: LegacyWorkspaceRegistry = serde_json::from_value(value)
+        .map_err(|error| invalid_registry(format!("invalid legacy registry: {error}")))?;
+    let valid_ids: HashSet<String> = legacy
+        .workspaces
+        .iter()
+        .map(|workspace| workspace.id.clone())
+        .collect();
+    let mut overrides_by_workspace: BTreeMap<String, Vec<PathBuf>> = BTreeMap::new();
+    for (path, workspace_id) in legacy.path_overrides {
+        if valid_ids.contains(&workspace_id) {
+            overrides_by_workspace
+                .entry(workspace_id)
+                .or_default()
+                .push(path);
+        }
+    }
+
+    let mut registry = WorkspaceRegistry::default();
+    for legacy_workspace in legacy.workspaces {
+        let workspace_id = legacy_workspace.id.clone();
+        registry.workspaces.push(Workspace {
+            id: legacy_workspace.id,
+            name: legacy_workspace.name,
+            owner_machine_id: context.machine_id.clone(),
+            git_remote: legacy_workspace.git_remote,
+            ship_mode: legacy_workspace.ship_mode,
+            base_branch: legacy_workspace.base_branch,
+            status: legacy_workspace.status,
+            created_at: legacy_workspace.created_at,
+            updated_at: legacy_workspace.updated_at,
+        });
+        registry.checkouts.push(WorkspaceCheckout {
+            workspace_id: workspace_id.clone(),
+            repo_root: legacy_workspace.root,
+            orbit_dir: legacy_workspace.orbit_dir,
+            // Only standalone mode has a compatibility rule for legacy
+            // checkouts that predate explicit roles. Multi-host modes must
+            // fail closed instead of inferring ownership from a local path.
+            role: (context.mode == HostMode::Standalone).then_some(WorkspaceCheckoutRole::Owner),
+            owner_machine_id: None,
+            path_overrides: overrides_by_workspace
+                .remove(&workspace_id)
+                .unwrap_or_default(),
+        });
+    }
+    Ok(registry)
+}
+
+fn write_registry(registry: &WorkspaceRegistry, path: &Path) -> Result<(), OrbitError> {
+    let content = serde_json::to_string_pretty(registry)
+        .map_err(|e| OrbitError::WorkspaceError(format!("failed to serialize registry: {e}")))?;
+    atomic_write_text(path, &content).map_err(Into::into)
+}
+
+fn invalid_registry(message: String) -> OrbitError {
+    OrbitError::WorkspaceError(format!("invalid registry: {message}"))
+}
+
+fn legacy_default_base_branch() -> String {
+    "main".to_string()
+}
+
+fn legacy_default_status() -> WorkspaceStatus {
+    WorkspaceStatus::Active
+}
+
+#[cfg(test)]
+#[path = "tests/workspace_registry.rs"]
+mod tests;
 
 fn home_dir() -> Result<PathBuf, OrbitError> {
     dirs_or_fallback()

--- a/crates/orbit-dashboard/src/lib.rs
+++ b/crates/orbit-dashboard/src/lib.rs
@@ -140,15 +140,13 @@ fn build_state(root_override: Option<&Path>) -> Result<state::DashboardState, Or
     let cwd = std::env::current_dir().ok();
     let default_workspace = default_workspace_selection(&registry, root_override, cwd.as_deref());
 
-    let entries = registry
-        .workspaces
-        .iter()
-        .map(|ws| state::WsEntry {
-            id: ws.id.clone(),
-            name: ws.name.clone(),
-            repo_root: ws.root.clone(),
-            orbit_dir: ws.orbit_dir.clone(),
-            active: ws.status == WorkspaceStatus::Active,
+    let entries = workspace_registry::local_workspaces(&registry)
+        .map(|(workspace, checkout)| state::WsEntry {
+            id: workspace.id.clone(),
+            name: workspace.name.clone(),
+            repo_root: checkout.repo_root.clone(),
+            orbit_dir: checkout.orbit_dir.clone(),
+            active: workspace.status == WorkspaceStatus::Active,
         })
         .collect();
 
@@ -163,12 +161,18 @@ fn build_state(root_override: Option<&Path>) -> Result<state::DashboardState, Or
 /// repo root is the longest prefix of `cwd`, if the server was launched inside
 /// one. `None` means the frontend opens on the aggregate "all workspaces" view.
 fn default_workspace_for_cwd(registry: &WorkspaceRegistry, cwd: &Path) -> Option<String> {
-    registry
-        .workspaces
-        .iter()
-        .filter(|ws| ws.status == WorkspaceStatus::Active && cwd.starts_with(&ws.root))
-        .max_by_key(|ws| ws.root.as_os_str().len())
-        .map(|ws| ws.id.clone())
+    workspace_registry::local_workspaces(registry)
+        .filter(|(workspace, _)| workspace.status == WorkspaceStatus::Active)
+        .filter_map(|(workspace, checkout)| {
+            std::iter::once(&checkout.repo_root)
+                .chain(&checkout.path_overrides)
+                .filter(|candidate| cwd.starts_with(candidate))
+                .map(|candidate| candidate.as_os_str().len())
+                .max()
+                .map(|prefix_len| (workspace, prefix_len))
+        })
+        .max_by_key(|(_, prefix_len)| *prefix_len)
+        .map(|(workspace, _)| workspace.id.clone())
 }
 
 /// Precedence logic for the dropdown's default-preselected workspace: an

--- a/crates/orbit-dashboard/src/tests/state.rs
+++ b/crates/orbit-dashboard/src/tests/state.rs
@@ -5,19 +5,18 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use chrono::Utc;
-use orbit_common::types::{Workspace, WorkspaceRegistry, WorkspaceStatus};
+use orbit_common::types::{Workspace, WorkspaceCheckout, WorkspaceRegistry, WorkspaceStatus};
 use orbit_core::OrbitRuntime;
 
 use crate::state::{DashboardState, WsEntry};
 use crate::{default_workspace_for_cwd, default_workspace_selection};
 
-fn workspace(id: &str, root: &str, status: WorkspaceStatus) -> Workspace {
+fn workspace(id: &str, status: WorkspaceStatus) -> Workspace {
     let now = Utc::now();
     Workspace {
         id: id.to_string(),
         name: id.to_string(),
-        root: PathBuf::from(root),
-        orbit_dir: PathBuf::from(root).join(".orbit"),
+        owner_machine_id: None,
         git_remote: None,
         ship_mode: None,
         base_branch: "main".to_string(),
@@ -25,6 +24,14 @@ fn workspace(id: &str, root: &str, status: WorkspaceStatus) -> Workspace {
         created_at: now,
         updated_at: now,
     }
+}
+
+fn checkout(id: &str, root: &str) -> WorkspaceCheckout {
+    WorkspaceCheckout::owner(
+        id.to_string(),
+        PathBuf::from(root),
+        PathBuf::from(root).join(".orbit"),
+    )
 }
 
 #[test]
@@ -61,11 +68,16 @@ fn global_mode_rejects_inactive_and_unknown_workspaces() {
 fn default_workspace_for_cwd_picks_longest_active_prefix() {
     let registry = WorkspaceRegistry {
         workspaces: vec![
-            workspace("outer", "/repos", WorkspaceStatus::Active),
-            workspace("inner", "/repos/inner", WorkspaceStatus::Active),
-            workspace("stale", "/repos/inner/sub", WorkspaceStatus::Invalid),
+            workspace("outer", WorkspaceStatus::Active),
+            workspace("inner", WorkspaceStatus::Active),
+            workspace("stale", WorkspaceStatus::Invalid),
         ],
-        path_overrides: Default::default(),
+        checkouts: vec![
+            checkout("outer", "/repos"),
+            checkout("inner", "/repos/inner"),
+            checkout("stale", "/repos/inner/sub"),
+        ],
+        ..Default::default()
     };
 
     // Deepest active workspace wins; the still-deeper inactive one is ignored.
@@ -84,10 +96,14 @@ fn default_workspace_for_cwd_picks_longest_active_prefix() {
 fn default_workspace_selection_root_override_beats_cwd() {
     let registry = WorkspaceRegistry {
         workspaces: vec![
-            workspace("outer", "/repos", WorkspaceStatus::Active),
-            workspace("inner", "/repos/inner", WorkspaceStatus::Active),
+            workspace("outer", WorkspaceStatus::Active),
+            workspace("inner", WorkspaceStatus::Active),
         ],
-        path_overrides: Default::default(),
+        checkouts: vec![
+            checkout("outer", "/repos"),
+            checkout("inner", "/repos/inner"),
+        ],
+        ..Default::default()
     };
 
     // cwd would resolve to "outer", but an explicit --root pointing at
@@ -107,8 +123,9 @@ fn default_workspace_selection_root_override_beats_cwd() {
 #[test]
 fn default_workspace_selection_unmatched_root_override_falls_back_to_none() {
     let registry = WorkspaceRegistry {
-        workspaces: vec![workspace("outer", "/repos", WorkspaceStatus::Active)],
-        path_overrides: Default::default(),
+        workspaces: vec![workspace("outer", WorkspaceStatus::Active)],
+        checkouts: vec![checkout("outer", "/repos")],
+        ..Default::default()
     };
 
     // An unmatched --root falls back to "All workspaces" (None) even though
@@ -142,8 +159,7 @@ fn default_workspace_selection_resolves_relative_root_override_against_cwd() {
         workspaces: vec![Workspace {
             id: "my_workspace".to_string(),
             name: "my_workspace".to_string(),
-            root: canonical_ws_root.clone(),
-            orbit_dir: canonical_ws_root.join(".orbit"),
+            owner_machine_id: None,
             git_remote: None,
             ship_mode: None,
             base_branch: "main".to_string(),
@@ -151,7 +167,12 @@ fn default_workspace_selection_resolves_relative_root_override_against_cwd() {
             created_at: Utc::now(),
             updated_at: Utc::now(),
         }],
-        path_overrides: Default::default(),
+        checkouts: vec![WorkspaceCheckout::owner(
+            "my_workspace".to_string(),
+            canonical_ws_root.clone(),
+            canonical_ws_root.join(".orbit"),
+        )],
+        ..Default::default()
     };
 
     // Relative root_override, resolved against a cwd that is the parent of
@@ -170,8 +191,9 @@ fn default_workspace_selection_resolves_relative_root_override_against_cwd() {
 #[test]
 fn default_workspace_selection_no_root_override_falls_back_to_cwd() {
     let registry = WorkspaceRegistry {
-        workspaces: vec![workspace("outer", "/repos", WorkspaceStatus::Active)],
-        path_overrides: Default::default(),
+        workspaces: vec![workspace("outer", WorkspaceStatus::Active)],
+        checkouts: vec![checkout("outer", "/repos")],
+        ..Default::default()
     };
 
     assert_eq!(

--- a/docs/design/host-registry/1_overview.md
+++ b/docs/design/host-registry/1_overview.md
@@ -10,7 +10,7 @@ summary: First-class, validated machine identity plus a main-host inventory, ena
 tags: [host-registry, multi-host, dispatch, routines]
 paths: ["crates/orbit-core/**", "crates/orbit-store/**", "crates/orbit-mcp/**", "crates/orbit-common/**"]
 related_features: [host-registry, mcp-bridge, routines, remote-access]
-related_artifacts: [ORB-00424, ADR-0200, ADR-0205, ADR-0208, ADR-0226, ADR-0227, ADR-0228, ADR-0229, ADR-0230, ADR-0231, ADR-0232]
+related_artifacts: [ORB-00424, ORB-10248, ADR-0200, ADR-0205, ADR-0208, ADR-0226, ADR-0227, ADR-0228, ADR-0229, ADR-0230, ADR-0231, ADR-0232]
 ---
 
 # Host Registry — Overview
@@ -97,7 +97,7 @@ authority — that direction was already rejected ([ADR-0200], the archived
 |---------|------|------|
 | Host identity file (`host.toml`) | [crates/orbit-core/src/routines/host.rs](../../../crates/orbit-core/src/routines/host.rs) | — |
 | Global/workspace seeding (`orbit init`) | [crates/orbit-core/src/command/init.rs](../../../crates/orbit-core/src/command/init.rs) | — |
-| Workspace registry (gains `owner` field) | [crates/orbit-core/src/workspace_registry.rs](../../../crates/orbit-core/src/workspace_registry.rs) | — |
+| Versioned logical-workspace catalog + local checkout bindings | [crates/orbit-core/src/workspace_registry.rs](../../../crates/orbit-core/src/workspace_registry.rs) | [ORB-10248] |
 | Task ID single-authority allocator | [crates/orbit-store/src/sqlite/task_registry/](../../../crates/orbit-store/src/sqlite/task_registry/) | — |
 | MCP surface (`orbit.host.*`, placement) | [mcp-bridge/2_design.md](../mcp-bridge/2_design.md) | [ORB-00424] |
 | Routine sweep host filter | [docs/design/routines/2_design.md](../routines/2_design.md) | — |
@@ -110,5 +110,7 @@ Detailed mechanisms in [2_design.md](./2_design.md); open directions in
 - [ORB-00424] — proposed the local/remote Orbit MCP unification this registry
   complements (one canonical contract, one hub target, local owner/derived
   placement, Bridge parity retired).
+- [ORB-10248] — split the versioned workspace catalog from machine-local
+  checkout paths and owner/replica bindings.
 
 > Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.

--- a/docs/design/host-registry/2_design.md
+++ b/docs/design/host-registry/2_design.md
@@ -10,12 +10,13 @@ summary: Target mechanisms for host identity, the main-host registry, the coordi
 tags: [host-registry, multi-host, dispatch, routines, data-placement]
 paths: ["crates/orbit-core/**", "crates/orbit-store/**", "crates/orbit-mcp/**", "crates/orbit-common/**"]
 related_features: [host-registry, mcp-bridge, routines, remote-access, mcp-session-context]
-related_artifacts: [ORB-00424, ORB-10247, ADR-0200, ADR-0205, ADR-0208, ADR-0226, ADR-0227, ADR-0228, ADR-0229, ADR-0230, ADR-0231, ADR-0232]
+related_artifacts: [ORB-00424, ORB-10247, ORB-10248, ADR-0200, ADR-0205, ADR-0208, ADR-0226, ADR-0227, ADR-0228, ADR-0229, ADR-0230, ADR-0231, ADR-0232]
 ---
 
 # Host Registry — Design
 
-This doc specifies the **target** design; nothing here has landed and the folder is
+This doc specifies the **target** design; the Phase 1 host identity and workspace
+registry foundations have landed, while later phases remain pending. The folder is
 Accepted. It covers host identity, the registry, the coordination-plane/workspace-
 ownership split, execution placement (including the hub→satellite protocol), the
 per-record data-placement split, and the revision to routine sweep ownership. It
@@ -147,6 +148,33 @@ locally readable:
   (`orbit workspace link`, resolving names then). The trusted hub `machine_id` →
   SSH-target mapping is machine-level state in `~/.orbit/mcp.toml`; workspace role
   carries no transport target and never grants or redirects access to its owner.
+
+**Concrete local registry schema ([ORB-10248]).** `~/.orbit/workspaces.json` is
+versioned independently of `host.toml`. Schema v1 has two collections:
+
+- `workspaces: Vec<Workspace>` is the path-free logical catalog. Each record keeps
+  stable ID/name, owner `machine_id` (optional only for pre-identity standalone
+  installs), Git/workflow metadata, status, and timestamps. A hub may therefore
+  retain a workspace it cannot check out without fabricating a path.
+- `checkouts: Vec<WorkspaceCheckout>` is machine-local. Each binding names the
+  `workspace_id`, `repo_root`, `orbit_dir`, path overrides, and `role`. `owner`
+  carries no replica owner field; `replica` must carry `owner_machine_id`, which
+  must equal the logical record's stable owner.
+
+ID/name lookup reads only `workspaces`. Path lookup uses longest-prefix matching
+across `WorkspaceCheckout.repo_root` and that checkout's overrides; a checkoutless
+logical workspace can never resolve to a path. Existing list output renders `-`
+for such a record rather than inventing a root.
+
+Legacy unversioned registries migrate in one atomic write in standalone mode: every
+legacy workspace becomes one logical record plus one local owner checkout, while
+IDs, names, Git/workflow fields, status, timestamps, and valid overrides are
+retained. A second load is byte-stable. Pre-host-identity input is the standalone
+compatibility case; an absent local role canonicalizes to `owner`. Hub/spoke loads,
+including unversioned input without an explicit role, require stable owner identity
+and reject missing/unknown roles, owner/replica contradictions, and replicas without
+an owner, naming the workspace ID. Malformed/future schemas are read-only failures,
+and a failed staged write leaves the prior file readable.
 
 Enforcement reads only local data, so it works offline; what fails offline is the
 MCP write itself, loudly. Two local rules (§5 for the record types they guard):
@@ -348,5 +376,7 @@ of that routine.** Consequences:
 - [ORB-10247] — implemented the versioned `HostIdentity` (§1): `schema_version` /
   `machine_id` / `host_id` / `mode`, `orbit init` ownership, legacy migration, and
   strict fail-closed loading (Phase 1 / Unit B1 under ORB-10246).
+- [ORB-10248] — implemented the versioned path-free workspace catalog and
+  machine-local owner/replica checkout bindings (§3; Phase 1 / Unit B2).
 
 > Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.

--- a/docs/design/host-registry/4_decisions.md
+++ b/docs/design/host-registry/4_decisions.md
@@ -1,7 +1,7 @@
 ---
 title: Host Registry — Decisions
 owner: claude
-last_updated: 2026-07-17
+last_updated: 2026-07-18
 status: Accepted
 feature: host-registry
 doc_role: decisions
@@ -10,7 +10,7 @@ summary: Accepted ADR log for the coupled Host Registry and MCP Bridge v1 contra
 tags: [host-registry, mcp-bridge, multi-host, placement]
 paths: ["crates/orbit-core/**", "crates/orbit-store/**", "crates/orbit-mcp/**"]
 related_features: [host-registry, mcp-bridge]
-related_artifacts: [ORB-00424, ORB-10245, ADR-0226, ADR-0227, ADR-0228, ADR-0229, ADR-0230, ADR-0231, ADR-0232]
+related_artifacts: [ORB-00424, ORB-10245, ORB-10248, ADR-0226, ADR-0227, ADR-0228, ADR-0229, ADR-0230, ADR-0231, ADR-0232]
 ---
 
 # Host Registry — Decisions
@@ -22,7 +22,7 @@ v1 decision set shared with [mcp-bridge](../mcp-bridge/4_decisions.md).
 
 ## ADR-0226 — Singular coordination hub, workspace owner, and per-run placement
 
-**Status:** Accepted · 2026-07 · [ORB-10245] accepted the coupled v1 contract.
+**Status:** Accepted · 2026-07 · [ORB-10245] accepted the coupled v1 contract; [ORB-10248] implemented the workspace boundary.
 
 ### Context
 
@@ -33,11 +33,13 @@ ownership implicit.
 ### Decision
 
 Use exactly one coordination hub for every workspace, declare one workspace owner,
-and select execution placement per run with the owner as the default.
+and select execution placement per run with the owner as the default. Persist the
+logical workspace/owner separately from machine-local checkout bindings.
 
 ### Consequences
 
 - Coordination writes remain hub-routed while knowledge authorship remains owner-bound.
+- Logical workspace lookup never requires or fabricates a checkout path; local path lookup consults checkout bindings only.
 - Cost: hub downtime stalls coordination for every workspace, and disconnected machines cannot write coordination records.
 
 ## ADR-0227 — Stable machine identity, registry, and out-of-band hub pin
@@ -160,5 +162,6 @@ for its non-Orbit constellation domains.
 
 - [ORB-00424] — completed design proposal for canonical Orbit MCP and Bridge parity retirement.
 - [ORB-10245] — accepted the coupled contract and recorded this ADR set.
+- [ORB-10248] — implemented the versioned logical-workspace/local-checkout split.
 
 > Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.


### PR DESCRIPTION
## Task

[ORB-10248](https://orbit-cli.com/tasks/ORB-10248) — Split logical workspace catalog from local checkout bindings

### Description

## Problem

The current global workspace registry stores logical identity and machine-local filesystem paths in one `Workspace` record. A hub must know a workspace exists and who owns it without fabricating `root` or `orbit_dir` paths for a checkout it does not have.

This is Phase 1 / Unit B2 under implementation umbrella ORB-10246. It follows ORB-10245 and the stable host identity introduced by Unit B1.

## Required outcome

Version `~/.orbit/workspaces.json` and separate:

- a path-free logical workspace catalog containing stable workspace identity and non-local metadata; and
- machine-local checkout bindings containing `repo_root`, `orbit_dir`, path overrides, and local role.

A local binding declares either `owner` or an explicit replica-of owner `machine_id`. In standalone mode, a migrated legacy workspace with no role behaves as a local owner. In hub or spoke mode, a missing or contradictory owner/role binding fails with an actionable error rather than being inferred from checkout presence, hostname, workspace name, or path.

## Migration and compatibility

- Migrate the existing unversioned/legacy registry additively and idempotently, retaining workspace IDs, names, workflow metadata, remotes, branches, status, timestamps, and all valid path overrides.
- Preserve lookup by workspace ID/name and longest-prefix local path lookup; path lookup consults only local checkout bindings.
- Reject future schema versions without mutation.
- Use atomic writes and deterministic temporary-directory fixtures; a failed migration must preserve the last readable registry.
- Existing standalone commands and workspace-list output remain compatible unless a new field is explicitly additive.
- This task adds no hub registry rows, network transport, placement broker, knowledge routing, or HA behavior.
- Update the Host Registry design docs in the same PR if concrete schema names refine the accepted contract.

### Acceptance Criteria

- A versioned workspace-registry schema represents logical workspaces without required filesystem paths and represents local checkout paths/overrides/role in a separate binding structure.
- Migrating a legacy workspaces.json produces one logical record and one local owner checkout per legacy workspace, preserves all IDs and workflow metadata, preserves valid path overrides, and a second migration is byte-stable or semantically identical.
- Standalone mode treats a migrated missing role as local owner, while hub and spoke modes reject missing, unknown, contradictory, or replica-without-owner-machine roles with errors naming the workspace ID.
- Workspace lookup by ID/name remains path-independent; longest-prefix lookup resolves only through local checkout bindings and cannot invent a path for a checkoutless logical workspace.
- Malformed and future-version registries fail closed without rewriting the source; injected write failure leaves the prior registry readable.
- cargo test -p orbit-common, cargo test -p orbit-core, and cargo test -p orbit-cli pass.
- make ci-fast passes from the Orbit repository root.

## Execution Summary

<details>
<summary>Click to expand</summary>

Implemented the versioned workspace registry split for ORB-10248.

Changes:
- Added schema v1 with a path-free logical `Workspace` catalog and separate machine-local `WorkspaceCheckout` bindings carrying repo/orbit paths, path overrides, and explicit owner/replica role metadata.
- Added strict legacy/current parsing, additive standalone migration, deterministic canonicalization, duplicate/reference validation, mode-aware owner/replica checks, future/malformed fail-closed behavior, and atomic persistence with injected-write-failure coverage. Standalone missing roles canonicalize to owner; hub/spoke missing, unknown, contradictory, or incomplete roles fail with the workspace ID and leave input untouched.
- Preserved ID/name lookup independently of paths and moved longest-prefix resolution to local checkout roots/overrides only, so checkoutless logical records cannot acquire invented paths.
- Updated workspace init/list/show/teardown, runtime resolution/building, routine discovery/sweep, ship dispatch, dashboard state, and directly affected fixtures to consume local checkout bindings while preserving standalone command output (checkoutless list entries render `-`).
- Synchronized the Host Registry overview, design, and accepted decision record with the concrete v1 schema and migration contract. No new dependency edge was added.

Validation:
- PASS: `cargo test -p orbit-common` (223 unit tests plus integration tests).
- PASS: `umask 077; unset ORBIT_AGENT_MODEL ORBIT_AGENT_NAME; cargo test -p orbit-cli` (full unit/integration suite).
- PASS: `cargo test -p orbit-core workspace_registry::tests` (8/8 migration, role, lookup, and failure-path tests).
- PASS: targeted dashboard state tests (7/7), affected core tests, `cargo check -p orbit-common -p orbit-core -p orbit-cli -p orbit-dashboard`, `git diff --check`, and `make ci-fast`.
- Baseline issue: full `cargo test -p orbit-core` reports 572 passed, 1 failed, 1 ignored. The sole failure is the unrelated pre-existing `triage_agent_allowlist_makes_write_surfaces_structurally_impossible` assertion: the checked-in triage activity now allowlists `orbit.task.update` while its stale structural-security test forbids it. Neither file was changed here; friction F2026-07-076 records the mismatch.

Learning checkpoint: L-0092 already captures the strict-resolution migration/caller-audit guardrail applied here; no new durable learning was needed.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10248-6a5ae781`
- Behind base: 0
- Ahead of base: 1

*authored by: codex*