### PR TITLE
fix: restore CI diagnostic baseline

### DIFF
--- a/crates/orbit-cli/src/command/run/tests/ship.rs
+++ b/crates/orbit-cli/src/command/run/tests/ship.rs
@@ -104,7 +104,7 @@ fn ship_threads_explicit_review_controls() {
 
 #[test]
 fn ship_rejects_enabled_review_without_explicit_crew() {
-    let mut args = ship_args(&[], ShipMode::Pr, None);
+    let mut args = ship_args(&["T20260425-2010"], ShipMode::Pr, None);
     args.review = true;
 
     let error = build_plan(&args, "agent-main").expect_err("review crew is required");

--- a/crates/orbit-store/src/sqlite/task_registry/store.rs
+++ b/crates/orbit-store/src/sqlite/task_registry/store.rs
@@ -430,7 +430,7 @@ impl TaskRegistryStore {
 
         let replacement_edges = envelopes
             .iter()
-            .flat_map(|envelope| task_relation_edges(envelope))
+            .flat_map(task_relation_edges)
             .collect::<Vec<_>>();
         let replacement_sources = envelopes
             .iter()


### PR DESCRIPTION
Repairs two pre-existing diagnostics that were failing on the exact agent-main baseline: removes a redundant closure in the SQLite task registry and updates the review-pipeline prerequisite test to provide an explicit task ID before asserting the missing-review-crew error.\n\nValidated on the candidate head with rustfmt, the focused ship test, cargo clippy -p orbit-store -- -D warnings, make ci-fast, and git diff --check.\n\nThis is a bounded Build Week operational fix; no Orbit task is attached.