### PR TITLE
Propagate independent review controls through ship pipelines

### DIFF
--- a/.orbit/resources/jobs/task_auto_pipeline.yaml
+++ b/.orbit/resources/jobs/task_auto_pipeline.yaml
@@ -37,6 +37,8 @@ spec:
     mode: pr
     base_branch: main
     base_sync: remote
+    review: false
+    review_crew: null
     max_bundles: 10
     concurrency: 5
     max_bundle_size: 5
@@ -70,6 +72,8 @@ spec:
               mode: "{{ input.mode }}"
               base_branch: "{{ input.base_branch }}"
               base_sync: "{{ input.base_sync }}"
+              review: "{{ input.review }}"
+              review_crew: "{{ input.review_crew }}"
       fan_in:
         join:
           mode: all

--- a/.orbit/resources/jobs/task_gate_pipeline.yaml
+++ b/.orbit/resources/jobs/task_gate_pipeline.yaml
@@ -45,6 +45,8 @@ spec:
     mode: pr
     base_branch: main
     base_sync: remote
+    review: false
+    review_crew: null
     max_wait_seconds: 3600
     poll_interval_seconds: 30
     ttl_seconds: 7200
@@ -84,6 +86,8 @@ spec:
           task_ids: "{{ input.task_ids }}"
           base_branch: "{{ input.base_branch }}"
           base_sync: "{{ input.base_sync }}"
+          review: "{{ input.review }}"
+          review_crew: "{{ input.review_crew }}"
           auto_push: true
         admission_task_ids: "{{ input.task_ids }}"
         admission_workflow: worktree_setup

--- a/.orbit/resources/jobs/task_local_pipeline.yaml
+++ b/.orbit/resources/jobs/task_local_pipeline.yaml
@@ -8,7 +8,8 @@
 #
 # Optional review step:
 # - `review_bundle` runs after `implement_bundle` when `input.review` is
-#   `true` (default `false`). It invokes `agent_review`, which records
+#   `true` (default `false`) and uses only the required explicit
+#   `input.review_crew`. It invokes `agent_review`, which records
 #   blocking findings as `ReviewThread`s on the participating tasks via
 #   `orbit.task.review_thread.*` and applies fixes in-place. The pipeline
 #   does not gate on agent output; unresolved threads remain on the tasks
@@ -28,6 +29,7 @@ spec:
     base_branch: main
     base_sync: remote
     review: false
+    review_crew: null
   
   steps:
     - id: worktree
@@ -62,6 +64,7 @@ spec:
         task_ids: "{{ input.task_ids }}"
         workspace_path: "{{ steps.worktree.output.workspace_path }}"
         base_branch: "{{ input.base_branch }}"
+        crew: "{{ input.review_crew }}"
 
     - id: commit
       recovery_activity: step_failure_recovery

--- a/.orbit/resources/jobs/task_pr_pipeline.yaml
+++ b/.orbit/resources/jobs/task_pr_pipeline.yaml
@@ -15,7 +15,8 @@
 #
 # Optional review step:
 # - `review_bundle` runs after `implement_bundle` when `input.review` is
-#   `true` (default `false`). It invokes `agent_review`, which records
+#   `true` (default `false`) and uses only the required explicit
+#   `input.review_crew`. It invokes `agent_review`, which records
 #   blocking findings as `ReviewThread`s on the participating tasks via
 #   `orbit.task.review_thread.*` and applies fixes in-place. Unresolved
 #   threads ride through to the PR via the existing review-thread sync;
@@ -34,6 +35,7 @@ spec:
     base_branch: main
     base_sync: remote
     review: false
+    review_crew: null
     title: null
     body: null
 
@@ -71,6 +73,7 @@ spec:
         task_ids: "{{ input.task_ids }}"
         workspace_path: "{{ steps.worktree.output.workspace_path }}"
         base_branch: "{{ input.base_branch }}"
+        crew: "{{ input.review_crew }}"
 
     - id: commit
       recovery_activity: step_failure_recovery

