### PR TITLE
fix: keep scheduled ship sweep disabled

### DIFF
--- a/.orbit/routines/ship_sweep.yaml
+++ b/.orbit/routines/ship_sweep.yaml
@@ -13,7 +13,7 @@ description: >
   Ship this workspace's ready backlog through the normal gated task pipeline.
   Disabled by default; set enabled to true in this versioned definition to
   opt this workspace into scheduled shipment.
-enabled: true
+enabled: false
 hosts:
   - dk-server-1
 trigger:


### PR DESCRIPTION
R0 inventory found the committed ship-sweep definition contradicted its own disabled-by-default contract and the current orchestrator-driven dispatch policy. This changes only enabled: true to enabled: false. Validation: make ci-fast and git diff --check pass.