### PR TITLE
docs: design resident orchestrator epic pickup

### DIFF
--- a/docs/design/CONVENTIONS.md
+++ b/docs/design/CONVENTIONS.md
@@ -1,7 +1,7 @@
 ---
 title: Design Doc Conventions
 owner: daniel
-last_updated: 2026-07-16
+last_updated: 2026-07-17
 status: Accepted
 ---
 
@@ -204,6 +204,7 @@ Retired features stay listed with their `_archive/` path as a historical record.
 | Policy & Sandboxing | [docs/design/policy-sandbox/](./policy-sandbox/) | claude |
 | Project Learnings | [docs/design/project-learnings/](./project-learnings/) | claude |
 | Remote Access | [docs/design/remote-access/](./remote-access/) | claude |
+| Resident Orchestrator | [docs/design/resident-orchestrator/](./resident-orchestrator/) | codex |
 | Routines | [docs/design/routines/](./routines/) | claude |
 | Task Artifacts | [docs/design/task-artifacts/](./task-artifacts/) | codex |
 | Task Sync (archived) | [docs/design/_archive/task-sync/](./_archive/task-sync/) | claude |

--- a/docs/design/resident-orchestrator/1_overview.md
+++ b/docs/design/resident-orchestrator/1_overview.md
@@ -1,0 +1,89 @@
+---
+title: Resident Orchestrator — Overview
+owner: codex
+last_updated: 2026-07-17
+status: Draft
+feature: resident-orchestrator
+doc_role: overview
+type: design
+summary: Workspace-addressed epic delegation to a specialized CLI orchestrator that decomposes and shepherds work without a resident server.
+tags: [resident-orchestrator, epic, routines, cli]
+paths: [".orbit/resources/activities/**", ".orbit/resources/jobs/**", ".orbit/routines/**", "crates/orbit-core/assets/**"]
+related_features: [resident-orchestrator, activity-job, routines, agent-families]
+related_artifacts: []
+---
+
+# Resident Orchestrator — Overview
+
+A **resident orchestrator** is a specialized agent bound to one Orbit workspace. The workspace is
+its address, a root task tagged `epic` is its durable work order, and a workspace-local routine
+wakes a bounded `backend: cli` ownership cycle. The resident decomposes the epic into normal child
+tasks, ships explicit child task IDs through the existing delivery workflows, and shepherds the
+whole tree to a verified terminal state. No per-agent server, inbox pump, or retained HTTP agent
+session is required.
+
+## 1. Motivation
+
+The constellation currently has two useful but insufficient levels of delegation:
+
+1. A front-door orchestrator can make cross-workspace decisions.
+2. A one-shot runner can execute one scoped leaf mandate.
+
+What is missing is durable, codebase-local ownership between those levels. A single front door
+cannot retain deep context for several codebases while also following every task, workflow run,
+review, merge conflict, and acceptance criterion to completion. Repeated generic runner calls do
+not solve that problem: the front door remains the shepherd and must reconstruct the codebase's
+state on every turn.
+
+Orbit already provides the durable pieces needed for a smaller solution: workspace routing,
+tagged tasks, parent/child task relationships, dependencies, CLI agent activities, jobs, routines,
+and explicit-ID shipment workflows. The missing mechanism is a convention and a thin pickup cycle
+that hand ownership of a high-level task to the workspace's specialized orchestrator.
+
+The existing `task_epic_pipeline` is not that mechanism. It assumes child tasks already exist,
+uses an HTTP agent loop with retained session state, and treats `review` as the end of automated
+shipment. Orbit v1 supports CLI agent invocation; the resident must also own decomposition and the
+post-review delivery loop. This design replaces the HTTP epic path instead of porting it.
+
+## 2. Core Concepts
+
+**Resident workspace.** One Orbit workspace is the durable address for one specialized
+orchestrator. For example, an Orbit systems agent receives work in the Orbit codebase workspace;
+no separate agent queue is required.
+
+**Epic assignment.** A root task with no `parent_id` and the tag `epic`. Creating that task in a
+workspace is the act of delegation. Its description and acceptance criteria define the outcome;
+the resident authors the execution plan after pickup.
+
+**Resident activity.** A workspace-local `agent_loop` activity using `backend: cli`. It explicitly
+binds the provider, model, and identity-loading instruction for that workspace's resident agent.
+Different workspaces can use different resident agents without a new invocation service.
+
+**Ownership cycle.** One bounded resident invocation. It resumes an active epic before selecting a
+new one, advances as much of its task tree as current state permits, persists every decision in
+Orbit, and exits. A later routine fire resumes from durable state rather than conversation memory.
+
+**Child task.** A normal task created with `parent_id` pointing to the epic. Child tasks use the
+ordinary lifecycle, dependency, crew, validation, review, and PR machinery; the `epic` tag does not
+create a second execution model.
+
+**Shepherding.** The resident's responsibility for the entire workspace-local delivery loop:
+decomposition, explicit dispatch, run observation, failure recovery, independent review,
+conflict/finding resolution, merge verification, child closure, and finally parent closure.
+
+## 3. At a Glance
+
+| Concern | File | Task |
+|---------|------|------|
+| Resident CLI identity | workspace `.orbit/resources/activities/resident_orchestrator.yaml` | Not allocated |
+| Epic selection and resume | proposed deterministic `select_resident_epic` activity | Not allocated |
+| Bounded ownership cycle | proposed `resident_epic_cycle` job | Not allocated |
+| Scheduled pickup | workspace `.orbit/routines/resident_epic.yaml` | Not allocated |
+| Child delivery | existing `task_gate_pipeline` / explicit-ID shipment workflows | Existing mechanism |
+| HTTP epic retirement | existing `task_epic_pipeline` and `epic_orchestrator` assets | Not allocated |
+
+## Task References
+
+- None yet — implementation tasks will be allocated after this Draft is accepted.
+
+> Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.

