### PR TITLE
Add hub host-registry core with permanent aliases and retirement

### DIFF
--- a/.orbit/adrs/accepted/ADR-0227/adr.yaml
+++ b/.orbit/adrs/accepted/ADR-0227/adr.yaml
@@ -5,12 +5,13 @@ status: accepted
 owner: codex
 created_at: 2026-07-17T07:03:20.499802205Z
 accepted_at: 2026-07-17T07:03:26.175980952Z
-last_updated: 2026-07-17T07:03:26.175980952Z
+last_updated: 2026-07-18T07:04:05.364678543Z
 related_features:
 - host-registry
 - mcp-bridge
 related_tasks:
 - ORB-10245
+- ORB-10255
 tags:
 - identity
 - registry

--- a/crates/orbit-common/src/types/host.rs
+++ b/crates/orbit-common/src/types/host.rs
@@ -1,0 +1,107 @@
+use std::collections::BTreeSet;
+use std::fmt;
+use std::str::FromStr;
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+/// Durable lifecycle state of a registered Orbit host.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum HostStatus {
+    Active,
+    Retired,
+}
+
+impl HostStatus {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Active => "active",
+            Self::Retired => "retired",
+        }
+    }
+}
+
+impl fmt::Display for HostStatus {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(self.as_str())
+    }
+}
+
+impl FromStr for HostStatus {
+    type Err = String;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "active" => Ok(Self::Active),
+            "retired" => Ok(Self::Retired),
+            other => Err(format!("unknown host status '{other}'")),
+        }
+    }
+}
+
+/// Stable fields supplied when a machine registers with the hub.
+///
+/// Registration timestamps and liveness are store-owned. Repeating this
+/// declaration is idempotent only while all three fields remain compatible.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct HostRegistration {
+    pub machine_id: String,
+    pub host_id: String,
+    #[serde(default)]
+    pub labels: BTreeSet<String>,
+}
+
+/// Durable host-registry projection. It intentionally contains no transport,
+/// credential, filesystem, or workspace-coordination fields.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct HostRecord {
+    pub machine_id: String,
+    pub host_id: String,
+    pub labels: BTreeSet<String>,
+    pub status: HostStatus,
+    pub registered_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+    pub retired_at: Option<DateTime<Utc>>,
+    /// Updated only by explicit registry operations. Audit traffic is never a
+    /// liveness source.
+    pub last_seen_at: Option<DateTime<Utc>>,
+}
+
+/// One permanent historical name for a registered machine.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct HostAlias {
+    pub alias_host_id: String,
+    pub machine_id: String,
+    pub created_at: DateTime<Utc>,
+    pub warning: String,
+}
+
+/// Typed result of resolving a human-authored host name.
+///
+/// The `Retired` variant is returned for both a retired host's current name
+/// and its old aliases. `Collision` is retained as an explicit fail-closed
+/// outcome even though the current schema and typed mutations prevent it; it
+/// keeps callers safe if externally modified or legacy data is inconsistent.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum HostNameResolution {
+    Active {
+        host: HostRecord,
+    },
+    Alias {
+        host: HostRecord,
+        alias: HostAlias,
+    },
+    Retired {
+        host: HostRecord,
+        alias: Option<HostAlias>,
+    },
+    Unknown {
+        host_id: String,
+    },
+    Collision {
+        host_id: String,
+        machine_ids: Vec<String>,
+    },
+}

--- a/crates/orbit-common/src/types/mod.rs
+++ b/crates/orbit-common/src/types/mod.rs
@@ -35,6 +35,7 @@ pub mod error;
 pub mod event;
 pub mod executor_def;
 pub mod friction;
+pub mod host;
 pub mod id;
 pub mod invocation;
 pub mod job;
@@ -97,6 +98,7 @@ pub use executor_def::{
     ExecutorDef, ExecutorSandboxKind, ExecutorType, ModelPairOverride, StdoutFormat,
 };
 pub use friction::{FrictionEntry, FrictionFrontmatter, FrictionRecord, FrictionStatus};
