### PR TITLE
Bind task registry records to logical workspace IDs

### DIFF
--- a/crates/orbit-cli/src/command/run/sweep.rs
+++ b/crates/orbit-cli/src/command/run/sweep.rs
@@ -9,10 +9,7 @@ use std::path::Path;
 use clap::Args;
 use orbit_common::types::{Workspace, WorkspaceCheckout, WorkspaceStatus};
 use orbit_core::workspace_registry;
-use orbit_core::{
-    JobRunState, OrbitError, OrbitRuntime, TaskStatus, build_task_status_index,
-    task_dependencies_ready,
-};
+use orbit_core::{JobRunState, OrbitError, OrbitRuntime, TaskStatus, task_dependencies_ready};
 use serde_json::{Value, json};
 
 use super::ship::ShipMode;
@@ -199,7 +196,7 @@ fn sweep_active_workspace(
     }
 
     let tasks = runtime.list_tasks()?;
-    let status_by_id = build_task_status_index(&tasks);
+    let status_by_id = runtime.task_status_index()?;
     let ready_backlog = tasks
         .iter()
         .filter(|task| {

--- a/crates/orbit-cli/src/command/task/list.rs
+++ b/crates/orbit-cli/src/command/task/list.rs
@@ -1,7 +1,7 @@
 use clap::{ArgAction, Args};
 use orbit_core::{
     ExternalRef, OrbitError, OrbitRuntime, TaskPriority, TaskStatus, TaskType,
-    build_task_status_index, task_dependencies_ready, task_selectors_contain_path,
+    task_dependencies_ready, task_selectors_contain_path,
 };
 use serde_json::Value;
 
@@ -83,7 +83,7 @@ impl Execute for TaskListArgs {
         let ready = self.ready;
 
         let tasks_matching_tags = runtime.list_tasks_by_tags(&tags)?;
-        let status_by_id = build_task_status_index(&runtime.list_tasks()?);
+        let status_by_id = runtime.task_status_index()?;
         let active_statuses = [TaskStatus::Backlog, TaskStatus::InProgress];
         let status_filter =
             default_task_list_status_filter(all, &status, job_run_id.as_deref(), &active_statuses);

--- a/crates/orbit-cli/src/command/task/output.rs
+++ b/crates/orbit-cli/src/command/task/output.rs
@@ -2,9 +2,7 @@ use std::collections::{BTreeMap, BTreeSet};
 
 use chrono::{DateTime, Utc};
 use orbit_common::types::{ArtifactManifestFileV2, TaskArtifact};
-use orbit_core::{
-    OrbitError, OrbitRuntime, TaskStatus, build_task_status_index, resolve_task_dependencies,
-};
+use orbit_core::{OrbitError, OrbitRuntime, TaskStatus, resolve_task_dependencies};
 use serde_json::{Value, json};
 
 pub(crate) fn task_to_signal_json(task: &orbit_core::Task) -> Value {
@@ -57,7 +55,7 @@ pub(crate) fn task_to_json_for_runtime(
     runtime: &OrbitRuntime,
     task: &orbit_core::Task,
 ) -> Result<Value, OrbitError> {
-    let status_by_id = build_task_status_index(&runtime.list_tasks()?);
+    let status_by_id = runtime.task_status_index()?;
     task_to_json_with_sidecars(runtime, task, &status_by_id)
 }
 

--- a/crates/orbit-cli/src/command/task/show.rs
+++ b/crates/orbit-cli/src/command/task/show.rs
@@ -1,5 +1,5 @@
 use clap::Args;
-use orbit_core::{OrbitError, OrbitRuntime, TaskRelatedDoc, build_task_status_index};
+use orbit_core::{OrbitError, OrbitRuntime, TaskRelatedDoc};
 use serde_json::Value;
 
 use crate::command::Execute;
@@ -31,7 +31,7 @@ pub struct TaskShowArgs {
 impl Execute for TaskShowArgs {
     fn execute(self, runtime: &OrbitRuntime) -> Result<(), OrbitError> {
         let task = runtime.get_task(&self.id)?;
-        let status_by_id = build_task_status_index(&runtime.list_tasks()?);
+        let status_by_id = runtime.task_status_index()?;
         let fields = normalize_task_show_fields(&self.fields)?;
 
         if !fields.is_empty() {

--- a/crates/orbit-common/src/types/task.rs
+++ b/crates/orbit-common/src/types/task.rs
@@ -872,18 +872,6 @@ pub fn validate_task_dependencies(
     current_task_id: Option<&str>,
     dependencies: &[OrbitId],
 ) -> Result<(), OrbitError> {
-    let task_ids = tasks
-        .iter()
-        .map(|task| task.id.clone())
-        .collect::<BTreeSet<_>>();
-    for dependency in dependencies {
-        if !task_ids.contains(dependency) {
-            return Err(OrbitError::InvalidInput(format!(
-                "task dependency '{dependency}' does not resolve in this workspace"
-            )));
-        }
-    }
-
     let Some(current_task_id) = current_task_id else {
         return Ok(());
     };

--- a/crates/orbit-core/src/command/activity.rs
+++ b/crates/orbit-core/src/command/activity.rs
@@ -274,9 +274,8 @@ mod tests {
                     // pipeline / job dispatch
                     "orbit.pipeline.invoke",
                     "orbit.pipeline.wait",
-                    // task lifecycle writes (dispositions are applied by the
-                    // deterministic step, never the agent)
-                    "orbit.task.update",
+                    // task lifecycle writes other than the activity's one
+                    // evidence-gated blocked -> done reconciliation
                     "orbit.task.start",
                     "orbit.task.approve",
                     "orbit.task.reject",
@@ -292,6 +291,7 @@ mod tests {
                 }
                 for allowed in [
                     "orbit.task.show",
+                    "orbit.task.update",
                     "orbit.friction.add",
                     "fs.read",
                     "fs.delete",

--- a/crates/orbit-core/src/command/task/query.rs
+++ b/crates/orbit-core/src/command/task/query.rs
@@ -1,3 +1,5 @@
+use std::collections::BTreeMap;
+
 use orbit_common::types::{
     ArtifactManifestFileV2, ExternalRef, NotFoundKind, OrbitError, ReviewThread, Task,
     TaskArtifact, TaskComment, TaskHistoryEntry, prune_missing_context_files,
@@ -63,6 +65,14 @@ impl OrbitRuntime {
 
     pub fn list_tasks(&self) -> Result<Vec<Task>, OrbitError> {
         self.stores().tasks().list()
+    }
+
+    /// Returns the coordination registry's global status projection for
+    /// dependency readiness while leaving task listing workspace-scoped.
+    pub fn task_status_index(
+        &self,
+    ) -> Result<BTreeMap<String, orbit_common::types::TaskStatus>, OrbitError> {
+        self.stores().tasks().status_index()
     }
 
     pub fn list_tasks_by_tags(&self, tags: &[String]) -> Result<Vec<Task>, OrbitError> {

--- a/crates/orbit-core/src/command/task/transitions.rs
+++ b/crates/orbit-core/src/command/task/transitions.rs
@@ -1,7 +1,7 @@
 use chrono::Utc;
 use orbit_common::types::{
     NotFoundKind, OrbitError, OrbitEvent, Task, TaskHistoryEntry, TaskRelationType, TaskStatus,
-    build_task_status_index, is_valid_friction_id, unmet_task_dependencies,
+    is_valid_friction_id, unmet_task_dependencies,
 };
 use orbit_store::friction_store::{resolve_friction_by_task, show_friction};
 
@@ -270,7 +270,7 @@ impl OrbitRuntime {
             crew_override.as_deref(),
             task.crew.as_deref(),
         )?;
-        let dependency_status_index = build_task_status_index(&self.list_tasks()?);
+        let dependency_status_index = self.task_status_index()?;
         let unmet_dependencies = unmet_task_dependencies(&task, &dependency_status_index);
         if in_progress_transition_requires_plan(task.status) {
             ensure_task_has_execution_plan(id, task.plan.as_str())?;

--- a/crates/orbit-core/src/runtime/orbit_tool_host/json.rs
+++ b/crates/orbit-core/src/runtime/orbit_tool_host/json.rs
@@ -2,7 +2,7 @@ use std::collections::BTreeMap;
 
 use orbit_common::types::{
     Learning, OrbitError, Task, TaskArtifact, TaskComment, TaskHistoryEntry, TaskStatus,
-    build_task_status_index, resolve_task_dependencies,
+    resolve_task_dependencies,
 };
 use serde_json::{Map, Value, json};
 
@@ -75,8 +75,7 @@ pub(super) fn task_to_json(task: &Task, status_by_id: &BTreeMap<String, TaskStat
 }
 
 pub(super) fn serialize_task(runtime: &OrbitRuntime, task: &Task) -> Result<Value, OrbitError> {
-    let tasks = runtime.list_tasks()?;
-    let status_by_id = build_task_status_index(&tasks);
+    let status_by_id = runtime.task_status_index()?;
     let mut value = task_to_json(task, &status_by_id);
     let object = value.as_object_mut().ok_or_else(|| {
         OrbitError::Execution("task JSON projection did not produce an object".to_string())
@@ -132,7 +131,7 @@ pub(super) fn task_fields_to_json(
     fields: &[String],
 ) -> Result<Value, OrbitError> {
     let status_by_id = if fields.iter().any(|field| field == "resolved_dependencies") {
-        Some(build_task_status_index(&runtime.list_tasks()?))
+        Some(runtime.task_status_index()?)
     } else {
         None
     };

--- a/crates/orbit-core/src/runtime/orbit_tool_host/task_tools.rs
+++ b/crates/orbit-core/src/runtime/orbit_tool_host/task_tools.rs
@@ -1,9 +1,9 @@
 use std::collections::BTreeSet;
 
 use orbit_common::types::{
-    OrbitError, TaskPriority, build_task_status_index, optional_csv_or_string_list_alias,
-    optional_raw_string, optional_string, optional_string_alias, optional_string_list_alias,
-    required_string, strip_retired_task_add_input_fields, task_dependencies_ready,
+    OrbitError, TaskPriority, optional_csv_or_string_list_alias, optional_raw_string,
+    optional_string, optional_string_alias, optional_string_list_alias, required_string,
+    strip_retired_task_add_input_fields, task_dependencies_ready,
 };
 use serde_json::{Value, json};
 
@@ -135,7 +135,7 @@ pub(super) fn list(runtime: &OrbitRuntime, input: Value) -> Result<Value, OrbitE
         None,
         None,
     )?;
-    let status_by_id = build_task_status_index(&runtime.list_tasks()?);
+    let status_by_id = runtime.task_status_index()?;
     let tasks = all_tasks
         .into_iter()
         .filter(|task| orbit_common::types::task_matches_tags(task, &tags))

--- a/crates/orbit-core/src/runtime/orbit_tool_host/tests/task_tools.rs
+++ b/crates/orbit-core/src/runtime/orbit_tool_host/tests/task_tools.rs
@@ -1123,7 +1123,7 @@ fn task_update_tool_clears_source_task_id_with_empty_string() {
 }
 
 #[test]
-fn task_update_tool_stores_unresolved_source_task_id() {
+fn task_update_tool_rejects_unresolved_source_task_id_atomically() {
     // ORB-00255 retired `source_task_id` from the `orbit.task.add` schema,
     // so an unresolved ID must travel via `orbit.task.update`.
     let (_root, runtime, _repo_root) = test_runtime();
@@ -1148,7 +1148,7 @@ fn task_update_tool_stores_unresolved_source_task_id() {
         Some(&Value::Null),
         "retired add-side source_task_id must be ignored"
     );
-    let output = runtime
+    let error = runtime
         .execute_tool_command(
             "orbit.task.update",
             json!({
@@ -1158,12 +1158,14 @@ fn task_update_tool_stores_unresolved_source_task_id() {
             Some("codex".to_string()),
             Some(orbit_common::test_fixtures::TEST_CODEX_MODEL.to_string()),
         )
-        .expect("update stores a loose source reference");
+        .expect_err("global task relation target must resolve");
 
-    assert_eq!(
-        output.get("source_task_id").and_then(Value::as_str),
-        Some(unresolved_from_update)
-    );
+    assert!(error.to_string().contains(unresolved_from_update));
+    assert!(error.to_string().contains("coordination registry"));
+    let unchanged = runtime
+        .get_task(update_target["id"].as_str().expect("task id"))
+        .expect("read unchanged task");
+    assert_eq!(unchanged.source_task_id(), None);
 }
 
 #[test]

--- a/crates/orbit-core/src/runtime/store_delegates.rs
+++ b/crates/orbit-core/src/runtime/store_delegates.rs
@@ -20,6 +20,7 @@ use orbit_store::{
     TaskReservationStoreBackend, TaskReviewStoreBackend, TaskReviewUpdateParams, TaskStoreBackend,
     ToolStoreBackend,
 };
+use std::collections::BTreeMap;
 
 use crate::context::OrbitStores;
 
@@ -223,6 +224,10 @@ impl TaskRecords<'_> {
 
     pub(crate) fn list(&self) -> Result<Vec<Task>, OrbitError> {
         self.store.list_tasks()
+    }
+
+    pub(crate) fn status_index(&self) -> Result<BTreeMap<String, TaskStatus>, OrbitError> {
+        self.store.task_status_index()
     }
 
     pub(crate) fn list_by_tags(&self, tags: &[String]) -> Result<Vec<Task>, OrbitError> {

--- a/crates/orbit-core/src/runtime/v2_host/backlog_exclusion.rs
+++ b/crates/orbit-core/src/runtime/v2_host/backlog_exclusion.rs
@@ -2,8 +2,7 @@ use std::collections::BTreeMap;
 use std::path::Path;
 
 use orbit_common::types::{
-    Task, TaskStatus, TaskType, build_task_status_index, prune_missing_context_files,
-    task_dependencies_ready,
+    Task, TaskStatus, TaskType, prune_missing_context_files, task_dependencies_ready,
 };
 use orbit_common::utility::path::workspace_relative_paths_overlap;
 use orbit_common::utility::selector::canonical_selector_in_workspace;
@@ -140,7 +139,12 @@ pub(super) fn list_backlog_tasks(
             .cloned()
             .map(|task| (task.id.clone(), task))
             .collect();
-        let status_by_id = build_task_status_index(&all_tasks);
+        let status_by_id = runtime.task_status_index().map_err(|err| {
+            DispatchError::DeterministicActionFailed {
+                action: action.to_string(),
+                message: format!("load global task status projection: {err}"),
+            }
+        })?;
         let workspace_root = runtime.paths().repo_root.as_path();
         let lock_holders = active_task_lock_holders(task_lookup.values(), workspace_root);
         let mut backlog: Vec<Task> = all_tasks

--- a/crates/orbit-core/src/runtime/v2_host/dispatch.rs
+++ b/crates/orbit-core/src/runtime/v2_host/dispatch.rs
@@ -1,9 +1,7 @@
 use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::time::{Duration, Instant};
 
-use orbit_common::types::{
-    OrbitError, Role, build_task_status_index, optional_string_list_alias, unmet_task_dependencies,
-};
+use orbit_common::types::{OrbitError, Role, optional_string_list_alias, unmet_task_dependencies};
 use orbit_engine::DispatchError;
 use orbit_engine::{StateExecutionContext, execute_deterministic_action};
 use orbit_tools::ToolContext;
@@ -352,7 +350,7 @@ fn unmet_dependency_ids_for_input(
     };
     let task_ids = parse_task_ids(&serde_json::json!({ "task_ids": raw_task_ids }))?;
     let tasks = runtime.stores().tasks().list()?;
-    let status_by_id = build_task_status_index(&tasks);
+    let status_by_id = runtime.task_status_index()?;
     let task_by_id = tasks
         .into_iter()
         .map(|task| (task.id.clone(), task))

--- a/crates/orbit-store/src/backend/contracts.rs
+++ b/crates/orbit-store/src/backend/contracts.rs
@@ -8,6 +8,7 @@ use orbit_common::types::{
 };
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
+use std::collections::BTreeMap;
 use std::path::PathBuf;
 
 use crate::sqlite::audit_event_store::{
@@ -345,6 +346,13 @@ pub struct JobRunQuery {
 pub trait TaskStoreBackend: Send + Sync {
     fn create_task(&self, params: TaskCreateParams) -> Result<Task, OrbitError>;
     fn list_tasks(&self) -> Result<Vec<Task>, OrbitError>;
+    fn task_status_index(&self) -> Result<BTreeMap<OrbitId, TaskStatus>, OrbitError> {
+        Ok(self
+            .list_tasks()?
+            .into_iter()
+            .map(|task| (task.id, task.status))
+            .collect())
+    }
     fn list_tasks_by_tags(&self, tags: &[String]) -> Result<Vec<Task>, OrbitError> {
         let required_tags = normalize_task_tags(tags.to_vec());
         let mut tasks = self.list_tasks()?;

--- a/crates/orbit-store/src/backend/factory/mod.rs
+++ b/crates/orbit-store/src/backend/factory/mod.rs
@@ -53,6 +53,23 @@ pub fn workspace_task_backends(
     }
 }
 
+/// Constructs coordination-only task backends for a logical workspace that
+/// has no checkout on this machine. Canonical bundles and registry indexes
+/// remain available; checkout-local projections are intentionally omitted.
+pub fn coordination_task_backends(
+    registry: TaskRegistryStore,
+    workspace_id: String,
+) -> WorkspaceTaskBackends {
+    let store = Arc::new(TaskV2Store::new_checkoutless(registry, workspace_id));
+    WorkspaceTaskBackends {
+        task: store.clone(),
+        document: store.clone(),
+        history: store.clone(),
+        review: store.clone(),
+        artifact: store,
+    }
+}
+
 pub fn workspace_job_run_store(
     store: Store,
     workspace_id: impl Into<String>,

--- a/crates/orbit-store/src/backend/factory/tests/factory.rs
+++ b/crates/orbit-store/src/backend/factory/tests/factory.rs
@@ -1,10 +1,43 @@
 // Migrated from backend/factory.rs per ORB-00231
-use orbit_common::types::{TaskPriority, TaskStatus, TaskType};
+use orbit_common::types::{
+    TaskPriority, TaskRelation, TaskRelationType, TaskStatus, TaskType, task_dependencies_ready,
+};
 use tempfile::TempDir;
 
 use super::super::*;
 use crate::backend::TaskCreateParams;
-use crate::sqlite::task_registry::{BindWorkspaceParams, TaskRegistryStore, task_registry_path};
+use crate::sqlite::task_registry::{
+    BindWorkspaceParams, RegisterWorkspaceParams, TaskRegistryStore, task_registry_path,
+};
+
+fn task_params(title: &str, status: TaskStatus) -> TaskCreateParams {
+    TaskCreateParams {
+        actor: "codex".to_string(),
+        parent_id: None,
+        title: title.to_string(),
+        description: "coordination task".to_string(),
+        acceptance_criteria: vec!["round trips".to_string()],
+        dependencies: Vec::new(),
+        relations: Vec::new(),
+        tags: Vec::new(),
+        plan: "1. Execute".to_string(),
+        execution_summary: String::new(),
+        context_files: Vec::new(),
+        workspace_path: None,
+        repo_root: None,
+        created_by: Some("codex".to_string()),
+        planned_by: Some("codex".to_string()),
+        implemented_by: None,
+        status,
+        priority: TaskPriority::Medium,
+        complexity: None,
+        task_type: TaskType::Feature,
+        external_refs: Vec::new(),
+        source_task_id: None,
+        crew: None,
+        comments: Vec::new(),
+    }
+}
 
 #[test]
 fn workspace_task_backends_exposes_create_get_and_list_trait_surface() {
@@ -73,6 +106,77 @@ fn workspace_task_backends_exposes_create_get_and_list_trait_surface() {
         "Trait-created v2 task"
     );
     assert_eq!(backends.task.list_tasks().expect("list tasks").len(), 1);
+}
+
+#[test]
+fn coordination_backends_create_and_schedule_across_checkoutless_workspaces() {
+    let temp = TempDir::new().expect("tempdir");
+    let registry =
+        TaskRegistryStore::open(&task_registry_path(temp.path())).expect("open registry");
+    for (workspace_id, slug) in [
+        ("logical-alpha-aaaaaa", "Logical Alpha"),
+        ("logical-beta-bbbbbb", "Logical Beta"),
+    ] {
+        registry
+            .register_workspace(RegisterWorkspaceParams {
+                workspace_id: workspace_id.to_string(),
+                slug: slug.to_string(),
+                repo_fingerprint: None,
+            })
+            .expect("register logical workspace");
+        assert!(
+            registry
+                .find_workspace_checkout(workspace_id)
+                .expect("find checkout")
+                .is_none()
+        );
+    }
+
+    let beta = coordination_task_backends(registry.clone(), "logical-beta-bbbbbb".into());
+    let target = beta
+        .task
+        .create_task(task_params("Completed remote target", TaskStatus::Done))
+        .expect("create target without checkout");
+    let alpha = coordination_task_backends(registry.clone(), "logical-alpha-aaaaaa".into());
+    let mut source_params = task_params("Ready cross-workspace source", TaskStatus::Backlog);
+    source_params.dependencies = vec![target.id.clone()];
+    source_params.relations.push(TaskRelation {
+        relation_type: TaskRelationType::RelatedTo,
+        target: target.id.clone(),
+    });
+    let source = alpha
+        .task
+        .create_task(source_params)
+        .expect("create cross-workspace source without checkout");
+
+    let statuses = alpha.task.task_status_index().expect("global statuses");
+    assert!(task_dependencies_ready(&source, &statuses));
+    assert_eq!(alpha.task.list_tasks().expect("alpha list").len(), 1);
+    assert_eq!(beta.task.list_tasks().expect("beta list").len(), 1);
+    assert_eq!(
+        alpha
+            .task
+            .get_task(&source.id)
+            .expect("query source")
+            .expect("source exists")
+            .dependencies(),
+        vec![target.id]
+    );
+
+    let allocator_before = registry.allocator_next_number().expect("allocator before");
+    let mut missing = task_params("Missing dependency", TaskStatus::Backlog);
+    missing.dependencies = vec!["ORB-09999".into()];
+    let error = alpha
+        .task
+        .create_task(missing)
+        .expect_err("missing global target must fail");
+    assert!(error.to_string().contains("ORB-09999"));
+    assert!(error.to_string().contains("logical-alpha-aaaaaa"));
+    assert_eq!(
+        registry.allocator_next_number().expect("allocator after"),
+        allocator_before
+    );
+    assert_eq!(alpha.task.list_tasks().expect("alpha list after").len(), 1);
 }
 
 #[test]

--- a/crates/orbit-store/src/backend/file_backends/mod.rs
+++ b/crates/orbit-store/src/backend/file_backends/mod.rs
@@ -1,3 +1,5 @@
+use std::collections::BTreeMap;
+
 use orbit_common::types::{
     Adr, AdrStatus, ArtifactManifestFileV2, ExecutorDef, ExternalRef, Learning, LearningStatus,
     OrbitError, PolicyDef, ReviewThread, Task, TaskArtifact, TaskComment, TaskHistoryEntry,
@@ -26,6 +28,10 @@ impl TaskStoreBackend for TaskV2Store {
 
     fn list_tasks(&self) -> Result<Vec<Task>, OrbitError> {
         self.list_tasks()
+    }
+
+    fn task_status_index(&self) -> Result<BTreeMap<String, TaskStatus>, OrbitError> {
+        self.task_status_index()
     }
 
     fn list_tasks_by_tags(&self, tags: &[String]) -> Result<Vec<Task>, OrbitError> {

--- a/crates/orbit-store/src/file/task_store/tests/v2_bundle.rs
+++ b/crates/orbit-store/src/file/task_store/tests/v2_bundle.rs
@@ -134,7 +134,14 @@ fn delete_bundle_removes_canonical_projection_and_registry_rows() {
 
     assert!(store.delete_bundle("ORB-00000").expect("delete bundle"));
     assert!(!bundle_dir.exists());
-    assert!(!store.workspace_orbit_dir.join("tasks/ORB-00000").exists());
+    assert!(
+        !store
+            .workspace_orbit_dir
+            .as_ref()
+            .expect("checkout fixture")
+            .join("tasks/ORB-00000")
+            .exists()
+    );
     assert_eq!(
         store
             .registry
@@ -163,7 +170,16 @@ fn delete_bundle_unregisters_stale_binding_when_canonical_dir_is_missing() {
     fs::remove_dir_all(&bundle_dir).expect("remove canonical bundle");
 
     assert!(store.delete_bundle("ORB-00000").expect("delete stale"));
-    assert!(fs::symlink_metadata(store.workspace_orbit_dir.join("tasks/ORB-00000")).is_err());
+    assert!(
+        fs::symlink_metadata(
+            store
+                .workspace_orbit_dir
+                .as_ref()
+                .expect("checkout fixture")
+                .join("tasks/ORB-00000")
+        )
+        .is_err()
+    );
     assert_eq!(
         store
             .registry
@@ -262,7 +278,11 @@ fn create_bundle_cleans_partial_directory_and_lock_on_validation_error() {
 fn create_bundle_treats_projection_error_as_degraded_success() {
     let temp = TempDir::new().expect("tempdir");
     let store = bundle_store(&temp);
-    let projection_dir = store.workspace_orbit_dir.join("tasks");
+    let projection_dir = store
+        .workspace_orbit_dir
+        .as_ref()
+        .expect("checkout fixture")
+        .join("tasks");
     fs::create_dir_all(&projection_dir).expect("create projection dir");
     fs::write(projection_dir.join("ORB-00000"), "not a symlink").expect("write blocker");
 

--- a/crates/orbit-store/src/file/task_store/v2/crud.rs
+++ b/crates/orbit-store/src/file/task_store/v2/crud.rs
@@ -13,9 +13,13 @@ impl TaskV2Store {
             ));
         }
         let relations = relations_from_create_params(&params)?;
+        self.registry
+            .validate_new_task_relation_targets(&self.workspace_id, &relations)?;
 
         let now = Utc::now();
         let id = self.registry.allocate_task_id(&self.workspace_id)?;
+        self.registry
+            .validate_task_relations(&self.workspace_id, &id, &relations)?;
         let comments = params
             .comments
             .iter()

--- a/crates/orbit-store/src/file/task_store/v2/index.rs
+++ b/crates/orbit-store/src/file/task_store/v2/index.rs
@@ -1,6 +1,12 @@
 use super::*;
 
 impl TaskV2Store {
+    pub(crate) fn task_status_index(
+        &self,
+    ) -> Result<std::collections::BTreeMap<String, TaskStatus>, OrbitError> {
+        self.registry.global_task_status_index()
+    }
+
     pub(super) fn indexed_tasks(
         &self,
         filter: TaskIndexFilter,

--- a/crates/orbit-store/src/file/task_store/v2/mod.rs
+++ b/crates/orbit-store/src/file/task_store/v2/mod.rs
@@ -82,4 +82,15 @@ impl TaskV2Store {
             workspace_id,
         }
     }
+
+    pub(crate) fn new_checkoutless(registry: TaskRegistryStore, workspace_id: String) -> Self {
+        Self {
+            bundle_store: TaskBundleStoreV2::new_checkoutless(
+                registry.clone(),
+                workspace_id.clone(),
+            ),
+            registry,
+            workspace_id,
+        }
+    }
 }

--- a/crates/orbit-store/src/file/task_store/v2/updates.rs
+++ b/crates/orbit-store/src/file/task_store/v2/updates.rs
@@ -16,6 +16,9 @@ impl TaskV2Store {
             let mut bundle = self.read_existing_bundle(id)?;
             let mut envelope_changed = false;
             let mut title_changed = false;
+            let relations_changed = fields.dependencies.is_some()
+                || fields.source_task_id.is_some()
+                || fields.relations.is_some();
 
             if let Some(value) = &fields.title {
                 if value.trim().is_empty() {
@@ -100,6 +103,14 @@ impl TaskV2Store {
             if let Some(value) = &fields.external_refs {
                 bundle.envelope.external_refs = value.clone();
                 envelope_changed = true;
+            }
+
+            if relations_changed {
+                self.registry.validate_task_relations(
+                    &self.workspace_id,
+                    id,
+                    &bundle.envelope.relations,
+                )?;
             }
 
             if let Some(value) = &fields.description {

--- a/crates/orbit-store/src/file/task_store/v2_bundle.rs
+++ b/crates/orbit-store/src/file/task_store/v2_bundle.rs
@@ -41,7 +41,7 @@ pub(crate) struct TaskBundleStoreV2 {
     // deliberately rather than keep nested anti-pattern).
     pub(crate) registry: TaskRegistryStore,
     pub(crate) workspace_id: String,
-    pub(crate) workspace_orbit_dir: PathBuf,
+    pub(crate) workspace_orbit_dir: Option<PathBuf>,
 }
 
 impl TaskBundleStoreV2 {
@@ -53,7 +53,15 @@ impl TaskBundleStoreV2 {
         Self {
             registry,
             workspace_id,
-            workspace_orbit_dir,
+            workspace_orbit_dir: Some(workspace_orbit_dir),
+        }
+    }
+
+    pub(crate) fn new_checkoutless(registry: TaskRegistryStore, workspace_id: String) -> Self {
+        Self {
+            registry,
+            workspace_id,
+            workspace_orbit_dir: None,
         }
     }
 
@@ -133,27 +141,34 @@ impl TaskBundleStoreV2 {
                     return Err(err);
                 }
             };
-        let projection = match self
-            .registry
-            .rebuild_projection(&self.workspace_orbit_dir, &self.workspace_id)
-        {
-            Ok(projection) => projection,
-            Err(err) => {
-                orbit_common::tracing::warn!(
-                    target: "orbit.store.task_bundle_v2",
-                    task_id,
-                    workspace_id = %self.workspace_id,
-                    error = %err,
-                    "task bundle created, but projection rebuild failed; continuing in degraded mode",
-                );
-                ProjectionRebuildResult {
-                    projected: 0,
-                    repaired: 0,
-                    degraded_reason: Some(format!(
-                        "projection rebuild failed after bundle creation: {err}"
-                    )),
+        let projection = match self.workspace_orbit_dir.as_deref() {
+            None => ProjectionRebuildResult {
+                projected: 0,
+                repaired: 0,
+                degraded_reason: None,
+            },
+            Some(workspace_orbit_dir) => match self
+                .registry
+                .rebuild_projection(workspace_orbit_dir, &self.workspace_id)
+            {
+                Ok(projection) => projection,
+                Err(err) => {
+                    orbit_common::tracing::warn!(
+                        target: "orbit.store.task_bundle_v2",
+                        task_id,
+                        workspace_id = %self.workspace_id,
+                        error = %err,
+                        "task bundle created, but projection rebuild failed; continuing in degraded mode",
+                    );
+                    ProjectionRebuildResult {
+                        projected: 0,
+                        repaired: 0,
+                        degraded_reason: Some(format!(
+                            "projection rebuild failed after bundle creation: {err}"
+                        )),
+                    }
                 }
-            }
+            },
         };
 
         Ok(TaskBundleCreateResult {
@@ -171,7 +186,9 @@ impl TaskBundleStoreV2 {
         orbit_common::types::validate_orb_task_id(task_id)?;
         let bundle_dir = self.bundle_path(task_id)?;
 
-        ensure_projection_entry_removable(&self.workspace_orbit_dir, task_id)?;
+        if let Some(workspace_orbit_dir) = self.workspace_orbit_dir.as_deref() {
+            ensure_projection_entry_removable(workspace_orbit_dir, task_id)?;
+        }
         let unregistered = self
             .registry
             .unregister_task_bundle(task_id, &self.workspace_id)?;
@@ -180,7 +197,10 @@ impl TaskBundleStoreV2 {
             Err(err) if err.kind() == std::io::ErrorKind::NotFound => false,
             Err(err) => return Err(OrbitError::Io(err.to_string())),
         };
-        let removed_projection = remove_projection_entry(&self.workspace_orbit_dir, task_id)?;
+        let removed_projection = match self.workspace_orbit_dir.as_deref() {
+            Some(workspace_orbit_dir) => remove_projection_entry(workspace_orbit_dir, task_id)?,
+            None => false,
+        };
         Ok(unregistered || removed_bundle || removed_projection)
     }
 

--- a/crates/orbit-store/src/lib.rs
+++ b/crates/orbit-store/src/lib.rs
@@ -129,11 +129,11 @@ pub use backend::{
     TaskReservationReleaseReason, TaskReservationReleaseResult, TaskReservationReserveParams,
     TaskReservationReserveResult, TaskReservationStoreBackend, TaskReviewStoreBackend,
     TaskReviewUpdateParams, TaskStoreBackend, ToolStoreBackend, V2AuditEnvelopeStoreBackend,
-    WorkspaceTaskBackends, audit_event_store_sqlite, global_executor_def_store,
-    global_policy_def_store, layered_policy_def_store, session_learning_state_store_sqlite,
-    task_reservation_store_sqlite, tool_store_sqlite, v2_audit_event_store_sqlite,
-    workspace_adr_backends, workspace_job_run_store, workspace_learning_backend,
-    workspace_policy_def_store, workspace_task_backends,
+    WorkspaceTaskBackends, audit_event_store_sqlite, coordination_task_backends,
+    global_executor_def_store, global_policy_def_store, layered_policy_def_store,
+    session_learning_state_store_sqlite, task_reservation_store_sqlite, tool_store_sqlite,
+    v2_audit_event_store_sqlite, workspace_adr_backends, workspace_job_run_store,
+    workspace_learning_backend, workspace_policy_def_store, workspace_task_backends,
 };
 pub use file_lock::{LockHolderInfo, read_lock_holder};
 pub use json_schema::{validate_instance_against_schema, validate_schema_document};

--- a/crates/orbit-store/src/sqlite/task_registry/mod.rs
+++ b/crates/orbit-store/src/sqlite/task_registry/mod.rs
@@ -20,13 +20,14 @@ mod workspace_config;
 mod workspace_id;
 
 const CONFIG_SCHEMA_VERSION: u32 = 1;
-const REGISTRY_SCHEMA_VERSION: u32 = 3;
+const REGISTRY_SCHEMA_VERSION: u32 = 4;
 
 pub use store::TaskRegistryStore;
 pub(crate) use store::parse_orb_task_number;
 pub use types::{
-    AllocatorSeedOutcome, BindWorkspaceParams, ProjectionRebuildResult, TaskBundleBinding,
-    TaskIndexFilter, WorkspaceBinding, WorkspaceConfig,
+    AllocatorSeedOutcome, BindWorkspaceParams, ProjectionRebuildResult, RegisterWorkspaceParams,
+    TaskBundleBinding, TaskIndexFilter, WorkspaceBinding, WorkspaceCheckoutBinding,
+    WorkspaceConfig,
 };
 pub use workspace_config::{
     assign_workspace_id, home_task_workspace_dir, read_workspace_config,

--- a/crates/orbit-store/src/sqlite/task_registry/queries.rs
+++ b/crates/orbit-store/src/sqlite/task_registry/queries.rs
@@ -5,19 +5,18 @@ use chrono::{DateTime, Utc};
 use orbit_common::types::{OrbitError, TaskEnvelopeV2, normalize_task_tags};
 use rusqlite::{Connection, OptionalExtension, params};
 
-use super::types::{TaskBundleBinding, WorkspaceBinding};
+use super::types::{TaskBundleBinding, WorkspaceBinding, WorkspaceCheckoutBinding};
 use super::util::{path_to_string, relation_type_name, terminal_month};
 
 pub(super) fn workspace_by_orbit_dir(
     conn: &Connection,
     orbit_dir: &Path,
-) -> Result<Option<WorkspaceBinding>, OrbitError> {
+) -> Result<Option<WorkspaceCheckoutBinding>, OrbitError> {
     conn.query_row(
-        "SELECT workspace_id, slug, repo_root, workspace_path, orbit_dir,
-            repo_fingerprint, created_at, updated_at
-         FROM workspace_bindings WHERE orbit_dir = ?1",
+        "SELECT workspace_id, repo_root, workspace_path, orbit_dir, created_at, updated_at
+         FROM workspace_checkout_bindings WHERE orbit_dir = ?1",
         [path_to_string(orbit_dir)],
-        decode_workspace_binding,
+        decode_workspace_checkout_binding,
     )
     .optional()
     .map_err(|e| OrbitError::Store(e.to_string()))
@@ -28,11 +27,24 @@ pub(super) fn workspace_by_id(
     workspace_id: &str,
 ) -> Result<Option<WorkspaceBinding>, OrbitError> {
     conn.query_row(
-        "SELECT workspace_id, slug, repo_root, workspace_path, orbit_dir,
-            repo_fingerprint, created_at, updated_at
+        "SELECT workspace_id, slug, repo_fingerprint, created_at, updated_at
          FROM workspace_bindings WHERE workspace_id = ?1",
         [workspace_id],
         decode_workspace_binding,
+    )
+    .optional()
+    .map_err(|e| OrbitError::Store(e.to_string()))
+}
+
+pub(super) fn workspace_checkout_by_id(
+    conn: &Connection,
+    workspace_id: &str,
+) -> Result<Option<WorkspaceCheckoutBinding>, OrbitError> {
+    conn.query_row(
+        "SELECT workspace_id, repo_root, workspace_path, orbit_dir, created_at, updated_at
+         FROM workspace_checkout_bindings WHERE workspace_id = ?1",
+        [workspace_id],
+        decode_workspace_checkout_binding,
     )
     .optional()
     .map_err(|e| OrbitError::Store(e.to_string()))
@@ -139,12 +151,22 @@ pub(super) fn decode_workspace_binding(
     Ok(WorkspaceBinding {
         workspace_id: row.get(0)?,
         slug: row.get(1)?,
-        repo_root: PathBuf::from(row.get::<_, String>(2)?),
-        workspace_path: PathBuf::from(row.get::<_, String>(3)?),
-        orbit_dir: PathBuf::from(row.get::<_, String>(4)?),
-        repo_fingerprint: row.get(5)?,
-        created_at: parse_timestamp(&row.get::<_, String>(6)?)?,
-        updated_at: parse_timestamp(&row.get::<_, String>(7)?)?,
+        repo_fingerprint: row.get(2)?,
+        created_at: parse_timestamp(&row.get::<_, String>(3)?)?,
+        updated_at: parse_timestamp(&row.get::<_, String>(4)?)?,
+    })
+}
+
+pub(super) fn decode_workspace_checkout_binding(
+    row: &rusqlite::Row<'_>,
+) -> rusqlite::Result<WorkspaceCheckoutBinding> {
+    Ok(WorkspaceCheckoutBinding {
+        workspace_id: row.get(0)?,
+        repo_root: PathBuf::from(row.get::<_, String>(1)?),
+        workspace_path: PathBuf::from(row.get::<_, String>(2)?),
+        orbit_dir: PathBuf::from(row.get::<_, String>(3)?),
+        created_at: parse_timestamp(&row.get::<_, String>(4)?)?,
+        updated_at: parse_timestamp(&row.get::<_, String>(5)?)?,
     })
 }
 

--- a/crates/orbit-store/src/sqlite/task_registry/schema.rs
+++ b/crates/orbit-store/src/sqlite/task_registry/schema.rs
@@ -5,6 +5,7 @@ use super::REGISTRY_SCHEMA_VERSION;
 use super::util::now_string;
 
 pub(super) fn apply_schema(conn: &Connection) -> Result<(), OrbitError> {
+    migrate_path_coupled_workspace_bindings(conn)?;
     conn.execute_batch(
         "
         CREATE TABLE IF NOT EXISTS allocator_state (
@@ -16,15 +17,22 @@ pub(super) fn apply_schema(conn: &Connection) -> Result<(), OrbitError> {
         CREATE TABLE IF NOT EXISTS workspace_bindings (
             workspace_id TEXT PRIMARY KEY,
             slug TEXT NOT NULL,
-            repo_root TEXT NOT NULL,
-            workspace_path TEXT NOT NULL,
-            orbit_dir TEXT NOT NULL UNIQUE,
             repo_fingerprint TEXT,
             created_at TEXT NOT NULL,
             updated_at TEXT NOT NULL
         );
-        CREATE INDEX IF NOT EXISTS idx_workspace_bindings_paths
-            ON workspace_bindings(repo_root, workspace_path, orbit_dir);
+
+        CREATE TABLE IF NOT EXISTS workspace_checkout_bindings (
+            workspace_id TEXT PRIMARY KEY,
+            repo_root TEXT NOT NULL,
+            workspace_path TEXT NOT NULL,
+            orbit_dir TEXT NOT NULL UNIQUE,
+            created_at TEXT NOT NULL,
+            updated_at TEXT NOT NULL,
+            FOREIGN KEY(workspace_id) REFERENCES workspace_bindings(workspace_id) ON DELETE CASCADE
+        );
+        CREATE INDEX IF NOT EXISTS idx_workspace_checkout_bindings_paths
+            ON workspace_checkout_bindings(repo_root, workspace_path, orbit_dir);
 
         CREATE TABLE IF NOT EXISTS task_bundle_bindings (
             task_id TEXT PRIMARY KEY,
@@ -116,6 +124,74 @@ pub(super) fn apply_schema(conn: &Connection) -> Result<(), OrbitError> {
     conn.pragma_update(None, "user_version", i64::from(REGISTRY_SCHEMA_VERSION))
         .map_err(|e| OrbitError::Store(format!("failed to set registry user_version: {e}")))?;
     Ok(())
+}
+
+/// Schema v4 splits stable coordination identity from machine-local checkout
+/// paths. Rebuild the parent table under the same final name so existing child
+/// foreign keys keep referencing `workspace_bindings` without rewriting any
+/// task, index, tag, relation, or allocator rows.
+fn migrate_path_coupled_workspace_bindings(conn: &Connection) -> Result<(), OrbitError> {
+    if !table_has_column(conn, "workspace_bindings", "repo_root")? {
+        return Ok(());
+    }
+
+    conn.execute_batch("PRAGMA foreign_keys = OFF; BEGIN IMMEDIATE;")
+        .map_err(|e| OrbitError::Store(format!("start task registry v4 migration: {e}")))?;
+    let migration = conn.execute_batch(
+        "
+        CREATE TABLE workspace_bindings_v4 (
+            workspace_id TEXT PRIMARY KEY,
+            slug TEXT NOT NULL,
+            repo_fingerprint TEXT,
+            created_at TEXT NOT NULL,
+            updated_at TEXT NOT NULL
+        );
+        INSERT INTO workspace_bindings_v4(
+            workspace_id, slug, repo_fingerprint, created_at, updated_at
+        )
+        SELECT workspace_id, slug, repo_fingerprint, created_at, updated_at
+        FROM workspace_bindings;
+
+        CREATE TABLE workspace_checkout_bindings (
+            workspace_id TEXT PRIMARY KEY,
+            repo_root TEXT NOT NULL,
+            workspace_path TEXT NOT NULL,
+            orbit_dir TEXT NOT NULL UNIQUE,
+            created_at TEXT NOT NULL,
+            updated_at TEXT NOT NULL,
+            FOREIGN KEY(workspace_id) REFERENCES workspace_bindings(workspace_id) ON DELETE CASCADE
+        );
+        INSERT INTO workspace_checkout_bindings(
+            workspace_id, repo_root, workspace_path, orbit_dir, created_at, updated_at
+        )
+        SELECT workspace_id, repo_root, workspace_path, orbit_dir, created_at, updated_at
+        FROM workspace_bindings;
+
+        DROP TABLE workspace_bindings;
+        ALTER TABLE workspace_bindings_v4 RENAME TO workspace_bindings;
+        ",
+    );
+    if let Err(error) = migration {
+        let _ = conn.execute_batch("ROLLBACK; PRAGMA foreign_keys = ON;");
+        return Err(OrbitError::Store(format!(
+            "migrate task registry workspace bindings to v4: {error}"
+        )));
+    }
+    conn.execute_batch("COMMIT; PRAGMA foreign_keys = ON;")
+        .map_err(|e| OrbitError::Store(format!("finish task registry v4 migration: {e}")))?;
+    Ok(())
+}
+
+fn table_has_column(conn: &Connection, table: &str, column: &str) -> Result<bool, OrbitError> {
+    let mut stmt = conn
+        .prepare(&format!("PRAGMA table_info({table})"))
+        .map_err(|e| OrbitError::Store(e.to_string()))?;
+    let columns = stmt
+        .query_map([], |row| row.get::<_, String>(1))
+        .map_err(|e| OrbitError::Store(e.to_string()))?
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|e| OrbitError::Store(e.to_string()))?;
+    Ok(columns.iter().any(|candidate| candidate == column))
 }
 
 pub(super) fn reject_unsupported_registry_schema(conn: &Connection) -> Result<(), OrbitError> {

--- a/crates/orbit-store/src/sqlite/task_registry/store.rs
+++ b/crates/orbit-store/src/sqlite/task_registry/store.rs
@@ -4,24 +4,28 @@ use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 
 use orbit_common::types::{
-    NotFoundKind, ORB_TASK_ID_MAX, OrbitError, TaskEnvelopeV2, TaskRelationType,
-    format_orb_task_id, normalize_task_tags, validate_orb_task_id,
+    NotFoundKind, ORB_TASK_ID_MAX, OrbitError, TaskEnvelopeV2, TaskRelation, TaskRelationEdge,
+    TaskRelationType, TaskStatus, format_orb_task_id, is_valid_orb_task_id, normalize_task_tags,
+    validate_orb_task_id, validate_task_relations_for_source,
 };
 use rusqlite::{Connection, OptionalExtension, TransactionBehavior, params, params_from_iter};
 
 use super::projection::create_projection_symlink;
 use super::queries::{
-    decode_task_bundle_binding, decode_workspace_binding, task_bundle_by_id,
-    task_ids_for_workspace, workspace_by_id, workspace_by_orbit_dir, write_task_index_rows,
+    decode_task_bundle_binding, decode_workspace_checkout_binding, task_bundle_by_id,
+    task_ids_for_workspace, workspace_by_id, workspace_by_orbit_dir, workspace_checkout_by_id,
+    write_task_index_rows,
 };
 use super::schema::{
     apply_schema, assert_registry_user_version, reject_unsupported_registry_schema,
 };
 use super::types::{
-    AllocatorSeedOutcome, BindWorkspaceParams, ProjectionRebuildResult, TaskBundleBinding,
-    TaskIndexFilter, WorkspaceBinding,
+    AllocatorSeedOutcome, BindWorkspaceParams, ProjectionRebuildResult, RegisterWorkspaceParams,
+    TaskBundleBinding, TaskIndexFilter, WorkspaceBinding, WorkspaceCheckoutBinding,
 };
-use super::util::{normalize_path, now_string, path_to_string, relation_type_name};
+use super::util::{
+    normalize_path, now_string, parse_relation_type_name, path_to_string, relation_type_name,
+};
 use super::workspace_id::{next_workspace_id_candidate, sanitize_slug, validate_workspace_id};
 
 #[derive(Clone)]
@@ -65,7 +69,7 @@ impl TaskRegistryStore {
     pub fn bind_workspace(
         &self,
         params: BindWorkspaceParams,
-    ) -> Result<WorkspaceBinding, OrbitError> {
+    ) -> Result<WorkspaceCheckoutBinding, OrbitError> {
         let repo_root = normalize_path(&params.repo_root);
         let workspace_path = normalize_path(&params.workspace_path);
         let orbit_dir = normalize_path(&params.orbit_dir);
@@ -103,32 +107,80 @@ impl TaskRegistryStore {
             Some(id) => id,
             None => next_workspace_id_candidate(&tx, &slug, &workspace_path)?,
         };
-        if workspace_by_id(&tx, &workspace_id)?.is_some() {
+        if let Some(existing) = workspace_checkout_by_id(&tx, &workspace_id)? {
             return Err(OrbitError::Store(format!(
-                "workspace id '{workspace_id}' is already bound to a different orbit dir"
+                "workspace id '{workspace_id}' already has a local checkout at '{}'",
+                existing.orbit_dir.display()
             )));
         }
 
         let now = now_string();
+        if workspace_by_id(&tx, &workspace_id)?.is_none() {
+            tx.execute(
+                "INSERT INTO workspace_bindings (
+                    workspace_id, slug, repo_fingerprint, created_at, updated_at
+                ) VALUES (?1, ?2, ?3, ?4, ?4)",
+                params![workspace_id, slug, params.repo_fingerprint, now],
+            )
+            .map_err(|e| OrbitError::Store(e.to_string()))?;
+        }
         tx.execute(
-            "INSERT INTO workspace_bindings (
-                workspace_id, slug, repo_root, workspace_path, orbit_dir, repo_fingerprint,
-                created_at, updated_at
-            ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?7)",
+            "INSERT INTO workspace_checkout_bindings (
+                workspace_id, repo_root, workspace_path, orbit_dir, created_at, updated_at
+            ) VALUES (?1, ?2, ?3, ?4, ?5, ?5)",
             params![
                 workspace_id,
-                slug,
                 path_to_string(&repo_root),
                 path_to_string(&workspace_path),
                 path_to_string(&orbit_dir),
-                params.repo_fingerprint,
                 now,
             ],
         )
         .map_err(|e| OrbitError::Store(e.to_string()))?;
 
-        let binding = workspace_by_id(&tx, &workspace_id)?
-            .ok_or_else(|| OrbitError::Store("failed to read inserted workspace binding".into()))?;
+        let binding = workspace_checkout_by_id(&tx, &workspace_id)?.ok_or_else(|| {
+            OrbitError::Store("failed to read inserted workspace checkout binding".into())
+        })?;
+        tx.commit().map_err(|e| OrbitError::Store(e.to_string()))?;
+        Ok(binding)
+    }
+
+    /// Register a logical workspace in the coordination registry without
+    /// inventing a machine-local checkout path.
+    pub fn register_workspace(
+        &self,
+        params: RegisterWorkspaceParams,
+    ) -> Result<WorkspaceBinding, OrbitError> {
+        let workspace_id = validate_workspace_id(&params.workspace_id)?;
+        let slug = sanitize_slug(&params.slug);
+        let mut conn = self
+            .conn
+            .lock()
+            .map_err(|e| OrbitError::Store(format!("mutex poisoned: {e}")))?;
+        let tx = conn
+            .transaction_with_behavior(TransactionBehavior::Immediate)
+            .map_err(|e| OrbitError::Store(e.to_string()))?;
+        if let Some(existing) = workspace_by_id(&tx, &workspace_id)? {
+            if existing.slug != slug || existing.repo_fingerprint != params.repo_fingerprint {
+                return Err(OrbitError::InvalidInput(format!(
+                    "logical workspace '{workspace_id}' is already registered with different metadata"
+                )));
+            }
+            tx.commit().map_err(|e| OrbitError::Store(e.to_string()))?;
+            return Ok(existing);
+        }
+
+        let now = now_string();
+        tx.execute(
+            "INSERT INTO workspace_bindings(
+                workspace_id, slug, repo_fingerprint, created_at, updated_at
+             ) VALUES (?1, ?2, ?3, ?4, ?4)",
+            params![workspace_id, slug, params.repo_fingerprint, now],
+        )
+        .map_err(|e| OrbitError::Store(e.to_string()))?;
+        let binding = workspace_by_id(&tx, &workspace_id)?.ok_or_else(|| {
+            OrbitError::Store("failed to read inserted logical workspace binding".into())
+        })?;
         tx.commit().map_err(|e| OrbitError::Store(e.to_string()))?;
         Ok(binding)
     }
@@ -322,6 +374,15 @@ impl TaskRegistryStore {
             )));
         }
 
+        validate_relations_in_registry(
+            &tx,
+            &workspace_id,
+            &envelope.id,
+            &envelope.relations,
+            std::slice::from_ref(&envelope.id),
+            &[],
+        )?;
+
         tx.execute(
             "DELETE FROM task_bundle_tags WHERE task_id = ?1",
             [&envelope.id],
@@ -365,6 +426,25 @@ impl TaskRegistryStore {
                 "task index rebuild for workspace '{}' expected registered ids {:?}, got {:?}",
                 workspace_id, registered, requested
             )));
+        }
+
+        let replacement_edges = envelopes
+            .iter()
+            .flat_map(|envelope| task_relation_edges(envelope))
+            .collect::<Vec<_>>();
+        let replacement_sources = envelopes
+            .iter()
+            .map(|envelope| envelope.id.clone())
+            .collect::<Vec<_>>();
+        for envelope in envelopes {
+            validate_relations_in_registry(
+                &tx,
+                &workspace_id,
+                &envelope.id,
+                &envelope.relations,
+                &replacement_sources,
+                &replacement_edges,
+            )?;
         }
 
         tx.execute(
@@ -431,6 +511,75 @@ impl TaskRegistryStore {
             )
             .map_err(|e| OrbitError::Store(e.to_string()))?;
         usize::try_from(count).map_err(|e| OrbitError::Store(e.to_string()))
+    }
+
+    /// Status projection for every task in the coordination registry. Task
+    /// lists remain workspace-scoped; dependency readiness is global because
+    /// ORB task IDs are globally unique.
+    pub fn global_task_status_index(&self) -> Result<BTreeMap<String, TaskStatus>, OrbitError> {
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| OrbitError::Store(format!("mutex poisoned: {e}")))?;
+        let mut stmt = conn
+            .prepare("SELECT task_id, status FROM task_bundle_index ORDER BY task_id ASC")
+            .map_err(|e| OrbitError::Store(e.to_string()))?;
+        let rows = stmt
+            .query_map([], |row| {
+                Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+            })
+            .map_err(|e| OrbitError::Store(e.to_string()))?;
+        let mut statuses = BTreeMap::new();
+        for row in rows {
+            let (task_id, raw_status) = row.map_err(|e| OrbitError::Store(e.to_string()))?;
+            let status = raw_status.parse::<TaskStatus>().map_err(|e| {
+                OrbitError::Store(format!(
+                    "invalid indexed status '{raw_status}' for task '{task_id}': {e}"
+                ))
+            })?;
+            statuses.insert(task_id, status);
+        }
+        Ok(statuses)
+    }
+
+    /// Validate task relations against every workspace in the coordination
+    /// registry without mutating allocator, bundle, or index state.
+    pub fn validate_task_relations(
+        &self,
+        workspace_id: &str,
+        source_task_id: &str,
+        relations: &[TaskRelation],
+    ) -> Result<(), OrbitError> {
+        let workspace_id = validate_workspace_id(workspace_id)?;
+        validate_orb_task_id(source_task_id)?;
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| OrbitError::Store(format!("mutex poisoned: {e}")))?;
+        validate_relations_in_registry(
+            &conn,
+            &workspace_id,
+            source_task_id,
+            relations,
+            &[source_task_id.to_string()],
+            &[],
+        )
+    }
+
+    /// Preflight relation targets for a task whose globally allocated source ID
+    /// does not exist yet. This runs before allocation so a missing target
+    /// cannot consume an ID or write a partial bundle.
+    pub fn validate_new_task_relation_targets(
+        &self,
+        workspace_id: &str,
+        relations: &[TaskRelation],
+    ) -> Result<(), OrbitError> {
+        let workspace_id = validate_workspace_id(workspace_id)?;
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| OrbitError::Store(format!("mutex poisoned: {e}")))?;
+        validate_relation_targets_exist(&conn, &workspace_id, None, relations)
     }
 
     pub fn indexed_task_ids_filtered(
@@ -569,7 +718,7 @@ impl TaskRegistryStore {
         repo_root: &Path,
         workspace_path: &Path,
         orbit_dir: &Path,
-    ) -> Result<Vec<WorkspaceBinding>, OrbitError> {
+    ) -> Result<Vec<WorkspaceCheckoutBinding>, OrbitError> {
         let repo_root = normalize_path(repo_root);
         let workspace_path = normalize_path(workspace_path);
         let orbit_dir = normalize_path(orbit_dir);
@@ -579,9 +728,8 @@ impl TaskRegistryStore {
             .map_err(|e| OrbitError::Store(format!("mutex poisoned: {e}")))?;
         let mut stmt = conn
             .prepare(
-                "SELECT workspace_id, slug, repo_root, workspace_path, orbit_dir,
-                    repo_fingerprint, created_at, updated_at
-                 FROM workspace_bindings
+                "SELECT workspace_id, repo_root, workspace_path, orbit_dir, created_at, updated_at
+                 FROM workspace_checkout_bindings
                  WHERE repo_root = ?1 OR workspace_path = ?2 OR orbit_dir = ?3
                  ORDER BY updated_at DESC, workspace_id ASC",
             )
@@ -593,7 +741,7 @@ impl TaskRegistryStore {
                     path_to_string(&workspace_path),
                     path_to_string(&orbit_dir),
                 ],
-                decode_workspace_binding,
+                decode_workspace_checkout_binding,
             )
             .map_err(|e| OrbitError::Store(e.to_string()))?;
         rows.collect::<Result<Vec<_>, _>>()
@@ -606,6 +754,15 @@ impl TaskRegistryStore {
         workspace_id: &str,
     ) -> Result<ProjectionRebuildResult, OrbitError> {
         let workspace_id = validate_workspace_id(workspace_id)?;
+        let checkout = self.require_workspace_checkout(&workspace_id)?;
+        if normalize_path(workspace_orbit_dir) != normalize_path(&checkout.orbit_dir) {
+            return Err(OrbitError::InvalidInput(format!(
+                "workspace '{}' checkout is bound to '{}', not '{}'",
+                workspace_id,
+                checkout.orbit_dir.display(),
+                workspace_orbit_dir.display()
+            )));
+        }
         let projection_dir = workspace_orbit_dir.join("tasks");
         fs::create_dir_all(&projection_dir).map_err(|e| OrbitError::Io(e.to_string()))?;
 
@@ -658,7 +815,7 @@ impl TaskRegistryStore {
         &self.workspaces_dir
     }
 
-    /// Look up a workspace binding by id. Public wrapper over the internal query
+    /// Look up a logical workspace by id. Public wrapper over the internal query
     /// so migration tooling can resolve a target workspace without opening the
     /// SQLite connection directly.
     pub fn find_workspace_binding(
@@ -671,6 +828,32 @@ impl TaskRegistryStore {
             .lock()
             .map_err(|e| OrbitError::Store(format!("mutex poisoned: {e}")))?;
         workspace_by_id(&conn, &workspace_id)
+    }
+
+    /// Look up the machine-local checkout for a logical workspace, if this
+    /// machine has one.
+    pub fn find_workspace_checkout(
+        &self,
+        workspace_id: &str,
+    ) -> Result<Option<WorkspaceCheckoutBinding>, OrbitError> {
+        let workspace_id = validate_workspace_id(workspace_id)?;
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| OrbitError::Store(format!("mutex poisoned: {e}")))?;
+        workspace_checkout_by_id(&conn, &workspace_id)
+    }
+
+    /// Resolve a checkout before a task operation touches checkout-local files.
+    pub fn require_workspace_checkout(
+        &self,
+        workspace_id: &str,
+    ) -> Result<WorkspaceCheckoutBinding, OrbitError> {
+        self.find_workspace_checkout(workspace_id)?.ok_or_else(|| {
+            OrbitError::InvalidInput(format!(
+                "workspace '{workspace_id}' has no local checkout binding; link or initialize a checkout before running this file operation"
+            ))
+        })
     }
 
     /// Look up a task-bundle binding by task id. Task ids are a global primary
@@ -793,6 +976,93 @@ fn set_allocator_next_number(conn: &Connection, value: u32) -> Result<(), OrbitE
     )
     .map_err(|e| OrbitError::Store(e.to_string()))?;
     Ok(())
+}
+
+fn validate_relations_in_registry(
+    conn: &Connection,
+    source_workspace_id: &str,
+    source_task_id: &str,
+    relations: &[TaskRelation],
+    replaced_sources: &[String],
+    replacement_edges: &[TaskRelationEdge],
+) -> Result<(), OrbitError> {
+    validate_relation_targets_exist(conn, source_workspace_id, Some(source_task_id), relations)?;
+
+    let replaced_sources = replaced_sources.iter().collect::<BTreeSet<_>>();
+    let mut stmt = conn
+        .prepare(
+            "SELECT source_task_id, relation_type, target_task_id
+             FROM task_bundle_relations
+             ORDER BY source_task_id, relation_type, target_task_id",
+        )
+        .map_err(|e| OrbitError::Store(e.to_string()))?;
+    let rows = stmt
+        .query_map([], |row| {
+            Ok((
+                row.get::<_, String>(0)?,
+                row.get::<_, String>(1)?,
+                row.get::<_, String>(2)?,
+            ))
+        })
+        .map_err(|e| OrbitError::Store(e.to_string()))?;
+    let mut existing_edges = Vec::new();
+    for row in rows {
+        let (source, relation_type, target) = row.map_err(|e| OrbitError::Store(e.to_string()))?;
+        if replaced_sources.contains(&source) || !is_valid_orb_task_id(&target) {
+            continue;
+        }
+        existing_edges.push(TaskRelationEdge {
+            source,
+            relation_type: parse_relation_type_name(&relation_type).map_err(OrbitError::Store)?,
+            target,
+        });
+    }
+    existing_edges.extend(
+        replacement_edges
+            .iter()
+            .filter(|edge| edge.source != source_task_id)
+            .cloned(),
+    );
+    validate_task_relations_for_source(source_task_id, relations, &existing_edges)
+}
+
+fn validate_relation_targets_exist(
+    conn: &Connection,
+    source_workspace_id: &str,
+    source_task_id: Option<&str>,
+    relations: &[TaskRelation],
+) -> Result<(), OrbitError> {
+    if workspace_by_id(conn, source_workspace_id)?.is_none() {
+        return Err(OrbitError::not_found(
+            NotFoundKind::Workspace,
+            source_workspace_id.to_string(),
+        ));
+    }
+    for relation in relations {
+        if is_valid_orb_task_id(&relation.target)
+            && source_task_id != Some(relation.target.as_str())
+            && task_bundle_by_id(conn, &relation.target)?.is_none()
+        {
+            return Err(OrbitError::InvalidInput(format!(
+                "task relation target '{}' from workspace '{}' does not resolve in the coordination registry",
+                relation.target, source_workspace_id
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn task_relation_edges(envelope: &TaskEnvelopeV2) -> Vec<TaskRelationEdge> {
+    envelope
+        .relations
+        .iter()
+        .filter(|relation| is_valid_orb_task_id(&relation.target))
+        .map(|relation| TaskRelationEdge {
+            source: envelope.id.clone(),
+            relation_type: relation.relation_type,
+            target: relation.target.clone(),
+        })
+        .collect()
 }
 
 /// Parse the numeric suffix of a canonical `ORB-00000` task id.

--- a/crates/orbit-store/src/sqlite/task_registry/tests/mod.rs
+++ b/crates/orbit-store/src/sqlite/task_registry/tests/mod.rs
@@ -15,9 +15,10 @@ use super::REGISTRY_SCHEMA_VERSION;
 use super::schema::registry_user_version;
 use super::util::{normalize_path, now_string};
 use super::{
-    BindWorkspaceParams, ProjectionRebuildResult, TaskIndexFilter, TaskRegistryStore,
-    WorkspaceBinding, WorkspaceConfig, read_workspace_config, read_workspace_config_optional,
-    task_registry_path, workspace_config_path, workspace_id_for_orbit_dir, write_workspace_config,
+    BindWorkspaceParams, ProjectionRebuildResult, RegisterWorkspaceParams, TaskIndexFilter,
+    TaskRegistryStore, WorkspaceCheckoutBinding, WorkspaceConfig, read_workspace_config,
+    read_workspace_config_optional, task_registry_path, workspace_config_path,
+    workspace_id_for_orbit_dir, write_workspace_config,
 };
 
 fn registry_path(temp: &TempDir) -> PathBuf {
@@ -28,7 +29,7 @@ fn store(temp: &TempDir) -> TaskRegistryStore {
     TaskRegistryStore::open(&registry_path(temp)).expect("open registry")
 }
 
-fn bind(store: &TaskRegistryStore, root: &Path) -> WorkspaceBinding {
+fn bind(store: &TaskRegistryStore, root: &Path) -> WorkspaceCheckoutBinding {
     let orbit_dir = root.join(".orbit");
     fs::create_dir_all(&orbit_dir).expect("create orbit dir");
     store
@@ -45,7 +46,7 @@ fn bind(store: &TaskRegistryStore, root: &Path) -> WorkspaceBinding {
 
 fn create_canonical_bundle(
     store: &TaskRegistryStore,
-    workspace: &WorkspaceBinding,
+    workspace: &WorkspaceCheckoutBinding,
     task_id: &str,
 ) -> PathBuf {
     let bundle_dir = store
@@ -196,6 +197,188 @@ fn open_migrates_existing_task_index_columns_before_creating_indexes() {
 }
 
 #[test]
+fn open_migrates_path_coupled_registry_once_without_changing_coordination_state() {
+    let temp = TempDir::new().expect("tempdir");
+    let path = registry_path(&temp);
+    fs::create_dir_all(path.parent().expect("registry parent")).expect("create parent");
+    let repo_root = temp.path().join("legacy-repo");
+    let orbit_dir = repo_root.join(".orbit");
+    let canonical_path = temp
+        .path()
+        .join("tasks/workspaces/legacy-workspace-aaaaaa/ORB-00041");
+    fs::create_dir_all(&canonical_path).expect("create canonical task payload");
+    fs::write(canonical_path.join("payload.sentinel"), "preserve-me")
+        .expect("write payload sentinel");
+    let timestamp = "2026-07-17T00:00:00+00:00";
+
+    let conn = Connection::open(&path).expect("open legacy sqlite");
+    conn.execute_batch(
+        "
+        CREATE TABLE allocator_state (
+            authority TEXT PRIMARY KEY,
+            next_number INTEGER NOT NULL,
+            updated_at TEXT NOT NULL
+        );
+        CREATE TABLE workspace_bindings (
+            workspace_id TEXT PRIMARY KEY,
+            slug TEXT NOT NULL,
+            repo_root TEXT NOT NULL,
+            workspace_path TEXT NOT NULL,
+            orbit_dir TEXT NOT NULL UNIQUE,
+            repo_fingerprint TEXT,
+            created_at TEXT NOT NULL,
+            updated_at TEXT NOT NULL
+        );
+        CREATE TABLE task_bundle_bindings (
+            task_id TEXT PRIMARY KEY,
+            workspace_id TEXT NOT NULL,
+            canonical_path TEXT NOT NULL,
+            created_at TEXT NOT NULL,
+            updated_at TEXT NOT NULL
+        );
+        CREATE TABLE task_bundle_index (
+            task_id TEXT PRIMARY KEY,
+            workspace_id TEXT NOT NULL,
+            status TEXT NOT NULL,
+            priority TEXT NOT NULL,
+            job_run_id TEXT,
+            created_at TEXT NOT NULL,
+            updated_at TEXT NOT NULL,
+            terminal_month TEXT
+        );
+        CREATE TABLE task_bundle_tags (
+            task_id TEXT NOT NULL,
+            workspace_id TEXT NOT NULL,
+            tag TEXT NOT NULL,
+            PRIMARY KEY(task_id, tag)
+        );
+        CREATE TABLE task_bundle_relations (
+            source_task_id TEXT NOT NULL,
+            workspace_id TEXT NOT NULL,
+            relation_type TEXT NOT NULL,
+            target_task_id TEXT NOT NULL,
+            PRIMARY KEY(source_task_id, relation_type, target_task_id)
+        );
+        PRAGMA user_version = 3;
+        ",
+    )
+    .expect("create legacy schema");
+    conn.execute(
+        "INSERT INTO allocator_state VALUES ('local', 42, ?1)",
+        [timestamp],
+    )
+    .expect("seed allocator");
+    conn.execute(
+        "INSERT INTO workspace_bindings VALUES (?1, ?2, ?3, ?3, ?4, ?5, ?6, ?6)",
+        params![
+            "legacy-workspace-aaaaaa",
+            "legacy-workspace",
+            repo_root.to_string_lossy(),
+            orbit_dir.to_string_lossy(),
+            "legacy-fingerprint",
+            timestamp,
+        ],
+    )
+    .expect("seed workspace");
+    conn.execute(
+        "INSERT INTO task_bundle_bindings VALUES (?1, ?2, ?3, ?4, ?4)",
+        params![
+            "ORB-00041",
+            "legacy-workspace-aaaaaa",
+            canonical_path.to_string_lossy(),
+            timestamp,
+        ],
+    )
+    .expect("seed task binding");
+    conn.execute(
+        "INSERT INTO task_bundle_index VALUES (?1, ?2, 'done', 'high', NULL, ?3, ?3, '2026-07')",
+        params!["ORB-00041", "legacy-workspace-aaaaaa", timestamp],
+    )
+    .expect("seed task index");
+    conn.execute(
+        "INSERT INTO task_bundle_tags VALUES (?1, ?2, 'migration')",
+        params!["ORB-00041", "legacy-workspace-aaaaaa"],
+    )
+    .expect("seed tag");
+    conn.execute(
+        "INSERT INTO task_bundle_relations VALUES (?1, ?2, 'resolves', 'F2026-07-001')",
+        params!["ORB-00041", "legacy-workspace-aaaaaa"],
+    )
+    .expect("seed relation");
+    drop(conn);
+
+    let migrated = TaskRegistryStore::open(&path).expect("migrate registry");
+    let workspace = migrated
+        .find_workspace_binding("legacy-workspace-aaaaaa")
+        .expect("find logical workspace")
+        .expect("logical workspace exists");
+    let checkout = migrated
+        .find_workspace_checkout("legacy-workspace-aaaaaa")
+        .expect("find checkout")
+        .expect("checkout exists");
+    let tasks = migrated
+        .tasks_for_workspace("legacy-workspace-aaaaaa")
+        .expect("task bindings");
+    let statuses = migrated
+        .global_task_status_index()
+        .expect("status projection");
+    assert_eq!(workspace.slug, "legacy-workspace");
+    assert_eq!(
+        workspace.repo_fingerprint.as_deref(),
+        Some("legacy-fingerprint")
+    );
+    assert_eq!(checkout.repo_root, normalize_path(&repo_root));
+    assert_eq!(checkout.orbit_dir, normalize_path(&orbit_dir));
+    assert_eq!(tasks[0].task_id, "ORB-00041");
+    assert_eq!(tasks[0].canonical_path, normalize_path(&canonical_path));
+    assert_eq!(statuses.get("ORB-00041"), Some(&TaskStatus::Done));
+    assert_eq!(migrated.allocator_next_number().expect("allocator"), 42);
+    assert_eq!(
+        fs::read_to_string(canonical_path.join("payload.sentinel")).expect("read payload"),
+        "preserve-me"
+    );
+    drop(migrated);
+
+    let conn = Connection::open(&path).expect("inspect migrated sqlite");
+    let logical_columns = table_columns(&conn, "workspace_bindings");
+    assert!(!logical_columns.iter().any(|column| column == "repo_root"));
+    assert!(
+        !logical_columns
+            .iter()
+            .any(|column| column == "workspace_path")
+    );
+    assert!(!logical_columns.iter().any(|column| column == "orbit_dir"));
+    drop(conn);
+
+    let reopened = TaskRegistryStore::open(&path).expect("reopen migrated registry");
+    assert_eq!(
+        reopened
+            .find_workspace_binding("legacy-workspace-aaaaaa")
+            .expect("find logical workspace"),
+        Some(workspace)
+    );
+    assert_eq!(
+        reopened
+            .find_workspace_checkout("legacy-workspace-aaaaaa")
+            .expect("find checkout"),
+        Some(checkout)
+    );
+    assert_eq!(
+        reopened
+            .tasks_for_workspace("legacy-workspace-aaaaaa")
+            .expect("task bindings"),
+        tasks
+    );
+    assert_eq!(
+        reopened
+            .global_task_status_index()
+            .expect("status projection"),
+        statuses
+    );
+    assert_eq!(reopened.allocator_next_number().expect("allocator"), 42);
+}
+
+#[test]
 fn open_rejects_newer_registry_schema_version() {
     let temp = TempDir::new().expect("tempdir");
     let path = registry_path(&temp);
@@ -245,6 +428,176 @@ fn allocator_is_global_across_workspaces() {
 }
 
 #[test]
+fn checkoutless_workspaces_coordinate_cross_workspace_relations_without_paths() {
+    let temp = TempDir::new().expect("tempdir");
+    let store = store(&temp);
+    let first = store
+        .register_workspace(RegisterWorkspaceParams {
+            workspace_id: "logical-first-aaaaaa".into(),
+            slug: "Logical First".into(),
+            repo_fingerprint: Some("first-fingerprint".into()),
+        })
+        .expect("register first logical workspace");
+    let second = store
+        .register_workspace(RegisterWorkspaceParams {
+            workspace_id: "logical-second-bbbbbb".into(),
+            slug: "Logical Second".into(),
+            repo_fingerprint: None,
+        })
+        .expect("register second logical workspace");
+
+    assert!(
+        store
+            .find_workspace_checkout(&first.workspace_id)
+            .expect("find first checkout")
+            .is_none()
+    );
+    assert!(
+        store
+            .find_workspace_checkout(&second.workspace_id)
+            .expect("find second checkout")
+            .is_none()
+    );
+
+    let target_id = store
+        .allocate_task_id(&second.workspace_id)
+        .expect("allocate target");
+    let source_id = store
+        .allocate_task_id(&first.workspace_id)
+        .expect("allocate source");
+    assert_eq!(
+        (target_id.as_str(), source_id.as_str()),
+        ("ORB-00000", "ORB-00001")
+    );
+
+    for (workspace_id, task_id) in [
+        (second.workspace_id.as_str(), target_id.as_str()),
+        (first.workspace_id.as_str(), source_id.as_str()),
+    ] {
+        let path = store
+            .canonical_task_bundle_path(workspace_id, task_id)
+            .expect("canonical coordination path");
+        fs::create_dir_all(&path).expect("create canonical bundle");
+        store
+            .register_task_bundle(task_id, workspace_id, &path)
+            .expect("register canonical bundle");
+    }
+    store
+        .replace_task_index(
+            &second.workspace_id,
+            &envelope(&target_id, TaskStatus::Done, Vec::new(), Vec::new()),
+        )
+        .expect("index completed target");
+    store
+        .replace_task_index(
+            &first.workspace_id,
+            &envelope(
+                &source_id,
+                TaskStatus::Backlog,
+                Vec::new(),
+                vec![
+                    TaskRelation {
+                        relation_type: TaskRelationType::BlockedBy,
+                        target: target_id.clone(),
+                    },
+                    TaskRelation {
+                        relation_type: TaskRelationType::RelatedTo,
+                        target: target_id.clone(),
+                    },
+                ],
+            ),
+        )
+        .expect("index cross-workspace relations");
+
+    assert_eq!(
+        store
+            .global_task_status_index()
+            .expect("global statuses")
+            .get(&target_id),
+        Some(&TaskStatus::Done)
+    );
+    assert_eq!(
+        store
+            .indexed_relation_targets(&first.workspace_id, &source_id, TaskRelationType::BlockedBy,)
+            .expect("cross-workspace dependency"),
+        vec![target_id.clone()]
+    );
+    assert_eq!(
+        store
+            .indexed_task_count_for_workspace(&first.workspace_id)
+            .expect("first count"),
+        1
+    );
+    assert_eq!(
+        store
+            .indexed_task_count_for_workspace(&second.workspace_id)
+            .expect("second count"),
+        1
+    );
+
+    let fake_checkout = temp.path().join("must-not-be-created").join(".orbit");
+    let error = store
+        .rebuild_projection(&fake_checkout, &first.workspace_id)
+        .expect_err("checkout-local projection requires a binding");
+    assert!(error.to_string().contains(&first.workspace_id));
+    assert!(error.to_string().contains("no local checkout binding"));
+    assert!(
+        !fake_checkout.exists(),
+        "preflight must happen before mutation"
+    );
+
+    let before_allocator = store.allocator_next_number().expect("allocator before");
+    let missing_target = "ORB-09999";
+    let error = store
+        .validate_new_task_relation_targets(
+            &first.workspace_id,
+            &[TaskRelation {
+                relation_type: TaskRelationType::BlockedBy,
+                target: missing_target.into(),
+            }],
+        )
+        .expect_err("missing global target");
+    assert!(error.to_string().contains(missing_target));
+    assert!(error.to_string().contains(&first.workspace_id));
+    assert_eq!(
+        store.allocator_next_number().expect("allocator after"),
+        before_allocator,
+        "missing target preflight must not consume an ID"
+    );
+
+    let error = store
+        .replace_task_index(
+            &first.workspace_id,
+            &envelope(
+                &source_id,
+                TaskStatus::Review,
+                Vec::new(),
+                vec![TaskRelation {
+                    relation_type: TaskRelationType::RelatedTo,
+                    target: missing_target.into(),
+                }],
+            ),
+        )
+        .expect_err("missing relation target");
+    assert!(error.to_string().contains(missing_target));
+    assert!(error.to_string().contains(&first.workspace_id));
+    assert_eq!(
+        store
+            .global_task_status_index()
+            .expect("status after rejected update")
+            .get(&source_id),
+        Some(&TaskStatus::Backlog),
+        "rejected relation update must be atomic"
+    );
+    assert_eq!(
+        store
+            .indexed_relation_targets(&first.workspace_id, &source_id, TaskRelationType::BlockedBy,)
+            .expect("relation after rejected update"),
+        vec![target_id]
+    );
+}
+
+#[test]
 fn allocator_reports_exhaustion() {
     let temp = TempDir::new().expect("tempdir");
     let store = store(&temp);
@@ -283,7 +636,7 @@ fn bind_workspace_is_idempotent_for_orbit_dir() {
         .expect("idempotent bind");
 
     assert_eq!(first.workspace_id, second.workspace_id);
-    assert_eq!(first.slug, second.slug);
+    assert_eq!(first.workspace_id, second.workspace_id);
 }
 
 #[test]
@@ -516,10 +869,12 @@ fn generated_relation_index_supports_forward_and_inverse_lookup() {
     let temp = TempDir::new().expect("tempdir");
     let store = store(&temp);
     let workspace = bind(&store, temp.path());
-    let bundle_dir = create_canonical_bundle(&store, &workspace, "ORB-00000");
-    store
-        .register_task_bundle("ORB-00000", &workspace.workspace_id, &bundle_dir)
-        .expect("register bundle");
+    for task_id in ["ORB-00000", "ORB-00001", "ORB-00002"] {
+        let bundle_dir = create_canonical_bundle(&store, &workspace, task_id);
+        store
+            .register_task_bundle(task_id, &workspace.workspace_id, &bundle_dir)
+            .expect("register bundle");
+    }
 
     store
         .replace_task_index(

--- a/crates/orbit-store/src/sqlite/task_registry/types.rs
+++ b/crates/orbit-store/src/sqlite/task_registry/types.rs
@@ -19,14 +19,30 @@ pub struct BindWorkspaceParams {
     pub repo_fingerprint: Option<String>,
 }
 
+/// Path-free coordination record for a logical workspace.
+#[derive(Debug, Clone)]
+pub struct RegisterWorkspaceParams {
+    pub workspace_id: String,
+    pub slug: String,
+    pub repo_fingerprint: Option<String>,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct WorkspaceBinding {
     pub workspace_id: String,
     pub slug: String,
+    pub repo_fingerprint: Option<String>,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+/// Machine-local checkout attached to a logical workspace, when one exists.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WorkspaceCheckoutBinding {
+    pub workspace_id: String,
     pub repo_root: PathBuf,
     pub workspace_path: PathBuf,
     pub orbit_dir: PathBuf,
-    pub repo_fingerprint: Option<String>,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
 }

--- a/crates/orbit-store/src/sqlite/task_registry/util.rs
+++ b/crates/orbit-store/src/sqlite/task_registry/util.rs
@@ -49,3 +49,17 @@ pub(super) fn relation_type_name(relation_type: TaskRelationType) -> &'static st
         TaskRelationType::Resolves => "resolves",
     }
 }
+
+pub(super) fn parse_relation_type_name(raw: &str) -> Result<TaskRelationType, String> {
+    match raw {
+        "blocked_by" => Ok(TaskRelationType::BlockedBy),
+        "child_of" => Ok(TaskRelationType::ChildOf),
+        "spawned_from" => Ok(TaskRelationType::SpawnedFrom),
+        "regression_from" => Ok(TaskRelationType::RegressionFrom),
+        "supersedes" => Ok(TaskRelationType::Supersedes),
+        "related_to" => Ok(TaskRelationType::RelatedTo),
+        "produces" => Ok(TaskRelationType::Produces),
+        "resolves" => Ok(TaskRelationType::Resolves),
+        other => Err(format!("unknown task relation type '{other}'")),
+    }
+}

--- a/crates/orbit-store/src/task_migration/mod.rs
+++ b/crates/orbit-store/src/task_migration/mod.rs
@@ -66,7 +66,7 @@ use crate::file::task_store::v2_bundle::{
     TaskBundleV2, copy_artifact_blobs, read_bundle_at, write_bundle_at,
 };
 use crate::sqlite::task_registry::{
-    BindWorkspaceParams, ProjectionRebuildResult, TaskRegistryStore, parse_orb_task_number,
+    ProjectionRebuildResult, RegisterWorkspaceParams, TaskRegistryStore, parse_orb_task_number,
 };
 
 mod archive;
@@ -159,7 +159,7 @@ pub struct ImportedTask {
 pub struct ImportOutcome {
     /// Target workspace the tasks landed in.
     pub workspace_id: String,
-    /// True if import registered a new (previously unknown) workspace binding.
+    /// True if import registered a new (previously unknown) logical workspace.
     pub registered_workspace: bool,
     /// Per-task records.
     pub tasks: Vec<ImportedTask>,
@@ -183,7 +183,7 @@ pub fn export_tasks(
         .find_workspace_binding(workspace_id)?
         .ok_or_else(|| {
             OrbitError::InvalidInput(format!(
-                "workspace '{workspace_id}' is not registered locally"
+                "workspace '{workspace_id}' is not registered in the coordination registry"
             ))
         })?;
     let workspace_id = binding.workspace_id.clone();
@@ -267,9 +267,9 @@ struct StagedBundle {
 /// Resolved import target after workspace resolution.
 struct ImportTarget {
     workspace_id: String,
-    orbit_dir: PathBuf,
-    /// Set when import must register a new binding for this workspace.
-    register: Option<BindWorkspaceParams>,
+    orbit_dir: Option<PathBuf>,
+    /// Set when import must register a new logical workspace record.
+    register: Option<RegisterWorkspaceParams>,
 }
 
 /// Import tasks from a tar.zst archive into the local registry.
@@ -359,9 +359,7 @@ pub fn import_tasks(
     let mut guard = WriteGuard::new(registry);
 
     let registered_workspace = if let Some(params) = &target.register {
-        std::fs::create_dir_all(&target.orbit_dir).map_err(|e| OrbitError::Io(e.to_string()))?;
-        guard.created_workspace_dir = Some(target.orbit_dir.clone());
-        registry.bind_workspace(params.clone())?;
+        registry.register_workspace(params.clone())?;
         true
     } else {
         false
@@ -535,7 +533,7 @@ fn stage_bundles(
     Ok(staged)
 }
 
-/// Resolve where imported tasks should land, and whether a new workspace binding
+/// Resolve where imported tasks should land, and whether a new logical workspace
 /// must be registered.
 fn resolve_target(
     registry: &TaskRegistryStore,
@@ -545,12 +543,14 @@ fn resolve_target(
     if let Some(requested) = target_workspace_id {
         let binding = registry.find_workspace_binding(requested)?.ok_or_else(|| {
             OrbitError::InvalidInput(format!(
-                "target workspace '{requested}' is not registered locally; initialize it first or omit --workspace to register the source workspace"
+                "target workspace '{requested}' is not registered in the coordination registry; register it first or omit --workspace to register the source workspace"
             ))
         })?;
         return Ok(ImportTarget {
             workspace_id: binding.workspace_id,
-            orbit_dir: binding.orbit_dir,
+            orbit_dir: registry
+                .find_workspace_checkout(requested)?
+                .map(|checkout| checkout.orbit_dir),
             register: None,
         });
     }
@@ -558,33 +558,24 @@ fn resolve_target(
     if let Some(binding) = registry.find_workspace_binding(&manifest.source_workspace_id)? {
         return Ok(ImportTarget {
             workspace_id: binding.workspace_id,
-            orbit_dir: binding.orbit_dir,
+            orbit_dir: registry
+                .find_workspace_checkout(&manifest.source_workspace_id)?
+                .map(|checkout| checkout.orbit_dir),
             register: None,
         });
     }
 
-    // Source workspace is unknown locally and no target was named: register a
-    // detached binding pinned to the source id. Its synthetic orbit_dir lives
-    // beside the workspaces tree so the projection has somewhere to land until
-    // the real repo is initialized with this workspace id. The directory is
-    // created in Phase 2 (not here) so a classification failure leaves no leak.
-    let detached_root = registry
-        .workspaces_dir()
-        .parent()
-        .map(|parent| parent.join("detached"))
-        .unwrap_or_else(|| registry.workspaces_dir().join("detached"));
-    let orbit_dir = detached_root.join(&manifest.source_workspace_id);
-    let params = BindWorkspaceParams {
-        workspace_id: Some(manifest.source_workspace_id.clone()),
+    // Source workspace is unknown locally and no target was named: register
+    // only its logical coordination identity. A later checkout link may add a
+    // local projection; migration must never fabricate checkout paths.
+    let params = RegisterWorkspaceParams {
+        workspace_id: manifest.source_workspace_id.clone(),
         slug: manifest.source_workspace_slug.clone(),
-        repo_root: orbit_dir.clone(),
-        workspace_path: orbit_dir.clone(),
-        orbit_dir: orbit_dir.clone(),
         repo_fingerprint: None,
     };
     Ok(ImportTarget {
         workspace_id: manifest.source_workspace_id.clone(),
-        orbit_dir,
+        orbit_dir: None,
         register: Some(params),
     })
 }
@@ -627,7 +618,14 @@ fn rebuild_projection_best_effort(
     registry: &TaskRegistryStore,
     target: &ImportTarget,
 ) -> ProjectionRebuildResult {
-    match registry.rebuild_projection(&target.orbit_dir, &target.workspace_id) {
+    let Some(orbit_dir) = target.orbit_dir.as_deref() else {
+        return ProjectionRebuildResult {
+            projected: 0,
+            repaired: 0,
+            degraded_reason: None,
+        };
+    };
+    match registry.rebuild_projection(orbit_dir, &target.workspace_id) {
         Ok(result) => result,
         Err(err) => ProjectionRebuildResult {
             projected: 0,
@@ -655,8 +653,6 @@ struct WriteGuard<'a> {
     registry: &'a TaskRegistryStore,
     written_dirs: Vec<PathBuf>,
     registered_ids: Vec<String>,
-    /// Synthetic orbit dir created for a freshly registered detached workspace.
-    created_workspace_dir: Option<PathBuf>,
     armed: bool,
 }
 
@@ -666,7 +662,6 @@ impl<'a> WriteGuard<'a> {
             registry,
             written_dirs: Vec::new(),
             registered_ids: Vec::new(),
-            created_workspace_dir: None,
             armed: true,
         }
     }
@@ -690,13 +685,6 @@ impl<'a> WriteGuard<'a> {
             }
         }
         for dir in self.written_dirs.drain(..) {
-            let _ = std::fs::remove_dir_all(&dir);
-        }
-        // The empty detached workspace dir we created (bundle dirs live under a
-        // separate `workspaces/` tree, so this only holds a not-yet-built
-        // projection). The workspace binding row is left in place — an empty
-        // binding is benign and idempotent to re-create on retry.
-        if let Some(dir) = self.created_workspace_dir.take() {
             let _ = std::fs::remove_dir_all(&dir);
         }
         self.armed = false;

--- a/crates/orbit-store/src/task_migration/reindex.rs
+++ b/crates/orbit-store/src/task_migration/reindex.rs
@@ -35,7 +35,7 @@ pub fn reindex_workspace(
         .find_workspace_binding(workspace_id)?
         .ok_or_else(|| {
             OrbitError::InvalidInput(format!(
-                "workspace '{workspace_id}' is not registered locally"
+                "workspace '{workspace_id}' is not registered in the coordination registry"
             ))
         })?;
     let workspace_id = binding.workspace_id.clone();
@@ -76,7 +76,15 @@ pub fn reindex_workspace(
         registry.bump_allocator_to_at_least(max + 1)?;
     }
 
-    let projection = registry.rebuild_projection(&binding.orbit_dir, &workspace_id)?;
+    let projection = if let Some(checkout) = registry.find_workspace_checkout(&workspace_id)? {
+        registry.rebuild_projection(&checkout.orbit_dir, &workspace_id)?
+    } else {
+        ProjectionRebuildResult {
+            projected: 0,
+            repaired: 0,
+            degraded_reason: None,
+        }
+    };
 
     Ok(ReindexOutcome {
         workspace_id,

--- a/crates/orbit-store/src/task_migration/tests/mod.rs
+++ b/crates/orbit-store/src/task_migration/tests/mod.rs
@@ -12,7 +12,7 @@ use tempfile::TempDir;
 
 use crate::file::task_store::v2_bundle::{TaskBundleStoreV2, TaskBundleV2, read_bundle_at};
 use crate::sqlite::task_registry::{
-    BindWorkspaceParams, TaskRegistryStore, WorkspaceBinding, task_registry_path,
+    BindWorkspaceParams, TaskRegistryStore, WorkspaceCheckoutBinding, task_registry_path,
 };
 
 use super::*;
@@ -21,7 +21,7 @@ fn open_registry(global: &Path) -> TaskRegistryStore {
     TaskRegistryStore::open(&task_registry_path(global)).expect("open registry")
 }
 
-fn bind(registry: &TaskRegistryStore, global: &Path, ws_id: &str) -> WorkspaceBinding {
+fn bind(registry: &TaskRegistryStore, global: &Path, ws_id: &str) -> WorkspaceCheckoutBinding {
     let orbit_dir = global.join("repos").join(ws_id).join(".orbit");
     fs::create_dir_all(&orbit_dir).expect("create orbit dir");
     registry
@@ -36,7 +36,10 @@ fn bind(registry: &TaskRegistryStore, global: &Path, ws_id: &str) -> WorkspaceBi
         .expect("bind workspace")
 }
 
-fn bundle_store(registry: &TaskRegistryStore, binding: &WorkspaceBinding) -> TaskBundleStoreV2 {
+fn bundle_store(
+    registry: &TaskRegistryStore,
+    binding: &WorkspaceCheckoutBinding,
+) -> TaskBundleStoreV2 {
     TaskBundleStoreV2::new(
         registry.clone(),
         binding.workspace_id.clone(),
@@ -276,7 +279,12 @@ fn import_into_unregistered_workspace_registers_it() {
     assert_eq!(outcome.workspace_id, ws);
     assert!(outcome.registered_workspace);
     assert!(registry.find_workspace_binding(ws).unwrap().is_some());
+    assert!(
+        registry.find_workspace_checkout(ws).unwrap().is_none(),
+        "migration must not fabricate a detached checkout"
+    );
     assert_eq!(registry.tasks_for_workspace(ws).unwrap().len(), 2);
+    assert!(!dst.path().join("tasks/detached").exists());
 }
 
 #[test]
@@ -492,6 +500,11 @@ fn reindex_reregisters_disk_bundles_and_drops_stale() {
     assert_eq!(registered, vec!["ORB-00000", "ORB-00003"]);
     // Allocator moved past the highest on-disk id.
     assert!(registry.allocator_next_number().unwrap() >= 4);
+
+    let again = reindex_workspace(&registry, ws).expect("reindex again");
+    assert_eq!(again.indexed, outcome.indexed);
+    assert_eq!(again.removed_stale, 0);
+    assert_eq!(registry.allocator_next_number().unwrap(), 4);
 }
 
 fn read_id_map(path: &PathBuf) -> std::collections::BTreeMap<String, String> {

--- a/docs/design/host-registry/1_overview.md
+++ b/docs/design/host-registry/1_overview.md
@@ -10,7 +10,7 @@ summary: First-class, validated machine identity plus a main-host inventory, ena
 tags: [host-registry, multi-host, dispatch, routines]
 paths: ["crates/orbit-core/**", "crates/orbit-store/**", "crates/orbit-mcp/**", "crates/orbit-common/**"]
 related_features: [host-registry, mcp-bridge, routines, remote-access]
-related_artifacts: [ORB-00424, ORB-10248, ADR-0200, ADR-0205, ADR-0208, ADR-0226, ADR-0227, ADR-0228, ADR-0229, ADR-0230, ADR-0231, ADR-0232]
+related_artifacts: [ORB-00424, ORB-10248, ORB-10249, ADR-0200, ADR-0205, ADR-0208, ADR-0226, ADR-0227, ADR-0228, ADR-0229, ADR-0230, ADR-0231, ADR-0232]
 ---
 
 # Host Registry — Overview
@@ -98,7 +98,7 @@ authority — that direction was already rejected ([ADR-0200], the archived
 | Host identity file (`host.toml`) | [crates/orbit-core/src/routines/host.rs](../../../crates/orbit-core/src/routines/host.rs) | — |
 | Global/workspace seeding (`orbit init`) | [crates/orbit-core/src/command/init.rs](../../../crates/orbit-core/src/command/init.rs) | — |
 | Versioned logical-workspace catalog + local checkout bindings | [crates/orbit-core/src/workspace_registry.rs](../../../crates/orbit-core/src/workspace_registry.rs) | [ORB-10248] |
-| Task ID single-authority allocator | [crates/orbit-store/src/sqlite/task_registry/](../../../crates/orbit-store/src/sqlite/task_registry/) | — |
+| Logical task coordination registry + single-authority allocator | [crates/orbit-store/src/sqlite/task_registry/](../../../crates/orbit-store/src/sqlite/task_registry/) | [ORB-10249] |
 | MCP surface (`orbit.host.*`, placement) | [mcp-bridge/2_design.md](../mcp-bridge/2_design.md) | [ORB-00424] |
 | Routine sweep host filter | [docs/design/routines/2_design.md](../routines/2_design.md) | — |
 
@@ -112,5 +112,7 @@ Detailed mechanisms in [2_design.md](./2_design.md); open directions in
   placement, Bridge parity retired).
 - [ORB-10248] — split the versioned workspace catalog from machine-local
   checkout paths and owner/replica bindings.
+- [ORB-10249] — split logical task-registry workspace records from optional
+  local checkout bindings and made task relations/readiness global by task ID.
 
 > Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.

--- a/docs/design/host-registry/2_design.md
+++ b/docs/design/host-registry/2_design.md
@@ -10,7 +10,7 @@ summary: Target mechanisms for host identity, the main-host registry, the coordi
 tags: [host-registry, multi-host, dispatch, routines, data-placement]
 paths: ["crates/orbit-core/**", "crates/orbit-store/**", "crates/orbit-mcp/**", "crates/orbit-common/**"]
 related_features: [host-registry, mcp-bridge, routines, remote-access, mcp-session-context]
-related_artifacts: [ORB-00424, ORB-10247, ORB-10248, ADR-0200, ADR-0205, ADR-0208, ADR-0226, ADR-0227, ADR-0228, ADR-0229, ADR-0230, ADR-0231, ADR-0232]
+related_artifacts: [ORB-00424, ORB-10247, ORB-10248, ORB-10249, ADR-0200, ADR-0205, ADR-0208, ADR-0226, ADR-0227, ADR-0228, ADR-0229, ADR-0230, ADR-0231, ADR-0232]
 ---
 
 # Host Registry — Design
@@ -194,6 +194,28 @@ warning-only when the cache is absent or stale. Scheduling keeps working offline
 Neither role is ever selected per-task: coordination has one writer by construction,
 and two owners for one workspace is the split-brain the system already rejected
 ([ADR-0200]).
+
+**Concrete task coordination schema ([ORB-10249]).** The hub task registry's
+`workspace_bindings` table is a path-free logical record: `workspace_id`, slug,
+optional repository fingerprint, and timestamps. Machine-local paths live only in
+the optional one-to-one `workspace_checkout_bindings` table (`workspace_id`,
+`repo_root`, `workspace_path`, `orbit_dir`, timestamps). Allocator, canonical task
+bundle, workspace index, tag, and relation rows reference the logical
+`workspace_id`; none requires a checkout row. Canonical bundles remain in the
+hub's coordination tree, so a checkoutless workspace can create, read, update, and
+schedule tasks without a fabricated repository path. Checkout-local projections
+resolve the optional checkout binding first and fail before filesystem mutation,
+naming the workspace when absent.
+
+Task IDs remain globally unique. Every ORB-valued dependency or typed-relation
+target resolves through the whole coordination registry, while task list/index
+queries remain workspace-scoped. The global status projection supplies dependency
+readiness across workspaces without opening either checkout. Missing ORB targets
+are rejected before task allocation or bundle/index mutation with both target ID
+and source workspace in the error. Schema v4 migrates each legacy path-coupled row
+into one logical record plus one checkout binding without changing task IDs,
+canonical bundle paths, payloads, relations, workspace associations, or allocator
+state; repeated open/reindex is idempotent.
 
 ## 4. Execution Placement
 

--- a/docs/design/host-registry/4_decisions.md
+++ b/docs/design/host-registry/4_decisions.md
@@ -10,7 +10,7 @@ summary: Accepted ADR log for the coupled Host Registry and MCP Bridge v1 contra
 tags: [host-registry, mcp-bridge, multi-host, placement]
 paths: ["crates/orbit-core/**", "crates/orbit-store/**", "crates/orbit-mcp/**"]
 related_features: [host-registry, mcp-bridge]
-related_artifacts: [ORB-00424, ORB-10245, ORB-10248, ADR-0226, ADR-0227, ADR-0228, ADR-0229, ADR-0230, ADR-0231, ADR-0232]
+related_artifacts: [ORB-00424, ORB-10245, ORB-10248, ORB-10249, ADR-0226, ADR-0227, ADR-0228, ADR-0229, ADR-0230, ADR-0231, ADR-0232]
 ---
 
 # Host Registry — Decisions
@@ -22,7 +22,7 @@ v1 decision set shared with [mcp-bridge](../mcp-bridge/4_decisions.md).
 
 ## ADR-0226 — Singular coordination hub, workspace owner, and per-run placement
 
-**Status:** Accepted · 2026-07 · [ORB-10245] accepted the coupled v1 contract; [ORB-10248] implemented the workspace boundary.
+**Status:** Accepted · 2026-07 · [ORB-10245] accepted the coupled v1 contract; [ORB-10248] implemented the workspace boundary; [ORB-10249] applied it to task coordination.
 
 ### Context
 
@@ -40,6 +40,7 @@ logical workspace/owner separately from machine-local checkout bindings.
 
 - Coordination writes remain hub-routed while knowledge authorship remains owner-bound.
 - Logical workspace lookup never requires or fabricates a checkout path; local path lookup consults checkout bindings only.
+- Task coordination, global relation resolution, and dependency readiness use logical workspace IDs and never require either workspace checkout.
 - Cost: hub downtime stalls coordination for every workspace, and disconnected machines cannot write coordination records.
 
 ## ADR-0227 — Stable machine identity, registry, and out-of-band hub pin
@@ -163,5 +164,6 @@ for its non-Orbit constellation domains.
 - [ORB-00424] — completed design proposal for canonical Orbit MCP and Bridge parity retirement.
 - [ORB-10245] — accepted the coupled contract and recorded this ADR set.
 - [ORB-10248] — implemented the versioned logical-workspace/local-checkout split.
+- [ORB-10249] — implemented path-free task coordination and global task-relation/readiness lookup.
 
 > Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.


### PR DESCRIPTION
## Task

[ORB-10249](https://orbit-cli.com/tasks/ORB-10249) — Bind task registry records to logical workspace IDs

### Description

## Problem

Orbit's task registry currently couples a workspace binding to repo_root, workspace_path, and orbit_dir. A central hub must own canonical task coordination for a logical workspace even when that workspace's checkout exists only on its owner machine. Fabricating hub-local paths would make task routing and bundle ownership incorrect.

The current workspace-local dependency validator also rejects a globally unique task ID in another registered workspace. That surfaced when ready Orbit Unit R1 could not record completed Constellation R0/ORB-10256 as a dependency. Hub coordination must evaluate task relationships across logical workspace bindings without requiring either checkout.

This is Phase 1 / Unit B3 under implementation umbrella ORB-10246. It follows the logical catalog/local checkout split in Unit B2.

## Required outcome

Refactor task-registry workspace binding so canonical coordination records bind to stable logical workspace_id without requiring a local checkout path. Keep checkout resolution as a separate local concern used only when a command actually needs filesystem access.

Preserve:

- the existing global task-ID allocator and ID stability;
- each task bundle's canonical path when a local authoritative checkout exists;
- task add/show/list/update/review behavior in standalone mode;
- workspace-scoped task indexes and projection rebuilds; and
- migration/archive rollback behavior.

A hub must be able to create, index, query, relate, and schedule a task for a registered logical workspace with no hub checkout. Dependencies and typed task relations resolve globally unique task IDs through the coordination registry across logical workspaces, and ready/dependency projections evaluate those targets without opening either workspace checkout.

A local file operation for a task must resolve through an explicit local checkout binding or fail before mutation with an error naming the workspace ID; it must never synthesize repo_root, workspace_path, or orbit_dir.

## Migration and boundaries

- Migrate existing task-registry rows and fixtures idempotently without changing task IDs, relations, task bundle content, allocator state, or workspace association.
- Keep old standalone fixtures readable and prove migration/reindex is safe to rerun.
- Use deterministic temporary registries/checkouts, including two checkoutless logical workspaces with a cross-workspace dependency.
- This task centralizes coordination lookup only; it adds no MCP transport, placement broker, lease state, host registry tables, knowledge routing, or HA behavior.
- Update Host Registry design docs in the same PR if concrete task-binding schema names refine the accepted contract.

### Acceptance Criteria

- Task-registry coordination records use logical workspace_id without requiring repo_root, workspace_path, or orbit_dir columns/values for checkoutless workspaces.
- A deterministic fixture registers a logical workspace with no local checkout, creates and queries a task for it, and preserves the global allocator and workspace-scoped index without synthetic paths.
- Globally unique dependency and typed-relation targets resolve through the coordination registry across logical workspaces, and ready/dependency projections evaluate a completed target in another workspace without either checkout.
- A missing global relation/dependency target fails atomically with the target ID and source workspace; a valid cross-workspace target is never rejected merely because it is outside the source workspace.
- Commands that require task-bundle file access resolve an explicit local checkout binding; when none exists they fail before mutation with an actionable error containing the workspace ID.
- Migration preserves every task ID, canonical bundle path, task payload, relation/dependency, workspace association, and allocator counter; running migration/reindex twice makes no further changes.
- Standalone add/show/list/update/review, dependency readiness, typed relations, and task-migration behavior remain compatible.
- cargo test -p orbit-store and cargo test -p orbit-core pass.
- make ci-fast passes from the Orbit repository root.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Split task-registry logical workspace rows from optional local checkout bindings with an idempotent v4 migration preserving task bundles, indexes, relations, workspace associations, and allocator state.
- Added checkoutless coordination task backends, explicit checkout projection preflight, and removed synthetic detached migration paths.
- Resolved ORB relation targets and dependency statuses globally across logical workspaces with atomic missing-target rejection while keeping task listings workspace-scoped.
- Added deterministic checkoutless, cross-workspace, migration, rerun, and failure-path coverage and synchronized the Host Registry design docs.
- Corrected a stale triage activity assertion encountered during required orbit-core validation so it matches the existing evidence-gated task.update contract.

Validation:
- cargo test -p orbit-common
- cargo test -p orbit-store
- cargo test -p orbit-core
- cargo check -p orbit-store -p orbit-core -p orbit-cli
- make ci-fast
- git diff --check

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10249-6a5b011c`
- Behind base: 0
- Ahead of base: 1