--- a/docs/design/resident-orchestrator/2_design.md
+++ b/docs/design/resident-orchestrator/2_design.md
@@ -1,0 +1,267 @@
+---
+title: Resident Orchestrator — Design
+owner: codex
+last_updated: 2026-07-17
+status: Draft
+feature: resident-orchestrator
+doc_role: design
+type: design
+summary: CLI-backed pickup, checkpoint, decomposition, and shepherding contract for workspace-resident orchestrators.
+tags: [resident-orchestrator, epic, routines, cli]
+paths: [".orbit/resources/activities/**", ".orbit/resources/jobs/**", ".orbit/routines/**", "crates/orbit-core/assets/**"]
+related_features: [resident-orchestrator, activity-job, routines, agent-families, host-registry]
+related_artifacts: []
+---
+
+# Resident Orchestrator — Design
+
+This document specifies the proposed resident-orchestrator contract. It covers how a high-level
+assignment is addressed, selected, resumed, decomposed, dispatched, and closed using Orbit's CLI
+backend and durable task state. It does not change leaf implementation pipelines or introduce a
+general distributed workflow engine.
+
+## 1. Addressing Work Through the Workspace
+
+The destination workspace is the agent address. The front-door orchestrator delegates by creating
+one task in that workspace with:
+
+- no `parent_id`;
+- tag `epic`;
+- an outcome-oriented description;
+- observable epic-level acceptance criteria;
+- the appropriate priority; and
+- `proposed` or `backlog` status under the workspace's normal approval policy.
+
+There is no required `assignee` field. In v1, a workspace has at most one configured resident
+orchestrator, so workspace routing plus the `epic` tag is unambiguous. The task remains a normal
+Orbit task: it can be searched, blocked, rejected, archived, related to other artifacts, and
+inspected by any operator.
+
+The `epic` tag is deliberately behavioral only at the resident pickup boundary. It does not alter
+the task schema or create a new task type. Child tasks are recognized by `parent_id`, not by a
+special child tag.
+
+## 2. Workspace-Local Resident Identity
+
+Each participating workspace owns an activity named `resident_orchestrator`. The activity is the
+declarative invocation profile for that workspace's specialized agent:
+
+```yaml
+schemaVersion: 2
+kind: Activity
+metadata:
+  name: resident_orchestrator
+spec:
+  type: agent_loop
+  description: Run one bounded ownership cycle for this workspace's resident orchestrator.
+  backend: cli
+  provider: codex
+  model: gpt-5.6-sol
+  max_iterations: 1
+  wall_clock_timeout_seconds: 7200
+  instruction: |
+    Read the resident identity and active rules before acting.
+    You own one bounded epic-shepherding cycle in this workspace.
+```
+
+The example values are illustrative; each workspace chooses its own provider, model, and identity
+instruction. The resolved provider/model must be explicit and must match the named resident's
+identity. Defaults or role overrides that silently change the resolved identity are invalid for a
+resident activity.
+
+Identity memory remains outside Orbit's task store. The activity instruction points the CLI agent
+to its versioned memory layer, and the CLI harness loads the workspace's normal repository
+instructions. Orbit owns invocation, task state, and audit evidence; it does not become an agent
+memory service.
+
+Using a normal activity asset is intentional. It reuses the existing CLI executor and lets every
+workspace version its own resident binding without adding an identity registry or another server.
+
+The first Constellation canary is `ws_orbit`: Hohmann is bound explicitly to Codex Sol and loads
+its versioned memory layer before each cycle. Adopting this design changes Hohmann from a leaf that
+returns review/merge/closure to the front door into a codebase-bounded orchestrator that owns those
+steps inside `ws_orbit`. The front door still owns cross-workspace routing, product priority, and
+any independent oversight required by live policy.
+
+## 3. The Resident Epic Cycle
+
+A new `resident_epic_cycle` job performs one bounded ownership cycle:
+
+1. **Select.** A deterministic `select_resident_epic` activity searches the source workspace.
+2. **Invoke.** When a task is selected, the job invokes `activity:resident_orchestrator` with the
+   workspace identity, parent task snapshot, known child summaries, and relevant run pointers.
+3. **Record.** The CLI agent performs task and workflow operations through Orbit's managed tool
+   surface; those writes are the checkpoint.
+4. **Exit.** The job ends after the resident reports the cycle outcome. It does not sleep while a
+   child workflow is running and does not retain a provider session for the next fire.
+
+Selection order is deterministic:
+
+1. resume the oldest `in-progress`, root, `epic` task;
+2. otherwise select the highest-priority ready `backlog` root epic, then creation order;
+3. otherwise select a `proposed` root epic only when workspace policy permits the resident to plan
+   and start it; and
+4. otherwise return a successful no-op.
+
+The first version permits one active epic per workspace. The routine uses `overlap: forbid`, pins
+one host, and the selector always resumes active ownership before admitting new work. These three
+constraints avoid a new lease or assignee subsystem. A concurrent manual lifecycle transition is
+resolved by the task store's existing status validation; the losing cycle refreshes instead of
+forcing state.
+
+## 4. Resident Cycle Contract
+
+The resident is an orchestrator within one workspace, not a leaf implementer and not a global
+supervisor. During each cycle it must:
+
+1. load the parent task, its plan, acceptance criteria, children, dependencies, review threads,
+   artifacts, and active workflow runs;
+2. author or refine the parent plan before starting an unplanned proposal;
+3. start the parent when it accepts ownership;
+4. create independently shippable child tasks with `parent_id`, strong acceptance criteria,
+   precise `context_files`, dependencies, priority, complexity, and crew;
+5. dispatch only explicit ready child IDs through the workspace's normal shipment workflow;
+6. observe existing child runs before dispatching anything, so a restart never duplicates an
+   in-flight shipment;
+7. obtain and enforce the workspace's independent-review policy;
+8. resolve failures, review findings, merge conflicts, and stale branches within its workspace;
+9. verify landed commits and child lifecycle state rather than trusting agent prose or a PR merge
+   button; and
+10. complete the parent only after every required child is terminal and the parent-level acceptance
+    criteria have been verified as an integrated outcome.
+
+The resident may inspect adjacent workspaces to understand an interface, but it must not silently
+edit or dispatch into them. A cross-workspace dependency becomes a separate epic assignment in the
+destination workspace, related from the source task with explicit workspace and task pointers.
+The front-door orchestrator remains the authority for cross-workspace priority and product scope.
+
+## 5. Durable Checkpoints and Resumption
+
+No correctness may depend on CLI conversation history. The recovery state is the Orbit graph:
+
+- the parent task's status, plan, comments, execution summary, and acceptance criteria;
+- child tasks connected by `parent_id`;
+- child `dependencies` and relations;
+- workflow/run IDs attached to tasks or recorded in artifacts/comments;
+- review threads and structured verdicts; and
+- repository/PR state verified during the cycle.
+
+The resident writes a concise cycle checkpoint to the parent before exiting. At minimum it records
+what changed, which children or runs remain active, the next safe action, and any blocker requiring
+new authority. Checkpoints are pointers, not copied logs.
+
+Crash behavior follows from where the failure occurs:
+
+| Failure point | Durable result | Next fire |
+|---------------|----------------|-----------|
+| Before selection | No task mutation | Select normally |
+| After selection, before start | Parent remains proposed/backlog | Re-evaluate and retry |
+| After parent start | Parent remains `in-progress` | Resume it before new work |
+| After child creation | Children remain attached | Continue decomposition/dispatch |
+| After workflow submit | Run/task link remains authoritative | Observe; do not redispatch |
+| While waiting for review or CI evidence | Parent remains active | Recheck only the required gate |
+| Genuine product-authority blocker | Parent moves to `blocked` with exact question | Stop automatic retries |
+
+## 6. Routine Contract
+
+Each resident workspace may enable a versioned routine targeting `job:resident_epic_cycle`:
+
+```yaml
+schemaVersion: 1
+name: resident-epic-orbit
+enabled: true
+hosts: [dk-server-1]
+trigger: { cron: "*/5 * * * *", missed_run: skip }
+target: job:resident_epic_cycle
+policy:
+  timeout_minutes: 120
+  overlap: forbid
+```
+
+The routine is only a clock and admission boundary. It must not discover or ship ordinary backlog
+tasks. An `epic` root was deliberately placed in this workspace by an upstream orchestrator or
+human, so pickup is explicit delegation rather than blind auto-dispatch.
+
+Routine definitions remain disabled by default when seeded. Enabling a resident is a versioned
+workspace decision, and the activity must resolve to a valid CLI provider/model on the pinned host
+before enablement.
+
+## 7. Child Shipment and Completion
+
+The resident reuses existing leaf delivery workflows. It does not implement code inside the epic
+cycle unless the workspace's delivery policy explicitly treats a bounded change as direct work.
+Normally it promotes ready children and invokes shipment with explicit task IDs, selected mode,
+crew, base branch, and independent review configuration.
+
+An epic may have sequential and parallel children. Ordering is expressed durably through child
+`dependencies`; disjoint ready children may be shipped concurrently within the workspace's normal
+run and lock limits. Dependency inference that exists only in a model's reasoning is incomplete —
+the resident must write it to the child tasks before dispatch.
+
+The parent does not become `done` merely because all children reached `review`. Completion requires:
+
+- every required child is `done`, `rejected`, or explicitly accepted as out of scope;
+- no open blocking review thread remains;
+- required PRs are merged and candidate commits are on the integration branch;
+- parent-level integration checks pass; and
+- the parent execution summary contains a structured final verdict and evidence pointers.
+
+## 8. Phasing Out the HTTP Epic Pipeline
+
+`task_epic_pipeline` and its `epic_orchestrator` activity are legacy after the resident CLI path is
+available. They should not be converted in place because their contract differs materially:
+
+| HTTP epic path | Resident CLI path |
+|----------------|-------------------|
+| Requires pre-existing children | Owns decomposition and child creation |
+| Uses `backend: http` and a retained `session:` loop | Uses bounded `backend: cli` cycles |
+| Keeps progress partly in provider conversation state | Derives progress from durable Orbit state |
+| Dispatches child gates | Shepherds dispatch, review, merge, and closure |
+| Treats `review` as shipped/terminal | Requires verified task and integration completion |
+
+Retirement proceeds in four stages:
+
+1. ship the resident selector, CLI activity contract, cycle job, and disabled routine;
+2. canary one workspace and verify crash/resume, duplicate-dispatch prevention, review repair, and
+   final parent closure;
+3. remove `task_epic_pipeline` from seeded/default catalog references and migrate active users; and
+4. delete the HTTP-only epic activities/actions once no live run or workspace references them,
+   updating the Activity / Job decisions and task references in the same change.
+
+Historical run records remain readable after catalog retirement. Removal must fail closed for a
+workspace that still has an enabled routine or job reference to the legacy pipeline.
+
+## 9. Security and Authority
+
+`backend: cli` delegates tool enforcement to the provider harness, so the resident activity is a
+trusted workspace capability. The routine therefore requires the same review boundary as any
+versioned automation asset, and the CLI run must retain Orbit's managed run identity and audit
+envelope.
+
+The resident's authority is bounded by the source workspace and live repository instructions.
+It may exercise routine lifecycle operations needed to shepherd already-authorized work, but it
+must block and surface a precise question when completion needs new product authority or a material
+scope expansion.
+
+## 10. Concerns & Honest Limitations
+
+- **Workspace ownership is singular in v1.** Multiple resident orchestrators in one workspace need
+  an explicit routing or lease design; tags alone are not enough.
+- **Polling adds latency.** A five-minute cadence is simple and robust but delays pickup and
+  resumption. Event triggers remain outside routines v1.
+- **CLI cycles rehydrate context.** Durable state prevents correctness loss, but each invocation
+  pays the cost of reading identity, task state, and repository context again.
+- **Cross-workspace epics are not one graph.** Each workspace owns its own task tree; the front door
+  must relate and observe multiple parent tasks when one product outcome spans codebases.
+- **Provider harness trust is real.** CLI activities do not receive the HTTP backend's builtin tool
+  allowlist enforcement. Host sandboxing and provider policy remain part of the security boundary.
+- **A resident can still make poor decomposition choices.** Deterministic selection and durable
+  state make those choices inspectable and recoverable; they do not eliminate judgment risk.
+- **Legacy removal needs migration evidence.** Deleting the HTTP epic assets before all routine,
+  job, and live-run references are checked would turn a design cleanup into an operational break.
+
+## Task References
+
+- None yet — implementation tasks will be allocated after this Draft is accepted.
+
+> Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.