--- a/crates/orbit-cli/src/command/run/ship.rs
+++ b/crates/orbit-cli/src/command/run/ship.rs
@@ -29,7 +29,7 @@ impl ShipMode {
 #[command(
     about = "Ship backlog or explicitly selected tasks through the gated task pipeline",
     override_usage = "orbit run ship [<TASK_ID>...] [OPTIONS]",
-    after_help = "Examples:\n  orbit run ship\n  orbit run ship T123\n  orbit run ship T123 T456 --mode local\n  orbit run ship T123 --base main\n\nInspect submitted runs with `orbit run history -j task_auto_pipeline` and `orbit run show <RUN_ID>`."
+    after_help = "Examples:\n  orbit run ship\n  orbit run ship T123\n  orbit run ship T123 T456 --mode local\n  orbit run ship T123 --base main\n  orbit run ship T123 --review --review-crew opus-review\n\nInspect submitted runs with `orbit run history -j task_auto_pipeline` and `orbit run show <RUN_ID>`."
 )]
 pub struct ShipCommand {
     /// Optional task IDs to seed explicit gated shipment. Omit for auto mode.
@@ -44,6 +44,13 @@ pub struct ShipCommand {
     /// `[workflow] base_branch` from `config.toml` (or `main` if unset).
     #[arg(short = 'b', long)]
     pub base: Option<String>,
+    /// Run an independent review after implementation and before shipment.
+    /// Requires `--review-crew`.
+    #[arg(long)]
+    pub review: bool,
+    /// Explicit crew used only for the independent review step.
+    #[arg(long, value_name = "CREW")]
+    pub review_crew: Option<String>,
     /// Output as JSON.
     #[arg(long)]
     pub json: bool,
@@ -127,7 +134,13 @@ pub(crate) fn build_ship_run_plan(
     let base = args.base.as_deref().unwrap_or(config_base_branch);
     Ok(WorkflowRunPlan {
         workflow_alias,
-        input: build_ship_input(mode, base, &args.task_ids)?,
+        input: build_ship_input(
+            mode,
+            base,
+            &args.task_ids,
+            args.review,
+            args.review_crew.as_deref(),
+        )?,
     })
 }
 

--- a/crates/orbit-cli/src/command/run/sweep.rs
+++ b/crates/orbit-cli/src/command/run/sweep.rs
@@ -226,7 +226,7 @@ fn sweep_active_workspace(
         });
     }
 
-    let invoke = runtime.submit_ship_run(mode, None, &[], Some("ship-sweep"))?;
+    let invoke = runtime.submit_ship_run(mode, None, &[], false, None, Some("ship-sweep"))?;
     Ok(SweepReport {
         workspace_id: ws.id.clone(),
         workspace_name: ws.name.clone(),

--- a/crates/orbit-cli/src/command/run/tests/ship.rs
+++ b/crates/orbit-cli/src/command/run/tests/ship.rs
@@ -10,6 +10,8 @@ fn ship_args(task_ids: &[&str], mode: ShipMode, base: Option<&str>) -> ShipComma
         task_ids: task_ids.iter().map(|value| value.to_string()).collect(),
         mode: Some(mode),
         base: base.map(str::to_string),
+        review: false,
+        review_crew: None,
         json: false,
     }
 }
@@ -85,6 +87,30 @@ fn explicit_ship_preserves_local_mode_and_base_override() {
             "base_branch": "main",
             "task_ids": ["T20260425-2010"],
         })
+    );
+}
+
+#[test]
+fn ship_threads_explicit_review_controls() {
+    let mut args = ship_args(&["T20260425-2010"], ShipMode::Pr, None);
+    args.review = true;
+    args.review_crew = Some("opus-review".to_string());
+
+    let plan = build_plan(&args, "agent-main").expect("build review plan");
+
+    assert_eq!(plan.input["review"], true);
+    assert_eq!(plan.input["review_crew"], "opus-review");
+}
+
+#[test]
+fn ship_rejects_enabled_review_without_explicit_crew() {
+    let mut args = ship_args(&[], ShipMode::Pr, None);
+    args.review = true;
+
+    let error = build_plan(&args, "agent-main").expect_err("review crew is required");
+    assert!(
+        error.to_string().contains("non-blank explicit review crew"),
+        "unexpected error: {error}"
     );
 }
 