+pub use host::{HostAlias, HostNameResolution, HostRecord, HostRegistration, HostStatus};
 pub use id::OrbitId;
 pub use invocation::{InvocationTrace, TokenUsage, ToolCallTrace};
 pub use job::{

--- a/crates/orbit-common/src/types/tests/host.rs
+++ b/crates/orbit-common/src/types/tests/host.rs
@@ -1,0 +1,87 @@
+use std::collections::BTreeSet;
+
+use chrono::{TimeZone, Utc};
+use serde_json::json;
+
+use crate::types::{HostAlias, HostNameResolution, HostRecord, HostStatus};
+
+fn host() -> HostRecord {
+    let timestamp = Utc
+        .with_ymd_and_hms(2026, 7, 18, 6, 0, 0)
+        .single()
+        .expect("fixed timestamp");
+    HostRecord {
+        machine_id: "hm_alpha".to_string(),
+        host_id: "alpha".to_string(),
+        labels: BTreeSet::from(["codex".to_string(), "os:linux".to_string()]),
+        status: HostStatus::Active,
+        registered_at: timestamp,
+        updated_at: timestamp,
+        retired_at: None,
+        last_seen_at: Some(timestamp),
+    }
+}
+
+#[test]
+fn host_projection_serializes_only_registry_core_fields() {
+    let value = serde_json::to_value(host()).expect("serialize host");
+    assert_eq!(
+        value,
+        json!({
+            "machine_id": "hm_alpha",
+            "host_id": "alpha",
+            "labels": ["codex", "os:linux"],
+            "status": "active",
+            "registered_at": "2026-07-18T06:00:00Z",
+            "updated_at": "2026-07-18T06:00:00Z",
+            "retired_at": null,
+            "last_seen_at": "2026-07-18T06:00:00Z"
+        })
+    );
+    let serialized = value.to_string();
+    for forbidden in [
+        "credential",
+        "secret",
+        "ssh",
+        "workspace",
+        "repo_root",
+        "orbit_dir",
+        "transport",
+        "target",
+    ] {
+        assert!(
+            !serialized.contains(forbidden),
+            "host projection must not expose {forbidden}"
+        );
+    }
+}
+
+#[test]
+fn alias_and_retired_resolution_keep_warning_and_lifecycle_metadata() {
+    let mut retired = host();
+    retired.status = HostStatus::Retired;
+    retired.retired_at = Some(retired.updated_at);
+    let alias = HostAlias {
+        alias_host_id: "alpha-old".to_string(),
+        machine_id: retired.machine_id.clone(),
+        created_at: retired.registered_at,
+        warning: "permanent tombstone alias".to_string(),
+    };
+
+    let resolution = HostNameResolution::Retired {
+        host: retired,
+        alias: Some(alias),
+    };
+    let value = serde_json::to_value(resolution).expect("serialize resolution");
+    assert_eq!(value["kind"], "retired");
+    assert_eq!(value["alias"]["alias_host_id"], "alpha-old");
+    assert_eq!(value["alias"]["warning"], "permanent tombstone alias");
+}
+
+#[test]
+fn status_parse_and_display_round_trip() {
+    for status in [HostStatus::Active, HostStatus::Retired] {
+        assert_eq!(status.to_string().parse::<HostStatus>(), Ok(status));
+    }
+    assert!("unknown".parse::<HostStatus>().is_err());
+}

--- a/crates/orbit-common/src/types/tests/mod.rs
+++ b/crates/orbit-common/src/types/tests/mod.rs
@@ -6,6 +6,7 @@ mod audit_event;
 mod error;
 mod executor_def;
 mod friction;
+mod host;
 mod job;
 mod learning;
 mod resource;

--- a/crates/orbit-core/src/host_registry.rs
+++ b/crates/orbit-core/src/host_registry.rs
@@ -1,0 +1,63 @@
+//! Typed core service for the hub host registry [ORB-10255].
+//!
+//! This layer binds B1's stable local [`HostIdentity`] declaration to the
+//! durable hub-store API. It intentionally does not coordinate local
+//! `host.toml` renames, expose administration commands, or add transport;
+//! those surfaces belong to the later registry-administration unit.
+
+use std::collections::BTreeSet;
+
+use orbit_common::types::{
+    HostAlias, HostNameResolution, HostRecord, HostRegistration, OrbitError,
+};
+use orbit_store::Store;
+
+use crate::routines::HostIdentity;
+
+#[derive(Clone)]
+pub struct HostRegistryService {
+    store: Store,
+}
+
+impl HostRegistryService {
+    pub fn new(store: Store) -> Self {
+        Self { store }
+    }
+
+    /// Register B1's stable machine identity with a compatible label set.
+    pub fn register_identity(
+        &self,
+        identity: &HostIdentity,
+        labels: BTreeSet<String>,
+    ) -> Result<HostRecord, OrbitError> {
+        self.store.register_host(&HostRegistration {
+            machine_id: identity.machine_id.clone(),
+            host_id: identity.host_id.clone(),
+            labels,
+        })
+    }
+
+    pub fn rename(&self, machine_id: &str, new_host_id: &str) -> Result<HostRecord, OrbitError> {
+        self.store.rename_host(machine_id, new_host_id)
+    }
+
+    pub fn retire(&self, machine_id: &str) -> Result<HostRecord, OrbitError> {
+        self.store.retire_host(machine_id)
+    }
+
+    pub fn resolve(&self, host_id: &str) -> Result<HostNameResolution, OrbitError> {
+        self.store.resolve_host_id(host_id)
+    }
+
+    pub fn active_hosts(&self) -> Result<Vec<HostRecord>, OrbitError> {
+        self.store.list_active_hosts()
+    }
+
+    pub fn aliases(&self, machine_id: &str) -> Result<Vec<HostAlias>, OrbitError> {
+        self.store.list_host_aliases(machine_id)
+    }
+}
+
+#[cfg(test)]
+#[path = "tests/host_registry.rs"]
+mod tests;

--- a/crates/orbit-core/src/lib.rs
+++ b/crates/orbit-core/src/lib.rs
@@ -48,6 +48,7 @@ pub mod auto_tasks;
 pub mod command;
 pub mod config;
 pub mod context;
+pub mod host_registry;
 pub mod metrics;
 mod paths;
 pub mod routines;
@@ -73,14 +74,16 @@ pub use command::search::{
 };
 pub use command::workflow::{ShipMode, build_ship_input, find_workflow, resolved_ship_mode};
 pub use context::ActorIdentity;
+pub use host_registry::HostRegistryService;
 // Shared domain types (owned by orbit-common) that the CLI and dashboard
 // render or construct.
 pub use auto_tasks::{AutoTaskAddParams, AutoTaskUpdateParams};
 pub use orbit_common::types::{
     AuditEvent, AuditEventStatus, AuditStats, AutoTaskDefinition, AutoTaskSchedule,
-    AutoTaskTemplate, DedupePolicy, EvidenceKind, ExecutorDef, ExternalRef, JobRun, JobRunState,
-    JobRunStep, JobTargetType, Learning, LearningEvidence, LearningScope, LearningStatus,
-    ReviewThreadStatus, Task, TaskComplexity, TaskCreateStatus, TaskPriority, TaskStatus, TaskType,
+    AutoTaskTemplate, DedupePolicy, EvidenceKind, ExecutorDef, ExternalRef, HostAlias,
+    HostNameResolution, HostRecord, HostRegistration, HostStatus, JobRun, JobRunState, JobRunStep,
+    JobTargetType, Learning, LearningEvidence, LearningScope, LearningStatus, ReviewThreadStatus,
+    Task, TaskComplexity, TaskCreateStatus, TaskPriority, TaskStatus, TaskType,
     build_task_status_index, resolve_task_dependencies, task_dependencies_ready,
 };
 pub use orbit_common::types::{MissedRunPolicy, NotFoundKind, OrbitError, OverlapPolicy};

--- a/crates/orbit-core/src/tests/host_registry.rs
+++ b/crates/orbit-core/src/tests/host_registry.rs
@@ -1,0 +1,59 @@
+use std::collections::BTreeSet;
+
+use orbit_common::types::{HostNameResolution, HostStatus};
+use orbit_store::Store;
+
+use super::HostRegistryService;
+use crate::routines::{HOST_IDENTITY_SCHEMA_VERSION, HostIdentity, HostMode};
+
+fn identity(machine_id: &str, host_id: &str, mode: HostMode) -> HostIdentity {
+    HostIdentity {
+        schema_version: HOST_IDENTITY_SCHEMA_VERSION,
+        machine_id: machine_id.to_string(),
+        host_id: host_id.to_string(),
+        mode,
+    }
+}
+
+#[test]
+fn service_registers_stable_identity_and_preserves_typed_lifecycle_results() {
+    let service = HostRegistryService::new(Store::open_in_memory().expect("store"));
+    let hub = identity("hm_hub", "hub", HostMode::Hub);
+    let spoke = identity("hm_spoke", "spoke", HostMode::Spoke);
+
+    let registered = service
+        .register_identity(&hub, BTreeSet::from(["codex".to_string()]))
+        .expect("register hub");
+    assert_eq!(registered.machine_id, hub.machine_id);
+    assert_eq!(registered.host_id, hub.host_id);
+    assert_eq!(registered.status, HostStatus::Active);
+    assert_eq!(
+        service
+            .register_identity(&hub, BTreeSet::from(["codex".to_string()]))
+            .expect("idempotent registration"),
+        registered
+    );
+    service
+        .register_identity(&spoke, BTreeSet::new())
+        .expect("register spoke");
+
+    service.rename("hm_spoke", "worker").expect("rename");
+    match service.resolve("spoke").expect("resolve alias") {
+        HostNameResolution::Alias { host, alias } => {
+            assert_eq!(host.host_id, "worker");
+            assert_eq!(alias.alias_host_id, "spoke");
+        }
+        other => panic!("expected alias, got {other:?}"),
+    }
+    service.retire("hm_spoke").expect("retire");
+    assert_eq!(
+        service
+            .active_hosts()
+            .expect("active hosts")
+            .iter()
+            .map(|host| host.host_id.as_str())
+            .collect::<Vec<_>>(),
+        vec!["hub"]
+    );
+    assert_eq!(service.aliases("hm_spoke").expect("aliases").len(), 1);
+}

--- a/crates/orbit-store/src/lib.rs
+++ b/crates/orbit-store/src/lib.rs
@@ -137,6 +137,9 @@ pub use backend::{
 };
 pub use file_lock::{LockHolderInfo, read_lock_holder};
 pub use json_schema::{validate_instance_against_schema, validate_schema_document};
+pub use orbit_common::types::{
+    HostAlias, HostNameResolution, HostRecord, HostRegistration, HostStatus,
+};
 pub use sqlite::audit_event_store::{
     AuditEventFilter, AuditEventInsertParams, AuditRoleAggregate, AuditToolAggregate,
     AuditToolCallCountsByRole, AuditToolCallCountsBySurfaceAndRole, AuditTopToolCall,

--- a/crates/orbit-store/src/sqlite/host_registry.rs
+++ b/crates/orbit-store/src/sqlite/host_registry.rs
@@ -1,0 +1,533 @@
+//! Durable host-registry core for the coordination hub [ORB-10255].
+//!
+//! The registry keys machines by immutable `machine_id`, keeps every current
+//! and historical human `host_id` reserved forever, and records retirement
+//! without deleting identity. Registration, rename, and retirement use
+//! `BEGIN IMMEDIATE` transactions so collision preflight and mutation share a
+//! single writer boundary.
+
+use std::collections::BTreeSet;
+use std::str::FromStr;
+
+use orbit_common::types::{
+    HostAlias, HostNameResolution, HostRecord, HostRegistration, HostStatus, OrbitError,
+};
+use rusqlite::{Connection, OptionalExtension, TransactionBehavior, params};
+
+use crate::Store;
+
+const HOST_COLUMNS: &str = "machine_id, host_id, labels_json, status, registered_at, \
+                            updated_at, retired_at, last_seen_at";
+const ALIAS_COLUMNS: &str = "host_id, machine_id, created_at, warning";
+
+impl Store {
+    /// Register a stable machine declaration. Repeating an active declaration
+    /// with the same name and labels returns the existing row without changing
+    /// timestamps. A changed name, changed labels, or retired row is an
+    /// incompatible declaration and cannot silently rename/reactivate it.
+    pub fn register_host(&self, registration: &HostRegistration) -> Result<HostRecord, OrbitError> {
+        validate_registration(registration)?;
+        self.with_transaction_behavior(TransactionBehavior::Immediate, |tx| {
+            if let Some(existing) = host_by_machine_id(&tx.tx, &registration.machine_id)? {
+                ensure_compatible_registration(&existing, registration)?;
+                return Ok(existing);
+            }
+
+            ensure_name_available(&tx.tx, &registration.host_id)?;
+            let now = crate::now_string();
+            let labels_json = serde_json::to_string(&registration.labels)
+                .map_err(|error| OrbitError::Store(error.to_string()))?;
+            tx.tx
+                .execute(
+                    "INSERT INTO hosts(
+                        machine_id, host_id, labels_json, status, registered_at,
+                        updated_at, retired_at, last_seen_at
+                     ) VALUES (?1, ?2, ?3, ?4, ?5, ?5, NULL, ?5)",
+                    params![
+                        registration.machine_id,
+                        registration.host_id,
+                        labels_json,
+                        HostStatus::Active.as_str(),
+                        now,
+                    ],
+                )
+                .map_err(|error| host_mutation_error("register", &registration.host_id, error))?;
+
+            host_by_machine_id(&tx.tx, &registration.machine_id)?.ok_or_else(|| {
+                OrbitError::Store(format!(
+                    "registered host_id '{}' but could not read it back",
+                    registration.host_id
+                ))
+            })
+        })
+    }
+
+    /// Rename an active machine and atomically preserve its old name as a
+    /// permanent tombstone alias. Renaming to its current name is a no-op;
+    /// every other current, retired, or alias name is unavailable.
+    pub fn rename_host(
+        &self,
+        machine_id: &str,
+        new_host_id: &str,
+    ) -> Result<HostRecord, OrbitError> {
+        validate_machine_id(machine_id)?;
+        validate_host_id(new_host_id)?;
+        self.with_transaction_behavior(TransactionBehavior::Immediate, |tx| {
+            let existing = host_by_machine_id(&tx.tx, machine_id)?.ok_or_else(|| {
+                OrbitError::InvalidInput(format!(
+                    "cannot rename unknown host machine_id '{machine_id}'"
+                ))
+            })?;
+            if existing.status == HostStatus::Retired {
+                return Err(OrbitError::InvalidInput(format!(
+                    "host_id '{}' is retired and cannot be renamed",
+                    existing.host_id
+                )));
+            }
+            if existing.host_id == new_host_id {
+                return Ok(existing);
+            }
+            ensure_name_available(&tx.tx, new_host_id)?;
+
+            let old_host_id = existing.host_id;
+            let now = crate::now_string();
+            tx.tx
+                .execute(
+                    "UPDATE hosts SET host_id = ?2, updated_at = ?3 WHERE machine_id = ?1",
+                    params![machine_id, new_host_id, now],
+                )
+                .map_err(|error| host_mutation_error("rename", new_host_id, error))?;
+            let warning = format!(
+                "host_id '{old_host_id}' is a permanent tombstone alias for machine_id \
+                 '{machine_id}' and cannot be reused"
+            );
+            tx.tx
+                .execute(
+                    "INSERT INTO host_aliases(host_id, machine_id, created_at, warning)
+                     VALUES (?1, ?2, ?3, ?4)",
+                    params![old_host_id, machine_id, now, warning],
+                )
+                .map_err(|error| host_mutation_error("preserve alias", &old_host_id, error))?;
+
+            host_by_machine_id(&tx.tx, machine_id)?.ok_or_else(|| {
+                OrbitError::Store(format!(
+                    "renamed host_id '{old_host_id}' but could not read machine_id \
+                     '{machine_id}' back"
+                ))
+            })
+        })
+    }
+
+    /// Retire a machine without deleting its identity or aliases. Repeating a
+    /// retirement returns the existing row without moving lifecycle times.
+    pub fn retire_host(&self, machine_id: &str) -> Result<HostRecord, OrbitError> {
+        validate_machine_id(machine_id)?;
+        self.with_transaction_behavior(TransactionBehavior::Immediate, |tx| {
+            let existing = host_by_machine_id(&tx.tx, machine_id)?.ok_or_else(|| {
+                OrbitError::InvalidInput(format!(
+                    "cannot retire unknown host machine_id '{machine_id}'"
+                ))
+            })?;
+            if existing.status == HostStatus::Retired {
+                return Ok(existing);
+            }
+            let now = crate::now_string();
+            tx.tx
+                .execute(
+                    "UPDATE hosts
+                     SET status = ?2, retired_at = ?3, updated_at = ?3
+                     WHERE machine_id = ?1",
+                    params![machine_id, HostStatus::Retired.as_str(), now],
+                )
+                .map_err(|error| host_mutation_error("retire", &existing.host_id, error))?;
+            host_by_machine_id(&tx.tx, machine_id)?.ok_or_else(|| {
+                OrbitError::Store(format!(
+                    "retired host_id '{}' but could not read it back",
+                    existing.host_id
+                ))
+            })
+        })
+    }
+
+    /// Look up one machine by its immutable ID.
+    pub fn get_host(&self, machine_id: &str) -> Result<Option<HostRecord>, OrbitError> {
+        validate_machine_id(machine_id)?;
+        let conn = self.read()?;
+        host_by_machine_id(&conn, machine_id)
+    }
+
+    /// Enumerate active machines in stable human-name order. Retired rows stay
+    /// durable but are deliberately absent from this projection.
+    pub fn list_active_hosts(&self) -> Result<Vec<HostRecord>, OrbitError> {
+        let conn = self.read()?;
+        let mut statement = conn
+            .prepare(&format!(
+                "SELECT {HOST_COLUMNS} FROM hosts WHERE status = ?1 ORDER BY host_id ASC"
+            ))
+            .map_err(|error| OrbitError::Store(error.to_string()))?;
+        let rows = statement
+            .query_map([HostStatus::Active.as_str()], host_row)
+            .map_err(|error| OrbitError::Store(error.to_string()))?;
+        collect_hosts(rows)
+    }
+
+    /// List the permanent name history of a machine, oldest first.
+    pub fn list_host_aliases(&self, machine_id: &str) -> Result<Vec<HostAlias>, OrbitError> {
+        validate_machine_id(machine_id)?;
+        let conn = self.read()?;
+        let mut statement = conn
+            .prepare(&format!(
+                "SELECT {ALIAS_COLUMNS} FROM host_aliases
+                 WHERE machine_id = ?1 ORDER BY created_at ASC, host_id ASC"
+            ))
+            .map_err(|error| OrbitError::Store(error.to_string()))?;
+        let rows = statement
+            .query_map([machine_id], alias_row)
+            .map_err(|error| OrbitError::Store(error.to_string()))?;
+        collect_aliases(rows)
+    }
+
+    /// Resolve a current or historical human name without guessing. Retired
+    /// machines remain resolvable, aliases retain warning metadata, unknown is
+    /// explicit, and inconsistent cross-table matches fail closed as a typed
+    /// collision outcome.
+    pub fn resolve_host_id(&self, host_id: &str) -> Result<HostNameResolution, OrbitError> {
+        validate_host_id(host_id)?;
+        let conn = self.read()?;
+        let mut statement = conn
+            .prepare(
+                "SELECT
+                    h.machine_id, h.host_id, h.labels_json, h.status,
+                    h.registered_at, h.updated_at, h.retired_at, h.last_seen_at,
+                    NULL, NULL, NULL, NULL
+                 FROM hosts h WHERE h.host_id = ?1
+                 UNION ALL
+                 SELECT
+                    h.machine_id, h.host_id, h.labels_json, h.status,
+                    h.registered_at, h.updated_at, h.retired_at, h.last_seen_at,
+                    a.host_id, a.machine_id, a.created_at, a.warning
+                 FROM host_aliases a
+                 JOIN hosts h ON h.machine_id = a.machine_id
+                 WHERE a.host_id = ?1",
+            )
+            .map_err(|error| OrbitError::Store(error.to_string()))?;
+        let rows = statement
+            .query_map([host_id], resolution_row)
+            .map_err(|error| OrbitError::Store(error.to_string()))?;
+        let mut matches = Vec::new();
+        for row in rows {
+            let raw = row.map_err(|error| OrbitError::Store(error.to_string()))?;
+            matches.push((
+                HostRecord::try_from(raw.host)?,
+                raw.alias.map(HostAlias::try_from).transpose()?,
+            ));
+        }
+
+        if matches.is_empty() {
+            return Ok(HostNameResolution::Unknown {
+                host_id: host_id.to_string(),
+            });
+        }
+        if matches.len() > 1 {
+            let mut machine_ids: Vec<String> = matches
+                .into_iter()
+                .map(|(host, _)| host.machine_id)
+                .collect();
+            machine_ids.sort();
+            machine_ids.dedup();
+            return Ok(HostNameResolution::Collision {
+                host_id: host_id.to_string(),
+                machine_ids,
+            });
+        }
+
+        let (host, alias) = matches.pop().ok_or_else(|| {
+            OrbitError::Store(format!(
+                "host_id '{host_id}' resolution lost its only match"
+            ))
+        })?;
+        match (host.status, alias) {
+            (HostStatus::Active, None) => Ok(HostNameResolution::Active { host }),
+            (HostStatus::Active, Some(alias)) => Ok(HostNameResolution::Alias { host, alias }),
+            (HostStatus::Retired, alias) => Ok(HostNameResolution::Retired { host, alias }),
+        }
+    }
+}
+
+fn validate_registration(registration: &HostRegistration) -> Result<(), OrbitError> {
+    validate_machine_id(&registration.machine_id)?;
+    validate_host_id(&registration.host_id)?;
+    for label in &registration.labels {
+        validate_registry_text("host label", label)?;
+    }
+    Ok(())
+}
+
+fn validate_machine_id(machine_id: &str) -> Result<(), OrbitError> {
+    validate_registry_text("machine_id", machine_id)
+}
+
+fn validate_host_id(host_id: &str) -> Result<(), OrbitError> {
+    validate_registry_text("host_id", host_id)
+}
+
+fn validate_registry_text(field: &str, value: &str) -> Result<(), OrbitError> {
+    if value.is_empty() {
+        return Err(OrbitError::InvalidInput(format!(
+            "{field} must not be empty"
+        )));
+    }
+    if value.trim() != value {
+        return Err(OrbitError::InvalidInput(format!(
+            "{field} must not contain leading or trailing whitespace"
+        )));
+    }
+    if value.len() > 128 {
+        return Err(OrbitError::InvalidInput(format!(
+            "{field} must not exceed 128 bytes"
+        )));
+    }
+    if value.chars().any(char::is_control) || value.contains(['/', '\\']) {
+        return Err(OrbitError::InvalidInput(format!(
+            "{field} must be a logical registry identifier, not a path"
+        )));
+    }
+    Ok(())
+}
+
+fn ensure_compatible_registration(
+    existing: &HostRecord,
+    registration: &HostRegistration,
+) -> Result<(), OrbitError> {
+    if existing.status == HostStatus::Retired {
+        return Err(OrbitError::InvalidInput(format!(
+            "host_id '{}' for machine_id '{}' is retired; re-registration cannot reactivate it",
+            existing.host_id, existing.machine_id
+        )));
+    }
+    if existing.host_id != registration.host_id {
+        return Err(OrbitError::InvalidInput(format!(
+            "machine_id '{}' is already registered as host_id '{}'; re-registration cannot \
+             rename it to '{}' (use explicit rename)",
+            existing.machine_id, existing.host_id, registration.host_id
+        )));
+    }
+    if existing.labels != registration.labels {
+        return Err(OrbitError::InvalidInput(format!(
+            "host_id '{}' for machine_id '{}' is already registered with a different label \
+             declaration",
+            existing.host_id, existing.machine_id
+        )));
+    }
+    Ok(())
+}
+
+fn ensure_name_available(conn: &Connection, host_id: &str) -> Result<(), OrbitError> {
+    if let Some(host) = host_by_host_id(conn, host_id)? {
+        let lifecycle = if host.status == HostStatus::Retired {
+            "retired"
+        } else {
+            "active"
+        };
+        return Err(OrbitError::InvalidInput(format!(
+            "host_id '{host_id}' is already reserved by {lifecycle} machine_id '{}' and cannot \
+             be reused",
+            host.machine_id
+        )));
+    }
+    if let Some(alias) = alias_by_host_id(conn, host_id)? {
+        return Err(OrbitError::InvalidInput(format!(
+            "host_id '{host_id}' is a permanent tombstone alias for machine_id '{}' and cannot \
+             be reclaimed",
+            alias.machine_id
+        )));
+    }
+    Ok(())
+}
+
+fn host_by_machine_id(
+    conn: &Connection,
+    machine_id: &str,
+) -> Result<Option<HostRecord>, OrbitError> {
+    conn.query_row(
+        &format!("SELECT {HOST_COLUMNS} FROM hosts WHERE machine_id = ?1"),
+        [machine_id],
+        host_row,
+    )
+    .optional()
+    .map_err(|error| OrbitError::Store(error.to_string()))?
+    .map(HostRecord::try_from)
+    .transpose()
+}
+
+fn host_by_host_id(conn: &Connection, host_id: &str) -> Result<Option<HostRecord>, OrbitError> {
+    conn.query_row(
+        &format!("SELECT {HOST_COLUMNS} FROM hosts WHERE host_id = ?1"),
+        [host_id],
+        host_row,
+    )
+    .optional()
+    .map_err(|error| OrbitError::Store(error.to_string()))?
+    .map(HostRecord::try_from)
+    .transpose()
+}
+
+fn alias_by_host_id(conn: &Connection, host_id: &str) -> Result<Option<HostAlias>, OrbitError> {
+    conn.query_row(
+        &format!("SELECT {ALIAS_COLUMNS} FROM host_aliases WHERE host_id = ?1"),
+        [host_id],
+        alias_row,
+    )
+    .optional()
+    .map_err(|error| OrbitError::Store(error.to_string()))?
+    .map(HostAlias::try_from)
+    .transpose()
+}
+
+struct RawHostRow {
+    machine_id: String,
+    host_id: String,
+    labels_json: String,
+    status: String,
+    registered_at: String,
+    updated_at: String,
+    retired_at: Option<String>,
+    last_seen_at: Option<String>,
+}
+
+fn host_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<RawHostRow> {
+    Ok(RawHostRow {
+        machine_id: row.get(0)?,
+        host_id: row.get(1)?,
+        labels_json: row.get(2)?,
+        status: row.get(3)?,
+        registered_at: row.get(4)?,
+        updated_at: row.get(5)?,
+        retired_at: row.get(6)?,
+        last_seen_at: row.get(7)?,
+    })
+}
+
+impl TryFrom<RawHostRow> for HostRecord {
+    type Error = OrbitError;
+
+    fn try_from(row: RawHostRow) -> Result<Self, Self::Error> {
+        let labels: BTreeSet<String> = serde_json::from_str(&row.labels_json).map_err(|error| {
+            OrbitError::Store(format!(
+                "host_id '{}' has invalid labels_json: {error}",
+                row.host_id
+            ))
+        })?;
+        let status = HostStatus::from_str(&row.status)
+            .map_err(|error| OrbitError::Store(format!("host_id '{}': {error}", row.host_id)))?;
+        Ok(Self {
+            machine_id: row.machine_id,
+            host_id: row.host_id,
+            labels,
+            status,
+            registered_at: crate::parse_timestamp(&row.registered_at)
+                .map_err(|error| OrbitError::Store(error.to_string()))?,
+            updated_at: crate::parse_timestamp(&row.updated_at)
+                .map_err(|error| OrbitError::Store(error.to_string()))?,
+            retired_at: parse_optional_timestamp(row.retired_at)?,
+            last_seen_at: parse_optional_timestamp(row.last_seen_at)?,
+        })
+    }
+}
+
+struct RawAliasRow {
+    host_id: String,
+    machine_id: String,
+    created_at: String,
+    warning: String,
+}
+
+struct RawResolutionRow {
+    host: RawHostRow,
+    alias: Option<RawAliasRow>,
+}
+
+fn resolution_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<RawResolutionRow> {
+    let alias_host_id: Option<String> = row.get(8)?;
+    let alias = match alias_host_id {
+        Some(host_id) => Some(RawAliasRow {
+            host_id,
+            machine_id: row.get(9)?,
+            created_at: row.get(10)?,
+            warning: row.get(11)?,
+        }),
+        None => None,
+    };
+    Ok(RawResolutionRow {
+        host: RawHostRow {
+            machine_id: row.get(0)?,
+            host_id: row.get(1)?,
+            labels_json: row.get(2)?,
+            status: row.get(3)?,
+            registered_at: row.get(4)?,
+            updated_at: row.get(5)?,
+            retired_at: row.get(6)?,
+            last_seen_at: row.get(7)?,
+        },
+        alias,
+    })
+}
+
+fn alias_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<RawAliasRow> {
+    Ok(RawAliasRow {
+        host_id: row.get(0)?,
+        machine_id: row.get(1)?,
+        created_at: row.get(2)?,
+        warning: row.get(3)?,
+    })
+}
+
+impl TryFrom<RawAliasRow> for HostAlias {
+    type Error = OrbitError;
+
+    fn try_from(row: RawAliasRow) -> Result<Self, Self::Error> {
+        Ok(Self {
+            alias_host_id: row.host_id,
+            machine_id: row.machine_id,
+            created_at: crate::parse_timestamp(&row.created_at)
+                .map_err(|error| OrbitError::Store(error.to_string()))?,
+            warning: row.warning,
+        })
+    }
+}
+
+fn parse_optional_timestamp(
+    value: Option<String>,
+) -> Result<Option<chrono::DateTime<chrono::Utc>>, OrbitError> {
+    value
+        .map(|value| {
+            crate::parse_timestamp(&value).map_err(|error| OrbitError::Store(error.to_string()))
+        })
+        .transpose()
+}
+
+fn collect_hosts(
+    rows: impl Iterator<Item = rusqlite::Result<RawHostRow>>,
+) -> Result<Vec<HostRecord>, OrbitError> {
+    rows.map(|row| {
+        row.map_err(|error| OrbitError::Store(error.to_string()))?
+            .try_into()
+    })
+    .collect()
+}
+
+fn collect_aliases(
+    rows: impl Iterator<Item = rusqlite::Result<RawAliasRow>>,
+) -> Result<Vec<HostAlias>, OrbitError> {
+    rows.map(|row| {
+        row.map_err(|error| OrbitError::Store(error.to_string()))?
+            .try_into()
+    })
+    .collect()
+}
+
+fn host_mutation_error(operation: &str, host_id: &str, error: rusqlite::Error) -> OrbitError {
+    OrbitError::Store(format!(
+        "failed to {operation} host_id '{host_id}': {error}"
+    ))
+}

--- a/crates/orbit-store/src/sqlite/migration/ledger.rs
+++ b/crates/orbit-store/src/sqlite/migration/ledger.rs
@@ -53,12 +53,17 @@ pub(crate) const MIGRATIONS: &[Migration] = &[
         name: "job_run_archive_stage",
         apply: super::apply_job_run_archive_stage,
     },
+    Migration {
+        version: 5,
+        name: "host_registry_core",
+        apply: super::apply_host_registry_core,
+    },
 ];
 
 /// Highest schema version this binary knows how to produce. Public for
 /// the future `orbit migrate` surface (P3.4), alongside
 /// [`AppliedMigration`] and the `Store` version accessors.
