### PR TITLE
Make review_bundle materialize or fail closed

### DIFF
--- a/.orbit/adrs/accepted/ADR-0233/adr.yaml
+++ b/.orbit/adrs/accepted/ADR-0233/adr.yaml
@@ -1,0 +1,30 @@
+schema_version: 2
+id: ADR-0233
+title: Materialize independent review as a post-publication child Run
+status: accepted
+owner: codex
+created_at: 2026-07-18T07:45:27.176426944Z
+accepted_at: 2026-07-18T07:45:35.717603285Z
+last_updated: 2026-07-18T08:02:33.018082025Z
+related_features:
+- activity-job
+related_tasks:
+- ORB-10266
+tags:
+- workflow
+- independent-review
+- exact-head
+paths:
+- crates/orbit-core/assets/jobs/task_*_pipeline.yaml
+- .orbit/resources/jobs/task_*_pipeline.yaml
+- crates/orbit-core/assets/activities/agent_review.yaml
+- .orbit/resources/activities/agent_review.yaml
+- crates/orbit-core/assets/activities/invoke_and_wait.yaml
+- .orbit/resources/activities/invoke_and_wait.yaml
+- crates/orbit-core/src/command/pipeline_run.rs
+- crates/orbit-core/src/runtime/v2_host/pipeline_actions.rs
+- crates/orbit-dashboard/src/projections.rs
+supersedes: []
+legacy_ids: []
+validation_warnings: []
+legacy_validation: none

--- a/.orbit/adrs/accepted/ADR-0233/body.md
+++ b/.orbit/adrs/accepted/ADR-0233/body.md
@@ -1,0 +1,13 @@
+## Context
+
+An inline `agent_review` step ran before the PR candidate was committed, pushed, or published and left no independently addressable review Run. Orbit could keep that inline activity and add more output checks, or materialize review only after publication as its own durable child bound to the pushed SHA.
+
+## Decision
+
+For explicit-task PR shipment with review enabled, dispatch exactly one `task_review_pipeline` child after push, PR publication, and task promotion. Snapshot the parent run, task IDs, workspace, explicit review crew, candidate branch, pushed SHA, and PR identity in the child input; require a structured verdict whose reviewed SHA exactly matches that snapshot. Preflight the selected crew and deployed job/activity contract before inserting the implementation run, and reject review outside PR mode.
+
+## Consequences
+
+- Independent review is observable and resumable through normal job-run records and cannot silently inherit the implementation crew.
+- `review=false` keeps the implementation-only shipment path, while review-enabled no-diff and local shipments do not invent an unpublished candidate to review.
+- Cost: review-enabled shipment adds a child Run and wait boundary after PR publication, increasing latency and requiring source/shipped workflow assets to stay synchronized.

--- a/.orbit/learnings/L-0094/learning.yaml
+++ b/.orbit/learnings/L-0094/learning.yaml
@@ -1,0 +1,29 @@
+schema_version: 1
+id: L-0094
+status: active
+scope:
+  paths:
+  - crates/orbit-core/src/command/pipeline_run.rs
+  - crates/orbit-core/src/runtime/v2_host/pipeline_actions.rs
+  - crates/orbit-core/assets/jobs/task_*_pipeline.yaml
+  - .orbit/resources/jobs/task_*_pipeline.yaml
+  - crates/orbit-core/assets/activities/agent_review.yaml
+  - .orbit/resources/activities/agent_review.yaml
+  - crates/orbit-core/assets/activities/invoke_and_wait.yaml
+  - .orbit/resources/activities/invoke_and_wait.yaml
+  tags:
+  - workflow
+  - independent-review
+summary: Preflight opt-in workflow capabilities against deployed assets before inserting a parent Run; represent independent review as a durable post-publication child bound to the exact candidate.
+body: ORB-10255 requested `review=true` with a distinct review crew, but request propagation alone left the deployed PR leaf with an inline pre-publication agent step and produced no independently addressable review Run. Capabilities that change the promised workflow must be validated against the actual selected crew plus deployed source/shipped job and activity contract before any implementation run is inserted. A reviewer advertised as independent must execute after candidate publication in its own durable Run, snapshot parent/task/workspace/crew/head/PR lineage, and feed a deterministic exact-head structured-output guard; otherwise reject the request rather than silently behaving like the disabled/default path. If retry or resume can replay child dispatch, deduplicate against a durable parent-lineage field and fail on multiple matches so the independent-review cardinality remains exactly one.
+evidence:
+- kind: task
+  reference: ORB-10255
+- kind: task
+  reference: ORB-10266
+- kind: external
+  reference: jrun-20260718-0641
+created_at: 2026-07-18T07:46:38.090533713Z
+updated_at: 2026-07-18T08:02:57.280651310Z
+created_by: codex
+priority: 210

--- a/.orbit/resources/activities/agent_review.yaml
+++ b/.orbit/resources/activities/agent_review.yaml
@@ -5,15 +5,16 @@ metadata:
 spec:
   type: agent_loop
   description: >
-    Review the pending changes in a bundle's worktree against the participating
-    tasks' acceptance criteria, record blocking findings as durable review
-    threads on each task, and apply targeted fixes in-place. Findings and fix
-    state are tracked via `orbit.task.review_thread.*`; the activity response
-    body is NOT the source of truth and must not be relied on by downstream
-    pipeline steps.
+    Independently review an already-published PR candidate against the
+    participating tasks' acceptance criteria, record blocking findings as
+    durable review threads, and return a structured verdict bound to the exact
+    published candidate SHA. This activity is read-only with respect to the
+    candidate worktree.
   input_schema_json:
     type: object
-    required: [task_ids, workspace_path]
+    required:
+      [task_ids, workspace_path, base_branch, crew, parent_run_id, candidate_head,
+       candidate_head_sha, pr_number]
     properties:
       task_ids:
         type: array
@@ -23,25 +24,45 @@ spec:
         type: string
       base_branch:
         type: string
+      crew:
+        type: string
+      parent_run_id:
+        type: string
+      candidate_head:
+        type: string
+      candidate_head_sha:
+        type: string
+      pr_number:
+        type: string
+      pr_url:
+        type: [string, "null"]
   output_schema_json:
     type: object
+    required: [verdict, reviewed_head_sha]
+    properties:
+      verdict:
+        type: string
+        enum: [approve, request_changes]
+      reviewed_head_sha:
+        type: string
   instruction: |
-    You are reviewing a bundle's pending code changes and applying fixes.
+    You are the independent final reviewer of an already-published PR candidate.
 
-    Durable record: review threads, not this response. Use
-    `orbit.task.review_thread.add` to record blocking issues and
-    `orbit.task.review_thread.resolve` to mark each issue resolved after the
-    corresponding fix lands. Calls to `review_thread.add` and
-    `review_thread.reply` require `model`; `review_thread.list` and
-    `review_thread.resolve` do not, though `resolve` may include it for
-    provenance. The pipeline does not parse your response body.
+    The durable records are this child Run's structured verdict plus any review
+    threads you create. Do not edit, delete, commit, push, or otherwise mutate
+    the candidate. Do not transition task status. Use
+    `orbit.task.review_thread.add` for every blocking issue; include `model`.
+    Leave your own threads open for the implementation owner.
 
     Procedure:
 