--- a/crates/orbit-core/assets/jobs/task_auto_pipeline.yaml
+++ b/crates/orbit-core/assets/jobs/task_auto_pipeline.yaml
@@ -37,6 +37,8 @@ spec:
     mode: pr
     base_branch: main
     base_sync: remote
+    review: false
+    review_crew: null
     max_bundles: 10
     concurrency: 5
     max_bundle_size: 5
@@ -70,6 +72,8 @@ spec:
               mode: "{{ input.mode }}"
               base_branch: "{{ input.base_branch }}"
               base_sync: "{{ input.base_sync }}"
+              review: "{{ input.review }}"
+              review_crew: "{{ input.review_crew }}"
       fan_in:
         join:
           mode: all

--- a/crates/orbit-core/assets/jobs/task_gate_pipeline.yaml
+++ b/crates/orbit-core/assets/jobs/task_gate_pipeline.yaml
@@ -45,6 +45,8 @@ spec:
     mode: pr
     base_branch: main
     base_sync: remote
+    review: false
+    review_crew: null
     max_wait_seconds: 3600
     poll_interval_seconds: 30
     ttl_seconds: 7200
@@ -84,6 +86,8 @@ spec:
           task_ids: "{{ input.task_ids }}"
           base_branch: "{{ input.base_branch }}"
           base_sync: "{{ input.base_sync }}"
+          review: "{{ input.review }}"
+          review_crew: "{{ input.review_crew }}"
           auto_push: true
         admission_task_ids: "{{ input.task_ids }}"
         admission_workflow: worktree_setup

--- a/crates/orbit-core/assets/jobs/task_local_pipeline.yaml
+++ b/crates/orbit-core/assets/jobs/task_local_pipeline.yaml
@@ -8,7 +8,8 @@
 #
 # Optional review step:
 # - `review_bundle` runs after `implement_bundle` when `input.review` is
-#   `true` (default `false`). It invokes `agent_review`, which records
+#   `true` (default `false`) and uses only the required explicit
+#   `input.review_crew`. It invokes `agent_review`, which records
 #   blocking findings as `ReviewThread`s on the participating tasks via
 #   `orbit.task.review_thread.*` and applies fixes in-place. The pipeline
 #   does not gate on agent output; unresolved threads remain on the tasks
@@ -28,6 +29,7 @@ spec:
     base_branch: main
     base_sync: remote
     review: false
+    review_crew: null
   
   steps:
     - id: worktree
@@ -62,6 +64,7 @@ spec:
         task_ids: "{{ input.task_ids }}"
         workspace_path: "{{ steps.worktree.output.workspace_path }}"
         base_branch: "{{ input.base_branch }}"
+        crew: "{{ input.review_crew }}"
 
     - id: commit
       recovery_activity: step_failure_recovery

--- a/crates/orbit-core/assets/jobs/task_pr_pipeline.yaml
+++ b/crates/orbit-core/assets/jobs/task_pr_pipeline.yaml
@@ -15,7 +15,8 @@
 #
 # Optional review step:
 # - `review_bundle` runs after `implement_bundle` when `input.review` is
-#   `true` (default `false`). It invokes `agent_review`, which records
+#   `true` (default `false`) and uses only the required explicit
+#   `input.review_crew`. It invokes `agent_review`, which records
 #   blocking findings as `ReviewThread`s on the participating tasks via
 #   `orbit.task.review_thread.*` and applies fixes in-place. Unresolved
 #   threads ride through to the PR via the existing review-thread sync;
@@ -34,6 +35,7 @@ spec:
     base_branch: main
     base_sync: remote
     review: false
+    review_crew: null
     title: null
     body: null
 
@@ -71,6 +73,7 @@ spec:
         task_ids: "{{ input.task_ids }}"
         workspace_path: "{{ steps.worktree.output.workspace_path }}"
         base_branch: "{{ input.base_branch }}"
