### PR TITLE
Add workspace ownership, presence, and execution-profile projections

### DIFF
--- a/crates/orbit-common/src/types/agent_pair.rs
+++ b/crates/orbit-common/src/types/agent_pair.rs
@@ -48,6 +48,15 @@ pub struct CrewRoleAssignment {
 pub struct Crew {
     pub name: String,
     pub assignment: CrewRoleAssignment,
+    /// Optional human-facing summary carried through every canonical crew
+    /// projection. Execution-profile publication normalizes blank values to
+    /// `None`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    /// Search/discovery labels. Runtime config loading canonicalizes these to
+    /// a sorted, deduplicated list of non-empty strings.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub tags: Vec<String>,
 }
 
 impl Crew {

--- a/crates/orbit-common/src/types/execution_profile.rs
+++ b/crates/orbit-common/src/types/execution_profile.rs
@@ -1,0 +1,388 @@
+//! Versioned owner-published execution facts for multi-host coordination.
+
+use std::path::PathBuf;
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+use super::activity_job::{Backend, Provider};
+use super::{Crew, OrbitError};
+
+pub const EXECUTION_PROFILE_SCHEMA_VERSION: u32 = 1;
+pub const EXECUTION_CONFIG_DIGEST_DOMAIN: &[u8] = b"orbit.execution-profile.config.v1\0";
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WorkspaceOwnership {
+    pub workspace_id: String,
+    pub owner_machine_id: String,
+    pub bound_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+/// Private, host-keyed checkout declaration. `root` is deliberately absent
+/// from every sanitized/public projection below.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct HostWorkspacePresence {
+    pub machine_id: String,
+    pub workspace_id: String,
+    pub root: PathBuf,
+    pub last_verified: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WorkspacePresenceDeclaration {
+    pub workspace_id: String,
+    pub root: PathBuf,
+    pub last_verified: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ProjectionFreshness {
+    Missing,
+    Current,
+    Stale,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SanitizedWorkspacePresence {
+    pub workspace_id: String,
+    pub machine_id: String,
+    pub owner_machine_id: Option<String>,
+    pub freshness: ProjectionFreshness,
+    pub last_verified: Option<DateTime<Utc>>,
+    pub age_seconds: Option<u64>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ExecutionProfileCrewV1 {
+    pub name: String,
+    pub provider: String,
+    pub model: String,
+    pub backend: String,
+    pub description: Option<String>,
+    pub tags: Vec<String>,
+}
+
+impl ExecutionProfileCrewV1 {
+    pub fn from_crew(crew: &Crew, auto_backend: Backend) -> Result<Self, OrbitError> {
+        let name = required_trimmed("crew name", &crew.name)?;
+        let provider = Provider::parse(&crew.assignment.provider).map_err(|error| {
+            OrbitError::InvalidInput(format!("crew '{name}' has invalid provider: {error}"))
+        })?;
+        let model = required_trimmed("crew model", &crew.assignment.model)?;
+        let configured_backend = Backend::parse(&crew.assignment.backend).ok_or_else(|| {
+            OrbitError::InvalidInput(format!(
+                "crew '{name}' has unknown backend '{}'",
+                crew.assignment.backend
+            ))
+        })?;
+        let backend = match configured_backend {
+            Backend::Auto => auto_backend,
+            concrete => concrete,
+        };
+        if backend == Backend::Auto {
+            return Err(OrbitError::InvalidInput(format!(
+                "crew '{name}' did not resolve backend:auto to a concrete backend"
+            )));
+        }
+        match backend {
+            Backend::Http if !provider.has_http_transport() => {
+                return Err(OrbitError::InvalidInput(format!(
+                    "crew '{name}' selects provider '{}' without an HTTP transport",
+                    provider.as_str()
+                )));
+            }
+            Backend::Cli if !provider.has_cli_runtime() => {
+                return Err(OrbitError::InvalidInput(format!(
+                    "crew '{name}' selects provider '{}' without a CLI runtime",
+                    provider.as_str()
+                )));
+            }
+            Backend::Http | Backend::Cli => {}
+            Backend::Auto => unreachable!("auto rejected above"),
+        }
+
+        let description = crew
+            .description
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(ToOwned::to_owned);
+        let mut tags = crew
+            .tags
+            .iter()
+            .map(|tag| tag.trim())
+            .filter(|tag| !tag.is_empty())
+            .map(ToOwned::to_owned)
+            .collect::<Vec<_>>();
+        tags.sort();
+        tags.dedup();
+
+        Ok(Self {
+            name,
+            provider: provider.as_str().to_string(),
+            model,
+            backend: backend.as_str().to_string(),
+            description,
+            tags,
+        })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ExecutionProfileShipV1 {
+    pub mode: String,
+    pub base_branch: String,
+    pub ship_closure_digest: String,
+}
+
+/// Frozen owner payload. Hub-owned generation/receipt metadata belongs only
+/// to [`StoredExecutionProfile`].
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ExecutionProfileV1 {
+    pub schema_version: u32,
+    pub workspace_id: String,
+    pub owner_machine_id: String,
+    pub observed_at: DateTime<Utc>,
+    pub config_digest: String,
+    pub default_crew: String,
+    pub crews: Vec<ExecutionProfileCrewV1>,
+    pub ship: ExecutionProfileShipV1,
+}
+
+impl ExecutionProfileV1 {
+    pub fn validate(&self) -> Result<(), OrbitError> {
+        if self.schema_version != EXECUTION_PROFILE_SCHEMA_VERSION {
+            return Err(OrbitError::InvalidInput(format!(
+                "unsupported execution profile schema_version {}",
+                self.schema_version
+            )));
+        }
+        validate_logical_id("workspace_id", &self.workspace_id)?;
+        validate_logical_id("owner_machine_id", &self.owner_machine_id)?;
+        let default_crew = required_trimmed("default_crew", &self.default_crew)?;
+        if default_crew != self.default_crew {
+            return Err(OrbitError::InvalidInput(
+                "default_crew must be normalized without surrounding whitespace".to_string(),
+            ));
+        }
+        if self.crews.is_empty() {
+            return Err(OrbitError::InvalidInput(
+                "execution profile must contain at least one crew".to_string(),
+            ));
+        }
+        let mut previous: Option<&str> = None;
+        let mut has_default = false;
+        for crew in &self.crews {
+            validate_profile_crew(crew)?;
+            if previous.is_some_and(|name| name >= crew.name.as_str()) {
+                return Err(OrbitError::InvalidInput(
+                    "execution profile crews must have unique names sorted ascending".to_string(),
+                ));
+            }
+            previous = Some(&crew.name);
+            has_default |= crew.name == self.default_crew;
+        }
+        if !has_default {
+            return Err(OrbitError::InvalidInput(format!(
+                "default_crew '{}' does not name an execution profile crew",
+                self.default_crew
+            )));
+        }
+        if !matches!(self.ship.mode.as_str(), "pr" | "local") {
+            return Err(OrbitError::InvalidInput(format!(
+                "execution profile ship mode '{}' is not pr or local",
+                self.ship.mode
+            )));
+        }
+        let base_branch = required_trimmed("ship base_branch", &self.ship.base_branch)?;
+        if base_branch != self.ship.base_branch {
+            return Err(OrbitError::InvalidInput(
+                "ship base_branch must be normalized without surrounding whitespace".to_string(),
+            ));
+        }
+        validate_sha256("config_digest", &self.config_digest)?;
+        validate_sha256("ship_closure_digest", &self.ship.ship_closure_digest)?;
+        let expected = self.compute_config_digest()?;
+        if self.config_digest != expected {
+            return Err(OrbitError::InvalidInput(format!(
+                "execution profile config_digest mismatch: expected {expected}"
+            )));
+        }
+        Ok(())
+    }
+
+    pub fn compute_config_digest(&self) -> Result<String, OrbitError> {
+        #[derive(Serialize)]
+        struct ConfigDigestPayload<'a> {
+            schema_version: u32,
+            default_crew: &'a str,
+            crews: &'a [ExecutionProfileCrewV1],
+            ship_mode: &'a str,
+            ship_base_branch: &'a str,
+        }
+
+        let payload = ConfigDigestPayload {
+            schema_version: self.schema_version,
+            default_crew: &self.default_crew,
+            crews: &self.crews,
+            ship_mode: &self.ship.mode,
+            ship_base_branch: &self.ship.base_branch,
+        };
+        let canonical = serde_json::to_vec(&payload)
+            .map_err(|error| OrbitError::Store(format!("serialize config digest: {error}")))?;
+        let mut hasher = Sha256::new();
+        hasher.update(EXECUTION_CONFIG_DIGEST_DOMAIN);
+        hasher.update(canonical);
+        Ok(format!("{:x}", hasher.finalize()))
+    }
+
+    pub fn semantic_eq(&self, other: &Self) -> bool {
+        self.schema_version == other.schema_version
+            && self.workspace_id == other.workspace_id
+            && self.owner_machine_id == other.owner_machine_id
+            && self.config_digest == other.config_digest
+            && self.default_crew == other.default_crew
+            && self.crews == other.crews
+            && self.ship == other.ship
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct StoredExecutionProfile {
+    pub profile: ExecutionProfileV1,
+    pub generation: u64,
+    pub received_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SanitizedExecutionProfile {
+    pub workspace_id: String,
+    pub owner_machine_id: Option<String>,
+    pub freshness: ProjectionFreshness,
+    pub generation: Option<u64>,
+    pub observed_at: Option<DateTime<Utc>>,
+    pub received_at: Option<DateTime<Utc>>,
+    pub age_seconds: Option<u64>,
+    pub profile: Option<ExecutionProfileV1>,
+}
+
+fn validate_profile_crew(crew: &ExecutionProfileCrewV1) -> Result<(), OrbitError> {
+    let name = required_trimmed("crew name", &crew.name)?;
+    if name != crew.name {
+        return Err(OrbitError::InvalidInput(format!(
+            "crew '{}' name is not normalized",
+            crew.name
+        )));
+    }
+    let provider = Provider::parse(&crew.provider).map_err(|error| {
+        OrbitError::InvalidInput(format!(
+            "crew '{}' has invalid provider: {error}",
+            crew.name
+        ))
+    })?;
+    if provider.as_str() != crew.provider {
+        return Err(OrbitError::InvalidInput(format!(
+            "crew '{}' provider '{}' is not canonical",
+            crew.name, crew.provider
+        )));
+    }
+    let model = required_trimmed("crew model", &crew.model)?;
+    if model != crew.model {
+        return Err(OrbitError::InvalidInput(format!(
+            "crew '{}' model is not normalized",
+            crew.name
+        )));
+    }
+    let backend = Backend::parse(&crew.backend).ok_or_else(|| {
+        OrbitError::InvalidInput(format!(
+            "crew '{}' has unknown backend '{}'",
+            crew.name, crew.backend
+        ))
+    })?;
+    if backend == Backend::Auto || backend.as_str() != crew.backend {
+        return Err(OrbitError::InvalidInput(format!(
+            "crew '{}' backend '{}' is not concrete and canonical",
+            crew.name, crew.backend
+        )));
+    }
+    match backend {
+        Backend::Http if !provider.has_http_transport() => {
+            return Err(OrbitError::InvalidInput(format!(
+                "crew '{}' selects provider '{}' without an HTTP transport",
+                crew.name, crew.provider
+            )));
+        }
+        Backend::Cli if !provider.has_cli_runtime() => {
+            return Err(OrbitError::InvalidInput(format!(
+                "crew '{}' selects provider '{}' without a CLI runtime",
+                crew.name, crew.provider
+            )));
+        }
+        Backend::Http | Backend::Cli => {}
+        Backend::Auto => unreachable!("auto rejected above"),
+    }
+    if crew
+        .description
+        .as_deref()
+        .is_some_and(|value| value.is_empty() || value.trim() != value)
+    {
+        return Err(OrbitError::InvalidInput(format!(
+            "crew '{}' description is not normalized",
+            crew.name
+        )));
+    }
+    let mut previous: Option<&str> = None;
+    for tag in &crew.tags {
+        if tag.is_empty() || tag.trim() != tag {
+            return Err(OrbitError::InvalidInput(format!(
+                "crew '{}' contains an empty or non-normalized tag",
+                crew.name
+            )));
+        }
+        if previous.is_some_and(|value| value >= tag.as_str()) {
+            return Err(OrbitError::InvalidInput(format!(
+                "crew '{}' tags must be sorted and deduplicated",
+                crew.name
+            )));
+        }
+        previous = Some(tag);
+    }
+    Ok(())
+}
+
+fn required_trimmed(field: &str, value: &str) -> Result<String, OrbitError> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        return Err(OrbitError::InvalidInput(format!(
+            "{field} must not be empty"
+        )));
+    }
+    Ok(trimmed.to_string())
+}
+
+fn validate_logical_id(field: &str, value: &str) -> Result<(), OrbitError> {
+    let normalized = required_trimmed(field, value)?;
+    if normalized != value || value.chars().any(char::is_control) || value.contains(['/', '\\']) {
+        return Err(OrbitError::InvalidInput(format!(
+            "{field} must be a normalized logical identifier, not a path"
+        )));
+    }
+    Ok(())
+}
+
+fn validate_sha256(field: &str, value: &str) -> Result<(), OrbitError> {
+    if value.len() != 64
+        || !value
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+    {
+        return Err(OrbitError::InvalidInput(format!(
+            "{field} must be 64 lowercase hexadecimal characters"
+        )));
+    }
+    Ok(())
+}

--- a/crates/orbit-common/src/types/mod.rs
+++ b/crates/orbit-common/src/types/mod.rs
@@ -33,6 +33,7 @@ pub mod auto_task;
 pub mod duel;
 pub mod error;
 pub mod event;
+pub mod execution_profile;
 pub mod executor_def;
 pub mod friction;
 pub mod host;
@@ -94,6 +95,12 @@ pub use duel::{
 };
 pub use error::{NotFoundKind, OrbitError};
 pub use event::OrbitEvent;
+pub use execution_profile::{
+    EXECUTION_CONFIG_DIGEST_DOMAIN, EXECUTION_PROFILE_SCHEMA_VERSION, ExecutionProfileCrewV1,
+    ExecutionProfileShipV1, ExecutionProfileV1, HostWorkspacePresence, ProjectionFreshness,
+    SanitizedExecutionProfile, SanitizedWorkspacePresence, StoredExecutionProfile,
+    WorkspaceOwnership, WorkspacePresenceDeclaration,
+};
 pub use executor_def::{
     ExecutorDef, ExecutorSandboxKind, ExecutorType, ModelPairOverride, StdoutFormat,
 };

--- a/crates/orbit-common/src/types/tests/agent_pair.rs
+++ b/crates/orbit-common/src/types/tests/agent_pair.rs
@@ -21,6 +21,8 @@ mod resolution {
             Crew {
                 name: "codex".to_string(),
                 assignment: assignment(TEST_CODEX_MODEL, "codex"),
+                description: None,
+                tags: Vec::new(),
             },
         );
         registry.insert(
@@ -28,6 +30,8 @@ mod resolution {
             Crew {
                 name: "claude".to_string(),
                 assignment: assignment(TEST_CLAUDE_WEAK_MODEL, "claude"),
+                description: None,
+                tags: Vec::new(),
             },
         );
         registry

--- a/crates/orbit-common/src/types/tests/execution_profile.rs
+++ b/crates/orbit-common/src/types/tests/execution_profile.rs
@@ -1,0 +1,131 @@
+use chrono::{Duration, TimeZone, Utc};
+
+use super::super::{
+    Crew, CrewRoleAssignment, ExecutionProfileCrewV1, ExecutionProfileShipV1, ExecutionProfileV1,
+};
+use crate::types::activity_job::Backend;
+
+fn profile() -> ExecutionProfileV1 {
+    let crews = vec![ExecutionProfileCrewV1 {
+        name: "alpha".to_string(),
+        provider: "codex".to_string(),
+        model: "gpt-test".to_string(),
+        backend: "cli".to_string(),
+        description: None,
+        tags: vec!["fast".to_string(), "review".to_string()],
+    }];
+    let mut profile = ExecutionProfileV1 {
+        schema_version: 1,
+        workspace_id: "ws_alpha".to_string(),
+        owner_machine_id: "hm_alpha".to_string(),
+        observed_at: Utc
+            .with_ymd_and_hms(2026, 7, 18, 8, 0, 0)
+            .single()
+            .expect("timestamp"),
+        config_digest: String::new(),
+        default_crew: "alpha".to_string(),
+        crews,
+        ship: ExecutionProfileShipV1 {
+            mode: "pr".to_string(),
+            base_branch: "agent-main".to_string(),
+            ship_closure_digest: "a".repeat(64),
+        },
+    };
+    profile.config_digest = profile.compute_config_digest().expect("digest");
+    profile
+}
+
+#[test]
+fn crew_normalization_canonicalizes_alias_metadata_and_auto_backend() {
+    let crew = Crew {
+        name: " alpha ".to_string(),
+        assignment: CrewRoleAssignment {
+            provider: " OpenAI ".to_string(),
+            model: " gpt-test ".to_string(),
+            backend: "auto".to_string(),
+        },
+        description: Some("  Fast implementation  ".to_string()),
+        tags: vec![
+            " zeta ".to_string(),
+            String::new(),
+            "alpha".to_string(),
+            "alpha".to_string(),
+        ],
+    };
+
+    let normalized =
+        ExecutionProfileCrewV1::from_crew(&crew, Backend::Cli).expect("crew normalizes");
+    assert_eq!(normalized.name, "alpha");
+    assert_eq!(normalized.provider, "codex");
+    assert_eq!(normalized.model, "gpt-test");
+    assert_eq!(normalized.backend, "cli");
+    assert_eq!(
+        normalized.description.as_deref(),
+        Some("Fast implementation")
+    );
+    assert_eq!(normalized.tags, vec!["alpha", "zeta"]);
+}
+
+#[test]
+fn config_digest_excludes_identity_observation_closure_and_hub_fields() {
+    let original = profile();
+    let mut changed_excluded = original.clone();
+    changed_excluded.workspace_id = "ws_other".to_string();
+    changed_excluded.owner_machine_id = "hm_other".to_string();
+    changed_excluded.observed_at += Duration::hours(1);
+    changed_excluded.ship.ship_closure_digest = "b".repeat(64);
+    assert_eq!(
+        original.compute_config_digest().expect("original digest"),
+        changed_excluded
+            .compute_config_digest()
+            .expect("excluded digest")
+    );
+
+    for mutate in [
+        |profile: &mut ExecutionProfileV1| profile.crews[0].model.push_str("-new"),
+        |profile: &mut ExecutionProfileV1| profile.ship.mode = "local".to_string(),
+        |profile: &mut ExecutionProfileV1| profile.ship.base_branch = "main".to_string(),
+    ] {
+        let mut changed = original.clone();
+        mutate(&mut changed);
+        assert_ne!(
+            original.compute_config_digest().expect("original digest"),
+            changed.compute_config_digest().expect("changed digest")
+        );
+    }
+}
+
+#[test]
+fn validation_rejects_lossy_or_ambiguous_profile_shapes() {
+    let mut unsorted = profile();
+    unsorted.crews.push(ExecutionProfileCrewV1 {
+        name: "aardvark".to_string(),
+        provider: "codex".to_string(),
+        model: "gpt-test".to_string(),
+        backend: "cli".to_string(),
+        description: None,
+        tags: Vec::new(),
+    });
+    assert!(unsorted.validate().is_err());
+
+    let mut auto = profile();
+    auto.crews[0].backend = "auto".to_string();
+    assert!(auto.validate().is_err());
+
+    let mut alias = profile();
+    alias.crews[0].provider = "openai".to_string();
+    assert!(alias.validate().is_err());
+
+    let mut unknown_provider = profile();
+    unknown_provider.crews[0].provider = "ambiguous".to_string();
+    assert!(unknown_provider.validate().is_err());
+
+    let mut unknown_backend = profile();
+    unknown_backend.crews[0].backend = "ambiguous".to_string();
+    assert!(unknown_backend.validate().is_err());
+
+    let mut missing_default = profile();
+    missing_default.default_crew = "missing".to_string();
+    missing_default.config_digest = missing_default.compute_config_digest().expect("digest");
+    assert!(missing_default.validate().is_err());
+}

--- a/crates/orbit-common/src/types/tests/mod.rs
+++ b/crates/orbit-common/src/types/tests/mod.rs
@@ -4,6 +4,7 @@ mod agent_family;
 mod agent_pair;
 mod audit_event;
 mod error;
+mod execution_profile;
 mod executor_def;
 mod friction;
 mod host;

--- a/crates/orbit-core/src/config/bootstrap.rs
+++ b/crates/orbit-core/src/config/bootstrap.rs
@@ -76,6 +76,8 @@ fn render_crews(
                     provider: Some(crew.assignment.provider),
                     model: Some(crew.assignment.model),
                     backend: Some(crew.assignment.backend),
+                    description: crew.description,
+                    tags: crew.tags,
                     planner: None,
                     implementer: None,
                     reviewer: None,
@@ -96,6 +98,8 @@ fn render_crews(
                 provider: assignment.provider.clone(),
                 model: assignment.model.clone(),
                 backend: assignment.backend.clone(),
+                description: None,
+                tags: Vec::new(),
                 planner: None,
                 implementer: None,
                 reviewer: None,
@@ -112,6 +116,8 @@ fn render_crews(
             provider: qa.provider,
             model: qa.model,
             backend: qa.backend,
+            description: None,
+            tags: Vec::new(),
             planner: None,
             implementer: None,
             reviewer: None,
@@ -166,6 +172,25 @@ fn render_crew_table(name: &str, entry: &RawCrewEntry) -> Result<String, OrbitEr
             "{field} = {}\n",
             toml::Value::String(value.to_string())
         ));
+    }
+    if let Some(description) = entry
+        .description
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    {
+        rendered.push_str(&format!(
+            "description = {}\n",
+            toml::Value::String(description.to_string())
+        ));
+    }
+    if !entry.tags.is_empty() {
+        let tags = entry
+            .tags
+            .iter()
+            .map(|tag| toml::Value::String(tag.clone()))
+            .collect::<Vec<_>>();
+        rendered.push_str(&format!("tags = {}\n", toml::Value::Array(tags)));
     }
     rendered.push('\n');
     Ok(rendered)

--- a/crates/orbit-core/src/config/raw.rs
+++ b/crates/orbit-core/src/config/raw.rs
@@ -40,6 +40,10 @@ pub struct RawCrewEntry {
     pub model: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub backend: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub tags: Vec<String>,
     /// Legacy three-role fields retained for compatibility. Runtime loading
     /// selects `implementer` and warns when the discarded roles diverge.
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/crates/orbit-core/src/config/registry.rs
+++ b/crates/orbit-core/src/config/registry.rs
@@ -244,6 +244,8 @@ fn default_admission_crews() -> BTreeMap<String, Crew> {
                 provider: DEFAULT_WORKFLOW_CREW.to_string(),
                 backend: String::new(),
             },
+            description: None,
+            tags: Vec::new(),
         },
     )])
 }

--- a/crates/orbit-core/src/config/runtime.rs
+++ b/crates/orbit-core/src/config/runtime.rs
@@ -256,6 +256,8 @@ pub(crate) fn default_crews() -> BTreeMap<String, Crew> {
         Crew {
             name: "claude".to_string(),
             assignment: crew_role(CLAUDE_DEFAULT_WEAK, "claude", "cli"),
+            description: None,
+            tags: Vec::new(),
         },
     );
     crews.insert(
@@ -263,6 +265,8 @@ pub(crate) fn default_crews() -> BTreeMap<String, Crew> {
         Crew {
             name: "codex".to_string(),
             assignment: crew_role(CODEX_DEFAULT_MODEL, "codex", "cli"),
+            description: None,
+            tags: Vec::new(),
         },
     );
     crews.insert(
@@ -270,6 +274,8 @@ pub(crate) fn default_crews() -> BTreeMap<String, Crew> {
         Crew {
             name: "gemini".to_string(),
             assignment: crew_role(GEMINI_CREW_MODEL, "gemini", "cli"),
+            description: None,
+            tags: Vec::new(),
         },
     );
     crews.insert(
@@ -277,6 +283,8 @@ pub(crate) fn default_crews() -> BTreeMap<String, Crew> {
         Crew {
             name: "grok".to_string(),
             assignment: crew_role(GROK_DEFAULT_MODEL, "grok", "cli"),
+            description: None,
+            tags: Vec::new(),
         },
     );
     crews
@@ -318,8 +326,14 @@ fn crews_from_raw(
         let crew = Crew {
             name: trimmed.to_string(),
             assignment: crew_assignment_from_raw(trimmed, entry)?,
+            description: normalized_crew_description(entry.description.as_deref()),
+            tags: normalized_crew_tags(&entry.tags),
         };
-        crews.insert(trimmed.to_string(), crew);
+        if crews.insert(trimmed.to_string(), crew).is_some() {
+            return Err(OrbitError::InvalidInput(format!(
+                "[crews] contains duplicate name '{trimmed}' after whitespace normalization"
+            )));
+        }
     }
     if crews.is_empty() {
         return Err(OrbitError::InvalidInput(
@@ -327,6 +341,24 @@ fn crews_from_raw(
         ));
     }
     Ok(crews)
+}
+
+fn normalized_crew_description(raw: Option<&str>) -> Option<String> {
+    raw.map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
+}
+
+fn normalized_crew_tags(raw: &[String]) -> Vec<String> {
+    let mut tags = raw
+        .iter()
+        .map(|value| value.trim())
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
+        .collect::<Vec<_>>();
+    tags.sort();
+    tags.dedup();
+    tags
 }
 
 fn crew_assignment_from_raw(

--- a/crates/orbit-core/src/config/tests/runtime.rs
+++ b/crates/orbit-core/src/config/tests/runtime.rs
@@ -17,6 +17,8 @@ fn single_family_crew(name: &str) -> Crew {
     Crew {
         name: name.to_string(),
         assignment: role,
+        description: None,
+        tags: Vec::new(),
     }
 }
 
@@ -37,6 +39,27 @@ fn assert_invalid_duel_config(body: &str, substrings: &[&str]) {
             "expected {message:?} to contain {substring:?}"
         );
     }
+}
+
+#[test]
+fn crew_description_and_tags_normalize_without_loss() {
+    let config = load_config(
+        r#"
+[workflow]
+default_crew = "sol"
+
+[crews.sol]
+model = "gpt-test"
+provider = "codex"
+backend = "cli"
+description = "  Systems implementation  "
+tags = [" review ", "", "hard", "review"]
+"#,
+    )
+    .expect("config loads");
+    let crew = config.crews.get("sol").expect("sol crew");
+    assert_eq!(crew.description.as_deref(), Some("Systems implementation"));
+    assert_eq!(crew.tags, vec!["hard", "review"]);
 }
 
 #[test]

--- a/crates/orbit-core/src/host_registry.rs
+++ b/crates/orbit-core/src/host_registry.rs
@@ -5,14 +5,48 @@
 //! `host.toml` renames, expose administration commands, or add transport;
 //! those surfaces belong to the later registry-administration unit.
 
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 
-use orbit_common::types::{
-    HostAlias, HostNameResolution, HostRecord, HostRegistration, OrbitError,
+use chrono::{DateTime, Duration, Utc};
+use orbit_common::types::activity_job::{
+    Backend, JobV2Step, JobV2StepBody, resolve_activity_backends, resolve_job_backends,
+    validate_job_loop_session_backends,
 };
+use orbit_common::types::{
+    ActivityV2, Crew, CrewRoleAssignment, EXECUTION_PROFILE_SCHEMA_VERSION, ExecutionProfileCrewV1,
+    ExecutionProfileShipV1, ExecutionProfileV1, HostAlias, HostNameResolution, HostRecord,
+    HostRegistration, HostWorkspacePresence, JobV2, OrbitError, SanitizedExecutionProfile,
+    SanitizedWorkspacePresence, StoredExecutionProfile, Workspace, WorkspaceOwnership,
+    WorkspacePresenceDeclaration, WorkspaceRegistry, WorkspaceStatus,
+};
+use orbit_engine::{dispatch_error_to_orbit, resolve_job_catalog_refs_for_execution, validate_job};
 use orbit_store::Store;
+use serde::Serialize;
+use serde_json::Value;
+use sha2::{Digest, Sha256};
 
 use crate::routines::HostIdentity;
+use crate::{OrbitRuntime, resolved_ship_mode};
+
+const PROFILE_FRESHNESS_TTL: Duration = Duration::minutes(10);
+const PROFILE_MAX_OBSERVATION_AGE: Duration = Duration::minutes(10);
+const PROFILE_MAX_FUTURE_SKEW: Duration = Duration::minutes(2);
+const PRESENCE_FRESHNESS_TTL: Duration = Duration::minutes(5);
+const SHIP_CLOSURE_DIGEST_DOMAIN: &[u8] = b"orbit.ship-closure.v1\0";
+const SHIP_CONTRACT_REVISION: u32 = 1;
+const SHIP_JOB_NAMES: [&str; 4] = [
+    "task_auto_pipeline",
+    "task_gate_pipeline",
+    "task_local_pipeline",
+    "task_pr_pipeline",
+];
+const UNSUPPORTED_PROFILE_ENV_OVERRIDES: [&str; 5] = [
+    "ORBIT_JOB_DIR",
+    "ORBIT_V2_JOB_DIR",
+    "ORBIT_ACTIVITY_DIR",
+    "ORBIT_V2_CATALOG_DIR",
+    "ORBIT_BACKEND",
+];
 
 #[derive(Clone)]
 pub struct HostRegistryService {
@@ -56,6 +90,380 @@ impl HostRegistryService {
     pub fn aliases(&self, machine_id: &str) -> Result<Vec<HostAlias>, OrbitError> {
         self.store.list_host_aliases(machine_id)
     }
+
+    pub fn bind_workspace_owner(
+        &self,
+        registry: &WorkspaceRegistry,
+        workspace_id: &str,
+        owner_machine_id: &str,
+    ) -> Result<WorkspaceOwnership, OrbitError> {
+        let workspace = require_logical_workspace(registry, workspace_id)?;
+        if let Some(mirror) = workspace.owner_machine_id.as_deref()
+            && mirror != owner_machine_id
+        {
+            return Err(OrbitError::InvalidInput(format!(
+                "workspace_id '{workspace_id}' local owner mirror '{mirror}' does not match requested hub owner '{owner_machine_id}'"
+            )));
+        }
+        self.store
+            .bind_workspace_owner(workspace_id, owner_machine_id)
+    }
+
+    pub fn publish_presence(
+        &self,
+        registry: &WorkspaceRegistry,
+        caller_machine_id: &str,
+        declarations: &[WorkspacePresenceDeclaration],
+    ) -> Result<Vec<HostWorkspacePresence>, OrbitError> {
+        self.publish_presence_at(registry, caller_machine_id, declarations, Utc::now())
+    }
+
+    fn publish_presence_at(
+        &self,
+        registry: &WorkspaceRegistry,
+        caller_machine_id: &str,
+        declarations: &[WorkspacePresenceDeclaration],
+        received_at: DateTime<Utc>,
+    ) -> Result<Vec<HostWorkspacePresence>, OrbitError> {
+        for declaration in declarations {
+            require_logical_workspace(registry, &declaration.workspace_id)?;
+        }
+        self.store
+            .replace_host_workspace_presence(caller_machine_id, declarations, received_at)
+    }
+
+    pub fn presence_status(
+        &self,
+        machine_id: &str,
+        workspace_id: &str,
+    ) -> Result<SanitizedWorkspacePresence, OrbitError> {
+        self.store.sanitized_workspace_presence(
+            machine_id,
+            workspace_id,
+            Utc::now(),
+            PRESENCE_FRESHNESS_TTL,
+        )
+    }
+
+    pub fn publish_execution_profile(
+        &self,
+        caller_machine_id: &str,
+        expected_generation: u64,
+        profile: &ExecutionProfileV1,
+    ) -> Result<StoredExecutionProfile, OrbitError> {
+        self.publish_execution_profile_at(
+            caller_machine_id,
+            expected_generation,
+            profile,
+            Utc::now(),
+        )
+    }
+
+    fn publish_execution_profile_at(
+        &self,
+        caller_machine_id: &str,
+        expected_generation: u64,
+        profile: &ExecutionProfileV1,
+        received_at: DateTime<Utc>,
+    ) -> Result<StoredExecutionProfile, OrbitError> {
+        self.store.publish_execution_profile(
+            caller_machine_id,
+            expected_generation,
+            profile,
+            received_at,
+            PROFILE_MAX_OBSERVATION_AGE,
+            PROFILE_MAX_FUTURE_SKEW,
+        )
+    }
+
+    pub fn execution_profile_status(
+        &self,
+        workspace_id: &str,
+    ) -> Result<SanitizedExecutionProfile, OrbitError> {
+        self.store
+            .sanitized_execution_profile(workspace_id, Utc::now(), PROFILE_FRESHNESS_TTL)
+    }
+}
+
+impl OrbitRuntime {
+    /// Build the frozen owner payload from the exact runtime/config/catalog
+    /// authorities execution uses. The returned value contains only stable
+    /// IDs and semantic digests; no source path or raw asset is retained.
+    pub fn build_execution_profile_v1(
+        &self,
+        workspace: &Workspace,
+        owner_machine_id: &str,
+        observed_at: DateTime<Utc>,
+    ) -> Result<ExecutionProfileV1, OrbitError> {
+        reject_execution_profile_env_overrides()?;
+        let runtime_workspace_id = self.workspace_id()?;
+        if runtime_workspace_id != workspace.id {
+            return Err(OrbitError::InvalidInput(format!(
+                "runtime workspace_id '{runtime_workspace_id}' does not match logical workspace_id '{}'",
+                workspace.id
+            )));
+        }
+        if let Some(mirror) = workspace.owner_machine_id.as_deref()
+            && mirror != owner_machine_id
+        {
+            return Err(OrbitError::InvalidInput(format!(
+                "workspace_id '{}' local owner mirror '{mirror}' does not match publishing owner '{owner_machine_id}'",
+                workspace.id
+            )));
+        }
+        let registry_base = workspace.base_branch.trim();
+        let runtime_base = self.workflow_base_branch().trim();
+        if registry_base.is_empty() || runtime_base.is_empty() || registry_base != runtime_base {
+            return Err(OrbitError::InvalidInput(format!(
+                "workspace_id '{}' registry base_branch '{}' does not match runtime workflow base_branch '{}'",
+                workspace.id,
+                workspace.base_branch,
+                self.workflow_base_branch()
+            )));
+        }
+
+        let registry = self.configured_crew_registry_projection();
+        let default_crew = registry.default_crew.ok_or_else(|| {
+            OrbitError::InvalidInput(
+                "execution profile publication requires a configured default_crew".to_string(),
+            )
+        })?;
+        let resolved_backend = self.resolve_v2_backend(None).backend;
+        let mut crews = registry
+            .crews
+            .into_iter()
+            .map(|crew| {
+                ExecutionProfileCrewV1::from_crew(
+                    &Crew {
+                        name: crew.name,
+                        assignment: CrewRoleAssignment {
+                            provider: crew.provider,
+                            model: crew.model,
+                            backend: crew.backend,
+                        },
+                        description: crew.description,
+                        tags: crew.tags,
+                    },
+                    resolved_backend,
+                )
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        crews.sort_by(|left, right| left.name.cmp(&right.name));
+
+        let mode = resolved_ship_mode(workspace).as_input_value().to_string();
+        let ship_closure_digest = self.build_ship_closure_digest(resolved_backend)?;
+        let mut profile = ExecutionProfileV1 {
+            schema_version: EXECUTION_PROFILE_SCHEMA_VERSION,
+            workspace_id: workspace.id.clone(),
+            owner_machine_id: owner_machine_id.to_string(),
+            observed_at,
+            config_digest: String::new(),
+            default_crew,
+            crews,
+            ship: ExecutionProfileShipV1 {
+                mode,
+                base_branch: runtime_base.to_string(),
+                ship_closure_digest,
+            },
+        };
+        profile.config_digest = profile.compute_config_digest()?;
+        profile.validate()?;
+        Ok(profile)
+    }
+
+    fn build_ship_closure_digest(&self, resolved_backend: Backend) -> Result<String, OrbitError> {
+        let catalog = self.v2_activity_catalog().map_err(|error| {
+            OrbitError::InvalidInput(format!(
+                "build execution activity catalog for profile: {error}"
+            ))
+        })?;
+        let mut reachable_activities = BTreeSet::new();
+        let mut jobs = Vec::with_capacity(SHIP_JOB_NAMES.len());
+
+        for name in SHIP_JOB_NAMES {
+            let (_, mut job) = self.load_v2_job_asset_by_name(name)?;
+            resolve_job_catalog_refs_for_execution(&mut job, &catalog)
+                .map_err(dispatch_error_to_orbit)?;
+            resolve_job_backends(&mut job, resolved_backend);
+            validate_job_loop_session_backends(&job, name)
+                .map_err(|error| OrbitError::InvalidInput(error.to_string()))?;
+            validate_job(&job).map_err(dispatch_error_to_orbit)?;
+
+            let mut activity_bindings = BTreeMap::new();
+            collect_job_activity_bindings(&job, &mut activity_bindings, &mut reachable_activities);
+            let materialized_job = serde_json::to_value(&job).map_err(|error| {
+                OrbitError::Store(format!(
+                    "serialize materialized ship job '{name}' for digest: {error}"
+                ))
+            })?;
+            jobs.push(ShipJobSemanticV1 {
+                name: name.to_string(),
+                materialized_job,
+                activity_bindings,
+            });
+        }
+
+        let mut activities = BTreeMap::new();
+        for name in reachable_activities {
+            let mut activity = catalog.get(&name).cloned().ok_or_else(|| {
+                OrbitError::InvalidInput(format!(
+                    "reachable ship activity '{name}' is absent from execution catalog"
+                ))
+            })?;
+            resolve_activity_backends(&mut activity, resolved_backend);
+            activities.insert(name, activity);
+        }
+
+        let dto = ShipClosureSemanticV1 {
+            contract: ShipContractSemanticV1 {
+                revision: SHIP_CONTRACT_REVISION,
+                alias: "ship",
+                root_job: "task_auto_pipeline",
+                explicit_task_ids: "non-empty task_ids select exactly those tasks; empty selects backlog",
+                supported_modes: ["local", "pr"],
+                base_semantics: "submission uses the effective runtime workflow base branch",
+                review_semantics: "review is PR-only and requires explicit task_ids plus review_crew",
+            },
+            jobs,
+            activities,
+        };
+        let canonical = serde_json::to_vec(&dto).map_err(|error| {
+            OrbitError::Store(format!("serialize ship closure digest DTO: {error}"))
+        })?;
+        let mut hasher = Sha256::new();
+        hasher.update(SHIP_CLOSURE_DIGEST_DOMAIN);
+        hasher.update(canonical);
+        Ok(format!("{:x}", hasher.finalize()))
+    }
+}
+
+#[derive(Serialize)]
+struct ShipClosureSemanticV1 {
+    contract: ShipContractSemanticV1,
+    jobs: Vec<ShipJobSemanticV1>,
+    activities: BTreeMap<String, ActivityV2>,
+}
+
+#[derive(Serialize)]
+struct ShipContractSemanticV1 {
+    revision: u32,
+    alias: &'static str,
+    root_job: &'static str,
+    explicit_task_ids: &'static str,
+    supported_modes: [&'static str; 2],
+    base_semantics: &'static str,
+    review_semantics: &'static str,
+}
+
+#[derive(Serialize)]
+struct ShipJobSemanticV1 {
+    name: String,
+    materialized_job: Value,
+    activity_bindings: BTreeMap<String, String>,
+}
+
+fn collect_job_activity_bindings(
+    job: &JobV2,
+    bindings: &mut BTreeMap<String, String>,
+    reachable: &mut BTreeSet<String>,
+) {
+    if let Some(name) = &job.recovery_activity {
+        bindings.insert("recovery".to_string(), name.clone());
+        reachable.insert(name.clone());
+    }
+    for (index, step) in job.steps.iter().enumerate() {
+        collect_step_activity_bindings(step, &index.to_string(), bindings, reachable);
+    }
+}
+
+fn collect_step_activity_bindings(
+    step: &JobV2Step,
+    path: &str,
+    bindings: &mut BTreeMap<String, String>,
+    reachable: &mut BTreeSet<String>,
+) {
+    if let Some(name) = &step.recovery_activity {
+        bindings.insert(format!("{path}.recovery"), name.clone());
+        reachable.insert(name.clone());
+    }
+    match &step.body {
+        JobV2StepBody::Target(target) => {
+            if let Some(name) = &target.activity_name {
+                bindings.insert(format!("{path}.activity"), name.clone());
+                reachable.insert(name.clone());
+            }
+        }
+        JobV2StepBody::TargetRef(reference) => {
+            bindings.insert(format!("{path}.activity"), reference.target.clone());
+            reachable.insert(reference.target.clone());
+        }
+        JobV2StepBody::Parallel { parallel } => {
+            for (index, branch) in parallel.branches.iter().enumerate() {
+                collect_step_activity_bindings(
+                    branch,
+                    &format!("{path}.parallel.{index}"),
+                    bindings,
+                    reachable,
+                );
+            }
+        }
+        JobV2StepBody::FanOut { fan_out, .. } => collect_step_activity_bindings(
+            &fan_out.worker,
+            &format!("{path}.fan_out"),
+            bindings,
+            reachable,
+        ),
+        JobV2StepBody::Loop { loop_ } => {
+            for (index, nested) in loop_.steps.iter().enumerate() {
+                collect_step_activity_bindings(
+                    nested,
+                    &format!("{path}.loop.{index}"),
+                    bindings,
+                    reachable,
+                );
+            }
+        }
+    }
+}
+
+fn require_logical_workspace<'a>(
+    registry: &'a WorkspaceRegistry,
+    workspace_id: &str,
+) -> Result<&'a Workspace, OrbitError> {
+    let workspace = registry
+        .workspaces
+        .iter()
+        .find(|workspace| workspace.id == workspace_id)
+        .ok_or_else(|| {
+            OrbitError::InvalidInput(format!("unknown logical workspace_id '{workspace_id}'"))
+        })?;
+    if workspace.status != WorkspaceStatus::Active {
+        return Err(OrbitError::InvalidInput(format!(
+            "logical workspace_id '{workspace_id}' is not active"
+        )));
+    }
+    Ok(workspace)
+}
+
+fn reject_execution_profile_env_overrides() -> Result<(), OrbitError> {
+    reject_execution_profile_env_overrides_from(|name| std::env::var(name).ok())
+}
+
+fn reject_execution_profile_env_overrides_from(
+    read: impl Fn(&str) -> Option<String>,
+) -> Result<(), OrbitError> {
+    let active = UNSUPPORTED_PROFILE_ENV_OVERRIDES
+        .iter()
+        .filter(|name| read(name).is_some_and(|value| !value.trim().is_empty()))
+        .copied()
+        .collect::<Vec<_>>();
+    if active.is_empty() {
+        return Ok(());
+    }
+    Err(OrbitError::InvalidInput(format!(
+        "execution profile publication does not support execution-affecting environment overrides: {}",
+        active.join(", ")
+    )))
 }
 
 #[cfg(test)]

--- a/crates/orbit-core/src/lib.rs
+++ b/crates/orbit-core/src/lib.rs
@@ -80,11 +80,14 @@ pub use host_registry::HostRegistryService;
 pub use auto_tasks::{AutoTaskAddParams, AutoTaskUpdateParams};
 pub use orbit_common::types::{
     AuditEvent, AuditEventStatus, AuditStats, AutoTaskDefinition, AutoTaskSchedule,
-    AutoTaskTemplate, DedupePolicy, EvidenceKind, ExecutorDef, ExternalRef, HostAlias,
-    HostNameResolution, HostRecord, HostRegistration, HostStatus, JobRun, JobRunState, JobRunStep,
-    JobTargetType, Learning, LearningEvidence, LearningScope, LearningStatus, ReviewThreadStatus,
-    Task, TaskComplexity, TaskCreateStatus, TaskPriority, TaskStatus, TaskType,
-    build_task_status_index, resolve_task_dependencies, task_dependencies_ready,
+    AutoTaskTemplate, DedupePolicy, EvidenceKind, ExecutionProfileCrewV1, ExecutionProfileShipV1,
+    ExecutionProfileV1, ExecutorDef, ExternalRef, HostAlias, HostNameResolution, HostRecord,
+    HostRegistration, HostStatus, HostWorkspacePresence, JobRun, JobRunState, JobRunStep,
+    JobTargetType, Learning, LearningEvidence, LearningScope, LearningStatus, ProjectionFreshness,
+    ReviewThreadStatus, SanitizedExecutionProfile, SanitizedWorkspacePresence,
+    StoredExecutionProfile, Task, TaskComplexity, TaskCreateStatus, TaskPriority, TaskStatus,
+    TaskType, WorkspaceOwnership, WorkspacePresenceDeclaration, build_task_status_index,
+    resolve_task_dependencies, task_dependencies_ready,
 };
 pub use orbit_common::types::{MissedRunPolicy, NotFoundKind, OrbitError, OverlapPolicy};
 pub use orbit_common::utility::redaction::redact_sensitive_env_text;

--- a/crates/orbit-core/src/runtime/engine/crew.rs
+++ b/crates/orbit-core/src/runtime/engine/crew.rs
@@ -51,6 +51,10 @@ pub struct ConfiguredCrewRegistryProjection {
 pub struct ConfiguredCrewProjection {
     pub name: String,
     pub model: String,
+    pub provider: String,
+    pub backend: String,
+    pub description: Option<String>,
+    pub tags: Vec<String>,
     pub is_default: bool,
 }
 
@@ -59,6 +63,10 @@ impl ConfiguredCrewProjection {
         Self {
             name: crew.name.clone(),
             model: crew.assignment.model.clone(),
+            provider: crew.assignment.provider.clone(),
+            backend: crew.assignment.backend.clone(),
+            description: crew.description.clone(),
+            tags: crew.tags.clone(),
             is_default,
         }
     }

--- a/crates/orbit-core/src/tests/host_registry.rs
+++ b/crates/orbit-core/src/tests/host_registry.rs
@@ -1,9 +1,19 @@
 use std::collections::BTreeSet;
+use std::fs;
+use std::path::{Path, PathBuf};
 
-use orbit_common::types::{HostNameResolution, HostStatus};
+use chrono::{Duration, TimeZone, Utc};
+use orbit_common::types::{
+    HostNameResolution, HostStatus, ProjectionFreshness, Workspace, WorkspaceRegistry,
+    WorkspaceStatus,
+};
 use orbit_store::Store;
+use orbit_store::sqlite::task_registry::{WorkspaceConfig, write_workspace_config};
 
-use super::HostRegistryService;
+use super::{HostRegistryService, reject_execution_profile_env_overrides_from};
+use crate::OrbitRuntime;
+use crate::command::activity::seed_default_activities;
+use crate::command::job::seed_default_jobs;
 use crate::routines::{HOST_IDENTITY_SCHEMA_VERSION, HostIdentity, HostMode};
 
 fn identity(machine_id: &str, host_id: &str, mode: HostMode) -> HostIdentity {
@@ -56,4 +66,425 @@ fn service_registers_stable_identity_and_preserves_typed_lifecycle_results() {
         vec!["hub"]
     );
     assert_eq!(service.aliases("hm_spoke").expect("aliases").len(), 1);
+}
+
+fn workspace(id: &str, owner_machine_id: Option<&str>) -> Workspace {
+    let now = Utc
+        .with_ymd_and_hms(2026, 7, 18, 8, 0, 0)
+        .single()
+        .expect("timestamp");
+    Workspace {
+        id: id.to_string(),
+        name: id.to_string(),
+        owner_machine_id: owner_machine_id.map(ToOwned::to_owned),
+        git_remote: Some("git@github.com:example/repo.git".to_string()),
+        ship_mode: Some("pr".to_string()),
+        base_branch: "agent-main".to_string(),
+        status: WorkspaceStatus::Active,
+        created_at: now,
+        updated_at: now,
+    }
+}
+
+fn workspace_registry(workspaces: Vec<Workspace>) -> WorkspaceRegistry {
+    WorkspaceRegistry {
+        schema_version: 1,
+        workspaces,
+        checkouts: Vec::new(),
+    }
+}
+
+#[test]
+fn service_requires_explicit_existing_workspace_and_consistent_local_owner_mirror() {
+    let store = Store::open_in_memory().expect("store");
+    let service = HostRegistryService::new(store);
+    service
+        .register_identity(&identity("hm_hub", "hub", HostMode::Hub), BTreeSet::new())
+        .expect("register hub");
+    service
+        .register_identity(
+            &identity("hm_spoke", "spoke", HostMode::Spoke),
+            BTreeSet::new(),
+        )
+        .expect("register spoke");
+    let registry = workspace_registry(vec![workspace("ws_alpha", Some("hm_hub"))]);
+
+    let missing = service
+        .bind_workspace_owner(&registry, "ws_missing", "hm_hub")
+        .expect_err("missing workspace fails")
+        .to_string();
+    assert!(missing.contains("unknown logical workspace_id"));
+    let mirror = service
+        .bind_workspace_owner(&registry, "ws_alpha", "hm_spoke")
+        .expect_err("mirror mismatch fails")
+        .to_string();
+    assert!(mirror.contains("local owner mirror"));
+    let bound = service
+        .bind_workspace_owner(&registry, "ws_alpha", "hm_hub")
+        .expect("bind owner");
+    assert_eq!(bound.owner_machine_id, "hm_hub");
+}
+
+const PROFILE_CONFIG: &str = r#"
+[workflow]
+base_branch = "agent-main"
+default_crew = "sol"
+
+[crews.sol]
+model = "gpt-test"
+provider = "openai"
+backend = "cli"
+description = "  Systems implementation  "
+tags = ["review", " hard ", "review", ""]
+
+[crews.qa]
+model = "claude-test"
+provider = "claude"
+backend = "cli"
+"#;
+
+const PROFILE_WORKSPACE_ID: &str = "alpha-abc123";
+
+fn profile_runtime(config: &str) -> (tempfile::TempDir, OrbitRuntime, PathBuf, PathBuf, Workspace) {
+    let root = tempfile::tempdir().expect("tempdir");
+    let global_root = root.path().join("global");
+    let repo_root = root.path().join("repo");
+    let workspace_root = repo_root.join(".orbit");
+    fs::create_dir_all(&global_root).expect("global root");
+    fs::create_dir_all(&workspace_root).expect("workspace root");
+    write_workspace_config(
+        &workspace_root,
+        &WorkspaceConfig {
+            schema_version: 1,
+            workspace_id: PROFILE_WORKSPACE_ID.to_string(),
+        },
+    )
+    .expect("workspace config");
+    fs::write(workspace_root.join("config.toml"), config).expect("runtime config");
+    seed_default_activities(&global_root.join("resources/activities"), true)
+        .expect("seed activities");
+    seed_default_jobs(&global_root.join("resources/jobs"), true).expect("seed jobs");
+    let runtime = OrbitRuntime::from_roots(&global_root, &workspace_root).expect("runtime");
+    (
+        root,
+        runtime,
+        global_root,
+        workspace_root,
+        workspace(PROFILE_WORKSPACE_ID, Some("hm_owner")),
+    )
+}
+
+fn build_profile(runtime: &OrbitRuntime, workspace: &Workspace) -> super::ExecutionProfileV1 {
+    runtime
+        .build_execution_profile_v1(
+            workspace,
+            "hm_owner",
+            Utc.with_ymd_and_hms(2026, 7, 18, 9, 0, 0)
+                .single()
+                .expect("timestamp"),
+        )
+        .expect("build profile")
+}
+
+fn append_comment(path: &Path) {
+    let mut body = fs::read_to_string(path).expect("read asset");
+    body.push_str("\n# formatting-only profile fixture\n");
+    fs::write(path, body).expect("write commented asset");
+}
+
+#[test]
+fn execution_profile_payload_is_frozen_normalized_and_path_format_order_stable() {
+    let (_root_a, runtime_a, global_a, _workspace_a, workspace_a) = profile_runtime(PROFILE_CONFIG);
+    let profile_a = build_profile(&runtime_a, &workspace_a);
+    assert_eq!(profile_a.crews[0].name, "qa");
+    let sol = profile_a
+        .crews
+        .iter()
+        .find(|crew| crew.name == "sol")
+        .expect("sol crew");
+    assert_eq!(sol.provider, "codex", "provider alias canonicalizes");
+    assert_eq!(sol.description.as_deref(), Some("Systems implementation"));
+    assert_eq!(sol.tags, vec!["hard", "review"]);
+
+    let payload = serde_json::to_value(&profile_a).expect("profile JSON");
+    let keys = payload
+        .as_object()
+        .expect("profile object")
+        .keys()
+        .map(String::as_str)
+        .collect::<BTreeSet<_>>();
+    assert_eq!(
+        keys,
+        BTreeSet::from([
+            "schema_version",
+            "workspace_id",
+            "owner_machine_id",
+            "observed_at",
+            "config_digest",
+            "default_crew",
+            "crews",
+            "ship",
+        ])
+    );
+    assert!(payload.get("generation").is_none());
+    assert!(payload.get("received_at").is_none());
+    assert_eq!(
+        payload["ship"]
+            .as_object()
+            .expect("ship object")
+            .keys()
+            .map(String::as_str)
+            .collect::<BTreeSet<_>>(),
+        BTreeSet::from(["mode", "base_branch", "ship_closure_digest"])
+    );
+
+    append_comment(
+        &global_a
+            .join("resources/jobs")
+            .join("task_auto_pipeline.yaml"),
+    );
+    let formatting_only = build_profile(&runtime_a, &workspace_a);
+    assert_eq!(
+        formatting_only.ship.ship_closure_digest,
+        profile_a.ship.ship_closure_digest
+    );
+
+    let reordered = r#"
+[workflow]
+base_branch = "agent-main"
+default_crew = "sol"
+
+[crews.qa]
+model = "claude-test"
+provider = "claude"
+backend = "cli"
+
+[crews.sol]
+tags = ["", "review", " hard ", "review"]
+description = "  Systems implementation  "
+backend = "cli"
+provider = "openai"
+model = "gpt-test"
+"#;
+    let (_root_b, runtime_b, _global_b, _workspace_b, workspace_b) = profile_runtime(reordered);
+    let profile_b = build_profile(&runtime_b, &workspace_b);
+    assert_eq!(profile_b.config_digest, profile_a.config_digest);
+    assert_eq!(
+        profile_b.ship.ship_closure_digest,
+        profile_a.ship.ship_closure_digest
+    );
+}
+
+#[test]
+fn closure_digest_tracks_execution_precedence_jobs_activities_recovery_and_ignores_unrelated_assets()
+ {
+    let (_root, runtime, global_root, workspace_root, workspace) = profile_runtime(PROFILE_CONFIG);
+    let baseline = build_profile(&runtime, &workspace);
+
+    // List/show precedence prefers workspace assets, but name-based execution
+    // keeps shipped global defaults authoritative for these fixed job names.
+    let local_job = workspace_root.join("resources/jobs/task_local_pipeline.yaml");
+    fs::create_dir_all(local_job.parent().expect("job parent")).expect("job parent");
+    fs::write(
+        &local_job,
+        "schemaVersion: 2\nkind: Job\nmetadata: { name: task_local_pipeline }\nspec: { state: enabled, steps: [] }\n",
+    )
+    .expect("workspace shadow");
+    let workspace_shadow = build_profile(&runtime, &workspace);
+    assert_eq!(
+        workspace_shadow.ship.ship_closure_digest,
+        baseline.ship.ship_closure_digest
+    );
+
+    append_comment(
+        &global_root
+            .join("resources/jobs")
+            .join("workspace_ship_pipeline.yaml"),
+    );
+    fs::write(
+        global_root.join("resources/jobs/unrelated.yaml"),
+        "schemaVersion: 2\nkind: Job\nmetadata: { name: unrelated }\nspec: { state: enabled, steps: [] }\n",
+    )
+    .expect("unrelated job");
+    fs::write(
+        global_root.join("resources/activities/unrelated.yaml"),
+        "schemaVersion: 2\nkind: Activity\nmetadata: { name: unrelated }\nspec: { type: deterministic, description: unrelated, action: unrelated }\n",
+    )
+    .expect("unrelated activity");
+    let unrelated = build_profile(&runtime, &workspace);
+    assert_eq!(
+        unrelated.ship.ship_closure_digest,
+        baseline.ship.ship_closure_digest
+    );
+
+    let local_path = global_root.join("resources/jobs/task_local_pipeline.yaml");
+    let local_body = fs::read_to_string(&local_path).expect("local job");
+    fs::write(
+        &local_path,
+        local_body.replacen(
+            "recovery_activity: step_failure_recovery",
+            "recovery_activity: agent_implement",
+            1,
+        ),
+    )
+    .expect("mutate recovery binding");
+    let recovery_binding_changed = build_profile(&runtime, &workspace);
+    assert_ne!(
+        recovery_binding_changed.ship.ship_closure_digest,
+        baseline.ship.ship_closure_digest
+    );
+    fs::write(&local_path, &local_body).expect("restore recovery binding");
+
+    fs::write(
+        &local_path,
+        local_body.replacen("max_active_runs: 10", "max_active_runs: 9", 1),
+    )
+    .expect("mutate selected job");
+    let job_changed = build_profile(&runtime, &workspace);
+    assert_ne!(
+        job_changed.ship.ship_closure_digest,
+        baseline.ship.ship_closure_digest
+    );
+    fs::write(&local_path, local_body).expect("restore selected job");
+
+    let recovery_path = global_root.join("resources/activities/step_failure_recovery.yaml");
+    let recovery_body = fs::read_to_string(&recovery_path).expect("recovery activity");
+    fs::write(
+        &recovery_path,
+        recovery_body.replacen(
+            "Generic v2 task workflow recovery hook.",
+            "Changed recovery semantics for digest fixture.",
+            1,
+        ),
+    )
+    .expect("mutate recovery");
+    let recovery_changed = build_profile(&runtime, &workspace);
+    assert_ne!(
+        recovery_changed.ship.ship_closure_digest,
+        baseline.ship.ship_closure_digest
+    );
+
+    let auto_body =
+        recovery_body.replacen("  role: reviewer", "  backend: auto\n  role: reviewer", 1);
+    fs::write(&recovery_path, &auto_body).expect("use backend auto");
+    let auto_resolved = build_profile(&runtime, &workspace);
+    assert_eq!(
+        auto_resolved.ship.ship_closure_digest, baseline.ship.ship_closure_digest,
+        "backend:auto must hash its concrete execution result"
+    );
+    fs::write(
+        &recovery_path,
+        auto_body.replacen("backend: auto", "backend: http", 1),
+    )
+    .expect("use concrete alternate backend");
+    let backend_changed = build_profile(&runtime, &workspace);
+    assert_ne!(
+        backend_changed.ship.ship_closure_digest,
+        baseline.ship.ship_closure_digest
+    );
+    fs::write(
+        &recovery_path,
+        auto_body.replacen("backend: auto", "backend: ambiguous", 1),
+    )
+    .expect("use unknown backend");
+    let backend_error = runtime
+        .build_execution_profile_v1(&workspace, "hm_owner", Utc::now())
+        .expect_err("unknown backend fails profile publication")
+        .to_string();
+    assert!(backend_error.contains("backend") || backend_error.contains("ambiguous"));
+}
+
+#[test]
+fn config_digest_tracks_crew_mode_and_base_while_closure_is_independent() {
+    let (_root, runtime, _global, _workspace, workspace) = profile_runtime(PROFILE_CONFIG);
+    let baseline = build_profile(&runtime, &workspace);
+
+    let changed_crew_config = PROFILE_CONFIG.replace("model = \"gpt-test\"", "model = \"gpt-new\"");
+    let (_crew_root, crew_runtime, _crew_global, _crew_workspace, crew_ws) =
+        profile_runtime(&changed_crew_config);
+    let crew_changed = build_profile(&crew_runtime, &crew_ws);
+    assert_ne!(crew_changed.config_digest, baseline.config_digest);
+    assert_eq!(
+        crew_changed.ship.ship_closure_digest,
+        baseline.ship.ship_closure_digest
+    );
+
+    let mut local_workspace = workspace.clone();
+    local_workspace.ship_mode = Some("local".to_string());
+    let mode_changed = build_profile(&runtime, &local_workspace);
+    assert_ne!(mode_changed.config_digest, baseline.config_digest);
+    assert_eq!(
+        mode_changed.ship.ship_closure_digest,
+        baseline.ship.ship_closure_digest
+    );
+
+    let mismatch_config = PROFILE_CONFIG.replace("agent-main", "main");
+    let (_base_root, base_runtime, _base_global, _base_workspace, mut base_ws) =
+        profile_runtime(&mismatch_config);
+    let mismatch = base_runtime
+        .build_execution_profile_v1(&base_ws, "hm_owner", Utc::now())
+        .expect_err("base mismatch fails")
+        .to_string();
+    assert!(mismatch.contains("does not match runtime"));
+    base_ws.base_branch = "main".to_string();
+    let base_changed = build_profile(&base_runtime, &base_ws);
+    assert_ne!(base_changed.config_digest, baseline.config_digest);
+    assert_eq!(
+        base_changed.ship.ship_closure_digest,
+        baseline.ship.ship_closure_digest
+    );
+}
+
+#[test]
+fn unsupported_execution_environment_overrides_fail_closed_without_values() {
+    let error = reject_execution_profile_env_overrides_from(|name| {
+        (name == "ORBIT_JOB_DIR").then(|| "/secret/catalog/path".to_string())
+    })
+    .expect_err("override must fail")
+    .to_string();
+    assert!(error.contains("ORBIT_JOB_DIR"));
+    assert!(!error.contains("/secret/catalog/path"));
+}
+
+#[test]
+fn service_profile_publication_uses_hub_receipt_for_freshness() {
+    let (_root, runtime, _global, _workspace_root, workspace) = profile_runtime(PROFILE_CONFIG);
+    let store = Store::open_in_memory().expect("store");
+    let service = HostRegistryService::new(store.clone());
+    service
+        .register_identity(
+            &identity("hm_owner", "owner", HostMode::Hub),
+            BTreeSet::new(),
+        )
+        .expect("host");
+    let registry = workspace_registry(vec![workspace.clone()]);
+    service
+        .bind_workspace_owner(&registry, PROFILE_WORKSPACE_ID, "hm_owner")
+        .expect("ownership");
+    let received_at = Utc
+        .with_ymd_and_hms(2026, 7, 18, 9, 0, 0)
+        .single()
+        .expect("timestamp");
+    let profile = runtime
+        .build_execution_profile_v1(&workspace, "hm_owner", received_at)
+        .expect("profile");
+    service
+        .publish_execution_profile_at("hm_owner", 0, &profile, received_at)
+        .expect("publish");
+    let current = store
+        .sanitized_execution_profile(
+            PROFILE_WORKSPACE_ID,
+            received_at + Duration::minutes(9),
+            Duration::minutes(10),
+        )
+        .expect("current");
+    assert_eq!(current.freshness, ProjectionFreshness::Current);
+    let stale = store
+        .sanitized_execution_profile(
+            PROFILE_WORKSPACE_ID,
+            received_at + Duration::minutes(11),
+            Duration::minutes(10),
+        )
+        .expect("stale");
+    assert_eq!(stale.freshness, ProjectionFreshness::Stale);
 }

--- a/crates/orbit-store/src/lib.rs
+++ b/crates/orbit-store/src/lib.rs
@@ -138,7 +138,10 @@ pub use backend::{
 pub use file_lock::{LockHolderInfo, read_lock_holder};
 pub use json_schema::{validate_instance_against_schema, validate_schema_document};
 pub use orbit_common::types::{
-    HostAlias, HostNameResolution, HostRecord, HostRegistration, HostStatus,
+    ExecutionProfileV1, HostAlias, HostNameResolution, HostRecord, HostRegistration, HostStatus,
+    HostWorkspacePresence, ProjectionFreshness, SanitizedExecutionProfile,
+    SanitizedWorkspacePresence, StoredExecutionProfile, WorkspaceOwnership,
+    WorkspacePresenceDeclaration,
 };
 pub use sqlite::audit_event_store::{
     AuditEventFilter, AuditEventInsertParams, AuditRoleAggregate, AuditToolAggregate,

--- a/crates/orbit-store/src/sqlite/host_registry.rs
+++ b/crates/orbit-store/src/sqlite/host_registry.rs
@@ -7,10 +7,15 @@
 //! single writer boundary.
 
 use std::collections::BTreeSet;
+use std::path::Path;
 use std::str::FromStr;
 
+use chrono::{DateTime, Duration, Utc};
 use orbit_common::types::{
-    HostAlias, HostNameResolution, HostRecord, HostRegistration, HostStatus, OrbitError,
+    ExecutionProfileV1, HostAlias, HostNameResolution, HostRecord, HostRegistration, HostStatus,
+    HostWorkspacePresence, OrbitError, ProjectionFreshness, SanitizedExecutionProfile,
+    SanitizedWorkspacePresence, StoredExecutionProfile, WorkspaceOwnership,
+    WorkspacePresenceDeclaration,
 };
 use rusqlite::{Connection, OptionalExtension, TransactionBehavior, params};
 
@@ -252,6 +257,526 @@ impl Store {
             (HostStatus::Retired, alias) => Ok(HostNameResolution::Retired { host, alias }),
         }
     }
+
+    /// Declare the one durable owner of an existing logical workspace. The
+    /// service layer validates logical-workspace existence; this store layer
+    /// validates stable identifiers and active host lifecycle. Repeating the
+    /// same binding is idempotent, while rebinding fails closed.
+    pub fn bind_workspace_owner(
+        &self,
+        workspace_id: &str,
+        owner_machine_id: &str,
+    ) -> Result<WorkspaceOwnership, OrbitError> {
+        validate_registry_text("workspace_id", workspace_id)?;
+        validate_machine_id(owner_machine_id)?;
+        self.with_transaction_behavior(TransactionBehavior::Immediate, |tx| {
+            require_active_host(&tx.tx, owner_machine_id)?;
+            if let Some(existing) = ownership_by_workspace(&tx.tx, workspace_id)? {
+                if existing.owner_machine_id != owner_machine_id {
+                    return Err(OrbitError::InvalidInput(format!(
+                        "workspace_id '{workspace_id}' is already owned by machine_id '{}'; ownership migration must be explicit",
+                        existing.owner_machine_id
+                    )));
+                }
+                return Ok(existing);
+            }
+            let now = crate::now_string();
+            tx.tx
+                .execute(
+                    "INSERT INTO workspace_ownership(
+                        workspace_id, owner_machine_id, bound_at, updated_at
+                     ) VALUES (?1, ?2, ?3, ?3)",
+                    params![workspace_id, owner_machine_id, now],
+                )
+                .map_err(|error| {
+                    OrbitError::Store(format!(
+                        "bind owner for workspace_id '{workspace_id}': {error}"
+                    ))
+                })?;
+            ownership_by_workspace(&tx.tx, workspace_id)?.ok_or_else(|| {
+                OrbitError::Store(format!(
+                    "bound owner for workspace_id '{workspace_id}' but could not read it back"
+                ))
+            })
+        })
+    }
+
+    pub fn get_workspace_ownership(
+        &self,
+        workspace_id: &str,
+    ) -> Result<Option<WorkspaceOwnership>, OrbitError> {
+        validate_registry_text("workspace_id", workspace_id)?;
+        let conn = self.read()?;
+        ownership_by_workspace(&conn, workspace_id)
+    }
+
+    /// Atomically replace one authenticated machine's full declared presence
+    /// map and stamp that host's explicit `last_seen_at`. Roots stay confined
+    /// to this private store projection.
+    pub fn replace_host_workspace_presence(
+        &self,
+        caller_machine_id: &str,
+        declarations: &[WorkspacePresenceDeclaration],
+        received_at: DateTime<Utc>,
+    ) -> Result<Vec<HostWorkspacePresence>, OrbitError> {
+        validate_machine_id(caller_machine_id)?;
+        let mut workspace_ids = BTreeSet::new();
+        for declaration in declarations {
+            validate_registry_text("workspace_id", &declaration.workspace_id)?;
+            if !workspace_ids.insert(declaration.workspace_id.as_str()) {
+                return Err(OrbitError::InvalidInput(format!(
+                    "presence declaration repeats workspace_id '{}'",
+                    declaration.workspace_id
+                )));
+            }
+            validate_presence_root(&declaration.root)?;
+        }
+
+        self.with_transaction_behavior(TransactionBehavior::Immediate, |tx| {
+            require_active_host(&tx.tx, caller_machine_id)?;
+            tx.tx
+                .execute(
+                    "DELETE FROM host_workspace_presence WHERE machine_id = ?1",
+                    [caller_machine_id],
+                )
+                .map_err(|error| OrbitError::Store(error.to_string()))?;
+            for declaration in declarations {
+                let root = declaration.root.to_str().ok_or_else(|| {
+                    OrbitError::InvalidInput(format!(
+                        "presence root for workspace_id '{}' must be valid UTF-8",
+                        declaration.workspace_id
+                    ))
+                })?;
+                tx.tx
+                    .execute(
+                        "INSERT INTO host_workspace_presence(
+                            machine_id, workspace_id, root, last_verified
+                         ) VALUES (?1, ?2, ?3, ?4)",
+                        params![
+                            caller_machine_id,
+                            declaration.workspace_id,
+                            root,
+                            declaration.last_verified.to_rfc3339(),
+                        ],
+                    )
+                    .map_err(|error| {
+                        OrbitError::Store(format!(
+                            "publish presence for workspace_id '{}': {error}",
+                            declaration.workspace_id
+                        ))
+                    })?;
+            }
+            tx.tx
+                .execute(
+                    "UPDATE hosts SET last_seen_at = ?2 WHERE machine_id = ?1",
+                    params![caller_machine_id, received_at.to_rfc3339()],
+                )
+                .map_err(|error| OrbitError::Store(format!("update host last_seen: {error}")))?;
+            presence_for_machine(&tx.tx, caller_machine_id)
+        })
+    }
+
+    pub fn list_host_workspace_presence_private(
+        &self,
+        machine_id: &str,
+    ) -> Result<Vec<HostWorkspacePresence>, OrbitError> {
+        validate_machine_id(machine_id)?;
+        let conn = self.read()?;
+        presence_for_machine(&conn, machine_id)
+    }
+
+    pub fn sanitized_workspace_presence(
+        &self,
+        machine_id: &str,
+        workspace_id: &str,
+        now: DateTime<Utc>,
+        freshness_ttl: Duration,
+    ) -> Result<SanitizedWorkspacePresence, OrbitError> {
+        validate_machine_id(machine_id)?;
+        validate_registry_text("workspace_id", workspace_id)?;
+        validate_nonnegative_duration("presence freshness TTL", freshness_ttl)?;
+        let conn = self.read()?;
+        let owner_machine_id = ownership_by_workspace(&conn, workspace_id)?
+            .map(|ownership| ownership.owner_machine_id);
+        let presence = presence_by_key(&conn, machine_id, workspace_id)?;
+        let Some(presence) = presence else {
+            return Ok(SanitizedWorkspacePresence {
+                workspace_id: workspace_id.to_string(),
+                machine_id: machine_id.to_string(),
+                owner_machine_id,
+                freshness: ProjectionFreshness::Missing,
+                last_verified: None,
+                age_seconds: None,
+            });
+        };
+        let age = age_seconds(now, presence.last_verified);
+        let freshness = if now.signed_duration_since(presence.last_verified) > freshness_ttl {
+            ProjectionFreshness::Stale
+        } else {
+            ProjectionFreshness::Current
+        };
+        Ok(SanitizedWorkspacePresence {
+            workspace_id: workspace_id.to_string(),
+            machine_id: machine_id.to_string(),
+            owner_machine_id,
+            freshness,
+            last_verified: Some(presence.last_verified),
+            age_seconds: Some(age),
+        })
+    }
+
+    /// Authenticate and compare-and-set an owner profile. The caller supplies
+    /// the generation it read (zero for missing). Semantically unchanged
+    /// payloads keep the generation while refreshing owner/hub observations.
+    pub fn publish_execution_profile(
+        &self,
+        caller_machine_id: &str,
+        expected_generation: u64,
+        profile: &ExecutionProfileV1,
+        received_at: DateTime<Utc>,
+        max_observation_age: Duration,
+        max_future_skew: Duration,
+    ) -> Result<StoredExecutionProfile, OrbitError> {
+        validate_machine_id(caller_machine_id)?;
+        validate_nonnegative_duration("maximum observation age", max_observation_age)?;
+        validate_nonnegative_duration("maximum future skew", max_future_skew)?;
+        profile.validate()?;
+        if profile.owner_machine_id != caller_machine_id {
+            return Err(OrbitError::InvalidInput(format!(
+                "execution profile owner_machine_id '{}' does not match authenticated caller '{}'",
+                profile.owner_machine_id, caller_machine_id
+            )));
+        }
+        if profile.observed_at < received_at - max_observation_age {
+            return Err(OrbitError::InvalidInput(format!(
+                "execution profile observation for workspace_id '{}' is already stale",
+                profile.workspace_id
+            )));
+        }
+        if profile.observed_at > received_at + max_future_skew {
+            return Err(OrbitError::InvalidInput(format!(
+                "execution profile observation for workspace_id '{}' is implausibly future-dated",
+                profile.workspace_id
+            )));
+        }
+
+        self.with_transaction_behavior(TransactionBehavior::Immediate, |tx| {
+            require_active_host(&tx.tx, caller_machine_id)?;
+            let ownership = ownership_by_workspace(&tx.tx, &profile.workspace_id)?.ok_or_else(|| {
+                OrbitError::InvalidInput(format!(
+                    "workspace_id '{}' has no declared owner",
+                    profile.workspace_id
+                ))
+            })?;
+            if ownership.owner_machine_id != caller_machine_id {
+                return Err(OrbitError::InvalidInput(format!(
+                    "machine_id '{caller_machine_id}' is not the owner of workspace_id '{}'",
+                    profile.workspace_id
+                )));
+            }
+
+            let existing = stored_profile_by_workspace(&tx.tx, &profile.workspace_id)?;
+            let actual_generation = existing.as_ref().map_or(0, |record| record.generation);
+            if expected_generation != actual_generation {
+                return Err(OrbitError::InvalidInput(format!(
+                    "stale execution profile generation for workspace_id '{}': expected {}, current {}",
+                    profile.workspace_id, expected_generation, actual_generation
+                )));
+            }
+            if existing
+                .as_ref()
+                .is_some_and(|record| profile.observed_at < record.profile.observed_at)
+            {
+                return Err(OrbitError::InvalidInput(format!(
+                    "execution profile observation for workspace_id '{}' is older than the stored observation",
+                    profile.workspace_id
+                )));
+            }
+
+            let generation = match existing.as_ref() {
+                None => 1,
+                Some(record) if record.profile.semantic_eq(profile) => record.generation,
+                Some(record) => record.generation.checked_add(1).ok_or_else(|| {
+                    OrbitError::Store(format!(
+                        "execution profile generation overflow for workspace_id '{}'",
+                        profile.workspace_id
+                    ))
+                })?,
+            };
+            let payload_json = serde_json::to_string(profile).map_err(|error| {
+                OrbitError::Store(format!("serialize execution profile: {error}"))
+            })?;
+            let generation_sql = i64::try_from(generation).map_err(|error| {
+                OrbitError::Store(format!("execution profile generation is too large: {error}"))
+            })?;
+            tx.tx
+                .execute(
+                    "INSERT INTO workspace_execution_profiles(
+                        workspace_id, owner_machine_id, generation, payload_json, received_at
+                     ) VALUES (?1, ?2, ?3, ?4, ?5)
+                     ON CONFLICT(workspace_id) DO UPDATE SET
+                        owner_machine_id = excluded.owner_machine_id,
+                        generation = excluded.generation,
+                        payload_json = excluded.payload_json,
+                        received_at = excluded.received_at",
+                    params![
+                        profile.workspace_id,
+                        caller_machine_id,
+                        generation_sql,
+                        payload_json,
+                        received_at.to_rfc3339(),
+                    ],
+                )
+                .map_err(|error| OrbitError::Store(format!(
+                    "publish execution profile for workspace_id '{}': {error}",
+                    profile.workspace_id
+                )))?;
+            stored_profile_by_workspace(&tx.tx, &profile.workspace_id)?.ok_or_else(|| {
+                OrbitError::Store(format!(
+                    "published execution profile for workspace_id '{}' but could not read it back",
+                    profile.workspace_id
+                ))
+            })
+        })
+    }
+
+    pub fn get_execution_profile(
+        &self,
+        workspace_id: &str,
+    ) -> Result<Option<StoredExecutionProfile>, OrbitError> {
+        validate_registry_text("workspace_id", workspace_id)?;
+        let conn = self.read()?;
+        stored_profile_by_workspace(&conn, workspace_id)
+    }
+
+    pub fn sanitized_execution_profile(
+        &self,
+        workspace_id: &str,
+        now: DateTime<Utc>,
+        freshness_ttl: Duration,
+    ) -> Result<SanitizedExecutionProfile, OrbitError> {
+        validate_registry_text("workspace_id", workspace_id)?;
+        validate_nonnegative_duration("execution profile freshness TTL", freshness_ttl)?;
+        let conn = self.read()?;
+        let owner_machine_id = ownership_by_workspace(&conn, workspace_id)?
+            .map(|ownership| ownership.owner_machine_id);
+        let record = stored_profile_by_workspace(&conn, workspace_id)?;
+        let Some(record) = record else {
+            return Ok(SanitizedExecutionProfile {
+                workspace_id: workspace_id.to_string(),
+                owner_machine_id,
+                freshness: ProjectionFreshness::Missing,
+                generation: None,
+                observed_at: None,
+                received_at: None,
+                age_seconds: None,
+                profile: None,
+            });
+        };
+        let age = age_seconds(now, record.received_at);
+        let freshness = if now.signed_duration_since(record.received_at) > freshness_ttl {
+            ProjectionFreshness::Stale
+        } else {
+            ProjectionFreshness::Current
+        };
+        Ok(SanitizedExecutionProfile {
+            workspace_id: workspace_id.to_string(),
+            owner_machine_id,
+            freshness,
+            generation: Some(record.generation),
+            observed_at: Some(record.profile.observed_at),
+            received_at: Some(record.received_at),
+            age_seconds: Some(age),
+            profile: Some(record.profile),
+        })
+    }
+}
+
+fn require_active_host(conn: &Connection, machine_id: &str) -> Result<HostRecord, OrbitError> {
+    let host = host_by_machine_id(conn, machine_id)?.ok_or_else(|| {
+        OrbitError::InvalidInput(format!("unknown host machine_id '{machine_id}'"))
+    })?;
+    if host.status != HostStatus::Active {
+        return Err(OrbitError::InvalidInput(format!(
+            "host machine_id '{machine_id}' is retired"
+        )));
+    }
+    Ok(host)
+}
+
+fn ownership_by_workspace(
+    conn: &Connection,
+    workspace_id: &str,
+) -> Result<Option<WorkspaceOwnership>, OrbitError> {
+    conn.query_row(
+        "SELECT workspace_id, owner_machine_id, bound_at, updated_at
+         FROM workspace_ownership WHERE workspace_id = ?1",
+        [workspace_id],
+        |row| {
+            Ok((
+                row.get::<_, String>(0)?,
+                row.get::<_, String>(1)?,
+                row.get::<_, String>(2)?,
+                row.get::<_, String>(3)?,
+            ))
+        },
+    )
+    .optional()
+    .map_err(|error| OrbitError::Store(error.to_string()))?
+    .map(|(workspace_id, owner_machine_id, bound_at, updated_at)| {
+        Ok(WorkspaceOwnership {
+            workspace_id,
+            owner_machine_id,
+            bound_at: crate::parse_timestamp(&bound_at)
+                .map_err(|error| OrbitError::Store(error.to_string()))?,
+            updated_at: crate::parse_timestamp(&updated_at)
+                .map_err(|error| OrbitError::Store(error.to_string()))?,
+        })
+    })
+    .transpose()
+}
+
+fn presence_for_machine(
+    conn: &Connection,
+    machine_id: &str,
+) -> Result<Vec<HostWorkspacePresence>, OrbitError> {
+    let mut statement = conn
+        .prepare(
+            "SELECT machine_id, workspace_id, root, last_verified
+             FROM host_workspace_presence WHERE machine_id = ?1 ORDER BY workspace_id",
+        )
+        .map_err(|error| OrbitError::Store(error.to_string()))?;
+    let rows = statement
+        .query_map([machine_id], raw_presence_row)
+        .map_err(|error| OrbitError::Store(error.to_string()))?;
+    rows.map(|row| {
+        row.map_err(|error| OrbitError::Store(error.to_string()))?
+            .try_into()
+    })
+    .collect()
+}
+
+fn presence_by_key(
+    conn: &Connection,
+    machine_id: &str,
+    workspace_id: &str,
+) -> Result<Option<HostWorkspacePresence>, OrbitError> {
+    conn.query_row(
+        "SELECT machine_id, workspace_id, root, last_verified
+         FROM host_workspace_presence WHERE machine_id = ?1 AND workspace_id = ?2",
+        params![machine_id, workspace_id],
+        raw_presence_row,
+    )
+    .optional()
+    .map_err(|error| OrbitError::Store(error.to_string()))?
+    .map(TryInto::try_into)
+    .transpose()
+}
+
+struct RawPresenceRow {
+    machine_id: String,
+    workspace_id: String,
+    root: String,
+    last_verified: String,
+}
+
+fn raw_presence_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<RawPresenceRow> {
+    Ok(RawPresenceRow {
+        machine_id: row.get(0)?,
+        workspace_id: row.get(1)?,
+        root: row.get(2)?,
+        last_verified: row.get(3)?,
+    })
+}
+
+impl TryFrom<RawPresenceRow> for HostWorkspacePresence {
+    type Error = OrbitError;
+
+    fn try_from(row: RawPresenceRow) -> Result<Self, Self::Error> {
+        Ok(Self {
+            machine_id: row.machine_id,
+            workspace_id: row.workspace_id,
+            root: row.root.into(),
+            last_verified: crate::parse_timestamp(&row.last_verified)
+                .map_err(|error| OrbitError::Store(error.to_string()))?,
+        })
+    }
+}
+
+fn stored_profile_by_workspace(
+    conn: &Connection,
+    workspace_id: &str,
+) -> Result<Option<StoredExecutionProfile>, OrbitError> {
+    conn.query_row(
+        "SELECT payload_json, generation, received_at
+         FROM workspace_execution_profiles WHERE workspace_id = ?1",
+        [workspace_id],
+        |row| {
+            Ok((
+                row.get::<_, String>(0)?,
+                row.get::<_, i64>(1)?,
+                row.get::<_, String>(2)?,
+            ))
+        },
+    )
+    .optional()
+    .map_err(|error| OrbitError::Store(error.to_string()))?
+    .map(|(payload_json, generation, received_at)| {
+        let profile =
+            serde_json::from_str::<ExecutionProfileV1>(&payload_json).map_err(|error| {
+                OrbitError::Store(format!(
+                    "workspace_id '{workspace_id}' has invalid execution profile JSON: {error}"
+                ))
+            })?;
+        profile.validate().map_err(|error| {
+            OrbitError::Store(format!(
+                "workspace_id '{workspace_id}' has invalid execution profile: {error}"
+            ))
+        })?;
+        let generation = u64::try_from(generation).map_err(|error| {
+            OrbitError::Store(format!(
+                "workspace_id '{workspace_id}' has invalid profile generation: {error}"
+            ))
+        })?;
+        Ok(StoredExecutionProfile {
+            profile,
+            generation,
+            received_at: crate::parse_timestamp(&received_at)
+                .map_err(|error| OrbitError::Store(error.to_string()))?,
+        })
+    })
+    .transpose()
+}
+
+fn validate_presence_root(root: &Path) -> Result<(), OrbitError> {
+    if !root.is_absolute() {
+        return Err(OrbitError::InvalidInput(format!(
+            "presence root '{}' must be absolute",
+            root.display()
+        )));
+    }
+    let raw = root
+        .to_str()
+        .ok_or_else(|| OrbitError::InvalidInput("presence root must be valid UTF-8".to_string()))?;
+    if raw.chars().any(char::is_control) {
+        return Err(OrbitError::InvalidInput(
+            "presence root must not contain control characters".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+fn validate_nonnegative_duration(field: &str, duration: Duration) -> Result<(), OrbitError> {
+    if duration < Duration::zero() {
+        return Err(OrbitError::InvalidInput(format!(
+            "{field} must not be negative"
+        )));
+    }
+    Ok(())
+}
+
+fn age_seconds(now: DateTime<Utc>, observed: DateTime<Utc>) -> u64 {
+    u64::try_from(now.signed_duration_since(observed).num_seconds().max(0)).unwrap_or_default()
 }
 
 fn validate_registration(registration: &HostRegistration) -> Result<(), OrbitError> {

--- a/crates/orbit-store/src/sqlite/migration/ledger.rs
+++ b/crates/orbit-store/src/sqlite/migration/ledger.rs
@@ -58,12 +58,17 @@ pub(crate) const MIGRATIONS: &[Migration] = &[
         name: "host_registry_core",
         apply: super::apply_host_registry_core,
     },
+    Migration {
+        version: 6,
+        name: "workspace_coordination_projections",
+        apply: super::apply_workspace_coordination_projections,
+    },
 ];
 
 /// Highest schema version this binary knows how to produce. Public for
 /// the future `orbit migrate` surface (P3.4), alongside
 /// [`AppliedMigration`] and the `Store` version accessors.
-pub const SUPPORTED_SCHEMA_VERSION: u32 = 5;
+pub const SUPPORTED_SCHEMA_VERSION: u32 = 6;
 
 const LEDGER_KEY_PREFIX: &str = "migration.v";
 

--- a/crates/orbit-store/src/sqlite/migration/mod.rs
+++ b/crates/orbit-store/src/sqlite/migration/mod.rs
@@ -796,6 +796,80 @@ fn apply_host_registry_core(conn: &Connection) -> Result<(), OrbitError> {
     .map_err(|error| OrbitError::Store(error.to_string()))
 }
 
+/// v6 `workspace_coordination_projections` migration (ORB-10257): singular
+/// workspace ownership, private host-keyed presence, and owner-published
+/// execution profiles. The schema is additive and keeps owner payload JSON
+/// separate from hub-owned generation/receipt metadata.
+fn apply_workspace_coordination_projections(conn: &Connection) -> Result<(), OrbitError> {
+    conn.execute_batch(
+        r#"
+            CREATE TABLE IF NOT EXISTS workspace_ownership (
+                workspace_id     TEXT PRIMARY KEY,
+                owner_machine_id TEXT NOT NULL,
+                bound_at         TEXT NOT NULL,
+                updated_at       TEXT NOT NULL,
+                CHECK (length(workspace_id) > 0),
+                FOREIGN KEY(owner_machine_id) REFERENCES hosts(machine_id)
+                    ON UPDATE RESTRICT ON DELETE RESTRICT
+            );
+
+            CREATE INDEX IF NOT EXISTS idx_workspace_ownership_owner
+                ON workspace_ownership(owner_machine_id, workspace_id);
+
+            CREATE TABLE IF NOT EXISTS host_workspace_presence (
+                machine_id   TEXT NOT NULL,
+                workspace_id TEXT NOT NULL,
+                root         TEXT NOT NULL,
+                last_verified TEXT NOT NULL,
+                PRIMARY KEY(machine_id, workspace_id),
+                CHECK (length(workspace_id) > 0),
+                CHECK (length(root) > 0),
+                FOREIGN KEY(machine_id) REFERENCES hosts(machine_id)
+                    ON UPDATE RESTRICT ON DELETE RESTRICT
+            );
+
+            CREATE INDEX IF NOT EXISTS idx_host_workspace_presence_workspace
+                ON host_workspace_presence(workspace_id, machine_id);
+
+            CREATE TABLE IF NOT EXISTS workspace_execution_profiles (
+                workspace_id     TEXT PRIMARY KEY,
+                owner_machine_id TEXT NOT NULL,
+                generation       INTEGER NOT NULL CHECK (generation >= 1),
+                payload_json     TEXT NOT NULL,
+                received_at      TEXT NOT NULL,
+                CHECK (json_valid(payload_json) AND json_type(payload_json) = 'object'),
+                FOREIGN KEY(workspace_id) REFERENCES workspace_ownership(workspace_id)
+                    ON UPDATE RESTRICT ON DELETE RESTRICT,
+                FOREIGN KEY(owner_machine_id) REFERENCES hosts(machine_id)
+                    ON UPDATE RESTRICT ON DELETE RESTRICT
+            );
+
+            CREATE TRIGGER IF NOT EXISTS execution_profile_owner_matches_insert
+            BEFORE INSERT ON workspace_execution_profiles
+            WHEN NOT EXISTS (
+                SELECT 1 FROM workspace_ownership o
+                WHERE o.workspace_id = NEW.workspace_id
+                  AND o.owner_machine_id = NEW.owner_machine_id
+            )
+            BEGIN
+                SELECT RAISE(ABORT, 'execution profile owner does not match workspace ownership');
+            END;
+
+            CREATE TRIGGER IF NOT EXISTS execution_profile_owner_matches_update
+            BEFORE UPDATE OF workspace_id, owner_machine_id ON workspace_execution_profiles
+            WHEN NOT EXISTS (
+                SELECT 1 FROM workspace_ownership o
+                WHERE o.workspace_id = NEW.workspace_id
+                  AND o.owner_machine_id = NEW.owner_machine_id
+            )
+            BEGIN
+                SELECT RAISE(ABORT, 'execution profile owner does not match workspace ownership');
+            END;
+        "#,
+    )
+    .map_err(|error| OrbitError::Store(error.to_string()))
+}
+
 fn ensure_task_reservations_schema(conn: &Connection) -> Result<(), OrbitError> {
     conn.execute_batch(
         r#"

--- a/crates/orbit-store/src/sqlite/migration/tests/ledger.rs
+++ b/crates/orbit-store/src/sqlite/migration/tests/ledger.rs
@@ -46,6 +46,9 @@ fn fresh_db_applies_baseline_and_records_ledger() {
     assert_eq!(applied[4].version, 5);
     assert_eq!(applied[4].name, "host_registry_core");
     assert!(!applied[4].applied_at.is_empty());
+    assert_eq!(applied[5].version, 6);
+    assert_eq!(applied[5].name, "workspace_coordination_projections");
+    assert!(!applied[5].applied_at.is_empty());
 }
 
 #[test]
@@ -166,6 +169,10 @@ fn legacy_db_adopts_versioned_ledger() {
                 "migration.v0005".to_string(),
                 "host_registry_core".to_string()
             ),
+            (
+                "migration.v0006".to_string(),
+                "workspace_coordination_projections".to_string()
+            ),
         ]
     );
 }
@@ -177,7 +184,7 @@ fn refuses_db_from_a_newer_binary() {
 
     conn.execute(
         "INSERT INTO schema_meta(key, value, updated_at)
-         VALUES ('migration.v0006', 'from-the-future', '2099-01-01T00:00:00Z')",
+         VALUES ('migration.v0007', 'from-the-future', '2099-01-01T00:00:00Z')",
         [],
     )
     .expect("record future migration");
@@ -193,7 +200,7 @@ fn refuses_db_from_a_newer_binary() {
 }
 
 #[test]
-fn store_reopens_database_at_shipped_schema_v4_and_applies_v5() {
+fn store_reopens_database_at_shipped_schema_v4_and_applies_v5_and_v6() {
     let dir = tempfile::tempdir().expect("tempdir");
     let path = dir.path().join("orbit.db");
 
@@ -220,17 +227,18 @@ fn store_reopens_database_at_shipped_schema_v4_and_applies_v5() {
     drop(conn);
 
     let store = crate::Store::open(&path).expect("reopen shipped v4 store");
-    assert_eq!(store.schema_version().expect("schema version"), 5);
+    assert_eq!(store.schema_version().expect("schema version"), 6);
     let applied = store.applied_migrations().expect("applied migrations");
-    assert_eq!(applied.last().map(|migration| migration.version), Some(5));
+    assert_eq!(applied.last().map(|migration| migration.version), Some(6));
     assert_eq!(
         applied.last().map(|migration| migration.name.as_str()),
-        Some("host_registry_core")
+        Some("workspace_coordination_projections")
     );
     let connection = store.connection();
     let conn = connection.lock().expect("connection");
     assert!(table_exists(&conn, "hosts").expect("hosts table"));
     assert!(table_exists(&conn, "host_aliases").expect("aliases table"));
+    assert!(table_exists(&conn, "workspace_ownership").expect("ownership table"));
     let preserved: i64 = conn
         .query_row(
             "SELECT COUNT(*) FROM job_runs WHERE id = 'preserved-run'",

--- a/crates/orbit-store/src/sqlite/migration/tests/migration.rs
+++ b/crates/orbit-store/src/sqlite/migration/tests/migration.rs
@@ -113,7 +113,7 @@ fn run_archive_stage_migration_adds_archived_at() {
 }
 
 #[test]
-fn host_registry_migration_creates_typed_tables_without_touching_existing_records() {
+fn coordination_migrations_create_typed_tables_without_touching_existing_records() {
     let conn = Connection::open_in_memory().expect("open in-memory connection");
     conn.execute_batch(
         r#"
@@ -161,7 +161,14 @@ fn host_registry_migration_creates_typed_tables_without_touching_existing_record
         )
         .expect("existing row");
     assert_eq!(preserved, "unchanged");
-    assert_eq!(current_schema_version(&conn).expect("version"), 5);
+    assert_eq!(current_schema_version(&conn).expect("version"), 6);
+    for table in [
+        "workspace_ownership",
+        "host_workspace_presence",
+        "workspace_execution_profiles",
+    ] {
+        assert!(table_exists(&conn, table).expect("coordination table"));
+    }
 
     let first = applied_migrations(&conn).expect("first ledger");
     apply_schema(&conn).expect("reapply");

--- a/crates/orbit-store/src/sqlite/tests/host_registry.rs
+++ b/crates/orbit-store/src/sqlite/tests/host_registry.rs
@@ -1,6 +1,11 @@
 use std::collections::BTreeSet;
+use std::path::PathBuf;
 
-use orbit_common::types::{HostNameResolution, HostRegistration, HostStatus};
+use chrono::{Duration, TimeZone, Utc};
+use orbit_common::types::{
+    ExecutionProfileCrewV1, ExecutionProfileShipV1, ExecutionProfileV1, HostNameResolution,
+    HostRegistration, HostStatus, ProjectionFreshness, WorkspacePresenceDeclaration,
+};
 
 use crate::Store;
 
@@ -14,6 +19,36 @@ fn registration(machine_id: &str, host_id: &str, labels: &[&str]) -> HostRegistr
 
 fn error_text(result: Result<impl std::fmt::Debug, orbit_common::types::OrbitError>) -> String {
     result.expect_err("operation must fail").to_string()
+}
+
+fn execution_profile(
+    workspace_id: &str,
+    owner_machine_id: &str,
+    observed_at: chrono::DateTime<Utc>,
+) -> ExecutionProfileV1 {
+    let mut profile = ExecutionProfileV1 {
+        schema_version: 1,
+        workspace_id: workspace_id.to_string(),
+        owner_machine_id: owner_machine_id.to_string(),
+        observed_at,
+        config_digest: String::new(),
+        default_crew: "sol".to_string(),
+        crews: vec![ExecutionProfileCrewV1 {
+            name: "sol".to_string(),
+            provider: "codex".to_string(),
+            model: "gpt-test".to_string(),
+            backend: "cli".to_string(),
+            description: Some("Systems implementation".to_string()),
+            tags: vec!["hard".to_string()],
+        }],
+        ship: ExecutionProfileShipV1 {
+            mode: "pr".to_string(),
+            base_branch: "agent-main".to_string(),
+            ship_closure_digest: "a".repeat(64),
+        },
+    };
+    profile.config_digest = profile.compute_config_digest().expect("config digest");
+    profile
 }
 
 #[test]
@@ -284,4 +319,333 @@ fn identifiers_reject_paths_instead_of_persisting_them() {
         assert!(error.contains("not a path"));
     }
     assert!(store.list_active_hosts().expect("active hosts").is_empty());
+}
+
+#[test]
+fn two_host_multi_workspace_fixture_covers_ownership_presence_profile_cas_and_freshness() {
+    let store = Store::open_in_memory().expect("store");
+    store
+        .register_host(&registration("hm_alpha", "alpha", &["codex"]))
+        .expect("register alpha");
+    store
+        .register_host(&registration("hm_beta", "beta", &["claude"]))
+        .expect("register beta");
+
+    let alpha_owner = store
+        .bind_workspace_owner("ws_alpha", "hm_alpha")
+        .expect("bind alpha owner");
+    assert_eq!(
+        store
+            .bind_workspace_owner("ws_alpha", "hm_alpha")
+            .expect("repeat binding"),
+        alpha_owner
+    );
+    store
+        .bind_workspace_owner("ws_beta", "hm_beta")
+        .expect("bind beta owner");
+    let duplicate_owner = error_text(store.bind_workspace_owner("ws_alpha", "hm_beta"));
+    assert!(duplicate_owner.contains("already owned"));
+
+    let now = Utc
+        .with_ymd_and_hms(2026, 7, 18, 9, 0, 0)
+        .single()
+        .expect("timestamp");
+    let alpha_presence = vec![
+        WorkspacePresenceDeclaration {
+            workspace_id: "ws_alpha".to_string(),
+            root: PathBuf::from("/alpha/ws-alpha"),
+            last_verified: now,
+        },
+        WorkspacePresenceDeclaration {
+            workspace_id: "ws_beta".to_string(),
+            root: PathBuf::from("/alpha/ws-beta"),
+            last_verified: now,
+        },
+    ];
+    store
+        .replace_host_workspace_presence("hm_alpha", &alpha_presence, now)
+        .expect("publish alpha presence");
+    store
+        .replace_host_workspace_presence(
+            "hm_beta",
+            &[WorkspacePresenceDeclaration {
+                workspace_id: "ws_alpha".to_string(),
+                root: PathBuf::from("/beta/ws-alpha"),
+                last_verified: now,
+            }],
+            now,
+        )
+        .expect("non-owner presence is valid");
+    assert_eq!(
+        store
+            .get_host("hm_alpha")
+            .expect("host")
+            .expect("alpha")
+            .last_seen_at,
+        Some(now)
+    );
+    let private = store
+        .list_host_workspace_presence_private("hm_alpha")
+        .expect("private presence");
+    assert_eq!(private.len(), 2);
+    assert_eq!(private[0].root, PathBuf::from("/alpha/ws-alpha"));
+
+    // An insert failure after DELETE rolls back the whole replacement.
+    {
+        let connection = store.connection();
+        let conn = connection.lock().expect("connection");
+        conn.execute_batch(
+            "CREATE TRIGGER fail_beta_presence
+             BEFORE INSERT ON host_workspace_presence
+             WHEN NEW.machine_id = 'hm_alpha' AND NEW.workspace_id = 'ws_beta'
+             BEGIN SELECT RAISE(ABORT, 'injected presence failure'); END;",
+        )
+        .expect("install trigger");
+    }
+    let replacement_error = error_text(store.replace_host_workspace_presence(
+        "hm_alpha",
+        &[WorkspacePresenceDeclaration {
+            workspace_id: "ws_beta".to_string(),
+            root: PathBuf::from("/alpha/new-beta"),
+            last_verified: now + Duration::minutes(1),
+        }],
+        now + Duration::minutes(1),
+    ));
+    assert!(replacement_error.contains("injected presence failure"));
+    assert_eq!(
+        store
+            .list_host_workspace_presence_private("hm_alpha")
+            .expect("rolled-back presence"),
+        private
+    );
+    {
+        let connection = store.connection();
+        connection
+            .lock()
+            .expect("connection")
+            .execute_batch("DROP TRIGGER fail_beta_presence")
+            .expect("drop trigger");
+    }
+    store
+        .replace_host_workspace_presence(
+            "hm_alpha",
+            &[WorkspacePresenceDeclaration {
+                workspace_id: "ws_beta".to_string(),
+                root: PathBuf::from("/alpha/new-beta"),
+                last_verified: now + Duration::minutes(1),
+            }],
+            now + Duration::minutes(1),
+        )
+        .expect("replace presence");
+    assert_eq!(
+        store
+            .list_host_workspace_presence_private("hm_alpha")
+            .expect("replaced presence")
+            .iter()
+            .map(|presence| presence.workspace_id.as_str())
+            .collect::<Vec<_>>(),
+        vec!["ws_beta"]
+    );
+    let missing_presence = store
+        .sanitized_workspace_presence(
+            "hm_alpha",
+            "ws_alpha",
+            now + Duration::minutes(1),
+            Duration::minutes(5),
+        )
+        .expect("missing presence");
+    assert_eq!(missing_presence.freshness, ProjectionFreshness::Missing);
+    assert!(
+        !serde_json::to_string(&missing_presence)
+            .expect("serialize sanitized presence")
+            .contains("/alpha")
+    );
+    let stale_presence = store
+        .sanitized_workspace_presence(
+            "hm_beta",
+            "ws_alpha",
+            now + Duration::minutes(6),
+            Duration::minutes(5),
+        )
+        .expect("stale presence");
+    assert_eq!(stale_presence.freshness, ProjectionFreshness::Stale);
+
+    let missing_profile = store
+        .sanitized_execution_profile("ws_alpha", now, Duration::minutes(5))
+        .expect("missing profile");
+    assert_eq!(missing_profile.freshness, ProjectionFreshness::Missing);
+    assert_eq!(
+        missing_profile.owner_machine_id.as_deref(),
+        Some("hm_alpha")
+    );
+
+    let profile = execution_profile("ws_alpha", "hm_alpha", now);
+    let non_owner = error_text(store.publish_execution_profile(
+        "hm_beta",
+        0,
+        &profile,
+        now,
+        Duration::minutes(10),
+        Duration::minutes(2),
+    ));
+    assert!(non_owner.contains("authenticated caller"));
+    let stale = execution_profile("ws_alpha", "hm_alpha", now - Duration::minutes(11));
+    assert!(
+        error_text(store.publish_execution_profile(
+            "hm_alpha",
+            0,
+            &stale,
+            now,
+            Duration::minutes(10),
+            Duration::minutes(2),
+        ))
+        .contains("already stale")
+    );
+    let future = execution_profile("ws_alpha", "hm_alpha", now + Duration::minutes(3));
+    assert!(
+        error_text(store.publish_execution_profile(
+            "hm_alpha",
+            0,
+            &future,
+            now,
+            Duration::minutes(10),
+            Duration::minutes(2),
+        ))
+        .contains("future-dated")
+    );
+
+    let first = store
+        .publish_execution_profile(
+            "hm_alpha",
+            0,
+            &profile,
+            now,
+            Duration::minutes(10),
+            Duration::minutes(2),
+        )
+        .expect("first profile");
+    assert_eq!(first.generation, 1);
+    let mut refreshed = profile.clone();
+    refreshed.observed_at = now + Duration::minutes(1);
+    let unchanged = store
+        .publish_execution_profile(
+            "hm_alpha",
+            1,
+            &refreshed,
+            now + Duration::minutes(1),
+            Duration::minutes(10),
+            Duration::minutes(2),
+        )
+        .expect("unchanged refresh");
+    assert_eq!(unchanged.generation, 1);
+    assert_eq!(unchanged.received_at, now + Duration::minutes(1));
+
+    let mut changed = refreshed.clone();
+    changed.crews[0].model = "gpt-test-new".to_string();
+    changed.config_digest = changed.compute_config_digest().expect("changed digest");
+    let advanced = store
+        .publish_execution_profile(
+            "hm_alpha",
+            1,
+            &changed,
+            now + Duration::minutes(2),
+            Duration::minutes(10),
+            Duration::minutes(2),
+        )
+        .expect("semantic change");
+    assert_eq!(advanced.generation, 2);
+    let stale_generation = error_text(store.publish_execution_profile(
+        "hm_alpha",
+        1,
+        &changed,
+        now + Duration::minutes(2),
+        Duration::minutes(10),
+        Duration::minutes(2),
+    ));
+    assert!(stale_generation.contains("stale execution profile generation"));
+    let older_observation = error_text(store.publish_execution_profile(
+        "hm_alpha",
+        2,
+        &profile,
+        now + Duration::minutes(2),
+        Duration::minutes(10),
+        Duration::minutes(2),
+    ));
+    assert!(older_observation.contains("older than the stored"));
+
+    let current = store
+        .sanitized_execution_profile("ws_alpha", now + Duration::minutes(3), Duration::minutes(5))
+        .expect("current profile");
+    assert_eq!(current.freshness, ProjectionFreshness::Current);
+    assert_eq!(current.generation, Some(2));
+    let stale = store
+        .sanitized_execution_profile("ws_alpha", now + Duration::minutes(8), Duration::minutes(5))
+        .expect("stale profile");
+    assert_eq!(stale.freshness, ProjectionFreshness::Stale);
+}
+
+#[test]
+fn reopen_preserves_workspace_coordination_projections() {
+    let directory = tempfile::tempdir().expect("tempdir");
+    let path = directory.path().join("orbit.db");
+    let now = Utc
+        .with_ymd_and_hms(2026, 7, 18, 10, 0, 0)
+        .single()
+        .expect("timestamp");
+    let store = Store::open(&path).expect("store");
+    store
+        .register_host(&registration("hm_alpha", "alpha", &[]))
+        .expect("host");
+    store
+        .bind_workspace_owner("ws_alpha", "hm_alpha")
+        .expect("ownership");
+    store
+        .replace_host_workspace_presence(
+            "hm_alpha",
+            &[WorkspacePresenceDeclaration {
+                workspace_id: "ws_alpha".to_string(),
+                root: PathBuf::from("/alpha/ws-alpha"),
+                last_verified: now,
+            }],
+            now,
+        )
+        .expect("presence");
+    store
+        .publish_execution_profile(
+            "hm_alpha",
+            0,
+            &execution_profile("ws_alpha", "hm_alpha", now),
+            now,
+            Duration::minutes(10),
+            Duration::minutes(2),
+        )
+        .expect("profile");
+    let ledger = store.applied_migrations().expect("ledger");
+    drop(store);
+
+    let reopened = Store::open(&path).expect("reopen");
+    assert_eq!(reopened.applied_migrations().expect("ledger"), ledger);
+    assert_eq!(
+        reopened
+            .get_workspace_ownership("ws_alpha")
+            .expect("ownership")
+            .expect("bound")
+            .owner_machine_id,
+        "hm_alpha"
+    );
+    assert_eq!(
+        reopened
+            .list_host_workspace_presence_private("hm_alpha")
+            .expect("presence")
+            .len(),
+        1
+    );
+    assert_eq!(
+        reopened
+            .get_execution_profile("ws_alpha")
+            .expect("profile")
+            .expect("published")
+            .generation,
+        1
+    );
 }

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -41,6 +41,8 @@ A **crew** is one provider-model-backend assignment. Every activity role (`plann
 | `model` | Model identifier passed to the provider CLI | Provider-specific (e.g. `opus`, `sonnet`, `gpt-5.5`, `pro`, `grok-build`) |
 | `provider` | Agent family | `claude`, `codex`, `gemini`, `grok` (the CLI-executable families; see [Provider identity and resolution](#provider-identity-and-resolution) for the full canonical set) |
 | `backend` | How Orbit dispatches the agent | `cli` (today the only supported value for these roles) |
+| `description` | Optional human-facing crew summary | Any non-empty string after trimming |
+| `tags` | Optional discovery labels | Array of strings; normalized, sorted, and deduplicated |
 
 Example — a Codex crew:
 
@@ -49,9 +51,19 @@ Example — a Codex crew:
 model = "gpt-5.5"
 provider = "codex"
 backend = "cli"
+description = "Systems implementation"
+tags = ["implementation", "review"]
 ```
 
 You can define any number of crews. Set the workspace-wide fallback with `workflow.default_crew`; assign a specific crew to individual tasks via the [per-task crew override](#per-task-crew-override). Crews are validated at load time: each crew must have non-empty `model`, `provider`, and `backend`; `workflow.default_crew` must name a defined crew.
+
+Crew metadata is canonical runtime data, not display-only TOML. Orbit trims
+`description` (blank becomes absent), trims each tag, drops blank tags, and stores
+tags in sorted deduplicated order. Legacy crew entries without these fields
+normalize to no description and an empty tag list. Owner execution-profile
+publication carries this complete projection to the hub; publication is stricter
+than legacy dispatch compatibility and fails closed if provider or backend cannot
+be canonicalized to a concrete executable combination.
 
 > **Legacy compatibility.** Orbit still accepts the former `planner` / `implementer` / `reviewer` inline-table shape. It uses the `implementer` assignment for every role and logs an `orbit.config.crew` warning when planner or reviewer differs. Rewrite legacy crews to the flat shape above; cross-provider comparison belongs in the duel system.
 

--- a/docs/design/host-registry/2_design.md
+++ b/docs/design/host-registry/2_design.md
@@ -10,7 +10,7 @@ summary: Target mechanisms for host identity, the main-host registry, the coordi
 tags: [host-registry, multi-host, dispatch, routines, data-placement]
 paths: ["crates/orbit-core/**", "crates/orbit-store/**", "crates/orbit-mcp/**", "crates/orbit-common/**"]
 related_features: [host-registry, mcp-bridge, routines, remote-access, mcp-session-context]
-related_artifacts: [ORB-00424, ORB-10247, ORB-10248, ORB-10249, ORB-10255, ORB-10258, ADR-0200, ADR-0205, ADR-0208, ADR-0226, ADR-0227, ADR-0228, ADR-0229, ADR-0230, ADR-0231, ADR-0232]
+related_artifacts: [ORB-00424, ORB-10247, ORB-10248, ORB-10249, ORB-10255, ORB-10257, ORB-10258, ADR-0200, ADR-0205, ADR-0208, ADR-0226, ADR-0227, ADR-0228, ADR-0229, ADR-0230, ADR-0231, ADR-0232]
 ---
 
 # Host Registry — Design
@@ -201,6 +201,39 @@ including unversioned input without an explicit role, require stable owner ident
 and reject missing/unknown roles, owner/replica contradictions, and replicas without
 an owner, naming the workspace ID. Malformed/future schemas are read-only failures,
 and a failed staged write leaves the prior file readable.
+
+**Concrete hub coordination projections ([ORB-10257]).** Additive store migration
+v6 creates three path-separated projections:
+
+- `workspace_ownership` binds each stable logical `workspace_id` to exactly one
+  active, known `owner_machine_id`. Binding validates the logical workspace through
+  `HostRegistryService`; the B2 `owner_machine_id` is checked only as the local
+  mirror. Rebinding is not inferred or silently performed.
+- `host_workspace_presence` is private and keyed by
+  `(machine_id, workspace_id)`. An authenticated publication atomically replaces
+  that host's complete declared map and explicitly stamps host `last_seen_at`.
+  The reported absolute root is the sole path-bearing hub-link exception: it is
+  retained only in this private placement projection and is absent from sanitized
+  reads, profiles, audit, leases, routing frames, and remote execution.
+- `workspace_execution_profiles` stores one owner payload plus hub-owned
+  `generation` and `received_at`. The frozen `ExecutionProfileV1` is exactly
+  identity, owner `observed_at`, `config_digest`, normalized effective crews, and
+  `{mode, base_branch, ship_closure_digest}`. Identical semantic publication
+  refreshes both timestamps without advancing generation; a semantic change
+  advances it atomically. Owner authentication, generation CAS, active ownership,
+  already-stale/future observations, and observations older than the stored one
+  all fail before overwrite. Freshness is calculated only from hub `received_at`.
+
+`config_digest` hashes domain-separated canonical compact JSON of the normalized
+crew/config and effective mode/base branch. `ship_closure_digest` separately hashes
+the execution-selected, fully materialized four-job ship closure, its reachable
+named and recovery activities, resolved backends, and versioned static ship
+contract. Neither digest contains identities, clocks, paths, raw config/assets or
+environment values. Publication rejects execution-affecting catalog/backend
+environment overrides and unknown provider/backend values rather than publishing
+an ambiguous projection. These projections are typed service/store foundations;
+administration, dispatch gating, run snapshots, leases, and connectors remain later
+units.
 
 Enforcement reads only local data, so it works offline; what fails offline is the
 MCP write itself, loudly. Two local rules (§5 for the record types they guard):
@@ -429,6 +462,9 @@ of that routine.** Consequences:
 - [ORB-10255] — implemented the append-only v5 host/alias schema and typed C1
   registry core: compatible idempotent registration, collision refusal, permanent
   rename chains, retirement, active enumeration, and fail-closed name resolution.
+- [ORB-10257] — implemented additive v6 singular workspace ownership, private
+  host-keyed presence replacement/freshness, and owner-authenticated execution
+  profile CAS with canonical config and fully materialized ship-closure digests.
 - [ORB-10258] — implemented origin-aware routine loading (§6 items 1–2; Unit R1 under
   ORB-10246): committed definitions fail closed without a non-empty host pin,
   `.orbit/routines/local/` definitions are implicit to the loading host and reject

--- a/docs/design/mcp-bridge/2_design.md
+++ b/docs/design/mcp-bridge/2_design.md
@@ -10,13 +10,15 @@ summary: Target design for a local Orbit MCP broker with one SSH hub link, hub-o
 tags: [mcp, remote-access, host-registry, bridge, ssh, routing]
 paths: ["crates/orbit-mcp/**", "crates/orbit-cli/src/command/mcp/**", "crates/orbit-core/src/command/tool.rs", "crates/orbit-common/src/types/tool.rs"]
 related_features: [mcp-bridge, host-registry, mcp-session-context, remote-access, orbit-search, orbit-graph, project-learnings]
-related_artifacts: [ORB-00424, ADR-0181, ADR-0199, ADR-0200, ADR-0201, ADR-0226, ADR-0227, ADR-0228, ADR-0229, ADR-0230, ADR-0231, ADR-0232]
+related_artifacts: [ORB-00424, ORB-10257, ADR-0181, ADR-0199, ADR-0200, ADR-0201, ADR-0226, ADR-0227, ADR-0228, ADR-0229, ADR-0230, ADR-0231, ADR-0232]
 ---
 
 # Orbit MCP Bridge — Design
 
-This document specifies the **target** design; nothing here has landed. It replaces
-both Bridge's HTTP parity layer and the earlier
+This document specifies the **target** design. The host-registry identity,
+workspace, registry-core, and C2 coordination projections it depends on have
+landed; the broker/transport surfaces here remain pending. It replaces both
+Bridge's HTTP parity layer and the earlier
 per-workspace-authority draft with a local broker that has one remote destination:
 the coordination hub. It covers client→hub transport and local tool placement. The
 reverse direction — placing a run, leasing it from a spoke, and reporting its result
@@ -484,12 +486,27 @@ Four independent routing choices remain separate:
 
 The hub must validate crew and dispatch without contacting the owner. Therefore the
 workspace owner publishes a small **execution profile** to the hub during register/
-poll and whenever relevant config changes. At minimum it contains:
+poll and whenever relevant config changes. The landed C2 contract ([ORB-10257])
+freezes `ExecutionProfileV1` to `schema_version`, stable workspace/owner IDs, owner
+`observed_at`, `config_digest`, default crew, sorted normalized effective crew
+entries (name, canonical provider, model, concrete backend, description, tags), and
+ship mode/base branch plus `ship_closure_digest`. Hub-owned generation and
+`received_at` remain in the stored envelope rather than the payload.
 
-- config revision/digest and observed-at timestamp;
-- default crew and effective crew entries (name, provider, model, backend,
-  description, tags); and
-- dispatch facts required by `workflow.ship` that are otherwise checkout-local.
+The config digest covers only the canonical crew/mode/base semantics. The
+independent closure digest covers the versioned ship contract,
+execution-selected materialized task-auto/gate/PR/local jobs, and every reachable
+named or recovery activity after execution precedence, inlining, validation, and
+`backend:auto` resolution. Neither projection stores paths, raw assets, environment
+values, secrets, commands, or repository content.
+
+Publication is authenticated as the current owner and compare-and-set against the
+hub generation. An identical semantic payload refreshes observation/receipt
+freshness without advancing generation; a semantic change advances it atomically.
+The hub rejects stale generation, non-owner publication, stale/future/older owner
+observations, execution-affecting environment overrides, and unknown or ambiguous
+provider/backend resolution. Freshness is based on hub `received_at`, never the
+owner's clock.
 
 This is one-way spoke→hub coordination metadata, not repo content and not a live
 proxy. `orbit.crew.list`, task crew validation, and workflow preflight all read the


### PR DESCRIPTION
## Task

[ORB-10257](https://orbit-cli.com/tasks/ORB-10257) — Add workspace ownership, presence, and execution-profile projections

### Description

## Problem

The hub host-registry core (C1) establishes durable machine identity and lifecycle, but dispatch and knowledge enforcement also need explicit workspace ownership, checkout presence, and owner-published execution facts. These must be durable coordination projections at the hub, never inferred from a checkout, workspace name, audit traffic, or a synchronous call to the owner.

This is Unit C2 of implementation umbrella ORB-10246. It follows C1/ORB-10255.

## Required outcome

Add versioned typed persistence and service APIs for three related hub projections:

1. **Workspace ownership**
   - exactly one declared owner `machine_id` per stable logical `workspace_id`;
   - optional current display `host_id` is a projection only, never the durable key;
   - binding is explicit and validates active known machines and logical workspaces; and
   - B2's local `owner_machine_id` is a mirror of this hub authority, never a second independently mutable ownership source.

2. **Host/workspace presence**
   - keyed by `machine_id + workspace_id`;
   - carries the root reported by that machine and `last_verified`;
   - publish replaces that machine's declared presence atomically and updates explicit host `last_seen`; and
   - the hub never treats a hub path as the execution path on another machine.

3. **Owner execution profile**
   - freeze the owner-published `ExecutionProfileV1` payload to: `schema_version = 1`, `workspace_id`, `owner_machine_id`, owner `observed_at`, `config_digest`, `default_crew`, sorted effective crew entries (`name`, canonical `provider`, non-empty `model`, concrete `backend`, normalized `description`, sorted/deduplicated `tags`), and `ship { mode, base_branch, ship_closure_digest }`;
   - keep hub-owned `generation` and hub-stamped `received_at` in the stored record envelope, not in the owner payload or either digest;
   - compute `config_digest` as a domain-separated SHA-256 over canonical compact JSON containing schema version, default crew, full normalized/sorted crew entries, and effective ship mode/base branch. Exclude identity, timestamps, digest fields, hub metadata, paths, raw config/assets, environment names/values, secrets, presence, commands, repository content, and unrelated settings such as `auto_ship`;
   - compute one domain-separated `ship_closure_digest` from the execution-selected and fully materialized `ship -> task_auto_pipeline -> task_gate_pipeline -> task_pr_pipeline/task_local_pipeline` closure plus every reachable named and recovery activity, after real execution catalog precedence, named-activity inlining, `backend:auto` resolution, and existing loader/allowlist validation. Hash a dedicated semantic DTO that includes resolved recovery behavior; do not blindly serialize `JobV2`, use list/show precedence, include the `workspace_ship_pipeline` routine wrapper, or substitute full/separate job/workflow/activity catalog digests;
   - include the static ship contract revision and constants (alias/root, explicit task IDs, supported modes, base/review semantics) inside the closure digest's domain DTO rather than duplicating them as mutable profile fields;
   - use `resolved_ship_mode(workspace)` for mode and the same effective runtime base branch that submission uses. Establish one base-branch authority or reject a registry/runtime mismatch;
   - forbid execution-affecting environment overrides for multi-host profile publication, or derive the closure from their effective result without storing their names/values; an ambiguous/unknown provider or backend fails publication closed rather than warning/falling back;
   - widen the canonical crew config/projection to supply description/tags. Legacy entries may normalize absent values to `null`/`[]`, but a permanently lossy projection is not an implementation of the accepted contract; and
   - bind publication to the authenticated current owner. Compare-and-set a hub-owned record generation: identical semantic payload refreshes observed/received freshness without generation advance; semantic changes advance generation atomically; stale generation, non-owner, already-stale observation, future-skewed observation, or observation older than the stored one fails without overwriting newer data.

Expose typed freshness/generation reads and sanitized projections for later C3/H1 consumers. Freshness uses hub `received_at`; owner `observed_at` is retained separately. Missing/stale data remains explicit. Dispatch blocking, run snapshots, selected-runner digest recomputation, and lease compatibility belong to H1/I units.

## Boundaries

- No CLI/MCP admin commands, workspace link UX, satellite cache, SSH transport, broker, workflow submission, host selection, run snapshot, runner comparison, or lease behavior.
- No synchronous hub-to-owner request and no owner connector.
- Store no credentials, API keys, SSH material, raw environment values, provider tokens, absolute profile paths, arbitrary repository content, executable command fragments, raw TOML/YAML, or source paths.
- Ownership is per workspace and singular; do not add a per-workspace coordination target or multi-hub/HA field.
- Local owner/replica enforcement and owner migration orchestration belong to later units.

Presence-root exception: the authenticated registration/poll presence update may carry that reporting machine's absolute checkout root into the hub's host-keyed private presence projection because Host Registry placement validation requires it. This is the sole path-bearing hub-link payload: the root is never part of the logical workspace record, public discovery, execution profile, registry cache, audit event, lease envelope, ordinary routing/session frame, or remote execution path, and the hub never sends it back to another machine.

### Acceptance Criteria

- Additive versioned persistence represents one explicit owner machine_id per logical workspace, host/workspace presence with last_verified, and a stored execution-profile record containing owner ExecutionProfileV1 plus hub-owned generation and received_at.
- ExecutionProfileV1 is exactly schema_version/workspace_id/owner_machine_id/observed_at/config_digest/default_crew/sorted effective crews and ship{mode,base_branch,ship_closure_digest}; hub generation/received_at and static ship constants are not duplicated inside the published payload.
- Each effective crew entry has unique non-empty name, canonical provider (aliases resolved), trimmed non-empty model, concrete validated backend (never auto/unknown), normalized optional description, and sorted/deduplicated non-empty tags; default_crew must name an entry.
- Canonical crew config/projection is widened to carry description and tags. Legacy absent metadata may normalize deterministically to null/empty-list, but the published projection cannot remain permanently lossy.
- config_digest is domain-separated SHA-256 over canonical compact JSON of schema_version, default_crew, full normalized/sorted crew entries, and effective ship mode/base branch. Identity, observations, hub metadata, digest fields, paths, raw config/assets/environment, secrets, presence, commands, repository content, auto_ship, and workflow closure are excluded.
- ship_closure_digest is domain-separated SHA-256 over one dedicated semantic DTO containing ship contract revision/constants and the execution-selected, fully materialized task_auto/task_gate/task_pr/task_local jobs plus every reachable named/recovery activity after execution precedence, inlining, backend:auto resolution, and existing validation.
- The closure digest includes resolved recovery behavior even though JobV2 skips that field during ordinary serialization; YAML formatting/comments, filesystem paths, workspace_ship_pipeline, unrelated catalog entries, and separate/full catalog digests do not affect the authoritative gate.
- Mode comes from resolved_ship_mode(workspace); base_branch comes from the same effective runtime authority used by submission. Registry/runtime base mismatches are resolved to one authority or rejected, never silently hashed one way and executed another.
- Execution-affecting environment overrides are forbidden for multi-host profile publication or represented only through their resolved semantic result; raw names/values are never stored. Unknown provider/backend values fail closed rather than warning/falling back.
- Publication is authenticated as the current owner and compare-and-set against hub record generation. Identical semantic payload refreshes observed_at/received_at without generation advance; semantic changes advance generation atomically; stale generation or non-owner writes cannot overwrite newer data.
- Hub stamps received_at and uses it for freshness. Owner observed_at remains separate and publication rejects already-stale, implausibly future-dated, or older-than-stored observations without trusting owner clock for TTL.
- Ownership binding validates an existing logical workspace and active known machine, is never inferred from paths/names/presence, cannot create two owners, and B2 owner_machine_id remains only the local mirror of hub authority.
- Presence publication is keyed by caller machine_id, atomically replaces that machine's declared workspace map, updates explicit last_seen, and keeps reported roots private to that host; sanitized profile/presence reads expose missing/current/stale state, owner, generation, observations, receipt, and age without secrets or paths.
- Deterministic tests prove formatting/path/order stability; semantic crew/mode/base/job/activity/recovery/backend changes alter the correct digest; execution rather than list/show precedence determines the closure; unsupported overrides/ambiguous backends fail closed; and unchanged publication refreshes freshness without generation advance.
- A two-host/multi-workspace fixture covers singular/CAS ownership, owner/non-owner presence, non-owner/stale/future/old profile refusal, semantic generation advance, atomic replacement, and missing/current/stale reads. No connector/admin/cache/routing/workflow/run/runner/lease behavior is added; migration/reopen/replay is transactional/idempotent and targeted orbit-common/orbit-store/orbit-core tests plus make ci-fast pass.
- Authenticated presence publication is the sole path-bearing hub-link exception: it stores the caller machine's reported root only in the private host-keyed presence projection for placement validation; public/sanitized reads, profiles, caches, audits, lease envelopes, ordinary MCP frames, and remote execution expose only stable IDs and freshness.

## Execution Summary

<details>
<summary>Click to expand</summary>

Implemented ORB-10257 end to end without changing task status.

- Added additive SQLite migration v6 for singular logical-workspace ownership, private host/workspace presence, and stored owner execution profiles with hub generation/received_at.
- Added typed orbit-common projections and exact ExecutionProfileV1 validation/normalization, widened canonical crew config/projections with description and tags, and implemented domain-separated canonical config digests.
- Added HostRegistryService/store ownership, atomic presence replacement/freshness, authenticated owner profile CAS/freshness, and OrbitRuntime profile construction with resolved ship mode, base-authority mismatch refusal, environment override refusal, and a dedicated fully materialized ship-closure digest including recovery bindings and resolved backends.
- Added deterministic common/store/core coverage for normalization, digest inclusion/exclusion, execution-vs-list precedence, path/format/order stability, backend and recovery semantics, stale/future/non-owner/CAS refusal, two-host/multi-workspace replacement/freshness, migration replay, and reopen.
- Synchronized docs/CONFIG.md and both accepted host-registry/mcp-bridge design contracts.
- Scoped unlisted compatibility edits were limited to crates/orbit-core/src/config/bootstrap.rs and crates/orbit-core/src/config/tests/runtime.rs, as recorded in the task comment.

Validation passed:
- cargo test -p orbit-common execution_profile
- cargo test -p orbit-store sqlite::migration
- cargo test -p orbit-store sqlite::tests::host_registry
- cargo test -p orbit-core host_registry
- cargo test -p orbit-core crew_description_and_tags_normalize_without_loss
- cargo test -p orbit-common -p orbit-store -p orbit-core --no-run
- cargo check -p orbit-common -p orbit-store -p orbit-core
- make ci-fast
- git diff --check

An extra strict targeted clippy attempt could not complete because of a pre-existing unrelated redundant-closure lint in unmodified crates/orbit-store/src/sqlite/task_registry/store.rs:433; the required repository validation and all scoped tests above pass.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-10257-6a5b3e36`
- Behind base: 0
- Ahead of base: 1