### PR TITLE
Use the global task-status projection for cross-workspace HTTP dependencies

### DIFF
--- a/crates/orbit-dashboard/src/api/tasks.rs
+++ b/crates/orbit-dashboard/src/api/tasks.rs
@@ -178,10 +178,18 @@ fn list_dashboard_tasks(runtime: &OrbitRuntime) -> Result<Vec<Task>, orbit_core:
     Ok(tasks)
 }
 
+/// Dependency-status projection for dashboard task serialization.
+///
+/// Uses the coordination registry's global status index
+/// ([`OrbitRuntime::task_status_index`]) rather than `runtime.list_tasks()`
+/// (workspace-scoped), so a task depending on another registered workspace's
+/// task resolves that dependency's real status instead of `[missing]`
+/// (ORB-10291). Task *listing* stays workspace-scoped: this index is only
+/// consulted to label dependencies, never to add tasks to the response body.
 fn dashboard_status_index(
     runtime: &OrbitRuntime,
 ) -> Result<std::collections::BTreeMap<String, TaskStatus>, orbit_core::OrbitError> {
-    Ok(orbit_core::build_task_status_index(&runtime.list_tasks()?))
+    runtime.task_status_index()
 }
 
 pub(super) async fn get_task(Ws(runtime): Ws, Path(id): Path<String>) -> Response {

--- a/crates/orbit-dashboard/src/api/tests/workspaces.rs
+++ b/crates/orbit-dashboard/src/api/tests/workspaces.rs
@@ -259,6 +259,116 @@ async fn workspace_selection_errors_are_clean_4xx_json() {
     assert_eq!(response.status(), axum::http::StatusCode::OK);
 }
 
+/// ORB-10291: a task in one registered workspace depending on a task in
+/// another workspace sharing the same global root must resolve that
+/// dependency's real status, not `[missing]`. Dependency resolution has to
+/// use the coordination registry's global status projection
+/// (`OrbitRuntime::task_status_index`) rather than the selected workspace's
+/// own task list.
+#[tokio::test]
+async fn cross_workspace_dependency_resolves_global_status_not_missing() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let global_root = tmp.path().join("global");
+    std::fs::create_dir_all(&global_root).expect("create global root");
+
+    let (beta_orbit, beta_repo) = seed_workspace(&global_root, tmp.path(), "beta");
+    let beta_task = {
+        let beta_runtime = OrbitRuntime::from_roots(&global_root, &beta_orbit)
+            .expect("build beta runtime")
+            .with_actor(ActorIdentity::human("human"));
+        beta_runtime
+            .add_task(TaskAddParams {
+                title: "beta dependency".to_string(),
+                description: "seed".to_string(),
+                workspace_path: Some(".".to_string()),
+                status: Some(TaskStatus::Done),
+                ..Default::default()
+            })
+            .expect("add beta task")
+    };
+
+    let alpha_repo = tmp.path().join("alpha");
+    let alpha_orbit = alpha_repo.join(".orbit");
+    std::fs::create_dir_all(&alpha_orbit).expect("create .orbit");
+    std::fs::write(alpha_orbit.join("config.toml"), "").expect("write config");
+    let alpha_task = {
+        let alpha_runtime = OrbitRuntime::from_roots(&global_root, &alpha_orbit)
+            .expect("build alpha runtime")
+            .with_actor(ActorIdentity::human("human"));
+        alpha_runtime
+            .add_task(TaskAddParams {
+                title: "alpha dependent".to_string(),
+                description: "seed".to_string(),
+                workspace_path: Some(".".to_string()),
+                status: Some(TaskStatus::InProgress),
+                dependencies: vec![beta_task.id.clone()],
+                ..Default::default()
+            })
+            .expect("add alpha task")
+    };
+
+    let entries = vec![
+        WsEntry {
+            id: "alpha".to_string(),
+            name: "alpha".to_string(),
+            repo_root: alpha_repo,
+            orbit_dir: alpha_orbit,
+            active: true,
+        },
+        WsEntry {
+            id: "beta".to_string(),
+            name: "beta".to_string(),
+            repo_root: beta_repo,
+            orbit_dir: beta_orbit,
+            active: true,
+        },
+    ];
+    let state = DashboardState::global(global_root, entries, Some("alpha".to_string()));
+    let expected_label = format!("{} [done]", beta_task.id);
+
+    // GET /tasks?workspace=alpha: the cross-workspace dependency resolves to
+    // beta's real status, and the response contains only alpha's own task.
+    let response = router()
+        .with_state(state.clone())
+        .oneshot(get("/tasks?workspace=alpha"))
+        .await
+        .expect("response");
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = body_json(response).await;
+    let tasks = body.as_array().expect("array");
+    assert_eq!(
+        tasks.len(),
+        1,
+        "workspace-local list must contain only alpha's own task, got {tasks:?}"
+    );
+    let alpha_row = &tasks[0];
+    assert_eq!(alpha_row["id"], json!(alpha_task.id));
+    let labels: Vec<&str> = alpha_row["resolved_dependencies"]
+        .as_array()
+        .expect("resolved_dependencies array")
+        .iter()
+        .map(|value| value.as_str().expect("dependency label"))
+        .collect();
+    assert_eq!(labels, vec![expected_label.as_str()]);
+
+    // GET /tasks/<alpha-id>?workspace=alpha: the show projection reports the
+    // identical cross-workspace dependency status.
+    let response = router()
+        .with_state(state)
+        .oneshot(get(&format!("/tasks/{}?workspace=alpha", alpha_task.id)))
+        .await
+        .expect("response");
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = body_json(response).await;
+    let labels: Vec<&str> = body["resolved_dependencies"]
+        .as_array()
+        .expect("resolved_dependencies array")
+        .iter()
+        .map(|value| value.as_str().expect("dependency label"))
+        .collect();
+    assert_eq!(labels, vec![expected_label.as_str()]);
+}
+
 /// ORB-00037: the pure display helper collapses `$HOME` to `~` and otherwise
 /// renders paths verbatim.
 #[test]


