### PR TITLE
orbit HTTP task API: accept typed `relations` on POST /api/tasks and PATCH /api/tasks/:id

### DIFF
--- a/crates/orbit-dashboard/src/api/tasks.rs
+++ b/crates/orbit-dashboard/src/api/tasks.rs
@@ -5,6 +5,7 @@ use axum::body::Body;
 use axum::extract::Path;
 use axum::http::{HeaderName, HeaderValue, header};
 use axum::response::{IntoResponse, Json, Response};
+use orbit_common::types::task_artifacts::TaskRelation;
 use orbit_common::types::validate_relative_artifact_path;
 use orbit_core::command::task::{TaskAddParams, TaskUpdateParams};
 use orbit_core::{
@@ -55,6 +56,8 @@ pub(super) struct CreateTaskBody {
     acceptance_criteria: Vec<String>,
     #[serde(default)]
     dependencies: Vec<String>,
+    #[serde(default)]
+    relations: Vec<TaskRelation>,
     #[serde(default)]
     tags: Vec<String>,
     #[serde(default)]
@@ -109,6 +112,8 @@ pub(super) struct UpdateTaskBody {
     acceptance_criteria: Option<Vec<String>>,
     #[serde(default)]
     dependencies: Option<Vec<String>>,
+    #[serde(default)]
+    relations: Option<Vec<TaskRelation>>,
     #[serde(default)]
     tags: Option<Vec<String>>,
     #[serde(default)]
@@ -299,7 +304,7 @@ pub(super) async fn create_task_action(
         description: body.description,
         acceptance_criteria: body.acceptance_criteria,
         dependencies: body.dependencies,
-        relations: Vec::new(),
+        relations: body.relations,
         tags: body.tags,
         plan: body.plan,
         comment: None,
@@ -340,7 +345,7 @@ pub(super) async fn update_task_action(
         description: body.description,
         acceptance_criteria: body.acceptance_criteria,
         dependencies: body.dependencies,
-        relations: None,
+        relations: body.relations,
         tags: body.tags,
         plan: body.plan,
         execution_summary: body.execution_summary,

--- a/crates/orbit-dashboard/src/api/tests/tasks.rs
+++ b/crates/orbit-dashboard/src/api/tests/tasks.rs
@@ -7,6 +7,7 @@ use axum::body::{Body, to_bytes};
 use axum::http::{HeaderValue, Method, Request, StatusCode, header};
 use orbit_common::test_fixtures::TEST_CODEX_MODEL;
 use orbit_common::types::TaskArtifact;
+use orbit_common::types::task_artifacts::{TaskRelation, TaskRelationType};
 use orbit_core::command::task::{TaskAddParams, TaskUpdateParams};
 use orbit_core::{OrbitRuntime, TaskComplexity, TaskStatus};
 use serde_json::{Value, json};
@@ -23,6 +24,28 @@ fn post_json(uri: &str, body: Value) -> Request<Body> {
         .header(header::CONTENT_TYPE, "application/json")
         .body(Body::from(body.to_string()))
         .expect("request")
+}
+
+fn patch_json(uri: &str, body: Value) -> Request<Body> {
+    Request::builder()
+        .method(Method::PATCH)
+        .uri(uri)
+        .header(header::ORIGIN, "http://localhost:7878")
+        .header(header::CONTENT_TYPE, "application/json")
+        .body(Body::from(body.to_string()))
+        .expect("request")
+}
+
+fn seed_backlog_task(runtime: &OrbitRuntime, title: &str) -> orbit_core::Task {
+    runtime
+        .add_task(TaskAddParams {
+            title: title.to_string(),
+            description: format!("Fixture task: {title}."),
+            status: Some(TaskStatus::Backlog),
+            workspace_path: Some(".".to_string()),
+            ..Default::default()
+        })
+        .expect("seed backlog task")
 }
 
 fn seed_task_with_artifact(runtime: &OrbitRuntime) -> orbit_core::Task {
@@ -846,4 +869,145 @@ async fn create_task_only_accepts_creation_legal_statuses_and_ignores_comment() 
     let body = body_json(created).await;
     assert_eq!(body["status"], json!("backlog"));
     assert_eq!(body["comments"], json!([]));
+}
+
+/// ORB-10253: `POST /api/tasks` accepts a `relations` array of {type, target}
+/// objects and persists them on the created task (mirroring the native MCP
+/// wire shape). Previously `create_task_action` hardcoded `relations: Vec::new()`.
+#[tokio::test]
+async fn create_task_persists_relations_from_body() {
+    let runtime = OrbitRuntime::in_memory().expect("build runtime");
+    let target = seed_backlog_task(&runtime, "Relation target");
+    let app = router().with_state(crate::state::DashboardState::single(Arc::new(runtime)));
+
+    let response = app
+        .oneshot(post_json(
+            "/tasks",
+            json!({
+                "title": "task with relations",
+                "description": "records a typed relation on create",
+                "status": "backlog",
+                "relations": [{ "type": "related_to", "target": target.id }],
+            }),
+        ))
+        .await
+        .expect("response");
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = body_json(response).await;
+    assert_eq!(
+        body["relations"],
+        json!([{ "type": "related_to", "target": target.id }])
+    );
+}
+
+/// ORB-10253: a present `relations` array on `PATCH /api/tasks/:id` replaces the
+/// existing relation set. Previously `update_task_action` hardcoded
+/// `relations: None`, so relations could never be edited over HTTP.
+#[tokio::test]
+async fn update_task_replaces_relation_set() {
+    let runtime = OrbitRuntime::in_memory().expect("build runtime");
+    let first = seed_backlog_task(&runtime, "First relation target");
+    let second = seed_backlog_task(&runtime, "Second relation target");
+    let task = runtime
+        .add_task(TaskAddParams {
+            title: "Task with an initial relation".to_string(),
+            description: "relation set will be replaced over HTTP".to_string(),
+            status: Some(TaskStatus::Backlog),
+            workspace_path: Some(".".to_string()),
+            relations: vec![TaskRelation {
+                relation_type: TaskRelationType::RelatedTo,
+                target: first.id.clone(),
+            }],
+            ..Default::default()
+        })
+        .expect("seed task with relation");
+    let app = router().with_state(crate::state::DashboardState::single(Arc::new(runtime)));
+
+    let response = app
+        .oneshot(patch_json(
+            &format!("/tasks/{}", task.id),
+            json!({ "relations": [{ "type": "related_to", "target": second.id }] }),
+        ))
+        .await
+        .expect("response");
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = body_json(response).await;
+    assert_eq!(
+        body["relations"],
+        json!([{ "type": "related_to", "target": second.id }]),
+        "present relations array replaces the set (drops the prior target)"
+    );
+}
+
+/// ORB-10253: an empty `relations` array on `PATCH /api/tasks/:id` clears the
+/// relation set, while an absent field leaves it unchanged (covered implicitly
+/// by every other PATCH test that omits `relations`).
+#[tokio::test]
+async fn update_task_clears_relations_with_empty_array() {
+    let runtime = OrbitRuntime::in_memory().expect("build runtime");
+    let target = seed_backlog_task(&runtime, "Relation target to be cleared");
+    let task = runtime
+        .add_task(TaskAddParams {
+            title: "Task whose relations get cleared".to_string(),
+            description: "empty array clears the relation set".to_string(),
+            status: Some(TaskStatus::Backlog),
+            workspace_path: Some(".".to_string()),
+            relations: vec![TaskRelation {
+                relation_type: TaskRelationType::RelatedTo,
+                target: target.id.clone(),
+            }],
+            ..Default::default()
+        })
+        .expect("seed task with relation");
+    let app = router().with_state(crate::state::DashboardState::single(Arc::new(runtime)));
+
+    let response = app
+        .oneshot(patch_json(
+            &format!("/tasks/{}", task.id),
+            json!({ "relations": [] }),
+        ))
+        .await
+        .expect("response");
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = body_json(response).await;
+    assert_eq!(body["relations"], json!([]), "empty array clears relations");
+}
+
+/// ORB-10253: an invalid relation target must surface Orbit's own validation
+/// error as a 4xx — never a silent drop. A malformed target fails
+/// `validate_task_relations_for_source` and reaches the client through
+/// `map_runtime_error` as a 400.
+#[tokio::test]
+async fn create_task_rejects_invalid_relation_target() {
+    let runtime = OrbitRuntime::in_memory().expect("build runtime");
+    let app = router().with_state(crate::state::DashboardState::single(Arc::new(runtime)));
+
+    let response = app
+        .oneshot(post_json(
+            "/tasks",
+            json!({
+                "title": "task with a bad relation",
+                "description": "malformed relation target must be rejected",
+                "status": "backlog",
+                "relations": [{ "type": "related_to", "target": "not-a-task-id" }],
+            }),
+        ))
+        .await
+        .expect("response");
+
+    assert!(
+        response.status().is_client_error(),
+        "invalid relation target must be a 4xx, got {}",
+        response.status()
+    );
+    let body = body_json(response).await;
+    assert!(
+        body["error"]
+            .as_str()
+            .is_some_and(|m| m.contains("not-a-task-id")),
+        "error must carry Orbit's validation text: {body}"
+    );
 }


### PR DESCRIPTION
## Task

[ORB-10253](https://orbit-cli.com/tasks/ORB-10253) — orbit HTTP task API: accept typed `relations` on POST /api/tasks and PATCH /api/tasks/:id

### Description

## Problem

Bridge's `orbit_task_add` / `orbit_task_update` cannot forward typed task
`relations` end-to-end (ORB-10190) because Orbit's **HTTP** task API — the
dashboard `/api` surface Bridge proxies — does not accept them:

- `POST /api/tasks` (`CreateTaskBody`) has no `relations` field;
  `create_task_action` hardcodes `relations: Vec::new()`.
- `PATCH /api/tasks/:id` (`UpdateTaskBody`) has no `relations` field;
  `update_task_action` hardcodes `relations: None`.

The runtime and native MCP tools already support relations end-to-end
(`TaskAddParams.relations` / `TaskUpdateParams.relations`, validated by
`validate_task_relations_for_source`, exposed by `orbit.task.add` /
`orbit.task.update`). Only the HTTP body plumbing is missing, so Bridge — which
has no generic tool-execution HTTP route — cannot reach that capability.

## Why It Matters

`mcp-bridge` is delivery scope. Bridge advertises Orbit's `relations` schema on
its parity surface, so callers connecting through Bridge must be able to record
typed relations (hierarchy, `supersedes`, dependency/provenance) exactly as they
can against Orbit's native tool surface. Until the HTTP API carries relations,
Bridge must keep honestly omitting the field, and ORB-10190 stays blocked.

## Scope

Extend the dashboard HTTP task create/update endpoints to accept and forward
`relations`, mirroring the native MCP schema and semantics. Do not change the
relation model, validation, or wire shape.

## Implementation Notes

In `crates/orbit-dashboard/src/api/tasks.rs`:

- Import `TaskRelation` (`orbit_common::types::task_artifacts::TaskRelation`).
- `CreateTaskBody`: add `#[serde(default)] relations: Vec<TaskRelation>,` and
  pass `relations: body.relations` into `TaskAddParams` (replacing the current
  `relations: Vec::new()`).
- `UpdateTaskBody`: add `#[serde(default)] relations: Option<Vec<TaskRelation>>,`
  and pass `relations: body.relations` into `TaskUpdateParams` (replacing the
  current `relations: None`). Absent field ⇒ `None` (unchanged); `[]` ⇒ replace
  with empty (clear).
- Rely on the existing runtime validation
  (`validate_task_relations_for_source`) so invalid relation type/target,
  dangling-policy, and lifecycle violations surface through
  `map_runtime_error` as 4xx with Orbit's own error text — never a silent drop.

Wire shape (unchanged): `relations` is an array of `{ "type": <relation_type>,
"target": <task-id> }`. `TaskRelationType` variants: `blocked_by`, `child_of`,
`spawned_from`, `regression_from`, `supersedes`, `related_to`, `produces`,
`resolves` (serde-renamed).

Add handler tests in `crates/orbit-dashboard/src/api/tests/tasks.rs`:
create-with-relations, update-replace, update-clear (`[]`), invalid-relation-
type/target rejection (4xx).

## Downstream

Unblocks ORB-10190 (Bridge task-relations parity). After this lands, ORB-10190
adds the `relations` param to Bridge's `orbit_task_add` / `orbit_task_update`,
forwards it in the request body, removes the parity-snapshot omission, and
replaces its honest-gap tests with create/replace/clear/invalid/routing/backend-
error coverage.

### Acceptance Criteria

- POST /api/tasks accepts a `relations` array of {type target} objects and persists them on the created task
- PATCH /api/tasks/:id accepts `relations`: a present array replaces the relation set and an empty array clears it while an absent field leaves relations unchanged
- Invalid relation type/target dangling-policy and lifecycle violations return 4xx carrying Orbit HTTP error text with no silent drop
- Native MCP relation schema wire shape and validation semantics remain unchanged
- orbit-dashboard handler tests cover create-with-relations update-replace update-clear and invalid-relation rejection

## Execution Summary

<details>
<summary>Click to expand</summary>

Extended the dashboard HTTP task create/update endpoints to accept and forward typed `relations`, closing the last gap that blocked Bridge from recording task relations end-to-end (ORB-10190). All changes are in crates/orbit-dashboard/src/api/tasks.rs and its sibling tests.

Production change (tasks.rs):
- Imported `orbit_common::types::task_artifacts::TaskRelation`.
- CreateTaskBody: added `#[serde(default)] relations: Vec<TaskRelation>` and passed `relations: body.relations` into TaskAddParams (was hardcoded `Vec::new()`).
- UpdateTaskBody: added `#[serde(default)] relations: Option<Vec<TaskRelation>>` and passed `relations: body.relations` into TaskUpdateParams (was hardcoded `None`). Absent field => None (unchanged); [] => replace with empty (clear).
- No change to the relation model, validation, or wire shape. Invalid type/target/dangling/lifecycle violations continue to surface through the existing runtime validation (validate_task_relations_for_source) and map_runtime_error as 4xx carrying Orbit's own error text — verified by test. Native MCP schema/semantics untouched.

Wire shape (unchanged): relations is an array of {"type": <relation_type>, "target": <id>}; TaskRelationType serde-renamed variants blocked_by/child_of/spawned_from/regression_from/supersedes/related_to/produces/resolves.

Tests added (api/tests/tasks.rs), plus patch_json + seed_backlog_task helpers:
- create_task_persists_relations_from_body — POST /tasks with a related_to relation persists it (response projects relations).
- update_task_replaces_relation_set — PATCH with a present relations array replaces the prior set.
- update_task_clears_relations_with_empty_array — PATCH {"relations": []} clears the set (absent-field=unchanged is covered by every other PATCH test).
- create_task_rejects_invalid_relation_target — malformed target returns 4xx (400) with Orbit's validation text, no silent drop.

Validation: `cargo test -p orbit-dashboard --lib api::tests::tasks` => 21 passed (4 new). `cargo fmt -p orbit-dashboard --check` clean. `make ci-fast` passed. No design-doc/ADR change needed — purely additive HTTP plumbing that mirrors existing accepted native-MCP relation semantics; wire shape and validation are unchanged.

Downstream: unblocks ORB-10190 (Bridge task-relations parity).

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10253-6a5aef43`
- Behind base: 0
- Ahead of base: 1