+        crew: "{{ input.review_crew }}"
 
     - id: commit
       recovery_activity: step_failure_recovery

--- a/crates/orbit-core/src/command/job/catalog.rs
+++ b/crates/orbit-core/src/command/job/catalog.rs
@@ -443,6 +443,138 @@ spec:
     }
 
     #[test]
+    fn ship_review_controls_propagate_through_auto_and_gate_pipelines() {
+        let auto_yaml = DEFAULT_JOB_FILES
+            .iter()
+            .find_map(|(name, yaml)| (*name == "task_auto_pipeline").then_some(*yaml))
+            .expect("task auto pipeline default exists");
+        let auto = load_job_asset(auto_yaml).expect("parse task auto pipeline");
+        let auto_defaults = auto
+            .spec
+            .default_input
+            .as_ref()
+            .expect("task auto pipeline default input");
+        assert_eq!(auto_defaults["review"], false);
+        assert_eq!(auto_defaults["review_crew"], Value::Null);
+
+        let auto_dispatch = auto
+            .spec
+            .steps
+            .iter()
+            .find(|step| step.id == "dispatch")
+            .expect("task auto pipeline dispatch step");
+        let JobV2StepBody::FanOut { fan_out, .. } = &auto_dispatch.body else {
+            panic!("task auto pipeline dispatch must be a fan-out");
+        };
+        let JobV2StepBody::TargetRef(auto_target) = &fan_out.worker.body else {
+            panic!("task auto pipeline worker must reference invoke_and_wait");
+        };
+        let auto_run_input = &auto_target
+            .default_input
+            .as_ref()
+            .expect("task auto pipeline dispatch input");
+        assert_eq!(auto_run_input["job_name"], "task_gate_pipeline");
+        let auto_run_input = &auto_run_input["run_input"];
+        assert_eq!(auto_run_input["review"], "{{ input.review }}");
+        assert_eq!(auto_run_input["review_crew"], "{{ input.review_crew }}");
+
+        let gate_yaml = DEFAULT_JOB_FILES
+            .iter()
+            .find_map(|(name, yaml)| (*name == "task_gate_pipeline").then_some(*yaml))
+            .expect("task gate pipeline default exists");
+        let gate = load_job_asset(gate_yaml).expect("parse task gate pipeline");
+        let gate_defaults = gate
+            .spec
+            .default_input
+            .as_ref()
+            .expect("task gate pipeline default input");
+        assert_eq!(gate_defaults["review"], false);
+        assert_eq!(gate_defaults["review_crew"], Value::Null);
+
+        let gate_dispatch = gate
+            .spec
+            .steps
+            .iter()
+            .find(|step| step.id == "dispatch_child")
+            .expect("task gate pipeline child dispatch step");
+        let JobV2StepBody::TargetRef(gate_target) = &gate_dispatch.body else {
+            panic!("task gate pipeline dispatch must reference invoke_and_wait");
+        };
+        let gate_run_input = &gate_target
+            .default_input
+            .as_ref()
+            .expect("task gate pipeline dispatch input");
+        assert_eq!(gate_run_input["job_name"], "task_{{ input.mode }}_pipeline");
+        let gate_run_input = &gate_run_input["run_input"];
+        assert_eq!(gate_run_input["review"], "{{ input.review }}");
+        assert_eq!(gate_run_input["review_crew"], "{{ input.review_crew }}");
+    }
+
+    #[test]
+    fn leaf_ship_review_is_opt_in_and_uses_only_the_explicit_review_crew() {
+        for job_name in ["task_pr_pipeline", "task_local_pipeline"] {
+            let yaml = DEFAULT_JOB_FILES
+                .iter()
+                .find_map(|(name, yaml)| (*name == job_name).then_some(*yaml))
+                .unwrap_or_else(|| panic!("default job {job_name} exists"));
+            let asset = load_job_asset(yaml)
+                .unwrap_or_else(|err| panic!("default job {job_name} should parse: {err}"));
+            let defaults = asset
+                .spec
+                .default_input
+                .as_ref()
+                .unwrap_or_else(|| panic!("default job {job_name} has default input"));
+            assert_eq!(defaults["review"], false);
+            assert_eq!(defaults["review_crew"], Value::Null);
+
+            let review = asset
+                .spec
+                .steps
+                .iter()
+                .find(|step| step.id == "review_bundle")
+                .unwrap_or_else(|| panic!("default job {job_name} has review_bundle"));
+            assert_eq!(review.when.as_deref(), Some("{{ input.review }} == true"));
+            let JobV2StepBody::TargetRef(review_target) = &review.body else {
+                panic!("default job {job_name} review_bundle must reference agent_review");
+            };
+            assert_eq!(review_target.target, "activity:agent_review");
+            let review_input = review_target
+                .default_input
+                .as_ref()
+                .expect("review_bundle input");
+            assert_eq!(review_input["crew"], "{{ input.review_crew }}");
+
+            let implement = asset
+                .spec
+                .steps
+                .iter()
+                .find(|step| step.id == "implement_bundle")
+                .unwrap_or_else(|| panic!("default job {job_name} has implement_bundle"));
+            let JobV2StepBody::Loop { loop_ } = &implement.body else {
+                panic!("default job {job_name} implement_bundle must be a loop");
+            };
+            let implement_one = loop_
+                .steps
+                .iter()
+                .find(|step| step.id == "implement_one")
+                .expect("implement_bundle has implement_one");
+            let JobV2StepBody::TargetRef(implement_target) = &implement_one.body else {
+                panic!("default job {job_name} implement_one must reference agent_implement");
+            };
+            assert_eq!(implement_target.target, "activity:agent_implement");
+            assert!(
+                implement_target
+                    .default_input
+                    .as_ref()
+                    .expect("implement_one input")
+                    .get("crew")
+                    .is_none(),
+                "default job {job_name} must not apply review_crew to implementation"
+            );
+        }
+    }
+
+    #[test]
     fn pr_pipeline_models_handoff_phases_as_ordered_activity_checkpoints() {
         let yaml = DEFAULT_JOB_FILES
             .iter()

--- a/crates/orbit-core/src/command/pipeline_run.rs
+++ b/crates/orbit-core/src/command/pipeline_run.rs
@@ -57,18 +57,22 @@ impl OrbitRuntime {
     /// falls back to the workspace's `[workflow] base_branch`; an empty
     /// `task_ids` slice selects auto (backlog-discovery) mode. One-shot:
     /// returns as soon as the run is persisted and its worker spawned.
+    /// `review_crew` is required and applied only when `review` is enabled.
     pub fn submit_ship_run(
         &self,
         mode: crate::command::workflow::ShipMode,
         base_branch: Option<&str>,
         task_ids: &[String],
+        review: bool,
+        review_crew: Option<&str>,
         actor: Option<&str>,
     ) -> Result<PipelineInvokeResult, OrbitError> {
         let workflow =
             crate::command::workflow::find_workflow(crate::command::workflow::SHIP_WORKFLOW_ALIAS)
                 .ok_or_else(|| OrbitError::InvalidInput("unknown workflow 'ship'".to_string()))?;
         let base = base_branch.unwrap_or_else(|| self.workflow_base_branch());
-        let input = crate::command::workflow::build_ship_input(mode, base, task_ids)?;
+        let input =
+            crate::command::workflow::build_ship_input(mode, base, task_ids, review, review_crew)?;
         self.submit_pipeline_run(workflow.job_id, input, None, actor)
     }
 

--- a/crates/orbit-core/src/command/workflow.rs
+++ b/crates/orbit-core/src/command/workflow.rs
@@ -123,10 +123,15 @@ pub fn resolved_ship_mode(workspace: &orbit_common::types::Workspace) -> ShipMod
 /// An empty `task_ids` slice selects auto mode (the pipeline discovers
 /// backlog tasks itself). Explicit ids are validated for duplicates and
 /// emptiness so every submission surface rejects the same malformed input.
+/// Review controls are omitted from the resulting document when disabled to
+/// preserve the historical ship input exactly. Enabling review requires a
+/// non-blank explicit crew so review never inherits implementation routing.
 pub fn build_ship_input(
     mode: ShipMode,
     base_branch: &str,
     task_ids: &[String],
+    review: bool,
+    review_crew: Option<&str>,
 ) -> Result<Value, OrbitError> {
     if base_branch.trim().is_empty() {
         return Err(OrbitError::InvalidInput(
@@ -160,6 +165,21 @@ pub fn build_ship_input(
         map.insert(
             "task_ids".to_string(),
             Value::Array(task_ids.iter().cloned().map(Value::String).collect()),
+        );
+    }
+    if review {
+        let review_crew = review_crew
+            .map(str::trim)
+            .filter(|crew| !crew.is_empty())
+            .ok_or_else(|| {
+                OrbitError::InvalidInput(
+                    "ship review requires a non-blank explicit review crew".to_string(),
+                )
+            })?;
+        map.insert("review".to_string(), Value::Bool(true));
+        map.insert(
+            "review_crew".to_string(),
+            Value::String(review_crew.to_string()),
         );
     }
     Ok(Value::Object(map))
@@ -326,16 +346,19 @@ mod ship_input_tests {
 
     #[test]
     fn build_ship_input_auto_mode_omits_task_ids() {
-        let input = build_ship_input(ShipMode::Pr, "main", &[]).expect("input builds");
+        let input = build_ship_input(ShipMode::Pr, "main", &[], false, None).expect("input builds");
         assert_eq!(input["mode"], "pr");
         assert_eq!(input["base_branch"], "main");
         assert!(input.get("task_ids").is_none());
+        assert!(input.get("review").is_none());
+        assert!(input.get("review_crew").is_none());
     }
 
     #[test]
     fn build_ship_input_explicit_tasks_and_local_mode() {
         let task_ids = vec!["T1".to_string(), "T2".to_string()];
-        let input = build_ship_input(ShipMode::Local, "agent-main", &task_ids).expect("builds");
+        let input = build_ship_input(ShipMode::Local, "agent-main", &task_ids, false, None)
+            .expect("builds");
         assert_eq!(input["mode"], "local");
         assert_eq!(input["base_branch"], "agent-main");
         assert_eq!(input["task_ids"], serde_json::json!(["T1", "T2"]));
@@ -344,12 +367,33 @@ mod ship_input_tests {
     #[test]
     fn build_ship_input_rejects_duplicates_blank_ids_and_empty_base() {
         let dup = vec!["T1".to_string(), "T1".to_string()];
-        assert!(build_ship_input(ShipMode::Pr, "main", &dup).is_err());
+        assert!(build_ship_input(ShipMode::Pr, "main", &dup, false, None).is_err());
 
         let blank = vec!["  ".to_string()];
-        assert!(build_ship_input(ShipMode::Pr, "main", &blank).is_err());
+        assert!(build_ship_input(ShipMode::Pr, "main", &blank, false, None).is_err());
 
-        assert!(build_ship_input(ShipMode::Pr, "  ", &[]).is_err());
+        assert!(build_ship_input(ShipMode::Pr, "  ", &[], false, None).is_err());
+    }
+
+    #[test]
+    fn build_ship_input_includes_explicit_review_controls() {
+        let input = build_ship_input(ShipMode::Pr, "main", &[], true, Some("opus-review"))
+            .expect("review input builds");
+
+        assert_eq!(input["review"], true);
+        assert_eq!(input["review_crew"], "opus-review");
+    }
+
+    #[test]
+    fn build_ship_input_rejects_enabled_review_without_non_blank_crew() {
+        for review_crew in [None, Some(""), Some("   ")] {
+            let error = build_ship_input(ShipMode::Pr, "main", &[], true, review_crew)
+                .expect_err("enabled review requires a crew");
+            assert!(
+                error.to_string().contains("non-blank explicit review crew"),
+                "unexpected error: {error}"
+            );
+        }
     }
 
     #[test]

--- a/crates/orbit-core/src/runtime/v2_host/dispatch.rs
+++ b/crates/orbit-core/src/runtime/v2_host/dispatch.rs
@@ -325,12 +325,17 @@ fn resolve_workspace_ship_input(
         .map(crate::command::workflow::resolved_ship_mode)
         .unwrap_or(crate::command::workflow::ShipMode::Local);
 
-    crate::command::workflow::build_ship_input(mode, runtime.workflow_base_branch(), &[]).map_err(
-        |error| DispatchError::DeterministicActionFailed {
-            action: action.to_string(),
-            message: format!("resolve workspace ship input: {error}"),
-        },
+    crate::command::workflow::build_ship_input(
+        mode,
+        runtime.workflow_base_branch(),
+        &[],
+        false,
+        None,
     )
+    .map_err(|error| DispatchError::DeterministicActionFailed {
+        action: action.to_string(),
+        message: format!("resolve workspace ship input: {error}"),
+    })
 }
 
 fn unmet_dependency_ids_for_input(

--- a/crates/orbit-dashboard/src/api/runs.rs
+++ b/crates/orbit-dashboard/src/api/runs.rs
@@ -34,6 +34,12 @@ pub(super) struct ShipBody {
     /// Base branch override; defaults to the workspace's `[workflow] base_branch`.
     #[serde(default)]
     base: Option<String>,
+    /// Whether to run an independent review before shipment.
+    #[serde(default)]
+    review: bool,
+    /// Explicit crew used only for the independent review step.
+    #[serde(default)]
+    review_crew: Option<String>,
 }
 
 /// Submit a `ship` workflow run (`POST /workflows/ship?workspace=<id>`).
@@ -54,6 +60,8 @@ pub(super) async fn ship_workflow_action(
         mode,
         body.base.as_deref(),
         &body.task_ids,
+        body.review,
+        body.review_crew.as_deref(),
         Some("dashboard"),
     ) {
         Ok(invoke) => Json(json!({

--- a/crates/orbit-dashboard/src/api/tests/runs.rs
+++ b/crates/orbit-dashboard/src/api/tests/runs.rs
@@ -619,7 +619,15 @@ async fn ship_endpoint_submits_task_auto_pipeline_run() {
     let runtime = OrbitRuntime::in_memory().expect("build runtime");
     write_replay_job(&runtime, "task_auto_pipeline");
 
-    let response = request_ship(runtime.clone(), Some(json!({ "mode": "pr" }))).await;
+    let response = request_ship(
+        runtime.clone(),
+        Some(json!({
+            "mode": "pr",
+            "review": true,
+            "review_crew": "opus-review",
+        })),
+    )
+    .await;
 
     assert_eq!(response.status(), StatusCode::OK);
     let payload = body_json(response).await;
@@ -632,6 +640,15 @@ async fn ship_endpoint_submits_task_auto_pipeline_run() {
     let run_id = payload["run_id"].as_str().expect("run id");
     let stored = runtime.show_job_run(run_id).expect("stored ship run");
     assert_eq!(stored.job_id, "task_auto_pipeline");
+    assert_eq!(
+        stored.input,
+        Some(json!({
+            "mode": "pr",
+            "base_branch": "main",
+            "review": true,
+            "review_crew": "opus-review",
+        }))
+    );
 }
 
 #[tokio::test]
@@ -646,6 +663,21 @@ async fn ship_endpoint_rejects_unknown_mode() {
         payload["error"]
             .as_str()
             .is_some_and(|message| message.contains("unknown ship mode"))
+    );
+}
+
+#[tokio::test]
+async fn ship_endpoint_rejects_enabled_review_without_explicit_crew() {
+    let runtime = OrbitRuntime::in_memory().expect("build runtime");
+
+    let response = request_ship(runtime, Some(json!({ "review": true }))).await;
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    let payload = body_json(response).await;
+    assert!(
+        payload["error"]
+            .as_str()
+            .is_some_and(|message| message.contains("non-blank explicit review crew"))
     );
 }
 


### PR DESCRIPTION
## Task

[ORB-10251](https://orbit-cli.com/tasks/ORB-10251) — Propagate independent review controls through ship pipelines

### Description

## Problem
The canonical Orbit ship path cannot request the seeded `review_bundle`: `build_ship_input`, the CLI/pipeline command, the dashboard ship endpoint, `task_auto_pipeline`, and `task_gate_pipeline` do not accept or forward `review`. Even a direct leaf-pipeline invocation reuses the implementation task's flat crew because the review step has no explicit crew override.

## Why It Matters
Large Build Week changes require an independent Opus/Fable review, but normal orchestration cannot activate that review or keep it independent from implementation. This is Orbit's half of F2026-07-075 and defines the canonical contract consumed by Bridge.

## Required Contract
- Add ship inputs `review` (default `false`) and `review_crew`.
- When review is requested, require a non-blank explicit `review_crew`; do not silently inherit the task/implementation crew.
- Propagate both fields through canonical ship input construction and `task_auto_pipeline -> task_gate_pipeline -> task_pr_pipeline|task_local_pipeline`.
- Apply `review_crew` only to `review_bundle` / `activity:agent_review`; implementation and all other steps retain their existing crew resolution.
- Preserve byte-for-byte-equivalent behavior for callers that omit review controls.
- Expose the same contract through the CLI/pipeline command and dashboard ship endpoint.
- Keep bundled assets and tracked workspace resource copies synchronized.

## Cross-Repository Boundary
The companion Bridge task must depend on this task and forward the same field names and validation semantics from `workflow_ship`. Together they resolve F2026-07-075.

### Acceptance Criteria

- `build_ship_input` and every canonical ship entry point accept `review` plus `review_crew`; `review=false` remains the default and existing callers/tests retain their prior behavior.
- A ship request with `review=true` and blank/missing `review_crew` fails with a clear validation error before a job run is submitted.
- Automated catalog/fixture tests prove `review` and `review_crew` propagate from `task_auto_pipeline` through `task_gate_pipeline` to both PR and local child pipelines.
- Job tests prove `review_bundle` is skipped when `review=false`, runs when `review=true`, and receives the explicit review crew without changing the crew used by `implement_bundle`.
- Dashboard API tests prove `/api/runs/ship` accepts the review controls, persists them in the `task_auto_pipeline` run input, and rejects an invalid enabled-review request.
- CLI/core/dashboard targeted tests pass, bundled and `.orbit/resources` job definitions remain synchronized, and `make ci-fast` passes.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Extended the canonical ship input builder, runtime submission API, CLI `orbit run ship`, and dashboard ship request body with opt-in `review` and explicit `review_crew` controls. Review-disabled callers retain the historical input document, while enabled review with a missing or blank crew fails before run submission.
- Propagated both controls through `task_auto_pipeline -> task_gate_pipeline -> task_pr_pipeline|task_local_pipeline`; only `review_bundle` maps `review_crew` to the activity `crew`, leaving `implement_bundle` and every other step's crew resolution unchanged.
- Kept the four bundled job definitions byte-identical to their tracked `.orbit/resources/jobs` copies and documented the explicit review-crew behavior in the leaf jobs.
- Added core builder and catalog contract tests, CLI plan tests, and dashboard API persistence/rejection tests.
Assessment: The canonical ship path now supports independent review without changing default shipment behavior, and structural coverage locks propagation and crew isolation across both PR and local pipelines.
Deviations from original plan:
- Updated `crates/orbit-cli/src/command/run/sweep.rs` and `crates/orbit-core/src/runtime/v2_host/dispatch.rs` with review-disabled compatibility arguments, plus `crates/orbit-cli/src/command/run/tests/ship.rs` for the directly affected CLI contract. These unlisted files and reasons were recorded in a task comment before editing.
Validation:
- `cargo test -p orbit-core ship_input_tests --lib` (6 passed)
- `cargo test -p orbit-core ship_review --lib` (2 passed)
- `cargo test -p orbit-cli command::run::tests::ship` (11 passed)
- `cargo test -p orbit-dashboard ship_endpoint --lib` (6 passed)
- Bundled/workspace YAML copy diffs: clean
- `git diff --check`: passed
- `make ci-fast`: passed

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10251-6a5aeba5`
- Behind base: 0
- Ahead of base: 1