-    1. Treat `input.workspace_path` as the active worktree. Diff it against
-       `input.base_branch` (the workflow's configured base, e.g. `main` or
-       `agent-main`) using `proc.spawn` git, e.g. `git diff <base>...HEAD`
-       and `git diff` for unstaged changes.
+    1. Treat `input.workspace_path` as the active worktree. Before reviewing,
+       use `proc.spawn` git to obtain `git rev-parse HEAD` and `git status
+       --porcelain`. The resolved HEAD MUST equal `input.candidate_head_sha`
+       exactly and the worktree MUST be clean. Also resolve
+       `input.candidate_head` and require it to name the same SHA. On any
+       mismatch, return a failed Orbit response envelope; do not review a
+       different head.
     2. For each task id in `input.task_ids`, call `orbit.task.show` to
        recover its description, acceptance criteria, plan, and context
        files. Read context selectors via `orbit.graph.show` (and
@@ -51,32 +72,30 @@ spec:
        `semantic: "<task-id>"` to surface prior similar tasks whose review
        threads or decisions may inform this review; skip if the companion
        binary is not installed.
-    3. For each blocking issue you find — correctness bug, broken contract,
+    3. Diff `input.base_branch...input.candidate_head_sha` and inspect the
+       published candidate. For each blocking issue you find — correctness bug,
        acceptance-criteria miss, obvious regression — record it with
        `orbit.task.review_thread.add` against the most relevant task. Use
        inline `path` and string `line` (`"line": "<line>"`) when the issue is
        file-specific; omit them for general findings. Include `model` on every
        `review_thread.add` call. Skip stylistic nits.
-    4. Apply fixes directly in the worktree, scoped to files the bundle
-       already touches. Do not widen scope: out-of-scope concerns belong in
-       new tasks created later, not in this review pass.
-    5. After landing each fix, call `orbit.task.review_thread.resolve` on
-       the corresponding thread.
-    6. If a fix cannot be applied (ambiguity, missing context, scope
-       boundary), leave the thread `open` and move on. Open threads will
-       surface to human reviewers via the existing PR review-thread sync.
-    7. Before stopping, run the learning checkpoint: if this review surfaced a
+    4. Before stopping, run the learning checkpoint: if this review surfaced a
        contradicted assumption, recurring failure mode, non-obvious gotcha that
        took more than 10 minutes to debug, or incident-style root cause, follow
        the `orbit-knowledge` skill and call the `add` action on
        `orbit.learning` (or use that skill's update/supersede flow when it
        points to existing guidance).
        Skip if none apply.
-    8. Stop when no further blocking issues remain. Do not synthesize a
-       summary in the response — the review-thread records are the result.
+    5. Return exactly one Orbit response envelope. Use status `success`, set
+       `result.verdict` to `approve` only when no blocking issue remains, or
+       `request_changes` when at least one blocking thread is open, and set
+       `result.reviewed_head_sha` to the exact SHA you verified. The required
+       shape is:
+       {"schemaVersion":1,"status":"success","result":{"verdict":"approve|request_changes","reviewed_head_sha":"<sha>"},"error":null}
   tools:
-    - orbit.task.*
-    - orbit.friction.*
+    - orbit.task.show
+    - orbit.task.review_thread.add
+    - orbit.task.review_thread.list
     - orbit.graph.*
     - orbit.search
     - orbit.learning.show
@@ -84,12 +103,11 @@ spec:
     - orbit.learning.update
     - orbit.learning.supersede
     - fs.read
-    - fs.delete
     - proc.spawn
   proc_allowed_programs:
     - git
     - rg
   on_denial: terminate
   max_iterations: 20
-  role: reviewer
+  require_response_envelope: true
   wall_clock_timeout_seconds: 3600

--- a/.orbit/resources/activities/independent_review_guard.yaml
+++ b/.orbit/resources/activities/independent_review_guard.yaml
@@ -1,0 +1,32 @@
+schemaVersion: 2
+kind: Activity
+metadata:
+  name: independent_review_guard
+spec:
+  type: deterministic
+  description: >
+    Require an independent review verdict and prove that the reviewer bound it
+    to the exact candidate SHA published by the parent PR pipeline.
+  input_schema_json:
+    type: object
+    required: [verdict, reviewed_head_sha, candidate_head_sha]
+    properties:
+      verdict:
+        type: string
+        enum: [approve, request_changes]
+      reviewed_head_sha:
+        type: string
+      candidate_head_sha:
+        type: string
+  output_schema_json:
+    type: object
+    required: [verdict, reviewed_head_sha, exact_head]
+    properties:
+      verdict:
+        type: string
+      reviewed_head_sha:
+        type: string
+      exact_head:
+        type: boolean
+  action: independent_review_guard
+  config: {}

--- a/.orbit/resources/activities/invoke_and_wait.yaml
+++ b/.orbit/resources/activities/invoke_and_wait.yaml
@@ -11,7 +11,10 @@ spec:
     `orbit.pipeline.wait` (to block on completion). Workflows that require
     a successful child Run should follow this activity with
     `pipeline_success_guard` after any cleanup that depends on the raw
-    child status. The returned `status` mirrors the child Run's terminal state:
+    child status. Callers that must create at most one child across parent
+    retry/resume may set `dedupe_run_input_field`; an existing child with the
+    same job and exact persisted input-field value is reused, while multiple
+    matches fail closed. The returned `status` mirrors the child Run's terminal state:
     `succeeded`,
     `failed`, `cancelled`, or `timeout`. A `timeout` here means the
     WAIT side of the activity exceeded `timeout_seconds`; the child
@@ -39,6 +42,9 @@ spec:
       priority:
         type: string
         enum: [low, medium, high, critical]
+      dedupe_run_input_field:
+        type: string
+        minLength: 1
       admission_task_ids:
         type: array
         items:

--- a/.orbit/resources/jobs/task_local_pipeline.yaml
+++ b/.orbit/resources/jobs/task_local_pipeline.yaml
@@ -6,14 +6,11 @@
 # - If all implementations succeed, `commit` snapshots the bundle branch before merge.
 # - Tasks move to `review` only after the full bundle commits and merges cleanly.
 #
-# Optional review step:
-# - `review_bundle` runs after `implement_bundle` when `input.review` is
-#   `true` (default `false`) and uses only the required explicit
-#   `input.review_crew`. It invokes `agent_review`, which records
-#   blocking findings as `ReviewThread`s on the participating tasks via
-#   `orbit.task.review_thread.*` and applies fixes in-place. The pipeline
-#   does not gate on agent output; unresolved threads remain on the tasks
-#   for downstream visibility.
+# Independent review is a published-candidate contract and is supported only
+# by `task_pr_pipeline`. The canonical ship surface rejects local review
+# before submission; the first step below also fails closed for direct leaf
+# invocations so an enabled review cannot be silently ignored or start local
+# implementation work.
 
 schemaVersion: 2
 kind: Job
@@ -32,6 +29,15 @@ spec:
     review_crew: null
   
   steps:
+    - id: reject_unsupported_review
+      when: "{{ input.review }} == true"
+      target: activity:pipeline_success_guard
+      default_input:
+        context: task_local_pipeline review is unsupported
+        result:
+          status: failed
+          error: independent review requires PR mode and a published candidate
+
     - id: worktree
       target: activity:worktree_setup
       retry:
@@ -55,16 +61,6 @@ spec:
             default_input:
               task_id: "{{ item }}"
               workspace_path: "{{ steps.worktree.output.workspace_path }}"
-
-    - id: review_bundle
-      when: "{{ input.review }} == true"
-      recovery_activity: step_failure_recovery
-      target: activity:agent_review
-      default_input:
-        task_ids: "{{ input.task_ids }}"
-        workspace_path: "{{ steps.worktree.output.workspace_path }}"
-        base_branch: "{{ input.base_branch }}"
-        crew: "{{ input.review_crew }}"
 
     - id: commit
       recovery_activity: step_failure_recovery

--- a/.orbit/resources/jobs/task_pr_pipeline.yaml
+++ b/.orbit/resources/jobs/task_pr_pipeline.yaml
@@ -13,14 +13,14 @@
 #   for automation that requires a human/orchestrator decision to clear. Tasks
 #   already in `review`/`done` are left untouched.
 #
-# Optional review step:
-# - `review_bundle` runs after `implement_bundle` when `input.review` is
-#   `true` (default `false`) and uses only the required explicit
-#   `input.review_crew`. It invokes `agent_review`, which records
-#   blocking findings as `ReviewThread`s on the participating tasks via
-#   `orbit.task.review_thread.*` and applies fixes in-place. Unresolved
-#   threads ride through to the PR via the existing review-thread sync;
-#   the pipeline does not gate on agent output.
+# Optional independent review:
+# - `independent_review` starts exactly one durable `task_review_pipeline`
+#   child only after the candidate branch is pushed, the PR is published, and
+#   the participating tasks are promoted to review. Its input snapshots the
+#   parent run, task bundle, worktree, PR, candidate branch, and exact pushed
+#   SHA. The child uses only the required explicit `input.review_crew` and
+#   cannot mutate the published candidate. A structured exact-head verdict is
+#   required before this parent may succeed.
 
 schemaVersion: 2
 kind: Job
@@ -64,16 +64,6 @@ spec:
               task_id: "{{ item }}"
               workspace_path: "{{ steps.worktree.output.workspace_path }}"
               repo_root: "{{ steps.worktree.output.workspace_path }}"
-
-    - id: review_bundle
-      when: "{{ input.review }} == true"
-      recovery_activity: step_failure_recovery
-      target: activity:agent_review
-      default_input:
-        task_ids: "{{ input.task_ids }}"
-        workspace_path: "{{ steps.worktree.output.workspace_path }}"
-        base_branch: "{{ input.base_branch }}"
-        crew: "{{ input.review_crew }}"
 
     - id: commit
       recovery_activity: step_failure_recovery
@@ -154,6 +144,31 @@ spec:
         base_ref: "{{ steps.sync_base.output.base_ref }}"
         pr_number: "{{ steps.pr_open.output.pr_number }}"
         pr_url: "{{ steps.pr_open.output.pr_url }}"
+
+    - id: independent_review
+      when: "{{ input.review }} == true && {{ steps.commit.output.skipped_no_diff_expected }} != true"
+      target: activity:invoke_and_wait
+      default_input:
+        job_name: task_review_pipeline
+        run_input:
+          task_ids: "{{ input.task_ids }}"
+          workspace_path: "{{ steps.worktree.output.workspace_path }}"
+          base_branch: "{{ input.base_branch }}"
+          crew: "{{ input.review_crew }}"
+          parent_run_id: "{{ steps.worktree.output.job_run_id }}"
+          candidate_head: "{{ steps.push.output.branch }}"
+          candidate_head_sha: "{{ steps.push.output.local_sha }}"
+          pr_number: "{{ steps.pr_open.output.pr_number }}"
+          pr_url: "{{ steps.pr_open.output.pr_url }}"
+        dedupe_run_input_field: parent_run_id
+        timeout_seconds: 7200
+
+    - id: require_independent_review_success
+      when: "{{ input.review }} == true && {{ steps.commit.output.skipped_no_diff_expected }} != true"
+      target: activity:pipeline_success_guard
+      default_input:
+        context: task_pr_pipeline independent review
+        result: "{{ steps.independent_review.output }}"
 
     - id: promote_no_diff
       when: "{{ steps.commit.output.skipped_no_diff_expected }} == true"

--- a/.orbit/resources/jobs/task_review_pipeline.yaml
+++ b/.orbit/resources/jobs/task_review_pipeline.yaml
@@ -1,0 +1,47 @@
+# Independent exact-head review pipeline.
+#
+# This job is invoked only by `task_pr_pipeline` after candidate publication.
+# Its persisted input is the lineage projection: parent run, task bundle,
+# workspace/worktree, PR, candidate branch, exact pushed SHA, and explicit
+# review crew. The agent response is followed by a deterministic guard so a
+# successful Run always contains a structured verdict bound to that SHA.
+
+schemaVersion: 2
+kind: Job
+metadata:
+  name: task_review_pipeline
+spec:
+  state: enabled
+  kind: workflow
+  max_active_runs: 10
+  default_input:
+    task_ids: []
+    workspace_path: null
+    base_branch: null
+    crew: null
+    parent_run_id: null
+    candidate_head: null
+    candidate_head_sha: null
+    pr_number: null
+    pr_url: null
+
+  steps:
+    - id: independent_review
+      target: activity:agent_review
+      default_input:
+        task_ids: "{{ input.task_ids }}"
+        workspace_path: "{{ input.workspace_path }}"
+        base_branch: "{{ input.base_branch }}"
+        crew: "{{ input.crew }}"
+        parent_run_id: "{{ input.parent_run_id }}"
+        candidate_head: "{{ input.candidate_head }}"
+        candidate_head_sha: "{{ input.candidate_head_sha }}"
+        pr_number: "{{ input.pr_number }}"
+        pr_url: "{{ input.pr_url }}"
+
+    - id: require_exact_head_verdict
+      target: activity:independent_review_guard
+      default_input:
+        verdict: "{{ steps.independent_review.output.verdict }}"
+        reviewed_head_sha: "{{ steps.independent_review.output.reviewed_head_sha }}"
+        candidate_head_sha: "{{ input.candidate_head_sha }}"

--- a/crates/orbit-core/assets/activities/agent_review.yaml
+++ b/crates/orbit-core/assets/activities/agent_review.yaml
@@ -5,15 +5,16 @@ metadata:
 spec:
   type: agent_loop
   description: >
-    Review the pending changes in a bundle's worktree against the participating
-    tasks' acceptance criteria, record blocking findings as durable review
-    threads on each task, and apply targeted fixes in-place. Findings and fix
-    state are tracked via `orbit.task.review_thread.*`; the activity response
-    body is NOT the source of truth and must not be relied on by downstream
-    pipeline steps.
+    Independently review an already-published PR candidate against the
+    participating tasks' acceptance criteria, record blocking findings as
+    durable review threads, and return a structured verdict bound to the exact
+    published candidate SHA. This activity is read-only with respect to the
+    candidate worktree.
   input_schema_json:
     type: object
-    required: [task_ids, workspace_path]
+    required:
+      [task_ids, workspace_path, base_branch, crew, parent_run_id, candidate_head,
+       candidate_head_sha, pr_number]
     properties:
       task_ids:
         type: array
@@ -23,25 +24,45 @@ spec:
         type: string
       base_branch:
         type: string
+      crew:
+        type: string
+      parent_run_id:
+        type: string
+      candidate_head:
+        type: string
+      candidate_head_sha:
+        type: string
+      pr_number:
+        type: string
+      pr_url:
+        type: [string, "null"]
   output_schema_json:
     type: object
+    required: [verdict, reviewed_head_sha]
+    properties:
+      verdict:
+        type: string
+        enum: [approve, request_changes]
+      reviewed_head_sha:
+        type: string
   instruction: |
-    You are reviewing a bundle's pending code changes and applying fixes.
+    You are the independent final reviewer of an already-published PR candidate.
 
-    Durable record: review threads, not this response. Use
-    `orbit.task.review_thread.add` to record blocking issues and
-    `orbit.task.review_thread.resolve` to mark each issue resolved after the
-    corresponding fix lands. Calls to `review_thread.add` and
-    `review_thread.reply` require `model`; `review_thread.list` and
-    `review_thread.resolve` do not, though `resolve` may include it for
-    provenance. The pipeline does not parse your response body.
+    The durable records are this child Run's structured verdict plus any review
+    threads you create. Do not edit, delete, commit, push, or otherwise mutate
+    the candidate. Do not transition task status. Use
+    `orbit.task.review_thread.add` for every blocking issue; include `model`.
+    Leave your own threads open for the implementation owner.
 
     Procedure:
 
-    1. Treat `input.workspace_path` as the active worktree. Diff it against
-       `input.base_branch` (the workflow's configured base, e.g. `main` or
-       `agent-main`) using `proc.spawn` git, e.g. `git diff <base>...HEAD`
-       and `git diff` for unstaged changes.
+    1. Treat `input.workspace_path` as the active worktree. Before reviewing,
+       use `proc.spawn` git to obtain `git rev-parse HEAD` and `git status
+       --porcelain`. The resolved HEAD MUST equal `input.candidate_head_sha`
+       exactly and the worktree MUST be clean. Also resolve
+       `input.candidate_head` and require it to name the same SHA. On any
+       mismatch, return a failed Orbit response envelope; do not review a
+       different head.
     2. For each task id in `input.task_ids`, call `orbit.task.show` to
        recover its description, acceptance criteria, plan, and context
        files. Read context selectors via `orbit.graph.show` (and
@@ -51,32 +72,30 @@ spec:
        `semantic: "<task-id>"` to surface prior similar tasks whose review
        threads or decisions may inform this review; skip if the companion
        binary is not installed.
-    3. For each blocking issue you find — correctness bug, broken contract,
+    3. Diff `input.base_branch...input.candidate_head_sha` and inspect the
+       published candidate. For each blocking issue you find — correctness bug,
        acceptance-criteria miss, obvious regression — record it with
        `orbit.task.review_thread.add` against the most relevant task. Use
        inline `path` and string `line` (`"line": "<line>"`) when the issue is
        file-specific; omit them for general findings. Include `model` on every
        `review_thread.add` call. Skip stylistic nits.
-    4. Apply fixes directly in the worktree, scoped to files the bundle
-       already touches. Do not widen scope: out-of-scope concerns belong in
-       new tasks created later, not in this review pass.
-    5. After landing each fix, call `orbit.task.review_thread.resolve` on
-       the corresponding thread.
-    6. If a fix cannot be applied (ambiguity, missing context, scope
-       boundary), leave the thread `open` and move on. Open threads will
-       surface to human reviewers via the existing PR review-thread sync.
-    7. Before stopping, run the learning checkpoint: if this review surfaced a
+    4. Before stopping, run the learning checkpoint: if this review surfaced a
        contradicted assumption, recurring failure mode, non-obvious gotcha that
        took more than 10 minutes to debug, or incident-style root cause, follow
        the `orbit-knowledge` skill and call the `add` action on
        `orbit.learning` (or use that skill's update/supersede flow when it
        points to existing guidance).
        Skip if none apply.
-    8. Stop when no further blocking issues remain. Do not synthesize a
-       summary in the response — the review-thread records are the result.
+    5. Return exactly one Orbit response envelope. Use status `success`, set
+       `result.verdict` to `approve` only when no blocking issue remains, or
+       `request_changes` when at least one blocking thread is open, and set
+       `result.reviewed_head_sha` to the exact SHA you verified. The required
+       shape is:
+       {"schemaVersion":1,"status":"success","result":{"verdict":"approve|request_changes","reviewed_head_sha":"<sha>"},"error":null}
   tools:
-    - orbit.task.*
-    - orbit.friction.*
+    - orbit.task.show
+    - orbit.task.review_thread.add
+    - orbit.task.review_thread.list
     - orbit.graph.*
     - orbit.search
     - orbit.learning.show
@@ -84,12 +103,11 @@ spec:
     - orbit.learning.update
     - orbit.learning.supersede
     - fs.read
-    - fs.delete
     - proc.spawn
   proc_allowed_programs:
     - git
     - rg
   on_denial: terminate
   max_iterations: 20
-  role: reviewer
+  require_response_envelope: true
   wall_clock_timeout_seconds: 3600

--- a/crates/orbit-core/assets/activities/independent_review_guard.yaml
+++ b/crates/orbit-core/assets/activities/independent_review_guard.yaml
@@ -1,0 +1,32 @@
+schemaVersion: 2
+kind: Activity
+metadata:
+  name: independent_review_guard
+spec:
+  type: deterministic
+  description: >
+    Require an independent review verdict and prove that the reviewer bound it
+    to the exact candidate SHA published by the parent PR pipeline.
+  input_schema_json:
+    type: object
+    required: [verdict, reviewed_head_sha, candidate_head_sha]
+    properties:
+      verdict:
+        type: string
+        enum: [approve, request_changes]
+      reviewed_head_sha:
+        type: string
+      candidate_head_sha:
+        type: string
+  output_schema_json:
+    type: object
+    required: [verdict, reviewed_head_sha, exact_head]
+    properties:
+      verdict:
+        type: string
+      reviewed_head_sha:
+        type: string
+      exact_head:
+        type: boolean
+  action: independent_review_guard
+  config: {}

--- a/crates/orbit-core/assets/activities/invoke_and_wait.yaml
+++ b/crates/orbit-core/assets/activities/invoke_and_wait.yaml
@@ -11,7 +11,10 @@ spec:
     `orbit.pipeline.wait` (to block on completion). Workflows that require
     a successful child Run should follow this activity with
     `pipeline_success_guard` after any cleanup that depends on the raw
-    child status. The returned `status` mirrors the child Run's terminal state:
+    child status. Callers that must create at most one child across parent
+    retry/resume may set `dedupe_run_input_field`; an existing child with the
+    same job and exact persisted input-field value is reused, while multiple
+    matches fail closed. The returned `status` mirrors the child Run's terminal state:
     `succeeded`,
     `failed`, `cancelled`, or `timeout`. A `timeout` here means the
     WAIT side of the activity exceeded `timeout_seconds`; the child
@@ -39,6 +42,9 @@ spec:
       priority:
         type: string
         enum: [low, medium, high, critical]
+      dedupe_run_input_field:
+        type: string
+        minLength: 1
       admission_task_ids:
         type: array
         items:

--- a/crates/orbit-core/assets/jobs/task_local_pipeline.yaml
+++ b/crates/orbit-core/assets/jobs/task_local_pipeline.yaml
@@ -6,14 +6,11 @@
 # - If all implementations succeed, `commit` snapshots the bundle branch before merge.
 # - Tasks move to `review` only after the full bundle commits and merges cleanly.
 #
-# Optional review step:
-# - `review_bundle` runs after `implement_bundle` when `input.review` is
-#   `true` (default `false`) and uses only the required explicit
-#   `input.review_crew`. It invokes `agent_review`, which records
-#   blocking findings as `ReviewThread`s on the participating tasks via
-#   `orbit.task.review_thread.*` and applies fixes in-place. The pipeline
-#   does not gate on agent output; unresolved threads remain on the tasks
-#   for downstream visibility.
+# Independent review is a published-candidate contract and is supported only
+# by `task_pr_pipeline`. The canonical ship surface rejects local review
+# before submission; the first step below also fails closed for direct leaf
+# invocations so an enabled review cannot be silently ignored or start local
+# implementation work.
 
 schemaVersion: 2
 kind: Job
@@ -32,6 +29,15 @@ spec:
     review_crew: null
   
   steps:
+    - id: reject_unsupported_review
+      when: "{{ input.review }} == true"
+      target: activity:pipeline_success_guard
+      default_input:
+        context: task_local_pipeline review is unsupported
+        result:
+          status: failed
+          error: independent review requires PR mode and a published candidate
+
     - id: worktree
       target: activity:worktree_setup
       retry:
@@ -55,16 +61,6 @@ spec:
             default_input:
               task_id: "{{ item }}"
               workspace_path: "{{ steps.worktree.output.workspace_path }}"
-
-    - id: review_bundle
-      when: "{{ input.review }} == true"
-      recovery_activity: step_failure_recovery
-      target: activity:agent_review
-      default_input:
-        task_ids: "{{ input.task_ids }}"
-        workspace_path: "{{ steps.worktree.output.workspace_path }}"
-        base_branch: "{{ input.base_branch }}"
-        crew: "{{ input.review_crew }}"
 
     - id: commit
       recovery_activity: step_failure_recovery

--- a/crates/orbit-core/assets/jobs/task_pr_pipeline.yaml
+++ b/crates/orbit-core/assets/jobs/task_pr_pipeline.yaml
@@ -13,14 +13,14 @@
 #   for automation that requires a human/orchestrator decision to clear. Tasks
 #   already in `review`/`done` are left untouched.
 #
-# Optional review step:
-# - `review_bundle` runs after `implement_bundle` when `input.review` is
-#   `true` (default `false`) and uses only the required explicit
-#   `input.review_crew`. It invokes `agent_review`, which records
-#   blocking findings as `ReviewThread`s on the participating tasks via
-#   `orbit.task.review_thread.*` and applies fixes in-place. Unresolved
-#   threads ride through to the PR via the existing review-thread sync;
-#   the pipeline does not gate on agent output.
+# Optional independent review:
+# - `independent_review` starts exactly one durable `task_review_pipeline`
+#   child only after the candidate branch is pushed, the PR is published, and
+#   the participating tasks are promoted to review. Its input snapshots the
+#   parent run, task bundle, worktree, PR, candidate branch, and exact pushed
+#   SHA. The child uses only the required explicit `input.review_crew` and
+#   cannot mutate the published candidate. A structured exact-head verdict is
+#   required before this parent may succeed.
 
 schemaVersion: 2
 kind: Job
@@ -64,16 +64,6 @@ spec:
               task_id: "{{ item }}"
               workspace_path: "{{ steps.worktree.output.workspace_path }}"
               repo_root: "{{ steps.worktree.output.workspace_path }}"
-
-    - id: review_bundle
-      when: "{{ input.review }} == true"
-      recovery_activity: step_failure_recovery
-      target: activity:agent_review
-      default_input:
-        task_ids: "{{ input.task_ids }}"
-        workspace_path: "{{ steps.worktree.output.workspace_path }}"
-        base_branch: "{{ input.base_branch }}"
-        crew: "{{ input.review_crew }}"
 
     - id: commit
       recovery_activity: step_failure_recovery
@@ -154,6 +144,31 @@ spec:
         base_ref: "{{ steps.sync_base.output.base_ref }}"
         pr_number: "{{ steps.pr_open.output.pr_number }}"
         pr_url: "{{ steps.pr_open.output.pr_url }}"
+
+    - id: independent_review
+      when: "{{ input.review }} == true && {{ steps.commit.output.skipped_no_diff_expected }} != true"
+      target: activity:invoke_and_wait
+      default_input:
+        job_name: task_review_pipeline
+        run_input:
+          task_ids: "{{ input.task_ids }}"
+          workspace_path: "{{ steps.worktree.output.workspace_path }}"
+          base_branch: "{{ input.base_branch }}"
+          crew: "{{ input.review_crew }}"
+          parent_run_id: "{{ steps.worktree.output.job_run_id }}"
+          candidate_head: "{{ steps.push.output.branch }}"
+          candidate_head_sha: "{{ steps.push.output.local_sha }}"
+          pr_number: "{{ steps.pr_open.output.pr_number }}"
+          pr_url: "{{ steps.pr_open.output.pr_url }}"
+        dedupe_run_input_field: parent_run_id
+        timeout_seconds: 7200
+
+    - id: require_independent_review_success
+      when: "{{ input.review }} == true && {{ steps.commit.output.skipped_no_diff_expected }} != true"
+      target: activity:pipeline_success_guard
+      default_input:
+        context: task_pr_pipeline independent review
+        result: "{{ steps.independent_review.output }}"
 
     - id: promote_no_diff
       when: "{{ steps.commit.output.skipped_no_diff_expected }} == true"

--- a/crates/orbit-core/assets/jobs/task_review_pipeline.yaml
+++ b/crates/orbit-core/assets/jobs/task_review_pipeline.yaml
@@ -1,0 +1,47 @@
+# Independent exact-head review pipeline.
+#
+# This job is invoked only by `task_pr_pipeline` after candidate publication.
+# Its persisted input is the lineage projection: parent run, task bundle,
+# workspace/worktree, PR, candidate branch, exact pushed SHA, and explicit
+# review crew. The agent response is followed by a deterministic guard so a
+# successful Run always contains a structured verdict bound to that SHA.
+
+schemaVersion: 2
+kind: Job
+metadata:
+  name: task_review_pipeline
+spec:
+  state: enabled
+  kind: workflow
+  max_active_runs: 10
+  default_input:
+    task_ids: []
+    workspace_path: null
+    base_branch: null
+    crew: null
+    parent_run_id: null
+    candidate_head: null
+    candidate_head_sha: null
+    pr_number: null
+    pr_url: null
+
+  steps:
+    - id: independent_review
+      target: activity:agent_review
+      default_input:
+        task_ids: "{{ input.task_ids }}"
+        workspace_path: "{{ input.workspace_path }}"
+        base_branch: "{{ input.base_branch }}"
+        crew: "{{ input.crew }}"
+        parent_run_id: "{{ input.parent_run_id }}"
+        candidate_head: "{{ input.candidate_head }}"
+        candidate_head_sha: "{{ input.candidate_head_sha }}"
+        pr_number: "{{ input.pr_number }}"
+        pr_url: "{{ input.pr_url }}"
+
+    - id: require_exact_head_verdict
+      target: activity:independent_review_guard
+      default_input:
+        verdict: "{{ steps.independent_review.output.verdict }}"
+        reviewed_head_sha: "{{ steps.independent_review.output.reviewed_head_sha }}"
+        candidate_head_sha: "{{ input.candidate_head_sha }}"

--- a/crates/orbit-core/src/command/activity.rs
+++ b/crates/orbit-core/src/command/activity.rs
@@ -57,6 +57,10 @@ pub(crate) const DEFAULT_ACTIVITY_FILES: &[(&str, &str)] = &[
         include_str!("../../assets/activities/invoke_and_wait.yaml"),
     ),
     (
+        "independent_review_guard",
+        include_str!("../../assets/activities/independent_review_guard.yaml"),
+    ),
+    (
         "pipeline_wait",
         include_str!("../../assets/activities/pipeline_wait.yaml"),
     ),
@@ -181,6 +185,7 @@ mod tests {
             ("pr_promote", "pr_promote"),
             ("release_locks", "release_locks"),
             ("pipeline_wait", "pipeline_wait"),
+            ("independent_review_guard", "independent_review_guard"),
             ("list_triage_candidates", "list_triage_candidates"),
             ("apply_triage_dispositions", "apply_triage_dispositions"),
         ] {
@@ -225,7 +230,7 @@ mod tests {
     fn agent_response_contract_matches_durable_handoff_shape() {
         for (name, required) in [
             ("agent_implement", false),
-            ("agent_review", false),
+            ("agent_review", true),
             ("triage_failed_runs", true),
             ("epic_orchestrator", true),
         ] {
@@ -242,6 +247,32 @@ mod tests {
                 ),
                 other => panic!("expected agent_loop {name} activity, got {other:?}"),
             }
+        }
+    }
+
+    #[test]
+    fn agent_review_is_read_only_and_requires_an_exact_head_verdict() {
+        let (_, yaml) = DEFAULT_ACTIVITY_FILES
+            .iter()
+            .find(|(name, _)| *name == "agent_review")
+            .expect("agent review activity is seeded");
+        let asset = load_activity_asset(yaml).expect("parse agent review activity");
+        assert_eq!(
+            asset.spec.output_schema_json["required"],
+            serde_json::json!(["verdict", "reviewed_head_sha"])
+        );
+        match asset.spec.spec {
+            ActivityV2Spec::AgentLoop(spec) => {
+                assert!(spec.require_response_envelope);
+                assert_eq!(
+                    spec.role, None,
+                    "flat review crew must not need a role field"
+                );
+                assert!(!spec.tools.iter().any(|tool| tool == "fs.delete"));
+                assert!(spec.instruction.contains("candidate_head_sha"));
+                assert!(spec.instruction.contains("Do not edit"));
+            }
+            other => panic!("expected agent_loop agent_review, got {other:?}"),
         }
     }
 

--- a/crates/orbit-core/src/command/job/catalog.rs
+++ b/crates/orbit-core/src/command/job/catalog.rs
@@ -48,6 +48,10 @@ const DEFAULT_JOB_FILES: &[(&str, &str)] = &[
         include_str!("../../../assets/jobs/task_pr_pipeline.yaml"),
     ),
     (
+        "task_review_pipeline",
+        include_str!("../../../assets/jobs/task_review_pipeline.yaml"),
+    ),
+    (
         "task_triage_pipeline",
         include_str!("../../../assets/jobs/task_triage_pipeline.yaml"),
     ),
@@ -511,67 +515,190 @@ spec:
     }
 
     #[test]
-    fn leaf_ship_review_is_opt_in_and_uses_only_the_explicit_review_crew() {
+    fn pr_review_materializes_one_exact_head_child_with_the_explicit_crew() {
+        let yaml = DEFAULT_JOB_FILES
+            .iter()
+            .find_map(|(name, yaml)| (*name == "task_pr_pipeline").then_some(*yaml))
+            .expect("task PR pipeline exists");
+        let asset = load_job_asset(yaml).expect("task PR pipeline parses");
+        let defaults = asset.spec.default_input.as_ref().expect("default input");
+        assert_eq!(defaults["review"], false);
+        assert_eq!(defaults["review_crew"], Value::Null);
+        assert!(
+            asset
+                .spec
+                .steps
+                .iter()
+                .all(|step| step.id != "review_bundle"),
+            "the implementation run must not inline the independent reviewer"
+        );
+
+        let review_steps = asset
+            .spec
+            .steps
+            .iter()
+            .filter(|step| {
+                matches!(
+                    &step.body,
+                    JobV2StepBody::TargetRef(target)
+                        if target.target == "activity:invoke_and_wait"
+                            && target
+                                .default_input
+                                .as_ref()
+                                .and_then(|input| input.get("job_name"))
+                                .and_then(Value::as_str)
+                                == Some("task_review_pipeline")
+                )
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(review_steps.len(), 1, "exactly one review Run is submitted");
+        let review = review_steps[0];
+        assert_eq!(review.id, "independent_review");
+        assert_eq!(review.retry, None);
+        assert_eq!(review.recovery_activity, None);
+        assert_eq!(
+            review.when.as_deref(),
+            Some(
+                "{{ input.review }} == true && {{ steps.commit.output.skipped_no_diff_expected }} != true"
+            )
+        );
+        let JobV2StepBody::TargetRef(target) = &review.body else {
+            panic!("independent review must use invoke_and_wait");
+        };
+        assert_eq!(target.target, "activity:invoke_and_wait");
+        let input = target
+            .default_input
+            .as_ref()
+            .expect("review dispatch input");
+        assert_eq!(input["job_name"], "task_review_pipeline");
+        assert_eq!(input["dedupe_run_input_field"], "parent_run_id");
+        let run_input = &input["run_input"];
+        assert_eq!(run_input["crew"], "{{ input.review_crew }}");
+        assert_eq!(
+            run_input["parent_run_id"],
+            "{{ steps.worktree.output.job_run_id }}"
+        );
+        assert_eq!(run_input["task_ids"], "{{ input.task_ids }}");
+        assert_eq!(
+            run_input["workspace_path"],
+            "{{ steps.worktree.output.workspace_path }}"
+        );
+        assert_eq!(
+            run_input["candidate_head"],
+            "{{ steps.push.output.branch }}"
+        );
+        assert_eq!(
+            run_input["candidate_head_sha"],
+            "{{ steps.push.output.local_sha }}"
+        );
+        assert_eq!(
+            run_input["pr_number"],
+            "{{ steps.pr_open.output.pr_number }}"
+        );
+
+        let step_ids = asset
+            .spec
+            .steps
+            .iter()
+            .map(|step| step.id.as_str())
+            .collect::<Vec<_>>();
+        let review_index = step_ids
+            .iter()
+            .position(|id| *id == "independent_review")
+            .expect("review index");
+        for prerequisite in ["push", "pr_open", "promote_tasks"] {
+            assert!(
+                step_ids
+                    .iter()
+                    .position(|id| *id == prerequisite)
+                    .expect("phase")
+                    < review_index,
+                "review must run after {prerequisite}"
+            );
+        }
+
         for job_name in ["task_pr_pipeline", "task_local_pipeline"] {
             let yaml = DEFAULT_JOB_FILES
                 .iter()
                 .find_map(|(name, yaml)| (*name == job_name).then_some(*yaml))
                 .unwrap_or_else(|| panic!("default job {job_name} exists"));
-            let asset = load_job_asset(yaml)
-                .unwrap_or_else(|err| panic!("default job {job_name} should parse: {err}"));
-            let defaults = asset
-                .spec
-                .default_input
-                .as_ref()
-                .unwrap_or_else(|| panic!("default job {job_name} has default input"));
-            assert_eq!(defaults["review"], false);
-            assert_eq!(defaults["review_crew"], Value::Null);
-
-            let review = asset
-                .spec
-                .steps
-                .iter()
-                .find(|step| step.id == "review_bundle")
-                .unwrap_or_else(|| panic!("default job {job_name} has review_bundle"));
-            assert_eq!(review.when.as_deref(), Some("{{ input.review }} == true"));
-            let JobV2StepBody::TargetRef(review_target) = &review.body else {
-                panic!("default job {job_name} review_bundle must reference agent_review");
-            };
-            assert_eq!(review_target.target, "activity:agent_review");
-            let review_input = review_target
-                .default_input
-                .as_ref()
-                .expect("review_bundle input");
-            assert_eq!(review_input["crew"], "{{ input.review_crew }}");
-
+            let asset = load_job_asset(yaml).expect("leaf job parses");
             let implement = asset
                 .spec
                 .steps
                 .iter()
                 .find(|step| step.id == "implement_bundle")
-                .unwrap_or_else(|| panic!("default job {job_name} has implement_bundle"));
+                .expect("implement bundle");
             let JobV2StepBody::Loop { loop_ } = &implement.body else {
-                panic!("default job {job_name} implement_bundle must be a loop");
+                panic!("implement bundle must be a loop");
             };
-            let implement_one = loop_
-                .steps
-                .iter()
-                .find(|step| step.id == "implement_one")
-                .expect("implement_bundle has implement_one");
-            let JobV2StepBody::TargetRef(implement_target) = &implement_one.body else {
-                panic!("default job {job_name} implement_one must reference agent_implement");
+            let JobV2StepBody::TargetRef(implement_target) = &loop_.steps[0].body else {
+                panic!("implement step must reference agent_implement");
             };
-            assert_eq!(implement_target.target, "activity:agent_implement");
             assert!(
                 implement_target
                     .default_input
                     .as_ref()
-                    .expect("implement_one input")
+                    .expect("implement input")
                     .get("crew")
                     .is_none(),
-                "default job {job_name} must not apply review_crew to implementation"
+                "review crew must not reach {job_name} implementation"
             );
         }
+    }
+
+    #[test]
+    fn independent_review_job_requires_structured_exact_head_verdict() {
+        let yaml = DEFAULT_JOB_FILES
+            .iter()
+            .find_map(|(name, yaml)| (*name == "task_review_pipeline").then_some(*yaml))
+            .expect("review pipeline exists");
+        let asset = load_job_asset(yaml).expect("review pipeline parses");
+        assert_eq!(asset.spec.steps.len(), 2);
+        let JobV2StepBody::TargetRef(review) = &asset.spec.steps[0].body else {
+            panic!("review step must be an activity reference");
+        };
+        assert_eq!(review.target, "activity:agent_review");
+        let review_input = review.default_input.as_ref().expect("review input");
+        for field in [
+            "task_ids",
+            "workspace_path",
+            "crew",
+            "parent_run_id",
+            "candidate_head",
+            "candidate_head_sha",
+            "pr_number",
+        ] {
+            assert!(review_input.get(field).is_some(), "missing {field}");
+        }
+        let JobV2StepBody::TargetRef(guard) = &asset.spec.steps[1].body else {
+            panic!("verdict guard must be an activity reference");
+        };
+        assert_eq!(guard.target, "activity:independent_review_guard");
+    }
+
+    #[test]
+    fn local_review_fails_before_worktree_or_implementation() {
+        let yaml = DEFAULT_JOB_FILES
+            .iter()
+            .find_map(|(name, yaml)| (*name == "task_local_pipeline").then_some(*yaml))
+            .expect("local pipeline exists");
+        let asset = load_job_asset(yaml).expect("local pipeline parses");
+        let first = asset.spec.steps.first().expect("local pipeline has steps");
+        assert_eq!(first.id, "reject_unsupported_review");
+        assert_eq!(first.when.as_deref(), Some("{{ input.review }} == true"));
+        assert!(matches!(
+            &first.body,
+            JobV2StepBody::TargetRef(target)
+                if target.target == "activity:pipeline_success_guard"
+        ));
+        assert!(
+            asset
+                .spec
+                .steps
+                .iter()
+                .all(|step| step.id != "review_bundle")
+        );
     }
 
     #[test]
@@ -600,11 +727,6 @@ spec:
             vec![
                 ("worktree", "activity:worktree_setup", None),
                 (
-                    "review_bundle",
-                    "activity:agent_review",
-                    Some("step_failure_recovery")
-                ),
-                (
                     "commit",
                     "activity:git_commit",
                     Some("step_failure_recovery")
@@ -625,6 +747,12 @@ spec:
                     "promote_tasks",
                     "activity:pr_promote",
                     Some("step_failure_recovery")
+                ),
+                ("independent_review", "activity:invoke_and_wait", None),
+                (
+                    "require_independent_review_success",
+                    "activity:pipeline_success_guard",
+                    None
                 ),
                 (
                     "promote_no_diff",
@@ -952,6 +1080,16 @@ spec:
                 "task_triage_pipeline",
                 "triage",
                 "steps.triage.output.dispositions",
+            ),
+            (
+                "task_review_pipeline",
+                "independent_review",
+                "steps.independent_review.output.verdict",
+            ),
+            (
+                "task_review_pipeline",
+                "independent_review",
+                "steps.independent_review.output.reviewed_head_sha",
             ),
         ]);
 

--- a/crates/orbit-core/src/command/pipeline_run.rs
+++ b/crates/orbit-core/src/command/pipeline_run.rs
@@ -5,14 +5,17 @@ use std::thread;
 use std::time::{Duration, Instant};
 
 use chrono::Utc;
+use orbit_common::types::activity_job::{ActivityV2Spec, Backend, JobV2StepBody, Provider};
 use orbit_common::types::{
-    AuditEventStatus, JobRun, JobRunState, JobScheduleState, JobTargetType, NotFoundKind,
-    OrbitError, OrbitEvent, PipelineState, audit_execution_id,
+    AuditEventStatus, Crew, JobRun, JobRunState, JobScheduleState, JobTargetType, JobV2,
+    NotFoundKind, OrbitError, OrbitEvent, PipelineState, audit_execution_id,
 };
 use orbit_store::{AuditEventInsertParams, JobRunStepParams, TaskReservationReleaseReason};
 use serde::Serialize;
 use serde_json::{Value, json};
 use sha2::{Digest, Sha256};
+
+use orbit_engine::V2RuntimeHost;
 
 use crate::OrbitRuntime;
 
@@ -23,6 +26,8 @@ const PIPELINE_WAIT_DEFAULT_TIMEOUT_SECONDS: u64 = 3600;
 const PIPELINE_WAIT_MAX_TIMEOUT_SECONDS: u64 = 7200;
 const PIPELINE_WAIT_DEFAULT_POLL_SECONDS: u64 = 5;
 const PIPELINE_WAIT_MIN_POLL_SECONDS: u64 = 1;
+// ADR-0233: independent review is a post-publication exact-head child Run.
+const INDEPENDENT_REVIEW_JOB: &str = "task_review_pipeline";
 
 #[derive(Debug, Clone, Serialize)]
 pub struct PipelineInvokeResult {
@@ -73,7 +78,116 @@ impl OrbitRuntime {
         let base = base_branch.unwrap_or_else(|| self.workflow_base_branch());
         let input =
             crate::command::workflow::build_ship_input(mode, base, task_ids, review, review_crew)?;
+        if review {
+            let review_crew = input
+                .get("review_crew")
+                .and_then(Value::as_str)
+                .ok_or_else(|| {
+                    OrbitError::InvalidInput(
+                        "ship review requires a materialized review crew".to_string(),
+                    )
+                })?;
+            self.preflight_independent_review(task_ids, review_crew)?;
+        }
         self.submit_pipeline_run(workflow.job_id, input, None, actor)
+    }
+
+    fn preflight_independent_review(
+        &self,
+        task_ids: &[String],
+        review_crew_name: &str,
+    ) -> Result<(), OrbitError> {
+        // L-0094: opt-in workflow promises must be materializable before the parent Run exists.
+        let review_crew = self.resolve_crew_for_task(Some(review_crew_name), None)?;
+        validate_review_crew_runtime(self, &review_crew)?;
+
+        for task_id in task_ids {
+            let task = self.get_task(task_id)?;
+            let implementation_crew = self.resolve_crew_for_task(None, task.crew.as_deref())?;
+            if implementation_crew.name == review_crew.name
+                || crews_share_runtime_assignment(&implementation_crew, &review_crew)
+            {
+                return Err(OrbitError::InvalidInput(format!(
+                    "ship review crew '{}' is not independent from task {} implementation crew '{}'",
+                    review_crew.name, task.id, implementation_crew.name
+                )));
+            }
+        }
+
+        self.preflight_independent_review_assets()
+    }
+
+    fn preflight_independent_review_assets(&self) -> Result<(), OrbitError> {
+        let load_job = |name: &str| {
+            self.load_v2_job_asset_by_name(name)
+                .map_err(|error| review_asset_error(format!("load deployed {name}: {error}")))
+        };
+        let (_, auto) = load_job("task_auto_pipeline")?;
+        let (_, gate) = load_job("task_gate_pipeline")?;
+        for (name, job) in [("task_auto_pipeline", &auto), ("task_gate_pipeline", &gate)] {
+            if !job_forwards_review_controls(job) {
+                return Err(review_asset_error(format!(
+                    "deployed {name} does not forward review and review_crew"
+                )));
+            }
+        }
+
+        let (_, pr) = load_job("task_pr_pipeline")?;
+        validate_pr_review_contract(&pr)?;
+
+        let (_, review) = load_job(INDEPENDENT_REVIEW_JOB)?;
+        validate_review_job_contract(&review)?;
+
+        let activities = self.v2_activity_catalog().map_err(|error| {
+            review_asset_error(format!("load deployed review activities: {error}"))
+        })?;
+        let agent_review = activities
+            .get("agent_review")
+            .ok_or_else(|| review_asset_error("deployed agent_review activity is missing"))?;
+        let ActivityV2Spec::AgentLoop(agent_spec) = &agent_review.spec else {
+            return Err(review_asset_error(
+                "deployed agent_review is not an agent_loop activity",
+            ));
+        };
+        if agent_spec.role.is_some()
+            || !agent_spec.require_response_envelope
+            || !schema_requires(&agent_review.output_schema_json, "verdict")
+            || !schema_requires(&agent_review.output_schema_json, "reviewed_head_sha")
+        {
+            return Err(review_asset_error(
+                "deployed agent_review still relies on a role or does not require a structured exact-head verdict",
+            ));
+        }
+
+        let guard = activities
+            .get("independent_review_guard")
+            .ok_or_else(|| review_asset_error("deployed independent_review_guard is missing"))?;
+        match &guard.spec {
+            ActivityV2Spec::Deterministic(spec) if spec.action == "independent_review_guard" => {}
+            _ => {
+                return Err(review_asset_error(
+                    "deployed independent_review_guard has the wrong action",
+                ));
+            }
+        }
+        for (name, action) in [
+            ("invoke_and_wait", "invoke_and_wait"),
+            ("pipeline_success_guard", "pipeline_success_guard"),
+        ] {
+            let activity = activities.get(name).ok_or_else(|| {
+                review_asset_error(format!("deployed {name} activity is missing"))
+            })?;
+            match &activity.spec {
+                ActivityV2Spec::Deterministic(spec) if spec.action == action => {}
+                _ => {
+                    return Err(review_asset_error(format!(
+                        "deployed {name} activity has the wrong action"
+                    )));
+                }
+            }
+        }
+
+        Ok(())
     }
 
     pub fn submit_pipeline_run(
@@ -714,6 +828,274 @@ impl OrbitRuntime {
             step_index: None,
         })
     }
+}
+
+fn validate_review_crew_runtime(runtime: &OrbitRuntime, crew: &Crew) -> Result<(), OrbitError> {
+    if crew.assignment.model.trim().is_empty() {
+        return Err(OrbitError::InvalidInput(format!(
+            "ship review crew '{}' has no materializable model",
+            crew.name
+        )));
+    }
+    let provider = Provider::parse(&crew.assignment.provider).map_err(|error| {
+        OrbitError::InvalidInput(format!(
+            "ship review crew '{}' has an unmaterializable provider: {error}",
+            crew.name
+        ))
+    })?;
+    let backend = Backend::parse(&crew.assignment.backend).ok_or_else(|| {
+        OrbitError::InvalidInput(format!(
+            "ship review crew '{}' has unknown backend '{}'",
+            crew.name, crew.assignment.backend
+        ))
+    })?;
+
+    match backend {
+        Backend::Cli => V2RuntimeHost::resolve_cli_executor(runtime, provider.as_str())
+            .map(|_| ())
+            .map_err(|error| {
+                OrbitError::InvalidInput(format!(
+                    "ship review crew '{}' cannot materialize its CLI executor: {error}",
+                    crew.name
+                ))
+            }),
+        Backend::Http if provider.has_http_transport() => Ok(()),
+        Backend::Http => Err(OrbitError::InvalidInput(format!(
+            "ship review crew '{}' selects provider '{}' without an HTTP transport",
+            crew.name, provider
+        ))),
+        Backend::Auto => Err(OrbitError::InvalidInput(format!(
+            "ship review crew '{}' must resolve to a concrete backend before submission",
+            crew.name
+        ))),
+    }
+}
+
+fn crews_share_runtime_assignment(left: &Crew, right: &Crew) -> bool {
+    left.assignment.model.trim() == right.assignment.model.trim()
+        && Provider::parse(&left.assignment.provider).ok()
+            == Provider::parse(&right.assignment.provider).ok()
+        && Backend::parse(&left.assignment.backend) == Backend::parse(&right.assignment.backend)
+}
+
+fn job_forwards_review_controls(job: &JobV2) -> bool {
+    let Some(defaults) = job.default_input.as_ref() else {
+        return false;
+    };
+    if defaults.get("review") != Some(&Value::Bool(false))
+        || defaults.get("review_crew") != Some(&Value::Null)
+    {
+        return false;
+    }
+    serde_json::to_value(job)
+        .ok()
+        .is_some_and(|value| value_contains_review_forwarding(&value))
+}
+
+fn value_contains_review_forwarding(value: &Value) -> bool {
+    match value {
+        Value::Object(map) => {
+            let matches = map.get("review").and_then(Value::as_str) == Some("{{ input.review }}")
+                && map.get("review_crew").and_then(Value::as_str)
+                    == Some("{{ input.review_crew }}");
+            matches || map.values().any(value_contains_review_forwarding)
+        }
+        Value::Array(values) => values.iter().any(value_contains_review_forwarding),
+        _ => false,
+    }
+}
+
+fn validate_pr_review_contract(job: &JobV2) -> Result<(), OrbitError> {
+    let review_steps = job
+        .steps
+        .iter()
+        .filter(|step| {
+            matches!(
+                &step.body,
+                JobV2StepBody::TargetRef(target)
+                    if target.target == "activity:invoke_and_wait"
+                        && target
+                            .default_input
+                            .as_ref()
+                            .and_then(|input| input.get("job_name"))
+                            .and_then(Value::as_str)
+                            == Some(INDEPENDENT_REVIEW_JOB)
+            )
+        })
+        .collect::<Vec<_>>();
+    if review_steps.len() != 1 {
+        return Err(review_asset_error(format!(
+            "deployed task_pr_pipeline has {} independent review dispatches (expected exactly one)",
+            review_steps.len()
+        )));
+    }
+    let review = review_steps[0];
+    if review.id != "independent_review" {
+        return Err(review_asset_error(
+            "deployed task_pr_pipeline review dispatch has the wrong step id",
+        ));
+    }
+    if review.retry.is_some() || review.recovery_activity.is_some() {
+        return Err(review_asset_error(
+            "deployed task_pr_pipeline review dispatch can retry and create multiple review Runs",
+        ));
+    }
+    if review.when.as_deref().is_none_or(|when| {
+        !when.contains("input.review") || !when.contains("skipped_no_diff_expected")
+    }) {
+        return Err(review_asset_error(
+            "deployed task_pr_pipeline review dispatch is not opt-in and candidate-gated",
+        ));
+    }
+    let JobV2StepBody::TargetRef(target) = &review.body else {
+        return Err(review_asset_error(
+            "deployed task_pr_pipeline review dispatch is not an activity reference",
+        ));
+    };
+    if target.target != "activity:invoke_and_wait" {
+        return Err(review_asset_error(
+            "deployed task_pr_pipeline review dispatch does not create a durable child Run",
+        ));
+    }
+    let input = target
+        .default_input
+        .as_ref()
+        .ok_or_else(|| review_asset_error("deployed review dispatch has no input"))?;
+    if input.get("dedupe_run_input_field").and_then(Value::as_str) != Some("parent_run_id") {
+        return Err(review_asset_error(
+            "deployed review dispatch does not deduplicate retry/resume by parent_run_id",
+        ));
+    }
+    let run_input = input
+        .get("run_input")
+        .and_then(Value::as_object)
+        .ok_or_else(|| review_asset_error("deployed review dispatch has no run_input object"))?;
+    for field in [
+        "task_ids",
+        "workspace_path",
+        "crew",
+        "parent_run_id",
+        "candidate_head",
+        "candidate_head_sha",
+        "pr_number",
+    ] {
+        if !run_input.contains_key(field) {
+            return Err(review_asset_error(format!(
+                "deployed review dispatch omits lineage field '{field}'"
+            )));
+        }
+    }
+
+    let review_index = job
+        .steps
+        .iter()
+        .position(|step| step.id == "independent_review")
+        .unwrap_or_default();
+    for prerequisite in ["push", "pr_open", "promote_tasks"] {
+        let Some(index) = job.steps.iter().position(|step| step.id == prerequisite) else {
+            return Err(review_asset_error(format!(
+                "deployed task_pr_pipeline omits prerequisite '{prerequisite}'"
+            )));
+        };
+        if index >= review_index {
+            return Err(review_asset_error(format!(
+                "deployed task_pr_pipeline starts review before '{prerequisite}'"
+            )));
+        }
+    }
+
+    let Some(guard) = job
+        .steps
+        .iter()
+        .skip(review_index + 1)
+        .find(|step| step.id == "require_independent_review_success")
+    else {
+        return Err(review_asset_error(
+            "deployed task_pr_pipeline does not gate on the independent review Run",
+        ));
+    };
+    if !matches!(
+        &guard.body,
+        JobV2StepBody::TargetRef(target) if target.target == "activity:pipeline_success_guard"
+    ) {
+        return Err(review_asset_error(
+            "deployed task_pr_pipeline independent review gate has the wrong activity",
+        ));
+    }
+
+    Ok(())
+}
+
+fn validate_review_job_contract(job: &JobV2) -> Result<(), OrbitError> {
+    let agent_steps = job
+        .steps
+        .iter()
+        .filter(|step| {
+            matches!(
+                &step.body,
+                JobV2StepBody::TargetRef(target) if target.target == "activity:agent_review"
+            )
+        })
+        .collect::<Vec<_>>();
+    if agent_steps.len() != 1 {
+        return Err(review_asset_error(format!(
+            "deployed task_review_pipeline has {} agent_review steps (expected exactly one)",
+            agent_steps.len()
+        )));
+    }
+    let agent_input = match &agent_steps[0].body {
+        JobV2StepBody::TargetRef(target) => target.default_input.as_ref(),
+        _ => None,
+    }
+    .and_then(Value::as_object)
+    .ok_or_else(|| review_asset_error("deployed agent_review step has no input object"))?;
+    for field in [
+        "task_ids",
+        "workspace_path",
+        "crew",
+        "parent_run_id",
+        "candidate_head",
+        "candidate_head_sha",
+        "pr_number",
+    ] {
+        if !agent_input.contains_key(field) {
+            return Err(review_asset_error(format!(
+                "deployed agent_review step omits lineage field '{field}'"
+            )));
+        }
+    }
+
+    let guards = job
+        .steps
+        .iter()
+        .filter(|step| {
+            matches!(
+                &step.body,
+                JobV2StepBody::TargetRef(target)
+                    if target.target == "activity:independent_review_guard"
+            )
+        })
+        .count();
+    if guards != 1 {
+        return Err(review_asset_error(format!(
+            "deployed task_review_pipeline has {guards} exact-head verdict guards (expected one)"
+        )));
+    }
+    Ok(())
+}
+
+fn schema_requires(schema: &Value, field: &str) -> bool {
+    schema
+        .get("required")
+        .and_then(Value::as_array)
+        .is_some_and(|required| required.iter().any(|value| value.as_str() == Some(field)))
+}
+
+fn review_asset_error(message: impl Into<String>) -> OrbitError {
+    OrbitError::InvalidInput(format!(
+        "ship review cannot be materialized by deployed assets: {}",
+        message.into()
+    ))
 }
 
 /// Return a stable path suitable for launching a fresh worker process.

--- a/crates/orbit-core/src/command/tests/pipeline_run.rs
+++ b/crates/orbit-core/src/command/tests/pipeline_run.rs
@@ -7,9 +7,12 @@ use orbit_common::types::{AuditEventStatus, JobRunState};
 use tempfile::TempDir;
 
 use crate::OrbitRuntime;
+use crate::command::job::JobRunListParams;
 use crate::command::pipeline_run::{
     configure_pipeline_worker_command, resolve_pipeline_worker_executable,
 };
+use crate::command::task::TaskAddParams;
+use crate::command::workflow::ShipMode;
 
 fn test_runtime() -> (TempDir, OrbitRuntime) {
     let root = TempDir::new().expect("tempdir");
@@ -20,6 +23,65 @@ fn test_runtime() -> (TempDir, OrbitRuntime) {
     let runtime =
         OrbitRuntime::from_roots(&global_root, &workspace_root).expect("build test runtime");
     (root, runtime)
+}
+
+fn review_test_runtime() -> (TempDir, OrbitRuntime) {
+    let root = TempDir::new().expect("tempdir");
+    let global_root = root.path().join("global");
+    let workspace_root = root.path().join("repo/.orbit");
+    std::fs::create_dir_all(&global_root).expect("create global root");
+    std::fs::create_dir_all(&workspace_root).expect("create workspace root");
+    std::fs::write(
+        workspace_root.join("config.toml"),
+        r#"
+[workflow]
+base_branch = "main"
+default_crew = "sol"
+
+[crews.sol]
+model = "gpt-5.6-sol"
+provider = "codex"
+backend = "cli"
+
+[crews.opus]
+model = "opus"
+provider = "claude"
+backend = "cli"
+
+[crews.opus_alias]
+model = "opus"
+provider = "claude"
+backend = "cli"
+
+[crews.opus_vendor_alias]
+model = "opus"
+provider = "anthropic"
+backend = "cli"
+
+[crews.unmaterializable]
+model = "mystery"
+provider = "not-a-provider"
+backend = "cli"
+"#,
+    )
+    .expect("write config");
+    let runtime =
+        OrbitRuntime::from_roots(&global_root, &workspace_root).expect("build test runtime");
+    (root, runtime)
+}
+
+fn add_review_test_task(runtime: &OrbitRuntime, crew: &str) -> String {
+    runtime
+        .add_task(TaskAddParams {
+            title: "review preflight fixture".to_string(),
+            description: "prove review validation occurs before submission".to_string(),
+            plan: "validate without implementation side effects".to_string(),
+            status: Some(orbit_common::types::TaskStatus::Backlog),
+            crew: Some(crew.to_string()),
+            ..TaskAddParams::default()
+        })
+        .expect("add task")
+        .id
 }
 
 #[test]
@@ -124,5 +186,72 @@ fn deleted_current_executable_resolves_to_replaced_installed_path() {
         resolve_pipeline_worker_executable(deleted_inode_path),
         installed,
         "the worker must launch through the replacement at the installed path"
+    );
+}
+
+#[test]
+fn review_submission_rejects_unknown_same_or_unmaterializable_crews_before_run_insert() {
+    for (review_crew, expected) in [
+        ("missing", "is not defined"),
+        ("sol", "is not independent"),
+        ("opus_alias", "is not independent"),
+        ("opus_vendor_alias", "is not independent"),
+        ("unmaterializable", "unmaterializable provider"),
+    ] {
+        let (_root, runtime) = review_test_runtime();
+        let implementation_crew = if matches!(review_crew, "opus_alias" | "opus_vendor_alias") {
+            "opus"
+        } else {
+            "sol"
+        };
+        let task_id = add_review_test_task(&runtime, implementation_crew);
+
+        let error = runtime
+            .submit_ship_run(
+                ShipMode::Pr,
+                Some("main"),
+                &[task_id],
+                true,
+                Some(review_crew),
+                Some("test"),
+            )
+            .expect_err("invalid review crew must fail before submission");
+
+        assert!(
+            error.to_string().contains(expected),
+            "unexpected error for {review_crew}: {error}"
+        );
+        assert!(
+            runtime
+                .list_job_runs(JobRunListParams::default())
+                .expect("list job runs")
+                .is_empty(),
+            "validation failure must not persist an implementation run"
+        );
+    }
+}
+
+#[test]
+fn review_submission_fails_closed_when_deployed_review_assets_are_missing() {
+    let (_root, runtime) = review_test_runtime();
+    let task_id = add_review_test_task(&runtime, "sol");
+
+    let error = runtime
+        .submit_ship_run(
+            ShipMode::Pr,
+            Some("main"),
+            &[task_id],
+            true,
+            Some("opus"),
+            Some("test"),
+        )
+        .expect_err("missing review assets must fail before submission");
+
+    assert!(error.to_string().contains("job not found"), "{error}");
+    assert!(
+        runtime
+            .list_job_runs(JobRunListParams::default())
+            .expect("list job runs")
+            .is_empty()
     );
 }

--- a/crates/orbit-core/src/command/workflow.rs
+++ b/crates/orbit-core/src/command/workflow.rs
@@ -138,6 +138,16 @@ pub fn build_ship_input(
             "ship base branch must not be empty".to_string(),
         ));
     }
+    if review && mode != ShipMode::Pr {
+        return Err(OrbitError::InvalidInput(
+            "ship review is supported only for PR mode".to_string(),
+        ));
+    }
+    if review && task_ids.is_empty() {
+        return Err(OrbitError::InvalidInput(
+            "ship review requires an explicit task id selection".to_string(),
+        ));
+    }
     let mut seen = std::collections::HashSet::new();
     for task_id in task_ids {
         if task_id.trim().is_empty() {
@@ -377,23 +387,53 @@ mod ship_input_tests {
 
     #[test]
     fn build_ship_input_includes_explicit_review_controls() {
-        let input = build_ship_input(ShipMode::Pr, "main", &[], true, Some("opus-review"))
-            .expect("review input builds");
+        let input = build_ship_input(
+            ShipMode::Pr,
+            "main",
+            &["ORB-10000".to_string()],
+            true,
+            Some("opus-review"),
+        )
+        .expect("review input builds");
 
         assert_eq!(input["review"], true);
         assert_eq!(input["review_crew"], "opus-review");
+        assert_eq!(input["task_ids"], serde_json::json!(["ORB-10000"]));
     }
 
     #[test]
     fn build_ship_input_rejects_enabled_review_without_non_blank_crew() {
         for review_crew in [None, Some(""), Some("   ")] {
-            let error = build_ship_input(ShipMode::Pr, "main", &[], true, review_crew)
-                .expect_err("enabled review requires a crew");
+            let error = build_ship_input(
+                ShipMode::Pr,
+                "main",
+                &["ORB-10000".to_string()],
+                true,
+                review_crew,
+            )
+            .expect_err("enabled review requires a crew");
             assert!(
                 error.to_string().contains("non-blank explicit review crew"),
                 "unexpected error: {error}"
             );
         }
+    }
+
+    #[test]
+    fn build_ship_input_rejects_review_without_explicit_pr_tasks() {
+        let auto_error = build_ship_input(ShipMode::Pr, "main", &[], true, Some("opus"))
+            .expect_err("review cannot auto-discover tasks");
+        assert!(auto_error.to_string().contains("explicit task id"));
+
+        let local_error = build_ship_input(
+            ShipMode::Local,
+            "main",
+            &["ORB-10000".to_string()],
+            true,
+            Some("opus"),
+        )
+        .expect_err("review is PR-only");
+        assert!(local_error.to_string().contains("only for PR mode"));
     }
 
     #[test]

--- a/crates/orbit-core/src/runtime/v2_host/dispatch.rs
+++ b/crates/orbit-core/src/runtime/v2_host/dispatch.rs
@@ -292,6 +292,9 @@ pub(super) fn run_deterministic(
         // Fail a workflow if one or more child pipeline wait results did not
         // reach `succeeded`.
         "pipeline_success_guard" => pipeline_actions::pipeline_success_guard(action, input),
+        // Require the independent reviewer to return a structured verdict for
+        // the exact candidate SHA snapshotted by the PR pipeline.
+        "independent_review_guard" => pipeline_actions::independent_review_guard(action, input),
         // Post-loop gate signal: the admission window never opened in
         // time. Emits a `gate.starvation` audit event with task_ids and
         // conflicting_files so an epic-orchestrator parent can decide

--- a/crates/orbit-core/src/runtime/v2_host/mod.rs
+++ b/crates/orbit-core/src/runtime/v2_host/mod.rs
@@ -281,6 +281,33 @@ impl V2RuntimeHost for OrbitRuntime {
         )
     }
 
+    fn explicit_agent_crew_config_for_input(
+        &self,
+        input: &serde_json::Value,
+    ) -> Result<Option<AgentRoleConfig>, DispatchError> {
+        let Some(explicit) = input
+            .get("crew")
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+        else {
+            return Ok(None);
+        };
+        let crew = self
+            .resolve_crew_for_task(Some(explicit), None)
+            .map_err(|error| {
+                DispatchError::JobValidation(format!(
+                    "explicit activity crew '{explicit}' cannot be resolved: {error}"
+                ))
+            })?;
+        Ok(Some(
+            crate::runtime::engine::environment_host::typed_role_config_from_assignment(
+                AgentRole::Reviewer,
+                &crew.assignment,
+            ),
+        ))
+    }
+
     fn api_key_for(&self, provider: &str) -> Result<String, DispatchError> {
         match provider {
             "anthropic" => {

--- a/crates/orbit-core/src/runtime/v2_host/pipeline_actions.rs
+++ b/crates/orbit-core/src/runtime/v2_host/pipeline_actions.rs
@@ -7,6 +7,7 @@ use orbit_tools::ToolContext;
 use serde_json::Value;
 
 use crate::OrbitRuntime;
+use crate::command::job::JobRunListParams;
 use crate::runtime::orbit_tool_host::parse_task_ids;
 
 pub(super) fn validate_bundles(action: &str, input: &Value) -> Result<Value, DispatchError> {
@@ -101,34 +102,39 @@ pub(super) fn invoke_and_wait(
         .get("run_input")
         .cloned()
         .unwrap_or_else(|| Value::Object(Default::default()));
-    let mut invoke_args = serde_json::Map::new();
-    invoke_args.insert("job_name".to_string(), Value::String(job_name.clone()));
-    invoke_args.insert("input".to_string(), run_input);
-    if let Some(priority) = input.get("priority").cloned() {
-        invoke_args.insert("priority".to_string(), priority);
-    }
+    let run_id = match deduped_child_run_id(runtime, action, input, &job_name, &run_input)? {
+        Some(run_id) => run_id,
+        None => {
+            let mut invoke_args = serde_json::Map::new();
+            invoke_args.insert("job_name".to_string(), Value::String(job_name.clone()));
+            invoke_args.insert("input".to_string(), run_input);
+            if let Some(priority) = input.get("priority").cloned() {
+                invoke_args.insert("priority".to_string(), priority);
+            }
 
-    let invoke_ctx = tool_context.clone();
-    let invoke_output = runtime
-        .run_tool_with_context_and_role(
-            "orbit.pipeline.invoke",
-            Value::Object(invoke_args),
-            Role::Admin,
-            invoke_ctx,
-        )
-        .map_err(|err| DispatchError::DeterministicActionFailed {
-            action: action.to_string(),
-            message: format!("pipeline.invoke failed: {err}"),
-        })?;
+            let invoke_ctx = tool_context.clone();
+            let invoke_output = runtime
+                .run_tool_with_context_and_role(
+                    "orbit.pipeline.invoke",
+                    Value::Object(invoke_args),
+                    Role::Admin,
+                    invoke_ctx,
+                )
+                .map_err(|err| DispatchError::DeterministicActionFailed {
+                    action: action.to_string(),
+                    message: format!("pipeline.invoke failed: {err}"),
+                })?;
 
-    let run_id = invoke_output
-        .get("run_id")
-        .and_then(Value::as_str)
-        .ok_or_else(|| DispatchError::DeterministicActionFailed {
-            action: action.to_string(),
-            message: "pipeline.invoke returned no run_id".to_string(),
-        })?
-        .to_string();
+            invoke_output
+                .get("run_id")
+                .and_then(Value::as_str)
+                .ok_or_else(|| DispatchError::DeterministicActionFailed {
+                    action: action.to_string(),
+                    message: "pipeline.invoke returned no run_id".to_string(),
+                })?
+                .to_string()
+        }
+    };
 
     let mut wait_args = serde_json::Map::new();
     wait_args.insert(
@@ -166,6 +172,64 @@ pub(super) fn invoke_and_wait(
             })
         });
     Ok(first)
+}
+
+fn deduped_child_run_id(
+    runtime: &OrbitRuntime,
+    action: &str,
+    input: &Value,
+    job_name: &str,
+    run_input: &Value,
+) -> Result<Option<String>, DispatchError> {
+    let Some(field) = input
+        .get("dedupe_run_input_field")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    else {
+        return Ok(None);
+    };
+    let key = run_input
+        .get(field)
+        .filter(|value| !value.is_null())
+        .ok_or_else(|| {
+            action_failed(
+                action,
+                format!("dedupe field '{field}' is missing from run_input"),
+            )
+        })?;
+    let runs = runtime
+        .list_job_runs(JobRunListParams {
+            job_id: Some(job_name.to_string()),
+            ..JobRunListParams::default()
+        })
+        .map_err(|error| {
+            action_failed(
+                action,
+                format!("list existing {job_name} Runs for dedupe: {error}"),
+            )
+        })?;
+    let matches = runs
+        .into_iter()
+        .filter(|run| {
+            run.input
+                .as_ref()
+                .and_then(|value| value.get(field))
+                .is_some_and(|value| value == key)
+        })
+        .map(|run| run.run_id)
+        .collect::<Vec<_>>();
+    match matches.as_slice() {
+        [] => Ok(None),
+        [run_id] => Ok(Some(run_id.clone())),
+        _ => Err(action_failed(
+            action,
+            format!(
+                "multiple {job_name} Runs match dedupe field '{field}' value {key}: {}",
+                matches.join(", ")
+            ),
+        )),
+    }
 }
 
 fn stale_gate_admission_noop(
@@ -411,6 +475,57 @@ pub(super) fn pipeline_success_guard(action: &str, input: &Value) -> Result<Valu
     }))
 }
 
+pub(super) fn independent_review_guard(
+    action: &str,
+    input: &Value,
+) -> Result<Value, DispatchError> {
+    let verdict = input
+        .get("verdict")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| action_failed(action, "missing non-blank `verdict`".to_string()))?;
+    if !matches!(verdict, "approve" | "request_changes") {
+        return Err(action_failed(
+            action,
+            format!(
+                "unknown independent review verdict '{verdict}' (expected 'approve' or 'request_changes')"
+            ),
+        ));
+    }
+
+    let reviewed_head_sha = input
+        .get("reviewed_head_sha")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| {
+            action_failed(action, "missing non-blank `reviewed_head_sha`".to_string())
+        })?;
+    let candidate_head_sha = input
+        .get("candidate_head_sha")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| {
+            action_failed(action, "missing non-blank `candidate_head_sha`".to_string())
+        })?;
+    if reviewed_head_sha != candidate_head_sha {
+        return Err(action_failed(
+            action,
+            format!(
+                "independent review head mismatch: reviewer reported '{reviewed_head_sha}', published candidate is '{candidate_head_sha}'"
+            ),
+        ));
+    }
+
+    Ok(serde_json::json!({
+        "verdict": verdict,
+        "reviewed_head_sha": reviewed_head_sha,
+        "exact_head": true,
+    }))
+}
+
 fn pipeline_wait_entry_failure(label: &str, entry: &Value) -> Option<String> {
     let Some(status) = entry.get("status").and_then(Value::as_str) else {
         return Some(format!("{label} missing string status"));
@@ -604,5 +719,103 @@ mod tests {
         let message = action_failure_message(err);
         assert!(message.contains("results[1] run jrun-cancelled status cancelled"));
         assert!(message.contains("results[2] missing string status"));
+    }
+
+    #[test]
+    fn invoke_and_wait_dedupe_reuses_one_run_and_rejects_multiple_matches() {
+        let runtime = OrbitRuntime::in_memory().expect("runtime");
+        let first = runtime
+            .stores()
+            .jobs()
+            .insert_run(
+                "task_review_pipeline",
+                1,
+                chrono::Utc::now(),
+                Some(json!({ "parent_run_id": "jrun-parent" })),
+                None,
+            )
+            .expect("insert first review run");
+        let action_input = json!({ "dedupe_run_input_field": "parent_run_id" });
+        let run_input = json!({ "parent_run_id": "jrun-parent" });
+
+        let reused = deduped_child_run_id(
+            &runtime,
+            "invoke_and_wait",
+            &action_input,
+            "task_review_pipeline",
+            &run_input,
+        )
+        .expect("dedupe lookup");
+        assert_eq!(reused.as_deref(), Some(first.run_id.as_str()));
+
+        runtime
+            .stores()
+            .jobs()
+            .insert_run(
+                "task_review_pipeline",
+                1,
+                chrono::Utc::now(),
+                Some(json!({ "parent_run_id": "jrun-parent" })),
+                None,
+            )
+            .expect("insert duplicate review run");
+        let error = deduped_child_run_id(
+            &runtime,
+            "invoke_and_wait",
+            &action_input,
+            "task_review_pipeline",
+            &run_input,
+        )
+        .expect_err("multiple matching review runs fail closed");
+        assert!(matches!(
+            error,
+            DispatchError::DeterministicActionFailed { .. }
+        ));
+    }
+
+    #[test]
+    fn independent_review_guard_accepts_both_exact_head_verdicts() {
+        for verdict in ["approve", "request_changes"] {
+            let output = independent_review_guard(
+                "independent_review_guard",
+                &json!({
+                    "verdict": verdict,
+                    "reviewed_head_sha": "abc123",
+                    "candidate_head_sha": "abc123",
+                }),
+            )
+            .expect("exact-head verdict passes");
+
+            assert_eq!(output["verdict"], verdict);
+            assert_eq!(output["reviewed_head_sha"], "abc123");
+            assert_eq!(output["exact_head"], true);
+        }
+    }
+
+    #[test]
+    fn independent_review_guard_fails_closed_on_missing_or_mismatched_verdict() {
+        for input in [
+            json!({
+                "reviewed_head_sha": "abc123",
+                "candidate_head_sha": "abc123",
+            }),
+            json!({
+                "verdict": "looks_good",
+                "reviewed_head_sha": "abc123",
+                "candidate_head_sha": "abc123",
+            }),
+            json!({
+                "verdict": "approve",
+                "reviewed_head_sha": "def456",
+                "candidate_head_sha": "abc123",
+            }),
+        ] {
+            let error = independent_review_guard("independent_review_guard", &input)
+                .expect_err("invalid verdict must fail");
+            assert!(matches!(
+                error,
+                DispatchError::DeterministicActionFailed { .. }
+            ));
+        }
     }
 }

--- a/crates/orbit-dashboard/src/api/tests/runs.rs
+++ b/crates/orbit-dashboard/src/api/tests/runs.rs
@@ -9,6 +9,8 @@ use axum::http::{Method, Request, StatusCode, header};
 use axum::response::Response;
 use chrono::Utc;
 use orbit_common::utility::blob_store::BlobStore;
+use orbit_core::command::job::JobRunListParams;
+use orbit_core::command::task::TaskAddParams;
 use orbit_core::{JobRunState, OrbitRuntime, V2AuditEventInsertParams};
 use serde_json::{Value, json};
 use tower::ServiceExt;
@@ -595,6 +597,49 @@ fn run_detail_uses_v2_audit_steps_when_step_bundle_is_empty() {
     assert_eq!(steps[0]["duration_ms"], 2_000);
 }
 
+#[test]
+fn independent_review_run_detail_projects_crew_and_exact_head_lineage() {
+    let runtime = OrbitRuntime::in_memory().expect("build runtime");
+    let scheduled_at = Utc::now();
+    let run = orbit_core::JobRun {
+        run_id: "jrun-independent-review".to_string(),
+        job_id: "task_review_pipeline".to_string(),
+        attempt: 1,
+        state: JobRunState::Success,
+        scheduled_at,
+        started_at: Some(scheduled_at),
+        finished_at: Some(scheduled_at),
+        duration_ms: Some(1),
+        created_at: scheduled_at,
+        pid: None,
+        pid_start_time: None,
+        input: Some(json!({
+            "task_ids": ["ORB-10266"],
+            "workspace_path": "/tmp/review-worktree",
+            "crew": "opus",
+            "parent_run_id": "jrun-parent",
+            "candidate_head": "orbit/ORB-10266-branch",
+            "candidate_head_sha": "abc123",
+            "pr_number": "633",
+        })),
+        retry_source_run_id: None,
+        knowledge_metrics: None,
+        resolved_crew: Some("opus".to_string()),
+        crew_model: Some("opus".to_string()),
+        steps: Vec::new(),
+    };
+
+    let detail = job_run_detail_to_json(&runtime, &run);
+    assert_eq!(detail["run"]["job_id"], "task_review_pipeline");
+    assert_eq!(detail["run"]["resolved_crew"], "opus");
+    let lineage = &detail["run"]["review_lineage"];
+    assert_eq!(lineage["parent_run_id"], "jrun-parent");
+    assert_eq!(lineage["task_ids"], json!(["ORB-10266"]));
+    assert_eq!(lineage["workspace_path"], "/tmp/review-worktree");
+    assert_eq!(lineage["candidate_head_sha"], "abc123");
+    assert_eq!(lineage["pr_number"], "633");
+}
+
 async fn request_ship(runtime: OrbitRuntime, body: Option<Value>) -> Response {
     let mut builder = Request::builder()
         .method(Method::POST)
@@ -614,17 +659,211 @@ async fn request_ship(runtime: OrbitRuntime, body: Option<Value>) -> Response {
         .expect("response")
 }
 
+fn review_ship_runtime() -> (tempfile::TempDir, OrbitRuntime, String) {
+    let root = tempfile::tempdir().expect("tempdir");
+    let global_root = root.path().join("global");
+    let orbit_root = root.path().join("repo/.orbit");
+    std::fs::create_dir_all(&global_root).expect("create global root");
+    std::fs::create_dir_all(&orbit_root).expect("create orbit root");
+    std::fs::write(
+        orbit_root.join("config.toml"),
+        r#"
+[workflow]
+base_branch = "main"
+default_crew = "sol"
+
+[crews.sol]
+model = "gpt-5.6-sol"
+provider = "codex"
+backend = "cli"
+
+[crews.opus]
+model = "opus"
+provider = "claude"
+backend = "cli"
+"#,
+    )
+    .expect("write config");
+    let runtime = OrbitRuntime::from_roots(&global_root, &orbit_root).expect("build runtime");
+    seed_review_ship_assets(&runtime);
+    let task_id = runtime
+        .add_task(TaskAddParams {
+            title: "review ship endpoint fixture".to_string(),
+            description: "persist explicit review controls".to_string(),
+            plan: "submit only".to_string(),
+            status: Some(orbit_core::TaskStatus::Backlog),
+            crew: Some("sol".to_string()),
+            ..TaskAddParams::default()
+        })
+        .expect("add review fixture task")
+        .id;
+    (root, runtime, task_id)
+}
+
+fn seed_review_ship_assets(runtime: &OrbitRuntime) {
+    let jobs = runtime.global_root().join("resources/jobs");
+    let activities = runtime.global_root().join("resources/activities");
+    std::fs::create_dir_all(&jobs).expect("create jobs");
+    std::fs::create_dir_all(&activities).expect("create activities");
+
+    let forwarding_stub = |name: &str| {
+        format!(
+            r#"schemaVersion: 2
+kind: Job
+metadata:
+  name: {name}
+spec:
+  state: enabled
+  kind: workflow
+  default_input:
+    review: false
+    review_crew: null
+  steps:
+    - id: nap
+      default_input:
+        seconds: 0
+        review: "{{{{ input.review }}}}"
+        review_crew: "{{{{ input.review_crew }}}}"
+      spec:
+        type: deterministic
+        action: sleep
+        config: {{}}
+"#
+        )
+    };
+    std::fs::write(
+        jobs.join("task_auto_pipeline.yaml"),
+        forwarding_stub("task_auto_pipeline"),
+    )
+    .expect("write auto job");
+    std::fs::write(
+        jobs.join("task_gate_pipeline.yaml"),
+        forwarding_stub("task_gate_pipeline"),
+    )
+    .expect("write gate job");
+    std::fs::write(
+        jobs.join("task_pr_pipeline.yaml"),
+        r#"schemaVersion: 2
+kind: Job
+metadata:
+  name: task_pr_pipeline
+spec:
+  state: enabled
+  kind: workflow
+  steps:
+    - id: push
+      spec: { type: deterministic, action: sleep, config: {} }
+    - id: pr_open
+      spec: { type: deterministic, action: sleep, config: {} }
+    - id: promote_tasks
+      spec: { type: deterministic, action: sleep, config: {} }
+    - id: independent_review
+      when: "{{ input.review }} == true && {{ steps.commit.output.skipped_no_diff_expected }} != true"
+      target: activity:invoke_and_wait
+      default_input:
+        job_name: task_review_pipeline
+        run_input:
+          task_ids: "{{ input.task_ids }}"
+          workspace_path: "{{ input.workspace_path }}"
+          crew: "{{ input.review_crew }}"
+          parent_run_id: "{{ input.parent_run_id }}"
+          candidate_head: "{{ input.candidate_head }}"
+          candidate_head_sha: "{{ input.candidate_head_sha }}"
+          pr_number: "{{ input.pr_number }}"
+        dedupe_run_input_field: parent_run_id
+    - id: require_independent_review_success
+      target: activity:pipeline_success_guard
+      default_input: { result: "{{ steps.independent_review.output }}" }
+"#,
+    )
+    .expect("write PR job");
+    std::fs::write(
+        jobs.join("task_review_pipeline.yaml"),
+        r#"schemaVersion: 2
+kind: Job
+metadata:
+  name: task_review_pipeline
+spec:
+  state: enabled
+  kind: workflow
+  steps:
+    - id: independent_review
+      target: activity:agent_review
+      default_input:
+        task_ids: "{{ input.task_ids }}"
+        workspace_path: "{{ input.workspace_path }}"
+        crew: "{{ input.crew }}"
+        parent_run_id: "{{ input.parent_run_id }}"
+        candidate_head: "{{ input.candidate_head }}"
+        candidate_head_sha: "{{ input.candidate_head_sha }}"
+        pr_number: "{{ input.pr_number }}"
+    - id: guard
+      target: activity:independent_review_guard
+"#,
+    )
+    .expect("write review job");
+    std::fs::write(
+        activities.join("agent_review.yaml"),
+        r#"schemaVersion: 2
+kind: Activity
+metadata:
+  name: agent_review
+spec:
+  type: agent_loop
+  description: fixture
+  output_schema_json:
+    type: object
+    required: [verdict, reviewed_head_sha]
+  instruction: fixture
+  require_response_envelope: true
+"#,
+    )
+    .expect("write review activity");
+    std::fs::write(
+        activities.join("independent_review_guard.yaml"),
+        r#"schemaVersion: 2
+kind: Activity
+metadata:
+  name: independent_review_guard
+spec:
+  type: deterministic
+  description: fixture
+  action: independent_review_guard
+  config: {}
+"#,
+    )
+    .expect("write guard activity");
+    for name in ["invoke_and_wait", "pipeline_success_guard"] {
+        std::fs::write(
+            activities.join(format!("{name}.yaml")),
+            format!(
+                r#"schemaVersion: 2
+kind: Activity
+metadata:
+  name: {name}
+spec:
+  type: deterministic
+  description: fixture
+  action: {name}
+  config: {{}}
+"#
+            ),
+        )
+        .expect("write orchestration activity");
+    }
+}
+
 #[tokio::test]
 async fn ship_endpoint_submits_task_auto_pipeline_run() {
-    let runtime = OrbitRuntime::in_memory().expect("build runtime");
-    write_replay_job(&runtime, "task_auto_pipeline");
+    let (_root, runtime, task_id) = review_ship_runtime();
 
     let response = request_ship(
         runtime.clone(),
         Some(json!({
+            "task_ids": [task_id],
             "mode": "pr",
             "review": true,
-            "review_crew": "opus-review",
+            "review_crew": "opus",
         })),
     )
     .await;
@@ -645,8 +884,9 @@ async fn ship_endpoint_submits_task_auto_pipeline_run() {
         Some(json!({
             "mode": "pr",
             "base_branch": "main",
+            "task_ids": [task_id],
             "review": true,
-            "review_crew": "opus-review",
+            "review_crew": "opus",
         }))
     );
 }
@@ -670,7 +910,11 @@ async fn ship_endpoint_rejects_unknown_mode() {
 async fn ship_endpoint_rejects_enabled_review_without_explicit_crew() {
     let runtime = OrbitRuntime::in_memory().expect("build runtime");
 
-    let response = request_ship(runtime, Some(json!({ "review": true }))).await;
+    let response = request_ship(
+        runtime,
+        Some(json!({ "task_ids": ["ORB-99999"], "review": true })),
+    )
+    .await;
 
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     let payload = body_json(response).await;
@@ -803,6 +1047,35 @@ async fn ship_endpoint_rejects_unknown_workspace_with_404_json() {
             .as_str()
             .is_some_and(|m| m.contains("unknown workspace: ghost"))
     );
+}
+
+#[tokio::test]
+async fn ship_endpoint_review_false_preserves_implementation_only_input() {
+    let runtime = OrbitRuntime::in_memory().expect("build runtime");
+    write_replay_job(&runtime, "task_auto_pipeline");
+
+    let response = request_ship(
+        runtime.clone(),
+        Some(json!({
+            "mode": "pr",
+            "review": false,
+        })),
+    )
+    .await;
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let payload = body_json(response).await;
+    let run_id = payload["run_id"].as_str().expect("run id");
+    let run = runtime
+        .list_job_runs(JobRunListParams::default())
+        .expect("list submitted runs")
+        .into_iter()
+        .find(|run| run.run_id == run_id)
+        .expect("submitted run exists");
+    let input = run.input.expect("persisted run input");
+    assert_eq!(input["mode"], "pr");
+    assert!(input.get("review").is_none());
+    assert!(input.get("review_crew").is_none());
 }
 
 #[tokio::test]

--- a/crates/orbit-dashboard/src/projections.rs
+++ b/crates/orbit-dashboard/src/projections.rs
@@ -150,6 +150,7 @@ pub(crate) fn job_run_to_json_with_state(run: &JobRun, state: Option<&PipelineSt
         "knowledge_metrics": run.knowledge_metrics,
         "resolved_crew": run.resolved_crew,
         "crew_model": run.crew_model,
+        "review_lineage": independent_review_lineage(run),
         "steps": run.steps.iter().map(|s| json!({
             "step_index": s.step_index,
             "target_type": s.target_type.to_string(),
@@ -165,6 +166,22 @@ pub(crate) fn job_run_to_json_with_state(run: &JobRun, state: Option<&PipelineSt
         })).collect::<Vec<_>>(),
         "created_at": run.created_at.to_rfc3339(),
     })
+}
+
+fn independent_review_lineage(run: &JobRun) -> Option<Value> {
+    if run.job_id != "task_review_pipeline" {
+        return None;
+    }
+    let input = run.input.as_ref()?.as_object()?;
+    Some(json!({
+        "parent_run_id": input.get("parent_run_id"),
+        "task_ids": input.get("task_ids"),
+        "workspace_path": input.get("workspace_path"),
+        "candidate_head": input.get("candidate_head"),
+        "candidate_head_sha": input.get("candidate_head_sha"),
+        "pr_number": input.get("pr_number"),
+        "pr_url": input.get("pr_url"),
+    }))
 }
 
 pub(crate) fn task_to_json(task: &Task, status_by_id: &BTreeMap<String, TaskStatus>) -> Value {

--- a/crates/orbit-engine/src/activity_job/agent_role.rs
+++ b/crates/orbit-engine/src/activity_job/agent_role.rs
@@ -20,7 +20,7 @@ use orbit_common::types::activity_job::{AgentLoopSpec, AgentRole, Backend, Provi
 
 use crate::context::AgentRoleConfig;
 
-use super::dispatcher::V2RuntimeHost;
+use super::dispatcher::{DispatchError, V2RuntimeHost};
 
 /// Resolved `(provider, model, backend)` triple ready to apply to a cloned
 /// [`AgentLoopSpec`] before downstream dispatch.
@@ -42,6 +42,21 @@ pub fn resolve_agent_settings(
 ) -> ResolvedAgentSettings {
     let config = host.agent_role_config_for_input(role, input);
     resolve_from_config(config.as_ref(), inline)
+}
+
+/// Resolve the flat crew selected explicitly by a rendered activity input.
+/// Returns `None` only when the input did not select a crew, leaving untagged
+/// activities on their inline baseline. A selected crew that the host cannot
+/// materialize is an error rather than an inline-provider fallback.
+pub fn resolve_explicit_crew_settings(
+    host: &dyn V2RuntimeHost,
+    inline: &AgentLoopSpec,
+    input: &serde_json::Value,
+) -> Result<Option<ResolvedAgentSettings>, DispatchError> {
+    let Some(config) = host.explicit_agent_crew_config_for_input(input)? else {
+        return Ok(None);
+    };
+    Ok(Some(resolve_from_config(Some(&config), inline)))
 }
 
 /// Pure helper used by both the host-driven path and the unit tests so the

--- a/crates/orbit-engine/src/activity_job/dispatcher.rs
+++ b/crates/orbit-engine/src/activity_job/dispatcher.rs
@@ -196,6 +196,27 @@ pub trait V2RuntimeHost: Send + Sync {
     ) -> Option<AgentRoleConfig> {
         self.agent_role_config(role)
     }
+
+    /// Resolve a flat crew selected explicitly by the rendered activity
+    /// input. This is separate from role-tag lookup: modern crews have one
+    /// assignment, so an activity carrying `crew` does not need a synthetic
+    /// reviewer/implementer/planner role merely to select that assignment.
+    fn explicit_agent_crew_config_for_input(
+        &self,
+        input: &Value,
+    ) -> Result<Option<AgentRoleConfig>, DispatchError> {
+        if let Some(crew) = input
+            .get("crew")
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+        {
+            return Err(DispatchError::JobValidation(format!(
+                "explicit activity crew '{crew}' cannot be resolved by this runtime host"
+            )));
+        }
+        Ok(None)
+    }
 }
 
 /// Input bundle for a single v2 activity dispatch.

--- a/crates/orbit-engine/src/activity_job/job_executor/mod.rs
+++ b/crates/orbit-engine/src/activity_job/job_executor/mod.rs
@@ -45,7 +45,9 @@ use crate::job_runner::evaluate_bool_expr;
 use crate::template::{self, TemplateContext};
 
 use super::agent_loop_driver::drive_agent_loop_with_session;
-use super::agent_role::{apply_resolved_settings, resolve_agent_settings};
+use super::agent_role::{
+    apply_resolved_settings, resolve_agent_settings, resolve_explicit_crew_settings,
+};
 use super::audit_writer::{V2AuditWriter, WriteError};
 use super::dispatcher::{
     DispatchError, V2DispatchInput, V2RuntimeHost, dispatch_v2_activity,

--- a/crates/orbit-engine/src/activity_job/job_executor/target.rs
+++ b/crates/orbit-engine/src/activity_job/job_executor/target.rs
@@ -11,11 +11,10 @@ pub(super) fn run_target(
     let tctx = ctx.template_ctx();
     let rendered_input = render_input(t.default_input.as_ref(), &ctx.input, &tctx)?;
 
-    // Role override (ADR-029) — `step.role` (TargetStep) wins over
-    // `activity.role` (AgentLoopSpec) when both are set. We only need to
-    // synthesize a substitute spec when the matched arm is AgentLoop *and*
-    // an effective role is present.
-    let role_override = role_overridden_spec(t, ctx);
+    // Agent settings override — `step.role` (TargetStep) wins over
+    // `activity.role` (AgentLoopSpec) when both are set; without either role,
+    // a rendered explicit `crew` may select the modern flat assignment.
+    let role_override = role_overridden_spec(t, ctx, &rendered_input)?;
     match (&t.spec, &t.session) {
         (ActivityV2Spec::AgentLoop(inline_spec), Some(binding)) => {
             let agent_spec_owned = role_override.clone();
@@ -191,18 +190,31 @@ pub(super) fn replay_active() -> bool {
     std::env::var("ORBIT_V2_REPLAY").is_ok() || std::env::var("ORBIT_V2_REPLAY_FIXTURE").is_ok()
 }
 
-/// Build a role-overridden clone of an [`AgentLoopSpec`] when the step or
-/// inline activity declares a role and the host has a matching
-/// `[agent.<role>]` entry. Returns `None` for non-`AgentLoop` specs and for
-/// the path where no effective role is set — the caller can then dispatch
-/// against the inline spec without paying for a clone.
-pub(super) fn role_overridden_spec(t: &TargetStep, ctx: &ExecCtx<'_>) -> Option<AgentLoopSpec> {
+/// Build a crew-overridden clone of an [`AgentLoopSpec`]. A declared activity
+/// role uses the role-labelled path; otherwise an explicit rendered `crew`
+/// input may select the modern flat crew assignment without inventing a role.
+pub(super) fn role_overridden_spec(
+    t: &TargetStep,
+    ctx: &ExecCtx<'_>,
+    rendered_input: &Value,
+) -> Result<Option<AgentLoopSpec>, DispatchError> {
     let ActivityV2Spec::AgentLoop(inline_spec) = &t.spec else {
-        return None;
+        return Ok(None);
     };
-    let effective_role = t.role.or(inline_spec.role)?;
-    let resolved = resolve_agent_settings(effective_role, ctx.host, inline_spec, &ctx.input);
+    let resolved = match t.role.or(inline_spec.role) {
+        Some(effective_role) => {
+            resolve_agent_settings(effective_role, ctx.host, inline_spec, &ctx.input)
+        }
+        None => {
+            let Some(resolved) =
+                resolve_explicit_crew_settings(ctx.host, inline_spec, rendered_input)?
+            else {
+                return Ok(None);
+            };
+            resolved
+        }
+    };
     let mut spec = inline_spec.clone();
     apply_resolved_settings(&mut spec, &resolved);
-    Some(spec)
+    Ok(Some(spec))
 }

--- a/crates/orbit-engine/src/activity_job/job_executor/tests/target.rs
+++ b/crates/orbit-engine/src/activity_job/job_executor/tests/target.rs
@@ -76,6 +76,22 @@ impl V2RuntimeHost for RoleHost {
         self.observed.lock().expect("observed lock").push(role);
         self.config.get(&role).cloned()
     }
+
+    fn explicit_agent_crew_config_for_input(
+        &self,
+        input: &Value,
+    ) -> Result<Option<AgentRoleConfig>, DispatchError> {
+        if input.get("crew").and_then(Value::as_str).is_none() {
+            return Ok(None);
+        }
+        self.config
+            .get(&AgentRole::Reviewer)
+            .cloned()
+            .map(Some)
+            .ok_or_else(|| {
+                DispatchError::JobValidation("explicit test crew is unknown".to_string())
+            })
+    }
 }
 
 fn inline_agent_loop_spec() -> AgentLoopSpec {
@@ -140,7 +156,9 @@ fn role_override_pulls_provider_from_host_for_step_role() {
     let ctx = exec_ctx(&host);
     let target = target_step_with_role(inline_agent_loop_spec(), Some(AgentRole::Implementer));
 
-    let overridden = role_overridden_spec(&target, &ctx).expect("override expected");
+    let overridden = role_overridden_spec(&target, &ctx, &ctx.input)
+        .expect("resolve override")
+        .expect("override expected");
     assert_eq!(overridden.provider, Provider::Codex);
     // Field-by-field fallback: model and backend stay inline.
     assert_eq!(overridden.model.as_deref(), Some(TEST_CLAUDE_MODEL));
@@ -158,7 +176,9 @@ fn role_override_step_role_wins_over_activity_role() {
     spec.role = Some(AgentRole::Planner);
     let target = target_step_with_role(spec, Some(AgentRole::Implementer));
 
-    let overridden = role_overridden_spec(&target, &ctx).expect("override expected");
+    let overridden = role_overridden_spec(&target, &ctx, &ctx.input)
+        .expect("resolve override")
+        .expect("override expected");
     assert_eq!(overridden.provider, Provider::Codex);
     // Only Implementer was looked up; Planner was never queried.
     assert_eq!(host.observed_lookups(), vec![AgentRole::Implementer]);
@@ -172,7 +192,9 @@ fn role_override_falls_back_to_activity_role_when_step_role_absent() {
     spec.role = Some(AgentRole::Implementer);
     let target = target_step_with_role(spec, None);
 
-    let overridden = role_overridden_spec(&target, &ctx).expect("override expected");
+    let overridden = role_overridden_spec(&target, &ctx, &ctx.input)
+        .expect("resolve override")
+        .expect("override expected");
     assert_eq!(overridden.provider, Provider::Codex);
     assert_eq!(host.observed_lookups(), vec![AgentRole::Implementer]);
 }
@@ -185,8 +207,49 @@ fn role_override_returns_none_when_no_role_anywhere() {
 
     // Inline activity role is also None — no override should be built and
     // the host should not be queried at all.
-    assert!(role_overridden_spec(&target, &ctx).is_none());
+    assert!(
+        role_overridden_spec(&target, &ctx, &ctx.input)
+            .expect("resolve override")
+            .is_none()
+    );
     assert!(host.observed_lookups().is_empty());
+}
+
+#[test]
+fn explicit_flat_crew_overrides_untagged_agent_activity() {
+    let mut config = HashMap::new();
+    config.insert(
+        AgentRole::Reviewer,
+        AgentRoleConfig {
+            provider: Some(Provider::Codex),
+            model: Some("gpt-review".to_string()),
+            backend: Some(Backend::Cli),
+        },
+    );
+    let host = RoleHost::new(config);
+    let ctx = exec_ctx(&host);
+    let rendered_input = json!({ "crew": "independent-review" });
+    let target = target_step_with_role(inline_agent_loop_spec(), None);
+
+    let overridden = role_overridden_spec(&target, &ctx, &rendered_input)
+        .expect("resolve explicit rendered crew")
+        .expect("explicit rendered crew override");
+    assert_eq!(overridden.provider, Provider::Codex);
+    assert_eq!(overridden.model.as_deref(), Some("gpt-review"));
+    assert_eq!(overridden.backend, Backend::Cli);
+    assert!(host.observed_lookups().is_empty());
+}
+
+#[test]
+fn explicit_flat_crew_resolution_failure_does_not_fall_back_inline() {
+    let host = RoleHost::new(HashMap::new());
+    let ctx = exec_ctx(&host);
+    let rendered_input = json!({ "crew": "unknown-review" });
+    let target = target_step_with_role(inline_agent_loop_spec(), None);
+
+    let error = role_overridden_spec(&target, &ctx, &rendered_input)
+        .expect_err("unknown explicit crew must fail closed");
+    assert!(matches!(error, DispatchError::JobValidation(_)));
 }
 
 #[test]
@@ -199,7 +262,9 @@ fn role_override_returns_none_when_host_has_no_matching_entry() {
     let ctx = exec_ctx(&host);
     let target = target_step_with_role(inline_agent_loop_spec(), Some(AgentRole::Reviewer));
 
-    let overridden = role_overridden_spec(&target, &ctx).expect("override expected");
+    let overridden = role_overridden_spec(&target, &ctx, &ctx.input)
+        .expect("resolve override")
+        .expect("override expected");
     assert_eq!(overridden.provider, Provider::Claude);
     assert_eq!(overridden.model.as_deref(), Some(TEST_CLAUDE_MODEL));
     assert_eq!(overridden.backend, Backend::Cli);
@@ -224,7 +289,11 @@ fn role_override_does_not_apply_to_non_agent_loop_specs() {
         session: None,
         role: Some(AgentRole::Implementer),
     };
-    assert!(role_overridden_spec(&target, &ctx).is_none());
+    assert!(
+        role_overridden_spec(&target, &ctx, &ctx.input)
+            .expect("resolve override")
+            .is_none()
+    );
     assert!(host.observed_lookups().is_empty());
 }
 
@@ -269,7 +338,9 @@ fn role_override_does_not_disable_replay_short_circuit() {
     let ctx = exec_ctx(&host);
     let target = target_step_with_role(inline_agent_loop_spec(), Some(AgentRole::Implementer));
 
-    let overridden = role_overridden_spec(&target, &ctx).expect("override expected");
+    let overridden = role_overridden_spec(&target, &ctx, &ctx.input)
+        .expect("resolve override")
+        .expect("override expected");
     assert_eq!(overridden.provider, Provider::Codex);
     // Replay short-circuit still triggers — independent of the override.
     assert!(super::replay_active());

--- a/docs/design/activity-job/2_design.md
+++ b/docs/design/activity-job/2_design.md
@@ -3,7 +3,7 @@ summary: "Activity / Job — Design"
 type: design
 title: "Activity / Job — Design"
 owner: codex
-last_updated: 2026-07-16
+last_updated: 2026-07-18
 status: Draft
 feature: activity-job
 doc_role: design
@@ -143,6 +143,8 @@ After [ORB-10232], `task_pr_pipeline` exposes the PR handoff as ordered durable 
 `pr_prepare` is the pre-rewrite authority boundary. It records the exact head SHA, base SHA, and observed remote task-branch SHA before `git_rebase` may rewrite history. `git_push` classifies the remote ref as missing, current, fast-forwardable, remote-ahead, or diverged. Missing and fast-forwardable refs use normal push; current refs are reused; remote-ahead refs fail closed. Divergence may use force-with-lease only when the persisted preparation SHA still exactly matches the observed remote SHA and `git_rebase` reports a performed or recovery-reused rewrite. The underlying tool emits a branch-scoped `--force-with-lease=refs/heads/<branch>:<expected-sha>`, so a concurrent remote update rejects the push instead of overwriting it. This is [ADR-0225].
 
 PR creation is restartable within its own checkpoint. `pr_open` first looks up the open PR by head branch; only the explicit no-PR result permits `github.pr.create`. If creation succeeds but PR view or local step-output persistence fails, the retry finds that same external PR and returns it as reused. `pr_promote` then idempotently applies the GitHub PR external ref and the per-task implementation attribution before moving tasks to `review`.
+
+After [ORB-10266], explicit-task PR shipment with independent review enabled preflights the selected review crew and the deployed auto/gate/PR/review assets before inserting the implementation run. `task_pr_pipeline` materializes exactly one `task_review_pipeline` child only after push, PR publication, and task promotion, snapshotting the parent run, tasks, workspace, explicit crew, candidate branch, pushed SHA, and PR identity. Parent retry/resume reuses the child whose persisted `parent_run_id` matches; multiple matches fail closed, and the dispatch step has no recovery retry that could create a second reviewer. The read-only reviewer returns a structured verdict and reviewed SHA; a deterministic guard requires that SHA to equal the published candidate before either the child or waiting parent can succeed. Review-disabled shipment is unchanged, while review-enabled local, auto-discovery, missing-crew, same-assignment, unknown-crew, and unmaterializable configurations fail before implementation. This is [ADR-0233].
 
 The seeded `list_backlog_tasks` deterministic activity starts `task_auto_pipeline`. Automatic mode admits tasks by `status: backlog`. It emits `task_count`, `task_ids`, `tasks`, singleton `bundles`, and an `excluded` array for admitted backlog tasks filtered because their context files overlap `in-progress` or `review` locks. `excluded` covers only lock overlap; status-based admission and `max_tasks` truncation stay silent, and explicit `task_ids` mode omits it. This attribution contract was added in [T20260421-0542-2].
 

--- a/docs/design/activity-job/4_decisions.md
+++ b/docs/design/activity-job/4_decisions.md
@@ -3,7 +3,7 @@ summary: "Activity / Job — Decisions"
 type: design
 title: "Activity / Job — Decisions"
 owner: codex
-last_updated: 2026-07-16
+last_updated: 2026-07-18
 status: Draft
 feature: activity-job
 doc_role: decisions
@@ -624,6 +624,21 @@ Rejected alternatives: reconciling by parent linkage (no parent run id is persis
 
 ---
 
+## ADR-0233 — Materialize independent review as a post-publication child Run
+
+**Status:** Accepted · 2026-07 · [ORB-10266]
+
+**Context.** An inline `agent_review` step ran before the PR candidate was committed, pushed, or published and left no independently addressable review Run. Orbit could keep that inline activity and add more output checks, or materialize review only after publication as its own durable child bound to the pushed SHA.
+
+**Decision.** For explicit-task PR shipment with review enabled, dispatch exactly one `task_review_pipeline` child after push, PR publication, and task promotion. Snapshot the parent run, task IDs, workspace, explicit review crew, candidate branch, pushed SHA, and PR identity in the child input; require a structured verdict whose reviewed SHA exactly matches that snapshot. Preflight the selected crew and deployed job/activity contract before inserting the implementation run, and reject review outside PR mode.
+
+**Consequences.**
+- Independent review is observable and resumable through normal job-run records and cannot silently inherit the implementation crew.
+- `review=false` keeps the implementation-only shipment path, while review-enabled no-diff and local shipments do not invent an unpublished candidate to review.
+- Cost: review-enabled shipment adds a child Run and wait boundary after PR publication, increasing latency and requiring source/shipped workflow assets to stay synchronized.
+
+---
+
 ## Task References
 
 - **[T20260418-2018]** — Add `JobV2` DAG constructs (`parallel`, `fan_out`, `loop`, `retry`, `when`).
@@ -694,5 +709,6 @@ Rejected alternatives: reconciling by parent linkage (no parent run id is persis
 - **[ORB-00374]** — Remove the `shell` activity variant and `run_shell` dispatch (fail-closed resolution of [ORB-00363]).
 - **[ORB-10202]** — Remove the retired friction task status while preserving workflow admission and triage behavior.
 - **[ORB-10232]** — Model recoverable PR handoff as checkpointed job activities with exact-SHA force-push provenance.
+- **[ORB-10266]** — Materialize independent review as a durable exact-head child Run or fail before implementation.
 
 > Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.


### PR DESCRIPTION
## Task

[ORB-10266](https://orbit-cli.com/tasks/ORB-10266) — Make review_bundle materialize or fail closed

### Description

## Problem

The deployed Bridge/Orbit surface accepts `workflow_ship(review=true, review_crew=opus)`, but the ORB-10255 submission `jrun-20260718-0641` completed its parent, gate, and PR child without creating any independent review run. The task stopped in `review` only because the implementation pipeline ends there. This violates the Build Week review contract and makes the advertised control silently behave like `review=false`.

Friction F2026-07-079 preserves the exact live evidence. ORB-10251 introduced the explicit review controls; this task closes the remaining execution gap without changing the implementation crew model.

## Required outcome

Trace the request from the HTTP/Bridge submission payload through Orbit's workflow input materialization and versioned job/activity assets. For an explicit-ID PR-mode submission with `review=true` and a distinct `review_crew`:

- materialize one durable independent review run after the PR candidate exists;
- bind the reviewer to the exact published candidate head and selected workspace/task;
- expose the review run and its lineage through the normal job-run APIs;
- keep the task in `review` until an independent structured verdict exists;
- reject the submission before implementation if the deployed assets/backend cannot honor the requested review; and
- never silently inherit the implementation crew or downgrade to implementation-only behavior.

Preserve `review=false` compatibility and explicit-task-only dispatch. Do not add auto-discovery, scheduled shipping, or GitHub-CI gating.

## Boundaries

This task repairs review-control materialization and fail-closed validation only. It does not redesign review semantics, crew assignment, task status rules, GitHub CI policy, or the Host Registry/MCP Bridge feature contract. If Bridge request propagation is correct and the defect is Orbit-only, do not modify Bridge. If a Bridge parity change is actually required, stop and report the cross-repository boundary rather than mixing repos.

Use the existing ORB-10255/PR #633 sequence as a regression shape, but tests must be hermetic and must not depend on that live task.

### Acceptance Criteria

- A hermetic explicit-ID PR-mode submission with review=true and review_crew=opus creates exactly one durable independent review run after candidate publication, and the run projects its parent/task/workspace/candidate-head lineage.
- The review run resolves to the explicit review crew and cannot silently use the implementation crew; missing, same-as-implementation, unknown, or unmaterializable review configuration fails before implementation side effects.
- The task remains review-gated until a structured independent verdict exists, while review=false preserves the existing implementation-only PR flow.
- The shipped and source job/activity assets remain byte/semantic synchronized and agent_review no longer relies on a removed reviewer-role field.
- Tests cover request propagation, workflow/job input materialization, exact-head binding, one-review-only behavior, fail-closed cases, and review=false compatibility.
- No auto-discovery shipping, scheduled sweep, CI merge gate, Host Registry behavior, or cross-repository implementation is introduced.
- Targeted orbit-core/orbit-dashboard workflow tests, asset validation, git diff --check, and make ci-fast pass.

## Execution Summary

<details>
<summary>Click to expand</summary>

Implemented fail-closed durable independent review for explicit-task PR shipment.

Outcome
- `review=true` now requires PR mode, explicit task IDs, and a nonblank distinct review crew before submission. The preflight resolves every task's implementation crew, compares canonical runtime assignments (including provider aliases), validates provider/backend/executor materialization, and validates the deployed auto/gate/PR/review job and activity contract before inserting the implementation Run. Unknown, same-name, same-assignment, unmaterializable, missing-asset, role-dependent, or malformed review configurations fail with no implementation Run.
- `task_pr_pipeline` now publishes/opens/promotes the candidate first, then creates exactly one durable `task_review_pipeline` child with parent/task/workspace/crew/branch/SHA/PR lineage. The child dispatch has no recovery retry and `invoke_and_wait` reuses the persisted child by `parent_run_id` across retry/resume; multiple matches fail closed. `review=false` keeps the prior implementation-only input/path. Review-enabled local or auto-discovery shipment is rejected before work; the local leaf also fails review=true before worktree setup for direct invocations.
- `agent_review` is read-only, no longer has a reviewer role, resolves the explicit flat crew with fail-closed engine behavior, requires a strict response envelope, and produces `verdict` plus `reviewed_head_sha`. A deterministic guard accepts only approve/request_changes and requires the reviewed SHA to equal the exact pushed candidate SHA. The parent waits for child success, so tasks remain in review while the structured verdict is outstanding.
- Normal dashboard job-run JSON now projects independent-review lineage alongside resolved crew/model. Source and shipped job/activity assets are byte-identical, including the new review job and exact-head guard.
- Synchronized activity-job design documentation and accepted ADR-0233. Added incident learning L-0094 with ORB-10255/ORB-10266/jrun-20260718-0641 evidence. No Bridge, auto-discovery shipping, routine/sweep, CI merge-gate, Host Registry, or cross-repository behavior was added.

Scoped supporting files
- Added the review job/guard assets and their catalog/dispatch registrations.
- Updated the tightly coupled engine flat-crew resolver, invoke-and-wait dedupe contract, dashboard projection/tests, local leaf fail-closed guard, activity-job design/ADR, and tool-managed learning. Each unlisted supporting area was recorded in task comments before editing.

Validation (all passed)
- `cargo test -p orbit-core command::job::catalog --lib` (23)
- `cargo test -p orbit-core command::tests::pipeline_run --lib` (6)
- `cargo test -p orbit-core runtime::v2_host::pipeline_actions::tests --lib` (6)
- `cargo test -p orbit-core review --lib` (36)
- `cargo test -p orbit-engine --lib` (252)
- `cargo test -p orbit-dashboard api::tests::runs --lib` (21)
- byte comparison for source/shipped auto, gate, local, PR, review, agent_review, invoke_and_wait, and independent_review_guard assets
- `git diff --check`
- `make ci-fast`

No-diff PR shipment does not create a review child because it publishes no candidate. The worktree is intentionally uncommitted, and the task remains in-progress for the pipeline-owned commit/PR/review transition.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10266-6a5b2729`
- Behind base: 0
- Ahead of base: 1