--- a/docs/design/resident-orchestrator/3_vision.md
+++ b/docs/design/resident-orchestrator/3_vision.md
@@ -1,0 +1,91 @@
+---
+title: Resident Orchestrator — Vision
+owner: codex
+last_updated: 2026-07-17
+status: Draft
+feature: resident-orchestrator
+doc_role: vision
+type: design
+summary: Forward-looking questions for multi-resident routing, event-driven wakeups, and cross-workspace epic observability.
+tags: [resident-orchestrator, epic, routines, cli]
+paths: [".orbit/resources/activities/**", ".orbit/resources/jobs/**", ".orbit/routines/**"]
+related_features: [resident-orchestrator, routines, host-registry, mcp-bridge]
+related_artifacts: []
+---
+
+# Resident Orchestrator — Vision
+
+This document records directions that are intentionally outside the first CLI-backed resident
+cycle. The first release should prove that one workspace, one resident, one active epic, and
+durable task state are sufficient before adding routing or coordination machinery.
+
+## 1. Open Questions
+
+1. **Should pickup become event-driven?** Routines v1 deliberately use an OS clock and have no
+   event triggers. A future task-created event could reduce latency, but it would introduce a
+   resident process, webhook, or durable event consumer that the first design avoids.
+2. **Can one workspace support several residents?** Multiple specialists would require an explicit
+   routing key, capability declaration, and lease/claim semantics. Workspace plus `epic` is only
+   unambiguous while ownership is singular.
+3. **How should cross-workspace outcomes roll up?** A product epic spanning several repositories may
+   need a top-level constellation task that relates workspace-local epics without pretending their
+   local `parent_id` trees share one store.
+4. **Should resident health become first-class?** Operators may eventually need last successful
+   cycle, current epic, stalled duration, and identity/config mismatch surfaced alongside routine
+   health.
+5. **What is the right checkpoint artifact?** Parent comments are sufficient for v1. A structured
+   resident-cycle artifact could improve dashboards and replay, but risks duplicating task and run
+   state.
+6. **Should identity be promoted beyond an activity asset?** If many products need resident agents,
+   a typed resident profile may become worthwhile. It should be justified by repeated configuration
+   drift, not introduced before the activity-based canary.
+
+## 2. Prior Work
+
+### Orbit routines and jobs
+
+Routines already establish the desired scheduler boundary: the OS owns the clock, Orbit performs a
+stateless sweep, and a versioned routine targets a catalog job. Activity / Job provides CLI agent
+invocation and deterministic control flow. Resident orchestration composes those primitives rather
+than adding another scheduler.
+
+### Actor and queue systems
+
+Actor mailboxes and work queues demonstrate that an address plus a durable message can decouple
+senders from owners. The resident design borrows that separation but keeps the address at workspace
+granularity and the message as an ordinary Orbit task, avoiding another queue schema.
+
+### Hierarchical planning agents
+
+Planner/executor systems commonly decompose goals into leaf work. Orbit's distinction is intended
+to be operational rather than algorithmic: decomposition becomes parent/child tasks and
+dependencies, while shipment, review, and merge remain independently auditable workflows.
+
+## 3. What May Be Distinctive
+
+The individual ingredients are conventional. The potentially useful combination is that agent
+delegation, durable ownership, decomposition, and delivery evidence all reuse the repository's
+existing task and workflow model. The resident has a durable home and a specialized identity, but
+there is still no resident agent server. A CLI process can disappear after every cycle without
+losing the meaning or current state of the assignment.
+
+## 4. References
+
+**Orbit-internal**
+
+- [Resident Orchestrator design](./2_design.md)
+- [Activity / Job overview](../activity-job/1_overview.md)
+- [Routines design](../routines/2_design.md)
+- [Host Registry design](../host-registry/2_design.md)
+- [MCP Bridge design](../mcp-bridge/2_design.md)
+
+**External**
+
+- [The Actor Model](https://www.microsoft.com/en-us/research/publication/actors-a-model-of-concurrent-computation-in-distributed-systems/)
+- [Temporal durable execution](https://docs.temporal.io/temporal)
+
+## Task References
+
+- None yet — implementation tasks will be allocated after this Draft is accepted.
+
+> Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.

--- a/docs/design/resident-orchestrator/4_decisions.md
+++ b/docs/design/resident-orchestrator/4_decisions.md
@@ -1,0 +1,31 @@
+---
+title: Resident Orchestrator — Decisions
+owner: codex
+last_updated: 2026-07-17
+status: Draft
+feature: resident-orchestrator
+doc_role: decisions
+type: design
+summary: ADR log for workspace-addressed epic delegation and CLI-backed resident orchestration.
+tags: [resident-orchestrator, epic, routines, cli]
+paths: [".orbit/resources/activities/**", ".orbit/resources/jobs/**", ".orbit/routines/**"]
+related_features: [resident-orchestrator, activity-job, routines]
+related_artifacts: []
+---
+
+# Resident Orchestrator — Decisions
+
+ADR log for Resident Orchestrator. Entries are append-only and ordered by ascending global ID.
+Allocate every `ADR-NNNN` through `orbit.adr.add` before adding its heading. The store remains the
+source of truth for status, owner, related features, and related tasks.
+
+This folder is still Draft and has no allocated ADR. The candidate choices described in
+[2_design.md](./2_design.md)—workspace-addressed `epic` tasks, bounded CLI ownership cycles, and
+replacement rather than conversion of the HTTP epic pipeline—remain proposals until the design is
+accepted and implementation tasks are allocated.
+
+## Task References
+
+- None yet — implementation tasks will be allocated after this Draft is accepted.
+
+> Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.


### PR DESCRIPTION
## Summary

Defines workspace-addressed epic tasks, a bounded CLI resident ownership cycle, and workspace-local routine pickup. The resident owns decomposition, explicit child shipment, independent review and repair, merge verification, and parent closure. The design phases out task_epic_pipeline and its HTTP session-based activities and names Hohmann on ws_orbit as the first canary.

## Why

The front-door orchestrator can route work and generic runners can execute leaf mandates, but neither provides durable codebase-local shepherding. Orbit task state becomes the checkpoint, avoiding a per-agent server or retained HTTP model session.

## Validation

make ci-fast; git diff --check; generated docs index freshness.