-pub const SUPPORTED_SCHEMA_VERSION: u32 = 4;
+pub const SUPPORTED_SCHEMA_VERSION: u32 = 5;
 
 const LEDGER_KEY_PREFIX: &str = "migration.v";
 

--- a/crates/orbit-store/src/sqlite/migration/mod.rs
+++ b/crates/orbit-store/src/sqlite/migration/mod.rs
@@ -710,6 +710,92 @@ fn apply_job_run_archive_stage(conn: &Connection) -> Result<(), OrbitError> {
     add_column_if_missing(conn, "ALTER TABLE job_runs ADD COLUMN archived_at TEXT")
 }
 
+/// v5 `host_registry_core` migration (ORB-10255): durable machine identity,
+/// lifecycle state, and immutable historical names in the hub-global store.
+///
+/// This migration is strictly additive. Cross-table triggers backstop the
+/// typed API's preflight so a current or tombstoned `host_id` can never exist
+/// for two machines, even when the database is modified outside that API.
+fn apply_host_registry_core(conn: &Connection) -> Result<(), OrbitError> {
+    conn.execute_batch(
+        r#"
+            CREATE TABLE IF NOT EXISTS hosts (
+                machine_id    TEXT PRIMARY KEY,
+                host_id       TEXT NOT NULL UNIQUE,
+                labels_json   TEXT NOT NULL DEFAULT '[]',
+                status        TEXT NOT NULL CHECK (status IN ('active', 'retired')),
+                registered_at TEXT NOT NULL,
+                updated_at    TEXT NOT NULL,
+                retired_at    TEXT,
+                last_seen_at  TEXT,
+                CHECK (length(machine_id) > 0),
+                CHECK (length(host_id) > 0),
+                CHECK (json_valid(labels_json) AND json_type(labels_json) = 'array'),
+                CHECK (
+                    (status = 'active' AND retired_at IS NULL)
+                    OR (status = 'retired' AND retired_at IS NOT NULL)
+                )
+            );
+
+            CREATE TABLE IF NOT EXISTS host_aliases (
+                host_id    TEXT PRIMARY KEY,
+                machine_id TEXT NOT NULL,
+                created_at TEXT NOT NULL,
+                warning    TEXT NOT NULL,
+                CHECK (length(host_id) > 0),
+                CHECK (length(warning) > 0),
+                FOREIGN KEY(machine_id) REFERENCES hosts(machine_id)
+                    ON UPDATE RESTRICT ON DELETE RESTRICT
+            );
+
+            CREATE INDEX IF NOT EXISTS idx_hosts_status_host_id
+                ON hosts(status, host_id);
+            CREATE INDEX IF NOT EXISTS idx_host_aliases_machine_id
+                ON host_aliases(machine_id, created_at);
+
+            CREATE TRIGGER IF NOT EXISTS hosts_host_id_not_alias_insert
+            BEFORE INSERT ON hosts
+            WHEN EXISTS (
+                SELECT 1 FROM host_aliases WHERE host_id = NEW.host_id
+            )
+            BEGIN
+                SELECT RAISE(ABORT, 'host_id is reserved by a permanent alias');
+            END;
+
+            CREATE TRIGGER IF NOT EXISTS hosts_host_id_not_alias_update
+            BEFORE UPDATE OF host_id ON hosts
+            WHEN EXISTS (
+                SELECT 1 FROM host_aliases WHERE host_id = NEW.host_id
+            )
+            BEGIN
+                SELECT RAISE(ABORT, 'host_id is reserved by a permanent alias');
+            END;
+
+            CREATE TRIGGER IF NOT EXISTS host_alias_not_current_name_insert
+            BEFORE INSERT ON host_aliases
+            WHEN EXISTS (
+                SELECT 1 FROM hosts WHERE host_id = NEW.host_id
+            )
+            BEGIN
+                SELECT RAISE(ABORT, 'host alias conflicts with a current host_id');
+            END;
+
+            CREATE TRIGGER IF NOT EXISTS host_aliases_immutable_update
+            BEFORE UPDATE ON host_aliases
+            BEGIN
+                SELECT RAISE(ABORT, 'host aliases are immutable');
+            END;
+
+            CREATE TRIGGER IF NOT EXISTS host_aliases_immutable_delete
+            BEFORE DELETE ON host_aliases
+            BEGIN
+                SELECT RAISE(ABORT, 'host aliases are permanent');
+            END;
+        "#,
+    )
+    .map_err(|error| OrbitError::Store(error.to_string()))
+}
+
 fn ensure_task_reservations_schema(conn: &Connection) -> Result<(), OrbitError> {
     conn.execute_batch(
         r#"

--- a/crates/orbit-store/src/sqlite/migration/tests/ledger.rs
+++ b/crates/orbit-store/src/sqlite/migration/tests/ledger.rs
@@ -43,6 +43,9 @@ fn fresh_db_applies_baseline_and_records_ledger() {
     assert_eq!(applied[3].version, 4);
     assert_eq!(applied[3].name, "job_run_archive_stage");
     assert!(!applied[3].applied_at.is_empty());
+    assert_eq!(applied[4].version, 5);
+    assert_eq!(applied[4].name, "host_registry_core");
+    assert!(!applied[4].applied_at.is_empty());
 }
 
 #[test]
@@ -159,6 +162,10 @@ fn legacy_db_adopts_versioned_ledger() {
                 "migration.v0004".to_string(),
                 "job_run_archive_stage".to_string()
             ),
+            (
+                "migration.v0005".to_string(),
+                "host_registry_core".to_string()
+            ),
         ]
     );
 }