### PR DESCRIPTION
## Task

[ORB-10291](https://orbit-cli.com/tasks/ORB-10291) — Use the global task-status projection for cross-workspace HTTP dependencies

### Description

## Problem

Dashboard HTTP task list/show projections resolve dependency statuses from runtime.list_tasks(), which contains only the selected workspace. Consequently, a task depending on a globally valid task in another registered workspace is serialized as ORB-NNNNN [missing].

Live reproductions:

- ORB-10287 in ws_constellation reports ORB-10285 and ORB-10286 as missing even though both resolve in ws_polaris.
- ORB-10285 and ORB-10286 in ws_polaris likewise report their ws_orbit dependencies as missing.

## Impact

Bridge consumes these HTTP projections. orbit_task_show displays false missing dependencies, and orbit_task_list(ready=true) filters client-side on the same labels, so a cross-workspace-dependent task can remain invisible after its prerequisites reach done. This undermines promotion and orchestration decisions for the accepted Host Registry/MCP Bridge rollout.

Workflow execution is not using this faulty resolver: core MCP/CLI readiness and reserve_locks use the coordination registry's global task_status_index. This task fixes visibility/projection only and must not change execution admission semantics.

## Required outcome

Use the global coordination task-status projection for Dashboard HTTP task list/show serialization. Add a deterministic two-workspace regression fixture. Preserve workspace-scoped task listing and existing HTTP response shapes; resolving a dependency status must not add cross-workspace task bodies to the selected workspace's response.

## Boundaries

- Change only Dashboard HTTP task projection and its regression coverage.
- Do not change Bridge, task storage, global task IDs, task relations, core dependency admission, workflow locks, task body routing, or workspace selection.
- Do not make list/show return cross-workspace task bodies.
- Keep response labels and Bridge's existing ready=true compatibility contract unchanged.

### Acceptance Criteria

- A regression test creates two registered workspaces sharing one global root, with an alpha task depending on a beta task, and proves GET /tasks?workspace=alpha reports the beta task's exact status instead of [missing].
- The same fixture proves GET /tasks/<alpha-task-id>?workspace=alpha reports the identical cross-workspace dependency status.
- With the beta dependency in done, the emitted label is exactly ORB-NNNNN [done], satisfying Bridge's existing ready=true contract without a Bridge code change.
- Workspace-local list responses still contain only tasks owned by the selected workspace; resolving dependency status does not leak cross-workspace task bodies.
- Existing same-workspace done, archived, rejected, missing, and blocked dependency projection coverage remains green.
- Core workflow/admission behavior is unchanged; tests or code review confirm the fix uses the existing global task_status_index rather than creating another resolver.
- cargo test -p orbit-dashboard and make ci-fast pass.

## Execution Summary

<details>
<summary>Click to expand</summary>

Fixed the dashboard HTTP task list/show projections to resolve dependency statuses from the coordination registry's global task-status index instead of the workspace-scoped task list.

Root cause: `dashboard_status_index()` in crates/orbit-dashboard/src/api/tasks.rs built its status map via `orbit_core::build_task_status_index(&runtime.list_tasks()?)`, and `runtime.list_tasks()` only returns tasks owned by the currently selected workspace. A task depending on a task in a different workspace registered against the same global root therefore always resolved to `[missing]`, even though the dependency was globally valid and done.

Fix: `dashboard_status_index()` now calls `runtime.task_status_index()` (crates/orbit-core/src/command/task/query.rs), which delegates through the store layer to `TaskRegistryStore::global_task_status_index()` (crates/orbit-store/src/sqlite/task_registry/store.rs) — a query with no `workspace_id` filter over the shared sqlite registry keyed at the global root. This is the exact same accessor already used by core workflow/admission code (reserve_locks in orbit-core/src/runtime/v2_host/dispatch.rs, CLI task list/show, backlog_exclusion, orbit_tool_host) for readiness checks, so the dashboard now matches admission semantics instead of diverging from them. No new resolver was created; task *listing* (`list_dashboard_tasks`) is untouched and remains workspace-scoped via `list_tasks_filtered`, so `/tasks` and `/tasks/all` responses still contain only the selected workspace's own task bodies — only the dependency-status lookup used to label `resolved_dependencies` became global.

Added a regression test `cross_workspace_dependency_resolves_global_status_not_missing` in crates/orbit-dashboard/src/api/tests/workspaces.rs: two workspaces (alpha, beta) sharing one global root via `OrbitRuntime::from_roots`, a beta task seeded directly in `done` status, and an alpha task with `dependencies: vec![beta_task.id]`. Verifies (1) `GET /tasks?workspace=alpha` returns exactly one task (alpha's own — no cross-workspace body leak) whose `resolved_dependencies` label is exactly `"<beta_id> [done]"` instead of `[missing]`, and (2) `GET /tasks/<alpha_id>?workspace=alpha` reports the identical label.

Validation: `cargo test -p orbit-dashboard` — 177 passed, 1 failed. The failure (`routines_endpoint_returns_envelope_for_empty_host`) is pre-existing and unrelated: reproduced identically via `git stash` on the unmodified branch before this change, so it is a pre-existing environment-dependent test issue, not a regression from this fix. `make ci-fast` passes clean (fmt, doc index, installer/security checks, dependency-direction guard, cli-import guard, stability tiers, learning-layout, artifact-redaction guardrail, changelog style, error-translation guard).

Scope: only crates/orbit-dashboard/src/api/tasks.rs and crates/orbit-dashboard/src/api/tests/workspaces.rs changed, matching the task's context_files exactly. No changes to Bridge, task storage, global task IDs, task relations, core dependency admission, workflow locks, task body routing, or workspace selection.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10291-6a5b42dd`
- Behind base: 0
- Ahead of base: 1