### PR TITLE
orbit HTTP friction API: accept friction create (POST /api/frictions)

### DIFF
--- a/crates/orbit-dashboard/src/api/frictions.rs
+++ b/crates/orbit-dashboard/src/api/frictions.rs
@@ -1,6 +1,7 @@
 //! Friction artifact scan and triage handlers.
 
 use crate::state::Ws;
+use axum::extract::rejection::JsonRejection;
 use axum::extract::{Path, Query};
 use axum::response::{IntoResponse, Json, Response};
 use orbit_core::{OrbitError, OrbitRuntime};
@@ -26,6 +27,25 @@ pub(super) struct FrictionsQuery {
     limit: Option<usize>,
     #[serde(default)]
     offset: Option<usize>,
+}
+
+/// Create body for `POST /frictions`. Mirrors the `orbit.friction.add` tool
+/// schema: `body` is required, `model` provenance and `tags`/`during_task` are
+/// optional. Field parsing and validation stay in the shared runtime add path
+/// so the wire shape and defaults match the native MCP tool exactly. `model`
+/// falls back to the dashboard default (`FRICTION_TOOL_MODEL`) via
+/// [`run_friction_tool`] when the caller omits it, matching the other friction
+/// routes.
+#[derive(Deserialize, Default)]
+pub(super) struct CreateFrictionBody {
+    #[serde(default)]
+    model: Option<String>,
+    #[serde(default)]
+    body: Option<String>,
+    #[serde(default)]
+    tags: Option<Vec<String>>,
+    #[serde(default)]
+    during_task: Option<String>,
 }
 
 #[derive(Deserialize, Default)]
@@ -75,6 +95,44 @@ pub(super) async fn list_frictions(
         "items": items,
     }))
     .into_response()