@@ -170,7 +177,7 @@ fn refuses_db_from_a_newer_binary() {
 
     conn.execute(
         "INSERT INTO schema_meta(key, value, updated_at)
-         VALUES ('migration.v0005', 'from-the-future', '2099-01-01T00:00:00Z')",
+         VALUES ('migration.v0006', 'from-the-future', '2099-01-01T00:00:00Z')",
         [],
     )
     .expect("record future migration");
@@ -186,35 +193,52 @@ fn refuses_db_from_a_newer_binary() {
 }
 
 #[test]
-fn store_reopens_database_at_shipped_schema_v4() {
+fn store_reopens_database_at_shipped_schema_v4_and_applies_v5() {
     let dir = tempfile::tempdir().expect("tempdir");
     let path = dir.path().join("orbit.db");
 
-    // Start with whatever schema the current binary produces, then model the
-    // real incident: a previously shipped binary added the v4 column and
-    // ledger entry before this binary tried to reopen the shared store.
-    drop(crate::Store::open(&path).expect("create store"));
+    // Model a database last opened by the shipped v4 binary. V5 is additive
+    // and must preserve that schema while installing the host registry.
     let conn = Connection::open(&path).expect("open raw store connection");
-    if !table_has_column(&conn, "job_runs", "archived_at").expect("inspect job_runs") {
-        conn.execute_batch("ALTER TABLE job_runs ADD COLUMN archived_at TEXT")
-            .expect("apply shipped v4 schema");
-    }
-    conn.execute(
-        "INSERT OR REPLACE INTO schema_meta(key, value, updated_at)
-         VALUES ('migration.v0004', 'job_run_archive_stage', '2026-07-15T22:11:59Z')",
-        [],
+    conn.execute_batch(
+        r#"
+            CREATE TABLE schema_meta (
+                key TEXT PRIMARY KEY,
+                value TEXT NOT NULL,
+                updated_at TEXT NOT NULL
+            );
+            INSERT INTO schema_meta VALUES
+                ('migration.v0001', 'baseline', '2026-07-01T00:00:00Z'),
+                ('migration.v0002', 'learnings_index_workspace_scope', '2026-07-02T00:00:00Z'),
+                ('migration.v0003', 'flat_crew_model', '2026-07-03T00:00:00Z'),
+                ('migration.v0004', 'job_run_archive_stage', '2026-07-04T00:00:00Z');
+            CREATE TABLE job_runs (id TEXT PRIMARY KEY, archived_at TEXT);
+            INSERT INTO job_runs(id, archived_at) VALUES ('preserved-run', NULL);
+        "#,
     )
-    .expect("record shipped v4 migration");
+    .expect("seed shipped v4 database");
     drop(conn);
 
     let store = crate::Store::open(&path).expect("reopen shipped v4 store");
-    assert_eq!(store.schema_version().expect("schema version"), 4);
+    assert_eq!(store.schema_version().expect("schema version"), 5);
     let applied = store.applied_migrations().expect("applied migrations");
-    assert_eq!(applied.last().map(|migration| migration.version), Some(4));
+    assert_eq!(applied.last().map(|migration| migration.version), Some(5));
     assert_eq!(
         applied.last().map(|migration| migration.name.as_str()),
-        Some("job_run_archive_stage")
+        Some("host_registry_core")
     );
+    let connection = store.connection();
+    let conn = connection.lock().expect("connection");
+    assert!(table_exists(&conn, "hosts").expect("hosts table"));
+    assert!(table_exists(&conn, "host_aliases").expect("aliases table"));
+    let preserved: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM job_runs WHERE id = 'preserved-run'",
+            [],
+            |row| row.get(0),
+        )
+        .expect("preserved v4 record");
+    assert_eq!(preserved, 1);
 }
 
 #[test]

--- a/crates/orbit-store/src/sqlite/migration/tests/migration.rs
+++ b/crates/orbit-store/src/sqlite/migration/tests/migration.rs
@@ -113,6 +113,96 @@ fn run_archive_stage_migration_adds_archived_at() {
 }
 
 #[test]
+fn host_registry_migration_creates_typed_tables_without_touching_existing_records() {
+    let conn = Connection::open_in_memory().expect("open in-memory connection");
+    conn.execute_batch(
+        r#"
+            CREATE TABLE schema_meta (
+                key TEXT PRIMARY KEY,
+                value TEXT NOT NULL,
+                updated_at TEXT NOT NULL
+            );
+            INSERT INTO schema_meta VALUES
+                ('migration.v0001', 'baseline', '2026-07-01T00:00:00Z'),
+                ('migration.v0002', 'learnings_index_workspace_scope', '2026-07-02T00:00:00Z'),
+                ('migration.v0003', 'flat_crew_model', '2026-07-03T00:00:00Z'),
+                ('migration.v0004', 'job_run_archive_stage', '2026-07-04T00:00:00Z');
+            CREATE TABLE existing_records (id TEXT PRIMARY KEY, value TEXT NOT NULL);
+            INSERT INTO existing_records VALUES ('keep-me', 'unchanged');
+        "#,
+    )
+    .expect("seed v4 database");
+
+    apply_schema(&conn).expect("apply host registry migration");
+
+    for table in ["hosts", "host_aliases"] {
+        assert!(table_exists(&conn, table).expect("table lookup"));
+    }
+    for column in [
+        "machine_id",
+        "host_id",
+        "labels_json",
+        "status",
+        "registered_at",
+        "updated_at",
+        "retired_at",
+        "last_seen_at",
+    ] {
+        assert!(
+            table_has_column(&conn, "hosts", column).expect("host column"),
+            "missing hosts.{column}"
+        );
+    }
+    let preserved: String = conn
+        .query_row(
+            "SELECT value FROM existing_records WHERE id = 'keep-me'",
+            [],
+            |row| row.get(0),
+        )
+        .expect("existing row");
+    assert_eq!(preserved, "unchanged");
+    assert_eq!(current_schema_version(&conn).expect("version"), 5);
+
+    let first = applied_migrations(&conn).expect("first ledger");
+    apply_schema(&conn).expect("reapply");
+    assert_eq!(applied_migrations(&conn).expect("second ledger"), first);
+}
+
+#[test]
+fn failed_host_registry_migration_rolls_back_schema_and_ledger() {
+    let conn = Connection::open_in_memory().expect("open in-memory connection");
+    conn.execute_batch(
+        r#"
+            CREATE TABLE schema_meta (
+                key TEXT PRIMARY KEY,
+                value TEXT NOT NULL,
+                updated_at TEXT NOT NULL
+            );
+            INSERT INTO schema_meta VALUES
+                ('migration.v0001', 'baseline', '2026-07-01T00:00:00Z'),
+                ('migration.v0002', 'learnings_index_workspace_scope', '2026-07-02T00:00:00Z'),
+                ('migration.v0003', 'flat_crew_model', '2026-07-03T00:00:00Z'),
+                ('migration.v0004', 'job_run_archive_stage', '2026-07-04T00:00:00Z');
+            CREATE TABLE hosts (machine_id TEXT PRIMARY KEY);
+            INSERT INTO hosts VALUES ('preexisting-sentinel');
+        "#,
+    )
+    .expect("seed incompatible v4 database");
+
+    let error = apply_schema(&conn).expect_err("v5 must fail on incompatible table");
+    assert!(error.to_string().contains("status"), "unexpected: {error}");
+    assert_eq!(current_schema_version(&conn).expect("version"), 4);
+    assert!(
+        !table_exists(&conn, "host_aliases").expect("alias table rolled back"),
+        "partially created alias table must roll back"
+    );
+    let sentinel: String = conn
+        .query_row("SELECT machine_id FROM hosts", [], |row| row.get(0))
+        .expect("sentinel remains");
+    assert_eq!(sentinel, "preexisting-sentinel");
+}
+
+#[test]
 fn learnings_index_migration_rekeys_by_workspace_and_discards_legacy_rows() {
     let conn = Connection::open_in_memory().expect("open in-memory connection");
     // Simulate a legacy database whose learning envelope index is keyed only

--- a/crates/orbit-store/src/sqlite/mod.rs
+++ b/crates/orbit-store/src/sqlite/mod.rs
@@ -1,5 +1,6 @@
 pub mod audit_event_store;
 pub mod connection;
+pub mod host_registry;
 pub mod id_allocator;
 pub(crate) mod invocation_store;
 pub mod job_run_store;

--- a/crates/orbit-store/src/sqlite/tests/host_registry.rs
+++ b/crates/orbit-store/src/sqlite/tests/host_registry.rs
@@ -1,0 +1,287 @@
+use std::collections::BTreeSet;
+
+use orbit_common::types::{HostNameResolution, HostRegistration, HostStatus};
+
+use crate::Store;
+
+fn registration(machine_id: &str, host_id: &str, labels: &[&str]) -> HostRegistration {
+    HostRegistration {
+        machine_id: machine_id.to_string(),
+        host_id: host_id.to_string(),
+        labels: labels.iter().map(|label| (*label).to_string()).collect(),
+    }
+}
+
+fn error_text(result: Result<impl std::fmt::Debug, orbit_common::types::OrbitError>) -> String {
+    result.expect_err("operation must fail").to_string()
+}
+
+#[test]
+fn deterministic_two_host_fixture_covers_registry_lifecycle_and_name_safety() {
+    let store = Store::open_in_memory().expect("store");
+    let alpha = registration("hm_alpha", "alpha", &["codex", "os:linux"]);
+    let beta = registration("hm_beta", "beta", &["claude", "os:macos"]);
+
+    let first_alpha = store.register_host(&alpha).expect("register alpha");
+    let repeated_alpha = store.register_host(&alpha).expect("repeat alpha");
+    assert_eq!(repeated_alpha, first_alpha, "registration must be a no-op");
+    assert_eq!(first_alpha.status, HostStatus::Active);
+    assert_eq!(first_alpha.last_seen_at, Some(first_alpha.registered_at));
+
+    let incompatible_name = error_text(store.register_host(&registration(
+        "hm_alpha",
+        "alpha-renamed-by-register",
+        &["codex", "os:linux"],
+    )));
+    assert!(incompatible_name.contains("alpha"));
+    assert!(incompatible_name.contains("cannot rename"));
+    let incompatible_labels =
+        error_text(store.register_host(&registration("hm_alpha", "alpha", &["different"])));
+    assert!(incompatible_labels.contains("alpha"));
+    assert!(incompatible_labels.contains("different label"));
+
+    let active_collision =
+        error_text(store.register_host(&registration("hm_beta", "alpha", &["claude", "os:macos"])));
+    assert!(active_collision.contains("host_id 'alpha'"));
+    assert!(active_collision.contains("active"));
+    assert_eq!(store.get_host("hm_beta").expect("beta lookup"), None);
+
+    store.register_host(&beta).expect("register beta");
+    store
+        .rename_host("hm_alpha", "alpha-2")
+        .expect("first rename");
+    match store.resolve_host_id("alpha").expect("resolve first alias") {
+        HostNameResolution::Alias { host, alias } => {
+            assert_eq!(host.host_id, "alpha-2");
+            assert_eq!(alias.alias_host_id, "alpha");
+            assert!(alias.warning.contains("permanent tombstone alias"));
+        }
+        other => panic!("expected alias resolution, got {other:?}"),
+    }
+    store
+        .rename_host("hm_alpha", "alpha-3")
+        .expect("second rename");
+    let aliases = store.list_host_aliases("hm_alpha").expect("alias history");
+    let alias_names: BTreeSet<&str> = aliases
+        .iter()
+        .map(|alias| alias.alias_host_id.as_str())
+        .collect();
+    assert_eq!(alias_names, BTreeSet::from(["alpha", "alpha-2"]));
+    for alias in &aliases {
+        match store
+            .resolve_host_id(&alias.alias_host_id)
+            .expect("resolve chained alias")
+        {
+            HostNameResolution::Alias { host, .. } => assert_eq!(host.host_id, "alpha-3"),
+            other => panic!("expected active alias, got {other:?}"),
+        }
+    }
+
+    for forbidden_alias in ["alpha", "alpha-2"] {
+        let error =
+            error_text(store.register_host(&registration("hm_gamma", forbidden_alias, &[])));
+        assert!(error.contains(forbidden_alias));
+        assert!(error.contains("permanent tombstone alias"));
+    }
+
+    let retired = store.retire_host("hm_alpha").expect("retire alpha");
+    assert_eq!(retired.status, HostStatus::Retired);
+    assert!(retired.retired_at.is_some());
+    assert_eq!(store.retire_host("hm_alpha").expect("re-retire"), retired);
+    assert_eq!(
+        store
+            .list_active_hosts()
+            .expect("active hosts")
+            .iter()
+            .map(|host| host.host_id.as_str())
+            .collect::<Vec<_>>(),
+        vec!["beta"]
+    );
+
+    match store
+        .resolve_host_id("alpha-3")
+        .expect("resolve retired current name")
+    {
+        HostNameResolution::Retired { host, alias } => {
+            assert_eq!(host.machine_id, "hm_alpha");
+            assert!(alias.is_none());
+        }
+        other => panic!("expected retired current resolution, got {other:?}"),
+    }
+    match store
+        .resolve_host_id("alpha")
+        .expect("resolve retired alias")
+    {
+        HostNameResolution::Retired { host, alias } => {
+            assert_eq!(host.machine_id, "hm_alpha");
+            assert_eq!(alias.expect("alias metadata").alias_host_id, "alpha");
+        }
+        other => panic!("expected retired alias resolution, got {other:?}"),
+    }
+
+    let retired_reuse = error_text(store.register_host(&registration("hm_gamma", "alpha-3", &[])));
+    assert!(retired_reuse.contains("host_id 'alpha-3'"));
+    assert!(retired_reuse.contains("retired"));
+    let reactivation = error_text(store.register_host(&alpha));
+    assert!(reactivation.contains("host_id 'alpha-3'"));
+    assert!(reactivation.contains("cannot reactivate"));
+    let rename_retired = error_text(store.rename_host("hm_alpha", "alpha-4"));
+    assert!(rename_retired.contains("host_id 'alpha-3'"));
+    assert!(rename_retired.contains("retired"));
+
+    assert_eq!(
+        store.resolve_host_id("missing").expect("unknown"),
+        HostNameResolution::Unknown {
+            host_id: "missing".to_string()
+        }
+    );
+}
+
+#[test]
+fn rename_failure_rolls_back_current_name_and_alias_insert() {
+    let store = Store::open_in_memory().expect("store");
+    store
+        .register_host(&registration("hm_alpha", "alpha", &[]))
+        .expect("register");
+    {
+        let connection = store.connection();
+        let conn = connection.lock().expect("connection");
+        conn.execute_batch(
+            "CREATE TRIGGER fail_host_alias_insert
+             BEFORE INSERT ON host_aliases
+             BEGIN SELECT RAISE(ABORT, 'injected alias failure'); END;",
+        )
+        .expect("install failure trigger");
+    }
+
+    let error = error_text(store.rename_host("hm_alpha", "alpha-2"));
+    assert!(error.contains("alpha"));
+    assert!(error.contains("injected alias failure"));
+    let host = store
+        .get_host("hm_alpha")
+        .expect("host lookup")
+        .expect("host exists");
+    assert_eq!(host.host_id, "alpha", "host update must roll back");
+    assert!(
+        store
+            .list_host_aliases("hm_alpha")
+            .expect("aliases")
+            .is_empty(),
+        "alias insert must roll back"
+    );
+}
+
+#[test]
+fn aliases_are_immutable_and_cross_table_uniqueness_is_enforced() {
+    let store = Store::open_in_memory().expect("store");
+    store
+        .register_host(&registration("hm_alpha", "alpha", &[]))
+        .expect("register alpha");
+    store
+        .rename_host("hm_alpha", "alpha-2")
+        .expect("rename alpha");
+
+    let connection = store.connection();
+    let conn = connection.lock().expect("connection");
+    let update = conn
+        .execute(
+            "UPDATE host_aliases SET host_id = 'reclaimed' WHERE host_id = 'alpha'",
+            [],
+        )
+        .expect_err("aliases cannot update");
+    assert!(update.to_string().contains("immutable"));
+    let delete = conn
+        .execute("DELETE FROM host_aliases WHERE host_id = 'alpha'", [])
+        .expect_err("aliases cannot delete");
+    assert!(delete.to_string().contains("permanent"));
+    let collision = conn
+        .execute(
+            "INSERT INTO hosts(
+                machine_id, host_id, labels_json, status, registered_at,
+                updated_at, retired_at, last_seen_at
+             ) VALUES (
+                'hm_beta', 'alpha', '[]', 'active',
+                '2026-07-18T06:00:00Z', '2026-07-18T06:00:00Z', NULL, NULL
+             )",
+            [],
+        )
+        .expect_err("alias name cannot become current");
+    assert!(collision.to_string().contains("permanent alias"));
+
+    // If an external actor removes the schema backstop and creates an
+    // inconsistent legacy state, typed resolution must fail closed rather
+    // than choose one machine.
+    conn.execute_batch("DROP TRIGGER hosts_host_id_not_alias_insert")
+        .expect("remove trigger for corruption fixture");
+    conn.execute(
+        "INSERT INTO hosts(
+            machine_id, host_id, labels_json, status, registered_at,
+            updated_at, retired_at, last_seen_at
+         ) VALUES (
+            'hm_beta', 'alpha', '[]', 'active',
+            '2026-07-18T06:00:00Z', '2026-07-18T06:00:00Z', NULL, NULL
+         )",
+        [],
+    )
+    .expect("inject inconsistent name owner");
+    drop(conn);
+    match store.resolve_host_id("alpha").expect("resolve collision") {
+        HostNameResolution::Collision {
+            host_id,
+            machine_ids,
+        } => {
+            assert_eq!(host_id, "alpha");
+            assert_eq!(machine_ids, vec!["hm_alpha", "hm_beta"]);
+        }
+        other => panic!("expected typed collision, got {other:?}"),
+    }
+}
+
+#[test]
+fn reopening_store_preserves_registry_semantics_and_migration_is_a_noop() {
+    let directory = tempfile::tempdir().expect("tempdir");
+    let path = directory.path().join("orbit.db");
+    let store = Store::open(&path).expect("store");
+    store
+        .register_host(&registration("hm_alpha", "alpha", &["codex"]))
+        .expect("register");
+    store.rename_host("hm_alpha", "alpha-2").expect("rename");
+    let first_ledger = store.applied_migrations().expect("first ledger");
+    drop(store);
+
+    let reopened = Store::open(&path).expect("reopen");
+    assert_eq!(
+        reopened.applied_migrations().expect("second ledger"),
+        first_ledger
+    );
+    let host = reopened
+        .get_host("hm_alpha")
+        .expect("host")
+        .expect("host exists");
+    assert_eq!(host.host_id, "alpha-2");
+    assert_eq!(
+        reopened
+            .list_host_aliases("hm_alpha")
+            .expect("aliases")
+            .len(),
+        1
+    );
+    assert!(matches!(
+        reopened.resolve_host_id("alpha").expect("resolve"),
+        HostNameResolution::Alias { .. }
+    ));
+}
+
+#[test]
+fn identifiers_reject_paths_instead_of_persisting_them() {
+    let store = Store::open_in_memory().expect("store");
+    for registration in [
+        registration("/home/operator/.ssh/id", "alpha", &[]),
+        registration("hm_alpha", "/workspace/orbit", &[]),
+        registration("hm_alpha", "alpha", &["checkout:/workspace/orbit"]),
+    ] {
+        let error = error_text(store.register_host(&registration));
+        assert!(error.contains("not a path"));
+    }
+    assert!(store.list_active_hosts().expect("active hosts").is_empty());
+}

--- a/crates/orbit-store/src/sqlite/tests/mod.rs
+++ b/crates/orbit-store/src/sqlite/tests/mod.rs
@@ -1,3 +1,4 @@
 mod connection;
+mod host_registry;
 mod invocation_store;
 mod read_pool;

--- a/docs/design/host-registry/2_design.md
+++ b/docs/design/host-registry/2_design.md
@@ -10,18 +10,19 @@ summary: Target mechanisms for host identity, the main-host registry, the coordi
 tags: [host-registry, multi-host, dispatch, routines, data-placement]
 paths: ["crates/orbit-core/**", "crates/orbit-store/**", "crates/orbit-mcp/**", "crates/orbit-common/**"]
 related_features: [host-registry, mcp-bridge, routines, remote-access, mcp-session-context]
-related_artifacts: [ORB-00424, ORB-10247, ORB-10248, ORB-10249, ORB-10258, ADR-0200, ADR-0205, ADR-0208, ADR-0226, ADR-0227, ADR-0228, ADR-0229, ADR-0230, ADR-0231, ADR-0232]
+related_artifacts: [ORB-00424, ORB-10247, ORB-10248, ORB-10249, ORB-10255, ORB-10258, ADR-0200, ADR-0205, ADR-0208, ADR-0226, ADR-0227, ADR-0228, ADR-0229, ADR-0230, ADR-0231, ADR-0232]
 ---
 
 # Host Registry — Design
 
-This doc specifies the **target** design; the Phase 1 host identity and workspace
-registry foundations have landed, while later phases remain pending. The folder is
-Accepted. It covers host identity, the registry, the coordination-plane/workspace-
-ownership split, execution placement (including the hub→satellite protocol), the
-per-record data-placement split, and the revision to routine sweep ownership. It
-leaves client→hub transport to the [MCP bridge](../mcp-bridge/2_design.md)
-([ORB-00424]) and everything speculative to [3_vision.md](./3_vision.md).
+This doc specifies the **target** design; the Phase 1 host identity, workspace
+registry, and host-registry core foundations have landed, while later phases remain
+pending. The folder is Accepted. It covers host identity, the registry, the
+coordination-plane/workspace-ownership split, execution placement (including the
+hub→satellite protocol), the per-record data-placement split, and the revision to
+routine sweep ownership. It leaves client→hub transport to the
+[MCP bridge](../mcp-bridge/2_design.md) ([ORB-00424]) and everything speculative to
+[3_vision.md](./3_vision.md).
 
 ## 1. Host Identity (`host.toml`)
 
@@ -72,7 +73,7 @@ The registry is the main host's inventory of known machines — a `hosts` table 
 main host's global store (`~/.orbit/orbit.db`), not a per-machine file. A registry
 nobody can enumerate isn't a registry.
 
-Per entry: `machine_id` (key), `host_id` (unique among non-retired entries),
+Per entry: `machine_id` (key), `host_id` (globally reserved across active and retired entries),
 `labels` (free-form: providers installed such as `claude`/`codex`, OS), a
 **workspace presence map** (below), `status` (`active` | `retired`),
 `registered_at`, `last_seen`.
@@ -112,6 +113,31 @@ Per entry: `machine_id` (key), `host_id` (unique among non-retired entries),
 - **Retire.** Retired hosts stay in the registry so old provenance, pins, and
   bindings keep resolving; dispatch and pins targeting a retired host fail
   validation with the retirement visible in the error.
+
+**Concrete registry-core schema ([ORB-10255]).** Store migration v5 adds two
+hub-global tables without changing any existing row or standalone path:
+
+- `hosts` is keyed by immutable `machine_id` and carries the current globally
+  reserved `host_id`, canonical label-set JSON, `active|retired` status,
+  `registered_at`, `updated_at`, optional `retired_at`, and optional
+  `last_seen_at`. Initial registration is an explicit observation, so it seeds
+  `last_seen_at`; a compatible repeated registration is a true no-op and does not
+  move any timestamp. Later poll/heartbeat updates remain C2 work and must be
+  explicit — audit traffic is never a liveness input.
+- `host_aliases` is keyed by the historical human name and carries only its stable
+  `machine_id`, creation timestamp, and warning text. Database triggers make alias
+  rows update/delete-proof and enforce current-name/alias disjointness across the
+  two tables; a retired row's current name remains unique as well.
+
+Typed store operations take an immediate transaction before collision preflight.
+Registration is idempotent only for the same active `machine_id`, `host_id`, and
+label set; it cannot rename, relabel, or reactivate. Rename changes the current name
+and inserts the old one as a tombstone in one transaction, so chained renames keep
+the full history. Retirement changes lifecycle state without deleting either table.
+Resolution returns an explicit active, alias-with-warning, retired, unknown, or
+fail-closed collision projection. `HostRegistryService` binds these operations to
+B1's `HostIdentity` declaration without adding CLI/MCP administration or local
+`host.toml` rename coordination; those remain C3.
 
 **Boundary with `~/.orbit/mcp.toml`.** The registry is server-side *inventory*;
 `mcp.toml` is the client's trust policy for its one hub route. They stay separate:
@@ -400,6 +426,9 @@ of that routine.** Consequences:
   strict fail-closed loading (Phase 1 / Unit B1 under ORB-10246).
 - [ORB-10248] — implemented the versioned path-free workspace catalog and
   machine-local owner/replica checkout bindings (§3; Phase 1 / Unit B2).
+- [ORB-10255] — implemented the append-only v5 host/alias schema and typed C1
+  registry core: compatible idempotent registration, collision refusal, permanent
+  rename chains, retirement, active enumeration, and fail-closed name resolution.
 - [ORB-10258] — implemented origin-aware routine loading (§6 items 1–2; Unit R1 under
   ORB-10246): committed definitions fail closed without a non-empty host pin,
   `.orbit/routines/local/` definitions are implicit to the loading host and reject

--- a/docs/design/host-registry/4_decisions.md
+++ b/docs/design/host-registry/4_decisions.md
@@ -10,7 +10,7 @@ summary: Accepted ADR log for the coupled Host Registry and MCP Bridge v1 contra
 tags: [host-registry, mcp-bridge, multi-host, placement]
 paths: ["crates/orbit-core/**", "crates/orbit-store/**", "crates/orbit-mcp/**"]
 related_features: [host-registry, mcp-bridge]
-related_artifacts: [ORB-00424, ORB-10245, ORB-10248, ORB-10249, ORB-10258, ADR-0226, ADR-0227, ADR-0228, ADR-0229, ADR-0230, ADR-0231, ADR-0232]
+related_artifacts: [ORB-00424, ORB-10245, ORB-10248, ORB-10249, ORB-10255, ORB-10258, ADR-0226, ADR-0227, ADR-0228, ADR-0229, ADR-0230, ADR-0231, ADR-0232]
 ---
 
 # Host Registry — Decisions
@@ -45,7 +45,7 @@ logical workspace/owner separately from machine-local checkout bindings.
 
 ## ADR-0227 — Stable machine identity, registry, and out-of-band hub pin
 
-**Status:** Accepted · 2026-07 · [ORB-10245] froze the host identity boundary.
+**Status:** Accepted · 2026-07 · [ORB-10245] froze the host identity boundary; [ORB-10255] implemented the durable registry core.
 
 ### Context
 
@@ -60,6 +60,9 @@ and pin the one hub `machine_id` out of band in machine-local `mcp.toml`.
 ### Consequences
 
 - Names resolve at binding time and persisted records retain stable identity.
+- Current and historical names remain reserved across active and retired lifecycle
+  states; explicit rename appends a permanent alias and registration cannot rename
+  or reactivate.
 - Cost: bootstrap transfers hub identity out of band, and registry/trust drift needs explicit diagnosis.
 
 ## ADR-0228 — Local placement broker with capability-set filtering
@@ -165,6 +168,9 @@ for its non-Orbit constellation domains.
 - [ORB-10245] — accepted the coupled contract and recorded this ADR set.
 - [ORB-10248] — implemented the versioned logical-workspace/local-checkout split.
 - [ORB-10249] — implemented path-free task coordination and global task-relation/readiness lookup.
+- [ORB-10255] — implemented ADR-0227's append-only SQLite host/alias core with
+  compatible idempotent registration, permanent rename history, typed resolution,
+  and non-deleting retirement.
 - [ORB-10258] — implemented the enforcement half of ADR-0231 (Unit R1 of ORB-10246):
   origin-aware routine loading. Committed definitions fail closed without a non-empty host
   pin; `.orbit/routines/local/` definitions are implicit to the loading host and may not


### PR DESCRIPTION
## Task

[ORB-10255](https://orbit-cli.com/tasks/ORB-10255) — Add hub host-registry core with permanent aliases and retirement

### Description

## Problem

Orbit now has stable machine identity (B1) and is landing a path-free logical workspace catalog (B2), but the hub has no durable registry of machines. The coupled Host Registry + MCP Bridge design requires machine identity, human-name collision rules, permanent aliases, and retirement semantics before ownership, presence, transport, or placement can be built safely.

This is Unit C1 of implementation umbrella ORB-10246. It follows ORB-10247 and ORB-10248.

## Required outcome

Add the next append-only hub-store migration plus typed store/service APIs for the host-registry core:

- active and retired host rows keyed durably by immutable `machine_id`;
- current unique human `host_id`, labels, registration/lifecycle timestamps, and a field suitable for later explicit `last_seen` updates;
- permanent tombstone aliases that resolve every old human name to its original `machine_id`;
- idempotent registration by the same `machine_id` only when the declaration is compatible;
- hard collision refusal when a requested active, retired, or tombstoned `host_id` belongs to another machine;
- explicit rename that atomically installs the new name and preserves the full old-name chain; and
- retire without deleting identity or alias history.

Re-registration must never silently rename or reactivate a machine. Typed name resolution must distinguish active names, tombstone aliases (with warning metadata), retired machines, unknown names, and collisions without guessing from hostname, checkout paths, workspace names, or audit activity.

## Boundaries

- Implement only host rows, typed store/service APIs, aliases, rename, and retirement.
- Reserve workspace ownership, presence maps, execution profiles, freshness/revision projections for C2.
- Reserve CLI/MCP administration, local `host.toml` rename coordination, workspace linking/discovery, and satellite cache for C3.
- Reuse B1's machine identity; do not add another generator or silently normalize human names.
- Store no credentials, SSH material, secrets, workspace paths, or per-workspace coordination targets.
- Add no network, transport, broker, lease, HA, or multi-hub behavior.
- Preserve standalone behavior when these APIs are unused and follow the existing transactional/idempotent SQLite migration ledger conventions.

### Acceptance Criteria

- The next append-only SQLite migration creates typed host and tombstone-alias persistence without disturbing existing databases, records, or standalone behavior.
- Host records support stable machine_id, current host_id, labels, active/retired status, registration timestamp, and a field suitable for later explicit last_seen updates; liveness is never inferred from audit traffic.
- Registering the same machine_id with the same compatible declaration is idempotent; re-registration cannot silently rename or reactivate it.
- Reusing an active, retired, or tombstoned host_id for another machine fails atomically before mutation with an error naming the human identifier.
- Explicit rename preserves every prior name as a permanent alias to the original machine_id with alias/warning metadata; chained renames retain the full history and aliases are non-reclaimable.
- Retire never deletes the host or its aliases, excludes it from active enumeration, and makes active-target resolution report retirement rather than unknown or implicit reactivation.
- Host rows, aliases, errors, and projections contain no credentials, SSH material, secrets, workspace paths, or per-workspace coordination targets.
- Migration and operation failures are transactional; reopening and rerunning migration produces no further semantic changes.
- A deterministic in-process two-host fixture covers idempotent registration, incompatible re-registration, collisions, rename chains, alias resolution, retirement, and forbidden name reuse.
- Targeted orbit-common, orbit-store, orbit-core tests and make ci-fast pass.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Added shared HostStatus, HostRegistration, HostRecord, HostAlias, and typed HostNameResolution projections; serialized surfaces contain no transport, credential, secret, workspace-path, or coordination-target fields.
- Appended SQLite migration v5 (host_registry_core) with hosts and permanent host_aliases tables, lifecycle/last_seen fields, cross-table name-reservation triggers, immutable aliases, and ledger/reopen/rollback coverage.
- Added transactional Store APIs for compatible idempotent registration, incompatible re-registration refusal, active/retired/alias collisions, chained rename history, retirement, active enumeration, alias listing, and fail-closed active/alias/retired/unknown/collision resolution.
- Added HostRegistryService in orbit-core to bind B1 HostIdentity declarations to the durable store without adding CLI/MCP administration, local host.toml rename coordination, transport, or standalone side effects.
- Added deterministic in-process two-host, forced rename rollback, corrupt-name collision, migration failure, reopen/idempotence, forbidden path-shaped identifiers, and projection-minimization tests.
- Synchronized the accepted Host Registry design/decision log and ADR-0227 implementation evidence with ORB-10255.

Assessment: The scoped C1 registry core is complete and preserves the coupled singular-hub/stable-machine-identity contract. Registration and lifecycle mutations serialize under BEGIN IMMEDIATE, aliases are non-reclaimable at both API and schema layers, and no liveness derives from audit traffic.

Strategic decisions:
- A compatible registration means the same active machine_id, exact current host_id, and canonical label set; repeated calls are timestamp-stable no-ops.
- Explicit registration seeds last_seen_at once; later poll/heartbeat updates remain C2 and must be explicit.
- Typed resolution uses one SQLite UNION query so current-name and alias classification observes one read snapshot; inconsistent externally modified data returns Collision rather than guessing.

Deviations from original plan:
- Added the new core service/test files documented in the task comment because no pre-existing service module existed; no dependency edge or broader behavior was added.

Validation:
- PASS: cargo test -p orbit-common --no-fail-fast (228 unit tests plus integration fixtures).
- PASS: cargo test -p orbit-store --no-fail-fast (279 unit tests, including all v5 migration and host-registry cases).
- PASS: cargo test -p orbit-core --no-fail-fast (586 passed, 1 ignored, plus integration tests).
- PASS after the final resolution-query refinement: targeted orbit-store host-registry and orbit-core service tests.
- PASS: cargo clippy -p orbit-common -p orbit-store -p orbit-core --all-targets --no-deps -- -A clippy::redundant_closure -D warnings.
- PASS: make ci-fast, cargo fmt --all -- --check, and git diff --check.
- Baseline note: the same clippy command without the narrow allow is blocked by an unmodified pre-existing redundant closure at crates/orbit-store/src/sqlite/task_registry/store.rs:433; this task did not change that out-of-scope file.
- Orbit tooling note: orbit.adr.update wrote ADR-0227 and returned the correct ORB-10255 link, but immediate orbit.adr.show reads stale indexed metadata despite the updated worktree artifact. Filed F2026-07-078; on-disk ADR YAML and the update result are correct.

Design weaknesses / risks:
- C2 still owns workspace presence, execution-profile projections, and explicit poll-driven last_seen refresh; C3 still owns administration and local host.toml rename coordination.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10255-6a5b2015`
- Behind base: 0
- Ahead of base: 1