+}
+
+/// `POST /frictions` — file a new friction, mirroring `orbit.friction.add`.
+/// The request body is passed through the shared runtime add path so validation
+/// and defaults stay identical to the native MCP tool; the created friction JSON
+/// (same projection the list/get handlers emit) is returned on success.
+/// Malformed JSON is rejected with a structured 400; deeper validation errors
+/// (missing/empty `body`, bad fields) surface through [`map_runtime_error`] as
+/// 4xx carrying Orbit's own error text.
+pub(super) async fn create_friction_action(
+    Ws(runtime): Ws,
+    body: Result<Json<CreateFrictionBody>, JsonRejection>,
+) -> Response {
+    let Json(body) = match body {
+        Ok(body) => body,
+        Err(rejection) => {
+            return bad_request(format!("malformed friction create payload: {rejection}"));
+        }
+    };
+
+    let mut input = Map::new();
+    if let Some(model) = body.model.as_deref().and_then(non_empty_string) {
+        input.insert("model".to_string(), Value::String(model));
+    }
+    if let Some(friction_body) = body.body {
+        input.insert("body".to_string(), Value::String(friction_body));
+    }
+    if let Some(tags) = body.tags {
+        input.insert("tags".to_string(), json!(tags));
+    }
+    if let Some(during_task) = body.during_task.as_deref().and_then(non_empty_string) {
+        input.insert("during_task".to_string(), Value::String(during_task));
+    }
+
+    match run_friction_tool(&runtime, "orbit.friction.add", Value::Object(input)) {
+        Ok(friction) => Json(friction).into_response(),
+        Err(e) => map_runtime_error(e),
+    }
 }
 
 pub(super) async fn get_friction(Ws(runtime): Ws, Path(id): Path<String>) -> Response {

--- a/crates/orbit-dashboard/src/api/mod.rs
+++ b/crates/orbit-dashboard/src/api/mod.rs
@@ -326,7 +326,10 @@ pub(super) fn router() -> Router<crate::state::DashboardState> {
         )
         .route("/adrs/:id/accept", post(adrs::accept_adr_action))
         .route("/adrs/:id/supersede", post(adrs::supersede_adr_action))
-        .route("/frictions", get(frictions::list_frictions))
+        .route(
+            "/frictions",
+            get(frictions::list_frictions).post(frictions::create_friction_action),
+        )
         .route("/frictions/stats", get(frictions::friction_stats))
         .route(
             "/frictions/:id",

--- a/crates/orbit-dashboard/src/api/tests/frictions.rs
+++ b/crates/orbit-dashboard/src/api/tests/frictions.rs
@@ -102,6 +102,127 @@ async fn resolve_requires_localhost_origin() {
 }
 
 #[tokio::test]
+async fn create_persists_and_echoes_fields() {
+    let runtime = OrbitRuntime::in_memory().expect("build runtime");
+
+    let response = request(
+        runtime.clone(),
+        Method::POST,
+        "/frictions".to_string(),
+        Some("http://localhost:7878"),
+        Some(json!({
+            "body": "# Slow tool\nThe CLI hung for a minute.",
+            "tags": ["tooling"],
+            "model": TEST_CODEX_MODEL,
+        })),
+    )
+    .await;
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let created = body_json(response).await;
+    let id = created["id"]
+        .as_str()
+        .expect("created friction id")
+        .to_string();
+    assert_eq!(
+        created["body"],
+        json!("# Slow tool\nThe CLI hung for a minute.")
+    );
+    assert_eq!(created["tags"], json!(["tooling"]));
+    assert_eq!(created["status"], "open");
+
+    // Persisted: readable through the existing GET surface.
+    let response = request(runtime, Method::GET, format!("/frictions/{id}"), None, None).await;
+    assert_eq!(response.status(), StatusCode::OK);
+    let fetched = body_json(response).await;
+    assert_eq!(fetched["id"], json!(id));
+    assert_eq!(
+        fetched["body"],
+        json!("# Slow tool\nThe CLI hung for a minute.")
+    );
+    assert_eq!(fetched["tags"], json!(["tooling"]));
+}
+
+#[tokio::test]
+async fn create_requires_localhost_origin() {
+    let runtime = OrbitRuntime::in_memory().expect("build runtime");
+
+    for (origin, label) in [(None, "missing"), (Some("http://example.com"), "foreign")] {
+        let response = request(
+            runtime.clone(),
+            Method::POST,
+            "/frictions".to_string(),
+            origin,
+            Some(json!({
+                "body": "# Snag\nDetails.",
+                "model": TEST_CODEX_MODEL,
+            })),
+        )
+        .await;
+
+        assert_eq!(response.status(), StatusCode::FORBIDDEN, "{label}");
+    }
+}
+
+#[tokio::test]
+async fn create_empty_body_is_rejected_with_error_text() {
+    let runtime = OrbitRuntime::in_memory().expect("build runtime");
+
+    let response = request(
+        runtime,
+        Method::POST,
+        "/frictions".to_string(),
+        Some("http://localhost:7878"),
+        Some(json!({
+            "body": "   ",
+            "model": TEST_CODEX_MODEL,
+        })),
+    )
+    .await;
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    let payload = body_json(response).await;
+    let error = payload["error"].as_str().expect("error text");
+    assert!(
+        error.contains("body"),
+        "error should name the offending `body` field: {error}"
+    );
+}
+
+#[tokio::test]
+async fn create_round_trips_tags_and_during_task() {
+    let runtime = OrbitRuntime::in_memory().expect("build runtime");
+
+    let response = request(
+        runtime.clone(),
+        Method::POST,
+        "/frictions".to_string(),
+        Some("http://localhost:7878"),
+        Some(json!({
+            "body": "# Blocked\nCould not run the tool.",
+            "tags": ["tooling", "docs"],
+            "during_task": "ORB-10260",
+            "model": TEST_CODEX_MODEL,
+        })),
+    )
+    .await;
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let created = body_json(response).await;
+    let id = created["id"]
+        .as_str()
+        .expect("created friction id")
+        .to_string();
+    assert_eq!(created["tags"], json!(["docs", "tooling"]));
+    assert_eq!(created["during_task"], json!("ORB-10260"));
+
+    let response = request(runtime, Method::GET, format!("/frictions/{id}"), None, None).await;
+    let fetched = body_json(response).await;
+    assert_eq!(fetched["tags"], json!(["docs", "tooling"]));
+    assert_eq!(fetched["during_task"], json!("ORB-10260"));
+}
+
+#[tokio::test]
 async fn path_traversal_id_is_rejected() {
     let runtime = OrbitRuntime::in_memory().expect("build runtime");
 


### PR DESCRIPTION
## Task

[ORB-10260](https://orbit-cli.com/tasks/ORB-10260) — orbit HTTP friction API: accept friction create (POST /api/frictions)

### Description

## Problem

Bridge cannot expose `orbit_friction_add` (friction-create parity) because Orbit's **HTTP** API —
the dashboard `/api` surface Bridge proxies — has no friction-create route. Current router
(`crates/orbit-dashboard/src/api/mod.rs`): `GET /frictions`, `GET /frictions/stats`,
`GET|PATCH /frictions/:id`, `POST /frictions/:id/resolve` — list, read, update, resolve, but no
create. The runtime and native MCP surface already support friction creation end-to-end
(`FrictionAddParams { model, body, tags, during_task, created_at }` in
`crates/orbit-store/src/file/friction_store/mod.rs`; native tool host in
`crates/orbit-core/src/runtime/orbit_tool_host/friction_tools.rs`), so only the HTTP body/route
plumbing is missing — the same shape as the task-relations gap fixed by ORB-10253.

## Why It Matters

Orbit's required self-reporting path says agents file frictions when tooling causes operational
problems. Remote agents connect through Bridge (`mcp-bridge` is Build Week delivery scope), and
Bridge deliberately refuses to advertise calls its transport cannot execute — so until this route
exists, no remote agent can file a friction through the authoritative surface (Sol is currently
blocked from filing a real report; see Bridge-side follow-up task in `ws_bridge`).

## Scope

Add `POST /api/frictions` to `orbit-dashboard`, mirroring the native MCP friction-add schema and
semantics. Do not change the friction model, validation, or wire shape.

## Implementation Notes

- Router (`api/mod.rs`): `.route("/frictions", get(frictions::list_frictions).post(frictions::create_friction_action))`.
- `frictions.rs`: add a `CreateFrictionBody` deserializing the native MCP friction-add fields
  (`model` provenance, `body`, optional `tags`, optional `during_task`) and pass through the
  existing runtime add path so validation and defaults stay identical to the native tool.
- Invalid input (empty body, malformed fields, bad `during_task` reference per existing runtime
  behavior) must surface through `map_runtime_error` as 4xx carrying Orbit's own error text —
  never a silent drop or success rewrite.
- Response: the created friction JSON as projected by the existing get/list handlers.
- Handler tests alongside the existing friction API tests: create-success (fields persisted and
  echoed), invalid-input rejection (4xx with error text), and tags/during_task round-trip.

## Downstream

Unblocks the `ws_bridge` friction-create parity task (Bridge `orbit_friction_add`): after this
merges, Bridge adds the workspace-routed tool, forwards the body verbatim, updates its parity
snapshot, and validates live create + search/read.

### Acceptance Criteria

- POST /api/frictions accepts the native-MCP-compatible friction-add fields (model provenance, body, optional tags, optional during_task), persists via the existing runtime add path, and returns the created friction JSON
- Invalid input returns 4xx carrying Orbit's own error text with no silent drop or success rewrite
- Native MCP friction schema, semantics, and validation remain unchanged; HTTP reuses the shared runtime path
- orbit-dashboard handler tests cover create-success, invalid-input rejection, and tags/during_task round-trip
- The repository's required task-scoped gates pass (make ci-fast)

## Execution Summary

<details>
<summary>Click to expand</summary>

Added POST /api/frictions to orbit-dashboard, mirroring the native orbit.friction.add MCP schema.

Changes:
- crates/orbit-dashboard/src/api/frictions.rs: new CreateFrictionBody (optional model provenance, body, optional tags, optional during_task) and create_friction_action handler. The handler builds the tool input map and delegates to the existing run_friction_tool("orbit.friction.add", ...) shared runtime path, so validation, tag normalization, model-provenance defaulting (FRICTION_TOOL_MODEL when omitted), and the response projection (record_to_json: path/title + record fields) stay identical to the native tool. Malformed JSON is rejected with a structured 400; body/field validation errors surface through map_runtime_error as 4xx carrying Orbit's own error text. Added JsonRejection import.
- crates/orbit-dashboard/src/api/mod.rs: router now `.route("/frictions", get(list_frictions).post(create_friction_action))`.
- crates/orbit-dashboard/src/api/tests/frictions.rs: 4 new handler tests — create-success (fields persisted + echoed, round-tripped via GET), create requires localhost origin (CSRF middleware), empty-body rejection (400 with error text naming `body`), and tags/during_task round-trip (tags normalized/sorted).

Native MCP friction schema, semantics, and validation are unchanged; HTTP reuses the shared runtime add path exactly like the ORB-10253 task-relations precedent. No docs/ADR changes needed (analogous ORB-10253 touched only handler+tests).

Validation: cargo test -p orbit-dashboard --lib api::tests::frictions (9 passed), cargo clippy -p orbit-dashboard --all-targets (clean), make ci-fast (pass). Unblocks the ws_bridge orbit_friction_add parity task.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10260-6a5b0282`
- Behind base: 0
- Ahead of base: 1